### PR TITLE
perf(orchestrator): replace FetchCandidateIssues scan with FetchIssueByID in HandleRetryTimer

### DIFF
--- a/internal/orchestrator/metrics_test.go
+++ b/internal/orchestrator/metrics_test.go
@@ -647,9 +647,7 @@ func TestHandleRetryTimerMetrics(t *testing.T) {
 		HandleRetryTimer(state, issueID, HandleRetryTimerParams{
 			Store: store,
 			TrackerAdapter: &mockRetryTracker{
-				candidates: []domain.Issue{
-					{ID: issueID, Identifier: "RT-1-ident", Title: "Test", State: "To Do"},
-				},
+				fetchedIssue: domain.Issue{ID: issueID, Identifier: "RT-1-ident", Title: "Test", State: "To Do"},
 			},
 			ActiveStates:      []string{"To Do"},
 			TerminalStates:    []string{"Done"},
@@ -755,9 +753,7 @@ func TestHandleRetryTimerMetrics(t *testing.T) {
 		HandleRetryTimer(state, issueID, HandleRetryTimerParams{
 			Store: store,
 			TrackerAdapter: &mockRetryTracker{
-				candidates: []domain.Issue{
-					{ID: issueID, Identifier: "RT-4-ident", Title: "Test", State: "To Do"},
-				},
+				fetchedIssue: domain.Issue{ID: issueID, Identifier: "RT-4-ident", Title: "Test", State: "To Do"},
 			},
 			ActiveStates:      []string{"To Do"},
 			TerminalStates:    []string{"Done"},

--- a/internal/orchestrator/retry.go
+++ b/internal/orchestrator/retry.go
@@ -2,6 +2,7 @@ package orchestrator
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"strings"
 	"time"
@@ -35,8 +36,8 @@ type HandleRetryTimerParams struct {
 	TrackerAdapter domain.TrackerAdapter
 
 	// ActiveStates is the current list of configured active issue states.
-	// Not used directly by HandleRetryTimer because presence in the
-	// candidate set returned by FetchCandidateIssues implies active state.
+	// Used by HandleRetryTimer to validate that the retried issue's current
+	// state is still active after the single-issue fetch.
 	ActiveStates []string
 
 	// TerminalStates is the current list of configured terminal issue
@@ -180,13 +181,29 @@ func HandleRetryTimer(state *State, issueID string, params HandleRetryTimerParam
 		}
 	}
 
-	// Re-fetch active candidates from the tracker.
-	candidates, err := params.TrackerAdapter.FetchCandidateIssues(ctx)
+	// Re-validate the issue with a single tracker API call instead of a
+	// full candidate sweep. FetchIssueByID costs one API request regardless
+	// of how many active issues the tracker holds.
+	issue, err := params.TrackerAdapter.FetchIssueByID(ctx, issueID)
 	if err != nil {
+		var trackerErr *domain.TrackerError
+		if errors.As(err, &trackerErr) && trackerErr.Kind == domain.ErrTrackerNotFound {
+			log.Info("issue no longer exists in tracker, releasing claim")
+			delete(state.Claimed, issueID)
+
+			if delErr := params.Store.DeleteRetryEntry(ctx, issueID); delErr != nil {
+				log.Error("failed to delete retry entry from store",
+					slog.Any("error", delErr),
+				)
+			}
+			return
+		}
+
+		// Transient error (transport, API, payload): reschedule the retry.
 		nextAttempt := popped.Attempt + 1
 		delayMS := computeBackoffDelay(nextAttempt, params.MaxRetryBackoffMS)
 
-		log.Error("retry poll failed, rescheduling",
+		log.Error("retry issue fetch failed, rescheduling",
 			slog.Int("attempt", nextAttempt),
 			slog.Int64("delay_ms", delayMS),
 			slog.Any("error", err),
@@ -198,7 +215,7 @@ func HandleRetryTimer(state *State, issueID string, params HandleRetryTimerParam
 			DisplayID:    popped.DisplayID,
 			Attempt:      nextAttempt,
 			DelayMS:      delayMS,
-			Error:        "retry poll failed",
+			Error:        "retry issue fetch failed",
 			SessionID:    popped.SessionID,
 			ReactionKind: popped.ReactionKind,
 		}, params.OnRetryFire)
@@ -208,10 +225,16 @@ func HandleRetryTimer(state *State, issueID string, params HandleRetryTimerParam
 		return
 	}
 
-	// Locate the issue by ID in the fetched candidates.
-	issue, found := findIssueByID(candidates, issueID)
-	if !found {
-		log.Info("issue no longer active, releasing claim")
+	// Validate the issue's current state against the configured active states.
+	// This is the sole gate replacing the implicit activeStates filter that
+	// FetchCandidateIssues applied at the tracker level. The queryFilter
+	// (adapter-internal JQL or search fragment) is not re-evaluated here:
+	// retry eligibility uses the state constraint only.
+	activeSet := stateSet(params.ActiveStates)
+	if _, active := activeSet[strings.ToLower(issue.State)]; !active {
+		log.Info("issue no longer in active state, releasing claim",
+			slog.String("issue_state", issue.State),
+		)
 		delete(state.Claimed, issueID)
 
 		if err := params.Store.DeleteRetryEntry(ctx, issueID); err != nil {
@@ -222,12 +245,9 @@ func HandleRetryTimer(state *State, issueID string, params HandleRetryTimerParam
 		return
 	}
 
-	// Validate retry eligibility — required fields, terminal
-	// state exclusion, and blocker rule. FetchCandidateIssues returns
-	// active-state issues, but a mis-configured active_states list or an
-	// adapter that returns terminal issues would bypass the normal
-	// ShouldDispatch terminal-state gate. The explicit check keeps the
-	// retry path consistent with the main dispatch path.
+	// Validate retry eligibility — required fields, terminal state
+	// exclusion (defense-in-depth), and the blocker rule. Keeps the
+	// retry dispatch path consistent with the main dispatch path.
 	terminalSet := stateSet(params.TerminalStates)
 	_, isTerminal := terminalSet[strings.ToLower(issue.State)]
 	if issue.ID == "" || issue.Identifier == "" || issue.Title == "" || issue.State == "" ||
@@ -382,16 +402,4 @@ func persistRetryEntry(ctx context.Context, log *slog.Logger, store RetryTimerSt
 			slog.Any("error", err),
 		)
 	}
-}
-
-// findIssueByID performs a linear scan of the candidate list looking for
-// an issue whose ID matches the given id. Returns the issue and true if
-// found, or a zero-value Issue and false otherwise.
-func findIssueByID(issues []domain.Issue, id string) (domain.Issue, bool) {
-	for _, issue := range issues {
-		if issue.ID == id {
-			return issue, true
-		}
-	}
-	return domain.Issue{}, false
 }

--- a/internal/orchestrator/retry_test.go
+++ b/internal/orchestrator/retry_test.go
@@ -75,23 +75,25 @@ func (m *mockRetryStore) DeleteReactionFingerprint(_ context.Context, _, _ strin
 }
 
 // mockRetryTracker implements domain.TrackerAdapter for retry timer tests.
-// Only FetchCandidateIssues is used by HandleRetryTimer; the remaining
-// methods panic if called.
+// FetchIssueByID is the primary entry point; FetchCandidateIssues panics
+// if called — HandleRetryTimer must not invoke it.
 type mockRetryTracker struct {
-	candidates []domain.Issue
-	fetchErr   error
-	fetchCount int
+	fetchedIssue domain.Issue
+	fetchErr     error
+	fetchCount   int
+	fetchedID    string // records the last issueID arg received by FetchIssueByID
 }
 
 var _ domain.TrackerAdapter = (*mockRetryTracker)(nil)
 
 func (m *mockRetryTracker) FetchCandidateIssues(_ context.Context) ([]domain.Issue, error) {
-	m.fetchCount++
-	return m.candidates, m.fetchErr
+	panic("FetchCandidateIssues must not be called by HandleRetryTimer")
 }
 
-func (m *mockRetryTracker) FetchIssueByID(context.Context, string) (domain.Issue, error) {
-	panic("FetchIssueByID must not be called by HandleRetryTimer")
+func (m *mockRetryTracker) FetchIssueByID(_ context.Context, issueID string) (domain.Issue, error) {
+	m.fetchCount++
+	m.fetchedID = issueID
+	return m.fetchedIssue, m.fetchErr
 }
 
 func (m *mockRetryTracker) FetchIssuesByStates(context.Context, []string) ([]domain.Issue, error) {
@@ -196,7 +198,7 @@ func TestHandleRetryTimer(t *testing.T) {
 			check: func(t *testing.T, _ string, _ *State, store *mockRetryStore, tracker *mockRetryTracker, _ bool) {
 				t.Helper()
 				if tracker.fetchCount != 0 {
-					t.Errorf("FetchCandidateIssues call count = %d, want 0", tracker.fetchCount)
+					t.Errorf("FetchIssueByID call count = %d, want 0", tracker.fetchCount)
 				}
 				if len(store.savedEntries) != 0 {
 					t.Errorf("SaveRetryEntry call count = %d, want 0", len(store.savedEntries))
@@ -235,7 +237,7 @@ func TestHandleRetryTimer(t *testing.T) {
 				}
 				// No tracker calls.
 				if tracker.fetchCount != 0 {
-					t.Errorf("FetchCandidateIssues call count = %d, want 0", tracker.fetchCount)
+					t.Errorf("FetchIssueByID call count = %d, want 0", tracker.fetchCount)
 				}
 				// No store calls.
 				if len(store.savedEntries) != 0 {
@@ -271,9 +273,7 @@ func TestHandleRetryTimer(t *testing.T) {
 			store: func() *mockRetryStore { return &mockRetryStore{} },
 			tracker: func(id string) *mockRetryTracker {
 				return &mockRetryTracker{
-					candidates: []domain.Issue{
-						candidateIssue(id, id, "To Do"),
-					},
+					fetchedIssue: candidateIssue(id, id, "To Do"),
 				}
 			},
 			workerFn: func(ch chan<- struct{}) WorkerFunc {
@@ -285,7 +285,7 @@ func TestHandleRetryTimer(t *testing.T) {
 				t.Helper()
 				// Tracker was called — entry was NOT treated as stale.
 				if tracker.fetchCount != 1 {
-					t.Errorf("FetchCandidateIssues call count = %d, want 1", tracker.fetchCount)
+					t.Errorf("FetchIssueByID call count = %d, want 1", tracker.fetchCount)
 				}
 				// Issue dispatched.
 				if _, ok := state.Running[id]; !ok {
@@ -327,8 +327,8 @@ func TestHandleRetryTimer(t *testing.T) {
 				if entry.Attempt != 3 {
 					t.Errorf("RetryAttempts[%s].Attempt = %d, want 3", id, entry.Attempt)
 				}
-				if entry.Error != "retry poll failed" {
-					t.Errorf("RetryAttempts[%s].Error = %q, want %q", id, entry.Error, "retry poll failed")
+				if entry.Error != "retry issue fetch failed" {
+					t.Errorf("RetryAttempts[%s].Error = %q, want %q", id, entry.Error, "retry issue fetch failed")
 				}
 				if entry.DueAtMS == 0 {
 					t.Errorf("RetryAttempts[%s].DueAtMS = 0, want non-zero", id)
@@ -375,14 +375,11 @@ func TestHandleRetryTimer(t *testing.T) {
 			},
 			store: func() *mockRetryStore { return &mockRetryStore{} },
 			tracker: func(_ string) *mockRetryTracker {
-				// Return candidates that do NOT contain the target issue.
 				return &mockRetryTracker{
-					candidates: []domain.Issue{
-						candidateIssue("OTHER-1", "OTHER-1", "To Do"),
-					},
+					fetchErr: &domain.TrackerError{Kind: domain.ErrTrackerNotFound, Message: "issue not found: ISS-1"},
 				}
 			},
-			check: func(t *testing.T, id string, state *State, store *mockRetryStore, _ *mockRetryTracker, _ bool) {
+			check: func(t *testing.T, id string, state *State, store *mockRetryStore, tracker *mockRetryTracker, _ bool) {
 				t.Helper()
 				// Claim released.
 				if _, claimed := state.Claimed[id]; claimed {
@@ -399,6 +396,9 @@ func TestHandleRetryTimer(t *testing.T) {
 				// SaveRetryEntry not called.
 				if len(store.savedEntries) != 0 {
 					t.Errorf("SaveRetryEntry call count = %d, want 0", len(store.savedEntries))
+				}
+				if tracker.fetchCount != 1 {
+					t.Errorf("FetchIssueByID call count = %d, want 1", tracker.fetchCount)
 				}
 			},
 		},
@@ -420,10 +420,7 @@ func TestHandleRetryTimer(t *testing.T) {
 			store: func() *mockRetryStore { return &mockRetryStore{} },
 			tracker: func(id string) *mockRetryTracker {
 				return &mockRetryTracker{
-					candidates: []domain.Issue{
-						candidateIssue(id, id, "To Do"),
-						candidateIssue("OTHER-1", "OTHER-1", "To Do"),
-					},
+					fetchedIssue: candidateIssue(id, id, "To Do"),
 				}
 			},
 			check: func(t *testing.T, id string, state *State, store *mockRetryStore, _ *mockRetryTracker, _ bool) {
@@ -473,9 +470,7 @@ func TestHandleRetryTimer(t *testing.T) {
 			store: func() *mockRetryStore { return &mockRetryStore{} },
 			tracker: func(id string) *mockRetryTracker {
 				return &mockRetryTracker{
-					candidates: []domain.Issue{
-						candidateIssue(id, id, "To Do"),
-					},
+					fetchedIssue: candidateIssue(id, id, "To Do"),
 				}
 			},
 			workerFn: func(ch chan<- struct{}) WorkerFunc {
@@ -522,9 +517,7 @@ func TestHandleRetryTimer(t *testing.T) {
 			store: func() *mockRetryStore { return &mockRetryStore{} },
 			tracker: func(id string) *mockRetryTracker {
 				return &mockRetryTracker{
-					candidates: []domain.Issue{
-						candidateIssue(id, id, "In Progress"),
-					},
+					fetchedIssue: candidateIssue(id, id, "In Progress"),
 				}
 			},
 			workerFn: func(ch chan<- struct{}) WorkerFunc {
@@ -596,11 +589,8 @@ func TestHandleRetryTimer(t *testing.T) {
 				return &mockRetryStore{deleteRetryEntryErr: errors.New("locked")}
 			},
 			tracker: func(_ string) *mockRetryTracker {
-				// Candidates don't contain the target issue → release path.
 				return &mockRetryTracker{
-					candidates: []domain.Issue{
-						candidateIssue("OTHER-1", "OTHER-1", "To Do"),
-					},
+					fetchErr: &domain.TrackerError{Kind: domain.ErrTrackerNotFound, Message: "issue not found: ISS-1"},
 				}
 			},
 			check: func(t *testing.T, id string, state *State, store *mockRetryStore, _ *mockRetryTracker, _ bool) {
@@ -633,7 +623,7 @@ func TestHandleRetryTimer(t *testing.T) {
 					{ID: "BLOCK-1", Identifier: "BLOCK-1", State: "In Progress"},
 				}
 				return &mockRetryTracker{
-					candidates: []domain.Issue{issue},
+					fetchedIssue: issue,
 				}
 			},
 			check: func(t *testing.T, id string, state *State, store *mockRetryStore, _ *mockRetryTracker, _ bool) {
@@ -671,9 +661,7 @@ func TestHandleRetryTimer(t *testing.T) {
 			tracker: func(id string) *mockRetryTracker {
 				// Issue has empty Title — fails required field check.
 				return &mockRetryTracker{
-					candidates: []domain.Issue{
-						{ID: id, Identifier: id, Title: "", State: "To Do"},
-					},
+					fetchedIssue: domain.Issue{ID: id, Identifier: id, Title: "", State: "To Do"},
 				}
 			},
 			check: func(t *testing.T, id string, state *State, store *mockRetryStore, _ *mockRetryTracker, _ bool) {
@@ -705,11 +693,9 @@ func TestHandleRetryTimer(t *testing.T) {
 			},
 			store: func() *mockRetryStore { return &mockRetryStore{} },
 			tracker: func(id string) *mockRetryTracker {
-				// Issue is in terminal state "Done" — rejected by Step 3b.
+				// Issue is in terminal state "Done" — rejected by active-state check.
 				return &mockRetryTracker{
-					candidates: []domain.Issue{
-						candidateIssue(id, id, "Done"),
-					},
+					fetchedIssue: candidateIssue(id, id, "Done"),
 				}
 			},
 			check: func(t *testing.T, id string, state *State, store *mockRetryStore, _ *mockRetryTracker, _ bool) {
@@ -747,10 +733,8 @@ func TestHandleRetryTimer(t *testing.T) {
 			store: func() *mockRetryStore {
 				return &mockRetryStore{runHistoryCount: 3}
 			},
-			tracker: func(id string) *mockRetryTracker {
-				return &mockRetryTracker{
-					candidates: []domain.Issue{candidateIssue(id, "PROJ-BUDGET", "To Do")},
-				}
+			tracker: func(_ string) *mockRetryTracker {
+				return &mockRetryTracker{}
 			},
 			check: func(t *testing.T, id string, state *State, store *mockRetryStore, tracker *mockRetryTracker, _ bool) {
 				t.Helper()
@@ -768,7 +752,7 @@ func TestHandleRetryTimer(t *testing.T) {
 				}
 				// Tracker never called — budget check runs before fetch.
 				if tracker.fetchCount != 0 {
-					t.Errorf("FetchCandidateIssues call count = %d, want 0", tracker.fetchCount)
+					t.Errorf("FetchIssueByID call count = %d, want 0", tracker.fetchCount)
 				}
 				// DeleteRetryEntry called.
 				if len(store.deletedIssueID) != 1 || store.deletedIssueID[0] != id {
@@ -793,7 +777,7 @@ func TestHandleRetryTimer(t *testing.T) {
 			},
 			tracker: func(id string) *mockRetryTracker {
 				return &mockRetryTracker{
-					candidates: []domain.Issue{candidateIssue(id, "PROJ-UNDER", "To Do")},
+					fetchedIssue: candidateIssue(id, "PROJ-UNDER", "To Do"),
 				}
 			},
 			workerFn: func(ch chan<- struct{}) WorkerFunc {
@@ -805,7 +789,7 @@ func TestHandleRetryTimer(t *testing.T) {
 				t.Helper()
 				// Tracker called.
 				if tracker.fetchCount != 1 {
-					t.Errorf("FetchCandidateIssues call count = %d, want 1", tracker.fetchCount)
+					t.Errorf("FetchIssueByID call count = %d, want 1", tracker.fetchCount)
 				}
 				// Issue dispatched.
 				if _, ok := state.Running[id]; !ok {
@@ -832,7 +816,7 @@ func TestHandleRetryTimer(t *testing.T) {
 			},
 			tracker: func(id string) *mockRetryTracker {
 				return &mockRetryTracker{
-					candidates: []domain.Issue{candidateIssue(id, "PROJ-NOLIMIT", "To Do")},
+					fetchedIssue: candidateIssue(id, "PROJ-NOLIMIT", "To Do"),
 				}
 			},
 			workerFn: func(ch chan<- struct{}) WorkerFunc {
@@ -848,7 +832,7 @@ func TestHandleRetryTimer(t *testing.T) {
 				}
 				// Tracker called.
 				if tracker.fetchCount != 1 {
-					t.Errorf("FetchCandidateIssues call count = %d, want 1", tracker.fetchCount)
+					t.Errorf("FetchIssueByID call count = %d, want 1", tracker.fetchCount)
 				}
 				// Issue dispatched.
 				if _, ok := state.Running[id]; !ok {
@@ -874,7 +858,7 @@ func TestHandleRetryTimer(t *testing.T) {
 			},
 			tracker: func(id string) *mockRetryTracker {
 				return &mockRetryTracker{
-					candidates: []domain.Issue{candidateIssue(id, "PROJ-FAIL", "To Do")},
+					fetchedIssue: candidateIssue(id, "PROJ-FAIL", "To Do"),
 				}
 			},
 			workerFn: func(ch chan<- struct{}) WorkerFunc {
@@ -890,7 +874,7 @@ func TestHandleRetryTimer(t *testing.T) {
 				}
 				// Tracker called — fail-open.
 				if tracker.fetchCount != 1 {
-					t.Errorf("FetchCandidateIssues call count = %d, want 1 (fail-open)", tracker.fetchCount)
+					t.Errorf("FetchIssueByID call count = %d, want 1 (fail-open)", tracker.fetchCount)
 				}
 				// Issue dispatched despite count error.
 				if _, ok := state.Running[id]; !ok {
@@ -902,6 +886,204 @@ func TestHandleRetryTimer(t *testing.T) {
 				// Claim preserved (issue is running).
 				if _, claimed := state.Claimed[id]; !claimed {
 					t.Errorf("Claimed[%s] missing, want claimed", id)
+				}
+			},
+		},
+		{
+			name:    "ErrTrackerNotFound releases claim",
+			issueID: "ISS-X",
+			state: func(t *testing.T, id string) *State {
+				t.Helper()
+				return retryState(t, id, id, 1)
+			},
+			store: func() *mockRetryStore { return &mockRetryStore{} },
+			tracker: func(_ string) *mockRetryTracker {
+				return &mockRetryTracker{
+					fetchErr: &domain.TrackerError{Kind: domain.ErrTrackerNotFound, Message: "issue not found: ISS-X"},
+				}
+			},
+			check: func(t *testing.T, id string, state *State, store *mockRetryStore, tracker *mockRetryTracker, _ bool) {
+				t.Helper()
+				if _, claimed := state.Claimed[id]; claimed {
+					t.Errorf("Claimed[%s] still present, want released", id)
+				}
+				if _, ok := state.RetryAttempts[id]; ok {
+					t.Errorf("RetryAttempts[%s] still present, want removed", id)
+				}
+				if len(store.deletedIssueID) != 1 || store.deletedIssueID[0] != id {
+					t.Errorf("DeleteRetryEntry calls = %v, want [%s]", store.deletedIssueID, id)
+				}
+				if len(store.savedEntries) != 0 {
+					t.Errorf("SaveRetryEntry call count = %d, want 0", len(store.savedEntries))
+				}
+				if tracker.fetchCount != 1 {
+					t.Errorf("FetchIssueByID call count = %d, want 1", tracker.fetchCount)
+				}
+			},
+		},
+		{
+			name:    "non-NotFound tracker error reschedules with backoff",
+			issueID: "ISS-TRANSPORT",
+			state: func(t *testing.T, id string) *State {
+				t.Helper()
+				return retryState(t, id, id, 1)
+			},
+			store: func() *mockRetryStore { return &mockRetryStore{} },
+			tracker: func(_ string) *mockRetryTracker {
+				return &mockRetryTracker{
+					fetchErr: &domain.TrackerError{Kind: domain.ErrTrackerTransport, Message: "timeout"},
+				}
+			},
+			check: func(t *testing.T, id string, state *State, store *mockRetryStore, tracker *mockRetryTracker, _ bool) {
+				t.Helper()
+				entry, ok := state.RetryAttempts[id]
+				if !ok {
+					t.Fatalf("RetryAttempts[%s] missing after transport error", id)
+				}
+				if entry.Attempt != 2 {
+					t.Errorf("RetryAttempts[%s].Attempt = %d, want 2", id, entry.Attempt)
+				}
+				if entry.Error != "retry issue fetch failed" {
+					t.Errorf("RetryAttempts[%s].Error = %q, want %q", id, entry.Error, "retry issue fetch failed")
+				}
+				if _, claimed := state.Claimed[id]; !claimed {
+					t.Errorf("Claimed[%s] missing after transport error, want claimed", id)
+				}
+				if len(store.savedEntries) != 1 {
+					t.Fatalf("SaveRetryEntry call count = %d, want 1", len(store.savedEntries))
+				}
+				if len(store.deletedIssueID) != 0 {
+					t.Errorf("DeleteRetryEntry call count = %d, want 0", len(store.deletedIssueID))
+				}
+				if tracker.fetchCount != 1 {
+					t.Errorf("FetchIssueByID call count = %d, want 1", tracker.fetchCount)
+				}
+				if entry.TimerHandle != nil {
+					entry.TimerHandle.Stop()
+				}
+			},
+		},
+		{
+			name:    "issue in non-active state releases claim",
+			issueID: "ISS-INACTIVE",
+			state: func(t *testing.T, id string) *State {
+				t.Helper()
+				return retryState(t, id, id, 1)
+			},
+			store: func() *mockRetryStore { return &mockRetryStore{} },
+			tracker: func(id string) *mockRetryTracker {
+				return &mockRetryTracker{
+					fetchedIssue: candidateIssue(id, id, "Done"),
+				}
+			},
+			check: func(t *testing.T, id string, state *State, store *mockRetryStore, _ *mockRetryTracker, _ bool) {
+				t.Helper()
+				if _, claimed := state.Claimed[id]; claimed {
+					t.Errorf("Claimed[%s] still present, want released (non-active state)", id)
+				}
+				if _, ok := state.RetryAttempts[id]; ok {
+					t.Errorf("RetryAttempts[%s] still present, want removed", id)
+				}
+				if len(store.deletedIssueID) != 1 || store.deletedIssueID[0] != id {
+					t.Errorf("DeleteRetryEntry calls = %v, want [%s]", store.deletedIssueID, id)
+				}
+				if len(store.savedEntries) != 0 {
+					t.Errorf("SaveRetryEntry call count = %d, want 0", len(store.savedEntries))
+				}
+			},
+		},
+		{
+			name:    "issue in active state proceeds to dispatch",
+			issueID: "ISS-ACTIVE",
+			state: func(t *testing.T, id string) *State {
+				t.Helper()
+				return retryState(t, id, id, 1)
+			},
+			store: func() *mockRetryStore { return &mockRetryStore{} },
+			tracker: func(id string) *mockRetryTracker {
+				return &mockRetryTracker{
+					fetchedIssue: candidateIssue(id, id, "In Progress"),
+				}
+			},
+			workerFn: func(ch chan<- struct{}) WorkerFunc {
+				return func(_ context.Context, _ domain.Issue, _ *int) {
+					ch <- struct{}{}
+				}
+			},
+			check: func(t *testing.T, id string, state *State, store *mockRetryStore, tracker *mockRetryTracker, workerCalled bool) {
+				t.Helper()
+				if _, ok := state.Running[id]; !ok {
+					t.Fatalf("Running[%s] missing after dispatch, want present", id)
+				}
+				if !workerCalled {
+					t.Error("worker function not invoked, want invoked")
+				}
+				if _, ok := state.RetryAttempts[id]; ok {
+					t.Errorf("RetryAttempts[%s] still present after dispatch, want cleared", id)
+				}
+				if len(store.deletedIssueID) != 1 || store.deletedIssueID[0] != id {
+					t.Errorf("DeleteRetryEntry calls = %v, want [%s]", store.deletedIssueID, id)
+				}
+				if tracker.fetchCount != 1 {
+					t.Errorf("FetchIssueByID call count = %d, want 1", tracker.fetchCount)
+				}
+			},
+		},
+		{
+			name:    "FetchIssueByID called with correct issueID",
+			issueID: "ISS-IDCHECK",
+			state: func(t *testing.T, id string) *State {
+				t.Helper()
+				return retryState(t, id, id, 1)
+			},
+			store: func() *mockRetryStore { return &mockRetryStore{} },
+			tracker: func(id string) *mockRetryTracker {
+				return &mockRetryTracker{
+					fetchedIssue: candidateIssue(id, id, "To Do"),
+				}
+			},
+			workerFn: func(ch chan<- struct{}) WorkerFunc {
+				return func(_ context.Context, _ domain.Issue, _ *int) {
+					ch <- struct{}{}
+				}
+			},
+			check: func(t *testing.T, id string, _ *State, _ *mockRetryStore, tracker *mockRetryTracker, _ bool) {
+				t.Helper()
+				if tracker.fetchedID != id {
+					t.Errorf("FetchIssueByID issueID = %q, want %q", tracker.fetchedID, id)
+				}
+			},
+		},
+		{
+			name:    "context cancellation error reschedules",
+			issueID: "ISS-CTX",
+			state: func(t *testing.T, id string) *State {
+				t.Helper()
+				return retryState(t, id, id, 1)
+			},
+			store: func() *mockRetryStore { return &mockRetryStore{} },
+			tracker: func(_ string) *mockRetryTracker {
+				return &mockRetryTracker{
+					fetchErr: context.Canceled,
+				}
+			},
+			check: func(t *testing.T, id string, state *State, store *mockRetryStore, tracker *mockRetryTracker, _ bool) {
+				t.Helper()
+				entry, ok := state.RetryAttempts[id]
+				if !ok {
+					t.Fatalf("RetryAttempts[%s] missing after context cancellation", id)
+				}
+				if entry.Attempt != 2 {
+					t.Errorf("RetryAttempts[%s].Attempt = %d, want 2", id, entry.Attempt)
+				}
+				if entry.Error != "retry issue fetch failed" {
+					t.Errorf("RetryAttempts[%s].Error = %q, want %q", id, entry.Error, "retry issue fetch failed")
+				}
+				if tracker.fetchCount != 1 {
+					t.Errorf("FetchIssueByID call count = %d, want 1", tracker.fetchCount)
+				}
+				if entry.TimerHandle != nil {
+					entry.TimerHandle.Stop()
 				}
 			},
 		},
@@ -943,10 +1125,7 @@ func TestHandleRetryTimer_WorkerStillRunningReschedulesInsteadOfDispatching(t *t
 	t.Parallel()
 
 	store := &mockRetryStore{}
-	tracker := &mockRetryTracker{
-		// If the guard works, FetchCandidateIssues should never be called.
-		candidates: []domain.Issue{candidateIssue("ISS-1", "ISS-1", "To Do")},
-	}
+	tracker := &mockRetryTracker{}
 
 	state := retryState(t, "ISS-1", "ISS-1", 2)
 	// Place the issue in Running to simulate a cancelled-but-not-yet-exited worker.
@@ -972,9 +1151,9 @@ func TestHandleRetryTimer_WorkerStillRunningReschedulesInsteadOfDispatching(t *t
 		t.Error("worker dispatched while issue still in Running, want no dispatch")
 	}
 
-	// FetchCandidateIssues should not have been called — guard returns early.
+	// FetchIssueByID should not be called — guard returns early.
 	if tracker.fetchCount != 0 {
-		t.Errorf("FetchCandidateIssues call count = %d, want 0", tracker.fetchCount)
+		t.Errorf("FetchIssueByID call count = %d, want 0", tracker.fetchCount)
 	}
 
 	// Retry entry rescheduled with same attempt number.
@@ -1014,7 +1193,7 @@ func TestHandleRetryTimer_SSHHostAcquisition(t *testing.T) {
 		hp := NewHostPool([]string{"host-a", "host-b"}, 2)
 		store := &mockRetryStore{}
 		tracker := &mockRetryTracker{
-			candidates: []domain.Issue{candidateIssue("ISS-SSH", "ISS-SSH", "To Do")},
+			fetchedIssue: candidateIssue("ISS-SSH", "ISS-SSH", "To Do"),
 		}
 
 		state := retryState(t, "ISS-SSH", "ISS-SSH", 2)
@@ -1055,7 +1234,7 @@ func TestHandleRetryTimer_SSHHostAcquisition(t *testing.T) {
 
 		store := &mockRetryStore{}
 		tracker := &mockRetryTracker{
-			candidates: []domain.Issue{candidateIssue("ISS-FULL", "ISS-FULL", "To Do")},
+			fetchedIssue: candidateIssue("ISS-FULL", "ISS-FULL", "To Do"),
 		}
 
 		state := retryState(t, "ISS-FULL", "ISS-FULL", 1)
@@ -1089,58 +1268,6 @@ func TestHandleRetryTimer_SSHHostAcquisition(t *testing.T) {
 			entry.TimerHandle.Stop()
 		}
 	})
-}
-
-func TestFindIssueByID(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name   string
-		issues []domain.Issue
-		id     string
-		want   bool
-		wantID string
-	}{
-		{
-			name:   "empty list",
-			issues: nil,
-			id:     "ISS-1",
-			want:   false,
-		},
-		{
-			name: "found",
-			issues: []domain.Issue{
-				candidateIssue("A", "A-1", "To Do"),
-				candidateIssue("B", "B-1", "To Do"),
-			},
-			id:     "B",
-			want:   true,
-			wantID: "B",
-		},
-		{
-			name: "not found",
-			issues: []domain.Issue{
-				candidateIssue("A", "A-1", "To Do"),
-			},
-			id:   "Z",
-			want: false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			got, found := findIssueByID(tt.issues, tt.id)
-
-			if found != tt.want {
-				t.Fatalf("findIssueByID(%v, %q) found = %v, want %v", tt.issues, tt.id, found, tt.want)
-			}
-			if found && got.ID != tt.wantID {
-				t.Errorf("findIssueByID(%v, %q).ID = %q, want %q", tt.issues, tt.id, got.ID, tt.wantID)
-			}
-		})
-	}
 }
 
 func TestIsStaleRetryTimer(t *testing.T) {
@@ -1215,7 +1342,7 @@ func TestHandleRetryTimer_WorkflowFilePropagated(t *testing.T) {
 	// RunningEntry so it is persisted by HandleWorkerExit.
 	store := &mockRetryStore{}
 	tracker := &mockRetryTracker{
-		candidates: []domain.Issue{candidateIssue("ISS-WF", "ISS-WF", "To Do")},
+		fetchedIssue: candidateIssue("ISS-WF", "ISS-WF", "To Do"),
 	}
 
 	state := retryState(t, "ISS-WF", "ISS-WF", 1)
@@ -1258,7 +1385,7 @@ func TestHandleRetryTimer_BudgetExhaustedBlocksShouldDispatch(t *testing.T) {
 	state := retryState(t, id, "PROJ-COMP", 2)
 	store := &mockRetryStore{runHistoryCount: 3}
 	tracker := &mockRetryTracker{
-		candidates: []domain.Issue{candidateIssue(id, "PROJ-COMP", "To Do")},
+		fetchedIssue: candidateIssue(id, "PROJ-COMP", "To Do"),
 	}
 
 	params := defaultRetryParams(t, store, tracker)
@@ -1308,7 +1435,7 @@ func TestHandleRetryTimer_ContinuationContextPropagated(t *testing.T) {
 
 	store := &mockRetryStore{}
 	tracker := &mockRetryTracker{
-		candidates: []domain.Issue{candidateIssue(id, id, "In Progress")},
+		fetchedIssue: candidateIssue(id, id, "In Progress"),
 	}
 	params := defaultRetryParams(t, store, tracker)
 
@@ -1353,7 +1480,7 @@ func TestHandleRetryTimer_NilContinuationContext_NotPropagated(t *testing.T) {
 
 	store := &mockRetryStore{}
 	tracker := &mockRetryTracker{
-		candidates: []domain.Issue{candidateIssue(id, id, "In Progress")},
+		fetchedIssue: candidateIssue(id, id, "In Progress"),
 	}
 	params := defaultRetryParams(t, store, tracker)
 
@@ -1389,7 +1516,7 @@ func TestHandleRetryTimer_ContinuationDispatch_MarksReactionDispatched(t *testin
 
 	store := &mockRetryStore{}
 	tracker := &mockRetryTracker{
-		candidates: []domain.Issue{candidateIssue(id, id, "In Progress")},
+		fetchedIssue: candidateIssue(id, id, "In Progress"),
 	}
 	params := defaultRetryParams(t, store, tracker)
 
@@ -1428,7 +1555,7 @@ func TestHandleRetryTimer_NonReactionRetry_DoesNotMarkDispatched(t *testing.T) {
 
 	store := &mockRetryStore{}
 	tracker := &mockRetryTracker{
-		candidates: []domain.Issue{candidateIssue(id, id, "To Do")},
+		fetchedIssue: candidateIssue(id, id, "To Do"),
 	}
 	params := defaultRetryParams(t, store, tracker)
 
@@ -1507,7 +1634,7 @@ func TestHandleRetryTimer_ContinuationMarkDispatchedError(t *testing.T) {
 
 	store := &mockRetryStore{markDispatchedErr: errors.New("db locked")}
 	tracker := &mockRetryTracker{
-		candidates: []domain.Issue{candidateIssue(id, id, "In Progress")},
+		fetchedIssue: candidateIssue(id, id, "In Progress"),
 	}
 	params := defaultRetryParams(t, store, tracker)
 
@@ -1535,7 +1662,7 @@ func TestHandleRetryTimer_SessionID_PassedToMakeWorkerFn(t *testing.T) {
 
 	store := &mockRetryStore{}
 	tracker := &mockRetryTracker{
-		candidates: []domain.Issue{candidateIssue(id, id, "In Progress")},
+		fetchedIssue: candidateIssue(id, id, "In Progress"),
 	}
 	params := defaultRetryParams(t, store, tracker)
 
@@ -1578,10 +1705,7 @@ func TestHandleRetryTimer_Reschedule_PreservesSessionID(t *testing.T) {
 
 	store := &mockRetryStore{}
 	tracker := &mockRetryTracker{
-		candidates: []domain.Issue{
-			candidateIssue(id, id, "To Do"),
-			candidateIssue("OTHER-1", "OTHER-1", "To Do"),
-		},
+		fetchedIssue: candidateIssue(id, id, "To Do"),
 	}
 	params := defaultRetryParams(t, store, tracker)
 

--- a/internal/scm/github/tracker_test.go
+++ b/internal/scm/github/tracker_test.go
@@ -2282,3 +2282,130 @@ func TestFetchIssueStatesByIDs_NetworkError_CachePreserved(t *testing.T) {
 		t.Errorf("third call result[\"30\"] = %q, want backlog (304 from preserved cache)", result3["30"])
 	}
 }
+
+func TestFetchCandidateIssueByIDEquivalence(t *testing.T) {
+	t.Parallel()
+
+	// Three cases:
+	// - Issue 1 ("backlog" label): active, returned by FetchCandidateIssues, local check accepts.
+	// - Issue 3 ("done" label): non-active, not returned by FetchCandidateIssues, local check rejects.
+	// - Issue 2 (pull request): skipped by FetchCandidateIssues, FetchIssueByID returns ErrTrackerNotFound.
+	issue1Body := issueJSON(1, "backlog", "open")
+	issue2PRBody := `{"id":200,"number":2,"title":"A PR","body":null,"state":"open","html_url":"https://github.com/owner/repo/pull/2","labels":[{"name":"in-progress"}],"assignees":[],"type":null,"pull_request":{},"created_at":"2026-01-01T00:00:00Z","updated_at":"2026-01-01T00:00:00Z"}`
+	issue3Body := issueJSON(3, "done", "open")
+	issueListBody := "[" + issue1Body + "," + issue2PRBody + "," + issue3Body + "]"
+	emptyList := "[]"
+	emptyComments := "[]"
+
+	mux := http.NewServeMux()
+
+	// FetchCandidateIssues endpoint.
+	mux.HandleFunc("/repos/owner/repo/issues", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(issueListBody)) //nolint:errcheck // test helper
+	})
+
+	// Issue 1: active, exists.
+	mux.HandleFunc("/repos/owner/repo/issues/1/dependencies/blocked_by", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	})
+	mux.HandleFunc("/repos/owner/repo/issues/1/parent", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	})
+	mux.HandleFunc("/repos/owner/repo/issues/1/comments", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(emptyComments)) //nolint:errcheck // test helper
+	})
+	mux.HandleFunc("/repos/owner/repo/issues/1", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(issue1Body)) //nolint:errcheck // test helper
+	})
+
+	// Issue 2 (PR): FetchIssueByID returns ErrTrackerNotFound for PRs.
+	mux.HandleFunc("/repos/owner/repo/issues/2", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(issue2PRBody)) //nolint:errcheck // test helper
+	})
+
+	// Issue 3: non-active, exists.
+	mux.HandleFunc("/repos/owner/repo/issues/3/dependencies/blocked_by", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	})
+	mux.HandleFunc("/repos/owner/repo/issues/3/parent", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	})
+	mux.HandleFunc("/repos/owner/repo/issues/3/comments", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(emptyComments)) //nolint:errcheck // test helper
+	})
+	mux.HandleFunc("/repos/owner/repo/issues/3", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(issue3Body)) //nolint:errcheck // test helper
+	})
+
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	// Configure with active states matching the test labels.
+	cfg := validConfig(srv.URL)
+	cfg["active_states"] = []any{"backlog", "in-progress"}
+	cfg["terminal_states"] = []any{"done"}
+	a := mustAdapter(t, cfg)
+	ctx := context.Background()
+
+	candidates, err := a.FetchCandidateIssues(ctx)
+	if err != nil {
+		t.Fatalf("FetchCandidateIssues: %v", err)
+	}
+	// Only issue #1 (backlog) appears — PR (#2) filtered, done (#3) non-active.
+	if len(candidates) != 1 {
+		t.Fatalf("FetchCandidateIssues: got %d issues, want 1 (only backlog)", len(candidates))
+	}
+	if candidates[0].ID != "1" {
+		t.Errorf("candidates[0].ID = %q, want 1", candidates[0].ID)
+	}
+
+	activeSet := make(map[string]bool, len(a.activeStates))
+	for _, s := range a.activeStates {
+		activeSet[s] = true // GitHub adapter already lowercases
+	}
+
+	// Case 1: active issue — FetchIssueByID succeeds and local check accepts.
+	issue1, err := a.FetchIssueByID(ctx, "1")
+	if err != nil {
+		t.Fatalf("FetchIssueByID(1): %v", err)
+	}
+	if issue1.ID != candidates[0].ID {
+		t.Errorf("FetchIssueByID(1).ID = %q, want %q", issue1.ID, candidates[0].ID)
+	}
+	if issue1.State != candidates[0].State {
+		t.Errorf("FetchIssueByID(1).State = %q, want %q (detail vs candidate differ)", issue1.State, candidates[0].State)
+	}
+	if !activeSet[issue1.State] {
+		t.Errorf("issue 1 (state=%q): local active check rejects it but it was a candidate", issue1.State)
+	}
+
+	// Case 2: PR — FetchIssueByID returns ErrTrackerNotFound.
+	_, err = a.FetchIssueByID(ctx, "2")
+	assertTrackerErrorKind(t, err, domain.ErrTrackerNotFound)
+
+	// Case 3: non-active issue — FetchIssueByID succeeds but local check rejects.
+	issue3, err := a.FetchIssueByID(ctx, "3")
+	if err != nil {
+		t.Fatalf("FetchIssueByID(3): %v", err)
+	}
+	if issue3.State == "" {
+		t.Fatalf("FetchIssueByID(3).State is empty")
+	}
+	if activeSet[issue3.State] {
+		t.Errorf("issue 3 (state=%q): local active check accepts it but it was not a candidate", issue3.State)
+	}
+	// Verify issue 3 was not in candidates (ensuring the exclusion is consistent).
+	for _, c := range candidates {
+		if c.ID == "3" {
+			t.Errorf("issue 3 appeared in candidates, want excluded (non-active state)")
+		}
+	}
+
+	_ = emptyList // suppress unused warning
+}

--- a/internal/tracker/file/file_test.go
+++ b/internal/tracker/file/file_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 
@@ -1268,4 +1269,51 @@ func TestCommentIssue(t *testing.T) {
 			t.Errorf("comment count = %d, want 21", len(comments))
 		}
 	})
+}
+
+func TestFetchCandidateIssueByIDEquivalence(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	activeStates := []any{"to do", "in progress"}
+	a := newAdapter(t, fixture("basic.json"), activeStates)
+
+	candidates, err := a.FetchCandidateIssues(ctx)
+	if err != nil {
+		t.Fatalf("FetchCandidateIssues: %v", err)
+	}
+
+	candidateSet := make(map[string]bool, len(candidates))
+	for _, c := range candidates {
+		candidateSet[c.ID] = true
+	}
+
+	activeSet := make(map[string]bool, len(activeStates))
+	for _, s := range activeStates {
+		activeSet[s.(string)] = true
+	}
+
+	// Equivalence: issue in candidates iff FetchIssueByID returns it without error
+	// and its state is in the configured active states.
+	allIDs := []string{"10001", "10002", "10003"}
+	for _, id := range allIDs {
+		issue, fetchErr := a.FetchIssueByID(ctx, id)
+		if fetchErr != nil {
+			// FetchIssueByID error means the issue must not be in candidates.
+			if candidateSet[id] {
+				t.Errorf("issue %s: in candidates but FetchIssueByID returned error: %v", id, fetchErr)
+			}
+			continue
+		}
+		inActive := activeSet[strings.ToLower(issue.State)]
+		inCandidates := candidateSet[id]
+		if inActive != inCandidates {
+			t.Errorf("issue %s (state=%q): in candidates=%v, in active states=%v \u2014 must be equal",
+				id, issue.State, inCandidates, inActive)
+		}
+	}
+
+	// Negative: non-existent ID returns ErrTrackerNotFound.
+	_, err = a.FetchIssueByID(ctx, "99999")
+	requireTrackerErrorKind(t, err, domain.ErrTrackerNotFound)
 }

--- a/internal/tracker/jira/jira_test.go
+++ b/internal/tracker/jira/jira_test.go
@@ -1994,11 +1994,6 @@ func TestFetchCandidateIssueByIDEquivalence(t *testing.T) {
 		t.Fatalf("FetchCandidateIssues: got %d issues, want 2", len(candidates))
 	}
 
-	candidateSet := make(map[string]bool, len(candidates))
-	for _, c := range candidates {
-		candidateSet[c.ID] = true
-	}
-
 	activeSet := make(map[string]bool, len(a.activeStates))
 	for _, s := range a.activeStates {
 		activeSet[strings.ToLower(s)] = true

--- a/internal/tracker/jira/jira_test.go
+++ b/internal/tracker/jira/jira_test.go
@@ -1955,3 +1955,78 @@ func TestNewJiraAdapter_UserAgentFromConfig(t *testing.T) {
 		})
 	}
 }
+
+func TestFetchCandidateIssueByIDEquivalence(t *testing.T) {
+	t.Parallel()
+
+	issue1JSON := `{"id":"10001","key":"PROJ-1","fields":{"summary":"Auth feature","status":{"name":"To Do"},"priority":{"id":"2"},"labels":[],"assignee":null,"issuetype":{"name":"Story"},"parent":null,"issuelinks":[],"description":null,"created":"2025-01-01T00:00:00.000+0000","updated":"2025-01-01T00:00:00.000+0000"}}`
+	issue2JSON := `{"id":"10002","key":"PROJ-2","fields":{"summary":"Fix bug","status":{"name":"In Progress"},"priority":{"id":"1"},"labels":[],"assignee":null,"issuetype":{"name":"Bug"},"parent":null,"issuelinks":[],"description":null,"created":"2025-01-02T00:00:00.000+0000","updated":"2025-01-02T00:00:00.000+0000"}}`
+	searchResp := `{"issues":[` + issue1JSON + `,` + issue2JSON + `]}`
+	emptyComments := `{"comments":[],"total":0,"maxResults":50}`
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/comment"):
+			w.Write([]byte(emptyComments)) //nolint:errcheck // test helper
+		case strings.HasSuffix(r.URL.Path, "/search/jql"):
+			w.Write([]byte(searchResp)) //nolint:errcheck // test helper
+		case strings.HasSuffix(r.URL.Path, "/issue/10001"):
+			w.Write([]byte(issue1JSON)) //nolint:errcheck // test helper
+		case strings.HasSuffix(r.URL.Path, "/issue/10002"):
+			w.Write([]byte(issue2JSON)) //nolint:errcheck // test helper
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	// Configure the adapter with active states matching the test issue states.
+	cfg := validConfig(srv.URL)
+	cfg["active_states"] = []any{"To Do", "In Progress"}
+	a := mustAdapter(t, cfg)
+	ctx := context.Background()
+
+	candidates, err := a.FetchCandidateIssues(ctx)
+	if err != nil {
+		t.Fatalf("FetchCandidateIssues: %v", err)
+	}
+	if len(candidates) != 2 {
+		t.Fatalf("FetchCandidateIssues: got %d issues, want 2", len(candidates))
+	}
+
+	candidateSet := make(map[string]bool, len(candidates))
+	for _, c := range candidates {
+		candidateSet[c.ID] = true
+	}
+
+	activeSet := make(map[string]bool, len(a.activeStates))
+	for _, s := range a.activeStates {
+		activeSet[strings.ToLower(s)] = true
+	}
+
+	// Equivalence: every candidate is also returned by FetchIssueByID with consistent state.
+	for _, candidate := range candidates {
+		issue, fetchErr := a.FetchIssueByID(ctx, candidate.ID)
+		if fetchErr != nil {
+			t.Errorf("issue %s: FetchIssueByID failed: %v", candidate.ID, fetchErr)
+			continue
+		}
+		if issue.ID != candidate.ID {
+			t.Errorf("issue %s: FetchIssueByID.ID = %q, want %q", candidate.ID, issue.ID, candidate.ID)
+		}
+		if issue.Identifier != candidate.Identifier {
+			t.Errorf("issue %s: FetchIssueByID.Identifier = %q, want %q", candidate.ID, issue.Identifier, candidate.Identifier)
+		}
+		if issue.State != candidate.State {
+			t.Errorf("issue %s: FetchIssueByID.State = %q, want %q (search vs detail differ)", candidate.ID, issue.State, candidate.State)
+		}
+		// Local active-state check must accept every candidate.
+		if !activeSet[strings.ToLower(issue.State)] {
+			t.Errorf("issue %s (state=%q): FetchCandidateIssues returned it but local active check rejects it", candidate.ID, issue.State)
+		}
+	}
+
+	// Negative: a 404 response from the server returns ErrTrackerNotFound.
+	_, err = a.FetchIssueByID(ctx, "99999")
+	assertTrackerErrorKind(t, err, domain.ErrTrackerNotFound)
+}


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Perf

**Intent:** Each retry timer event previously triggered a full paginated sweep of all active issues (`FetchCandidateIssues`) just to validate one issue, costing O(pages) tracker API calls. This replaces that sweep with a single `FetchIssueByID` call plus a local active-state membership check, reducing each timer fire to exactly one API call regardless of scale.

**Related Issues:** #206

### 🧭 Reviewer Guide

**Complexity:** Medium

#### Entry Point

`internal/orchestrator/retry.go` - the core change is in `HandleRetryTimer`, replacing the `FetchCandidateIssues` + `findIssueByID` block (~lines 181-240) with a `FetchIssueByID` call. Three error paths branch from the result: `ErrTrackerNotFound` releases the claim, transient errors reschedule with backoff, and a non-active state releases the claim.

#### Sensitive Areas

- `internal/orchestrator/retry.go`: Retry claim lifecycle - verify the three new branches (not-found, transient error, non-active state) each correctly release or reschedule without leaking claims.
- `internal/orchestrator/retry_test.go`: `mockRetryTracker` is inverted - `FetchCandidateIssues` now panics if called (enforces the new contract at test runtime); `FetchIssueByID` is the primary entry point.
- `internal/scm/github/tracker_test.go`: Covers the PR-as-issue edge case - GitHub adapter returns `ErrTrackerNotFound` for pull requests, so the optimized path correctly releases any PR claim.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes. `domain.TrackerAdapter` interface is unmodified; `FetchIssueByID` was already present. The `RetryEntry.Error` string changes from `"retry poll failed"` to `"retry issue fetch failed"` for transient fetch errors - any log queries or dashboards matching the old string will need updating.
- **Migrations/State:** No migrations or state changes.