### PR TITLE
feat(orchestrator): add self-review loop before PR creation

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -99,6 +99,9 @@ Important boundary:
    - Builds prompt from issue + workflow template.
    - Launches the coding agent session via the configured agent adapter.
    - Relays agent updates back to the orchestrator.
+   - Optionally runs a bounded self-review loop after the coding turn loop completes:
+     configurable verification commands, workspace diff generation, and structured
+     agent feedback for iterative fix cycles. Opt-in; disabled by default.
 
 7. `Persistence Layer`
    - SQLite database for retry queues, session metadata, workspace registry, token accounting, and
@@ -608,6 +611,37 @@ Filesystem path for the SQLite database file.
 - Changes to `db_path` during dynamic reload update the in-memory config but have no
   effect on the already-open database connection; a restart is required.
 
+#### 5.3.8 `self_review` (object, optional)
+
+Self-review loop configuration. When `enabled` is true and `verification_commands` is
+non-empty, the orchestrator runs a bounded review-fix cycle after the coding turn loop
+completes. Each iteration executes verification commands, generates a workspace diff, and
+presents both to the agent for a structured verdict. Disabled by default; zero overhead
+when disabled.
+
+Fields:
+
+- `enabled` (boolean)
+  - Activates the self-review loop. Default: `false`.
+  - When `true`, `verification_commands` must be non-empty or a configuration error is
+    raised.
+- `max_iterations` (integer)
+  - Hard cap on review iterations. Default: `3`. Range: [1, 10].
+  - Each iteration consists of a review turn and (if the verdict is `iterate`) a fix turn.
+    `max_iterations: N` means up to `2N − 1` additional agent turns.
+- `verification_commands` (list of strings)
+  - Shell commands executed during each review iteration. Required when `enabled` is true.
+  - Each command runs in its own subprocess with the workspace as `cwd`, process group
+    isolation, and per-command timeout.
+- `verification_timeout_ms` (integer)
+  - Per-command timeout in milliseconds. Default: `120000` (2 minutes).
+- `max_diff_bytes` (integer)
+  - Maximum bytes of workspace diff included in the review prompt. Default: `102400`
+    (100 KB). Diffs exceeding this limit are truncated with a marker.
+- `reviewer` (string)
+  - Which agent performs the review. Default: `"same"`. Only `"same"` (reuse the current
+    session) is supported in v1.
+
 ### 5.4 Prompt Template Contract
 
 The Markdown body of `WORKFLOW.md` is the per-issue prompt template.
@@ -783,6 +817,12 @@ This section is intentionally redundant so a coding agent can implement the conf
   `comment`)
 - `ci_feedback.escalation_label`: string, default `needs-human`; label applied during `label`
   escalation
+- `self_review.enabled`: boolean, default `false`; activates the self-review loop
+- `self_review.max_iterations`: integer, default `3`, range [1, 10]; review iteration cap
+- `self_review.verification_commands`: list of strings, required when enabled; shell commands
+- `self_review.verification_timeout_ms`: integer, default `120000`; per-command timeout
+- `self_review.max_diff_bytes`: integer, default `102400`; diff truncation limit
+- `self_review.reviewer`: string, default `"same"`; only `"same"` supported in v1
 - `server.port` (extension): integer, optional; overrides the default server port (7678);
   `0` disables the HTTP server; CLI `--port` takes precedence
 - `server.host` (extension): string (IP address), optional; overrides the default bind
@@ -841,12 +881,14 @@ A run attempt transitions through these phases:
 3. `LaunchingAgentProcess`
 4. `InitializingSession`
 5. `StreamingTurn`
-6. `Finishing`
-7. `Succeeded`
-8. `Failed`
-9. `TimedOut`
-10. `Stalled`
-11. `CanceledByReconciliation`
+6. `SelfReviewing` — entered only when `self_review.enabled` is true and the coding turn
+   loop completed successfully (not on turn failure).
+7. `Finishing`
+8. `Succeeded`
+9. `Failed`
+10. `TimedOut`
+11. `Stalled`
+12. `CanceledByReconciliation`
 
 Distinct terminal reasons are important because retry logic and logs differ.
 
@@ -1137,6 +1179,18 @@ Failure semantics:
 - `before_run` failure or timeout is fatal to the current run attempt.
 - `after_run` failure or timeout is logged and ignored.
 - `before_remove` failure or timeout is logged and ignored.
+
+Hook environment variables (available to all hooks):
+
+- `SORTIE_ISSUE_ID` — tracker-internal issue ID.
+- `SORTIE_ISSUE_IDENTIFIER` — human-readable ticket key.
+- `SORTIE_WORKSPACE` — absolute path to the per-issue workspace directory.
+- `SORTIE_ATTEMPT` — current attempt number.
+- `SORTIE_SELF_REVIEW_STATUS` — self-review outcome for the current run: `"disabled"`,
+  `"passed"`, `"cap_reached"`, or `"error"`. Set on all `after_run` hook invocations.
+  Defaults to `"disabled"` when self-review is not configured.
+- `SORTIE_SELF_REVIEW_SUMMARY_PATH` — absolute path to `.sortie/review_summary.md` in
+  the workspace. Absent when self-review did not run or summary was not written.
 
 ### 9.5 Workspace SCM metadata (`.sortie/scm.json`)
 
@@ -2539,8 +2593,28 @@ function run_agent_attempt(issue, attempt, orchestrator_channel):
 
     turn_number = turn_number + 1
 
+  // Self-review phase (between turn loop exit and session teardown).
+  review_metadata = null
+  cfg = current_config()  // re-read for dynamic reload
+  if cfg.self_review.enabled AND issue.state is active AND context not cancelled:
+    review_metadata = run_self_review_loop(
+      session, workspace, issue, cfg.self_review, agent_adapter, orchestrator_channel
+    )
+
+  self_review_status = "disabled"
+  if review_metadata != null:
+    if review_metadata.final_verdict == "pass":
+      self_review_status = "passed"
+    else if review_metadata.cap_reached:
+      self_review_status = "cap_reached"
+    else:
+      self_review_status = "error"
+
   agent_adapter.stop_session(session)
-  run_hook_best_effort("after_run", workspace.path)
+  run_hook_best_effort("after_run", workspace.path, {
+    SORTIE_SELF_REVIEW_STATUS: self_review_status,
+    SORTIE_SELF_REVIEW_SUMMARY_PATH: workspace.path + "/.sortie/review_summary.md"
+  })
 
   exit_normal()
 ```
@@ -2709,6 +2783,14 @@ Unless otherwise noted, Sections 17.1 through 17.7 are `Core Conformance`. Bulle
 - Escalation label failure is logged but does not block claim release
 - `.sortie/scm.json` symlink rejection prevents CI check enqueue
 - `.sortie/scm.json` oversized or malformed files degrade to no-CI behavior
+- Self-review disabled adds zero overhead (no review turns, no review metadata)
+- Self-review runs verification commands and passes results to agent
+- Review verdict "pass" terminates loop
+- Review verdict "iterate" triggers fix turn and next iteration
+- Iteration cap enforced; worker exits with cap_reached metadata
+- Missing verdict treated as iterate (non-final) / pass (final)
+- Verification command timeout does not block remaining commands
+- Review progress visible in runtime snapshot via selfReviewCh
 
 ### 17.5 Coding-Agent Adapter Client
 
@@ -2859,8 +2941,9 @@ Note: `timer_handle` is runtime-only and is not stored.
 | `workspace`     | TEXT    | Workspace path                            |
 | `started_at`    | TEXT    | ISO-8601 timestamp                        |
 | `completed_at`  | TEXT    | ISO-8601 timestamp                        |
-| `status`        | TEXT    | Terminal status (succeeded, failed, etc.) |
-| `error`         | TEXT    | Error message if failed, may be null      |
+| `status`          | TEXT    | Terminal status (succeeded, failed, etc.) |
+| `error`           | TEXT    | Error message if failed, may be null      |
+| `review_metadata` | TEXT    | JSON-encoded self-review metadata, may be null (migration 007) |
 
 **`session_metadata`** — last known session metadata per issue (for observability and debug)
 
@@ -2943,6 +3026,41 @@ channel only.
 The full protocol specification — including file format, parsing rules, read timing, cleanup
 obligations, versioning, security considerations, and design rationale — is in
 [agent-to-orchestrator-protocol.md](agent-to-orchestrator-protocol.md).
+
+### 21.2 `.sortie/review_verdict.json`
+
+During the self-review phase, the agent writes a structured review verdict to
+`.sortie/review_verdict.json`. The orchestrator reads this file after each review turn to
+determine the next action.
+
+JSON schema:
+
+```json
+{
+  "verdict": "pass | iterate",
+  "issues": [
+    {
+      "file": "path/to/file.go",
+      "line": 42,
+      "severity": "error | warning | info",
+      "message": "Description of the issue"
+    }
+  ]
+}
+```
+
+- `verdict` (string): `"pass"` ends the review loop; `"iterate"` requests a fix turn.
+  Unrecognized values are normalized to `"iterate"`.
+- `issues` (array, optional): structured list of review findings for the fix prompt.
+
+Safety rules:
+
+- Maximum file size: 65536 bytes (64 KB). Oversized files are rejected.
+- Symlink protection: both `.sortie/` and `.sortie/review_verdict.json` are checked via
+  `Lstat` before reading. If either is a symbolic link, the file is rejected. This follows
+  the same pattern as `.sortie/status` (Section 21.1).
+- Missing verdict file on a non-final iteration is treated as `"iterate"`. Missing verdict
+  file on the final iteration is treated as `"pass"`.
 
 ## Appendix A. SSH Worker Extension (Optional)
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1180,15 +1180,18 @@ Failure semantics:
 - `after_run` failure or timeout is logged and ignored.
 - `before_remove` failure or timeout is logged and ignored.
 
-Hook environment variables (available to all hooks):
+Hook environment variables available to all hooks:
 
 - `SORTIE_ISSUE_ID` — tracker-internal issue ID.
 - `SORTIE_ISSUE_IDENTIFIER` — human-readable ticket key.
 - `SORTIE_WORKSPACE` — absolute path to the per-issue workspace directory.
 - `SORTIE_ATTEMPT` — current attempt number.
+
+Hook environment variables available only to `after_run`:
+
 - `SORTIE_SELF_REVIEW_STATUS` — self-review outcome for the current run: `"disabled"`,
-  `"passed"`, `"cap_reached"`, or `"error"`. Set on all `after_run` hook invocations.
-  Defaults to `"disabled"` when self-review is not configured.
+  `"passed"`, `"cap_reached"`, or `"error"`. Defaults to `"disabled"` when self-review
+  is not configured.
 - `SORTIE_SELF_REVIEW_SUMMARY_PATH` — absolute path to `.sortie/review_summary.md` in
   the workspace. Absent when self-review did not run or summary was not written.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -3050,7 +3050,7 @@ JSON schema:
 ```
 
 - `verdict` (string): `"pass"` ends the review loop; `"iterate"` requests a fix turn.
-  Unrecognized values are normalized to `"iterate"`.
+  Any other value is rejected as invalid.
 - `issues` (array, optional): structured list of review findings for the fix prompt.
 
 Safety rules:
@@ -3059,8 +3059,9 @@ Safety rules:
 - Symlink protection: both `.sortie/` and `.sortie/review_verdict.json` are checked via
   `Lstat` before reading. If either is a symbolic link, the file is rejected. This follows
   the same pattern as `.sortie/status` (Section 21.1).
-- Missing verdict file on a non-final iteration is treated as `"iterate"`. Missing verdict
-  file on the final iteration is treated as `"pass"`.
+- Missing or invalid verdict content on a non-final iteration is treated as `"iterate"`.
+  Missing or invalid verdict content on the final iteration does not count as `"pass"`; the
+  run ends with no final verdict recorded and `CapReached=true`.
 
 ## Appendix A. SSH Worker Extension (Optional)
 

--- a/docs/workflow-reference.md
+++ b/docs/workflow-reference.md
@@ -1450,14 +1450,19 @@ Issue dispatched
 
 All hooks receive the following environment variables:
 
-| Variable                          | Description                                                                                                                      |
-| --------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
-| `SORTIE_ISSUE_ID`                 | Stable tracker-internal issue ID.                                                                                                |
-| `SORTIE_ISSUE_IDENTIFIER`         | Human-readable ticket key (e.g., `PROJ-123`).                                                                                    |
-| `SORTIE_WORKSPACE`                | Absolute path to the per-issue workspace directory.                                                                              |
-| `SORTIE_ATTEMPT`                  | Current attempt number (integer).                                                                                                |
-| `SORTIE_SELF_REVIEW_STATUS`       | Self-review outcome for the current run: `"disabled"`, `"passed"`, `"cap_reached"`, or `"error"`. Set on all `after_run` hook invocations. |
-| `SORTIE_SELF_REVIEW_SUMMARY_PATH` | Absolute path to `.sortie/review_summary.md` in the workspace. Absent when self-review did not run or the summary file was not written.   |
+| Variable                  | Description                                           |
+| ------------------------- | ----------------------------------------------------- |
+| `SORTIE_ISSUE_ID`         | Stable tracker-internal issue ID.                     |
+| `SORTIE_ISSUE_IDENTIFIER` | Human-readable ticket key (e.g., `PROJ-123`).         |
+| `SORTIE_WORKSPACE`        | Absolute path to the per-issue workspace directory.   |
+| `SORTIE_ATTEMPT`          | Current attempt number (integer).                     |
+
+`after_run` hooks also receive the following environment variables:
+
+| Variable                          | Description                                                                                                    |
+| --------------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| `SORTIE_SELF_REVIEW_STATUS`       | Self-review outcome for the current run: `"disabled"`, `"passed"`, `"cap_reached"`, or `"error"`.            |
+| `SORTIE_SELF_REVIEW_SUMMARY_PATH` | Absolute path to `.sortie/review_summary.md` in the workspace. Absent when self-review did not run or the summary file was not written. |
 
 These allow hooks to make decisions without parsing orchestrator internals.
 

--- a/docs/workflow-reference.md
+++ b/docs/workflow-reference.md
@@ -137,7 +137,7 @@ After parsing, the loader produces a struct with three fields:
 
 ### 2.1 Top-Level Keys
 
-The core schema recognizes seven top-level keys:
+The core schema recognizes eight top-level keys:
 
 ```yaml
 tracker: # Issue tracker connection and query settings
@@ -147,6 +147,7 @@ hooks: # Workspace lifecycle hook scripts
 agent: # Coding agent adapter, timeouts, and limits
 db_path: # SQLite database file path
 ci_feedback: # CI failure feedback loop (optional)
+self_review: # Self-review verification loop (optional)
 ```
 
 **Unknown top-level keys are ignored** by the core schema for forward compatibility. They
@@ -449,6 +450,52 @@ and are shared with the tracker adapter when both use the same SCM provider.
 
 ---
 
+### 2.9 `self_review` — Self-Review Configuration
+
+```yaml
+self_review:
+  enabled: true
+  max_iterations: 3
+  verification_commands:
+    - "go test ./..."
+    - "go vet ./..."
+  verification_timeout_ms: 120000
+  max_diff_bytes: 102400
+  reviewer: same
+```
+
+The self-review section configures an optional post-coding verification and iterative
+review phase. When enabled, the orchestrator runs verification commands after the coding
+turn loop, generates a workspace diff, and presents both to the agent for a structured
+verdict. If the agent identifies issues ("iterate"), a fix turn runs and the cycle repeats
+up to `max_iterations`.
+
+| Key                        | Type     | Required           | Default    | Description                                                       |
+| -------------------------- | -------- | ------------------ | ---------- | ----------------------------------------------------------------- |
+| `enabled`                  | boolean  | No                 | `false`    | Activates the self-review loop.                                   |
+| `max_iterations`           | integer  | No                 | `3`        | Hard cap on review iterations. Range: 1–10.                       |
+| `verification_commands`    | [string] | When `enabled: true` | —        | Shell commands to run during each review iteration.               |
+| `verification_timeout_ms`  | integer  | No                 | `120000`   | Per-command timeout in milliseconds.                              |
+| `max_diff_bytes`           | integer  | No                 | `102400`   | Max bytes of diff to include in review prompt.                    |
+| `reviewer`                 | string   | No                 | `"same"`   | Which agent reviews. Only `"same"` in v1.                         |
+
+**Turn Accounting:** `max_iterations: N` means up to `2N − 1` additional agent turns
+(N review turns + N−1 fix turns). For the default `max_iterations: 3`, this is up to 5
+additional turns beyond the coding turn loop. Plan token budgets accordingly.
+
+**Validation rules:**
+
+- When `enabled` is `true`, `verification_commands` must be a non-empty list. An empty list
+  is rejected with a configuration error.
+- `max_iterations` must be in the range [1, 10]. Values outside this range are rejected with
+  a configuration error.
+- `reviewer` must be `"same"`. Other values are reserved for future use and are rejected
+  with a configuration error.
+- When `enabled` is `false` or the section is absent, all other fields are ignored and the
+  self-review phase adds zero overhead.
+
+---
+
 ## 3. Environment Variable Overrides
 
 Sortie supports a curated set of `SORTIE_*` environment variables that override YAML front
@@ -627,6 +674,7 @@ as an environment variable reference.
 | `hooks.timeout_ms`                     | Low-risk tuning; hooks are rarely changed per-environment       |
 | `agent.max_concurrent_agents_by_state` | Complex map type; no clean single-value representation          |
 | `ci_feedback.escalation_label`         | Low-risk default; rarely differs per environment                |
+| `self_review.*`                        | Verification commands are security-sensitive privileged configuration that must come from the version-controlled WORKFLOW.md |
 | Extensions (`server`, `worker`, etc.)  | Extension-defined; would couple core env parsing to extensions  |
 | `logging.level` (via extensions)       | Resolved from `--log-level` flag; not part of typed config layer |
 
@@ -1402,12 +1450,14 @@ Issue dispatched
 
 All hooks receive the following environment variables:
 
-| Variable                  | Description                                         |
-| ------------------------- | --------------------------------------------------- |
-| `SORTIE_ISSUE_ID`         | Stable tracker-internal issue ID.                   |
-| `SORTIE_ISSUE_IDENTIFIER` | Human-readable ticket key (e.g., `PROJ-123`).       |
-| `SORTIE_WORKSPACE`        | Absolute path to the per-issue workspace directory. |
-| `SORTIE_ATTEMPT`          | Current attempt number (integer).                   |
+| Variable                          | Description                                                                                                                      |
+| --------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| `SORTIE_ISSUE_ID`                 | Stable tracker-internal issue ID.                                                                                                |
+| `SORTIE_ISSUE_IDENTIFIER`         | Human-readable ticket key (e.g., `PROJ-123`).                                                                                    |
+| `SORTIE_WORKSPACE`                | Absolute path to the per-issue workspace directory.                                                                              |
+| `SORTIE_ATTEMPT`                  | Current attempt number (integer).                                                                                                |
+| `SORTIE_SELF_REVIEW_STATUS`       | Self-review outcome for the current run: `"disabled"`, `"passed"`, `"cap_reached"`, or `"error"`. Set on all `after_run` hook invocations. |
+| `SORTIE_SELF_REVIEW_SUMMARY_PATH` | Absolute path to `.sortie/review_summary.md` in the workspace. Absent when self-review did not run or the summary file was not written.   |
 
 These allow hooks to make decisions without parsing orchestrator internals.
 
@@ -1677,6 +1727,12 @@ lists the `SORTIE_*` variable that overrides the field, or "—" if not overrida
 | `ci_feedback.max_log_lines`             | integer          | `50`                         | —                                        | `0` = disable log fetching; restart required                                           |
 | `ci_feedback.escalation`                | string           | `label`                      | —                                        | `"label"` or `"comment"`                                                               |
 | `ci_feedback.escalation_label`          | string           | `needs-human`                | —                                        | Applied when `escalation` is `"label"`                                                 |
+| `self_review.enabled`                   | boolean          | `false`                      | —                                        | Activates self-review loop                                                             |
+| `self_review.max_iterations`            | integer          | `3`                          | —                                        | Range [1, 10]; up to `2N−1` extra turns                                                |
+| `self_review.verification_commands`     | `[string]`       | _(required when enabled)_    | —                                        | Shell commands for verification                                                        |
+| `self_review.verification_timeout_ms`   | integer          | `120000`                     | —                                        | Per-command timeout                                                                    |
+| `self_review.max_diff_bytes`            | integer          | `102400`                     | —                                        | Diff truncation limit                                                                  |
+| `self_review.reviewer`                  | string           | `"same"`                     | —                                        | Only `"same"` in v1                                                                    |
 | **Extensions**                          |                  |                              |                                          |                                                                                        |
 | `server.port`                           | integer          | `7678`                       | —                                        | CLI `--port` overrides; `0` disables server                                    |
 | `server.host`                           | string (IP)      | `127.0.0.1`                  | —                                        | CLI `--host` overrides                                                         |
@@ -1876,6 +1932,51 @@ Diagnose the root cause before making changes.
 
 {{ .issue.parent.identifier }}
 {{ end }}
