### PR TITLE
feat(orchestrator): add runtime terminal workspace sweep

### DIFF
--- a/internal/domain/metrics.go
+++ b/internal/domain/metrics.go
@@ -51,7 +51,7 @@ type Metrics interface {
 	IncRetries(trigger string)
 
 	// IncReconciliationActions increments the reconciliation outcome
-	// counter. action is "stop", "cleanup", or "keep"
+	// counter. action is "stop", "cleanup", "keep", or "sweep_cleanup"
 	// (sortie_reconciliation_actions_total{action} counter).
 	IncReconciliationActions(action string)
 

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -390,6 +390,23 @@ func (o *Orchestrator) handleTick(ctx context.Context) {
 		ReviewPendingTTL:  reviewPendingDefaultTTL,
 	})
 
+	// Sweep terminal workspaces periodically to catch issues that
+	// transitioned after their worker exited.
+	o.state.SweepTickCounter++
+	if o.state.SweepTickCounter >= sweepEveryNTicks {
+		o.state.SweepTickCounter = 0
+		SweepTerminalWorkspaces(o.state, SweepTerminalWorkspacesParams{
+			WorkspaceRoot:    cfg.Workspace.Root,
+			TrackerAdapter:   o.trackerAdapter,
+			TerminalStates:   cfg.Tracker.TerminalStates,
+			BeforeRemoveHook: cfg.Hooks.BeforeRemove,
+			HookTimeoutMS:    cfg.Hooks.TimeoutMS,
+			Ctx:              ctx,
+			Logger:           o.logger,
+			Metrics:          o.metrics,
+		})
+	}
+
 	// On preflight failure, skip dispatch but still notify observers
 	// so the UI reflects the reconciliation outcome.
 	if !validation.OK() {

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -3,6 +3,7 @@ package orchestrator
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -4252,4 +4253,133 @@ func TestOrchestratorScenarios(t *testing.T) {
 			t.Error("issue still in Running after handoff, want absent")
 		}
 	})
