### PR TITLE
test(codex): integration test suite, sandbox casing fix, and default models

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -264,6 +264,44 @@ jobs:
       - name: Run integration tests
         run: go test -race -count=1 -v -timeout 300s -run 'Integration' ./internal/agent/copilot/...
 
+  test-integration-codex:
+    name: "Integration: OpenAI Codex"
+    needs: [lint, test-unit]
+    runs-on: ubuntu-latest
+    env:
+      SORTIE_CODEX_TEST: "1"
+      CODEX_API_KEY: ${{ secrets.CODEX_API_KEY }}
+    steps:
+      - name: Verify Codex secrets are configured
+        run: |
+          missing=()
+          [ -z "$CODEX_API_KEY" ] && missing+=("CODEX_API_KEY")
+          if [ ${#missing[@]} -ne 0 ]; then
+            echo "::error::Missing required secrets: ${missing[*]}"
+            echo "Configure these in Settings → Secrets and variables → Actions"
+            exit 1
+          fi
+          echo "✓ All Codex secrets are present"
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+
+      - name: Set up Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: "22"
+
+      - name: Install GitHub Copilot CLI
+        run: npm install -g @openai/codex
+
+      - name: Run integration tests
+        run: go test -race -count=1 -v -timeout 300s -run 'Integration' ./internal/agent/codex/...
+
   release:
     name: Tag & Release
     needs:
@@ -274,6 +312,7 @@ jobs:
       - test-e2e-github
       - test-integration-claude
       - test-integration-copilot
+      - test-integration-codex
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -296,7 +296,7 @@ jobs:
         with:
           node-version: "22"
 
-      - name: Install GitHub Copilot CLI
+      - name: Install OpenAI Codex CLI
         run: npm install -g @openai/codex
 
       - name: Run integration tests

--- a/docs/codex-adapter-notes.md
+++ b/docs/codex-adapter-notes.md
@@ -226,7 +226,7 @@ Then:
   "model": "gpt-5.4",
   "cwd": "/var/sortie/workspaces/PROJ-123",
   "approvalPolicy": "never",
-  "sandbox": "workspaceWrite",
+  "sandbox": "workspace-write",
   "dynamicTools": [
     {
       "name": "tracker_api",
@@ -420,12 +420,16 @@ Normalization to Sortie's `{input_tokens, output_tokens, total_tokens}`:
 
 Codex enforces OS-level sandboxing (Seatbelt on macOS, bwrap + seccomp on Linux).
 
-| Sandbox mode          | `sandboxPolicy.type`  | Description                                    |
-| --------------------- | --------------------- | ---------------------------------------------- |
-| Read-only             | `readOnly`            | No file writes, no network.                    |
-| Workspace write       | `workspaceWrite`      | Writes allowed within workspace root. No network by default. |
-| Danger full access    | `dangerFullAccess`    | No sandbox. Full filesystem and network access. |
-| External sandbox      | `externalSandbox`     | Codex skips its sandbox; external enforcement assumed. |
+| Sandbox mode          | `thread/start` sandbox | `sandboxPolicy.type` | Description                                    |
+| --------------------- | ---------------------- | -------------------- | ---------------------------------------------- |
+| Read-only             | `read-only`            | `readOnly`           | No file writes, no network.                    |
+| Workspace write       | `workspace-write`      | `workspaceWrite`     | Writes allowed within workspace root. No network by default. |
+| Danger full access    | `danger-full-access`   | `dangerFullAccess`   | No sandbox. Full filesystem and network access. |
+| External sandbox      | `external-sandbox`     | `externalSandbox`    | Codex skips its sandbox; external enforcement assumed. |
+
+The app-server uses **kebab-case** for the `sandbox` field on `thread/start` and **camelCase**
+for `sandboxPolicy.type` on `turn/start`. The adapter's WORKFLOW.md config (`thread_sandbox`)
+accepts camelCase values and translates to the correct wire format for each endpoint.
 
 For Sortie's headless operation in sandboxed containers, two approaches:
 
@@ -747,7 +751,7 @@ $ codex app-server
 ← {"id":2,"result":{"account":{"type":"apiKey"},"requiresOpenaiAuth":false}}
 
 # 4. Start thread
-→ {"method":"thread/start","id":10,"params":{"model":"gpt-5.4","cwd":"/var/sortie/workspaces/PROJ-123","approvalPolicy":"never","sandbox":"workspaceWrite","dynamicTools":[{"name":"tracker_api","description":"Issue tracker operations","inputSchema":{"type":"object","required":["operation"],"properties":{"operation":{"type":"string"},"issue_id":{"type":"string"},"target_state":{"type":"string"}}}}]}}
+→ {"method":"thread/start","id":10,"params":{"model":"gpt-5.4","cwd":"/var/sortie/workspaces/PROJ-123","approvalPolicy":"never","sandbox":"workspace-write","dynamicTools":[{"name":"tracker_api","description":"Issue tracker operations","inputSchema":{"type":"object","required":["operation"],"properties":{"operation":{"type":"string"},"issue_id":{"type":"string"},"target_state":{"type":"string"}}}}]}}
 ← {"id":10,"result":{"thread":{"id":"thr_abc123"}}}
 ← {"method":"thread/started","params":{"thread":{"id":"thr_abc123"}}}
 

--- a/examples/docker/README.md
+++ b/examples/docker/README.md
@@ -11,6 +11,7 @@ Build an agent-specific image from the repository root:
 
 ```sh
 docker build -f examples/docker/claude-code.Dockerfile -t sortie-claude .
+docker build -f examples/docker/codex.Dockerfile -t sortie-codex .
 docker build -f examples/docker/copilot.Dockerfile -t sortie-copilot .
 ```
 
@@ -30,6 +31,7 @@ docker run --rm --init \
 | File | Agent | Base image |
 |---|---|---|
 | `claude-code.Dockerfile` | Claude Code | `node:24-slim` |
+| `codex.Dockerfile` | OpenAI Codex CLI | `debian:bookworm-slim` |
 | `copilot.Dockerfile` | GitHub Copilot | `node:24-slim` |
 
 Each Dockerfile follows the same pattern: copy the Sortie binary from the

--- a/examples/docker/codex.Dockerfile
+++ b/examples/docker/codex.Dockerfile
@@ -27,8 +27,15 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # Install Codex CLI. The Rust binary is statically linked and does not
 # require Node.js.
-RUN curl -fsSL https://github.com/openai/codex/releases/latest/download/codex-linux-$(dpkg --print-architecture).tar.gz \
-    | tar -xz -C /usr/local/bin codex && \
+RUN set -eux; \
+    debian_arch="$(dpkg --print-architecture)"; \
+    case "${debian_arch}" in \
+    amd64) codex_arch="x86_64-unknown-linux-musl" ;; \
+    arm64) codex_arch="aarch64-unknown-linux-musl" ;; \
+    *) echo "unsupported Codex architecture: ${debian_arch}" >&2; exit 1 ;; \
+    esac; \
+    curl -fsSL "https://github.com/openai/codex/releases/latest/download/codex-${codex_arch}.tar.gz" \
+    | tar -xz -C /usr/local/bin codex; \
     chmod +x /usr/local/bin/codex
 
 # Create a non-root user.

--- a/examples/docker/codex.Dockerfile
+++ b/examples/docker/codex.Dockerfile
@@ -1,0 +1,51 @@
+# examples/docker/codex.Dockerfile
+#
+# Complete working example: Sortie + OpenAI Codex CLI agent.
+#
+# Codex CLI is a statically linked Rust binary — no Node.js runtime required.
+# The container runs as a non-root user for security best practices.
+#
+# Build:
+#   docker build -f examples/docker/codex.Dockerfile -t sortie-codex .
+#
+# Run:
+#   docker run --rm --init \
+#     -e CODEX_API_KEY \
+#     -v "$(pwd)/workspaces:/home/sortie/workspaces" \
+#     -v "$(pwd)/WORKFLOW.md:/home/sortie/WORKFLOW.md:ro" \
+#     -p 7678:7678 \
+#     sortie-codex /home/sortie/WORKFLOW.md
+
+FROM ghcr.io/sortie-ai/sortie:latest AS sortie
+
+FROM debian:bookworm-slim
+
+# Install git (Codex requires a git repo) and download utilities.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git ca-certificates curl wget && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install Codex CLI. The Rust binary is statically linked and does not
+# require Node.js.
+RUN curl -fsSL https://github.com/openai/codex/releases/latest/download/codex-linux-$(dpkg --print-architecture).tar.gz \
+    | tar -xz -C /usr/local/bin codex && \
+    chmod +x /usr/local/bin/codex
+
+# Create a non-root user.
+RUN useradd --create-home --shell /bin/bash --uid 1000 sortie
+
+# Copy the Sortie binary from the distroless image.
+COPY --from=sortie /usr/bin/sortie /usr/bin/sortie
+
+# Switch to the non-root user for all subsequent operations.
+USER sortie
+WORKDIR /home/sortie
+
+# The HTTP observability server listens on all interfaces so the host
+# can reach it through the published port.
+EXPOSE 7678
+
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+    CMD wget -qO /dev/null http://localhost:7678/readyz || exit 1
+
+ENTRYPOINT ["/usr/bin/sortie", "--host", "0.0.0.0", "--log-format", "json"]

--- a/internal/agent/claude/integration_test.go
+++ b/internal/agent/claude/integration_test.go
@@ -26,13 +26,14 @@ func skipUnlessIntegration(t *testing.T) {
 // repeated test runs.
 func integrationConfig(t *testing.T) map[string]any {
 	t.Helper()
-	cfg := map[string]any{
+	model := os.Getenv("SORTIE_CLAUDE_MODEL")
+	if model == "" {
+		model = "claude-haiku-4-5"
+	}
+	return map[string]any{
 		"session_persistence": false,
+		"model":               model,
 	}
-	if model := os.Getenv("SORTIE_CLAUDE_MODEL"); model != "" {
-		cfg["model"] = model
-	}
-	return cfg
 }
 
 // integrationCommand returns the Claude Code binary path from the

--- a/internal/agent/codex/integration_test.go
+++ b/internal/agent/codex/integration_test.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"sync"
 	"testing"
 	"time"
@@ -270,7 +271,7 @@ func TestIntegration_RunTurn(t *testing.T) {
 
 	adapter := mustNewAdapter(t)
 	workspace := gitInitWorkspace(t)
-	if err := os.WriteFile(workspace+"/hello.txt", []byte("Hello"), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(workspace, "hello.txt"), []byte("Hello"), 0o644); err != nil {
 		t.Fatalf("WriteFile: %v", err)
 	}
 
@@ -419,7 +420,9 @@ func TestIntegration_MultiTurn(t *testing.T) {
 
 	session := mustStartSession(t, ctx, adapter, workspace)
 	state := session.Internal.(*sessionState)
+	state.mu.Lock()
 	pidAfterStart := state.proc.Pid
+	state.mu.Unlock()
 
 	// Turn 1: must emit EventSessionStarted and complete successfully.
 	onEvent1, collected1 := makeEventCollector(t)

--- a/internal/agent/codex/integration_test.go
+++ b/internal/agent/codex/integration_test.go
@@ -5,6 +5,10 @@
 //	SORTIE_CODEX_TEST=1     enable this suite
 //	CODEX_API_KEY           Codex API key for authentication
 //
+// Optional environment variables:
+//
+//	SORTIE_CODEX_COMMAND    override the default "codex app-server" binary command
+//
 // Run:
 //
 //	SORTIE_CODEX_TEST=1 CODEX_API_KEY=... make test PKG=./internal/agent/codex/... RUN=Integration
@@ -12,6 +16,7 @@ package codex
 
 import (
 	"context"
+	"errors"
 	"os"
 	"os/exec"
 	"sync"
@@ -20,6 +25,8 @@ import (
 
 	"github.com/sortie-ai/sortie/internal/domain"
 )
+
+// --- Integration test helpers ---
 
 // skipUnlessCodexIntegration skips the current test when SORTIE_CODEX_TEST
 // is not set to "1", so disabled integration tests are reported as skipped
@@ -34,6 +41,19 @@ func skipUnlessCodexIntegration(t *testing.T) {
 	}
 }
 
+// integrationConfig builds the adapter config map for integration tests.
+func integrationConfig() map[string]any {
+	model := os.Getenv("SORTIE_CODEX_MODEL")
+	if model == "" {
+		model = "gpt-5.4-nano"
+	}
+	return map[string]any{
+		"approval_policy": "never",
+		"thread_sandbox":  "workspaceWrite",
+		"model":           model,
+	}
+}
+
 // integrationCommand returns the Codex CLI binary command from the
 // SORTIE_CODEX_COMMAND environment variable, defaulting to "codex app-server".
 func integrationCommand() string {
@@ -41,6 +61,30 @@ func integrationCommand() string {
 		return cmd
 	}
 	return "codex app-server"
+}
+
+// integrationAgentConfig returns the [domain.AgentConfig] used by
+// integration tests. Timeouts are deliberately generous to accommodate
+// API latency variance.
+func integrationAgentConfig() domain.AgentConfig {
+	return domain.AgentConfig{
+		Command:       integrationCommand(),
+		TurnTimeoutMS: 90000,
+		ReadTimeoutMS: 30000,
+	}
+}
+
+// gitInitWorkspace creates a temp directory and runs git init inside it.
+// The absolute path is returned. The test fails immediately if git init
+// fails, because the Codex app-server requires a git repository by default.
+func gitInitWorkspace(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	cmd := exec.CommandContext(context.Background(), "git", "-C", dir, "init")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("gitInitWorkspace: git init: %v\n%s", err, out)
+	}
+	return dir
 }
 
 // assertContainsEventType asserts that at least one event in the slice
@@ -59,70 +103,465 @@ func assertContainsEventType(t *testing.T, events []domain.AgentEvent, eventType
 	t.Errorf("expected event type %q not found; got types: %v", eventType, types)
 }
 
-func TestCodexAdapter_Integration(t *testing.T) {
+// assertNoEventType asserts that no event in the slice has the given type.
+func assertNoEventType(t *testing.T, events []domain.AgentEvent, eventType domain.AgentEventType) {
+	t.Helper()
+	for _, e := range events {
+		if e.Type == eventType {
+			t.Errorf("unexpected event type %q found with message: %q", eventType, e.Message)
+			return
+		}
+	}
+}
+
+// requireAgentErrorKind asserts err is a *domain.AgentError with the given Kind.
+func requireAgentErrorKind(t *testing.T, err error, wantKind domain.AgentErrorKind) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("expected error with kind %q, got nil", wantKind)
+	}
+	var ae *domain.AgentError
+	if !errors.As(err, &ae) {
+		t.Fatalf("error type = %T, want *domain.AgentError", err)
+	}
+	if ae.Kind != wantKind {
+		t.Errorf("AgentError.Kind = %q, want %q", ae.Kind, wantKind)
+	}
+}
+
+// makeEventCollector returns an OnEvent callback and a snapshot function.
+// The snapshot function returns a copy of all events collected so far
+// and is safe to call from any goroutine.
+func makeEventCollector(t *testing.T) (onEvent func(domain.AgentEvent), collected func() []domain.AgentEvent) {
+	t.Helper()
+	var mu sync.Mutex
+	var events []domain.AgentEvent
+	onEvent = func(e domain.AgentEvent) {
+		mu.Lock()
+		events = append(events, e)
+		mu.Unlock()
+	}
+	collected = func() []domain.AgentEvent {
+		mu.Lock()
+		defer mu.Unlock()
+		out := make([]domain.AgentEvent, len(events))
+		copy(out, events)
+		return out
+	}
+	return onEvent, collected
+}
+
+// mustNewAdapter creates a CodexAdapter from integrationConfig or fails the
+// test immediately.
+func mustNewAdapter(t *testing.T) *CodexAdapter {
+	t.Helper()
+	a, err := NewCodexAdapter(integrationConfig())
+	if err != nil {
+		t.Fatalf("NewCodexAdapter: %v", err)
+	}
+	return a.(*CodexAdapter)
+}
+
+// mustStartSession calls StartSession with the standard integration config and
+// registers a StopSession cleanup. It fails the test immediately on error.
+func mustStartSession(t *testing.T, ctx context.Context, adapter *CodexAdapter, workspace string) domain.Session {
+	t.Helper()
+	session, err := adapter.StartSession(ctx, domain.StartSessionParams{
+		WorkspacePath: workspace,
+		AgentConfig:   integrationAgentConfig(),
+	})
+	if err != nil {
+		t.Fatalf("StartSession: %v", err)
+	}
+	t.Cleanup(func() { _ = adapter.StopSession(context.Background(), session) })
+	return session
+}
+
+// --- Integration test functions ---
+
+// TestIntegration_StartSession verifies that StartSession returns a populated
+// Session with a non-empty thread ID and process PID.
+func TestIntegration_StartSession(t *testing.T) {
 	skipUnlessCodexIntegration(t)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	adapter := mustNewAdapter(t)
+	workspace := gitInitWorkspace(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
-	// Create a temp directory with git init for the workspace.
-	dir := t.TempDir()
-	gitCmd := exec.CommandContext(ctx, "git", "-C", dir, "init")
-	if out, err := gitCmd.CombinedOutput(); err != nil {
-		t.Fatalf("git init: %v\n%s", err, out)
-	}
-
-	adapter, err := NewCodexAdapter(map[string]any{})
-	if err != nil {
-		t.Fatalf("NewCodexAdapter() error = %v", err)
-	}
-
 	session, err := adapter.StartSession(ctx, domain.StartSessionParams{
-		WorkspacePath: dir,
-		AgentConfig: domain.AgentConfig{
-			Command:       integrationCommand(),
-			TurnTimeoutMS: 60000,
-			ReadTimeoutMS: 30000,
-		},
+		WorkspacePath: workspace,
+		AgentConfig:   integrationAgentConfig(),
 	})
 	if err != nil {
-		t.Fatalf("StartSession() error = %v", err)
+		t.Fatalf("StartSession: %v", err)
 	}
+	t.Cleanup(func() { _ = adapter.StopSession(context.Background(), session) })
 
 	if session.ID == "" {
-		t.Error("session.ID is empty")
+		t.Error("session.ID is empty; expected non-empty thread ID from app-server")
 	}
+	if session.AgentPID == "" {
+		t.Error("session.AgentPID is empty; expected PID of the persistent subprocess")
+	}
+	if session.Internal == nil {
+		t.Error("session.Internal is nil")
+	}
+}
 
-	var (
-		mu     sync.Mutex
-		events []domain.AgentEvent
-	)
+// TestIntegration_StopSession verifies that StopSession terminates the
+// persistent subprocess cleanly when called after a successful StartSession
+// but before any RunTurn. This validates that the subprocess lifecycle is
+// correctly managed at both ends.
+func TestIntegration_StopSession(t *testing.T) {
+	skipUnlessCodexIntegration(t)
 
-	result, runErr := adapter.RunTurn(ctx, session, domain.RunTurnParams{
-		Prompt: "Say hello in exactly one word. Do not write any code.",
-		OnEvent: func(ev domain.AgentEvent) {
-			mu.Lock()
-			events = append(events, ev)
-			mu.Unlock()
-		},
+	adapter := mustNewAdapter(t)
+	workspace := gitInitWorkspace(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	session, err := adapter.StartSession(ctx, domain.StartSessionParams{
+		WorkspacePath: workspace,
+		AgentConfig:   integrationAgentConfig(),
 	})
-
-	if runErr != nil {
-		t.Logf("RunTurn() error = %v (non-fatal: recording for diagnostics)", runErr)
+	if err != nil {
+		t.Fatalf("StartSession: %v", err)
 	}
 
+	// StopSession before any RunTurn must terminate the subprocess.
+	if err := adapter.StopSession(context.Background(), session); err != nil {
+		t.Fatalf("StopSession (idle): %v", err)
+	}
+
+	// A second StopSession call must be idempotent and not panic.
+	if err := adapter.StopSession(context.Background(), session); err != nil {
+		t.Errorf("StopSession (second call): %v", err)
+	}
+}
+
+// TestIntegration_StartSession_InvalidCommand verifies that StartSession
+// returns a properly typed ErrAgentNotFound error when the agent binary
+// does not exist on PATH.
+func TestIntegration_StartSession_InvalidCommand(t *testing.T) {
+	skipUnlessCodexIntegration(t)
+
+	adapter := mustNewAdapter(t)
+
+	_, err := adapter.StartSession(context.Background(), domain.StartSessionParams{
+		WorkspacePath: t.TempDir(),
+		AgentConfig:   domain.AgentConfig{Command: "sortie-nonexistent-codex-binary-99999"},
+	})
+	if err == nil {
+		t.Fatal("expected error for nonexistent command, got nil")
+	}
+
+	requireAgentErrorKind(t, err, domain.ErrAgentNotFound)
+}
+
+// TestIntegration_RunTurn executes a single turn and verifies the mandatory
+// event sequence, token usage, and tool result correlation. A file-read
+// prompt is used so the adapter emits at least one EventToolResult with a
+// populated ToolName.
+func TestIntegration_RunTurn(t *testing.T) {
+	skipUnlessCodexIntegration(t)
+
+	adapter := mustNewAdapter(t)
+	workspace := gitInitWorkspace(t)
+	if err := os.WriteFile(workspace+"/hello.txt", []byte("Hello"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	session := mustStartSession(t, ctx, adapter, workspace)
+	onEvent, collected := makeEventCollector(t)
+
+	result, err := adapter.RunTurn(ctx, session, domain.RunTurnParams{
+		Prompt:  "Read the file hello.txt. Output EXACTLY the file content and absolutely nothing else. No preamble, no explanation.",
+		OnEvent: onEvent,
+	})
+	if err != nil {
+		t.Fatalf("RunTurn: %v", err)
+	}
+
+	events := collected()
+	t.Logf("received %d events, exit reason: %q", len(events), result.ExitReason)
+
+	// Session ID must equal the thread ID established by StartSession.
 	if result.SessionID != session.ID {
 		t.Errorf("TurnResult.SessionID = %q, want %q", result.SessionID, session.ID)
 	}
+	if result.ExitReason != domain.EventTurnCompleted {
+		t.Errorf("TurnResult.ExitReason = %q, want %q", result.ExitReason, domain.EventTurnCompleted)
+	}
+	if len(events) == 0 {
+		t.Fatal("no events received via OnEvent")
+	}
 
-	mu.Lock()
-	capturedEvents := append([]domain.AgentEvent(nil), events...)
-	mu.Unlock()
+	assertContainsEventType(t, events, domain.EventSessionStarted)
+	assertContainsEventType(t, events, domain.EventTurnCompleted)
+	assertContainsEventType(t, events, domain.EventTokenUsage)
+	assertNoEventType(t, events, domain.EventTurnFailed)
+	assertNoEventType(t, events, domain.EventStartupFailed)
 
-	t.Logf("received %d events, exit reason: %q", len(capturedEvents), result.ExitReason)
-	assertContainsEventType(t, capturedEvents, domain.EventSessionStarted)
+	// Token totals must be internally consistent if the app-server provides
+	// usage data. Some app-server versions omit the usage field; log rather
+	// than fail so the test remains useful across versions.
+	if result.Usage.TotalTokens > 0 {
+		if result.Usage.TotalTokens != result.Usage.InputTokens+result.Usage.OutputTokens {
+			t.Errorf("TurnResult.Usage.TotalTokens = %d, want %d (input + output)",
+				result.Usage.TotalTokens, result.Usage.InputTokens+result.Usage.OutputTokens)
+		}
+	} else {
+		t.Log("token usage not provided by this app-server version (TotalTokens = 0)")
+	}
 
-	if stopErr := adapter.StopSession(ctx, session); stopErr != nil {
-		t.Errorf("StopSession() error = %v", stopErr)
+	// The file-read prompt causes at least one commandExecution or
+	// dynamicToolCall item, producing a correlated EventToolResult with
+	// a populated ToolName.
+	var foundToolResult bool
+	for _, e := range events {
+		if e.Type == domain.EventToolResult && e.ToolName != "" {
+			foundToolResult = true
+			if e.ToolDurationMS < 0 {
+				t.Errorf("EventToolResult.ToolDurationMS = %d, want >= 0", e.ToolDurationMS)
+			}
+			break
+		}
+	}
+	if !foundToolResult {
+		var toolNames []string
+		for _, e := range events {
+			if e.Type == domain.EventToolResult {
+				toolNames = append(toolNames, e.ToolName)
+			}
+		}
+		t.Errorf("expected EventToolResult with non-empty ToolName; got tool results with names: %v", toolNames)
+	}
+}
+
+// TestIntegration_RunTurn_StopDuringTurn verifies that calling StopSession
+// while RunTurn is blocked on the event stream causes RunTurn to unblock
+// and return an error without deadlocking. This is the persistent subprocess
+// equivalent of context cancellation: it tests the critical lifecycle
+// invariant that StopSession always terminates an in-flight turn.
+func TestIntegration_RunTurn_StopDuringTurn(t *testing.T) {
+	skipUnlessCodexIntegration(t)
+
+	adapter := mustNewAdapter(t)
+	workspace := gitInitWorkspace(t)
+
+	outerCtx, outerCancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer outerCancel()
+
+	session, err := adapter.StartSession(outerCtx, domain.StartSessionParams{
+		WorkspacePath: workspace,
+		AgentConfig:   integrationAgentConfig(),
+	})
+	if err != nil {
+		t.Fatalf("StartSession: %v", err)
+	}
+
+	type turnOutcome struct {
+		result domain.TurnResult
+		err    error
+	}
+	outcomeCh := make(chan turnOutcome, 1)
+
+	go func() {
+		r, e := adapter.RunTurn(outerCtx, session, domain.RunTurnParams{
+			// A prompt that causes the model to start a long tool execution,
+			// ensuring the turn is genuinely in-flight when we stop it.
+			Prompt:  "Execute the shell command: sleep 30",
+			OnEvent: func(_ domain.AgentEvent) {},
+		})
+		outcomeCh <- turnOutcome{result: r, err: e}
+	}()
+
+	// Give the turn time to start (turn/start sent, model begins processing).
+	// 400ms is well above the turn/start round-trip latency.
+	time.Sleep(400 * time.Millisecond)
+
+	// StopSession must terminate the subprocess, unblocking RunTurn.
+	if stopErr := adapter.StopSession(context.Background(), session); stopErr != nil {
+		t.Errorf("StopSession during turn: %v", stopErr)
+	}
+
+	// RunTurn must return within a reasonable bound after the subprocess exits.
+	select {
+	case outcome := <-outcomeCh:
+		if outcome.err == nil {
+			t.Error("RunTurn returned nil after StopSession was called mid-turn; expected an error")
+		}
+		t.Logf("RunTurn returned error after StopSession: %v", outcome.err)
+	case <-time.After(10 * time.Second):
+		t.Error("RunTurn did not unblock within 10s after StopSession; possible deadlock in reader goroutine")
+	}
+}
+
+// TestIntegration_MultiTurn validates the core architectural invariant of the
+// Codex adapter: the subprocess and thread persist across turns within a
+// session. Turn 1 emits EventSessionStarted; turn 2 emits only
+// EventNotification for the turn/started notification. Both turns share the
+// same SessionID (the thread ID), and the subprocess PID does not change.
+func TestIntegration_MultiTurn(t *testing.T) {
+	skipUnlessCodexIntegration(t)
+
+	adapter := mustNewAdapter(t)
+	workspace := gitInitWorkspace(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 180*time.Second)
+	defer cancel()
+
+	session := mustStartSession(t, ctx, adapter, workspace)
+	state := session.Internal.(*sessionState)
+	pidAfterStart := state.proc.Pid
+
+	// Turn 1: must emit EventSessionStarted and complete successfully.
+	onEvent1, collected1 := makeEventCollector(t)
+	result1, err := adapter.RunTurn(ctx, session, domain.RunTurnParams{
+		Prompt:  "Say exactly one word: hello",
+		OnEvent: onEvent1,
+	})
+	if err != nil {
+		t.Fatalf("RunTurn (turn 1): %v", err)
+	}
+	if result1.ExitReason != domain.EventTurnCompleted {
+		t.Fatalf("RunTurn (turn 1): ExitReason = %q, want %q", result1.ExitReason, domain.EventTurnCompleted)
+	}
+	if result1.SessionID != session.ID {
+		t.Errorf("turn 1: TurnResult.SessionID = %q, want %q", result1.SessionID, session.ID)
+	}
+	assertContainsEventType(t, collected1(), domain.EventSessionStarted)
+
+	// Verify internal turn counter after turn 1.
+	if state.turnCount != 1 {
+		t.Errorf("state.turnCount after turn 1 = %d, want 1", state.turnCount)
+	}
+
+	// Verify the subprocess PID has not changed after turn 1.
+	state.mu.Lock()
+	pidAfterTurn1 := state.proc.Pid
+	state.mu.Unlock()
+	if pidAfterTurn1 != pidAfterStart {
+		t.Errorf("subprocess PID changed after turn 1: before=%d after=%d (persistent subprocess must survive turns)", pidAfterStart, pidAfterTurn1)
+	}
+
+	// Turn 2: must NOT emit EventSessionStarted (only turn 1 does that).
+	// The turn/started notification for subsequent turns maps to EventNotification.
+	onEvent2, collected2 := makeEventCollector(t)
+	result2, err := adapter.RunTurn(ctx, session, domain.RunTurnParams{
+		Prompt:  "Say exactly one word: world",
+		OnEvent: onEvent2,
+	})
+	if err != nil {
+		t.Fatalf("RunTurn (turn 2): %v", err)
+	}
+	if result2.ExitReason != domain.EventTurnCompleted {
+		t.Errorf("RunTurn (turn 2): ExitReason = %q, want %q", result2.ExitReason, domain.EventTurnCompleted)
+	}
+	if result2.SessionID != session.ID {
+		t.Errorf("turn 2: TurnResult.SessionID = %q, want %q (must remain same thread)", result2.SessionID, session.ID)
+	}
+
+	events2 := collected2()
+	assertNoEventType(t, events2, domain.EventSessionStarted)
+	assertContainsEventType(t, events2, domain.EventTurnCompleted)
+
+	// Verify internal turn counter after turn 2.
+	if state.turnCount != 2 {
+		t.Errorf("state.turnCount after turn 2 = %d, want 2", state.turnCount)
+	}
+
+	// The subprocess PID must still be the same original PID.
+	state.mu.Lock()
+	pidAfterTurn2 := state.proc.Pid
+	state.mu.Unlock()
+	if pidAfterTurn2 != pidAfterStart {
+		t.Errorf("subprocess PID changed after turn 2: original=%d current=%d (persistent subprocess must survive all turns)", pidAfterStart, pidAfterTurn2)
+	}
+
+	// Thread ID must be identical across both turns.
+	if result1.SessionID != result2.SessionID {
+		t.Errorf("SessionID changed between turns: turn1=%q turn2=%q (same thread must be reused)", result1.SessionID, result2.SessionID)
+	}
+}
+
+// TestIntegration_ResumeSession verifies that StartSession with a
+// ResumeSessionID sends thread/resume and returns a session whose ID
+// matches the provided thread ID. A turn on the resumed session must
+// complete successfully.
+func TestIntegration_ResumeSession(t *testing.T) {
+	skipUnlessCodexIntegration(t)
+
+	workspace := gitInitWorkspace(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 180*time.Second)
+	defer cancel()
+
+	// Establish an original session and capture its thread ID.
+	adapter1 := mustNewAdapter(t)
+	session1, err := adapter1.StartSession(ctx, domain.StartSessionParams{
+		WorkspacePath: workspace,
+		AgentConfig:   integrationAgentConfig(),
+	})
+	if err != nil {
+		t.Fatalf("StartSession (original): %v", err)
+	}
+
+	result1, err := adapter1.RunTurn(ctx, session1, domain.RunTurnParams{
+		Prompt:  "Say exactly one word: hello",
+		OnEvent: func(_ domain.AgentEvent) {},
+	})
+	if err != nil {
+		t.Fatalf("RunTurn (original): %v", err)
+	}
+	if result1.ExitReason != domain.EventTurnCompleted {
+		t.Fatalf("original turn: ExitReason = %q, want %q", result1.ExitReason, domain.EventTurnCompleted)
+	}
+	originalThreadID := result1.SessionID
+	if originalThreadID == "" {
+		t.Fatal("original turn: TurnResult.SessionID is empty")
+	}
+
+	// Stop the original session so the thread is persisted.
+	if err := adapter1.StopSession(context.Background(), session1); err != nil {
+		t.Fatalf("StopSession (original): %v", err)
+	}
+
+	// Resume via a fresh adapter and StartSession with the captured thread ID.
+	adapter2 := mustNewAdapter(t)
+	session2, err := adapter2.StartSession(ctx, domain.StartSessionParams{
+		WorkspacePath:   workspace,
+		AgentConfig:     integrationAgentConfig(),
+		ResumeSessionID: originalThreadID,
+	})
+	if err != nil {
+		t.Fatalf("StartSession (resume): %v", err)
+	}
+	t.Cleanup(func() { _ = adapter2.StopSession(context.Background(), session2) })
+
+	// The resumed session must carry the same thread ID.
+	if session2.ID != originalThreadID {
+		t.Errorf("resumed session.ID = %q, want %q (provided ResumeSessionID)", session2.ID, originalThreadID)
+	}
+
+	// A turn on the resumed session must complete successfully.
+	result2, err := adapter2.RunTurn(ctx, session2, domain.RunTurnParams{
+		Prompt:  "Say exactly one word: world",
+		OnEvent: func(_ domain.AgentEvent) {},
+	})
+	if err != nil {
+		t.Fatalf("RunTurn (resumed): %v", err)
+	}
+	if result2.ExitReason != domain.EventTurnCompleted {
+		t.Errorf("resumed turn: ExitReason = %q, want %q", result2.ExitReason, domain.EventTurnCompleted)
+	}
+	if result2.SessionID != originalThreadID {
+		t.Errorf("resumed turn: TurnResult.SessionID = %q, want %q", result2.SessionID, originalThreadID)
 	}
 }

--- a/internal/agent/codex/integration_test.go
+++ b/internal/agent/codex/integration_test.go
@@ -8,6 +8,7 @@
 // Optional environment variables:
 //
 //	SORTIE_CODEX_COMMAND    override the default "codex app-server" binary command
+//	SORTIE_CODEX_MODEL      override the default "gpt-5.4-nano" model
 //
 // Run:
 //

--- a/internal/agent/codex/parse_test.go
+++ b/internal/agent/codex/parse_test.go
@@ -461,6 +461,62 @@ func TestBuildDynamicTools(t *testing.T) {
 	})
 }
 
+func TestNormalizeSandbox(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"workspaceWrite", "workspace-write"},
+		{"readOnly", "read-only"},
+		{"dangerFullAccess", "danger-full-access"},
+		{"externalSandbox", "external-sandbox"},
+		{"workspace-write", "workspace-write"},
+		{"read-only", "read-only"},
+		{"", ""},
+		{"custom-value", "custom-value"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			t.Parallel()
+			got := normalizeSandbox(tt.input)
+			if got != tt.want {
+				t.Errorf("normalizeSandbox(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDenormalizeSandbox(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"workspace-write", "workspaceWrite"},
+		{"read-only", "readOnly"},
+		{"danger-full-access", "dangerFullAccess"},
+		{"external-sandbox", "externalSandbox"},
+		{"workspaceWrite", "workspaceWrite"},
+		{"readOnly", "readOnly"},
+		{"", ""},
+		{"custom-value", "custom-value"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			t.Parallel()
+			got := denormalizeSandbox(tt.input)
+			if got != tt.want {
+				t.Errorf("denormalizeSandbox(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestBuildSandboxPolicy_Default(t *testing.T) {
 	t.Parallel()
 

--- a/internal/agent/codex/parse_test.go
+++ b/internal/agent/codex/parse_test.go
@@ -479,7 +479,11 @@ func TestNormalizeSandbox(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.input, func(t *testing.T) {
+		name := tt.input
+		if name == "" {
+			name = "empty"
+		}
+		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			got := normalizeSandbox(tt.input)
 			if got != tt.want {
@@ -507,7 +511,11 @@ func TestDenormalizeSandbox(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.input, func(t *testing.T) {
+		name := tt.input
+		if name == "" {
+			name = "empty"
+		}
+		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			got := denormalizeSandbox(tt.input)
 			if got != tt.want {

--- a/internal/agent/codex/protocol.go
+++ b/internal/agent/codex/protocol.go
@@ -303,9 +303,9 @@ func startThread(ctx context.Context, state *sessionState, scanCh <-chan scanRes
 		approvalPolicy = "never"
 	}
 
-	sandbox := pt.ThreadSandbox
+	sandbox := normalizeSandbox(pt.ThreadSandbox)
 	if sandbox == "" {
-		sandbox = "workspaceWrite"
+		sandbox = "workspace-write"
 	}
 
 	params := map[string]any{
@@ -425,7 +425,7 @@ func buildDynamicTools(tools []domain.AgentTool) []map[string]any {
 // (WORKFLOW.md turn_sandbox_policy) are merged on top and may
 // replace any key, including writableRoots and networkAccess.
 func buildSandboxPolicy(state *sessionState, pt passthroughConfig) map[string]any {
-	sandboxType := pt.ThreadSandbox
+	sandboxType := denormalizeSandbox(pt.ThreadSandbox)
 	if sandboxType == "" {
 		sandboxType = "workspaceWrite"
 	}
@@ -442,6 +442,43 @@ func buildSandboxPolicy(state *sessionState, pt passthroughConfig) map[string]an
 		}
 	}
 	return policy
+}
+
+// normalizeSandbox maps user-friendly camelCase sandbox values from
+// WORKFLOW.md to the kebab-case wire format expected by the app-server
+// thread/start sandbox field. Values already in kebab-case are passed
+// through unchanged.
+func normalizeSandbox(s string) string {
+	switch s {
+	case "workspaceWrite":
+		return "workspace-write"
+	case "readOnly":
+		return "read-only"
+	case "dangerFullAccess":
+		return "danger-full-access"
+	case "externalSandbox":
+		return "external-sandbox"
+	default:
+		return s
+	}
+}
+
+// denormalizeSandbox maps kebab-case sandbox values to the camelCase wire
+// format expected by the app-server turn/start sandboxPolicy.type field.
+// Values already in camelCase are passed through unchanged.
+func denormalizeSandbox(s string) string {
+	switch s {
+	case "workspace-write":
+		return "workspaceWrite"
+	case "read-only":
+		return "readOnly"
+	case "danger-full-access":
+		return "dangerFullAccess"
+	case "external-sandbox":
+		return "externalSandbox"
+	default:
+		return s
+	}
 }
 
 // readTimeout returns the read timeout duration from the agent config,

--- a/internal/agent/copilot/integration_test.go
+++ b/internal/agent/copilot/integration_test.go
@@ -36,13 +36,14 @@ func skipUnlessCopilotIntegration(t *testing.T) {
 
 // integrationConfig builds the adapter config map for integration tests.
 func integrationConfig() map[string]any {
-	cfg := map[string]any{
+	model := os.Getenv("SORTIE_COPILOT_MODEL")
+	if model == "" {
+		model = "claude-haiku-4-5"
+	}
+	return map[string]any{
 		"max_autopilot_continues": float64(5),
+		"model":                   model,
 	}
-	if model := os.Getenv("SORTIE_COPILOT_MODEL"); model != "" {
-		cfg["model"] = model
-	}
-	return cfg
 }
 
 // integrationCommand returns the Copilot CLI binary path from the


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Fix | Test

**Intent:** The Codex app-server uses two inconsistent casing conventions for sandbox values across its endpoints (`workspace-write` on `thread/start`, `workspaceWrite` on `turn/start`). This PR fixes the adapter to translate correctly, adds a full integration test suite that validates the fix against a live `codex app-server`, sets cheap default models for all three adapter integration test suites, corrects the corresponding documentation, adds the `codex.Dockerfile` example, and addresses review feedback on tests and CI.

### 🧭 Reviewer Guide

**Complexity:** Medium

#### Entry Point

`internal/agent/codex/protocol.go` — the bug fix lives here: `normalizeSandbox` translates camelCase WORKFLOW config values to the kebab-case wire format required by `thread/start.sandbox`, and `denormalizeSandbox` does the reverse for `turn/start.sandboxPolicy.type`.

#### Sensitive Areas

- `internal/agent/codex/protocol.go`: Wire format translation between two incompatible casing conventions in the same app-server binary. Any change here must keep `normalizeSandbox` and `denormalizeSandbox` as inverse operations for the four known sandbox modes.
- `internal/agent/codex/integration_test.go`: Six integration tests against a real `codex app-server` subprocess. The `TestIntegration_RunTurn_StopDuringTurn` test calls `StopSession` mid-turn to verify the adapter unblocks cleanly — ensure the 400ms sleep is not made shorter, as the model responds fast.
- `examples/docker/codex.Dockerfile`: Downloads the Codex binary from GitHub releases. Arch mapping (`amd64→x86_64-unknown-linux-musl`, `arm64→aarch64-unknown-linux-musl`) must stay in sync with the actual asset names published to `github.com/openai/codex/releases`.
- `.github/workflows/release.yml`: New `test-integration-codex` CI job. Requires `CODEX_API_KEY` secret in the repo.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes. WORKFLOW.md operators continue to write camelCase sandbox values (`workspaceWrite`) — the adapter now translates them correctly instead of sending them verbatim.
- **Migrations/State:** No migrations or state changes.