### PR TITLE
refactor(registry): split AdapterMeta into TrackerMeta and AgentMeta

### DIFF
--- a/internal/agent/claude/claude.go
+++ b/internal/agent/claude/claude.go
@@ -31,7 +31,7 @@ import (
 )
 
 func init() {
-	registry.Agents.RegisterWithMeta("claude-code", NewClaudeCodeAdapter, registry.AdapterMeta{
+	registry.Agents.RegisterWithMeta("claude-code", NewClaudeCodeAdapter, registry.AgentMeta{
 		RequiresCommand: true,
 	})
 }

--- a/internal/agent/copilot/copilot.go
+++ b/internal/agent/copilot/copilot.go
@@ -31,7 +31,7 @@ import (
 )
 
 func init() {
-	registry.Agents.RegisterWithMeta("copilot-cli", NewCopilotAdapter, registry.AdapterMeta{
+	registry.Agents.RegisterWithMeta("copilot-cli", NewCopilotAdapter, registry.AgentMeta{
 		RequiresCommand: true,
 	})
 }

--- a/internal/agent/copilot/copilot_test.go
+++ b/internal/agent/copilot/copilot_test.go
@@ -117,9 +117,9 @@ func TestRegistration(t *testing.T) {
 	}
 
 	// Verify RequiresCommand metadata is set.
-	meta := registry.Agents.Meta("copilot-cli")
+	meta, _ := registry.Agents.Meta("copilot-cli")
 	if !meta.RequiresCommand {
-		t.Error("AdapterMeta.RequiresCommand = false, want true")
+		t.Error("AgentMeta.RequiresCommand = false, want true")
 	}
 }
 

--- a/internal/agent/copilot/copilot_test.go
+++ b/internal/agent/copilot/copilot_test.go
@@ -117,7 +117,10 @@ func TestRegistration(t *testing.T) {
 	}
 
 	// Verify RequiresCommand metadata is set.
-	meta, _ := registry.Agents.Meta("copilot-cli")
+	meta, ok := registry.Agents.Meta("copilot-cli")
+	if !ok {
+		t.Fatal(`registry.Agents.Meta("copilot-cli") reported not registered`)
+	}
 	if !meta.RequiresCommand {
 		t.Error("AgentMeta.RequiresCommand = false, want true")
 	}

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -1308,11 +1308,11 @@ func passingPreflightRegistries() PreflightParams {
 	return PreflightParams{
 		TrackerRegistry: &stubTrackerRegistry{
 			getFunc:  func(string) (registry.TrackerConstructor, error) { return nil, nil },
-			metaFunc: func(string) registry.AdapterMeta { return registry.AdapterMeta{} },
+			metaFunc: func(string) (registry.TrackerMeta, bool) { return registry.TrackerMeta{}, true },
 		},
 		AgentRegistry: &stubAgentRegistry{
 			getFunc:  func(string) (registry.AgentConstructor, error) { return nil, nil },
-			metaFunc: func(string) registry.AdapterMeta { return registry.AdapterMeta{} },
+			metaFunc: func(string) (registry.AgentMeta, bool) { return registry.AgentMeta{}, true },
 		},
 	}
 }

--- a/internal/orchestrator/preflight.go
+++ b/internal/orchestrator/preflight.go
@@ -77,14 +77,14 @@ type PreflightParams struct {
 	// for the configured tracker kind.
 	TrackerRegistry interface {
 		Get(kind string) (registry.TrackerConstructor, error)
-		Meta(kind string) registry.AdapterMeta
+		Meta(kind string) (registry.TrackerMeta, bool)
 	}
 
 	// AgentRegistry provides adapter lookup and metadata queries
 	// for the configured agent kind.
 	AgentRegistry interface {
 		Get(kind string) (registry.AgentConstructor, error)
-		Meta(kind string) registry.AdapterMeta
+		Meta(kind string) (registry.AgentMeta, bool)
 	}
 }
 
@@ -122,7 +122,7 @@ func ValidateDispatchConfig(params PreflightParams) PreflightResult {
 	// Tracker-specific validations share a single Meta() lookup.
 	var warns []PreflightWarning
 	if cfg.Tracker.Kind != "" {
-		trackerMeta := params.TrackerRegistry.Meta(cfg.Tracker.Kind)
+		trackerMeta, _ := params.TrackerRegistry.Meta(cfg.Tracker.Kind)
 
 		// API key is mandatory for adapters that declare it required.
 		if trackerMeta.RequiresAPIKey && cfg.Tracker.APIKey == "" {
@@ -181,8 +181,9 @@ func ValidateDispatchConfig(params PreflightParams) PreflightResult {
 	}
 
 	// Command is mandatory for adapters that declare it required.
-	if cfg.Agent.Kind != "" && params.AgentRegistry.Meta(cfg.Agent.Kind).RequiresCommand {
-		if cfg.Agent.Command == "" {
+	if cfg.Agent.Kind != "" {
+		agentMeta, _ := params.AgentRegistry.Meta(cfg.Agent.Kind)
+		if agentMeta.RequiresCommand && cfg.Agent.Command == "" {
 			errs = append(errs, PreflightError{
 				Check:   "agent.command",
 				Message: "agent.command is required for agent kind " + strconv.Quote(cfg.Agent.Kind),

--- a/internal/orchestrator/preflight_test.go
+++ b/internal/orchestrator/preflight_test.go
@@ -18,14 +18,14 @@ import (
 // PreflightParams with configurable Get and Meta behavior.
 type stubTrackerRegistry struct {
 	getFunc  func(string) (registry.TrackerConstructor, error)
-	metaFunc func(string) registry.AdapterMeta
+	metaFunc func(string) (registry.TrackerMeta, bool)
 }
 
 func (s *stubTrackerRegistry) Get(kind string) (registry.TrackerConstructor, error) {
 	return s.getFunc(kind)
 }
 
-func (s *stubTrackerRegistry) Meta(kind string) registry.AdapterMeta {
+func (s *stubTrackerRegistry) Meta(kind string) (registry.TrackerMeta, bool) {
 	return s.metaFunc(kind)
 }
 
@@ -33,14 +33,14 @@ func (s *stubTrackerRegistry) Meta(kind string) registry.AdapterMeta {
 // PreflightParams with configurable Get and Meta behavior.
 type stubAgentRegistry struct {
 	getFunc  func(string) (registry.AgentConstructor, error)
-	metaFunc func(string) registry.AdapterMeta
+	metaFunc func(string) (registry.AgentMeta, bool)
 }
 
 func (s *stubAgentRegistry) Get(kind string) (registry.AgentConstructor, error) {
 	return s.getFunc(kind)
 }
 
-func (s *stubAgentRegistry) Meta(kind string) registry.AdapterMeta {
+func (s *stubAgentRegistry) Meta(kind string) (registry.AgentMeta, bool) {
 	return s.metaFunc(kind)
 }
 
@@ -63,11 +63,11 @@ func validPreflightParams() PreflightParams {
 		},
 		TrackerRegistry: &stubTrackerRegistry{
 			getFunc:  func(string) (registry.TrackerConstructor, error) { return nil, nil },
-			metaFunc: func(string) registry.AdapterMeta { return registry.AdapterMeta{} },
+			metaFunc: func(string) (registry.TrackerMeta, bool) { return registry.TrackerMeta{}, true },
 		},
 		AgentRegistry: &stubAgentRegistry{
 			getFunc:  func(string) (registry.AgentConstructor, error) { return nil, nil },
-			metaFunc: func(string) registry.AdapterMeta { return registry.AdapterMeta{} },
+			metaFunc: func(string) (registry.AgentMeta, bool) { return registry.AgentMeta{}, true },
 		},
 	}
 }
@@ -191,8 +191,8 @@ func TestValidateDispatchConfig(t *testing.T) {
 				}
 				p.TrackerRegistry = &stubTrackerRegistry{
 					getFunc: func(string) (registry.TrackerConstructor, error) { return nil, nil },
-					metaFunc: func(string) registry.AdapterMeta {
-						return registry.AdapterMeta{RequiresAPIKey: true}
+					metaFunc: func(string) (registry.TrackerMeta, bool) {
+						return registry.TrackerMeta{RequiresAPIKey: true}, true
 					},
 				}
 			},
@@ -215,8 +215,8 @@ func TestValidateDispatchConfig(t *testing.T) {
 				}
 				p.TrackerRegistry = &stubTrackerRegistry{
 					getFunc: func(string) (registry.TrackerConstructor, error) { return nil, nil },
-					metaFunc: func(string) registry.AdapterMeta {
-						return registry.AdapterMeta{RequiresProject: true}
+					metaFunc: func(string) (registry.TrackerMeta, bool) {
+						return registry.TrackerMeta{RequiresProject: true}, true
 					},
 				}
 			},
@@ -239,8 +239,8 @@ func TestValidateDispatchConfig(t *testing.T) {
 				}
 				p.TrackerRegistry = &stubTrackerRegistry{
 					getFunc: func(string) (registry.TrackerConstructor, error) { return nil, nil },
-					metaFunc: func(string) registry.AdapterMeta {
-						return registry.AdapterMeta{RequiresProject: false}
+					metaFunc: func(string) (registry.TrackerMeta, bool) {
+						return registry.TrackerMeta{RequiresProject: false}, true
 					},
 				}
 			},
@@ -258,7 +258,7 @@ func TestValidateDispatchConfig(t *testing.T) {
 							Available: []string{},
 						}
 					},
-					metaFunc: func(string) registry.AdapterMeta { return registry.AdapterMeta{} },
+					metaFunc: func(string) (registry.TrackerMeta, bool) { return registry.TrackerMeta{}, true },
 				}
 			},
 			wantChecks: []string{"tracker_adapter"},
@@ -279,8 +279,8 @@ func TestValidateDispatchConfig(t *testing.T) {
 				}
 				p.AgentRegistry = &stubAgentRegistry{
 					getFunc: func(string) (registry.AgentConstructor, error) { return nil, nil },
-					metaFunc: func(string) registry.AdapterMeta {
-						return registry.AdapterMeta{RequiresCommand: true}
+					metaFunc: func(string) (registry.AgentMeta, bool) {
+						return registry.AgentMeta{RequiresCommand: true}, true
 					},
 				}
 			},
@@ -302,8 +302,8 @@ func TestValidateDispatchConfig(t *testing.T) {
 				}
 				p.AgentRegistry = &stubAgentRegistry{
 					getFunc: func(string) (registry.AgentConstructor, error) { return nil, nil },
-					metaFunc: func(string) registry.AdapterMeta {
-						return registry.AdapterMeta{RequiresCommand: false}
+					metaFunc: func(string) (registry.AgentMeta, bool) {
+						return registry.AgentMeta{RequiresCommand: false}, true
 					},
 				}
 			},
@@ -330,8 +330,8 @@ func TestValidateDispatchConfig(t *testing.T) {
 							Available: []string{},
 						}
 					},
-					metaFunc: func(string) registry.AdapterMeta {
-						return registry.AdapterMeta{RequiresCommand: true}
+					metaFunc: func(string) (registry.AgentMeta, bool) {
+						return registry.AgentMeta{RequiresCommand: true}, true
 					},
 				}
 			},
@@ -349,7 +349,7 @@ func TestValidateDispatchConfig(t *testing.T) {
 							Available: []string{},
 						}
 					},
-					metaFunc: func(string) registry.AdapterMeta { return registry.AdapterMeta{} },
+					metaFunc: func(string) (registry.AgentMeta, bool) { return registry.AgentMeta{}, true },
 				}
 			},
 			wantChecks: []string{"agent_adapter"},
@@ -368,7 +368,7 @@ func TestValidateDispatchConfig(t *testing.T) {
 							Available: []string{},
 						}
 					},
-					metaFunc: func(string) registry.AdapterMeta { return registry.AdapterMeta{} },
+					metaFunc: func(string) (registry.AgentMeta, bool) { return registry.AgentMeta{}, true },
 				}
 			},
 			wantChecks: []string{"tracker.kind", "agent.kind"},
@@ -398,8 +398,8 @@ func TestValidateDispatchConfig(t *testing.T) {
 				}
 				p.TrackerRegistry = &stubTrackerRegistry{
 					getFunc: func(string) (registry.TrackerConstructor, error) { return nil, nil },
-					metaFunc: func(string) registry.AdapterMeta {
-						return registry.AdapterMeta{RequiresAPIKey: false}
+					metaFunc: func(string) (registry.TrackerMeta, bool) {
+						return registry.TrackerMeta{RequiresAPIKey: false}, true
 					},
 				}
 			},
@@ -422,8 +422,8 @@ func TestValidateDispatchConfig(t *testing.T) {
 				}
 				p.TrackerRegistry = &stubTrackerRegistry{
 					getFunc: func(string) (registry.TrackerConstructor, error) { return nil, nil },
-					metaFunc: func(string) registry.AdapterMeta {
-						return registry.AdapterMeta{RequiresAPIKey: true}
+					metaFunc: func(string) (registry.TrackerMeta, bool) {
+						return registry.TrackerMeta{RequiresAPIKey: true}, true
 					},
 				}
 			},
@@ -445,11 +445,11 @@ func TestValidateDispatchConfig(t *testing.T) {
 				// Both registries return zero-value meta (simulating plain Register).
 				p.TrackerRegistry = &stubTrackerRegistry{
 					getFunc:  func(string) (registry.TrackerConstructor, error) { return nil, nil },
-					metaFunc: func(string) registry.AdapterMeta { return registry.AdapterMeta{} },
+					metaFunc: func(string) (registry.TrackerMeta, bool) { return registry.TrackerMeta{}, true },
 				}
 				p.AgentRegistry = &stubAgentRegistry{
 					getFunc:  func(string) (registry.AgentConstructor, error) { return nil, nil },
-					metaFunc: func(string) registry.AdapterMeta { return registry.AdapterMeta{} },
+					metaFunc: func(string) (registry.AgentMeta, bool) { return registry.AgentMeta{}, true },
 				}
 			},
 			wantOK:   true,
@@ -459,14 +459,14 @@ func TestValidateDispatchConfig(t *testing.T) {
 			modify: func(p *PreflightParams) {
 				p.TrackerRegistry = &stubTrackerRegistry{
 					getFunc: func(string) (registry.TrackerConstructor, error) { return nil, nil },
-					metaFunc: func(string) registry.AdapterMeta {
-						return registry.AdapterMeta{
+					metaFunc: func(string) (registry.TrackerMeta, bool) {
+						return registry.TrackerMeta{
 							ValidateTrackerConfig: func(_ registry.TrackerConfigFields) []registry.ValidationDiag {
 								return []registry.ValidationDiag{
 									{Severity: "error", Check: "test.adapter.check", Message: "adapter error"},
 								}
 							},
-						}
+						}, true
 					},
 				}
 			},
@@ -478,14 +478,14 @@ func TestValidateDispatchConfig(t *testing.T) {
 			modify: func(p *PreflightParams) {
 				p.TrackerRegistry = &stubTrackerRegistry{
 					getFunc: func(string) (registry.TrackerConstructor, error) { return nil, nil },
-					metaFunc: func(string) registry.AdapterMeta {
-						return registry.AdapterMeta{
+					metaFunc: func(string) (registry.TrackerMeta, bool) {
+						return registry.TrackerMeta{
 							ValidateTrackerConfig: func(_ registry.TrackerConfigFields) []registry.ValidationDiag {
 								return []registry.ValidationDiag{
 									{Severity: "warning", Check: "test.adapter.warn", Message: "adapter warning"},
 								}
 							},
-						}
+						}, true
 					},
 				}
 			},
@@ -498,8 +498,8 @@ func TestValidateDispatchConfig(t *testing.T) {
 			modify: func(p *PreflightParams) {
 				p.TrackerRegistry = &stubTrackerRegistry{
 					getFunc: func(string) (registry.TrackerConstructor, error) { return nil, nil },
-					metaFunc: func(string) registry.AdapterMeta {
-						return registry.AdapterMeta{} // ValidateTrackerConfig is nil
+					metaFunc: func(string) (registry.TrackerMeta, bool) {
+						return registry.TrackerMeta{}, true // ValidateTrackerConfig is nil
 					},
 				}
 			},

--- a/internal/registry/adapter_meta_test.go
+++ b/internal/registry/adapter_meta_test.go
@@ -47,7 +47,10 @@ func TestAdapterMeta_RealRegistrations(t *testing.T) {
 			t.Run(tt.name, func(t *testing.T) {
 				t.Parallel()
 
-				meta, _ := registry.Trackers.Meta(tt.kind)
+				meta, ok := registry.Trackers.Meta(tt.kind)
+				if !ok {
+					t.Fatalf("Trackers.Meta(%q) reported not registered", tt.kind)
+				}
 
 				if meta.RequiresAPIKey != tt.wantAPIKey {
 					t.Errorf("Trackers.Meta(%q).RequiresAPIKey = %v, want %v", tt.kind, meta.RequiresAPIKey, tt.wantAPIKey)
@@ -82,7 +85,10 @@ func TestAdapterMeta_RealRegistrations(t *testing.T) {
 			t.Run(tt.name, func(t *testing.T) {
 				t.Parallel()
 
-				meta, _ := registry.Agents.Meta(tt.kind)
+				meta, ok := registry.Agents.Meta(tt.kind)
+				if !ok {
+					t.Fatalf("Agents.Meta(%q) reported not registered", tt.kind)
+				}
 
 				if meta.RequiresCommand != tt.wantCommand {
 					t.Errorf("Agents.Meta(%q).RequiresCommand = %v, want %v", tt.kind, meta.RequiresCommand, tt.wantCommand)
@@ -94,7 +100,10 @@ func TestAdapterMeta_RealRegistrations(t *testing.T) {
 	t.Run("github exposes ValidateTrackerConfig", func(t *testing.T) {
 		t.Parallel()
 
-		meta, _ := registry.Trackers.Meta("github")
+		meta, ok := registry.Trackers.Meta("github")
+		if !ok {
+			t.Fatal(`Trackers.Meta("github") reported not registered`)
+		}
 		if meta.ValidateTrackerConfig == nil {
 			t.Error(`Trackers.Meta("github").ValidateTrackerConfig = nil, want non-nil`)
 		}

--- a/internal/registry/adapter_meta_test.go
+++ b/internal/registry/adapter_meta_test.go
@@ -24,7 +24,6 @@ func TestAdapterMeta_RealRegistrations(t *testing.T) {
 			kind        string
 			wantAPIKey  bool
 			wantProject bool
-			wantCommand bool
 		}{
 			{
 				name:        "jira requires api_key and project",
@@ -48,16 +47,13 @@ func TestAdapterMeta_RealRegistrations(t *testing.T) {
 			t.Run(tt.name, func(t *testing.T) {
 				t.Parallel()
 
-				meta := registry.Trackers.Meta(tt.kind)
+				meta, _ := registry.Trackers.Meta(tt.kind)
 
 				if meta.RequiresAPIKey != tt.wantAPIKey {
 					t.Errorf("Trackers.Meta(%q).RequiresAPIKey = %v, want %v", tt.kind, meta.RequiresAPIKey, tt.wantAPIKey)
 				}
 				if meta.RequiresProject != tt.wantProject {
 					t.Errorf("Trackers.Meta(%q).RequiresProject = %v, want %v", tt.kind, meta.RequiresProject, tt.wantProject)
-				}
-				if meta.RequiresCommand != tt.wantCommand {
-					t.Errorf("Trackers.Meta(%q).RequiresCommand = %v, want %v", tt.kind, meta.RequiresCommand, tt.wantCommand)
 				}
 			})
 		}
@@ -69,8 +65,6 @@ func TestAdapterMeta_RealRegistrations(t *testing.T) {
 		tests := []struct {
 			name        string
 			kind        string
-			wantAPIKey  bool
-			wantProject bool
 			wantCommand bool
 		}{
 			{
@@ -88,14 +82,8 @@ func TestAdapterMeta_RealRegistrations(t *testing.T) {
 			t.Run(tt.name, func(t *testing.T) {
 				t.Parallel()
 
-				meta := registry.Agents.Meta(tt.kind)
+				meta, _ := registry.Agents.Meta(tt.kind)
 
-				if meta.RequiresAPIKey != tt.wantAPIKey {
-					t.Errorf("Agents.Meta(%q).RequiresAPIKey = %v, want %v", tt.kind, meta.RequiresAPIKey, tt.wantAPIKey)
-				}
-				if meta.RequiresProject != tt.wantProject {
-					t.Errorf("Agents.Meta(%q).RequiresProject = %v, want %v", tt.kind, meta.RequiresProject, tt.wantProject)
-				}
 				if meta.RequiresCommand != tt.wantCommand {
 					t.Errorf("Agents.Meta(%q).RequiresCommand = %v, want %v", tt.kind, meta.RequiresCommand, tt.wantCommand)
 				}
@@ -106,7 +94,7 @@ func TestAdapterMeta_RealRegistrations(t *testing.T) {
 	t.Run("github exposes ValidateTrackerConfig", func(t *testing.T) {
 		t.Parallel()
 
-		meta := registry.Trackers.Meta("github")
+		meta, _ := registry.Trackers.Meta("github")
 		if meta.ValidateTrackerConfig == nil {
 			t.Error(`Trackers.Meta("github").ValidateTrackerConfig = nil, want non-nil`)
 		}

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -23,7 +23,7 @@ type TrackerConstructor func(config map[string]any) (domain.TrackerAdapter, erro
 // Trackers is the default tracker adapter registry. Adapter packages
 // register themselves via [Registry.Register] in their init functions;
 // the orchestrator resolves adapters via [Registry.Get] at runtime.
-var Trackers = NewRegistry[TrackerConstructor]("tracker")
+var Trackers = NewRegistry[TrackerConstructor, TrackerMeta]("tracker")
 
 // AgentConstructor creates a [domain.AgentAdapter] from opaque
 // adapter-specific configuration. The config parameter is the raw map
@@ -35,7 +35,7 @@ type AgentConstructor func(config map[string]any) (domain.AgentAdapter, error)
 // Agents is the default agent adapter registry. Adapter packages
 // register themselves via [Registry.Register] in their init functions;
 // the orchestrator resolves adapters via [Registry.Get] at runtime.
-var Agents = NewRegistry[AgentConstructor]("agent")
+var Agents = NewRegistry[AgentConstructor, AgentMeta]("agent")
 
 // CIProviderConstructor creates a [domain.CIStatusProvider] from
 // a maximum log-line count and opaque adapter-specific configuration.
@@ -50,7 +50,7 @@ type CIProviderConstructor func(maxLogLines int, adapterConfig map[string]any) (
 // packages register themselves via [Registry.Register] in their init
 // functions; the orchestrator resolves adapters via [Registry.Get] at
 // runtime.
-var CIProviders = NewRegistry[CIProviderConstructor]("ci_provider")
+var CIProviders = NewRegistry[CIProviderConstructor, struct{}]("ci_provider")
 
 // SCMAdapterConstructor creates a [domain.SCMAdapter] from opaque
 // adapter-specific configuration. The adapterConfig parameter is the
@@ -63,7 +63,7 @@ type SCMAdapterConstructor func(adapterConfig map[string]any) (domain.SCMAdapter
 // SCMAdapters is the default SCM adapter registry. Adapter packages
 // register themselves via [Registry.Register] in their init functions;
 // the orchestrator resolves adapters via [Registry.Get] at runtime.
-var SCMAdapters = NewRegistry[SCMAdapterConstructor]("scm")
+var SCMAdapters = NewRegistry[SCMAdapterConstructor, struct{}]("scm")
 
 // TrackerConfigFields holds the config values passed to adapter
 // validation functions. This is a plain data struct that avoids
@@ -87,10 +87,10 @@ type ValidationDiag struct {
 	Message  string // operator-friendly description
 }
 
-// AdapterMeta holds optional adapter-declared properties queried by
-// the orchestrator at preflight time. Zero value means no special
-// requirements.
-type AdapterMeta struct {
+// TrackerMeta holds optional tracker-adapter-declared properties
+// queried by the orchestrator at preflight time. Zero value means no
+// special requirements.
+type TrackerMeta struct {
 	// RequiresProject indicates the tracker adapter requires a
 	// non-empty tracker.project config value.
 	RequiresProject bool
@@ -99,45 +99,52 @@ type AdapterMeta struct {
 	// non-empty tracker.api_key config value.
 	RequiresAPIKey bool
 
-	// RequiresCommand indicates the agent adapter requires a
-	// non-empty agent.command config value.
-	RequiresCommand bool
-
 	// ValidateTrackerConfig is an optional function the preflight
 	// pipeline calls to run tracker-specific config validation.
 	// Nil means no adapter-specific validation.
 	ValidateTrackerConfig func(fields TrackerConfigFields) []ValidationDiag
 }
 
+// AgentMeta holds optional agent-adapter-declared properties queried
+// by the orchestrator at preflight time. Zero value means no special
+// requirements.
+type AgentMeta struct {
+	// RequiresCommand indicates the agent adapter requires a
+	// non-empty agent.command config value.
+	RequiresCommand bool
+}
+
 // Registry is a typed adapter registry mapping kind strings to
 // constructor functions. Safe for concurrent use; registrations are
 // expected during init and lookups happen at runtime.
 //
-// Registry is generic over the constructor function type to serve
-// both tracker and agent dimensions with a single implementation.
-type Registry[T any] struct {
+// Registry is generic over the constructor function type T and the
+// metadata type M to serve all adapter dimensions with a single
+// implementation.
+type Registry[T any, M any] struct {
 	name     string
 	mu       sync.RWMutex
 	adapters map[string]T
-	meta     map[string]AdapterMeta
+	meta     map[string]M
 }
 
 // NewRegistry creates an empty [Registry] with the given dimension
 // name. The name appears in error messages produced by [Registry.Get]
 // (e.g. "tracker", "agent").
-func NewRegistry[T any](name string) *Registry[T] {
-	return &Registry[T]{
+func NewRegistry[T any, M any](name string) *Registry[T, M] {
+	return &Registry[T, M]{
 		name:     name,
 		adapters: make(map[string]T),
-		meta:     make(map[string]AdapterMeta),
+		meta:     make(map[string]M),
 	}
 }
 
 // Register associates a kind string with a constructor function.
 // Panics if kind is empty or already registered. Registration is
 // expected during init(); duplicate registration is a programming
-// error.
-func (r *Registry[T]) Register(kind string, constructor T) {
+// error. The zero value of M is stored as metadata so that [Meta]
+// returns (zero, true) for kinds registered without explicit metadata.
+func (r *Registry[T, M]) Register(kind string, constructor T) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
@@ -148,11 +155,13 @@ func (r *Registry[T]) Register(kind string, constructor T) {
 		panic(fmt.Sprintf("registry: duplicate registration for kind %q", kind))
 	}
 	r.adapters[kind] = constructor
+	var zero M
+	r.meta[kind] = zero
 }
 
 // RegisterWithMeta associates a kind string with a constructor and
 // declared metadata. Panics on the same conditions as [Register].
-func (r *Registry[T]) RegisterWithMeta(kind string, constructor T, meta AdapterMeta) {
+func (r *Registry[T, M]) RegisterWithMeta(kind string, constructor T, meta M) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
@@ -166,19 +175,20 @@ func (r *Registry[T]) RegisterWithMeta(kind string, constructor T, meta AdapterM
 	r.meta[kind] = meta
 }
 
-// Meta returns the metadata for the given kind. Returns zero-value
-// [AdapterMeta] if the kind is not registered or was registered
-// without metadata.
-func (r *Registry[T]) Meta(kind string) AdapterMeta {
+// Meta returns the metadata for the given kind and a boolean
+// indicating whether the kind is registered. Returns (zero, false)
+// for unknown kinds and (meta, true) for registered kinds.
+func (r *Registry[T, M]) Meta(kind string) (M, bool) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	return r.meta[kind]
+	m, ok := r.meta[kind]
+	return m, ok
 }
 
 // Get returns the constructor for the given kind, or a
 // [*RegistryError] if the kind is not registered. The kind lookup is
 // exact-match (case-sensitive).
-func (r *Registry[T]) Get(kind string) (T, error) {
+func (r *Registry[T, M]) Get(kind string) (T, error) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
@@ -196,7 +206,7 @@ func (r *Registry[T]) Get(kind string) (T, error) {
 
 // Kinds returns a sorted list of all registered kind strings. The
 // returned slice is always non-nil.
-func (r *Registry[T]) Kinds() []string {
+func (r *Registry[T, M]) Kinds() []string {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 	return r.sortedKinds()
@@ -204,7 +214,7 @@ func (r *Registry[T]) Kinds() []string {
 
 // sortedKinds collects and sorts the registered kind strings. The
 // caller must hold r.mu (read or write). Always returns a non-nil slice.
-func (r *Registry[T]) sortedKinds() []string {
+func (r *Registry[T, M]) sortedKinds() []string {
 	kinds := make([]string, 0, len(r.adapters))
 	for k := range r.adapters {
 		kinds = append(kinds, k)

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -14,8 +14,13 @@ import (
 
 type testConstructor func() string
 
-func newTestRegistry() *Registry[testConstructor] {
-	return NewRegistry[testConstructor]("test")
+type testMeta struct {
+	RequiresProject bool
+	RequiresCommand bool
+}
+
+func newTestRegistry() *Registry[testConstructor, testMeta] {
+	return NewRegistry[testConstructor, testMeta]("test")
 }
 
 func dummyConstructor() testConstructor {
@@ -113,7 +118,7 @@ func TestRegister_Panics(t *testing.T) {
 	tests := []struct {
 		name    string
 		kind    string
-		setup   func(*Registry[testConstructor])
+		setup   func(*Registry[testConstructor, testMeta])
 		wantMsg string
 	}{
 		{
@@ -125,7 +130,7 @@ func TestRegister_Panics(t *testing.T) {
 		{
 			name: "duplicate kind",
 			kind: "dup",
-			setup: func(r *Registry[testConstructor]) {
+			setup: func(r *Registry[testConstructor, testMeta]) {
 				r.Register("dup", dummyConstructor())
 			},
 			wantMsg: "duplicate",
@@ -209,12 +214,15 @@ func TestRegisterWithMeta_AndMeta(t *testing.T) {
 		t.Parallel()
 
 		r := newTestRegistry()
-		r.RegisterWithMeta("alpha", dummyConstructor(), AdapterMeta{
+		r.RegisterWithMeta("alpha", dummyConstructor(), testMeta{
 			RequiresProject: true,
 			RequiresCommand: true,
 		})
 
-		got := r.Meta("alpha")
+		got, ok := r.Meta("alpha")
+		if !ok {
+			t.Fatalf("Meta(%q) ok = false, want true", "alpha")
+		}
 		if !got.RequiresProject {
 			t.Errorf("Meta(%q).RequiresProject = false, want true", "alpha")
 		}
@@ -227,7 +235,7 @@ func TestRegisterWithMeta_AndMeta(t *testing.T) {
 		t.Parallel()
 
 		r := newTestRegistry()
-		r.RegisterWithMeta("beta", dummyConstructor(), AdapterMeta{RequiresProject: true})
+		r.RegisterWithMeta("beta", dummyConstructor(), testMeta{RequiresProject: true})
 
 		got, err := r.Get("beta")
 		if err != nil {
@@ -244,7 +252,10 @@ func TestRegisterWithMeta_AndMeta(t *testing.T) {
 		r := newTestRegistry()
 		r.Register("gamma", dummyConstructor())
 
-		got := r.Meta("gamma")
+		got, ok := r.Meta("gamma")
+		if !ok {
+			t.Fatalf("Meta(%q) ok = false, want true for plain Register", "gamma")
+		}
 		if got.RequiresProject {
 			t.Errorf("Meta(%q).RequiresProject = true, want false for plain Register", "gamma")
 		}
@@ -258,7 +269,10 @@ func TestRegisterWithMeta_AndMeta(t *testing.T) {
 
 		r := newTestRegistry()
 
-		got := r.Meta("nonexistent")
+		got, ok := r.Meta("nonexistent")
+		if ok {
+			t.Errorf("Meta(%q) ok = true, want false for unregistered kind", "nonexistent")
+		}
 		if got.RequiresProject {
 			t.Errorf("Meta(%q).RequiresProject = true, want false for unregistered kind", "nonexistent")
 		}
@@ -274,7 +288,7 @@ func TestRegisterWithMeta_Panics(t *testing.T) {
 	tests := []struct {
 		name    string
 		kind    string
-		setup   func(*Registry[testConstructor])
+		setup   func(*Registry[testConstructor, testMeta])
 		wantMsg string
 	}{
 		{
@@ -286,15 +300,15 @@ func TestRegisterWithMeta_Panics(t *testing.T) {
 		{
 			name: "duplicate kind",
 			kind: "dup",
-			setup: func(r *Registry[testConstructor]) {
-				r.RegisterWithMeta("dup", dummyConstructor(), AdapterMeta{})
+			setup: func(r *Registry[testConstructor, testMeta]) {
+				r.RegisterWithMeta("dup", dummyConstructor(), testMeta{})
 			},
 			wantMsg: "duplicate",
 		},
 		{
 			name: "duplicate kind across Register and RegisterWithMeta",
 			kind: "dup",
-			setup: func(r *Registry[testConstructor]) {
+			setup: func(r *Registry[testConstructor, testMeta]) {
 				r.Register("dup", dummyConstructor())
 			},
 			wantMsg: "duplicate",
@@ -321,7 +335,7 @@ func TestRegisterWithMeta_Panics(t *testing.T) {
 				}
 			}()
 
-			r.RegisterWithMeta(tt.kind, dummyConstructor(), AdapterMeta{RequiresProject: true})
+			r.RegisterWithMeta(tt.kind, dummyConstructor(), testMeta{RequiresProject: true})
 		})
 	}
 }
@@ -410,7 +424,7 @@ func (m *mockTrackerAdapter) AddLabel(_ context.Context, _ string, _ string) err
 func TestTrackerRegistry(t *testing.T) {
 	t.Parallel()
 
-	r := NewRegistry[TrackerConstructor]("tracker")
+	r := NewRegistry[TrackerConstructor, TrackerMeta]("tracker")
 	r.Register("mock", func(_ map[string]any) (domain.TrackerAdapter, error) {
 		return &mockTrackerAdapter{}, nil
 	})
@@ -452,7 +466,7 @@ func (m *mockAgentAdapter) EventStream() <-chan domain.AgentEvent {
 func TestAgentRegistry(t *testing.T) {
 	t.Parallel()
 
-	r := NewRegistry[AgentConstructor]("agent")
+	r := NewRegistry[AgentConstructor, AgentMeta]("agent")
 	r.Register("mock", func(_ map[string]any) (domain.AgentAdapter, error) {
 		return &mockAgentAdapter{}, nil
 	})

--- a/internal/scm/github/tracker.go
+++ b/internal/scm/github/tracker.go
@@ -31,7 +31,7 @@ import (
 )
 
 func init() {
-	registry.Trackers.RegisterWithMeta("github", NewGitHubAdapter, registry.AdapterMeta{
+	registry.Trackers.RegisterWithMeta("github", NewGitHubAdapter, registry.TrackerMeta{
 		RequiresProject:       true,
 		RequiresAPIKey:        true,
 		ValidateTrackerConfig: validateConfig,

--- a/internal/tracker/jira/jira.go
+++ b/internal/tracker/jira/jira.go
@@ -19,7 +19,7 @@ import (
 )
 
 func init() {
-	registry.Trackers.RegisterWithMeta("jira", NewJiraAdapter, registry.AdapterMeta{
+	registry.Trackers.RegisterWithMeta("jira", NewJiraAdapter, registry.TrackerMeta{
 		RequiresProject: true,
 		RequiresAPIKey:  true,
 	})


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Refactor

**Intent:** `AdapterMeta` conflates tracker-only and agent-only fields in a single struct, allowing nonsensical combinations (e.g., an agent adapter setting `RequiresAPIKey`) with no compile-time rejection. Splitting into `TrackerMeta` and `AgentMeta` makes invalid cross-dimension registrations unrepresentable at compile time.

**Related Issues:** #210

### 🧭 Reviewer Guide

**Complexity:** Medium

#### Entry Point

`internal/registry/registry.go` — the core change. `AdapterMeta` is deleted and replaced by `TrackerMeta` (tracker-only fields) and `AgentMeta` (agent-only fields). `Registry[T]` gains a second type parameter `Registry[T, M]` that constrains the meta type per registry. `Meta(kind)` now returns `(M, bool)` to distinguish "registered without explicit meta" from "not registered at all". `Register` stores the zero value of `M` to uphold this invariant.

#### Sensitive Areas

- `internal/registry/registry.go`: Generic type parameter change — all four package-level registry variables updated; `Meta` signature change cascades to all consumers.
- `internal/orchestrator/preflight.go`: Inline interface method signatures for `TrackerRegistry` and `AgentRegistry` updated; agent meta lookup extracted to a local variable (multi-value returns cannot be used inline in Go).
- `internal/orchestrator/orchestrator_test.go`: `passingPreflightRegistries` helper was not listed in the original plan but required the same stub type updates to compile.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes — `internal/registry` is under `internal/`; no external consumers exist. All call sites are updated in this PR.
- **Migrations/State:** No migrations or state changes.