### PR TITLE
feat(docker): add OpenCode example Dockerfile

### DIFF
--- a/examples/docker/README.md
+++ b/examples/docker/README.md
@@ -13,6 +13,7 @@ Build an agent-specific image from the repository root:
 docker build -f examples/docker/claude-code.Dockerfile -t sortie-claude .
 docker build -f examples/docker/codex.Dockerfile -t sortie-codex .
 docker build -f examples/docker/copilot.Dockerfile -t sortie-copilot .
+docker build -f examples/docker/opencode.Dockerfile -t sortie-opencode .
 ```
 
 Run it:
@@ -33,6 +34,7 @@ docker run --rm --init \
 | `claude-code.Dockerfile` | Claude Code | `node:24-slim` |
 | `codex.Dockerfile` | OpenAI Codex CLI | `debian:bookworm-slim` |
 | `copilot.Dockerfile` | GitHub Copilot | `node:24-slim` |
+| `opencode.Dockerfile` | OpenCode | `node:24-slim` |
 
 Each Dockerfile follows the same pattern: copy the Sortie binary from the
 distroless image (`ghcr.io/sortie-ai/sortie`), install the agent, create a

--- a/examples/docker/opencode.Dockerfile
+++ b/examples/docker/opencode.Dockerfile
@@ -1,0 +1,51 @@
+# examples/docker/opencode.Dockerfile
+#
+# Complete working example: Sortie + OpenCode agent.
+#
+# OpenCode requires Node.js (>= 18), npm, and git. It authenticates through
+# provider environment variables such as ANTHROPIC_API_KEY or OPENAI_API_KEY.
+# The container runs as a non-root user for security best practices.
+#
+# Build:
+#   docker build -f examples/docker/opencode.Dockerfile -t sortie-opencode .
+#
+# Run:
+#   docker run --rm --init \
+#     -e ANTHROPIC_API_KEY \
+#     -v "$(pwd)/workspaces:/home/sortie/workspaces" \
+#     -v "$(pwd)/WORKFLOW.md:/home/sortie/WORKFLOW.md:ro" \
+#     -p 7678:7678 \
+#     sortie-opencode /home/sortie/WORKFLOW.md
+
+FROM ghcr.io/sortie-ai/sortie:latest AS sortie
+
+FROM node:24-slim
+
+# Install git for repository-backed runs.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git wget && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install OpenCode globally.
+RUN npm install -g opencode-ai@latest && npm cache clean --force
+
+# Create a non-root user. The node base image ships a "node" user at UID 1000;
+# remove it so we can claim that UID for the sortie user.
+RUN userdel -r node 2>/dev/null; \
+    useradd --create-home --shell /bin/bash --uid 1000 sortie
+
+# Copy the Sortie binary from the distroless image.
+COPY --from=sortie /usr/bin/sortie /usr/bin/sortie
+
+# Switch to the non-root user for all subsequent operations.
+USER sortie
+WORKDIR /home/sortie
+
+# The HTTP observability server listens on all interfaces so the host
+# can reach it through the published port.
+EXPOSE 7678
+
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+    CMD wget -qO /dev/null http://localhost:7678/readyz || exit 1
+
+ENTRYPOINT ["/usr/bin/sortie", "--host", "0.0.0.0", "--log-format", "json"]


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Feat

**Intent:** Add `examples/docker/opencode.Dockerfile` that bundles Sortie with the OpenCode CLI (`opencode-ai` npm package) in a single container image, mirroring the existing Claude Code, Copilot, and Codex examples. 

**Related Issues:** #478

### 🧭 Reviewer Guide

**Complexity:** Low

#### Entry Point

`examples/docker/opencode.Dockerfile` - new Dockerfile following the same multi-stage pattern as the other agent examples: copies the Sortie binary from `ghcr.io/sortie-ai/sortie:latest`, uses `node:24-slim` as the base (OpenCode requires Node.js), installs `opencode-ai@latest` via npm, and creates a non-root `sortie` user at UID 1000.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes
- **Migrations/State:** No migrations or state changes