### PR TITLE
refactor(typeutil): extract shared ExtractStringSlice into internal/typeutil

### DIFF
--- a/.github/agents/tester.agent.md
+++ b/.github/agents/tester.agent.md
@@ -57,7 +57,11 @@ At least one criterion must be met. Do not write useless tests. Your KPI is test
 | Config       | `internal/config/`       | Unit                                      | Template rendering, `$VAR` resolution, `~` expansion, validation  |
 | Persistence  | `internal/persistence/`  | Integration (in-memory SQLite)            | Migrations, CRUD, idempotent upserts, recovery                    |
 | Tracker      | `internal/tracker/*/`    | Unit (httptest) + Integration (env-gated) | Response normalization, pagination, error categories              |
+| SCM          | `internal/scm/*/`        | Unit (httptest) + Integration (env-gated) | SCM integration, response normalization, pagination               |
 | Agent        | `internal/agent/*/`      | Unit (fixtures) + Integration (env-gated) | Event parsing, token extraction, timeout handling                 |
+| Agent util   | `internal/agent/agenttest/` | (test helper)                          | Shared test helpers for agent adapter tests                       |
+| Agent util   | `internal/agent/procutil/`  | Unit                                   | Subprocess lifecycle, exit code extraction                        |
+| Agent util   | `internal/agent/sshutil/`   | Unit                                   | SSH invocation, shell quoting                                     |
 | Workspace    | `internal/workspace/`    | Unit + Integration (temp dirs)            | Path containment (**SECURITY**), symlink rejection, hook env vars |
 | Orchestrator | `internal/orchestrator/` | Unit (mock adapters) + E2E (env-gated)    | Dispatch order, concurrency, reconciliation, retry scheduling, full dispatch cycle with real adapters |
 | Server       | `internal/server/`       | Unit (httptest)                           | JSON serialization, endpoint routing, error envelopes, 405 handling |
@@ -65,6 +69,7 @@ At least one criterion must be met. Do not write useless tests. Your KPI is test
 | Registry     | `internal/registry/`     | Unit                                      | Adapter registration, duplicate detection, lookup                 |
 | Logging      | `internal/logging/`      | Unit                                      | Logger setup, context field helpers                               |
 | Maputil      | `internal/maputil/`      | Unit                                      | Sorted key iteration, generic map helpers                         |
+| Typeutil     | `internal/typeutil/`     | Unit                                      | Type coercion for loosely-typed JSON/YAML values                  |
 | Tool         | `internal/tool/trackerapi/` | Unit                                   | Interface compliance, project scoping, input validation           |
 | Tool         | `internal/tool/history/`    | Unit                                   | Run history retrieval, attempt formatting                         |
 | Tool         | `internal/tool/mcpserver/`  | Unit                                   | JSON-RPC 2.0 routing, stdio transport, tool dispatch              |

