### PR TITLE
refactor(agentcore): extract shared workspace, binary, launch, event, and token utilities

### DIFF
--- a/internal/agent/agentcore/binary.go
+++ b/internal/agent/agentcore/binary.go
@@ -21,7 +21,7 @@ func ResolveBinary(command string) (string, *domain.AgentError) {
 	if strings.ContainsAny(command, " \t") {
 		return "", &domain.AgentError{
 			Kind:    domain.ErrAgentNotFound,
-			Message: fmt.Sprintf("ResolveBinary requires a single command token, got %q", command),
+			Message: fmt.Sprintf("agent command must be a single token, got %q", command),
 		}
 	}
 

--- a/internal/agent/agentcore/binary.go
+++ b/internal/agent/agentcore/binary.go
@@ -1,0 +1,38 @@
+package agentcore
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"github.com/sortie-ai/sortie/internal/domain"
+)
+
+// ResolveBinary resolves command to an absolute executable path using
+// exec.LookPath. It returns a [*domain.AgentError] with Kind
+// [domain.ErrAgentNotFound] when the binary cannot be found on PATH.
+//
+// command must be a single token (no embedded spaces). If command contains
+// whitespace, ResolveBinary returns ErrAgentNotFound immediately with a
+// message indicating the caller must split the command string first. For
+// multi-token commands such as "codex app-server", callers must split on
+// whitespace and pass only the first token.
+func ResolveBinary(command string) (string, *domain.AgentError) {
+	if strings.ContainsAny(command, " \t") {
+		return "", &domain.AgentError{
+			Kind:    domain.ErrAgentNotFound,
+			Message: fmt.Sprintf("ResolveBinary requires a single command token, got %q", command),
+		}
+	}
+
+	absPath, err := exec.LookPath(command)
+	if err != nil {
+		return "", &domain.AgentError{
+			Kind:    domain.ErrAgentNotFound,
+			Message: fmt.Sprintf("agent command %q not found", command),
+			Err:     err,
+		}
+	}
+
+	return absPath, nil
+}

--- a/internal/agent/agentcore/binary_test.go
+++ b/internal/agent/agentcore/binary_test.go
@@ -31,13 +31,13 @@ func TestResolveBinary(t *testing.T) {
 			name:     "multi-token command with space",
 			command:  "codex app-server",
 			wantKind: domain.ErrAgentNotFound,
-			wantMsg:  `ResolveBinary requires a single command token, got "codex app-server"`,
+			wantMsg:  `agent command must be a single token, got "codex app-server"`,
 		},
 		{
 			name:     "multi-token command with tab",
 			command:  "codex\tapp-server",
 			wantKind: domain.ErrAgentNotFound,
-			wantMsg:  "ResolveBinary requires a single command token, got \"codex\\tapp-server\"",
+			wantMsg:  "agent command must be a single token, got \"codex\\tapp-server\"",
 		},
 	}
 

--- a/internal/agent/agentcore/binary_test.go
+++ b/internal/agent/agentcore/binary_test.go
@@ -1,0 +1,71 @@
+package agentcore
+
+import (
+	"testing"
+
+	"github.com/sortie-ai/sortie/internal/domain"
+)
+
+func TestResolveBinary(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		command   string
+		wantKind  domain.AgentErrorKind
+		wantMsg   string
+		wantNoErr bool
+	}{
+		{
+			name:      "binary on PATH",
+			command:   "sh",
+			wantNoErr: true,
+		},
+		{
+			name:     "binary not found",
+			command:  "sortie-no-such-binary-xyzzy",
+			wantKind: domain.ErrAgentNotFound,
+			wantMsg:  `agent command "sortie-no-such-binary-xyzzy" not found`,
+		},
+		{
+			name:     "multi-token command with space",
+			command:  "codex app-server",
+			wantKind: domain.ErrAgentNotFound,
+			wantMsg:  `ResolveBinary requires a single command token, got "codex app-server"`,
+		},
+		{
+			name:     "multi-token command with tab",
+			command:  "codex\tapp-server",
+			wantKind: domain.ErrAgentNotFound,
+			wantMsg:  "ResolveBinary requires a single command token, got \"codex\\tapp-server\"",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, agentErr := ResolveBinary(tt.command)
+
+			if tt.wantNoErr {
+				if agentErr != nil {
+					t.Fatalf("ResolveBinary(%q) unexpected error: %v", tt.command, agentErr)
+				}
+				if got == "" {
+					t.Errorf("ResolveBinary(%q) = %q, want non-empty path", tt.command, got)
+				}
+				return
+			}
+
+			if agentErr == nil {
+				t.Fatalf("ResolveBinary(%q) = %q, want error with kind %q", tt.command, got, tt.wantKind)
+			}
+			if agentErr.Kind != tt.wantKind {
+				t.Errorf("AgentError.Kind = %q, want %q", agentErr.Kind, tt.wantKind)
+			}
+			if tt.wantMsg != "" && agentErr.Message != tt.wantMsg {
+				t.Errorf("AgentError.Message = %q, want %q", agentErr.Message, tt.wantMsg)
+			}
+		})
+	}
+}

--- a/internal/agent/agentcore/events.go
+++ b/internal/agent/agentcore/events.go
@@ -1,0 +1,79 @@
+package agentcore
+
+import (
+	"time"
+
+	"github.com/sortie-ai/sortie/internal/domain"
+	"github.com/sortie-ai/sortie/internal/typeutil"
+)
+
+// EmitSessionStarted emits an EventSessionStarted event with the given agent
+// process ID and session identifier. agentPID is set directly on AgentPID;
+// pass "" when the process ID is unavailable. Subprocess adapters (Claude,
+// Copilot) pass strconv.Itoa(cmd.Process.Pid) after cmd.Start; persistent-
+// process adapters (Codex) pass session.AgentPID directly.
+func EmitSessionStarted(emit func(domain.AgentEvent), agentPID string, sessionID string) {
+	emit(domain.AgentEvent{
+		Type:      domain.EventSessionStarted,
+		Timestamp: time.Now().UTC(),
+		AgentPID:  agentPID,
+		SessionID: sessionID,
+		Message:   "session started",
+	})
+}
+
+// EmitTurnCompleted emits an EventTurnCompleted event. message is a
+// human-readable summary; use "" when unavailable. apiDurationMS is the LLM
+// API response wait time in milliseconds for this turn; use 0 when
+// unavailable.
+func EmitTurnCompleted(emit func(domain.AgentEvent), message string, apiDurationMS int64) {
+	emit(domain.AgentEvent{
+		Type:          domain.EventTurnCompleted,
+		Timestamp:     time.Now().UTC(),
+		Message:       message,
+		APIDurationMS: apiDurationMS,
+	})
+}
+
+// EmitTurnFailed emits an EventTurnFailed event. message describes the
+// failure. apiDurationMS is attached to the event; use 0 when unavailable.
+func EmitTurnFailed(emit func(domain.AgentEvent), message string, apiDurationMS int64) {
+	emit(domain.AgentEvent{
+		Type:          domain.EventTurnFailed,
+		Timestamp:     time.Now().UTC(),
+		Message:       message,
+		APIDurationMS: apiDurationMS,
+	})
+}
+
+// EmitTurnCancelled emits an EventTurnCancelled event with the given
+// human-readable message.
+func EmitTurnCancelled(emit func(domain.AgentEvent), message string) {
+	emit(domain.AgentEvent{
+		Type:      domain.EventTurnCancelled,
+		Timestamp: time.Now().UTC(),
+		Message:   message,
+	})
+}
+
+// EmitMalformed emits an EventMalformed event. line is the raw unparseable
+// bytes from the agent output stream; it is truncated to 500 Unicode code
+// points before inclusion in the event message.
+func EmitMalformed(emit func(domain.AgentEvent), line []byte) {
+	emit(domain.AgentEvent{
+		Type:      domain.EventMalformed,
+		Timestamp: time.Now().UTC(),
+		Message:   typeutil.TruncateRunes(string(line), 500),
+	})
+}
+
+// EmitNotification emits an EventNotification event with the given
+// informational message. message may be empty for stall-timer-reset
+// notifications.
+func EmitNotification(emit func(domain.AgentEvent), message string) {
+	emit(domain.AgentEvent{
+		Type:      domain.EventNotification,
+		Timestamp: time.Now().UTC(),
+		Message:   message,
+	})
+}

--- a/internal/agent/agentcore/events_test.go
+++ b/internal/agent/agentcore/events_test.go
@@ -1,0 +1,193 @@
+package agentcore
+
+import (
+	"strings"
+	"testing"
+	"time"
+	"unicode/utf8"
+
+	"github.com/sortie-ai/sortie/internal/domain"
+)
+
+func captureOne(t *testing.T, fn func(emit func(domain.AgentEvent))) domain.AgentEvent {
+	t.Helper()
+	var got domain.AgentEvent
+	count := 0
+	fn(func(e domain.AgentEvent) {
+		count++
+		got = e
+	})
+	if count != 1 {
+		t.Fatalf("emit called %d times, want 1", count)
+	}
+	return got
+}
+
+func assertTimestamp(t *testing.T, ts time.Time) {
+	t.Helper()
+	if ts.IsZero() {
+		t.Error("Timestamp is zero, want non-zero")
+	}
+	if ts.Location() != time.UTC {
+		t.Errorf("Timestamp.Location = %v, want UTC", ts.Location())
+	}
+}
+
+func TestEmitSessionStarted(t *testing.T) {
+	t.Parallel()
+
+	got := captureOne(t, func(emit func(domain.AgentEvent)) {
+		EmitSessionStarted(emit, "42", "sess-1")
+	})
+
+	if got.Type != domain.EventSessionStarted {
+		t.Errorf("Type = %q, want EventSessionStarted", got.Type)
+	}
+	assertTimestamp(t, got.Timestamp)
+	if got.AgentPID != "42" {
+		t.Errorf("AgentPID = %q, want 42", got.AgentPID)
+	}
+	if got.SessionID != "sess-1" {
+		t.Errorf("SessionID = %q, want sess-1", got.SessionID)
+	}
+	if got.Message != "session started" {
+		t.Errorf("Message = %q, want 'session started'", got.Message)
+	}
+}
+
+func TestEmitSessionStarted_EmptyPID(t *testing.T) {
+	t.Parallel()
+
+	got := captureOne(t, func(emit func(domain.AgentEvent)) {
+		EmitSessionStarted(emit, "", "sess-2")
+	})
+	if got.AgentPID != "" {
+		t.Errorf("AgentPID = %q, want empty", got.AgentPID)
+	}
+}
+
+func TestEmitTurnCompleted(t *testing.T) {
+	t.Parallel()
+
+	got := captureOne(t, func(emit func(domain.AgentEvent)) {
+		EmitTurnCompleted(emit, "done", 250)
+	})
+
+	if got.Type != domain.EventTurnCompleted {
+		t.Errorf("Type = %q, want EventTurnCompleted", got.Type)
+	}
+	assertTimestamp(t, got.Timestamp)
+	if got.Message != "done" {
+		t.Errorf("Message = %q, want 'done'", got.Message)
+	}
+	if got.APIDurationMS != 250 {
+		t.Errorf("APIDurationMS = %d, want 250", got.APIDurationMS)
+	}
+	if got.AgentPID != "" || got.SessionID != "" {
+		t.Errorf("AgentPID/SessionID should be zero, got %q/%q", got.AgentPID, got.SessionID)
+	}
+}
+
+func TestEmitTurnFailed(t *testing.T) {
+	t.Parallel()
+
+	got := captureOne(t, func(emit func(domain.AgentEvent)) {
+		EmitTurnFailed(emit, "oops", 100)
+	})
+
+	if got.Type != domain.EventTurnFailed {
+		t.Errorf("Type = %q, want EventTurnFailed", got.Type)
+	}
+	assertTimestamp(t, got.Timestamp)
+	if got.Message != "oops" {
+		t.Errorf("Message = %q, want 'oops'", got.Message)
+	}
+	if got.APIDurationMS != 100 {
+		t.Errorf("APIDurationMS = %d, want 100", got.APIDurationMS)
+	}
+}
+
+func TestEmitTurnCancelled(t *testing.T) {
+	t.Parallel()
+
+	got := captureOne(t, func(emit func(domain.AgentEvent)) {
+		EmitTurnCancelled(emit, "cancelled by user")
+	})
+
+	if got.Type != domain.EventTurnCancelled {
+		t.Errorf("Type = %q, want EventTurnCancelled", got.Type)
+	}
+	assertTimestamp(t, got.Timestamp)
+	if got.Message != "cancelled by user" {
+		t.Errorf("Message = %q, want 'cancelled by user'", got.Message)
+	}
+}
+
+func TestEmitMalformed_ShortLine(t *testing.T) {
+	t.Parallel()
+
+	line := []byte("bad json")
+	got := captureOne(t, func(emit func(domain.AgentEvent)) {
+		EmitMalformed(emit, line)
+	})
+
+	if got.Type != domain.EventMalformed {
+		t.Errorf("Type = %q, want EventMalformed", got.Type)
+	}
+	assertTimestamp(t, got.Timestamp)
+	if got.Message != "bad json" {
+		t.Errorf("Message = %q, want %q", got.Message, "bad json")
+	}
+}
+
+func TestEmitMalformed_Truncation(t *testing.T) {
+	t.Parallel()
+
+	// Build a string with 600 Unicode code points (Greek letters to avoid
+	// single-byte/multi-byte ambiguity).
+	var sb strings.Builder
+	for range 600 {
+		sb.WriteRune('α')
+	}
+	line := []byte(sb.String())
+
+	got := captureOne(t, func(emit func(domain.AgentEvent)) {
+		EmitMalformed(emit, line)
+	})
+
+	runeCount := utf8.RuneCountInString(got.Message)
+	// TruncateRunes appends "…" (1 rune) after 500, so total = 501.
+	if runeCount > 501 {
+		t.Errorf("Message rune count = %d, want ≤ 501 after truncation", runeCount)
+	}
+	if !strings.HasSuffix(got.Message, "…") {
+		t.Errorf("Message should end with '…' after truncation, got %q", got.Message[max(0, len(got.Message)-10):])
+	}
+}
+
+func TestEmitNotification(t *testing.T) {
+	t.Parallel()
+
+	got := captureOne(t, func(emit func(domain.AgentEvent)) {
+		EmitNotification(emit, "plan updated")
+	})
+
+	if got.Type != domain.EventNotification {
+		t.Errorf("Type = %q, want EventNotification", got.Type)
+	}
+	assertTimestamp(t, got.Timestamp)
+	if got.Message != "plan updated" {
+		t.Errorf("Message = %q, want 'plan updated'", got.Message)
+	}
+}
+
+func TestEmitNotification_Empty(t *testing.T) {
+	t.Parallel()
+
+	got := captureOne(t, func(emit func(domain.AgentEvent)) {
+		EmitNotification(emit, "")
+	})
+	if got.Message != "" {
+		t.Errorf("Message = %q, want empty", got.Message)
+	}
+}

