### PR TITLE
feat(jira): add User-Agent header to every Jira HTTP request

### DIFF
--- a/cmd/sortie/main.go
+++ b/cmd/sortie/main.go
@@ -204,6 +204,7 @@ func run(ctx context.Context, args []string, stdout io.Writer, stderr io.Writer)
 		return 1
 	}
 	trackerCfgMap := trackerConfigMap(cfg.Tracker)
+	trackerCfgMap["user_agent"] = "sortie/" + Version
 	mergeExtensions(trackerCfgMap, cfg.Extensions, cfg.Tracker.Kind)
 	trackerAdapter, err := trackerCtor(trackerCfgMap)
 	if err != nil {

--- a/internal/tracker/jira/client.go
+++ b/internal/tracker/jira/client.go
@@ -19,16 +19,18 @@ type jiraClient struct {
 	httpClient *http.Client
 	baseURL    string
 	authHeader string
+	userAgent  string
 }
 
 // newJiraClient constructs a jiraClient with Basic authentication
 // derived from the email and API token. The baseURL is stripped of
-// any trailing slash.
-func newJiraClient(baseURL, email, token string) *jiraClient {
+// any trailing slash. The userAgent value is set on every outgoing request.
+func newJiraClient(baseURL, email, token, userAgent string) *jiraClient {
 	return &jiraClient{
 		httpClient: &http.Client{Timeout: 30 * time.Second},
 		baseURL:    strings.TrimRight(baseURL, "/"),
 		authHeader: "Basic " + base64.StdEncoding.EncodeToString([]byte(email+":"+token)),
+		userAgent:  userAgent,
 	}
 }
 
@@ -118,6 +120,7 @@ func (c *jiraClient) do(ctx context.Context, method, path string, params url.Val
 	req.Header.Set("Authorization", c.authHeader)
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", c.userAgent)
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
@@ -170,6 +173,7 @@ func (c *jiraClient) doJSON(ctx context.Context, method, path string, body io.Re
 	req.Header.Set("Authorization", c.authHeader)
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", c.userAgent)
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {

--- a/internal/tracker/jira/client_test.go
+++ b/internal/tracker/jira/client_test.go
@@ -24,7 +24,7 @@ func TestClientDo_Success(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := newJiraClient(srv.URL, "user@test.com", "tok123")
+	c := newJiraClient(srv.URL, "user@test.com", "tok123", "sortie/test")
 	body, err := c.do(context.Background(), "GET", "/test", nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -54,7 +54,7 @@ func TestClientDo_QueryParams(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := newJiraClient(srv.URL, "u@t.com", "t")
+	c := newJiraClient(srv.URL, "u@t.com", "t", "sortie/test")
 	params := url.Values{"jql": {"project = X"}, "maxResults": {"50"}}
 	_, err := c.do(context.Background(), "GET", "/search", params)
 	if err != nil {
@@ -136,7 +136,7 @@ func TestClientDo_ErrorMapping(t *testing.T) {
 			}))
 			defer srv.Close()
 
-			c := newJiraClient(srv.URL, "u@t.com", "t")
+			c := newJiraClient(srv.URL, "u@t.com", "t", "sortie/test")
 			_, err := c.do(context.Background(), "GET", "/test", nil)
 			if err == nil {
 				t.Fatal("expected error, got nil")
@@ -162,7 +162,7 @@ func TestClientDo_NetworkFailure(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
 	srv.Close() // close immediately to cause connection refused
 
-	c := newJiraClient(srv.URL, "u@t.com", "t")
+	c := newJiraClient(srv.URL, "u@t.com", "t", "sortie/test")
 	_, err := c.do(context.Background(), "GET", "/test", nil)
 	if err == nil {
 		t.Fatal("expected error, got nil")
@@ -188,7 +188,7 @@ func TestClientDo_ContextCancellation(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // cancel before request
 
-	c := newJiraClient(srv.URL, "u@t.com", "t")
+	c := newJiraClient(srv.URL, "u@t.com", "t", "sortie/test")
 	_, err := c.do(ctx, "GET", "/test", nil)
 	if err == nil {
 		t.Fatal("expected error, got nil")
@@ -219,7 +219,7 @@ func TestClientDoJSON_Success(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := newJiraClient(srv.URL, "user@test.com", "tok123")
+	c := newJiraClient(srv.URL, "user@test.com", "tok123", "sortie/test")
 	body, err := c.doJSON(context.Background(), "POST", "/transitions", strings.NewReader(`{"transition":{"id":"31"}}`))
 	if err != nil {
 		t.Fatalf("doJSON() unexpected error: %v", err)
@@ -253,7 +253,7 @@ func TestClientDoJSON_200_WithBody(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := newJiraClient(srv.URL, "u@t.com", "t")
+	c := newJiraClient(srv.URL, "u@t.com", "t", "sortie/test")
 	body, err := c.doJSON(context.Background(), "POST", "/test", strings.NewReader("{}"))
 	if err != nil {
 		t.Fatalf("doJSON() unexpected error: %v", err)
@@ -288,7 +288,7 @@ func TestClientDoJSON_ErrorMapping(t *testing.T) {
 			}))
 			defer srv.Close()
 
-			c := newJiraClient(srv.URL, "u@t.com", "t")
+			c := newJiraClient(srv.URL, "u@t.com", "t", "sortie/test")
 			_, err := c.doJSON(context.Background(), "POST", "/test", strings.NewReader("{}"))
 			if err == nil {
 				t.Fatal("doJSON() expected error, got nil")
@@ -316,7 +316,7 @@ func TestClientDoJSON_ContextCancellation(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	c := newJiraClient(srv.URL, "u@t.com", "t")
+	c := newJiraClient(srv.URL, "u@t.com", "t", "sortie/test")
 	_, err := c.doJSON(ctx, "POST", "/test", strings.NewReader("{}"))
 	if err == nil {
 		t.Fatal("doJSON() expected error, got nil")
@@ -327,5 +327,78 @@ func TestClientDoJSON_ContextCancellation(t *testing.T) {
 	var te *domain.TrackerError
 	if errors.As(err, &te) {
 		t.Errorf("context cancellation should not be wrapped in TrackerError, got Kind=%q", te.Kind)
+	}
+}
+
+// --- User-Agent header tests ---
+
+func TestClientDo_UserAgentHeader(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		userAgent string
+		want      string
+	}{
+		{"release version", "sortie/v0.8.3", "sortie/v0.8.3"},
+		{"dev fallback", "sortie/dev", "sortie/dev"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var gotUA string
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotUA = r.Header.Get("User-Agent")
+				w.WriteHeader(http.StatusOK)
+				w.Write([]byte("{}")) //nolint:errcheck // test helper
+			}))
+			defer srv.Close()
+
+			c := newJiraClient(srv.URL, "u@t.com", "t", tt.userAgent)
+			_, err := c.do(context.Background(), "GET", "/test", nil)
+			if err != nil {
+				t.Fatalf("do() unexpected error: %v", err)
+			}
+			if gotUA != tt.want {
+				t.Errorf("User-Agent header = %q, want %q", gotUA, tt.want)
+			}
+		})
+	}
+}
+
+func TestClientDoJSON_UserAgentHeader(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		userAgent string
+		want      string
+	}{
+		{"release version", "sortie/v0.8.3", "sortie/v0.8.3"},
+		{"dev fallback", "sortie/dev", "sortie/dev"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var gotUA string
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotUA = r.Header.Get("User-Agent")
+				w.WriteHeader(http.StatusNoContent)
+			}))
+			defer srv.Close()
+
+			c := newJiraClient(srv.URL, "u@t.com", "t", tt.userAgent)
+			_, err := c.doJSON(context.Background(), "POST", "/test", strings.NewReader("{}"))
+			if err != nil {
+				t.Fatalf("doJSON() unexpected error: %v", err)
+			}
+			if gotUA != tt.want {
+				t.Errorf("User-Agent header = %q, want %q", gotUA, tt.want)
+			}
+		})
 	}
 }

--- a/internal/tracker/jira/jira.go
+++ b/internal/tracker/jira/jira.go
@@ -109,8 +109,13 @@ func NewJiraAdapter(config map[string]any) (domain.TrackerAdapter, error) {
 
 	queryFilter, _ := config["query_filter"].(string)
 
+	userAgent, _ := config["user_agent"].(string)
+	if userAgent == "" {
+		userAgent = "sortie/dev"
+	}
+
 	return &JiraAdapter{
-		client:       newJiraClient(endpoint, email, token),
+		client:       newJiraClient(endpoint, email, token, userAgent),
 		project:      project,
 		activeStates: activeStates,
 		endpoint:     endpoint,

--- a/internal/tracker/jira/jira_test.go
+++ b/internal/tracker/jira/jira_test.go
@@ -1803,3 +1803,44 @@ func TestJiraAdapterMetrics(t *testing.T) {
 		a.TransitionIssue(ctx, "PROJ-123", "Human Review")       //nolint:errcheck // verifying no panic
 	})
 }
+
+func TestNewJiraAdapter_UserAgentFromConfig(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		version string // empty means key is omitted
+		wantUA  string
+	}{
+		{"explicit version", "v1.2.3", "sortie/v1.2.3"},
+		{"missing version defaults to dev", "", "sortie/dev"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var gotUA string
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotUA = r.Header.Get("User-Agent")
+				w.Header().Set("Content-Type", "application/json")
+				w.Write([]byte(`{"issues":[]}`)) //nolint:errcheck // test helper
+			}))
+			defer srv.Close()
+
+			cfg := validConfig(srv.URL)
+			if tt.version != "" {
+				cfg["user_agent"] = "sortie/" + tt.version
+			}
+
+			a := mustAdapter(t, cfg)
+			_, err := a.FetchCandidateIssues(context.Background())
+			if err != nil {
+				t.Fatalf("FetchCandidateIssues: %v", err)
+			}
+			if gotUA != tt.wantUA {
+				t.Errorf("User-Agent = %q, want %q", gotUA, tt.wantUA)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Feat

**Intent:** Operators running Sortie against Jira Cloud cannot currently distinguish Sortie traffic in Jira audit logs or Atlassian analytics. This change adds a `User-Agent: sortie/<version>` header to every HTTP request made by the Jira adapter, enabling traffic attribution and audit traceability.

**Related Issues:** #201

### 🧭 Reviewer Guide

**Complexity:** Medium

#### Entry Point

Start at `internal/tracker/jira/client.go` — the `jiraClient` struct gains a `userAgent` field, `newJiraClient` accepts it as a fourth parameter, and both `do()` and `doJSON()` inject it via `req.Header.Set`. This is the core mechanism; the remaining files wire the value in and test it.

#### Sensitive Areas

- `cmd/sortie/main.go`: The `user_agent` key is injected into the tracker config map *before* `mergeExtensions`, ensuring the build-time version cannot be overridden via YAML extensions.
- `internal/tracker/jira/jira.go`: `NewJiraAdapter` reads `user_agent` from the opaque config map — format logic stays in the wiring layer, not in the adapter.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes — `newJiraClient` is unexported; only internal call sites updated.
- **Migrations/State:** No migrations or state changes.