### PR TITLE
docs(decisions): add ADR-0010 keep TrackerAdapter unified

### DIFF
--- a/cmd/sortie/main_test.go
+++ b/cmd/sortie/main_test.go
@@ -25,16 +25,17 @@ import (
 // full run() startup sequence. These tests verify startup behavior
 // (logging, DB creation, flag parsing) and do not need to wait for a
 // poll cycle — the orchestrator shuts down as soon as the context
-// expires. Keep this short to avoid a cumulative 100+ second test suite.
+// expires.
 //
-// Windows CI runners need a longer budget because the pure-Go SQLite
-// driver (modernc.org/sqlite) performs slower disk I/O on NTFS, and
-// schema migrations can exceed the default 500 ms deadline.
+// The pure-Go SQLite driver (modernc.org/sqlite) is significantly slower
+// under the race detector and on resource-constrained CI runners, where
+// PRAGMA execution and schema migrations can exceed a sub-second budget.
+// Windows NTFS adds further disk I/O overhead.
 var runTestTimeout = func() time.Duration {
 	if runtime.GOOS == "windows" {
 		return 10 * time.Second
 	}
-	return 500 * time.Millisecond
+	return 2 * time.Second
 }()
 
 // minimalWorkflow returns a minimal valid WORKFLOW.md content that

--- a/docs/decisions/0010-keep-tracker-adapter-unified.md
+++ b/docs/decisions/0010-keep-tracker-adapter-unified.md
@@ -1,0 +1,71 @@
+---
+status: accepted
+date: 2026-04-16
+decision-makers: Serghei Iakovlev
+---
+
+# Keep TrackerAdapter as a Unified Interface
+
+## Context and Problem Statement
+
+The `TrackerAdapter` interface has 9 methods: 6 read operations, 2 core write operations
+(`TransitionIssue`, `CommentIssue`), and 1 escalation write operation (`AddLabel`). As
+the roadmap anticipates additional tracker write methods (`RemoveLabel`, `AddAssignee`,
+`ChangeStatus`), the question is whether the single-interface pattern will become a
+maintenance burden that violates Go's small-interface convention, or whether splitting
+introduces unnecessary complexity for the current scale.
+
+## Decision Drivers
+
+1. **Compile-time safety.** All adapter implementations are internal to this repository.
+   The compiler should catch every missing method at build time, not at runtime via type
+   assertions.
+2. **Orchestrator simplicity.** The orchestrator calls tracker methods unconditionally.
+   Introducing type-assertion branches adds conditional logic, fallback handling, and
+   additional test paths at every call site.
+3. **No-op cost.** When an adapter does not meaningfully support a method, it returns
+   `nil`. The cost of one no-op stub per adapter per method is trivial at current scale.
+4. **Go interface cohesion.** Interface size is justified when methods form a cohesive
+   behavior contract. All 9 methods describe "what an issue tracker can do for the
+   orchestrator" — a single responsibility.
+
+## Considered Options
+
+- Keep `TrackerAdapter` as a single unified interface
+- Split into `TrackerAdapter` (core read/write) + `TrackerEscalation` (optional capability
+  discovered via type assertion)
+
+## Decision Outcome
+
+Chosen option: **Keep `TrackerAdapter` as a single unified interface**, because the cost
+of splitting exceeds the cost of the current pattern at the present scale.
+
+Only 1 of 9 methods is a no-op in 1 adapter (`FileAdapter.AddLabel`). Splitting would
+require type-assertion branches at 2 orchestrator call sites, trading compile-time safety
+for runtime discovery — a trade that is unnecessary when all adapters are internal and
+every implementation is under our control. The 10 test doubles each gain one stub line per
+new method; saving approximately 3 stubs does not justify the structural change.
+
+### Reassessment Trigger
+
+Revisit this decision when **all three** conditions are true simultaneously:
+
+1. The interface exceeds 12 methods.
+2. At least 3 methods are no-ops in 2 or more adapter implementations.
+3. A concrete new adapter is being built that genuinely cannot support the no-op methods
+   (e.g., a read-only tracker where write methods would violate the adapter's contract
+   rather than being harmless no-ops).
+
+Until these conditions are met, the unified interface is the simpler and safer choice.
+
+### Considered Options in Detail
+
+**Split into core + optional escalation interface.** Under this option, escalation methods
+(`AddLabel`, future `RemoveLabel`, `AddAssignee`) would move to a `TrackerEscalation`
+interface. The orchestrator would discover the capability via type assertion
+(`if esc, ok := tracker.(TrackerEscalation); ok { ... }`). This pattern is appropriate
+when adapters are external and the set of implementations is open. For Sortie, all
+adapters are internal, the set is closed, and the type-assertion branches add complexity
+without benefit. Each call site gains a branch, a log line, and a test path for the
+"not supported" case — producing the same outcome that today's no-op `nil` return achieves
+with zero branching.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -16,3 +16,4 @@ This directory contains architecturally significant decisions for Sortie, docume
 | [0007](0007-handoff-state-and-tracker-writes.md) | Use Handoff State Transitions to Signal Agent Completion         | Accepted |
 | [0008](0008-observability-model.md)              | Use Embedded Dashboard with Prometheus Metrics for Observability | Accepted |
 | [0009](0009-mcp-stdio-sidecar-for-tool-execution.md) | Use MCP stdio sidecar for agent tool execution               | Accepted |
+| [0010](0010-keep-tracker-adapter-unified.md)         | Keep TrackerAdapter as a Unified Interface                    | Accepted |


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Chore

**Intent:** Records the architectural decision to keep `TrackerAdapter` as a single unified interface rather than splitting into a core + optional escalation interface. Also fixes flaky CI test timeouts caused by the pure-Go SQLite driver under the race detector.

**Related Issues:** #377

### 🧭 Reviewer Guide

**Complexity:** Low

#### Entry Point

`docs/decisions/0010-keep-tracker-adapter-unified.md` - the new ADR. It documents the decision drivers, two considered options, the chosen outcome with rationale, and a three-condition reassessment trigger that defines when to re-evaluate the decision.

#### Sensitive Areas

- `docs/decisions/README.md`: index table updated with the new ADR row.
- `cmd/sortie/main_test.go`: `runTestTimeout` increased from 500ms to 2s on Linux to prevent flaky failures when the race detector slows SQLite PRAGMA execution and schema migrations.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes
- **Migrations/State:** No migrations or state changes