### PR TITLE
fix(orchestrator): rebuild handoff-stage pending reactions on startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   exit-time claim state and the handoff path; blocked soft stops remain
   ineligible and existing review-reaction idempotency is preserved.
   ([#506](https://github.com/sortie-ai/sortie/issues/506))
+- Orchestrator: handoff-stage pending review and CI reactions are now
+  reconstructed on startup. `state.PendingReactions` is a runtime-only
+  map, so a restart after a successful handoff previously left the
+  issue with no pending review entry — the tracker issue was no longer
+  active, the dispatch loop did not rediscover it, and human review
+  comments on agent-created PRs went unobserved until an operator
+  manually re-engaged the issue. Startup now rebuilds eligible review
+  and CI pending entries from `run_history`, tracker state, and
+  `.sortie/scm.json`, bounded to the most recent 200 unique issues
+  completed within the last 30 days and gated by a single batched
+  `FetchIssueStatesByIDs` call. Stale candidates age out via a new
+  optional `pushed_at` field in `.sortie/scm.json` (falling back to
+  `run_history.completed_at` when absent), and existing
+  `reaction_fingerprints` continue to suppress duplicate review-fix
+  dispatches.
+  ([#507](https://github.com/sortie-ai/sortie/issues/507))
 
 ## [1.9.0] - 2026-04-26
 

--- a/cmd/sortie/main.go
+++ b/cmd/sortie/main.go
@@ -283,36 +283,34 @@ func run(ctx context.Context, args []string, stdout io.Writer, stderr io.Writer)
 		)
 	}
 
-	recoveryNow := time.Now().UTC()
-	recoveryLookback := orchestrator.PendingReactionRecoveryLookback
-	recoveryCutoff := recoveryNow.Add(-recoveryLookback)
-	recoveryRuns, err := store.LoadLatestSuccessfulRunsForReactionRecovery(ctx, recoveryCutoff, orchestrator.PendingReactionRecoveryMaxCandidates)
-	if err != nil {
-		br.logger.Warn("failed to load pending reaction recovery candidates",
-			slog.Any("error", err),
-		)
-		recoveryRuns = []persistence.RunHistory{}
+	recoveryEnabled := br.cfg.Tracker.HandoffState != "" && (ciProvider != nil || scmAdapter != nil)
+	recoveryOutcome := orchestrator.PendingReactionRecoveryResult{}
+	var recoveryErr error
+	if recoveryEnabled {
+		recoveryNow := time.Now().UTC()
+		recoveryLookback := orchestrator.PendingReactionRecoveryLookback
+		recoveryCutoff := recoveryNow.Add(-recoveryLookback)
+		var recoveryRuns []persistence.RunHistory
+		recoveryRuns, recoveryErr = store.LoadLatestSuccessfulRunsForReactionRecovery(ctx, recoveryCutoff, orchestrator.PendingReactionRecoveryMaxCandidates)
+		if recoveryErr == nil {
+			recoveryOutcome, recoveryErr = orchestrator.RecoverPendingReactions(ctx, state, recoveryRuns, orchestrator.PendingReactionRecoveryParams{
+				WorkspaceRoot:    br.cfg.Workspace.Root,
+				TrackerAdapter:   br.trackerAdapter,
+				HandoffState:     br.cfg.Tracker.HandoffState,
+				TerminalStates:   br.cfg.Tracker.TerminalStates,
+				CIProvider:       ciProvider,
+				SCMAdapter:       scmAdapter,
+				RecoveryLookback: recoveryLookback,
+				MaxCandidates:    orchestrator.PendingReactionRecoveryMaxCandidates,
+				NowFunc: func() time.Time {
+					return recoveryNow
+				},
+				Logger: br.logger,
+			})
+		}
 	}
-	recoveryOutcome, err := orchestrator.RecoverPendingReactions(ctx, state, recoveryRuns, orchestrator.PendingReactionRecoveryParams{
-		WorkspaceRoot:    br.cfg.Workspace.Root,
-		TrackerAdapter:   br.trackerAdapter,
-		HandoffState:     br.cfg.Tracker.HandoffState,
-		TerminalStates:   br.cfg.Tracker.TerminalStates,
-		CIProvider:       ciProvider,
-		SCMAdapter:       scmAdapter,
-		RecoveryLookback: recoveryLookback,
-		MaxCandidates:    orchestrator.PendingReactionRecoveryMaxCandidates,
-		NowFunc: func() time.Time {
-			return recoveryNow
-		},
-		Logger: br.logger,
-	})
-	if err != nil {
-		br.logger.Warn("pending reaction recovery failed",
-			slog.Any("error", err),
-		)
-	}
-	br.logger.Info("pending reaction recovery completed",
+	recoveryLogAttrs := []any{
+		slog.Bool("enabled", recoveryEnabled),
 		slog.Int("candidates", recoveryOutcome.Candidates),
 		slog.Int("cap_skipped", recoveryOutcome.CapSkipped),
 		slog.Int("state_checked", recoveryOutcome.StateChecked),
@@ -320,7 +318,14 @@ func run(ctx context.Context, args []string, stdout io.Writer, stderr io.Writer)
 		slog.Int("ci_recovered", recoveryOutcome.CIRecovered),
 		slog.Int("stale_skipped", recoveryOutcome.StaleSkipped),
 		slog.Int("skipped", recoveryOutcome.Skipped),
-	)
+	}
+	if recoveryErr != nil {
+		recoveryLogAttrs = append(recoveryLogAttrs, slog.Bool("success", false), slog.Any("error", recoveryErr))
+		br.logger.Warn("pending reaction recovery failed", recoveryLogAttrs...)
+	} else {
+		recoveryLogAttrs = append(recoveryLogAttrs, slog.Bool("success", true))
+		br.logger.Info("pending reaction recovery completed", recoveryLogAttrs...)
+	}
 
 	// Attempt to bind the HTTP server before constructing metrics so
 	// that graceful degradation on an implicit default port conflict

--- a/cmd/sortie/main.go
+++ b/cmd/sortie/main.go
@@ -283,6 +283,45 @@ func run(ctx context.Context, args []string, stdout io.Writer, stderr io.Writer)
 		)
 	}
 
+	recoveryNow := time.Now().UTC()
+	recoveryLookback := orchestrator.PendingReactionRecoveryLookback
+	recoveryCutoff := recoveryNow.Add(-recoveryLookback)
+	recoveryRuns, err := store.LoadLatestSuccessfulRunsForReactionRecovery(ctx, recoveryCutoff, orchestrator.PendingReactionRecoveryMaxCandidates)
+	if err != nil {
+		br.logger.Warn("failed to load pending reaction recovery candidates",
+			slog.Any("error", err),
+		)
+		recoveryRuns = []persistence.RunHistory{}
+	}
+	recoveryOutcome, err := orchestrator.RecoverPendingReactions(ctx, state, recoveryRuns, orchestrator.PendingReactionRecoveryParams{
+		WorkspaceRoot:    br.cfg.Workspace.Root,
+		TrackerAdapter:   br.trackerAdapter,
+		HandoffState:     br.cfg.Tracker.HandoffState,
+		TerminalStates:   br.cfg.Tracker.TerminalStates,
+		CIProvider:       ciProvider,
+		SCMAdapter:       scmAdapter,
+		RecoveryLookback: recoveryLookback,
+		MaxCandidates:    orchestrator.PendingReactionRecoveryMaxCandidates,
+		NowFunc: func() time.Time {
+			return recoveryNow
+		},
+		Logger: br.logger,
+	})
+	if err != nil {
+		br.logger.Warn("pending reaction recovery failed",
+			slog.Any("error", err),
+		)
+	}
+	br.logger.Info("pending reaction recovery completed",
+		slog.Int("candidates", recoveryOutcome.Candidates),
+		slog.Int("cap_skipped", recoveryOutcome.CapSkipped),
+		slog.Int("state_checked", recoveryOutcome.StateChecked),
+		slog.Int("review_recovered", recoveryOutcome.ReviewRecovered),
+		slog.Int("ci_recovered", recoveryOutcome.CIRecovered),
+		slog.Int("stale_skipped", recoveryOutcome.StaleSkipped),
+		slog.Int("skipped", recoveryOutcome.Skipped),
+	)
+
 	// Attempt to bind the HTTP server before constructing metrics so
 	// that graceful degradation on an implicit default port conflict
 	// skips Prometheus collector creation entirely.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -340,8 +340,9 @@ Fields:
   dispatched per issue and reaction kind; reset when the issue leaves the running/retry maps;
   runtime-only, not persisted)
 - `pending_reactions` (map `issue_id:kind -> PendingReaction`; populated by worker exit on normal
-  exits with SCM metadata when a CI status provider or SCM adapter is configured; consumed by
-  per-kind reconcile functions during the reconcile tick — `reconcile_ci_status` for kind `ci`,
+  exits with SCM metadata when a CI status provider or SCM adapter is configured, and reconstructed
+  at startup by `RecoverPendingReactions` for eligible handoff-stage runs; consumed by per-kind
+  reconcile functions during the reconcile tick — `reconcile_ci_status` for kind `ci`,
   `reconcile_review_comments` for kind `review`; runtime-only, not persisted)
 
 ### 4.2 Stable Identifiers and Normalization Rules
@@ -1065,6 +1066,9 @@ Distinct terminal reasons are important because retry logic and logs differ.
 - Restart recovery uses persisted state from SQLite for retry queues and session metadata,
   supplemented by tracker polling for current issue states and filesystem inspection for workspace
   existence.
