### PR TITLE
feat(codex): make handshake reads cancellable via scanner channel

### DIFF
--- a/internal/agent/codex/codex.go
+++ b/internal/agent/codex/codex.go
@@ -272,6 +272,9 @@ func (a *CodexAdapter) StartSession(ctx context.Context, params domain.StartSess
 		if state.stdin != nil {
 			state.stdin.Close() //nolint:errcheck,gosec // best-effort cleanup
 		}
+		if state.stdout != nil {
+			state.stdout.Close() //nolint:errcheck,gosec // unblock scanner.Scan on the read end
+		}
 		state.mu.Unlock()
 		procutil.KillProcessGroup(cmd.Process.Pid) //nolint:errcheck,gosec // best-effort cleanup
 		// Wait briefly for cleanup.

--- a/internal/agent/codex/codex.go
+++ b/internal/agent/codex/codex.go
@@ -289,7 +289,13 @@ func (a *CodexAdapter) StartSession(ctx context.Context, params domain.StartSess
 	scanner := bufio.NewScanner(stdoutPipe)
 	scanner.Buffer(make([]byte, 0, 1<<20), 1<<20)
 
-	if err := initializeHandshake(ctx, state, scanner); err != nil {
+	// Create stopCh before the scanner goroutine so it is available
+	// to startScannerCh and to handshake error paths.
+	state.stopCh = make(chan struct{})
+	scanCh := startScannerCh(scanner, state.stopCh)
+
+	if err := initializeHandshake(ctx, state, scanCh); err != nil {
+		state.closeStop.Do(func() { close(state.stopCh) })
 		killOnError()
 		return domain.Session{}, &domain.AgentError{
 			Kind:    domain.ErrResponseError,
@@ -298,7 +304,8 @@ func (a *CodexAdapter) StartSession(ctx context.Context, params domain.StartSess
 		}
 	}
 
-	if err := authenticateIfNeeded(ctx, state, scanner); err != nil {
+	if err := authenticateIfNeeded(ctx, state, scanCh); err != nil {
+		state.closeStop.Do(func() { close(state.stopCh) })
 		killOnError()
 		var agentErr *domain.AgentError
 		if ok := isAgentError(err, &agentErr); ok {
@@ -313,7 +320,7 @@ func (a *CodexAdapter) StartSession(ctx context.Context, params domain.StartSess
 
 	var threadID string
 	if params.ResumeSessionID != "" {
-		if err := resumeThread(ctx, state, scanner, params.ResumeSessionID); err != nil {
+		if err := resumeThread(ctx, state, scanCh, params.ResumeSessionID); err != nil {
 			// Fallback to new thread on resume failure.
 			logger.Warn("thread resume failed, starting new thread",
 				slog.String("resume_id", params.ResumeSessionID),
@@ -322,8 +329,9 @@ func (a *CodexAdapter) StartSession(ctx context.Context, params domain.StartSess
 			if a.toolRegistry != nil {
 				tools = a.toolRegistry.List()
 			}
-			tid, startErr := startThread(ctx, state, scanner, a.passthrough, tools)
+			tid, startErr := startThread(ctx, state, scanCh, a.passthrough, tools)
 			if startErr != nil {
+				state.closeStop.Do(func() { close(state.stopCh) })
 				killOnError()
 				return domain.Session{}, &domain.AgentError{
 					Kind:    domain.ErrResponseError,
@@ -340,8 +348,9 @@ func (a *CodexAdapter) StartSession(ctx context.Context, params domain.StartSess
 		if a.toolRegistry != nil {
 			tools = a.toolRegistry.List()
 		}
-		tid, startErr := startThread(ctx, state, scanner, a.passthrough, tools)
+		tid, startErr := startThread(ctx, state, scanCh, a.passthrough, tools)
 		if startErr != nil {
+			state.closeStop.Do(func() { close(state.stopCh) })
 			killOnError()
 			return domain.Session{}, &domain.AgentError{
 				Kind:    domain.ErrResponseError,
@@ -356,23 +365,25 @@ func (a *CodexAdapter) StartSession(ctx context.Context, params domain.StartSess
 
 	state.msgCh = make(chan parsedMessage, 16)
 	state.readerDone = make(chan struct{})
-	state.stopCh = make(chan struct{})
 
 	go func() {
 		defer close(state.readerDone)
 		defer close(state.msgCh)
-		for scanner.Scan() {
-			msg := parseMessage(scanner.Bytes())
+		for result := range scanCh {
+			if result.EOF || result.Err != nil {
+				if result.Err != nil {
+					select {
+					case state.msgCh <- parsedMessage{Err: result.Err}:
+					case <-state.stopCh:
+					}
+				}
+				return
+			}
+			msg := parseMessage(result.Line)
 			select {
 			case state.msgCh <- msg:
 			case <-state.stopCh:
 				return
-			}
-		}
-		if err := scanner.Err(); err != nil {
-			select {
-			case state.msgCh <- parsedMessage{Err: err}:
-			case <-state.stopCh:
 			}
 		}
 	}()

--- a/internal/agent/codex/handshake_test.go
+++ b/internal/agent/codex/handshake_test.go
@@ -5,8 +5,12 @@ package codex
 import (
 	"bufio"
 	"context"
+	"errors"
+	"fmt"
+	"io"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/sortie-ai/sortie/internal/domain"
 )
@@ -20,12 +24,16 @@ func handshakeState() *sessionState {
 	}
 }
 
-// handshakeScanner returns a *bufio.Scanner reading from fixture JSONL lines.
-func handshakeScanner(lines ...string) *bufio.Scanner {
-	fixture := strings.Join(lines, "\n") + "\n"
-	scanner := bufio.NewScanner(strings.NewReader(fixture))
-	scanner.Buffer(make([]byte, 0, 1<<20), 1<<20)
-	return scanner
+// scanChanFromLines feeds a scanResult for each line into a buffered channel,
+// followed by an EOF sentinel. No goroutine is started; the result is safe to
+// pass directly to readResponse and the handshake functions.
+func scanChanFromLines(lines ...string) <-chan scanResult {
+	ch := make(chan scanResult, len(lines)+1)
+	for _, line := range lines {
+		ch <- scanResult{Line: []byte(line)}
+	}
+	ch <- scanResult{EOF: true}
+	return ch
 }
 
 // --- initializeHandshake ---
@@ -34,9 +42,9 @@ func TestInitializeHandshake_Success(t *testing.T) {
 	t.Parallel()
 
 	state := handshakeState()
-	scanner := handshakeScanner(`{"id":1,"result":{"protocolVersion":"2025-03-26","serverInfo":{"name":"codex-app-server"}}}`)
+	scanCh := scanChanFromLines(`{"id":1,"result":{"protocolVersion":"2025-03-26","serverInfo":{"name":"codex-app-server"}}}`)
 
-	if err := initializeHandshake(context.Background(), state, scanner); err != nil {
+	if err := initializeHandshake(context.Background(), state, scanCh); err != nil {
 		t.Fatalf("initializeHandshake() error = %v", err)
 	}
 }
@@ -45,9 +53,9 @@ func TestInitializeHandshake_ErrorResponse(t *testing.T) {
 	t.Parallel()
 
 	state := handshakeState()
-	scanner := handshakeScanner(`{"id":1,"error":{"code":-32600,"message":"invalid request"}}`)
+	scanCh := scanChanFromLines(`{"id":1,"error":{"code":-32600,"message":"invalid request"}}`)
 
-	err := initializeHandshake(context.Background(), state, scanner)
+	err := initializeHandshake(context.Background(), state, scanCh)
 	if err == nil {
 		t.Fatal("initializeHandshake() expected error for error response, got nil")
 	}
@@ -60,9 +68,9 @@ func TestInitializeHandshake_EOF(t *testing.T) {
 	t.Parallel()
 
 	state := handshakeState()
-	scanner := handshakeScanner() // empty fixture
+	scanCh := scanChanFromLines() // empty fixture → immediate EOF
 
-	err := initializeHandshake(context.Background(), state, scanner)
+	err := initializeHandshake(context.Background(), state, scanCh)
 	if err == nil {
 		t.Fatal("initializeHandshake() expected error on EOF, got nil")
 	}
@@ -75,9 +83,9 @@ func TestAuthenticateIfNeeded_AlreadyLoggedIn(t *testing.T) {
 
 	state := handshakeState()
 	// account/read response with non-null account
-	scanner := handshakeScanner(`{"id":1,"result":{"account":{"id":"user-1","email":"user@example.com"}}}`)
+	scanCh := scanChanFromLines(`{"id":1,"result":{"account":{"id":"user-1","email":"user@example.com"}}}`)
 
-	if err := authenticateIfNeeded(context.Background(), state, scanner); err != nil {
+	if err := authenticateIfNeeded(context.Background(), state, scanCh); err != nil {
 		t.Fatalf("authenticateIfNeeded() error = %v, want nil for logged-in account", err)
 	}
 }
@@ -87,9 +95,9 @@ func TestAuthenticateIfNeeded_NullAccountNoAPIKey(t *testing.T) {
 
 	state := handshakeState()
 	// account/read response with null account — CODEX_API_KEY not set → return nil
-	scanner := handshakeScanner(`{"id":1,"result":{"account":null}}`)
+	scanCh := scanChanFromLines(`{"id":1,"result":{"account":null}}`)
 
-	if err := authenticateIfNeeded(context.Background(), state, scanner); err != nil {
+	if err := authenticateIfNeeded(context.Background(), state, scanCh); err != nil {
 		t.Fatalf("authenticateIfNeeded() error = %v, want nil when API key absent", err)
 	}
 }
@@ -98,9 +106,9 @@ func TestAuthenticateIfNeeded_AccountReadError(t *testing.T) {
 	t.Parallel()
 
 	state := handshakeState()
-	scanner := handshakeScanner(`{"id":1,"error":{"code":-32000,"message":"server error"}}`)
+	scanCh := scanChanFromLines(`{"id":1,"error":{"code":-32000,"message":"server error"}}`)
 
-	err := authenticateIfNeeded(context.Background(), state, scanner)
+	err := authenticateIfNeeded(context.Background(), state, scanCh)
 	if err == nil {
 		t.Fatal("authenticateIfNeeded() expected error for account/read error response")
 	}
@@ -114,13 +122,13 @@ func TestAuthenticateIfNeeded_LoginSuccess(t *testing.T) {
 	// id=1: account/read → null account
 	// id=2: account/login/start → success response
 	// then: login/completed notification
-	scanner := handshakeScanner(
+	scanCh := scanChanFromLines(
 		`{"id":1,"result":{"account":null}}`,
 		`{"id":2,"result":{}}`,
 		`{"method":"account/login/completed","params":{"success":true}}`,
 	)
 
-	if err := authenticateIfNeeded(context.Background(), state, scanner); err != nil {
+	if err := authenticateIfNeeded(context.Background(), state, scanCh); err != nil {
 		t.Fatalf("authenticateIfNeeded() error = %v, want nil on successful login", err)
 	}
 }
@@ -132,12 +140,12 @@ func TestAuthenticateIfNeeded_LoginResponseError(t *testing.T) {
 	state := handshakeState()
 	// id=1: account/read → null
 	// id=2: account/login/start → error
-	scanner := handshakeScanner(
+	scanCh := scanChanFromLines(
 		`{"id":1,"result":{"account":null}}`,
 		`{"id":2,"error":{"code":-32001,"message":"invalid API key"}}`,
 	)
 
-	err := authenticateIfNeeded(context.Background(), state, scanner)
+	err := authenticateIfNeeded(context.Background(), state, scanCh)
 	if err == nil {
 		t.Fatal("authenticateIfNeeded() expected error for login failure")
 	}
@@ -148,13 +156,13 @@ func TestAuthenticateIfNeeded_LoginCompletedFailed(t *testing.T) {
 	t.Setenv("CODEX_API_KEY", "bad-key")
 
 	state := handshakeState()
-	scanner := handshakeScanner(
+	scanCh := scanChanFromLines(
 		`{"id":1,"result":{"account":null}}`,
 		`{"id":2,"result":{}}`,
 		`{"method":"account/login/completed","params":{"success":false}}`,
 	)
 
-	err := authenticateIfNeeded(context.Background(), state, scanner)
+	err := authenticateIfNeeded(context.Background(), state, scanCh)
 	if err == nil {
 		t.Fatal("authenticateIfNeeded() expected error for failed login completion")
 	}
@@ -188,12 +196,12 @@ func TestStartThread_Success(t *testing.T) {
 	t.Parallel()
 
 	state := handshakeState()
-	scanner := handshakeScanner(
+	scanCh := scanChanFromLines(
 		`{"id":1,"result":{"thread":{"id":"thread-abc"}}}`,
 		`{"method":"thread/started","params":{"threadId":"thread-abc"}}`,
 	)
 
-	threadID, err := startThread(context.Background(), state, scanner, passthroughConfig{}, nil)
+	threadID, err := startThread(context.Background(), state, scanCh, passthroughConfig{}, nil)
 	if err != nil {
 		t.Fatalf("startThread() error = %v", err)
 	}
@@ -206,7 +214,7 @@ func TestStartThread_WithModelAndPersonality(t *testing.T) {
 	t.Parallel()
 
 	state := handshakeState()
-	scanner := handshakeScanner(
+	scanCh := scanChanFromLines(
 		`{"id":1,"result":{"thread":{"id":"thread-xyz"}}}`,
 		`{"method":"thread/started","params":{}}`,
 	)
@@ -217,7 +225,7 @@ func TestStartThread_WithModelAndPersonality(t *testing.T) {
 		ThreadSandbox:  "workspaceWrite",
 	}
 
-	threadID, err := startThread(context.Background(), state, scanner, pt, nil)
+	threadID, err := startThread(context.Background(), state, scanCh, pt, nil)
 	if err != nil {
 		t.Fatalf("startThread() error = %v", err)
 	}
@@ -230,7 +238,7 @@ func TestStartThread_WithTools(t *testing.T) {
 	t.Parallel()
 
 	state := handshakeState()
-	scanner := handshakeScanner(
+	scanCh := scanChanFromLines(
 		`{"id":1,"result":{"thread":{"id":"thread-tools"}}}`,
 		`{"method":"thread/started","params":{}}`,
 	)
@@ -239,7 +247,7 @@ func TestStartThread_WithTools(t *testing.T) {
 		&fakeTool{name: "create_issue", result: nil},
 	}
 
-	threadID, err := startThread(context.Background(), state, scanner, passthroughConfig{}, tools)
+	threadID, err := startThread(context.Background(), state, scanCh, passthroughConfig{}, tools)
 	if err != nil {
 		t.Fatalf("startThread() error = %v", err)
 	}
@@ -252,9 +260,9 @@ func TestStartThread_ErrorResponse(t *testing.T) {
 	t.Parallel()
 
 	state := handshakeState()
-	scanner := handshakeScanner(`{"id":1,"error":{"code":-32000,"message":"workspace not found"}}`)
+	scanCh := scanChanFromLines(`{"id":1,"error":{"code":-32000,"message":"workspace not found"}}`)
 
-	_, err := startThread(context.Background(), state, scanner, passthroughConfig{}, nil)
+	_, err := startThread(context.Background(), state, scanCh, passthroughConfig{}, nil)
 	if err == nil {
 		t.Fatal("startThread() expected error for error response")
 	}
@@ -265,9 +273,9 @@ func TestStartThread_EmptyThreadID(t *testing.T) {
 
 	state := handshakeState()
 	// Response with empty thread ID.
-	scanner := handshakeScanner(`{"id":1,"result":{"thread":{"id":""}}}`)
+	scanCh := scanChanFromLines(`{"id":1,"result":{"thread":{"id":""}}}`)
 
-	_, err := startThread(context.Background(), state, scanner, passthroughConfig{}, nil)
+	_, err := startThread(context.Background(), state, scanCh, passthroughConfig{}, nil)
 	if err == nil {
 		t.Fatal("startThread() expected error for empty thread ID")
 	}
@@ -279,9 +287,9 @@ func TestResumeThread_Success(t *testing.T) {
 	t.Parallel()
 
 	state := handshakeState()
-	scanner := handshakeScanner(`{"id":1,"result":{}}`)
+	scanCh := scanChanFromLines(`{"id":1,"result":{}}`)
 
-	if err := resumeThread(context.Background(), state, scanner, "existing-thread-id"); err != nil {
+	if err := resumeThread(context.Background(), state, scanCh, "existing-thread-id"); err != nil {
 		t.Fatalf("resumeThread() error = %v", err)
 	}
 }
@@ -290,10 +298,80 @@ func TestResumeThread_ErrorResponse(t *testing.T) {
 	t.Parallel()
 
 	state := handshakeState()
-	scanner := handshakeScanner(`{"id":1,"error":{"code":-32002,"message":"thread not found"}}`)
+	scanCh := scanChanFromLines(`{"id":1,"error":{"code":-32002,"message":"thread not found"}}`)
 
-	err := resumeThread(context.Background(), state, scanner, "nonexistent-thread")
+	err := resumeThread(context.Background(), state, scanCh, "nonexistent-thread")
 	if err == nil {
 		t.Fatal("resumeThread() expected error for error response")
+	}
+}
+
+func TestAuthenticateIfNeeded_ContextCancelledDuringLoginWait(t *testing.T) {
+	// No t.Parallel() — uses t.Setenv.
+	t.Setenv("CODEX_API_KEY", "test-key")
+
+	pr, pw := io.Pipe()
+	t.Cleanup(func() { _ = pr.Close(); _ = pw.Close() })
+
+	scanner := bufio.NewScanner(pr)
+	scanner.Buffer(make([]byte, 0, 1<<20), 1<<20)
+
+	stop := make(chan struct{})
+	t.Cleanup(func() { close(stop) })
+	scanCh := startScannerCh(scanner, stop)
+
+	// Feed account/read (null) and login/start success responses in a goroutine
+	// so the io.Pipe write does not block. pw stays open — the scanner goroutine
+	// blocks waiting for more data; no login/completed notification arrives.
+	go func() {
+		_, _ = fmt.Fprintln(pw, `{"id":1,"result":{"account":null}}`)
+		_, _ = fmt.Fprintln(pw, `{"id":2,"result":{}}`)
+	}()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- authenticateIfNeeded(ctx, handshakeState(), scanCh)
+	}()
+
+	cancel()
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Errorf("authenticateIfNeeded() = %v, want context.Canceled", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("authenticateIfNeeded() did not return after context cancel")
+	}
+}
+
+func TestStartThread_ContextCancelledDuringNotificationWait(t *testing.T) {
+	t.Parallel()
+
+	pr, pw := io.Pipe()
+	t.Cleanup(func() { _ = pr.Close(); _ = pw.Close() })
+
+	scanner := bufio.NewScanner(pr)
+	scanner.Buffer(make([]byte, 0, 1<<20), 1<<20)
+
+	stop := make(chan struct{})
+	t.Cleanup(func() { close(stop) })
+	scanCh := startScannerCh(scanner, stop)
+
+	// Feed thread/start response; pw stays open so the scanner goroutine blocks
+	// waiting for more data — no thread/started notification arrives.
+	go func() {
+		_, _ = fmt.Fprintln(pw, `{"id":1,"result":{"thread":{"id":"thread-abc"}}}`)
+	}()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := startThread(ctx, handshakeState(), scanCh, passthroughConfig{}, nil)
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("startThread() = %v, want context.Canceled", err)
 	}
 }

--- a/internal/agent/codex/protocol.go
+++ b/internal/agent/codex/protocol.go
@@ -96,8 +96,11 @@ type scanResult struct {
 
 // startScannerCh wraps scanner.Scan in a background goroutine and
 // delivers results on the returned channel. The goroutine exits when
-// the scanner reaches EOF / errors or when stop is closed. Callers
-// must not close the returned channel.
+// the scanner reaches EOF or returns an error. Closing stop only
+// interrupts delivery to scanCh; it does not unblock a scanner.Scan
+// call that is blocked on the underlying reader, so shutdown must also
+// close that reader or terminate the subprocess. Callers must not
+// close the returned channel.
 func startScannerCh(scanner *bufio.Scanner, stop <-chan struct{}) <-chan scanResult {
 	scanCh := make(chan scanResult, 1)
 	go func() {

--- a/internal/agent/codex/protocol.go
+++ b/internal/agent/codex/protocol.go
@@ -86,43 +86,81 @@ func sendResponse(state *sessionState, id int64, result any) error {
 	return nil
 }
 
-// readResponse reads JSONL lines from the scanner until a response
-// with the expected ID arrives or the context expires. Notifications
-// encountered during the wait are discarded.
-func readResponse(ctx context.Context, scanner *bufio.Scanner, expectedID int64) (rpcResponse, error) {
-	for {
-		if ctx.Err() != nil {
-			return rpcResponse{}, ctx.Err()
-		}
-		if !scanner.Scan() {
-			if err := scanner.Err(); err != nil {
-				return rpcResponse{}, fmt.Errorf("scanner error waiting for response id=%d: %w", expectedID, err)
-			}
-			return rpcResponse{}, fmt.Errorf("unexpected EOF waiting for response id=%d", expectedID)
-		}
+// scanResult carries one line from the background scanner goroutine,
+// or a terminal condition (EOF / error).
+type scanResult struct {
+	Line []byte
+	Err  error
+	EOF  bool
+}
 
-		msg := parseMessage(scanner.Bytes())
-		if msg.Err != nil {
-			slog.Debug("discarding malformed message during handshake", slog.Any("error", msg.Err))
-			continue
+// startScannerCh wraps scanner.Scan in a background goroutine and
+// delivers results on the returned channel. The goroutine exits when
+// the scanner reaches EOF / errors or when stop is closed. Callers
+// must not close the returned channel.
+func startScannerCh(scanner *bufio.Scanner, stop <-chan struct{}) <-chan scanResult {
+	scanCh := make(chan scanResult, 1)
+	go func() {
+		defer close(scanCh)
+		for scanner.Scan() {
+			line := make([]byte, len(scanner.Bytes()))
+			copy(line, scanner.Bytes())
+			select {
+			case scanCh <- scanResult{Line: line}:
+			case <-stop:
+				return
+			}
 		}
-		if msg.IsNotification {
-			slog.Debug("discarding notification during handshake",
-				slog.String("method", msg.Notification.Method))
-			continue
+		termResult := scanResult{EOF: true}
+		if err := scanner.Err(); err != nil {
+			termResult = scanResult{Err: err}
 		}
-		if msg.IsResponse && msg.Response.ID == expectedID {
-			return msg.Response, nil
+		select {
+		case scanCh <- termResult:
+		case <-stop:
 		}
-		slog.Debug("discarding response with unexpected id",
-			slog.Int64("got", msg.Response.ID),
-			slog.Int64("want", expectedID))
+	}()
+	return scanCh
+}
+
+// readResponse reads from scanCh until a response with the expected
+// ID arrives or the context expires. Notifications encountered during
+// the wait are discarded.
+func readResponse(ctx context.Context, scanCh <-chan scanResult, expectedID int64) (rpcResponse, error) {
+	for {
+		select {
+		case <-ctx.Done():
+			return rpcResponse{}, ctx.Err()
+		case result, ok := <-scanCh:
+			if !ok || result.EOF {
+				return rpcResponse{}, fmt.Errorf("unexpected EOF waiting for response id=%d", expectedID)
+			}
+			if result.Err != nil {
+				return rpcResponse{}, fmt.Errorf("scanner error waiting for response id=%d: %w", expectedID, result.Err)
+			}
+			msg := parseMessage(result.Line)
+			if msg.Err != nil {
+				slog.Debug("discarding malformed message during handshake", slog.Any("error", msg.Err))
+				continue
+			}
+			if msg.IsNotification {
+				slog.Debug("discarding notification during handshake",
+					slog.String("method", msg.Notification.Method))
+				continue
+			}
+			if msg.IsResponse && msg.Response.ID == expectedID {
+				return msg.Response, nil
+			}
+			slog.Debug("discarding response with unexpected id",
+				slog.Int64("got", msg.Response.ID),
+				slog.Int64("want", expectedID))
+		}
 	}
 }
 
 // initializeHandshake sends the initialize request and initialized
 // notification per the app-server protocol.
-func initializeHandshake(ctx context.Context, state *sessionState, scanner *bufio.Scanner) error {
+func initializeHandshake(ctx context.Context, state *sessionState, scanCh <-chan scanResult) error {
 	type clientInfo struct {
 		Name    string `json:"name"`
 		Title   string `json:"title"`
@@ -152,7 +190,7 @@ func initializeHandshake(ctx context.Context, state *sessionState, scanner *bufi
 		return fmt.Errorf("initialize: %w", err)
 	}
 
-	resp, err := readResponse(ctx, scanner, id)
+	resp, err := readResponse(ctx, scanCh, id)
 	if err != nil {
 		return fmt.Errorf("initialize response: %w", err)
 	}
@@ -168,13 +206,13 @@ func initializeHandshake(ctx context.Context, state *sessionState, scanner *bufi
 
 // authenticateIfNeeded checks the app-server auth state and performs
 // API key login if needed.
-func authenticateIfNeeded(ctx context.Context, state *sessionState, scanner *bufio.Scanner) error {
+func authenticateIfNeeded(ctx context.Context, state *sessionState, scanCh <-chan scanResult) error {
 	id, err := sendRequest(state, "account/read", map[string]any{"refreshToken": false})
 	if err != nil {
 		return fmt.Errorf("account/read: %w", err)
 	}
 
-	resp, err := readResponse(ctx, scanner, id)
+	resp, err := readResponse(ctx, scanCh, id)
 	if err != nil {
 		return fmt.Errorf("account/read response: %w", err)
 	}
@@ -207,8 +245,7 @@ func authenticateIfNeeded(ctx context.Context, state *sessionState, scanner *buf
 		return fmt.Errorf("account/login/start: %w", err)
 	}
 
-	// Read until login response and login/completed notification.
-	loginResp, err := readResponse(ctx, scanner, loginID)
+	loginResp, err := readResponse(ctx, scanCh, loginID)
 	if err != nil {
 		return fmt.Errorf("account/login/start response: %w", err)
 	}
@@ -219,8 +256,7 @@ func authenticateIfNeeded(ctx context.Context, state *sessionState, scanner *buf
 		}
 	}
 
-	// Wait for account/login/completed notification. Read lines
-	// until we find it.
+	// Wait for account/login/completed notification.
 	deadline := time.After(readTimeout(state))
 	for {
 		select {
@@ -228,37 +264,37 @@ func authenticateIfNeeded(ctx context.Context, state *sessionState, scanner *buf
 			return ctx.Err()
 		case <-deadline:
 			return fmt.Errorf("timeout waiting for account/login/completed")
-		default:
-		}
-		if !scanner.Scan() {
-			if err := scanner.Err(); err != nil {
-				return fmt.Errorf("scanner error waiting for login: %w", err)
+		case result, ok := <-scanCh:
+			if !ok || result.EOF {
+				return fmt.Errorf("unexpected EOF waiting for login")
 			}
-			return fmt.Errorf("unexpected EOF waiting for login")
-		}
-		msg := parseMessage(scanner.Bytes())
-		if msg.Err != nil {
-			continue
-		}
-		if msg.IsNotification && msg.Notification.Method == "account/login/completed" {
-			var loginNotif accountLoginNotification
-			if err := json.Unmarshal(msg.Notification.Params, &loginNotif); err != nil {
-				return fmt.Errorf("login notification unmarshal: %w", err)
+			if result.Err != nil {
+				return fmt.Errorf("scanner error waiting for login: %w", result.Err)
 			}
-			if !loginNotif.Success {
-				return &domain.AgentError{
-					Kind:    domain.ErrResponseError,
-					Message: "authentication failed",
+			msg := parseMessage(result.Line)
+			if msg.Err != nil {
+				continue
+			}
+			if msg.IsNotification && msg.Notification.Method == "account/login/completed" {
+				var loginNotif accountLoginNotification
+				if err := json.Unmarshal(msg.Notification.Params, &loginNotif); err != nil {
+					return fmt.Errorf("login notification unmarshal: %w", err)
 				}
+				if !loginNotif.Success {
+					return &domain.AgentError{
+						Kind:    domain.ErrResponseError,
+						Message: "authentication failed",
+					}
+				}
+				return nil
 			}
-			return nil
 		}
 	}
 }
 
 // startThread sends thread/start and waits for the thread/started
 // notification. Returns the thread ID.
-func startThread(ctx context.Context, state *sessionState, scanner *bufio.Scanner, pt passthroughConfig, tools []domain.AgentTool) (string, error) {
+func startThread(ctx context.Context, state *sessionState, scanCh <-chan scanResult, pt passthroughConfig, tools []domain.AgentTool) (string, error) {
 	approvalPolicy := pt.ApprovalPolicy
 	if approvalPolicy == "" {
 		approvalPolicy = "never"
@@ -291,7 +327,7 @@ func startThread(ctx context.Context, state *sessionState, scanner *bufio.Scanne
 		return "", fmt.Errorf("thread/start: %w", err)
 	}
 
-	resp, err := readResponse(ctx, scanner, id)
+	resp, err := readResponse(ctx, scanCh, id)
 	if err != nil {
 		return "", fmt.Errorf("thread/start response: %w", err)
 	}
@@ -318,26 +354,27 @@ func startThread(ctx context.Context, state *sessionState, scanner *bufio.Scanne
 			// Accept the thread ID even without the notification.
 			// Some app-server versions may not emit it.
 			return threadID, nil
-		default:
-		}
-		if !scanner.Scan() {
-			if scanErr := scanner.Err(); scanErr != nil {
-				slog.Debug("scanner error waiting for thread/started", slog.Any("error", scanErr))
+		case result, ok := <-scanCh:
+			if !ok || result.EOF {
+				return threadID, nil
 			}
-			return threadID, nil
-		}
-		msg := parseMessage(scanner.Bytes())
-		if msg.Err != nil {
-			continue
-		}
-		if msg.IsNotification && msg.Notification.Method == "thread/started" {
-			return threadID, nil
+			if result.Err != nil {
+				slog.Debug("scanner error waiting for thread/started", slog.Any("error", result.Err))
+				return threadID, nil
+			}
+			msg := parseMessage(result.Line)
+			if msg.Err != nil {
+				continue
+			}
+			if msg.IsNotification && msg.Notification.Method == "thread/started" {
+				return threadID, nil
+			}
 		}
 	}
 }
 
 // resumeThread sends thread/resume for an existing thread.
-func resumeThread(ctx context.Context, state *sessionState, scanner *bufio.Scanner, threadID string) error {
+func resumeThread(ctx context.Context, state *sessionState, scanCh <-chan scanResult, threadID string) error {
 	id, err := sendRequest(state, "thread/resume", map[string]any{
 		"threadId": threadID,
 	})
@@ -345,7 +382,7 @@ func resumeThread(ctx context.Context, state *sessionState, scanner *bufio.Scann
 		return fmt.Errorf("thread/resume: %w", err)
 	}
 
-	resp, err := readResponse(ctx, scanner, id)
+	resp, err := readResponse(ctx, scanCh, id)
 	if err != nil {
 		return fmt.Errorf("thread/resume response: %w", err)
 	}

--- a/internal/agent/codex/protocol_test.go
+++ b/internal/agent/codex/protocol_test.go
@@ -6,6 +6,7 @@ import (
 	"bufio"
 	"context"
 	"errors"
+	"io"
 	"strings"
 	"testing"
 	"time"
@@ -26,14 +27,12 @@ func TestSendNotification_WritesToStdin(t *testing.T) {
 func TestReadResponse_SkipsNotifications(t *testing.T) {
 	t.Parallel()
 
-	fixture := strings.NewReader(
-		"{\"method\":\"some/notification\",\"params\":{}}\n" +
-			"{\"id\":1,\"result\":{\"ok\":true}}\n",
+	scanCh := scanChanFromLines(
+		`{"method":"some/notification","params":{}}`,
+		`{"id":1,"result":{"ok":true}}`,
 	)
-	scanner := bufio.NewScanner(fixture)
-	scanner.Buffer(make([]byte, 0, 1<<20), 1<<20)
 
-	resp, err := readResponse(context.Background(), scanner, 1)
+	resp, err := readResponse(context.Background(), scanCh, 1)
 	if err != nil {
 		t.Fatalf("readResponse() error = %v", err)
 	}
@@ -45,14 +44,12 @@ func TestReadResponse_SkipsNotifications(t *testing.T) {
 func TestReadResponse_SkipsWrongID(t *testing.T) {
 	t.Parallel()
 
-	fixture := strings.NewReader(
-		"{\"id\":99,\"result\":{}}\n" + // wrong ID
-			"{\"id\":1,\"result\":{\"ok\":true}}\n",
+	scanCh := scanChanFromLines(
+		`{"id":99,"result":{}}`,
+		`{"id":1,"result":{"ok":true}}`,
 	)
-	scanner := bufio.NewScanner(fixture)
-	scanner.Buffer(make([]byte, 0, 1<<20), 1<<20)
 
-	resp, err := readResponse(context.Background(), scanner, 1)
+	resp, err := readResponse(context.Background(), scanCh, 1)
 	if err != nil {
 		t.Fatalf("readResponse() error = %v", err)
 	}
@@ -64,10 +61,9 @@ func TestReadResponse_SkipsWrongID(t *testing.T) {
 func TestReadResponse_UnexpectedEOF(t *testing.T) {
 	t.Parallel()
 
-	scanner := bufio.NewScanner(strings.NewReader(""))
-	scanner.Buffer(make([]byte, 0, 1<<20), 1<<20)
+	scanCh := scanChanFromLines() // immediate EOF
 
-	_, err := readResponse(context.Background(), scanner, 1)
+	_, err := readResponse(context.Background(), scanCh, 1)
 	if err == nil {
 		t.Fatal("readResponse() expected error on empty input, got nil")
 	}
@@ -82,10 +78,8 @@ func TestReadResponse_ContextCancelled(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	scanner := bufio.NewScanner(strings.NewReader("{\"id\":1,\"result\":{}}\n"))
-	scanner.Buffer(make([]byte, 0, 1<<20), 1<<20)
-
-	_, err := readResponse(ctx, scanner, 1)
+	scanCh := make(chan scanResult) // no sender; ctx.Done() is the only ready case
+	_, err := readResponse(ctx, scanCh, 1)
 	if !errors.Is(err, context.Canceled) {
 		t.Errorf("readResponse() error = %v, want context.Canceled", err)
 	}
@@ -94,14 +88,12 @@ func TestReadResponse_ContextCancelled(t *testing.T) {
 func TestReadResponse_MalformedMessageSkipped(t *testing.T) {
 	t.Parallel()
 
-	fixture := strings.NewReader(
-		"not-valid-json\n" +
-			"{\"id\":1,\"result\":{\"ok\":true}}\n",
+	scanCh := scanChanFromLines(
+		"not-valid-json",
+		`{"id":1,"result":{"ok":true}}`,
 	)
-	scanner := bufio.NewScanner(fixture)
-	scanner.Buffer(make([]byte, 0, 1<<20), 1<<20)
 
-	resp, err := readResponse(context.Background(), scanner, 1)
+	resp, err := readResponse(context.Background(), scanCh, 1)
 	if err != nil {
 		t.Fatalf("readResponse() error = %v", err)
 	}
@@ -167,4 +159,58 @@ func TestStartSession_SSHBinaryNotFound(t *testing.T) {
 		AgentConfig:   domain.AgentConfig{Command: "codex app-server"},
 	})
 	requireAgentError(t, err, domain.ErrAgentNotFound)
+}
+
+func TestReadResponse_ContextCancelledWhileBlocked(t *testing.T) {
+	t.Parallel()
+
+	pr, pw := io.Pipe()
+	t.Cleanup(func() { _ = pr.Close(); _ = pw.Close() })
+
+	scanner := bufio.NewScanner(pr)
+	scanner.Buffer(make([]byte, 0, 1<<20), 1<<20)
+
+	stop := make(chan struct{})
+	t.Cleanup(func() { close(stop) })
+	scanCh := startScannerCh(scanner, stop)
+
+	// Pipe never writes; scanner goroutine blocks in pr.Read(). Only ctx.Done()
+	// will be ready in the select, so the result is deterministic.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := readResponse(ctx, scanCh, 1)
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("readResponse() = %v, want context.Canceled", err)
+	}
+}
+
+func TestStartScannerCh_NoLeakOnContextCancel(t *testing.T) {
+	t.Parallel()
+
+	pr, pw := io.Pipe()
+	t.Cleanup(func() { _ = pr.Close(); _ = pw.Close() })
+
+	scanner := bufio.NewScanner(pr)
+	scanner.Buffer(make([]byte, 0, 1<<20), 1<<20)
+
+	stop := make(chan struct{})
+	scanCh := startScannerCh(scanner, stop)
+
+	// Close stop to signal the goroutine, then close the write end so that
+	// scanner.Scan unblocks and the goroutine can observe the stop signal.
+	close(stop)
+	_ = pw.Close()
+
+	deadline := time.After(time.Second)
+	for {
+		select {
+		case _, ok := <-scanCh:
+			if !ok {
+				return // channel closed — goroutine exited, no leak
+			}
+		case <-deadline:
+			t.Fatal("startScannerCh goroutine did not exit within 1s after stop closed")
+		}
+	}
 }


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Feat

**Intent:** `readResponse`, the login-wait loop in `authenticateIfNeeded`, and the notification-wait loop in `startThread` all called `scanner.Scan()` directly in the calling goroutine. Because `Scan()` blocks on the underlying `io.Reader`, a stalled subprocess could hang the worker run indefinitely — context cancellation and `ReadTimeoutMS` deadlines had no effect. This change replaces those blocking calls with a background scanner goroutine that delivers results via a channel, so all handshake functions can select on both the channel and `ctx.Done()`.

**Related Issues:** #463

### 🧭 Reviewer Guide

**Complexity:** Medium

#### Entry Point

Start with `internal/agent/codex/protocol.go` — `startScannerCh` is the new primitive, and the refactored `readResponse`, `authenticateIfNeeded`, `startThread`, and `resumeThread` signatures all follow from it. The pattern mirrors what the `RunTurn` event loop already does via `state.msgCh`.

#### Sensitive Areas

- `internal/agent/codex/codex.go`: `StartSession` moves `state.stopCh` creation earlier (before `startScannerCh`) and adds `state.closeStop.Do` to every handshake error path. Two unblocking mechanisms are required: closing `stopCh` (unblocks goroutine blocked on channel send) and calling `killOnError()` (closes stdout pipe, unblocks `Scan()`). Both must fire on cancellation to prevent goroutine leaks.
- `internal/agent/codex/protocol.go`: `startScannerCh` copies `scanner.Bytes()` into a fresh slice before each send — `Bytes()` is only valid until the next `Scan()` call. The channel buffer of 1 prevents one-ahead reads from blocking while still allowing the `select`-on-stop exit path.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes — all changes are internal to `internal/agent/codex/`. No interface or public API modifications.
- **Migrations/State:** No migrations or state changes.