### PR TITLE
feat(tracker): add GitHub Issues tracker adapter

### DIFF
--- a/cmd/sortie/main.go
+++ b/cmd/sortie/main.go
@@ -40,6 +40,7 @@ import (
 	_ "github.com/sortie-ai/sortie/internal/agent/claude"
 	_ "github.com/sortie-ai/sortie/internal/agent/mock"
 	_ "github.com/sortie-ai/sortie/internal/tracker/file"
+	_ "github.com/sortie-ai/sortie/internal/tracker/github"
 	_ "github.com/sortie-ai/sortie/internal/tracker/jira"
 )
 

--- a/internal/domain/metrics.go
+++ b/internal/domain/metrics.go
@@ -66,7 +66,7 @@ type Metrics interface {
 	// IncTrackerRequests increments the tracker adapter API call
 	// counter. operation is one of "fetch_candidates", "fetch_issue",
 	// "fetch_comments", "fetch_by_states", "fetch_states_by_ids",
-	// "fetch_states_by_identifiers", "transition".
+	// "fetch_states_by_identifiers", "transition", "comment".
 	// result is "success" or "error"
 	// (sortie_tracker_requests_total{operation,result} counter).
 	IncTrackerRequests(operation string, result string)

--- a/internal/domain/metrics_test.go
+++ b/internal/domain/metrics_test.go
@@ -45,7 +45,7 @@ func TestNoopMetricsSatisfiesInterface(t *testing.T) {
 	m.IncPollCycles("error")
 	m.IncPollCycles("skipped")
 
-	// Counters — IncTrackerRequests (all 7 operations)
+	// Counters — IncTrackerRequests (all 8 operations)
 	m.IncTrackerRequests("fetch_candidates", "success")
 	m.IncTrackerRequests("fetch_issue", "error")
 	m.IncTrackerRequests("fetch_comments", "success")
@@ -53,6 +53,7 @@ func TestNoopMetricsSatisfiesInterface(t *testing.T) {
 	m.IncTrackerRequests("fetch_states_by_ids", "error")
 	m.IncTrackerRequests("fetch_states_by_identifiers", "success")
 	m.IncTrackerRequests("transition", "error")
+	m.IncTrackerRequests("comment", "success")
 
 	// Counters — IncHandoffTransitions
 	m.IncHandoffTransitions("success")

--- a/internal/registry/adapter_meta_test.go
+++ b/internal/registry/adapter_meta_test.go
@@ -9,6 +9,7 @@ import (
 	_ "github.com/sortie-ai/sortie/internal/agent/claude"
 	_ "github.com/sortie-ai/sortie/internal/agent/mock"
 	_ "github.com/sortie-ai/sortie/internal/tracker/file"
+	_ "github.com/sortie-ai/sortie/internal/tracker/github"
 	_ "github.com/sortie-ai/sortie/internal/tracker/jira"
 )
 
@@ -28,6 +29,12 @@ func TestAdapterMeta_RealRegistrations(t *testing.T) {
 			{
 				name:        "jira requires api_key and project",
 				kind:        "jira",
+				wantAPIKey:  true,
+				wantProject: true,
+			},
+			{
+				name:        "github requires api_key and project",
+				kind:        "github",
 				wantAPIKey:  true,
 				wantProject: true,
 			},

--- a/internal/tracker/github/client.go
+++ b/internal/tracker/github/client.go
@@ -1,0 +1,358 @@
+package github
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/sortie-ai/sortie/internal/domain"
+)
+
+// maxErrorBody is the maximum number of bytes read from non-success
+// response bodies for diagnostic error messages.
+const maxErrorBody = 512
+
+type githubClient struct {
+	httpClient *http.Client
+	baseURL    string
+	authHeader string
+	userAgent  string
+	apiVersion string
+}
+
+func newGitHubClient(baseURL, token, userAgent string) *githubClient {
+	return &githubClient{
+		httpClient: &http.Client{Timeout: 30 * time.Second},
+		baseURL:    strings.TrimRight(baseURL, "/"),
+		authHeader: "Bearer " + token,
+		userAgent:  userAgent,
+		apiVersion: "2026-03-10",
+	}
+}
+
+// setHeaders applies the common GitHub API headers to a request.
+func (c *githubClient) setHeaders(req *http.Request) {
+	req.Header.Set("Authorization", c.authHeader)
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("X-GitHub-Api-Version", c.apiVersion)
+	req.Header.Set("User-Agent", c.userAgent)
+}
+
+// do executes an HTTP request against the GitHub REST API and returns
+// the response body and the Link rel="next" URL on success. Non-200
+// responses are classified via [classifyHTTPError]. Context
+// cancellation is propagated directly.
+func (c *githubClient) do(ctx context.Context, method, path string, params url.Values) ([]byte, string, error) { //nolint:unparam // method is GET today but the signature mirrors doJSON for consistency
+	reqURL := c.baseURL + path
+	if len(params) > 0 {
+		reqURL += "?" + params.Encode()
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, reqURL, nil) //nolint:gosec // URL is constructed from operator-configured base URL + internal API paths, not user data
+	if err != nil {
+		if ctx.Err() != nil {
+			return nil, "", ctx.Err()
+		}
+		return nil, "", &domain.TrackerError{
+			Kind:    domain.ErrTrackerTransport,
+			Message: fmt.Sprintf("failed to build request: %s %s", method, path),
+			Err:     err,
+		}
+	}
+
+	c.setHeaders(req)
+
+	resp, err := c.httpClient.Do(req) //nolint:gosec // controlled URL, see above
+	if err != nil {
+		if ctx.Err() != nil {
+			return nil, "", ctx.Err()
+		}
+		return nil, "", &domain.TrackerError{
+			Kind:    domain.ErrTrackerTransport,
+			Message: fmt.Sprintf("%s %s: network error", method, path),
+			Err:     err,
+		}
+	}
+	defer resp.Body.Close() //nolint:errcheck // best-effort cleanup on response body
+
+	if resp.StatusCode == http.StatusOK {
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return nil, "", &domain.TrackerError{
+				Kind:    domain.ErrTrackerTransport,
+				Message: "failed to read response body",
+				Err:     err,
+			}
+		}
+		linkNext := parseLinkNext(resp.Header.Get("Link"))
+		return body, linkNext, nil
+	}
+
+	if resp.StatusCode == http.StatusNotModified {
+		return nil, "", nil
+	}
+
+	return nil, "", classifyHTTPError(resp, method, path)
+}
+
+// doURL executes a GET request using a full URL (typically from a Link
+// header). Sets the same authentication and API version headers as
+// [githubClient.do]. Used exclusively for pagination.
+func (c *githubClient) doURL(ctx context.Context, fullURL string) ([]byte, string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fullURL, nil) //nolint:gosec // fullURL comes from GitHub Link headers, not user input
+	if err != nil {
+		if ctx.Err() != nil {
+			return nil, "", ctx.Err()
+		}
+		return nil, "", &domain.TrackerError{
+			Kind:    domain.ErrTrackerTransport,
+			Message: fmt.Sprintf("failed to build pagination request: %s", fullURL),
+			Err:     err,
+		}
+	}
+
+	c.setHeaders(req)
+
+	resp, err := c.httpClient.Do(req) //nolint:gosec // controlled URL from Link header
+	if err != nil {
+		if ctx.Err() != nil {
+			return nil, "", ctx.Err()
+		}
+		return nil, "", &domain.TrackerError{
+			Kind:    domain.ErrTrackerTransport,
+			Message: fmt.Sprintf("GET %s: network error", fullURL),
+			Err:     err,
+		}
+	}
+	defer resp.Body.Close() //nolint:errcheck // best-effort cleanup on response body
+
+	if resp.StatusCode == http.StatusOK {
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return nil, "", &domain.TrackerError{
+				Kind:    domain.ErrTrackerTransport,
+				Message: "failed to read response body",
+				Err:     err,
+			}
+		}
+		linkNext := parseLinkNext(resp.Header.Get("Link"))
+		return body, linkNext, nil
+	}
+
+	return nil, "", classifyHTTPError(resp, http.MethodGet, fullURL)
+}
+
+// doJSON executes an HTTP request with a JSON body. Successful
+// responses (200-299) return the response body. Non-success responses
+// are classified via [classifyHTTPError].
+func (c *githubClient) doJSON(ctx context.Context, method, path string, body io.Reader) ([]byte, error) { //nolint:unparam // callers may inspect response body in future operations
+	reqURL := c.baseURL + path
+
+	req, err := http.NewRequestWithContext(ctx, method, reqURL, body)
+	if err != nil {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+		return nil, &domain.TrackerError{
+			Kind:    domain.ErrTrackerTransport,
+			Message: fmt.Sprintf("failed to build request: %s %s", method, path),
+			Err:     err,
+		}
+	}
+
+	c.setHeaders(req)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+		return nil, &domain.TrackerError{
+			Kind:    domain.ErrTrackerTransport,
+			Message: fmt.Sprintf("%s %s: network error", method, path),
+			Err:     err,
+		}
+	}
+	defer resp.Body.Close() //nolint:errcheck // best-effort cleanup on response body
+
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		respBody, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return nil, &domain.TrackerError{
+				Kind:    domain.ErrTrackerTransport,
+				Message: "failed to read response body",
+				Err:     err,
+			}
+		}
+		return respBody, nil
+	}
+
+	return nil, classifyHTTPError(resp, method, path)
+}
+
+// doNoBody executes an HTTP request without a request body and
+// discards the response body. Accepts 200 and 204 as success. Used
+// for label removal (DELETE).
+func (c *githubClient) doNoBody(ctx context.Context, method, path string) error { //nolint:unparam // DELETE is the only caller today; method kept for interface consistency
+	reqURL := c.baseURL + path
+
+	req, err := http.NewRequestWithContext(ctx, method, reqURL, nil)
+	if err != nil {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		return &domain.TrackerError{
+			Kind:    domain.ErrTrackerTransport,
+			Message: fmt.Sprintf("failed to build request: %s %s", method, path),
+			Err:     err,
+		}
+	}
+
+	c.setHeaders(req)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		return &domain.TrackerError{
+			Kind:    domain.ErrTrackerTransport,
+			Message: fmt.Sprintf("%s %s: network error", method, path),
+			Err:     err,
+		}
+	}
+	defer resp.Body.Close() //nolint:errcheck // best-effort cleanup on response body
+
+	if resp.StatusCode == http.StatusOK || resp.StatusCode == http.StatusNoContent {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		return nil
+	}
+
+	return classifyHTTPError(resp, method, path)
+}
+
+// classifyHTTPError maps a non-success HTTP response to a
+// [*domain.TrackerError] with GitHub-specific 403 disambiguation.
+func classifyHTTPError(resp *http.Response, method, path string) error {
+	snippet, _ := io.ReadAll(io.LimitReader(resp.Body, maxErrorBody))
+	_, _ = io.Copy(io.Discard, resp.Body)
+	detail := string(snippet)
+
+	switch {
+	case resp.StatusCode == http.StatusBadRequest:
+		return &domain.TrackerError{
+			Kind:    domain.ErrTrackerPayload,
+			Message: fmt.Sprintf("%s %s: bad request: %s", method, path, detail),
+		}
+
+	case resp.StatusCode == http.StatusUnauthorized:
+		return &domain.TrackerError{
+			Kind:    domain.ErrTrackerAuth,
+			Message: fmt.Sprintf("%s %s: bad credentials", method, path),
+		}
+
+	case resp.StatusCode == http.StatusForbidden:
+		// Three-tier 403 disambiguation per spec Section 3.5.
+		if resp.Header.Get("X-Ratelimit-Remaining") == "0" {
+			return &domain.TrackerError{
+				Kind:    domain.ErrTrackerAPI,
+				Message: fmt.Sprintf("%s %s: rate limited (primary)", method, path),
+			}
+		}
+		if strings.Contains(strings.ToLower(detail), "rate limit") {
+			msg := fmt.Sprintf("%s %s: rate limited (secondary)", method, path)
+			if ra := resp.Header.Get("Retry-After"); ra != "" {
+				msg += fmt.Sprintf(" (retry after %s seconds)", ra)
+			}
+			return &domain.TrackerError{
+				Kind:    domain.ErrTrackerAPI,
+				Message: msg,
+			}
+		}
+		return &domain.TrackerError{
+			Kind:    domain.ErrTrackerAuth,
+			Message: fmt.Sprintf("%s %s: insufficient permissions", method, path),
+		}
+
+	case resp.StatusCode == http.StatusNotFound:
+		return &domain.TrackerError{
+			Kind:    domain.ErrTrackerNotFound,
+			Message: fmt.Sprintf("%s %s: not found", method, path),
+		}
+
+	case resp.StatusCode == http.StatusGone:
+		return &domain.TrackerError{
+			Kind:    domain.ErrTrackerAPI,
+			Message: fmt.Sprintf("%s %s: gone (410): %s", method, path, detail),
+		}
+
+	case resp.StatusCode == http.StatusUnprocessableEntity:
+		return &domain.TrackerError{
+			Kind:    domain.ErrTrackerPayload,
+			Message: fmt.Sprintf("%s %s: validation failed: %s", method, path, detail),
+		}
+
+	case resp.StatusCode == http.StatusTooManyRequests:
+		msg := fmt.Sprintf("%s %s: rate limited", method, path)
+		if ra := resp.Header.Get("Retry-After"); ra != "" {
+			msg += fmt.Sprintf(" (retry after %s seconds)", ra)
+		}
+		return &domain.TrackerError{
+			Kind:    domain.ErrTrackerAPI,
+			Message: msg,
+		}
+
+	case resp.StatusCode >= 500:
+		return &domain.TrackerError{
+			Kind:    domain.ErrTrackerTransport,
+			Message: fmt.Sprintf("%s %s: server error %d: %s", method, path, resp.StatusCode, detail),
+		}
+
+	default:
+		return &domain.TrackerError{
+			Kind:    domain.ErrTrackerAPI,
+			Message: fmt.Sprintf("%s %s: unexpected status %d: %s", method, path, resp.StatusCode, detail),
+		}
+	}
+}
+
+// parseLinkNext extracts the URL with rel="next" from the Link header
+// value. Returns an empty string when absent or malformed.
+func parseLinkNext(header string) string {
+	if header == "" {
+		return ""
+	}
+
+	for _, segment := range strings.Split(header, ",") {
+		parts := strings.Split(segment, ";")
+		if len(parts) < 2 {
+			continue
+		}
+
+		hasNext := false
+		for _, attr := range parts[1:] {
+			attr = strings.TrimSpace(attr)
+			if strings.EqualFold(attr, `rel="next"`) {
+				hasNext = true
+				break
+			}
+		}
+		if !hasNext {
+			continue
+		}
+
+		urlPart := strings.TrimSpace(parts[0])
+		if start := strings.Index(urlPart, "<"); start != -1 {
+			if end := strings.Index(urlPart[start:], ">"); end != -1 {
+				return urlPart[start+1 : start+end]
+			}
+		}
+	}
+
+	return ""
+}

--- a/internal/tracker/github/client.go
+++ b/internal/tracker/github/client.go
@@ -92,10 +92,6 @@ func (c *githubClient) do(ctx context.Context, method, path string, params url.V
 		return body, linkNext, nil
 	}
 
-	if resp.StatusCode == http.StatusNotModified {
-		return nil, "", nil
-	}
-
 	return nil, "", classifyHTTPError(resp, method, path)
 }
 