--- a/internal/agent/agentcore/launchtarget.go
+++ b/internal/agent/agentcore/launchtarget.go
@@ -1,0 +1,117 @@
+package agentcore
+
+import (
+	"cmp"
+	"os/exec"
+	"slices"
+	"strings"
+
+	"github.com/sortie-ai/sortie/internal/domain"
+)
+
+// LaunchTarget captures the resolved launch parameters for a single agent
+// session. It is populated once by [ResolveLaunchTarget] during
+// [domain.AgentAdapter.StartSession] and stored in adapter session state.
+// RunTurn uses it to construct the subprocess command.
+//
+// When RemoteCommand is non-empty the session runs in SSH mode: Command is
+// the local ssh binary, SSHHost is the remote destination, and RemoteCommand
+// is the agent command to execute there. When RemoteCommand is empty the
+// session runs locally: Command is the resolved agent binary and Args contains
+// any initial CLI arguments (e.g., ["app-server"]).
+type LaunchTarget struct {
+	// Command is the resolved absolute path to the local binary to exec.
+	// In SSH mode this is the path to the ssh binary.
+	// In local mode this is the path to the agent binary.
+	Command string
+
+	// Args contains initial CLI arguments inserted before per-turn
+	// arguments. Non-empty only in local mode when the configured command
+	// contains multiple tokens (e.g., "codex app-server" yields
+	// Args: ["app-server"]). Empty in SSH mode.
+	Args []string
+
+	// WorkspacePath is the validated absolute path to the agent workspace
+	// directory. Both local and SSH mode set this field.
+	WorkspacePath string
+
+	// RemoteCommand is the agent command string to run on the SSH host.
+	// Non-empty signals SSH mode. Empty in local mode.
+	RemoteCommand string
+
+	// SSHHost is the SSH destination string after whitespace trimming.
+	// Non-empty when RemoteCommand is non-empty.
+	SSHHost string
+
+	// SSHStrictHostKeyChecking is the OpenSSH StrictHostKeyChecking value
+	// passed through from StartSessionParams. Empty means the SSH caller
+	// defaults to "accept-new".
+	SSHStrictHostKeyChecking string
+}
+
+// ResolveLaunchTarget resolves the workspace path and agent binary for a
+// session, choosing between SSH and local launch modes based on
+// params.SSHHost. It returns a populated [LaunchTarget] and a nil error on
+// success, or a zero [LaunchTarget] and a [*domain.AgentError] on failure.
+//
+// defaultCommand is the fallback agent command when params.AgentConfig.Command
+// is empty (e.g., "claude", "copilot", "codex app-server").
+//
+// Adapter-specific post-resolution steps (canary version checks, auth
+// preflights, environment variable prefixing for the remote command) are the
+// caller's responsibility and must run after ResolveLaunchTarget returns
+// successfully.
+func ResolveLaunchTarget(params domain.StartSessionParams, defaultCommand string) (LaunchTarget, *domain.AgentError) {
+	absPath, agentErr := ResolveWorkspace(params.WorkspacePath)
+	if agentErr != nil {
+		return LaunchTarget{}, agentErr
+	}
+
+	command := cmp.Or(params.AgentConfig.Command, defaultCommand)
+	sshHost := strings.TrimSpace(params.SSHHost)
+
+	if strings.TrimSpace(command) == "" {
+		return LaunchTarget{}, &domain.AgentError{
+			Kind:    domain.ErrAgentNotFound,
+			Message: "agent command is empty or whitespace-only",
+		}
+	}
+
+	if sshHost != "" {
+		sshPath, lookErr := exec.LookPath("ssh")
+		if lookErr != nil {
+			return LaunchTarget{}, &domain.AgentError{
+				Kind:    domain.ErrAgentNotFound,
+				Message: "ssh binary not found on orchestrator host",
+				Err:     lookErr,
+			}
+		}
+		return LaunchTarget{
+			Command:                  sshPath,
+			Args:                     nil,
+			WorkspacePath:            absPath,
+			RemoteCommand:            command,
+			SSHHost:                  sshHost,
+			SSHStrictHostKeyChecking: params.SSHStrictHostKeyChecking,
+		}, nil
+	}
+
+	parts := strings.Fields(command)
+	if len(parts) == 0 {
+		return LaunchTarget{}, &domain.AgentError{
+			Kind:    domain.ErrAgentNotFound,
+			Message: "agent command is empty or whitespace-only",
+		}
+	}
+
+	resolved, agentErr := ResolveBinary(parts[0])
+	if agentErr != nil {
+		return LaunchTarget{}, agentErr
+	}
+
+	return LaunchTarget{
+		Command:       resolved,
+		Args:          slices.Clone(parts[1:]),
+		WorkspacePath: absPath,
+	}, nil
+}

--- a/internal/agent/agentcore/launchtarget_test.go
+++ b/internal/agent/agentcore/launchtarget_test.go
@@ -1,0 +1,232 @@
+package agentcore
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/sortie-ai/sortie/internal/domain"
+)
+
+// fakeSSHDir writes a no-op executable named "ssh" to a temp directory and
+// returns the directory path. The directory should be prepended to PATH via
+// t.Setenv.
+func fakeSSHDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	p := filepath.Join(dir, "ssh")
+	if err := os.WriteFile(p, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("fakeSSHDir: %v", err)
+	}
+	return dir
+}
+
+// emptyDir returns a temp directory that contains no binaries.
+func emptyDir(t *testing.T) string {
+	t.Helper()
+	return t.TempDir()
+}
+
+func makeParams(t *testing.T, workspace, sshHost string, command string) domain.StartSessionParams {
+	t.Helper()
+	return domain.StartSessionParams{
+		WorkspacePath: workspace,
+		SSHHost:       sshHost,
+		AgentConfig: domain.AgentConfig{
+			Command: command,
+		},
+	}
+}
+
+func TestResolveLaunchTarget(t *testing.T) {
+	// Not parallel: some subtests use t.Setenv, which is incompatible with
+	// parallel parent tests. Individual subtests that do not modify env call
+	// t.Parallel() themselves.
+	dir := t.TempDir()
+
+	tests := []struct {
+		name           string
+		setup          func(t *testing.T)
+		params         func(t *testing.T) domain.StartSessionParams
+		defaultCommand string
+		wantKind       domain.AgentErrorKind
+		wantMsg        string
+		wantNoErr      bool
+		check          func(t *testing.T, lt LaunchTarget)
+	}{
+		{
+			name:           "local mode: binary present and workspace valid",
+			defaultCommand: "sh",
+			params:         func(t *testing.T) domain.StartSessionParams { return makeParams(t, dir, "", "") },
+			wantNoErr:      true,
+			check: func(t *testing.T, lt LaunchTarget) {
+				t.Helper()
+				if lt.RemoteCommand != "" {
+					t.Errorf("RemoteCommand = %q, want empty (local mode)", lt.RemoteCommand)
+				}
+				if lt.Command == "" {
+					t.Error("Command is empty, want resolved path")
+				}
+				if lt.WorkspacePath != dir {
+					t.Errorf("WorkspacePath = %q, want %q", lt.WorkspacePath, dir)
+				}
+			},
+		},
+		{
+			name:           "local mode: multi-token command produces Args",
+			defaultCommand: "sh -c",
+			params:         func(t *testing.T) domain.StartSessionParams { return makeParams(t, dir, "", "") },
+			wantNoErr:      true,
+			check: func(t *testing.T, lt LaunchTarget) {
+				t.Helper()
+				if len(lt.Args) != 1 || lt.Args[0] != "-c" {
+					t.Errorf("Args = %v, want [-c]", lt.Args)
+				}
+			},
+		},
+		{
+			name:           "local mode: binary absent",
+			defaultCommand: "sortie-no-such-binary-xyzzy",
+			params:         func(t *testing.T) domain.StartSessionParams { return makeParams(t, dir, "", "") },
+			wantKind:       domain.ErrAgentNotFound,
+		},
+		{
+			name:           "local mode: workspace invalid",
+			defaultCommand: "sh",
+			params: func(t *testing.T) domain.StartSessionParams {
+				return makeParams(t, filepath.Join(dir, "nope"), "", "")
+			},
+			wantKind: domain.ErrInvalidWorkspaceCwd,
+		},
+		{
+			name:           "ssh mode: ssh present",
+			defaultCommand: "claude",
+			setup: func(t *testing.T) {
+				t.Helper()
+				t.Setenv("PATH", fakeSSHDir(t)+":"+os.Getenv("PATH"))
+			},
+			params: func(t *testing.T) domain.StartSessionParams {
+				return makeParams(t, dir, "user@host", "")
+			},
+			wantNoErr: true,
+			check: func(t *testing.T, lt LaunchTarget) {
+				t.Helper()
+				if lt.RemoteCommand == "" {
+					t.Error("RemoteCommand is empty, want ssh mode")
+				}
+				if lt.SSHHost != "user@host" {
+					t.Errorf("SSHHost = %q, want user@host", lt.SSHHost)
+				}
+				if lt.Args != nil {
+					t.Errorf("Args = %v, want nil in ssh mode", lt.Args)
+				}
+			},
+		},
+		{
+			name:           "ssh mode: ssh absent",
+			defaultCommand: "claude",
+			setup: func(t *testing.T) {
+				t.Helper()
+				t.Setenv("PATH", emptyDir(t))
+			},
+			params: func(t *testing.T) domain.StartSessionParams {
+				return makeParams(t, dir, "user@host", "")
+			},
+			wantKind: domain.ErrAgentNotFound,
+			wantMsg:  "ssh binary not found on orchestrator host",
+		},
+		{
+			name:           "ssh mode: workspace invalid",
+			defaultCommand: "claude",
+			setup: func(t *testing.T) {
+				t.Helper()
+				t.Setenv("PATH", fakeSSHDir(t)+":"+os.Getenv("PATH"))
+			},
+			params: func(t *testing.T) domain.StartSessionParams {
+				return makeParams(t, filepath.Join(dir, "nope"), "user@host", "")
+			},
+			wantKind: domain.ErrInvalidWorkspaceCwd,
+		},
+		{
+			name:           "ssh mode: SSHHost whitespace trimmed",
+			defaultCommand: "claude",
+			setup: func(t *testing.T) {
+				t.Helper()
+				t.Setenv("PATH", fakeSSHDir(t)+":"+os.Getenv("PATH"))
+			},
+			params: func(t *testing.T) domain.StartSessionParams {
+				return makeParams(t, dir, "  user@host  ", "")
+			},
+			wantNoErr: true,
+			check: func(t *testing.T, lt LaunchTarget) {
+				t.Helper()
+				if lt.SSHHost != "user@host" {
+					t.Errorf("SSHHost = %q, want %q (whitespace trimmed)", lt.SSHHost, "user@host")
+				}
+			},
+		},
+		{
+			name:           "empty command",
+			defaultCommand: "",
+			params:         func(t *testing.T) domain.StartSessionParams { return makeParams(t, dir, "", "") },
+			wantKind:       domain.ErrAgentNotFound,
+			wantMsg:        "agent command is empty or whitespace-only",
+		},
+		{
+			name:           "whitespace-only command",
+			defaultCommand: "   ",
+			params:         func(t *testing.T) domain.StartSessionParams { return makeParams(t, dir, "", "") },
+			wantKind:       domain.ErrAgentNotFound,
+			wantMsg:        "agent command is empty or whitespace-only",
+		},
+		{
+			name:           "ssh mode: empty command",
+			defaultCommand: "",
+			params:         func(t *testing.T) domain.StartSessionParams { return makeParams(t, dir, "user@host", "") },
+			wantKind:       domain.ErrAgentNotFound,
+			wantMsg:        "agent command is empty or whitespace-only",
+		},
+		{
+			name:           "params command overrides default",
+			defaultCommand: "sortie-no-such-binary-xyzzy",
+			params: func(t *testing.T) domain.StartSessionParams {
+				return makeParams(t, dir, "", "sh")
+			},
+			wantNoErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.setup == nil {
+				t.Parallel()
+			}
+
+			if tt.setup != nil {
+				tt.setup(t)
+			}
+
+			got, agentErr := ResolveLaunchTarget(tt.params(t), tt.defaultCommand)
+
+			if tt.wantNoErr {
+				if agentErr != nil {
+					t.Fatalf("ResolveLaunchTarget unexpected error: %v", agentErr)
+				}
+				if tt.check != nil {
+					tt.check(t, got)
+				}
+				return
+			}
+
+			if agentErr == nil {
+				t.Fatalf("ResolveLaunchTarget returned no error, want kind %q", tt.wantKind)
+			}
+			if agentErr.Kind != tt.wantKind {
+				t.Errorf("AgentError.Kind = %q, want %q", agentErr.Kind, tt.wantKind)
+			}
+			if tt.wantMsg != "" && agentErr.Message != tt.wantMsg {
+				t.Errorf("AgentError.Message = %q, want %q", agentErr.Message, tt.wantMsg)
+			}
+		})
+	}
+}

--- a/internal/agent/agentcore/tooltracker.go
+++ b/internal/agent/agentcore/tooltracker.go
@@ -1,7 +1,8 @@
 // Package agentcore provides shared utilities used by agent adapter
 // packages. It must not import any specific adapter package (claude,
-// copilot, codex, etc.); its only allowed internal import is
-// internal/domain.
+// copilot, codex, etc.). Its allowed internal imports are
+// internal/domain, internal/agent/procutil, internal/agent/sshutil,
+// and internal/typeutil.
 package agentcore
 
 import "time"

--- a/internal/agent/agentcore/usage.go
+++ b/internal/agent/agentcore/usage.go
@@ -1,0 +1,57 @@
+package agentcore
+
+import "github.com/sortie-ai/sortie/internal/domain"
+
+// UsageAccumulator tracks cumulative token usage across the events of a
+// single agent turn. It is not safe for concurrent use; each RunTurn
+// invocation constructs its own UsageAccumulator and uses it on a single
+// goroutine.
+type UsageAccumulator struct {
+	current domain.TokenUsage
+}
+
+// NewUsageAccumulator returns a zero-value UsageAccumulator ready for use.
+func NewUsageAccumulator() *UsageAccumulator {
+	return &UsageAccumulator{}
+}
+
+// AddDelta adds per-request token delta counts to the running cumulative
+// totals and returns the updated snapshot. ready is true when cumulative
+// output tokens are non-zero, indicating the snapshot is suitable for
+// emission as an EventTokenUsage event. When ready is false the snapshot is
+// valid but the caller should defer emission.
+//
+// TotalTokens in the returned snapshot is always InputTokens + OutputTokens.
+// All arguments must be non-negative; negative values are clamped to 0.
+func (u *UsageAccumulator) AddDelta(input, output, cacheRead int64) (domain.TokenUsage, bool) {
+	if input < 0 {
+		input = 0
+	}
+	if output < 0 {
+		output = 0
+	}
+	if cacheRead < 0 {
+		cacheRead = 0
+	}
+	u.current.InputTokens += input
+	u.current.OutputTokens += output
+	u.current.CacheReadTokens += cacheRead
+	u.current.TotalTokens = u.current.InputTokens + u.current.OutputTokens
+	return u.current, u.current.OutputTokens > 0
+}
+
+// ReplaceCumulative replaces the accumulator's internal state with the
+// complete snapshot in and returns it unchanged. Use this for adapters that
+// receive a single authoritative usage event (e.g., Codex's turn/completed).
+// Subsequent calls to [UsageAccumulator.Snapshot] return in.
+func (u *UsageAccumulator) ReplaceCumulative(in domain.TokenUsage) domain.TokenUsage {
+	u.current = in
+	return in
+}
+
+// Snapshot returns the current cumulative token usage without modifying the
+// accumulator. Returns a zero [domain.TokenUsage] when no deltas have been
+// added and ReplaceCumulative has not been called.
+func (u *UsageAccumulator) Snapshot() domain.TokenUsage {
+	return u.current
+}