+}
+
+// sweepThrottleTracker is a test double for [TestHandleTickSweepThrottle].
+// It records invocations of FetchIssueStatesByIdentifiers and returns
+// configurable state data. All other methods return safe zero values so
+// that tick-loop side effects (reconcile, dispatch) do not panic.
+type sweepThrottleTracker struct {
+	mu          sync.Mutex
+	calls       int
+	statesByKey map[string]string
+}
+
+var _ domain.TrackerAdapter = (*sweepThrottleTracker)(nil)
+
+func (s *sweepThrottleTracker) FetchIssueStatesByIdentifiers(_ context.Context, _ []string) (map[string]string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.calls++
+	return s.statesByKey, nil
+}
+
+func (s *sweepThrottleTracker) callCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.calls
+}
+
+func (s *sweepThrottleTracker) FetchCandidateIssues(_ context.Context) ([]domain.Issue, error) {
+	return nil, nil
+}
+
+func (s *sweepThrottleTracker) FetchIssueByID(_ context.Context, _ string) (domain.Issue, error) {
+	return domain.Issue{}, nil
+}
+
+func (s *sweepThrottleTracker) FetchIssuesByStates(_ context.Context, _ []string) ([]domain.Issue, error) {
+	return nil, nil
+}
+
+func (s *sweepThrottleTracker) FetchIssueStatesByIDs(_ context.Context, _ []string) (map[string]string, error) {
+	return nil, nil
+}
+
+func (s *sweepThrottleTracker) FetchIssueComments(_ context.Context, _ string) ([]domain.Comment, error) {
+	return nil, nil
+}
+
+func (s *sweepThrottleTracker) TransitionIssue(_ context.Context, _, _ string) error { return nil }
+
+func (s *sweepThrottleTracker) CommentIssue(_ context.Context, _, _ string) error { return nil }
+
+func (s *sweepThrottleTracker) AddLabel(_ context.Context, _, _ string) error { return nil }
+
+// --- TestHandleTickSweepThrottle ---
+
+func TestHandleTickSweepThrottle(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	if err := os.Mkdir(filepath.Join(tmpDir, "PROJ-10"), 0o755); err != nil {
+		t.Fatalf("os.Mkdir PROJ-10: %v", err)
+	}
+
+	tracker := &sweepThrottleTracker{
+		statesByKey: map[string]string{"PROJ-10": "Done"},
+	}
+
+	cfg := config.ServiceConfig{
+		Tracker: config.TrackerConfig{
+			Kind:           "mock",
+			APIKey:         "test-key",
+			ActiveStates:   []string{"To Do"},
+			TerminalStates: []string{"Done"},
+		},
+		Polling:   config.PollingConfig{IntervalMS: 60000},
+		Workspace: config.WorkspaceConfig{Root: tmpDir},
+		Hooks:     config.HooksConfig{TimeoutMS: 5000},
+		Agent: config.AgentConfig{
+			Kind:                "mock",
+			Command:             "/usr/bin/agent",
+			MaxConcurrentAgents: 1,
+		},
+	}
+
+	wm := &stubWorkflowManager{config: cfg}
+	regs := passingPreflightRegistries()
+
+	state := NewState(60000, 1, nil, AgentTotals{})
+	o := NewOrchestrator(OrchestratorParams{
+		State:           state,
+		Logger:          discardLogger(),
+		TrackerAdapter:  tracker,
+		AgentAdapter:    &mockAgentAdapter{},
+		WorkflowManager: wm,
+		Store:           &stubStore{},
+		PreflightParams: PreflightParams{
+			ReloadWorkflow:  func() error { return nil },
+			ConfigFunc:      wm.Config,
+			TrackerRegistry: regs.TrackerRegistry,
+			AgentRegistry:   regs.AgentRegistry,
+		},
+	})
+
+	ctx := context.Background()
+
+	// Ticks 1 through sweepEveryNTicks-1: sweep must not fire.
+	for i := 0; i < sweepEveryNTicks-1; i++ {
+		o.handleTick(ctx)
+	}
+	if got := tracker.callCount(); got != 0 {
+		t.Errorf("FetchIssueStatesByIdentifiers called %d times before tick %d, want 0",
+			got, sweepEveryNTicks)
+	}
+
+	// Tick sweepEveryNTicks: sweep fires exactly once.
+	o.handleTick(ctx)
+	if got := tracker.callCount(); got != 1 {
+		t.Errorf("FetchIssueStatesByIdentifiers called %d times at tick %d, want 1",
+			got, sweepEveryNTicks)
+	}
+
+	wsPath := filepath.Join(tmpDir, "PROJ-10")
+	if _, err := os.Stat(wsPath); !errors.Is(err, os.ErrNotExist) {
+		t.Error("workspace PROJ-10 still exists after sweep, want removed")
+	}
+
+	if got := o.state.SweepTickCounter; got != 0 {
+		t.Errorf("SweepTickCounter = %d after sweep, want 0", got)
+	}
 }

--- a/internal/orchestrator/reconcile.go
+++ b/internal/orchestrator/reconcile.go
@@ -302,9 +302,9 @@ func reconcileTrackerState(state *State, params ReconcileParams, log *slog.Logge
 }
 
 // sweepEveryNTicks is the number of poll ticks between terminal workspace
-// sweeps. At the default 10s poll interval this fires roughly every 10
-// minutes — frequent enough for eventual consistency, infrequent enough to
-// avoid unbounded tracker API load from orphaned non-terminal workspaces.
+// sweeps. Running this sweep every 60 ticks is frequent enough for eventual
+// consistency while avoiding unbounded tracker API load from orphaned
+// non-terminal workspaces.
 const sweepEveryNTicks = 60
 
 // SweepTerminalWorkspacesParams holds the dependencies for

--- a/internal/orchestrator/reconcile.go
+++ b/internal/orchestrator/reconcile.go
@@ -10,6 +10,7 @@ import (
 	"github.com/sortie-ai/sortie/internal/domain"
 	"github.com/sortie-ai/sortie/internal/logging"
 	"github.com/sortie-ai/sortie/internal/persistence"
+	"github.com/sortie-ai/sortie/internal/workspace"
 )
 
 // ReconcileStore is the persistence interface required by
