### PR TITLE
feat(tool): add sortie_status MCP tool for session runtime metadata

### DIFF
--- a/.github/skills/managing-github-issues/SKILL.md
+++ b/.github/skills/managing-github-issues/SKILL.md
@@ -67,11 +67,15 @@ added or renamed between sessions.
 
 ## Milestone conventions
 
-Every issue must belong to a milestone — it is the primary organizational
-axis. The user may refer to milestones by shorthand ("M10", "milestone 10").
-Match the shorthand against the full titles from the taxonomy output.
+Milestones are the primary organizational axis. The user may refer to
+milestones by shorthand ("M10", "milestone 10"). Match the shorthand against
+the full titles from the taxonomy output.
 
-If the user omits the milestone, ask. Do not guess.
+If the user specifies a milestone, use the exact full title from taxonomy.
+If the user omits the milestone, try to pick the best-fitting open milestone
+based on the issue's theme. If no milestone fits well, create the issue
+**without** a milestone — omit `--milestone` entirely. Do not block creation
+or ask the user to pick one.
 
 ## Before creating an issue
 
@@ -311,7 +315,7 @@ Before executing `gh issue create`, verify:
 - [ ] Title: imperative, under 80 chars, no trailing period
 - [ ] Issue type set via GraphQL `updateIssue` with `node_id` from taxonomy
 - [ ] At least one `area:` label from taxonomy
-- [ ] Milestone set using full title from taxonomy
+- [ ] Milestone set using full title from taxonomy, or omitted if no milestone fits
 - [ ] Body matches the template for its issue type
 - [ ] Verification criteria present and testable
 - [ ] No private information (usernames, keys, internal URLs)
@@ -324,7 +328,7 @@ Before executing `gh issue create`, verify:
 | Error | Recovery |
 |---|---|
 | Issue type not found | Re-run taxonomy script; use exact `node_id` from output |
-| Milestone not found | Re-run taxonomy script; use exact title from output |
+| Milestone not found | Re-run taxonomy script; if still no match, create issue without `--milestone` |
 | Label not found | Re-run taxonomy script; label may have been renamed |
 | Project not found | `gh project list --owner sortie-ai` to verify name |
 | HTTP 403 | `gh auth refresh -s project` to add project scope |

--- a/cmd/sortie/mcpserver.go
+++ b/cmd/sortie/mcpserver.go
@@ -15,6 +15,7 @@ import (
 	"github.com/sortie-ai/sortie/internal/logging"
 	"github.com/sortie-ai/sortie/internal/registry"
 	"github.com/sortie-ai/sortie/internal/tool/mcpserver"
+	"github.com/sortie-ai/sortie/internal/tool/status"
 	"github.com/sortie-ai/sortie/internal/tool/trackerapi"
 	"github.com/sortie-ai/sortie/internal/workflow"
 )