+- Startup pending reaction recovery uses `run_history`, tracker state, and `.sortie/scm.json` to
+  reconstruct runtime `pending_reactions` for recent handoff-stage runs before the first poll tick.
+  The scan is bounded by `PendingReactionRecoveryLookback` and a fixed candidate cap.
 - Startup terminal cleanup removes stale workspaces for issues already in terminal states.
 
 #### Startup Recovery Sequence (SQLite)
@@ -1073,8 +1077,10 @@ Distinct terminal reasons are important because retry logic and logs differ.
 2. Load persisted retry entries from SQLite.
 3. Reconstruct retry timers from persisted `due_at` timestamps.
 4. Query tracker for terminal-state issues and clean corresponding workspaces.
-5. Query tracker for active issues and reconcile with persisted state.
-6. Begin normal polling loop.
+5. Construct reaction providers and call `RecoverPendingReactions` to restore eligible CI and
+  review pending entries for handoff-stage issues.
+6. Query tracker for active issues and reconcile with persisted state.
+7. Begin normal polling loop.
 
 ## 8. Polling, Scheduling, and Reconciliation
 
@@ -1348,9 +1354,9 @@ feedback, review comment routing, and other features can reuse.
   absent, the file is treated as missing and CI status queries are skipped.
 - `sha` (string, optional): the commit SHA at push time. When present, the orchestrator passes
   this to `CIStatusProvider.FetchCIStatus` instead of the branch name for deterministic results.
-- `pushed_at` (string, optional): ISO-8601 timestamp of the push. This field is reserved metadata
-  for producers and future consumers of `.sortie/scm.json`. The orchestrator does not use it for
-  CI gating today.
+- `pushed_at` (string, optional): ISO-8601 timestamp of the push. Startup pending reaction recovery
+  uses this timestamp to skip stale SCM activity. When absent, recovery falls back to
+  `run_history.completed_at`.
 - `pr_number` (integer, optional): the pull request number associated with this branch. Zero or
   absent when no PR has been created. Written by the agent or post-push hook. When positive and
   `owner` and `repo` are non-empty, the orchestrator creates a pending review comment reaction
@@ -2169,7 +2175,12 @@ Review comment reconciliation only processes PRs created by Sortie:
 1. `SCMMetadata.pr_number > 0` — only workspaces where the agent created a PR have this field.
    Since `.sortie/scm.json` is written by the agent inside a Sortie-managed workspace, this is
    inherently scoped.
-2. Claimed check: only issues in `claimed` get review polling. Released issues are not polled.
+2. Runtime scope: review polling processes entries in `pending_reactions`. Normal worker exit can
+  create those entries while the issue is still claimed, and startup recovery can recreate them for
+  recent handoff-stage issues after the claim has been released.
+
+Future reaction kinds whose lifecycle outlives active tracker states MUST define restart recovery
+and kind-specific `.sortie/scm.json` metadata validation before they can be polled after handoff.
 
 ## 12. Prompt Construction and Context Assembly
 

--- a/docs/workflow-reference.md
+++ b/docs/workflow-reference.md
@@ -579,6 +579,12 @@ and non-empty. Agent-created PRs MUST write `pr_number`, `owner`, and `repo` to
 (written by the agent), not from the tracker project configuration. This decouples SCM
 repository identity from the tracker project identifier.
 
+**Recovery timestamp:** Hooks that push commits or create PRs SHOULD write `pushed_at` to
+`.sortie/scm.json` when review or CI reaction recovery is enabled. Startup recovery uses
+`pushed_at` to decide whether handoff-stage reaction work is fresh. If `pushed_at` is absent,
+recovery falls back to `run_history.completed_at`, so long-lived PRs can age out based on the
+agent completion time instead of the latest push time.
+
 **Debounce behavior:** When review comments are detected but the newest comment timestamp
 is within the debounce window, dispatch is deferred. This ensures the reviewer has finished
 their full review before the agent starts addressing comments.

--- a/internal/orchestrator/recovery.go
+++ b/internal/orchestrator/recovery.go
@@ -1,6 +1,16 @@
 package orchestrator
 
-import "github.com/sortie-ai/sortie/internal/persistence"
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/sortie-ai/sortie/internal/domain"
+	"github.com/sortie-ai/sortie/internal/logging"
+	"github.com/sortie-ai/sortie/internal/persistence"
+	"github.com/sortie-ai/sortie/internal/workspace"
+)
 
 // PopulateRetries loads persisted retry entries into state maps without
 // starting timers. Each entry is stored in [State.RetryAttempts] with
@@ -35,4 +45,289 @@ func PopulateRetries(state *State, entries []persistence.PendingRetry) {
 		}
 		state.Claimed[e.IssueID] = struct{}{}
 	}
