### PR TITLE
test(orchestrator): add GitHub E2E full dispatch cycle integration test

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -167,17 +167,16 @@ jobs:
       SORTIE_GITHUB_TOKEN: ${{ secrets.SORTIE_GITHUB_TOKEN }}
       SORTIE_GITHUB_PROJECT: sortie-ai/sortie-test
     steps:
-      - name: Verify GitHub secrets are configured
+      - name: Verify GitHub token secret is configured
         run: |
           missing=()
-          [ -z "$SORTIE_GITHUB_TOKEN" ]   && missing+=("SORTIE_GITHUB_TOKEN")
-          [ -z "$SORTIE_GITHUB_PROJECT" ] && missing+=("SORTIE_GITHUB_PROJECT")
+          [ -z "$SORTIE_GITHUB_TOKEN" ] && missing+=("SORTIE_GITHUB_TOKEN")
           if [ ${#missing[@]} -ne 0 ]; then
             echo "::error::Missing required secrets: ${missing[*]}"
-            echo "Configure these in Settings → Secrets and variables → Actions"
+            echo "Configure SORTIE_GITHUB_TOKEN in Settings → Secrets and variables → Actions"
             exit 1
           fi
-          echo "✓ All GitHub E2E secrets are present"
+          echo "✓ GitHub E2E token secret is present"
 
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ Spec-first, agent-developed orchestration service. The architecture document is 
 - **Symphony is prior art, not a template.** Sortie derives from OpenAI Symphony but diverges intentionally (Go instead of Elixir, SQLite persistence, adapter interfaces). Do not copy Symphony patterns or Elixir idioms.
 - **Workspace safety invariants are security boundaries.** Path containment under workspace root, sanitized workspace keys (`[A-Za-z0-9._-]` only), and cwd validation before agent launch are mandatory — not suggestions. See architecture Section 9.5.
 - **Generic naming in core code.** Use `agent_*`, `tracker_*`, `session_*` in orchestrator core. Never `jira_*`, `claude_*`, `codex_*` outside their adapter packages.
-- **Integration tests are env-gated.** `SORTIE_JIRA_TEST=1` for Jira, `SORTIE_GITHUB_TEST=1` for GitHub, `SORTIE_CLAUDE_TEST=1` for Claude Code. Without these vars, integration tests must skip cleanly — never fail.
+- **Integration tests are env-gated.** `SORTIE_JIRA_TEST=1` for Jira, `SORTIE_GITHUB_TEST=1` for GitHub adapter integration tests, `SORTIE_GITHUB_E2E=1` for GitHub E2E orchestrator tests (also requires `SORTIE_GITHUB_TOKEN` and `SORTIE_GITHUB_PROJECT`), `SORTIE_CLAUDE_TEST=1` for Claude Code. Without these vars, integration tests must skip cleanly — never fail.
 - **SQLite library is `modernc.org/sqlite` only.** Never `mattn/go-sqlite3` — CGo breaks the single-binary zero-dependency deployment model.
 
 ## Boundaries

--- a/internal/orchestrator/github_integration_test.go
+++ b/internal/orchestrator/github_integration_test.go
@@ -56,10 +56,11 @@ func skipUnlessGitHubE2E(t *testing.T) {
 // against the GitHub REST API. It is not used during the test itself;
 // the orchestrator uses the real adapter.
 type githubAPIClient struct {
-	token   string
-	owner   string
-	repo    string
-	baseURL string
+	token      string
+	owner      string
+	repo       string
+	baseURL    string
+	httpClient *http.Client
 }
 
 func newGitHubAPIClient(t *testing.T) *githubAPIClient {
@@ -70,10 +71,11 @@ func newGitHubAPIClient(t *testing.T) *githubAPIClient {
 		t.Fatalf("SORTIE_GITHUB_PROJECT must be owner/repo, got %q", project)
 	}
 	return &githubAPIClient{
-		token:   os.Getenv("SORTIE_GITHUB_TOKEN"),
-		owner:   parts[0],
-		repo:    parts[1],
-		baseURL: "https://api.github.com",
+		token:      os.Getenv("SORTIE_GITHUB_TOKEN"),
+		owner:      parts[0],
+		repo:       parts[1],
+		baseURL:    "https://api.github.com",
+		httpClient: &http.Client{Timeout: 30 * time.Second},
 	}
 }
 
@@ -113,7 +115,7 @@ func (c *githubAPIClient) doRequest(t *testing.T, method, path string, body any)
 		req.Header.Set("Content-Type", "application/json")
 	}
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		t.Fatalf("%s %s: %v", method, path, err)
 	}
@@ -162,7 +164,8 @@ func (c *githubAPIClient) fetchIssue(t *testing.T, number string) githubIssueRes
 	return issue
 }
 
-// restoreIssueState reopens an issue and resets it to the backlog label.
+// restoreIssueState removes state labels added by the orchestrator and closes
+// the issue as not_planned, leaving the test repository clean.
 func (c *githubAPIClient) restoreIssueState(t *testing.T, number string) {
 	t.Helper()
 	path := fmt.Sprintf("/repos/%s/%s/issues/%s", c.owner, c.repo, number)
@@ -178,7 +181,7 @@ func (c *githubAPIClient) restoreIssueState(t *testing.T, number string) {
 		req.Header.Set("Authorization", "Bearer "+c.token)
 		req.Header.Set("Accept", "application/vnd.github+json")
 		req.Header.Set("X-GitHub-Api-Version", "2026-03-10")
-		resp, err := http.DefaultClient.Do(req)
+		resp, err := c.httpClient.Do(req)
 		if err == nil {
 			resp.Body.Close() //nolint:errcheck // cleanup helper
 		}
@@ -220,6 +223,9 @@ func TestGitHubIntegration_FullDispatchCycle(t *testing.T) {
 		"project":         os.Getenv("SORTIE_GITHUB_PROJECT"),
 		"active_states":   []string{"backlog", "in-progress", "review"},
 		"terminal_states": []string{"done", "wontfix"},
+		// Scope fetches to this test's issue only so concurrent test runs
+		// cannot dispatch one another's issues.
+		"query_filter": issueTitle + " in:title",
 	})
 	if err != nil {
 		t.Fatalf("NewGitHubAdapter: %v", err)


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Feat

**Intent:** Adds an orchestrator-level end-to-end integration test that exercises the full poll → dispatch → handoff cycle using the real GitHub tracker adapter, mock agent, real SQLite store, and real workspace manager. Closes the gap between unit/stub tests and production behaviour.

**Related Issues:** #301

### 🧭 Reviewer Guide

**Complexity:** Medium

#### Entry Point

`internal/orchestrator/github_integration_test.go` — the new test file. `TestGitHubIntegration_FullDispatchCycle` creates a live GitHub issue, runs the orchestrator until the issue is transitioned to `done` (closed), then verifies labels, SQLite run history, and workspace directory creation.

#### Sensitive Areas

- `internal/orchestrator/github_integration_test.go`: Uses `http.DefaultClient` directly for test setup/teardown GitHub API calls (issue create, label cleanup). The token is sourced from env only; no credentials are hard-coded.
- `.github/workflows/release.yml`: Adds `test-e2e-github` as a release gate job using existing `SORTIE_GITHUB_TOKEN` and `SORTIE_GITHUB_PROJECT` secrets. The project is hard-coded to `sortie-ai/sortie-test` (the dedicated test repo) rather than read from a secret, since it is not sensitive.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes
- **Migrations/State:** No migrations or state changes