### PR TITLE
refactor(orchestrator): generalize continuation context and reaction tracking primitives

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -321,11 +321,12 @@ Fields:
 - `completed` (set of issue IDs; bookkeeping only, not dispatch gating)
 - `agent_totals` (aggregate tokens + runtime seconds)
 - `agent_rate_limits` (latest rate-limit snapshot from agent events)
-- `ci_fix_attempts` (map `issue_id -> integer`; number of CI-fix continuations dispatched;
-  reset when the issue leaves the running/retry maps; runtime-only, not persisted)
-- `pending_ci_check` (map `issue_id -> PendingCICheckEntry`; populated by worker exit on normal
-  exits with SCM metadata when a CI status provider is configured; consumed by CI reconciliation;
+- `reaction_attempts` (map `issue_id:kind -> integer`; number of reaction-fix continuations
+  dispatched per issue and reaction kind; reset when the issue leaves the running/retry maps;
   runtime-only, not persisted)
+- `pending_reactions` (map `issue_id:kind -> PendingReaction`; populated by worker exit on normal
+  exits with SCM metadata when a CI status provider is configured; consumed by per-kind reconcile
+  functions during the reconcile tick; runtime-only, not persisted)
 
 ### 4.2 Stable Identifiers and Normalization Rules
 
@@ -1080,10 +1081,10 @@ Part B: Tracker state refresh
 
 Part C: CI status reconciliation (when `ci_feedback.kind` is configured)
 
-- For each entry in `pending_ci_check`:
+- For each entry in `pending_reactions` with kind `ci`:
   - Call `CIStatusProvider.FetchCIStatus` with the SCM ref (SHA preferred, branch as fallback).
   - If the call fails: log a warning, re-enqueue the entry, and continue to the next entry.
-  - If status is `passing`: clear CI fix attempts for the issue.
+  - If status is `passing`: clear reaction attempts for the issue and kind.
   - If status is `pending`: re-enqueue the entry for the next tick.
   - If status is `failing`: handle as a CI failure (see Section 7.3, "CI Status Failing").
 
@@ -1747,11 +1748,11 @@ CI status reconciliation runs as Part C of active run reconciliation (Section 8.
 state refresh. The flow is:
 
 1. Skip entirely when `ci_feedback.kind` is not configured (no `CIStatusProvider` constructed).
-2. For each entry in `pending_ci_check`:
+2. For each entry in `pending_reactions` with kind `ci`:
    a. Remove the entry from the map (prevents reprocessing within the same tick).
    b. Call `CIStatusProvider.FetchCIStatus` with the SCM ref (SHA preferred, branch as fallback).
    c. On fetch error: re-enqueue the entry; continue.
-   d. On `passing`: clear `ci_fix_attempts` for the issue.
+   d. On `passing`: clear `reaction_attempts` for the issue and kind.
    e. On `pending`: re-enqueue the entry.
    f. On `failing`: handle CI failure (see Section 11A.5).
 
@@ -1760,21 +1761,21 @@ state refresh. The flow is:
 When CI status is `failing`:
 
 1. Persist a CI-failure run history entry (`status: ci_failed`).
-2. Increment `ci_fix_attempts[issue_id]`.
-3. If `ci_fix_attempts` exceeds `ci_feedback.max_retries`: escalate (Section 11A.6).
+2. Increment `reaction_attempts[issue_id:ci]`.
+3. If `reaction_attempts[issue_id:ci]` exceeds `ci_feedback.max_retries`: escalate (Section 11A.6).
 4. Otherwise:
    a. Convert `CIResult` to a template map via `ToTemplateMap()`.
    b. Cancel the existing continuation retry for the issue.
    c. Schedule a CI-fix dispatch carrying the CI failure context. The retry entry's
-      `CIFailureContext` field carries the map through the timer to the worker goroutine.
-   d. The worker injects the context into the prompt on turn 1 via `prompt.WithCIFailure`.
+      `ContinuationContext` field carries the map through the timer to the worker goroutine.
+   d. The worker injects the context into the prompt on turn 1 via `prompt.WithContinuationContext`.
 
 CI-fix dispatches count toward the regular retry machinery but use a fixed delay rather than
 exponential backoff.
 
 ### 11A.6 Escalation behavior
 
-When `ci_fix_attempts` exceeds `ci_feedback.max_retries`:
+When `reaction_attempts[issue_id:ci]` exceeds `ci_feedback.max_retries`:
 
 - `escalation: label` (default): add `escalation_label` (default `needs-human`) to the tracker
   issue via `TrackerAdapter.AddLabel`. The label call runs in a detached goroutine with a 30-second
@@ -1788,7 +1789,7 @@ After escalation:
 - Cancel any pending retry for the issue.
 - Delete the persisted retry entry from SQLite.
 - Release the claim (`delete claimed[issue_id]`).
-- Clear `ci_fix_attempts[issue_id]`.
+- Clear all `reaction_attempts` and `pending_reactions` entries for the issue.
 
 Escalation failures are logged and counted (`sortie_ci_escalations_total{action="error"}`) but do
 not block claim release.
@@ -1835,8 +1836,8 @@ Inputs to prompt rendering:
   - `ref`: the git ref that was queried
 
 CI failure context is injected only on turn 1 of a CI-fix dispatch. The worker reads the context
-from the dispatch site (carried via `context.WithValue` or the retry entry's `CIFailureContext`
-field) and passes it to `prompt.WithCIFailure`. Templates SHOULD use a conditional guard:
+from the dispatch site (carried via `context.WithValue` or the retry entry's `ContinuationContext`
+field) and passes it to `prompt.WithContinuationContext`. Templates SHOULD use a conditional guard:
 `{{ if .ci_failure }}...{{ end }}`. When `ci_failure` is nil, the template variable is still
 present in the data map (set to nil) so strict `missingkey=error` evaluation does not reject
 templates that reference the field.
@@ -2465,22 +2466,22 @@ function reconcile_ci_status(state):
   if ci_provider is nil:
     return state
 
-  for issue_id, pending in state.pending_ci_check:
-    delete(state.pending_ci_check, issue_id)
+  for key, pending in state.pending_reactions where pending.kind == "ci":
+    delete(state.pending_reactions, key)
 
     ref = pending.sha or pending.branch
     result, err = ci_provider.fetch_ci_status(ref)
 
     if err:
       log_warn("CI status fetch failed, will retry next tick")
-      state.pending_ci_check[issue_id] = pending
+      state.pending_reactions[key] = pending
       continue
 
     switch result.status:
       case "passing":
-        delete(state.ci_fix_attempts, issue_id)
+        delete(state.reaction_attempts, key)
       case "pending":
-        state.pending_ci_check[issue_id] = pending
+        state.pending_reactions[key] = pending
       case "failing":
         handle_ci_failure(state, pending, result)
 
@@ -2642,9 +2643,10 @@ on_worker_exit(issue_id, reason, state):
       if issue_id in state.claimed:
         scm = read_scm_metadata(workspace_path)
         if scm.branch is not empty:
-          state.pending_ci_check[issue_id] = {
+          rkey = reaction_key(issue_id, "ci")
+          state.pending_reactions[rkey] = {
             issue_id, identifier, display_id, attempt,
-            branch: scm.branch, sha: scm.sha
+            kind: "ci", branch: scm.branch, sha: scm.sha
           }
   else:
     state = schedule_retry(state, issue_id, next_attempt_from(running_entry), {
@@ -2782,7 +2784,7 @@ Unless otherwise noted, Sections 17.1 through 17.7 are `Core Conformance`. Bulle
 - CI status pending re-enqueues the pending check for the next tick
 - CI status failing within `max_retries` schedules a CI-fix dispatch with failure context
 - CI status failing beyond `max_retries` escalates (label or comment) and releases the claim
-- CI failure context is injected into turn 1 prompt via `prompt.WithCIFailure`
+- CI failure context is injected into turn 1 prompt via `prompt.WithContinuationContext`
 - Escalation label failure is logged but does not block claim release
 - `.sortie/scm.json` symlink rejection prevents CI check enqueue
 - `.sortie/scm.json` oversized or malformed files degrade to no-CI behavior

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -9,6 +9,7 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
 )
@@ -31,6 +32,12 @@ type ServiceConfig struct {
 	// SelfReview holds self-review loop configuration.
 	// Zero-value (Enabled == false) means self-review is disabled.
 	SelfReview SelfReviewConfig
+
+	// Reactions maps reaction kind to its configuration. An empty map
+	// means no reactions are configured. Keys are lowercase kind strings
+	// (e.g. "review_comments"). The existing ci_feedback section is not
+	// represented here; CI configuration uses the CIFeedback field.
+	Reactions map[string]ReactionConfig
 
 	// DBPath is the environment- and tilde-expanded path for the SQLite
 	// database. It may be relative; callers resolve it against the
@@ -115,6 +122,7 @@ var knownTopLevelKeys = map[string]bool{
 	"db_path":     true,
 	"ci_feedback": true,
 	"self_review": true,
+	"reactions":   true,
 }
 
 // NewServiceConfig converts a raw front matter map into a validated
@@ -243,6 +251,11 @@ func NewServiceConfig(raw map[string]any) (ServiceConfig, error) {
 		return ServiceConfig{}, err
 	}
 
+	reactions, err := buildReactionsConfig(extractSubMap(raw, "reactions"))
+	if err != nil {
+		return ServiceConfig{}, err
+	}
+
 	extensions := make(map[string]any)
 	for k, v := range raw {
 		if !knownTopLevelKeys[k] {
@@ -258,6 +271,7 @@ func NewServiceConfig(raw map[string]any) (ServiceConfig, error) {
 		Agent:      agent,
 		CIFeedback: ciFeedback,
 		SelfReview: selfReview,
+		Reactions:  reactions,
 		DBPath:     dbPath,
 		Extensions: extensions,
 	}, nil
@@ -914,6 +928,110 @@ type CIFeedbackConfig struct {
 	// EscalationLabel is the label applied when escalation is "label".
 	// Default "needs-human".
 	EscalationLabel string
+}
+
+// ReactionConfig holds per-kind configuration for a single reaction type.
+type ReactionConfig struct {
+	// MaxRetries is the maximum number of fix continuation dispatches
+	// per issue before escalation. Default: 2.
+	MaxRetries int
+
+	// Escalation controls what happens when MaxRetries is exceeded.
+	// Valid values: "label" (default), "comment".
+	Escalation string
+
+	// EscalationLabel is the label applied when Escalation is "label".
+	// Default: "needs-human".
+	EscalationLabel string
+
+	// Extra holds kind-specific fields not covered by the common schema.
+	Extra map[string]any
+}
+
+// reactionKeyPattern matches valid reaction kind identifiers: a lowercase
+// letter followed by zero or more lowercase letters, digits, underscores,
+// or hyphens.
+var reactionKeyPattern = regexp.MustCompile(`^[a-z][a-z0-9_-]*$`)
+
+// knownReactionFields enumerates keys consumed by buildReactionsConfig
+// per-kind parsing. Anything else is collected into Extra.
+var knownReactionFields = map[string]bool{
+	"max_retries":      true,
+	"escalation":       true,
+	"escalation_label": true,
+}
+
+func buildReactionsConfig(m map[string]any) (map[string]ReactionConfig, error) {
+	result := make(map[string]ReactionConfig)
+	if len(m) == 0 {
+		return result, nil
+	}
+
+	for k, v := range m {
+		if !reactionKeyPattern.MatchString(k) {
+			return nil, &ConfigError{
+				Field:   "reactions." + k,
+				Message: "key must match [a-z][a-z0-9_-]*",
+			}
+		}
+
+		vm, ok := v.(map[string]any)
+		if !ok {
+			return nil, &ConfigError{
+				Field:   "reactions." + k,
+				Message: fmt.Sprintf("expected map, got %T", v),
+			}
+		}
+
+		maxRetries := 2
+		if raw, exists := vm["max_retries"]; exists && raw != nil {
+			parsed, parseErr := coerceInt(raw)
+			if parseErr != nil {
+				return nil, &ConfigError{
+					Field:   "reactions." + k + ".max_retries",
+					Message: fmt.Sprintf("invalid integer value: %v", raw),
+				}
+			}
+			maxRetries = parsed
+		}
+		if maxRetries < 0 {
+			return nil, &ConfigError{
+				Field:   "reactions." + k + ".max_retries",
+				Message: "must be non-negative",
+			}
+		}
+
+		escalation := "label"
+		if raw := extractString(vm, "escalation"); raw != "" {
+			escalation = raw
+		}
+		if escalation != "label" && escalation != "comment" {
+			return nil, &ConfigError{
+				Field:   "reactions." + k + ".escalation",
+				Message: fmt.Sprintf("must be \"label\" or \"comment\", got %q", escalation),
+			}
+		}
+
+		escalationLabel := "needs-human"
+		if raw := extractString(vm, "escalation_label"); raw != "" {
+			escalationLabel = raw
+		}
+
+		extra := make(map[string]any)
+		for ek, ev := range vm {
+			if !knownReactionFields[ek] {
+				extra[ek] = ev
+			}
+		}
+
+		result[k] = ReactionConfig{
+			MaxRetries:      maxRetries,
+			Escalation:      escalation,
+			EscalationLabel: escalationLabel,
+			Extra:           extra,
+		}
+	}
+	return result, nil
 }
 
 func normalizeByStateMap(raw any) map[string]int {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -813,6 +813,117 @@ func TestNewServiceConfig(t *testing.T) {
 		})
 		assertConfigErrorField(t, err, "tracker.in_progress_state")
 	})
+
+	// --- Reactions subtests ---
+
+	t.Run("Reactions/Absent", func(t *testing.T) {
+		t.Parallel()
+		cfg, err := NewServiceConfig(map[string]any{})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if cfg.Reactions == nil {
+			t.Error("Reactions is nil, want non-nil empty map")
+		}
+		if len(cfg.Reactions) != 0 {
+			t.Errorf("Reactions length = %d, want 0", len(cfg.Reactions))
+		}
+	})
+
+	t.Run("Reactions/FutureKindParsed", func(t *testing.T) {
+		t.Parallel()
+		cfg, err := NewServiceConfig(map[string]any{
+			"reactions": map[string]any{
+				"review_comments": map[string]any{
+					"max_retries":      3,
+					"escalation":       "comment",
+					"escalation_label": "ci-escalated",
+				},
+			},
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		rc, ok := cfg.Reactions["review_comments"]
+		if !ok {
+			t.Fatal("Reactions missing key \"review_comments\"")
+		}
+		assertIntEqual(t, "Reactions[review_comments].MaxRetries", 3, rc.MaxRetries)
+		assertStringEqual(t, "Reactions[review_comments].Escalation", "comment", rc.Escalation)
+		assertStringEqual(t, "Reactions[review_comments].EscalationLabel", "ci-escalated", rc.EscalationLabel)
+	})
+
+	t.Run("Reactions/DefaultsApplied", func(t *testing.T) {
+		t.Parallel()
+		cfg, err := NewServiceConfig(map[string]any{
+			"reactions": map[string]any{
+				"ci": map[string]any{},
+			},
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		rc := cfg.Reactions["ci"]
+		assertIntEqual(t, "Reactions[ci].MaxRetries", 2, rc.MaxRetries)
+		assertStringEqual(t, "Reactions[ci].Escalation", "label", rc.Escalation)
+		assertStringEqual(t, "Reactions[ci].EscalationLabel", "needs-human", rc.EscalationLabel)
+	})
+
+	t.Run("Reactions/UnknownKeyStoredInExtra", func(t *testing.T) {
+		t.Parallel()
+		cfg, err := NewServiceConfig(map[string]any{
+			"reactions": map[string]any{
+				"ci": map[string]any{
+					"max_retries": 1,
+					"custom_flag": "value42",
+				},
+			},
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		rc := cfg.Reactions["ci"]
+		if rc.Extra == nil {
+			t.Fatal("Reactions[ci].Extra is nil, want map with unknown key")
+		}
+		if rc.Extra["custom_flag"] != "value42" {
+			t.Errorf("Reactions[ci].Extra[\"custom_flag\"] = %v, want %q", rc.Extra["custom_flag"], "value42")
+		}
+	})
+
+	t.Run("Reactions/InvalidMaxRetriesNegative", func(t *testing.T) {
+		t.Parallel()
+		_, err := NewServiceConfig(map[string]any{
+			"reactions": map[string]any{
+				"ci": map[string]any{
+					"max_retries": -1,
+				},
+			},
+		})
+		assertConfigErrorField(t, err, "reactions.ci.max_retries")
+	})
+
+	t.Run("Reactions/InvalidEscalationValue", func(t *testing.T) {
+		t.Parallel()
+		_, err := NewServiceConfig(map[string]any{
+			"reactions": map[string]any{
+				"ci": map[string]any{
+					"escalation": "email",
+				},
+			},
+		})
+		assertConfigErrorField(t, err, "reactions.ci.escalation")
+	})
+
+	t.Run("Reactions/InvalidKeyFormatUppercase", func(t *testing.T) {
+		t.Parallel()
+		_, err := NewServiceConfig(map[string]any{
+			"reactions": map[string]any{
+				"CI_Feedback": map[string]any{},
+			},
+		})
+		assertConfigErrorField(t, err, "reactions.CI_Feedback")
+	})
 }
 
 // --- test helpers ---

--- a/internal/orchestrator/ci_reconcile.go
+++ b/internal/orchestrator/ci_reconcile.go
@@ -19,7 +19,7 @@ const ciPendingBackoffBaseDefault = 10 * time.Second
 // ciPendingBackoffCap is the maximum interval between CI status checks.
 const ciPendingBackoffCap = 5 * time.Minute
 
-// ciPendingDefaultTTL is the default lifetime of a PendingCICheck entry.
+// ciPendingDefaultTTL is the default lifetime of a PendingReaction entry.
 // Entries older than this are dropped on the next reconcile tick.
 const ciPendingDefaultTTL = 30 * time.Minute
 
@@ -45,13 +45,13 @@ func computeCIPendingDelay(base time.Duration, attempts int) time.Duration {
 	return delay
 }
 
-// reconcileCIStatus polls CI status for each entry in state.PendingCICheck.
-// Called from ReconcileRunningIssues after reconcileTrackerState. Skipped
-// entirely when params.CIProvider is nil.
+// reconcileCIStatus polls CI status for each CI-kind entry in
+// state.PendingReactions. Called from ReconcileRunningIssues after
+// reconcileTrackerState. Skipped entirely when params.CIProvider is nil.
 //
-// Entries that are not yet due (PendingRetryAt in the future) are re-enqueued
-// without making an API call, applying exponential backoff. Entries older
-// than the configured TTL are dropped and a warning is logged.
+// Entries that are not yet due (PendingRetryAt in the future) are
+// re-enqueued without making an API call, applying exponential backoff.
+// Entries older than the configured TTL are dropped and a warning is logged.
 func reconcileCIStatus(state *State, params ReconcileParams, log *slog.Logger, ctx context.Context, metrics domain.Metrics) {
 	if params.CIProvider == nil {
 		return
@@ -65,10 +65,22 @@ func reconcileCIStatus(state *State, params ReconcileParams, log *slog.Logger, c
 	ttl := params.CIPendingTTL
 	base := time.Duration(state.PollIntervalMS) * time.Millisecond
 
-	for issueID, pending := range state.PendingCICheck {
-		delete(state.PendingCICheck, issueID)
+	for key, pending := range state.PendingReactions {
+		if pending.Kind != ReactionKindCI {
+			continue
+		}
+		delete(state.PendingReactions, key)
 
-		entryLog := logging.WithIssue(log, issueID, pending.Identifier)
+		ciData, ok := pending.KindData.(*CIReactionData)
+		if !ok {
+			log.ErrorContext(ctx, "unexpected KindData type for CI reaction",
+				slog.String("issue_id", pending.IssueID),
+				slog.String("type", fmt.Sprintf("%T", pending.KindData)),
+			)
+			continue
+		}
+
+		entryLog := logging.WithIssue(log, pending.IssueID, pending.Identifier)
 
 		if ttl > 0 && now.Sub(pending.CreatedAt) > ttl {
 			entryLog.Warn("ci pending entry exceeded ttl, dropping",
@@ -79,13 +91,33 @@ func reconcileCIStatus(state *State, params ReconcileParams, log *slog.Logger, c
 		}
 
 		if now.Before(pending.PendingRetryAt) {
-			state.PendingCICheck[issueID] = pending
+			state.PendingReactions[key] = pending
 			continue
 		}
 
-		ref := pending.SHA
+		ref := ciData.SHA
 		if ref == "" {
-			ref = pending.Branch
+			ref = ciData.Branch
+		}
+
+		// Fingerprint dedup: upsert the fingerprint row (resets dispatched
+		// when the ref changes) and skip entries already dispatched for this
+		// exact ref. Errors are non-fatal — best-effort dedup.
+		if err := params.Store.UpsertReactionFingerprint(ctx, pending.IssueID, ReactionKindCI, ref); err != nil {
+			entryLog.Warn("failed to upsert reaction fingerprint",
+				slog.Any("error", err),
+			)
+		}
+		storedFP, dispatched, fpErr := params.Store.GetReactionFingerprint(ctx, pending.IssueID, ReactionKindCI)
+		if fpErr != nil {
+			entryLog.Warn("failed to get reaction fingerprint, proceeding without dedup",
+				slog.Any("error", fpErr),
+			)
+		} else if storedFP == ref && dispatched {
+			entryLog.Debug("CI reaction already dispatched for this ref, skipping",
+				slog.String("ref", ref),
+			)
+			continue
 		}
 
 		result, err := params.CIProvider.FetchCIStatus(ctx, ref)
@@ -100,15 +132,22 @@ func reconcileCIStatus(state *State, params ReconcileParams, log *slog.Logger, c
 				slog.Int64("retry_after_ms", int64(delay/time.Millisecond)),
 			)
 			metrics.IncCIStatusChecks("error")
-			state.PendingCICheck[issueID] = pending
+			state.PendingReactions[key] = pending
 			continue
 		}
 
 		metrics.IncCIStatusChecks(string(result.Status))
 
+		rkey := ReactionKey(pending.IssueID, ReactionKindCI)
+
 		switch result.Status {
 		case domain.CIStatusPassing:
-			delete(state.CIFixAttempts, issueID)
+			delete(state.ReactionAttempts, rkey)
+			if err := params.Store.DeleteReactionFingerprint(ctx, pending.IssueID, ReactionKindCI); err != nil {
+				entryLog.Warn("failed to delete reaction fingerprint on CI pass",
+					slog.Any("error", err),
+				)
+			}
 			entryLog.Info("CI passing, no action needed",
 				slog.String("ref", ref),
 			)
@@ -117,7 +156,7 @@ func reconcileCIStatus(state *State, params ReconcileParams, log *slog.Logger, c
 			pending.PendingAttempts++
 			delay := computeCIPendingDelay(base, pending.PendingAttempts)
 			pending.PendingRetryAt = now.Add(delay)
-			state.PendingCICheck[issueID] = pending
+			state.PendingReactions[key] = pending
 			entryLog.Debug("CI pending, will re-check after backoff",
 				slog.String("ref", ref),
 				slog.Int("pending_attempts", pending.PendingAttempts),
@@ -135,7 +174,7 @@ func reconcileCIStatus(state *State, params ReconcileParams, log *slog.Logger, c
 			metrics.IncCIStatusChecks("error")
 			pending.PendingAttempts++
 			pending.PendingRetryAt = now.Add(computeCIPendingDelay(base, pending.PendingAttempts))
-			state.PendingCICheck[issueID] = pending
+			state.PendingReactions[key] = pending
 		}
 	}
 }
@@ -146,7 +185,7 @@ func reconcileCIStatus(state *State, params ReconcileParams, log *slog.Logger, c
 func handleCIFailure(
 	state *State,
 	params ReconcileParams,
-	pending *PendingCICheckEntry,
+	pending *PendingReaction,
 	result domain.CIResult,
 	ref string,
 	log *slog.Logger,
@@ -171,8 +210,9 @@ func handleCIFailure(
 		)
 	}
 
-	state.CIFixAttempts[pending.IssueID]++
-	attempts := state.CIFixAttempts[pending.IssueID]
+	rkey := ReactionKey(pending.IssueID, ReactionKindCI)
+	state.ReactionAttempts[rkey]++
+	attempts := state.ReactionAttempts[rkey]
 
 	maxRetries := params.CIFeedback.MaxRetries
 
@@ -188,16 +228,24 @@ func handleCIFailure(
 	nextAttempt := pending.Attempt
 
 	ScheduleRetry(state, ScheduleRetryParams{
-		IssueID:          pending.IssueID,
-		Identifier:       pending.Identifier,
-		DisplayID:        pending.DisplayID,
-		Attempt:          nextAttempt,
-		DelayMS:          continuationDelayMS,
-		Error:            "",
-		LastSSHHost:      pending.LastSSHHost,
-		CIFailureContext: ciContext,
+		IssueID:     pending.IssueID,
+		Identifier:  pending.Identifier,
+		DisplayID:   pending.DisplayID,
+		Attempt:     nextAttempt,
+		DelayMS:     continuationDelayMS,
+		Error:       "",
+		LastSSHHost: pending.LastSSHHost,
+		ContinuationContext: map[string]any{
+			"ci_failure": ciContext,
+		},
 	}, params.OnRetryFire)
 	metrics.IncRetries(triggerCIFix)
+
+	if err := params.Store.MarkReactionDispatched(ctx, pending.IssueID, ReactionKindCI); err != nil {
+		log.Warn("failed to mark reaction fingerprint dispatched",
+			slog.Any("error", err),
+		)
+	}
 
 	log.Info("CI failure detected, scheduling CI fix dispatch",
 		slog.String("ref", ref),
@@ -213,7 +261,7 @@ func handleCIFailure(
 func escalateCIFailure(
 	state *State,
 	params ReconcileParams,
-	pending *PendingCICheckEntry,
+	pending *PendingReaction,
 	result domain.CIResult,
 	ref string,
 	attempts int,
@@ -292,7 +340,13 @@ func escalateCIFailure(
 	}
 
 	delete(state.Claimed, pending.IssueID)
-	delete(state.CIFixAttempts, pending.IssueID)
+	ClearReactionsForIssue(ctx, state, params.Store, pending.IssueID, log)
+
+	if err := params.Store.DeleteReactionFingerprint(ctx, pending.IssueID, ReactionKindCI); err != nil {
+		log.Warn("failed to delete reaction fingerprint during CI escalation",
+			slog.Any("error", err),
+		)
+	}
 }
 
 // buildCIEscalationComment builds a plain-text escalation comment for

--- a/internal/orchestrator/ci_reconcile_test.go
+++ b/internal/orchestrator/ci_reconcile_test.go
@@ -36,9 +36,23 @@ type ciReconcileStore struct {
 	deletedIssueIDs []string
 	runHistories    []persistence.RunHistory
 
-	saveRetryEntryErr   error
-	deleteRetryEntryErr error
-	appendRunHistoryErr error
+	saveRetryEntryErr                    error
+	deleteRetryEntryErr                  error
+	appendRunHistoryErr                  error
+	deleteReactionFingerprintsByIssueErr error
+
+	// Fingerprint dedup fields.
+	upsertFingerprintCalls int
+	getFingerprintCalls    int
+	markDispatchedCalls    int
+	deleteFingerprintCalls int
+
+	upsertFingerprintErr     error
+	getFingerprintResult     string
+	getFingerprintDispatched bool
+	getFingerprintErr        error
+	markDispatchedErr        error
+	deleteFingerprintErr     error
 }
 
 var _ ReconcileStore = (*ciReconcileStore)(nil)
@@ -56,6 +70,30 @@ func (s *ciReconcileStore) DeleteRetryEntry(_ context.Context, issueID string) e
 func (s *ciReconcileStore) AppendRunHistory(_ context.Context, run persistence.RunHistory) (persistence.RunHistory, error) {
 	s.runHistories = append(s.runHistories, run)
 	return run, s.appendRunHistoryErr
+}
+
+func (s *ciReconcileStore) DeleteReactionFingerprintsByIssue(_ context.Context, _ string) error {
+	return s.deleteReactionFingerprintsByIssueErr
+}
+
+func (s *ciReconcileStore) UpsertReactionFingerprint(_ context.Context, _, _, _ string) error {
+	s.upsertFingerprintCalls++
+	return s.upsertFingerprintErr
+}
+
+func (s *ciReconcileStore) GetReactionFingerprint(_ context.Context, _, _ string) (string, bool, error) {
+	s.getFingerprintCalls++
+	return s.getFingerprintResult, s.getFingerprintDispatched, s.getFingerprintErr
+}
+
+func (s *ciReconcileStore) MarkReactionDispatched(_ context.Context, _, _ string) error {
+	s.markDispatchedCalls++
+	return s.markDispatchedErr
+}
+
+func (s *ciReconcileStore) DeleteReactionFingerprint(_ context.Context, _, _ string) error {
+	s.deleteFingerprintCalls++
+	return s.deleteFingerprintErr
 }
 
 // ciTrackerStub is a no-panic TrackerAdapter for CI reconcile tests.
@@ -123,16 +161,18 @@ func (s *ciMetricsSpy) IncRetries(trigger string)       { s.retriesByTrigger[tri
 // ciBaseTime is a fixed reference for CI reconcile tests.
 var ciBaseTime = time.Date(2026, 4, 1, 9, 0, 0, 0, time.UTC)
 
-// newPendingEntry builds a PendingCICheckEntry for a test issue.
-func newPendingEntry(issueID, identifier, branch string, attempt int) *PendingCICheckEntry {
-	return &PendingCICheckEntry{
+// newPendingEntry builds a PendingReaction for a test CI issue.
+func newPendingEntry(issueID, identifier, branch string, attempt int) *PendingReaction {
+	return &PendingReaction{
 		IssueID:    issueID,
 		Identifier: identifier,
 		DisplayID:  identifier,
 		Attempt:    attempt,
-		Branch:     branch,
-		SHA:        "",
+		Kind:       ReactionKindCI,
 		CreatedAt:  ciBaseTime,
+		KindData: &CIReactionData{
+			Branch: branch,
+		},
 	}
 }
 
@@ -146,11 +186,12 @@ func defaultCIFeedback() config.CIFeedbackConfig {
 	}
 }
 
-// stateWithPendingCICheck creates a State with one PendingCICheck entry.
-func stateWithPendingCICheck(t *testing.T, issueID, branch string, attempt int) *State {
+// stateWithPendingReaction creates a State with one CI PendingReaction entry.
+func stateWithPendingReaction(t *testing.T, issueID, branch string, attempt int) *State {
 	t.Helper()
 	s := NewState(5000, 4, nil, AgentTotals{})
-	s.PendingCICheck[issueID] = newPendingEntry(issueID, issueID+"-ident", branch, attempt)
+	rkey := ReactionKey(issueID, ReactionKindCI)
+	s.PendingReactions[rkey] = newPendingEntry(issueID, issueID+"-ident", branch, attempt)
 	s.Claimed[issueID] = struct{}{}
 	return s
 }
@@ -176,7 +217,7 @@ func ciParams(t *testing.T, store *ciReconcileStore, ci domain.CIStatusProvider,
 func TestReconcileCIStatus_NilProvider(t *testing.T) {
 	t.Parallel()
 
-	state := stateWithPendingCICheck(t, "ISS-CI-1", "feature/fix", 1)
+	state := stateWithPendingReaction(t, "ISS-CI-1", "feature/fix", 1)
 	store := &ciReconcileStore{}
 	metrics := newCIMetricsSpy()
 	params := ciParams(t, store, nil, nil)
@@ -184,8 +225,8 @@ func TestReconcileCIStatus_NilProvider(t *testing.T) {
 	reconcileCIStatus(state, params, discardLogger(), context.Background(), metrics)
 
 	// nil CIProvider: entire phase is a no-op.
-	if _, ok := state.PendingCICheck["ISS-CI-1"]; !ok {
-		t.Error("PendingCICheck entry consumed when CIProvider is nil; want no-op")
+	if _, ok := state.PendingReactions[ReactionKey("ISS-CI-1", ReactionKindCI)]; !ok {
+		t.Error("PendingReactions entry consumed when CIProvider is nil; want no-op")
 	}
 	if len(metrics.ciStatusChecks) != 0 {
 		t.Errorf("IncCIStatusChecks called with nil provider; want no calls")
@@ -198,7 +239,7 @@ func TestReconcileCIStatus_NilProvider(t *testing.T) {
 func TestReconcileCIStatus_FetchError_ReEnqueues(t *testing.T) {
 	t.Parallel()
 
-	state := stateWithPendingCICheck(t, "ISS-CI-2", "main", 1)
+	state := stateWithPendingReaction(t, "ISS-CI-2", "main", 1)
 	store := &ciReconcileStore{}
 	metrics := newCIMetricsSpy()
 	ci := &mockCIProvider{err: errors.New("network timeout")}
@@ -206,8 +247,8 @@ func TestReconcileCIStatus_FetchError_ReEnqueues(t *testing.T) {
 
 	reconcileCIStatus(state, params, discardLogger(), context.Background(), metrics)
 
-	if _, ok := state.PendingCICheck["ISS-CI-2"]; !ok {
-		t.Error("PendingCICheck entry dropped on FetchCIStatus error; want re-enqueued")
+	if _, ok := state.PendingReactions[ReactionKey("ISS-CI-2", ReactionKindCI)]; !ok {
+		t.Error("PendingReactions entry dropped on FetchCIStatus error; want re-enqueued")
 	}
 	if metrics.ciStatusChecks["error"] != 1 {
 		t.Errorf(`IncCIStatusChecks("error") = %d, want 1`, metrics.ciStatusChecks["error"])
@@ -217,11 +258,11 @@ func TestReconcileCIStatus_FetchError_ReEnqueues(t *testing.T) {
 	}
 }
 
-func TestReconcileCIStatus_Passing_ClearsCIFixAttempts(t *testing.T) {
+func TestReconcileCIStatus_Passing_ClearsReactionAttempts(t *testing.T) {
 	t.Parallel()
 
-	state := stateWithPendingCICheck(t, "ISS-CI-3", "feature/done", 1)
-	state.CIFixAttempts["ISS-CI-3"] = 1 // pre-seeded
+	state := stateWithPendingReaction(t, "ISS-CI-3", "feature/done", 1)
+	state.ReactionAttempts[ReactionKey("ISS-CI-3", ReactionKindCI)] = 1 // pre-seeded
 	store := &ciReconcileStore{}
 	metrics := newCIMetricsSpy()
 	ci := &mockCIProvider{result: domain.CIResult{Status: domain.CIStatusPassing}}
@@ -229,11 +270,11 @@ func TestReconcileCIStatus_Passing_ClearsCIFixAttempts(t *testing.T) {
 
 	reconcileCIStatus(state, params, discardLogger(), context.Background(), metrics)
 
-	if _, ok := state.PendingCICheck["ISS-CI-3"]; ok {
-		t.Error("PendingCICheck entry still present after passing; want consumed")
+	if _, ok := state.PendingReactions[ReactionKey("ISS-CI-3", ReactionKindCI)]; ok {
+		t.Error("PendingReactions entry still present after passing; want consumed")
 	}
-	if _, ok := state.CIFixAttempts["ISS-CI-3"]; ok {
-		t.Error("CIFixAttempts not cleared after CI passing; want cleared")
+	if _, ok := state.ReactionAttempts[ReactionKey("ISS-CI-3", ReactionKindCI)]; ok {
+		t.Error("ReactionAttempts not cleared after CI passing; want cleared")
 	}
 	if _, ok := state.RetryAttempts["ISS-CI-3"]; ok {
 		t.Error("retry scheduled after CI passing; want none")
@@ -246,7 +287,7 @@ func TestReconcileCIStatus_Passing_ClearsCIFixAttempts(t *testing.T) {
 func TestReconcileCIStatus_Pending_ReEnqueues(t *testing.T) {
 	t.Parallel()
 
-	state := stateWithPendingCICheck(t, "ISS-CI-4", "feature/wip", 1)
+	state := stateWithPendingReaction(t, "ISS-CI-4", "feature/wip", 1)
 	store := &ciReconcileStore{}
 	metrics := newCIMetricsSpy()
 	ci := &mockCIProvider{result: domain.CIResult{Status: domain.CIStatusPending}}
@@ -254,8 +295,8 @@ func TestReconcileCIStatus_Pending_ReEnqueues(t *testing.T) {
 
 	reconcileCIStatus(state, params, discardLogger(), context.Background(), metrics)
 
-	if _, ok := state.PendingCICheck["ISS-CI-4"]; !ok {
-		t.Error("PendingCICheck entry not re-enqueued after pending; want re-enqueued")
+	if _, ok := state.PendingReactions[ReactionKey("ISS-CI-4", ReactionKindCI)]; !ok {
+		t.Error("PendingReactions entry not re-enqueued after pending; want re-enqueued")
 	}
 	if _, ok := state.RetryAttempts["ISS-CI-4"]; ok {
 		t.Error("retry scheduled after CI pending; want none")
@@ -268,8 +309,8 @@ func TestReconcileCIStatus_Pending_ReEnqueues(t *testing.T) {
 func TestReconcileCIStatus_Failing_UnderMaxRetries(t *testing.T) {
 	t.Parallel()
 
-	// CIFixAttempts starts at 0; maxRetries=2 → no escalation after increment to 1.
-	state := stateWithPendingCICheck(t, "ISS-CI-5", "feature/break", 1)
+	// ReactionAttempts starts at 0; maxRetries=2 → no escalation after increment to 1.
+	state := stateWithPendingReaction(t, "ISS-CI-5", "feature/break", 1)
 	store := &ciReconcileStore{}
 	metrics := newCIMetricsSpy()
 	ci := &mockCIProvider{result: domain.CIResult{
@@ -284,8 +325,8 @@ func TestReconcileCIStatus_Failing_UnderMaxRetries(t *testing.T) {
 	reconcileCIStatus(state, params, discardLogger(), context.Background(), metrics)
 
 	// Entry consumed (not re-enqueued as pending-check).
-	if _, ok := state.PendingCICheck["ISS-CI-5"]; ok {
-		t.Error("PendingCICheck entry re-enqueued on CI failure; want consumed")
+	if _, ok := state.PendingReactions[ReactionKey("ISS-CI-5", ReactionKindCI)]; ok {
+		t.Error("PendingReactions entry re-enqueued on CI failure; want consumed")
 	}
 
 	// RunHistory appended with "ci_failed".
@@ -309,13 +350,13 @@ func TestReconcileCIStatus_Failing_UnderMaxRetries(t *testing.T) {
 	if !ok {
 		t.Fatal("retry not scheduled after CI failure; want scheduled")
 	}
-	if entry.CIFailureContext == nil {
-		t.Error("RetryEntry.CIFailureContext is nil; want CI failure map")
+	if entry.ContinuationContext == nil {
+		t.Error("RetryEntry.ContinuationContext is nil; want continuation map")
 	}
 
-	// CIFixAttempts incremented.
-	if state.CIFixAttempts["ISS-CI-5"] != 1 {
-		t.Errorf("CIFixAttempts[ISS-CI-5] = %d, want 1", state.CIFixAttempts["ISS-CI-5"])
+	// ReactionAttempts incremented.
+	if state.ReactionAttempts[ReactionKey("ISS-CI-5", ReactionKindCI)] != 1 {
+		t.Errorf("ReactionAttempts[ISS-CI-5] = %d, want 1", state.ReactionAttempts[ReactionKey("ISS-CI-5", ReactionKindCI)])
 	}
 
 	// Metrics.
@@ -335,9 +376,9 @@ func TestReconcileCIStatus_Failing_UnderMaxRetries(t *testing.T) {
 func TestReconcileCIStatus_Failing_ExceedsMaxRetries_Escalates(t *testing.T) {
 	t.Parallel()
 
-	// CIFixAttempts at 2; after increment → 3 > maxRetries(2) → escalate.
-	state := stateWithPendingCICheck(t, "ISS-CI-6", "feature/broken", 3)
-	state.CIFixAttempts["ISS-CI-6"] = 2
+	// ReactionAttempts at 2; after increment → 3 > maxRetries(2) → escalate.
+	state := stateWithPendingReaction(t, "ISS-CI-6", "feature/broken", 3)
+	state.ReactionAttempts[ReactionKey("ISS-CI-6", ReactionKindCI)] = 2
 	store := &ciReconcileStore{}
 	metrics := newCIMetricsSpy()
 	tracker := &ciTrackerStub{}
@@ -359,9 +400,9 @@ func TestReconcileCIStatus_Failing_ExceedsMaxRetries_Escalates(t *testing.T) {
 		t.Error("claim not released after CI escalation; want released")
 	}
 
-	// CIFixAttempts cleared.
-	if _, ok := state.CIFixAttempts["ISS-CI-6"]; ok {
-		t.Error("CIFixAttempts not cleared after escalation; want cleared")
+	// ReactionAttempts cleared.
+	if _, ok := state.ReactionAttempts[ReactionKey("ISS-CI-6", ReactionKindCI)]; ok {
+		t.Error("ReactionAttempts not cleared after escalation; want cleared")
 	}
 
 	// Escalation metric incremented (label mode from defaultCIFeedback).
@@ -383,8 +424,8 @@ func TestReconcileCIStatus_Failing_ExceedsMaxRetries_Escalates(t *testing.T) {
 func TestReconcileCIStatus_Failing_CommentEscalation(t *testing.T) {
 	t.Parallel()
 
-	state := stateWithPendingCICheck(t, "ISS-CI-7", "main", 1)
-	state.CIFixAttempts["ISS-CI-7"] = 2
+	state := stateWithPendingReaction(t, "ISS-CI-7", "main", 1)
+	state.ReactionAttempts[ReactionKey("ISS-CI-7", ReactionKindCI)] = 2
 	store := &ciReconcileStore{}
 	metrics := newCIMetricsSpy()
 	tracker := &ciTrackerStub{}
@@ -568,10 +609,10 @@ func TestEscalateCIFailure_LabelTracksTrackerOps(t *testing.T) {
 	gate := make(chan struct{})
 	tracker := &blockingCITracker{addLabelGate: gate}
 
-	// CIFixAttempts=2 with maxRetries=2 means next increment (→3) exceeds
+	// ReactionAttempts=2 with maxRetries=2 means next increment (→3) exceeds
 	// the limit and triggers escalation.
-	state := stateWithPendingCICheck(t, "ESC-WG-1", "main/broken", 3)
-	state.CIFixAttempts["ESC-WG-1"] = 2
+	state := stateWithPendingReaction(t, "ESC-WG-1", "main/broken", 3)
+	state.ReactionAttempts[ReactionKey("ESC-WG-1", ReactionKindCI)] = 2
 	store := &ciReconcileStore{}
 	metrics := newCIMetricsSpy()
 	ci := &mockCIProvider{result: domain.CIResult{Status: domain.CIStatusFailing}}
@@ -612,8 +653,8 @@ func TestEscalateCIFailure_CommentTracksTrackerOps(t *testing.T) {
 	gate := make(chan struct{})
 	tracker := &blockingCITracker{commentGate: gate}
 
-	state := stateWithPendingCICheck(t, "ESC-WG-2", "feature/broken", 2)
-	state.CIFixAttempts["ESC-WG-2"] = 2
+	state := stateWithPendingReaction(t, "ESC-WG-2", "feature/broken", 2)
+	state.ReactionAttempts[ReactionKey("ESC-WG-2", ReactionKindCI)] = 2
 	store := &ciReconcileStore{}
 	metrics := newCIMetricsSpy()
 	ci := &mockCIProvider{result: domain.CIResult{Status: domain.CIStatusFailing}}
@@ -751,7 +792,7 @@ func TestReconcileCIStatus_BackoffUsesStatePollInterval(t *testing.T) {
 	entry.PendingAttempts = 1
 
 	state := NewState(30000, 4, nil, AgentTotals{})
-	state.PendingCICheck["ISS-PPI-1"] = entry
+	state.PendingReactions[ReactionKey("ISS-PPI-1", ReactionKindCI)] = entry
 	state.Claimed["ISS-PPI-1"] = struct{}{}
 
 	store := &ciReconcileStore{}
@@ -762,9 +803,9 @@ func TestReconcileCIStatus_BackoffUsesStatePollInterval(t *testing.T) {
 
 	reconcileCIStatus(state, params, discardLogger(), context.Background(), metrics)
 
-	got, ok := state.PendingCICheck["ISS-PPI-1"]
+	got, ok := state.PendingReactions[ReactionKey("ISS-PPI-1", ReactionKindCI)]
 	if !ok {
-		t.Fatal("PendingCICheck entry not re-enqueued after CIStatusPending; want re-enqueued")
+		t.Fatal("PendingReactions entry not re-enqueued after CIStatusPending; want re-enqueued")
 	}
 
 	wantAttempts := 2
@@ -797,7 +838,7 @@ func TestReconcileCIStatus_BackoffSkip(t *testing.T) {
 	entry.PendingRetryAt = futureRetry
 
 	state := NewState(5000, 4, nil, AgentTotals{})
-	state.PendingCICheck["ISS-SKIP-1"] = entry
+	state.PendingReactions[ReactionKey("ISS-SKIP-1", ReactionKindCI)] = entry
 	state.Claimed["ISS-SKIP-1"] = struct{}{}
 
 	store := &ciReconcileStore{}
@@ -814,9 +855,9 @@ func TestReconcileCIStatus_BackoffSkip(t *testing.T) {
 	}
 
 	// Entry must be re-enqueued with identical PendingAttempts and PendingRetryAt.
-	got, ok := state.PendingCICheck["ISS-SKIP-1"]
+	got, ok := state.PendingReactions[ReactionKey("ISS-SKIP-1", ReactionKindCI)]
 	if !ok {
-		t.Fatal("PendingCICheck entry dropped during backoff skip; want re-enqueued")
+		t.Fatal("PendingReactions entry dropped during backoff skip; want re-enqueued")
 	}
 	if got.PendingAttempts != 2 {
 		t.Errorf("PendingAttempts = %d, want 2 (unchanged)", got.PendingAttempts)
@@ -835,7 +876,7 @@ func TestReconcileCIStatus_BackoffIncrements_OnPending(t *testing.T) {
 	entry.PendingAttempts = 2
 
 	state := NewState(5000, 4, nil, AgentTotals{})
-	state.PendingCICheck["ISS-BIP-1"] = entry
+	state.PendingReactions[ReactionKey("ISS-BIP-1", ReactionKindCI)] = entry
 	state.Claimed["ISS-BIP-1"] = struct{}{}
 
 	store := &ciReconcileStore{}
@@ -846,9 +887,9 @@ func TestReconcileCIStatus_BackoffIncrements_OnPending(t *testing.T) {
 
 	reconcileCIStatus(state, params, discardLogger(), context.Background(), metrics)
 
-	got, ok := state.PendingCICheck["ISS-BIP-1"]
+	got, ok := state.PendingReactions[ReactionKey("ISS-BIP-1", ReactionKindCI)]
 	if !ok {
-		t.Fatal("PendingCICheck entry not re-enqueued after CIStatusPending; want re-enqueued")
+		t.Fatal("PendingReactions entry not re-enqueued after CIStatusPending; want re-enqueued")
 	}
 
 	wantAttempts := 3
@@ -875,7 +916,7 @@ func TestReconcileCIStatus_BackoffIncrements_OnError(t *testing.T) {
 	entry.PendingAttempts = 1
 
 	state := NewState(5000, 4, nil, AgentTotals{})
-	state.PendingCICheck["ISS-BIE-1"] = entry
+	state.PendingReactions[ReactionKey("ISS-BIE-1", ReactionKindCI)] = entry
 	state.Claimed["ISS-BIE-1"] = struct{}{}
 
 	store := &ciReconcileStore{}
@@ -886,9 +927,9 @@ func TestReconcileCIStatus_BackoffIncrements_OnError(t *testing.T) {
 
 	reconcileCIStatus(state, params, discardLogger(), context.Background(), metrics)
 
-	got, ok := state.PendingCICheck["ISS-BIE-1"]
+	got, ok := state.PendingReactions[ReactionKey("ISS-BIE-1", ReactionKindCI)]
 	if !ok {
-		t.Fatal("PendingCICheck entry not re-enqueued after fetch error; want re-enqueued")
+		t.Fatal("PendingReactions entry not re-enqueued after fetch error; want re-enqueued")
 	}
 
 	wantAttempts := 2
@@ -933,7 +974,7 @@ func TestReconcileCIStatus_TTLExpiry(t *testing.T) {
 			entry.CreatedAt = createdAt
 
 			state := NewState(5000, 4, nil, AgentTotals{})
-			state.PendingCICheck["ISS-TTL-1"] = entry
+			state.PendingReactions[ReactionKey("ISS-TTL-1", ReactionKindCI)] = entry
 			state.Claimed["ISS-TTL-1"] = struct{}{}
 
 			store := &ciReconcileStore{}
@@ -945,17 +986,168 @@ func TestReconcileCIStatus_TTLExpiry(t *testing.T) {
 
 			reconcileCIStatus(state, params, discardLogger(), context.Background(), metrics)
 
-			_, stillPresent := state.PendingCICheck["ISS-TTL-1"]
+			_, stillPresent := state.PendingReactions[ReactionKey("ISS-TTL-1", ReactionKindCI)]
 
 			if tt.wantDropped && stillPresent {
-				t.Error("PendingCICheck entry not dropped after TTL expiry; want dropped")
+				t.Error("PendingReactions entry not dropped after TTL expiry; want dropped")
 			}
 			if !tt.wantDropped && !stillPresent {
-				t.Error("PendingCICheck entry dropped before TTL expiry; want kept")
+				t.Error("PendingReactions entry dropped before TTL expiry; want kept")
 			}
 			if tt.wantDropped && ci.calls != 0 {
 				t.Errorf("FetchCIStatus called %d times after TTL expiry; want 0", ci.calls)
 			}
 		})
+	}
+}
+
+// --- Fingerprint dedup tests ---
+
+// TestReconcileCIStatus_DedupSkip verifies that when GetReactionFingerprint
+// returns the current ref with dispatched=true, the entry is consumed without
+// calling FetchCIStatus.
+func TestReconcileCIStatus_DedupSkip(t *testing.T) {
+	t.Parallel()
+
+	const ref = "sha-already-done"
+	state := stateWithPendingReaction(t, "ISS-FP-1", ref, 1)
+	store := &ciReconcileStore{
+		getFingerprintResult:     ref,
+		getFingerprintDispatched: true,
+	}
+	metrics := newCIMetricsSpy()
+	ci := &mockCIProvider{}
+	params := ciParams(t, store, ci, nil)
+
+	reconcileCIStatus(state, params, discardLogger(), context.Background(), metrics)
+
+	if ci.calls != 0 {
+		t.Errorf("FetchCIStatus called %d times when entry already dispatched; want 0", ci.calls)
+	}
+	if _, ok := state.PendingReactions[ReactionKey("ISS-FP-1", ReactionKindCI)]; ok {
+		t.Error("PendingReactions entry still present after dedup skip; want consumed")
+	}
+	if store.upsertFingerprintCalls != 1 {
+		t.Errorf("UpsertReactionFingerprint calls = %d, want 1", store.upsertFingerprintCalls)
+	}
+	if store.getFingerprintCalls != 1 {
+		t.Errorf("GetReactionFingerprint calls = %d, want 1", store.getFingerprintCalls)
+	}
+}
+
+// TestReconcileCIStatus_FingerprintReset verifies that when the stored
+// fingerprint differs from the current ref (ref changed), UpsertReactionFingerprint
+// is called and reconciliation proceeds (FetchCIStatus is called).
+func TestReconcileCIStatus_FingerprintReset(t *testing.T) {
+	t.Parallel()
+
+	// Store returns old ref as dispatched; entry's branch is the new ref.
+	const newRef = "sha-new"
+	state := stateWithPendingReaction(t, "ISS-FP-2", newRef, 1)
+	store := &ciReconcileStore{
+		getFingerprintResult:     "sha-old",
+		getFingerprintDispatched: true,
+	}
+	metrics := newCIMetricsSpy()
+	ci := &mockCIProvider{result: domain.CIResult{Status: domain.CIStatusPassing}}
+	params := ciParams(t, store, ci, nil)
+
+	reconcileCIStatus(state, params, discardLogger(), context.Background(), metrics)
+
+	if ci.calls != 1 {
+		t.Errorf("FetchCIStatus calls = %d, want 1 (ref changed, dedup must not skip)", ci.calls)
+	}
+	if store.upsertFingerprintCalls != 1 {
+		t.Errorf("UpsertReactionFingerprint calls = %d, want 1", store.upsertFingerprintCalls)
+	}
+}
+
+// TestReconcileCIStatus_Passing_DeletesFingerprint verifies that on a
+// CI-passing result DeleteReactionFingerprint is called.
+func TestReconcileCIStatus_Passing_DeletesFingerprint(t *testing.T) {
+	t.Parallel()
+
+	state := stateWithPendingReaction(t, "ISS-FP-3", "sha-pass", 1)
+	store := &ciReconcileStore{}
+	metrics := newCIMetricsSpy()
+	ci := &mockCIProvider{result: domain.CIResult{Status: domain.CIStatusPassing}}
+	params := ciParams(t, store, ci, nil)
+
+	reconcileCIStatus(state, params, discardLogger(), context.Background(), metrics)
+
+	if store.deleteFingerprintCalls != 1 {
+		t.Errorf("DeleteReactionFingerprint calls = %d, want 1 on CI pass", store.deleteFingerprintCalls)
+	}
+}
+
+// TestReconcileCIStatus_FingerprintGetError_Continues verifies that when
+// GetReactionFingerprint returns an error the reconcile loop continues and
+// FetchCIStatus is still called (best-effort dedup pattern).
+func TestReconcileCIStatus_FingerprintGetError_Continues(t *testing.T) {
+	t.Parallel()
+
+	state := stateWithPendingReaction(t, "ISS-FP-4", "sha-fperr", 1)
+	store := &ciReconcileStore{
+		getFingerprintErr: errors.New("db unavailable"),
+	}
+	metrics := newCIMetricsSpy()
+	ci := &mockCIProvider{result: domain.CIResult{Status: domain.CIStatusPassing}}
+	params := ciParams(t, store, ci, nil)
+
+	reconcileCIStatus(state, params, discardLogger(), context.Background(), metrics)
+
+	if ci.calls != 1 {
+		t.Errorf("FetchCIStatus calls = %d, want 1 even when GetReactionFingerprint errors", ci.calls)
+	}
+}
+
+// TestReconcileCIStatus_Failing_MarksDispatched verifies that after scheduling
+// a CI-fix retry, MarkReactionDispatched is called.
+func TestReconcileCIStatus_Failing_MarksDispatched(t *testing.T) {
+	t.Parallel()
+
+	// ReactionAttempts=0 → under maxRetries=2, so handleCIFailure schedules retry.
+	state := stateWithPendingReaction(t, "ISS-FP-5", "sha-fail", 1)
+	store := &ciReconcileStore{}
+	metrics := newCIMetricsSpy()
+	ci := &mockCIProvider{result: domain.CIResult{Status: domain.CIStatusFailing, FailingCount: 1}}
+	params := ciParams(t, store, ci, nil)
+
+	reconcileCIStatus(state, params, discardLogger(), context.Background(), metrics)
+
+	if store.markDispatchedCalls != 1 {
+		t.Errorf("MarkReactionDispatched calls = %d, want 1 after CI failure dispatch", store.markDispatchedCalls)
+	}
+	// Retry must have been scheduled.
+	if _, ok := state.RetryAttempts["ISS-FP-5"]; !ok {
+		t.Error("retry not scheduled after CI failure; want scheduled")
+	}
+}
+
+// TestEscalateCIFailure_DeletesFingerprint verifies that escalateCIFailure
+// calls DeleteReactionFingerprint after clearing reactions.
+func TestEscalateCIFailure_DeletesFingerprint(t *testing.T) {
+	t.Parallel()
+
+	// ReactionAttempts=2, maxRetries=2 → next increment (→3) triggers escalation.
+	state := stateWithPendingReaction(t, "ISS-FP-6", "sha-escal", 3)
+	state.ReactionAttempts[ReactionKey("ISS-FP-6", ReactionKindCI)] = 2
+	store := &ciReconcileStore{}
+	metrics := newCIMetricsSpy()
+	tracker := &ciTrackerStub{}
+	ci := &mockCIProvider{result: domain.CIResult{Status: domain.CIStatusFailing, FailingCount: 1}}
+	params := ciParams(t, store, ci, tracker)
+
+	reconcileCIStatus(state, params, discardLogger(), context.Background(), metrics)
+
+	// Wait for any escalation goroutine to finish.
+	state.TrackerOpsWg.Wait()
+
+	if store.deleteFingerprintCalls != 1 {
+		t.Errorf("DeleteReactionFingerprint calls = %d, want 1 during CI escalation", store.deleteFingerprintCalls)
+	}
+	// Claim must be released.
+	if _, ok := state.Claimed["ISS-FP-6"]; ok {
+		t.Error("claim not released after escalation")
 	}
 }

--- a/internal/orchestrator/ci_state_test.go
+++ b/internal/orchestrator/ci_state_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-func TestCIFailureContext_RoundTrip(t *testing.T) {
+func TestContinuationContext_RoundTrip(t *testing.T) {
 	t.Parallel()
 
 	data := map[string]any{
@@ -14,56 +14,54 @@ func TestCIFailureContext_RoundTrip(t *testing.T) {
 		"ref":           "feature/abc",
 	}
 
-	ctx := WithCIFailureContext(context.Background(), data)
-	got := CIFailureFromContext(ctx)
+	ctx := WithContinuationContext(context.Background(), data)
+	got := ContinuationFromContext(ctx)
 
 	if got == nil {
-		t.Fatal("CIFailureFromContext() = nil; want non-nil map")
+		t.Fatal("ContinuationFromContext() = nil; want non-nil map")
 	}
 	if got["status"] != "failing" {
-		t.Errorf("CIFailureFromContext()[status] = %v, want %q", got["status"], "failing")
+		t.Errorf("ContinuationFromContext()[status] = %v, want %q", got["status"], "failing")
 	}
 	if got["failing_count"] != 2 {
-		t.Errorf("CIFailureFromContext()[failing_count] = %v, want 2", got["failing_count"])
+		t.Errorf("ContinuationFromContext()[failing_count] = %v, want 2", got["failing_count"])
 	}
 	if got["ref"] != "feature/abc" {
-		t.Errorf("CIFailureFromContext()[ref] = %v, want %q", got["ref"], "feature/abc")
+		t.Errorf("ContinuationFromContext()[ref] = %v, want %q", got["ref"], "feature/abc")
 	}
 }
 
-func TestCIFailureContext_AbsentReturnsNil(t *testing.T) {
+func TestContinuationContext_AbsentReturnsNil(t *testing.T) {
 	t.Parallel()
 
-	got := CIFailureFromContext(context.Background())
+	got := ContinuationFromContext(context.Background())
 	if got != nil {
-		t.Errorf("CIFailureFromContext(plain context) = %v; want nil", got)
+		t.Errorf("ContinuationFromContext(plain context) = %v; want nil", got)
 	}
 }
 
-func TestCIFailureContext_NilDataRoundTrip(t *testing.T) {
+func TestContinuationContext_NilDataRoundTrip(t *testing.T) {
 	t.Parallel()
 
-	ctx := WithCIFailureContext(context.Background(), nil)
-	got := CIFailureFromContext(ctx)
+	ctx := WithContinuationContext(context.Background(), nil)
+	got := ContinuationFromContext(ctx)
 	if got != nil {
-		t.Errorf("CIFailureFromContext(nil data) = %v; want nil", got)
+		t.Errorf("ContinuationFromContext(nil data) = %v; want nil", got)
 	}
 }
 
-func TestCIFailureContext_ParentContextNotAffected(t *testing.T) {
+func TestContinuationContext_ParentContextNotAffected(t *testing.T) {
 	t.Parallel()
 
 	parent := context.Background()
 	data := map[string]any{"ref": "main"}
 
-	child := WithCIFailureContext(parent, data)
+	child := WithContinuationContext(parent, data)
 
-	// Child has the data.
-	if CIFailureFromContext(child) == nil {
-		t.Fatal("CIFailureFromContext(child) = nil; want non-nil")
+	if ContinuationFromContext(child) == nil {
+		t.Fatal("ContinuationFromContext(child) = nil; want non-nil")
 	}
-	// Parent is unmodified (context.WithValue creates a new context).
-	if CIFailureFromContext(parent) != nil {
-		t.Error("CIFailureFromContext(parent) != nil; parent context must not be affected")
+	if ContinuationFromContext(parent) != nil {
+		t.Error("ContinuationFromContext(parent) != nil; parent context must not be affected")
 	}
 }

--- a/internal/orchestrator/dispatch.go
+++ b/internal/orchestrator/dispatch.go
@@ -226,9 +226,10 @@ type ScheduleRetryParams struct {
 	Error       string
 	LastSSHHost string // Runtime-only: SSH host from previous attempt for retry affinity.
 
-	// CIFailureContext carries CI failure data to inject into the prompt
-	// template on the first turn of the retry worker. Nil for non-CI retries.
-	CIFailureContext map[string]any
+	// ContinuationContext carries reaction continuation data to inject
+	// into the prompt template on the first turn of the retry worker.
+	// Nil for non-reaction retries.
+	ContinuationContext map[string]any
 }
 
 // ScheduleRetry cancels any existing retry for the issue, creates a new
@@ -261,17 +262,17 @@ func ScheduleRetry(state *State, params ScheduleRetryParams, onFire func(issueID
 	})
 
 	state.RetryAttempts[params.IssueID] = &RetryEntry{
-		IssueID:          params.IssueID,
-		Identifier:       params.Identifier,
-		DisplayID:        params.DisplayID,
-		Attempt:          params.Attempt,
-		DueAtMS:          dueAtMS,
-		Error:            params.Error,
-		TimerHandle:      timer,
-		LastSSHHost:      params.LastSSHHost,
-		CIFailureContext: params.CIFailureContext,
-		scheduledAt:      time.Now(),
-		scheduledDelayMS: delayMS,
+		IssueID:             params.IssueID,
+		Identifier:          params.Identifier,
+		DisplayID:           params.DisplayID,
+		Attempt:             params.Attempt,
+		DueAtMS:             dueAtMS,
+		Error:               params.Error,
+		TimerHandle:         timer,
+		LastSSHHost:         params.LastSSHHost,
+		ContinuationContext: params.ContinuationContext,
+		scheduledAt:         time.Now(),
+		scheduledDelayMS:    delayMS,
 	}
 }
 

--- a/internal/orchestrator/exit.go
+++ b/internal/orchestrator/exit.go
@@ -104,8 +104,8 @@ type HandleWorkerExitParams struct {
 	HostPool *HostPool
 
 	// CIProvider is the CI status provider. When non-nil, HandleWorkerExit
-	// populates state.PendingCICheck on normal exits so the reconcile loop
-	// can poll CI status.
+	// populates state.PendingReactions on normal exits so the reconcile
+	// loop can poll CI status.
 	CIProvider domain.CIStatusProvider
 }
 
@@ -383,15 +383,19 @@ func HandleWorkerExit(state *State, workerResult WorkerResult, params HandleWork
 					if params.NowFunc != nil {
 						nowCI = params.NowFunc().UTC()
 					}
-					state.PendingCICheck[workerResult.IssueID] = &PendingCICheckEntry{
+					rkey := ReactionKey(workerResult.IssueID, ReactionKindCI)
+					state.PendingReactions[rkey] = &PendingReaction{
 						IssueID:     workerResult.IssueID,
 						Identifier:  workerResult.Identifier,
 						DisplayID:   entry.Issue.DisplayID,
 						Attempt:     normalizeAttempt(entry.RetryAttempt) + 1,
-						Branch:      scm.Branch,
-						SHA:         scm.SHA,
+						Kind:        ReactionKindCI,
 						LastSSHHost: workerResult.SSHHost,
 						CreatedAt:   nowCI,
+						KindData: &CIReactionData{
+							Branch: scm.Branch,
+							SHA:    scm.SHA,
+						},
 					}
 				}
 			}

--- a/internal/orchestrator/exit_test.go
+++ b/internal/orchestrator/exit_test.go
@@ -2556,7 +2556,7 @@ func (c *ciProviderStubExit) FetchCIStatus(_ context.Context, _ string) (domain.
 	panic("FetchCIStatus must not be called by HandleWorkerExit")
 }
 
-func TestHandleWorkerExit_CIProvider_PopulatesPendingCICheck(t *testing.T) {
+func TestHandleWorkerExit_CIProvider_PopulatesPendingReaction(t *testing.T) {
 	t.Parallel()
 
 	wsPath := t.TempDir()
@@ -2575,22 +2575,27 @@ func TestHandleWorkerExit_CIProvider_PopulatesPendingCICheck(t *testing.T) {
 		WorkspacePath: wsPath,
 	}, params)
 
-	entry, ok := state.PendingCICheck["CI-ISS-1"]
+	rkey := ReactionKey("CI-ISS-1", ReactionKindCI)
+	entry, ok := state.PendingReactions[rkey]
 	if !ok {
-		t.Fatal("PendingCICheck[CI-ISS-1] missing; want entry after normal exit with branch")
+		t.Fatal("PendingReactions[CI-ISS-1:ci] missing; want entry after normal exit with branch")
 	}
-	if entry.Branch != "feature/ci-test" {
-		t.Errorf("PendingCICheck.Branch = %q, want %q", entry.Branch, "feature/ci-test")
+	ciData, ok := entry.KindData.(*CIReactionData)
+	if !ok {
+		t.Fatal("KindData is not *CIReactionData")
 	}
-	if entry.SHA != "abc123" {
-		t.Errorf("PendingCICheck.SHA = %q, want %q", entry.SHA, "abc123")
+	if ciData.Branch != "feature/ci-test" {
+		t.Errorf("CIReactionData.Branch = %q, want %q", ciData.Branch, "feature/ci-test")
+	}
+	if ciData.SHA != "abc123" {
+		t.Errorf("CIReactionData.SHA = %q, want %q", ciData.SHA, "abc123")
 	}
 	if entry.IssueID != "CI-ISS-1" {
-		t.Errorf("PendingCICheck.IssueID = %q, want %q", entry.IssueID, "CI-ISS-1")
+		t.Errorf("PendingReaction.IssueID = %q, want %q", entry.IssueID, "CI-ISS-1")
 	}
 }
 
-func TestHandleWorkerExit_CIProvider_NilProvider_NoPendingCICheck(t *testing.T) {
+func TestHandleWorkerExit_CIProvider_NilProvider_NoPendingReaction(t *testing.T) {
 	t.Parallel()
 
 	wsPath := t.TempDir()
@@ -2609,12 +2614,12 @@ func TestHandleWorkerExit_CIProvider_NilProvider_NoPendingCICheck(t *testing.T) 
 		WorkspacePath: wsPath,
 	}, params)
 
-	if _, ok := state.PendingCICheck["CI-ISS-2"]; ok {
-		t.Error("PendingCICheck populated when CIProvider is nil; want absent")
+	if _, ok := state.PendingReactions[ReactionKey("CI-ISS-2", ReactionKindCI)]; ok {
+		t.Error("PendingReactions populated when CIProvider is nil; want absent")
 	}
 }
 
-func TestHandleWorkerExit_CIProvider_EmptyWorkspace_NoPendingCICheck(t *testing.T) {
+func TestHandleWorkerExit_CIProvider_EmptyWorkspace_NoPendingReaction(t *testing.T) {
 	t.Parallel()
 
 	store := &mockExitStore{}
@@ -2631,12 +2636,12 @@ func TestHandleWorkerExit_CIProvider_EmptyWorkspace_NoPendingCICheck(t *testing.
 		WorkspacePath: "",
 	}, params)
 
-	if _, ok := state.PendingCICheck["CI-ISS-3"]; ok {
-		t.Error("PendingCICheck populated for empty workspace; want absent")
+	if _, ok := state.PendingReactions[ReactionKey("CI-ISS-3", ReactionKindCI)]; ok {
+		t.Error("PendingReactions populated for empty workspace; want absent")
 	}
 }
 
-func TestHandleWorkerExit_CIProvider_NoBranchInSCM_NoPendingCICheck(t *testing.T) {
+func TestHandleWorkerExit_CIProvider_NoBranchInSCM_NoPendingReaction(t *testing.T) {
 	t.Parallel()
 
 	wsPath := t.TempDir()
@@ -2662,12 +2667,12 @@ func TestHandleWorkerExit_CIProvider_NoBranchInSCM_NoPendingCICheck(t *testing.T
 		WorkspacePath: wsPath,
 	}, params)
 
-	if _, ok := state.PendingCICheck["CI-ISS-4"]; ok {
-		t.Error("PendingCICheck populated when SCM branch is empty; want absent")
+	if _, ok := state.PendingReactions[ReactionKey("CI-ISS-4", ReactionKindCI)]; ok {
+		t.Error("PendingReactions populated when SCM branch is empty; want absent")
 	}
 }
 
-func TestHandleWorkerExit_CIProvider_SoftStop_NoPendingCICheck(t *testing.T) {
+func TestHandleWorkerExit_CIProvider_SoftStop_NoPendingReaction(t *testing.T) {
 	t.Parallel()
 
 	wsPath := t.TempDir()
@@ -2678,7 +2683,7 @@ func TestHandleWorkerExit_CIProvider_SoftStop_NoPendingCICheck(t *testing.T) {
 	params := defaultExitParams(t, store)
 	params.CIProvider = &ciProviderStubExit{}
 
-	// SoftStop: claim is released before the CI check; PendingCICheck must not be populated.
+	// SoftStop: claim is released before the CI check; PendingReactions must not be populated.
 	HandleWorkerExit(state, WorkerResult{
 		IssueID:        "CI-ISS-5",
 		Identifier:     "CI-ISS-5-ident",
@@ -2689,8 +2694,8 @@ func TestHandleWorkerExit_CIProvider_SoftStop_NoPendingCICheck(t *testing.T) {
 		WorkspacePath:  wsPath,
 	}, params)
 
-	if _, ok := state.PendingCICheck["CI-ISS-5"]; ok {
-		t.Error("PendingCICheck populated after SoftStop; want absent (claim released before CI check)")
+	if _, ok := state.PendingReactions[ReactionKey("CI-ISS-5", ReactionKindCI)]; ok {
+		t.Error("PendingReactions populated after SoftStop; want absent (claim released before CI check)")
 	}
 }
 

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -35,6 +35,11 @@ type OrchestratorStore interface {
 	DeleteRetryEntry(ctx context.Context, issueID string) error
 	CountRunHistoryByIssue(ctx context.Context, issueID string) (int, error)
 	QueryBudgetExhaustedIssues(ctx context.Context, candidateIDs []string, maxSessions int) ([]string, error)
+	DeleteReactionFingerprintsByIssue(ctx context.Context, issueID string) error
+	UpsertReactionFingerprint(ctx context.Context, issueID, kind, fingerprint string) error
+	GetReactionFingerprint(ctx context.Context, issueID, kind string) (fingerprint string, dispatched bool, err error)
+	MarkReactionDispatched(ctx context.Context, issueID, kind string) error
+	DeleteReactionFingerprint(ctx context.Context, issueID, kind string) error
 }
 
 // Observer receives notifications when orchestrator state changes.

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -142,6 +142,26 @@ func (s *stubStore) QueryBudgetExhaustedIssues(_ context.Context, _ []string, _ 
 	return result, nil
 }
 
+func (s *stubStore) DeleteReactionFingerprintsByIssue(_ context.Context, _ string) error {
+	return nil
+}
+
+func (s *stubStore) UpsertReactionFingerprint(_ context.Context, _, _, _ string) error {
+	return nil
+}
+
+func (s *stubStore) GetReactionFingerprint(_ context.Context, _, _ string) (string, bool, error) {
+	return "", false, nil
+}
+
+func (s *stubStore) MarkReactionDispatched(_ context.Context, _, _ string) error {
+	return nil
+}
+
+func (s *stubStore) DeleteReactionFingerprint(_ context.Context, _, _ string) error {
+	return nil
+}
+
 // stubObserver implements [Observer] with an atomic call counter.
 type stubObserver struct {
 	calls atomic.Int64

--- a/internal/orchestrator/reconcile.go
+++ b/internal/orchestrator/reconcile.go
@@ -19,6 +19,11 @@ type ReconcileStore interface {
 	SaveRetryEntry(ctx context.Context, entry persistence.RetryEntry) error
 	DeleteRetryEntry(ctx context.Context, issueID string) error
 	AppendRunHistory(ctx context.Context, run persistence.RunHistory) (persistence.RunHistory, error)
+	DeleteReactionFingerprintsByIssue(ctx context.Context, issueID string) error
+	UpsertReactionFingerprint(ctx context.Context, issueID, kind, fingerprint string) error
+	GetReactionFingerprint(ctx context.Context, issueID, kind string) (fingerprint string, dispatched bool, err error)
+	MarkReactionDispatched(ctx context.Context, issueID, kind string) error
+	DeleteReactionFingerprint(ctx context.Context, issueID, kind string) error
 }
 
 // ReconcileParams holds the dependencies for [ReconcileRunningIssues] that
@@ -65,14 +70,14 @@ type ReconcileParams struct {
 	Metrics domain.Metrics
 
 	// CIProvider is the CI status provider. When non-nil, the reconcile
-	// loop polls CI status for issues in state.PendingCICheck.
+	// loop polls CI status for issues in state.PendingReactions.
 	CIProvider domain.CIStatusProvider
 
 	// CIFeedback holds CI feedback tuning (max retries, escalation mode).
 	// Only read when CIProvider is non-nil.
 	CIFeedback config.CIFeedbackConfig
 
-	// CIPendingTTL is the maximum age of a PendingCICheck entry before
+	// CIPendingTTL is the maximum age of a PendingReaction entry before
 	// it is dropped and a warning is logged. Protects against indefinite
 	// spinning when the CI provider is unreachable and no new worker exit
 	// refreshes the entry. Zero or negative disables TTL enforcement

--- a/internal/orchestrator/reconcile_test.go
+++ b/internal/orchestrator/reconcile_test.go
@@ -39,6 +39,26 @@ func (m *mockReconcileStore) AppendRunHistory(_ context.Context, run persistence
 	return run, nil
 }
 
+func (m *mockReconcileStore) DeleteReactionFingerprintsByIssue(_ context.Context, _ string) error {
+	return nil
+}
+
+func (m *mockReconcileStore) UpsertReactionFingerprint(_ context.Context, _, _, _ string) error {
+	return nil
+}
+
+func (m *mockReconcileStore) GetReactionFingerprint(_ context.Context, _, _ string) (string, bool, error) {
+	return "", false, nil
+}
+
+func (m *mockReconcileStore) MarkReactionDispatched(_ context.Context, _, _ string) error {
+	return nil
+}
+
+func (m *mockReconcileStore) DeleteReactionFingerprint(_ context.Context, _, _ string) error {
+	return nil
+}
+
 // mockReconcileTracker implements domain.TrackerAdapter for reconcile tests.
 // Only FetchIssueStatesByIDs is exercised; the other methods panic if called.
 type mockReconcileTracker struct {

--- a/internal/orchestrator/retry.go
+++ b/internal/orchestrator/retry.go
@@ -302,13 +302,13 @@ func HandleRetryTimer(state *State, issueID string, params HandleRetryTimerParam
 	// next worker exit, not at dispatch time.
 	attempt := popped.Attempt
 	dispatchCtx := ctx
-	if popped.CIFailureContext != nil {
-		dispatchCtx = WithCIFailureContext(ctx, popped.CIFailureContext)
+	if popped.ContinuationContext != nil {
+		dispatchCtx = WithContinuationContext(ctx, popped.ContinuationContext)
 	}
 	DispatchIssue(dispatchCtx, state, issue, &attempt, host, params.MakeWorkerFn("", host))
 	if entry := state.Running[issue.ID]; entry != nil {
 		entry.WorkflowFile = params.WorkflowFile
-		entry.CIFailureContext = popped.CIFailureContext
+		entry.ContinuationContext = popped.ContinuationContext
 	}
 	metrics.IncDispatches(outcomeSuccess)
 

--- a/internal/orchestrator/retry_test.go
+++ b/internal/orchestrator/retry_test.go
@@ -46,6 +46,26 @@ func (m *mockRetryStore) AppendRunHistory(_ context.Context, run persistence.Run
 	return run, nil
 }
 
+func (m *mockRetryStore) DeleteReactionFingerprintsByIssue(_ context.Context, _ string) error {
+	return nil
+}
+
+func (m *mockRetryStore) UpsertReactionFingerprint(_ context.Context, _, _, _ string) error {
+	return nil
+}
+
+func (m *mockRetryStore) GetReactionFingerprint(_ context.Context, _, _ string) (string, bool, error) {
+	return "", false, nil
+}
+
+func (m *mockRetryStore) MarkReactionDispatched(_ context.Context, _, _ string) error {
+	return nil
+}
+
+func (m *mockRetryStore) DeleteReactionFingerprint(_ context.Context, _, _ string) error {
+	return nil
+}
+
 // mockRetryTracker implements domain.TrackerAdapter for retry timer tests.
 // Only FetchCandidateIssues is used by HandleRetryTimer; the remaining
 // methods panic if called.
@@ -1239,25 +1259,27 @@ func TestHandleRetryTimer_BudgetExhaustedBlocksShouldDispatch(t *testing.T) {
 	}
 }
 
-func TestHandleRetryTimer_CIFailureContextPropagated(t *testing.T) {
+func TestHandleRetryTimer_ContinuationContextPropagated(t *testing.T) {
 	t.Parallel()
 
-	// CI failure context carried on the retry entry should be forwarded to
+	// Continuation context carried on the retry entry should be forwarded to
 	// the running entry so the worker can inject it into the turn prompt.
 	const id = "ISS-CI-RETRY"
-	ciContext := map[string]any{
-		"status":        "failing",
-		"failing_count": 3,
-		"ref":           "feature/fix",
+	contContext := map[string]any{
+		"ci_failure": map[string]any{
+			"status":        "failing",
+			"failing_count": 3,
+			"ref":           "feature/fix",
+		},
 	}
 
 	state := NewState(5000, 4, nil, AgentTotals{})
 	state.Claimed[id] = struct{}{}
 	state.RetryAttempts[id] = &RetryEntry{
-		IssueID:          id,
-		Identifier:       id,
-		Attempt:          2,
-		CIFailureContext: ciContext,
+		IssueID:             id,
+		Identifier:          id,
+		Attempt:             2,
+		ContinuationContext: contContext,
 	}
 
 	store := &mockRetryStore{}
@@ -1274,31 +1296,35 @@ func TestHandleRetryTimer_CIFailureContextPropagated(t *testing.T) {
 	if !ok {
 		t.Fatal("issue not dispatched; state.Running[id] missing")
 	}
-	if entry.CIFailureContext == nil {
-		t.Fatal("RunningEntry.CIFailureContext is nil; want CI failure map")
+	if entry.ContinuationContext == nil {
+		t.Fatal("RunningEntry.ContinuationContext is nil; want continuation map")
 	}
-	if entry.CIFailureContext["status"] != "failing" {
-		t.Errorf("CIFailureContext[status] = %v, want %q", entry.CIFailureContext["status"], "failing")
+	ciData, ok := entry.ContinuationContext["ci_failure"].(map[string]any)
+	if !ok {
+		t.Fatal("ContinuationContext[ci_failure] is not map[string]any")
 	}
-	if entry.CIFailureContext["failing_count"] != 3 {
-		t.Errorf("CIFailureContext[failing_count] = %v, want 3", entry.CIFailureContext["failing_count"])
+	if ciData["status"] != "failing" {
+		t.Errorf("ContinuationContext[ci_failure][status] = %v, want %q", ciData["status"], "failing")
+	}
+	if ciData["failing_count"] != 3 {
+		t.Errorf("ContinuationContext[ci_failure][failing_count] = %v, want 3", ciData["failing_count"])
 	}
 }
 
-func TestHandleRetryTimer_NilCIFailureContext_NotPropagated(t *testing.T) {
+func TestHandleRetryTimer_NilContinuationContext_NotPropagated(t *testing.T) {
 	t.Parallel()
 
-	// When the retry entry carries no CI failure context, the running entry
+	// When the retry entry carries no continuation context, the running entry
 	// must not have one set either (field stays nil; no accidental injection).
 	const id = "ISS-NO-CI"
 
 	state := NewState(5000, 4, nil, AgentTotals{})
 	state.Claimed[id] = struct{}{}
 	state.RetryAttempts[id] = &RetryEntry{
-		IssueID:          id,
-		Identifier:       id,
-		Attempt:          1,
-		CIFailureContext: nil, // explicit nil
+		IssueID:             id,
+		Identifier:          id,
+		Attempt:             1,
+		ContinuationContext: nil,
 	}
 
 	store := &mockRetryStore{}
@@ -1315,7 +1341,7 @@ func TestHandleRetryTimer_NilCIFailureContext_NotPropagated(t *testing.T) {
 	if !ok {
 		t.Fatal("issue not dispatched; state.Running[id] missing")
 	}
-	if entry.CIFailureContext != nil {
-		t.Errorf("RunningEntry.CIFailureContext = %v, want nil", entry.CIFailureContext)
+	if entry.ContinuationContext != nil {
+		t.Errorf("RunningEntry.ContinuationContext = %v, want nil", entry.ContinuationContext)
 	}
 }

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -2,6 +2,7 @@ package orchestrator
 
 import (
 	"context"
+	"log/slog"
 	"maps"
 	"slices"
 	"strings"
@@ -195,10 +196,10 @@ type RunningEntry struct {
 	// APIDurationMS > 0.
 	APITimeMs int64
 
-	// CIFailureContext carries CI failure data from a ci_fix retry into
-	// the worker session. Populated by HandleRetryTimer when the retry
-	// trigger is triggerCIFix. Nil for normal dispatches and non-CI retries.
-	CIFailureContext map[string]any
+	// ContinuationContext carries reaction continuation data from a retry
+	// into the worker session. Populated by HandleRetryTimer when the
+	// retry carries reaction context. Nil for normal dispatches.
+	ContinuationContext map[string]any
 
 	// SelfReviewActive is true when the worker is in the self-review phase.
 	// Mutated only by the event loop via selfReviewCh.
@@ -241,17 +242,29 @@ type RetryEntry struct {
 	// from a replaced timer.
 	scheduledDelayMS int64
 
-	// CIFailureContext carries CI failure data for template injection on
-	// the first turn of the retry worker. Populated by reconcileCIStatus
-	// when scheduling a ci_fix retry. Nil for non-CI retries.
-	CIFailureContext map[string]any
+	// ContinuationContext carries reaction continuation data for template
+	// injection on the first turn of the retry worker. Populated by
+	// reconcile functions when scheduling a continuation retry. Nil for
+	// non-reaction retries.
+	ContinuationContext map[string]any
 }
 
-// PendingCICheckEntry records that an issue's worker exited normally and
-// its CI status should be polled on the next reconcile tick. If CI is
-// failing, the reconcile loop either redispatches with failure context
-// or escalates. Runtime-only (not persisted to SQLite).
-type PendingCICheckEntry struct {
+// ReactionKindCI is the reaction kind constant for CI failure reactions.
+const ReactionKindCI = "ci"
+
+// ReactionKey returns the composite map key for a pending reaction.
+// Callers must not pass IDs containing colons; the delimiter is a plain
+// colon between issueID and kind.
+func ReactionKey(issueID, kind string) string {
+	return issueID + ":" + kind
+}
+
+// PendingReaction records that an issue needs external signal
+// reconciliation. Created by worker exit handlers or external event
+// receivers. Consumed by per-kind reconcile functions during the
+// reconcile tick. Runtime-only (not persisted to SQLite — cross-restart
+// deduplication uses reaction_fingerprints).
+type PendingReaction struct {
 	// IssueID is the domain issue ID.
 	IssueID string
 
@@ -264,29 +277,42 @@ type PendingCICheckEntry struct {
 	// Attempt is the overall run attempt number from the completed worker.
 	Attempt int
 
-	// Branch is the git branch name from SCM metadata.
-	Branch string
-
-	// SHA is the git commit SHA from SCM metadata. When non-empty, used
-	// as the ref for CIStatusProvider.FetchCIStatus.
-	SHA string
+	// Kind is the reaction type constant (e.g. ReactionKindCI).
+	Kind string
 
 	// LastSSHHost is the SSH host from the completed worker, used for
-	// host preference on CI-fix redispatch.
+	// host preference on fix redispatch.
 	LastSSHHost string
 
 	// CreatedAt is the UTC time the entry was created.
 	CreatedAt time.Time
 
 	// PendingAttempts is the number of times the entry has been
-	// re-enqueued without a definitive CI result (pending status or
+	// re-enqueued without a definitive result (pending status or
 	// transient fetch error). Used to compute exponential backoff.
 	PendingAttempts int
 
-	// PendingRetryAt is the earliest UTC time at which reconcileCIStatus
-	// should call FetchCIStatus again. Zero means the entry is ready
-	// immediately (first check or explicit reset).
+	// PendingRetryAt is the earliest UTC time at which the reconcile
+	// function should poll again. Zero means ready immediately.
 	PendingRetryAt time.Time
+
+	// KindData holds kind-specific typed data. CI reactions use
+	// [*CIReactionData]; future reaction types define their own structs.
+	// The reconcile function for each kind is responsible for a single
+	// type assertion at the top of its loop body.
+	KindData any
+}
+
+// CIReactionData holds CI-specific fields for a pending CI reaction.
+// Stored in [PendingReaction.KindData] for reactions with Kind ==
+// [ReactionKindCI].
+type CIReactionData struct {
+	// Branch is the git branch name from SCM metadata.
+	Branch string
+
+	// SHA is the git commit SHA from SCM metadata. When non-empty, used
+	// as the ref for CIStatusProvider.FetchCIStatus.
+	SHA string
 }
 
 // State is the single authoritative runtime state owned by the orchestrator.
@@ -354,33 +380,66 @@ type State struct {
 	// any agent event. Nil when no rate-limit data has been observed.
 	AgentRateLimits *RateLimitSnapshot
 
-	// CIFixAttempts maps issue ID to the number of CI-fix continuations
-	// dispatched for that issue. Reset when the issue leaves the Running
-	// or RetryAttempts maps. Runtime-only (not persisted).
-	CIFixAttempts map[string]int
-
-	// PendingCICheck maps issue ID to a PendingCICheckEntry. Populated by
-	// HandleWorkerExit when a normal exit occurs and a CIStatusProvider is
-	// available. Consumed by reconcileCIStatus during the reconcile tick.
+	// ReactionAttempts maps composite key (issueID:kind) to the number of
+	// reaction-triggered continuations dispatched for that combination.
+	// Reset when the issue leaves the Running or RetryAttempts maps.
 	// Runtime-only (not persisted).
-	PendingCICheck map[string]*PendingCICheckEntry
+	ReactionAttempts map[string]int
+
+	// PendingReactions maps composite key (issueID:kind) to a
+	// [PendingReaction]. Populated by [HandleWorkerExit] when a normal
+	// exit occurs and a reaction provider is configured. Consumed by
+	// per-kind reconcile functions during the reconcile tick. Runtime-only
+	// (not persisted).
+	PendingReactions map[string]*PendingReaction
 }
 
-// ciFailureCtxKey is the context key for CI failure data passed from
-// the dispatch site to the worker goroutine via context.WithValue.
-type ciFailureCtxKey struct{}
+// continuationCtxKey is the context key for reaction continuation data
+// passed from the dispatch site to the worker goroutine via
+// context.WithValue.
+type continuationCtxKey struct{}
 
-// WithCIFailureContext returns a child context carrying CI failure data
-// for prompt injection. The worker reads this with [CIFailureFromContext].
-func WithCIFailureContext(ctx context.Context, data map[string]any) context.Context {
-	return context.WithValue(ctx, ciFailureCtxKey{}, data)
+// WithContinuationContext returns a child context carrying reaction
+// continuation data for prompt injection. The worker reads this with
+// [ContinuationFromContext].
+func WithContinuationContext(ctx context.Context, data map[string]any) context.Context {
+	return context.WithValue(ctx, continuationCtxKey{}, data)
 }
 
-// CIFailureFromContext extracts the CI failure map injected by
-// [WithCIFailureContext]. Returns nil when no CI failure data is present.
-func CIFailureFromContext(ctx context.Context) map[string]any {
-	v, _ := ctx.Value(ciFailureCtxKey{}).(map[string]any)
+// ContinuationFromContext extracts the continuation map injected by
+// [WithContinuationContext]. Returns nil when no continuation data is
+// present.
+func ContinuationFromContext(ctx context.Context) map[string]any {
+	v, _ := ctx.Value(continuationCtxKey{}).(map[string]any)
 	return v
+}
+
+// ClearReactionsForIssue removes all PendingReactions and
+// ReactionAttempts entries whose key starts with the given issue ID
+// prefix, and deletes the corresponding reaction_fingerprints rows from
+// SQLite. The SQLite call is best-effort: a failure is logged at warn
+// level but does not block the caller.
+func ClearReactionsForIssue(ctx context.Context, state *State, store ReconcileStore, issueID string, log *slog.Logger) {
+	prefix := issueID + ":"
+	for key := range state.PendingReactions {
+		if strings.HasPrefix(key, prefix) {
+			delete(state.PendingReactions, key)
+		}
+	}
+	for key := range state.ReactionAttempts {
+		if strings.HasPrefix(key, prefix) {
+			delete(state.ReactionAttempts, key)
+		}
+	}
+	if err := store.DeleteReactionFingerprintsByIssue(ctx, issueID); err != nil {
+		if log == nil {
+			log = slog.Default()
+		}
+		log.WarnContext(ctx, "failed to delete reaction fingerprints",
+			slog.String("issue_id", issueID),
+			slog.Any("error", err),
+		)
+	}
 }
 
 // NewState creates an initialized [State] with empty collections and the
@@ -402,8 +461,8 @@ func NewState(pollIntervalMS, maxConcurrentAgents int, maxConcurrentByState map[
 		Completed:            make(map[string]struct{}),
 		BudgetExhausted:      make(map[string]struct{}),
 		AgentTotals:          totals,
-		CIFixAttempts:        make(map[string]int),
-		PendingCICheck:       make(map[string]*PendingCICheckEntry),
+		ReactionAttempts:     make(map[string]int),
+		PendingReactions:     make(map[string]*PendingReaction),
 	}
 }
 

--- a/internal/orchestrator/worker.go
+++ b/internal/orchestrator/worker.go
@@ -214,10 +214,10 @@ type WorkerDeps struct {
 	// Tier 1 tool access.
 	DBPath string
 
-	// CIFailureContext carries CI failure data to inject into the prompt
-	// template on the first turn. Non-nil only for CI-fix continuation
-	// dispatches. Nil for normal dispatches and non-CI retries.
-	CIFailureContext map[string]any
+	// ContinuationContext carries reaction continuation data to inject
+	// into the prompt template on the first turn. Non-nil only for
+	// reaction-triggered continuation dispatches.
+	ContinuationContext map[string]any
 
 	// OnProgress relays self-review progress to the orchestrator's event
 	// loop. Called from the worker goroutine; must be safe for concurrent
@@ -632,12 +632,12 @@ func RunWorkerAttempt(ctx context.Context, issue domain.Issue, attempt *int, dep
 		issueMap := issue.ToTemplateMap()
 		var renderOpts []prompt.RenderOption
 		if turnNumber == 1 {
-			ciCtx := deps.CIFailureContext
-			if ciCtx == nil {
-				ciCtx = CIFailureFromContext(ctx)
+			contCtx := deps.ContinuationContext
+			if contCtx == nil {
+				contCtx = ContinuationFromContext(ctx)
 			}
-			if ciCtx != nil {
-				renderOpts = append(renderOpts, prompt.WithCIFailure(ciCtx))
+			if contCtx != nil {
+				renderOpts = append(renderOpts, prompt.WithContinuationContext(contCtx))
 			}
 		}
 		rendered, err := prompt.BuildTurnPrompt(tmpl, issueMap, attemptInt, turnNumber, maxTurns, renderOpts...)

--- a/internal/persistence/migrations.go
+++ b/internal/persistence/migrations.go
@@ -32,6 +32,9 @@ var migration006SQL string
 //go:embed sql/007_self_review.sql
 var migration007SQL string
 
+//go:embed sql/008_reaction_fingerprints.sql
+var migration008SQL string
+
 var migrations = []Migration{
 	{Version: 1, Description: "core persistence tables", SQL: migration001SQL},
 	{Version: 2, Description: "extended token metrics", SQL: migration002SQL},
@@ -40,4 +43,5 @@ var migrations = []Migration{
 	{Version: 5, Description: "turns completed in run history", SQL: migration005SQL},
 	{Version: 6, Description: "display identifier in run history", SQL: migration006SQL},
 	{Version: 7, Description: "self-review metadata in run history", SQL: migration007SQL},
+	{Version: 8, Description: "reaction fingerprints for cross-restart dedup", SQL: migration008SQL},
 }

--- a/internal/persistence/reaction_fingerprints.go
+++ b/internal/persistence/reaction_fingerprints.go
@@ -1,0 +1,83 @@
+package persistence
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"time"
+)
+
+// UpsertReactionFingerprint inserts or updates a reaction fingerprint.
+// If the fingerprint value changes, dispatched is reset to 0.
+func (s *Store) UpsertReactionFingerprint(ctx context.Context, issueID, kind, fingerprint string) error {
+	now := time.Now().UTC().Format(time.RFC3339)
+	_, err := s.db.ExecContext(ctx, `
+		INSERT INTO reaction_fingerprints (issue_id, kind, fingerprint, dispatched, updated_at)
+		VALUES (?, ?, ?, 0, ?)
+		ON CONFLICT (issue_id, kind) DO UPDATE SET
+			fingerprint = CASE
+				WHEN excluded.fingerprint != reaction_fingerprints.fingerprint
+				THEN excluded.fingerprint
+				ELSE reaction_fingerprints.fingerprint
+			END,
+			dispatched = CASE
+				WHEN excluded.fingerprint != reaction_fingerprints.fingerprint
+				THEN 0
+				ELSE reaction_fingerprints.dispatched
+			END,
+			updated_at = excluded.updated_at`,
+		issueID, kind, fingerprint, now,
+	)
+	return err
+}
+
+// GetReactionFingerprint returns the stored fingerprint and dispatched
+// flag for the given issue and kind. Returns ("", false, nil) when no
+// row exists.
+func (s *Store) GetReactionFingerprint(ctx context.Context, issueID, kind string) (fingerprint string, dispatched bool, err error) {
+	var dispatchedInt int
+	err = s.db.QueryRowContext(ctx, `
+		SELECT fingerprint, dispatched FROM reaction_fingerprints
+		WHERE issue_id = ? AND kind = ?`,
+		issueID, kind,
+	).Scan(&fingerprint, &dispatchedInt)
+	if errors.Is(err, sql.ErrNoRows) {
+		return "", false, nil
+	}
+	if err != nil {
+		return "", false, err
+	}
+	return fingerprint, dispatchedInt != 0, nil
+}
+
+// MarkReactionDispatched sets dispatched=1 for the given issue and kind.
+// No-op if the row does not exist.
+func (s *Store) MarkReactionDispatched(ctx context.Context, issueID, kind string) error {
+	now := time.Now().UTC().Format(time.RFC3339)
+	_, err := s.db.ExecContext(ctx, `
+		UPDATE reaction_fingerprints SET dispatched = 1, updated_at = ?
+		WHERE issue_id = ? AND kind = ?`,
+		now, issueID, kind,
+	)
+	return err
+}
+
+// DeleteReactionFingerprint removes the fingerprint row for the given
+// issue and kind.
+func (s *Store) DeleteReactionFingerprint(ctx context.Context, issueID, kind string) error {
+	_, err := s.db.ExecContext(ctx, `
+		DELETE FROM reaction_fingerprints WHERE issue_id = ? AND kind = ?`,
+		issueID, kind,
+	)
+	return err
+}
+
+// DeleteReactionFingerprintsByIssue removes all fingerprint rows for
+// the given issue (all kinds).
+func (s *Store) DeleteReactionFingerprintsByIssue(ctx context.Context, issueID string) error {
+	_, err := s.db.ExecContext(ctx, `
+		DELETE FROM reaction_fingerprints WHERE issue_id = ?`,
+		issueID,
+	)
+	return err
+}

--- a/internal/persistence/reaction_fingerprints_test.go
+++ b/internal/persistence/reaction_fingerprints_test.go
@@ -1,0 +1,253 @@
+package persistence
+
+import (
+	"context"
+	"testing"
+)
+
+func mustOpenStore(t *testing.T) *Store {
+	t.Helper()
+	s, err := Open(context.Background(), ":memory:")
+	if err != nil {
+		t.Fatalf("Open(:memory:): %v", err)
+	}
+	migrateOrFatal(t, s)
+	t.Cleanup(func() { closeStore(t, s) })
+	return s
+}
+
+func TestUpsertReactionFingerprint_NewRow(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	s := mustOpenStore(t)
+
+	if err := s.UpsertReactionFingerprint(ctx, "ISS-1", "ci", "sha-abc"); err != nil {
+		t.Fatalf("UpsertReactionFingerprint: %v", err)
+	}
+
+	fp, dispatched, err := s.GetReactionFingerprint(ctx, "ISS-1", "ci")
+	if err != nil {
+		t.Fatalf("GetReactionFingerprint: %v", err)
+	}
+	if fp != "sha-abc" {
+		t.Errorf("GetReactionFingerprint() fingerprint = %q, want %q", fp, "sha-abc")
+	}
+	if dispatched {
+		t.Error("GetReactionFingerprint() dispatched = true, want false for new row")
+	}
+}
+
+func TestUpsertReactionFingerprint_SameFingerprintPreservesDispatched(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	s := mustOpenStore(t)
+
+	if err := s.UpsertReactionFingerprint(ctx, "ISS-2", "ci", "sha-abc"); err != nil {
+		t.Fatalf("UpsertReactionFingerprint (initial): %v", err)
+	}
+	if err := s.MarkReactionDispatched(ctx, "ISS-2", "ci"); err != nil {
+		t.Fatalf("MarkReactionDispatched: %v", err)
+	}
+
+	// Upsert same fingerprint again — dispatched must remain 1.
+	if err := s.UpsertReactionFingerprint(ctx, "ISS-2", "ci", "sha-abc"); err != nil {
+		t.Fatalf("UpsertReactionFingerprint (repeat): %v", err)
+	}
+
+	_, dispatched, err := s.GetReactionFingerprint(ctx, "ISS-2", "ci")
+	if err != nil {
+		t.Fatalf("GetReactionFingerprint: %v", err)
+	}
+	if !dispatched {
+		t.Error("GetReactionFingerprint() dispatched = false, want true (same fingerprint must not reset)")
+	}
+}
+
+func TestUpsertReactionFingerprint_ChangedFingerprintResetsDispatched(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	s := mustOpenStore(t)
+
+	if err := s.UpsertReactionFingerprint(ctx, "ISS-3", "ci", "sha-old"); err != nil {
+		t.Fatalf("UpsertReactionFingerprint (old): %v", err)
+	}
+	if err := s.MarkReactionDispatched(ctx, "ISS-3", "ci"); err != nil {
+		t.Fatalf("MarkReactionDispatched: %v", err)
+	}
+
+	// Upsert a different fingerprint — dispatched must be reset to 0.
+	if err := s.UpsertReactionFingerprint(ctx, "ISS-3", "ci", "sha-new"); err != nil {
+		t.Fatalf("UpsertReactionFingerprint (new): %v", err)
+	}
+
+	fp, dispatched, err := s.GetReactionFingerprint(ctx, "ISS-3", "ci")
+	if err != nil {
+		t.Fatalf("GetReactionFingerprint: %v", err)
+	}
+	if fp != "sha-new" {
+		t.Errorf("GetReactionFingerprint() fingerprint = %q, want %q", fp, "sha-new")
+	}
+	if dispatched {
+		t.Error("GetReactionFingerprint() dispatched = true, want false after fingerprint change")
+	}
+}
+
+func TestGetReactionFingerprint_Absent(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	s := mustOpenStore(t)
+
+	fp, dispatched, err := s.GetReactionFingerprint(ctx, "ISS-NOTHERE", "ci")
+	if err != nil {
+		t.Fatalf("GetReactionFingerprint: %v", err)
+	}
+	if fp != "" {
+		t.Errorf("GetReactionFingerprint() fingerprint = %q, want %q", fp, "")
+	}
+	if dispatched {
+		t.Error("GetReactionFingerprint() dispatched = true, want false for absent row")
+	}
+}
+
+func TestGetReactionFingerprint_AfterMarkDispatched(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	s := mustOpenStore(t)
+
+	if err := s.UpsertReactionFingerprint(ctx, "ISS-4", "ci", "sha-dispatched"); err != nil {
+		t.Fatalf("UpsertReactionFingerprint: %v", err)
+	}
+	if err := s.MarkReactionDispatched(ctx, "ISS-4", "ci"); err != nil {
+		t.Fatalf("MarkReactionDispatched: %v", err)
+	}
+
+	fp, dispatched, err := s.GetReactionFingerprint(ctx, "ISS-4", "ci")
+	if err != nil {
+		t.Fatalf("GetReactionFingerprint: %v", err)
+	}
+	if fp != "sha-dispatched" {
+		t.Errorf("GetReactionFingerprint() fingerprint = %q, want %q", fp, "sha-dispatched")
+	}
+	if !dispatched {
+		t.Error("GetReactionFingerprint() dispatched = false, want true after MarkReactionDispatched")
+	}
+}
+
+func TestMarkReactionDispatched_AbsentRow(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	s := mustOpenStore(t)
+
+	// MarkReactionDispatched on a non-existent row must be a no-op (not an error).
+	if err := s.MarkReactionDispatched(ctx, "ISS-NOTHERE", "ci"); err != nil {
+		t.Fatalf("MarkReactionDispatched on absent row returned error: %v", err)
+	}
+}
+
+func TestDeleteReactionFingerprint_RemovesRow(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	s := mustOpenStore(t)
+
+	if err := s.UpsertReactionFingerprint(ctx, "ISS-5", "ci", "sha-delete"); err != nil {
+		t.Fatalf("UpsertReactionFingerprint: %v", err)
+	}
+
+	if err := s.DeleteReactionFingerprint(ctx, "ISS-5", "ci"); err != nil {
+		t.Fatalf("DeleteReactionFingerprint: %v", err)
+	}
+
+	fp, dispatched, err := s.GetReactionFingerprint(ctx, "ISS-5", "ci")
+	if err != nil {
+		t.Fatalf("GetReactionFingerprint after delete: %v", err)
+	}
+	if fp != "" || dispatched {
+		t.Errorf("GetReactionFingerprint() = (%q, %v), want (%q, false) after delete", fp, dispatched, "")
+	}
+}
+
+func TestDeleteReactionFingerprintsByIssue_RemovesAllKinds(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	s := mustOpenStore(t)
+
+	const issueID = "ISS-6"
+
+	kinds := []string{"ci", "review_comments", "custom_kind"}
+	for _, kind := range kinds {
+		if err := s.UpsertReactionFingerprint(ctx, issueID, kind, "fp-"+kind); err != nil {
+			t.Fatalf("UpsertReactionFingerprint(%q): %v", kind, err)
+		}
+	}
+
+	// Also insert a row for a different issue to confirm it is not deleted.
+	if err := s.UpsertReactionFingerprint(ctx, "ISS-OTHER", "ci", "sha-other"); err != nil {
+		t.Fatalf("UpsertReactionFingerprint(ISS-OTHER): %v", err)
+	}
+
+	if err := s.DeleteReactionFingerprintsByIssue(ctx, issueID); err != nil {
+		t.Fatalf("DeleteReactionFingerprintsByIssue: %v", err)
+	}
+
+	for _, kind := range kinds {
+		fp, dispatched, err := s.GetReactionFingerprint(ctx, issueID, kind)
+		if err != nil {
+			t.Fatalf("GetReactionFingerprint(%q) after bulk delete: %v", kind, err)
+		}
+		if fp != "" || dispatched {
+			t.Errorf("GetReactionFingerprint(%q) = (%q, %v), want (%q, false) after bulk delete", kind, fp, dispatched, "")
+		}
+	}
+
+	// Unrelated issue row must be untouched.
+	fp, _, err := s.GetReactionFingerprint(ctx, "ISS-OTHER", "ci")
+	if err != nil {
+		t.Fatalf("GetReactionFingerprint(ISS-OTHER) after bulk delete: %v", err)
+	}
+	if fp != "sha-other" {
+		t.Errorf("GetReactionFingerprint(ISS-OTHER) = %q, want %q", fp, "sha-other")
+	}
+}
+
+func TestUpsertReactionFingerprint_MultipleKindsIndependent(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	s := mustOpenStore(t)
+
+	const issueID = "ISS-7"
+
+	if err := s.UpsertReactionFingerprint(ctx, issueID, "ci", "sha-ci"); err != nil {
+		t.Fatalf("UpsertReactionFingerprint(ci): %v", err)
+	}
+	if err := s.UpsertReactionFingerprint(ctx, issueID, "review_comments", "sha-review"); err != nil {
+		t.Fatalf("UpsertReactionFingerprint(review_comments): %v", err)
+	}
+	if err := s.MarkReactionDispatched(ctx, issueID, "ci"); err != nil {
+		t.Fatalf("MarkReactionDispatched(ci): %v", err)
+	}
+
+	_, ciDispatched, err := s.GetReactionFingerprint(ctx, issueID, "ci")
+	if err != nil {
+		t.Fatalf("GetReactionFingerprint(ci): %v", err)
+	}
+	_, reviewDispatched, err := s.GetReactionFingerprint(ctx, issueID, "review_comments")
+	if err != nil {
+		t.Fatalf("GetReactionFingerprint(review_comments): %v", err)
+	}
+
+	if !ciDispatched {
+		t.Error("GetReactionFingerprint(ci) dispatched = false, want true")
+	}
+	if reviewDispatched {
+		t.Error("GetReactionFingerprint(review_comments) dispatched = true, want false (independent of ci)")
+	}
+}

--- a/internal/persistence/sql/008_reaction_fingerprints.sql
+++ b/internal/persistence/sql/008_reaction_fingerprints.sql
@@ -1,0 +1,16 @@
+-- Migration 8: Cross-restart reaction deduplication
+--
+-- Tracks fingerprints for each (issue, reaction-kind) pair so the
+-- orchestrator can detect already-dispatched reactions after a restart.
+-- dispatched is 1 when a fix dispatch has been sent for this fingerprint,
+-- 0 when only recorded. Upserts reset dispatched to 0 when the
+-- fingerprint value changes.
+
+CREATE TABLE reaction_fingerprints (
+    issue_id    TEXT    NOT NULL,
+    kind        TEXT    NOT NULL,
+    fingerprint TEXT    NOT NULL,
+    dispatched  INTEGER NOT NULL DEFAULT 0,
+    updated_at  TEXT    NOT NULL,
+    PRIMARY KEY (issue_id, kind)
+);

--- a/internal/prompt/prompt.go
+++ b/internal/prompt/prompt.go
@@ -116,15 +116,42 @@ func Parse(body, source string, frontMatterLines int) (*Template, error) {
 }
 
 // RenderOption applies optional overrides to the template data map
-// before execution. Use [WithCIFailure] to inject CI failure context.
+// before execution. Use [WithContinuationContext] to inject reaction
+// continuation data.
 type RenderOption func(m map[string]any)
 
-// WithCIFailure returns a [RenderOption] that sets the "ci_failure"
-// template variable to the provided map. Pass nil to explicitly clear
-// (which is also the default when no option is supplied).
-func WithCIFailure(data map[string]any) RenderOption {
+// continuationKeys lists all template variable names reserved for
+// reaction continuation context. Each key receives a nil default in
+// [Template.Render] so templates using missingkey=error do not reject
+// references to absent reaction types.
+var continuationKeys = []string{"ci_failure"}
+
+// isContinuationKey reports whether key is a registered continuation
+// template variable name.
+func isContinuationKey(key string) bool {
+	for _, k := range continuationKeys {
+		if k == key {
+			return true
+		}
+	}
+	return false
+}
+
+// WithContinuationContext returns a [RenderOption] that merges each
+// key from data into the template data map. Keys must be registered
+// in [continuationKeys]; passing an unregistered key panics
+// (programmer error: the reaction kind must register its template key
+// before use).
+func WithContinuationContext(data map[string]any) RenderOption {
+	for k := range data {
+		if !isContinuationKey(k) {
+			panic(fmt.Sprintf("prompt: continuation key %q is not in continuationKeys whitelist", k))
+		}
+	}
 	return func(m map[string]any) {
-		m["ci_failure"] = data
+		for k, v := range data {
+			m[k] = v
+		}
 	}
 }
 
@@ -137,10 +164,12 @@ func WithCIFailure(data map[string]any) RenderOption {
 // with line numbers adjusted to WORKFLOW.md-relative positions.
 func (t *Template) Render(issue map[string]any, attempt any, run RunContext, opts ...RenderOption) (string, error) {
 	templateVars := map[string]any{
-		"issue":      issue,
-		"attempt":    attempt,
-		"run":        runContextToMap(run),
-		"ci_failure": nil,
+		"issue":   issue,
+		"attempt": attempt,
+		"run":     runContextToMap(run),
+	}
+	for _, k := range continuationKeys {
+		templateVars[k] = nil
 	}
 
 	for _, opt := range opts {

--- a/internal/prompt/prompt.go
+++ b/internal/prompt/prompt.go
@@ -157,9 +157,10 @@ func WithContinuationContext(data map[string]any) RenderOption {
 
 // Render executes the template with the given inputs and returns the
 // rendered prompt string. The data map contains the top-level keys
-// "issue", "attempt", "run", and "ci_failure". The ci_failure key
-// defaults to nil when no [RenderOption] overrides it, ensuring
-// missingkey=error does not reject templates that reference the field.
+// "issue", "attempt", and "run", plus every key in [continuationKeys]
+// (currently "ci_failure"). Continuation keys default to nil when no
+// [RenderOption] overrides them, ensuring missingkey=error does not
+// reject templates that reference these fields.
 // Returns a [*TemplateError] with Kind [ErrTemplateRender] on failure,
 // with line numbers adjusted to WORKFLOW.md-relative positions.
 func (t *Template) Render(issue map[string]any, attempt any, run RunContext, opts ...RenderOption) (string, error) {

--- a/internal/prompt/prompt_test.go
+++ b/internal/prompt/prompt_test.go
@@ -481,7 +481,19 @@ func TestRender_Concurrent(t *testing.T) {
 	wg.Wait()
 }
 
-func TestRender_WithCIFailure(t *testing.T) {
+func TestWithContinuationContext_UnregisteredKeyPanics(t *testing.T) {
+	t.Parallel()
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("WithContinuationContext with unregistered key did not panic; want panic")
+		}
+	}()
+
+	WithContinuationContext(map[string]any{"unregistered_key": "value"})
+}
+
+func TestRender_WithContinuationContext(t *testing.T) {
 	t.Parallel()
 
 	t.Run("DefaultNil_NoError", func(t *testing.T) {
@@ -501,7 +513,7 @@ func TestRender_WithCIFailure(t *testing.T) {
 		}
 	})
 
-	t.Run("WithCIFailure_nil_Falsy", func(t *testing.T) {
+	t.Run("WithContinuationContext_nil_Falsy", func(t *testing.T) {
 		t.Parallel()
 		tmpl, err := Parse(`{{ if .ci_failure }}FAIL{{ end }}`, "WORKFLOW.md", 0)
 		if err != nil {
@@ -510,17 +522,17 @@ func TestRender_WithCIFailure(t *testing.T) {
 		got, err := tmpl.Render(
 			map[string]any{"title": "t"}, nil,
 			RunContext{TurnNumber: 1, MaxTurns: 5},
-			WithCIFailure(nil),
+			WithContinuationContext(map[string]any{"ci_failure": nil}),
 		)
 		if err != nil {
-			t.Fatalf("render with WithCIFailure(nil): %v", err)
+			t.Fatalf("render with WithContinuationContext(ci_failure=nil): %v", err)
 		}
 		if got != "" {
-			t.Errorf("rendered %q, want empty string when WithCIFailure(nil)", got)
+			t.Errorf("rendered %q, want empty string when WithContinuationContext(ci_failure=nil)", got)
 		}
 	})
 
-	t.Run("WithCIFailure_map_Truthy", func(t *testing.T) {
+	t.Run("WithContinuationContext_map_Truthy", func(t *testing.T) {
 		t.Parallel()
 		tmpl, err := Parse(
 			`{{ if .ci_failure }}{{ index .ci_failure "status" }}{{ end }}`,
@@ -532,7 +544,7 @@ func TestRender_WithCIFailure(t *testing.T) {
 		got, err := tmpl.Render(
 			map[string]any{"title": "t"}, nil,
 			RunContext{TurnNumber: 1, MaxTurns: 5},
-			WithCIFailure(map[string]any{"status": "failing"}),
+			WithContinuationContext(map[string]any{"ci_failure": map[string]any{"status": "failing"}}),
 		)
 		if err != nil {
 			t.Fatalf("render with ci_failure map: %v", err)
@@ -554,7 +566,7 @@ func TestRender_WithCIFailure(t *testing.T) {
 		got, err := BuildTurnPrompt(
 			tmpl,
 			map[string]any{"title": "t"}, nil, 1, 5,
-			WithCIFailure(map[string]any{"count": 3}),
+			WithContinuationContext(map[string]any{"ci_failure": map[string]any{"count": 3}}),
 		)
 		if err != nil {
 			t.Fatalf("BuildTurnPrompt: %v", err)


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Refactor

**Intent:** Extract shared reaction primitives from CI-specific structures so that upcoming reaction types (review comment routing, merge conflict detection, auto-merge) build on a clean foundation rather than copying CI-specific fields, maps, and context keys for each new consumer.

**Related Issues:** #414

### 🧭 Reviewer Guide

**Complexity:** High

#### Entry Point

`internal/orchestrator/state.go` — defines the renamed and generalized types (`PendingReaction`, `ReactionAttempts`, `WithContinuationContext`/`ContinuationFromContext`, `ClearReactionsForIssue`, `ReactionKey`, `ReactionKindCI`). All other changed files flow from these definitions.

#### Sensitive Areas

- `internal/orchestrator/state.go`: core state structure; `PendingCICheck`/`CIFixAttempts` replaced by `PendingReactions`/`ReactionAttempts` keyed by `issueID:kind` — verify initialisation in `NewState` and cleanup in `ClearReactionsForIssue`
- `internal/orchestrator/exit.go`: populates `PendingReactions` on normal worker exit; was `PendingCICheck`
- `internal/orchestrator/dispatch.go`: reads `ContinuationContext` from `RetryEntry` and injects via `WithContinuationContext`; was `CIFailureContext`/`WithCIFailureContext`
- `internal/orchestrator/ci_reconcile.go`: updated to write into `PendingReactions` and `ReactionAttempts`; CI-specific fields (`Branch`, `SHA`) moved into the `CIDetail` sub-struct embedded on `PendingReaction`
- `internal/persistence/reaction_fingerprints.go`: new SQLite-backed store for cross-restart deduplication (migration 8)
- `internal/config/config.go`: new `ReactionConfig` struct and `reactions` map in `ServiceConfig`; `CIFeedbackConfig` is unchanged for backward compatibility

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes — all existing CI feedback behaviour is preserved; only internal field and function names changed
- **Migrations/State:** Migration 8 adds the `reaction_fingerprints` table; runs automatically on startup with no manual steps