+}
+
+// PendingReactionRecoveryLookback is the maximum age of a run_history row or
+// SCM activity timestamp considered eligible for pending reaction recovery on
+// startup.
+const PendingReactionRecoveryLookback = 30 * 24 * time.Hour
+
+// PendingReactionRecoveryMaxCandidates is the maximum number of unique issues
+// considered for pending reaction recovery in a single startup pass.
+const PendingReactionRecoveryMaxCandidates = 200
+
+// ReactionRecoveryRunStore is the persistence contract consumed by startup
+// wiring and orchestrator tests.
+type ReactionRecoveryRunStore interface {
+	LoadLatestSuccessfulRunsForReactionRecovery(ctx context.Context, completedAfter time.Time, limit int) ([]persistence.RunHistory, error)
+}
+
+// PendingReactionRecoveryParams holds all inputs for [RecoverPendingReactions].
+type PendingReactionRecoveryParams struct {
+	WorkspaceRoot    string
+	TrackerAdapter   domain.TrackerAdapter
+	HandoffState     string
+	TerminalStates   []string
+	CIProvider       domain.CIStatusProvider
+	SCMAdapter       domain.SCMAdapter
+	RecoveryLookback time.Duration
+	MaxCandidates    int
+	NowFunc          func() time.Time
+	Logger           *slog.Logger
+}
+
+// PendingReactionRecoveryResult reports outcome counts from a single
+// [RecoverPendingReactions] call.
+type PendingReactionRecoveryResult struct {
+	Candidates      int
+	CapSkipped      int
+	StateChecked    int
+	ReviewRecovered int
+	CIRecovered     int
+	StaleSkipped    int
+	Skipped         int
+}
+
+// RecoverPendingReactions reconstructs runtime pending reaction entries from
+// persisted run history, tracker state, and workspace SCM metadata. It must be
+// called before the orchestrator event loop starts.
+//
+// Recovery is best-effort: per-candidate invalid data is skipped, while a
+// tracker state fetch failure aborts recovery for this startup and returns a
+// zero result with the fetch error.
+func RecoverPendingReactions(ctx context.Context, state *State, runs []persistence.RunHistory, params PendingReactionRecoveryParams) (PendingReactionRecoveryResult, error) {
+	if params.HandoffState == "" || (params.SCMAdapter == nil && params.CIProvider == nil) {
+		return PendingReactionRecoveryResult{}, nil
+	}
+	if err := ctx.Err(); err != nil {
+		return PendingReactionRecoveryResult{}, err
+	}
+
+	log := params.Logger
+	if log == nil {
+		log = slog.Default()
+	}
+
+	now := time.Now().UTC()
+	if params.NowFunc != nil {
+		now = params.NowFunc().UTC()
+	}
+	lookback := params.RecoveryLookback
+	if lookback <= 0 {
+		lookback = PendingReactionRecoveryLookback
+	}
+	if lookback > PendingReactionRecoveryLookback {
+		lookback = PendingReactionRecoveryLookback
+	}
+	cutoff := now.Add(-lookback)
+
+	maxCandidates := params.MaxCandidates
+	if maxCandidates <= 0 {
+		maxCandidates = PendingReactionRecoveryMaxCandidates
+	}
+	if maxCandidates > PendingReactionRecoveryMaxCandidates {
+		maxCandidates = PendingReactionRecoveryMaxCandidates
+	}
+
+	outcome := PendingReactionRecoveryResult{Candidates: len(runs)}
+	eligibleRuns := filterReactionRecoveryRuns(state, runs, &outcome)
+	if len(eligibleRuns) > maxCandidates {
+		outcome.CapSkipped = len(eligibleRuns) - maxCandidates
+		eligibleRuns = eligibleRuns[:maxCandidates]
+	}
+
+	validRuns, issueIDs := validReactionRecoveryRuns(eligibleRuns, log, &outcome)
+	if len(validRuns) == 0 {
+		return outcome, nil
+	}
+
+	statesByID, err := params.TrackerAdapter.FetchIssueStatesByIDs(ctx, issueIDs)
+	if err != nil {
+		return PendingReactionRecoveryResult{}, err
+	}
+	outcome.StateChecked = len(issueIDs)
+
+	terminalSet := stateSet(params.TerminalStates)
+	if state.PendingReactions == nil {
+		state.PendingReactions = make(map[string]*PendingReaction)
+	}
+
+	for _, run := range validRuns {
+		if err := ctx.Err(); err != nil {
+			return PendingReactionRecoveryResult{}, err
+		}
+
+		stateName, ok := statesByID[run.IssueID]
+		if !ok {
+			outcome.Skipped++
+			continue
+		}
+		if _, terminal := terminalSet[strings.ToLower(stateName)]; terminal {
+			outcome.Skipped++
+			continue
+		}
+		if !strings.EqualFold(stateName, params.HandoffState) {
+			outcome.Skipped++
+			continue
+		}
+
+		pathResult, err := workspace.ComputePath(params.WorkspaceRoot, run.Identifier)
+		if err != nil {
+			warnReactionRecoverySkip(log, run, "workspace path", slog.Any("error", err))
+			outcome.Skipped++
+			continue
+		}
+
+		meta := workspace.ReadSCMMetadata(pathResult.Path, log)
+		if meta == (domain.SCMMetadata{}) {
+			outcome.Skipped++
+			continue
+		}
+		if !freshReactionRecoveryActivity(run, meta, cutoff) {
+			outcome.StaleSkipped++
+			continue
+		}
+
+		if recoverPendingReactionKinds(state, run, meta, now, params, &outcome) == 0 {
+			outcome.Skipped++
+		}
+	}
+
+	return outcome, nil
+}
+
+func filterReactionRecoveryRuns(state *State, runs []persistence.RunHistory, outcome *PendingReactionRecoveryResult) []persistence.RunHistory {
+	eligibleRuns := make([]persistence.RunHistory, 0, len(runs))
+	for _, run := range runs {
+		if _, exists := state.Running[run.IssueID]; exists {
+			outcome.Skipped++
+			continue
+		}
+		if _, exists := state.RetryAttempts[run.IssueID]; exists {
+			outcome.Skipped++
+			continue
+		}
+		if _, exists := state.Claimed[run.IssueID]; exists {
+			outcome.Skipped++
+			continue
+		}
+		eligibleRuns = append(eligibleRuns, run)
+	}
+	return eligibleRuns
+}
+
+func validReactionRecoveryRuns(runs []persistence.RunHistory, log *slog.Logger, outcome *PendingReactionRecoveryResult) ([]persistence.RunHistory, []string) {
+	validRuns := make([]persistence.RunHistory, 0, len(runs))
+	issueIDs := make([]string, 0, len(runs))
+	seen := make(map[string]struct{}, len(runs))
+
+	for _, run := range runs {
+		switch {
+		case run.IssueID == "":
+			warnReactionRecoverySkip(log, run, "missing issue id")
+			outcome.Skipped++
+			continue
+		case run.Identifier == "":
+			warnReactionRecoverySkip(log, run, "missing identifier")
+			outcome.Skipped++
+			continue
+		case run.Workspace == "":
+			warnReactionRecoverySkip(log, run, "missing workspace")
+			outcome.Skipped++
+			continue
+		case run.Attempt <= 0:
+			warnReactionRecoverySkip(log, run, "invalid attempt", slog.Int("attempt", run.Attempt))
+			outcome.Skipped++
+			continue
+		}
+
+		validRuns = append(validRuns, run)
+		if _, exists := seen[run.IssueID]; exists {
+			continue
+		}
+		seen[run.IssueID] = struct{}{}
+		issueIDs = append(issueIDs, run.IssueID)
+	}
+
+	return validRuns, issueIDs
+}
+
+func recoverPendingReactionKinds(
+	state *State,
+	run persistence.RunHistory,
+	meta domain.SCMMetadata,
+	now time.Time,
+	params PendingReactionRecoveryParams,
+	outcome *PendingReactionRecoveryResult,
+) int {
+	added := 0
+
+	if params.SCMAdapter != nil && meta.PRNumber > 0 && meta.Owner != "" && meta.Repo != "" && meta.Branch != "" {
+		key := ReactionKey(run.IssueID, ReactionKindReview)
+		if _, exists := state.PendingReactions[key]; !exists {
+			state.PendingReactions[key] = &PendingReaction{
+				IssueID:    run.IssueID,
+				Identifier: run.Identifier,
+				DisplayID:  run.DisplayID,
+				Attempt:    run.Attempt,
+				Kind:       ReactionKindReview,
+				CreatedAt:  now,
+				KindData: &ReviewReactionData{
+					PRNumber: meta.PRNumber,
+					Owner:    meta.Owner,
+					Repo:     meta.Repo,
+					Branch:   meta.Branch,
+					SHA:      meta.SHA,
+				},
+			}
+			outcome.ReviewRecovered++
+			added++
+		}
+	}
+
+	if params.CIProvider != nil && meta.Branch != "" {
+		key := ReactionKey(run.IssueID, ReactionKindCI)
+		if _, exists := state.PendingReactions[key]; !exists {
+			state.PendingReactions[key] = &PendingReaction{
+				IssueID:    run.IssueID,
+				Identifier: run.Identifier,
+				DisplayID:  run.DisplayID,
+				Attempt:    run.Attempt,
+				Kind:       ReactionKindCI,
+				CreatedAt:  now,
+				KindData: &CIReactionData{
+					Branch: meta.Branch,
+					SHA:    meta.SHA,
+				},
+			}
+			outcome.CIRecovered++
+			added++
+		}
+	}
+
+	return added
+}
+
+func freshReactionRecoveryActivity(run persistence.RunHistory, meta domain.SCMMetadata, cutoff time.Time) bool {
+	activity := meta.PushedAt
+	if activity == "" {
+		activity = run.CompletedAt
+	}
+	parsed, err := time.Parse(time.RFC3339, activity)
+	if err != nil {
+		return false
+	}
+	return !parsed.UTC().Before(cutoff)
+}
+
+func warnReactionRecoverySkip(log *slog.Logger, run persistence.RunHistory, reason string, attrs ...slog.Attr) {
+	entryLog := logging.WithIssue(log, run.IssueID, run.Identifier)
+	logAttrs := []any{
+		slog.Int64("run_history_id", run.ID),
+		slog.String("reason", reason),
+	}
+	for _, attr := range attrs {
+		logAttrs = append(logAttrs, attr)
+	}
+	entryLog.Warn("skipped pending reaction recovery candidate", logAttrs...)
 }

--- a/internal/orchestrator/recovery.go
+++ b/internal/orchestrator/recovery.go
@@ -2,6 +2,7 @@ package orchestrator
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"strings"
 	"time"
@@ -143,7 +144,7 @@ func RecoverPendingReactions(ctx context.Context, state *State, runs []persisten
 
 	statesByID, err := params.TrackerAdapter.FetchIssueStatesByIDs(ctx, issueIDs)
 	if err != nil {
-		return PendingReactionRecoveryResult{}, err
+		return PendingReactionRecoveryResult{}, fmt.Errorf("fetch pending reaction recovery issue states: %w", err)
 	}
 	outcome.StateChecked = len(issueIDs)
 

--- a/internal/orchestrator/recovery_test.go
+++ b/internal/orchestrator/recovery_test.go
@@ -1,9 +1,16 @@
 package orchestrator
 
 import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
+	"github.com/sortie-ai/sortie/internal/domain"
 	"github.com/sortie-ai/sortie/internal/persistence"
 )
 