@@ -98,6 +99,9 @@ func runMCPServer(ctx context.Context, args []string, stdout io.Writer, stderr i
 	toolRegistry := domain.NewToolRegistry()
 	if trackerAdapter != nil && cfg.Tracker.Project != "" {
 		toolRegistry.Register(trackerapi.New(trackerAdapter, cfg.Tracker.Project))
+	}
+	if workspacePath := os.Getenv("SORTIE_WORKSPACE"); workspacePath != "" {
+		toolRegistry.Register(status.New(workspacePath))
 	}
 
 	srv := mcpserver.NewServer(toolRegistry, os.Stdin, stdout, logger, Version)

--- a/cmd/sortie/mcpserver_test.go
+++ b/cmd/sortie/mcpserver_test.go
@@ -3,8 +3,17 @@ package main
 import (
 	"bytes"
 	"context"
+	"encoding/json"
+	"log/slog"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/sortie-ai/sortie/internal/domain"
+	"github.com/sortie-ai/sortie/internal/tool/mcpserver"
+	"github.com/sortie-ai/sortie/internal/tool/status"
 )
 
 func TestRunMCPServer_Help_ReturnsZero(t *testing.T) {
@@ -36,5 +45,143 @@ func TestRunMCPServer_InvalidWorkflowPath_ReturnsOne(t *testing.T) {
 	code := runMCPServer(context.Background(), []string{"--workflow", "/nonexistent/WORKFLOW.md"}, &stdout, &stderr)
 	if code != 1 {
 		t.Errorf("runMCPServer(nonexistent path) = %d, want 1", code)
+	}
+}
+
+// writeMCPStateFile writes a state.json file to <dir>/.sortie/ for use in
+// MCP server smoke tests.
+func writeMCPStateFile(t *testing.T, dir string, data map[string]any) {
+	t.Helper()
+	dotSortie := filepath.Join(dir, ".sortie")
+	if err := os.MkdirAll(dotSortie, 0o750); err != nil {
+		t.Fatalf("MkdirAll(%q): %v", dotSortie, err)
+	}
+	b, err := json.Marshal(data)
+	if err != nil {
+		t.Fatalf("json.Marshal state: %v", err)
+	}
+	dst := filepath.Join(dotSortie, "state.json")
+	if err := os.WriteFile(dst, b, 0o600); err != nil {
+		t.Fatalf("WriteFile(%q): %v", dst, err)
+	}
+}
+
+// buildMCPRequest constructs a newline-terminated JSON-RPC 2.0 request string.
+func buildMCPRequest(t *testing.T, method string, id any, params any) string {
+	t.Helper()
+	type req struct {
+		JSONRPC string `json:"jsonrpc"`
+		ID      any    `json:"id"`
+		Method  string `json:"method"`
+		Params  any    `json:"params,omitempty"`
+	}
+	b, err := json.Marshal(req{JSONRPC: "2.0", ID: id, Method: method, Params: params})
+	if err != nil {
+		t.Fatalf("buildMCPRequest(%q): %v", method, err)
+	}
+	return string(b) + "\n"
+}
+
+// parseMCPResponses splits newline-delimited JSON into a slice of maps.
+func parseMCPResponses(t *testing.T, data []byte) []map[string]any {
+	t.Helper()
+	var results []map[string]any
+	for _, line := range bytes.Split(data, []byte("\n")) {
+		line = bytes.TrimSpace(line)
+		if len(line) == 0 {
+			continue
+		}
+		var m map[string]any
+		if err := json.Unmarshal(line, &m); err != nil {
+			t.Fatalf("parseMCPResponses: unmarshal %q: %v", line, err)
+		}
+		results = append(results, m)
+	}
+	return results
+}
+
+func TestMCPServer_StatusTool_Dispatch(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	writeMCPStateFile(t, dir, map[string]any{
+		"turn_number":       7,
+		"max_turns":         10,
+		"attempt":           nil,
+		"started_at":        time.Now().UTC().Format(time.RFC3339Nano),
+		"input_tokens":      int64(5000),
+		"output_tokens":     int64(1200),
+		"total_tokens":      int64(6200),
+		"cache_read_tokens": int64(800),
+	})
+
+	reg := domain.NewToolRegistry()
+	reg.Register(status.New(dir))
+
+	input := buildMCPRequest(t, "tools/call", 1, map[string]any{
+		"name":      "sortie_status",
+		"arguments": map[string]any{},
+	})
+
+	var outBuf bytes.Buffer
+	logger := slog.New(slog.DiscardHandler)
+	srv := mcpserver.NewServer(reg, strings.NewReader(input), &outBuf, logger, "test")
+	if err := srv.Serve(context.Background()); err != nil {
+		t.Fatalf("Serve: %v", err)
+	}
+
+	resps := parseMCPResponses(t, outBuf.Bytes())
+	if len(resps) != 1 {
+		t.Fatalf("response count = %d, want 1", len(resps))
+	}
+	resp := resps[0]
+
+	if resp["error"] != nil {
+		t.Fatalf("JSON-RPC error: %v", resp["error"])
+	}
+
+	result, ok := resp["result"].(map[string]any)
+	if !ok {
+		t.Fatalf("result is not an object: %v", resp["result"])
+	}
+	content, ok := result["content"].([]any)
+	if !ok || len(content) == 0 {
+		t.Fatalf("content = %v, want non-empty array", result["content"])
+	}
+	text, ok := content[0].(map[string]any)["text"].(string)
+	if !ok {
+		t.Fatalf("content[0].text is not a string: %v", content[0])
+	}
+
+	var statusResp map[string]any
+	if err := json.Unmarshal([]byte(text), &statusResp); err != nil {
+		t.Fatalf("unmarshal status response %q: %v", text, err)
+	}
+
+	if got, ok := statusResp["turn_number"].(float64); !ok || int(got) != 7 {
+		t.Errorf("turn_number = %v, want 7", statusResp["turn_number"])
+	}
+	if got, ok := statusResp["max_turns"].(float64); !ok || int(got) != 10 {
+		t.Errorf("max_turns = %v, want 10", statusResp["max_turns"])
+	}
+	if got, ok := statusResp["turns_remaining"].(float64); !ok || int(got) != 3 {
+		t.Errorf("turns_remaining = %v, want 3", statusResp["turns_remaining"])
+	}
+
+	tokens, ok := statusResp["tokens"].(map[string]any)
+	if !ok {
+		t.Fatalf("tokens is not an object: %v", statusResp["tokens"])
+	}
+	if got, ok := tokens["input_tokens"].(float64); !ok || got != 5000 {
+		t.Errorf("tokens.input_tokens = %v, want 5000", tokens["input_tokens"])
+	}
+	if got, ok := tokens["output_tokens"].(float64); !ok || got != 1200 {
+		t.Errorf("tokens.output_tokens = %v, want 1200", tokens["output_tokens"])
+	}
+	if got, ok := tokens["total_tokens"].(float64); !ok || got != 6200 {
+		t.Errorf("tokens.total_tokens = %v, want 6200", tokens["total_tokens"])
+	}
+	if got, ok := tokens["cache_read_tokens"].(float64); !ok || got != 800 {
+		t.Errorf("tokens.cache_read_tokens = %v, want 800", tokens["cache_read_tokens"])
 	}
 }

--- a/internal/orchestrator/mcpconfig.go
+++ b/internal/orchestrator/mcpconfig.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 )
 
@@ -30,6 +31,12 @@ type MCPConfigParams struct {
 
 	// SessionID is the agent session identifier (may be empty).
 	SessionID string
+
+	// Attempt is the retry attempt number for this worker session.
+	// Nil on the first run; non-nil (>= 1) on retries and
+	// continuations. When non-nil, written to the env block as
+	// SORTIE_ATTEMPT.
+	Attempt *int
 
 	// OperatorMCPConfigPath is the path to the operator-provided MCP
 	// config file. Empty when no operator config is specified.
@@ -66,6 +73,9 @@ func GenerateMCPConfig(params MCPConfigParams) (string, error) {
 	env["SORTIE_WORKSPACE"] = params.WorkspacePath
 	env["SORTIE_DB_PATH"] = params.DBPath
 	env["SORTIE_SESSION_ID"] = params.SessionID
+	if params.Attempt != nil {
+		env["SORTIE_ATTEMPT"] = strconv.Itoa(*params.Attempt)
+	}
 
 	entry := map[string]any{
 		"type":    "stdio",

--- a/internal/orchestrator/mcpconfig.go
+++ b/internal/orchestrator/mcpconfig.go
@@ -33,9 +33,8 @@ type MCPConfigParams struct {
 	SessionID string
 
 	// Attempt is the retry attempt number for this worker session.
-	// Nil on the first run; non-nil (>= 1) on retries and
-	// continuations. When non-nil, written to the env block as
-	// SORTIE_ATTEMPT.
+	// Nil on the first run; non-nil on retries and continuations.
+	// When non-nil, written to the env block as SORTIE_ATTEMPT.
 	Attempt *int
 
 	// OperatorMCPConfigPath is the path to the operator-provided MCP

--- a/internal/orchestrator/mcpconfig_test.go
+++ b/internal/orchestrator/mcpconfig_test.go
@@ -445,6 +445,57 @@ func TestGenerateMCPConfig(t *testing.T) {
 	})
 }
 
+func TestGenerateMCPConfig_Attempt(t *testing.T) {
+	t.Parallel()
+
+	t.Run("attempt_written_to_env_when_non_nil", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		p := mcpParams(dir)
+		p.Attempt = intPtr(2)
+
+		_, err := GenerateMCPConfig(p)
+		if err != nil {
+			t.Fatalf("GenerateMCPConfig: %v", err)
+		}
+
+		entry := sortieEntry(t, readMCPConfig(t, dir))
+		env, ok := entry["env"].(map[string]any)
+		if !ok {
+			t.Fatalf("env is not an object: %v", entry["env"])
+		}
+
+		if got, ok := env["SORTIE_ATTEMPT"].(string); !ok || got != "2" {
+			t.Errorf("env[%q] = %q, want %q", "SORTIE_ATTEMPT", env["SORTIE_ATTEMPT"], "2")
+		}
+		if len(env) != 6 {
+			t.Errorf("env key count = %d, want 6: %v", len(env), env)
+		}
+	})
+
+	t.Run("attempt_absent_from_env_when_nil", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		p := mcpParams(dir)
+		p.Attempt = nil
+
+		_, err := GenerateMCPConfig(p)
+		if err != nil {
+			t.Fatalf("GenerateMCPConfig: %v", err)
+		}
+
+		entry := sortieEntry(t, readMCPConfig(t, dir))
+		env, ok := entry["env"].(map[string]any)
+		if !ok {
+			t.Fatalf("env is not an object: %v", entry["env"])
+		}
+
+		if _, present := env["SORTIE_ATTEMPT"]; present {
+			t.Errorf("env[%q] = %v, want key absent when Attempt is nil", "SORTIE_ATTEMPT", env["SORTIE_ATTEMPT"])
+		}
+	})
+}
+
 func TestCollectSortieEnv(t *testing.T) {
 	// t.Setenv cannot be used with t.Parallel.
 

--- a/internal/orchestrator/worker.go
+++ b/internal/orchestrator/worker.go
@@ -2,6 +2,7 @@ package orchestrator
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"maps"
@@ -36,6 +37,38 @@ const (
 	// (reconciliation kill, stall timeout, or graceful shutdown).
 	WorkerExitCancelled WorkerExitKind = "cancelled"
 )
+
+type workerState struct {
+	TurnNumber      int    `json:"turn_number"`
+	MaxTurns        int    `json:"max_turns"`
+	Attempt         *int   `json:"attempt"`
+	StartedAt       string `json:"started_at"`
+	InputTokens     int64  `json:"input_tokens"`
+	OutputTokens    int64  `json:"output_tokens"`
+	TotalTokens     int64  `json:"total_tokens"`
+	CacheReadTokens int64  `json:"cache_read_tokens"`
+}
+
+// writeWorkerState atomically writes session runtime state to
+// .sortie/state.json inside the workspace. The write uses a
+// temp-file-plus-rename pattern so readers never observe a partial
+// write. Errors are returned to the caller, which logs and continues.
+func writeWorkerState(workspacePath string, state workerState) error {
+	data, err := json.Marshal(state)
+	if err != nil {
+		return fmt.Errorf("marshal worker state: %w", err)
+	}
+	dir := filepath.Join(workspacePath, ".sortie")
+	tmpPath := filepath.Join(dir, "state.json.tmp")
+	outPath := filepath.Join(dir, "state.json")
+	if err := os.WriteFile(tmpPath, data, 0o600); err != nil {
+		return fmt.Errorf("write worker state temp file: %w", err)
+	}
+	if err := os.Rename(tmpPath, outPath); err != nil {
+		return fmt.Errorf("rename worker state file: %w", err)
+	}
+	return nil
+}
 
 // WorkerResult is the terminal outcome of a single worker attempt,
 // delivered to the orchestrator via [WorkerDeps.OnExit].
@@ -305,6 +338,17 @@ func RunWorkerAttempt(ctx context.Context, issue domain.Issue, attempt *int, dep
 	var session domain.Session
 	var sessionStarted bool
 	var mcpConfigPath string
+	var sessionStartedAt time.Time
+	var (
+		localInputTokens         int64
+		localOutputTokens        int64
+		localTotalTokens         int64
+		localCacheReadTokens     int64
+		localLastInputTokens     int64
+		localLastOutputTokens    int64
+		localLastTotalTokens     int64
+		localLastCacheReadTokens int64
+	)
 
 	defer func() {
 		if r := recover(); r != nil {
@@ -444,6 +488,7 @@ func RunWorkerAttempt(ctx context.Context, issue domain.Issue, attempt *int, dep
 			Identifier:            issue.Identifier,
 			DBPath:                deps.DBPath,
 			SessionID:             "",
+			Attempt:               attempt,
 			OperatorMCPConfigPath: operatorPath,
 			ProcessEnv:            CollectSortieEnv(),
 		})
@@ -512,6 +557,8 @@ func RunWorkerAttempt(ctx context.Context, issue domain.Issue, attempt *int, dep
 	logger = logging.WithSession(logger, session.ID)
 	logger.Info("agent session started")
 
+	sessionStartedAt = time.Now().UTC()
+
 	// Execute turns until the issue leaves an active state or max_turns is reached.
 	maxTurns := cfg.Agent.MaxTurns
 	if maxTurns < 1 {
@@ -521,7 +568,32 @@ func RunWorkerAttempt(ctx context.Context, issue domain.Issue, attempt *int, dep
 	turnNumber := 1
 	activeStates := cfg.Tracker.ActiveStates
 
+	if err := writeWorkerState(wsResult.Path, workerState{
+		TurnNumber: 0,
+		MaxTurns:   maxTurns,
+		Attempt:    attempt,
+		StartedAt:  sessionStartedAt.Format(time.RFC3339Nano),
+	}); err != nil {
+		logger.Warn("failed to write status state file at session start", slog.Any("error", err))
+	}
+
 	for {
+		if err := writeWorkerState(wsResult.Path, workerState{
+			TurnNumber:      turnNumber,
+			MaxTurns:        maxTurns,
+			Attempt:         attempt,
+			StartedAt:       sessionStartedAt.Format(time.RFC3339Nano),
+			InputTokens:     localInputTokens,
+			OutputTokens:    localOutputTokens,
+			TotalTokens:     localTotalTokens,
+			CacheReadTokens: localCacheReadTokens,
+		}); err != nil {
+			logger.Warn("failed to write status state file at turn start",
+				slog.Int("turn_number", turnNumber),
+				slog.Any("error", err),
+			)
+		}
+
 		// Render the prompt template for this turn.
 		issueMap := issue.ToTemplateMap()
 		rendered, err := prompt.BuildTurnPrompt(tmpl, issueMap, attemptInt, turnNumber, maxTurns)
@@ -563,6 +635,33 @@ func RunWorkerAttempt(ctx context.Context, issue domain.Issue, attempt *int, dep
 				// iterates a map that the adapter may still mutate.
 				if event.RateLimits != nil {
 					event.RateLimits = maps.Clone(event.RateLimits)
+				}
+				if event.Type == domain.EventTokenUsage {
+					dIn := max(event.Usage.InputTokens-localLastInputTokens, 0)
+					dOut := max(event.Usage.OutputTokens-localLastOutputTokens, 0)
+					dTot := max(event.Usage.TotalTokens-localLastTotalTokens, 0)
+					dCR := max(event.Usage.CacheReadTokens-localLastCacheReadTokens, 0)
+					localInputTokens += dIn
+					localOutputTokens += dOut
+					localTotalTokens += dTot
+					localCacheReadTokens += dCR
+					localLastInputTokens = max(localLastInputTokens, event.Usage.InputTokens)
+					localLastOutputTokens = max(localLastOutputTokens, event.Usage.OutputTokens)
+					localLastTotalTokens = max(localLastTotalTokens, event.Usage.TotalTokens)
+					localLastCacheReadTokens = max(localLastCacheReadTokens, event.Usage.CacheReadTokens)
+
+					if err := writeWorkerState(wsResult.Path, workerState{
+						TurnNumber:      turnNumber,
+						MaxTurns:        maxTurns,
+						Attempt:         attempt,
+						StartedAt:       sessionStartedAt.Format(time.RFC3339Nano),
+						InputTokens:     localInputTokens,
+						OutputTokens:    localOutputTokens,
+						TotalTokens:     localTotalTokens,
+						CacheReadTokens: localCacheReadTokens,
+					}); err != nil {
+						logger.Warn("failed to write status state file on token event", slog.Any("error", err))
+					}
 				}
 				deps.OnEvent(issue.ID, event)
 			},

--- a/internal/orchestrator/worker.go
+++ b/internal/orchestrator/worker.go
@@ -53,12 +53,27 @@ type workerState struct {
 // .sortie/state.json inside the workspace. The write uses a
 // temp-file-plus-rename pattern so readers never observe a partial
 // write. Errors are returned to the caller, which logs and continues.
+//
+// The .sortie directory is validated with Lstat to reject symlinks;
+// an agent that replaces .sortie with a symlink cannot trick the
+// orchestrator into writing outside the workspace.
 func writeWorkerState(workspacePath string, state workerState) error {
+	dir := filepath.Join(workspacePath, ".sortie")
+	fi, err := os.Lstat(dir)
+	if err != nil {
+		return fmt.Errorf("stat .sortie dir: %w", err)
+	}
+	if fi.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf(".sortie is a symlink, refusing to write state file")
+	}
+	if !fi.IsDir() {
+		return fmt.Errorf(".sortie is not a directory")
+	}
+
 	data, err := json.Marshal(state)
 	if err != nil {
 		return fmt.Errorf("marshal worker state: %w", err)
 	}
-	dir := filepath.Join(workspacePath, ".sortie")
 	tmpPath := filepath.Join(dir, "state.json.tmp")
 	outPath := filepath.Join(dir, "state.json")
 	if err := os.WriteFile(tmpPath, data, 0o600); err != nil {
@@ -568,30 +583,34 @@ func RunWorkerAttempt(ctx context.Context, issue domain.Issue, attempt *int, dep
 	turnNumber := 1
 	activeStates := cfg.Tracker.ActiveStates
 
-	if err := writeWorkerState(wsResult.Path, workerState{
-		TurnNumber: 0,
-		MaxTurns:   maxTurns,
-		Attempt:    attempt,
-		StartedAt:  sessionStartedAt.Format(time.RFC3339Nano),
-	}); err != nil {
-		logger.Warn("failed to write status state file at session start", slog.Any("error", err))
+	if mcpConfigPath != "" {
+		if err := writeWorkerState(wsResult.Path, workerState{
+			TurnNumber: 0,
+			MaxTurns:   maxTurns,
+			Attempt:    attempt,
+			StartedAt:  sessionStartedAt.Format(time.RFC3339Nano),
+		}); err != nil {
+			logger.Warn("failed to write status state file at session start", slog.Any("error", err))
+		}
 	}
 
 	for {
-		if err := writeWorkerState(wsResult.Path, workerState{
-			TurnNumber:      turnNumber,
-			MaxTurns:        maxTurns,
-			Attempt:         attempt,
-			StartedAt:       sessionStartedAt.Format(time.RFC3339Nano),
-			InputTokens:     localInputTokens,
-			OutputTokens:    localOutputTokens,
-			TotalTokens:     localTotalTokens,
-			CacheReadTokens: localCacheReadTokens,
-		}); err != nil {
-			logger.Warn("failed to write status state file at turn start",
-				slog.Int("turn_number", turnNumber),
-				slog.Any("error", err),
-			)
+		if mcpConfigPath != "" {
+			if err := writeWorkerState(wsResult.Path, workerState{
+				TurnNumber:      turnNumber,
+				MaxTurns:        maxTurns,
+				Attempt:         attempt,
+				StartedAt:       sessionStartedAt.Format(time.RFC3339Nano),
+				InputTokens:     localInputTokens,
+				OutputTokens:    localOutputTokens,
+				TotalTokens:     localTotalTokens,
+				CacheReadTokens: localCacheReadTokens,
+			}); err != nil {
+				logger.Warn("failed to write status state file at turn start",
+					slog.Int("turn_number", turnNumber),
+					slog.Any("error", err),
+				)
+			}
 		}
 
 		// Render the prompt template for this turn.
@@ -650,17 +669,19 @@ func RunWorkerAttempt(ctx context.Context, issue domain.Issue, attempt *int, dep
 					localLastTotalTokens = max(localLastTotalTokens, event.Usage.TotalTokens)
 					localLastCacheReadTokens = max(localLastCacheReadTokens, event.Usage.CacheReadTokens)
 
-					if err := writeWorkerState(wsResult.Path, workerState{
-						TurnNumber:      turnNumber,
-						MaxTurns:        maxTurns,
-						Attempt:         attempt,
-						StartedAt:       sessionStartedAt.Format(time.RFC3339Nano),
-						InputTokens:     localInputTokens,
-						OutputTokens:    localOutputTokens,
-						TotalTokens:     localTotalTokens,
-						CacheReadTokens: localCacheReadTokens,
-					}); err != nil {
-						logger.Warn("failed to write status state file on token event", slog.Any("error", err))
+					if mcpConfigPath != "" {
+						if err := writeWorkerState(wsResult.Path, workerState{
+							TurnNumber:      turnNumber,
+							MaxTurns:        maxTurns,
+							Attempt:         attempt,
+							StartedAt:       sessionStartedAt.Format(time.RFC3339Nano),
+							InputTokens:     localInputTokens,
+							OutputTokens:    localOutputTokens,
+							TotalTokens:     localTotalTokens,
+							CacheReadTokens: localCacheReadTokens,
+						}); err != nil {
+							logger.Warn("failed to write status state file on token event", slog.Any("error", err))
+						}
 					}
 				}
 				deps.OnEvent(issue.ID, event)

--- a/internal/tool/status/status.go
+++ b/internal/tool/status/status.go
@@ -1,0 +1,140 @@
+// Package status implements [domain.AgentTool] for the sortie_status tool,
+// which returns live session runtime metadata to agents: current turn number,
+// remaining turns, session duration, and cumulative token usage. It reads
+// from the .sortie/state.json file written by the worker goroutine inside
+// the session workspace.
+package status
+
+import (
+	"context"
+	"encoding/json"
+	"math"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/sortie-ai/sortie/internal/domain"
+)
+
+var _ domain.AgentTool = (*StatusTool)(nil)
+
+var inputSchema = json.RawMessage(`{
+  "type": "object",
+  "properties": {},
+  "additionalProperties": false
+}`)
+
+type stateFile struct {
+	TurnNumber      int    `json:"turn_number"`
+	MaxTurns        int    `json:"max_turns"`
+	Attempt         *int   `json:"attempt"`
+	StartedAt       string `json:"started_at"`
+	InputTokens     int64  `json:"input_tokens"`
+	OutputTokens    int64  `json:"output_tokens"`
+	TotalTokens     int64  `json:"total_tokens"`
+	CacheReadTokens int64  `json:"cache_read_tokens"`
+}
+
+type statusResponse struct {
+	TurnNumber             int     `json:"turn_number"`
+	MaxTurns               int     `json:"max_turns"`
+	TurnsRemaining         int     `json:"turns_remaining"`
+	Attempt                *int    `json:"attempt"`
+	SessionDurationSeconds float64 `json:"session_duration_seconds"`
+	Tokens                 tokens  `json:"tokens"`
+}
+
+type tokens struct {
+	InputTokens     int64 `json:"input_tokens"`
+	OutputTokens    int64 `json:"output_tokens"`
+	TotalTokens     int64 `json:"total_tokens"`
+	CacheReadTokens int64 `json:"cache_read_tokens"`
+}
+
+// StatusTool implements [domain.AgentTool] for the sortie_status tool.
+// Construct via [New]; it is safe for concurrent use after construction.
+type StatusTool struct {
+	stateFilePath string
+}
+
+// New returns a [StatusTool] that reads session state from the
+// .sortie/state.json file inside workspacePath.
+//
+// workspacePath must be an absolute path to the session workspace
+// directory. New panics if workspacePath is empty (programming error).
+func New(workspacePath string) *StatusTool {
+	if workspacePath == "" {
+		panic("status.New: workspacePath must not be empty")
+	}
+	return &StatusTool{
+		stateFilePath: filepath.Join(workspacePath, ".sortie", "state.json"),
+	}
+}
+
+// Name returns "sortie_status".
+func (t *StatusTool) Name() string { return "sortie_status" }
+
+// Description returns a human-readable summary of the tool.
+func (t *StatusTool) Description() string {
+	return "Returns live session runtime metadata: current turn number, " +
+		"remaining turns, session duration, and cumulative token usage."
+}
+
+// InputSchema returns the JSON Schema for sortie_status input.
+// The tool accepts no parameters; the schema is an empty object.
+// The returned slice is a defensive copy.
+func (t *StatusTool) InputSchema() json.RawMessage {
+	out := make(json.RawMessage, len(inputSchema))
+	copy(out, inputSchema)
+	return out
+}
+
+// Execute reads the worker state file and returns the current session
+// metadata as a JSON object.
+//
+// Execute returns a tool-error response when the state file is absent,
+// unreadable, or contains invalid JSON. The Go error return is non-nil
+// only for internal marshal failures.
+func (t *StatusTool) Execute(_ context.Context, _ json.RawMessage) (json.RawMessage, error) {
+	data, err := os.ReadFile(t.stateFilePath)
+	if err != nil {
+		return errorResponse("state file unavailable: " + err.Error())
+	}
+
+	var sf stateFile
+	if err := json.Unmarshal(data, &sf); err != nil {
+		return errorResponse("state file malformed: " + err.Error())
+	}
+
+	startedAt, err := time.Parse(time.RFC3339Nano, sf.StartedAt)
+	if err != nil {
+		return errorResponse("state file has invalid started_at: " + err.Error())
+	}
+
+	turnsRemaining := sf.MaxTurns - sf.TurnNumber
+	if turnsRemaining < 0 {
+		turnsRemaining = 0
+	}
+
+	durationSeconds := math.Round(time.Since(startedAt).Seconds()*1000) / 1000
+
+	resp := statusResponse{
+		TurnNumber:             sf.TurnNumber,
+		MaxTurns:               sf.MaxTurns,
+		TurnsRemaining:         turnsRemaining,
+		Attempt:                sf.Attempt,
+		SessionDurationSeconds: durationSeconds,
+		Tokens: tokens{
+			InputTokens:     sf.InputTokens,
+			OutputTokens:    sf.OutputTokens,
+			TotalTokens:     sf.TotalTokens,
+			CacheReadTokens: sf.CacheReadTokens,
+		},
+	}
+
+	return json.Marshal(resp)
+}
+
+func errorResponse(msg string) (json.RawMessage, error) {
+	return json.Marshal(map[string]string{"error": msg})
+}

--- a/internal/tool/status/status.go
+++ b/internal/tool/status/status.go
@@ -18,6 +18,8 @@ import (
 
 var _ domain.AgentTool = (*StatusTool)(nil)
 
+const maxStateFileBytes = 4096
+
 var inputSchema = json.RawMessage(`{
   "type": "object",
   "properties": {},
@@ -96,6 +98,17 @@ func (t *StatusTool) InputSchema() json.RawMessage {
 // unreadable, or contains invalid JSON. The Go error return is non-nil
 // only for internal marshal failures.
 func (t *StatusTool) Execute(_ context.Context, _ json.RawMessage) (json.RawMessage, error) {
+	fi, err := os.Lstat(t.stateFilePath)
+	if err != nil {
+		return errorResponse("state file unavailable: " + err.Error())
+	}
+	if fi.Mode()&os.ModeSymlink != 0 {
+		return errorResponse("state file is a symlink")
+	}
+	if fi.Size() > maxStateFileBytes {
+		return errorResponse("state file exceeds size limit")
+	}
+
 	data, err := os.ReadFile(t.stateFilePath)
 	if err != nil {
 		return errorResponse("state file unavailable: " + err.Error())

--- a/internal/tool/status/status_test.go
+++ b/internal/tool/status/status_test.go
@@ -1,0 +1,306 @@
+package status
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// writeStateFile creates <dir>/.sortie/state.json containing the JSON
+// encoding of sf. Fails the test immediately on any I/O error.
+func writeStateFile(t *testing.T, dir string, sf stateFile) {
+	t.Helper()
+	dotSortie := filepath.Join(dir, ".sortie")
+	if err := os.MkdirAll(dotSortie, 0o750); err != nil {
+		t.Fatalf("MkdirAll(%q): %v", dotSortie, err)
+	}
+	data, err := json.Marshal(sf)
+	if err != nil {
+		t.Fatalf("json.Marshal stateFile: %v", err)
+	}
+	dst := filepath.Join(dotSortie, "state.json")
+	if err := os.WriteFile(dst, data, 0o600); err != nil {
+		t.Fatalf("WriteFile(%q): %v", dst, err)
+	}
+}
+
+// executeOK calls Execute and fails the test if either the Go error is
+// non-nil or the JSON cannot be parsed. Returns the decoded map.
+func executeOK(t *testing.T, tool *StatusTool) map[string]any {
+	t.Helper()
+	out, err := tool.Execute(context.Background(), json.RawMessage(`{}`))
+	if err != nil {
+		t.Fatalf("Execute: unexpected Go error: %v", err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(out, &m); err != nil {
+		t.Fatalf("Execute: unmarshal response %q: %v", out, err)
+	}
+	return m
+}
+
+func TestStatusTool_Name(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	tool := New(dir)
+	if got := tool.Name(); got != "sortie_status" {
+		t.Errorf("Name() = %q, want %q", got, "sortie_status")
+	}
+}
+
+func TestStatusTool_CorrectTurnAndBudget(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	writeStateFile(t, dir, stateFile{
+		TurnNumber: 3,
+		MaxTurns:   20,
+		Attempt:    nil,
+		StartedAt:  time.Now().UTC().Format(time.RFC3339Nano),
+	})
+
+	tool := New(dir)
+	m := executeOK(t, tool)
+
+	if got, ok := m["turn_number"].(float64); !ok || int(got) != 3 {
+		t.Errorf("turn_number = %v, want 3", m["turn_number"])
+	}
+	if got, ok := m["max_turns"].(float64); !ok || int(got) != 20 {
+		t.Errorf("max_turns = %v, want 20", m["max_turns"])
+	}
+	if got, ok := m["turns_remaining"].(float64); !ok || int(got) != 17 {
+		t.Errorf("turns_remaining = %v, want 17", m["turns_remaining"])
+	}
+
+	// nil Attempt → JSON null: key present but value nil.
+	if attempt, exists := m["attempt"]; !exists {
+		t.Error("attempt key missing from response")
+	} else if attempt != nil {
+		t.Errorf("attempt = %v, want null (nil)", attempt)
+	}
+
+	dur, ok := m["session_duration_seconds"].(float64)
+	if !ok {
+		t.Fatalf("session_duration_seconds is not a float64: %v", m["session_duration_seconds"])
+	}
+	if dur < 0 {
+		t.Errorf("session_duration_seconds = %f, want >= 0", dur)
+	}
+
+	tokens, ok := m["tokens"].(map[string]any)
+	if !ok {
+		t.Fatalf("tokens is not an object: %v", m["tokens"])
+	}
+	if got, _ := tokens["input_tokens"].(float64); got != 0 {
+		t.Errorf("tokens.input_tokens = %v, want 0", tokens["input_tokens"])
+	}
+}
+
+func TestStatusTool_AttemptNullAndInteger(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil_attempt_is_json_null", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		writeStateFile(t, dir, stateFile{
+			TurnNumber: 1,
+			MaxTurns:   10,
+			Attempt:    nil,
+			StartedAt:  time.Now().UTC().Format(time.RFC3339Nano),
+		})
+		m := executeOK(t, New(dir))
+		if attempt, exists := m["attempt"]; !exists {
+			t.Error("attempt key missing, want null")
+		} else if attempt != nil {
+			t.Errorf("attempt = %v, want null", attempt)
+		}
+	})
+
+	t.Run("integer_attempt_is_preserved", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		n := 2
+		writeStateFile(t, dir, stateFile{
+			TurnNumber: 1,
+			MaxTurns:   10,
+			Attempt:    &n,
+			StartedAt:  time.Now().UTC().Format(time.RFC3339Nano),
+		})
+		m := executeOK(t, New(dir))
+		got, ok := m["attempt"].(float64)
+		if !ok {
+			t.Fatalf("attempt = %v (%T), want float64", m["attempt"], m["attempt"])
+		}
+		if int(got) != 2 {
+			t.Errorf("attempt = %v, want 2", got)
+		}
+	})
+}
+
+func TestStatusTool_TokenCounts(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	writeStateFile(t, dir, stateFile{
+		TurnNumber:      5,
+		MaxTurns:        20,
+		StartedAt:       time.Now().UTC().Format(time.RFC3339Nano),
+		InputTokens:     15000,
+		OutputTokens:    3000,
+		TotalTokens:     18000,
+		CacheReadTokens: 2000,
+	})
+
+	tool := New(dir)
+	m := executeOK(t, tool)
+
+	tokens, ok := m["tokens"].(map[string]any)
+	if !ok {
+		t.Fatalf("tokens is not an object: %v", m["tokens"])
+	}
+
+	checks := map[string]float64{
+		"input_tokens":      15000,
+		"output_tokens":     3000,
+		"total_tokens":      18000,
+		"cache_read_tokens": 2000,
+	}
+	for field, want := range checks {
+		got, ok := tokens[field].(float64)
+		if !ok {
+			t.Errorf("tokens.%s = %v (%T), want float64", field, tokens[field], tokens[field])
+			continue
+		}
+		if got != want {
+			t.Errorf("tokens.%s = %v, want %v", field, got, want)
+		}
+	}
+}
+
+func TestStatusTool_TurnsRemainingFloor(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	writeStateFile(t, dir, stateFile{
+		TurnNumber: 21,
+		MaxTurns:   20,
+		StartedAt:  time.Now().UTC().Format(time.RFC3339Nano),
+	})
+
+	tool := New(dir)
+	m := executeOK(t, tool)
+
+	remaining, ok := m["turns_remaining"].(float64)
+	if !ok {
+		t.Fatalf("turns_remaining = %v (%T), want float64", m["turns_remaining"], m["turns_remaining"])
+	}
+	if remaining < 0 {
+		t.Errorf("turns_remaining = %v, want >= 0 (floored at zero)", remaining)
+	}
+	if remaining != 0 {
+		t.Errorf("turns_remaining = %v, want 0 when turn_number > max_turns", remaining)
+	}
+}
+
+func TestStatusTool_MissingStateFile(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	tool := New(dir)
+
+	out, err := tool.Execute(context.Background(), json.RawMessage(`{}`))
+	if err != nil {
+		t.Fatalf("Execute: unexpected Go error: %v", err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(out, &m); err != nil {
+		t.Fatalf("unmarshal response %q: %v", out, err)
+	}
+	if _, hasErr := m["error"]; !hasErr {
+		t.Errorf("response = %v, want 'error' key for missing state file", m)
+	}
+}
+
+func TestStatusTool_MalformedJSON(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	dotSortie := filepath.Join(dir, ".sortie")
+	if err := os.MkdirAll(dotSortie, 0o750); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dotSortie, "state.json"), []byte(`{not valid json`), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	tool := New(dir)
+	out, err := tool.Execute(context.Background(), json.RawMessage(`{}`))
+	if err != nil {
+		t.Fatalf("Execute: unexpected Go error: %v", err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(out, &m); err != nil {
+		t.Fatalf("unmarshal response %q: %v", out, err)
+	}
+	if _, hasErr := m["error"]; !hasErr {
+		t.Errorf("response = %v, want 'error' key for malformed JSON", m)
+	}
+}
+
+func TestStatusTool_EmptyJSONInput(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	writeStateFile(t, dir, stateFile{
+		TurnNumber: 1,
+		MaxTurns:   5,
+		StartedAt:  time.Now().UTC().Format(time.RFC3339Nano),
+	})
+
+	tool := New(dir)
+	out, err := tool.Execute(context.Background(), json.RawMessage(`{}`))
+	if err != nil {
+		t.Fatalf("Execute({}): unexpected Go error: %v", err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(out, &m); err != nil {
+		t.Fatalf("unmarshal response %q: %v", out, err)
+	}
+	if _, hasErr := m["error"]; hasErr {
+		t.Errorf("response = %v, want no 'error' key for empty JSON input", m)
+	}
+	if _, ok := m["turn_number"]; !ok {
+		t.Error("turn_number missing from success response")
+	}
+}
+
+func TestStatusTool_NullInput(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	writeStateFile(t, dir, stateFile{
+		TurnNumber: 1,
+		MaxTurns:   5,
+		StartedAt:  time.Now().UTC().Format(time.RFC3339Nano),
+	})
+
+	tool := New(dir)
+	out, err := tool.Execute(context.Background(), json.RawMessage(`null`))
+	if err != nil {
+		t.Fatalf("Execute(null): unexpected Go error: %v", err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(out, &m); err != nil {
+		t.Fatalf("unmarshal response %q: %v", out, err)
+	}
+	if _, hasErr := m["error"]; hasErr {
+		t.Errorf("response = %v, want no 'error' key for null input", m)
+	}
+	if _, ok := m["turn_number"]; !ok {
+		t.Error("turn_number missing from success response")
+	}
+}


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Feat

**Intent:** Agents inside Sortie sessions have no way to query their own orchestration context. This adds `sortie_status`, a read-only Tier 1 MCP tool that returns current turn number, remaining turns, session duration, and cumulative token usage — all sourced from a worker-written file, with no external calls or SQLite queries.

**Related Issues:** #226

### 🧭 Reviewer Guide

**Complexity:** Medium

#### Entry Point

`internal/tool/status/status.go` — the new `StatusTool` implementing `domain.AgentTool`. Its `Execute` method validates the state file (symlink rejection, 4 KiB size cap) before reading `.sortie/state.json`, unmarshals the worker state, and returns a JSON object. This is the simplest path through the feature.

The companion write path lives in `internal/orchestrator/worker.go`: `writeWorkerState` (atomic temp-file-plus-rename helper with symlink rejection on the `.sortie` directory) and the three call sites — session-start sentinel, turn-start write, and mid-turn write inside the `OnEvent` relay closure on `EventTokenUsage` events. All three call sites are guarded by `mcpConfigPath != ""` so no writes occur when MCP is not enabled.

#### Sensitive Areas

- `internal/orchestrator/worker.go`: The `OnEvent` closure captures and mutates eight goroutine-local token accumulator variables. All reads and writes occur on the single worker goroutine (inside `RunTurn`, which blocks it), so no mutex is required — but the no-mutex assumption depends on the closure not escaping to another goroutine. All `writeWorkerState` calls are guarded by `mcpConfigPath != ""` to avoid log spam and unnecessary I/O when `.sortie/` does not exist.
- `internal/orchestrator/mcpconfig.go`: `SORTIE_ATTEMPT` is conditionally written to the sidecar env block. Nil `Attempt` means first run and the key must be absent — not zero — from the generated `mcp.json`. The `Attempt` field doc no longer claims `>= 1` since the value is not validated before writing.
- `internal/tool/status/status.go`: `Execute` uses `os.Lstat` to reject symlinks and enforces a 4 KiB size cap before reading `state.json`, preventing symlink escape and large allocations on the MCP sidecar read path.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes. `MCPConfigParams.Attempt` is a new optional field (nil on all existing call sites).
- **Migrations/State:** No database migrations. The `.sortie/state.json` file is ephemeral per-session and gitignored.