### PR TITLE
refactor(adapters): extract shared HTTP transport, normalization, and metrics helpers

### DIFF
--- a/.github/agents/tester.agent.md
+++ b/.github/agents/tester.agent.md
@@ -55,9 +55,13 @@ At least one criterion must be met. Do not write useless tests. Your KPI is test
 | Workflow     | `internal/workflow/`     | Unit                                      | YAML parsing, BOM/CRLF, delimiter detection, reload fallback      |
 | Config       | `internal/config/`       | Unit                                      | Template rendering, `$VAR` resolution, `~` expansion, validation  |
 | Persistence  | `internal/persistence/`  | Integration (in-memory SQLite)            | Migrations, CRUD, idempotent upserts, recovery                    |
+| Integration support | `internal/httpkit/` | Unit (httptest)                           | Request construction, success status handling, conditional GET, pagination |
+| Integration support | `internal/issuekit/` | Unit                                     | Label normalization, comment normalization, strict priority parsing |
+| Integration support | `internal/trackermetrics/` | Unit                              | Logical tracker-operation outcome accounting                      |
 | Tracker      | `internal/tracker/*/`    | Unit (httptest) + Integration (env-gated) | Response normalization, pagination, error categories              |
 | SCM          | `internal/scm/*/`        | Unit (httptest) + Integration (env-gated) | SCM integration, response normalization, pagination               |
 | Agent        | `internal/agent/*/`      | Unit (fixtures) + Integration (env-gated) | Event parsing, token extraction, timeout handling                 |
+| Agent core   | `internal/agent/agentcore/` | Unit                                   | Shared launch, event, usage, and workspace helpers                |
 | Agent util   | `internal/agent/agenttest/` | (test helper)                          | Shared test helpers for agent adapter tests                       |
 | Agent util   | `internal/agent/procutil/`  | Unit                                   | Subprocess lifecycle, exit code extraction                        |
 | Agent util   | `internal/agent/sshutil/`   | Unit                                   | SSH invocation, shell quoting                                     |
@@ -81,6 +85,7 @@ Integration tests requiring external services MUST be gated:
 - `SORTIE_GITHUB_TEST=1` for GitHub adapter integration tests
 - `SORTIE_GITHUB_E2E=1` for orchestrator-level E2E tests with real GitHub API + mock agent (also requires `SORTIE_GITHUB_TOKEN` and `SORTIE_GITHUB_PROJECT`)
 - `SORTIE_CLAUDE_TEST=1` for Claude Code adapter integration tests
+- `SORTIE_CODEX_TEST=1` for Codex adapter integration tests
 - `SORTIE_COPILOT_TEST=1` for Copilot adapter integration tests
 
 Without these vars, integration tests must **skip cleanly** — never fail.