@@ -400,5 +407,752 @@ func TestPopulateRetries_SessionID_Nil(t *testing.T) {
 	}
 	if got.SessionID != "" {
 		t.Errorf("PopulateRetries_SessionID_Nil: SessionID = %q, want empty", got.SessionID)
+	}
+}
+
+// --- RecoverPendingReactions tests ---
+
+// recoveryNow is a fixed instant used as the NowFunc reference for recovery tests.
+var recoveryNow = time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+
+// writeRecoverySCM writes meta as .sortie/scm.json inside <wsRoot>/<key>.
+// The directory is created if absent. key is the sanitized identifier (e.g. "PROJ-1").
+func writeRecoverySCM(t *testing.T, wsRoot, key string, meta domain.SCMMetadata) {
+	t.Helper()
+	dir := filepath.Join(wsRoot, key, ".sortie")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("writeSCMMetadata MkdirAll: %v", err)
+	}
+	data, err := json.Marshal(meta)
+	if err != nil {
+		t.Fatalf("writeSCMMetadata Marshal: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "scm.json"), data, 0o644); err != nil {
+		t.Fatalf("writeSCMMetadata WriteFile: %v", err)
+	}
+}
+
+// freshSCMTime returns an RFC3339 timestamp that is within the 30-day lookback.
+func freshSCMTime(daysAgo int) string {
+	return recoveryNow.Add(-time.Duration(daysAgo) * 24 * time.Hour).UTC().Format(time.RFC3339)
+}
+
+// freshRun builds a persistence.RunHistory for recovery tests.
+func freshRun(issueID, identifier, displayID string, attempt int) persistence.RunHistory {
+	return persistence.RunHistory{
+		IssueID:      issueID,
+		Identifier:   identifier,
+		DisplayID:    displayID,
+		Attempt:      attempt,
+		AgentAdapter: "mock",
+		Workspace:    "/ws/" + identifier,
+		StartedAt:    freshSCMTime(2),
+		CompletedAt:  freshSCMTime(2),
+		Status:       "succeeded",
+	}
+}
+
+// recoveryTrackerStub satisfies domain.TrackerAdapter; returns a configurable state map.
+type recoveryTrackerStub struct {
+	states     map[string]string
+	err        error
+	fetchedIDs []string
+}
+
+var _ domain.TrackerAdapter = (*recoveryTrackerStub)(nil)
+
+func (s *recoveryTrackerStub) FetchIssuesByStates(_ context.Context, _ []string) ([]domain.Issue, error) {
+	return nil, nil
+}
+func (s *recoveryTrackerStub) FetchCandidateIssues(_ context.Context) ([]domain.Issue, error) {
+	return nil, nil
+}
+func (s *recoveryTrackerStub) FetchIssueByID(_ context.Context, _ string) (domain.Issue, error) {
+	return domain.Issue{}, nil
+}
+func (s *recoveryTrackerStub) FetchIssueStatesByIDs(_ context.Context, ids []string) (map[string]string, error) {
+	s.fetchedIDs = append(s.fetchedIDs, ids...)
+	if s.err != nil {
+		return nil, s.err
+	}
+	result := make(map[string]string, len(ids))
+	for _, id := range ids {
+		if st, ok := s.states[id]; ok {
+			result[id] = st
+		}
+	}
+	return result, nil
+}
+func (s *recoveryTrackerStub) FetchIssueStatesByIdentifiers(_ context.Context, _ []string) (map[string]string, error) {
+	return nil, nil
+}
+func (s *recoveryTrackerStub) FetchIssueComments(_ context.Context, _ string) ([]domain.Comment, error) {
+	return nil, nil
+}
+func (s *recoveryTrackerStub) TransitionIssue(_ context.Context, _ string, _ string) error {
+	return nil
+}
+func (s *recoveryTrackerStub) CommentIssue(_ context.Context, _ string, _ string) error {
+	return nil
+}
+func (s *recoveryTrackerStub) AddLabel(_ context.Context, _ string, _ string) error {
+	return nil
+}
+
+// panicSCMAdapter panics if any method is called. Used to assert FR-7.
+type panicSCMAdapter struct{}
+
+var _ domain.SCMAdapter = (*panicSCMAdapter)(nil)
+
+func (p *panicSCMAdapter) FetchPendingReviews(_ context.Context, _ int, _, _ string) ([]domain.ReviewComment, error) {
+	panic("FetchPendingReviews must not be called during RecoverPendingReactions")
+}
+
+// panicCIProvider panics if FetchCIStatus is called. Used to assert FR-7.
+type panicCIProvider struct{}
+
+var _ domain.CIStatusProvider = (*panicCIProvider)(nil)
+
+func (p *panicCIProvider) FetchCIStatus(_ context.Context, _ string) (domain.CIResult, error) {
+	panic("FetchCIStatus must not be called during RecoverPendingReactions")
+}
+
+// stubSCMForRecovery is a non-nil SCMAdapter that satisfies the interface without panicking,
+// used when a non-nil adapter is required for the recovery guard but the fetch must not fire.
+type stubSCMForRecovery struct{}
+
+var _ domain.SCMAdapter = (*stubSCMForRecovery)(nil)
+
+func (s *stubSCMForRecovery) FetchPendingReviews(_ context.Context, _ int, _, _ string) ([]domain.ReviewComment, error) {
+	return nil, nil
+}
+
+// stubCIForRecovery is a non-nil CIStatusProvider for recovery guard, never called during recovery.
+type stubCIForRecovery struct{}
+
+var _ domain.CIStatusProvider = (*stubCIForRecovery)(nil)
+
+func (s *stubCIForRecovery) FetchCIStatus(_ context.Context, _ string) (domain.CIResult, error) {
+	return domain.CIResult{}, nil
+}
+
+// defaultRecoveryParams builds PendingReactionRecoveryParams with sensible defaults for tests.
+func defaultRecoveryParams(wsRoot string, tracker domain.TrackerAdapter) PendingReactionRecoveryParams {
+	return PendingReactionRecoveryParams{
+		WorkspaceRoot:    wsRoot,
+		TrackerAdapter:   tracker,
+		HandoffState:     "In Review",
+		TerminalStates:   []string{"Done", "Closed"},
+		SCMAdapter:       &stubSCMForRecovery{},
+		CIProvider:       &stubCIForRecovery{},
+		RecoveryLookback: PendingReactionRecoveryLookback,
+		MaxCandidates:    PendingReactionRecoveryMaxCandidates,
+		NowFunc:          func() time.Time { return recoveryNow },
+		Logger:           discardLogger(),
+	}
+}
+
+func TestRecoverPendingReactions_RecreatesReviewAfterRestart(t *testing.T) {
+	t.Parallel()
+
+	wsRoot := t.TempDir()
+	writeRecoverySCM(t, wsRoot, "PROJ-1", domain.SCMMetadata{
+		Branch:   "feature/fix",
+		SHA:      "abc123",
+		PushedAt: freshSCMTime(1),
+		PRNumber: 42,
+		Owner:    "owner",
+		Repo:     "repo",
+	})
+
+	tracker := &recoveryTrackerStub{states: map[string]string{"ISS-1": "In Review"}}
+	state := NewState(5000, 4, nil, AgentTotals{})
+	run := freshRun("ISS-1", "PROJ-1", "owner/repo#42", 2)
+	params := defaultRecoveryParams(wsRoot, tracker)
+
+	result, err := RecoverPendingReactions(context.Background(), state, []persistence.RunHistory{run}, params)
+	if err != nil {
+		t.Fatalf("RecoverPendingReactions: %v", err)
+	}
+	if result.ReviewRecovered != 1 {
+		t.Errorf("ReviewRecovered = %d, want 1", result.ReviewRecovered)
+	}
+
+	rkey := ReactionKey("ISS-1", ReactionKindReview)
+	pr, ok := state.PendingReactions[rkey]
+	if !ok {
+		t.Fatalf("PendingReactions[%q] missing, want present", rkey)
+	}
+	if pr.IssueID != "ISS-1" {
+		t.Errorf("PendingReaction.IssueID = %q, want %q", pr.IssueID, "ISS-1")
+	}
+	if pr.Attempt != 2 {
+		t.Errorf("PendingReaction.Attempt = %d, want 2", pr.Attempt)
+	}
+	if pr.DisplayID != "owner/repo#42" {
+		t.Errorf("PendingReaction.DisplayID = %q, want %q", pr.DisplayID, "owner/repo#42")
+	}
+	rd, ok := pr.KindData.(*ReviewReactionData)
+	if !ok {
+		t.Fatalf("KindData type = %T, want *ReviewReactionData", pr.KindData)
+	}
+	if rd.PRNumber != 42 {
+		t.Errorf("ReviewReactionData.PRNumber = %d, want 42", rd.PRNumber)
+	}
+	if rd.Owner != "owner" {
+		t.Errorf("ReviewReactionData.Owner = %q, want %q", rd.Owner, "owner")
+	}
+	if rd.Repo != "repo" {
+		t.Errorf("ReviewReactionData.Repo = %q, want %q", rd.Repo, "repo")
+	}
+	if rd.Branch != "feature/fix" {
+		t.Errorf("ReviewReactionData.Branch = %q, want %q", rd.Branch, "feature/fix")
+	}
+	if rd.SHA != "abc123" {
+		t.Errorf("ReviewReactionData.SHA = %q, want %q", rd.SHA, "abc123")
+	}
+	// FR-5: issue must not be claimed.
+	if _, claimed := state.Claimed["ISS-1"]; claimed {
+		t.Error("ISS-1 found in state.Claimed after recovery, want not claimed")
+	}
+}
+
+func TestRecoverPendingReactions_RecreatesCIAfterRestart(t *testing.T) {
+	t.Parallel()
+
+	wsRoot := t.TempDir()
+	writeRecoverySCM(t, wsRoot, "PROJ-2", domain.SCMMetadata{
+		Branch:   "feature/ci-fix",
+		SHA:      "deadbeef",
+		PushedAt: freshSCMTime(1),
+	})
+
+	tracker := &recoveryTrackerStub{states: map[string]string{"ISS-2": "In Review"}}
+	state := NewState(5000, 4, nil, AgentTotals{})
+	run := freshRun("ISS-2", "PROJ-2", "", 1)
+	params := defaultRecoveryParams(wsRoot, tracker)
+
+	result, err := RecoverPendingReactions(context.Background(), state, []persistence.RunHistory{run}, params)
+	if err != nil {
+		t.Fatalf("RecoverPendingReactions: %v", err)
+	}
+	if result.CIRecovered != 1 {
+		t.Errorf("CIRecovered = %d, want 1", result.CIRecovered)
+	}
+
+	rkey := ReactionKey("ISS-2", ReactionKindCI)
+	pr, ok := state.PendingReactions[rkey]
+	if !ok {
+		t.Fatalf("PendingReactions[%q] missing, want present", rkey)
+	}
+	ci, ok := pr.KindData.(*CIReactionData)
+	if !ok {
+		t.Fatalf("KindData type = %T, want *CIReactionData", pr.KindData)
+	}
+	if ci.Branch != "feature/ci-fix" {
+		t.Errorf("CIReactionData.Branch = %q, want %q", ci.Branch, "feature/ci-fix")
+	}
+	if ci.SHA != "deadbeef" {
+		t.Errorf("CIReactionData.SHA = %q, want %q", ci.SHA, "deadbeef")
+	}
+	// FR-5: issue must not be claimed.
+	if _, claimed := state.Claimed["ISS-2"]; claimed {
+		t.Error("ISS-2 found in state.Claimed after CI recovery, want not claimed")
+	}
+}
+
+func TestRecoverPendingReactions_SkipsWhenHandoffStateEmpty(t *testing.T) {
+	t.Parallel()
+
+	wsRoot := t.TempDir()
+	tracker := &recoveryTrackerStub{states: map[string]string{"ISS-3": "In Review"}}
+	state := NewState(5000, 4, nil, AgentTotals{})
+	run := freshRun("ISS-3", "PROJ-3", "", 1)
+	params := defaultRecoveryParams(wsRoot, tracker)
+	params.HandoffState = ""
+
+	result, err := RecoverPendingReactions(context.Background(), state, []persistence.RunHistory{run}, params)
+	if err != nil {
+		t.Fatalf("RecoverPendingReactions: %v", err)
+	}
+	if result.ReviewRecovered != 0 || result.CIRecovered != 0 {
+		t.Errorf("recovered = review:%d ci:%d, want 0/0 when HandoffState is empty",
+			result.ReviewRecovered, result.CIRecovered)
+	}
+	if len(state.PendingReactions) != 0 {
+		t.Errorf("PendingReactions len = %d, want 0", len(state.PendingReactions))
+	}
+	if len(tracker.fetchedIDs) != 0 {
+		t.Error("FetchIssueStatesByIDs was called with empty HandoffState, want no call")
+	}
+}
+
+func TestRecoverPendingReactions_SkipsWhenProvidersNil(t *testing.T) {
+	t.Parallel()
+
+	wsRoot := t.TempDir()
+	tracker := &recoveryTrackerStub{states: map[string]string{"ISS-4": "In Review"}}
+	state := NewState(5000, 4, nil, AgentTotals{})
+	run := freshRun("ISS-4", "PROJ-4", "", 1)
+	params := defaultRecoveryParams(wsRoot, tracker)
+	params.SCMAdapter = nil
+	params.CIProvider = nil
+
+	result, err := RecoverPendingReactions(context.Background(), state, []persistence.RunHistory{run}, params)
+	if err != nil {
+		t.Fatalf("RecoverPendingReactions: %v", err)
+	}
+	if result.ReviewRecovered != 0 || result.CIRecovered != 0 {
+		t.Errorf("recovered = review:%d ci:%d, want 0/0 when both providers are nil",
+			result.ReviewRecovered, result.CIRecovered)
+	}
+	if len(tracker.fetchedIDs) != 0 {
+		t.Error("FetchIssueStatesByIDs was called with nil providers, want no call")
+	}
+}
+
+func TestRecoverPendingReactions_SkipsNonHandoffState(t *testing.T) {
+	t.Parallel()
+
+	wsRoot := t.TempDir()
+	writeRecoverySCM(t, wsRoot, "PROJ-5", domain.SCMMetadata{
+		Branch:   "feature/x",
+		PushedAt: freshSCMTime(1),
+		PRNumber: 10,
+		Owner:    "o",
+		Repo:     "r",
+	})
+
+	// Tracker returns "In Progress" — not the handoff state "In Review".
+	tracker := &recoveryTrackerStub{states: map[string]string{"ISS-5": "In Progress"}}
+	state := NewState(5000, 4, nil, AgentTotals{})
+	run := freshRun("ISS-5", "PROJ-5", "", 1)
+	params := defaultRecoveryParams(wsRoot, tracker)
+
+	result, err := RecoverPendingReactions(context.Background(), state, []persistence.RunHistory{run}, params)
+	if err != nil {
+		t.Fatalf("RecoverPendingReactions: %v", err)
+	}
+	if result.ReviewRecovered != 0 {
+		t.Errorf("ReviewRecovered = %d, want 0 for non-handoff state", result.ReviewRecovered)
+	}
+	if len(state.PendingReactions) != 0 {
+		t.Errorf("PendingReactions len = %d, want 0", len(state.PendingReactions))
+	}
+}
+
+func TestRecoverPendingReactions_SkipsTerminalState(t *testing.T) {
+	t.Parallel()
+
+	wsRoot := t.TempDir()
+	writeRecoverySCM(t, wsRoot, "PROJ-6", domain.SCMMetadata{
+		Branch:   "feature/done",
+		PushedAt: freshSCMTime(1),
+		PRNumber: 99,
+		Owner:    "o",
+		Repo:     "r",
+	})
+
+	// Tracker returns "Done" — a configured terminal state.
+	tracker := &recoveryTrackerStub{states: map[string]string{"ISS-6": "Done"}}
+	state := NewState(5000, 4, nil, AgentTotals{})
+	run := freshRun("ISS-6", "PROJ-6", "", 1)
+	params := defaultRecoveryParams(wsRoot, tracker)
+
+	result, err := RecoverPendingReactions(context.Background(), state, []persistence.RunHistory{run}, params)
+	if err != nil {
+		t.Fatalf("RecoverPendingReactions: %v", err)
+	}
+	if result.ReviewRecovered != 0 {
+		t.Errorf("ReviewRecovered = %d, want 0 for terminal state", result.ReviewRecovered)
+	}
+	if len(state.PendingReactions) != 0 {
+		t.Errorf("PendingReactions len = %d, want 0", len(state.PendingReactions))
+	}
+}
+
+func TestRecoverPendingReactions_SkipsClaimedOrRetryingIssue(t *testing.T) {
+	t.Parallel()
+
+	wsRoot := t.TempDir()
+	for _, id := range []string{"PROJ-7", "PROJ-8", "PROJ-9"} {
+		writeRecoverySCM(t, wsRoot, id, domain.SCMMetadata{
+			Branch: "feature/x", PushedAt: freshSCMTime(1), PRNumber: 1, Owner: "o", Repo: "r",
+		})
+	}
+
+	tracker := &recoveryTrackerStub{states: map[string]string{
+		"ISS-CLAIMED": "In Review",
+		"ISS-RETRY":   "In Review",
+		"ISS-RUNNING": "In Review",
+	}}
+	state := NewState(5000, 4, nil, AgentTotals{})
+	// Seed claimed, retry, and running.
+	state.Claimed["ISS-CLAIMED"] = struct{}{}
+	state.RetryAttempts["ISS-RETRY"] = &RetryEntry{IssueID: "ISS-RETRY", Identifier: "PROJ-8"}
+	state.Claimed["ISS-RETRY"] = struct{}{}
+	state.Running["ISS-RUNNING"] = &RunningEntry{}
+
+	runs := []persistence.RunHistory{
+		freshRun("ISS-CLAIMED", "PROJ-7", "", 1),
+		freshRun("ISS-RETRY", "PROJ-8", "", 1),
+		freshRun("ISS-RUNNING", "PROJ-9", "", 1),
+	}
+	params := defaultRecoveryParams(wsRoot, tracker)
+
+	result, err := RecoverPendingReactions(context.Background(), state, runs, params)
+	if err != nil {
+		t.Fatalf("RecoverPendingReactions: %v", err)
+	}
+	if result.ReviewRecovered != 0 {
+		t.Errorf("ReviewRecovered = %d, want 0 for claimed/retry/running issues", result.ReviewRecovered)
+	}
+	// Retry state unchanged.
+	if _, ok := state.RetryAttempts["ISS-RETRY"]; !ok {
+		t.Error("state.RetryAttempts[ISS-RETRY] was removed by recovery, want unchanged")
+	}
+	if len(state.PendingReactions) != 0 {
+		t.Errorf("PendingReactions len = %d, want 0", len(state.PendingReactions))
+	}
+}
+
+func TestRecoverPendingReactions_LimitsTrackerFetchCandidates(t *testing.T) {
+	t.Parallel()
+
+	wsRoot := t.TempDir()
+	// Generate 250 runs; recovery should cap at PendingReactionRecoveryMaxCandidates (200).
+	const total = 250
+	runs := make([]persistence.RunHistory, total)
+	stateMap := make(map[string]string, total)
+	for i := range total {
+		issueID := fmt.Sprintf("ISS-%04d", i)
+		identifier := fmt.Sprintf("PROJ-%04d", i)
+		runs[i] = freshRun(issueID, identifier, "", 1)
+		stateMap[issueID] = "In Review"
+		writeRecoverySCM(t, wsRoot, identifier, domain.SCMMetadata{
+			Branch:   "feature/x",
+			PushedAt: freshSCMTime(1),
+			PRNumber: i + 1,
+			Owner:    "o",
+			Repo:     "r",
+		})
+	}
+
+	tracker := &recoveryTrackerStub{states: stateMap}
+	state := NewState(5000, 4, nil, AgentTotals{})
+	params := defaultRecoveryParams(wsRoot, tracker)
+
+	result, err := RecoverPendingReactions(context.Background(), state, runs, params)
+	if err != nil {
+		t.Fatalf("RecoverPendingReactions: %v", err)
+	}
+	if result.CapSkipped != total-PendingReactionRecoveryMaxCandidates {
+		t.Errorf("CapSkipped = %d, want %d", result.CapSkipped, total-PendingReactionRecoveryMaxCandidates)
+	}
+	if len(tracker.fetchedIDs) > PendingReactionRecoveryMaxCandidates {
+		t.Errorf("FetchIssueStatesByIDs received %d IDs, want <= %d",
+			len(tracker.fetchedIDs), PendingReactionRecoveryMaxCandidates)
+	}
+}
+
+func TestRecoverPendingReactions_SkipsStaleSCMActivity(t *testing.T) {
+	t.Parallel()
+
+	wsRoot := t.TempDir()
+	// Case 1: stale pushed_at (> 30 days ago).
+	writeRecoverySCM(t, wsRoot, "PROJ-STALE", domain.SCMMetadata{
+		Branch:   "feature/stale",
+		PushedAt: freshSCMTime(35),
+		PRNumber: 1,
+		Owner:    "o",
+		Repo:     "r",
+	})
+	// Case 2: malformed pushed_at.
+	writeRecoverySCM(t, wsRoot, "PROJ-MALFORMED", domain.SCMMetadata{
+		Branch:   "feature/malformed",
+		PushedAt: "not-a-date",
+		PRNumber: 2,
+		Owner:    "o",
+		Repo:     "r",
+	})
+	// Case 3: absent pushed_at + stale completed_at (fallback).
+	runStaleCompleted := freshRun("ISS-STALE-COMPLETED", "PROJ-STALE-COMPLETED", "", 1)
+	runStaleCompleted.CompletedAt = freshSCMTime(35)
+	writeRecoverySCM(t, wsRoot, "PROJ-STALE-COMPLETED", domain.SCMMetadata{
+		Branch:   "feature/stale-completed",
+		PRNumber: 3,
+		Owner:    "o",
+		Repo:     "r",
+		// PushedAt empty
+	})
+
+	tracker := &recoveryTrackerStub{states: map[string]string{
+		"ISS-STALE":           "In Review",
+		"ISS-MALFORMED":       "In Review",
+		"ISS-STALE-COMPLETED": "In Review",
+	}}
+	state := NewState(5000, 4, nil, AgentTotals{})
+	runs := []persistence.RunHistory{
+		freshRun("ISS-STALE", "PROJ-STALE", "", 1),
+		freshRun("ISS-MALFORMED", "PROJ-MALFORMED", "", 1),
+		runStaleCompleted,
+	}
+	params := defaultRecoveryParams(wsRoot, tracker)
+
+	result, err := RecoverPendingReactions(context.Background(), state, runs, params)
+	if err != nil {
+		t.Fatalf("RecoverPendingReactions: %v", err)
+	}
+	if result.StaleSkipped != 3 {
+		t.Errorf("StaleSkipped = %d, want 3 (stale pushed_at, malformed pushed_at, stale completed_at)", result.StaleSkipped)
+	}
+	if len(state.PendingReactions) != 0 {
+		t.Errorf("PendingReactions len = %d, want 0", len(state.PendingReactions))
+	}
+}
+
+func TestRecoverPendingReactions_DoesNotOverwriteExistingReview(t *testing.T) {
+	t.Parallel()
+
+	wsRoot := t.TempDir()
+	writeRecoverySCM(t, wsRoot, "PROJ-EXISTING", domain.SCMMetadata{
+		Branch:   "feature/new",
+		PushedAt: freshSCMTime(1),
+		PRNumber: 77,
+		Owner:    "o",
+		Repo:     "r",
+	})
+
+	tracker := &recoveryTrackerStub{states: map[string]string{"ISS-EXISTING": "In Review"}}
+	state := NewState(5000, 4, nil, AgentTotals{})
+	// Pre-populate a pending reaction — recovery must not overwrite it.
+	existing := &PendingReaction{
+		IssueID: "ISS-EXISTING", Kind: ReactionKindReview,
+		KindData: &ReviewReactionData{PRNumber: 9999, Owner: "old", Repo: "old", Branch: "old"},
+	}
+	state.PendingReactions[ReactionKey("ISS-EXISTING", ReactionKindReview)] = existing
+
+	run := freshRun("ISS-EXISTING", "PROJ-EXISTING", "", 1)
+	params := defaultRecoveryParams(wsRoot, tracker)
+
+	result, err := RecoverPendingReactions(context.Background(), state, []persistence.RunHistory{run}, params)
+	if err != nil {
+		t.Fatalf("RecoverPendingReactions: %v", err)
+	}
+	if result.ReviewRecovered != 0 {
+		t.Errorf("ReviewRecovered = %d, want 0 (existing entry preserved)", result.ReviewRecovered)
+	}
+
+	rkey := ReactionKey("ISS-EXISTING", ReactionKindReview)
+	got := state.PendingReactions[rkey]
+	if got != existing {
+		t.Error("existing PendingReaction pointer was replaced by recovery; want unchanged")
+	}
+	rd := got.KindData.(*ReviewReactionData)
+	if rd.PRNumber != 9999 {
+		t.Errorf("PRNumber = %d, want 9999 (original value preserved)", rd.PRNumber)
+	}
+}
+
+func TestRecoverPendingReactions_ProviderFetchesNotCalled(t *testing.T) {
+	t.Parallel()
+
+	wsRoot := t.TempDir()
+	writeRecoverySCM(t, wsRoot, "PROJ-NOFETCH", domain.SCMMetadata{
+		Branch:   "feature/nofetch",
+		PushedAt: freshSCMTime(1),
+		PRNumber: 5,
+		Owner:    "o",
+		Repo:     "r",
+	})
+
+	tracker := &recoveryTrackerStub{states: map[string]string{"ISS-NOFETCH": "In Review"}}
+	state := NewState(5000, 4, nil, AgentTotals{})
+	run := freshRun("ISS-NOFETCH", "PROJ-NOFETCH", "", 1)
+	params := defaultRecoveryParams(wsRoot, tracker)
+	// Use panic adapters to assert FR-7: no fetch methods called during recovery.
+	params.SCMAdapter = &panicSCMAdapter{}
+	params.CIProvider = &panicCIProvider{}
+
+	// Must not panic; FetchPendingReviews / FetchCIStatus are not called.
+	_, err := RecoverPendingReactions(context.Background(), state, []persistence.RunHistory{run}, params)
+	if err != nil {
+		t.Fatalf("RecoverPendingReactions: %v", err)
+	}
+}
+
+func TestRecoverPendingReactions_InvalidSCMMetadataSkips(t *testing.T) {
+	t.Parallel()
+
+	wsRoot := t.TempDir()
+	// No .sortie/scm.json written — ReadSCMMetadata returns zero value.
+
+	tracker := &recoveryTrackerStub{states: map[string]string{"ISS-NOMETA": "In Review"}}
+	state := NewState(5000, 4, nil, AgentTotals{})
+	run := freshRun("ISS-NOMETA", "PROJ-NOMETA", "", 1)
+	params := defaultRecoveryParams(wsRoot, tracker)
+
+	result, err := RecoverPendingReactions(context.Background(), state, []persistence.RunHistory{run}, params)
+	if err != nil {
+		t.Fatalf("RecoverPendingReactions: %v", err)
+	}
+	if result.ReviewRecovered != 0 || result.CIRecovered != 0 {
+		t.Errorf("recovered = review:%d ci:%d, want 0/0 for missing scm.json",
+			result.ReviewRecovered, result.CIRecovered)
+	}
+	if len(state.PendingReactions) != 0 {
+		t.Errorf("PendingReactions len = %d, want 0", len(state.PendingReactions))
+	}
+}
+
+func TestRecoverPendingReactions_TrackerFetchError(t *testing.T) {
+	t.Parallel()
+
+	wsRoot := t.TempDir()
+	writeRecoverySCM(t, wsRoot, "PROJ-FETCHERR", domain.SCMMetadata{
+		Branch:   "feature/err",
+		PushedAt: freshSCMTime(1),
+		PRNumber: 3,
+		Owner:    "o",
+		Repo:     "r",
+	})
+
+	fetchErr := errors.New("tracker unavailable")
+	tracker := &recoveryTrackerStub{err: fetchErr}
+	state := NewState(5000, 4, nil, AgentTotals{})
+	run := freshRun("ISS-FETCHERR", "PROJ-FETCHERR", "", 1)
+	params := defaultRecoveryParams(wsRoot, tracker)
+
+	result, err := RecoverPendingReactions(context.Background(), state, []persistence.RunHistory{run}, params)
+	if err == nil {
+		t.Fatal("RecoverPendingReactions tracker fetch error = nil, want error")
+	}
+	if !errors.Is(err, fetchErr) {
+		t.Errorf("RecoverPendingReactions err = %v, want wrapping %v", err, fetchErr)
+	}
+	if result.ReviewRecovered != 0 || result.CIRecovered != 0 {
+		t.Errorf("recovered = review:%d ci:%d, want 0/0 on tracker fetch error",
+			result.ReviewRecovered, result.CIRecovered)
+	}
+	if len(state.PendingReactions) != 0 {
+		t.Errorf("PendingReactions len = %d, want 0 on tracker fetch error", len(state.PendingReactions))
+	}
+}
+
+func TestRecoverPendingReactions_DispatchedFingerprintStillDedups(t *testing.T) {
+	t.Parallel()
+
+	wsRoot := t.TempDir()
+	writeRecoverySCM(t, wsRoot, "PROJ-DEDUP", domain.SCMMetadata{
+		Branch:   "feature/dedup",
+		PushedAt: freshSCMTime(1),
+		PRNumber: 7,
+		Owner:    "owner",
+		Repo:     "repo",
+	})
+
+	tracker := &recoveryTrackerStub{states: map[string]string{"ISS-DEDUP": "In Review"}}
+	state := NewState(5000, 4, nil, AgentTotals{})
+	run := freshRun("ISS-DEDUP", "PROJ-DEDUP", "owner/repo#7", 1)
+	params := defaultRecoveryParams(wsRoot, tracker)
+
+	// Step 1: recover the review reaction.
+	result, err := RecoverPendingReactions(context.Background(), state, []persistence.RunHistory{run}, params)
+	if err != nil {
+		t.Fatalf("RecoverPendingReactions: %v", err)
+	}
+	if result.ReviewRecovered != 1 {
+		t.Fatalf("ReviewRecovered = %d, want 1", result.ReviewRecovered)
+	}
+
+	// Step 2: seed the store so the fingerprint appears already dispatched.
+	comments := []domain.ReviewComment{
+		{ID: "fp-1", Body: "lgtm", SubmittedAt: reviewBaseTime.Add(-5 * time.Minute)},
+	}
+	fp := buildReviewFingerprint(comments)
+	store := &reviewReconcileStore{
+		getFingerprintResult:     fp,
+		getFingerprintDispatched: true,
+	}
+
+	// Step 3: run reconcile with the already-dispatched fingerprint.
+	scm := &mockSCMAdapter{comments: comments}
+	reconcileParams := reviewParams(store, scm, nil)
+	reconcileReviewComments(state, reconcileParams, discardLogger(), context.Background(), newReviewMetricsSpy())
+
+	// The entry should be re-enqueued (fingerprint already dispatched), not trigger a new dispatch.
+	rkey := ReactionKey("ISS-DEDUP", ReactionKindReview)
+	if _, ok := state.PendingReactions[rkey]; !ok {
+		t.Error("PendingReactions[ISS-DEDUP:review] removed for dispatched fingerprint; want re-enqueued")
+	}
+	if store.markDispatchedCalls != 0 {
+		t.Errorf("MarkReactionDispatched calls = %d, want 0 (already dispatched)", store.markDispatchedCalls)
+	}
+	if _, ok := state.RetryAttempts["ISS-DEDUP"]; ok {
+		t.Error("retry scheduled for already-dispatched fingerprint; want none")
+	}
+}
+
+func TestRecoverPendingReactions_RecoveredReviewDispatchesContinuation(t *testing.T) {
+	t.Parallel()
+
+	wsRoot := t.TempDir()
+	writeRecoverySCM(t, wsRoot, "PROJ-DISPATCH", domain.SCMMetadata{
+		Branch:   "feature/cont",
+		PushedAt: freshSCMTime(1),
+		PRNumber: 11,
+		Owner:    "owner",
+		Repo:     "repo",
+	})
+
+	tracker := &recoveryTrackerStub{states: map[string]string{"ISS-DISPATCH": "In Review"}}
+	state := NewState(5000, 4, nil, AgentTotals{})
+	run := freshRun("ISS-DISPATCH", "PROJ-DISPATCH", "owner/repo#11", 1)
+	params := defaultRecoveryParams(wsRoot, tracker)
+
+	// Recover.
+	result, err := RecoverPendingReactions(context.Background(), state, []persistence.RunHistory{run}, params)
+	if err != nil {
+		t.Fatalf("RecoverPendingReactions: %v", err)
+	}
+	if result.ReviewRecovered != 1 {
+		t.Fatalf("ReviewRecovered = %d, want 1", result.ReviewRecovered)
+	}
+
+	// Issue was NOT claimed before reconcile.
+	if _, claimed := state.Claimed["ISS-DISPATCH"]; claimed {
+		t.Error("ISS-DISPATCH claimed before reconcile; want not claimed at recovery time")
+	}
+
+	// New comment outside the debounce window.
+	comments := []domain.ReviewComment{
+		{ID: "c-new", Body: "please fix", SubmittedAt: reviewBaseTime.Add(-5 * time.Minute)},
+	}
+	store := &reviewReconcileStore{
+		getFingerprintResult:     "",
+		getFingerprintDispatched: false,
+	}
+	scm := &mockSCMAdapter{comments: comments}
+	reconcileParams := reviewParams(store, scm, nil)
+
+	reconcileReviewComments(state, reconcileParams, discardLogger(), context.Background(), newReviewMetricsSpy())
+
+	// After dispatch, entry removed from pending reactions and a retry is scheduled.
+	rkey := ReactionKey("ISS-DISPATCH", ReactionKindReview)
+	if _, ok := state.PendingReactions[rkey]; ok {
+		t.Error("PendingReactions[ISS-DISPATCH:review] present after dispatch; want consumed")
+	}
+	retry, ok := state.RetryAttempts["ISS-DISPATCH"]
+	if !ok {
+		t.Fatal("RetryAttempts[ISS-DISPATCH] missing after review dispatch; want scheduled")
+	}
+	if retry.ContinuationContext == nil {
+		t.Error("RetryEntry.ContinuationContext is nil; want review_comments map")
+	}
+	if retry.ReactionKind != ReactionKindReview {
+		t.Errorf("RetryEntry.ReactionKind = %q, want %q", retry.ReactionKind, ReactionKindReview)
+	}
+	if store.markDispatchedCalls != 1 {
+		t.Errorf("MarkReactionDispatched calls = %d, want 1", store.markDispatchedCalls)
 	}
 }

