### PR TITLE
feat(tool): add workspace_history MCP tool

### DIFF
--- a/cmd/sortie/mcpserver.go
+++ b/cmd/sortie/mcpserver.go
@@ -13,7 +13,9 @@ import (
 	"github.com/sortie-ai/sortie/internal/config"
 	"github.com/sortie-ai/sortie/internal/domain"
 	"github.com/sortie-ai/sortie/internal/logging"
+	"github.com/sortie-ai/sortie/internal/persistence"
 	"github.com/sortie-ai/sortie/internal/registry"
+	"github.com/sortie-ai/sortie/internal/tool/history"
 	"github.com/sortie-ai/sortie/internal/tool/mcpserver"
 	"github.com/sortie-ai/sortie/internal/tool/status"
 	"github.com/sortie-ai/sortie/internal/tool/trackerapi"
@@ -103,6 +105,19 @@ func runMCPServer(ctx context.Context, args []string, stdout io.Writer, stderr i
 	if workspacePath := os.Getenv("SORTIE_WORKSPACE"); workspacePath != "" {
 		toolRegistry.Register(status.New(workspacePath))
 	}
+	if dbPath := os.Getenv("SORTIE_DB_PATH"); dbPath != "" {
+		if issueID := os.Getenv("SORTIE_ISSUE_ID"); issueID != "" {
+			store, storeErr := persistence.OpenReadOnly(ctx, dbPath)
+			if storeErr != nil {
+				logger.Warn("failed to open read-only db for workspace_history",
+					slog.String("db_path", dbPath),
+					slog.Any("error", storeErr))
+			} else {
+				defer store.Close() //nolint:errcheck // best-effort cleanup at shutdown
+				toolRegistry.Register(history.New(buildHistoryQuery(store), issueID))
+			}
+		}
+	}
 
 	srv := mcpserver.NewServer(toolRegistry, os.Stdin, stdout, logger, Version)
 	if err := srv.Serve(ctx); err != nil {
@@ -111,4 +126,28 @@ func runMCPServer(ctx context.Context, args []string, stdout io.Writer, stderr i
 	}
 
 	return 0
+}
+
+func buildHistoryQuery(store *persistence.Store) history.QueryFunc {
+	return func(ctx context.Context, issueID string, limit int) ([]history.Entry, error) {
+		rows, err := store.QueryRunHistoryByIssue(ctx, issueID)
+		if err != nil {
+			return nil, err
+		}
+		if limit > 0 && len(rows) > limit {
+			rows = rows[:limit]
+		}
+		entries := make([]history.Entry, len(rows))
+		for i, r := range rows {
+			entries[i] = history.Entry{
+				Attempt:      r.Attempt,
+				AgentAdapter: r.AgentAdapter,
+				StartedAt:    r.StartedAt,
+				CompletedAt:  r.CompletedAt,
+				Status:       r.Status,
+				Error:        r.Error,
+			}
+		}
+		return entries, nil
+	}
 }

--- a/internal/persistence/store.go
+++ b/internal/persistence/store.go
@@ -54,6 +54,31 @@ func Open(ctx context.Context, path string) (*Store, error) {
 	return &Store{db: db}, nil
 }
 
+// OpenReadOnly opens an existing SQLite database at the given path in
+// read-only mode by appending ?mode=ro to the DSN. It does not set WAL
+// journal mode or run migrations — the database is assumed to be already
+// initialized by the orchestrator's [Open] + [Store.Migrate] sequence.
+// Write operations on the returned [Store] will fail at the driver level
+// with an SQLITE_READONLY error.
+//
+// The caller must call [Store.Close] when the store is no longer needed.
+func OpenReadOnly(ctx context.Context, path string) (*Store, error) {
+	dsn := "file:" + path + "?mode=ro"
+	db, err := sql.Open("sqlite", dsn)
+	if err != nil {
+		return nil, fmt.Errorf("open sqlite read-only %q: %w", path, err)
+	}
+
+	db.SetMaxOpenConns(1)
+
+	if err := db.PingContext(ctx); err != nil {
+		db.Close() //nolint:errcheck,gosec // best-effort cleanup on open failure
+		return nil, fmt.Errorf("ping sqlite read-only %q: %w", path, err)
+	}
+
+	return &Store{db: db}, nil
+}
+
 // Close closes the underlying database connection.
 func (s *Store) Close() error {
 	return s.db.Close()

--- a/internal/persistence/store_test.go
+++ b/internal/persistence/store_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -2116,5 +2117,114 @@ func TestUpsertAggregateMetrics_CacheReadTokensUpdate(t *testing.T) {
 	}
 	if got.CacheReadTokens != 9999 {
 		t.Errorf("CacheReadTokens = %d, want 9999", got.CacheReadTokens)
+	}
+}
+
+func TestOpenReadOnly(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+
+	// Create and migrate a file-backed database via the standard Open path.
+	s, err := Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("Open(%q): %v", dbPath, err)
+	}
+	if err := s.Migrate(ctx); err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+	closeStore(t, s)
+
+	// Re-open in read-only mode and verify the connection is alive.
+	ro, err := OpenReadOnly(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("OpenReadOnly(%q): %v", dbPath, err)
+	}
+	defer closeStore(t, ro)
+
+	if err := ro.Ping(ctx); err != nil {
+		t.Fatalf("Ping on read-only store: %v", err)
+	}
+}
+
+func TestOpenReadOnly_RejectWrite(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+
+	// Create and migrate a file-backed database.
+	s, err := Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("Open(%q): %v", dbPath, err)
+	}
+	if err := s.Migrate(ctx); err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+	closeStore(t, s)
+
+	// Re-open in read-only mode.
+	ro, err := OpenReadOnly(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("OpenReadOnly(%q): %v", dbPath, err)
+	}
+	defer closeStore(t, ro)
+
+	// Any mutation must be rejected by the driver with an SQLITE_READONLY error.
+	_, writeErr := ro.db.ExecContext(ctx,
+		`INSERT INTO run_history
+			(issue_id, identifier, attempt, agent_adapter, workspace, started_at, completed_at, status)
+		VALUES ('x', 'x', 1, 'mock', '/ws', '2026-01-01T00:00:00Z', '2026-01-01T00:00:01Z', 'succeeded')`)
+	if writeErr == nil {
+		t.Fatal("ExecContext on read-only store succeeded, want SQLITE_READONLY error")
+	}
+	if !strings.Contains(strings.ToLower(writeErr.Error()), "readonly") {
+		t.Errorf("write error = %q, want to contain %q", writeErr.Error(), "readonly")
+	}
+}
+
+func TestOpenReadOnly_ReadsExistingData(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+
+	// Create, migrate, insert one row, then close.
+	s, err := Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("Open(%q): %v", dbPath, err)
+	}
+	if err := s.Migrate(ctx); err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+	run := newTestRun(1)
+	if _, err := s.AppendRunHistory(ctx, run); err != nil {
+		t.Fatalf("AppendRunHistory: %v", err)
+	}
+	closeStore(t, s)
+
+	// Re-open read-only and verify the inserted row is visible.
+	ro, err := OpenReadOnly(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("OpenReadOnly(%q): %v", dbPath, err)
+	}
+	defer closeStore(t, ro)
+
+	entries, err := ro.QueryRunHistoryByIssue(ctx, run.IssueID)
+	if err != nil {
+		t.Fatalf("QueryRunHistoryByIssue: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("len(entries) = %d, want 1", len(entries))
+	}
+	if entries[0].IssueID != run.IssueID {
+		t.Errorf("IssueID = %q, want %q", entries[0].IssueID, run.IssueID)
+	}
+	if entries[0].Identifier != run.Identifier {
+		t.Errorf("Identifier = %q, want %q", entries[0].Identifier, run.Identifier)
 	}
 }

