### PR TITLE
feat(config): migrate ci_failure into reactions.ci_failure unified block

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,6 +4,20 @@
     "**/CODEOWNERS": "plaintext"
   },
 
+  // ── Explorer: File Nesting ──────────────────────────────────────────────────
+  // Collapses related artifacts under their logical parent in the sidebar,
+  // reducing visual noise without hiding anything from the file system.
+  "explorer.fileNesting.enabled": true,
+  "explorer.fileNesting.expand": false,
+  "explorer.fileNesting.patterns": {
+    "*.go": "${capture}_test.go, ${capture}_integration_test.go",
+    "go.mod": "go.sum",
+    "codecov.yml": "coverage.html, coverage.json, coverage.xml, coverage.out",
+    ".env": ".env, .env.*",
+    "Dockerfile": "Dockerfile, compose.yml, docker-compose.yml, .dockerignore",
+    "AGENTS.md": "AGENTS.md, CLAUDE.md"
+  },
+
   // ── GitHub Copilot Custom Instructions ─────────────────────────────────────
   // Custom instruction files for code review for the current selection.
   // See: https://code.visualstudio.com/docs/copilot/customization/custom-instructions

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,10 +12,10 @@
   "explorer.fileNesting.patterns": {
     "*.go": "${capture}_test.go, ${capture}_integration_test.go",
     "go.mod": "go.sum",
-    "codecov.yml": "coverage.html, coverage.json, coverage.xml, coverage.out",
-    ".env": ".env, .env.*",
-    "Dockerfile": "Dockerfile, compose.yml, docker-compose.yml, .dockerignore",
-    "AGENTS.md": "AGENTS.md, CLAUDE.md"
+    "codecov.yml": "coverage.*",
+    ".env": ".env.*",
+    "Dockerfile": "compose.yml, docker-compose.yml, .dockerignore",
+    "AGENTS.md": "CLAUDE.md"
   },
 
   // ── GitHub Copilot Custom Instructions ─────────────────────────────────────

