### PR TITLE
feat(release): add SBOM generation to release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -179,6 +179,9 @@ jobs:
         with:
           go-version-file: go.mod
 
+      - name: Install Syft
+        uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+
       - name: Create and push tag
         if: ${{ !inputs.dry_run }}
         run: |
@@ -220,6 +223,7 @@ jobs:
           echo "- \`sortie_${{ inputs.version }}_windows_amd64.zip\`" >> "$GITHUB_STEP_SUMMARY"
           echo "- \`sortie_${{ inputs.version }}_windows_arm64.zip\`" >> "$GITHUB_STEP_SUMMARY"
           echo "- \`checksums.txt\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- SBOM manifests (\`*.sbom.json\`)" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Dry run summary
         if: ${{ inputs.dry_run }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -47,6 +47,9 @@ checksum:
   name_template: "checksums.txt"
   algorithm: sha256
 
+sboms:
+  - artifacts: archive
+
 brews:
   - name: sortie
     repository:

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,4 @@
 golang 1.26.1
 golangci-lint 2.11.4
+goreleaser 2.14.3
 python 3.13.12


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Feat

**Intent:** Each release should include a Software Bill of Materials so downstream consumers can audit dependencies. This wires `syft` into the release pipeline via `anchore/sbom-action/download-syft` and enables GoReleaser's built-in SBOM support to produce SPDX JSON manifests for every archive artifact.

**Related Issues:** #214

### 🧭 Reviewer Guide

**Complexity:** Low

#### Entry Point

`.goreleaser.yaml` — the `sboms` block is the core change; GoReleaser's default configuration generates one `*.sbom.json` file per archive artifact using the `syft` binary installed in the prior workflow step.

#### Sensitive Areas

- `.github/workflows/release.yml`: new `Install Syft` step uses `anchore/sbom-action/download-syft` pinned by SHA (`e22c389904149dbc22b58101806040fa8d37a610`, v0.24.0), consistent with the pin-by-SHA policy used for all other actions in this file.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes
- **Migrations/State:** No migrations or state changes