### PR TITLE
fix(config): reject non-string values in reactions fields with ConfigError

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -901,6 +901,21 @@ func extractString(m map[string]any, key string) string {
 	return s
 }
 
+func requireStringField(m map[string]any, key, fieldPath string) (string, bool, error) {
+	raw, exists := m[key]
+	if !exists || raw == nil {
+		return "", false, nil
+	}
+	s, ok := raw.(string)
+	if !ok {
+		return "", false, &ConfigError{
+			Field:   fieldPath,
+			Message: fmt.Sprintf("expected string, got %T", raw),
+		}
+	}
+	return s, true, nil
+}
+
 func extractStringSlice(raw any) []string {
 	if raw == nil {
 		return nil
@@ -1062,8 +1077,10 @@ func buildReactionsConfig(m map[string]any) (map[string]ReactionConfig, error) {
 		}
 
 		escalation := "label"
-		if raw := extractString(vm, "escalation"); raw != "" {
-			escalation = raw
+		if s, found, err := requireStringField(vm, "escalation", "reactions."+k+".escalation"); err != nil {
+			return nil, err
+		} else if found && s != "" {
+			escalation = s
 		}
 		if escalation != "label" && escalation != "comment" {
 			return nil, &ConfigError{
@@ -1073,8 +1090,10 @@ func buildReactionsConfig(m map[string]any) (map[string]ReactionConfig, error) {
 		}
 
 		escalationLabel := "needs-human"
-		if raw := extractString(vm, "escalation_label"); raw != "" {
-			escalationLabel = raw
+		if s, found, err := requireStringField(vm, "escalation_label", "reactions."+k+".escalation_label"); err != nil {
+			return nil, err
+		} else if found && s != "" {
+			escalationLabel = s
 		}
 
 		extra := make(map[string]any)
@@ -1084,7 +1103,10 @@ func buildReactionsConfig(m map[string]any) (map[string]ReactionConfig, error) {
 			}
 		}
 
-		provider := extractString(vm, "provider")
+		provider, _, err := requireStringField(vm, "provider", "reactions."+k+".provider")
+		if err != nil {
+			return nil, err
+		}
 
 		result[k] = ReactionConfig{
 			Provider:        provider,

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -924,6 +924,42 @@ func TestNewServiceConfig(t *testing.T) {
 		})
 		assertConfigErrorField(t, err, "reactions.CI_Feedback")
 	})
+
+	t.Run("Reactions/ProviderNonStringRejected", func(t *testing.T) {
+		t.Parallel()
+		_, err := NewServiceConfig(map[string]any{
+			"reactions": map[string]any{
+				"ci_failure": map[string]any{
+					"provider": 123,
+				},
+			},
+		})
+		assertConfigErrorField(t, err, "reactions.ci_failure.provider")
+	})
+
+	t.Run("Reactions/EscalationNonStringRejected", func(t *testing.T) {
+		t.Parallel()
+		_, err := NewServiceConfig(map[string]any{
+			"reactions": map[string]any{
+				"ci": map[string]any{
+					"escalation": true,
+				},
+			},
+		})
+		assertConfigErrorField(t, err, "reactions.ci.escalation")
+	})
+
+	t.Run("Reactions/EscalationLabelNonStringRejected", func(t *testing.T) {
+		t.Parallel()
+		_, err := NewServiceConfig(map[string]any{
+			"reactions": map[string]any{
+				"ci": map[string]any{
+					"escalation_label": 42,
+				},
+			},
+		})
+		assertConfigErrorField(t, err, "reactions.ci.escalation_label")
+	})
 }
 
 // --- test helpers ---


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Fix

**Intent:** `buildReactionsConfig` used `extractString` for `provider`, `escalation`, and `escalation_label`, which silently coerced non-string YAML values (integers, booleans) to an empty string. This adds a `requireStringField` helper that returns a `*ConfigError` for any present key holding a non-string type, making the misconfiguration explicit.

**Related Issues:** #423

### 🧭 Reviewer Guide

**Complexity:** Low

#### Entry Point

`internal/config/config.go` — the new `requireStringField` helper (after `extractString`) and its three call sites inside `buildReactionsConfig`. Each site replaces a bare `extractString` call, threading the error up to the caller.

#### Sensitive Areas

- `internal/config/config.go`: `buildReactionsConfig` now propagates errors from field extraction — verify the three replaced call sites handle the `(value, found, error)` return correctly and that the `else if found && s != ""` branch preserves the existing default-assignment semantics.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes — valid string values and absent keys behave identically to before.
- **Migrations/State:** No migrations or state changes.