### PR TITLE
refactor(codex): move stdout reader to session-scoped goroutine

### DIFF
--- a/docs/workflow-reference.md
+++ b/docs/workflow-reference.md
@@ -359,7 +359,7 @@ agent:
 
 | Field                            | Type                              | Required                            | Default         | Dynamic Reload                             | Description                                                                                                                                                                      |
 | -------------------------------- | --------------------------------- | ----------------------------------- | --------------- | ------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `kind`                           | string                            | No                                  | `claude-code`   | Future dispatches                          | Agent adapter identifier. This codebase ships with the `claude-code` adapter. Other kinds (for example, HTTP-based adapters) are available only if you register them separately. |
+| `kind`                           | string                            | No                                  | `claude-code`   | Future dispatches                          | Agent adapter identifier. Built-in adapters: `claude-code`, `copilot-cli`, `codex`. Other kinds (for example, HTTP-based adapters) are available only if you register them separately. |
 | `command`                        | string (shell command)            | When adapter requires local process | Adapter-defined | Future dispatches                          | Shell command to launch the agent for adapters that run as a local subprocess (such as `claude-code`). Adapters that do not start a local process ignore this field.             |
 | `turn_timeout_ms`                | integer                           | No                                  | `3600000` (1h)  | Future worker attempts                     | Total timeout for a single agent turn.                                                                                                                                           |
 | `read_timeout_ms`                | integer                           | No                                  | `5000` (5s)     | Future worker attempts                     | Request/response timeout during startup and synchronous operations.                                                                                                              |
@@ -1271,11 +1271,15 @@ token_rates:
     input_per_mtok: 2.00
     output_per_mtok: 8.00
     cache_read_per_mtok: 0.20
