### PR TITLE
feat(procutil): harden StderrCollector with scanner buffer cap and memory limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,14 @@ Sortie turns issue tracker tickets into autonomous coding agent sessions. Engine
 
 Sortie assumes your coding agent already produces useful results when you run it manually. It handles scheduling, retry, isolation, and persistence around that agent — it does not improve the agent's output.
 
+## Install
+
+```bash
+curl -sSL https://get.sortie-ai.com/install.sh | sh
+```
+
+Or via Homebrew: `brew install sortie-ai/tap/sortie`
+
 ## The Problem
 
 Coding agents can handle routine engineering tasks — bug fixes, dependency updates, test coverage, feature work — when they have good system prompts, appropriate tool permissions, and have been tested on representative issues. But running validated agents at scale requires infrastructure that doesn't exist yet: isolated workspaces, retry logic, state reconciliation, tracker integration, cost tracking. Teams build this ad-hoc, poorly, and differently each time.
@@ -25,42 +33,19 @@ tracker:
   project: acme/billing-api
   query_filter: "label:agent-ready"
   active_states: [todo, in-progress]
-  in_progress_state: in-progress
-  terminal_states: [done, wontfix]
+  handoff_state: review
+  terminal_states: [done]
 
 agent:
   kind: claude-code
-  max_turns: 10
-  max_sessions: 3
   max_concurrent_agents: 4
-
-workspace:
-  root: ~/workspace/billing-api
-
-hooks:
-  after_create: |
-    git clone --depth 1 git@github.com:acme/billing-api.git .
-  before_run: |
-    git fetch origin main
-    git checkout -B "sortie/$SORTIE_ISSUE_IDENTIFIER" origin/main
-  after_run: |
-    git add -A && git diff --cached --quiet || \
-      git commit -m "sortie($SORTIE_ISSUE_IDENTIFIER): automated changes"
-    git push origin "sortie/$SORTIE_ISSUE_IDENTIFIER"
 ---
 
-You are a senior Go engineer working on the billing-api service.
+You are a senior engineer.
 
 ## {{ .issue.identifier }}: {{ .issue.title }}
 
 {{ .issue.description }}