--- a/internal/tracker/github/client_test.go
+++ b/internal/tracker/github/client_test.go
@@ -1,0 +1,578 @@
+package github
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/sortie-ai/sortie/internal/domain"
+)
+
+// newTestClient creates a githubClient pointed at the given base URL with
+// a test token and user-agent.
+func newTestClient(t *testing.T, baseURL string) *githubClient {
+	t.Helper()
+	return newGitHubClient(baseURL, "test-token", "sortie/test")
+}
+
+// assertClientError asserts that err is a *domain.TrackerError with the
+// expected Kind. Fatals when err is nil.
+func assertClientError(t *testing.T, err error, want domain.TrackerErrorKind) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("expected error with kind %q, got nil", want)
+	}
+	var te *domain.TrackerError
+	if !errors.As(err, &te) {
+		t.Fatalf("error type = %T, want *domain.TrackerError", err)
+	}
+	if te.Kind != want {
+		t.Errorf("TrackerError.Kind = %q, want %q", te.Kind, want)
+	}
+}
+
+// --- parseLinkNext ---
+
+func TestParseLinkNext(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		header string
+		want   string
+	}{
+		{
+			name:   "single rel next",
+			header: `<https://api.github.com/repos/o/r/issues?page=2>; rel="next"`,
+			want:   "https://api.github.com/repos/o/r/issues?page=2",
+		},
+		{
+			name:   "next among multiple rels",
+			header: `<https://api.github.com/repos/o/r/issues?page=3>; rel="last", <https://api.github.com/repos/o/r/issues?page=2>; rel="next"`,
+			want:   "https://api.github.com/repos/o/r/issues?page=2",
+		},
+		{
+			name:   "no next rel returns empty",
+			header: `<https://api.github.com/repos/o/r/issues?page=3>; rel="last"`,
+			want:   "",
+		},
+		{
+			name:   "empty header returns empty",
+			header: "",
+			want:   "",
+		},
+		{
+			name:   "malformed header no angle brackets",
+			header: `https://api.github.com; rel="next"`,
+			want:   "",
+		},
+		{
+			name:   "prev and next together",
+			header: `<https://example.com/page=1>; rel="prev", <https://example.com/page=3>; rel="next"`,
+			want:   "https://example.com/page=3",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := parseLinkNext(tt.header)
+			if got != tt.want {
+				t.Errorf("parseLinkNext(%q) = %q, want %q", tt.header, got, tt.want)
+			}
+		})
+	}
+}
+
+// --- classifyHTTPError ---
+
+func TestClassifyHTTPError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		status   int
+		headers  map[string]string
+		body     string
+		wantKind domain.TrackerErrorKind
+	}{
+		{
+			name:     "400 bad request",
+			status:   http.StatusBadRequest,
+			body:     "bad input",
+			wantKind: domain.ErrTrackerPayload,
+		},
+		{
+			name:     "401 unauthorized",
+			status:   http.StatusUnauthorized,
+			wantKind: domain.ErrTrackerAuth,
+		},
+		{
+			name:     "403 rate limited primary X-Ratelimit-Remaining=0",
+			status:   http.StatusForbidden,
+			headers:  map[string]string{"X-Ratelimit-Remaining": "0"},
+			wantKind: domain.ErrTrackerAPI,
+		},
+		{
+			name:     "403 rate limited secondary body contains rate limit",
+			status:   http.StatusForbidden,
+			body:     `{"message":"You have exceeded a secondary rate limit"}`,
+			wantKind: domain.ErrTrackerAPI,
+		},
+		{
+			name:     "403 permission denied other 403",
+			status:   http.StatusForbidden,
+			body:     "forbidden",
+			wantKind: domain.ErrTrackerAuth,
+		},
+		{
+			name:     "404 not found",
+			status:   http.StatusNotFound,
+			wantKind: domain.ErrTrackerNotFound,
+		},
+		{
+			name:     "410 gone",
+			status:   http.StatusGone,
+			wantKind: domain.ErrTrackerAPI,
+		},
+		{
+			name:     "422 validation failed",
+			status:   http.StatusUnprocessableEntity,
+			body:     "validation error",
+			wantKind: domain.ErrTrackerPayload,
+		},
+		{
+			name:     "429 rate limited",
+			status:   http.StatusTooManyRequests,
+			headers:  map[string]string{"Retry-After": "60"},
+			wantKind: domain.ErrTrackerAPI,
+		},
+		{
+			name:     "500 server error",
+			status:   http.StatusInternalServerError,
+			body:     "oops",
+			wantKind: domain.ErrTrackerTransport,
+		},
+		{
+			name:     "502 bad gateway",
+			status:   http.StatusBadGateway,
+			wantKind: domain.ErrTrackerTransport,
+		},
+		{
+			name:     "503 service unavailable",
+			status:   http.StatusServiceUnavailable,
+			wantKind: domain.ErrTrackerTransport,
+		},
+		{
+			name:     "unexpected status",
+			status:   418,
+			body:     "I'm a teapot",
+			wantKind: domain.ErrTrackerAPI,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := make(http.Header)
+			for k, v := range tt.headers {
+				h.Set(k, v)
+			}
+			resp := &http.Response{
+				StatusCode: tt.status,
+				Header:     h,
+				Body:       io.NopCloser(bytes.NewBufferString(tt.body)),
+			}
+			defer resp.Body.Close() //nolint:errcheck // NopCloser.Close always returns nil
+
+			err := classifyHTTPError(resp, "GET", "/test/path")
+			assertClientError(t, err, tt.wantKind)
+		})
+	}
+}
+
+func TestClassifyHTTPError_429_RetryAfterInMessage(t *testing.T) {
+	t.Parallel()
+
+	resp := &http.Response{
+		StatusCode: http.StatusTooManyRequests,
+		Header:     http.Header{"Retry-After": []string{"30"}},
+		Body:       io.NopCloser(bytes.NewBufferString("")),
+	}
+	defer resp.Body.Close() //nolint:errcheck // NopCloser.Close always returns nil
+
+	err := classifyHTTPError(resp, "GET", "/repos/o/r/issues")
+	var te *domain.TrackerError
+	if !errors.As(err, &te) {
+		t.Fatalf("error type = %T, want *domain.TrackerError", err)
+	}
+	if !strings.Contains(te.Message, "30") {
+		t.Errorf("message = %q, should contain Retry-After value", te.Message)
+	}
+}
+
+// --- do ---
+
+func TestDo_Success(t *testing.T) {
+	t.Parallel()
+
+	var gotHeaders http.Header
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotHeaders = r.Header.Clone()
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"ok":true}`)) //nolint:errcheck // test helper
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv.URL)
+	body, linkNext, err := c.do(context.Background(), "GET", "/repos/o/r/issues", nil)
+	if err != nil {
+		t.Fatalf("do: %v", err)
+	}
+	if string(body) != `{"ok":true}` {
+		t.Errorf("body = %q, want %q", body, `{"ok":true}`)
+	}
+	if linkNext != "" {
+		t.Errorf("linkNext = %q, want empty", linkNext)
+	}
+
+	// Verify required GitHub API headers.
+	if got := gotHeaders.Get("Authorization"); got != "Bearer test-token" {
+		t.Errorf("Authorization = %q, want %q", got, "Bearer test-token")
+	}
+	if got := gotHeaders.Get("Accept"); got != "application/vnd.github+json" {
+		t.Errorf("Accept = %q, want %q", got, "application/vnd.github+json")
+	}
+	if got := gotHeaders.Get("X-GitHub-Api-Version"); got != "2026-03-10" {
+		t.Errorf("X-GitHub-Api-Version = %q, want %q", got, "2026-03-10")
+	}
+	if got := gotHeaders.Get("User-Agent"); got != "sortie/test" {
+		t.Errorf("User-Agent = %q, want %q", got, "sortie/test")
+	}
+}
+
+func TestDo_LinkHeaderParsed(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Link", `<https://api.github.com/repos/o/r/issues?page=2>; rel="next", <https://api.github.com/repos/o/r/issues?page=5>; rel="last"`)
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("[]")) //nolint:errcheck // test helper
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv.URL)
+	_, linkNext, err := c.do(context.Background(), "GET", "/repos/o/r/issues", nil)
+	if err != nil {
+		t.Fatalf("do: %v", err)
+	}
+	if linkNext != "https://api.github.com/repos/o/r/issues?page=2" {
+		t.Errorf("linkNext = %q, want page=2 URL", linkNext)
+	}
+}
+
+func TestDo_QueryParams(t *testing.T) {
+	t.Parallel()
+
+	var gotQuery url.Values
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.Query()
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("[]")) //nolint:errcheck // test helper
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv.URL)
+	params := url.Values{"state": {"open"}, "per_page": {"50"}}
+	_, _, err := c.do(context.Background(), "GET", "/repos/o/r/issues", params)
+	if err != nil {
+		t.Fatalf("do: %v", err)
+	}
+	if got := gotQuery.Get("state"); got != "open" {
+		t.Errorf("state param = %q, want %q", got, "open")
+	}
+	if got := gotQuery.Get("per_page"); got != "50" {
+		t.Errorf("per_page param = %q, want %q", got, "50")
+	}
+}
+
+func TestDo_304NotModified(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotModified)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv.URL)
+	body, linkNext, err := c.do(context.Background(), "GET", "/path", nil)
+	if err != nil {
+		t.Fatalf("do 304: unexpected error: %v", err)
+	}
+	if body != nil {
+		t.Errorf("body = %v, want nil on 304", body)
+	}
+	if linkNext != "" {
+		t.Errorf("linkNext = %q, want empty on 304", linkNext)
+	}
+}
+
+func TestDo_ContextCancellation(t *testing.T) {
+	t.Parallel()
+
+	started := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		close(started)
+		<-r.Context().Done()
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	c := newTestClient(t, srv.URL)
+
+	errCh := make(chan error, 1)
+	go func() {
+		_, _, err := c.do(ctx, "GET", "/repos/o/r/issues", nil)
+		errCh <- err
+	}()
+
+	<-started
+	cancel()
+
+	err := <-errCh
+	if err == nil {
+		t.Fatal("expected error after context cancel, got nil")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("error = %v, want context.Canceled", err)
+	}
+}
+
+func TestDo_ErrorStatus(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		status   int
+		wantKind domain.TrackerErrorKind
+	}{
+		{"401", http.StatusUnauthorized, domain.ErrTrackerAuth},
+		{"403 perm", http.StatusForbidden, domain.ErrTrackerAuth},
+		{"404", http.StatusNotFound, domain.ErrTrackerNotFound},
+		{"500", http.StatusInternalServerError, domain.ErrTrackerTransport},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tt.status)
+			}))
+			defer srv.Close()
+
+			c := newTestClient(t, srv.URL)
+			_, _, err := c.do(context.Background(), "GET", "/path", nil)
+			assertClientError(t, err, tt.wantKind)
+		})
+	}
+}
+
+// --- doURL ---
+
+func TestDoURL_AuthHeadersSent(t *testing.T) {
+	t.Parallel()
+
+	var gotHeaders http.Header
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotHeaders = r.Header.Clone()
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("[]")) //nolint:errcheck // test helper
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv.URL)
+	_, _, err := c.doURL(context.Background(), srv.URL+"/repos/o/r/issues?page=2")
+	if err != nil {
+		t.Fatalf("doURL: %v", err)
+	}
+
+	if got := gotHeaders.Get("Authorization"); got != "Bearer test-token" {
+		t.Errorf("Authorization = %q, want Bearer prefix", got)
+	}
+	if got := gotHeaders.Get("X-GitHub-Api-Version"); got != "2026-03-10" {
+		t.Errorf("X-GitHub-Api-Version = %q, want %q", got, "2026-03-10")
+	}
+}
+
+func TestDoURL_LinkHeaderParsed(t *testing.T) {
+	t.Parallel()
+
+	nextURL := "https://api.github.com/repos/o/r/issues?page=3"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Link", `<`+nextURL+`>; rel="next"`)
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("[]")) //nolint:errcheck // test helper
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv.URL)
+	_, got, err := c.doURL(context.Background(), srv.URL+"/page")
+	if err != nil {
+		t.Fatalf("doURL: %v", err)
+	}
+	if got != nextURL {
+		t.Errorf("linkNext = %q, want %q", got, nextURL)
+	}
+}
+
+// --- doJSON ---
+
+func TestDoJSON_Success(t *testing.T) {
+	t.Parallel()
+
+	var gotMethod string
+	var gotContentType string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotContentType = r.Header.Get("Content-Type")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"result":"ok"}`)) //nolint:errcheck // test helper
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv.URL)
+	payload := bytes.NewBufferString(`{"labels":["review"]}`)
+	body, err := c.doJSON(context.Background(), "POST", "/repos/o/r/issues/1/labels", payload)
+	if err != nil {
+		t.Fatalf("doJSON: %v", err)
+	}
+	if string(body) != `{"result":"ok"}` {
+		t.Errorf("body = %q", body)
+	}
+	if gotMethod != "POST" {
+		t.Errorf("method = %q, want %q", gotMethod, "POST")
+	}
+	if gotContentType != "application/json" {
+		t.Errorf("Content-Type = %q, want %q", gotContentType, "application/json")
+	}
+}
+
+func TestDoJSON_2xxRange(t *testing.T) {
+	t.Parallel()
+
+	for _, status := range []int{200, 201, 204} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			t.Parallel()
+
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(status)
+			}))
+			defer srv.Close()
+
+			c := newTestClient(t, srv.URL)
+			_, err := c.doJSON(context.Background(), "PATCH", "/repos/o/r/issues/1", bytes.NewBufferString("{}"))
+			if err != nil {
+				t.Errorf("doJSON %d: unexpected error: %v", status, err)
+			}
+		})
+	}
+}
+
+func TestDoJSON_Error(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		w.Write([]byte(`{"errors":["invalid"]}`)) //nolint:errcheck // test helper
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv.URL)
+	_, err := c.doJSON(context.Background(), "POST", "/labels", bytes.NewBufferString("{}"))
+	assertClientError(t, err, domain.ErrTrackerPayload)
+}
+
+// --- doNoBody ---
+
+func TestDoNoBody_200(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv.URL)
+	if err := c.doNoBody(context.Background(), "DELETE", "/repos/o/r/issues/1/labels/backlog"); err != nil {
+		t.Errorf("doNoBody 200: unexpected error: %v", err)
+	}
+}
+
+func TestDoNoBody_204(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "DELETE" {
+			t.Errorf("method = %q, want DELETE", r.Method)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv.URL)
+	if err := c.doNoBody(context.Background(), "DELETE", "/repos/o/r/issues/1/labels/backlog"); err != nil {
+		t.Errorf("doNoBody 204: unexpected error: %v", err)
+	}
+}
+
+func TestDoNoBody_Error(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv.URL)
+	err := c.doNoBody(context.Background(), "DELETE", "/repos/o/r/issues/1/labels/backlog")
+	assertClientError(t, err, domain.ErrTrackerAuth)
+}
+
+func TestDoNoBody_ContextCancellation(t *testing.T) {
+	t.Parallel()
+
+	started := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		close(started)
+		<-r.Context().Done()
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	c := newTestClient(t, srv.URL)
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- c.doNoBody(ctx, "DELETE", "/repos/o/r/issues/1/labels/backlog")
+	}()
+
+	<-started
+	cancel()
+
+	err := <-errCh
+	if err == nil {
+		t.Fatal("expected error after context cancel")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("error = %v, want context.Canceled", err)
+	}
+}

--- a/internal/tracker/github/client_test.go
+++ b/internal/tracker/github/client_test.go
@@ -577,3 +577,82 @@ func TestDoNoBody_ContextCancellation(t *testing.T) {
 		t.Errorf("error = %v, want context.Canceled", err)
 	}
 }
+
+func TestDoURL_NonOKStatus(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv.URL)
+	_, _, err := c.doURL(context.Background(), srv.URL+"/repos/o/r/issues?page=2")
+	assertClientError(t, err, domain.ErrTrackerAuth)
+}
+
+func TestDoURL_ContextCancellation(t *testing.T) {
+	t.Parallel()
+
+	started := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		close(started)
+		<-r.Context().Done()
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	c := newTestClient(t, srv.URL)
+
+	errCh := make(chan error, 1)
+	go func() {
+		_, _, err := c.doURL(ctx, srv.URL+"/repos/o/r/issues?page=2")
+		errCh <- err
+	}()
+
+	<-started
+	cancel()
+
+	err := <-errCh
+	if err == nil {
+		t.Fatal("expected error after context cancel")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("error = %v, want context.Canceled", err)
+	}
+}
+
+func TestDoJSON_ContextCancellation(t *testing.T) {
+	t.Parallel()
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		close(started)
+		<-release // unblocked by the test to allow srv.Close() to finish cleanly
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	c := newTestClient(t, srv.URL)
+
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := c.doJSON(ctx, "PATCH", "/repos/o/r/issues/1", bytes.NewBufferString(`{}`))
+		errCh <- err
+	}()
+
+	<-started
+	cancel()
+
+	err := <-errCh
+	close(release) // let the handler return so srv.Close() does not hang
+
+	if err == nil {
+		t.Fatal("expected error after context cancel")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("error = %v, want context.Canceled", err)
+	}
+}

--- a/internal/tracker/github/client_test.go
+++ b/internal/tracker/github/client_test.go
@@ -313,15 +313,16 @@ func TestDo_304NotModified(t *testing.T) {
 	defer srv.Close()
 
 	c := newTestClient(t, srv.URL)
-	body, linkNext, err := c.do(context.Background(), "GET", "/path", nil)
-	if err != nil {
-		t.Fatalf("do 304: unexpected error: %v", err)
+	_, _, err := c.do(context.Background(), "GET", "/path", nil)
+	if err == nil {
+		t.Fatal("do 304: expected error, got nil")
 	}
-	if body != nil {
-		t.Errorf("body = %v, want nil on 304", body)
+	var trackerErr *domain.TrackerError
+	if !errors.As(err, &trackerErr) {
+		t.Fatalf("error type = %T, want *domain.TrackerError", err)
 	}
-	if linkNext != "" {
-		t.Errorf("linkNext = %q, want empty on 304", linkNext)
+	if trackerErr.Kind != domain.ErrTrackerAPI {
+		t.Errorf("TrackerError.Kind = %q, want %q", trackerErr.Kind, domain.ErrTrackerAPI)
 	}
 }
 

--- a/internal/tracker/github/github.go
+++ b/internal/tracker/github/github.go
@@ -484,12 +484,11 @@ func (a *GitHubAdapter) FetchIssuesByStates(ctx context.Context, states []string
 		stateSet[strings.ToLower(s)] = struct{}{}
 	}
 
-	activeSet := make(map[string]struct{}, len(a.activeStates))
-	for _, s := range a.activeStates {
-		activeSet[s] = struct{}{}
-	}
-
-	// Partition requested states.
+	// Partition requested states into open-fetch vs closed-search.
+	// Non-terminal states (active and unknown) route through the issues
+	// endpoint (state=open). An unknown state label on a closed issue
+	// will not be found — this is intentional: only configured terminal
+	// states warrant the closed-issue search path.
 	var requestedTerminal []string
 	needOpenFetch := false
 	for s := range stateSet {
@@ -834,6 +833,15 @@ func (a *GitHubAdapter) fetchAllComments(ctx context.Context, issueNumber string
 // because individual label operations are idempotent.
 func (a *GitHubAdapter) TransitionIssue(ctx context.Context, issueID string, targetState string) error {
 	targetLower := strings.ToLower(targetState)
+
+	if !isActiveState(targetLower, a.activeStates) && !isTerminalState(targetLower, a.terminalStates) {
+		a.incTrackerRequest("transition", "error")
+		return &domain.TrackerError{
+			Kind:    domain.ErrTrackerPayload,
+			Message: fmt.Sprintf("invalid target state: %q is not a configured active or terminal state", targetState),
+		}
+	}
+
 	basePath := "/repos/" + a.owner + "/" + a.repo + "/issues/" + issueID
 
 	// Step 1: Fetch current issue to read labels and native state.
@@ -868,7 +876,7 @@ func (a *GitHubAdapter) TransitionIssue(ctx context.Context, issueID string, tar
 
 	// Step 3: Add target state label if different from current.
 	if currentLabel != targetLower {
-		payload, err := json.Marshal(map[string][]string{"labels": {targetState}})
+		payload, err := json.Marshal(map[string][]string{"labels": {targetLower}})
 		if err != nil {
 			a.incTrackerRequest("transition", "error")
 			return &domain.TrackerError{

--- a/internal/tracker/github/github.go
+++ b/internal/tracker/github/github.go
@@ -333,7 +333,7 @@ func (a *GitHubAdapter) fetchCandidatesViaSearch(ctx context.Context) ([]domain.
 // FetchIssueByID returns a fully populated issue including comments,
 // blockers, and parent. The issueID is the issue number as a string.
 func (a *GitHubAdapter) FetchIssueByID(ctx context.Context, issueID string) (domain.Issue, error) {
-	basePath := "/repos/" + a.owner + "/" + a.repo + "/issues/" + issueID
+	basePath := "/repos/" + a.owner + "/" + a.repo + "/issues/" + url.PathEscape(issueID)
 
 	// Step 1: Fetch the issue itself.
 	body, _, err := a.client.do(ctx, "GET", basePath, nil)
@@ -395,7 +395,7 @@ func (a *GitHubAdapter) FetchIssueByID(ctx context.Context, issueID string) (dom
 }
 
 func (a *GitHubAdapter) fetchBlockers(ctx context.Context, issueID string) ([]domain.BlockerRef, error) {
-	path := "/repos/" + a.owner + "/" + a.repo + "/issues/" + issueID + "/dependencies/blocked_by"
+	path := "/repos/" + a.owner + "/" + a.repo + "/issues/" + url.PathEscape(issueID) + "/dependencies/blocked_by"
 	params := url.Values{"per_page": {"50"}}
 
 	body, nextURL, err := a.client.do(ctx, "GET", path, params)
@@ -444,7 +444,7 @@ func (a *GitHubAdapter) fetchBlockers(ctx context.Context, issueID string) ([]do
 }
 
 func (a *GitHubAdapter) fetchParent(ctx context.Context, issueID string) (*domain.ParentRef, error) {
-	path := "/repos/" + a.owner + "/" + a.repo + "/issues/" + issueID + "/parent"
+	path := "/repos/" + a.owner + "/" + a.repo + "/issues/" + url.PathEscape(issueID) + "/parent"
 
 	body, _, err := a.client.do(ctx, "GET", path, nil)
 	if err != nil {
@@ -617,7 +617,7 @@ func (a *GitHubAdapter) fetchOpenIssuesByStates(ctx context.Context, stateSet ma
 }
 
 func (a *GitHubAdapter) fetchClosedIssuesByLabel(ctx context.Context, label string, seen map[string]struct{}) ([]domain.Issue, error) {
-	q := fmt.Sprintf("repo:%s/%s type:issue state:closed label:%s", a.owner, a.repo, label)
+	q := fmt.Sprintf(`repo:%s/%s type:issue state:closed label:"%s"`, a.owner, a.repo, label)
 	params := url.Values{
 		"q":        {q},
 		"sort":     {"created"},
@@ -734,7 +734,7 @@ func (a *GitHubAdapter) fetchStatesByNumbers(ctx context.Context, numbers []stri
 			return nil, ctx.Err()
 		}
 
-		path := "/repos/" + a.owner + "/" + a.repo + "/issues/" + num
+		path := "/repos/" + a.owner + "/" + a.repo + "/issues/" + url.PathEscape(num)
 		body, _, err := a.client.do(ctx, "GET", path, nil)
 		if err != nil {
 			if isNotFound(err) {
@@ -773,7 +773,7 @@ func (a *GitHubAdapter) FetchIssueComments(ctx context.Context, issueID string) 
 }
 
 func (a *GitHubAdapter) fetchAllComments(ctx context.Context, issueNumber string) ([]domain.Comment, error) {
-	path := "/repos/" + a.owner + "/" + a.repo + "/issues/" + issueNumber + "/comments"
+	path := "/repos/" + a.owner + "/" + a.repo + "/issues/" + url.PathEscape(issueNumber) + "/comments"
 	params := url.Values{"per_page": {"50"}}
 
 	body, nextURL, err := a.client.do(ctx, "GET", path, params)
@@ -842,7 +842,7 @@ func (a *GitHubAdapter) TransitionIssue(ctx context.Context, issueID string, tar
 		}
 	}
 
-	basePath := "/repos/" + a.owner + "/" + a.repo + "/issues/" + issueID
+	basePath := "/repos/" + a.owner + "/" + a.repo + "/issues/" + url.PathEscape(issueID)
 
 	// Step 1: Fetch current issue to read labels and native state.
 	body, _, err := a.client.do(ctx, "GET", basePath, nil)
@@ -929,7 +929,7 @@ func (a *GitHubAdapter) TransitionIssue(ctx context.Context, issueID string, tar
 // CommentIssue posts a Markdown comment on the specified issue.
 // GitHub natively accepts Markdown, so no format conversion is needed.
 func (a *GitHubAdapter) CommentIssue(ctx context.Context, issueID string, text string) error {
-	path := "/repos/" + a.owner + "/" + a.repo + "/issues/" + issueID + "/comments"
+	path := "/repos/" + a.owner + "/" + a.repo + "/issues/" + url.PathEscape(issueID) + "/comments"
 
 	payload, err := json.Marshal(map[string]string{"body": text})
 	if err != nil {

--- a/internal/tracker/github/github.go
+++ b/internal/tracker/github/github.go
@@ -107,19 +107,21 @@ func NewGitHubAdapter(config map[string]any) (domain.TrackerAdapter, error) {
 	}
 	endpoint = strings.TrimRight(endpoint, "/")
 
-	activeStates := extractStringSlice(config["active_states"])
-	if len(activeStates) == 0 {
-		activeStates = append([]string{}, defaultActiveStates...)
+	activeRaw := extractStringSlice(config["active_states"])
+	if len(activeRaw) == 0 {
+		activeRaw = defaultActiveStates
 	}
-	for i, s := range activeStates {
+	activeStates := make([]string, len(activeRaw))
+	for i, s := range activeRaw {
 		activeStates[i] = strings.ToLower(s)
 	}
 
-	terminalStates := extractStringSlice(config["terminal_states"])
-	if len(terminalStates) == 0 {
-		terminalStates = append([]string{}, defaultTerminalStates...)
+	terminalRaw := extractStringSlice(config["terminal_states"])
+	if len(terminalRaw) == 0 {
+		terminalRaw = defaultTerminalStates
 	}
-	for i, s := range terminalStates {
+	terminalStates := make([]string, len(terminalRaw))
+	for i, s := range terminalRaw {
 		terminalStates[i] = strings.ToLower(s)
 	}
 

--- a/internal/tracker/github/github.go
+++ b/internal/tracker/github/github.go
@@ -1,0 +1,984 @@
+// Package github implements [domain.TrackerAdapter] for the GitHub
+// REST API (version 2026-03-10). Issues are fetched via the issues
+// list endpoint (or search endpoint when query_filter is configured),
+// normalized to domain types with labels lowercased, nil priority
+// (GitHub has no native priority), and label-based state derivation.
+// State is determined by scanning issue labels against configured
+// active_states and terminal_states in config order; the first match
+// wins. Comments are Markdown pass-through (no ADF conversion).
+// Registered under kind "github" via an init function.
+//
+// Unlike the Jira adapter, this adapter stores both activeStates and
+// terminalStates. Jira has native workflow states that the adapter
+// reads directly, so it needs only activeStates for candidate
+// filtering. GitHub has no native workflow states — only open and
+// closed — so the adapter must derive Sortie states entirely from
+// labels. This requires knowledge of both active and terminal state
+// sets for extractState fallback logic, FetchIssuesByStates
+// open/closed routing, and TransitionIssue close/reopen decisions.
+package github
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/sortie-ai/sortie/internal/domain"
+	"github.com/sortie-ai/sortie/internal/registry"
+)
+
+func init() {
+	registry.Trackers.RegisterWithMeta("github", NewGitHubAdapter, registry.AdapterMeta{
+		RequiresProject: true,
+		RequiresAPIKey:  true,
+	})
+}
+
+// Compile-time interface satisfaction check.
+var _ domain.TrackerAdapter = (*GitHubAdapter)(nil)
+
+// maxPages is the upper bound on paginated fetches. At 50 items per
+// page this allows up to 10,000 results before the adapter stops and
+// returns what it has.
+const maxPages = 200
+
+// defaultActiveStates is applied when the config omits active_states.
+var defaultActiveStates = []string{"backlog", "in-progress", "review"}
+
+// defaultTerminalStates is applied when the config omits terminal_states.
+var defaultTerminalStates = []string{"done", "wontfix"}
+
+// GitHubAdapter implements [domain.TrackerAdapter] against the GitHub
+// REST API. Safe for concurrent use.
+type GitHubAdapter struct {
+	client         *githubClient
+	owner          string
+	repo           string
+	activeStates   []string
+	terminalStates []string
+	queryFilter    string
+	metrics        domain.Metrics
+}
+
+// NewGitHubAdapter creates a [GitHubAdapter] from adapter configuration.
+// Required config keys: "api_key" (personal access token or fine-grained
+// token), "project" (owner/repo format). Optional: "endpoint" (defaults
+// to https://api.github.com), "active_states", "terminal_states",
+// "query_filter", "user_agent".
+func NewGitHubAdapter(config map[string]any) (domain.TrackerAdapter, error) {
+	apiKey, _ := config["api_key"].(string)
+	if apiKey == "" {
+		return nil, &domain.TrackerError{
+			Kind:    domain.ErrMissingTrackerAPIKey,
+			Message: "missing required config key: api_key",
+		}
+	}
+
+	project, _ := config["project"].(string)
+	if project == "" {
+		return nil, &domain.TrackerError{
+			Kind:    domain.ErrMissingTrackerProject,
+			Message: "missing required config key: project",
+		}
+	}
+
+	if strings.Count(project, "/") != 1 {
+		return nil, &domain.TrackerError{
+			Kind:    domain.ErrTrackerPayload,
+			Message: "project must be in owner/repo format",
+		}
+	}
+	parts := strings.SplitN(project, "/", 2)
+	if parts[0] == "" || parts[1] == "" {
+		return nil, &domain.TrackerError{
+			Kind:    domain.ErrTrackerPayload,
+			Message: "project must be in owner/repo format",
+		}
+	}
+
+	endpoint, _ := config["endpoint"].(string)
+	if endpoint == "" {
+		endpoint = "https://api.github.com"
+	}
+	endpoint = strings.TrimRight(endpoint, "/")
+
+	activeStates := extractStringSlice(config["active_states"])
+	if len(activeStates) == 0 {
+		activeStates = append([]string{}, defaultActiveStates...)
+	}
+	for i, s := range activeStates {
+		activeStates[i] = strings.ToLower(s)
+	}
+
+	terminalStates := extractStringSlice(config["terminal_states"])
+	if len(terminalStates) == 0 {
+		terminalStates = append([]string{}, defaultTerminalStates...)
+	}
+	for i, s := range terminalStates {
+		terminalStates[i] = strings.ToLower(s)
+	}
+
+	queryFilter, _ := config["query_filter"].(string)
+
+	userAgent, _ := config["user_agent"].(string)
+	if userAgent == "" {
+		userAgent = "sortie/dev"
+	}
+
+	return &GitHubAdapter{
+		client:         newGitHubClient(endpoint, apiKey, userAgent),
+		owner:          parts[0],
+		repo:           parts[1],
+		activeStates:   activeStates,
+		terminalStates: terminalStates,
+		queryFilter:    queryFilter,
+	}, nil
+}
+
+// FetchCandidateIssues returns issues in configured active states for
+// the configured repository. When queryFilter is empty, uses the
+// issues endpoint with client-side state filtering. When queryFilter
+// is set, routes through the search endpoint for server-side
+// filtering. Comments are set to nil on all returned issues.
+func (a *GitHubAdapter) FetchCandidateIssues(ctx context.Context) ([]domain.Issue, error) {
+	if a.queryFilter != "" {
+		return a.fetchCandidatesViaSearch(ctx)
+	}
+	return a.fetchCandidatesViaIssues(ctx)
+}
+
+func (a *GitHubAdapter) fetchCandidatesViaIssues(ctx context.Context) ([]domain.Issue, error) {
+	path := "/repos/" + a.owner + "/" + a.repo + "/issues"
+	params := url.Values{
+		"state":     {"open"},
+		"sort":      {"created"},
+		"direction": {"asc"},
+		"per_page":  {"50"},
+	}
+
+	body, nextURL, err := a.client.do(ctx, "GET", path, params)
+	if err != nil {
+		a.incTrackerRequest("fetch_candidates", "error")
+		return nil, err
+	}
+
+	var raw []githubIssue
+	if err := json.Unmarshal(body, &raw); err != nil {
+		a.incTrackerRequest("fetch_candidates", "error")
+		return nil, &domain.TrackerError{
+			Kind:    domain.ErrTrackerPayload,
+			Message: "failed to parse issues response",
+			Err:     err,
+		}
+	}
+
+	activeSet := make(map[string]struct{}, len(a.activeStates))
+	for _, s := range a.activeStates {
+		activeSet[s] = struct{}{}
+	}
+
+	var result []domain.Issue
+	for _, gi := range raw {
+		if isPullRequest(gi) {
+			continue
+		}
+		issue := normalizeIssue(gi, a.activeStates, a.terminalStates)
+		if _, ok := activeSet[issue.State]; !ok {
+			continue
+		}
+		issue.Comments = nil
+		result = append(result, issue)
+	}
+
+	pageCount := 1
+	for nextURL != "" && pageCount < maxPages {
+		pageCount++
+		body, nextURL, err = a.client.doURL(ctx, nextURL)
+		if err != nil {
+			a.incTrackerRequest("fetch_candidates", "error")
+			return nil, err
+		}
+
+		raw = raw[:0]
+		if err := json.Unmarshal(body, &raw); err != nil {
+			a.incTrackerRequest("fetch_candidates", "error")
+			return nil, &domain.TrackerError{
+				Kind:    domain.ErrTrackerPayload,
+				Message: "failed to parse issues response",
+				Err:     err,
+			}
+		}
+		for _, gi := range raw {
+			if isPullRequest(gi) {
+				continue
+			}
+			issue := normalizeIssue(gi, a.activeStates, a.terminalStates)
+			if _, ok := activeSet[issue.State]; !ok {
+				continue
+			}
+			issue.Comments = nil
+			result = append(result, issue)
+		}
+	}
+
+	if pageCount >= maxPages {
+		slog.Warn("pagination limit reached", //nolint:gosec // endpoint is an internal API path constant, not user input
+			slog.Int("max_pages", maxPages),
+			slog.String("endpoint", path))
+	}
+
+	if result == nil {
+		result = []domain.Issue{}
+	}
+	a.incTrackerRequest("fetch_candidates", "success")
+	return result, nil
+}
+
+func (a *GitHubAdapter) fetchCandidatesViaSearch(ctx context.Context) ([]domain.Issue, error) {
+	q := fmt.Sprintf("repo:%s/%s type:issue state:open %s", a.owner, a.repo, a.queryFilter)
+	params := url.Values{
+		"q":        {q},
+		"sort":     {"created"},
+		"order":    {"asc"},
+		"per_page": {"50"},
+	}
+
+	body, nextURL, err := a.client.do(ctx, "GET", "/search/issues", params)
+	if err != nil {
+		a.incTrackerRequest("fetch_candidates", "error")
+		return nil, err
+	}
+
+	var sr searchResponse
+	if err := json.Unmarshal(body, &sr); err != nil {
+		a.incTrackerRequest("fetch_candidates", "error")
+		return nil, &domain.TrackerError{
+			Kind:    domain.ErrTrackerPayload,
+			Message: "failed to parse search response",
+			Err:     err,
+		}
+	}
+	if sr.IncompleteResults {
+		slog.Warn("github search returned incomplete results",
+			slog.Int("total_count", sr.TotalCount))
+	}
+
+	activeSet := make(map[string]struct{}, len(a.activeStates))
+	for _, s := range a.activeStates {
+		activeSet[s] = struct{}{}
+	}
+
+	var result []domain.Issue
+	for _, gi := range sr.Items {
+		if isPullRequest(gi) {
+			continue
+		}
+		issue := normalizeIssue(gi, a.activeStates, a.terminalStates)
+		if _, ok := activeSet[issue.State]; !ok {
+			continue
+		}
+		issue.Comments = nil
+		result = append(result, issue)
+	}
+
+	pageCount := 1
+	for nextURL != "" && pageCount < maxPages {
+		pageCount++
+		body, nextURL, err = a.client.doURL(ctx, nextURL)
+		if err != nil {
+			a.incTrackerRequest("fetch_candidates", "error")
+			return nil, err
+		}
+
+		var page searchResponse
+		if err := json.Unmarshal(body, &page); err != nil {
+			a.incTrackerRequest("fetch_candidates", "error")
+			return nil, &domain.TrackerError{
+				Kind:    domain.ErrTrackerPayload,
+				Message: "failed to parse search response",
+				Err:     err,
+			}
+		}
+		for _, gi := range page.Items {
+			if isPullRequest(gi) {
+				continue
+			}
+			issue := normalizeIssue(gi, a.activeStates, a.terminalStates)
+			if _, ok := activeSet[issue.State]; !ok {
+				continue
+			}
+			issue.Comments = nil
+			result = append(result, issue)
+		}
+	}
+
+	if pageCount >= maxPages {
+		slog.Warn("pagination limit reached", //nolint:gosec // endpoint is an internal API path constant, not user input
+			slog.Int("max_pages", maxPages),
+			slog.String("endpoint", "/search/issues"))
+	}
+
+	if result == nil {
+		result = []domain.Issue{}
+	}
+	a.incTrackerRequest("fetch_candidates", "success")
+	return result, nil
+}
+
+// FetchIssueByID returns a fully populated issue including comments,
+// blockers, and parent. The issueID is the issue number as a string.
+func (a *GitHubAdapter) FetchIssueByID(ctx context.Context, issueID string) (domain.Issue, error) {
+	basePath := "/repos/" + a.owner + "/" + a.repo + "/issues/" + issueID
+
+	// Step 1: Fetch the issue itself.
+	body, _, err := a.client.do(ctx, "GET", basePath, nil)
+	if err != nil {
+		a.incTrackerRequest("fetch_issue", "error")
+		if isNotFound(err) {
+			return domain.Issue{}, &domain.TrackerError{
+				Kind:    domain.ErrTrackerNotFound,
+				Message: fmt.Sprintf("issue not found: %s", issueID),
+			}
+		}
+		return domain.Issue{}, err
+	}
+
+	var gi githubIssue
+	if err := json.Unmarshal(body, &gi); err != nil {
+		a.incTrackerRequest("fetch_issue", "error")
+		return domain.Issue{}, &domain.TrackerError{
+			Kind:    domain.ErrTrackerPayload,
+			Message: "failed to parse issue response",
+			Err:     err,
+		}
+	}
+
+	if isPullRequest(gi) {
+		a.incTrackerRequest("fetch_issue", "error")
+		return domain.Issue{}, &domain.TrackerError{
+			Kind:    domain.ErrTrackerNotFound,
+			Message: fmt.Sprintf("resource is a pull request, not an issue: %s", issueID),
+		}
+	}
+
+	issue := normalizeIssue(gi, a.activeStates, a.terminalStates)
+
+	// Step 2: Fetch blockers (dependencies/blocked_by).
+	issue.BlockedBy, err = a.fetchBlockers(ctx, issueID)
+	if err != nil {
+		a.incTrackerRequest("fetch_issue", "error")
+		return domain.Issue{}, err
+	}
+
+	// Step 3: Fetch parent.
+	issue.Parent, err = a.fetchParent(ctx, issueID)
+	if err != nil {
+		a.incTrackerRequest("fetch_issue", "error")
+		return domain.Issue{}, err
+	}
+
+	// Step 4: Fetch comments.
+	comments, err := a.fetchAllComments(ctx, issueID)
+	if err != nil {
+		a.incTrackerRequest("fetch_issue", "error")
+		return domain.Issue{}, err
+	}
+	issue.Comments = comments
+
+	a.incTrackerRequest("fetch_issue", "success")
+	return issue, nil
+}
+
+func (a *GitHubAdapter) fetchBlockers(ctx context.Context, issueID string) ([]domain.BlockerRef, error) {
+	path := "/repos/" + a.owner + "/" + a.repo + "/issues/" + issueID + "/dependencies/blocked_by"
+	params := url.Values{"per_page": {"50"}}
+
+	body, nextURL, err := a.client.do(ctx, "GET", path, params)
+	if err != nil {
+		if isNotFound(err) {
+			return []domain.BlockerRef{}, nil
+		}
+		return nil, err
+	}
+
+	var blockers []githubIssue
+	if err := json.Unmarshal(body, &blockers); err != nil {
+		return nil, &domain.TrackerError{
+			Kind:    domain.ErrTrackerPayload,
+			Message: "failed to parse blockers response",
+			Err:     err,
+		}
+	}
+
+	pageCount := 1
+	for nextURL != "" && pageCount < maxPages {
+		pageCount++
+		body, nextURL, err = a.client.doURL(ctx, nextURL)
+		if err != nil {
+			return nil, err
+		}
+
+		var page []githubIssue
+		if err := json.Unmarshal(body, &page); err != nil {
+			return nil, &domain.TrackerError{
+				Kind:    domain.ErrTrackerPayload,
+				Message: "failed to parse blockers response",
+				Err:     err,
+			}
+		}
+		blockers = append(blockers, page...)
+	}
+
+	if pageCount >= maxPages {
+		slog.Warn("pagination limit reached", //nolint:gosec // endpoint is an internal API path constant, not user input
+			slog.Int("max_pages", maxPages),
+			slog.String("endpoint", path))
+	}
+
+	return normalizeBlockers(blockers, a.activeStates, a.terminalStates), nil
+}
+
+func (a *GitHubAdapter) fetchParent(ctx context.Context, issueID string) (*domain.ParentRef, error) {
+	path := "/repos/" + a.owner + "/" + a.repo + "/issues/" + issueID + "/parent"
+
+	body, _, err := a.client.do(ctx, "GET", path, nil)
+	if err != nil {
+		if isNotFound(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	var parent githubIssue
+	if err := json.Unmarshal(body, &parent); err != nil {
+		return nil, &domain.TrackerError{
+			Kind:    domain.ErrTrackerPayload,
+			Message: "failed to parse parent response",
+			Err:     err,
+		}
+	}
+
+	num := strconv.Itoa(parent.Number)
+	return &domain.ParentRef{
+		ID:         num,
+		Identifier: num,
+	}, nil
+}
+
+// FetchIssuesByStates returns issues in the specified states using a
+// dual strategy: the issues endpoint for active states (open issues,
+// client-side filtering) and the search endpoint for terminal states
+// (closed issues, server-side label filtering).
+func (a *GitHubAdapter) FetchIssuesByStates(ctx context.Context, states []string) ([]domain.Issue, error) {
+	if len(states) == 0 {
+		return []domain.Issue{}, nil
+	}
+
+	stateSet := make(map[string]struct{}, len(states))
+	for _, s := range states {
+		stateSet[strings.ToLower(s)] = struct{}{}
+	}
+
+	activeSet := make(map[string]struct{}, len(a.activeStates))
+	for _, s := range a.activeStates {
+		activeSet[s] = struct{}{}
+	}
+
+	// Partition requested states.
+	var requestedTerminal []string
+	needOpenFetch := false
+	for s := range stateSet {
+		if isTerminalState(s, a.terminalStates) {
+			requestedTerminal = append(requestedTerminal, s)
+		} else {
+			needOpenFetch = true
+		}
+	}
+
+	var result []domain.Issue
+	seen := make(map[string]struct{})
+
+	// Active/unknown states: issues endpoint with client-side filtering.
+	if needOpenFetch {
+		issues, err := a.fetchOpenIssuesByStates(ctx, stateSet, seen)
+		if err != nil {
+			a.incTrackerRequest("fetch_by_states", "error")
+			return nil, err
+		}
+		result = append(result, issues...)
+	}
+
+	// Terminal states: search endpoint with server-side label filtering.
+	for _, label := range requestedTerminal {
+		if ctx.Err() != nil {
+			a.incTrackerRequest("fetch_by_states", "error")
+			return nil, ctx.Err()
+		}
+
+		issues, err := a.fetchClosedIssuesByLabel(ctx, label, seen)
+		if err != nil {
+			a.incTrackerRequest("fetch_by_states", "error")
+			return nil, err
+		}
+		result = append(result, issues...)
+	}
+
+	if result == nil {
+		result = []domain.Issue{}
+	}
+	a.incTrackerRequest("fetch_by_states", "success")
+	return result, nil
+}
+
+func (a *GitHubAdapter) fetchOpenIssuesByStates(ctx context.Context, stateSet map[string]struct{}, seen map[string]struct{}) ([]domain.Issue, error) {
+	path := "/repos/" + a.owner + "/" + a.repo + "/issues"
+	params := url.Values{
+		"state":     {"open"},
+		"sort":      {"created"},
+		"direction": {"asc"},
+		"per_page":  {"50"},
+	}
+
+	body, nextURL, err := a.client.do(ctx, "GET", path, params)
+	if err != nil {
+		return nil, err
+	}
+
+	var result []domain.Issue
+	var raw []githubIssue
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return nil, &domain.TrackerError{
+			Kind:    domain.ErrTrackerPayload,
+			Message: "failed to parse issues response",
+			Err:     err,
+		}
+	}
+	for _, gi := range raw {
+		if isPullRequest(gi) {
+			continue
+		}
+		issue := normalizeIssue(gi, a.activeStates, a.terminalStates)
+		if _, ok := stateSet[issue.State]; !ok {
+			continue
+		}
+		if _, dup := seen[issue.Identifier]; dup {
+			continue
+		}
+		issue.Comments = nil
+		result = append(result, issue)
+		seen[issue.Identifier] = struct{}{}
+	}
+
+	pageCount := 1
+	for nextURL != "" && pageCount < maxPages {
+		pageCount++
+		body, nextURL, err = a.client.doURL(ctx, nextURL)
+		if err != nil {
+			return nil, err
+		}
+
+		raw = raw[:0]
+		if err := json.Unmarshal(body, &raw); err != nil {
+			return nil, &domain.TrackerError{
+				Kind:    domain.ErrTrackerPayload,
+				Message: "failed to parse issues response",
+				Err:     err,
+			}
+		}
+		for _, gi := range raw {
+			if isPullRequest(gi) {
+				continue
+			}
+			issue := normalizeIssue(gi, a.activeStates, a.terminalStates)
+			if _, ok := stateSet[issue.State]; !ok {
+				continue
+			}
+			if _, dup := seen[issue.Identifier]; dup {
+				continue
+			}
+			issue.Comments = nil
+			result = append(result, issue)
+			seen[issue.Identifier] = struct{}{}
+		}
+	}
+
+	if pageCount >= maxPages {
+		slog.Warn("pagination limit reached", //nolint:gosec // endpoint is an internal API path constant, not user input
+			slog.Int("max_pages", maxPages),
+			slog.String("endpoint", path),
+			slog.String("state", "open"))
+	}
+
+	return result, nil
+}
+
+func (a *GitHubAdapter) fetchClosedIssuesByLabel(ctx context.Context, label string, seen map[string]struct{}) ([]domain.Issue, error) {
+	q := fmt.Sprintf("repo:%s/%s type:issue state:closed label:%s", a.owner, a.repo, label)
+	params := url.Values{
+		"q":        {q},
+		"sort":     {"created"},
+		"order":    {"asc"},
+		"per_page": {"50"},
+	}
+
+	body, nextURL, err := a.client.do(ctx, "GET", "/search/issues", params)
+	if err != nil {
+		return nil, err
+	}
+
+	var sr searchResponse
+	if err := json.Unmarshal(body, &sr); err != nil {
+		return nil, &domain.TrackerError{
+			Kind:    domain.ErrTrackerPayload,
+			Message: "failed to parse search response",
+			Err:     err,
+		}
+	}
+	if sr.IncompleteResults {
+		slog.Warn("github search returned incomplete results",
+			slog.String("label", label))
+	}
+
+	var result []domain.Issue
+	for _, gi := range sr.Items {
+		if isPullRequest(gi) {
+			continue
+		}
+		issue := normalizeIssue(gi, a.activeStates, a.terminalStates)
+		if _, dup := seen[issue.Identifier]; dup {
+			continue
+		}
+		issue.Comments = nil
+		result = append(result, issue)
+		seen[issue.Identifier] = struct{}{}
+	}
+
+	pageCount := 1
+	for nextURL != "" && pageCount < maxPages {
+		pageCount++
+		body, nextURL, err = a.client.doURL(ctx, nextURL)
+		if err != nil {
+			return nil, err
+		}
+
+		var page searchResponse
+		if err := json.Unmarshal(body, &page); err != nil {
+			return nil, &domain.TrackerError{
+				Kind:    domain.ErrTrackerPayload,
+				Message: "failed to parse search response",
+				Err:     err,
+			}
+		}
+		for _, gi := range page.Items {
+			if isPullRequest(gi) {
+				continue
+			}
+			issue := normalizeIssue(gi, a.activeStates, a.terminalStates)
+			if _, dup := seen[issue.Identifier]; dup {
+				continue
+			}
+			issue.Comments = nil
+			result = append(result, issue)
+			seen[issue.Identifier] = struct{}{}
+		}
+	}
+
+	if pageCount >= maxPages {
+		slog.Warn("pagination limit reached", //nolint:gosec // endpoint is an internal API path constant, not user input
+			slog.Int("max_pages", maxPages),
+			slog.String("endpoint", "/search/issues"),
+			slog.String("label", label))
+	}
+
+	return result, nil
+}
+
+// FetchIssueStatesByIDs returns the current state for each requested
+// issue ID. Since ID and Identifier are both the issue number, this
+// delegates to [GitHubAdapter.fetchStatesByNumbers].
+func (a *GitHubAdapter) FetchIssueStatesByIDs(ctx context.Context, issueIDs []string) (map[string]string, error) {
+	result, err := a.fetchStatesByNumbers(ctx, issueIDs)
+	if err != nil {
+		a.incTrackerRequest("fetch_states_by_ids", "error")
+		return nil, err
+	}
+	a.incTrackerRequest("fetch_states_by_ids", "success")
+	return result, nil
+}
+
+// FetchIssueStatesByIdentifiers returns the current state for each
+// requested issue identifier. Since ID and Identifier are both the
+// issue number, this delegates to [GitHubAdapter.fetchStatesByNumbers].
+func (a *GitHubAdapter) FetchIssueStatesByIdentifiers(ctx context.Context, identifiers []string) (map[string]string, error) {
+	result, err := a.fetchStatesByNumbers(ctx, identifiers)
+	if err != nil {
+		a.incTrackerRequest("fetch_states_by_identifiers", "error")
+		return nil, err
+	}
+	a.incTrackerRequest("fetch_states_by_identifiers", "success")
+	return result, nil
+}
+
+func (a *GitHubAdapter) fetchStatesByNumbers(ctx context.Context, numbers []string) (map[string]string, error) {
+	if len(numbers) == 0 {
+		return map[string]string{}, nil
+	}
+
+	result := make(map[string]string, len(numbers))
+	for _, num := range numbers {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+
+		path := "/repos/" + a.owner + "/" + a.repo + "/issues/" + num
+		body, _, err := a.client.do(ctx, "GET", path, nil)
+		if err != nil {
+			if isNotFound(err) {
+				continue
+			}
+			return nil, err
+		}
+
+		var gi githubIssue
+		if err := json.Unmarshal(body, &gi); err != nil {
+			return nil, &domain.TrackerError{
+				Kind:    domain.ErrTrackerPayload,
+				Message: "failed to parse issue response",
+				Err:     err,
+			}
+		}
+		if isPullRequest(gi) {
+			continue
+		}
+		result[num] = extractState(gi.Labels, gi.State, a.activeStates, a.terminalStates)
+	}
+
+	return result, nil
+}
+
+// FetchIssueComments returns comments for the specified issue.
+// Returns an empty non-nil slice when no comments exist.
+func (a *GitHubAdapter) FetchIssueComments(ctx context.Context, issueID string) ([]domain.Comment, error) {
+	comments, err := a.fetchAllComments(ctx, issueID)
+	if err != nil {
+		a.incTrackerRequest("fetch_comments", "error")
+		return nil, err
+	}
+	a.incTrackerRequest("fetch_comments", "success")
+	return comments, nil
+}
+
+func (a *GitHubAdapter) fetchAllComments(ctx context.Context, issueNumber string) ([]domain.Comment, error) {
+	path := "/repos/" + a.owner + "/" + a.repo + "/issues/" + issueNumber + "/comments"
+	params := url.Values{"per_page": {"50"}}
+
+	body, nextURL, err := a.client.do(ctx, "GET", path, params)
+	if err != nil {
+		if isNotFound(err) {
+			return nil, &domain.TrackerError{
+				Kind:    domain.ErrTrackerNotFound,
+				Message: fmt.Sprintf("issue not found: %s", issueNumber),
+			}
+		}
+		return nil, err
+	}
+
+	var allComments []githubComment
+	var page []githubComment
+	if err := json.Unmarshal(body, &page); err != nil {
+		return nil, &domain.TrackerError{
+			Kind:    domain.ErrTrackerPayload,
+			Message: "failed to parse comments response",
+			Err:     err,
+		}
+	}
+	allComments = append(allComments, page...)
+
+	pageCount := 1
+	for nextURL != "" && pageCount < maxPages {
+		pageCount++
+		body, nextURL, err = a.client.doURL(ctx, nextURL)
+		if err != nil {
+			return nil, err
+		}
+
+		page = page[:0]
+		if err := json.Unmarshal(body, &page); err != nil {
+			return nil, &domain.TrackerError{
+				Kind:    domain.ErrTrackerPayload,
+				Message: "failed to parse comments response",
+				Err:     err,
+			}
+		}
+		allComments = append(allComments, page...)
+	}
+
+	if pageCount >= maxPages {
+		slog.Warn("pagination limit reached", //nolint:gosec // endpoint is an internal API path constant, not user input
+			slog.Int("max_pages", maxPages),
+			slog.String("endpoint", path))
+	}
+
+	return normalizeComments(allComments), nil
+}
+
+// TransitionIssue moves an issue to the specified target state by
+// swapping the state label and updating the native open/closed status
+// as needed. Up to three sequential API calls: remove old label, add
+// new label, patch native state. Partial failures converge on retry
+// because individual label operations are idempotent.
+func (a *GitHubAdapter) TransitionIssue(ctx context.Context, issueID string, targetState string) error {
+	targetLower := strings.ToLower(targetState)
+	basePath := "/repos/" + a.owner + "/" + a.repo + "/issues/" + issueID
+
+	// Step 1: Fetch current issue to read labels and native state.
+	body, _, err := a.client.do(ctx, "GET", basePath, nil)
+	if err != nil {
+		a.incTrackerRequest("transition", "error")
+		return err
+	}
+
+	var gi githubIssue
+	if err := json.Unmarshal(body, &gi); err != nil {
+		a.incTrackerRequest("transition", "error")
+		return &domain.TrackerError{
+			Kind:    domain.ErrTrackerPayload,
+			Message: "failed to parse issue response",
+			Err:     err,
+		}
+	}
+
+	currentLabel := findCurrentStateLabel(gi.Labels, a.activeStates, a.terminalStates)
+	currentNative := gi.State
+
+	// Step 2: Remove old state label if present and different.
+	if currentLabel != "" && currentLabel != targetLower {
+		labelPath := basePath + "/labels/" + url.PathEscape(currentLabel)
+		err := a.client.doNoBody(ctx, "DELETE", labelPath)
+		if err != nil && !isNotFound(err) {
+			a.incTrackerRequest("transition", "error")
+			return err
+		}
+	}
+
+	// Step 3: Add target state label if different from current.
+	if currentLabel != targetLower {
+		payload, err := json.Marshal(map[string][]string{"labels": {targetState}})
+		if err != nil {
+			a.incTrackerRequest("transition", "error")
+			return &domain.TrackerError{
+				Kind:    domain.ErrTrackerPayload,
+				Message: "failed to marshal label payload",
+				Err:     err,
+			}
+		}
+		if _, err := a.client.doJSON(ctx, "POST", basePath+"/labels", bytes.NewReader(payload)); err != nil {
+			a.incTrackerRequest("transition", "error")
+			return err
+		}
+	}
+
+	// Step 4: Open/close the issue if the native state needs to change.
+	if isTerminalState(targetLower, a.terminalStates) && currentNative == "open" {
+		payload, err := json.Marshal(map[string]any{"state": "closed", "state_reason": "completed"})
+		if err != nil {
+			a.incTrackerRequest("transition", "error")
+			return &domain.TrackerError{
+				Kind:    domain.ErrTrackerPayload,
+				Message: "failed to marshal state payload",
+				Err:     err,
+			}
+		}
+		if _, err := a.client.doJSON(ctx, "PATCH", basePath, bytes.NewReader(payload)); err != nil {
+			a.incTrackerRequest("transition", "error")
+			return err
+		}
+	} else if isActiveState(targetLower, a.activeStates) && currentNative == "closed" {
+		payload, err := json.Marshal(map[string]any{"state": "open"})
+		if err != nil {
+			a.incTrackerRequest("transition", "error")
+			return &domain.TrackerError{
+				Kind:    domain.ErrTrackerPayload,
+				Message: "failed to marshal state payload",
+				Err:     err,
+			}
+		}
+		if _, err := a.client.doJSON(ctx, "PATCH", basePath, bytes.NewReader(payload)); err != nil {
+			a.incTrackerRequest("transition", "error")
+			return err
+		}
+	}
+
+	a.incTrackerRequest("transition", "success")
+	return nil
+}
+
+// CommentIssue posts a Markdown comment on the specified issue.
+// GitHub natively accepts Markdown, so no format conversion is needed.
+func (a *GitHubAdapter) CommentIssue(ctx context.Context, issueID string, text string) error {
+	path := "/repos/" + a.owner + "/" + a.repo + "/issues/" + issueID + "/comments"
+
+	payload, err := json.Marshal(map[string]string{"body": text})
+	if err != nil {
+		a.incTrackerRequest("comment", "error")
+		return &domain.TrackerError{
+			Kind:    domain.ErrTrackerPayload,
+			Message: "failed to marshal comment payload",
+			Err:     err,
+		}
+	}
+
+	if _, err := a.client.doJSON(ctx, "POST", path, bytes.NewReader(payload)); err != nil {
+		a.incTrackerRequest("comment", "error")
+		return err
+	}
+	a.incTrackerRequest("comment", "success")
+	return nil
+}
+
+// SetMetrics configures the metrics recorder for tracker API call
+// instrumentation. When not called or called with nil, the adapter
+// operates without recording metrics. Safe to call before any
+// adapter operations. Not safe to call concurrently with adapter
+// operations.
+func (a *GitHubAdapter) SetMetrics(m domain.Metrics) {
+	a.metrics = m
+}
+
+func (a *GitHubAdapter) incTrackerRequest(operation, result string) {
+	if a.metrics != nil {
+		a.metrics.IncTrackerRequests(operation, result)
+	}
+}
+
+// isNotFound checks whether an error is a TrackerError with kind
+// ErrTrackerNotFound (HTTP 404).
+func isNotFound(err error) bool {
+	te, ok := err.(*domain.TrackerError)
+	return ok && te.Kind == domain.ErrTrackerNotFound
+}
+
+// extractStringSlice converts a value that may be []any (from JSON
+// unmarshaling) or []string (from typed config) to []string, skipping
+// non-string elements.
+func extractStringSlice(v any) []string {
+	switch s := v.(type) {
+	case []any:
+		result := make([]string, 0, len(s))
+		for _, item := range s {
+			if str, ok := item.(string); ok {
+				result = append(result, str)
+			}
+		}
+		return result
+	case []string:
+		return s
+	default:
+		return nil
+	}
+}

--- a/internal/tracker/github/github_test.go
+++ b/internal/tracker/github/github_test.go
@@ -733,8 +733,40 @@ func TestFetchIssuesByStates_TerminalStatesUsesSearchEndpoint(t *testing.T) {
 	if !strings.Contains(gotQ, "state:closed") {
 		t.Errorf("q = %q, should contain state:closed for terminal", gotQ)
 	}
-	if !strings.Contains(gotQ, "label:done") {
-		t.Errorf("q = %q, should contain label:done", gotQ)
+	if !strings.Contains(gotQ, `label:"done"`) {
+		t.Errorf("q = %q, should contain label:\"done\" (quoted)", gotQ)
+	}
+}
+
+func TestFetchIssuesByStates_TerminalStateMultiWordLabelQuoted(t *testing.T) {
+	t.Parallel()
+
+	// Multi-word terminal state must produce label:"code review" (quoted) in the
+	// search query so GitHub parses it as a single label, not two separate terms.
+	var gotQ string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotQ = r.URL.Query().Get("q")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"total_count":0,"incomplete_results":false,"items":[]}`)) //nolint:errcheck // test helper
+	}))
+	defer srv.Close()
+
+	cfg := validConfig(srv.URL)
+	cfg["terminal_states"] = []any{"code review"}
+	a := mustAdapter(t, cfg)
+
+	_, err := a.FetchIssuesByStates(context.Background(), []string{"code review"})
+	if err != nil {
+		t.Fatalf("FetchIssuesByStates: %v", err)
+	}
+
+	// Quoted form prevents "code" and "review" from being treated as separate tokens.
+	if !strings.Contains(gotQ, `label:"code review"`) {
+		t.Errorf("q = %q, should contain label:\"code review\" (quoted for multi-word label)", gotQ)
+	}
+	// Unquoted form must not appear.
+	if strings.Contains(gotQ, "label:code review") {
+		t.Errorf("q = %q, must not contain unquoted label:code review", gotQ)
 	}
 }
 