--- a/.github/instructions/code-review.instructions.md
+++ b/.github/instructions/code-review.instructions.md
@@ -34,13 +34,15 @@ internal/workflow/     → internal/config, prompt            (no orchestrator, 
 internal/workspace/    → internal/domain, config, persistence
 internal/persistence/  → internal/domain, config
 internal/registry/     → internal/domain                   (adapter registration — no orchestrator, no persistence)
-internal/tracker/*/    → internal/domain, registry          (no cross-adapter imports)
+internal/tracker/*/    → internal/domain, registry, typeutil (no cross-adapter imports)
+internal/scm/*/        → internal/domain, registry, typeutil (no cross-adapter imports)
 internal/agent/*/      → internal/domain, registry, agent/procutil, agent/sshutil (no cross-adapter imports)
 internal/tool/*/        → internal/domain                  (agent tool implementations)
 internal/config/       → internal/domain, maputil          (no orchestrator, no persistence)
 internal/prompt/       → internal/domain, maputil          (no orchestrator, no persistence, no config)
 internal/domain/       → (nothing internal)                (pure types, interfaces, constants)
 internal/maputil/      → (nothing internal)                (generic map helpers)
+internal/typeutil/     → (nothing internal)                (type coercion helpers)
 internal/logging/      → (nothing internal)                (stdlib only)
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,13 +94,15 @@ internal/
   domain/              pure types, interfaces, error categories (imports nothing)
   logging/             structured slog helpers (imports nothing)
   maputil/             generic map utility helpers (imports nothing)
+  typeutil/            type coercion helpers (imports nothing)
   orchestrator/        dispatch, retry, reconciliation, state machine
   persistence/         SQLite store, migrations, retry queues
   prompt/              text/template rendering, strict mode
   registry/            adapter registration
   server/              HTTP API, dashboard, metrics
   tool/                agent tools (trackerapi/, history/, mcpserver/, status/)
-  tracker/             tracker adapters (jira/, github/, file/, etc.)
+  tracker/             tracker adapters (jira/, file/, etc.)
+  scm/                 SCM adapters (github/)
   workflow/            WORKFLOW.md parser, file watcher
   workspace/           filesystem isolation, path safety, hook execution
 docs/
@@ -108,9 +110,10 @@ docs/
   decisions/           Architecture Decision Records (ADRs)
 ```
 
-Imports flow downward. `domain/` and `logging/` sit at the bottom with no internal
-dependencies. Adapters (`tracker/*`, `agent/*`) implement interfaces defined in
-`domain/` and never import each other or the orchestrator.
+Imports flow downward. `domain/`, `logging/`, `maputil/`, and `typeutil/` sit at the
+bottom with no internal dependencies. Adapters (`tracker/*`, `scm/*`, `agent/*`)
+implement interfaces defined in `domain/` and never import each other or the
+orchestrator.
 
 ## Code conventions
 

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -193,6 +193,7 @@ Sortie is a single-binary Go service with this internal layout:
 | `internal/registry/`     | Support       | Adapter registration                                 |
 | `internal/logging/`      | Support       | Structured logging setup                             |
 | `internal/maputil/`      | Support       | Generic map helpers, sorted key iteration            |
+| `internal/typeutil/`     | Support       | Type coercion helpers for loosely-typed values        |
 | `internal/tool/trackerapi/` | Support    | Agent tool for tracker operations                    |
 | `internal/tool/history/`    | Support    | Agent tool for workspace run history                 |
 | `internal/tool/mcpserver/`  | Support    | MCP stdio server for tool dispatch                   |

--- a/internal/scm/github/tracker.go
+++ b/internal/scm/github/tracker.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/sortie-ai/sortie/internal/domain"
 	"github.com/sortie-ai/sortie/internal/registry"
+	"github.com/sortie-ai/sortie/internal/typeutil"
 )
 
 func init() {
@@ -105,7 +106,7 @@ func NewGitHubAdapter(config map[string]any) (domain.TrackerAdapter, error) {
 	}
 	endpoint = strings.TrimRight(endpoint, "/")
 
-	activeRaw := extractStringSlice(config["active_states"])
+	activeRaw := typeutil.ExtractStringSlice(config["active_states"])
 	if len(activeRaw) == 0 {
 		activeRaw = defaultActiveStates
 	}
@@ -114,7 +115,7 @@ func NewGitHubAdapter(config map[string]any) (domain.TrackerAdapter, error) {
 		activeStates[i] = strings.ToLower(s)
 	}
 
-	terminalRaw := extractStringSlice(config["terminal_states"])
+	terminalRaw := typeutil.ExtractStringSlice(config["terminal_states"])
 	if len(terminalRaw) == 0 {
 		terminalRaw = defaultTerminalStates
 	}
@@ -1034,24 +1035,4 @@ func (a *GitHubAdapter) incTrackerRequest(operation, outcome string) {
 func isNotFound(err error) bool {
 	te, ok := err.(*domain.TrackerError)
 	return ok && te.Kind == domain.ErrTrackerNotFound
-}
-
-// extractStringSlice converts a value that may be []any (from JSON
-// unmarshaling) or []string (from typed config) to []string, skipping
-// non-string elements.
-func extractStringSlice(v any) []string {
-	switch s := v.(type) {
-	case []any:
-		strs := make([]string, 0, len(s))
-		for _, elem := range s {
-			if str, ok := elem.(string); ok {
-				strs = append(strs, str)
-			}
-		}
-		return strs
-	case []string:
-		return s
-	default:
-		return nil
-	}
 }

--- a/internal/scm/github/tracker_test.go
+++ b/internal/scm/github/tracker_test.go
@@ -1937,42 +1937,6 @@ func TestTransitionIssue_DeleteLabelIsNotFound(t *testing.T) {
 	}
 }
 
-// --- extractStringSlice ---
-
-func TestExtractStringSlice(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name  string
-		input any
-		want  []string
-	}{
-		{name: "nil", input: nil, want: nil},
-		{name: "[]any strings", input: []any{"A", "B"}, want: []string{"A", "B"}},
-		{name: "[]string", input: []string{"X", "Y"}, want: []string{"X", "Y"}},
-		{name: "[]any mixed types", input: []any{"ok", 42, "yes"}, want: []string{"ok", "yes"}},
-		{name: "[]any empty", input: []any{}, want: []string{}},
-		{name: "int type wrong", input: 42, want: nil},
-		{name: "string scalar wrong", input: "single", want: nil},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			got := extractStringSlice(tt.input)
-			if len(got) != len(tt.want) {
-				t.Fatalf("extractStringSlice(%v) len = %d, want %d", tt.input, len(got), len(tt.want))
-			}
-			for i := range got {
-				if got[i] != tt.want[i] {
-					t.Errorf("extractStringSlice(%v)[%d] = %q, want %q", tt.input, i, got[i], tt.want[i])
-				}
-			}
-		})
-	}
-}
-
 // --- ETag cache constructor tests ---
 
 func TestNewGitHubAdapter_ETagCacheSizeDefault(t *testing.T) {

--- a/internal/tracker/file/file.go
+++ b/internal/tracker/file/file.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/sortie-ai/sortie/internal/domain"
 	"github.com/sortie-ai/sortie/internal/registry"
+	"github.com/sortie-ai/sortie/internal/typeutil"
 )
 
 func init() {
@@ -66,7 +67,7 @@ func NewFileAdapter(config map[string]any) (domain.TrackerAdapter, error) {
 
 	return &FileAdapter{
 		path:             path,
-		activeStates:     toStringSet(extractStringSlice(config["active_states"])),
+		activeStates:     toStringSet(typeutil.ExtractStringSlice(config["active_states"])),
 		overrides:        make(map[string]string),
 		commentOverrides: make(map[string][]domain.Comment),
 	}, nil
@@ -505,26 +506,6 @@ func normalize(raw rawIssue) domain.Issue {
 	}
 
 	return iss
-}
-
-// extractStringSlice safely extracts a []string from a value that may
-// be []any (as produced by YAML decoders) or []string. Non-string
-// elements are silently skipped.
-func extractStringSlice(val any) []string {
-	switch v := val.(type) {
-	case []any:
-		out := make([]string, 0, len(v))
-		for _, elem := range v {
-			if s, ok := elem.(string); ok {
-				out = append(out, s)
-			}
-		}
-		return out
-	case []string:
-		return v
-	default:
-		return nil
-	}
 }
 
 func toStringSet(ss []string) map[string]bool {

--- a/internal/tracker/jira/jira.go
+++ b/internal/tracker/jira/jira.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/sortie-ai/sortie/internal/domain"
 	"github.com/sortie-ai/sortie/internal/registry"
+	"github.com/sortie-ai/sortie/internal/typeutil"
 )
 
 func init() {
@@ -102,7 +103,7 @@ func NewJiraAdapter(config map[string]any) (domain.TrackerAdapter, error) {
 		}
 	}
 
-	activeStates := extractStringSlice(config["active_states"])
+	activeStates := typeutil.ExtractStringSlice(config["active_states"])
 	if len(activeStates) == 0 {
 		activeStates = defaultActiveStates
 	}
@@ -528,24 +529,4 @@ func (a *JiraAdapter) fetchComments(ctx context.Context, issueID string) ([]doma
 func isNotFound(err error) bool {
 	te, ok := err.(*domain.TrackerError)
 	return ok && te.Kind == domain.ErrTrackerNotFound
-}
-
-// extractStringSlice converts a value that may be []any (from JSON
-// unmarshaling) or []string (from typed config) to []string, skipping
-// non-string elements.
-func extractStringSlice(v any) []string {
-	switch s := v.(type) {
-	case []any:
-		strs := make([]string, 0, len(s))
-		for _, elem := range s {
-			if str, ok := elem.(string); ok {
-				strs = append(strs, str)
-			}
-		}
-		return strs
-	case []string:
-		return s
-	default:
-		return nil
-	}
 }

--- a/internal/tracker/jira/jira_test.go
+++ b/internal/tracker/jira/jira_test.go
@@ -190,38 +190,6 @@ func TestNewJiraAdapter_CustomActiveStates_StringSlice(t *testing.T) {
 	}
 }
 
-func TestExtractStringSlice(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name  string
-		input any
-		want  []string
-	}{
-		{name: "nil", input: nil, want: nil},
-		{name: "[]any strings", input: []any{"A", "B"}, want: []string{"A", "B"}},
-		{name: "[]string", input: []string{"X", "Y"}, want: []string{"X", "Y"}},
-		{name: "[]any mixed", input: []any{"ok", 42, "yes"}, want: []string{"ok", "yes"}},
-		{name: "[]any empty", input: []any{}, want: []string{}},
-		{name: "wrong type int", input: 42, want: nil},
-		{name: "wrong type string", input: "single", want: nil},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			got := extractStringSlice(tt.input)
-			if len(got) != len(tt.want) {
-				t.Fatalf("extractStringSlice(%v) len = %d, want %d", tt.input, len(got), len(tt.want))
-			}
-			for i := range got {
-				if got[i] != tt.want[i] {
-					t.Errorf("extractStringSlice(%v)[%d] = %q, want %q", tt.input, i, got[i], tt.want[i])
-				}
-			}
-		})
-	}
-}
-
 func TestNewJiraAdapter_QueryFilter(t *testing.T) {
 	t.Parallel()
 

--- a/internal/typeutil/typeutil.go
+++ b/internal/typeutil/typeutil.go
@@ -1,0 +1,27 @@
+// Package typeutil provides type coercion utilities for loosely-typed values
+// produced by JSON and YAML decoders. These helpers are shared across adapter
+// packages that cannot import each other.
+package typeutil
+
+// ExtractStringSlice converts a loosely-typed value to []string.
+//
+// It handles []any (as produced by JSON and YAML decoders) by extracting
+// string elements and skipping non-string values, and []string by returning
+// it directly without copying. For any other type, including nil, it returns
+// nil.
+func ExtractStringSlice(v any) []string {
+	switch s := v.(type) {
+	case []any:
+		strs := make([]string, 0, len(s))
+		for _, elem := range s {
+			if str, ok := elem.(string); ok {
+				strs = append(strs, str)
+			}
+		}
+		return strs
+	case []string:
+		return s
+	default:
+		return nil
+	}
+}

--- a/internal/typeutil/typeutil_test.go
+++ b/internal/typeutil/typeutil_test.go
@@ -1,0 +1,53 @@
+package typeutil
+
+import "testing"
+
+func TestExtractStringSlice(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		input   any
+		want    []string
+		wantNil bool
+	}{
+		{name: "nil", input: nil, want: nil, wantNil: true},
+		{name: "[]any strings", input: []any{"A", "B"}, want: []string{"A", "B"}},
+		{name: "[]string passthrough", input: []string{"X", "Y"}, want: []string{"X", "Y"}},
+		{name: "[]any mixed types", input: []any{"ok", 42, "yes"}, want: []string{"ok", "yes"}},
+		{name: "[]any empty", input: []any{}, want: []string{}},
+		{name: "wrong type int", input: 42, want: nil, wantNil: true},
+		{name: "wrong type string", input: "single", want: nil, wantNil: true},
+		{name: "[]any with nil element", input: []any{nil, "a", nil}, want: []string{"a"}},
+		{name: "[]any all non-string", input: []any{1, 2.5, true}, want: []string{}},
+		{name: "map type", input: map[string]any{"k": "v"}, want: nil, wantNil: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := ExtractStringSlice(tt.input)
+
+			if tt.wantNil {
+				if got != nil {
+					t.Fatalf("ExtractStringSlice() = %v, want nil", got)
+				}
+				return
+			}
+
+			if got == nil {
+				t.Fatalf("ExtractStringSlice() = nil, want non-nil %v", tt.want)
+			}
+
+			if len(got) != len(tt.want) {
+				t.Fatalf("ExtractStringSlice() len = %d, want %d", len(got), len(tt.want))
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("ExtractStringSlice()[%d] = %q, want %q", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Refactor

**Intent:** Four copies of a private `extractStringSlice` helper existed across three adapter packages (`tracker/jira`, `tracker/file`, `scm/github`) with identical semantics. This PR extracts the shared implementation into a new leaf package `internal/typeutil`, eliminating duplication and giving future adapters a single, tested point of maintenance for JSON/YAML type coercion.

**Related Issues:** #308

### 🧭 Reviewer Guide

**Complexity:** Low

#### Entry Point

`internal/typeutil/typeutil.go` — the new shared leaf package. The exported `ExtractStringSlice` function is a direct promotion of the three private implementations, with behavior preserved exactly: `[]any` extracts string elements (skipping non-strings), `[]string` is returned as-is, and any other type (including nil) returns nil.

#### Sensitive Areas

- `internal/config/config.go`: Intentionally **not** modified. The config package has a private `extractStringSlice` with divergent semantics (`fmt.Sprintf` for non-string elements) and is out of scope for this change.
- `.github/instructions/code-review.instructions.md`: Layer boundary rules updated to authorize `typeutil` imports from `tracker/*/` and `scm/*/` adapters; also adds the `internal/typeutil/` leaf entry.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes. All changes are internal — no exported API surfaces or adapter interfaces are touched.
- **Migrations/State:** No migrations or state changes.