### PR TITLE
chore: prepare 0.0.8 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,55 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.0.8] - 2026-03-26
+
+### Added
+
+- JSON API server with `GET /api/v1/state`, `GET /api/v1/<identifier>`, and
+  `POST /api/v1/refresh` endpoints for programmatic access to orchestrator
+  state. Enabled via `--port` flag or `server.port` config.
+- HTML dashboard at `/` with auto-refreshing view of running sessions, retry
+  queue, token totals, and runtime statistics when the HTTP server is enabled.
+- `/livez` and `/readyz` health endpoints following Kubernetes z-pages
+  conventions. `/readyz` checks database accessibility, preflight validation,
+  and workflow loading.
+- Prometheus `/metrics` endpoint exposing session gauges, dispatch/worker/retry
+  counters, token counters, tracker request counters, tool call counters,
+  poll and worker duration histograms, and `sortie_build_info`. Uses a dedicated
+  `prometheus.Registry` — compatible with standard Prometheus scrape configs.
+- `tracker_api` client-side tool: agents can query the tracker during sessions
+  to fetch issues and comments, scoped to the configured project.
+- SSH worker extension via `worker.ssh_hosts` config: dispatch agent runs to
+  remote hosts over SSH with round-robin host selection and per-host concurrency
+  limits (`worker.max_concurrent_agents_per_host`).
+- Per-session token breakdown in JSON API and dashboard: `input_tokens`,
+  `output_tokens`, `cache_creation_tokens`, `cache_read_tokens`.
+- Per-session timing breakdown in JSON API and dashboard: `elapsed`,
+  `agent_time`, `idle_time`, `agent_pct`.
+- Claude Code adapter: `tool_result` events now emitted, making agent tool
+  invocations visible in the dashboard and API.
+- Worker failure logging in `HandleWorkerExit`: WARN with `next_attempt` and
+  `delay_ms` for retryable errors, ERROR for non-retryable errors.
+- Structured logging: `issue_id`, `issue_identifier`, and `session_id` context
+  fields now present on all orchestrator lifecycle log lines. Agent tool calls
+  logged at INFO level.
+- POSIX-compatible install script (`install.sh`) for automated binary
+  installation.
+
+### Changed
+
+- `POST /api/v1/refresh` returns `409 Conflict` during graceful shutdown
+  instead of accepting requests that cannot be fulfilled.
+
+### Fixed
+
+- Claude Code adapter: duplicate `token_usage` events no longer emitted when
+  assistant-level usage is already reported in the result message.
+- HTTP server: `405 Method Not Allowed` responses now include the `Allow`
+  header per RFC 9110.
+- Jira adapter: `sortie_tracker_requests_total` counter no longer increments
+  on no-op calls with empty ID lists.
+
 ## [0.0.7] - 2026-03-24
 
 ### Added
@@ -195,7 +244,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   execution via GitHub Actions.
 - Architecture Decision Records (ADR-0001 through ADR-0005).
 
-[Unreleased]: https://github.com/sortie-ai/sortie/compare/0.0.7...HEAD
+[Unreleased]: https://github.com/sortie-ai/sortie/compare/0.0.8...HEAD
+[0.0.8]: https://github.com/sortie-ai/sortie/compare/0.0.7...0.0.8
 [0.0.7]: https://github.com/sortie-ai/sortie/compare/0.0.6...0.0.7
 [0.0.6]: https://github.com/sortie-ai/sortie/compare/0.0.5...0.0.6
 [0.0.5]: https://github.com/sortie-ai/sortie/compare/0.0.4...0.0.5

--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ Single binary, zero dependencies, SQLite persistence.
 
 > Sortie is in active development. The core system is implemented: tracker adapters
 > (Jira, file-based), agent adapter (Claude Code), workspace management, persistence,
-> and the orchestrator (dispatch, retry, reconciliation, multi-turn sessions). Current
-> work: observability surfaces, self-hosting, and hardening.
-> See [TODO.md](TODO.md) for current status.
+> orchestrator (dispatch, retry, reconciliation, multi-turn sessions), and observability
+> (JSON API, HTML dashboard, Prometheus metrics, health endpoints). Current work:
+> self-hosting, hardening, and documentation. See [TODO.md](TODO.md) for current status.
 
 ## The Problem
 


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Chore

**Intent:** Prepare the 0.0.8 release by documenting all Milestone 8 changes in CHANGELOG.md and updating the README development status banner to reflect completed observability work.

### 🧭 Reviewer Guide

**Complexity:** Low

#### Entry Point

`CHANGELOG.md` — the new `[0.0.8]` section is the primary change. Review that every entry accurately describes a user-observable change introduced since 0.0.7.

#### Sensitive Areas

- `CHANGELOG.md`: confirm each entry is consumer-facing signal, not internal noise; verify the 409 Conflict status code for `POST /api/v1/refresh` (not 503).
- `README.md`: the development status blockquote should reflect what is built and what is still in progress.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes
- **Migrations/State:** No migrations or state changes