### PR TITLE
feat(observability): add INFO structured log for agent tool calls

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -889,7 +889,7 @@ JSON API + HTML dashboard, Prometheus `/metrics`), and adds agent capabilities.
       registry, confirms `sortie_tool_calls_total` is incremented with
       correct `tool` and `result` labels. Metric appears in `/metrics`.
 
-- [ ] 8.21 Add structured logging for agent tool calls. On each tool call
+- [x] 8.21 Add structured logging for agent tool calls. On each tool call
       completion, emit an INFO log line with structured fields: `issue_id`,
       `issue_identifier`, `session_id`, `tool` (tool name), `duration_ms`,
       `result` (`success` or `error`), and `error` (message, omitted on

--- a/internal/orchestrator/event.go
+++ b/internal/orchestrator/event.go
@@ -85,6 +85,25 @@ func HandleAgentEvent(state *State, issueID string, event domain.AgentEvent, log
 			result = outcomeError
 		}
 		metrics.IncToolCalls(event.ToolName, result)
+
+		if event.ToolError {
+			errMsg := event.Message
+			if errMsg == "" {
+				errMsg = "tool returned error"
+			}
+			log.Info("tool call completed",
+				slog.String("tool", event.ToolName),
+				slog.Int64("duration_ms", event.ToolDurationMS),
+				slog.String("result", result),
+				slog.String("error", errMsg),
+			)
+		} else {
+			log.Info("tool call completed",
+				slog.String("tool", event.ToolName),
+				slog.Int64("duration_ms", event.ToolDurationMS),
+				slog.String("result", result),
+			)
+		}
 	}
 
 	// Increment TurnCount on turn-finalization events only. Every
@@ -190,12 +209,7 @@ func HandleAgentEvent(state *State, issueID string, event domain.AgentEvent, log
 		)
 	case domain.EventTokenUsage:
 		// Logged inside the delta computation block above.
-	case domain.EventToolResult:
-		log.Debug("agent event processed",
-			slog.Any("event_type", event.Type),
-			slog.String("tool_name", event.ToolName),
-			slog.Int64("duration_ms", event.ToolDurationMS),
-		)
+
 	case domain.EventTurnCompleted,
 		domain.EventTurnFailed,
 		domain.EventTurnCancelled,

--- a/internal/orchestrator/event_test.go
+++ b/internal/orchestrator/event_test.go
@@ -1156,3 +1156,145 @@ func TestHandleAgentEvent_ToolCallMetric(t *testing.T) {
 		})
 	}
 }
