### PR TITLE
feat(server): add accordion expand/collapse to dashboard tables

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -18,6 +18,10 @@
     "AGENTS.md": "CLAUDE.md"
   },
 
+  "[html]": {
+    "editor.formatOnSave": false
+  },
+
   // ── GitHub Copilot Custom Instructions ─────────────────────────────────────
   // Custom instruction files for code review for the current selection.
   // See: https://code.visualstudio.com/docs/copilot/customization/custom-instructions

--- a/internal/server/dashboard.html
+++ b/internal/server/dashboard.html
@@ -376,6 +376,7 @@
             <tr
               class="accordion-header{{if even $i}} row-even{{end}}"
               aria-expanded="false"
+              aria-controls="detail-running-{{$i}}"
               tabindex="0"
               role="button"
             >
@@ -388,7 +389,7 @@
               <td>{{$e.Duration}}</td>
               <td>{{$e.LastEvent}}</td>
             </tr>
-            <tr class="row-detail" aria-hidden="true">
+            <tr class="row-detail" id="detail-running-{{$i}}" aria-hidden="true">
               <td colspan="5">
                 <div class="detail-panel">
                   <dl class="detail-grid">
@@ -420,10 +421,7 @@
                       <dt>Tokens</dt>
                       <dd>
                         {{fmtInt $e.TotalTokens}}{{if $e.CacheReadTokens}}
-                        <small
-                          title="Prompt cache read tokens — served from cache, not reprocessed"
-                          >({{fmtInt $e.CacheReadTokens}} cached)</small
-                        >{{end}}
+                        <small title="Prompt cache read tokens — served from cache, not reprocessed">({{fmtInt $e.CacheReadTokens}} cached)</small>{{end}}
                       </dd>
                     </div>
                     <div class="detail-item">
@@ -462,6 +460,7 @@
             <tr
               class="accordion-header{{if even $i}} row-even{{end}}"
               aria-expanded="false"
+              aria-controls="detail-retry-{{$i}}"
               tabindex="0"
               role="button"
             >
@@ -471,7 +470,7 @@
               <td class="text-right">{{$e.Attempt}}</td>
               <td>{{$e.DueIn}}</td>
             </tr>
-            <tr class="row-detail" aria-hidden="true">
+            <tr class="row-detail" id="detail-retry-{{$i}}" aria-hidden="true">
               <td colspan="3">
                 <div class="detail-panel">
                   <dl class="detail-grid">
@@ -508,6 +507,7 @@
             <tr
               class="accordion-header{{if even $i}} row-even{{end}}"
               aria-expanded="false"
+              aria-controls="detail-history-{{$i}}"
               tabindex="0"
               role="button"
             >
@@ -518,7 +518,7 @@
               <td>{{$e.StartedAt}}</td>
               <td>{{$e.Duration}}</td>
             </tr>
-            <tr class="row-detail" aria-hidden="true">
+            <tr class="row-detail" id="detail-history-{{$i}}" aria-hidden="true">
               <td colspan="4">
                 <div class="detail-panel">
                   <dl class="detail-grid">

--- a/internal/server/dashboard.html
+++ b/internal/server/dashboard.html
@@ -377,6 +377,7 @@
               class="accordion-header{{if even $i}} row-even{{end}}"
               aria-expanded="false"
               aria-controls="detail-running-{{$i}}"
+              data-expand-key="running:{{$e.Identifier}}"
               tabindex="0"
               role="button"
             >
@@ -389,7 +390,11 @@
               <td>{{$e.Duration}}</td>
               <td>{{$e.LastEvent}}</td>
             </tr>
-            <tr class="row-detail" id="detail-running-{{$i}}" aria-hidden="true">
+            <tr
+              class="row-detail"
+              id="detail-running-{{$i}}"
+              aria-hidden="true"
+            >
               <td colspan="5">
                 <div class="detail-panel">
                   <dl class="detail-grid">
@@ -421,7 +426,10 @@
                       <dt>Tokens</dt>
                       <dd>
                         {{fmtInt $e.TotalTokens}}{{if $e.CacheReadTokens}}
-                        <small title="Prompt cache read tokens — served from cache, not reprocessed">({{fmtInt $e.CacheReadTokens}} cached)</small>{{end}}
+                        <small
+                          title="Prompt cache read tokens — served from cache, not reprocessed"
+                          >({{fmtInt $e.CacheReadTokens}} cached)</small
+                        >{{end}}
                       </dd>
                     </div>
                     <div class="detail-item">
