### PR TITLE
chore(deps): add gopkg.in/yaml.v3 for YAML front matter parsing

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -63,7 +63,7 @@ business logic. Every subsequent task assumes this foundation exists.
 Parse `WORKFLOW.md`, expose typed config, and support dynamic reload. No orchestration logic
 yet - just the ability to read, validate, and watch the workflow file.
 
-- [ ] 1.1 Select and add parsing libraries to `go.mod` based on ADR-0004 (workflow file format)
+- [x] 1.1 Select and add parsing libraries to `go.mod` based on ADR-0004 (workflow file format)
       and ADR-0005 (template engine) decisions. If YAML was chosen: evaluate `gopkg.in/yaml.v3`
       vs `github.com/goccy/go-yaml`. If TOML: evaluate `github.com/BurntSushi/toml` vs
       `github.com/pelletier/go-toml/v2`. For the template engine, add the library selected in

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/sergeyklay/sortie
 
 go 1.26.1
+
+require gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,3 @@
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Chore

**Intent:** Adds `gopkg.in/yaml.v3` as the YAML parsing dependency required for the workflow loader (task 1.2 and beyond). This is the only library that satisfies the YAML 1.2 semantics mandate for `map[string]any` decoding — bare `NO`/`ON`/`YES` values decode as strings, not booleans. No external dependency is needed for the template engine; `text/template` is stdlib.

### 🧭 Reviewer Guide

**Complexity:** Low

#### Entry Point

`go.mod` — the single `require` directive added is `gopkg.in/yaml.v3 v3.0.1`. No source files changed; the import will be introduced in task 1.2 when the workflow loader is implemented.

#### Sensitive Areas

- `go.sum`: new checksum entries for `gopkg.in/yaml.v3` and its transitive test dependency `gopkg.in/check.v1`

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes
- **Migrations/State:** No migrations or state changes