### PR TITLE
chore: sync layer boundaries across dev tooling

### DIFF
--- a/.github/instructions/code-review.instructions.md
+++ b/.github/instructions/code-review.instructions.md
@@ -24,17 +24,20 @@ Follow these steps in order. Do not skip steps.
 ## Architectural Layer Boundaries
 
 Imports flow strictly downward. A violation at this level is always a critical finding.
+`logging` is a utility package — any package may import it; it is omitted from the list below for brevity.
 
 ```
 cmd/sortie/            → internal/*                        (wiring only, no business logic)
-internal/orchestrator/ → internal/domain, persistence, workspace, tracker/*, agent/*, config, logging
-internal/workspace/    → internal/domain, logging
-internal/persistence/  → internal/domain, logging
-internal/tracker/*/    → internal/domain, logging          (no cross-adapter imports)
-internal/agent/*/      → internal/domain, logging          (no cross-adapter imports)
-internal/config/       → internal/domain, logging          (no orchestrator, no persistence)
-internal/workflow/     → internal/logging                  (no orchestrator, no persistence, no config)
-internal/prompt/       → internal/logging                  (no orchestrator, no persistence, no config)
+internal/server/       → internal/domain, config, orchestrator (HTTP API surface)
+internal/orchestrator/ → internal/domain, config, persistence, workspace, registry, tracker/*, agent/*, prompt, workflow
+internal/workflow/     → internal/config, prompt            (no orchestrator, no persistence, no domain)
+internal/workspace/    → internal/domain, config, persistence
+internal/persistence/  → internal/domain, config
+internal/registry/     → internal/domain                   (adapter registration — no orchestrator, no persistence)
+internal/tracker/*/    → internal/domain, registry          (no cross-adapter imports)
+internal/agent/*/      → internal/domain, registry          (no cross-adapter imports)
+internal/config/       → internal/domain                   (no orchestrator, no persistence)
+internal/prompt/       → internal/domain                   (no orchestrator, no persistence, no config)
 internal/domain/       → (nothing internal)                (pure types, interfaces, constants)
 internal/logging/      → (nothing internal)                (stdlib only)
 ```

--- a/.github/instructions/go-environment.instructions.md
+++ b/.github/instructions/go-environment.instructions.md
@@ -25,7 +25,6 @@ Read the Makefile to discover available targets before running any Go toolchain 
 ## Constraints
 
 - NEVER prefix commands with `GOPATH=...`, `GOMODCACHE=...`, or any Go environment overrides. The asdf shim configures everything.
-- NEVER run `go test`, `go build`, `go vet`, or `golangci-lint` directly. Use the corresponding `make` target.
 - NEVER use `/usr/local/go/bin/go`, `/usr/bin/go`, or any absolute path to a Go binary.
 - NEVER downgrade the `go` directive in `go.mod`. NEVER add or modify `toolchain` directives in `go.mod` unless explicitly asked.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,16 +6,18 @@ Sortie uses the standard Go `cmd/internal` pattern:
 
 ```
 cmd/sortie/            — main entry point, CLI flag parsing
-internal/domain/       — domain types: Issue, TrackerAdapter, AgentAdapter interfaces
-internal/workflow/     — WORKFLOW.md loader (front matter + prompt body split), file watcher
-internal/config/       — typed config structs, defaults, $VAR resolution, validation
-internal/prompt/       — prompt template rendering (text/template, strict mode, FuncMap)
-internal/persistence/  — SQLite-backed durable storage (retry queues, run history, metrics)
-internal/orchestrator/ — poll loop, dispatch, reconciliation, retry, state machine
-internal/tracker/      — tracker adapter implementations (jira, file, etc.)
 internal/agent/        — agent adapter implementations (claude-code, mock, etc.)
-internal/workspace/    — workspace creation, path safety, hook execution
+internal/config/       — typed config structs, defaults, $VAR resolution, validation
+internal/domain/       — domain types: Issue, TrackerAdapter, AgentAdapter interfaces
+internal/logging/      — structured logging utilities
+internal/orchestrator/ — poll loop, dispatch, reconciliation, retry, state machine
+internal/persistence/  — SQLite-backed durable storage (retry queues, run history, metrics)
+internal/prompt/       — prompt template rendering (text/template, strict mode, FuncMap)
+internal/registry/     — adapter registry for tracker and agent implementations
 internal/server/       — HTTP API and dashboard
+internal/tracker/      — tracker adapter implementations (jira, file, etc.)
+internal/workflow/     — WORKFLOW.md loader (front matter + prompt body split), file watcher
+internal/workspace/    — workspace creation, path safety, hook execution
 ```
 
 The `internal/` directory enforces package-level encapsulation at the compiler

--- a/scripts/hooks/check-layer-imports.sh
+++ b/scripts/hooks/check-layer-imports.sh
@@ -6,11 +6,15 @@
 # Checks Go import statements against the dependency graph:
 #
 #   domain       <- (no internal imports)