--- a/internal/tool/history/history.go
+++ b/internal/tool/history/history.go
@@ -1,0 +1,118 @@
+// Package history implements [domain.AgentTool] for the workspace_history
+// tool. It returns the most recent completed run attempts for the current
+// issue so that agents can learn from prior session outcomes.
+package history
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/sortie-ai/sortie/internal/domain"
+)
+
+var _ domain.AgentTool = (*HistoryTool)(nil)
+
+const maxEntries = 10
+
+var inputSchema = json.RawMessage(`{
+  "type": "object",
+  "properties": {},
+  "additionalProperties": false
+}`)
+
+// QueryFunc returns the most recent run history entries for a given issue,
+// up to limit entries, ordered newest-first. Implementations must return a
+// non-nil empty slice when no entries exist. A limit of 0 means no limit.
+type QueryFunc func(ctx context.Context, issueID string, limit int) ([]Entry, error)
+
+// Entry represents a single completed run attempt as returned by [QueryFunc].
+type Entry struct {
+	Attempt      int     // Attempt number at time of run (1-based).
+	AgentAdapter string  // Agent adapter kind used (e.g. "claude-code").
+	StartedAt    string  // ISO-8601 timestamp of run start.
+	CompletedAt  string  // ISO-8601 timestamp of run completion.
+	Status       string  // Terminal status: succeeded, failed, timed_out, stalled, cancelled.
+	Error        *string // Error message if failed; nil on success.
+}
+
+// HistoryTool implements [domain.AgentTool] for the workspace_history tool.
+// Construct via [New]; safe for concurrent use after construction.
+type HistoryTool struct {
+	query   QueryFunc
+	issueID string
+}
+
+type historyEntry struct {
+	Attempt      int     `json:"attempt"`
+	AgentAdapter string  `json:"agent_adapter"`
+	StartedAt    string  `json:"started_at"`
+	CompletedAt  string  `json:"completed_at"`
+	Status       string  `json:"status"`
+	Error        *string `json:"error"`
+}
+
+type historyResponse struct {
+	IssueID string         `json:"issue_id"`
+	Entries []historyEntry `json:"entries"`
+}
+
+// New returns a [HistoryTool] that queries run history for the given issue.
+//
+// New panics if query is nil or issueID is empty (programming errors).
+func New(query QueryFunc, issueID string) *HistoryTool {
+	if query == nil {
+		panic("history.New: query must not be nil")
+	}
+	if issueID == "" {
+		panic("history.New: issueID must not be empty")
+	}
+	return &HistoryTool{query: query, issueID: issueID}
+}
+
+// Name returns "workspace_history".
+func (t *HistoryTool) Name() string { return "workspace_history" }
+
+// Description returns a human-readable summary of the tool.
+func (t *HistoryTool) Description() string {
+	return "Returns the most recent completed run attempts for the current issue, " +
+		"including status, error messages, and timing. Use this to understand what " +
+		"happened in prior sessions before deciding on a strategy."
+}
+
+// InputSchema returns the JSON Schema for workspace_history input.
+// The tool accepts no parameters; the schema is an empty object.
+// The returned slice is a defensive copy.
+func (t *HistoryTool) InputSchema() json.RawMessage {
+	out := make(json.RawMessage, len(inputSchema))
+	copy(out, inputSchema)
+	return out
+}
+
+// Execute queries run history for the current issue and returns the results
+// as a JSON object. Query failures are returned as a JSON error response with
+// a nil Go error. Only internal marshal failures produce a non-nil Go error.
+func (t *HistoryTool) Execute(ctx context.Context, _ json.RawMessage) (json.RawMessage, error) {
+	results, err := t.query(ctx, t.issueID, maxEntries)
+	if err != nil {
+		resp, marshalErr := json.Marshal(map[string]string{"error": err.Error()})
+		if marshalErr != nil {
+			return nil, marshalErr
+		}
+		return resp, nil
+	}
+
+	entries := make([]historyEntry, len(results))
+	for i, r := range results {
+		entries[i] = historyEntry(r)
+	}
+
+	// Guarantee non-nil slice so JSON serializes as [] not null.
+	if len(entries) == 0 {
+		entries = []historyEntry{}
+	}
+
+	return json.Marshal(historyResponse{
+		IssueID: t.issueID,
+		Entries: entries,
+	})
+}