+```
+
+---
+
+### 11.3 Self-Review with Go Verification
+
+A workflow enabling automated self-review after each coding session:
+
+```yaml
+---
+tracker:
+  kind: jira
+  endpoint: $SORTIE_JIRA_ENDPOINT
+  api_key: $SORTIE_JIRA_API_KEY
+  project: PROJ
+  active_states: [To Do, In Progress]
+  terminal_states: [Done]
+
+agent:
+  kind: claude-code
+  max_turns: 10
+
+# ─── Self-Review ───────────────────────────────────────────────
+# After the coding turn loop, run verification and let the agent
+# review its own work. Up to 3 iterations (5 additional turns).
+self_review:
+  enabled: true
+  max_iterations: 3           # 3 review rounds = up to 5 extra turns
+  verification_commands:
+    - "make fmt"              # Format check
+    - "make lint"             # Static analysis
+    - "make test"             # Full test suite
+  verification_timeout_ms: 180000  # 3 min per command
+  max_diff_bytes: 102400      # 100 KB diff cap
+  reviewer: same              # Reuse the same agent session
+
+hooks:
+  after_run: |
+    echo "Self-review status: $SORTIE_SELF_REVIEW_STATUS"
+    if [ -f "$SORTIE_SELF_REVIEW_SUMMARY_PATH" ]; then
+      cat "$SORTIE_SELF_REVIEW_SUMMARY_PATH"
+    fi
+---
+
+Fix {{ .issue.identifier }}: {{ .issue.title }}
 ```
 
 ---

--- a/examples/grafana-dashboard.json
+++ b/examples/grafana-dashboard.json
@@ -1570,6 +1570,177 @@
     },
     {
       "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 83 },
+      "id": 30,
+      "title": "Self-Review",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "showPoints": "auto"
+          }
+        }
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 84 },
+      "id": 31,
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom" },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "editorMode": "code",
+          "expr": "sum(rate(sortie_self_review_iterations_total[5m])) by (verdict)",
+          "legendFormat": "{{verdict}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Self-Review Iterations",
+      "description": "Self-review iterations per second by verdict (pass, iterate, none).",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "showPoints": "auto"
+          }
+        }
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 84 },
+      "id": 32,
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom" },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "editorMode": "code",
+          "expr": "sum(rate(sortie_self_review_sessions_total[5m])) by (final_verdict)",
+          "legendFormat": "{{final_verdict}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Self-Review Sessions",
+      "description": "Self-review sessions per second by final verdict.",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "showPoints": "auto"
+          }
+        }
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 92 },
+      "id": 33,
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom" },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum(rate(sortie_self_review_verification_duration_seconds_bucket[5m])) by (le, command))",
+          "legendFormat": "p95 {{command}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Self-Review Verification Duration",
+      "description": "P95 verification command duration by command.",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "showPoints": "auto"
+          }
+        }
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 92 },
+      "id": 34,
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom" },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "editorMode": "code",
+          "expr": "sum(rate(sortie_self_review_cap_reached_total[5m]))",
+          "legendFormat": "cap_reached",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Self-Review Cap Reached",
+      "description": "Rate of self-review sessions that hit the iteration cap.",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
       "gridPos": { "h": 1, "w": 24, "x": 0, "y": 85 },
       "id": 21,
       "title": "Agent",

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -597,6 +597,12 @@ func buildSelfReviewConfig(m map[string]any) (SelfReviewConfig, error) {
 		}
 		timeoutMS = parsed
 	}
+	if timeoutMS <= 0 {
+		return SelfReviewConfig{}, &ConfigError{
+			Field:   "self_review.verification_timeout_ms",
+			Message: "must be greater than 0",
+		}
+	}
 
 	maxDiffBytes := 102400
 	if v, exists := m["max_diff_bytes"]; exists && v != nil {
@@ -608,6 +614,12 @@ func buildSelfReviewConfig(m map[string]any) (SelfReviewConfig, error) {
 			}
 		}
 		maxDiffBytes = parsed
+	}
+	if maxDiffBytes <= 0 {
+		return SelfReviewConfig{}, &ConfigError{
+			Field:   "self_review.max_diff_bytes",
+			Message: "must be greater than 0",
+		}
 	}
 
 	reviewer := "same"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -28,6 +28,10 @@ type ServiceConfig struct {
 	// Zero-value (Kind == "") means CI feedback is disabled.
 	CIFeedback CIFeedbackConfig
 
+	// SelfReview holds self-review loop configuration.
+	// Zero-value (Enabled == false) means self-review is disabled.
+	SelfReview SelfReviewConfig
+
 	// DBPath is the environment- and tilde-expanded path for the SQLite
 	// database. It may be relative; callers resolve it against the
 	// WORKFLOW.md directory. Empty string means the caller should apply
@@ -110,6 +114,7 @@ var knownTopLevelKeys = map[string]bool{
 	"agent":       true,
 	"db_path":     true,
 	"ci_feedback": true,
+	"self_review": true,
 }
 
 // NewServiceConfig converts a raw front matter map into a validated
@@ -233,6 +238,11 @@ func NewServiceConfig(raw map[string]any) (ServiceConfig, error) {
 		return ServiceConfig{}, err
 	}
 
+	selfReview, err := buildSelfReviewConfig(extractSubMap(raw, "self_review"))
+	if err != nil {
+		return ServiceConfig{}, err
+	}
+
 	extensions := make(map[string]any)
 	for k, v := range raw {
 		if !knownTopLevelKeys[k] {
@@ -247,6 +257,7 @@ func NewServiceConfig(raw map[string]any) (ServiceConfig, error) {
 		Hooks:      hooks,
 		Agent:      agent,
 		CIFeedback: ciFeedback,
+		SelfReview: selfReview,
 		DBPath:     dbPath,
 		Extensions: extensions,
 	}, nil
@@ -524,6 +535,90 @@ func buildCIFeedbackConfig(m map[string]any) (CIFeedbackConfig, error) {
 	}, nil
 }
 
+func buildSelfReviewConfig(m map[string]any) (SelfReviewConfig, error) {
+	if len(m) == 0 {
+		return SelfReviewConfig{
+			MaxIterations:         3,
+			VerificationTimeoutMS: 120000,
+			MaxDiffBytes:          102400,
+			Reviewer:              "same",
+		}, nil
+	}
+
+	enabled := coerceBool(m, "enabled")
+
+	maxIter := 3
+	if v, exists := m["max_iterations"]; exists && v != nil {
+		parsed, err := coerceInt(v)
+		if err != nil {
+			return SelfReviewConfig{}, &ConfigError{
+				Field:   "self_review.max_iterations",
+				Message: fmt.Sprintf("invalid integer value: %v", v),
+			}
+		}
+		maxIter = parsed
+	}
+	if maxIter < 1 || maxIter > 10 {
+		return SelfReviewConfig{}, &ConfigError{
+			Field:   "self_review.max_iterations",
+			Message: "must be between 1 and 10",
+		}
+	}
+
+	verificationCommands := extractStringSlice(mapVal(m, "verification_commands"))
+
+	if enabled && len(verificationCommands) == 0 {
+		return SelfReviewConfig{}, &ConfigError{
+			Field:   "self_review.verification_commands",
+			Message: "required when self_review is enabled",
+		}
+	}
+
+	timeoutMS := 120000
+	if v, exists := m["verification_timeout_ms"]; exists && v != nil {
+		parsed, err := coerceInt(v)
+		if err != nil {
+			return SelfReviewConfig{}, &ConfigError{
+				Field:   "self_review.verification_timeout_ms",
+				Message: fmt.Sprintf("invalid integer value: %v", v),
+			}
+		}
+		timeoutMS = parsed
+	}
+
+	maxDiffBytes := 102400
+	if v, exists := m["max_diff_bytes"]; exists && v != nil {
+		parsed, err := coerceInt(v)
+		if err != nil {
+			return SelfReviewConfig{}, &ConfigError{
+				Field:   "self_review.max_diff_bytes",
+				Message: fmt.Sprintf("invalid integer value: %v", v),
+			}
+		}
+		maxDiffBytes = parsed
+	}
+
+	reviewer := "same"
+	if v := extractString(m, "reviewer"); v != "" {
+		reviewer = v
+	}
+	if reviewer != "same" {
+		return SelfReviewConfig{}, &ConfigError{
+			Field:   "self_review.reviewer",
+			Message: "only \"same\" is supported",
+		}
+	}
+
+	return SelfReviewConfig{
+		Enabled:               enabled,
+		MaxIterations:         maxIter,
+		VerificationCommands:  verificationCommands,
+		VerificationTimeoutMS: timeoutMS,
+		MaxDiffBytes:          maxDiffBytes,
+		Reviewer:              reviewer,
+	}, nil
+}
+
 // validateHandoffState checks that handoffState does not collide with
 // active or terminal states. Returns a *ConfigError on violation.
 func validateHandoffState(handoffState string, activeStates, terminalStates []string) error {
@@ -740,6 +835,33 @@ func mapVal(m map[string]any, key string) any {
 		return nil
 	}
 	return m[key]
+}
+
+// SelfReviewConfig holds self-review loop configuration. When Enabled
+// is false (the default), self-review is disabled and adds zero overhead.
+type SelfReviewConfig struct {
+	// Enabled activates the self-review loop. Default false.
+	Enabled bool
+
+	// MaxIterations is the hard cap on review iterations. Default 3.
+	// Range [1, 10].
+	MaxIterations int
+
+	// VerificationCommands is the list of shell commands to run during
+	// each review iteration. Required and non-empty when Enabled is true.
+	VerificationCommands []string
+
+	// VerificationTimeoutMS is the per-command timeout in milliseconds.
+	// Default 120000 (2 minutes).
+	VerificationTimeoutMS int
+
+	// MaxDiffBytes is the maximum number of bytes to include in the diff
+	// output sent to the agent. Default 102400 (100 KB).
+	MaxDiffBytes int
+
+	// Reviewer controls which agent runs the review turns.
+	// "same" (default and only supported value): reuse the existing session.
+	Reviewer string
 }
 
 // CIFeedbackConfig holds CI feedback provider selection and tuning.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -547,6 +547,18 @@ func buildSelfReviewConfig(m map[string]any) (SelfReviewConfig, error) {
 
 	enabled := coerceBool(m, "enabled")
 
+	// When self_review is disabled, return defaults without validating
+	// other fields so operators are not surprised by config errors for
+	// a feature they opted out of.
+	if !enabled {
+		return SelfReviewConfig{
+			MaxIterations:         3,
+			VerificationTimeoutMS: 120000,
+			MaxDiffBytes:          102400,
+			Reviewer:              "same",
+		}, nil
+	}
+
 	maxIter := 3
 	if v, exists := m["max_iterations"]; exists && v != nil {
 		parsed, err := coerceInt(v)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1354,7 +1354,7 @@ func TestNewServiceConfig_SelfReview(t *testing.T) {
 	t.Run("MaxIterations_Below1", func(t *testing.T) {
 		t.Parallel()
 		_, err := NewServiceConfig(map[string]any{
-			"self_review": map[string]any{"max_iterations": 0},
+			"self_review": map[string]any{"enabled": true, "verification_commands": []any{"echo ok"}, "max_iterations": 0},
 		})
 		assertConfigErrorField(t, err, "self_review.max_iterations")
 	})
@@ -1362,7 +1362,7 @@ func TestNewServiceConfig_SelfReview(t *testing.T) {
 	t.Run("MaxIterations_Above10", func(t *testing.T) {
 		t.Parallel()
 		_, err := NewServiceConfig(map[string]any{
-			"self_review": map[string]any{"max_iterations": 11},
+			"self_review": map[string]any{"enabled": true, "verification_commands": []any{"echo ok"}, "max_iterations": 11},
 		})
 		assertConfigErrorField(t, err, "self_review.max_iterations")
 	})
@@ -1371,7 +1371,7 @@ func TestNewServiceConfig_SelfReview(t *testing.T) {
 		t.Parallel()
 		for _, n := range []int{1, 10} {
 			cfg, err := NewServiceConfig(map[string]any{
-				"self_review": map[string]any{"max_iterations": n},
+				"self_review": map[string]any{"enabled": true, "verification_commands": []any{"echo ok"}, "max_iterations": n},
 			})
 			if err != nil {
 				t.Fatalf("max_iterations=%d: unexpected error: %v", n, err)
@@ -1383,7 +1383,7 @@ func TestNewServiceConfig_SelfReview(t *testing.T) {
 	t.Run("Reviewer_Invalid", func(t *testing.T) {
 		t.Parallel()
 		_, err := NewServiceConfig(map[string]any{
-			"self_review": map[string]any{"reviewer": "other-agent"},
+			"self_review": map[string]any{"enabled": true, "verification_commands": []any{"echo ok"}, "reviewer": "other-agent"},
 		})
 		assertConfigErrorField(t, err, "self_review.reviewer")
 	})
@@ -1391,7 +1391,7 @@ func TestNewServiceConfig_SelfReview(t *testing.T) {
 	t.Run("Reviewer_Same", func(t *testing.T) {
 		t.Parallel()
 		cfg, err := NewServiceConfig(map[string]any{
-			"self_review": map[string]any{"reviewer": "same"},
+			"self_review": map[string]any{"enabled": true, "verification_commands": []any{"echo ok"}, "reviewer": "same"},
 		})
 		if err != nil {
 			t.Fatalf("NewServiceConfig: %v", err)
@@ -1403,6 +1403,8 @@ func TestNewServiceConfig_SelfReview(t *testing.T) {
 		t.Parallel()
 		cfg, err := NewServiceConfig(map[string]any{
 			"self_review": map[string]any{
+				"enabled":                 true,
+				"verification_commands":   []any{"echo ok"},
 				"max_iterations":          "5",
 				"verification_timeout_ms": float64(60000),
 				"max_diff_bytes":          "51200",
@@ -1414,6 +1416,23 @@ func TestNewServiceConfig_SelfReview(t *testing.T) {
 		assertIntEqual(t, "SelfReview.MaxIterations", 5, cfg.SelfReview.MaxIterations)
 		assertIntEqual(t, "SelfReview.VerificationTimeoutMS", 60000, cfg.SelfReview.VerificationTimeoutMS)
 		assertIntEqual(t, "SelfReview.MaxDiffBytes", 51200, cfg.SelfReview.MaxDiffBytes)
+	})
+
+	t.Run("Disabled_SkipsValidation", func(t *testing.T) {
+		t.Parallel()
+		cfg, err := NewServiceConfig(map[string]any{
+			"self_review": map[string]any{
+				"enabled":        false,
+				"max_iterations": 0,
+				"reviewer":       "nonexistent",
+			},
+		})
+		if err != nil {
+			t.Fatalf("Disabled self_review with invalid fields should not error: %v", err)
+		}
+		if cfg.SelfReview.Enabled {
+			t.Error("SelfReview.Enabled = true, want false")
+		}
 	})
 
 	t.Run("SchemaUnknownKey", func(t *testing.T) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1300,3 +1300,150 @@ func TestNewServiceConfig_CIFeedback(t *testing.T) {
 		}
 	})
 }
+
+func TestNewServiceConfig_SelfReview(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Defaults", func(t *testing.T) {
+		t.Parallel()
+		cfg, err := NewServiceConfig(map[string]any{})
+		if err != nil {
+			t.Fatalf("NewServiceConfig: %v", err)
+		}
+		if cfg.SelfReview.Enabled {
+			t.Error("SelfReview.Enabled = true, want false")
+		}
+		assertIntEqual(t, "SelfReview.MaxIterations", 3, cfg.SelfReview.MaxIterations)
+		assertIntEqual(t, "SelfReview.VerificationTimeoutMS", 120000, cfg.SelfReview.VerificationTimeoutMS)
+		assertIntEqual(t, "SelfReview.MaxDiffBytes", 102400, cfg.SelfReview.MaxDiffBytes)
+		assertStringEqual(t, "SelfReview.Reviewer", "same", cfg.SelfReview.Reviewer)
+	})
+
+	t.Run("Enabled_WithCommands", func(t *testing.T) {
+		t.Parallel()
+		cfg, err := NewServiceConfig(map[string]any{
+			"self_review": map[string]any{
+				"enabled":               true,
+				"verification_commands": []any{"make test", "make lint"},
+			},
+		})
+		if err != nil {
+			t.Fatalf("NewServiceConfig: %v", err)
+		}
+		if !cfg.SelfReview.Enabled {
+			t.Error("SelfReview.Enabled = false, want true")
+		}
+		if len(cfg.SelfReview.VerificationCommands) != 2 {
+			t.Fatalf("SelfReview.VerificationCommands len = %d, want 2",
+				len(cfg.SelfReview.VerificationCommands))
+		}
+		assertStringEqual(t, "VerificationCommands[0]", "make test", cfg.SelfReview.VerificationCommands[0])
+		assertStringEqual(t, "VerificationCommands[1]", "make lint", cfg.SelfReview.VerificationCommands[1])
+	})
+
+	t.Run("Enabled_NoCommands", func(t *testing.T) {
+		t.Parallel()
+		_, err := NewServiceConfig(map[string]any{
+			"self_review": map[string]any{
+				"enabled": true,
+			},
+		})
+		assertConfigErrorField(t, err, "self_review.verification_commands")
+	})
+
+	t.Run("MaxIterations_Below1", func(t *testing.T) {
+		t.Parallel()
+		_, err := NewServiceConfig(map[string]any{
+			"self_review": map[string]any{"max_iterations": 0},
+		})
+		assertConfigErrorField(t, err, "self_review.max_iterations")
+	})
+
+	t.Run("MaxIterations_Above10", func(t *testing.T) {
+		t.Parallel()
+		_, err := NewServiceConfig(map[string]any{
+			"self_review": map[string]any{"max_iterations": 11},
+		})
+		assertConfigErrorField(t, err, "self_review.max_iterations")
+	})
+
+	t.Run("MaxIterations_Boundary", func(t *testing.T) {
+		t.Parallel()
+		for _, n := range []int{1, 10} {
+			cfg, err := NewServiceConfig(map[string]any{
+				"self_review": map[string]any{"max_iterations": n},
+			})
+			if err != nil {
+				t.Fatalf("max_iterations=%d: unexpected error: %v", n, err)
+			}
+			assertIntEqual(t, "SelfReview.MaxIterations", n, cfg.SelfReview.MaxIterations)
+		}
+	})
+
+	t.Run("Reviewer_Invalid", func(t *testing.T) {
+		t.Parallel()
+		_, err := NewServiceConfig(map[string]any{
+			"self_review": map[string]any{"reviewer": "other-agent"},
+		})
+		assertConfigErrorField(t, err, "self_review.reviewer")
+	})
+
+	t.Run("Reviewer_Same", func(t *testing.T) {
+		t.Parallel()
+		cfg, err := NewServiceConfig(map[string]any{
+			"self_review": map[string]any{"reviewer": "same"},
+		})
+		if err != nil {
+			t.Fatalf("NewServiceConfig: %v", err)
+		}
+		assertStringEqual(t, "SelfReview.Reviewer", "same", cfg.SelfReview.Reviewer)
+	})
+
+	t.Run("IntegerCoercion", func(t *testing.T) {
+		t.Parallel()
+		cfg, err := NewServiceConfig(map[string]any{
+			"self_review": map[string]any{
+				"max_iterations":          "5",
+				"verification_timeout_ms": float64(60000),
+				"max_diff_bytes":          "51200",
+			},
+		})
+		if err != nil {
+			t.Fatalf("NewServiceConfig: %v", err)
+		}
+		assertIntEqual(t, "SelfReview.MaxIterations", 5, cfg.SelfReview.MaxIterations)
+		assertIntEqual(t, "SelfReview.VerificationTimeoutMS", 60000, cfg.SelfReview.VerificationTimeoutMS)
+		assertIntEqual(t, "SelfReview.MaxDiffBytes", 51200, cfg.SelfReview.MaxDiffBytes)
+	})
+
+	t.Run("SchemaUnknownKey", func(t *testing.T) {
+		t.Parallel()
+		// Unknown keys inside self_review must not cause a crash; the
+		// schema layer emits a warning but NewServiceConfig still succeeds.
+		cfg, err := NewServiceConfig(map[string]any{
+			"self_review": map[string]any{"unknown_field": "value"},
+		})
+		if err != nil {
+			t.Fatalf("NewServiceConfig: %v", err)
+		}
+		if cfg.SelfReview.Enabled {
+			t.Error("SelfReview.Enabled = true, want false")
+		}
+	})
+
+	t.Run("NotLeakedToExtensions", func(t *testing.T) {
+		t.Parallel()
+		cfg, err := NewServiceConfig(map[string]any{
+			"self_review": map[string]any{
+				"enabled":               true,
+				"verification_commands": []any{"make test"},
+			},
+		})
+		if err != nil {
+			t.Fatalf("NewServiceConfig: %v", err)
+		}
+		if _, ok := cfg.Extensions["self_review"]; ok {
+			t.Error("self_review leaked into cfg.Extensions; want absent")
+		}
+	})
+}

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -99,6 +99,16 @@ var knownFieldsRegistry = map[string]SectionSchema{
 			{Name: "escalation_label", Type: FieldString},
 		},
 	},
+	"self_review": {
+		Fields: []FieldDef{
+			{Name: "enabled", Type: FieldBool},
+			{Name: "max_iterations", Type: FieldInt},
+			{Name: "verification_commands", Type: FieldStringList},
+			{Name: "verification_timeout_ms", Type: FieldInt},
+			{Name: "max_diff_bytes", Type: FieldInt},
+			{Name: "reviewer", Type: FieldString},
+		},
+	},
 }
 
 // staticKnownExtensionKeys lists extension top-level keys defined by

--- a/internal/domain/metrics.go
+++ b/internal/domain/metrics.go
@@ -113,6 +113,26 @@ type Metrics interface {
 	// action is "label", "comment", or "error"
 	// (sortie_ci_escalations_total{action} counter).
 	IncCIEscalations(action string)
+
+	// IncSelfReviewIterations increments the review iteration counter.
+	// verdict is "pass", "iterate", or "none"
+	// (sortie_self_review_iterations_total{verdict} counter).
+	IncSelfReviewIterations(verdict string)
+
+	// IncSelfReviewSessions increments the review session counter.
+	// finalVerdict is "pass", "iterate", or "none"
+	// (sortie_self_review_sessions_total{final_verdict} counter).
+	IncSelfReviewSessions(finalVerdict string)
+
+	// ObserveSelfReviewVerificationDuration records the duration of a
+	// single verification command in seconds.
+	// command is truncated to the first 64 characters before use as label
+	// (sortie_self_review_verification_duration_seconds{command} histogram).
+	ObserveSelfReviewVerificationDuration(command string, seconds float64)
+
+	// IncSelfReviewCapReached increments the cap-reached counter
+	// (sortie_self_review_cap_reached_total counter).
+	IncSelfReviewCapReached()
 }
 
 // NoopMetrics is a [Metrics] implementation where every method is a no-op.
@@ -123,27 +143,31 @@ type NoopMetrics struct{}
 
 var _ Metrics = (*NoopMetrics)(nil)
 
-func (*NoopMetrics) SetRunningSessions(int)                {}
-func (*NoopMetrics) SetRetryingSessions(int)               {}
-func (*NoopMetrics) SetAvailableSlots(int)                 {}
-func (*NoopMetrics) SetActiveSessionsElapsed(float64)      {}
-func (*NoopMetrics) AddTokens(string, int64)               {}
-func (*NoopMetrics) AddAgentRuntime(float64)               {}
-func (*NoopMetrics) IncDispatches(string)                  {}
-func (*NoopMetrics) IncWorkerExits(string)                 {}
-func (*NoopMetrics) IncRetries(string)                     {}
-func (*NoopMetrics) IncReconciliationActions(string)       {}
-func (*NoopMetrics) IncPollCycles(string)                  {}
-func (*NoopMetrics) IncTrackerRequests(string, string)     {}
-func (*NoopMetrics) IncHandoffTransitions(string)          {}
-func (*NoopMetrics) IncDispatchTransitions(string)         {}
-func (*NoopMetrics) IncTrackerComments(string, string)     {}
-func (*NoopMetrics) IncToolCalls(string, string)           {}
-func (*NoopMetrics) ObservePollDuration(float64)           {}
-func (*NoopMetrics) ObserveWorkerDuration(string, float64) {}
-func (*NoopMetrics) SetSSHHostUsage(string, int)           {}
-func (*NoopMetrics) IncCIStatusChecks(string)              {}
-func (*NoopMetrics) IncCIEscalations(string)               {}
+func (*NoopMetrics) SetRunningSessions(int)                                {}
+func (*NoopMetrics) SetRetryingSessions(int)                               {}
+func (*NoopMetrics) SetAvailableSlots(int)                                 {}
+func (*NoopMetrics) SetActiveSessionsElapsed(float64)                      {}
+func (*NoopMetrics) AddTokens(string, int64)                               {}
+func (*NoopMetrics) AddAgentRuntime(float64)                               {}
+func (*NoopMetrics) IncDispatches(string)                                  {}
+func (*NoopMetrics) IncWorkerExits(string)                                 {}
+func (*NoopMetrics) IncRetries(string)                                     {}
+func (*NoopMetrics) IncReconciliationActions(string)                       {}
+func (*NoopMetrics) IncPollCycles(string)                                  {}
+func (*NoopMetrics) IncTrackerRequests(string, string)                     {}
+func (*NoopMetrics) IncHandoffTransitions(string)                          {}
+func (*NoopMetrics) IncDispatchTransitions(string)                         {}
+func (*NoopMetrics) IncTrackerComments(string, string)                     {}
+func (*NoopMetrics) IncToolCalls(string, string)                           {}
+func (*NoopMetrics) ObservePollDuration(float64)                           {}
+func (*NoopMetrics) ObserveWorkerDuration(string, float64)                 {}
+func (*NoopMetrics) SetSSHHostUsage(string, int)                           {}
+func (*NoopMetrics) IncCIStatusChecks(string)                              {}
+func (*NoopMetrics) IncCIEscalations(string)                               {}
+func (*NoopMetrics) IncSelfReviewIterations(string)                        {}
+func (*NoopMetrics) IncSelfReviewSessions(string)                          {}
+func (*NoopMetrics) ObserveSelfReviewVerificationDuration(string, float64) {}
+func (*NoopMetrics) IncSelfReviewCapReached()                              {}
 
 // MetricsSetter is implemented by adapters that accept a [Metrics]
 // recorder for self-instrumentation.

--- a/internal/domain/review.go
+++ b/internal/domain/review.go
@@ -1,0 +1,116 @@
+package domain
+
+// MaxVerificationOutputBytes is the per-stream cap on stdout and stderr
+// captured from each verification command during the self-review loop.
+// This prevents a runaway test suite from consuming unbounded memory.
+const MaxVerificationOutputBytes = 65536
+
+// VerificationResult holds the outcome of a single verification command
+// executed during the self-review loop.
+type VerificationResult struct {
+	// Command is the shell command that was executed.
+	Command string `json:"command"`
+
+	// ExitCode is the process exit code. 0 indicates success.
+	// -1 indicates the command could not be started or timed out.
+	ExitCode int `json:"exit_code"`
+
+	// Stdout is the captured standard output, truncated to
+	// MaxVerificationOutputBytes.
+	Stdout string `json:"stdout"`
+
+	// Stderr is the captured standard error, truncated to
+	// MaxVerificationOutputBytes.
+	Stderr string `json:"stderr"`
+
+	// DurationMS is the wall-clock execution time in milliseconds.
+	DurationMS int64 `json:"duration_ms"`
+
+	// TimedOut is true when the command exceeded VerificationTimeoutMS.
+	TimedOut bool `json:"timed_out"`
+
+	// ExecutionError is non-empty when the command could not be
+	// started (binary not found, permission denied). Empty when the
+	// command ran (regardless of exit code).
+	ExecutionError string `json:"execution_error,omitempty"`
+}
+
+// ReviewIssue describes a single finding in the agent's review.
+type ReviewIssue struct {
+	// File is the relative path within the workspace.
+	File string `json:"file"`
+
+	// Line is the starting line number. 0 when not applicable.
+	Line int `json:"line,omitempty"`
+
+	// EndLine is the ending line number. 0 when not applicable.
+	EndLine int `json:"end_line,omitempty"`
+
+	// Severity is the finding severity: "error", "warning", "info".
+	Severity string `json:"severity"`
+
+	// Message describes the issue and suggested fix direction.
+	Message string `json:"message"`
+}
+
+// ReviewVerdict is the structured response from the agent's review turn,
+// read from .sortie/review_verdict.json in the workspace directory.
+type ReviewVerdict struct {
+	// Verdict is the agent's assessment: "pass" or "iterate".
+	Verdict string `json:"verdict"`
+
+	// Summary is a one-line summary of the review finding.
+	Summary string `json:"summary"`
+
+	// Issues is a list of specific findings. Present only when
+	// Verdict is "iterate".
+	Issues []ReviewIssue `json:"issues,omitempty"`
+}
+
+// ReviewIterationRecord captures one iteration of the self-review loop
+// for persistence and observability.
+type ReviewIterationRecord struct {
+	// Iteration is the 1-based iteration number.
+	Iteration int `json:"iteration"`
+
+	// DiffSizeBytes is the size of the diff in bytes before truncation.
+	DiffSizeBytes int `json:"diff_size_bytes"`
+
+	// DiffTruncated is true when the diff was truncated to max_diff_bytes.
+	DiffTruncated bool `json:"diff_truncated"`
+
+	// VerificationResults holds the outcome of each verification command.
+	VerificationResults []VerificationResult `json:"verification_results"`
+
+	// Verdict is the parsed verdict from the agent. Empty when the
+	// verdict file was missing or unparseable.
+	Verdict string `json:"verdict"`
+
+	// VerdictRaw is the raw JSON content of .sortie/review_verdict.json.
+	// Empty when the file was absent.
+	VerdictRaw string `json:"verdict_raw,omitempty"`
+
+	// VerdictParseError is non-empty when the verdict file existed but
+	// could not be parsed or was absent.
+	VerdictParseError string `json:"verdict_parse_error,omitempty"`
+}
+
+// ReviewMetadata captures the self-review loop outcome for persistence,
+// observability, and PR annotation.
+type ReviewMetadata struct {
+	// Enabled is true when self-review was configured and ran.
+	Enabled bool `json:"enabled"`
+
+	// Iterations holds the per-iteration records.
+	Iterations []ReviewIterationRecord `json:"iterations"`
+
+	// TotalIterations is the number of review iterations completed.
+	TotalIterations int `json:"total_iterations"`
+
+	// FinalVerdict is the last verdict: "pass", "iterate", or "none".
+	FinalVerdict string `json:"final_verdict"`
+
+	// CapReached is true when the iteration cap was reached without
+	// a "pass" verdict.
+	CapReached bool `json:"cap_reached"`
+}

--- a/internal/domain/review_test.go
+++ b/internal/domain/review_test.go
@@ -1,0 +1,199 @@
+package domain
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestVerificationResult_ZeroValue(t *testing.T) {
+	t.Parallel()
+
+	var vr VerificationResult
+	if vr.Command != "" {
+		t.Errorf("Command = %q, want empty", vr.Command)
+	}
+	if vr.ExitCode != 0 {
+		t.Errorf("ExitCode = %d, want 0", vr.ExitCode)
+	}
+	if vr.Stdout != "" {
+		t.Errorf("Stdout = %q, want empty", vr.Stdout)
+	}
+	if vr.Stderr != "" {
+		t.Errorf("Stderr = %q, want empty", vr.Stderr)
+	}
+	if vr.DurationMS != 0 {
+		t.Errorf("DurationMS = %d, want 0", vr.DurationMS)
+	}
+	if vr.TimedOut {
+		t.Error("TimedOut = true, want false")
+	}
+	if vr.ExecutionError != "" {
+		t.Errorf("ExecutionError = %q, want empty", vr.ExecutionError)
+	}
+}
+
+func TestReviewMetadata_ZeroValue(t *testing.T) {
+	t.Parallel()
+
+	var rm ReviewMetadata
+	if rm.Enabled {
+		t.Error("Enabled = true, want false")
+	}
+	if rm.Iterations != nil {
+		t.Errorf("Iterations = %v, want nil", rm.Iterations)
+	}
+	if rm.TotalIterations != 0 {
+		t.Errorf("TotalIterations = %d, want 0", rm.TotalIterations)
+	}
+	if rm.FinalVerdict != "" {
+		t.Errorf("FinalVerdict = %q, want empty", rm.FinalVerdict)
+	}
+	if rm.CapReached {
+		t.Error("CapReached = true, want false")
+	}
+}
+
+func TestReviewVerdict_JSONRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		verdict ReviewVerdict
+	}{
+		{
+			name: "pass verdict no issues",
+			verdict: ReviewVerdict{
+				Verdict: "pass",
+				Summary: "All checks passed",
+			},
+		},
+		{
+			name: "iterate verdict with issues",
+			verdict: ReviewVerdict{
+				Verdict: "iterate",
+				Summary: "Found 2 issues",
+				Issues: []ReviewIssue{
+					{File: "main.go", Line: 42, Severity: "error", Message: "nil dereference"},
+					{File: "util.go", Severity: "warning", Message: "unused variable"},
+				},
+			},
+		},
+		{
+			name:    "zero value",
+			verdict: ReviewVerdict{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			data, err := json.Marshal(tt.verdict)
+			if err != nil {
+				t.Fatalf("json.Marshal(ReviewVerdict) error: %v", err)
+			}
+
+			var got ReviewVerdict
+			if err := json.Unmarshal(data, &got); err != nil {
+				t.Fatalf("json.Unmarshal(ReviewVerdict) error: %v", err)
+			}
+
+			if got.Verdict != tt.verdict.Verdict {
+				t.Errorf("Verdict = %q, want %q", got.Verdict, tt.verdict.Verdict)
+			}
+			if got.Summary != tt.verdict.Summary {
+				t.Errorf("Summary = %q, want %q", got.Summary, tt.verdict.Summary)
+			}
+			if len(got.Issues) != len(tt.verdict.Issues) {
+				t.Fatalf("Issues len = %d, want %d", len(got.Issues), len(tt.verdict.Issues))
+			}
+			for i, wantIssue := range tt.verdict.Issues {
+				gotIssue := got.Issues[i]
+				if gotIssue.File != wantIssue.File {
+					t.Errorf("Issues[%d].File = %q, want %q", i, gotIssue.File, wantIssue.File)
+				}
+				if gotIssue.Line != wantIssue.Line {
+					t.Errorf("Issues[%d].Line = %d, want %d", i, gotIssue.Line, wantIssue.Line)
+				}
+				if gotIssue.Severity != wantIssue.Severity {
+					t.Errorf("Issues[%d].Severity = %q, want %q", i, gotIssue.Severity, wantIssue.Severity)
+				}
+				if gotIssue.Message != wantIssue.Message {
+					t.Errorf("Issues[%d].Message = %q, want %q", i, gotIssue.Message, wantIssue.Message)
+				}
+			}
+		})
+	}
+}
+
+func TestReviewIssue_JSONRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		issue ReviewIssue
+	}{
+		{
+			name: "full issue with line range",
+			issue: ReviewIssue{
+				File:     "internal/foo/bar.go",
+				Line:     10,
+				EndLine:  15,
+				Severity: "error",
+				Message:  "index out of bounds",
+			},
+		},
+		{
+			name: "issue without line numbers",
+			issue: ReviewIssue{
+				File:     "README.md",
+				Severity: "info",
+				Message:  "missing example",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			data, err := json.Marshal(tt.issue)
+			if err != nil {
+				t.Fatalf("json.Marshal(ReviewIssue) error: %v", err)
+			}
+
+			var got ReviewIssue
+			if err := json.Unmarshal(data, &got); err != nil {
+				t.Fatalf("json.Unmarshal(ReviewIssue) error: %v", err)
+			}
+
+			if got.File != tt.issue.File {
+				t.Errorf("File = %q, want %q", got.File, tt.issue.File)
+			}
+			if got.Line != tt.issue.Line {
+				t.Errorf("Line = %d, want %d", got.Line, tt.issue.Line)
+			}
+			if got.EndLine != tt.issue.EndLine {
+				t.Errorf("EndLine = %d, want %d", got.EndLine, tt.issue.EndLine)
+			}
+			if got.Severity != tt.issue.Severity {
+				t.Errorf("Severity = %q, want %q", got.Severity, tt.issue.Severity)
+			}
+			if got.Message != tt.issue.Message {
+				t.Errorf("Message = %q, want %q", got.Message, tt.issue.Message)
+			}
+		})
+	}
+}
+
+func TestMaxVerificationOutputBytes(t *testing.T) {
+	t.Parallel()
+
+	if MaxVerificationOutputBytes <= 0 {
+		t.Errorf("MaxVerificationOutputBytes = %d, want positive", MaxVerificationOutputBytes)
+	}
+	// Sanity-check the documented value (64 KB).
+	if MaxVerificationOutputBytes != 65536 {
+		t.Errorf("MaxVerificationOutputBytes = %d, want 65536", MaxVerificationOutputBytes)
+	}
+}

--- a/internal/orchestrator/exit.go
+++ b/internal/orchestrator/exit.go
@@ -2,6 +2,7 @@ package orchestrator
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -216,6 +217,15 @@ func HandleWorkerExit(state *State, workerResult WorkerResult, params HandleWork
 		Error:          errorStringPtr(workerResult.Error),
 		WorkflowFile:   entry.WorkflowFile,
 		TurnsCompleted: workerResult.TurnsCompleted,
+	}
+	if workerResult.ReviewMetadata != nil {
+		data, marshalErr := json.Marshal(workerResult.ReviewMetadata)
+		if marshalErr != nil {
+			log.Warn("failed to marshal review metadata", slog.Any("error", marshalErr))
+		} else {
+			s := string(data)
+			runHistory.ReviewMetadata = &s
+		}
 	}
 	if _, err := params.Store.AppendRunHistory(ctx, runHistory); err != nil {
 		log.Error("failed to persist run history",

--- a/internal/orchestrator/exit_test.go
+++ b/internal/orchestrator/exit_test.go
@@ -3,6 +3,7 @@ package orchestrator
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -2742,5 +2743,78 @@ func TestHandleWorkerExit_TrackerOpsWgDrains(t *testing.T) {
 	case <-waitDone:
 	case <-time.After(2 * time.Second):
 		t.Fatal("TrackerOpsWg.Wait() did not return after CommentIssue goroutine completed")
+	}
+}
+
+func TestHandleWorkerExit_ReviewMetadata_Persisted(t *testing.T) {
+	t.Parallel()
+
+	store := &mockExitStore{}
+	state := exitState(t, "RM-1", nil)
+	params := defaultExitParams(t, store)
+
+	meta := &domain.ReviewMetadata{
+		Enabled:         true,
+		TotalIterations: 2,
+		FinalVerdict:    "pass",
+		CapReached:      false,
+		Iterations: []domain.ReviewIterationRecord{
+			{Iteration: 1, Verdict: "iterate"},
+			{Iteration: 2, Verdict: "pass"},
+		},
+	}
+
+	HandleWorkerExit(state, WorkerResult{
+		IssueID:        "RM-1",
+		Identifier:     "RM-1-ident",
+		ExitKind:       WorkerExitNormal,
+		AgentAdapter:   "mock",
+		ReviewMetadata: meta,
+	}, params)
+
+	if len(store.runHistories) != 1 {
+		t.Fatalf("AppendRunHistory called %d times, want 1", len(store.runHistories))
+	}
+
+	rh := store.runHistories[0]
+	if rh.ReviewMetadata == nil {
+		t.Fatal("RunHistory.ReviewMetadata = nil, want non-nil JSON string")
+	}
+
+	var got domain.ReviewMetadata
+	if err := json.Unmarshal([]byte(*rh.ReviewMetadata), &got); err != nil {
+		t.Fatalf("unmarshal RunHistory.ReviewMetadata: %v", err)
+	}
+	if got.FinalVerdict != "pass" {
+		t.Errorf("ReviewMetadata.FinalVerdict = %q, want %q", got.FinalVerdict, "pass")
+	}
+	if got.TotalIterations != 2 {
+		t.Errorf("ReviewMetadata.TotalIterations = %d, want 2", got.TotalIterations)
+	}
+	if got.CapReached {
+		t.Error("ReviewMetadata.CapReached = true, want false")
+	}
+}
+
+func TestHandleWorkerExit_ReviewMetadata_Nil(t *testing.T) {
+	t.Parallel()
+
+	store := &mockExitStore{}
+	state := exitState(t, "RM-2", nil)
+	params := defaultExitParams(t, store)
+
+	HandleWorkerExit(state, WorkerResult{
+		IssueID:        "RM-2",
+		Identifier:     "RM-2-ident",
+		ExitKind:       WorkerExitNormal,
+		AgentAdapter:   "mock",
+		ReviewMetadata: nil,
+	}, params)
+
+	if len(store.runHistories) != 1 {
+		t.Fatalf("AppendRunHistory called %d times, want 1", len(store.runHistories))
+	}
+	if store.runHistories[0].ReviewMetadata != nil {
+		t.Errorf("RunHistory.ReviewMetadata = %q, want nil", *store.runHistories[0].ReviewMetadata)
 	}
 }

--- a/internal/orchestrator/metrics_test.go
+++ b/internal/orchestrator/metrics_test.go
@@ -187,6 +187,14 @@ func (s *spyMetrics) IncCIStatusChecks(_ string) {}
 
 func (s *spyMetrics) IncCIEscalations(_ string) {}
 
+func (s *spyMetrics) IncSelfReviewIterations(_ string) {}
+
+func (s *spyMetrics) IncSelfReviewSessions(_ string) {}
+
+func (s *spyMetrics) ObserveSelfReviewVerificationDuration(_ string, _ float64) {}
+
+func (s *spyMetrics) IncSelfReviewCapReached() {}
+
 // --- Tests ---
 
 func TestActiveElapsedSeconds(t *testing.T) {

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -276,8 +276,13 @@ func (o *Orchestrator) Run(ctx context.Context) {
 
 		case msg := <-o.selfReviewCh:
 			if entry, ok := o.state.Running[msg.IssueID]; ok {
-				entry.SelfReviewActive = msg.Message != "self_review_done"
-				entry.SelfReviewIteration = msg.Iteration
+				if msg.Message == "self_review_done" {
+					entry.SelfReviewActive = false
+					entry.SelfReviewIteration = 0
+				} else {
+					entry.SelfReviewActive = true
+					entry.SelfReviewIteration = msg.Iteration
+				}
 			}
 
 		case req := <-o.snapshotCh:

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -108,6 +108,7 @@ type Orchestrator struct {
 	workerExitCh chan WorkerResult
 	retryTimerCh chan string
 	agentEventCh chan agentEventMsg
+	selfReviewCh chan selfReviewProgressMsg
 	snapshotCh   chan snapshotRequest
 	refreshCh    chan struct{}
 
@@ -183,6 +184,7 @@ func NewOrchestrator(params OrchestratorParams) *Orchestrator {
 		workerExitCh:     make(chan WorkerResult, exitBuf),
 		retryTimerCh:     make(chan string, retryBuf),
 		agentEventCh:     make(chan agentEventMsg, eventBuf),
+		selfReviewCh:     make(chan selfReviewProgressMsg, eventBuf),
 		snapshotCh:       make(chan snapshotRequest, 4),
 		refreshCh:        make(chan struct{}, 1),
 		preflightParams:  params.PreflightParams,
@@ -271,6 +273,12 @@ func (o *Orchestrator) Run(ctx context.Context) {
 
 		case msg := <-o.agentEventCh:
 			HandleAgentEvent(o.state, msg.IssueID, msg.Event, o.logger, o.metrics)
+
+		case msg := <-o.selfReviewCh:
+			if entry, ok := o.state.Running[msg.IssueID]; ok {
+				entry.SelfReviewActive = msg.Message != "self_review_done"
+				entry.SelfReviewIteration = msg.Iteration
+			}
 
 		case req := <-o.snapshotCh:
 			snap := RuntimeSnapshot(o.state, time.Now())
@@ -474,6 +482,15 @@ func (o *Orchestrator) makeWorkerFn(resumeSessionID string, sshHost string) Work
 			},
 			OnExit: func(issueID string, result WorkerResult) {
 				o.workerExitCh <- result
+			},
+			OnProgress: func(msg selfReviewProgressMsg) {
+				select {
+				case o.selfReviewCh <- msg:
+				default:
+					logger.Warn("self-review progress channel full, dropping",
+						slog.String("issue_id", msg.IssueID),
+					)
+				}
 			},
 			ResumeSessionID:          resumeSessionID,
 			Logger:                   logger,

--- a/internal/orchestrator/self_review.go
+++ b/internal/orchestrator/self_review.go
@@ -10,7 +10,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/sortie-ai/sortie/internal/agent/procutil"
@@ -44,6 +43,29 @@ type RunSelfReviewParams struct {
 
 // maxVerdictFileBytes is the cap on .sortie/review_verdict.json reads.
 const maxVerdictFileBytes = 65536
+
+// cappedWriter captures up to max bytes of written data, silently
+// discarding excess. Write always reports the full input length so the
+// writing subprocess never blocks on a full pipe buffer.
+type cappedWriter struct {
+	buf strings.Builder
+	max int
+}
+
+func (w *cappedWriter) Write(p []byte) (int, error) {
+	if w.buf.Len() < w.max {
+		remaining := w.max - w.buf.Len()
+		if remaining > len(p) {
+			remaining = len(p)
+		}
+		w.buf.Write(p[:remaining])
+	}
+	return len(p), nil
+}
+
+func (w *cappedWriter) String() string {
+	return w.buf.String()
+}
 
 func generateWorkspaceDiff(ctx context.Context, workspacePath string, maxDiffBytes int) (diff string, originalSize int, truncated bool, err error) {
 	// Stage intent-to-add so new files appear in the diff.
@@ -88,24 +110,20 @@ func runSingleVerification(ctx context.Context, command, workspacePath string, t
 	cmd.Dir = workspacePath
 	procutil.SetProcessGroup(cmd)
 
-	var stdoutBuf, stderrBuf strings.Builder
+	// Use cappedWriter for stdout/stderr instead of StdoutPipe/StderrPipe.
+	// On Windows, ReadFile on a pipe can remain blocked after the subprocess
+	// is killed, causing wg.Wait() to hang before cmd.Wait() is reached.
+	// Assigning direct writers lets Go manage the internal pipe goroutines
+	// and WaitDelay ensures Wait returns even if those goroutines are stuck.
+	var stdoutBuf, stderrBuf cappedWriter
+	stdoutBuf.max = int(domain.MaxVerificationOutputBytes)
+	stderrBuf.max = int(domain.MaxVerificationOutputBytes)
+	cmd.Stdout = &stdoutBuf
+	cmd.Stderr = &stderrBuf
 
-	stdoutPipe, pipeErr := cmd.StdoutPipe()
-	if pipeErr != nil {
-		return domain.VerificationResult{
-			Command:        command,
-			ExitCode:       -1,
-			ExecutionError: pipeErr.Error(),
-		}
-	}
-	stderrPipe, pipeErr := cmd.StderrPipe()
-	if pipeErr != nil {
-		return domain.VerificationResult{
-			Command:        command,
-			ExitCode:       -1,
-			ExecutionError: pipeErr.Error(),
-		}
-	}
+	// WaitDelay lets cmd.Wait return after process termination even when
+	// internal I/O goroutines are still blocked on pipe reads (Windows).
+	cmd.WaitDelay = 5 * time.Second
 
 	start := time.Now()
 	if err := cmd.Start(); err != nil {
@@ -121,35 +139,6 @@ func runSingleVerification(ctx context.Context, command, workspacePath string, t
 			ExecutionError: err.Error(),
 		}
 	}
-
-	// Drain stdout and stderr concurrently to avoid deadlock when either
-	// pipe fills its OS buffer while the other is not being read.
-	var wg sync.WaitGroup
-	wg.Add(2)
-	readLimited := func(r io.Reader, w *strings.Builder) {
-		defer wg.Done()
-		limited := io.LimitReader(r, domain.MaxVerificationOutputBytes)
-		_, _ = io.Copy(w, limited)
-	}
-	go readLimited(stdoutPipe, &stdoutBuf)
-	go readLimited(stderrPipe, &stderrBuf)
-
-	// On some platforms (notably Windows with MSYS2 shells), the write
-	// end of the stdout/stderr pipes may not close promptly when the
-	// process is killed via context cancellation. Explicitly close the
-	// read ends when the context expires so that the drain goroutines
-	// are unblocked and wg.Wait() can return.
-	drainDone := make(chan struct{})
-	go func() {
-		select {
-		case <-cmdCtx.Done():
-			stdoutPipe.Close()
-			stderrPipe.Close()
-		case <-drainDone:
-		}
-	}()
-	wg.Wait()
-	close(drainDone)
 
 	err := cmd.Wait()
 	duration := time.Since(start)

--- a/internal/orchestrator/self_review.go
+++ b/internal/orchestrator/self_review.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/sortie-ai/sortie/internal/agent/procutil"
@@ -44,7 +45,7 @@ type RunSelfReviewParams struct {
 // maxVerdictFileBytes is the cap on .sortie/review_verdict.json reads.
 const maxVerdictFileBytes = 65536
 
-func generateWorkspaceDiff(ctx context.Context, workspacePath string, maxDiffBytes int) (string, bool, error) {
+func generateWorkspaceDiff(ctx context.Context, workspacePath string, maxDiffBytes int) (diff string, originalSize int, truncated bool, err error) {
 	// Stage intent-to-add so new files appear in the diff.
 	intentCmd := exec.CommandContext(ctx, "git", "add", "--intent-to-add", ".")
 	intentCmd.Dir = workspacePath
@@ -52,25 +53,25 @@ func generateWorkspaceDiff(ctx context.Context, workspacePath string, maxDiffByt
 
 	cmd := exec.CommandContext(ctx, "git", "diff", "HEAD")
 	cmd.Dir = workspacePath
-	output, err := cmd.CombinedOutput()
-	if err != nil {
+	output, cmdErr := cmd.CombinedOutput()
+	if cmdErr != nil {
 		// Fallback: try without HEAD (empty repo with staged files).
 		cmd2 := exec.CommandContext(ctx, "git", "diff")
 		cmd2.Dir = workspacePath
 		output2, err2 := cmd2.CombinedOutput()
 		if err2 != nil {
-			return "", false, fmt.Errorf("git diff failed: %w (fallback: %w)", err, err2)
+			return "", 0, false, fmt.Errorf("git diff failed: %w (fallback: %w)", cmdErr, err2)
 		}
 		output = output2
 	}
 
-	truncated := false
+	originalSize = len(output)
 	if maxDiffBytes > 0 && len(output) > maxDiffBytes {
 		output = output[:maxDiffBytes]
 		truncated = true
 	}
 
-	return string(output), truncated, nil
+	return string(output), originalSize, truncated, nil
 }
 
 func runSingleVerification(ctx context.Context, command, workspacePath string, timeoutMS int, logger *slog.Logger, metrics domain.Metrics) domain.VerificationResult {
@@ -121,13 +122,18 @@ func runSingleVerification(ctx context.Context, command, workspacePath string, t
 		}
 	}
 
-	// Read stdout and stderr with limits.
+	// Drain stdout and stderr concurrently to avoid deadlock when either
+	// pipe fills its OS buffer while the other is not being read.
+	var wg sync.WaitGroup
+	wg.Add(2)
 	readLimited := func(r io.Reader, w *strings.Builder) {
+		defer wg.Done()
 		limited := io.LimitReader(r, domain.MaxVerificationOutputBytes)
 		_, _ = io.Copy(w, limited)
 	}
-	readLimited(stdoutPipe, &stdoutBuf)
-	readLimited(stderrPipe, &stderrBuf)
+	go readLimited(stdoutPipe, &stdoutBuf)
+	go readLimited(stderrPipe, &stderrBuf)
+	wg.Wait()
 
 	err := cmd.Wait()
 	duration := time.Since(start)
@@ -136,7 +142,7 @@ func runSingleVerification(ctx context.Context, command, workspacePath string, t
 
 	if cmdCtx.Err() == context.DeadlineExceeded {
 		if cmd.Process != nil {
-			_ = procutil.SignalProcessGroup(cmd.Process.Pid, 9) // SIGKILL
+			_ = procutil.KillProcessGroup(cmd.Process.Pid)
 		}
 		logger.Info("verification command timed out",
 			slog.String("command", command),
@@ -194,10 +200,23 @@ func readReviewVerdict(workspacePath string) (*domain.ReviewVerdict, string, str
 	}
 
 	path := filepath.Join(dir, "review_verdict.json")
-	f, err := os.Open(path) //nolint:gosec // path is constructed from operator-controlled workspace root
-	if os.IsNotExist(err) {
-		return nil, "", "verdict file not found"
+
+	// Reject symlinked verdict files to prevent reading arbitrary host files.
+	fileFI, fileErr := os.Lstat(path)
+	if fileErr != nil {
+		if os.IsNotExist(fileErr) {
+			return nil, "", "verdict file not found"
+		}
+		return nil, "", fmt.Sprintf("verdict stat error: %v", fileErr)
 	}
+	if fileFI.Mode()&os.ModeSymlink != 0 {
+		return nil, "", "refusing to read symlinked verdict file"
+	}
+	if !fileFI.Mode().IsRegular() {
+		return nil, "", "verdict path is not a regular file"
+	}
+
+	f, err := os.Open(path) //nolint:gosec // path is constructed from operator-controlled workspace root
 	if err != nil {
 		return nil, "", fmt.Sprintf("verdict open error: %v", err)
 	}
@@ -427,15 +446,11 @@ func runSelfReviewLoop(ctx context.Context, params RunSelfReviewParams) *domain.
 			break
 		}
 
-		diff, truncated, diffErr := generateWorkspaceDiff(ctx, params.WorkspacePath, params.Config.MaxDiffBytes)
+		diff, diffSize, truncated, diffErr := generateWorkspaceDiff(ctx, params.WorkspacePath, params.Config.MaxDiffBytes)
 		if diffErr != nil {
 			logger.Warn("self-review diff generation failed", slog.Any("error", diffErr))
 			diff = ""
-		}
-
-		diffSize := len(diff)
-		if truncated {
-			diffSize = params.Config.MaxDiffBytes
+			diffSize = 0
 		}
 
 		var verificationResults []domain.VerificationResult
@@ -449,8 +464,23 @@ func runSelfReviewLoop(ctx context.Context, params RunSelfReviewParams) *domain.
 
 		reviewPrompt := assembleReviewPrompt(params.Issue, diff, truncated, verificationResults, i, maxIter)
 
-		// Remove previous verdict file before the review turn.
-		_ = os.Remove(filepath.Join(params.WorkspacePath, ".sortie", "review_verdict.json"))
+		// Remove previous verdict file only when .sortie is a real directory.
+		sortieDirPath := filepath.Join(params.WorkspacePath, ".sortie")
+		sortieInfo, sortieErr := os.Lstat(sortieDirPath)
+		if sortieErr == nil {
+			if sortieInfo.Mode()&os.ModeSymlink == 0 && sortieInfo.IsDir() {
+				_ = os.Remove(filepath.Join(sortieDirPath, "review_verdict.json"))
+			} else {
+				logger.Warn("self-review verdict cleanup skipped: .sortie is a symlink or not a directory",
+					slog.Int("iteration", i),
+				)
+			}
+		} else if !os.IsNotExist(sortieErr) {
+			logger.Warn("self-review verdict cleanup failed",
+				slog.Int("iteration", i),
+				slog.Any("error", sortieErr),
+			)
+		}
 
 		_, turnErr := params.AgentAdapter.RunTurn(ctx, params.Session, domain.RunTurnParams{
 			Prompt: reviewPrompt,

--- a/internal/orchestrator/self_review.go
+++ b/internal/orchestrator/self_review.go
@@ -334,12 +334,18 @@ func assembleReviewPrompt(issue domain.Issue, diff string, truncated bool, vresu
 	return sb.String()
 }
 
-func buildFixPrompt(verdict *domain.ReviewVerdict, _ string, iteration, maxIterations int) string {
+func buildFixPrompt(verdict *domain.ReviewVerdict, parseErr string, iteration, maxIterations int) string {
 	var sb strings.Builder
 
 	fmt.Fprintf(&sb, "## Self-Review Fix: Iteration %d of %d\n\n", iteration, maxIterations)
 	sb.WriteString("The self-review identified issues that need to be fixed. Your previous review feedback\n")
 	sb.WriteString("is in your conversation history above.\n\n")
+
+	if parseErr != "" {
+		sb.WriteString("The orchestrator could not parse your previous review verdict.\n")
+		sb.WriteString("Ensure `.sortie/review_verdict.json` is present and valid JSON with a `verdict` field set to `pass` or `iterate`.\n")
+		fmt.Fprintf(&sb, "Parse error: %s\n\n", parseErr)
+	}
 
 	if verdict != nil && len(verdict.Issues) > 0 {
 		sb.WriteString("Focus on these issues:\n")

--- a/internal/orchestrator/self_review.go
+++ b/internal/orchestrator/self_review.go
@@ -133,7 +133,23 @@ func runSingleVerification(ctx context.Context, command, workspacePath string, t
 	}
 	go readLimited(stdoutPipe, &stdoutBuf)
 	go readLimited(stderrPipe, &stderrBuf)
+
+	// On some platforms (notably Windows with MSYS2 shells), the write
+	// end of the stdout/stderr pipes may not close promptly when the
+	// process is killed via context cancellation. Explicitly close the
+	// read ends when the context expires so that the drain goroutines
+	// are unblocked and wg.Wait() can return.
+	drainDone := make(chan struct{})
+	go func() {
+		select {
+		case <-cmdCtx.Done():
+			stdoutPipe.Close()
+			stderrPipe.Close()
+		case <-drainDone:
+		}
+	}()
 	wg.Wait()
+	close(drainDone)
 
 	err := cmd.Wait()
 	duration := time.Since(start)

--- a/internal/orchestrator/self_review.go
+++ b/internal/orchestrator/self_review.go
@@ -1,0 +1,617 @@
+package orchestrator
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/sortie-ai/sortie/internal/agent/procutil"
+	"github.com/sortie-ai/sortie/internal/config"
+	"github.com/sortie-ai/sortie/internal/domain"
+	"github.com/sortie-ai/sortie/internal/workspace"
+)
+
+// selfReviewProgressMsg carries self-review loop progress from the
+// worker goroutine to the orchestrator event loop.
+type selfReviewProgressMsg struct {
+	IssueID       string
+	Message       string
+	Iteration     int
+	MaxIterations int
+}
+
+// RunSelfReviewParams captures all inputs for runSelfReviewLoop.
+type RunSelfReviewParams struct {
+	Session        domain.Session
+	Issue          domain.Issue
+	WorkspacePath  string
+	Config         config.SelfReviewConfig
+	AgentAdapter   domain.AgentAdapter
+	OnEvent        func(issueID string, event domain.AgentEvent)
+	OnProgress     func(selfReviewProgressMsg)
+	Logger         *slog.Logger
+	Metrics        domain.Metrics
+	TurnsCompleted *int
+}
+
+// maxVerdictFileBytes is the cap on .sortie/review_verdict.json reads.
+const maxVerdictFileBytes = 65536
+
+func generateWorkspaceDiff(ctx context.Context, workspacePath string, maxDiffBytes int) (string, bool, error) {
+	// Stage intent-to-add so new files appear in the diff.
+	intentCmd := exec.CommandContext(ctx, "git", "add", "--intent-to-add", ".")
+	intentCmd.Dir = workspacePath
+	_ = intentCmd.Run() // best-effort
+
+	cmd := exec.CommandContext(ctx, "git", "diff", "HEAD")
+	cmd.Dir = workspacePath
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		// Fallback: try without HEAD (empty repo with staged files).
+		cmd2 := exec.CommandContext(ctx, "git", "diff")
+		cmd2.Dir = workspacePath
+		output2, err2 := cmd2.CombinedOutput()
+		if err2 != nil {
+			return "", false, fmt.Errorf("git diff failed: %w (fallback: %w)", err, err2)
+		}
+		output = output2
+	}
+
+	truncated := false
+	if maxDiffBytes > 0 && len(output) > maxDiffBytes {
+		output = output[:maxDiffBytes]
+		truncated = true
+	}
+
+	return string(output), truncated, nil
+}
+
+func runSingleVerification(ctx context.Context, command, workspacePath string, timeoutMS int, logger *slog.Logger, metrics domain.Metrics) domain.VerificationResult {
+	var cmdCtx context.Context
+	var cancel context.CancelFunc
+	if timeoutMS > 0 {
+		cmdCtx, cancel = context.WithTimeout(ctx, time.Duration(timeoutMS)*time.Millisecond)
+	} else {
+		cmdCtx, cancel = context.WithCancel(ctx)
+	}
+	defer cancel()
+
+	cmd := exec.CommandContext(cmdCtx, "sh", "-c", command) //nolint:gosec // command comes from operator-controlled config
+	cmd.Dir = workspacePath
+	procutil.SetProcessGroup(cmd)
+
+	var stdoutBuf, stderrBuf strings.Builder
+
+	stdoutPipe, pipeErr := cmd.StdoutPipe()
+	if pipeErr != nil {
+		return domain.VerificationResult{
+			Command:        command,
+			ExitCode:       -1,
+			ExecutionError: pipeErr.Error(),
+		}
+	}
+	stderrPipe, pipeErr := cmd.StderrPipe()
+	if pipeErr != nil {
+		return domain.VerificationResult{
+			Command:        command,
+			ExitCode:       -1,
+			ExecutionError: pipeErr.Error(),
+		}
+	}
+
+	start := time.Now()
+	if err := cmd.Start(); err != nil {
+		duration := time.Since(start)
+		logger.Warn("verification command failed to start",
+			slog.String("command", command),
+			slog.Any("error", err),
+		)
+		return domain.VerificationResult{
+			Command:        command,
+			ExitCode:       -1,
+			DurationMS:     duration.Milliseconds(),
+			ExecutionError: err.Error(),
+		}
+	}
+
+	// Read stdout and stderr with limits.
+	readLimited := func(r io.Reader, w *strings.Builder) {
+		limited := io.LimitReader(r, domain.MaxVerificationOutputBytes)
+		_, _ = io.Copy(w, limited)
+	}
+	readLimited(stdoutPipe, &stdoutBuf)
+	readLimited(stderrPipe, &stderrBuf)
+
+	err := cmd.Wait()
+	duration := time.Since(start)
+
+	metrics.ObserveSelfReviewVerificationDuration(command, duration.Seconds())
+
+	if cmdCtx.Err() == context.DeadlineExceeded {
+		if cmd.Process != nil {
+			_ = procutil.SignalProcessGroup(cmd.Process.Pid, 9) // SIGKILL
+		}
+		logger.Info("verification command timed out",
+			slog.String("command", command),
+			slog.Int64("duration_ms", duration.Milliseconds()),
+		)
+		return domain.VerificationResult{
+			Command:    command,
+			ExitCode:   -1,
+			Stdout:     stdoutBuf.String(),
+			Stderr:     stderrBuf.String(),
+			DurationMS: duration.Milliseconds(),
+			TimedOut:   true,
+		}
+	}
+
+	exitCode := 0
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			exitCode = exitErr.ExitCode()
+		} else {
+			return domain.VerificationResult{
+				Command:        command,
+				ExitCode:       -1,
+				Stdout:         stdoutBuf.String(),
+				Stderr:         stderrBuf.String(),
+				DurationMS:     duration.Milliseconds(),
+				ExecutionError: err.Error(),
+			}
+		}
+	}
+
+	logger.Debug("verification command completed",
+		slog.String("command", command),
+		slog.Int("exit_code", exitCode),
+		slog.Int64("duration_ms", duration.Milliseconds()),
+	)
+
+	return domain.VerificationResult{
+		Command:    command,
+		ExitCode:   exitCode,
+		Stdout:     stdoutBuf.String(),
+		Stderr:     stderrBuf.String(),
+		DurationMS: duration.Milliseconds(),
+	}
+}
+
+func readReviewVerdict(workspacePath string) (*domain.ReviewVerdict, string, string) {
+	dir := filepath.Join(workspacePath, ".sortie")
+	fi, err := os.Lstat(dir)
+	if err != nil {
+		return nil, "", "verdict directory not found"
+	}
+	if fi.Mode()&os.ModeSymlink != 0 {
+		return nil, "", "refusing to read from symlinked .sortie"
+	}
+
+	path := filepath.Join(dir, "review_verdict.json")
+	f, err := os.Open(path) //nolint:gosec // path is constructed from operator-controlled workspace root
+	if os.IsNotExist(err) {
+		return nil, "", "verdict file not found"
+	}
+	if err != nil {
+		return nil, "", fmt.Sprintf("verdict open error: %v", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	limited := io.LimitReader(f, maxVerdictFileBytes+1)
+	data, err := io.ReadAll(limited)
+	if err != nil {
+		return nil, "", fmt.Sprintf("verdict read error: %v", err)
+	}
+	if len(data) > maxVerdictFileBytes {
+		return nil, "", "verdict file exceeds 64 KB size limit"
+	}
+
+	var verdict domain.ReviewVerdict
+	if err := json.Unmarshal(data, &verdict); err != nil {
+		return nil, string(data), fmt.Sprintf("verdict parse error: %v", err)
+	}
+
+	verdict.Verdict = strings.ToLower(strings.TrimSpace(verdict.Verdict))
+	if verdict.Verdict != "pass" && verdict.Verdict != "iterate" {
+		return nil, string(data), fmt.Sprintf("unrecognized verdict: %q", verdict.Verdict)
+	}
+
+	return &verdict, string(data), ""
+}
+
+func assembleReviewPrompt(issue domain.Issue, diff string, truncated bool, vresults []domain.VerificationResult, iteration, maxIterations int) string {
+	var sb strings.Builder
+
+	fmt.Fprintf(&sb, "## Self-Review: Iteration %d of %d\n\n", iteration, maxIterations)
+	sb.WriteString("You are reviewing your own changes. Analyze the diff and verification results below, then\n")
+	sb.WriteString("write your verdict to `.sortie/review_verdict.json`.\n\n")
+
+	sb.WriteString("### Original Task\n\n")
+	sb.WriteString(issue.Title)
+	sb.WriteString("\n")
+	if issue.Description != "" {
+		sb.WriteString(issue.Description)
+		sb.WriteString("\n")
+	}
+	sb.WriteString("\n")
+
+	sb.WriteString("### Workspace Diff\n\n")
+	if diff == "" {
+		sb.WriteString("[Diff unavailable]\n\n")
+	} else {
+		if truncated {
+			fmt.Fprintf(&sb, "[Diff truncated at %d bytes]\n\n", len(diff))
+		}
+		sb.WriteString("```diff\n")
+		sb.WriteString(diff)
+		sb.WriteString("\n```\n\n")
+	}
+
+	sb.WriteString("### Verification Results\n\n")
+	for _, result := range vresults {
+		fmt.Fprintf(&sb, "#### Command: `%s`\n", result.Command)
+		fmt.Fprintf(&sb, "- Exit code: %d\n", result.ExitCode)
+		fmt.Fprintf(&sb, "- Duration: %dms\n", result.DurationMS)
+		if result.TimedOut {
+			sb.WriteString("- **TIMED OUT**\n")
+		}
+		if result.ExecutionError != "" {
+			fmt.Fprintf(&sb, "- **EXECUTION ERROR:** %s\n", result.ExecutionError)
+		}
+		sb.WriteString("\n")
+
+		if result.Stdout != "" {
+			sb.WriteString("**stdout:**\n```\n")
+			sb.WriteString(result.Stdout)
+			sb.WriteString("\n```\n\n")
+		}
+
+		if result.Stderr != "" {
+			sb.WriteString("**stderr:**\n```\n")
+			sb.WriteString(result.Stderr)
+			sb.WriteString("\n```\n\n")
+		}
+	}
+
+	if iteration > 1 {
+		sb.WriteString("### Previous Review Feedback\n\n")
+		fmt.Fprintf(&sb, "Your previous review found issues. This is iteration %d. Focus on the issues identified in the previous review.\n\n", iteration)
+	}
+
+	sb.WriteString("### Instructions\n\n")
+	sb.WriteString("1. Review the diff for correctness, style, and completeness relative to the original task.\n")
+	sb.WriteString("2. Check whether the verification commands passed. If any failed, identify the root cause.\n")
+	sb.WriteString("3. Write your verdict as a JSON file:\n\n")
+	sb.WriteString("Create or overwrite the file `.sortie/review_verdict.json` with the following JSON content:\n\n")
+	sb.WriteString("```json\n")
+	sb.WriteString("{\n")
+	sb.WriteString("  \"verdict\": \"pass or iterate\",\n")
+	sb.WriteString("  \"summary\": \"one-line summary\",\n")
+	sb.WriteString("  \"issues\": [\n")
+	sb.WriteString("    {\n")
+	sb.WriteString("      \"file\": \"path/to/file.go\",\n")
+	sb.WriteString("      \"line\": 42,\n")
+	sb.WriteString("      \"severity\": \"error\",\n")
+	sb.WriteString("      \"message\": \"description and fix direction\"\n")
+	sb.WriteString("    }\n")
+	sb.WriteString("  ]\n")
+	sb.WriteString("}\n")
+	sb.WriteString("```\n\n")
+	sb.WriteString("Use \"pass\" when the changes are correct and verification passes. Use \"iterate\" when\n")
+	sb.WriteString("issues need to be fixed. On \"iterate\", the orchestrator will give you another turn to\n")
+	sb.WriteString("fix the identified issues.\n")
+
+	return sb.String()
+}
+
+func buildFixPrompt(verdict *domain.ReviewVerdict, _ string, iteration, maxIterations int) string {
+	var sb strings.Builder
+
+	fmt.Fprintf(&sb, "## Self-Review Fix: Iteration %d of %d\n\n", iteration, maxIterations)
+	sb.WriteString("The self-review identified issues that need to be fixed. Your previous review feedback\n")
+	sb.WriteString("is in your conversation history above.\n\n")
+
+	if verdict != nil && len(verdict.Issues) > 0 {
+		sb.WriteString("Focus on these issues:\n")
+		for _, issue := range verdict.Issues {
+			if issue.Line > 0 {
+				fmt.Fprintf(&sb, "- [%s] %s:%d — %s\n", issue.Severity, issue.File, issue.Line, issue.Message)
+			} else {
+				fmt.Fprintf(&sb, "- [%s] %s — %s\n", issue.Severity, issue.File, issue.Message)
+			}
+		}
+		sb.WriteString("\n")
+	} else {
+		sb.WriteString("Review your previous feedback and fix the issues you identified.\n\n")
+	}
+
+	sb.WriteString("After making fixes, the orchestrator will run verification commands and review again.\n")
+
+	return sb.String()
+}
+
+func writeReviewSummary(workspacePath string, meta domain.ReviewMetadata, logger *slog.Logger) {
+	dir := filepath.Join(workspacePath, ".sortie")
+
+	fi, err := os.Lstat(dir)
+	if err != nil {
+		logger.Warn("review summary: cannot stat .sortie directory", slog.Any("error", err))
+		return
+	}
+	if fi.Mode()&os.ModeSymlink != 0 {
+		logger.Warn("review summary: .sortie is a symlink, refusing to write")
+		return
+	}
+
+	var sb strings.Builder
+	sb.WriteString("## Self-Review Summary\n\n")
+
+	status := meta.FinalVerdict
+	if meta.CapReached {
+		status = fmt.Sprintf("Cap reached (iteration %d of %d)", meta.TotalIterations, len(meta.Iterations))
+	} else if status == "pass" {
+		status = fmt.Sprintf("Passed (iteration %d)", meta.TotalIterations)
+	}
+
+	fmt.Fprintf(&sb, "- **Status:** %s\n", status)
+
+	passedCount := 0
+	failedCount := 0
+	if len(meta.Iterations) > 0 {
+		last := meta.Iterations[len(meta.Iterations)-1]
+		for _, vr := range last.VerificationResults {
+			if vr.ExitCode == 0 {
+				passedCount++
+			} else {
+				failedCount++
+			}
+		}
+	}
+	fmt.Fprintf(&sb, "- **Verification commands:** %d passed, %d failed\n", passedCount, failedCount)
+	fmt.Fprintf(&sb, "- **Final verdict:** %s\n\n", meta.FinalVerdict)
+
+	for _, iter := range meta.Iterations {
+		fmt.Fprintf(&sb, "### Iteration %d\n", iter.Iteration)
+		if iter.Verdict != "" {
+			fmt.Fprintf(&sb, "- Verdict: %s\n", iter.Verdict)
+		} else if iter.VerdictParseError != "" {
+			fmt.Fprintf(&sb, "- Verdict: (error: %s)\n", iter.VerdictParseError)
+		}
+
+		for _, vr := range iter.VerificationResults {
+			result := "passed"
+			if vr.ExitCode != 0 {
+				result = fmt.Sprintf("failed (exit %d)", vr.ExitCode)
+			}
+			if vr.TimedOut {
+				result = "timed out"
+			}
+			fmt.Fprintf(&sb, "- Verification: `%s` %s\n", vr.Command, result)
+		}
+		sb.WriteString("\n")
+	}
+
+	tmpPath := filepath.Join(dir, "review_summary.md.tmp")
+	outPath := filepath.Join(dir, "review_summary.md")
+	if err := os.WriteFile(tmpPath, []byte(sb.String()), 0o600); err != nil {
+		logger.Warn("review summary write failed", slog.Any("error", err))
+		return
+	}
+	if err := os.Rename(tmpPath, outPath); err != nil {
+		logger.Warn("review summary rename failed", slog.Any("error", err))
+	}
+}
+
+func runSelfReviewLoop(ctx context.Context, params RunSelfReviewParams) *domain.ReviewMetadata {
+	maxIter := params.Config.MaxIterations
+	iterations := make([]domain.ReviewIterationRecord, 0, maxIter)
+	logger := params.Logger
+
+	if params.OnProgress != nil {
+		params.OnProgress(selfReviewProgressMsg{
+			IssueID:       params.Issue.ID,
+			Message:       "self_review_started",
+			Iteration:     0,
+			MaxIterations: maxIter,
+		})
+	}
+
+	for i := 1; i <= maxIter; i++ {
+		if ctx.Err() != nil {
+			break
+		}
+
+		diff, truncated, diffErr := generateWorkspaceDiff(ctx, params.WorkspacePath, params.Config.MaxDiffBytes)
+		if diffErr != nil {
+			logger.Warn("self-review diff generation failed", slog.Any("error", diffErr))
+			diff = ""
+		}
+
+		diffSize := len(diff)
+		if truncated {
+			diffSize = params.Config.MaxDiffBytes
+		}
+
+		var verificationResults []domain.VerificationResult
+		for _, cmd := range params.Config.VerificationCommands {
+			if ctx.Err() != nil {
+				break
+			}
+			result := runSingleVerification(ctx, cmd, params.WorkspacePath, params.Config.VerificationTimeoutMS, logger, params.Metrics)
+			verificationResults = append(verificationResults, result)
+		}
+
+		reviewPrompt := assembleReviewPrompt(params.Issue, diff, truncated, verificationResults, i, maxIter)
+
+		// Remove previous verdict file before the review turn.
+		_ = os.Remove(filepath.Join(params.WorkspacePath, ".sortie", "review_verdict.json"))
+
+		_, turnErr := params.AgentAdapter.RunTurn(ctx, params.Session, domain.RunTurnParams{
+			Prompt: reviewPrompt,
+			Issue:  params.Issue,
+			OnEvent: func(event domain.AgentEvent) {
+				params.OnEvent(params.Issue.ID, event)
+			},
+		})
+		if turnErr != nil {
+			logger.Warn("self-review turn failed",
+				slog.Int("iteration", i),
+				slog.Any("error", turnErr),
+			)
+			iterations = append(iterations, domain.ReviewIterationRecord{
+				Iteration:           i,
+				DiffSizeBytes:       diffSize,
+				DiffTruncated:       truncated,
+				VerificationResults: verificationResults,
+				VerdictParseError:   fmt.Sprintf("turn error: %v", turnErr),
+			})
+			break
+		}
+
+		*params.TurnsCompleted++
+
+		// Check A2O status for early abort signals.
+		statusSignal := workspace.ReadStatusFile(params.WorkspacePath, logger)
+		if statusSignal.IsRecognized() {
+			logger.Info("self-review aborted by agent status",
+				slog.Int("iteration", i),
+				slog.String("status", string(statusSignal)),
+			)
+			iterations = append(iterations, domain.ReviewIterationRecord{
+				Iteration:           i,
+				DiffSizeBytes:       diffSize,
+				DiffTruncated:       truncated,
+				VerificationResults: verificationResults,
+				VerdictParseError:   fmt.Sprintf("aborted: agent status %q", statusSignal),
+			})
+			break
+		}
+
+		verdict, rawJSON, parseErr := readReviewVerdict(params.WorkspacePath)
+
+		record := domain.ReviewIterationRecord{
+			Iteration:           i,
+			DiffSizeBytes:       diffSize,
+			DiffTruncated:       truncated,
+			VerificationResults: verificationResults,
+		}
+		if verdict != nil {
+			record.Verdict = verdict.Verdict
+			record.VerdictRaw = rawJSON
+		}
+		if parseErr != "" {
+			record.VerdictParseError = parseErr
+		}
+		iterations = append(iterations, record)
+
+		verdictLabel := record.Verdict
+		if verdictLabel == "" {
+			verdictLabel = "none"
+		}
+		params.Metrics.IncSelfReviewIterations(verdictLabel)
+
+		if params.OnProgress != nil {
+			params.OnProgress(selfReviewProgressMsg{
+				IssueID:       params.Issue.ID,
+				Message:       "self_review_iteration",
+				Iteration:     i,
+				MaxIterations: maxIter,
+			})
+		}
+
+		if verdict != nil && verdict.Verdict == "pass" {
+			logger.Info("self-review passed", slog.Int("iteration", i))
+			break
+		}
+
+		if i == maxIter {
+			logger.Warn("self-review cap reached",
+				slog.Int("iterations", maxIter),
+				slog.String("final_verdict", record.Verdict),
+			)
+			params.Metrics.IncSelfReviewCapReached()
+			break
+		}
+
+		// "iterate" or missing verdict: give the agent a fix turn.
+		if verdict != nil && verdict.Verdict == "iterate" {
+			logger.Info("self-review iterate",
+				slog.Int("iteration", i),
+				slog.String("summary", verdict.Summary),
+			)
+		} else {
+			logger.Warn("self-review verdict missing or invalid",
+				slog.Int("iteration", i),
+				slog.String("parse_error", parseErr),
+			)
+		}
+
+		fixPrompt := buildFixPrompt(verdict, parseErr, i, maxIter)
+
+		_, fixErr := params.AgentAdapter.RunTurn(ctx, params.Session, domain.RunTurnParams{
+			Prompt: fixPrompt,
+			Issue:  params.Issue,
+			OnEvent: func(event domain.AgentEvent) {
+				params.OnEvent(params.Issue.ID, event)
+			},
+		})
+		if fixErr != nil {
+			logger.Warn("self-review fix turn failed",
+				slog.Int("iteration", i),
+				slog.Any("error", fixErr),
+			)
+			break
+		}
+
+		*params.TurnsCompleted++
+
+		// Check A2O status after fix turn.
+		statusSignal = workspace.ReadStatusFile(params.WorkspacePath, logger)
+		if statusSignal.IsRecognized() {
+			logger.Info("self-review aborted by agent status after fix",
+				slog.Int("iteration", i),
+				slog.String("status", string(statusSignal)),
+			)
+			break
+		}
+	}
+
+	finalVerdict := "none"
+	if len(iterations) > 0 {
+		last := iterations[len(iterations)-1]
+		if last.Verdict != "" {
+			finalVerdict = last.Verdict
+		}
+	}
+
+	capReached := len(iterations) == maxIter && finalVerdict != "pass"
+
+	meta := &domain.ReviewMetadata{
+		Enabled:         true,
+		Iterations:      iterations,
+		TotalIterations: len(iterations),
+		FinalVerdict:    finalVerdict,
+		CapReached:      capReached,
+	}
+
+	writeReviewSummary(params.WorkspacePath, *meta, logger)
+
+	if params.OnProgress != nil {
+		params.OnProgress(selfReviewProgressMsg{
+			IssueID:       params.Issue.ID,
+			Message:       "self_review_done",
+			Iteration:     len(iterations),
+			MaxIterations: maxIter,
+		})
+	}
+
+	params.Metrics.IncSelfReviewSessions(finalVerdict)
+
+	return meta
+}

