### PR TITLE
feat(dashboard): show workflow filename in session and run history tables

### DIFF
--- a/cmd/sortie/main.go
+++ b/cmd/sortie/main.go
@@ -356,15 +356,16 @@ func run(ctx context.Context, args []string, stdout io.Writer, stderr io.Writer)
 	}
 
 	o := orchestrator.NewOrchestrator(orchestrator.OrchestratorParams{
-		State:           state,
-		Logger:          logger,
-		TrackerAdapter:  trackerAdapter,
-		AgentAdapter:    agentAdapter,
-		WorkflowManager: mgr,
-		Store:           store,
-		PreflightParams: preflightParams,
-		Metrics:         orchMetrics,
-		ToolRegistry:    toolRegistry,
+		State:            state,
+		Logger:           logger,
+		TrackerAdapter:   trackerAdapter,
+		AgentAdapter:     agentAdapter,
+		WorkflowManager:  mgr,
+		Store:            store,
+		PreflightParams:  preflightParams,
+		Metrics:          orchMetrics,
+		ToolRegistry:     toolRegistry,
+		WorkflowFileFunc: mgr.FilePath,
 	})
 
 	var srv *server.Server
@@ -382,6 +383,25 @@ func run(ctx context.Context, args []string, stdout io.Writer, stderr io.Writer)
 			DBPingFn:         func(ctx context.Context) error { return store.Ping(ctx) },
 			PreflightFn:      o.PreflightOK,
 			WorkflowLoadedFn: func() bool { return mgr.Config().Tracker.Kind != "" },
+			RunHistoryFn: func(ctx context.Context, limit int) ([]server.RunHistoryEntry, error) {
+				runs, err := store.QueryRecentRunHistory(ctx, limit, 0)
+				if err != nil {
+					return nil, err
+				}
+				out := make([]server.RunHistoryEntry, len(runs))
+				for i, r := range runs {
+					out[i] = server.RunHistoryEntry{
+						Identifier:   r.Identifier,
+						Attempt:      r.Attempt,
+						Status:       r.Status,
+						WorkflowFile: r.WorkflowFile,
+						StartedAt:    r.StartedAt,
+						CompletedAt:  r.CompletedAt,
+						Error:        r.Error,
+					}
+				}
+				return out, nil
+			},
 		})
 		o.AddObserver(srv)
 