@@ -297,5 +298,142 @@ func reconcileTrackerState(state *State, params ReconcileParams, log *slog.Logge
 		entryLog.Info("stopping worker for non-active issue",
 			slog.String("state", stateName),
 		)
+	}
+}
+
+// sweepEveryNTicks is the number of poll ticks between terminal workspace
+// sweeps. At the default 10s poll interval this fires roughly every 10
+// minutes — frequent enough for eventual consistency, infrequent enough to
+// avoid unbounded tracker API load from orphaned non-terminal workspaces.
+const sweepEveryNTicks = 60
+
+// SweepTerminalWorkspacesParams holds the dependencies for
+// [SweepTerminalWorkspaces]. All fields except Logger and Metrics are
+// required; nil Logger defaults to [slog.Default] and nil Metrics defaults
+// to [domain.NoopMetrics].
+type SweepTerminalWorkspacesParams struct {
+	WorkspaceRoot    string
+	TrackerAdapter   domain.TrackerAdapter
+	TerminalStates   []string
+	BeforeRemoveHook string
+	HookTimeoutMS    int
+	Ctx              context.Context
+	Logger           *slog.Logger
+	Metrics          domain.Metrics
+}
+
+// SweepTerminalWorkspaces removes workspace directories for issues that
+// transitioned to a terminal state after their worker exited. It lists
+// workspace keys on disk, excludes any that belong to in-flight entries,
+// queries the tracker for the remaining identifiers, and cleans up those
+// whose state is terminal.
+func SweepTerminalWorkspaces(state *State, params SweepTerminalWorkspacesParams) {
+	log := params.Logger
+	if log == nil {
+		log = slog.Default()
+	}
+
+	metrics := params.Metrics
+	if metrics == nil {
+		metrics = &domain.NoopMetrics{}
+	}
+
+	keys, err := workspace.ListWorkspaceKeys(params.WorkspaceRoot)
+	if err != nil {
+		log.Warn("sweep: failed to list workspace keys",
+			slog.Any("error", err),
+		)
+		return
+	}
+	if len(keys) == 0 {
+		return
+	}
+
+	inFlightKeys := make(map[string]struct{})
+	for _, entry := range state.Running {
+		k, sErr := workspace.SanitizeKey(entry.Identifier)
+		if sErr != nil {
+			log.Warn("sweep: failed to sanitize running identifier",
+				slog.String("identifier", entry.Identifier),
+				slog.Any("error", sErr),
+			)
+			continue
+		}
+		inFlightKeys[k] = struct{}{}
+	}
+	for _, entry := range state.RetryAttempts {
+		k, sErr := workspace.SanitizeKey(entry.Identifier)
+		if sErr != nil {
+			log.Warn("sweep: failed to sanitize retry identifier",
+				slog.String("identifier", entry.Identifier),
+				slog.Any("error", sErr),
+			)
+			continue
+		}
+		inFlightKeys[k] = struct{}{}
+	}
+	for _, entry := range state.PendingReactions {
+		k, sErr := workspace.SanitizeKey(entry.Identifier)
+		if sErr != nil {
+			log.Warn("sweep: failed to sanitize pending reaction identifier",
+				slog.String("identifier", entry.Identifier),
+				slog.Any("error", sErr),
+			)
+			continue
+		}
+		inFlightKeys[k] = struct{}{}
+	}
+
+	unclaimedKeys := make([]string, 0, len(keys))
+	for _, key := range keys {
+		if _, ok := inFlightKeys[key]; !ok {
+			unclaimedKeys = append(unclaimedKeys, key)
+		}
+	}
+	if len(unclaimedKeys) == 0 {
+		return
+	}
+
+	statesByKey, err := params.TrackerAdapter.FetchIssueStatesByIdentifiers(params.Ctx, unclaimedKeys)
+	if err != nil {
+		log.Warn("sweep: failed to fetch issue states",
+			slog.Any("error", err),
+		)
+		return
+	}
+
+	terminalSet := make(map[string]struct{}, len(params.TerminalStates))
+	for _, s := range params.TerminalStates {
+		terminalSet[strings.ToLower(s)] = struct{}{}
+	}
+
+	var toClean []string
+	for _, key := range unclaimedKeys {
+		stateName, ok := statesByKey[key]
+		if !ok {
+			continue
+		}
+		if _, terminal := terminalSet[strings.ToLower(stateName)]; terminal {
+			toClean = append(toClean, key)
+		}
+	}
+	if len(toClean) == 0 {
+		return
+	}
+
+	log.Info("sweep: cleaning terminal workspaces",
+		slog.Int("count", len(toClean)),
+	)
+
+	result := workspace.CleanupTerminal(params.Ctx, workspace.CleanupTerminalParams{
+		Root:          params.WorkspaceRoot,
+		Identifiers:   toClean,
+		BeforeRemove:  params.BeforeRemoveHook,
+		HookTimeoutMS: params.HookTimeoutMS,
+		Logger:        log,
+	})
+
+	for range result.Removed {
+		metrics.IncReconciliationActions(actionSweepCleanup)
 	}
 }

