### PR TITLE
feat(examples): add Jira + OpenCode sample workflow

### DIFF
--- a/cmd/sortie/sample_workflow_test.go
+++ b/cmd/sortie/sample_workflow_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 
@@ -341,6 +342,22 @@ func TestSampleWorkflowOpenCodeExtension(t *testing.T) {
 	}
 	if v, _ := opencodeCfg["disable_autocompact"].(bool); !v {
 		t.Error("opencode extension 'disable_autocompact' must be true")
+	}
+	allowedTools, ok := opencodeCfg["allowed_tools"].([]any)
+	if !ok {
+		t.Fatal("opencode extension missing 'allowed_tools' list")
+	}
+	gotAllowedTools := make([]string, 0, len(allowedTools))
+	for _, tool := range allowedTools {
+		name, ok := tool.(string)
+		if !ok {
+			t.Fatalf("allowed tool type = %T, want string", tool)
+		}
+		gotAllowedTools = append(gotAllowedTools, name)
+	}
+	wantAllowedTools := []string{"read", "glob", "grep", "edit", "bash"}
+	if !slices.Equal(gotAllowedTools, wantAllowedTools) {
+		t.Errorf("opencode extension allowed_tools = %v, want %v", gotAllowedTools, wantAllowedTools)
 	}
 
 	agent, ok := wf.Config["agent"].(map[string]any)

--- a/cmd/sortie/sample_workflow_test.go
+++ b/cmd/sortie/sample_workflow_test.go
@@ -90,6 +90,11 @@ func TestSampleWorkflowLoad(t *testing.T) {
 			file:     "WORKFLOW.test.md",
 			wantKeys: []string{"tracker", "polling", "workspace", "agent", "file"},
 		},
+		{
+			name:     "WORKFLOW.opencode.md loads with expected config keys",
+			file:     "WORKFLOW.opencode.md",
+			wantKeys: []string{"tracker", "polling", "workspace", "hooks", "agent", "opencode", "server"},
+		},
 	}
 
 	for _, tt := range tests {
@@ -139,6 +144,16 @@ func TestSampleWorkflowRender(t *testing.T) {
 		{
 			name:  "WORKFLOW.test.md minimal issue",
 			file:  "WORKFLOW.test.md",
+			issue: minimalIssue(),
+		},
+		{
+			name:  "WORKFLOW.opencode.md full issue",
+			file:  "WORKFLOW.opencode.md",
+			issue: fullIssue(),
+		},
+		{
+			name:  "WORKFLOW.opencode.md minimal issue",
+			file:  "WORKFLOW.opencode.md",
 			issue: minimalIssue(),
 		},
 	}
@@ -281,7 +296,7 @@ func TestSampleWorkflowTestFilePathConfig(t *testing.T) {
 func TestSampleWorkflowNoHTMLComments(t *testing.T) {
 	t.Parallel()
 
-	files := []string{"WORKFLOW.md", "WORKFLOW.test.md"}
+	files := []string{"WORKFLOW.md", "WORKFLOW.test.md", "WORKFLOW.opencode.md"}
 	for _, name := range files {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -297,6 +312,54 @@ func TestSampleWorkflowNoHTMLComments(t *testing.T) {
 				t.Errorf("%s prompt body contains HTML comment (<!--); use Go template comments {{/* */}} instead", name)
 			}
 		})
+	}
+}
+
+func TestSampleWorkflowOpenCodeExtension(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(repoRoot(t), "examples", "WORKFLOW.opencode.md")
+	wf, err := workflow.Load(path)
+	if err != nil {
+		t.Fatalf("workflow.Load(WORKFLOW.opencode.md): %v", err)
+	}
+
+	raw, ok := wf.Config["opencode"]
+	if !ok {
+		t.Fatal("WORKFLOW.opencode.md config missing 'opencode' extension block")
+	}
+	opencodeCfg, ok := raw.(map[string]any)
+	if !ok {
+		t.Fatalf("opencode extension type = %T, want map[string]any", raw)
+	}
+
+	if _, ok := opencodeCfg["model"]; !ok {
+		t.Error("opencode extension missing 'model' field")
+	}
+	if v, _ := opencodeCfg["dangerously_skip_permissions"].(bool); !v {
+		t.Error("opencode extension 'dangerously_skip_permissions' must be true")
+	}
+	if v, _ := opencodeCfg["disable_autocompact"].(bool); !v {
+		t.Error("opencode extension 'disable_autocompact' must be true")
+	}
+
+	agent, ok := wf.Config["agent"].(map[string]any)
+	if !ok {
+		t.Fatal("WORKFLOW.opencode.md config missing 'agent' map")
+	}
+	if kind, _ := agent["kind"].(string); kind != "opencode" {
+		t.Errorf("agent.kind = %q, want %q", kind, "opencode")
+	}
+	if cmd, _ := agent["command"].(string); cmd != "opencode" {
+		t.Errorf("agent.command = %q, want %q", cmd, "opencode")
+	}
+
+	tracker, ok := wf.Config["tracker"].(map[string]any)
+	if !ok {
+		t.Fatal("WORKFLOW.opencode.md config missing 'tracker' map")
+	}
+	if kind, _ := tracker["kind"].(string); kind != "jira" {
+		t.Errorf("tracker.kind = %q, want %q", kind, "jira")
 	}
 }
 