--- a/internal/orchestrator/exit.go
+++ b/internal/orchestrator/exit.go
@@ -196,6 +196,7 @@ func HandleWorkerExit(state *State, result WorkerResult, params HandleWorkerExit
 		CompletedAt:  now.Format(time.RFC3339),
 		Status:       status,
 		Error:        errorStringPtr(result.Error),
+		WorkflowFile: entry.WorkflowFile,
 	}
 	if _, err := params.Store.AppendRunHistory(ctx, runHistory); err != nil {
 		log.Error("failed to persist run history",

--- a/internal/orchestrator/exit_test.go
+++ b/internal/orchestrator/exit_test.go
@@ -1592,3 +1592,28 @@ func TestHandleWorkerExit_LastSSHHostPropagated(t *testing.T) {
 		t.Errorf("RetryEntry.LastSSHHost = %q, want %q", entry.LastSSHHost, "worker-7")
 	}
 }
+
+func TestHandleWorkerExit_WorkflowFilePersisted(t *testing.T) {
+	t.Parallel()
+
+	store := &mockExitStore{}
+	state := exitState(t, "WF-1", nil)
+	// WorkflowFile is set on the running entry to simulate it being captured at
+	// dispatch time.
+	state.Running["WF-1"].WorkflowFile = "backend.WORKFLOW.md"
+	params := defaultExitParams(t, store)
+
+	HandleWorkerExit(state, WorkerResult{
+		IssueID:      "WF-1",
+		Identifier:   "WF-1-ident",
+		ExitKind:     WorkerExitNormal,
+		AgentAdapter: "mock",
+	}, params)
+
+	if len(store.runHistories) != 1 {
+		t.Fatalf("AppendRunHistory called %d times, want 1", len(store.runHistories))
+	}
+	if got := store.runHistories[0].WorkflowFile; got != "backend.WORKFLOW.md" {
+		t.Errorf("RunHistory.WorkflowFile = %q, want %q", got, "backend.WORKFLOW.md")
+	}
+}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -70,6 +70,12 @@ type OrchestratorParams struct {
 	Metrics         domain.Metrics       // may be nil; defaults to NoopMetrics
 	ToolRegistry    *domain.ToolRegistry // may be nil
 	HostPool        *HostPool            // may be nil; defaults to local-mode pool
+
+	// WorkflowFileFunc returns the base filename of the active workflow
+	// file (e.g. "WORKFLOW.md"). Used for observability: recorded on
+	// RunningEntry and persisted in run_history. If nil, defaults to
+	// empty string.
+	WorkflowFileFunc func() string
 }
 
 // Orchestrator owns the poll-and-dispatch event loop and all runtime
@@ -92,13 +98,14 @@ type Orchestrator struct {
 	snapshotCh   chan snapshotRequest
 	refreshCh    chan struct{}
 
-	preflightParams PreflightParams
-	observers       []Observer
-	drainTimeout    time.Duration
-	toolRegistry    *domain.ToolRegistry
-	preflightOK     atomic.Bool
-	draining        atomic.Bool
-	hostPool        *HostPool
+	preflightParams  PreflightParams
+	observers        []Observer
+	drainTimeout     time.Duration
+	toolRegistry     *domain.ToolRegistry
+	preflightOK      atomic.Bool
+	draining         atomic.Bool
+	hostPool         *HostPool
+	workflowFileFunc func() string
 }
 
 // NewOrchestrator creates an [Orchestrator] with all dependencies wired.
@@ -146,23 +153,24 @@ func NewOrchestrator(params OrchestratorParams) *Orchestrator {
 	}
 
 	o := &Orchestrator{
-		state:           params.State,
-		logger:          logger,
-		trackerAdapter:  params.TrackerAdapter,
-		agentAdapter:    params.AgentAdapter,
-		workflowManager: params.WorkflowManager,
-		store:           params.Store,
-		metrics:         metrics,
-		workerExitCh:    make(chan WorkerResult, exitBuf),
-		retryTimerCh:    make(chan string, retryBuf),
-		agentEventCh:    make(chan agentEventMsg, eventBuf),
-		snapshotCh:      make(chan snapshotRequest, 4),
-		refreshCh:       make(chan struct{}, 1),
-		preflightParams: params.PreflightParams,
-		observers:       observers,
-		drainTimeout:    defaultDrainTimeout,
-		toolRegistry:    params.ToolRegistry,
-		hostPool:        hostPool,
+		state:            params.State,
+		logger:           logger,
+		trackerAdapter:   params.TrackerAdapter,
+		agentAdapter:     params.AgentAdapter,
+		workflowManager:  params.WorkflowManager,
+		store:            params.Store,
+		metrics:          metrics,
+		workerExitCh:     make(chan WorkerResult, exitBuf),
+		retryTimerCh:     make(chan string, retryBuf),
+		agentEventCh:     make(chan agentEventMsg, eventBuf),
+		snapshotCh:       make(chan snapshotRequest, 4),
+		refreshCh:        make(chan struct{}, 1),
+		preflightParams:  params.PreflightParams,
+		observers:        observers,
+		drainTimeout:     defaultDrainTimeout,
+		toolRegistry:     params.ToolRegistry,
+		hostPool:         hostPool,
+		workflowFileFunc: params.WorkflowFileFunc,
 	}
 	// Startup preflight must have passed for the orchestrator to be
 	// constructed, so the initial value is true.
@@ -231,6 +239,7 @@ func (o *Orchestrator) Run(ctx context.Context) {
 				MaxSessions:       cfg.Agent.MaxSessions,
 				Metrics:           o.metrics,
 				HostPool:          o.hostPool,
+				WorkflowFile:      o.workflowFile(),
 			})
 			o.updateGauges(time.Now())
 			o.notifyObservers()
@@ -373,6 +382,9 @@ func (o *Orchestrator) handleTick(ctx context.Context) {
 			break
 		}
 		DispatchIssue(ctx, o.state, issue, nil, host, o.makeWorkerFn("", host))
+		if entry := o.state.Running[issue.ID]; entry != nil {
+			entry.WorkflowFile = o.workflowFile()
+		}
 		o.metrics.IncDispatches(outcomeSuccess)
 		dispatched++
 	}
@@ -423,6 +435,15 @@ func (o *Orchestrator) makeWorkerFn(resumeSessionID string, sshHost string) Work
 
 		RunWorkerAttempt(ctx, issue, attempt, deps)
 	}
+}
+
+// workflowFile returns the base filename of the active workflow file.
+// Returns empty string when no callback is configured.
+func (o *Orchestrator) workflowFile() string {
+	if o.workflowFileFunc != nil {
+		return o.workflowFileFunc()
+	}
+	return ""
 }
 
 // onRetryFire delivers a retry timer event to the event loop channel.

--- a/internal/orchestrator/retry.go
+++ b/internal/orchestrator/retry.go
@@ -77,6 +77,10 @@ type HandleRetryTimerParams struct {
 	// HostPool is the SSH host pool for host acquisition on retry.
 	// May be nil (local mode).
 	HostPool *HostPool
+
+	// WorkflowFile is the base filename of the active WORKFLOW.md file.
+	// Recorded on the RunningEntry for observability.
+	WorkflowFile string
 }
 
 // HandleRetryTimer processes a retry timer event for the given issue.
@@ -294,6 +298,9 @@ func HandleRetryTimer(state *State, issueID string, params HandleRetryTimerParam
 	// next worker exit, not at dispatch time.
 	attempt := popped.Attempt
 	DispatchIssue(ctx, state, issue, &attempt, host, params.MakeWorkerFn("", host))
+	if entry := state.Running[issue.ID]; entry != nil {
+		entry.WorkflowFile = params.WorkflowFile
+	}
 	metrics.IncDispatches(outcomeSuccess)
 
 	log.Info("retried issue dispatched",

--- a/internal/orchestrator/retry_test.go
+++ b/internal/orchestrator/retry_test.go
@@ -1147,3 +1147,42 @@ func TestIsStaleRetryTimer(t *testing.T) {
 		})
 	}
 }
