### PR TITLE
docs(examples): add sample WORKFLOW.md for Jira + Codex CLI

### DIFF
--- a/examples/WORKFLOW.codex.md
+++ b/examples/WORKFLOW.codex.md
@@ -1,0 +1,166 @@
+---
+tracker:
+  kind: jira
+  endpoint: $SORTIE_JIRA_ENDPOINT
+  api_key: $SORTIE_JIRA_API_KEY
+  project: $SORTIE_JIRA_PROJECT
+  query_filter: "labels = 'agent-ready'"
+  active_states:
+    - To Do
+    - In Progress
+  in_progress_state: In Progress
+  handoff_state: Human Review
+  terminal_states:
+    - Done
+    - Won't Do
+
+polling:
+  interval_ms: 45000
+
+workspace:
+  root: $SORTIE_WORKSPACE_ROOT
+
+hooks:
+  after_create: |
+    git clone --depth 1 $SORTIE_REPO_URL .
+  before_run: |
+    git fetch origin main
+    git checkout -B "sortie/$SORTIE_ISSUE_IDENTIFIER" origin/main
+  after_run: |
+    git add -A
+    git diff --cached --quiet || \
+      git commit -m "sortie($SORTIE_ISSUE_IDENTIFIER): automated changes"
+    git push origin "sortie/$SORTIE_ISSUE_IDENTIFIER" --force-with-lease
+  before_remove: |
+    git push origin --delete "sortie/$SORTIE_ISSUE_IDENTIFIER" 2>/dev/null || true
+  timeout_ms: 120000
+
+agent:
+  kind: codex
+  command: codex app-server
+  max_turns: 15
+  max_concurrent_agents: 4
+  turn_timeout_ms: 3600000
+  read_timeout_ms: 5000
+  stall_timeout_ms: 300000
+  max_retry_backoff_ms: 300000
+
+codex:
+  model: o3
+  effort: medium
+  approval_policy: never
+  thread_sandbox: workspaceWrite
+  skip_git_repo_check: false
+
+server:
+  port: 8642
+---
+
+{{/* Sortie sample workflow — Jira + Codex CLI (OpenAI).
+
+     The Codex adapter uses a persistent app-server subprocess launched
+     once per session. Turns are JSON-RPC requests on the same thread,
+     so no --resume flag is needed between turns.
+
+     Required env vars:
+       SORTIE_JIRA_ENDPOINT  — Jira Cloud base URL (e.g. https://mycompany.atlassian.net)
+       SORTIE_JIRA_API_KEY   — Jira API token
+       SORTIE_JIRA_PROJECT   — Jira project key (e.g. PROJ)
+       SORTIE_REPO_URL       — Git clone URL for the repository
+       CODEX_API_KEY         — OpenAI API key for Codex CLI
+
+     Optional:
+       SORTIE_WORKSPACE_ROOT — Base directory for per-issue workspaces
+                               (defaults to system temp) */}}
+You are a senior engineer. Your work is tracked by an automated orchestrator (Sortie)
+that manages your session, retries failures, and monitors progress.
+
+## Your task
+
+**{{ .issue.identifier }}**: {{ .issue.title }}
+
+{{ if .issue.description }}
+
+### Description
+
+{{ .issue.description }}
+{{ end }}
+
+## Context
+
+Before making changes, read:
+
+- `AGENTS.md` or `CONTRIBUTING.md` for build commands and project conventions
+- Any existing tests in the area you are modifying
+- Related source files to understand current patterns
+
+## Rules
+
+1. Run the project's lint and test commands before finishing. All checks must pass.
+2. Do not modify protected files (architecture docs, ADRs, LICENSE) unless the task
+   explicitly requires it.
+3. Write tests for new functionality. Cover edge cases, not just the happy path.
+4. Keep changes minimal — implement exactly what the task requires.
+5. If you encounter a problem outside the scope of this task, stop and explain what
+   blocked you.
+
+{{ if not .run.is_continuation }}
+
+## Approach
+
+1. Read the relevant documentation and existing code before writing anything.
+2. Implement the minimal change that satisfies the task requirements.
+3. Write or update tests to cover the new behavior.
+4. Run verification commands and fix any failures.
+5. If the task is complete, confirm by reviewing your changes.
+{{ end }}
+
+{{ if .run.is_continuation }}
+
+## Continuation
+
+You are resuming work on this task (turn {{ .run.turn_number }} of {{ .run.max_turns }}).
+Review the current state of the workspace — check test output, lint results, and any
+partial changes. Do not repeat work already completed. Proceed with the next step.
+{{ end }}
+
+{{ if .attempt }}
+
+## Retry
+
+This is retry attempt {{ .attempt }}. A previous run failed or timed out. Check the
+workspace for partial work and do not start from scratch. Review any error output from
+the previous attempt if visible in the workspace.
+{{ end }}
+
+{{ if .issue.url }}
+
+## Reference
+
+Ticket: {{ .issue.url }}
+{{ end }}
+
+{{ if .issue.labels }}
+
+## Labels
+
+{{ .issue.labels | join ", " }}
+{{ end }}
+
+{{ if .issue.parent }}
+
+## Parent issue
+
+{{ .issue.parent.identifier }}
+{{ end }}
+
+{{ if .issue.blocked_by }}
+
+## Blockers
+
+The following issues block this task. If any are unresolved, focus on preparation work
+that does not depend on the blocked functionality (tests, scaffolding, documentation).
+
+{{ range .issue.blocked_by }}- **{{ .identifier }}**{{ if .state }} ({{ .state }}){{ end }}
+{{ end }}
+{{ end }}


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Docs

**Intent:** Add a sample `WORKFLOW.md` demonstrating the Jira tracker + Codex CLI agent combination, giving operators a copy-paste starting point equivalent to the existing Claude Code and Copilot CLI examples.

**Related Issues:** #456

### 🧭 Reviewer Guide

**Complexity:** Low

#### Entry Point

`examples/WORKFLOW.codex.md` — the sole file added. It mirrors the structure of `examples/WORKFLOW.md` (Jira + Claude Code) while substituting the `codex` agent kind, the `codex app-server` command, and the `codex:` pass-through block. The prompt template body and hook scripts are intentionally aligned with the existing examples for consistency.

#### Sensitive Areas

- `examples/WORKFLOW.codex.md`: contains env var references (`CODEX_API_KEY`, `SORTIE_JIRA_*`, `SORTIE_REPO_URL`) that operators will substitute; no secrets are hardcoded.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes
- **Migrations/State:** No migrations or state changes