### PR TITLE
feat(persistence): add startup recovery loader for retry entries

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -138,11 +138,11 @@ No orchestration logic yet - just the storage primitives.
       issue_id, query recent runs with pagination.
       **Verify:** unit tests for append, query by issue, and pagination.
 
-- [ ] 2.5 Implement CRUD operations for `session_metadata` and `aggregate_metrics`: upsert
+- [x] 2.5 Implement CRUD operations for `session_metadata` and `aggregate_metrics`: upsert
       session metadata, read/write aggregate metrics (including `seconds_running`).
       **Verify:** unit tests for each operation.
 
-- [ ] 2.6 Implement startup recovery: load persisted retry entries, reconstruct timers from
+- [x] 2.6 Implement startup recovery: load persisted retry entries, reconstruct timers from
       `due_at_ms` timestamps, return a list of entries with computed remaining delays.
       **Verify:** unit test creates retry entries with past and future `due_at_ms`, confirms
       the loader returns correct remaining delays (past entries get delay 0).

--- a/internal/persistence/retry.go
+++ b/internal/persistence/retry.go
@@ -17,6 +17,15 @@ type RetryEntry struct {
 	Error      *string // Last error message; nil when no error.
 }
 
+// PendingRetry pairs a persisted [RetryEntry] with the computed delay
+// remaining until its timer should fire. RemainingMs is zero when the entry's
+// due time has already passed, meaning the retry should fire immediately on
+// startup.
+type PendingRetry struct {
+	Entry       RetryEntry
+	RemainingMs int64 // max(entry.DueAtMs - nowMs, 0); always >= 0
+}
+
 // SaveRetryEntry persists a retry entry using upsert semantics. If an entry
 // with the same IssueID already exists, it is replaced entirely.
 func (s *Store) SaveRetryEntry(ctx context.Context, entry RetryEntry) error {
@@ -82,4 +91,26 @@ func (s *Store) DeleteRetryEntry(ctx context.Context, issueID string) error {
 		return fmt.Errorf("delete retry entry %q: %w", issueID, err)
 	}
 	return nil
+}
+
+// LoadRetryEntriesForRecovery loads all persisted retry entries and computes
+// the remaining delay for each relative to nowMs (Unix epoch milliseconds).
+// Entries whose due_at_ms has already passed get RemainingMs = 0, meaning the
+// retry should fire immediately. Results are ordered by due_at_ms ascending
+// then issue_id ascending (same order as [Store.LoadRetryEntries]).
+func (s *Store) LoadRetryEntriesForRecovery(ctx context.Context, nowMs int64) ([]PendingRetry, error) {
+	entries, err := s.LoadRetryEntries(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("load retry entries for recovery: %w", err)
+	}
+
+	result := make([]PendingRetry, len(entries))
+	for i, e := range entries {
+		remaining := e.DueAtMs - nowMs
+		if remaining < 0 {
+			remaining = 0
+		}
+		result[i] = PendingRetry{Entry: e, RemainingMs: remaining}
+	}
+	return result, nil
 }

--- a/internal/persistence/store_test.go
+++ b/internal/persistence/store_test.go
@@ -1144,3 +1144,187 @@ func TestUpsertAggregateMetrics_SecondsRunningPrecision(t *testing.T) {
 		t.Errorf("SecondsRunning = %v, want %v (diff=%v)", got.SecondsRunning, want, math.Abs(got.SecondsRunning-want))
 	}
 }
