### PR TITLE
refactor(orchestrator): return config warnings instead of global slog

### DIFF
--- a/cmd/sortie/dryrun.go
+++ b/cmd/sortie/dryrun.go
@@ -32,6 +32,9 @@ func runDryRun(ctx context.Context, cfg config.ServiceConfig, logger *slog.Logge
 	)
 
 	wc := orchestrator.ParseWorkerConfig(cfg.Extensions)
+	for _, w := range wc.Warnings {
+		logger.LogAttrs(ctx, slog.LevelWarn, w.Message, w.Attrs...) //nolint:sloglint // WorkerWarning.Message is one of two fixed string constants from parseSSHStrictHostKeyChecking
+	}
 	hostPool := orchestrator.NewHostPool(wc.SSHHosts, wc.MaxPerHost)
 
 	activeSet := dryRunStateSet(cfg.Tracker.ActiveStates)

--- a/internal/orchestrator/hostpool.go
+++ b/internal/orchestrator/hostpool.go
@@ -336,7 +336,7 @@ func workerWarningsEqual(a, b []WorkerWarning) bool {
 			if a[i].Attrs[j].Key != b[i].Attrs[j].Key {
 				return false
 			}
-			if a[i].Attrs[j].Value.String() != b[i].Attrs[j].Value.String() {
+			if !a[i].Attrs[j].Value.Equal(b[i].Attrs[j].Value) {
 				return false
 			}
 		}

--- a/internal/orchestrator/hostpool.go
+++ b/internal/orchestrator/hostpool.go
@@ -198,6 +198,15 @@ func deduplicateHosts(hosts []string) []string {
 	return deduped
 }
 
+// WorkerWarning is a structured validation diagnostic produced by
+// [ParseWorkerConfig]. It carries a stable log message and typed
+// slog attributes so the caller can emit it through its scoped
+// logger without interpolating variable data into the message string.
+type WorkerWarning struct {
+	Message string
+	Attrs   []slog.Attr
+}
+
 // WorkerConfig holds parsed worker extension configuration.
 type WorkerConfig struct {
 	// SSHHosts is the list of SSH host strings for remote dispatch.
@@ -211,6 +220,12 @@ type WorkerConfig struct {
 	// value used when building SSH arguments for agent adapters.
 	// Valid values: "accept-new", "yes", "no". Empty means "accept-new".
 	SSHStrictHostKeyChecking string
+
+	// Warnings contains structured validation diagnostics produced
+	// during parsing. Empty when all values are valid or absent.
+	// The caller logs these through its scoped logger after
+	// change-detection.
+	Warnings []WorkerWarning
 }
 
 // ParseWorkerConfig parses worker extension configuration from the
@@ -256,43 +271,75 @@ func ParseWorkerConfig(extensions map[string]any) WorkerConfig {
 		}
 	}
 
-	strictHostKeyChecking := parseSSHStrictHostKeyChecking(workerMap)
+	strictHostKeyChecking, warn := parseSSHStrictHostKeyChecking(workerMap)
+
+	var warnings []WorkerWarning
+	if warn != nil {
+		warnings = append(warnings, *warn)
+	}
 
 	hosts = deduplicateHosts(hosts)
 	return WorkerConfig{
 		SSHHosts:                 hosts,
 		MaxPerHost:               maxPerHost,
 		SSHStrictHostKeyChecking: strictHostKeyChecking,
+		Warnings:                 warnings,
 	}
 }
 
 // parseSSHStrictHostKeyChecking extracts and validates the
 // ssh_strict_host_key_checking value from the worker extension map.