--- a/internal/persistence/run_history.go
+++ b/internal/persistence/run_history.go
@@ -5,7 +5,10 @@ import (
 	"database/sql"
 	"fmt"
 	"strings"
+	"time"
 )
+
+const reactionRecoveryMaxCandidates = 200
 
 // RunHistory represents a single completed run attempt persisted in the
 // run_history table. The ID field is assigned by the database on insert and
@@ -115,6 +118,77 @@ func (s *Store) QueryRunHistoryByIssue(ctx context.Context, issueID string) ([]R
 	}
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("query run history by issue: %w", err)
+	}
+	return entries, nil
+}
+
+// LoadLatestSuccessfulRunsForReactionRecovery returns at most limit latest
+// successful run_history rows, one per issue, for rows with non-empty
+// workspace paths and completed_at >= completedAfter. Results are ordered by
+// descending run_history id. The limit is clamped to the recovery maximum
+// before querying. Returns an empty non-nil slice when no rows qualify.
+func (s *Store) LoadLatestSuccessfulRunsForReactionRecovery(ctx context.Context, completedAfter time.Time, limit int) ([]RunHistory, error) {
+	if limit <= 0 {
+		limit = 1
+	}
+	if limit > reactionRecoveryMaxCandidates {
+		limit = reactionRecoveryMaxCandidates
+	}
+
+	rows, err := s.db.QueryContext(ctx,
+		`WITH latest AS (
+			SELECT issue_id, MAX(id) AS latest_id
+			FROM run_history
+			WHERE status = 'succeeded'
+			  AND workspace <> ''
+			  AND completed_at >= ?
+			GROUP BY issue_id
+		), bounded AS (
+			SELECT latest_id
+			FROM latest
+			ORDER BY latest_id DESC
+			LIMIT ?
+		)
+		SELECT r.id, r.issue_id, r.identifier, r.display_identifier, r.attempt, r.agent_adapter,
+			r.workspace, r.started_at, r.completed_at, r.status, r.error, r.workflow_file,
+			r.turns_completed, r.review_metadata
+		FROM run_history AS r
+		JOIN bounded ON bounded.latest_id = r.id
+		ORDER BY r.id DESC`, completedAfter.UTC().Format(time.RFC3339), limit)
+	if err != nil {
+		return nil, fmt.Errorf("load recovery runs: %w", err)
+	}
+	defer rows.Close() //nolint:errcheck // read-only query; close error is non-actionable
+
+	entries := []RunHistory{}
+	for rows.Next() {
+		var run RunHistory
+		var errVal, wfVal, dispIDVal, reviewMetaVal sql.NullString
+		if err := rows.Scan(
+			&run.ID, &run.IssueID, &run.Identifier, &dispIDVal, &run.Attempt, &run.AgentAdapter,
+			&run.Workspace, &run.StartedAt, &run.CompletedAt, &run.Status, &errVal, &wfVal,
+			&run.TurnsCompleted, &reviewMetaVal,
+		); err != nil {
+			return nil, fmt.Errorf("load recovery runs: %w", err)
+		}
+		if errVal.Valid {
+			errorText := errVal.String
+			run.Error = &errorText
+		}
+		if wfVal.Valid {
+			run.WorkflowFile = wfVal.String
+		}
+		if dispIDVal.Valid {
+			run.DisplayID = dispIDVal.String
+		}
+		if reviewMetaVal.Valid {
+			metaJSON := reviewMetaVal.String
+			run.ReviewMetadata = &metaJSON
+		}
+		entries = append(entries, run)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("load recovery runs: %w", err)
 	}
 	return entries, nil
 }