-
-{{ if .run.is_continuation }}
-Resuming work — review workspace state before continuing.
-{{ end }}
-{{ if .attempt }}
-Retry attempt {{ .attempt }}. Check the workspace for partial work.
-{{ end }}
 ```
 
 Set `GITHUB_TOKEN` to a fine-grained PAT with **Issues: Read and write** permission

--- a/internal/agent/procutil/procutil.go
+++ b/internal/agent/procutil/procutil.go
@@ -5,10 +5,71 @@ package procutil
 import (
 	"bufio"
 	"errors"
+	"fmt"
 	"io"
 	"log/slog"
 	"os/exec"
 )
+
+const (
+	// DefaultScannerMaxSize is the maximum token size for the stderr
+	// bufio.Scanner, matching the stdout scanner in agent adapters.
+	DefaultScannerMaxSize = 10 * 1024 * 1024
+
+	// DefaultMaxLines is the maximum number of stderr lines retained
+	// in memory. When exceeded, the collector keeps the first half
+	// and last half, discarding the middle.
+	DefaultMaxLines = 1000
+
+	// DefaultMaxBytes is the total byte budget for retained stderr
+	// lines across head and tail combined.
+	DefaultMaxBytes = 5 * 1024 * 1024
+
+	droppedMarkerFmt = "... (%d lines discarded) ..."
+)
+
+type collectorConfig struct {
+	maxLines   int
+	maxBytes   int
+	scannerMax int
+}
+
+// CollectorOption configures a [StderrCollector].
+type CollectorOption func(*collectorConfig)
+
+// WithMaxLines sets the maximum number of stderr lines retained in
+// memory. When the line count exceeds n, the collector retains the
+// first n/2 and last n-n/2 lines, discarding the middle. Zero or
+// negative values are ignored (default applies).
+func WithMaxLines(n int) CollectorOption {
+	return func(cfg *collectorConfig) {
+		if n > 0 {
+			cfg.maxLines = n
+		}
+	}
+}
+
+// WithMaxBytes sets the total byte budget for retained stderr lines.
+// When the budget is exhausted, the collector continues draining and
+// logging lines but stops storing them. Zero or negative values are
+// ignored (default applies).
+func WithMaxBytes(n int) CollectorOption {
+	return func(cfg *collectorConfig) {
+		if n > 0 {
+			cfg.maxBytes = n
+		}
+	}
+}
+
+// WithScannerMax sets the maximum token size for the internal
+// bufio.Scanner. Zero or negative values are ignored (default applies).
+func WithScannerMax(n int) CollectorOption {
+	return func(cfg *collectorConfig) {
+		if n > 0 {
+			cfg.scannerMax = n
+		}
+	}
+}
 
 // ExtractExitCode returns the process exit code from an
 // [*exec.ExitError], or -1 if the error is not an ExitError.
@@ -30,22 +91,64 @@ func ExtractExitCode(err error) int {
 // [NewStderrCollector] to start the drain goroutine and
 // [StderrCollector.Lines] to retrieve collected output after the
 // subprocess exits.
+//
+// When the number of lines exceeds the configured maximum, the
+// collector retains the first half (head) and last half (tail ring
+// buffer), discarding the middle. A byte budget independently caps
+// total retained bytes. In both cases the collector continues draining
+// the reader to avoid blocking the subprocess.
 type StderrCollector struct {
-	lines  []string
-	done   chan struct{}
-	logger *slog.Logger
+	head       []string
+	tail       []string
+	tailPos    int
+	tailFull   bool
+	dropped    int
+	headCap    int
+	tailCap    int
+	maxBytes   int
+	bytesUsed  int
+	scannerMax int
+	done       chan struct{}
+	logger     *slog.Logger
 }
 
 // NewStderrCollector starts a goroutine that drains r line by line,
 // logging each line at DEBUG level, and collecting them for later
 // retrieval via [StderrCollector.Lines].
-func NewStderrCollector(r io.Reader, logger *slog.Logger) *StderrCollector {
+//
+// Options override the default scanner buffer size, line cap, and byte
+// budget. With no options the collector uses [DefaultScannerMaxSize],
+// [DefaultMaxLines], and [DefaultMaxBytes].
+func NewStderrCollector(r io.Reader, logger *slog.Logger, opts ...CollectorOption) *StderrCollector {
 	if logger == nil {
 		logger = slog.Default()
 	}
+
+	cfg := collectorConfig{}
+	for _, o := range opts {
+		o(&cfg)
+	}
+	if cfg.maxLines == 0 {
+		cfg.maxLines = DefaultMaxLines
+	}
+	if cfg.maxBytes == 0 {
+		cfg.maxBytes = DefaultMaxBytes
+	}
+	if cfg.scannerMax == 0 {
+		cfg.scannerMax = DefaultScannerMaxSize
+	}
+
+	headCap := cfg.maxLines / 2
+	tailCap := cfg.maxLines - headCap
+
 	c := &StderrCollector{
-		done:   make(chan struct{}),
-		logger: logger,
+		tail:       make([]string, tailCap),
+		headCap:    headCap,
+		tailCap:    tailCap,
+		maxBytes:   cfg.maxBytes,
+		scannerMax: cfg.scannerMax,
+		done:       make(chan struct{}),
+		logger:     logger,
 	}
 	go c.drain(r)
 	return c
@@ -54,10 +157,41 @@ func NewStderrCollector(r io.Reader, logger *slog.Logger) *StderrCollector {
 func (c *StderrCollector) drain(r io.Reader) {
 	defer close(c.done)
 	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 0, 64*1024), c.scannerMax)
+
 	for scanner.Scan() {
 		line := scanner.Text()
 		c.logger.Debug("agent stderr", slog.String("line", line))
-		c.lines = append(c.lines, line)
+
+		if len(c.head) < c.headCap {
+			if c.bytesUsed+len(line) > c.maxBytes {
+				c.dropped++
+				continue
+			}
+			c.head = append(c.head, line)
+			c.bytesUsed += len(line)
+			continue
+		}
+
+		reclaimable := 0
+		if c.tailFull {
+			reclaimable = len(c.tail[c.tailPos])
+		}
+
+		if c.bytesUsed-reclaimable+len(line) > c.maxBytes {
+			c.dropped++
+			continue
+		}
+
+		if c.tailFull {
+			c.dropped++
+		}
+		c.tail[c.tailPos] = line
+		c.bytesUsed = c.bytesUsed - reclaimable + len(line)
+		c.tailPos = (c.tailPos + 1) % c.tailCap
+		if c.tailPos == 0 {
+			c.tailFull = true
+		}
 	}
 	if err := scanner.Err(); err != nil {
 		c.logger.Debug("agent stderr drain failed", slog.Any("error", err))
@@ -65,11 +199,39 @@ func (c *StderrCollector) drain(r io.Reader) {
 }
 
 // Lines blocks until the drain goroutine finishes and returns all
-// collected stderr lines. Safe to call after the subprocess has
-// exited.
+// collected stderr lines in chronological order. When lines were
+// discarded, a synthetic marker line is inserted between the head and
+// tail sections. Safe to call after the subprocess has exited.
 func (c *StderrCollector) Lines() []string {
 	<-c.done
-	return c.lines
+
+	hasTail := c.tailFull || c.tailPos > 0
+	if len(c.head) == 0 && !hasTail {
+		return nil
+	}
+
+	result := make([]string, len(c.head), len(c.head)+1+c.tailCap)
+	copy(result, c.head)
+
+	if c.dropped > 0 {
+		result = append(result, fmt.Sprintf(droppedMarkerFmt, c.dropped))
+	}
+
+	if c.tailFull {
+		result = append(result, c.tail[c.tailPos:]...)
+		result = append(result, c.tail[:c.tailPos]...)
+	} else {
+		result = append(result, c.tail[:c.tailPos]...)
+	}
+
+	return result
+}
+
+// Dropped blocks until the drain goroutine finishes and returns the
+// number of stderr lines discarded due to the line cap or byte budget.
+func (c *StderrCollector) Dropped() int {
+	<-c.done
+	return c.dropped
 }
 
 // WarnLines blocks until the drain goroutine finishes, then re-emits

--- a/internal/agent/procutil/procutil.go
+++ b/internal/agent/procutil/procutil.go
@@ -50,9 +50,9 @@ func WithMaxLines(n int) CollectorOption {
 }
 
 // WithMaxBytes sets the total byte budget for retained stderr lines.
-// When the budget is exhausted, the collector continues draining and
-// logging lines but stops storing them. Zero or negative values are
-// ignored (default applies).
+// The collector continues draining and logging all lines, but skips
+// retaining any individual line whose storage would exceed the current
+// byte budget. Zero or negative values are ignored (default applies).
 func WithMaxBytes(n int) CollectorOption {
 	return func(cfg *collectorConfig) {
 		if n > 0 {
@@ -118,7 +118,9 @@ type StderrCollector struct {
 //
 // Options override the default scanner buffer size, line cap, and byte
 // budget. With no options the collector uses [DefaultScannerMaxSize],
-// [DefaultMaxLines], and [DefaultMaxBytes].
+// [DefaultMaxLines], and [DefaultMaxBytes], which means default
+// behavior includes truncation safeguards that were not present in
+// earlier versions.
 func NewStderrCollector(r io.Reader, logger *slog.Logger, opts ...CollectorOption) *StderrCollector {
 	if logger == nil {
 		logger = slog.Default()
@@ -207,6 +209,9 @@ func (c *StderrCollector) Lines() []string {
 
 	hasTail := c.tailFull || c.tailPos > 0
 	if len(c.head) == 0 && !hasTail {
+		if c.dropped > 0 {
+			return []string{fmt.Sprintf(droppedMarkerFmt, c.dropped)}
+		}
 		return nil
 	}
 

--- a/internal/agent/procutil/procutil.go
+++ b/internal/agent/procutil/procutil.go
@@ -159,7 +159,11 @@ func NewStderrCollector(r io.Reader, logger *slog.Logger, opts ...CollectorOptio
 func (c *StderrCollector) drain(r io.Reader) {
 	defer close(c.done)
 	scanner := bufio.NewScanner(r)
-	scanner.Buffer(make([]byte, 0, 64*1024), c.scannerMax)
+	initCap := 64 * 1024
+	if c.scannerMax < initCap {
+		initCap = c.scannerMax
+	}
+	scanner.Buffer(make([]byte, 0, initCap), c.scannerMax)
 
 	for scanner.Scan() {
 		line := scanner.Text()

--- a/internal/agent/procutil/procutil_test.go
+++ b/internal/agent/procutil/procutil_test.go
@@ -134,8 +134,8 @@ func TestStderrCollector_NilLogger(t *testing.T) {
 
 func TestStderrCollector_ScannerError(t *testing.T) {
 	t.Parallel()
-	// Feed a line that exceeds the 64 KiB initial buffer len (65536 bytes) so
-	// the scanner's grow path checks maxTokenSize and returns ErrTooLong.
+	// Feed a line that exceeds the configured 128-byte scanner max so the
+	// scanner returns ErrTooLong while draining stderr.
 	longLine := strings.Repeat("x", 65537)
 	var buf bytes.Buffer
 	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))

--- a/internal/agent/procutil/procutil_test.go
+++ b/internal/agent/procutil/procutil_test.go
@@ -1,9 +1,9 @@
 package procutil
 
 import (
-	"bufio"
 	"bytes"
 	"errors"
+	"fmt"
 	"log/slog"
 	"os/exec"
 	"runtime"
@@ -134,16 +134,258 @@ func TestStderrCollector_NilLogger(t *testing.T) {
 
 func TestStderrCollector_ScannerError(t *testing.T) {
 	t.Parallel()
-	longLine := strings.Repeat("x", bufio.MaxScanTokenSize+1)
+	// Feed a line that exceeds the 64 KiB initial buffer len (65536 bytes) so
+	// the scanner's grow path checks maxTokenSize and returns ErrTooLong.
+	longLine := strings.Repeat("x", 65537)
 	var buf bytes.Buffer
 	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
 
-	c := NewStderrCollector(strings.NewReader(longLine), logger)
+	c := NewStderrCollector(strings.NewReader(longLine), logger, WithScannerMax(128))
 	_ = c.Lines()
 
 	if !strings.Contains(buf.String(), "agent stderr drain failed") {
 		t.Errorf("StderrCollector did not log scanner error; output = %q", buf.String())
 	}
+}
+
+func TestStderrCollector_LargeLineCollected(t *testing.T) {
+	t.Parallel()
+
+	bigLine := strings.Repeat("x", 100*1024)
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	c := NewStderrCollector(strings.NewReader(bigLine+"\n"), logger)
+	got := c.Lines()
+
+	if len(got) != 1 {
+		t.Fatalf("Lines() returned %d lines, want 1", len(got))
+	}
+	if got[0] != bigLine {
+		t.Errorf("Lines()[0] length = %d, want %d", len(got[0]), len(bigLine))
+	}
+	if strings.Contains(buf.String(), "agent stderr drain failed") {
+		t.Error("StderrCollector logged scanner error for large line within default scanner max")
+	}
+}
+
+func TestStderrCollector_LineCap(t *testing.T) {
+	t.Parallel()
+
+	makeInput := func(n int) (string, []string) {
+		ls := make([]string, n)
+		var sb strings.Builder
+		for i := range n {
+			s := fmt.Sprintf("line%d", i+1)
+			ls[i] = s
+			sb.WriteString(s)
+			sb.WriteByte('\n')
+		}
+		return sb.String(), ls
+	}
+
+	tests := []struct {
+		name       string
+		n          int
+		wantLen    int
+		wantDrop   int
+		wantMarker bool
+		wantFirst  []string
+		wantLast   []string
+	}{
+		{
+			name:       "exactly at cap",
+			n:          10,
+			wantLen:    10,
+			wantDrop:   0,
+			wantMarker: false,
+			wantFirst:  []string{"line1", "line2", "line3", "line4", "line5"},
+			wantLast:   []string{"line6", "line7", "line8", "line9", "line10"},
+		},
+		{
+			name:       "one over cap",
+			n:          11,
+			wantLen:    11,
+			wantDrop:   1,
+			wantMarker: true,
+			wantFirst:  []string{"line1", "line2", "line3", "line4", "line5"},
+			wantLast:   []string{"line7", "line8", "line9", "line10", "line11"},
+		},
+		{
+			name:       "large overage",
+			n:          25,
+			wantLen:    11,
+			wantDrop:   15,
+			wantMarker: true,
+			wantFirst:  []string{"line1", "line2", "line3", "line4", "line5"},
+			wantLast:   []string{"line21", "line22", "line23", "line24", "line25"},
+		},
+		{
+			name:       "all fit in head",
+			n:          3,
+			wantLen:    3,
+			wantDrop:   0,
+			wantMarker: false,
+			wantFirst:  []string{"line1", "line2", "line3"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			input, _ := makeInput(tt.n)
+			c := NewStderrCollector(strings.NewReader(input), slog.Default(), WithMaxLines(10))
+			got := c.Lines()
+			dropped := c.Dropped()
+
+			if len(got) != tt.wantLen {
+				t.Fatalf("len(Lines()) = %d, want %d; lines = %v", len(got), tt.wantLen, got)
+			}
+			if dropped != tt.wantDrop {
+				t.Errorf("Dropped() = %d, want %d", dropped, tt.wantDrop)
+			}
+			for i, want := range tt.wantFirst {
+				if i >= len(got) {
+					break
+				}
+				if got[i] != want {
+					t.Errorf("Lines()[%d] = %q, want %q", i, got[i], want)
+				}
+			}
+			for i, want := range tt.wantLast {
+				idx := len(got) - len(tt.wantLast) + i
+				if got[idx] != want {
+					t.Errorf("Lines()[%d] = %q, want %q", idx, got[idx], want)
+				}
+			}
+			wantMarkerStr := fmt.Sprintf(droppedMarkerFmt, tt.wantDrop)
+			hasMarker := false
+			for _, line := range got {
+				if line == wantMarkerStr {
+					hasMarker = true
+					break
+				}
+			}
+			if hasMarker != tt.wantMarker {
+				t.Errorf("marker %q present = %v, want %v", wantMarkerStr, hasMarker, tt.wantMarker)
+			}
+		})
+	}
+}
+
+func TestStderrCollector_WithScannerMax(t *testing.T) {
+	t.Parallel()
+
+	// A line of 128 KiB + 1 byte exceeds the 128 KiB scanner limit but
+	// would be collected fine under the default 10 MiB scanner limit.
+	const customMax = 128 * 1024
+	bigLine := strings.Repeat("y", customMax+1)
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	c := NewStderrCollector(strings.NewReader(bigLine+"\n"), logger, WithScannerMax(customMax))
+	got := c.Lines()
+
+	if !strings.Contains(buf.String(), "agent stderr drain failed") {
+		t.Error("StderrCollector did not log scanner error for line exceeding WithScannerMax(128 KiB)")
+	}
+	for _, line := range got {
+		if line == bigLine {
+			t.Error("Lines() contains the oversized line that exceeded WithScannerMax(128 KiB)")
+		}
+	}
+}
+
+func TestStderrCollector_ByteBudget(t *testing.T) {
+	t.Parallel()
+
+	t.Run("under budget", func(t *testing.T) {
+		t.Parallel()
+		line := strings.Repeat("a", 20)
+		var sb strings.Builder
+		for range 10 {
+			sb.WriteString(line)
+			sb.WriteByte('\n')
+		}
+		c := NewStderrCollector(strings.NewReader(sb.String()), slog.Default(),
+			WithMaxBytes(256), WithMaxLines(100))
+		got := c.Lines()
+		if len(got) != 10 {
+			t.Errorf("Lines() count = %d, want 10", len(got))
+		}
+		if d := c.Dropped(); d != 0 {
+			t.Errorf("Dropped() = %d, want 0", d)
+		}
+	})
+
+	t.Run("over budget", func(t *testing.T) {
+		t.Parallel()
+		line := strings.Repeat("b", 20)
+		var sb strings.Builder
+		for range 20 {
+			sb.WriteString(line)
+			sb.WriteByte('\n')
+		}
+		c := NewStderrCollector(strings.NewReader(sb.String()), slog.Default(),
+			WithMaxBytes(256), WithMaxLines(100))
+		got := c.Lines()
+		if d := c.Dropped(); d <= 0 {
+			t.Errorf("Dropped() = %d, want > 0", d)
+		}
+		var total int
+		for _, l := range got {
+			// Exclude the synthetic drop-marker line from the byte sum.
+			if !strings.HasPrefix(l, "...") {
+				total += len(l)
+			}
+		}
+		if total > 256 {
+			t.Errorf("retained bytes = %d, want ≤ 256", total)
+		}
+	})
+
+	t.Run("head partially filled", func(t *testing.T) {
+		t.Parallel()
+		line := strings.Repeat("c", 100)
+		var sb strings.Builder
+		for range 5 {
+			sb.WriteString(line)
+			sb.WriteByte('\n')
+		}
+		c := NewStderrCollector(strings.NewReader(sb.String()), slog.Default(),
+			WithMaxBytes(256), WithMaxLines(100))
+		got := c.Lines()
+		if len(got) >= 5 {
+			t.Errorf("Lines() count = %d, want < 5 (budget exhausted before all lines stored)", len(got))
+		}
+		if d := c.Dropped(); d <= 0 {
+			t.Errorf("Dropped() = %d, want > 0", d)
+		}
+	})
+
+	t.Run("ring reclamation", func(t *testing.T) {
+		t.Parallel()
+		headLine := strings.Repeat("h", 10)
+		tailLine := strings.Repeat("t", 25)
+		extraLine := strings.Repeat("e", 20)
+		var sb strings.Builder
+		for range 3 {
+			sb.WriteString(headLine)
+			sb.WriteByte('\n')
+		}
+		for range 3 {
+			sb.WriteString(tailLine)
+			sb.WriteByte('\n')
+		}
+		sb.WriteString(extraLine)
+		sb.WriteByte('\n')
+		c := NewStderrCollector(strings.NewReader(sb.String()), slog.Default(),
+			WithMaxBytes(120), WithMaxLines(6))
+		if d := c.Dropped(); d != 1 {
+			t.Errorf("Dropped() = %d, want 1 (one tail eviction via byte reclamation)", d)
+		}
+	})
 }
 
 func TestStderrCollector_WarnLines(t *testing.T) {

--- a/internal/agent/procutil/procutil_test.go
+++ b/internal/agent/procutil/procutil_test.go
@@ -136,7 +136,7 @@ func TestStderrCollector_ScannerError(t *testing.T) {
 	t.Parallel()
 	// Feed a line that exceeds the configured 128-byte scanner max so the
 	// scanner returns ErrTooLong while draining stderr.
-	longLine := strings.Repeat("x", 65537)
+	longLine := strings.Repeat("x", 129)
 	var buf bytes.Buffer
 	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
 

--- a/scripts/.gitignore
+++ b/scripts/.gitignore
@@ -1,0 +1,1 @@
+demo-metrics-push.py


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Feat

**Intent:** `StderrCollector` used the default 64 KiB `bufio.Scanner` token limit and collected lines without bound. This change raises the scanner cap to 10 MiB and adds a head/tail ring-buffer retention strategy with a byte budget, preventing silent data loss and unbounded memory growth during a turn.

**Related Issues:** #387

### 🧭 Reviewer Guide

**Complexity:** Medium

#### Entry Point

`internal/agent/procutil/procutil.go` — all changes are confined to this file. Start at `NewStderrCollector` to understand the functional-options pattern and defaults, then follow `drain` for the ring-buffer algorithm and `Lines` for the assembly step.

#### Sensitive Areas

- `internal/agent/procutil/procutil.go`: Ring-buffer index arithmetic (`tailPos`, `tailFull`, byte reclamation) and the `Lines()` unroll order are the most subtle areas. The invariant is: when `tailFull`, the oldest tail entry sits at `tailPos`, so unroll as `tail[tailPos:]` then `tail[:tailPos]`.
- `internal/agent/procutil/procutil_test.go`: `TestStderrCollector_ByteBudget` "ring reclamation" subtest exercises the reclaim-before-check path; `TestStderrCollector_LineCap` "large overage" verifies exact head/marker/tail structure.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes — `NewStderrCollector(r, logger)` with no options compiles and behaves identically to before. Both adapter call sites (`internal/agent/claude`, `internal/agent/copilot`) were verified to compile unchanged.
- **Migrations/State:** No migrations or state changes.