+  codex:
+    input_per_mtok: 2.50
+    output_per_mtok: 10.00
+    cache_read_per_mtok: 0.25
 ```
 
 When `token_rates` is configured, the dashboard displays estimated USD cost for
 currently running sessions. Keys are agent adapter kind strings (e.g., `"claude-code"`,
-`"copilot-cli"`). All rates are in USD per 1 million tokens.
+`"copilot-cli"`, `"codex"`). All rates are in USD per 1 million tokens.
 
 When `token_rates` is absent or empty, the dashboard shows raw token counts without
 cost estimates.
@@ -1344,6 +1348,32 @@ to CLI flags.
 > limit controls how many turns the worker runs before exiting. The adapter limit controls
 > the Claude Code CLI's internal turn budget. They serve different purposes and should
 > typically have different values.
+
+**Codex adapter:**
+
+```yaml
+codex:
+  model: o3                       # Model override (e.g., "gpt-5.4", "o3")
+  effort: medium                  # Reasoning effort: "low", "medium", "high"
+  approval_policy: never          # "never" (default), "onRequest", "unlessTrusted", "always"
+  thread_sandbox: workspaceWrite  # "workspaceWrite" (default), "readOnly", "dangerFullAccess", "externalSandbox"
+  personality: concise            # Personality preset
+  skip_git_repo_check: false      # Skip git repo validation for non-git workspaces
+  turn_sandbox_policy:            # Per-turn sandbox policy override (optional)
+    networkAccess: true
+```
+
+The `codex` block is forwarded to the Codex adapter, which uses these fields
+when initializing the `codex app-server` subprocess and starting threads.
+
+The Codex adapter uses a persistent subprocess model: the app-server is launched
+once in `StartSession` and kept alive across turns, unlike the per-turn subprocess
+model used by `claude-code` and `copilot-cli`.
+
+> **Sandbox defaults:** When `thread_sandbox` is omitted, the adapter defaults to
+> `workspaceWrite` with `writableRoots` set to the workspace path and
+> `networkAccess: false`. Use `turn_sandbox_policy` to override specific sandbox
+> fields per turn.
 
 **Custom or future adapters (illustrative example):**
 

--- a/internal/agent/codex/codex.go
+++ b/internal/agent/codex/codex.go
@@ -84,10 +84,12 @@ type sessionState struct {
 	// stdout after the handshake and delivers parsed messages to
 	// RunTurn via msgCh. stopCh is closed by StopSession to unblock
 	// the reader if msgCh is full. readerDone is closed by the reader
-	// when it exits.
+	// when it exits. closeStop guards against double-closing stopCh
+	// when StopSession is called more than once.
 	msgCh      chan parsedMessage
 	readerDone chan struct{}
 	stopCh     chan struct{}
+	closeStop  sync.Once
 }
 
 // NewCodexAdapter creates a [CodexAdapter] from adapter configuration.
@@ -793,9 +795,11 @@ func (a *CodexAdapter) StopSession(_ context.Context, session domain.Session) er
 
 	// Signal the reader goroutine to stop before closing stdin,
 	// preventing it from blocking on a full msgCh during teardown.
-	if state.stopCh != nil {
-		close(state.stopCh)
-	}
+	state.closeStop.Do(func() {
+		if state.stopCh != nil {
+			close(state.stopCh)
+		}
+	})
 
 	// Close stdin to signal EOF to the app-server.
 	state.mu.Lock()
@@ -836,7 +840,11 @@ func (a *CodexAdapter) StopSession(_ context.Context, session domain.Session) er
 		select {
 		case <-state.readerDone:
 		case <-time.After(2 * time.Second):
-			slog.Warn("reader goroutine did not exit after process termination")
+			logger := logging.WithSession(
+				slog.Default().With(slog.String("component", "codex-adapter")),
+				state.threadID,
+			)
+			logger.Warn("reader goroutine did not exit after process termination")
 		}
 	}
 

--- a/internal/agent/codex/codex.go
+++ b/internal/agent/codex/codex.go
@@ -79,6 +79,15 @@ type sessionState struct {
 	stdin           io.WriteCloser
 	stdout          io.ReadCloser
 	stderrCollector *procutil.StderrCollector
+
+	// Session-scoped reader channels. The reader goroutine reads
+	// stdout after the handshake and delivers parsed messages to
+	// RunTurn via msgCh. stopCh is closed by StopSession to unblock
+	// the reader if msgCh is full. readerDone is closed by the reader
+	// when it exits.
+	msgCh      chan parsedMessage
+	readerDone chan struct{}
+	stopCh     chan struct{}
 }
 
 // NewCodexAdapter creates a [CodexAdapter] from adapter configuration.
@@ -343,6 +352,29 @@ func (a *CodexAdapter) StartSession(ctx context.Context, params domain.StartSess
 
 	state.threadID = threadID
 
+	state.msgCh = make(chan parsedMessage, 16)
+	state.readerDone = make(chan struct{})
+	state.stopCh = make(chan struct{})
+
+	go func() {
+		defer close(state.readerDone)
+		defer close(state.msgCh)
+		for scanner.Scan() {
+			msg := parseMessage(scanner.Bytes())
+			select {
+			case state.msgCh <- msg:
+			case <-state.stopCh:
+				return
+			}
+		}
+		if err := scanner.Err(); err != nil {
+			select {
+			case state.msgCh <- parsedMessage{Err: err}:
+			case <-state.stopCh:
+			}
+		}
+	}()
+
 	return domain.Session{
 		ID:       threadID,
 		AgentPID: strconv.Itoa(cmd.Process.Pid),
@@ -399,18 +431,39 @@ func (a *CodexAdapter) RunTurn(ctx context.Context, session domain.Session, para
 		}
 	}
 
-	// Read the turn/start response synchronously before entering the
-	// event loop. The stdout pipe is not yet shared with the
-	// background reader.
-	scanner := bufio.NewScanner(state.stdout)
-	scanner.Buffer(make([]byte, 0, 1<<20), 1<<20)
-
-	turnStartResp, err := readResponse(ctx, scanner, id)
-	if err != nil {
+	// Fast-path: return immediately if the context is already done.
+	if ctx.Err() != nil {
 		return domain.TurnResult{}, &domain.AgentError{
 			Kind:    domain.ErrPortExit,
-			Message: fmt.Sprintf("turn/start response: %v", err),
-			Err:     err,
+			Message: fmt.Sprintf("turn/start response: %v", ctx.Err()),
+			Err:     ctx.Err(),
+		}
+	}
+
+	// Wait for the turn/start response from the session-scoped reader.
+	var turnStartResp rpcResponse
+	for turnStartResp.ID == 0 {
+		select {
+		case <-ctx.Done():
+			return domain.TurnResult{}, &domain.AgentError{
+				Kind:    domain.ErrPortExit,
+				Message: fmt.Sprintf("turn/start response: %v", ctx.Err()),
+				Err:     ctx.Err(),
+			}
+		case msg, ok := <-state.msgCh:
+			if !ok {
+				return domain.TurnResult{}, &domain.AgentError{
+					Kind:    domain.ErrPortExit,
+					Message: "stdout closed before turn/start response",
+				}
+			}
+			if msg.Err != nil {
+				logger.Warn("ignoring unparseable stdout line", slog.Any("error", msg.Err))
+				continue
+			}
+			if msg.IsResponse && msg.Response.ID == id {
+				turnStartResp = msg.Response
+			}
 		}
 	}
 	if turnStartResp.Error != nil {
@@ -428,21 +481,6 @@ func (a *CodexAdapter) RunTurn(ctx context.Context, session domain.Session, para
 		logger.Warn("turn/start result unmarshal failed", slog.Any("error", err))
 	}
 	turnID := turnResult.Turn.ID
-
-	// Background reader goroutine: feeds parsed messages into a
-	// buffered channel so the event loop can select on ctx.Done()
-	// without blocking on a hung subprocess.
-	msgCh := make(chan parsedMessage, 16)
-	go func() {
-		defer close(msgCh)
-		for scanner.Scan() {
-			msg := parseMessage(scanner.Bytes())
-			msgCh <- msg
-		}
-		if err := scanner.Err(); err != nil {
-			msgCh <- parsedMessage{Err: err}
-		}
-	}()
 
 	inFlight := make(map[string]inFlightTool)
 	var usage domain.TokenUsage
@@ -468,7 +506,7 @@ func (a *CodexAdapter) RunTurn(ctx context.Context, session domain.Session, para
 			// Continue reading until turn/completed or channel close.
 			continue
 
-		case msg, ok := <-msgCh:
+		case msg, ok := <-state.msgCh:
 			if !ok {
 				// Channel closed — subprocess stdout ended.
 				toolWg.Wait()
@@ -753,6 +791,12 @@ func (a *CodexAdapter) StopSession(_ context.Context, session domain.Session) er
 		return fmt.Errorf("unexpected session internal type %T", session.Internal)
 	}
 
+	// Signal the reader goroutine to stop before closing stdin,
+	// preventing it from blocking on a full msgCh during teardown.
+	if state.stopCh != nil {
+		close(state.stopCh)
+	}
+
 	// Close stdin to signal EOF to the app-server.
 	state.mu.Lock()
 	if state.stdin != nil {
@@ -784,6 +828,15 @@ func (a *CodexAdapter) StopSession(_ context.Context, session domain.Session) er
 				case <-time.After(2 * time.Second):
 				}
 			}
+		}
+	}
+
+	// Wait for the reader goroutine to finish after process exit.
+	if state.readerDone != nil {
+		select {
+		case <-state.readerDone:
+		case <-time.After(2 * time.Second):
+			slog.Warn("reader goroutine did not exit after process termination")
 		}
 	}
 

--- a/internal/agent/codex/runturn_test.go
+++ b/internal/agent/codex/runturn_test.go
@@ -3,6 +3,7 @@
 package codex
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
@@ -36,13 +37,39 @@ func loadFixture(t *testing.T, name string) []byte {
 // for use in RunTurn and handleToolCall unit tests that do not launch a
 // real subprocess.
 func makeTestState(fixtureData []byte) *sessionState {
-	return &sessionState{
+	state := &sessionState{
 		threadID:      "thread-001",
 		workspacePath: "/tmp",
 		waitCh:        make(chan struct{}),
 		stdin:         nopWriteCloser{},
-		stdout:        io.NopCloser(bytes.NewReader(fixtureData)),
+		stdout:        io.NopCloser(bytes.NewReader(nil)),
+		msgCh:         make(chan parsedMessage, 16),
+		readerDone:    make(chan struct{}),
+		stopCh:        make(chan struct{}),
 	}
+
+	go func() {
+		defer close(state.readerDone)
+		defer close(state.msgCh)
+		scanner := bufio.NewScanner(bytes.NewReader(fixtureData))
+		scanner.Buffer(make([]byte, 0, 1<<20), 1<<20)
+		for scanner.Scan() {
+			msg := parseMessage(scanner.Bytes())
+			select {
+			case state.msgCh <- msg:
+			case <-state.stopCh:
+				return
+			}
+		}
+		if err := scanner.Err(); err != nil {
+			select {
+			case state.msgCh <- parsedMessage{Err: err}:
+			case <-state.stopCh:
+			}
+		}
+	}()
+
+	return state
 }
 
 // fakeSession wraps state in a domain.Session suitable for RunTurn.
@@ -201,6 +228,21 @@ func TestRunTurn_StdoutClosedBeforeTurnCompleted(t *testing.T) {
 	fixture := "{\"id\":1,\"result\":{\"turn\":{\"id\":\"turn-001\",\"status\":\"starting\"}}}\n" +
 		"{\"method\":\"turn/started\",\"params\":{}}\n"
 	state := makeTestState([]byte(fixture))
+	adapter, _ := NewCodexAdapter(map[string]any{})
+
+	_, err := adapter.RunTurn(context.Background(), fakeSession(state), domain.RunTurnParams{
+		Prompt:  "go",
+		OnEvent: func(domain.AgentEvent) {},
+	})
+	requireAgentError(t, err, domain.ErrPortExit)
+}
+
+func TestRunTurn_StdoutEOFBeforeTurnStartResponse(t *testing.T) {
+	t.Parallel()
+
+	// Empty fixture: msgCh closes before any turn/start response arrives.
+	// Tests the !ok path in the session-scoped response-wait loop.
+	state := makeTestState(nil)
 	adapter, _ := NewCodexAdapter(map[string]any{})
 
 	_, err := adapter.RunTurn(context.Background(), fakeSession(state), domain.RunTurnParams{
@@ -608,6 +650,75 @@ func TestStopSession_InvalidInternalType(t *testing.T) {
 	}
 }
 
+func TestRunTurn_MultiTurnNoRace(t *testing.T) {
+	t.Parallel()
+
+	fixture := "{\"id\":1,\"result\":{\"turn\":{\"id\":\"turn-001\",\"status\":\"starting\"}}}\n" +
+		"{\"method\":\"turn/started\",\"params\":{\"turnId\":\"turn-001\"}}\n" +
+		"{\"method\":\"turn/completed\",\"params\":{\"turn\":{\"id\":\"turn-001\",\"status\":\"completed\"},\"usage\":{\"input_tokens\":100,\"output_tokens\":50,\"cached_input_tokens\":10}}}\n" +
+		"{\"id\":2,\"result\":{\"turn\":{\"id\":\"turn-002\",\"status\":\"starting\"}}}\n" +
+		"{\"method\":\"turn/started\",\"params\":{\"turnId\":\"turn-002\"}}\n" +
+		"{\"method\":\"turn/completed\",\"params\":{\"turn\":{\"id\":\"turn-002\",\"status\":\"completed\"},\"usage\":{\"input_tokens\":200,\"output_tokens\":100,\"cached_input_tokens\":20}}}\n"
+
+	state := makeTestState([]byte(fixture))
+	adapter, _ := NewCodexAdapter(map[string]any{})
+	session := fakeSession(state)
+
+	result1, err := adapter.RunTurn(context.Background(), session, domain.RunTurnParams{
+		Prompt:  "first turn",
+		OnEvent: func(domain.AgentEvent) {},
+	})
+	if err != nil {
+		t.Fatalf("RunTurn(1) error = %v", err)
+	}
+	if result1.ExitReason != domain.EventTurnCompleted {
+		t.Errorf("RunTurn(1) ExitReason = %v, want %v", result1.ExitReason, domain.EventTurnCompleted)
+	}
+
+	result2, err := adapter.RunTurn(context.Background(), session, domain.RunTurnParams{
+		Prompt:  "second turn",
+		OnEvent: func(domain.AgentEvent) {},
+	})
+	if err != nil {
+		t.Fatalf("RunTurn(2) error = %v", err)
+	}
+	if result2.ExitReason != domain.EventTurnCompleted {
+		t.Errorf("RunTurn(2) ExitReason = %v, want %v", result2.ExitReason, domain.EventTurnCompleted)
+	}
+}
+
+func TestRunTurn_StdoutEOFBetweenTurns(t *testing.T) {
+	t.Parallel()
+
+	// One complete turn in the fixture. After the first RunTurn drains the
+	// channel, the reader goroutine closes msgCh on EOF. A second RunTurn
+	// call receives !ok immediately and returns ErrPortExit — the
+	// "stdout EOF between turns" behavior introduced by the session-scoped
+	// reader refactoring (previously undetected).
+	fixture := "{\"id\":1,\"result\":{\"turn\":{\"id\":\"turn-001\",\"status\":\"starting\"}}}\n" +
+		"{\"method\":\"turn/started\",\"params\":{\"turnId\":\"turn-001\"}}\n" +
+		"{\"method\":\"turn/completed\",\"params\":{\"turn\":{\"id\":\"turn-001\",\"status\":\"completed\"},\"usage\":{\"input_tokens\":10,\"output_tokens\":5,\"cached_input_tokens\":0}}}\n"
+
+	state := makeTestState([]byte(fixture))
+	adapter, _ := NewCodexAdapter(map[string]any{})
+	session := fakeSession(state)
+
+	if _, err := adapter.RunTurn(context.Background(), session, domain.RunTurnParams{
+		Prompt:  "first turn",
+		OnEvent: func(domain.AgentEvent) {},
+	}); err != nil {
+		t.Fatalf("RunTurn(1) unexpected error: %v", err)
+	}
+
+	// After the first turn, the fixture is exhausted and msgCh is closed.
+	// The second call must return ErrPortExit immediately.
+	_, err := adapter.RunTurn(context.Background(), session, domain.RunTurnParams{
+		Prompt:  "second turn",
+		OnEvent: func(domain.AgentEvent) {},
+	})
+	requireAgentError(t, err, domain.ErrPortExit)
+}
+
 func TestStopSession_NilState(t *testing.T) {
 	t.Parallel()
 
@@ -620,6 +731,31 @@ func TestStopSession_NilState(t *testing.T) {
 	err := adapter.StopSession(context.Background(), domain.Session{Internal: state})
 	if err != nil {
 		t.Fatalf("StopSession() error = %v", err)
+	}
+}
+
+func TestStopSession_WithActiveReaderGoroutine(t *testing.T) {
+	t.Parallel()
+
+	// Provide more messages than the channel buffer (16) so the reader
+	// goroutine is blocked on a channel send when StopSession closes stopCh.
+	line := []byte("{\"method\":\"turn/started\",\"params\":{}}\n")
+	state := makeTestState(bytes.Repeat(line, 20))
+	// Simulate the subprocess having already exited so waitCh does not block.
+	close(state.waitCh)
+
+	adapter, _ := NewCodexAdapter(map[string]any{})
+	err := adapter.StopSession(context.Background(), domain.Session{Internal: state})
+	if err != nil {
+		t.Fatalf("StopSession() error = %v", err)
+	}
+
+	// StopSession waits on readerDone internally; it must be closed on return.
+	select {
+	case <-state.readerDone:
+		// OK
+	default:
+		t.Error("readerDone should be closed after StopSession")
 	}
 }
 


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Refactor

**Intent:** Eliminate a latent data race in the Codex adapter where two concurrent `bufio.Scanner` readers could exist on the same `io.Reader` across sequential `RunTurn` calls. A single session-scoped goroutine now owns the stdout pipe for the entire session lifetime.

**Related Issues:** #461

### 🧭 Reviewer Guide

**Complexity:** Medium

#### Entry Point

`internal/agent/codex/codex.go` — three new fields on `sessionState` (`msgCh`, `readerDone`, `stopCh`) drive the change. The reader goroutine starts at the end of `StartSession` after the handshake completes (scanner ownership transfers there). `RunTurn` now drains `state.msgCh` instead of creating a per-turn scanner. `StopSession` closes `stopCh` first to unblock the goroutine under backpressure, then waits on `readerDone` after process exit.

#### Sensitive Areas

- `internal/agent/codex/codex.go`: Goroutine lifecycle and channel coordination — verify `stopCh` is always closed before stdin close, and `readerDone` wait has the timeout guard.
- `internal/agent/codex/runturn_test.go`: `makeTestState` now owns a live goroutine feeding `state.msgCh`; all existing tests run through this path.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes — `domain.AgentAdapter` interface and all public adapter contracts are unchanged.
- **Migrations/State:** No migrations or state changes.