--- a/internal/orchestrator/reconcile_test.go
+++ b/internal/orchestrator/reconcile_test.go
@@ -4,6 +4,10 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"os"
+	"path/filepath"
+	"slices"
+	"sort"
 	"testing"
 	"time"
 
@@ -102,6 +106,57 @@ func (m *mockReconcileTracker) CommentIssue(context.Context, string, string) err
 
 func (m *mockReconcileTracker) AddLabel(context.Context, string, string) error {
 	panic("AddLabel must not be called by ReconcileRunningIssues")
+}
+
+// sweepTracker is a test double for [SweepTerminalWorkspaces]. Its
+// FetchIssueStatesByIdentifiers records the identifiers it receives and
+// returns the configured statesByKey map and fetchErr. All other methods
+// panic if called, matching the guard pattern in [mockReconcileTracker].
+type sweepTracker struct {
+	calledWith  []string          // copy of ids passed to FetchIssueStatesByIdentifiers
+	statesByKey map[string]string // keyed by workspace key (sanitized identifier)
+	fetchErr    error
+}
+
+var _ domain.TrackerAdapter = (*sweepTracker)(nil)
+
+func (s *sweepTracker) FetchIssueStatesByIdentifiers(_ context.Context, ids []string) (map[string]string, error) {
+	cp := make([]string, len(ids))
+	copy(cp, ids)
+	s.calledWith = cp
+	return s.statesByKey, s.fetchErr
+}
+
+func (s *sweepTracker) FetchCandidateIssues(context.Context) ([]domain.Issue, error) {
+	panic("FetchCandidateIssues must not be called by SweepTerminalWorkspaces")
+}
+
+func (s *sweepTracker) FetchIssueByID(context.Context, string) (domain.Issue, error) {
+	panic("FetchIssueByID must not be called by SweepTerminalWorkspaces")
+}
+
+func (s *sweepTracker) FetchIssuesByStates(context.Context, []string) ([]domain.Issue, error) {
+	panic("FetchIssuesByStates must not be called by SweepTerminalWorkspaces")
+}
+
+func (s *sweepTracker) FetchIssueStatesByIDs(context.Context, []string) (map[string]string, error) {
+	panic("FetchIssueStatesByIDs must not be called by SweepTerminalWorkspaces")
+}
+
+func (s *sweepTracker) FetchIssueComments(context.Context, string) ([]domain.Comment, error) {
+	panic("FetchIssueComments must not be called by SweepTerminalWorkspaces")
+}
+
+func (s *sweepTracker) TransitionIssue(context.Context, string, string) error {
+	panic("TransitionIssue must not be called by SweepTerminalWorkspaces")
+}
+
+func (s *sweepTracker) CommentIssue(context.Context, string, string) error {
+	panic("CommentIssue must not be called by SweepTerminalWorkspaces")
+}
+
+func (s *sweepTracker) AddLabel(context.Context, string, string) error {
+	panic("AddLabel must not be called by SweepTerminalWorkspaces")
 }
 
 // --- Test helpers ---