+
+// infoLogger returns a *slog.Logger that writes text records at INFO level
+// to buf. Debug-level lines are excluded, enabling clean negative assertions.
+func infoLogger(t *testing.T, buf *bytes.Buffer) *slog.Logger {
+	t.Helper()
+	return slog.New(slog.NewTextHandler(buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+}
+
+// TestHandleAgentEvent_ToolCallLogging verifies the INFO-level structured
+// log emitted for tool_result events with non-empty ToolName. Covers
+// success, error with message, error with empty message (fallback), and
+// the empty-ToolName negative case.
+func TestHandleAgentEvent_ToolCallLogging(t *testing.T) {
+	t.Parallel()
+
+	const issueID = "TCL-1"
+	const identifier = "TCL-1-ident"
+	const sessionID = "sess-tcl"
+
+	t.Run("success logs tool, duration_ms, result without error field", func(t *testing.T) {
+		t.Parallel()
+
+		var buf bytes.Buffer
+		logger := infoLogger(t, &buf)
+		spy := &spyMetrics{}
+
+		state, entry := newStateWithEntry(issueID)
+		entry.Identifier = identifier
+		entry.SessionID = sessionID
+
+		HandleAgentEvent(state, issueID, domain.AgentEvent{
+			Type:           domain.EventToolResult,
+			Timestamp:      time.Now().UTC(),
+			ToolName:       "Bash",
+			ToolDurationMS: 150,
+			ToolError:      false,
+		}, logger, spy)
+
+		out := buf.String()
+		for _, want := range []string{
+			"level=INFO",
+			"tool call completed",
+			"issue_id=" + issueID,
+			"issue_identifier=" + identifier,
+			"session_id=" + sessionID,
+			"tool=Bash",
+			"duration_ms=150",
+			"result=success",
+		} {
+			if !strings.Contains(out, want) {
+				t.Errorf("log output missing %q\ngot: %s", want, out)
+			}
+		}
+		if strings.Contains(out, "error=") {
+			t.Errorf("log output contains error= on success path\ngot: %s", out)
+		}
+	})
+
+	t.Run("error logs tool, result, and error message", func(t *testing.T) {
+		t.Parallel()
+
+		var buf bytes.Buffer
+		logger := infoLogger(t, &buf)
+		spy := &spyMetrics{}
+
+		state, entry := newStateWithEntry(issueID)
+		entry.Identifier = identifier
+		entry.SessionID = sessionID
+
+		HandleAgentEvent(state, issueID, domain.AgentEvent{
+			Type:           domain.EventToolResult,
+			Timestamp:      time.Now().UTC(),
+			ToolName:       "Bash",
+			ToolDurationMS: 0,
+			ToolError:      true,
+			Message:        "command failed",
+		}, logger, spy)
+
+		out := buf.String()
+		for _, want := range []string{
+			"level=INFO",
+			"tool call completed",
+			"tool=Bash",
+			"result=error",
+			`error="command failed"`,
+		} {
+			if !strings.Contains(out, want) {
+				t.Errorf("log output missing %q\ngot: %s", want, out)
+			}
+		}
+	})
+
+	t.Run("error with empty message uses fallback", func(t *testing.T) {
+		t.Parallel()
+
+		var buf bytes.Buffer
+		logger := infoLogger(t, &buf)
+		spy := &spyMetrics{}
+
+		state, entry := newStateWithEntry(issueID)
+		entry.Identifier = identifier
+		entry.SessionID = sessionID
+
+		HandleAgentEvent(state, issueID, domain.AgentEvent{
+			Type:           domain.EventToolResult,
+			Timestamp:      time.Now().UTC(),
+			ToolName:       "Bash",
+			ToolDurationMS: 0,
+			ToolError:      true,
+			Message:        "",
+		}, logger, spy)
+
+		out := buf.String()
+		if !strings.Contains(out, `error="tool returned error"`) {
+			t.Errorf("log output missing fallback error message\ngot: %s", out)
+		}
+	})
+
+	t.Run("empty ToolName does not emit INFO log", func(t *testing.T) {
+		t.Parallel()
+
+		var buf bytes.Buffer
+		logger := infoLogger(t, &buf)
+		spy := &spyMetrics{}
+
+		state, entry := newStateWithEntry(issueID)
+		entry.Identifier = identifier
+		entry.SessionID = sessionID
+
+		HandleAgentEvent(state, issueID, domain.AgentEvent{
+			Type:           domain.EventToolResult,
+			Timestamp:      time.Now().UTC(),
+			ToolName:       "",
+			ToolDurationMS: 100,
+		}, logger, spy)
+
+		out := buf.String()
+		if strings.Contains(out, "tool call completed") {
+			t.Errorf("log output contains 'tool call completed' for empty ToolName\ngot: %s", out)
+		}
+	})
+}


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Feat

**Intent:** Emit an INFO-level structured log line on each agent tool call completion so operators can grep logs for tool interaction details without requiring the dashboard or Prometheus.

### 🧭 Reviewer Guide

**Complexity:** Low

#### Entry Point

`internal/orchestrator/event.go` - the `HandleAgentEvent` function, inside the `EventToolResult` + non-empty `ToolName` guard block. Two sibling `log.Info` calls (one for success, one for error) were added after the existing `metrics.IncToolCalls` call. The pre-existing Debug-level `case domain.EventToolResult:` arm in the bottom switch was removed since the new INFO log is a strict superset.

#### Sensitive Areas

- `internal/orchestrator/event.go`: the `error` field is conditionally emitted only on failure (`ToolError == true`). A fallback of `"tool returned error"` is used when `event.Message` is empty to prevent blank `error=` fields in log output. The two-branch `log.Info` pattern is intentional — `[]slog.Attr` cannot be spread into `...any` (does not compile), `log.LogAttrs` requires a `context.Context` not available in `HandleAgentEvent`, and the two explicit calls avoid a per-event `[]slog.Attr` heap allocation.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes
- **Migrations/State:** No migrations or state changes

<!-- START COPILOT CODING AGENT TIPS -->
---

💬 Send tasks to Copilot coding agent from [Slack](https://gh.io/cca-slack-docs) and [Teams](https://gh.io/cca-teams-docs) to turn conversations into code. Copilot posts an update in your thread when it's finished.