--- a/internal/tool/history/history_test.go
+++ b/internal/tool/history/history_test.go
@@ -1,0 +1,251 @@
+package history
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// --- Helpers ---
+
+var noopQuery QueryFunc = func(_ context.Context, _ string, _ int) ([]Entry, error) {
+	return []Entry{}, nil
+}
+
+func executeOK(t *testing.T, tool *HistoryTool) map[string]any {
+	t.Helper()
+	out, err := tool.Execute(context.Background(), json.RawMessage(`{}`))
+	if err != nil {
+		t.Fatalf("Execute: unexpected Go error: %v", err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(out, &m); err != nil {
+		t.Fatalf("Execute: unmarshal response %q: %v", out, err)
+	}
+	return m
+}
+
+// --- Tests ---
+
+func TestHistoryTool_Name(t *testing.T) {
+	t.Parallel()
+
+	tool := New(noopQuery, "10042")
+	if got := tool.Name(); got != "workspace_history" {
+		t.Errorf("Name() = %q, want %q", got, "workspace_history")
+	}
+}
+
+func TestHistoryTool_Description(t *testing.T) {
+	t.Parallel()
+
+	tool := New(noopQuery, "10042")
+	if got := tool.Description(); got == "" {
+		t.Error(`Description() = "", want non-empty`)
+	}
+}
+
+func TestHistoryTool_InputSchema_ValidJSON(t *testing.T) {
+	t.Parallel()
+
+	tool := New(noopQuery, "10042")
+	schema := tool.InputSchema()
+
+	var m map[string]any
+	if err := json.Unmarshal(schema, &m); err != nil {
+		t.Fatalf("InputSchema() unmarshal: %v", err)
+	}
+
+	v, ok := m["additionalProperties"]
+	if !ok {
+		t.Fatal("additionalProperties key missing from schema")
+	}
+	if v != false {
+		t.Errorf("additionalProperties = %v, want false", v)
+	}
+}
+
+func TestHistoryTool_InputSchema_DefensiveCopy(t *testing.T) {
+	t.Parallel()
+
+	tool := New(noopQuery, "10042")
+	schema1 := tool.InputSchema()
+
+	// Overwrite every byte of the first copy.
+	for i := range schema1 {
+		schema1[i] = 'X'
+	}
+
+	// The second call must still return valid JSON.
+	schema2 := tool.InputSchema()
+	var m map[string]any
+	if err := json.Unmarshal(schema2, &m); err != nil {
+		t.Fatalf("InputSchema() after mutation: unmarshal: %v", err)
+	}
+}
+
+func TestHistoryTool_Execute_EntriesReturned(t *testing.T) {
+	t.Parallel()
+
+	errMsg := "agent crashed"
+	canned := []Entry{
+		{Attempt: 1, AgentAdapter: "claude-code", StartedAt: "2026-03-01T10:00:00Z", CompletedAt: "2026-03-01T10:30:00Z", Status: "succeeded", Error: nil},
+		{Attempt: 2, AgentAdapter: "claude-code", StartedAt: "2026-03-02T10:00:00Z", CompletedAt: "2026-03-02T10:05:00Z", Status: "failed", Error: &errMsg},
+		{Attempt: 3, AgentAdapter: "mock", StartedAt: "2026-03-03T10:00:00Z", CompletedAt: "2026-03-03T10:15:00Z", Status: "succeeded", Error: nil},
+	}
+	query := func(_ context.Context, _ string, _ int) ([]Entry, error) {
+		return canned, nil
+	}
+
+	tool := New(query, "10042")
+	m := executeOK(t, tool)
+
+	if got, ok := m["issue_id"].(string); !ok || got != "10042" {
+		t.Errorf("issue_id = %v, want %q", m["issue_id"], "10042")
+	}
+
+	rawEntries, ok := m["entries"].([]any)
+	if !ok {
+		t.Fatalf("entries is not an array: %T %v", m["entries"], m["entries"])
+	}
+	if len(rawEntries) != 3 {
+		t.Fatalf("len(entries) = %d, want 3", len(rawEntries))
+	}
+
+	// entries[0]: succeeded, nil error → JSON null.
+	e0, ok := rawEntries[0].(map[string]any)
+	if !ok {
+		t.Fatalf("entries[0] is not an object: %T", rawEntries[0])
+	}
+	if got, _ := e0["status"].(string); got != "succeeded" {
+		t.Errorf("entries[0].status = %q, want %q", got, "succeeded")
+	}
+	if e0["error"] != nil {
+		t.Errorf("entries[0].error = %v, want null", e0["error"])
+	}
+
+	// entries[1]: failed, non-nil error → JSON string.
+	e1, ok := rawEntries[1].(map[string]any)
+	if !ok {
+		t.Fatalf("entries[1] is not an object: %T", rawEntries[1])
+	}
+	if got, _ := e1["status"].(string); got != "failed" {
+		t.Errorf("entries[1].status = %q, want %q", got, "failed")
+	}
+	if got, ok := e1["error"].(string); !ok || got != "agent crashed" {
+		t.Errorf("entries[1].error = %v, want %q", e1["error"], "agent crashed")
+	}
+}
+
+func TestHistoryTool_Execute_EmptyEntries(t *testing.T) {
+	t.Parallel()
+
+	query := func(_ context.Context, _ string, _ int) ([]Entry, error) {
+		return []Entry{}, nil
+	}
+
+	tool := New(query, "10042")
+	out, err := tool.Execute(context.Background(), json.RawMessage(`{}`))
+	if err != nil {
+		t.Fatalf("Execute: unexpected Go error: %v", err)
+	}
+
+	var m map[string]any
+	if err := json.Unmarshal(out, &m); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+
+	// entries must be a JSON array ([]), not null.
+	entries, ok := m["entries"].([]any)
+	if !ok {
+		t.Fatalf("entries is not an array: %T %v", m["entries"], m["entries"])
+	}
+	if len(entries) != 0 {
+		t.Errorf("len(entries) = %d, want 0", len(entries))
+	}
+}
+
+func TestHistoryTool_Execute_LimitPassthrough(t *testing.T) {
+	t.Parallel()
+
+	called := false
+	query := func(_ context.Context, _ string, limit int) ([]Entry, error) {
+		called = true
+		if limit != maxEntries {
+			t.Errorf("QueryFunc limit = %d, want %d", limit, maxEntries)
+		}
+		out := make([]Entry, maxEntries)
+		for i := range out {
+			out[i] = Entry{Attempt: i + 1, AgentAdapter: "mock", Status: "succeeded"}
+		}
+		return out, nil
+	}
+
+	tool := New(query, "10042")
+	m := executeOK(t, tool)
+
+	if !called {
+		t.Fatal("QueryFunc was not called")
+	}
+	rawEntries, ok := m["entries"].([]any)
+	if !ok {
+		t.Fatalf("entries is not an array: %T %v", m["entries"], m["entries"])
+	}
+	if len(rawEntries) != maxEntries {
+		t.Errorf("len(entries) = %d, want %d", len(rawEntries), maxEntries)
+	}
+}
+
+func TestHistoryTool_Execute_QueryError(t *testing.T) {
+	t.Parallel()
+
+	query := func(_ context.Context, _ string, _ int) ([]Entry, error) {
+		return nil, fmt.Errorf("database is locked")
+	}
+
+	tool := New(query, "10042")
+	out, err := tool.Execute(context.Background(), json.RawMessage(`{}`))
+	if err != nil {
+		t.Fatalf("Execute: expected nil Go error on query failure, got: %v", err)
+	}
+
+	var m map[string]any
+	if err := json.Unmarshal(out, &m); err != nil {
+		t.Fatalf("unmarshal error response %q: %v", out, err)
+	}
+
+	if _, ok := m["error"]; !ok {
+		t.Fatal(`response missing "error" key`)
+	}
+	errStr, ok := m["error"].(string)
+	if !ok {
+		t.Fatalf("error value is not a string: %T %v", m["error"], m["error"])
+	}
+	if !strings.Contains(errStr, "database is locked") {
+		t.Errorf("error value = %q, want to contain %q", errStr, "database is locked")
+	}
+}
+
+func TestNew_PanicsOnNilQuery(t *testing.T) {
+	t.Parallel()
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error(`New(nil, "10042") did not panic`)
+		}
+	}()
+	New(nil, "10042")
+}
+
+func TestNew_PanicsOnEmptyIssueID(t *testing.T) {
+	t.Parallel()
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error(`New(noopQuery, "") did not panic`)
+		}
+	}()
+	New(noopQuery, "")
+}


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Feat