-// Returns one of "accept-new", "yes", "no", or empty string (meaning
-// the caller should use the default "accept-new" behavior).
-func parseSSHStrictHostKeyChecking(workerMap map[string]any) string {
+// Returns the normalized value (one of "accept-new", "yes", "no", or
+// empty for default) and a structured diagnostic. The diagnostic is
+// non-nil when the raw value has the wrong type or is unrecognized.
+func parseSSHStrictHostKeyChecking(workerMap map[string]any) (string, *WorkerWarning) {
 	raw, ok := workerMap["ssh_strict_host_key_checking"]
 	if !ok {
-		return ""
+		return "", nil
 	}
 
 	s, ok := raw.(string)
 	if !ok {
-		slog.Warn("received non-string ssh_strict_host_key_checking, using default",
-			slog.String("default", "accept-new"),
-		)
-		return ""
+		return "", &WorkerWarning{
+			Message: "received non-string ssh_strict_host_key_checking, using default",
+			Attrs:   []slog.Attr{slog.String("default", "accept-new")},
+		}
 	}
 
 	normalized := strings.ToLower(strings.TrimSpace(s))
 	switch normalized {
 	case "accept-new", "yes", "no":
-		return normalized
+		return normalized, nil
 	default:
-		slog.Warn("rejected unrecognized ssh_strict_host_key_checking value",
-			slog.String("value", s),
-			slog.String("default", "accept-new"),
-		)
-		return ""
+		return "", &WorkerWarning{
+			Message: "rejected unrecognized ssh_strict_host_key_checking value",
+			Attrs:   []slog.Attr{slog.String("value", s), slog.String("default", "accept-new")},
+		}
 	}
+}
+
+func workerWarningsEqual(a, b []WorkerWarning) bool {
+	if len(a) == 0 && len(b) == 0 {
+		return true
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i].Message != b[i].Message {
+			return false
+		}
+		if len(a[i].Attrs) != len(b[i].Attrs) {
+			return false
+		}
+		for j := range a[i].Attrs {
+			if a[i].Attrs[j].Key != b[i].Attrs[j].Key {
+				return false
+			}
+			if a[i].Attrs[j].Value.String() != b[i].Attrs[j].Value.String() {
+				return false
+			}
+		}
+	}
+	return true
 }

--- a/internal/orchestrator/hostpool_test.go
+++ b/internal/orchestrator/hostpool_test.go
@@ -1,6 +1,7 @@
 package orchestrator
 
 import (
+	"log/slog"
 	"testing"
 )
 
@@ -260,6 +261,7 @@ func TestParseWorkerConfig(t *testing.T) {
 		wantHosts                 []string
 		wantMaxPerHost            int
 		wantSSHStrictHostKeyCheck string
+		wantWarnings              []WorkerWarning
 	}{
 		{
 			name:       "nil extensions",
@@ -374,6 +376,12 @@ func TestParseWorkerConfig(t *testing.T) {
 				},
 			},
 			wantSSHStrictHostKeyCheck: "",
+			wantWarnings: []WorkerWarning{
+				{
+					Message: "rejected unrecognized ssh_strict_host_key_checking value",
+					Attrs:   []slog.Attr{slog.String("value", "ask"), slog.String("default", "accept-new")},
+				},
+			},
 		},
 		{
 			name: "wrong type integer falls back to empty",
@@ -383,6 +391,12 @@ func TestParseWorkerConfig(t *testing.T) {
 				},
 			},
 			wantSSHStrictHostKeyCheck: "",
+			wantWarnings: []WorkerWarning{
+				{
+					Message: "received non-string ssh_strict_host_key_checking, using default",
+					Attrs:   []slog.Attr{slog.String("default", "accept-new")},
+				},
+			},
 		},
 	}
 
