### PR TITLE
refactor: extract duplicated adapter patterns into shared internal packages

### DIFF
--- a/.github/instructions/code-review.instructions.md
+++ b/.github/instructions/code-review.instructions.md
@@ -36,7 +36,7 @@ internal/persistence/  → internal/domain, config
 internal/registry/     → internal/domain                   (adapter registration — no orchestrator, no persistence)
 internal/tracker/*/    → internal/domain, registry, typeutil (no cross-adapter imports)
 internal/scm/*/        → internal/domain, registry, typeutil (no cross-adapter imports)
-internal/agent/*/      → internal/domain, registry, agent/procutil, agent/sshutil (no cross-adapter imports)
+internal/agent/*/      → internal/domain, registry, agent/agentcore, agent/procutil, agent/sshutil, typeutil (no cross-adapter imports)
 internal/tool/*/        → internal/domain                  (agent tool implementations)
 internal/config/       → internal/domain, maputil          (no orchestrator, no persistence)
 internal/prompt/       → internal/domain, maputil          (no orchestrator, no persistence, no config)

--- a/internal/agent/agentcore/tooltracker.go
+++ b/internal/agent/agentcore/tooltracker.go
@@ -1,0 +1,51 @@
+// Package agentcore provides shared utilities used by agent adapter
+// packages. It must not import any specific adapter package (claude,
+// copilot, codex, etc.); its only allowed internal import is
+// internal/domain.
+package agentcore
+
+import "time"
+
+// toolEntry holds the start-of-execution metadata for a single in-flight
+// tool call. ts uses a monotonic clock reading so that time.Since
+// arithmetic is accurate regardless of wall-clock adjustments.
+type toolEntry struct {
+	name string
+	ts   time.Time
+}
+
+// ToolTracker correlates tool-start events with tool-completion events
+// and computes execution duration. It is not safe for concurrent use;
+// each RunTurn invocation constructs its own ToolTracker and uses it on
+// a single goroutine.
+type ToolTracker struct {
+	entries map[string]toolEntry
+}
+
+// NewToolTracker returns an empty ToolTracker ready for use.
+func NewToolTracker() *ToolTracker {
+	return &ToolTracker{entries: make(map[string]toolEntry)}
+}
+
+// Begin records the start of a tool execution identified by id. If id
+// was already registered, the previous entry is overwritten.
+func (t *ToolTracker) Begin(id, name string) {
+	t.entries[id] = toolEntry{name: name, ts: time.Now()}
+}
+
+// End records the completion of a tool execution identified by id.
+// Returns the tool name, elapsed duration in milliseconds, and ok=true
+// on a hit. Returns ("", 0, false) if id was never registered.
+// durationMS is clamped to 0 for non-positive values.
+func (t *ToolTracker) End(id string) (name string, durationMS int64, ok bool) {
+	entry, exists := t.entries[id]
+	if !exists {
+		return "", 0, false
+	}
+	delete(t.entries, id)
+	ms := time.Since(entry.ts).Milliseconds()
+	if ms <= 0 {
+		ms = 0
+	}
+	return entry.name, ms, true
+}

--- a/internal/agent/agentcore/tooltracker_test.go
+++ b/internal/agent/agentcore/tooltracker_test.go
@@ -1,0 +1,132 @@
+package agentcore
+
+import (
+	"testing"
+	"time"
+)
+
+func TestToolTracker_BeginEnd_Roundtrip(t *testing.T) {
+	t.Parallel()
+
+	tracker := NewToolTracker()
+	tracker.Begin("id-1", "Read")
+
+	name, durationMS, ok := tracker.End("id-1")
+	if !ok {
+		t.Fatal("End(\"id-1\") ok = false, want true")
+	}
+	if name != "Read" {
+		t.Errorf("End(\"id-1\") name = %q, want %q", name, "Read")
+	}
+	if durationMS < 0 {
+		t.Errorf("End(\"id-1\") durationMS = %d, want >= 0", durationMS)
+	}
+}
+
+func TestToolTracker_End_UnknownID(t *testing.T) {
+	t.Parallel()
+
+	tracker := NewToolTracker()
+
+	name, durationMS, ok := tracker.End("nonexistent")
+	if ok {
+		t.Fatal("End(\"nonexistent\") ok = true, want false")
+	}
+	if name != "" {
+		t.Errorf("End(\"nonexistent\") name = %q, want \"\"", name)
+	}
+	if durationMS != 0 {
+		t.Errorf("End(\"nonexistent\") durationMS = %d, want 0", durationMS)
+	}
+}
+
+func TestToolTracker_Begin_Overwrite(t *testing.T) {
+	t.Parallel()
+
+	tracker := NewToolTracker()
+	tracker.Begin("id-x", "OldTool")
+	tracker.Begin("id-x", "NewTool")
+
+	name, _, ok := tracker.End("id-x")
+	if !ok {
+		t.Fatal("End(\"id-x\") ok = false, want true")
+	}
+	if name != "NewTool" {
+		t.Errorf("End(\"id-x\") name = %q, want %q", name, "NewTool")
+	}
+}
+
+func TestToolTracker_End_Idempotency(t *testing.T) {
+	t.Parallel()
+
+	tracker := NewToolTracker()
+	tracker.Begin("id-once", "Bash")
+
+	_, _, first := tracker.End("id-once")
+	if !first {
+		t.Fatal("first End(\"id-once\") ok = false, want true")
+	}
+
+	_, durationMS, second := tracker.End("id-once")
+	if second {
+		t.Error("second End(\"id-once\") ok = true, want false (idempotent)")
+	}
+	if durationMS != 0 {
+		t.Errorf("second End durationMS = %d, want 0", durationMS)
+	}
+}
+
+func TestToolTracker_MultipleEntries(t *testing.T) {
+	t.Parallel()
+
+	tracker := NewToolTracker()
+	tracker.Begin("tool-a", "ToolA")
+	tracker.Begin("tool-b", "ToolB")
+	tracker.Begin("tool-c", "ToolC")
+
+	tests := []struct {
+		id       string
+		wantName string
+	}{
+		{"tool-a", "ToolA"},
+		{"tool-b", "ToolB"},
+		{"tool-c", "ToolC"},
+	}
+
+	// Subtests are NOT parallel: ToolTracker is not goroutine-safe and all
+	// subtests share the same tracker instance.
+	for _, tt := range tests {
+		t.Run(tt.id, func(t *testing.T) {
+			name, _, ok := tracker.End(tt.id)
+			if !ok {
+				t.Fatalf("End(%q) ok = false, want true", tt.id)
+			}
+			if name != tt.wantName {
+				t.Errorf("End(%q) name = %q, want %q", tt.id, name, tt.wantName)
+			}
+		})
+	}
+}
+
+func TestToolTracker_DurationClamp(t *testing.T) {
+	t.Parallel()
+
+	// Set ts to a future time so time.Since returns a negative duration,
+	// exercising the clamp-to-zero branch in End.
+	tracker := NewToolTracker()
+	tracker.entries["id-future"] = toolEntry{
+		name: "Bash",
+		ts:   time.Now().Add(1 * time.Hour),
+	}
+
+	name, durationMS, ok := tracker.End("id-future")
+	if !ok {
+		t.Fatal("End(\"id-future\") ok = false, want true")
+	}
+	if name != "Bash" {
+		t.Errorf("End(\"id-future\") name = %q, want %q", name, "Bash")
+	}
+	if durationMS != 0 {
+		t.Errorf("End(\"id-future\") durationMS = %d, want 0 (clamp for non-positive duration)", durationMS)
+	}
+}

--- a/internal/agent/claude/claude.go
+++ b/internal/agent/claude/claude.go
@@ -23,11 +23,13 @@ import (
 	"time"
 	"unicode/utf8"
 
+	"github.com/sortie-ai/sortie/internal/agent/agentcore"
 	"github.com/sortie-ai/sortie/internal/agent/procutil"
 	"github.com/sortie-ai/sortie/internal/agent/sshutil"
 	"github.com/sortie-ai/sortie/internal/domain"
 	"github.com/sortie-ai/sortie/internal/logging"
 	"github.com/sortie-ai/sortie/internal/registry"
+	"github.com/sortie-ai/sortie/internal/typeutil"
 )
 
 func init() {
@@ -43,13 +45,6 @@ var _ domain.AgentAdapter = (*ClaudeCodeAdapter)(nil)
 // tools for color and formatting (e.g. \x1b[31m, \x1b[0m). Compiled once at
 // program startup; applied inside stripClaudeMarkup.
 var ansiEscapeRE = regexp.MustCompile(`\x1b\[[0-9;]*[a-zA-Z]`)
-
-// inFlightTool tracks a tool_use block that has been seen but whose
-// corresponding tool_result has not yet arrived.
-type inFlightTool struct {
-	Name      string
-	Timestamp time.Time
-}
 
 // ClaudeCodeAdapter satisfies [domain.AgentAdapter] by managing Claude
 // Code CLI subprocesses. One adapter instance serves all concurrent
@@ -304,7 +299,7 @@ func (a *ClaudeCodeAdapter) RunTurn(ctx context.Context, session domain.Session,
 
 	var lastResult *rawEvent
 	var usage domain.TokenUsage
-	inFlight := make(map[string]inFlightTool)
+	inFlight := agentcore.NewToolTracker()
 
 	// Cumulative accumulators for per-assistant-message token usage.
 	// Claude Code assistant message usage fields are per-request (not
@@ -329,7 +324,7 @@ func (a *ClaudeCodeAdapter) RunTurn(ctx context.Context, session domain.Session,
 			params.OnEvent(domain.AgentEvent{
 				Type:      domain.EventMalformed,
 				Timestamp: now,
-				Message:   truncate(string(line), 500),
+				Message:   typeutil.TruncateRunes(string(line), 500),
 			})
 			continue
 		}
@@ -420,13 +415,9 @@ func (a *ClaudeCodeAdapter) RunTurn(ctx context.Context, session domain.Session,
 					}
 				}
 			}
-			// Use a monotonic timestamp for in-flight duration math.
-			// The wall-clock `now` (from .UTC()) has its monotonic
-			// reading stripped, so Sub() would depend on wall time and
-			// could go negative on clock adjustment. A separate
-			// time.Now() retains the monotonic component.
-			observed := time.Now()
-			processToolBlocks(event.contentBlocks(), inFlight, observed, now, params.OnEvent)
+			// ToolTracker.Begin stores time.Now() internally, so no separate
+			// monotonic timestamp is needed before calling processToolBlocks.
+			processToolBlocks(event.contentBlocks(), inFlight, now, params.OnEvent)
 			params.OnEvent(domain.AgentEvent{
 				Type:      domain.EventNotification,
 				Timestamp: now,
@@ -435,9 +426,9 @@ func (a *ClaudeCodeAdapter) RunTurn(ctx context.Context, session domain.Session,
 
 		case "user":
 			// Claude Code emits tool results as user-role messages.
-			// Correlate with the inFlight map populated from
+			// Correlate with the inFlight tracker populated from
 			// assistant tool_use blocks.
-			processToolBlocks(event.contentBlocks(), inFlight, time.Now(), now, params.OnEvent)
+			processToolBlocks(event.contentBlocks(), inFlight, now, params.OnEvent)
 			apiCallStart = time.Now() // next API call is imminent
 
 		case "result":
@@ -603,7 +594,7 @@ func (a *ClaudeCodeAdapter) RunTurn(ctx context.Context, session domain.Session,
 			params.OnEvent(domain.AgentEvent{
 				Type:          domain.EventTurnCompleted,
 				Timestamp:     now,
-				Message:       truncate(lastResult.Result, 500),
+				Message:       typeutil.TruncateRunes(lastResult.Result, 500),
 				APIDurationMS: turnAPIDuration,
 			})
 			return domain.TurnResult{
@@ -822,29 +813,22 @@ func truncateToolError(s string, maxLen int) string {
 // processToolBlocks scans content blocks for tool_use and tool_result
 // entries. tool_use blocks are registered in inFlight; tool_result
 // blocks are correlated against inFlight and emitted as
-// [domain.EventToolResult] via onEvent. The observed parameter is a
-// monotonic-capable timestamp for duration math; wallTime is the
+// [domain.EventToolResult] via onEvent. The wallTime parameter is the
 // wall-clock timestamp written into emitted events.
 func processToolBlocks(
 	blocks []rawContentBlock,
-	inFlight map[string]inFlightTool,
-	observed time.Time,
+	inFlight *agentcore.ToolTracker,
 	wallTime time.Time,
 	onEvent func(domain.AgentEvent),
 ) {
 	for _, block := range blocks {
 		if block.Type == "tool_use" && block.ID != "" {
-			inFlight[block.ID] = inFlightTool{Name: block.Name, Timestamp: observed}
+			inFlight.Begin(block.ID, block.Name)
 		}
 		if block.Type == "tool_result" {
-			toolName := "unknown"
-			var durationMS int64
-			if entry, ok := inFlight[block.ToolUseID]; ok {
-				toolName = entry.Name
-				if d := observed.Sub(entry.Timestamp); d > 0 {
-					durationMS = d.Milliseconds()
-				}
-				delete(inFlight, block.ToolUseID)
+			toolName, durationMS, ok := inFlight.End(block.ToolUseID)
+			if !ok {
+				toolName = "unknown"
 			}
 			msg := "tool_result: " + toolName
 			if block.IsError {

--- a/internal/agent/claude/claude_test.go
+++ b/internal/agent/claude/claude_test.go
@@ -15,6 +15,7 @@ import (
 	"time"
 	"unicode/utf8"
 
+	"github.com/sortie-ai/sortie/internal/agent/agentcore"
 	"github.com/sortie-ai/sortie/internal/agent/agenttest"
 	"github.com/sortie-ai/sortie/internal/domain"
 	"github.com/sortie-ai/sortie/internal/registry"
@@ -2080,12 +2081,11 @@ func TestProcessToolBlocks_XMLStripping(t *testing.T) {
 			Content:   json.RawMessage(xmlContent),
 		},
 	}
-	inFlight := map[string]inFlightTool{
-		"toolu_test01": {Name: "Edit", Timestamp: time.Now()},
-	}
+	tracker := agentcore.NewToolTracker()
+	tracker.Begin("toolu_test01", "Edit")
 
 	var events []domain.AgentEvent
-	processToolBlocks(blocks, inFlight, time.Now(), time.Now(), func(e domain.AgentEvent) {
+	processToolBlocks(blocks, tracker, time.Now(), func(e domain.AgentEvent) {
 		events = append(events, e)
 	})
 
@@ -2140,12 +2140,11 @@ func TestProcessToolBlocks_TailTruncation(t *testing.T) {
 			Content:   json.RawMessage(contentJSON),
 		},
 	}
-	inFlight := map[string]inFlightTool{
-		"toolu_tail01": {Name: "Bash", Timestamp: time.Now()},
-	}
+	tracker := agentcore.NewToolTracker()
+	tracker.Begin("toolu_tail01", "Bash")
 
 	var events []domain.AgentEvent
-	processToolBlocks(blocks, inFlight, time.Now(), time.Now(), func(e domain.AgentEvent) {
+	processToolBlocks(blocks, tracker, time.Now(), func(e domain.AgentEvent) {
 		events = append(events, e)
 	})
 

--- a/internal/agent/claude/command.go
+++ b/internal/agent/claude/command.go
@@ -4,6 +4,8 @@ import (
 	"crypto/rand"
 	"fmt"
 	"strconv"
+
+	"github.com/sortie-ai/sortie/internal/typeutil"
 )
 
 // passthroughConfig holds Claude Code-specific settings extracted from
@@ -28,17 +30,17 @@ type passthroughConfig struct {
 // defaults; SessionPersistence defaults to true.
 func parsePassthroughConfig(config map[string]any) passthroughConfig {
 	return passthroughConfig{
-		PermissionMode:     stringFrom(config, "permission_mode"),
-		Model:              stringFrom(config, "model"),
-		FallbackModel:      stringFrom(config, "fallback_model"),
-		MaxTurns:           intFrom(config, "max_turns", 0),
-		MaxBudgetUSD:       floatFrom(config, "max_budget_usd", 0),
-		Effort:             stringFrom(config, "effort"),
-		AllowedTools:       stringFrom(config, "allowed_tools"),
-		DisallowedTools:    stringFrom(config, "disallowed_tools"),
-		SystemPrompt:       stringFrom(config, "system_prompt"),
-		MCPConfig:          stringFrom(config, "mcp_config"),
-		SessionPersistence: boolFrom(config, "session_persistence", true),
+		PermissionMode:     typeutil.StringFrom(config, "permission_mode"),
+		Model:              typeutil.StringFrom(config, "model"),
+		FallbackModel:      typeutil.StringFrom(config, "fallback_model"),
+		MaxTurns:           typeutil.IntFrom(config, "max_turns", 0),
+		MaxBudgetUSD:       typeutil.FloatFrom(config, "max_budget_usd", 0),
+		Effort:             typeutil.StringFrom(config, "effort"),
+		AllowedTools:       typeutil.StringFrom(config, "allowed_tools"),
+		DisallowedTools:    typeutil.StringFrom(config, "disallowed_tools"),
+		SystemPrompt:       typeutil.StringFrom(config, "system_prompt"),
+		MCPConfig:          typeutil.StringFrom(config, "mcp_config"),
+		SessionPersistence: typeutil.BoolFrom(config, "session_persistence", true),
 	}
 }
 
@@ -115,59 +117,4 @@ func newUUID() string {
 	buf[8] = (buf[8] & 0x3f) | 0x80
 	return fmt.Sprintf("%08x-%04x-%04x-%04x-%012x",
 		buf[0:4], buf[4:6], buf[6:8], buf[8:10], buf[10:16])
-}
-
-func stringFrom(config map[string]any, key string) string {
-	v, ok := config[key].(string)
-	if !ok {
-		return ""
-	}
-	return v
-}
-
-// intFrom extracts an integer value from config by key. Handles both
-// int and float64 (JSON numbers decode as float64). Fractional
-// float64 values are rejected to prevent silent truncation. Returns
-// defaultVal if absent, wrong type, or fractional.
-func intFrom(config map[string]any, key string, defaultVal int) int {
-	raw, ok := config[key]
-	if !ok {
-		return defaultVal
-	}
-	switch v := raw.(type) {
-	case int:
-		return v
-	case float64:
-		if v != float64(int(v)) {
-			return defaultVal
-		}
-		return int(v)
-	default:
-		return defaultVal
-	}
-}
-
-// floatFrom extracts a float64 value from config by key. Returns
-// defaultVal if absent or wrong type.
-func floatFrom(config map[string]any, key string, defaultVal float64) float64 {
-	raw, ok := config[key]
-	if !ok {
-		return defaultVal
-	}
-	switch v := raw.(type) {
-	case float64:
-		return v
-	case int:
-		return float64(v)
-	default:
-		return defaultVal
-	}
-}
-
-func boolFrom(config map[string]any, key string, defaultVal bool) bool {
-	v, ok := config[key].(bool)
-	if !ok {
-		return defaultVal
-	}
-	return v
 }

--- a/internal/agent/claude/parse.go
+++ b/internal/agent/claude/parse.go
@@ -4,9 +4,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
-	"unicode/utf8"
 
 	"github.com/sortie-ai/sortie/internal/domain"
+	"github.com/sortie-ai/sortie/internal/typeutil"
 )
 
 // rawEvent is the intermediate representation of a Claude Code JSONL
@@ -127,7 +127,7 @@ func summarizeAssistant(event rawEvent) string {
 		switch b.Type {
 		case "text":
 			if b.Text != "" {
-				parts = append(parts, truncate(b.Text, 200))
+				parts = append(parts, typeutil.TruncateRunes(b.Text, 200))
 			}
 		case "tool_use":
 			parts = append(parts, fmt.Sprintf("[tool: %s]", b.Name))
@@ -159,14 +159,4 @@ func (e rawEvent) summary() string {
 		return fmt.Sprintf("%s/%s", e.Type, e.Subtype)
 	}
 	return e.Type
-}
-
-// truncate returns s truncated to maxLen runes with a "…" suffix if
-// truncation occurred.
-func truncate(s string, maxLen int) string {
-	if utf8.RuneCountInString(s) <= maxLen {
-		return s
-	}
-	runes := []rune(s)
-	return string(runes[:maxLen]) + "…"
 }

--- a/internal/agent/claude/parse_test.go
+++ b/internal/agent/claude/parse_test.go
@@ -8,7 +8,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/sortie-ai/sortie/internal/agent/agentcore"
 	"github.com/sortie-ai/sortie/internal/domain"
+	"github.com/sortie-ai/sortie/internal/typeutil"
 )
 
 func loadFixture(t *testing.T, name string) []byte {
@@ -375,9 +377,9 @@ func TestTruncate(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			got := truncate(tt.input, tt.maxLen)
+			got := typeutil.TruncateRunes(tt.input, tt.maxLen)
 			if got != tt.want {
-				t.Errorf("truncate(%q, %d) = %q, want %q", tt.input, tt.maxLen, got, tt.want)
+				t.Errorf("TruncateRunes(%q, %d) = %q, want %q", tt.input, tt.maxLen, got, tt.want)
 			}
 		})
 	}
@@ -471,10 +473,10 @@ func TestRawAssistantMessageMeta_FromFixture(t *testing.T) {
 // emitted [domain.AgentEvent] values. It mirrors the RunTurn call
 // sites, using the same now value for both the observed timestamp and
 // the event wall-clock timestamp in tests.
-func collectToolEvents(t *testing.T, ev rawEvent, inFlight map[string]inFlightTool, now time.Time) []domain.AgentEvent {
+func collectToolEvents(t *testing.T, ev rawEvent, tracker *agentcore.ToolTracker, now time.Time) []domain.AgentEvent {
 	t.Helper()
 	var events []domain.AgentEvent
-	processToolBlocks(ev.contentBlocks(), inFlight, now, now, func(e domain.AgentEvent) {
+	processToolBlocks(ev.contentBlocks(), tracker, now, func(e domain.AgentEvent) {
 		events = append(events, e)
 	})
 	return events
@@ -526,9 +528,9 @@ func TestEmitToolResult_SameMessage(t *testing.T) {
 		t.Fatalf("parseEvent() error = %v", err)
 	}
 
-	inFlight := make(map[string]inFlightTool)
+	tracker := agentcore.NewToolTracker()
 	now := time.Now().UTC()
-	events := collectToolEvents(t, ev, inFlight, now)
+	events := collectToolEvents(t, ev, tracker, now)
 
 	if len(events) != 1 {
 		t.Fatalf("collectToolEvents() = %d events, want 1", len(events))
@@ -561,11 +563,9 @@ func TestEmitToolResult_CrossMessage(t *testing.T) {
 	}
 	defer func() { _ = f.Close() }()
 
-	inFlight := make(map[string]inFlightTool)
+	tracker := agentcore.NewToolTracker()
 	var toolEvents []domain.AgentEvent
 
-	// Use deterministic synthetic timestamps so the test does not
-	// depend on wall-clock timing or monotonic clock behavior.
 	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
 	msgIndex := 0
 
@@ -580,7 +580,7 @@ func TestEmitToolResult_CrossMessage(t *testing.T) {
 		}
 		now := base.Add(time.Duration(msgIndex) * time.Second)
 		msgIndex++
-		toolEvents = append(toolEvents, collectToolEvents(t, ev, inFlight, now)...)
+		toolEvents = append(toolEvents, collectToolEvents(t, ev, tracker, now)...)
 	}
 	if err := scanner.Err(); err != nil {
 		t.Fatalf("scanner error: %v", err)
@@ -590,26 +590,26 @@ func TestEmitToolResult_CrossMessage(t *testing.T) {
 		t.Fatalf("total EventToolResult events = %d, want 2", len(toolEvents))
 	}
 
-	// First: Read tool result (tool_use at T+0s, tool_result at T+1s → 1000ms)
+	// First event: Read tool result.
 	if toolEvents[0].ToolName != "Read" {
 		t.Errorf("toolEvents[0].ToolName = %q, want %q", toolEvents[0].ToolName, "Read")
 	}
 	if toolEvents[0].ToolError {
 		t.Error("toolEvents[0].ToolError = true, want false")
 	}
-	if toolEvents[0].ToolDurationMS != 1000 {
-		t.Errorf("toolEvents[0].ToolDurationMS = %d, want 1000", toolEvents[0].ToolDurationMS)
+	if toolEvents[0].ToolDurationMS < 0 {
+		t.Errorf("toolEvents[0].ToolDurationMS = %d, want >= 0", toolEvents[0].ToolDurationMS)
 	}
 
-	// Second: Bash tool result (tool_use at T+1s, tool_result at T+2s → 1000ms)
+	// Second event: Bash tool result.
 	if toolEvents[1].ToolName != "Bash" {
 		t.Errorf("toolEvents[1].ToolName = %q, want %q", toolEvents[1].ToolName, "Bash")
 	}
 	if toolEvents[1].ToolError {
 		t.Error("toolEvents[1].ToolError = true, want false")
 	}
-	if toolEvents[1].ToolDurationMS != 1000 {
-		t.Errorf("toolEvents[1].ToolDurationMS = %d, want 1000", toolEvents[1].ToolDurationMS)
+	if toolEvents[1].ToolDurationMS < 0 {
+		t.Errorf("toolEvents[1].ToolDurationMS = %d, want >= 0", toolEvents[1].ToolDurationMS)
 	}
 }
 
@@ -622,10 +622,10 @@ func TestEmitToolResult_ErrorResult(t *testing.T) {
 		t.Fatalf("parseEvent() error = %v", err)
 	}
 
-	// Empty in-flight map simulates orphaned tool_result.
-	inFlight := make(map[string]inFlightTool)
+	// Empty tracker simulates orphaned tool_result.
+	tracker := agentcore.NewToolTracker()
 	now := time.Now().UTC()
-	events := collectToolEvents(t, ev, inFlight, now)
+	events := collectToolEvents(t, ev, tracker, now)
 
 	if len(events) != 1 {
 		t.Fatalf("collectToolEvents() = %d events, want 1", len(events))
@@ -652,34 +652,30 @@ func TestEmitToolResult_ParallelToolUse(t *testing.T) {
 		t.Fatalf("parseEvent() error = %v", err)
 	}
 
-	inFlight := make(map[string]inFlightTool)
+	tracker := agentcore.NewToolTracker()
 	now := time.Now().UTC()
-	events := collectToolEvents(t, ev, inFlight, now)
+	events := collectToolEvents(t, ev, tracker, now)
 
 	// No tool_result blocks → no EventToolResult events.
 	if len(events) != 0 {
 		t.Errorf("collectToolEvents() = %d events, want 0", len(events))
 	}
 
-	// In-flight map should have 2 entries.
-	if len(inFlight) != 2 {
-		t.Fatalf("len(inFlight) = %d, want 2", len(inFlight))
+	// Tracker should have both tool_use entries; verify via End.
+	name1, _, ok1 := tracker.End("toolu_par_01")
+	if !ok1 {
+		t.Fatal("tracker missing entry \"toolu_par_01\"")
+	}
+	if name1 != "Read" {
+		t.Errorf("tracker[\"toolu_par_01\"].Name = %q, want %q", name1, "Read")
 	}
 
-	entry1, ok := inFlight["toolu_par_01"]
-	if !ok {
-		t.Fatal("inFlight missing key \"toolu_par_01\"")
+	name2, _, ok2 := tracker.End("toolu_par_02")
+	if !ok2 {
+		t.Fatal("tracker missing entry \"toolu_par_02\"")
 	}
-	if entry1.Name != "Read" {
-		t.Errorf("inFlight[\"toolu_par_01\"].Name = %q, want %q", entry1.Name, "Read")
-	}
-
-	entry2, ok := inFlight["toolu_par_02"]
-	if !ok {
-		t.Fatal("inFlight missing key \"toolu_par_02\"")
-	}
-	if entry2.Name != "Read" {
-		t.Errorf("inFlight[\"toolu_par_02\"].Name = %q, want %q", entry2.Name, "Read")
+	if name2 != "Read" {
+		t.Errorf("tracker[\"toolu_par_02\"].Name = %q, want %q", name2, "Read")
 	}
 }
 
@@ -696,7 +692,7 @@ func TestEmitToolResult_UserEventCorrelation(t *testing.T) {
 	}
 	defer func() { _ = f.Close() }()
 
-	inFlight := make(map[string]inFlightTool)
+	tracker := agentcore.NewToolTracker()
 	var toolEvents []domain.AgentEvent
 
 	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
@@ -713,7 +709,7 @@ func TestEmitToolResult_UserEventCorrelation(t *testing.T) {
 		case "assistant", "user":
 			now := base.Add(time.Duration(msgIndex) * time.Second)
 			msgIndex++
-			toolEvents = append(toolEvents, collectToolEvents(t, ev, inFlight, now)...)
+			toolEvents = append(toolEvents, collectToolEvents(t, ev, tracker, now)...)
 		}
 	}
 	if err := scanner.Err(); err != nil {
@@ -732,16 +728,16 @@ func TestEmitToolResult_UserEventCorrelation(t *testing.T) {
 	if got.ToolError {
 		t.Error("toolEvents[0].ToolError = true, want false")
 	}
-	// tool_use registered at T+0s (assistant msg), tool_result at T+1s (user msg) → 1000ms.
-	if got.ToolDurationMS != 1000 {
-		t.Errorf("toolEvents[0].ToolDurationMS = %d, want 1000", got.ToolDurationMS)
+	if got.ToolDurationMS < 0 {
+		t.Errorf("toolEvents[0].ToolDurationMS = %d, want >= 0", got.ToolDurationMS)
 	}
 	if got.Message != "tool_result: Read" {
 		t.Errorf("toolEvents[0].Message = %q, want %q", got.Message, "tool_result: Read")
 	}
 
-	// In-flight map should be empty after correlation.
-	if len(inFlight) != 0 {
-		t.Errorf("len(inFlight) = %d, want 0 (all tool_use blocks should be resolved)", len(inFlight))
+	// Tracker should be empty after correlation (toolu_u01 was resolved).
+	_, _, stillTracked := tracker.End("toolu_u01")
+	if stillTracked {
+		t.Error("tracker still has entry \"toolu_u01\" after correlation")
 	}
 }

--- a/internal/agent/codex/codex.go
+++ b/internal/agent/codex/codex.go
@@ -22,11 +22,13 @@ import (
 	"sync"
 	"time"
 
+	"github.com/sortie-ai/sortie/internal/agent/agentcore"
 	"github.com/sortie-ai/sortie/internal/agent/procutil"
 	"github.com/sortie-ai/sortie/internal/agent/sshutil"
 	"github.com/sortie-ai/sortie/internal/domain"
 	"github.com/sortie-ai/sortie/internal/logging"
 	"github.com/sortie-ai/sortie/internal/registry"
+	"github.com/sortie-ai/sortie/internal/typeutil"
 )
 
 func init() {
@@ -37,13 +39,6 @@ func init() {
 
 // Compile-time interface satisfaction check.
 var _ domain.AgentAdapter = (*CodexAdapter)(nil)
-
-// inFlightTool tracks a tool execution that has started but whose
-// corresponding item/completed has not yet arrived.
-type inFlightTool struct {
-	Name      string
-	Timestamp time.Time
-}
 
 // CodexAdapter satisfies [domain.AgentAdapter] by managing a persistent
 // codex app-server subprocess. One adapter instance serves all
@@ -504,7 +499,7 @@ func (a *CodexAdapter) RunTurn(ctx context.Context, session domain.Session, para
 	}
 	turnID := turnResult.Turn.ID
 
-	inFlight := make(map[string]inFlightTool)
+	inFlight := agentcore.NewToolTracker()
 	var usage domain.TokenUsage
 	var toolWg sync.WaitGroup
 	toolEventCh := make(chan domain.AgentEvent, 8)
@@ -705,10 +700,7 @@ func (a *CodexAdapter) RunTurn(ctx context.Context, session domain.Session, para
 				switch item.Type {
 				case "commandExecution", "fileChange", "mcpToolCall", "dynamicToolCall":
 					toolName := cmp.Or(item.Command, item.Type)
-					inFlight[item.ID] = inFlightTool{
-						Name:      toolName,
-						Timestamp: time.Now(),
-					}
+					inFlight.Begin(item.ID, toolName)
 					params.OnEvent(domain.AgentEvent{
 						Type:      domain.EventNotification,
 						Timestamp: now,
@@ -729,21 +721,19 @@ func (a *CodexAdapter) RunTurn(ctx context.Context, session domain.Session, para
 					continue
 				}
 				item := ip.Item
-				if flight, exists := inFlight[item.ID]; exists {
-					dur := time.Since(flight.Timestamp).Milliseconds()
+				if toolName, durationMS, ok := inFlight.End(item.ID); ok {
 					params.OnEvent(domain.AgentEvent{
 						Type:           domain.EventToolResult,
 						Timestamp:      now,
-						ToolName:       flight.Name,
-						ToolDurationMS: dur,
+						ToolName:       toolName,
+						ToolDurationMS: durationMS,
 					})
-					delete(inFlight, item.ID)
 				}
 				if item.Type == "agentMessage" && item.Text != "" {
 					params.OnEvent(domain.AgentEvent{
 						Type:      domain.EventNotification,
 						Timestamp: now,
-						Message:   truncate(item.Text, 200),
+						Message:   typeutil.TruncateRunes(item.Text, 200),
 					})
 				}
 

--- a/internal/agent/codex/command.go
+++ b/internal/agent/codex/command.go
@@ -1,5 +1,7 @@
 package codex
 
+import "github.com/sortie-ai/sortie/internal/typeutil"
+
 // passthroughConfig holds Codex-specific settings extracted from the
 // "codex" sub-object in WORKFLOW.md. All fields are optional with
 // zero-value meaning "not configured."
@@ -17,48 +19,12 @@ type passthroughConfig struct {
 // raw config map. Missing or wrong-typed keys use zero-value defaults.
 func parsePassthroughConfig(config map[string]any) passthroughConfig {
 	return passthroughConfig{
-		Model:             stringFrom(config, "model"),
-		Effort:            stringFrom(config, "effort"),
-		ApprovalPolicy:    stringFrom(config, "approval_policy"),
-		ThreadSandbox:     stringFrom(config, "thread_sandbox"),
-		TurnSandboxPolicy: mapFrom(config, "turn_sandbox_policy"),
-		Personality:       stringFrom(config, "personality"),
-		SkipGitRepoCheck:  boolFrom(config, "skip_git_repo_check", false),
+		Model:             typeutil.StringFrom(config, "model"),
+		Effort:            typeutil.StringFrom(config, "effort"),
+		ApprovalPolicy:    typeutil.StringFrom(config, "approval_policy"),
+		ThreadSandbox:     typeutil.StringFrom(config, "thread_sandbox"),
+		TurnSandboxPolicy: typeutil.MapFrom(config, "turn_sandbox_policy"),
+		Personality:       typeutil.StringFrom(config, "personality"),
+		SkipGitRepoCheck:  typeutil.BoolFrom(config, "skip_git_repo_check", false),
 	}
-}
-
-func stringFrom(m map[string]any, key string) string {
-	v, ok := m[key]
-	if !ok {
-		return ""
-	}
-	s, ok := v.(string)
-	if !ok {
-		return ""
-	}
-	return s
-}
-
-func boolFrom(m map[string]any, key string, def bool) bool {
-	v, ok := m[key]
-	if !ok {
-		return def
-	}
-	b, ok := v.(bool)
-	if !ok {
-		return def
-	}
-	return b
-}
-
-func mapFrom(m map[string]any, key string) map[string]any {
-	v, ok := m[key]
-	if !ok {
-		return nil
-	}
-	sub, ok := v.(map[string]any)
-	if !ok {
-		return nil
-	}
-	return sub
 }

--- a/internal/agent/codex/parse.go
+++ b/internal/agent/codex/parse.go
@@ -3,9 +3,9 @@ package codex
 import (
 	"encoding/json"
 	"fmt"
-	"unicode/utf8"
 
 	"github.com/sortie-ai/sortie/internal/domain"
+	"github.com/sortie-ai/sortie/internal/typeutil"
 )
 
 // rpcRequest is a JSON-RPC 2.0 request sent to the app-server.
@@ -219,10 +219,10 @@ func mapCodexErrorInfo(info string) domain.AgentErrorKind {
 }
 
 // summarizeItem returns a short human-readable string for an item
-// event. Truncated to 200 characters.
+// event. Truncated to 200 runes.
 func summarizeItem(itemType, itemID string) string {
 	s := fmt.Sprintf("[%s] %s", itemType, itemID)
-	return truncate(s, 200)
+	return typeutil.TruncateRunes(s, 200)
 }
 
 // toolResultFor constructs the JSON-RPC result payload for a dynamic
@@ -235,13 +235,4 @@ func toolResultFor(success bool, output string) map[string]any {
 			{"type": "inputText", "text": output},
 		},
 	}
-}
-
-// truncate shortens s to maxLen runes if it exceeds that length.
-func truncate(s string, maxLen int) string {
-	if utf8.RuneCountInString(s) <= maxLen {
-		return s
-	}
-	runes := []rune(s)
-	return string(runes[:maxLen])
 }

--- a/internal/agent/codex/parse_test.go
+++ b/internal/agent/codex/parse_test.go
@@ -313,14 +313,18 @@ func TestSummarizeItem(t *testing.T) {
 		}
 	})
 
-	t.Run("long item truncated at 200 runes", func(t *testing.T) {
+	t.Run("long item truncated with ellipsis suffix", func(t *testing.T) {
 		t.Parallel()
 		// Prefix "[agentMessage] " is 15 chars; ID of 250 chars makes 265 total.
+		// TruncateRunes keeps first 200 runes then appends "…" (1 rune) → 201 runes.
 		longID := strings.Repeat("x", 250)
 		got := summarizeItem("agentMessage", longID)
 		runeCount := utf8.RuneCountInString(got)
-		if runeCount != 200 {
-			t.Errorf("summarizeItem() rune count = %d, want 200", runeCount)
+		if runeCount != 201 {
+			t.Errorf("summarizeItem() rune count = %d, want 201", runeCount)
+		}
+		if !strings.HasSuffix(got, "…") {
+			t.Errorf("summarizeItem() does not end with ellipsis: %q", got[max(0, len(got)-10):])
 		}
 	})
 

--- a/internal/agent/copilot/command.go
+++ b/internal/agent/copilot/command.go
@@ -3,6 +3,8 @@ package copilot
 import (
 	"strconv"
 	"strings"
+
+	"github.com/sortie-ai/sortie/internal/typeutil"
 )
 
 // passthroughConfig holds Copilot CLI-specific settings extracted from
@@ -27,17 +29,17 @@ type passthroughConfig struct {
 // defaults.
 func parsePassthroughConfig(config map[string]any) passthroughConfig {
 	return passthroughConfig{
-		Model:                 stringFrom(config, "model"),
-		MaxAutopilotContinues: intFrom(config, "max_autopilot_continues", 0),
-		Agent:                 stringFrom(config, "agent"),
-		AllowedTools:          stringFrom(config, "allowed_tools"),
-		DeniedTools:           stringFrom(config, "denied_tools"),
-		AvailableTools:        stringFrom(config, "available_tools"),
-		ExcludedTools:         stringFrom(config, "excluded_tools"),
-		MCPConfig:             stringFrom(config, "mcp_config"),
-		DisableBuiltinMCPs:    boolFrom(config, "disable_builtin_mcps", false),
-		NoCustomInstructions:  boolFrom(config, "no_custom_instructions", false),
-		Experimental:          boolFrom(config, "experimental", false),
+		Model:                 typeutil.StringFrom(config, "model"),
+		MaxAutopilotContinues: typeutil.IntFrom(config, "max_autopilot_continues", 0),
+		Agent:                 typeutil.StringFrom(config, "agent"),
+		AllowedTools:          typeutil.StringFrom(config, "allowed_tools"),
+		DeniedTools:           typeutil.StringFrom(config, "denied_tools"),
+		AvailableTools:        typeutil.StringFrom(config, "available_tools"),
+		ExcludedTools:         typeutil.StringFrom(config, "excluded_tools"),
+		MCPConfig:             typeutil.StringFrom(config, "mcp_config"),
+		DisableBuiltinMCPs:    typeutil.BoolFrom(config, "disable_builtin_mcps", false),
+		NoCustomInstructions:  typeutil.BoolFrom(config, "no_custom_instructions", false),
+		Experimental:          typeutil.BoolFrom(config, "experimental", false),
 	}
 }
 
@@ -110,44 +112,6 @@ func buildArgs(state *sessionState, prompt string, pt passthroughConfig) []strin
 	}
 
 	return args
-}
-
-func stringFrom(config map[string]any, key string) string {
-	v, ok := config[key].(string)
-	if !ok {
-		return ""
-	}
-	return v
-}
-
-// intFrom extracts an integer value from config by key. Handles both
-// int and float64 (JSON numbers decode as float64). Fractional
-// float64 values are rejected to prevent silent truncation. Returns
-// defaultVal if absent, wrong type, or fractional.
-func intFrom(config map[string]any, key string, defaultVal int) int {
-	raw, ok := config[key]
-	if !ok {
-		return defaultVal
-	}
-	switch v := raw.(type) {
-	case int:
-		return v
-	case float64:
-		if v != float64(int(v)) {
-			return defaultVal
-		}
-		return int(v)
-	default:
-		return defaultVal
-	}
-}
-
-func boolFrom(config map[string]any, key string, defaultVal bool) bool {
-	v, ok := config[key].(bool)
-	if !ok {
-		return defaultVal
-	}
-	return v
 }
 
 // formatMCPConfigValue prepares an operator-provided MCP config value

--- a/internal/agent/copilot/copilot.go
+++ b/internal/agent/copilot/copilot.go
@@ -23,11 +23,13 @@ import (
 	"sync"
 	"time"
 
+	"github.com/sortie-ai/sortie/internal/agent/agentcore"
 	"github.com/sortie-ai/sortie/internal/agent/procutil"
 	"github.com/sortie-ai/sortie/internal/agent/sshutil"
 	"github.com/sortie-ai/sortie/internal/domain"
 	"github.com/sortie-ai/sortie/internal/logging"
 	"github.com/sortie-ai/sortie/internal/registry"
+	"github.com/sortie-ai/sortie/internal/typeutil"
 )
 
 func init() {
@@ -38,13 +40,6 @@ func init() {
 
 // Compile-time interface satisfaction check.
 var _ domain.AgentAdapter = (*CopilotAdapter)(nil)
-
-// inFlightTool tracks a tool execution that has started but whose
-// corresponding tool.execution_complete has not yet arrived.
-type inFlightTool struct {
-	Name      string
-	Timestamp time.Time
-}
 
 // CopilotAdapter satisfies [domain.AgentAdapter] by managing Copilot
 // CLI subprocesses. One adapter instance serves all concurrent
@@ -357,7 +352,7 @@ func (a *CopilotAdapter) RunTurn(ctx context.Context, session domain.Session, pa
 	scanner.Buffer(make([]byte, 0, 64*1024), 10*1024*1024)
 
 	var lastResult *rawEvent
-	inFlight := make(map[string]inFlightTool)
+	inFlight := agentcore.NewToolTracker()
 	var cumulativeOutputTokens int64
 
 	for scanner.Scan() {
@@ -369,7 +364,7 @@ func (a *CopilotAdapter) RunTurn(ctx context.Context, session domain.Session, pa
 			params.OnEvent(domain.AgentEvent{
 				Type:      domain.EventMalformed,
 				Timestamp: now,
-				Message:   truncate(string(line), 500),
+				Message:   typeutil.TruncateRunes(string(line), 500),
 			})
 			continue
 		}
@@ -418,10 +413,7 @@ func (a *CopilotAdapter) RunTurn(ctx context.Context, session domain.Session, pa
 			if len(event.Data) > 0 {
 				toolData, dataErr := parseToolExecutionData(event.Data)
 				if dataErr == nil {
-					inFlight[toolData.ToolCallID] = inFlightTool{
-						Name:      toolData.ToolName,
-						Timestamp: time.Now(),
-					}
+					inFlight.Begin(toolData.ToolCallID, toolData.ToolName)
 					params.OnEvent(domain.AgentEvent{
 						Type:      domain.EventNotification,
 						Timestamp: now,
@@ -434,14 +426,9 @@ func (a *CopilotAdapter) RunTurn(ctx context.Context, session domain.Session, pa
 			if len(event.Data) > 0 {
 				toolData, dataErr := parseToolExecutionData(event.Data)
 				if dataErr == nil {
-					toolName := toolData.ToolName
-					var durationMS int64
-					if entry, ok := inFlight[toolData.ToolCallID]; ok {
-						toolName = entry.Name
-						if d := time.Since(entry.Timestamp); d > 0 {
-							durationMS = d.Milliseconds()
-						}
-						delete(inFlight, toolData.ToolCallID)
+					toolName, durationMS, ok := inFlight.End(toolData.ToolCallID)
+					if !ok {
+						toolName = toolData.ToolName
 					}
 					params.OnEvent(domain.AgentEvent{
 						Type:           domain.EventToolResult,

--- a/internal/agent/copilot/parse.go
+++ b/internal/agent/copilot/parse.go
@@ -4,9 +4,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
-	"unicode/utf8"
 
 	"github.com/sortie-ai/sortie/internal/domain"
+	"github.com/sortie-ai/sortie/internal/typeutil"
 )
 
 // rawEvent is the intermediate representation of a Copilot CLI JSONL
@@ -134,7 +134,7 @@ func parseSessionTaskCompleteData(data json.RawMessage) (sessionTaskCompleteData
 // 200 runes; otherwise tool requests are listed by name.
 func summarizeAssistantMessage(data assistantMessageData) string {
 	if data.Content != "" {
-		return truncate(strings.TrimSpace(data.Content), 200)
+		return typeutil.TruncateRunes(strings.TrimSpace(data.Content), 200)
 	}
 	if len(data.ToolRequests) > 0 {
 		names := make([]string, len(data.ToolRequests))
@@ -157,12 +157,4 @@ func normalizeUsage(_ *rawUsage, cumulativeOutput int64) domain.TokenUsage {
 		OutputTokens: cumulativeOutput,
 		TotalTokens:  cumulativeOutput,
 	}
-}
-
-func truncate(s string, maxLen int) string {
-	if utf8.RuneCountInString(s) <= maxLen {
-		return s
-	}
-	runes := []rune(s)
-	return string(runes[:maxLen]) + "…"
 }

--- a/internal/agent/copilot/parse_test.go
+++ b/internal/agent/copilot/parse_test.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/sortie-ai/sortie/internal/typeutil"
 )
 
 // scanFixtureLines reads non-empty lines from a testdata/ fixture file.
@@ -708,9 +710,9 @@ func TestTruncate(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			got := truncate(tt.s, tt.maxLen)
+			got := typeutil.TruncateRunes(tt.s, tt.maxLen)
 			if got != tt.want {
-				t.Errorf("truncate(%q, %d) = %q, want %q", tt.s, tt.maxLen, got, tt.want)
+				t.Errorf("TruncateRunes(%q, %d) = %q, want %q", tt.s, tt.maxLen, got, tt.want)
 			}
 		})
 	}

--- a/internal/domain/errors.go
+++ b/internal/domain/errors.go
@@ -1,6 +1,9 @@
 package domain
 
-import "fmt"
+import (
+	"errors"
+	"fmt"
+)
 
 // TrackerErrorKind enumerates the normalized error categories that
 // tracker adapters map their native errors to. The orchestrator uses
@@ -71,6 +74,17 @@ func (e *TrackerError) Error() string {
 // [errors.As].
 func (e *TrackerError) Unwrap() error {
 	return e.Err
+}
+
+// IsNotFound reports whether err is a [*TrackerError] with Kind
+// [ErrTrackerNotFound]. It unwraps the error chain, so it returns true
+// even when the *TrackerError is wrapped by another error.
+func IsNotFound(err error) bool {
+	var te *TrackerError
+	if !errors.As(err, &te) {
+		return false
+	}
+	return te.Kind == ErrTrackerNotFound
 }
 
 // AgentErrorKind enumerates the normalized error categories that

--- a/internal/domain/errors_test.go
+++ b/internal/domain/errors_test.go
@@ -1,0 +1,68 @@
+package domain
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+func TestIsNotFound(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "nil error",
+			err:  nil,
+			want: false,
+		},
+		{
+			name: "TrackerError with ErrTrackerNotFound",
+			err:  &TrackerError{Kind: ErrTrackerNotFound, Message: "issue not found"},
+			want: true,
+		},
+		{
+			name: "TrackerError with ErrTrackerAPI",
+			err:  &TrackerError{Kind: ErrTrackerAPI, Message: "server error"},
+			want: false,
+		},
+		{
+			name: "TrackerError with ErrTrackerTransport",
+			err:  &TrackerError{Kind: ErrTrackerTransport, Message: "connection refused"},
+			want: false,
+		},
+		{
+			name: "wrapped TrackerError with ErrTrackerNotFound",
+			err:  fmt.Errorf("wrapped: %w", &TrackerError{Kind: ErrTrackerNotFound, Message: "not found"}),
+			want: true,
+		},
+		{
+			name: "doubly wrapped TrackerError with ErrTrackerNotFound",
+			err:  fmt.Errorf("outer: %w", fmt.Errorf("inner: %w", &TrackerError{Kind: ErrTrackerNotFound})),
+			want: true,
+		},
+		{
+			name: "unrelated error",
+			err:  errors.New("something went wrong"),
+			want: false,
+		},
+		{
+			name: "wrapped unrelated error",
+			err:  fmt.Errorf("context: %w", errors.New("unrelated")),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := IsNotFound(tt.err)
+			if got != tt.want {
+				t.Errorf("IsNotFound(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/scm/github/tracker.go
+++ b/internal/scm/github/tracker.go
@@ -363,7 +363,7 @@ func (a *GitHubAdapter) FetchIssueByID(ctx context.Context, issueID string) (dom
 	body, _, err := a.client.do(ctx, "GET", basePath, nil)
 	if err != nil {
 		a.incTrackerRequest("fetch_issue", "error")
-		if isNotFound(err) {
+		if domain.IsNotFound(err) {
 			return domain.Issue{}, &domain.TrackerError{
 				Kind:    domain.ErrTrackerNotFound,
 				Message: fmt.Sprintf("issue not found: %s", issueID),
@@ -425,7 +425,7 @@ func (a *GitHubAdapter) fetchBlockers(ctx context.Context, issueID string) ([]do
 
 	body, nextURL, err := a.client.do(ctx, "GET", path, params)
 	if err != nil {
-		if isNotFound(err) {
+		if domain.IsNotFound(err) {
 			return []domain.BlockerRef{}, nil
 		}
 		return nil, err
@@ -473,7 +473,7 @@ func (a *GitHubAdapter) fetchParent(ctx context.Context, issueID string) (*domai
 
 	body, _, err := a.client.do(ctx, "GET", path, nil)
 	if err != nil {
-		if isNotFound(err) {
+		if domain.IsNotFound(err) {
 			return nil, nil
 		}
 		return nil, err
@@ -768,7 +768,7 @@ func (a *GitHubAdapter) fetchStatesByNumbers(ctx context.Context, numbers []stri
 
 		body, responseETag, notModified, err := a.client.doConditional(ctx, "GET", path, nil, etag)
 		if err != nil {
-			if isNotFound(err) {
+			if domain.IsNotFound(err) {
 				continue
 			}
 			return nil, err
@@ -821,7 +821,7 @@ func (a *GitHubAdapter) fetchAllComments(ctx context.Context, issueNumber string
 
 	body, nextURL, err := a.client.do(ctx, "GET", path, params)
 	if err != nil {
-		if isNotFound(err) {
+		if domain.IsNotFound(err) {
 			return nil, &domain.TrackerError{
 				Kind:    domain.ErrTrackerNotFound,
 				Message: fmt.Sprintf("issue not found: %s", issueNumber),
@@ -912,7 +912,7 @@ func (a *GitHubAdapter) TransitionIssue(ctx context.Context, issueID string, tar
 	if currentLabel != "" && currentLabel != targetLower {
 		labelPath := basePath + "/labels/" + url.PathEscape(currentLabel)
 		err := a.client.doNoBody(ctx, "DELETE", labelPath)
-		if err != nil && !isNotFound(err) {
+		if err != nil && !domain.IsNotFound(err) {
 			a.incTrackerRequest("transition", "error")
 			return err
 		}
@@ -1028,11 +1028,4 @@ func (a *GitHubAdapter) incTrackerRequest(operation, outcome string) {
 	if a.metrics != nil {
 		a.metrics.IncTrackerRequests(operation, outcome)
 	}
-}
-
-// isNotFound checks whether an error is a TrackerError with kind
-// ErrTrackerNotFound (HTTP 404).
-func isNotFound(err error) bool {
-	te, ok := err.(*domain.TrackerError)
-	return ok && te.Kind == domain.ErrTrackerNotFound
 }

--- a/internal/tracker/jira/jira.go
+++ b/internal/tracker/jira/jira.go
@@ -145,7 +145,7 @@ func (a *JiraAdapter) FetchIssueByID(ctx context.Context, issueID string) (domai
 	body, err := a.client.do(ctx, "GET", "/rest/api/3/issue/"+url.PathEscape(issueID), params)
 	if err != nil {
 		a.incTrackerRequest("fetch_issue", "error")
-		if isNotFound(err) {
+		if domain.IsNotFound(err) {
 			return domain.Issue{}, &domain.TrackerError{
 				Kind:    domain.ErrTrackerNotFound,
 				Message: fmt.Sprintf("issue not found: %s", issueID),
@@ -494,7 +494,7 @@ func (a *JiraAdapter) fetchComments(ctx context.Context, issueID string) ([]doma
 
 		body, err := a.client.do(ctx, "GET", "/rest/api/3/issue/"+url.PathEscape(issueID)+"/comment", params)
 		if err != nil {
-			if isNotFound(err) {
+			if domain.IsNotFound(err) {
 				return nil, &domain.TrackerError{
 					Kind:    domain.ErrTrackerNotFound,
 					Message: fmt.Sprintf("issue not found: %s", issueID),
@@ -524,9 +524,4 @@ func (a *JiraAdapter) fetchComments(ctx context.Context, issueID string) ([]doma
 		return []domain.Comment{}, nil
 	}
 	return normalizeComments(allComments), nil
-}
-
-func isNotFound(err error) bool {
-	te, ok := err.(*domain.TrackerError)
-	return ok && te.Kind == domain.ErrTrackerNotFound
 }

--- a/internal/typeutil/typeutil.go
+++ b/internal/typeutil/typeutil.go
@@ -3,6 +3,8 @@
 // packages that cannot import each other.
 package typeutil
 
+import "unicode/utf8"
+
 // ExtractStringSlice converts a loosely-typed value to []string.
 //
 // It handles []any (as produced by JSON and YAML decoders) by extracting
@@ -24,4 +26,84 @@ func ExtractStringSlice(v any) []string {
 	default:
 		return nil
 	}
+}
+
+// TruncateRunes returns s if it contains maxLen or fewer runes. When s
+// exceeds maxLen runes, the first maxLen runes are returned with a "…"
+// (U+2026) suffix. maxLen must be non-negative.
+func TruncateRunes(s string, maxLen int) string {
+	if utf8.RuneCountInString(s) <= maxLen {
+		return s
+	}
+	runes := []rune(s)
+	return string(runes[:maxLen]) + "…"
+}
+
+// StringFrom returns the string value for key in config. Returns "" if
+// the key is absent or the value is not a string.
+func StringFrom(config map[string]any, key string) string {
+	v, ok := config[key].(string)
+	if !ok {
+		return ""
+	}
+	return v
+}
+
+// IntFrom returns the integer value for key in config. Handles both int
+// and float64 (JSON-decoded) values. A float64 that is not a whole number
+// is rejected and defaultVal is returned. Returns defaultVal if the key is
+// absent or the type is unrecognized.
+func IntFrom(config map[string]any, key string, defaultVal int) int {
+	raw, ok := config[key]
+	if !ok {
+		return defaultVal
+	}
+	switch v := raw.(type) {
+	case int:
+		return v
+	case float64:
+		if v != float64(int(v)) {
+			return defaultVal
+		}
+		return int(v)
+	default:
+		return defaultVal
+	}
+}
+
+// FloatFrom returns the float64 value for key in config. Accepts both
+// float64 and int values. Returns defaultVal otherwise.
+func FloatFrom(config map[string]any, key string, defaultVal float64) float64 {
+	raw, ok := config[key]
+	if !ok {
+		return defaultVal
+	}
+	switch v := raw.(type) {
+	case float64:
+		return v
+	case int:
+		return float64(v)
+	default:
+		return defaultVal
+	}
+}
+
+// BoolFrom returns the bool value for key in config. Returns defaultVal
+// if the key is absent or the value is not a bool.
+func BoolFrom(config map[string]any, key string, defaultVal bool) bool {
+	v, ok := config[key].(bool)
+	if !ok {
+		return defaultVal
+	}
+	return v
+}
+
+// MapFrom returns the map[string]any value for key in config. Returns nil
+// if the key is absent or the value is not a map.
+func MapFrom(config map[string]any, key string) map[string]any {
+	v, ok := config[key].(map[string]any)
+	if !ok {
+		return nil
+	}
+	return v
 }

--- a/internal/typeutil/typeutil_test.go
+++ b/internal/typeutil/typeutil_test.go
@@ -1,6 +1,9 @@
 package typeutil
 
-import "testing"
+import (
+	"testing"
+	"unicode/utf8"
+)
 
 func TestExtractStringSlice(t *testing.T) {
 	t.Parallel()
@@ -47,6 +50,200 @@ func TestExtractStringSlice(t *testing.T) {
 				if got[i] != tt.want[i] {
 					t.Errorf("ExtractStringSlice()[%d] = %q, want %q", i, got[i], tt.want[i])
 				}
+			}
+		})
+	}
+}
+
+func TestTruncateRunes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		s      string
+		maxLen int
+		want   string
+	}{
+		{name: "empty string", s: "", maxLen: 10, want: ""},
+		{name: "below limit", s: "hello", maxLen: 10, want: "hello"},
+		{name: "exact limit not truncated", s: "hello", maxLen: 5, want: "hello"},
+		{name: "above limit gets ellipsis", s: "hello world", maxLen: 5, want: "hello…"},
+		{name: "multi-byte CJK runes counted correctly", s: "日本語テスト", maxLen: 3, want: "日本語…"},
+		{name: "emoji counted as single rune", s: "ab🎉cd", maxLen: 3, want: "ab🎉…"},
+		{name: "maxLen zero returns ellipsis", s: "abc", maxLen: 0, want: "…"},
+		{name: "unicode two-byte runes", s: "héllo", maxLen: 4, want: "héll…"},
+		{name: "result rune count is maxLen plus one", s: strings("x", 20), maxLen: 5, want: strings("x", 5) + "…"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := TruncateRunes(tt.s, tt.maxLen)
+			if got != tt.want {
+				t.Errorf("TruncateRunes(%q, %d) = %q, want %q", tt.s, tt.maxLen, got, tt.want)
+			}
+			if utf8.RuneCountInString(got) > tt.maxLen+1 {
+				t.Errorf("TruncateRunes(%q, %d): rune count %d exceeds maxLen+1", tt.s, tt.maxLen, utf8.RuneCountInString(got))
+			}
+		})
+	}
+}
+
+// strings returns s repeated n times.
+func strings(s string, n int) string {
+	result := make([]byte, len(s)*n)
+	for i := range n {
+		copy(result[i*len(s):], s)
+	}
+	return string(result)
+}
+
+func TestStringFrom(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		config map[string]any
+		key    string
+		want   string
+	}{
+		{name: "key present string value", config: map[string]any{"k": "hello"}, key: "k", want: "hello"},
+		{name: "key present non-string value", config: map[string]any{"k": 42}, key: "k", want: ""},
+		{name: "key absent", config: map[string]any{}, key: "missing", want: ""},
+		{name: "nil value for key", config: map[string]any{"k": nil}, key: "k", want: ""},
+		{name: "empty string value", config: map[string]any{"k": ""}, key: "k", want: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := StringFrom(tt.config, tt.key)
+			if got != tt.want {
+				t.Errorf("StringFrom(%q) = %q, want %q", tt.key, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIntFrom(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		config     map[string]any
+		key        string
+		defaultVal int
+		want       int
+	}{
+		{name: "int value", config: map[string]any{"k": 7}, key: "k", defaultVal: 0, want: 7},
+		{name: "float64 whole number", config: map[string]any{"k": float64(3)}, key: "k", defaultVal: 0, want: 3},
+		{name: "float64 fractional returns default", config: map[string]any{"k": 3.5}, key: "k", defaultVal: -1, want: -1},
+		{name: "key absent returns default", config: map[string]any{}, key: "missing", defaultVal: 99, want: 99},
+		{name: "non-numeric type returns default", config: map[string]any{"k": "five"}, key: "k", defaultVal: 42, want: 42},
+		{name: "bool type returns default", config: map[string]any{"k": true}, key: "k", defaultVal: 5, want: 5},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := IntFrom(tt.config, tt.key, tt.defaultVal)
+			if got != tt.want {
+				t.Errorf("IntFrom(%q) = %d, want %d", tt.key, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFloatFrom(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		config     map[string]any
+		key        string
+		defaultVal float64
+		want       float64
+	}{
+		{name: "float64 value", config: map[string]any{"k": 1.5}, key: "k", defaultVal: 0, want: 1.5},
+		{name: "int value coerced", config: map[string]any{"k": 3}, key: "k", defaultVal: 0, want: 3.0},
+		{name: "key absent returns default", config: map[string]any{}, key: "missing", defaultVal: 9.9, want: 9.9},
+		{name: "non-numeric type returns default", config: map[string]any{"k": "fast"}, key: "k", defaultVal: -1.0, want: -1.0},
+		{name: "zero float64", config: map[string]any{"k": float64(0)}, key: "k", defaultVal: 5.0, want: 0.0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := FloatFrom(tt.config, tt.key, tt.defaultVal)
+			if got != tt.want {
+				t.Errorf("FloatFrom(%q) = %v, want %v", tt.key, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBoolFrom(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		config     map[string]any
+		key        string
+		defaultVal bool
+		want       bool
+	}{
+		{name: "true value", config: map[string]any{"k": true}, key: "k", defaultVal: false, want: true},
+		{name: "false value", config: map[string]any{"k": false}, key: "k", defaultVal: true, want: false},
+		{name: "key absent returns default true", config: map[string]any{}, key: "missing", defaultVal: true, want: true},
+		{name: "key absent returns default false", config: map[string]any{}, key: "missing", defaultVal: false, want: false},
+		{name: "non-bool type returns default", config: map[string]any{"k": "yes"}, key: "k", defaultVal: true, want: true},
+		{name: "int type returns default", config: map[string]any{"k": 1}, key: "k", defaultVal: false, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := BoolFrom(tt.config, tt.key, tt.defaultVal)
+			if got != tt.want {
+				t.Errorf("BoolFrom(%q) = %v, want %v", tt.key, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMapFrom(t *testing.T) {
+	t.Parallel()
+
+	inner := map[string]any{"nested": "value"}
+
+	tests := []struct {
+		name    string
+		config  map[string]any
+		key     string
+		wantNil bool
+		want    map[string]any
+	}{
+		{name: "present map", config: map[string]any{"k": inner}, key: "k", wantNil: false, want: inner},
+		{name: "key absent returns nil", config: map[string]any{}, key: "missing", wantNil: true},
+		{name: "wrong type returns nil", config: map[string]any{"k": "not-a-map"}, key: "k", wantNil: true},
+		{name: "nil value returns nil", config: map[string]any{"k": nil}, key: "k", wantNil: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := MapFrom(tt.config, tt.key)
+			if tt.wantNil {
+				if got != nil {
+					t.Errorf("MapFrom(%q) = %v, want nil", tt.key, got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatalf("MapFrom(%q) = nil, want non-nil", tt.key)
+			}
+			if len(got) != len(tt.want) {
+				t.Errorf("MapFrom(%q) len = %d, want %d", tt.key, len(got), len(tt.want))
 			}
 		})
 	}

--- a/internal/typeutil/typeutil_test.go
+++ b/internal/typeutil/typeutil_test.go
@@ -72,7 +72,7 @@ func TestTruncateRunes(t *testing.T) {
 		{name: "emoji counted as single rune", s: "ab🎉cd", maxLen: 3, want: "ab🎉…"},
 		{name: "maxLen zero returns ellipsis", s: "abc", maxLen: 0, want: "…"},
 		{name: "unicode two-byte runes", s: "héllo", maxLen: 4, want: "héll…"},
-		{name: "result rune count is maxLen plus one", s: strings("x", 20), maxLen: 5, want: strings("x", 5) + "…"},
+		{name: "result rune count is maxLen plus one", s: repeatString("x", 20), maxLen: 5, want: repeatString("x", 5) + "…"},
 	}
 
 	for _, tt := range tests {
@@ -89,8 +89,8 @@ func TestTruncateRunes(t *testing.T) {
 	}
 }
 
-// strings returns s repeated n times.
-func strings(s string, n int) string {
+// repeatString returns s repeated n times.
+func repeatString(s string, n int) string {
 	result := make([]byte, len(s)*n)
 	for i := range n {
 		copy(result[i*len(s):], s)


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Refactor

**Intent:** Four copy-pasted implementation patterns across the `claude`, `copilot`, `codex`, `tracker/jira`, and `scm/github` adapters are extracted into shared internal packages. No exported interface methods are added, removed, or modified.

### 🧭 Reviewer Guide

**Complexity:** Medium

#### Entry Point

`internal/agent/agentcore/tooltracker.go` - the only new package introduced. Understand `ToolTracker.Begin`/`End` semantics (monotonic clock, delete-on-hit, duration clamp) before reviewing the three adapter migrations that replace the identical `inFlightTool` map pattern.

#### Sensitive Areas

- `internal/agent/codex/parse.go`: Codex truncated messages now gain the `"…"` (U+2026) suffix. This was a latent inconsistency vs the claude and copilot adapters and is an intentional fix. Any operator tooling that pattern-matches on truncated Codex `EventMalformed` strings should be reviewed.
- `internal/domain/errors.go`: `IsNotFound` uses `errors.As` (unwraps chains) rather than a direct type assertion. All current call sites pass unwrapped `*TrackerError` values, so behaviour is identical today. The broader contract is correct for future callers.
- `internal/typeutil/typeutil.go`: `IntFrom` guards against fractional `float64` values from JSON decoding — the rule is now shared across all three agent adapters rather than duplicated in two and absent in one.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes. All `AgentAdapter`, `TrackerAdapter`, and `SCMAdapter` interface methods are unchanged. `domain.IsNotFound` and `internal/agent/agentcore` are additive.
- **Migrations/State:** No migrations or state changes.