--- a/cmd/sortie/closer_test.go
+++ b/cmd/sortie/closer_test.go
@@ -188,7 +188,7 @@ func TestRunAdapterCloseNotCalledForNonClosers(t *testing.T) {
 	wfPath := setupRunDir(t)
 
 	var stdout, stderr bytes.Buffer
-	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), runTestTimeout)
 	defer cancel()
 
 	code := run(ctx, []string{wfPath}, &stdout, &stderr)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,6 +6,7 @@ package config
 
 import (
 	"fmt"
+	"log/slog"
 	"math"
 	"os"
 	"path/filepath"
@@ -35,8 +36,9 @@ type ServiceConfig struct {
 
 	// Reactions maps reaction kind to its configuration. An empty map
 	// means no reactions are configured. Keys are lowercase kind strings
-	// (e.g. "review_comments"). The existing ci_feedback section is not
-	// represented here; CI configuration uses the CIFeedback field.
+	// (e.g. "review_comments"). The "ci_failure" key, if present in
+	// YAML, is consumed into the CIFeedback field and removed from this
+	// map.
 	Reactions map[string]ReactionConfig
 
 	// DBPath is the environment- and tilde-expanded path for the SQLite
@@ -246,6 +248,8 @@ func NewServiceConfig(raw map[string]any) (ServiceConfig, error) {
 		return ServiceConfig{}, err
 	}
 
+	hasCIFeedbackSection := raw["ci_feedback"] != nil
+
 	selfReview, err := buildSelfReviewConfig(extractSubMap(raw, "self_review"))
 	if err != nil {
 		return ServiceConfig{}, err
@@ -254,6 +258,18 @@ func NewServiceConfig(raw map[string]any) (ServiceConfig, error) {
 	reactions, err := buildReactionsConfig(extractSubMap(raw, "reactions"))
 	if err != nil {
 		return ServiceConfig{}, err
+	}
+
+	if ciReaction, ok := reactions["ci_failure"]; ok {
+		ciFeedback, err = populateCIFeedbackFromReactions(ciReaction)
+		if err != nil {
+			return ServiceConfig{}, err
+		}
+		if hasCIFeedbackSection {
+			slog.Warn("ci_feedback section is deprecated; using reactions.ci_failure instead",
+				slog.String("hint", "remove the ci_feedback section from your WORKFLOW.md"))
+		}
+		delete(reactions, "ci_failure")
 	}
 
 	extensions := make(map[string]any)
@@ -546,6 +562,43 @@ func buildCIFeedbackConfig(m map[string]any) (CIFeedbackConfig, error) {
 		MaxLogLines:     maxLogLines,
 		Escalation:      escalation,
 		EscalationLabel: escalationLabel,
+	}, nil
+}
+
+// populateCIFeedbackFromReactions converts a ReactionConfig for the
+// "ci_failure" reaction kind into a CIFeedbackConfig. Provider maps to
+// Kind, MaxRetries/Escalation/EscalationLabel pass through directly,
+// and MaxLogLines is read from Extra["max_log_lines"] with a default
+// of 50. An empty Provider returns a zero CIFeedbackConfig (CI disabled).
+func populateCIFeedbackFromReactions(rc ReactionConfig) (CIFeedbackConfig, error) {
+	if rc.Provider == "" {
+		return CIFeedbackConfig{}, nil
+	}
+
+	maxLogLines := 50
+	if raw, ok := rc.Extra["max_log_lines"]; ok && raw != nil {
+		parsed, err := coerceInt(raw)
+		if err != nil {
+			return CIFeedbackConfig{}, &ConfigError{
+				Field:   "reactions.ci_failure.max_log_lines",
+				Message: fmt.Sprintf("invalid integer value: %v", raw),
+			}
+		}
+		maxLogLines = parsed
+	}
+	if maxLogLines < 0 {
+		return CIFeedbackConfig{}, &ConfigError{
+			Field:   "reactions.ci_failure.max_log_lines",
+			Message: "must be non-negative",
+		}
+	}
+
+	return CIFeedbackConfig{
+		Kind:            rc.Provider,
+		MaxRetries:      rc.MaxRetries,
+		MaxLogLines:     maxLogLines,
+		Escalation:      rc.Escalation,
+		EscalationLabel: rc.EscalationLabel,
 	}, nil
 }
 
@@ -932,6 +985,12 @@ type CIFeedbackConfig struct {
 
 // ReactionConfig holds per-kind configuration for a single reaction type.
 type ReactionConfig struct {
+	// Provider identifies the external system adapter for this reaction
+	// kind (e.g. "github-actions" for CI failure reactions). Empty string
+	// means no provider is configured and the reaction is disabled for
+	// provider-dependent kinds.
+	Provider string
+
 	// MaxRetries is the maximum number of fix continuation dispatches
 	// per issue before escalation. Default: 2.
 	MaxRetries int
@@ -956,6 +1015,7 @@ var reactionKeyPattern = regexp.MustCompile(`^[a-z][a-z0-9_-]*$`)
 // knownReactionFields enumerates keys consumed by buildReactionsConfig
 // per-kind parsing. Anything else is collected into Extra.
 var knownReactionFields = map[string]bool{
+	"provider":         true,
 	"max_retries":      true,
 	"escalation":       true,
 	"escalation_label": true,
@@ -1024,7 +1084,10 @@ func buildReactionsConfig(m map[string]any) (map[string]ReactionConfig, error) {
 			}
 		}
 
+		provider := extractString(vm, "provider")
+
 		result[k] = ReactionConfig{
+			Provider:        provider,
 			MaxRetries:      maxRetries,
 			Escalation:      escalation,
 			EscalationLabel: escalationLabel,

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1577,3 +1577,325 @@ func TestNewServiceConfig_SelfReview(t *testing.T) {
 		}
 	})
 }
+
+// TestPopulateCIFeedbackFromReactions exercises the bridge function that
+// maps a ReactionConfig for the "ci_failure" kind into a CIFeedbackConfig.
+func TestPopulateCIFeedbackFromReactions(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		rc        ReactionConfig
+		want      CIFeedbackConfig
+		wantErr   bool
+		wantField string
+	}{
+		{
+			name: "ProviderMapsToKind",
+			rc: ReactionConfig{
+				Provider:        "github-actions",
+				MaxRetries:      2,
+				Escalation:      "label",
+				EscalationLabel: "needs-human",
+			},
+			want: CIFeedbackConfig{
+				Kind:            "github-actions",
+				MaxRetries:      2,
+				MaxLogLines:     50,
+				Escalation:      "label",
+				EscalationLabel: "needs-human",
+			},
+		},
+		{
+			name: "MaxLogLinesDefault",
+			rc: ReactionConfig{
+				Provider: "github-actions",
+				Extra:    nil,
+			},
+			want: CIFeedbackConfig{
+				Kind:        "github-actions",
+				MaxLogLines: 50,
+			},
+		},
+		{
+			name: "MaxLogLinesFromExtra",
+			rc: ReactionConfig{
+				Provider: "github-actions",
+				Extra:    map[string]any{"max_log_lines": 100},
+			},
+			want: CIFeedbackConfig{
+				Kind:        "github-actions",
+				MaxLogLines: 100,
+			},
+		},
+		{
+			name: "MaxLogLinesFromExtraFloat64",
+			rc: ReactionConfig{
+				Provider: "github",
+				Extra:    map[string]any{"max_log_lines": float64(200)},
+			},
+			want: CIFeedbackConfig{
+				Kind:        "github",
+				MaxLogLines: 200,
+			},
+		},
+		{
+			name: "MaxLogLinesNegative",
+			rc: ReactionConfig{
+				Provider: "github-actions",
+				Extra:    map[string]any{"max_log_lines": -1},
+			},
+			wantErr:   true,
+			wantField: "reactions.ci_failure.max_log_lines",
+		},
+		{
+			name: "MaxLogLinesNonInteger",
+			rc: ReactionConfig{
+				Provider: "github-actions",
+				Extra:    map[string]any{"max_log_lines": "abc"},
+			},
+			wantErr:   true,
+			wantField: "reactions.ci_failure.max_log_lines",
+		},
+		{
+			name: "EmptyProviderReturnsZero",
+			rc:   ReactionConfig{Provider: ""},
+			want: CIFeedbackConfig{},
+		},
+		{
+			name: "EscalationAndLabelPassThrough",
+			rc: ReactionConfig{
+				Provider:        "circle-ci",
+				Escalation:      "comment",
+				EscalationLabel: "blocked",
+				MaxRetries:      5,
+			},
+			want: CIFeedbackConfig{
+				Kind:            "circle-ci",
+				MaxRetries:      5,
+				MaxLogLines:     50,
+				Escalation:      "comment",
+				EscalationLabel: "blocked",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := populateCIFeedbackFromReactions(tt.rc)
+
+			if tt.wantErr {
+				assertConfigErrorField(t, err, tt.wantField)
+				return
+			}
+			if err != nil {
+				t.Fatalf("populateCIFeedbackFromReactions() unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("populateCIFeedbackFromReactions() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestCIFailureMigration verifies the full precedence logic for the
+// reactions.ci_failure → CIFeedback migration path through NewServiceConfig.
+func TestCIFailureMigration(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Reactions/CIFailure/ProviderMapsToKind", func(t *testing.T) {
+		t.Parallel()
+		cfg, err := NewServiceConfig(map[string]any{
+			"reactions": map[string]any{
+				"ci_failure": map[string]any{
+					"provider": "github-actions",
+				},
+			},
+		})
+		if err != nil {
+			t.Fatalf("NewServiceConfig: %v", err)
+		}
+		assertStringEqual(t, "CIFeedback.Kind", "github-actions", cfg.CIFeedback.Kind)
+	})
+
+	t.Run("Reactions/CIFailure/MaxLogLinesFromExtra", func(t *testing.T) {
+		t.Parallel()
+		cfg, err := NewServiceConfig(map[string]any{
+			"reactions": map[string]any{
+				"ci_failure": map[string]any{
+					"provider":      "github-actions",
+					"max_log_lines": 100,
+				},
+			},
+		})
+		if err != nil {
+			t.Fatalf("NewServiceConfig: %v", err)
+		}
+		assertIntEqual(t, "CIFeedback.MaxLogLines", 100, cfg.CIFeedback.MaxLogLines)
+	})
+
+	t.Run("Reactions/CIFailure/MaxLogLinesDefault", func(t *testing.T) {
+		t.Parallel()
+		cfg, err := NewServiceConfig(map[string]any{
+			"reactions": map[string]any{
+				"ci_failure": map[string]any{
+					"provider": "github-actions",
+				},
+			},
+		})
+		if err != nil {
+			t.Fatalf("NewServiceConfig: %v", err)
+		}
+		assertIntEqual(t, "CIFeedback.MaxLogLines", 50, cfg.CIFeedback.MaxLogLines)
+	})
+
+	t.Run("Reactions/CIFailure/MaxLogLinesNegative", func(t *testing.T) {
+		t.Parallel()
+		_, err := NewServiceConfig(map[string]any{
+			"reactions": map[string]any{
+				"ci_failure": map[string]any{
+					"provider":      "github-actions",
+					"max_log_lines": -1,
+				},
+			},
+		})
+		assertConfigErrorField(t, err, "reactions.ci_failure.max_log_lines")
+	})
+
+	t.Run("Reactions/CIFailure/MaxLogLinesNonInteger", func(t *testing.T) {
+		t.Parallel()
+		_, err := NewServiceConfig(map[string]any{
+			"reactions": map[string]any{
+				"ci_failure": map[string]any{
+					"provider":      "github-actions",
+					"max_log_lines": "abc",
+				},
+			},
+		})
+		assertConfigErrorField(t, err, "reactions.ci_failure.max_log_lines")
+	})
+
+	t.Run("Reactions/CIFailure/RemovedFromReactionsMap", func(t *testing.T) {
+		t.Parallel()
+		cfg, err := NewServiceConfig(map[string]any{
+			"reactions": map[string]any{
+				"ci_failure": map[string]any{
+					"provider": "github-actions",
+				},
+			},
+		})
+		if err != nil {
+			t.Fatalf("NewServiceConfig: %v", err)
+		}
+		if _, ok := cfg.Reactions["ci_failure"]; ok {
+			t.Error("Reactions[\"ci_failure\"] still present; want removed after migration")
+		}
+	})
+
+	t.Run("Reactions/CIFailure/OtherReactionsPreserved", func(t *testing.T) {
+		t.Parallel()
+		cfg, err := NewServiceConfig(map[string]any{
+			"reactions": map[string]any{
+				"ci_failure": map[string]any{
+					"provider": "github-actions",
+				},
+				"review_comments": map[string]any{
+					"max_retries": 3,
+				},
+			},
+		})
+		if err != nil {
+			t.Fatalf("NewServiceConfig: %v", err)
+		}
+		if _, ok := cfg.Reactions["review_comments"]; !ok {
+			t.Error("Reactions[\"review_comments\"] missing; want preserved")
+		}
+	})
+
+	t.Run("Reactions/CIFailure/EmptyProvider", func(t *testing.T) {
+		t.Parallel()
+		cfg, err := NewServiceConfig(map[string]any{
+			"reactions": map[string]any{
+				"ci_failure": map[string]any{},
+			},
+		})
+		if err != nil {
+			t.Fatalf("NewServiceConfig: %v", err)
+		}
+		assertStringEqual(t, "CIFeedback.Kind", "", cfg.CIFeedback.Kind)
+	})
+
+	t.Run("Precedence/BothPresent/ReactionsWins", func(t *testing.T) {
+		t.Parallel()
+		cfg, err := NewServiceConfig(map[string]any{
+			"ci_feedback": map[string]any{
+				"kind":        "circle-ci",
+				"max_retries": 1,
+			},
+			"reactions": map[string]any{
+				"ci_failure": map[string]any{
+					"provider":         "github-actions",
+					"max_retries":      4,
+					"max_log_lines":    75,
+					"escalation":       "comment",
+					"escalation_label": "ci-blocked",
+				},
+			},
+		})
+		if err != nil {
+			t.Fatalf("NewServiceConfig: %v", err)
+		}
+		assertStringEqual(t, "CIFeedback.Kind", "github-actions", cfg.CIFeedback.Kind)
+		assertIntEqual(t, "CIFeedback.MaxRetries", 4, cfg.CIFeedback.MaxRetries)
+		assertIntEqual(t, "CIFeedback.MaxLogLines", 75, cfg.CIFeedback.MaxLogLines)
+		assertStringEqual(t, "CIFeedback.Escalation", "comment", cfg.CIFeedback.Escalation)
+		assertStringEqual(t, "CIFeedback.EscalationLabel", "ci-blocked", cfg.CIFeedback.EscalationLabel)
+	})
+
+	t.Run("Precedence/CIFeedbackOnly", func(t *testing.T) {
+		t.Parallel()
+		cfg, err := NewServiceConfig(map[string]any{
+			"ci_feedback": map[string]any{
+				"kind":        "github",
+				"max_retries": 3,
+			},
+		})
+		if err != nil {
+			t.Fatalf("NewServiceConfig: %v", err)
+		}
+		assertStringEqual(t, "CIFeedback.Kind", "github", cfg.CIFeedback.Kind)
+		assertIntEqual(t, "CIFeedback.MaxRetries", 3, cfg.CIFeedback.MaxRetries)
+	})
+
+	t.Run("Precedence/NeitherPresent", func(t *testing.T) {
+		t.Parallel()
+		cfg, err := NewServiceConfig(map[string]any{})
+		if err != nil {
+			t.Fatalf("NewServiceConfig: %v", err)
+		}
+		if cfg.CIFeedback != (CIFeedbackConfig{}) {
+			t.Errorf("CIFeedback = %+v, want zero value when neither section present", cfg.CIFeedback)
+		}
+	})
+
+	t.Run("Provider/ParsedForNonCIReaction", func(t *testing.T) {
+		t.Parallel()
+		cfg, err := NewServiceConfig(map[string]any{
+			"reactions": map[string]any{
+				"review_comments": map[string]any{
+					"provider": "github",
+				},
+			},
+		})
+		if err != nil {
+			t.Fatalf("NewServiceConfig: %v", err)
+		}
+		rc, ok := cfg.Reactions["review_comments"]
+		if !ok {
+			t.Fatal("Reactions[\"review_comments\"] missing")
+		}
+		assertStringEqual(t, "Reactions[review_comments].Provider", "github", rc.Provider)
+	})
+}

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -31,7 +31,8 @@ type FieldDef struct {
 // SectionSchema defines the known fields for one top-level config section.
 type SectionSchema struct {
 	Fields                  []FieldDef // recognized keys within this section
-	AllowAdapterPassthrough bool       // exempt adapter-kind sub-objects from unknown-key warnings
+	AllowAdapterPassthrough bool       // exempt the adapter-kind sub-object from unknown-key warnings
+	AllowDynamicKeys        bool       // skip all sub-key name and type validation (map-of-maps sections)
 }
 
 // knownFieldsRegistry enumerates the known sub-keys for each top-level
@@ -108,6 +109,10 @@ var knownFieldsRegistry = map[string]SectionSchema{
 			{Name: "max_diff_bytes", Type: FieldInt},
 			{Name: "reviewer", Type: FieldString},
 		},
+	},
+	"reactions": {
+		Fields:           []FieldDef{},
+		AllowDynamicKeys: true,
 	},
 }
 
@@ -188,6 +193,10 @@ func ValidateFrontMatter(raw map[string]any, cfg ServiceConfig) []FrontMatterWar
 				Field:   sectionName,
 				Message: fmt.Sprintf("expected map, got %T", sectionVal),
 			})
+			continue
+		}
+
+		if schema.AllowDynamicKeys {
 			continue
 		}
 

--- a/internal/config/schema_test.go
+++ b/internal/config/schema_test.go
@@ -441,3 +441,104 @@ func TestValidateFrontMatter(t *testing.T) {
 		})
 	}
 }
