### PR TITLE
refactor(server): move accordion toggle from role=button on tr to button element

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+# Ignore all HTML files:
+**/*.html

--- a/internal/server/dashboard.html
+++ b/internal/server/dashboard.html
@@ -201,7 +201,18 @@
         background: inherit;
       }
 
-      .accordion-header:focus-visible {
+      .accordion-toggle {
+        background: none;
+        border: none;
+        padding: 0;
+        margin: 0;
+        font: inherit;
+        color: inherit;
+        cursor: pointer;
+        text-align: left;
+      }
+
+      .accordion-toggle:focus-visible {
         outline: 2px solid var(--color-link);
         outline-offset: -2px;
       }
@@ -215,7 +226,7 @@
         font-size: 0.7rem;
       }
 
-      .accordion-header[aria-expanded="true"] .expand-indicator {
+      .accordion-toggle[aria-expanded="true"] .expand-indicator {
         transform: rotate(90deg);
       }
 
@@ -293,7 +304,8 @@
       @media (prefers-reduced-motion: reduce) {
         .detail-panel,
         .expand-indicator,
-        .accordion-header {
+        .accordion-header,
+        .accordion-toggle {
           transition: none;
         }
       }
@@ -380,15 +392,18 @@
             {{range $i, $e := .Running}}
             <tr
               class="accordion-header{{if even $i}} row-even{{end}}"
-              aria-expanded="false"
-              aria-controls="detail-running-{{$i}}"
               data-expand-key="running:{{$e.Identifier}}"
-              tabindex="0"
-              role="button"
             >
               <td>
-                <span class="expand-indicator">&#9654;</span
-                ><a href="{{$e.DetailURL}}">{{$e.Identifier}}</a>
+                <button
+                  type="button"
+                  class="accordion-toggle"
+                  aria-expanded="false"
+                  aria-controls="detail-running-{{$i}}"
+                >
+                  <span class="expand-indicator">&#9654;</span
+                  ><a href="{{$e.DetailURL}}">{{$e.Identifier}}</a>
+                </button>
               </td>
               <td>{{$e.State}}</td>
               <td class="text-right">{{$e.TurnCount}}</td>
@@ -467,14 +482,17 @@
             {{range $i, $e := .Retrying}}
             <tr
               class="accordion-header{{if even $i}} row-even{{end}}"
-              aria-expanded="false"
-              aria-controls="detail-retry-{{$i}}"
               data-expand-key="retry:{{$e.Identifier}}"
-              tabindex="0"
-              role="button"
             >
               <td>
-                <span class="expand-indicator">&#9654;</span>{{$e.Identifier}}
+                <button
+                  type="button"
+                  class="accordion-toggle"
+                  aria-expanded="false"
+                  aria-controls="detail-retry-{{$i}}"
+                >
+                  <span class="expand-indicator">&#9654;</span>{{$e.Identifier}}
+                </button>
               </td>
               <td class="text-right">{{$e.Attempt}}</td>
               <td>{{$e.DueIn}}</td>
@@ -515,14 +533,17 @@
             {{range $i, $e := .RunHistory}}
             <tr
               class="accordion-header{{if even $i}} row-even{{end}}"
-              aria-expanded="false"
-              aria-controls="detail-history-{{$i}}"
               data-expand-key="history:{{$e.Identifier}}:{{$e.Attempt}}"
-              tabindex="0"
-              role="button"
             >
               <td>
-                <span class="expand-indicator">&#9654;</span>{{$e.Identifier}}
+                <button
+                  type="button"
+                  class="accordion-toggle"
+                  aria-expanded="false"
+                  aria-controls="detail-history-{{$i}}"
+                >
+                  <span class="expand-indicator">&#9654;</span>{{$e.Identifier}}
+                </button>
               </td>
               <td>{{$e.Status}}</td>
               <td>{{$e.StartedAt}}</td>
@@ -601,10 +622,15 @@
           }
         }
 
+        function getToggleButton(headerRow) {
+          return headerRow.querySelector(".accordion-toggle");
+        }
+
         function expandRow(headerRow) {
           var detail = headerRow.nextElementSibling;
           if (!detail || !detail.classList.contains("row-detail")) return;
-          headerRow.setAttribute("aria-expanded", "true");
+          var btn = getToggleButton(headerRow);
+          if (btn) btn.setAttribute("aria-expanded", "true");
           detail.setAttribute("aria-hidden", "false");
           detail.classList.add("open");
         }
@@ -612,13 +638,15 @@
         function collapseRow(headerRow) {
           var detail = headerRow.nextElementSibling;
           if (!detail || !detail.classList.contains("row-detail")) return;
-          headerRow.setAttribute("aria-expanded", "false");
+          var btn = getToggleButton(headerRow);
+          if (btn) btn.setAttribute("aria-expanded", "false");
           detail.setAttribute("aria-hidden", "true");
           detail.classList.remove("open");
         }
 
         function toggleRow(headerRow) {
-          var expanded = headerRow.getAttribute("aria-expanded") === "true";
+          var btn = getToggleButton(headerRow);
+          var expanded = btn && btn.getAttribute("aria-expanded") === "true";
           if (expanded) {
             collapseRow(headerRow);
           } else {
@@ -630,9 +658,10 @@
         function syncStorage() {
           var keys = [];
           document
-            .querySelectorAll('.accordion-header[aria-expanded="true"]')
-            .forEach(function (row) {
-              var key = row.getAttribute("data-expand-key");
+            .querySelectorAll('.accordion-toggle[aria-expanded="true"]')
+            .forEach(function (btn) {
+              var row = btn.closest(".accordion-header");
+              var key = row && row.getAttribute("data-expand-key");
               if (key) keys.push(key);
             });
           saveExpanded(keys);
@@ -658,17 +687,13 @@
 
         document.addEventListener("click", function (e) {
           if (e.target.closest("a")) return;
+          var btn = e.target.closest(".accordion-toggle");
+          if (btn) {
+            toggleRow(btn.closest(".accordion-header"));
+            return;
+          }
           var header = e.target.closest(".accordion-header");
           if (header) toggleRow(header);
-        });
-
-        document.addEventListener("keydown", function (e) {
-          if (e.key !== "Enter" && e.key !== " ") return;
-          var el = document.activeElement;
-          if (el && el.classList.contains("accordion-header")) {
-            e.preventDefault();
-            toggleRow(el);
-          }
         });
       })();
     </script>

--- a/internal/server/dashboard.html
+++ b/internal/server/dashboard.html
@@ -444,7 +444,6 @@
                     </div>
                     <div class="detail-item">
                       <dt>Tokens</dt>
-                      <!-- prettier-ignore -->
                       <dd>{{fmtInt $e.TotalTokens}}{{if $e.CacheReadTokens}} <small title="Prompt cache read tokens — served from cache, not reprocessed">({{fmtInt $e.CacheReadTokens}} cached)</small>{{end}}</dd>
                     </div>
                     <div class="detail-item">
@@ -603,11 +602,11 @@
       (function () {
         "use strict";
 
-        var STORAGE_KEY = "sortie-expanded";
+        const STORAGE_KEY = "sortie-expanded";
 
         function loadExpanded() {
           try {
-            var raw = sessionStorage.getItem(STORAGE_KEY);
+            const raw = sessionStorage.getItem(STORAGE_KEY);
             return raw ? JSON.parse(raw) : [];
           } catch (e) {
             return [];
@@ -627,26 +626,27 @@
         }
 
         function expandRow(headerRow) {
-          var detail = headerRow.nextElementSibling;
+          const detail = headerRow.nextElementSibling;
           if (!detail || !detail.classList.contains("row-detail")) return;
-          var btn = getToggleButton(headerRow);
+          const btn = getToggleButton(headerRow);
           if (btn) btn.setAttribute("aria-expanded", "true");
           detail.setAttribute("aria-hidden", "false");
           detail.classList.add("open");
         }
 
         function collapseRow(headerRow) {
-          var detail = headerRow.nextElementSibling;
+          const detail = headerRow.nextElementSibling;
           if (!detail || !detail.classList.contains("row-detail")) return;
-          var btn = getToggleButton(headerRow);
+          const btn = getToggleButton(headerRow);
           if (btn) btn.setAttribute("aria-expanded", "false");
           detail.setAttribute("aria-hidden", "true");
           detail.classList.remove("open");
         }
 
         function toggleRow(headerRow) {
-          var btn = getToggleButton(headerRow);
-          var expanded = btn && btn.getAttribute("aria-expanded") === "true";
+          const btn = getToggleButton(headerRow);
+          const expanded =
+            btn && btn.getAttribute("aria-expanded") === "true";
           if (expanded) {
             collapseRow(headerRow);
           } else {
@@ -656,21 +656,21 @@
         }
 
         function syncStorage() {
-          var keys = [];
+          const keys = [];
           document
             .querySelectorAll('.accordion-toggle[aria-expanded="true"]')
             .forEach(function (btn) {
-              var row = btn.closest(".accordion-header");
-              var key = row && row.getAttribute("data-expand-key");
+              const row = btn.closest(".accordion-header");
+              const key = row && row.getAttribute("data-expand-key");
               if (key) keys.push(key);
             });
           saveExpanded(keys);
         }
 
         // Restore expanded state from sessionStorage on page load.
-        var saved = loadExpanded();
+        const saved = loadExpanded();
         if (saved.length > 0) {
-          var savedSet = {};
+          const savedSet = {};
           saved.forEach(function (k) {
             savedSet[k] = true;
           });
@@ -687,12 +687,12 @@
 
         document.addEventListener("click", function (e) {
           if (e.target.closest("a")) return;
-          var btn = e.target.closest(".accordion-toggle");
+          const btn = e.target.closest(".accordion-toggle");
           if (btn) {
             toggleRow(btn.closest(".accordion-header"));
             return;
           }
-          var header = e.target.closest(".accordion-header");
+          const header = e.target.closest(".accordion-header");
           if (header) toggleRow(header);
         });
       })();

--- a/internal/server/dashboard.html
+++ b/internal/server/dashboard.html
@@ -400,10 +400,11 @@
                   class="accordion-toggle"
                   aria-expanded="false"
                   aria-controls="detail-running-{{$i}}"
+                  aria-label="Toggle details for {{$e.Identifier}}"
                 >
                   <span class="expand-indicator">&#9654;</span>
-                </button
-                ><a href="{{$e.DetailURL}}">{{$e.Identifier}}</a>
+                </button>
+                <a href="{{$e.DetailURL}}">{{$e.Identifier}}</a>
               </td>
               <td>{{$e.State}}</td>
               <td class="text-right">{{$e.TurnCount}}</td>

--- a/internal/server/dashboard.html
+++ b/internal/server/dashboard.html
@@ -401,9 +401,9 @@
                   aria-expanded="false"
                   aria-controls="detail-running-{{$i}}"
                 >
-                  <span class="expand-indicator">&#9654;</span
-                  ><a href="{{$e.DetailURL}}">{{$e.Identifier}}</a>
-                </button>
+                  <span class="expand-indicator">&#9654;</span>
+                </button
+                ><a href="{{$e.DetailURL}}">{{$e.Identifier}}</a>
               </td>
               <td>{{$e.State}}</td>
               <td class="text-right">{{$e.TurnCount}}</td>

--- a/internal/server/dashboard_test.go
+++ b/internal/server/dashboard_test.go
@@ -1471,27 +1471,29 @@ func TestHandleDashboard_AccordionToggleRefactor(t *testing.T) {
 
 	t.Run("accordion-toggle button present in every accordion-header row", func(t *testing.T) {
 		t.Parallel()
-		if !strings.Contains(body, `<button type="button" class="accordion-toggle"`) {
-			t.Error(`body missing <button type="button" class="accordion-toggle">`)
+		if !strings.Contains(body, `class="accordion-toggle"`) {
+			t.Error(`body missing class="accordion-toggle"`)
 		}
 		// 2 running + 1 retrying + 1 history = 4 accordion-toggle buttons.
 		const wantCount = 4
-		if got := strings.Count(body, `<button type="button" class="accordion-toggle"`); got != wantCount {
-			t.Errorf("accordion-toggle button count = %d, want %d", got, wantCount)
+		if got := strings.Count(body, `class="accordion-toggle"`); got != wantCount {
+			t.Errorf("accordion-toggle class count = %d, want %d", got, wantCount)
 		}
 	})
 
 	t.Run("aria-expanded=false is on button not on tr", func(t *testing.T) {
 		t.Parallel()
-		// Positive: aria-expanded must appear as a button attribute.
-		if !strings.Contains(body, `class="accordion-toggle" aria-expanded="false"`) {
-			t.Error(`body missing aria-expanded="false" on accordion-toggle button`)
+		// Positive: aria-expanded must appear somewhere in the body.
+		if !strings.Contains(body, `aria-expanded="false"`) {
+			t.Error(`body missing aria-expanded="false"`)
 		}
-		// Negative: <tr elements must not carry aria-expanded.
-		// The old pattern placed aria-expanded directly on the <tr> alongside
-		// role="button"; its absence confirms the refactor is complete.
-		if strings.Contains(body, `tabindex="0"`) {
-			t.Error(`body contains tabindex="0" — must not appear after accordion toggle refactor`)
+		// Negative: accordion header <tr> elements must not carry aria-expanded.
+		// The refactor moved that state onto the nested button, so any
+		// accordion-header row containing aria-expanded indicates a regression.
+		if strings.Contains(body, `class="accordion-header" aria-expanded="`) ||
+			strings.Contains(body, `aria-expanded="false" class="accordion-header"`) ||
+			strings.Contains(body, `aria-expanded="true" class="accordion-header"`) {
+			t.Error(`body contains aria-expanded on accordion-header tr — it must only appear on accordion-toggle button`)
 		}
 	})
 

--- a/internal/server/dashboard_test.go
+++ b/internal/server/dashboard_test.go
@@ -1422,3 +1422,104 @@ func TestDashboard_DetailRowColspan(t *testing.T) {
 		}
 	}
 }
+
+// TestHandleDashboard_AccordionToggleRefactor verifies that accordion rows use
+// a <button> in the first cell rather than role="button" on the <tr>. It covers
+// all three table sections (running, retrying, run history).
+func TestHandleDashboard_AccordionToggleRefactor(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 3, 24, 12, 0, 0, 0, time.UTC)
+	snap := orchestrator.RuntimeSnapshotResult{
+		GeneratedAt: now,
+		Running: []orchestrator.SnapshotRunningEntry{
+			// StartedAt ascending → R0 is index 0, R1 is index 1 after sort.
+			{IssueID: "id-r0", Identifier: "MT-R0", State: "In Progress", StartedAt: now.Add(-5 * time.Minute)},
+			{IssueID: "id-r1", Identifier: "MT-R1", State: "In Progress", StartedAt: now.Add(-3 * time.Minute)},
+		},
+		Retrying: []orchestrator.SnapshotRetryEntry{
+			{IssueID: "id-q0", Identifier: "MT-Q0", Attempt: 1, DueAtMS: now.Add(30 * time.Second).UnixMilli(), Error: "no slots"},
+		},
+	}
+
+	srv := New(Params{
+		SnapshotFn: fixedSnapshot(snap),
+		RefreshFn:  acceptingRefresh(),
+		Logger:     slog.New(slog.DiscardHandler),
+		StartedAt:  now.Add(-1 * time.Hour),
+		RunHistoryFn: func(_ context.Context, _ int) ([]RunHistoryEntry, error) {
+			return []RunHistoryEntry{
+				{Identifier: "MT-H0", Attempt: 1, Status: "succeeded", StartedAt: "2026-03-24T08:00:00Z", CompletedAt: "2026-03-24T08:01:00Z"},
+			}, nil
+		},
+	})
+	ts := httptest.NewServer(srv.Mux())
+	t.Cleanup(ts.Close)
+
+	dr := getDashboard(t, ts, "/")
+	if dr.StatusCode != http.StatusOK {
+		t.Fatalf("GET / status = %d, want %d", dr.StatusCode, http.StatusOK)
+	}
+	body := dr.Body
+
+	t.Run("no role=button on tr", func(t *testing.T) {
+		t.Parallel()
+		if strings.Contains(body, `role="button"`) {
+			t.Error(`body contains role="button" — must not appear after accordion toggle refactor`)
+		}
+	})
+
+	t.Run("accordion-toggle button present in every accordion-header row", func(t *testing.T) {
+		t.Parallel()
+		if !strings.Contains(body, `<button type="button" class="accordion-toggle"`) {
+			t.Error(`body missing <button type="button" class="accordion-toggle">`)
+		}
+		// 2 running + 1 retrying + 1 history = 4 accordion-toggle buttons.
+		const wantCount = 4
+		if got := strings.Count(body, `<button type="button" class="accordion-toggle"`); got != wantCount {
+			t.Errorf("accordion-toggle button count = %d, want %d", got, wantCount)
+		}
+	})
+
+	t.Run("aria-expanded=false is on button not on tr", func(t *testing.T) {
+		t.Parallel()
+		// Positive: aria-expanded must appear as a button attribute.
+		if !strings.Contains(body, `class="accordion-toggle" aria-expanded="false"`) {
+			t.Error(`body missing aria-expanded="false" on accordion-toggle button`)
+		}
+		// Negative: <tr elements must not carry aria-expanded.
+		// The old pattern placed aria-expanded directly on the <tr> alongside
+		// role="button"; its absence confirms the refactor is complete.
+		if strings.Contains(body, `tabindex="0"`) {
+			t.Error(`body contains tabindex="0" — must not appear after accordion toggle refactor`)
+		}
+	})
+
+	t.Run("aria-controls on button matches id of detail row", func(t *testing.T) {
+		t.Parallel()
+		// Each table section uses its own ID prefix with 0-based row counter.
+		pairs := [][2]string{
+			{`aria-controls="detail-running-0"`, `id="detail-running-0"`},
+			{`aria-controls="detail-running-1"`, `id="detail-running-1"`},
+			{`aria-controls="detail-retry-0"`, `id="detail-retry-0"`},
+			{`aria-controls="detail-history-0"`, `id="detail-history-0"`},
+		}
+		for _, pair := range pairs {
+			if !strings.Contains(body, pair[0]) {
+				t.Errorf("body missing button attribute %q", pair[0])
+			}
+			if !strings.Contains(body, pair[1]) {
+				t.Errorf("body missing detail row attribute %q", pair[1])
+			}
+		}
+	})
+
+	t.Run("no tabindex=0 on tr", func(t *testing.T) {
+		t.Parallel()
+		// tabindex="0" was only ever used on accordion <tr> rows; its absence
+		// confirms the attribute was removed from table rows.
+		if strings.Contains(body, `tabindex="0"`) {
+			t.Error(`body contains tabindex="0" — must not appear after accordion toggle refactor`)
+		}
+	})
+}


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Refactor

**Intent:** Replace invalid `role="button"` ARIA attribute on `<tr>` elements with a native `<button>` inside the first `<td>`. The ARIA-in-HTML spec restricts `<tr>` to the `row`/`rowheader` roles, so the previous pattern was technically invalid and could be misannounced by screen readers.

**Related Issues:** #444

### 🧭 Reviewer Guide

**Complexity:** Low

#### Entry Point

`internal/server/dashboard.html` - contains all three changes in one file: the HTML markup refactor (button inside first `<td>`, `aria-expanded`/`aria-controls` moved to button), CSS additions (`.accordion-toggle` invisible button chrome, focus-visible ring, updated expand-indicator rotation selector), and JS update (toggleRow reads/writes `aria-expanded` on the button; custom keydown handler removed since native `<button>` handles Enter/Space).

#### Sensitive Areas

- `internal/server/dashboard.html`: Keyboard and click event delegation changed — the row click still toggles via the button for convenience, but the canonical control is now the `<button>`. Worth verifying the link-passthrough guard still works correctly.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes
- **Migrations/State:** No migrations or state changes