-#   config       <- domain
-#   persistence  <- domain, config
-#   workspace    <- domain, config, persistence
-#   tracker/*    <- domain
-#   agent/*      <- domain
+#   logging      <- (no internal imports)
+#   config       <- domain, logging
+#   prompt       <- domain, logging
+#   registry     <- domain, logging
+#   persistence  <- domain, config, logging
+#   workspace    <- domain, config, persistence, logging
+#   workflow     <- config, prompt, logging
+#   tracker/*    <- domain, registry, logging
+#   agent/*      <- domain, registry, logging
 #   orchestrator <- everything above
 #
 # Why no false positives: import rules are deterministic. A domain package
@@ -48,29 +52,49 @@ case "$PKG" in
       VIOLATION="domain must not import other internal packages"
     fi
     ;;
+  logging*)
+    if grep -E '".*sortie/internal/' "$FILE_PATH" | grep -qvE '".*sortie/internal/logging'; then
+      VIOLATION="logging must not import other internal packages"
+    fi
+    ;;
   config*)
-    if grep -qE '".*sortie/internal/(orchestrator|agent|workspace|persistence|tracker)' "$FILE_PATH"; then
-      VIOLATION="config may only import domain"
+    if grep -qE '".*sortie/internal/(orchestrator|agent|workspace|persistence|tracker|registry|prompt|workflow|server)' "$FILE_PATH"; then
+      VIOLATION="config may only import domain, logging"
+    fi
+    ;;
+  prompt*)
+    if grep -qE '".*sortie/internal/(orchestrator|agent|workspace|persistence|tracker|registry|config|workflow|server)' "$FILE_PATH"; then
+      VIOLATION="prompt may only import domain, logging"
+    fi
+    ;;
+  registry*)
+    if grep -qE '".*sortie/internal/(orchestrator|agent|workspace|persistence|tracker|config|prompt|workflow|server)' "$FILE_PATH"; then
+      VIOLATION="registry may only import domain, logging"
     fi
     ;;
   persistence*)
-    if grep -qE '".*sortie/internal/(orchestrator|agent|workspace|tracker)' "$FILE_PATH"; then
-      VIOLATION="persistence may only import domain and config"
+    if grep -qE '".*sortie/internal/(orchestrator|agent|workspace|tracker|registry|prompt|workflow|server)' "$FILE_PATH"; then
+      VIOLATION="persistence may only import domain, config, logging"
     fi
     ;;
   workspace*)
-    if grep -qE '".*sortie/internal/(orchestrator|agent|tracker)' "$FILE_PATH"; then
-      VIOLATION="workspace may only import domain, config, persistence"
+    if grep -qE '".*sortie/internal/(orchestrator|agent|tracker|registry|prompt|workflow|server)' "$FILE_PATH"; then
+      VIOLATION="workspace may only import domain, config, persistence, logging"
+    fi
+    ;;
+  workflow*)
+    if grep -qE '".*sortie/internal/(orchestrator|agent|workspace|persistence|tracker|registry|domain|server)' "$FILE_PATH"; then
+      VIOLATION="workflow may only import config, prompt, logging"
     fi
     ;;
   tracker/*)
-    if grep -qE '".*sortie/internal/(orchestrator|agent|workspace|persistence|config)' "$FILE_PATH"; then
-      VIOLATION="tracker adapters may only import domain"
+    if grep -qE '".*sortie/internal/(orchestrator|agent|workspace|persistence|config|prompt|workflow|server)' "$FILE_PATH"; then
+      VIOLATION="tracker adapters may only import domain, registry, logging"
     fi
     ;;
   agent/*)
-    if grep -qE '".*sortie/internal/(orchestrator|tracker|workspace|persistence|config)' "$FILE_PATH"; then
-      VIOLATION="agent adapters may only import domain"
+    if grep -qE '".*sortie/internal/(orchestrator|tracker|workspace|persistence|config|prompt|workflow|server)' "$FILE_PATH"; then
+      VIOLATION="agent adapters may only import domain, registry, logging"
     fi
     ;;
 esac


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Chore

**Intent:** The layer boundary rules documented in the code-review instructions and enforced by the `check-layer-imports.sh` hook had drifted from the actual codebase — missing packages (`registry`, `server`), wrong allowed-import sets for `workflow` and adapters, and no enforcement for newer packages like `prompt` and `registry`. This PR brings all three artefacts into sync with the real import graph.

### 🧭 Reviewer Guide

**Complexity:** Low

#### Entry Point

`scripts/hooks/check-layer-imports.sh` — the hook is the executable enforcement of the layer rules. Start here to verify the `case` blocks match the import graph.

#### Sensitive Areas

- `scripts/hooks/check-layer-imports.sh`: Logic change — new `case` arms added for `logging`, `prompt`, `registry`, `workflow`; `tracker/*` and `agent/*` arms updated to permit `registry` imports. A false-positive here would block agent edits with spurious warnings.
- `.github/instructions/code-review.instructions.md`: The boundary table is authoritative for reviewers — an incorrect rule here causes real bugs to be missed or correct code to be flagged.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes
- **Migrations/State:** No migrations or state changes