@@ -943,4 +998,272 @@ func TestReconcileStalled_WarnLogOnlyOnFirstTick(t *testing.T) {
 	if debugCount != 1 {
 		t.Errorf("Debug('stall retry already scheduled, skipping reschedule') emitted %d times, want 1", debugCount)
 	}
+}
+
+// --- SweepTerminalWorkspaces helpers ---
+
+// defaultSweepParams returns SweepTerminalWorkspacesParams with the given
+// root and tracker. TerminalStates, Ctx, Logger, and Metrics use
+// test-suitable defaults.
+func defaultSweepParams(t *testing.T, root string, tracker *sweepTracker) SweepTerminalWorkspacesParams {
+	t.Helper()
+	return SweepTerminalWorkspacesParams{
+		WorkspaceRoot:  root,
+		TrackerAdapter: tracker,
+		TerminalStates: []string{"Done"},
+		Ctx:            context.Background(),
+		Logger:         discardLogger(),
+		Metrics:        &domain.NoopMetrics{},
+	}
+}
+
+// mustMkdirSweep creates a directory under path or fatals the test.
+func mustMkdirSweep(t *testing.T, path string) {
+	t.Helper()
+	if err := os.Mkdir(path, 0o755); err != nil {
+		t.Fatalf("os.Mkdir(%q): %v", path, err)
+	}
+}
+
+// assertSweepDirExists fails if the directory at path does not exist.
+func assertSweepDirExists(t *testing.T, path string) {
+	t.Helper()
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("directory %q should exist: %v", path, err)
+	}
+}
+
+// assertSweepDirRemoved fails if path still exists on disk.
+func assertSweepDirRemoved(t *testing.T, path string) {
+	t.Helper()
+	if _, err := os.Stat(path); !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("path %q should have been removed, want ErrNotExist", path)
+	}
+}
+
+// --- TestSweepTerminalWorkspaces ---
+
+func TestSweepTerminalWorkspaces(t *testing.T) {
+	t.Parallel()
+
+	t.Run("EmptyWorkspaceRoot", func(t *testing.T) {
+		t.Parallel()
+
+		tracker := &sweepTracker{}
+		state := NewState(5000, 4, nil, AgentTotals{})
+		SweepTerminalWorkspaces(state, SweepTerminalWorkspacesParams{
+			WorkspaceRoot:  "",
+			TrackerAdapter: tracker,
+			TerminalStates: []string{"Done"},
+			Ctx:            context.Background(),
+			Logger:         discardLogger(),
+			Metrics:        &domain.NoopMetrics{},
+		})
+
+		if tracker.calledWith != nil {
+			t.Errorf("FetchIssueStatesByIdentifiers called with %v, want not called", tracker.calledWith)
+		}
+	})
+
+	t.Run("NoWorkspaceDirectories", func(t *testing.T) {
+		t.Parallel()
+
+		tmpDir := t.TempDir()
+		tracker := &sweepTracker{}
+		state := NewState(5000, 4, nil, AgentTotals{})
+
+		SweepTerminalWorkspaces(state, defaultSweepParams(t, tmpDir, tracker))
+
+		if tracker.calledWith != nil {
+			t.Errorf("FetchIssueStatesByIdentifiers called with %v, want not called", tracker.calledWith)
+		}
+	})
+
+	t.Run("AllRunning", func(t *testing.T) {
+		t.Parallel()
+
+		tmpDir := t.TempDir()
+		mustMkdirSweep(t, filepath.Join(tmpDir, "PROJ-1"))
+
+		tracker := &sweepTracker{}
+		state := NewState(5000, 4, nil, AgentTotals{})
+		state.Running["id1"] = &RunningEntry{Identifier: "PROJ-1"}
+
+		SweepTerminalWorkspaces(state, defaultSweepParams(t, tmpDir, tracker))
+
+		if tracker.calledWith != nil {
+			t.Errorf("FetchIssueStatesByIdentifiers called with %v, want not called", tracker.calledWith)
+		}
+		assertSweepDirExists(t, filepath.Join(tmpDir, "PROJ-1"))
+	})
+
+	t.Run("AllRetryAttempts", func(t *testing.T) {
+		t.Parallel()
+
+		tmpDir := t.TempDir()
+		mustMkdirSweep(t, filepath.Join(tmpDir, "PROJ-2"))
+
+		tracker := &sweepTracker{}
+		state := NewState(5000, 4, nil, AgentTotals{})
+		state.RetryAttempts["id2"] = &RetryEntry{Identifier: "PROJ-2"}
+
+		SweepTerminalWorkspaces(state, defaultSweepParams(t, tmpDir, tracker))
+
+		if tracker.calledWith != nil {
+			t.Errorf("FetchIssueStatesByIdentifiers called with %v, want not called", tracker.calledWith)
+		}
+		assertSweepDirExists(t, filepath.Join(tmpDir, "PROJ-2"))
+	})
+
+	t.Run("AllPendingReactions", func(t *testing.T) {
+		t.Parallel()
+
+		tmpDir := t.TempDir()
+		mustMkdirSweep(t, filepath.Join(tmpDir, "PROJ-3"))
+
+		tracker := &sweepTracker{}
+		state := NewState(5000, 4, nil, AgentTotals{})
+		state.PendingReactions["id3:ci"] = &PendingReaction{Identifier: "PROJ-3"}
+
+		SweepTerminalWorkspaces(state, defaultSweepParams(t, tmpDir, tracker))
+
+		if tracker.calledWith != nil {
+			t.Errorf("FetchIssueStatesByIdentifiers called with %v, want not called", tracker.calledWith)
+		}
+		assertSweepDirExists(t, filepath.Join(tmpDir, "PROJ-3"))
+	})
+
+	t.Run("SanitizeKeyError_Running", func(t *testing.T) {
+		t.Parallel()
+
+		tmpDir := t.TempDir()
+		mustMkdirSweep(t, filepath.Join(tmpDir, "PROJ-4"))
+
+		// Empty identifier fails SanitizeKey; the running entry is
+		// skipped when building inFlightKeys, leaving PROJ-4 unclaimed.
+		tracker := &sweepTracker{
+			statesByKey: map[string]string{"PROJ-4": "Done"},
+		}
+		state := NewState(5000, 4, nil, AgentTotals{})
+		state.Running["id1"] = &RunningEntry{Identifier: ""}
+
+		SweepTerminalWorkspaces(state, defaultSweepParams(t, tmpDir, tracker))
+
+		if tracker.calledWith == nil {
+			t.Fatal("FetchIssueStatesByIdentifiers not called, want called with [PROJ-4]")
+		}
+		got := append([]string(nil), tracker.calledWith...)
+		sort.Strings(got)
+		want := []string{"PROJ-4"}
+		if !slices.Equal(got, want) {
+			t.Errorf("FetchIssueStatesByIdentifiers received %v, want %v", got, want)
+		}
+		assertSweepDirRemoved(t, filepath.Join(tmpDir, "PROJ-4"))
+	})
+
+	t.Run("MixedRunningAndTerminal", func(t *testing.T) {
+		t.Parallel()
+
+		tmpDir := t.TempDir()
+		mustMkdirSweep(t, filepath.Join(tmpDir, "PROJ-5"))
+		mustMkdirSweep(t, filepath.Join(tmpDir, "PROJ-6"))
+
+		tracker := &sweepTracker{
+			statesByKey: map[string]string{"PROJ-6": "Done"},
+		}
+		state := NewState(5000, 4, nil, AgentTotals{})
+		state.Running["id5"] = &RunningEntry{Identifier: "PROJ-5"}
+
+		SweepTerminalWorkspaces(state, defaultSweepParams(t, tmpDir, tracker))
+
+		assertSweepDirExists(t, filepath.Join(tmpDir, "PROJ-5"))
+		assertSweepDirRemoved(t, filepath.Join(tmpDir, "PROJ-6"))
+	})
+
+	t.Run("MixedTerminalAndActive", func(t *testing.T) {
+		t.Parallel()
+
+		tmpDir := t.TempDir()
+		mustMkdirSweep(t, filepath.Join(tmpDir, "PROJ-7"))
+		mustMkdirSweep(t, filepath.Join(tmpDir, "PROJ-8"))
+
+		tracker := &sweepTracker{
+			statesByKey: map[string]string{
+				"PROJ-7": "Done",
+				"PROJ-8": "In Progress",
+			},
+		}
+		state := NewState(5000, 4, nil, AgentTotals{})
+
+		SweepTerminalWorkspaces(state, defaultSweepParams(t, tmpDir, tracker))
+
+		assertSweepDirRemoved(t, filepath.Join(tmpDir, "PROJ-7"))
+		assertSweepDirExists(t, filepath.Join(tmpDir, "PROJ-8"))
+	})
+
+	t.Run("TrackerFetchFailure", func(t *testing.T) {
+		t.Parallel()
+
+		tmpDir := t.TempDir()
+		mustMkdirSweep(t, filepath.Join(tmpDir, "PROJ-9"))
+
+		tracker := &sweepTracker{
+			fetchErr: errors.New("tracker unavailable"),
+		}
+		state := NewState(5000, 4, nil, AgentTotals{})
+
+		SweepTerminalWorkspaces(state, defaultSweepParams(t, tmpDir, tracker))
+
+		assertSweepDirExists(t, filepath.Join(tmpDir, "PROJ-9"))
+	})
+
+	t.Run("UnclaimedKeyMissingFromTracker", func(t *testing.T) {
+		t.Parallel()
+
+		tmpDir := t.TempDir()
+		mustMkdirSweep(t, filepath.Join(tmpDir, "PROJ-9"))
+
+		// Tracker returns an empty map; PROJ-9 is absent from it.
+		tracker := &sweepTracker{
+			statesByKey: map[string]string{},
+		}
+		state := NewState(5000, 4, nil, AgentTotals{})
+
+		SweepTerminalWorkspaces(state, defaultSweepParams(t, tmpDir, tracker))
+
+		assertSweepDirExists(t, filepath.Join(tmpDir, "PROJ-9"))
+	})
+
+	t.Run("MetricEmitted", func(t *testing.T) {
+		t.Parallel()
+
+		tmpDir := t.TempDir()
+		mustMkdirSweep(t, filepath.Join(tmpDir, "PROJ-10"))
+
+		tracker := &sweepTracker{
+			statesByKey: map[string]string{"PROJ-10": "Done"},
+		}
+		state := NewState(5000, 4, nil, AgentTotals{})
+
+		spy := &spyMetrics{}
+		params := defaultSweepParams(t, tmpDir, tracker)
+		params.Metrics = spy
+
+		SweepTerminalWorkspaces(state, params)
+
+		spy.mu.Lock()
+		acts := append([]string(nil), spy.reconciliationActs...)
+		spy.mu.Unlock()
+
+		var sweepCount int
+		for _, a := range acts {
+			if a == actionSweepCleanup {
+				sweepCount++
+			}
+		}
+		if sweepCount != 1 {
+			t.Errorf("IncReconciliationActions(%q) called %d times, want 1", actionSweepCleanup, sweepCount)
+		}
+		assertSweepDirRemoved(t, filepath.Join(tmpDir, "PROJ-10"))
+	})
 }

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -33,9 +33,10 @@ const (
 	triggerStall        = "stall"
 	triggerCIFix        = "ci_fix"
 
-	actionStop    = "stop"
-	actionCleanup = "cleanup"
-	actionKeep    = "keep"
+	actionStop         = "stop"
+	actionCleanup      = "cleanup"
+	actionKeep         = "keep"
+	actionSweepCleanup = "sweep_cleanup"
 
 	handoffSuccess = "success"
 	handoffError   = "error"
@@ -441,6 +442,11 @@ type State struct {
 	// per-kind reconcile functions during the reconcile tick. Runtime-only
 	// (not persisted).
 	PendingReactions map[string]*PendingReaction
+
+	// SweepTickCounter tracks poll ticks since the last terminal workspace
+	// sweep. Incremented by handleTick; reset to zero when the sweep fires.
+	// Runtime-only (not persisted).
+	SweepTickCounter int
 }
 
 // continuationCtxKey is the context key for reaction continuation data


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Feat

**Intent:** Closes the gap where workspace directories accumulate on disk for issues that reach a terminal tracker state after their worker has already exited. The existing startup sweep and in-flight reconciliation do not cover this case; this adds a third cleanup path that runs periodically inside the event loop.

**Related Issues:** #428

### 🧭 Reviewer Guide

**Complexity:** Medium

#### Entry Point

`internal/orchestrator/reconcile.go` — the new `SweepTerminalWorkspaces` function is the core of the change. It enumerates workspace keys on disk, excludes any that match in-flight entries (`Running`, `RetryAttempts`, `PendingReactions`), queries the tracker for the remaining unclaimed keys, and delegates cleanup to `workspace.CleanupTerminal`. The throttling mechanism lives in `internal/orchestrator/orchestrator.go` (`handleTick`): a `SweepTickCounter` field on `State` fires the sweep every 60 ticks.

#### Sensitive Areas

- `internal/orchestrator/reconcile.go`: exclusion-set construction covers all three in-flight maps — missing any one of them risks removing a workspace that is still governed by the orchestrator.
- `internal/orchestrator/state.go`: `SweepTickCounter` is event-loop-only state; it must not be persisted or accessed from other goroutines.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes
- **Migrations/State:** No migrations or state changes. `SweepTickCounter` is runtime-only and resets to zero on restart (the startup sweep handles the restart case).