--- a/examples/WORKFLOW.opencode.md
+++ b/examples/WORKFLOW.opencode.md
@@ -49,6 +49,12 @@ opencode:
   model: anthropic/claude-sonnet-4-5
   dangerously_skip_permissions: true
   disable_autocompact: true
+  allowed_tools:
+    - read
+    - glob
+    - grep
+    - edit
+    - bash
 
 server:
   port: 8642
@@ -59,6 +65,9 @@ server:
      The OpenCode adapter launches one `opencode run` subprocess per
      turn. Session IDs are preserved across turns, so continuation uses
      the existing session instead of starting over.
+
+     This sample also pins an explicit tool allowlist so OpenCode does
+     not fall back to its permissive default tool policy.
 
      Required env vars:
        SORTIE_JIRA_ENDPOINT  — Jira Cloud base URL (e.g. https://mycompany.atlassian.net)

--- a/examples/WORKFLOW.opencode.md
+++ b/examples/WORKFLOW.opencode.md
@@ -1,0 +1,164 @@
+---
+tracker:
+  kind: jira
+  endpoint: $SORTIE_JIRA_ENDPOINT
+  api_key: $SORTIE_JIRA_API_KEY
+  project: $SORTIE_JIRA_PROJECT
+  query_filter: "labels = 'agent-ready'"
+  active_states:
+    - To Do
+    - In Progress
+  in_progress_state: In Progress
+  handoff_state: Human Review
+  terminal_states:
+    - Done
+    - Won't Do
+
+polling:
+  interval_ms: 45000
+
+workspace:
+  root: $SORTIE_WORKSPACE_ROOT
+
+hooks:
+  after_create: |
+    git clone --depth 1 $SORTIE_REPO_URL .
+  before_run: |
+    git fetch origin main
+    git checkout -B "sortie/$SORTIE_ISSUE_IDENTIFIER" origin/main
+  after_run: |
+    git add -A
+    git diff --cached --quiet || \
+      git commit -m "sortie($SORTIE_ISSUE_IDENTIFIER): automated changes"
+    git push origin "sortie/$SORTIE_ISSUE_IDENTIFIER" --force-with-lease
+  before_remove: |
+    git push origin --delete "sortie/$SORTIE_ISSUE_IDENTIFIER" 2>/dev/null || true
+  timeout_ms: 120000
+
+agent:
+  kind: opencode
+  command: opencode
+  max_turns: 15
+  max_concurrent_agents: 4
+  turn_timeout_ms: 3600000
+  read_timeout_ms: 5000
+  stall_timeout_ms: 300000
+  max_retry_backoff_ms: 300000
+
+opencode:
+  model: anthropic/claude-sonnet-4-5
+  dangerously_skip_permissions: true
+  disable_autocompact: true
+
+server:
+  port: 8642
+---
+
+{{/* Sortie sample workflow — Jira + OpenCode CLI (Anthropic).
+
+     The OpenCode adapter launches one `opencode run` subprocess per
+     turn. Session IDs are preserved across turns, so continuation uses
+     the existing session instead of starting over.
+
+     Required env vars:
+       SORTIE_JIRA_ENDPOINT  — Jira Cloud base URL (e.g. https://mycompany.atlassian.net)
+       SORTIE_JIRA_API_KEY   — Jira API token
+       SORTIE_JIRA_PROJECT   — Jira project key (e.g. PROJ)
+       SORTIE_REPO_URL       — Git clone URL for the repository
+       ANTHROPIC_API_KEY     — Anthropic API key for OpenCode
+
+     Optional:
+       SORTIE_WORKSPACE_ROOT — Base directory for per-issue workspaces
+                               (defaults to system temp) */}}
+You are a senior engineer. Your work is tracked by an automated orchestrator (Sortie)
+that manages your session, retries failures, and monitors progress.
+
+## Your task
+
+**{{ .issue.identifier }}**: {{ .issue.title }}
+
+{{ if .issue.description }}
+
+### Description
+
+{{ .issue.description }}
+{{ end }}
+
+## Context
+
+Before making changes, read:
+
+- `AGENTS.md` or `CONTRIBUTING.md` for build commands and project conventions
+- Any existing tests in the area you are modifying
+- Related source files to understand current patterns
+
+## Rules
+
+1. Run the project's lint and test commands before finishing. All checks must pass.
+2. Do not modify protected files (architecture docs, ADRs, LICENSE) unless the task
+   explicitly requires it.
+3. Write tests for new functionality. Cover edge cases, not just the happy path.
+4. Keep changes minimal — implement exactly what the task requires.
+5. If you encounter a problem outside the scope of this task, stop and explain what
+   blocked you.
+
+{{ if not .run.is_continuation }}
+
+## Approach
+
+1. Read the relevant documentation and existing code before writing anything.
+2. Implement the minimal change that satisfies the task requirements.
+3. Write or update tests to cover the new behavior.
+4. Run verification commands and fix any failures.
+5. If the task is complete, confirm by reviewing your changes.
+{{ end }}
+
+{{ if .run.is_continuation }}
+
+## Continuation
+
+You are resuming work on this task (turn {{ .run.turn_number }} of {{ .run.max_turns }}).
+Review the current state of the workspace — check test output, lint results, and any
+partial changes. Do not repeat work already completed. Proceed with the next step.
+{{ end }}
+
+{{ if .attempt }}
+
+## Retry
+
+This is retry attempt {{ .attempt }}. A previous run failed or timed out. Check the
+workspace for partial work and do not start from scratch. Review any error output from
+the previous attempt if visible in the workspace.
+{{ end }}
+
+{{ if .issue.url }}
+
+## Reference
+
+Ticket: {{ .issue.url }}
+{{ end }}
+
+{{ if .issue.labels }}
+
+## Labels
+
+{{ .issue.labels | join ", " }}
+{{ end }}
+
+{{ if .issue.parent }}
+
+## Parent issue
+
+{{ .issue.parent.identifier }}
+{{ end }}
+
+{{ if .issue.blocked_by }}
+
+## Blockers
+
+The following issues block this task. If any are unresolved, focus on preparation work
+that does not depend on the blocked functionality (tests, scaffolding, documentation).
+
+{{ range .issue.blocked_by }}- **{{ .identifier }}**{{ if .state }} ({{ .state }}){{ end }}
+{{ end }}
+{{ end }}


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Feat

**Intent:** Adds `examples/WORKFLOW.opencode.md`, a ready-to-copy sample workflow pairing the Jira tracker with the OpenCode CLI agent. Companion to the OpenCode adapter (#476) and published alongside the existing Claude Code, Copilot, and Codex examples.

**Related Issues:** Closes #479

### 🧭 Reviewer Guide

**Complexity:** Low

#### Entry Point

`examples/WORKFLOW.opencode.md` — the new sample file. Review the `opencode:` extension block (model, `dangerously_skip_permissions`, `disable_autocompact`) against what `internal/agent/opencode/command.go` reads from passthrough config, and confirm the hooks match the Jira + Codex pattern.

#### Sensitive Areas

- `cmd/sortie/sample_workflow_test.go`: extends four existing test functions and adds `TestSampleWorkflowOpenCodeExtension` to validate the `opencode:` extension block fields, `agent.kind`, and `tracker.kind` at load time.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes
- **Migrations/State:** No migrations or state changes