### PR TITLE
test: improve idioms across all test packages

### DIFF
--- a/internal/agent/claude/claude_test.go
+++ b/internal/agent/claude/claude_test.go
@@ -42,7 +42,7 @@ func TestNewClaudeCodeAdapter(t *testing.T) {
 		}
 		a := adapter.(*ClaudeCodeAdapter)
 		if a.passthrough.Model != "claude-sonnet-4-20250514" {
-			t.Errorf("Model = %q", a.passthrough.Model)
+			t.Errorf("Model = %q, want %q", a.passthrough.Model, "claude-sonnet-4-20250514")
 		}
 		if a.passthrough.MaxTurns != 10 {
 			t.Errorf("MaxTurns = %d, want 10", a.passthrough.MaxTurns)
@@ -51,7 +51,7 @@ func TestNewClaudeCodeAdapter(t *testing.T) {
 			t.Errorf("MaxBudgetUSD = %f, want 1.5", a.passthrough.MaxBudgetUSD)
 		}
 		if a.passthrough.PermissionMode != "bypassPermissions" {
-			t.Errorf("PermissionMode = %q", a.passthrough.PermissionMode)
+			t.Errorf("PermissionMode = %q, want %q", a.passthrough.PermissionMode, "bypassPermissions")
 		}
 	})
 }
@@ -68,7 +68,7 @@ func TestRegistration(t *testing.T) {
 		t.Fatalf("factory() error = %v", err)
 	}
 	if _, ok := adapter.(*ClaudeCodeAdapter); !ok {
-		t.Error("factory returned wrong type")
+		t.Errorf("factory() type = %T, want *ClaudeCodeAdapter", adapter)
 	}
 }
 