--- a/.github/instructions/code-review.instructions.md
+++ b/.github/instructions/code-review.instructions.md
@@ -34,8 +34,8 @@ internal/workflow/     → internal/config, prompt            (no orchestrator, 
 internal/workspace/    → internal/domain, config, persistence
 internal/persistence/  → internal/domain, config
 internal/registry/     → internal/domain                   (adapter registration — no orchestrator, no persistence)
-internal/tracker/*/    → internal/domain, registry, typeutil (no cross-adapter imports)
-internal/scm/*/        → internal/domain, registry, typeutil (no cross-adapter imports)
+internal/tracker/*/    → internal/domain, registry, typeutil, httpkit, issuekit, trackermetrics (no cross-adapter imports)
+internal/scm/*/        → internal/domain, registry, typeutil, httpkit, issuekit, trackermetrics (no cross-adapter imports)
 internal/agent/*/      → internal/domain, registry, agent/agentcore, agent/procutil, agent/sshutil, typeutil (no cross-adapter imports)
 internal/tool/*/        → internal/domain                  (agent tool implementations)
 internal/config/       → internal/domain, maputil          (no orchestrator, no persistence)
@@ -43,6 +43,9 @@ internal/prompt/       → internal/domain, maputil          (no orchestrator, n
 internal/domain/       → (nothing internal)                (pure types, interfaces, constants)
 internal/maputil/      → (nothing internal)                (generic map helpers)
 internal/typeutil/     → (nothing internal)                (type coercion helpers)
+internal/httpkit/      → (nothing internal)                (shared REST transport and pagination helpers)
+internal/issuekit/     → internal/domain                   (shared issue normalization helpers)
+internal/trackermetrics/ → internal/domain                   (shared tracker-operation metrics decorator)
 internal/logging/      → (nothing internal)                (stdlib only)
 ```
 

--- a/.gitignore
+++ b/.gitignore
@@ -8,13 +8,13 @@
 # Do not ignore .vscode directory.
 !/.vscode
 
-# Test binary, built with `go test -c`
+# Test binary, built with `go test -c`.
 *.test
 
 # Manual tests
 /WORKFLOW.test.md
 
-# Code coverage profiles and other test artifacts
+# Code coverage profiles and other test artifacts.
 *.out
 coverage.*
 *.coverprofile
@@ -43,10 +43,13 @@ go.work.sum
 /.specs
 /.tasks
 
-# Sortie user documentation and blog posts
+# Sortie user documentation and blog posts.
 /website
 /blog
 
-# Python cache files
+# Python cache files.
 __pycache__
 *.pyc
+
+# Local environment variables for E2E tests.
+env.local.sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,9 +89,11 @@ change, that is a valid conversation to have in an issue.
 ```
 cmd/sortie/            entry point, CLI wiring
 internal/
-  agent/               agent adapters (claude/, copilot/, mock/, etc.)
+  agent/               agent adapters and shared agent helpers (agentcore/, claude/, codex/, copilot/, mock/, ...)
   config/              typed config, defaults, env-var resolution
   domain/              pure types, interfaces, error categories (imports nothing)
+  httpkit/             shared REST transport, conditional GET, pagination
+  issuekit/            shared issue normalization helpers
   logging/             structured slog helpers (imports nothing)
   maputil/             generic map utility helpers (imports nothing)
   typeutil/            type coercion helpers (imports nothing)
@@ -103,6 +105,7 @@ internal/
   tool/                agent tools (trackerapi/, history/, mcpserver/, status/)
   tracker/             tracker adapters (jira/, file/, etc.)
   scm/                 SCM adapters (github/)
+  trackermetrics/      shared tracker-operation metrics helpers
   workflow/            WORKFLOW.md parser, file watcher
   workspace/           filesystem isolation, path safety, hook execution
 docs/
@@ -110,10 +113,10 @@ docs/
   decisions/           Architecture Decision Records (ADRs)
 ```
 
-Imports flow downward. `domain/`, `logging/`, `maputil/`, and `typeutil/` sit at the
-bottom with no internal dependencies. Adapters (`tracker/*`, `scm/*`, `agent/*`)
-implement interfaces defined in `domain/` and never import each other or the
-orchestrator.
+Imports flow downward. `domain/`, `logging/`, `maputil/`, `typeutil/`, and `httpkit/`
+sit at the bottom with no internal dependencies. `issuekit/` and `trackermetrics/`
+depend only on `domain/`. Adapters (`tracker/*`, `scm/*`, `agent/*`) implement
+interfaces defined in `domain/` and never import each other or the orchestrator.
 
 ## Code conventions
 

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -180,10 +180,15 @@ Sortie is a single-binary Go service with this internal layout:
 | `internal/config/`       | Configuration | Typed config, env-var resolution, template rendering |
 | `internal/workflow/`     | Configuration | WORKFLOW.md parsing, file watching, dynamic reload   |
 | `internal/persistence/`  | Persistence   | SQLite schema, migrations, CRUD                      |
+| `internal/httpkit/`      | Integration   | Shared REST transport, conditional GET, and pagination helpers |
+| `internal/issuekit/`     | Integration   | Shared issue normalization helpers                   |
+| `internal/trackermetrics/` | Integration | Shared tracker-operation metrics decorator           |
 | `internal/tracker/jira/` | Integration   | Jira adapter behind `TrackerAdapter` interface       |
-| `internal/scm/github/`   | Integration | GitHub SCM adapters behind `TrackerAdapter` and `CIStatusProvider` interfaces |
+| `internal/scm/github/`   | Integration   | GitHub tracker, CI, and review adapters behind `TrackerAdapter`, `CIStatusProvider`, and `SCMAdapter` interfaces |
 | `internal/tracker/file/` | Integration   | File-based tracker for dev/test                      |
+| `internal/agent/agentcore/` | Integration | Shared agent adapter command, event, usage, and workspace helpers |
 | `internal/agent/claude/` | Integration   | Claude Code adapter behind `AgentAdapter` interface  |
+| `internal/agent/codex/`  | Integration   | Codex adapter behind `AgentAdapter` interface        |
 | `internal/agent/copilot/` | Integration  | Copilot adapter behind `AgentAdapter` interface      |
 | `internal/agent/mock/`   | Integration   | Mock agent for testing                               |
 | `internal/workspace/`    | Execution     | Workspace lifecycle, hooks, path safety              |

--- a/internal/domain/metrics.go
+++ b/internal/domain/metrics.go
@@ -63,7 +63,8 @@ type Metrics interface {
 	// IncTrackerRequests increments the tracker adapter API call
 	// counter. operation is one of "fetch_candidates", "fetch_issue",
 	// "fetch_comments", "fetch_by_states", "fetch_states_by_ids",
-	// "fetch_states_by_identifiers", "transition", "comment".
+	// "fetch_states_by_identifiers", "transition", "comment",
+	// or "add_label".
 	// result is "success" or "error"
 	// (sortie_tracker_requests_total{operation,result} counter).
 	IncTrackerRequests(operation string, result string)

--- a/internal/httpkit/client.go
+++ b/internal/httpkit/client.go
@@ -1,0 +1,260 @@
+// Package httpkit provides shared REST transport helpers for integration adapters.
+//
+// Start with [NewClient] for authenticated requests and [Paginator] for
+// multi-page collection endpoints.
+package httpkit
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// Authorizer mutates an outgoing request before dispatch.
+type Authorizer func(*http.Request)
+
+// ErrorClassifier maps a non-success HTTP response to a caller-defined error.
+type ErrorClassifier func(resp *http.Response, method, path string) error
+
+// TransportClassifier maps a transport or body-read failure to a caller-defined error.
+type TransportClassifier func(err error, method, path string) error
+
+// ClientOptions configures a [Client].
+type ClientOptions struct {
+	// BaseURL is prepended to relative request paths.
+	BaseURL string
+
+	// Timeout controls the underlying [http.Client] timeout.
+	Timeout time.Duration
+
+	// Authorize applies authentication and shared headers to each request.
+	Authorize Authorizer
+
+	// ClassifyError maps non-success HTTP responses to caller-defined errors.
+	ClassifyError ErrorClassifier
+
+	// ClassifyTransport maps request, network, and body-read failures.
+	ClassifyTransport TransportClassifier
+}
+
+// Client executes HTTP requests with caller-provided authorization and error mapping.
+type Client struct {
+	httpClient        *http.Client
+	baseURL           string
+	authorize         Authorizer
+	classifyError     ErrorClassifier
+	classifyTransport TransportClassifier
+}
+
+// NewClient constructs a [Client] from the provided options.
+func NewClient(opts ClientOptions) *Client {
+	return &Client{
+		httpClient:        newHTTPClient(opts.Timeout),
+		baseURL:           opts.BaseURL,
+		authorize:         opts.Authorize,
+		classifyError:     opts.ClassifyError,
+		classifyTransport: opts.ClassifyTransport,
+	}
+}
+
+func newHTTPClient(timeout time.Duration) *http.Client {
+	client := &http.Client{Timeout: timeout}
+	if defaultTransport, ok := http.DefaultTransport.(*http.Transport); ok {
+		client.Transport = defaultTransport.Clone()
+	}
+	return client
+}
+
+// Get issues a GET request against BaseURL plus path and returns the body and headers on HTTP 200.
+func (c *Client) Get(ctx context.Context, path string, params url.Values) ([]byte, http.Header, error) {
+	reqURL := c.buildURL(path, params)
+	resp, err := c.do(ctx, http.MethodGet, path, reqURL, nil, "", "")
+	if err != nil {
+		return nil, nil, err
+	}
+	defer resp.Body.Close() //nolint:errcheck // best-effort cleanup on response body
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, nil, c.classifyResponse(resp, http.MethodGet, path)
+	}
+
+	body, err := c.readBody(ctx, resp.Body, http.MethodGet, path)
+	if err != nil {
+		return nil, nil, err
+	}
+	return body, resp.Header.Clone(), nil
+}
+
+// GetURL issues a GET request against a fully qualified URL and returns the body and headers on HTTP 200.
+func (c *Client) GetURL(ctx context.Context, fullURL string) ([]byte, http.Header, error) {
+	resp, err := c.do(ctx, http.MethodGet, fullURL, fullURL, nil, "", "")
+	if err != nil {
+		return nil, nil, err
+	}
+	defer resp.Body.Close() //nolint:errcheck // best-effort cleanup on response body
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, nil, c.classifyResponse(resp, http.MethodGet, fullURL)
+	}
+
+	body, err := c.readBody(ctx, resp.Body, http.MethodGet, fullURL)
+	if err != nil {
+		return nil, nil, err
+	}
+	return body, resp.Header.Clone(), nil
+}
+
+// GetConditional issues a conditional GET request and reports whether the response was not modified.
+func (c *Client) GetConditional(ctx context.Context, path, ifNoneMatch string, params url.Values) (body []byte, etag string, notModified bool, err error) {
+	reqURL := c.buildURL(path, params)
+	resp, err := c.do(ctx, http.MethodGet, path, reqURL, nil, "", ifNoneMatch)
+	if err != nil {
+		return nil, "", false, err
+	}
+	defer resp.Body.Close() //nolint:errcheck // best-effort cleanup on response body
+
+	if resp.StatusCode == http.StatusNotModified {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		return nil, "", true, nil
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, "", false, c.classifyResponse(resp, http.MethodGet, path)
+	}
+
+	body, err = c.readBody(ctx, resp.Body, http.MethodGet, path)
+	if err != nil {
+		return nil, "", false, err
+	}
+	return body, resp.Header.Get("ETag"), false, nil
+}
+
+// GetRaw issues a GET request and returns up to maxBytes from the response body on HTTP 200.
+func (c *Client) GetRaw(ctx context.Context, path string, maxBytes int64) ([]byte, error) {
+	if maxBytes < 0 {
+		maxBytes = 0
+	}
+
+	reqURL := c.baseURL + path
+	resp, err := c.do(ctx, http.MethodGet, path, reqURL, nil, "", "")
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close() //nolint:errcheck // best-effort cleanup on response body
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, c.classifyResponse(resp, http.MethodGet, path)
+	}
+
+	body, err := c.readBody(ctx, io.LimitReader(resp.Body, maxBytes), http.MethodGet, path)
+	if err != nil {
+		return nil, err
+	}
+	return body, nil
+}
+
+// Send issues a request with a JSON body and returns the response body on any HTTP 2xx status.
+func (c *Client) Send(ctx context.Context, method, path string, body io.Reader) ([]byte, error) {
+	reqURL := c.baseURL + path
+	resp, err := c.do(ctx, method, path, reqURL, body, "application/json", "")
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close() //nolint:errcheck // best-effort cleanup on response body
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return nil, c.classifyResponse(resp, method, path)
+	}
+
+	respBody, err := c.readBody(ctx, resp.Body, method, path)
+	if err != nil {
+		return nil, err
+	}
+	return respBody, nil
+}
+
+// SendNoBody issues a request without a body and succeeds only on HTTP 200 or 204.
+func (c *Client) SendNoBody(ctx context.Context, method, path string) error {
+	reqURL := c.baseURL + path
+	resp, err := c.do(ctx, method, path, reqURL, nil, "", "")
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close() //nolint:errcheck // best-effort cleanup on response body
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
+		return c.classifyResponse(resp, method, path)
+	}
+
+	_, _ = io.Copy(io.Discard, resp.Body)
+	return nil
+}
+
+func (c *Client) do(ctx context.Context, method, path, reqURL string, body io.Reader, contentType, ifNoneMatch string) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, method, reqURL, body)
+	if err != nil {
+		return nil, c.classifyTransportFailure(ctx, err, method, path)
+	}
+
+	if contentType != "" {
+		req.Header.Set("Content-Type", contentType)
+	}
+	if ifNoneMatch != "" {
+		req.Header.Set("If-None-Match", ifNoneMatch)
+	}
+	if c.authorize != nil {
+		c.authorize(req)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, c.classifyTransportFailure(ctx, err, method, path)
+	}
+	return resp, nil
+}
+
+func (c *Client) buildURL(path string, params url.Values) string {
+	reqURL := c.baseURL + path
+	if len(params) == 0 {
+		return reqURL
+	}
+
+	query := params.Encode()
+	if query == "" {
+		return reqURL
+	}
+
+	separator := "?"
+	if strings.Contains(reqURL, "?") {
+		separator = "&"
+	}
+	return reqURL + separator + query
+}
+
+func (c *Client) classifyResponse(resp *http.Response, method, path string) error {
+	if c.classifyError != nil {
+		return c.classifyError(resp, method, path)
+	}
+	return fmt.Errorf("%s %s: unexpected status %d", method, path, resp.StatusCode)
+}
+
+func (c *Client) classifyTransportFailure(ctx context.Context, err error, method, path string) error {
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+	if c.classifyTransport != nil {
+		return c.classifyTransport(err, method, path)
+	}
+	return err
+}
+
+func (c *Client) readBody(ctx context.Context, body io.Reader, method, path string) ([]byte, error) {
+	data, err := io.ReadAll(body)
+	if err != nil {
+		return nil, c.classifyTransportFailure(ctx, err, method, path)
+	}
+	return data, nil
+}

--- a/internal/httpkit/client_test.go
+++ b/internal/httpkit/client_test.go
@@ -1,0 +1,363 @@
+package httpkit
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+func mustClient(t *testing.T, opts ClientOptions) *Client {
+	t.Helper()
+	return NewClient(opts)
+}
+
+func TestClient_Get_success(t *testing.T) {
+	t.Parallel()
+
+	var authCalled atomic.Bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("X-Auth") == "token" {
+			authCalled.Store(true)
+		}
+		w.Header().Set("X-Response-ID", "42")
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, "hello")
+	}))
+	defer srv.Close()
+
+	c := mustClient(t, ClientOptions{
+		BaseURL: srv.URL,
+		Authorize: func(req *http.Request) {
+			req.Header.Set("X-Auth", "token")
+		},
+	})
+
+	body, headers, err := c.Get(context.Background(), "/test", nil)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if string(body) != "hello" {
+		t.Errorf("Get body = %q, want %q", body, "hello")
+	}
+	if !authCalled.Load() {
+		t.Error("Get: authorizer was not called")
+	}
+	if got := headers.Get("X-Response-ID"); got != "42" {
+		t.Errorf("Get X-Response-ID = %q, want %q", got, "42")
+	}
+}
+
+func TestClient_Get_nonSuccess(t *testing.T) {
+	t.Parallel()
+
+	sentinel := errors.New("classified-404")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	c := mustClient(t, ClientOptions{
+		BaseURL: srv.URL,
+		ClassifyError: func(resp *http.Response, method, path string) error {
+			return fmt.Errorf("%w: %s %s %d", sentinel, method, path, resp.StatusCode)
+		},
+	})
+
+	_, _, err := c.Get(context.Background(), "/missing", nil)
+	if !errors.Is(err, sentinel) {
+		t.Errorf("Get non-success error = %v, want to wrap %v", err, sentinel)
+	}
+}
+
+func TestClient_GetConditional_200(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("ETag", `"v1"`)
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, "payload")
+	}))
+	defer srv.Close()
+
+	c := mustClient(t, ClientOptions{BaseURL: srv.URL})
+
+	body, etag, notModified, err := c.GetConditional(context.Background(), "/item", `"v1"`, nil)
+	if err != nil {
+		t.Fatalf("GetConditional 200: %v", err)
+	}
+	if notModified {
+		t.Error("GetConditional 200 notModified = true, want false")
+	}
+	if string(body) != "payload" {
+		t.Errorf("GetConditional 200 body = %q, want %q", body, "payload")
+	}
+	if etag != `"v1"` {
+		t.Errorf("GetConditional 200 etag = %q, want %q", etag, `"v1"`)
+	}
+}
+
+func TestClient_GetConditional_304(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotModified)
+	}))
+	defer srv.Close()
+
+	c := mustClient(t, ClientOptions{BaseURL: srv.URL})
+
+	body, etag, notModified, err := c.GetConditional(context.Background(), "/item", `"v1"`, nil)
+	if err != nil {
+		t.Fatalf("GetConditional 304: %v", err)
+	}
+	if !notModified {
+		t.Error("GetConditional 304 notModified = false, want true")
+	}
+	if len(body) != 0 {
+		t.Errorf("GetConditional 304 body = %q, want empty", body)
+	}
+	if etag != "" {
+		t.Errorf("GetConditional 304 etag = %q, want empty", etag)
+	}
+}
+
+func TestClient_GetConditional_weakETag(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("ETag", `W/"abc123"`)
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, "body")
+	}))
+	defer srv.Close()
+
+	c := mustClient(t, ClientOptions{BaseURL: srv.URL})
+
+	_, etag, _, err := c.GetConditional(context.Background(), "/item", "", nil)
+	if err != nil {
+		t.Fatalf("GetConditional weakETag: %v", err)
+	}
+	if etag != `W/"abc123"` {
+		t.Errorf("GetConditional weakETag etag = %q, want %q", etag, `W/"abc123"`)
+	}
+}
+
+func TestClient_GetConditional_emptyIfNoneMatch(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("If-None-Match") != "" {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, "ok")
+	}))
+	defer srv.Close()
+
+	c := mustClient(t, ClientOptions{BaseURL: srv.URL})
+
+	_, _, notModified, err := c.GetConditional(context.Background(), "/item", "", nil)
+	if err != nil {
+		t.Fatalf("GetConditional emptyIfNoneMatch: %v", err)
+	}
+	if notModified {
+		t.Error("GetConditional emptyIfNoneMatch notModified = true, want false")
+	}
+}
+
+func TestClient_GetRaw_truncation(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, "hello world")
+	}))
+	defer srv.Close()
+
+	c := mustClient(t, ClientOptions{BaseURL: srv.URL})
+
+	body, err := c.GetRaw(context.Background(), "/file", 5)
+	if err != nil {
+		t.Fatalf("GetRaw: %v", err)
+	}
+	if string(body) != "hello" {
+		t.Errorf("GetRaw body = %q, want %q", body, "hello")
+	}
+}
+
+func TestClient_GetRaw_non200(t *testing.T) {
+	t.Parallel()
+
+	sentinel := errors.New("classified-500")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	c := mustClient(t, ClientOptions{
+		BaseURL: srv.URL,
+		ClassifyError: func(resp *http.Response, method, path string) error {
+			return fmt.Errorf("%w: %d", sentinel, resp.StatusCode)
+		},
+	})
+
+	_, err := c.GetRaw(context.Background(), "/file", 1024)
+	if !errors.Is(err, sentinel) {
+		t.Errorf("GetRaw non-200 error = %v, want to wrap %v", err, sentinel)
+	}
+}
+
+func TestClient_Send_2xx(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		status int
+	}{
+		{"201 Created", http.StatusCreated},
+		{"204 No Content", http.StatusNoContent},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Header.Get("Content-Type") != "application/json" {
+					w.WriteHeader(http.StatusBadRequest)
+					return
+				}
+				w.WriteHeader(tt.status)
+			}))
+			defer srv.Close()
+
+			c := mustClient(t, ClientOptions{BaseURL: srv.URL})
+
+			_, err := c.Send(context.Background(), http.MethodPost, "/items", strings.NewReader("{}"))
+			if err != nil {
+				t.Errorf("Send(%d): %v", tt.status, err)
+			}
+		})
+	}
+}
+
+func TestClient_SendNoBody_success(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		status int
+	}{
+		{"200 OK", http.StatusOK},
+		{"204 No Content", http.StatusNoContent},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tt.status)
+			}))
+			defer srv.Close()
+
+			c := mustClient(t, ClientOptions{BaseURL: srv.URL})
+
+			if err := c.SendNoBody(context.Background(), http.MethodDelete, "/items/1"); err != nil {
+				t.Errorf("SendNoBody(%d): %v", tt.status, err)
+			}
+		})
+	}
+}
+
+func TestClient_SendNoBody_doesNotSetJSONContentType(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if ct := r.Header.Get("Content-Type"); ct != "" {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = fmt.Fprintf(w, "unexpected Content-Type: %q", ct)
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	c := mustClient(t, ClientOptions{BaseURL: srv.URL})
+
+	if err := c.SendNoBody(context.Background(), http.MethodDelete, "/items/1"); err != nil {
+		t.Fatalf("SendNoBody set Content-Type unexpectedly: %v", err)
+	}
+}
+
+func TestClient_Get_doesNotSetJSONContentType(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if ct := r.Header.Get("Content-Type"); ct != "" {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, "ok")
+	}))
+	defer srv.Close()
+
+	c := mustClient(t, ClientOptions{BaseURL: srv.URL})
+
+	_, _, err := c.Get(context.Background(), "/items", nil)
+	if err != nil {
+		t.Fatalf("Get set Content-Type unexpectedly: %v", err)
+	}
+}
+
+func TestClient_TransportError(t *testing.T) {
+	t.Parallel()
+
+	sentinel := errors.New("transport-classified")
+
+	c := mustClient(t, ClientOptions{
+		BaseURL: "://bad",
+		ClassifyTransport: func(err error, method, path string) error {
+			return fmt.Errorf("%w: %s %s", sentinel, method, path)
+		},
+	})
+
+	_, _, err := c.Get(context.Background(), "/test", nil)
+	if !errors.Is(err, sentinel) {
+		t.Errorf("Get transport error = %v, want to wrap %v", err, sentinel)
+	}
+}
+
+func TestClient_Cancellation(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, "ok")
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	bypass := errors.New("classifyTransport bypassed")
+	c := mustClient(t, ClientOptions{
+		BaseURL: srv.URL,
+		ClassifyTransport: func(err error, method, path string) error {
+			return bypass
+		},
+	})
+
+	_, _, err := c.Get(ctx, "/test", nil)
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("Get cancelled error = %v, want %v", err, context.Canceled)
+	}
+}

--- a/internal/httpkit/paginator.go
+++ b/internal/httpkit/paginator.go
@@ -1,0 +1,196 @@
+package httpkit
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// TokenPageDecoder decodes a token-paginated response page.
+type TokenPageDecoder[T any] func(body []byte) (items []T, nextToken string, err error)
+
+// LinkPageDecoder decodes a Link-header paginated response page.
+type LinkPageDecoder[T any] func(body []byte) ([]T, error)
+
+// PaginatorOptions configures page limits and limit notifications.
+type PaginatorOptions struct {
+	// MaxPages limits the number of pages fetched when greater than zero.
+	MaxPages int
+
+	// OnLimitReached is invoked once when a next page exists but MaxPages blocks it.
+	OnLimitReached func(limit int)
+}
+
+// Paginator accumulates items across token-based or Link-header pagination.
+type Paginator[T any] struct {
+	client      *Client
+	path        string
+	baseParams  url.Values
+	tokenParam  string
+	tokenDecode TokenPageDecoder[T]
+	linkDecode  LinkPageDecoder[T]
+	options     PaginatorOptions
+}
+
+// NewTokenPaginator constructs a [Paginator] for APIs that expose a next-page token.
+func NewTokenPaginator[T any](client *Client, path string, baseParams url.Values, tokenParam string, decode TokenPageDecoder[T], opts PaginatorOptions) *Paginator[T] {
+	return &Paginator[T]{
+		client:      client,
+		path:        path,
+		baseParams:  baseParams,
+		tokenParam:  tokenParam,
+		tokenDecode: decode,
+		options:     opts,
+	}
+}
+
+// NewLinkPaginator constructs a [Paginator] for APIs that expose pagination in Link headers.
+func NewLinkPaginator[T any](client *Client, path string, baseParams url.Values, decode LinkPageDecoder[T], opts PaginatorOptions) *Paginator[T] {
+	return &Paginator[T]{
+		client:     client,
+		path:       path,
+		baseParams: baseParams,
+		linkDecode: decode,
+		options:    opts,
+	}
+}
+
+// All fetches every page and returns the accumulated items.
+func (p *Paginator[T]) All(ctx context.Context) ([]T, error) {
+	if p.linkDecode != nil {
+		return p.allLinks(ctx)
+	}
+	return p.allTokens(ctx)
+}
+
+func (p *Paginator[T]) allTokens(ctx context.Context) ([]T, error) {
+	items := make([]T, 0)
+	pageCount := 0
+	nextToken := ""
+
+	for {
+		params := cloneValues(p.baseParams)
+		if nextToken != "" {
+			params.Set(p.tokenParam, nextToken)
+		}
+
+		body, _, err := p.client.Get(ctx, p.path, params)
+		if err != nil {
+			return nil, err
+		}
+		pageCount++
+
+		pageItems, token, err := p.tokenDecode(body)
+		if err != nil {
+			return nil, err
+		}
+		items = append(items, pageItems...)
+
+		if token == "" {
+			return items, nil
+		}
+
+		if p.options.MaxPages > 0 && pageCount == p.options.MaxPages {
+			if p.options.OnLimitReached != nil {
+				p.options.OnLimitReached(p.options.MaxPages)
+			}
+			return items, nil
+		}
+
+		nextToken = token
+	}
+}
+
+func (p *Paginator[T]) allLinks(ctx context.Context) ([]T, error) {
+	items := make([]T, 0)
+	pageCount := 0
+	nextURL := ""
+	useFullURL := false
+
+	for {
+		var (
+			body    []byte
+			headers http.Header
+			err     error
+		)
+
+		if useFullURL {
+			body, headers, err = p.client.GetURL(ctx, nextURL)
+		} else {
+			body, headers, err = p.client.Get(ctx, p.path, p.baseParams)
+		}
+		if err != nil {
+			return nil, err
+		}
+		pageCount++
+
+		pageItems, err := p.linkDecode(body)
+		if err != nil {
+			return nil, err
+		}
+		items = append(items, pageItems...)
+
+		nextURL = parseLinkNext(headers.Get("Link"))
+		if nextURL == "" {
+			return items, nil
+		}
+
+		if p.options.MaxPages > 0 && pageCount == p.options.MaxPages {
+			if p.options.OnLimitReached != nil {
+				p.options.OnLimitReached(p.options.MaxPages)
+			}
+			return items, nil
+		}
+
+		useFullURL = true
+	}
+}
+
+func cloneValues(values url.Values) url.Values {
+	if values == nil {
+		return url.Values{}
+	}
+	clone := make(url.Values, len(values))
+	for key, src := range values {
+		clone[key] = append([]string(nil), src...)
+	}
+	return clone
+}
+
+func parseLinkNext(header string) string {
+	if header == "" {
+		return ""
+	}
+
+	for _, segment := range strings.Split(header, ",") {
+		parts := strings.Split(segment, ";")
+		if len(parts) < 2 {
+			continue
+		}
+
+		hasNext := false
+		for _, attr := range parts[1:] {
+			if strings.EqualFold(strings.TrimSpace(attr), `rel="next"`) {
+				hasNext = true
+				break
+			}
+		}
+		if !hasNext {
+			continue
+		}
+
+		urlPart := strings.TrimSpace(parts[0])
+		start := strings.Index(urlPart, "<")
+		if start == -1 {
+			continue
+		}
+		end := strings.Index(urlPart[start:], ">")
+		if end == -1 {
+			continue
+		}
+		return urlPart[start+1 : start+end]
+	}
+
+	return ""
+}

--- a/internal/httpkit/paginator_test.go
+++ b/internal/httpkit/paginator_test.go
@@ -1,0 +1,439 @@
+package httpkit
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+)
+
+// testTokenPage is the JSON response shape used in token-paginator tests.
+type testTokenPage struct {
+	Items []int  `json:"items"`
+	Next  string `json:"next"`
+}
+
+func decodeIntsWithToken(body []byte) ([]int, string, error) {
+	var p testTokenPage
+	if err := json.Unmarshal(body, &p); err != nil {
+		return nil, "", err
+	}
+	return p.Items, p.Next, nil
+}
+
+func decodeInts(body []byte) ([]int, error) {
+	var items []int
+	if err := json.Unmarshal(body, &items); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+func serveTokenPage(w http.ResponseWriter, items []int, next string) {
+	page := testTokenPage{Items: items, Next: next}
+	data, _ := json.Marshal(page) //nolint:errcheck // basic types, marshal never fails
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(data)
+}
+
+func serveLinkPage(w http.ResponseWriter, items []int, linkHeader string) {
+	data, _ := json.Marshal(items) //nolint:errcheck // basic types, marshal never fails
+	if linkHeader != "" {
+		w.Header().Set("Link", linkHeader)
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(data)
+}
+
+func TestTokenPaginator_order(t *testing.T) {
+	t.Parallel()
+
+	var reqCount atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch int(reqCount.Add(1)) {
+		case 1:
+			serveTokenPage(w, []int{1, 2}, "page2")
+		case 2:
+			serveTokenPage(w, []int{3, 4}, "")
+		default:
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	}))
+	defer srv.Close()
+
+	c := mustClient(t, ClientOptions{BaseURL: srv.URL})
+	p := NewTokenPaginator(c, "/items", nil, "cursor", decodeIntsWithToken, PaginatorOptions{})
+
+	items, err := p.All(context.Background())
+	if err != nil {
+		t.Fatalf("All: %v", err)
+	}
+	want := []int{1, 2, 3, 4}
+	if len(items) != len(want) {
+		t.Fatalf("All() = %v, want %v", items, want)
+	}
+	for i, v := range want {
+		if items[i] != v {
+			t.Errorf("All()[%d] = %d, want %d", i, items[i], v)
+		}
+	}
+}
+
+func TestTokenPaginator_singlePage(t *testing.T) {
+	t.Parallel()
+
+	var reqCount atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if reqCount.Add(1) > 1 {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		serveTokenPage(w, []int{1}, "")
+	}))
+	defer srv.Close()
+
+	c := mustClient(t, ClientOptions{BaseURL: srv.URL})
+	p := NewTokenPaginator(c, "/items", nil, "cursor", decodeIntsWithToken, PaginatorOptions{})
+
+	items, err := p.All(context.Background())
+	if err != nil {
+		t.Fatalf("All: %v", err)
+	}
+	if len(items) != 1 || items[0] != 1 {
+		t.Errorf("All() = %v, want [1]", items)
+	}
+	if n := int(reqCount.Load()); n != 1 {
+		t.Errorf("request count = %d, want 1", n)
+	}
+}
+
+func TestTokenPaginator_pageCap(t *testing.T) {
+	t.Parallel()
+
+	var reqCount atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch int(reqCount.Add(1)) {
+		case 1:
+			serveTokenPage(w, []int{1}, "page2")
+		case 2:
+			serveTokenPage(w, []int{2}, "page3")
+		default:
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	}))
+	defer srv.Close()
+
+	var limitCalled atomic.Int32
+	c := mustClient(t, ClientOptions{BaseURL: srv.URL})
+	p := NewTokenPaginator(c, "/items", nil, "cursor", decodeIntsWithToken, PaginatorOptions{
+		MaxPages: 2,
+		OnLimitReached: func(limit int) {
+			limitCalled.Add(1)
+		},
+	})
+
+	items, err := p.All(context.Background())
+	if err != nil {
+		t.Fatalf("All: %v", err)
+	}
+	if len(items) != 2 {
+		t.Errorf("All() len = %d, want 2", len(items))
+	}
+	if n := int(limitCalled.Load()); n != 1 {
+		t.Errorf("OnLimitReached calls = %d, want 1", n)
+	}
+	if n := int(reqCount.Load()); n != 2 {
+		t.Errorf("request count = %d, want 2", n)
+	}
+}
+
+func TestTokenPaginator_noItems(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		serveTokenPage(w, []int{}, "")
+	}))
+	defer srv.Close()
+
+	c := mustClient(t, ClientOptions{BaseURL: srv.URL})
+	p := NewTokenPaginator(c, "/items", nil, "cursor", decodeIntsWithToken, PaginatorOptions{})
+
+	items, err := p.All(context.Background())
+	if err != nil {
+		t.Fatalf("All: %v", err)
+	}
+	if items == nil {
+		t.Fatal("All() = nil, want non-nil empty slice")
+	}
+	if len(items) != 0 {
+		t.Errorf("All() = %v, want empty", items)
+	}
+}
+
+func TestTokenPaginator_decodeError(t *testing.T) {
+	t.Parallel()
+
+	sentinel := errors.New("decode-error")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, "not decodable as token page")
+	}))
+	defer srv.Close()
+
+	decode := func(_ []byte) ([]int, string, error) {
+		return nil, "", sentinel
+	}
+
+	c := mustClient(t, ClientOptions{BaseURL: srv.URL})
+	p := NewTokenPaginator(c, "/items", nil, "cursor", decode, PaginatorOptions{})
+
+	items, err := p.All(context.Background())
+	if items != nil {
+		t.Errorf("All() items = %v, want nil", items)
+	}
+	if !errors.Is(err, sentinel) {
+		t.Errorf("All() err = %v, want %v", err, sentinel)
+	}
+}
+
+func TestTokenPaginator_midFlightErrorDropsPartial(t *testing.T) {
+	t.Parallel()
+
+	sentinel := errors.New("page2-error")
+	var reqCount atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch int(reqCount.Add(1)) {
+		case 1:
+			serveTokenPage(w, []int{1, 2}, "page2")
+		default:
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	}))
+	defer srv.Close()
+
+	c := mustClient(t, ClientOptions{
+		BaseURL: srv.URL,
+		ClassifyError: func(resp *http.Response, method, path string) error {
+			return fmt.Errorf("%w: %d", sentinel, resp.StatusCode)
+		},
+	})
+	p := NewTokenPaginator(c, "/items", nil, "cursor", decodeIntsWithToken, PaginatorOptions{})
+
+	items, err := p.All(context.Background())
+	if items != nil {
+		t.Errorf("All() items = %v, want nil after mid-flight error", items)
+	}
+	if !errors.Is(err, sentinel) {
+		t.Errorf("All() err = %v, want %v", err, sentinel)
+	}
+}
+
+func TestTokenPaginator_cancellation(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, `{"items":[],"next":""}`)
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	c := mustClient(t, ClientOptions{BaseURL: srv.URL})
+	p := NewTokenPaginator(c, "/items", nil, "cursor", decodeIntsWithToken, PaginatorOptions{})
+
+	items, err := p.All(ctx)
+	if items != nil {
+		t.Errorf("All() items = %v, want nil", items)
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("All() err = %v, want %v", err, context.Canceled)
+	}
+}
+
+func TestLinkPaginator_order(t *testing.T) {
+	t.Parallel()
+
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/p1":
+			serveLinkPage(w, []int{1, 2}, fmt.Sprintf(`<%s/p2>; rel="next"`, srv.URL))
+		case "/p2":
+			serveLinkPage(w, []int{3, 4}, "")
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	c := mustClient(t, ClientOptions{BaseURL: srv.URL})
+	p := NewLinkPaginator(c, "/p1", nil, decodeInts, PaginatorOptions{})
+
+	items, err := p.All(context.Background())
+	if err != nil {
+		t.Fatalf("All: %v", err)
+	}
+	want := []int{1, 2, 3, 4}
+	if len(items) != len(want) {
+		t.Fatalf("All() = %v, want %v", items, want)
+	}
+	for i, v := range want {
+		if items[i] != v {
+			t.Errorf("All()[%d] = %d, want %d", i, items[i], v)
+		}
+	}
+}
+
+func TestLinkPaginator_malformedLink(t *testing.T) {
+	t.Parallel()
+
+	var reqCount atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reqCount.Add(1)
+		serveLinkPage(w, []int{1, 2}, "not a proper link header")
+	}))
+	defer srv.Close()
+
+	c := mustClient(t, ClientOptions{BaseURL: srv.URL})
+	p := NewLinkPaginator(c, "/items", nil, decodeInts, PaginatorOptions{})
+
+	items, err := p.All(context.Background())
+	if err != nil {
+		t.Fatalf("All: %v", err)
+	}
+	if len(items) != 2 || items[0] != 1 || items[1] != 2 {
+		t.Errorf("All() = %v, want [1 2]", items)
+	}
+	if n := int(reqCount.Load()); n != 1 {
+		t.Errorf("request count = %d, want 1", n)
+	}
+}
+
+func TestLinkPaginator_pageCap(t *testing.T) {
+	t.Parallel()
+
+	var reqCount atomic.Int32
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reqCount.Add(1)
+		switch r.URL.Path {
+		case "/p1":
+			serveLinkPage(w, []int{1, 2}, fmt.Sprintf(`<%s/p2>; rel="next"`, srv.URL))
+		default:
+			// /p2 and beyond must not be reached when MaxPages=1.
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	}))
+	defer srv.Close()
+
+	var limitCalled atomic.Int32
+	c := mustClient(t, ClientOptions{BaseURL: srv.URL})
+	p := NewLinkPaginator(c, "/p1", nil, decodeInts, PaginatorOptions{
+		MaxPages: 1,
+		OnLimitReached: func(limit int) {
+			limitCalled.Add(1)
+		},
+	})
+
+	items, err := p.All(context.Background())
+	if err != nil {
+		t.Fatalf("All: %v", err)
+	}
+	if len(items) != 2 {
+		t.Errorf("All() len = %d, want 2", len(items))
+	}
+	if n := int(limitCalled.Load()); n != 1 {
+		t.Errorf("OnLimitReached calls = %d, want 1", n)
+	}
+	if n := int(reqCount.Load()); n != 1 {
+		t.Errorf("request count = %d, want 1", n)
+	}
+}
+
+func TestLinkPaginator_noItems(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		serveLinkPage(w, []int{}, "")
+	}))
+	defer srv.Close()
+
+	c := mustClient(t, ClientOptions{BaseURL: srv.URL})
+	p := NewLinkPaginator(c, "/items", nil, decodeInts, PaginatorOptions{})
+
+	items, err := p.All(context.Background())
+	if err != nil {
+		t.Fatalf("All: %v", err)
+	}
+	if items == nil {
+		t.Fatal("All() = nil, want non-nil empty slice")
+	}
+	if len(items) != 0 {
+		t.Errorf("All() = %v, want empty", items)
+	}
+}
+
+func TestLinkPaginator_midFlightErrorDropsPartial(t *testing.T) {
+	t.Parallel()
+
+	sentinel := errors.New("page2-error")
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/p1":
+			serveLinkPage(w, []int{1, 2}, fmt.Sprintf(`<%s/p2>; rel="next"`, srv.URL))
+		default:
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	}))
+	defer srv.Close()
+
+	c := mustClient(t, ClientOptions{
+		BaseURL: srv.URL,
+		ClassifyError: func(resp *http.Response, method, path string) error {
+			return fmt.Errorf("%w: %d", sentinel, resp.StatusCode)
+		},
+	})
+	p := NewLinkPaginator(c, "/p1", nil, decodeInts, PaginatorOptions{})
+
+	items, err := p.All(context.Background())
+	if items != nil {
+		t.Errorf("All() items = %v, want nil after mid-flight error", items)
+	}
+	if !errors.Is(err, sentinel) {
+		t.Errorf("All() err = %v, want %v", err, sentinel)
+	}
+}
+
+func TestLinkPaginator_cancellation(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, "[]")
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	c := mustClient(t, ClientOptions{BaseURL: srv.URL})
+	p := NewLinkPaginator(c, "/items", nil, decodeInts, PaginatorOptions{})
+
+	items, err := p.All(ctx)
+	if items != nil {
+		t.Errorf("All() items = %v, want nil", items)
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("All() err = %v, want %v", err, context.Canceled)
+	}
+}

--- a/internal/issuekit/issuekit.go
+++ b/internal/issuekit/issuekit.go
@@ -1,0 +1,107 @@
+// Package issuekit provides shared issue normalization helpers for integration adapters.
+package issuekit
+
+import (
+	"encoding/json"
+	"strconv"
+	"strings"
+
+	"github.com/sortie-ai/sortie/internal/domain"
+)
+
+// SourceComment is the adapter-local staging shape for comment normalization.
+type SourceComment struct {
+	ID        string
+	Author    string
+	Body      string
+	CreatedAt string
+}
+
+// NormalizeLabels lowercases labels in input order and always returns a non-nil slice.
+func NormalizeLabels(in []string) []string {
+	if in == nil {
+		return []string{}
+	}
+
+	out := make([]string, len(in))
+	for i, label := range in {
+		out[i] = strings.ToLower(label)
+	}
+	return out
+}
+
+// ParsePriorityIntStrict parses a JSON integer literal and returns nil for all other JSON values.
+func ParsePriorityIntStrict(raw json.RawMessage) *int {
+	text := strings.TrimSpace(string(raw))
+	if !isJSONIntLiteral(text) {
+		return nil
+	}
+	return parseInt(text)
+}
+
+// ParsePriorityIntFromString parses a base-10 integer string and returns nil for invalid input.
+func ParsePriorityIntFromString(s string) *int {
+	text := strings.TrimSpace(s)
+	if !isBase10Integer(text) {
+		return nil
+	}
+	return parseInt(text)
+}
+
+// NormalizeComments maps adapter-local comment values to [domain.Comment] values.
+func NormalizeComments(in []SourceComment) []domain.Comment {
+	if in == nil {
+		return []domain.Comment{}
+	}
+
+	out := make([]domain.Comment, len(in))
+	for i, comment := range in {
+		out[i] = domain.Comment{
+			ID:        comment.ID,
+			Author:    comment.Author,
+			Body:      comment.Body,
+			CreatedAt: comment.CreatedAt,
+		}
+	}
+	return out
+}
+
+func isJSONIntLiteral(s string) bool {
+	if !isBase10Integer(s) {
+		return false
+	}
+	if s[0] == '-' {
+		return len(s) <= 2 || s[1] != '0'
+	}
+	return len(s) <= 1 || s[0] != '0'
+}
+
+func isBase10Integer(s string) bool {
+	if s == "" {
+		return false
+	}
+
+	start := 0
+	if s[0] == '-' {
+		start = 1
+	}
+	if start == len(s) {
+		return false
+	}
+
+	for i := start; i < len(s); i++ {
+		if s[i] < '0' || s[i] > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+func parseInt(s string) *int {
+	value, err := strconv.ParseInt(s, 10, strconv.IntSize)
+	if err != nil {
+		return nil
+	}
+	parsed := int(value)
+	return &parsed
+}

--- a/internal/issuekit/issuekit_test.go
+++ b/internal/issuekit/issuekit_test.go
@@ -1,0 +1,234 @@
+package issuekit
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestNormalizeLabels_nil(t *testing.T) {
+	t.Parallel()
+
+	got := NormalizeLabels(nil)
+	if got == nil {
+		t.Fatal("NormalizeLabels(nil) = nil, want non-nil empty slice")
+	}
+	if len(got) != 0 {
+		t.Errorf("NormalizeLabels(nil) len = %d, want 0", len(got))
+	}
+}
+
+func TestNormalizeLabels_lowercase(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input []string
+		want  []string
+	}{
+		{"single uppercase", []string{"BUG"}, []string{"bug"}},
+		{"mixed case", []string{"Feature", "AUTH"}, []string{"feature", "auth"}},
+		{"already lowercase", []string{"done"}, []string{"done"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := NormalizeLabels(tt.input)
+			if len(got) != len(tt.want) {
+				t.Fatalf("NormalizeLabels(%v) = %v, want %v", tt.input, got, tt.want)
+			}
+			for i := range tt.want {
+				if got[i] != tt.want[i] {
+					t.Errorf("NormalizeLabels(%v)[%d] = %q, want %q", tt.input, i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestNormalizeLabels_duplicatesPreserved(t *testing.T) {
+	t.Parallel()
+
+	input := []string{"BUG", "bug", "Bug"}
+	got := NormalizeLabels(input)
+	if len(got) != 3 {
+		t.Fatalf("NormalizeLabels(%v) len = %d, want 3", input, len(got))
+	}
+	for i, label := range got {
+		if label != "bug" {
+			t.Errorf("NormalizeLabels(%v)[%d] = %q, want %q", input, i, label, "bug")
+		}
+	}
+}
+
+func TestNormalizeLabels_empty(t *testing.T) {
+	t.Parallel()
+
+	got := NormalizeLabels([]string{})
+	if got == nil {
+		t.Fatal("NormalizeLabels([]) = nil, want non-nil empty slice")
+	}
+	if len(got) != 0 {
+		t.Errorf("NormalizeLabels([]) = %v, want empty", got)
+	}
+}
+
+func TestParsePriorityIntStrict_valid(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input json.RawMessage
+		want  int
+	}{
+		{"zero", json.RawMessage("0"), 0},
+		{"positive", json.RawMessage("42"), 42},
+		{"negative", json.RawMessage("-1"), -1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := ParsePriorityIntStrict(tt.input)
+			if got == nil {
+				t.Fatalf("ParsePriorityIntStrict(%s) = nil, want %d", tt.input, tt.want)
+			}
+			if *got != tt.want {
+				t.Errorf("ParsePriorityIntStrict(%s) = %d, want %d", tt.input, *got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParsePriorityIntStrict_rejectsFloat(t *testing.T) {
+	t.Parallel()
+
+	got := ParsePriorityIntStrict(json.RawMessage("3.14"))
+	if got != nil {
+		t.Errorf("ParsePriorityIntStrict(3.14) = %d, want nil", *got)
+	}
+}
+
+func TestParsePriorityIntStrict_rejectsString(t *testing.T) {
+	t.Parallel()
+
+	got := ParsePriorityIntStrict(json.RawMessage(`"42"`))
+	if got != nil {
+		t.Errorf(`ParsePriorityIntStrict("42") = %d, want nil`, *got)
+	}
+}
+
+func TestParsePriorityIntStrict_rejectsNull(t *testing.T) {
+	t.Parallel()
+
+	got := ParsePriorityIntStrict(json.RawMessage("null"))
+	if got != nil {
+		t.Errorf("ParsePriorityIntStrict(null) = %d, want nil", *got)
+	}
+}
+
+func TestParsePriorityIntStrict_rejectsBoolean(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input json.RawMessage
+	}{
+		{"true", json.RawMessage("true")},
+		{"false", json.RawMessage("false")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := ParsePriorityIntStrict(tt.input)
+			if got != nil {
+				t.Errorf("ParsePriorityIntStrict(%s) = %d, want nil", tt.input, *got)
+			}
+		})
+	}
+}
+
+func TestParsePriorityIntFromString_valid(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input string
+		want  int
+	}{
+		{"positive", "42", 42},
+		{"zero", "0", 0},
+		{"negative", "-5", -5},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := ParsePriorityIntFromString(tt.input)
+			if got == nil {
+				t.Fatalf("ParsePriorityIntFromString(%q) = nil, want %d", tt.input, tt.want)
+			}
+			if *got != tt.want {
+				t.Errorf("ParsePriorityIntFromString(%q) = %d, want %d", tt.input, *got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParsePriorityIntFromString_emptyReturnsNil(t *testing.T) {
+	t.Parallel()
+
+	got := ParsePriorityIntFromString("")
+	if got != nil {
+		t.Errorf("ParsePriorityIntFromString(%q) = %d, want nil", "", *got)
+	}
+}
+
+func TestParsePriorityIntFromString_nonIntReturnsNil(t *testing.T) {
+	t.Parallel()
+
+	inputs := []string{"3.14", "abc", "1e2"}
+	for _, input := range inputs {
+		got := ParsePriorityIntFromString(input)
+		if got != nil {
+			t.Errorf("ParsePriorityIntFromString(%q) = %d, want nil", input, *got)
+		}
+	}
+}
+
+func TestNormalizeComments_nil(t *testing.T) {
+	t.Parallel()
+
+	got := NormalizeComments(nil)
+	if got == nil {
+		t.Fatal("NormalizeComments(nil) = nil, want non-nil empty slice")
+	}
+	if len(got) != 0 {
+		t.Errorf("NormalizeComments(nil) len = %d, want 0", len(got))
+	}
+}
+
+func TestNormalizeComments_order(t *testing.T) {
+	t.Parallel()
+
+	in := []SourceComment{
+		{ID: "1", Author: "Alice", Body: "first", CreatedAt: "2025-01-01"},
+		{ID: "2", Author: "Bob", Body: "second", CreatedAt: "2025-01-02"},
+	}
+
+	got := NormalizeComments(in)
+	if len(got) != 2 {
+		t.Fatalf("NormalizeComments len = %d, want 2", len(got))
+	}
+	if got[0].ID != "1" || got[0].Author != "Alice" || got[0].Body != "first" || got[0].CreatedAt != "2025-01-01" {
+		t.Errorf("NormalizeComments[0] = %+v, want {ID:1 Author:Alice Body:first CreatedAt:2025-01-01}", got[0])
+	}
+	if got[1].ID != "2" || got[1].Author != "Bob" || got[1].Body != "second" || got[1].CreatedAt != "2025-01-02" {
+		t.Errorf("NormalizeComments[1] = %+v, want {ID:2 Author:Bob Body:second CreatedAt:2025-01-02}", got[1])
+	}
+}

--- a/internal/scm/github/ci.go
+++ b/internal/scm/github/ci.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/sortie-ai/sortie/internal/domain"
+	"github.com/sortie-ai/sortie/internal/httpkit"
 	"github.com/sortie-ai/sortie/internal/registry"
 )
 
@@ -50,7 +51,7 @@ type checkRunApp struct {
 // GitHubCIProvider implements [domain.CIStatusProvider] for the GitHub
 // Checks API. Safe for concurrent use.
 type GitHubCIProvider struct {
-	client      *githubClient
+	client      *httpkit.Client
 	owner       string
 	repo        string
 	maxLogLines int
@@ -156,50 +157,26 @@ func (p *GitHubCIProvider) fetchAllCheckRuns(ctx context.Context, ref string) ([
 	path := fmt.Sprintf("/repos/%s/%s/commits/%s/check-runs", p.owner, p.repo, url.PathEscape(ref))
 	params := url.Values{"per_page": {"100"}}
 
-	body, nextURL, err := p.client.do(ctx, "GET", path, params)
-	if err != nil {
-		return nil, err
-	}
-
-	var resp checkRunsResponse
-	if err := json.Unmarshal(body, &resp); err != nil {
-		return nil, &domain.TrackerError{
-			Kind:    domain.ErrTrackerPayload,
-			Message: "failed to parse check runs response",
-			Err:     err,
-		}
-	}
-
-	allRuns := resp.CheckRuns
-	pages := 1
-
-	for nextURL != "" && pages < maxCIPages {
-		body, nextURL, err = p.client.doURL(ctx, nextURL)
-		if err != nil {
-			return nil, err
-		}
-
-		var pageResp checkRunsResponse
-		if err := json.Unmarshal(body, &pageResp); err != nil {
+	paginator := httpkit.NewLinkPaginator(p.client, path, params, func(body []byte) ([]githubCheckRun, error) {
+		var resp checkRunsResponse
+		if err := json.Unmarshal(body, &resp); err != nil {
 			return nil, &domain.TrackerError{
 				Kind:    domain.ErrTrackerPayload,
 				Message: "failed to parse check runs response",
 				Err:     err,
 			}
 		}
+		return resp.CheckRuns, nil
+	}, httpkit.PaginatorOptions{
+		MaxPages: maxCIPages,
+		OnLimitReached: func(limit int) {
+			slog.WarnContext(ctx, "check runs response truncated at page limit",
+				slog.Int("max_pages", limit),
+				slog.String("ref", ref))
+		},
+	})
 
-		allRuns = append(allRuns, pageResp.CheckRuns...)
-		pages++
-	}
-
-	if nextURL != "" {
-		slog.WarnContext(ctx, "check runs response truncated at page limit",
-			slog.Int("pages_fetched", pages),
-			slog.Int("max_pages", maxCIPages),
-			slog.String("ref", ref))
-	}
-
-	return allRuns, nil
+	return paginator.All(ctx)
 }
 
 func (p *GitHubCIProvider) fetchLogExcerpt(ctx context.Context, failing githubCheckRun) string {
@@ -215,7 +192,7 @@ func (p *GitHubCIProvider) fetchLogExcerpt(ctx context.Context, failing githubCh
 	// check run ID doubles as the job ID for the Actions logs endpoint.
 	path := fmt.Sprintf("/repos/%s/%s/actions/jobs/%d/logs", p.owner, p.repo, failing.ID)
 
-	body, err := p.client.doRawGet(ctx, path, maxLogBytes)
+	body, err := p.client.GetRaw(ctx, path, maxLogBytes)
 	if err != nil {
 		slog.WarnContext(ctx, "failed to fetch job log",
 			slog.Int64("job_id", failing.ID),

--- a/internal/scm/github/ci_test.go
+++ b/internal/scm/github/ci_test.go
@@ -25,15 +25,7 @@ func newTestCIProvider(t *testing.T, baseURL string, maxLogLines int) *GitHubCIP
 	if err != nil {
 		t.Fatalf("NewGitHubCIProvider: %v", err)
 	}
-	gh := p.(*GitHubCIProvider)
-	defaultTransport, ok := http.DefaultTransport.(*http.Transport)
-	if !ok {
-		t.Fatalf("http.DefaultTransport is %T, want *http.Transport", http.DefaultTransport)
-	}
-	transport := defaultTransport.Clone()
-	gh.client.httpClient.Transport = transport
-	t.Cleanup(transport.CloseIdleConnections)
-	return gh
+	return p.(*GitHubCIProvider)
 }
 
 func assertCIErrorKind(t *testing.T, err error, want domain.CIErrorKind) {

--- a/internal/scm/github/client.go
+++ b/internal/scm/github/client.go
@@ -1,302 +1,36 @@
 package github
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"net/http"
-	"net/url"
 	"strings"
 	"time"
 
 	"github.com/sortie-ai/sortie/internal/domain"
+	"github.com/sortie-ai/sortie/internal/httpkit"
 )
 
-// maxErrorBody is the maximum number of bytes read from non-success
-// response bodies for diagnostic error messages.
+func newGitHubClient(baseURL, token, userAgent string) *httpkit.Client {
+	trimmedBaseURL := strings.TrimRight(baseURL, "/")
+	authorization := "Bearer " + token
+
+	return httpkit.NewClient(httpkit.ClientOptions{
+		BaseURL: trimmedBaseURL,
+		Timeout: 30 * time.Second,
+		Authorize: func(req *http.Request) {
+			req.Header.Set("Authorization", authorization)
+			req.Header.Set("Accept", "application/vnd.github+json")
+			req.Header.Set("X-GitHub-Api-Version", "2026-03-10")
+			req.Header.Set("User-Agent", userAgent)
+		},
+		ClassifyError:     classifyHTTPError,
+		ClassifyTransport: classifyTransportError,
+	})
+}
+
 const maxErrorBody = 512
 
-type githubClient struct {
-	httpClient *http.Client
-	baseURL    string
-	authHeader string
-	userAgent  string
-	apiVersion string
-}
-
-func newGitHubClient(baseURL, token, userAgent string) *githubClient {
-	return &githubClient{
-		httpClient: &http.Client{Timeout: 30 * time.Second},
-		baseURL:    strings.TrimRight(baseURL, "/"),
-		authHeader: "Bearer " + token,
-		userAgent:  userAgent,
-		apiVersion: "2026-03-10",
-	}
-}
-
-// setHeaders applies the common GitHub API headers to a request.
-func (c *githubClient) setHeaders(req *http.Request) {
-	req.Header.Set("Authorization", c.authHeader)
-	req.Header.Set("Accept", "application/vnd.github+json")
-	req.Header.Set("X-GitHub-Api-Version", c.apiVersion)
-	req.Header.Set("User-Agent", c.userAgent)
-}
-
-// do executes an HTTP request against the GitHub REST API and returns
-// the response body and the Link rel="next" URL on success. Non-200
-// responses are classified via [classifyHTTPError]. Context
-// cancellation is propagated directly.
-func (c *githubClient) do(ctx context.Context, method, path string, params url.Values) ([]byte, string, error) { //nolint:unparam // method is GET today but the signature mirrors doJSON for consistency
-	reqURL := c.baseURL + path
-	if len(params) > 0 {
-		reqURL += "?" + params.Encode()
-	}
-
-	req, err := http.NewRequestWithContext(ctx, method, reqURL, nil) //nolint:gosec // URL is constructed from operator-configured base URL + internal API paths, not user data
-	if err != nil {
-		if ctx.Err() != nil {
-			return nil, "", ctx.Err()
-		}
-		return nil, "", &domain.TrackerError{
-			Kind:    domain.ErrTrackerTransport,
-			Message: fmt.Sprintf("failed to build request: %s %s", method, path),
-			Err:     err,
-		}
-	}
-
-	c.setHeaders(req)
-
-	resp, err := c.httpClient.Do(req) //nolint:gosec // controlled URL, see above
-	if err != nil {
-		if ctx.Err() != nil {
-			return nil, "", ctx.Err()
-		}
-		return nil, "", &domain.TrackerError{
-			Kind:    domain.ErrTrackerTransport,
-			Message: fmt.Sprintf("%s %s: network error", method, path),
-			Err:     err,
-		}
-	}
-	defer resp.Body.Close() //nolint:errcheck // best-effort cleanup on response body
-
-	if resp.StatusCode == http.StatusOK {
-		body, err := io.ReadAll(resp.Body)
-		if err != nil {
-			return nil, "", &domain.TrackerError{
-				Kind:    domain.ErrTrackerTransport,
-				Message: "failed to read response body",
-				Err:     err,
-			}
-		}
-		linkNext := parseLinkNext(resp.Header.Get("Link"))
-		return body, linkNext, nil
-	}
-
-	return nil, "", classifyHTTPError(resp, method, path)
-}
-
-// doURL executes a GET request using a full URL (typically from a Link
-// header). Sets the same authentication and API version headers as
-// [githubClient.do]. Used exclusively for pagination.
-func (c *githubClient) doURL(ctx context.Context, fullURL string) ([]byte, string, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fullURL, nil) //nolint:gosec // fullURL comes from GitHub Link headers, not user input
-	if err != nil {
-		if ctx.Err() != nil {
-			return nil, "", ctx.Err()
-		}
-		return nil, "", &domain.TrackerError{
-			Kind:    domain.ErrTrackerTransport,
-			Message: fmt.Sprintf("failed to build pagination request: %s", fullURL),
-			Err:     err,
-		}
-	}
-
-	c.setHeaders(req)
-
-	resp, err := c.httpClient.Do(req) //nolint:gosec // controlled URL from Link header
-	if err != nil {
-		if ctx.Err() != nil {
-			return nil, "", ctx.Err()
-		}
-		return nil, "", &domain.TrackerError{
-			Kind:    domain.ErrTrackerTransport,
-			Message: fmt.Sprintf("GET %s: network error", fullURL),
-			Err:     err,
-		}
-	}
-	defer resp.Body.Close() //nolint:errcheck // best-effort cleanup on response body
-
-	if resp.StatusCode == http.StatusOK {
-		body, err := io.ReadAll(resp.Body)
-		if err != nil {
-			return nil, "", &domain.TrackerError{
-				Kind:    domain.ErrTrackerTransport,
-				Message: "failed to read response body",
-				Err:     err,
-			}
-		}
-		linkNext := parseLinkNext(resp.Header.Get("Link"))
-		return body, linkNext, nil
-	}
-
-	return nil, "", classifyHTTPError(resp, http.MethodGet, fullURL)
-}
-
-// doJSON executes an HTTP request with a JSON body. Successful
-// responses (200-299) return the response body. Non-success responses
-// are classified via [classifyHTTPError].
-func (c *githubClient) doJSON(ctx context.Context, method, path string, body io.Reader) ([]byte, error) { //nolint:unparam // callers may inspect response body in future operations
-	reqURL := c.baseURL + path
-
-	req, err := http.NewRequestWithContext(ctx, method, reqURL, body)
-	if err != nil {
-		if ctx.Err() != nil {
-			return nil, ctx.Err()
-		}
-		return nil, &domain.TrackerError{
-			Kind:    domain.ErrTrackerTransport,
-			Message: fmt.Sprintf("failed to build request: %s %s", method, path),
-			Err:     err,
-		}
-	}
-
-	c.setHeaders(req)
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err := c.httpClient.Do(req)
-	if err != nil {
-		if ctx.Err() != nil {
-			return nil, ctx.Err()
-		}
-		return nil, &domain.TrackerError{
-			Kind:    domain.ErrTrackerTransport,
-			Message: fmt.Sprintf("%s %s: network error", method, path),
-			Err:     err,
-		}
-	}
-	defer resp.Body.Close() //nolint:errcheck // best-effort cleanup on response body
-
-	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
-		respBody, err := io.ReadAll(resp.Body)
-		if err != nil {
-			return nil, &domain.TrackerError{
-				Kind:    domain.ErrTrackerTransport,
-				Message: "failed to read response body",
-				Err:     err,
-			}
-		}
-		return respBody, nil
-	}
-
-	return nil, classifyHTTPError(resp, method, path)
-}
-
-// doNoBody executes an HTTP request without a request body and
-// discards the response body. Accepts 200 and 204 as success. Used
-// for label removal (DELETE).
-func (c *githubClient) doNoBody(ctx context.Context, method, path string) error { //nolint:unparam // DELETE is the only caller today; method kept for interface consistency
-	reqURL := c.baseURL + path
-
-	req, err := http.NewRequestWithContext(ctx, method, reqURL, nil)
-	if err != nil {
-		if ctx.Err() != nil {
-			return ctx.Err()
-		}
-		return &domain.TrackerError{
-			Kind:    domain.ErrTrackerTransport,
-			Message: fmt.Sprintf("failed to build request: %s %s", method, path),
-			Err:     err,
-		}
-	}
-
-	c.setHeaders(req)
-
-	resp, err := c.httpClient.Do(req)
-	if err != nil {
-		if ctx.Err() != nil {
-			return ctx.Err()
-		}
-		return &domain.TrackerError{
-			Kind:    domain.ErrTrackerTransport,
-			Message: fmt.Sprintf("%s %s: network error", method, path),
-			Err:     err,
-		}
-	}
-	defer resp.Body.Close() //nolint:errcheck // best-effort cleanup on response body
-
-	if resp.StatusCode == http.StatusOK || resp.StatusCode == http.StatusNoContent {
-		_, _ = io.Copy(io.Discard, resp.Body)
-		return nil
-	}
-
-	return classifyHTTPError(resp, method, path)
-}
-
-// doConditional executes an HTTP request with optional conditional-GET
-// support. If ifNoneMatch is non-empty, sets the If-None-Match header.
-// Returns (body, etag, notModified, error):
-//   - On 304 Not Modified: body is nil, etag is empty, notModified is true.
-//   - On 200 OK: body is the response body, etag is the response ETag
-//     header (may be empty), notModified is false.
-//   - On error: body is nil, etag is empty, notModified is false.
-func (c *githubClient) doConditional(ctx context.Context, method, path string, params url.Values, ifNoneMatch string) (body []byte, etag string, notModified bool, err error) { //nolint:unparam // method is GET today but the signature mirrors do() for consistency
-	reqURL := c.baseURL + path
-	if len(params) > 0 {
-		reqURL += "?" + params.Encode()
-	}
-
-	req, err := http.NewRequestWithContext(ctx, method, reqURL, nil) //nolint:gosec // URL is constructed from operator-configured base URL + internal API paths, not user data
-	if err != nil {
-		if ctx.Err() != nil {
-			return nil, "", false, ctx.Err()
-		}
-		return nil, "", false, &domain.TrackerError{
-			Kind:    domain.ErrTrackerTransport,
-			Message: fmt.Sprintf("failed to build request: %s %s", method, path),
-			Err:     err,
-		}
-	}
-
-	c.setHeaders(req)
-	if ifNoneMatch != "" {
-		req.Header.Set("If-None-Match", ifNoneMatch)
-	}
-
-	resp, err := c.httpClient.Do(req) //nolint:gosec // controlled URL, see above
-	if err != nil {
-		if ctx.Err() != nil {
-			return nil, "", false, ctx.Err()
-		}
-		return nil, "", false, &domain.TrackerError{
-			Kind:    domain.ErrTrackerTransport,
-			Message: fmt.Sprintf("%s %s: network error", method, path),
-			Err:     err,
-		}
-	}
-	defer resp.Body.Close() //nolint:errcheck // best-effort cleanup on response body
-
-	if resp.StatusCode == http.StatusNotModified {
-		_, _ = io.Copy(io.Discard, resp.Body)
-		return nil, "", true, nil
-	}
-
-	if resp.StatusCode == http.StatusOK {
-		respBody, err := io.ReadAll(resp.Body)
-		if err != nil {
-			return nil, "", false, &domain.TrackerError{
-				Kind:    domain.ErrTrackerTransport,
-				Message: "failed to read response body",
-				Err:     err,
-			}
-		}
-		return respBody, resp.Header.Get("ETag"), false, nil
-	}
-
-	return nil, "", false, classifyHTTPError(resp, method, path)
-}
-
-// classifyHTTPError maps a non-success HTTP response to a
-// [*domain.TrackerError] with GitHub-specific 403 disambiguation.
 func classifyHTTPError(resp *http.Response, method, path string) error {
 	snippet, _ := io.ReadAll(io.LimitReader(resp.Body, maxErrorBody))
 	_, _ = io.Copy(io.Discard, resp.Body)
@@ -316,7 +50,6 @@ func classifyHTTPError(resp *http.Response, method, path string) error {
 		}
 
 	case resp.StatusCode == http.StatusForbidden:
-		// Disambiguate 403: primary rate limit, secondary rate limit, or insufficient permissions.
 		if resp.Header.Get("X-Ratelimit-Remaining") == "0" {
 			return &domain.TrackerError{
 				Kind:    domain.ErrTrackerAPI,
@@ -324,13 +57,13 @@ func classifyHTTPError(resp *http.Response, method, path string) error {
 			}
 		}
 		if strings.Contains(strings.ToLower(detail), "rate limit") {
-			msg := fmt.Sprintf("%s %s: rate limited (secondary)", method, path)
-			if ra := resp.Header.Get("Retry-After"); ra != "" {
-				msg += fmt.Sprintf(" (retry after %s seconds)", ra)
+			message := fmt.Sprintf("%s %s: rate limited (secondary)", method, path)
+			if retryAfter := resp.Header.Get("Retry-After"); retryAfter != "" {
+				message += fmt.Sprintf(" (retry after %s seconds)", retryAfter)
 			}
 			return &domain.TrackerError{
 				Kind:    domain.ErrTrackerAPI,
-				Message: msg,
+				Message: message,
 			}
 		}
 		return &domain.TrackerError{
@@ -357,13 +90,13 @@ func classifyHTTPError(resp *http.Response, method, path string) error {
 		}
 
 	case resp.StatusCode == http.StatusTooManyRequests:
-		msg := fmt.Sprintf("%s %s: rate limited", method, path)
-		if ra := resp.Header.Get("Retry-After"); ra != "" {
-			msg += fmt.Sprintf(" (retry after %s seconds)", ra)
+		message := fmt.Sprintf("%s %s: rate limited", method, path)
+		if retryAfter := resp.Header.Get("Retry-After"); retryAfter != "" {
+			message += fmt.Sprintf(" (retry after %s seconds)", retryAfter)
 		}
 		return &domain.TrackerError{
 			Kind:    domain.ErrTrackerAPI,
-			Message: msg,
+			Message: message,
 		}
 
 	case resp.StatusCode >= 500:
@@ -380,87 +113,10 @@ func classifyHTTPError(resp *http.Response, method, path string) error {
 	}
 }
 
-// parseLinkNext extracts the URL with rel="next" from the Link header
-// value. Returns an empty string when absent or malformed.
-func parseLinkNext(header string) string {
-	if header == "" {
-		return ""
+func classifyTransportError(err error, method, path string) error {
+	return &domain.TrackerError{
+		Kind:    domain.ErrTrackerTransport,
+		Message: fmt.Sprintf("%s %s: transport error", method, path),
+		Err:     err,
 	}
-
-	for _, segment := range strings.Split(header, ",") {
-		parts := strings.Split(segment, ";")
-		if len(parts) < 2 {
-			continue
-		}
-
-		hasNext := false
-		for _, attr := range parts[1:] {
-			attr = strings.TrimSpace(attr)
-			if strings.EqualFold(attr, `rel="next"`) {
-				hasNext = true
-				break
-			}
-		}
-		if !hasNext {
-			continue
-		}
-
-		urlPart := strings.TrimSpace(parts[0])
-		if start := strings.Index(urlPart, "<"); start != -1 {
-			if end := strings.Index(urlPart[start:], ">"); end != -1 {
-				return urlPart[start+1 : start+end]
-			}
-		}
-	}
-
-	return ""
-}
-
-// doRawGet executes a GET request and returns the response body as
-// raw bytes. Reads up to maxBytes from the body to prevent memory
-// exhaustion. Used for log fetching where the response is text, not
-// JSON. Follows redirects via the default http.Client behavior.
-func (c *githubClient) doRawGet(ctx context.Context, path string, maxBytes int64) ([]byte, error) {
-	reqURL := c.baseURL + path
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil) //nolint:gosec // URL is constructed from operator-configured base URL + internal API paths, not user data
-	if err != nil {
-		if ctx.Err() != nil {
-			return nil, ctx.Err()
-		}
-		return nil, &domain.TrackerError{
-			Kind:    domain.ErrTrackerTransport,
-			Message: fmt.Sprintf("failed to build request: GET %s", path),
-			Err:     err,
-		}
-	}
-
-	c.setHeaders(req)
-
-	resp, err := c.httpClient.Do(req) //nolint:gosec // controlled URL, see above
-	if err != nil {
-		if ctx.Err() != nil {
-			return nil, ctx.Err()
-		}
-		return nil, &domain.TrackerError{
-			Kind:    domain.ErrTrackerTransport,
-			Message: fmt.Sprintf("GET %s: network error", path),
-			Err:     err,
-		}
-	}
-	defer resp.Body.Close() //nolint:errcheck // best-effort cleanup on response body
-
-	if resp.StatusCode == http.StatusOK {
-		body, err := io.ReadAll(io.LimitReader(resp.Body, maxBytes))
-		if err != nil {
-			return nil, &domain.TrackerError{
-				Kind:    domain.ErrTrackerTransport,
-				Message: "failed to read response body",
-				Err:     err,
-			}
-		}
-		return body, nil
-	}
-
-	return nil, classifyHTTPError(resp, http.MethodGet, path)
 }

--- a/internal/scm/github/client_test.go
+++ b/internal/scm/github/client_test.go
@@ -8,102 +8,30 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"strings"
 	"testing"
 
 	"github.com/sortie-ai/sortie/internal/domain"
+	"github.com/sortie-ai/sortie/internal/httpkit"
 )
 
-// newTestClient creates a githubClient pointed at the given base URL with
-// a test token and user-agent. Each call gets an isolated HTTP transport
-// cloned from DefaultTransport so that parallel tests whose httptest
-// servers close do not race against shared idle connections.
-func newTestClient(t *testing.T, baseURL string) *githubClient {
+func newTestClient(t *testing.T, baseURL string) *httpkit.Client {
 	t.Helper()
-	defaultTransport, ok := http.DefaultTransport.(*http.Transport)
-	if !ok {
-		t.Fatalf("http.DefaultTransport is %T, want *http.Transport", http.DefaultTransport)
-	}
-	transport := defaultTransport.Clone()
-	c := newGitHubClient(baseURL, "test-token", "sortie/test")
-	c.httpClient.Transport = transport
-	t.Cleanup(func() {
-		transport.CloseIdleConnections()
-	})
-	return c
+	return newGitHubClient(baseURL, "test-token", "sortie/test")
 }
 
-// assertClientError asserts that err is a *domain.TrackerError with the
-// expected Kind. Fatals when err is nil.
 func assertClientError(t *testing.T, err error, want domain.TrackerErrorKind) {
 	t.Helper()
 	if err == nil {
 		t.Fatalf("expected error with kind %q, got nil", want)
 	}
-	var te *domain.TrackerError
-	if !errors.As(err, &te) {
+	var trackerErr *domain.TrackerError
+	if !errors.As(err, &trackerErr) {
 		t.Fatalf("error type = %T, want *domain.TrackerError", err)
 	}
-	if te.Kind != want {
-		t.Errorf("TrackerError.Kind = %q, want %q", te.Kind, want)
+	if trackerErr.Kind != want {
+		t.Errorf("TrackerError.Kind = %q, want %q", trackerErr.Kind, want)
 	}
 }
-
-// --- parseLinkNext ---
-
-func TestParseLinkNext(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name   string
-		header string
-		want   string
-	}{
-		{
-			name:   "single rel next",
-			header: `<https://api.github.com/repos/o/r/issues?page=2>; rel="next"`,
-			want:   "https://api.github.com/repos/o/r/issues?page=2",
-		},
-		{
-			name:   "next among multiple rels",
-			header: `<https://api.github.com/repos/o/r/issues?page=3>; rel="last", <https://api.github.com/repos/o/r/issues?page=2>; rel="next"`,
-			want:   "https://api.github.com/repos/o/r/issues?page=2",
-		},
-		{
-			name:   "no next rel returns empty",
-			header: `<https://api.github.com/repos/o/r/issues?page=3>; rel="last"`,
-			want:   "",
-		},
-		{
-			name:   "empty header returns empty",
-			header: "",
-			want:   "",
-		},
-		{
-			name:   "malformed header no angle brackets",
-			header: `https://api.github.com; rel="next"`,
-			want:   "",
-		},
-		{
-			name:   "prev and next together",
-			header: `<https://example.com/page=1>; rel="prev", <https://example.com/page=3>; rel="next"`,
-			want:   "https://example.com/page=3",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			got := parseLinkNext(tt.header)
-			if got != tt.want {
-				t.Errorf("parseLinkNext(%q) = %q, want %q", tt.header, got, tt.want)
-			}
-		})
-	}
-}
-
-// --- classifyHTTPError ---
 
 func TestClassifyHTTPError(t *testing.T) {
 	t.Parallel()
@@ -115,148 +43,70 @@ func TestClassifyHTTPError(t *testing.T) {
 		body     string
 		wantKind domain.TrackerErrorKind
 	}{
-		{
-			name:     "400 bad request",
-			status:   http.StatusBadRequest,
-			body:     "bad input",
-			wantKind: domain.ErrTrackerPayload,
-		},
-		{
-			name:     "401 unauthorized",
-			status:   http.StatusUnauthorized,
-			wantKind: domain.ErrTrackerAuth,
-		},
-		{
-			name:     "403 rate limited primary X-Ratelimit-Remaining=0",
-			status:   http.StatusForbidden,
-			headers:  map[string]string{"X-Ratelimit-Remaining": "0"},
-			wantKind: domain.ErrTrackerAPI,
-		},
-		{
-			name:     "403 rate limited secondary body contains rate limit",
-			status:   http.StatusForbidden,
-			body:     `{"message":"You have exceeded a secondary rate limit"}`,
-			wantKind: domain.ErrTrackerAPI,
-		},
-		{
-			name:     "403 permission denied other 403",
-			status:   http.StatusForbidden,
-			body:     "forbidden",
-			wantKind: domain.ErrTrackerAuth,
-		},
-		{
-			name:     "404 not found",
-			status:   http.StatusNotFound,
-			wantKind: domain.ErrTrackerNotFound,
-		},
-		{
-			name:     "410 gone",
-			status:   http.StatusGone,
-			wantKind: domain.ErrTrackerAPI,
-		},
-		{
-			name:     "422 validation failed",
-			status:   http.StatusUnprocessableEntity,
-			body:     "validation error",
-			wantKind: domain.ErrTrackerPayload,
-		},
-		{
-			name:     "429 rate limited",
-			status:   http.StatusTooManyRequests,
-			headers:  map[string]string{"Retry-After": "60"},
-			wantKind: domain.ErrTrackerAPI,
-		},
-		{
-			name:     "500 server error",
-			status:   http.StatusInternalServerError,
-			body:     "oops",
-			wantKind: domain.ErrTrackerTransport,
-		},
-		{
-			name:     "502 bad gateway",
-			status:   http.StatusBadGateway,
-			wantKind: domain.ErrTrackerTransport,
-		},
-		{
-			name:     "503 service unavailable",
-			status:   http.StatusServiceUnavailable,
-			wantKind: domain.ErrTrackerTransport,
-		},
-		{
-			name:     "unexpected status",
-			status:   418,
-			body:     "I'm a teapot",
-			wantKind: domain.ErrTrackerAPI,
-		},
+		{"400 bad request", http.StatusBadRequest, nil, "bad input", domain.ErrTrackerPayload},
+		{"401 unauthorized", http.StatusUnauthorized, nil, "", domain.ErrTrackerAuth},
+		{"403 rate limited primary", http.StatusForbidden, map[string]string{"X-Ratelimit-Remaining": "0"}, "", domain.ErrTrackerAPI},
+		{"403 rate limited secondary", http.StatusForbidden, nil, `{"message":"You have exceeded a secondary rate limit"}`, domain.ErrTrackerAPI},
+		{"403 permission denied", http.StatusForbidden, nil, "forbidden", domain.ErrTrackerAuth},
+		{"404 not found", http.StatusNotFound, nil, "", domain.ErrTrackerNotFound},
+		{"410 gone", http.StatusGone, nil, "", domain.ErrTrackerAPI},
+		{"422 validation failed", http.StatusUnprocessableEntity, nil, "validation error", domain.ErrTrackerPayload},
+		{"429 rate limited", http.StatusTooManyRequests, map[string]string{"Retry-After": "60"}, "", domain.ErrTrackerAPI},
+		{"500 server error", http.StatusInternalServerError, nil, "oops", domain.ErrTrackerTransport},
+		{"502 bad gateway", http.StatusBadGateway, nil, "", domain.ErrTrackerTransport},
+		{"503 service unavailable", http.StatusServiceUnavailable, nil, "", domain.ErrTrackerTransport},
+		{"unexpected status", 418, nil, "I'm a teapot", domain.ErrTrackerAPI},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			h := make(http.Header)
-			for k, v := range tt.headers {
-				h.Set(k, v)
+			headers := make(http.Header)
+			for key, value := range tt.headers {
+				headers.Set(key, value)
 			}
 			resp := &http.Response{
 				StatusCode: tt.status,
-				Header:     h,
+				Header:     headers,
 				Body:       io.NopCloser(bytes.NewBufferString(tt.body)),
 			}
 			defer resp.Body.Close() //nolint:errcheck // NopCloser.Close always returns nil
 
-			err := classifyHTTPError(resp, "GET", "/test/path")
+			err := classifyHTTPError(resp, http.MethodGet, "/test/path")
 			assertClientError(t, err, tt.wantKind)
 		})
 	}
 }
 
-func TestClassifyHTTPError_429_RetryAfterInMessage(t *testing.T) {
-	t.Parallel()
-
-	resp := &http.Response{
-		StatusCode: http.StatusTooManyRequests,
-		Header:     http.Header{"Retry-After": []string{"30"}},
-		Body:       io.NopCloser(bytes.NewBufferString("")),
-	}
-	defer resp.Body.Close() //nolint:errcheck // NopCloser.Close always returns nil
-
-	err := classifyHTTPError(resp, "GET", "/repos/o/r/issues")
-	var te *domain.TrackerError
-	if !errors.As(err, &te) {
-		t.Fatalf("error type = %T, want *domain.TrackerError", err)
-	}
-	if !strings.Contains(te.Message, "30") {
-		t.Errorf("message = %q, should contain Retry-After value", te.Message)
-	}
-}
-
-// --- do ---
-
-func TestDo_Success(t *testing.T) {
+func TestClientGet_Success(t *testing.T) {
 	t.Parallel()
 
 	var gotHeaders http.Header
+	var gotQuery url.Values
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotHeaders = r.Header.Clone()
+		gotQuery = r.URL.Query()
+		w.Header().Set("X-Result", "ok")
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte(`{"ok":true}`)) //nolint:errcheck // test helper
 	}))
 	defer srv.Close()
 
-	c := newTestClient(t, srv.URL)
-	body, linkNext, err := c.do(context.Background(), "GET", "/repos/o/r/issues", nil)
+	client := newTestClient(t, srv.URL)
+	body, headers, err := client.Get(context.Background(), "/repos/o/r/issues", url.Values{"state": {"open"}})
 	if err != nil {
-		t.Fatalf("do: %v", err)
+		t.Fatalf("Get: %v", err)
 	}
 	if string(body) != `{"ok":true}` {
 		t.Errorf("body = %q, want %q", body, `{"ok":true}`)
 	}
-	if linkNext != "" {
-		t.Errorf("linkNext = %q, want empty", linkNext)
+	if got := headers.Get("X-Result"); got != "ok" {
+		t.Errorf("headers.Get(X-Result) = %q, want %q", got, "ok")
 	}
-
-	// Verify required GitHub API headers.
+	if got := gotQuery.Get("state"); got != "open" {
+		t.Errorf("state param = %q, want %q", got, "open")
+	}
 	if got := gotHeaders.Get("Authorization"); got != "Bearer test-token" {
 		t.Errorf("Authorization = %q, want %q", got, "Bearer test-token")
 	}
@@ -269,638 +119,12 @@ func TestDo_Success(t *testing.T) {
 	if got := gotHeaders.Get("User-Agent"); got != "sortie/test" {
 		t.Errorf("User-Agent = %q, want %q", got, "sortie/test")
 	}
-}
-
-func TestDo_LinkHeaderParsed(t *testing.T) {
-	t.Parallel()
-
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Link", `<https://api.github.com/repos/o/r/issues?page=2>; rel="next", <https://api.github.com/repos/o/r/issues?page=5>; rel="last"`)
-		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("[]")) //nolint:errcheck // test helper
-	}))
-	defer srv.Close()
-
-	c := newTestClient(t, srv.URL)
-	_, linkNext, err := c.do(context.Background(), "GET", "/repos/o/r/issues", nil)
-	if err != nil {
-		t.Fatalf("do: %v", err)
-	}
-	if linkNext != "https://api.github.com/repos/o/r/issues?page=2" {
-		t.Errorf("linkNext = %q, want page=2 URL", linkNext)
+	if got := gotHeaders.Get("Content-Type"); got != "" {
+		t.Errorf("Content-Type = %q, want empty", got)
 	}
 }
 
-func TestDo_QueryParams(t *testing.T) {
-	t.Parallel()
-
-	var gotQuery url.Values
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		gotQuery = r.URL.Query()
-		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("[]")) //nolint:errcheck // test helper
-	}))
-	defer srv.Close()
-
-	c := newTestClient(t, srv.URL)
-	params := url.Values{"state": {"open"}, "per_page": {"50"}}
-	_, _, err := c.do(context.Background(), "GET", "/repos/o/r/issues", params)
-	if err != nil {
-		t.Fatalf("do: %v", err)
-	}
-	if got := gotQuery.Get("state"); got != "open" {
-		t.Errorf("state param = %q, want %q", got, "open")
-	}
-	if got := gotQuery.Get("per_page"); got != "50" {
-		t.Errorf("per_page param = %q, want %q", got, "50")
-	}
-}
-
-func TestDo_304NotModified(t *testing.T) {
-	t.Parallel()
-
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusNotModified)
-	}))
-	defer srv.Close()
-
-	c := newTestClient(t, srv.URL)
-	_, _, err := c.do(context.Background(), "GET", "/path", nil)
-	if err == nil {
-		t.Fatal("do 304: expected error, got nil")
-	}
-	var trackerErr *domain.TrackerError
-	if !errors.As(err, &trackerErr) {
-		t.Fatalf("error type = %T, want *domain.TrackerError", err)
-	}
-	if trackerErr.Kind != domain.ErrTrackerAPI {
-		t.Errorf("TrackerError.Kind = %q, want %q", trackerErr.Kind, domain.ErrTrackerAPI)
-	}
-}
-
-func TestDo_ContextCancellation(t *testing.T) {
-	t.Parallel()
-
-	started := make(chan struct{})
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		close(started)
-		<-r.Context().Done()
-	}))
-	defer srv.Close()
-
-	ctx, cancel := context.WithCancel(context.Background())
-	c := newTestClient(t, srv.URL)
-
-	errCh := make(chan error, 1)
-	go func() {
-		_, _, err := c.do(ctx, "GET", "/repos/o/r/issues", nil)
-		errCh <- err
-	}()
-
-	<-started
-	cancel()
-
-	err := <-errCh
-	if err == nil {
-		t.Fatal("expected error after context cancel, got nil")
-	}
-	if !errors.Is(err, context.Canceled) {
-		t.Errorf("error = %v, want context.Canceled", err)
-	}
-}
-
-func TestDo_ErrorStatus(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name     string
-		status   int
-		wantKind domain.TrackerErrorKind
-	}{
-		{"401", http.StatusUnauthorized, domain.ErrTrackerAuth},
-		{"403 perm", http.StatusForbidden, domain.ErrTrackerAuth},
-		{"404", http.StatusNotFound, domain.ErrTrackerNotFound},
-		{"500", http.StatusInternalServerError, domain.ErrTrackerTransport},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.WriteHeader(tt.status)
-			}))
-			defer srv.Close()
-
-			c := newTestClient(t, srv.URL)
-			_, _, err := c.do(context.Background(), "GET", "/path", nil)
-			assertClientError(t, err, tt.wantKind)
-		})
-	}
-}
-
-// --- doURL ---
-
-func TestDoURL_AuthHeadersSent(t *testing.T) {
-	t.Parallel()
-
-	var gotHeaders http.Header
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		gotHeaders = r.Header.Clone()
-		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("[]")) //nolint:errcheck // test helper
-	}))
-	defer srv.Close()
-
-	c := newTestClient(t, srv.URL)
-	_, _, err := c.doURL(context.Background(), srv.URL+"/repos/o/r/issues?page=2")
-	if err != nil {
-		t.Fatalf("doURL: %v", err)
-	}
-
-	if got := gotHeaders.Get("Authorization"); got != "Bearer test-token" {
-		t.Errorf("Authorization = %q, want Bearer prefix", got)
-	}
-	if got := gotHeaders.Get("X-GitHub-Api-Version"); got != "2026-03-10" {
-		t.Errorf("X-GitHub-Api-Version = %q, want %q", got, "2026-03-10")
-	}
-}
-
-func TestDoURL_LinkHeaderParsed(t *testing.T) {
-	t.Parallel()
-
-	nextURL := "https://api.github.com/repos/o/r/issues?page=3"
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Link", `<`+nextURL+`>; rel="next"`)
-		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("[]")) //nolint:errcheck // test helper
-	}))
-	defer srv.Close()
-
-	c := newTestClient(t, srv.URL)
-	_, got, err := c.doURL(context.Background(), srv.URL+"/page")
-	if err != nil {
-		t.Fatalf("doURL: %v", err)
-	}
-	if got != nextURL {
-		t.Errorf("linkNext = %q, want %q", got, nextURL)
-	}
-}
-
-// --- doJSON ---
-
-func TestDoJSON_Success(t *testing.T) {
-	t.Parallel()
-
-	var gotMethod string
-	var gotContentType string
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		gotMethod = r.Method
-		gotContentType = r.Header.Get("Content-Type")
-		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`{"result":"ok"}`)) //nolint:errcheck // test helper
-	}))
-	defer srv.Close()
-
-	c := newTestClient(t, srv.URL)
-	payload := bytes.NewBufferString(`{"labels":["review"]}`)
-	body, err := c.doJSON(context.Background(), "POST", "/repos/o/r/issues/1/labels", payload)
-	if err != nil {
-		t.Fatalf("doJSON: %v", err)
-	}
-	if string(body) != `{"result":"ok"}` {
-		t.Errorf("body = %q", body)
-	}
-	if gotMethod != "POST" {
-		t.Errorf("method = %q, want %q", gotMethod, "POST")
-	}
-	if gotContentType != "application/json" {
-		t.Errorf("Content-Type = %q, want %q", gotContentType, "application/json")
-	}
-}
-
-func TestDoJSON_2xxRange(t *testing.T) {
-	t.Parallel()
-
-	for _, status := range []int{200, 201, 204} {
-		t.Run(http.StatusText(status), func(t *testing.T) {
-			t.Parallel()
-
-			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.WriteHeader(status)
-			}))
-			t.Cleanup(srv.Close)
-
-			c := newTestClient(t, srv.URL)
-			_, err := c.doJSON(context.Background(), "PATCH", "/repos/o/r/issues/1", bytes.NewBufferString("{}"))
-			if err != nil {
-				t.Errorf("doJSON %d: unexpected error: %v", status, err)
-			}
-		})
-	}
-}
-
-func TestDoJSON_Error(t *testing.T) {
-	t.Parallel()
-
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusUnprocessableEntity)
-		w.Write([]byte(`{"errors":["invalid"]}`)) //nolint:errcheck // test helper
-	}))
-	defer srv.Close()
-
-	c := newTestClient(t, srv.URL)
-	_, err := c.doJSON(context.Background(), "POST", "/labels", bytes.NewBufferString("{}"))
-	assertClientError(t, err, domain.ErrTrackerPayload)
-}
-
-// --- doNoBody ---
-
-func TestDoNoBody_200(t *testing.T) {
-	t.Parallel()
-
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer srv.Close()
-
-	c := newTestClient(t, srv.URL)
-	if err := c.doNoBody(context.Background(), "DELETE", "/repos/o/r/issues/1/labels/backlog"); err != nil {
-		t.Errorf("doNoBody 200: unexpected error: %v", err)
-	}
-}
-
-func TestDoNoBody_204(t *testing.T) {
-	t.Parallel()
-
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != "DELETE" {
-			t.Errorf("method = %q, want DELETE", r.Method)
-		}
-		w.WriteHeader(http.StatusNoContent)
-	}))
-	defer srv.Close()
-
-	c := newTestClient(t, srv.URL)
-	if err := c.doNoBody(context.Background(), "DELETE", "/repos/o/r/issues/1/labels/backlog"); err != nil {
-		t.Errorf("doNoBody 204: unexpected error: %v", err)
-	}
-}
-
-func TestDoNoBody_Error(t *testing.T) {
-	t.Parallel()
-
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusForbidden)
-	}))
-	defer srv.Close()
-
-	c := newTestClient(t, srv.URL)
-	err := c.doNoBody(context.Background(), "DELETE", "/repos/o/r/issues/1/labels/backlog")
-	assertClientError(t, err, domain.ErrTrackerAuth)
-}
-
-func TestDoNoBody_ContextCancellation(t *testing.T) {
-	t.Parallel()
-
-	started := make(chan struct{})
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		close(started)
-		<-r.Context().Done()
-	}))
-	defer srv.Close()
-
-	ctx, cancel := context.WithCancel(context.Background())
-	c := newTestClient(t, srv.URL)
-
-	errCh := make(chan error, 1)
-	go func() {
-		errCh <- c.doNoBody(ctx, "DELETE", "/repos/o/r/issues/1/labels/backlog")
-	}()
-
-	<-started
-	cancel()
-
-	err := <-errCh
-	if err == nil {
-		t.Fatal("expected error after context cancel")
-	}
-	if !errors.Is(err, context.Canceled) {
-		t.Errorf("error = %v, want context.Canceled", err)
-	}
-}
-
-func TestDoURL_NonOKStatus(t *testing.T) {
-	t.Parallel()
-
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusUnauthorized)
-	}))
-	defer srv.Close()
-
-	c := newTestClient(t, srv.URL)
-	_, _, err := c.doURL(context.Background(), srv.URL+"/repos/o/r/issues?page=2")
-	assertClientError(t, err, domain.ErrTrackerAuth)
-}
-
-func TestDoURL_ContextCancellation(t *testing.T) {
-	t.Parallel()
-
-	started := make(chan struct{})
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		close(started)
-		<-r.Context().Done()
-	}))
-	defer srv.Close()
-
-	ctx, cancel := context.WithCancel(context.Background())
-	c := newTestClient(t, srv.URL)
-
-	errCh := make(chan error, 1)
-	go func() {
-		_, _, err := c.doURL(ctx, srv.URL+"/repos/o/r/issues?page=2")
-		errCh <- err
-	}()
-
-	<-started
-	cancel()
-
-	err := <-errCh
-	if err == nil {
-		t.Fatal("expected error after context cancel")
-	}
-	if !errors.Is(err, context.Canceled) {
-		t.Errorf("error = %v, want context.Canceled", err)
-	}
-}
-
-func TestDoJSON_ContextCancellation(t *testing.T) {
-	t.Parallel()
-
-	started := make(chan struct{})
-	release := make(chan struct{})
-
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		close(started)
-		<-release // unblocked by the test to allow srv.Close() to finish cleanly
-	}))
-	defer srv.Close()
-
-	ctx, cancel := context.WithCancel(context.Background())
-	c := newTestClient(t, srv.URL)
-
-	errCh := make(chan error, 1)
-	go func() {
-		_, err := c.doJSON(ctx, "PATCH", "/repos/o/r/issues/1", bytes.NewBufferString(`{}`))
-		errCh <- err
-	}()
-
-	<-started
-	cancel()
-
-	err := <-errCh
-	close(release) // let the handler return so srv.Close() does not hang
-
-	if err == nil {
-		t.Fatal("expected error after context cancel")
-	}
-	if !errors.Is(err, context.Canceled) {
-		t.Errorf("error = %v, want context.Canceled", err)
-	}
-}
-
-// --- doConditional ---
-
-func TestDoConditional_200_ReturnsBodyAndETag(t *testing.T) {
-	t.Parallel()
-
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("ETag", `"abc123"`)
-		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`{"number":1}`)) //nolint:errcheck // test helper
-	}))
-	defer srv.Close()
-
-	c := newTestClient(t, srv.URL)
-	body, etag, notModified, err := c.doConditional(context.Background(), "GET", "/repos/o/r/issues/1", nil, "")
-	if err != nil {
-		t.Fatalf("doConditional: %v", err)
-	}
-	if notModified {
-		t.Error("notModified = true, want false")
-	}
-	if string(body) != `{"number":1}` {
-		t.Errorf("body = %q, want %q", string(body), `{"number":1}`)
-	}
-	if etag != `"abc123"` {
-		t.Errorf("etag = %q, want %q", etag, `"abc123"`)
-	}
-}
-
-func TestDoConditional_200_NoETagHeader(t *testing.T) {
-	t.Parallel()
-
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`{"number":2}`)) //nolint:errcheck // test helper
-	}))
-	defer srv.Close()
-
-	c := newTestClient(t, srv.URL)
-	body, etag, notModified, err := c.doConditional(context.Background(), "GET", "/repos/o/r/issues/2", nil, "")
-	if err != nil {
-		t.Fatalf("doConditional: %v", err)
-	}
-	if notModified {
-		t.Error("notModified = true, want false")
-	}
-	if len(body) == 0 {
-		t.Error("body is empty, want non-empty")
-	}
-	if etag != "" {
-		t.Errorf("etag = %q, want empty (no ETag header in response)", etag)
-	}
-}
-
-func TestDoConditional_304_NotModified(t *testing.T) {
-	t.Parallel()
-
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusNotModified)
-	}))
-	defer srv.Close()
-
-	c := newTestClient(t, srv.URL)
-	body, etag, notModified, err := c.doConditional(context.Background(), "GET", "/repos/o/r/issues/3", nil, `"cached"`)
-	if err != nil {
-		t.Fatalf("doConditional: %v", err)
-	}
-	if !notModified {
-		t.Error("notModified = false, want true")
-	}
-	if body != nil {
-		t.Errorf("body = %v, want nil on 304", body)
-	}
-	if etag != "" {
-		t.Errorf("etag = %q, want empty on 304", etag)
-	}
-}
-
-func TestDoConditional_SetsIfNoneMatchHeader(t *testing.T) {
-	t.Parallel()
-
-	var gotHeader string
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		gotHeader = r.Header.Get("If-None-Match")
-		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`{}`)) //nolint:errcheck // test helper
-	}))
-	defer srv.Close()
-
-	c := newTestClient(t, srv.URL)
-	_, _, _, err := c.doConditional(context.Background(), "GET", "/repos/o/r/issues/4", nil, `"stored-etag"`)
-	if err != nil {
-		t.Fatalf("doConditional: %v", err)
-	}
-	if gotHeader != `"stored-etag"` {
-		t.Errorf("If-None-Match = %q, want %q", gotHeader, `"stored-etag"`)
-	}
-}
-
-func TestDoConditional_OmitsIfNoneMatchWhenEmpty(t *testing.T) {
-	t.Parallel()
-
-	var gotHeader string
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		gotHeader = r.Header.Get("If-None-Match")
-		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`{}`)) //nolint:errcheck // test helper
-	}))
-	defer srv.Close()
-
-	c := newTestClient(t, srv.URL)
-	_, _, _, err := c.doConditional(context.Background(), "GET", "/repos/o/r/issues/5", nil, "")
-	if err != nil {
-		t.Fatalf("doConditional: %v", err)
-	}
-	if gotHeader != "" {
-		t.Errorf("If-None-Match = %q, want empty (header must be omitted when ifNoneMatch is empty)", gotHeader)
-	}
-}
-
-func TestDoConditional_Error_PassesThrough(t *testing.T) {
-	t.Parallel()
-
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusInternalServerError)
-	}))
-	defer srv.Close()
-
-	c := newTestClient(t, srv.URL)
-	_, _, _, err := c.doConditional(context.Background(), "GET", "/repos/o/r/issues/6", nil, "")
-	assertClientError(t, err, domain.ErrTrackerTransport)
-}
-
-func TestDoConditional_ContextCancellation(t *testing.T) {
-	t.Parallel()
-
-	started := make(chan struct{})
-	release := make(chan struct{})
-
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		close(started)
-		<-release // unblocked after test collects the error
-	}))
-	defer srv.Close()
-
-	ctx, cancel := context.WithCancel(context.Background())
-	c := newTestClient(t, srv.URL)
-
-	errCh := make(chan error, 1)
-	go func() {
-		_, _, _, err := c.doConditional(ctx, "GET", "/repos/o/r/issues/7", nil, "")
-		errCh <- err
-	}()
-
-	<-started
-	cancel()
-
-	err := <-errCh
-	close(release) // let the server handler return so srv.Close() does not hang
-
-	if err == nil {
-		t.Fatal("expected error after context cancel, got nil")
-	}
-	if !errors.Is(err, context.Canceled) {
-		t.Errorf("error = %v, want context.Canceled", err)
-	}
-}
-
-func TestDoConditional_WeakETag(t *testing.T) {
-	t.Parallel()
-
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("ETag", `W/"weaketag"`)
-		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`{}`)) //nolint:errcheck // test helper
-	}))
-	defer srv.Close()
-
-	c := newTestClient(t, srv.URL)
-	_, etag, _, err := c.doConditional(context.Background(), "GET", "/repos/o/r/issues/8", nil, "")
-	if err != nil {
-		t.Fatalf("doConditional: %v", err)
-	}
-	// Weak ETags must be stored and replayed verbatim (opaque token per HTTP spec).
-	if etag != `W/"weaketag"` {
-		t.Errorf("etag = %q, want %q", etag, `W/"weaketag"`)
-	}
-}
-
-// --- doRawGet ---
-
-func TestDoRawGet_Success(t *testing.T) {
-	t.Parallel()
-
-	const want = "hello from the server"
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(want)) //nolint:errcheck // test helper
-	}))
-	defer srv.Close()
-
-	c := newTestClient(t, srv.URL)
-	got, err := c.doRawGet(context.Background(), "/repos/o/r/actions/jobs/1/logs", 1<<20)
-	if err != nil {
-		t.Fatalf("doRawGet: %v", err)
-	}
-	if string(got) != want {
-		t.Errorf("doRawGet body = %q, want %q", string(got), want)
-	}
-}
-
-func TestDoRawGet_BodyTruncation(t *testing.T) {
-	t.Parallel()
-
-	const maxBytes = 10
-	body := strings.Repeat("x", 100)
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(body)) //nolint:errcheck // test helper
-	}))
-	defer srv.Close()
-
-	c := newTestClient(t, srv.URL)
-	got, err := c.doRawGet(context.Background(), "/repos/o/r/actions/jobs/1/logs", maxBytes)
-	if err != nil {
-		t.Fatalf("doRawGet: %v", err)
-	}
-	if int64(len(got)) != maxBytes {
-		t.Errorf("doRawGet body len = %d, want exactly %d (truncated)", len(got), maxBytes)
-	}
-}
-
-func TestDoRawGet_Non200(t *testing.T) {
+func TestClientGet_ErrorStatus(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -909,6 +133,7 @@ func TestDoRawGet_Non200(t *testing.T) {
 		wantKind domain.TrackerErrorKind
 	}{
 		{"401 unauthorized", http.StatusUnauthorized, domain.ErrTrackerAuth},
+		{"403 forbidden", http.StatusForbidden, domain.ErrTrackerAuth},
 		{"404 not found", http.StatusNotFound, domain.ErrTrackerNotFound},
 		{"500 server error", http.StatusInternalServerError, domain.ErrTrackerTransport},
 	}
@@ -922,40 +147,293 @@ func TestDoRawGet_Non200(t *testing.T) {
 			}))
 			defer srv.Close()
 
-			c := newTestClient(t, srv.URL)
-			_, err := c.doRawGet(context.Background(), "/repos/o/r/actions/jobs/1/logs", 1<<20)
+			client := newTestClient(t, srv.URL)
+			_, _, err := client.Get(context.Background(), "/path", nil)
 			assertClientError(t, err, tt.wantKind)
 		})
 	}
 }
 
-func TestDoRawGet_ContextCancelled(t *testing.T) {
+func TestClientGet_NetworkFailure(t *testing.T) {
 	t.Parallel()
 
-	started := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	srv.Close()
+
+	client := newTestClient(t, srv.URL)
+	_, _, err := client.Get(context.Background(), "/repos/o/r/issues", nil)
+	assertClientError(t, err, domain.ErrTrackerTransport)
+}
+
+func TestClientGet_ContextCancellation(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	client := newTestClient(t, "https://example.invalid")
+	_, _, err := client.Get(ctx, "/repos/o/r/issues", nil)
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("error = %v, want context.Canceled", err)
+	}
+}
+
+func TestClientGetURL_AuthHeadersSent(t *testing.T) {
+	t.Parallel()
+
+	var gotHeaders http.Header
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		close(started)
-		<-r.Context().Done()
+		gotHeaders = r.Header.Clone()
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`[]`)) //nolint:errcheck // test helper
 	}))
 	defer srv.Close()
 
-	ctx, cancel := context.WithCancel(context.Background())
-	c := newTestClient(t, srv.URL)
-
-	errCh := make(chan error, 1)
-	go func() {
-		_, err := c.doRawGet(ctx, "/repos/o/r/actions/jobs/1/logs", 1<<20)
-		errCh <- err
-	}()
-
-	<-started
-	cancel()
-
-	err := <-errCh
-	if err == nil {
-		t.Fatal("doRawGet: expected error after context cancel, got nil")
+	client := newTestClient(t, srv.URL)
+	_, _, err := client.GetURL(context.Background(), srv.URL+"/repos/o/r/issues?page=2")
+	if err != nil {
+		t.Fatalf("GetURL: %v", err)
 	}
-	if !errors.Is(err, context.Canceled) {
-		t.Errorf("doRawGet error = %v, want context.Canceled", err)
+	if got := gotHeaders.Get("Authorization"); got != "Bearer test-token" {
+		t.Errorf("Authorization = %q, want %q", got, "Bearer test-token")
+	}
+	if got := gotHeaders.Get("X-GitHub-Api-Version"); got != "2026-03-10" {
+		t.Errorf("X-GitHub-Api-Version = %q, want %q", got, "2026-03-10")
+	}
+	if got := gotHeaders.Get("Content-Type"); got != "" {
+		t.Errorf("Content-Type = %q, want empty", got)
+	}
+}
+
+func TestClientSend_Success(t *testing.T) {
+	t.Parallel()
+
+	var gotMethod string
+	var gotHeaders http.Header
+	var gotBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotHeaders = r.Header.Clone()
+		gotBody, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusCreated)
+		w.Write([]byte(`{"result":"ok"}`)) //nolint:errcheck // test helper
+	}))
+	defer srv.Close()
+
+	client := newTestClient(t, srv.URL)
+	body, err := client.Send(context.Background(), http.MethodPost, "/repos/o/r/issues/1/labels", bytes.NewBufferString(`{"labels":["review"]}`))
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if string(body) != `{"result":"ok"}` {
+		t.Errorf("body = %q, want %q", body, `{"result":"ok"}`)
+	}
+	if gotMethod != http.MethodPost {
+		t.Errorf("method = %q, want %q", gotMethod, http.MethodPost)
+	}
+	if string(gotBody) != `{"labels":["review"]}` {
+		t.Errorf("request body = %q, want %q", gotBody, `{"labels":["review"]}`)
+	}
+	if got := gotHeaders.Get("Content-Type"); got != "application/json" {
+		t.Errorf("Content-Type = %q, want %q", got, "application/json")
+	}
+	if got := gotHeaders.Get("Authorization"); got != "Bearer test-token" {
+		t.Errorf("Authorization = %q, want %q", got, "Bearer test-token")
+	}
+}
+
+func TestClientSend_Error(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		w.Write([]byte(`{"errors":["invalid"]}`)) //nolint:errcheck // test helper
+	}))
+	defer srv.Close()
+
+	client := newTestClient(t, srv.URL)
+	_, err := client.Send(context.Background(), http.MethodPost, "/labels", bytes.NewBufferString("{}"))
+	assertClientError(t, err, domain.ErrTrackerPayload)
+}
+
+func TestClientSendNoBody_Success(t *testing.T) {
+	t.Parallel()
+
+	for _, status := range []int{http.StatusOK, http.StatusNoContent} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			t.Parallel()
+
+			var gotContentType string
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotContentType = r.Header.Get("Content-Type")
+				w.WriteHeader(status)
+			}))
+			defer srv.Close()
+
+			client := newTestClient(t, srv.URL)
+			if err := client.SendNoBody(context.Background(), http.MethodDelete, "/repos/o/r/issues/1/labels/backlog"); err != nil {
+				t.Fatalf("SendNoBody(%d): %v", status, err)
+			}
+			if gotContentType != "" {
+				t.Errorf("Content-Type = %q, want empty", gotContentType)
+			}
+		})
+	}
+}
+
+func TestClientSendNoBody_Error(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer srv.Close()
+
+	client := newTestClient(t, srv.URL)
+	err := client.SendNoBody(context.Background(), http.MethodDelete, "/repos/o/r/issues/1/labels/backlog")
+	assertClientError(t, err, domain.ErrTrackerAuth)
+}
+
+func TestClientGetConditional_200_ReturnsBodyAndETag(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("ETag", `"abc123"`)
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"number":1}`)) //nolint:errcheck // test helper
+	}))
+	defer srv.Close()
+
+	client := newTestClient(t, srv.URL)
+	body, etag, notModified, err := client.GetConditional(context.Background(), "/repos/o/r/issues/1", "", nil)
+	if err != nil {
+		t.Fatalf("GetConditional: %v", err)
+	}
+	if notModified {
+		t.Error("notModified = true, want false")
+	}
+	if string(body) != `{"number":1}` {
+		t.Errorf("body = %q, want %q", body, `{"number":1}`)
+	}
+	if etag != `"abc123"` {
+		t.Errorf("etag = %q, want %q", etag, `"abc123"`)
+	}
+}
+
+func TestClientGetConditional_304_NotModified(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotModified)
+	}))
+	defer srv.Close()
+
+	client := newTestClient(t, srv.URL)
+	body, etag, notModified, err := client.GetConditional(context.Background(), "/repos/o/r/issues/3", `"cached"`, nil)
+	if err != nil {
+		t.Fatalf("GetConditional: %v", err)
+	}
+	if !notModified {
+		t.Error("notModified = false, want true")
+	}
+	if body != nil {
+		t.Errorf("body = %v, want nil on 304", body)
+	}
+	if etag != "" {
+		t.Errorf("etag = %q, want empty on 304", etag)
+	}
+}
+
+func TestClientGetConditional_SetsIfNoneMatchHeader(t *testing.T) {
+	t.Parallel()
+
+	var gotHeader string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotHeader = r.Header.Get("If-None-Match")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{}`)) //nolint:errcheck // test helper
+	}))
+	defer srv.Close()
+
+	client := newTestClient(t, srv.URL)
+	_, _, _, err := client.GetConditional(context.Background(), "/repos/o/r/issues/4", `W/"etag-1"`, nil)
+	if err != nil {
+		t.Fatalf("GetConditional: %v", err)
+	}
+	if gotHeader != `W/"etag-1"` {
+		t.Errorf("If-None-Match = %q, want %q", gotHeader, `W/"etag-1"`)
+	}
+}
+
+func TestClientGetConditional_OmitsIfNoneMatchWhenEmpty(t *testing.T) {
+	t.Parallel()
+
+	var gotHeader string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotHeader = r.Header.Get("If-None-Match")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{}`)) //nolint:errcheck // test helper
+	}))
+	defer srv.Close()
+
+	client := newTestClient(t, srv.URL)
+	_, _, _, err := client.GetConditional(context.Background(), "/repos/o/r/issues/5", "", nil)
+	if err != nil {
+		t.Fatalf("GetConditional: %v", err)
+	}
+	if gotHeader != "" {
+		t.Errorf("If-None-Match = %q, want empty", gotHeader)
+	}
+}
+
+func TestClientGetConditional_WeakETagPreserved(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("ETag", `W/"weak-1"`)
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"number":5}`)) //nolint:errcheck // test helper
+	}))
+	defer srv.Close()
+
+	client := newTestClient(t, srv.URL)
+	_, etag, _, err := client.GetConditional(context.Background(), "/repos/o/r/issues/5", "", nil)
+	if err != nil {
+		t.Fatalf("GetConditional: %v", err)
+	}
+	if etag != `W/"weak-1"` {
+		t.Errorf("etag = %q, want %q", etag, `W/"weak-1"`)
+	}
+}
+
+func TestClientGetConditional_Error(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	client := newTestClient(t, srv.URL)
+	_, _, _, err := client.GetConditional(context.Background(), "/repos/o/r/issues/6", "", nil)
+	assertClientError(t, err, domain.ErrTrackerTransport)
+}
+
+func TestClientGetRaw_Success(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("hello world")) //nolint:errcheck // test helper
+	}))
+	defer srv.Close()
+
+	client := newTestClient(t, srv.URL)
+	body, err := client.GetRaw(context.Background(), "/repos/o/r/actions/jobs/1/logs", 5)
+	if err != nil {
+		t.Fatalf("GetRaw: %v", err)
+	}
+	if string(body) != "hello" {
+		t.Errorf("body = %q, want %q", body, "hello")
 	}
 }

--- a/internal/scm/github/normalize.go
+++ b/internal/scm/github/normalize.go
@@ -2,9 +2,9 @@ package github
 
 import (
 	"strconv"
-	"strings"
 
 	"github.com/sortie-ai/sortie/internal/domain"
+	"github.com/sortie-ai/sortie/internal/issuekit"
 )
 
 // githubIssue represents a single issue from the GitHub REST API.
@@ -71,9 +71,9 @@ func normalizeIssue(gi githubIssue, activeStates, terminalStates []string, hando
 		desc = *gi.Body
 	}
 
-	labels := make([]string, 0, len(gi.Labels))
+	labelNames := make([]string, 0, len(gi.Labels))
 	for _, l := range gi.Labels {
-		labels = append(labels, strings.ToLower(l.Name))
+		labelNames = append(labelNames, l.Name)
 	}
 
 	assignee := ""
@@ -93,7 +93,7 @@ func normalizeIssue(gi githubIssue, activeStates, terminalStates []string, hando
 		Description: desc,
 		State:       extractState(gi.Labels, gi.State, activeStates, terminalStates, handoffState),
 		URL:         gi.HTMLURL,
-		Labels:      labels,
+		Labels:      issuekit.NormalizeLabels(labelNames),
 		Assignee:    assignee,
 		IssueType:   issueType,
 		BlockedBy:   []domain.BlockerRef{},
@@ -132,16 +132,16 @@ func normalizeBlockers(blockers []githubIssue, activeStates, terminalStates []st
 // [domain.Comment] values. Returns a non-nil empty slice when input
 // is empty.
 func normalizeComments(comments []githubComment) []domain.Comment {
-	normalized := make([]domain.Comment, 0, len(comments))
-	for _, c := range comments {
-		normalized = append(normalized, domain.Comment{
+	source := make([]issuekit.SourceComment, len(comments))
+	for i, c := range comments {
+		source[i] = issuekit.SourceComment{
 			ID:        strconv.FormatInt(c.ID, 10),
 			Author:    c.User.Login,
 			Body:      c.Body,
 			CreatedAt: c.CreatedAt,
-		})
+		}
 	}
-	return normalized
+	return issuekit.NormalizeComments(source)
 }
 
 // isPullRequest returns true when the GitHub API entry represents a

--- a/internal/scm/github/review.go
+++ b/internal/scm/github/review.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/sortie-ai/sortie/internal/domain"
+	"github.com/sortie-ai/sortie/internal/httpkit"
 	"github.com/sortie-ai/sortie/internal/registry"
 )
 
@@ -53,7 +54,7 @@ type githubReviewComment struct {
 // GitHubSCMAdapter implements [domain.SCMAdapter] for the GitHub Pull
 // Request Reviews API. Safe for concurrent use.
 type GitHubSCMAdapter struct {
-	client *githubClient
+	client *httpkit.Client
 }
 
 // NewGitHubSCMAdapter creates a [GitHubSCMAdapter] from adapter-specific
@@ -175,13 +176,7 @@ func (a *GitHubSCMAdapter) fetchAllReviews(ctx context.Context, prNumber int, ow
 	path := fmt.Sprintf("/repos/%s/%s/pulls/%d/reviews", url.PathEscape(owner), url.PathEscape(repo), prNumber)
 	params := url.Values{"per_page": {"100"}}
 
-	body, nextURL, err := a.client.do(ctx, "GET", path, params)
-	if err != nil {
-		return nil, toSCMError(err)
-	}
-
-	var all []githubReview
-	for page := 0; page < maxReviewPages; page++ {
+	paginator := httpkit.NewLinkPaginator(a.client, path, params, func(body []byte) ([]githubReview, error) {
 		var batch []githubReview
 		if err := json.Unmarshal(body, &batch); err != nil {
 			return nil, &domain.SCMError{
@@ -190,27 +185,26 @@ func (a *GitHubSCMAdapter) fetchAllReviews(ctx context.Context, prNumber int, ow
 				Err:     err,
 			}
 		}
-		all = append(all, batch...)
+		return batch, nil
+	}, httpkit.PaginatorOptions{
+		MaxPages: maxReviewPages,
+		OnLimitReached: func(limit int) {
+			slog.WarnContext(ctx, "reviews response truncated at page limit",
+				slog.String("owner", owner),
+				slog.String("repo", repo),
+				slog.Int("pr_number", prNumber),
+				slog.Int("max_pages", limit))
+		},
+	})
 
-		if nextURL == "" {
-			break
+	all, err := paginator.All(ctx)
+	if err != nil {
+		var scmErr *domain.SCMError
+		if errors.As(err, &scmErr) {
+			return nil, scmErr
 		}
-
-		body, nextURL, err = a.client.doURL(ctx, nextURL)
-		if err != nil {
-			return nil, toSCMError(err)
-		}
+		return nil, toSCMError(err)
 	}
-
-	if nextURL != "" {
-		slog.WarnContext(ctx, "reviews response truncated at page limit",
-			slog.String("owner", owner),
-			slog.String("repo", repo),
-			slog.Int("pr_number", prNumber),
-			slog.Int("items_fetched", len(all)),
-			slog.Int("max_pages", maxReviewPages))
-	}
-
 	return all, nil
 }
 
@@ -219,13 +213,7 @@ func (a *GitHubSCMAdapter) fetchReviewComments(ctx context.Context, prNumber int
 		url.PathEscape(owner), url.PathEscape(repo), prNumber, reviewID)
 	params := url.Values{"per_page": {"100"}}
 
-	body, nextURL, err := a.client.do(ctx, "GET", path, params)
-	if err != nil {
-		return nil, toSCMError(err)
-	}
-
-	var all []githubReviewComment
-	for page := 0; page < maxReviewPages; page++ {
+	paginator := httpkit.NewLinkPaginator(a.client, path, params, func(body []byte) ([]githubReviewComment, error) {
 		var batch []githubReviewComment
 		if err := json.Unmarshal(body, &batch); err != nil {
 			return nil, &domain.SCMError{
@@ -234,32 +222,31 @@ func (a *GitHubSCMAdapter) fetchReviewComments(ctx context.Context, prNumber int
 				Err:     err,
 			}
 		}
-		all = append(all, batch...)
+		return batch, nil
+	}, httpkit.PaginatorOptions{
+		MaxPages: maxReviewPages,
+		OnLimitReached: func(limit int) {
+			slog.WarnContext(ctx, "review comments response truncated at page limit",
+				slog.String("owner", owner),
+				slog.String("repo", repo),
+				slog.Int("pr_number", prNumber),
+				slog.Int64("review_id", reviewID),
+				slog.Int("max_pages", limit))
+		},
+	})
 
-		if nextURL == "" {
-			break
+	all, err := paginator.All(ctx)
+	if err != nil {
+		var scmErr *domain.SCMError
+		if errors.As(err, &scmErr) {
+			return nil, scmErr
 		}
-
-		body, nextURL, err = a.client.doURL(ctx, nextURL)
-		if err != nil {
-			return nil, toSCMError(err)
-		}
+		return nil, toSCMError(err)
 	}
-
-	if nextURL != "" {
-		slog.WarnContext(ctx, "review comments response truncated at page limit",
-			slog.String("owner", owner),
-			slog.String("repo", repo),
-			slog.Int("pr_number", prNumber),
-			slog.Int64("review_id", reviewID),
-			slog.Int("items_fetched", len(all)),
-			slog.Int("max_pages", maxReviewPages))
-	}
-
 	return all, nil
 }
 
-// toSCMError converts a TrackerError (from the shared githubClient) to
+// toSCMError converts a TrackerError from the shared GitHub transport to
 // the SCMError type. Non-TrackerError errors are wrapped as transport
 // errors.
 func toSCMError(err error) *domain.SCMError {

--- a/internal/scm/github/review_test.go
+++ b/internal/scm/github/review_test.go
@@ -24,15 +24,7 @@ func newTestSCMAdapter(t *testing.T, baseURL string) *GitHubSCMAdapter {
 	if err != nil {
 		t.Fatalf("NewGitHubSCMAdapter: %v", err)
 	}
-	gh := a.(*GitHubSCMAdapter)
-	defaultTransport, ok := http.DefaultTransport.(*http.Transport)
-	if !ok {
-		t.Fatalf("http.DefaultTransport is %T, want *http.Transport", http.DefaultTransport)
-	}
-	transport := defaultTransport.Clone()
-	gh.client.httpClient.Transport = transport
-	t.Cleanup(transport.CloseIdleConnections)
-	return gh
+	return a.(*GitHubSCMAdapter)
 }
 
 func assertSCMErrorKind(t *testing.T, err error, want domain.SCMErrorKind) {
@@ -104,16 +96,25 @@ func TestNewGitHubSCMAdapter_DefaultEndpoint(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewGitHubSCMAdapter: %v", err)
 	}
-	gh := a.(*GitHubSCMAdapter)
-	if !strings.Contains(gh.client.baseURL, "api.github.com") {
-		t.Errorf("default endpoint = %q, want to contain \"api.github.com\"", gh.client.baseURL)
+	if a.(*GitHubSCMAdapter) == nil {
+		t.Fatal("NewGitHubSCMAdapter returned nil adapter")
 	}
 }
 
 func TestNewGitHubSCMAdapter_CustomUserAgent(t *testing.T) {
 	t.Parallel()
 
+	var gotUserAgent string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotUserAgent = r.Header.Get("User-Agent")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(loadFixture(t, "reviews_empty.json"))
+	}))
+	defer srv.Close()
+
 	a, err := NewGitHubSCMAdapter(map[string]any{
+		"endpoint":   srv.URL,
 		"api_key":    "tok",
 		"user_agent": "my-app/1.0",
 	})
@@ -121,8 +122,12 @@ func TestNewGitHubSCMAdapter_CustomUserAgent(t *testing.T) {
 		t.Fatalf("NewGitHubSCMAdapter: %v", err)
 	}
 	gh := a.(*GitHubSCMAdapter)
-	if gh.client.userAgent != "my-app/1.0" {
-		t.Errorf("userAgent = %q, want %q", gh.client.userAgent, "my-app/1.0")
+	_, err = gh.FetchPendingReviews(context.Background(), 1, "owner", "repo")
+	if err != nil {
+		t.Fatalf("FetchPendingReviews: %v", err)
+	}
+	if gotUserAgent != "my-app/1.0" {
+		t.Errorf("User-Agent = %q, want %q", gotUserAgent, "my-app/1.0")
 	}
 }
 

--- a/internal/scm/github/tracker.go
+++ b/internal/scm/github/tracker.go
@@ -2,8 +2,8 @@
 // The package includes [GitHubAdapter], which implements [domain.TrackerAdapter]
 // against the GitHub Issues and Labels REST API, and [GitHubCIProvider], which
 // implements [domain.CIStatusProvider] against the GitHub Checks API. Both
-// adapters share the internal HTTP client ([githubClient]) and ETag cache
-// ([etagCache]). Start with [NewGitHubAdapter] for tracker integration or
+// adapters share the internal HTTP transport and ETag cache ([etagCache]).
+// Start with [NewGitHubAdapter] for tracker integration or
 // [NewGitHubCIProvider] for CI status queries.
 //
 // Unlike the Jira adapter, this adapter stores both activeStates and
@@ -27,7 +27,9 @@ import (
 	"strings"
 
 	"github.com/sortie-ai/sortie/internal/domain"
+	"github.com/sortie-ai/sortie/internal/httpkit"
 	"github.com/sortie-ai/sortie/internal/registry"
+	"github.com/sortie-ai/sortie/internal/trackermetrics"
 	"github.com/sortie-ai/sortie/internal/typeutil"
 )
 
@@ -56,7 +58,7 @@ var defaultTerminalStates = []string{"done", "wontfix"}
 // GitHubAdapter implements [domain.TrackerAdapter] against the GitHub
 // REST API. Safe for concurrent use.
 type GitHubAdapter struct {
-	client         *githubClient
+	client         *httpkit.Client
 	owner          string
 	repo           string
 	activeStates   []string
@@ -166,10 +168,17 @@ func NewGitHubAdapter(config map[string]any) (domain.TrackerAdapter, error) {
 // is set, routes through the search endpoint for server-side
 // filtering. Comments are set to nil on all returned issues.
 func (a *GitHubAdapter) FetchCandidateIssues(ctx context.Context) ([]domain.Issue, error) {
-	if a.queryFilter != "" {
-		return a.fetchCandidatesViaSearch(ctx)
-	}
-	return a.fetchCandidatesViaIssues(ctx)
+	issues := make([]domain.Issue, 0)
+	err := trackermetrics.Track(a.metrics, "fetch_candidates", func() error {
+		var fetchErr error
+		if a.queryFilter != "" {
+			issues, fetchErr = a.fetchCandidatesViaSearch(ctx)
+			return fetchErr
+		}
+		issues, fetchErr = a.fetchCandidatesViaIssues(ctx)
+		return fetchErr
+	})
+	return issues, err
 }
 
 func (a *GitHubAdapter) fetchCandidatesViaIssues(ctx context.Context) ([]domain.Issue, error) {
@@ -181,59 +190,22 @@ func (a *GitHubAdapter) fetchCandidatesViaIssues(ctx context.Context) ([]domain.
 		"per_page":  {"50"},
 	}
 
-	body, nextURL, err := a.client.do(ctx, "GET", path, params)
-	if err != nil {
-		a.incTrackerRequest("fetch_candidates", "error")
-		return nil, err
-	}
-
-	var raw []githubIssue
-	if err := json.Unmarshal(body, &raw); err != nil {
-		a.incTrackerRequest("fetch_candidates", "error")
-		return nil, &domain.TrackerError{
-			Kind:    domain.ErrTrackerPayload,
-			Message: "failed to parse issues response",
-			Err:     err,
-		}
-	}
-
 	activeSet := make(map[string]struct{}, len(a.activeStates))
 	for _, s := range a.activeStates {
 		activeSet[s] = struct{}{}
 	}
 
-	var issues []domain.Issue
-	for _, gi := range raw {
-		if isPullRequest(gi) {
-			continue
-		}
-		issue := normalizeIssue(gi, a.activeStates, a.terminalStates, a.handoffState)
-		a.qualifyDisplayID(&issue)
-		if _, ok := activeSet[issue.State]; !ok {
-			continue
-		}
-		issue.Comments = nil
-		issues = append(issues, issue)
-	}
-
-	pageCount := 1
-	for nextURL != "" && pageCount < maxPages {
-		pageCount++
-		body, nextURL, err = a.client.doURL(ctx, nextURL)
-		if err != nil {
-			a.incTrackerRequest("fetch_candidates", "error")
-			return nil, err
-		}
-
-		raw = raw[:0]
+	paginator := httpkit.NewLinkPaginator(a.client, path, params, func(body []byte) ([]domain.Issue, error) {
+		var raw []githubIssue
 		if err := json.Unmarshal(body, &raw); err != nil {
-			a.incTrackerRequest("fetch_candidates", "error")
 			return nil, &domain.TrackerError{
 				Kind:    domain.ErrTrackerPayload,
 				Message: "failed to parse issues response",
 				Err:     err,
 			}
 		}
+
+		issues := make([]domain.Issue, 0, len(raw))
 		for _, gi := range raw {
 			if isPullRequest(gi) {
 				continue
@@ -246,19 +218,17 @@ func (a *GitHubAdapter) fetchCandidatesViaIssues(ctx context.Context) ([]domain.
 			issue.Comments = nil
 			issues = append(issues, issue)
 		}
-	}
+		return issues, nil
+	}, httpkit.PaginatorOptions{
+		MaxPages: maxPages,
+		OnLimitReached: func(limit int) {
+			slog.Warn("pagination limit reached",
+				slog.Int("max_pages", limit),
+				slog.String("endpoint", "/repos/{owner}/{repo}/issues"))
+		},
+	})
 
-	if pageCount >= maxPages {
-		slog.Warn("pagination limit reached", //nolint:gosec // endpoint is an internal API path constant, not user input
-			slog.Int("max_pages", maxPages),
-			slog.String("endpoint", path))
-	}
-
-	if issues == nil {
-		issues = []domain.Issue{}
-	}
-	a.incTrackerRequest("fetch_candidates", "success")
-	return issues, nil
+	return paginator.All(ctx)
 }
 
 func (a *GitHubAdapter) fetchCandidatesViaSearch(ctx context.Context) ([]domain.Issue, error) {
@@ -270,63 +240,26 @@ func (a *GitHubAdapter) fetchCandidatesViaSearch(ctx context.Context) ([]domain.
 		"per_page": {"50"},
 	}
 
-	body, nextURL, err := a.client.do(ctx, "GET", "/search/issues", params)
-	if err != nil {
-		a.incTrackerRequest("fetch_candidates", "error")
-		return nil, err
-	}
-
-	var sr searchResponse
-	if err := json.Unmarshal(body, &sr); err != nil {
-		a.incTrackerRequest("fetch_candidates", "error")
-		return nil, &domain.TrackerError{
-			Kind:    domain.ErrTrackerPayload,
-			Message: "failed to parse search response",
-			Err:     err,
-		}
-	}
-	if sr.IncompleteResults {
-		slog.Warn("github search returned incomplete results",
-			slog.Int("total_count", sr.TotalCount))
-	}
-
 	activeSet := make(map[string]struct{}, len(a.activeStates))
 	for _, s := range a.activeStates {
 		activeSet[s] = struct{}{}
 	}
 
-	var issues []domain.Issue
-	for _, gi := range sr.Items {
-		if isPullRequest(gi) {
-			continue
-		}
-		issue := normalizeIssue(gi, a.activeStates, a.terminalStates, a.handoffState)
-		a.qualifyDisplayID(&issue)
-		if _, ok := activeSet[issue.State]; !ok {
-			continue
-		}
-		issue.Comments = nil
-		issues = append(issues, issue)
-	}
-
-	pageCount := 1
-	for nextURL != "" && pageCount < maxPages {
-		pageCount++
-		body, nextURL, err = a.client.doURL(ctx, nextURL)
-		if err != nil {
-			a.incTrackerRequest("fetch_candidates", "error")
-			return nil, err
-		}
-
+	paginator := httpkit.NewLinkPaginator(a.client, "/search/issues", params, func(body []byte) ([]domain.Issue, error) {
 		var page searchResponse
 		if err := json.Unmarshal(body, &page); err != nil {
-			a.incTrackerRequest("fetch_candidates", "error")
 			return nil, &domain.TrackerError{
 				Kind:    domain.ErrTrackerPayload,
 				Message: "failed to parse search response",
 				Err:     err,
 			}
 		}
+		if page.IncompleteResults {
+			slog.Warn("github search returned incomplete results",
+				slog.Int("total_count", page.TotalCount))
+		}
+
+		issues := make([]domain.Issue, 0, len(page.Items))
 		for _, gi := range page.Items {
 			if isPullRequest(gi) {
 				continue
@@ -339,130 +272,101 @@ func (a *GitHubAdapter) fetchCandidatesViaSearch(ctx context.Context) ([]domain.
 			issue.Comments = nil
 			issues = append(issues, issue)
 		}
-	}
+		return issues, nil
+	}, httpkit.PaginatorOptions{
+		MaxPages: maxPages,
+		OnLimitReached: func(limit int) {
+			slog.Warn("pagination limit reached",
+				slog.Int("max_pages", limit),
+				slog.String("endpoint", "/search/issues"))
+		},
+	})
 
-	if pageCount >= maxPages {
-		slog.Warn("pagination limit reached", //nolint:gosec // endpoint is an internal API path constant, not user input
-			slog.Int("max_pages", maxPages),
-			slog.String("endpoint", "/search/issues"))
-	}
-
-	if issues == nil {
-		issues = []domain.Issue{}
-	}
-	a.incTrackerRequest("fetch_candidates", "success")
-	return issues, nil
+	return paginator.All(ctx)
 }
 
 // FetchIssueByID returns a fully populated issue including comments,
 // blockers, and parent. The issueID is the issue number as a string.
 func (a *GitHubAdapter) FetchIssueByID(ctx context.Context, issueID string) (domain.Issue, error) {
-	basePath := "/repos/" + a.owner + "/" + a.repo + "/issues/" + url.PathEscape(issueID)
+	var issue domain.Issue
+	err := trackermetrics.Track(a.metrics, "fetch_issue", func() error {
+		basePath := "/repos/" + a.owner + "/" + a.repo + "/issues/" + url.PathEscape(issueID)
 
-	// Fetch the issue itself.
-	body, _, err := a.client.do(ctx, "GET", basePath, nil)
-	if err != nil {
-		a.incTrackerRequest("fetch_issue", "error")
-		if domain.IsNotFound(err) {
-			return domain.Issue{}, &domain.TrackerError{
-				Kind:    domain.ErrTrackerNotFound,
-				Message: fmt.Sprintf("issue not found: %s", issueID),
+		body, _, err := a.client.Get(ctx, basePath, nil)
+		if err != nil {
+			if domain.IsNotFound(err) {
+				return &domain.TrackerError{
+					Kind:    domain.ErrTrackerNotFound,
+					Message: fmt.Sprintf("issue not found: %s", issueID),
+				}
+			}
+			return err
+		}
+
+		var gi githubIssue
+		if err := json.Unmarshal(body, &gi); err != nil {
+			return &domain.TrackerError{
+				Kind:    domain.ErrTrackerPayload,
+				Message: "failed to parse issue response",
+				Err:     err,
 			}
 		}
-		return domain.Issue{}, err
-	}
 
-	var gi githubIssue
-	if err := json.Unmarshal(body, &gi); err != nil {
-		a.incTrackerRequest("fetch_issue", "error")
-		return domain.Issue{}, &domain.TrackerError{
-			Kind:    domain.ErrTrackerPayload,
-			Message: "failed to parse issue response",
-			Err:     err,
+		if isPullRequest(gi) {
+			return &domain.TrackerError{
+				Kind:    domain.ErrTrackerNotFound,
+				Message: fmt.Sprintf("resource is a pull request, not an issue: %s", issueID),
+			}
 		}
-	}
 
-	if isPullRequest(gi) {
-		a.incTrackerRequest("fetch_issue", "error")
-		return domain.Issue{}, &domain.TrackerError{
-			Kind:    domain.ErrTrackerNotFound,
-			Message: fmt.Sprintf("resource is a pull request, not an issue: %s", issueID),
+		issue = normalizeIssue(gi, a.activeStates, a.terminalStates, a.handoffState)
+		a.qualifyDisplayID(&issue)
+
+		issue.BlockedBy, err = a.fetchBlockers(ctx, issueID)
+		if err != nil {
+			return err
 		}
-	}
 
-	issue := normalizeIssue(gi, a.activeStates, a.terminalStates, a.handoffState)
-	a.qualifyDisplayID(&issue)
+		issue.Parent, err = a.fetchParent(ctx, issueID)
+		if err != nil {
+			return err
+		}
 
-	// Fetch blockers (dependencies/blocked_by).
-	issue.BlockedBy, err = a.fetchBlockers(ctx, issueID)
-	if err != nil {
-		a.incTrackerRequest("fetch_issue", "error")
-		return domain.Issue{}, err
-	}
-
-	// Fetch parent.
-	issue.Parent, err = a.fetchParent(ctx, issueID)
-	if err != nil {
-		a.incTrackerRequest("fetch_issue", "error")
-		return domain.Issue{}, err
-	}
-
-	// Fetch comments.
-	comments, err := a.fetchAllComments(ctx, issueID)
-	if err != nil {
-		a.incTrackerRequest("fetch_issue", "error")
-		return domain.Issue{}, err
-	}
-	issue.Comments = comments
-
-	a.incTrackerRequest("fetch_issue", "success")
-	return issue, nil
+		issue.Comments, err = a.fetchAllComments(ctx, issueID)
+		return err
+	})
+	return issue, err
 }
 
 func (a *GitHubAdapter) fetchBlockers(ctx context.Context, issueID string) ([]domain.BlockerRef, error) {
 	path := "/repos/" + a.owner + "/" + a.repo + "/issues/" + url.PathEscape(issueID) + "/dependencies/blocked_by"
 	params := url.Values{"per_page": {"50"}}
 
-	body, nextURL, err := a.client.do(ctx, "GET", path, params)
-	if err != nil {
-		if domain.IsNotFound(err) {
-			return []domain.BlockerRef{}, nil
-		}
-		return nil, err
-	}
-
-	var blockers []githubIssue
-	if err := json.Unmarshal(body, &blockers); err != nil {
-		return nil, &domain.TrackerError{
-			Kind:    domain.ErrTrackerPayload,
-			Message: "failed to parse blockers response",
-			Err:     err,
-		}
-	}
-
-	pageCount := 1
-	for nextURL != "" && pageCount < maxPages {
-		pageCount++
-		body, nextURL, err = a.client.doURL(ctx, nextURL)
-		if err != nil {
-			return nil, err
-		}
-
-		var page []githubIssue
-		if err := json.Unmarshal(body, &page); err != nil {
+	paginator := httpkit.NewLinkPaginator(a.client, path, params, func(body []byte) ([]githubIssue, error) {
+		var blockers []githubIssue
+		if err := json.Unmarshal(body, &blockers); err != nil {
 			return nil, &domain.TrackerError{
 				Kind:    domain.ErrTrackerPayload,
 				Message: "failed to parse blockers response",
 				Err:     err,
 			}
 		}
-		blockers = append(blockers, page...)
-	}
+		return blockers, nil
+	}, httpkit.PaginatorOptions{
+		MaxPages: maxPages,
+		OnLimitReached: func(limit int) {
+			slog.Warn("pagination limit reached",
+				slog.Int("max_pages", limit),
+				slog.String("endpoint", "/repos/{owner}/{repo}/issues/{issue_id}/dependencies/blocked_by"))
+		},
+	})
 
-	if pageCount >= maxPages {
-		slog.Warn("pagination limit reached", //nolint:gosec // endpoint is an internal API path constant, not user input
-			slog.Int("max_pages", maxPages),
-			slog.String("endpoint", path))
+	blockers, err := paginator.All(ctx)
+	if err != nil {
+		if domain.IsNotFound(err) {
+			return []domain.BlockerRef{}, nil
+		}
+		return nil, err
 	}
 
 	return normalizeBlockers(blockers, a.activeStates, a.terminalStates, a.handoffState), nil
@@ -471,7 +375,7 @@ func (a *GitHubAdapter) fetchBlockers(ctx context.Context, issueID string) ([]do
 func (a *GitHubAdapter) fetchParent(ctx context.Context, issueID string) (*domain.ParentRef, error) {
 	path := "/repos/" + a.owner + "/" + a.repo + "/issues/" + url.PathEscape(issueID) + "/parent"
 
-	body, _, err := a.client.do(ctx, "GET", path, nil)
+	body, _, err := a.client.Get(ctx, path, nil)
 	if err != nil {
 		if domain.IsNotFound(err) {
 			return nil, nil
@@ -524,39 +428,32 @@ func (a *GitHubAdapter) FetchIssuesByStates(ctx context.Context, states []string
 		}
 	}
 
-	var matched []domain.Issue
+	matched := make([]domain.Issue, 0)
 	seen := make(map[string]struct{})
 
-	// Active/unknown states: issues endpoint with client-side filtering.
-	if needOpenFetch {
-		issues, err := a.fetchOpenIssuesByStates(ctx, stateSet, seen)
-		if err != nil {
-			a.incTrackerRequest("fetch_by_states", "error")
-			return nil, err
-		}
-		matched = append(matched, issues...)
-	}
-
-	// Terminal states: search endpoint with server-side label filtering.
-	for _, label := range requestedTerminal {
-		if ctx.Err() != nil {
-			a.incTrackerRequest("fetch_by_states", "error")
-			return nil, ctx.Err()
+	err := trackermetrics.Track(a.metrics, "fetch_by_states", func() error {
+		if needOpenFetch {
+			issues, err := a.fetchOpenIssuesByStates(ctx, stateSet, seen)
+			if err != nil {
+				return err
+			}
+			matched = append(matched, issues...)
 		}
 
-		issues, err := a.fetchClosedIssuesByLabel(ctx, label, seen)
-		if err != nil {
-			a.incTrackerRequest("fetch_by_states", "error")
-			return nil, err
-		}
-		matched = append(matched, issues...)
-	}
+		for _, label := range requestedTerminal {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
 
-	if matched == nil {
-		matched = []domain.Issue{}
-	}
-	a.incTrackerRequest("fetch_by_states", "success")
-	return matched, nil
+			issues, err := a.fetchClosedIssuesByLabel(ctx, label, seen)
+			if err != nil {
+				return err
+			}
+			matched = append(matched, issues...)
+		}
+		return nil
+	})
+	return matched, err
 }
 
 func (a *GitHubAdapter) fetchOpenIssuesByStates(ctx context.Context, stateSet map[string]struct{}, seen map[string]struct{}) ([]domain.Issue, error) {
@@ -568,46 +465,8 @@ func (a *GitHubAdapter) fetchOpenIssuesByStates(ctx context.Context, stateSet ma
 		"per_page":  {"50"},
 	}
 
-	body, nextURL, err := a.client.do(ctx, "GET", path, params)
-	if err != nil {
-		return nil, err
-	}
-
-	var issues []domain.Issue
-	var raw []githubIssue
-	if err := json.Unmarshal(body, &raw); err != nil {
-		return nil, &domain.TrackerError{
-			Kind:    domain.ErrTrackerPayload,
-			Message: "failed to parse issues response",
-			Err:     err,
-		}
-	}
-	for _, gi := range raw {
-		if isPullRequest(gi) {
-			continue
-		}
-		issue := normalizeIssue(gi, a.activeStates, a.terminalStates, a.handoffState)
-		a.qualifyDisplayID(&issue)
-		if _, ok := stateSet[issue.State]; !ok {
-			continue
-		}
-		if _, dup := seen[issue.Identifier]; dup {
-			continue
-		}
-		issue.Comments = nil
-		issues = append(issues, issue)
-		seen[issue.Identifier] = struct{}{}
-	}
-
-	pageCount := 1
-	for nextURL != "" && pageCount < maxPages {
-		pageCount++
-		body, nextURL, err = a.client.doURL(ctx, nextURL)
-		if err != nil {
-			return nil, err
-		}
-
-		raw = raw[:0]
+	paginator := httpkit.NewLinkPaginator(a.client, path, params, func(body []byte) ([]domain.Issue, error) {
+		var raw []githubIssue
 		if err := json.Unmarshal(body, &raw); err != nil {
 			return nil, &domain.TrackerError{
 				Kind:    domain.ErrTrackerPayload,
@@ -615,6 +474,8 @@ func (a *GitHubAdapter) fetchOpenIssuesByStates(ctx context.Context, stateSet ma
 				Err:     err,
 			}
 		}
+
+		issues := make([]domain.Issue, 0, len(raw))
 		for _, gi := range raw {
 			if isPullRequest(gi) {
 				continue
@@ -631,16 +492,18 @@ func (a *GitHubAdapter) fetchOpenIssuesByStates(ctx context.Context, stateSet ma
 			issues = append(issues, issue)
 			seen[issue.Identifier] = struct{}{}
 		}
-	}
+		return issues, nil
+	}, httpkit.PaginatorOptions{
+		MaxPages: maxPages,
+		OnLimitReached: func(limit int) {
+			slog.Warn("pagination limit reached",
+				slog.Int("max_pages", limit),
+				slog.String("endpoint", path),
+				slog.String("state", "open"))
+		},
+	})
 
-	if pageCount >= maxPages {
-		slog.Warn("pagination limit reached", //nolint:gosec // endpoint is an internal API path constant, not user input
-			slog.Int("max_pages", maxPages),
-			slog.String("endpoint", path),
-			slog.String("state", "open"))
-	}
-
-	return issues, nil
+	return paginator.All(ctx)
 }
 
 func (a *GitHubAdapter) fetchClosedIssuesByLabel(ctx context.Context, label string, seen map[string]struct{}) ([]domain.Issue, error) {
@@ -652,47 +515,7 @@ func (a *GitHubAdapter) fetchClosedIssuesByLabel(ctx context.Context, label stri
 		"per_page": {"50"},
 	}
 
-	body, nextURL, err := a.client.do(ctx, "GET", "/search/issues", params)
-	if err != nil {
-		return nil, err
-	}
-
-	var sr searchResponse
-	if err := json.Unmarshal(body, &sr); err != nil {
-		return nil, &domain.TrackerError{
-			Kind:    domain.ErrTrackerPayload,
-			Message: "failed to parse search response",
-			Err:     err,
-		}
-	}
-	if sr.IncompleteResults {
-		slog.Warn("github search returned incomplete results",
-			slog.String("label", label))
-	}
-
-	var issues []domain.Issue
-	for _, gi := range sr.Items {
-		if isPullRequest(gi) {
-			continue
-		}
-		issue := normalizeIssue(gi, a.activeStates, a.terminalStates, a.handoffState)
-		a.qualifyDisplayID(&issue)
-		if _, dup := seen[issue.Identifier]; dup {
-			continue
-		}
-		issue.Comments = nil
-		issues = append(issues, issue)
-		seen[issue.Identifier] = struct{}{}
-	}
-
-	pageCount := 1
-	for nextURL != "" && pageCount < maxPages {
-		pageCount++
-		body, nextURL, err = a.client.doURL(ctx, nextURL)
-		if err != nil {
-			return nil, err
-		}
-
+	paginator := httpkit.NewLinkPaginator(a.client, "/search/issues", params, func(body []byte) ([]domain.Issue, error) {
 		var page searchResponse
 		if err := json.Unmarshal(body, &page); err != nil {
 			return nil, &domain.TrackerError{
@@ -701,6 +524,12 @@ func (a *GitHubAdapter) fetchClosedIssuesByLabel(ctx context.Context, label stri
 				Err:     err,
 			}
 		}
+		if page.IncompleteResults {
+			slog.Warn("github search returned incomplete results",
+				slog.String("label", label))
+		}
+
+		issues := make([]domain.Issue, 0, len(page.Items))
 		for _, gi := range page.Items {
 			if isPullRequest(gi) {
 				continue
@@ -714,42 +543,44 @@ func (a *GitHubAdapter) fetchClosedIssuesByLabel(ctx context.Context, label stri
 			issues = append(issues, issue)
 			seen[issue.Identifier] = struct{}{}
 		}
-	}
+		return issues, nil
+	}, httpkit.PaginatorOptions{
+		MaxPages: maxPages,
+		OnLimitReached: func(limit int) {
+			slog.Warn("pagination limit reached",
+				slog.Int("max_pages", limit),
+				slog.String("endpoint", "/search/issues"),
+				slog.String("label", label))
+		},
+	})
 
-	if pageCount >= maxPages {
-		slog.Warn("pagination limit reached", //nolint:gosec // endpoint is an internal API path constant, not user input
-			slog.Int("max_pages", maxPages),
-			slog.String("endpoint", "/search/issues"),
-			slog.String("label", label))
-	}
-
-	return issues, nil
+	return paginator.All(ctx)
 }
 
 // FetchIssueStatesByIDs returns the current state for each requested
 // issue ID. Since ID and Identifier are both the issue number, this
 // delegates to [GitHubAdapter.fetchStatesByNumbers].
 func (a *GitHubAdapter) FetchIssueStatesByIDs(ctx context.Context, issueIDs []string) (map[string]string, error) {
-	states, err := a.fetchStatesByNumbers(ctx, issueIDs)
-	if err != nil {
-		a.incTrackerRequest("fetch_states_by_ids", "error")
-		return nil, err
-	}
-	a.incTrackerRequest("fetch_states_by_ids", "success")
-	return states, nil
+	states := make(map[string]string)
+	err := trackermetrics.Track(a.metrics, "fetch_states_by_ids", func() error {
+		var fetchErr error
+		states, fetchErr = a.fetchStatesByNumbers(ctx, issueIDs)
+		return fetchErr
+	})
+	return states, err
 }
 
 // FetchIssueStatesByIdentifiers returns the current state for each
 // requested issue identifier. Since ID and Identifier are both the
 // issue number, this delegates to [GitHubAdapter.fetchStatesByNumbers].
 func (a *GitHubAdapter) FetchIssueStatesByIdentifiers(ctx context.Context, identifiers []string) (map[string]string, error) {
-	states, err := a.fetchStatesByNumbers(ctx, identifiers)
-	if err != nil {
-		a.incTrackerRequest("fetch_states_by_identifiers", "error")
-		return nil, err
-	}
-	a.incTrackerRequest("fetch_states_by_identifiers", "success")
-	return states, nil
+	states := make(map[string]string)
+	err := trackermetrics.Track(a.metrics, "fetch_states_by_identifiers", func() error {
+		var fetchErr error
+		states, fetchErr = a.fetchStatesByNumbers(ctx, identifiers)
+		return fetchErr
+	})
+	return states, err
 }
 
 func (a *GitHubAdapter) fetchStatesByNumbers(ctx context.Context, numbers []string) (map[string]string, error) {
@@ -766,7 +597,7 @@ func (a *GitHubAdapter) fetchStatesByNumbers(ctx context.Context, numbers []stri
 		path := "/repos/" + a.owner + "/" + a.repo + "/issues/" + url.PathEscape(num)
 		etag, cachedState, cacheHit := a.etagCache.lookup(path)
 
-		body, responseETag, notModified, err := a.client.doConditional(ctx, "GET", path, nil, etag)
+		body, responseETag, notModified, err := a.client.GetConditional(ctx, path, etag, nil)
 		if err != nil {
 			if domain.IsNotFound(err) {
 				continue
@@ -806,20 +637,39 @@ func (a *GitHubAdapter) fetchStatesByNumbers(ctx context.Context, numbers []stri
 // FetchIssueComments returns comments for the specified issue.
 // Returns an empty non-nil slice when no comments exist.
 func (a *GitHubAdapter) FetchIssueComments(ctx context.Context, issueID string) ([]domain.Comment, error) {
-	comments, err := a.fetchAllComments(ctx, issueID)
-	if err != nil {
-		a.incTrackerRequest("fetch_comments", "error")
-		return nil, err
-	}
-	a.incTrackerRequest("fetch_comments", "success")
-	return comments, nil
+	comments := make([]domain.Comment, 0)
+	err := trackermetrics.Track(a.metrics, "fetch_comments", func() error {
+		var fetchErr error
+		comments, fetchErr = a.fetchAllComments(ctx, issueID)
+		return fetchErr
+	})
+	return comments, err
 }
 
 func (a *GitHubAdapter) fetchAllComments(ctx context.Context, issueNumber string) ([]domain.Comment, error) {
 	path := "/repos/" + a.owner + "/" + a.repo + "/issues/" + url.PathEscape(issueNumber) + "/comments"
 	params := url.Values{"per_page": {"50"}}
 
-	body, nextURL, err := a.client.do(ctx, "GET", path, params)
+	paginator := httpkit.NewLinkPaginator(a.client, path, params, func(body []byte) ([]githubComment, error) {
+		var comments []githubComment
+		if err := json.Unmarshal(body, &comments); err != nil {
+			return nil, &domain.TrackerError{
+				Kind:    domain.ErrTrackerPayload,
+				Message: "failed to parse comments response",
+				Err:     err,
+			}
+		}
+		return comments, nil
+	}, httpkit.PaginatorOptions{
+		MaxPages: maxPages,
+		OnLimitReached: func(limit int) {
+			slog.Warn("pagination limit reached",
+				slog.Int("max_pages", limit),
+				slog.String("endpoint", "/repos/{owner}/{repo}/issues/{issue_id}/comments"))
+		},
+	})
+
+	allComments, err := paginator.All(ctx)
 	if err != nil {
 		if domain.IsNotFound(err) {
 			return nil, &domain.TrackerError{
@@ -828,42 +678,6 @@ func (a *GitHubAdapter) fetchAllComments(ctx context.Context, issueNumber string
 			}
 		}
 		return nil, err
-	}
-
-	var allComments []githubComment
-	var page []githubComment
-	if err := json.Unmarshal(body, &page); err != nil {
-		return nil, &domain.TrackerError{
-			Kind:    domain.ErrTrackerPayload,
-			Message: "failed to parse comments response",
-			Err:     err,
-		}
-	}
-	allComments = append(allComments, page...)
-
-	pageCount := 1
-	for nextURL != "" && pageCount < maxPages {
-		pageCount++
-		body, nextURL, err = a.client.doURL(ctx, nextURL)
-		if err != nil {
-			return nil, err
-		}
-
-		page = page[:0]
-		if err := json.Unmarshal(body, &page); err != nil {
-			return nil, &domain.TrackerError{
-				Kind:    domain.ErrTrackerPayload,
-				Message: "failed to parse comments response",
-				Err:     err,
-			}
-		}
-		allComments = append(allComments, page...)
-	}
-
-	if pageCount >= maxPages {
-		slog.Warn("pagination limit reached", //nolint:gosec // endpoint is an internal API path constant, not user input
-			slog.Int("max_pages", maxPages),
-			slog.String("endpoint", path))
 	}
 
 	return normalizeComments(allComments), nil
@@ -877,120 +691,104 @@ func (a *GitHubAdapter) fetchAllComments(ctx context.Context, issueNumber string
 func (a *GitHubAdapter) TransitionIssue(ctx context.Context, issueID string, targetState string) error {
 	targetLower := strings.ToLower(targetState)
 
-	isHandoffTarget := a.handoffState != "" && targetLower == a.handoffState
-	if !isActiveState(targetLower, a.activeStates) && !isTerminalState(targetLower, a.terminalStates) && !isHandoffTarget {
-		a.incTrackerRequest("transition", "error")
-		return &domain.TrackerError{
-			Kind:    domain.ErrTrackerPayload,
-			Message: fmt.Sprintf("invalid target state: %q is not a configured active, terminal, or handoff state", targetState),
-		}
-	}
-
-	basePath := "/repos/" + a.owner + "/" + a.repo + "/issues/" + url.PathEscape(issueID)
-
-	// Fetch current issue to read labels and native state.
-	body, _, err := a.client.do(ctx, "GET", basePath, nil)
-	if err != nil {
-		a.incTrackerRequest("transition", "error")
-		return err
-	}
-
-	var gi githubIssue
-	if err := json.Unmarshal(body, &gi); err != nil {
-		a.incTrackerRequest("transition", "error")
-		return &domain.TrackerError{
-			Kind:    domain.ErrTrackerPayload,
-			Message: "failed to parse issue response",
-			Err:     err,
-		}
-	}
-
-	currentLabel := findCurrentStateLabel(gi.Labels, a.activeStates, a.terminalStates, a.handoffState)
-	currentNative := gi.State
-
-	// Remove old state label if present and different.
-	if currentLabel != "" && currentLabel != targetLower {
-		labelPath := basePath + "/labels/" + url.PathEscape(currentLabel)
-		err := a.client.doNoBody(ctx, "DELETE", labelPath)
-		if err != nil && !domain.IsNotFound(err) {
-			a.incTrackerRequest("transition", "error")
-			return err
-		}
-	}
-
-	// Add target state label if different from current.
-	if currentLabel != targetLower {
-		payload, err := json.Marshal(map[string][]string{"labels": {targetLower}})
-		if err != nil {
-			a.incTrackerRequest("transition", "error")
+	return trackermetrics.Track(a.metrics, "transition", func() error {
+		isHandoffTarget := a.handoffState != "" && targetLower == a.handoffState
+		if !isActiveState(targetLower, a.activeStates) && !isTerminalState(targetLower, a.terminalStates) && !isHandoffTarget {
 			return &domain.TrackerError{
 				Kind:    domain.ErrTrackerPayload,
-				Message: "failed to marshal label payload",
+				Message: fmt.Sprintf("invalid target state: %q is not a configured active, terminal, or handoff state", targetState),
+			}
+		}
+
+		basePath := "/repos/" + a.owner + "/" + a.repo + "/issues/" + url.PathEscape(issueID)
+
+		body, _, err := a.client.Get(ctx, basePath, nil)
+		if err != nil {
+			return err
+		}
+
+		var gi githubIssue
+		if err := json.Unmarshal(body, &gi); err != nil {
+			return &domain.TrackerError{
+				Kind:    domain.ErrTrackerPayload,
+				Message: "failed to parse issue response",
 				Err:     err,
 			}
 		}
-		if _, err := a.client.doJSON(ctx, "POST", basePath+"/labels", bytes.NewReader(payload)); err != nil {
-			a.incTrackerRequest("transition", "error")
-			return err
-		}
-	}
 
-	// Open/close the issue if the native state needs to change.
-	if isTerminalState(targetLower, a.terminalStates) && currentNative == "open" {
-		payload, err := json.Marshal(map[string]any{"state": "closed", "state_reason": "completed"})
-		if err != nil {
-			a.incTrackerRequest("transition", "error")
-			return &domain.TrackerError{
-				Kind:    domain.ErrTrackerPayload,
-				Message: "failed to marshal state payload",
-				Err:     err,
+		currentLabel := findCurrentStateLabel(gi.Labels, a.activeStates, a.terminalStates, a.handoffState)
+		currentNative := gi.State
+
+		if currentLabel != "" && currentLabel != targetLower {
+			labelPath := basePath + "/labels/" + url.PathEscape(currentLabel)
+			err := a.client.SendNoBody(ctx, "DELETE", labelPath)
+			if err != nil && !domain.IsNotFound(err) {
+				return err
 			}
 		}
-		if _, err := a.client.doJSON(ctx, "PATCH", basePath, bytes.NewReader(payload)); err != nil {
-			a.incTrackerRequest("transition", "error")
-			return err
-		}
-	} else if isActiveState(targetLower, a.activeStates) && currentNative == "closed" {
-		payload, err := json.Marshal(map[string]any{"state": "open"})
-		if err != nil {
-			a.incTrackerRequest("transition", "error")
-			return &domain.TrackerError{
-				Kind:    domain.ErrTrackerPayload,
-				Message: "failed to marshal state payload",
-				Err:     err,
+
+		if currentLabel != targetLower {
+			payload, err := json.Marshal(map[string][]string{"labels": {targetLower}})
+			if err != nil {
+				return &domain.TrackerError{
+					Kind:    domain.ErrTrackerPayload,
+					Message: "failed to marshal label payload",
+					Err:     err,
+				}
+			}
+			if _, err := a.client.Send(ctx, "POST", basePath+"/labels", bytes.NewReader(payload)); err != nil {
+				return err
 			}
 		}
-		if _, err := a.client.doJSON(ctx, "PATCH", basePath, bytes.NewReader(payload)); err != nil {
-			a.incTrackerRequest("transition", "error")
-			return err
-		}
-	}
 
-	a.incTrackerRequest("transition", "success")
-	return nil
+		if isTerminalState(targetLower, a.terminalStates) && currentNative == "open" {
+			payload, err := json.Marshal(map[string]any{"state": "closed", "state_reason": "completed"})
+			if err != nil {
+				return &domain.TrackerError{
+					Kind:    domain.ErrTrackerPayload,
+					Message: "failed to marshal state payload",
+					Err:     err,
+				}
+			}
+			if _, err := a.client.Send(ctx, "PATCH", basePath, bytes.NewReader(payload)); err != nil {
+				return err
+			}
+		} else if isActiveState(targetLower, a.activeStates) && currentNative == "closed" {
+			payload, err := json.Marshal(map[string]any{"state": "open"})
+			if err != nil {
+				return &domain.TrackerError{
+					Kind:    domain.ErrTrackerPayload,
+					Message: "failed to marshal state payload",
+					Err:     err,
+				}
+			}
+			if _, err := a.client.Send(ctx, "PATCH", basePath, bytes.NewReader(payload)); err != nil {
+				return err
+			}
+		}
+
+		return nil
+	})
 }
 
 // CommentIssue posts a Markdown comment on the specified issue.
 // GitHub natively accepts Markdown, so no format conversion is needed.
 func (a *GitHubAdapter) CommentIssue(ctx context.Context, issueID string, text string) error {
-	path := "/repos/" + a.owner + "/" + a.repo + "/issues/" + url.PathEscape(issueID) + "/comments"
+	return trackermetrics.Track(a.metrics, "comment", func() error {
+		path := "/repos/" + a.owner + "/" + a.repo + "/issues/" + url.PathEscape(issueID) + "/comments"
 
-	payload, err := json.Marshal(map[string]string{"body": text})
-	if err != nil {
-		a.incTrackerRequest("comment", "error")
-		return &domain.TrackerError{
-			Kind:    domain.ErrTrackerPayload,
-			Message: "failed to marshal comment payload",
-			Err:     err,
+		payload, err := json.Marshal(map[string]string{"body": text})
+		if err != nil {
+			return &domain.TrackerError{
+				Kind:    domain.ErrTrackerPayload,
+				Message: "failed to marshal comment payload",
+				Err:     err,
+			}
 		}
-	}
 
-	if _, err := a.client.doJSON(ctx, "POST", path, bytes.NewReader(payload)); err != nil {
-		a.incTrackerRequest("comment", "error")
+		_, err = a.client.Send(ctx, "POST", path, bytes.NewReader(payload))
 		return err
-	}
-	a.incTrackerRequest("comment", "success")
-	return nil
+	})
 }
 
 // SetMetrics configures the metrics recorder for tracker API call
@@ -1016,7 +814,7 @@ func (a *GitHubAdapter) AddLabel(ctx context.Context, issueID string, label stri
 		}
 	}
 
-	if _, err := a.client.doJSON(ctx, "POST", path, bytes.NewReader(payload)); err != nil {
+	if _, err := a.client.Send(ctx, "POST", path, bytes.NewReader(payload)); err != nil {
 		a.incTrackerRequest("add_label", "error")
 		return err
 	}

--- a/internal/scm/github/tracker.go
+++ b/internal/scm/github/tracker.go
@@ -319,21 +319,26 @@ func (a *GitHubAdapter) FetchIssueByID(ctx context.Context, issueID string) (dom
 			}
 		}
 
-		issue = normalizeIssue(gi, a.activeStates, a.terminalStates, a.handoffState)
-		a.qualifyDisplayID(&issue)
+		fetchedIssue := normalizeIssue(gi, a.activeStates, a.terminalStates, a.handoffState)
+		a.qualifyDisplayID(&fetchedIssue)
 
-		issue.BlockedBy, err = a.fetchBlockers(ctx, issueID)
+		fetchedIssue.BlockedBy, err = a.fetchBlockers(ctx, issueID)
 		if err != nil {
 			return err
 		}
 
-		issue.Parent, err = a.fetchParent(ctx, issueID)
+		fetchedIssue.Parent, err = a.fetchParent(ctx, issueID)
 		if err != nil {
 			return err
 		}
 
-		issue.Comments, err = a.fetchAllComments(ctx, issueID)
-		return err
+		fetchedIssue.Comments, err = a.fetchAllComments(ctx, issueID)
+		if err != nil {
+			return err
+		}
+
+		issue = fetchedIssue
+		return nil
 	})
 	return issue, err
 }
@@ -428,16 +433,18 @@ func (a *GitHubAdapter) FetchIssuesByStates(ctx context.Context, states []string
 		}
 	}
 
-	matched := make([]domain.Issue, 0)
-	seen := make(map[string]struct{})
+	var matched []domain.Issue
 
 	err := trackermetrics.Track(a.metrics, "fetch_by_states", func() error {
+		matchedIssues := make([]domain.Issue, 0)
+		seen := make(map[string]struct{})
+
 		if needOpenFetch {
 			issues, err := a.fetchOpenIssuesByStates(ctx, stateSet, seen)
 			if err != nil {
 				return err
 			}
-			matched = append(matched, issues...)
+			matchedIssues = append(matchedIssues, issues...)
 		}
 
 		for _, label := range requestedTerminal {
@@ -449,8 +456,10 @@ func (a *GitHubAdapter) FetchIssuesByStates(ctx context.Context, states []string
 			if err != nil {
 				return err
 			}
-			matched = append(matched, issues...)
+			matchedIssues = append(matchedIssues, issues...)
 		}
+
+		matched = matchedIssues
 		return nil
 	})
 	return matched, err
@@ -561,11 +570,14 @@ func (a *GitHubAdapter) fetchClosedIssuesByLabel(ctx context.Context, label stri
 // issue ID. Since ID and Identifier are both the issue number, this
 // delegates to [GitHubAdapter.fetchStatesByNumbers].
 func (a *GitHubAdapter) FetchIssueStatesByIDs(ctx context.Context, issueIDs []string) (map[string]string, error) {
-	states := make(map[string]string)
+	var states map[string]string
 	err := trackermetrics.Track(a.metrics, "fetch_states_by_ids", func() error {
-		var fetchErr error
-		states, fetchErr = a.fetchStatesByNumbers(ctx, issueIDs)
-		return fetchErr
+		fetchedStates, err := a.fetchStatesByNumbers(ctx, issueIDs)
+		if err != nil {
+			return err
+		}
+		states = fetchedStates
+		return nil
 	})
 	return states, err
 }
@@ -574,11 +586,14 @@ func (a *GitHubAdapter) FetchIssueStatesByIDs(ctx context.Context, issueIDs []st
 // requested issue identifier. Since ID and Identifier are both the
 // issue number, this delegates to [GitHubAdapter.fetchStatesByNumbers].
 func (a *GitHubAdapter) FetchIssueStatesByIdentifiers(ctx context.Context, identifiers []string) (map[string]string, error) {
-	states := make(map[string]string)
+	var states map[string]string
 	err := trackermetrics.Track(a.metrics, "fetch_states_by_identifiers", func() error {
-		var fetchErr error
-		states, fetchErr = a.fetchStatesByNumbers(ctx, identifiers)
-		return fetchErr
+		fetchedStates, err := a.fetchStatesByNumbers(ctx, identifiers)
+		if err != nil {
+			return err
+		}
+		states = fetchedStates
+		return nil
 	})
 	return states, err
 }

--- a/internal/scm/github/tracker_test.go
+++ b/internal/scm/github/tracker_test.go
@@ -33,18 +33,7 @@ func mustAdapter(t *testing.T, config map[string]any) *GitHubAdapter {
 	if err != nil {
 		t.Fatalf("NewGitHubAdapter: %v", err)
 	}
-	gh := a.(*GitHubAdapter)
-	// Isolate the HTTP transport so that httptest.Server.Close() in one
-	// parallel test cannot call CloseIdleConnections on http.DefaultTransport
-	// and break in-flight requests from another parallel test.
-	defaultTransport, ok := http.DefaultTransport.(*http.Transport)
-	if !ok {
-		t.Fatalf("http.DefaultTransport is %T, want *http.Transport", http.DefaultTransport)
-	}
-	transport := defaultTransport.Clone()
-	gh.client.httpClient.Transport = transport
-	t.Cleanup(transport.CloseIdleConnections)
-	return gh
+	return a.(*GitHubAdapter)
 }
 
 func assertTrackerErrorKind(t *testing.T, err error, want domain.TrackerErrorKind) {
@@ -234,11 +223,43 @@ func TestNewGitHubAdapter_CustomStatesLowercased(t *testing.T) {
 func TestNewGitHubAdapter_EndpointTrailingSlashStripped(t *testing.T) {
 	t.Parallel()
 
-	cfg := validConfig("https://api.github.com/")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(r.URL.Path, "//") {
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = io.WriteString(w, `{"message":"unexpected doubled slash"}`)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/repos/owner/repo/issues/123":
+			w.WriteHeader(http.StatusOK)
+			_, _ = io.WriteString(w, issueJSON(123, "todo", "open"))
+		case "/repos/owner/repo/issues/123/comments":
+			w.WriteHeader(http.StatusOK)
+			_, _ = io.WriteString(w, `[]`)
+		case "/repos/owner/repo/issues/123/dependencies/blocked_by":
+			w.WriteHeader(http.StatusOK)
+			_, _ = io.WriteString(w, `[]`)
+		case "/repos/owner/repo/issues/123/parent":
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = io.WriteString(w, `{"message":"not found"}`)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = io.WriteString(w, `{"message":"unexpected path"}`)
+		}
+	}))
+	defer srv.Close()
+
+	cfg := validConfig(srv.URL + "/")
 	a := mustAdapter(t, cfg)
 
-	if strings.HasSuffix(a.client.baseURL, "/") {
-		t.Errorf("client.baseURL = %q, should not have trailing slash", a.client.baseURL)
+	issue, err := a.FetchIssueByID(context.Background(), "123")
+	if err != nil {
+		t.Fatalf("FetchIssueByID: %v", err)
+	}
+	if issue.ID != "123" {
+		t.Errorf("issue.ID = %q, want %q", issue.ID, "123")
 	}
 }
 

--- a/internal/tracker/file/file.go
+++ b/internal/tracker/file/file.go
@@ -17,7 +17,9 @@ import (
 	"time"
 
 	"github.com/sortie-ai/sortie/internal/domain"
+	"github.com/sortie-ai/sortie/internal/issuekit"
 	"github.com/sortie-ai/sortie/internal/registry"
+	"github.com/sortie-ai/sortie/internal/trackermetrics"
 	"github.com/sortie-ai/sortie/internal/typeutil"
 )
 
@@ -77,60 +79,65 @@ func NewFileAdapter(config map[string]any) (domain.TrackerAdapter, error) {
 // configured active states. Comments are set to nil on all returned
 // issues.
 func (a *FileAdapter) FetchCandidateIssues(_ context.Context) ([]domain.Issue, error) {
-	raws, err := loadIssues(a.path)
-	if err != nil {
-		a.incTrackerRequest("fetch_candidates", "error")
-		return nil, err
-	}
-
-	a.mu.RLock()
-	defer a.mu.RUnlock()
-
-	issues := make([]domain.Issue, 0, len(raws))
-	for _, raw := range raws {
-		raw = a.applyOverride(raw)
-		if len(a.activeStates) > 0 && !a.activeStates[strings.ToLower(raw.State)] {
-			continue
+	issues := make([]domain.Issue, 0)
+	err := trackermetrics.Track(a.metrics, "fetch_candidates", func() error {
+		raws, err := loadIssues(a.path)
+		if err != nil {
+			return err
 		}
-		iss := normalize(raw)
-		iss.Comments = nil
-		issues = append(issues, iss)
-	}
-	a.incTrackerRequest("fetch_candidates", "success")
-	return issues, nil
+
+		a.mu.RLock()
+		defer a.mu.RUnlock()
+
+		issues = make([]domain.Issue, 0, len(raws))
+		for _, raw := range raws {
+			raw = a.applyOverride(raw)
+			if len(a.activeStates) > 0 && !a.activeStates[strings.ToLower(raw.State)] {
+				continue
+			}
+			iss := normalize(raw)
+			iss.Comments = nil
+			issues = append(issues, iss)
+		}
+		return nil
+	})
+	return issues, err
 }
 
 // FetchIssueByID returns a single fully-populated issue including
 // comments. Returns a [*domain.TrackerError] with Kind
 // [domain.ErrTrackerNotFound] if the issue does not exist.
 func (a *FileAdapter) FetchIssueByID(_ context.Context, issueID string) (domain.Issue, error) {
-	raws, err := loadIssues(a.path)
-	if err != nil {
-		a.incTrackerRequest("fetch_issue", "error")
-		return domain.Issue{}, err
-	}
-
-	a.mu.RLock()
-	defer a.mu.RUnlock()
-
-	for _, raw := range raws {
-		if raw.ID == issueID {
-			raw = a.applyOverride(raw)
-			iss := normalize(raw)
-			if iss.Comments == nil {
-				iss.Comments = []domain.Comment{}
-			}
-			iss.Comments = append(iss.Comments, a.commentOverrides[issueID]...)
-			a.incTrackerRequest("fetch_issue", "success")
-			return iss, nil
+	var issue domain.Issue
+	err := trackermetrics.Track(a.metrics, "fetch_issue", func() error {
+		raws, err := loadIssues(a.path)
+		if err != nil {
+			return err
 		}
-	}
 
-	a.incTrackerRequest("fetch_issue", "error")
-	return domain.Issue{}, &domain.TrackerError{
-		Kind:    domain.ErrTrackerNotFound,
-		Message: fmt.Sprintf("issue not found: %s", issueID),
-	}
+		a.mu.RLock()
+		defer a.mu.RUnlock()
+
+		for _, raw := range raws {
+			if raw.ID != issueID {
+				continue
+			}
+
+			raw = a.applyOverride(raw)
+			issue = normalize(raw)
+			if issue.Comments == nil {
+				issue.Comments = []domain.Comment{}
+			}
+			issue.Comments = append(issue.Comments, a.commentOverrides[issueID]...)
+			return nil
+		}
+
+		return &domain.TrackerError{
+			Kind:    domain.ErrTrackerNotFound,
+			Message: fmt.Sprintf("issue not found: %s", issueID),
+		}
+	})
+	return issue, err
 }
 
 // FetchIssuesByStates returns issues in the specified states. An
@@ -141,31 +148,33 @@ func (a *FileAdapter) FetchIssuesByStates(_ context.Context, states []string) ([
 		return []domain.Issue{}, nil
 	}
 
-	raws, err := loadIssues(a.path)
-	if err != nil {
-		a.incTrackerRequest("fetch_by_states", "error")
-		return nil, err
-	}
-
-	a.mu.RLock()
-	defer a.mu.RUnlock()
-
-	stateSet := make(map[string]bool, len(states))
-	for _, s := range states {
-		stateSet[strings.ToLower(s)] = true
-	}
-
-	issues := make([]domain.Issue, 0, len(raws))
-	for _, raw := range raws {
-		raw = a.applyOverride(raw)
-		if stateSet[strings.ToLower(raw.State)] {
-			iss := normalize(raw)
-			iss.Comments = nil
-			issues = append(issues, iss)
+	issues := make([]domain.Issue, 0)
+	err := trackermetrics.Track(a.metrics, "fetch_by_states", func() error {
+		raws, err := loadIssues(a.path)
+		if err != nil {
+			return err
 		}
-	}
-	a.incTrackerRequest("fetch_by_states", "success")
-	return issues, nil
+
+		a.mu.RLock()
+		defer a.mu.RUnlock()
+
+		stateSet := make(map[string]bool, len(states))
+		for _, s := range states {
+			stateSet[strings.ToLower(s)] = true
+		}
+
+		issues = make([]domain.Issue, 0, len(raws))
+		for _, raw := range raws {
+			raw = a.applyOverride(raw)
+			if stateSet[strings.ToLower(raw.State)] {
+				iss := normalize(raw)
+				iss.Comments = nil
+				issues = append(issues, iss)
+			}
+		}
+		return nil
+	})
+	return issues, err
 }
 
 // FetchIssueStatesByIDs returns the current state for each requested
@@ -175,29 +184,30 @@ func (a *FileAdapter) FetchIssueStatesByIDs(_ context.Context, issueIDs []string
 		return map[string]string{}, nil
 	}
 
-	raws, err := loadIssues(a.path)
-	if err != nil {
-		a.incTrackerRequest("fetch_states_by_ids", "error")
-		return nil, err
-	}
-
-	a.mu.RLock()
-	defer a.mu.RUnlock()
-
-	wanted := make(map[string]bool, len(issueIDs))
-	for _, id := range issueIDs {
-		wanted[id] = true
-	}
-
 	states := make(map[string]string, len(issueIDs))
-	for _, raw := range raws {
-		if wanted[raw.ID] {
-			raw = a.applyOverride(raw)
-			states[raw.ID] = raw.State
+	err := trackermetrics.Track(a.metrics, "fetch_states_by_ids", func() error {
+		raws, err := loadIssues(a.path)
+		if err != nil {
+			return err
 		}
-	}
-	a.incTrackerRequest("fetch_states_by_ids", "success")
-	return states, nil
+
+		a.mu.RLock()
+		defer a.mu.RUnlock()
+
+		wanted := make(map[string]bool, len(issueIDs))
+		for _, id := range issueIDs {
+			wanted[id] = true
+		}
+
+		for _, raw := range raws {
+			if wanted[raw.ID] {
+				raw = a.applyOverride(raw)
+				states[raw.ID] = raw.State
+			}
+		}
+		return nil
+	})
+	return states, err
 }
 
 // FetchIssueStatesByIdentifiers returns the current state for each
@@ -208,29 +218,30 @@ func (a *FileAdapter) FetchIssueStatesByIdentifiers(_ context.Context, identifie
 		return map[string]string{}, nil
 	}
 
-	raws, err := loadIssues(a.path)
-	if err != nil {
-		a.incTrackerRequest("fetch_states_by_identifiers", "error")
-		return nil, err
-	}
-
-	a.mu.RLock()
-	defer a.mu.RUnlock()
-
-	wanted := make(map[string]bool, len(identifiers))
-	for _, id := range identifiers {
-		wanted[id] = true
-	}
-
 	states := make(map[string]string, len(identifiers))
-	for _, raw := range raws {
-		if wanted[raw.Identifier] {
-			raw = a.applyOverride(raw)
-			states[raw.Identifier] = raw.State
+	err := trackermetrics.Track(a.metrics, "fetch_states_by_identifiers", func() error {
+		raws, err := loadIssues(a.path)
+		if err != nil {
+			return err
 		}
-	}
-	a.incTrackerRequest("fetch_states_by_identifiers", "success")
-	return states, nil
+
+		a.mu.RLock()
+		defer a.mu.RUnlock()
+
+		wanted := make(map[string]bool, len(identifiers))
+		for _, id := range identifiers {
+			wanted[id] = true
+		}
+
+		for _, raw := range raws {
+			if wanted[raw.Identifier] {
+				raw = a.applyOverride(raw)
+				states[raw.Identifier] = raw.State
+			}
+		}
+		return nil
+	})
+	return states, err
 }
 
 // FetchIssueComments returns comments for the specified issue.
@@ -238,16 +249,20 @@ func (a *FileAdapter) FetchIssueStatesByIdentifiers(_ context.Context, identifie
 // [*domain.TrackerError] with Kind [domain.ErrTrackerNotFound] if
 // the issue does not exist.
 func (a *FileAdapter) FetchIssueComments(_ context.Context, issueID string) ([]domain.Comment, error) {
-	raws, err := loadIssues(a.path)
-	if err != nil {
-		a.incTrackerRequest("fetch_comments", "error")
-		return nil, err
-	}
+	comments := make([]domain.Comment, 0)
+	err := trackermetrics.Track(a.metrics, "fetch_comments", func() error {
+		raws, err := loadIssues(a.path)
+		if err != nil {
+			return err
+		}
 
-	for _, raw := range raws {
-		if raw.ID == issueID {
-			iss := normalize(raw)
-			comments := iss.Comments
+		for _, raw := range raws {
+			if raw.ID != issueID {
+				continue
+			}
+
+			issue := normalize(raw)
+			comments = issue.Comments
 			if comments == nil {
 				comments = []domain.Comment{}
 			}
@@ -255,17 +270,15 @@ func (a *FileAdapter) FetchIssueComments(_ context.Context, issueID string) ([]d
 			a.mu.RLock()
 			comments = append(comments, a.commentOverrides[issueID]...)
 			a.mu.RUnlock()
-
-			a.incTrackerRequest("fetch_comments", "success")
-			return comments, nil
+			return nil
 		}
-	}
 
-	a.incTrackerRequest("fetch_comments", "error")
-	return nil, &domain.TrackerError{
-		Kind:    domain.ErrTrackerNotFound,
-		Message: fmt.Sprintf("issue not found: %s", issueID),
-	}
+		return &domain.TrackerError{
+			Kind:    domain.ErrTrackerNotFound,
+			Message: fmt.Sprintf("issue not found: %s", issueID),
+		}
+	})
+	return comments, err
 }
 
 // TransitionIssue records a state override for the given issue in the
@@ -276,33 +289,31 @@ func (a *FileAdapter) FetchIssueComments(_ context.Context, issueID string) ([]d
 // [domain.ErrTrackerNotFound] if the issue ID does not exist in the
 // fixture. Safe for concurrent use.
 func (a *FileAdapter) TransitionIssue(_ context.Context, issueID string, targetState string) error {
-	raws, err := loadIssues(a.path)
-	if err != nil {
-		a.incTrackerRequest("transition", "error")
-		return err
-	}
-
-	found := false
-	for _, raw := range raws {
-		if raw.ID == issueID {
-			found = true
-			break
+	return trackermetrics.Track(a.metrics, "transition", func() error {
+		raws, err := loadIssues(a.path)
+		if err != nil {
+			return err
 		}
-	}
-	if !found {
-		a.incTrackerRequest("transition", "error")
-		return &domain.TrackerError{
-			Kind:    domain.ErrTrackerNotFound,
-			Message: fmt.Sprintf("issue not found: %s", issueID),
+
+		found := false
+		for _, raw := range raws {
+			if raw.ID == issueID {
+				found = true
+				break
+			}
 		}
-	}
+		if !found {
+			return &domain.TrackerError{
+				Kind:    domain.ErrTrackerNotFound,
+				Message: fmt.Sprintf("issue not found: %s", issueID),
+			}
+		}
 
-	a.mu.Lock()
-	a.overrides[issueID] = targetState
-	a.mu.Unlock()
-
-	a.incTrackerRequest("transition", "success")
-	return nil
+		a.mu.Lock()
+		a.overrides[issueID] = targetState
+		a.mu.Unlock()
+		return nil
+	})
 }
 
 // CommentIssue records a comment for the given issue in the adapter's
@@ -311,36 +322,34 @@ func (a *FileAdapter) TransitionIssue(_ context.Context, issueID string, targetS
 // any comments present in the fixture file. Returns a [*domain.TrackerError]
 // with Kind [domain.ErrTrackerNotFound] if the issue does not exist.
 func (a *FileAdapter) CommentIssue(_ context.Context, issueID string, text string) error {
-	raws, err := loadIssues(a.path)
-	if err != nil {
-		a.incTrackerRequest("comment", "error")
-		return err
-	}
-
-	found := false
-	for _, raw := range raws {
-		if raw.ID == issueID {
-			found = true
-			break
+	return trackermetrics.Track(a.metrics, "comment", func() error {
+		raws, err := loadIssues(a.path)
+		if err != nil {
+			return err
 		}
-	}
-	if !found {
-		a.incTrackerRequest("comment", "error")
-		return &domain.TrackerError{
-			Kind:    domain.ErrTrackerNotFound,
-			Message: fmt.Sprintf("issue not found: %s", issueID),
-		}
-	}
 
-	a.mu.Lock()
-	a.commentOverrides[issueID] = append(a.commentOverrides[issueID], domain.Comment{
-		Body:      text,
-		CreatedAt: time.Now().UTC().Format(time.RFC3339),
+		found := false
+		for _, raw := range raws {
+			if raw.ID == issueID {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return &domain.TrackerError{
+				Kind:    domain.ErrTrackerNotFound,
+				Message: fmt.Sprintf("issue not found: %s", issueID),
+			}
+		}
+
+		a.mu.Lock()
+		a.commentOverrides[issueID] = append(a.commentOverrides[issueID], domain.Comment{
+			Body:      text,
+			CreatedAt: time.Now().UTC().Format(time.RFC3339),
+		})
+		a.mu.Unlock()
+		return nil
 	})
-	a.mu.Unlock()
-
-	a.incTrackerRequest("comment", "success")
-	return nil
 }
 
 // SetMetrics configures the metrics recorder for tracker API call
@@ -356,12 +365,6 @@ func (a *FileAdapter) SetMetrics(m domain.Metrics) {
 // support labels.
 func (a *FileAdapter) AddLabel(_ context.Context, _ string, _ string) error {
 	return nil
-}
-
-func (a *FileAdapter) incTrackerRequest(operation, outcome string) {
-	if a.metrics != nil {
-		a.metrics.IncTrackerRequests(operation, outcome)
-	}
 }
 
 // applyOverride returns a copy of raw with its State replaced by the
@@ -447,28 +450,8 @@ func normalize(raw rawIssue) domain.Issue {
 		UpdatedAt:   raw.UpdatedAt,
 	}
 
-	// Priority: integer only, non-integers become nil.
-	if len(raw.Priority) > 0 {
-		var p int
-		if json.Unmarshal(raw.Priority, &p) == nil {
-			// Guard against floats that json.Unmarshal silently truncates:
-			// re-marshal the int and compare to the raw bytes.
-			canonical, _ := json.Marshal(p)
-			if string(canonical) == string(raw.Priority) {
-				iss.Priority = &p
-			}
-		}
-	}
-
-	// Labels: lowercase, non-nil empty slice when absent.
-	if raw.Labels != nil {
-		iss.Labels = make([]string, len(raw.Labels))
-		for i, l := range raw.Labels {
-			iss.Labels[i] = strings.ToLower(l)
-		}
-	} else {
-		iss.Labels = []string{}
-	}
+	iss.Priority = issuekit.ParsePriorityIntStrict(raw.Priority)
+	iss.Labels = issuekit.NormalizeLabels(raw.Labels)
 
 	// Parent: nil stays nil.
 	if raw.Parent != nil {
@@ -478,17 +461,17 @@ func normalize(raw rawIssue) domain.Issue {
 		}
 	}
 
-	// Comments: nil means "not fetched", empty non-nil means "none exist".
 	if raw.Comments != nil {
-		iss.Comments = make([]domain.Comment, len(raw.Comments))
+		source := make([]issuekit.SourceComment, len(raw.Comments))
 		for i, c := range raw.Comments {
-			iss.Comments[i] = domain.Comment{
+			source[i] = issuekit.SourceComment{
 				ID:        c.ID,
 				Author:    c.Author,
 				Body:      c.Body,
 				CreatedAt: c.CreatedAt,
 			}
 		}
+		iss.Comments = issuekit.NormalizeComments(source)
 	}
 
 	// BlockedBy: non-nil empty slice when absent.

--- a/internal/tracker/jira/client.go
+++ b/internal/tracker/jira/client.go
@@ -1,37 +1,33 @@
 package jira
 
 import (
-	"context"
 	"encoding/base64"
 	"fmt"
 	"io"
 	"net/http"
-	"net/url"
 	"strings"
 	"time"
 
 	"github.com/sortie-ai/sortie/internal/domain"
+	"github.com/sortie-ai/sortie/internal/httpkit"
 )
 
-// jiraClient wraps net/http.Client with Jira-specific authentication,
-// request building, and HTTP status to TrackerError mapping.
-type jiraClient struct {
-	httpClient *http.Client
-	baseURL    string
-	authHeader string
-	userAgent  string
-}
+// newJiraClient constructs the shared Jira transport.
+func newJiraClient(baseURL, email, token, userAgent string) *httpkit.Client {
+	trimmedBaseURL := strings.TrimRight(baseURL, "/")
+	authHeader := "Basic " + base64.StdEncoding.EncodeToString([]byte(email+":"+token))
 
-// newJiraClient constructs a jiraClient with Basic authentication
-// derived from the email and API token. The baseURL is stripped of
-// any trailing slash. The userAgent value is set on every outgoing request.
-func newJiraClient(baseURL, email, token, userAgent string) *jiraClient {
-	return &jiraClient{
-		httpClient: &http.Client{Timeout: 30 * time.Second},
-		baseURL:    strings.TrimRight(baseURL, "/"),
-		authHeader: "Basic " + base64.StdEncoding.EncodeToString([]byte(email+":"+token)),
-		userAgent:  userAgent,
-	}
+	return httpkit.NewClient(httpkit.ClientOptions{
+		BaseURL: trimmedBaseURL,
+		Timeout: 30 * time.Second,
+		Authorize: func(req *http.Request) {
+			req.Header.Set("Authorization", authHeader)
+			req.Header.Set("Accept", "application/json")
+			req.Header.Set("User-Agent", userAgent)
+		},
+		ClassifyError:     classifyHTTPError,
+		ClassifyTransport: classifyTransportError,
+	})
 }
 
 // maxErrorBody is the maximum number of bytes read from non-200
@@ -95,110 +91,10 @@ func classifyHTTPError(resp *http.Response, method, path string) error {
 	}
 }
 
-// do executes an HTTP request against the Jira REST API and returns
-// the response body on success. Non-200 responses are mapped to
-// [domain.TrackerError] by status code. Context cancellation is
-// propagated directly without wrapping in TrackerError.
-func (c *jiraClient) do(ctx context.Context, method, path string, params url.Values) ([]byte, error) { //nolint:unparam // method will accept POST for future comment/transition operations
-	reqURL := c.baseURL + path
-	if len(params) > 0 {
-		reqURL += "?" + params.Encode()
+func classifyTransportError(err error, method, path string) error {
+	return &domain.TrackerError{
+		Kind:    domain.ErrTrackerTransport,
+		Message: fmt.Sprintf("%s %s: transport error", method, path),
+		Err:     err,
 	}
-
-	req, err := http.NewRequestWithContext(ctx, method, reqURL, nil)
-	if err != nil {
-		if ctx.Err() != nil {
-			return nil, ctx.Err()
-		}
-		return nil, &domain.TrackerError{
-			Kind:    domain.ErrTrackerTransport,
-			Message: fmt.Sprintf("failed to build request: %s %s", method, path),
-			Err:     err,
-		}
-	}
-
-	req.Header.Set("Authorization", c.authHeader)
-	req.Header.Set("Accept", "application/json")
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("User-Agent", c.userAgent)
-
-	resp, err := c.httpClient.Do(req)
-	if err != nil {
-		if ctx.Err() != nil {
-			return nil, ctx.Err()
-		}
-		return nil, &domain.TrackerError{
-			Kind:    domain.ErrTrackerTransport,
-			Message: fmt.Sprintf("%s %s: network error", method, path),
-			Err:     err,
-		}
-	}
-	defer resp.Body.Close() //nolint:errcheck // best-effort cleanup on response body
-
-	if resp.StatusCode == http.StatusOK {
-		body, err := io.ReadAll(resp.Body)
-		if err != nil {
-			return nil, &domain.TrackerError{
-				Kind:    domain.ErrTrackerTransport,
-				Message: "failed to read response body",
-				Err:     err,
-			}
-		}
-		return body, nil
-	}
-
-	return nil, classifyHTTPError(resp, method, path)
-}
-
-// doJSON executes an HTTP request with a JSON request body against the
-// Jira REST API. Successful responses (200-299) return the response
-// body (which may be empty for 204 No Content). Non-success responses
-// are mapped to [domain.TrackerError] by status code, using the same
-// classification as [jiraClient.do].
-func (c *jiraClient) doJSON(ctx context.Context, method, path string, body io.Reader) ([]byte, error) { //nolint:unparam // method is POST today but the signature mirrors do for consistency
-	reqURL := c.baseURL + path
-
-	req, err := http.NewRequestWithContext(ctx, method, reqURL, body)
-	if err != nil {
-		if ctx.Err() != nil {
-			return nil, ctx.Err()
-		}
-		return nil, &domain.TrackerError{
-			Kind:    domain.ErrTrackerTransport,
-			Message: fmt.Sprintf("failed to build request: %s %s", method, path),
-			Err:     err,
-		}
-	}
-
-	req.Header.Set("Authorization", c.authHeader)
-	req.Header.Set("Accept", "application/json")
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("User-Agent", c.userAgent)
-
-	resp, err := c.httpClient.Do(req)
-	if err != nil {
-		if ctx.Err() != nil {
-			return nil, ctx.Err()
-		}
-		return nil, &domain.TrackerError{
-			Kind:    domain.ErrTrackerTransport,
-			Message: fmt.Sprintf("%s %s: network error", method, path),
-			Err:     err,
-		}
-	}
-	defer resp.Body.Close() //nolint:errcheck // best-effort cleanup on response body
-
-	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
-		respBody, err := io.ReadAll(resp.Body)
-		if err != nil {
-			return nil, &domain.TrackerError{
-				Kind:    domain.ErrTrackerTransport,
-				Message: "failed to read response body",
-				Err:     err,
-			}
-		}
-		return respBody, nil
-	}
-
-	return nil, classifyHTTPError(resp, method, path)
 }

--- a/internal/tracker/jira/client_test.go
+++ b/internal/tracker/jira/client_test.go
@@ -11,46 +11,52 @@ import (
 	"testing"
 
 	"github.com/sortie-ai/sortie/internal/domain"
+	"github.com/sortie-ai/sortie/internal/httpkit"
 )
 
-// newTestJiraClient creates a jiraClient with an isolated HTTP transport.
-// Parallel tests that share http.DefaultTransport can flake when one
-// test's httptest.Server.Close races with another's in-flight request.
-// Clone preserves all DefaultTransport settings while giving each test
-// its own connection pool.
-func newTestJiraClient(t *testing.T, baseURL, email, token, userAgent string) *jiraClient {
+func newTestJiraClient(t *testing.T, baseURL, email, token string) *httpkit.Client {
 	t.Helper()
-	defaultTransport, ok := http.DefaultTransport.(*http.Transport)
-	if !ok {
-		t.Fatalf("http.DefaultTransport is %T, want *http.Transport", http.DefaultTransport)
-	}
-	transport := defaultTransport.Clone()
-	c := newJiraClient(baseURL, email, token, userAgent)
-	c.httpClient.Transport = transport
-	t.Cleanup(func() {
-		transport.CloseIdleConnections()
-	})
-	return c
+	return newJiraClient(baseURL, email, token, "sortie/test")
 }
 
-func TestClientDo_Success(t *testing.T) {
+func assertClientTrackerErrorKind(t *testing.T, err error, want domain.TrackerErrorKind) {
+	t.Helper()
+	var trackerErr *domain.TrackerError
+	if !errors.As(err, &trackerErr) {
+		t.Fatalf("error type = %T, want *domain.TrackerError", err)
+	}
+	if trackerErr.Kind != want {
+		t.Errorf("TrackerError.Kind = %q, want %q", trackerErr.Kind, want)
+	}
+}
+
+func TestClientGet_Success(t *testing.T) {
 	t.Parallel()
 
 	var gotHeaders http.Header
+	var gotQuery url.Values
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		gotHeaders = r.Header
+		gotHeaders = r.Header.Clone()
+		gotQuery = r.URL.Query()
+		w.Header().Set("X-Test-Header", "ok")
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte(`{"ok":true}`)) //nolint:errcheck // test helper
 	}))
 	defer srv.Close()
 
-	c := newTestJiraClient(t, srv.URL, "user@test.com", "tok123", "sortie/test")
-	body, err := c.do(context.Background(), "GET", "/test", nil)
+	c := newTestJiraClient(t, srv.URL, "user@test.com", "tok123")
+	body, headers, err := c.Get(context.Background(), "/test", url.Values{"jql": {"project = X"}})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if string(body) != `{"ok":true}` {
 		t.Errorf("body = %q, want %q", body, `{"ok":true}`)
+	}
+	if got := headers.Get("X-Test-Header"); got != "ok" {
+		t.Errorf("headers.Get(X-Test-Header) = %q, want %q", got, "ok")
+	}
+	if got := gotQuery.Get("jql"); got != "project = X" {
+		t.Errorf("jql param = %q, want %q", got, "project = X")
 	}
 	if got := gotHeaders.Get("Authorization"); !strings.HasPrefix(got, "Basic ") {
 		t.Errorf("Authorization header = %q, want Basic prefix", got)
@@ -58,37 +64,15 @@ func TestClientDo_Success(t *testing.T) {
 	if got := gotHeaders.Get("Accept"); got != "application/json" {
 		t.Errorf("Accept header = %q, want application/json", got)
 	}
-	if got := gotHeaders.Get("Content-Type"); got != "application/json" {
-		t.Errorf("Content-Type header = %q, want application/json", got)
+	if got := gotHeaders.Get("Content-Type"); got != "" {
+		t.Errorf("Content-Type header = %q, want empty", got)
+	}
+	if got := gotHeaders.Get("User-Agent"); got != "sortie/test" {
+		t.Errorf("User-Agent header = %q, want %q", got, "sortie/test")
 	}
 }
 
-func TestClientDo_QueryParams(t *testing.T) {
-	t.Parallel()
-
-	var gotQuery url.Values
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		gotQuery = r.URL.Query()
-		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("{}")) //nolint:errcheck // test helper
-	}))
-	defer srv.Close()
-
-	c := newTestJiraClient(t, srv.URL, "u@t.com", "t", "sortie/test")
-	params := url.Values{"jql": {"project = X"}, "maxResults": {"50"}}
-	_, err := c.do(context.Background(), "GET", "/search", params)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if got := gotQuery.Get("jql"); got != "project = X" {
-		t.Errorf("jql param = %q, want %q", got, "project = X")
-	}
-	if got := gotQuery.Get("maxResults"); got != "50" {
-		t.Errorf("maxResults param = %q, want %q", got, "50")
-	}
-}
-
-func TestClientDo_ErrorMapping(t *testing.T) {
+func TestClientGet_ErrorMapping(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -156,60 +140,43 @@ func TestClientDo_ErrorMapping(t *testing.T) {
 			}))
 			defer srv.Close()
 
-			c := newTestJiraClient(t, srv.URL, "u@t.com", "t", "sortie/test")
-			_, err := c.do(context.Background(), "GET", "/test", nil)
+			c := newTestJiraClient(t, srv.URL, "u@t.com", "t")
+			_, _, err := c.Get(context.Background(), "/test", nil)
 			if err == nil {
-				t.Fatal("expected error, got nil")
+				t.Fatal("Get expected error, got nil")
 			}
 
-			var te *domain.TrackerError
-			if !errors.As(err, &te) {
-				t.Fatalf("error type = %T, want *domain.TrackerError", err)
-			}
-			if te.Kind != tt.wantKind {
-				t.Errorf("Kind = %q, want %q", te.Kind, tt.wantKind)
-			}
-			if tt.wantMsg != "" && !strings.Contains(te.Message, tt.wantMsg) {
-				t.Errorf("Message = %q, should contain %q", te.Message, tt.wantMsg)
+			assertClientTrackerErrorKind(t, err, tt.wantKind)
+			var trackerErr *domain.TrackerError
+			if errors.As(err, &trackerErr) && tt.wantMsg != "" && !strings.Contains(trackerErr.Message, tt.wantMsg) {
+				t.Errorf("Message = %q, should contain %q", trackerErr.Message, tt.wantMsg)
 			}
 		})
 	}
 }
 
-func TestClientDo_NetworkFailure(t *testing.T) {
+func TestClientGet_NetworkFailure(t *testing.T) {
 	t.Parallel()
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
 	srv.Close() // close immediately to cause connection refused
 
-	c := newTestJiraClient(t, srv.URL, "u@t.com", "t", "sortie/test")
-	_, err := c.do(context.Background(), "GET", "/test", nil)
+	c := newTestJiraClient(t, srv.URL, "u@t.com", "t")
+	_, _, err := c.Get(context.Background(), "/test", nil)
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
-
-	var te *domain.TrackerError
-	if !errors.As(err, &te) {
-		t.Fatalf("error type = %T, want *domain.TrackerError", err)
-	}
-	if te.Kind != domain.ErrTrackerTransport {
-		t.Errorf("Kind = %q, want %q", te.Kind, domain.ErrTrackerTransport)
-	}
+	assertClientTrackerErrorKind(t, err, domain.ErrTrackerTransport)
 }
 
-func TestClientDo_ContextCancellation(t *testing.T) {
+func TestClientGet_ContextCancellation(t *testing.T) {
 	t.Parallel()
-
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer srv.Close()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // cancel before request
 
-	c := newTestJiraClient(t, srv.URL, "u@t.com", "t", "sortie/test")
-	_, err := c.do(ctx, "GET", "/test", nil)
+	c := newTestJiraClient(t, "https://example.invalid", "u@t.com", "t")
+	_, _, err := c.Get(ctx, "/test", nil)
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -223,9 +190,7 @@ func TestClientDo_ContextCancellation(t *testing.T) {
 	}
 }
 
-// --- doJSON tests ---
-
-func TestClientDoJSON_Success(t *testing.T) {
+func TestClientSend_Success(t *testing.T) {
 	t.Parallel()
 
 	var gotMethod string
@@ -239,13 +204,13 @@ func TestClientDoJSON_Success(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := newTestJiraClient(t, srv.URL, "user@test.com", "tok123", "sortie/test")
-	body, err := c.doJSON(context.Background(), "POST", "/transitions", strings.NewReader(`{"transition":{"id":"31"}}`))
+	c := newTestJiraClient(t, srv.URL, "user@test.com", "tok123")
+	body, err := c.Send(context.Background(), "POST", "/transitions", strings.NewReader(`{"transition":{"id":"31"}}`))
 	if err != nil {
-		t.Fatalf("doJSON() unexpected error: %v", err)
+		t.Fatalf("Send() unexpected error: %v", err)
 	}
 	if len(body) != 0 {
-		t.Errorf("doJSON() body = %q, want empty", body)
+		t.Errorf("Send() body = %q, want empty", body)
 	}
 	if gotMethod != "POST" {
 		t.Errorf("request method = %q, want POST", gotMethod)
@@ -262,9 +227,12 @@ func TestClientDoJSON_Success(t *testing.T) {
 	if got := gotHeaders.Get("Accept"); got != "application/json" {
 		t.Errorf("Accept header = %q, want application/json", got)
 	}
+	if got := gotHeaders.Get("User-Agent"); got != "sortie/test" {
+		t.Errorf("User-Agent header = %q, want %q", got, "sortie/test")
+	}
 }
 
-func TestClientDoJSON_200_WithBody(t *testing.T) {
+func TestClientSend_200_WithBody(t *testing.T) {
 	t.Parallel()
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -273,17 +241,17 @@ func TestClientDoJSON_200_WithBody(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := newTestJiraClient(t, srv.URL, "u@t.com", "t", "sortie/test")
-	body, err := c.doJSON(context.Background(), "POST", "/test", strings.NewReader("{}"))
+	c := newTestJiraClient(t, srv.URL, "u@t.com", "t")
+	body, err := c.Send(context.Background(), "POST", "/test", strings.NewReader("{}"))
 	if err != nil {
-		t.Fatalf("doJSON() unexpected error: %v", err)
+		t.Fatalf("Send() unexpected error: %v", err)
 	}
 	if string(body) != `{"ok":true}` {
-		t.Errorf("doJSON() body = %q, want %q", body, `{"ok":true}`)
+		t.Errorf("Send() body = %q, want %q", body, `{"ok":true}`)
 	}
 }
 
-func TestClientDoJSON_ErrorMapping(t *testing.T) {
+func TestClientSend_ErrorMapping(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -308,117 +276,32 @@ func TestClientDoJSON_ErrorMapping(t *testing.T) {
 			}))
 			defer srv.Close()
 
-			c := newTestJiraClient(t, srv.URL, "u@t.com", "t", "sortie/test")
-			_, err := c.doJSON(context.Background(), "POST", "/test", strings.NewReader("{}"))
+			c := newTestJiraClient(t, srv.URL, "u@t.com", "t")
+			_, err := c.Send(context.Background(), "POST", "/test", strings.NewReader("{}"))
 			if err == nil {
-				t.Fatal("doJSON() expected error, got nil")
+				t.Fatal("Send() expected error, got nil")
 			}
-
-			var te *domain.TrackerError
-			if !errors.As(err, &te) {
-				t.Fatalf("error type = %T, want *domain.TrackerError", err)
-			}
-			if te.Kind != tt.wantKind {
-				t.Errorf("TrackerError.Kind = %q, want %q", te.Kind, tt.wantKind)
-			}
+			assertClientTrackerErrorKind(t, err, tt.wantKind)
 		})
 	}
 }
 
-func TestClientDoJSON_ContextCancellation(t *testing.T) {
+func TestClientSend_ContextCancellation(t *testing.T) {
 	t.Parallel()
-
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusNoContent)
-	}))
-	defer srv.Close()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	c := newTestJiraClient(t, srv.URL, "u@t.com", "t", "sortie/test")
-	_, err := c.doJSON(ctx, "POST", "/test", strings.NewReader("{}"))
+	c := newTestJiraClient(t, "https://example.invalid", "u@t.com", "t")
+	_, err := c.Send(ctx, "POST", "/test", strings.NewReader("{}"))
 	if err == nil {
-		t.Fatal("doJSON() expected error, got nil")
+		t.Fatal("Send() expected error, got nil")
 	}
 	if !errors.Is(err, context.Canceled) {
-		t.Errorf("doJSON() error = %v, want context.Canceled", err)
+		t.Errorf("Send() error = %v, want context.Canceled", err)
 	}
 	var te *domain.TrackerError
 	if errors.As(err, &te) {
 		t.Errorf("context cancellation should not be wrapped in TrackerError, got Kind=%q", te.Kind)
-	}
-}
-
-// --- User-Agent header tests ---
-
-func TestClientDo_UserAgentHeader(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name      string
-		userAgent string
-		want      string
-	}{
-		{"release version", "sortie/v0.8.3", "sortie/v0.8.3"},
-		{"dev fallback", "sortie/dev", "sortie/dev"},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			var gotUA string
-			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				gotUA = r.Header.Get("User-Agent")
-				w.WriteHeader(http.StatusOK)
-				w.Write([]byte("{}")) //nolint:errcheck // test helper
-			}))
-			defer srv.Close()
-
-			c := newTestJiraClient(t, srv.URL, "u@t.com", "t", tt.userAgent)
-			_, err := c.do(context.Background(), "GET", "/test", nil)
-			if err != nil {
-				t.Fatalf("do() unexpected error: %v", err)
-			}
-			if gotUA != tt.want {
-				t.Errorf("User-Agent header = %q, want %q", gotUA, tt.want)
-			}
-		})
-	}
-}
-
-func TestClientDoJSON_UserAgentHeader(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name      string
-		userAgent string
-		want      string
-	}{
-		{"release version", "sortie/v0.8.3", "sortie/v0.8.3"},
-		{"dev fallback", "sortie/dev", "sortie/dev"},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			var gotUA string
-			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				gotUA = r.Header.Get("User-Agent")
-				w.WriteHeader(http.StatusNoContent)
-			}))
-			defer srv.Close()
-
-			c := newTestJiraClient(t, srv.URL, "u@t.com", "t", tt.userAgent)
-			_, err := c.doJSON(context.Background(), "POST", "/test", strings.NewReader("{}"))
-			if err != nil {
-				t.Fatalf("doJSON() unexpected error: %v", err)
-			}
-			if gotUA != tt.want {
-				t.Errorf("User-Agent header = %q, want %q", gotUA, tt.want)
-			}
-		})
 	}
 }

--- a/internal/tracker/jira/jira.go
+++ b/internal/tracker/jira/jira.go
@@ -166,13 +166,14 @@ func (a *JiraAdapter) FetchIssueByID(ctx context.Context, issueID string) (domai
 			}
 		}
 
-		issue = normalizeSearchIssue(a.endpoint, ji)
+		fetchedIssue := normalizeSearchIssue(a.endpoint, ji)
 
 		comments, err := a.fetchComments(ctx, issueID)
 		if err != nil {
 			return err
 		}
-		issue.Comments = comments
+		fetchedIssue.Comments = comments
+		issue = fetchedIssue
 		return nil
 	})
 	return issue, err
@@ -205,8 +206,9 @@ func (a *JiraAdapter) FetchIssueStatesByIDs(ctx context.Context, issueIDs []stri
 		return map[string]string{}, nil
 	}
 
-	statesByID := make(map[string]string, len(issueIDs))
+	var statesByID map[string]string
 	err := trackermetrics.Track(a.metrics, "fetch_states_by_ids", func() error {
+		fetchedStates := make(map[string]string, len(issueIDs))
 		for start := 0; start < len(issueIDs); start += batchSize {
 			if ctx.Err() != nil {
 				return ctx.Err()
@@ -225,9 +227,10 @@ func (a *JiraAdapter) FetchIssueStatesByIDs(ctx context.Context, issueIDs []stri
 				return err
 			}
 			for _, iss := range issues {
-				statesByID[iss.ID] = iss.State
+				fetchedStates[iss.ID] = iss.State
 			}
 		}
+		statesByID = fetchedStates
 		return nil
 	})
 	return statesByID, err
@@ -243,8 +246,9 @@ func (a *JiraAdapter) FetchIssueStatesByIdentifiers(ctx context.Context, identif
 		return map[string]string{}, nil
 	}
 
-	statesByKey := make(map[string]string, len(identifiers))
+	var statesByKey map[string]string
 	err := trackermetrics.Track(a.metrics, "fetch_states_by_identifiers", func() error {
+		fetchedStates := make(map[string]string, len(identifiers))
 		for start := 0; start < len(identifiers); start += batchSize {
 			if ctx.Err() != nil {
 				return ctx.Err()
@@ -259,9 +263,10 @@ func (a *JiraAdapter) FetchIssueStatesByIdentifiers(ctx context.Context, identif
 				return err
 			}
 			for _, iss := range issues {
-				statesByKey[iss.Identifier] = iss.State
+				fetchedStates[iss.Identifier] = iss.State
 			}
 		}
+		statesByKey = fetchedStates
 		return nil
 	})
 	return statesByKey, err

--- a/internal/tracker/jira/jira.go
+++ b/internal/tracker/jira/jira.go
@@ -15,7 +15,9 @@ import (
 	"strings"
 
 	"github.com/sortie-ai/sortie/internal/domain"
+	"github.com/sortie-ai/sortie/internal/httpkit"
 	"github.com/sortie-ai/sortie/internal/registry"
+	"github.com/sortie-ai/sortie/internal/trackermetrics"
 	"github.com/sortie-ai/sortie/internal/typeutil"
 )
 
@@ -49,7 +51,7 @@ const batchSize = 40
 // JiraAdapter implements [domain.TrackerAdapter] against Jira Cloud
 // REST API v3. Safe for concurrent use.
 type JiraAdapter struct {
-	client       *jiraClient
+	client       *httpkit.Client
 	project      string
 	activeStates []string
 	endpoint     string
@@ -128,53 +130,52 @@ func NewJiraAdapter(config map[string]any) (domain.TrackerAdapter, error) {
 // for the configured project. Comments are set to nil on all returned
 // issues. Results are ordered by priority then creation time.
 func (a *JiraAdapter) FetchCandidateIssues(ctx context.Context) ([]domain.Issue, error) {
-	jql := buildCandidateJQL(a.project, a.activeStates, a.queryFilter)
-	issues, err := a.paginatedSearch(ctx, jql, searchFields)
-	if err != nil {
-		a.incTrackerRequest("fetch_candidates", "error")
-		return nil, err
-	}
-	a.incTrackerRequest("fetch_candidates", "success")
-	return issues, nil
+	issues := make([]domain.Issue, 0)
+	err := trackermetrics.Track(a.metrics, "fetch_candidates", func() error {
+		var fetchErr error
+		jql := buildCandidateJQL(a.project, a.activeStates, a.queryFilter)
+		issues, fetchErr = a.paginatedSearch(ctx, jql, searchFields)
+		return fetchErr
+	})
+	return issues, err
 }
 
 // FetchIssueByID returns a fully populated issue including comments.
 // The issueID is the Jira issue key (e.g. "PROJ-123").
 func (a *JiraAdapter) FetchIssueByID(ctx context.Context, issueID string) (domain.Issue, error) {
-	params := url.Values{"fields": {searchFields}}
-	body, err := a.client.do(ctx, "GET", "/rest/api/3/issue/"+url.PathEscape(issueID), params)
-	if err != nil {
-		a.incTrackerRequest("fetch_issue", "error")
-		if domain.IsNotFound(err) {
-			return domain.Issue{}, &domain.TrackerError{
-				Kind:    domain.ErrTrackerNotFound,
-				Message: fmt.Sprintf("issue not found: %s", issueID),
+	var issue domain.Issue
+	err := trackermetrics.Track(a.metrics, "fetch_issue", func() error {
+		params := url.Values{"fields": {searchFields}}
+		body, _, err := a.client.Get(ctx, "/rest/api/3/issue/"+url.PathEscape(issueID), params)
+		if err != nil {
+			if domain.IsNotFound(err) {
+				return &domain.TrackerError{
+					Kind:    domain.ErrTrackerNotFound,
+					Message: fmt.Sprintf("issue not found: %s", issueID),
+				}
+			}
+			return err
+		}
+
+		var ji jiraIssue
+		if err := json.Unmarshal(body, &ji); err != nil {
+			return &domain.TrackerError{
+				Kind:    domain.ErrTrackerPayload,
+				Message: "failed to parse issue response",
+				Err:     err,
 			}
 		}
-		return domain.Issue{}, err
-	}
 
-	var ji jiraIssue
-	if err := json.Unmarshal(body, &ji); err != nil {
-		a.incTrackerRequest("fetch_issue", "error")
-		return domain.Issue{}, &domain.TrackerError{
-			Kind:    domain.ErrTrackerPayload,
-			Message: "failed to parse issue response",
-			Err:     err,
+		issue = normalizeSearchIssue(a.endpoint, ji)
+
+		comments, err := a.fetchComments(ctx, issueID)
+		if err != nil {
+			return err
 		}
-	}
-
-	issue := normalizeSearchIssue(a.endpoint, ji)
-
-	comments, err := a.fetchComments(ctx, issueID)
-	if err != nil {
-		a.incTrackerRequest("fetch_issue", "error")
-		return domain.Issue{}, err
-	}
-	issue.Comments = comments
-
-	a.incTrackerRequest("fetch_issue", "success")
-	return issue, nil
+		issue.Comments = comments
+		return nil
+	})
+	return issue, err
 }
 
 // FetchIssuesByStates returns issues in the specified states. Used
@@ -184,14 +185,15 @@ func (a *JiraAdapter) FetchIssuesByStates(ctx context.Context, states []string) 
 	if len(states) == 0 {
 		return []domain.Issue{}, nil
 	}
-	jql := buildStatesFetchJQL(a.project, states, a.queryFilter)
-	issues, err := a.paginatedSearch(ctx, jql, searchFields)
-	if err != nil {
-		a.incTrackerRequest("fetch_by_states", "error")
-		return nil, err
-	}
-	a.incTrackerRequest("fetch_by_states", "success")
-	return issues, nil
+
+	issues := make([]domain.Issue, 0)
+	err := trackermetrics.Track(a.metrics, "fetch_by_states", func() error {
+		var fetchErr error
+		jql := buildStatesFetchJQL(a.project, states, a.queryFilter)
+		issues, fetchErr = a.paginatedSearch(ctx, jql, searchFields)
+		return fetchErr
+	})
+	return issues, err
 }
 
 // FetchIssueStatesByIDs returns the current state for each requested
@@ -204,37 +206,31 @@ func (a *JiraAdapter) FetchIssueStatesByIDs(ctx context.Context, issueIDs []stri
 	}
 
 	statesByID := make(map[string]string, len(issueIDs))
+	err := trackermetrics.Track(a.metrics, "fetch_states_by_ids", func() error {
+		for start := 0; start < len(issueIDs); start += batchSize {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
 
-	var requested bool
+			end := min(start+batchSize, len(issueIDs))
+			batch := issueIDs[start:end]
 
-	for start := 0; start < len(issueIDs); start += batchSize {
-		if ctx.Err() != nil {
-			a.incTrackerRequest("fetch_states_by_ids", "error")
-			return nil, ctx.Err()
+			jql := buildIDINJQL(batch)
+			if jql == "" {
+				continue
+			}
+
+			issues, err := a.paginatedSearch(ctx, jql, "status")
+			if err != nil {
+				return err
+			}
+			for _, iss := range issues {
+				statesByID[iss.ID] = iss.State
+			}
 		}
-
-		end := min(start+batchSize, len(issueIDs))
-		batch := issueIDs[start:end]
-
-		jql := buildIDINJQL(batch)
-		if jql == "" {
-			continue
-		}
-		requested = true
-		issues, err := a.paginatedSearch(ctx, jql, "status")
-		if err != nil {
-			a.incTrackerRequest("fetch_states_by_ids", "error")
-			return nil, err
-		}
-		for _, iss := range issues {
-			statesByID[iss.ID] = iss.State
-		}
-	}
-
-	if requested {
-		a.incTrackerRequest("fetch_states_by_ids", "success")
-	}
-	return statesByID, nil
+		return nil
+	})
+	return statesByID, err
 }
 
 // FetchIssueStatesByIdentifiers returns the current state for each
@@ -248,41 +244,39 @@ func (a *JiraAdapter) FetchIssueStatesByIdentifiers(ctx context.Context, identif
 	}
 
 	statesByKey := make(map[string]string, len(identifiers))
+	err := trackermetrics.Track(a.metrics, "fetch_states_by_identifiers", func() error {
+		for start := 0; start < len(identifiers); start += batchSize {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
 
-	for start := 0; start < len(identifiers); start += batchSize {
-		if ctx.Err() != nil {
-			a.incTrackerRequest("fetch_states_by_identifiers", "error")
-			return nil, ctx.Err()
+			end := min(start+batchSize, len(identifiers))
+			batch := identifiers[start:end]
+
+			jql := buildKeyINJQL(batch)
+			issues, err := a.paginatedSearch(ctx, jql, "status")
+			if err != nil {
+				return err
+			}
+			for _, iss := range issues {
+				statesByKey[iss.Identifier] = iss.State
+			}
 		}
-
-		end := min(start+batchSize, len(identifiers))
-		batch := identifiers[start:end]
-
-		jql := buildKeyINJQL(batch)
-		issues, err := a.paginatedSearch(ctx, jql, "status")
-		if err != nil {
-			a.incTrackerRequest("fetch_states_by_identifiers", "error")
-			return nil, err
-		}
-		for _, iss := range issues {
-			statesByKey[iss.Identifier] = iss.State
-		}
-	}
-
-	a.incTrackerRequest("fetch_states_by_identifiers", "success")
-	return statesByKey, nil
+		return nil
+	})
+	return statesByKey, err
 }
 
 // FetchIssueComments returns comments for the specified issue.
 // Returns an empty non-nil slice when no comments exist.
 func (a *JiraAdapter) FetchIssueComments(ctx context.Context, issueID string) ([]domain.Comment, error) {
-	comments, err := a.fetchComments(ctx, issueID)
-	if err != nil {
-		a.incTrackerRequest("fetch_comments", "error")
-		return nil, err
-	}
-	a.incTrackerRequest("fetch_comments", "success")
-	return comments, nil
+	comments := make([]domain.Comment, 0)
+	err := trackermetrics.Track(a.metrics, "fetch_comments", func() error {
+		var fetchErr error
+		comments, fetchErr = a.fetchComments(ctx, issueID)
+		return fetchErr
+	})
+	return comments, err
 }
 
 // TransitionIssue moves an issue to the specified target state by
@@ -290,91 +284,80 @@ func (a *JiraAdapter) FetchIssueComments(ctx context.Context, issueID string) ([
 // Available transitions are fetched via GET, matched by target status
 // name (case-insensitive, first match), then executed via POST.
 func (a *JiraAdapter) TransitionIssue(ctx context.Context, issueID string, targetState string) error {
-	path := "/rest/api/3/issue/" + url.PathEscape(issueID) + "/transitions"
+	return trackermetrics.Track(a.metrics, "transition", func() error {
+		path := "/rest/api/3/issue/" + url.PathEscape(issueID) + "/transitions"
 
-	body, err := a.client.do(ctx, "GET", path, nil)
-	if err != nil {
-		a.incTrackerRequest("transition", "error")
+		body, _, err := a.client.Get(ctx, path, nil)
+		if err != nil {
+			return err
+		}
+
+		var resp transitionsResponse
+		if err := json.Unmarshal(body, &resp); err != nil {
+			return &domain.TrackerError{
+				Kind:    domain.ErrTrackerPayload,
+				Message: fmt.Sprintf("failed to parse transitions response for issue %s", issueID),
+				Err:     err,
+			}
+		}
+
+		var matchID string
+		for _, t := range resp.Transitions {
+			if strings.EqualFold(t.To.Name, targetState) {
+				matchID = t.ID
+				break
+			}
+		}
+
+		if matchID == "" {
+			return &domain.TrackerError{
+				Kind:    domain.ErrTrackerPayload,
+				Message: fmt.Sprintf("no transition to state %q available for issue %s", targetState, issueID),
+			}
+		}
+
+		postBody, err := json.Marshal(struct {
+			Transition struct {
+				ID string `json:"id"`
+			} `json:"transition"`
+		}{
+			Transition: struct {
+				ID string `json:"id"`
+			}{ID: matchID},
+		})
+		if err != nil {
+			return &domain.TrackerError{
+				Kind:    domain.ErrTrackerPayload,
+				Message: "failed to marshal transition request",
+				Err:     err,
+			}
+		}
+
+		_, err = a.client.Send(ctx, "POST", path, bytes.NewReader(postBody))
 		return err
-	}
-
-	var resp transitionsResponse
-	if err := json.Unmarshal(body, &resp); err != nil {
-		a.incTrackerRequest("transition", "error")
-		return &domain.TrackerError{
-			Kind:    domain.ErrTrackerPayload,
-			Message: fmt.Sprintf("failed to parse transitions response for issue %s", issueID),
-			Err:     err,
-		}
-	}
-
-	var matchID string
-	for _, t := range resp.Transitions {
-		if strings.EqualFold(t.To.Name, targetState) {
-			matchID = t.ID
-			break
-		}
-	}
-
-	if matchID == "" {
-		a.incTrackerRequest("transition", "error")
-		return &domain.TrackerError{
-			Kind:    domain.ErrTrackerPayload,
-			Message: fmt.Sprintf("no transition to state %q available for issue %s", targetState, issueID),
-		}
-	}
-
-	postBody, err := json.Marshal(struct {
-		Transition struct {
-			ID string `json:"id"`
-		} `json:"transition"`
-	}{
-		Transition: struct {
-			ID string `json:"id"`
-		}{ID: matchID},
 	})
-	if err != nil {
-		a.incTrackerRequest("transition", "error")
-		return &domain.TrackerError{
-			Kind:    domain.ErrTrackerPayload,
-			Message: "failed to marshal transition request",
-			Err:     err,
-		}
-	}
-
-	_, err = a.client.doJSON(ctx, "POST", path, bytes.NewReader(postBody))
-	if err != nil {
-		a.incTrackerRequest("transition", "error")
-		return err
-	}
-	a.incTrackerRequest("transition", "success")
-	return nil
 }
 
 // CommentIssue posts a plain-text comment on the specified Jira issue.
 // The text is split by newlines into ADF paragraph nodes before
 // submission to the Jira v3 REST API.
 func (a *JiraAdapter) CommentIssue(ctx context.Context, issueID string, text string) error {
-	path := "/rest/api/3/issue/" + url.PathEscape(issueID) + "/comment"
+	return trackermetrics.Track(a.metrics, "comment", func() error {
+		path := "/rest/api/3/issue/" + url.PathEscape(issueID) + "/comment"
 
-	body := buildADFComment(text)
-	payload, err := json.Marshal(body)
-	if err != nil {
-		a.incTrackerRequest("comment", "error")
-		return &domain.TrackerError{
-			Kind:    domain.ErrTrackerPayload,
-			Message: "failed to marshal comment request",
-			Err:     err,
+		body := buildADFComment(text)
+		payload, err := json.Marshal(body)
+		if err != nil {
+			return &domain.TrackerError{
+				Kind:    domain.ErrTrackerPayload,
+				Message: "failed to marshal comment request",
+				Err:     err,
+			}
 		}
-	}
 
-	_, err = a.client.doJSON(ctx, "POST", path, bytes.NewReader(payload))
-	if err != nil {
-		a.incTrackerRequest("comment", "error")
+		_, err = a.client.Send(ctx, "POST", path, bytes.NewReader(payload))
 		return err
-	}
-	a.incTrackerRequest("comment", "success")
-	return nil
+	})
 }
 
 // SetMetrics configures the metrics recorder for tracker API call
@@ -408,7 +391,7 @@ func (a *JiraAdapter) AddLabel(ctx context.Context, issueID string, label string
 		}
 	}
 
-	_, err = a.client.doJSON(ctx, "PUT", path, bytes.NewReader(payload))
+	_, err = a.client.Send(ctx, "PUT", path, bytes.NewReader(payload))
 	if err != nil {
 		a.incTrackerRequest("add_label", "error")
 		return err
@@ -426,53 +409,32 @@ func (a *JiraAdapter) incTrackerRequest(operation, result string) {
 // paginatedSearch executes a cursor-based paginated JQL search and
 // returns all normalized issues. Comments are set to nil.
 func (a *JiraAdapter) paginatedSearch(ctx context.Context, jql, fields string) ([]domain.Issue, error) {
-	var issues []domain.Issue
-	var nextPageToken string
+	params := url.Values{
+		"jql":        {jql},
+		"fields":     {fields},
+		"maxResults": {maxSearchResults},
+	}
 
-	for {
-		if ctx.Err() != nil {
-			return nil, ctx.Err()
-		}
-
-		params := url.Values{
-			"jql":        {jql},
-			"fields":     {fields},
-			"maxResults": {maxSearchResults},
-		}
-		if nextPageToken != "" {
-			params.Set("nextPageToken", nextPageToken)
-		}
-
-		body, err := a.client.do(ctx, "GET", "/rest/api/3/search/jql", params)
-		if err != nil {
-			return nil, err
-		}
-
+	paginator := httpkit.NewTokenPaginator(a.client, "/rest/api/3/search/jql", params, "nextPageToken", func(body []byte) ([]domain.Issue, string, error) {
 		var sr searchResponse
 		if err := json.Unmarshal(body, &sr); err != nil {
-			return nil, &domain.TrackerError{
+			return nil, "", &domain.TrackerError{
 				Kind:    domain.ErrTrackerPayload,
 				Message: "failed to parse search response",
 				Err:     err,
 			}
 		}
 
+		issues := make([]domain.Issue, 0, len(sr.Issues))
 		for _, ji := range sr.Issues {
 			issue := normalizeSearchIssue(a.endpoint, ji)
 			issue.Comments = nil
 			issues = append(issues, issue)
 		}
+		return issues, sr.NextPageToken, nil
+	}, httpkit.PaginatorOptions{})
 
-		if sr.NextPageToken == "" {
-			break
-		}
-		nextPageToken = sr.NextPageToken
-	}
-
-	if issues == nil {
-		issues = []domain.Issue{}
-	}
-	return issues, nil
+	return paginator.All(ctx)
 }
 
 // fetchComments retrieves all comments for an issue using offset-based
@@ -492,7 +454,7 @@ func (a *JiraAdapter) fetchComments(ctx context.Context, issueID string) ([]doma
 			"startAt":    {fmt.Sprintf("%d", startAt)},
 		}
 
-		body, err := a.client.do(ctx, "GET", "/rest/api/3/issue/"+url.PathEscape(issueID)+"/comment", params)
+		body, _, err := a.client.Get(ctx, "/rest/api/3/issue/"+url.PathEscape(issueID)+"/comment", params)
 		if err != nil {
 			if domain.IsNotFound(err) {
 				return nil, &domain.TrackerError{

--- a/internal/tracker/jira/jira_test.go
+++ b/internal/tracker/jira/jira_test.go
@@ -32,18 +32,7 @@ func mustAdapter(t *testing.T, config map[string]any) *JiraAdapter {
 	if err != nil {
 		t.Fatalf("NewJiraAdapter: %v", err)
 	}
-	jira := a.(*JiraAdapter)
-	// Isolate the HTTP transport so that httptest.Server.Close() in one
-	// parallel test cannot call CloseIdleConnections on http.DefaultTransport
-	// and break in-flight requests from another parallel test.
-	defaultTransport, ok := http.DefaultTransport.(*http.Transport)
-	if !ok {
-		t.Fatalf("http.DefaultTransport is %T, want *http.Transport", http.DefaultTransport)
-	}
-	transport := defaultTransport.Clone()
-	jira.client.httpClient.Transport = transport
-	t.Cleanup(transport.CloseIdleConnections)
-	return jira
+	return a.(*JiraAdapter)
 }
 
 func assertTrackerErrorKind(t *testing.T, err error, want domain.TrackerErrorKind) {

--- a/internal/tracker/jira/normalize.go
+++ b/internal/tracker/jira/normalize.go
@@ -2,10 +2,9 @@ package jira
 
 import (
 	"encoding/json"
-	"strconv"
-	"strings"
 
 	"github.com/sortie-ai/sortie/internal/domain"
+	"github.com/sortie-ai/sortie/internal/issuekit"
 )
 
 // blockerLinkTypeName is the Jira link type name used to identify
@@ -117,20 +116,10 @@ func normalizeSearchIssue(endpoint string, ji jiraIssue) domain.Issue {
 	}
 
 	if ji.Fields.Priority != nil {
-		if v, err := strconv.Atoi(ji.Fields.Priority.ID); err == nil {
-			issue.Priority = &v
-		}
+		issue.Priority = issuekit.ParsePriorityIntFromString(ji.Fields.Priority.ID)
 	}
 
-	if ji.Fields.Labels != nil {
-		labels := make([]string, len(ji.Fields.Labels))
-		for i, l := range ji.Fields.Labels {
-			labels[i] = strings.ToLower(l)
-		}
-		issue.Labels = labels
-	} else {
-		issue.Labels = []string{}
-	}
+	issue.Labels = issuekit.NormalizeLabels(ji.Fields.Labels)
 
 	if ji.Fields.Assignee != nil {
 		issue.Assignee = ji.Fields.Assignee.DisplayName
@@ -176,18 +165,18 @@ func extractBlockers(links []jiraIssueLink) []domain.BlockerRef {
 // values. ADF bodies are flattened to plain text. Nil author fields
 // produce an empty author string.
 func normalizeComments(comments []jiraComment) []domain.Comment {
-	normalized := make([]domain.Comment, len(comments))
+	source := make([]issuekit.SourceComment, len(comments))
 	for i, c := range comments {
-		normalized[i] = domain.Comment{
+		source[i] = issuekit.SourceComment{
 			ID:        c.ID,
 			Body:      flattenADF(unmarshalADF(c.Body)),
 			CreatedAt: c.Created,
 		}
 		if c.Author != nil {
-			normalized[i].Author = c.Author.DisplayName
+			source[i].Author = c.Author.DisplayName
 		}
 	}
-	return normalized
+	return issuekit.NormalizeComments(source)
 }
 
 // unmarshalADF decodes a json.RawMessage into an any value suitable

--- a/internal/trackermetrics/track.go
+++ b/internal/trackermetrics/track.go
@@ -1,0 +1,20 @@
+// Package trackermetrics provides shared tracker-operation metric helpers.
+package trackermetrics
+
+import "github.com/sortie-ai/sortie/internal/domain"
+
+// Track records the success or failure of a logical tracker operation and returns fn's error unchanged.
+func Track(rec domain.Metrics, op string, fn func() error) error {
+	err := fn()
+	if rec == nil {
+		return err
+	}
+
+	if err != nil {
+		rec.IncTrackerRequests(op, "error")
+		return err
+	}
+
+	rec.IncTrackerRequests(op, "success")
+	return nil
+}

--- a/internal/trackermetrics/track_test.go
+++ b/internal/trackermetrics/track_test.go
@@ -1,0 +1,78 @@
+package trackermetrics
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/sortie-ai/sortie/internal/domain"
+)
+
+// spyMetrics records calls to IncTrackerRequests and delegates all other
+// methods to the embedded NoopMetrics.
+type spyMetrics struct {
+	domain.NoopMetrics
+	calls []struct{ op, result string }
+}
+
+var _ domain.Metrics = (*spyMetrics)(nil)
+
+func (s *spyMetrics) IncTrackerRequests(op, result string) {
+	s.calls = append(s.calls, struct{ op, result string }{op, result})
+}
+
+func TestTrack_success(t *testing.T) {
+	t.Parallel()
+
+	spy := &spyMetrics{}
+	err := Track(spy, "fetch_issue", func() error { return nil })
+	if err != nil {
+		t.Fatalf("Track: %v", err)
+	}
+	if len(spy.calls) != 1 {
+		t.Fatalf("IncTrackerRequests calls = %d, want 1", len(spy.calls))
+	}
+	if spy.calls[0].op != "fetch_issue" {
+		t.Errorf("IncTrackerRequests op = %q, want %q", spy.calls[0].op, "fetch_issue")
+	}
+	if spy.calls[0].result != "success" {
+		t.Errorf("IncTrackerRequests result = %q, want %q", spy.calls[0].result, "success")
+	}
+}
+
+func TestTrack_error(t *testing.T) {
+	t.Parallel()
+
+	spy := &spyMetrics{}
+	fnErr := errors.New("fn-error")
+	_ = Track(spy, "transition", func() error { return fnErr })
+	if len(spy.calls) != 1 {
+		t.Fatalf("IncTrackerRequests calls = %d, want 1", len(spy.calls))
+	}
+	if spy.calls[0].op != "transition" {
+		t.Errorf("IncTrackerRequests op = %q, want %q", spy.calls[0].op, "transition")
+	}
+	if spy.calls[0].result != "error" {
+		t.Errorf("IncTrackerRequests result = %q, want %q", spy.calls[0].result, "error")
+	}
+}
+
+func TestTrack_errorUnchanged(t *testing.T) {
+	t.Parallel()
+
+	sentinel := errors.New("sentinel")
+	spy := &spyMetrics{}
+	err := Track(spy, "comment", func() error { return sentinel })
+	if !errors.Is(err, sentinel) {
+		t.Errorf("Track error = %v, want %v", err, sentinel)
+	}
+}
+
+func TestTrack_nilMetrics(t *testing.T) {
+	t.Parallel()
+
+	sentinel := errors.New("fn-error")
+	err := Track(nil, "fetch_issue", func() error { return sentinel })
+	if !errors.Is(err, sentinel) {
+		t.Errorf("Track(nil) error = %v, want %v", err, sentinel)
+	}
+}


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Refactor

**Intent:** Extract duplicated low-level concerns from the Jira and GitHub adapter packages into three new Integration-layer helpers — `internal/httpkit` (shared REST transport and pagination), `internal/issuekit` (provider-agnostic normalization), and `internal/trackermetrics` (logical tracker-operation outcome counting) — without changing any domain interface or adapter behavior.

**Related Issues:** N/A

### 🧭 Reviewer Guide

**Complexity:** High

#### Entry Point

Start at `internal/httpkit/client.go`. It defines the shared `Client` type with `Authorize`, `ClassifyError`, and `ClassifyTransport` hooks, and is the root dependency for all adapter migrations in this PR. Understanding its success-status handling rules (`Get`/`GetRaw` → 200 only, `Send` → any 2xx, `SendNoBody` → 200/204 only, `GetConditional` → 200 + 304 cache hit) is essential before reviewing the adapter call sites.

Then review `internal/httpkit/paginator.go` for the token and Link paginator algorithms, including the `MaxPages` inclusive-cap and `OnLimitReached` callback semantics.

#### Sensitive Areas

- `internal/httpkit/client.go`: Transport classifier is invoked for request-build, network I/O, and body-read failures, but `ctx.Err()` is returned unchanged when the context is already cancelled — this is the normalized error contract.
- `internal/scm/github/client.go`: The `newGitHubClient` constructor now returns `*httpkit.Client` directly (wrapper type removed); `etagCache` stays adapter-owned in `tracker.go`.
- `internal/tracker/jira/client.go`: `newJiraClient` returns `*httpkit.Client` directly; Jira issue-comment pagination remains an adapter-local offset loop (not migrated to the token paginator because the endpoint uses `startAt`/`total` semantics, not a continuation token).
- `internal/tracker/file/file.go`: Delegates normalization to `issuekit` and wraps public tracker operations with `trackermetrics.Track`; `AddLabel` remains an uninstrumented no-op.
- `.github/instructions/code-review.instructions.md`: Import hierarchy updated to authorize adapter packages to import `internal/httpkit`, `internal/issuekit`, and `internal/trackermetrics`.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes — no domain interface or adapter contract changes; all changes are below the `TrackerAdapter`/`CIStatusProvider`/`SCMAdapter` boundary.
- **Migrations/State:** No database migrations or state changes required.