### PR TITLE
fix(orchestrator): move MarkReactionDispatched to actual dispatch site

### DIFF
--- a/internal/orchestrator/ci_reconcile.go
+++ b/internal/orchestrator/ci_reconcile.go
@@ -238,14 +238,9 @@ func handleCIFailure(
 		ContinuationContext: map[string]any{
 			"ci_failure": ciContext,
 		},
+		ReactionKind: ReactionKindCI,
 	}, params.OnRetryFire)
 	metrics.IncRetries(triggerCIFix)
-
-	if err := params.Store.MarkReactionDispatched(ctx, pending.IssueID, ReactionKindCI); err != nil {
-		log.Warn("failed to mark reaction fingerprint dispatched",
-			slog.Any("error", err),
-		)
-	}
 
 	log.Info("CI failure detected, scheduling CI fix dispatch",
 		slog.String("ref", ref),

--- a/internal/orchestrator/ci_reconcile_test.go
+++ b/internal/orchestrator/ci_reconcile_test.go
@@ -1101,9 +1101,10 @@ func TestReconcileCIStatus_FingerprintGetError_Continues(t *testing.T) {
 	}
 }
 
-// TestReconcileCIStatus_Failing_MarksDispatched verifies that after scheduling
-// a CI-fix retry, MarkReactionDispatched is called.
-func TestReconcileCIStatus_Failing_MarksDispatched(t *testing.T) {
+// TestReconcileCIStatus_Failing_DoesNotMarkDispatched verifies that
+// handleCIFailure no longer calls MarkReactionDispatched at schedule time.
+// The mark is deferred to HandleRetryTimer after actual dispatch.
+func TestReconcileCIStatus_Failing_DoesNotMarkDispatched(t *testing.T) {
 	t.Parallel()
 
 	// ReactionAttempts=0 → under maxRetries=2, so handleCIFailure schedules retry.
@@ -1115,10 +1116,11 @@ func TestReconcileCIStatus_Failing_MarksDispatched(t *testing.T) {
 
 	reconcileCIStatus(state, params, discardLogger(), context.Background(), metrics)
 
-	if store.markDispatchedCalls != 1 {
-		t.Errorf("MarkReactionDispatched calls = %d, want 1 after CI failure dispatch", store.markDispatchedCalls)
+	// MarkReactionDispatched must NOT be called at schedule time.
+	if store.markDispatchedCalls != 0 {
+		t.Errorf("MarkReactionDispatched calls = %d, want 0 (mark deferred to dispatch site)", store.markDispatchedCalls)
 	}
-	// Retry must have been scheduled.
+	// Retry must still be scheduled.
 	if _, ok := state.RetryAttempts["ISS-FP-5"]; !ok {
 		t.Error("retry not scheduled after CI failure; want scheduled")
 	}

--- a/internal/orchestrator/dispatch.go
+++ b/internal/orchestrator/dispatch.go
@@ -230,6 +230,11 @@ type ScheduleRetryParams struct {
 	// into the prompt template on the first turn of the retry worker.
 	// Nil for non-reaction retries.
 	ContinuationContext map[string]any
+
+	// ReactionKind is the reaction type that triggered this retry.
+	// Propagated to [RetryEntry.ReactionKind]. Empty for non-reaction
+	// retries.
+	ReactionKind string
 }
 
 // ScheduleRetry cancels any existing retry for the issue, creates a new
@@ -271,6 +276,7 @@ func ScheduleRetry(state *State, params ScheduleRetryParams, onFire func(issueID
 		TimerHandle:         timer,
 		LastSSHHost:         params.LastSSHHost,
 		ContinuationContext: params.ContinuationContext,
+		ReactionKind:        params.ReactionKind,
 		scheduledAt:         time.Now(),
 		scheduledDelayMS:    delayMS,
 	}

--- a/internal/orchestrator/retry.go
+++ b/internal/orchestrator/retry.go
@@ -18,6 +18,7 @@ type RetryTimerStore interface {
 	SaveRetryEntry(ctx context.Context, entry persistence.RetryEntry) error
 	DeleteRetryEntry(ctx context.Context, issueID string) error
 	CountRunHistoryByIssue(ctx context.Context, issueID string) (int, error)
+	MarkReactionDispatched(ctx context.Context, issueID, kind string) error
 }
 
 // HandleRetryTimerParams holds the dependencies for [HandleRetryTimer]
@@ -140,12 +141,13 @@ func HandleRetryTimer(state *State, issueID string, params HandleRetryTimerParam
 			slog.Int("attempt", popped.Attempt),
 		)
 		ScheduleRetry(state, ScheduleRetryParams{
-			IssueID:    issueID,
-			Identifier: popped.Identifier,
-			DisplayID:  popped.DisplayID,
-			Attempt:    popped.Attempt,
-			DelayMS:    delayMS,
-			Error:      popped.Error,
+			IssueID:      issueID,
+			Identifier:   popped.Identifier,
+			DisplayID:    popped.DisplayID,
+			Attempt:      popped.Attempt,
+			DelayMS:      delayMS,
+			Error:        popped.Error,
+			ReactionKind: popped.ReactionKind,
 		}, params.OnRetryFire)
 		persistRetryEntry(ctx, log, params.Store, state, issueID)
 		metrics.IncRetries(triggerTimer)
@@ -190,12 +192,13 @@ func HandleRetryTimer(state *State, issueID string, params HandleRetryTimerParam
 		)
 
 		ScheduleRetry(state, ScheduleRetryParams{
-			IssueID:    issueID,
-			Identifier: popped.Identifier,
-			DisplayID:  popped.DisplayID,
-			Attempt:    nextAttempt,
-			DelayMS:    delayMS,
-			Error:      "retry poll failed",
+			IssueID:      issueID,
+			Identifier:   popped.Identifier,
+			DisplayID:    popped.DisplayID,
+			Attempt:      nextAttempt,
+			DelayMS:      delayMS,
+			Error:        "retry poll failed",
+			ReactionKind: popped.ReactionKind,
 		}, params.OnRetryFire)
 
 		persistRetryEntry(ctx, log, params.Store, state, issueID)
@@ -251,12 +254,13 @@ func HandleRetryTimer(state *State, issueID string, params HandleRetryTimerParam
 		)
 
 		ScheduleRetry(state, ScheduleRetryParams{
-			IssueID:    issueID,
-			Identifier: popped.Identifier,
-			DisplayID:  popped.DisplayID,
-			Attempt:    nextAttempt,
-			DelayMS:    delayMS,
-			Error:      "no available orchestrator slots",
+			IssueID:      issueID,
+			Identifier:   popped.Identifier,
+			DisplayID:    popped.DisplayID,
+			Attempt:      nextAttempt,
+			DelayMS:      delayMS,
+			Error:        "no available orchestrator slots",
+			ReactionKind: popped.ReactionKind,
 		}, params.OnRetryFire)
 
 		persistRetryEntry(ctx, log, params.Store, state, issueID)
@@ -279,12 +283,13 @@ func HandleRetryTimer(state *State, issueID string, params HandleRetryTimerParam
 			)
 
 			ScheduleRetry(state, ScheduleRetryParams{
-				IssueID:    issueID,
-				Identifier: popped.Identifier,
-				DisplayID:  popped.DisplayID,
-				Attempt:    nextAttempt,
-				DelayMS:    delayMS,
-				Error:      "no available SSH hosts",
+				IssueID:      issueID,
+				Identifier:   popped.Identifier,
+				DisplayID:    popped.DisplayID,
+				Attempt:      nextAttempt,
+				DelayMS:      delayMS,
+				Error:        "no available SSH hosts",
+				ReactionKind: popped.ReactionKind,
 			}, params.OnRetryFire)
 
 			persistRetryEntry(ctx, log, params.Store, state, issueID)
@@ -311,6 +316,18 @@ func HandleRetryTimer(state *State, issueID string, params HandleRetryTimerParam
 		entry.ContinuationContext = popped.ContinuationContext
 	}
 	metrics.IncDispatches(outcomeSuccess)
+
+	// Mark the reaction fingerprint dispatched only after actual dispatch
+	// succeeds. Scoped to reaction-triggered retries; non-reaction retries
+	// have no fingerprint row to update.
+	if popped.ReactionKind != "" {
+		if err := params.Store.MarkReactionDispatched(ctx, issueID, popped.ReactionKind); err != nil {
+			log.Warn("failed to mark reaction dispatched after retry dispatch",
+				slog.String("kind", popped.ReactionKind),
+				slog.Any("error", err),
+			)
+		}
+	}
 
 	log.Info("retried issue dispatched",
 		slog.Int("attempt", attempt),

--- a/internal/orchestrator/retry_test.go
+++ b/internal/orchestrator/retry_test.go
@@ -23,6 +23,11 @@ type mockRetryStore struct {
 	runHistoryCount           int
 	countRunHistoryByIssueErr error
 	countedIssueIDs           []string
+
+	markDispatchedCalls   int
+	markDispatchedIssueID string
+	markDispatchedKind    string
+	markDispatchedErr     error
 }
 
 var _ RetryTimerStore = (*mockRetryStore)(nil)
@@ -58,8 +63,11 @@ func (m *mockRetryStore) GetReactionFingerprint(_ context.Context, _, _ string) 
 	return "", false, nil
 }
 
-func (m *mockRetryStore) MarkReactionDispatched(_ context.Context, _, _ string) error {
-	return nil
+func (m *mockRetryStore) MarkReactionDispatched(_ context.Context, issueID, kind string) error {
+	m.markDispatchedCalls++
+	m.markDispatchedIssueID = issueID
+	m.markDispatchedKind = kind
+	return m.markDispatchedErr
 }
 
 func (m *mockRetryStore) DeleteReactionFingerprint(_ context.Context, _, _ string) error {
@@ -1343,5 +1351,159 @@ func TestHandleRetryTimer_NilContinuationContext_NotPropagated(t *testing.T) {
 	}
 	if entry.ContinuationContext != nil {
 		t.Errorf("RunningEntry.ContinuationContext = %v, want nil", entry.ContinuationContext)
+	}
+}
+
+func TestHandleRetryTimer_ContinuationDispatch_MarksReactionDispatched(t *testing.T) {
+	t.Parallel()
+
+	// A retry entry carrying ReactionKindCI must call MarkReactionDispatched
+	// after successful dispatch, recording the correct issue ID and kind.
+	const id = "ISS-CI-1"
+
+	state := NewState(5000, 4, nil, AgentTotals{})
+	state.Claimed[id] = struct{}{}
+	state.RetryAttempts[id] = &RetryEntry{
+		IssueID:             id,
+		Identifier:          id,
+		Attempt:             1,
+		ReactionKind:        ReactionKindCI,
+		ContinuationContext: map[string]any{"ci_failure": map[string]any{}},
+	}
+
+	store := &mockRetryStore{}
+	tracker := &mockRetryTracker{
+		candidates: []domain.Issue{candidateIssue(id, id, "In Progress")},
+	}
+	params := defaultRetryParams(t, store, tracker)
+
+	HandleRetryTimer(state, id, params)
+	t.Cleanup(func() { state.WorkerWg.Wait() })
+
+	if store.markDispatchedCalls != 1 {
+		t.Errorf("MarkReactionDispatched calls = %d, want 1", store.markDispatchedCalls)
+	}
+	if store.markDispatchedIssueID != id {
+		t.Errorf("MarkReactionDispatched issueID = %q, want %q", store.markDispatchedIssueID, id)
+	}
+	if store.markDispatchedKind != ReactionKindCI {
+		t.Errorf("MarkReactionDispatched kind = %q, want %q", store.markDispatchedKind, ReactionKindCI)
+	}
+	if _, ok := state.Running[id]; !ok {
+		t.Errorf("Running[%s] missing after dispatch, want present", id)
+	}
+}
+
+func TestHandleRetryTimer_NonReactionRetry_DoesNotMarkDispatched(t *testing.T) {
+	t.Parallel()
+
+	// A retry entry with empty ReactionKind (normal error retry) must not
+	// call MarkReactionDispatched even when dispatch succeeds.
+	const id = "ISS-ERR-1"
+
+	state := NewState(5000, 4, nil, AgentTotals{})
+	state.Claimed[id] = struct{}{}
+	state.RetryAttempts[id] = &RetryEntry{
+		IssueID:    id,
+		Identifier: id,
+		Attempt:    2,
+		// ReactionKind is intentionally empty — normal error retry.
+	}
+
+	store := &mockRetryStore{}
+	tracker := &mockRetryTracker{
+		candidates: []domain.Issue{candidateIssue(id, id, "To Do")},
+	}
+	params := defaultRetryParams(t, store, tracker)
+
+	HandleRetryTimer(state, id, params)
+	t.Cleanup(func() { state.WorkerWg.Wait() })
+
+	if store.markDispatchedCalls != 0 {
+		t.Errorf("MarkReactionDispatched calls = %d, want 0 for non-reaction retry", store.markDispatchedCalls)
+	}
+	if _, ok := state.Running[id]; !ok {
+		t.Errorf("Running[%s] missing after dispatch, want present", id)
+	}
+}
+
+func TestHandleRetryTimer_ReschedulePreservesReactionKind(t *testing.T) {
+	t.Parallel()
+
+	// When the running-guard triggers a reschedule (worker still active),
+	// ReactionKind must be preserved on the rescheduled entry so that the
+	// eventual dispatch can call MarkReactionDispatched.
+	const id = "ISS-CI-2"
+
+	state := NewState(5000, 4, nil, AgentTotals{})
+	state.Claimed[id] = struct{}{}
+	state.RetryAttempts[id] = &RetryEntry{
+		IssueID:      id,
+		Identifier:   id,
+		Attempt:      1,
+		ReactionKind: ReactionKindCI,
+	}
+	// Place issue in Running to trigger the running-guard reschedule path.
+	state.Running[id] = &RunningEntry{
+		Identifier: id,
+		Issue:      candidateIssue(id, id, "In Progress"),
+		StartedAt:  time.Now().UTC(),
+	}
+
+	store := &mockRetryStore{}
+	tracker := &mockRetryTracker{}
+	params := defaultRetryParams(t, store, tracker)
+
+	HandleRetryTimer(state, id, params)
+
+	if store.markDispatchedCalls != 0 {
+		t.Errorf("MarkReactionDispatched calls = %d, want 0 (reschedule, no dispatch)", store.markDispatchedCalls)
+	}
+
+	entry, ok := state.RetryAttempts[id]
+	if !ok {
+		t.Fatal("RetryAttempts[ISS-CI-2] missing, want rescheduled")
+	}
+	if entry.ReactionKind != ReactionKindCI {
+		t.Errorf("rescheduled RetryAttempts[%s].ReactionKind = %q, want %q", id, entry.ReactionKind, ReactionKindCI)
+	}
+	if entry.TimerHandle != nil {
+		entry.TimerHandle.Stop()
+	}
+}
+
+func TestHandleRetryTimer_ContinuationMarkDispatchedError(t *testing.T) {
+	t.Parallel()
+
+	// When MarkReactionDispatched returns an error, the dispatch is not
+	// rolled back — the issue remains in Running and the error is non-fatal.
+	const id = "ISS-CI-3"
+
+	state := NewState(5000, 4, nil, AgentTotals{})
+	state.Claimed[id] = struct{}{}
+	state.RetryAttempts[id] = &RetryEntry{
+		IssueID:             id,
+		Identifier:          id,
+		Attempt:             1,
+		ReactionKind:        ReactionKindCI,
+		ContinuationContext: map[string]any{"ci_failure": map[string]any{}},
+	}
+
+	store := &mockRetryStore{markDispatchedErr: errors.New("db locked")}
+	tracker := &mockRetryTracker{
+		candidates: []domain.Issue{candidateIssue(id, id, "In Progress")},
+	}
+	params := defaultRetryParams(t, store, tracker)
+
+	HandleRetryTimer(state, id, params)
+	t.Cleanup(func() { state.WorkerWg.Wait() })
+
+	// Attempt was made despite the error.
+	if store.markDispatchedCalls != 1 {
+		t.Errorf("MarkReactionDispatched calls = %d, want 1", store.markDispatchedCalls)
+	}
+	// Dispatch was not rolled back — issue still running.
+	if _, ok := state.Running[id]; !ok {
+		t.Errorf("Running[%s] missing after dispatch, want present (error is non-fatal)", id)
 	}
 }

--- a/internal/orchestrator/retry_test.go
+++ b/internal/orchestrator/retry_test.go
@@ -309,7 +309,9 @@ func TestHandleRetryTimer(t *testing.T) {
 			issueID: "ISS-2",
 			state: func(t *testing.T, id string) *State {
 				t.Helper()
-				return retryState(t, id, id, 2)
+				state := retryState(t, id, id, 2)
+				state.RetryAttempts[id].ReactionKind = ReactionKindCI
+				return state
 			},
 			store: func() *mockRetryStore { return &mockRetryStore{} },
 			tracker: func(_ string) *mockRetryTracker {
@@ -358,6 +360,10 @@ func TestHandleRetryTimer(t *testing.T) {
 				if len(store.deletedIssueID) != 0 {
 					t.Errorf("DeleteRetryEntry call count = %d, want 0", len(store.deletedIssueID))
 				}
+				// ReactionKind preserved across reschedule.
+				if entry.ReactionKind != ReactionKindCI {
+					t.Errorf("RetryAttempts[%s].ReactionKind = %q, want %q", id, entry.ReactionKind, ReactionKindCI)
+				}
 			},
 		},
 		{
@@ -402,6 +408,7 @@ func TestHandleRetryTimer(t *testing.T) {
 			state: func(t *testing.T, id string) *State {
 				t.Helper()
 				state := retryState(t, id, id, 1)
+				state.RetryAttempts[id].ReactionKind = ReactionKindCI
 				// Fill the single slot with another running issue.
 				state.MaxConcurrentAgents = 1
 				state.Running["OTHER-1"] = &RunningEntry{
@@ -449,6 +456,10 @@ func TestHandleRetryTimer(t *testing.T) {
 				}
 				if store.savedEntries[0].Attempt != 2 {
 					t.Errorf("saved entry Attempt = %d, want 2", store.savedEntries[0].Attempt)
+				}
+				// ReactionKind preserved across reschedule.
+				if entry.ReactionKind != ReactionKindCI {
+					t.Errorf("RetryAttempts[%s].ReactionKind = %q, want %q", id, entry.ReactionKind, ReactionKindCI)
 				}
 			},
 		},
@@ -1048,6 +1059,7 @@ func TestHandleRetryTimer_SSHHostAcquisition(t *testing.T) {
 		}
 
 		state := retryState(t, "ISS-FULL", "ISS-FULL", 1)
+		state.RetryAttempts["ISS-FULL"].ReactionKind = ReactionKindCI
 		params := defaultRetryParams(t, store, tracker)
 		params.HostPool = hp
 
@@ -1068,6 +1080,10 @@ func TestHandleRetryTimer_SSHHostAcquisition(t *testing.T) {
 		}
 		if entry.Error != "no available SSH hosts" {
 			t.Errorf("rescheduled Error = %q, want %q", entry.Error, "no available SSH hosts")
+		}
+		// ReactionKind preserved across reschedule.
+		if entry.ReactionKind != ReactionKindCI {
+			t.Errorf("rescheduled ReactionKind = %q, want %q", entry.ReactionKind, ReactionKindCI)
 		}
 		if entry.TimerHandle != nil {
 			entry.TimerHandle.Stop()

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -247,6 +247,12 @@ type RetryEntry struct {
 	// reconcile functions when scheduling a continuation retry. Nil for
 	// non-reaction retries.
 	ContinuationContext map[string]any
+
+	// ReactionKind is the reaction type that triggered this retry (e.g.
+	// ReactionKindCI). Empty for non-reaction retries. When non-empty,
+	// HandleRetryTimer calls MarkReactionDispatched after successful
+	// dispatch. Runtime-only (not persisted to SQLite).
+	ReactionKind string
 }
 
 // ReactionKindCI is the reaction kind constant for CI failure reactions.


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Fix

**Intent:** `MarkReactionDispatched` was called in `handleCIFailure` immediately after `ScheduleRetry`, before the retry timer fired. If the process restarted in that window, the in-memory `RetryEntry` was lost while `reaction_fingerprints.dispatched` stayed `1`, permanently silencing future CI-fix reactions for that SHA. This fix moves the call to `HandleRetryTimer`, after `DispatchIssue` succeeds, so `dispatched` reflects actual dispatch rather than scheduled intent.

**Related Issues:** #420

### 🧭 Reviewer Guide

**Complexity:** Medium

#### Entry Point

Start with `internal/orchestrator/retry.go` — `HandleRetryTimer` is where the mark now lives. The `MarkReactionDispatched` call sits after `metrics.IncDispatches(outcomeSuccess)`, gated on `popped.ReactionKind != ""`. The four reschedule paths (running guard, fetch failure, slot exhaustion, SSH host exhaustion) each propagate `ReactionKind: popped.ReactionKind` to preserve the kind across reschedules.

#### Sensitive Areas

- `internal/orchestrator/retry.go`: All four `ScheduleRetry` reschedule sites inside `HandleRetryTimer` must carry `ReactionKind` forward — a missed site silently loses the kind and skips the eventual mark.
- `internal/orchestrator/ci_reconcile.go`: The removed `MarkReactionDispatched` block must be absent; the compensating `ReactionKind: ReactionKindCI` field must be present on the `ScheduleRetryParams` literal.
- `internal/orchestrator/state.go` / `internal/orchestrator/dispatch.go`: `ReactionKind` is runtime-only — not persisted to SQLite. The reconcile loop self-heals on restart via the existing `PendingReaction` path.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes — `RetryTimerStore` is an internal interface in `internal/orchestrator`; no external consumers.
- **Migrations/State:** No schema changes. `reaction_fingerprints` table and its SQL are unchanged. `ReactionKind` is not added to the `retry_entries` table.