--- a/internal/agent/agentcore/usage_test.go
+++ b/internal/agent/agentcore/usage_test.go
@@ -1,0 +1,159 @@
+package agentcore
+
+import (
+	"math/rand/v2"
+	"testing"
+
+	"github.com/sortie-ai/sortie/internal/domain"
+)
+
+func TestUsageAccumulator_SnapshotZeroBeforeAnyCall(t *testing.T) {
+	t.Parallel()
+
+	acc := NewUsageAccumulator()
+	got := acc.Snapshot()
+	if got != (domain.TokenUsage{}) {
+		t.Errorf("Snapshot() = %+v, want zero", got)
+	}
+}
+
+func TestUsageAccumulator_AddDelta_ReadyWhenOutputNonZero(t *testing.T) {
+	t.Parallel()
+
+	acc := NewUsageAccumulator()
+	snap, ready := acc.AddDelta(10, 5, 0)
+	if !ready {
+		t.Error("ready = false, want true when output > 0")
+	}
+	if snap.OutputTokens != 5 {
+		t.Errorf("OutputTokens = %d, want 5", snap.OutputTokens)
+	}
+}
+
+func TestUsageAccumulator_AddDelta_NotReadyWhenOutputZero(t *testing.T) {
+	t.Parallel()
+
+	acc := NewUsageAccumulator()
+	_, ready := acc.AddDelta(10, 0, 3)
+	if ready {
+		t.Error("ready = true, want false when output == 0")
+	}
+}
+
+func TestUsageAccumulator_AddDelta_AccumulatesAcrossCalls(t *testing.T) {
+	t.Parallel()
+
+	acc := NewUsageAccumulator()
+	acc.AddDelta(10, 5, 2)
+	snap, _ := acc.AddDelta(20, 10, 3)
+
+	if snap.InputTokens != 30 {
+		t.Errorf("InputTokens = %d, want 30", snap.InputTokens)
+	}
+	if snap.OutputTokens != 15 {
+		t.Errorf("OutputTokens = %d, want 15", snap.OutputTokens)
+	}
+	if snap.CacheReadTokens != 5 {
+		t.Errorf("CacheReadTokens = %d, want 5", snap.CacheReadTokens)
+	}
+	if snap.TotalTokens != 45 {
+		t.Errorf("TotalTokens = %d, want 45 (InputTokens+OutputTokens)", snap.TotalTokens)
+	}
+}
+
+func TestUsageAccumulator_AddDelta_ClampsNegatives(t *testing.T) {
+	t.Parallel()
+
+	acc := NewUsageAccumulator()
+	snap, _ := acc.AddDelta(-5, -10, -3)
+
+	if snap.InputTokens != 0 {
+		t.Errorf("InputTokens = %d, want 0 (clamped)", snap.InputTokens)
+	}
+	if snap.OutputTokens != 0 {
+		t.Errorf("OutputTokens = %d, want 0 (clamped)", snap.OutputTokens)
+	}
+	if snap.TotalTokens != 0 {
+		t.Errorf("TotalTokens = %d, want 0", snap.TotalTokens)
+	}
+}
+
+func TestUsageAccumulator_ReplaceCumulative_Overwrites(t *testing.T) {
+	t.Parallel()
+
+	acc := NewUsageAccumulator()
+	acc.AddDelta(100, 50, 10)
+
+	in := domain.TokenUsage{
+		InputTokens:     200,
+		OutputTokens:    80,
+		CacheReadTokens: 5,
+		TotalTokens:     280,
+	}
+	got := acc.ReplaceCumulative(in)
+
+	if got != in {
+		t.Errorf("ReplaceCumulative() = %+v, want %+v", got, in)
+	}
+	if snap := acc.Snapshot(); snap != in {
+		t.Errorf("Snapshot() after ReplaceCumulative = %+v, want %+v", snap, in)
+	}
+}
+
+func TestUsageAccumulator_AddDelta_AfterReplaceCumulative(t *testing.T) {
+	t.Parallel()
+
+	acc := NewUsageAccumulator()
+	acc.ReplaceCumulative(domain.TokenUsage{
+		InputTokens:  100,
+		OutputTokens: 50,
+		TotalTokens:  150,
+	})
+	snap, _ := acc.AddDelta(10, 5, 0)
+
+	if snap.InputTokens != 110 {
+		t.Errorf("InputTokens = %d, want 110", snap.InputTokens)
+	}
+	if snap.TotalTokens != snap.InputTokens+snap.OutputTokens {
+		t.Errorf("TotalTokens = %d, want InputTokens+OutputTokens = %d",
+			snap.TotalTokens, snap.InputTokens+snap.OutputTokens)
+	}
+}
+
+func TestUsageAccumulator_Property_TotalAlwaysInputPlusOutput(t *testing.T) {
+	t.Parallel()
+
+	rng := rand.New(rand.NewPCG(12345, 67890))
+	acc := NewUsageAccumulator()
+
+	var prevInput, prevOutput, prevCache int64
+
+	for i := range 100 {
+		input := rng.Int64N(500)
+		output := rng.Int64N(500)
+		cache := rng.Int64N(100)
+
+		snap, _ := acc.AddDelta(input, output, cache)
+
+		if snap.TotalTokens != snap.InputTokens+snap.OutputTokens {
+			t.Errorf("iteration %d: TotalTokens = %d, want InputTokens(%d)+OutputTokens(%d)=%d",
+				i, snap.TotalTokens, snap.InputTokens, snap.OutputTokens,
+				snap.InputTokens+snap.OutputTokens)
+		}
+		if snap.InputTokens < prevInput {
+			t.Errorf("iteration %d: InputTokens decreased from %d to %d",
+				i, prevInput, snap.InputTokens)
+		}
+		if snap.OutputTokens < prevOutput {
+			t.Errorf("iteration %d: OutputTokens decreased from %d to %d",
+				i, prevOutput, snap.OutputTokens)
+		}
+		if snap.CacheReadTokens < prevCache {
+			t.Errorf("iteration %d: CacheReadTokens decreased from %d to %d",
+				i, prevCache, snap.CacheReadTokens)
+		}
+		prevInput = snap.InputTokens
+		prevOutput = snap.OutputTokens
+		prevCache = snap.CacheReadTokens
+	}
+}

--- a/internal/agent/agentcore/workspace.go
+++ b/internal/agent/agentcore/workspace.go
@@ -1,0 +1,52 @@
+package agentcore
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/sortie-ai/sortie/internal/domain"
+)
+
+// ResolveWorkspace validates path for use as an agent workspace directory.
+// It performs four checks in order: non-empty, resolvable to absolute form,
+// existence, and directory kind. On success it returns the absolute resolved
+// path. On failure it returns a [*domain.AgentError] with Kind
+// [domain.ErrInvalidWorkspaceCwd].
+//
+// ResolveWorkspace does not check workspace root containment; that invariant
+// is enforced by the workspace manager before StartSession is called.
+func ResolveWorkspace(path string) (string, *domain.AgentError) {
+	if path == "" {
+		return "", &domain.AgentError{
+			Kind:    domain.ErrInvalidWorkspaceCwd,
+			Message: "empty workspace path",
+		}
+	}
+
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return "", &domain.AgentError{
+			Kind:    domain.ErrInvalidWorkspaceCwd,
+			Message: "cannot resolve workspace path",
+			Err:     err,
+		}
+	}
+
+	fi, err := os.Stat(absPath)
+	if err != nil {
+		return "", &domain.AgentError{
+			Kind:    domain.ErrInvalidWorkspaceCwd,
+			Message: "workspace path does not exist",
+			Err:     err,
+		}
+	}
+
+	if !fi.IsDir() {
+		return "", &domain.AgentError{
+			Kind:    domain.ErrInvalidWorkspaceCwd,
+			Message: "workspace path is not a directory",
+		}
+	}
+
+	return absPath, nil
+}

--- a/internal/agent/agentcore/workspace_test.go
+++ b/internal/agent/agentcore/workspace_test.go
@@ -1,0 +1,100 @@
+package agentcore
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/sortie-ai/sortie/internal/domain"
+)
+
+func TestResolveWorkspace(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	file := filepath.Join(dir, "somefile")
+	if err := os.WriteFile(file, []byte("x"), 0o600); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	symlink := filepath.Join(dir, "link")
+	if err := os.Symlink(dir, symlink); err != nil {
+		if runtime.GOOS == "windows" {
+			t.Skip("symlink creation requires elevated privileges on Windows")
+		}
+		t.Fatalf("setup symlink: %v", err)
+	}
+
+	tests := []struct {
+		name      string
+		path      string
+		wantKind  domain.AgentErrorKind
+		wantMsg   string
+		wantNoErr bool
+	}{
+		{
+			name:     "empty path",
+			path:     "",
+			wantKind: domain.ErrInvalidWorkspaceCwd,
+			wantMsg:  "empty workspace path",
+		},
+		{
+			name:      "valid directory",
+			path:      dir,
+			wantNoErr: true,
+		},
+		{
+			name:      "relative path resolving to valid directory",
+			path:      ".",
+			wantNoErr: true,
+		},
+		{
+			name:     "non-existent path",
+			path:     filepath.Join(dir, "does-not-exist"),
+			wantKind: domain.ErrInvalidWorkspaceCwd,
+			wantMsg:  "workspace path does not exist",
+		},
+		{
+			name:     "file not a directory",
+			path:     file,
+			wantKind: domain.ErrInvalidWorkspaceCwd,
+			wantMsg:  "workspace path is not a directory",
+		},
+		{
+			name:      "symlink to valid directory",
+			path:      symlink,
+			wantNoErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, agentErr := ResolveWorkspace(tt.path)
+
+			if tt.wantNoErr {
+				if agentErr != nil {
+					t.Fatalf("ResolveWorkspace(%q) unexpected error: %v", tt.path, agentErr)
+				}
+				if got == "" {
+					t.Errorf("ResolveWorkspace(%q) = %q, want non-empty path", tt.path, got)
+				}
+				if !filepath.IsAbs(got) {
+					t.Errorf("ResolveWorkspace(%q) = %q, want absolute path", tt.path, got)
+				}
+				return
+			}
+
+			if agentErr == nil {
+				t.Fatalf("ResolveWorkspace(%q) = %q, want error with kind %q", tt.path, got, tt.wantKind)
+			}
+			if agentErr.Kind != tt.wantKind {
+				t.Errorf("AgentError.Kind = %q, want %q", agentErr.Kind, tt.wantKind)
+			}
+			if tt.wantMsg != "" && agentErr.Message != tt.wantMsg {
+				t.Errorf("AgentError.Message = %q, want %q", agentErr.Message, tt.wantMsg)
+			}
+		})
+	}
+}

