### PR TITLE
test(orchestrator): extend SoftStop exit with edge-case sub-tests and fix godoc

### DIFF
--- a/internal/orchestrator/exit_test.go
+++ b/internal/orchestrator/exit_test.go
@@ -1078,9 +1078,9 @@ func TestHandleWorkerExit_CleanupFailureNonFatal(t *testing.T) {
 	}
 }
 
-// PendingCleanup uses the actual workspace path from the worker
-// result, not a path reconstructed from config. This prevents orphaned
-// workspaces when workspace.root changes at runtime via dynamic config reload.
+// TestHandleWorkerExit_PendingCleanupUsesActualPath verifies that workspace
+// cleanup uses the path recorded by the worker, not a path recomputed from the
+// current config, preventing orphaned workspaces after a live config reload.
 func TestHandleWorkerExit_PendingCleanupUsesActualPath(t *testing.T) {
 	t.Parallel()
 
@@ -2351,6 +2351,92 @@ func TestHandleWorkerExit_SoftStop(t *testing.T) {
 		}
 		if strings.Contains(text, "re-queuing") {
 			t.Errorf("soft-stop comment should not contain %q\ngot: %q", "re-queuing", text)
+		}
+	})
+
+	// CancelRetry removes a pre-existing RetryAttempts entry when soft-stop fires,
+	// even when a retry was pre-scheduled (e.g. from a stall-timeout reschedule)
+	// before the agent exited.
+	t.Run("cancels_preexisting_retry_entry", func(t *testing.T) {
+		t.Parallel()
+
+		store := &mockExitStore{}
+		state := exitState(t, "SS-6", nil)
+		// Seed a pre-existing retry entry, simulating a stall-timeout
+		// reschedule that arrived before the worker soft-stop result.
+		preexisting := &RetryEntry{
+			IssueID:    "SS-6",
+			Identifier: "SS-6-ident",
+			Attempt:    2,
+			// Use a long-lived timer so it does not fire during the test.
+			TimerHandle: time.AfterFunc(1*time.Hour, func() {}),
+		}
+		state.RetryAttempts["SS-6"] = preexisting
+		params := defaultExitParams(t, store)
+		params.ActiveStates = []string{"In Progress"}
+		state.Running["SS-6"].Issue.State = "In Progress"
+
+		HandleWorkerExit(state, WorkerResult{
+			IssueID:        "SS-6",
+			Identifier:     "SS-6-ident",
+			ExitKind:       WorkerExitNormal,
+			AgentAdapter:   "mock",
+			SoftStop:       true,
+			SoftStopReason: "blocked",
+		}, params)
+
+		// CancelRetry must have removed the pre-existing entry.
+		if _, ok := state.RetryAttempts["SS-6"]; ok {
+			t.Error("pre-existing RetryAttempts entry not removed by CancelRetry on soft-stop")
+		}
+
+		// Claim released and no new retry entry persisted.
+		if _, ok := state.Claimed["SS-6"]; ok {
+			t.Error("claim preserved after soft-stop with pre-existing retry, want released")
+		}
+		if len(store.retryEntries) != 0 {
+			t.Errorf("SaveRetryEntry called %d times, want 0", len(store.retryEntries))
+		}
+	})
+
+	// SoftStop is checked before the handoff branch in the inner switch, so a
+	// configured HandoffState must not trigger a tracker transition when SoftStop
+	// is true.
+	t.Run("handoff_skipped_when_soft_stop", func(t *testing.T) {
+		t.Parallel()
+
+		store := &mockExitStore{}
+		tracker := &mockTrackerAdapter{}
+		state := exitState(t, "SS-7", nil)
+		state.Running["SS-7"].Issue.State = "In Progress"
+		params := defaultExitParams(t, store)
+		params.ActiveStates = []string{"In Progress"}
+		params.HandoffState = "In Review"
+		params.TrackerAdapter = tracker
+
+		HandleWorkerExit(state, WorkerResult{
+			IssueID:        "SS-7",
+			Identifier:     "SS-7-ident",
+			ExitKind:       WorkerExitNormal,
+			AgentAdapter:   "mock",
+			SoftStop:       true,
+			SoftStopReason: "blocked",
+		}, params)
+
+		// Handoff must not have been attempted.
+		if len(tracker.transitionCalls) != 0 {
+			t.Errorf("TransitionIssue called %d times, want 0 (handoff must be skipped when SoftStop is true)",
+				len(tracker.transitionCalls))
+		}
+
+		// Claim released.
+		if _, ok := state.Claimed["SS-7"]; ok {
+			t.Error("claim preserved after soft-stop, want released")
+		}
+
+		// No retry scheduled.
+		if _, ok := state.RetryAttempts["SS-7"]; ok {
+			t.Error("retry scheduled after soft-stop with handoff configured, want suppressed")
 		}
 	})
 }

--- a/internal/orchestrator/exit_test.go
+++ b/internal/orchestrator/exit_test.go
@@ -2390,6 +2390,13 @@ func TestHandleWorkerExit_SoftStop(t *testing.T) {
 			t.Error("pre-existing RetryAttempts entry not removed by CancelRetry on soft-stop")
 		}
 
+		// CancelRetry must have stopped the timer, not only deleted the map entry.
+		// Stop() returns false when the timer was already stopped; true means it
+		// was still live — a bug where CancelRetry skipped the Stop() call.
+		if preexisting.TimerHandle.Stop() {
+			t.Error("timer was not stopped by CancelRetry: Stop() returned true (timer was still live)")
+		}
+
 		// Claim released and no new retry entry persisted.
 		if _, ok := state.Claimed["SS-6"]; ok {
 			t.Error("claim preserved after soft-stop with pre-existing retry, want released")


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Test

**Intent:** Adds two edge-case sub-tests to `TestHandleWorkerExit_SoftStop` that strengthen isolation of the soft-stop contract, and fixes a godoc comment on a nearby test function to conform to project documentation guidelines.

**Related Issues:** #232

### 🧭 Reviewer Guide

**Complexity:** Low

#### Entry Point

`internal/orchestrator/exit_test.go` - the only changed file. All changes are within the `TestHandleWorkerExit_SoftStop` sub-test group and an adjacent godoc comment.

#### Sensitive Areas

- `internal/orchestrator/exit_test.go`: The two new sub-tests use a live `time.AfterFunc` timer (stopped by `CancelRetry`) and a mock tracker adapter. Both patterns are already established in the file.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes
- **Migrations/State:** No migrations or state changes