### PR TITLE
fix(orchestrator): correct ci_escalations_total double-count in escalateCIFailure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   phantom escalation that was never performed. Both defects are fixed; the metric
   now increments exactly once per operation outcome, matching the pattern in
   `escalateReviewFailure`.
-  ([#449](https://github.com/sortie-ai/sortie/issues/449))
+  ([#449](https://github.com/sortie-ai/sortie/issues/449),
+  [#450](https://github.com/sortie-ai/sortie/pull/450))
 
 ## [1.7.0] - 2026-04-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Orchestrator: `sortie_ci_escalations_total` over-counted during CI escalation.
+  `escalateCIFailure` incremented the metric unconditionally before calling the
+  tracker API, then incremented again on error — producing two increments for one
+  failed operation. It also incremented when `TrackerAdapter` was nil, recording a
+  phantom escalation that was never performed. Both defects are fixed; the metric
+  now increments exactly once per operation outcome, matching the pattern in
+  `escalateReviewFailure`.
+  ([#449](https://github.com/sortie-ai/sortie/issues/449))
+
 ## [1.7.0] - 2026-04-13
 
 ### Added

--- a/internal/orchestrator/ci_reconcile.go
+++ b/internal/orchestrator/ci_reconcile.go
@@ -270,8 +270,6 @@ func escalateCIFailure(
 		slog.Int("max_retries", params.CIFeedback.MaxRetries),
 	)
 
-	metrics.IncCIEscalations(params.CIFeedback.Escalation)
-
 	switch params.CIFeedback.Escalation {
 	case "label":
 		label := params.CIFeedback.EscalationLabel
@@ -283,6 +281,7 @@ func escalateCIFailure(
 			tracker := params.TrackerAdapter
 			m := metrics
 			escalLog := log
+			escalAction := params.CIFeedback.Escalation
 
 			state.TrackerOpsWg.Add(1)
 			go func() {
@@ -296,6 +295,8 @@ func escalateCIFailure(
 						slog.Any("error", err),
 					)
 					m.IncCIEscalations("error")
+				} else {
+					m.IncCIEscalations(escalAction)
 				}
 			}()
 		}
@@ -308,6 +309,10 @@ func escalateCIFailure(
 			m := metrics
 			escalLog := log
 			ct := commentText
+			escalAction := params.CIFeedback.Escalation
+			if escalAction == "" {
+				escalAction = "comment"
+			}
 
 			state.TrackerOpsWg.Add(1)
 			go func() {
@@ -321,6 +326,8 @@ func escalateCIFailure(
 						slog.Any("error", err),
 					)
 					m.IncCIEscalations("error")
+				} else {
+					m.IncCIEscalations(escalAction)
 				}
 			}()
 		}

--- a/internal/orchestrator/ci_reconcile_test.go
+++ b/internal/orchestrator/ci_reconcile_test.go
@@ -103,6 +103,7 @@ type ciTrackerStub struct {
 	addLabelCalled    int
 	commentIssueCalls int
 	addLabelErr       error
+	commentIssueErr   error
 }
 
 var _ domain.TrackerAdapter = (*ciTrackerStub)(nil)
@@ -128,7 +129,7 @@ func (s *ciTrackerStub) FetchIssueComments(_ context.Context, _ string) ([]domai
 func (s *ciTrackerStub) TransitionIssue(_ context.Context, _ string, _ string) error { return nil }
 func (s *ciTrackerStub) CommentIssue(_ context.Context, _ string, _ string) error {
 	s.commentIssueCalls++
-	return nil
+	return s.commentIssueErr
 }
 func (s *ciTrackerStub) AddLabel(_ context.Context, _ string, _ string) error {
 	s.addLabelCalled++
@@ -405,6 +406,9 @@ func TestReconcileCIStatus_Failing_ExceedsMaxRetries_Escalates(t *testing.T) {
 		t.Error("ReactionAttempts not cleared after escalation; want cleared")
 	}
 
+	// Wait for the async escalation goroutine before reading metrics.
+	state.TrackerOpsWg.Wait()
+
 	// Escalation metric incremented (label mode from defaultCIFeedback).
 	if metrics.ciEscalations["label"] != 1 {
 		t.Errorf(`IncCIEscalations("label") = %d, want 1`, metrics.ciEscalations["label"])
@@ -434,6 +438,9 @@ func TestReconcileCIStatus_Failing_CommentEscalation(t *testing.T) {
 	params.CIFeedback.Escalation = "comment"
 
 	reconcileCIStatus(state, params, discardLogger(), context.Background(), metrics)
+
+	// Wait for the async escalation goroutine before reading metrics.
+	state.TrackerOpsWg.Wait()
 
 	if metrics.ciEscalations["comment"] != 1 {
 		t.Errorf(`IncCIEscalations("comment") = %d, want 1`, metrics.ciEscalations["comment"])
@@ -1123,6 +1130,103 @@ func TestReconcileCIStatus_Failing_DoesNotMarkDispatched(t *testing.T) {
 	// Retry must still be scheduled.
 	if _, ok := state.RetryAttempts["ISS-FP-5"]; !ok {
 		t.Error("retry not scheduled after CI failure; want scheduled")
+	}
+}
+
+// TestEscalateCIFailure_LabelFailure_IncrementsErrorMetric verifies that when
+// AddLabel returns an error the escalation goroutine increments
+// IncCIEscalations("error") and does not increment IncCIEscalations("label").
+func TestEscalateCIFailure_LabelFailure_IncrementsErrorMetric(t *testing.T) {
+	t.Parallel()
+
+	tracker := &ciTrackerStub{addLabelErr: errors.New("tracker unavailable")}
+
+	state := stateWithPendingReaction(t, "ESC-ERR-1", "main/broken", 3)
+	state.ReactionAttempts[ReactionKey("ESC-ERR-1", ReactionKindCI)] = 2
+	store := &ciReconcileStore{}
+	metrics := newCIMetricsSpy()
+	ci := &mockCIProvider{result: domain.CIResult{Status: domain.CIStatusFailing}}
+	params := ciParams(t, store, ci, tracker)
+	// defaultCIFeedback sets escalation: "label".
+
+	reconcileCIStatus(state, params, discardLogger(), context.Background(), metrics)
+	state.TrackerOpsWg.Wait()
+
+	if metrics.ciEscalations["error"] != 1 {
+		t.Errorf(`IncCIEscalations("error") = %d, want 1 on label tracker failure`, metrics.ciEscalations["error"])
+	}
+	if metrics.ciEscalations["label"] != 0 {
+		t.Errorf(`IncCIEscalations("label") = %d, want 0 on label tracker failure`, metrics.ciEscalations["label"])
+	}
+}
+
+// TestEscalateCIFailure_CommentFailure_IncrementsErrorMetric verifies that
+// when CommentIssue returns an error the escalation goroutine increments
+// IncCIEscalations("error") and does not increment IncCIEscalations("comment").
+func TestEscalateCIFailure_CommentFailure_IncrementsErrorMetric(t *testing.T) {
+	t.Parallel()
+
+	tracker := &ciTrackerStub{commentIssueErr: errors.New("tracker unavailable")}
+
+	state := stateWithPendingReaction(t, "ESC-ERR-2", "feature/broken", 2)
+	state.ReactionAttempts[ReactionKey("ESC-ERR-2", ReactionKindCI)] = 2
+	store := &ciReconcileStore{}
+	metrics := newCIMetricsSpy()
+	ci := &mockCIProvider{result: domain.CIResult{Status: domain.CIStatusFailing}}
+	params := ciParams(t, store, ci, tracker)
+	params.CIFeedback.Escalation = "comment"
+
+	reconcileCIStatus(state, params, discardLogger(), context.Background(), metrics)
+	state.TrackerOpsWg.Wait()
+
+	if metrics.ciEscalations["error"] != 1 {
+		t.Errorf(`IncCIEscalations("error") = %d, want 1 on comment tracker failure`, metrics.ciEscalations["error"])
+	}
+	if metrics.ciEscalations["comment"] != 0 {
+		t.Errorf(`IncCIEscalations("comment") = %d, want 0 on comment tracker failure`, metrics.ciEscalations["comment"])
+	}
+}
+
+// TestEscalateCIFailure_NilTracker_ZeroIncrements verifies that when
+// TrackerAdapter is nil the escalation path spawns no goroutine and
+// IncCIEscalations is never called.
+func TestEscalateCIFailure_NilTracker_ZeroIncrements(t *testing.T) {
+	t.Parallel()
+
+	state := stateWithPendingReaction(t, "ESC-NIL-1", "main/broken", 3)
+	state.ReactionAttempts[ReactionKey("ESC-NIL-1", ReactionKindCI)] = 2
+	store := &ciReconcileStore{}
+	metrics := newCIMetricsSpy()
+	ci := &mockCIProvider{result: domain.CIResult{Status: domain.CIStatusFailing}}
+	params := ciParams(t, store, ci, nil) // nil TrackerAdapter
+	// defaultCIFeedback sets escalation: "label".
+
+	reconcileCIStatus(state, params, discardLogger(), context.Background(), metrics)
+	state.TrackerOpsWg.Wait()
+
+	if len(metrics.ciEscalations) != 0 {
+		t.Errorf("IncCIEscalations called with nil TrackerAdapter; want zero increments, got %v", metrics.ciEscalations)
+	}
+}
+
+// TestEscalateCIFailure_NilTracker_ZeroIncrements_Comment verifies the same
+// zero-increment guarantee for the comment escalation path with nil tracker.
+func TestEscalateCIFailure_NilTracker_ZeroIncrements_Comment(t *testing.T) {
+	t.Parallel()
+
+	state := stateWithPendingReaction(t, "ESC-NIL-2", "feature/broken", 2)
+	state.ReactionAttempts[ReactionKey("ESC-NIL-2", ReactionKindCI)] = 2
+	store := &ciReconcileStore{}
+	metrics := newCIMetricsSpy()
+	ci := &mockCIProvider{result: domain.CIResult{Status: domain.CIStatusFailing}}
+	params := ciParams(t, store, ci, nil) // nil TrackerAdapter
+	params.CIFeedback.Escalation = "comment"
+
+	reconcileCIStatus(state, params, discardLogger(), context.Background(), metrics)
+	state.TrackerOpsWg.Wait()
+
+	if len(metrics.ciEscalations) != 0 {
+		t.Errorf("IncCIEscalations called with nil TrackerAdapter; want zero increments, got %v", metrics.ciEscalations)
 	}
 }
 


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Fix

**Intent:** Correct two metric accounting defects in `escalateCIFailure` that caused `sortie_ci_escalations_total` to record incorrect counts — over-counting on tracker API errors and phantom-counting when no tracker adapter is configured.

**Related Issues:** [#449](https://github.com/sortie-ai/sortie/issues/449)

### 🧭 Reviewer Guide

**Complexity:** Low

#### Entry Point

`internal/orchestrator/ci_reconcile.go` — `escalateCIFailure`. The function previously called `metrics.IncCIEscalations` once unconditionally before the `switch`, then again inside the goroutine on error. The fix removes the pre-increment and moves all increments inside the goroutine, after the tracker result is known — matching the existing correct pattern in `escalateReviewFailure`.

#### Sensitive Areas

- `internal/orchestrator/ci_reconcile.go`: metric increment timing changed from synchronous-before-I/O to async-inside-goroutine; tests must `state.TrackerOpsWg.Wait()` before reading metric values.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes
- **Migrations/State:** No migrations or state changes