### PR TITLE
feat(prompt): implement prompt template rendering

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,7 @@ cmd/sortie/            — main entry point, CLI flag parsing
 internal/domain/       — domain types: Issue, TrackerAdapter, AgentAdapter interfaces
 internal/workflow/     — WORKFLOW.md loader (front matter + prompt body split), file watcher
 internal/config/       — typed config structs, defaults, $VAR resolution, validation
+internal/prompt/       — prompt template rendering (text/template, strict mode, FuncMap)
 internal/orchestrator/ — poll loop, dispatch, reconciliation, retry, state machine
 internal/tracker/      — tracker adapter implementations (jira, file, etc.)
 internal/agent/        — agent adapter implementations (claude-code, mock, etc.)

--- a/TODO.md
+++ b/TODO.md
@@ -75,7 +75,7 @@ yet - just the ability to read, validate, and watch the workflow file.
       cases: missing file, invalid YAML, non-map front matter.
       **Verify:** unit tests cover happy path, missing file, bad YAML, non-map YAML.
 
-- [ ] 1.3 Implement the typed config layer: define Go structs for all config sections
+- [x] 1.3 Implement the typed config layer: define Go structs for all config sections
       (`tracker`, `polling`, `workspace`, `hooks`, `agent`). Apply defaults. Resolve `$VAR`
       environment indirection and `~` path expansion. Validate required fields. Reference
       architecture Section 6.4 for the complete field list. Key `agent` fields that must be
@@ -87,7 +87,7 @@ yet - just the ability to read, validate, and watch the workflow file.
       **Verify:** unit tests cover defaults, env resolution, path expansion, validation errors,
       per-state concurrency map normalization.
 