--- a/internal/tracker/github/github_test.go
+++ b/internal/tracker/github/github_test.go
@@ -1352,6 +1352,411 @@ func TestSetMetrics_NilMetricsDoesNotPanic(t *testing.T) {
 	}
 }
 
+// --- FetchCandidateIssues (search path) ---
+
+func TestFetchCandidateIssues_SearchPagination(t *testing.T) {
+	t.Parallel()
+
+	// Two-page search result. query_filter non-empty routes through fetchCandidatesViaSearch.
+	page1 := `{"total_count":2,"incomplete_results":false,"items":[{"id":10,"number":10,"title":"T10","body":null,"state":"open","html_url":"u","labels":[{"name":"review"}],"assignees":[],"type":null,"pull_request":null,"created_at":"2026-01-01T00:00:00Z","updated_at":"2026-01-01T00:00:00Z"}]}`
+	page2 := `{"total_count":2,"incomplete_results":false,"items":[{"id":20,"number":20,"title":"T20","body":null,"state":"open","html_url":"u","labels":[{"name":"backlog"}],"assignees":[],"type":null,"pull_request":null,"created_at":"2026-01-01T00:00:00Z","updated_at":"2026-01-01T00:00:00Z"}]}`
+
+	var srvURL string
+	var callCount int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&callCount, 1)
+		if n == 1 {
+			w.Header().Set("Link", fmt.Sprintf(`<%s/search/issues?q=...&page=2>; rel="next"`, srvURL))
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(page1)) //nolint:errcheck // test helper
+		} else {
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(page2)) //nolint:errcheck // test helper
+		}
+	}))
+	defer srv.Close()
+	srvURL = srv.URL
+
+	cfg := validConfig(srv.URL)
+	cfg["query_filter"] = "label:important"
+	a := mustAdapter(t, cfg)
+	issues, err := a.FetchCandidateIssues(context.Background())
+	if err != nil {
+		t.Fatalf("FetchCandidateIssues search pagination: %v", err)
+	}
+	if len(issues) != 2 {
+		t.Errorf("len = %d, want 2 (one from each search page)", len(issues))
+	}
+}
+
+func TestFetchCandidateIssues_SearchIncompleteResults(t *testing.T) {
+	t.Parallel()
+
+	// incomplete_results=true should log a warning but not return an error.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"total_count":100,"incomplete_results":true,"items":[{"id":1,"number":1,"title":"T","body":null,"state":"open","html_url":"u","labels":[{"name":"review"}],"assignees":[],"type":null,"pull_request":null,"created_at":"2026-01-01T00:00:00Z","updated_at":"2026-01-01T00:00:00Z"}]}`)) //nolint:errcheck // test helper
+	}))
+	defer srv.Close()
+
+	cfg := validConfig(srv.URL)
+	cfg["query_filter"] = "type:bug"
+	a := mustAdapter(t, cfg)
+	issues, err := a.FetchCandidateIssues(context.Background())
+	if err != nil {
+		t.Fatalf("FetchCandidateIssues incomplete results: unexpected error: %v", err)
+	}
+	if len(issues) != 1 {
+		t.Errorf("len = %d, want 1", len(issues))
+	}
+}
+
+func TestFetchCandidateIssues_SearchAPIError(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	cfg := validConfig(srv.URL)
+	cfg["query_filter"] = "label:critical"
+	a := mustAdapter(t, cfg)
+	_, err := a.FetchCandidateIssues(context.Background())
+	assertTrackerErrorKind(t, err, domain.ErrTrackerTransport)
+}
+
+// --- FetchIssueByID additional error paths ---
+
+func TestFetchIssueByID_NonNotFoundError(t *testing.T) {
+	t.Parallel()
+
+	// 500 on the issue fetch should return ErrTrackerTransport (not ErrTrackerNotFound).
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	a := mustAdapter(t, validConfig(srv.URL))
+	_, err := a.FetchIssueByID(context.Background(), "42")
+	assertTrackerErrorKind(t, err, domain.ErrTrackerTransport)
+}
+
+func TestFetchIssueByID_BlockerAPIError(t *testing.T) {
+	t.Parallel()
+
+	// blockers endpoint returns 500 (not 404) → error propagated.
+	issueFix := loadFixture(t, "issue.json")
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/owner/repo/issues/42/dependencies/blocked_by", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+	mux.HandleFunc("/repos/owner/repo/issues/42", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write(issueFix) //nolint:errcheck // test helper
+	})
+
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	a := mustAdapter(t, validConfig(srv.URL))
+	_, err := a.FetchIssueByID(context.Background(), "42")
+	assertTrackerErrorKind(t, err, domain.ErrTrackerTransport)
+}
+
+func TestFetchIssueByID_ParentAPIError(t *testing.T) {
+	t.Parallel()
+
+	// parent endpoint returns 500 (not 404) → error propagated.
+	issueFix := loadFixture(t, "issue.json")
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/owner/repo/issues/42/dependencies/blocked_by", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("[]")) //nolint:errcheck // test helper
+	})
+	mux.HandleFunc("/repos/owner/repo/issues/42/parent", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+	mux.HandleFunc("/repos/owner/repo/issues/42", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write(issueFix) //nolint:errcheck // test helper
+	})
+
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	a := mustAdapter(t, validConfig(srv.URL))
+	_, err := a.FetchIssueByID(context.Background(), "42")
+	assertTrackerErrorKind(t, err, domain.ErrTrackerTransport)
+}
+
+// --- FetchIssuesByStates additional paths ---
+
+func TestFetchIssuesByStates_OpenPagination(t *testing.T) {
+	t.Parallel()
+
+	// Server returns page1 (issues.json) with a Link header; second call returns page2 (issues_page2.json).
+	page1 := loadFixture(t, "issues.json")
+	page2 := loadFixture(t, "issues_page2.json")
+
+	var srvURL string
+	var callCount int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&callCount, 1)
+		if n == 1 {
+			w.Header().Set("Link", fmt.Sprintf(`<%s/repos/owner/repo/issues?state=open&page=2>; rel="next"`, srvURL))
+			w.WriteHeader(http.StatusOK)
+			w.Write(page1) //nolint:errcheck // test helper
+		} else {
+			w.WriteHeader(http.StatusOK)
+			w.Write(page2) //nolint:errcheck // test helper
+		}
+	}))
+	defer srv.Close()
+	srvURL = srv.URL
+
+	a := mustAdapter(t, validConfig(srv.URL))
+	// Request only active states; none are terminal so uses fetchOpenIssuesByStates.
+	issues, err := a.FetchIssuesByStates(context.Background(), []string{"backlog", "in-progress", "review"})
+	if err != nil {
+		t.Fatalf("FetchIssuesByStates open pagination: %v", err)
+	}
+	// issues.json: #1 backlog + #3 in-progress (2 non-PR active issues, #4 done is filtered out).
+	// issues_page2.json: #5 review (1 issue).
+	if len(issues) != 3 {
+		t.Errorf("len = %d, want 3 across 2 pages", len(issues))
+	}
+}
+
+func TestFetchIssuesByStates_ClosedSearchPagination(t *testing.T) {
+	t.Parallel()
+
+	page1 := `{"total_count":2,"incomplete_results":false,"items":[{"id":100,"number":100,"title":"D1","body":null,"state":"closed","html_url":"u","labels":[{"name":"done"}],"assignees":[],"type":null,"pull_request":null,"created_at":"2026-01-01T00:00:00Z","updated_at":"2026-01-01T00:00:00Z"}]}`
+	page2 := `{"total_count":2,"incomplete_results":false,"items":[{"id":200,"number":200,"title":"D2","body":null,"state":"closed","html_url":"u","labels":[{"name":"done"}],"assignees":[],"type":null,"pull_request":null,"created_at":"2026-01-01T00:00:00Z","updated_at":"2026-01-01T00:00:00Z"}]}`
+
+	var srvURL string
+	var callCount int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&callCount, 1)
+		if n == 1 {
+			w.Header().Set("Link", fmt.Sprintf(`<%s/search/issues?q=...&page=2>; rel="next"`, srvURL))
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(page1)) //nolint:errcheck // test helper
+		} else {
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(page2)) //nolint:errcheck // test helper
+		}
+	}))
+	defer srv.Close()
+	srvURL = srv.URL
+
+	a := mustAdapter(t, validConfig(srv.URL))
+	issues, err := a.FetchIssuesByStates(context.Background(), []string{"done"})
+	if err != nil {
+		t.Fatalf("FetchIssuesByStates closed search pagination: %v", err)
+	}
+	if len(issues) != 2 {
+		t.Errorf("len = %d, want 2 across 2 search pages", len(issues))
+	}
+}
+
+func TestFetchIssuesByStates_ClosedSearchIncompleteResults(t *testing.T) {
+	t.Parallel()
+
+	// incomplete_results=true for closed search: should log warning, not error.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"total_count":999,"incomplete_results":true,"items":[{"id":50,"number":50,"title":"Partial","body":null,"state":"closed","html_url":"u","labels":[{"name":"done"}],"assignees":[],"type":null,"pull_request":null,"created_at":"2026-01-01T00:00:00Z","updated_at":"2026-01-01T00:00:00Z"}]}`)) //nolint:errcheck // test helper
+	}))
+	defer srv.Close()
+
+	a := mustAdapter(t, validConfig(srv.URL))
+	issues, err := a.FetchIssuesByStates(context.Background(), []string{"done"})
+	if err != nil {
+		t.Fatalf("FetchIssuesByStates closed incomplete: unexpected error: %v", err)
+	}
+	if len(issues) != 1 {
+		t.Errorf("len = %d, want 1", len(issues))
+	}
+}
+
+func TestFetchIssuesByStates_ActiveStatesError(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	a := mustAdapter(t, validConfig(srv.URL))
+	_, err := a.FetchIssuesByStates(context.Background(), []string{"backlog"})
+	assertTrackerErrorKind(t, err, domain.ErrTrackerTransport)
+}
+
+func TestFetchIssuesByStates_TerminalStateError(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	a := mustAdapter(t, validConfig(srv.URL))
+	_, err := a.FetchIssuesByStates(context.Background(), []string{"done"})
+	assertTrackerErrorKind(t, err, domain.ErrTrackerTransport)
+}
+
+func TestFetchIssuesByStates_ContextCancelledDuringTerminal(t *testing.T) {
+	t.Parallel()
+
+	// Two terminal states: first search succeeds, context is cancelled before
+	// the second search, exercising the ctx.Err() guard between iterations.
+	started := make(chan struct{}, 1)
+	var callCount int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&callCount, 1)
+		if n == 1 {
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"total_count":0,"incomplete_results":false,"items":[]}`)) //nolint:errcheck // test helper
+			started <- struct{}{}
+			return
+		}
+		// Second search: block until context is cancelled.
+		<-r.Context().Done()
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	a := mustAdapter(t, validConfig(srv.URL))
+	errCh := make(chan error, 1)
+	go func() {
+		// defaultTerminalStates = ["done", "wontfix"]; both are terminal so both
+		// iterate through the ctx.Err() guarded loop in FetchIssuesByStates.
+		_, err := a.FetchIssuesByStates(ctx, []string{"done", "wontfix"})
+		errCh <- err
+	}()
+
+	<-started
+	cancel()
+
+	err := <-errCh
+	if err == nil {
+		t.Fatal("expected error after context cancel, got nil")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("error = %v, want context.Canceled", err)
+	}
+}
+
+// --- FetchIssueStatesByIDs additional paths ---
+
+func TestFetchIssueStatesByIDs_SkipsPullRequest(t *testing.T) {
+	t.Parallel()
+
+	// API returns a PR for the requested identifier → it must be omitted from the result map.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		// pull_request:{} marks this as a PR.
+		w.Write([]byte(`{"id":1,"number":1,"title":"PR","body":null,"state":"open","html_url":"u","labels":[],"assignees":[],"type":null,"pull_request":{},"created_at":"2026-01-01T00:00:00Z","updated_at":"2026-01-01T00:00:00Z"}`)) //nolint:errcheck // test helper
+	}))
+	defer srv.Close()
+
+	a := mustAdapter(t, validConfig(srv.URL))
+	result, err := a.FetchIssueStatesByIDs(context.Background(), []string{"1"})
+	if err != nil {
+		t.Fatalf("FetchIssueStatesByIDs: %v", err)
+	}
+	if _, ok := result["1"]; ok {
+		t.Error("pull request should be omitted from the result map")
+	}
+}
+
+func TestFetchIssueStatesByIdentifiers_Error(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	a := mustAdapter(t, validConfig(srv.URL))
+	_, err := a.FetchIssueStatesByIdentifiers(context.Background(), []string{"5"})
+	assertTrackerErrorKind(t, err, domain.ErrTrackerAuth)
+}
+
+// --- FetchIssueComments additional paths ---
+
+func TestFetchIssueComments_NonNotFoundError(t *testing.T) {
+	t.Parallel()
+
+	// 500 from comments endpoint → ErrTrackerTransport (not wrapped as NotFound).
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	a := mustAdapter(t, validConfig(srv.URL))
+	_, err := a.FetchIssueComments(context.Background(), "42")
+	assertTrackerErrorKind(t, err, domain.ErrTrackerTransport)
+}
+
+// --- TransitionIssue additional paths ---
+
+func TestTransitionIssue_GetIssueError(t *testing.T) {
+	t.Parallel()
+
+	// Step 1 (GET issue) returns 500 → error propagated; not a NotFound.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	a := mustAdapter(t, validConfig(srv.URL))
+	err := a.TransitionIssue(context.Background(), "42", "review")
+	assertTrackerErrorKind(t, err, domain.ErrTrackerTransport)
+}
+
+func TestTransitionIssue_DeleteLabelIsNotFound(t *testing.T) {
+	t.Parallel()
+
+	// DELETE existing label returns 404 (already removed) → treated as no-op; POST still executes.
+	var postCount int32
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/owner/repo/issues/1", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPatch {
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(issueJSON(1, "review", "open"))) //nolint:errcheck // test helper
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(issueJSON(1, "backlog", "open"))) //nolint:errcheck // test helper
+	})
+	mux.HandleFunc("/repos/owner/repo/issues/1/labels/backlog", func(w http.ResponseWriter, r *http.Request) {
+		// Label was already removed on a prior attempt.
+		w.WriteHeader(http.StatusNotFound)
+	})
+	mux.HandleFunc("/repos/owner/repo/issues/1/labels", func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&postCount, 1)
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("[]")) //nolint:errcheck // test helper
+	})
+
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	a := mustAdapter(t, validConfig(srv.URL))
+	if err := a.TransitionIssue(context.Background(), "1", "review"); err != nil {
+		t.Fatalf("TransitionIssue 404-on-delete: %v", err)
+	}
+	if got := atomic.LoadInt32(&postCount); got != 1 {
+		t.Errorf("POST count = %d, want 1 (add-label must still execute)", got)
+	}
+}
+
 // --- extractStringSlice ---
 
 func TestExtractStringSlice(t *testing.T) {

--- a/internal/tracker/github/github_test.go
+++ b/internal/tracker/github/github_test.go
@@ -231,6 +231,34 @@ func TestNewGitHubAdapter_EndpointTrailingSlashStripped(t *testing.T) {
 	}
 }
 
+func TestNewGitHubAdapter_DoesNotMutateConfigSlices(t *testing.T) {
+	t.Parallel()
+
+	// NewGitHubAdapter lowercases state values internally; it must not write
+	// those lowercased values back into the caller-supplied slices.
+	cfg := validConfig("https://api.github.com")
+	cfg["active_states"] = []string{"InProgress", "Review"}
+	cfg["terminal_states"] = []string{"Done", "WontFix"}
+
+	mustAdapter(t, cfg)
+
+	active := cfg["active_states"].([]string)
+	if active[0] != "InProgress" {
+		t.Errorf("active_states[0] = %q after construction, want original %q", active[0], "InProgress")
+	}
+	if active[1] != "Review" {
+		t.Errorf("active_states[1] = %q after construction, want original %q", active[1], "Review")
+	}
+
+	terminal := cfg["terminal_states"].([]string)
+	if terminal[0] != "Done" {
+		t.Errorf("terminal_states[0] = %q after construction, want original %q", terminal[0], "Done")
+	}
+	if terminal[1] != "WontFix" {
+		t.Errorf("terminal_states[1] = %q after construction, want original %q", terminal[1], "WontFix")
+	}
+}
+
 // --- FetchCandidateIssues ---
 
 func TestFetchCandidateIssues_FiltersPullRequests(t *testing.T) {

--- a/internal/tracker/github/github_test.go
+++ b/internal/tracker/github/github_test.go
@@ -1160,6 +1160,15 @@ func TestTransitionIssue_PartialFailure_AddLabel(t *testing.T) {
 	}
 }
 
+func TestTransitionIssue_InvalidTargetState(t *testing.T) {
+	t.Parallel()
+
+	// "unknown" is not in the default active or terminal state lists.
+	a := mustAdapter(t, validConfig("http://localhost"))
+	err := a.TransitionIssue(context.Background(), "1", "unknown")
+	assertTrackerErrorKind(t, err, domain.ErrTrackerPayload)
+}
+
 func TestTransitionIssue_PartialFailure_Close(t *testing.T) {
 	t.Parallel()
 

--- a/internal/tracker/github/github_test.go
+++ b/internal/tracker/github/github_test.go
@@ -1,0 +1,1348 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/sortie-ai/sortie/internal/domain"
+)
+
+// --- helpers ---
+
+func validConfig(endpoint string) map[string]any {
+	return map[string]any{
+		"endpoint": endpoint,
+		"api_key":  "test-token",
+		"project":  "owner/repo",
+	}
+}
+
+func mustAdapter(t *testing.T, config map[string]any) *GitHubAdapter {
+	t.Helper()
+	a, err := NewGitHubAdapter(config)
+	if err != nil {
+		t.Fatalf("NewGitHubAdapter: %v", err)
+	}
+	return a.(*GitHubAdapter)
+}
+
+func assertTrackerErrorKind(t *testing.T, err error, want domain.TrackerErrorKind) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("expected error with kind %q, got nil", want)
+	}
+	var te *domain.TrackerError
+	if !errors.As(err, &te) {
+		t.Fatalf("error type = %T, want *domain.TrackerError", err)
+	}
+	if te.Kind != want {
+		t.Errorf("TrackerError.Kind = %q, want %q", te.Kind, want)
+	}
+}
+
+func loadFixture(t *testing.T, name string) []byte {
+	t.Helper()
+	data, err := os.ReadFile("testdata/" + name)
+	if err != nil {
+		t.Fatalf("reading fixture %s: %v", name, err)
+	}
+	return data
+}
+
+// issueJSON returns a minimal valid GitHub issue JSON with the given number
+// and state label. Used in server handlers that need simple inline responses.
+func issueJSON(number int, stateLabel string, nativeState string) string {
+	return fmt.Sprintf(`{"id":%d,"number":%d,"title":"Issue %d","body":null,"state":%q,"html_url":"https://github.com/owner/repo/issues/%d","labels":[{"name":%q}],"assignees":[],"type":null,"pull_request":null,"created_at":"2026-01-01T00:00:00Z","updated_at":"2026-01-01T00:00:00Z"}`,
+		number*100, number, number, nativeState, number, stateLabel)
+}
+
+// spyMetrics records IncTrackerRequests calls for assertions.
+type spyMetrics struct {
+	domain.NoopMetrics
+	calls []string
+}
+
+func (s *spyMetrics) IncTrackerRequests(operation, result string) {
+	s.calls = append(s.calls, operation+":"+result)
+}
+
+// --- Constructor tests ---
+
+func TestNewGitHubAdapter(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		config   map[string]any
+		wantErr  bool
+		wantKind domain.TrackerErrorKind
+	}{
+		{
+			name:   "valid config",
+			config: validConfig("https://api.github.com"),
+		},
+		{
+			name:     "missing api_key",
+			config:   map[string]any{"project": "owner/repo"},
+			wantErr:  true,
+			wantKind: domain.ErrMissingTrackerAPIKey,
+		},
+		{
+			name:     "empty api_key",
+			config:   map[string]any{"api_key": "", "project": "owner/repo"},
+			wantErr:  true,
+			wantKind: domain.ErrMissingTrackerAPIKey,
+		},
+		{
+			name:     "missing project",
+			config:   map[string]any{"api_key": "tok"},
+			wantErr:  true,
+			wantKind: domain.ErrMissingTrackerProject,
+		},
+		{
+			name:     "empty project",
+			config:   map[string]any{"api_key": "tok", "project": ""},
+			wantErr:  true,
+			wantKind: domain.ErrMissingTrackerProject,
+		},
+		{
+			name:     "project with no slash",
+			config:   map[string]any{"api_key": "tok", "project": "ownerrepo"},
+			wantErr:  true,
+			wantKind: domain.ErrTrackerPayload,
+		},
+		{
+			name:     "project with two slashes",
+			config:   map[string]any{"api_key": "tok", "project": "owner/repo/extra"},
+			wantErr:  true,
+			wantKind: domain.ErrTrackerPayload,
+		},
+		{
+			name:     "project with empty owner",
+			config:   map[string]any{"api_key": "tok", "project": "/repo"},
+			wantErr:  true,
+			wantKind: domain.ErrTrackerPayload,
+		},
+		{
+			name:     "project with empty repo",
+			config:   map[string]any{"api_key": "tok", "project": "owner/"},
+			wantErr:  true,
+			wantKind: domain.ErrTrackerPayload,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			a, err := NewGitHubAdapter(tt.config)
+			if tt.wantErr {
+				assertTrackerErrorKind(t, err, tt.wantKind)
+				if a != nil {
+					t.Error("adapter should be nil on error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if a == nil {
+				t.Fatal("adapter is nil")
+			}
+		})
+	}
+}
+
+func TestNewGitHubAdapter_Defaults(t *testing.T) {
+	t.Parallel()
+
+	a := mustAdapter(t, validConfig("https://api.github.com"))
+
+	// Default active states: lowercased.
+	if len(a.activeStates) != 3 {
+		t.Fatalf("activeStates len = %d, want 3", len(a.activeStates))
+	}
+	if a.activeStates[0] != "backlog" {
+		t.Errorf("activeStates[0] = %q, want %q", a.activeStates[0], "backlog")
+	}
+
+	// Default terminal states.
+	if len(a.terminalStates) != 2 {
+		t.Fatalf("terminalStates len = %d, want 2", len(a.terminalStates))
+	}
+	if a.terminalStates[0] != "done" {
+		t.Errorf("terminalStates[0] = %q, want %q", a.terminalStates[0], "done")
+	}
+
+	// Default query filter is empty.
+	if a.queryFilter != "" {
+		t.Errorf("queryFilter = %q, want empty", a.queryFilter)
+	}
+
+	// Owner and repo split correctly.
+	if a.owner != "owner" {
+		t.Errorf("owner = %q, want %q", a.owner, "owner")
+	}
+	if a.repo != "repo" {
+		t.Errorf("repo = %q, want %q", a.repo, "repo")
+	}
+}
+
+func TestNewGitHubAdapter_CustomStatesLowercased(t *testing.T) {
+	t.Parallel()
+
+	cfg := validConfig("https://api.github.com")
+	cfg["active_states"] = []any{"Todo", "IN-PROGRESS"}
+	cfg["terminal_states"] = []string{"Done", "WONTFIX"}
+	a := mustAdapter(t, cfg)
+
+	if a.activeStates[0] != "todo" {
+		t.Errorf("activeStates[0] = %q, want %q", a.activeStates[0], "todo")
+	}
+	if a.activeStates[1] != "in-progress" {
+		t.Errorf("activeStates[1] = %q, want %q", a.activeStates[1], "in-progress")
+	}
+	if a.terminalStates[0] != "done" {
+		t.Errorf("terminalStates[0] = %q, want %q", a.terminalStates[0], "done")
+	}
+	if a.terminalStates[1] != "wontfix" {
+		t.Errorf("terminalStates[1] = %q, want %q", a.terminalStates[1], "wontfix")
+	}
+}
+
+func TestNewGitHubAdapter_EndpointTrailingSlashStripped(t *testing.T) {
+	t.Parallel()
+
+	cfg := validConfig("https://api.github.com/")
+	a := mustAdapter(t, cfg)
+
+	if strings.HasSuffix(a.client.baseURL, "/") {
+		t.Errorf("client.baseURL = %q, should not have trailing slash", a.client.baseURL)
+	}
+}
+
+// --- FetchCandidateIssues ---
+
+func TestFetchCandidateIssues_FiltersPullRequests(t *testing.T) {
+	t.Parallel()
+
+	// issues.json contains: backlog issue (#1), PR (#2, filtered), in-progress (#3), done (#4, non-active).
+	fixture := loadFixture(t, "issues.json")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write(fixture) //nolint:errcheck // test helper
+	}))
+	defer srv.Close()
+
+	a := mustAdapter(t, validConfig(srv.URL))
+	issues, err := a.FetchCandidateIssues(context.Background())
+	if err != nil {
+		t.Fatalf("FetchCandidateIssues: %v", err)
+	}
+
+	// Issues 1 (backlog) and 3 (in-progress) pass. PR #2 filtered. #4 (done=terminal) filtered.
+	if len(issues) != 2 {
+		t.Fatalf("len = %d, want 2 (PR and non-active filtered)", len(issues))
+	}
+	ids := make(map[string]bool)
+	for _, iss := range issues {
+		ids[iss.Identifier] = true
+	}
+	if ids["2"] {
+		t.Error("PR #2 should be filtered out")
+	}
+	if ids["4"] {
+		t.Error("issue #4 (done state) should be filtered out (non-active)")
+	}
+}
+
+func TestFetchCandidateIssues_CommentsNil(t *testing.T) {
+	t.Parallel()
+
+	fixture := loadFixture(t, "issues.json")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write(fixture) //nolint:errcheck // test helper
+	}))
+	defer srv.Close()
+
+	a := mustAdapter(t, validConfig(srv.URL))
+	issues, err := a.FetchCandidateIssues(context.Background())
+	if err != nil {
+		t.Fatalf("FetchCandidateIssues: %v", err)
+	}
+
+	for _, iss := range issues {
+		if iss.Comments != nil {
+			t.Errorf("issue %s: Comments should be nil in candidate list", iss.Identifier)
+		}
+		if iss.BlockedBy == nil {
+			t.Errorf("issue %s: BlockedBy should be non-nil empty slice", iss.Identifier)
+		}
+		if iss.Labels == nil {
+			t.Errorf("issue %s: Labels should be non-nil", iss.Identifier)
+		}
+	}
+}
+
+func TestFetchCandidateIssues_NonNilEmptySlice(t *testing.T) {
+	t.Parallel()
+
+	// Empty response → non-nil empty slice, not nil.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("[]")) //nolint:errcheck // test helper
+	}))
+	defer srv.Close()
+
+	a := mustAdapter(t, validConfig(srv.URL))
+	issues, err := a.FetchCandidateIssues(context.Background())
+	if err != nil {
+		t.Fatalf("FetchCandidateIssues: %v", err)
+	}
+	if issues == nil {
+		t.Fatal("issues is nil, want non-nil empty slice")
+	}
+	if len(issues) != 0 {
+		t.Errorf("len = %d, want 0", len(issues))
+	}
+}
+
+func TestFetchCandidateIssues_Pagination(t *testing.T) {
+	t.Parallel()
+
+	page1 := loadFixture(t, "issues.json")       // issues 1, 3 active
+	page2 := loadFixture(t, "issues_page2.json") // issue 5 (review)
+
+	var srvURL string
+	var callCount int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&callCount, 1)
+		if n == 1 {
+			// First page: set Link header pointing to page 2.
+			w.Header().Set("Link", fmt.Sprintf(`<%s/repos/owner/repo/issues?page=2>; rel="next"`, srvURL))
+			w.WriteHeader(http.StatusOK)
+			w.Write(page1) //nolint:errcheck // test helper
+		} else {
+			w.WriteHeader(http.StatusOK)
+			w.Write(page2) //nolint:errcheck // test helper
+		}
+	}))
+	defer srv.Close()
+	srvURL = srv.URL
+
+	a := mustAdapter(t, validConfig(srv.URL))
+	issues, err := a.FetchCandidateIssues(context.Background())
+	if err != nil {
+		t.Fatalf("FetchCandidateIssues: %v", err)
+	}
+
+	// page1 has 2 active issues; page2 has 1 active issue.
+	if len(issues) != 3 {
+		t.Fatalf("len = %d, want 3 across 2 pages", len(issues))
+	}
+	if got := atomic.LoadInt32(&callCount); got != 2 {
+		t.Errorf("call count = %d, want 2", got)
+	}
+}
+
+func TestFetchCandidateIssues_MaxPagesGuard(t *testing.T) {
+	t.Parallel()
+
+	// Server always returns a Link header, forcing the guard to trigger.
+	var callCount int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&callCount, 1)
+		nextURL := fmt.Sprintf("http://%s/repos/owner/repo/issues?p=%d", r.Host, n+1)
+		w.Header().Set("Link", fmt.Sprintf(`<%s>; rel="next"`, nextURL))
+		w.WriteHeader(http.StatusOK)
+		// Return one active issue per page.
+		w.Write([]byte(`[{"id":` + fmt.Sprint(n) + `,"number":` + fmt.Sprint(n) + `,"title":"T","body":null,"state":"open","html_url":"u","labels":[{"name":"backlog"}],"assignees":[],"type":null,"pull_request":null,"created_at":"2026-01-01T00:00:00Z","updated_at":"2026-01-01T00:00:00Z"}]`)) //nolint:errcheck // test helper
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	a := mustAdapter(t, validConfig(srv.URL))
+	issues, err := a.FetchCandidateIssues(ctx)
+	if err != nil {
+		t.Fatalf("FetchCandidateIssues: %v", err)
+	}
+
+	got := int(atomic.LoadInt32(&callCount))
+	if got > maxPages {
+		t.Errorf("call count = %d, exceeded maxPages = %d", got, maxPages)
+	}
+	if len(issues) == 0 {
+		t.Error("issues should not be empty")
+	}
+}
+
+func TestFetchCandidateIssues_SearchEndpoint(t *testing.T) {
+	t.Parallel()
+
+	fixture := loadFixture(t, "search.json")
+	var gotPath string
+	var gotQ string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotQ = r.URL.Query().Get("q")
+		w.WriteHeader(http.StatusOK)
+		w.Write(fixture) //nolint:errcheck // test helper
+	}))
+	defer srv.Close()
+
+	cfg := validConfig(srv.URL)
+	cfg["query_filter"] = "label:critical"
+	a := mustAdapter(t, cfg)
+	issues, err := a.FetchCandidateIssues(context.Background())
+	if err != nil {
+		t.Fatalf("FetchCandidateIssues: %v", err)
+	}
+
+	if gotPath != "/search/issues" {
+		t.Errorf("path = %q, want /search/issues", gotPath)
+	}
+	if !strings.Contains(gotQ, "repo:owner/repo") {
+		t.Errorf("q = %q, should contain repo qualifier", gotQ)
+	}
+	if !strings.Contains(gotQ, "type:issue") {
+		t.Errorf("q = %q, should contain type:issue", gotQ)
+	}
+	if !strings.Contains(gotQ, "label:critical") {
+		t.Errorf("q = %q, should contain queryFilter", gotQ)
+	}
+
+	// search.json has one "review" state issue.
+	if len(issues) != 1 {
+		t.Fatalf("len = %d, want 1", len(issues))
+	}
+	if issues[0].State != "review" {
+		t.Errorf("issues[0].State = %q, want %q", issues[0].State, "review")
+	}
+}
+
+func TestFetchCandidateIssues_AuthError(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	a := mustAdapter(t, validConfig(srv.URL))
+	_, err := a.FetchCandidateIssues(context.Background())
+	assertTrackerErrorKind(t, err, domain.ErrTrackerAuth)
+}
+
+// --- FetchIssueByID ---
+
+func TestFetchIssueByID_FullPopulation(t *testing.T) {
+	t.Parallel()
+
+	issueFix := loadFixture(t, "issue.json")
+	blockersFix := loadFixture(t, "blockers.json")
+	parentFix := loadFixture(t, "parent.json")
+	commentsFix := loadFixture(t, "comments.json")
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/owner/repo/issues/42/dependencies/blocked_by", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write(blockersFix) //nolint:errcheck // test helper
+	})
+	mux.HandleFunc("/repos/owner/repo/issues/42/parent", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write(parentFix) //nolint:errcheck // test helper
+	})
+	mux.HandleFunc("/repos/owner/repo/issues/42/comments", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write(commentsFix) //nolint:errcheck // test helper
+	})
+	mux.HandleFunc("/repos/owner/repo/issues/42", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write(issueFix) //nolint:errcheck // test helper
+	})
+
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	a := mustAdapter(t, validConfig(srv.URL))
+	issue, err := a.FetchIssueByID(context.Background(), "42")
+	if err != nil {
+		t.Fatalf("FetchIssueByID: %v", err)
+	}
+
+	// issue.json: number=42, title="Add dark mode support", in-progress label.
+	if issue.ID != "42" || issue.Identifier != "42" {
+		t.Errorf("ID/Identifier = %q/%q, want 42/42", issue.ID, issue.Identifier)
+	}
+	if issue.Title != "Add dark mode support" {
+		t.Errorf("Title = %q", issue.Title)
+	}
+	if issue.State != "in-progress" {
+		t.Errorf("State = %q, want in-progress", issue.State)
+	}
+	if issue.Description != "Users want a **dark mode** option." {
+		t.Errorf("Description = %q", issue.Description)
+	}
+	if issue.IssueType != "Feature" {
+		t.Errorf("IssueType = %q, want Feature", issue.IssueType)
+	}
+	if issue.Assignee != "alice" {
+		t.Errorf("Assignee = %q, want alice", issue.Assignee)
+	}
+
+	// Blockers from blockers.json: one blocker (#5).
+	if len(issue.BlockedBy) != 1 {
+		t.Fatalf("BlockedBy len = %d, want 1", len(issue.BlockedBy))
+	}
+	if issue.BlockedBy[0].Identifier != "5" {
+		t.Errorf("BlockedBy[0].Identifier = %q, want 5", issue.BlockedBy[0].Identifier)
+	}
+
+	// Parent from parent.json: #7.
+	if issue.Parent == nil {
+		t.Fatal("Parent is nil, want non-nil")
+	}
+	if issue.Parent.Identifier != "7" {
+		t.Errorf("Parent.Identifier = %q, want 7", issue.Parent.Identifier)
+	}
+
+	// Comments from comments.json: two comments.
+	if len(issue.Comments) != 2 {
+		t.Fatalf("Comments len = %d, want 2", len(issue.Comments))
+	}
+	if issue.Comments[0].Author != "alice" {
+		t.Errorf("Comments[0].Author = %q", issue.Comments[0].Author)
+	}
+	if issue.Comments[0].Body != "Looks good, please proceed." {
+		t.Errorf("Comments[0].Body = %q", issue.Comments[0].Body)
+	}
+}
+
+func TestFetchIssueByID_NotFound(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	a := mustAdapter(t, validConfig(srv.URL))
+	_, err := a.FetchIssueByID(context.Background(), "99")
+	assertTrackerErrorKind(t, err, domain.ErrTrackerNotFound)
+
+	var te *domain.TrackerError
+	if errors.As(err, &te) {
+		if !strings.Contains(te.Message, "99") {
+			t.Errorf("TrackerError.Message = %q, should contain issue ID 99", te.Message)
+		}
+	}
+}
+
+func TestFetchIssueByID_PRReturnsNotFound(t *testing.T) {
+	t.Parallel()
+
+	// Response is a GitHub "issue" that has a pull_request field set.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"id":1,"number":1,"title":"PR","body":null,"state":"open","html_url":"u","labels":[],"assignees":[],"pull_request":{},"created_at":"2026-01-01T00:00:00Z","updated_at":"2026-01-01T00:00:00Z"}`)) //nolint:errcheck // test helper
+	}))
+	defer srv.Close()
+
+	a := mustAdapter(t, validConfig(srv.URL))
+	_, err := a.FetchIssueByID(context.Background(), "1")
+	assertTrackerErrorKind(t, err, domain.ErrTrackerNotFound)
+}
+
+func TestFetchIssueByID_BlockerNotFound_Degrades(t *testing.T) {
+	t.Parallel()
+
+	// blockers endpoint returns 404 → BlockedBy should be empty non-nil slice.
+	issueFix := loadFixture(t, "issue.json")
+	commentsFix := loadFixture(t, "comments.json")
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/owner/repo/issues/42/dependencies/blocked_by", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	})
+	mux.HandleFunc("/repos/owner/repo/issues/42/parent", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	})
+	mux.HandleFunc("/repos/owner/repo/issues/42/comments", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write(commentsFix) //nolint:errcheck // test helper
+	})
+	mux.HandleFunc("/repos/owner/repo/issues/42", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write(issueFix) //nolint:errcheck // test helper
+	})
+
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	a := mustAdapter(t, validConfig(srv.URL))
+	issue, err := a.FetchIssueByID(context.Background(), "42")
+	if err != nil {
+		t.Fatalf("FetchIssueByID: %v", err)
+	}
+
+	// 404 on blockers → empty non-nil slice.
+	if issue.BlockedBy == nil {
+		t.Error("BlockedBy is nil, want non-nil empty slice on 404")
+	}
+	if len(issue.BlockedBy) != 0 {
+		t.Errorf("BlockedBy len = %d, want 0", len(issue.BlockedBy))
+	}
+
+	// 404 on parent → nil.
+	if issue.Parent != nil {
+		t.Errorf("Parent = %v, want nil on 404", issue.Parent)
+	}
+}
+
+func TestFetchIssueByID_CommentsNotFound(t *testing.T) {
+	t.Parallel()
+
+	issueFix := loadFixture(t, "issue.json")
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/owner/repo/issues/42/dependencies/blocked_by", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("[]")) //nolint:errcheck // test helper
+	})
+	mux.HandleFunc("/repos/owner/repo/issues/42/parent", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	})
+	mux.HandleFunc("/repos/owner/repo/issues/42/comments", func(w http.ResponseWriter, r *http.Request) {
+		// 404 on comments is propagated as ErrTrackerNotFound.
+		w.WriteHeader(http.StatusNotFound)
+	})
+	mux.HandleFunc("/repos/owner/repo/issues/42", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write(issueFix) //nolint:errcheck // test helper
+	})
+
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	a := mustAdapter(t, validConfig(srv.URL))
+	_, err := a.FetchIssueByID(context.Background(), "42")
+	assertTrackerErrorKind(t, err, domain.ErrTrackerNotFound)
+}
+
+// --- FetchIssuesByStates ---
+
+func TestFetchIssuesByStates_EmptyInput(t *testing.T) {
+	t.Parallel()
+
+	var called bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+	}))
+	defer srv.Close()
+
+	a := mustAdapter(t, validConfig(srv.URL))
+	issues, err := a.FetchIssuesByStates(context.Background(), []string{})
+	if err != nil {
+		t.Fatalf("FetchIssuesByStates: %v", err)
+	}
+	if issues == nil {
+		t.Fatal("issues is nil, want non-nil empty slice")
+	}
+	if len(issues) != 0 {
+		t.Errorf("len = %d, want 0", len(issues))
+	}
+	if called {
+		t.Error("server called for empty states — should short-circuit")
+	}
+}
+
+func TestFetchIssuesByStates_ActiveStatesUsesIssuesEndpoint(t *testing.T) {
+	t.Parallel()
+
+	fixture := loadFixture(t, "issues.json")
+	var gotPath string
+	var gotState string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotState = r.URL.Query().Get("state")
+		w.WriteHeader(http.StatusOK)
+		w.Write(fixture) //nolint:errcheck // test helper
+	}))
+	defer srv.Close()
+
+	a := mustAdapter(t, validConfig(srv.URL))
+	// "backlog" is an active state — should use issues endpoint.
+	issues, err := a.FetchIssuesByStates(context.Background(), []string{"backlog"})
+	if err != nil {
+		t.Fatalf("FetchIssuesByStates: %v", err)
+	}
+
+	if gotPath != "/repos/owner/repo/issues" {
+		t.Errorf("path = %q, want /repos/owner/repo/issues", gotPath)
+	}
+	if gotState != "open" {
+		t.Errorf("state param = %q, want open", gotState)
+	}
+
+	// Only backlog issue (#1) should be in result.
+	if len(issues) != 1 {
+		t.Fatalf("len = %d, want 1 (backlog only)", len(issues))
+	}
+	if issues[0].Identifier != "1" {
+		t.Errorf("Identifier = %q, want 1", issues[0].Identifier)
+	}
+}
+
+func TestFetchIssuesByStates_TerminalStatesUsesSearchEndpoint(t *testing.T) {
+	t.Parallel()
+
+	// Return an empty search result; we only care about the endpoint used.
+	var gotPath string
+	var gotQ string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotQ = r.URL.Query().Get("q")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"total_count":0,"incomplete_results":false,"items":[]}`)) //nolint:errcheck // test helper
+	}))
+	defer srv.Close()
+
+	a := mustAdapter(t, validConfig(srv.URL))
+	// "done" is a terminal state — must use search endpoint.
+	_, err := a.FetchIssuesByStates(context.Background(), []string{"done"})
+	if err != nil {
+		t.Fatalf("FetchIssuesByStates: %v", err)
+	}
+
+	if gotPath != "/search/issues" {
+		t.Errorf("path = %q, want /search/issues", gotPath)
+	}
+	if !strings.Contains(gotQ, "state:closed") {
+		t.Errorf("q = %q, should contain state:closed for terminal", gotQ)
+	}
+	if !strings.Contains(gotQ, "label:done") {
+		t.Errorf("q = %q, should contain label:done", gotQ)
+	}
+}
+
+func TestFetchIssuesByStates_Dedup(t *testing.T) {
+	t.Parallel()
+
+	// Serve the same issue for both the open endpoint and search endpoint.
+	// The adapter should deduplicate by identifier.
+	singleItem := `[{"id":100,"number":1,"title":"Dedup issue","body":null,"state":"open","html_url":"u","labels":[{"name":"backlog"}],"assignees":[],"type":null,"pull_request":null,"created_at":"2026-01-01T00:00:00Z","updated_at":"2026-01-01T00:00:00Z"}]`
+	singleSearch := `{"total_count":1,"incomplete_results":false,"items":[{"id":100,"number":1,"title":"Dedup issue","body":null,"state":"closed","html_url":"u","labels":[{"name":"done"}],"assignees":[],"type":null,"pull_request":null,"created_at":"2026-01-01T00:00:00Z","updated_at":"2026-01-01T00:00:00Z"}]}`
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		if r.URL.Path == "/search/issues" {
+			w.Write([]byte(singleSearch)) //nolint:errcheck // test helper
+		} else {
+			w.Write([]byte(singleItem)) //nolint:errcheck // test helper
+		}
+	}))
+	defer srv.Close()
+
+	a := mustAdapter(t, validConfig(srv.URL))
+	// Request both active ("backlog") and terminal ("done") — issue #1 matches both.
+	issues, err := a.FetchIssuesByStates(context.Background(), []string{"backlog", "done"})
+	if err != nil {
+		t.Fatalf("FetchIssuesByStates: %v", err)
+	}
+
+	if len(issues) != 1 {
+		t.Fatalf("len = %d, want 1 (deduplication)", len(issues))
+	}
+}
+
+// --- FetchIssueStatesByIDs ---
+
+func TestFetchIssueStatesByIDs_Success(t *testing.T) {
+	t.Parallel()
+
+	issueData := issueJSON(42, "in-progress", "open")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(issueData)) //nolint:errcheck // test helper
+	}))
+	defer srv.Close()
+
+	a := mustAdapter(t, validConfig(srv.URL))
+	result, err := a.FetchIssueStatesByIDs(context.Background(), []string{"42"})
+	if err != nil {
+		t.Fatalf("FetchIssueStatesByIDs: %v", err)
+	}
+
+	if result["42"] != "in-progress" {
+		t.Errorf("result[\"42\"] = %q, want in-progress", result["42"])
+	}
+}
+
+func TestFetchIssueStatesByIDs_Empty(t *testing.T) {
+	t.Parallel()
+
+	a := mustAdapter(t, validConfig("http://localhost"))
+	result, err := a.FetchIssueStatesByIDs(context.Background(), []string{})
+	if err != nil {
+		t.Fatalf("FetchIssueStatesByIDs: %v", err)
+	}
+	if result == nil {
+		t.Fatal("result is nil, want non-nil empty map")
+	}
+	if len(result) != 0 {
+		t.Errorf("len = %d, want 0", len(result))
+	}
+}
+
+func TestFetchIssueStatesByIDs_NotFoundOmitted(t *testing.T) {
+	t.Parallel()
+
+	// First issue found, second returns 404 (omit from map).
+	var callNum int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&callNum, 1)
+		if n == 1 {
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(issueJSON(1, "backlog", "open"))) //nolint:errcheck // test helper
+		} else {
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	a := mustAdapter(t, validConfig(srv.URL))
+	result, err := a.FetchIssueStatesByIDs(context.Background(), []string{"1", "999"})
+	if err != nil {
+		t.Fatalf("FetchIssueStatesByIDs: %v", err)
+	}
+
+	if _, ok := result["1"]; !ok {
+		t.Error("result should contain issue 1")
+	}
+	if _, ok := result["999"]; ok {
+		t.Error("result should NOT contain 999 (not found)")
+	}
+}
+
+func TestFetchIssueStatesByIDs_ContextCancellation(t *testing.T) {
+	t.Parallel()
+
+	started := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		close(started)
+		<-r.Context().Done()
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	a := mustAdapter(t, validConfig(srv.URL))
+
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := a.FetchIssueStatesByIDs(ctx, []string{"1"})
+		errCh <- err
+	}()
+
+	<-started
+	cancel()
+
+	err := <-errCh
+	if err == nil {
+		t.Fatal("expected error after context cancel, got nil")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("error = %v, want context.Canceled", err)
+	}
+}
+
+// --- FetchIssueStatesByIdentifiers ---
+
+func TestFetchIssueStatesByIdentifiers_Success(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(issueJSON(7, "review", "open"))) //nolint:errcheck // test helper
+	}))
+	defer srv.Close()
+
+	a := mustAdapter(t, validConfig(srv.URL))
+	result, err := a.FetchIssueStatesByIdentifiers(context.Background(), []string{"7"})
+	if err != nil {
+		t.Fatalf("FetchIssueStatesByIdentifiers: %v", err)
+	}
+
+	// Since ID == Identifier == number, keyed by number.
+	if result["7"] != "review" {
+		t.Errorf("result[\"7\"] = %q, want review", result["7"])
+	}
+}
+
+// --- FetchIssueComments ---
+
+func TestFetchIssueComments_SinglePage(t *testing.T) {
+	t.Parallel()
+
+	fixture := loadFixture(t, "comments.json")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write(fixture) //nolint:errcheck // test helper
+	}))
+	defer srv.Close()
+
+	a := mustAdapter(t, validConfig(srv.URL))
+	comments, err := a.FetchIssueComments(context.Background(), "42")
+	if err != nil {
+		t.Fatalf("FetchIssueComments: %v", err)
+	}
+
+	if len(comments) != 2 {
+		t.Fatalf("len = %d, want 2", len(comments))
+	}
+	if comments[0].Author != "alice" {
+		t.Errorf("comments[0].Author = %q, want alice", comments[0].Author)
+	}
+	if comments[1].Author != "bob" {
+		t.Errorf("comments[1].Author = %q, want bob", comments[1].Author)
+	}
+}
+
+func TestFetchIssueComments_EmptyIsNonNil(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("[]")) //nolint:errcheck // test helper
+	}))
+	defer srv.Close()
+
+	a := mustAdapter(t, validConfig(srv.URL))
+	comments, err := a.FetchIssueComments(context.Background(), "42")
+	if err != nil {
+		t.Fatalf("FetchIssueComments: %v", err)
+	}
+	if comments == nil {
+		t.Fatal("comments is nil, want non-nil empty slice")
+	}
+	if len(comments) != 0 {
+		t.Errorf("len = %d, want 0", len(comments))
+	}
+}
+
+func TestFetchIssueComments_Pagination(t *testing.T) {
+	t.Parallel()
+
+	page1 := loadFixture(t, "comments.json") // 2 comments
+	page2 := `[{"id":9999,"user":{"login":"charlie"},"body":"Third comment.","created_at":"2026-01-17T09:00:00Z"}]`
+
+	var srvURL string
+	var callCount int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&callCount, 1)
+		if n == 1 {
+			w.Header().Set("Link", fmt.Sprintf(`<%s/repos/owner/repo/issues/42/comments?page=2>; rel="next"`, srvURL))
+			w.WriteHeader(http.StatusOK)
+			w.Write(page1) //nolint:errcheck // test helper
+		} else {
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(page2)) //nolint:errcheck // test helper
+		}
+	}))
+	defer srv.Close()
+	srvURL = srv.URL
+
+	a := mustAdapter(t, validConfig(srv.URL))
+	comments, err := a.FetchIssueComments(context.Background(), "42")
+	if err != nil {
+		t.Fatalf("FetchIssueComments: %v", err)
+	}
+
+	if len(comments) != 3 {
+		t.Fatalf("len = %d, want 3 across 2 pages", len(comments))
+	}
+	if comments[2].Author != "charlie" {
+		t.Errorf("comments[2].Author = %q, want charlie", comments[2].Author)
+	}
+}
+
+func TestFetchIssueComments_NotFound(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	a := mustAdapter(t, validConfig(srv.URL))
+	_, err := a.FetchIssueComments(context.Background(), "999")
+	assertTrackerErrorKind(t, err, domain.ErrTrackerNotFound)
+}
+
+// --- TransitionIssue ---
+
+// transitionServer sets up an httptest server that simulates GitHub label and
+// state operations for TransitionIssue. It tracks which API calls were made.
+type transitionServer struct {
+	srv            *httptest.Server
+	deleteCount    int32
+	postCount      int32
+	patchCount     int32
+	deleteFailWith int // if non-zero, respond with this status on DELETE
+	postFailWith   int // if non-zero, respond with this status on POST labels
+	patchFailWith  int // if non-zero, respond with this status on PATCH
+}
+
+func newTransitionServer(t *testing.T, number int, currentLabel, nativeState string) *transitionServer {
+	t.Helper()
+	ts := &transitionServer{}
+	base := fmt.Sprintf("/repos/owner/repo/issues/%d", number)
+
+	mux := http.NewServeMux()
+	// GET issue
+	mux.HandleFunc(base, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "PATCH" {
+			// Open/close call.
+			if ts.patchFailWith != 0 {
+				w.WriteHeader(ts.patchFailWith)
+				return
+			}
+			atomic.AddInt32(&ts.patchCount, 1)
+			w.WriteHeader(http.StatusOK)
+			body, _ := io.ReadAll(r.Body)
+			w.Write(body) //nolint:errcheck // test helper
+			return
+		}
+		// GET
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(issueJSON(number, currentLabel, nativeState))) //nolint:errcheck // test helper
+	})
+	// DELETE label
+	mux.HandleFunc(base+"/labels/", func(w http.ResponseWriter, r *http.Request) {
+		if ts.deleteFailWith != 0 {
+			w.WriteHeader(ts.deleteFailWith)
+			return
+		}
+		atomic.AddInt32(&ts.deleteCount, 1)
+		w.WriteHeader(http.StatusOK)
+	})
+	// POST labels
+	mux.HandleFunc(base+"/labels", func(w http.ResponseWriter, r *http.Request) {
+		if ts.postFailWith != 0 {
+			w.WriteHeader(ts.postFailWith)
+			return
+		}
+		atomic.AddInt32(&ts.postCount, 1)
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`[]`)) //nolint:errcheck // test helper
+	})
+
+	ts.srv = httptest.NewServer(mux)
+	t.Cleanup(ts.srv.Close)
+	return ts
+}
+
+func TestTransitionIssue_LabelSwap(t *testing.T) {
+	t.Parallel()
+
+	// Current: "backlog" (active), native: open → Target: "review" (active).
+	// Expected: DELETE backlog, POST review, no PATCH.
+	ts := newTransitionServer(t, 1, "backlog", "open")
+
+	a := mustAdapter(t, validConfig(ts.srv.URL))
+	if err := a.TransitionIssue(context.Background(), "1", "review"); err != nil {
+		t.Fatalf("TransitionIssue: %v", err)
+	}
+
+	if got := atomic.LoadInt32(&ts.deleteCount); got != 1 {
+		t.Errorf("DELETE count = %d, want 1", got)
+	}
+	if got := atomic.LoadInt32(&ts.postCount); got != 1 {
+		t.Errorf("POST count = %d, want 1", got)
+	}
+	if got := atomic.LoadInt32(&ts.patchCount); got != 0 {
+		t.Errorf("PATCH count = %d, want 0 (no native state change needed)", got)
+	}
+}
+
+func TestTransitionIssue_CloseOnTerminal(t *testing.T) {
+	t.Parallel()
+
+	// Current: "in-progress" (active), native: open → Target: "done" (terminal).
+	// Expected: DELETE in-progress, POST done, PATCH close.
+	ts := newTransitionServer(t, 5, "in-progress", "open")
+
+	a := mustAdapter(t, validConfig(ts.srv.URL))
+	if err := a.TransitionIssue(context.Background(), "5", "done"); err != nil {
+		t.Fatalf("TransitionIssue: %v", err)
+	}
+
+	if got := atomic.LoadInt32(&ts.deleteCount); got != 1 {
+		t.Errorf("DELETE count = %d, want 1", got)
+	}
+	if got := atomic.LoadInt32(&ts.postCount); got != 1 {
+		t.Errorf("POST count = %d, want 1", got)
+	}
+	if got := atomic.LoadInt32(&ts.patchCount); got != 1 {
+		t.Errorf("PATCH count = %d, want 1 (close issue)", got)
+	}
+}
+
+func TestTransitionIssue_ReopenOnActive(t *testing.T) {
+	t.Parallel()
+
+	// Current: "done" (terminal), native: closed → Target: "review" (active).
+	// Expected: DELETE done, POST review, PATCH reopen.
+	ts := newTransitionServer(t, 8, "done", "closed")
+
+	a := mustAdapter(t, validConfig(ts.srv.URL))
+	if err := a.TransitionIssue(context.Background(), "8", "review"); err != nil {
+		t.Fatalf("TransitionIssue: %v", err)
+	}
+
+	if got := atomic.LoadInt32(&ts.deleteCount); got != 1 {
+		t.Errorf("DELETE count = %d, want 1", got)
+	}
+	if got := atomic.LoadInt32(&ts.postCount); got != 1 {
+		t.Errorf("POST count = %d, want 1", got)
+	}
+	if got := atomic.LoadInt32(&ts.patchCount); got != 1 {
+		t.Errorf("PATCH count = %d, want 1 (reopen issue)", got)
+	}
+}
+
+func TestTransitionIssue_IdempotentNoOp(t *testing.T) {
+	t.Parallel()
+
+	// Current label already matches target → no label API calls.
+	ts := newTransitionServer(t, 3, "review", "open")
+
+	a := mustAdapter(t, validConfig(ts.srv.URL))
+	if err := a.TransitionIssue(context.Background(), "3", "review"); err != nil {
+		t.Fatalf("TransitionIssue idempotent: %v", err)
+	}
+
+	if got := atomic.LoadInt32(&ts.deleteCount); got != 0 {
+		t.Errorf("DELETE count = %d, want 0", got)
+	}
+	if got := atomic.LoadInt32(&ts.postCount); got != 0 {
+		t.Errorf("POST count = %d, want 0", got)
+	}
+}
+
+func TestTransitionIssue_PartialFailure_AddLabel(t *testing.T) {
+	t.Parallel()
+
+	// DELETE succeeds, POST fails → error returned.
+	// On retry, DELETE is 404 (already removed) and POST should succeed.
+	ts := newTransitionServer(t, 2, "backlog", "open")
+	ts.postFailWith = http.StatusInternalServerError
+
+	a := mustAdapter(t, validConfig(ts.srv.URL))
+	err := a.TransitionIssue(context.Background(), "2", "review")
+	assertTrackerErrorKind(t, err, domain.ErrTrackerTransport)
+
+	if got := atomic.LoadInt32(&ts.deleteCount); got != 1 {
+		t.Errorf("DELETE count = %d, want 1 (delete succeeded before add failed)", got)
+	}
+}
+
+func TestTransitionIssue_PartialFailure_Close(t *testing.T) {
+	t.Parallel()
+
+	// DELETE and POST succeed, PATCH close fails → error returned.
+	ts := newTransitionServer(t, 6, "review", "open")
+	ts.patchFailWith = http.StatusInternalServerError
+
+	a := mustAdapter(t, validConfig(ts.srv.URL))
+	err := a.TransitionIssue(context.Background(), "6", "done")
+	assertTrackerErrorKind(t, err, domain.ErrTrackerTransport)
+
+	if got := atomic.LoadInt32(&ts.deleteCount); got != 1 {
+		t.Errorf("DELETE count = %d, want 1", got)
+	}
+	if got := atomic.LoadInt32(&ts.postCount); got != 1 {
+		t.Errorf("POST count = %d, want 1", got)
+	}
+}
+
+func TestTransitionIssue_LabelURLEncoding(t *testing.T) {
+	t.Parallel()
+
+	// Label with spaces must be URL-path-escaped in DELETE request.
+	var deletedLabelPath string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/owner/repo/issues/1", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		// Current label has a space.
+		w.Write([]byte(`{"id":1,"number":1,"title":"T","body":null,"state":"open","html_url":"u","labels":[{"name":"code review"}],"assignees":[],"type":null,"pull_request":null,"created_at":"2026-01-01T00:00:00Z","updated_at":"2026-01-01T00:00:00Z"}`)) //nolint:errcheck // test helper
+	})
+	mux.HandleFunc("/repos/owner/repo/issues/1/labels/", func(w http.ResponseWriter, r *http.Request) {
+		// EscapedPath() returns the percent-encoded form, confirming the label
+		// was properly URL-encoded before sending (spaces → %20).
+		deletedLabelPath = r.URL.EscapedPath()
+		w.WriteHeader(http.StatusOK)
+	})
+	mux.HandleFunc("/repos/owner/repo/issues/1/labels", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("[]")) //nolint:errcheck // test helper
+	})
+
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	cfg := validConfig(srv.URL)
+	cfg["active_states"] = []any{"code review", "done-review"}
+	cfg["terminal_states"] = []any{"complete"}
+	a := mustAdapter(t, cfg)
+
+	if err := a.TransitionIssue(context.Background(), "1", "done-review"); err != nil {
+		t.Fatalf("TransitionIssue: %v", err)
+	}
+
+	// Verify "code review" was URL-encoded in the DELETE path.
+	if !strings.Contains(deletedLabelPath, "code%20review") {
+		t.Errorf("DELETE path = %q, should contain URL-encoded label 'code%%20review'", deletedLabelPath)
+	}
+}
+
+// --- CommentIssue ---
+
+func TestCommentIssue_Success(t *testing.T) {
+	t.Parallel()
+
+	var gotBody map[string]string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" {
+			t.Errorf("method = %q, want POST", r.Method)
+		}
+		body, _ := io.ReadAll(r.Body)
+		json.Unmarshal(body, &gotBody) //nolint:errcheck // test helper
+		w.WriteHeader(http.StatusCreated)
+		w.Write([]byte(`{"id":12345}`)) //nolint:errcheck // test helper
+	}))
+	defer srv.Close()
+
+	a := mustAdapter(t, validConfig(srv.URL))
+	if err := a.CommentIssue(context.Background(), "42", "Hello from Sortie!"); err != nil {
+		t.Fatalf("CommentIssue: %v", err)
+	}
+
+	if gotBody["body"] != "Hello from Sortie!" {
+		t.Errorf("request body.body = %q, want %q", gotBody["body"], "Hello from Sortie!")
+	}
+}
+
+func TestCommentIssue_Error(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	a := mustAdapter(t, validConfig(srv.URL))
+	err := a.CommentIssue(context.Background(), "999", "comment")
+	assertTrackerErrorKind(t, err, domain.ErrTrackerNotFound)
+}
+
+// --- SetMetrics ---
+
+func TestSetMetrics_RecordsOperations(t *testing.T) {
+	t.Parallel()
+
+	fixture := loadFixture(t, "issues.json")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write(fixture) //nolint:errcheck // test helper
+	}))
+	defer srv.Close()
+
+	spy := &spyMetrics{}
+	a := mustAdapter(t, validConfig(srv.URL))
+	a.SetMetrics(spy)
+
+	_, err := a.FetchCandidateIssues(context.Background())
+	if err != nil {
+		t.Fatalf("FetchCandidateIssues: %v", err)
+	}
+
+	found := false
+	for _, call := range spy.calls {
+		if call == "fetch_candidates:success" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("metrics calls = %v, want fetch_candidates:success recorded", spy.calls)
+	}
+}
+
+func TestSetMetrics_NilMetricsDoesNotPanic(t *testing.T) {
+	t.Parallel()
+
+	fixture := loadFixture(t, "issues.json")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write(fixture) //nolint:errcheck // test helper
+	}))
+	defer srv.Close()
+
+	// Adapter with no SetMetrics call — metrics field is nil.
+	a := mustAdapter(t, validConfig(srv.URL))
+	// Must not panic.
+	_, err := a.FetchCandidateIssues(context.Background())
+	if err != nil {
+		t.Fatalf("FetchCandidateIssues: %v", err)
+	}
+}
+
+// --- extractStringSlice ---
+
+func TestExtractStringSlice(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input any
+		want  []string
+	}{
+		{name: "nil", input: nil, want: nil},
+		{name: "[]any strings", input: []any{"A", "B"}, want: []string{"A", "B"}},
+		{name: "[]string", input: []string{"X", "Y"}, want: []string{"X", "Y"}},
+		{name: "[]any mixed types", input: []any{"ok", 42, "yes"}, want: []string{"ok", "yes"}},
+		{name: "[]any empty", input: []any{}, want: []string{}},
+		{name: "int type wrong", input: 42, want: nil},
+		{name: "string scalar wrong", input: "single", want: nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := extractStringSlice(tt.input)
+			if len(got) != len(tt.want) {
+				t.Fatalf("extractStringSlice(%v) len = %d, want %d", tt.input, len(got), len(tt.want))
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("extractStringSlice(%v)[%d] = %q, want %q", tt.input, i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}

--- a/internal/tracker/github/integration_test.go
+++ b/internal/tracker/github/integration_test.go
@@ -1,0 +1,135 @@
+package github
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+)
+
+// skipUnlessGitHubIntegration skips the test unless SORTIE_GITHUB_TEST=1.
+// Tests also require SORTIE_GITHUB_TOKEN and SORTIE_GITHUB_PROJECT to be set.
+func skipUnlessGitHubIntegration(t *testing.T) {
+	t.Helper()
+	if os.Getenv("SORTIE_GITHUB_TEST") != "1" {
+		t.Skip("skipping GitHub integration test: set SORTIE_GITHUB_TEST=1 to enable")
+	}
+	if os.Getenv("SORTIE_GITHUB_TOKEN") == "" {
+		t.Skip("skipping GitHub integration test: SORTIE_GITHUB_TOKEN not set")
+	}
+	if os.Getenv("SORTIE_GITHUB_PROJECT") == "" {
+		t.Skip("skipping GitHub integration test: SORTIE_GITHUB_PROJECT not set")
+	}
+}
+
+func integrationAdapter(t *testing.T) *GitHubAdapter {
+	t.Helper()
+	cfg := map[string]any{
+		"api_key": os.Getenv("SORTIE_GITHUB_TOKEN"),
+		"project": os.Getenv("SORTIE_GITHUB_PROJECT"),
+	}
+	a, err := NewGitHubAdapter(cfg)
+	if err != nil {
+		t.Fatalf("NewGitHubAdapter: %v", err)
+	}
+	return a.(*GitHubAdapter)
+}
+
+func TestIntegration_FetchCandidateIssues(t *testing.T) {
+	skipUnlessGitHubIntegration(t)
+
+	a := integrationAdapter(t)
+	issues, err := a.FetchCandidateIssues(context.Background())
+	if err != nil {
+		t.Fatalf("FetchCandidateIssues: %v", err)
+	}
+
+	t.Logf("fetched %d candidate issues", len(issues))
+
+	for _, iss := range issues {
+		if iss.ID == "" {
+			t.Errorf("issue has empty ID: %+v", iss)
+		}
+		if iss.Identifier == "" {
+			t.Errorf("issue has empty Identifier: %+v", iss)
+		}
+		if iss.ID != iss.Identifier {
+			t.Errorf("issue %q: ID != Identifier (%q != %q)", iss.ID, iss.ID, iss.Identifier)
+		}
+		if iss.Title == "" {
+			t.Errorf("issue %s has empty Title", iss.ID)
+		}
+		if iss.Comments != nil {
+			t.Errorf("issue %s: Comments should be nil in candidate list", iss.ID)
+		}
+		if iss.BlockedBy == nil {
+			t.Errorf("issue %s: BlockedBy should be non-nil", iss.ID)
+		}
+		if iss.Priority != nil {
+			t.Errorf("issue %s: Priority should always be nil (GitHub has no native priority)", iss.ID)
+		}
+		// All labels should be lowercased.
+		for _, l := range iss.Labels {
+			if l != strings.ToLower(l) {
+				t.Errorf("issue %s: label %q is not lowercase", iss.ID, l)
+			}
+		}
+	}
+}
+
+func TestIntegration_FetchIssueByID(t *testing.T) {
+	skipUnlessGitHubIntegration(t)
+
+	issueID := os.Getenv("SORTIE_GITHUB_ISSUE_ID")
+	if issueID == "" {
+		t.Skip("skipping: SORTIE_GITHUB_ISSUE_ID not set; set to a valid issue number")
+	}
+
+	a := integrationAdapter(t)
+	issue, err := a.FetchIssueByID(context.Background(), issueID)
+	if err != nil {
+		t.Fatalf("FetchIssueByID(%q): %v", issueID, err)
+	}
+
+	t.Logf("fetched issue %s: %q state=%q", issue.ID, issue.Title, issue.State)
+
+	if issue.ID != issueID {
+		t.Errorf("ID = %q, want %q", issue.ID, issueID)
+	}
+	if issue.ID != issue.Identifier {
+		t.Errorf("ID != Identifier: %q != %q", issue.ID, issue.Identifier)
+	}
+	if issue.Title == "" {
+		t.Error("Title is empty")
+	}
+	if issue.BlockedBy == nil {
+		t.Error("BlockedBy is nil, want non-nil (may be empty)")
+	}
+	if issue.Priority != nil {
+		t.Error("Priority should always be nil for GitHub issues")
+	}
+}
+
+func TestIntegration_FetchIssueStatesByIDs(t *testing.T) {
+	skipUnlessGitHubIntegration(t)
+
+	issueID := os.Getenv("SORTIE_GITHUB_ISSUE_ID")
+	if issueID == "" {
+		t.Skip("skipping: SORTIE_GITHUB_ISSUE_ID not set")
+	}
+
+	a := integrationAdapter(t)
+	result, err := a.FetchIssueStatesByIDs(context.Background(), []string{issueID})
+	if err != nil {
+		t.Fatalf("FetchIssueStatesByIDs: %v", err)
+	}
+
+	state, ok := result[issueID]
+	if !ok {
+		t.Fatalf("issue %q not in result map", issueID)
+	}
+	if state == "" {
+		t.Errorf("issue %q has empty state", issueID)
+	}
+	t.Logf("issue %s state = %q", issueID, state)
+}

--- a/internal/tracker/github/normalize.go
+++ b/internal/tracker/github/normalize.go
@@ -1,0 +1,143 @@
+package github
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/sortie-ai/sortie/internal/domain"
+)
+
+// githubIssue represents a single issue from the GitHub REST API.
+type githubIssue struct {
+	ID          int64            `json:"id"`
+	Number      int              `json:"number"`
+	Title       string           `json:"title"`
+	Body        *string          `json:"body"`
+	State       string           `json:"state"`
+	StateReason *string          `json:"state_reason"`
+	HTMLURL     string           `json:"html_url"`
+	Labels      []githubLabel    `json:"labels"`
+	Assignees   []githubUser     `json:"assignees"`
+	Type        *githubIssueType `json:"type"`
+	PullRequest *githubPR        `json:"pull_request"`
+	CreatedAt   string           `json:"created_at"`
+	UpdatedAt   string           `json:"updated_at"`
+}
+
+type githubLabel struct {
+	Name string `json:"name"`
+}
+
+type githubUser struct {
+	Login string `json:"login"`
+}
+
+type githubIssueType struct {
+	Name string `json:"name"`
+}
+
+// githubPR is a marker struct — its mere presence (non-nil pointer)
+// indicates the list entry is a pull request, not an issue.
+type githubPR struct{}
+
+type githubComment struct {
+	ID        int64      `json:"id"`
+	User      githubUser `json:"user"`
+	Body      string     `json:"body"`
+	CreatedAt string     `json:"created_at"`
+}
+
+// searchResponse represents GET /search/issues response.
+type searchResponse struct {
+	TotalCount        int           `json:"total_count"`
+	IncompleteResults bool          `json:"incomplete_results"`
+	Items             []githubIssue `json:"items"`
+}
+
+// normalizeIssue maps a GitHub API issue response to a [domain.Issue].
+// The ID and Identifier are both set to the issue number since the
+// GitHub REST API indexes issues by number, not by global integer ID.
+// Parent, Comments, and BlockedBy are set to list-path defaults (nil,
+// nil, empty slice respectively); callers requiring full population
+// must use [GitHubAdapter.FetchIssueByID].
+func normalizeIssue(gi githubIssue, activeStates, terminalStates []string) domain.Issue {
+	num := strconv.Itoa(gi.Number)
+
+	desc := ""
+	if gi.Body != nil {
+		desc = *gi.Body
+	}
+
+	labels := make([]string, 0, len(gi.Labels))
+	for _, l := range gi.Labels {
+		labels = append(labels, strings.ToLower(l.Name))
+	}
+
+	assignee := ""
+	if len(gi.Assignees) > 0 {
+		assignee = gi.Assignees[0].Login
+	}
+
+	issueType := ""
+	if gi.Type != nil {
+		issueType = gi.Type.Name
+	}
+
+	return domain.Issue{
+		ID:          num,
+		Identifier:  num,
+		Title:       gi.Title,
+		Description: desc,
+		Priority:    nil,
+		State:       extractState(gi.Labels, gi.State, activeStates, terminalStates),
+		BranchName:  "",
+		URL:         gi.HTMLURL,
+		Labels:      labels,
+		Assignee:    assignee,
+		IssueType:   issueType,
+		Parent:      nil,
+		Comments:    nil,
+		BlockedBy:   []domain.BlockerRef{},
+		CreatedAt:   gi.CreatedAt,
+		UpdatedAt:   gi.UpdatedAt,
+	}
+}
+
+// normalizeBlockers converts blocker issue responses to
+// [domain.BlockerRef] values. Returns a non-nil empty slice when
+// input is empty.
+func normalizeBlockers(blockers []githubIssue, activeStates, terminalStates []string) []domain.BlockerRef {
+	result := make([]domain.BlockerRef, 0, len(blockers))
+	for _, b := range blockers {
+		num := strconv.Itoa(b.Number)
+		result = append(result, domain.BlockerRef{
+			ID:         num,
+			Identifier: num,
+			State:      extractState(b.Labels, b.State, activeStates, terminalStates),
+		})
+	}
+	return result
+}
+
+// normalizeComments converts GitHub comment responses to
+// [domain.Comment] values. Returns a non-nil empty slice when input
+// is empty.
+func normalizeComments(comments []githubComment) []domain.Comment {
+	result := make([]domain.Comment, 0, len(comments))
+	for _, c := range comments {
+		result = append(result, domain.Comment{
+			ID:        strconv.FormatInt(c.ID, 10),
+			Author:    c.User.Login,
+			Body:      c.Body,
+			CreatedAt: c.CreatedAt,
+		})
+	}
+	return result
+}
+
+// isPullRequest returns true when the GitHub API entry represents a
+// pull request rather than an issue. The issues list endpoint
+// co-mingles both; this filter removes PRs.
+func isPullRequest(gi githubIssue) bool {
+	return gi.PullRequest != nil
+}

--- a/internal/tracker/github/normalize_test.go
+++ b/internal/tracker/github/normalize_test.go
@@ -1,0 +1,337 @@
+package github
+
+import (
+	"testing"
+
+	"github.com/sortie-ai/sortie/internal/domain"
+)
+
+func strPtr(s string) *string              { return &s }
+func typePtr(name string) *githubIssueType { return &githubIssueType{Name: name} }
+func prMarker() *githubPR                  { return &githubPR{} }
+
+// --- normalizeIssue ---
+
+func TestNormalizeIssue_AllFields(t *testing.T) {
+	t.Parallel()
+
+	gi := githubIssue{
+		ID:        987654,
+		Number:    42,
+		Title:     "Add dark mode",
+		Body:      strPtr("Users want dark mode."),
+		State:     "open",
+		HTMLURL:   "https://github.com/owner/repo/issues/42",
+		Labels:    []githubLabel{{Name: "In-Progress"}, {Name: "UI"}},
+		Assignees: []githubUser{{Login: "alice"}},
+		Type:      typePtr("Feature"),
+		CreatedAt: "2026-01-01T00:00:00Z",
+		UpdatedAt: "2026-01-02T00:00:00Z",
+	}
+
+	active := []string{"backlog", "in-progress", "review"}
+	terminal := []string{"done", "wontfix"}
+
+	got := normalizeIssue(gi, active, terminal)
+
+	// ID and Identifier are both the issue number (not global int64 ID).
+	if got.ID != "42" {
+		t.Errorf("ID = %q, want %q", got.ID, "42")
+	}
+	if got.Identifier != "42" {
+		t.Errorf("Identifier = %q, want %q", got.Identifier, "42")
+	}
+	if got.Title != "Add dark mode" {
+		t.Errorf("Title = %q, want %q", got.Title, "Add dark mode")
+	}
+	if got.Description != "Users want dark mode." {
+		t.Errorf("Description = %q, want %q", got.Description, "Users want dark mode.")
+	}
+	if got.Priority != nil {
+		t.Errorf("Priority = %v, want nil (GitHub has no native priority)", got.Priority)
+	}
+	if got.State != "in-progress" {
+		t.Errorf("State = %q, want %q", got.State, "in-progress")
+	}
+	if got.URL != "https://github.com/owner/repo/issues/42" {
+		t.Errorf("URL = %q", got.URL)
+	}
+	if got.Assignee != "alice" {
+		t.Errorf("Assignee = %q, want %q", got.Assignee, "alice")
+	}
+	if got.IssueType != "Feature" {
+		t.Errorf("IssueType = %q, want %q", got.IssueType, "Feature")
+	}
+	if got.CreatedAt != "2026-01-01T00:00:00Z" {
+		t.Errorf("CreatedAt = %q", got.CreatedAt)
+	}
+	if got.UpdatedAt != "2026-01-02T00:00:00Z" {
+		t.Errorf("UpdatedAt = %q", got.UpdatedAt)
+	}
+	if got.BranchName != "" {
+		t.Errorf("BranchName = %q, want empty (not available from API)", got.BranchName)
+	}
+
+	// List-path defaults.
+	if got.Parent != nil {
+		t.Errorf("Parent = %v, want nil in list normalization", got.Parent)
+	}
+	if got.Comments != nil {
+		t.Errorf("Comments = %v, want nil in list normalization", got.Comments)
+	}
+}
+
+func TestNormalizeIssue_LabelsLowercased(t *testing.T) {
+	t.Parallel()
+
+	gi := githubIssue{
+		Number: 1,
+		State:  "open",
+		Labels: []githubLabel{{Name: "BACKLOG"}, {Name: "Priority-High"}},
+	}
+	got := normalizeIssue(gi, []string{"backlog"}, nil)
+
+	if len(got.Labels) != 2 {
+		t.Fatalf("Labels len = %d, want 2", len(got.Labels))
+	}
+	if got.Labels[0] != "backlog" {
+		t.Errorf("Labels[0] = %q, want %q", got.Labels[0], "backlog")
+	}
+	if got.Labels[1] != "priority-high" {
+		t.Errorf("Labels[1] = %q, want %q", got.Labels[1], "priority-high")
+	}
+}
+
+func TestNormalizeIssue_NonNilEmptyLabels(t *testing.T) {
+	t.Parallel()
+
+	gi := githubIssue{Number: 1, State: "open", Labels: nil}
+	got := normalizeIssue(gi, nil, nil)
+
+	if got.Labels == nil {
+		t.Error("Labels is nil, want non-nil empty slice")
+	}
+	if len(got.Labels) != 0 {
+		t.Errorf("Labels len = %d, want 0", len(got.Labels))
+	}
+}
+
+func TestNormalizeIssue_NilBody(t *testing.T) {
+	t.Parallel()
+
+	gi := githubIssue{Number: 1, State: "open", Body: nil}
+	got := normalizeIssue(gi, nil, nil)
+
+	if got.Description != "" {
+		t.Errorf("Description = %q, want empty string for nil Body", got.Description)
+	}
+}
+
+func TestNormalizeIssue_NilType(t *testing.T) {
+	t.Parallel()
+
+	gi := githubIssue{Number: 1, State: "open", Type: nil}
+	got := normalizeIssue(gi, nil, nil)
+
+	if got.IssueType != "" {
+		t.Errorf("IssueType = %q, want empty string for nil Type", got.IssueType)
+	}
+}
+
+func TestNormalizeIssue_EmptyAssignees(t *testing.T) {
+	t.Parallel()
+
+	gi := githubIssue{Number: 1, State: "open", Assignees: nil}
+	got := normalizeIssue(gi, nil, nil)
+
+	if got.Assignee != "" {
+		t.Errorf("Assignee = %q, want empty string for no assignees", got.Assignee)
+	}
+}
+
+func TestNormalizeIssue_MultipleAssignees(t *testing.T) {
+	t.Parallel()
+
+	gi := githubIssue{
+		Number:    1,
+		State:     "open",
+		Assignees: []githubUser{{Login: "alice"}, {Login: "bob"}},
+	}
+	got := normalizeIssue(gi, nil, nil)
+
+	// Only the first assignee is used.
+	if got.Assignee != "alice" {
+		t.Errorf("Assignee = %q, want first assignee %q", got.Assignee, "alice")
+	}
+}
+
+func TestNormalizeIssue_NonNilEmptyBlockedBy(t *testing.T) {
+	t.Parallel()
+
+	gi := githubIssue{Number: 1, State: "open"}
+	got := normalizeIssue(gi, nil, nil)
+
+	if got.BlockedBy == nil {
+		t.Error("BlockedBy is nil, want non-nil empty slice in list normalization")
+	}
+	if len(got.BlockedBy) != 0 {
+		t.Errorf("BlockedBy len = %d, want 0", len(got.BlockedBy))
+	}
+}
+
+func TestNormalizeIssue_NilPriority(t *testing.T) {
+	t.Parallel()
+
+	gi := githubIssue{Number: 1, State: "open"}
+	got := normalizeIssue(gi, nil, nil)
+
+	if got.Priority != nil {
+		t.Errorf("Priority = %v, want nil (GitHub has no native priority)", got.Priority)
+	}
+}
+
+func TestNormalizeIssue_IDEqualsIdentifier(t *testing.T) {
+	t.Parallel()
+
+	gi := githubIssue{ID: 99999999, Number: 123, State: "open"}
+	got := normalizeIssue(gi, nil, nil)
+
+	// Both ID and Identifier must be the issue number, not the global int64 ID.
+	if got.ID != "123" {
+		t.Errorf("ID = %q, want issue number %q (not global ID)", got.ID, "123")
+	}
+	if got.Identifier != "123" {
+		t.Errorf("Identifier = %q, want issue number %q", got.Identifier, "123")
+	}
+	if got.ID != got.Identifier {
+		t.Errorf("ID %q != Identifier %q", got.ID, got.Identifier)
+	}
+}
+
+// --- normalizeBlockers ---
+
+func TestNormalizeBlockers_NonEmpty(t *testing.T) {
+	t.Parallel()
+
+	blockers := []githubIssue{
+		{ID: 500, Number: 5, State: "open", Labels: []githubLabel{{Name: "in-progress"}}},
+		{ID: 600, Number: 6, State: "closed", Labels: []githubLabel{{Name: "done"}}},
+	}
+	active := []string{"backlog", "in-progress", "review"}
+	terminal := []string{"done", "wontfix"}
+
+	got := normalizeBlockers(blockers, active, terminal)
+
+	if len(got) != 2 {
+		t.Fatalf("normalizeBlockers len = %d, want 2", len(got))
+	}
+	if got[0].ID != "5" || got[0].Identifier != "5" {
+		t.Errorf("got[0] ID/Identifier = %q/%q, want 5/5", got[0].ID, got[0].Identifier)
+	}
+	if got[0].State != "in-progress" {
+		t.Errorf("got[0].State = %q, want %q", got[0].State, "in-progress")
+	}
+	if got[1].ID != "6" {
+		t.Errorf("got[1].ID = %q, want %q", got[1].ID, "6")
+	}
+	if got[1].State != "done" {
+		t.Errorf("got[1].State = %q, want %q", got[1].State, "done")
+	}
+}
+
+func TestNormalizeBlockers_EmptyReturnsNonNilSlice(t *testing.T) {
+	t.Parallel()
+
+	got := normalizeBlockers(nil, nil, nil)
+
+	if got == nil {
+		t.Error("normalizeBlockers(nil) returned nil, want non-nil empty slice")
+	}
+	if len(got) != 0 {
+		t.Errorf("len = %d, want 0", len(got))
+	}
+}
+
+// --- normalizeComments ---
+
+func TestNormalizeComments_NonEmpty(t *testing.T) {
+	t.Parallel()
+
+	comments := []githubComment{
+		{ID: 9001, User: githubUser{Login: "alice"}, Body: "Looks good!", CreatedAt: "2026-01-15T10:00:00Z"},
+		{ID: 9002, User: githubUser{Login: "bob"}, Body: "Fix indentation.", CreatedAt: "2026-01-16T11:30:00Z"},
+	}
+
+	got := normalizeComments(comments)
+
+	if len(got) != 2 {
+		t.Fatalf("normalizeComments len = %d, want 2", len(got))
+	}
+	// ID is strconv.FormatInt of the int64 id.
+	if got[0].ID != "9001" {
+		t.Errorf("got[0].ID = %q, want %q", got[0].ID, "9001")
+	}
+	if got[0].Author != "alice" {
+		t.Errorf("got[0].Author = %q, want %q", got[0].Author, "alice")
+	}
+	if got[0].Body != "Looks good!" {
+		t.Errorf("got[0].Body = %q", got[0].Body)
+	}
+	if got[0].CreatedAt != "2026-01-15T10:00:00Z" {
+		t.Errorf("got[0].CreatedAt = %q", got[0].CreatedAt)
+	}
+	if got[1].ID != "9002" {
+		t.Errorf("got[1].ID = %q, want %q", got[1].ID, "9002")
+	}
+}
+
+func TestNormalizeComments_EmptyReturnsNonNilSlice(t *testing.T) {
+	t.Parallel()
+
+	got := normalizeComments(nil)
+
+	if got == nil {
+		t.Error("normalizeComments(nil) returned nil, want non-nil empty slice")
+	}
+	if len(got) != 0 {
+		t.Errorf("len = %d, want 0", len(got))
+	}
+}
+
+// --- isPullRequest ---
+
+func TestIsPullRequest(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		gi   githubIssue
+		want bool
+	}{
+		{
+			name: "pull_request field set is PR",
+			gi:   githubIssue{Number: 1, PullRequest: prMarker()},
+			want: true,
+		},
+		{
+			name: "pull_request field nil is issue",
+			gi:   githubIssue{Number: 2, PullRequest: nil},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := isPullRequest(tt.gi)
+			if got != tt.want {
+				t.Errorf("isPullRequest() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// --- domain type sanity check (compile-time) ---
+
+var _ domain.Issue = domain.Issue{}

--- a/internal/tracker/github/state.go
+++ b/internal/tracker/github/state.go
@@ -1,0 +1,80 @@
+package github
+
+import "strings"
+
+// extractState derives the Sortie state from GitHub issue labels by
+// scanning configured active and terminal states in config order.
+// The first label match wins. When no state label is found, the
+// function falls back to the first configured state matching the
+// native open/closed status, or passes through the native state
+// unchanged as a last resort.
+func extractState(labels []githubLabel, nativeState string, activeStates, terminalStates []string) string {
+	lowerSet := make(map[string]struct{}, len(labels))
+	for _, l := range labels {
+		lowerSet[strings.ToLower(l.Name)] = struct{}{}
+	}
+
+	for _, s := range activeStates {
+		if _, ok := lowerSet[s]; ok {
+			return s
+		}
+	}
+
+	for _, s := range terminalStates {
+		if _, ok := lowerSet[s]; ok {
+			return s
+		}
+	}
+
+	if nativeState == "open" && len(activeStates) > 0 {
+		return activeStates[0]
+	}
+	if nativeState == "closed" && len(terminalStates) > 0 {
+		return terminalStates[0]
+	}
+
+	return nativeState
+}
+
+// isTerminalState returns true when the given lowercased state
+// appears in terminalStates.
+func isTerminalState(state string, terminalStates []string) bool {
+	for _, s := range terminalStates {
+		if s == state {
+			return true
+		}
+	}
+	return false
+}
+
+// isActiveState returns true when the given lowercased state appears
+// in activeStates.
+func isActiveState(state string, activeStates []string) bool {
+	for _, s := range activeStates {
+		if s == state {
+			return true
+		}
+	}
+	return false
+}
+
+// findCurrentStateLabel returns the first issue label (lowercased)
+// that matches any configured active or terminal state. Returns an
+// empty string when no state label is found.
+func findCurrentStateLabel(labels []githubLabel, activeStates, terminalStates []string) string {
+	all := make(map[string]struct{}, len(activeStates)+len(terminalStates))
+	for _, s := range activeStates {
+		all[s] = struct{}{}
+	}
+	for _, s := range terminalStates {
+		all[s] = struct{}{}
+	}
+
+	for _, l := range labels {
+		lower := strings.ToLower(l.Name)
+		if _, ok := all[lower]; ok {
+			return lower
+		}
+	}
+	return ""
+}

--- a/internal/tracker/github/state_test.go
+++ b/internal/tracker/github/state_test.go
@@ -1,0 +1,225 @@
+package github
+
+import "testing"
+
+func TestExtractState(t *testing.T) {
+	t.Parallel()
+
+	active := []string{"backlog", "in-progress", "review"}
+	terminal := []string{"done", "wontfix"}
+
+	tests := []struct {
+		name           string
+		labels         []githubLabel
+		nativeState    string
+		activeStates   []string
+		terminalStates []string
+		want           string
+	}{
+		{
+			name:           "single active label match",
+			labels:         []githubLabel{{Name: "in-progress"}},
+			nativeState:    "open",
+			activeStates:   active,
+			terminalStates: terminal,
+			want:           "in-progress",
+		},
+		{
+			name:           "single terminal label match",
+			labels:         []githubLabel{{Name: "done"}},
+			nativeState:    "closed",
+			activeStates:   active,
+			terminalStates: terminal,
+			want:           "done",
+		},
+		{
+			// "backlog" precedes "review" in config order; backlog wins even though
+			// "review" appears first in the label slice.
+			name:           "multiple active labels first config-order wins",
+			labels:         []githubLabel{{Name: "review"}, {Name: "backlog"}},
+			nativeState:    "open",
+			activeStates:   active,
+			terminalStates: terminal,
+			want:           "backlog",
+		},
+		{
+			// Active state scan occurs before terminal state scan.
+			name:           "active label beats terminal label",
+			labels:         []githubLabel{{Name: "done"}, {Name: "backlog"}},
+			nativeState:    "open",
+			activeStates:   active,
+			terminalStates: terminal,
+			want:           "backlog",
+		},
+		{
+			// No matching label on open issue → fallback to first active state.
+			name:           "no state labels open issue fallback first active",
+			labels:         []githubLabel{{Name: "bug"}},
+			nativeState:    "open",
+			activeStates:   active,
+			terminalStates: terminal,
+			want:           "backlog",
+		},
+		{
+			// No matching label on closed issue → fallback to first terminal state.
+			name:           "no state labels closed issue fallback first terminal",
+			labels:         []githubLabel{{Name: "bug"}},
+			nativeState:    "closed",
+			activeStates:   active,
+			terminalStates: terminal,
+			want:           "done",
+		},
+		{
+			// Empty config with open native state → passthrough "open".
+			name:           "empty config open passthrough native",
+			labels:         []githubLabel{},
+			nativeState:    "open",
+			activeStates:   nil,
+			terminalStates: nil,
+			want:           "open",
+		},
+		{
+			// Upper-case label should match lower-case config entry.
+			name:           "uppercase label matches lowercase config",
+			labels:         []githubLabel{{Name: "IN-PROGRESS"}},
+			nativeState:    "open",
+			activeStates:   active,
+			terminalStates: terminal,
+			want:           "in-progress",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := extractState(tt.labels, tt.nativeState, tt.activeStates, tt.terminalStates)
+			if got != tt.want {
+				t.Errorf("extractState() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsTerminalState(t *testing.T) {
+	t.Parallel()
+
+	terminal := []string{"done", "wontfix"}
+
+	tests := []struct {
+		name           string
+		state          string
+		terminalStates []string
+		want           bool
+	}{
+		{"done is terminal", "done", terminal, true},
+		{"wontfix is terminal", "wontfix", terminal, true},
+		{"active state not terminal", "in-progress", terminal, false},
+		{"empty state not terminal", "", terminal, false},
+		{"empty terminal list", "done", nil, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := isTerminalState(tt.state, tt.terminalStates)
+			if got != tt.want {
+				t.Errorf("isTerminalState(%q) = %v, want %v", tt.state, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsActiveState(t *testing.T) {
+	t.Parallel()
+
+	active := []string{"backlog", "in-progress", "review"}
+
+	tests := []struct {
+		name         string
+		state        string
+		activeStates []string
+		want         bool
+	}{
+		{"backlog is active", "backlog", active, true},
+		{"in-progress is active", "in-progress", active, true},
+		{"review is active", "review", active, true},
+		{"terminal state not active", "done", active, false},
+		{"empty state not active", "", active, false},
+		{"empty active list", "backlog", nil, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := isActiveState(tt.state, tt.activeStates)
+			if got != tt.want {
+				t.Errorf("isActiveState(%q) = %v, want %v", tt.state, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFindCurrentStateLabel(t *testing.T) {
+	t.Parallel()
+
+	active := []string{"backlog", "in-progress", "review"}
+	terminal := []string{"done", "wontfix"}
+
+	tests := []struct {
+		name           string
+		labels         []githubLabel
+		activeStates   []string
+		terminalStates []string
+		want           string
+	}{
+		{
+			name:           "active state label found",
+			labels:         []githubLabel{{Name: "in-progress"}, {Name: "bug"}},
+			activeStates:   active,
+			terminalStates: terminal,
+			want:           "in-progress",
+		},
+		{
+			name:           "terminal state label found",
+			labels:         []githubLabel{{Name: "done"}},
+			activeStates:   active,
+			terminalStates: terminal,
+			want:           "done",
+		},
+		{
+			name:           "uppercase label returned lowercased",
+			labels:         []githubLabel{{Name: "BACKLOG"}},
+			activeStates:   active,
+			terminalStates: terminal,
+			want:           "backlog",
+		},
+		{
+			name:           "no state label returns empty string",
+			labels:         []githubLabel{{Name: "bug"}, {Name: "priority"}},
+			activeStates:   active,
+			terminalStates: terminal,
+			want:           "",
+		},
+		{
+			name:           "empty labels returns empty string",
+			labels:         nil,
+			activeStates:   active,
+			terminalStates: terminal,
+			want:           "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := findCurrentStateLabel(tt.labels, tt.activeStates, tt.terminalStates)
+			if got != tt.want {
+				t.Errorf("findCurrentStateLabel() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/tracker/github/testdata/blockers.json
+++ b/internal/tracker/github/testdata/blockers.json
@@ -1,0 +1,16 @@
+[
+  {
+    "id": 500,
+    "number": 5,
+    "title": "Blocking dependency",
+    "body": null,
+    "state": "open",
+    "html_url": "https://github.com/owner/repo/issues/5",
+    "labels": [{ "name": "in-progress" }],
+    "assignees": [],
+    "type": null,
+    "pull_request": null,
+    "created_at": "2025-12-01T00:00:00Z",
+    "updated_at": "2025-12-01T00:00:00Z"
+  }
+]

--- a/internal/tracker/github/testdata/comments.json
+++ b/internal/tracker/github/testdata/comments.json
@@ -1,0 +1,14 @@
+[
+  {
+    "id": 9001,
+    "user": { "login": "alice" },
+    "body": "Looks good, please proceed.",
+    "created_at": "2026-01-15T10:00:00Z"
+  },
+  {
+    "id": 9002,
+    "user": { "login": "bob" },
+    "body": "Please fix the indentation.",
+    "created_at": "2026-01-16T11:30:00Z"
+  }
+]

--- a/internal/tracker/github/testdata/issue.json
+++ b/internal/tracker/github/testdata/issue.json
@@ -1,0 +1,19 @@
+{
+  "id": 987654,
+  "number": 42,
+  "title": "Add dark mode support",
+  "body": "Users want a **dark mode** option.",
+  "state": "open",
+  "state_reason": null,
+  "html_url": "https://github.com/owner/repo/issues/42",
+  "labels": [
+    { "name": "in-progress" },
+    { "name": "UI" },
+    { "name": "Enhancement" }
+  ],
+  "assignees": [{ "login": "alice" }],
+  "type": { "name": "Feature" },
+  "pull_request": null,
+  "created_at": "2026-01-01T00:00:00Z",
+  "updated_at": "2026-01-02T00:00:00Z"
+}

--- a/internal/tracker/github/testdata/issues.json
+++ b/internal/tracker/github/testdata/issues.json
@@ -1,0 +1,58 @@
+[
+  {
+    "id": 100,
+    "number": 1,
+    "title": "Backlog task",
+    "body": "needs attention",
+    "state": "open",
+    "html_url": "https://github.com/owner/repo/issues/1",
+    "labels": [{ "name": "backlog" }],
+    "assignees": [],
+    "type": null,
+    "pull_request": null,
+    "created_at": "2026-01-01T00:00:00Z",
+    "updated_at": "2026-01-01T00:00:00Z"
+  },
+  {
+    "id": 101,
+    "number": 2,
+    "title": "Active PR — should be filtered",
+    "body": null,
+    "state": "open",
+    "html_url": "https://github.com/owner/repo/pull/2",
+    "labels": [{ "name": "in-progress" }],
+    "assignees": [],
+    "type": null,
+    "pull_request": {},
+    "created_at": "2026-01-01T00:00:00Z",
+    "updated_at": "2026-01-01T00:00:00Z"
+  },
+  {
+    "id": 102,
+    "number": 3,
+    "title": "In-progress bug",
+    "body": "currently being worked on",
+    "state": "open",
+    "html_url": "https://github.com/owner/repo/issues/3",
+    "labels": [{ "name": "in-progress" }],
+    "assignees": [{ "login": "bob" }],
+    "type": null,
+    "pull_request": null,
+    "created_at": "2026-01-02T00:00:00Z",
+    "updated_at": "2026-01-02T00:00:00Z"
+  },
+  {
+    "id": 103,
+    "number": 4,
+    "title": "Issue with done label — non-active",
+    "body": "finished",
+    "state": "open",
+    "html_url": "https://github.com/owner/repo/issues/4",
+    "labels": [{ "name": "done" }],
+    "assignees": [],
+    "type": null,
+    "pull_request": null,
+    "created_at": "2026-01-03T00:00:00Z",
+    "updated_at": "2026-01-03T00:00:00Z"
+  }
+]

--- a/internal/tracker/github/testdata/issues_page2.json
+++ b/internal/tracker/github/testdata/issues_page2.json
@@ -1,0 +1,16 @@
+[
+  {
+    "id": 110,
+    "number": 5,
+    "title": "Page-two issue",
+    "body": "second page result",
+    "state": "open",
+    "html_url": "https://github.com/owner/repo/issues/5",
+    "labels": [{ "name": "review" }],
+    "assignees": [],
+    "type": null,
+    "pull_request": null,
+    "created_at": "2026-01-04T00:00:00Z",
+    "updated_at": "2026-01-04T00:00:00Z"
+  }
+]

--- a/internal/tracker/github/testdata/parent.json
+++ b/internal/tracker/github/testdata/parent.json
@@ -1,0 +1,14 @@
+{
+  "id": 300,
+  "number": 7,
+  "title": "Parent epic",
+  "body": "Epic grouping.",
+  "state": "open",
+  "html_url": "https://github.com/owner/repo/issues/7",
+  "labels": [],
+  "assignees": [],
+  "type": null,
+  "pull_request": null,
+  "created_at": "2025-11-01T00:00:00Z",
+  "updated_at": "2025-11-01T00:00:00Z"
+}

--- a/internal/tracker/github/testdata/search.json
+++ b/internal/tracker/github/testdata/search.json
@@ -1,0 +1,20 @@
+{
+  "total_count": 1,
+  "incomplete_results": false,
+  "items": [
+    {
+      "id": 200,
+      "number": 10,
+      "title": "Search result: review phase",
+      "body": "Found via search.",
+      "state": "open",
+      "html_url": "https://github.com/owner/repo/issues/10",
+      "labels": [{ "name": "review" }],
+      "assignees": [],
+      "type": null,
+      "pull_request": null,
+      "created_at": "2026-02-01T00:00:00Z",
+      "updated_at": "2026-02-01T00:00:00Z"
+    }
+  ]
+}


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Feat

**Intent:** Add a GitHub Issues tracker adapter so teams managing work in GitHub Issues can use Sortie without migrating to a separate issue tracker. This is the second production tracker adapter and validates the adapter extensibility model.

**Related Issues:** #218

### 🧭 Reviewer Guide

**Complexity:** High

#### Entry Point

Start with `internal/tracker/github/github.go` - it contains the `GitHubAdapter` struct, constructor with validation, all eight `domain.TrackerAdapter` interface methods, and the `init()` registration. From there, follow into `client.go` for the HTTP layer, `normalize.go` for response types and field mapping, and `state.go` for label-based state derivation.

#### Sensitive Areas

- `internal/tracker/github/client.go`: HTTP client with 30 s timeout, GitHub 403 disambiguation (rate-limited vs permission-denied), `X-GitHub-Api-Version` header on every request, `parseLinkNext` pagination, and context cancellation propagation
- `internal/tracker/github/github.go`: `TransitionIssue` makes up to three sequential label/state API calls that are not atomic - partial-failure retry convergence logic is critical; target state is validated against configured active/terminal states before any mutation; new state label is applied using the lowercased canonical form for idempotency; issue IDs are path-escaped in all URL constructions; config slices are copied before lowercasing to avoid mutating caller data
- `internal/tracker/github/github.go`: `fetchClosedIssuesByLabel` quotes terminal state labels in the GitHub search query to handle labels containing spaces or special characters
- `internal/tracker/github/state.go`: `extractState` determines Sortie state from GitHub labels; both `ID` and `Identifier` map to issue number (not global ID) - deviation from Jira adapter intentional and documented in the spec

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes
- **Migrations/State:** No migrations or state changes

<!-- START COPILOT CODING AGENT TIPS -->
---

⚡ Quickly spin up Copilot coding agent tasks from anywhere on your macOS or Windows machine with [Raycast](https://gh.io/cca-raycast-docs).
