### PR TITLE
fix(tracker): return ErrTrackerNotFound for missing issues in FetchIssueByID and FetchIssueComments

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -578,7 +578,7 @@ the system does real work.
       `claude-code.max_turns: 50` confirms Claude Code CLI receives
       `--max-turns 50` (visible via agent command log or parse test).
 
-- [ ] 7.16 Normalize `FetchIssueByID` and `FetchIssueComments` not-found errors
+- [x] 7.16 Normalize `FetchIssueByID` and `FetchIssueComments` not-found errors
       to use `ErrTrackerNotFound` instead of `ErrTrackerPayload`. The interface
       contract in `domain/tracker.go` and both adapter implementations (file,
       Jira) currently return `ErrTrackerPayload` when an issue is not found,

--- a/internal/domain/tracker.go
+++ b/internal/domain/tracker.go
@@ -19,7 +19,7 @@ type TrackerAdapter interface {
 	// FetchIssueByID returns a single fully-populated issue including
 	// comments. Used for pre-dispatch revalidation and prompt
 	// rendering. Returns a [*TrackerError] with Kind
-	// [ErrTrackerPayload] if the issue cannot be found.
+	// [ErrTrackerNotFound] if the issue does not exist.
 	FetchIssueByID(ctx context.Context, issueID string) (Issue, error)
 
 	// FetchIssuesByStates returns issues in the specified states.
@@ -45,6 +45,8 @@ type TrackerAdapter interface {
 	// FetchIssueComments returns comments for the specified issue.
 	// Used for continuation runs and the agent workpad pattern.
 	// Returns an empty non-nil slice when no comments exist.
+	// Returns a [*TrackerError] with Kind [ErrTrackerNotFound]
+	// if the issue does not exist.
 	FetchIssueComments(ctx context.Context, issueID string) ([]Comment, error)
 
 	// TransitionIssue moves an issue to the specified target state in

--- a/internal/tracker/file/file.go
+++ b/internal/tracker/file/file.go
@@ -94,8 +94,8 @@ func (a *FileAdapter) FetchCandidateIssues(_ context.Context) ([]domain.Issue, e
 }
 
 // FetchIssueByID returns a single fully-populated issue including
-// comments. Returns a [*domain.TrackerError] if the issue is not
-// found.
+// comments. Returns a [*domain.TrackerError] with Kind
+// [domain.ErrTrackerNotFound] if the issue does not exist.
 func (a *FileAdapter) FetchIssueByID(_ context.Context, issueID string) (domain.Issue, error) {
 	raws, err := loadIssues(a.path)
 	if err != nil {
@@ -117,7 +117,7 @@ func (a *FileAdapter) FetchIssueByID(_ context.Context, issueID string) (domain.
 	}
 
 	return domain.Issue{}, &domain.TrackerError{
-		Kind:    domain.ErrTrackerPayload,
+		Kind:    domain.ErrTrackerNotFound,
 		Message: fmt.Sprintf("issue not found: %s", issueID),
 	}
 }
@@ -218,7 +218,8 @@ func (a *FileAdapter) FetchIssueStatesByIdentifiers(_ context.Context, identifie
 
 // FetchIssueComments returns comments for the specified issue.
 // Returns an empty non-nil slice when no comments exist. Returns a
-// [*domain.TrackerError] if the issue is not found.
+// [*domain.TrackerError] with Kind [domain.ErrTrackerNotFound] if
+// the issue does not exist.
 func (a *FileAdapter) FetchIssueComments(_ context.Context, issueID string) ([]domain.Comment, error) {
 	raws, err := loadIssues(a.path)
 	if err != nil {
@@ -236,7 +237,7 @@ func (a *FileAdapter) FetchIssueComments(_ context.Context, issueID string) ([]d
 	}
 
 	return nil, &domain.TrackerError{
-		Kind:    domain.ErrTrackerPayload,
+		Kind:    domain.ErrTrackerNotFound,
 		Message: fmt.Sprintf("issue not found: %s", issueID),
 	}
 }

--- a/internal/tracker/file/file_test.go
+++ b/internal/tracker/file/file_test.go
@@ -309,7 +309,7 @@ func TestFetchIssueByID(t *testing.T) {
 		t.Parallel()
 
 		_, err := a.FetchIssueByID(ctx, "99999")
-		requireTrackerError(t, err)
+		requireTrackerErrorKind(t, err, domain.ErrTrackerNotFound)
 	})
 
 	t.Run("empty comments array", func(t *testing.T) {
@@ -572,7 +572,7 @@ func TestFetchIssueComments(t *testing.T) {
 		t.Parallel()
 
 		_, err := a.FetchIssueComments(ctx, "99999")
-		requireTrackerError(t, err)
+		requireTrackerErrorKind(t, err, domain.ErrTrackerNotFound)
 	})
 }
 

--- a/internal/tracker/jira/integration_test.go
+++ b/internal/tracker/jira/integration_test.go
@@ -273,8 +273,8 @@ func TestIntegration_FetchIssueByID_NotFound(t *testing.T) {
 	if !errors.As(err, &te) {
 		t.Fatalf("error type = %T, want *domain.TrackerError", err)
 	}
-	if te.Kind != domain.ErrTrackerPayload {
-		t.Errorf("TrackerError.Kind = %q, want %q", te.Kind, domain.ErrTrackerPayload)
+	if te.Kind != domain.ErrTrackerNotFound {
+		t.Errorf("TrackerError.Kind = %q, want %q", te.Kind, domain.ErrTrackerNotFound)
 	}
 }
 

--- a/internal/tracker/jira/jira.go
+++ b/internal/tracker/jira/jira.go
@@ -133,7 +133,7 @@ func (a *JiraAdapter) FetchIssueByID(ctx context.Context, issueID string) (domai
 	if err != nil {
 		if isNotFound(err) {
 			return domain.Issue{}, &domain.TrackerError{
-				Kind:    domain.ErrTrackerPayload,
+				Kind:    domain.ErrTrackerNotFound,
 				Message: fmt.Sprintf("issue not found: %s", issueID),
 			}
 		}
@@ -381,7 +381,7 @@ func (a *JiraAdapter) fetchComments(ctx context.Context, issueID string) ([]doma
 		if err != nil {
 			if isNotFound(err) {
 				return nil, &domain.TrackerError{
-					Kind:    domain.ErrTrackerPayload,
+					Kind:    domain.ErrTrackerNotFound,
 					Message: fmt.Sprintf("issue not found: %s", issueID),
 				}
 			}

--- a/internal/tracker/jira/jira_test.go
+++ b/internal/tracker/jira/jira_test.go
@@ -580,7 +580,7 @@ func TestFetchIssueByID_NotFound(t *testing.T) {
 
 	a := mustAdapter(t, validConfig(srv.URL))
 	_, err := a.FetchIssueByID(context.Background(), "PROJ-999")
-	assertTrackerErrorKind(t, err, domain.ErrTrackerPayload)
+	assertTrackerErrorKind(t, err, domain.ErrTrackerNotFound)
 
 	var te *domain.TrackerError
 	errors.As(err, &te)
@@ -1099,7 +1099,7 @@ func TestFetchIssueComments_NotFound(t *testing.T) {
 
 	a := mustAdapter(t, validConfig(srv.URL))
 	_, err := a.FetchIssueComments(context.Background(), "PROJ-999")
-	assertTrackerErrorKind(t, err, domain.ErrTrackerPayload)
+	assertTrackerErrorKind(t, err, domain.ErrTrackerNotFound)
 }
 
 // --- Full lifecycle integration test ---


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Fix

**Intent:** `FetchIssueByID` and `FetchIssueComments` were returning `*TrackerError{Kind: ErrTrackerPayload}` when an issue does not exist. This is inconsistent with `TransitionIssue`, which already uses `ErrTrackerNotFound` for the same semantic. This change normalizes the error kind so callers can distinguish "issue does not exist" from "response was malformed" without inspecting error message strings.

### 🧭 Reviewer Guide

**Complexity:** Low

#### Entry Point

internal/domain/tracker.go — the interface doc comments are the canonical contract consumers read first. The changes here define what both adapter implementations must now return.

#### Sensitive Areas

- `internal/tracker/file/file.go`: Two `Kind` field changes in not-found return sites (`FetchIssueByID` and `FetchIssueComments`). All other `ErrTrackerPayload` sites (file read errors, JSON parse errors, missing config key) are intentionally unchanged.
- `internal/tracker/jira/jira.go`: Two `Kind` field changes inside `isNotFound(err)` guards (`FetchIssueByID` and `fetchComments`). Re-wrapping with domain-level message is retained — only the `Kind` changes. All other `ErrTrackerPayload` sites remain.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes. Both `ErrTrackerNotFound` and `ErrTrackerPayload` carry identical `RetryClassification` (non-retryable, no backoff), so orchestrator retry behaviour is unchanged. No current orchestrator code switches on the error kind for these two operations.
- **Migrations/State:** No migrations or state changes.