+
+func TestHandleRetryTimer_WorkflowFilePropagated(t *testing.T) {
+	t.Parallel()
+
+	// Section 9.5: WorkflowFile captured at dispatch should appear on the
+	// RunningEntry so it is persisted by HandleWorkerExit.
+	store := &mockRetryStore{}
+	tracker := &mockRetryTracker{
+		candidates: []domain.Issue{candidateIssue("ISS-WF", "ISS-WF", "To Do")},
+	}
+
+	state := retryState(t, "ISS-WF", "ISS-WF", 1)
+
+	params := defaultRetryParams(t, store, tracker)
+	params.WorkflowFile = "infra.WORKFLOW.md"
+
+	workerCalled := make(chan struct{}, 1)
+	params.MakeWorkerFn = func(_, _ string) WorkerFunc {
+		return func(_ context.Context, _ domain.Issue, _ *int) {
+			workerCalled <- struct{}{}
+		}
+	}
+
+	HandleRetryTimer(state, "ISS-WF", params)
+
+	select {
+	case <-workerCalled:
+	case <-time.After(time.Second):
+		t.Fatal("worker goroutine did not execute within 1 second")
+	}
+
+	running, ok := state.Running["ISS-WF"]
+	if !ok {
+		t.Fatal("Running[ISS-WF] missing after dispatch")
+	}
+	if running.WorkflowFile != "infra.WORKFLOW.md" {
+		t.Errorf("Running[ISS-WF].WorkflowFile = %q, want %q", running.WorkflowFile, "infra.WORKFLOW.md")
+	}
+}

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -172,6 +172,11 @@ type RunningEntry struct {
 	// it from config (which may have changed via dynamic config reload).
 	WorkspacePath string
 
+	// WorkflowFile is the base filename of the WORKFLOW.md file that was
+	// active when this session was dispatched (e.g. "WORKFLOW.md").
+	// Recorded for observability and persisted in run_history.
+	WorkflowFile string
+
 	// SSHHost is the SSH host that this worker is executing on. Empty
 	// for local execution. Used by [HandleWorkerExit] for host pool
 	// release, [RuntimeSnapshot] for observability, and the retry
@@ -333,6 +338,7 @@ type SnapshotRunningEntry struct {
 	SSHHost            string                `json:"ssh_host,omitempty"`
 	ToolTimeMs         int64                 `json:"tool_time_ms"`
 	APITimeMs          int64                 `json:"api_time_ms"`
+	WorkflowFile       string                `json:"workflow_file,omitempty"`
 }
 
 // SnapshotRetryEntry is a read-only view of a pending retry for
@@ -439,6 +445,7 @@ func RuntimeSnapshot(state *State, now time.Time) RuntimeSnapshotResult {
 			SSHHost:            entry.SSHHost,
 			ToolTimeMs:         entry.ToolTimeMs,
 			APITimeMs:          entry.APITimeMs,
+			WorkflowFile:       entry.WorkflowFile,
 		})
 
 		if !entry.StartedAt.IsZero() {

--- a/internal/orchestrator/state_test.go
+++ b/internal/orchestrator/state_test.go
@@ -675,3 +675,55 @@ func TestRuntimeSnapshot(t *testing.T) {
 		}
 	})
 }
+
+func TestRuntimeSnapshot_WorkflowFile(t *testing.T) {
+	t.Parallel()
+
+	fixedNow := time.Date(2026, 3, 24, 12, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name         string
+		workflowFile string
+		wantFile     string
+	}{
+		{
+			name:         "workflow file propagated to snapshot",
+			workflowFile: "WORKFLOW.md",
+			wantFile:     "WORKFLOW.md",
+		},
+		{
+			name:         "custom workflow filename propagated",
+			workflowFile: "backend.WORKFLOW.md",
+			wantFile:     "backend.WORKFLOW.md",
+		},
+		{
+			name:         "empty workflow file preserved as empty",
+			workflowFile: "",
+			wantFile:     "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			state := NewState(5000, 4, nil, AgentTotals{})
+			state.Running["ISS-1"] = &RunningEntry{
+				Identifier:   "PROJ-1",
+				Issue:        domain.Issue{ID: "ISS-1", State: "In Progress"},
+				StartedAt:    fixedNow.Add(-5 * time.Minute),
+				WorkflowFile: tt.workflowFile,
+			}
+
+			result := RuntimeSnapshot(state, fixedNow)
+
+			if len(result.Running) != 1 {
+				t.Fatalf("len(Running) = %d, want 1", len(result.Running))
+			}
+			got := result.Running[0].WorkflowFile
+			if got != tt.wantFile {
+				t.Errorf("WorkflowFile = %q, want %q", got, tt.wantFile)
+			}
+		})
+	}
+}