--- a/internal/agent/claude/claude.go
+++ b/internal/agent/claude/claude.go
@@ -8,14 +8,12 @@ package claude
 
 import (
 	"bufio"
-	"cmp"
 	"context"
 	"encoding/json"
 	"fmt"
 	"log/slog"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
@@ -58,25 +56,11 @@ type ClaudeCodeAdapter struct {
 // Internal. It tracks the Claude Code session ID and subprocess
 // handle across turns.
 type sessionState struct {
-	workspacePath   string
-	command         string
+	target          agentcore.LaunchTarget
 	claudeSessionID string
 	isContinuation  bool
 	agentConfig     domain.AgentConfig
 	turnCount       int
-
-	// sshHost is the SSH destination for remote execution. Empty for
-	// local mode.
-	sshHost string
-
-	// remoteCommand is the agent command to run on the remote host
-	// when sshHost is non-empty. Empty for local mode. The local
-	// command field holds the resolved path to the ssh binary.
-	remoteCommand string
-
-	// sshStrictHostKeyChecking is the OpenSSH StrictHostKeyChecking
-	// value. Empty means accept-new.
-	sshStrictHostKeyChecking string
 
 	// mcpConfigPath is the worker-generated MCP config file path.
 	mcpConfigPath string
@@ -97,71 +81,13 @@ func NewClaudeCodeAdapter(config map[string]any) (domain.AgentAdapter, error) {
 	return &ClaudeCodeAdapter{passthrough: pt}, nil
 }
 
-// StartSession validates the workspace path, resolves the claude
-// binary, and initializes per-session state. No subprocess is spawned;
-// that happens in [ClaudeCodeAdapter.RunTurn].
+// StartSession validates the workspace path, resolves the claude binary, and
+// initializes per-session state. No subprocess is spawned; that happens in
+// [ClaudeCodeAdapter.RunTurn].
 func (a *ClaudeCodeAdapter) StartSession(_ context.Context, params domain.StartSessionParams) (domain.Session, error) {
-	if params.WorkspacePath == "" {
-		return domain.Session{}, &domain.AgentError{
-			Kind:    domain.ErrInvalidWorkspaceCwd,
-			Message: "empty workspace path",
-		}
-	}
-
-	absPath, err := filepath.Abs(params.WorkspacePath)
-	if err != nil {
-		return domain.Session{}, &domain.AgentError{
-			Kind:    domain.ErrInvalidWorkspaceCwd,
-			Message: "cannot resolve workspace path",
-			Err:     err,
-		}
-	}
-
-	fi, err := os.Stat(absPath)
-	if err != nil {
-		return domain.Session{}, &domain.AgentError{
-			Kind:    domain.ErrInvalidWorkspaceCwd,
-			Message: "workspace path does not exist",
-			Err:     err,
-		}
-	}
-	if !fi.IsDir() {
-		return domain.Session{}, &domain.AgentError{
-			Kind:    domain.ErrInvalidWorkspaceCwd,
-			Message: "workspace path is not a directory",
-		}
-	}
-
-	command := cmp.Or(params.AgentConfig.Command, "claude")
-
-	var resolvedPath string
-	var sshHost string
-	var remoteCommand string
-
-	if params.SSHHost != "" {
-		// SSH mode: resolve "ssh" locally, skip local LookPath for
-		// the agent command (it resolves on the remote host).
-		sshPath, lookErr := exec.LookPath("ssh")
-		if lookErr != nil {
-			return domain.Session{}, &domain.AgentError{
-				Kind:    domain.ErrAgentNotFound,
-				Message: "ssh binary not found on orchestrator host",
-				Err:     lookErr,
-			}
-		}
-		resolvedPath = sshPath
-		sshHost = params.SSHHost
-		remoteCommand = command
-	} else {
-		var lookErr error
-		resolvedPath, lookErr = exec.LookPath(command)
-		if lookErr != nil {
-			return domain.Session{}, &domain.AgentError{
-				Kind:    domain.ErrAgentNotFound,
-				Message: fmt.Sprintf("agent command %q not found", command),
-				Err:     lookErr,
-			}
-		}
+	target, agentErr := agentcore.ResolveLaunchTarget(params, "claude")
+	if agentErr != nil {
+		return domain.Session{}, agentErr
 	}
 
 	isContinuation := false
@@ -174,15 +100,11 @@ func (a *ClaudeCodeAdapter) StartSession(_ context.Context, params domain.StartS
 	}
 
 	state := &sessionState{
-		workspacePath:            absPath,
-		command:                  resolvedPath,
-		claudeSessionID:          sessionUUID,
-		isContinuation:           isContinuation,
-		agentConfig:              params.AgentConfig,
-		sshHost:                  sshHost,
-		remoteCommand:            remoteCommand,
-		sshStrictHostKeyChecking: params.SSHStrictHostKeyChecking,
-		mcpConfigPath:            params.MCPConfigPath,
+		target:          target,
+		claudeSessionID: sessionUUID,
+		isContinuation:  isContinuation,
+		agentConfig:     params.AgentConfig,
+		mcpConfigPath:   params.MCPConfigPath,
 	}
 
 	return domain.Session{
@@ -223,20 +145,21 @@ func (a *ClaudeCodeAdapter) RunTurn(ctx context.Context, session domain.Session,
 	defer cancelCmd()
 
 	var cmd *exec.Cmd
-	if state.sshHost != "" {
-		sshArgs := sshutil.BuildSSHArgs(state.sshHost, state.workspacePath, state.remoteCommand, args, sshutil.SSHOptions{
-			StrictHostKeyChecking: state.sshStrictHostKeyChecking,
+	if state.target.RemoteCommand != "" {
+		sshArgs := sshutil.BuildSSHArgs(state.target.SSHHost, state.target.WorkspacePath, state.target.RemoteCommand, args, sshutil.SSHOptions{
+			StrictHostKeyChecking: state.target.SSHStrictHostKeyChecking,
 		})
-		cmd = exec.CommandContext(cmdCtx, state.command, sshArgs...) //nolint:gosec // args are constructed programmatically with shell quoting
+		cmd = exec.CommandContext(cmdCtx, state.target.Command, sshArgs...) //nolint:gosec // args are constructed programmatically with shell quoting
 	} else {
-		cmd = exec.CommandContext(cmdCtx, state.command, args...) //nolint:gosec // args are constructed programmatically
+		allArgs := append(state.target.Args, args...)                       //nolint:gocritic // intentional: target.Args has cap==len so append always allocates
+		cmd = exec.CommandContext(cmdCtx, state.target.Command, allArgs...) //nolint:gosec // args are constructed programmatically
 	}
 	procutil.SetProcessGroup(cmd)
 	cmd.Cancel = func() error {
 		return procutil.SignalGraceful(cmd.Process.Pid)
 	}
 	cmd.WaitDelay = 5 * time.Second
-	cmd.Dir = state.workspacePath
+	cmd.Dir = state.target.WorkspacePath
 	cmd.Env = os.Environ()
 
 	stdoutPipe, err := cmd.StdoutPipe()
@@ -262,11 +185,7 @@ func (a *ClaudeCodeAdapter) RunTurn(ctx context.Context, session domain.Session,
 	if err != nil {
 		state.mu.Unlock()
 		if ctx.Err() != nil {
-			params.OnEvent(domain.AgentEvent{
-				Type:      domain.EventTurnCancelled,
-				Timestamp: time.Now().UTC(),
-				Message:   "context cancelled",
-			})
+			agentcore.EmitTurnCancelled(params.OnEvent, "context cancelled")
 			return domain.TurnResult{
 					SessionID:  state.claudeSessionID,
 					ExitReason: domain.EventTurnCancelled,
@@ -301,18 +220,12 @@ func (a *ClaudeCodeAdapter) RunTurn(ctx context.Context, session domain.Session,
 	var usage domain.TokenUsage
 	inFlight := agentcore.NewToolTracker()
 
-	// Cumulative accumulators for per-assistant-message token usage.
-	// Claude Code assistant message usage fields are per-request (not
-	// cumulative). The orchestrator delta algorithm requires cumulative
-	// values, so we accumulate here and emit cumulative totals.
+	acc := agentcore.NewUsageAccumulator()
 	var (
-		cumulativeInput     int64
-		cumulativeOutput    int64
-		cumulativeCacheRead int64
-		lastModel           string
-		emittedUsage        bool
-		apiCallStart        time.Time // monotonic timestamp of the last event before an API call
-		emittedAPITiming    bool      // true once per-request APIDurationMS has been emitted
+		lastModel        string
+		emittedUsage     bool
+		apiCallStart     time.Time // monotonic timestamp of the last event before an API call
+		emittedAPITiming bool      // true once per-request APIDurationMS has been emitted
 	)
 
 	for scanner.Scan() {
@@ -321,11 +234,7 @@ func (a *ClaudeCodeAdapter) RunTurn(ctx context.Context, session domain.Session,
 
 		event, parseErr := parseEvent(line)
 		if parseErr != nil {
-			params.OnEvent(domain.AgentEvent{
-				Type:      domain.EventMalformed,
-				Timestamp: now,
-				Message:   typeutil.TruncateRunes(string(line), 500),
-			})
+			agentcore.EmitMalformed(params.OnEvent, line)
 			continue
 		}
 
@@ -336,13 +245,7 @@ func (a *ClaudeCodeAdapter) RunTurn(ctx context.Context, session domain.Session,
 				if event.SessionID != "" {
 					state.claudeSessionID = event.SessionID
 				}
-				params.OnEvent(domain.AgentEvent{
-					Type:      domain.EventSessionStarted,
-					Timestamp: now,
-					AgentPID:  strconv.Itoa(cmd.Process.Pid),
-					SessionID: state.claudeSessionID,
-					Message:   "session started",
-				})
+				agentcore.EmitSessionStarted(params.OnEvent, strconv.Itoa(cmd.Process.Pid), state.claudeSessionID)
 				// The first API call is imminent. Start the monotonic timer.
 				// This first measurement includes agent initialization overhead
 				// (workspace scanning, .claude.json parsing, system prompt
@@ -351,17 +254,9 @@ func (a *ClaudeCodeAdapter) RunTurn(ctx context.Context, session domain.Session,
 				// overhead.
 				apiCallStart = time.Now()
 			case "api_retry":
-				params.OnEvent(domain.AgentEvent{
-					Type:      domain.EventNotification,
-					Timestamp: now,
-					Message:   formatAPIRetry(event),
-				})
+				agentcore.EmitNotification(params.OnEvent, formatAPIRetry(event))
 			default:
-				params.OnEvent(domain.AgentEvent{
-					Type:      domain.EventNotification,
-					Timestamp: now,
-					Message:   event.summary(),
-				})
+				agentcore.EmitNotification(params.OnEvent, event.summary())
 			}
 
 		case "assistant":
@@ -373,26 +268,18 @@ func (a *ClaudeCodeAdapter) RunTurn(ctx context.Context, session domain.Session,
 						lastModel = meta.Model
 					}
 					if meta.Usage != nil {
-						cumulativeInput += meta.Usage.InputTokens
-						cumulativeOutput += meta.Usage.OutputTokens
-						cumulativeCacheRead += meta.Usage.CacheReadInputTokens
+						snapshot, ready := acc.AddDelta(meta.Usage.InputTokens, meta.Usage.OutputTokens, meta.Usage.CacheReadInputTokens)
 						// Claude Code 2.x: tool_use-only assistant messages may
 						// carry output_tokens=0 (streaming message_start snapshot).
 						// Defer the token_usage event until cumulative output is
 						// non-zero so the orchestrator never receives an event
 						// claiming zero output tokens for a real API turn.
-						if cumulativeOutput > 0 {
-							cumulativeTotal := cumulativeInput + cumulativeOutput
-							usage = domain.TokenUsage{
-								InputTokens:     cumulativeInput,
-								OutputTokens:    cumulativeOutput,
-								TotalTokens:     cumulativeTotal,
-								CacheReadTokens: cumulativeCacheRead,
-							}
+						if ready {
+							usage = snapshot
 							tokenEvt := domain.AgentEvent{
 								Type:      domain.EventTokenUsage,
 								Timestamp: now,
-								Usage:     usage,
+								Usage:     snapshot,
 								Model:     lastModel,
 							}
 							if !apiCallStart.IsZero() {
@@ -418,11 +305,7 @@ func (a *ClaudeCodeAdapter) RunTurn(ctx context.Context, session domain.Session,
 			// ToolTracker.Begin stores time.Now() internally, so no separate
 			// monotonic timestamp is needed before calling processToolBlocks.
 			processToolBlocks(event.contentBlocks(), inFlight, now, params.OnEvent)
-			params.OnEvent(domain.AgentEvent{
-				Type:      domain.EventNotification,
-				Timestamp: now,
-				Message:   summarizeAssistant(event),
-			})
+			agentcore.EmitNotification(params.OnEvent, summarizeAssistant(event))
 
 		case "user":
 			// Claude Code emits tool results as user-role messages.
@@ -434,24 +317,23 @@ func (a *ClaudeCodeAdapter) RunTurn(ctx context.Context, session domain.Session,
 		case "result":
 			captured := event
 			lastResult = &captured
-			usage = normalizeUsage(event.Usage)
 			// Only emit token_usage from the result event when no
 			// per-assistant-message usage was already emitted. This
 			// avoids inflating APIRequestCount in the orchestrator.
 			if !emittedUsage {
+				usage = acc.ReplaceCumulative(normalizeUsage(event.Usage))
 				params.OnEvent(domain.AgentEvent{
 					Type:      domain.EventTokenUsage,
 					Timestamp: now,
 					Usage:     usage,
 					Model:     lastModel,
 				})
+			} else {
+				usage = acc.Snapshot()
 			}
 
 		case "stream_event":
-			params.OnEvent(domain.AgentEvent{
-				Type:      domain.EventNotification,
-				Timestamp: now,
-			})
+			agentcore.EmitNotification(params.OnEvent, "")
 
 		default:
 			params.OnEvent(domain.AgentEvent{
@@ -477,12 +359,7 @@ func (a *ClaudeCodeAdapter) RunTurn(ctx context.Context, session domain.Session,
 		// Context cancellation propagates through exec.CommandContext
 		// and can surface as a pipe read error. Treat as cancellation.
 		if ctx.Err() != nil {
-			now := time.Now().UTC()
-			params.OnEvent(domain.AgentEvent{
-				Type:      domain.EventTurnCancelled,
-				Timestamp: now,
-				Message:   "context cancelled",
-			})
+			agentcore.EmitTurnCancelled(params.OnEvent, "context cancelled")
 			return domain.TurnResult{
 					SessionID:  state.claudeSessionID,
 					ExitReason: domain.EventTurnCancelled,
@@ -495,12 +372,7 @@ func (a *ClaudeCodeAdapter) RunTurn(ctx context.Context, session domain.Session,
 		}
 
 		procutil.EmitWarnLines(stderrLines, logger)
-		now := time.Now().UTC()
-		params.OnEvent(domain.AgentEvent{
-			Type:      domain.EventTurnFailed,
-			Timestamp: now,
-			Message:   "stdout read error: " + scanErr.Error(),
-		})
+		agentcore.EmitTurnFailed(params.OnEvent, "stdout read error: "+scanErr.Error(), 0)
 		return domain.TurnResult{
 				SessionID:  state.claudeSessionID,
 				ExitReason: domain.EventTurnFailed,
@@ -529,14 +401,8 @@ func (a *ClaudeCodeAdapter) RunTurn(ctx context.Context, session domain.Session,
 	state.waitCh = nil
 	state.mu.Unlock()
 
-	now := time.Now().UTC()
-
 	if ctx.Err() != nil {
-		params.OnEvent(domain.AgentEvent{
-			Type:      domain.EventTurnCancelled,
-			Timestamp: now,
-			Message:   "context cancelled",
-		})
+		agentcore.EmitTurnCancelled(params.OnEvent, "context cancelled")
 		return domain.TurnResult{
 				SessionID:  state.claudeSessionID,
 				ExitReason: domain.EventTurnCancelled,
@@ -552,11 +418,7 @@ func (a *ClaudeCodeAdapter) RunTurn(ctx context.Context, session domain.Session,
 
 	if exitCode == 127 {
 		procutil.EmitWarnLines(stderrLines, logger)
-		params.OnEvent(domain.AgentEvent{
-			Type:      domain.EventTurnFailed,
-			Timestamp: now,
-			Message:   "claude binary not found",
-		})
+		agentcore.EmitTurnFailed(params.OnEvent, "claude binary not found", 0)
 		return domain.TurnResult{
 				SessionID:  state.claudeSessionID,
 				ExitReason: domain.EventTurnFailed,
@@ -568,11 +430,7 @@ func (a *ClaudeCodeAdapter) RunTurn(ctx context.Context, session domain.Session,
 	}
 
 	if procutil.WasSignaled(waitErr) {
-		params.OnEvent(domain.AgentEvent{
-			Type:      domain.EventTurnCancelled,
-			Timestamp: now,
-			Message:   "killed by signal",
-		})
+		agentcore.EmitTurnCancelled(params.OnEvent, "killed by signal")
 		return domain.TurnResult{
 				SessionID:  state.claudeSessionID,
 				ExitReason: domain.EventTurnCancelled,
@@ -591,12 +449,7 @@ func (a *ClaudeCodeAdapter) RunTurn(ctx context.Context, session domain.Session,
 			turnAPIDuration = lastResult.DurationAPI
 		}
 		if lastResult.Subtype == "success" && !lastResult.IsError {
-			params.OnEvent(domain.AgentEvent{
-				Type:          domain.EventTurnCompleted,
-				Timestamp:     now,
-				Message:       typeutil.TruncateRunes(lastResult.Result, 500),
-				APIDurationMS: turnAPIDuration,
-			})
+			agentcore.EmitTurnCompleted(params.OnEvent, typeutil.TruncateRunes(lastResult.Result, 500), turnAPIDuration)
 			return domain.TurnResult{
 				SessionID:  state.claudeSessionID,
 				ExitReason: domain.EventTurnCompleted,
@@ -604,12 +457,7 @@ func (a *ClaudeCodeAdapter) RunTurn(ctx context.Context, session domain.Session,
 			}, nil
 		}
 		procutil.EmitWarnLines(stderrLines, logger)
-		params.OnEvent(domain.AgentEvent{
-			Type:          domain.EventTurnFailed,
-			Timestamp:     now,
-			Message:       lastResult.Subtype,
-			APIDurationMS: turnAPIDuration,
-		})
+		agentcore.EmitTurnFailed(params.OnEvent, lastResult.Subtype, turnAPIDuration)
 		return domain.TurnResult{
 				SessionID:  state.claudeSessionID,
 				ExitReason: domain.EventTurnFailed,
@@ -622,11 +470,7 @@ func (a *ClaudeCodeAdapter) RunTurn(ctx context.Context, session domain.Session,
 
 	if exitCode != 0 {
 		procutil.EmitWarnLines(stderrLines, logger)
-		params.OnEvent(domain.AgentEvent{
-			Type:      domain.EventTurnFailed,
-			Timestamp: now,
-			Message:   "non-zero exit",
-		})
+		agentcore.EmitTurnFailed(params.OnEvent, "non-zero exit", 0)
 		return domain.TurnResult{
 				SessionID:  state.claudeSessionID,
 				ExitReason: domain.EventTurnFailed,
@@ -638,14 +482,10 @@ func (a *ClaudeCodeAdapter) RunTurn(ctx context.Context, session domain.Session,
 	}
 
 	// No result event and exit code 0.
-	if cumulativeOutput == 0 {
+	if acc.Snapshot().OutputTokens == 0 {
 		procutil.EmitWarnLines(stderrLines, logger)
 		logger.Warn("agent exited without producing output, treating as failure")
-		params.OnEvent(domain.AgentEvent{
-			Type:      domain.EventTurnFailed,
-			Timestamp: now,
-			Message:   "agent exited without producing output",
-		})
+		agentcore.EmitTurnFailed(params.OnEvent, "agent exited without producing output", 0)
 		return domain.TurnResult{
 				SessionID:  state.claudeSessionID,
 				ExitReason: domain.EventTurnFailed,
@@ -656,10 +496,7 @@ func (a *ClaudeCodeAdapter) RunTurn(ctx context.Context, session domain.Session,
 			}
 	}
 
-	params.OnEvent(domain.AgentEvent{
-		Type:      domain.EventTurnCompleted,
-		Timestamp: now,
-	})
+	agentcore.EmitTurnCompleted(params.OnEvent, "", 0)
 	return domain.TurnResult{
 		SessionID:  state.claudeSessionID,
 		ExitReason: domain.EventTurnCompleted,

--- a/internal/agent/claude/claude_test.go
+++ b/internal/agent/claude/claude_test.go
@@ -1280,7 +1280,7 @@ func TestRunTurn_PanicsOnNilOnEvent(t *testing.T) {
 	adapter, _ := NewClaudeCodeAdapter(map[string]any{})
 	session := domain.Session{
 		ID:       "panic-test",
-		Internal: &sessionState{command: "/bin/sh", workspacePath: t.TempDir()},
+		Internal: &sessionState{target: agentcore.LaunchTarget{Command: "/bin/sh", WorkspacePath: t.TempDir()}},
 	}
 
 	defer func() {

--- a/internal/agent/codex/codex.go
+++ b/internal/agent/codex/codex.go
@@ -16,9 +16,7 @@ import (
 	"log/slog"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"strconv"
-	"strings"
 	"sync"
 	"time"
 
@@ -53,18 +51,14 @@ type CodexAdapter struct {
 // Internal. It tracks the persistent app-server subprocess, thread
 // ID, and turn state across the session lifetime.
 type sessionState struct {
-	workspacePath string
-	command       string
-	agentConfig   domain.AgentConfig
-	turnCount     int
+	target      agentcore.LaunchTarget
+	agentConfig domain.AgentConfig
+	turnCount   int
 
 	threadID      string
 	nextRequestID int64
 
-	sshHost                  string
-	remoteCommand            string
-	sshStrictHostKeyChecking string
-	mcpConfigPath            string
+	mcpConfigPath string
 
 	// mu guards proc, waitCh, stdin, stdout, and stderrCollector for
 	// concurrent access from StopSession and the event read loop.
@@ -104,109 +98,33 @@ func NewCodexAdapter(config map[string]any) (domain.AgentAdapter, error) {
 	return adapter, nil
 }
 
-// StartSession validates the workspace path, resolves the codex
-// binary, launches the app-server subprocess, performs the
-// initialization handshake, authenticates if needed, and starts or
-// resumes a thread.
+// StartSession validates the workspace path, resolves the codex binary,
+// launches the app-server subprocess, performs the initialization handshake,
+// authenticates if needed, and starts or resumes a thread.
 func (a *CodexAdapter) StartSession(ctx context.Context, params domain.StartSessionParams) (domain.Session, error) {
-	if params.WorkspacePath == "" {
-		return domain.Session{}, &domain.AgentError{
-			Kind:    domain.ErrInvalidWorkspaceCwd,
-			Message: "empty workspace path",
-		}
+	target, agentErr := agentcore.ResolveLaunchTarget(params, "codex app-server")
+	if agentErr != nil {
+		return domain.Session{}, agentErr
 	}
-
-	absPath, err := filepath.Abs(params.WorkspacePath)
-	if err != nil {
-		return domain.Session{}, &domain.AgentError{
-			Kind:    domain.ErrInvalidWorkspaceCwd,
-			Message: "cannot resolve workspace path",
-			Err:     err,
-		}
-	}
-
-	fi, err := os.Stat(absPath)
-	if err != nil {
-		return domain.Session{}, &domain.AgentError{
-			Kind:    domain.ErrInvalidWorkspaceCwd,
-			Message: "workspace path does not exist",
-			Err:     err,
-		}
-	}
-	if !fi.IsDir() {
-		return domain.Session{}, &domain.AgentError{
-			Kind:    domain.ErrInvalidWorkspaceCwd,
-			Message: "workspace path is not a directory",
-		}
-	}
-
-	command := cmp.Or(params.AgentConfig.Command, "codex app-server")
 
 	state := &sessionState{
-		workspacePath:            absPath,
-		agentConfig:              params.AgentConfig,
-		sshStrictHostKeyChecking: params.SSHStrictHostKeyChecking,
-		mcpConfigPath:            params.MCPConfigPath,
+		target:        target,
+		agentConfig:   params.AgentConfig,
+		mcpConfigPath: params.MCPConfigPath,
 	}
 
-	var cmdPath string
-	var cmdArgs []string
-
-	sshHostTrimmed := strings.TrimSpace(params.SSHHost)
-	if sshHostTrimmed != "" {
-		sshPath, lookErr := exec.LookPath("ssh")
-		if lookErr != nil {
-			return domain.Session{}, &domain.AgentError{
-				Kind:    domain.ErrAgentNotFound,
-				Message: "ssh binary not found on orchestrator host",
-				Err:     lookErr,
-			}
-		}
-
-		// Build the remote command, prefixing CODEX_API_KEY if present
-		// so it reaches the remote shell.
-		remoteCmd := command
-		if apiKey := os.Getenv("CODEX_API_KEY"); apiKey != "" {
-			remoteCmd = fmt.Sprintf("CODEX_API_KEY=%s %s", sshutil.ShellQuote(apiKey), command)
-		}
-
-		sshArgs := sshutil.BuildSSHArgs(sshHostTrimmed, absPath, remoteCmd, nil, sshutil.SSHOptions{
-			StrictHostKeyChecking: params.SSHStrictHostKeyChecking,
+	var cmd *exec.Cmd
+	if target.RemoteCommand != "" {
+		remoteCmd := buildSSHRemoteCmd(target.RemoteCommand, os.Getenv("CODEX_API_KEY"))
+		sshArgs := sshutil.BuildSSHArgs(target.SSHHost, target.WorkspacePath, remoteCmd, nil, sshutil.SSHOptions{
+			StrictHostKeyChecking: target.SSHStrictHostKeyChecking,
 		})
-
-		cmdPath = sshPath
-		cmdArgs = sshArgs
-		state.command = sshPath
-		state.sshHost = sshHostTrimmed
-		state.remoteCommand = command
+		cmd = exec.CommandContext(ctx, target.Command, sshArgs...) //nolint:gosec // args are constructed programmatically with shell quoting
 	} else {
-		// Local mode: the command may be "codex app-server" (with args).
-		// Split on first space to extract binary and arguments.
-		parts := strings.Fields(command)
-		if len(parts) == 0 {
-			return domain.Session{}, &domain.AgentError{
-				Kind:    domain.ErrAgentNotFound,
-				Message: "agent command is empty or whitespace-only",
-			}
-		}
-		resolved, lookErr := exec.LookPath(parts[0])
-		if lookErr != nil {
-			return domain.Session{}, &domain.AgentError{
-				Kind:    domain.ErrAgentNotFound,
-				Message: fmt.Sprintf("agent command %q not found", parts[0]),
-				Err:     lookErr,
-			}
-		}
-		cmdPath = resolved
-		if len(parts) > 1 {
-			cmdArgs = parts[1:]
-		}
-		state.command = resolved
+		cmd = exec.CommandContext(ctx, target.Command, target.Args...) //nolint:gosec // args are constructed programmatically
 	}
-
-	cmd := exec.CommandContext(ctx, cmdPath, cmdArgs...) //nolint:gosec // args are constructed programmatically
 	procutil.SetProcessGroup(cmd)
-	cmd.Dir = absPath
+	cmd.Dir = target.WorkspacePath
 	cmd.Env = os.Environ()
 
 	stdinPipe, err := cmd.StdinPipe()
@@ -420,7 +338,7 @@ func (a *CodexAdapter) RunTurn(ctx context.Context, session domain.Session, para
 	turnParams := map[string]any{
 		"threadId": state.threadID,
 		"input":    []map[string]any{{"type": "text", "text": params.Prompt}},
-		"cwd":      state.workspacePath,
+		"cwd":      state.target.WorkspacePath,
 	}
 
 	if state.turnCount == 1 || a.passthrough.TurnSandboxPolicy != nil {
@@ -500,6 +418,7 @@ func (a *CodexAdapter) RunTurn(ctx context.Context, session domain.Session, para
 	turnID := turnResult.Turn.ID
 
 	inFlight := agentcore.NewToolTracker()
+	acc := agentcore.NewUsageAccumulator()
 	var usage domain.TokenUsage
 	var toolWg sync.WaitGroup
 	toolEventCh := make(chan domain.AgentEvent, 8)
@@ -513,31 +432,16 @@ func (a *CodexAdapter) RunTurn(ctx context.Context, session domain.Session, para
 		if !m.IsNotification {
 			continue
 		}
-		now := time.Now().UTC()
 		method := m.Notification.Method
 		switch method {
 		case "turn/started":
 			if state.turnCount == 1 {
-				params.OnEvent(domain.AgentEvent{
-					Type:      domain.EventSessionStarted,
-					Timestamp: now,
-					SessionID: state.threadID,
-					AgentPID:  session.AgentPID,
-					Message:   "session started",
-				})
+				agentcore.EmitSessionStarted(params.OnEvent, session.AgentPID, state.threadID)
 			} else {
-				params.OnEvent(domain.AgentEvent{
-					Type:      domain.EventNotification,
-					Timestamp: now,
-					Message:   "turn started",
-				})
+				agentcore.EmitNotification(params.OnEvent, "turn started")
 			}
 		default:
-			params.OnEvent(domain.AgentEvent{
-				Type:      domain.EventNotification,
-				Timestamp: now,
-				Message:   method,
-			})
+			agentcore.EmitNotification(params.OnEvent, method)
 		}
 	}
 
@@ -580,12 +484,7 @@ func (a *CodexAdapter) RunTurn(ctx context.Context, session domain.Session, para
 					}
 			}
 			if msg.Err != nil {
-				now := time.Now().UTC()
-				params.OnEvent(domain.AgentEvent{
-					Type:      domain.EventTurnFailed,
-					Timestamp: now,
-					Message:   msg.Err.Error(),
-				})
+				agentcore.EmitTurnFailed(params.OnEvent, msg.Err.Error(), 0)
 				go func() { toolWg.Wait(); close(toolEventCh) }()
 				for evt := range toolEventCh {
 					params.OnEvent(evt)
@@ -616,19 +515,9 @@ func (a *CodexAdapter) RunTurn(ctx context.Context, session domain.Session, para
 			switch method {
 			case "turn/started":
 				if state.turnCount == 1 {
-					params.OnEvent(domain.AgentEvent{
-						Type:      domain.EventSessionStarted,
-						Timestamp: now,
-						SessionID: state.threadID,
-						AgentPID:  session.AgentPID,
-						Message:   "session started",
-					})
+					agentcore.EmitSessionStarted(params.OnEvent, session.AgentPID, state.threadID)
 				} else {
-					params.OnEvent(domain.AgentEvent{
-						Type:      domain.EventNotification,
-						Timestamp: now,
-						Message:   "turn started",
-					})
+					agentcore.EmitNotification(params.OnEvent, "turn started")
 				}
 
 			case "turn/completed":
@@ -638,18 +527,14 @@ func (a *CodexAdapter) RunTurn(ctx context.Context, session domain.Session, para
 				}
 
 				if tc.Usage != nil {
-					usage = normalizeUsage(tc.Usage)
+					usage = acc.ReplaceCumulative(normalizeUsage(tc.Usage))
 				}
 				exitReason := mapTurnStatus(tc.Turn.Status)
 
 				if tc.Turn.Status == "failed" && tc.Turn.Error != nil {
 					kind := mapCodexErrorInfo(tc.Turn.Error.CodexErrorInfo)
 					errMsg := tc.Turn.Error.Message
-					params.OnEvent(domain.AgentEvent{
-						Type:      domain.EventTurnFailed,
-						Timestamp: now,
-						Message:   errMsg,
-					})
+					agentcore.EmitTurnFailed(params.OnEvent, errMsg, 0)
 					params.OnEvent(domain.AgentEvent{
 						Type:      domain.EventTokenUsage,
 						Timestamp: now,
@@ -669,11 +554,14 @@ func (a *CodexAdapter) RunTurn(ctx context.Context, session domain.Session, para
 						}
 				}
 
-				params.OnEvent(domain.AgentEvent{
-					Type:      exitReason,
-					Timestamp: now,
-					Message:   "turn " + tc.Turn.Status,
-				})
+				switch exitReason {
+				case domain.EventTurnCompleted:
+					agentcore.EmitTurnCompleted(params.OnEvent, "turn "+tc.Turn.Status, 0)
+				case domain.EventTurnCancelled:
+					agentcore.EmitTurnCancelled(params.OnEvent, "turn "+tc.Turn.Status)
+				default:
+					agentcore.EmitTurnFailed(params.OnEvent, "turn "+tc.Turn.Status, 0)
+				}
 				params.OnEvent(domain.AgentEvent{
 					Type:      domain.EventTokenUsage,
 					Timestamp: now,
@@ -701,17 +589,9 @@ func (a *CodexAdapter) RunTurn(ctx context.Context, session domain.Session, para
 				case "commandExecution", "fileChange", "mcpToolCall", "dynamicToolCall":
 					toolName := cmp.Or(item.Command, item.Type)
 					inFlight.Begin(item.ID, toolName)
-					params.OnEvent(domain.AgentEvent{
-						Type:      domain.EventNotification,
-						Timestamp: now,
-						Message:   summarizeItem(item.Type, item.ID),
-					})
+					agentcore.EmitNotification(params.OnEvent, summarizeItem(item.Type, item.ID))
 				default:
-					params.OnEvent(domain.AgentEvent{
-						Type:      domain.EventNotification,
-						Timestamp: now,
-						Message:   summarizeItem(item.Type, item.ID),
-					})
+					agentcore.EmitNotification(params.OnEvent, summarizeItem(item.Type, item.ID))
 				}
 
 			case "item/completed":
@@ -730,18 +610,11 @@ func (a *CodexAdapter) RunTurn(ctx context.Context, session domain.Session, para
 					})
 				}
 				if item.Type == "agentMessage" && item.Text != "" {
-					params.OnEvent(domain.AgentEvent{
-						Type:      domain.EventNotification,
-						Timestamp: now,
-						Message:   typeutil.TruncateRunes(item.Text, 200),
-					})
+					agentcore.EmitNotification(params.OnEvent, typeutil.TruncateRunes(item.Text, 200))
 				}
 
 			case "item/agentMessage/delta", "item/commandExecution/outputDelta":
-				params.OnEvent(domain.AgentEvent{
-					Type:      domain.EventNotification,
-					Timestamp: now,
-				})
+				agentcore.EmitNotification(params.OnEvent, "")
 
 			case "item/tool/call":
 				if evt := a.handleToolCall(ctx, state, &toolWg, msg, toolEventCh, logger); evt != nil {
@@ -749,11 +622,7 @@ func (a *CodexAdapter) RunTurn(ctx context.Context, session domain.Session, para
 				}
 
 			case "turn/plan/updated":
-				params.OnEvent(domain.AgentEvent{
-					Type:      domain.EventNotification,
-					Timestamp: now,
-					Message:   "plan updated",
-				})
+				agentcore.EmitNotification(params.OnEvent, "plan updated")
 
 			case "turn/diff/updated":
 				logger.Debug("diff updated")

--- a/internal/agent/codex/command.go
+++ b/internal/agent/codex/command.go
@@ -1,6 +1,9 @@
 package codex
 
-import "github.com/sortie-ai/sortie/internal/typeutil"
+import (
+	"github.com/sortie-ai/sortie/internal/agent/sshutil"
+	"github.com/sortie-ai/sortie/internal/typeutil"
+)
 
 // passthroughConfig holds Codex-specific settings extracted from the
 // "codex" sub-object in WORKFLOW.md. All fields are optional with
@@ -27,4 +30,16 @@ func parsePassthroughConfig(config map[string]any) passthroughConfig {
 		Personality:       typeutil.StringFrom(config, "personality"),
 		SkipGitRepoCheck:  typeutil.BoolFrom(config, "skip_git_repo_check", false),
 	}
+}
+
+// buildSSHRemoteCmd returns the remote command string for SSH mode.
+// When apiKey is non-empty, CODEX_API_KEY is prepended and the value
+// is shell-quoted to prevent injection through the remote shell when
+// the key contains metacharacters such as single quotes, dollar signs,
+// semicolons, or backticks.
+func buildSSHRemoteCmd(remoteCommand, apiKey string) string {
+	if apiKey == "" {
+		return remoteCommand
+	}
+	return "CODEX_API_KEY=" + sshutil.ShellQuote(apiKey) + " " + remoteCommand
 }

--- a/internal/agent/codex/command_test.go
+++ b/internal/agent/codex/command_test.go
@@ -1,0 +1,150 @@
+package codex
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/sortie-ai/sortie/internal/agent/sshutil"
+)
+
+func TestBuildSSHRemoteCmd(t *testing.T) {
+	t.Parallel()
+
+	const base = "codex app-server"
+
+	tests := []struct {
+		name          string
+		remoteCommand string
+		apiKey        string
+		want          string
+	}{
+		{
+			name:          "empty key returns command unchanged",
+			remoteCommand: base,
+			apiKey:        "",
+			want:          base,
+		},
+		{
+			name:          "simple alphanumeric key",
+			remoteCommand: base,
+			apiKey:        "sk-abc123",
+			want:          "CODEX_API_KEY='sk-abc123' " + base,
+		},
+		{
+			name:          "key with dollar sign",
+			remoteCommand: base,
+			apiKey:        "sk-$secret",
+			want:          "CODEX_API_KEY='sk-$secret' " + base,
+		},
+		{
+			name:          "key with single quote",
+			remoteCommand: base,
+			apiKey:        "it's",
+			want:          "CODEX_API_KEY='it'\\''s' " + base,
+		},
+		{
+			name:          "key with combined metacharacters (spec example)",
+			remoteCommand: base,
+			apiKey:        "'foo'$bar",
+			want:          "CODEX_API_KEY=''\\''foo'\\''$bar' " + base,
+		},
+		{
+			name:          "key with semicolon",
+			remoteCommand: base,
+			apiKey:        "key;rm -rf /",
+			want:          "CODEX_API_KEY='key;rm -rf /' " + base,
+		},
+		{
+			name:          "key with backtick",
+			remoteCommand: base,
+			apiKey:        "key`whoami`",
+			want:          "CODEX_API_KEY='key`whoami`' " + base,
+		},
+		{
+			name:          "key with double quote",
+			remoteCommand: base,
+			apiKey:        `key"value"`,
+			want:          `CODEX_API_KEY='key"value"' ` + base,
+		},
+		{
+			name:          "key with spaces",
+			remoteCommand: base,
+			apiKey:        "key with spaces",
+			want:          "CODEX_API_KEY='key with spaces' " + base,
+		},
+		{
+			name:          "remote command preserved unchanged",
+			remoteCommand: "codex app-server --flag value",
+			apiKey:        "sk-abc",
+			want:          "CODEX_API_KEY='sk-abc' codex app-server --flag value",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := buildSSHRemoteCmd(tt.remoteCommand, tt.apiKey)
+			if got != tt.want {
+				t.Errorf("buildSSHRemoteCmd(%q, %q) = %q, want %q", tt.remoteCommand, tt.apiKey, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestBuildSSHRemoteCmd_MetacharactersDoNotLeakIntoSSHArgs verifies that
+// the full pipeline (buildSSHRemoteCmd → BuildSSHArgs) does not produce a
+// final SSH remote-command argument that contains the raw API key value
+// when the key includes shell metacharacters. An unquoted metacharacter
+// would allow injection through the remote shell.
+func TestBuildSSHRemoteCmd_MetacharactersDoNotLeakIntoSSHArgs(t *testing.T) {
+	t.Parallel()
+
+	metacharKeys := []struct {
+		name   string
+		apiKey string
+	}{
+		{"single quote", "'secret'"},
+		{"dollar sign", "$SECRET"},
+		{"combined spec example", "'foo'$bar"},
+		{"semicolon injection attempt", "key; rm -rf /"},
+		{"backtick injection attempt", "key`whoami`"},
+		{"subshell injection attempt", "$(cat /etc/passwd)"},
+	}
+
+	const (
+		base      = "codex app-server"
+		host      = "remote.host"
+		workspace = "/workspace"
+	)
+
+	for _, tc := range metacharKeys {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			remoteCmd := buildSSHRemoteCmd(base, tc.apiKey)
+			sshArgs := sshutil.BuildSSHArgs(host, workspace, remoteCmd, nil, sshutil.SSHOptions{})
+
+			// The last SSH arg is the full remote command string passed to the
+			// remote shell. It must not contain the raw API key value, because
+			// that would mean the key was concatenated without quoting.
+			finalArg := sshArgs[len(sshArgs)-1]
+			rawKeyAssignment := "CODEX_API_KEY=" + tc.apiKey
+			if strings.Contains(finalArg, rawKeyAssignment) {
+				t.Errorf("SSH remote-command arg contains unquoted API key assignment %q in %q",
+					rawKeyAssignment, finalArg)
+			}
+
+			// The final arg must still carry the CODEX_API_KEY= prefix so the
+			// environment variable is set on the remote host.
+			if !strings.Contains(finalArg, "CODEX_API_KEY=") {
+				t.Errorf("SSH remote-command arg missing CODEX_API_KEY= prefix in %q", finalArg)
+			}
+
+			// The base command must be present so the agent binary is invoked.
+			if !strings.Contains(finalArg, base) {
+				t.Errorf("SSH remote-command arg missing base command %q in %q", base, finalArg)
+			}
+		})
+	}
+}

--- a/internal/agent/codex/handshake_test.go
+++ b/internal/agent/codex/handshake_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/sortie-ai/sortie/internal/agent/agentcore"
 	"github.com/sortie-ai/sortie/internal/domain"
 )
 
@@ -19,8 +20,8 @@ import (
 // It has a valid workspacePath and a discarding stdin.
 func handshakeState() *sessionState {
 	return &sessionState{
-		workspacePath: "/tmp",
-		stdin:         nopWriteCloser{},
+		target: agentcore.LaunchTarget{WorkspacePath: "/tmp"},
+		stdin:  nopWriteCloser{},
 	}
 }
 

--- a/internal/agent/codex/parse_test.go
+++ b/internal/agent/codex/parse_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"unicode/utf8"
 
+	"github.com/sortie-ai/sortie/internal/agent/agentcore"
 	"github.com/sortie-ai/sortie/internal/domain"
 )
 
@@ -532,7 +533,7 @@ func TestDenormalizeSandbox(t *testing.T) {
 func TestBuildSandboxPolicy_Default(t *testing.T) {
 	t.Parallel()
 
-	state := &sessionState{workspacePath: "/workspace/abc"}
+	state := &sessionState{target: agentcore.LaunchTarget{WorkspacePath: "/workspace/abc"}}
 	policy := buildSandboxPolicy(state, passthroughConfig{})
 
 	if policy["type"] != "workspaceWrite" {
@@ -559,7 +560,7 @@ func TestBuildSandboxPolicy_Default(t *testing.T) {
 func TestBuildSandboxPolicy_Override(t *testing.T) {
 	t.Parallel()
 
-	state := &sessionState{workspacePath: "/workspace/abc"}
+	state := &sessionState{target: agentcore.LaunchTarget{WorkspacePath: "/workspace/abc"}}
 	pt := passthroughConfig{
 		ThreadSandbox: "dangerouslyUnrestricted",
 		TurnSandboxPolicy: map[string]any{

--- a/internal/agent/codex/protocol.go
+++ b/internal/agent/codex/protocol.go
@@ -309,7 +309,7 @@ func startThread(ctx context.Context, state *sessionState, scanCh <-chan scanRes
 	}
 
 	params := map[string]any{
-		"cwd":            state.workspacePath,
+		"cwd":            state.target.WorkspacePath,
 		"approvalPolicy": approvalPolicy,
 		"sandbox":        sandbox,
 	}
@@ -432,7 +432,7 @@ func buildSandboxPolicy(state *sessionState, pt passthroughConfig) map[string]an
 
 	policy := map[string]any{
 		"type":          sandboxType,
-		"writableRoots": []string{state.workspacePath},
+		"writableRoots": []string{state.target.WorkspacePath},
 		"networkAccess": false,
 	}
 

--- a/internal/agent/codex/runturn_test.go
+++ b/internal/agent/codex/runturn_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/sortie-ai/sortie/internal/agent/agentcore"
 	"github.com/sortie-ai/sortie/internal/domain"
 )
 
@@ -39,14 +40,14 @@ func loadFixture(t *testing.T, name string) []byte {
 // real subprocess.
 func makeTestState(fixtureData []byte) *sessionState {
 	state := &sessionState{
-		threadID:      "thread-001",
-		workspacePath: "/tmp",
-		waitCh:        make(chan struct{}),
-		stdin:         nopWriteCloser{},
-		stdout:        io.NopCloser(bytes.NewReader(nil)),
-		msgCh:         make(chan parsedMessage, 16),
-		readerDone:    make(chan struct{}),
-		stopCh:        make(chan struct{}),
+		threadID:   "thread-001",
+		target:     agentcore.LaunchTarget{WorkspacePath: "/tmp"},
+		waitCh:     make(chan struct{}),
+		stdin:      nopWriteCloser{},
+		stdout:     io.NopCloser(bytes.NewReader(nil)),
+		msgCh:      make(chan parsedMessage, 16),
+		readerDone: make(chan struct{}),
+		stopCh:     make(chan struct{}),
 	}
 
 	go func() {

--- a/internal/agent/copilot/copilot.go
+++ b/internal/agent/copilot/copilot.go
@@ -10,14 +10,12 @@ package copilot
 
 import (
 	"bufio"
-	"cmp"
 	"context"
 	"fmt"
 	"io"
 	"log/slog"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
@@ -29,7 +27,6 @@ import (
 	"github.com/sortie-ai/sortie/internal/domain"
 	"github.com/sortie-ai/sortie/internal/logging"
 	"github.com/sortie-ai/sortie/internal/registry"
-	"github.com/sortie-ai/sortie/internal/typeutil"
 )
 
 func init() {
@@ -53,23 +50,10 @@ type CopilotAdapter struct {
 // Internal. It tracks the Copilot CLI session ID and subprocess
 // handle across turns.
 type sessionState struct {
-	workspacePath    string
-	command          string
+	target           agentcore.LaunchTarget
 	copilotSessionID string
 	agentConfig      domain.AgentConfig
 	turnCount        int
-
-	// sshHost is the SSH destination for remote execution. Empty for
-	// local mode.
-	sshHost string
-
-	// remoteCommand is the agent command to run on the remote host.
-	// Empty for local mode.
-	remoteCommand string
-
-	// sshStrictHostKeyChecking is the OpenSSH StrictHostKeyChecking
-	// value. Empty means accept-new.
-	sshStrictHostKeyChecking string
 
 	// mcpConfigPath is the worker-generated MCP config file path.
 	mcpConfigPath string
@@ -95,79 +79,20 @@ func NewCopilotAdapter(config map[string]any) (domain.AgentAdapter, error) {
 	return &CopilotAdapter{passthrough: pt}, nil
 }
 
-// StartSession validates the workspace path, resolves the copilot
-// binary, and initializes per-session state. No subprocess is spawned;
-// that happens in [CopilotAdapter.RunTurn].
+// StartSession validates the workspace path, resolves the copilot binary, and
+// initializes per-session state. No subprocess is spawned; that happens in
+// [CopilotAdapter.RunTurn].
 func (a *CopilotAdapter) StartSession(ctx context.Context, params domain.StartSessionParams) (domain.Session, error) {
-	if params.WorkspacePath == "" {
-		return domain.Session{}, &domain.AgentError{
-			Kind:    domain.ErrInvalidWorkspaceCwd,
-			Message: "empty workspace path",
-		}
+	target, agentErr := agentcore.ResolveLaunchTarget(params, "copilot")
+	if agentErr != nil {
+		return domain.Session{}, agentErr
 	}
 
-	absPath, err := filepath.Abs(params.WorkspacePath)
-	if err != nil {
-		return domain.Session{}, &domain.AgentError{
-			Kind:    domain.ErrInvalidWorkspaceCwd,
-			Message: "cannot resolve workspace path",
-			Err:     err,
-		}
-	}
-
-	fi, err := os.Stat(absPath)
-	if err != nil {
-		return domain.Session{}, &domain.AgentError{
-			Kind:    domain.ErrInvalidWorkspaceCwd,
-			Message: "workspace path does not exist",
-			Err:     err,
-		}
-	}
-	if !fi.IsDir() {
-		return domain.Session{}, &domain.AgentError{
-			Kind:    domain.ErrInvalidWorkspaceCwd,
-			Message: "workspace path is not a directory",
-		}
-	}
-
-	command := cmp.Or(params.AgentConfig.Command, "copilot")
-
-	var resolvedPath string
-	var sshHost string
-	var remoteCommand string
-
-	sshHostTrimmed := strings.TrimSpace(params.SSHHost)
-	if sshHostTrimmed != "" {
-		// SSH mode: resolve "ssh" locally, skip local LookPath for
-		// the agent command (it resolves on the remote host).
-		sshPath, lookErr := exec.LookPath("ssh")
-		if lookErr != nil {
-			return domain.Session{}, &domain.AgentError{
-				Kind:    domain.ErrAgentNotFound,
-				Message: "ssh binary not found on orchestrator host",
-				Err:     lookErr,
-			}
-		}
-		resolvedPath = sshPath
-		sshHost = sshHostTrimmed
-		remoteCommand = command
-	} else {
-		var lookErr error
-		resolvedPath, lookErr = exec.LookPath(command)
-		if lookErr != nil {
-			return domain.Session{}, &domain.AgentError{
-				Kind:    domain.ErrAgentNotFound,
-				Message: fmt.Sprintf("agent command %q not found", command),
-				Err:     lookErr,
-			}
-		}
-
-		// Canary check: validate the binary is functional (Node.js
-		// 22+ runtime present). Use a 5-second timeout to avoid
-		// hanging on a broken installation.
+	// Canary check and auth preflight are local-mode only.
+	if target.RemoteCommand == "" {
 		canaryCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 		defer cancel()
-		out, canaryErr := exec.CommandContext(canaryCtx, resolvedPath, "--version").CombinedOutput() //nolint:gosec // resolvedPath from LookPath
+		out, canaryErr := exec.CommandContext(canaryCtx, target.Command, "--version").CombinedOutput() //nolint:gosec // target.Command from LookPath
 		if canaryErr != nil {
 			return domain.Session{}, &domain.AgentError{
 				Kind:    domain.ErrAgentNotFound,
@@ -177,8 +102,6 @@ func (a *CopilotAdapter) StartSession(ctx context.Context, params domain.StartSe
 		}
 		slog.Debug("copilot version check passed", slog.String("version", strings.TrimSpace(string(out))))
 
-		// Authentication preflight: verify at least one GitHub
-		// authentication source is available.
 		if authErr := checkAuth(ctx); authErr != nil {
 			return domain.Session{}, authErr
 		}
@@ -190,14 +113,10 @@ func (a *CopilotAdapter) StartSession(ctx context.Context, params domain.StartSe
 	}
 
 	state := &sessionState{
-		workspacePath:            absPath,
-		command:                  resolvedPath,
-		copilotSessionID:         copilotSessionID,
-		agentConfig:              params.AgentConfig,
-		sshHost:                  sshHost,
-		remoteCommand:            remoteCommand,
-		sshStrictHostKeyChecking: params.SSHStrictHostKeyChecking,
-		mcpConfigPath:            params.MCPConfigPath,
+		target:           target,
+		copilotSessionID: copilotSessionID,
+		agentConfig:      params.AgentConfig,
+		mcpConfigPath:    params.MCPConfigPath,
 	}
 
 	return domain.Session{
@@ -265,20 +184,21 @@ func (a *CopilotAdapter) RunTurn(ctx context.Context, session domain.Session, pa
 	defer cancelCmd()
 
 	var cmd *exec.Cmd
-	if state.sshHost != "" {
-		sshArgs := sshutil.BuildSSHArgs(state.sshHost, state.workspacePath, state.remoteCommand, args, sshutil.SSHOptions{
-			StrictHostKeyChecking: state.sshStrictHostKeyChecking,
+	if state.target.RemoteCommand != "" {
+		sshArgs := sshutil.BuildSSHArgs(state.target.SSHHost, state.target.WorkspacePath, state.target.RemoteCommand, args, sshutil.SSHOptions{
+			StrictHostKeyChecking: state.target.SSHStrictHostKeyChecking,
 		})
-		cmd = exec.CommandContext(cmdCtx, state.command, sshArgs...) //nolint:gosec // args are constructed programmatically with shell quoting
+		cmd = exec.CommandContext(cmdCtx, state.target.Command, sshArgs...) //nolint:gosec // args are constructed programmatically with shell quoting
 	} else {
-		cmd = exec.CommandContext(cmdCtx, state.command, args...) //nolint:gosec // args are constructed programmatically
+		allArgs := append(state.target.Args, args...)                       //nolint:gocritic // intentional: target.Args has cap==len so append always allocates
+		cmd = exec.CommandContext(cmdCtx, state.target.Command, allArgs...) //nolint:gosec // args are constructed programmatically
 	}
 	procutil.SetProcessGroup(cmd)
 	cmd.Cancel = func() error {
 		return procutil.SignalGraceful(cmd.Process.Pid)
 	}
 	cmd.WaitDelay = 5 * time.Second
-	cmd.Dir = state.workspacePath
+	cmd.Dir = state.target.WorkspacePath
 	cmd.Env = os.Environ()
 
 	stdoutPipe, err := cmd.StdoutPipe()
@@ -304,11 +224,7 @@ func (a *CopilotAdapter) RunTurn(ctx context.Context, session domain.Session, pa
 	if err != nil {
 		state.mu.Unlock()
 		if ctx.Err() != nil {
-			params.OnEvent(domain.AgentEvent{
-				Type:      domain.EventTurnCancelled,
-				Timestamp: time.Now().UTC(),
-				Message:   "context cancelled",
-			})
+			agentcore.EmitTurnCancelled(params.OnEvent, "context cancelled")
 			return domain.TurnResult{
 					SessionID:  state.copilotSessionID,
 					ExitReason: domain.EventTurnCancelled,
@@ -337,14 +253,7 @@ func (a *CopilotAdapter) RunTurn(ctx context.Context, session domain.Session, pa
 	// Emit session_started before the scan loop begins. On turn 1
 	// the session ID is empty — this is an accepted tradeoff since
 	// Copilot CLI only reports the session ID in its result event.
-	now := time.Now().UTC()
-	params.OnEvent(domain.AgentEvent{
-		Type:      domain.EventSessionStarted,
-		Timestamp: now,
-		AgentPID:  strconv.Itoa(cmd.Process.Pid),
-		SessionID: state.copilotSessionID,
-		Message:   "session started",
-	})
+	agentcore.EmitSessionStarted(params.OnEvent, strconv.Itoa(cmd.Process.Pid), state.copilotSessionID)
 
 	stderrCollector := procutil.NewStderrCollector(stderrPipe, logger)
 
@@ -353,72 +262,49 @@ func (a *CopilotAdapter) RunTurn(ctx context.Context, session domain.Session, pa
 
 	var lastResult *rawEvent
 	inFlight := agentcore.NewToolTracker()
-	var cumulativeOutputTokens int64
+	acc := agentcore.NewUsageAccumulator()
 
 	for scanner.Scan() {
 		line := scanner.Bytes()
-		now = time.Now().UTC()
+		now := time.Now().UTC()
 
 		event, parseErr := parseEvent(line)
 		if parseErr != nil {
-			params.OnEvent(domain.AgentEvent{
-				Type:      domain.EventMalformed,
-				Timestamp: now,
-				Message:   typeutil.TruncateRunes(string(line), 500),
-			})
+			agentcore.EmitMalformed(params.OnEvent, line)
 			continue
 		}
 
 		switch event.Type {
 		case "assistant.message_delta":
 			// Stall timer reset; ephemeral streaming content.
-			params.OnEvent(domain.AgentEvent{
-				Type:      domain.EventNotification,
-				Timestamp: now,
-			})
+			agentcore.EmitNotification(params.OnEvent, "")
 
 		case "assistant.message":
 			if len(event.Data) > 0 {
 				msgData, dataErr := parseAssistantMessageData(event.Data)
 				if dataErr == nil {
-					cumulativeOutputTokens += msgData.OutputTokens
+					snapshot, _ := acc.AddDelta(0, msgData.OutputTokens, 0)
 					params.OnEvent(domain.AgentEvent{
 						Type:      domain.EventTokenUsage,
 						Timestamp: now,
-						Usage:     normalizeUsage(nil, cumulativeOutputTokens),
+						Usage:     snapshot,
 					})
-					params.OnEvent(domain.AgentEvent{
-						Type:      domain.EventNotification,
-						Timestamp: now,
-						Message:   summarizeAssistantMessage(msgData),
-					})
+					agentcore.EmitNotification(params.OnEvent, summarizeAssistantMessage(msgData))
 				} else {
 					logger.Debug("failed to parse assistant.message data", slog.Any("error", dataErr))
-					params.OnEvent(domain.AgentEvent{
-						Type:      domain.EventNotification,
-						Timestamp: now,
-						Message:   "assistant message",
-					})
+					agentcore.EmitNotification(params.OnEvent, "assistant message")
 				}
 			}
 
 		case "assistant.turn_start", "assistant.turn_end":
-			params.OnEvent(domain.AgentEvent{
-				Type:      domain.EventNotification,
-				Timestamp: now,
-				Message:   event.Type,
-			})
+			agentcore.EmitNotification(params.OnEvent, event.Type)
 
 		case "tool.execution_start":
 			if len(event.Data) > 0 {
 				toolData, dataErr := parseToolExecutionData(event.Data)
 				if dataErr == nil {
 					inFlight.Begin(toolData.ToolCallID, toolData.ToolName)
-					params.OnEvent(domain.AgentEvent{
-						Type:      domain.EventNotification,
-						Timestamp: now,
-						Message:   fmt.Sprintf("tool started: %s", toolData.ToolName),
-					})
+					agentcore.EmitNotification(params.OnEvent, fmt.Sprintf("tool started: %s", toolData.ToolName))
 				}
 			}
 
@@ -449,11 +335,7 @@ func (a *CopilotAdapter) RunTurn(ctx context.Context, session domain.Session, pa
 				}
 			}
 			logger.Warn("copilot session warning", slog.String("message", msg))
-			params.OnEvent(domain.AgentEvent{
-				Type:      domain.EventNotification,
-				Timestamp: now,
-				Message:   msg,
-			})
+			agentcore.EmitNotification(params.OnEvent, msg)
 
 		case "session.info":
 			msg := "session info"
@@ -463,11 +345,7 @@ func (a *CopilotAdapter) RunTurn(ctx context.Context, session domain.Session, pa
 					msg = infoData.Message
 				}
 			}
-			params.OnEvent(domain.AgentEvent{
-				Type:      domain.EventNotification,
-				Timestamp: now,
-				Message:   msg,
-			})
+			agentcore.EmitNotification(params.OnEvent, msg)
 
 		case "session.task_complete":
 			msg := "task complete"
@@ -477,11 +355,7 @@ func (a *CopilotAdapter) RunTurn(ctx context.Context, session domain.Session, pa
 					msg = taskData.Summary
 				}
 			}
-			params.OnEvent(domain.AgentEvent{
-				Type:      domain.EventNotification,
-				Timestamp: now,
-				Message:   msg,
-			})
+			agentcore.EmitNotification(params.OnEvent, msg)
 
 		case "session.mcp_server_status_changed", "session.mcp_servers_loaded",
 			"session.tools_updated", "user.message":
@@ -515,16 +389,11 @@ func (a *CopilotAdapter) RunTurn(ctx context.Context, session domain.Session, pa
 		// Context cancellation propagates through exec.CommandContext
 		// and can surface as a pipe read error. Treat as cancellation.
 		if ctx.Err() != nil {
-			now = time.Now().UTC()
-			params.OnEvent(domain.AgentEvent{
-				Type:      domain.EventTurnCancelled,
-				Timestamp: now,
-				Message:   "context cancelled",
-			})
+			agentcore.EmitTurnCancelled(params.OnEvent, "context cancelled")
 			return domain.TurnResult{
 					SessionID:  state.copilotSessionID,
 					ExitReason: domain.EventTurnCancelled,
-					Usage:      normalizeUsage(nil, cumulativeOutputTokens),
+					Usage:      acc.Snapshot(),
 				}, &domain.AgentError{
 					Kind:    domain.ErrTurnCancelled,
 					Message: "turn cancelled",
@@ -533,16 +402,11 @@ func (a *CopilotAdapter) RunTurn(ctx context.Context, session domain.Session, pa
 		}
 
 		procutil.EmitWarnLines(stderrLines, logger)
-		now = time.Now().UTC()
-		params.OnEvent(domain.AgentEvent{
-			Type:      domain.EventTurnFailed,
-			Timestamp: now,
-			Message:   "stdout read error: " + scanErr.Error(),
-		})
+		agentcore.EmitTurnFailed(params.OnEvent, "stdout read error: "+scanErr.Error(), 0)
 		return domain.TurnResult{
 				SessionID:  state.copilotSessionID,
 				ExitReason: domain.EventTurnFailed,
-				Usage:      normalizeUsage(nil, cumulativeOutputTokens),
+				Usage:      acc.Snapshot(),
 			}, &domain.AgentError{
 				Kind:    domain.ErrPortExit,
 				Message: "stdout scanner error",
@@ -565,20 +429,10 @@ func (a *CopilotAdapter) RunTurn(ctx context.Context, session domain.Session, pa
 	state.waitCh = nil
 	state.mu.Unlock()
 
-	now = time.Now().UTC()
-
-	var resultUsage *rawUsage
-	if lastResult != nil {
-		resultUsage = lastResult.Usage
-	}
-	usage := normalizeUsage(resultUsage, cumulativeOutputTokens)
+	usage := acc.Snapshot()
 
 	if ctx.Err() != nil {
-		params.OnEvent(domain.AgentEvent{
-			Type:      domain.EventTurnCancelled,
-			Timestamp: now,
-			Message:   "context cancelled",
-		})
+		agentcore.EmitTurnCancelled(params.OnEvent, "context cancelled")
 		return domain.TurnResult{
 				SessionID:  state.copilotSessionID,
 				ExitReason: domain.EventTurnCancelled,
@@ -594,11 +448,7 @@ func (a *CopilotAdapter) RunTurn(ctx context.Context, session domain.Session, pa
 
 	if exitCode == 127 {
 		procutil.EmitWarnLines(stderrLines, logger)
-		params.OnEvent(domain.AgentEvent{
-			Type:      domain.EventTurnFailed,
-			Timestamp: now,
-			Message:   "copilot binary not found",
-		})
+		agentcore.EmitTurnFailed(params.OnEvent, "copilot binary not found", 0)
 		return domain.TurnResult{
 				SessionID:  state.copilotSessionID,
 				ExitReason: domain.EventTurnFailed,
@@ -610,11 +460,7 @@ func (a *CopilotAdapter) RunTurn(ctx context.Context, session domain.Session, pa
 	}
 
 	if procutil.WasSignaled(waitErr) {
-		params.OnEvent(domain.AgentEvent{
-			Type:      domain.EventTurnCancelled,
-			Timestamp: now,
-			Message:   "killed by signal",
-		})
+		agentcore.EmitTurnCancelled(params.OnEvent, "killed by signal")
 		return domain.TurnResult{
 				SessionID:  state.copilotSessionID,
 				ExitReason: domain.EventTurnCancelled,
@@ -649,11 +495,7 @@ func (a *CopilotAdapter) RunTurn(ctx context.Context, session domain.Session, pa
 		}
 
 		if lastResult.ExitCode != nil && *lastResult.ExitCode == 0 {
-			params.OnEvent(domain.AgentEvent{
-				Type:          domain.EventTurnCompleted,
-				Timestamp:     now,
-				APIDurationMS: apiDurationMS,
-			})
+			agentcore.EmitTurnCompleted(params.OnEvent, "", apiDurationMS)
 			return domain.TurnResult{
 				SessionID:  state.copilotSessionID,
 				ExitReason: domain.EventTurnCompleted,
@@ -661,12 +503,7 @@ func (a *CopilotAdapter) RunTurn(ctx context.Context, session domain.Session, pa
 			}, nil
 		}
 		procutil.EmitWarnLines(stderrLines, logger)
-		params.OnEvent(domain.AgentEvent{
-			Type:          domain.EventTurnFailed,
-			Timestamp:     now,
-			Message:       "non-zero exit in result event",
-			APIDurationMS: apiDurationMS,
-		})
+		agentcore.EmitTurnFailed(params.OnEvent, "non-zero exit in result event", apiDurationMS)
 		return domain.TurnResult{
 				SessionID:  state.copilotSessionID,
 				ExitReason: domain.EventTurnFailed,
@@ -680,11 +517,7 @@ func (a *CopilotAdapter) RunTurn(ctx context.Context, session domain.Session, pa
 	// No result event.
 	if exitCode != 0 {
 		procutil.EmitWarnLines(stderrLines, logger)
-		params.OnEvent(domain.AgentEvent{
-			Type:      domain.EventTurnFailed,
-			Timestamp: now,
-			Message:   "non-zero exit",
-		})
+		agentcore.EmitTurnFailed(params.OnEvent, "non-zero exit", 0)
 		return domain.TurnResult{
 				SessionID:  state.copilotSessionID,
 				ExitReason: domain.EventTurnFailed,
@@ -696,14 +529,10 @@ func (a *CopilotAdapter) RunTurn(ctx context.Context, session domain.Session, pa
 	}
 
 	// No result event and exit code 0.
-	if cumulativeOutputTokens == 0 {
+	if acc.Snapshot().OutputTokens == 0 {
 		procutil.EmitWarnLines(stderrLines, logger)
 		logger.Warn("agent exited without producing output, treating as failure")
-		params.OnEvent(domain.AgentEvent{
-			Type:      domain.EventTurnFailed,
-			Timestamp: now,
-			Message:   "agent exited without producing output",
-		})
+		agentcore.EmitTurnFailed(params.OnEvent, "agent exited without producing output", 0)
 		return domain.TurnResult{
 				SessionID:  state.copilotSessionID,
 				ExitReason: domain.EventTurnFailed,
@@ -714,10 +543,7 @@ func (a *CopilotAdapter) RunTurn(ctx context.Context, session domain.Session, pa
 			}
 	}
 
-	params.OnEvent(domain.AgentEvent{
-		Type:      domain.EventTurnCompleted,
-		Timestamp: now,
-	})
+	agentcore.EmitTurnCompleted(params.OnEvent, "", 0)
 	return domain.TurnResult{
 		SessionID:  state.copilotSessionID,
 		ExitReason: domain.EventTurnCompleted,

--- a/internal/agent/copilot/copilot_test.go
+++ b/internal/agent/copilot/copilot_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/sortie-ai/sortie/internal/agent/agentcore"
 	"github.com/sortie-ai/sortie/internal/agent/agenttest"
 	"github.com/sortie-ai/sortie/internal/domain"
 	"github.com/sortie-ai/sortie/internal/registry"
@@ -253,17 +254,17 @@ func TestStartSession_NewSession(t *testing.T) {
 	if state.copilotSessionID != "" {
 		t.Errorf("state.copilotSessionID = %q, want empty for new session", state.copilotSessionID)
 	}
-	if state.workspacePath != workspace {
+	if state.target.WorkspacePath != workspace {
 		// t.TempDir() may return a path through a symlink; compare with os.Stat.
-		if state.workspacePath != filepath.Clean(workspace) {
-			t.Errorf("state.workspacePath = %q, want %q", state.workspacePath, workspace)
+		if state.target.WorkspacePath != filepath.Clean(workspace) {
+			t.Errorf("state.target.WorkspacePath = %q, want %q", state.target.WorkspacePath, workspace)
 		}
 	}
 	if state.fallbackToContinue {
 		t.Error("state.fallbackToContinue = true, want false for new session")
 	}
-	if state.sshHost != "" {
-		t.Errorf("state.sshHost = %q, want empty for local mode", state.sshHost)
+	if state.target.SSHHost != "" {
+		t.Errorf("state.target.SSHHost = %q, want empty for local mode", state.target.SSHHost)
 	}
 }
 
@@ -333,14 +334,14 @@ func TestStartSession_SSHMode(t *testing.T) {
 	}
 
 	state := session.Internal.(*sessionState)
-	if state.sshHost != "dev-host.example.com" {
-		t.Errorf("state.sshHost = %q, want %q", state.sshHost, "dev-host.example.com")
+	if state.target.SSHHost != "dev-host.example.com" {
+		t.Errorf("state.target.SSHHost = %q, want %q", state.target.SSHHost, "dev-host.example.com")
 	}
-	if state.remoteCommand != "copilot" {
-		t.Errorf("state.remoteCommand = %q, want %q", state.remoteCommand, "copilot")
+	if state.target.RemoteCommand != "copilot" {
+		t.Errorf("state.target.RemoteCommand = %q, want %q", state.target.RemoteCommand, "copilot")
 	}
-	if state.command != sshPath {
-		t.Errorf("state.command = %q, want %q (ssh binary)", state.command, sshPath)
+	if state.target.Command != sshPath {
+		t.Errorf("state.target.Command = %q, want %q (ssh binary)", state.target.Command, sshPath)
 	}
 	// Auth check is skipped in SSH mode.
 }
@@ -381,11 +382,11 @@ func TestStartSession_SSHHostWhitespaceOnly(t *testing.T) {
 	}
 
 	state := session.Internal.(*sessionState)
-	if state.sshHost != "" {
-		t.Errorf("state.sshHost = %q, want empty (whitespace-only SSHHost treated as local mode)", state.sshHost)
+	if state.target.SSHHost != "" {
+		t.Errorf("state.target.SSHHost = %q, want empty (whitespace-only SSHHost treated as local mode)", state.target.SSHHost)
 	}
-	if state.remoteCommand != "" {
-		t.Errorf("state.remoteCommand = %q, want empty for local mode", state.remoteCommand)
+	if state.target.RemoteCommand != "" {
+		t.Errorf("state.target.RemoteCommand = %q, want empty for local mode", state.target.RemoteCommand)
 	}
 }
 
@@ -492,7 +493,7 @@ func TestRunTurn_HappyPath(t *testing.T) {
 
 	adapter, session := newTestSession(t, t.TempDir())
 	state := session.Internal.(*sessionState)
-	state.command = fakeCopilotBinaryWithOutput(t, loadTestFixture(t, "simple_session.jsonl"), 0)
+	state.target.Command = fakeCopilotBinaryWithOutput(t, loadTestFixture(t, "simple_session.jsonl"), 0)
 
 	var events []domain.AgentEvent
 	result, err := adapter.RunTurn(context.Background(), session, domain.RunTurnParams{
@@ -556,7 +557,7 @@ func TestRunTurn_ExitCode127(t *testing.T) {
 
 	adapter, session := newTestSession(t, t.TempDir())
 	state := session.Internal.(*sessionState)
-	state.command = fakeCopilotBinaryWithOutput(t, "", 127)
+	state.target.Command = fakeCopilotBinaryWithOutput(t, "", 127)
 
 	var events []domain.AgentEvent
 	_, err := adapter.RunTurn(context.Background(), session, domain.RunTurnParams{
@@ -575,7 +576,7 @@ func TestRunTurn_NonZeroExitNoResult(t *testing.T) {
 
 	adapter, session := newTestSession(t, t.TempDir())
 	state := session.Internal.(*sessionState)
-	state.command = fakeCopilotBinaryWithOutput(t, "", 1)
+	state.target.Command = fakeCopilotBinaryWithOutput(t, "", 1)
 
 	var events []domain.AgentEvent
 	_, err := adapter.RunTurn(context.Background(), session, domain.RunTurnParams{
@@ -593,7 +594,7 @@ func TestRunTurn_NoOutputExitZero(t *testing.T) {
 
 	adapter, session := newTestSession(t, t.TempDir())
 	state := session.Internal.(*sessionState)
-	state.command = fakeCopilotBinaryWithOutput(t, "", 0)
+	state.target.Command = fakeCopilotBinaryWithOutput(t, "", 0)
 
 	var events []domain.AgentEvent
 	result, err := adapter.RunTurn(context.Background(), session, domain.RunTurnParams{
@@ -616,7 +617,7 @@ func TestRunTurn_PartialOutputNoResultExitZero(t *testing.T) {
 	state := session.Internal.(*sessionState)
 
 	const jsonl = `{"type":"assistant.message","timestamp":"2026-04-08T00:00:00Z","data":{"role":"assistant","content":"hello","outputTokens":42}}` + "\n"
-	state.command = fakeCopilotBinaryWithOutput(t, jsonl, 0)
+	state.target.Command = fakeCopilotBinaryWithOutput(t, jsonl, 0)
 
 	var events []domain.AgentEvent
 	result, err := adapter.RunTurn(context.Background(), session, domain.RunTurnParams{
@@ -645,7 +646,7 @@ func TestRunTurn_StderrWarnOnNoOutputExitZero(t *testing.T) {
 
 	adapter, session := newTestSession(t, t.TempDir())
 	state := session.Internal.(*sessionState)
-	state.command = fakeCopilotBinaryWithStderrAndExit(t, "Invalid JSON in --additional-mcp-config", 0)
+	state.target.Command = fakeCopilotBinaryWithStderrAndExit(t, "Invalid JSON in --additional-mcp-config", 0)
 
 	var events []domain.AgentEvent
 	result, err := adapter.RunTurn(context.Background(), session, domain.RunTurnParams{
@@ -675,7 +676,7 @@ func TestRunTurn_ContextCancelled(t *testing.T) {
 	t.Setenv("GH_TOKEN", "test-token-for-unit-test")
 
 	adapter, session := newTestSession(t, t.TempDir())
-	// state.command is fakeCopilotBinary: exits 0 immediately, no output.
+	// state.target.Command is fakeCopilotBinary: exits 0 immediately, no output.
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // pre-cancel before RunTurn
@@ -697,7 +698,7 @@ func TestRunTurn_MalformedLines(t *testing.T) {
 
 	adapter, session := newTestSession(t, t.TempDir())
 	state := session.Internal.(*sessionState)
-	state.command = fakeCopilotBinaryWithOutput(t, loadTestFixture(t, "malformed_lines.jsonl"), 0)
+	state.target.Command = fakeCopilotBinaryWithOutput(t, loadTestFixture(t, "malformed_lines.jsonl"), 0)
 
 	var events []domain.AgentEvent
 	_, err := adapter.RunTurn(context.Background(), session, domain.RunTurnParams{
@@ -718,7 +719,7 @@ func TestRunTurn_ToolUseEvents(t *testing.T) {
 
 	adapter, session := newTestSession(t, t.TempDir())
 	state := session.Internal.(*sessionState)
-	state.command = fakeCopilotBinaryWithOutput(t, loadTestFixture(t, "tool_use_session.jsonl"), 0)
+	state.target.Command = fakeCopilotBinaryWithOutput(t, loadTestFixture(t, "tool_use_session.jsonl"), 0)
 
 	var events []domain.AgentEvent
 	result, err := adapter.RunTurn(context.Background(), session, domain.RunTurnParams{
@@ -756,7 +757,7 @@ func TestRunTurn_NonZeroResultExitCode(t *testing.T) {
 
 	adapter, session := newTestSession(t, t.TempDir())
 	state := session.Internal.(*sessionState)
-	state.command = fakeCopilotBinaryWithOutput(t, failResultJSONL, 0)
+	state.target.Command = fakeCopilotBinaryWithOutput(t, failResultJSONL, 0)
 
 	var events []domain.AgentEvent
 	_, err := adapter.RunTurn(context.Background(), session, domain.RunTurnParams{
@@ -781,7 +782,7 @@ func TestRunTurn_TurnFailed_APIDurationMS(t *testing.T) {
 
 	adapter, session := newTestSession(t, t.TempDir())
 	state := session.Internal.(*sessionState)
-	state.command = fakeCopilotBinaryWithOutput(t, failJSONL, 0)
+	state.target.Command = fakeCopilotBinaryWithOutput(t, failJSONL, 0)
 
 	var events []domain.AgentEvent
 	_, err := adapter.RunTurn(context.Background(), session, domain.RunTurnParams{
@@ -867,7 +868,7 @@ func TestStopSession_NilProc(t *testing.T) {
 	// Bare session with no running subprocess (proc == nil).
 	session := domain.Session{
 		Internal: &sessionState{
-			workspacePath: t.TempDir(),
+			target: agentcore.LaunchTarget{WorkspacePath: t.TempDir()},
 		},
 	}
 	if err := adapter.StopSession(context.Background(), session); err != nil {
@@ -885,7 +886,7 @@ func TestStopSession_TerminatesProcess(t *testing.T) {
 
 	adapter, session := newTestSession(t, t.TempDir())
 	state := session.Internal.(*sessionState)
-	state.command = sleepBin
+	state.target.Command = sleepBin
 
 	processStarted := make(chan struct{}, 1)
 	runDone := make(chan struct{})
@@ -945,7 +946,7 @@ func TestRunTurn_StderrWarnOnExitCode127(t *testing.T) {
 
 	adapter, session := newTestSession(t, t.TempDir())
 	state := session.Internal.(*sessionState)
-	state.command = fakeCopilotBinaryWithStderrAndExit(t, "license check failed: no valid license", 127)
+	state.target.Command = fakeCopilotBinaryWithStderrAndExit(t, "license check failed: no valid license", 127)
 
 	result, runErr := adapter.RunTurn(context.Background(), session, domain.RunTurnParams{
 		Prompt:  "do the thing",
@@ -975,7 +976,7 @@ func TestRunTurn_StderrWarnOnNonZeroExit(t *testing.T) {
 
 	adapter, session := newTestSession(t, t.TempDir())
 	state := session.Internal.(*sessionState)
-	state.command = fakeCopilotBinaryWithStderrAndExit(t, "internal agent panic", 1)
+	state.target.Command = fakeCopilotBinaryWithStderrAndExit(t, "internal agent panic", 1)
 
 	result, runErr := adapter.RunTurn(context.Background(), session, domain.RunTurnParams{
 		Prompt:  "do the thing",
@@ -1015,7 +1016,7 @@ func TestRunTurn_StderrNoWarnOnSuccess(t *testing.T) {
 	if err := os.WriteFile(outFile, []byte(successJSONL+"\n"), 0o644); err != nil {
 		t.Fatalf("writing stdout file: %v", err)
 	}
-	state.command = agenttest.WriteScript(t, dir, "copilot",
+	state.target.Command = agenttest.WriteScript(t, dir, "copilot",
 		fmt.Sprintf("cat '%s' >&2\ncat '%s'", errFile, outFile))
 
 	result, err := adapter.RunTurn(context.Background(), session, domain.RunTurnParams{

--- a/internal/agent/copilot/parse.go
+++ b/internal/agent/copilot/parse.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/sortie-ai/sortie/internal/domain"
 	"github.com/sortie-ai/sortie/internal/typeutil"
 )
 
@@ -144,17 +143,4 @@ func summarizeAssistantMessage(data assistantMessageData) string {
 		return fmt.Sprintf("requesting %d tool(s): %s", len(data.ToolRequests), strings.Join(names, ", "))
 	}
 	return "assistant message"
-}
-
-// normalizeUsage converts raw usage counters and cumulative output
-// token data into a [domain.TokenUsage]. Input tokens are not
-// available from Copilot CLI JSONL output, so only output tokens are
-// populated. raw is accepted for forward compatibility with future
-// Copilot CLI versions that may include per-token counts in the result
-// event.
-func normalizeUsage(_ *rawUsage, cumulativeOutput int64) domain.TokenUsage {
-	return domain.TokenUsage{
-		OutputTokens: cumulativeOutput,
-		TotalTokens:  cumulativeOutput,
-	}
 }

--- a/internal/agent/copilot/parse_test.go
+++ b/internal/agent/copilot/parse_test.go
@@ -654,41 +654,6 @@ func TestSummarizeAssistantMessage(t *testing.T) {
 	}
 }
 
-func TestNormalizeUsage(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name             string
-		raw              *rawUsage
-		cumulativeOutput int64
-		wantOutput       int64
-	}{
-		{"zero tokens nil raw", nil, 0, 0},
-		{"some output tokens nil raw", nil, 42, 42},
-		{"large token count", nil, 100_000, 100_000},
-		{"non-nil raw does not change output", &rawUsage{PremiumRequests: 10, TotalAPIDurMS: 500}, 55, 55},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			got := normalizeUsage(tt.raw, tt.cumulativeOutput)
-			if got.InputTokens != 0 {
-				t.Errorf("normalizeUsage().InputTokens = %d, want 0", got.InputTokens)
-			}
-			if got.OutputTokens != tt.wantOutput {
-				t.Errorf("normalizeUsage().OutputTokens = %d, want %d", got.OutputTokens, tt.wantOutput)
-			}
-			if got.TotalTokens != tt.wantOutput {
-				t.Errorf("normalizeUsage().TotalTokens = %d, want %d", got.TotalTokens, tt.wantOutput)
-			}
-			if got.CacheReadTokens != 0 {
-				t.Errorf("normalizeUsage().CacheReadTokens = %d, want 0", got.CacheReadTokens)
-			}
-		})
-	}
-}
-
 func TestTruncate(t *testing.T) {
 	t.Parallel()
 

--- a/internal/agent/copilot/process_group_unix_test.go
+++ b/internal/agent/copilot/process_group_unix_test.go
@@ -98,7 +98,7 @@ func TestRunTurn_ProcessGroupKill_ContextCancel(t *testing.T) {
 	adapter, session := newTestSession(t, workspace)
 
 	pidFile := filepath.Join(workspace, "child.pid")
-	session.Internal.(*sessionState).command = writeCopilotPgidScript(t, workspace, pidFile)
+	session.Internal.(*sessionState).target.Command = writeCopilotPgidScript(t, workspace, pidFile)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -145,7 +145,7 @@ func TestRunTurn_ProcessGroupKill_StopSession(t *testing.T) {
 	adapter, session := newTestSession(t, workspace)
 
 	pidFile := filepath.Join(workspace, "child.pid")
-	session.Internal.(*sessionState).command = writeCopilotPgidScript(t, workspace, pidFile)
+	session.Internal.(*sessionState).target.Command = writeCopilotPgidScript(t, workspace, pidFile)
 
 	type turnResult struct {
 		result domain.TurnResult


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Refactor

**Intent:** Extract five patterns copy-pasted across the `claude`, `copilot`, and `codex` adapters into the existing `internal/agent/agentcore` package. The patterns had drifted (only Copilot trimmed SSH host whitespace; only Codex split multi-token commands; `Timestamp=time.Now().UTC()` on events was convention-only). Centralizing them makes the invariants auditable and eliminates ~430 LoC of duplication.

**Related Issues:** #491

### 🧭 Reviewer Guide

**Complexity:** High

#### Entry Point

`internal/agent/agentcore/launchtarget.go` — `ResolveLaunchTarget` is the most complex new function. It unifies SSH/local launch-mode resolution across all three adapters, calls `ResolveWorkspace` and `ResolveBinary` internally, trims `SSHHost` whitespace for all adapters, and returns a `LaunchTarget` value that each adapter stores in `sessionState`. Understanding this file makes the adapter diffs easy to follow.

#### Sensitive Areas

- `internal/agent/agentcore/workspace.go`: four-step workspace path validation is a security boundary - step order and error messages are spec-mandated
- `internal/agent/codex/codex.go`: `buildSSHRemoteCmd` call replaces inline `CODEX_API_KEY` shell-quoting; the empty-key guard and `sshutil.ShellQuote` are both mandatory to prevent injection
- `internal/agent/claude/claude.go`: `UsageAccumulator` replaces the 60-line inline delta-accumulation block; `apiCallStart` timing management stays inline and is orthogonal to `acc.ready`
- `internal/agent/copilot/parse.go`: `normalizeUsage` removed as dead code after `UsageAccumulator` migration - `rawUsage` struct retained for `TotalAPIDurMS`/`PremiumRequests` fields

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes - `domain.AgentAdapter`, `domain.StartSessionParams`, `domain.RunTurnParams`, `domain.TurnResult`, and `domain.Session` are unchanged
- **Migrations/State:** No migrations or state changes