### PR TITLE
feat(release): add Homebrew tap distribution via GoReleaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -205,6 +205,7 @@ jobs:
           args: release ${{ inputs.dry_run && '--skip=publish --skip=announce' || '' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAP_GITHUB_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }}
 
       - name: Release summary
         if: ${{ !inputs.dry_run }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -47,6 +47,27 @@ checksum:
   name_template: "checksums.txt"
   algorithm: sha256
 
+brews:
+  - name: sortie
+    repository:
+      owner: sortie-ai
+      name: homebrew-tap
+      branch: main
+      token: "{{ .Env.TAP_GITHUB_TOKEN }}"
+    directory: Formula
+    commit_author:
+      name: goreleaserbot
+      email: goreleaserbot@users.noreply.github.com
+    commit_msg_template: "chore(formula): update {{ .ProjectName }} to {{ .Tag }}"
+    homepage: "https://github.com/sortie-ai/sortie"
+    description: "Spec-first orchestration service for coding agents"
+    license: "Apache-2.0"
+    install: |
+      bin.install "sortie"
+    test: |
+      assert_match version.to_s, shell_output("#{bin}/sortie --version")
+    skip_upload: "auto"
+
 changelog:
   sort: asc
   use: git


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Feat

**Intent:** Enables `brew install sortie-ai/tap/sortie` by automating formula generation and publishing to `sortie-ai/homebrew-tap` on every stable release. Distributes the existing pre-built binary — no Go source build, no CGo, no runtime dependencies added.

**Related Issues:** #202

### 🧭 Reviewer Guide

**Complexity:** Low

#### Entry Point

`.goreleaser.yaml` — the new `brews` section (after `checksum`) defines the full formula: repository target, commit identity, install rule, test block, and pre-release gate (`skip_upload: "auto"`). The workflow change is a one-line addition.

#### Sensitive Areas

- `.goreleaser.yaml`: `skip_upload: "auto"` is the critical safety gate — it prevents pre-release tags (e.g. `v1.0.0-rc.1`) from updating the tap. Verify it is present and spelled correctly.
- `.github/workflows/release.yml`: `TAP_GITHUB_TOKEN` is a fine-grained PAT scoped only to `sortie-ai/homebrew-tap` (Contents: Read + Write). It must not be confused with `GITHUB_TOKEN`, which cannot push to a different repository.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes
- **Migrations/State:** No migrations or state changes