+
+// --- Startup Recovery Tests ---
+
+func TestLoadRetryEntriesForRecovery_Empty(t *testing.T) {
+	s := openTestStore(t)
+	migrateOrFatal(t, s)
+	ctx := context.Background()
+
+	pending, err := s.LoadRetryEntriesForRecovery(ctx, 5000)
+	if err != nil {
+		t.Fatalf("LoadRetryEntriesForRecovery: %v", err)
+	}
+	if pending == nil {
+		t.Fatal("returned nil slice, want non-nil empty slice")
+	}
+	if len(pending) != 0 {
+		t.Fatalf("got %d entries, want 0", len(pending))
+	}
+}
+
+func TestLoadRetryEntriesForRecovery_FutureDueAt(t *testing.T) {
+	s := openTestStore(t)
+	migrateOrFatal(t, s)
+	ctx := context.Background()
+
+	for _, e := range []RetryEntry{
+		{IssueID: "ISS-1", Identifier: "PROJ-1", Attempt: 1, DueAtMs: 5000},
+		{IssueID: "ISS-2", Identifier: "PROJ-2", Attempt: 2, DueAtMs: 8000},
+	} {
+		if err := s.SaveRetryEntry(ctx, e); err != nil {
+			t.Fatalf("SaveRetryEntry(%s): %v", e.IssueID, err)
+		}
+	}
+
+	pending, err := s.LoadRetryEntriesForRecovery(ctx, 3000)
+	if err != nil {
+		t.Fatalf("LoadRetryEntriesForRecovery: %v", err)
+	}
+	if len(pending) != 2 {
+		t.Fatalf("got %d entries, want 2", len(pending))
+	}
+	if pending[0].RemainingMs != 2000 {
+		t.Errorf("pending[0].RemainingMs = %d, want 2000", pending[0].RemainingMs)
+	}
+	if pending[1].RemainingMs != 5000 {
+		t.Errorf("pending[1].RemainingMs = %d, want 5000", pending[1].RemainingMs)
+	}
+}
+
+func TestLoadRetryEntriesForRecovery_PastDueAt(t *testing.T) {
+	s := openTestStore(t)
+	migrateOrFatal(t, s)
+	ctx := context.Background()
+
+	for _, e := range []RetryEntry{
+		{IssueID: "ISS-1", Identifier: "PROJ-1", Attempt: 1, DueAtMs: 1000},
+		{IssueID: "ISS-2", Identifier: "PROJ-2", Attempt: 2, DueAtMs: 2000},
+	} {
+		if err := s.SaveRetryEntry(ctx, e); err != nil {
+			t.Fatalf("SaveRetryEntry(%s): %v", e.IssueID, err)
+		}
+	}
+
+	pending, err := s.LoadRetryEntriesForRecovery(ctx, 5000)
+	if err != nil {
+		t.Fatalf("LoadRetryEntriesForRecovery: %v", err)
+	}
+	if len(pending) != 2 {
+		t.Fatalf("got %d entries, want 2", len(pending))
+	}
+	for i, p := range pending {
+		if p.RemainingMs != 0 {
+			t.Errorf("pending[%d].RemainingMs = %d, want 0", i, p.RemainingMs)
+		}
+	}
+}
+
+func TestLoadRetryEntriesForRecovery_Mixed(t *testing.T) {
+	s := openTestStore(t)
+	migrateOrFatal(t, s)
+	ctx := context.Background()
+
+	for _, e := range []RetryEntry{
+		{IssueID: "ISS-1", Identifier: "PROJ-1", Attempt: 1, DueAtMs: 1000},
+		{IssueID: "ISS-2", Identifier: "PROJ-2", Attempt: 2, DueAtMs: 5000},
+		{IssueID: "ISS-3", Identifier: "PROJ-3", Attempt: 3, DueAtMs: 9000},
+	} {
+		if err := s.SaveRetryEntry(ctx, e); err != nil {
+			t.Fatalf("SaveRetryEntry(%s): %v", e.IssueID, err)
+		}
+	}
+
+	pending, err := s.LoadRetryEntriesForRecovery(ctx, 5000)
+	if err != nil {
+		t.Fatalf("LoadRetryEntriesForRecovery: %v", err)
+	}
+	if len(pending) != 3 {
+		t.Fatalf("got %d entries, want 3", len(pending))
+	}
+
+	// Past entry (DueAtMs=1000, nowMs=5000) → 0.
+	if pending[0].RemainingMs != 0 {
+		t.Errorf("pending[0].RemainingMs = %d, want 0", pending[0].RemainingMs)
+	}
+	// Exact-now entry (DueAtMs=5000, nowMs=5000) → 0.
+	if pending[1].RemainingMs != 0 {
+		t.Errorf("pending[1].RemainingMs = %d, want 0", pending[1].RemainingMs)
+	}
+	// Future entry (DueAtMs=9000, nowMs=5000) → 4000.
+	if pending[2].RemainingMs != 4000 {
+		t.Errorf("pending[2].RemainingMs = %d, want 4000", pending[2].RemainingMs)
+	}
+
+	// Ordering must be due_at_ms ascending.
+	wantDue := []int64{1000, 5000, 9000}
+	for i, want := range wantDue {
+		if pending[i].Entry.DueAtMs != want {
+			t.Errorf("pending[%d].Entry.DueAtMs = %d, want %d", i, pending[i].Entry.DueAtMs, want)
+		}
+	}
+}
+
+func TestLoadRetryEntriesForRecovery_PreservesEntryFields(t *testing.T) {
+	s := openTestStore(t)
+	migrateOrFatal(t, s)
+	ctx := context.Background()
+
+	errMsg := "agent timeout"
+	entry := RetryEntry{
+		IssueID:    "ISS-42",
+		Identifier: "PROJ-42",
+		Attempt:    3,
+		DueAtMs:    7500,
+		Error:      &errMsg,
+	}
+	if err := s.SaveRetryEntry(ctx, entry); err != nil {
+		t.Fatalf("SaveRetryEntry: %v", err)
+	}
+
+	pending, err := s.LoadRetryEntriesForRecovery(ctx, 5000)
+	if err != nil {
+		t.Fatalf("LoadRetryEntriesForRecovery: %v", err)
+	}
+	if len(pending) != 1 {
+		t.Fatalf("got %d entries, want 1", len(pending))
+	}
+
+	got := pending[0].Entry
+	if got.IssueID != "ISS-42" {
+		t.Errorf("IssueID = %q, want %q", got.IssueID, "ISS-42")
+	}
+	if got.Identifier != "PROJ-42" {
+		t.Errorf("Identifier = %q, want %q", got.Identifier, "PROJ-42")
+	}
+	if got.Attempt != 3 {
+		t.Errorf("Attempt = %d, want 3", got.Attempt)
+	}
+	if got.DueAtMs != 7500 {
+		t.Errorf("DueAtMs = %d, want 7500", got.DueAtMs)
+	}
+	if got.Error == nil {
+		t.Fatal("Error = nil, want non-nil")
+	}
+	if *got.Error != "agent timeout" {
+		t.Errorf("Error = %q, want %q", *got.Error, "agent timeout")
+	}
+	if pending[0].RemainingMs != 2500 {
+		t.Errorf("RemainingMs = %d, want 2500", pending[0].RemainingMs)
+	}
+}
+
+func TestLoadRetryEntriesForRecovery_DBError(t *testing.T) {
+	s := openTestStore(t)
+	migrateOrFatal(t, s)
+
+	if err := s.db.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	_, err := s.LoadRetryEntriesForRecovery(context.Background(), 5000)
+	if err == nil {
+		t.Fatal("expected error from LoadRetryEntriesForRecovery on closed DB, got nil")
+	}
+}


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Feat

**Intent:** Add `PendingRetry` type and `Store.LoadRetryEntriesForRecovery` to the persistence layer so the orchestrator can reconstruct in-memory retry timers after a process restart without losing queued retries.

### 🧭 Reviewer Guide

**Complexity:** Low

#### Entry Point

`internal/persistence/retry.go` — contains the new `PendingRetry` struct and `LoadRetryEntriesForRecovery` method. The method delegates all SQL to the existing `LoadRetryEntries` query and adds a single computation loop that clamps `due_at_ms - nowMs` to zero for past-due entries.

#### Sensitive Areas

- `internal/persistence/retry.go`: The `nowMs` parameter is caller-injected (not read from the system clock) — this is intentional for deterministic testability. The orchestrator startup path will pass `time.Now().UnixMilli()` at call time.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes — additive only.
- **Migrations/State:** No migrations or state changes. The method reads from the existing `retry_entries` table.