+
+// TestValidateFrontMatterReactions verifies that the reactions section with
+// AllowDynamicKeys=true never emits unknown_sub_key warnings for any reaction
+// kind keys, while still emitting type_mismatch when the top-level value is
+// not a map.
+func TestValidateFrontMatterReactions(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		raw        map[string]any
+		cfg        ServiceConfig
+		wantCount  int
+		wantChecks []string
+		wantFields []string
+	}{
+		{
+			name: "ci_failure key produces no unknown_sub_key warning",
+			raw: map[string]any{
+				"reactions": map[string]any{
+					"ci_failure": map[string]any{
+						"provider":      "github-actions",
+						"max_log_lines": 100,
+					},
+				},
+			},
+			wantCount: 0,
+		},
+		{
+			name: "arbitrary reaction kind key produces no warning",
+			raw: map[string]any{
+				"reactions": map[string]any{
+					"review_comments": map[string]any{
+						"max_retries": 3,
+						"custom_flag": "anything",
+					},
+				},
+			},
+			wantCount: 0,
+		},
+		{
+			name: "multiple reaction kinds produce no warnings",
+			raw: map[string]any{
+				"reactions": map[string]any{
+					"ci_failure":      map[string]any{"provider": "github-actions"},
+					"review_comments": map[string]any{"max_retries": 3},
+					"new_kind":        map[string]any{"arbitrary_key": "value"},
+				},
+			},
+			wantCount: 0,
+		},
+		{
+			name:       "reactions section as scalar emits type_mismatch",
+			raw:        map[string]any{"reactions": "not-a-map"},
+			wantCount:  1,
+			wantChecks: []string{"type_mismatch"},
+			wantFields: []string{"reactions"},
+		},
+		{
+			name:      "reactions section absent produces no warning",
+			raw:       map[string]any{},
+			wantCount: 0,
+		},
+		{
+			name: "tracker adapter passthrough unaffected by reactions AllowDynamicKeys",
+			raw: map[string]any{
+				"tracker": map[string]any{
+					"kind": "jira",
+					"jira": map[string]any{"foo": "bar"},
+				},
+				"reactions": map[string]any{
+					"ci_failure": map[string]any{"provider": "github-actions"},
+				},
+			},
+			cfg:       ServiceConfig{Tracker: TrackerConfig{Kind: "jira"}},
+			wantCount: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := ValidateFrontMatter(tt.raw, tt.cfg)
+
+			if len(got) != tt.wantCount {
+				t.Fatalf("ValidateFrontMatter() returned %d warnings, want %d\nwarnings: %+v", len(got), tt.wantCount, got)
+			}
+			for i, wantCheck := range tt.wantChecks {
+				if got[i].Check != wantCheck {
+					t.Errorf("warnings[%d].Check = %q, want %q", i, got[i].Check, wantCheck)
+				}
+			}
+			for i, wantField := range tt.wantFields {
+				if got[i].Field != wantField {
+					t.Errorf("warnings[%d].Field = %q, want %q", i, got[i].Field, wantField)
+				}
+			}
+		})
+	}
+}

