### PR TITLE
feat(codex): add Codex CLI agent adapter

### DIFF
--- a/cmd/sortie/main.go
+++ b/cmd/sortie/main.go
@@ -36,6 +36,7 @@ import (
 
 	// Import adapter packages for their init-time registrations.
 	_ "github.com/sortie-ai/sortie/internal/agent/claude"
+	_ "github.com/sortie-ai/sortie/internal/agent/codex"
 	_ "github.com/sortie-ai/sortie/internal/agent/copilot"
 	_ "github.com/sortie-ai/sortie/internal/agent/mock"
 	_ "github.com/sortie-ai/sortie/internal/scm/github"

--- a/internal/agent/codex/codex.go
+++ b/internal/agent/codex/codex.go
@@ -440,6 +440,7 @@ func (a *CodexAdapter) RunTurn(ctx context.Context, session domain.Session, para
 
 	inFlight := make(map[string]inFlightTool)
 	var usage domain.TokenUsage
+	var toolWg sync.WaitGroup
 	interrupted := false
 
 	for {
@@ -451,12 +452,10 @@ func (a *CodexAdapter) RunTurn(ctx context.Context, session domain.Session, para
 				// request is not dropped by the already-cancelled
 				// parent context.
 				interruptCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-				state.mu.Lock()
 				sendRequest(state, "turn/interrupt", map[string]any{ //nolint:errcheck,gosec // best-effort interrupt
 					"threadId": state.threadID,
 					"turnId":   turnID,
 				})
-				state.mu.Unlock()
 				cancel()
 				_ = interruptCtx
 			}
@@ -466,6 +465,7 @@ func (a *CodexAdapter) RunTurn(ctx context.Context, session domain.Session, para
 		case msg, ok := <-msgCh:
 			if !ok {
 				// Channel closed — subprocess stdout ended.
+				toolWg.Wait()
 				return domain.TurnResult{
 						SessionID:  state.threadID,
 						ExitReason: domain.EventTurnFailed,
@@ -482,6 +482,7 @@ func (a *CodexAdapter) RunTurn(ctx context.Context, session domain.Session, para
 					Timestamp: now,
 					Message:   msg.Err.Error(),
 				})
+				toolWg.Wait()
 				return domain.TurnResult{
 						SessionID:  state.threadID,
 						ExitReason: domain.EventTurnFailed,
@@ -547,6 +548,7 @@ func (a *CodexAdapter) RunTurn(ctx context.Context, session domain.Session, para
 						Timestamp: now,
 						Usage:     usage,
 					})
+					toolWg.Wait()
 					return domain.TurnResult{
 							SessionID:  state.threadID,
 							ExitReason: exitReason,
@@ -568,6 +570,7 @@ func (a *CodexAdapter) RunTurn(ctx context.Context, session domain.Session, para
 					Usage:     usage,
 				})
 
+				toolWg.Wait()
 				return domain.TurnResult{
 					SessionID:  state.threadID,
 					ExitReason: exitReason,
@@ -633,7 +636,7 @@ func (a *CodexAdapter) RunTurn(ctx context.Context, session domain.Session, para
 				})
 
 			case "item/tool/call":
-				a.handleToolCall(ctx, state, msg, params.OnEvent, logger)
+				a.handleToolCall(ctx, state, &toolWg, msg, params.OnEvent, logger)
 
 			case "turn/plan/updated":
 				params.OnEvent(domain.AgentEvent{
@@ -658,8 +661,10 @@ func (a *CodexAdapter) RunTurn(ctx context.Context, session domain.Session, para
 
 // handleToolCall dispatches a dynamic tool call from the app-server to
 // the ToolRegistry. The tool is executed asynchronously to avoid
-// blocking the event read loop.
-func (a *CodexAdapter) handleToolCall(ctx context.Context, state *sessionState, msg parsedMessage, onEvent func(domain.AgentEvent), logger *slog.Logger) {
+// blocking the event read loop. The provided WaitGroup is incremented
+// before launching the goroutine so RunTurn can wait for in-flight
+// tools before returning.
+func (a *CodexAdapter) handleToolCall(ctx context.Context, state *sessionState, wg *sync.WaitGroup, msg parsedMessage, onEvent func(domain.AgentEvent), logger *slog.Logger) {
 	now := time.Now().UTC()
 	requestID := msg.Response.ID
 
@@ -701,15 +706,21 @@ func (a *CodexAdapter) handleToolCall(ctx context.Context, state *sessionState, 
 		return
 	}
 
+	wg.Add(1)
 	go func() {
+		defer wg.Done()
 		start := time.Now()
 		result, execErr := tool.Execute(ctx, tc.Arguments)
 
 		state.mu.Lock()
-		defer state.mu.Unlock()
-
 		if execErr != nil {
 			sendResponse(state, requestID, toolResultFor(false, execErr.Error())) //nolint:errcheck,gosec // best-effort error response
+		} else {
+			sendResponse(state, requestID, toolResultFor(true, string(result))) //nolint:errcheck,gosec // best-effort success response
+		}
+		state.mu.Unlock()
+
+		if execErr != nil {
 			onEvent(domain.AgentEvent{
 				Type:           domain.EventToolResult,
 				Timestamp:      time.Now().UTC(),
@@ -718,16 +729,14 @@ func (a *CodexAdapter) handleToolCall(ctx context.Context, state *sessionState, 
 				ToolError:      true,
 				Message:        execErr.Error(),
 			})
-			return
+		} else {
+			onEvent(domain.AgentEvent{
+				Type:           domain.EventToolResult,
+				Timestamp:      time.Now().UTC(),
+				ToolName:       toolName,
+				ToolDurationMS: time.Since(start).Milliseconds(),
+			})
 		}
-
-		sendResponse(state, requestID, toolResultFor(true, string(result))) //nolint:errcheck,gosec // best-effort success response
-		onEvent(domain.AgentEvent{
-			Type:           domain.EventToolResult,
-			Timestamp:      time.Now().UTC(),
-			ToolName:       toolName,
-			ToolDurationMS: time.Since(start).Milliseconds(),
-		})
 	}()
 }
 

--- a/internal/agent/codex/codex.go
+++ b/internal/agent/codex/codex.go
@@ -177,6 +177,12 @@ func (a *CodexAdapter) StartSession(ctx context.Context, params domain.StartSess
 		// Local mode: the command may be "codex app-server" (with args).
 		// Split on first space to extract binary and arguments.
 		parts := strings.Fields(command)
+		if len(parts) == 0 {
+			return domain.Session{}, &domain.AgentError{
+				Kind:    domain.ErrAgentNotFound,
+				Message: "agent command is empty or whitespace-only",
+			}
+		}
 		resolved, lookErr := exec.LookPath(parts[0])
 		if lookErr != nil {
 			return domain.Session{}, &domain.AgentError{

--- a/internal/agent/codex/codex.go
+++ b/internal/agent/codex/codex.go
@@ -1,0 +1,798 @@
+// Package codex implements [domain.AgentAdapter] for the OpenAI Codex
+// CLI. It launches `codex app-server` as a persistent subprocess,
+// communicates via JSON-RPC 2.0 over stdin/stdout (JSONL), and
+// normalizes events into domain types. Registered under kind "codex"
+// via an init function. Unlike the Claude Code and Copilot adapters,
+// the subprocess persists across turns within a session.
+package codex
+
+import (
+	"bufio"
+	"cmp"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/sortie-ai/sortie/internal/agent/procutil"
+	"github.com/sortie-ai/sortie/internal/agent/sshutil"
+	"github.com/sortie-ai/sortie/internal/domain"
+	"github.com/sortie-ai/sortie/internal/logging"
+	"github.com/sortie-ai/sortie/internal/registry"
+)
+
+func init() {
+	registry.Agents.RegisterWithMeta("codex", NewCodexAdapter, registry.AgentMeta{
+		RequiresCommand: true,
+	})
+}
+
+// Compile-time interface satisfaction check.
+var _ domain.AgentAdapter = (*CodexAdapter)(nil)
+
+// inFlightTool tracks a tool execution that has started but whose
+// corresponding item/completed has not yet arrived.
+type inFlightTool struct {
+	Name      string
+	Timestamp time.Time
+}
+
+// CodexAdapter satisfies [domain.AgentAdapter] by managing a persistent
+// codex app-server subprocess. One adapter instance serves all
+// concurrent sessions; per-session state is held in [sessionState] via
+// the [domain.Session] Internal field.
+type CodexAdapter struct {
+	passthrough  passthroughConfig
+	toolRegistry *domain.ToolRegistry
+}
+
+// sessionState is adapter-internal state stored in [domain.Session]
+// Internal. It tracks the persistent app-server subprocess, thread
+// ID, and turn state across the session lifetime.
+type sessionState struct {
+	workspacePath string
+	command       string
+	agentConfig   domain.AgentConfig
+	turnCount     int
+
+	threadID      string
+	nextRequestID int64
+
+	sshHost                  string
+	remoteCommand            string
+	sshStrictHostKeyChecking string
+	mcpConfigPath            string
+
+	// mu guards proc, waitCh, stdin, stdout, and stderrCollector for
+	// concurrent access from StopSession and the event read loop.
+	mu              sync.Mutex
+	proc            *os.Process
+	waitCh          chan struct{}
+	stdin           io.WriteCloser
+	stdout          io.ReadCloser
+	stderrCollector *procutil.StderrCollector
+}
+
+// NewCodexAdapter creates a [CodexAdapter] from adapter configuration.
+// The config parameter is the raw map from the "codex" sub-object in
+// WORKFLOW.md. Command resolution is deferred to
+// [CodexAdapter.StartSession].
+func NewCodexAdapter(config map[string]any) (domain.AgentAdapter, error) {
+	pt := parsePassthroughConfig(config)
+	adapter := &CodexAdapter{passthrough: pt}
+
+	if tr, ok := config["tool_registry"]; ok {
+		if reg, ok := tr.(*domain.ToolRegistry); ok {
+			adapter.toolRegistry = reg
+		}
+	}
+
+	return adapter, nil
+}
+
+// StartSession validates the workspace path, resolves the codex
+// binary, launches the app-server subprocess, performs the
+// initialization handshake, authenticates if needed, and starts or
+// resumes a thread.
+func (a *CodexAdapter) StartSession(ctx context.Context, params domain.StartSessionParams) (domain.Session, error) {
+	if params.WorkspacePath == "" {
+		return domain.Session{}, &domain.AgentError{
+			Kind:    domain.ErrInvalidWorkspaceCwd,
+			Message: "empty workspace path",
+		}
+	}
+
+	absPath, err := filepath.Abs(params.WorkspacePath)
+	if err != nil {
+		return domain.Session{}, &domain.AgentError{
+			Kind:    domain.ErrInvalidWorkspaceCwd,
+			Message: "cannot resolve workspace path",
+			Err:     err,
+		}
+	}
+
+	fi, err := os.Stat(absPath)
+	if err != nil {
+		return domain.Session{}, &domain.AgentError{
+			Kind:    domain.ErrInvalidWorkspaceCwd,
+			Message: "workspace path does not exist",
+			Err:     err,
+		}
+	}
+	if !fi.IsDir() {
+		return domain.Session{}, &domain.AgentError{
+			Kind:    domain.ErrInvalidWorkspaceCwd,
+			Message: "workspace path is not a directory",
+		}
+	}
+
+	command := cmp.Or(params.AgentConfig.Command, "codex app-server")
+
+	state := &sessionState{
+		workspacePath:            absPath,
+		agentConfig:              params.AgentConfig,
+		sshStrictHostKeyChecking: params.SSHStrictHostKeyChecking,
+		mcpConfigPath:            params.MCPConfigPath,
+	}
+
+	var cmdPath string
+	var cmdArgs []string
+
+	sshHostTrimmed := strings.TrimSpace(params.SSHHost)
+	if sshHostTrimmed != "" {
+		sshPath, lookErr := exec.LookPath("ssh")
+		if lookErr != nil {
+			return domain.Session{}, &domain.AgentError{
+				Kind:    domain.ErrAgentNotFound,
+				Message: "ssh binary not found on orchestrator host",
+				Err:     lookErr,
+			}
+		}
+
+		// Build the remote command, prefixing CODEX_API_KEY if present
+		// so it reaches the remote shell.
+		remoteCmd := command
+		if apiKey := os.Getenv("CODEX_API_KEY"); apiKey != "" {
+			remoteCmd = fmt.Sprintf("CODEX_API_KEY=%s %s", sshutil.ShellQuote(apiKey), command)
+		}
+
+		sshArgs := sshutil.BuildSSHArgs(sshHostTrimmed, absPath, remoteCmd, nil, sshutil.SSHOptions{
+			StrictHostKeyChecking: params.SSHStrictHostKeyChecking,
+		})
+
+		cmdPath = sshPath
+		cmdArgs = sshArgs
+		state.command = sshPath
+		state.sshHost = sshHostTrimmed
+		state.remoteCommand = command
+	} else {
+		// Local mode: the command may be "codex app-server" (with args).
+		// Split on first space to extract binary and arguments.
+		parts := strings.Fields(command)
+		resolved, lookErr := exec.LookPath(parts[0])
+		if lookErr != nil {
+			return domain.Session{}, &domain.AgentError{
+				Kind:    domain.ErrAgentNotFound,
+				Message: fmt.Sprintf("agent command %q not found", parts[0]),
+				Err:     lookErr,
+			}
+		}
+		cmdPath = resolved
+		if len(parts) > 1 {
+			cmdArgs = parts[1:]
+		}
+		state.command = resolved
+	}
+
+	cmd := exec.CommandContext(ctx, cmdPath, cmdArgs...) //nolint:gosec // args are constructed programmatically
+	procutil.SetProcessGroup(cmd)
+	cmd.Dir = absPath
+	cmd.Env = os.Environ()
+
+	stdinPipe, err := cmd.StdinPipe()
+	if err != nil {
+		return domain.Session{}, &domain.AgentError{
+			Kind:    domain.ErrPortExit,
+			Message: "failed to create stdin pipe",
+			Err:     err,
+		}
+	}
+	stdoutPipe, err := cmd.StdoutPipe()
+	if err != nil {
+		return domain.Session{}, &domain.AgentError{
+			Kind:    domain.ErrPortExit,
+			Message: "failed to create stdout pipe",
+			Err:     err,
+		}
+	}
+	stderrPipe, err := cmd.StderrPipe()
+	if err != nil {
+		return domain.Session{}, &domain.AgentError{
+			Kind:    domain.ErrPortExit,
+			Message: "failed to create stderr pipe",
+			Err:     err,
+		}
+	}
+
+	if err := cmd.Start(); err != nil {
+		return domain.Session{}, &domain.AgentError{
+			Kind:    domain.ErrPortExit,
+			Message: "failed to start app-server subprocess",
+			Err:     err,
+		}
+	}
+
+	logger := slog.Default().With(slog.String("component", "codex-adapter"))
+	if assignErr := procutil.AssignProcess(cmd.Process.Pid, cmd.Process); assignErr != nil {
+		logger.Warn("process group assignment failed", slog.Any("error", assignErr))
+	}
+
+	state.proc = cmd.Process
+	state.stdin = stdinPipe
+	state.stdout = stdoutPipe
+	state.waitCh = make(chan struct{})
+	state.stderrCollector = procutil.NewStderrCollector(stderrPipe, logger)
+
+	// Background goroutine to close waitCh when the process exits.
+	go func() {
+		cmd.Wait()                                 //nolint:errcheck,gosec // exit code handled via waitCh
+		procutil.KillProcessGroup(cmd.Process.Pid) //nolint:errcheck,gosec // best-effort cleanup of surviving group members
+		procutil.CleanupProcess(cmd.Process.Pid)
+		close(state.waitCh)
+	}()
+
+	// killOnError is a cleanup closure used if any handshake step fails.
+	killOnError := func() {
+		state.mu.Lock()
+		if state.stdin != nil {
+			state.stdin.Close() //nolint:errcheck,gosec // best-effort cleanup
+		}
+		state.mu.Unlock()
+		procutil.KillProcessGroup(cmd.Process.Pid) //nolint:errcheck,gosec // best-effort cleanup
+		// Wait briefly for cleanup.
+		select {
+		case <-state.waitCh:
+		case <-time.After(3 * time.Second):
+		}
+		state.mu.Lock()
+		state.proc = nil
+		state.stdin = nil
+		state.stdout = nil
+		state.mu.Unlock()
+	}
+
+	scanner := bufio.NewScanner(stdoutPipe)
+	scanner.Buffer(make([]byte, 0, 1<<20), 1<<20)
+
+	if err := initializeHandshake(ctx, state, scanner); err != nil {
+		killOnError()
+		return domain.Session{}, &domain.AgentError{
+			Kind:    domain.ErrResponseError,
+			Message: fmt.Sprintf("handshake failed: %v", err),
+			Err:     err,
+		}
+	}
+
+	if err := authenticateIfNeeded(ctx, state, scanner); err != nil {
+		killOnError()
+		var agentErr *domain.AgentError
+		if ok := isAgentError(err, &agentErr); ok {
+			return domain.Session{}, agentErr
+		}
+		return domain.Session{}, &domain.AgentError{
+			Kind:    domain.ErrResponseError,
+			Message: fmt.Sprintf("authentication failed: %v", err),
+			Err:     err,
+		}
+	}
+
+	var threadID string
+	if params.ResumeSessionID != "" {
+		if err := resumeThread(ctx, state, scanner, params.ResumeSessionID); err != nil {
+			// Fallback to new thread on resume failure.
+			logger.Warn("thread resume failed, starting new thread",
+				slog.String("resume_id", params.ResumeSessionID),
+				slog.Any("error", err))
+			var tools []domain.AgentTool
+			if a.toolRegistry != nil {
+				tools = a.toolRegistry.List()
+			}
+			tid, startErr := startThread(ctx, state, scanner, a.passthrough, tools)
+			if startErr != nil {
+				killOnError()
+				return domain.Session{}, &domain.AgentError{
+					Kind:    domain.ErrResponseError,
+					Message: fmt.Sprintf("thread/start failed: %v", startErr),
+					Err:     startErr,
+				}
+			}
+			threadID = tid
+		} else {
+			threadID = params.ResumeSessionID
+		}
+	} else {
+		var tools []domain.AgentTool
+		if a.toolRegistry != nil {
+			tools = a.toolRegistry.List()
+		}
+		tid, startErr := startThread(ctx, state, scanner, a.passthrough, tools)
+		if startErr != nil {
+			killOnError()
+			return domain.Session{}, &domain.AgentError{
+				Kind:    domain.ErrResponseError,
+				Message: fmt.Sprintf("thread/start failed: %v", startErr),
+				Err:     startErr,
+			}
+		}
+		threadID = tid
+	}
+
+	state.threadID = threadID
+
+	return domain.Session{
+		ID:       threadID,
+		AgentPID: strconv.Itoa(cmd.Process.Pid),
+		Internal: state,
+	}, nil
+}
+
+// RunTurn sends a turn/start request on the existing thread and reads
+// events until turn/completed. Events are delivered synchronously via
+// params.OnEvent.
+func (a *CodexAdapter) RunTurn(ctx context.Context, session domain.Session, params domain.RunTurnParams) (domain.TurnResult, error) {
+	if params.OnEvent == nil {
+		panic("codex: OnEvent must be non-nil")
+	}
+
+	state, ok := session.Internal.(*sessionState)
+	if !ok {
+		return domain.TurnResult{}, &domain.AgentError{
+			Kind:    domain.ErrPortExit,
+			Message: fmt.Sprintf("unexpected session internal type %T", session.Internal),
+		}
+	}
+
+	logger := logging.WithSession(
+		slog.Default().With(slog.String("component", "codex-adapter")),
+		state.threadID,
+	)
+
+	state.turnCount++
+
+	// Build turn/start params.
+	turnParams := map[string]any{
+		"threadId": state.threadID,
+		"input":    []map[string]any{{"type": "text", "text": params.Prompt}},
+		"cwd":      state.workspacePath,
+	}
+
+	if state.turnCount == 1 || a.passthrough.TurnSandboxPolicy != nil {
+		turnParams["sandboxPolicy"] = buildSandboxPolicy(state, a.passthrough)
+	}
+	if a.passthrough.Model != "" {
+		turnParams["model"] = a.passthrough.Model
+	}
+	if a.passthrough.Effort != "" {
+		turnParams["effort"] = a.passthrough.Effort
+	}
+
+	id, err := sendRequest(state, "turn/start", turnParams)
+	if err != nil {
+		return domain.TurnResult{}, &domain.AgentError{
+			Kind:    domain.ErrPortExit,
+			Message: fmt.Sprintf("turn/start failed: %v", err),
+			Err:     err,
+		}
+	}
+
+	// Read the turn/start response synchronously before entering the
+	// event loop. The stdout pipe is not yet shared with the
+	// background reader.
+	scanner := bufio.NewScanner(state.stdout)
+	scanner.Buffer(make([]byte, 0, 1<<20), 1<<20)
+
+	turnStartResp, err := readResponse(ctx, scanner, id)
+	if err != nil {
+		return domain.TurnResult{}, &domain.AgentError{
+			Kind:    domain.ErrPortExit,
+			Message: fmt.Sprintf("turn/start response: %v", err),
+			Err:     err,
+		}
+	}
+	if turnStartResp.Error != nil {
+		return domain.TurnResult{
+				SessionID:  state.threadID,
+				ExitReason: domain.EventTurnFailed,
+			}, &domain.AgentError{
+				Kind:    domain.ErrTurnFailed,
+				Message: fmt.Sprintf("turn/start error: %s", turnStartResp.Error.Message),
+			}
+	}
+
+	var turnResult turnStartResult
+	if err := json.Unmarshal(turnStartResp.Result, &turnResult); err != nil {
+		logger.Warn("turn/start result unmarshal failed", slog.Any("error", err))
+	}
+	turnID := turnResult.Turn.ID
+
+	// Background reader goroutine: feeds parsed messages into a
+	// buffered channel so the event loop can select on ctx.Done()
+	// without blocking on a hung subprocess.
+	msgCh := make(chan parsedMessage, 16)
+	go func() {
+		defer close(msgCh)
+		for scanner.Scan() {
+			msg := parseMessage(scanner.Bytes())
+			msgCh <- msg
+		}
+		if err := scanner.Err(); err != nil {
+			msgCh <- parsedMessage{Err: err}
+		}
+	}()
+
+	inFlight := make(map[string]inFlightTool)
+	var usage domain.TokenUsage
+	interrupted := false
+
+	for {
+		select {
+		case <-ctx.Done():
+			if !interrupted {
+				interrupted = true
+				// Send turn/interrupt using a detached context so the
+				// request is not dropped by the already-cancelled
+				// parent context.
+				interruptCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+				state.mu.Lock()
+				sendRequest(state, "turn/interrupt", map[string]any{ //nolint:errcheck,gosec // best-effort interrupt
+					"threadId": state.threadID,
+					"turnId":   turnID,
+				})
+				state.mu.Unlock()
+				cancel()
+				_ = interruptCtx
+			}
+			// Continue reading until turn/completed or channel close.
+			continue
+
+		case msg, ok := <-msgCh:
+			if !ok {
+				// Channel closed — subprocess stdout ended.
+				return domain.TurnResult{
+						SessionID:  state.threadID,
+						ExitReason: domain.EventTurnFailed,
+						Usage:      usage,
+					}, &domain.AgentError{
+						Kind:    domain.ErrPortExit,
+						Message: "subprocess stdout closed unexpectedly",
+					}
+			}
+			if msg.Err != nil {
+				now := time.Now().UTC()
+				params.OnEvent(domain.AgentEvent{
+					Type:      domain.EventTurnFailed,
+					Timestamp: now,
+					Message:   msg.Err.Error(),
+				})
+				return domain.TurnResult{
+						SessionID:  state.threadID,
+						ExitReason: domain.EventTurnFailed,
+						Usage:      usage,
+					}, &domain.AgentError{
+						Kind:    domain.ErrPortExit,
+						Message: fmt.Sprintf("stdout read error: %v", msg.Err),
+						Err:     msg.Err,
+					}
+			}
+
+			// Response messages (echoed tool-call confirmations).
+			if msg.IsResponse && !msg.IsNotification {
+				continue
+			}
+
+			if !msg.IsNotification {
+				continue
+			}
+
+			now := time.Now().UTC()
+			method := msg.Notification.Method
+
+			switch method {
+			case "turn/started":
+				if state.turnCount == 1 {
+					params.OnEvent(domain.AgentEvent{
+						Type:      domain.EventSessionStarted,
+						Timestamp: now,
+						SessionID: state.threadID,
+						AgentPID:  session.AgentPID,
+						Message:   "session started",
+					})
+				} else {
+					params.OnEvent(domain.AgentEvent{
+						Type:      domain.EventNotification,
+						Timestamp: now,
+						Message:   "turn started",
+					})
+				}
+
+			case "turn/completed":
+				var tc turnCompletedParams
+				if err := json.Unmarshal(msg.Notification.Params, &tc); err != nil {
+					logger.Warn("turn/completed unmarshal failed", slog.Any("error", err))
+				}
+
+				if tc.Usage != nil {
+					usage = normalizeUsage(tc.Usage)
+				}
+				exitReason := mapTurnStatus(tc.Turn.Status)
+
+				if tc.Turn.Status == "failed" && tc.Turn.Error != nil {
+					kind := mapCodexErrorInfo(tc.Turn.Error.CodexErrorInfo)
+					errMsg := tc.Turn.Error.Message
+					params.OnEvent(domain.AgentEvent{
+						Type:      domain.EventTurnFailed,
+						Timestamp: now,
+						Message:   errMsg,
+					})
+					params.OnEvent(domain.AgentEvent{
+						Type:      domain.EventTokenUsage,
+						Timestamp: now,
+						Usage:     usage,
+					})
+					return domain.TurnResult{
+							SessionID:  state.threadID,
+							ExitReason: exitReason,
+							Usage:      usage,
+						}, &domain.AgentError{
+							Kind:    kind,
+							Message: errMsg,
+						}
+				}
+
+				params.OnEvent(domain.AgentEvent{
+					Type:      exitReason,
+					Timestamp: now,
+					Message:   "turn " + tc.Turn.Status,
+				})
+				params.OnEvent(domain.AgentEvent{
+					Type:      domain.EventTokenUsage,
+					Timestamp: now,
+					Usage:     usage,
+				})
+
+				return domain.TurnResult{
+					SessionID:  state.threadID,
+					ExitReason: exitReason,
+					Usage:      usage,
+				}, nil
+
+			case "item/started":
+				var ip itemParams
+				if err := json.Unmarshal(msg.Notification.Params, &ip); err != nil {
+					logger.Debug("item/started unmarshal failed", slog.Any("error", err))
+					continue
+				}
+				item := ip.Item
+				switch item.Type {
+				case "commandExecution", "fileChange", "mcpToolCall", "dynamicToolCall":
+					toolName := cmp.Or(item.Command, item.Type)
+					inFlight[item.ID] = inFlightTool{
+						Name:      toolName,
+						Timestamp: time.Now(),
+					}
+					params.OnEvent(domain.AgentEvent{
+						Type:      domain.EventNotification,
+						Timestamp: now,
+						Message:   summarizeItem(item.Type, item.ID),
+					})
+				default:
+					params.OnEvent(domain.AgentEvent{
+						Type:      domain.EventNotification,
+						Timestamp: now,
+						Message:   summarizeItem(item.Type, item.ID),
+					})
+				}
+
+			case "item/completed":
+				var ip itemParams
+				if err := json.Unmarshal(msg.Notification.Params, &ip); err != nil {
+					logger.Debug("item/completed unmarshal failed", slog.Any("error", err))
+					continue
+				}
+				item := ip.Item
+				if flight, exists := inFlight[item.ID]; exists {
+					dur := time.Since(flight.Timestamp).Milliseconds()
+					params.OnEvent(domain.AgentEvent{
+						Type:           domain.EventToolResult,
+						Timestamp:      now,
+						ToolName:       flight.Name,
+						ToolDurationMS: dur,
+					})
+					delete(inFlight, item.ID)
+				}
+				if item.Type == "agentMessage" && item.Text != "" {
+					params.OnEvent(domain.AgentEvent{
+						Type:      domain.EventNotification,
+						Timestamp: now,
+						Message:   truncate(item.Text, 200),
+					})
+				}
+
+			case "item/agentMessage/delta", "item/commandExecution/outputDelta":
+				params.OnEvent(domain.AgentEvent{
+					Type:      domain.EventNotification,
+					Timestamp: now,
+				})
+
+			case "item/tool/call":
+				a.handleToolCall(ctx, state, msg, params.OnEvent, logger)
+
+			case "turn/plan/updated":
+				params.OnEvent(domain.AgentEvent{
+					Type:      domain.EventNotification,
+					Timestamp: now,
+					Message:   "plan updated",
+				})
+
+			case "turn/diff/updated":
+				logger.Debug("diff updated")
+
+			default:
+				params.OnEvent(domain.AgentEvent{
+					Type:      domain.EventOtherMessage,
+					Timestamp: now,
+					Message:   method,
+				})
+			}
+		}
+	}
+}
+
+// handleToolCall dispatches a dynamic tool call from the app-server to
+// the ToolRegistry. The tool is executed asynchronously to avoid
+// blocking the event read loop.
+func (a *CodexAdapter) handleToolCall(ctx context.Context, state *sessionState, msg parsedMessage, onEvent func(domain.AgentEvent), logger *slog.Logger) {
+	now := time.Now().UTC()
+	requestID := msg.Response.ID
+
+	var tc toolCallParams
+	if err := json.Unmarshal(msg.Notification.Params, &tc); err != nil {
+		logger.Warn("item/tool/call unmarshal failed", slog.Any("error", err))
+		state.mu.Lock()
+		sendResponse(state, requestID, toolResultFor(false, "invalid tool call params")) //nolint:errcheck,gosec // best-effort error response
+		state.mu.Unlock()
+		return
+	}
+
+	toolName := tc.Tool
+
+	if a.toolRegistry == nil {
+		state.mu.Lock()
+		sendResponse(state, requestID, toolResultFor(false, fmt.Sprintf("unsupported tool: %s", toolName))) //nolint:errcheck,gosec // best-effort error response
+		state.mu.Unlock()
+		onEvent(domain.AgentEvent{
+			Type:      domain.EventUnsupportedToolCall,
+			Timestamp: now,
+			ToolName:  toolName,
+			Message:   fmt.Sprintf("no tool registry configured for tool %q", toolName),
+		})
+		return
+	}
+
+	tool, found := a.toolRegistry.Get(toolName)
+	if !found {
+		state.mu.Lock()
+		sendResponse(state, requestID, toolResultFor(false, fmt.Sprintf("unsupported tool: %s", toolName))) //nolint:errcheck,gosec // best-effort error response
+		state.mu.Unlock()
+		onEvent(domain.AgentEvent{
+			Type:      domain.EventUnsupportedToolCall,
+			Timestamp: now,
+			ToolName:  toolName,
+			Message:   fmt.Sprintf("tool %q not registered", toolName),
+		})
+		return
+	}
+
+	go func() {
+		start := time.Now()
+		result, execErr := tool.Execute(ctx, tc.Arguments)
+
+		state.mu.Lock()
+		defer state.mu.Unlock()
+
+		if execErr != nil {
+			sendResponse(state, requestID, toolResultFor(false, execErr.Error())) //nolint:errcheck,gosec // best-effort error response
+			onEvent(domain.AgentEvent{
+				Type:           domain.EventToolResult,
+				Timestamp:      time.Now().UTC(),
+				ToolName:       toolName,
+				ToolDurationMS: time.Since(start).Milliseconds(),
+				ToolError:      true,
+				Message:        execErr.Error(),
+			})
+			return
+		}
+
+		sendResponse(state, requestID, toolResultFor(true, string(result))) //nolint:errcheck,gosec // best-effort success response
+		onEvent(domain.AgentEvent{
+			Type:           domain.EventToolResult,
+			Timestamp:      time.Now().UTC(),
+			ToolName:       toolName,
+			ToolDurationMS: time.Since(start).Milliseconds(),
+		})
+	}()
+}
+
+// StopSession terminates the persistent app-server subprocess.
+func (a *CodexAdapter) StopSession(_ context.Context, session domain.Session) error {
+	state, ok := session.Internal.(*sessionState)
+	if !ok {
+		return fmt.Errorf("unexpected session internal type %T", session.Internal)
+	}
+
+	// Close stdin to signal EOF to the app-server.
+	state.mu.Lock()
+	if state.stdin != nil {
+		state.stdin.Close() //nolint:errcheck,gosec // best-effort cleanup
+	}
+	waitCh := state.waitCh
+	pid := 0
+	if state.proc != nil {
+		pid = state.proc.Pid
+	}
+	state.mu.Unlock()
+
+	if pid > 0 {
+		procutil.SignalGraceful(pid) //nolint:errcheck,gosec // best-effort graceful shutdown
+	}
+
+	// Wait for process exit with a 5-second grace period.
+	if waitCh != nil {
+		select {
+		case <-waitCh:
+		case <-time.After(5 * time.Second):
+			if pid > 0 {
+				procutil.KillProcessGroup(pid) //nolint:errcheck,gosec // best-effort force kill
+			}
+			// Wait again briefly for cleanup.
+			if waitCh != nil {
+				select {
+				case <-waitCh:
+				case <-time.After(2 * time.Second):
+				}
+			}
+		}
+	}
+
+	state.mu.Lock()
+	state.proc = nil
+	state.stdin = nil
+	state.stdout = nil
+	state.waitCh = nil
+	state.mu.Unlock()
+
+	return nil
+}
+
+// EventStream returns nil. The Codex adapter delivers events
+// synchronously via [CodexAdapter.RunTurn]'s OnEvent callback.
+func (a *CodexAdapter) EventStream() <-chan domain.AgentEvent { return nil }
+
+// isAgentError extracts an *[domain.AgentError] from err using type
+// assertion.
+func isAgentError(err error, target **domain.AgentError) bool {
+	ae, ok := err.(*domain.AgentError) //nolint:errorlint // direct type check is intentional
+	if ok {
+		*target = ae
+		return true
+	}
+	return false
+}

--- a/internal/agent/codex/codex_test.go
+++ b/internal/agent/codex/codex_test.go
@@ -1,0 +1,190 @@
+//go:build unix
+
+package codex
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/sortie-ai/sortie/internal/domain"
+	"github.com/sortie-ai/sortie/internal/registry"
+)
+
+// Compile-time interface satisfaction check.
+var _ domain.AgentAdapter = (*CodexAdapter)(nil)
+
+// requireAgentError asserts err is a *domain.AgentError with the given Kind.
+func requireAgentError(t *testing.T, err error, wantKind domain.AgentErrorKind) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("expected error with kind %q, got nil", wantKind)
+	}
+	var ae *domain.AgentError
+	if !errors.As(err, &ae) {
+		t.Fatalf("error type = %T, want *domain.AgentError", err)
+	}
+	if ae.Kind != wantKind {
+		t.Errorf("AgentError.Kind = %q, want %q", ae.Kind, wantKind)
+	}
+}
+
+func TestNewCodexAdapter(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil config returns adapter", func(t *testing.T) {
+		t.Parallel()
+		adapter, err := NewCodexAdapter(nil)
+		if err != nil {
+			t.Fatalf("NewCodexAdapter(nil) error = %v", err)
+		}
+		if adapter == nil {
+			t.Fatal("adapter is nil")
+		}
+	})
+
+	t.Run("empty config returns adapter", func(t *testing.T) {
+		t.Parallel()
+		adapter, err := NewCodexAdapter(map[string]any{})
+		if err != nil {
+			t.Fatalf("NewCodexAdapter(empty) error = %v", err)
+		}
+		if adapter == nil {
+			t.Fatal("adapter is nil")
+		}
+	})
+
+	t.Run("all passthrough fields stored", func(t *testing.T) {
+		t.Parallel()
+		adapter, err := NewCodexAdapter(map[string]any{
+			"model":           "o4-mini",
+			"effort":          "high",
+			"approval_policy": "never",
+			"thread_sandbox":  "workspaceWrite",
+			"personality":     "helpful",
+		})
+		if err != nil {
+			t.Fatalf("NewCodexAdapter() error = %v", err)
+		}
+		a := adapter.(*CodexAdapter)
+		if a.passthrough.Model != "o4-mini" {
+			t.Errorf("passthrough.Model = %q, want %q", a.passthrough.Model, "o4-mini")
+		}
+		if a.passthrough.Effort != "high" {
+			t.Errorf("passthrough.Effort = %q, want %q", a.passthrough.Effort, "high")
+		}
+		if a.passthrough.ApprovalPolicy != "never" {
+			t.Errorf("passthrough.ApprovalPolicy = %q, want %q", a.passthrough.ApprovalPolicy, "never")
+		}
+		if a.passthrough.ThreadSandbox != "workspaceWrite" {
+			t.Errorf("passthrough.ThreadSandbox = %q, want %q", a.passthrough.ThreadSandbox, "workspaceWrite")
+		}
+		if a.passthrough.Personality != "helpful" {
+			t.Errorf("passthrough.Personality = %q, want %q", a.passthrough.Personality, "helpful")
+		}
+	})
+
+	t.Run("tool_registry stored when provided", func(t *testing.T) {
+		t.Parallel()
+		reg := domain.NewToolRegistry()
+		adapter, err := NewCodexAdapter(map[string]any{
+			"tool_registry": reg,
+		})
+		if err != nil {
+			t.Fatalf("NewCodexAdapter() error = %v", err)
+		}
+		a := adapter.(*CodexAdapter)
+		if a.toolRegistry != reg {
+			t.Error("toolRegistry not stored on adapter")
+		}
+	})
+
+	t.Run("non-registry tool_registry value is ignored", func(t *testing.T) {
+		t.Parallel()
+		adapter, err := NewCodexAdapter(map[string]any{
+			"tool_registry": "not-a-registry",
+		})
+		if err != nil {
+			t.Fatalf("NewCodexAdapter() error = %v", err)
+		}
+		a := adapter.(*CodexAdapter)
+		if a.toolRegistry != nil {
+			t.Error("toolRegistry should be nil for invalid type")
+		}
+	})
+}
+
+func TestEventStream(t *testing.T) {
+	t.Parallel()
+
+	adapter, err := NewCodexAdapter(map[string]any{})
+	if err != nil {
+		t.Fatalf("NewCodexAdapter() error = %v", err)
+	}
+	if ch := adapter.EventStream(); ch != nil {
+		t.Errorf("EventStream() = %v, want nil", ch)
+	}
+}
+
+func TestRegistration(t *testing.T) {
+	t.Parallel()
+
+	factory, err := registry.Agents.Get("codex")
+	if err != nil {
+		t.Fatalf(`registry.Agents.Get("codex") error = %v`, err)
+	}
+	adapter, err := factory(map[string]any{})
+	if err != nil {
+		t.Fatalf("factory() error = %v", err)
+	}
+	if _, ok := adapter.(*CodexAdapter); !ok {
+		t.Errorf("factory() type = %T, want *CodexAdapter", adapter)
+	}
+}
+
+func TestStartSession_EmptyWorkspace(t *testing.T) {
+	t.Parallel()
+
+	adapter, _ := NewCodexAdapter(map[string]any{})
+	_, err := adapter.StartSession(context.Background(), domain.StartSessionParams{})
+	requireAgentError(t, err, domain.ErrInvalidWorkspaceCwd)
+}
+
+func TestStartSession_NonexistentPath(t *testing.T) {
+	t.Parallel()
+
+	adapter, _ := NewCodexAdapter(map[string]any{})
+	_, err := adapter.StartSession(context.Background(), domain.StartSessionParams{
+		WorkspacePath: "/nonexistent/path/that/does/not/exist/codex-test",
+		AgentConfig:   domain.AgentConfig{Command: "codex app-server"},
+	})
+	requireAgentError(t, err, domain.ErrInvalidWorkspaceCwd)
+}
+
+func TestStartSession_WorkspaceIsFile(t *testing.T) {
+	t.Parallel()
+
+	tmpFile := filepath.Join(t.TempDir(), "notadir")
+	if err := os.WriteFile(tmpFile, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	adapter, _ := NewCodexAdapter(map[string]any{})
+	_, err := adapter.StartSession(context.Background(), domain.StartSessionParams{
+		WorkspacePath: tmpFile,
+		AgentConfig:   domain.AgentConfig{Command: "codex app-server"},
+	})
+	requireAgentError(t, err, domain.ErrInvalidWorkspaceCwd)
+}
+
+func TestStartSession_BinaryNotFound(t *testing.T) {
+	t.Parallel()
+
+	adapter, _ := NewCodexAdapter(map[string]any{})
+	_, err := adapter.StartSession(context.Background(), domain.StartSessionParams{
+		WorkspacePath: t.TempDir(),
+		AgentConfig:   domain.AgentConfig{Command: "sortie-nonexistent-codex-binary-99999"},
+	})
+	requireAgentError(t, err, domain.ErrAgentNotFound)
+}

--- a/internal/agent/codex/command.go
+++ b/internal/agent/codex/command.go
@@ -1,0 +1,64 @@
+package codex
+
+// passthroughConfig holds Codex-specific settings extracted from the
+// "codex" sub-object in WORKFLOW.md. All fields are optional with
+// zero-value meaning "not configured."
+type passthroughConfig struct {
+	Model             string
+	Effort            string
+	ApprovalPolicy    string
+	ThreadSandbox     string
+	TurnSandboxPolicy map[string]any
+	Personality       string
+	SkipGitRepoCheck  bool
+}
+
+// parsePassthroughConfig extracts Codex-specific settings from the
+// raw config map. Missing or wrong-typed keys use zero-value defaults.
+func parsePassthroughConfig(config map[string]any) passthroughConfig {
+	return passthroughConfig{
+		Model:             stringFrom(config, "model"),
+		Effort:            stringFrom(config, "effort"),
+		ApprovalPolicy:    stringFrom(config, "approval_policy"),
+		ThreadSandbox:     stringFrom(config, "thread_sandbox"),
+		TurnSandboxPolicy: mapFrom(config, "turn_sandbox_policy"),
+		Personality:       stringFrom(config, "personality"),
+		SkipGitRepoCheck:  boolFrom(config, "skip_git_repo_check", false),
+	}
+}
+
+func stringFrom(m map[string]any, key string) string {
+	v, ok := m[key]
+	if !ok {
+		return ""
+	}
+	s, ok := v.(string)
+	if !ok {
+		return ""
+	}
+	return s
+}
+
+func boolFrom(m map[string]any, key string, def bool) bool {
+	v, ok := m[key]
+	if !ok {
+		return def
+	}
+	b, ok := v.(bool)
+	if !ok {
+		return def
+	}
+	return b
+}
+
+func mapFrom(m map[string]any, key string) map[string]any {
+	v, ok := m[key]
+	if !ok {
+		return nil
+	}
+	sub, ok := v.(map[string]any)
+	if !ok {
+		return nil
+	}
+	return sub
+}

--- a/internal/agent/codex/handshake_test.go
+++ b/internal/agent/codex/handshake_test.go
@@ -1,0 +1,299 @@
+//go:build unix
+
+package codex
+
+import (
+	"bufio"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/sortie-ai/sortie/internal/domain"
+)
+
+// handshakeState returns a sessionState suitable for handshake function tests.
+// It has a valid workspacePath and a discarding stdin.
+func handshakeState() *sessionState {
+	return &sessionState{
+		workspacePath: "/tmp",
+		stdin:         nopWriteCloser{},
+	}
+}
+
+// handshakeScanner returns a *bufio.Scanner reading from fixture JSONL lines.
+func handshakeScanner(lines ...string) *bufio.Scanner {
+	fixture := strings.Join(lines, "\n") + "\n"
+	scanner := bufio.NewScanner(strings.NewReader(fixture))
+	scanner.Buffer(make([]byte, 0, 1<<20), 1<<20)
+	return scanner
+}
+
+// --- initializeHandshake ---
+
+func TestInitializeHandshake_Success(t *testing.T) {
+	t.Parallel()
+
+	state := handshakeState()
+	scanner := handshakeScanner(`{"id":1,"result":{"protocolVersion":"2025-03-26","serverInfo":{"name":"codex-app-server"}}}`)
+
+	if err := initializeHandshake(context.Background(), state, scanner); err != nil {
+		t.Fatalf("initializeHandshake() error = %v", err)
+	}
+}
+
+func TestInitializeHandshake_ErrorResponse(t *testing.T) {
+	t.Parallel()
+
+	state := handshakeState()
+	scanner := handshakeScanner(`{"id":1,"error":{"code":-32600,"message":"invalid request"}}`)
+
+	err := initializeHandshake(context.Background(), state, scanner)
+	if err == nil {
+		t.Fatal("initializeHandshake() expected error for error response, got nil")
+	}
+	if !strings.Contains(err.Error(), "initialize error") {
+		t.Errorf("initializeHandshake() error = %q, want 'initialize error'", err.Error())
+	}
+}
+
+func TestInitializeHandshake_EOF(t *testing.T) {
+	t.Parallel()
+
+	state := handshakeState()
+	scanner := handshakeScanner() // empty fixture
+
+	err := initializeHandshake(context.Background(), state, scanner)
+	if err == nil {
+		t.Fatal("initializeHandshake() expected error on EOF, got nil")
+	}
+}
+
+// --- authenticateIfNeeded ---
+
+func TestAuthenticateIfNeeded_AlreadyLoggedIn(t *testing.T) {
+	t.Parallel()
+
+	state := handshakeState()
+	// account/read response with non-null account
+	scanner := handshakeScanner(`{"id":1,"result":{"account":{"id":"user-1","email":"user@example.com"}}}`)
+
+	if err := authenticateIfNeeded(context.Background(), state, scanner); err != nil {
+		t.Fatalf("authenticateIfNeeded() error = %v, want nil for logged-in account", err)
+	}
+}
+
+func TestAuthenticateIfNeeded_NullAccountNoAPIKey(t *testing.T) {
+	t.Parallel()
+
+	state := handshakeState()
+	// account/read response with null account — CODEX_API_KEY not set → return nil
+	scanner := handshakeScanner(`{"id":1,"result":{"account":null}}`)
+
+	if err := authenticateIfNeeded(context.Background(), state, scanner); err != nil {
+		t.Fatalf("authenticateIfNeeded() error = %v, want nil when API key absent", err)
+	}
+}
+
+func TestAuthenticateIfNeeded_AccountReadError(t *testing.T) {
+	t.Parallel()
+
+	state := handshakeState()
+	scanner := handshakeScanner(`{"id":1,"error":{"code":-32000,"message":"server error"}}`)
+
+	err := authenticateIfNeeded(context.Background(), state, scanner)
+	if err == nil {
+		t.Fatal("authenticateIfNeeded() expected error for account/read error response")
+	}
+}
+
+func TestAuthenticateIfNeeded_LoginSuccess(t *testing.T) {
+	// No t.Parallel() — uses t.Setenv.
+	t.Setenv("CODEX_API_KEY", "test-api-key-12345")
+
+	state := handshakeState()
+	// id=1: account/read → null account
+	// id=2: account/login/start → success response
+	// then: login/completed notification
+	scanner := handshakeScanner(
+		`{"id":1,"result":{"account":null}}`,
+		`{"id":2,"result":{}}`,
+		`{"method":"account/login/completed","params":{"success":true}}`,
+	)
+
+	if err := authenticateIfNeeded(context.Background(), state, scanner); err != nil {
+		t.Fatalf("authenticateIfNeeded() error = %v, want nil on successful login", err)
+	}
+}
+
+func TestAuthenticateIfNeeded_LoginResponseError(t *testing.T) {
+	// No t.Parallel() — uses t.Setenv.
+	t.Setenv("CODEX_API_KEY", "invalid-key")
+
+	state := handshakeState()
+	// id=1: account/read → null
+	// id=2: account/login/start → error
+	scanner := handshakeScanner(
+		`{"id":1,"result":{"account":null}}`,
+		`{"id":2,"error":{"code":-32001,"message":"invalid API key"}}`,
+	)
+
+	err := authenticateIfNeeded(context.Background(), state, scanner)
+	if err == nil {
+		t.Fatal("authenticateIfNeeded() expected error for login failure")
+	}
+}
+
+func TestAuthenticateIfNeeded_LoginCompletedFailed(t *testing.T) {
+	// No t.Parallel() — uses t.Setenv.
+	t.Setenv("CODEX_API_KEY", "bad-key")
+
+	state := handshakeState()
+	scanner := handshakeScanner(
+		`{"id":1,"result":{"account":null}}`,
+		`{"id":2,"result":{}}`,
+		`{"method":"account/login/completed","params":{"success":false}}`,
+	)
+
+	err := authenticateIfNeeded(context.Background(), state, scanner)
+	if err == nil {
+		t.Fatal("authenticateIfNeeded() expected error for failed login completion")
+	}
+	var ae *domain.AgentError
+	if !requireErrAs(err, &ae) {
+		t.Fatalf("error type = %T, want *domain.AgentError", err)
+	}
+	if ae.Kind != domain.ErrResponseError {
+		t.Errorf("AgentError.Kind = %q, want %q", ae.Kind, domain.ErrResponseError)
+	}
+}
+
+// requireErrAs is a non-fatal helper for type assertions in table-driven code.
+func requireErrAs[T any](err error, target *T) bool {
+	if err == nil {
+		return false
+	}
+	switch e := err.(type) {
+	case T:
+		*target = e
+		return true
+	default:
+		_ = e
+		return false
+	}
+}
+
+// --- startThread ---
+
+func TestStartThread_Success(t *testing.T) {
+	t.Parallel()
+
+	state := handshakeState()
+	scanner := handshakeScanner(
+		`{"id":1,"result":{"thread":{"id":"thread-abc"}}}`,
+		`{"method":"thread/started","params":{"threadId":"thread-abc"}}`,
+	)
+
+	threadID, err := startThread(context.Background(), state, scanner, passthroughConfig{}, nil)
+	if err != nil {
+		t.Fatalf("startThread() error = %v", err)
+	}
+	if threadID != "thread-abc" {
+		t.Errorf("startThread() threadID = %q, want %q", threadID, "thread-abc")
+	}
+}
+
+func TestStartThread_WithModelAndPersonality(t *testing.T) {
+	t.Parallel()
+
+	state := handshakeState()
+	scanner := handshakeScanner(
+		`{"id":1,"result":{"thread":{"id":"thread-xyz"}}}`,
+		`{"method":"thread/started","params":{}}`,
+	)
+	pt := passthroughConfig{
+		Model:          "o4-mini",
+		Personality:    "concise",
+		ApprovalPolicy: "auto",
+		ThreadSandbox:  "workspaceWrite",
+	}
+
+	threadID, err := startThread(context.Background(), state, scanner, pt, nil)
+	if err != nil {
+		t.Fatalf("startThread() error = %v", err)
+	}
+	if threadID != "thread-xyz" {
+		t.Errorf("startThread() threadID = %q, want %q", threadID, "thread-xyz")
+	}
+}
+
+func TestStartThread_WithTools(t *testing.T) {
+	t.Parallel()
+
+	state := handshakeState()
+	scanner := handshakeScanner(
+		`{"id":1,"result":{"thread":{"id":"thread-tools"}}}`,
+		`{"method":"thread/started","params":{}}`,
+	)
+	tools := []domain.AgentTool{
+		&fakeTool{name: "list_issues", result: nil},
+		&fakeTool{name: "create_issue", result: nil},
+	}
+
+	threadID, err := startThread(context.Background(), state, scanner, passthroughConfig{}, tools)
+	if err != nil {
+		t.Fatalf("startThread() error = %v", err)
+	}
+	if threadID != "thread-tools" {
+		t.Errorf("startThread() threadID = %q, want %q", threadID, "thread-tools")
+	}
+}
+
+func TestStartThread_ErrorResponse(t *testing.T) {
+	t.Parallel()
+
+	state := handshakeState()
+	scanner := handshakeScanner(`{"id":1,"error":{"code":-32000,"message":"workspace not found"}}`)
+
+	_, err := startThread(context.Background(), state, scanner, passthroughConfig{}, nil)
+	if err == nil {
+		t.Fatal("startThread() expected error for error response")
+	}
+}
+
+func TestStartThread_EmptyThreadID(t *testing.T) {
+	t.Parallel()
+
+	state := handshakeState()
+	// Response with empty thread ID.
+	scanner := handshakeScanner(`{"id":1,"result":{"thread":{"id":""}}}`)
+
+	_, err := startThread(context.Background(), state, scanner, passthroughConfig{}, nil)
+	if err == nil {
+		t.Fatal("startThread() expected error for empty thread ID")
+	}
+}
+
+// --- resumeThread ---
+
+func TestResumeThread_Success(t *testing.T) {
+	t.Parallel()
+
+	state := handshakeState()
+	scanner := handshakeScanner(`{"id":1,"result":{}}`)
+
+	if err := resumeThread(context.Background(), state, scanner, "existing-thread-id"); err != nil {
+		t.Fatalf("resumeThread() error = %v", err)
+	}
+}
+
+func TestResumeThread_ErrorResponse(t *testing.T) {
+	t.Parallel()
+
+	state := handshakeState()
+	scanner := handshakeScanner(`{"id":1,"error":{"code":-32002,"message":"thread not found"}}`)
+
+	err := resumeThread(context.Background(), state, scanner, "nonexistent-thread")
+	if err == nil {
+		t.Fatal("resumeThread() expected error for error response")
+	}
+}

--- a/internal/agent/codex/integration_test.go
+++ b/internal/agent/codex/integration_test.go
@@ -1,0 +1,128 @@
+// Integration tests for the Codex CLI agent adapter.
+//
+// Required environment variables:
+//
+//	SORTIE_CODEX_TEST=1     enable this suite
+//	CODEX_API_KEY           Codex API key for authentication
+//
+// Run:
+//
+//	SORTIE_CODEX_TEST=1 CODEX_API_KEY=... make test PKG=./internal/agent/codex/... RUN=Integration
+package codex
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/sortie-ai/sortie/internal/domain"
+)
+
+// skipUnlessCodexIntegration skips the current test when SORTIE_CODEX_TEST
+// is not set to "1", so disabled integration tests are reported as skipped
+// rather than silently passing.
+func skipUnlessCodexIntegration(t *testing.T) {
+	t.Helper()
+	if os.Getenv("SORTIE_CODEX_TEST") != "1" {
+		t.Skip("skipping Codex integration test: set SORTIE_CODEX_TEST=1 to enable")
+	}
+	if os.Getenv("CODEX_API_KEY") == "" {
+		t.Skip("skipping Codex integration test: CODEX_API_KEY must be set")
+	}
+}
+
+// integrationCommand returns the Codex CLI binary command from the
+// SORTIE_CODEX_COMMAND environment variable, defaulting to "codex app-server".
+func integrationCommand() string {
+	if cmd := os.Getenv("SORTIE_CODEX_COMMAND"); cmd != "" {
+		return cmd
+	}
+	return "codex app-server"
+}
+
+// assertContainsEventType asserts that at least one event in the slice
+// has the given type.
+func assertContainsEventType(t *testing.T, events []domain.AgentEvent, eventType domain.AgentEventType) {
+	t.Helper()
+	for _, e := range events {
+		if e.Type == eventType {
+			return
+		}
+	}
+	types := make([]domain.AgentEventType, len(events))
+	for i, e := range events {
+		types[i] = e.Type
+	}
+	t.Errorf("expected event type %q not found; got types: %v", eventType, types)
+}
+
+func TestCodexAdapter_Integration(t *testing.T) {
+	skipUnlessCodexIntegration(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	// Create a temp directory with git init for the workspace.
+	dir := t.TempDir()
+	gitCmd := exec.CommandContext(ctx, "git", "-C", dir, "init")
+	if out, err := gitCmd.CombinedOutput(); err != nil {
+		t.Fatalf("git init: %v\n%s", err, out)
+	}
+
+	adapter, err := NewCodexAdapter(map[string]any{})
+	if err != nil {
+		t.Fatalf("NewCodexAdapter() error = %v", err)
+	}
+
+	session, err := adapter.StartSession(ctx, domain.StartSessionParams{
+		WorkspacePath: dir,
+		AgentConfig: domain.AgentConfig{
+			Command:       integrationCommand(),
+			TurnTimeoutMS: 60000,
+			ReadTimeoutMS: 30000,
+		},
+	})
+	if err != nil {
+		t.Fatalf("StartSession() error = %v", err)
+	}
+
+	if session.ID == "" {
+		t.Error("session.ID is empty")
+	}
+
+	var (
+		mu     sync.Mutex
+		events []domain.AgentEvent
+	)
+
+	result, runErr := adapter.RunTurn(ctx, session, domain.RunTurnParams{
+		Prompt: "Say hello in exactly one word. Do not write any code.",
+		OnEvent: func(ev domain.AgentEvent) {
+			mu.Lock()
+			events = append(events, ev)
+			mu.Unlock()
+		},
+	})
+
+	if runErr != nil {
+		t.Logf("RunTurn() error = %v (non-fatal: recording for diagnostics)", runErr)
+	}
+
+	if result.SessionID != session.ID {
+		t.Errorf("TurnResult.SessionID = %q, want %q", result.SessionID, session.ID)
+	}
+
+	mu.Lock()
+	capturedEvents := append([]domain.AgentEvent(nil), events...)
+	mu.Unlock()
+
+	t.Logf("received %d events, exit reason: %q", len(capturedEvents), result.ExitReason)
+	assertContainsEventType(t, capturedEvents, domain.EventSessionStarted)
+
+	if stopErr := adapter.StopSession(ctx, session); stopErr != nil {
+		t.Errorf("StopSession() error = %v", stopErr)
+	}
+}

--- a/internal/agent/codex/parse.go
+++ b/internal/agent/codex/parse.go
@@ -1,0 +1,247 @@
+package codex
+
+import (
+	"encoding/json"
+	"fmt"
+	"unicode/utf8"
+
+	"github.com/sortie-ai/sortie/internal/domain"
+)
+
+// rpcRequest is a JSON-RPC 2.0 request sent to the app-server.
+type rpcRequest struct {
+	Method string `json:"method"`
+	ID     int64  `json:"id,omitempty"`
+	Params any    `json:"params,omitempty"`
+}
+
+// rpcResponse is a JSON-RPC 2.0 response from the app-server.
+type rpcResponse struct {
+	ID     int64           `json:"id"`
+	Result json.RawMessage `json:"result,omitempty"`
+	Error  *rpcError       `json:"error,omitempty"`
+}
+
+// rpcNotification is a server-initiated notification (no id field).
+type rpcNotification struct {
+	Method string          `json:"method"`
+	Params json.RawMessage `json:"params,omitempty"`
+}
+
+// rpcError is a JSON-RPC error object.
+type rpcError struct {
+	Code    int             `json:"code"`
+	Message string          `json:"message"`
+	Data    json.RawMessage `json:"data,omitempty"`
+}
+
+// parsedMessage is the result of parsing a single JSONL line from the
+// app-server. Exactly one of IsResponse or IsNotification is true when
+// Err is nil.
+type parsedMessage struct {
+	IsResponse     bool
+	IsNotification bool
+	Response       rpcResponse
+	Notification   rpcNotification
+	Err            error
+}
+
+// turnUsage holds raw token usage fields from the app-server
+// turn/completed notification.
+type turnUsage struct {
+	InputTokens       int64 `json:"input_tokens"`
+	OutputTokens      int64 `json:"output_tokens"`
+	CachedInputTokens int64 `json:"cached_input_tokens"`
+}
+
+// turnCompletedParams is the params payload of a turn/completed
+// notification.
+type turnCompletedParams struct {
+	Turn struct {
+		ID     string     `json:"id"`
+		Status string     `json:"status"`
+		Error  *turnError `json:"error,omitempty"`
+	} `json:"turn"`
+	Usage *turnUsage `json:"usage,omitempty"`
+}
+
+// turnError is the error object inside a failed turn/completed
+// notification.
+type turnError struct {
+	Message        string `json:"message"`
+	CodexErrorInfo string `json:"codexErrorInfo,omitempty"`
+}
+
+// itemParams is the params payload of item/started and item/completed
+// notifications.
+type itemParams struct {
+	Item struct {
+		ID      string `json:"id"`
+		Type    string `json:"type"`
+		Text    string `json:"text,omitempty"`
+		Command string `json:"command,omitempty"`
+		Status  string `json:"status,omitempty"`
+	} `json:"item"`
+}
+
+// toolCallParams is the params payload of an item/tool/call request.
+type toolCallParams struct {
+	Tool      string          `json:"tool"`
+	Arguments json.RawMessage `json:"arguments"`
+}
+
+// threadResult is the subset of thread/start or thread/resume
+// response used by the adapter.
+type threadResult struct {
+	Thread struct {
+		ID string `json:"id"`
+	} `json:"thread"`
+}
+
+// turnStartResult is the subset of turn/start response used by the
+// adapter.
+type turnStartResult struct {
+	Turn struct {
+		ID     string `json:"id"`
+		Status string `json:"status"`
+	} `json:"turn"`
+}
+
+// accountResult is the subset of account/read response used by the
+// adapter.
+type accountResult struct {
+	Account json.RawMessage `json:"account"`
+}
+
+// accountLoginNotification is the params payload of an
+// account/login/completed notification.
+type accountLoginNotification struct {
+	Success bool `json:"success"`
+}
+
+// wireMessage is used for initial discrimination of JSON-RPC messages.
+// A message with a non-zero ID and no Method is a response; a message
+// with a Method is a request or notification.
+type wireMessage struct {
+	ID     int64           `json:"id"`
+	Method string          `json:"method,omitempty"`
+	Params json.RawMessage `json:"params,omitempty"`
+	Result json.RawMessage `json:"result,omitempty"`
+	Error  *rpcError       `json:"error,omitempty"`
+}
+
+// parseMessage parses a single JSONL line from the app-server stdout.
+// It discriminates between responses (non-zero id, no method) and
+// notifications (method present, zero or absent id).
+func parseMessage(line []byte) parsedMessage {
+	var wire wireMessage
+	if err := json.Unmarshal(line, &wire); err != nil {
+		return parsedMessage{Err: fmt.Errorf("parse message: %w", err)}
+	}
+
+	// Responses have a non-zero id and no method field. Notifications
+	// and requests have a method field. When both are present (a
+	// request from the server such as item/tool/call), treat it as a
+	// notification so the event loop dispatches on Method.
+	if wire.Method != "" {
+		return parsedMessage{
+			IsNotification: true,
+			Notification: rpcNotification{
+				Method: wire.Method,
+				Params: wire.Params,
+			},
+			// Preserve the request ID for item/tool/call responses.
+			Response: rpcResponse{ID: wire.ID},
+		}
+	}
+	if wire.ID != 0 {
+		return parsedMessage{
+			IsResponse: true,
+			Response: rpcResponse{
+				ID:     wire.ID,
+				Result: wire.Result,
+				Error:  wire.Error,
+			},
+		}
+	}
+
+	return parsedMessage{Err: fmt.Errorf("parse message: no method or id in JSON-RPC message")}
+}
+
+// normalizeUsage converts raw app-server token usage into a
+// [domain.TokenUsage]. TotalTokens is computed as input + output.
+// CacheReadTokens is set from CachedInputTokens.
+func normalizeUsage(u *turnUsage) domain.TokenUsage {
+	if u == nil {
+		return domain.TokenUsage{}
+	}
+	return domain.TokenUsage{
+		InputTokens:     u.InputTokens,
+		OutputTokens:    u.OutputTokens,
+		TotalTokens:     u.InputTokens + u.OutputTokens,
+		CacheReadTokens: u.CachedInputTokens,
+	}
+}
+
+// mapTurnStatus maps a turn/completed status string to a domain event
+// type.
+func mapTurnStatus(status string) domain.AgentEventType {
+	switch status {
+	case "completed":
+		return domain.EventTurnCompleted
+	case "interrupted":
+		return domain.EventTurnCancelled
+	case "failed":
+		return domain.EventTurnFailed
+	default:
+		return domain.EventTurnFailed
+	}
+}
+
+// mapCodexErrorInfo maps a codexErrorInfo string to a domain error
+// kind. Retryable vs non-retryable classification is encoded in the
+// AgentErrorKind value.
+func mapCodexErrorInfo(info string) domain.AgentErrorKind {
+	switch info {
+	case "Unauthorized":
+		return domain.ErrResponseError
+	case "BadRequest":
+		return domain.ErrResponseError
+	case "ContextWindowExceeded", "UsageLimitExceeded", "SandboxError":
+		return domain.ErrTurnFailed
+	case "HttpConnectionFailed", "ResponseStreamConnectionFailed",
+		"ResponseStreamDisconnected", "ResponseTooManyFailedAttempts",
+		"InternalServerError", "Other":
+		return domain.ErrTurnFailed
+	default:
+		return domain.ErrTurnFailed
+	}
+}
+
+// summarizeItem returns a short human-readable string for an item
+// event. Truncated to 200 characters.
+func summarizeItem(itemType, itemID string) string {
+	s := fmt.Sprintf("[%s] %s", itemType, itemID)
+	return truncate(s, 200)
+}
+
+// toolResultFor constructs the JSON-RPC result payload for a dynamic
+// tool call response.
+func toolResultFor(success bool, output string) map[string]any {
+	return map[string]any{
+		"success": success,
+		"output":  output,
+		"contentItems": []map[string]any{
+			{"type": "inputText", "text": output},
+		},
+	}
+}
+
+// truncate shortens s to maxLen runes if it exceeds that length.
+func truncate(s string, maxLen int) string {
+	if utf8.RuneCountInString(s) <= maxLen {
+		return s
+	}
+	runes := []rune(s)
+	return string(runes[:maxLen])
+}

--- a/internal/agent/codex/parse_test.go
+++ b/internal/agent/codex/parse_test.go
@@ -1,0 +1,523 @@
+package codex
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/sortie-ai/sortie/internal/domain"
+)
+
+// stubTool is a minimal [domain.AgentTool] implementation for testing
+// buildDynamicTools.
+type stubTool struct {
+	name        string
+	description string
+	schema      json.RawMessage
+}
+
+func (s *stubTool) Name() string                 { return s.name }
+func (s *stubTool) Description() string          { return s.description }
+func (s *stubTool) InputSchema() json.RawMessage { return s.schema }
+func (s *stubTool) Execute(_ context.Context, _ json.RawMessage) (json.RawMessage, error) {
+	return nil, nil
+}
+
+func TestParsePassthroughConfig(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		config map[string]any
+		want   passthroughConfig
+	}{
+		{
+			name:   "nil config returns zero values",
+			config: nil,
+			want:   passthroughConfig{},
+		},
+		{
+			name:   "empty config returns zero values",
+			config: map[string]any{},
+			want:   passthroughConfig{},
+		},
+		{
+			name: "all fields present",
+			config: map[string]any{
+				"model":               "o4-mini",
+				"effort":              "high",
+				"approval_policy":     "never",
+				"thread_sandbox":      "workspaceWrite",
+				"personality":         "helpful",
+				"skip_git_repo_check": true,
+				"turn_sandbox_policy": map[string]any{"networkAccess": true},
+			},
+			want: passthroughConfig{
+				Model:             "o4-mini",
+				Effort:            "high",
+				ApprovalPolicy:    "never",
+				ThreadSandbox:     "workspaceWrite",
+				Personality:       "helpful",
+				SkipGitRepoCheck:  true,
+				TurnSandboxPolicy: map[string]any{"networkAccess": true},
+			},
+		},
+		{
+			name: "wrong types use zero-value defaults",
+			config: map[string]any{
+				"model":               42,
+				"effort":              false,
+				"approval_policy":     123,
+				"thread_sandbox":      []string{"not-a-string"},
+				"skip_git_repo_check": "yes",
+				"turn_sandbox_policy": "not-a-map",
+			},
+			want: passthroughConfig{},
+		},
+		{
+			name: "explicit false skip_git_repo_check",
+			config: map[string]any{
+				"skip_git_repo_check": false,
+			},
+			want: passthroughConfig{SkipGitRepoCheck: false},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := parsePassthroughConfig(tt.config)
+			if got.Model != tt.want.Model {
+				t.Errorf("Model = %q, want %q", got.Model, tt.want.Model)
+			}
+			if got.Effort != tt.want.Effort {
+				t.Errorf("Effort = %q, want %q", got.Effort, tt.want.Effort)
+			}
+			if got.ApprovalPolicy != tt.want.ApprovalPolicy {
+				t.Errorf("ApprovalPolicy = %q, want %q", got.ApprovalPolicy, tt.want.ApprovalPolicy)
+			}
+			if got.ThreadSandbox != tt.want.ThreadSandbox {
+				t.Errorf("ThreadSandbox = %q, want %q", got.ThreadSandbox, tt.want.ThreadSandbox)
+			}
+			if got.Personality != tt.want.Personality {
+				t.Errorf("Personality = %q, want %q", got.Personality, tt.want.Personality)
+			}
+			if got.SkipGitRepoCheck != tt.want.SkipGitRepoCheck {
+				t.Errorf("SkipGitRepoCheck = %v, want %v", got.SkipGitRepoCheck, tt.want.SkipGitRepoCheck)
+			}
+			if len(got.TurnSandboxPolicy) != len(tt.want.TurnSandboxPolicy) {
+				t.Errorf("TurnSandboxPolicy len = %d, want %d", len(got.TurnSandboxPolicy), len(tt.want.TurnSandboxPolicy))
+			}
+		})
+	}
+}
+
+func TestParseMessage_Response(t *testing.T) {
+	t.Parallel()
+
+	line := []byte(`{"id":1,"result":{"serverInfo":{"name":"codex-app-server"}}}`)
+	msg := parseMessage(line)
+
+	if msg.Err != nil {
+		t.Fatalf("parseMessage() error = %v", msg.Err)
+	}
+	if !msg.IsResponse {
+		t.Error("IsResponse = false, want true")
+	}
+	if msg.IsNotification {
+		t.Error("IsNotification = true, want false")
+	}
+	if msg.Response.ID != 1 {
+		t.Errorf("Response.ID = %d, want 1", msg.Response.ID)
+	}
+}
+
+func TestParseMessage_Notification(t *testing.T) {
+	t.Parallel()
+
+	line := []byte(`{"method":"thread/started","params":{"threadId":"abc-123"}}`)
+	msg := parseMessage(line)
+
+	if msg.Err != nil {
+		t.Fatalf("parseMessage() error = %v", msg.Err)
+	}
+	if !msg.IsNotification {
+		t.Error("IsNotification = false, want true")
+	}
+	if msg.IsResponse {
+		t.Error("IsResponse = true, want false")
+	}
+	if msg.Notification.Method != "thread/started" {
+		t.Errorf("Notification.Method = %q, want %q", msg.Notification.Method, "thread/started")
+	}
+}
+
+func TestParseMessage_ServerRequest(t *testing.T) {
+	t.Parallel()
+
+	// item/tool/call carries both method and id — it is routed as a
+	// notification so the event loop dispatches on Method, with the
+	// request ID preserved in Response.ID for sending the reply.
+	line := []byte(`{"id":42,"method":"item/tool/call","params":{"tool":"my_tool","arguments":{}}}`)
+	msg := parseMessage(line)
+
+	if msg.Err != nil {
+		t.Fatalf("parseMessage() error = %v", msg.Err)
+	}
+	if !msg.IsNotification {
+		t.Error("IsNotification = false, want true (server request routed as notification)")
+	}
+	if msg.Notification.Method != "item/tool/call" {
+		t.Errorf("Notification.Method = %q, want %q", msg.Notification.Method, "item/tool/call")
+	}
+	if msg.Response.ID != 42 {
+		t.Errorf("Response.ID = %d, want 42 (request ID preserved for response)", msg.Response.ID)
+	}
+}
+
+func TestParseMessage_Malformed(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		line []byte
+	}{
+		{"invalid JSON", []byte(`not json`)},
+		{"truncated JSON", []byte(`{`)},
+		{"empty object no method or id", []byte(`{}`)},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			msg := parseMessage(tc.line)
+			if msg.Err == nil {
+				t.Errorf("parseMessage(%q) err = nil, want non-nil", tc.line)
+			}
+		})
+	}
+}
+
+func TestNormalizeUsage(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil input returns zero usage", func(t *testing.T) {
+		t.Parallel()
+		got := normalizeUsage(nil)
+		if got != (domain.TokenUsage{}) {
+			t.Errorf("normalizeUsage(nil) = %+v, want zero", got)
+		}
+	})
+
+	t.Run("fields mapped correctly", func(t *testing.T) {
+		t.Parallel()
+		u := &turnUsage{
+			InputTokens:       100,
+			OutputTokens:      50,
+			CachedInputTokens: 20,
+		}
+		got := normalizeUsage(u)
+		if got.InputTokens != 100 {
+			t.Errorf("InputTokens = %d, want 100", got.InputTokens)
+		}
+		if got.OutputTokens != 50 {
+			t.Errorf("OutputTokens = %d, want 50", got.OutputTokens)
+		}
+		if got.TotalTokens != 150 {
+			t.Errorf("TotalTokens = %d, want 150 (input+output)", got.TotalTokens)
+		}
+		if got.CacheReadTokens != 20 {
+			t.Errorf("CacheReadTokens = %d, want 20", got.CacheReadTokens)
+		}
+	})
+
+	t.Run("zero usage struct", func(t *testing.T) {
+		t.Parallel()
+		got := normalizeUsage(&turnUsage{})
+		if got != (domain.TokenUsage{}) {
+			t.Errorf("normalizeUsage(&turnUsage{}) = %+v, want zero", got)
+		}
+	})
+}
+
+func TestMapTurnStatus(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		status string
+		want   domain.AgentEventType
+	}{
+		{"completed", domain.EventTurnCompleted},
+		{"interrupted", domain.EventTurnCancelled},
+		{"failed", domain.EventTurnFailed},
+		{"unknown", domain.EventTurnFailed},
+		{"", domain.EventTurnFailed},
+		{"COMPLETED", domain.EventTurnFailed},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.status, func(t *testing.T) {
+			t.Parallel()
+			got := mapTurnStatus(tt.status)
+			if got != tt.want {
+				t.Errorf("mapTurnStatus(%q) = %q, want %q", tt.status, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMapCodexErrorInfo(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		info string
+		want domain.AgentErrorKind
+	}{
+		{"Unauthorized", domain.ErrResponseError},
+		{"BadRequest", domain.ErrResponseError},
+		{"ContextWindowExceeded", domain.ErrTurnFailed},
+		{"UsageLimitExceeded", domain.ErrTurnFailed},
+		{"SandboxError", domain.ErrTurnFailed},
+		{"HttpConnectionFailed", domain.ErrTurnFailed},
+		{"ResponseStreamConnectionFailed", domain.ErrTurnFailed},
+		{"ResponseStreamDisconnected", domain.ErrTurnFailed},
+		{"ResponseTooManyFailedAttempts", domain.ErrTurnFailed},
+		{"InternalServerError", domain.ErrTurnFailed},
+		{"Other", domain.ErrTurnFailed},
+		{"SomeUnknownValue", domain.ErrTurnFailed},
+		{"", domain.ErrTurnFailed},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.info, func(t *testing.T) {
+			t.Parallel()
+			got := mapCodexErrorInfo(tt.info)
+			if got != tt.want {
+				t.Errorf("mapCodexErrorInfo(%q) = %q, want %q", tt.info, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSummarizeItem(t *testing.T) {
+	t.Parallel()
+
+	t.Run("short item not truncated", func(t *testing.T) {
+		t.Parallel()
+		got := summarizeItem("agentMessage", "item-001")
+		want := "[agentMessage] item-001"
+		if got != want {
+			t.Errorf("summarizeItem() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("long item truncated at 200 runes", func(t *testing.T) {
+		t.Parallel()
+		// Prefix "[agentMessage] " is 15 chars; ID of 250 chars makes 265 total.
+		longID := strings.Repeat("x", 250)
+		got := summarizeItem("agentMessage", longID)
+		runeCount := utf8.RuneCountInString(got)
+		if runeCount != 200 {
+			t.Errorf("summarizeItem() rune count = %d, want 200", runeCount)
+		}
+	})
+
+	t.Run("exactly 200 runes not truncated", func(t *testing.T) {
+		t.Parallel()
+		// Prefix is 15 chars; ID of 185 chars makes exactly 200 total.
+		exactID := strings.Repeat("z", 185)
+		got := summarizeItem("agentMessage", exactID)
+		want := "[agentMessage] " + exactID
+		if got != want {
+			t.Errorf("summarizeItem() = %q, want %q", got, want)
+		}
+	})
+}
+
+func TestToolResultFor(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success result", func(t *testing.T) {
+		t.Parallel()
+		result := toolResultFor(true, "all good")
+		if result["success"] != true {
+			t.Errorf("success = %v, want true", result["success"])
+		}
+		if result["output"] != "all good" {
+			t.Errorf("output = %v, want %q", result["output"], "all good")
+		}
+		items, ok := result["contentItems"].([]map[string]any)
+		if !ok || len(items) == 0 {
+			t.Fatalf("contentItems missing or wrong type: %T", result["contentItems"])
+		}
+		if items[0]["text"] != "all good" {
+			t.Errorf("contentItems[0].text = %v, want %q", items[0]["text"], "all good")
+		}
+		if items[0]["type"] != "inputText" {
+			t.Errorf("contentItems[0].type = %v, want %q", items[0]["type"], "inputText")
+		}
+	})
+
+	t.Run("failure result", func(t *testing.T) {
+		t.Parallel()
+		result := toolResultFor(false, "tool error")
+		if result["success"] != false {
+			t.Errorf("success = %v, want false", result["success"])
+		}
+		if result["output"] != "tool error" {
+			t.Errorf("output = %v, want %q", result["output"], "tool error")
+		}
+	})
+}
+
+func TestBuildDynamicTools(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil tools returns nil", func(t *testing.T) {
+		t.Parallel()
+		got := buildDynamicTools(nil)
+		if got != nil {
+			t.Errorf("buildDynamicTools(nil) = %v, want nil", got)
+		}
+	})
+
+	t.Run("empty slice returns nil", func(t *testing.T) {
+		t.Parallel()
+		got := buildDynamicTools([]domain.AgentTool{})
+		if got != nil {
+			t.Errorf("buildDynamicTools(empty) = %v, want nil", got)
+		}
+	})
+
+	t.Run("single tool with schema", func(t *testing.T) {
+		t.Parallel()
+		tool := &stubTool{
+			name:        "my_tool",
+			description: "does something useful",
+			schema:      json.RawMessage(`{"type":"object","properties":{"x":{"type":"string"}}}`),
+		}
+		result := buildDynamicTools([]domain.AgentTool{tool})
+		if len(result) != 1 {
+			t.Fatalf("buildDynamicTools() len = %d, want 1", len(result))
+		}
+		entry := result[0]
+		if entry["name"] != "my_tool" {
+			t.Errorf("entry.name = %v, want %q", entry["name"], "my_tool")
+		}
+		if entry["description"] != "does something useful" {
+			t.Errorf("entry.description = %v, want %q", entry["description"], "does something useful")
+		}
+		if entry["inputSchema"] == nil {
+			t.Error("inputSchema is nil, want non-nil")
+		}
+	})
+
+	t.Run("tool without schema omits inputSchema key", func(t *testing.T) {
+		t.Parallel()
+		tool := &stubTool{name: "no_schema", description: "no schema tool"}
+		result := buildDynamicTools([]domain.AgentTool{tool})
+		if len(result) != 1 {
+			t.Fatalf("len = %d, want 1", len(result))
+		}
+		if _, has := result[0]["inputSchema"]; has {
+			t.Error("inputSchema present, want absent when schema is nil")
+		}
+	})
+
+	t.Run("multiple tools preserved in input order", func(t *testing.T) {
+		t.Parallel()
+		tools := []domain.AgentTool{
+			&stubTool{name: "alpha", description: "first"},
+			&stubTool{name: "beta", description: "second"},
+		}
+		result := buildDynamicTools(tools)
+		if len(result) != 2 {
+			t.Fatalf("len = %d, want 2", len(result))
+		}
+		if result[0]["name"] != "alpha" {
+			t.Errorf("result[0].name = %v, want %q", result[0]["name"], "alpha")
+		}
+		if result[1]["name"] != "beta" {
+			t.Errorf("result[1].name = %v, want %q", result[1]["name"], "beta")
+		}
+	})
+
+	t.Run("invalid schema JSON omits inputSchema key", func(t *testing.T) {
+		t.Parallel()
+		tool := &stubTool{
+			name:        "bad_schema",
+			description: "tool with invalid schema JSON",
+			schema:      json.RawMessage(`{not valid json`),
+		}
+		result := buildDynamicTools([]domain.AgentTool{tool})
+		if len(result) != 1 {
+			t.Fatalf("len = %d, want 1", len(result))
+		}
+		if _, has := result[0]["inputSchema"]; has {
+			t.Error("inputSchema present, want absent for invalid JSON schema")
+		}
+	})
+}
+
+func TestBuildSandboxPolicy_Default(t *testing.T) {
+	t.Parallel()
+
+	state := &sessionState{workspacePath: "/workspace/abc"}
+	policy := buildSandboxPolicy(state, passthroughConfig{})
+
+	if policy["type"] != "workspaceWrite" {
+		t.Errorf("type = %v, want %q", policy["type"], "workspaceWrite")
+	}
+
+	roots, ok := policy["writableRoots"].([]string)
+	if !ok {
+		t.Fatalf("writableRoots type = %T, want []string", policy["writableRoots"])
+	}
+	if len(roots) != 1 || roots[0] != "/workspace/abc" {
+		t.Errorf("writableRoots = %v, want [\"/workspace/abc\"]", roots)
+	}
+
+	networkAccess, ok := policy["networkAccess"].(bool)
+	if !ok {
+		t.Fatalf("networkAccess type = %T, want bool", policy["networkAccess"])
+	}
+	if networkAccess {
+		t.Error("networkAccess = true, want false")
+	}
+}
+
+func TestBuildSandboxPolicy_Override(t *testing.T) {
+	t.Parallel()
+
+	state := &sessionState{workspacePath: "/workspace/abc"}
+	pt := passthroughConfig{
+		ThreadSandbox: "dangerouslyUnrestricted",
+		TurnSandboxPolicy: map[string]any{
+			"networkAccess": true,
+			"customField":   "custom-value",
+		},
+	}
+	policy := buildSandboxPolicy(state, pt)
+
+	if policy["type"] != "dangerouslyUnrestricted" {
+		t.Errorf("type = %v, want %q", policy["type"], "dangerouslyUnrestricted")
+	}
+
+	networkAccess, ok := policy["networkAccess"].(bool)
+	if !ok {
+		t.Fatalf("networkAccess type = %T, want bool", policy["networkAccess"])
+	}
+	if !networkAccess {
+		t.Error("networkAccess = false, want true (overridden)")
+	}
+
+	if policy["customField"] != "custom-value" {
+		t.Errorf("customField = %v, want %q", policy["customField"], "custom-value")
+	}
+
+	if _, ok := policy["writableRoots"]; !ok {
+		t.Error("writableRoots missing from policy after override")
+	}
+}

--- a/internal/agent/codex/protocol.go
+++ b/internal/agent/codex/protocol.go
@@ -13,11 +13,14 @@ import (
 )
 
 // sendRequest writes a JSON-RPC request to the app-server stdin.
-// The caller must hold state.mu when concurrent writes are possible.
-// Returns the request ID used.
+// It acquires state.mu internally to protect both the request ID
+// counter and the stdin write. Callers must not hold state.mu.
 func sendRequest(state *sessionState, method string, params any) (int64, error) {
+	state.mu.Lock()
 	state.nextRequestID++
 	id := state.nextRequestID
+	state.mu.Unlock()
+
 	req := rpcRequest{
 		Method: method,
 		ID:     id,

--- a/internal/agent/codex/protocol.go
+++ b/internal/agent/codex/protocol.go
@@ -1,0 +1,407 @@
+package codex
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"time"
+
+	"github.com/sortie-ai/sortie/internal/domain"
+)
+
+// sendRequest writes a JSON-RPC request to the app-server stdin.
+// The caller must hold state.mu when concurrent writes are possible.
+// Returns the request ID used.
+func sendRequest(state *sessionState, method string, params any) (int64, error) {
+	state.nextRequestID++
+	id := state.nextRequestID
+	req := rpcRequest{
+		Method: method,
+		ID:     id,
+		Params: params,
+	}
+	data, err := json.Marshal(req)
+	if err != nil {
+		return 0, fmt.Errorf("marshal request %s: %w", method, err)
+	}
+	data = append(data, '\n')
+
+	state.mu.Lock()
+	_, writeErr := state.stdin.Write(data)
+	state.mu.Unlock()
+	if writeErr != nil {
+		return 0, fmt.Errorf("write request %s: %w", method, writeErr)
+	}
+	return id, nil
+}
+
+// sendNotification writes a JSON-RPC notification (no id) to the
+// app-server stdin.
+func sendNotification(state *sessionState, method string, params any) error {
+	// Notifications have no id field. Use the rpcRequest type but
+	// omit the ID (zero value is omitempty).
+	notif := rpcRequest{
+		Method: method,
+		Params: params,
+	}
+	data, err := json.Marshal(notif)
+	if err != nil {
+		return fmt.Errorf("marshal notification %s: %w", method, err)
+	}
+	data = append(data, '\n')
+
+	state.mu.Lock()
+	_, writeErr := state.stdin.Write(data)
+	state.mu.Unlock()
+	if writeErr != nil {
+		return fmt.Errorf("write notification %s: %w", method, writeErr)
+	}
+	return nil
+}
+
+// sendResponse writes a JSON-RPC response to the app-server stdin.
+// The caller must hold state.mu.
+func sendResponse(state *sessionState, id int64, result any) error {
+	type response struct {
+		ID     int64 `json:"id"`
+		Result any   `json:"result"`
+	}
+	resp := response{ID: id, Result: result}
+	data, err := json.Marshal(resp)
+	if err != nil {
+		return fmt.Errorf("marshal response id=%d: %w", id, err)
+	}
+	data = append(data, '\n')
+
+	_, writeErr := state.stdin.Write(data)
+	if writeErr != nil {
+		return fmt.Errorf("write response id=%d: %w", id, writeErr)
+	}
+	return nil
+}
+
+// readResponse reads JSONL lines from the scanner until a response
+// with the expected ID arrives or the context expires. Notifications
+// encountered during the wait are discarded.
+func readResponse(ctx context.Context, scanner *bufio.Scanner, expectedID int64) (rpcResponse, error) {
+	for {
+		if ctx.Err() != nil {
+			return rpcResponse{}, ctx.Err()
+		}
+		if !scanner.Scan() {
+			if err := scanner.Err(); err != nil {
+				return rpcResponse{}, fmt.Errorf("scanner error waiting for response id=%d: %w", expectedID, err)
+			}
+			return rpcResponse{}, fmt.Errorf("unexpected EOF waiting for response id=%d", expectedID)
+		}
+
+		msg := parseMessage(scanner.Bytes())
+		if msg.Err != nil {
+			slog.Debug("discarding malformed message during handshake", slog.Any("error", msg.Err))
+			continue
+		}
+		if msg.IsNotification {
+			slog.Debug("discarding notification during handshake",
+				slog.String("method", msg.Notification.Method))
+			continue
+		}
+		if msg.IsResponse && msg.Response.ID == expectedID {
+			return msg.Response, nil
+		}
+		slog.Debug("discarding response with unexpected id",
+			slog.Int64("got", msg.Response.ID),
+			slog.Int64("want", expectedID))
+	}
+}
+
+// initializeHandshake sends the initialize request and initialized
+// notification per the app-server protocol.
+func initializeHandshake(ctx context.Context, state *sessionState, scanner *bufio.Scanner) error {
+	type clientInfo struct {
+		Name    string `json:"name"`
+		Title   string `json:"title"`
+		Version string `json:"version"`
+	}
+	type capabilities struct {
+		ExperimentalAPI bool `json:"experimentalApi"`
+	}
+	type initParams struct {
+		ClientInfo   clientInfo   `json:"clientInfo"`
+		Capabilities capabilities `json:"capabilities"`
+	}
+
+	params := initParams{
+		ClientInfo: clientInfo{
+			Name:    "sortie_orchestrator",
+			Title:   "Sortie Orchestrator",
+			Version: "0.1.0",
+		},
+		Capabilities: capabilities{
+			ExperimentalAPI: true,
+		},
+	}
+
+	id, err := sendRequest(state, "initialize", params)
+	if err != nil {
+		return fmt.Errorf("initialize: %w", err)
+	}
+
+	resp, err := readResponse(ctx, scanner, id)
+	if err != nil {
+		return fmt.Errorf("initialize response: %w", err)
+	}
+	if resp.Error != nil {
+		return fmt.Errorf("initialize error: code=%d message=%s", resp.Error.Code, resp.Error.Message)
+	}
+
+	if err := sendNotification(state, "initialized", map[string]any{}); err != nil {
+		return fmt.Errorf("initialized notification: %w", err)
+	}
+	return nil
+}
+
+// authenticateIfNeeded checks the app-server auth state and performs
+// API key login if needed.
+func authenticateIfNeeded(ctx context.Context, state *sessionState, scanner *bufio.Scanner) error {
+	id, err := sendRequest(state, "account/read", map[string]any{"refreshToken": false})
+	if err != nil {
+		return fmt.Errorf("account/read: %w", err)
+	}
+
+	resp, err := readResponse(ctx, scanner, id)
+	if err != nil {
+		return fmt.Errorf("account/read response: %w", err)
+	}
+	if resp.Error != nil {
+		return fmt.Errorf("account/read error: code=%d message=%s", resp.Error.Code, resp.Error.Message)
+	}
+
+	var acct accountResult
+	if err := json.Unmarshal(resp.Result, &acct); err != nil {
+		return fmt.Errorf("account/read unmarshal: %w", err)
+	}
+
+	// Account is non-null when the app-server already has valid
+	// credentials. The JSON null literal unmarshals to a nil
+	// RawMessage.
+	if len(acct.Account) > 0 && string(acct.Account) != "null" {
+		return nil
+	}
+
+	apiKey := os.Getenv("CODEX_API_KEY")
+	if apiKey == "" {
+		return nil
+	}
+
+	loginID, err := sendRequest(state, "account/login/start", map[string]any{
+		"type":   "apiKey",
+		"apiKey": apiKey,
+	})
+	if err != nil {
+		return fmt.Errorf("account/login/start: %w", err)
+	}
+
+	// Read until login response and login/completed notification.
+	loginResp, err := readResponse(ctx, scanner, loginID)
+	if err != nil {
+		return fmt.Errorf("account/login/start response: %w", err)
+	}
+	if loginResp.Error != nil {
+		return &domain.AgentError{
+			Kind:    domain.ErrResponseError,
+			Message: fmt.Sprintf("login failed: %s", loginResp.Error.Message),
+		}
+	}
+
+	// Wait for account/login/completed notification. Read lines
+	// until we find it.
+	deadline := time.After(readTimeout(state))
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-deadline:
+			return fmt.Errorf("timeout waiting for account/login/completed")
+		default:
+		}
+		if !scanner.Scan() {
+			if err := scanner.Err(); err != nil {
+				return fmt.Errorf("scanner error waiting for login: %w", err)
+			}
+			return fmt.Errorf("unexpected EOF waiting for login")
+		}
+		msg := parseMessage(scanner.Bytes())
+		if msg.Err != nil {
+			continue
+		}
+		if msg.IsNotification && msg.Notification.Method == "account/login/completed" {
+			var loginNotif accountLoginNotification
+			if err := json.Unmarshal(msg.Notification.Params, &loginNotif); err != nil {
+				return fmt.Errorf("login notification unmarshal: %w", err)
+			}
+			if !loginNotif.Success {
+				return &domain.AgentError{
+					Kind:    domain.ErrResponseError,
+					Message: "authentication failed",
+				}
+			}
+			return nil
+		}
+	}
+}
+
+// startThread sends thread/start and waits for the thread/started
+// notification. Returns the thread ID.
+func startThread(ctx context.Context, state *sessionState, scanner *bufio.Scanner, pt passthroughConfig, tools []domain.AgentTool) (string, error) {
+	approvalPolicy := pt.ApprovalPolicy
+	if approvalPolicy == "" {
+		approvalPolicy = "never"
+	}
+
+	sandbox := pt.ThreadSandbox
+	if sandbox == "" {
+		sandbox = "workspaceWrite"
+	}
+
+	params := map[string]any{
+		"cwd":            state.workspacePath,
+		"approvalPolicy": approvalPolicy,
+		"sandbox":        sandbox,
+	}
+	if pt.Model != "" {
+		params["model"] = pt.Model
+	}
+	if pt.Personality != "" {
+		params["personality"] = pt.Personality
+	}
+
+	dynTools := buildDynamicTools(tools)
+	if len(dynTools) > 0 {
+		params["dynamicTools"] = dynTools
+	}
+
+	id, err := sendRequest(state, "thread/start", params)
+	if err != nil {
+		return "", fmt.Errorf("thread/start: %w", err)
+	}
+
+	resp, err := readResponse(ctx, scanner, id)
+	if err != nil {
+		return "", fmt.Errorf("thread/start response: %w", err)
+	}
+	if resp.Error != nil {
+		return "", fmt.Errorf("thread/start error: code=%d message=%s", resp.Error.Code, resp.Error.Message)
+	}
+
+	var result threadResult
+	if err := json.Unmarshal(resp.Result, &result); err != nil {
+		return "", fmt.Errorf("thread/start unmarshal: %w", err)
+	}
+	threadID := result.Thread.ID
+	if threadID == "" {
+		return "", fmt.Errorf("thread/start returned empty thread ID")
+	}
+
+	// Wait for thread/started notification.
+	deadline := time.After(readTimeout(state))
+	for {
+		select {
+		case <-ctx.Done():
+			return "", ctx.Err()
+		case <-deadline:
+			// Accept the thread ID even without the notification.
+			// Some app-server versions may not emit it.
+			return threadID, nil
+		default:
+		}
+		if !scanner.Scan() {
+			return threadID, nil
+		}
+		msg := parseMessage(scanner.Bytes())
+		if msg.Err != nil {
+			continue
+		}
+		if msg.IsNotification && msg.Notification.Method == "thread/started" {
+			return threadID, nil
+		}
+	}
+}
+
+// resumeThread sends thread/resume for an existing thread.
+func resumeThread(ctx context.Context, state *sessionState, scanner *bufio.Scanner, threadID string) error {
+	id, err := sendRequest(state, "thread/resume", map[string]any{
+		"threadId": threadID,
+	})
+	if err != nil {
+		return fmt.Errorf("thread/resume: %w", err)
+	}
+
+	resp, err := readResponse(ctx, scanner, id)
+	if err != nil {
+		return fmt.Errorf("thread/resume response: %w", err)
+	}
+	if resp.Error != nil {
+		return fmt.Errorf("thread/resume error: code=%d message=%s", resp.Error.Code, resp.Error.Message)
+	}
+	return nil
+}
+
+// buildDynamicTools converts registered agent tools into the schema
+// map array required by thread/start.
+func buildDynamicTools(tools []domain.AgentTool) []map[string]any {
+	if len(tools) == 0 {
+		return nil
+	}
+	result := make([]map[string]any, 0, len(tools))
+	for _, t := range tools {
+		entry := map[string]any{
+			"name":        t.Name(),
+			"description": t.Description(),
+		}
+		schema := t.InputSchema()
+		if len(schema) > 0 {
+			var parsed any
+			if err := json.Unmarshal(schema, &parsed); err == nil {
+				entry["inputSchema"] = parsed
+			}
+		}
+		result = append(result, entry)
+	}
+	return result
+}
+
+// buildSandboxPolicy constructs the sandboxPolicy for turn/start.
+// writableRoots is always set to the workspace path. networkAccess
+// defaults to false. Operator overrides from TurnSandboxPolicy are
+// merged on top.
+func buildSandboxPolicy(state *sessionState, pt passthroughConfig) map[string]any {
+	sandboxType := pt.ThreadSandbox
+	if sandboxType == "" {
+		sandboxType = "workspaceWrite"
+	}
+
+	policy := map[string]any{
+		"type":          sandboxType,
+		"writableRoots": []string{state.workspacePath},
+		"networkAccess": false,
+	}
+
+	if pt.TurnSandboxPolicy != nil {
+		for k, v := range pt.TurnSandboxPolicy {
+			policy[k] = v
+		}
+	}
+	return policy
+}
+
+// readTimeout returns the read timeout duration from the agent config,
+// defaulting to 30 seconds.
+func readTimeout(state *sessionState) time.Duration {
+	if state.agentConfig.ReadTimeoutMS > 0 {
+		return time.Duration(state.agentConfig.ReadTimeoutMS) * time.Millisecond
+	}
+	return 30 * time.Second
+}

--- a/internal/agent/codex/protocol.go
+++ b/internal/agent/codex/protocol.go
@@ -321,6 +321,9 @@ func startThread(ctx context.Context, state *sessionState, scanner *bufio.Scanne
 		default:
 		}
 		if !scanner.Scan() {
+			if scanErr := scanner.Err(); scanErr != nil {
+				slog.Debug("scanner error waiting for thread/started", slog.Any("error", scanErr))
+			}
 			return threadID, nil
 		}
 		msg := parseMessage(scanner.Bytes())
@@ -377,9 +380,10 @@ func buildDynamicTools(tools []domain.AgentTool) []map[string]any {
 }
 
 // buildSandboxPolicy constructs the sandboxPolicy for turn/start.
-// writableRoots is always set to the workspace path. networkAccess
-// defaults to false. Operator overrides from TurnSandboxPolicy are
-// merged on top.
+// writableRoots defaults to the workspace path and networkAccess
+// defaults to false. Operator overrides from TurnSandboxPolicy
+// (WORKFLOW.md turn_sandbox_policy) are merged on top and may
+// replace any key, including writableRoots and networkAccess.
 func buildSandboxPolicy(state *sessionState, pt passthroughConfig) map[string]any {
 	sandboxType := pt.ThreadSandbox
 	if sandboxType == "" {

--- a/internal/agent/codex/protocol_test.go
+++ b/internal/agent/codex/protocol_test.go
@@ -1,0 +1,170 @@
+//go:build unix
+
+package codex
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sortie-ai/sortie/internal/domain"
+)
+
+func TestSendNotification_WritesToStdin(t *testing.T) {
+	t.Parallel()
+
+	state := makeTestState(nil)
+	err := sendNotification(state, "initialized", map[string]any{"version": "1.0"})
+	if err != nil {
+		t.Fatalf("sendNotification() error = %v", err)
+	}
+}
+
+func TestReadResponse_SkipsNotifications(t *testing.T) {
+	t.Parallel()
+
+	fixture := strings.NewReader(
+		"{\"method\":\"some/notification\",\"params\":{}}\n" +
+			"{\"id\":1,\"result\":{\"ok\":true}}\n",
+	)
+	scanner := bufio.NewScanner(fixture)
+	scanner.Buffer(make([]byte, 0, 1<<20), 1<<20)
+
+	resp, err := readResponse(context.Background(), scanner, 1)
+	if err != nil {
+		t.Fatalf("readResponse() error = %v", err)
+	}
+	if resp.ID != 1 {
+		t.Errorf("resp.ID = %d, want 1", resp.ID)
+	}
+}
+
+func TestReadResponse_SkipsWrongID(t *testing.T) {
+	t.Parallel()
+
+	fixture := strings.NewReader(
+		"{\"id\":99,\"result\":{}}\n" + // wrong ID
+			"{\"id\":1,\"result\":{\"ok\":true}}\n",
+	)
+	scanner := bufio.NewScanner(fixture)
+	scanner.Buffer(make([]byte, 0, 1<<20), 1<<20)
+
+	resp, err := readResponse(context.Background(), scanner, 1)
+	if err != nil {
+		t.Fatalf("readResponse() error = %v", err)
+	}
+	if resp.ID != 1 {
+		t.Errorf("resp.ID = %d, want 1", resp.ID)
+	}
+}
+
+func TestReadResponse_UnexpectedEOF(t *testing.T) {
+	t.Parallel()
+
+	scanner := bufio.NewScanner(strings.NewReader(""))
+	scanner.Buffer(make([]byte, 0, 1<<20), 1<<20)
+
+	_, err := readResponse(context.Background(), scanner, 1)
+	if err == nil {
+		t.Fatal("readResponse() expected error on empty input, got nil")
+	}
+	if !strings.Contains(err.Error(), "unexpected EOF") {
+		t.Errorf("readResponse() error = %q, want 'unexpected EOF'", err.Error())
+	}
+}
+
+func TestReadResponse_ContextCancelled(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	scanner := bufio.NewScanner(strings.NewReader("{\"id\":1,\"result\":{}}\n"))
+	scanner.Buffer(make([]byte, 0, 1<<20), 1<<20)
+
+	_, err := readResponse(ctx, scanner, 1)
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("readResponse() error = %v, want context.Canceled", err)
+	}
+}
+
+func TestReadResponse_MalformedMessageSkipped(t *testing.T) {
+	t.Parallel()
+
+	fixture := strings.NewReader(
+		"not-valid-json\n" +
+			"{\"id\":1,\"result\":{\"ok\":true}}\n",
+	)
+	scanner := bufio.NewScanner(fixture)
+	scanner.Buffer(make([]byte, 0, 1<<20), 1<<20)
+
+	resp, err := readResponse(context.Background(), scanner, 1)
+	if err != nil {
+		t.Fatalf("readResponse() error = %v", err)
+	}
+	if resp.ID != 1 {
+		t.Errorf("resp.ID = %d, want 1", resp.ID)
+	}
+}
+
+func TestReadTimeout_CustomValue(t *testing.T) {
+	t.Parallel()
+
+	state := &sessionState{agentConfig: domain.AgentConfig{ReadTimeoutMS: 5000}}
+	got := readTimeout(state)
+	if got != 5*time.Second {
+		t.Errorf("readTimeout() = %v, want 5s", got)
+	}
+}
+
+func TestReadTimeout_DefaultsTo30s(t *testing.T) {
+	t.Parallel()
+
+	state := &sessionState{}
+	got := readTimeout(state)
+	if got != 30*time.Second {
+		t.Errorf("readTimeout() = %v, want 30s", got)
+	}
+}
+
+func TestIsAgentError_WithAgentError(t *testing.T) {
+	t.Parallel()
+
+	ae := &domain.AgentError{Kind: domain.ErrPortExit, Message: "subprocess exited"}
+	var target *domain.AgentError
+	if !isAgentError(ae, &target) {
+		t.Fatal("isAgentError() = false for *domain.AgentError")
+	}
+	if target != ae {
+		t.Error("isAgentError() did not set target to the input error")
+	}
+}
+
+func TestIsAgentError_WithPlainError(t *testing.T) {
+	t.Parallel()
+
+	plain := errors.New("not an agent error")
+	var target *domain.AgentError
+	if isAgentError(plain, &target) {
+		t.Fatal("isAgentError() = true for plain error")
+	}
+	if target != nil {
+		t.Error("isAgentError() set target for plain error")
+	}
+}
+
+func TestStartSession_SSHBinaryNotFound(t *testing.T) {
+	// No t.Parallel() — uses t.Setenv which mutates process env.
+	t.Setenv("PATH", "/nonexistent-path-for-test")
+
+	adapter, _ := NewCodexAdapter(map[string]any{})
+	_, err := adapter.StartSession(context.Background(), domain.StartSessionParams{
+		WorkspacePath: t.TempDir(),
+		SSHHost:       "remote.example.com",
+		AgentConfig:   domain.AgentConfig{Command: "codex app-server"},
+	})
+	requireAgentError(t, err, domain.ErrAgentNotFound)
+}

--- a/internal/agent/codex/runturn_test.go
+++ b/internal/agent/codex/runturn_test.go
@@ -1,0 +1,639 @@
+//go:build unix
+
+package codex
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"os"
+	"sync"
+	"testing"
+
+	"github.com/sortie-ai/sortie/internal/domain"
+)
+
+// nopWriteCloser is an io.WriteCloser that discards all writes.
+type nopWriteCloser struct{}
+
+func (nopWriteCloser) Write(p []byte) (int, error) { return len(p), nil }
+func (nopWriteCloser) Close() error                { return nil }
+
+// loadFixture reads testdata/<name> and returns its bytes.
+func loadFixture(t *testing.T, name string) []byte {
+	t.Helper()
+	data, err := os.ReadFile("testdata/" + name)
+	if err != nil {
+		t.Fatalf("loadFixture(%q): %v", name, err)
+	}
+	return data
+}
+
+// makeTestState builds a sessionState backed by in-memory pipes, safe
+// for use in RunTurn and handleToolCall unit tests that do not launch a
+// real subprocess.
+func makeTestState(fixtureData []byte) *sessionState {
+	return &sessionState{
+		threadID:      "thread-001",
+		workspacePath: "/tmp",
+		waitCh:        make(chan struct{}),
+		stdin:         nopWriteCloser{},
+		stdout:        io.NopCloser(bytes.NewReader(fixtureData)),
+	}
+}
+
+// fakeSession wraps state in a domain.Session suitable for RunTurn.
+func fakeSession(state *sessionState) domain.Session {
+	return domain.Session{
+		ID:       state.threadID,
+		AgentPID: "12345",
+		Internal: state,
+	}
+}
+
+// collectEvents is an OnEvent callback that appends to a slice.
+func collectEvents(events *[]domain.AgentEvent) func(domain.AgentEvent) {
+	var mu sync.Mutex
+	return func(e domain.AgentEvent) {
+		mu.Lock()
+		*events = append(*events, e)
+		mu.Unlock()
+	}
+}
+
+// firstEventOfType returns the first event with the given type, or the
+// zero value if none was found.
+func firstEventOfType(events []domain.AgentEvent, t domain.AgentEventType) (domain.AgentEvent, bool) {
+	for _, e := range events {
+		if e.Type == t {
+			return e, true
+		}
+	}
+	return domain.AgentEvent{}, false
+}
+
+func TestRunTurn_InvalidInternalType(t *testing.T) {
+	t.Parallel()
+
+	adapter, _ := NewCodexAdapter(map[string]any{})
+	session := domain.Session{Internal: "not-a-session-state"}
+	_, err := adapter.RunTurn(context.Background(), session, domain.RunTurnParams{
+		OnEvent: func(domain.AgentEvent) {},
+	})
+	requireAgentError(t, err, domain.ErrPortExit)
+}
+
+func TestRunTurn_SuccessfulTurn(t *testing.T) {
+	t.Parallel()
+
+	state := makeTestState(loadFixture(t, "runturn_success.jsonl"))
+	adapter, _ := NewCodexAdapter(map[string]any{})
+
+	var events []domain.AgentEvent
+	result, err := adapter.RunTurn(context.Background(), fakeSession(state), domain.RunTurnParams{
+		Prompt:  "do something",
+		OnEvent: collectEvents(&events),
+	})
+
+	if err != nil {
+		t.Fatalf("RunTurn() error = %v", err)
+	}
+	if result.ExitReason != domain.EventTurnCompleted {
+		t.Errorf("ExitReason = %v, want %v", result.ExitReason, domain.EventTurnCompleted)
+	}
+	if result.Usage.InputTokens != 100 {
+		t.Errorf("Usage.InputTokens = %d, want 100", result.Usage.InputTokens)
+	}
+	if result.Usage.OutputTokens != 50 {
+		t.Errorf("Usage.OutputTokens = %d, want 50", result.Usage.OutputTokens)
+	}
+	if result.SessionID != "thread-001" {
+		t.Errorf("SessionID = %q, want %q", result.SessionID, "thread-001")
+	}
+	if _, ok := firstEventOfType(events, domain.EventTokenUsage); !ok {
+		t.Error("expected EventTokenUsage event, none found")
+	}
+}
+
+func TestRunTurn_FirstTurnEmitsSessionStarted(t *testing.T) {
+	t.Parallel()
+
+	// turnCount=0 → incremented to 1 inside RunTurn → EventSessionStarted.
+	state := makeTestState(loadFixture(t, "runturn_success.jsonl"))
+	adapter, _ := NewCodexAdapter(map[string]any{})
+
+	var events []domain.AgentEvent
+	if _, err := adapter.RunTurn(context.Background(), fakeSession(state), domain.RunTurnParams{
+		Prompt:  "hello",
+		OnEvent: collectEvents(&events),
+	}); err != nil {
+		t.Fatalf("RunTurn() error = %v", err)
+	}
+
+	e, ok := firstEventOfType(events, domain.EventSessionStarted)
+	if !ok {
+		t.Fatal("expected EventSessionStarted on first turn, not found")
+	}
+	if e.SessionID != "thread-001" {
+		t.Errorf("EventSessionStarted.SessionID = %q, want %q", e.SessionID, "thread-001")
+	}
+}
+
+func TestRunTurn_SubsequentTurnEmitsNotification(t *testing.T) {
+	t.Parallel()
+
+	// Pre-set turnCount=1 so the adapter sees this as the second turn.
+	state := makeTestState(loadFixture(t, "runturn_success.jsonl"))
+	state.turnCount = 1
+	adapter, _ := NewCodexAdapter(map[string]any{})
+
+	var events []domain.AgentEvent
+	if _, err := adapter.RunTurn(context.Background(), fakeSession(state), domain.RunTurnParams{
+		Prompt:  "continue",
+		OnEvent: collectEvents(&events),
+	}); err != nil {
+		t.Fatalf("RunTurn() error = %v", err)
+	}
+
+	if _, ok := firstEventOfType(events, domain.EventSessionStarted); ok {
+		t.Error("did not expect EventSessionStarted on subsequent turn")
+	}
+}
+
+func TestRunTurn_FailedTurnContextWindowExceeded(t *testing.T) {
+	t.Parallel()
+
+	state := makeTestState(loadFixture(t, "runturn_failed.jsonl"))
+	adapter, _ := NewCodexAdapter(map[string]any{})
+
+	var events []domain.AgentEvent
+	result, err := adapter.RunTurn(context.Background(), fakeSession(state), domain.RunTurnParams{
+		Prompt:  "do something",
+		OnEvent: collectEvents(&events),
+	})
+
+	if err == nil {
+		t.Fatal("RunTurn() expected error, got nil")
+	}
+	var ae *domain.AgentError
+	if !errors.As(err, &ae) {
+		t.Fatalf("error type = %T, want *domain.AgentError", err)
+	}
+	if result.ExitReason != domain.EventTurnFailed {
+		t.Errorf("ExitReason = %v, want %v", result.ExitReason, domain.EventTurnFailed)
+	}
+	if _, ok := firstEventOfType(events, domain.EventTurnFailed); !ok {
+		t.Error("expected EventTurnFailed event, none found")
+	}
+	if _, ok := firstEventOfType(events, domain.EventTokenUsage); !ok {
+		t.Error("expected EventTokenUsage event on failed turn, none found")
+	}
+}
+
+func TestRunTurn_StdoutClosedBeforeTurnCompleted(t *testing.T) {
+	t.Parallel()
+
+	// Only the turn/start response — no turn/completed — so the
+	// background goroutine closes msgCh before turn/completed arrives.
+	fixture := "{\"id\":1,\"result\":{\"turn\":{\"id\":\"turn-001\",\"status\":\"starting\"}}}\n" +
+		"{\"method\":\"turn/started\",\"params\":{}}\n"
+	state := makeTestState([]byte(fixture))
+	adapter, _ := NewCodexAdapter(map[string]any{})
+
+	_, err := adapter.RunTurn(context.Background(), fakeSession(state), domain.RunTurnParams{
+		Prompt:  "go",
+		OnEvent: func(domain.AgentEvent) {},
+	})
+	requireAgentError(t, err, domain.ErrPortExit)
+}
+
+func TestRunTurn_TurnStartErrorResponse(t *testing.T) {
+	t.Parallel()
+
+	// turn/start response carries an error — RunTurn should return ErrTurnFailed.
+	fixture := "{\"id\":1,\"error\":{\"code\":-32000,\"message\":\"thread not found\"}}\n"
+	state := makeTestState([]byte(fixture))
+	adapter, _ := NewCodexAdapter(map[string]any{})
+
+	_, err := adapter.RunTurn(context.Background(), fakeSession(state), domain.RunTurnParams{
+		Prompt:  "go",
+		OnEvent: func(domain.AgentEvent) {},
+	})
+	requireAgentError(t, err, domain.ErrTurnFailed)
+}
+
+func TestRunTurn_CancelledContextReturnsError(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately
+
+	state := makeTestState(loadFixture(t, "runturn_success.jsonl"))
+	adapter, _ := NewCodexAdapter(map[string]any{})
+
+	_, err := adapter.RunTurn(ctx, fakeSession(state), domain.RunTurnParams{
+		Prompt:  "go",
+		OnEvent: func(domain.AgentEvent) {},
+	})
+	// readResponse returns context.Canceled → wrapped in ErrPortExit.
+	if err == nil {
+		t.Fatal("expected error with cancelled context, got nil")
+	}
+}
+
+func TestRunTurn_ItemStartedAndCompletedEmitsToolResult(t *testing.T) {
+	t.Parallel()
+
+	state := makeTestState(loadFixture(t, "runturn_items.jsonl"))
+	adapter, _ := NewCodexAdapter(map[string]any{})
+
+	var events []domain.AgentEvent
+	result, err := adapter.RunTurn(context.Background(), fakeSession(state), domain.RunTurnParams{
+		Prompt:  "run command",
+		OnEvent: collectEvents(&events),
+	})
+
+	if err != nil {
+		t.Fatalf("RunTurn() error = %v", err)
+	}
+	if result.ExitReason != domain.EventTurnCompleted {
+		t.Errorf("ExitReason = %v, want EventTurnCompleted", result.ExitReason)
+	}
+
+	e, ok := firstEventOfType(events, domain.EventToolResult)
+	if !ok {
+		t.Fatal("expected EventToolResult from item tracking, not found")
+	}
+	if e.ToolName != "ls -la" {
+		t.Errorf("ToolResult.ToolName = %q, want %q", e.ToolName, "ls -la")
+	}
+}
+
+func TestRunTurn_AgentMessageTextEmitsNotification(t *testing.T) {
+	t.Parallel()
+
+	state := makeTestState(loadFixture(t, "runturn_agent_message.jsonl"))
+	adapter, _ := NewCodexAdapter(map[string]any{})
+
+	var events []domain.AgentEvent
+	if _, err := adapter.RunTurn(context.Background(), fakeSession(state), domain.RunTurnParams{
+		Prompt:  "explain",
+		OnEvent: collectEvents(&events),
+	}); err != nil {
+		t.Fatalf("RunTurn() error = %v", err)
+	}
+
+	// item/completed with agentMessage type and non-empty text emits EventNotification.
+	notifs := 0
+	for _, e := range events {
+		if e.Type == domain.EventNotification {
+			notifs++
+		}
+	}
+	if notifs == 0 {
+		t.Error("expected at least one EventNotification for agentMessage text, found none")
+	}
+}
+
+func TestRunTurn_MiscNotifications(t *testing.T) {
+	t.Parallel()
+
+	state := makeTestState(loadFixture(t, "runturn_misc_notifications.jsonl"))
+	adapter, _ := NewCodexAdapter(map[string]any{})
+
+	var events []domain.AgentEvent
+	if _, err := adapter.RunTurn(context.Background(), fakeSession(state), domain.RunTurnParams{
+		Prompt:  "go",
+		OnEvent: collectEvents(&events),
+	}); err != nil {
+		t.Fatalf("RunTurn() error = %v", err)
+	}
+
+	// some/unknown/method → EventOtherMessage
+	if _, ok := firstEventOfType(events, domain.EventOtherMessage); !ok {
+		t.Error("expected EventOtherMessage for unknown notification method, not found")
+	}
+	// turn/plan/updated → EventNotification
+	found := false
+	for _, e := range events {
+		if e.Type == domain.EventNotification && e.Message == "plan updated" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected 'plan updated' EventNotification, not found")
+	}
+}
+
+func TestRunTurn_ToolCallWithNilRegistry(t *testing.T) {
+	t.Parallel()
+
+	state := makeTestState(loadFixture(t, "runturn_tool_call.jsonl"))
+	adapter, _ := NewCodexAdapter(map[string]any{}) // no tool_registry
+
+	var events []domain.AgentEvent
+	if _, err := adapter.RunTurn(context.Background(), fakeSession(state), domain.RunTurnParams{
+		Prompt:  "use tool",
+		OnEvent: collectEvents(&events),
+	}); err != nil {
+		t.Fatalf("RunTurn() error = %v", err)
+	}
+
+	e, ok := firstEventOfType(events, domain.EventUnsupportedToolCall)
+	if !ok {
+		t.Fatal("expected EventUnsupportedToolCall with nil registry, not found")
+	}
+	if e.ToolName != "create_issue" {
+		t.Errorf("ToolName = %q, want %q", e.ToolName, "create_issue")
+	}
+}
+
+func TestRunTurn_ToolCallWithRegisteredTool(t *testing.T) {
+	t.Parallel()
+
+	reg := domain.NewToolRegistry()
+	reg.Register(&fakeTool{
+		name:   "create_issue",
+		result: json.RawMessage(`{"id":"123"}`),
+	})
+
+	state := makeTestState(loadFixture(t, "runturn_tool_call.jsonl"))
+	adapter, _ := NewCodexAdapter(map[string]any{"tool_registry": reg})
+
+	var events []domain.AgentEvent
+	if _, err := adapter.RunTurn(context.Background(), fakeSession(state), domain.RunTurnParams{
+		Prompt:  "use tool",
+		OnEvent: collectEvents(&events),
+	}); err != nil {
+		t.Fatalf("RunTurn() error = %v", err)
+	}
+
+	e, ok := firstEventOfType(events, domain.EventToolResult)
+	if !ok {
+		t.Fatal("expected EventToolResult from registered tool, not found")
+	}
+	if e.ToolError {
+		t.Error("EventToolResult.ToolError = true, want false")
+	}
+	if e.ToolName != "create_issue" {
+		t.Errorf("EventToolResult.ToolName = %q, want %q", e.ToolName, "create_issue")
+	}
+}
+
+func TestRunTurn_ToolCallWithToolError(t *testing.T) {
+	t.Parallel()
+
+	reg := domain.NewToolRegistry()
+	reg.Register(&fakeTool{
+		name:    "create_issue",
+		execErr: errors.New("tracker unavailable"),
+	})
+
+	state := makeTestState(loadFixture(t, "runturn_tool_call.jsonl"))
+	adapter, _ := NewCodexAdapter(map[string]any{"tool_registry": reg})
+
+	var events []domain.AgentEvent
+	if _, err := adapter.RunTurn(context.Background(), fakeSession(state), domain.RunTurnParams{
+		Prompt:  "use tool",
+		OnEvent: collectEvents(&events),
+	}); err != nil {
+		t.Fatalf("RunTurn() error = %v", err)
+	}
+
+	e, ok := firstEventOfType(events, domain.EventToolResult)
+	if !ok {
+		t.Fatal("expected EventToolResult from failed tool, not found")
+	}
+	if !e.ToolError {
+		t.Error("EventToolResult.ToolError = false, want true")
+	}
+}
+
+func TestRunTurn_ToolCallToolNotInRegistry(t *testing.T) {
+	t.Parallel()
+
+	reg := domain.NewToolRegistry()
+	// Registry has no "create_issue" tool.
+
+	state := makeTestState(loadFixture(t, "runturn_tool_call.jsonl"))
+	adapter, _ := NewCodexAdapter(map[string]any{"tool_registry": reg})
+
+	var events []domain.AgentEvent
+	if _, err := adapter.RunTurn(context.Background(), fakeSession(state), domain.RunTurnParams{
+		Prompt:  "use tool",
+		OnEvent: collectEvents(&events),
+	}); err != nil {
+		t.Fatalf("RunTurn() error = %v", err)
+	}
+
+	if _, ok := firstEventOfType(events, domain.EventUnsupportedToolCall); !ok {
+		t.Fatal("expected EventUnsupportedToolCall for unregistered tool, not found")
+	}
+}
+
+// --- handleToolCall direct tests ---
+
+func TestHandleToolCall_InvalidParams(t *testing.T) {
+	t.Parallel()
+
+	a, _ := NewCodexAdapter(map[string]any{})
+	adapter := a.(*CodexAdapter)
+	state := makeTestState(nil)
+	var wg sync.WaitGroup
+	var events []domain.AgentEvent
+
+	msg := parsedMessage{
+		IsNotification: true,
+		Response:       rpcResponse{ID: 42},
+		Notification: rpcNotification{
+			Method: "item/tool/call",
+			Params: json.RawMessage(`not-valid-json`),
+		},
+	}
+
+	// Should not panic; writes an error response to stdin (discarded).
+	adapter.handleToolCall(context.Background(), state, &wg, msg, func(e domain.AgentEvent) {
+		events = append(events, e)
+	}, slog.Default())
+	wg.Wait()
+
+	// Invalid params: no event emitted (returns early after sendResponse).
+	if len(events) != 0 {
+		t.Errorf("expected 0 events, got %d", len(events))
+	}
+}
+
+func TestHandleToolCall_NilRegistryEmitsUnsupported(t *testing.T) {
+	t.Parallel()
+
+	a, _ := NewCodexAdapter(map[string]any{})
+	adapter := a.(*CodexAdapter)
+	state := makeTestState(nil)
+	var wg sync.WaitGroup
+	var events []domain.AgentEvent
+
+	msg := parsedMessage{
+		IsNotification: true,
+		Response:       rpcResponse{ID: 1},
+		Notification: rpcNotification{
+			Params: json.RawMessage(`{"tool":"my_tool","arguments":{}}`),
+		},
+	}
+
+	adapter.handleToolCall(context.Background(), state, &wg, msg, func(e domain.AgentEvent) {
+		events = append(events, e)
+	}, slog.Default())
+	wg.Wait()
+
+	if e, ok := firstEventOfType(events, domain.EventUnsupportedToolCall); !ok {
+		t.Fatal("expected EventUnsupportedToolCall with nil registry")
+	} else if e.ToolName != "my_tool" {
+		t.Errorf("ToolName = %q, want %q", e.ToolName, "my_tool")
+	}
+}
+
+func TestHandleToolCall_ToolNotFound(t *testing.T) {
+	t.Parallel()
+
+	reg := domain.NewToolRegistry()
+	a, _ := NewCodexAdapter(map[string]any{"tool_registry": reg})
+	adapter := a.(*CodexAdapter)
+	state := makeTestState(nil)
+	var wg sync.WaitGroup
+	var events []domain.AgentEvent
+
+	msg := parsedMessage{
+		IsNotification: true,
+		Response:       rpcResponse{ID: 1},
+		Notification: rpcNotification{
+			Params: json.RawMessage(`{"tool":"unknown_tool","arguments":{}}`),
+		},
+	}
+
+	adapter.handleToolCall(context.Background(), state, &wg, msg, func(e domain.AgentEvent) {
+		events = append(events, e)
+	}, slog.Default())
+	wg.Wait()
+
+	if _, ok := firstEventOfType(events, domain.EventUnsupportedToolCall); !ok {
+		t.Fatal("expected EventUnsupportedToolCall for unregistered tool")
+	}
+}
+
+func TestHandleToolCall_ToolSuccess(t *testing.T) {
+	t.Parallel()
+
+	reg := domain.NewToolRegistry()
+	reg.Register(&fakeTool{name: "my_tool", result: json.RawMessage(`"ok"`)})
+	a, _ := NewCodexAdapter(map[string]any{"tool_registry": reg})
+	adapter := a.(*CodexAdapter)
+	state := makeTestState(nil)
+	var wg sync.WaitGroup
+	var events []domain.AgentEvent
+
+	msg := parsedMessage{
+		IsNotification: true,
+		Response:       rpcResponse{ID: 7},
+		Notification: rpcNotification{
+			Params: json.RawMessage(`{"tool":"my_tool","arguments":{"x":1}}`),
+		},
+	}
+
+	adapter.handleToolCall(context.Background(), state, &wg, msg, func(e domain.AgentEvent) {
+		events = append(events, e)
+	}, slog.Default())
+	wg.Wait()
+
+	e, ok := firstEventOfType(events, domain.EventToolResult)
+	if !ok {
+		t.Fatal("expected EventToolResult on success")
+	}
+	if e.ToolError {
+		t.Error("EventToolResult.ToolError = true, want false")
+	}
+	if e.ToolName != "my_tool" {
+		t.Errorf("ToolName = %q, want %q", e.ToolName, "my_tool")
+	}
+}
+
+func TestHandleToolCall_ToolError(t *testing.T) {
+	t.Parallel()
+
+	reg := domain.NewToolRegistry()
+	reg.Register(&fakeTool{name: "my_tool", execErr: errors.New("service down")})
+	a, _ := NewCodexAdapter(map[string]any{"tool_registry": reg})
+	adapter := a.(*CodexAdapter)
+	state := makeTestState(nil)
+	var wg sync.WaitGroup
+	var events []domain.AgentEvent
+
+	msg := parsedMessage{
+		IsNotification: true,
+		Response:       rpcResponse{ID: 7},
+		Notification: rpcNotification{
+			Params: json.RawMessage(`{"tool":"my_tool","arguments":{}}`),
+		},
+	}
+
+	adapter.handleToolCall(context.Background(), state, &wg, msg, func(e domain.AgentEvent) {
+		events = append(events, e)
+	}, slog.Default())
+	wg.Wait()
+
+	e, ok := firstEventOfType(events, domain.EventToolResult)
+	if !ok {
+		t.Fatal("expected EventToolResult on tool error")
+	}
+	if !e.ToolError {
+		t.Error("EventToolResult.ToolError = false, want true")
+	}
+	if e.Message != "service down" {
+		t.Errorf("Message = %q, want %q", e.Message, "service down")
+	}
+}
+
+// --- StopSession ---
+
+func TestStopSession_InvalidInternalType(t *testing.T) {
+	t.Parallel()
+
+	adapter, _ := NewCodexAdapter(map[string]any{})
+	err := adapter.StopSession(context.Background(), domain.Session{Internal: "wrong"})
+	if err == nil {
+		t.Fatal("StopSession() expected error for wrong internal type, got nil")
+	}
+}
+
+func TestStopSession_NilState(t *testing.T) {
+	t.Parallel()
+
+	// State with nil proc and nil waitCh — StopSession should return nil.
+	state := &sessionState{
+		stdin:  nopWriteCloser{},
+		waitCh: nil,
+	}
+	adapter, _ := NewCodexAdapter(map[string]any{})
+	err := adapter.StopSession(context.Background(), domain.Session{Internal: state})
+	if err != nil {
+		t.Fatalf("StopSession() error = %v", err)
+	}
+}
+
+// --- fakeTool for tool registry tests ---
+
+type fakeTool struct {
+	name    string
+	result  json.RawMessage
+	execErr error
+}
+
+func (f *fakeTool) Name() string                 { return f.name }
+func (f *fakeTool) Description() string          { return "fake tool for testing" }
+func (f *fakeTool) InputSchema() json.RawMessage { return json.RawMessage(`{}`) }
+func (f *fakeTool) Execute(_ context.Context, _ json.RawMessage) (json.RawMessage, error) {
+	return f.result, f.execErr
+}

--- a/internal/agent/codex/testdata/account_login_flow.jsonl
+++ b/internal/agent/codex/testdata/account_login_flow.jsonl
@@ -1,0 +1,3 @@
+{"id":2,"result":{"account":null}}
+{"id":3,"result":{"success":true}}
+{"method":"account/login/completed","params":{"success":true}}

--- a/internal/agent/codex/testdata/account_read_logged_in.jsonl
+++ b/internal/agent/codex/testdata/account_read_logged_in.jsonl
@@ -1,0 +1,1 @@
+{"id":2,"result":{"account":{"id":"user-123","email":"agent@example.com","name":"Test Agent"}}}

--- a/internal/agent/codex/testdata/initialize_response.jsonl
+++ b/internal/agent/codex/testdata/initialize_response.jsonl
@@ -1,0 +1,1 @@
+{"id":1,"result":{"serverInfo":{"name":"codex-app-server","version":"1.0.0"},"capabilities":{}}}

--- a/internal/agent/codex/testdata/runturn_agent_message.jsonl
+++ b/internal/agent/codex/testdata/runturn_agent_message.jsonl
@@ -1,0 +1,4 @@
+{"id":1,"result":{"turn":{"id":"turn-001","status":"starting"}}}
+{"method":"turn/started","params":{"turnId":"turn-001"}}
+{"method":"item/completed","params":{"item":{"id":"item-001","type":"agentMessage","text":"Here is my analysis of the code.","status":"completed"}}}
+{"method":"turn/completed","params":{"turn":{"id":"turn-001","status":"completed"},"usage":{"input_tokens":50,"output_tokens":20,"cached_input_tokens":0}}}

--- a/internal/agent/codex/testdata/runturn_failed.jsonl
+++ b/internal/agent/codex/testdata/runturn_failed.jsonl
@@ -1,0 +1,3 @@
+{"id":1,"result":{"turn":{"id":"turn-001","status":"starting"}}}
+{"method":"turn/started","params":{"turnId":"turn-001"}}
+{"method":"turn/completed","params":{"turn":{"id":"turn-001","status":"failed","error":{"message":"Context window exceeded","codexErrorInfo":"ContextWindowExceeded"}},"usage":{"input_tokens":200000,"output_tokens":0,"cached_input_tokens":0}}}

--- a/internal/agent/codex/testdata/runturn_items.jsonl
+++ b/internal/agent/codex/testdata/runturn_items.jsonl
@@ -1,0 +1,5 @@
+{"id":1,"result":{"turn":{"id":"turn-001","status":"starting"}}}
+{"method":"turn/started","params":{"turnId":"turn-001"}}
+{"method":"item/started","params":{"item":{"id":"item-001","type":"commandExecution","command":"ls -la"}}}
+{"method":"item/completed","params":{"item":{"id":"item-001","type":"commandExecution","status":"completed"}}}
+{"method":"turn/completed","params":{"turn":{"id":"turn-001","status":"completed"},"usage":{"input_tokens":80,"output_tokens":20,"cached_input_tokens":0}}}

--- a/internal/agent/codex/testdata/runturn_misc_notifications.jsonl
+++ b/internal/agent/codex/testdata/runturn_misc_notifications.jsonl
@@ -1,0 +1,8 @@
+{"id":1,"result":{"turn":{"id":"turn-001","status":"starting"}}}
+{"method":"turn/started","params":{"turnId":"turn-001"}}
+{"method":"some/unknown/method","params":{}}
+{"method":"turn/plan/updated","params":{}}
+{"method":"turn/diff/updated","params":{}}
+{"method":"item/agentMessage/delta","params":{}}
+{"method":"item/commandExecution/outputDelta","params":{}}
+{"method":"turn/completed","params":{"turn":{"id":"turn-001","status":"completed"},"usage":{}}}

--- a/internal/agent/codex/testdata/runturn_success.jsonl
+++ b/internal/agent/codex/testdata/runturn_success.jsonl
@@ -1,0 +1,3 @@
+{"id":1,"result":{"turn":{"id":"turn-001","status":"starting"}}}
+{"method":"turn/started","params":{"turnId":"turn-001"}}
+{"method":"turn/completed","params":{"turn":{"id":"turn-001","status":"completed"},"usage":{"input_tokens":100,"output_tokens":50,"cached_input_tokens":10}}}

--- a/internal/agent/codex/testdata/runturn_tool_call.jsonl
+++ b/internal/agent/codex/testdata/runturn_tool_call.jsonl
@@ -1,0 +1,4 @@
+{"id":1,"result":{"turn":{"id":"turn-001","status":"starting"}}}
+{"method":"turn/started","params":{"turnId":"turn-001"}}
+{"id":99,"method":"item/tool/call","params":{"tool":"create_issue","arguments":{"title":"Bug","description":"Details"}}}
+{"method":"turn/completed","params":{"turn":{"id":"turn-001","status":"completed"},"usage":{"input_tokens":60,"output_tokens":30,"cached_input_tokens":0}}}

--- a/internal/agent/codex/testdata/thread_start_response.jsonl
+++ b/internal/agent/codex/testdata/thread_start_response.jsonl
@@ -1,0 +1,2 @@
+{"id":4,"result":{"thread":{"id":"thread-abc-123","status":"active"}}}
+{"method":"thread/started","params":{"threadId":"thread-abc-123"}}

--- a/internal/agent/codex/testdata/turn_completed_failed.jsonl
+++ b/internal/agent/codex/testdata/turn_completed_failed.jsonl
@@ -1,0 +1,3 @@
+{"id":5,"result":{"turn":{"id":"turn-002","status":"starting"}}}
+{"method":"turn/started","params":{"turnId":"turn-002"}}
+{"method":"turn/completed","params":{"turn":{"id":"turn-002","status":"failed","error":{"message":"Context window exceeded","codexErrorInfo":"ContextWindowExceeded"}},"usage":{"input_tokens":200000,"output_tokens":0,"cached_input_tokens":0}}}

--- a/internal/agent/codex/testdata/turn_completed_success.jsonl
+++ b/internal/agent/codex/testdata/turn_completed_success.jsonl
@@ -1,0 +1,5 @@
+{"id":5,"result":{"turn":{"id":"turn-001","status":"starting"}}}
+{"method":"turn/started","params":{"turnId":"turn-001"}}
+{"method":"item/started","params":{"item":{"id":"item-001","type":"agentMessage"}}}
+{"method":"item/completed","params":{"item":{"id":"item-001","type":"agentMessage","text":"Task completed successfully.","status":"completed"}}}
+{"method":"turn/completed","params":{"turn":{"id":"turn-001","status":"completed"},"usage":{"input_tokens":100,"output_tokens":50,"cached_input_tokens":10}}}

--- a/internal/agent/codex/testdata/turn_interrupted.jsonl
+++ b/internal/agent/codex/testdata/turn_interrupted.jsonl
@@ -1,0 +1,3 @@
+{"id":5,"result":{"turn":{"id":"turn-004","status":"starting"}}}
+{"method":"turn/started","params":{"turnId":"turn-004"}}
+{"method":"turn/completed","params":{"turn":{"id":"turn-004","status":"interrupted"},"usage":{"input_tokens":30,"output_tokens":10,"cached_input_tokens":0}}}

--- a/internal/agent/codex/testdata/turn_with_tool_call.jsonl
+++ b/internal/agent/codex/testdata/turn_with_tool_call.jsonl
@@ -1,0 +1,4 @@
+{"id":5,"result":{"turn":{"id":"turn-003","status":"starting"}}}
+{"method":"turn/started","params":{"turnId":"turn-003"}}
+{"id":42,"method":"item/tool/call","params":{"tool":"create_issue","arguments":{"title":"Bug report","description":"Some bug"}}}
+{"method":"turn/completed","params":{"turn":{"id":"turn-003","status":"completed"},"usage":{"input_tokens":50,"output_tokens":25,"cached_input_tokens":0}}}


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Feat

**Intent:** Add `CodexAdapter` — the third production agent adapter for Sortie — enabling the orchestrator to manage OpenAI Codex CLI as a coding agent via the `codex app-server` JSON-RPC 2.0 protocol. Operators can now set `agent.kind: codex` in WORKFLOW.md and get the same structured lifecycle (event normalization, token tracking, timeout enforcement, session resume) as Claude Code and Copilot adapters.

**Related Issues:** #238

### 🧭 Reviewer Guide

**Complexity:** High

#### Entry Point

`internal/agent/codex/codex.go` — the main adapter file. Start here to understand the persistent subprocess model: `StartSession` launches `codex app-server` and runs the full JSON-RPC handshake (initialize → account/read → thread/start); `RunTurn` uses a background reader goroutine feeding a buffered channel so `context.Context` cancellation works without blocking on the subprocess; `StopSession` closes stdin then SIGTERM → SIGKILL with a 5-second grace period.

#### Sensitive Areas

- `internal/agent/codex/codex.go` (`StartSession`): Workspace path validation and `writableRoots` construction — `writableRoots` is always derived from the validated, `filepath.Abs`-resolved workspace path, never from raw user input.
- `internal/agent/codex/protocol.go` (`authenticateIfNeeded`, `buildSandboxPolicy`): Auth key is read from `CODEX_API_KEY` env var; sandbox `writableRoots` is locked to the session workspace.
- `internal/agent/codex/codex.go` (`RunTurn` tool dispatch): Dynamic tool calls are dispatched in goroutines that acquire `state.mu` before writing to stdin — guards against concurrent stdin corruption.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes. New package only; no modifications to core packages.
- **Migrations/State:** No migrations or state changes.