@@ -461,6 +469,7 @@
               class="accordion-header{{if even $i}} row-even{{end}}"
               aria-expanded="false"
               aria-controls="detail-retry-{{$i}}"
+              data-expand-key="retry:{{$e.Identifier}}"
               tabindex="0"
               role="button"
             >
@@ -508,6 +517,7 @@
               class="accordion-header{{if even $i}} row-even{{end}}"
               aria-expanded="false"
               aria-controls="detail-history-{{$i}}"
+              data-expand-key="history:{{$e.Identifier}}:{{$e.Attempt}}"
               tabindex="0"
               role="button"
             >
@@ -518,7 +528,11 @@
               <td>{{$e.StartedAt}}</td>
               <td>{{$e.Duration}}</td>
             </tr>
-            <tr class="row-detail" id="detail-history-{{$i}}" aria-hidden="true">
+            <tr
+              class="row-detail"
+              id="detail-history-{{$i}}"
+              aria-hidden="true"
+            >
               <td colspan="4">
                 <div class="detail-panel">
                   <dl class="detail-grid">
@@ -568,18 +582,78 @@
       (function () {
         "use strict";
 
-        function toggleRow(headerRow) {
+        var STORAGE_KEY = "sortie-expanded";
+
+        function loadExpanded() {
+          try {
+            var raw = sessionStorage.getItem(STORAGE_KEY);
+            return raw ? JSON.parse(raw) : [];
+          } catch (e) {
+            return [];
+          }
+        }
+
+        function saveExpanded(keys) {
+          try {
+            sessionStorage.setItem(STORAGE_KEY, JSON.stringify(keys));
+          } catch (e) {
+            /* storage full or unavailable — silent */
+          }
+        }
+
+        function expandRow(headerRow) {
           var detail = headerRow.nextElementSibling;
           if (!detail || !detail.classList.contains("row-detail")) return;
+          headerRow.setAttribute("aria-expanded", "true");
+          detail.setAttribute("aria-hidden", "false");
+          detail.classList.add("open");
+        }
 
+        function collapseRow(headerRow) {
+          var detail = headerRow.nextElementSibling;
+          if (!detail || !detail.classList.contains("row-detail")) return;
+          headerRow.setAttribute("aria-expanded", "false");
+          detail.setAttribute("aria-hidden", "true");
+          detail.classList.remove("open");
+        }
+
+        function toggleRow(headerRow) {
           var expanded = headerRow.getAttribute("aria-expanded") === "true";
-          headerRow.setAttribute("aria-expanded", expanded ? "false" : "true");
-          detail.setAttribute("aria-hidden", expanded ? "true" : "false");
           if (expanded) {
-            detail.classList.remove("open");
+            collapseRow(headerRow);
           } else {
-            detail.classList.add("open");
+            expandRow(headerRow);
           }
+          syncStorage();
+        }
+
+        function syncStorage() {
+          var keys = [];
+          document
+            .querySelectorAll('.accordion-header[aria-expanded="true"]')
+            .forEach(function (row) {
+              var key = row.getAttribute("data-expand-key");
+              if (key) keys.push(key);
+            });
+          saveExpanded(keys);
+        }
+
+        // Restore expanded state from sessionStorage on page load.
+        var saved = loadExpanded();
+        if (saved.length > 0) {
+          var savedSet = {};
+          saved.forEach(function (k) {
+            savedSet[k] = true;
+          });
+          document
+            .querySelectorAll(".accordion-header[data-expand-key]")
+            .forEach(function (row) {
+              if (savedSet[row.getAttribute("data-expand-key")]) {
+                expandRow(row);
+              }
+            });
+          // Prune keys for rows no longer on the page.
+          syncStorage();
         }
 
         document.addEventListener("click", function (e) {

--- a/internal/server/dashboard.html
+++ b/internal/server/dashboard.html
@@ -424,13 +424,8 @@
                     </div>
                     <div class="detail-item">
                       <dt>Tokens</dt>
-                      <dd>
-                        {{fmtInt $e.TotalTokens}}{{if $e.CacheReadTokens}}
-                        <small
-                          title="Prompt cache read tokens — served from cache, not reprocessed"
-                          >({{fmtInt $e.CacheReadTokens}} cached)</small
-                        >{{end}}
-                      </dd>
+                      <!-- prettier-ignore -->
+                      <dd>{{fmtInt $e.TotalTokens}}{{if $e.CacheReadTokens}} <small title="Prompt cache read tokens — served from cache, not reprocessed">({{fmtInt $e.CacheReadTokens}} cached)</small>{{end}}</dd>
                     </div>
                     <div class="detail-item">
                       <dt>Tool Time</dt>

--- a/internal/server/dashboard.html
+++ b/internal/server/dashboard.html
@@ -201,6 +201,11 @@
         background: inherit;
       }
 
+      .accordion-header:focus-visible {
+        outline: 2px solid var(--color-link);
+        outline-offset: -2px;
+      }
+
       .expand-indicator {
         display: inline-block;
         width: 1em;

--- a/internal/server/dashboard.html
+++ b/internal/server/dashboard.html
@@ -183,8 +183,114 @@
         border-bottom: 1px solid var(--border);
       }
 
-      tr:nth-child(even) td {
+      .row-even > td {
         background: var(--table-stripe);
+      }
+
+      .accordion-header {
+        cursor: pointer;
+        user-select: none;
+        transition: background 0.15s ease;
+      }
+
+      .accordion-header:hover {
+        background: var(--table-hover);
+      }
+
+      .accordion-header:hover td {
+        background: inherit;
+      }
+
+      .expand-indicator {
+        display: inline-block;
+        width: 1em;
+        margin-right: 0.4em;
+        transition: transform 0.2s ease;
+        color: var(--text-secondary);
+        font-size: 0.7rem;
+      }
+
+      .accordion-header[aria-expanded="true"] .expand-indicator {
+        transform: rotate(90deg);
+      }
+
+      .row-detail {
+        display: none;
+      }
+
+      .row-detail.open {
+        display: table-row;
+      }
+
+      .row-detail td {
+        background: var(--bg-secondary);
+        border-bottom: 1px solid var(--border);
+        padding: 0;
+      }
+
+      .detail-panel {
+        padding: 0 0.75rem;
+        max-height: 0;
+        overflow: hidden;
+        transition:
+          max-height 0.25s ease,
+          padding 0.25s ease;
+      }
+
+      .row-detail.open .detail-panel {
+        max-height: 500px;
+        overflow-y: auto;
+        padding: 0.75rem;
+      }
+
+      .detail-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+        gap: 0.75rem;
+        margin: 0;
+      }
+
+      .detail-item {
+        display: flex;
+        flex-direction: column;
+      }
+
+      .detail-item dt {
+        font-size: 0.7rem;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        color: var(--text-secondary);
+        margin-bottom: 0.15rem;
+      }
+
+      .detail-item dd {
+        font-size: 0.875rem;
+        margin: 0;
+        word-break: break-word;
+      }
+
+      .detail-error {
+        grid-column: 1 / -1;
+      }
+
+      .detail-error dd {
+        font-family: monospace;
+        font-size: 0.8rem;
+        white-space: pre-wrap;
+        background: var(--bg);
+        padding: 0.5rem;
+        border-radius: 4px;
+        border: 1px solid var(--border);
+        max-height: 200px;
+        overflow-y: auto;
+      }
+
+      @media (prefers-reduced-motion: reduce) {
+        .detail-panel,
+        .expand-indicator,
+        .accordion-header {
+          transition: none;
+        }
       }
 
       .empty-state {
@@ -206,13 +312,6 @@
 
       .text-right {
         text-align: right;
-      }
-
-      .error-cell {
-        max-width: 300px;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
       }
 
       footer {
@@ -267,42 +366,77 @@
             <tr>
               <th>Identifier</th>
               <th>State</th>
-              <th>Workflow</th>
-              {{if $.HasSSH}}
-              <th>Host</th>
-              {{end}}
               <th class="text-right">Turns</th>
               <th>Duration</th>
               <th>Last Event</th>
-              <th>Model</th>
-              <th class="text-right">Requests</th>
-              <th class="text-right">Tokens</th>
-              <th class="text-right">Tool %</th>
-              <th class="text-right">API %</th>
             </tr>
           </thead>
           <tbody>
-            {{range .Running}}
-            <tr>
-              <td><a href="{{.DetailURL}}">{{.Identifier}}</a></td>
-              <td>{{.State}}</td>
+            {{range $i, $e := .Running}}
+            <tr
+              class="accordion-header{{if even $i}} row-even{{end}}"
+              aria-expanded="false"
+              tabindex="0"
+              role="button"
+            >
               <td>
-                {{if .WorkflowFile}}{{.WorkflowFile}}{{else}}&mdash;{{end}}
+                <span class="expand-indicator">&#9654;</span
+                ><a href="{{$e.DetailURL}}">{{$e.Identifier}}</a>
               </td>
-              {{if $.HasSSH}}
-              <td>{{if .Host}}{{.Host}}{{else}}local{{end}}</td>
-              {{end}}
-              <td class="text-right">{{.TurnCount}}</td>
-              <td>{{.Duration}}</td>
-              <td>{{.LastEvent}}</td>
-              <td>{{if .ModelName}}{{.ModelName}}{{else}}&mdash;{{end}}</td>
-              <td class="text-right">{{.APIRequestCount}}</td>
-              <td class="text-right">
-                {{fmtInt .TotalTokens}}{{if .CacheReadTokens}}
-                <small title="Prompt cache read tokens — served from cache, not reprocessed">({{fmtInt .CacheReadTokens}} cached)</small>{{end}}
+              <td>{{$e.State}}</td>
+              <td class="text-right">{{$e.TurnCount}}</td>
+              <td>{{$e.Duration}}</td>
+              <td>{{$e.LastEvent}}</td>
+            </tr>
+            <tr class="row-detail" aria-hidden="true">
+              <td colspan="5">
+                <div class="detail-panel">
+                  <dl class="detail-grid">
+                    <div class="detail-item">
+                      <dt>Workflow</dt>
+                      <dd>
+                        {{if
+                        $e.WorkflowFile}}{{$e.WorkflowFile}}{{else}}&mdash;{{end}}
+                      </dd>
+                    </div>
+                    {{if $.HasSSH}}
+                    <div class="detail-item">
+                      <dt>Host</dt>
+                      <dd>{{if $e.Host}}{{$e.Host}}{{else}}local{{end}}</dd>
+                    </div>
+                    {{end}}
+                    <div class="detail-item">
+                      <dt>Model</dt>
+                      <dd>
+                        {{if
+                        $e.ModelName}}{{$e.ModelName}}{{else}}&mdash;{{end}}
+                      </dd>
+                    </div>
+                    <div class="detail-item">
+                      <dt>API Requests</dt>
+                      <dd>{{$e.APIRequestCount}}</dd>
+                    </div>
+                    <div class="detail-item">
+                      <dt>Tokens</dt>
+                      <dd>
+                        {{fmtInt $e.TotalTokens}}{{if $e.CacheReadTokens}}
+                        <small
+                          title="Prompt cache read tokens — served from cache, not reprocessed"
+                          >({{fmtInt $e.CacheReadTokens}} cached)</small
+                        >{{end}}
+                      </dd>
+                    </div>
+                    <div class="detail-item">
+                      <dt>Tool Time</dt>
+                      <dd>{{$e.ToolTimePct}}</dd>
+                    </div>
+                    <div class="detail-item">
+                      <dt>API Time</dt>
+                      <dd>{{$e.APITimePct}}</dd>
+                    </div>
+                  </dl>
+                </div>
               </td>
-              <td class="text-right">{{.ToolTimePct}}</td>
-              <td class="text-right">{{.APITimePct}}</td>
             </tr>
             {{end}}
           </tbody>
@@ -321,16 +455,33 @@
               <th>Identifier</th>
               <th class="text-right">Attempt</th>
               <th>Due</th>
-              <th>Error</th>
             </tr>
           </thead>
           <tbody>
-            {{range .Retrying}}
-            <tr>
-              <td>{{.Identifier}}</td>
-              <td class="text-right">{{.Attempt}}</td>
-              <td>{{.DueIn}}</td>
-              <td class="error-cell" title="{{.Error}}">{{.Error}}</td>
+            {{range $i, $e := .Retrying}}
+            <tr
+              class="accordion-header{{if even $i}} row-even{{end}}"
+              aria-expanded="false"
+              tabindex="0"
+              role="button"
+            >
+              <td>
+                <span class="expand-indicator">&#9654;</span>{{$e.Identifier}}
+              </td>
+              <td class="text-right">{{$e.Attempt}}</td>
+              <td>{{$e.DueIn}}</td>
+            </tr>
+            <tr class="row-detail" aria-hidden="true">
+              <td colspan="3">
+                <div class="detail-panel">
+                  <dl class="detail-grid">
+                    <div class="detail-item detail-error">
+                      <dt>Error</dt>
+                      <dd>{{if $e.Error}}{{$e.Error}}{{else}}&mdash;{{end}}</dd>
+                    </div>
+                  </dl>
+                </div>
+              </td>
             </tr>
             {{end}}
           </tbody>
@@ -347,27 +498,51 @@
           <thead>
             <tr>
               <th>Identifier</th>
-              <th class="text-right">Attempt</th>
-              <th class="text-right">Turns</th>
               <th>Status</th>
-              <th>Workflow</th>
               <th>Started</th>
               <th>Duration</th>
-              <th>Error</th>
             </tr>
           </thead>
           <tbody>
-            {{range .RunHistory}}
-            <tr>
-              <td>{{.Identifier}}</td>
-              <td class="text-right">{{.Attempt}}</td>
-              <td class="text-right">{{.Turns}}</td>
-              <td>{{.Status}}</td>
-              <td>{{.WorkflowFile}}</td>
-              <td>{{.StartedAt}}</td>
-              <td>{{.Duration}}</td>
-              <td class="error-cell" title="{{.Error}}">
-                {{if .Error}}{{.Error}}{{else}}&mdash;{{end}}
+            {{range $i, $e := .RunHistory}}
+            <tr
+              class="accordion-header{{if even $i}} row-even{{end}}"
+              aria-expanded="false"
+              tabindex="0"
+              role="button"
+            >
+              <td>
+                <span class="expand-indicator">&#9654;</span>{{$e.Identifier}}
+              </td>
+              <td>{{$e.Status}}</td>
+              <td>{{$e.StartedAt}}</td>
+              <td>{{$e.Duration}}</td>
+            </tr>
+            <tr class="row-detail" aria-hidden="true">
+              <td colspan="4">
+                <div class="detail-panel">
+                  <dl class="detail-grid">
+                    <div class="detail-item">
+                      <dt>Attempt</dt>
+                      <dd>{{$e.Attempt}}</dd>
+                    </div>
+                    <div class="detail-item">
+                      <dt>Turns</dt>
+                      <dd>{{$e.Turns}}</dd>
+                    </div>
+                    <div class="detail-item">
+                      <dt>Workflow</dt>
+                      <dd>
+                        {{if
+                        $e.WorkflowFile}}{{$e.WorkflowFile}}{{else}}&mdash;{{end}}
+                      </dd>
+                    </div>
+                    <div class="detail-item detail-error">
+                      <dt>Error</dt>
+                      <dd>{{if $e.Error}}{{$e.Error}}{{else}}&mdash;{{end}}</dd>
+                    </div>
+                  </dl>
+                </div>
               </td>
             </tr>
             {{end}}
@@ -389,5 +564,39 @@
       </div>
       <div>Auto-refresh every 5s</div>
     </footer>
+    <script>
+      (function () {
+        "use strict";
+
+        function toggleRow(headerRow) {
+          var detail = headerRow.nextElementSibling;
+          if (!detail || !detail.classList.contains("row-detail")) return;
+
+          var expanded = headerRow.getAttribute("aria-expanded") === "true";
+          headerRow.setAttribute("aria-expanded", expanded ? "false" : "true");
+          detail.setAttribute("aria-hidden", expanded ? "true" : "false");
+          if (expanded) {
+            detail.classList.remove("open");
+          } else {
+            detail.classList.add("open");
+          }
+        }
+
+        document.addEventListener("click", function (e) {
+          if (e.target.closest("a")) return;
+          var header = e.target.closest(".accordion-header");
+          if (header) toggleRow(header);
+        });
+
+        document.addEventListener("keydown", function (e) {
+          if (e.key !== "Enter" && e.key !== " ") return;
+          var el = document.activeElement;
+          if (el && el.classList.contains("accordion-header")) {
+            e.preventDefault();
+            toggleRow(el);
+          }
+        });
+      })();
+    </script>
   </body>
 </html>

--- a/internal/server/dashboard_test.go
+++ b/internal/server/dashboard_test.go
@@ -1,7 +1,9 @@
 package server
 
 import (
+	"bytes"
 	"context"
+	"html/template"
 	"io"
 	"log/slog"
 	"net/http"
@@ -129,6 +131,10 @@ func TestHandleDashboard_OK(t *testing.T) {
 		"In Progress",
 		"turn_completed",
 		"no available orchestrator slots",
+		"accordion-header",
+		"row-detail",
+		`aria-expanded="false"`,
+		"expand-indicator",
 	} {
 		if !strings.Contains(dr.Body, want) {
 			t.Errorf("body missing %q", want)
@@ -632,8 +638,9 @@ func TestDashboard_HTMLEscaping(t *testing.T) {
 	dr := getDashboard(t, ts, "/")
 
 	// html/template must escape the script tag.
-	if strings.Contains(dr.Body, "<script>") {
-		t.Error("body contains unescaped <script> tag — XSS vulnerability")
+	// Check for the XSS payload specifically; the legitimate accordion script block is also present.
+	if strings.Contains(dr.Body, "<script>alert") {
+		t.Error("body contains unescaped XSS payload — XSS vulnerability")
 	}
 	// The escaped version should be present.
 	if !strings.Contains(dr.Body, "&lt;script&gt;") {
@@ -939,7 +946,7 @@ func TestHandleDashboard_RunHistory(t *testing.T) {
 	if dr.StatusCode != http.StatusOK {
 		t.Fatalf("status = %d, want %d", dr.StatusCode, http.StatusOK)
 	}
-	for _, want := range []string{"MT-100", "backend.WORKFLOW.md", "Run History", "Turns"} {
+	for _, want := range []string{"MT-100", "backend.WORKFLOW.md", "Run History", "Turns", "accordion-header", "row-detail"} {
 		if !strings.Contains(dr.Body, want) {
 			t.Errorf("body missing %q", want)
 		}
@@ -1204,5 +1211,209 @@ func TestMapRunHistoryEntries_DisplayID(t *testing.T) {
 				t.Errorf("Identifier = %q, want %q", got[0].Identifier, tt.wantID)
 			}
 		})
+	}
+}
+
+func TestEvenTemplateFunc(t *testing.T) {
+	t.Parallel()
+
+	tmpl := template.Must(template.New("test").Funcs(template.FuncMap{
+		"even": func(i int) bool { return i%2 == 0 },
+	}).Parse(`{{if even .}}yes{{else}}no{{end}}`))
+
+	tests := []struct {
+		input int
+		want  string
+	}{
+		{0, "yes"},
+		{1, "no"},
+		{2, "yes"},
+		{3, "no"},
+	}
+
+	for _, tt := range tests {
+		t.Run("", func(t *testing.T) {
+			t.Parallel()
+
+			var buf bytes.Buffer
+			if err := tmpl.Execute(&buf, tt.input); err != nil {
+				t.Fatalf("Execute(%d): %v", tt.input, err)
+			}
+			if got := buf.String(); got != tt.want {
+				t.Errorf("even(%d) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDashboard_RowsCollapsedByDefault(t *testing.T) {
+	t.Parallel()
+
+	snap := dashboardSnapshot()
+	ts := dashboardServer(t, fixedSnapshot(snap), "1.0.0", func() int { return 5 })
+	dr := getDashboard(t, ts, "/")
+
+	if strings.Contains(dr.Body, `aria-expanded="true" tabindex`) {
+		t.Error(`accordion header has aria-expanded="true" — all rows must start collapsed`)
+	}
+	if strings.Contains(dr.Body, `row-detail open"`) || strings.Contains(dr.Body, `row-detail open `) {
+		t.Error("body contains open detail row — all rows must start collapsed")
+	}
+}
+
+func TestDashboard_DetailPanelFields(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 3, 24, 12, 0, 0, 0, time.UTC)
+
+	t.Run("running session fields in detail panel", func(t *testing.T) {
+		t.Parallel()
+
+		snap := orchestrator.RuntimeSnapshotResult{
+			GeneratedAt: now,
+			Running: []orchestrator.SnapshotRunningEntry{
+				{
+					IssueID:          "id-dp",
+					Identifier:       "MT-DP",
+					State:            "In Progress",
+					StartedAt:        now.Add(-10 * time.Minute),
+					AgentTotalTokens: 5000,
+					ModelName:        "claude-sonnet-4-20250514",
+					WorkflowFile:     "backend.WORKFLOW.md",
+					ToolTimeMs:       12000,
+					APITimeMs:        45000,
+				},
+			},
+		}
+		ts := dashboardServer(t, fixedSnapshot(snap), "1.0.0", func() int { return 5 })
+		dr := getDashboard(t, ts, "/")
+
+		if dr.StatusCode != http.StatusOK {
+			t.Fatalf("status = %d, want %d", dr.StatusCode, http.StatusOK)
+		}
+		for _, want := range []string{"claude-sonnet-4-20250514", "backend.WORKFLOW.md"} {
+			if !strings.Contains(dr.Body, want) {
+				t.Errorf("body missing detail panel field %q", want)
+			}
+		}
+	})
+
+	t.Run("run history error appears in detail panel", func(t *testing.T) {
+		t.Parallel()
+
+		errMsg := "agent timed out"
+		srv := New(Params{
+			SnapshotFn: fixedSnapshot(orchestrator.RuntimeSnapshotResult{GeneratedAt: now}),
+			RefreshFn:  acceptingRefresh(),
+			Logger:     slog.New(slog.DiscardHandler),
+			StartedAt:  now.Add(-1 * time.Hour),
+			RunHistoryFn: func(_ context.Context, _ int) ([]RunHistoryEntry, error) {
+				return []RunHistoryEntry{
+					{
+						Identifier:  "MT-ERR",
+						Attempt:     2,
+						Status:      "failed",
+						StartedAt:   "2026-03-24T09:00:00Z",
+						CompletedAt: "2026-03-24T09:01:00Z",
+						Error:       &errMsg,
+					},
+				}, nil
+			},
+		})
+		ts := httptest.NewServer(srv.Mux())
+		t.Cleanup(ts.Close)
+
+		dr := getDashboard(t, ts, "/")
+		if !strings.Contains(dr.Body, "agent timed out") {
+			t.Error("body missing run history error message in detail panel")
+		}
+	})
+}
+
+func TestDashboard_StripingAlternates(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 3, 24, 12, 0, 0, 0, time.UTC)
+	snap := orchestrator.RuntimeSnapshotResult{
+		GeneratedAt: now,
+		Running: []orchestrator.SnapshotRunningEntry{
+			{IssueID: "id-1", Identifier: "MT-S1", State: "In Progress", StartedAt: now.Add(-3 * time.Minute)},
+			{IssueID: "id-2", Identifier: "MT-S2", State: "In Progress", StartedAt: now.Add(-2 * time.Minute)},
+			{IssueID: "id-3", Identifier: "MT-S3", State: "In Progress", StartedAt: now.Add(-1 * time.Minute)},
+		},
+	}
+
+	srv := New(Params{
+		SnapshotFn: fixedSnapshot(snap),
+		RefreshFn:  acceptingRefresh(),
+		Logger:     slog.New(slog.DiscardHandler),
+		StartedAt:  now.Add(-1 * time.Hour),
+		RunHistoryFn: func(_ context.Context, _ int) ([]RunHistoryEntry, error) {
+			return []RunHistoryEntry{
+				{Identifier: "MT-H1", Attempt: 1, Status: "succeeded", StartedAt: "2026-03-24T08:00:00Z", CompletedAt: "2026-03-24T08:01:00Z"},
+				{Identifier: "MT-H2", Attempt: 1, Status: "succeeded", StartedAt: "2026-03-24T08:01:00Z", CompletedAt: "2026-03-24T08:02:00Z"},
+				{Identifier: "MT-H3", Attempt: 1, Status: "succeeded", StartedAt: "2026-03-24T08:02:00Z", CompletedAt: "2026-03-24T08:03:00Z"},
+			}, nil
+		},
+	})
+	ts := httptest.NewServer(srv.Mux())
+	t.Cleanup(ts.Close)
+
+	dr := getDashboard(t, ts, "/")
+
+	if !strings.Contains(dr.Body, "row-even") {
+		t.Error("body missing row-even class — striping not applied")
+	}
+	if strings.Contains(dr.Body, "tr:nth-child") {
+		t.Error("body contains tr:nth-child — old CSS rule must be removed")
+	}
+}
+
+func TestDashboard_RunningSessionsIdentifierLinks(t *testing.T) {
+	t.Parallel()
+
+	snap := dashboardSnapshot()
+	ts := dashboardServer(t, fixedSnapshot(snap), "1.0.0", func() int { return 5 })
+	dr := getDashboard(t, ts, "/")
+
+	if !strings.Contains(dr.Body, "<a href=") {
+		t.Error("body missing anchor tag — running session identifier links not rendered")
+	}
+}
+
+func TestDashboard_DetailRowColspan(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 3, 24, 12, 0, 0, 0, time.UTC)
+	snap := orchestrator.RuntimeSnapshotResult{
+		GeneratedAt: now,
+		Running: []orchestrator.SnapshotRunningEntry{
+			{IssueID: "id-1", Identifier: "MT-CS1", State: "In Progress", StartedAt: now.Add(-1 * time.Minute)},
+		},
+		Retrying: []orchestrator.SnapshotRetryEntry{
+			{IssueID: "id-2", Identifier: "MT-CS2", Attempt: 1, DueAtMS: now.Add(1 * time.Minute).UnixMilli(), Error: "timeout"},
+		},
+	}
+
+	srv := New(Params{
+		SnapshotFn: fixedSnapshot(snap),
+		RefreshFn:  acceptingRefresh(),
+		Logger:     slog.New(slog.DiscardHandler),
+		StartedAt:  now.Add(-1 * time.Hour),
+		RunHistoryFn: func(_ context.Context, _ int) ([]RunHistoryEntry, error) {
+			return []RunHistoryEntry{
+				{Identifier: "MT-CS-H1", Attempt: 1, Status: "succeeded", StartedAt: "2026-03-24T08:00:00Z", CompletedAt: "2026-03-24T08:01:00Z"},
+			}, nil
+		},
+	})
+	ts := httptest.NewServer(srv.Mux())
+	t.Cleanup(ts.Close)
+
+	dr := getDashboard(t, ts, "/")
+
+	for _, want := range []string{`colspan="5"`, `colspan="3"`, `colspan="4"`} {
+		if !strings.Contains(dr.Body, want) {
+			t.Errorf("body missing %q — detail row colspan incorrect", want)
+		}
 	}
 }

--- a/internal/server/dashboard_test.go
+++ b/internal/server/dashboard_test.go
@@ -1254,7 +1254,11 @@ func TestDashboard_RowsCollapsedByDefault(t *testing.T) {
 	ts := dashboardServer(t, fixedSnapshot(snap), "1.0.0", func() int { return 5 })
 	dr := getDashboard(t, ts, "/")
 
-	if strings.Contains(dr.Body, `aria-expanded="true" tabindex`) {
+	// Check for expanded rows in the rendered markup. The CSS and JS also
+	// contain the literal string aria-expanded="true" (in selectors and
+	// querySelector calls), so match the attribute in element context only.
+	if strings.Contains(dr.Body, `aria-expanded="true"
+`) || strings.Contains(dr.Body, `aria-expanded="true">`) {
 		t.Error(`accordion header has aria-expanded="true" — all rows must start collapsed`)
 	}
 	if strings.Contains(dr.Body, `row-detail open"`) || strings.Contains(dr.Body, `row-detail open `) {

--- a/internal/server/dashboard_test.go
+++ b/internal/server/dashboard_test.go
@@ -1222,17 +1222,18 @@ func TestEvenTemplateFunc(t *testing.T) {
 	}).Parse(`{{if even .}}yes{{else}}no{{end}}`))
 
 	tests := []struct {
+		name  string
 		input int
 		want  string
 	}{
-		{0, "yes"},
-		{1, "no"},
-		{2, "yes"},
-		{3, "no"},
+		{"zero_is_even", 0, "yes"},
+		{"one_is_odd", 1, "no"},
+		{"two_is_even", 2, "yes"},
+		{"three_is_odd", 3, "no"},
 	}
 
 	for _, tt := range tests {
-		t.Run("", func(t *testing.T) {
+		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
 			var buf bytes.Buffer

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -167,6 +167,7 @@ func New(params Params) *Server {
 	tmpl := template.Must(
 		template.New("dashboard").Funcs(template.FuncMap{
 			"fmtInt": fmtInt,
+			"even":   func(i int) bool { return i%2 == 0 },
 		}).Parse(dashboardHTML),
 	)
 


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Feat

**Intent:** The HTML dashboard tables were wide and cluttered — especially Running Sessions with 12 columns. This replaces all three flat tables with an accordion pattern so operators can glance at primary status columns and expand a row to see secondary detail on demand. Expanded rows survive the 5-second auto-refresh using sessionStorage keyed by issue identifier.

**Related Issues:** #432

### 🧭 Reviewer Guide

**Complexity:** Medium

#### Entry Point

`internal/server/dashboard.html` — all CSS, markup, and JS live here. The accordion refactor touches the Running Sessions (12→5 columns), Retry Queue (4→3 columns), and Run History (8→4 columns) table bodies. Each data row is now a pair: an `.accordion-header` `<tr>` and a hidden `.row-detail` `<tr>` containing a definition-list detail panel.

#### Sensitive Areas

- `internal/server/dashboard.html`: The `tr:nth-child(even)` striping rule was replaced with class-based `.row-even` striping (applied via the new `even` template function) because interleaved detail rows break `nth-child` counting. The vanilla JS toggle manipulates `aria-expanded`, `aria-hidden`, and the `open` class with `aria-controls` linking header rows to their controlled regions. Expansion state is saved to `sessionStorage` (key `sortie-expanded`) on every toggle, and restored on page load by matching `data-expand-key` attributes (`running:<id>`, `retry:<id>`, `history:<id>:<attempt>`). Keys for rows no longer present in the page are pruned automatically.
- `internal/server/server.go`: One-line change — the `even` function is added to the `template.FuncMap` alongside `fmtInt`. Template parsing fails at startup if this is missing.
- `.vscode/settings.json`: HTML format-on-save is disabled to prevent Prettier from reformatting Go template syntax inside `dashboard.html`.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes. No API surface, struct types, persistence schema, or adapter packages were modified.
- **Migrations/State:** No migrations or state changes. sessionStorage is browser-local and cleared when the tab closes.