--- a/internal/orchestrator/self_review_test.go
+++ b/internal/orchestrator/self_review_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -642,6 +643,13 @@ func TestRunVerification_Timeout(t *testing.T) {
 
 func TestRunVerification_CommandNotFound(t *testing.T) {
 	t.Parallel()
+	if runtime.GOOS == "windows" {
+		// Git Bash sh.exe startup overhead plus named-pipe drain time
+		// races the 5 s cmdCtx deadline, producing TimedOut = true
+		// non-deterministically. The behaviour under test is POSIX exit-127
+		// semantics, which don't apply natively on Windows.
+		t.Skip("sh command-not-found timing is unreliable on Windows")
+	}
 
 	wsPath := t.TempDir()
 	// sh returns exit 127 when a command is not found.


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Refactor

**Intent:** Makes `reactions.ci_failure` the canonical CI configuration path, eliminating the structural inconsistency where CI feedback was the only reaction type configured outside the `reactions` block. Full backward compatibility is preserved — existing `ci_feedback` YAML continues to work.

**Related Issues:** #418

### 🧭 Reviewer Guide

**Complexity:** Medium

#### Entry Point

`internal/config/config.go` — contains all structural changes: the new `Provider` field on `ReactionConfig`, the `populateCIFeedbackFromReactions` bridge function, and the precedence logic added to `NewServiceConfig` that routes `reactions.ci_failure` into `CIFeedbackConfig` (and deletes it from the `Reactions` map).

#### Sensitive Areas

- `internal/config/config.go`: Precedence logic in `NewServiceConfig` determines which source wins when both `ci_feedback` and `reactions.ci_failure` are present. The `delete(reactions, "ci_failure")` call ensures consumed config does not appear in two places simultaneously.
- `internal/config/schema.go`: `AllowDynamicKeys` suppresses sub-key validation for `reactions` — verify the guard placement does not accidentally skip validation for other sections with `AllowAdapterPassthrough`.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes. Existing `ci_feedback` YAML is fully supported; `CIFeedbackConfig` type and `ReconcileParams.CIFeedback` are untouched.
- **Migrations/State:** No migrations or state changes.