### PR TITLE
feat(orchestrator): propagate session ID through retry chain for cross-retry resume

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1138,7 +1138,7 @@ Optional SSH host limit:
 Retry entry creation:
 
 - Cancel any existing retry timer for the same issue.
-- Store `attempt`, `identifier`, `error`, `due_at_ms`, and new timer handle.
+- Store `attempt`, `identifier`, `error`, `due_at_ms`, `session_id` (continuation retries propagate the session ID from the exiting worker; error and reaction retries leave it null), and new timer handle.
 
 Backoff formula:
 
@@ -3066,7 +3066,8 @@ on_worker_exit(issue_id, reason, state):
     state.completed.add(issue_id)  # bookkeeping only
     state = schedule_retry(state, issue_id, 1, {
       identifier: running_entry.identifier,
-      delay_type: continuation
+      delay_type: continuation,
+      session_id: running_entry.session_id
     })
 
     # Enqueue CI check when provider is configured and workspace has SCM metadata
@@ -3114,7 +3115,8 @@ on_retry_timer(issue_id, state):
   if fetch failed:
     return schedule_retry(state, issue_id, retry_entry.attempt + 1, {
       identifier: retry_entry.identifier,
-      error: "retry poll failed"
+      error: "retry poll failed",
+      session_id: retry_entry.session_id
     })
 
   issue = find_by_id(candidates, issue_id)
@@ -3125,10 +3127,12 @@ on_retry_timer(issue_id, state):
   if available_slots(state) == 0:
     return schedule_retry(state, issue_id, retry_entry.attempt + 1, {
       identifier: issue.identifier,
-      error: "no available orchestrator slots"
+      error: "no available orchestrator slots",
+      session_id: retry_entry.session_id
     })
 