-- [ ] 1.4 Implement prompt template rendering using `text/template` with strict mode (no
+- [x] 1.4 Implement prompt template rendering using `text/template` with strict mode (no
       undefined variables). Accept `issue`, `attempt`, and `run` as template inputs. The `run`
       object contains `turn_number` (integer), `max_turns` (integer), and `is_continuation`
       (boolean). Test with a sample template that exercises all variables.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,3 +1,7 @@
+// Package config converts raw workflow front matter into typed runtime
+// configuration. Start with [NewServiceConfig] to obtain a
+// [ServiceConfig] from a generic map, and inspect [ConfigError] for
+// structured diagnostics on invalid values.
 package config
 
 import (

--- a/internal/config/errors.go
+++ b/internal/config/errors.go
@@ -1,7 +1,3 @@
-// Package config converts raw workflow front matter into typed runtime
-// configuration. Start with [NewServiceConfig] to obtain a
-// [ServiceConfig] from a generic map, and inspect [ConfigError] for
-// structured diagnostics on invalid values.
 package config
 
 import "fmt"

--- a/internal/prompt/errors.go
+++ b/internal/prompt/errors.go
@@ -1,0 +1,61 @@
+package prompt
+
+import "fmt"
+
+// ErrorKind classifies prompt template failures into parse-time and
+// render-time categories. Callers can switch on Kind to determine
+// whether the failure blocks all dispatch or only the current run
+// attempt.
+type ErrorKind int
+
+const (
+	// ErrTemplateParse indicates the template body contains invalid
+	// syntax and could not be compiled. This blocks dispatch until the
+	// workflow file is corrected.
+	ErrTemplateParse ErrorKind = iota + 1
+
+	// ErrTemplateRender indicates the template executed but failed on a
+	// missing variable, broken pipeline, or FuncMap error. This fails
+	// only the current run attempt.
+	ErrTemplateRender
+)
+
+// TemplateError represents a structured prompt template failure. Use
+// [errors.As] to extract it from the error returned by [Parse] or
+// [Template.Render], then inspect Kind for programmatic handling and
+// Line for operator-facing diagnostics.
+type TemplateError struct {
+	// Kind distinguishes parse errors (dispatch-blocking) from render
+	// errors (per-attempt).
+	Kind ErrorKind
+
+	// Source is the workflow file path for operator-facing messages.
+	Source string
+
+	// Line is the 1-based line number in the original WORKFLOW.md file
+	// (front matter offset applied). Zero when the line cannot be
+	// determined from the underlying error.
+	Line int
+
+	// Err is the underlying cause from text/template.
+	Err error
+}
+
+// Error returns a human-readable diagnostic including the source path
+// and, when available, the adjusted line number.
+func (e *TemplateError) Error() string {
+	kind := "render"
+	if e.Kind == ErrTemplateParse {
+		kind = "parse"
+	}
+	if e.Line > 0 {
+		return fmt.Sprintf("template %s error in %s (line %d): %v", kind, e.Source, e.Line, e.Err)
+	}
+	return fmt.Sprintf("template %s error in %s: %v", kind, e.Source, e.Err)
+}
+
+// Unwrap returns the underlying error, enabling [errors.Is] and
+// [errors.As] chains through the wrapped cause.
+func (e *TemplateError) Unwrap() error {
+	return e.Err
+}

--- a/internal/prompt/prompt.go
+++ b/internal/prompt/prompt.go
@@ -1,0 +1,149 @@
+// Package prompt renders per-issue prompt templates using Go
+// [text/template] in strict mode. Start with [Parse] to compile a
+// template body, then call [Template.Render] for each issue. Inspect
+// [TemplateError] for structured failure diagnostics with
+// WORKFLOW.md-relative line numbers.
+package prompt
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+	"text/template"
+)
+
+// RunContext carries per-turn metadata passed to the prompt template as
+// the "run" variable. Converted to a map with snake_case keys before
+// template execution so workflow authors write {{ .run.turn_number }}
+// matching the architecture doc verbatim.
+type RunContext struct {
+	TurnNumber     int
+	MaxTurns       int
+	IsContinuation bool
+}
+
+// runContextToMap converts a [RunContext] to the map representation used
+// as the "run" template variable. Keys use snake_case to match the
+// architecture doc naming convention.
+func runContextToMap(rc RunContext) map[string]any {
+	return map[string]any{
+		"turn_number":     rc.TurnNumber,
+		"max_turns":       rc.MaxTurns,
+		"is_continuation": rc.IsContinuation,
+	}
+}
+
+// promptFuncMap is the minimal, prompt-essential FuncMap shipped with
+// every template. Each entry is permanent API surface.
+var promptFuncMap = template.FuncMap{
+	"toJSON": func(v any) (string, error) {
+		b, err := json.Marshal(v)
+		if err != nil {
+			return "", err
+		}
+		return string(b), nil
+	},
+	"join": func(sep string, v any) (string, error) {
+		switch list := v.(type) {
+		case []string:
+			return strings.Join(list, sep), nil
+		case []any:
+			s := make([]string, len(list))
+			for i, elem := range list {
+				s[i] = fmt.Sprint(elem)
+			}
+			return strings.Join(s, sep), nil
+		default:
+			return "", fmt.Errorf("join: unsupported type %T, want []string or []any", v)
+		}
+	},
+	"lower": strings.ToLower,
+}
+
+// linePattern matches text/template error messages and captures the
+// template-relative line number. Handles both "name:line:col:" and
+// "name:line:" formats. Compiled once at package init.
+var linePattern = regexp.MustCompile(`template: [^:]+:(\d+)`)
+
+// Template is a parsed prompt template ready for per-issue execution.
+// Obtain via [Parse]. Safe for concurrent [Template.Render] calls.
+type Template struct {
+	tmpl             *template.Template
+	frontMatterLines int
+	source           string
+}
+
+// Parse compiles a prompt template body with strict mode
+// (missingkey=error) and the standard [FuncMap]. frontMatterLines is the
+// number of lines consumed by front matter in the source file (used to
+// rewrite error positions to WORKFLOW.md-relative line numbers). Returns
+// a [*TemplateError] with Kind [ErrTemplateParse] on failure.
+func Parse(body, source string, frontMatterLines int) (*Template, error) {
+	tmpl, err := template.New("prompt").
+		Option("missingkey=error").
+		Funcs(promptFuncMap).
+		Parse(body)
+	if err != nil {
+		line := extractTemplateLine(err)
+		if line > 0 {
+			line += frontMatterLines
+		}
+		return nil, &TemplateError{
+			Kind:   ErrTemplateParse,
+			Source: source,
+			Line:   line,
+			Err:    err,
+		}
+	}
+	return &Template{
+		tmpl:             tmpl,
+		frontMatterLines: frontMatterLines,
+		source:           source,
+	}, nil
+}
+
+// Render executes the template with the given inputs and returns the
+// rendered prompt string. The data map contains exactly three top-level
+// keys: "issue", "attempt", and "run". Returns a [*TemplateError] with
+// Kind [ErrTemplateRender] on failure, with line numbers adjusted to
+// WORKFLOW.md-relative positions.
+func (t *Template) Render(issue map[string]any, attempt any, run RunContext) (string, error) {
+	data := map[string]any{
+		"issue":   issue,
+		"attempt": attempt,
+		"run":     runContextToMap(run),
+	}
+
+	var buf bytes.Buffer
+	if err := t.tmpl.Execute(&buf, data); err != nil {
+		line := extractTemplateLine(err)
+		if line > 0 {
+			line += t.frontMatterLines
+		}
+		return "", &TemplateError{
+			Kind:   ErrTemplateRender,
+			Source: t.source,
+			Line:   line,
+			Err:    err,
+		}
+	}
+	return buf.String(), nil
+}
+
+// extractTemplateLine parses the template-relative line number from a
+// text/template error message. Returns 0 when the pattern does not
+// match.
+func extractTemplateLine(err error) int {
+	matches := linePattern.FindStringSubmatch(err.Error())
+	if len(matches) < 2 {
+		return 0
+	}
+	n, parseErr := strconv.Atoi(matches[1])
+	if parseErr != nil {
+		return 0
+	}
+	return n
+}

--- a/internal/prompt/prompt_test.go
+++ b/internal/prompt/prompt_test.go
@@ -1,0 +1,428 @@
+package prompt
+
+import (
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+)
+
+func TestParse(t *testing.T) {
+	t.Run("ValidTemplate", func(t *testing.T) {
+		tmpl, err := Parse("Hello {{ .issue.title }}", "WORKFLOW.md", 0)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if tmpl == nil {
+			t.Fatal("expected non-nil *Template")
+		}
+	})
+
+	t.Run("EmptyBody", func(t *testing.T) {
+		tmpl, err := Parse("", "WORKFLOW.md", 0)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if tmpl == nil {
+			t.Fatal("expected non-nil *Template")
+		}
+	})
+
+	t.Run("InvalidSyntax", func(t *testing.T) {
+		_, err := Parse("{{ .issue.title", "WORKFLOW.md", 0)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		var te *TemplateError
+		if !errors.As(err, &te) {
+			t.Fatalf("expected *TemplateError, got %T: %v", err, err)
+		}
+		if te.Kind != ErrTemplateParse {
+			t.Errorf("Kind = %d, want ErrTemplateParse (%d)", te.Kind, ErrTemplateParse)
+		}
+	})
+
+	t.Run("ParseErrorLineOffset", func(t *testing.T) {
+		// Put the error on line 3 of the template body.
+		body := "line1\nline2\n{{ .issue.title"
+		_, err := Parse(body, "WORKFLOW.md", 10)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		var te *TemplateError
+		if !errors.As(err, &te) {
+			t.Fatalf("expected *TemplateError, got %T: %v", err, err)
+		}
+		// Template line 3 + front matter 10 = WORKFLOW.md line 13.
+		if te.Line != 13 {
+			t.Errorf("Line = %d, want 13", te.Line)
+		}
+		if te.Source != "WORKFLOW.md" {
+			t.Errorf("Source = %q, want %q", te.Source, "WORKFLOW.md")
+		}
+	})
+
+	t.Run("UnknownFunction", func(t *testing.T) {
+		_, err := Parse("{{ .issue.title | nonexistent }}", "WORKFLOW.md", 0)
+		if err == nil {
+			t.Fatal("expected error for unknown function")
+		}
+		var te *TemplateError
+		if !errors.As(err, &te) {
+			t.Fatalf("expected *TemplateError, got %T: %v", err, err)
+		}
+		if te.Kind != ErrTemplateParse {
+			t.Errorf("Kind = %d, want ErrTemplateParse", te.Kind)
+		}
+	})
+}
+
+func TestRender(t *testing.T) {
+	sampleIssue := map[string]any{
+		"id":         "12345",
+		"identifier": "PROJ-42",
+		"title":      "Fix the login bug",
+		"state":      "In Progress",
+		"labels":     []string{"bug", "urgent"},
+		"blocked_by": []map[string]any{
+			{"identifier": "PROJ-40", "state": "Done"},
+			{"identifier": "PROJ-41", "state": "In Progress"},
+		},
+		"parent":   map[string]any{"identifier": "PROJ-10"},
+		"assignee": "alice",
+	}
+
+	t.Run("AllVariables", func(t *testing.T) {
+		tmpl, err := Parse(
+			"Issue: {{ .issue.title }} Attempt: {{ .attempt }} Turn: {{ .run.turn_number }}",
+			"WORKFLOW.md", 0,
+		)
+		if err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		got, err := tmpl.Render(sampleIssue, 2, RunContext{TurnNumber: 3, MaxTurns: 20})
+		if err != nil {
+			t.Fatalf("render: %v", err)
+		}
+		want := "Issue: Fix the login bug Attempt: 2 Turn: 3"
+		if got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("AttemptNil_FirstRun", func(t *testing.T) {
+		tmpl, err := Parse(
+			"{{ if .attempt }}retry #{{ .attempt }}{{ else }}first run{{ end }}",
+			"WORKFLOW.md", 0,
+		)
+		if err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		got, err := tmpl.Render(sampleIssue, nil, RunContext{TurnNumber: 1, MaxTurns: 20})
+		if err != nil {
+			t.Fatalf("render: %v", err)
+		}
+		if got != "first run" {
+			t.Errorf("got %q, want %q", got, "first run")
+		}
+	})
+
+	t.Run("AttemptInteger_Retry", func(t *testing.T) {
+		tmpl, err := Parse(
+			"{{ if .attempt }}retry #{{ .attempt }}{{ else }}first run{{ end }}",
+			"WORKFLOW.md", 0,
+		)
+		if err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		got, err := tmpl.Render(sampleIssue, 3, RunContext{TurnNumber: 1, MaxTurns: 20})
+		if err != nil {
+			t.Fatalf("render: %v", err)
+		}
+		if got != "retry #3" {
+			t.Errorf("got %q, want %q", got, "retry #3")
+		}
+	})
+
+	t.Run("RunFields", func(t *testing.T) {
+		tmpl, err := Parse(
+			"turn={{ .run.turn_number }} max={{ .run.max_turns }} cont={{ .run.is_continuation }}",
+			"WORKFLOW.md", 0,
+		)
+		if err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		got, err := tmpl.Render(sampleIssue, nil, RunContext{
+			TurnNumber:     5,
+			MaxTurns:       20,
+			IsContinuation: true,
+		})
+		if err != nil {
+			t.Fatalf("render: %v", err)
+		}
+		want := "turn=5 max=20 cont=true"
+		if got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("NestedLabels", func(t *testing.T) {
+		tmpl, err := Parse(
+			"{{ range .issue.labels }}[{{ . }}]{{ end }}",
+			"WORKFLOW.md", 0,
+		)
+		if err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		got, err := tmpl.Render(sampleIssue, nil, RunContext{TurnNumber: 1, MaxTurns: 20})
+		if err != nil {
+			t.Fatalf("render: %v", err)
+		}
+		if got != "[bug][urgent]" {
+			t.Errorf("got %q, want %q", got, "[bug][urgent]")
+		}
+	})
+
+	t.Run("NestedBlockedBy", func(t *testing.T) {
+		tmpl, err := Parse(
+			"{{ range .issue.blocked_by }}{{ .identifier }} {{ end }}",
+			"WORKFLOW.md", 0,
+		)
+		if err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		got, err := tmpl.Render(sampleIssue, nil, RunContext{TurnNumber: 1, MaxTurns: 20})
+		if err != nil {
+			t.Fatalf("render: %v", err)
+		}
+		if got != "PROJ-40 PROJ-41 " {
+			t.Errorf("got %q, want %q", got, "PROJ-40 PROJ-41 ")
+		}
+	})
+
+	t.Run("ParentAccess", func(t *testing.T) {
+		tmpl, err := Parse(
+			"{{ if .issue.parent }}parent={{ .issue.parent.identifier }}{{ end }}",
+			"WORKFLOW.md", 0,
+		)
+		if err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		got, err := tmpl.Render(sampleIssue, nil, RunContext{TurnNumber: 1, MaxTurns: 20})
+		if err != nil {
+			t.Fatalf("render: %v", err)
+		}
+		if got != "parent=PROJ-10" {
+			t.Errorf("got %q, want %q", got, "parent=PROJ-10")
+		}
+	})
+}
+
+func TestRender_FuncMap(t *testing.T) {
+	issue := map[string]any{
+		"title":  "Test Issue",
+		"state":  "In Progress",
+		"labels": []string{"bug", "urgent"},
+	}
+	run := RunContext{TurnNumber: 1, MaxTurns: 20}
+
+	t.Run("toJSON", func(t *testing.T) {
+		tmpl, err := Parse("{{ .issue.labels | toJSON }}", "WORKFLOW.md", 0)
+		if err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		got, err := tmpl.Render(issue, nil, run)
+		if err != nil {
+			t.Fatalf("render: %v", err)
+		}
+		if got != `["bug","urgent"]` {
+			t.Errorf("got %q, want %q", got, `["bug","urgent"]`)
+		}
+	})
+
+	t.Run("join", func(t *testing.T) {
+		tmpl, err := Parse(`{{ join ", " .issue.labels }}`, "WORKFLOW.md", 0)
+		if err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		got, err := tmpl.Render(issue, nil, run)
+		if err != nil {
+			t.Fatalf("render: %v", err)
+		}
+		if got != "bug, urgent" {
+			t.Errorf("got %q, want %q", got, "bug, urgent")
+		}
+	})
+
+	t.Run("join_AnySlice", func(t *testing.T) {
+		// YAML decoder produces []any, not []string. Verify join handles it.
+		issueAny := map[string]any{
+			"labels": []any{"bug", "urgent"},
+		}
+		tmpl, err := Parse(`{{ join ", " .issue.labels }}`, "WORKFLOW.md", 0)
+		if err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		got, err := tmpl.Render(issueAny, nil, run)
+		if err != nil {
+			t.Fatalf("render: %v", err)
+		}
+		if got != "bug, urgent" {
+			t.Errorf("got %q, want %q", got, "bug, urgent")
+		}
+	})
+
+	t.Run("lower", func(t *testing.T) {
+		tmpl, err := Parse("{{ .issue.state | lower }}", "WORKFLOW.md", 0)
+		if err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		got, err := tmpl.Render(issue, nil, run)
+		if err != nil {
+			t.Fatalf("render: %v", err)
+		}
+		if got != "in progress" {
+			t.Errorf("got %q, want %q", got, "in progress")
+		}
+	})
+}
+
+func TestRender_Errors(t *testing.T) {
+	issue := map[string]any{
+		"title": "Test Issue",
+	}
+	run := RunContext{TurnNumber: 1, MaxTurns: 20}
+
+	t.Run("DollarRootAccess", func(t *testing.T) {
+		// ADR-0005: inside {{ range }}, $ accesses the root data map.
+		issueWithLabels := map[string]any{
+			"title":  "Test Issue",
+			"labels": []any{"bug", "urgent"},
+		}
+		tmpl, err := Parse(
+			"{{ range .issue.labels }}{{ . }}: {{ $.issue.title }}; {{ end }}",
+			"WORKFLOW.md", 0,
+		)
+		if err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		got, err := tmpl.Render(issueWithLabels, nil, run)
+		if err != nil {
+			t.Fatalf("render: %v", err)
+		}
+		want := "bug: Test Issue; urgent: Test Issue; "
+		if got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("EmptyIssueMap", func(t *testing.T) {
+		tmpl, err := Parse("{{ .issue.title }}", "WORKFLOW.md", 0)
+		if err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		_, err = tmpl.Render(map[string]any{}, nil, run)
+		if err == nil {
+			t.Fatal("expected error for missing key in empty issue map")
+		}
+		var te *TemplateError
+		if !errors.As(err, &te) {
+			t.Fatalf("expected *TemplateError, got %T: %v", err, err)
+		}
+		if te.Kind != ErrTemplateRender {
+			t.Errorf("Kind = %d, want ErrTemplateRender (%d)", te.Kind, ErrTemplateRender)
+		}
+	})
+
+	t.Run("UnknownTopLevelKey", func(t *testing.T) {
+		tmpl, err := Parse("{{ .config }}", "WORKFLOW.md", 0)
+		if err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		_, err = tmpl.Render(issue, nil, run)
+		if err == nil {
+			t.Fatal("expected error for unknown key .config")
+		}
+		var te *TemplateError
+		if !errors.As(err, &te) {
+			t.Fatalf("expected *TemplateError, got %T: %v", err, err)
+		}
+		if te.Kind != ErrTemplateRender {
+			t.Errorf("Kind = %d, want ErrTemplateRender (%d)", te.Kind, ErrTemplateRender)
+		}
+	})
+
+	t.Run("RenderErrorLineOffset", func(t *testing.T) {
+		// Error on template line 2, with 7 front matter lines.
+		body := "line 1\n{{ .nonexistent }}"
+		tmpl, err := Parse(body, "WORKFLOW.md", 7)
+		if err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		_, err = tmpl.Render(issue, nil, run)
+		if err == nil {
+			t.Fatal("expected error for .nonexistent")
+		}
+		var te *TemplateError
+		if !errors.As(err, &te) {
+			t.Fatalf("expected *TemplateError, got %T: %v", err, err)
+		}
+		// Template line 2 + front matter 7 = WORKFLOW.md line 9.
+		if te.Line != 9 {
+			t.Errorf("Line = %d, want 9", te.Line)
+		}
+	})
+
+	t.Run("ErrorMessageContainsSource", func(t *testing.T) {
+		tmpl, err := Parse("{{ .config }}", "my/WORKFLOW.md", 5)
+		if err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		_, err = tmpl.Render(issue, nil, run)
+		if err == nil {
+			t.Fatal("expected render error")
+		}
+		msg := err.Error()
+		if !strings.Contains(msg, "my/WORKFLOW.md") {
+			t.Errorf("error message missing source path\n  got: %q", msg)
+		}
+		if !strings.Contains(msg, "render") {
+			t.Errorf("error message missing error kind\n  got: %q", msg)
+		}
+	})
+}
+
+func TestTemplateError_Unwrap(t *testing.T) {
+	sentinel := errors.New("sentinel")
+	te := &TemplateError{Kind: ErrTemplateParse, Source: "x.md", Err: sentinel}
+	if !errors.Is(te, sentinel) {
+		t.Error("Unwrap did not expose the underlying sentinel error")
+	}
+}
+
+func TestRender_Concurrent(t *testing.T) {
+	tmpl, err := Parse(
+		"{{ .issue.title }} turn={{ .run.turn_number }}",
+		"WORKFLOW.md", 0,
+	)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	var wg sync.WaitGroup
+	for i := range 50 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			issue := map[string]any{"title": "concurrent test"}
+			_, renderErr := tmpl.Render(issue, nil, RunContext{
+				TurnNumber: i + 1,
+				MaxTurns:   50,
+			})
+			if renderErr != nil {
+				t.Errorf("concurrent render %d failed: %v", i, renderErr)
+			}
+		}()
+	}
+	wg.Wait()
+}

--- a/internal/workflow/loader.go
+++ b/internal/workflow/loader.go
@@ -29,6 +29,12 @@ type Workflow struct {
 	// PromptTemplate is the Markdown body after the closing ---
 	// delimiter, trimmed of leading and trailing whitespace.
 	PromptTemplate string
+
+	// FrontMatterLines is the number of lines from the start of the
+	// file through and including the closing --- delimiter. Zero when
+	// the file has no front matter block. Used by the prompt renderer
+	// to rewrite template error line numbers to file-relative positions.
+	FrontMatterLines int
 }
 
 // Load reads the workflow file at path and returns the parsed [Workflow].
@@ -56,7 +62,7 @@ func Load(path string) (Workflow, error) {
 
 	rest := content[firstNL+1:] // skip opening delimiter line
 
-	fmBytes, promptBody := splitAtClosingDelimiter(rest)
+	fmBytes, promptBody, closingFound := splitAtClosingDelimiter(rest)
 
 	var parsed any
 	if err := yaml.Unmarshal([]byte(fmBytes), &parsed); err != nil {
@@ -79,22 +85,30 @@ func Load(path string) (Workflow, error) {
 		}
 	}
 
+	// Count lines consumed by front matter: opening delimiter (1) +
+	// YAML body lines + closing delimiter (1 if found).
+	fmLines := 1 + strings.Count(fmBytes, "\n")
+	if closingFound {
+		fmLines++
+	}
+
 	return Workflow{
-		Config:         config,
-		PromptTemplate: strings.TrimSpace(promptBody),
+		Config:           config,
+		PromptTemplate:   strings.TrimSpace(promptBody),
+		FrontMatterLines: fmLines,
 	}, nil
 }
 
 // splitAtClosingDelimiter scans content for a line that is exactly "---"
 // (with optional trailing whitespace). It returns the front matter text
-// before the delimiter and the prompt body after it. When no closing
-// delimiter is found the entire content is treated as front matter and
-// the prompt body is empty.
+// before the delimiter, the prompt body after it, and whether the closing
+// delimiter was found. When no closing delimiter is found the entire
+// content is treated as front matter and the prompt body is empty.
 //
 // A manual line scanner is used instead of strings.Cut or strings.SplitN
 // on "\n---\n" because the closing delimiter tolerates trailing whitespace
 // (e.g. "---   \n"), which a fixed-pattern split cannot express.
-func splitAtClosingDelimiter(content string) (frontMatter, promptBody string) {
+func splitAtClosingDelimiter(content string) (frontMatter, promptBody string, found bool) {
 	offset := 0
 	for offset < len(content) {
 		nlIdx := strings.IndexByte(content[offset:], '\n')
@@ -113,7 +127,7 @@ func splitAtClosingDelimiter(content string) (frontMatter, promptBody string) {
 			} else {
 				promptBody = content[offset+nlIdx+1:]
 			}
-			return frontMatter, promptBody
+			return frontMatter, promptBody, true
 		}
 
 		if nlIdx == -1 {
@@ -122,5 +136,5 @@ func splitAtClosingDelimiter(content string) (frontMatter, promptBody string) {
 		offset += nlIdx + 1
 	}
 
-	return content, ""
+	return content, "", false
 }

--- a/internal/workflow/loader_test.go
+++ b/internal/workflow/loader_test.go
@@ -11,13 +11,14 @@ import (
 
 func TestLoad(t *testing.T) {
 	tests := []struct {
-		name           string
-		content        []byte // nil means do not create the file
-		wantErr        bool
-		wantKind       ErrorKind
-		wantConfig     map[string]any
-		wantPrompt     string
-		skipFileCreate bool
+		name                 string
+		content              []byte // nil means do not create the file
+		wantErr              bool
+		wantKind             ErrorKind
+		wantConfig           map[string]any
+		wantPrompt           string
+		wantFrontMatterLines int
+		skipFileCreate       bool
 	}{
 		{
 			name:    "HappyPath",
@@ -26,19 +27,22 @@ func TestLoad(t *testing.T) {
 				"tracker": map[string]any{"kind": "jira", "project": "SORT"},
 				"agent":   map[string]any{"kind": "claude-code"},
 			},
-			wantPrompt: "# Task\n\nFix the bug in {{ .issue.title }}.",
+			wantPrompt:           "# Task\n\nFix the bug in {{ .issue.title }}.",
+			wantFrontMatterLines: 7,
 		},
 		{
-			name:       "NoFrontMatter",
-			content:    []byte("# Just a prompt\n\nDo the thing.\n"),
-			wantConfig: map[string]any{},
-			wantPrompt: "# Just a prompt\n\nDo the thing.",
+			name:                 "NoFrontMatter",
+			content:              []byte("# Just a prompt\n\nDo the thing.\n"),
+			wantConfig:           map[string]any{},
+			wantPrompt:           "# Just a prompt\n\nDo the thing.",
+			wantFrontMatterLines: 0,
 		},
 		{
-			name:       "EmptyFrontMatter",
-			content:    []byte("---\n---\nprompt body\n"),
-			wantConfig: map[string]any{},
-			wantPrompt: "prompt body",
+			name:                 "EmptyFrontMatter",
+			content:              []byte("---\n---\nprompt body\n"),
+			wantConfig:           map[string]any{},
+			wantPrompt:           "prompt body",
+			wantFrontMatterLines: 2,
 		},
 		{
 			name:           "MissingFile",
@@ -70,7 +74,8 @@ func TestLoad(t *testing.T) {
 			wantConfig: map[string]any{
 				"key": "value",
 			},
-			wantPrompt: "the prompt",
+			wantPrompt:           "the prompt",
+			wantFrontMatterLines: 3,
 		},
 		{
 			name:    "TrailingWhitespaceOnDelimiters",
@@ -78,7 +83,8 @@ func TestLoad(t *testing.T) {
 			wantConfig: map[string]any{
 				"key": "value",
 			},
-			wantPrompt: "the prompt",
+			wantPrompt:           "the prompt",
+			wantFrontMatterLines: 3,
 		},
 		{
 			name:    "NoClosingDelimiter",
@@ -86,7 +92,8 @@ func TestLoad(t *testing.T) {
 			wantConfig: map[string]any{
 				"key": "value",
 			},
-			wantPrompt: "",
+			wantPrompt:           "",
+			wantFrontMatterLines: 2,
 		},
 		{
 			// YAML 1.1 treats bare NO, ON, YES as booleans. yaml.v3 follows
@@ -100,19 +107,22 @@ func TestLoad(t *testing.T) {
 				"b": "ON",
 				"c": "YES",
 			},
-			wantPrompt: "prompt",
+			wantPrompt:           "prompt",
+			wantFrontMatterLines: 5,
 		},
 		{
-			name:       "PromptBodyTrimming",
-			content:    []byte("---\nk: v\n---\n\n\n  prompt text  \n\n\n"),
-			wantConfig: map[string]any{"k": "v"},
-			wantPrompt: "prompt text",
+			name:                 "PromptBodyTrimming",
+			content:              []byte("---\nk: v\n---\n\n\n  prompt text  \n\n\n"),
+			wantConfig:           map[string]any{"k": "v"},
+			wantPrompt:           "prompt text",
+			wantFrontMatterLines: 3,
 		},
 		{
-			name:       "GoTemplateDirectivesPreserved",
-			content:    []byte("---\nk: v\n---\n{{ .issue.title }} — {{ if .attempt }}retry{{ end }}\n"),
-			wantConfig: map[string]any{"k": "v"},
-			wantPrompt: "{{ .issue.title }} — {{ if .attempt }}retry{{ end }}",
+			name:                 "GoTemplateDirectivesPreserved",
+			content:              []byte("---\nk: v\n---\n{{ .issue.title }} — {{ if .attempt }}retry{{ end }}\n"),
+			wantConfig:           map[string]any{"k": "v"},
+			wantPrompt:           "{{ .issue.title }} — {{ if .attempt }}retry{{ end }}",
+			wantFrontMatterLines: 3,
 		},
 		{
 			name:    "UTF8BOMStripping",
@@ -120,37 +130,43 @@ func TestLoad(t *testing.T) {
 			wantConfig: map[string]any{
 				"key": "value",
 			},
-			wantPrompt: "prompt",
+			wantPrompt:           "prompt",
+			wantFrontMatterLines: 3,
 		},
 		{
-			name:       "EmptyFile",
-			content:    []byte(""),
-			wantConfig: map[string]any{},
-			wantPrompt: "",
+			name:                 "EmptyFile",
+			content:              []byte(""),
+			wantConfig:           map[string]any{},
+			wantPrompt:           "",
+			wantFrontMatterLines: 0,
 		},
 		{
-			name:       "DelimiterOnlyNoTrailingNewline",
-			content:    []byte("---"),
-			wantConfig: map[string]any{},
-			wantPrompt: "---",
+			name:                 "DelimiterOnlyNoTrailingNewline",
+			content:              []byte("---"),
+			wantConfig:           map[string]any{},
+			wantPrompt:           "---",
+			wantFrontMatterLines: 0,
 		},
 		{
-			name:       "OpeningDelimiterOnly",
-			content:    []byte("---\n"),
-			wantConfig: map[string]any{},
-			wantPrompt: "",
+			name:                 "OpeningDelimiterOnly",
+			content:              []byte("---\n"),
+			wantConfig:           map[string]any{},
+			wantPrompt:           "",
+			wantFrontMatterLines: 1,
 		},
 		{
-			name:       "DashesInQuotedYAMLValue",
-			content:    []byte("---\nkey: \"---\"\n---\nprompt\n"),
-			wantConfig: map[string]any{"key": "---"},
-			wantPrompt: "prompt",
+			name:                 "DashesInQuotedYAMLValue",
+			content:              []byte("---\nkey: \"---\"\n---\nprompt\n"),
+			wantConfig:           map[string]any{"key": "---"},
+			wantPrompt:           "prompt",
+			wantFrontMatterLines: 3,
 		},
 		{
-			name:       "DashesInBlockScalar",
-			content:    []byte("---\nkey: |\n  ---\n  more\n---\nprompt\n"),
-			wantConfig: map[string]any{"key": "---\nmore\n"},
-			wantPrompt: "prompt",
+			name:                 "DashesInBlockScalar",
+			content:              []byte("---\nkey: |\n  ---\n  more\n---\nprompt\n"),
+			wantConfig:           map[string]any{"key": "---\nmore\n"},
+			wantPrompt:           "prompt",
+			wantFrontMatterLines: 5,
 		},
 	}
 
@@ -197,6 +213,10 @@ func TestLoad(t *testing.T) {
 
 			if wf.PromptTemplate != tt.wantPrompt {
 				t.Errorf("PromptTemplate mismatch\n  want: %q\n  got:  %q", tt.wantPrompt, wf.PromptTemplate)
+			}
+
+			if wf.FrontMatterLines != tt.wantFrontMatterLines {
+				t.Errorf("FrontMatterLines mismatch\n  want: %d\n  got:  %d", tt.wantFrontMatterLines, wf.FrontMatterLines)
 			}
 		})
 	}


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Feat

**Intent:** Add prompt template rendering using `text/template` with strict mode, supporting `issue`, `attempt`, and `run` template inputs with built-in functions (`toJSON`, `join`, `lower`). This completes task 1.4 of the foundation milestone.

### 🧭 Reviewer Guide

**Complexity:** Medium

#### Entry Point

`internal/prompt/prompt.go` - Core rendering logic: `Parse()` creates a strict template with `missingkey=error` and a curated FuncMap; `Render()` assembles the data map from issue/attempt/run inputs and executes with line-offset error rewriting.

#### Sensitive Areas

- `internal/prompt/errors.go`: `TemplateError` type with line offset rewriting - verify offset math accounts for front matter lines correctly
- `internal/workflow/loader.go`: `FrontMatterLines` field addition and `splitAtClosingDelimiter` bool return - verify no regressions in existing loader behavior

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes
- **Migrations/State:** No migrations or state changes