--- a/internal/orchestrator/self_review_test.go
+++ b/internal/orchestrator/self_review_test.go
@@ -1,0 +1,1138 @@
+package orchestrator
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/sortie-ai/sortie/internal/config"
+	"github.com/sortie-ai/sortie/internal/domain"
+)
+
+// --- Shared test helpers ---
+
+// writeVerdictFile writes a ReviewVerdict as JSON to <wsPath>/.sortie/review_verdict.json.
+func writeVerdictFile(t *testing.T, wsPath string, verdict domain.ReviewVerdict) {
+	t.Helper()
+	dir := filepath.Join(wsPath, ".sortie")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(.sortie): %v", err)
+	}
+	data, err := json.Marshal(verdict)
+	if err != nil {
+		t.Fatalf("json.Marshal(verdict): %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "review_verdict.json"), data, 0o600); err != nil {
+		t.Fatalf("WriteFile(review_verdict.json): %v", err)
+	}
+}
+
+// runGit executes a git command inside dir and fails the test on error.
+func runGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+}
+
+// initGitRepo creates a bare git repo in dir with an empty initial commit.
+func initGitRepo(t *testing.T, dir string) {
+	t.Helper()
+	runGit(t, dir, "init")
+	runGit(t, dir, "config", "user.email", "test@example.com")
+	runGit(t, dir, "config", "user.name", "Test")
+	runGit(t, dir, "commit", "--allow-empty", "-m", "init")
+}
+
+// selfReviewCfg returns a minimal SelfReviewConfig for testing.
+func selfReviewCfg() config.SelfReviewConfig {
+	return config.SelfReviewConfig{
+		MaxIterations:         3,
+		VerificationCommands:  []string{"echo ok"},
+		VerificationTimeoutMS: 5000,
+		MaxDiffBytes:          102400,
+		Reviewer:              "same",
+	}
+}
+
+// selfReviewIssue returns a minimal Issue for testing.
+func selfReviewIssue() domain.Issue {
+	return domain.Issue{
+		ID:          "SR-1",
+		Identifier:  "TEST-42",
+		Title:       "Test self-review issue",
+		Description: "Detailed description",
+	}
+}
+
+// reviewMetricsCount tracks self-review metric calls.
+type reviewMetricsCount struct {
+	domain.NoopMetrics
+	iterations []string
+	sessions   []string
+	capReached int
+	verCmds    []string
+}
+
+func (m *reviewMetricsCount) IncSelfReviewIterations(verdict string) {
+	m.iterations = append(m.iterations, verdict)
+}
+func (m *reviewMetricsCount) IncSelfReviewSessions(finalVerdict string) {
+	m.sessions = append(m.sessions, finalVerdict)
+}
+func (m *reviewMetricsCount) IncSelfReviewCapReached() { m.capReached++ }
+func (m *reviewMetricsCount) ObserveSelfReviewVerificationDuration(cmd string, _ float64) {
+	m.verCmds = append(m.verCmds, cmd)
+}
+
+// --- verdictWriter is a test AgentAdapter that writes verdict files ---
+
+// verdictWriter implements domain.AgentAdapter. Each call to RunTurn writes
+// the next verdict in the slice to the workspace, then returns success.
+type verdictWriter struct {
+	wsPath   string
+	verdicts []domain.ReviewVerdict // nil entry = no file written
+	callIdx  int
+}
+
+func (v *verdictWriter) StartSession(_ context.Context, _ domain.StartSessionParams) (domain.Session, error) {
+	return domain.Session{ID: "test-sess"}, nil
+}
+
+func (v *verdictWriter) StopSession(_ context.Context, _ domain.Session) error { return nil }
+
+func (v *verdictWriter) EventStream() <-chan domain.AgentEvent { return nil }
+
+func (v *verdictWriter) RunTurn(ctx context.Context, session domain.Session, params domain.RunTurnParams) (domain.TurnResult, error) {
+	idx := v.callIdx
+	v.callIdx++
+
+	if idx < len(v.verdicts) && v.verdicts[idx].Verdict != "" {
+		dir := filepath.Join(v.wsPath, ".sortie")
+		_ = os.MkdirAll(dir, 0o755)
+		data, _ := json.Marshal(v.verdicts[idx])
+		_ = os.WriteFile(filepath.Join(dir, "review_verdict.json"), data, 0o600)
+	}
+
+	if params.OnEvent != nil {
+		params.OnEvent(domain.AgentEvent{Type: domain.EventNotification, Message: fmt.Sprintf("turn %d", idx+1)})
+	}
+
+	return domain.TurnResult{SessionID: session.ID, ExitReason: domain.EventTurnCompleted}, nil
+}
+
+// failOnFirstAdapter is an AgentAdapter whose first RunTurn returns an error.
+type failOnFirstAdapter struct {
+	wsPath  string
+	callIdx int
+}
+
+func (f *failOnFirstAdapter) StartSession(_ context.Context, _ domain.StartSessionParams) (domain.Session, error) {
+	return domain.Session{ID: "fail-sess"}, nil
+}
+func (f *failOnFirstAdapter) StopSession(_ context.Context, _ domain.Session) error { return nil }
+func (f *failOnFirstAdapter) EventStream() <-chan domain.AgentEvent                 { return nil }
+func (f *failOnFirstAdapter) RunTurn(_ context.Context, s domain.Session, _ domain.RunTurnParams) (domain.TurnResult, error) {
+	f.callIdx++
+	return domain.TurnResult{}, fmt.Errorf("simulated turn error")
+}
+
+// statusWriterAdapter writes a status file to .sortie/status during RunTurn.
+type statusWriterAdapter struct {
+	wsPath string
+	status string
+}
+
+func (s *statusWriterAdapter) StartSession(_ context.Context, _ domain.StartSessionParams) (domain.Session, error) {
+	return domain.Session{ID: "status-sess"}, nil
+}
+func (s *statusWriterAdapter) StopSession(_ context.Context, _ domain.Session) error { return nil }
+func (s *statusWriterAdapter) EventStream() <-chan domain.AgentEvent                 { return nil }
+func (s *statusWriterAdapter) RunTurn(_ context.Context, sess domain.Session, _ domain.RunTurnParams) (domain.TurnResult, error) {
+	dir := filepath.Join(s.wsPath, ".sortie")
+	_ = os.MkdirAll(dir, 0o755)
+	_ = os.WriteFile(filepath.Join(dir, "status"), []byte(s.status), 0o600)
+	return domain.TurnResult{SessionID: sess.ID, ExitReason: domain.EventTurnCompleted}, nil
+}
+
+// --- readReviewVerdict tests ---
+
+func TestReadReviewVerdict_Pass(t *testing.T) {
+	t.Parallel()
+
+	wsPath := t.TempDir()
+	writeVerdictFile(t, wsPath, domain.ReviewVerdict{Verdict: "pass", Summary: "all good"})
+
+	verdict, raw, parseErr := readReviewVerdict(wsPath)
+
+	if parseErr != "" {
+		t.Fatalf("parseErr = %q, want empty", parseErr)
+	}
+	if verdict == nil {
+		t.Fatal("verdict = nil, want non-nil")
+	}
+	if verdict.Verdict != "pass" {
+		t.Errorf("Verdict = %q, want %q", verdict.Verdict, "pass")
+	}
+	if verdict.Summary != "all good" {
+		t.Errorf("Summary = %q, want %q", verdict.Summary, "all good")
+	}
+	if raw == "" {
+		t.Error("raw JSON is empty, want non-empty")
+	}
+}
+
+func TestReadReviewVerdict_Iterate(t *testing.T) {
+	t.Parallel()
+
+	wsPath := t.TempDir()
+	writeVerdictFile(t, wsPath, domain.ReviewVerdict{
+		Verdict: "iterate",
+		Summary: "found issues",
+		Issues: []domain.ReviewIssue{
+			{File: "main.go", Line: 10, Severity: "error", Message: "nil ptr"},
+		},
+	})
+
+	verdict, _, parseErr := readReviewVerdict(wsPath)
+
+	if parseErr != "" {
+		t.Fatalf("parseErr = %q, want empty", parseErr)
+	}
+	if verdict == nil {
+		t.Fatal("verdict = nil, want non-nil")
+	}
+	if verdict.Verdict != "iterate" {
+		t.Errorf("Verdict = %q, want %q", verdict.Verdict, "iterate")
+	}
+	if len(verdict.Issues) != 1 {
+		t.Fatalf("Issues len = %d, want 1", len(verdict.Issues))
+	}
+	if verdict.Issues[0].File != "main.go" {
+		t.Errorf("Issues[0].File = %q, want %q", verdict.Issues[0].File, "main.go")
+	}
+}
+
+func TestReadReviewVerdict_Missing(t *testing.T) {
+	t.Parallel()
+
+	wsPath := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(wsPath, ".sortie"), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+
+	verdict, _, parseErr := readReviewVerdict(wsPath)
+
+	if verdict != nil {
+		t.Error("verdict should be nil when file is missing")
+	}
+	if parseErr == "" {
+		t.Error("parseErr should be non-empty when file is missing")
+	}
+}
+
+func TestReadReviewVerdict_NoDotSortieDir(t *testing.T) {
+	t.Parallel()
+
+	wsPath := t.TempDir()
+
+	verdict, _, parseErr := readReviewVerdict(wsPath)
+
+	if verdict != nil {
+		t.Error("verdict should be nil when .sortie dir is absent")
+	}
+	if parseErr == "" {
+		t.Error("parseErr should be non-empty when .sortie dir is absent")
+	}
+}
+
+func TestReadReviewVerdict_MalformedJSON(t *testing.T) {
+	t.Parallel()
+
+	wsPath := t.TempDir()
+	dir := filepath.Join(wsPath, ".sortie")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "review_verdict.json"), []byte("{not valid json"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	verdict, raw, parseErr := readReviewVerdict(wsPath)
+
+	if verdict != nil {
+		t.Error("verdict should be nil on malformed JSON")
+	}
+	if raw == "" {
+		t.Error("raw should contain the malformed content")
+	}
+	if parseErr == "" {
+		t.Error("parseErr should be non-empty on malformed JSON")
+	}
+}
+
+func TestReadReviewVerdict_UnknownVerdict(t *testing.T) {
+	t.Parallel()
+
+	wsPath := t.TempDir()
+	writeVerdictFile(t, wsPath, domain.ReviewVerdict{Verdict: "maybe", Summary: "unknown"})
+
+	verdict, _, parseErr := readReviewVerdict(wsPath)
+
+	if verdict != nil {
+		t.Error("verdict should be nil for unrecognized verdict string")
+	}
+	if !strings.Contains(parseErr, "unrecognized verdict") {
+		t.Errorf("parseErr = %q, want to contain %q", parseErr, "unrecognized verdict")
+	}
+}
+
+func TestReadReviewVerdict_OversizedFile(t *testing.T) {
+	t.Parallel()
+
+	wsPath := t.TempDir()
+	dir := filepath.Join(wsPath, ".sortie")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	oversized := make([]byte, maxVerdictFileBytes+1)
+	for i := range oversized {
+		oversized[i] = 'a'
+	}
+	if err := os.WriteFile(filepath.Join(dir, "review_verdict.json"), oversized, 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	verdict, _, parseErr := readReviewVerdict(wsPath)
+
+	if verdict != nil {
+		t.Error("verdict should be nil for oversized file")
+	}
+	if !strings.Contains(parseErr, "size limit") {
+		t.Errorf("parseErr = %q, want to contain %q", parseErr, "size limit")
+	}
+}
+
+func TestReadReviewVerdict_SymlinkRejection(t *testing.T) {
+	t.Parallel()
+
+	wsPath := t.TempDir()
+	target := t.TempDir()
+	symlinkPath := filepath.Join(wsPath, ".sortie")
+	if err := os.Symlink(target, symlinkPath); err != nil {
+		t.Fatalf("Symlink: %v", err)
+	}
+
+	verdict, _, parseErr := readReviewVerdict(wsPath)
+
+	if verdict != nil {
+		t.Error("verdict should be nil when .sortie is a symlink")
+	}
+	if !strings.Contains(parseErr, "symlink") {
+		t.Errorf("parseErr = %q, want to contain %q", parseErr, "symlink")
+	}
+}
+
+func TestReadReviewVerdict_CaseNormalization(t *testing.T) {
+	t.Parallel()
+
+	wsPath := t.TempDir()
+	dir := filepath.Join(wsPath, ".sortie")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	data := []byte(`{"verdict":"PASS","summary":"uppercase test"}`)
+	if err := os.WriteFile(filepath.Join(dir, "review_verdict.json"), data, 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	verdict, _, parseErr := readReviewVerdict(wsPath)
+
+	if parseErr != "" {
+		t.Fatalf("parseErr = %q, want empty", parseErr)
+	}
+	if verdict == nil {
+		t.Fatal("verdict = nil, want non-nil")
+	}
+	if verdict.Verdict != "pass" {
+		t.Errorf("Verdict = %q, want %q (lowercased)", verdict.Verdict, "pass")
+	}
+}
+
+// --- assembleReviewPrompt tests ---
+
+func TestAssembleReviewPrompt_ContainsKeyFields(t *testing.T) {
+	t.Parallel()
+
+	issue := domain.Issue{
+		ID:          "ISS-1",
+		Identifier:  "PROJ-1",
+		Title:       "Fix the bug",
+		Description: "Detailed description here",
+	}
+	diff := "--- a/main.go\n+++ b/main.go\n@@ -1 +1 @@\n-old\n+new"
+	vresults := []domain.VerificationResult{
+		{Command: "make test", ExitCode: 0, DurationMS: 500, Stdout: "ok"},
+	}
+
+	prompt := assembleReviewPrompt(issue, diff, false, vresults, 1, 3)
+
+	checks := []struct {
+		label string
+		want  string
+	}{
+		{"iteration header", "Iteration 1 of 3"},
+		{"issue title", "Fix the bug"},
+		{"issue description", "Detailed description here"},
+		{"diff content", diff},
+		{"verification command", "make test"},
+		{"verdict file instructions", "review_verdict.json"},
+	}
+	for _, c := range checks {
+		if !strings.Contains(prompt, c.want) {
+			t.Errorf("prompt missing %s (%q)", c.label, c.want)
+		}
+	}
+}
+
+func TestAssembleReviewPrompt_NoDiff(t *testing.T) {
+	t.Parallel()
+
+	issue := domain.Issue{ID: "ISS-1", Title: "Fix bug"}
+	prompt := assembleReviewPrompt(issue, "", false, nil, 1, 3)
+
+	if !strings.Contains(prompt, "unavailable") {
+		t.Errorf("prompt = %q, want to contain %q", prompt, "unavailable")
+	}
+}
+
+func TestAssembleReviewPrompt_TruncatedDiff(t *testing.T) {
+	t.Parallel()
+
+	issue := domain.Issue{ID: "ISS-1", Title: "Fix"}
+	diff := strings.Repeat("x", 100)
+	prompt := assembleReviewPrompt(issue, diff, true, nil, 1, 3)
+
+	if !strings.Contains(prompt, "truncated") {
+		t.Errorf("prompt = %q, want to contain %q", prompt, "truncated")
+	}
+}
+
+func TestAssembleReviewPrompt_PreviousFeedback(t *testing.T) {
+	t.Parallel()
+
+	issue := domain.Issue{ID: "ISS-1", Title: "Fix"}
+	prompt := assembleReviewPrompt(issue, "", false, nil, 2, 3)
+
+	if !strings.Contains(prompt, "previous") {
+		t.Errorf("iteration 2 prompt missing previous-feedback section; prompt = %q", prompt)
+	}
+}
+
+// --- buildFixPrompt tests ---
+
+func TestBuildFixPrompt_WithIssues(t *testing.T) {
+	t.Parallel()
+
+	verdict := &domain.ReviewVerdict{
+		Verdict: "iterate",
+		Issues: []domain.ReviewIssue{
+			{File: "main.go", Line: 42, Severity: "error", Message: "nil pointer dereference"},
+		},
+	}
+
+	prompt := buildFixPrompt(verdict, "", 1, 3)
+
+	if !strings.Contains(prompt, "main.go") {
+		t.Errorf("prompt missing issue file; prompt = %q", prompt)
+	}
+	if !strings.Contains(prompt, "42") {
+		t.Errorf("prompt missing line number; prompt = %q", prompt)
+	}
+	if !strings.Contains(prompt, "nil pointer") {
+		t.Errorf("prompt missing issue message; prompt = %q", prompt)
+	}
+}
+
+func TestBuildFixPrompt_NoIssues(t *testing.T) {
+	t.Parallel()
+
+	verdict := &domain.ReviewVerdict{Verdict: "iterate", Summary: "generic issues"}
+	prompt := buildFixPrompt(verdict, "", 1, 3)
+
+	if !strings.Contains(prompt, "previous feedback") {
+		t.Errorf("prompt with no specific issues missing fallback text; prompt = %q", prompt)
+	}
+}
+
+func TestBuildFixPrompt_ParseError(t *testing.T) {
+	t.Parallel()
+
+	prompt := buildFixPrompt(nil, "verdict file not found", 1, 3)
+
+	if !strings.Contains(prompt, "previous feedback") {
+		t.Errorf("prompt with nil verdict missing fallback text; prompt = %q", prompt)
+	}
+}
+
+// --- writeReviewSummary tests ---
+
+func TestWriteReviewSummary_Pass(t *testing.T) {
+	t.Parallel()
+
+	wsPath := t.TempDir()
+	sortieDir := filepath.Join(wsPath, ".sortie")
+	if err := os.MkdirAll(sortieDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+
+	meta := domain.ReviewMetadata{
+		Enabled:         true,
+		TotalIterations: 1,
+		FinalVerdict:    "pass",
+		Iterations: []domain.ReviewIterationRecord{
+			{
+				Iteration: 1,
+				Verdict:   "pass",
+				VerificationResults: []domain.VerificationResult{
+					{Command: "make test", ExitCode: 0, DurationMS: 200},
+				},
+			},
+		},
+	}
+
+	writeReviewSummary(wsPath, meta, discardLogger())
+
+	data, err := os.ReadFile(filepath.Join(sortieDir, "review_summary.md"))
+	if err != nil {
+		t.Fatalf("reading review_summary.md: %v", err)
+	}
+	content := string(data)
+
+	if !strings.Contains(content, "Self-Review Summary") {
+		t.Errorf("summary missing heading; content = %q", content)
+	}
+	if !strings.Contains(content, "make test") {
+		t.Errorf("summary missing verification command; content = %q", content)
+	}
+	if !strings.Contains(content, "passed") {
+		t.Errorf("summary missing passed result; content = %q", content)
+	}
+}
+
+func TestWriteReviewSummary_CapReached(t *testing.T) {
+	t.Parallel()
+
+	wsPath := t.TempDir()
+	sortieDir := filepath.Join(wsPath, ".sortie")
+	if err := os.MkdirAll(sortieDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+
+	meta := domain.ReviewMetadata{
+		Enabled:         true,
+		TotalIterations: 3,
+		FinalVerdict:    "iterate",
+		CapReached:      true,
+		Iterations: []domain.ReviewIterationRecord{
+			{Iteration: 1, Verdict: "iterate"},
+			{Iteration: 2, Verdict: "iterate"},
+			{Iteration: 3, Verdict: "iterate"},
+		},
+	}
+
+	writeReviewSummary(wsPath, meta, discardLogger())
+
+	data, err := os.ReadFile(filepath.Join(sortieDir, "review_summary.md"))
+	if err != nil {
+		t.Fatalf("reading review_summary.md: %v", err)
+	}
+	if !strings.Contains(string(data), "Cap reached") {
+		t.Errorf("summary should mention cap reached; got: %q", string(data))
+	}
+}
+
+func TestWriteReviewSummary_SymlinkRejected(t *testing.T) {
+	t.Parallel()
+
+	wsPath := t.TempDir()
+	target := t.TempDir()
+	symlinkPath := filepath.Join(wsPath, ".sortie")
+	if err := os.Symlink(target, symlinkPath); err != nil {
+		t.Fatalf("Symlink: %v", err)
+	}
+
+	writeReviewSummary(wsPath, domain.ReviewMetadata{Enabled: true}, discardLogger())
+
+	if _, err := os.Stat(filepath.Join(target, "review_summary.md")); !os.IsNotExist(err) {
+		t.Error("review_summary.md written through symlink, expected rejection")
+	}
+}
+
+// --- runSingleVerification tests ---
+
+func TestRunVerification_Success(t *testing.T) {
+	t.Parallel()
+
+	wsPath := t.TempDir()
+	m := &reviewMetricsCount{}
+
+	result := runSingleVerification(context.Background(), "echo hello", wsPath, 5000, discardLogger(), m)
+
+	if result.ExitCode != 0 {
+		t.Errorf("ExitCode = %d, want 0", result.ExitCode)
+	}
+	if !strings.Contains(result.Stdout, "hello") {
+		t.Errorf("Stdout = %q, want to contain %q", result.Stdout, "hello")
+	}
+	if result.TimedOut {
+		t.Error("TimedOut = true, want false")
+	}
+	if result.ExecutionError != "" {
+		t.Errorf("ExecutionError = %q, want empty", result.ExecutionError)
+	}
+	if result.DurationMS < 0 {
+		t.Errorf("DurationMS = %d, want >= 0", result.DurationMS)
+	}
+	if len(m.verCmds) != 1 {
+		t.Errorf("ObserveSelfReviewVerificationDuration called %d times, want 1", len(m.verCmds))
+	}
+}
+
+func TestRunVerification_Failure(t *testing.T) {
+	t.Parallel()
+
+	wsPath := t.TempDir()
+	result := runSingleVerification(context.Background(), "exit 42", wsPath, 5000, discardLogger(), &domain.NoopMetrics{})
+
+	if result.ExitCode != 42 {
+		t.Errorf("ExitCode = %d, want 42", result.ExitCode)
+	}
+	if result.TimedOut {
+		t.Error("TimedOut = true, want false")
+	}
+	if result.ExecutionError != "" {
+		t.Errorf("ExecutionError = %q, want empty for clean exit", result.ExecutionError)
+	}
+}
+
+func TestRunVerification_Timeout(t *testing.T) {
+	t.Parallel()
+
+	wsPath := t.TempDir()
+	// Use an infinite shell-builtin loop so no child process is forked.
+	// This ensures the pipe closes promptly when the shell is killed.
+	result := runSingleVerification(context.Background(), "while true; do :; done", wsPath, 100, discardLogger(), &domain.NoopMetrics{})
+
+	if !result.TimedOut {
+		t.Error("TimedOut = false, want true")
+	}
+	if result.ExitCode != -1 {
+		t.Errorf("ExitCode = %d, want -1 on timeout", result.ExitCode)
+	}
+}
+
+func TestRunVerification_CommandNotFound(t *testing.T) {
+	t.Parallel()
+
+	wsPath := t.TempDir()
+	// sh returns exit 127 when a command is not found.
+	result := runSingleVerification(context.Background(), "nonexistent_binary_xyz_abc_sortie_test", wsPath, 5000, discardLogger(), &domain.NoopMetrics{})
+
+	if result.ExitCode == 0 {
+		t.Error("ExitCode = 0 for not-found binary, want non-zero")
+	}
+	if result.TimedOut {
+		t.Error("TimedOut = true, want false")
+	}
+}
+
+func TestRunVerification_OutputTruncation(t *testing.T) {
+	t.Parallel()
+
+	wsPath := t.TempDir()
+	// Generate stdout that exceeds MaxVerificationOutputBytes.
+	bigCount := domain.MaxVerificationOutputBytes + 1024
+	cmd := fmt.Sprintf("python3 -c \"import sys; sys.stdout.write('x' * %d)\"", bigCount)
+	result := runSingleVerification(context.Background(), cmd, wsPath, 10000, discardLogger(), &domain.NoopMetrics{})
+
+	if len(result.Stdout) > int(domain.MaxVerificationOutputBytes) {
+		t.Errorf("Stdout len = %d, exceeds MaxVerificationOutputBytes %d",
+			len(result.Stdout), domain.MaxVerificationOutputBytes)
+	}
+}
+
+func TestRunVerification_ContextCancelled(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	wsPath := t.TempDir()
+	// Should not panic when context is pre-cancelled.
+	result := runSingleVerification(ctx, "echo hello", wsPath, 5000, discardLogger(), &domain.NoopMetrics{})
+	_ = result
+}
+
+// --- generateWorkspaceDiff tests ---
+
+func TestGenerateDiff_EmptyDiff(t *testing.T) {
+	t.Parallel()
+
+	wsPath := t.TempDir()
+	initGitRepo(t, wsPath)
+
+	diff, truncated, err := generateWorkspaceDiff(context.Background(), wsPath, 102400)
+
+	if err != nil {
+		t.Fatalf("generateWorkspaceDiff: %v", err)
+	}
+	if truncated {
+		t.Error("truncated = true, want false for empty diff")
+	}
+	if diff != "" {
+		t.Errorf("diff = %q, want empty", diff)
+	}
+}
+
+func TestGenerateDiff_ModifiedFile(t *testing.T) {
+	t.Parallel()
+
+	wsPath := t.TempDir()
+	initGitRepo(t, wsPath)
+
+	// Commit a file, then modify it so git diff HEAD shows changes.
+	filePath := filepath.Join(wsPath, "hello.go")
+	if err := os.WriteFile(filePath, []byte("package main\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	runGit(t, wsPath, "add", "hello.go")
+	runGit(t, wsPath, "commit", "-m", "add hello.go")
+
+	if err := os.WriteFile(filePath, []byte("package main\n// modified\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile modify: %v", err)
+	}
+
+	diff, _, err := generateWorkspaceDiff(context.Background(), wsPath, 102400)
+
+	if err != nil {
+		t.Fatalf("generateWorkspaceDiff: %v", err)
+	}
+	if !strings.Contains(diff, "modified") {
+		t.Errorf("diff = %q, want to contain modified file content", diff)
+	}
+}
+
+func TestGenerateDiff_Truncation(t *testing.T) {
+	t.Parallel()
+
+	wsPath := t.TempDir()
+	initGitRepo(t, wsPath)
+
+	// Commit a file then modify it to create a diff.
+	filePath := filepath.Join(wsPath, "big.txt")
+	if err := os.WriteFile(filePath, []byte(strings.Repeat("original\n", 50)), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	runGit(t, wsPath, "add", "big.txt")
+	runGit(t, wsPath, "commit", "-m", "add big file")
+
+	if err := os.WriteFile(filePath, []byte(strings.Repeat("modified\n", 50)), 0o644); err != nil {
+		t.Fatalf("WriteFile modify: %v", err)
+	}
+
+	const maxBytes = 50
+	diff, truncated, err := generateWorkspaceDiff(context.Background(), wsPath, maxBytes)
+
+	if err != nil {
+		t.Fatalf("generateWorkspaceDiff: %v", err)
+	}
+	if len(diff) > maxBytes {
+		t.Errorf("diff len = %d, want <= %d", len(diff), maxBytes)
+	}
+	if !truncated {
+		// The diff 50 bytes may or may not be enough for the full header.
+		// Only fail if we got more than allowed.
+		t.Log("diff was not truncated; actual diff may be <= 50 bytes")
+	}
+}
+
+func TestGenerateDiff_NoGit(t *testing.T) {
+	t.Parallel()
+
+	wsPath := t.TempDir()
+
+	_, _, err := generateWorkspaceDiff(context.Background(), wsPath, 102400)
+
+	if err == nil {
+		t.Error("generateWorkspaceDiff with non-git dir: expected error, got nil")
+	}
+}
+
+// --- runSelfReviewLoop tests ---
+
+func TestSelfReviewLoop_PassOnFirst(t *testing.T) {
+	t.Parallel()
+
+	wsPath := t.TempDir()
+	m := &reviewMetricsCount{}
+	turns := 0
+
+	adapter := &verdictWriter{
+		wsPath:   wsPath,
+		verdicts: []domain.ReviewVerdict{{Verdict: "pass", Summary: "looks good"}},
+	}
+
+	meta := runSelfReviewLoop(context.Background(), RunSelfReviewParams{
+		Session:        domain.Session{ID: "sess"},
+		Issue:          selfReviewIssue(),
+		WorkspacePath:  wsPath,
+		Config:         selfReviewCfg(),
+		AgentAdapter:   adapter,
+		OnEvent:        func(_ string, _ domain.AgentEvent) {},
+		Logger:         discardLogger(),
+		Metrics:        m,
+		TurnsCompleted: &turns,
+	})
+
+	if meta == nil {
+		t.Fatal("meta = nil, want non-nil")
+	}
+	if !meta.Enabled {
+		t.Error("meta.Enabled = false, want true")
+	}
+	if meta.FinalVerdict != "pass" {
+		t.Errorf("FinalVerdict = %q, want %q", meta.FinalVerdict, "pass")
+	}
+	if meta.TotalIterations != 1 {
+		t.Errorf("TotalIterations = %d, want 1", meta.TotalIterations)
+	}
+	if meta.CapReached {
+		t.Error("CapReached = true, want false")
+	}
+	// review turn 1 only, no fix turn.
+	if turns != 1 {
+		t.Errorf("TurnsCompleted = %d, want 1", turns)
+	}
+	if len(m.iterations) != 1 || m.iterations[0] != "pass" {
+		t.Errorf("IncSelfReviewIterations = %v, want [pass]", m.iterations)
+	}
+	if len(m.sessions) != 1 || m.sessions[0] != "pass" {
+		t.Errorf("IncSelfReviewSessions = %v, want [pass]", m.sessions)
+	}
+	if m.capReached != 0 {
+		t.Errorf("IncSelfReviewCapReached = %d, want 0", m.capReached)
+	}
+}
+
+func TestSelfReviewLoop_IterateThenPass(t *testing.T) {
+	t.Parallel()
+
+	wsPath := t.TempDir()
+	m := &reviewMetricsCount{}
+	turns := 0
+
+	// Turn sequence (zero-indexed verdictWriter.callIdx):
+	//   0 = review turn 1 → iterate
+	//   1 = fix turn 1    → no verdict
+	//   2 = review turn 2 → pass
+	adapter := &verdictWriter{
+		wsPath: wsPath,
+		verdicts: []domain.ReviewVerdict{
+			{Verdict: "iterate", Summary: "need fix"},
+			{}, // fix turn: no verdict written
+			{Verdict: "pass", Summary: "done"},
+		},
+	}
+
+	meta := runSelfReviewLoop(context.Background(), RunSelfReviewParams{
+		Session:        domain.Session{ID: "sess"},
+		Issue:          selfReviewIssue(),
+		WorkspacePath:  wsPath,
+		Config:         selfReviewCfg(),
+		AgentAdapter:   adapter,
+		OnEvent:        func(_ string, _ domain.AgentEvent) {},
+		Logger:         discardLogger(),
+		Metrics:        m,
+		TurnsCompleted: &turns,
+	})
+
+	if meta.FinalVerdict != "pass" {
+		t.Errorf("FinalVerdict = %q, want %q", meta.FinalVerdict, "pass")
+	}
+	if meta.TotalIterations != 2 {
+		t.Errorf("TotalIterations = %d, want 2", meta.TotalIterations)
+	}
+	if meta.CapReached {
+		t.Error("CapReached = true, want false")
+	}
+	// review turn 1 + fix turn 1 + review turn 2 = 3 agent RunTurn calls,
+	// but TurnsCompleted counts only completed turns (not fix turn that led to re-review).
+	// Each iteration increments TurnsCompleted once per review turn and once per fix turn.
+	if turns != 3 {
+		t.Errorf("TurnsCompleted = %d, want 3", turns)
+	}
+}
+
+func TestSelfReviewLoop_CapReached(t *testing.T) {
+	t.Parallel()
+
+	wsPath := t.TempDir()
+	m := &reviewMetricsCount{}
+	turns := 0
+
+	cfg := selfReviewCfg()
+	cfg.MaxIterations = 2
+
+	// Turn sequence:
+	//   0 = review turn 1 → iterate
+	//   1 = fix turn 1    → no verdict
+	//   2 = review turn 2 → iterate (cap reached after this)
+	adapter := &verdictWriter{
+		wsPath: wsPath,
+		verdicts: []domain.ReviewVerdict{
+			{Verdict: "iterate", Summary: "still broken"},
+			{},
+			{Verdict: "iterate", Summary: "still broken"},
+		},
+	}
+
+	meta := runSelfReviewLoop(context.Background(), RunSelfReviewParams{
+		Session:        domain.Session{ID: "sess"},
+		Issue:          selfReviewIssue(),
+		WorkspacePath:  wsPath,
+		Config:         cfg,
+		AgentAdapter:   adapter,
+		OnEvent:        func(_ string, _ domain.AgentEvent) {},
+		Logger:         discardLogger(),
+		Metrics:        m,
+		TurnsCompleted: &turns,
+	})
+
+	if !meta.CapReached {
+		t.Error("CapReached = false, want true")
+	}
+	if meta.TotalIterations != 2 {
+		t.Errorf("TotalIterations = %d, want 2", meta.TotalIterations)
+	}
+	if meta.FinalVerdict != "iterate" {
+		t.Errorf("FinalVerdict = %q, want %q", meta.FinalVerdict, "iterate")
+	}
+	if m.capReached != 1 {
+		t.Errorf("IncSelfReviewCapReached = %d, want 1", m.capReached)
+	}
+	if len(m.sessions) != 1 || m.sessions[0] != "iterate" {
+		t.Errorf("IncSelfReviewSessions = %v, want [iterate]", m.sessions)
+	}
+}
+
+func TestSelfReviewLoop_MissingVerdict(t *testing.T) {
+	t.Parallel()
+
+	wsPath := t.TempDir()
+	turns := 0
+
+	cfg := selfReviewCfg()
+	cfg.MaxIterations = 1
+
+	// Adapter writes no verdict file.
+	adapter := &verdictWriter{wsPath: wsPath, verdicts: nil}
+
+	meta := runSelfReviewLoop(context.Background(), RunSelfReviewParams{
+		Session:        domain.Session{ID: "sess"},
+		Issue:          selfReviewIssue(),
+		WorkspacePath:  wsPath,
+		Config:         cfg,
+		AgentAdapter:   adapter,
+		OnEvent:        func(_ string, _ domain.AgentEvent) {},
+		Logger:         discardLogger(),
+		Metrics:        &domain.NoopMetrics{},
+		TurnsCompleted: &turns,
+	})
+
+	if meta.FinalVerdict != "none" {
+		t.Errorf("FinalVerdict = %q, want %q", meta.FinalVerdict, "none")
+	}
+	if !meta.CapReached {
+		t.Error("CapReached = false, want true when verdict missing and at cap")
+	}
+}
+
+func TestSelfReviewLoop_TurnError(t *testing.T) {
+	t.Parallel()
+
+	wsPath := t.TempDir()
+	turns := 0
+
+	adapter := &failOnFirstAdapter{wsPath: wsPath}
+
+	meta := runSelfReviewLoop(context.Background(), RunSelfReviewParams{
+		Session:        domain.Session{ID: "sess"},
+		Issue:          selfReviewIssue(),
+		WorkspacePath:  wsPath,
+		Config:         selfReviewCfg(),
+		AgentAdapter:   adapter,
+		OnEvent:        func(_ string, _ domain.AgentEvent) {},
+		Logger:         discardLogger(),
+		Metrics:        &domain.NoopMetrics{},
+		TurnsCompleted: &turns,
+	})
+
+	// Loop should break on error; TurnsCompleted must not increment.
+	if turns != 0 {
+		t.Errorf("TurnsCompleted = %d, want 0 after turn error", turns)
+	}
+	if meta.TotalIterations != 1 {
+		t.Errorf("TotalIterations = %d, want 1 (partial record appended)", meta.TotalIterations)
+	}
+}
+
+func TestSelfReviewLoop_StatusBlocked(t *testing.T) {
+	t.Parallel()
+
+	wsPath := t.TempDir()
+	turns := 0
+
+	// Adapter writes "blocked" status signal during the first review turn.
+	adapter := &statusWriterAdapter{wsPath: wsPath, status: "blocked"}
+
+	meta := runSelfReviewLoop(context.Background(), RunSelfReviewParams{
+		Session:        domain.Session{ID: "sess"},
+		Issue:          selfReviewIssue(),
+		WorkspacePath:  wsPath,
+		Config:         selfReviewCfg(),
+		AgentAdapter:   adapter,
+		OnEvent:        func(_ string, _ domain.AgentEvent) {},
+		Logger:         discardLogger(),
+		Metrics:        &domain.NoopMetrics{},
+		TurnsCompleted: &turns,
+	})
+
+	// TurnsCompleted increments because the turn itself succeeded even though
+	// the status signal triggered an abort. turns == 1.
+	if turns != 1 {
+		t.Errorf("TurnsCompleted = %d, want 1", turns)
+	}
+	// Only one iteration record should be present; loop aborted.
+	if meta.TotalIterations != 1 {
+		t.Errorf("TotalIterations = %d, want 1 (aborted after first iteration)", meta.TotalIterations)
+	}
+	if meta.Iterations[0].VerdictParseError == "" {
+		t.Error("VerdictParseError should be set when aborted by status signal")
+	}
+}
+
+func TestSelfReviewLoop_ContextCancelled(t *testing.T) {
+	t.Parallel()
+
+	wsPath := t.TempDir()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	turns := 0
+	adapter := &verdictWriter{
+		wsPath:   wsPath,
+		verdicts: []domain.ReviewVerdict{{Verdict: "pass", Summary: "done"}},
+	}
+
+	meta := runSelfReviewLoop(ctx, RunSelfReviewParams{
+		Session:        domain.Session{ID: "sess"},
+		Issue:          selfReviewIssue(),
+		WorkspacePath:  wsPath,
+		Config:         selfReviewCfg(),
+		AgentAdapter:   adapter,
+		OnEvent:        func(_ string, _ domain.AgentEvent) {},
+		Logger:         discardLogger(),
+		Metrics:        &domain.NoopMetrics{},
+		TurnsCompleted: &turns,
+	})
+
+	if meta.TotalIterations != 0 {
+		t.Errorf("TotalIterations = %d, want 0 for pre-cancelled context", meta.TotalIterations)
+	}
+}
+
+func TestSelfReviewLoop_ProgressEvents(t *testing.T) {
+	t.Parallel()
+
+	wsPath := t.TempDir()
+	turns := 0
+
+	var msgs []selfReviewProgressMsg
+	onProgress := func(m selfReviewProgressMsg) {
+		msgs = append(msgs, m)
+	}
+
+	adapter := &verdictWriter{
+		wsPath:   wsPath,
+		verdicts: []domain.ReviewVerdict{{Verdict: "pass", Summary: "good"}},
+	}
+
+	runSelfReviewLoop(context.Background(), RunSelfReviewParams{
+		Session:        domain.Session{ID: "sess"},
+		Issue:          selfReviewIssue(),
+		WorkspacePath:  wsPath,
+		Config:         selfReviewCfg(),
+		AgentAdapter:   adapter,
+		OnEvent:        func(_ string, _ domain.AgentEvent) {},
+		OnProgress:     onProgress,
+		Logger:         discardLogger(),
+		Metrics:        &domain.NoopMetrics{},
+		TurnsCompleted: &turns,
+	})
+
+	checkMsg := func(want string) {
+		t.Helper()
+		for _, m := range msgs {
+			if m.Message == want {
+				return
+			}
+		}
+		var got []string
+		for _, m := range msgs {
+			got = append(got, m.Message)
+		}
+		t.Errorf("progress messages %v missing %q", got, want)
+	}
+
+	checkMsg("self_review_started")
+	checkMsg("self_review_iteration")
+	checkMsg("self_review_done")
+}
+
+func TestSelfReviewLoop_ReviewSummaryWritten(t *testing.T) {
+	t.Parallel()
+
+	wsPath := t.TempDir()
+	turns := 0
+
+	adapter := &verdictWriter{
+		wsPath:   wsPath,
+		verdicts: []domain.ReviewVerdict{{Verdict: "pass", Summary: "ok"}},
+	}
+
+	runSelfReviewLoop(context.Background(), RunSelfReviewParams{
+		Session:        domain.Session{ID: "sess"},
+		Issue:          selfReviewIssue(),
+		WorkspacePath:  wsPath,
+		Config:         selfReviewCfg(),
+		AgentAdapter:   adapter,
+		OnEvent:        func(_ string, _ domain.AgentEvent) {},
+		Logger:         discardLogger(),
+		Metrics:        &domain.NoopMetrics{},
+		TurnsCompleted: &turns,
+	})
+
+	summaryPath := filepath.Join(wsPath, ".sortie", "review_summary.md")
+	if _, err := os.Stat(summaryPath); os.IsNotExist(err) {
+		t.Error("review_summary.md was not written after loop completion")
+	}
+}

--- a/internal/orchestrator/self_review_test.go
+++ b/internal/orchestrator/self_review_test.go
@@ -881,9 +881,8 @@ func TestSelfReviewLoop_IterateThenPass(t *testing.T) {
 	if meta.CapReached {
 		t.Error("CapReached = true, want false")
 	}
-	// review turn 1 + fix turn 1 + review turn 2 = 3 agent RunTurn calls,
-	// but TurnsCompleted counts only completed turns (not fix turn that led to re-review).
-	// Each iteration increments TurnsCompleted once per review turn and once per fix turn.
+	// review turn 1 + fix turn 1 + review turn 2 = 3 completed agent turns.
+	// TurnsCompleted includes both review turns and the intervening fix turn.
 	if turns != 3 {
 		t.Errorf("TurnsCompleted = %d, want 3", turns)
 	}

--- a/internal/orchestrator/self_review_test.go
+++ b/internal/orchestrator/self_review_test.go
@@ -43,7 +43,7 @@ func runGit(t *testing.T, dir string, args ...string) {
 	}
 }
 
-// initGitRepo creates a bare git repo in dir with an empty initial commit.
+// initGitRepo creates a git repo in dir with an empty initial commit.
 func initGitRepo(t *testing.T, dir string) {
 	t.Helper()
 	runGit(t, dir, "init")

--- a/internal/orchestrator/self_review_test.go
+++ b/internal/orchestrator/self_review_test.go
@@ -659,9 +659,16 @@ func TestRunVerification_OutputTruncation(t *testing.T) {
 	t.Parallel()
 
 	wsPath := t.TempDir()
-	// Generate stdout that exceeds MaxVerificationOutputBytes.
+
+	// Generate stdout that exceeds MaxVerificationOutputBytes using
+	// only POSIX shell builtins, avoiding a python3 dependency.
 	bigCount := domain.MaxVerificationOutputBytes + 1024
-	cmd := fmt.Sprintf("python3 -c \"import sys; sys.stdout.write('x' * %d)\"", bigCount)
+	outputPath := filepath.Join(wsPath, "verification-output.txt")
+	if err := os.WriteFile(outputPath, []byte(strings.Repeat("x", bigCount)), 0o600); err != nil {
+		t.Fatalf("WriteFile(%q): %v", outputPath, err)
+	}
+
+	cmd := fmt.Sprintf("cat %q", outputPath)
 	result := runSingleVerification(context.Background(), cmd, wsPath, 10000, discardLogger(), &domain.NoopMetrics{})
 
 	if len(result.Stdout) > int(domain.MaxVerificationOutputBytes) {
@@ -690,7 +697,7 @@ func TestGenerateDiff_EmptyDiff(t *testing.T) {
 	wsPath := t.TempDir()
 	initGitRepo(t, wsPath)
 
-	diff, truncated, err := generateWorkspaceDiff(context.Background(), wsPath, 102400)
+	diff, _, truncated, err := generateWorkspaceDiff(context.Background(), wsPath, 102400)
 
 	if err != nil {
 		t.Fatalf("generateWorkspaceDiff: %v", err)
@@ -721,7 +728,7 @@ func TestGenerateDiff_ModifiedFile(t *testing.T) {
 		t.Fatalf("WriteFile modify: %v", err)
 	}
 
-	diff, _, err := generateWorkspaceDiff(context.Background(), wsPath, 102400)
+	diff, _, _, err := generateWorkspaceDiff(context.Background(), wsPath, 102400)
 
 	if err != nil {
 		t.Fatalf("generateWorkspaceDiff: %v", err)
@@ -750,7 +757,7 @@ func TestGenerateDiff_Truncation(t *testing.T) {
 	}
 
 	const maxBytes = 50
-	diff, truncated, err := generateWorkspaceDiff(context.Background(), wsPath, maxBytes)
+	diff, _, truncated, err := generateWorkspaceDiff(context.Background(), wsPath, maxBytes)
 
 	if err != nil {
 		t.Fatalf("generateWorkspaceDiff: %v", err)
@@ -770,7 +777,7 @@ func TestGenerateDiff_NoGit(t *testing.T) {
 
 	wsPath := t.TempDir()
 
-	_, _, err := generateWorkspaceDiff(context.Background(), wsPath, 102400)
+	_, _, _, err := generateWorkspaceDiff(context.Background(), wsPath, 102400)
 
 	if err == nil {
 		t.Error("generateWorkspaceDiff with non-git dir: expected error, got nil")

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -199,6 +199,14 @@ type RunningEntry struct {
 	// the worker session. Populated by HandleRetryTimer when the retry
 	// trigger is triggerCIFix. Nil for normal dispatches and non-CI retries.
 	CIFailureContext map[string]any
+
+	// SelfReviewActive is true when the worker is in the self-review phase.
+	// Mutated only by the event loop via selfReviewCh.
+	SelfReviewActive bool
+
+	// SelfReviewIteration is the current review iteration (0 when not in review).
+	// Mutated only by the event loop via selfReviewCh.
+	SelfReviewIteration int
 }
 
 // RetryEntry holds the runtime state for a pending retry. The persisted
@@ -419,28 +427,30 @@ func RunningCountByState(running map[string]*RunningEntry, state string) int {
 // SnapshotRunningEntry is a read-only view of a single running session
 // for observability consumers. Produced by [RuntimeSnapshot].
 type SnapshotRunningEntry struct {
-	IssueID            string                `json:"issue_id"`
-	Identifier         string                `json:"issue_identifier"`
-	DisplayID          string                `json:"display_identifier,omitempty"`
-	State              string                `json:"state"`
-	SessionID          string                `json:"session_id"`
-	TurnCount          int                   `json:"turn_count"`
-	LastAgentEvent     domain.AgentEventType `json:"last_event"`
-	LastAgentTimestamp time.Time             `json:"last_event_at"`
-	LastAgentMessage   string                `json:"last_message"`
-	StartedAt          time.Time             `json:"started_at"`
-	AgentInputTokens   int64                 `json:"input_tokens"`
-	AgentOutputTokens  int64                 `json:"output_tokens"`
-	AgentTotalTokens   int64                 `json:"total_tokens"`
-	CacheReadTokens    int64                 `json:"cache_read_tokens"`
-	ModelName          string                `json:"model_name,omitempty"`
-	APIRequestCount    int                   `json:"api_request_count"`
-	RequestsByModel    map[string]int        `json:"requests_by_model,omitempty"`
-	WorkspacePath      string                `json:"workspace_path"`
-	SSHHost            string                `json:"ssh_host,omitempty"`
-	ToolTimeMs         int64                 `json:"tool_time_ms"`
-	APITimeMs          int64                 `json:"api_time_ms"`
-	WorkflowFile       string                `json:"workflow_file,omitempty"`
+	IssueID             string                `json:"issue_id"`
+	Identifier          string                `json:"issue_identifier"`
+	DisplayID           string                `json:"display_identifier,omitempty"`
+	State               string                `json:"state"`
+	SessionID           string                `json:"session_id"`
+	TurnCount           int                   `json:"turn_count"`
+	LastAgentEvent      domain.AgentEventType `json:"last_event"`
+	LastAgentTimestamp  time.Time             `json:"last_event_at"`
+	LastAgentMessage    string                `json:"last_message"`
+	StartedAt           time.Time             `json:"started_at"`
+	AgentInputTokens    int64                 `json:"input_tokens"`
+	AgentOutputTokens   int64                 `json:"output_tokens"`
+	AgentTotalTokens    int64                 `json:"total_tokens"`
+	CacheReadTokens     int64                 `json:"cache_read_tokens"`
+	ModelName           string                `json:"model_name,omitempty"`
+	APIRequestCount     int                   `json:"api_request_count"`
+	RequestsByModel     map[string]int        `json:"requests_by_model,omitempty"`
+	WorkspacePath       string                `json:"workspace_path"`
+	SSHHost             string                `json:"ssh_host,omitempty"`
+	ToolTimeMs          int64                 `json:"tool_time_ms"`
+	APITimeMs           int64                 `json:"api_time_ms"`
+	WorkflowFile        string                `json:"workflow_file,omitempty"`
+	SelfReviewActive    bool                  `json:"self_review_active,omitempty"`
+	SelfReviewIteration int                   `json:"self_review_iteration,omitempty"`
 }
 
 // SnapshotRetryEntry is a read-only view of a pending retry for
@@ -530,28 +540,30 @@ func RuntimeSnapshot(state *State, now time.Time) RuntimeSnapshotResult {
 			}
 		}
 		snap.Running = append(snap.Running, SnapshotRunningEntry{
-			IssueID:            entry.Issue.ID,
-			Identifier:         entry.Identifier,
-			DisplayID:          entry.Issue.DisplayID,
-			State:              entry.Issue.State,
-			SessionID:          entry.SessionID,
-			TurnCount:          entry.TurnCount,
-			LastAgentEvent:     entry.LastAgentEvent,
-			LastAgentTimestamp: entry.LastAgentTimestamp,
-			LastAgentMessage:   entry.LastAgentMessage,
-			StartedAt:          entry.StartedAt,
-			AgentInputTokens:   entry.AgentInputTokens,
-			AgentOutputTokens:  entry.AgentOutputTokens,
-			AgentTotalTokens:   entry.AgentTotalTokens,
-			CacheReadTokens:    entry.CacheReadTokens,
-			ModelName:          entry.ModelName,
-			APIRequestCount:    entry.APIRequestCount,
-			RequestsByModel:    modelRequests,
-			WorkspacePath:      entry.WorkspacePath,
-			SSHHost:            entry.SSHHost,
-			ToolTimeMs:         entry.ToolTimeMs,
-			APITimeMs:          entry.APITimeMs,
-			WorkflowFile:       entry.WorkflowFile,
+			IssueID:             entry.Issue.ID,
+			Identifier:          entry.Identifier,
+			DisplayID:           entry.Issue.DisplayID,
+			State:               entry.Issue.State,
+			SessionID:           entry.SessionID,
+			TurnCount:           entry.TurnCount,
+			LastAgentEvent:      entry.LastAgentEvent,
+			LastAgentTimestamp:  entry.LastAgentTimestamp,
+			LastAgentMessage:    entry.LastAgentMessage,
+			StartedAt:           entry.StartedAt,
+			AgentInputTokens:    entry.AgentInputTokens,
+			AgentOutputTokens:   entry.AgentOutputTokens,
+			AgentTotalTokens:    entry.AgentTotalTokens,
+			CacheReadTokens:     entry.CacheReadTokens,
+			ModelName:           entry.ModelName,
+			APIRequestCount:     entry.APIRequestCount,
+			RequestsByModel:     modelRequests,
+			WorkspacePath:       entry.WorkspacePath,
+			SSHHost:             entry.SSHHost,
+			ToolTimeMs:          entry.ToolTimeMs,
+			APITimeMs:           entry.APITimeMs,
+			WorkflowFile:        entry.WorkflowFile,
+			SelfReviewActive:    entry.SelfReviewActive,
+			SelfReviewIteration: entry.SelfReviewIteration,
 		})
 
 		if !entry.StartedAt.IsZero() {

--- a/internal/orchestrator/state_test.go
+++ b/internal/orchestrator/state_test.go
@@ -852,3 +852,67 @@ func TestRuntimeSnapshot_WorkflowFile(t *testing.T) {
 		})
 	}
 }
+
+func TestRuntimeSnapshot_SelfReviewFields(t *testing.T) {
+	t.Parallel()
+
+	fixedNow := time.Date(2026, 3, 24, 12, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name            string
+		active          bool
+		iteration       int
+		wantSRActive    bool
+		wantSRIteration int
+	}{
+		{
+			name:            "not in self-review phase",
+			active:          false,
+			iteration:       0,
+			wantSRActive:    false,
+			wantSRIteration: 0,
+		},
+		{
+			name:            "self-review active iteration 1",
+			active:          true,
+			iteration:       1,
+			wantSRActive:    true,
+			wantSRIteration: 1,
+		},
+		{
+			name:            "self-review active iteration 3",
+			active:          true,
+			iteration:       3,
+			wantSRActive:    true,
+			wantSRIteration: 3,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			state := NewState(5000, 4, nil, AgentTotals{})
+			state.Running["ISS-SR"] = &RunningEntry{
+				Identifier:          "PROJ-99",
+				Issue:               domain.Issue{ID: "ISS-SR", State: "In Progress"},
+				StartedAt:           fixedNow.Add(-2 * time.Minute),
+				SelfReviewActive:    tt.active,
+				SelfReviewIteration: tt.iteration,
+			}
+
+			result := RuntimeSnapshot(state, fixedNow)
+
+			if len(result.Running) != 1 {
+				t.Fatalf("len(Running) = %d, want 1", len(result.Running))
+			}
+			got := result.Running[0]
+			if got.SelfReviewActive != tt.wantSRActive {
+				t.Errorf("SelfReviewActive = %v, want %v", got.SelfReviewActive, tt.wantSRActive)
+			}
+			if got.SelfReviewIteration != tt.wantSRIteration {
+				t.Errorf("SelfReviewIteration = %d, want %d", got.SelfReviewIteration, tt.wantSRIteration)
+			}
+		})
+	}
+}

--- a/internal/orchestrator/worker.go
+++ b/internal/orchestrator/worker.go
@@ -856,8 +856,12 @@ func RunWorkerAttempt(ctx context.Context, issue domain.Issue, attempt *int, dep
 			selfReviewStatus = "error"
 		}
 		reviewSummaryPath := filepath.Join(wsResult.Path, ".sortie", "review_summary.md")
-		if _, statErr := os.Stat(reviewSummaryPath); statErr == nil {
-			selfReviewSummaryPath = reviewSummaryPath
+		sortieDirInfo, dirErr := os.Lstat(filepath.Join(wsResult.Path, ".sortie"))
+		if dirErr == nil && sortieDirInfo.Mode()&os.ModeSymlink == 0 && sortieDirInfo.IsDir() {
+			summaryInfo, sumErr := os.Lstat(reviewSummaryPath)
+			if sumErr == nil && summaryInfo.Mode()&os.ModeSymlink == 0 && summaryInfo.Mode().IsRegular() {
+				selfReviewSummaryPath = reviewSummaryPath
+			}
 		}
 	}
 

--- a/internal/orchestrator/worker.go
+++ b/internal/orchestrator/worker.go
@@ -855,7 +855,10 @@ func RunWorkerAttempt(ctx context.Context, issue domain.Issue, attempt *int, dep
 		default:
 			selfReviewStatus = "error"
 		}
-		selfReviewSummaryPath = filepath.Join(wsResult.Path, ".sortie", "review_summary.md")
+		reviewSummaryPath := filepath.Join(wsResult.Path, ".sortie", "review_summary.md")
+		if _, statErr := os.Stat(reviewSummaryPath); statErr == nil {
+			selfReviewSummaryPath = reviewSummaryPath
+		}
 	}
 
 	stopSessionBestEffort(ctx, deps.AgentAdapter, session, cfg, logger)

--- a/internal/orchestrator/worker.go
+++ b/internal/orchestrator/worker.go
@@ -135,6 +135,11 @@ type WorkerResult struct {
 	// false.
 	SoftStopReason string
 
+	// ReviewMetadata summarizes the self-review loop outcome.
+	// Nil when self-review is disabled or the worker exited before
+	// the review phase.
+	ReviewMetadata *domain.ReviewMetadata
+
 	// StartedAt is copied from the RunningEntry (set by DispatchIssue).
 	// The worker does not set this — it is populated by the exit
 	// handler from the running map entry.
@@ -213,6 +218,11 @@ type WorkerDeps struct {
 	// template on the first turn. Non-nil only for CI-fix continuation
 	// dispatches. Nil for normal dispatches and non-CI retries.
 	CIFailureContext map[string]any
+
+	// OnProgress relays self-review progress to the orchestrator's event
+	// loop. Called from the worker goroutine; must be safe for concurrent
+	// use. May be nil when self-review is not configured.
+	OnProgress func(selfReviewProgressMsg)
 }
 
 // normalizeAttempt converts the nullable attempt to a plain integer.
@@ -814,8 +824,53 @@ func RunWorkerAttempt(ctx context.Context, issue domain.Issue, attempt *int, dep
 		turnNumber++
 	}
 
+	// Self-review phase: run verification commands and iterate with the
+	// agent before final exit. Re-read config for dynamic reload.
+	reviewCfg := deps.ConfigFunc()
+	var reviewMeta *domain.ReviewMetadata
+
+	if reviewCfg.SelfReview.Enabled && isActiveState(issue.State, activeStates) && ctx.Err() == nil {
+		reviewMeta = runSelfReviewLoop(ctx, RunSelfReviewParams{
+			Session:        session,
+			Issue:          issue,
+			WorkspacePath:  wsResult.Path,
+			Config:         reviewCfg.SelfReview,
+			AgentAdapter:   deps.AgentAdapter,
+			OnEvent:        deps.OnEvent,
+			OnProgress:     deps.OnProgress,
+			Logger:         logger,
+			Metrics:        deps.Metrics,
+			TurnsCompleted: &turnsCompleted,
+		})
+	}
+
+	selfReviewStatus := "disabled"
+	selfReviewSummaryPath := ""
+	if reviewMeta != nil {
+		switch {
+		case reviewMeta.FinalVerdict == "pass":
+			selfReviewStatus = "passed"
+		case reviewMeta.CapReached:
+			selfReviewStatus = "cap_reached"
+		default:
+			selfReviewStatus = "error"
+		}
+		selfReviewSummaryPath = filepath.Join(wsResult.Path, ".sortie", "review_summary.md")
+	}
+
 	stopSessionBestEffort(ctx, deps.AgentAdapter, session, cfg, logger)
-	finishWorkspace()
+	workspace.Finish(ctx, workspace.FinishParams{
+		Path:                  wsResult.Path,
+		Identifier:            issue.Identifier,
+		IssueID:               issue.ID,
+		Attempt:               attemptInt,
+		AfterRun:              cfg.Hooks.AfterRun,
+		HookTimeoutMS:         cfg.Hooks.TimeoutMS,
+		Logger:                logger,
+		SSHHost:               deps.SSHHost,
+		SelfReviewStatus:      selfReviewStatus,
+		SelfReviewSummaryPath: selfReviewSummaryPath,
+	})
 
 	logger.Info("worker exiting",
 		slog.Any("exit_kind", WorkerExitNormal),
@@ -833,6 +888,7 @@ func RunWorkerAttempt(ctx context.Context, issue domain.Issue, attempt *int, dep
 		AgentAdapter:   cfg.Agent.Kind,
 		Attempt:        attempt,
 		SSHHost:        deps.SSHHost,
+		ReviewMetadata: reviewMeta,
 	})
 }
 

--- a/internal/persistence/migrate_test.go
+++ b/internal/persistence/migrate_test.go
@@ -197,6 +197,7 @@ func TestMigrate_ColumnCorrectness(t *testing.T) {
 				{"workflow_file", "TEXT", false, 0},
 				{"turns_completed", "INTEGER", true, 0},
 				{"display_identifier", "TEXT", false, 0},
+				{"review_metadata", "TEXT", false, 0},
 			},
 		},
 		{

--- a/internal/persistence/migrations.go
+++ b/internal/persistence/migrations.go
@@ -29,6 +29,9 @@ var migration005SQL string
 //go:embed sql/006_display_identifier.sql
 var migration006SQL string
 
+//go:embed sql/007_self_review.sql
+var migration007SQL string
+
 var migrations = []Migration{
 	{Version: 1, Description: "core persistence tables", SQL: migration001SQL},
 	{Version: 2, Description: "extended token metrics", SQL: migration002SQL},
@@ -36,4 +39,5 @@ var migrations = []Migration{
 	{Version: 4, Description: "run_history issue_id index", SQL: migration004SQL},
 	{Version: 5, Description: "turns completed in run history", SQL: migration005SQL},
 	{Version: 6, Description: "display identifier in run history", SQL: migration006SQL},
+	{Version: 7, Description: "self-review metadata in run history", SQL: migration007SQL},
 }

--- a/internal/persistence/run_history.go
+++ b/internal/persistence/run_history.go
@@ -24,6 +24,7 @@ type RunHistory struct {
 	Error          *string // Error message if failed; nil on success.
 	WorkflowFile   string  // Base filename of the WORKFLOW.md file; empty for pre-migration rows.
 	TurnsCompleted int     // Number of coding turns completed in this run.
+	ReviewMetadata *string // JSON-serialized ReviewMetadata; nil when self-review did not run.
 }
 
 // AppendRunHistory inserts a completed run attempt into run_history. The ID
@@ -45,13 +46,18 @@ func (s *Store) AppendRunHistory(ctx context.Context, run RunHistory) (RunHistor
 		dispIDVal = sql.NullString{String: run.DisplayID, Valid: true}
 	}
 
+	reviewMetaVal := sql.NullString{}
+	if run.ReviewMetadata != nil {
+		reviewMetaVal = sql.NullString{String: *run.ReviewMetadata, Valid: true}
+	}
+
 	res, err := s.db.ExecContext(ctx,
 		`INSERT INTO run_history
-			(issue_id, identifier, display_identifier, attempt, agent_adapter, workspace, started_at, completed_at, status, error, workflow_file, turns_completed)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			(issue_id, identifier, display_identifier, attempt, agent_adapter, workspace, started_at, completed_at, status, error, workflow_file, turns_completed, review_metadata)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		run.IssueID, run.Identifier, dispIDVal, run.Attempt, run.AgentAdapter,
 		run.Workspace, run.StartedAt, run.CompletedAt, run.Status, errVal, wfVal,
-		run.TurnsCompleted,
+		run.TurnsCompleted, reviewMetaVal,
 	)
 	if err != nil {
 		return RunHistory{}, fmt.Errorf("append run history for %q: %w", run.IssueID, err)
@@ -71,7 +77,7 @@ func (s *Store) AppendRunHistory(ctx context.Context, run RunHistory) (RunHistor
 func (s *Store) QueryRunHistoryByIssue(ctx context.Context, issueID string) ([]RunHistory, error) {
 	rows, err := s.db.QueryContext(ctx,
 		`SELECT id, issue_id, identifier, display_identifier, attempt, agent_adapter, workspace,
-			started_at, completed_at, status, error, workflow_file, turns_completed
+			started_at, completed_at, status, error, workflow_file, turns_completed, review_metadata
 		FROM run_history
 		WHERE issue_id = ?
 		ORDER BY id DESC`, issueID)
@@ -83,11 +89,11 @@ func (s *Store) QueryRunHistoryByIssue(ctx context.Context, issueID string) ([]R
 	entries := []RunHistory{}
 	for rows.Next() {
 		var r RunHistory
-		var errVal, wfVal, dispIDVal sql.NullString
+		var errVal, wfVal, dispIDVal, reviewMetaVal sql.NullString
 		if err := rows.Scan(
 			&r.ID, &r.IssueID, &r.Identifier, &dispIDVal, &r.Attempt, &r.AgentAdapter,
 			&r.Workspace, &r.StartedAt, &r.CompletedAt, &r.Status, &errVal, &wfVal,
-			&r.TurnsCompleted,
+			&r.TurnsCompleted, &reviewMetaVal,
 		); err != nil {
 			return nil, fmt.Errorf("scan run history: %w", err)
 		}
@@ -100,6 +106,10 @@ func (s *Store) QueryRunHistoryByIssue(ctx context.Context, issueID string) ([]R
 		}
 		if dispIDVal.Valid {
 			r.DisplayID = dispIDVal.String
+		}
+		if reviewMetaVal.Valid {
+			s := reviewMetaVal.String
+			r.ReviewMetadata = &s
 		}
 		entries = append(entries, r)
 	}
@@ -124,7 +134,7 @@ func (s *Store) QueryRecentRunHistory(ctx context.Context, limit int, afterID in
 	if afterID > 0 {
 		rows, err = s.db.QueryContext(ctx,
 			`SELECT id, issue_id, identifier, display_identifier, attempt, agent_adapter, workspace,
-				started_at, completed_at, status, error, workflow_file, turns_completed
+				started_at, completed_at, status, error, workflow_file, turns_completed, review_metadata
 			FROM run_history
 			WHERE id < ?
 			ORDER BY id DESC
@@ -132,7 +142,7 @@ func (s *Store) QueryRecentRunHistory(ctx context.Context, limit int, afterID in
 	} else {
 		rows, err = s.db.QueryContext(ctx,
 			`SELECT id, issue_id, identifier, display_identifier, attempt, agent_adapter, workspace,
-				started_at, completed_at, status, error, workflow_file, turns_completed
+				started_at, completed_at, status, error, workflow_file, turns_completed, review_metadata
 			FROM run_history
 			ORDER BY id DESC
 			LIMIT ?`, limit)
@@ -145,11 +155,11 @@ func (s *Store) QueryRecentRunHistory(ctx context.Context, limit int, afterID in
 	entries := []RunHistory{}
 	for rows.Next() {
 		var r RunHistory
-		var errVal, wfVal, dispIDVal sql.NullString
+		var errVal, wfVal, dispIDVal, reviewMetaVal sql.NullString
 		if err := rows.Scan(
 			&r.ID, &r.IssueID, &r.Identifier, &dispIDVal, &r.Attempt, &r.AgentAdapter,
 			&r.Workspace, &r.StartedAt, &r.CompletedAt, &r.Status, &errVal, &wfVal,
-			&r.TurnsCompleted,
+			&r.TurnsCompleted, &reviewMetaVal,
 		); err != nil {
 			return nil, fmt.Errorf("scan run history: %w", err)
 		}
@@ -162,6 +172,10 @@ func (s *Store) QueryRecentRunHistory(ctx context.Context, limit int, afterID in
 		}
 		if dispIDVal.Valid {
 			r.DisplayID = dispIDVal.String
+		}
+		if reviewMetaVal.Valid {
+			s := reviewMetaVal.String
+			r.ReviewMetadata = &s
 		}
 		entries = append(entries, r)
 	}

--- a/internal/persistence/run_history.go
+++ b/internal/persistence/run_history.go
@@ -108,8 +108,8 @@ func (s *Store) QueryRunHistoryByIssue(ctx context.Context, issueID string) ([]R
 			r.DisplayID = dispIDVal.String
 		}
 		if reviewMetaVal.Valid {
-			s := reviewMetaVal.String
-			r.ReviewMetadata = &s
+			metaJSON := reviewMetaVal.String
+			r.ReviewMetadata = &metaJSON
 		}
 		entries = append(entries, r)
 	}
@@ -174,8 +174,8 @@ func (s *Store) QueryRecentRunHistory(ctx context.Context, limit int, afterID in
 			r.DisplayID = dispIDVal.String
 		}
 		if reviewMetaVal.Valid {
-			s := reviewMetaVal.String
-			r.ReviewMetadata = &s
+			metaJSON := reviewMetaVal.String
+			r.ReviewMetadata = &metaJSON
 		}
 		entries = append(entries, r)
 	}

--- a/internal/persistence/sql/007_self_review.sql
+++ b/internal/persistence/sql/007_self_review.sql
@@ -1,0 +1,1 @@
+ALTER TABLE run_history ADD COLUMN review_metadata TEXT;

--- a/internal/persistence/store_test.go
+++ b/internal/persistence/store_test.go
@@ -2228,3 +2228,64 @@ func TestOpenReadOnly_ReadsExistingData(t *testing.T) {
 		t.Errorf("Identifier = %q, want %q", entries[0].Identifier, run.Identifier)
 	}
 }
+
+func TestAppendRunHistory_ReviewMetadata_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	s := openTestStore(t)
+	migrateOrFatal(t, s)
+	ctx := context.Background()
+
+	meta := `{"enabled":true,"iterations":[],"total_iterations":1,"final_verdict":"pass","cap_reached":false}`
+	run := newTestRun(100)
+	run.ReviewMetadata = &meta
+
+	got := appendOrFatal(t, s, run)
+	if got.ReviewMetadata == nil {
+		t.Fatal("ReviewMetadata = nil after insert, want non-nil")
+	}
+	if *got.ReviewMetadata != meta {
+		t.Errorf("ReviewMetadata = %q, want %q", *got.ReviewMetadata, meta)
+	}
+
+	entries, err := s.QueryRunHistoryByIssue(ctx, run.IssueID)
+	if err != nil {
+		t.Fatalf("QueryRunHistoryByIssue: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("entries len = %d, want 1", len(entries))
+	}
+	if entries[0].ReviewMetadata == nil {
+		t.Fatal("queried ReviewMetadata = nil, want non-nil")
+	}
+	if *entries[0].ReviewMetadata != meta {
+		t.Errorf("queried ReviewMetadata = %q, want %q", *entries[0].ReviewMetadata, meta)
+	}
+}
+
+func TestAppendRunHistory_ReviewMetadata_Null(t *testing.T) {
+	t.Parallel()
+
+	s := openTestStore(t)
+	migrateOrFatal(t, s)
+	ctx := context.Background()
+
+	run := newTestRun(101)
+	// ReviewMetadata is nil — self-review did not run.
+
+	got := appendOrFatal(t, s, run)
+	if got.ReviewMetadata != nil {
+		t.Errorf("ReviewMetadata = %q, want nil", *got.ReviewMetadata)
+	}
+
+	entries, err := s.QueryRunHistoryByIssue(ctx, run.IssueID)
+	if err != nil {
+		t.Fatalf("QueryRunHistoryByIssue: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("entries len = %d, want 1", len(entries))
+	}
+	if entries[0].ReviewMetadata != nil {
+		t.Errorf("queried ReviewMetadata = %q, want nil", *entries[0].ReviewMetadata)
+	}
+}

--- a/internal/server/grafana_coverage_test.go
+++ b/internal/server/grafana_coverage_test.go
@@ -37,6 +37,10 @@ var knownSortieMetrics = []string{
 	"sortie_ssh_host_usage",
 	"sortie_ci_status_checks_total",
 	"sortie_ci_escalations_total",
+	"sortie_self_review_iterations_total",
+	"sortie_self_review_sessions_total",
+	"sortie_self_review_verification_duration_seconds",
+	"sortie_self_review_cap_reached_total",
 }
 
 // stripHistogramSuffix removes PromQL-specific histogram suffixes so that

--- a/internal/server/metrics.go
+++ b/internal/server/metrics.go
@@ -35,6 +35,11 @@ type PromMetrics struct {
 	ciStatusChecksTotal   *prometheus.CounterVec
 	ciEscalationsTotal    *prometheus.CounterVec
 
+	selfReviewIterationsTotal      *prometheus.CounterVec
+	selfReviewSessionsTotal        *prometheus.CounterVec
+	selfReviewVerificationDuration *prometheus.HistogramVec
+	selfReviewCapReachedTotal      prometheus.Counter
+
 	pollDuration   prometheus.Histogram
 	workerDuration *prometheus.HistogramVec
 
@@ -190,6 +195,31 @@ func NewPromMetrics(version, goVersion string) *PromMetrics {
 		Help:      "CI escalation actions taken.",
 	}, []string{"action"})
 
+	selfReviewIterationsTotal := prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "sortie",
+		Name:      "self_review_iterations_total",
+		Help:      "Self-review iterations by verdict.",
+	}, []string{"verdict"})
+
+	selfReviewSessionsTotal := prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "sortie",
+		Name:      "self_review_sessions_total",
+		Help:      "Self-review sessions by final verdict.",
+	}, []string{"final_verdict"})
+
+	selfReviewVerificationDuration := prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: "sortie",
+		Name:      "self_review_verification_duration_seconds",
+		Help:      "Per-command verification duration.",
+		Buckets:   prometheus.ExponentialBuckets(10, 2, 12),
+	}, []string{"command"})
+
+	selfReviewCapReachedTotal := prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: "sortie",
+		Name:      "self_review_cap_reached_total",
+		Help:      "Self-review sessions that hit the iteration cap.",
+	})
+
 	reg.MustRegister(
 		sessionsRunning,
 		sessionsRetrying,
@@ -213,31 +243,39 @@ func NewPromMetrics(version, goVersion string) *PromMetrics {
 		sshHostUsage,
 		ciStatusChecksTotal,
 		ciEscalationsTotal,
+		selfReviewIterationsTotal,
+		selfReviewSessionsTotal,
+		selfReviewVerificationDuration,
+		selfReviewCapReachedTotal,
 	)
 
 	return &PromMetrics{
-		registry:              reg,
-		sessionsRunning:       sessionsRunning,
-		sessionsRetrying:      sessionsRetrying,
-		slotsAvailable:        slotsAvailable,
-		activeSessionsElapsed: activeSessionsElapsed,
-		tokensTotal:           tokensTotal,
-		agentRuntimeTotal:     agentRuntimeTotal,
-		dispatchesTotal:       dispatchesTotal,
-		workerExitsTotal:      workerExitsTotal,
-		retriesTotal:          retriesTotal,
-		reconciliationActions: reconciliationActions,
-		pollCyclesTotal:       pollCyclesTotal,
-		trackerRequestsTotal:  trackerRequestsTotal,
-		handoffTransitions:    handoffTransitions,
-		dispatchTransitions:   dispatchTransitions,
-		trackerCommentsTotal:  trackerCommentsTotal,
-		toolCallsTotal:        toolCallsTotal,
-		pollDuration:          pollDuration,
-		workerDuration:        workerDuration,
-		sshHostUsage:          sshHostUsage,
-		ciStatusChecksTotal:   ciStatusChecksTotal,
-		ciEscalationsTotal:    ciEscalationsTotal,
+		registry:                       reg,
+		sessionsRunning:                sessionsRunning,
+		sessionsRetrying:               sessionsRetrying,
+		slotsAvailable:                 slotsAvailable,
+		activeSessionsElapsed:          activeSessionsElapsed,
+		tokensTotal:                    tokensTotal,
+		agentRuntimeTotal:              agentRuntimeTotal,
+		dispatchesTotal:                dispatchesTotal,
+		workerExitsTotal:               workerExitsTotal,
+		retriesTotal:                   retriesTotal,
+		reconciliationActions:          reconciliationActions,
+		pollCyclesTotal:                pollCyclesTotal,
+		trackerRequestsTotal:           trackerRequestsTotal,
+		handoffTransitions:             handoffTransitions,
+		dispatchTransitions:            dispatchTransitions,
+		trackerCommentsTotal:           trackerCommentsTotal,
+		toolCallsTotal:                 toolCallsTotal,
+		pollDuration:                   pollDuration,
+		workerDuration:                 workerDuration,
+		sshHostUsage:                   sshHostUsage,
+		ciStatusChecksTotal:            ciStatusChecksTotal,
+		ciEscalationsTotal:             ciEscalationsTotal,
+		selfReviewIterationsTotal:      selfReviewIterationsTotal,
+		selfReviewSessionsTotal:        selfReviewSessionsTotal,
+		selfReviewVerificationDuration: selfReviewVerificationDuration,
+		selfReviewCapReachedTotal:      selfReviewCapReachedTotal,
 	}
 }
 
@@ -360,4 +398,28 @@ func (p *PromMetrics) IncCIStatusChecks(result string) {
 // IncCIEscalations increments the CI escalation action counter.
 func (p *PromMetrics) IncCIEscalations(action string) {
 	p.ciEscalationsTotal.WithLabelValues(action).Inc()
+}
+
+// IncSelfReviewIterations increments the review iteration counter.
+func (p *PromMetrics) IncSelfReviewIterations(verdict string) {
+	p.selfReviewIterationsTotal.WithLabelValues(verdict).Inc()
+}
+
+// IncSelfReviewSessions increments the review session counter.
+func (p *PromMetrics) IncSelfReviewSessions(finalVerdict string) {
+	p.selfReviewSessionsTotal.WithLabelValues(finalVerdict).Inc()
+}
+
+// ObserveSelfReviewVerificationDuration records the duration of a
+// verification command.
+func (p *PromMetrics) ObserveSelfReviewVerificationDuration(command string, seconds float64) {
+	if len(command) > 64 {
+		command = command[:64]
+	}
+	p.selfReviewVerificationDuration.WithLabelValues(command).Observe(seconds)
+}
+
+// IncSelfReviewCapReached increments the cap-reached counter.
+func (p *PromMetrics) IncSelfReviewCapReached() {
+	p.selfReviewCapReachedTotal.Inc()
 }

--- a/internal/server/metrics_test.go
+++ b/internal/server/metrics_test.go
@@ -131,6 +131,10 @@ func TestNewPromMetrics(t *testing.T) {
 	m.SetSSHHostUsage("test-host", 1)
 	m.IncCIStatusChecks("passing")
 	m.IncCIEscalations("label")
+	m.IncSelfReviewIterations("pass")
+	m.IncSelfReviewSessions("pass")
+	m.ObserveSelfReviewVerificationDuration("go test ./...", 1.5)
+	m.IncSelfReviewCapReached()
 
 	families := gatherFamilies(t, m)
 

--- a/internal/workspace/lifecycle.go
+++ b/internal/workspace/lifecycle.go
@@ -177,6 +177,14 @@ type FinishParams struct {
 	// SSHHost is the SSH destination host. When non-empty, hooks receive
 	// SORTIE_SSH_HOST in their environment.
 	SSHHost string
+
+	// SelfReviewStatus is the self-review outcome for hook env.
+	// "disabled", "passed", "cap_reached", or "error". Empty treated as "disabled".
+	SelfReviewStatus string
+
+	// SelfReviewSummaryPath is the absolute path to .sortie/review_summary.md.
+	// Empty when self-review did not run or the summary was not written.
+	SelfReviewSummaryPath string
 }
 
 // Finish runs the after_run hook if configured. Failure is logged and
@@ -198,6 +206,15 @@ func Finish(ctx context.Context, params FinishParams) {
 
 	detachedCtx := context.WithoutCancel(ctx)
 	env := HookEnv(params.IssueID, params.Identifier, params.Path, params.Attempt, params.SSHHost)
+
+	reviewStatus := params.SelfReviewStatus
+	if reviewStatus == "" {
+		reviewStatus = "disabled"
+	}
+	env["SORTIE_SELF_REVIEW_STATUS"] = reviewStatus
+	if params.SelfReviewSummaryPath != "" {
+		env["SORTIE_SELF_REVIEW_SUMMARY_PATH"] = params.SelfReviewSummaryPath
+	}
 
 	logger.InfoContext(ctx, "running hook", slog.String("hook", "after_run"), slog.String("workspace", params.Path))
 	_, hookErr := RunHook(detachedCtx, HookParams{

--- a/internal/workspace/lifecycle_test.go
+++ b/internal/workspace/lifecycle_test.go
@@ -463,6 +463,104 @@ func TestFinish(t *testing.T) {
 
 		assertFileExists(t, marker)
 	})
+
+	t.Run("SORTIE_SELF_REVIEW_STATUS defaults to disabled", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		out := filepath.Join(dir, "sr_status.txt")
+
+		Finish(context.Background(), FinishParams{
+			Path:             dir,
+			Identifier:       "F-SR-1",
+			IssueID:          "id-sr-1",
+			Attempt:          1,
+			AfterRun:         `echo -n "$SORTIE_SELF_REVIEW_STATUS" > "` + out + `"`,
+			HookTimeoutMS:    5000,
+			SelfReviewStatus: "", // empty → "disabled"
+		})
+
+		data, err := os.ReadFile(out)
+		if err != nil {
+			t.Fatalf("reading %q: %v", out, err)
+		}
+		if string(data) != "disabled" {
+			t.Errorf("SORTIE_SELF_REVIEW_STATUS = %q, want %q", string(data), "disabled")
+		}
+	})
+
+	t.Run("SORTIE_SELF_REVIEW_STATUS passed when set", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		out := filepath.Join(dir, "sr_status.txt")
+
+		Finish(context.Background(), FinishParams{
+			Path:             dir,
+			Identifier:       "F-SR-2",
+			IssueID:          "id-sr-2",
+			Attempt:          1,
+			AfterRun:         `echo -n "$SORTIE_SELF_REVIEW_STATUS" > "` + out + `"`,
+			HookTimeoutMS:    5000,
+			SelfReviewStatus: "passed",
+		})
+
+		data, err := os.ReadFile(out)
+		if err != nil {
+			t.Fatalf("reading %q: %v", out, err)
+		}
+		if string(data) != "passed" {
+			t.Errorf("SORTIE_SELF_REVIEW_STATUS = %q, want %q", string(data), "passed")
+		}
+	})
+
+	t.Run("SORTIE_SELF_REVIEW_SUMMARY_PATH set when non-empty", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		out := filepath.Join(dir, "sr_summary.txt")
+		summaryPath := "/workspace/.sortie/review_summary.md"
+
+		Finish(context.Background(), FinishParams{
+			Path:                  dir,
+			Identifier:            "F-SR-3",
+			IssueID:               "id-sr-3",
+			Attempt:               1,
+			AfterRun:              `echo -n "$SORTIE_SELF_REVIEW_SUMMARY_PATH" > "` + out + `"`,
+			HookTimeoutMS:         5000,
+			SelfReviewStatus:      "passed",
+			SelfReviewSummaryPath: summaryPath,
+		})
+
+		data, err := os.ReadFile(out)
+		if err != nil {
+			t.Fatalf("reading %q: %v", out, err)
+		}
+		if string(data) != summaryPath {
+			t.Errorf("SORTIE_SELF_REVIEW_SUMMARY_PATH = %q, want %q", string(data), summaryPath)
+		}
+	})
+
+	t.Run("SORTIE_SELF_REVIEW_SUMMARY_PATH absent when empty", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		out := filepath.Join(dir, "sr_summary.txt")
+
+		// Write "PRESENT" only if the env var exists and is non-empty.
+		Finish(context.Background(), FinishParams{
+			Path:                  dir,
+			Identifier:            "F-SR-4",
+			IssueID:               "id-sr-4",
+			Attempt:               1,
+			AfterRun:              `[ -n "$SORTIE_SELF_REVIEW_SUMMARY_PATH" ] && echo -n "PRESENT" > "` + out + `" || true`,
+			HookTimeoutMS:         5000,
+			SelfReviewStatus:      "disabled",
+			SelfReviewSummaryPath: "",
+		})
+
+		// File should not be created (env var absent or empty).
+		if _, err := os.Stat(out); !os.IsNotExist(err) {
+			data, _ := os.ReadFile(out)
+			t.Errorf("SORTIE_SELF_REVIEW_SUMMARY_PATH should be absent, but hook saw it; content = %q", data)
+		}
+	})
 }
 
 func TestCleanup(t *testing.T) {


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Feat

**Intent:** Adds an orchestrator-controlled self-review loop that runs between agent completion and PR creation. The orchestrator generates a workspace diff, executes configurable verification commands (tests, linters), assembles a structured review prompt, and iterates with the agent up to a configurable cap before proceeding.

**Related Issues:** #312

### 🧭 Reviewer Guide

**Complexity:** High

#### Entry Point

`internal/orchestrator/self_review.go` — contains `runSelfReviewLoop`, which orchestrates the entire review phase: diff generation, verification command execution, prompt assembly, verdict parsing, and iteration logic. Start here to understand the control flow before looking at how `worker.go` and `state.go` invoke it.

#### Sensitive Areas

- `internal/orchestrator/self_review.go`: Controls subprocess execution for verification commands and reads agent-written verdict files from the workspace. Sandboxed to the workspace path; verify path-containment logic holds.
- `internal/persistence/run_history.go`: Stores review metadata as JSON in the `review_metadata` column; confirm serialisation cannot produce unbounded blobs given `MaxVerificationOutputBytes` and `diff_max_bytes` caps.
- `internal/persistence/sql/007_self_review.sql`: Adds `review_metadata TEXT` column via `ALTER TABLE` — non-destructive, but verify migration ordering and the `migrate_test.go` coverage.
- `internal/config/config.go`: Parses `self_review` WORKFLOW.md block including `verify_commands`; these are passed verbatim to `exec.CommandContext`, so path validation and allow-listing may be worth reviewing.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes. The feature is opt-in via `self_review:` in WORKFLOW.md front matter; existing workflows are unaffected.
- **Migrations/State:** Migration `007_self_review.sql` adds a nullable `review_metadata TEXT` column to `run_history`. Non-destructive `ALTER TABLE`; existing rows default to `NULL`.