-  return dispatch_issue(issue, state, attempt=retry_entry.attempt)
+  return dispatch_issue(issue, state, attempt=retry_entry.attempt,
+    resume_session_id=retry_entry.session_id)
 ```
 
 ## 17. Test and Validation Matrix
@@ -3392,6 +3396,7 @@ runs all pending schema migrations before beginning normal operation.
 | `attempt`    | INTEGER | Retry attempt number (1-based)                     |
 | `due_at_ms`  | INTEGER | Unix epoch milliseconds; used to reconstruct timer |
 | `error`      | TEXT    | Last error message, may be null                    |
+| `session_id` | TEXT    | Adapter-assigned session ID from previous attempt, may be null |
 
 Note: `timer_handle` is runtime-only and is not stored.
 

--- a/internal/orchestrator/dispatch.go
+++ b/internal/orchestrator/dispatch.go
@@ -225,6 +225,7 @@ type ScheduleRetryParams struct {
 	DelayMS     int64 // Delay before timer fires, in milliseconds.
 	Error       string
 	LastSSHHost string // Runtime-only: SSH host from previous attempt for retry affinity.
+	SessionID   string // Session identifier from previous attempt for cross-retry resume.
 
 	// ContinuationContext carries reaction continuation data to inject
 	// into the prompt template on the first turn of the retry worker.
@@ -270,6 +271,7 @@ func ScheduleRetry(state *State, params ScheduleRetryParams, onFire func(issueID
 		IssueID:             params.IssueID,
 		Identifier:          params.Identifier,
 		DisplayID:           params.DisplayID,
+		SessionID:           params.SessionID,
 		Attempt:             params.Attempt,
 		DueAtMS:             dueAtMS,
 		Error:               params.Error,

--- a/internal/orchestrator/exit.go
+++ b/internal/orchestrator/exit.go
@@ -328,6 +328,7 @@ func HandleWorkerExit(state *State, workerResult WorkerResult, params HandleWork
 						DelayMS:     continuationDelayMS,
 						Error:       "",
 						LastSSHHost: workerResult.SSHHost,
+						SessionID:   sessionID,
 					}, params.OnRetryFire)
 					metrics.IncRetries(triggerContinuation)
 					retryScheduled = true
@@ -354,6 +355,7 @@ func HandleWorkerExit(state *State, workerResult WorkerResult, params HandleWork
 						DelayMS:     continuationDelayMS,
 						Error:       "",
 						LastSSHHost: workerResult.SSHHost,
+						SessionID:   sessionID,
 					}, params.OnRetryFire)
 					metrics.IncRetries(triggerContinuation)
 					retryScheduled = true
@@ -394,6 +396,7 @@ func HandleWorkerExit(state *State, workerResult WorkerResult, params HandleWork
 				DelayMS:     continuationDelayMS,
 				Error:       "",
 				LastSSHHost: workerResult.SSHHost,
+				SessionID:   sessionID,
 			}, params.OnRetryFire)
 			metrics.IncRetries(triggerContinuation)
 			retryScheduled = true
@@ -526,6 +529,7 @@ func HandleWorkerExit(state *State, workerResult WorkerResult, params HandleWork
 				Attempt:    retryEntry.Attempt,
 				DueAtMs:    retryEntry.DueAtMS,
 				Error:      stringPtr(retryEntry.Error),
+				SessionID:  stringPtr(retryEntry.SessionID),
 			}
 			if err := params.Store.SaveRetryEntry(ctx, pEntry); err != nil {
 				log.Error("failed to persist retry entry",

--- a/internal/orchestrator/exit_test.go
+++ b/internal/orchestrator/exit_test.go
@@ -3060,3 +3060,88 @@ func TestHandleWorkerExit_ReviewMetadata_Nil(t *testing.T) {
 		t.Errorf("RunHistory.ReviewMetadata = %q, want nil", *store.runHistories[0].ReviewMetadata)
 	}
 }
+
+func TestHandleWorkerExit_ContinuationRetry_SessionID(t *testing.T) {
+	t.Parallel()
+
+	store := &mockExitStore{}
+	state := exitState(t, "SESS-1", nil)
+	params := defaultExitParams(t, store)
+
+	HandleWorkerExit(state, WorkerResult{
+		IssueID:      "SESS-1",
+		Identifier:   "SESS-1-ident",
+		ExitKind:     WorkerExitNormal,
+		AgentAdapter: "mock",
+		SessionID:    "sess-abc",
+	}, params)
+
+	entry, ok := state.RetryAttempts["SESS-1"]
+	if !ok {
+		t.Fatal("RetryAttempts[SESS-1] missing after normal exit, want continuation retry")
+	}
+	if entry.SessionID != "sess-abc" {
+		t.Errorf("RetryAttempts[SESS-1].SessionID = %q, want %q", entry.SessionID, "sess-abc")
+	}
+	if entry.TimerHandle != nil {
+		entry.TimerHandle.Stop()
+	}
+}
+
+func TestHandleWorkerExit_ContinuationRetry_SessionID_FromEntry(t *testing.T) {
+	t.Parallel()
+
+	store := &mockExitStore{}
+	state := exitState(t, "SESS-2", nil)
+	// Populate SessionID on the running entry (simulates EventSessionStarted
+	// having been processed before the worker exited).
+	state.Running["SESS-2"].SessionID = "sess-xyz"
+	params := defaultExitParams(t, store)
+
+	HandleWorkerExit(state, WorkerResult{
+		IssueID:      "SESS-2",
+		Identifier:   "SESS-2-ident",
+		ExitKind:     WorkerExitNormal,
+		AgentAdapter: "mock",
+		SessionID:    "", // authoritative source is empty; fall back to entry
+	}, params)
+
+	entry, ok := state.RetryAttempts["SESS-2"]
+	if !ok {
+		t.Fatal("RetryAttempts[SESS-2] missing after normal exit, want continuation retry")
+	}
+	if entry.SessionID != "sess-xyz" {
+		t.Errorf("RetryAttempts[SESS-2].SessionID = %q, want %q", entry.SessionID, "sess-xyz")
+	}
+	if entry.TimerHandle != nil {
+		entry.TimerHandle.Stop()
+	}
+}
+
+func TestHandleWorkerExit_ErrorRetry_NoSessionID(t *testing.T) {
+	t.Parallel()
+
+	store := &mockExitStore{}
+	state := exitState(t, "SESS-3", nil)
+	params := defaultExitParams(t, store)
+
+	HandleWorkerExit(state, WorkerResult{
+		IssueID:      "SESS-3",
+		Identifier:   "SESS-3-ident",
+		ExitKind:     WorkerExitError,
+		AgentAdapter: "mock",
+		SessionID:    "sess-abc",
+		Error:        fmt.Errorf("something transient"),
+	}, params)
+
+	entry, ok := state.RetryAttempts["SESS-3"]
+	if !ok {
+		t.Fatal("RetryAttempts[SESS-3] missing after error exit, want error retry")
+	}
+	if entry.SessionID != "" {
+		t.Errorf("RetryAttempts[SESS-3].SessionID = %q, want empty (error retries do not resume sessions)", entry.SessionID)
+	}
+	if entry.TimerHandle != nil {
+		entry.TimerHandle.Stop()
+	}
+}

--- a/internal/orchestrator/recovery.go
+++ b/internal/orchestrator/recovery.go
@@ -19,9 +19,15 @@ func PopulateRetries(state *State, entries []persistence.PendingRetry) {
 			errStr = *e.Error
 		}
 
+		var sessionID string
+		if e.SessionID != nil {
+			sessionID = *e.SessionID
+		}
+
 		state.RetryAttempts[e.IssueID] = &RetryEntry{
 			IssueID:          e.IssueID,
 			Identifier:       e.Identifier,
+			SessionID:        sessionID,
 			Attempt:          e.Attempt,
 			DueAtMS:          e.DueAtMs,
 			Error:            errStr,

--- a/internal/orchestrator/recovery_test.go
+++ b/internal/orchestrator/recovery_test.go
@@ -345,3 +345,60 @@ func TestActivateReconstructedRetries(t *testing.T) {
 		}
 	})
 }
+
+func TestPopulateRetries_SessionID(t *testing.T) {
+	t.Parallel()
+
+	sessID := "sess-abc"
+	state := NewState(5000, 4, nil, AgentTotals{})
+	entries := []persistence.PendingRetry{
+		{
+			Entry: persistence.RetryEntry{
+				IssueID:    "id-sess",
+				Identifier: "PROJ-SESS",
+				Attempt:    1,
+				DueAtMs:    10000,
+				SessionID:  &sessID,
+			},
+			RemainingMs: 5000,
+		},
+	}
+
+	PopulateRetries(state, entries)
+
+	got, ok := state.RetryAttempts["id-sess"]
+	if !ok {
+		t.Fatal("RetryAttempts[id-sess] missing after PopulateRetries")
+	}
+	if got.SessionID != sessID {
+		t.Errorf("PopulateRetries_SessionID: SessionID = %q, want %q", got.SessionID, sessID)
+	}
+}
+
+func TestPopulateRetries_SessionID_Nil(t *testing.T) {
+	t.Parallel()
+
+	state := NewState(5000, 4, nil, AgentTotals{})
+	entries := []persistence.PendingRetry{
+		{
+			Entry: persistence.RetryEntry{
+				IssueID:    "id-nosess",
+				Identifier: "PROJ-NOSESS",
+				Attempt:    1,
+				DueAtMs:    10000,
+				SessionID:  nil,
+			},
+			RemainingMs: 0,
+		},
+	}
+
+	PopulateRetries(state, entries)
+
+	got, ok := state.RetryAttempts["id-nosess"]
+	if !ok {
+		t.Fatal("RetryAttempts[id-nosess] missing after PopulateRetries")
+	}
+	if got.SessionID != "" {
+		t.Errorf("PopulateRetries_SessionID_Nil: SessionID = %q, want empty", got.SessionID)
+	}
+}

--- a/internal/orchestrator/retry.go
+++ b/internal/orchestrator/retry.go
@@ -147,6 +147,7 @@ func HandleRetryTimer(state *State, issueID string, params HandleRetryTimerParam
 			Attempt:      popped.Attempt,
 			DelayMS:      delayMS,
 			Error:        popped.Error,
+			SessionID:    popped.SessionID,
 			ReactionKind: popped.ReactionKind,
 		}, params.OnRetryFire)
 		persistRetryEntry(ctx, log, params.Store, state, issueID)
@@ -198,6 +199,7 @@ func HandleRetryTimer(state *State, issueID string, params HandleRetryTimerParam
 			Attempt:      nextAttempt,
 			DelayMS:      delayMS,
 			Error:        "retry poll failed",
+			SessionID:    popped.SessionID,
 			ReactionKind: popped.ReactionKind,
 		}, params.OnRetryFire)
 
@@ -260,6 +262,7 @@ func HandleRetryTimer(state *State, issueID string, params HandleRetryTimerParam
 			Attempt:      nextAttempt,
 			DelayMS:      delayMS,
 			Error:        "no available orchestrator slots",
+			SessionID:    popped.SessionID,
 			ReactionKind: popped.ReactionKind,
 		}, params.OnRetryFire)
 
@@ -289,6 +292,7 @@ func HandleRetryTimer(state *State, issueID string, params HandleRetryTimerParam
 				Attempt:      nextAttempt,
 				DelayMS:      delayMS,
 				Error:        "no available SSH hosts",
+				SessionID:    popped.SessionID,
 				ReactionKind: popped.ReactionKind,
 			}, params.OnRetryFire)
 
@@ -310,7 +314,7 @@ func HandleRetryTimer(state *State, issueID string, params HandleRetryTimerParam
 	if popped.ContinuationContext != nil {
 		dispatchCtx = WithContinuationContext(ctx, popped.ContinuationContext)
 	}
-	DispatchIssue(dispatchCtx, state, issue, &attempt, host, params.MakeWorkerFn("", host))
+	DispatchIssue(dispatchCtx, state, issue, &attempt, host, params.MakeWorkerFn(popped.SessionID, host))
 	if entry := state.Running[issue.ID]; entry != nil {
 		entry.WorkflowFile = params.WorkflowFile
 		entry.ContinuationContext = popped.ContinuationContext
@@ -371,6 +375,7 @@ func persistRetryEntry(ctx context.Context, log *slog.Logger, store RetryTimerSt
 		Attempt:    retryEntry.Attempt,
 		DueAtMs:    retryEntry.DueAtMS,
 		Error:      stringPtr(retryEntry.Error),
+		SessionID:  stringPtr(retryEntry.SessionID),
 	}
 	if err := store.SaveRetryEntry(ctx, pEntry); err != nil {
 		log.Error("failed to persist retry entry",

--- a/internal/orchestrator/retry_test.go
+++ b/internal/orchestrator/retry_test.go
@@ -1523,3 +1523,78 @@ func TestHandleRetryTimer_ContinuationMarkDispatchedError(t *testing.T) {
 		t.Errorf("Running[%s] missing after dispatch, want present (error is non-fatal)", id)
 	}
 }
+
+func TestHandleRetryTimer_SessionID_PassedToMakeWorkerFn(t *testing.T) {
+	t.Parallel()
+
+	const id = "ISS-SESS"
+	const wantSessionID = "sess-abc"
+
+	state := retryState(t, id, id, 2)
+	state.RetryAttempts[id].SessionID = wantSessionID
+
+	store := &mockRetryStore{}
+	tracker := &mockRetryTracker{
+		candidates: []domain.Issue{candidateIssue(id, id, "In Progress")},
+	}
+	params := defaultRetryParams(t, store, tracker)
+
+	var gotSessionID string
+	ch := make(chan struct{}, 1)
+	params.MakeWorkerFn = func(resumeSessionID, _ string) WorkerFunc {
+		gotSessionID = resumeSessionID
+		return func(_ context.Context, _ domain.Issue, _ *int) {
+			ch <- struct{}{}
+		}
+	}
+
+	HandleRetryTimer(state, id, params)
+
+	select {
+	case <-ch:
+	case <-time.After(time.Second):
+		t.Fatal("worker did not execute within 1 second")
+	}
+
+	if gotSessionID != wantSessionID {
+		t.Errorf("MakeWorkerFn resumeSessionID = %q, want %q", gotSessionID, wantSessionID)
+	}
+}
+
+func TestHandleRetryTimer_Reschedule_PreservesSessionID(t *testing.T) {
+	t.Parallel()
+
+	const id = "ISS-SESS-RESCHEDULE"
+	const wantSessionID = "sess-preserve"
+
+	state := retryState(t, id, id, 2)
+	state.RetryAttempts[id].SessionID = wantSessionID
+	// Fill all slots so no dispatch occurs — forces the reschedule path.
+	state.MaxConcurrentAgents = 1
+	state.Running["OTHER-1"] = &RunningEntry{
+		Identifier: "OTHER-1",
+		Issue:      candidateIssue("OTHER-1", "OTHER-1", "To Do"),
+	}
+
+	store := &mockRetryStore{}
+	tracker := &mockRetryTracker{
+		candidates: []domain.Issue{
+			candidateIssue(id, id, "To Do"),
+			candidateIssue("OTHER-1", "OTHER-1", "To Do"),
+		},
+	}
+	params := defaultRetryParams(t, store, tracker)
+
+	HandleRetryTimer(state, id, params)
+
+	entry, ok := state.RetryAttempts[id]
+	if !ok {
+		t.Fatalf("RetryAttempts[%s] missing after no-slots reschedule, want present", id)
+	}
+	if entry.SessionID != wantSessionID {
+		t.Errorf("RetryAttempts[%s].SessionID = %q, want %q", id, entry.SessionID, wantSessionID)
+	}
+	if entry.TimerHandle != nil {
+		entry.TimerHandle.Stop()
+	}
+}

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -223,6 +223,7 @@ type RetryEntry struct {
 	IssueID     string
 	Identifier  string
 	DisplayID   string
+	SessionID   string
 	Attempt     int
 	DueAtMS     int64
 	Error       string

--- a/internal/persistence/migrate_test.go
+++ b/internal/persistence/migrate_test.go
@@ -179,6 +179,7 @@ func TestMigrate_ColumnCorrectness(t *testing.T) {
 				{"attempt", "INTEGER", true, 0},
 				{"due_at_ms", "INTEGER", true, 0},
 				{"error", "TEXT", false, 0},
+				{"session_id", "TEXT", false, 0},
 			},
 		},
 		{

--- a/internal/persistence/migrations.go
+++ b/internal/persistence/migrations.go
@@ -35,6 +35,9 @@ var migration007SQL string
 //go:embed sql/008_reaction_fingerprints.sql
 var migration008SQL string
 
+//go:embed sql/009_retry_session_id.sql
+var migration009SQL string
+
 var migrations = []Migration{
 	{Version: 1, Description: "core persistence tables", SQL: migration001SQL},
 	{Version: 2, Description: "extended token metrics", SQL: migration002SQL},
@@ -44,4 +47,5 @@ var migrations = []Migration{
 	{Version: 6, Description: "display identifier in run history", SQL: migration006SQL},
 	{Version: 7, Description: "self-review metadata in run history", SQL: migration007SQL},
 	{Version: 8, Description: "reaction fingerprints for cross-restart dedup", SQL: migration008SQL},
+	{Version: 9, Description: "session ID in retry entries for cross-retry resume", SQL: migration009SQL},
 }

--- a/internal/persistence/retry.go
+++ b/internal/persistence/retry.go
@@ -15,6 +15,7 @@ type RetryEntry struct {
 	Attempt    int     // Retry attempt number, 1-based.
 	DueAtMs    int64   // Unix epoch milliseconds when the retry timer should fire.
 	Error      *string // Last error message; nil when no error.
+	SessionID  *string // Adapter-assigned session identifier from the previous worker attempt. Nil when no session was established.
 }
 
 // PendingRetry pairs a persisted [RetryEntry] with the computed delay
@@ -34,15 +35,21 @@ func (s *Store) SaveRetryEntry(ctx context.Context, entry RetryEntry) error {
 		errVal = sql.NullString{String: *entry.Error, Valid: true}
 	}
 
+	ssnVal := sql.NullString{}
+	if entry.SessionID != nil {
+		ssnVal = sql.NullString{String: *entry.SessionID, Valid: true}
+	}
+
 	_, err := s.db.ExecContext(ctx,
-		`INSERT INTO retry_entries (issue_id, identifier, attempt, due_at_ms, error)
-		VALUES (?, ?, ?, ?, ?)
+		`INSERT INTO retry_entries (issue_id, identifier, attempt, due_at_ms, error, session_id)
+		VALUES (?, ?, ?, ?, ?, ?)
 		ON CONFLICT (issue_id) DO UPDATE SET
 			identifier = excluded.identifier,
 			attempt    = excluded.attempt,
 			due_at_ms  = excluded.due_at_ms,
-			error      = excluded.error`,
-		entry.IssueID, entry.Identifier, entry.Attempt, entry.DueAtMs, errVal,
+			error      = excluded.error,
+			session_id = excluded.session_id`,
+		entry.IssueID, entry.Identifier, entry.Attempt, entry.DueAtMs, errVal, ssnVal,
 	)
 	if err != nil {
 		return fmt.Errorf("save retry entry %q: %w", entry.IssueID, err)
@@ -55,7 +62,7 @@ func (s *Store) SaveRetryEntry(ctx context.Context, entry RetryEntry) error {
 // (not nil) when no entries exist.
 func (s *Store) LoadRetryEntries(ctx context.Context) ([]RetryEntry, error) {
 	rows, err := s.db.QueryContext(ctx,
-		`SELECT issue_id, identifier, attempt, due_at_ms, error
+		`SELECT issue_id, identifier, attempt, due_at_ms, error, session_id
 		FROM retry_entries
 		ORDER BY due_at_ms ASC, issue_id ASC`)
 	if err != nil {
@@ -67,12 +74,17 @@ func (s *Store) LoadRetryEntries(ctx context.Context) ([]RetryEntry, error) {
 	for rows.Next() {
 		var e RetryEntry
 		var errVal sql.NullString
-		if err := rows.Scan(&e.IssueID, &e.Identifier, &e.Attempt, &e.DueAtMs, &errVal); err != nil {
+		var ssnVal sql.NullString
+		if err := rows.Scan(&e.IssueID, &e.Identifier, &e.Attempt, &e.DueAtMs, &errVal, &ssnVal); err != nil {
 			return nil, fmt.Errorf("scan retry entry: %w", err)
 		}
 		if errVal.Valid {
 			s := errVal.String
 			e.Error = &s
+		}
+		if ssnVal.Valid {
+			s := ssnVal.String
+			e.SessionID = &s
 		}
 		entries = append(entries, e)
 	}

--- a/internal/persistence/sql/009_retry_session_id.sql
+++ b/internal/persistence/sql/009_retry_session_id.sql
@@ -1,0 +1,2 @@
+-- Migration 9: Add session_id to retry_entries for cross-retry session resume
+ALTER TABLE retry_entries ADD COLUMN session_id TEXT;

--- a/internal/persistence/store_test.go
+++ b/internal/persistence/store_test.go
@@ -452,9 +452,123 @@ func TestLoadRetryEntries_DeterministicTieBreak(t *testing.T) {
 	}
 }
 
-// --- Run History Tests ---
+func TestSaveAndLoadRetryEntry_SessionID(t *testing.T) {
+	t.Parallel()
 
-// newTestRun returns a RunHistory with all fields populated using the given
+	s := openTestStore(t)
+	migrateOrFatal(t, s)
+	ctx := context.Background()
+
+	sessID := "sess-abc"
+	entry := RetryEntry{
+		IssueID:    "ISS-1",
+		Identifier: "PROJ-1",
+		Attempt:    1,
+		DueAtMs:    1000,
+		SessionID:  &sessID,
+	}
+	if err := s.SaveRetryEntry(ctx, entry); err != nil {
+		t.Fatalf("SaveRetryEntry: %v", err)
+	}
+
+	entries, err := s.LoadRetryEntries(ctx)
+	if err != nil {
+		t.Fatalf("LoadRetryEntries: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("LoadRetryEntries count = %d, want 1", len(entries))
+	}
+	got := entries[0]
+	if got.SessionID == nil {
+		t.Fatal("SessionID = nil, want non-nil")
+	}
+	if *got.SessionID != sessID {
+		t.Errorf("SaveAndLoadRetryEntry_SessionID: SessionID = %q, want %q", *got.SessionID, sessID)
+	}
+}
+
+func TestSaveAndLoadRetryEntry_SessionID_Nil(t *testing.T) {
+	t.Parallel()
+
+	s := openTestStore(t)
+	migrateOrFatal(t, s)
+	ctx := context.Background()
+
+	entry := RetryEntry{
+		IssueID:    "ISS-NIL",
+		Identifier: "PROJ-NIL",
+		Attempt:    1,
+		DueAtMs:    2000,
+		SessionID:  nil,
+	}
+	if err := s.SaveRetryEntry(ctx, entry); err != nil {
+		t.Fatalf("SaveRetryEntry: %v", err)
+	}
+
+	entries, err := s.LoadRetryEntries(ctx)
+	if err != nil {
+		t.Fatalf("LoadRetryEntries: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("LoadRetryEntries count = %d, want 1", len(entries))
+	}
+	if entries[0].SessionID != nil {
+		t.Errorf("SaveAndLoadRetryEntry_SessionID_Nil: SessionID = %q, want nil", *entries[0].SessionID)
+	}
+}
+
+func TestSaveRetryEntry_Upsert_SessionID(t *testing.T) {
+	t.Parallel()
+
+	s := openTestStore(t)
+	migrateOrFatal(t, s)
+	ctx := context.Background()
+
+	// First upsert: SessionID nil.
+	entry1 := RetryEntry{
+		IssueID:    "ISS-UPS",
+		Identifier: "PROJ-UPS",
+		Attempt:    1,
+		DueAtMs:    3000,
+		SessionID:  nil,
+	}
+	if err := s.SaveRetryEntry(ctx, entry1); err != nil {
+		t.Fatalf("SaveRetryEntry (first): %v", err)
+	}
+
+	// Second upsert: same IssueID, now with a non-nil SessionID.
+	sessID := "sess-updated"
+	entry2 := RetryEntry{
+		IssueID:    "ISS-UPS",
+		Identifier: "PROJ-UPS",
+		Attempt:    2,
+		DueAtMs:    6000,
+		SessionID:  &sessID,
+	}
+	if err := s.SaveRetryEntry(ctx, entry2); err != nil {
+		t.Fatalf("SaveRetryEntry (upsert): %v", err)
+	}
+
+	entries, err := s.LoadRetryEntries(ctx)
+	if err != nil {
+		t.Fatalf("LoadRetryEntries: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("LoadRetryEntries count = %d, want 1", len(entries))
+	}
+	got := entries[0]
+	if got.Attempt != 2 {
+		t.Errorf("SaveRetryEntry_Upsert_SessionID: Attempt = %d, want 2", got.Attempt)
+	}
+	if got.SessionID == nil {
+		t.Fatal("SaveRetryEntry_Upsert_SessionID: SessionID = nil after upsert, want non-nil")
+	}
+	if *got.SessionID != sessID {
+		t.Errorf("SaveRetryEntry_Upsert_SessionID: SessionID = %q, want %q", *got.SessionID, sessID)
+	}
+}
+
+// --- Run History Tests ---
 // index for uniqueness. Error is nil (successful run).
 func newTestRun(i int) RunHistory {
 	return RunHistory{


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Feat

**Intent:** Continuation retries were losing the session ID from the previous worker because `HandleRetryTimer` always called `MakeWorkerFn` with an empty string. This change threads the session ID from the exiting worker through the retry entry — both in-memory and persisted to SQLite — so the next worker can resume the conversation instead of starting from scratch.

**Related Issues:** #207

### 🧭 Reviewer Guide

**Complexity:** High

#### Entry Point

`internal/orchestrator/retry.go` — `HandleRetryTimer` is where the session ID is finally consumed (`MakeWorkerFn(popped.SessionID, host)`). All other changes are plumbing that gets the value to this call site.

#### Sensitive Areas

- `internal/orchestrator/exit.go`: continuation retry paths (`WorkerExitNormal`) now pass `SessionID: sessionID`; the error retry path intentionally does not — verify that distinction is preserved
- `internal/persistence/sql/009_retry_session_id.sql`: `ALTER TABLE ... ADD COLUMN session_id TEXT` — nullable, safe on existing rows; existing entries recover as empty string → fresh-session behavior unchanged
- `internal/orchestrator/recovery.go`: `PopulateRetries` dereferences `*string` → `string`; nil maps to `""` for backward compatibility

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes
- **Migrations/State:** Migration 009 adds a nullable `session_id TEXT` column to `retry_entries`. `ALTER TABLE ... ADD COLUMN` with a nullable default-NULL column is safe and non-destructive on existing databases. Existing rows read back as empty string, preserving current fresh-start behavior.