@@ -405,6 +419,107 @@ func TestParseWorkerConfig(t *testing.T) {
 			}
 			if wc.SSHStrictHostKeyChecking != tt.wantSSHStrictHostKeyCheck {
 				t.Errorf("ParseWorkerConfig() SSHStrictHostKeyChecking = %q, want %q", wc.SSHStrictHostKeyChecking, tt.wantSSHStrictHostKeyCheck)
+			}
+			if len(wc.Warnings) != len(tt.wantWarnings) {
+				t.Fatalf("ParseWorkerConfig() Warnings count = %d, want %d", len(wc.Warnings), len(tt.wantWarnings))
+			}
+			for i, want := range tt.wantWarnings {
+				if wc.Warnings[i].Message != want.Message {
+					t.Errorf("Warnings[%d].Message = %q, want %q", i, wc.Warnings[i].Message, want.Message)
+				}
+				if len(wc.Warnings[i].Attrs) != len(want.Attrs) {
+					t.Fatalf("Warnings[%d].Attrs count = %d, want %d", i, len(wc.Warnings[i].Attrs), len(want.Attrs))
+				}
+				for j, wantAttr := range want.Attrs {
+					gotAttr := wc.Warnings[i].Attrs[j]
+					if gotAttr.Key != wantAttr.Key {
+						t.Errorf("Warnings[%d].Attrs[%d].Key = %q, want %q", i, j, gotAttr.Key, wantAttr.Key)
+					}
+					if gotAttr.Value.String() != wantAttr.Value.String() {
+						t.Errorf("Warnings[%d].Attrs[%d].Value = %q, want %q", i, j, gotAttr.Value.String(), wantAttr.Value.String())
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestWorkerWarningsEqual(t *testing.T) {
+	t.Parallel()
+
+	attrValue := func(key, val string) slog.Attr { return slog.String(key, val) }
+
+	tests := []struct {
+		name string
+		a    []WorkerWarning
+		b    []WorkerWarning
+		want bool
+	}{
+		{
+			name: "both nil",
+			a:    nil,
+			b:    nil,
+			want: true,
+		},
+		{
+			name: "both empty",
+			a:    []WorkerWarning{},
+			b:    []WorkerWarning{},
+			want: true,
+		},
+		{
+			name: "nil vs empty",
+			a:    nil,
+			b:    []WorkerWarning{},
+			want: true,
+		},
+		{
+			name: "single warning identical",
+			a: []WorkerWarning{
+				{Message: "some warning", Attrs: []slog.Attr{attrValue("key", "val")}},
+			},
+			b: []WorkerWarning{
+				{Message: "some warning", Attrs: []slog.Attr{attrValue("key", "val")}},
+			},
+			want: true,
+		},
+		{
+			name: "same message different attr value",
+			a: []WorkerWarning{
+				{Message: "some warning", Attrs: []slog.Attr{attrValue("key", "val-a")}},
+			},
+			b: []WorkerWarning{
+				{Message: "some warning", Attrs: []slog.Attr{attrValue("key", "val-b")}},
+			},
+			want: false,
+		},
+		{
+			name: "different message",
+			a: []WorkerWarning{
+				{Message: "warning-a", Attrs: []slog.Attr{attrValue("k", "v")}},
+			},
+			b: []WorkerWarning{
+				{Message: "warning-b", Attrs: []slog.Attr{attrValue("k", "v")}},
+			},
+			want: false,
+		},
+		{
+			name: "different lengths",
+			a: []WorkerWarning{
+				{Message: "w", Attrs: []slog.Attr{attrValue("k", "v")}},
+			},
+			b:    []WorkerWarning{},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := workerWarningsEqual(tt.a, tt.b)
+			if got != tt.want {
+				t.Errorf("workerWarningsEqual(%v, %v) = %t, want %t", tt.a, tt.b, got, tt.want)
 			}
 		})
 	}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -142,6 +142,8 @@ type Orchestrator struct {
 	// StrictHostKeyChecking value. Written by handleTick on every
 	// tick/reload; read by makeWorkerFn at dispatch time.
 	sshStrictHostKeyChecking string
+
+	prevWorkerWarnings []WorkerWarning
 }
 
 // NewOrchestrator creates an [Orchestrator] with all dependencies wired.
@@ -368,6 +370,13 @@ func (o *Orchestrator) handleTick(ctx context.Context) {
 	wc := ParseWorkerConfig(cfg.Extensions)
 	o.hostPool.Update(wc.SSHHosts, wc.MaxPerHost)
 	o.sshStrictHostKeyChecking = wc.SSHStrictHostKeyChecking
+
+	if !workerWarningsEqual(o.prevWorkerWarnings, wc.Warnings) {
+		for _, w := range wc.Warnings {
+			o.logger.LogAttrs(ctx, slog.LevelWarn, w.Message, w.Attrs...) //nolint:sloglint // WorkerWarning.Message is one of two fixed string constants from parseSSHStrictHostKeyChecking
+		}
+		o.prevWorkerWarnings = wc.Warnings
+	}
 
 	// Reconcile running issues unconditionally so in-flight workers
 	// are monitored even when dispatch is skipped.

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -4383,3 +4383,83 @@ func TestHandleTickSweepThrottle(t *testing.T) {
 		t.Errorf("SweepTickCounter = %d after sweep, want 0", got)
 	}
 }
+
+// --- TestHandleTick_WorkerWarningChangeDetection ---
+
+func TestHandleTick_WorkerWarningChangeDetection(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, nil))
+
+	cfg := config.ServiceConfig{
+		Tracker: config.TrackerConfig{
+			Kind:           "mock",
+			ActiveStates:   []string{"To Do"},
+			TerminalStates: []string{"Done"},
+		},
+		Polling:   config.PollingConfig{IntervalMS: 60000},
+		Workspace: config.WorkspaceConfig{Root: t.TempDir()},
+		Agent: config.AgentConfig{
+			Kind:                "mock",
+			MaxConcurrentAgents: 1,
+		},
+		Extensions: map[string]any{
+			"worker": map[string]any{
+				"ssh_strict_host_key_checking": "ask",
+			},
+		},
+	}
+
+	wm := &stubWorkflowManager{config: cfg}
+	state := NewState(60000, 1, nil, AgentTotals{})
+	o := NewOrchestrator(OrchestratorParams{
+		State:           state,
+		Logger:          logger,
+		TrackerAdapter:  &mockTrackerAdapter{},
+		AgentAdapter:    &mockAgentAdapter{},
+		WorkflowManager: wm,
+		Store:           &stubStore{},
+		PreflightParams: PreflightParams{
+			ReloadWorkflow: func() error { return errPreflightFailed },
+			ConfigFunc:     wm.Config,
+		},
+	})
+
+	ctx := context.Background()
+
+	const warnMsg = "rejected unrecognized ssh_strict_host_key_checking value"
+
+	// First tick: warning for "ask" must be logged.
+	o.handleTick(ctx)
+	// Second tick: same config, warning must be suppressed.
+	o.handleTick(ctx)
+	if got := strings.Count(buf.String(), warnMsg); got != 1 {
+		t.Errorf("warning count after two identical ticks = %d, want 1\nlog:\n%s", got, buf.String())
+	}
+
+	// Change to a different invalid value — a new warning must appear.
+	cfg.Extensions = map[string]any{
+		"worker": map[string]any{
+			"ssh_strict_host_key_checking": "strict",
+		},
+	}
+	wm.setConfig(cfg)
+	o.handleTick(ctx)
+	if got := strings.Count(buf.String(), warnMsg); got != 2 {
+		t.Errorf("warning count after changing value to 'strict' = %d, want 2\nlog:\n%s", got, buf.String())
+	}
+
+	// Change SSHHosts while keeping the same invalid value — warning must be suppressed.
+	cfg.Extensions = map[string]any{
+		"worker": map[string]any{
+			"ssh_strict_host_key_checking": "strict",
+			"ssh_hosts":                    []any{"host-a"},
+		},
+	}
+	wm.setConfig(cfg)
+	o.handleTick(ctx)
+	if got := strings.Count(buf.String(), warnMsg); got != 2 {
+		t.Errorf("warning count after changing SSHHosts only = %d, want 2\nlog:\n%s", got, buf.String())
+	}
+}


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Refactor

**Intent:** `ParseWorkerConfig` previously called `slog.Warn` directly for invalid `ssh_strict_host_key_checking` values, bypassing the orchestrator's scoped logger and emitting a repeated warning on every tick for stable misconfigured values. This change routes all validation diagnostics through the caller's scoped `*slog.Logger` with per-tick change-detection to suppress duplicate log lines.

**Related Issues:** #331

### 🧭 Reviewer Guide

**Complexity:** Medium

#### Entry Point

`internal/orchestrator/hostpool.go` — introduces `WorkerWarning` and `WorkerConfig.Warnings`, and refactors `parseSSHStrictHostKeyChecking` to return `(string, *WorkerWarning)` instead of calling `slog.Warn`. Start here to understand the diagnostic collection model before reading the orchestrator change-detection block.

#### Sensitive Areas

- `internal/orchestrator/orchestrator.go`: `handleTick` adds a `workerWarningsEqual` comparison to gate warning emission — the first tick always emits (nil initial state), subsequent identical warnings are suppressed.
- `cmd/sortie/dryrun.go`: single-shot path logs warnings unconditionally with no suppression; different semantics from the event loop path.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes — `ParseWorkerConfig` signature is unchanged; `Warnings` is an additive field; callers that ignore it compile and behave identically except for the removed global log side effect.
- **Migrations/State:** No migrations or state changes