### PR TITLE
feat(server): add token usage cost estimation to dashboard

### DIFF
--- a/cmd/sortie/main.go
+++ b/cmd/sortie/main.go
@@ -334,6 +334,11 @@ func run(ctx context.Context, args []string, stdout io.Writer, stderr io.Writer)
 
 	var srv *server.Server
 	if serverEnabled {
+		tokenRates, trWarnings := server.ParseTokenRates(br.cfg.Extensions)
+		for _, w := range trWarnings {
+			br.logger.Warn("token rate config warning", slog.String("detail", w))
+		}
+
 		addr := net.JoinHostPort(br.serverHost, strconv.Itoa(br.serverPort))
 		srv = server.New(server.Params{
 			SnapshotFn:       o.SnapshotFunc(),
@@ -347,6 +352,7 @@ func run(ctx context.Context, args []string, stdout io.Writer, stderr io.Writer)
 			DBPingFn:         func(ctx context.Context) error { return store.Ping(ctx) },
 			PreflightFn:      o.PreflightOK,
 			WorkflowLoadedFn: func() bool { return br.mgr.Config().Tracker.Kind != "" },
+			TokenRates:       tokenRates,
 			RunHistoryFn: func(ctx context.Context, limit int) ([]server.RunHistoryEntry, error) {
 				runs, err := store.QueryRecentRunHistory(ctx, limit, 0)
 				if err != nil {

--- a/cmd/sortie/main.go
+++ b/cmd/sortie/main.go
@@ -336,7 +336,7 @@ func run(ctx context.Context, args []string, stdout io.Writer, stderr io.Writer)
 	if serverEnabled {
 		tokenRates, trWarnings := server.ParseTokenRates(br.cfg.Extensions)
 		for _, w := range trWarnings {
-			br.logger.Warn("token rate config warning", slog.String("detail", w))
+			br.logger.Warn("skipped invalid token rate entry", slog.String("detail", w))
 		}
 
 		addr := net.JoinHostPort(br.serverHost, strconv.Itoa(br.serverPort))

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -120,9 +120,10 @@ var knownFieldsRegistry = map[string]SectionSchema{
 // the architecture spec. These are not core schema keys but are
 // recognized by Sortie's optional modules.
 var staticKnownExtensionKeys = map[string]bool{
-	"server":  true,
-	"logging": true,
-	"worker":  true,
+	"server":      true,
+	"logging":     true,
+	"worker":      true,
+	"token_rates": true,
 }
 
 // FrontMatterWarning represents a single advisory diagnostic from

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -287,6 +287,7 @@ func (o *Orchestrator) Run(ctx context.Context) {
 				Metrics:           o.metrics,
 				HostPool:          o.hostPool,
 				WorkflowFile:      o.workflowFile(),
+				AgentKind:         cfg.Agent.Kind,
 			})
 			o.updateGauges(time.Now())
 			o.notifyObservers()
@@ -491,6 +492,7 @@ func (o *Orchestrator) handleTick(ctx context.Context) {
 		DispatchIssue(ctx, o.state, issue, nil, host, o.makeWorkerFn("", host))
 		if entry := o.state.Running[issue.ID]; entry != nil {
 			entry.WorkflowFile = o.workflowFile()
+			entry.AgentKind = cfg.Agent.Kind
 		}
 		o.metrics.IncDispatches(outcomeSuccess)
 		dispatched++

--- a/internal/orchestrator/retry.go
+++ b/internal/orchestrator/retry.go
@@ -83,6 +83,10 @@ type HandleRetryTimerParams struct {
 	// WorkflowFile is the base filename of the active WORKFLOW.md file.
 	// Recorded on the RunningEntry for observability.
 	WorkflowFile string
+
+	// AgentKind is the adapter kind string from the active workflow
+	// config. Recorded on the RunningEntry for cost estimation.
+	AgentKind string
 }
 
 // HandleRetryTimer processes a retry timer event for the given issue.
@@ -337,6 +341,7 @@ func HandleRetryTimer(state *State, issueID string, params HandleRetryTimerParam
 	DispatchIssue(dispatchCtx, state, issue, &attempt, host, params.MakeWorkerFn(popped.SessionID, host))
 	if entry := state.Running[issue.ID]; entry != nil {
 		entry.WorkflowFile = params.WorkflowFile
+		entry.AgentKind = params.AgentKind
 		entry.ContinuationContext = popped.ContinuationContext
 	}
 	metrics.IncDispatches(outcomeSuccess)

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -212,6 +212,11 @@ type RunningEntry struct {
 	// SelfReviewIteration is the current review iteration (0 when not in review).
 	// Mutated only by the event loop via selfReviewCh.
 	SelfReviewIteration int
+
+	// AgentKind is the adapter kind string (e.g. "claude-code") from the
+	// workflow config active at dispatch time. Used for token cost
+	// estimation on the dashboard.
+	AgentKind string
 }
 
 // RetryEntry holds the runtime state for a pending retry. The persisted
@@ -566,6 +571,7 @@ type SnapshotRunningEntry struct {
 	WorkflowFile        string                `json:"workflow_file,omitempty"`
 	SelfReviewActive    bool                  `json:"self_review_active,omitempty"`
 	SelfReviewIteration int                   `json:"self_review_iteration,omitempty"`
+	AgentKind           string                `json:"agent_kind,omitempty"`
 }
 
 // SnapshotRetryEntry is a read-only view of a pending retry for
@@ -679,6 +685,7 @@ func RuntimeSnapshot(state *State, now time.Time) RuntimeSnapshotResult {
 			WorkflowFile:        entry.WorkflowFile,
 			SelfReviewActive:    entry.SelfReviewActive,
 			SelfReviewIteration: entry.SelfReviewIteration,
+			AgentKind:           entry.AgentKind,
 		})
 
 		if !entry.StartedAt.IsZero() {

--- a/internal/server/dashboard.go
+++ b/internal/server/dashboard.go
@@ -47,23 +47,29 @@ type dashboardData struct {
 	InputTokens     int64
 	OutputTokens    int64
 	CacheReadTokens int64
+
+	// Cost estimation (conditional on configured token rates).
+	HasTokenRates      bool
+	EstimatedCostUSD   *string
+	EstimatedCostLabel string
 }
 
 type dashboardRunningEntry struct {
-	Identifier      string
-	State           string
-	TurnCount       int
-	Duration        string
-	LastEvent       string
-	TotalTokens     int64
-	CacheReadTokens int64
-	ModelName       string
-	APIRequestCount int
-	DetailURL       string
-	Host            string
-	ToolTimePct     string
-	APITimePct      string
-	WorkflowFile    string
+	Identifier       string
+	State            string
+	TurnCount        int
+	Duration         string
+	LastEvent        string
+	TotalTokens      int64
+	CacheReadTokens  int64
+	ModelName        string
+	APIRequestCount  int
+	DetailURL        string
+	Host             string
+	ToolTimePct      string
+	APITimePct       string
+	WorkflowFile     string
+	EstimatedCostUSD string
 }
 
 type dashboardRetryEntry struct {
@@ -171,6 +177,7 @@ func buildDashboardData(
 	startedAt time.Time,
 	slotFunc func() int,
 	now time.Time,
+	tokenRates TokenRates,
 ) dashboardData {
 	if version == "" {
 		version = "dev"
@@ -216,6 +223,9 @@ func buildDashboardData(
 	})
 	running := make([]dashboardRunningEntry, len(sortedRunning))
 	hasSSH := false
+	hasRates := len(tokenRates) > 0
+	var aggregateCost float64
+	aggregateCostSet := false
 	for i, e := range sortedRunning {
 		dur := snap.GeneratedAt.Sub(e.StartedAt)
 		if dur < 0 {
@@ -242,25 +252,45 @@ func buildDashboardData(
 			displayID = e.DisplayID
 		}
 
+		var entryCostStr string
+		if hasRates && e.AgentKind != "" {
+			if rc, ok := tokenRates[e.AgentKind]; ok {
+				if c := estimateCost(e.AgentInputTokens, e.AgentOutputTokens, e.CacheReadTokens, &rc); c != nil {
+					entryCostStr = fmtCost(*c)
+					aggregateCost += *c
+					aggregateCostSet = true
+				}
+			}
+		}
+
 		running[i] = dashboardRunningEntry{
-			Identifier:      displayID,
-			State:           e.State,
-			TurnCount:       e.TurnCount,
-			Duration:        formatDuration(dur),
-			LastEvent:       string(e.LastAgentEvent),
-			TotalTokens:     e.AgentTotalTokens,
-			CacheReadTokens: e.CacheReadTokens,
-			ModelName:       e.ModelName,
-			APIRequestCount: e.APIRequestCount,
-			DetailURL:       "/api/v1/" + url.PathEscape(e.Identifier),
-			Host:            e.SSHHost,
-			ToolTimePct:     toolPct,
-			APITimePct:      apiPct,
-			WorkflowFile:    e.WorkflowFile,
+			Identifier:       displayID,
+			State:            e.State,
+			TurnCount:        e.TurnCount,
+			Duration:         formatDuration(dur),
+			LastEvent:        string(e.LastAgentEvent),
+			TotalTokens:      e.AgentTotalTokens,
+			CacheReadTokens:  e.CacheReadTokens,
+			ModelName:        e.ModelName,
+			APIRequestCount:  e.APIRequestCount,
+			DetailURL:        "/api/v1/" + url.PathEscape(e.Identifier),
+			Host:             e.SSHHost,
+			ToolTimePct:      toolPct,
+			APITimePct:       apiPct,
+			WorkflowFile:     e.WorkflowFile,
+			EstimatedCostUSD: entryCostStr,
 		}
 	}
 	data.Running = running
 	data.HasSSH = hasSSH
+	data.HasTokenRates = hasRates
+	if hasRates {
+		data.EstimatedCostLabel = "Active Est. Cost (USD)"
+	}
+	if aggregateCostSet {
+		s := fmtCost(aggregateCost)
+		data.EstimatedCostUSD = &s
+	}
 
 	// Copy and sort retry entries by DueAtMS ascending before mapping.
 	sortedRetrying := make([]orchestrator.SnapshotRetryEntry, len(snap.Retrying))
@@ -352,7 +382,7 @@ func (s *Server) handleDashboard(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	data := buildDashboardData(snap, s.version, s.startedAt, s.slotFunc, time.Now())
+	data := buildDashboardData(snap, s.version, s.startedAt, s.slotFunc, time.Now(), s.tokenRates)
 
 	if s.runHistoryFn != nil {
 		runs, err := s.runHistoryFn(r.Context(), 25)

--- a/internal/server/dashboard.html
+++ b/internal/server/dashboard.html
@@ -375,7 +375,7 @@
         </div>
         {{if .HasTokenRates}}
         <div class="card card-neutral">
-          <div class="card-number">{{if .EstimatedCostUSD}}{{.EstimatedCostUSD}}{{else}}$0.00{{end}}</div>
+          <div class="card-number">{{if .EstimatedCostUSD}}{{.EstimatedCostUSD}}{{else}}&mdash;{{end}}</div>
           <div class="card-label">{{.EstimatedCostLabel}}</div>
         </div>
         {{end}}
@@ -608,7 +608,7 @@
           >Cache Read: {{fmtInt .CacheReadTokens}}</span
         >
         &middot; Output: {{fmtInt .OutputTokens}}{{if .HasTokenRates}}
-        &middot; Est. Cost: {{if .EstimatedCostUSD}}{{.EstimatedCostUSD}}{{else}}$0.00{{end}}{{end}}
+        &middot; Est. Cost: {{if .EstimatedCostUSD}}{{.EstimatedCostUSD}}{{else}}&mdash;{{end}}{{end}}
       </div>
       {{if .HasTokenRates}}<div>Cost estimates are based on configured token rates and may differ from actual provider billing.</div>{{end}}
       <div>Auto-refresh every 5s</div>

--- a/internal/server/dashboard.html
+++ b/internal/server/dashboard.html
@@ -373,6 +373,12 @@
           <div class="card-number">{{fmtInt .TotalTokens}}</div>
           <div class="card-label">Total Tokens</div>
         </div>
+        {{if .HasTokenRates}}
+        <div class="card card-neutral">
+          <div class="card-number">{{if .EstimatedCostUSD}}{{.EstimatedCostUSD}}{{else}}$0.00{{end}}</div>
+          <div class="card-label">{{.EstimatedCostLabel}}</div>
+        </div>
+        {{end}}
       </section>
 
       <section>
@@ -455,6 +461,12 @@
                       <dt>API Time</dt>
                       <dd>{{$e.APITimePct}}</dd>
                     </div>
+                    {{if $.HasTokenRates}}
+                    <div class="detail-item">
+                      <dt>Est. Cost</dt>
+                      <dd>{{if $e.EstimatedCostUSD}}{{$e.EstimatedCostUSD}}{{else}}&mdash;{{end}}</dd>
+                    </div>
+                    {{end}}
                   </dl>
                 </div>
               </td>
@@ -595,8 +607,10 @@
           title="Prompt cache read tokens — served from cache, not reprocessed"
           >Cache Read: {{fmtInt .CacheReadTokens}}</span
         >
-        &middot; Output: {{fmtInt .OutputTokens}}
+        &middot; Output: {{fmtInt .OutputTokens}}{{if .HasTokenRates}}
+        &middot; Est. Cost: {{if .EstimatedCostUSD}}{{.EstimatedCostUSD}}{{else}}$0.00{{end}}{{end}}
       </div>
+      {{if .HasTokenRates}}<div>Cost estimates are based on configured token rates and may differ from actual provider billing.</div>{{end}}
       <div>Auto-refresh every 5s</div>
     </footer>
     <script>

--- a/internal/server/dashboard_test.go
+++ b/internal/server/dashboard_test.go
@@ -271,7 +271,7 @@ func TestBuildDashboardData(t *testing.T) {
 	t.Run("full snapshot", func(t *testing.T) {
 		t.Parallel()
 
-		data := buildDashboardData(snap, "0.2.0", startedAt, func() int { return 5 }, now)
+		data := buildDashboardData(snap, "0.2.0", startedAt, func() int { return 5 }, now, nil)
 
 		if data.Version != "0.2.0" {
 			t.Errorf("Version = %q, want %q", data.Version, "0.2.0")
@@ -333,7 +333,7 @@ func TestBuildDashboardData(t *testing.T) {
 	t.Run("empty version defaults to dev", func(t *testing.T) {
 		t.Parallel()
 
-		data := buildDashboardData(snap, "", startedAt, nil, now)
+		data := buildDashboardData(snap, "", startedAt, nil, now, nil)
 		if data.Version != "dev" {
 			t.Errorf("Version = %q, want %q", data.Version, "dev")
 		}
@@ -342,7 +342,7 @@ func TestBuildDashboardData(t *testing.T) {
 	t.Run("nil slotFunc yields zero available", func(t *testing.T) {
 		t.Parallel()
 
-		data := buildDashboardData(snap, "v1", startedAt, nil, now)
+		data := buildDashboardData(snap, "v1", startedAt, nil, now, nil)
 		if data.AvailableSlots != 0 {
 			t.Errorf("AvailableSlots = %d, want 0", data.AvailableSlots)
 		}
@@ -352,7 +352,7 @@ func TestBuildDashboardData(t *testing.T) {
 		t.Parallel()
 
 		// slotFunc returns 1 but 2 running → clamped to 0.
-		data := buildDashboardData(snap, "v1", startedAt, func() int { return 1 }, now)
+		data := buildDashboardData(snap, "v1", startedAt, func() int { return 1 }, now, nil)
 		if data.AvailableSlots != 0 {
 			t.Errorf("AvailableSlots = %d, want 0", data.AvailableSlots)
 		}
@@ -376,7 +376,7 @@ func TestBuildDashboardData(t *testing.T) {
 			},
 		}
 
-		data := buildDashboardData(timingSnap, "v1", startedAt, nil, now)
+		data := buildDashboardData(timingSnap, "v1", startedAt, nil, now, nil)
 
 		if len(data.Running) != 1 {
 			t.Fatalf("len(Running) = %d, want 1", len(data.Running))
@@ -405,7 +405,7 @@ func TestBuildDashboardData(t *testing.T) {
 			},
 		}
 
-		data := buildDashboardData(timingSnap, "v1", startedAt, nil, now)
+		data := buildDashboardData(timingSnap, "v1", startedAt, nil, now, nil)
 
 		if data.Running[0].ToolTimePct != "N/A" {
 			t.Errorf("ToolTimePct = %q, want %q", data.Running[0].ToolTimePct, "N/A")
@@ -431,7 +431,7 @@ func TestBuildDashboardData(t *testing.T) {
 			},
 		}
 
-		data := buildDashboardData(timingSnap, "v1", startedAt, nil, now)
+		data := buildDashboardData(timingSnap, "v1", startedAt, nil, now, nil)
 
 		if data.Running[0].ToolTimePct != "N/A" {
 			t.Errorf("ToolTimePct = %q, want %q (zero elapsed)", data.Running[0].ToolTimePct, "N/A")
@@ -457,7 +457,7 @@ func TestBuildDashboardData(t *testing.T) {
 			},
 		}
 
-		data := buildDashboardData(timingSnap, "v1", startedAt, nil, now)
+		data := buildDashboardData(timingSnap, "v1", startedAt, nil, now, nil)
 
 		if data.Running[0].ToolTimePct != "N/A" {
 			t.Errorf("ToolTimePct = %q, want %q (zero StartedAt)", data.Running[0].ToolTimePct, "N/A")
@@ -483,7 +483,7 @@ func TestBuildDashboardData(t *testing.T) {
 			},
 		}
 
-		data := buildDashboardData(midTurnSnap, "v1", startedAt, nil, now)
+		data := buildDashboardData(midTurnSnap, "v1", startedAt, nil, now, nil)
 
 		if len(data.Running) != 1 {
 			t.Fatalf("len(Running) = %d, want 1", len(data.Running))
@@ -737,7 +737,7 @@ func TestBuildDashboardData_ExtendedFields(t *testing.T) {
 		},
 	}
 
-	data := buildDashboardData(snap, "1.0.0", now.Add(-1*time.Hour), func() int { return 5 }, now)
+	data := buildDashboardData(snap, "1.0.0", now.Add(-1*time.Hour), func() int { return 5 }, now, nil)
 
 	if len(data.Running) != 1 {
 		t.Fatalf("len(Running) = %d, want 1", len(data.Running))
@@ -999,7 +999,7 @@ func TestBuildDashboardData_DisplayID(t *testing.T) {
 		},
 	}
 
-	data := buildDashboardData(snap, "1.0.0", now.Add(-1*time.Hour), nil, now)
+	data := buildDashboardData(snap, "1.0.0", now.Add(-1*time.Hour), nil, now, nil)
 
 	if len(data.Running) != 1 {
 		t.Fatalf("len(Running) = %d, want 1", len(data.Running))
@@ -1042,7 +1042,7 @@ func TestBuildDashboardData_FallsBackToIdentifier(t *testing.T) {
 		},
 	}
 
-	data := buildDashboardData(snap, "1.0.0", now.Add(-1*time.Hour), nil, now)
+	data := buildDashboardData(snap, "1.0.0", now.Add(-1*time.Hour), nil, now, nil)
 
 	if len(data.Running) != 1 {
 		t.Fatalf("len(Running) = %d, want 1", len(data.Running))
@@ -1524,4 +1524,237 @@ func TestHandleDashboard_AccordionToggleRefactor(t *testing.T) {
 			t.Error(`body contains tabindex="0" — must not appear after accordion toggle refactor`)
 		}
 	})
+}
+
+// --- Token-rate cost rendering ---
+
+func TestBuildDashboardData_TokenRates(t *testing.T) {
+	t.Parallel()
+
+	fptr := func(v float64) *float64 { return &v }
+	now := time.Date(2026, 3, 24, 12, 0, 0, 0, time.UTC)
+
+	rates := TokenRates{
+		"claude": TokenRateConfig{
+			InputPerMtok:  fptr(3.0),
+			OutputPerMtok: fptr(15.0),
+		},
+	}
+
+	t.Run("with rates and matching AgentKind computes aggregate cost", func(t *testing.T) {
+		t.Parallel()
+
+		// 2M input @ $3/Mtok = $6, 1M output @ $15/Mtok = $15 → $21
+		snap := orchestrator.RuntimeSnapshotResult{
+			GeneratedAt: now,
+			Running: []orchestrator.SnapshotRunningEntry{
+				{
+					Identifier:        "MT-1",
+					State:             "In Progress",
+					StartedAt:         now.Add(-5 * time.Minute),
+					AgentKind:         "claude",
+					AgentInputTokens:  2_000_000,
+					AgentOutputTokens: 1_000_000,
+				},
+			},
+		}
+
+		data := buildDashboardData(snap, "v1", now.Add(-1*time.Hour), nil, now, rates)
+
+		if !data.HasTokenRates {
+			t.Error("HasTokenRates = false, want true")
+		}
+		if data.EstimatedCostUSD == nil {
+			t.Fatal("EstimatedCostUSD = nil, want non-nil")
+		}
+		if *data.EstimatedCostUSD != "$21.00" {
+			t.Errorf("EstimatedCostUSD = %q, want %q", *data.EstimatedCostUSD, "$21.00")
+		}
+		if data.Running[0].EstimatedCostUSD != "$21.00" {
+			t.Errorf("Running[0].EstimatedCostUSD = %q, want %q", data.Running[0].EstimatedCostUSD, "$21.00")
+		}
+		if data.EstimatedCostLabel == "" {
+			t.Error("EstimatedCostLabel is empty, want non-empty")
+		}
+	})
+
+	t.Run("without token rates HasTokenRates is false", func(t *testing.T) {
+		t.Parallel()
+
+		snap := orchestrator.RuntimeSnapshotResult{
+			GeneratedAt: now,
+			Running: []orchestrator.SnapshotRunningEntry{
+				{
+					Identifier:        "MT-2",
+					State:             "In Progress",
+					StartedAt:         now.Add(-3 * time.Minute),
+					AgentKind:         "claude",
+					AgentInputTokens:  1_000_000,
+					AgentOutputTokens: 500_000,
+				},
+			},
+		}
+
+		data := buildDashboardData(snap, "v1", now.Add(-1*time.Hour), nil, now, nil)
+
+		if data.HasTokenRates {
+			t.Error("HasTokenRates = true, want false (nil rates)")
+		}
+		if data.EstimatedCostUSD != nil {
+			t.Errorf("EstimatedCostUSD = %q, want nil", *data.EstimatedCostUSD)
+		}
+	})
+
+	t.Run("rates configured but no matching AgentKind — cost nil", func(t *testing.T) {
+		t.Parallel()
+
+		snap := orchestrator.RuntimeSnapshotResult{
+			GeneratedAt: now,
+			Running: []orchestrator.SnapshotRunningEntry{
+				{
+					Identifier:        "MT-3",
+					State:             "In Progress",
+					StartedAt:         now.Add(-3 * time.Minute),
+					AgentKind:         "unknown-adapter",
+					AgentInputTokens:  1_000_000,
+					AgentOutputTokens: 500_000,
+				},
+			},
+		}
+
+		data := buildDashboardData(snap, "v1", now.Add(-1*time.Hour), nil, now, rates)
+
+		if !data.HasTokenRates {
+			t.Error("HasTokenRates = false, want true")
+		}
+		// No matching kind → no aggregate cost.
+		if data.EstimatedCostUSD != nil {
+			t.Errorf("EstimatedCostUSD = %q, want nil (no matching kind)", *data.EstimatedCostUSD)
+		}
+		// Per-entry cost string should be empty.
+		if data.Running[0].EstimatedCostUSD != "" {
+			t.Errorf("Running[0].EstimatedCostUSD = %q, want empty", data.Running[0].EstimatedCostUSD)
+		}
+	})
+
+	t.Run("zero tokens with rates shows $0.00", func(t *testing.T) {
+		t.Parallel()
+
+		snap := orchestrator.RuntimeSnapshotResult{
+			GeneratedAt: now,
+			Running: []orchestrator.SnapshotRunningEntry{
+				{
+					Identifier:        "MT-4",
+					State:             "In Progress",
+					StartedAt:         now.Add(-1 * time.Minute),
+					AgentKind:         "claude",
+					AgentInputTokens:  0,
+					AgentOutputTokens: 0,
+				},
+			},
+		}
+
+		data := buildDashboardData(snap, "v1", now.Add(-1*time.Hour), nil, now, rates)
+
+		if !data.HasTokenRates {
+			t.Error("HasTokenRates = false, want true")
+		}
+		if data.EstimatedCostUSD == nil {
+			t.Fatal("EstimatedCostUSD = nil, want \"$0.00\"")
+		}
+		if *data.EstimatedCostUSD != "$0.00" {
+			t.Errorf("EstimatedCostUSD = %q, want %q", *data.EstimatedCostUSD, "$0.00")
+		}
+	})
+}
+
+func TestHandleDashboard_WithTokenRates(t *testing.T) {
+	t.Parallel()
+
+	fptr := func(v float64) *float64 { return &v }
+	now := time.Date(2026, 3, 24, 12, 0, 0, 0, time.UTC)
+
+	snap := orchestrator.RuntimeSnapshotResult{
+		GeneratedAt: now,
+		Running: []orchestrator.SnapshotRunningEntry{
+			{
+				IssueID:           "id-cost-1",
+				Identifier:        "MT-COST",
+				State:             "In Progress",
+				StartedAt:         now.Add(-5 * time.Minute),
+				AgentKind:         "claude",
+				AgentInputTokens:  1_000_000,
+				AgentOutputTokens: 1_000_000,
+			},
+		},
+	}
+
+	srv := New(Params{
+		SnapshotFn: fixedSnapshot(snap),
+		RefreshFn:  acceptingRefresh(),
+		Logger:     slog.New(slog.DiscardHandler),
+		StartedAt:  now.Add(-1 * time.Hour),
+		TokenRates: TokenRates{
+			"claude": TokenRateConfig{
+				InputPerMtok:  fptr(3.0),
+				OutputPerMtok: fptr(15.0),
+			},
+		},
+	})
+	ts := httptest.NewServer(srv.Mux())
+	t.Cleanup(ts.Close)
+
+	dr := getDashboard(t, ts, "/")
+
+	if dr.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want %d", dr.StatusCode, http.StatusOK)
+	}
+
+	// Cost card, per-entry cost label, footer cost line, and disclaimer must all appear.
+	for _, want := range []string{
+		"Est. Cost",
+		"$",
+		"Cost estimates are based on configured token rates",
+	} {
+		if !strings.Contains(dr.Body, want) {
+			t.Errorf("body missing %q", want)
+		}
+	}
+}
+
+func TestHandleDashboard_WithoutTokenRates(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 3, 24, 12, 0, 0, 0, time.UTC)
+
+	snap := orchestrator.RuntimeSnapshotResult{
+		GeneratedAt: now,
+		Running: []orchestrator.SnapshotRunningEntry{
+			{
+				IssueID:           "id-nocost",
+				Identifier:        "MT-NOCOST",
+				State:             "In Progress",
+				StartedAt:         now.Add(-3 * time.Minute),
+				AgentKind:         "claude",
+				AgentInputTokens:  500_000,
+				AgentOutputTokens: 250_000,
+			},
+		},
+	}
+
+	// No TokenRates set → cost display suppressed.
+	ts := dashboardServer(t, fixedSnapshot(snap), "1.0.0", nil)
+
+	dr := getDashboard(t, ts, "/")
+
+	if dr.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want %d", dr.StatusCode, http.StatusOK)
+	}
+
+	if strings.Contains(dr.Body, "Est. Cost") {
+		t.Error("body contains 'Est. Cost' but no token rates configured")
+	}
+	if strings.Contains(dr.Body, "Cost estimates are based on configured token rates") {
+		t.Error("body contains cost disclaimer but no token rates configured")
+	}
 }

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -14,12 +14,13 @@ import (
 
 // stateResponse is the JSON wire format for GET /api/v1/state.
 type stateResponse struct {
-	GeneratedAt time.Time                        `json:"generated_at"`
-	Counts      stateCounts                      `json:"counts"`
-	Running     []runningEntryResponse           `json:"running"`
-	Retrying    []retryEntryResponse             `json:"retrying"`
-	AgentTotals orchestrator.SnapshotAgentTotals `json:"agent_totals"`
-	RateLimits  map[string]any                   `json:"rate_limits"`
+	GeneratedAt            time.Time                        `json:"generated_at"`
+	Counts                 stateCounts                      `json:"counts"`
+	Running                []runningEntryResponse           `json:"running"`
+	Retrying               []retryEntryResponse             `json:"retrying"`
+	AgentTotals            orchestrator.SnapshotAgentTotals `json:"agent_totals"`
+	RateLimits             map[string]any                   `json:"rate_limits"`
+	ActiveEstimatedCostUSD *float64                         `json:"active_estimated_cost_usd,omitempty"`
 }
 
 type stateCounts struct {
@@ -152,7 +153,7 @@ func toRetryEntryResponse(e orchestrator.SnapshotRetryEntry) retryEntryResponse 
 	}
 }
 
-func toStateResponse(snap orchestrator.RuntimeSnapshotResult) stateResponse {
+func toStateResponse(snap orchestrator.RuntimeSnapshotResult, tokenRates TokenRates) stateResponse {
 	running := make([]runningEntryResponse, 0, len(snap.Running))
 	for _, e := range snap.Running {
 		running = append(running, toRunningEntryResponse(e, snap.GeneratedAt))
@@ -168,7 +169,7 @@ func toStateResponse(snap orchestrator.RuntimeSnapshotResult) stateResponse {
 		rateLimits = map[string]any{}
 	}
 
-	return stateResponse{
+	resp := stateResponse{
 		GeneratedAt: snap.GeneratedAt.UTC(),
 		Counts: stateCounts{
 			Running:  len(running),
@@ -179,6 +180,27 @@ func toStateResponse(snap orchestrator.RuntimeSnapshotResult) stateResponse {
 		AgentTotals: snap.AgentTotals,
 		RateLimits:  rateLimits,
 	}
+
+	if len(tokenRates) > 0 {
+		var total float64
+		anySet := false
+		for _, e := range snap.Running {
+			if e.AgentKind == "" {
+				continue
+			}
+			if rc, ok := tokenRates[e.AgentKind]; ok {
+				if c := estimateCost(e.AgentInputTokens, e.AgentOutputTokens, e.CacheReadTokens, &rc); c != nil {
+					total += *c
+					anySet = true
+				}
+			}
+		}
+		if anySet {
+			resp.ActiveEstimatedCostUSD = &total
+		}
+	}
+
+	return resp
 }
 
 func writeJSON(w http.ResponseWriter, logger *slog.Logger, status int, v any) {
@@ -243,7 +265,7 @@ func (s *Server) handleState(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	resp := toStateResponse(snap)
+	resp := toStateResponse(snap, s.tokenRates)
 	writeJSON(w, s.logger, http.StatusOK, resp)
 
 	s.logger.Debug("request served",

--- a/internal/server/handler_test.go
+++ b/internal/server/handler_test.go
@@ -629,7 +629,7 @@ func TestToStateResponse(t *testing.T) {
 			AgentTotals: orchestrator.SnapshotAgentTotals{},
 		}
 
-		got := toStateResponse(snap)
+		got := toStateResponse(snap, nil)
 
 		if got.Running == nil {
 			t.Fatal("Running = nil, want non-nil empty slice")
@@ -664,7 +664,7 @@ func TestToStateResponse(t *testing.T) {
 			RateLimits:  nil,
 		}
 
-		got := toStateResponse(snap)
+		got := toStateResponse(snap, nil)
 
 		if got.RateLimits == nil {
 			t.Fatal("RateLimits = nil, want non-nil empty map")
@@ -688,13 +688,167 @@ func TestToStateResponse(t *testing.T) {
 			},
 		}
 
-		got := toStateResponse(snap)
+		got := toStateResponse(snap, nil)
 
 		if got.Counts.Running != 2 {
 			t.Errorf("Counts.Running = %d, want 2", got.Counts.Running)
 		}
 		if got.Counts.Retrying != 1 {
 			t.Errorf("Counts.Retrying = %d, want 1", got.Counts.Retrying)
+		}
+	})
+
+	t.Run("nil token rates — ActiveEstimatedCostUSD absent", func(t *testing.T) {
+		t.Parallel()
+
+		snap := orchestrator.RuntimeSnapshotResult{
+			GeneratedAt: time.Now().UTC(),
+			Running: []orchestrator.SnapshotRunningEntry{
+				{
+					IssueID:           "r",
+					Identifier:        "MT-R",
+					AgentKind:         "claude",
+					AgentInputTokens:  1_000_000,
+					AgentOutputTokens: 500_000,
+				},
+			},
+		}
+
+		got := toStateResponse(snap, nil)
+
+		if got.ActiveEstimatedCostUSD != nil {
+			t.Errorf("ActiveEstimatedCostUSD = %v, want nil", *got.ActiveEstimatedCostUSD)
+		}
+	})
+
+	t.Run("with token rates and matching AgentKind — cost computed", func(t *testing.T) {
+		t.Parallel()
+
+		fptr := func(v float64) *float64 { return &v }
+
+		// 2M input @ $3/Mtok = $6, 1M output @ $15/Mtok = $15 → $21
+		snap := orchestrator.RuntimeSnapshotResult{
+			GeneratedAt: time.Now().UTC(),
+			Running: []orchestrator.SnapshotRunningEntry{
+				{
+					IssueID:           "cost-1",
+					Identifier:        "MT-C1",
+					AgentKind:         "claude",
+					AgentInputTokens:  2_000_000,
+					AgentOutputTokens: 1_000_000,
+				},
+			},
+		}
+
+		rates := TokenRates{
+			"claude": TokenRateConfig{
+				InputPerMtok:  fptr(3.0),
+				OutputPerMtok: fptr(15.0),
+			},
+		}
+
+		got := toStateResponse(snap, rates)
+
+		if got.ActiveEstimatedCostUSD == nil {
+			t.Fatal("ActiveEstimatedCostUSD = nil, want non-nil")
+		}
+		want := 6.0 + 15.0 // $21
+		if diff := *got.ActiveEstimatedCostUSD - want; diff > 1e-9 || diff < -1e-9 {
+			t.Errorf("ActiveEstimatedCostUSD = %v, want %v", *got.ActiveEstimatedCostUSD, want)
+		}
+	})
+
+	t.Run("with token rates but no matching AgentKind — cost absent", func(t *testing.T) {
+		t.Parallel()
+
+		fptr := func(v float64) *float64 { return &v }
+
+		snap := orchestrator.RuntimeSnapshotResult{
+			GeneratedAt: time.Now().UTC(),
+			Running: []orchestrator.SnapshotRunningEntry{
+				{
+					IssueID:           "no-match",
+					Identifier:        "MT-NM",
+					AgentKind:         "other-adapter",
+					AgentInputTokens:  1_000_000,
+					AgentOutputTokens: 500_000,
+				},
+			},
+		}
+
+		rates := TokenRates{
+			"claude": TokenRateConfig{InputPerMtok: fptr(3.0)},
+		}
+
+		got := toStateResponse(snap, rates)
+
+		if got.ActiveEstimatedCostUSD != nil {
+			t.Errorf("ActiveEstimatedCostUSD = %v, want nil (no matching kind)", *got.ActiveEstimatedCostUSD)
+		}
+	})
+
+	t.Run("ActiveEstimatedCostUSD omitted from JSON when nil", func(t *testing.T) {
+		t.Parallel()
+
+		snap := orchestrator.RuntimeSnapshotResult{
+			GeneratedAt: time.Now().UTC(),
+		}
+
+		got := toStateResponse(snap, nil)
+		data, err := json.Marshal(got)
+		if err != nil {
+			t.Fatalf("json.Marshal: %v", err)
+		}
+
+		var decoded map[string]any
+		if err := json.Unmarshal(data, &decoded); err != nil {
+			t.Fatalf("json.Unmarshal: %v", err)
+		}
+
+		if _, exists := decoded["active_estimated_cost_usd"]; exists {
+			t.Error("JSON active_estimated_cost_usd present, want omitted (omitempty with nil pointer)")
+		}
+	})
+
+	t.Run("ActiveEstimatedCostUSD present in JSON when set", func(t *testing.T) {
+		t.Parallel()
+
+		fptr := func(v float64) *float64 { return &v }
+
+		snap := orchestrator.RuntimeSnapshotResult{
+			GeneratedAt: time.Now().UTC(),
+			Running: []orchestrator.SnapshotRunningEntry{
+				{
+					IssueID:           "json-cost",
+					Identifier:        "MT-JC",
+					AgentKind:         "claude",
+					AgentInputTokens:  1_000_000,
+					AgentOutputTokens: 0,
+				},
+			},
+		}
+
+		rates := TokenRates{
+			"claude": TokenRateConfig{InputPerMtok: fptr(5.0)},
+		}
+
+		got := toStateResponse(snap, rates)
+		data, err := json.Marshal(got)
+		if err != nil {
+			t.Fatalf("json.Marshal: %v", err)
+		}
+
+		var decoded map[string]any
+		if err := json.Unmarshal(data, &decoded); err != nil {
+			t.Fatalf("json.Unmarshal: %v", err)
+		}
+
+		costVal, exists := decoded["active_estimated_cost_usd"]
+		if !exists {
+			t.Fatal("JSON active_estimated_cost_usd missing, want present")
+		}
+		if costVal != float64(5.0) {
+			t.Errorf("JSON active_estimated_cost_usd = %v, want 5.0", costVal)
 		}
 	})
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -120,6 +120,11 @@ type Params struct {
 	// dashboard. Called on each dashboard render. When nil, the run
 	// history section is omitted.
 	RunHistoryFn RunHistoryFunc
+
+	// TokenRates maps agent adapter kind strings to per-token USD
+	// rates for cost estimation on the dashboard. When nil or empty,
+	// the dashboard shows raw token counts without cost estimates.
+	TokenRates TokenRates
 }
 
 // Server is the embedded HTTP server for JSON API, dashboard, and
@@ -141,6 +146,7 @@ type Server struct {
 	preflightFn      func() bool
 	workflowLoadedFn func() bool
 	runHistoryFn     RunHistoryFunc
+	tokenRates       TokenRates
 }
 
 // Compile-time assertion: Server satisfies orchestrator.Observer.
@@ -166,8 +172,9 @@ func New(params Params) *Server {
 
 	tmpl := template.Must(
 		template.New("dashboard").Funcs(template.FuncMap{
-			"fmtInt": fmtInt,
-			"even":   func(i int) bool { return i%2 == 0 },
+			"fmtInt":  fmtInt,
+			"fmtCost": fmtCost,
+			"even":    func(i int) bool { return i%2 == 0 },
 		}).Parse(dashboardHTML),
 	)
 
@@ -184,6 +191,7 @@ func New(params Params) *Server {
 		preflightFn:      params.PreflightFn,
 		workflowLoadedFn: params.WorkflowLoadedFn,
 		runHistoryFn:     params.RunHistoryFn,
+		tokenRates:       params.TokenRates,
 	}
 
 	// Method-specific pattern so non-GET methods receive the default

--- a/internal/server/token_rates.go
+++ b/internal/server/token_rates.go
@@ -2,8 +2,7 @@ package server
 
 import (
 	"fmt"
-	"strconv"
-	"strings"
+	"math"
 )
 
 // TokenRateConfig holds per-token-type USD rates for cost estimation.
@@ -66,6 +65,9 @@ func ParseTokenRates(extensions map[string]any) (TokenRates, []string) {
 			cfg.CacheReadPerMtok = v
 		}
 
+		if cfg.InputPerMtok == nil && cfg.OutputPerMtok == nil && cfg.CacheReadPerMtok == nil {
+			continue
+		}
 		rates[kind] = cfg
 	}
 
@@ -133,22 +135,14 @@ func estimateCost(input, output, cacheRead int64, rates *TokenRateConfig) *float
 
 // fmtCost formats a USD cost value as a string with two decimal places.
 // Values >= 1000 receive comma thousand separators (e.g. "$1,234.56").
+// Rounding is performed on the integer-cents representation to avoid
+// float splitting artifacts near boundaries (e.g. 999.999 → "$1,000.00").
 func fmtCost(v float64) string {
-	if v < 1000 {
-		return "$" + strconv.FormatFloat(v, 'f', 2, 64)
+	cents := int64(math.Round(v * 100))
+	dollars := cents / 100
+	remainder := cents % 100
+	if dollars >= 1000 {
+		return fmt.Sprintf("$%s.%02d", fmtInt(dollars), remainder)
 	}
-
-	// Format the integer part with commas, then append decimals.
-	intPart := int64(v)
-	frac := v - float64(intPart)
-
-	// Use fmtInt for the integer portion (with commas).
-	intStr := fmtInt(intPart)
-
-	// Format fractional part as two decimal digits.
-	fracStr := strconv.FormatFloat(frac, 'f', 2, 64)
-	// fracStr is "0.XX"; strip the leading "0".
-	fracStr = strings.TrimPrefix(fracStr, "0")
-
-	return "$" + intStr + fracStr
+	return fmt.Sprintf("$%d.%02d", dollars, remainder)
 }

--- a/internal/server/token_rates.go
+++ b/internal/server/token_rates.go
@@ -1,0 +1,154 @@
+package server
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// TokenRateConfig holds per-token-type USD rates for cost estimation.
+// All rates are in USD per 1 million tokens (per-mtok). A nil pointer
+// indicates the rate is not configured; cost estimation is suppressed
+// for that token type.
+type TokenRateConfig struct {
+	InputPerMtok     *float64
+	OutputPerMtok    *float64
+	CacheReadPerMtok *float64
+}
+
+// TokenRates maps agent adapter kind strings to their token rate
+// configuration. A nil or empty map means no cost estimates are shown
+// on the dashboard.
+type TokenRates map[string]TokenRateConfig
+
+// ParseTokenRates extracts and validates token rates from the
+// Extensions map produced by config parsing. Returns nil rates when
+// the "token_rates" key is absent or empty. Warnings are advisory
+// and do not prevent boot.
+func ParseTokenRates(extensions map[string]any) (TokenRates, []string) {
+	raw, ok := extensions["token_rates"]
+	if !ok || raw == nil {
+		return nil, nil
+	}
+
+	topMap, ok := raw.(map[string]any)
+	if !ok {
+		return nil, []string{fmt.Sprintf("token_rates: expected map, got %T", raw)}
+	}
+	if len(topMap) == 0 {
+		return nil, nil
+	}
+
+	var warnings []string
+	rates := make(TokenRates, len(topMap))
+
+	for kind, val := range topMap {
+		kindMap, ok := val.(map[string]any)
+		if !ok {
+			warnings = append(warnings, fmt.Sprintf("token_rates.%s: expected map, got %T", kind, val))
+			continue
+		}
+
+		var cfg TokenRateConfig
+		if v, w := extractRate(kindMap, "input_per_mtok", kind); w != "" {
+			warnings = append(warnings, w)
+		} else {
+			cfg.InputPerMtok = v
+		}
+		if v, w := extractRate(kindMap, "output_per_mtok", kind); w != "" {
+			warnings = append(warnings, w)
+		} else {
+			cfg.OutputPerMtok = v
+		}
+		if v, w := extractRate(kindMap, "cache_read_per_mtok", kind); w != "" {
+			warnings = append(warnings, w)
+		} else {
+			cfg.CacheReadPerMtok = v
+		}
+
+		rates[kind] = cfg
+	}
+
+	if len(rates) == 0 {
+		return nil, warnings
+	}
+	return rates, warnings
+}
+
+// extractRate reads a non-negative float64 from a map entry. Returns
+// nil with empty warning when the key is absent, nil with a warning
+// when the value is invalid.
+func extractRate(m map[string]any, key, kind string) (*float64, string) {
+	raw, ok := m[key]
+	if !ok || raw == nil {
+		return nil, ""
+	}
+
+	var f float64
+	switch v := raw.(type) {
+	case float64:
+		f = v
+	case int:
+		f = float64(v)
+	case int64:
+		f = float64(v)
+	default:
+		return nil, fmt.Sprintf("token_rates.%s.%s: expected number, got %T", kind, key, raw)
+	}
+
+	if f < 0 {
+		return nil, fmt.Sprintf("token_rates.%s.%s: negative rate %v", kind, key, f)
+	}
+	return &f, ""
+}
+
+// estimateCost computes estimated USD cost from token counts and a rate
+// config. Returns nil when rates is nil or all rate fields are nil.
+func estimateCost(input, output, cacheRead int64, rates *TokenRateConfig) *float64 {
+	if rates == nil {
+		return nil
+	}
+
+	anySet := false
+	var cost float64
+
+	if rates.InputPerMtok != nil {
+		cost += float64(input) * *rates.InputPerMtok / 1_000_000
+		anySet = true
+	}
+	if rates.OutputPerMtok != nil {
+		cost += float64(output) * *rates.OutputPerMtok / 1_000_000
+		anySet = true
+	}
+	if rates.CacheReadPerMtok != nil {
+		cost += float64(cacheRead) * *rates.CacheReadPerMtok / 1_000_000
+		anySet = true
+	}
+
+	if !anySet {
+		return nil
+	}
+	return &cost
+}
+
+// fmtCost formats a USD cost value as a string with two decimal places.
+// Values >= 1000 receive comma thousand separators (e.g. "$1,234.56").
+func fmtCost(v float64) string {
+	if v < 1000 {
+		return "$" + strconv.FormatFloat(v, 'f', 2, 64)
+	}
+
+	// Format the integer part with commas, then append decimals.
+	intPart := int64(v)
+	frac := v - float64(intPart)
+
+	// Use fmtInt for the integer portion (with commas).
+	intStr := fmtInt(intPart)
+
+	// Format fractional part as two decimal digits.
+	fracStr := strconv.FormatFloat(frac, 'f', 2, 64)
+	// fracStr is "0.XX"; strip the leading "0".
+	fracStr = strings.TrimPrefix(fracStr, "0")
+
+	return "$" + intStr + fracStr
+}

--- a/internal/server/token_rates_test.go
+++ b/internal/server/token_rates_test.go
@@ -207,8 +207,8 @@ func TestParseTokenRates(t *testing.T) {
 
 			got, warnings := ParseTokenRates(tt.extensions)
 
-			if len(warnings) < tt.wantWarnings {
-				t.Errorf("ParseTokenRates warnings = %d, want >= %d: %v", len(warnings), tt.wantWarnings, warnings)
+			if len(warnings) != tt.wantWarnings {
+				t.Errorf("ParseTokenRates warnings = %d, want %d: %v", len(warnings), tt.wantWarnings, warnings)
 			}
 
 			if tt.wantNil {

--- a/internal/server/token_rates_test.go
+++ b/internal/server/token_rates_test.go
@@ -35,6 +35,15 @@ func TestParseTokenRates(t *testing.T) {
 			wantNil:    true,
 		},
 		{
+			name: "kind with empty map is skipped, no rates returned",
+			extensions: map[string]any{
+				"token_rates": map[string]any{
+					"claude": map[string]any{},
+				},
+			},
+			wantNil: true,
+		},
+		{
 			name: "single kind all three rates present",
 			extensions: map[string]any{
 				"token_rates": map[string]any{
@@ -111,6 +120,32 @@ func TestParseTokenRates(t *testing.T) {
 			wantRates: TokenRates{
 				"claude": TokenRateConfig{InputPerMtok: nil, OutputPerMtok: fptr(15.0)},
 			},
+		},
+		{
+			name: "empty kind alongside populated kind yields only populated kind",
+			extensions: map[string]any{
+				"token_rates": map[string]any{
+					"empty":  map[string]any{},
+					"claude": map[string]any{"input_per_mtok": 3.0},
+				},
+			},
+			wantNil: false,
+			wantRates: TokenRates{
+				"claude": TokenRateConfig{InputPerMtok: fptr(3.0)},
+			},
+		},
+		{
+			name: "kind with all negative rates is skipped",
+			extensions: map[string]any{
+				"token_rates": map[string]any{
+					"bad": map[string]any{
+						"input_per_mtok":  -1.0,
+						"output_per_mtok": -2.0,
+					},
+				},
+			},
+			wantNil:      true,
+			wantWarnings: 2,
 		},
 		{
 			name: "explicit zero rate produces non-nil pointer to 0.0",
@@ -336,6 +371,8 @@ func TestFmtCost(t *testing.T) {
 		{"small", 0.05, "$0.05"},
 		{"under 10", 9.99, "$9.99"},
 		{"under 1000", 999.99, "$999.99"},
+		{"rounds up to 1000 from below", 999.999, "$1,000.00"},
+		{"rounds up fractional near boundary", 1234.9999, "$1,235.00"},
 		{"exact 1000", 1000.00, "$1,000.00"},
 		{"mid four digits", 1234.56, "$1,234.56"},
 		{"five digits with cents", 10000.50, "$10,000.50"},

--- a/internal/server/token_rates_test.go
+++ b/internal/server/token_rates_test.go
@@ -1,0 +1,354 @@
+package server
+
+import (
+	"math"
+	"testing"
+)
+
+// --- ParseTokenRates ---
+
+func TestParseTokenRates(t *testing.T) {
+	t.Parallel()
+
+	fptr := func(v float64) *float64 { return &v }
+
+	tests := []struct {
+		name         string
+		extensions   map[string]any
+		wantNil      bool
+		wantWarnings int
+		wantRates    TokenRates // only checked when wantNil is false
+	}{
+		{
+			name:       "absent token_rates key returns nil",
+			extensions: map[string]any{"other": "value"},
+			wantNil:    true,
+		},
+		{
+			name:       "nil extensions map returns nil",
+			extensions: nil,
+			wantNil:    true,
+		},
+		{
+			name:       "empty token_rates map returns nil",
+			extensions: map[string]any{"token_rates": map[string]any{}},
+			wantNil:    true,
+		},
+		{
+			name: "single kind all three rates present",
+			extensions: map[string]any{
+				"token_rates": map[string]any{
+					"claude": map[string]any{
+						"input_per_mtok":      3.0,
+						"output_per_mtok":     15.0,
+						"cache_read_per_mtok": 0.3,
+					},
+				},
+			},
+			wantNil: false,
+			wantRates: TokenRates{
+				"claude": TokenRateConfig{
+					InputPerMtok:     fptr(3.0),
+					OutputPerMtok:    fptr(15.0),
+					CacheReadPerMtok: fptr(0.3),
+				},
+			},
+		},
+		{
+			name: "multiple kinds all parsed",
+			extensions: map[string]any{
+				"token_rates": map[string]any{
+					"claude": map[string]any{
+						"input_per_mtok":  3.0,
+						"output_per_mtok": 15.0,
+					},
+					"gpt4": map[string]any{
+						"input_per_mtok":  10.0,
+						"output_per_mtok": 30.0,
+					},
+				},
+			},
+			wantNil: false,
+			wantRates: TokenRates{
+				"claude": TokenRateConfig{InputPerMtok: fptr(3.0), OutputPerMtok: fptr(15.0)},
+				"gpt4":   TokenRateConfig{InputPerMtok: fptr(10.0), OutputPerMtok: fptr(30.0)},
+			},
+		},
+		{
+			name: "non-map token_rates value yields warning",
+			extensions: map[string]any{
+				"token_rates": "not-a-map",
+			},
+			wantNil:      true,
+			wantWarnings: 1,
+		},
+		{
+			name: "non-map kind sub-value yields warning, partial result",
+			extensions: map[string]any{
+				"token_rates": map[string]any{
+					"claude": map[string]any{"input_per_mtok": 3.0},
+					"bad":    "not-a-map",
+				},
+			},
+			wantNil:      false,
+			wantWarnings: 1,
+			wantRates: TokenRates{
+				"claude": TokenRateConfig{InputPerMtok: fptr(3.0)},
+			},
+		},
+		{
+			name: "negative rate yields nil pointer for that field and warning",
+			extensions: map[string]any{
+				"token_rates": map[string]any{
+					"claude": map[string]any{
+						"input_per_mtok":  -1.0,
+						"output_per_mtok": 15.0,
+					},
+				},
+			},
+			wantNil:      false,
+			wantWarnings: 1,
+			wantRates: TokenRates{
+				"claude": TokenRateConfig{InputPerMtok: nil, OutputPerMtok: fptr(15.0)},
+			},
+		},
+		{
+			name: "explicit zero rate produces non-nil pointer to 0.0",
+			extensions: map[string]any{
+				"token_rates": map[string]any{
+					"claude": map[string]any{
+						"input_per_mtok": 0.0,
+					},
+				},
+			},
+			wantNil: false,
+			wantRates: TokenRates{
+				"claude": TokenRateConfig{InputPerMtok: fptr(0.0)},
+			},
+		},
+		{
+			name: "integer values coerced to float64",
+			extensions: map[string]any{
+				"token_rates": map[string]any{
+					"claude": map[string]any{
+						"input_per_mtok":  int(3),
+						"output_per_mtok": int64(15),
+					},
+				},
+			},
+			wantNil: false,
+			wantRates: TokenRates{
+				"claude": TokenRateConfig{
+					InputPerMtok:  fptr(3.0),
+					OutputPerMtok: fptr(15.0),
+				},
+			},
+		},
+		{
+			name: "missing individual field yields nil pointer for that field",
+			extensions: map[string]any{
+				"token_rates": map[string]any{
+					"claude": map[string]any{
+						"output_per_mtok": 15.0,
+						// input_per_mtok absent
+						// cache_read_per_mtok absent
+					},
+				},
+			},
+			wantNil: false,
+			wantRates: TokenRates{
+				"claude": TokenRateConfig{
+					InputPerMtok:     nil,
+					OutputPerMtok:    fptr(15.0),
+					CacheReadPerMtok: nil,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, warnings := ParseTokenRates(tt.extensions)
+
+			if len(warnings) < tt.wantWarnings {
+				t.Errorf("ParseTokenRates warnings = %d, want >= %d: %v", len(warnings), tt.wantWarnings, warnings)
+			}
+
+			if tt.wantNil {
+				if got != nil {
+					t.Errorf("ParseTokenRates = %v, want nil", got)
+				}
+				return
+			}
+
+			if got == nil {
+				t.Fatal("ParseTokenRates = nil, want non-nil")
+			}
+
+			for kind, wantCfg := range tt.wantRates {
+				gotCfg, ok := got[kind]
+				if !ok {
+					t.Errorf("missing kind %q in result", kind)
+					continue
+				}
+				assertRateField(t, kind, "input_per_mtok", gotCfg.InputPerMtok, wantCfg.InputPerMtok)
+				assertRateField(t, kind, "output_per_mtok", gotCfg.OutputPerMtok, wantCfg.OutputPerMtok)
+				assertRateField(t, kind, "cache_read_per_mtok", gotCfg.CacheReadPerMtok, wantCfg.CacheReadPerMtok)
+			}
+		})
+	}
+}
+
+func assertRateField(t *testing.T, kind, field string, got, want *float64) {
+	t.Helper()
+	if want == nil {
+		if got != nil {
+			t.Errorf("token_rates.%s.%s = %v, want nil", kind, field, *got)
+		}
+		return
+	}
+	if got == nil {
+		t.Fatalf("token_rates.%s.%s = nil, want %v", kind, field, *want)
+	}
+	if *got != *want {
+		t.Errorf("token_rates.%s.%s = %v, want %v", kind, field, *got, *want)
+	}
+}
+
+// --- estimateCost ---
+
+func TestEstimateCost(t *testing.T) {
+	t.Parallel()
+
+	fptr := func(v float64) *float64 { return &v }
+
+	tests := []struct {
+		name       string
+		input      int64
+		output     int64
+		cacheRead  int64
+		rates      *TokenRateConfig
+		wantNil    bool
+		wantResult float64
+	}{
+		{
+			name:      "nil rates returns nil",
+			input:     100,
+			output:    200,
+			cacheRead: 50,
+			rates:     nil,
+			wantNil:   true,
+		},
+		{
+			name:    "all rate fields nil on non-nil config returns nil",
+			input:   1000,
+			output:  500,
+			rates:   &TokenRateConfig{},
+			wantNil: true,
+		},
+		{
+			name:       "all rates configured computes correct sum",
+			input:      1_000_000,
+			output:     500_000,
+			cacheRead:  200_000,
+			rates:      &TokenRateConfig{InputPerMtok: fptr(3.0), OutputPerMtok: fptr(15.0), CacheReadPerMtok: fptr(0.3)},
+			wantResult: 3.0*1.0 + 15.0*0.5 + 0.3*0.2,
+		},
+		{
+			name:       "only output rate configured",
+			input:      1_000_000,
+			output:     2_000_000,
+			cacheRead:  500_000,
+			rates:      &TokenRateConfig{OutputPerMtok: fptr(15.0)},
+			wantResult: 15.0 * 2.0,
+		},
+		{
+			name:       "only input rate configured",
+			input:      2_000_000,
+			output:     500_000,
+			rates:      &TokenRateConfig{InputPerMtok: fptr(5.0)},
+			wantResult: 5.0 * 2.0,
+		},
+		{
+			name:       "zero token counts with rates returns pointer to 0.0",
+			input:      0,
+			output:     0,
+			cacheRead:  0,
+			rates:      &TokenRateConfig{InputPerMtok: fptr(3.0), OutputPerMtok: fptr(15.0)},
+			wantResult: 0.0,
+		},
+		{
+			name:       "zero rates with tokens returns pointer to 0.0",
+			input:      1_000_000,
+			output:     500_000,
+			rates:      &TokenRateConfig{InputPerMtok: fptr(0.0), OutputPerMtok: fptr(0.0)},
+			wantResult: 0.0,
+		},
+		{
+			name:       "large token counts produce finite result",
+			input:      1_000_000_000,
+			output:     1_000_000_000,
+			cacheRead:  1_000_000_000,
+			rates:      &TokenRateConfig{InputPerMtok: fptr(3.0), OutputPerMtok: fptr(15.0), CacheReadPerMtok: fptr(0.3)},
+			wantResult: 3000.0 + 15000.0 + 300.0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := estimateCost(tt.input, tt.output, tt.cacheRead, tt.rates)
+
+			if tt.wantNil {
+				if got != nil {
+					t.Errorf("estimateCost = %v, want nil", *got)
+				}
+				return
+			}
+
+			if got == nil {
+				t.Fatal("estimateCost = nil, want non-nil")
+			}
+			if math.IsInf(*got, 0) || math.IsNaN(*got) {
+				t.Fatalf("estimateCost = %v, want finite number", *got)
+			}
+			if diff := *got - tt.wantResult; diff > 1e-9 || diff < -1e-9 {
+				t.Errorf("estimateCost = %.10f, want %.10f", *got, tt.wantResult)
+			}
+		})
+	}
+}
+
+// --- fmtCost ---
+
+func TestFmtCost(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input float64
+		want  string
+	}{
+		{"zero", 0.00, "$0.00"},
+		{"small", 0.05, "$0.05"},
+		{"under 10", 9.99, "$9.99"},
+		{"under 1000", 999.99, "$999.99"},
+		{"exact 1000", 1000.00, "$1,000.00"},
+		{"mid four digits", 1234.56, "$1,234.56"},
+		{"five digits with cents", 10000.50, "$10,000.50"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := fmtCost(tt.input)
+			if got != tt.want {
+				t.Errorf("fmtCost(%v) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Feat

**Intent:** Surface fleet-level USD cost visibility on the Sortie dashboard. Operators configure token rates per agent adapter kind in WORKFLOW.md front matter; cost is estimated at render time from currently running sessions only, using each session's dispatched adapter kind. No new SQLite tables, HTTP endpoints, or runtime dependencies.

**Related Issues:** #436

### 🧭 Reviewer Guide

**Complexity:** Medium

#### Entry Point

`internal/server/token_rates.go` — new file that defines `TokenRateConfig`, `TokenRates`, `ParseTokenRates`, `estimateCost`, and `fmtCost`. This is the central logic for parsing WORKFLOW.md token rate config and computing per-session and aggregate USD cost estimates.

#### Sensitive Areas

- `internal/orchestrator/state.go`: Adds `AgentKind string` to `RunningEntry` and `SnapshotRunningEntry`. This is an additive field captured at dispatch time — verify it is correctly copied in `RuntimeSnapshot` and set at both dispatch sites (`orchestrator.go` and `retry.go`).
- `internal/server/dashboard.html`: All cost-related markup is guarded by `{{if .HasTokenRates}}` — verify zero-config behavior (no `token_rates` key) renders unchanged from before this PR.
- `internal/server/handler.go`: `ActiveEstimatedCostUSD *float64` uses `omitempty` — confirm the field is absent from JSON when token rates are not configured.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes. `buildDashboardData` gains a new `tokenRates` parameter (internal function, single call site updated). `toStateResponse` gains a `tokenRates` parameter (internal, single call site updated). All existing caller sites pass `nil`/empty and produce unchanged output.
- **Migrations/State:** No database migrations. No new persistence queries. No new SQLite tables.