--- a/internal/persistence/store_test.go
+++ b/internal/persistence/store_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 func closeStore(t *testing.T, s *Store) {
@@ -2401,5 +2402,226 @@ func TestAppendRunHistory_ReviewMetadata_Null(t *testing.T) {
 	}
 	if entries[0].ReviewMetadata != nil {
 		t.Errorf("queried ReviewMetadata = %q, want nil", *entries[0].ReviewMetadata)
+	}
+}
+
+// --- LoadLatestSuccessfulRunsForReactionRecovery Tests ---
+
+// recoveryRefTime is a fixed reference for recovery query tests.
+var recoveryRefTime = time.Date(2026, 1, 15, 12, 0, 0, 0, time.UTC)
+
+// recentCompletedAt returns an RFC3339 timestamp for a run completed daysAgo
+// days before recoveryRefTime.
+func recentCompletedAt(daysAgo int) string {
+	return recoveryRefTime.Add(-time.Duration(daysAgo) * 24 * time.Hour).UTC().Format(time.RFC3339)
+}
+
+// appendRecoveryRun inserts a recovery-eligible (succeeded, non-empty workspace) run and returns it.
+func appendRecoveryRun(t *testing.T, s *Store, issueID, identifier string, attempt int, completedAt string) RunHistory {
+	t.Helper()
+	run := RunHistory{
+		IssueID:      issueID,
+		Identifier:   identifier,
+		Attempt:      attempt,
+		AgentAdapter: "mock",
+		Workspace:    "/ws/" + identifier,
+		StartedAt:    completedAt,
+		CompletedAt:  completedAt,
+		Status:       "succeeded",
+	}
+	return appendOrFatal(t, s, run)
+}
+
+func TestLoadLatestSuccessfulRunsForReactionRecovery_Empty(t *testing.T) {
+	t.Parallel()
+
+	s := openTestStore(t)
+	migrateOrFatal(t, s)
+
+	cutoff := recoveryRefTime.Add(-30 * 24 * time.Hour)
+	got, err := s.LoadLatestSuccessfulRunsForReactionRecovery(context.Background(), cutoff, 200)
+	if err != nil {
+		t.Fatalf("LoadLatestSuccessfulRunsForReactionRecovery: %v", err)
+	}
+	if got == nil {
+		t.Fatal("result = nil, want non-nil empty slice")
+	}
+	if len(got) != 0 {
+		t.Fatalf("LoadLatestSuccessfulRunsForReactionRecovery() len = %d, want 0", len(got))
+	}
+}
+
+func TestLoadLatestSuccessfulRunsForReactionRecovery_LatestPerIssue(t *testing.T) {
+	t.Parallel()
+
+	s := openTestStore(t)
+	migrateOrFatal(t, s)
+	ctx := context.Background()
+	cutoff := recoveryRefTime.Add(-30 * 24 * time.Hour)
+
+	// Three runs for ISS-A; the third has the highest id and is the expected result.
+	appendRecoveryRun(t, s, "ISS-A", "PROJ-1", 1, recentCompletedAt(5))
+	appendRecoveryRun(t, s, "ISS-A", "PROJ-1", 2, recentCompletedAt(4))
+	latestA := appendRecoveryRun(t, s, "ISS-A", "PROJ-1", 3, recentCompletedAt(3))
+	// One run for ISS-B.
+	latestB := appendRecoveryRun(t, s, "ISS-B", "PROJ-2", 1, recentCompletedAt(2))
+
+	got, err := s.LoadLatestSuccessfulRunsForReactionRecovery(ctx, cutoff, 200)
+	if err != nil {
+		t.Fatalf("LoadLatestSuccessfulRunsForReactionRecovery: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("LoadLatestSuccessfulRunsForReactionRecovery() len = %d, want 2", len(got))
+	}
+	// Results are ordered newest id first.
+	if got[0].ID != latestB.ID {
+		t.Errorf("got[0].ID = %d, want %d (latest ISS-B)", got[0].ID, latestB.ID)
+	}
+	if got[1].ID != latestA.ID {
+		t.Errorf("got[1].ID = %d, want %d (latest ISS-A)", got[1].ID, latestA.ID)
+	}
+	if got[1].Attempt != 3 {
+		t.Errorf("got[1].Attempt = %d, want 3 (latest attempt for ISS-A)", got[1].Attempt)
+	}
+}
+
+func TestLoadLatestSuccessfulRunsForReactionRecovery_BoundsByCutoffAndLimit(t *testing.T) {
+	t.Parallel()
+
+	s := openTestStore(t)
+	migrateOrFatal(t, s)
+	ctx := context.Background()
+	cutoff := recoveryRefTime.Add(-30 * 24 * time.Hour)
+
+	// Insert 3 recent issues (within cutoff) and 1 old issue (outside cutoff).
+	r1 := appendRecoveryRun(t, s, "ISS-1", "PROJ-1", 1, recentCompletedAt(10))
+	r2 := appendRecoveryRun(t, s, "ISS-2", "PROJ-2", 1, recentCompletedAt(8))
+	r3 := appendRecoveryRun(t, s, "ISS-3", "PROJ-3", 1, recentCompletedAt(3))
+	// Old run: completed_at is 35 days ago, older than the 30-day cutoff.
+	appendRecoveryRun(t, s, "ISS-OLD", "PROJ-OLD", 1, recentCompletedAt(35))
+
+	// Limit=2: should return the 2 newest (r3, r2); r1 is capped out; ISS-OLD is excluded.
+	got, err := s.LoadLatestSuccessfulRunsForReactionRecovery(ctx, cutoff, 2)
+	if err != nil {
+		t.Fatalf("LoadLatestSuccessfulRunsForReactionRecovery: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("LoadLatestSuccessfulRunsForReactionRecovery(limit=2) len = %d, want 2", len(got))
+	}
+	// Ordered newest-first.
+	if got[0].ID != r3.ID {
+		t.Errorf("got[0].ID = %d, want %d (ISS-3, newest)", got[0].ID, r3.ID)
+	}
+	if got[1].ID != r2.ID {
+		t.Errorf("got[1].ID = %d, want %d (ISS-2)", got[1].ID, r2.ID)
+	}
+	// r1 excluded by cap.
+	for _, e := range got {
+		if e.IssueID == r1.IssueID {
+			t.Errorf("ISS-1 (r1) should be excluded by limit=2, but appears in result")
+		}
+		if e.IssueID == "ISS-OLD" {
+			t.Errorf("ISS-OLD should be excluded by cutoff, but appears in result")
+		}
+	}
+}
+
+func TestLoadLatestSuccessfulRunsForReactionRecovery_IgnoresFailedAndEmptyWorkspace(t *testing.T) {
+	t.Parallel()
+
+	s := openTestStore(t)
+	migrateOrFatal(t, s)
+	ctx := context.Background()
+	cutoff := recoveryRefTime.Add(-30 * 24 * time.Hour)
+
+	// Excluded: failed run.
+	appendOrFatal(t, s, RunHistory{
+		IssueID: "ISS-FAIL", Identifier: "PROJ-F", Attempt: 1,
+		AgentAdapter: "mock", Workspace: "/ws/PROJ-F",
+		StartedAt: recentCompletedAt(2), CompletedAt: recentCompletedAt(2),
+		Status: "failed",
+	})
+	// Excluded: cancelled run.
+	appendOrFatal(t, s, RunHistory{
+		IssueID: "ISS-CANCEL", Identifier: "PROJ-C", Attempt: 1,
+		AgentAdapter: "mock", Workspace: "/ws/PROJ-C",
+		StartedAt: recentCompletedAt(2), CompletedAt: recentCompletedAt(2),
+		Status: "cancelled",
+	})
+	// Excluded: succeeded but empty workspace.
+	appendOrFatal(t, s, RunHistory{
+		IssueID: "ISS-NOPATH", Identifier: "PROJ-NP", Attempt: 1,
+		AgentAdapter: "mock", Workspace: "",
+		StartedAt: recentCompletedAt(2), CompletedAt: recentCompletedAt(2),
+		Status: "succeeded",
+	})
+	// Included: succeeded with non-empty workspace.
+	eligible := appendRecoveryRun(t, s, "ISS-OK", "PROJ-OK", 1, recentCompletedAt(2))
+
+	got, err := s.LoadLatestSuccessfulRunsForReactionRecovery(ctx, cutoff, 200)
+	if err != nil {
+		t.Fatalf("LoadLatestSuccessfulRunsForReactionRecovery: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("LoadLatestSuccessfulRunsForReactionRecovery() len = %d, want 1", len(got))
+	}
+	if got[0].IssueID != eligible.IssueID {
+		t.Errorf("LoadLatestSuccessfulRunsForReactionRecovery().IssueID = %q, want %q", got[0].IssueID, eligible.IssueID)
+	}
+}
+
+func TestLoadLatestSuccessfulRunsForReactionRecovery_DisplayIDRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	s := openTestStore(t)
+	migrateOrFatal(t, s)
+	ctx := context.Background()
+	cutoff := recoveryRefTime.Add(-30 * 24 * time.Hour)
+
+	run := RunHistory{
+		IssueID:      "ISS-DISP",
+		Identifier:   "PROJ-100",
+		DisplayID:    "owner/repo#42",
+		Attempt:      3,
+		AgentAdapter: "mock",
+		Workspace:    "/ws/PROJ-100",
+		StartedAt:    recentCompletedAt(1),
+		CompletedAt:  recentCompletedAt(1),
+		Status:       "succeeded",
+	}
+	appendOrFatal(t, s, run)
+
+	got, err := s.LoadLatestSuccessfulRunsForReactionRecovery(ctx, cutoff, 200)
+	if err != nil {
+		t.Fatalf("LoadLatestSuccessfulRunsForReactionRecovery: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("LoadLatestSuccessfulRunsForReactionRecovery() len = %d, want 1", len(got))
+	}
+	if got[0].DisplayID != "owner/repo#42" {
+		t.Errorf("DisplayID = %q, want %q", got[0].DisplayID, "owner/repo#42")
+	}
+	if got[0].Attempt != 3 {
+		t.Errorf("Attempt = %d, want 3", got[0].Attempt)
+	}
+}
+
+func TestLoadLatestSuccessfulRunsForReactionRecovery_DBError(t *testing.T) {
+	t.Parallel()
+
+	s := openTestStore(t)
+	migrateOrFatal(t, s)
+
+	if err := s.db.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	cutoff := recoveryRefTime.Add(-30 * 24 * time.Hour)
+	_, err := s.LoadLatestSuccessfulRunsForReactionRecovery(context.Background(), cutoff, 200)
+	if err == nil {
+		t.Fatal("LoadLatestSuccessfulRunsForReactionRecovery on closed DB = nil, want error")
+	}
+	if !strings.Contains(err.Error(), "load recovery runs") {
+		t.Errorf("LoadLatestSuccessfulRunsForReactionRecovery error = %q, want wrapped 'load recovery runs'", err.Error())
 	}
 }


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Fix

**Intent:** Handoff-stage pending reactions (CI and review) were lost when the orchestrator restarted because `state.PendingReactions` is runtime-only. After a restart the tracker issue was no longer in an active state, so the dispatch loop did not rediscover it and any open PR sat with no CI or review polling until an operator manually re-engaged it. This fix reconstructs those entries at startup from persisted `run_history`, tracker state, and `.sortie/scm.json`, completing the restart-safety story that issue #506 started.

**Related Issues:** #507

### 🧭 Reviewer Guide

**Complexity:** Medium

#### Entry Point

`internal/orchestrator/recovery.go` - `RecoverPendingReactions` is the new entry point. It receives already-loaded `run_history` rows and `PendingReactionRecoveryParams`, applies the candidate filtering pipeline (cap, ownership check, tracker state match, workspace path safety, SCM metadata validity, staleness), and writes into `state.PendingReactions` before the event loop starts.

#### Sensitive Areas

- `cmd/sortie/main.go`: recovery is gated behind a `recoveryEnabled` check (non-empty `handoff_state` plus at least one provider non-nil) so the DB query is skipped on startups where recovery is a no-op. Recovery is still wired after provider construction and before `NewOrchestrator.Run`. Order matters — providers must exist before recovery checks whether they are nil, and recovery must finish before the first poll tick.
- `internal/persistence/run_history.go`: `LoadLatestSuccessfulRunsForReactionRecovery` uses a CTE with `MAX(id) GROUP BY issue_id` plus a `LIMIT` to keep the candidate set bounded before the tracker state fetch. The query must not scan unbounded history. No new index or migration is added for this query; if production latency proves it necessary, that is a separate performance issue.
- `internal/orchestrator/recovery.go`: tracker batch-state fetch errors are now wrapped with recovery context before propagating. The startup recovery log entry carries `success=true/false` and, on failure, the error, so operators can distinguish a clean zero-recovery pass from a failure.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes
- **Migrations/State:** No migrations or state changes. `state.PendingReactions` remains runtime-only per the existing design; no new SQLite table is added.