--- a/internal/persistence/migrate_test.go
+++ b/internal/persistence/migrate_test.go
@@ -194,6 +194,7 @@ func TestMigrate_ColumnCorrectness(t *testing.T) {
 				{"completed_at", "TEXT", true, 0},
 				{"status", "TEXT", true, 0},
 				{"error", "TEXT", false, 0},
+				{"workflow_file", "TEXT", false, 0},
 			},
 		},
 		{

--- a/internal/persistence/migrations.go
+++ b/internal/persistence/migrations.go
@@ -17,7 +17,11 @@ var migration001SQL string
 //go:embed sql/002_extended_token_metrics.sql
 var migration002SQL string
 
+//go:embed sql/003_workflow_file.sql
+var migration003SQL string
+
 var migrations = []Migration{
 	{Version: 1, Description: "core persistence tables", SQL: migration001SQL},
 	{Version: 2, Description: "extended token metrics", SQL: migration002SQL},
+	{Version: 3, Description: "workflow file in run history", SQL: migration003SQL},
 }

--- a/internal/persistence/run_history.go
+++ b/internal/persistence/run_history.go
@@ -20,6 +20,7 @@ type RunHistory struct {
 	CompletedAt  string  // ISO-8601 timestamp of run completion.
 	Status       string  // Terminal status: "succeeded", "failed", "timed_out", "stalled", etc.
 	Error        *string // Error message if failed; nil on success.
+	WorkflowFile string  // Base filename of the WORKFLOW.md file; empty for pre-migration rows.
 }
 
 // AppendRunHistory inserts a completed run attempt into run_history. The ID
@@ -31,12 +32,17 @@ func (s *Store) AppendRunHistory(ctx context.Context, run RunHistory) (RunHistor
 		errVal = sql.NullString{String: *run.Error, Valid: true}
 	}
 
+	wfVal := sql.NullString{}
+	if run.WorkflowFile != "" {
+		wfVal = sql.NullString{String: run.WorkflowFile, Valid: true}
+	}
+
 	res, err := s.db.ExecContext(ctx,
 		`INSERT INTO run_history
-			(issue_id, identifier, attempt, agent_adapter, workspace, started_at, completed_at, status, error)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			(issue_id, identifier, attempt, agent_adapter, workspace, started_at, completed_at, status, error, workflow_file)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		run.IssueID, run.Identifier, run.Attempt, run.AgentAdapter,
-		run.Workspace, run.StartedAt, run.CompletedAt, run.Status, errVal,
+		run.Workspace, run.StartedAt, run.CompletedAt, run.Status, errVal, wfVal,
 	)
 	if err != nil {
 		return RunHistory{}, fmt.Errorf("append run history for %q: %w", run.IssueID, err)
@@ -56,7 +62,7 @@ func (s *Store) AppendRunHistory(ctx context.Context, run RunHistory) (RunHistor
 func (s *Store) QueryRunHistoryByIssue(ctx context.Context, issueID string) ([]RunHistory, error) {
 	rows, err := s.db.QueryContext(ctx,
 		`SELECT id, issue_id, identifier, attempt, agent_adapter, workspace,
-			started_at, completed_at, status, error
+			started_at, completed_at, status, error, workflow_file
 		FROM run_history
 		WHERE issue_id = ?
 		ORDER BY id DESC`, issueID)
@@ -68,16 +74,19 @@ func (s *Store) QueryRunHistoryByIssue(ctx context.Context, issueID string) ([]R
 	entries := []RunHistory{}
 	for rows.Next() {
 		var r RunHistory
-		var errVal sql.NullString
+		var errVal, wfVal sql.NullString
 		if err := rows.Scan(
 			&r.ID, &r.IssueID, &r.Identifier, &r.Attempt, &r.AgentAdapter,
-			&r.Workspace, &r.StartedAt, &r.CompletedAt, &r.Status, &errVal,
+			&r.Workspace, &r.StartedAt, &r.CompletedAt, &r.Status, &errVal, &wfVal,
 		); err != nil {
 			return nil, fmt.Errorf("scan run history: %w", err)
 		}
 		if errVal.Valid {
 			s := errVal.String
 			r.Error = &s
+		}
+		if wfVal.Valid {
+			r.WorkflowFile = wfVal.String
 		}
 		entries = append(entries, r)
 	}
@@ -102,7 +111,7 @@ func (s *Store) QueryRecentRunHistory(ctx context.Context, limit int, afterID in
 	if afterID > 0 {
 		rows, err = s.db.QueryContext(ctx,
 			`SELECT id, issue_id, identifier, attempt, agent_adapter, workspace,
-				started_at, completed_at, status, error
+				started_at, completed_at, status, error, workflow_file
 			FROM run_history
 			WHERE id < ?
 			ORDER BY id DESC
@@ -110,7 +119,7 @@ func (s *Store) QueryRecentRunHistory(ctx context.Context, limit int, afterID in
 	} else {
 		rows, err = s.db.QueryContext(ctx,
 			`SELECT id, issue_id, identifier, attempt, agent_adapter, workspace,
-				started_at, completed_at, status, error
+				started_at, completed_at, status, error, workflow_file
 			FROM run_history
 			ORDER BY id DESC
 			LIMIT ?`, limit)
@@ -123,16 +132,19 @@ func (s *Store) QueryRecentRunHistory(ctx context.Context, limit int, afterID in
 	entries := []RunHistory{}
 	for rows.Next() {
 		var r RunHistory
-		var errVal sql.NullString
+		var errVal, wfVal sql.NullString
 		if err := rows.Scan(
 			&r.ID, &r.IssueID, &r.Identifier, &r.Attempt, &r.AgentAdapter,
-			&r.Workspace, &r.StartedAt, &r.CompletedAt, &r.Status, &errVal,
+			&r.Workspace, &r.StartedAt, &r.CompletedAt, &r.Status, &errVal, &wfVal,
 		); err != nil {
 			return nil, fmt.Errorf("scan run history: %w", err)
 		}
 		if errVal.Valid {
 			s := errVal.String
 			r.Error = &s
+		}
+		if wfVal.Valid {
+			r.WorkflowFile = wfVal.String
 		}
 		entries = append(entries, r)
 	}

--- a/internal/persistence/sql/003_workflow_file.sql
+++ b/internal/persistence/sql/003_workflow_file.sql
@@ -1,0 +1,3 @@
+-- Migration 3: Add workflow filename to run history
+
+ALTER TABLE run_history ADD COLUMN workflow_file TEXT;

--- a/internal/persistence/store_test.go
+++ b/internal/persistence/store_test.go
@@ -805,6 +805,76 @@ func TestAppendRunHistory_DBError(t *testing.T) {
 	}
 }
 
+func TestAppendRunHistory_WorkflowFile(t *testing.T) {
+	t.Parallel()
+
+	s := openTestStore(t)
+	migrateOrFatal(t, s)
+	ctx := context.Background()
+
+	run := newTestRun(1)
+	run.WorkflowFile = "backend.WORKFLOW.md"
+	appendOrFatal(t, s, run)
+
+	entries, err := s.QueryRunHistoryByIssue(ctx, run.IssueID)
+	if err != nil {
+		t.Fatalf("QueryRunHistoryByIssue: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("got %d entries, want 1", len(entries))
+	}
+	if entries[0].WorkflowFile != "backend.WORKFLOW.md" {
+		t.Errorf("WorkflowFile = %q, want %q", entries[0].WorkflowFile, "backend.WORKFLOW.md")
+	}
+}
+
+func TestAppendRunHistory_WorkflowFile_EmptyStoredAsNull(t *testing.T) {
+	t.Parallel()
+
+	s := openTestStore(t)
+	migrateOrFatal(t, s)
+	ctx := context.Background()
+
+	// newTestRun leaves WorkflowFile empty; must be stored as NULL and
+	// read back as empty string (not "<nil>" or similar).
+	run := newTestRun(2)
+	appendOrFatal(t, s, run)
+
+	entries, err := s.QueryRunHistoryByIssue(ctx, run.IssueID)
+	if err != nil {
+		t.Fatalf("QueryRunHistoryByIssue: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("got %d entries, want 1", len(entries))
+	}
+	if entries[0].WorkflowFile != "" {
+		t.Errorf("WorkflowFile = %q, want empty string for NULL column", entries[0].WorkflowFile)
+	}
+}
+
+func TestQueryRecentRunHistory_WorkflowFileRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	s := openTestStore(t)
+	migrateOrFatal(t, s)
+	ctx := context.Background()
+
+	run := newTestRun(1)
+	run.WorkflowFile = "infra.WORKFLOW.md"
+	appendOrFatal(t, s, run)
+
+	entries, err := s.QueryRecentRunHistory(ctx, 1, 0)
+	if err != nil {
+		t.Fatalf("QueryRecentRunHistory: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("got %d entries, want 1", len(entries))
+	}
+	if entries[0].WorkflowFile != "infra.WORKFLOW.md" {
+		t.Errorf("WorkflowFile = %q, want %q", entries[0].WorkflowFile, "infra.WORKFLOW.md")
+	}
+}
+
 // --- Session Metadata Tests ---
 
 func TestUpsertSessionMetadata(t *testing.T) {

--- a/internal/server/dashboard.go
+++ b/internal/server/dashboard.go
@@ -36,9 +36,10 @@ type dashboardData struct {
 	TotalTokens    int64
 
 	// Tables
-	Running  []dashboardRunningEntry
-	Retrying []dashboardRetryEntry
-	HasSSH   bool
+	Running    []dashboardRunningEntry
+	Retrying   []dashboardRetryEntry
+	RunHistory []dashboardRunHistoryEntry
+	HasSSH     bool
 
 	// Footer
 	RuntimeDisplay  string
@@ -61,6 +62,7 @@ type dashboardRunningEntry struct {
 	Host            string
 	ToolTimePct     string
 	APITimePct      string
+	WorkflowFile    string
 }
 
 type dashboardRetryEntry struct {
@@ -68,6 +70,16 @@ type dashboardRetryEntry struct {
 	Attempt    int
 	DueIn      string
 	Error      string
+}
+
+type dashboardRunHistoryEntry struct {
+	Identifier   string
+	Attempt      int
+	Status       string
+	WorkflowFile string
+	StartedAt    string
+	Duration     string
+	Error        string
 }
 
 // fmtInt formats an int64 with comma thousand separators.
@@ -237,6 +249,7 @@ func buildDashboardData(
 			Host:            e.SSHHost,
 			ToolTimePct:     toolPct,
 			APITimePct:      apiPct,
+			WorkflowFile:    e.WorkflowFile,
 		}
 	}
 	data.Running = running
@@ -262,6 +275,43 @@ func buildDashboardData(
 	return data
 }
 
+// mapRunHistoryEntries converts [RunHistoryEntry] values into the
+// dashboard-specific [dashboardRunHistoryEntry] with pre-formatted
+// fields. Duration is computed from StartedAt and CompletedAt when
+// both are valid RFC 3339 strings.
+func mapRunHistoryEntries(runs []RunHistoryEntry) []dashboardRunHistoryEntry {
+	out := make([]dashboardRunHistoryEntry, len(runs))
+	for i, r := range runs {
+		dur := ""
+		startT, errS := time.Parse(time.RFC3339, r.StartedAt)
+		endT, errE := time.Parse(time.RFC3339, r.CompletedAt)
+		if errS == nil && errE == nil {
+			dur = formatDuration(endT.Sub(startT))
+		}
+
+		errMsg := ""
+		if r.Error != nil {
+			errMsg = *r.Error
+		}
+
+		wf := r.WorkflowFile
+		if wf == "" {
+			wf = "\u2014" // em dash for missing
+		}
+
+		out[i] = dashboardRunHistoryEntry{
+			Identifier:   r.Identifier,
+			Attempt:      r.Attempt,
+			Status:       r.Status,
+			WorkflowFile: wf,
+			StartedAt:    r.StartedAt,
+			Duration:     dur,
+			Error:        errMsg,
+		}
+	}
+	return out
+}
+
 // handleFavicon serves the embedded favicon.ico with aggressive caching.
 func handleFavicon(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set("Content-Type", "image/x-icon")
@@ -285,6 +335,15 @@ func (s *Server) handleDashboard(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := buildDashboardData(snap, s.version, s.startedAt, s.slotFunc, time.Now())
+
+	if s.runHistoryFn != nil {
+		runs, err := s.runHistoryFn(r.Context(), 25)
+		if err != nil {
+			s.logger.Warn("dashboard run history query failed", slog.Any("error", err))
+		} else {
+			data.RunHistory = mapRunHistoryEntries(runs)
+		}
+	}
 
 	var buf bytes.Buffer
 	if err := s.dashboardTmpl.Execute(&buf, data); err != nil {

--- a/internal/server/dashboard.html
+++ b/internal/server/dashboard.html
@@ -267,6 +267,7 @@
             <tr>
               <th>Identifier</th>
               <th>State</th>
+              <th>Workflow</th>
               {{if $.HasSSH}}
               <th>Host</th>
               {{end}}
@@ -285,6 +286,7 @@
             <tr>
               <td><a href="{{.DetailURL}}">{{.Identifier}}</a></td>
               <td>{{.State}}</td>
+              <td>{{if .WorkflowFile}}{{.WorkflowFile}}{{else}}&mdash;{{end}}</td>
               {{if $.HasSSH}}
               <td>{{if .Host}}{{.Host}}{{else}}local{{end}}</td>
               {{end}}
@@ -335,6 +337,38 @@
         <div class="empty-state">No retries pending</div>
         {{end}}
       </section>
+
+      {{if .RunHistory}}
+      <section>
+        <h2>Run History</h2>
+        <table>
+          <thead>
+            <tr>
+              <th>Identifier</th>
+              <th class="text-right">Attempt</th>
+              <th>Status</th>
+              <th>Workflow</th>
+              <th>Started</th>
+              <th>Duration</th>
+              <th>Error</th>
+            </tr>
+          </thead>
+          <tbody>
+            {{range .RunHistory}}
+            <tr>
+              <td>{{.Identifier}}</td>
+              <td class="text-right">{{.Attempt}}</td>
+              <td>{{.Status}}</td>
+              <td>{{.WorkflowFile}}</td>
+              <td>{{.StartedAt}}</td>
+              <td>{{.Duration}}</td>
+              <td class="error-cell" title="{{.Error}}">{{if .Error}}{{.Error}}{{else}}&mdash;{{end}}</td>
+            </tr>
+            {{end}}
+          </tbody>
+        </table>
+      </section>
+      {{end}}
     </div>
 
     <footer>

--- a/internal/server/dashboard_test.go
+++ b/internal/server/dashboard_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"io"
 	"log/slog"
 	"net/http"
@@ -785,5 +786,157 @@ func TestHandleDashboard_ExtendedFieldsRendered(t *testing.T) {
 		if !strings.Contains(dr.Body, want) {
 			t.Errorf("body missing %q", want)
 		}
+	}
+}
+
+func TestMapRunHistoryEntries(t *testing.T) {
+	t.Parallel()
+
+	errMsg := "agent crashed"
+	tests := []struct {
+		name         string
+		input        RunHistoryEntry
+		wantWF       string
+		wantDuration string
+		wantError    string
+	}{
+		{
+			name: "non-empty workflow file passed through",
+			input: RunHistoryEntry{
+				Identifier:   "MT-1",
+				Attempt:      1,
+				Status:       "succeeded",
+				WorkflowFile: "WORKFLOW.md",
+				StartedAt:    "2026-03-24T10:00:00Z",
+				CompletedAt:  "2026-03-24T10:00:30Z",
+			},
+			wantWF:       "WORKFLOW.md",
+			wantDuration: "30s",
+			wantError:    "",
+		},
+		{
+			name: "empty workflow file becomes em dash",
+			input: RunHistoryEntry{
+				Identifier:   "MT-2",
+				Attempt:      1,
+				Status:       "succeeded",
+				WorkflowFile: "",
+				StartedAt:    "2026-03-24T10:00:00Z",
+				CompletedAt:  "2026-03-24T10:01:00Z",
+			},
+			wantWF:       "\u2014",
+			wantDuration: "1m 0s",
+			wantError:    "",
+		},
+		{
+			name: "non-nil error extracted",
+			input: RunHistoryEntry{
+				Identifier:   "MT-3",
+				Attempt:      2,
+				Status:       "failed",
+				WorkflowFile: "backend.WORKFLOW.md",
+				StartedAt:    "2026-03-24T10:00:00Z",
+				CompletedAt:  "2026-03-24T10:02:00Z",
+				Error:        &errMsg,
+			},
+			wantWF:       "backend.WORKFLOW.md",
+			wantDuration: "2m 0s",
+			wantError:    "agent crashed",
+		},
+		{
+			name: "invalid RFC3339 dates produce empty duration",
+			input: RunHistoryEntry{
+				Identifier:   "MT-4",
+				Attempt:      1,
+				Status:       "failed",
+				WorkflowFile: "WORKFLOW.md",
+				StartedAt:    "not-a-date",
+				CompletedAt:  "also-not-a-date",
+			},
+			wantWF:       "WORKFLOW.md",
+			wantDuration: "",
+			wantError:    "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := mapRunHistoryEntries([]RunHistoryEntry{tt.input})
+
+			if len(got) != 1 {
+				t.Fatalf("len = %d, want 1", len(got))
+			}
+			e := got[0]
+			if e.WorkflowFile != tt.wantWF {
+				t.Errorf("WorkflowFile = %q, want %q", e.WorkflowFile, tt.wantWF)
+			}
+			if e.Duration != tt.wantDuration {
+				t.Errorf("Duration = %q, want %q", e.Duration, tt.wantDuration)
+			}
+			if e.Error != tt.wantError {
+				t.Errorf("Error = %q, want %q", e.Error, tt.wantError)
+			}
+		})
+	}
+}
+
+func TestHandleDashboard_RunHistory(t *testing.T) {
+	t.Parallel()
+
+	snap := orchestrator.RuntimeSnapshotResult{
+		GeneratedAt: time.Date(2026, 3, 24, 12, 0, 0, 0, time.UTC),
+	}
+
+	srv := New(Params{
+		SnapshotFn: fixedSnapshot(snap),
+		RefreshFn:  acceptingRefresh(),
+		Logger:     slog.New(slog.DiscardHandler),
+		StartedAt:  time.Date(2026, 3, 24, 10, 0, 0, 0, time.UTC),
+		RunHistoryFn: func(_ context.Context, _ int) ([]RunHistoryEntry, error) {
+			return []RunHistoryEntry{
+				{
+					Identifier:   "MT-100",
+					Attempt:      1,
+					Status:       "succeeded",
+					WorkflowFile: "backend.WORKFLOW.md",
+					StartedAt:    "2026-03-24T09:00:00Z",
+					CompletedAt:  "2026-03-24T09:05:00Z",
+				},
+			}, nil
+		},
+	})
+	ts := httptest.NewServer(srv.Mux())
+	t.Cleanup(ts.Close)
+
+	dr := getDashboard(t, ts, "/")
+
+	if dr.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want %d", dr.StatusCode, http.StatusOK)
+	}
+	for _, want := range []string{"MT-100", "backend.WORKFLOW.md", "Run History"} {
+		if !strings.Contains(dr.Body, want) {
+			t.Errorf("body missing %q", want)
+		}
+	}
+}
+
+func TestHandleDashboard_NoRunHistoryFn(t *testing.T) {
+	t.Parallel()
+
+	snap := orchestrator.RuntimeSnapshotResult{
+		GeneratedAt: time.Date(2026, 3, 24, 12, 0, 0, 0, time.UTC),
+	}
+
+	// No RunHistoryFn → run history section must be omitted entirely.
+	ts := dashboardServer(t, fixedSnapshot(snap), "1.0.0", nil)
+	dr := getDashboard(t, ts, "/")
+
+	if dr.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want %d", dr.StatusCode, http.StatusOK)
+	}
+	if strings.Contains(dr.Body, "Run History") {
+		t.Error("body contains 'Run History', want omitted when RunHistoryFn is nil")
 	}
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -33,6 +33,23 @@ type RefreshFunc func() bool
 // If nil, available slots defaults to 0.
 type SlotFunc func() int
 
+// RunHistoryFunc returns recent run history entries for the dashboard.
+// Called on each dashboard render. If nil, the run history section
+// is omitted.
+type RunHistoryFunc func(ctx context.Context, limit int) ([]RunHistoryEntry, error)
+
+// RunHistoryEntry is a server-layer view of a completed run attempt.
+// Decoupled from persistence types to avoid leaking internal packages.
+type RunHistoryEntry struct {
+	Identifier   string
+	Attempt      int
+	Status       string
+	WorkflowFile string
+	StartedAt    string
+	CompletedAt  string
+	Error        *string
+}
+
 // DBPingFunc checks whether the SQLite database is accessible.
 // Returns nil on success, an error on failure. Called on each
 // GET /readyz request.
@@ -86,6 +103,11 @@ type Params struct {
 	// successfully loaded at least once. Called on each GET /readyz.
 	// When nil, the workflow check always reports "pass".
 	WorkflowLoadedFn func() bool
+
+	// RunHistoryFn returns recent run history entries for the
+	// dashboard. Called on each dashboard render. When nil, the run
+	// history section is omitted.
+	RunHistoryFn RunHistoryFunc
 }
 
 // Server is the embedded HTTP server for JSON API, dashboard, and
@@ -106,6 +128,7 @@ type Server struct {
 	dbPingFn         DBPingFunc
 	preflightFn      func() bool
 	workflowLoadedFn func() bool
+	runHistoryFn     RunHistoryFunc
 }
 
 // Compile-time assertion: Server satisfies orchestrator.Observer.
@@ -147,6 +170,7 @@ func New(params Params) *Server {
 		dbPingFn:         params.DBPingFn,
 		preflightFn:      params.PreflightFn,
 		workflowLoadedFn: params.WorkflowLoadedFn,
+		runHistoryFn:     params.RunHistoryFn,
 	}
 
 	// Dashboard route. Method-specific pattern so non-GET methods

--- a/internal/workflow/manager.go
+++ b/internal/workflow/manager.go
@@ -110,6 +110,13 @@ func (m *Manager) PromptTemplate() *prompt.Template {
 	return m.currentPrompt
 }
 
+// FilePath returns the base filename of the workflow file (e.g.
+// "WORKFLOW.md"). The full directory path is stripped to avoid
+// exposing sensitive directory structure.
+func (m *Manager) FilePath() string {
+	return filepath.Base(m.path)
+}
+
 // LastLoadError returns the error from the most recent reload attempt,
 // or nil if the last reload succeeded. Safe for concurrent use.
 func (m *Manager) LastLoadError() error {

--- a/internal/workflow/manager_test.go
+++ b/internal/workflow/manager_test.go
@@ -66,6 +66,40 @@ func mustRemove(t *testing.T, path string) {
 	}
 }
 
+func TestManager_FilePath(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		filename string
+	}{
+		{name: "standard name", filename: "WORKFLOW.md"},
+		{name: "custom prefix", filename: "backend.WORKFLOW.md"},
+		{name: "all lowercase", filename: "workflow.md"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			dir := t.TempDir()
+			path := filepath.Join(dir, tt.filename)
+			if err := os.WriteFile(path, validWorkflow(5000), 0o644); err != nil {
+				t.Fatalf("write workflow file: %v", err)
+			}
+			m, err := NewManager(path, testLogger())
+			if err != nil {
+				t.Fatalf("NewManager: %v", err)
+			}
+			m.Stop()
+
+			if got := m.FilePath(); got != tt.filename {
+				t.Errorf("FilePath() = %q, want %q", got, tt.filename)
+			}
+		})
+	}
+}
+
 func TestNewManager(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Feat

**Intent:** Each session and completed run now surfaces the WORKFLOW.md filename that governed it, giving operators instant clarity when multiple workflow files are in use or when a file has been renamed.

**Related Issues:** #277

### 🧭 Reviewer Guide

**Complexity:** High

#### Entry Point

Start at `internal/server/dashboard.go` — `mapRunHistoryEntries` and the updated `buildDashboardData` show how workflow file data flows from the server layer into the HTML template. Then trace the data backward through `internal/server/server.go` (`RunHistoryFunc`/`RunHistoryEntry`), `internal/orchestrator/orchestrator.go` (`WorkflowFileFunc` callback), and `internal/persistence/run_history.go` (SQL persistence).

#### Sensitive Areas

- `internal/persistence/sql/003_workflow_file.sql`: additive `ALTER TABLE` migration — must remain backwards-compatible (nullable column, no default required)
- `internal/persistence/run_history.go`: `sql.NullString` handling for the new column; both insert and two query paths updated
- `internal/orchestrator/orchestrator.go`: `WorkflowFileFunc` callback pattern chosen deliberately to avoid extending the `WorkflowManager` interface (which would require updating test doubles)
- `internal/server/dashboard.html`: new Run History `<section>` guarded by `{{if .RunHistory}}`; Workflow column added to Active Sessions table

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes
- **Migrations/State:** SQL migration 003 adds a nullable `workflow_file TEXT` column to `run_history` via `ALTER TABLE`. Pre-existing rows will have `NULL` for this column, rendered as an em dash in the dashboard. No manual steps required.