### PR TITLE
fix(codex): serialize onEvent calls from tool goroutines via channel

### DIFF
--- a/internal/agent/codex/codex.go
+++ b/internal/agent/codex/codex.go
@@ -487,10 +487,14 @@ func (a *CodexAdapter) RunTurn(ctx context.Context, session domain.Session, para
 	inFlight := make(map[string]inFlightTool)
 	var usage domain.TokenUsage
 	var toolWg sync.WaitGroup
+	toolEventCh := make(chan domain.AgentEvent, 8)
 	interrupted := false
 
 	for {
 		select {
+		case evt := <-toolEventCh:
+			params.OnEvent(evt)
+
 		case <-ctx.Done():
 			if !interrupted {
 				interrupted = true
@@ -511,7 +515,10 @@ func (a *CodexAdapter) RunTurn(ctx context.Context, session domain.Session, para
 		case msg, ok := <-state.msgCh:
 			if !ok {
 				// Channel closed — subprocess stdout ended.
-				toolWg.Wait()
+				go func() { toolWg.Wait(); close(toolEventCh) }()
+				for evt := range toolEventCh {
+					params.OnEvent(evt)
+				}
 				return domain.TurnResult{
 						SessionID:  state.threadID,
 						ExitReason: domain.EventTurnFailed,
@@ -528,7 +535,10 @@ func (a *CodexAdapter) RunTurn(ctx context.Context, session domain.Session, para
 					Timestamp: now,
 					Message:   msg.Err.Error(),
 				})
-				toolWg.Wait()
+				go func() { toolWg.Wait(); close(toolEventCh) }()
+				for evt := range toolEventCh {
+					params.OnEvent(evt)
+				}
 				return domain.TurnResult{
 						SessionID:  state.threadID,
 						ExitReason: domain.EventTurnFailed,
@@ -594,7 +604,10 @@ func (a *CodexAdapter) RunTurn(ctx context.Context, session domain.Session, para
 						Timestamp: now,
 						Usage:     usage,
 					})
-					toolWg.Wait()
+					go func() { toolWg.Wait(); close(toolEventCh) }()
+					for evt := range toolEventCh {
+						params.OnEvent(evt)
+					}
 					return domain.TurnResult{
 							SessionID:  state.threadID,
 							ExitReason: exitReason,
@@ -616,7 +629,10 @@ func (a *CodexAdapter) RunTurn(ctx context.Context, session domain.Session, para
 					Usage:     usage,
 				})
 
-				toolWg.Wait()
+				go func() { toolWg.Wait(); close(toolEventCh) }()
+				for evt := range toolEventCh {
+					params.OnEvent(evt)
+				}
 				return domain.TurnResult{
 					SessionID:  state.threadID,
 					ExitReason: exitReason,
@@ -682,7 +698,7 @@ func (a *CodexAdapter) RunTurn(ctx context.Context, session domain.Session, para
 				})
 
 			case "item/tool/call":
-				a.handleToolCall(ctx, state, &toolWg, msg, params.OnEvent, logger)
+				a.handleToolCall(ctx, state, &toolWg, msg, toolEventCh, logger)
 
 			case "turn/plan/updated":
 				params.OnEvent(domain.AgentEvent{
@@ -709,8 +725,9 @@ func (a *CodexAdapter) RunTurn(ctx context.Context, session domain.Session, para
 // the ToolRegistry. The tool is executed asynchronously to avoid
 // blocking the event read loop. The provided WaitGroup is incremented
 // before launching the goroutine so RunTurn can wait for in-flight
-// tools before returning.
-func (a *CodexAdapter) handleToolCall(ctx context.Context, state *sessionState, wg *sync.WaitGroup, msg parsedMessage, onEvent func(domain.AgentEvent), logger *slog.Logger) {
+// tools before returning. Events are sent via toolEventCh so that
+// OnEvent is called exclusively from the RunTurn goroutine.
+func (a *CodexAdapter) handleToolCall(ctx context.Context, state *sessionState, wg *sync.WaitGroup, msg parsedMessage, toolEventCh chan<- domain.AgentEvent, logger *slog.Logger) {
 	now := time.Now().UTC()
 	requestID := msg.Response.ID
 
@@ -729,12 +746,12 @@ func (a *CodexAdapter) handleToolCall(ctx context.Context, state *sessionState, 
 		state.mu.Lock()
 		sendResponse(state, requestID, toolResultFor(false, fmt.Sprintf("unsupported tool: %s", toolName))) //nolint:errcheck,gosec // best-effort error response
 		state.mu.Unlock()
-		onEvent(domain.AgentEvent{
+		toolEventCh <- domain.AgentEvent{
 			Type:      domain.EventUnsupportedToolCall,
 			Timestamp: now,
 			ToolName:  toolName,
 			Message:   fmt.Sprintf("no tool registry configured for tool %q", toolName),
-		})
+		}
 		return
 	}
 
@@ -743,12 +760,12 @@ func (a *CodexAdapter) handleToolCall(ctx context.Context, state *sessionState, 
 		state.mu.Lock()
 		sendResponse(state, requestID, toolResultFor(false, fmt.Sprintf("unsupported tool: %s", toolName))) //nolint:errcheck,gosec // best-effort error response
 		state.mu.Unlock()
-		onEvent(domain.AgentEvent{
+		toolEventCh <- domain.AgentEvent{
 			Type:      domain.EventUnsupportedToolCall,
 			Timestamp: now,
 			ToolName:  toolName,
 			Message:   fmt.Sprintf("tool %q not registered", toolName),
-		})
+		}
 		return
 	}
 
@@ -767,21 +784,21 @@ func (a *CodexAdapter) handleToolCall(ctx context.Context, state *sessionState, 
 		state.mu.Unlock()
 
 		if execErr != nil {
-			onEvent(domain.AgentEvent{
+			toolEventCh <- domain.AgentEvent{
 				Type:           domain.EventToolResult,
 				Timestamp:      time.Now().UTC(),
 				ToolName:       toolName,
 				ToolDurationMS: time.Since(start).Milliseconds(),
 				ToolError:      true,
 				Message:        execErr.Error(),
-			})
+			}
 		} else {
-			onEvent(domain.AgentEvent{
+			toolEventCh <- domain.AgentEvent{
 				Type:           domain.EventToolResult,
 				Timestamp:      time.Now().UTC(),
 				ToolName:       toolName,
 				ToolDurationMS: time.Since(start).Milliseconds(),
-			})
+			}
 		}
 	}()
 }

--- a/internal/agent/codex/codex.go
+++ b/internal/agent/codex/codex.go
@@ -698,7 +698,9 @@ func (a *CodexAdapter) RunTurn(ctx context.Context, session domain.Session, para
 				})
 
 			case "item/tool/call":
-				a.handleToolCall(ctx, state, &toolWg, msg, toolEventCh, logger)
+				if evt := a.handleToolCall(ctx, state, &toolWg, msg, toolEventCh, logger); evt != nil {
+					params.OnEvent(*evt)
+				}
 
 			case "turn/plan/updated":
 				params.OnEvent(domain.AgentEvent{
@@ -725,9 +727,11 @@ func (a *CodexAdapter) RunTurn(ctx context.Context, session domain.Session, para
 // the ToolRegistry. The tool is executed asynchronously to avoid
 // blocking the event read loop. The provided WaitGroup is incremented
 // before launching the goroutine so RunTurn can wait for in-flight
-// tools before returning. Events are sent via toolEventCh so that
-// OnEvent is called exclusively from the RunTurn goroutine.
-func (a *CodexAdapter) handleToolCall(ctx context.Context, state *sessionState, wg *sync.WaitGroup, msg parsedMessage, toolEventCh chan<- domain.AgentEvent, logger *slog.Logger) {
+// tools before returning. Asynchronous tool completion events are sent
+// via toolEventCh. Synchronous early-return events (unsupported tool)
+// are returned directly so the caller can deliver them without risking
+// a channel send from the reader goroutine.
+func (a *CodexAdapter) handleToolCall(ctx context.Context, state *sessionState, wg *sync.WaitGroup, msg parsedMessage, toolEventCh chan<- domain.AgentEvent, logger *slog.Logger) *domain.AgentEvent {
 	now := time.Now().UTC()
 	requestID := msg.Response.ID
 
@@ -737,7 +741,7 @@ func (a *CodexAdapter) handleToolCall(ctx context.Context, state *sessionState, 
 		state.mu.Lock()
 		sendResponse(state, requestID, toolResultFor(false, "invalid tool call params")) //nolint:errcheck,gosec // best-effort error response
 		state.mu.Unlock()
-		return
+		return nil
 	}
 
 	toolName := tc.Tool
@@ -746,13 +750,12 @@ func (a *CodexAdapter) handleToolCall(ctx context.Context, state *sessionState, 
 		state.mu.Lock()
 		sendResponse(state, requestID, toolResultFor(false, fmt.Sprintf("unsupported tool: %s", toolName))) //nolint:errcheck,gosec // best-effort error response
 		state.mu.Unlock()
-		toolEventCh <- domain.AgentEvent{
+		return &domain.AgentEvent{
 			Type:      domain.EventUnsupportedToolCall,
 			Timestamp: now,
 			ToolName:  toolName,
 			Message:   fmt.Sprintf("no tool registry configured for tool %q", toolName),
 		}
-		return
 	}
 
 	tool, found := a.toolRegistry.Get(toolName)
@@ -760,13 +763,12 @@ func (a *CodexAdapter) handleToolCall(ctx context.Context, state *sessionState, 
 		state.mu.Lock()
 		sendResponse(state, requestID, toolResultFor(false, fmt.Sprintf("unsupported tool: %s", toolName))) //nolint:errcheck,gosec // best-effort error response
 		state.mu.Unlock()
-		toolEventCh <- domain.AgentEvent{
+		return &domain.AgentEvent{
 			Type:      domain.EventUnsupportedToolCall,
 			Timestamp: now,
 			ToolName:  toolName,
 			Message:   fmt.Sprintf("tool %q not registered", toolName),
 		}
-		return
 	}
 
 	wg.Add(1)
@@ -801,6 +803,7 @@ func (a *CodexAdapter) handleToolCall(ctx context.Context, state *sessionState, 
 			}
 		}
 	}()
+	return nil
 }
 
 // StopSession terminates the persistent app-server subprocess.
@@ -843,11 +846,9 @@ func (a *CodexAdapter) StopSession(_ context.Context, session domain.Session) er
 				procutil.KillProcessGroup(pid) //nolint:errcheck,gosec // best-effort force kill
 			}
 			// Wait again briefly for cleanup.
-			if waitCh != nil {
-				select {
-				case <-waitCh:
-				case <-time.After(2 * time.Second):
-				}
+			select {
+			case <-waitCh:
+			case <-time.After(2 * time.Second):
 			}
 		}
 	}

--- a/internal/agent/codex/runturn_test.go
+++ b/internal/agent/codex/runturn_test.go
@@ -499,13 +499,16 @@ func TestHandleToolCall_InvalidParams(t *testing.T) {
 	}
 
 	// Should not panic; writes an error response to stdin (discarded).
-	adapter.handleToolCall(context.Background(), state, &wg, msg, toolEventCh, slog.Default())
+	evt := adapter.handleToolCall(context.Background(), state, &wg, msg, toolEventCh, slog.Default())
 	wg.Wait()
 	close(toolEventCh)
 
 	var events []domain.AgentEvent
-	for evt := range toolEventCh {
-		events = append(events, evt)
+	if evt != nil {
+		events = append(events, *evt)
+	}
+	for e := range toolEventCh {
+		events = append(events, e)
 	}
 
 	// Invalid params: no event emitted (returns early after sendResponse).
@@ -531,13 +534,16 @@ func TestHandleToolCall_NilRegistryEmitsUnsupported(t *testing.T) {
 		},
 	}
 
-	adapter.handleToolCall(context.Background(), state, &wg, msg, toolEventCh, slog.Default())
+	evt := adapter.handleToolCall(context.Background(), state, &wg, msg, toolEventCh, slog.Default())
 	wg.Wait()
 	close(toolEventCh)
 
 	var events []domain.AgentEvent
-	for evt := range toolEventCh {
-		events = append(events, evt)
+	if evt != nil {
+		events = append(events, *evt)
+	}
+	for e := range toolEventCh {
+		events = append(events, e)
 	}
 
 	if e, ok := firstEventOfType(events, domain.EventUnsupportedToolCall); !ok {
@@ -565,13 +571,16 @@ func TestHandleToolCall_ToolNotFound(t *testing.T) {
 		},
 	}
 
-	adapter.handleToolCall(context.Background(), state, &wg, msg, toolEventCh, slog.Default())
+	evt := adapter.handleToolCall(context.Background(), state, &wg, msg, toolEventCh, slog.Default())
 	wg.Wait()
 	close(toolEventCh)
 
 	var events []domain.AgentEvent
-	for evt := range toolEventCh {
-		events = append(events, evt)
+	if evt != nil {
+		events = append(events, *evt)
+	}
+	for e := range toolEventCh {
+		events = append(events, e)
 	}
 
 	if _, ok := firstEventOfType(events, domain.EventUnsupportedToolCall); !ok {

--- a/internal/agent/codex/runturn_test.go
+++ b/internal/agent/codex/runturn_test.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/sortie-ai/sortie/internal/domain"
 )
@@ -486,7 +487,7 @@ func TestHandleToolCall_InvalidParams(t *testing.T) {
 	adapter := a.(*CodexAdapter)
 	state := makeTestState(nil)
 	var wg sync.WaitGroup
-	var events []domain.AgentEvent
+	toolEventCh := make(chan domain.AgentEvent, 8)
 
 	msg := parsedMessage{
 		IsNotification: true,
@@ -498,10 +499,14 @@ func TestHandleToolCall_InvalidParams(t *testing.T) {
 	}
 
 	// Should not panic; writes an error response to stdin (discarded).
-	adapter.handleToolCall(context.Background(), state, &wg, msg, func(e domain.AgentEvent) {
-		events = append(events, e)
-	}, slog.Default())
+	adapter.handleToolCall(context.Background(), state, &wg, msg, toolEventCh, slog.Default())
 	wg.Wait()
+	close(toolEventCh)
+
+	var events []domain.AgentEvent
+	for evt := range toolEventCh {
+		events = append(events, evt)
+	}
 
 	// Invalid params: no event emitted (returns early after sendResponse).
 	if len(events) != 0 {
@@ -516,7 +521,7 @@ func TestHandleToolCall_NilRegistryEmitsUnsupported(t *testing.T) {
 	adapter := a.(*CodexAdapter)
 	state := makeTestState(nil)
 	var wg sync.WaitGroup
-	var events []domain.AgentEvent
+	toolEventCh := make(chan domain.AgentEvent, 8)
 
 	msg := parsedMessage{
 		IsNotification: true,
@@ -526,10 +531,14 @@ func TestHandleToolCall_NilRegistryEmitsUnsupported(t *testing.T) {
 		},
 	}
 
-	adapter.handleToolCall(context.Background(), state, &wg, msg, func(e domain.AgentEvent) {
-		events = append(events, e)
-	}, slog.Default())
+	adapter.handleToolCall(context.Background(), state, &wg, msg, toolEventCh, slog.Default())
 	wg.Wait()
+	close(toolEventCh)
+
+	var events []domain.AgentEvent
+	for evt := range toolEventCh {
+		events = append(events, evt)
+	}
 
 	if e, ok := firstEventOfType(events, domain.EventUnsupportedToolCall); !ok {
 		t.Fatal("expected EventUnsupportedToolCall with nil registry")
@@ -546,7 +555,7 @@ func TestHandleToolCall_ToolNotFound(t *testing.T) {
 	adapter := a.(*CodexAdapter)
 	state := makeTestState(nil)
 	var wg sync.WaitGroup
-	var events []domain.AgentEvent
+	toolEventCh := make(chan domain.AgentEvent, 8)
 
 	msg := parsedMessage{
 		IsNotification: true,
@@ -556,10 +565,14 @@ func TestHandleToolCall_ToolNotFound(t *testing.T) {
 		},
 	}
 
-	adapter.handleToolCall(context.Background(), state, &wg, msg, func(e domain.AgentEvent) {
-		events = append(events, e)
-	}, slog.Default())
+	adapter.handleToolCall(context.Background(), state, &wg, msg, toolEventCh, slog.Default())
 	wg.Wait()
+	close(toolEventCh)
+
+	var events []domain.AgentEvent
+	for evt := range toolEventCh {
+		events = append(events, evt)
+	}
 
 	if _, ok := firstEventOfType(events, domain.EventUnsupportedToolCall); !ok {
 		t.Fatal("expected EventUnsupportedToolCall for unregistered tool")
@@ -575,7 +588,7 @@ func TestHandleToolCall_ToolSuccess(t *testing.T) {
 	adapter := a.(*CodexAdapter)
 	state := makeTestState(nil)
 	var wg sync.WaitGroup
-	var events []domain.AgentEvent
+	toolEventCh := make(chan domain.AgentEvent, 8)
 
 	msg := parsedMessage{
 		IsNotification: true,
@@ -585,10 +598,14 @@ func TestHandleToolCall_ToolSuccess(t *testing.T) {
 		},
 	}
 
-	adapter.handleToolCall(context.Background(), state, &wg, msg, func(e domain.AgentEvent) {
-		events = append(events, e)
-	}, slog.Default())
+	adapter.handleToolCall(context.Background(), state, &wg, msg, toolEventCh, slog.Default())
 	wg.Wait()
+	close(toolEventCh)
+
+	var events []domain.AgentEvent
+	for evt := range toolEventCh {
+		events = append(events, evt)
+	}
 
 	e, ok := firstEventOfType(events, domain.EventToolResult)
 	if !ok {
@@ -611,7 +628,7 @@ func TestHandleToolCall_ToolError(t *testing.T) {
 	adapter := a.(*CodexAdapter)
 	state := makeTestState(nil)
 	var wg sync.WaitGroup
-	var events []domain.AgentEvent
+	toolEventCh := make(chan domain.AgentEvent, 8)
 
 	msg := parsedMessage{
 		IsNotification: true,
@@ -621,10 +638,14 @@ func TestHandleToolCall_ToolError(t *testing.T) {
 		},
 	}
 
-	adapter.handleToolCall(context.Background(), state, &wg, msg, func(e domain.AgentEvent) {
-		events = append(events, e)
-	}, slog.Default())
+	adapter.handleToolCall(context.Background(), state, &wg, msg, toolEventCh, slog.Default())
 	wg.Wait()
+	close(toolEventCh)
+
+	var events []domain.AgentEvent
+	for evt := range toolEventCh {
+		events = append(events, evt)
+	}
 
 	e, ok := firstEventOfType(events, domain.EventToolResult)
 	if !ok {
@@ -765,11 +786,85 @@ type fakeTool struct {
 	name    string
 	result  json.RawMessage
 	execErr error
+	delay   time.Duration
 }
 
 func (f *fakeTool) Name() string                 { return f.name }
 func (f *fakeTool) Description() string          { return "fake tool for testing" }
 func (f *fakeTool) InputSchema() json.RawMessage { return json.RawMessage(`{}`) }
 func (f *fakeTool) Execute(_ context.Context, _ json.RawMessage) (json.RawMessage, error) {
+	if f.delay > 0 {
+		time.Sleep(f.delay)
+	}
 	return f.result, f.execErr
+}
+
+// --- Race-detection tests ---
+
+func TestHandleToolCall_EventsSerialized(t *testing.T) {
+	t.Parallel()
+
+	reg := domain.NewToolRegistry()
+	reg.Register(&fakeTool{name: "slow_tool", result: json.RawMessage(`"ok"`), delay: time.Millisecond})
+	a, _ := NewCodexAdapter(map[string]any{"tool_registry": reg})
+	adapter := a.(*CodexAdapter)
+	state := makeTestState(nil)
+	var wg sync.WaitGroup
+	toolEventCh := make(chan domain.AgentEvent, 8)
+
+	msg := parsedMessage{
+		IsNotification: true,
+		Response:       rpcResponse{ID: 1},
+		Notification: rpcNotification{
+			Params: json.RawMessage(`{"tool":"slow_tool","arguments":{}}`),
+		},
+	}
+
+	adapter.handleToolCall(context.Background(), state, &wg, msg, toolEventCh, slog.Default())
+	wg.Wait()
+	close(toolEventCh)
+
+	var events []domain.AgentEvent
+	for evt := range toolEventCh {
+		events = append(events, evt)
+	}
+
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+	if events[0].Type != domain.EventToolResult {
+		t.Errorf("event type = %v, want EventToolResult", events[0].Type)
+	}
+}
+
+func TestRunTurn_ToolCallEventSerialization(t *testing.T) {
+	t.Parallel()
+
+	reg := domain.NewToolRegistry()
+	reg.Register(&fakeTool{
+		name:   "create_issue",
+		result: json.RawMessage(`{"id":"42"}`),
+		delay:  time.Millisecond,
+	})
+	state := makeTestState(loadFixture(t, "runturn_tool_call.jsonl"))
+	adapter, _ := NewCodexAdapter(map[string]any{"tool_registry": reg})
+
+	var events []domain.AgentEvent
+	result, err := adapter.RunTurn(context.Background(), fakeSession(state), domain.RunTurnParams{
+		Prompt:  "use tool",
+		OnEvent: collectEvents(&events),
+	})
+
+	if err != nil {
+		t.Fatalf("RunTurn() error = %v", err)
+	}
+	if result.ExitReason != domain.EventTurnCompleted {
+		t.Errorf("ExitReason = %v, want EventTurnCompleted", result.ExitReason)
+	}
+	if _, ok := firstEventOfType(events, domain.EventToolResult); !ok {
+		t.Error("expected EventToolResult, not found")
+	}
+	if _, ok := firstEventOfType(events, domain.EventTokenUsage); !ok {
+		t.Error("expected EventTokenUsage, not found")
+	}
 }


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Fix

**Intent:** Tool goroutines in `handleToolCall` called `params.OnEvent` directly, creating an unsynchronized concurrent access pattern with the main `RunTurn` event loop. This fix funnels all tool goroutine events through a buffered channel drained exclusively by the main goroutine, eliminating the latent data race.

**Related Issues:** #462

### 🧭 Reviewer Guide

**Complexity:** Medium

#### Entry Point

`internal/agent/codex/codex.go` — the core change lives in `RunTurn` and `handleToolCall`. Look for the `toolEventCh` channel declaration, the new `case evt := <-toolEventCh:` in the select loop, the four concurrent wait-and-drain patterns at each return path, and the updated `handleToolCall` signature.

#### Sensitive Areas

- `internal/agent/codex/codex.go`: Channel lifecycle — created once per `RunTurn` call, written to by tool goroutines, closed by a background goroutine after `toolWg.Wait()`. The concurrent wait-and-drain pattern at each return path is the deadlock-prevention mechanism; the sequential alternative would deadlock when the buffer fills.
- `internal/agent/codex/runturn_test.go`: The five updated `handleToolCall` tests pass a `chan domain.AgentEvent` instead of a closure. Two new race-detection tests (`TestHandleToolCall_EventsSerialized`, `TestRunTurn_ToolCallEventSerialization`) verify serialization under `-race -count=10`.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes — `handleToolCall` is unexported; all callers are within `codex.go`.
- **Migrations/State:** No migrations or state changes.