**Intent:** Agents dispatched on continuation runs and retries have no knowledge of prior session outcomes — they cannot see whether earlier runs succeeded, failed, or timed out. The `workspace_history` tool queries the `run_history` SQLite table and returns up to 10 recent completed run attempts for the current issue so agents can adapt their strategy accordingly.

**Related Issues:** #227

### 🧭 Reviewer Guide

**Complexity:** Medium

#### Entry Point

Start at `internal/tool/history/history.go` — it defines the `QueryFunc` injection contract, the `Entry` type, and the full `domain.AgentTool` implementation. The dependency inversion here (tool never imports persistence) is the key architectural decision: the wiring layer in `cmd/sortie/mcpserver.go` adapts `persistence.RunHistory` to `history.Entry` via `buildHistoryQuery`.

#### Sensitive Areas

- `internal/persistence/store.go`: The new `OpenReadOnly` constructor appends `?mode=ro` to a `file:` URI DSN. The `file:` prefix is required for the SQLite driver to honour the `mode` query parameter — without it the parameter is silently ignored and writes succeed, which would violate the read-only contract.
- `cmd/sortie/mcpserver.go`: The `defer store.Close()` inside the conditional block fires at `runMCPServer` return (correct Go semantics). An `OpenReadOnly` failure is intentionally non-fatal — the MCP server continues with other tools available.
- `internal/tool/history/history.go`: The `historyEntry(r)` struct conversion on line 106 is valid per the Go spec — since Go 1.8, struct types with identical underlying fields (same names, types, and order) are convertible regardless of differing struct tags. Both `Entry` and `historyEntry` satisfy this requirement.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes
- **Migrations/State:** No migrations or state changes — the `run_history` table already exists; `OpenReadOnly` reads it without modifying schema