@@ -80,35 +80,49 @@ func TestStartSession(t *testing.T) {
 
 	tests := []struct {
 		name    string
-		params  domain.StartSessionParams
+		setup   func(t *testing.T) domain.StartSessionParams
 		wantErr domain.AgentErrorKind
 	}{
 		{
-			name:    "empty workspace path",
-			params:  domain.StartSessionParams{},
+			name: "empty workspace path",
+			setup: func(_ *testing.T) domain.StartSessionParams {
+				return domain.StartSessionParams{}
+			},
 			wantErr: domain.ErrInvalidWorkspaceCwd,
 		},
 		{
 			name: "non-existent workspace",
-			params: domain.StartSessionParams{
-				WorkspacePath: "/nonexistent/path/that/does/not/exist",
-				AgentConfig:   domain.AgentConfig{Command: existingCmd},
+			setup: func(_ *testing.T) domain.StartSessionParams {
+				return domain.StartSessionParams{
+					WorkspacePath: "/nonexistent/path/that/does/not/exist",
+					AgentConfig:   domain.AgentConfig{Command: existingCmd},
+				}
 			},
 			wantErr: domain.ErrInvalidWorkspaceCwd,
 		},
 		{
 			name: "workspace is a file",
-			params: domain.StartSessionParams{
-				AgentConfig: domain.AgentConfig{Command: existingCmd},
-				// WorkspacePath set below
+			setup: func(t *testing.T) domain.StartSessionParams {
+				t.Helper()
+				tmpFile := filepath.Join(t.TempDir(), "afile")
+				if err := os.WriteFile(tmpFile, []byte("x"), 0o644); err != nil {
+					t.Fatal(err)
+				}
+				return domain.StartSessionParams{
+					WorkspacePath: tmpFile,
+					AgentConfig:   domain.AgentConfig{Command: existingCmd},
+				}
 			},
 			wantErr: domain.ErrInvalidWorkspaceCwd,
 		},
 		{
 			name: "command not found",
-			params: domain.StartSessionParams{
-				AgentConfig: domain.AgentConfig{Command: "sortie-nonexistent-binary-12345"},
-				// WorkspacePath set below
+			setup: func(t *testing.T) domain.StartSessionParams {
+				t.Helper()
+				return domain.StartSessionParams{
+					WorkspacePath: t.TempDir(),
+					AgentConfig:   domain.AgentConfig{Command: "sortie-nonexistent-binary-12345"},
+				}
 			},
 			wantErr: domain.ErrAgentNotFound,
 		},
@@ -119,17 +133,7 @@ func TestStartSession(t *testing.T) {
 			t.Parallel()
 			adapter, _ := NewClaudeCodeAdapter(map[string]any{})
 
-			params := tt.params
-			if tt.name == "workspace is a file" {
-				tmpFile := filepath.Join(t.TempDir(), "afile")
-				if err := os.WriteFile(tmpFile, []byte("x"), 0o644); err != nil {
-					t.Fatal(err)
-				}
-				params.WorkspacePath = tmpFile
-			}
-			if tt.name == "command not found" {
-				params.WorkspacePath = t.TempDir()
-			}
+			params := tt.setup(t)
 
 			_, err := adapter.StartSession(context.Background(), params)
 			if err == nil {

--- a/internal/agent/claude/parse_test.go
+++ b/internal/agent/claude/parse_test.go
@@ -4,26 +4,16 @@ import (
 	"bufio"
 	"os"
 	"path/filepath"
-	"runtime"
 	"testing"
 
 	"github.com/sortie-ai/sortie/internal/domain"
 )
 
-func testdataPath(t *testing.T, name string) string {
+func loadFixture(t *testing.T, name string) []byte {
 	t.Helper()
-	_, file, _, ok := runtime.Caller(0)
-	if !ok {
-		t.Fatal("cannot determine testdata path")
-	}
-	return filepath.Join(filepath.Dir(file), "testdata", name)
-}
-
-func readFixture(t *testing.T, name string) []byte {
-	t.Helper()
-	data, err := os.ReadFile(testdataPath(t, name))
+	data, err := os.ReadFile(filepath.Join("testdata", name))
 	if err != nil {
-		t.Fatalf("read fixture %s: %v", name, err)
+		t.Fatalf("loading fixture %s: %v", name, err)
 	}
 	return data
 }
@@ -186,7 +176,7 @@ func TestParseEvent(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			data := readFixture(t, tt.fixture)
+			data := loadFixture(t, tt.fixture)
 
 			ev, err := parseEvent(data)
 			if err != nil {
@@ -208,7 +198,7 @@ func TestParseEvent(t *testing.T) {
 func TestParseEvent_Malformed(t *testing.T) {
 	t.Parallel()
 
-	data := readFixture(t, "malformed_line.txt")
+	data := loadFixture(t, "malformed_line.txt")
 	_, err := parseEvent(data)
 	if err == nil {
 		t.Fatal("parseEvent(malformed) did not return error")
@@ -281,7 +271,7 @@ func TestSummarizeAssistant(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			data := readFixture(t, tt.fixture)
+			data := loadFixture(t, tt.fixture)
 			ev, err := parseEvent(data)
 			if err != nil {
 				t.Fatal(err)
@@ -307,7 +297,7 @@ func TestSummarizeAssistant_EmptyMessage(t *testing.T) {
 func TestFormatAPIRetry(t *testing.T) {
 	t.Parallel()
 
-	data := readFixture(t, "api_retry_event.json")
+	data := loadFixture(t, "api_retry_event.json")
 	ev, err := parseEvent(data)
 	if err != nil {
 		t.Fatal(err)
@@ -380,7 +370,7 @@ func TestTruncate(t *testing.T) {
 func TestParseFullSession(t *testing.T) {
 	t.Parallel()
 
-	f, err := os.Open(testdataPath(t, "full_session.jsonl"))
+	f, err := os.Open(filepath.Join("testdata", "full_session.jsonl"))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -10,6 +10,7 @@ import (
 
 func TestNewServiceConfig(t *testing.T) {
 	t.Run("Defaults/EmptyMap", func(t *testing.T) {
+		t.Parallel()
 		cfg, err := NewServiceConfig(map[string]any{})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
@@ -39,6 +40,7 @@ func TestNewServiceConfig(t *testing.T) {
 	})
 
 	t.Run("Defaults/NilMap", func(t *testing.T) {
+		t.Parallel()
 		cfg, err := NewServiceConfig(nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
@@ -185,6 +187,7 @@ func TestNewServiceConfig(t *testing.T) {
 	})
 
 	t.Run("PathExpansion/Tilde", func(t *testing.T) {
+		t.Parallel()
 		home, err := os.UserHomeDir()
 		if err != nil {
 			t.Skip("cannot determine home directory")
@@ -227,6 +230,7 @@ func TestNewServiceConfig(t *testing.T) {
 	})
 
 	t.Run("Coercion/StringToInt", func(t *testing.T) {
+		t.Parallel()
 		cfg, err := NewServiceConfig(map[string]any{
 			"polling": map[string]any{"interval_ms": "5000"},
 		})
@@ -237,6 +241,7 @@ func TestNewServiceConfig(t *testing.T) {
 	})
 
 	t.Run("Coercion/Float64ToInt", func(t *testing.T) {
+		t.Parallel()
 		cfg, err := NewServiceConfig(map[string]any{
 			"agent": map[string]any{"max_concurrent_agents": float64(5)},
 		})
@@ -247,28 +252,23 @@ func TestNewServiceConfig(t *testing.T) {
 	})
 
 	t.Run("Coercion/InvalidString", func(t *testing.T) {
+		t.Parallel()
 		_, err := NewServiceConfig(map[string]any{
 			"polling": map[string]any{"interval_ms": "notanumber"},
 		})
-		var cfgErr *ConfigError
-		if !errors.As(err, &cfgErr) {
-			t.Fatalf("expected *ConfigError, got %T: %v", err, err)
-		}
-		assertStringEqual(t, "ConfigError.Field", "polling.interval_ms", cfgErr.Field)
+		assertConfigErrorField(t, err, "polling.interval_ms")
 	})
 
 	t.Run("Coercion/FractionalFloat64Rejected", func(t *testing.T) {
+		t.Parallel()
 		_, err := NewServiceConfig(map[string]any{
 			"polling": map[string]any{"interval_ms": float64(0.9)},
 		})
-		var cfgErr *ConfigError
-		if !errors.As(err, &cfgErr) {
-			t.Fatalf("expected *ConfigError, got %T: %v", err, err)
-		}
-		assertStringEqual(t, "ConfigError.Field", "polling.interval_ms", cfgErr.Field)
+		assertConfigErrorField(t, err, "polling.interval_ms")
 	})
 
 	t.Run("ByStateMap/Normalization", func(t *testing.T) {
+		t.Parallel()
 		cfg, err := NewServiceConfig(map[string]any{
 			"agent": map[string]any{
 				"max_concurrent_agents_by_state": map[string]any{
@@ -288,6 +288,7 @@ func TestNewServiceConfig(t *testing.T) {
 	})
 
 	t.Run("ByStateMap/IgnoresNonPositive", func(t *testing.T) {
+		t.Parallel()
 		cfg, err := NewServiceConfig(map[string]any{
 			"agent": map[string]any{
 				"max_concurrent_agents_by_state": map[string]any{
@@ -305,6 +306,7 @@ func TestNewServiceConfig(t *testing.T) {
 	})
 
 	t.Run("ByStateMap/IgnoresNonNumeric", func(t *testing.T) {
+		t.Parallel()
 		cfg, err := NewServiceConfig(map[string]any{
 			"agent": map[string]any{
 				"max_concurrent_agents_by_state": map[string]any{
@@ -321,6 +323,7 @@ func TestNewServiceConfig(t *testing.T) {
 	})
 
 	t.Run("HooksTimeout/Zero", func(t *testing.T) {
+		t.Parallel()
 		cfg, err := NewServiceConfig(map[string]any{
 			"hooks": map[string]any{"timeout_ms": 0},
 		})
@@ -331,6 +334,7 @@ func TestNewServiceConfig(t *testing.T) {
 	})
 
 	t.Run("HooksTimeout/Negative", func(t *testing.T) {
+		t.Parallel()
 		cfg, err := NewServiceConfig(map[string]any{
 			"hooks": map[string]any{"timeout_ms": -100},
 		})
@@ -341,6 +345,7 @@ func TestNewServiceConfig(t *testing.T) {
 	})
 
 	t.Run("Extensions/Collected", func(t *testing.T) {
+		t.Parallel()
 		raw := map[string]any{
 			"server": map[string]any{"port": 8080},
 			"worker": map[string]any{"ssh_hosts": []any{"host1"}},
@@ -366,6 +371,7 @@ func TestNewServiceConfig(t *testing.T) {
 	})
 
 	t.Run("AgentCommand/PreservedAsIs", func(t *testing.T) {
+		t.Parallel()
 		cfg, err := NewServiceConfig(map[string]any{
 			"agent": map[string]any{"command": "claude --flag=$VAR"},
 		})
@@ -376,6 +382,7 @@ func TestNewServiceConfig(t *testing.T) {
 	})
 
 	t.Run("States/Extracted", func(t *testing.T) {
+		t.Parallel()
 		cfg, err := NewServiceConfig(map[string]any{
 			"tracker": map[string]any{
 				"active_states": []any{"To Do", "In Progress"},
@@ -388,6 +395,7 @@ func TestNewServiceConfig(t *testing.T) {
 	})
 
 	t.Run("StallTimeout/ZeroIsValid", func(t *testing.T) {
+		t.Parallel()
 		cfg, err := NewServiceConfig(map[string]any{
 			"agent": map[string]any{"stall_timeout_ms": 0},
 		})
@@ -398,6 +406,7 @@ func TestNewServiceConfig(t *testing.T) {
 	})
 
 	t.Run("StallTimeout/AbsentGetsDefault", func(t *testing.T) {
+		t.Parallel()
 		cfg, err := NewServiceConfig(map[string]any{
 			"agent": map[string]any{"kind": "claude-code"},
 		})
@@ -408,6 +417,7 @@ func TestNewServiceConfig(t *testing.T) {
 	})
 
 	t.Run("SectionAsNonMap", func(t *testing.T) {
+		t.Parallel()
 		cfg, err := NewServiceConfig(map[string]any{
 			"tracker": "not-a-map",
 		})
@@ -421,6 +431,20 @@ func TestNewServiceConfig(t *testing.T) {
 }
 
 // --- test helpers ---
+
+func assertConfigErrorField(t *testing.T, err error, wantField string) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("expected *ConfigError with field %q, got nil", wantField)
+	}
+	var ce *ConfigError
+	if !errors.As(err, &ce) {
+		t.Fatalf("error type = %T, want *ConfigError", err)
+	}
+	if ce.Field != wantField {
+		t.Errorf("ConfigError.Field = %q, want %q", ce.Field, wantField)
+	}
+}
 
 func assertStringEqual(t *testing.T, name, want, got string) {
 	t.Helper()

--- a/internal/domain/agent_test.go
+++ b/internal/domain/agent_test.go
@@ -32,6 +32,8 @@ func (m *mockAgentAdapter) EventStream() <-chan AgentEvent {
 // Section 10.3: verify all 13 normalized event type string values match the
 // architecture specification exactly.
 func TestAgentEventType_Values(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		constant AgentEventType
 		want     string
@@ -52,6 +54,7 @@ func TestAgentEventType_Values(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.want, func(t *testing.T) {
+			t.Parallel()
 			if string(tt.constant) != tt.want {
 				t.Errorf("AgentEventType constant = %q, want %q", tt.constant, tt.want)
 			}
@@ -65,6 +68,8 @@ func TestAgentEventType_Values(t *testing.T) {
 // Section 10.5: verify all 9 agent error kind string values match the
 // architecture specification exactly.
 func TestAgentErrorKind_Values(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		constant AgentErrorKind
 		want     string
@@ -81,6 +86,7 @@ func TestAgentErrorKind_Values(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.want, func(t *testing.T) {
+			t.Parallel()
 			if string(tt.constant) != tt.want {
 				t.Errorf("AgentErrorKind constant = %q, want %q", tt.constant, tt.want)
 			}
@@ -92,6 +98,8 @@ func TestAgentErrorKind_Values(t *testing.T) {
 }
 
 func TestAgentError_Error(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name string
 		err  AgentError
@@ -145,6 +153,7 @@ func TestAgentError_Error(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			if got := tt.err.Error(); got != tt.want {
 				t.Errorf("Error() = %q, want %q", got, tt.want)
 			}
@@ -153,6 +162,8 @@ func TestAgentError_Error(t *testing.T) {
 }
 
 func TestAgentError_Unwrap(t *testing.T) {
+	t.Parallel()
+
 	inner := fmt.Errorf("underlying error")
 	agentErr := &AgentError{
 		Kind:    ErrTurnTimeout,
@@ -161,7 +172,7 @@ func TestAgentError_Unwrap(t *testing.T) {
 	}
 
 	if agentErr.Unwrap() != inner {
-		t.Error("Unwrap() did not return the inner error")
+		t.Errorf("Unwrap() = %v, want %v", agentErr.Unwrap(), inner)
 	}
 
 	// Verify errors.As works through a wrapping chain.
@@ -176,6 +187,8 @@ func TestAgentError_Unwrap(t *testing.T) {
 }
 
 func TestAgentError_UnwrapNil(t *testing.T) {
+	t.Parallel()
+
 	err := &AgentError{
 		Kind:    ErrAgentNotFound,
 		Message: "command not in PATH",
@@ -187,6 +200,8 @@ func TestAgentError_UnwrapNil(t *testing.T) {
 
 // Section 10.2: Session.Internal carries adapter-specific opaque state.
 func TestSession_InternalRoundTrip(t *testing.T) {
+	t.Parallel()
+
 	type adapterState struct {
 		pid  int
 		pipe string
@@ -213,6 +228,8 @@ func TestSession_InternalRoundTrip(t *testing.T) {
 
 // Section 10.3: AgentEvent can carry all fields including token usage.
 func TestAgentEvent_Construction(t *testing.T) {
+	t.Parallel()
+
 	ts := time.Date(2026, 3, 20, 12, 0, 0, 0, time.UTC)
 	event := AgentEvent{
 		Type:      EventTokenUsage,
@@ -245,6 +262,8 @@ func TestAgentEvent_Construction(t *testing.T) {
 
 // TokenUsage zero value is the documented sentinel for non-token events.
 func TestTokenUsage_ZeroValue(t *testing.T) {
+	t.Parallel()
+
 	var usage TokenUsage
 	if usage.InputTokens != 0 || usage.OutputTokens != 0 || usage.TotalTokens != 0 {
 		t.Errorf("zero TokenUsage = %+v, want all zeros", usage)

--- a/internal/domain/issue_test.go
+++ b/internal/domain/issue_test.go
@@ -5,6 +5,8 @@ import "testing"
 func intPtr(v int) *int { return &v }
 
 func TestToTemplateMap_FullyPopulated(t *testing.T) {
+	t.Parallel()
+
 	iss := &Issue{
 		ID:          "10001",
 		Identifier:  "PROJ-42",
@@ -117,6 +119,8 @@ func TestToTemplateMap_FullyPopulated(t *testing.T) {
 }
 
 func TestToTemplateMap_Minimal(t *testing.T) {
+	t.Parallel()
+
 	iss := &Issue{
 		ID:         "10001",
 		Identifier: "PROJ-1",
@@ -158,6 +162,8 @@ func TestToTemplateMap_Minimal(t *testing.T) {
 }
 
 func TestToTemplateMap_NilVsEmptyComments(t *testing.T) {
+	t.Parallel()
+
 	// Nil comments = not fetched.
 	issNil := &Issue{
 		ID:         "1",
@@ -194,6 +200,8 @@ func TestToTemplateMap_NilVsEmptyComments(t *testing.T) {
 }
 
 func TestToTemplateMap_Priority(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name     string
 		priority *int
@@ -206,6 +214,7 @@ func TestToTemplateMap_Priority(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			iss := &Issue{
 				ID:         "1",
 				Identifier: "X-1",
@@ -225,6 +234,8 @@ func TestToTemplateMap_Priority(t *testing.T) {
 }
 
 func TestToTemplateMap_BlockedByEmptyState(t *testing.T) {
+	t.Parallel()
+
 	iss := &Issue{
 		ID:         "1",
 		Identifier: "X-1",
@@ -250,6 +261,8 @@ func TestToTemplateMap_BlockedByEmptyState(t *testing.T) {
 }
 
 func TestToTemplateMap_NilLabelsNormalized(t *testing.T) {
+	t.Parallel()
+
 	iss := &Issue{
 		ID:         "1",
 		Identifier: "X-1",

--- a/internal/domain/tracker_test.go
+++ b/internal/domain/tracker_test.go
@@ -32,32 +32,82 @@ func (m *mockTrackerAdapter) FetchIssueComments(_ context.Context, _ string) ([]
 	return nil, nil
 }
 
-func TestTrackerError_Error(t *testing.T) {
-	err := &TrackerError{
-		Kind:    ErrTrackerTransport,
-		Message: "connection refused",
+func TestTrackerErrorKind_Values(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		constant TrackerErrorKind
+		want     string
+	}{
+		{ErrUnsupportedTrackerKind, "unsupported_tracker_kind"},
+		{ErrMissingTrackerAPIKey, "missing_tracker_api_key"},
+		{ErrMissingTrackerProject, "missing_tracker_project"},
+		{ErrTrackerTransport, "tracker_transport_error"},
+		{ErrTrackerAuth, "tracker_auth_error"},
+		{ErrTrackerAPI, "tracker_api_error"},
+		{ErrTrackerPayload, "tracker_payload_error"},
+		{ErrTrackerMissingCursor, "tracker_missing_end_cursor"},
 	}
-	got := err.Error()
-	if got != "tracker: tracker_transport_error: connection refused" {
-		t.Errorf("Error() = %q, want %q", got, "tracker: tracker_transport_error: connection refused")
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			t.Parallel()
+			if string(tt.constant) != tt.want {
+				t.Errorf("TrackerErrorKind constant = %q, want %q", tt.constant, tt.want)
+			}
+		})
+	}
+	if len(tests) != 8 {
+		t.Errorf("expected 8 tracker error kinds, got %d", len(tests))
 	}
 }
 
-func TestTrackerError_ErrorWithWrapped(t *testing.T) {
-	inner := fmt.Errorf("dial tcp: connect refused")
-	err := &TrackerError{
-		Kind:    ErrTrackerTransport,
-		Message: "connection failed",
-		Err:     inner,
+func TestTrackerError_Error(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  TrackerError
+		want string
+	}{
+		{
+			name: "without wrapped error",
+			err:  TrackerError{Kind: ErrTrackerTransport, Message: "connection refused"},
+			want: "tracker: tracker_transport_error: connection refused",
+		},
+		{
+			name: "with wrapped error",
+			err:  TrackerError{Kind: ErrTrackerTransport, Message: "connection failed", Err: fmt.Errorf("dial tcp: connect refused")},
+			want: "tracker: tracker_transport_error: connection failed: dial tcp: connect refused",
+		},
+		{
+			name: "auth error",
+			err:  TrackerError{Kind: ErrTrackerAuth, Message: "invalid token"},
+			want: "tracker: tracker_auth_error: invalid token",
+		},
+		{
+			name: "api error",
+			err:  TrackerError{Kind: ErrTrackerAPI, Message: "status 500"},
+			want: "tracker: tracker_api_error: status 500",
+		},
+		{
+			name: "payload error",
+			err:  TrackerError{Kind: ErrTrackerPayload, Message: "unexpected field"},
+			want: "tracker: tracker_payload_error: unexpected field",
+		},
 	}
-	got := err.Error()
-	want := "tracker: tracker_transport_error: connection failed: dial tcp: connect refused"
-	if got != want {
-		t.Errorf("Error() = %q, want %q", got, want)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := tt.err.Error(); got != tt.want {
+				t.Errorf("Error() = %q, want %q", got, tt.want)
+			}
+		})
 	}
 }
 
 func TestTrackerError_Unwrap(t *testing.T) {
+	t.Parallel()
+
 	inner := fmt.Errorf("underlying error")
 	trackerErr := &TrackerError{
 		Kind:    ErrTrackerAuth,
@@ -66,7 +116,7 @@ func TestTrackerError_Unwrap(t *testing.T) {
 	}
 
 	if trackerErr.Unwrap() != inner {
-		t.Error("Unwrap() did not return the inner error")
+		t.Errorf("Unwrap() = %v, want %v", trackerErr.Unwrap(), inner)
 	}
 
 	// Verify errors.As works through a wrapping chain.
@@ -81,6 +131,8 @@ func TestTrackerError_Unwrap(t *testing.T) {
 }
 
 func TestTrackerError_UnwrapNil(t *testing.T) {
+	t.Parallel()
+
 	err := &TrackerError{
 		Kind:    ErrTrackerPayload,
 		Message: "unexpected field",

--- a/internal/logging/logging_test.go
+++ b/internal/logging/logging_test.go
@@ -17,17 +17,19 @@ func TestSetup(t *testing.T) {
 	output := buf.String()
 
 	if !strings.Contains(output, "startup complete") {
-		t.Errorf("expected log output to contain message, got: %s", output)
+		t.Errorf("Setup() output = %q, want containing %q", output, "startup complete")
 	}
 
 	buf.Reset()
 	slog.Default().Debug("should be filtered")
 	if buf.Len() != 0 {
-		t.Errorf("expected DEBUG message to be filtered at INFO level, got: %s", buf.String())
+		t.Errorf("Setup(LevelInfo) wrote DEBUG message: %q, want empty", buf.String())
 	}
 }
 
 func TestWithIssue(t *testing.T) {
+	t.Parallel()
+
 	var buf bytes.Buffer
 	logger := slog.New(slog.NewTextHandler(&buf, nil))
 
@@ -37,14 +39,16 @@ func TestWithIssue(t *testing.T) {
 	output := buf.String()
 
 	if !strings.Contains(output, "issue_id=10042") {
-		t.Errorf("expected issue_id=10042 in output, got: %s", output)
+		t.Errorf("WithIssue() output = %q, want containing %q", output, "issue_id=10042")
 	}
 	if !strings.Contains(output, "issue_identifier=PROJ-123") {
-		t.Errorf("expected issue_identifier=PROJ-123 in output, got: %s", output)
+		t.Errorf("WithIssue() output = %q, want containing %q", output, "issue_identifier=PROJ-123")
 	}
 }
 
 func TestWithSession(t *testing.T) {
+	t.Parallel()
+
 	var buf bytes.Buffer
 	logger := slog.New(slog.NewTextHandler(&buf, nil))
 
@@ -54,11 +58,13 @@ func TestWithSession(t *testing.T) {
 	output := buf.String()
 
 	if !strings.Contains(output, "session_id=sess-abc-def") {
-		t.Errorf("expected session_id=sess-abc-def in output, got: %s", output)
+		t.Errorf("WithSession() output = %q, want containing %q", output, "session_id=sess-abc-def")
 	}
 }
 
 func TestWithIssueAndSession(t *testing.T) {
+	t.Parallel()
+
 	var buf bytes.Buffer
 	logger := slog.New(slog.NewTextHandler(&buf, nil))
 
@@ -69,12 +75,14 @@ func TestWithIssueAndSession(t *testing.T) {
 
 	for _, key := range []string{"issue_id=10042", "issue_identifier=PROJ-123", "session_id=sess-abc-def"} {
 		if !strings.Contains(output, key) {
-			t.Errorf("expected %s in output, got: %s", key, output)
+			t.Errorf("WithSession(WithIssue()) output = %q, want containing %q", output, key)
 		}
 	}
 }
 
 func TestWithIssue_SpecialValues(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name            string
 		issueID         string
@@ -128,6 +136,8 @@ func TestWithIssue_SpecialValues(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			var buf bytes.Buffer
 			logger := slog.New(slog.NewTextHandler(&buf, nil))
 
@@ -137,16 +147,18 @@ func TestWithIssue_SpecialValues(t *testing.T) {
 			output := buf.String()
 
 			if !strings.Contains(output, tt.wantID) {
-				t.Errorf("expected %s in output, got: %s", tt.wantID, output)
+				t.Errorf("WithIssue(%q, %q) output = %q, want containing %q", tt.issueID, tt.issueIdentifier, output, tt.wantID)
 			}
 			if !strings.Contains(output, tt.wantIdentifier) {
-				t.Errorf("expected %s in output, got: %s", tt.wantIdentifier, output)
+				t.Errorf("WithIssue(%q, %q) output = %q, want containing %q", tt.issueID, tt.issueIdentifier, output, tt.wantIdentifier)
 			}
 		})
 	}
 }
 
 func TestWithSession_SpecialValues(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name      string
 		sessionID string
@@ -176,6 +188,8 @@ func TestWithSession_SpecialValues(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			var buf bytes.Buffer
 			logger := slog.New(slog.NewTextHandler(&buf, nil))
 
@@ -185,7 +199,7 @@ func TestWithSession_SpecialValues(t *testing.T) {
 			output := buf.String()
 
 			if !strings.Contains(output, tt.want) {
-				t.Errorf("expected %s in output, got: %s", tt.want, output)
+				t.Errorf("WithSession(%q) output = %q, want containing %q", tt.sessionID, output, tt.want)
 			}
 		})
 	}

--- a/internal/persistence/migrate_test.go
+++ b/internal/persistence/migrate_test.go
@@ -27,6 +27,8 @@ func migrateOrFatal(t *testing.T, s *Store) {
 }
 
 func TestMigrate_FreshDB(t *testing.T) {
+	t.Parallel()
+
 	s := openTestStore(t)
 	migrateOrFatal(t, s)
 
@@ -75,6 +77,8 @@ func TestMigrate_FreshDB(t *testing.T) {
 }
 
 func TestMigrate_Idempotent(t *testing.T) {
+	t.Parallel()
+
 	s := openTestStore(t)
 	migrateOrFatal(t, s)
 
@@ -93,6 +97,8 @@ func TestMigrate_Idempotent(t *testing.T) {
 }
 
 func TestMigrate_SchemaMigrationsTracking(t *testing.T) {
+	t.Parallel()
+
 	s := openTestStore(t)
 	migrateOrFatal(t, s)
 
@@ -149,6 +155,8 @@ func tableColumns(t *testing.T, s *Store, table string) []columnInfo {
 }
 
 func TestMigrate_ColumnCorrectness(t *testing.T) {
+	t.Parallel()
+
 	s := openTestStore(t)
 	migrateOrFatal(t, s)
 
@@ -246,6 +254,8 @@ func TestMigrate_ColumnCorrectness(t *testing.T) {
 }
 
 func TestMigrate_RunHistoryAutoincrement(t *testing.T) {
+	t.Parallel()
+
 	s := openTestStore(t)
 	migrateOrFatal(t, s)
 
@@ -261,6 +271,8 @@ func TestMigrate_RunHistoryAutoincrement(t *testing.T) {
 }
 
 func TestMigrate_DefaultValues(t *testing.T) {
+	t.Parallel()
+
 	s := openTestStore(t)
 	migrateOrFatal(t, s)
 
@@ -300,6 +312,8 @@ func TestMigrate_DefaultValues(t *testing.T) {
 }
 
 func TestMigrate_NullConstraints(t *testing.T) {
+	t.Parallel()
+
 	s := openTestStore(t)
 	migrateOrFatal(t, s)
 
@@ -336,6 +350,8 @@ func TestMigrate_NullConstraints(t *testing.T) {
 }
 
 func TestMigrate_PrimaryKeyConstraints(t *testing.T) {
+	t.Parallel()
+
 	s := openTestStore(t)
 	migrateOrFatal(t, s)
 
@@ -359,6 +375,8 @@ func TestMigrate_PrimaryKeyConstraints(t *testing.T) {
 
 // Verify the migrations slice is correctly ordered and non-empty.
 func TestMigrations_Registry(t *testing.T) {
+	t.Parallel()
+
 	if len(migrations) == 0 {
 		t.Fatal("migrations slice is empty")
 	}

--- a/internal/persistence/store_test.go
+++ b/internal/persistence/store_test.go
@@ -16,6 +16,8 @@ func closeStore(t *testing.T, s *Store) {
 }
 
 func TestOpen(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 
 	s, err := Open(ctx, ":memory:")
@@ -26,6 +28,8 @@ func TestOpen(t *testing.T) {
 }
 
 func TestOpen_WALEnabled(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 
 	// WAL requires a file-backed database; in-memory always reports "memory".
@@ -51,6 +55,8 @@ func TestOpen_WALEnabled(t *testing.T) {
 // It verifies that basic SQL operations work through the configured connection.
 // This test will be superseded by CRUD method tests in tasks 2.3–2.5.
 func TestOpen_BasicCRUD(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 
 	s, err := Open(ctx, ":memory:")
@@ -97,6 +103,8 @@ func TestOpen_BasicCRUD(t *testing.T) {
 }
 
 func TestSaveAndLoadRetryEntry(t *testing.T) {
+	t.Parallel()
+
 	s := openTestStore(t)
 	migrateOrFatal(t, s)
 	ctx := context.Background()
@@ -138,6 +146,8 @@ func TestSaveAndLoadRetryEntry(t *testing.T) {
 }
 
 func TestSaveRetryEntry_Upsert(t *testing.T) {
+	t.Parallel()
+
 	s := openTestStore(t)
 	migrateOrFatal(t, s)
 	ctx := context.Background()
@@ -188,6 +198,8 @@ func TestSaveRetryEntry_Upsert(t *testing.T) {
 }
 
 func TestSaveRetryEntry_UpsertClearsError(t *testing.T) {
+	t.Parallel()
+
 	s := openTestStore(t)
 	migrateOrFatal(t, s)
 	ctx := context.Background()
@@ -232,6 +244,8 @@ func TestSaveRetryEntry_UpsertClearsError(t *testing.T) {
 }
 
 func TestDeleteRetryEntry(t *testing.T) {
+	t.Parallel()
+
 	s := openTestStore(t)
 	migrateOrFatal(t, s)
 	ctx := context.Background()
@@ -262,6 +276,8 @@ func TestDeleteRetryEntry(t *testing.T) {
 }
 
 func TestDeleteRetryEntry_Nonexistent(t *testing.T) {
+	t.Parallel()
+
 	s := openTestStore(t)
 	migrateOrFatal(t, s)
 	ctx := context.Background()
@@ -272,6 +288,8 @@ func TestDeleteRetryEntry_Nonexistent(t *testing.T) {
 }
 
 func TestLoadRetryEntries_Empty(t *testing.T) {
+	t.Parallel()
+
 	s := openTestStore(t)
 	migrateOrFatal(t, s)
 	ctx := context.Background()
@@ -289,6 +307,8 @@ func TestLoadRetryEntries_Empty(t *testing.T) {
 }
 
 func TestLoadRetryEntries_OrderByDueAtMs(t *testing.T) {
+	t.Parallel()
+
 	s := openTestStore(t)
 	migrateOrFatal(t, s)
 	ctx := context.Background()
@@ -320,6 +340,8 @@ func TestLoadRetryEntries_OrderByDueAtMs(t *testing.T) {
 }
 
 func TestSaveRetryEntry_DBError(t *testing.T) {
+	t.Parallel()
+
 	s := openTestStore(t)
 	migrateOrFatal(t, s)
 	ctx := context.Background()
@@ -338,6 +360,8 @@ func TestSaveRetryEntry_DBError(t *testing.T) {
 }
 
 func TestLoadRetryEntries_QueryError(t *testing.T) {
+	t.Parallel()
+
 	s := openTestStore(t)
 	migrateOrFatal(t, s)
 	ctx := context.Background()
@@ -354,6 +378,8 @@ func TestLoadRetryEntries_QueryError(t *testing.T) {
 }
 
 func TestLoadRetryEntries_ScanError(t *testing.T) {
+	t.Parallel()
+
 	s := openTestStore(t)
 	migrateOrFatal(t, s)
 	ctx := context.Background()
@@ -374,6 +400,8 @@ func TestLoadRetryEntries_ScanError(t *testing.T) {
 }
 
 func TestDeleteRetryEntry_DBError(t *testing.T) {
+	t.Parallel()
+
 	s := openTestStore(t)
 	migrateOrFatal(t, s)
 	ctx := context.Background()
@@ -390,6 +418,8 @@ func TestDeleteRetryEntry_DBError(t *testing.T) {
 }
 
 func TestLoadRetryEntries_DeterministicTieBreak(t *testing.T) {
+	t.Parallel()
+
 	s := openTestStore(t)
 	migrateOrFatal(t, s)
 	ctx := context.Background()
@@ -448,6 +478,8 @@ func appendOrFatal(t *testing.T, s *Store, run RunHistory) RunHistory {
 }
 
 func TestAppendRunHistory(t *testing.T) {
+	t.Parallel()
+
 	s := openTestStore(t)
 	migrateOrFatal(t, s)
 
@@ -487,6 +519,8 @@ func TestAppendRunHistory(t *testing.T) {
 }
 
 func TestAppendRunHistory_WithError(t *testing.T) {
+	t.Parallel()
+
 	s := openTestStore(t)
 	migrateOrFatal(t, s)
 	ctx := context.Background()
@@ -517,6 +551,8 @@ func TestAppendRunHistory_WithError(t *testing.T) {
 }
 
 func TestAppendRunHistory_NilError(t *testing.T) {
+	t.Parallel()
+
 	s := openTestStore(t)
 	migrateOrFatal(t, s)
 	ctx := context.Background()
@@ -537,6 +573,8 @@ func TestAppendRunHistory_NilError(t *testing.T) {
 }
 
 func TestAppendRunHistory_MultipleAppendsAutoIncrement(t *testing.T) {
+	t.Parallel()
+
 	s := openTestStore(t)
 	migrateOrFatal(t, s)
 
@@ -552,6 +590,8 @@ func TestAppendRunHistory_MultipleAppendsAutoIncrement(t *testing.T) {
 }
 
 func TestQueryRunHistoryByIssue(t *testing.T) {
+	t.Parallel()
+
 	s := openTestStore(t)
 	migrateOrFatal(t, s)
 	ctx := context.Background()
@@ -585,6 +625,8 @@ func TestQueryRunHistoryByIssue(t *testing.T) {
 }
 
 func TestQueryRunHistoryByIssue_Empty(t *testing.T) {
+	t.Parallel()
+
 	s := openTestStore(t)
 	migrateOrFatal(t, s)
 	ctx := context.Background()
@@ -602,6 +644,8 @@ func TestQueryRunHistoryByIssue_Empty(t *testing.T) {
 }
 
 func TestQueryRecentRunHistory_FirstPage(t *testing.T) {
+	t.Parallel()
+
 	s := openTestStore(t)
 	migrateOrFatal(t, s)
 	ctx := context.Background()
@@ -632,6 +676,8 @@ func TestQueryRecentRunHistory_FirstPage(t *testing.T) {
 }
 
 func TestQueryRecentRunHistory_Pagination(t *testing.T) {
+	t.Parallel()
+
 	s := openTestStore(t)
 	migrateOrFatal(t, s)
 	ctx := context.Background()
@@ -684,6 +730,8 @@ func TestQueryRecentRunHistory_Pagination(t *testing.T) {
 }
 
 func TestQueryRecentRunHistory_Empty(t *testing.T) {
+	t.Parallel()
+
 	s := openTestStore(t)
 	migrateOrFatal(t, s)
 	ctx := context.Background()
@@ -701,6 +749,8 @@ func TestQueryRecentRunHistory_Empty(t *testing.T) {
 }
 
 func TestQueryRecentRunHistory_LimitExceedsRows(t *testing.T) {
+	t.Parallel()
+
 	s := openTestStore(t)
 	migrateOrFatal(t, s)
 	ctx := context.Background()
@@ -718,6 +768,8 @@ func TestQueryRecentRunHistory_LimitExceedsRows(t *testing.T) {
 }
 
 func TestQueryRecentRunHistory_NonPositiveLimit(t *testing.T) {
+	t.Parallel()
+
 	s := openTestStore(t)
 	migrateOrFatal(t, s)
 	ctx := context.Background()
@@ -738,6 +790,8 @@ func TestQueryRecentRunHistory_NonPositiveLimit(t *testing.T) {
 }
 
 func TestAppendRunHistory_DBError(t *testing.T) {
+	t.Parallel()
+
 	s := openTestStore(t)
 	migrateOrFatal(t, s)
 
@@ -754,6 +808,8 @@ func TestAppendRunHistory_DBError(t *testing.T) {
 // --- Session Metadata Tests ---
 
 func TestUpsertSessionMetadata(t *testing.T) {
+	t.Parallel()
+
 	s := openTestStore(t)
 	migrateOrFatal(t, s)
 	ctx := context.Background()
@@ -806,6 +862,8 @@ func TestUpsertSessionMetadata(t *testing.T) {
 }
 
 func TestUpsertSessionMetadata_Update(t *testing.T) {
+	t.Parallel()
+
 	s := openTestStore(t)
 	migrateOrFatal(t, s)
 	ctx := context.Background()
@@ -866,6 +924,8 @@ func TestUpsertSessionMetadata_Update(t *testing.T) {
 }
 
 func TestUpsertSessionMetadata_NilAgentPID(t *testing.T) {
+	t.Parallel()
+
 	s := openTestStore(t)
 	migrateOrFatal(t, s)
 	ctx := context.Background()
@@ -896,6 +956,8 @@ func TestUpsertSessionMetadata_NilAgentPID(t *testing.T) {
 }
 
 func TestLoadSessionMetadata_NotFound(t *testing.T) {
+	t.Parallel()
+
 	s := openTestStore(t)
 	migrateOrFatal(t, s)
 	ctx := context.Background()
@@ -913,6 +975,8 @@ func TestLoadSessionMetadata_NotFound(t *testing.T) {
 }
 
 func TestLoadAllSessionMetadata(t *testing.T) {
+	t.Parallel()
+
 	s := openTestStore(t)
 	migrateOrFatal(t, s)
 	ctx := context.Background()
@@ -946,6 +1010,8 @@ func TestLoadAllSessionMetadata(t *testing.T) {
 }
 
 func TestLoadAllSessionMetadata_Empty(t *testing.T) {
+	t.Parallel()
+
 	s := openTestStore(t)
 	migrateOrFatal(t, s)
 	ctx := context.Background()
@@ -963,6 +1029,8 @@ func TestLoadAllSessionMetadata_Empty(t *testing.T) {
 }
 
 func TestDeleteSessionMetadata(t *testing.T) {
+	t.Parallel()
+
 	s := openTestStore(t)
 	migrateOrFatal(t, s)
 	ctx := context.Background()
@@ -993,6 +1061,8 @@ func TestDeleteSessionMetadata(t *testing.T) {
 }
 
 func TestDeleteSessionMetadata_Nonexistent(t *testing.T) {
+	t.Parallel()
+
 	s := openTestStore(t)
 	migrateOrFatal(t, s)
 	ctx := context.Background()
@@ -1005,6 +1075,8 @@ func TestDeleteSessionMetadata_Nonexistent(t *testing.T) {
 // --- Aggregate Metrics Tests ---
 
 func TestUpsertAggregateMetrics(t *testing.T) {
+	t.Parallel()
+
 	s := openTestStore(t)
 	migrateOrFatal(t, s)
 	ctx := context.Background()
@@ -1049,6 +1121,8 @@ func TestUpsertAggregateMetrics(t *testing.T) {
 }
 
 func TestUpsertAggregateMetrics_Update(t *testing.T) {
+	t.Parallel()
+
 	s := openTestStore(t)
 	migrateOrFatal(t, s)
 	ctx := context.Background()
@@ -1102,6 +1176,8 @@ func TestUpsertAggregateMetrics_Update(t *testing.T) {
 }
 
 func TestLoadAggregateMetrics_NotFound(t *testing.T) {
+	t.Parallel()
+
 	s := openTestStore(t)
 	migrateOrFatal(t, s)
 	ctx := context.Background()
@@ -1119,6 +1195,8 @@ func TestLoadAggregateMetrics_NotFound(t *testing.T) {
 }
 
 func TestUpsertAggregateMetrics_SecondsRunningPrecision(t *testing.T) {
+	t.Parallel()
+
 	s := openTestStore(t)
 	migrateOrFatal(t, s)
 	ctx := context.Background()
@@ -1148,6 +1226,8 @@ func TestUpsertAggregateMetrics_SecondsRunningPrecision(t *testing.T) {
 // --- Startup Recovery Tests ---
 
 func TestLoadRetryEntriesForRecovery_Empty(t *testing.T) {
+	t.Parallel()
+
 	s := openTestStore(t)
 	migrateOrFatal(t, s)
 	ctx := context.Background()
@@ -1165,6 +1245,8 @@ func TestLoadRetryEntriesForRecovery_Empty(t *testing.T) {
 }
 
 func TestLoadRetryEntriesForRecovery_FutureDueAt(t *testing.T) {
+	t.Parallel()
+
 	s := openTestStore(t)
 	migrateOrFatal(t, s)
 	ctx := context.Background()
@@ -1194,6 +1276,8 @@ func TestLoadRetryEntriesForRecovery_FutureDueAt(t *testing.T) {
 }
 
 func TestLoadRetryEntriesForRecovery_PastDueAt(t *testing.T) {
+	t.Parallel()
+
 	s := openTestStore(t)
 	migrateOrFatal(t, s)
 	ctx := context.Background()
@@ -1222,6 +1306,8 @@ func TestLoadRetryEntriesForRecovery_PastDueAt(t *testing.T) {
 }
 
 func TestLoadRetryEntriesForRecovery_Mixed(t *testing.T) {
+	t.Parallel()
+
 	s := openTestStore(t)
 	migrateOrFatal(t, s)
 	ctx := context.Background()
@@ -1267,6 +1353,8 @@ func TestLoadRetryEntriesForRecovery_Mixed(t *testing.T) {
 }
 
 func TestLoadRetryEntriesForRecovery_PreservesEntryFields(t *testing.T) {
+	t.Parallel()
+
 	s := openTestStore(t)
 	migrateOrFatal(t, s)
 	ctx := context.Background()
@@ -1316,6 +1404,8 @@ func TestLoadRetryEntriesForRecovery_PreservesEntryFields(t *testing.T) {
 }
 
 func TestLoadRetryEntriesForRecovery_DBError(t *testing.T) {
+	t.Parallel()
+
 	s := openTestStore(t)
 	migrateOrFatal(t, s)
 

--- a/internal/prompt/prompt_test.go
+++ b/internal/prompt/prompt_test.go
@@ -8,7 +8,11 @@ import (
 )
 
 func TestParse(t *testing.T) {
+	t.Parallel()
+
 	t.Run("ValidTemplate", func(t *testing.T) {
+		t.Parallel()
+
 		tmpl, err := Parse("Hello {{ .issue.title }}", "WORKFLOW.md", 0)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
@@ -19,6 +23,8 @@ func TestParse(t *testing.T) {
 	})
 
 	t.Run("EmptyBody", func(t *testing.T) {
+		t.Parallel()
+
 		tmpl, err := Parse("", "WORKFLOW.md", 0)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
@@ -29,6 +35,8 @@ func TestParse(t *testing.T) {
 	})
 
 	t.Run("InvalidSyntax", func(t *testing.T) {
+		t.Parallel()
+
 		_, err := Parse("{{ .issue.title", "WORKFLOW.md", 0)
 		if err == nil {
 			t.Fatal("expected error, got nil")
@@ -43,6 +51,8 @@ func TestParse(t *testing.T) {
 	})
 
 	t.Run("ParseErrorLineOffset", func(t *testing.T) {
+		t.Parallel()
+
 		// Put the error on line 3 of the template body.
 		body := "line1\nline2\n{{ .issue.title"
 		_, err := Parse(body, "WORKFLOW.md", 10)
@@ -63,6 +73,8 @@ func TestParse(t *testing.T) {
 	})
 
 	t.Run("UnknownFunction", func(t *testing.T) {
+		t.Parallel()
+
 		_, err := Parse("{{ .issue.title | nonexistent }}", "WORKFLOW.md", 0)
 		if err == nil {
 			t.Fatal("expected error for unknown function")
@@ -78,6 +90,8 @@ func TestParse(t *testing.T) {
 }
 
 func TestRender(t *testing.T) {
+	t.Parallel()
+
 	sampleIssue := map[string]any{
 		"id":         "12345",
 		"identifier": "PROJ-42",
@@ -93,6 +107,8 @@ func TestRender(t *testing.T) {
 	}
 
 	t.Run("AllVariables", func(t *testing.T) {
+		t.Parallel()
+
 		tmpl, err := Parse(
 			"Issue: {{ .issue.title }} Attempt: {{ .attempt }} Turn: {{ .run.turn_number }}",
 			"WORKFLOW.md", 0,
@@ -106,11 +122,13 @@ func TestRender(t *testing.T) {
 		}
 		want := "Issue: Fix the login bug Attempt: 2 Turn: 3"
 		if got != want {
-			t.Errorf("got %q, want %q", got, want)
+			t.Errorf("Render() = %q, want %q", got, want)
 		}
 	})
 
 	t.Run("AttemptNil_FirstRun", func(t *testing.T) {
+		t.Parallel()
+
 		tmpl, err := Parse(
 			"{{ if .attempt }}retry #{{ .attempt }}{{ else }}first run{{ end }}",
 			"WORKFLOW.md", 0,
@@ -123,11 +141,13 @@ func TestRender(t *testing.T) {
 			t.Fatalf("render: %v", err)
 		}
 		if got != "first run" {
-			t.Errorf("got %q, want %q", got, "first run")
+			t.Errorf("Render() = %q, want %q", got, "first run")
 		}
 	})
 
 	t.Run("AttemptInteger_Retry", func(t *testing.T) {
+		t.Parallel()
+
 		tmpl, err := Parse(
 			"{{ if .attempt }}retry #{{ .attempt }}{{ else }}first run{{ end }}",
 			"WORKFLOW.md", 0,
@@ -140,11 +160,13 @@ func TestRender(t *testing.T) {
 			t.Fatalf("render: %v", err)
 		}
 		if got != "retry #3" {
-			t.Errorf("got %q, want %q", got, "retry #3")
+			t.Errorf("Render() = %q, want %q", got, "retry #3")
 		}
 	})
 
 	t.Run("RunFields", func(t *testing.T) {
+		t.Parallel()
+
 		tmpl, err := Parse(
 			"turn={{ .run.turn_number }} max={{ .run.max_turns }} cont={{ .run.is_continuation }}",
 			"WORKFLOW.md", 0,
@@ -162,11 +184,13 @@ func TestRender(t *testing.T) {
 		}
 		want := "turn=5 max=20 cont=true"
 		if got != want {
-			t.Errorf("got %q, want %q", got, want)
+			t.Errorf("Render() = %q, want %q", got, want)
 		}
 	})
 
 	t.Run("NestedLabels", func(t *testing.T) {
+		t.Parallel()
+
 		tmpl, err := Parse(
 			"{{ range .issue.labels }}[{{ . }}]{{ end }}",
 			"WORKFLOW.md", 0,
@@ -179,11 +203,13 @@ func TestRender(t *testing.T) {
 			t.Fatalf("render: %v", err)
 		}
 		if got != "[bug][urgent]" {
-			t.Errorf("got %q, want %q", got, "[bug][urgent]")
+			t.Errorf("Render() = %q, want %q", got, "[bug][urgent]")
 		}
 	})
 
 	t.Run("NestedBlockedBy", func(t *testing.T) {
+		t.Parallel()
+
 		tmpl, err := Parse(
 			"{{ range .issue.blocked_by }}{{ .identifier }} {{ end }}",
 			"WORKFLOW.md", 0,
@@ -196,11 +222,13 @@ func TestRender(t *testing.T) {
 			t.Fatalf("render: %v", err)
 		}
 		if got != "PROJ-40 PROJ-41 " {
-			t.Errorf("got %q, want %q", got, "PROJ-40 PROJ-41 ")
+			t.Errorf("Render() = %q, want %q", got, "PROJ-40 PROJ-41 ")
 		}
 	})
 
 	t.Run("ParentAccess", func(t *testing.T) {
+		t.Parallel()
+
 		tmpl, err := Parse(
 			"{{ if .issue.parent }}parent={{ .issue.parent.identifier }}{{ end }}",
 			"WORKFLOW.md", 0,
@@ -213,12 +241,14 @@ func TestRender(t *testing.T) {
 			t.Fatalf("render: %v", err)
 		}
 		if got != "parent=PROJ-10" {
-			t.Errorf("got %q, want %q", got, "parent=PROJ-10")
+			t.Errorf("Render() = %q, want %q", got, "parent=PROJ-10")
 		}
 	})
 }
 
 func TestRender_FuncMap(t *testing.T) {
+	t.Parallel()
+
 	issue := map[string]any{
 		"title":  "Test Issue",
 		"state":  "In Progress",
@@ -227,6 +257,8 @@ func TestRender_FuncMap(t *testing.T) {
 	run := RunContext{TurnNumber: 1, MaxTurns: 20}
 
 	t.Run("toJSON", func(t *testing.T) {
+		t.Parallel()
+
 		tmpl, err := Parse("{{ .issue.labels | toJSON }}", "WORKFLOW.md", 0)
 		if err != nil {
 			t.Fatalf("parse: %v", err)
@@ -236,11 +268,13 @@ func TestRender_FuncMap(t *testing.T) {
 			t.Fatalf("render: %v", err)
 		}
 		if got != `["bug","urgent"]` {
-			t.Errorf("got %q, want %q", got, `["bug","urgent"]`)
+			t.Errorf("Render() = %q, want %q", got, `["bug","urgent"]`)
 		}
 	})
 
 	t.Run("join", func(t *testing.T) {
+		t.Parallel()
+
 		tmpl, err := Parse(`{{ join ", " .issue.labels }}`, "WORKFLOW.md", 0)
 		if err != nil {
 			t.Fatalf("parse: %v", err)
@@ -250,11 +284,13 @@ func TestRender_FuncMap(t *testing.T) {
 			t.Fatalf("render: %v", err)
 		}
 		if got != "bug, urgent" {
-			t.Errorf("got %q, want %q", got, "bug, urgent")
+			t.Errorf("Render() = %q, want %q", got, "bug, urgent")
 		}
 	})
 
 	t.Run("join_AnySlice", func(t *testing.T) {
+		t.Parallel()
+
 		// YAML decoder produces []any, not []string. Verify join handles it.
 		issueAny := map[string]any{
 			"labels": []any{"bug", "urgent"},
@@ -268,11 +304,13 @@ func TestRender_FuncMap(t *testing.T) {
 			t.Fatalf("render: %v", err)
 		}
 		if got != "bug, urgent" {
-			t.Errorf("got %q, want %q", got, "bug, urgent")
+			t.Errorf("Render() = %q, want %q", got, "bug, urgent")
 		}
 	})
 
 	t.Run("lower", func(t *testing.T) {
+		t.Parallel()
+
 		tmpl, err := Parse("{{ .issue.state | lower }}", "WORKFLOW.md", 0)
 		if err != nil {
 			t.Fatalf("parse: %v", err)
@@ -282,18 +320,22 @@ func TestRender_FuncMap(t *testing.T) {
 			t.Fatalf("render: %v", err)
 		}
 		if got != "in progress" {
-			t.Errorf("got %q, want %q", got, "in progress")
+			t.Errorf("Render() = %q, want %q", got, "in progress")
 		}
 	})
 }
 
 func TestRender_Errors(t *testing.T) {
+	t.Parallel()
+
 	issue := map[string]any{
 		"title": "Test Issue",
 	}
 	run := RunContext{TurnNumber: 1, MaxTurns: 20}
 
 	t.Run("DollarRootAccess", func(t *testing.T) {
+		t.Parallel()
+
 		// ADR-0005: inside {{ range }}, $ accesses the root data map.
 		issueWithLabels := map[string]any{
 			"title":  "Test Issue",
@@ -312,11 +354,13 @@ func TestRender_Errors(t *testing.T) {
 		}
 		want := "bug: Test Issue; urgent: Test Issue; "
 		if got != want {
-			t.Errorf("got %q, want %q", got, want)
+			t.Errorf("Render() = %q, want %q", got, want)
 		}
 	})
 
 	t.Run("EmptyIssueMap", func(t *testing.T) {
+		t.Parallel()
+
 		tmpl, err := Parse("{{ .issue.title }}", "WORKFLOW.md", 0)
 		if err != nil {
 			t.Fatalf("parse: %v", err)
@@ -335,6 +379,8 @@ func TestRender_Errors(t *testing.T) {
 	})
 
 	t.Run("UnknownTopLevelKey", func(t *testing.T) {
+		t.Parallel()
+
 		tmpl, err := Parse("{{ .config }}", "WORKFLOW.md", 0)
 		if err != nil {
 			t.Fatalf("parse: %v", err)
@@ -353,6 +399,8 @@ func TestRender_Errors(t *testing.T) {
 	})
 
 	t.Run("RenderErrorLineOffset", func(t *testing.T) {
+		t.Parallel()
+
 		// Error on template line 2, with 7 front matter lines.
 		body := "line 1\n{{ .nonexistent }}"
 		tmpl, err := Parse(body, "WORKFLOW.md", 7)
@@ -374,6 +422,8 @@ func TestRender_Errors(t *testing.T) {
 	})
 
 	t.Run("ErrorMessageContainsSource", func(t *testing.T) {
+		t.Parallel()
+
 		tmpl, err := Parse("{{ .config }}", "my/WORKFLOW.md", 5)
 		if err != nil {
 			t.Fatalf("parse: %v", err)
@@ -393,14 +443,18 @@ func TestRender_Errors(t *testing.T) {
 }
 
 func TestTemplateError_Unwrap(t *testing.T) {
+	t.Parallel()
+
 	sentinel := errors.New("sentinel")
 	te := &TemplateError{Kind: ErrTemplateParse, Source: "x.md", Err: sentinel}
 	if !errors.Is(te, sentinel) {
-		t.Error("Unwrap did not expose the underlying sentinel error")
+		t.Errorf("errors.Is(TemplateError, sentinel) = false, want true")
 	}
 }
 
 func TestRender_Concurrent(t *testing.T) {
+	t.Parallel()
+
 	tmpl, err := Parse(
 		"{{ .issue.title }} turn={{ .run.turn_number }}",
 		"WORKFLOW.md", 0,

--- a/internal/prompt/turn_test.go
+++ b/internal/prompt/turn_test.go
@@ -12,12 +12,16 @@ import (
 const branchingTemplate = `{{ if .run.is_continuation }}Continue turn {{ .run.turn_number }} cont=true{{ else }}Task: {{ .issue.title }} cont=false{{ end }}`
 
 func TestBuildTurnPrompt(t *testing.T) {
+	t.Parallel()
+
 	issue := map[string]any{
 		"title": "Fix login bug",
 		"state": "In Progress",
 	}
 
 	t.Run("FirstTurnFullPrompt", func(t *testing.T) {
+		t.Parallel()
+
 		tmpl, err := Parse(branchingTemplate, "WORKFLOW.md", 0)
 		if err != nil {
 			t.Fatalf("parse: %v", err)
@@ -28,17 +32,19 @@ func TestBuildTurnPrompt(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		if !strings.Contains(got, "Fix login bug") {
-			t.Errorf("expected issue title in output, got %q", got)
+			t.Errorf("BuildTurnPrompt() = %q, want substring %q", got, "Fix login bug")
 		}
 		if !strings.Contains(got, "cont=false") {
-			t.Errorf("expected cont=false in output, got %q", got)
+			t.Errorf("BuildTurnPrompt() = %q, want substring %q", got, "cont=false")
 		}
 		if got == DefaultContinuationPrompt {
-			t.Error("first turn must not return DefaultContinuationPrompt")
+			t.Errorf("BuildTurnPrompt() = DefaultContinuationPrompt, want author-defined prompt")
 		}
 	})
 
 	t.Run("ContinuationTurnRendersTemplate", func(t *testing.T) {
+		t.Parallel()
+
 		tmpl, err := Parse(branchingTemplate, "WORKFLOW.md", 0)
 		if err != nil {
 			t.Fatalf("parse: %v", err)
@@ -49,14 +55,16 @@ func TestBuildTurnPrompt(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		if got == DefaultContinuationPrompt {
-			t.Error("expected author-defined continuation, got DefaultContinuationPrompt")
+			t.Errorf("BuildTurnPrompt() = DefaultContinuationPrompt, want author-defined continuation")
 		}
 		if !strings.Contains(got, "cont=true") {
-			t.Errorf("expected cont=true in output, got %q", got)
+			t.Errorf("BuildTurnPrompt() = %q, want substring %q", got, "cont=true")
 		}
 	})
 
 	t.Run("ContinuationTurnShorter", func(t *testing.T) {
+		t.Parallel()
+
 		tmpl, err := Parse(branchingTemplate, "WORKFLOW.md", 0)
 		if err != nil {
 			t.Fatalf("parse: %v", err)
@@ -71,14 +79,16 @@ func TestBuildTurnPrompt(t *testing.T) {
 			t.Fatalf("continuation turn: %v", err)
 		}
 		if len(cont) >= len(first) {
-			t.Errorf("continuation (%d bytes) should be shorter than first turn (%d bytes)", len(cont), len(first))
+			t.Errorf("BuildTurnPrompt() continuation len = %d, want < first turn len %d", len(cont), len(first))
 		}
 		if strings.Contains(cont, "Fix login bug") {
-			t.Error("continuation should not contain the issue title")
+			t.Errorf("BuildTurnPrompt() continuation = %q, want no issue title", cont)
 		}
 	})
 
 	t.Run("ContinuationFallbackOnEmptyOutput", func(t *testing.T) {
+		t.Parallel()
+
 		// Template emits nothing when is_continuation is true (no else branch).
 		body := `{{ if not .run.is_continuation }}Full task: {{ .issue.title }}{{ end }}`
 		tmpl, err := Parse(body, "WORKFLOW.md", 0)
@@ -91,11 +101,13 @@ func TestBuildTurnPrompt(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		if got != DefaultContinuationPrompt {
-			t.Errorf("expected DefaultContinuationPrompt, got %q", got)
+			t.Errorf("BuildTurnPrompt() = %q, want DefaultContinuationPrompt", got)
 		}
 	})
 
 	t.Run("ContinuationFallbackOnWhitespaceOnly", func(t *testing.T) {
+		t.Parallel()
+
 		body := "{{ if .run.is_continuation }}  \n  {{ else }}Full task{{ end }}"
 		tmpl, err := Parse(body, "WORKFLOW.md", 0)
 		if err != nil {
@@ -107,11 +119,13 @@ func TestBuildTurnPrompt(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		if got != DefaultContinuationPrompt {
-			t.Errorf("expected DefaultContinuationPrompt, got %q", got)
+			t.Errorf("BuildTurnPrompt() = %q, want DefaultContinuationPrompt", got)
 		}
 	})
 
 	t.Run("FirstTurnEmptyNoFallback", func(t *testing.T) {
+		t.Parallel()
+
 		// First-turn empty output must pass through as-is, NOT substitute
 		// DefaultContinuationPrompt. The fallback is for continuation turns only.
 		tmpl, err := Parse("", "WORKFLOW.md", 0)
@@ -124,11 +138,13 @@ func TestBuildTurnPrompt(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		if got == DefaultContinuationPrompt {
-			t.Error("first turn empty output must not fall back to DefaultContinuationPrompt")
+			t.Errorf("BuildTurnPrompt(turnNumber=1) = DefaultContinuationPrompt, want empty passthrough")
 		}
 	})
 
 	t.Run("FirstTurnRenderError", func(t *testing.T) {
+		t.Parallel()
+
 		body := "{{ .issue.nonexistent_field }}"
 		tmpl, err := Parse(body, "WORKFLOW.md", 0)
 		if err != nil {
@@ -149,6 +165,8 @@ func TestBuildTurnPrompt(t *testing.T) {
 	})
 
 	t.Run("ContinuationTurnRenderError", func(t *testing.T) {
+		t.Parallel()
+
 		// References a missing field unconditionally — errors on all turns.
 		body := "{{ .issue.missing_field }}"
 		tmpl, err := Parse(body, "WORKFLOW.md", 0)
@@ -167,6 +185,8 @@ func TestBuildTurnPrompt(t *testing.T) {
 	})
 
 	t.Run("InvalidTurnNumber", func(t *testing.T) {
+		t.Parallel()
+
 		tmpl, err := Parse("hello", "WORKFLOW.md", 0)
 		if err != nil {
 			t.Fatalf("parse: %v", err)
@@ -179,11 +199,13 @@ func TestBuildTurnPrompt(t *testing.T) {
 		// Must NOT be a *TemplateError — this is a caller bug, not a template issue.
 		var te *TemplateError
 		if errors.As(err, &te) {
-			t.Errorf("expected plain error, got *TemplateError: %v", err)
+			t.Errorf("BuildTurnPrompt(turnNumber=0) error type = %T, want plain error", err)
 		}
 	})
 
 	t.Run("NilAttemptFirstRun", func(t *testing.T) {
+		t.Parallel()
+
 		tmpl, err := Parse("{{ .issue.title }} attempt={{ .attempt }}", "WORKFLOW.md", 0)
 		if err != nil {
 			t.Fatalf("parse: %v", err)
@@ -194,11 +216,13 @@ func TestBuildTurnPrompt(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		if !strings.Contains(got, "Fix login bug") {
-			t.Errorf("expected issue title in output, got %q", got)
+			t.Errorf("BuildTurnPrompt() = %q, want substring %q", got, "Fix login bug")
 		}
 	})
 
 	t.Run("RetryAttemptFirstTurn", func(t *testing.T) {
+		t.Parallel()
+
 		tmpl, err := Parse("{{ .issue.title }} attempt={{ .attempt }}", "WORKFLOW.md", 0)
 		if err != nil {
 			t.Fatalf("parse: %v", err)
@@ -209,11 +233,13 @@ func TestBuildTurnPrompt(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		if !strings.Contains(got, "attempt=2") {
-			t.Errorf("expected attempt=2 in output, got %q", got)
+			t.Errorf("BuildTurnPrompt() = %q, want substring %q", got, "attempt=2")
 		}
 	})
 
 	t.Run("ContinuationConsistentAcrossTurns", func(t *testing.T) {
+		t.Parallel()
+
 		tmpl, err := Parse(branchingTemplate, "WORKFLOW.md", 0)
 		if err != nil {
 			t.Fatalf("parse: %v", err)

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/sortie-ai/sortie/internal/domain"
 )
 
-// testConstructor is a trivial function type used to test generic
-// Registry behavior without coupling to domain.TrackerAdapter.
+// --- Test helpers ---
+
 type testConstructor func() string
 
 func newTestRegistry() *Registry[testConstructor] {
@@ -22,169 +22,227 @@ func dummyConstructor() testConstructor {
 	return func() string { return "marker" }
 }
 
+// --- Tests ---
+
 func TestRegisterAndGet(t *testing.T) {
+	t.Parallel()
+
 	r := newTestRegistry()
 	r.Register("alpha", dummyConstructor())
 
 	got, err := r.Get("alpha")
 	if err != nil {
-		t.Fatalf("Get(\"alpha\") returned unexpected error: %v", err)
+		t.Fatalf("Get(%q) unexpected error: %v", "alpha", err)
 	}
 	if got() != "marker" {
-		t.Errorf("constructor returned %q, want %q", got(), "marker")
+		t.Errorf("Get(%q)() = %q, want %q", "alpha", got(), "marker")
 	}
 }
 
-func TestGetUnknownKind_Empty(t *testing.T) {
-	r := newTestRegistry()
+func TestGet_UnknownKind(t *testing.T) {
+	t.Parallel()
 
-	_, err := r.Get("nonexistent")
-	if err == nil {
-		t.Fatal("Get(\"nonexistent\") returned nil error, want *RegistryError")
+	tests := []struct {
+		name          string
+		register      []string
+		lookup        string
+		wantAvailable []string
+		wantMsgPart   string
+	}{
+		{
+			name:          "empty registry",
+			register:      nil,
+			lookup:        "nonexistent",
+			wantAvailable: []string{},
+			wantMsgPart:   "no adapters registered",
+		},
+		{
+			name:          "lists available kinds sorted",
+			register:      []string{"beta", "alpha"},
+			lookup:        "gamma",
+			wantAvailable: []string{"alpha", "beta"},
+			wantMsgPart:   "alpha",
+		},
 	}
 
-	var re *RegistryError
-	if !errors.As(err, &re) {
-		t.Fatalf("error type = %T, want *RegistryError", err)
-	}
-	if re.Dimension != "test" {
-		t.Errorf("Dimension = %q, want %q", re.Dimension, "test")
-	}
-	if re.Kind != "nonexistent" {
-		t.Errorf("Kind = %q, want %q", re.Kind, "nonexistent")
-	}
-	if re.Available == nil {
-		t.Fatal("Available is nil, want non-nil empty slice")
-	}
-	if len(re.Available) != 0 {
-		t.Errorf("len(Available) = %d, want 0", len(re.Available))
-	}
-	if msg := err.Error(); !strings.Contains(msg, "no adapters registered") {
-		t.Errorf("error message = %q, want it to contain %q", msg, "no adapters registered")
-	}
-}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-func TestGetUnknownKind_ListsAvailable(t *testing.T) {
-	r := newTestRegistry()
-	r.Register("beta", dummyConstructor())
-	r.Register("alpha", dummyConstructor())
+			r := newTestRegistry()
+			for _, k := range tt.register {
+				r.Register(k, dummyConstructor())
+			}
 
-	_, err := r.Get("gamma")
-	if err == nil {
-		t.Fatal("Get(\"gamma\") returned nil error")
-	}
+			_, err := r.Get(tt.lookup)
+			if err == nil {
+				t.Fatalf("Get(%q) returned nil error, want *RegistryError", tt.lookup)
+			}
 
-	var re *RegistryError
-	if !errors.As(err, &re) {
-		t.Fatalf("error type = %T, want *RegistryError", err)
-	}
-
-	want := []string{"alpha", "beta"}
-	if len(re.Available) != len(want) {
-		t.Fatalf("Available = %v, want %v", re.Available, want)
-	}
-	for i, v := range want {
-		if re.Available[i] != v {
-			t.Errorf("Available[%d] = %q, want %q", i, re.Available[i], v)
-		}
-	}
-
-	msg := err.Error()
-	if !strings.Contains(msg, "alpha") || !strings.Contains(msg, "beta") {
-		t.Errorf("error message = %q, want it to contain both %q and %q", msg, "alpha", "beta")
-	}
-}
-
-func TestRegisterDuplicate_Panics(t *testing.T) {
-	r := newTestRegistry()
-	r.Register("dup", dummyConstructor())
-
-	defer func() {
-		v := recover()
-		if v == nil {
-			t.Fatal("expected panic on duplicate registration")
-		}
-		msg := fmt.Sprint(v)
-		if !strings.Contains(msg, "duplicate") {
-			t.Errorf("panic message = %q, want it to contain %q", msg, "duplicate")
-		}
-	}()
-
-	r.Register("dup", dummyConstructor())
-}
-
-func TestRegisterEmptyKind_Panics(t *testing.T) {
-	r := newTestRegistry()
-
-	defer func() {
-		v := recover()
-		if v == nil {
-			t.Fatal("expected panic on empty kind")
-		}
-		msg := fmt.Sprint(v)
-		if !strings.Contains(msg, "empty") {
-			t.Errorf("panic message = %q, want it to contain %q", msg, "empty")
-		}
-	}()
-
-	r.Register("", dummyConstructor())
-}
-
-func TestKinds_Sorted(t *testing.T) {
-	r := newTestRegistry()
-	r.Register("zulu", dummyConstructor())
-	r.Register("alpha", dummyConstructor())
-	r.Register("mike", dummyConstructor())
-
-	got := r.Kinds()
-	want := []string{"alpha", "mike", "zulu"}
-	if len(got) != len(want) {
-		t.Fatalf("Kinds() = %v, want %v", got, want)
-	}
-	for i, v := range want {
-		if got[i] != v {
-			t.Errorf("Kinds()[%d] = %q, want %q", i, got[i], v)
-		}
+			var re *RegistryError
+			if !errors.As(err, &re) {
+				t.Fatalf("Get(%q) error type = %T, want *RegistryError", tt.lookup, err)
+			}
+			if re.Dimension != "test" {
+				t.Errorf("RegistryError.Dimension = %q, want %q", re.Dimension, "test")
+			}
+			if re.Kind != tt.lookup {
+				t.Errorf("RegistryError.Kind = %q, want %q", re.Kind, tt.lookup)
+			}
+			if re.Available == nil {
+				t.Fatal("RegistryError.Available is nil, want non-nil slice")
+			}
+			if len(re.Available) != len(tt.wantAvailable) {
+				t.Fatalf("RegistryError.Available = %v, want %v", re.Available, tt.wantAvailable)
+			}
+			for i, v := range tt.wantAvailable {
+				if re.Available[i] != v {
+					t.Errorf("RegistryError.Available[%d] = %q, want %q", i, re.Available[i], v)
+				}
+			}
+			if msg := err.Error(); !strings.Contains(msg, tt.wantMsgPart) {
+				t.Errorf("Error() = %q, want it to contain %q", msg, tt.wantMsgPart)
+			}
+		})
 	}
 }
 
-func TestKinds_Empty(t *testing.T) {
-	r := newTestRegistry()
+func TestRegister_Panics(t *testing.T) {
+	t.Parallel()
 
-	got := r.Kinds()
-	if got == nil {
-		t.Fatal("Kinds() returned nil, want non-nil empty slice")
+	tests := []struct {
+		name    string
+		kind    string
+		setup   func(*Registry[testConstructor])
+		wantMsg string
+	}{
+		{
+			name:    "empty kind",
+			kind:    "",
+			setup:   nil,
+			wantMsg: "empty",
+		},
+		{
+			name: "duplicate kind",
+			kind: "dup",
+			setup: func(r *Registry[testConstructor]) {
+				r.Register("dup", dummyConstructor())
+			},
+			wantMsg: "duplicate",
+		},
 	}
-	if len(got) != 0 {
-		t.Errorf("len(Kinds()) = %d, want 0", len(got))
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			r := newTestRegistry()
+			if tt.setup != nil {
+				tt.setup(r)
+			}
+
+			defer func() {
+				v := recover()
+				if v == nil {
+					t.Fatalf("Register(%q) did not panic", tt.kind)
+				}
+				msg := fmt.Sprint(v)
+				if !strings.Contains(msg, tt.wantMsg) {
+					t.Errorf("Register(%q) panic = %q, want it to contain %q", tt.kind, msg, tt.wantMsg)
+				}
+			}()
+
+			r.Register(tt.kind, dummyConstructor())
+		})
 	}
 }
 
-func TestRegistryError_Format_NoAvailable(t *testing.T) {
-	e := &RegistryError{
-		Dimension: "tracker",
-		Kind:      "linear",
-		Available: []string{},
+func TestKinds(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		register []string
+		want     []string
+	}{
+		{
+			name:     "empty registry",
+			register: nil,
+			want:     []string{},
+		},
+		{
+			name:     "returns sorted",
+			register: []string{"zulu", "alpha", "mike"},
+			want:     []string{"alpha", "mike", "zulu"},
+		},
 	}
-	want := `unknown tracker adapter kind "linear"; no adapters registered`
-	if got := e.Error(); got != want {
-		t.Errorf("Error() = %q, want %q", got, want)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			r := newTestRegistry()
+			for _, k := range tt.register {
+				r.Register(k, dummyConstructor())
+			}
+
+			got := r.Kinds()
+			if got == nil {
+				t.Fatal("Kinds() returned nil, want non-nil slice")
+			}
+			if len(got) != len(tt.want) {
+				t.Fatalf("Kinds() = %v, want %v", got, tt.want)
+			}
+			for i, v := range tt.want {
+				if got[i] != v {
+					t.Errorf("Kinds()[%d] = %q, want %q", i, got[i], v)
+				}
+			}
+		})
 	}
 }
 
-func TestRegistryError_Format_WithAvailable(t *testing.T) {
-	e := &RegistryError{
-		Dimension: "agent",
-		Kind:      "foo",
-		Available: []string{"claude-code", "mock"},
+func TestRegistryError_Error(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  *RegistryError
+		want string
+	}{
+		{
+			name: "no available adapters",
+			err: &RegistryError{
+				Dimension: "tracker",
+				Kind:      "linear",
+				Available: []string{},
+			},
+			want: `unknown tracker adapter kind "linear"; no adapters registered`,
+		},
+		{
+			name: "with available adapters",
+			err: &RegistryError{
+				Dimension: "agent",
+				Kind:      "foo",
+				Available: []string{"claude-code", "mock"},
+			},
+			want: `unknown agent adapter kind "foo"; registered: [claude-code, mock]`,
+		},
 	}
-	want := `unknown agent adapter kind "foo"; registered: [claude-code, mock]`
-	if got := e.Error(); got != want {
-		t.Errorf("Error() = %q, want %q", got, want)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := tt.err.Error(); got != tt.want {
+				t.Errorf("RegistryError.Error() = %q, want %q", got, tt.want)
+			}
+		})
 	}
 }
 
-// Compile-time interface satisfaction check.
+// --- Type-specific constructor tests ---
+
 var _ domain.TrackerAdapter = (*mockTrackerAdapter)(nil)
 
 type mockTrackerAdapter struct{}
@@ -209,7 +267,9 @@ func (m *mockTrackerAdapter) FetchIssueComments(_ context.Context, _ string) ([]
 	return nil, nil
 }
 
-func TestTrackerConstructor_Integration(t *testing.T) {
+func TestTrackerRegistry(t *testing.T) {
+	t.Parallel()
+
 	r := NewRegistry[TrackerConstructor]("tracker")
 	r.Register("mock", func(_ map[string]any) (domain.TrackerAdapter, error) {
 		return &mockTrackerAdapter{}, nil
@@ -217,36 +277,18 @@ func TestTrackerConstructor_Integration(t *testing.T) {
 
 	constructor, err := r.Get("mock")
 	if err != nil {
-		t.Fatalf("Get(\"mock\") returned unexpected error: %v", err)
+		t.Fatalf("Get(%q) unexpected error: %v", "mock", err)
 	}
 
 	adapter, err := constructor(nil)
 	if err != nil {
-		t.Fatalf("constructor returned unexpected error: %v", err)
+		t.Fatalf("TrackerConstructor() unexpected error: %v", err)
 	}
-
-	issues, err := adapter.FetchCandidateIssues(context.Background())
-	if err != nil {
-		t.Fatalf("FetchCandidateIssues returned unexpected error: %v", err)
-	}
-	if issues != nil {
-		t.Errorf("FetchCandidateIssues returned %v, want nil", issues)
+	if adapter == nil {
+		t.Fatal("TrackerConstructor() returned nil adapter")
 	}
 }
 
-func TestPackageLevelTrackers_Usable(t *testing.T) {
-	if Trackers == nil {
-		t.Fatal("Trackers is nil")
-	}
-	kinds := Trackers.Kinds()
-	if kinds == nil {
-		t.Fatal("Trackers.Kinds() returned nil, want non-nil slice")
-	}
-}
-
-// --- Agent adapter registry tests ---
-
-// Compile-time interface satisfaction check for agent mock.
 var _ domain.AgentAdapter = (*mockAgentAdapter)(nil)
 
 type mockAgentAdapter struct{}
@@ -267,7 +309,9 @@ func (m *mockAgentAdapter) EventStream() <-chan domain.AgentEvent {
 	return nil
 }
 
-func TestAgentConstructor_Integration(t *testing.T) {
+func TestAgentRegistry(t *testing.T) {
+	t.Parallel()
+
 	r := NewRegistry[AgentConstructor]("agent")
 	r.Register("mock", func(_ map[string]any) (domain.AgentAdapter, error) {
 		return &mockAgentAdapter{}, nil
@@ -275,52 +319,40 @@ func TestAgentConstructor_Integration(t *testing.T) {
 
 	constructor, err := r.Get("mock")
 	if err != nil {
-		t.Fatalf("Get(\"mock\") returned unexpected error: %v", err)
+		t.Fatalf("Get(%q) unexpected error: %v", "mock", err)
 	}
 
 	adapter, err := constructor(nil)
 	if err != nil {
-		t.Fatalf("constructor returned unexpected error: %v", err)
+		t.Fatalf("AgentConstructor() unexpected error: %v", err)
 	}
-
-	session, err := adapter.StartSession(context.Background(), domain.StartSessionParams{})
-	if err != nil {
-		t.Fatalf("StartSession returned unexpected error: %v", err)
-	}
-	if session.ID != "" {
-		t.Errorf("session.ID = %q, want empty string", session.ID)
+	if adapter == nil {
+		t.Fatal("AgentConstructor() returned nil adapter")
 	}
 }
 
-func TestAgentConstructor_UnknownKind(t *testing.T) {
-	r := NewRegistry[AgentConstructor]("agent")
-	r.Register("mock", func(_ map[string]any) (domain.AgentAdapter, error) {
-		return &mockAgentAdapter{}, nil
+func TestPackageLevelRegistries(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Trackers", func(t *testing.T) {
+		t.Parallel()
+
+		if Trackers == nil {
+			t.Fatal("Trackers is nil")
+		}
+		if kinds := Trackers.Kinds(); kinds == nil {
+			t.Fatal("Trackers.Kinds() returned nil, want non-nil slice")
+		}
 	})
 
-	_, err := r.Get("unknown")
-	if err == nil {
-		t.Fatal("Get(\"unknown\") returned nil error, want *RegistryError")
-	}
+	t.Run("Agents", func(t *testing.T) {
+		t.Parallel()
 
-	var re *RegistryError
-	if !errors.As(err, &re) {
-		t.Fatalf("error type = %T, want *RegistryError", err)
-	}
-	if re.Dimension != "agent" {
-		t.Errorf("Dimension = %q, want %q", re.Dimension, "agent")
-	}
-	if re.Kind != "unknown" {
-		t.Errorf("Kind = %q, want %q", re.Kind, "unknown")
-	}
-}
-
-func TestPackageLevelAgents_Usable(t *testing.T) {
-	if Agents == nil {
-		t.Fatal("Agents is nil")
-	}
-	kinds := Agents.Kinds()
-	if kinds == nil {
-		t.Fatal("Agents.Kinds() returned nil, want non-nil slice")
-	}
+		if Agents == nil {
+			t.Fatal("Agents is nil")
+		}
+		if kinds := Agents.Kinds(); kinds == nil {
+			t.Fatal("Agents.Kinds() returned nil, want non-nil slice")
+		}
+	})
 }

--- a/internal/tracker/file/file_test.go
+++ b/internal/tracker/file/file_test.go
@@ -41,6 +41,8 @@ func requireTrackerError(t *testing.T, err error) {
 // --- Constructor tests ---
 
 func TestNewFileAdapter(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name    string
 		config  map[string]any
@@ -63,6 +65,8 @@ func TestNewFileAdapter(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			a, err := NewFileAdapter(tt.config)
 			if tt.wantErr {
 				requireTrackerError(t, err)
@@ -82,6 +86,8 @@ func TestNewFileAdapter(t *testing.T) {
 }
 
 func TestNewFileAdapter_YAMLAnySliceExtraction(t *testing.T) {
+	t.Parallel()
+
 	// YAML decoders produce []any, not []string. Verify the constructor
 	// handles this without panic and lowercases state values.
 	config := map[string]any{
@@ -104,9 +110,13 @@ func TestNewFileAdapter_YAMLAnySliceExtraction(t *testing.T) {
 // --- FetchCandidateIssues tests ---
 
 func TestFetchCandidateIssues(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 
 	t.Run("filters by active states", func(t *testing.T) {
+		t.Parallel()
+
 		a := newAdapter(t, fixture("basic.json"), []any{"to do", "in progress"})
 		issues, err := a.FetchCandidateIssues(ctx)
 		if err != nil {
@@ -125,6 +135,8 @@ func TestFetchCandidateIssues(t *testing.T) {
 	})
 
 	t.Run("no active states returns all", func(t *testing.T) {
+		t.Parallel()
+
 		a := newAdapter(t, fixture("basic.json"), nil)
 		issues, err := a.FetchCandidateIssues(ctx)
 		if err != nil {
@@ -136,6 +148,8 @@ func TestFetchCandidateIssues(t *testing.T) {
 	})
 
 	t.Run("empty file", func(t *testing.T) {
+		t.Parallel()
+
 		a := newAdapter(t, fixture("empty.json"), nil)
 		issues, err := a.FetchCandidateIssues(ctx)
 		if err != nil {
@@ -150,18 +164,24 @@ func TestFetchCandidateIssues(t *testing.T) {
 	})
 
 	t.Run("malformed json", func(t *testing.T) {
+		t.Parallel()
+
 		a := newAdapter(t, fixture("malformed.json"), nil)
 		_, err := a.FetchCandidateIssues(ctx)
 		requireTrackerError(t, err)
 	})
 
 	t.Run("nonexistent file", func(t *testing.T) {
+		t.Parallel()
+
 		a := newAdapter(t, "testdata/does_not_exist.json", nil)
 		_, err := a.FetchCandidateIssues(ctx)
 		requireTrackerError(t, err)
 	})
 
 	t.Run("comments are nil", func(t *testing.T) {
+		t.Parallel()
+
 		a := newAdapter(t, fixture("basic.json"), nil)
 		issues, err := a.FetchCandidateIssues(ctx)
 		if err != nil {
@@ -175,6 +195,8 @@ func TestFetchCandidateIssues(t *testing.T) {
 	})
 
 	t.Run("case-insensitive state filtering", func(t *testing.T) {
+		t.Parallel()
+
 		a := newAdapter(t, fixture("basic.json"), []any{"TO DO"})
 		issues, err := a.FetchCandidateIssues(ctx)
 		if err != nil {
@@ -192,10 +214,14 @@ func TestFetchCandidateIssues(t *testing.T) {
 // --- FetchIssueByID tests ---
 
 func TestFetchIssueByID(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 	a := newAdapter(t, fixture("basic.json"), nil)
 
 	t.Run("fully populated issue", func(t *testing.T) {
+		t.Parallel()
+
 		iss, err := a.FetchIssueByID(ctx, "10001")
 		if err != nil {
 			t.Fatalf("FetchIssueByID: %v", err)
@@ -266,11 +292,15 @@ func TestFetchIssueByID(t *testing.T) {
 	})
 
 	t.Run("not found", func(t *testing.T) {
+		t.Parallel()
+
 		_, err := a.FetchIssueByID(ctx, "99999")
 		requireTrackerError(t, err)
 	})
 
 	t.Run("empty comments array", func(t *testing.T) {
+		t.Parallel()
+
 		iss, err := a.FetchIssueByID(ctx, "10002")
 		if err != nil {
 			t.Fatalf("FetchIssueByID: %v", err)
@@ -287,10 +317,14 @@ func TestFetchIssueByID(t *testing.T) {
 // --- FetchIssuesByStates tests ---
 
 func TestFetchIssuesByStates(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 	a := newAdapter(t, fixture("basic.json"), nil)
 
 	t.Run("match by original case", func(t *testing.T) {
+		t.Parallel()
+
 		issues, err := a.FetchIssuesByStates(ctx, []string{"Done"})
 		if err != nil {
 			t.Fatalf("FetchIssuesByStates: %v", err)
@@ -304,6 +338,8 @@ func TestFetchIssuesByStates(t *testing.T) {
 	})
 
 	t.Run("case-insensitive matching", func(t *testing.T) {
+		t.Parallel()
+
 		issues, err := a.FetchIssuesByStates(ctx, []string{"done"})
 		if err != nil {
 			t.Fatalf("FetchIssuesByStates: %v", err)
@@ -315,6 +351,8 @@ func TestFetchIssuesByStates(t *testing.T) {
 
 	// Section 17.3: empty states returns empty without API call.
 	t.Run("empty states slice", func(t *testing.T) {
+		t.Parallel()
+
 		issues, err := a.FetchIssuesByStates(ctx, []string{})
 		if err != nil {
 			t.Fatalf("FetchIssuesByStates: %v", err)
@@ -328,6 +366,8 @@ func TestFetchIssuesByStates(t *testing.T) {
 	})
 
 	t.Run("no matching states", func(t *testing.T) {
+		t.Parallel()
+
 		issues, err := a.FetchIssuesByStates(ctx, []string{"Nonexistent"})
 		if err != nil {
 			t.Fatalf("FetchIssuesByStates: %v", err)
@@ -341,10 +381,14 @@ func TestFetchIssuesByStates(t *testing.T) {
 // --- FetchIssueStatesByIDs tests ---
 
 func TestFetchIssueStatesByIDs(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 	a := newAdapter(t, fixture("basic.json"), nil)
 
 	t.Run("multiple found", func(t *testing.T) {
+		t.Parallel()
+
 		m, err := a.FetchIssueStatesByIDs(ctx, []string{"10001", "10002"})
 		if err != nil {
 			t.Fatalf("FetchIssueStatesByIDs: %v", err)
@@ -361,6 +405,8 @@ func TestFetchIssueStatesByIDs(t *testing.T) {
 	})
 
 	t.Run("missing ID omitted", func(t *testing.T) {
+		t.Parallel()
+
 		m, err := a.FetchIssueStatesByIDs(ctx, []string{"10001", "99999"})
 		if err != nil {
 			t.Fatalf("FetchIssueStatesByIDs: %v", err)
@@ -374,6 +420,8 @@ func TestFetchIssueStatesByIDs(t *testing.T) {
 	})
 
 	t.Run("empty IDs", func(t *testing.T) {
+		t.Parallel()
+
 		m, err := a.FetchIssueStatesByIDs(ctx, []string{})
 		if err != nil {
 			t.Fatalf("FetchIssueStatesByIDs: %v", err)
@@ -390,10 +438,14 @@ func TestFetchIssueStatesByIDs(t *testing.T) {
 // --- FetchIssueComments tests ---
 
 func TestFetchIssueComments(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 	a := newAdapter(t, fixture("basic.json"), nil)
 
 	t.Run("issue with comments", func(t *testing.T) {
+		t.Parallel()
+
 		comments, err := a.FetchIssueComments(ctx, "10001")
 		if err != nil {
 			t.Fatalf("FetchIssueComments: %v", err)
@@ -417,6 +469,8 @@ func TestFetchIssueComments(t *testing.T) {
 	})
 
 	t.Run("empty comments array", func(t *testing.T) {
+		t.Parallel()
+
 		comments, err := a.FetchIssueComments(ctx, "10002")
 		if err != nil {
 			t.Fatalf("FetchIssueComments: %v", err)
@@ -430,6 +484,8 @@ func TestFetchIssueComments(t *testing.T) {
 	})
 
 	t.Run("null comments coerced to empty", func(t *testing.T) {
+		t.Parallel()
+
 		comments, err := a.FetchIssueComments(ctx, "10003")
 		if err != nil {
 			t.Fatalf("FetchIssueComments: %v", err)
@@ -443,6 +499,8 @@ func TestFetchIssueComments(t *testing.T) {
 	})
 
 	t.Run("not found", func(t *testing.T) {
+		t.Parallel()
+
 		_, err := a.FetchIssueComments(ctx, "99999")
 		requireTrackerError(t, err)
 	})
@@ -451,6 +509,8 @@ func TestFetchIssueComments(t *testing.T) {
 // --- Normalization tests (Section 11.3) ---
 
 func TestNormalization(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 	a := newAdapter(t, fixture("normalization.json"), nil)
 	issues, err := a.FetchCandidateIssues(ctx)
@@ -464,6 +524,8 @@ func TestNormalization(t *testing.T) {
 	}
 
 	t.Run("labels lowercased", func(t *testing.T) {
+		t.Parallel()
+
 		iss := issueByID["n1"]
 		want := []string{"bug", "high-priority"}
 		if len(iss.Labels) != len(want) {
@@ -477,24 +539,32 @@ func TestNormalization(t *testing.T) {
 	})
 
 	t.Run("string priority is nil", func(t *testing.T) {
+		t.Parallel()
+
 		if issueByID["n2"].Priority != nil {
 			t.Errorf("Priority = %v, want nil", *issueByID["n2"].Priority)
 		}
 	})
 
 	t.Run("float priority is nil", func(t *testing.T) {
+		t.Parallel()
+
 		if issueByID["n3"].Priority != nil {
 			t.Errorf("Priority = %v, want nil", *issueByID["n3"].Priority)
 		}
 	})
 
 	t.Run("boolean priority is nil", func(t *testing.T) {
+		t.Parallel()
+
 		if issueByID["n4"].Priority != nil {
 			t.Errorf("Priority = %v, want nil", *issueByID["n4"].Priority)
 		}
 	})
 
 	t.Run("integer priority", func(t *testing.T) {
+		t.Parallel()
+
 		p := issueByID["n5"].Priority
 		if p == nil {
 			t.Fatal("Priority is nil, want 1")
@@ -505,18 +575,24 @@ func TestNormalization(t *testing.T) {
 	})
 
 	t.Run("null priority is nil", func(t *testing.T) {
+		t.Parallel()
+
 		if issueByID["n6"].Priority != nil {
 			t.Errorf("Priority = %v, want nil", *issueByID["n6"].Priority)
 		}
 	})
 
 	t.Run("absent priority is nil", func(t *testing.T) {
+		t.Parallel()
+
 		if issueByID["n7"].Priority != nil {
 			t.Errorf("Priority = %v, want nil", *issueByID["n7"].Priority)
 		}
 	})
 
 	t.Run("absent labels is non-nil empty", func(t *testing.T) {
+		t.Parallel()
+
 		iss := issueByID["n7"]
 		if iss.Labels == nil {
 			t.Fatal("Labels is nil, want non-nil empty slice")
@@ -527,6 +603,8 @@ func TestNormalization(t *testing.T) {
 	})
 
 	t.Run("absent blocked_by is non-nil empty", func(t *testing.T) {
+		t.Parallel()
+
 		iss := issueByID["n7"]
 		if iss.BlockedBy == nil {
 			t.Fatal("BlockedBy is nil, want non-nil empty slice")
@@ -537,12 +615,16 @@ func TestNormalization(t *testing.T) {
 	})
 
 	t.Run("absent parent is nil", func(t *testing.T) {
+		t.Parallel()
+
 		if issueByID["n7"].Parent != nil {
 			t.Errorf("Parent = %v, want nil", issueByID["n7"].Parent)
 		}
 	})
 
 	t.Run("absent description is empty string", func(t *testing.T) {
+		t.Parallel()
+
 		if issueByID["n7"].Description != "" {
 			t.Errorf("Description = %q, want empty", issueByID["n7"].Description)
 		}
@@ -552,6 +634,8 @@ func TestNormalization(t *testing.T) {
 // --- Registry integration test ---
 
 func TestRegistryIntegration(t *testing.T) {
+	t.Parallel()
+
 	ctor, err := registry.Trackers.Get("file")
 	if err != nil {
 		t.Fatalf("registry.Trackers.Get(\"file\"): %v", err)

--- a/internal/tracker/jira/adf_test.go
+++ b/internal/tracker/jira/adf_test.go
@@ -2,11 +2,12 @@ package jira
 
 import (
 	"encoding/json"
-	"os"
 	"testing"
 )
 
 func TestFlattenADF(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name  string
 		input any
@@ -180,6 +181,8 @@ func TestFlattenADF(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			got := flattenADF(tt.input)
 			if got != tt.want {
 				t.Errorf("flattenADF() = %q, want %q", got, tt.want)
@@ -189,10 +192,9 @@ func TestFlattenADF(t *testing.T) {
 }
 
 func TestFlattenADF_Fixture(t *testing.T) {
-	data, err := os.ReadFile("testdata/adf_description.json")
-	if err != nil {
-		t.Fatalf("reading fixture: %v", err)
-	}
+	t.Parallel()
+
+	data := loadFixture(t, "adf_description.json")
 
 	var node any
 	if err := json.Unmarshal(data, &node); err != nil {

--- a/internal/tracker/jira/client_test.go
+++ b/internal/tracker/jira/client_test.go
@@ -13,6 +13,8 @@ import (
 )
 
 func TestClientDo_Success(t *testing.T) {
+	t.Parallel()
+
 	var gotHeaders http.Header
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotHeaders = r.Header
@@ -41,6 +43,8 @@ func TestClientDo_Success(t *testing.T) {
 }
 
 func TestClientDo_QueryParams(t *testing.T) {
+	t.Parallel()
+
 	var gotQuery url.Values
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotQuery = r.URL.Query()
@@ -64,6 +68,8 @@ func TestClientDo_QueryParams(t *testing.T) {
 }
 
 func TestClientDo_ErrorMapping(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name     string
 		status   int
@@ -118,6 +124,8 @@ func TestClientDo_ErrorMapping(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				for k, v := range tt.headers {
 					w.Header().Set(k, v)
@@ -148,6 +156,8 @@ func TestClientDo_ErrorMapping(t *testing.T) {
 }
 
 func TestClientDo_NetworkFailure(t *testing.T) {
+	t.Parallel()
+
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
 	srv.Close() // close immediately to cause connection refused
 
@@ -167,6 +177,8 @@ func TestClientDo_NetworkFailure(t *testing.T) {
 }
 
 func TestClientDo_ContextCancellation(t *testing.T) {
+	t.Parallel()
+
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))

--- a/internal/tracker/jira/jira_test.go
+++ b/internal/tracker/jira/jira_test.go
@@ -59,6 +59,8 @@ func loadFixture(t *testing.T, name string) []byte {
 // --- Constructor tests ---
 
 func TestNewJiraAdapter(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name     string
 		config   map[string]any
@@ -120,6 +122,8 @@ func TestNewJiraAdapter(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			a, err := NewJiraAdapter(tt.config)
 			if tt.wantErr {
 				assertTrackerErrorKind(t, err, tt.wantKind)
@@ -139,6 +143,8 @@ func TestNewJiraAdapter(t *testing.T) {
 }
 
 func TestNewJiraAdapter_DefaultActiveStates(t *testing.T) {
+	t.Parallel()
+
 	a := mustAdapter(t, validConfig("https://x.atlassian.net"))
 	if len(a.activeStates) != 3 {
 		t.Fatalf("activeStates len = %d, want 3", len(a.activeStates))
@@ -149,6 +155,8 @@ func TestNewJiraAdapter_DefaultActiveStates(t *testing.T) {
 }
 
 func TestNewJiraAdapter_CustomActiveStates(t *testing.T) {
+	t.Parallel()
+
 	config := validConfig("https://x.atlassian.net")
 	config["active_states"] = []any{"Open", "WIP"}
 	a := mustAdapter(t, config)
@@ -158,6 +166,8 @@ func TestNewJiraAdapter_CustomActiveStates(t *testing.T) {
 }
 
 func TestNewJiraAdapter_QueryFilter(t *testing.T) {
+	t.Parallel()
+
 	config := validConfig("https://x.atlassian.net")
 	config["query_filter"] = "component = 'api'"
 	a := mustAdapter(t, config)
@@ -167,6 +177,8 @@ func TestNewJiraAdapter_QueryFilter(t *testing.T) {
 }
 
 func TestNewJiraAdapter_QueryFilter_Absent(t *testing.T) {
+	t.Parallel()
+
 	a := mustAdapter(t, validConfig("https://x.atlassian.net"))
 	if a.queryFilter != "" {
 		t.Errorf("queryFilter = %q, want empty", a.queryFilter)
@@ -174,6 +186,8 @@ func TestNewJiraAdapter_QueryFilter_Absent(t *testing.T) {
 }
 
 func TestNewJiraAdapter_EndpointTrailingSlash(t *testing.T) {
+	t.Parallel()
+
 	config := validConfig("https://x.atlassian.net/")
 	a := mustAdapter(t, config)
 	if a.endpoint != "https://x.atlassian.net" {
@@ -182,6 +196,8 @@ func TestNewJiraAdapter_EndpointTrailingSlash(t *testing.T) {
 }
 
 func TestRegistration(t *testing.T) {
+	t.Parallel()
+
 	ctor, err := registry.Trackers.Get("jira")
 	if err != nil {
 		t.Fatalf("registry.Trackers.Get(jira): %v", err)
@@ -194,6 +210,8 @@ func TestRegistration(t *testing.T) {
 // --- FetchCandidateIssues tests ---
 
 func TestFetchCandidateIssues_SinglePage(t *testing.T) {
+	t.Parallel()
+
 	fixture := loadFixture(t, "search_single_page.json")
 	var receivedJQL string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -238,6 +256,8 @@ func TestFetchCandidateIssues_SinglePage(t *testing.T) {
 }
 
 func TestFetchCandidateIssues_MultiPage(t *testing.T) {
+	t.Parallel()
+
 	page1 := loadFixture(t, "search_multi_page_1.json")
 	page2 := loadFixture(t, "search_multi_page_2.json")
 
@@ -272,6 +292,8 @@ func TestFetchCandidateIssues_MultiPage(t *testing.T) {
 }
 
 func TestFetchCandidateIssues_Empty(t *testing.T) {
+	t.Parallel()
+
 	fixture := loadFixture(t, "search_empty.json")
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Write(fixture) //nolint:errcheck // test helper
@@ -292,6 +314,8 @@ func TestFetchCandidateIssues_Empty(t *testing.T) {
 }
 
 func TestFetchCandidateIssues_AuthError(t *testing.T) {
+	t.Parallel()
+
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusUnauthorized)
 	}))
@@ -303,6 +327,8 @@ func TestFetchCandidateIssues_AuthError(t *testing.T) {
 }
 
 func TestFetchCandidateIssues_ServerError(t *testing.T) {
+	t.Parallel()
+
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
 	}))
@@ -314,6 +340,8 @@ func TestFetchCandidateIssues_ServerError(t *testing.T) {
 }
 
 func TestFetchCandidateIssues_JQLSanitization(t *testing.T) {
+	t.Parallel()
+
 	var receivedJQL string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		receivedJQL = r.URL.Query().Get("jql")
@@ -338,6 +366,8 @@ func TestFetchCandidateIssues_JQLSanitization(t *testing.T) {
 }
 
 func TestFetchCandidateIssues_QueryFilter(t *testing.T) {
+	t.Parallel()
+
 	var receivedJQL string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		receivedJQL = r.URL.Query().Get("jql")
@@ -358,6 +388,8 @@ func TestFetchCandidateIssues_QueryFilter(t *testing.T) {
 }
 
 func TestFetchCandidateIssues_NoQueryFilter(t *testing.T) {
+	t.Parallel()
+
 	var receivedJQL string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		receivedJQL = r.URL.Query().Get("jql")
@@ -384,6 +416,8 @@ func TestFetchCandidateIssues_NoQueryFilter(t *testing.T) {
 // --- FetchIssueByID tests ---
 
 func TestFetchIssueByID_WithComments(t *testing.T) {
+	t.Parallel()
+
 	issueData := loadFixture(t, "issue_detail.json")
 	commentsData := loadFixture(t, "comments.json")
 
@@ -433,6 +467,8 @@ func TestFetchIssueByID_WithComments(t *testing.T) {
 }
 
 func TestFetchIssueByID_NoComments(t *testing.T) {
+	t.Parallel()
+
 	issueData := loadFixture(t, "issue_detail.json")
 	emptyComments := loadFixture(t, "comments_empty.json")
 
@@ -459,6 +495,8 @@ func TestFetchIssueByID_NoComments(t *testing.T) {
 }
 
 func TestFetchIssueByID_NotFound(t *testing.T) {
+	t.Parallel()
+
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNotFound)
 	}))
@@ -476,6 +514,8 @@ func TestFetchIssueByID_NotFound(t *testing.T) {
 }
 
 func TestFetchIssueByID_MultiPageComments(t *testing.T) {
+	t.Parallel()
+
 	issueData := loadFixture(t, "issue_detail.json")
 	commentsPage1 := loadFixture(t, "comments_multi_page_1.json")
 	commentsPage2 := loadFixture(t, "comments_multi_page_2.json")
@@ -513,6 +553,8 @@ func TestFetchIssueByID_MultiPageComments(t *testing.T) {
 // --- FetchIssuesByStates tests ---
 
 func TestFetchIssuesByStates_EmptyStates(t *testing.T) {
+	t.Parallel()
+
 	var called bool
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		called = true
@@ -536,6 +578,8 @@ func TestFetchIssuesByStates_EmptyStates(t *testing.T) {
 }
 
 func TestFetchIssuesByStates_SingleState(t *testing.T) {
+	t.Parallel()
+
 	var receivedJQL string
 	fixture := loadFixture(t, "search_single_page.json")
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -561,6 +605,8 @@ func TestFetchIssuesByStates_SingleState(t *testing.T) {
 }
 
 func TestFetchIssuesByStates_QueryFilter(t *testing.T) {
+	t.Parallel()
+
 	var receivedJQL string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		receivedJQL = r.URL.Query().Get("jql")
@@ -583,6 +629,8 @@ func TestFetchIssuesByStates_QueryFilter(t *testing.T) {
 // --- FetchIssueStatesByIDs tests ---
 
 func TestFetchIssueStatesByIDs_Empty(t *testing.T) {
+	t.Parallel()
+
 	var called bool
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		called = true
@@ -606,6 +654,8 @@ func TestFetchIssueStatesByIDs_Empty(t *testing.T) {
 }
 
 func TestFetchIssueStatesByIDs_SingleBatch(t *testing.T) {
+	t.Parallel()
+
 	var receivedJQL string
 	resp := searchResponse{
 		Issues: []jiraIssue{
@@ -648,6 +698,8 @@ func TestFetchIssueStatesByIDs_SingleBatch(t *testing.T) {
 }
 
 func TestFetchIssueStatesByIDs_MultiBatch(t *testing.T) {
+	t.Parallel()
+
 	var requestCount int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		atomic.AddInt32(&requestCount, 1)
@@ -687,6 +739,8 @@ func TestFetchIssueStatesByIDs_MultiBatch(t *testing.T) {
 }
 
 func TestFetchIssueStatesByIDs_NoQueryFilter(t *testing.T) {
+	t.Parallel()
+
 	var receivedJQL string
 	resp := searchResponse{
 		Issues: []jiraIssue{
@@ -717,6 +771,8 @@ func TestFetchIssueStatesByIDs_NoQueryFilter(t *testing.T) {
 // --- FetchIssueComments tests ---
 
 func TestFetchIssueComments_MultiPage(t *testing.T) {
+	t.Parallel()
+
 	page1 := loadFixture(t, "comments_multi_page_1.json")
 	page2 := loadFixture(t, "comments_multi_page_2.json")
 
@@ -747,6 +803,8 @@ func TestFetchIssueComments_MultiPage(t *testing.T) {
 }
 
 func TestFetchIssueComments_Empty(t *testing.T) {
+	t.Parallel()
+
 	fixture := loadFixture(t, "comments_empty.json")
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Write(fixture) //nolint:errcheck // test helper
@@ -767,6 +825,8 @@ func TestFetchIssueComments_Empty(t *testing.T) {
 }
 
 func TestFetchIssueComments_NotFound(t *testing.T) {
+	t.Parallel()
+
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNotFound)
 	}))
@@ -780,6 +840,8 @@ func TestFetchIssueComments_NotFound(t *testing.T) {
 // --- Full lifecycle integration test ---
 
 func TestAdapterLifecycle(t *testing.T) {
+	t.Parallel()
+
 	searchFixture := loadFixture(t, "search_single_page.json")
 	issueFixture := loadFixture(t, "issue_detail.json")
 	commentsFixture := loadFixture(t, "comments.json")

--- a/internal/tracker/jira/jql_test.go
+++ b/internal/tracker/jira/jql_test.go
@@ -3,6 +3,8 @@ package jira
 import "testing"
 
 func TestEscapeJQLString(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name  string
 		input string
@@ -16,6 +18,8 @@ func TestEscapeJQLString(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			got := escapeJQLString(tt.input)
 			if got != tt.want {
 				t.Errorf("escapeJQLString(%q) = %q, want %q", tt.input, got, tt.want)
@@ -25,6 +29,8 @@ func TestEscapeJQLString(t *testing.T) {
 }
 
 func TestBuildStatusIN(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name   string
 		states []string
@@ -37,6 +43,8 @@ func TestBuildStatusIN(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			got := buildStatusIN(tt.states)
 			if got != tt.want {
 				t.Errorf("buildStatusIN(%v) = %q, want %q", tt.states, got, tt.want)
@@ -46,6 +54,8 @@ func TestBuildStatusIN(t *testing.T) {
 }
 
 func TestBuildCandidateJQL(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name        string
 		project     string
@@ -87,6 +97,8 @@ func TestBuildCandidateJQL(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			got := buildCandidateJQL(tt.project, tt.states, tt.queryFilter)
 			if got != tt.want {
 				t.Errorf("buildCandidateJQL() =\n  %q\nwant\n  %q", got, tt.want)
@@ -96,6 +108,8 @@ func TestBuildCandidateJQL(t *testing.T) {
 }
 
 func TestBuildStatesFetchJQL(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name        string
 		project     string
@@ -119,6 +133,8 @@ func TestBuildStatesFetchJQL(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			got := buildStatesFetchJQL(tt.project, tt.states, tt.queryFilter)
 			if got != tt.want {
 				t.Errorf("buildStatesFetchJQL() =\n  %q\nwant\n  %q", got, tt.want)
@@ -128,6 +144,8 @@ func TestBuildStatesFetchJQL(t *testing.T) {
 }
 
 func TestBuildKeyINJQL(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name string
 		keys []string
@@ -151,6 +169,8 @@ func TestBuildKeyINJQL(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			got := buildKeyINJQL(tt.keys)
 			if got != tt.want {
 				t.Errorf("buildKeyINJQL(%v) =\n  %q\nwant\n  %q", tt.keys, got, tt.want)

--- a/internal/tracker/jira/normalize_test.go
+++ b/internal/tracker/jira/normalize_test.go
@@ -6,6 +6,8 @@ import (
 )
 
 func TestNormalizeSearchIssue_AllFields(t *testing.T) {
+	t.Parallel()
+
 	pri := "2"
 	ji := jiraIssue{
 		ID:  "10001",
@@ -87,6 +89,8 @@ func TestNormalizeSearchIssue_AllFields(t *testing.T) {
 }
 
 func TestNormalizeSearchIssue_NilFields(t *testing.T) {
+	t.Parallel()
+
 	ji := jiraIssue{
 		ID:  "10002",
 		Key: "PROJ-2",
@@ -132,6 +136,8 @@ func TestNormalizeSearchIssue_NilFields(t *testing.T) {
 }
 
 func TestNormalizeSearchIssue_NonIntegerPriority(t *testing.T) {
+	t.Parallel()
+
 	ji := jiraIssue{
 		ID:  "1",
 		Key: "X-1",
@@ -146,6 +152,8 @@ func TestNormalizeSearchIssue_NonIntegerPriority(t *testing.T) {
 }
 
 func TestNormalizeSearchIssue_BlockerExtraction(t *testing.T) {
+	t.Parallel()
+
 	ji := jiraIssue{
 		ID:  "1",
 		Key: "X-1",
@@ -193,7 +201,11 @@ func TestNormalizeSearchIssue_BlockerExtraction(t *testing.T) {
 }
 
 func TestNormalizeComments(t *testing.T) {
+	t.Parallel()
+
 	t.Run("normal comments", func(t *testing.T) {
+		t.Parallel()
+
 		comments := []jiraComment{
 			{
 				ID:      "100",
@@ -221,6 +233,8 @@ func TestNormalizeComments(t *testing.T) {
 	})
 
 	t.Run("nil author", func(t *testing.T) {
+		t.Parallel()
+
 		comments := []jiraComment{
 			{
 				ID:      "200",
@@ -236,6 +250,8 @@ func TestNormalizeComments(t *testing.T) {
 	})
 
 	t.Run("empty list", func(t *testing.T) {
+		t.Parallel()
+
 		result := normalizeComments([]jiraComment{})
 		if result == nil {
 			t.Error("result is nil, want non-nil empty slice")
@@ -247,22 +263,32 @@ func TestNormalizeComments(t *testing.T) {
 }
 
 func TestUnmarshalADF(t *testing.T) {
+	t.Parallel()
+
 	t.Run("nil input", func(t *testing.T) {
+		t.Parallel()
+
 		if v := unmarshalADF(nil); v != nil {
 			t.Errorf("got %v, want nil", v)
 		}
 	})
 	t.Run("empty input", func(t *testing.T) {
+		t.Parallel()
+
 		if v := unmarshalADF(json.RawMessage{}); v != nil {
 			t.Errorf("got %v, want nil", v)
 		}
 	})
 	t.Run("invalid json", func(t *testing.T) {
+		t.Parallel()
+
 		if v := unmarshalADF(json.RawMessage(`{invalid`)); v != nil {
 			t.Errorf("got %v, want nil", v)
 		}
 	})
 	t.Run("valid json", func(t *testing.T) {
+		t.Parallel()
+
 		v := unmarshalADF(json.RawMessage(`{"type":"doc"}`))
 		if v == nil {
 			t.Error("got nil, want non-nil")
@@ -278,6 +304,8 @@ func TestUnmarshalADF(t *testing.T) {
 }
 
 func TestNormalizeSearchIssue_EmptyLabelsSlice(t *testing.T) {
+	t.Parallel()
+
 	// Empty labels array from Jira (not nil) → non-nil empty slice
 	ji := jiraIssue{
 		ID:  "1",
@@ -296,6 +324,8 @@ func TestNormalizeSearchIssue_EmptyLabelsSlice(t *testing.T) {
 }
 
 func TestExtractBlockers_Empty(t *testing.T) {
+	t.Parallel()
+
 	result := extractBlockers(nil)
 	if result == nil {
 		t.Error("result is nil, want non-nil empty slice")

--- a/internal/workflow/loader_test.go
+++ b/internal/workflow/loader_test.go
@@ -10,6 +10,8 @@ import (
 )
 
 func TestLoad(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name                 string
 		content              []byte // nil means do not create the file
@@ -172,6 +174,8 @@ func TestLoad(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			var path string
 			if tt.skipFileCreate {
 				path = filepath.Join(t.TempDir(), "nonexistent", "WORKFLOW.md")
@@ -187,24 +191,24 @@ func TestLoad(t *testing.T) {
 
 			if tt.wantErr {
 				if err == nil {
-					t.Fatal("expected error, got nil")
+					t.Fatalf("Load(%q) error = nil, want *WorkflowError", path)
 				}
 				var wErr *WorkflowError
 				if !errors.As(err, &wErr) {
-					t.Fatalf("expected *WorkflowError, got %T: %v", err, err)
+					t.Fatalf("Load(%q) error type = %T, want *WorkflowError", path, err)
 				}
 				if wErr.Kind != tt.wantKind {
-					t.Errorf("expected Kind %d, got %d", tt.wantKind, wErr.Kind)
+					t.Errorf("Load(%q) WorkflowError.Kind = %d, want %d", path, wErr.Kind, tt.wantKind)
 				}
 				return
 			}
 
 			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
+				t.Fatalf("Load(%q) unexpected error: %v", path, err)
 			}
 
 			if wf.Config == nil {
-				t.Fatal("Config must never be nil")
+				t.Fatalf("Load(%q) Config = nil, want non-nil", path)
 			}
 
 			if tt.wantConfig != nil {
@@ -212,43 +216,53 @@ func TestLoad(t *testing.T) {
 			}
 
 			if wf.PromptTemplate != tt.wantPrompt {
-				t.Errorf("PromptTemplate mismatch\n  want: %q\n  got:  %q", tt.wantPrompt, wf.PromptTemplate)
+				t.Errorf("Load(%q) PromptTemplate = %q, want %q", path, wf.PromptTemplate, tt.wantPrompt)
 			}
 
 			if wf.FrontMatterLines != tt.wantFrontMatterLines {
-				t.Errorf("FrontMatterLines mismatch\n  want: %d\n  got:  %d", tt.wantFrontMatterLines, wf.FrontMatterLines)
+				t.Errorf("Load(%q) FrontMatterLines = %d, want %d", path, wf.FrontMatterLines, tt.wantFrontMatterLines)
 			}
 		})
 	}
 }
 
 func TestWorkflowError_Error(t *testing.T) {
+	t.Parallel()
+
 	t.Run("ErrParseError_hint", func(t *testing.T) {
+		t.Parallel()
+
 		e := &WorkflowError{Kind: ErrParseError, Path: "test.md", Err: errors.New("yaml: bad")}
 		msg := e.Error()
 		if want := "did you forget the closing '---' delimiter?"; !strings.Contains(msg, want) {
-			t.Errorf("ErrParseError message missing hint\n  want substring: %q\n  got: %q", want, msg)
+			t.Errorf("WorkflowError{Kind: ErrParseError}.Error() = %q, want substring %q", msg, want)
 		}
 	})
 
 	t.Run("ErrMissingFile_path", func(t *testing.T) {
+		t.Parallel()
+
 		e := &WorkflowError{Kind: ErrMissingFile, Path: "/some/path.md", Err: errors.New("no such file")}
 		msg := e.Error()
-		if !strings.Contains(msg, "/some/path.md") {
-			t.Errorf("ErrMissingFile message missing path\n  got: %q", msg)
+		if want := "/some/path.md"; !strings.Contains(msg, want) {
+			t.Errorf("WorkflowError{Kind: ErrMissingFile}.Error() = %q, want substring %q", msg, want)
 		}
 	})
 
 	t.Run("ErrFrontMatterNotMap_type", func(t *testing.T) {
+		t.Parallel()
+
 		e := &WorkflowError{Kind: ErrFrontMatterNotMap, Path: "t.md", Err: errors.New("got []interface {}")}
 		msg := e.Error()
-		if !strings.Contains(msg, "YAML map") {
-			t.Errorf("ErrFrontMatterNotMap message missing 'YAML map'\n  got: %q", msg)
+		if want := "YAML map"; !strings.Contains(msg, want) {
+			t.Errorf("WorkflowError{Kind: ErrFrontMatterNotMap}.Error() = %q, want substring %q", msg, want)
 		}
 	})
 }
 
 func TestWorkflowError_Unwrap(t *testing.T) {
+	t.Parallel()
+
 	sentinel := errors.New("sentinel")
 	e := &WorkflowError{Kind: ErrParseError, Path: "x.md", Err: sentinel}
 	if !errors.Is(e, sentinel) {
@@ -263,7 +277,7 @@ func TestWorkflowError_Unwrap(t *testing.T) {
 func assertMapsEqual(t *testing.T, want, got map[string]any) {
 	t.Helper()
 	if len(want) != len(got) {
-		t.Errorf("map length mismatch: want %d, got %d\n  want: %v\n  got:  %v", len(want), len(got), want, got)
+		t.Errorf("map length = %d, want %d\n  got:  %v\n  want: %v", len(got), len(want), got, want)
 		return
 	}
 	for k, wv := range want {

--- a/internal/workflow/manager_test.go
+++ b/internal/workflow/manager_test.go
@@ -64,7 +64,11 @@ func mustRemove(t *testing.T, path string) {
 }
 
 func TestNewManager(t *testing.T) {
+	t.Parallel()
+
 	t.Run("ValidFile", func(t *testing.T) {
+		t.Parallel()
+
 		dir := t.TempDir()
 		path := filepath.Join(dir, "WORKFLOW.md")
 		mustWriteFile(t, path, validWorkflow(5000))
@@ -86,36 +90,44 @@ func TestNewManager(t *testing.T) {
 	})
 
 	t.Run("MissingFile", func(t *testing.T) {
+		t.Parallel()
+
 		_, err := NewManager(filepath.Join(t.TempDir(), "nonexistent.md"), testLogger())
 		if err == nil {
-			t.Fatal("expected error, got nil")
+			t.Fatal("NewManager() error = nil, want error")
 		}
 	})
 
 	t.Run("InvalidYAML", func(t *testing.T) {
+		t.Parallel()
+
 		dir := t.TempDir()
 		path := filepath.Join(dir, "WORKFLOW.md")
 		mustWriteFile(t, path, []byte("---\n: : : bad {{{\n---\nprompt\n"))
 
 		_, err := NewManager(path, testLogger())
 		if err == nil {
-			t.Fatal("expected error, got nil")
+			t.Fatal("NewManager() error = nil, want error")
 		}
 	})
 
 	t.Run("InvalidTemplate", func(t *testing.T) {
+		t.Parallel()
+
 		dir := t.TempDir()
 		path := filepath.Join(dir, "WORKFLOW.md")
 		mustWriteFile(t, path, []byte("---\nk: v\n---\n{{ .issue.title\n"))
 
 		_, err := NewManager(path, testLogger())
 		if err == nil {
-			t.Fatal("expected error, got nil")
+			t.Fatal("NewManager() error = nil, want error")
 		}
 	})
 }
 
 func TestManager_Reload(t *testing.T) {
+	t.Parallel()
+
 	dir := t.TempDir()
 	path := filepath.Join(dir, "WORKFLOW.md")
 	mustWriteFile(t, path, validWorkflow(5000))
@@ -140,6 +152,8 @@ func TestManager_Reload(t *testing.T) {
 }
 
 func TestManager_ReloadRetainsOnError(t *testing.T) {
+	t.Parallel()
+
 	dir := t.TempDir()
 	path := filepath.Join(dir, "WORKFLOW.md")
 	mustWriteFile(t, path, validWorkflow(5000))
@@ -154,7 +168,7 @@ func TestManager_ReloadRetainsOnError(t *testing.T) {
 
 	err = mgr.Reload()
 	if err == nil {
-		t.Fatal("expected Reload to return error")
+		t.Fatal("Reload() error = nil, want error")
 	}
 	if mgr.Config().Polling.IntervalMS != 5000 {
 		t.Errorf("after failed Reload: Polling.IntervalMS = %d, want 5000", mgr.Config().Polling.IntervalMS)
@@ -167,6 +181,8 @@ func TestManager_ReloadRetainsOnError(t *testing.T) {
 // Section 17.1: Workflow file changes are detected and trigger
 // re-read/re-apply without restart.
 func TestManager_WatchPicksUpChange(t *testing.T) {
+	t.Parallel()
+
 	dir := t.TempDir()
 	path := filepath.Join(dir, "WORKFLOW.md")
 	mustWriteFile(t, path, validWorkflow(5000))
@@ -200,6 +216,8 @@ func TestManager_WatchPicksUpChange(t *testing.T) {
 // Section 17.1: Invalid workflow reload keeps last known good effective
 // configuration and emits an operator-visible error.
 func TestManager_WatchInvalidRetainsGood(t *testing.T) {
+	t.Parallel()
+
 	dir := t.TempDir()
 	path := filepath.Join(dir, "WORKFLOW.md")
 	mustWriteFile(t, path, validWorkflow(5000))
@@ -237,6 +255,8 @@ func TestManager_WatchInvalidRetainsGood(t *testing.T) {
 }
 
 func TestManager_ConcurrentReadSafety(t *testing.T) {
+	t.Parallel()
+
 	dir := t.TempDir()
 	path := filepath.Join(dir, "WORKFLOW.md")
 	mustWriteFile(t, path, validWorkflow(5000))
@@ -290,6 +310,8 @@ func TestManager_ConcurrentReadSafety(t *testing.T) {
 }
 
 func TestManager_DebounceCoalescence(t *testing.T) {
+	t.Parallel()
+
 	dir := t.TempDir()
 	path := filepath.Join(dir, "WORKFLOW.md")
 	mustWriteFile(t, path, validWorkflow(1000))
@@ -326,6 +348,8 @@ func TestManager_DebounceCoalescence(t *testing.T) {
 }
 
 func TestManager_DeleteAndRecreate(t *testing.T) {
+	t.Parallel()
+
 	dir := t.TempDir()
 	path := filepath.Join(dir, "WORKFLOW.md")
 	mustWriteFile(t, path, validWorkflow(5000))
@@ -370,6 +394,8 @@ func TestManager_DeleteAndRecreate(t *testing.T) {
 }
 
 func TestManager_ContextCancellation(t *testing.T) {
+	t.Parallel()
+
 	dir := t.TempDir()
 	path := filepath.Join(dir, "WORKFLOW.md")
 	mustWriteFile(t, path, validWorkflow(5000))
@@ -402,6 +428,8 @@ func TestManager_ContextCancellation(t *testing.T) {
 }
 
 func TestManager_StopIdempotent(t *testing.T) {
+	t.Parallel()
+
 	dir := t.TempDir()
 	path := filepath.Join(dir, "WORKFLOW.md")
 	mustWriteFile(t, path, validWorkflow(5000))
@@ -423,6 +451,8 @@ func TestManager_StopIdempotent(t *testing.T) {
 }
 
 func TestManager_RecoverAfterInvalidReload(t *testing.T) {
+	t.Parallel()
+
 	dir := t.TempDir()
 	path := filepath.Join(dir, "WORKFLOW.md")
 	mustWriteFile(t, path, validWorkflow(5000))

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -124,7 +124,7 @@ func TestComputePath(t *testing.T) {
 
 		_, err := ComputePath("", "ABC-123")
 		if err == nil {
-			t.Fatal("ComputePath with empty root should error")
+			t.Fatal("ComputePath(\"\", \"ABC-123\") error = nil, want error")
 		}
 		var pe *PathError
 		if !errors.As(err, &pe) {
@@ -141,7 +141,7 @@ func TestComputePath(t *testing.T) {
 
 		_, err := ComputePath(root, "")
 		if err == nil {
-			t.Fatal("ComputePath with empty identifier should error")
+			t.Fatalf("ComputePath(%q, \"\") error = nil, want error", root)
 		}
 		var pe *PathError
 		if !errors.As(err, &pe) {
@@ -186,59 +186,53 @@ func TestComputePath(t *testing.T) {
 		}
 	})
 
+	// Section 9.5: workspace path must stay inside workspace root
 	t.Run("path is always under root", func(t *testing.T) {
 		t.Parallel()
 		root := t.TempDir()
 
 		identifiers := []string{"ABC-123", "A/B#C", "日本語", "my.task_1"}
 		for _, id := range identifiers {
-			res, err := ComputePath(root, id)
-			if err != nil {
-				t.Errorf("ComputePath(%q, %q) error: %v", root, id, err)
-				continue
-			}
+			t.Run(id, func(t *testing.T) {
+				t.Parallel()
 
-			dir := filepath.Dir(res.Path)
-			if dir != root {
-				t.Errorf("ComputePath(%q, %q): Dir(Path) = %q, want %q", root, id, dir, root)
-			}
-			if filepath.Base(res.Path) != res.Key {
-				t.Errorf("ComputePath(%q, %q): Base(Path) = %q, want Key %q", root, id, filepath.Base(res.Path), res.Key)
-			}
+				res, err := ComputePath(root, id)
+				if err != nil {
+					t.Fatalf("ComputePath(%q, %q) error: %v", root, id, err)
+				}
+
+				dir := filepath.Dir(res.Path)
+				if dir != root {
+					t.Errorf("ComputePath(%q, %q): Dir(Path) = %q, want %q", root, id, dir, root)
+				}
+				if filepath.Base(res.Path) != res.Key {
+					t.Errorf("ComputePath(%q, %q): Base(Path) = %q, want Key %q", root, id, filepath.Base(res.Path), res.Key)
+				}
+			})
 		}
 	})
 
-	t.Run("dot identifier rejected", func(t *testing.T) {
+	// Section 9.5: "." and ".." identifiers must be rejected
+	t.Run("special name identifiers rejected", func(t *testing.T) {
 		t.Parallel()
-		root := t.TempDir()
 
-		_, err := ComputePath(root, ".")
-		if err == nil {
-			t.Fatal("ComputePath with dot identifier should error")
-		}
-		var pe *PathError
-		if !errors.As(err, &pe) {
-			t.Fatalf("error type = %T, want *PathError", err)
-		}
-		if pe.Op != "sanitize" {
-			t.Errorf("PathError.Op = %q, want %q", pe.Op, "sanitize")
-		}
-	})
+		for _, id := range []string{".", ".."} {
+			t.Run(id, func(t *testing.T) {
+				t.Parallel()
+				root := t.TempDir()
 
-	t.Run("dotdot identifier rejected", func(t *testing.T) {
-		t.Parallel()
-		root := t.TempDir()
-
-		_, err := ComputePath(root, "..")
-		if err == nil {
-			t.Fatal("ComputePath with dotdot identifier should error")
-		}
-		var pe *PathError
-		if !errors.As(err, &pe) {
-			t.Fatalf("error type = %T, want *PathError", err)
-		}
-		if pe.Op != "sanitize" {
-			t.Errorf("PathError.Op = %q, want %q", pe.Op, "sanitize")
+				_, err := ComputePath(root, id)
+				if err == nil {
+					t.Fatalf("ComputePath(%q, %q) error = nil, want error", root, id)
+				}
+				var pe *PathError
+				if !errors.As(err, &pe) {
+					t.Fatalf("error type = %T, want *PathError", err)
+				}
+				if pe.Op != "sanitize" {
+					t.Errorf("PathError.Op = %q, want %q", pe.Op, "sanitize")
+				}
+			})
 		}
 	})
 }
@@ -348,7 +342,7 @@ func TestEnsure(t *testing.T) {
 
 		_, err := Ensure(root, "CONFLICT-1")
 		if err == nil {
-			t.Fatal("Ensure should return error for non-directory at workspace path")
+			t.Fatalf("Ensure(%q, %q) error = nil, want error", root, "CONFLICT-1")
 		}
 
 		var pe *PathError
@@ -412,7 +406,7 @@ func TestEnsure(t *testing.T) {
 
 		_, err := Ensure(root, "SYM-1")
 		if err == nil {
-			t.Fatal("Ensure should return error for symlink at workspace path")
+			t.Fatalf("Ensure(%q, %q) error = nil, want error", root, "SYM-1")
 		}
 
 		var pe *PathError
@@ -430,7 +424,7 @@ func TestEnsure(t *testing.T) {
 
 		_, err := Ensure(root, "")
 		if err == nil {
-			t.Fatal("Ensure with empty identifier should error")
+			t.Fatalf("Ensure(%q, \"\") error = nil, want error", root)
 		}
 		var pe *PathError
 		if !errors.As(err, &pe) {
@@ -446,7 +440,7 @@ func TestEnsure(t *testing.T) {
 
 		_, err := Ensure("", "X-1")
 		if err == nil {
-			t.Fatal("Ensure with empty root should error")
+			t.Fatal("Ensure(\"\", \"X-1\") error = nil, want error")
 		}
 		var pe *PathError
 		if !errors.As(err, &pe) {


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Refactor

**Intent:** Apply the go-testing skill guidelines uniformly across all 21 test files to make tests more idiomatic, faster under `-race`, and easier to debug when they fail.

### 🧭 Reviewer Guide

**Complexity:** Medium

#### Entry Point

`internal/registry/registry_test.go` — best representative of the full set of changes: near-duplicate standalone tests collapsed into table-driven cases (`TestGet_UnknownKind`, `TestRegister_Panics`, `TestKinds`, `TestRegistryError_Error`), `t.Parallel()` added at every level, and failure messages standardised to `FuncName(inputs) = got, want` format.

#### Sensitive Areas

- `internal/workspace/workspace_test.go`: consolidates the dot/dotdot identifier rejection cases into a single parameterised subtest with `t.Run`; wraps the bare identifier loop in named subtests so each case gets isolated parallel execution.
- `internal/agent/claude/claude_test.go`: replaces ad-hoc `if tt.name ==` conditional setup with per-case `setup func(t *testing.T)` on the table struct, removing fragile name-matching logic.
- `internal/agent/claude/parse_test.go`: replaces `runtime.Caller`-based path helper with a simple relative `filepath.Join("testdata", name)` call, matching the `loadFixture` naming convention from the skill.
- `internal/config/config_test.go`: extracts `assertConfigErrorField` helper to reduce repeated `errors.As` + field assertion boilerplate.
- `internal/domain/tracker_test.go`: adds `TestTrackerErrorKind_Values` table covering all 8 error kind string constants; collapses two single-case `Error()` tests into one table.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes
- **Migrations/State:** No migrations or state changes