### PR TITLE
feat: add dispatch rule routing for agent and template selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,41 +10,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Dispatch rule routing: a new optional `dispatch:` block in
-  `WORKFLOW.md` front matter lets operators route each issue to a
-  specific agent kind and prompt template. Rules are evaluated
-  first-match-wins against issue metadata — `match.labels`,
-  `match.issue_type`, `match.priority` (with `eq` / `in` / `lt` /
-  `lte` / `gt` / `gte` operators), `match.identifier`, and
-  `match.assignee` — combining with AND across keys and OR within a
-  key. `labels` and `identifier` use `path.Match` globs; `issue_type`
-  and `assignee` use case-insensitive equality. Each rule may set
-  `agent:` and/or `template:`; either may be omitted to inherit from
-  an optional `dispatch.default` block and, finally, from the
-  workflow-wide `agent.kind` and the `WORKFLOW.md` body template.
-  Per-rule prompt template files live as Markdown files under the
-  workflow directory tree; absolute paths, `~` expansion, and symlink
-  targets that escape the tree are rejected at load time, and
-  per-rule templates must not carry their own front matter.
-  `sortie validate` surfaces dispatch misconfiguration — unknown
-  agent kind, unreachable catch-all rule, duplicate rule name,
-  malformed glob or priority predicate, missing or out-of-tree
-  template — before any worker is dispatched. The resolved
-  `(agent_kind, template_id, rule_name)` is frozen at first dispatch
-  and reused across every retry and reaction-driven continuation, so
-  an issue routed to one agent never silently switches mid-run.
-  Persistence adds `rule_name`, `template_id`, and `agent_kind`
-  columns to `retry_entries` and a `rule_name` column to
-  `run_history` via an additive forward-only migration; pre-existing
-  retries with an empty `agent_kind` fall back to the workflow
-  default and emit `recovery=legacy_retry_default_agent` once per
-  row at startup for operator audit. Routing outcomes are visible
-  through a new Prometheus counter
-  `sortie_dispatch_rule_match_total{layer,rule}` (where `layer` is
-  one of `rule`, `default`, `fallback`) and through new
-  `dispatched_by_rule`, `dispatched_by_default`, and
-  `dispatched_by_fallback` fields on every `tick completed` log
-  line. Workflows that do not declare a `dispatch:` section behave
-  byte-for-byte identically to previous releases.
+  `WORKFLOW.md` front matter routes each issue to a specific agent
+  kind and prompt template based on issue metadata. Rules match
+  first-wins on `labels`, `issue_type`, `priority`, `identifier`, and
+  `assignee` (AND across keys, OR within a key), with optional
+  `dispatch.default` and a final fallback to the workflow-wide
+  `agent.kind` and body template. Per-rule templates live as
+  Markdown files under the workflow tree and must not carry their
+  own front matter; absolute paths, `~` expansion, and symlink
+  targets that escape the tree are rejected at load time.
+  `sortie validate` reports unknown agent kinds, unreachable
+  catch-all rules, duplicate names, malformed globs and priority
+  predicates, and missing or out-of-tree templates before dispatch.
+  The resolved `(agent_kind, template_id, rule_name)` is frozen at
+  first dispatch and reused across every retry and reaction
+  continuation. Routing outcomes are exposed via the
+  `sortie_dispatch_rule_match_total{layer,rule}` Prometheus counter
+  and new `dispatched_by_rule` / `dispatched_by_default` /
+  `dispatched_by_fallback` fields on the `tick completed` log line.
+  Workflows without a `dispatch:` section are unaffected.
   ([#435](https://github.com/sortie-ai/sortie/issues/435))
 
 ### Fixed
@@ -54,6 +38,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the issue is no longer in an active state. Fresh dispatch remains
   limited to active states.
   ([#513](https://github.com/sortie-ai/sortie/issues/513))
+
+### Migrations
+
+- 010: Add `rule_name`, `template_id`, and `agent_kind` to
+  `retry_entries` and `rule_name`, `template_id` to `run_history`.
+  Existing rows read back as empty strings and are treated as legacy
+  fallback dispatches.
 
 ## [1.9.1] - 2026-04-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,46 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Dispatch rule routing: a new optional `dispatch:` block in
+  `WORKFLOW.md` front matter lets operators route each issue to a
+  specific agent kind and prompt template. Rules are evaluated
+  first-match-wins against issue metadata — `match.labels`,
+  `match.issue_type`, `match.priority` (with `eq` / `in` / `lt` /
+  `lte` / `gt` / `gte` operators), `match.identifier`, and
+  `match.assignee` — combining with AND across keys and OR within a
+  key. `labels` and `identifier` use `path.Match` globs; `issue_type`
+  and `assignee` use case-insensitive equality. Each rule may set
+  `agent:` and/or `template:`; either may be omitted to inherit from
+  an optional `dispatch.default` block and, finally, from the
+  workflow-wide `agent.kind` and the `WORKFLOW.md` body template.
+  Per-rule prompt template files live as Markdown files under the
+  workflow directory tree; absolute paths, `~` expansion, and symlink
+  targets that escape the tree are rejected at load time, and
+  per-rule templates must not carry their own front matter.
+  `sortie validate` surfaces dispatch misconfiguration — unknown
+  agent kind, unreachable catch-all rule, duplicate rule name,
+  malformed glob or priority predicate, missing or out-of-tree
+  template — before any worker is dispatched. The resolved
+  `(agent_kind, template_id, rule_name)` is frozen at first dispatch
+  and reused across every retry and reaction-driven continuation, so
+  an issue routed to one agent never silently switches mid-run.
+  Persistence adds `rule_name`, `template_id`, and `agent_kind`
+  columns to `retry_entries` and a `rule_name` column to
+  `run_history` via an additive forward-only migration; pre-existing
+  retries with an empty `agent_kind` fall back to the workflow
+  default and emit `recovery=legacy_retry_default_agent` once per
+  row at startup for operator audit. Routing outcomes are visible
+  through a new Prometheus counter
+  `sortie_dispatch_rule_match_total{layer,rule}` (where `layer` is
+  one of `rule`, `default`, `fallback`) and through new
+  `dispatched_by_rule`, `dispatched_by_default`, and
+  `dispatched_by_fallback` fields on every `tick completed` log
+  line. Workflows that do not declare a `dispatch:` section behave
+  byte-for-byte identically to previous releases.
+  ([#435](https://github.com/sortie-ai/sortie/issues/435))
+
 ### Fixed
 
 - Orchestrator: CI-failure and review-comment retries now continue from

--- a/cmd/sortie/boot.go
+++ b/cmd/sortie/boot.go
@@ -143,7 +143,8 @@ func boot(ctx context.Context, p bootParams) (bootResult, int) {
 	logger := logging.Setup(p.stderr, effectiveLevel, effectiveFormat)
 
 	mgr, err := workflow.NewManager(path, logger,
-		workflow.WithValidateFunc(orchestrator.ValidateConfigForPromotion))
+		workflow.WithValidateFunc(orchestrator.ValidateConfigForPromotion),
+		workflow.WithAgentKindProbe(registry.Agents.Has))
 	if err != nil {
 		fmt.Fprintf(p.stderr, "sortie: %s\n", err) //nolint:errcheck // stderr write failure is unrecoverable
 		return bootResult{}, 1

--- a/cmd/sortie/main.go
+++ b/cmd/sortie/main.go
@@ -12,6 +12,7 @@ package main
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"log/slog"
 	"net"
@@ -25,6 +26,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/sortie-ai/sortie/internal/config"
 	"github.com/sortie-ai/sortie/internal/domain"
 	"github.com/sortie-ai/sortie/internal/logging"
 	"github.com/sortie-ai/sortie/internal/orchestrator"
@@ -49,6 +51,59 @@ import (
 // to drain active connections on graceful shutdown. Overridden in tests to
 // exercise the shutdown-error path without a 5-second wait.
 var serverShutdownTimeout = 5 * time.Second
+
+// buildAgentAdapterCache eagerly constructs every registered agent
+// adapter so dispatch-rule routing can resolve any referenced kind
+// without per-issue construction. The workflow default kind reuses
+// the already-constructed adapter to avoid double-initialization.
+// Adapter construction failures for non-default kinds are logged and
+// skipped; the dispatch builder's preflight probe rejects unknown
+// kinds before they reach the cache.
+func buildAgentAdapterCache(cfg config.ServiceConfig, defaultAdapter domain.AgentAdapter) (map[string]domain.AgentAdapter, error) {
+	cache := map[string]domain.AgentAdapter{
+		cfg.Agent.Kind: defaultAdapter,
+	}
+	for _, kind := range registry.Agents.Kinds() {
+		if _, exists := cache[kind]; exists {
+			continue
+		}
+		ctor, err := registry.Agents.Get(kind)
+		if err != nil {
+			return nil, fmt.Errorf("resolve agent adapter %q: %w", kind, err)
+		}
+		cfgMap := agentConfigMap(cfg.Agent)
+		cfgMap["kind"] = kind
+		mergeExtensions(cfgMap, cfg.Extensions, kind)
+		adapter, err := ctor(cfgMap)
+		if err != nil {
+			return nil, fmt.Errorf("construct agent adapter %q: %w", kind, err)
+		}
+		cache[kind] = adapter
+	}
+	return cache, nil
+}
+
+// makeAgentAdapterByKind returns the closure passed into
+// [orchestrator.OrchestratorParams.AgentAdapterByKind] and the retry
+// timer params. The returned function reads from cache for O(1)
+// lookup and returns a wrapped *[registry.RegistryError] for unknown
+// kinds so callers can detect the missing-adapter category.
+func makeAgentAdapterByKind(cache map[string]domain.AgentAdapter) func(kind string) (domain.AgentAdapter, error) {
+	return func(kind string) (domain.AgentAdapter, error) {
+		if adapter, ok := cache[kind]; ok {
+			return adapter, nil
+		}
+		available := make([]string, 0, len(cache))
+		for k := range cache {
+			available = append(available, k)
+		}
+		return nil, &registry.RegistryError{
+			Dimension: "agent",
+			Kind:      kind,
+			Available: available,
+		}
+	}
+}
 
 func main() {
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
@@ -146,7 +201,7 @@ func run(ctx context.Context, args []string, stdout io.Writer, stderr io.Writer)
 		br.cfg.Agent.MaxConcurrentByState,
 		totals,
 	)
-	orchestrator.PopulateRetries(state, pendingRetries)
+	orchestrator.PopulateRetries(state, pendingRetries, br.logger)
 
 	// --- Agent adapter construction ---
 
@@ -165,6 +220,29 @@ func run(ctx context.Context, args []string, stdout io.Writer, stderr io.Writer)
 	if closer, ok := agentAdapter.(io.Closer); ok {
 		defer closer.Close() //nolint:errcheck // best-effort cleanup at shutdown
 	}
+
+	agentAdapterCache, err := buildAgentAdapterCache(br.cfg, agentAdapter)
+	if err != nil {
+		br.logger.Error("failed to build agent adapter cache", slog.Any("error", err))
+		return 1
+	}
+	defer func() {
+		for kind, adapter := range agentAdapterCache {
+			if kind == br.cfg.Agent.Kind {
+				// Already closed via the top-level defer.
+				continue
+			}
+			if closer, ok := adapter.(io.Closer); ok {
+				if cerr := closer.Close(); cerr != nil {
+					br.logger.Warn("agent adapter close failed",
+						slog.String("kind", kind),
+						slog.Any("error", cerr),
+					)
+				}
+			}
+		}
+	}()
+	agentAdapterByKind := makeAgentAdapterByKind(agentAdapterCache)
 
 	// --- Startup terminal workspace cleanup ---
 
@@ -362,20 +440,21 @@ func run(ctx context.Context, args []string, stdout io.Writer, stderr io.Writer)
 	}
 
 	o := orchestrator.NewOrchestrator(orchestrator.OrchestratorParams{
-		State:            state,
-		Logger:           br.logger,
-		TrackerAdapter:   br.trackerAdapter,
-		AgentAdapter:     agentAdapter,
-		WorkflowManager:  br.mgr,
-		Store:            store,
-		PreflightParams:  br.preflightParams,
-		Metrics:          orchMetrics,
-		ToolRegistry:     toolRegistry,
-		WorkflowFileFunc: br.mgr.FilePath,
-		DBPath:           dbPath,
-		CIProvider:       ciProvider,
-		SCMAdapter:       scmAdapter,
-		ReviewConfig:     reviewConfig,
+		State:              state,
+		Logger:             br.logger,
+		TrackerAdapter:     br.trackerAdapter,
+		AgentAdapter:       agentAdapter,
+		AgentAdapterByKind: agentAdapterByKind,
+		WorkflowManager:    br.mgr,
+		Store:              store,
+		PreflightParams:    br.preflightParams,
+		Metrics:            orchMetrics,
+		ToolRegistry:       toolRegistry,
+		WorkflowFileFunc:   br.mgr.FilePath,
+		DBPath:             dbPath,
+		CIProvider:         ciProvider,
+		SCMAdapter:         scmAdapter,
+		ReviewConfig:       reviewConfig,
 	})
 
 	var srv *server.Server

--- a/cmd/sortie/main.go
+++ b/cmd/sortie/main.go
@@ -12,7 +12,6 @@ package main
 import (
 	"context"
 	"errors"
-	"fmt"
 	"io"
 	"log/slog"
 	"net"
@@ -56,10 +55,16 @@ var serverShutdownTimeout = 5 * time.Second
 // adapter so dispatch-rule routing can resolve any referenced kind
 // without per-issue construction. The workflow default kind reuses
 // the already-constructed adapter to avoid double-initialization.
-// Adapter construction failures for non-default kinds are logged and
-// skipped; the dispatch builder's preflight probe rejects unknown
-// kinds before they reach the cache.
-func buildAgentAdapterCache(cfg config.ServiceConfig, defaultAdapter domain.AgentAdapter) (map[string]domain.AgentAdapter, error) {
+// Adapter resolution and construction failures for non-default kinds
+// are logged at warn level and skipped, so a missing or misconfigured
+// optional adapter does not block startup; the dispatch builder's
+// preflight probe rejects unknown kinds before they reach this cache,
+// and any rule that references a skipped kind surfaces as an unknown
+// agent kind at dispatch time. If log is nil, [slog.Default] is used.
+func buildAgentAdapterCache(cfg config.ServiceConfig, defaultAdapter domain.AgentAdapter, log *slog.Logger) map[string]domain.AgentAdapter {
+	if log == nil {
+		log = slog.Default()
+	}
 	cache := map[string]domain.AgentAdapter{
 		cfg.Agent.Kind: defaultAdapter,
 	}
@@ -69,18 +74,26 @@ func buildAgentAdapterCache(cfg config.ServiceConfig, defaultAdapter domain.Agen
 		}
 		ctor, err := registry.Agents.Get(kind)
 		if err != nil {
-			return nil, fmt.Errorf("resolve agent adapter %q: %w", kind, err)
+			log.Warn("skipping agent adapter cache entry, registry lookup failed",
+				slog.String("kind", kind),
+				slog.Any("error", err),
+			)
+			continue
 		}
 		cfgMap := agentConfigMap(cfg.Agent)
 		cfgMap["kind"] = kind
 		mergeExtensions(cfgMap, cfg.Extensions, kind)
 		adapter, err := ctor(cfgMap)
 		if err != nil {
-			return nil, fmt.Errorf("construct agent adapter %q: %w", kind, err)
+			log.Warn("skipping agent adapter cache entry, construction failed",
+				slog.String("kind", kind),
+				slog.Any("error", err),
+			)
+			continue
 		}
 		cache[kind] = adapter
 	}
-	return cache, nil
+	return cache
 }
 
 // makeAgentAdapterByKind returns the closure passed into
@@ -221,11 +234,7 @@ func run(ctx context.Context, args []string, stdout io.Writer, stderr io.Writer)
 		defer closer.Close() //nolint:errcheck // best-effort cleanup at shutdown
 	}
 
-	agentAdapterCache, err := buildAgentAdapterCache(br.cfg, agentAdapter)
-	if err != nil {
-		br.logger.Error("failed to build agent adapter cache", slog.Any("error", err))
-		return 1
-	}
+	agentAdapterCache := buildAgentAdapterCache(br.cfg, agentAdapter, br.logger)
 	defer func() {
 		for kind, adapter := range agentAdapterCache {
 			if kind == br.cfg.Agent.Kind {

--- a/cmd/sortie/main.go
+++ b/cmd/sortie/main.go
@@ -14,12 +14,14 @@ import (
 	"errors"
 	"io"
 	"log/slog"
+	"maps"
 	"net"
 	"net/http"
 	"os"
 	"os/signal"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strconv"
 	"strings"
 	"syscall"
@@ -100,20 +102,18 @@ func buildAgentAdapterCache(cfg config.ServiceConfig, defaultAdapter domain.Agen
 // [orchestrator.OrchestratorParams.AgentAdapterByKind] and the retry
 // timer params. The returned function reads from cache for O(1)
 // lookup and returns a wrapped *[registry.RegistryError] for unknown
-// kinds so callers can detect the missing-adapter category.
+// kinds so callers can detect the missing-adapter category. The
+// Available list on the returned error is sorted for stable diagnostic
+// output, matching the contract of [registry.Registry.Get].
 func makeAgentAdapterByKind(cache map[string]domain.AgentAdapter) func(kind string) (domain.AgentAdapter, error) {
 	return func(kind string) (domain.AgentAdapter, error) {
 		if adapter, ok := cache[kind]; ok {
 			return adapter, nil
 		}
-		available := make([]string, 0, len(cache))
-		for k := range cache {
-			available = append(available, k)
-		}
 		return nil, &registry.RegistryError{
 			Dimension: "agent",
 			Kind:      kind,
-			Available: available,
+			Available: slices.Sorted(maps.Keys(cache)),
 		}
 	}
 }

--- a/cmd/sortie/main_test.go
+++ b/cmd/sortie/main_test.go
@@ -560,9 +560,13 @@ func TestRunServerShutdownError(t *testing.T) {
 		result <- run(ctx, []string{"--port", port, wfPath}, io.Discard, &stderr)
 	}()
 
-	// Wait until the HTTP server reports its bound address.
+	// Wait until the HTTP server reports its bound address. Windows
+	// CI runners need a wider budget because the SQLite migrations and
+	// workspace cleanup that run before the listener log can take
+	// several seconds on the slow NTFS path.
 	var addr string
-	deadline := time.Now().Add(3 * time.Second)
+	startWait := runTestTimeout
+	deadline := time.Now().Add(startWait)
 	for time.Now().Before(deadline) {
 		if log := stderr.String(); strings.Contains(log, "http server listening") {
 			if i := strings.Index(log, "addr="); i >= 0 {
@@ -581,7 +585,7 @@ func TestRunServerShutdownError(t *testing.T) {
 	}
 	if addr == "" {
 		cancel()
-		t.Fatal("HTTP server did not start or log its address within 3 s")
+		t.Fatalf("HTTP server did not start or log its address within %s; stderr:\n%s", startWait, stderr.String())
 	}
 
 	// Open a TCP connection and send an incomplete HTTP request (no
@@ -610,8 +614,9 @@ func TestRunServerShutdownError(t *testing.T) {
 			t.Errorf("run() = %d, want 0 (shutdown error is non-fatal); stderr:\n%s",
 				code, stderr.String())
 		}
-	case <-time.After(3 * time.Second):
-		t.Fatalf("run() did not return within 3 s after context cancel; stderr:\n%s", stderr.String())
+	case <-time.After(runTestTimeout):
+		t.Fatalf("run() did not return within %s after context cancel; stderr:\n%s",
+			runTestTimeout, stderr.String())
 	}
 
 	if !strings.Contains(stderr.String(), "http server shutdown error") {

--- a/cmd/sortie/testdata/help-validate.txt
+++ b/cmd/sortie/testdata/help-validate.txt
@@ -1,7 +1,7 @@
 Validate a workflow file without running the orchestrator.
 
-Checks syntax, required fields, and adapter configuration. Exits with
-a non-zero code if validation fails.
+Checks syntax, required fields, adapter configuration, and dispatch
+rule routing. Exits with a non-zero code if validation fails.
 
 Usage:
   sortie validate [flags] [workflow-path]

--- a/cmd/sortie/usage.go
+++ b/cmd/sortie/usage.go
@@ -44,8 +44,8 @@ func printValidateHelp(w io.Writer) {
 	fmt.Fprint(w, //nolint:errcheck // help output write failure is unrecoverable
 		`Validate a workflow file without running the orchestrator.
 
-Checks syntax, required fields, and adapter configuration. Exits with
-a non-zero code if validation fails.
+Checks syntax, required fields, adapter configuration, and dispatch
+rule routing. Exits with a non-zero code if validation fails.
 
 Usage:
   sortie validate [flags] [workflow-path]

--- a/cmd/sortie/validate.go
+++ b/cmd/sortie/validate.go
@@ -100,7 +100,8 @@ func runValidate(_ context.Context, args []string, stdout io.Writer, stderr io.W
 	logger := slog.New(slog.DiscardHandler)
 
 	mgr, err := workflow.NewManager(path, logger,
-		workflow.WithValidateFunc(orchestrator.ValidateConfigForPromotion))
+		workflow.WithValidateFunc(orchestrator.ValidateConfigForPromotion),
+		workflow.WithAgentKindProbe(registry.Agents.Has))
 	if err != nil {
 		emitDiags(stdout, stderr, *format, mapManagerError(err), warningDiags)
 		return 1
@@ -168,6 +169,13 @@ func writeJSON(w io.Writer, v any) error {
 	return json.NewEncoder(w).Encode(v)
 }
 
+// mapManagerError converts a workflow manager load error into one or
+// more validateDiag entries. Dispatch-section *ConfigError values
+// arrive here unchanged from BuildDispatchConfig and route through
+// the "config." + Field arm, producing entries such as
+// "config.dispatch.rules[0].agent". Per-rule template parse failures
+// arrive as *prompt.TemplateError and route through "template_parse"
+// with the offending absolute path included verbatim.
 func mapManagerError(err error) []validateDiag {
 	var we *workflow.WorkflowError
 	if errors.As(err, &we) {

--- a/cmd/sortie/validate_test.go
+++ b/cmd/sortie/validate_test.go
@@ -1452,3 +1452,337 @@ func TestValidateShortHelp(t *testing.T) {
 		t.Errorf("run([validate -h]) stderr = %q, want empty", stderr.String())
 	}
 }
+
+// --- dispatch-specific validate tests ---
+
+// makeDispatchWorkflow writes a WORKFLOW.md to dir with the given dispatch
+// section content and returns the absolute path to the workflow file.
+// The workflow includes the minimum required fields so that
+// ValidateConfigForPromotion and the preflight checks are satisfied:
+// tracker.kind, tracker.active_states, tracker.terminal_states, and agent.kind.
+func makeDispatchWorkflow(t *testing.T, dir string, dispatchYAML string) string {
+	t.Helper()
+	content := []byte("---\n" +
+		"polling:\n  interval_ms: 30000\n" +
+		"tracker:\n  kind: file\n  active_states: [\"To Do\"]\n  terminal_states: [\"Done\"]\n" +
+		"agent:\n  kind: mock\n" +
+		"file:\n  path: issues.json\n" +
+		dispatchYAML +
+		"---\nDo {{ .issue.title }}.\n")
+	return writeCustomWorkflowFile(t, dir, content)
+}
+
+func TestValidateDispatch_MalformedGlob(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	wfPath := makeDispatchWorkflow(t, dir, `dispatch:
+  rules:
+    - name: bad-glob
+      match:
+        labels: ["[unclosed"]
+      agent: mock
+`)
+
+	var stdout, stderr bytes.Buffer
+	ctx := context.Background()
+
+	code := run(ctx, []string{"validate", "--format", "json", wfPath}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("run(validate) = %d, want 1; stderr: %s", code, stderr.String())
+	}
+
+	var out validateOutput
+	if err := json.Unmarshal(stdout.Bytes(), &out); err != nil {
+		t.Fatalf("json.Unmarshal(%q) error: %v", stdout.String(), err)
+	}
+	if out.Valid {
+		t.Errorf("validateOutput.Valid = true, want false")
+	}
+	found := false
+	for _, d := range out.Errors {
+		if strings.Contains(d.Check, "dispatch.rules") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("validateOutput.Errors = %v, want a diagnostic mentioning dispatch.rules", out.Errors)
+	}
+}
+
+func TestValidateDispatch_UnreachableRule(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	// Write a prompt file so the template path validation passes.
+	if err := os.WriteFile(filepath.Join(dir, "catch.md"), []byte("catch all"), 0o644); err != nil {
+		t.Fatalf("write catch.md: %v", err)
+	}
+	wfPath := makeDispatchWorkflow(t, dir, `dispatch:
+  rules:
+    - name: catch-all
+      template: catch.md
+
+    - name: unreachable
+      match:
+        labels: ["bug"]
+      agent: mock
+`)
+
+	var stdout, stderr bytes.Buffer
+	ctx := context.Background()
+
+	code := run(ctx, []string{"validate", "--format", "json", wfPath}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("run(validate) = %d, want 1; stderr: %s", code, stderr.String())
+	}
+
+	var out validateOutput
+	if err := json.Unmarshal(stdout.Bytes(), &out); err != nil {
+		t.Fatalf("json.Unmarshal(%q) error: %v", stdout.String(), err)
+	}
+	if out.Valid {
+		t.Errorf("validateOutput.Valid = true, want false")
+	}
+	found := false
+	for _, d := range out.Errors {
+		if strings.Contains(d.Message, "unreachable_rules") || strings.Contains(d.Check, "dispatch.rules") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("validateOutput.Errors = %v, want a diagnostic mentioning unreachable_rules", out.Errors)
+	}
+}
+
+func TestValidateDispatch_AbsoluteTemplatePath(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	wfPath := makeDispatchWorkflow(t, dir, `dispatch:
+  rules:
+    - name: abs-rule
+      match:
+        labels: ["bug"]
+      template: /etc/hosts
+`)
+
+	var stdout, stderr bytes.Buffer
+	ctx := context.Background()
+
+	code := run(ctx, []string{"validate", "--format", "json", wfPath}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("run(validate) = %d, want 1; stderr: %s", code, stderr.String())
+	}
+
+	var out validateOutput
+	if err := json.Unmarshal(stdout.Bytes(), &out); err != nil {
+		t.Fatalf("json.Unmarshal(%q) error: %v", stdout.String(), err)
+	}
+	if out.Valid {
+		t.Errorf("validateOutput.Valid = true, want false")
+	}
+	found := false
+	for _, d := range out.Errors {
+		if strings.Contains(d.Message, "relative") || strings.Contains(d.Check, "dispatch.rules") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("validateOutput.Errors = %v, want a diagnostic about relative template path", out.Errors)
+	}
+}
+
+func TestValidateDispatch_TildeTemplatePath(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	wfPath := makeDispatchWorkflow(t, dir, `dispatch:
+  rules:
+    - name: tilde-rule
+      match:
+        labels: ["bug"]
+      template: ~/templates/custom.md
+`)
+
+	var stdout, stderr bytes.Buffer
+	ctx := context.Background()
+
+	code := run(ctx, []string{"validate", "--format", "json", wfPath}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("run(validate) = %d, want 1; stderr: %s", code, stderr.String())
+	}
+
+	var out validateOutput
+	if err := json.Unmarshal(stdout.Bytes(), &out); err != nil {
+		t.Fatalf("json.Unmarshal(%q) error: %v", stdout.String(), err)
+	}
+	if out.Valid {
+		t.Errorf("validateOutput.Valid = true, want false")
+	}
+}
+
+func TestValidateDispatch_MissingTemplateFile(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	wfPath := makeDispatchWorkflow(t, dir, `dispatch:
+  rules:
+    - name: missing-tmpl
+      match:
+        labels: ["bug"]
+      template: nonexistent/file.md
+`)
+
+	var stdout, stderr bytes.Buffer
+	ctx := context.Background()
+
+	code := run(ctx, []string{"validate", "--format", "json", wfPath}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("run(validate) = %d, want 1; stderr: %s", code, stderr.String())
+	}
+
+	var out validateOutput
+	if err := json.Unmarshal(stdout.Bytes(), &out); err != nil {
+		t.Fatalf("json.Unmarshal(%q) error: %v", stdout.String(), err)
+	}
+	if out.Valid {
+		t.Errorf("validateOutput.Valid = true, want false")
+	}
+	found := false
+	for _, d := range out.Errors {
+		if strings.Contains(d.Message, "cannot read template") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("validateOutput.Errors = %v, want a diagnostic with 'cannot read template'", out.Errors)
+	}
+}
+
+func TestValidateDispatch_FrontMatterInTemplate(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	tmplDir := filepath.Join(dir, "prompts")
+	if err := os.MkdirAll(tmplDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(tmplDir, "fm.md"), []byte("---\nkey: value\n---\nBody."), 0o644); err != nil {
+		t.Fatalf("write template: %v", err)
+	}
+	wfPath := makeDispatchWorkflow(t, dir, `dispatch:
+  rules:
+    - name: fm-rule
+      match:
+        labels: ["bug"]
+      template: prompts/fm.md
+`)
+
+	var stdout, stderr bytes.Buffer
+	ctx := context.Background()
+
+	code := run(ctx, []string{"validate", "--format", "json", wfPath}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("run(validate) = %d, want 1; stderr: %s", code, stderr.String())
+	}
+
+	var out validateOutput
+	if err := json.Unmarshal(stdout.Bytes(), &out); err != nil {
+		t.Fatalf("json.Unmarshal(%q) error: %v", stdout.String(), err)
+	}
+	if out.Valid {
+		t.Errorf("validateOutput.Valid = true, want false")
+	}
+
+	found := false
+	for _, d := range out.Errors {
+		if d.Check == "template_parse" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("validateOutput.Errors = %v, want a diagnostic with check %q", out.Errors, "template_parse")
+	}
+}
+
+func TestValidateDispatch_ValidRulesPassThrough(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	tmplDir := filepath.Join(dir, "prompts")
+	if err := os.MkdirAll(tmplDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(tmplDir, "bug.md"),
+		[]byte("You are a bug-fixing agent for {{ .issue.identifier }}."), 0o644); err != nil {
+		t.Fatalf("write bug.md: %v", err)
+	}
+	wfPath := makeDispatchWorkflow(t, dir, `dispatch:
+  rules:
+    - name: bug
+      match:
+        labels: ["bug"]
+      template: prompts/bug.md
+`)
+
+	var stdout, stderr bytes.Buffer
+	ctx := context.Background()
+
+	code := run(ctx, []string{"validate", "--format", "json", wfPath}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("run(validate) = %d, want 0; stderr: %s", code, stderr.String())
+	}
+
+	var out validateOutput
+	if err := json.Unmarshal(stdout.Bytes(), &out); err != nil {
+		t.Fatalf("json.Unmarshal(%q) error: %v", stdout.String(), err)
+	}
+	if !out.Valid {
+		t.Errorf("validateOutput.Valid = false, want true; errors: %v", out.Errors)
+	}
+}
+
+func TestValidateDispatch_ConfigErrorRouting(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	wfPath := makeDispatchWorkflow(t, dir, `dispatch:
+  rules:
+    - name: Invalid Name!
+      agent: mock
+`)
+
+	var stdout, stderr bytes.Buffer
+	ctx := context.Background()
+
+	code := run(ctx, []string{"validate", "--format", "json", wfPath}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("run(validate) = %d, want 1; stderr: %s", code, stderr.String())
+	}
+
+	var out validateOutput
+	if err := json.Unmarshal(stdout.Bytes(), &out); err != nil {
+		t.Fatalf("json.Unmarshal(%q) error: %v", stdout.String(), err)
+	}
+	if out.Valid {
+		t.Errorf("validateOutput.Valid = true, want false")
+	}
+
+	// mapManagerError routes *ConfigError to check "config." + Field.
+	found := false
+	for _, d := range out.Errors {
+		if strings.HasPrefix(d.Check, "config.dispatch") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("validateOutput.Errors = %v, want a diagnostic with check prefixed 'config.dispatch'", out.Errors)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -55,6 +55,19 @@ type ServiceConfig struct {
 	// core schema (e.g. "server", "worker"). Consumers access these
 	// via map lookup. Never nil after construction.
 	Extensions map[string]any
+
+	// Dispatch carries the parsed dispatch rule configuration. The
+	// workflow manager stitches this in via [ServiceConfig.SetDispatch]
+	// after [NewServiceConfig] returns. Zero value selects the
+	// workflow-wide fallback for every issue.
+	Dispatch DispatchConfig
+}
+
+// SetDispatch attaches a parsed [DispatchConfig] to the service
+// config. Called by the workflow manager after [BuildDispatchConfig]
+// runs.
+func (c *ServiceConfig) SetDispatch(d DispatchConfig) {
+	c.Dispatch = d
 }
 
 // TrackerConfig holds issue tracker connection and query settings.
@@ -125,6 +138,7 @@ var knownTopLevelKeys = map[string]bool{
 	"ci_feedback": true,
 	"self_review": true,
 	"reactions":   true,
+	"dispatch":    true,
 }
 
 // NewServiceConfig converts a raw front matter map into a validated

--- a/internal/config/dispatch.go
+++ b/internal/config/dispatch.go
@@ -1,0 +1,717 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// DispatchConfig holds the parsed dispatch rule set and default
+// selection. The zero value selects the workflow-wide fallback for
+// every issue.
+type DispatchConfig struct {
+	// Rules holds the ordered first-match-wins rule list. Empty when
+	// no rules are configured. Order is preserved from the YAML source.
+	Rules []DispatchRule
+
+	// Default carries the workflow-author fallback selection used when
+	// no rule matches. Zero value falls back further to the top-level
+	// agent kind and the WORKFLOW.md body template.
+	Default DispatchSelection
+}
+
+// DispatchRule pairs a match block with the selection it produces.
+// IsCatchAll is computed at load time so evaluation does not re-derive
+// it per issue.
+type DispatchRule struct {
+	// Name is the operator-supplied rule identifier used in logs and
+	// metrics. Empty when the YAML omits the key.
+	Name string
+
+	// Match holds the per-key predicates evaluated with AND across
+	// keys and OR within a key. A zero Match matches every issue.
+	Match DispatchMatch
+
+	// Selection holds the agent kind and template path overrides.
+	// Either field may be empty; missing fields fall through to the
+	// dispatch default and finally to the workflow-wide defaults.
+	Selection DispatchSelection
+
+	// IsCatchAll is true when Match carries no keys. Set by the
+	// builder and immutable thereafter.
+	IsCatchAll bool
+}
+
+// DispatchMatch enumerates the per-key predicates a rule applies to
+// the candidate issue. A key with a nil or empty slice is not
+// evaluated.
+type DispatchMatch struct {
+	Labels     []string
+	IssueType  []string
+	Priority   *PriorityPredicate
+	Identifier []string
+	Assignee   []string
+}
+
+// PriorityPredicate carries a single numeric operator and its
+// operand. Exactly one of Value or Values is meaningful depending on
+// Op: "in" uses Values; all other operators use Value.
+type PriorityPredicate struct {
+	Op     string
+	Value  int
+	Values []int
+}
+
+// DispatchSelection carries the rule-level overrides for agent kind
+// and template ID. Empty fields fall through to the dispatch default
+// and the workflow-wide defaults.
+type DispatchSelection struct {
+	// AgentKind is the adapter kind to dispatch with. Empty selects
+	// the fallback chain.
+	AgentKind string
+
+	// TemplateID is the resolved absolute template path used as the
+	// registry key. Empty selects the WORKFLOW.md body template.
+	TemplateID string
+}
+
+// ruleNamePattern enforces the rule-name lexical form.
+var ruleNamePattern = regexp.MustCompile(`^[a-z][a-z0-9_-]*$`)
+
+// matchKeyAllowed enumerates the closed set of recognized match keys.
+var matchKeyAllowed = map[string]bool{
+	"labels":     true,
+	"issue_type": true,
+	"priority":   true,
+	"identifier": true,
+	"assignee":   true,
+}
+
+// ruleKeyAllowed enumerates the closed set of recognized per-rule keys.
+var ruleKeyAllowed = map[string]bool{
+	"name":     true,
+	"match":    true,
+	"agent":    true,
+	"template": true,
+}
+
+// priorityOpAllowed enumerates the closed set of recognized priority
+// predicate operators.
+var priorityOpAllowed = map[string]bool{
+	"eq":  true,
+	"in":  true,
+	"lt":  true,
+	"lte": true,
+	"gt":  true,
+	"gte": true,
+}
+
+// BuildDispatchConfig parses the dispatch sub-map from the raw front
+// matter, validates structural and cross-reference rules, and resolves
+// every referenced template path against workflowDir. Returns the zero
+// value and nil error when the dispatch key is absent or its value is
+// nil. Returns the first *ConfigError encountered; the builder does
+// not accumulate errors.
+//
+// agentKindProbe is the orchestrator-supplied closure that reports
+// whether the kind is currently registered. The builder rejects
+// unknown kinds at load time so dispatch never spawns workers for an
+// adapter that cannot be constructed.
+func BuildDispatchConfig(raw map[string]any, workflowDir string, agentKindProbe func(kind string) bool) (DispatchConfig, error) {
+	if raw == nil {
+		return DispatchConfig{}, nil
+	}
+	dispatchRaw, exists := raw["dispatch"]
+	if !exists || dispatchRaw == nil {
+		return DispatchConfig{}, nil
+	}
+	dispatchMap, ok := dispatchRaw.(map[string]any)
+	if !ok {
+		return DispatchConfig{}, &ConfigError{
+			Field:   "dispatch",
+			Message: fmt.Sprintf("expected map, got %T", dispatchRaw),
+		}
+	}
+
+	resolvedWorkflowDir, err := resolveWorkflowDir(workflowDir)
+	if err != nil {
+		return DispatchConfig{}, &ConfigError{
+			Field:   "dispatch",
+			Message: fmt.Sprintf("cannot resolve workflow directory: %v", err),
+		}
+	}
+
+	rules, err := parseDispatchRules(dispatchMap["rules"])
+	if err != nil {
+		return DispatchConfig{}, err
+	}
+	if err := validateNoDuplicateRuleNames(rules); err != nil {
+		return DispatchConfig{}, err
+	}
+	if err := validateCatchAllPosition(rules); err != nil {
+		return DispatchConfig{}, err
+	}
+
+	defaultSel, err := parseDispatchDefault(dispatchMap["default"])
+	if err != nil {
+		return DispatchConfig{}, err
+	}
+
+	for i := range rules {
+		if err := probeAgentKind(rules[i].Selection.AgentKind, agentKindProbe, fmt.Sprintf("dispatch.rules[%d].agent", i)); err != nil {
+			return DispatchConfig{}, err
+		}
+	}
+	if err := probeAgentKind(defaultSel.AgentKind, agentKindProbe, "dispatch.default.agent"); err != nil {
+		return DispatchConfig{}, err
+	}
+
+	for i := range rules {
+		resolved, err := resolveTemplatePath(rules[i].Selection.TemplateID, resolvedWorkflowDir, fmt.Sprintf("dispatch.rules[%d].template", i))
+		if err != nil {
+			return DispatchConfig{}, err
+		}
+		rules[i].Selection.TemplateID = resolved
+	}
+	resolvedDefaultTemplate, err := resolveTemplatePath(defaultSel.TemplateID, resolvedWorkflowDir, "dispatch.default.template")
+	if err != nil {
+		return DispatchConfig{}, err
+	}
+	defaultSel.TemplateID = resolvedDefaultTemplate
+
+	return DispatchConfig{
+		Rules:   rules,
+		Default: defaultSel,
+	}, nil
+}
+
+// parseDispatchRules converts the raw dispatch.rules YAML sequence
+// into a typed slice. Returns an empty slice when the value is absent
+// or nil.
+func parseDispatchRules(raw any) ([]DispatchRule, error) {
+	if raw == nil {
+		return nil, nil
+	}
+	seq, ok := raw.([]any)
+	if !ok {
+		return nil, &ConfigError{
+			Field:   "dispatch.rules",
+			Message: fmt.Sprintf("expected sequence, got %T", raw),
+		}
+	}
+	if len(seq) == 0 {
+		return nil, nil
+	}
+	rules := make([]DispatchRule, 0, len(seq))
+	for i, elem := range seq {
+		rule, err := parseDispatchRule(i, elem)
+		if err != nil {
+			return nil, err
+		}
+		rules = append(rules, rule)
+	}
+	return rules, nil
+}
+
+// parseDispatchRule converts a single rule element into a DispatchRule.
+func parseDispatchRule(index int, elem any) (DispatchRule, error) {
+	ruleField := fmt.Sprintf("dispatch.rules[%d]", index)
+	ruleMap, ok := elem.(map[string]any)
+	if !ok {
+		return DispatchRule{}, &ConfigError{
+			Field:   ruleField,
+			Message: fmt.Sprintf("expected map, got %T", elem),
+		}
+	}
+
+	for key := range ruleMap {
+		if !ruleKeyAllowed[key] {
+			return DispatchRule{}, &ConfigError{
+				Field:   ruleField + "." + key,
+				Message: "unknown key",
+			}
+		}
+	}
+
+	hasMatch := ruleMap["match"] != nil
+	hasAgent := false
+	if v, ok := ruleMap["agent"]; ok && v != nil {
+		hasAgent = true
+	}
+	hasTemplate := false
+	if v, ok := ruleMap["template"]; ok && v != nil {
+		hasTemplate = true
+	}
+	if !hasMatch && !hasAgent && !hasTemplate {
+		return DispatchRule{}, &ConfigError{
+			Field:   ruleField,
+			Message: "rule must specify at least one of match, agent, or template",
+		}
+	}
+
+	name, err := extractRuleName(ruleMap, ruleField)
+	if err != nil {
+		return DispatchRule{}, err
+	}
+
+	match, err := parseDispatchMatch(ruleMap["match"], ruleField+".match")
+	if err != nil {
+		return DispatchRule{}, err
+	}
+
+	selection, err := parseDispatchSelection(ruleMap, ruleField)
+	if err != nil {
+		return DispatchRule{}, err
+	}
+
+	return DispatchRule{
+		Name:       name,
+		Match:      match,
+		Selection:  selection,
+		IsCatchAll: isEmptyMatch(match),
+	}, nil
+}
+
+// extractRuleName reads and validates the optional rule name.
+func extractRuleName(ruleMap map[string]any, ruleField string) (string, error) {
+	raw, ok := ruleMap["name"]
+	if !ok || raw == nil {
+		return "", nil
+	}
+	name, ok := raw.(string)
+	if !ok {
+		return "", &ConfigError{
+			Field:   ruleField + ".name",
+			Message: fmt.Sprintf("expected string, got %T", raw),
+		}
+	}
+	if name == "" {
+		return "", nil
+	}
+	if !ruleNamePattern.MatchString(name) {
+		return "", &ConfigError{
+			Field:   ruleField + ".name",
+			Message: fmt.Sprintf("must match ^[a-z][a-z0-9_-]*$, got %q", name),
+		}
+	}
+	return name, nil
+}
+
+// parseDispatchMatch decodes the per-key predicates in a rule's match
+// block. Returns the zero DispatchMatch when raw is nil.
+func parseDispatchMatch(raw any, matchField string) (DispatchMatch, error) {
+	if raw == nil {
+		return DispatchMatch{}, nil
+	}
+	matchMap, ok := raw.(map[string]any)
+	if !ok {
+		return DispatchMatch{}, &ConfigError{
+			Field:   matchField,
+			Message: fmt.Sprintf("expected map, got %T", raw),
+		}
+	}
+
+	for key := range matchMap {
+		if !matchKeyAllowed[key] {
+			return DispatchMatch{}, &ConfigError{
+				Field:   matchField + "." + key,
+				Message: "unknown match key",
+			}
+		}
+	}
+
+	labels, err := parseStringList(matchMap["labels"], matchField+".labels")
+	if err != nil {
+		return DispatchMatch{}, err
+	}
+	if err := validateGlobPatterns(labels, matchField+".labels"); err != nil {
+		return DispatchMatch{}, err
+	}
+
+	issueTypes, err := parseStringList(matchMap["issue_type"], matchField+".issue_type")
+	if err != nil {
+		return DispatchMatch{}, err
+	}
+
+	identifiers, err := parseStringList(matchMap["identifier"], matchField+".identifier")
+	if err != nil {
+		return DispatchMatch{}, err
+	}
+	if err := validateGlobPatterns(identifiers, matchField+".identifier"); err != nil {
+		return DispatchMatch{}, err
+	}
+
+	assignees, err := parseStringList(matchMap["assignee"], matchField+".assignee")
+	if err != nil {
+		return DispatchMatch{}, err
+	}
+
+	var priority *PriorityPredicate
+	if rawPrio, ok := matchMap["priority"]; ok && rawPrio != nil {
+		p, err := parsePriorityPredicate(rawPrio, matchField+".priority")
+		if err != nil {
+			return DispatchMatch{}, err
+		}
+		priority = p
+	}
+
+	return DispatchMatch{
+		Labels:     labels,
+		IssueType:  issueTypes,
+		Priority:   priority,
+		Identifier: identifiers,
+		Assignee:   assignees,
+	}, nil
+}
+
+// parseStringList decodes a YAML scalar or sequence into []string.
+// Returns nil when raw is nil. Scalar strings are wrapped in a
+// one-element slice for ergonomics.
+func parseStringList(raw any, field string) ([]string, error) {
+	if raw == nil {
+		return nil, nil
+	}
+	if s, ok := raw.(string); ok {
+		return []string{s}, nil
+	}
+	seq, ok := raw.([]any)
+	if !ok {
+		return nil, &ConfigError{
+			Field:   field,
+			Message: fmt.Sprintf("expected string or sequence of strings, got %T", raw),
+		}
+	}
+	out := make([]string, 0, len(seq))
+	for i, elem := range seq {
+		s, ok := elem.(string)
+		if !ok {
+			return nil, &ConfigError{
+				Field:   fmt.Sprintf("%s[%d]", field, i),
+				Message: fmt.Sprintf("expected string, got %T", elem),
+			}
+		}
+		out = append(out, s)
+	}
+	return out, nil
+}
+
+// validateGlobPatterns rejects malformed glob patterns at load time.
+func validateGlobPatterns(patterns []string, field string) error {
+	for i, p := range patterns {
+		if _, err := path.Match(p, ""); err != nil {
+			return &ConfigError{
+				Field:   fmt.Sprintf("%s[%d]", field, i),
+				Message: fmt.Sprintf("invalid glob pattern: %v", err),
+			}
+		}
+	}
+	return nil
+}
+
+// parsePriorityPredicate decodes a single-operator numeric predicate.
+func parsePriorityPredicate(raw any, field string) (*PriorityPredicate, error) {
+	predMap, ok := raw.(map[string]any)
+	if !ok {
+		return nil, &ConfigError{
+			Field:   field,
+			Message: fmt.Sprintf("expected map, got %T", raw),
+		}
+	}
+
+	var opFound string
+	for k := range predMap {
+		if !priorityOpAllowed[k] {
+			return nil, &ConfigError{
+				Field:   field,
+				Message: fmt.Sprintf("unknown operator %q; expected one of eq, in, lt, lte, gt, gte", k),
+			}
+		}
+		if opFound != "" {
+			return nil, &ConfigError{
+				Field:   field,
+				Message: "expected exactly one of eq, in, lt, lte, gt, gte",
+			}
+		}
+		opFound = k
+	}
+	if opFound == "" {
+		return nil, &ConfigError{
+			Field:   field,
+			Message: "expected exactly one of eq, in, lt, lte, gt, gte",
+		}
+	}
+
+	pred := &PriorityPredicate{Op: opFound}
+	rawVal := predMap[opFound]
+	if opFound == "in" {
+		seq, ok := rawVal.([]any)
+		if !ok {
+			return nil, &ConfigError{
+				Field:   field + ".in",
+				Message: fmt.Sprintf("expected sequence of integers, got %T", rawVal),
+			}
+		}
+		pred.Values = make([]int, 0, len(seq))
+		for i, elem := range seq {
+			n, err := coerceInt(elem)
+			if err != nil {
+				return nil, &ConfigError{
+					Field:   fmt.Sprintf("%s.in[%d]", field, i),
+					Message: fmt.Sprintf("expected integer, got %T", elem),
+				}
+			}
+			pred.Values = append(pred.Values, n)
+		}
+		return pred, nil
+	}
+	n, err := coerceInt(rawVal)
+	if err != nil {
+		return nil, &ConfigError{
+			Field:   field + "." + opFound,
+			Message: fmt.Sprintf("expected integer, got %T", rawVal),
+		}
+	}
+	pred.Value = n
+	return pred, nil
+}
+
+// parseDispatchSelection extracts the agent and template fields from
+// the rule map. The template value is carried verbatim through this
+// step; cross-reference resolution happens later.
+func parseDispatchSelection(ruleMap map[string]any, ruleField string) (DispatchSelection, error) {
+	var sel DispatchSelection
+
+	if raw, ok := ruleMap["agent"]; ok && raw != nil {
+		s, ok := raw.(string)
+		if !ok {
+			return DispatchSelection{}, &ConfigError{
+				Field:   ruleField + ".agent",
+				Message: fmt.Sprintf("expected string, got %T", raw),
+			}
+		}
+		sel.AgentKind = s
+	}
+
+	if raw, ok := ruleMap["template"]; ok && raw != nil {
+		s, ok := raw.(string)
+		if !ok {
+			return DispatchSelection{}, &ConfigError{
+				Field:   ruleField + ".template",
+				Message: fmt.Sprintf("expected string, got %T", raw),
+			}
+		}
+		sel.TemplateID = s
+	}
+
+	return sel, nil
+}
+
+// parseDispatchDefault decodes the optional dispatch.default block.
+func parseDispatchDefault(raw any) (DispatchSelection, error) {
+	if raw == nil {
+		return DispatchSelection{}, nil
+	}
+	defaultMap, ok := raw.(map[string]any)
+	if !ok {
+		return DispatchSelection{}, &ConfigError{
+			Field:   "dispatch.default",
+			Message: fmt.Sprintf("expected map, got %T", raw),
+		}
+	}
+
+	allowed := map[string]bool{"agent": true, "template": true}
+	for key := range defaultMap {
+		if !allowed[key] {
+			return DispatchSelection{}, &ConfigError{
+				Field:   "dispatch.default." + key,
+				Message: "unknown key",
+			}
+		}
+	}
+
+	var sel DispatchSelection
+	if raw, ok := defaultMap["agent"]; ok && raw != nil {
+		s, ok := raw.(string)
+		if !ok {
+			return DispatchSelection{}, &ConfigError{
+				Field:   "dispatch.default.agent",
+				Message: fmt.Sprintf("expected string, got %T", raw),
+			}
+		}
+		sel.AgentKind = s
+	}
+	if raw, ok := defaultMap["template"]; ok && raw != nil {
+		s, ok := raw.(string)
+		if !ok {
+			return DispatchSelection{}, &ConfigError{
+				Field:   "dispatch.default.template",
+				Message: fmt.Sprintf("expected string, got %T", raw),
+			}
+		}
+		sel.TemplateID = s
+	}
+	return sel, nil
+}
+
+// validateNoDuplicateRuleNames returns the first *ConfigError when two
+// rules share the same non-empty name.
+func validateNoDuplicateRuleNames(rules []DispatchRule) error {
+	seen := make(map[string]int, len(rules))
+	for i, r := range rules {
+		if r.Name == "" {
+			continue
+		}
+		if first, exists := seen[r.Name]; exists {
+			return &ConfigError{
+				Field:   fmt.Sprintf("dispatch.rules[%d]", i),
+				Message: fmt.Sprintf("duplicate rule name %q (first at index %d)", r.Name, first),
+			}
+		}
+		seen[r.Name] = i
+	}
+	return nil
+}
+
+// validateCatchAllPosition rejects any rule that lacks a match block
+// (catch-all) and is followed by another rule.
+func validateCatchAllPosition(rules []DispatchRule) error {
+	for i, r := range rules {
+		if !r.IsCatchAll {
+			continue
+		}
+		if i != len(rules)-1 {
+			return &ConfigError{
+				Field:   fmt.Sprintf("dispatch.rules[%d]", i),
+				Message: fmt.Sprintf("unreachable_rules: catch-all rule at index %d precedes rule at index %d", i, i+1),
+			}
+		}
+	}
+	return nil
+}
+
+// probeAgentKind validates that the kind, when non-empty, is currently
+// registered. A nil probe defaults to permissive behavior so callers
+// that have no orchestrator dependency (dryrun, tests) keep working.
+func probeAgentKind(kind string, probe func(string) bool, field string) error {
+	if kind == "" {
+		return nil
+	}
+	if probe == nil {
+		return nil
+	}
+	if probe(kind) {
+		return nil
+	}
+	return &ConfigError{
+		Field:   field,
+		Message: fmt.Sprintf("unknown agent kind %q", kind),
+	}
+}
+
+// resolveTemplatePath validates a per-rule template path. The literal
+// value gate rejects absolute paths and tilde expansion before any
+// filesystem call. The symlink/prefix gate rejects targets that
+// resolve outside the workflow directory tree. Returns the resolved
+// absolute path used as the template registry key. Empty input
+// returns empty output (the body template sentinel).
+func resolveTemplatePath(raw, workflowDir, field string) (string, error) {
+	if raw == "" {
+		return "", nil
+	}
+	if filepath.IsAbs(raw) {
+		return "", &ConfigError{
+			Field:   field,
+			Message: "template path must be relative to WORKFLOW.md",
+		}
+	}
+	if strings.HasPrefix(raw, "~") {
+		return "", &ConfigError{
+			Field:   field,
+			Message: "template path must be relative to WORKFLOW.md",
+		}
+	}
+
+	joined := filepath.Join(workflowDir, raw)
+	resolved, err := filepath.EvalSymlinks(joined)
+	if err != nil {
+		return "", &ConfigError{
+			Field:   field,
+			Message: fmt.Sprintf("cannot read template: %v", err),
+		}
+	}
+
+	if !isUnderDirectory(resolved, workflowDir) {
+		return "", &ConfigError{
+			Field:   field,
+			Message: "template path escapes workflow directory tree",
+		}
+	}
+
+	info, err := os.Stat(resolved)
+	if err != nil {
+		return "", &ConfigError{
+			Field:   field,
+			Message: fmt.Sprintf("cannot read template: %v", err),
+		}
+	}
+	if !info.Mode().IsRegular() {
+		return "", &ConfigError{
+			Field:   field,
+			Message: "template path must be a regular file",
+		}
+	}
+
+	return resolved, nil
+}
+
+// resolveWorkflowDir evaluates symlinks for the workflow directory so
+// the prefix containment check operates on canonical paths.
+func resolveWorkflowDir(workflowDir string) (string, error) {
+	if workflowDir == "" {
+		return "", fmt.Errorf("workflow directory is empty")
+	}
+	abs := workflowDir
+	if !filepath.IsAbs(abs) {
+		converted, err := filepath.Abs(abs)
+		if err != nil {
+			return "", err
+		}
+		abs = converted
+	}
+	resolved, err := filepath.EvalSymlinks(abs)
+	if err != nil {
+		return "", err
+	}
+	return resolved, nil
+}
+
+// isUnderDirectory reports whether candidate is the same path as root
+// or a path nested under root, using clean filesystem semantics. Both
+// arguments must be absolute paths produced by [filepath.EvalSymlinks]
+// to avoid relative-path false negatives.
+func isUnderDirectory(candidate, root string) bool {
+	rel, err := filepath.Rel(root, candidate)
+	if err != nil {
+		return false
+	}
+	if rel == "." {
+		return true
+	}
+	if strings.HasPrefix(rel, "..") {
+		return false
+	}
+	return !strings.Contains(rel, "..")
+}
+
+// isEmptyMatch reports whether the match block carries no keys and
+// therefore matches every issue.
+func isEmptyMatch(m DispatchMatch) bool {
+	return len(m.Labels) == 0 &&
+		len(m.IssueType) == 0 &&
+		len(m.Identifier) == 0 &&
+		len(m.Assignee) == 0 &&
+		m.Priority == nil
+}

--- a/internal/config/dispatch.go
+++ b/internal/config/dispatch.go
@@ -692,18 +692,17 @@ func resolveWorkflowDir(workflowDir string) (string, error) {
 // or a path nested under root, using clean filesystem semantics. Both
 // arguments must be absolute paths produced by [filepath.EvalSymlinks]
 // to avoid relative-path false negatives.
+//
+// The relative path is evaluated with [filepath.IsLocal] so component
+// names that happen to contain ".." as a substring (for example,
+// "prompts/v1..md") are accepted, while genuine upward-escape
+// segments are rejected.
 func isUnderDirectory(candidate, root string) bool {
 	rel, err := filepath.Rel(root, candidate)
 	if err != nil {
 		return false
 	}
-	if rel == "." {
-		return true
-	}
-	if strings.HasPrefix(rel, "..") {
-		return false
-	}
-	return !strings.Contains(rel, "..")
+	return filepath.IsLocal(rel)
 }
 
 // isEmptyMatch reports whether the match block carries no keys and

--- a/internal/config/dispatch_test.go
+++ b/internal/config/dispatch_test.go
@@ -1,0 +1,625 @@
+package config
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// --- helpers ---
+
+func alwaysRegistered(_ string) bool { return true }
+
+func neverRegistered(_ string) bool { return false }
+
+func mkDispatchDir(t *testing.T) string {
+	t.Helper()
+	return t.TempDir()
+}
+
+// writeFile creates a file at the given absolute path with content.
+func writeFile(t *testing.T, absPath string, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(absPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll %q: %v", filepath.Dir(absPath), err)
+	}
+	if err := os.WriteFile(absPath, []byte(content), 0o644); err != nil {
+		t.Fatalf("WriteFile %q: %v", absPath, err)
+	}
+}
+
+func requireConfigError(t *testing.T, err error) *ConfigError {
+	t.Helper()
+	if err == nil {
+		t.Fatal("BuildDispatchConfig() = nil error, want *ConfigError")
+	}
+	var ce *ConfigError
+	if !errors.As(err, &ce) {
+		t.Fatalf("BuildDispatchConfig() error type = %T, want *ConfigError", err)
+	}
+	return ce
+}
+
+// --- TestBuildDispatchConfig ---
+
+func TestBuildDispatchConfig_NilOrAbsent(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		raw  map[string]any
+	}{
+		{name: "nil raw map returns zero value", raw: nil},
+		{name: "absent dispatch key returns zero value", raw: map[string]any{"tracker": map[string]any{}}},
+		{name: "nil dispatch value returns zero value", raw: map[string]any{"dispatch": nil}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			dir := mkDispatchDir(t)
+			got, err := BuildDispatchConfig(tt.raw, dir, alwaysRegistered)
+
+			if err != nil {
+				t.Fatalf("BuildDispatchConfig() error = %v, want nil", err)
+			}
+			if len(got.Rules) != 0 {
+				t.Errorf("BuildDispatchConfig() Rules = %v, want empty", got.Rules)
+			}
+			if got.Default.AgentKind != "" || got.Default.TemplateID != "" {
+				t.Errorf("BuildDispatchConfig() Default = %+v, want zero", got.Default)
+			}
+		})
+	}
+}
+
+func TestBuildDispatchConfig_HappyPath(t *testing.T) {
+	t.Parallel()
+
+	dir := mkDispatchDir(t)
+	bugTmpl := filepath.Join(dir, "prompts", "bug.md")
+	writeFile(t, bugTmpl, "You are a bug-fixing agent for {{ .issue.identifier }}.")
+
+	raw := map[string]any{
+		"dispatch": map[string]any{
+			"rules": []any{
+				map[string]any{
+					"name":     "bug",
+					"match":    map[string]any{"labels": []any{"bug"}},
+					"template": "prompts/bug.md",
+					"agent":    "claude-code",
+				},
+			},
+			"default": map[string]any{
+				"agent": "claude-code",
+			},
+		},
+	}
+
+	got, err := BuildDispatchConfig(raw, dir, alwaysRegistered)
+
+	if err != nil {
+		t.Fatalf("BuildDispatchConfig() error = %v, want nil", err)
+	}
+	if len(got.Rules) != 1 {
+		t.Fatalf("Rules count = %d, want 1", len(got.Rules))
+	}
+	if got.Rules[0].Name != "bug" {
+		t.Errorf("Rules[0].Name = %q, want %q", got.Rules[0].Name, "bug")
+	}
+	if got.Rules[0].Selection.AgentKind != "claude-code" {
+		t.Errorf("Rules[0].Selection.AgentKind = %q, want %q", got.Rules[0].Selection.AgentKind, "claude-code")
+	}
+	if got.Rules[0].Selection.TemplateID != bugTmpl {
+		t.Errorf("Rules[0].Selection.TemplateID = %q, want %q", got.Rules[0].Selection.TemplateID, bugTmpl)
+	}
+	if got.Default.AgentKind != "claude-code" {
+		t.Errorf("Default.AgentKind = %q, want %q", got.Default.AgentKind, "claude-code")
+	}
+}
+
+func TestBuildDispatchConfig_CatchAllNoMatchBlock(t *testing.T) {
+	t.Parallel()
+
+	dir := mkDispatchDir(t)
+	tmpl := filepath.Join(dir, "catch.md")
+	writeFile(t, tmpl, "catch all template")
+
+	raw := map[string]any{
+		"dispatch": map[string]any{
+			"rules": []any{
+				map[string]any{
+					"template": "catch.md",
+				},
+			},
+		},
+	}
+
+	got, err := BuildDispatchConfig(raw, dir, alwaysRegistered)
+
+	if err != nil {
+		t.Fatalf("BuildDispatchConfig() error = %v, want nil", err)
+	}
+	if len(got.Rules) != 1 {
+		t.Fatalf("Rules count = %d, want 1", len(got.Rules))
+	}
+	if !got.Rules[0].IsCatchAll {
+		t.Errorf("Rules[0].IsCatchAll = false, want true for rule without match block")
+	}
+}
+
+func TestBuildDispatchConfig_ANDSemantics(t *testing.T) {
+	t.Parallel()
+
+	dir := mkDispatchDir(t)
+
+	raw := map[string]any{
+		"dispatch": map[string]any{
+			"rules": []any{
+				map[string]any{
+					"name":  "combined",
+					"match": map[string]any{"labels": []any{"bug"}, "issue_type": []any{"Bug"}},
+					"agent": "claude-code",
+				},
+			},
+		},
+	}
+
+	got, err := BuildDispatchConfig(raw, dir, alwaysRegistered)
+
+	if err != nil {
+		t.Fatalf("BuildDispatchConfig() error = %v, want nil", err)
+	}
+	if len(got.Rules[0].Match.Labels) != 1 || got.Rules[0].Match.Labels[0] != "bug" {
+		t.Errorf("Match.Labels = %v, want [bug]", got.Rules[0].Match.Labels)
+	}
+	if len(got.Rules[0].Match.IssueType) != 1 || got.Rules[0].Match.IssueType[0] != "Bug" {
+		t.Errorf("Match.IssueType = %v, want [Bug]", got.Rules[0].Match.IssueType)
+	}
+}
+
+func TestBuildDispatchConfig_ORWithinKey(t *testing.T) {
+	t.Parallel()
+
+	dir := mkDispatchDir(t)
+
+	raw := map[string]any{
+		"dispatch": map[string]any{
+			"rules": []any{
+				map[string]any{
+					"name":  "multi-label",
+					"match": map[string]any{"labels": []any{"bug", "regression"}},
+					"agent": "claude-code",
+				},
+			},
+		},
+	}
+
+	got, err := BuildDispatchConfig(raw, dir, alwaysRegistered)
+
+	if err != nil {
+		t.Fatalf("BuildDispatchConfig() error = %v, want nil", err)
+	}
+	if len(got.Rules[0].Match.Labels) != 2 {
+		t.Errorf("Match.Labels = %v, want [bug regression]", got.Rules[0].Match.Labels)
+	}
+}
+
+func TestBuildDispatchConfig_PriorityPredicates(t *testing.T) {
+	t.Parallel()
+
+	dir := mkDispatchDir(t)
+
+	tests := []struct {
+		name    string
+		priMap  map[string]any
+		wantOp  string
+		wantVal int
+	}{
+		{"eq", map[string]any{"eq": 1}, "eq", 1},
+		{"lt", map[string]any{"lt": 3}, "lt", 3},
+		{"lte", map[string]any{"lte": 2}, "lte", 2},
+		{"gt", map[string]any{"gt": 5}, "gt", 5},
+		{"gte", map[string]any{"gte": 4}, "gte", 4},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			raw := map[string]any{
+				"dispatch": map[string]any{
+					"rules": []any{
+						map[string]any{
+							"name":  "prio-rule",
+							"match": map[string]any{"priority": tt.priMap},
+							"agent": "mock",
+						},
+					},
+				},
+			}
+
+			got, err := BuildDispatchConfig(raw, dir, alwaysRegistered)
+
+			if err != nil {
+				t.Fatalf("BuildDispatchConfig() error = %v, want nil", err)
+			}
+			p := got.Rules[0].Match.Priority
+			if p == nil {
+				t.Fatal("Priority = nil, want non-nil")
+			}
+			if p.Op != tt.wantOp {
+				t.Errorf("Priority.Op = %q, want %q", p.Op, tt.wantOp)
+			}
+			if p.Value != tt.wantVal {
+				t.Errorf("Priority.Value = %d, want %d", p.Value, tt.wantVal)
+			}
+		})
+	}
+}
+
+func TestBuildDispatchConfig_PriorityInPredicate(t *testing.T) {
+	t.Parallel()
+
+	dir := mkDispatchDir(t)
+
+	raw := map[string]any{
+		"dispatch": map[string]any{
+			"rules": []any{
+				map[string]any{
+					"name":  "in-rule",
+					"match": map[string]any{"priority": map[string]any{"in": []any{1, 2, 3}}},
+					"agent": "mock",
+				},
+			},
+		},
+	}
+
+	got, err := BuildDispatchConfig(raw, dir, alwaysRegistered)
+
+	if err != nil {
+		t.Fatalf("BuildDispatchConfig() error = %v, want nil", err)
+	}
+	p := got.Rules[0].Match.Priority
+	if p == nil {
+		t.Fatal("Priority = nil, want non-nil")
+	}
+	if p.Op != "in" {
+		t.Errorf("Priority.Op = %q, want %q", p.Op, "in")
+	}
+	if len(p.Values) != 3 {
+		t.Errorf("Priority.Values = %v, want [1 2 3]", p.Values)
+	}
+}
+
+func TestBuildDispatchConfig_ErrorCases(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		raw       map[string]any
+		setup     func(dir string)
+		wantField string
+		wantMsg   string
+	}{
+		{
+			name:      "dispatch is not a map",
+			raw:       map[string]any{"dispatch": "not-a-map"},
+			wantField: "dispatch",
+		},
+		{
+			name: "dispatch.rules is not a sequence",
+			raw: map[string]any{
+				"dispatch": map[string]any{
+					"rules": "not-a-list",
+				},
+			},
+			wantField: "dispatch.rules",
+		},
+		{
+			name: "rule element is not a map",
+			raw: map[string]any{
+				"dispatch": map[string]any{
+					"rules": []any{"not-a-map"},
+				},
+			},
+			wantField: "dispatch.rules[0]",
+		},
+		{
+			name: "rule has no match, agent, or template",
+			raw: map[string]any{
+				"dispatch": map[string]any{
+					"rules": []any{
+						map[string]any{"name": "empty-rule"},
+					},
+				},
+			},
+			wantField: "dispatch.rules[0]",
+		},
+		{
+			name: "rule name with invalid characters",
+			raw: map[string]any{
+				"dispatch": map[string]any{
+					"rules": []any{
+						map[string]any{
+							"name":  "Invalid Rule!",
+							"agent": "mock",
+						},
+					},
+				},
+			},
+			wantField: "dispatch.rules[0].name",
+		},
+		{
+			name: "duplicate rule names",
+			raw: map[string]any{
+				"dispatch": map[string]any{
+					"rules": []any{
+						map[string]any{"name": "dup", "agent": "mock"},
+						map[string]any{"name": "dup", "agent": "mock"},
+					},
+				},
+			},
+			wantField: "dispatch.rules[1]",
+		},
+		{
+			name: "catch-all not at last position",
+			raw: map[string]any{
+				"dispatch": map[string]any{
+					"rules": []any{
+						map[string]any{"agent": "mock"},
+						map[string]any{"name": "after", "agent": "mock"},
+					},
+				},
+			},
+			wantField: "dispatch.rules[0]",
+			wantMsg:   "unreachable_rules",
+		},
+		{
+			name: "invalid glob in labels",
+			raw: map[string]any{
+				"dispatch": map[string]any{
+					"rules": []any{
+						map[string]any{
+							"name":  "bad-glob",
+							"match": map[string]any{"labels": []any{"[unclosed"}},
+							"agent": "mock",
+						},
+					},
+				},
+			},
+			wantField: "dispatch.rules[0].match.labels[0]",
+		},
+		{
+			name: "unknown priority operator",
+			raw: map[string]any{
+				"dispatch": map[string]any{
+					"rules": []any{
+						map[string]any{
+							"name":  "bad-prio",
+							"match": map[string]any{"priority": map[string]any{"ne": 1}},
+							"agent": "mock",
+						},
+					},
+				},
+			},
+			wantField: "dispatch.rules[0].match.priority",
+		},
+		{
+			name: "unknown agent kind",
+			raw: map[string]any{
+				"dispatch": map[string]any{
+					"rules": []any{
+						map[string]any{
+							"name":  "bad-agent",
+							"agent": "nonexistent-agent",
+						},
+					},
+				},
+			},
+			wantField: "dispatch.rules[0].agent",
+			wantMsg:   "unknown agent kind",
+		},
+		{
+			name: "unknown default agent kind",
+			raw: map[string]any{
+				"dispatch": map[string]any{
+					"default": map[string]any{
+						"agent": "unknown-kind",
+					},
+				},
+			},
+			wantField: "dispatch.default.agent",
+			wantMsg:   "unknown agent kind",
+		},
+		{
+			name: "absolute template path rejected",
+			raw: map[string]any{
+				"dispatch": map[string]any{
+					"rules": []any{
+						map[string]any{
+							"name":     "abs-path",
+							"template": "/etc/passwd",
+						},
+					},
+				},
+			},
+			wantField: "dispatch.rules[0].template",
+			wantMsg:   "must be relative to WORKFLOW.md",
+		},
+		{
+			name: "tilde-prefix template path rejected",
+			raw: map[string]any{
+				"dispatch": map[string]any{
+					"rules": []any{
+						map[string]any{
+							"name":     "tilde-path",
+							"template": "~/templates/bug.md",
+						},
+					},
+				},
+			},
+			wantField: "dispatch.rules[0].template",
+			wantMsg:   "must be relative to WORKFLOW.md",
+		},
+		{
+			name: "missing template file",
+			raw: map[string]any{
+				"dispatch": map[string]any{
+					"rules": []any{
+						map[string]any{
+							"name":     "missing-tmpl",
+							"template": "nonexistent/file.md",
+						},
+					},
+				},
+			},
+			wantField: "dispatch.rules[0].template",
+			wantMsg:   "cannot read template",
+		},
+		{
+			name: "parent traversal template path rejected",
+			raw: map[string]any{
+				"dispatch": map[string]any{
+					"rules": []any{
+						map[string]any{
+							"name":     "traversal",
+							"template": "../traversal-target.md",
+						},
+					},
+				},
+			},
+			setup: func(dir string) {
+				// Create the target outside the workflow dir so EvalSymlinks resolves
+				// it but the containment check then rejects it.
+				parent := filepath.Dir(dir)
+				writeFile(t, filepath.Join(parent, "traversal-target.md"), "outside content")
+			},
+			wantField: "dispatch.rules[0].template",
+			wantMsg:   "escapes",
+		},
+		{
+			name: "unknown rule key",
+			raw: map[string]any{
+				"dispatch": map[string]any{
+					"rules": []any{
+						map[string]any{
+							"name":    "valid",
+							"agent":   "mock",
+							"unknown": "field",
+						},
+					},
+				},
+			},
+			wantField: "dispatch.rules[0].unknown",
+			wantMsg:   "unknown key",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			dir := mkDispatchDir(t)
+			if tt.setup != nil {
+				tt.setup(dir)
+			}
+
+			_, err := BuildDispatchConfig(tt.raw, dir, neverRegistered)
+
+			ce := requireConfigError(t, err)
+			if ce.Field != tt.wantField {
+				t.Errorf("ConfigError.Field = %q, want %q", ce.Field, tt.wantField)
+			}
+			if tt.wantMsg != "" && ce.Message == "" {
+				t.Errorf("ConfigError.Message is empty, want substring %q", tt.wantMsg)
+			}
+		})
+	}
+}
+
+func TestBuildDispatchConfig_SinglePassFirstError(t *testing.T) {
+	t.Parallel()
+
+	// Two errors present: invalid glob in rule[0] AND another error in rule[1].
+	// Only the first error (invalid glob at rules[0]) should be returned
+	// because parseDispatchRules fails on the first bad rule it encounters.
+	dir := mkDispatchDir(t)
+
+	raw := map[string]any{
+		"dispatch": map[string]any{
+			"rules": []any{
+				map[string]any{
+					"name":  "bad-glob",
+					"match": map[string]any{"labels": []any{"[invalid"}},
+					"agent": "mock",
+				},
+				// This rule also has an error (unknown key), but it is never reached.
+				map[string]any{
+					"name":    "second",
+					"agent":   "mock",
+					"unknown": "field",
+				},
+			},
+		},
+	}
+
+	_, err := BuildDispatchConfig(raw, dir, alwaysRegistered)
+
+	ce := requireConfigError(t, err)
+	if ce.Field != "dispatch.rules[0].match.labels[0]" {
+		t.Errorf("ConfigError.Field = %q, want %q (first error wins)", ce.Field, "dispatch.rules[0].match.labels[0]")
+	}
+}
+
+func TestBuildDispatchConfig_TemplateResolvedToAbsPath(t *testing.T) {
+	t.Parallel()
+
+	dir := mkDispatchDir(t)
+	relPath := "tmpl.md"
+	writeFile(t, filepath.Join(dir, relPath), "template body")
+
+	raw := map[string]any{
+		"dispatch": map[string]any{
+			"default": map[string]any{
+				"template": relPath,
+			},
+		},
+	}
+
+	got, err := BuildDispatchConfig(raw, dir, alwaysRegistered)
+
+	if err != nil {
+		t.Fatalf("BuildDispatchConfig() error = %v, want nil", err)
+	}
+
+	wantAbs := filepath.Join(dir, relPath)
+	if got.Default.TemplateID != wantAbs {
+		t.Errorf("Default.TemplateID = %q, want %q", got.Default.TemplateID, wantAbs)
+	}
+}
+
+func TestBuildDispatchConfig_NilProbeIsPermissive(t *testing.T) {
+	t.Parallel()
+
+	dir := mkDispatchDir(t)
+
+	raw := map[string]any{
+		"dispatch": map[string]any{
+			"rules": []any{
+				map[string]any{
+					"name":  "any-kind",
+					"agent": "totally-unregistered-kind",
+				},
+			},
+		},
+	}
+
+	_, err := BuildDispatchConfig(raw, dir, nil)
+
+	if err != nil {
+		t.Errorf("BuildDispatchConfig() with nil probe error = %v, want nil (permissive)", err)
+	}
+}

--- a/internal/config/dispatch_test.go
+++ b/internal/config/dispatch_test.go
@@ -15,7 +15,18 @@ func neverRegistered(_ string) bool { return false }
 
 func mkDispatchDir(t *testing.T) string {
 	t.Helper()
-	return t.TempDir()
+	// Resolve the temp dir through EvalSymlinks so test paths match what
+	// BuildDispatchConfig's resolveWorkflowDir produces. On Windows,
+	// t.TempDir() may return an 8.3 short name (e.g. RUNNER~1) which
+	// EvalSymlinks canonicalizes to the long form (e.g. runneradmin);
+	// without canonicalization here, expected paths built by joining onto
+	// the raw temp dir disagree byte-for-byte with the resolved paths
+	// production returns.
+	dir, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatalf("EvalSymlinks(t.TempDir()): %v", err)
+	}
+	return dir
 }
 
 // writeFile creates a file at the given absolute path with content.
@@ -598,6 +609,67 @@ func TestBuildDispatchConfig_TemplateResolvedToAbsPath(t *testing.T) {
 	wantAbs := filepath.Join(dir, relPath)
 	if got.Default.TemplateID != wantAbs {
 		t.Errorf("Default.TemplateID = %q, want %q", got.Default.TemplateID, wantAbs)
+	}
+}
+
+// TestBuildDispatchConfig_TemplateIDIsCanonicalAcrossSymlinks locks the
+// invariant that BuildDispatchConfig returns the canonical,
+// EvalSymlinks-resolved absolute path for every template, even when
+// the workflow directory itself is reached through a symlink. Windows
+// CI runners exposed this drift via 8.3 short-name paths (a
+// t.TempDir() value such as RUNNER~1\... canonicalized to
+// runneradmin\... once EvalSymlinks ran); the symlink wiring below
+// reproduces the same drift on Linux and macOS so the contract is
+// verifiable on every supported runner. Skips gracefully on hosts
+// where os.Symlink is unsupported or forbidden.
+func TestBuildDispatchConfig_TemplateIDIsCanonicalAcrossSymlinks(t *testing.T) {
+	t.Parallel()
+
+	base, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatalf("EvalSymlinks(t.TempDir()) error = %v, want nil", err)
+	}
+	canonical := filepath.Join(base, "real")
+	if err := os.MkdirAll(filepath.Join(canonical, "prompts"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(%q) error = %v, want nil", filepath.Join(canonical, "prompts"), err)
+	}
+	bugPath := filepath.Join(canonical, "prompts", "bug.md")
+	if err := os.WriteFile(bugPath, []byte("body"), 0o644); err != nil {
+		t.Fatalf("WriteFile(%q) error = %v, want nil", bugPath, err)
+	}
+
+	via := filepath.Join(base, "via")
+	if err := os.Symlink(canonical, via); err != nil {
+		if errors.Is(err, errors.ErrUnsupported) {
+			t.Skipf("os.Symlink(%q -> %q) unsupported on this filesystem: %v", canonical, via, err)
+		}
+		t.Skipf("os.Symlink(%q -> %q) = %v (skipping symlink-based assertion)", canonical, via, err)
+	}
+
+	raw := map[string]any{
+		"dispatch": map[string]any{
+			"rules": []any{
+				map[string]any{
+					"name":     "bug",
+					"match":    map[string]any{"labels": []any{"bug"}},
+					"template": "prompts/bug.md",
+					"agent":    "claude-code",
+				},
+			},
+		},
+	}
+
+	got, err := BuildDispatchConfig(raw, via, alwaysRegistered)
+	if err != nil {
+		t.Fatalf("BuildDispatchConfig(via=%q) error = %v, want nil", via, err)
+	}
+	if len(got.Rules) != 1 {
+		t.Fatalf("BuildDispatchConfig(via=%q) Rules count = %d, want 1", via, len(got.Rules))
+	}
+	wantTemplate := filepath.Join(canonical, "prompts", "bug.md")
+	if got.Rules[0].Selection.TemplateID != wantTemplate {
+		t.Errorf("BuildDispatchConfig(via=%q) Rules[0].Selection.TemplateID = %q, want %q (canonical, symlink-resolved)",
+			via, got.Rules[0].Selection.TemplateID, wantTemplate)
 	}
 }
 

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -19,6 +19,7 @@ const (
 	FieldStringList                       // []string (YAML sequence)
 	FieldMap                              // map[string]any (YAML mapping)
 	FieldShellScript                      // multiline string (shell script)
+	FieldSequence                         // []any (YAML sequence of maps or scalars)
 )
 
 // FieldDef describes a single known configuration field within a section.
@@ -114,6 +115,36 @@ var knownFieldsRegistry = map[string]SectionSchema{
 		Fields:           []FieldDef{},
 		AllowDynamicKeys: true,
 	},
+	"dispatch": {
+		Fields: []FieldDef{
+			{Name: "rules", Type: FieldSequence},
+			{Name: "default", Type: FieldMap, Nested: []FieldDef{
+				{Name: "agent", Type: FieldString},
+				{Name: "template", Type: FieldString},
+			}},
+		},
+	},
+}
+
+// dispatchRuleAllowedKeys lists the recognized per-rule keys for
+// front-matter static analysis. Mirrors [ruleKeyAllowed] in
+// dispatch.go; kept here so schema descent does not import dispatch
+// helpers directly.
+var dispatchRuleAllowedKeys = map[string]bool{
+	"name":     true,
+	"match":    true,
+	"agent":    true,
+	"template": true,
+}
+
+// dispatchMatchAllowedKeys lists the recognized match keys for
+// front-matter static analysis.
+var dispatchMatchAllowedKeys = map[string]bool{
+	"labels":     true,
+	"issue_type": true,
+	"priority":   true,
+	"identifier": true,
+	"assignee":   true,
 }
 
 // staticKnownExtensionKeys lists extension top-level keys defined by
@@ -162,6 +193,16 @@ func ValidateFrontMatter(raw map[string]any, cfg ServiceConfig) []FrontMatterWar
 	}
 	if cfg.Agent.Kind != "" {
 		recognized[cfg.Agent.Kind] = true
+	}
+
+	// Augment the recognized set with every agent kind referenced by
+	// dispatch.rules and dispatch.default. Deriving from the raw map
+	// keeps this accurate when BuildDispatchConfig fails: the
+	// recognized set must still exempt pass-through blocks named in
+	// the failing rules so the operator sees the rule error, not a
+	// stream of spurious unknown_key warnings.
+	for _, kind := range derivePassThroughKindsFromRaw(raw) {
+		recognized[kind] = true
 	}
 
 	// Flag top-level keys not in the recognized set.
@@ -271,6 +312,11 @@ func ValidateFrontMatter(raw map[string]any, cfg ServiceConfig) []FrontMatterWar
 			// Element-level checking for string lists.
 			if field.Type == FieldStringList {
 				warnings = checkStringListElements(warnings, sectionName+"."+field.Name, v)
+			}
+			// Sequence descent for sections that carry a YAML sequence
+			// of maps (e.g. dispatch.rules).
+			if field.Type == FieldSequence && sectionName == "dispatch" && field.Name == "rules" {
+				warnings = descendDispatchRules(warnings, v)
 			}
 			// Nested map type checking (e.g. tracker.comments sub-fields).
 			if field.Nested != nil {
@@ -410,6 +456,9 @@ func typeMatches(v any, ft FieldType) bool {
 	case FieldStringList:
 		_, ok := v.([]any)
 		return ok
+	case FieldSequence:
+		_, ok := v.([]any)
+		return ok
 	case FieldInt:
 		switch val := v.(type) {
 		case int, int64, int32:
@@ -440,7 +489,97 @@ func typeName(ft FieldType) string {
 		return "list of strings"
 	case FieldMap:
 		return "map"
+	case FieldSequence:
+		return "sequence"
 	default:
 		return "unknown"
 	}
+}
+
+// descendDispatchRules walks the dispatch.rules sequence and emits
+// unknown_sub_key warnings for unrecognized per-rule keys and per-match
+// keys. The sequence shape itself is already type-checked.
+func descendDispatchRules(warnings []FrontMatterWarning, rulesVal any) []FrontMatterWarning {
+	seq, ok := rulesVal.([]any)
+	if !ok {
+		return warnings
+	}
+	for i, elem := range seq {
+		ruleMap, ok := elem.(map[string]any)
+		if !ok {
+			continue
+		}
+		rulePath := fmt.Sprintf("dispatch.rules[%d]", i)
+		keys := maputil.SortedKeys(ruleMap)
+		for _, key := range keys {
+			if !dispatchRuleAllowedKeys[key] {
+				warnings = append(warnings, FrontMatterWarning{
+					Check:   "unknown_sub_key",
+					Field:   rulePath + "." + key,
+					Message: fmt.Sprintf("unknown key %q in dispatch rule", key),
+				})
+			}
+		}
+		matchRaw, exists := ruleMap["match"]
+		if !exists || matchRaw == nil {
+			continue
+		}
+		matchMap, ok := matchRaw.(map[string]any)
+		if !ok {
+			continue
+		}
+		matchKeys := maputil.SortedKeys(matchMap)
+		for _, key := range matchKeys {
+			if !dispatchMatchAllowedKeys[key] {
+				warnings = append(warnings, FrontMatterWarning{
+					Check:   "unknown_sub_key",
+					Field:   rulePath + ".match." + key,
+					Message: fmt.Sprintf("unknown match key %q", key),
+				})
+			}
+		}
+	}
+	return warnings
+}
+
+// derivePassThroughKindsFromRaw scans the raw front matter for every
+// agent kind referenced by dispatch.rules and dispatch.default. The
+// returned slice may contain duplicates. Reading the raw map keeps
+// this resilient to [BuildDispatchConfig] failure: the
+// recognized-top-level-keys set must remain accurate even when the
+// typed config is the zero value.
+func derivePassThroughKindsFromRaw(raw map[string]any) []string {
+	if raw == nil {
+		return nil
+	}
+	dispatchRaw, ok := raw["dispatch"]
+	if !ok || dispatchRaw == nil {
+		return nil
+	}
+	dispatchMap, ok := dispatchRaw.(map[string]any)
+	if !ok {
+		return nil
+	}
+
+	var kinds []string
+
+	if rulesRaw, ok := dispatchMap["rules"].([]any); ok {
+		for _, elem := range rulesRaw {
+			ruleMap, ok := elem.(map[string]any)
+			if !ok {
+				continue
+			}
+			if s, ok := ruleMap["agent"].(string); ok && s != "" {
+				kinds = append(kinds, s)
+			}
+		}
+	}
+
+	if defaultMap, ok := dispatchMap["default"].(map[string]any); ok {
+		if s, ok := defaultMap["agent"].(string); ok && s != "" {
+			kinds = append(kinds, s)
+		}
+	}
+
+	return kinds
 }

--- a/internal/config/schema_test.go
+++ b/internal/config/schema_test.go
@@ -5,6 +5,178 @@ import (
 	"testing"
 )
 
+// TestValidateFrontMatterDispatchRulesSequence verifies that dispatch.rules
+// is treated as a FieldSequence: rule-level unknown keys and match-level
+// unknown keys are reported as unknown_sub_key warnings.
+func TestValidateFrontMatterDispatchRulesSequence(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		raw        map[string]any
+		wantCount  int
+		wantChecks []string
+		wantFields []string
+	}{
+		{
+			name: "unknown rule key emits unknown_sub_key",
+			raw: map[string]any{
+				"dispatch": map[string]any{
+					"rules": []any{
+						map[string]any{
+							"agent":      "mock",
+							"typo_field": "value",
+						},
+					},
+				},
+			},
+			wantCount:  1,
+			wantChecks: []string{"unknown_sub_key"},
+			wantFields: []string{"dispatch.rules[0].typo_field"},
+		},
+		{
+			name: "unknown match key emits unknown_sub_key",
+			raw: map[string]any{
+				"dispatch": map[string]any{
+					"rules": []any{
+						map[string]any{
+							"agent": "mock",
+							"match": map[string]any{
+								"labels":    []any{"bug"},
+								"not_a_key": "val",
+							},
+						},
+					},
+				},
+			},
+			wantCount:  1,
+			wantChecks: []string{"unknown_sub_key"},
+			wantFields: []string{"dispatch.rules[0].match.not_a_key"},
+		},
+		{
+			name: "valid rule keys emit no warnings",
+			raw: map[string]any{
+				"dispatch": map[string]any{
+					"rules": []any{
+						map[string]any{
+							"name":     "bug",
+							"match":    map[string]any{"labels": []any{"bug"}},
+							"agent":    "mock",
+							"template": "some/path.md",
+						},
+					},
+				},
+			},
+			wantCount: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := ValidateFrontMatter(tt.raw, ServiceConfig{Agent: AgentConfig{Kind: "mock"}})
+
+			if len(got) != tt.wantCount {
+				t.Fatalf("ValidateFrontMatter() returned %d warnings, want %d\nwarnings: %+v",
+					len(got), tt.wantCount, got)
+			}
+			for i, wantCheck := range tt.wantChecks {
+				if got[i].Check != wantCheck {
+					t.Errorf("warnings[%d].Check = %q, want %q", i, got[i].Check, wantCheck)
+				}
+			}
+			for i, wantField := range tt.wantFields {
+				if got[i].Field != wantField {
+					t.Errorf("warnings[%d].Field = %q, want %q", i, got[i].Field, wantField)
+				}
+			}
+		})
+	}
+}
+
+// TestDerivePassThroughKindsFromRaw verifies that the function extracts
+// agent kinds from dispatch rules and default even when BuildDispatchConfig
+// would fail.
+func TestDerivePassThroughKindsFromRaw(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		raw     map[string]any
+		wantLen int
+		wantIn  []string
+	}{
+		{
+			name:    "nil raw returns nil",
+			raw:     nil,
+			wantLen: 0,
+		},
+		{
+			name:    "absent dispatch key returns nil",
+			raw:     map[string]any{},
+			wantLen: 0,
+		},
+		{
+			name: "extracts kinds from rules and default",
+			raw: map[string]any{
+				"dispatch": map[string]any{
+					"rules": []any{
+						map[string]any{"agent": "claude-code"},
+						map[string]any{"agent": "codex"},
+					},
+					"default": map[string]any{
+						"agent": "mock",
+					},
+				},
+			},
+			wantLen: 3,
+			wantIn:  []string{"claude-code", "codex", "mock"},
+		},
+		{
+			name: "rules with bad dispatch config still extracted",
+			raw: map[string]any{
+				"dispatch": map[string]any{
+					"rules": []any{
+						map[string]any{
+							"agent": "my-agent",
+							"match": map[string]any{"labels": []any{"[unclosed"}},
+						},
+					},
+				},
+			},
+			wantLen: 1,
+			wantIn:  []string{"my-agent"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := derivePassThroughKindsFromRaw(tt.raw)
+
+			if len(got) != tt.wantLen {
+				t.Errorf("derivePassThroughKindsFromRaw() len = %d, want %d; got %v",
+					len(got), tt.wantLen, got)
+				return
+			}
+			for _, want := range tt.wantIn {
+				found := false
+				for _, k := range got {
+					if k == want {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("derivePassThroughKindsFromRaw() = %v, want to contain %q", got, want)
+				}
+			}
+		})
+	}
+}
+
 // TestValidateFrontMatter validates the advisory static analysis in
 // ValidateFrontMatter. Each case exercises a single warning category in
 // isolation so that ordering assumptions remain trivially verifiable.

--- a/internal/domain/metrics.go
+++ b/internal/domain/metrics.go
@@ -144,6 +144,14 @@ type Metrics interface {
 	// action is "label", "comment", or "error"
 	// (sortie_review_escalations_total{action} counter).
 	IncReviewEscalations(action string)
+
+	// IncDispatchRuleMatch increments the dispatch rule match counter.
+	// layer is one of "rule", "default", or "fallback" identifying
+	// which resolution layer produced the selection. rule is the
+	// matched rule name; empty rule names report as "<none>" to keep
+	// the label cardinality bounded.
+	// (sortie_dispatch_rule_match_total{layer,rule} counter).
+	IncDispatchRuleMatch(layer string, rule string)
 }
 
 // NoopMetrics is a [Metrics] implementation where every method is a no-op.
@@ -181,6 +189,7 @@ func (*NoopMetrics) ObserveSelfReviewVerificationDuration(string, float64) {}
 func (*NoopMetrics) IncSelfReviewCapReached()                              {}
 func (*NoopMetrics) IncReviewChecks(string)                                {}
 func (*NoopMetrics) IncReviewEscalations(string)                           {}
+func (*NoopMetrics) IncDispatchRuleMatch(string, string)                   {}
 
 // MetricsSetter is implemented by adapters that accept a [Metrics]
 // recorder for self-instrumentation.

--- a/internal/orchestrator/ci_reconcile.go
+++ b/internal/orchestrator/ci_reconcile.go
@@ -239,6 +239,9 @@ func handleCIFailure(
 			"ci_failure": ciContext,
 		},
 		ReactionKind: ReactionKindCI,
+		AgentKind:    pending.AgentKind,
+		RuleName:     pending.RuleName,
+		TemplateID:   pending.TemplateID,
 	}, params.OnRetryFire)
 	metrics.IncRetries(triggerCIFix)
 

--- a/internal/orchestrator/dispatch.go
+++ b/internal/orchestrator/dispatch.go
@@ -236,6 +236,21 @@ type ScheduleRetryParams struct {
 	// Propagated to [RetryEntry.ReactionKind]. Empty for non-reaction
 	// retries.
 	ReactionKind string
+
+	// AgentKind is the dispatch-frozen adapter kind. Propagated
+	// verbatim into the new [RetryEntry] so retries reuse the
+	// original adapter without re-running rule resolution.
+	AgentKind string
+
+	// RuleName is the dispatch-frozen rule name. Propagated verbatim
+	// into the new [RetryEntry] so logs and metrics report the
+	// original matched rule across every retry attempt.
+	RuleName string
+
+	// TemplateID is the dispatch-frozen template registry key.
+	// Propagated verbatim into the new [RetryEntry] so retries
+	// render the same template as the initial dispatch.
+	TemplateID string
 }
 
 // ScheduleRetry cancels any existing retry for the issue, creates a new
@@ -279,6 +294,9 @@ func ScheduleRetry(state *State, params ScheduleRetryParams, onFire func(issueID
 		LastSSHHost:         params.LastSSHHost,
 		ContinuationContext: params.ContinuationContext,
 		ReactionKind:        params.ReactionKind,
+		RuleName:            params.RuleName,
+		TemplateID:          params.TemplateID,
+		AgentKind:           params.AgentKind,
 		scheduledAt:         time.Now(),
 		scheduledDelayMS:    delayMS,
 	}

--- a/internal/orchestrator/exit.go
+++ b/internal/orchestrator/exit.go
@@ -223,6 +223,7 @@ func HandleWorkerExit(state *State, workerResult WorkerResult, params HandleWork
 		Error:          errorStringPtr(workerResult.Error),
 		WorkflowFile:   entry.WorkflowFile,
 		TurnsCompleted: workerResult.TurnsCompleted,
+		RuleName:       entry.RuleName,
 	}
 	if workerResult.ReviewMetadata != nil {
 		data, marshalErr := json.Marshal(workerResult.ReviewMetadata)
@@ -332,6 +333,9 @@ func HandleWorkerExit(state *State, workerResult WorkerResult, params HandleWork
 						Error:       "",
 						LastSSHHost: workerResult.SSHHost,
 						SessionID:   sessionID,
+						AgentKind:   entry.AgentKind,
+						RuleName:    entry.RuleName,
+						TemplateID:  entry.TemplateID,
 					}, params.OnRetryFire)
 					metrics.IncRetries(triggerContinuation)
 					retryScheduled = true
@@ -359,6 +363,9 @@ func HandleWorkerExit(state *State, workerResult WorkerResult, params HandleWork
 						Error:       "",
 						LastSSHHost: workerResult.SSHHost,
 						SessionID:   sessionID,
+						AgentKind:   entry.AgentKind,
+						RuleName:    entry.RuleName,
+						TemplateID:  entry.TemplateID,
 					}, params.OnRetryFire)
 					metrics.IncRetries(triggerContinuation)
 					retryScheduled = true
@@ -400,6 +407,9 @@ func HandleWorkerExit(state *State, workerResult WorkerResult, params HandleWork
 				Error:       "",
 				LastSSHHost: workerResult.SSHHost,
 				SessionID:   sessionID,
+				AgentKind:   entry.AgentKind,
+				RuleName:    entry.RuleName,
+				TemplateID:  entry.TemplateID,
 			}, params.OnRetryFire)
 			metrics.IncRetries(triggerContinuation)
 			retryScheduled = true
@@ -441,6 +451,9 @@ func HandleWorkerExit(state *State, workerResult WorkerResult, params HandleWork
 							Branch: scm.Branch,
 							SHA:    scm.SHA,
 						},
+						AgentKind:  entry.AgentKind,
+						RuleName:   entry.RuleName,
+						TemplateID: entry.TemplateID,
 					}
 				}
 			}
@@ -475,6 +488,9 @@ func HandleWorkerExit(state *State, workerResult WorkerResult, params HandleWork
 								Branch:   scm.Branch,
 								SHA:      scm.SHA,
 							},
+							AgentKind:  entry.AgentKind,
+							RuleName:   entry.RuleName,
+							TemplateID: entry.TemplateID,
 						}
 					}
 				}
@@ -516,6 +532,9 @@ func HandleWorkerExit(state *State, workerResult WorkerResult, params HandleWork
 				LastSSHHost:         workerResult.SSHHost,
 				ContinuationContext: entry.ContinuationContext,
 				ReactionKind:        entry.ReactionKind,
+				AgentKind:           entry.AgentKind,
+				RuleName:            entry.RuleName,
+				TemplateID:          entry.TemplateID,
 			}, params.OnRetryFire)
 			metrics.IncRetries(triggerError)
 			retryScheduled = true
@@ -537,6 +556,9 @@ func HandleWorkerExit(state *State, workerResult WorkerResult, params HandleWork
 					DueAtMs:    retryEntry.DueAtMS,
 					Error:      stringPtr(retryEntry.Error),
 					SessionID:  stringPtr(retryEntry.SessionID),
+					RuleName:   retryEntry.RuleName,
+					TemplateID: retryEntry.TemplateID,
+					AgentKind:  retryEntry.AgentKind,
 				}
 				if err := params.Store.SaveRetryEntry(ctx, pEntry); err != nil {
 					log.Error("failed to persist retry entry",

--- a/internal/orchestrator/exit.go
+++ b/internal/orchestrator/exit.go
@@ -224,6 +224,7 @@ func HandleWorkerExit(state *State, workerResult WorkerResult, params HandleWork
 		WorkflowFile:   entry.WorkflowFile,
 		TurnsCompleted: workerResult.TurnsCompleted,
 		RuleName:       entry.RuleName,
+		TemplateID:     entry.TemplateID,
 	}
 	if workerResult.ReviewMetadata != nil {
 		data, marshalErr := json.Marshal(workerResult.ReviewMetadata)

--- a/internal/orchestrator/metrics_test.go
+++ b/internal/orchestrator/metrics_test.go
@@ -199,6 +199,8 @@ func (s *spyMetrics) IncReviewChecks(_ string) {}
 
 func (s *spyMetrics) IncReviewEscalations(_ string) {}
 
+func (s *spyMetrics) IncDispatchRuleMatch(_ string, _ string) {}
+
 // --- Tests ---
 
 func TestActiveElapsedSeconds(t *testing.T) {
@@ -652,10 +654,13 @@ func TestHandleRetryTimerMetrics(t *testing.T) {
 			ActiveStates:      []string{"To Do"},
 			TerminalStates:    []string{"Done"},
 			MaxRetryBackoffMS: 300_000,
-			MakeWorkerFn: func(_, _ string) WorkerFunc {
+			MakeWorkerFn: func(_, _, _, _ string, _ domain.AgentAdapter) WorkerFunc {
 				return func(_ context.Context, _ domain.Issue, _ *int) {
 					// no-op worker
 				}
+			},
+			AgentAdapterByKind: func(_ string) (domain.AgentAdapter, error) {
+				return &mockAgentAdapter{}, nil
 			},
 			OnRetryFire: noopRetryFire,
 			Logger:      discardLogger(),

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -318,6 +318,7 @@ func (o *Orchestrator) Run(ctx context.Context) {
 				MaxRetryBackoffMS:  cfg.Agent.MaxRetryBackoffMS,
 				MakeWorkerFn:       o.makeWorkerFn,
 				AgentAdapterByKind: o.agentAdapterByKind,
+				DefaultAgentKind:   cfg.Agent.Kind,
 				OnRetryFire:        o.onRetryFire,
 				Ctx:                ctx,
 				Logger:             o.logger,

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -21,6 +21,7 @@ import (
 type WorkflowManager interface {
 	Config() config.ServiceConfig
 	PromptTemplate() *prompt.Template
+	PromptTemplateByID(id string) *prompt.Template
 	Reload() error
 	WorkflowAbsPath() string
 }
@@ -102,21 +103,32 @@ type OrchestratorParams struct {
 	// ReviewConfig holds validated review reaction configuration.
 	// Zero value when SCMAdapter is nil.
 	ReviewConfig ReviewReactionConfig
+
+	// AgentAdapterByKind resolves the agent adapter for the given
+	// kind. Constructed once at startup from the eagerly-built
+	// per-kind adapter cache. When nil, the orchestrator falls back
+	// to its single-adapter behavior using the AgentAdapter field
+	// for every kind that matches the workflow default and rejects
+	// every other kind. This fallback exists for legacy callers
+	// during the migration window; the production binary always
+	// populates this field.
+	AgentAdapterByKind func(kind string) (domain.AgentAdapter, error)
 }
 
 // Orchestrator owns the poll-and-dispatch event loop and all runtime
 // state. Construct via [NewOrchestrator] and run with [Orchestrator.Run].
-// Not safe for concurrent use — [Run] must be called from a single
+// Not safe for concurrent use - [Run] must be called from a single
 // goroutine. External events are delivered via channels.
 type Orchestrator struct {
 	state  *State
 	logger *slog.Logger
 
-	trackerAdapter  domain.TrackerAdapter
-	agentAdapter    domain.AgentAdapter
-	workflowManager WorkflowManager
-	store           OrchestratorStore
-	metrics         domain.Metrics
+	trackerAdapter     domain.TrackerAdapter
+	agentAdapter       domain.AgentAdapter
+	agentAdapterByKind func(kind string) (domain.AgentAdapter, error)
+	workflowManager    WorkflowManager
+	store              OrchestratorStore
+	metrics            domain.Metrics
 
 	workerExitCh chan WorkerResult
 	retryTimerCh chan string
@@ -190,30 +202,54 @@ func NewOrchestrator(params OrchestratorParams) *Orchestrator {
 		}
 	}
 
+	agentAdapterByKind := params.AgentAdapterByKind
+	if agentAdapterByKind == nil {
+		// Migration fallback for legacy callers (tests, dryrun) that
+		// have not wired the closure yet. The production binary
+		// always populates AgentAdapterByKind via the per-kind
+		// adapter cache constructed in cmd/sortie. Resolves the
+		// workflow default kind to the single AgentAdapter field;
+		// every other kind returns an error so the dispatch path
+		// gracefully skips the issue rather than panicking.
+		defaultAdapter := params.AgentAdapter
+		defaultKind := ""
+		if params.WorkflowManager != nil {
+			defaultKind = params.WorkflowManager.Config().Agent.Kind
+		}
+		agentAdapterByKind = func(kind string) (domain.AgentAdapter, error) {
+			if kind == defaultKind && defaultAdapter != nil {
+				return defaultAdapter, nil
+			}
+			return nil, fmt.Errorf("agent kind %q is not available (AgentAdapterByKind not wired)", kind)
+		}
+		logger.Warn("AgentAdapterByKind not provided; falling back to single-adapter mode for the workflow default kind only")
+	}
+
 	o := &Orchestrator{
-		state:            params.State,
-		logger:           logger,
-		trackerAdapter:   params.TrackerAdapter,
-		agentAdapter:     params.AgentAdapter,
-		workflowManager:  params.WorkflowManager,
-		store:            params.Store,
-		metrics:          metrics,
-		workerExitCh:     make(chan WorkerResult, exitBuf),
-		retryTimerCh:     make(chan string, retryBuf),
-		agentEventCh:     make(chan agentEventMsg, eventBuf),
-		selfReviewCh:     make(chan selfReviewProgressMsg, eventBuf),
-		snapshotCh:       make(chan snapshotRequest, 4),
-		refreshCh:        make(chan struct{}, 1),
-		preflightParams:  params.PreflightParams,
-		observers:        observers,
-		drainTimeout:     defaultDrainTimeout,
-		toolRegistry:     params.ToolRegistry,
-		hostPool:         hostPool,
-		workflowFileFunc: params.WorkflowFileFunc,
-		dbPath:           params.DBPath,
-		ciProvider:       params.CIProvider,
-		scmAdapter:       params.SCMAdapter,
-		reviewConfig:     params.ReviewConfig,
+		state:              params.State,
+		logger:             logger,
+		trackerAdapter:     params.TrackerAdapter,
+		agentAdapter:       params.AgentAdapter,
+		agentAdapterByKind: agentAdapterByKind,
+		workflowManager:    params.WorkflowManager,
+		store:              params.Store,
+		metrics:            metrics,
+		workerExitCh:       make(chan WorkerResult, exitBuf),
+		retryTimerCh:       make(chan string, retryBuf),
+		agentEventCh:       make(chan agentEventMsg, eventBuf),
+		selfReviewCh:       make(chan selfReviewProgressMsg, eventBuf),
+		snapshotCh:         make(chan snapshotRequest, 4),
+		refreshCh:          make(chan struct{}, 1),
+		preflightParams:    params.PreflightParams,
+		observers:          observers,
+		drainTimeout:       defaultDrainTimeout,
+		toolRegistry:       params.ToolRegistry,
+		hostPool:           hostPool,
+		workflowFileFunc:   params.WorkflowFileFunc,
+		dbPath:             params.DBPath,
+		ciProvider:         params.CIProvider,
+		scmAdapter:         params.SCMAdapter,
+		reviewConfig:       params.ReviewConfig,
 	}
 	// Startup preflight must have passed for the orchestrator to be
 	// constructed, so the initial value is true.
@@ -274,21 +310,21 @@ func (o *Orchestrator) Run(ctx context.Context) {
 		case issueID := <-o.retryTimerCh:
 			cfg := o.workflowManager.Config()
 			HandleRetryTimer(o.state, issueID, HandleRetryTimerParams{
-				Store:             o.store,
-				TrackerAdapter:    o.trackerAdapter,
-				ActiveStates:      cfg.Tracker.ActiveStates,
-				TerminalStates:    cfg.Tracker.TerminalStates,
-				HandoffState:      cfg.Tracker.HandoffState,
-				MaxRetryBackoffMS: cfg.Agent.MaxRetryBackoffMS,
-				MakeWorkerFn:      o.makeWorkerFn,
-				OnRetryFire:       o.onRetryFire,
-				Ctx:               ctx,
-				Logger:            o.logger,
-				MaxSessions:       cfg.Agent.MaxSessions,
-				Metrics:           o.metrics,
-				HostPool:          o.hostPool,
-				WorkflowFile:      o.workflowFile(),
-				AgentKind:         cfg.Agent.Kind,
+				Store:              o.store,
+				TrackerAdapter:     o.trackerAdapter,
+				ActiveStates:       cfg.Tracker.ActiveStates,
+				TerminalStates:     cfg.Tracker.TerminalStates,
+				HandoffState:       cfg.Tracker.HandoffState,
+				MaxRetryBackoffMS:  cfg.Agent.MaxRetryBackoffMS,
+				MakeWorkerFn:       o.makeWorkerFn,
+				AgentAdapterByKind: o.agentAdapterByKind,
+				OnRetryFire:        o.onRetryFire,
+				Ctx:                ctx,
+				Logger:             o.logger,
+				MaxSessions:        cfg.Agent.MaxSessions,
+				Metrics:            o.metrics,
+				HostPool:           o.hostPool,
+				WorkflowFile:       o.workflowFile(),
 			})
 			o.updateGauges(time.Now())
 			o.notifyObservers()
@@ -473,7 +509,7 @@ func (o *Orchestrator) handleTick(ctx context.Context) {
 	// Break only when global capacity is exhausted; skip individual
 	// issues whose per-state limit is full so issues in other states
 	// can still be dispatched.
-	var dispatched int
+	var dispatched, dispatchedByRule, dispatchedByDefault, dispatchedByFallback int
 	for _, issue := range sorted {
 		if GlobalAvailableSlots(o.state.MaxConcurrentAgents, len(o.state.Running)) == 0 {
 			break
@@ -487,22 +523,60 @@ func (o *Orchestrator) handleTick(ctx context.Context) {
 		if !ShouldDispatchWithSets(issue, o.state, activeSet, terminalSet) {
 			continue
 		}
+
+		resolution := ResolveRule(issue, cfg.Dispatch, cfg.Agent.Kind, "")
+		adapter, adapterErr := o.agentAdapterByKind(resolution.AgentKind)
+		if adapterErr != nil {
+			o.logger.Error("agent kind unavailable",
+				slog.String("rule_name", resolution.RuleName),
+				slog.String("agent_kind", resolution.AgentKind),
+				slog.Any("error", adapterErr),
+			)
+			o.metrics.IncDispatches(outcomeError)
+			o.metrics.IncDispatchRuleMatch(resolution.MatchedAt.String(), normalizeDispatchRuleName(resolution.RuleName))
+			continue
+		}
+		tmpl := o.workflowManager.PromptTemplateByID(resolution.TemplateID)
+		if tmpl == nil {
+			o.logger.Error("template id unavailable",
+				slog.String("rule_name", resolution.RuleName),
+				slog.String("template_id", resolution.TemplateID),
+			)
+			o.metrics.IncDispatches(outcomeError)
+			o.metrics.IncDispatchRuleMatch(resolution.MatchedAt.String(), normalizeDispatchRuleName(resolution.RuleName))
+			continue
+		}
+
 		host, ok := o.hostPool.AcquireHost(issue.ID, "")
 		if !ok {
 			break
 		}
-		DispatchIssue(ctx, o.state, issue, nil, host, o.makeWorkerFn("", host))
+		DispatchIssue(ctx, o.state, issue, nil, host, o.makeWorkerFn("", host, resolution.AgentKind, resolution.TemplateID, adapter))
 		if entry := o.state.Running[issue.ID]; entry != nil {
 			entry.WorkflowFile = o.workflowFile()
-			entry.AgentKind = cfg.Agent.Kind
+			entry.AgentKind = resolution.AgentKind
+			entry.RuleName = resolution.RuleName
+			entry.TemplateID = resolution.TemplateID
 		}
 		o.metrics.IncDispatches(outcomeSuccess)
+		o.metrics.IncDispatchRuleMatch(resolution.MatchedAt.String(), normalizeDispatchRuleName(resolution.RuleName))
+		switch resolution.MatchedAt {
+		case ResolvedFromRule:
+			dispatchedByRule++
+		case ResolvedFromDefault:
+			dispatchedByDefault++
+		default:
+			dispatchedByFallback++
+		}
 		dispatched++
 	}
 
 	o.logger.Info("tick completed",
 		slog.Int("candidates", len(sorted)),
 		slog.Int("dispatched", dispatched),
+		slog.Int("dispatched_by_rule", dispatchedByRule),
+		slog.Int("dispatched_by_default", dispatchedByDefault),
+		slog.Int("dispatched_by_fallback", dispatchedByFallback),
 		slog.Int("running", len(o.state.Running)),
 		slog.Int("retrying", len(o.state.RetryAttempts)),
 	)
@@ -513,20 +587,30 @@ func (o *Orchestrator) handleTick(ctx context.Context) {
 // makeWorkerFn returns a [WorkerFunc] closure that runs
 // [RunWorkerAttempt] with the orchestrator's shared dependencies.
 // The closure captures channel references for OnEvent and OnExit
-// delivery. The resumeSessionID must be read by the caller (on the
-// event loop goroutine) before the goroutine starts, to avoid a
-// data race on the Running map.
-func (o *Orchestrator) makeWorkerFn(resumeSessionID string, sshHost string) WorkerFunc {
+// delivery. agentKind, templateID, and adapter carry the rule-resolved
+// selection from the caller (handleTick for initial dispatches,
+// HandleRetryTimer for retries). The resumeSessionID must be read by
+// the caller (on the event loop goroutine) before the goroutine
+// starts, to avoid a data race on the Running map.
+func (o *Orchestrator) makeWorkerFn(resumeSessionID, sshHost, agentKind, templateID string, adapter domain.AgentAdapter) WorkerFunc {
 	strictHostKeyChecking := o.sshStrictHostKeyChecking
+	if adapter == nil {
+		adapter = o.agentAdapter
+	}
+	if agentKind == "" {
+		agentKind = o.workflowManager.Config().Agent.Kind
+	}
 	return func(ctx context.Context, issue domain.Issue, attempt *int) {
 
 		logger := logging.WithIssue(o.logger, issue.ID, issue.Identifier)
 
 		deps := WorkerDeps{
-			TrackerAdapter:     o.trackerAdapter,
-			AgentAdapter:       o.agentAdapter,
-			ConfigFunc:         o.workflowManager.Config,
-			PromptTemplateFunc: o.workflowManager.PromptTemplate,
+			TrackerAdapter:         o.trackerAdapter,
+			AgentAdapter:           adapter,
+			ConfigFunc:             o.workflowManager.Config,
+			PromptTemplateByIDFunc: o.workflowManager.PromptTemplateByID,
+			TemplateID:             templateID,
+			AgentKind:              agentKind,
 			OnEvent: func(issueID string, event domain.AgentEvent) {
 				select {
 				case o.agentEventCh <- agentEventMsg{IssueID: issueID, Event: event}:

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -27,11 +27,12 @@ import (
 // stubWorkflowManager implements [WorkflowManager] with configurable returns.
 // All methods are safe for concurrent use.
 type stubWorkflowManager struct {
-	mu       sync.RWMutex
-	config   config.ServiceConfig
-	template *prompt.Template
-	reloadFn func() error
-	absPath  string
+	mu            sync.RWMutex
+	config        config.ServiceConfig
+	template      *prompt.Template
+	templateIndex map[string]*prompt.Template
+	reloadFn      func() error
+	absPath       string
 }
 
 func (s *stubWorkflowManager) Config() config.ServiceConfig {
@@ -44,6 +45,20 @@ func (s *stubWorkflowManager) PromptTemplate() *prompt.Template {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	return s.template
+}
+
+func (s *stubWorkflowManager) PromptTemplateByID(id string) *prompt.Template {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.templateIndex != nil {
+		if tmpl, ok := s.templateIndex[id]; ok {
+			return tmpl
+		}
+	}
+	if id == "" {
+		return s.template
+	}
+	return nil
 }
 
 func (s *stubWorkflowManager) Reload() error {
@@ -648,7 +663,7 @@ func TestMakeWorkerFn(t *testing.T) {
 			Issue:      issue,
 		}
 
-		wfn := o.makeWorkerFn("", "")
+		wfn := o.makeWorkerFn("", "", "", "", nil)
 
 		exitDone := make(chan struct{})
 		go func() {
@@ -710,7 +725,7 @@ func TestMakeWorkerFn(t *testing.T) {
 			Issue:      issue,
 		}
 
-		wfn := o.makeWorkerFn("", "")
+		wfn := o.makeWorkerFn("", "", "", "", nil)
 
 		exitDone := make(chan struct{})
 		go func() {
@@ -765,7 +780,7 @@ func TestMakeWorkerFn(t *testing.T) {
 			SessionID:  "resume-sess-42",
 		}
 
-		wfn := o.makeWorkerFn("resume-sess-42", "")
+		wfn := o.makeWorkerFn("resume-sess-42", "", "", "", nil)
 
 		exitDone := make(chan struct{})
 		go func() {
@@ -819,7 +834,7 @@ func TestMakeWorkerFn(t *testing.T) {
 			Issue:      issue,
 		}
 
-		wfn := o.makeWorkerFn("", "")
+		wfn := o.makeWorkerFn("", "", "", "", nil)
 
 		exitDone := make(chan struct{})
 		go func() {
@@ -4461,5 +4476,246 @@ func TestHandleTick_WorkerWarningChangeDetection(t *testing.T) {
 	o.handleTick(ctx)
 	if got := strings.Count(buf.String(), warnMsg); got != 2 {
 		t.Errorf("warning count after changing SSHHosts only = %d, want 2\nlog:\n%s", got, buf.String())
+	}
+}
+
+// TestTickLogging_DispatchBreakdown verifies that the "tick completed" log
+// entry carries the dispatched_by_rule, dispatched_by_default, and
+// dispatched_by_fallback counters reflecting the actual resolution layers
+// used for each dispatched issue.
+func TestTickLogging_DispatchBreakdown(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	cfg := lifecycleConfig(tmpDir)
+
+	// Wire a dispatch config with one named rule that matches label "bug".
+	// Issue A-1 carries the label → resolved from rule.
+	// Issue A-2 carries no label → falls through to fallback (no default configured).
+	cfg.Dispatch = config.DispatchConfig{
+		Rules: []config.DispatchRule{
+			{
+				Name:       "bug-rule",
+				Match:      config.DispatchMatch{Labels: []string{"bug"}},
+				Selection:  config.DispatchSelection{},
+				IsCatchAll: false,
+			},
+		},
+	}
+
+	issues := []domain.Issue{
+		{ID: "id-1", Identifier: "A-1", Title: "Bug fix", State: "To Do", Labels: []string{"bug"}},
+		{ID: "id-2", Identifier: "A-2", Title: "Feature", State: "To Do"},
+	}
+
+	tmpl := mustParseTemplate(t, "work on {{ .issue.identifier }}")
+
+	lb := &lockedBuf{}
+	logger := slog.New(slog.NewTextHandler(lb, nil))
+
+	pf := passingPreflightRegistries()
+	pf.ReloadWorkflow = func() error { return nil }
+	pf.ConfigFunc = func() config.ServiceConfig { return cfg }
+
+	o := NewOrchestrator(OrchestratorParams{
+		State:  NewState(1000, 5, nil, AgentTotals{}),
+		Logger: logger,
+		TrackerAdapter: &candidateTrackerAdapter{
+			mockTrackerAdapter: &mockTrackerAdapter{},
+			fetchCandidatesFn: func(_ context.Context) ([]domain.Issue, error) {
+				return issues, nil
+			},
+		},
+		AgentAdapter:    &mockAgentAdapter{},
+		WorkflowManager: &stubWorkflowManager{config: cfg, template: tmpl},
+		Store:           &stubStore{},
+		PreflightParams: pf,
+	})
+
+	o.handleTick(context.Background())
+	o.state.WorkerWg.Wait()
+
+	got := lb.String()
+
+	if !strings.Contains(got, "tick completed") {
+		t.Fatalf("log missing 'tick completed': %s", got)
+	}
+	if !strings.Contains(got, "dispatched=2") {
+		t.Errorf("log missing dispatched=2: %s", got)
+	}
+	// One issue matched the named rule.
+	if !strings.Contains(got, "dispatched_by_rule=1") {
+		t.Errorf("log missing dispatched_by_rule=1: %s", got)
+	}
+	// No default configured, no default dispatch.
+	if !strings.Contains(got, "dispatched_by_default=0") {
+		t.Errorf("log missing dispatched_by_default=0: %s", got)
+	}
+	// One issue fell through to fallback.
+	if !strings.Contains(got, "dispatched_by_fallback=1") {
+		t.Errorf("log missing dispatched_by_fallback=1: %s", got)
+	}
+}
+
+// TestDispatch_RuleResolvedKindPersistsToRunHistory is a regression test for
+// the freeze-on-dispatch wiring through
+// ResolveRule → RunningEntry.AgentKind → WorkerDeps.AgentKind →
+// WorkerResult.AgentAdapter → RunHistory.AgentAdapter.
+//
+// Before the fix, RunWorkerAttempt always populated WorkerResult.AgentAdapter
+// from cfg.Agent.Kind (the workflow default) instead of deps.AgentKind, so
+// a rule that routed an issue to a non-default agent kind caused run_history
+// to record the wrong adapter name.
+func TestDispatch_RuleResolvedKindPersistsToRunHistory(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	cfg := lifecycleConfig(tmpDir)
+
+	// Workflow default is "claude-code". One rule routes issues labelled "bug"
+	// to "codex". The second issue carries no "bug" label and falls through to
+	// the workflow-wide fallback ("claude-code").
+	cfg.Agent.Kind = "claude-code"
+	cfg.Dispatch = config.DispatchConfig{
+		Rules: []config.DispatchRule{
+			{
+				Name:      "bug-router",
+				Match:     config.DispatchMatch{Labels: []string{"bug"}},
+				Selection: config.DispatchSelection{AgentKind: "codex"},
+			},
+		},
+	}
+
+	bugIssue := domain.Issue{
+		ID:         "id-bug",
+		Identifier: "DISP-1",
+		Title:      "Bug fix",
+		State:      "To Do",
+		Labels:     []string{"bug"},
+	}
+	docsIssue := domain.Issue{
+		ID:         "id-docs",
+		Identifier: "DISP-2",
+		Title:      "Docs update",
+		State:      "To Do",
+		Labels:     []string{"docs"},
+	}
+
+	tmpl := mustParseTemplate(t, "work on {{ .issue.identifier }}")
+
+	codexAdapter := &mockAgentAdapter{}
+	claudeAdapter := &mockAgentAdapter{}
+
+	tracker := &candidateTrackerAdapter{
+		mockTrackerAdapter: &mockTrackerAdapter{
+			fetchStatesFn: func(_ context.Context, ids []string) (map[string]string, error) {
+				result := make(map[string]string, len(ids))
+				for _, id := range ids {
+					result[id] = "Done"
+				}
+				return result, nil
+			},
+		},
+		fetchCandidatesFn: func(_ context.Context) ([]domain.Issue, error) {
+			return []domain.Issue{bugIssue, docsIssue}, nil
+		},
+	}
+
+	wm := &stubWorkflowManager{config: cfg, template: tmpl}
+	store := &stubStore{}
+	regs := passingPreflightRegistries()
+
+	state := NewState(cfg.Polling.IntervalMS, cfg.Agent.MaxConcurrentAgents, nil, AgentTotals{})
+	o := NewOrchestrator(OrchestratorParams{
+		State:          state,
+		Logger:         discardLogger(),
+		TrackerAdapter: tracker,
+		AgentAdapter:   claudeAdapter,
+		AgentAdapterByKind: func(kind string) (domain.AgentAdapter, error) {
+			switch kind {
+			case "codex":
+				return codexAdapter, nil
+			case "claude-code":
+				return claudeAdapter, nil
+			default:
+				return nil, fmt.Errorf("unknown agent kind %q", kind)
+			}
+		},
+		WorkflowManager: wm,
+		Store:           store,
+		PreflightParams: PreflightParams{
+			ReloadWorkflow:  func() error { return nil },
+			ConfigFunc:      wm.Config,
+			TrackerRegistry: regs.TrackerRegistry,
+			AgentRegistry:   regs.AgentRegistry,
+		},
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		o.Run(ctx)
+		close(done)
+	}()
+
+	// Wait until both issues have produced a RunHistory row.
+	deadline := time.After(15 * time.Second)
+	for {
+		select {
+		case <-deadline:
+			cancel()
+			<-done
+			store.mu.Lock()
+			n := len(store.runHistories)
+			store.mu.Unlock()
+			t.Fatalf("timed out: run histories = %d, want 2", n)
+		default:
+		}
+		store.mu.Lock()
+		n := len(store.runHistories)
+		store.mu.Unlock()
+		if n >= 2 {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	cancel()
+	<-done
+
+	// Index rows by IssueID so assertion order is independent of dispatch order.
+	store.mu.Lock()
+	rows := make(map[string]persistence.RunHistory, len(store.runHistories))
+	for _, rh := range store.runHistories {
+		rows[rh.IssueID] = rh
+	}
+	store.mu.Unlock()
+
+	if len(rows) != 2 {
+		t.Fatalf("len(runHistories) = %d, want 2", len(rows))
+	}
+
+	// Rule-routed issue: must record the rule-resolved kind, not the workflow default.
+	bugRow, ok := rows[bugIssue.ID]
+	if !ok {
+		t.Fatalf("no RunHistory row for bug issue %q", bugIssue.ID)
+	}
+	if bugRow.AgentAdapter != "codex" {
+		t.Errorf("RunHistory(%q).AgentAdapter = %q, want %q", bugIssue.Identifier, bugRow.AgentAdapter, "codex")
+	}
+	if bugRow.RuleName != "bug-router" {
+		t.Errorf("RunHistory(%q).RuleName = %q, want %q", bugIssue.Identifier, bugRow.RuleName, "bug-router")
+	}
+
+	// Fallback issue: must record the workflow-wide default kind.
+	docsRow, ok := rows[docsIssue.ID]
+	if !ok {
+		t.Fatalf("no RunHistory row for docs issue %q", docsIssue.ID)
+	}
+	if docsRow.AgentAdapter != "claude-code" {
+		t.Errorf("RunHistory(%q).AgentAdapter = %q, want %q", docsIssue.Identifier, docsRow.AgentAdapter, "claude-code")
+	}
+	if docsRow.RuleName != "" {
+		t.Errorf("RunHistory(%q).RuleName = %q, want %q", docsIssue.Identifier, docsRow.RuleName, "")
 	}
 }

--- a/internal/orchestrator/reconcile.go
+++ b/internal/orchestrator/reconcile.go
@@ -205,6 +205,9 @@ func reconcileStalled(state *State, params ReconcileParams, log *slog.Logger, ct
 			SessionID:           entry.SessionID,
 			ContinuationContext: entry.ContinuationContext,
 			ReactionKind:        entry.ReactionKind,
+			AgentKind:           entry.AgentKind,
+			RuleName:            entry.RuleName,
+			TemplateID:          entry.TemplateID,
 		}, params.OnRetryFire)
 		metrics.IncRetries(triggerStall)
 
@@ -228,6 +231,9 @@ func reconcileStalled(state *State, params ReconcileParams, log *slog.Logger, ct
 				Attempt:    retryEntry.Attempt,
 				DueAtMs:    retryEntry.DueAtMS,
 				Error:      stringPtr(retryEntry.Error),
+				RuleName:   retryEntry.RuleName,
+				TemplateID: retryEntry.TemplateID,
+				AgentKind:  retryEntry.AgentKind,
 			}
 			if err := params.Store.SaveRetryEntry(ctx, pEntry); err != nil {
 				entryLog.Error("failed to persist stall retry entry",

--- a/internal/orchestrator/recovery.go
+++ b/internal/orchestrator/recovery.go
@@ -299,8 +299,9 @@ func recoverPendingReactionKinds(
 					Branch:   meta.Branch,
 					SHA:      meta.SHA,
 				},
-				AgentKind: run.AgentAdapter,
-				RuleName:  run.RuleName,
+				AgentKind:  run.AgentAdapter,
+				RuleName:   run.RuleName,
+				TemplateID: run.TemplateID,
 			}
 			outcome.ReviewRecovered++
 			added++
@@ -321,8 +322,9 @@ func recoverPendingReactionKinds(
 					Branch: meta.Branch,
 					SHA:    meta.SHA,
 				},
-				AgentKind: run.AgentAdapter,
-				RuleName:  run.RuleName,
+				AgentKind:  run.AgentAdapter,
+				RuleName:   run.RuleName,
+				TemplateID: run.TemplateID,
 			}
 			outcome.CIRecovered++
 			added++

--- a/internal/orchestrator/recovery.go
+++ b/internal/orchestrator/recovery.go
@@ -19,9 +19,18 @@ import (
 // scheduledDelayMS for later activation. The issue is marked as Claimed
 // to prevent double-dispatch on the first poll tick.
 //
+// Legacy rows persisted before dispatch rule routing was added carry
+// an empty AgentKind. The orchestrator treats the empty value as the
+// workflow-wide default during retry dispatch; a one-shot audit log
+// records each legacy row so operators can correlate the routing
+// decision with run history.
+//
 // Must be called before [NewOrchestrator] so the retry timer channel
 // buffer can be sized to accommodate immediate-fire entries.
-func PopulateRetries(state *State, entries []persistence.PendingRetry) {
+func PopulateRetries(state *State, entries []persistence.PendingRetry, log *slog.Logger) {
+	if log == nil {
+		log = slog.Default()
+	}
 	for _, pending := range entries {
 		e := pending.Entry
 
@@ -42,9 +51,19 @@ func PopulateRetries(state *State, entries []persistence.PendingRetry) {
 			Attempt:          e.Attempt,
 			DueAtMS:          e.DueAtMs,
 			Error:            errStr,
+			RuleName:         e.RuleName,
+			TemplateID:       e.TemplateID,
+			AgentKind:        e.AgentKind,
 			scheduledDelayMS: pending.RemainingMs,
 		}
 		state.Claimed[e.IssueID] = struct{}{}
+
+		if e.AgentKind == "" {
+			log.Info("rehydrated legacy retry entry without agent kind",
+				slog.String("recovery", "legacy_retry_default_agent"),
+				slog.String("issue_id", e.IssueID),
+			)
+		}
 	}
 }
 
@@ -280,6 +299,8 @@ func recoverPendingReactionKinds(
 					Branch:   meta.Branch,
 					SHA:      meta.SHA,
 				},
+				AgentKind: run.AgentAdapter,
+				RuleName:  run.RuleName,
 			}
 			outcome.ReviewRecovered++
 			added++
@@ -300,6 +321,8 @@ func recoverPendingReactionKinds(
 					Branch: meta.Branch,
 					SHA:    meta.SHA,
 				},
+				AgentKind: run.AgentAdapter,
+				RuleName:  run.RuleName,
 			}
 			outcome.CIRecovered++
 			added++

--- a/internal/orchestrator/recovery_test.go
+++ b/internal/orchestrator/recovery_test.go
@@ -59,7 +59,7 @@ func TestPopulateRetries(t *testing.T) {
 			},
 		}
 
-		PopulateRetries(state, entries)
+		PopulateRetries(state, entries, nil)
 
 		if len(state.RetryAttempts) != 3 {
 			t.Fatalf("RetryAttempts count = %d, want 3", len(state.RetryAttempts))
@@ -112,7 +112,7 @@ func TestPopulateRetries(t *testing.T) {
 		t.Parallel()
 
 		state := NewState(5000, 4, nil, AgentTotals{})
-		PopulateRetries(state, nil)
+		PopulateRetries(state, nil, nil)
 
 		if len(state.RetryAttempts) != 0 {
 			t.Errorf("RetryAttempts count = %d, want 0", len(state.RetryAttempts))
@@ -371,7 +371,7 @@ func TestPopulateRetries_SessionID(t *testing.T) {
 		},
 	}
 
-	PopulateRetries(state, entries)
+	PopulateRetries(state, entries, nil)
 
 	got, ok := state.RetryAttempts["id-sess"]
 	if !ok {
@@ -399,7 +399,7 @@ func TestPopulateRetries_SessionID_Nil(t *testing.T) {
 		},
 	}
 
-	PopulateRetries(state, entries)
+	PopulateRetries(state, entries, nil)
 
 	got, ok := state.RetryAttempts["id-nosess"]
 	if !ok {

--- a/internal/orchestrator/retry.go
+++ b/internal/orchestrator/retry.go
@@ -71,6 +71,14 @@ type HandleRetryTimerParams struct {
 	// persisted retry row.
 	AgentAdapterByKind func(kind string) (domain.AgentAdapter, error)
 
+	// DefaultAgentKind is the workflow-wide default agent kind used
+	// when a popped retry entry carries an empty AgentKind (legacy
+	// rows persisted before dispatch rule routing was added). The
+	// retry handler coalesces the empty value to this default before
+	// adapter resolution, worker construction, and running-entry
+	// assignment so downstream state reflects the actual kind used.
+	DefaultAgentKind string
+
 	// OnRetryFire is the callback for re-scheduled retry timers.
 	// Routes back into the event loop.
 	OnRetryFire func(issueID string)
@@ -383,11 +391,21 @@ func HandleRetryTimer(state *State, issueID string, params HandleRetryTimerParam
 		panic("HandleRetryTimer: nil AgentAdapterByKind")
 	}
 
-	adapter, adapterErr := params.AgentAdapterByKind(popped.AgentKind)
+	// Legacy retry rows persisted before dispatch rule routing was
+	// added carry an empty AgentKind. Coalesce to the workflow-wide
+	// default so adapter resolution, worker construction, and the
+	// running-entry record below all observe a concrete kind. The
+	// one-shot audit log is emitted at recovery time by PopulateRetries.
+	agentKind := popped.AgentKind
+	if agentKind == "" {
+		agentKind = params.DefaultAgentKind
+	}
+
+	adapter, adapterErr := params.AgentAdapterByKind(agentKind)
 	if adapterErr != nil {
 		log.Error("retry agent kind unavailable",
 			slog.String("rule_name", popped.RuleName),
-			slog.String("agent_kind", popped.AgentKind),
+			slog.String("agent_kind", agentKind),
 			slog.Any("error", adapterErr),
 		)
 		delete(state.Claimed, issueID)
@@ -411,10 +429,10 @@ func HandleRetryTimer(state *State, issueID string, params HandleRetryTimerParam
 	if popped.ContinuationContext != nil {
 		dispatchCtx = WithContinuationContext(ctx, popped.ContinuationContext)
 	}
-	DispatchIssue(dispatchCtx, state, issue, &attempt, host, params.MakeWorkerFn(popped.SessionID, host, popped.AgentKind, popped.TemplateID, adapter))
+	DispatchIssue(dispatchCtx, state, issue, &attempt, host, params.MakeWorkerFn(popped.SessionID, host, agentKind, popped.TemplateID, adapter))
 	if entry := state.Running[issue.ID]; entry != nil {
 		entry.WorkflowFile = params.WorkflowFile
-		entry.AgentKind = popped.AgentKind
+		entry.AgentKind = agentKind
 		entry.RuleName = popped.RuleName
 		entry.TemplateID = popped.TemplateID
 		entry.ContinuationContext = popped.ContinuationContext

--- a/internal/orchestrator/retry.go
+++ b/internal/orchestrator/retry.go
@@ -57,9 +57,19 @@ type HandleRetryTimerParams struct {
 	MaxRetryBackoffMS int
 
 	// MakeWorkerFn constructs a [WorkerFunc] for the given resume
-	// session ID and SSH host. Replaces the former WorkerFn field to
-	// allow the retry handler to pass the acquired SSH host at fire time.
-	MakeWorkerFn func(resumeSessionID string, sshHost string) WorkerFunc
+	// session ID, SSH host, dispatch-frozen agent kind and template
+	// ID, and resolved adapter. The retry handler resolves the
+	// adapter through AgentAdapterByKind before invoking this
+	// constructor; the closure no longer performs adapter lookup
+	// itself.
+	MakeWorkerFn func(resumeSessionID, sshHost, agentKind, templateID string, adapter domain.AgentAdapter) WorkerFunc
+
+	// AgentAdapterByKind resolves the agent adapter for the given
+	// kind. Required when MakeWorkerFn is set. Returns a wrapped
+	// *registry.RegistryError when the kind is unknown; the retry
+	// handler logs the error, releases the claim, and deletes the
+	// persisted retry row.
+	AgentAdapterByKind func(kind string) (domain.AgentAdapter, error)
 
 	// OnRetryFire is the callback for re-scheduled retry timers.
 	// Routes back into the event loop.
@@ -89,10 +99,6 @@ type HandleRetryTimerParams struct {
 	// WorkflowFile is the base filename of the active WORKFLOW.md file.
 	// Recorded on the RunningEntry for observability.
 	WorkflowFile string
-
-	// AgentKind is the adapter kind string from the active workflow
-	// config. Recorded on the RunningEntry for cost estimation.
-	AgentKind string
 }
 
 // HandleRetryTimer processes a retry timer event for the given issue.
@@ -153,6 +159,9 @@ func HandleRetryTimer(state *State, issueID string, params HandleRetryTimerParam
 			SessionID:           popped.SessionID,
 			ContinuationContext: popped.ContinuationContext,
 			ReactionKind:        popped.ReactionKind,
+			AgentKind:           popped.AgentKind,
+			RuleName:            popped.RuleName,
+			TemplateID:          popped.TemplateID,
 		}, params.OnRetryFire)
 		if isKnownReactionKind(popped.ReactionKind) {
 			if err := params.Store.DeleteRetryEntry(ctx, issueID); err != nil {
@@ -370,6 +379,30 @@ func HandleRetryTimer(state *State, issueID string, params HandleRetryTimerParam
 		panic("HandleRetryTimer: nil MakeWorkerFn")
 	}
 
+	if params.AgentAdapterByKind == nil {
+		panic("HandleRetryTimer: nil AgentAdapterByKind")
+	}
+
+	adapter, adapterErr := params.AgentAdapterByKind(popped.AgentKind)
+	if adapterErr != nil {
+		log.Error("retry agent kind unavailable",
+			slog.String("rule_name", popped.RuleName),
+			slog.String("agent_kind", popped.AgentKind),
+			slog.Any("error", adapterErr),
+		)
+		delete(state.Claimed, issueID)
+		if delErr := params.Store.DeleteRetryEntry(ctx, issueID); delErr != nil {
+			log.Error("failed to delete retry entry after agent kind lookup failure",
+				slog.Any("error", delErr),
+			)
+		}
+		if params.HostPool != nil && host != "" {
+			params.HostPool.ReleaseHost(issueID)
+		}
+		metrics.IncRetries(triggerError)
+		return
+	}
+
 	// Dispatch the issue with the popped entry's attempt number.
 	// Pass the popped attempt as-is; NextAttempt increments only on the
 	// next worker exit, not at dispatch time.
@@ -378,10 +411,12 @@ func HandleRetryTimer(state *State, issueID string, params HandleRetryTimerParam
 	if popped.ContinuationContext != nil {
 		dispatchCtx = WithContinuationContext(ctx, popped.ContinuationContext)
 	}
-	DispatchIssue(dispatchCtx, state, issue, &attempt, host, params.MakeWorkerFn(popped.SessionID, host))
+	DispatchIssue(dispatchCtx, state, issue, &attempt, host, params.MakeWorkerFn(popped.SessionID, host, popped.AgentKind, popped.TemplateID, adapter))
 	if entry := state.Running[issue.ID]; entry != nil {
 		entry.WorkflowFile = params.WorkflowFile
-		entry.AgentKind = params.AgentKind
+		entry.AgentKind = popped.AgentKind
+		entry.RuleName = popped.RuleName
+		entry.TemplateID = popped.TemplateID
 		entry.ContinuationContext = popped.ContinuationContext
 		entry.ReactionKind = popped.ReactionKind
 	}
@@ -442,6 +477,9 @@ func persistRetryEntry(ctx context.Context, log *slog.Logger, store RetryTimerSt
 		DueAtMs:    retryEntry.DueAtMS,
 		Error:      stringPtr(retryEntry.Error),
 		SessionID:  stringPtr(retryEntry.SessionID),
+		RuleName:   retryEntry.RuleName,
+		TemplateID: retryEntry.TemplateID,
+		AgentKind:  retryEntry.AgentKind,
 	}
 	if err := store.SaveRetryEntry(ctx, pEntry); err != nil {
 		log.Error("failed to persist retry entry",

--- a/internal/orchestrator/retry_test.go
+++ b/internal/orchestrator/retry_test.go
@@ -161,10 +161,13 @@ func defaultRetryParams(t *testing.T, store *mockRetryStore, tracker *mockRetryT
 		ActiveStates:      []string{"To Do", "In Progress"},
 		TerminalStates:    []string{"Done"},
 		MaxRetryBackoffMS: 300_000,
-		MakeWorkerFn:      func(_, _ string) WorkerFunc { return func(_ context.Context, _ domain.Issue, _ *int) {} },
-		OnRetryFire:       noopRetryFire,
-		Ctx:               context.Background(),
-		Logger:            discardLogger(),
+		MakeWorkerFn: func(_, _, _, _ string, _ domain.AgentAdapter) WorkerFunc {
+			return func(_ context.Context, _ domain.Issue, _ *int) {}
+		},
+		AgentAdapterByKind: func(_ string) (domain.AgentAdapter, error) { return &mockAgentAdapter{}, nil },
+		OnRetryFire:        noopRetryFire,
+		Ctx:                context.Background(),
+		Logger:             discardLogger(),
 	}
 }
 
@@ -1101,7 +1104,7 @@ func TestHandleRetryTimer(t *testing.T) {
 			if tt.workerFn != nil {
 				ch := make(chan struct{}, 1)
 				wf := tt.workerFn(ch)
-				params.MakeWorkerFn = func(_, _ string) WorkerFunc { return wf }
+				params.MakeWorkerFn = func(_, _, _, _ string, _ domain.AgentAdapter) WorkerFunc { return wf }
 				HandleRetryTimer(state, id, params)
 				select {
 				case <-ch:
@@ -1135,7 +1138,7 @@ func TestHandleRetryTimer_WorkerStillRunningReschedulesInsteadOfDispatching(t *t
 	params := defaultRetryParams(t, store, tracker)
 
 	workerCalled := false
-	params.MakeWorkerFn = func(_, _ string) WorkerFunc {
+	params.MakeWorkerFn = func(_, _, _, _ string, _ domain.AgentAdapter) WorkerFunc {
 		return func(_ context.Context, _ domain.Issue, _ *int) {
 			workerCalled = true
 		}
@@ -1200,7 +1203,7 @@ func TestHandleRetryTimer_SSHHostAcquisition(t *testing.T) {
 		params.HostPool = hp
 
 		ch := make(chan struct{}, 1)
-		params.MakeWorkerFn = func(_, sshHost string) WorkerFunc {
+		params.MakeWorkerFn = func(_, sshHost, _, _ string, _ domain.AgentAdapter) WorkerFunc {
 			return func(_ context.Context, _ domain.Issue, _ *int) {
 				if sshHost != "host-b" {
 					t.Errorf("MakeWorkerFn sshHost = %q, want \"host-b\" (preferred)", sshHost)
@@ -1348,7 +1351,7 @@ func TestHandleRetryTimer_WorkflowFilePropagated(t *testing.T) {
 	params.WorkflowFile = "infra.WORKFLOW.md"
 
 	workerCalled := make(chan struct{}, 1)
-	params.MakeWorkerFn = func(_, _ string) WorkerFunc {
+	params.MakeWorkerFn = func(_, _, _, _ string, _ domain.AgentAdapter) WorkerFunc {
 		return func(_ context.Context, _ domain.Issue, _ *int) {
 			workerCalled <- struct{}{}
 		}
@@ -1665,7 +1668,7 @@ func TestHandleRetryTimer_SessionID_PassedToMakeWorkerFn(t *testing.T) {
 
 	var gotSessionID string
 	ch := make(chan struct{}, 1)
-	params.MakeWorkerFn = func(resumeSessionID, _ string) WorkerFunc {
+	params.MakeWorkerFn = func(resumeSessionID, _, _, _ string, _ domain.AgentAdapter) WorkerFunc {
 		gotSessionID = resumeSessionID
 		return func(_ context.Context, _ domain.Issue, _ *int) {
 			ch <- struct{}{}
@@ -2336,5 +2339,220 @@ func TestHandleRetryTimer_HandoffReactionStartsWithoutExistingClaim(t *testing.T
 	}
 	if _, claimed := state.Claimed[id]; !claimed {
 		t.Errorf("Claimed[%s] absent after dispatch, want DispatchIssue to add claim", id)
+	}
+}
+
+// --- Frozen-selection tests ---
+
+// TestHandleRetryTimer_FrozenFieldsPropagatedToRunningEntry verifies that
+// AgentKind, RuleName, and TemplateID are copied from the retry entry into
+// the RunningEntry after dispatch so the fields are preserved across retries.
+func TestHandleRetryTimer_FrozenFieldsPropagatedToRunningEntry(t *testing.T) {
+	t.Parallel()
+
+	const id = "ISS-FROZEN"
+	const wantAgentKind = "claude-code"
+	const wantRuleName = "bug-rule"
+	const wantTemplateID = "/abs/prompts/bug.md"
+
+	state := NewState(5000, 4, nil, AgentTotals{})
+	state.RetryAttempts[id] = &RetryEntry{
+		IssueID:    id,
+		Identifier: id,
+		Attempt:    2,
+		AgentKind:  wantAgentKind,
+		RuleName:   wantRuleName,
+		TemplateID: wantTemplateID,
+	}
+	state.Claimed[id] = struct{}{}
+
+	store := &mockRetryStore{}
+	tracker := &mockRetryTracker{
+		fetchedIssue: candidateIssue(id, id, "To Do"),
+	}
+
+	var capturedAgentKind, capturedTemplateID string
+	params := defaultRetryParams(t, store, tracker)
+	params.MakeWorkerFn = func(_, _, agentKind, templateID string, _ domain.AgentAdapter) WorkerFunc {
+		capturedAgentKind = agentKind
+		capturedTemplateID = templateID
+		return func(_ context.Context, _ domain.Issue, _ *int) {}
+	}
+	params.AgentAdapterByKind = func(kind string) (domain.AgentAdapter, error) {
+		if kind != wantAgentKind {
+			t.Errorf("AgentAdapterByKind(kind) = %q, want %q", kind, wantAgentKind)
+		}
+		return &mockAgentAdapter{}, nil
+	}
+
+	HandleRetryTimer(state, id, params)
+	t.Cleanup(func() { state.WorkerWg.Wait() })
+
+	entry, ok := state.Running[id]
+	if !ok {
+		t.Fatal("Running entry missing after retry dispatch")
+	}
+
+	if entry.AgentKind != wantAgentKind {
+		t.Errorf("RunningEntry.AgentKind = %q, want %q", entry.AgentKind, wantAgentKind)
+	}
+	if entry.RuleName != wantRuleName {
+		t.Errorf("RunningEntry.RuleName = %q, want %q", entry.RuleName, wantRuleName)
+	}
+	if entry.TemplateID != wantTemplateID {
+		t.Errorf("RunningEntry.TemplateID = %q, want %q", entry.TemplateID, wantTemplateID)
+	}
+	if capturedAgentKind != wantAgentKind {
+		t.Errorf("MakeWorkerFn agentKind = %q, want %q", capturedAgentKind, wantAgentKind)
+	}
+	if capturedTemplateID != wantTemplateID {
+		t.Errorf("MakeWorkerFn templateID = %q, want %q", capturedTemplateID, wantTemplateID)
+	}
+}
+
+// TestHandleRetryTimer_ReschedulePreservesFrozenFields verifies that when a
+// retry is rescheduled (e.g., no available slots), the frozen AgentKind,
+// RuleName, and TemplateID are preserved in the new RetryEntry.
+func TestHandleRetryTimer_ReschedulePreservesFrozenFields(t *testing.T) {
+	t.Parallel()
+
+	const id = "ISS-RESCHED"
+	const wantAgentKind = "copilot"
+	const wantRuleName = "feature-rule"
+	const wantTemplateID = "/abs/prompts/feature.md"
+
+	// Fill all slots so dispatch is blocked and the retry is rescheduled.
+	state := NewState(1, 1, nil, AgentTotals{})
+	state.RetryAttempts[id] = &RetryEntry{
+		IssueID:    id,
+		Identifier: id,
+		Attempt:    1,
+		AgentKind:  wantAgentKind,
+		RuleName:   wantRuleName,
+		TemplateID: wantTemplateID,
+	}
+	state.Claimed[id] = struct{}{}
+	// Occupy the single slot.
+	state.Running["OTHER"] = &RunningEntry{Identifier: "OTHER"}
+
+	store := &mockRetryStore{}
+	tracker := &mockRetryTracker{
+		fetchedIssue: candidateIssue(id, id, "To Do"),
+	}
+	params := defaultRetryParams(t, store, tracker)
+
+	HandleRetryTimer(state, id, params)
+
+	newEntry, ok := state.RetryAttempts[id]
+	if !ok {
+		t.Fatal("RetryAttempts entry missing after no-slots reschedule")
+	}
+	if newEntry.AgentKind != wantAgentKind {
+		t.Errorf("RetryEntry.AgentKind = %q, want %q", newEntry.AgentKind, wantAgentKind)
+	}
+	if newEntry.RuleName != wantRuleName {
+		t.Errorf("RetryEntry.RuleName = %q, want %q", newEntry.RuleName, wantRuleName)
+	}
+	if newEntry.TemplateID != wantTemplateID {
+		t.Errorf("RetryEntry.TemplateID = %q, want %q", newEntry.TemplateID, wantTemplateID)
+	}
+	if newEntry.TimerHandle != nil {
+		newEntry.TimerHandle.Stop()
+	}
+}
+
+// TestHandleRetryTimer_FrozenFieldsPersistedOnReschedule verifies that when a
+// retry is rescheduled, the SQLite row captures the frozen AgentKind, RuleName,
+// and TemplateID so they survive a process restart.
+func TestHandleRetryTimer_FrozenFieldsPersistedOnReschedule(t *testing.T) {
+	t.Parallel()
+
+	const id = "ISS-PERSIST"
+	const wantAgentKind = "codex"
+	const wantRuleName = "docs-rule"
+	const wantTemplateID = "/abs/prompts/docs.md"
+
+	// Fill all slots to force reschedule.
+	state := NewState(1, 1, nil, AgentTotals{})
+	state.RetryAttempts[id] = &RetryEntry{
+		IssueID:    id,
+		Identifier: id,
+		Attempt:    1,
+		AgentKind:  wantAgentKind,
+		RuleName:   wantRuleName,
+		TemplateID: wantTemplateID,
+	}
+	state.Claimed[id] = struct{}{}
+	state.Running["OTHER"] = &RunningEntry{Identifier: "OTHER"}
+
+	store := &mockRetryStore{}
+	tracker := &mockRetryTracker{
+		fetchedIssue: candidateIssue(id, id, "To Do"),
+	}
+	params := defaultRetryParams(t, store, tracker)
+
+	HandleRetryTimer(state, id, params)
+
+	if len(store.savedEntries) == 0 {
+		t.Fatal("SaveRetryEntry not called after reschedule")
+	}
+	saved := store.savedEntries[0]
+	if saved.AgentKind != wantAgentKind {
+		t.Errorf("saved RetryEntry.AgentKind = %q, want %q", saved.AgentKind, wantAgentKind)
+	}
+	if saved.RuleName != wantRuleName {
+		t.Errorf("saved RetryEntry.RuleName = %q, want %q", saved.RuleName, wantRuleName)
+	}
+	if saved.TemplateID != wantTemplateID {
+		t.Errorf("saved RetryEntry.TemplateID = %q, want %q", saved.TemplateID, wantTemplateID)
+	}
+	// Clean up the timer.
+	if entry, ok := state.RetryAttempts[id]; ok && entry.TimerHandle != nil {
+		entry.TimerHandle.Stop()
+	}
+}
+
+// TestHandleRetryTimer_AgentAdapterLookupUsesAgentKind verifies that when
+// AgentAdapterByKind returns an error for the frozen agent kind, the claim is
+// released and no dispatch occurs.
+func TestHandleRetryTimer_AgentAdapterLookupUsesAgentKind(t *testing.T) {
+	t.Parallel()
+
+	const id = "ISS-BADKIND"
+	const frozenKind = "unknown-agent"
+
+	state := NewState(5000, 4, nil, AgentTotals{})
+	state.RetryAttempts[id] = &RetryEntry{
+		IssueID:    id,
+		Identifier: id,
+		Attempt:    1,
+		AgentKind:  frozenKind,
+		RuleName:   "some-rule",
+		TemplateID: "",
+	}
+	state.Claimed[id] = struct{}{}
+
+	store := &mockRetryStore{}
+	tracker := &mockRetryTracker{
+		fetchedIssue: candidateIssue(id, id, "To Do"),
+	}
+	params := defaultRetryParams(t, store, tracker)
+	params.AgentAdapterByKind = func(kind string) (domain.AgentAdapter, error) {
+		if kind != frozenKind {
+			t.Errorf("AgentAdapterByKind(kind) = %q, want %q", kind, frozenKind)
+		}
+		return nil, errors.New("adapter not registered")
+	}
+
+	HandleRetryTimer(state, id, params)
+
+	if _, claimed := state.Claimed[id]; claimed {
+		t.Error("Claimed[id] still present after adapter lookup failure, want released")
+	}
+	if _, ok := state.Running[id]; ok {
+		t.Error("Running[id] present after adapter lookup failure, want not dispatched")
+	}
+	if len(store.deletedIssueID) == 0 {
+		t.Error("DeleteRetryEntry not called after adapter lookup failure")
 	}
 }

--- a/internal/orchestrator/review_reconcile.go
+++ b/internal/orchestrator/review_reconcile.go
@@ -179,6 +179,9 @@ func reconcileReviewComments(state *State, params ReconcileParams, log *slog.Log
 				"review_comments": reviewContext,
 			},
 			ReactionKind: ReactionKindReview,
+			AgentKind:    pending.AgentKind,
+			RuleName:     pending.RuleName,
+			TemplateID:   pending.TemplateID,
 		}, params.OnRetryFire)
 
 		state.ReactionAttempts[rkey]++

--- a/internal/orchestrator/route.go
+++ b/internal/orchestrator/route.go
@@ -1,0 +1,218 @@
+package orchestrator
+
+import (
+	"path"
+	"slices"
+	"strings"
+
+	"github.com/sortie-ai/sortie/internal/config"
+	"github.com/sortie-ai/sortie/internal/domain"
+)
+
+// ResolutionLayer identifies the layer that produced a dispatch
+// resolution: a matched rule, the dispatch default block, or the
+// workflow-wide fallback.
+type ResolutionLayer int
+
+const (
+	// ResolvedFromRule indicates a dispatch rule matched the issue.
+	ResolvedFromRule ResolutionLayer = 1
+
+	// ResolvedFromDefault indicates no rule matched and the dispatch
+	// default block supplied the selection.
+	ResolvedFromDefault ResolutionLayer = 2
+
+	// ResolvedFromFallback indicates neither a rule nor the dispatch
+	// default supplied a selection; the workflow-wide agent kind and
+	// the body template were used.
+	ResolvedFromFallback ResolutionLayer = 3
+)
+
+// String returns the lower-case identifier for this layer used in
+// log fields and metric label values.
+func (l ResolutionLayer) String() string {
+	switch l {
+	case ResolvedFromRule:
+		return "rule"
+	case ResolvedFromDefault:
+		return "default"
+	case ResolvedFromFallback:
+		return "fallback"
+	default:
+		return "unknown"
+	}
+}
+
+// DispatchResolution carries the agent kind, template ID, rule name,
+// and layer chosen for a single issue's initial dispatch. The
+// orchestrator persists these on [RunningEntry] and propagates them
+// through [RetryEntry] so retries and reaction continuations reuse
+// the original selection.
+type DispatchResolution struct {
+	// AgentKind is the resolved adapter kind. Always non-empty for a
+	// well-configured workflow; the resolver coalesces missing values
+	// through the fallback chain.
+	AgentKind string
+
+	// TemplateID is the resolved template registry key. The empty
+	// string selects the body template.
+	TemplateID string
+
+	// RuleName is the operator-defined name of the matched rule, or
+	// "default" when the dispatch default fired, or "" when both
+	// layers were absent.
+	RuleName string
+
+	// MatchedAt records which resolution layer produced this result.
+	MatchedAt ResolutionLayer
+}
+
+// ResolveRule selects the dispatch agent kind, template ID, and rule
+// name for an issue against a [config.DispatchConfig]. It is pure: no
+// I/O, no time dependence, no goroutine. defaultAgentKind is the
+// workflow-wide agent kind (typically cfg.Agent.Kind);
+// defaultTemplateID is the body-template sentinel (typically the
+// empty string). The same inputs always produce the same output.
+func ResolveRule(issue domain.Issue, dispatch config.DispatchConfig, defaultAgentKind, defaultTemplateID string) DispatchResolution {
+	for _, rule := range dispatch.Rules {
+		if !rule.IsCatchAll && !matchRule(rule.Match, issue) {
+			continue
+		}
+		return DispatchResolution{
+			AgentKind:  coalesce(rule.Selection.AgentKind, dispatch.Default.AgentKind, defaultAgentKind),
+			TemplateID: coalesce(rule.Selection.TemplateID, dispatch.Default.TemplateID, defaultTemplateID),
+			RuleName:   rule.Name,
+			MatchedAt:  ResolvedFromRule,
+		}
+	}
+
+	if dispatch.Default.AgentKind != "" || dispatch.Default.TemplateID != "" {
+		return DispatchResolution{
+			AgentKind:  coalesce(dispatch.Default.AgentKind, defaultAgentKind),
+			TemplateID: coalesce(dispatch.Default.TemplateID, defaultTemplateID),
+			RuleName:   "default",
+			MatchedAt:  ResolvedFromDefault,
+		}
+	}
+
+	return DispatchResolution{
+		AgentKind:  defaultAgentKind,
+		TemplateID: defaultTemplateID,
+		RuleName:   "",
+		MatchedAt:  ResolvedFromFallback,
+	}
+}
+
+// coalesce returns the first non-empty string from the arguments. An
+// all-empty call returns the empty string.
+func coalesce(values ...string) string {
+	for _, v := range values {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+// normalizeDispatchRuleName returns the rule name suitable for use as
+// a Prometheus label value. Empty rule names map to the literal
+// "<none>" sentinel so the dispatch rule match counter does not
+// emit time series with empty label values.
+func normalizeDispatchRuleName(name string) string {
+	if name == "" {
+		return "<none>"
+	}
+	return name
+}
+
+// matchRule applies AND across keys and OR within a key. An absent
+// key does not participate in the match.
+func matchRule(m config.DispatchMatch, issue domain.Issue) bool {
+	if len(m.Labels) > 0 {
+		if !anyGlobMatch(m.Labels, issue.Labels) {
+			return false
+		}
+	}
+	if len(m.IssueType) > 0 {
+		if !anyCIEq(m.IssueType, issue.IssueType) {
+			return false
+		}
+	}
+	if len(m.Assignee) > 0 {
+		if !anyCIEq(m.Assignee, issue.Assignee) {
+			return false
+		}
+	}
+	if len(m.Identifier) > 0 {
+		if !anyGlobMatch(m.Identifier, []string{issue.Identifier}) {
+			return false
+		}
+	}
+	if m.Priority != nil {
+		if issue.Priority == nil {
+			return false
+		}
+		if !priorityPredicateMatch(m.Priority, *issue.Priority) {
+			return false
+		}
+	}
+	return true
+}
+
+// anyGlobMatch reports whether any candidate value matches any
+// pattern under [path.Match] semantics. Builder pre-validation
+// guarantees pattern syntax; a runtime error treats the pair as
+// non-matching but does not block other pattern/value combinations.
+func anyGlobMatch(patterns, values []string) bool {
+	for _, p := range patterns {
+		for _, v := range values {
+			ok, err := path.Match(p, v)
+			if err != nil {
+				continue
+			}
+			if ok {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// anyCIEq reports whether value equals any entry in allowed under
+// case-insensitive comparison. Empty value never matches a non-empty
+// allowed entry, so issues without an assignee never satisfy an
+// assignee rule.
+func anyCIEq(allowed []string, value string) bool {
+	if value == "" {
+		return false
+	}
+	lower := strings.ToLower(value)
+	for _, a := range allowed {
+		if strings.ToLower(a) == lower {
+			return true
+		}
+	}
+	return false
+}
+
+// priorityPredicateMatch dispatches by operator. Unknown operators
+// return false defensively; the builder rejects unknown operators at
+// load time.
+func priorityPredicateMatch(p *config.PriorityPredicate, value int) bool {
+	switch p.Op {
+	case "eq":
+		return value == p.Value
+	case "in":
+		return slices.Contains(p.Values, value)
+	case "lt":
+		return value < p.Value
+	case "lte":
+		return value <= p.Value
+	case "gt":
+		return value > p.Value
+	case "gte":
+		return value >= p.Value
+	default:
+		return false
+	}
+}

--- a/internal/orchestrator/route_test.go
+++ b/internal/orchestrator/route_test.go
@@ -1,0 +1,643 @@
+package orchestrator
+
+import (
+	"testing"
+
+	"github.com/sortie-ai/sortie/internal/config"
+	"github.com/sortie-ai/sortie/internal/domain"
+)
+
+// --- helpers ---
+
+func prio(v int) *int { return &v }
+
+func issueWithLabels(labels ...string) domain.Issue {
+	return domain.Issue{
+		ID:         "ISS-1",
+		Identifier: "TEST-1",
+		Title:      "test issue",
+		State:      "To Do",
+		Labels:     labels,
+	}
+}
+
+// --- TestResolveRule ---
+
+func TestResolveRule(t *testing.T) {
+	t.Parallel()
+
+	const defaultKind = "claude-code"
+	const defaultTmpl = ""
+
+	tests := []struct {
+		name         string
+		issue        domain.Issue
+		dispatch     config.DispatchConfig
+		defaultKind  string
+		defaultTmpl  string
+		wantAgent    string
+		wantTemplate string
+		wantRuleName string
+		wantLayer    ResolutionLayer
+	}{
+		// --- Fallback chain ---
+		{
+			name:         "no dispatch section falls back to workflow defaults",
+			issue:        issueWithLabels("bug"),
+			dispatch:     config.DispatchConfig{},
+			defaultKind:  defaultKind,
+			defaultTmpl:  defaultTmpl,
+			wantAgent:    defaultKind,
+			wantTemplate: defaultTmpl,
+			wantRuleName: "",
+			wantLayer:    ResolvedFromFallback,
+		},
+		{
+			name:  "dispatch default fires when no rule matches",
+			issue: issueWithLabels("other"),
+			dispatch: config.DispatchConfig{
+				Rules: []config.DispatchRule{
+					{
+						Name:       "docs",
+						Match:      config.DispatchMatch{Labels: []string{"docs"}},
+						Selection:  config.DispatchSelection{AgentKind: "codex"},
+						IsCatchAll: false,
+					},
+				},
+				Default: config.DispatchSelection{AgentKind: "default-agent", TemplateID: "/tmpl/default.md"},
+			},
+			defaultKind:  defaultKind,
+			defaultTmpl:  defaultTmpl,
+			wantAgent:    "default-agent",
+			wantTemplate: "/tmpl/default.md",
+			wantRuleName: "default",
+			wantLayer:    ResolvedFromDefault,
+		},
+		{
+			name:  "dispatch default with partial fields falls through to workflow defaults",
+			issue: issueWithLabels("other"),
+			dispatch: config.DispatchConfig{
+				Default: config.DispatchSelection{AgentKind: "special-agent"},
+			},
+			defaultKind:  defaultKind,
+			defaultTmpl:  "/tmpl/body.md",
+			wantAgent:    "special-agent",
+			wantTemplate: "/tmpl/body.md",
+			wantRuleName: "default",
+			wantLayer:    ResolvedFromDefault,
+		},
+
+		// --- Rule matching ---
+		{
+			name:  "rule match returns ResolvedFromRule",
+			issue: issueWithLabels("bug"),
+			dispatch: config.DispatchConfig{
+				Rules: []config.DispatchRule{
+					{
+						Name:       "bug-rule",
+						Match:      config.DispatchMatch{Labels: []string{"bug"}},
+						Selection:  config.DispatchSelection{AgentKind: "codex", TemplateID: "/tmpl/bug.md"},
+						IsCatchAll: false,
+					},
+				},
+			},
+			defaultKind:  defaultKind,
+			defaultTmpl:  defaultTmpl,
+			wantAgent:    "codex",
+			wantTemplate: "/tmpl/bug.md",
+			wantRuleName: "bug-rule",
+			wantLayer:    ResolvedFromRule,
+		},
+		{
+			name:  "partial override agent-only uses workflow default template",
+			issue: issueWithLabels("bug"),
+			dispatch: config.DispatchConfig{
+				Rules: []config.DispatchRule{
+					{
+						Name:       "bug-agent-only",
+						Match:      config.DispatchMatch{Labels: []string{"bug"}},
+						Selection:  config.DispatchSelection{AgentKind: "codex"},
+						IsCatchAll: false,
+					},
+				},
+			},
+			defaultKind:  defaultKind,
+			defaultTmpl:  "/tmpl/body.md",
+			wantAgent:    "codex",
+			wantTemplate: "/tmpl/body.md",
+			wantRuleName: "bug-agent-only",
+			wantLayer:    ResolvedFromRule,
+		},
+		{
+			name:  "partial override template-only uses workflow default agent",
+			issue: issueWithLabels("bug"),
+			dispatch: config.DispatchConfig{
+				Rules: []config.DispatchRule{
+					{
+						Name:       "bug-tmpl-only",
+						Match:      config.DispatchMatch{Labels: []string{"bug"}},
+						Selection:  config.DispatchSelection{TemplateID: "/tmpl/bug.md"},
+						IsCatchAll: false,
+					},
+				},
+			},
+			defaultKind:  defaultKind,
+			defaultTmpl:  defaultTmpl,
+			wantAgent:    defaultKind,
+			wantTemplate: "/tmpl/bug.md",
+			wantRuleName: "bug-tmpl-only",
+			wantLayer:    ResolvedFromRule,
+		},
+
+		// --- Catch-all ---
+		{
+			name:  "catch-all rule short-circuits remaining rules",
+			issue: issueWithLabels("anything"),
+			dispatch: config.DispatchConfig{
+				Rules: []config.DispatchRule{
+					{
+						Name:       "all",
+						Match:      config.DispatchMatch{},
+						Selection:  config.DispatchSelection{AgentKind: "codex"},
+						IsCatchAll: true,
+					},
+				},
+			},
+			defaultKind:  defaultKind,
+			defaultTmpl:  defaultTmpl,
+			wantAgent:    "codex",
+			wantTemplate: defaultTmpl,
+			wantRuleName: "all",
+			wantLayer:    ResolvedFromRule,
+		},
+
+		// --- AND/OR semantics ---
+		{
+			name: "AND across keys: label matches but issue_type does not",
+			issue: domain.Issue{
+				ID: "1", Identifier: "T-1", Title: "t", State: "To Do",
+				Labels: []string{"bug"}, IssueType: "Feature",
+			},
+			dispatch: config.DispatchConfig{
+				Rules: []config.DispatchRule{
+					{
+						Name: "both",
+						Match: config.DispatchMatch{
+							Labels:    []string{"bug"},
+							IssueType: []string{"Bug"},
+						},
+						Selection:  config.DispatchSelection{AgentKind: "codex"},
+						IsCatchAll: false,
+					},
+				},
+			},
+			defaultKind:  defaultKind,
+			defaultTmpl:  defaultTmpl,
+			wantAgent:    defaultKind,
+			wantRuleName: "",
+			wantLayer:    ResolvedFromFallback,
+		},
+		{
+			name: "OR within labels: second label matches",
+			issue: domain.Issue{
+				ID: "1", Identifier: "T-1", Title: "t", State: "To Do",
+				Labels: []string{"documentation"},
+			},
+			dispatch: config.DispatchConfig{
+				Rules: []config.DispatchRule{
+					{
+						Name:       "doc-rule",
+						Match:      config.DispatchMatch{Labels: []string{"docs", "documentation"}},
+						Selection:  config.DispatchSelection{AgentKind: "codex"},
+						IsCatchAll: false,
+					},
+				},
+			},
+			defaultKind:  defaultKind,
+			defaultTmpl:  defaultTmpl,
+			wantAgent:    "codex",
+			wantRuleName: "doc-rule",
+			wantLayer:    ResolvedFromRule,
+		},
+
+		// --- Glob match ---
+		{
+			name:  "glob label match with wildcard",
+			issue: issueWithLabels("p0-critical"),
+			dispatch: config.DispatchConfig{
+				Rules: []config.DispatchRule{
+					{
+						Name:       "priority-wild",
+						Match:      config.DispatchMatch{Labels: []string{"p0-*"}},
+						Selection:  config.DispatchSelection{AgentKind: "codex"},
+						IsCatchAll: false,
+					},
+				},
+			},
+			defaultKind:  defaultKind,
+			defaultTmpl:  defaultTmpl,
+			wantAgent:    "codex",
+			wantRuleName: "priority-wild",
+			wantLayer:    ResolvedFromRule,
+		},
+		{
+			name:  "glob label no match",
+			issue: issueWithLabels("p1-minor"),
+			dispatch: config.DispatchConfig{
+				Rules: []config.DispatchRule{
+					{
+						Name:       "priority-wild",
+						Match:      config.DispatchMatch{Labels: []string{"p0-*"}},
+						Selection:  config.DispatchSelection{AgentKind: "codex"},
+						IsCatchAll: false,
+					},
+				},
+			},
+			defaultKind:  defaultKind,
+			defaultTmpl:  defaultTmpl,
+			wantAgent:    defaultKind,
+			wantRuleName: "",
+			wantLayer:    ResolvedFromFallback,
+		},
+
+		// --- Case-insensitive issue_type ---
+		{
+			name: "issue_type is case-insensitive",
+			issue: domain.Issue{
+				ID: "1", Identifier: "T-1", Title: "t", State: "To Do",
+				IssueType: "BUG",
+			},
+			dispatch: config.DispatchConfig{
+				Rules: []config.DispatchRule{
+					{
+						Name:       "bug-type",
+						Match:      config.DispatchMatch{IssueType: []string{"bug"}},
+						Selection:  config.DispatchSelection{AgentKind: "codex"},
+						IsCatchAll: false,
+					},
+				},
+			},
+			defaultKind:  defaultKind,
+			defaultTmpl:  defaultTmpl,
+			wantAgent:    "codex",
+			wantRuleName: "bug-type",
+			wantLayer:    ResolvedFromRule,
+		},
+
+		// --- Case-insensitive assignee ---
+		{
+			name: "assignee is case-insensitive",
+			issue: domain.Issue{
+				ID: "1", Identifier: "T-1", Title: "t", State: "To Do",
+				Assignee: "Alice",
+			},
+			dispatch: config.DispatchConfig{
+				Rules: []config.DispatchRule{
+					{
+						Name:       "alice-rule",
+						Match:      config.DispatchMatch{Assignee: []string{"alice"}},
+						Selection:  config.DispatchSelection{AgentKind: "codex"},
+						IsCatchAll: false,
+					},
+				},
+			},
+			defaultKind:  defaultKind,
+			defaultTmpl:  defaultTmpl,
+			wantAgent:    "codex",
+			wantRuleName: "alice-rule",
+			wantLayer:    ResolvedFromRule,
+		},
+		{
+			name: "empty assignee does not match non-empty allowed list",
+			issue: domain.Issue{
+				ID: "1", Identifier: "T-1", Title: "t", State: "To Do",
+				Assignee: "",
+			},
+			dispatch: config.DispatchConfig{
+				Rules: []config.DispatchRule{
+					{
+						Name:       "alice-rule",
+						Match:      config.DispatchMatch{Assignee: []string{"alice"}},
+						Selection:  config.DispatchSelection{AgentKind: "codex"},
+						IsCatchAll: false,
+					},
+				},
+			},
+			defaultKind:  defaultKind,
+			defaultTmpl:  defaultTmpl,
+			wantAgent:    defaultKind,
+			wantRuleName: "",
+			wantLayer:    ResolvedFromFallback,
+		},
+
+		// --- Identifier glob ---
+		{
+			name: "identifier glob match",
+			issue: domain.Issue{
+				ID: "1", Identifier: "FE-123", Title: "t", State: "To Do",
+			},
+			dispatch: config.DispatchConfig{
+				Rules: []config.DispatchRule{
+					{
+						Name:       "fe-rule",
+						Match:      config.DispatchMatch{Identifier: []string{"FE-*"}},
+						Selection:  config.DispatchSelection{AgentKind: "codex"},
+						IsCatchAll: false,
+					},
+				},
+			},
+			defaultKind:  defaultKind,
+			defaultTmpl:  defaultTmpl,
+			wantAgent:    "codex",
+			wantRuleName: "fe-rule",
+			wantLayer:    ResolvedFromRule,
+		},
+
+		// --- Priority predicates ---
+		{
+			name: "priority eq match",
+			issue: domain.Issue{
+				ID: "1", Identifier: "T-1", Title: "t", State: "To Do",
+				Priority: prio(1),
+			},
+			dispatch: config.DispatchConfig{
+				Rules: []config.DispatchRule{
+					{
+						Name:       "prio-eq",
+						Match:      config.DispatchMatch{Priority: &config.PriorityPredicate{Op: "eq", Value: 1}},
+						Selection:  config.DispatchSelection{AgentKind: "codex"},
+						IsCatchAll: false,
+					},
+				},
+			},
+			defaultKind:  defaultKind,
+			defaultTmpl:  defaultTmpl,
+			wantAgent:    "codex",
+			wantRuleName: "prio-eq",
+			wantLayer:    ResolvedFromRule,
+		},
+		{
+			name: "priority in match",
+			issue: domain.Issue{
+				ID: "1", Identifier: "T-1", Title: "t", State: "To Do",
+				Priority: prio(2),
+			},
+			dispatch: config.DispatchConfig{
+				Rules: []config.DispatchRule{
+					{
+						Name:       "prio-in",
+						Match:      config.DispatchMatch{Priority: &config.PriorityPredicate{Op: "in", Values: []int{1, 2, 3}}},
+						Selection:  config.DispatchSelection{AgentKind: "codex"},
+						IsCatchAll: false,
+					},
+				},
+			},
+			defaultKind:  defaultKind,
+			defaultTmpl:  defaultTmpl,
+			wantAgent:    "codex",
+			wantRuleName: "prio-in",
+			wantLayer:    ResolvedFromRule,
+		},
+		{
+			name: "priority lt match",
+			issue: domain.Issue{
+				ID: "1", Identifier: "T-1", Title: "t", State: "To Do",
+				Priority: prio(1),
+			},
+			dispatch: config.DispatchConfig{
+				Rules: []config.DispatchRule{
+					{
+						Name:       "prio-lt",
+						Match:      config.DispatchMatch{Priority: &config.PriorityPredicate{Op: "lt", Value: 3}},
+						Selection:  config.DispatchSelection{AgentKind: "codex"},
+						IsCatchAll: false,
+					},
+				},
+			},
+			defaultKind:  defaultKind,
+			defaultTmpl:  defaultTmpl,
+			wantAgent:    "codex",
+			wantRuleName: "prio-lt",
+			wantLayer:    ResolvedFromRule,
+		},
+		{
+			name: "priority lte match at boundary",
+			issue: domain.Issue{
+				ID: "1", Identifier: "T-1", Title: "t", State: "To Do",
+				Priority: prio(2),
+			},
+			dispatch: config.DispatchConfig{
+				Rules: []config.DispatchRule{
+					{
+						Name:       "prio-lte",
+						Match:      config.DispatchMatch{Priority: &config.PriorityPredicate{Op: "lte", Value: 2}},
+						Selection:  config.DispatchSelection{AgentKind: "codex"},
+						IsCatchAll: false,
+					},
+				},
+			},
+			defaultKind:  defaultKind,
+			defaultTmpl:  defaultTmpl,
+			wantAgent:    "codex",
+			wantRuleName: "prio-lte",
+			wantLayer:    ResolvedFromRule,
+		},
+		{
+			name: "priority gt match",
+			issue: domain.Issue{
+				ID: "1", Identifier: "T-1", Title: "t", State: "To Do",
+				Priority: prio(5),
+			},
+			dispatch: config.DispatchConfig{
+				Rules: []config.DispatchRule{
+					{
+						Name:       "prio-gt",
+						Match:      config.DispatchMatch{Priority: &config.PriorityPredicate{Op: "gt", Value: 3}},
+						Selection:  config.DispatchSelection{AgentKind: "codex"},
+						IsCatchAll: false,
+					},
+				},
+			},
+			defaultKind:  defaultKind,
+			defaultTmpl:  defaultTmpl,
+			wantAgent:    "codex",
+			wantRuleName: "prio-gt",
+			wantLayer:    ResolvedFromRule,
+		},
+		{
+			name: "priority gte match at boundary",
+			issue: domain.Issue{
+				ID: "1", Identifier: "T-1", Title: "t", State: "To Do",
+				Priority: prio(3),
+			},
+			dispatch: config.DispatchConfig{
+				Rules: []config.DispatchRule{
+					{
+						Name:       "prio-gte",
+						Match:      config.DispatchMatch{Priority: &config.PriorityPredicate{Op: "gte", Value: 3}},
+						Selection:  config.DispatchSelection{AgentKind: "codex"},
+						IsCatchAll: false,
+					},
+				},
+			},
+			defaultKind:  defaultKind,
+			defaultTmpl:  defaultTmpl,
+			wantAgent:    "codex",
+			wantRuleName: "prio-gte",
+			wantLayer:    ResolvedFromRule,
+		},
+		{
+			name: "nil priority never matches numeric predicate",
+			issue: domain.Issue{
+				ID: "1", Identifier: "T-1", Title: "t", State: "To Do",
+				Priority: nil,
+			},
+			dispatch: config.DispatchConfig{
+				Rules: []config.DispatchRule{
+					{
+						Name:       "prio-rule",
+						Match:      config.DispatchMatch{Priority: &config.PriorityPredicate{Op: "eq", Value: 1}},
+						Selection:  config.DispatchSelection{AgentKind: "codex"},
+						IsCatchAll: false,
+					},
+				},
+			},
+			defaultKind:  defaultKind,
+			defaultTmpl:  defaultTmpl,
+			wantAgent:    defaultKind,
+			wantRuleName: "",
+			wantLayer:    ResolvedFromFallback,
+		},
+
+		// --- First-match-wins order ---
+		{
+			name:  "first matching rule wins",
+			issue: issueWithLabels("bug"),
+			dispatch: config.DispatchConfig{
+				Rules: []config.DispatchRule{
+					{
+						Name:       "first",
+						Match:      config.DispatchMatch{Labels: []string{"bug"}},
+						Selection:  config.DispatchSelection{AgentKind: "first-agent"},
+						IsCatchAll: false,
+					},
+					{
+						Name:       "second",
+						Match:      config.DispatchMatch{Labels: []string{"bug"}},
+						Selection:  config.DispatchSelection{AgentKind: "second-agent"},
+						IsCatchAll: false,
+					},
+				},
+			},
+			defaultKind:  defaultKind,
+			defaultTmpl:  defaultTmpl,
+			wantAgent:    "first-agent",
+			wantRuleName: "first",
+			wantLayer:    ResolvedFromRule,
+		},
+
+		// --- Partial override falls through to dispatch default ---
+		{
+			name:  "rule agent-only falls through to dispatch default template",
+			issue: issueWithLabels("bug"),
+			dispatch: config.DispatchConfig{
+				Rules: []config.DispatchRule{
+					{
+						Name:       "bug-agent-only",
+						Match:      config.DispatchMatch{Labels: []string{"bug"}},
+						Selection:  config.DispatchSelection{AgentKind: "codex"},
+						IsCatchAll: false,
+					},
+				},
+				Default: config.DispatchSelection{TemplateID: "/tmpl/default.md"},
+			},
+			defaultKind:  defaultKind,
+			defaultTmpl:  defaultTmpl,
+			wantAgent:    "codex",
+			wantTemplate: "/tmpl/default.md",
+			wantRuleName: "bug-agent-only",
+			wantLayer:    ResolvedFromRule,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			kind := tt.defaultKind
+			if kind == "" {
+				kind = defaultKind
+			}
+			tmpl := tt.defaultTmpl
+
+			got := ResolveRule(tt.issue, tt.dispatch, kind, tmpl)
+
+			if got.AgentKind != tt.wantAgent {
+				t.Errorf("ResolveRule(%q).AgentKind = %q, want %q", tt.issue.Identifier, got.AgentKind, tt.wantAgent)
+			}
+			if got.TemplateID != tt.wantTemplate {
+				t.Errorf("ResolveRule(%q).TemplateID = %q, want %q", tt.issue.Identifier, got.TemplateID, tt.wantTemplate)
+			}
+			if got.RuleName != tt.wantRuleName {
+				t.Errorf("ResolveRule(%q).RuleName = %q, want %q", tt.issue.Identifier, got.RuleName, tt.wantRuleName)
+			}
+			if got.MatchedAt != tt.wantLayer {
+				t.Errorf("ResolveRule(%q).MatchedAt = %v, want %v", tt.issue.Identifier, got.MatchedAt, tt.wantLayer)
+			}
+		})
+	}
+}
+
+// --- TestNormalizeDispatchRuleName ---
+
+func TestNormalizeDispatchRuleName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{name: "empty string becomes none sentinel", input: "", want: "<none>"},
+		{name: "non-empty name is preserved", input: "bug-rule", want: "bug-rule"},
+		{name: "single char name", input: "a", want: "a"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := normalizeDispatchRuleName(tt.input)
+			if got != tt.want {
+				t.Errorf("normalizeDispatchRuleName(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+// --- TestResolutionLayer_String ---
+
+func TestResolutionLayer_String(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		layer ResolutionLayer
+		want  string
+	}{
+		{ResolvedFromRule, "rule"},
+		{ResolvedFromDefault, "default"},
+		{ResolvedFromFallback, "fallback"},
+		{ResolutionLayer(99), "unknown"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			t.Parallel()
+
+			got := tt.layer.String()
+			if got != tt.want {
+				t.Errorf("ResolutionLayer(%d).String() = %q, want %q", tt.layer, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -222,6 +222,18 @@ type RunningEntry struct {
 	// workflow config active at dispatch time. Used for token cost
 	// estimation on the dashboard.
 	AgentKind string
+
+	// RuleName is the dispatch rule name frozen at initial dispatch.
+	// Empty when no rule matched and the workflow-wide fallback fired,
+	// or "default" when the dispatch default block matched. Used in
+	// logs, metrics, and the passive dashboard display.
+	RuleName string
+
+	// TemplateID is the resolved template registry key frozen at
+	// initial dispatch. Empty selects the WORKFLOW.md body template.
+	// Used by the worker to look up the parsed template via the
+	// workflow manager's per-ID index.
+	TemplateID string
 }
 
 // RetryEntry holds the runtime state for a pending retry. The persisted
@@ -268,6 +280,21 @@ type RetryEntry struct {
 	// values cause HandleRetryTimer to call MarkReactionDispatched after
 	// successful dispatch. Runtime-only (not persisted to SQLite).
 	ReactionKind string
+
+	// RuleName is the dispatch rule name frozen at initial dispatch.
+	// Propagated verbatim through every retry so the freeze-on-dispatch
+	// contract holds across reschedule, slot-exhaustion, and reaction
+	// continuation paths.
+	RuleName string
+
+	// TemplateID is the resolved template registry key frozen at
+	// initial dispatch. Propagated verbatim through every retry.
+	TemplateID string
+
+	// AgentKind is the adapter kind frozen at initial dispatch.
+	// Propagated through every retry so [HandleRetryTimer] can look up
+	// the adapter without re-running rule resolution.
+	AgentKind string
 }
 
 // ReactionKindCI is the reaction kind constant for CI failure reactions.
@@ -335,6 +362,23 @@ type PendingReaction struct {
 	// The reconcile function for each kind is responsible for a single
 	// type assertion at the top of its loop body.
 	KindData any
+
+	// AgentKind is the dispatch-frozen adapter kind captured from the
+	// completed worker. Propagated into the reaction continuation
+	// retry so the same adapter handles the follow-up turn.
+	AgentKind string
+
+	// RuleName is the dispatch-frozen rule name captured from the
+	// completed worker. Propagated for logs and metrics so the
+	// continuation appears under the same rule as the original
+	// dispatch.
+	RuleName string
+
+	// TemplateID is the dispatch-frozen template registry key
+	// captured from the completed worker. Propagated so the
+	// continuation renders the same template as the original
+	// dispatch.
+	TemplateID string
 }
 
 // CIReactionData holds CI-specific fields for a pending CI reaction.
@@ -586,6 +630,7 @@ type SnapshotRunningEntry struct {
 	SelfReviewActive    bool                  `json:"self_review_active,omitempty"`
 	SelfReviewIteration int                   `json:"self_review_iteration,omitempty"`
 	AgentKind           string                `json:"agent_kind,omitempty"`
+	RuleName            string                `json:"rule_name,omitempty"`
 }
 
 // SnapshotRetryEntry is a read-only view of a pending retry for
@@ -700,6 +745,7 @@ func RuntimeSnapshot(state *State, now time.Time) RuntimeSnapshotResult {
 			SelfReviewActive:    entry.SelfReviewActive,
 			SelfReviewIteration: entry.SelfReviewIteration,
 			AgentKind:           entry.AgentKind,
+			RuleName:            entry.RuleName,
 		})
 
 		if !entry.StartedAt.IsZero() {

--- a/internal/orchestrator/worker.go
+++ b/internal/orchestrator/worker.go
@@ -115,7 +115,10 @@ type WorkerResult struct {
 	// Empty if workspace preparation failed.
 	WorkspacePath string
 
-	// AgentAdapter is the agent adapter kind string (from config.Agent.Kind).
+	// AgentAdapter is the agent adapter kind string used to dispatch
+	// this attempt. Equals the rule-resolved kind when dispatch routing
+	// selected a non-default agent; otherwise equals the workflow-wide
+	// default kind from config.Agent.Kind.
 	AgentAdapter string
 
 	// Attempt is the retry attempt parameter passed to the worker.
@@ -162,9 +165,22 @@ type WorkerDeps struct {
 	// values take effect for new attempts.
 	ConfigFunc func() config.ServiceConfig
 
-	// PromptTemplateFunc returns the current compiled prompt template.
-	// Called once per attempt at the start.
-	PromptTemplateFunc func() *prompt.Template
+	// PromptTemplateByIDFunc returns the parsed prompt template
+	// registered under the given ID. The empty-string key selects the
+	// WORKFLOW.md body template. Called once per attempt to resolve
+	// the freeze-on-dispatch template selection.
+	PromptTemplateByIDFunc func(id string) *prompt.Template
+
+	// TemplateID is the resolved template registry key chosen at
+	// initial dispatch and frozen for the lifetime of the claim.
+	// Empty selects the body template.
+	TemplateID string
+
+	// AgentKind is the rule-resolved agent adapter kind frozen at
+	// initial dispatch. Empty falls back to the workflow-wide default
+	// from config.Agent.Kind, preserving pre-routing behavior for
+	// callers that have not wired the freeze-on-dispatch selection.
+	AgentKind string
 
 	// OnEvent relays agent events to the orchestrator's serialized
 	// event loop. Called from the worker goroutine; must be safe for
@@ -305,15 +321,39 @@ func exitKindForErr(ctx context.Context) WorkerExitKind {
 // closure over deps.
 func RunWorkerAttempt(ctx context.Context, issue domain.Issue, attempt *int, deps WorkerDeps) {
 	cfg := deps.ConfigFunc()
-	tmpl := deps.PromptTemplateFunc()
+	tmpl := deps.PromptTemplateByIDFunc(deps.TemplateID)
 	attemptInt := normalizeAttempt(attempt)
 	logger := deps.Logger
 	if logger == nil {
 		logger = slog.Default()
 	}
 
+	// The rule-resolved kind is authoritative for run-history recording
+	// and dispatch-comment text. Callers that have not wired routing
+	// fall back to the workflow-wide default.
+	agentKind := deps.AgentKind
+	if agentKind == "" {
+		agentKind = cfg.Agent.Kind
+	}
+
 	if deps.Metrics == nil {
 		deps.Metrics = &domain.NoopMetrics{}
+	}
+
+	if tmpl == nil {
+		logger.Error("prompt template lookup returned nil",
+			slog.String("template_id", deps.TemplateID),
+		)
+		deps.OnExit(issue.ID, WorkerResult{
+			IssueID:      issue.ID,
+			Identifier:   issue.Identifier,
+			ExitKind:     WorkerExitError,
+			Error:        fmt.Errorf("prompt template %q is not registered", deps.TemplateID),
+			AgentAdapter: agentKind,
+			Attempt:      attempt,
+			SSHHost:      deps.SSHHost,
+		})
+		return
 	}
 
 	// Dispatch-time in-progress transition: move the issue to the
@@ -347,7 +387,7 @@ func RunWorkerAttempt(ctx context.Context, issue domain.Issue, attempt *int, dep
 	// Fires after in-progress transition, before workspace preparation.
 	// Failure is non-fatal — the worker continues regardless.
 	if cfg.Tracker.Comments.OnDispatch {
-		text := buildDispatchComment(cfg.Agent.Kind, attemptInt)
+		text := buildDispatchComment(agentKind, attemptInt)
 		if err := deps.TrackerAdapter.CommentIssue(ctx, issue.ID, text); err != nil {
 			logger.Warn("dispatch comment failed", slog.Any("error", err))
 			deps.Metrics.IncTrackerComments("dispatch", "error")
@@ -406,7 +446,7 @@ func RunWorkerAttempt(ctx context.Context, issue domain.Issue, attempt *int, dep
 					TurnsCompleted: turnsCompleted,
 					SessionID:      sessionID,
 					WorkspacePath:  workspacePath,
-					AgentAdapter:   cfg.Agent.Kind,
+					AgentAdapter:   agentKind,
 					Attempt:        attempt,
 					SSHHost:        deps.SSHHost,
 				})
@@ -436,7 +476,7 @@ func RunWorkerAttempt(ctx context.Context, issue domain.Issue, attempt *int, dep
 			Identifier:   issue.Identifier,
 			ExitKind:     exitKindForErr(ctx),
 			Error:        fmt.Errorf("workspace preparation: %w", err),
-			AgentAdapter: cfg.Agent.Kind,
+			AgentAdapter: agentKind,
 			Attempt:      attempt,
 			SSHHost:      deps.SSHHost,
 		})
@@ -475,7 +515,7 @@ func RunWorkerAttempt(ctx context.Context, issue domain.Issue, attempt *int, dep
 				ExitKind:      WorkerExitError,
 				Error:         fmt.Errorf("mcp config generation: resolve executable: %w", execErr),
 				WorkspacePath: wsResult.Path,
-				AgentAdapter:  cfg.Agent.Kind,
+				AgentAdapter:  agentKind,
 				Attempt:       attempt,
 				SSHHost:       deps.SSHHost,
 			})
@@ -492,7 +532,7 @@ func RunWorkerAttempt(ctx context.Context, issue domain.Issue, attempt *int, dep
 				ExitKind:      WorkerExitError,
 				Error:         fmt.Errorf("mcp config generation: resolve symlinks: %w", execErr),
 				WorkspacePath: wsResult.Path,
-				AgentAdapter:  cfg.Agent.Kind,
+				AgentAdapter:  agentKind,
 				Attempt:       attempt,
 				SSHHost:       deps.SSHHost,
 			})
@@ -531,7 +571,7 @@ func RunWorkerAttempt(ctx context.Context, issue domain.Issue, attempt *int, dep
 				ExitKind:      WorkerExitError,
 				Error:         fmt.Errorf("mcp config generation: %w", genErr),
 				WorkspacePath: wsResult.Path,
-				AgentAdapter:  cfg.Agent.Kind,
+				AgentAdapter:  agentKind,
 				Attempt:       attempt,
 				SSHHost:       deps.SSHHost,
 			})
@@ -551,7 +591,7 @@ func RunWorkerAttempt(ctx context.Context, issue domain.Issue, attempt *int, dep
 			Identifier:    issue.Identifier,
 			ExitKind:      WorkerExitCancelled,
 			WorkspacePath: wsResult.Path,
-			AgentAdapter:  cfg.Agent.Kind,
+			AgentAdapter:  agentKind,
 			Attempt:       attempt,
 			SSHHost:       deps.SSHHost,
 		})
@@ -575,7 +615,7 @@ func RunWorkerAttempt(ctx context.Context, issue domain.Issue, attempt *int, dep
 			ExitKind:      exitKindForErr(ctx),
 			Error:         fmt.Errorf("agent session start: %w", err),
 			WorkspacePath: wsResult.Path,
-			AgentAdapter:  cfg.Agent.Kind,
+			AgentAdapter:  agentKind,
 			Attempt:       attempt,
 			SSHHost:       deps.SSHHost,
 		})
@@ -653,7 +693,7 @@ func RunWorkerAttempt(ctx context.Context, issue domain.Issue, attempt *int, dep
 				TurnsCompleted: turnsCompleted,
 				SessionID:      session.ID,
 				WorkspacePath:  wsResult.Path,
-				AgentAdapter:   cfg.Agent.Kind,
+				AgentAdapter:   agentKind,
 				Attempt:        attempt,
 				SSHHost:        deps.SSHHost,
 			})
@@ -724,7 +764,7 @@ func RunWorkerAttempt(ctx context.Context, issue domain.Issue, attempt *int, dep
 				TurnsCompleted: turnsCompleted,
 				SessionID:      session.ID,
 				WorkspacePath:  wsResult.Path,
-				AgentAdapter:   cfg.Agent.Kind,
+				AgentAdapter:   agentKind,
 				Attempt:        attempt,
 				SSHHost:        deps.SSHHost,
 			})
@@ -752,7 +792,7 @@ func RunWorkerAttempt(ctx context.Context, issue domain.Issue, attempt *int, dep
 				TurnsCompleted: turnsCompleted,
 				SessionID:      session.ID,
 				WorkspacePath:  wsResult.Path,
-				AgentAdapter:   cfg.Agent.Kind,
+				AgentAdapter:   agentKind,
 				Attempt:        attempt,
 				SSHHost:        deps.SSHHost,
 			})
@@ -777,7 +817,7 @@ func RunWorkerAttempt(ctx context.Context, issue domain.Issue, attempt *int, dep
 				TurnsCompleted: turnsCompleted,
 				SessionID:      session.ID,
 				WorkspacePath:  wsResult.Path,
-				AgentAdapter:   cfg.Agent.Kind,
+				AgentAdapter:   agentKind,
 				Attempt:        attempt,
 				SSHHost:        deps.SSHHost,
 				SoftStop:       true,
@@ -800,7 +840,7 @@ func RunWorkerAttempt(ctx context.Context, issue domain.Issue, attempt *int, dep
 				TurnsCompleted: turnsCompleted,
 				SessionID:      session.ID,
 				WorkspacePath:  wsResult.Path,
-				AgentAdapter:   cfg.Agent.Kind,
+				AgentAdapter:   agentKind,
 				Attempt:        attempt,
 				SSHHost:        deps.SSHHost,
 			})
@@ -892,7 +932,7 @@ func RunWorkerAttempt(ctx context.Context, issue domain.Issue, attempt *int, dep
 		TurnsCompleted: turnsCompleted,
 		SessionID:      session.ID,
 		WorkspacePath:  wsResult.Path,
-		AgentAdapter:   cfg.Agent.Kind,
+		AgentAdapter:   agentKind,
 		Attempt:        attempt,
 		SSHHost:        deps.SSHHost,
 		ReviewMetadata: reviewMeta,

--- a/internal/orchestrator/worker_test.go
+++ b/internal/orchestrator/worker_test.go
@@ -392,11 +392,11 @@ func TestRunWorkerAttempt(t *testing.T) {
 					}, nil
 				},
 			},
-			ConfigFunc:         func() config.ServiceConfig { return cfg },
-			PromptTemplateFunc: func() *prompt.Template { return mustParseTemplate(t, "do work on {{ .issue.title }}") },
-			OnEvent:            func(_ string, _ domain.AgentEvent) {},
-			OnExit:             ec.onExit,
-			Logger:             discardLogger(),
+			ConfigFunc:             func() config.ServiceConfig { return cfg },
+			PromptTemplateByIDFunc: func(_ string) *prompt.Template { return mustParseTemplate(t, "do work on {{ .issue.title }}") },
+			OnEvent:                func(_ string, _ domain.AgentEvent) {},
+			OnExit:                 ec.onExit,
+			Logger:                 discardLogger(),
 		}
 
 		issue := workerTestIssue()
@@ -460,11 +460,11 @@ func TestRunWorkerAttempt(t *testing.T) {
 					return domain.TurnResult{SessionID: session.ID, ExitReason: domain.EventTurnCompleted}, nil
 				},
 			},
-			ConfigFunc:         func() config.ServiceConfig { return cfg },
-			PromptTemplateFunc: func() *prompt.Template { return mustParseTemplate(t, "work on {{ .issue.title }}") },
-			OnEvent:            func(_ string, _ domain.AgentEvent) {},
-			OnExit:             ec.onExit,
-			Logger:             discardLogger(),
+			ConfigFunc:             func() config.ServiceConfig { return cfg },
+			PromptTemplateByIDFunc: func(_ string) *prompt.Template { return mustParseTemplate(t, "work on {{ .issue.title }}") },
+			OnEvent:                func(_ string, _ domain.AgentEvent) {},
+			OnExit:                 ec.onExit,
+			Logger:                 discardLogger(),
 		}
 
 		RunWorkerAttempt(context.Background(), workerTestIssue(), nil, deps)
@@ -487,13 +487,13 @@ func TestRunWorkerAttempt(t *testing.T) {
 
 		ec := newExitCapture()
 		deps := WorkerDeps{
-			TrackerAdapter:     &mockTrackerAdapter{},
-			AgentAdapter:       &mockAgentAdapter{},
-			ConfigFunc:         func() config.ServiceConfig { return cfg },
-			PromptTemplateFunc: func() *prompt.Template { return mustParseTemplate(t, "work on {{ .issue.title }}") },
-			OnEvent:            func(_ string, _ domain.AgentEvent) {},
-			OnExit:             ec.onExit,
-			Logger:             discardLogger(),
+			TrackerAdapter:         &mockTrackerAdapter{},
+			AgentAdapter:           &mockAgentAdapter{},
+			ConfigFunc:             func() config.ServiceConfig { return cfg },
+			PromptTemplateByIDFunc: func(_ string) *prompt.Template { return mustParseTemplate(t, "work on {{ .issue.title }}") },
+			OnEvent:                func(_ string, _ domain.AgentEvent) {},
+			OnExit:                 ec.onExit,
+			Logger:                 discardLogger(),
 		}
 
 		RunWorkerAttempt(context.Background(), workerTestIssue(), nil, deps)
@@ -531,11 +531,11 @@ func TestRunWorkerAttempt(t *testing.T) {
 					return domain.TurnResult{SessionID: session.ID, ExitReason: domain.EventTurnCompleted}, nil
 				},
 			},
-			ConfigFunc:         func() config.ServiceConfig { return cfg },
-			PromptTemplateFunc: func() *prompt.Template { return mustParseTemplate(t, "work on {{ .issue.title }}") },
-			OnEvent:            func(_ string, _ domain.AgentEvent) {},
-			OnExit:             ec.onExit,
-			Logger:             discardLogger(),
+			ConfigFunc:             func() config.ServiceConfig { return cfg },
+			PromptTemplateByIDFunc: func(_ string) *prompt.Template { return mustParseTemplate(t, "work on {{ .issue.title }}") },
+			OnEvent:                func(_ string, _ domain.AgentEvent) {},
+			OnExit:                 ec.onExit,
+			Logger:                 discardLogger(),
 		}
 
 		RunWorkerAttempt(context.Background(), workerTestIssue(), nil, deps)
@@ -576,11 +576,11 @@ func TestRunWorkerAttempt(t *testing.T) {
 					}, nil
 				},
 			},
-			ConfigFunc:         func() config.ServiceConfig { return cfg },
-			PromptTemplateFunc: func() *prompt.Template { return mustParseTemplate(t, "work on {{ .issue.title }}") },
-			OnEvent:            func(_ string, _ domain.AgentEvent) {},
-			OnExit:             ec.onExit,
-			Logger:             discardLogger(),
+			ConfigFunc:             func() config.ServiceConfig { return cfg },
+			PromptTemplateByIDFunc: func(_ string) *prompt.Template { return mustParseTemplate(t, "work on {{ .issue.title }}") },
+			OnEvent:                func(_ string, _ domain.AgentEvent) {},
+			OnExit:                 ec.onExit,
+			Logger:                 discardLogger(),
 		}
 
 		RunWorkerAttempt(context.Background(), workerTestIssue(), nil, deps)
@@ -622,11 +622,11 @@ func TestRunWorkerAttempt(t *testing.T) {
 					return domain.Session{ID: "sess-1"}, nil
 				},
 			},
-			ConfigFunc:         func() config.ServiceConfig { return cfg },
-			PromptTemplateFunc: func() *prompt.Template { return mustParseTemplate(t, "{{ .issue.title }}") },
-			OnEvent:            func(_ string, _ domain.AgentEvent) {},
-			OnExit:             ec.onExit,
-			Logger:             discardLogger(),
+			ConfigFunc:             func() config.ServiceConfig { return cfg },
+			PromptTemplateByIDFunc: func(_ string) *prompt.Template { return mustParseTemplate(t, "{{ .issue.title }}") },
+			OnEvent:                func(_ string, _ domain.AgentEvent) {},
+			OnExit:                 ec.onExit,
+			Logger:                 discardLogger(),
 		}
 
 		RunWorkerAttempt(context.Background(), workerTestIssue(), nil, deps)
@@ -666,11 +666,11 @@ func TestRunWorkerAttempt(t *testing.T) {
 					return domain.Session{}, errors.New("session launch failed")
 				},
 			},
-			ConfigFunc:         func() config.ServiceConfig { return cfg },
-			PromptTemplateFunc: func() *prompt.Template { return mustParseTemplate(t, "{{ .issue.title }}") },
-			OnEvent:            func(_ string, _ domain.AgentEvent) {},
-			OnExit:             ec.onExit,
-			Logger:             discardLogger(),
+			ConfigFunc:             func() config.ServiceConfig { return cfg },
+			PromptTemplateByIDFunc: func(_ string) *prompt.Template { return mustParseTemplate(t, "{{ .issue.title }}") },
+			OnEvent:                func(_ string, _ domain.AgentEvent) {},
+			OnExit:                 ec.onExit,
+			Logger:                 discardLogger(),
 		}
 
 		RunWorkerAttempt(context.Background(), workerTestIssue(), nil, deps)
@@ -729,11 +729,11 @@ func TestRunWorkerAttempt(t *testing.T) {
 					return nil
 				},
 			},
-			ConfigFunc:         func() config.ServiceConfig { return cfg },
-			PromptTemplateFunc: func() *prompt.Template { return mustParseTemplate(t, "{{ .issue.title }}") },
-			OnEvent:            func(_ string, _ domain.AgentEvent) {},
-			OnExit:             ec.onExit,
-			Logger:             discardLogger(),
+			ConfigFunc:             func() config.ServiceConfig { return cfg },
+			PromptTemplateByIDFunc: func(_ string) *prompt.Template { return mustParseTemplate(t, "{{ .issue.title }}") },
+			OnEvent:                func(_ string, _ domain.AgentEvent) {},
+			OnExit:                 ec.onExit,
+			Logger:                 discardLogger(),
 		}
 
 		RunWorkerAttempt(ctx, workerTestIssue(), nil, deps)
@@ -771,13 +771,13 @@ func TestRunWorkerAttempt(t *testing.T) {
 		cancel() // Cancel immediately.
 
 		deps := WorkerDeps{
-			TrackerAdapter:     &mockTrackerAdapter{},
-			AgentAdapter:       &mockAgentAdapter{},
-			ConfigFunc:         func() config.ServiceConfig { return cfg },
-			PromptTemplateFunc: func() *prompt.Template { return mustParseTemplate(t, "{{ .issue.title }}") },
-			OnEvent:            func(_ string, _ domain.AgentEvent) {},
-			OnExit:             ec.onExit,
-			Logger:             discardLogger(),
+			TrackerAdapter:         &mockTrackerAdapter{},
+			AgentAdapter:           &mockAgentAdapter{},
+			ConfigFunc:             func() config.ServiceConfig { return cfg },
+			PromptTemplateByIDFunc: func(_ string) *prompt.Template { return mustParseTemplate(t, "{{ .issue.title }}") },
+			OnEvent:                func(_ string, _ domain.AgentEvent) {},
+			OnExit:                 ec.onExit,
+			Logger:                 discardLogger(),
 		}
 
 		RunWorkerAttempt(ctx, workerTestIssue(), nil, deps)
@@ -816,7 +816,7 @@ func TestRunWorkerAttempt(t *testing.T) {
 				},
 			},
 			ConfigFunc: func() config.ServiceConfig { return cfg },
-			PromptTemplateFunc: func() *prompt.Template {
+			PromptTemplateByIDFunc: func(_ string) *prompt.Template {
 				return mustParseTemplate(t, "turn={{ .run.turn_number }} cont={{ .run.is_continuation }}")
 			},
 			OnEvent: func(_ string, _ domain.AgentEvent) {},
@@ -875,12 +875,12 @@ func TestRunWorkerAttempt(t *testing.T) {
 					return nil, fmt.Errorf("tracker API timeout")
 				},
 			},
-			AgentAdapter:       &mockAgentAdapter{},
-			ConfigFunc:         func() config.ServiceConfig { return cfg },
-			PromptTemplateFunc: func() *prompt.Template { return mustParseTemplate(t, "{{ .issue.title }}") },
-			OnEvent:            func(_ string, _ domain.AgentEvent) {},
-			OnExit:             ec.onExit,
-			Logger:             discardLogger(),
+			AgentAdapter:           &mockAgentAdapter{},
+			ConfigFunc:             func() config.ServiceConfig { return cfg },
+			PromptTemplateByIDFunc: func(_ string) *prompt.Template { return mustParseTemplate(t, "{{ .issue.title }}") },
+			OnEvent:                func(_ string, _ domain.AgentEvent) {},
+			OnExit:                 ec.onExit,
+			Logger:                 discardLogger(),
 		}
 
 		RunWorkerAttempt(context.Background(), workerTestIssue(), nil, deps)
@@ -918,11 +918,11 @@ func TestRunWorkerAttempt(t *testing.T) {
 					return nil
 				},
 			},
-			ConfigFunc:         func() config.ServiceConfig { return cfg },
-			PromptTemplateFunc: func() *prompt.Template { return mustParseTemplate(t, "{{ .issue.title }}") },
-			OnEvent:            func(_ string, _ domain.AgentEvent) {},
-			OnExit:             ec.onExit,
-			Logger:             discardLogger(),
+			ConfigFunc:             func() config.ServiceConfig { return cfg },
+			PromptTemplateByIDFunc: func(_ string) *prompt.Template { return mustParseTemplate(t, "{{ .issue.title }}") },
+			OnEvent:                func(_ string, _ domain.AgentEvent) {},
+			OnExit:                 ec.onExit,
+			Logger:                 discardLogger(),
 		}
 
 		// Should not propagate the panic.
@@ -965,13 +965,13 @@ func TestRunWorkerAttempt(t *testing.T) {
 		ec := newExitCapture()
 
 		deps := WorkerDeps{
-			TrackerAdapter:     &mockTrackerAdapter{},
-			AgentAdapter:       &mockAgentAdapter{},
-			ConfigFunc:         func() config.ServiceConfig { return cfg },
-			PromptTemplateFunc: func() *prompt.Template { return mustParseTemplate(t, "{{ .issue.title }}") },
-			OnEvent:            func(_ string, _ domain.AgentEvent) {},
-			OnExit:             ec.onExit,
-			Logger:             discardLogger(),
+			TrackerAdapter:         &mockTrackerAdapter{},
+			AgentAdapter:           &mockAgentAdapter{},
+			ConfigFunc:             func() config.ServiceConfig { return cfg },
+			PromptTemplateByIDFunc: func(_ string) *prompt.Template { return mustParseTemplate(t, "{{ .issue.title }}") },
+			OnEvent:                func(_ string, _ domain.AgentEvent) {},
+			OnExit:                 ec.onExit,
+			Logger:                 discardLogger(),
 		}
 
 		attempt := intPtr(3)
@@ -999,13 +999,13 @@ func TestRunWorkerAttempt(t *testing.T) {
 		ec := newExitCapture()
 
 		deps := WorkerDeps{
-			TrackerAdapter:     &mockTrackerAdapter{},
-			AgentAdapter:       &mockAgentAdapter{},
-			ConfigFunc:         func() config.ServiceConfig { return cfg },
-			PromptTemplateFunc: func() *prompt.Template { return mustParseTemplate(t, "{{ .issue.title }}") },
-			OnEvent:            func(_ string, _ domain.AgentEvent) {},
-			OnExit:             ec.onExit,
-			Logger:             discardLogger(),
+			TrackerAdapter:         &mockTrackerAdapter{},
+			AgentAdapter:           &mockAgentAdapter{},
+			ConfigFunc:             func() config.ServiceConfig { return cfg },
+			PromptTemplateByIDFunc: func(_ string) *prompt.Template { return mustParseTemplate(t, "{{ .issue.title }}") },
+			OnEvent:                func(_ string, _ domain.AgentEvent) {},
+			OnExit:                 ec.onExit,
+			Logger:                 discardLogger(),
 		}
 
 		issue := workerTestIssue()
@@ -1038,12 +1038,12 @@ func TestRunWorkerAttempt(t *testing.T) {
 					return domain.Session{ID: "sess-resumed"}, nil
 				},
 			},
-			ConfigFunc:         func() config.ServiceConfig { return cfg },
-			PromptTemplateFunc: func() *prompt.Template { return mustParseTemplate(t, "{{ .issue.title }}") },
-			OnEvent:            func(_ string, _ domain.AgentEvent) {},
-			OnExit:             ec.onExit,
-			ResumeSessionID:    "prev-sess-123",
-			Logger:             discardLogger(),
+			ConfigFunc:             func() config.ServiceConfig { return cfg },
+			PromptTemplateByIDFunc: func(_ string) *prompt.Template { return mustParseTemplate(t, "{{ .issue.title }}") },
+			OnEvent:                func(_ string, _ domain.AgentEvent) {},
+			OnExit:                 ec.onExit,
+			ResumeSessionID:        "prev-sess-123",
+			Logger:                 discardLogger(),
 		}
 
 		RunWorkerAttempt(context.Background(), workerTestIssue(), nil, deps)
@@ -1093,11 +1093,11 @@ func TestRunWorkerAttempt(t *testing.T) {
 					return nil
 				},
 			},
-			ConfigFunc:         func() config.ServiceConfig { return cfg },
-			PromptTemplateFunc: func() *prompt.Template { return mustParseTemplate(t, "{{ .issue.title }}") },
-			OnEvent:            func(_ string, _ domain.AgentEvent) {},
-			OnExit:             ec.onExit,
-			Logger:             discardLogger(),
+			ConfigFunc:             func() config.ServiceConfig { return cfg },
+			PromptTemplateByIDFunc: func(_ string) *prompt.Template { return mustParseTemplate(t, "{{ .issue.title }}") },
+			OnEvent:                func(_ string, _ domain.AgentEvent) {},
+			OnExit:                 ec.onExit,
+			Logger:                 discardLogger(),
 		}
 
 		RunWorkerAttempt(context.Background(), workerTestIssue(), nil, deps)
@@ -1126,13 +1126,13 @@ func TestRunWorkerAttempt(t *testing.T) {
 		ec := newExitCapture()
 
 		deps := WorkerDeps{
-			TrackerAdapter:     &mockTrackerAdapter{},
-			AgentAdapter:       &mockAgentAdapter{},
-			ConfigFunc:         func() config.ServiceConfig { return cfg },
-			PromptTemplateFunc: func() *prompt.Template { return mustParseTemplate(t, "{{ .issue.title }}") },
-			OnEvent:            func(_ string, _ domain.AgentEvent) {},
-			OnExit:             ec.onExit,
-			Logger:             discardLogger(),
+			TrackerAdapter:         &mockTrackerAdapter{},
+			AgentAdapter:           &mockAgentAdapter{},
+			ConfigFunc:             func() config.ServiceConfig { return cfg },
+			PromptTemplateByIDFunc: func(_ string) *prompt.Template { return mustParseTemplate(t, "{{ .issue.title }}") },
+			OnEvent:                func(_ string, _ domain.AgentEvent) {},
+			OnExit:                 ec.onExit,
+			Logger:                 discardLogger(),
 		}
 
 		RunWorkerAttempt(context.Background(), workerTestIssue(), nil, deps)
@@ -1159,13 +1159,13 @@ func TestRunWorkerAttempt(t *testing.T) {
 		ec := newExitCapture()
 
 		deps := WorkerDeps{
-			TrackerAdapter:     &mockTrackerAdapter{},
-			AgentAdapter:       &mockAgentAdapter{},
-			ConfigFunc:         func() config.ServiceConfig { return cfg },
-			PromptTemplateFunc: func() *prompt.Template { return mustParseTemplate(t, "{{ .issue.title }}") },
-			OnEvent:            func(_ string, _ domain.AgentEvent) {},
-			OnExit:             ec.onExit,
-			Logger:             discardLogger(),
+			TrackerAdapter:         &mockTrackerAdapter{},
+			AgentAdapter:           &mockAgentAdapter{},
+			ConfigFunc:             func() config.ServiceConfig { return cfg },
+			PromptTemplateByIDFunc: func(_ string) *prompt.Template { return mustParseTemplate(t, "{{ .issue.title }}") },
+			OnEvent:                func(_ string, _ domain.AgentEvent) {},
+			OnExit:                 ec.onExit,
+			Logger:                 discardLogger(),
 		}
 
 		RunWorkerAttempt(context.Background(), workerTestIssue(), nil, deps)
@@ -1203,11 +1203,11 @@ func TestRunWorkerAttempt(t *testing.T) {
 					return domain.TurnResult{SessionID: session.ID, ExitReason: domain.EventTurnCompleted}, nil
 				},
 			},
-			ConfigFunc:         func() config.ServiceConfig { return cfg },
-			PromptTemplateFunc: func() *prompt.Template { return mustParseTemplate(t, "{{ .issue.title }}") },
-			OnEvent:            func(_ string, _ domain.AgentEvent) {},
-			OnExit:             ec.onExit,
-			Logger:             discardLogger(),
+			ConfigFunc:             func() config.ServiceConfig { return cfg },
+			PromptTemplateByIDFunc: func(_ string) *prompt.Template { return mustParseTemplate(t, "{{ .issue.title }}") },
+			OnEvent:                func(_ string, _ domain.AgentEvent) {},
+			OnExit:                 ec.onExit,
+			Logger:                 discardLogger(),
 		}
 
 		RunWorkerAttempt(context.Background(), workerTestIssue(), nil, deps)
@@ -1259,8 +1259,8 @@ func TestRunWorkerAttempt(t *testing.T) {
 					return domain.TurnResult{SessionID: session.ID, ExitReason: domain.EventTurnCompleted}, nil
 				},
 			},
-			ConfigFunc:         func() config.ServiceConfig { return cfg },
-			PromptTemplateFunc: func() *prompt.Template { return mustParseTemplate(t, "{{ .issue.title }}") },
+			ConfigFunc:             func() config.ServiceConfig { return cfg },
+			PromptTemplateByIDFunc: func(_ string) *prompt.Template { return mustParseTemplate(t, "{{ .issue.title }}") },
 			OnEvent: func(_ string, event domain.AgentEvent) {
 				if event.RateLimits != nil {
 					relayedMap.Store(event.RateLimits)
@@ -1319,12 +1319,12 @@ func TestRunWorkerAttempt(t *testing.T) {
 					return domain.TurnResult{SessionID: session.ID, ExitReason: domain.EventTurnCompleted}, nil
 				},
 			},
-			ConfigFunc:         func() config.ServiceConfig { return cfg },
-			PromptTemplateFunc: func() *prompt.Template { return mustParseTemplate(t, "do work on {{ .issue.title }}") },
-			OnEvent:            func(_ string, _ domain.AgentEvent) {},
-			OnExit:             ec.onExit,
-			Logger:             discardLogger(),
-			ToolRegistry:       reg,
+			ConfigFunc:             func() config.ServiceConfig { return cfg },
+			PromptTemplateByIDFunc: func(_ string) *prompt.Template { return mustParseTemplate(t, "do work on {{ .issue.title }}") },
+			OnEvent:                func(_ string, _ domain.AgentEvent) {},
+			OnExit:                 ec.onExit,
+			Logger:                 discardLogger(),
+			ToolRegistry:           reg,
 		}
 
 		RunWorkerAttempt(context.Background(), workerTestIssue(), nil, deps)
@@ -1374,12 +1374,12 @@ func TestRunWorkerAttempt(t *testing.T) {
 					return domain.TurnResult{SessionID: session.ID, ExitReason: domain.EventTurnCompleted}, nil
 				},
 			},
-			ConfigFunc:         func() config.ServiceConfig { return cfg },
-			PromptTemplateFunc: func() *prompt.Template { return mustParseTemplate(t, "turn={{ .run.turn_number }}") },
-			OnEvent:            func(_ string, _ domain.AgentEvent) {},
-			OnExit:             ec.onExit,
-			Logger:             discardLogger(),
-			ToolRegistry:       reg,
+			ConfigFunc:             func() config.ServiceConfig { return cfg },
+			PromptTemplateByIDFunc: func(_ string) *prompt.Template { return mustParseTemplate(t, "turn={{ .run.turn_number }}") },
+			OnEvent:                func(_ string, _ domain.AgentEvent) {},
+			OnExit:                 ec.onExit,
+			Logger:                 discardLogger(),
+			ToolRegistry:           reg,
 		}
 
 		RunWorkerAttempt(context.Background(), workerTestIssue(), nil, deps)
@@ -1435,12 +1435,12 @@ func TestRunWorkerAttempt(t *testing.T) {
 					return domain.TurnResult{SessionID: session.ID, ExitReason: domain.EventTurnCompleted}, nil
 				},
 			},
-			ConfigFunc:         func() config.ServiceConfig { return cfg },
-			PromptTemplateFunc: func() *prompt.Template { return mustParseTemplate(t, "do work on {{ .issue.title }}") },
-			OnEvent:            func(_ string, _ domain.AgentEvent) {},
-			OnExit:             ec.onExit,
-			Logger:             discardLogger(),
-			ToolRegistry:       nil,
+			ConfigFunc:             func() config.ServiceConfig { return cfg },
+			PromptTemplateByIDFunc: func(_ string) *prompt.Template { return mustParseTemplate(t, "do work on {{ .issue.title }}") },
+			OnEvent:                func(_ string, _ domain.AgentEvent) {},
+			OnExit:                 ec.onExit,
+			Logger:                 discardLogger(),
+			ToolRegistry:           nil,
 		}
 
 		RunWorkerAttempt(context.Background(), workerTestIssue(), nil, deps)
@@ -1480,12 +1480,12 @@ func TestRunWorkerAttempt(t *testing.T) {
 					return domain.TurnResult{SessionID: session.ID, ExitReason: domain.EventTurnCompleted}, nil
 				},
 			},
-			ConfigFunc:         func() config.ServiceConfig { return cfg },
-			PromptTemplateFunc: func() *prompt.Template { return mustParseTemplate(t, "do work on {{ .issue.title }}") },
-			OnEvent:            func(_ string, _ domain.AgentEvent) {},
-			OnExit:             ec.onExit,
-			Logger:             discardLogger(),
-			ToolRegistry:       domain.NewToolRegistry(),
+			ConfigFunc:             func() config.ServiceConfig { return cfg },
+			PromptTemplateByIDFunc: func(_ string) *prompt.Template { return mustParseTemplate(t, "do work on {{ .issue.title }}") },
+			OnEvent:                func(_ string, _ domain.AgentEvent) {},
+			OnExit:                 ec.onExit,
+			Logger:                 discardLogger(),
+			ToolRegistry:           domain.NewToolRegistry(),
 		}
 
 		RunWorkerAttempt(context.Background(), workerTestIssue(), nil, deps)
@@ -1522,7 +1522,7 @@ func TestRunWorkerAttempt(t *testing.T) {
 				},
 			},
 			ConfigFunc:               func() config.ServiceConfig { return cfg },
-			PromptTemplateFunc:       func() *prompt.Template { return mustParseTemplate(t, "{{ .issue.title }}") },
+			PromptTemplateByIDFunc:   func(_ string) *prompt.Template { return mustParseTemplate(t, "{{ .issue.title }}") },
 			OnEvent:                  func(_ string, _ domain.AgentEvent) {},
 			OnExit:                   ec.onExit,
 			Logger:                   discardLogger(),
@@ -1711,14 +1711,14 @@ func TestRunWorkerAttempt_DispatchTransition(t *testing.T) {
 		ec := newExitCapture()
 
 		deps := WorkerDeps{
-			TrackerAdapter:     tracker,
-			AgentAdapter:       &mockAgentAdapter{},
-			ConfigFunc:         func() config.ServiceConfig { return cfg },
-			PromptTemplateFunc: func() *prompt.Template { return mustParseTemplate(t, "work on {{ .issue.title }}") },
-			OnEvent:            func(_ string, _ domain.AgentEvent) {},
-			OnExit:             ec.onExit,
-			Logger:             discardLogger(),
-			Metrics:            spy,
+			TrackerAdapter:         tracker,
+			AgentAdapter:           &mockAgentAdapter{},
+			ConfigFunc:             func() config.ServiceConfig { return cfg },
+			PromptTemplateByIDFunc: func(_ string) *prompt.Template { return mustParseTemplate(t, "work on {{ .issue.title }}") },
+			OnEvent:                func(_ string, _ domain.AgentEvent) {},
+			OnExit:                 ec.onExit,
+			Logger:                 discardLogger(),
+			Metrics:                spy,
 		}
 
 		issue := workerTestIssue()
@@ -1761,14 +1761,14 @@ func TestRunWorkerAttempt_DispatchTransition(t *testing.T) {
 		ec := newExitCapture()
 
 		deps := WorkerDeps{
-			TrackerAdapter:     tracker,
-			AgentAdapter:       &mockAgentAdapter{},
-			ConfigFunc:         func() config.ServiceConfig { return cfg },
-			PromptTemplateFunc: func() *prompt.Template { return mustParseTemplate(t, "work on {{ .issue.title }}") },
-			OnEvent:            func(_ string, _ domain.AgentEvent) {},
-			OnExit:             ec.onExit,
-			Logger:             discardLogger(),
-			Metrics:            spy,
+			TrackerAdapter:         tracker,
+			AgentAdapter:           &mockAgentAdapter{},
+			ConfigFunc:             func() config.ServiceConfig { return cfg },
+			PromptTemplateByIDFunc: func(_ string) *prompt.Template { return mustParseTemplate(t, "work on {{ .issue.title }}") },
+			OnEvent:                func(_ string, _ domain.AgentEvent) {},
+			OnExit:                 ec.onExit,
+			Logger:                 discardLogger(),
+			Metrics:                spy,
 		}
 
 		RunWorkerAttempt(context.Background(), workerTestIssue(), nil, deps)
@@ -1805,14 +1805,14 @@ func TestRunWorkerAttempt_DispatchTransition(t *testing.T) {
 		ec := newExitCapture()
 
 		deps := WorkerDeps{
-			TrackerAdapter:     tracker,
-			AgentAdapter:       &mockAgentAdapter{},
-			ConfigFunc:         func() config.ServiceConfig { return cfg },
-			PromptTemplateFunc: func() *prompt.Template { return mustParseTemplate(t, "work on {{ .issue.title }}") },
-			OnEvent:            func(_ string, _ domain.AgentEvent) {},
-			OnExit:             ec.onExit,
-			Logger:             discardLogger(),
-			Metrics:            spy,
+			TrackerAdapter:         tracker,
+			AgentAdapter:           &mockAgentAdapter{},
+			ConfigFunc:             func() config.ServiceConfig { return cfg },
+			PromptTemplateByIDFunc: func(_ string) *prompt.Template { return mustParseTemplate(t, "work on {{ .issue.title }}") },
+			OnEvent:                func(_ string, _ domain.AgentEvent) {},
+			OnExit:                 ec.onExit,
+			Logger:                 discardLogger(),
+			Metrics:                spy,
 		}
 
 		RunWorkerAttempt(context.Background(), workerTestIssue(), nil, deps)
@@ -1857,14 +1857,14 @@ func TestRunWorkerAttempt_DispatchTransition(t *testing.T) {
 		tracker1 := &mockTrackerAdapter{}
 		ec1 := newExitCapture()
 		deps1 := WorkerDeps{
-			TrackerAdapter:     tracker1,
-			AgentAdapter:       &mockAgentAdapter{},
-			ConfigFunc:         makeConfig(tmpDir1),
-			PromptTemplateFunc: func() *prompt.Template { return mustParseTemplate(t, "work on {{ .issue.title }}") },
-			OnEvent:            func(_ string, _ domain.AgentEvent) {},
-			OnExit:             ec1.onExit,
-			Logger:             discardLogger(),
-			Metrics:            &spyMetrics{},
+			TrackerAdapter:         tracker1,
+			AgentAdapter:           &mockAgentAdapter{},
+			ConfigFunc:             makeConfig(tmpDir1),
+			PromptTemplateByIDFunc: func(_ string) *prompt.Template { return mustParseTemplate(t, "work on {{ .issue.title }}") },
+			OnEvent:                func(_ string, _ domain.AgentEvent) {},
+			OnExit:                 ec1.onExit,
+			Logger:                 discardLogger(),
+			Metrics:                &spyMetrics{},
 		}
 		RunWorkerAttempt(context.Background(), workerTestIssue(), nil, deps1)
 		ec1.waitResult(t)
@@ -1873,14 +1873,14 @@ func TestRunWorkerAttempt_DispatchTransition(t *testing.T) {
 		tracker2 := &mockTrackerAdapter{}
 		ec2 := newExitCapture()
 		deps2 := WorkerDeps{
-			TrackerAdapter:     tracker2,
-			AgentAdapter:       &mockAgentAdapter{},
-			ConfigFunc:         makeConfig(tmpDir2),
-			PromptTemplateFunc: func() *prompt.Template { return mustParseTemplate(t, "work on {{ .issue.title }}") },
-			OnEvent:            func(_ string, _ domain.AgentEvent) {},
-			OnExit:             ec2.onExit,
-			Logger:             discardLogger(),
-			Metrics:            &spyMetrics{},
+			TrackerAdapter:         tracker2,
+			AgentAdapter:           &mockAgentAdapter{},
+			ConfigFunc:             makeConfig(tmpDir2),
+			PromptTemplateByIDFunc: func(_ string) *prompt.Template { return mustParseTemplate(t, "work on {{ .issue.title }}") },
+			OnEvent:                func(_ string, _ domain.AgentEvent) {},
+			OnExit:                 ec2.onExit,
+			Logger:                 discardLogger(),
+			Metrics:                &spyMetrics{},
 		}
 		RunWorkerAttempt(context.Background(), workerTestIssue(), nil, deps2)
 		ec2.waitResult(t)
@@ -1921,14 +1921,14 @@ func TestRunWorkerAttempt_DispatchTransition(t *testing.T) {
 		issue.State = "In Progress"
 
 		deps := WorkerDeps{
-			TrackerAdapter:     tracker,
-			AgentAdapter:       &mockAgentAdapter{},
-			ConfigFunc:         func() config.ServiceConfig { return cfg },
-			PromptTemplateFunc: func() *prompt.Template { return mustParseTemplate(t, "work on {{ .issue.title }}") },
-			OnEvent:            func(_ string, _ domain.AgentEvent) {},
-			OnExit:             ec.onExit,
-			Logger:             discardLogger(),
-			Metrics:            spy,
+			TrackerAdapter:         tracker,
+			AgentAdapter:           &mockAgentAdapter{},
+			ConfigFunc:             func() config.ServiceConfig { return cfg },
+			PromptTemplateByIDFunc: func(_ string) *prompt.Template { return mustParseTemplate(t, "work on {{ .issue.title }}") },
+			OnEvent:                func(_ string, _ domain.AgentEvent) {},
+			OnExit:                 ec.onExit,
+			Logger:                 discardLogger(),
+			Metrics:                spy,
 		}
 
 		RunWorkerAttempt(context.Background(), issue, nil, deps)
@@ -1963,14 +1963,14 @@ func TestRunWorkerAttempt_DispatchTransition(t *testing.T) {
 		issue.State = "in progress"
 
 		deps := WorkerDeps{
-			TrackerAdapter:     tracker,
-			AgentAdapter:       &mockAgentAdapter{},
-			ConfigFunc:         func() config.ServiceConfig { return cfg },
-			PromptTemplateFunc: func() *prompt.Template { return mustParseTemplate(t, "work on {{ .issue.title }}") },
-			OnEvent:            func(_ string, _ domain.AgentEvent) {},
-			OnExit:             ec.onExit,
-			Logger:             discardLogger(),
-			Metrics:            spy,
+			TrackerAdapter:         tracker,
+			AgentAdapter:           &mockAgentAdapter{},
+			ConfigFunc:             func() config.ServiceConfig { return cfg },
+			PromptTemplateByIDFunc: func(_ string) *prompt.Template { return mustParseTemplate(t, "work on {{ .issue.title }}") },
+			OnEvent:                func(_ string, _ domain.AgentEvent) {},
+			OnExit:                 ec.onExit,
+			Logger:                 discardLogger(),
+			Metrics:                spy,
 		}
 
 		RunWorkerAttempt(context.Background(), issue, nil, deps)
@@ -2003,14 +2003,14 @@ func TestRunWorkerAttempt_DispatchTransition(t *testing.T) {
 		// issue.State = "To Do" (default from workerTestIssue) — states differ,
 		// so TransitionIssue must be called.
 		deps := WorkerDeps{
-			TrackerAdapter:     tracker,
-			AgentAdapter:       &mockAgentAdapter{},
-			ConfigFunc:         func() config.ServiceConfig { return cfg },
-			PromptTemplateFunc: func() *prompt.Template { return mustParseTemplate(t, "work on {{ .issue.title }}") },
-			OnEvent:            func(_ string, _ domain.AgentEvent) {},
-			OnExit:             ec.onExit,
-			Logger:             discardLogger(),
-			Metrics:            spy,
+			TrackerAdapter:         tracker,
+			AgentAdapter:           &mockAgentAdapter{},
+			ConfigFunc:             func() config.ServiceConfig { return cfg },
+			PromptTemplateByIDFunc: func(_ string) *prompt.Template { return mustParseTemplate(t, "work on {{ .issue.title }}") },
+			OnEvent:                func(_ string, _ domain.AgentEvent) {},
+			OnExit:                 ec.onExit,
+			Logger:                 discardLogger(),
+			Metrics:                spy,
 		}
 
 		RunWorkerAttempt(context.Background(), workerTestIssue(), nil, deps)
@@ -2047,14 +2047,14 @@ func TestRunWorkerAttempt_DispatchTransition(t *testing.T) {
 
 		attempt := 2
 		deps := WorkerDeps{
-			TrackerAdapter:     tracker,
-			AgentAdapter:       &mockAgentAdapter{},
-			ConfigFunc:         func() config.ServiceConfig { return cfg },
-			PromptTemplateFunc: func() *prompt.Template { return mustParseTemplate(t, "work on {{ .issue.title }}") },
-			OnEvent:            func(_ string, _ domain.AgentEvent) {},
-			OnExit:             ec.onExit,
-			Logger:             discardLogger(),
-			Metrics:            spy,
+			TrackerAdapter:         tracker,
+			AgentAdapter:           &mockAgentAdapter{},
+			ConfigFunc:             func() config.ServiceConfig { return cfg },
+			PromptTemplateByIDFunc: func(_ string) *prompt.Template { return mustParseTemplate(t, "work on {{ .issue.title }}") },
+			OnEvent:                func(_ string, _ domain.AgentEvent) {},
+			OnExit:                 ec.onExit,
+			Logger:                 discardLogger(),
+			Metrics:                spy,
 		}
 
 		RunWorkerAttempt(context.Background(), issue, &attempt, deps)
@@ -2098,12 +2098,12 @@ func TestRunWorkerAttempt_MCPConfig(t *testing.T) {
 					return domain.Session{ID: "sess-1"}, nil
 				},
 			},
-			ConfigFunc:         func() config.ServiceConfig { return cfg },
-			PromptTemplateFunc: func() *prompt.Template { return mustParseTemplate(t, "{{ .issue.title }}") },
-			OnEvent:            func(_ string, _ domain.AgentEvent) {},
-			OnExit:             ec.onExit,
-			Logger:             discardLogger(),
-			WorkflowPath:       "", // empty → MCP config skipped
+			ConfigFunc:             func() config.ServiceConfig { return cfg },
+			PromptTemplateByIDFunc: func(_ string) *prompt.Template { return mustParseTemplate(t, "{{ .issue.title }}") },
+			OnEvent:                func(_ string, _ domain.AgentEvent) {},
+			OnExit:                 ec.onExit,
+			Logger:                 discardLogger(),
+			WorkflowPath:           "", // empty → MCP config skipped
 		}
 
 		RunWorkerAttempt(context.Background(), workerTestIssue(), nil, deps)
@@ -2143,12 +2143,12 @@ func TestRunWorkerAttempt_MCPConfig(t *testing.T) {
 					return domain.Session{ID: "sess-1"}, nil
 				},
 			},
-			ConfigFunc:         func() config.ServiceConfig { return cfg },
-			PromptTemplateFunc: func() *prompt.Template { return mustParseTemplate(t, "{{ .issue.title }}") },
-			OnEvent:            func(_ string, _ domain.AgentEvent) {},
-			OnExit:             ec.onExit,
-			Logger:             discardLogger(),
-			WorkflowPath:       "/fake/WORKFLOW.md", // non-empty → MCP config generated
+			ConfigFunc:             func() config.ServiceConfig { return cfg },
+			PromptTemplateByIDFunc: func(_ string) *prompt.Template { return mustParseTemplate(t, "{{ .issue.title }}") },
+			OnEvent:                func(_ string, _ domain.AgentEvent) {},
+			OnExit:                 ec.onExit,
+			Logger:                 discardLogger(),
+			WorkflowPath:           "/fake/WORKFLOW.md", // non-empty → MCP config generated
 		}
 
 		RunWorkerAttempt(context.Background(), workerTestIssue(), nil, deps)
@@ -2218,12 +2218,12 @@ func TestRunWorkerAttempt_MCPConfig(t *testing.T) {
 					return domain.Session{ID: "sess-1"}, nil
 				},
 			},
-			ConfigFunc:         func() config.ServiceConfig { return cfg },
-			PromptTemplateFunc: func() *prompt.Template { return mustParseTemplate(t, "{{ .issue.title }}") },
-			OnEvent:            func(_ string, _ domain.AgentEvent) {},
-			OnExit:             ec.onExit,
-			Logger:             discardLogger(),
-			WorkflowPath:       "/fake/WORKFLOW.md",
+			ConfigFunc:             func() config.ServiceConfig { return cfg },
+			PromptTemplateByIDFunc: func(_ string) *prompt.Template { return mustParseTemplate(t, "{{ .issue.title }}") },
+			OnEvent:                func(_ string, _ domain.AgentEvent) {},
+			OnExit:                 ec.onExit,
+			Logger:                 discardLogger(),
+			WorkflowPath:           "/fake/WORKFLOW.md",
 		}
 
 		RunWorkerAttempt(context.Background(), workerTestIssue(), nil, deps)
@@ -2282,12 +2282,12 @@ func TestRunWorkerAttempt_MCPConfig(t *testing.T) {
 					return domain.Session{ID: "sess-1"}, nil
 				},
 			},
-			ConfigFunc:         func() config.ServiceConfig { return cfg },
-			PromptTemplateFunc: func() *prompt.Template { return mustParseTemplate(t, "{{ .issue.title }}") },
-			OnEvent:            func(_ string, _ domain.AgentEvent) {},
-			OnExit:             ec.onExit,
-			Logger:             discardLogger(),
-			WorkflowPath:       "/fake/WORKFLOW.md",
+			ConfigFunc:             func() config.ServiceConfig { return cfg },
+			PromptTemplateByIDFunc: func(_ string) *prompt.Template { return mustParseTemplate(t, "{{ .issue.title }}") },
+			OnEvent:                func(_ string, _ domain.AgentEvent) {},
+			OnExit:                 ec.onExit,
+			Logger:                 discardLogger(),
+			WorkflowPath:           "/fake/WORKFLOW.md",
 		}
 
 		RunWorkerAttempt(context.Background(), workerTestIssue(), nil, deps)
@@ -2360,11 +2360,11 @@ func TestRunWorkerAttempt_MCPConfig(t *testing.T) {
 					return domain.Session{ID: "sess-1"}, nil
 				},
 			},
-			ConfigFunc:         func() config.ServiceConfig { return cfg },
-			PromptTemplateFunc: func() *prompt.Template { return mustParseTemplate(t, "{{ .issue.title }}") },
-			OnEvent:            func(_ string, _ domain.AgentEvent) {},
-			OnExit:             ec.onExit,
-			Logger:             discardLogger(),
+			ConfigFunc:             func() config.ServiceConfig { return cfg },
+			PromptTemplateByIDFunc: func(_ string) *prompt.Template { return mustParseTemplate(t, "{{ .issue.title }}") },
+			OnEvent:                func(_ string, _ domain.AgentEvent) {},
+			OnExit:                 ec.onExit,
+			Logger:                 discardLogger(),
 			// WorkflowPath is inside workflowDir; the file itself need not exist.
 			WorkflowPath: filepath.Join(workflowDir, "WORKFLOW.md"),
 		}
@@ -2413,13 +2413,13 @@ func TestRunWorkerAttempt_MCPConfig(t *testing.T) {
 					return domain.Session{ID: "sess-1"}, nil
 				},
 			},
-			ConfigFunc:         func() config.ServiceConfig { return cfg },
-			PromptTemplateFunc: func() *prompt.Template { return mustParseTemplate(t, "{{ .issue.title }}") },
-			OnEvent:            func(_ string, _ domain.AgentEvent) {},
-			OnExit:             ec.onExit,
-			Logger:             discardLogger(),
-			WorkflowPath:       "/fake/WORKFLOW.md",
-			DBPath:             testDBPath,
+			ConfigFunc:             func() config.ServiceConfig { return cfg },
+			PromptTemplateByIDFunc: func(_ string) *prompt.Template { return mustParseTemplate(t, "{{ .issue.title }}") },
+			OnEvent:                func(_ string, _ domain.AgentEvent) {},
+			OnExit:                 ec.onExit,
+			Logger:                 discardLogger(),
+			WorkflowPath:           "/fake/WORKFLOW.md",
+			DBPath:                 testDBPath,
 		}
 
 		RunWorkerAttempt(context.Background(), workerTestIssue(), nil, deps)
@@ -2517,14 +2517,14 @@ func TestRunWorkerAttempt_DispatchComment(t *testing.T) {
 		issue := workerTestIssue()
 
 		deps := WorkerDeps{
-			TrackerAdapter:     tracker,
-			AgentAdapter:       &mockAgentAdapter{},
-			ConfigFunc:         func() config.ServiceConfig { return cfg },
-			PromptTemplateFunc: func() *prompt.Template { return mustParseTemplate(t, "work on {{ .issue.title }}") },
-			OnEvent:            func(_ string, _ domain.AgentEvent) {},
-			OnExit:             ec.onExit,
-			Logger:             discardLogger(),
-			Metrics:            spy,
+			TrackerAdapter:         tracker,
+			AgentAdapter:           &mockAgentAdapter{},
+			ConfigFunc:             func() config.ServiceConfig { return cfg },
+			PromptTemplateByIDFunc: func(_ string) *prompt.Template { return mustParseTemplate(t, "work on {{ .issue.title }}") },
+			OnEvent:                func(_ string, _ domain.AgentEvent) {},
+			OnExit:                 ec.onExit,
+			Logger:                 discardLogger(),
+			Metrics:                spy,
 		}
 
 		RunWorkerAttempt(context.Background(), issue, nil, deps)
@@ -2571,14 +2571,14 @@ func TestRunWorkerAttempt_DispatchComment(t *testing.T) {
 		ec := newExitCapture()
 
 		deps := WorkerDeps{
-			TrackerAdapter:     tracker,
-			AgentAdapter:       &mockAgentAdapter{},
-			ConfigFunc:         func() config.ServiceConfig { return cfg },
-			PromptTemplateFunc: func() *prompt.Template { return mustParseTemplate(t, "work on {{ .issue.title }}") },
-			OnEvent:            func(_ string, _ domain.AgentEvent) {},
-			OnExit:             ec.onExit,
-			Logger:             discardLogger(),
-			Metrics:            spy,
+			TrackerAdapter:         tracker,
+			AgentAdapter:           &mockAgentAdapter{},
+			ConfigFunc:             func() config.ServiceConfig { return cfg },
+			PromptTemplateByIDFunc: func(_ string) *prompt.Template { return mustParseTemplate(t, "work on {{ .issue.title }}") },
+			OnEvent:                func(_ string, _ domain.AgentEvent) {},
+			OnExit:                 ec.onExit,
+			Logger:                 discardLogger(),
+			Metrics:                spy,
 		}
 
 		RunWorkerAttempt(context.Background(), workerTestIssue(), nil, deps)
@@ -2615,14 +2615,14 @@ func TestRunWorkerAttempt_DispatchComment(t *testing.T) {
 		ec := newExitCapture()
 
 		deps := WorkerDeps{
-			TrackerAdapter:     tracker,
-			AgentAdapter:       &mockAgentAdapter{},
-			ConfigFunc:         func() config.ServiceConfig { return cfg },
-			PromptTemplateFunc: func() *prompt.Template { return mustParseTemplate(t, "work on {{ .issue.title }}") },
-			OnEvent:            func(_ string, _ domain.AgentEvent) {},
-			OnExit:             ec.onExit,
-			Logger:             discardLogger(),
-			Metrics:            spy,
+			TrackerAdapter:         tracker,
+			AgentAdapter:           &mockAgentAdapter{},
+			ConfigFunc:             func() config.ServiceConfig { return cfg },
+			PromptTemplateByIDFunc: func(_ string) *prompt.Template { return mustParseTemplate(t, "work on {{ .issue.title }}") },
+			OnEvent:                func(_ string, _ domain.AgentEvent) {},
+			OnExit:                 ec.onExit,
+			Logger:                 discardLogger(),
+			Metrics:                spy,
 		}
 
 		RunWorkerAttempt(context.Background(), workerTestIssue(), nil, deps)
@@ -2665,14 +2665,14 @@ func TestRunWorkerAttempt_DispatchComment(t *testing.T) {
 		attempt := intPtr(2)
 
 		deps := WorkerDeps{
-			TrackerAdapter:     tracker,
-			AgentAdapter:       &mockAgentAdapter{},
-			ConfigFunc:         func() config.ServiceConfig { return cfg },
-			PromptTemplateFunc: func() *prompt.Template { return mustParseTemplate(t, "work on {{ .issue.title }}") },
-			OnEvent:            func(_ string, _ domain.AgentEvent) {},
-			OnExit:             ec.onExit,
-			Logger:             discardLogger(),
-			Metrics:            &domain.NoopMetrics{},
+			TrackerAdapter:         tracker,
+			AgentAdapter:           &mockAgentAdapter{},
+			ConfigFunc:             func() config.ServiceConfig { return cfg },
+			PromptTemplateByIDFunc: func(_ string) *prompt.Template { return mustParseTemplate(t, "work on {{ .issue.title }}") },
+			OnEvent:                func(_ string, _ domain.AgentEvent) {},
+			OnExit:                 ec.onExit,
+			Logger:                 discardLogger(),
+			Metrics:                &domain.NoopMetrics{},
 		}
 
 		RunWorkerAttempt(context.Background(), workerTestIssue(), attempt, deps)
@@ -2723,11 +2723,11 @@ func TestRunWorkerAttempt_A2OStatusSignal(t *testing.T) {
 					return domain.TurnResult{SessionID: session.ID, ExitReason: domain.EventTurnCompleted}, nil
 				},
 			},
-			ConfigFunc:         func() config.ServiceConfig { return cfg },
-			PromptTemplateFunc: func() *prompt.Template { return mustParseTemplate(t, "{{ .issue.title }}") },
-			OnEvent:            func(_ string, _ domain.AgentEvent) {},
-			OnExit:             ec.onExit,
-			Logger:             discardLogger(),
+			ConfigFunc:             func() config.ServiceConfig { return cfg },
+			PromptTemplateByIDFunc: func(_ string) *prompt.Template { return mustParseTemplate(t, "{{ .issue.title }}") },
+			OnEvent:                func(_ string, _ domain.AgentEvent) {},
+			OnExit:                 ec.onExit,
+			Logger:                 discardLogger(),
 		}
 
 		RunWorkerAttempt(context.Background(), workerTestIssue(), nil, deps)
@@ -2777,11 +2777,11 @@ func TestRunWorkerAttempt_A2OStatusSignal(t *testing.T) {
 					return domain.TurnResult{SessionID: session.ID, ExitReason: domain.EventTurnCompleted}, nil
 				},
 			},
-			ConfigFunc:         func() config.ServiceConfig { return cfg },
-			PromptTemplateFunc: func() *prompt.Template { return mustParseTemplate(t, "{{ .issue.title }}") },
-			OnEvent:            func(_ string, _ domain.AgentEvent) {},
-			OnExit:             ec.onExit,
-			Logger:             discardLogger(),
+			ConfigFunc:             func() config.ServiceConfig { return cfg },
+			PromptTemplateByIDFunc: func(_ string) *prompt.Template { return mustParseTemplate(t, "{{ .issue.title }}") },
+			OnEvent:                func(_ string, _ domain.AgentEvent) {},
+			OnExit:                 ec.onExit,
+			Logger:                 discardLogger(),
 		}
 
 		RunWorkerAttempt(context.Background(), workerTestIssue(), nil, deps)
@@ -2822,12 +2822,12 @@ func TestRunWorkerAttempt_A2OStatusSignal(t *testing.T) {
 					return result, nil
 				},
 			},
-			AgentAdapter:       &mockAgentAdapter{},
-			ConfigFunc:         func() config.ServiceConfig { return cfg },
-			PromptTemplateFunc: func() *prompt.Template { return mustParseTemplate(t, "{{ .issue.title }}") },
-			OnEvent:            func(_ string, _ domain.AgentEvent) {},
-			OnExit:             ec.onExit,
-			Logger:             discardLogger(),
+			AgentAdapter:           &mockAgentAdapter{},
+			ConfigFunc:             func() config.ServiceConfig { return cfg },
+			PromptTemplateByIDFunc: func(_ string) *prompt.Template { return mustParseTemplate(t, "{{ .issue.title }}") },
+			OnEvent:                func(_ string, _ domain.AgentEvent) {},
+			OnExit:                 ec.onExit,
+			Logger:                 discardLogger(),
 		}
 
 		RunWorkerAttempt(context.Background(), workerTestIssue(), nil, deps)
@@ -2874,13 +2874,13 @@ func TestRunWorkerAttempt_A2OStatusSignal(t *testing.T) {
 
 		deps := WorkerDeps{
 			// runTurnFn writes nothing; the stale file should be gone by now.
-			TrackerAdapter:     &mockTrackerAdapter{},
-			AgentAdapter:       &mockAgentAdapter{},
-			ConfigFunc:         func() config.ServiceConfig { return cfg },
-			PromptTemplateFunc: func() *prompt.Template { return mustParseTemplate(t, "{{ .issue.title }}") },
-			OnEvent:            func(_ string, _ domain.AgentEvent) {},
-			OnExit:             ec.onExit,
-			Logger:             discardLogger(),
+			TrackerAdapter:         &mockTrackerAdapter{},
+			AgentAdapter:           &mockAgentAdapter{},
+			ConfigFunc:             func() config.ServiceConfig { return cfg },
+			PromptTemplateByIDFunc: func(_ string) *prompt.Template { return mustParseTemplate(t, "{{ .issue.title }}") },
+			OnEvent:                func(_ string, _ domain.AgentEvent) {},
+			OnExit:                 ec.onExit,
+			Logger:                 discardLogger(),
 		}
 
 		RunWorkerAttempt(context.Background(), workerTestIssue(), nil, deps)
@@ -2945,11 +2945,11 @@ func TestRuntimeStatusSuffixInjection(t *testing.T) {
 					return domain.TurnResult{SessionID: session.ID, ExitReason: domain.EventTurnCompleted}, nil
 				},
 			},
-			ConfigFunc:         func() config.ServiceConfig { return cfg },
-			PromptTemplateFunc: func() *prompt.Template { return mustParseTemplate(t, "do work on {{ .issue.title }}") },
-			OnEvent:            func(_ string, _ domain.AgentEvent) {},
-			OnExit:             ec.onExit,
-			Logger:             discardLogger(),
+			ConfigFunc:             func() config.ServiceConfig { return cfg },
+			PromptTemplateByIDFunc: func(_ string) *prompt.Template { return mustParseTemplate(t, "do work on {{ .issue.title }}") },
+			OnEvent:                func(_ string, _ domain.AgentEvent) {},
+			OnExit:                 ec.onExit,
+			Logger:                 discardLogger(),
 		}
 
 		RunWorkerAttempt(context.Background(), workerTestIssue(), nil, deps)
@@ -2998,12 +2998,12 @@ func TestRuntimeStatusSuffixInjection(t *testing.T) {
 					return domain.TurnResult{SessionID: session.ID, ExitReason: domain.EventTurnCompleted}, nil
 				},
 			},
-			ConfigFunc:         func() config.ServiceConfig { return cfg },
-			PromptTemplateFunc: func() *prompt.Template { return mustParseTemplate(t, "do work on {{ .issue.title }}") },
-			OnEvent:            func(_ string, _ domain.AgentEvent) {},
-			OnExit:             ec.onExit,
-			Logger:             discardLogger(),
-			ToolRegistry:       reg,
+			ConfigFunc:             func() config.ServiceConfig { return cfg },
+			PromptTemplateByIDFunc: func(_ string) *prompt.Template { return mustParseTemplate(t, "do work on {{ .issue.title }}") },
+			OnEvent:                func(_ string, _ domain.AgentEvent) {},
+			OnExit:                 ec.onExit,
+			Logger:                 discardLogger(),
+			ToolRegistry:           reg,
 		}
 
 		RunWorkerAttempt(context.Background(), workerTestIssue(), nil, deps)
@@ -3052,11 +3052,11 @@ func TestRuntimeStatusSuffixInjection(t *testing.T) {
 					return domain.TurnResult{SessionID: session.ID, ExitReason: domain.EventTurnCompleted}, nil
 				},
 			},
-			ConfigFunc:         func() config.ServiceConfig { return cfg },
-			PromptTemplateFunc: func() *prompt.Template { return mustParseTemplate(t, "turn={{ .run.turn_number }}") },
-			OnEvent:            func(_ string, _ domain.AgentEvent) {},
-			OnExit:             ec.onExit,
-			Logger:             discardLogger(),
+			ConfigFunc:             func() config.ServiceConfig { return cfg },
+			PromptTemplateByIDFunc: func(_ string) *prompt.Template { return mustParseTemplate(t, "turn={{ .run.turn_number }}") },
+			OnEvent:                func(_ string, _ domain.AgentEvent) {},
+			OnExit:                 ec.onExit,
+			Logger:                 discardLogger(),
 		}
 
 		RunWorkerAttempt(context.Background(), workerTestIssue(), nil, deps)
@@ -3107,11 +3107,11 @@ func TestRuntimeStatusSuffixInjection(t *testing.T) {
 					return domain.TurnResult{SessionID: session.ID, ExitReason: domain.EventTurnCompleted}, nil
 				},
 			},
-			ConfigFunc:         func() config.ServiceConfig { return cfg },
-			PromptTemplateFunc: func() *prompt.Template { return mustParseTemplate(t, "") },
-			OnEvent:            func(_ string, _ domain.AgentEvent) {},
-			OnExit:             ec.onExit,
-			Logger:             discardLogger(),
+			ConfigFunc:             func() config.ServiceConfig { return cfg },
+			PromptTemplateByIDFunc: func(_ string) *prompt.Template { return mustParseTemplate(t, "") },
+			OnEvent:                func(_ string, _ domain.AgentEvent) {},
+			OnExit:                 ec.onExit,
+			Logger:                 discardLogger(),
 		}
 
 		RunWorkerAttempt(context.Background(), workerTestIssue(), nil, deps)
@@ -3126,4 +3126,90 @@ func TestRuntimeStatusSuffixInjection(t *testing.T) {
 			t.Errorf("first-turn prompt missing RuntimeStatusSuffix with empty template:\n%s", p)
 		}
 	})
+}
+
+// --- PromptTemplateByIDFunc dispatch ID tests ---
+
+// TestRunWorkerAttempt_PromptTemplateByIDFunc_ForwardsTemplateID verifies that
+// RunWorkerAttempt calls PromptTemplateByIDFunc with the TemplateID from
+// WorkerDeps, allowing the frozen dispatch selection to resolve the correct
+// per-rule template.
+func TestRunWorkerAttempt_PromptTemplateByIDFunc_ForwardsTemplateID(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	cfg := defaultWorkerConfig(tmpDir)
+
+	const wantTemplateID = "/abs/prompts/bug.md"
+
+	var capturedID string
+	ruleTemplate := mustParseTemplate(t, "rule prompt: {{ .issue.title }}")
+
+	ec := newExitCapture()
+	deps := WorkerDeps{
+		TrackerAdapter: &mockTrackerAdapter{
+			fetchStatesFn: func(_ context.Context, ids []string) (map[string]string, error) {
+				result := make(map[string]string, len(ids))
+				for _, id := range ids {
+					result[id] = "Done"
+				}
+				return result, nil
+			},
+		},
+		AgentAdapter: &mockAgentAdapter{},
+		ConfigFunc:   func() config.ServiceConfig { return cfg },
+		PromptTemplateByIDFunc: func(id string) *prompt.Template {
+			capturedID = id
+			return ruleTemplate
+		},
+		TemplateID: wantTemplateID,
+		OnEvent:    func(_ string, _ domain.AgentEvent) {},
+		OnExit:     ec.onExit,
+		Logger:     discardLogger(),
+		Metrics:    &domain.NoopMetrics{},
+	}
+
+	RunWorkerAttempt(context.Background(), workerTestIssue(), nil, deps)
+	ec.waitResult(t)
+
+	if capturedID != wantTemplateID {
+		t.Errorf("PromptTemplateByIDFunc(id) = %q, want %q", capturedID, wantTemplateID)
+	}
+}
+
+// TestRunWorkerAttempt_PromptTemplateByIDFunc_NilTemplateExitsWithError verifies
+// that when PromptTemplateByIDFunc returns nil for the configured TemplateID,
+// the worker calls OnExit with WorkerExitError rather than panicking.
+func TestRunWorkerAttempt_PromptTemplateByIDFunc_NilTemplateExitsWithError(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	cfg := defaultWorkerConfig(tmpDir)
+
+	const badTemplateID = "/nonexistent/template.md"
+
+	ec := newExitCapture()
+	deps := WorkerDeps{
+		TrackerAdapter: &mockTrackerAdapter{},
+		AgentAdapter:   &mockAgentAdapter{},
+		ConfigFunc:     func() config.ServiceConfig { return cfg },
+		PromptTemplateByIDFunc: func(_ string) *prompt.Template {
+			return nil
+		},
+		TemplateID: badTemplateID,
+		OnEvent:    func(_ string, _ domain.AgentEvent) {},
+		OnExit:     ec.onExit,
+		Logger:     discardLogger(),
+		Metrics:    &domain.NoopMetrics{},
+	}
+
+	RunWorkerAttempt(context.Background(), workerTestIssue(), nil, deps)
+	result := ec.waitResult(t)
+
+	if result.ExitKind != WorkerExitError {
+		t.Errorf("WorkerResult.ExitKind = %q, want %q", result.ExitKind, WorkerExitError)
+	}
+	if result.Error == nil {
+		t.Error("WorkerResult.Error = nil, want non-nil error for nil template")
+	}
 }

--- a/internal/persistence/migrate_test.go
+++ b/internal/persistence/migrate_test.go
@@ -203,6 +203,7 @@ func TestMigrate_ColumnCorrectness(t *testing.T) {
 				{"display_identifier", "TEXT", false, 0},
 				{"review_metadata", "TEXT", false, 0},
 				{"rule_name", "TEXT", true, 0},
+				{"template_id", "TEXT", true, 0},
 			},
 		},
 		{

--- a/internal/persistence/migrate_test.go
+++ b/internal/persistence/migrate_test.go
@@ -180,6 +180,9 @@ func TestMigrate_ColumnCorrectness(t *testing.T) {
 				{"due_at_ms", "INTEGER", true, 0},
 				{"error", "TEXT", false, 0},
 				{"session_id", "TEXT", false, 0},
+				{"rule_name", "TEXT", true, 0},
+				{"template_id", "TEXT", true, 0},
+				{"agent_kind", "TEXT", true, 0},
 			},
 		},
 		{
@@ -199,6 +202,7 @@ func TestMigrate_ColumnCorrectness(t *testing.T) {
 				{"turns_completed", "INTEGER", true, 0},
 				{"display_identifier", "TEXT", false, 0},
 				{"review_metadata", "TEXT", false, 0},
+				{"rule_name", "TEXT", true, 0},
 			},
 		},
 		{

--- a/internal/persistence/migrations.go
+++ b/internal/persistence/migrations.go
@@ -38,6 +38,9 @@ var migration008SQL string
 //go:embed sql/009_retry_session_id.sql
 var migration009SQL string
 
+//go:embed sql/010_dispatch_rule_routing.sql
+var migration010SQL string
+
 var migrations = []Migration{
 	{Version: 1, Description: "core persistence tables", SQL: migration001SQL},
 	{Version: 2, Description: "extended token metrics", SQL: migration002SQL},
@@ -48,4 +51,5 @@ var migrations = []Migration{
 	{Version: 7, Description: "self-review metadata in run history", SQL: migration007SQL},
 	{Version: 8, Description: "reaction fingerprints for cross-restart dedup", SQL: migration008SQL},
 	{Version: 9, Description: "session ID in retry entries for cross-retry resume", SQL: migration009SQL},
+	{Version: 10, Description: "dispatch rule routing columns on retry_entries and run_history", SQL: migration010SQL},
 }

--- a/internal/persistence/retry.go
+++ b/internal/persistence/retry.go
@@ -16,6 +16,9 @@ type RetryEntry struct {
 	DueAtMs    int64   // Unix epoch milliseconds when the retry timer should fire.
 	Error      *string // Last error message; nil when no error.
 	SessionID  *string // Adapter-assigned session identifier from the previous worker attempt. Nil when no session was established.
+	RuleName   string  // Dispatch rule name frozen at initial dispatch; empty for legacy rows and fallback dispatches.
+	TemplateID string  // Resolved template path frozen at initial dispatch; empty selects the WORKFLOW.md body template.
+	AgentKind  string  // Agent adapter kind frozen at initial dispatch; empty for legacy rows.
 }
 
 // PendingRetry pairs a persisted [RetryEntry] with the computed delay
@@ -41,15 +44,19 @@ func (s *Store) SaveRetryEntry(ctx context.Context, entry RetryEntry) error {
 	}
 
 	_, err := s.db.ExecContext(ctx,
-		`INSERT INTO retry_entries (issue_id, identifier, attempt, due_at_ms, error, session_id)
-		VALUES (?, ?, ?, ?, ?, ?)
+		`INSERT INTO retry_entries (issue_id, identifier, attempt, due_at_ms, error, session_id, rule_name, template_id, agent_kind)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT (issue_id) DO UPDATE SET
-			identifier = excluded.identifier,
-			attempt    = excluded.attempt,
-			due_at_ms  = excluded.due_at_ms,
-			error      = excluded.error,
-			session_id = excluded.session_id`,
+			identifier  = excluded.identifier,
+			attempt     = excluded.attempt,
+			due_at_ms   = excluded.due_at_ms,
+			error       = excluded.error,
+			session_id  = excluded.session_id,
+			rule_name   = excluded.rule_name,
+			template_id = excluded.template_id,
+			agent_kind  = excluded.agent_kind`,
 		entry.IssueID, entry.Identifier, entry.Attempt, entry.DueAtMs, errVal, ssnVal,
+		entry.RuleName, entry.TemplateID, entry.AgentKind,
 	)
 	if err != nil {
 		return fmt.Errorf("save retry entry %q: %w", entry.IssueID, err)
@@ -62,7 +69,7 @@ func (s *Store) SaveRetryEntry(ctx context.Context, entry RetryEntry) error {
 // (not nil) when no entries exist.
 func (s *Store) LoadRetryEntries(ctx context.Context) ([]RetryEntry, error) {
 	rows, err := s.db.QueryContext(ctx,
-		`SELECT issue_id, identifier, attempt, due_at_ms, error, session_id
+		`SELECT issue_id, identifier, attempt, due_at_ms, error, session_id, rule_name, template_id, agent_kind
 		FROM retry_entries
 		ORDER BY due_at_ms ASC, issue_id ASC`)
 	if err != nil {
@@ -75,7 +82,8 @@ func (s *Store) LoadRetryEntries(ctx context.Context) ([]RetryEntry, error) {
 		var e RetryEntry
 		var errVal sql.NullString
 		var ssnVal sql.NullString
-		if err := rows.Scan(&e.IssueID, &e.Identifier, &e.Attempt, &e.DueAtMs, &errVal, &ssnVal); err != nil {
+		if err := rows.Scan(&e.IssueID, &e.Identifier, &e.Attempt, &e.DueAtMs, &errVal, &ssnVal,
+			&e.RuleName, &e.TemplateID, &e.AgentKind); err != nil {
 			return nil, fmt.Errorf("scan retry entry: %w", err)
 		}
 		if errVal.Valid {

--- a/internal/persistence/run_history.go
+++ b/internal/persistence/run_history.go
@@ -28,6 +28,7 @@ type RunHistory struct {
 	WorkflowFile   string  // Base filename of the WORKFLOW.md file; empty for pre-migration rows.
 	TurnsCompleted int     // Number of coding turns completed in this run.
 	ReviewMetadata *string // JSON-serialized ReviewMetadata; nil when self-review did not run.
+	RuleName       string  // Dispatch rule name frozen at initial dispatch; empty for legacy rows and fallback dispatches.
 }
 
 // AppendRunHistory inserts a completed run attempt into run_history. The ID
@@ -56,11 +57,11 @@ func (s *Store) AppendRunHistory(ctx context.Context, run RunHistory) (RunHistor
 
 	res, err := s.db.ExecContext(ctx,
 		`INSERT INTO run_history
-			(issue_id, identifier, display_identifier, attempt, agent_adapter, workspace, started_at, completed_at, status, error, workflow_file, turns_completed, review_metadata)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			(issue_id, identifier, display_identifier, attempt, agent_adapter, workspace, started_at, completed_at, status, error, workflow_file, turns_completed, review_metadata, rule_name)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		run.IssueID, run.Identifier, dispIDVal, run.Attempt, run.AgentAdapter,
 		run.Workspace, run.StartedAt, run.CompletedAt, run.Status, errVal, wfVal,
-		run.TurnsCompleted, reviewMetaVal,
+		run.TurnsCompleted, reviewMetaVal, run.RuleName,
 	)
 	if err != nil {
 		return RunHistory{}, fmt.Errorf("append run history for %q: %w", run.IssueID, err)
@@ -80,7 +81,7 @@ func (s *Store) AppendRunHistory(ctx context.Context, run RunHistory) (RunHistor
 func (s *Store) QueryRunHistoryByIssue(ctx context.Context, issueID string) ([]RunHistory, error) {
 	rows, err := s.db.QueryContext(ctx,
 		`SELECT id, issue_id, identifier, display_identifier, attempt, agent_adapter, workspace,
-			started_at, completed_at, status, error, workflow_file, turns_completed, review_metadata
+			started_at, completed_at, status, error, workflow_file, turns_completed, review_metadata, rule_name
 		FROM run_history
 		WHERE issue_id = ?
 		ORDER BY id DESC`, issueID)
@@ -96,7 +97,7 @@ func (s *Store) QueryRunHistoryByIssue(ctx context.Context, issueID string) ([]R
 		if err := rows.Scan(
 			&r.ID, &r.IssueID, &r.Identifier, &dispIDVal, &r.Attempt, &r.AgentAdapter,
 			&r.Workspace, &r.StartedAt, &r.CompletedAt, &r.Status, &errVal, &wfVal,
-			&r.TurnsCompleted, &reviewMetaVal,
+			&r.TurnsCompleted, &reviewMetaVal, &r.RuleName,
 		); err != nil {
 			return nil, fmt.Errorf("scan run history: %w", err)
 		}
@@ -151,7 +152,7 @@ func (s *Store) LoadLatestSuccessfulRunsForReactionRecovery(ctx context.Context,
 		)
 		SELECT r.id, r.issue_id, r.identifier, r.display_identifier, r.attempt, r.agent_adapter,
 			r.workspace, r.started_at, r.completed_at, r.status, r.error, r.workflow_file,
-			r.turns_completed, r.review_metadata
+			r.turns_completed, r.review_metadata, r.rule_name
 		FROM run_history AS r
 		JOIN bounded ON bounded.latest_id = r.id
 		ORDER BY r.id DESC`, completedAfter.UTC().Format(time.RFC3339), limit)
@@ -167,7 +168,7 @@ func (s *Store) LoadLatestSuccessfulRunsForReactionRecovery(ctx context.Context,
 		if err := rows.Scan(
 			&run.ID, &run.IssueID, &run.Identifier, &dispIDVal, &run.Attempt, &run.AgentAdapter,
 			&run.Workspace, &run.StartedAt, &run.CompletedAt, &run.Status, &errVal, &wfVal,
-			&run.TurnsCompleted, &reviewMetaVal,
+			&run.TurnsCompleted, &reviewMetaVal, &run.RuleName,
 		); err != nil {
 			return nil, fmt.Errorf("load recovery runs: %w", err)
 		}
@@ -208,7 +209,7 @@ func (s *Store) QueryRecentRunHistory(ctx context.Context, limit int, afterID in
 	if afterID > 0 {
 		rows, err = s.db.QueryContext(ctx,
 			`SELECT id, issue_id, identifier, display_identifier, attempt, agent_adapter, workspace,
-				started_at, completed_at, status, error, workflow_file, turns_completed, review_metadata
+				started_at, completed_at, status, error, workflow_file, turns_completed, review_metadata, rule_name
 			FROM run_history
 			WHERE id < ?
 			ORDER BY id DESC
@@ -216,7 +217,7 @@ func (s *Store) QueryRecentRunHistory(ctx context.Context, limit int, afterID in
 	} else {
 		rows, err = s.db.QueryContext(ctx,
 			`SELECT id, issue_id, identifier, display_identifier, attempt, agent_adapter, workspace,
-				started_at, completed_at, status, error, workflow_file, turns_completed, review_metadata
+				started_at, completed_at, status, error, workflow_file, turns_completed, review_metadata, rule_name
 			FROM run_history
 			ORDER BY id DESC
 			LIMIT ?`, limit)
@@ -233,7 +234,7 @@ func (s *Store) QueryRecentRunHistory(ctx context.Context, limit int, afterID in
 		if err := rows.Scan(
 			&r.ID, &r.IssueID, &r.Identifier, &dispIDVal, &r.Attempt, &r.AgentAdapter,
 			&r.Workspace, &r.StartedAt, &r.CompletedAt, &r.Status, &errVal, &wfVal,
-			&r.TurnsCompleted, &reviewMetaVal,
+			&r.TurnsCompleted, &reviewMetaVal, &r.RuleName,
 		); err != nil {
 			return nil, fmt.Errorf("scan run history: %w", err)
 		}

--- a/internal/persistence/run_history.go
+++ b/internal/persistence/run_history.go
@@ -29,6 +29,7 @@ type RunHistory struct {
 	TurnsCompleted int     // Number of coding turns completed in this run.
 	ReviewMetadata *string // JSON-serialized ReviewMetadata; nil when self-review did not run.
 	RuleName       string  // Dispatch rule name frozen at initial dispatch; empty for legacy rows and fallback dispatches.
+	TemplateID     string  // Resolved template path frozen at initial dispatch; empty for legacy rows and the workflow body template.
 }
 
 // AppendRunHistory inserts a completed run attempt into run_history. The ID
@@ -57,11 +58,11 @@ func (s *Store) AppendRunHistory(ctx context.Context, run RunHistory) (RunHistor
 
 	res, err := s.db.ExecContext(ctx,
 		`INSERT INTO run_history
-			(issue_id, identifier, display_identifier, attempt, agent_adapter, workspace, started_at, completed_at, status, error, workflow_file, turns_completed, review_metadata, rule_name)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			(issue_id, identifier, display_identifier, attempt, agent_adapter, workspace, started_at, completed_at, status, error, workflow_file, turns_completed, review_metadata, rule_name, template_id)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		run.IssueID, run.Identifier, dispIDVal, run.Attempt, run.AgentAdapter,
 		run.Workspace, run.StartedAt, run.CompletedAt, run.Status, errVal, wfVal,
-		run.TurnsCompleted, reviewMetaVal, run.RuleName,
+		run.TurnsCompleted, reviewMetaVal, run.RuleName, run.TemplateID,
 	)
 	if err != nil {
 		return RunHistory{}, fmt.Errorf("append run history for %q: %w", run.IssueID, err)
@@ -81,7 +82,7 @@ func (s *Store) AppendRunHistory(ctx context.Context, run RunHistory) (RunHistor
 func (s *Store) QueryRunHistoryByIssue(ctx context.Context, issueID string) ([]RunHistory, error) {
 	rows, err := s.db.QueryContext(ctx,
 		`SELECT id, issue_id, identifier, display_identifier, attempt, agent_adapter, workspace,
-			started_at, completed_at, status, error, workflow_file, turns_completed, review_metadata, rule_name
+			started_at, completed_at, status, error, workflow_file, turns_completed, review_metadata, rule_name, template_id
 		FROM run_history
 		WHERE issue_id = ?
 		ORDER BY id DESC`, issueID)
@@ -97,7 +98,7 @@ func (s *Store) QueryRunHistoryByIssue(ctx context.Context, issueID string) ([]R
 		if err := rows.Scan(
 			&r.ID, &r.IssueID, &r.Identifier, &dispIDVal, &r.Attempt, &r.AgentAdapter,
 			&r.Workspace, &r.StartedAt, &r.CompletedAt, &r.Status, &errVal, &wfVal,
-			&r.TurnsCompleted, &reviewMetaVal, &r.RuleName,
+			&r.TurnsCompleted, &reviewMetaVal, &r.RuleName, &r.TemplateID,
 		); err != nil {
 			return nil, fmt.Errorf("scan run history: %w", err)
 		}
@@ -152,7 +153,7 @@ func (s *Store) LoadLatestSuccessfulRunsForReactionRecovery(ctx context.Context,
 		)
 		SELECT r.id, r.issue_id, r.identifier, r.display_identifier, r.attempt, r.agent_adapter,
 			r.workspace, r.started_at, r.completed_at, r.status, r.error, r.workflow_file,
-			r.turns_completed, r.review_metadata, r.rule_name
+			r.turns_completed, r.review_metadata, r.rule_name, r.template_id
 		FROM run_history AS r
 		JOIN bounded ON bounded.latest_id = r.id
 		ORDER BY r.id DESC`, completedAfter.UTC().Format(time.RFC3339), limit)
@@ -168,7 +169,7 @@ func (s *Store) LoadLatestSuccessfulRunsForReactionRecovery(ctx context.Context,
 		if err := rows.Scan(
 			&run.ID, &run.IssueID, &run.Identifier, &dispIDVal, &run.Attempt, &run.AgentAdapter,
 			&run.Workspace, &run.StartedAt, &run.CompletedAt, &run.Status, &errVal, &wfVal,
-			&run.TurnsCompleted, &reviewMetaVal, &run.RuleName,
+			&run.TurnsCompleted, &reviewMetaVal, &run.RuleName, &run.TemplateID,
 		); err != nil {
 			return nil, fmt.Errorf("load recovery runs: %w", err)
 		}
@@ -209,7 +210,7 @@ func (s *Store) QueryRecentRunHistory(ctx context.Context, limit int, afterID in
 	if afterID > 0 {
 		rows, err = s.db.QueryContext(ctx,
 			`SELECT id, issue_id, identifier, display_identifier, attempt, agent_adapter, workspace,
-				started_at, completed_at, status, error, workflow_file, turns_completed, review_metadata, rule_name
+				started_at, completed_at, status, error, workflow_file, turns_completed, review_metadata, rule_name, template_id
 			FROM run_history
 			WHERE id < ?
 			ORDER BY id DESC
@@ -217,7 +218,7 @@ func (s *Store) QueryRecentRunHistory(ctx context.Context, limit int, afterID in
 	} else {
 		rows, err = s.db.QueryContext(ctx,
 			`SELECT id, issue_id, identifier, display_identifier, attempt, agent_adapter, workspace,
-				started_at, completed_at, status, error, workflow_file, turns_completed, review_metadata, rule_name
+				started_at, completed_at, status, error, workflow_file, turns_completed, review_metadata, rule_name, template_id
 			FROM run_history
 			ORDER BY id DESC
 			LIMIT ?`, limit)
@@ -234,7 +235,7 @@ func (s *Store) QueryRecentRunHistory(ctx context.Context, limit int, afterID in
 		if err := rows.Scan(
 			&r.ID, &r.IssueID, &r.Identifier, &dispIDVal, &r.Attempt, &r.AgentAdapter,
 			&r.Workspace, &r.StartedAt, &r.CompletedAt, &r.Status, &errVal, &wfVal,
-			&r.TurnsCompleted, &reviewMetaVal, &r.RuleName,
+			&r.TurnsCompleted, &reviewMetaVal, &r.RuleName, &r.TemplateID,
 		); err != nil {
 			return nil, fmt.Errorf("scan run history: %w", err)
 		}

--- a/internal/persistence/sql/010_dispatch_rule_routing.sql
+++ b/internal/persistence/sql/010_dispatch_rule_routing.sql
@@ -3,3 +3,4 @@ ALTER TABLE retry_entries ADD COLUMN rule_name TEXT NOT NULL DEFAULT '';
 ALTER TABLE retry_entries ADD COLUMN template_id TEXT NOT NULL DEFAULT '';
 ALTER TABLE retry_entries ADD COLUMN agent_kind TEXT NOT NULL DEFAULT '';
 ALTER TABLE run_history ADD COLUMN rule_name TEXT NOT NULL DEFAULT '';
+ALTER TABLE run_history ADD COLUMN template_id TEXT NOT NULL DEFAULT '';

--- a/internal/persistence/sql/010_dispatch_rule_routing.sql
+++ b/internal/persistence/sql/010_dispatch_rule_routing.sql
@@ -1,0 +1,5 @@
+-- Migration 10: Add dispatch rule routing columns to retry_entries and run_history
+ALTER TABLE retry_entries ADD COLUMN rule_name TEXT NOT NULL DEFAULT '';
+ALTER TABLE retry_entries ADD COLUMN template_id TEXT NOT NULL DEFAULT '';
+ALTER TABLE retry_entries ADD COLUMN agent_kind TEXT NOT NULL DEFAULT '';
+ALTER TABLE run_history ADD COLUMN rule_name TEXT NOT NULL DEFAULT '';

--- a/internal/persistence/store_test.go
+++ b/internal/persistence/store_test.go
@@ -2625,3 +2625,117 @@ func TestLoadLatestSuccessfulRunsForReactionRecovery_DBError(t *testing.T) {
 		t.Errorf("LoadLatestSuccessfulRunsForReactionRecovery error = %q, want wrapped 'load recovery runs'", err.Error())
 	}
 }
+
+func TestSaveRetryEntry_DispatchColumnsRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	s := openTestStore(t)
+	migrateOrFatal(t, s)
+	ctx := context.Background()
+
+	entry := RetryEntry{
+		IssueID:    "ISS-99",
+		Identifier: "PROJ-99",
+		Attempt:    2,
+		DueAtMs:    9000,
+		RuleName:   "bug-rule",
+		TemplateID: "/abs/path/bug.md",
+		AgentKind:  "claude-code",
+	}
+	if err := s.SaveRetryEntry(ctx, entry); err != nil {
+		t.Fatalf("SaveRetryEntry: %v", err)
+	}
+
+	entries, err := s.LoadRetryEntries(ctx)
+	if err != nil {
+		t.Fatalf("LoadRetryEntries: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("LoadRetryEntries() count = %d, want 1", len(entries))
+	}
+
+	got := entries[0]
+	if got.RuleName != "bug-rule" {
+		t.Errorf("RuleName = %q, want %q", got.RuleName, "bug-rule")
+	}
+	if got.TemplateID != "/abs/path/bug.md" {
+		t.Errorf("TemplateID = %q, want %q", got.TemplateID, "/abs/path/bug.md")
+	}
+	if got.AgentKind != "claude-code" {
+		t.Errorf("AgentKind = %q, want %q", got.AgentKind, "claude-code")
+	}
+}
+
+func TestSaveRetryEntry_LegacyRowsDefaultToEmptyDispatchFields(t *testing.T) {
+	t.Parallel()
+
+	s := openTestStore(t)
+	migrateOrFatal(t, s)
+	ctx := context.Background()
+
+	// Insert without dispatch columns to simulate legacy rows.
+	if _, err := s.db.ExecContext(ctx,
+		`INSERT INTO retry_entries (issue_id, identifier, attempt, due_at_ms)
+		 VALUES ('legacy-1', 'MT-1', 1, 1000)`); err != nil {
+		t.Fatalf("insert legacy row: %v", err)
+	}
+
+	entries, err := s.LoadRetryEntries(ctx)
+	if err != nil {
+		t.Fatalf("LoadRetryEntries: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("LoadRetryEntries() count = %d, want 1", len(entries))
+	}
+
+	got := entries[0]
+	if got.RuleName != "" {
+		t.Errorf("legacy RuleName = %q, want empty string", got.RuleName)
+	}
+	if got.TemplateID != "" {
+		t.Errorf("legacy TemplateID = %q, want empty string", got.TemplateID)
+	}
+	if got.AgentKind != "" {
+		t.Errorf("legacy AgentKind = %q, want empty string", got.AgentKind)
+	}
+}
+
+func TestAppendRunHistory_RuleNameRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	s := openTestStore(t)
+	migrateOrFatal(t, s)
+	ctx := context.Background()
+
+	run := RunHistory{
+		IssueID:      "ISS-77",
+		Identifier:   "PROJ-77",
+		Attempt:      1,
+		AgentAdapter: "claude-code",
+		Workspace:    "/tmp/ws",
+		StartedAt:    "2026-01-01T00:00:00Z",
+		CompletedAt:  "2026-01-01T00:05:00Z",
+		Status:       "succeeded",
+		RuleName:     "docs-rule",
+	}
+	inserted, err := s.AppendRunHistory(ctx, run)
+	if err != nil {
+		t.Fatalf("AppendRunHistory: %v", err)
+	}
+
+	entries, err := s.QueryRunHistoryByIssue(ctx, "ISS-77")
+	if err != nil {
+		t.Fatalf("QueryRunHistoryByIssue: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("QueryRunHistoryByIssue() count = %d, want 1", len(entries))
+	}
+
+	got := entries[0]
+	if got.RuleName != "docs-rule" {
+		t.Errorf("RuleName = %q, want %q", got.RuleName, "docs-rule")
+	}
+	if got.ID != inserted.ID {
+		t.Errorf("ID = %d, want %d", got.ID, inserted.ID)
+	}
+}

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -212,6 +212,16 @@ func (r *Registry[T, M]) Kinds() []string {
 	return r.sortedKinds()
 }
 
+// Has reports whether the given kind is registered. The lookup is
+// exact-match (case-sensitive) and allocates nothing. Safe for
+// concurrent use.
+func (r *Registry[T, M]) Has(kind string) bool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	_, ok := r.adapters[kind]
+	return ok
+}
+
 // sortedKinds collects and sorts the registered kind strings. The
 // caller must hold r.mu (read or write). Always returns a non-nil slice.
 func (r *Registry[T, M]) sortedKinds() []string {

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -521,3 +521,61 @@ func TestPackageLevelRegistries(t *testing.T) {
 		}
 	})
 }
+
+func TestHas(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		register []string
+		lookup   string
+		want     bool
+	}{
+		{
+			name:     "registered kind returns true",
+			register: []string{"alpha", "beta"},
+			lookup:   "alpha",
+			want:     true,
+		},
+		{
+			name:     "second registered kind returns true",
+			register: []string{"alpha", "beta"},
+			lookup:   "beta",
+			want:     true,
+		},
+		{
+			name:     "unknown kind returns false",
+			register: []string{"alpha"},
+			lookup:   "gamma",
+			want:     false,
+		},
+		{
+			name:     "empty registry returns false",
+			register: nil,
+			lookup:   "anything",
+			want:     false,
+		},
+		{
+			name:     "case-sensitive lookup: wrong case returns false",
+			register: []string{"Claude-Code"},
+			lookup:   "claude-code",
+			want:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			r := newTestRegistry()
+			for _, k := range tt.register {
+				r.Register(k, dummyConstructor())
+			}
+
+			got := r.Has(tt.lookup)
+			if got != tt.want {
+				t.Errorf("Has(%q) = %v, want %v", tt.lookup, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/server/metrics.go
+++ b/internal/server/metrics.go
@@ -36,6 +36,7 @@ type PromMetrics struct {
 	ciEscalationsTotal     *prometheus.CounterVec
 	reviewChecksTotal      *prometheus.CounterVec
 	reviewEscalationsTotal *prometheus.CounterVec
+	dispatchRuleMatchTotal *prometheus.CounterVec
 
 	selfReviewIterationsTotal      *prometheus.CounterVec
 	selfReviewSessionsTotal        *prometheus.CounterVec
@@ -209,6 +210,12 @@ func NewPromMetrics(version, goVersion string) *PromMetrics {
 		Help:      "Review reaction escalation outcomes.",
 	}, []string{"action"})
 
+	dispatchRuleMatchTotal := prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "sortie",
+		Name:      "dispatch_rule_match_total",
+		Help:      "Dispatch rule match outcomes by resolution layer and rule name.",
+	}, []string{"layer", "rule"})
+
 	selfReviewIterationsTotal := prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "sortie",
 		Name:      "self_review_iterations_total",
@@ -259,6 +266,7 @@ func NewPromMetrics(version, goVersion string) *PromMetrics {
 		ciEscalationsTotal,
 		reviewChecksTotal,
 		reviewEscalationsTotal,
+		dispatchRuleMatchTotal,
 		selfReviewIterationsTotal,
 		selfReviewSessionsTotal,
 		selfReviewVerificationDuration,
@@ -290,6 +298,7 @@ func NewPromMetrics(version, goVersion string) *PromMetrics {
 		ciEscalationsTotal:             ciEscalationsTotal,
 		reviewChecksTotal:              reviewChecksTotal,
 		reviewEscalationsTotal:         reviewEscalationsTotal,
+		dispatchRuleMatchTotal:         dispatchRuleMatchTotal,
 		selfReviewIterationsTotal:      selfReviewIterationsTotal,
 		selfReviewSessionsTotal:        selfReviewSessionsTotal,
 		selfReviewVerificationDuration: selfReviewVerificationDuration,
@@ -426,6 +435,14 @@ func (p *PromMetrics) IncReviewChecks(result string) {
 // IncReviewEscalations increments the review escalation action counter.
 func (p *PromMetrics) IncReviewEscalations(action string) {
 	p.reviewEscalationsTotal.WithLabelValues(action).Inc()
+}
+
+// IncDispatchRuleMatch increments the dispatch rule match counter.
+// layer is one of "rule", "default", or "fallback"; rule is the
+// matched rule name with empty values replaced by "<none>" to keep
+// the label cardinality bounded.
+func (p *PromMetrics) IncDispatchRuleMatch(layer, rule string) {
+	p.dispatchRuleMatchTotal.WithLabelValues(layer, rule).Inc()
 }
 
 // IncSelfReviewIterations increments the review iteration counter.

--- a/internal/server/metrics.go
+++ b/internal/server/metrics.go
@@ -438,10 +438,14 @@ func (p *PromMetrics) IncReviewEscalations(action string) {
 }
 
 // IncDispatchRuleMatch increments the dispatch rule match counter.
-// layer is one of "rule", "default", or "fallback"; rule is the
-// matched rule name with empty values replaced by "<none>" to keep
-// the label cardinality bounded.
+// layer is one of "rule", "default", or "fallback". An empty rule
+// value is normalized to "<none>" inside this method so callers
+// cannot accidentally emit an empty-label time series, keeping the
+// label cardinality bounded.
 func (p *PromMetrics) IncDispatchRuleMatch(layer, rule string) {
+	if rule == "" {
+		rule = "<none>"
+	}
 	p.dispatchRuleMatchTotal.WithLabelValues(layer, rule).Inc()
 }
 

--- a/internal/server/metrics_test.go
+++ b/internal/server/metrics_test.go
@@ -747,13 +747,19 @@ func TestIncDispatchRuleMatch_CardinalityBounded(t *testing.T) {
 		t.Errorf("metric family cardinality = %d, want 3", len(f.GetMetric()))
 	}
 
-	// Empty-rule normalization: calling with rule="" produces a distinct time series
-	// only when the caller passes an already-normalized label. The production code
-	// always normalizes before calling, so passing "<none>" is the expected form.
+	// IncDispatchRuleMatch normalizes rule=="" to "<none>" inside the
+	// method, so passing an empty string folds into the same series as
+	// the already-normalized "<none>" call without growing cardinality.
 	m.IncDispatchRuleMatch("fallback", "<none>")
+	m.IncDispatchRuleMatch("fallback", "")
 	families = gatherFamilies(t, m)
 	f = families["sortie_dispatch_rule_match_total"]
 	if len(f.GetMetric()) != 3 {
-		t.Errorf("second <none> call grew cardinality to %d, want 3", len(f.GetMetric()))
+		t.Errorf("empty-rule fold grew cardinality to %d, want 3", len(f.GetMetric()))
+	}
+	got := counterValue(t, families, "sortie_dispatch_rule_match_total",
+		map[string]string{"layer": "fallback", "rule": "<none>"})
+	if got != 3 {
+		t.Errorf("fallback/<none> counter = %v, want 3", got)
 	}
 }

--- a/internal/server/metrics_test.go
+++ b/internal/server/metrics_test.go
@@ -668,3 +668,92 @@ func TestPromMetrics_CICounters(t *testing.T) {
 		}
 	})
 }
+
+func TestIncDispatchRuleMatch(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		calls     []struct{ layer, rule string }
+		wantLabel struct{ layer, rule string }
+		wantCount float64
+	}{
+		{
+			name: "rule layer increments counter",
+			calls: []struct{ layer, rule string }{
+				{"rule", "bug-rule"},
+				{"rule", "bug-rule"},
+			},
+			wantLabel: struct{ layer, rule string }{"rule", "bug-rule"},
+			wantCount: 2,
+		},
+		{
+			name: "default layer increments counter",
+			calls: []struct{ layer, rule string }{
+				{"default", "default"},
+			},
+			wantLabel: struct{ layer, rule string }{"default", "default"},
+			wantCount: 1,
+		},
+		{
+			name: "fallback layer with none sentinel",
+			calls: []struct{ layer, rule string }{
+				{"fallback", "<none>"},
+				{"fallback", "<none>"},
+				{"fallback", "<none>"},
+			},
+			wantLabel: struct{ layer, rule string }{"fallback", "<none>"},
+			wantCount: 3,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			m := newTestMetrics(t)
+			for _, c := range tt.calls {
+				m.IncDispatchRuleMatch(c.layer, c.rule)
+			}
+
+			families := gatherFamilies(t, m)
+			got := counterValue(t, families, "sortie_dispatch_rule_match_total",
+				map[string]string{"layer": tt.wantLabel.layer, "rule": tt.wantLabel.rule})
+			if got != tt.wantCount {
+				t.Errorf("IncDispatchRuleMatch(%q, %q) counter = %v, want %v",
+					tt.wantLabel.layer, tt.wantLabel.rule, got, tt.wantCount)
+			}
+		})
+	}
+}
+
+func TestIncDispatchRuleMatch_CardinalityBounded(t *testing.T) {
+	t.Parallel()
+
+	m := newTestMetrics(t)
+
+	// Three distinct rule names produce three label pairs for the same layer.
+	m.IncDispatchRuleMatch("rule", "bug-rule")
+	m.IncDispatchRuleMatch("rule", "docs-rule")
+	m.IncDispatchRuleMatch("fallback", "<none>")
+
+	families := gatherFamilies(t, m)
+	f, ok := families["sortie_dispatch_rule_match_total"]
+	if !ok {
+		t.Fatal("sortie_dispatch_rule_match_total not found")
+	}
+
+	if len(f.GetMetric()) != 3 {
+		t.Errorf("metric family cardinality = %d, want 3", len(f.GetMetric()))
+	}
+
+	// Empty-rule normalization: calling with rule="" produces a distinct time series
+	// only when the caller passes an already-normalized label. The production code
+	// always normalizes before calling, so passing "<none>" is the expected form.
+	m.IncDispatchRuleMatch("fallback", "<none>")
+	families = gatherFamilies(t, m)
+	f = families["sortie_dispatch_rule_match_total"]
+	if len(f.GetMetric()) != 3 {
+		t.Errorf("second <none> call grew cardinality to %d, want 3", len(f.GetMetric()))
+	}
+}

--- a/internal/workflow/manager.go
+++ b/internal/workflow/manager.go
@@ -1,9 +1,11 @@
 package workflow
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"log/slog"
+	"os"
 	"path/filepath"
 	"sync"
 	"sync/atomic"
@@ -35,19 +37,34 @@ func WithValidateFunc(fn ValidateFunc) ManagerOption {
 	return func(m *Manager) { m.validateFunc = fn }
 }
 
+// WithAgentKindProbe sets the agent-kind registry probe used by
+// dispatch-rule validation at workflow load time. The probe receives
+// an agent kind string and returns true when the kind is currently
+// registered. Callers wire the closure to the registry pointer; the
+// workflow package never imports the registry package itself.
+//
+// When the probe is nil (the default), the dispatch builder treats
+// every agent kind as registered. The orchestrator's startup
+// preflight still rejects unknown kinds as a defense-in-depth gate.
+func WithAgentKindProbe(probe func(kind string) bool) ManagerOption {
+	return func(m *Manager) { m.agentKindProbe = probe }
+}
+
 // Manager watches a workflow file for changes and maintains the current
 // effective configuration. The latest config and prompt template are
 // available via [Manager.Config] and [Manager.PromptTemplate]. Safe for
 // concurrent use.
 type Manager struct {
-	path         string
-	logger       *slog.Logger
-	validateFunc ValidateFunc
+	path           string
+	logger         *slog.Logger
+	validateFunc   ValidateFunc
+	agentKindProbe func(kind string) bool
 
-	mu            sync.RWMutex
-	currentConfig config.ServiceConfig
-	currentPrompt *prompt.Template
-	lastLoadErr   error
+	mu                   sync.RWMutex
+	currentConfig        config.ServiceConfig
+	currentPrompt        *prompt.Template
+	currentTemplateIndex map[string]*prompt.Template
+	lastLoadErr          error
 
 	watcher *fsnotify.Watcher
 	done    chan struct{}
@@ -75,7 +92,7 @@ func NewManager(path string, logger *slog.Logger, opts ...ManagerOption) (*Manag
 		o(m)
 	}
 
-	cfg, tmpl, err := m.loadPipeline()
+	cfg, tmpl, index, err := m.loadPipeline()
 	if err != nil {
 		return nil, err
 	}
@@ -88,6 +105,7 @@ func NewManager(path string, logger *slog.Logger, opts ...ManagerOption) (*Manag
 
 	m.currentConfig = cfg
 	m.currentPrompt = tmpl
+	m.currentTemplateIndex = index
 	return m, nil
 }
 
@@ -107,6 +125,25 @@ func (m *Manager) PromptTemplate() *prompt.Template {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	return m.currentPrompt
+}
+
+// PromptTemplateByID returns the parsed prompt template registered
+// under id. The empty-string key returns the WORKFLOW.md body
+// template. Returns nil when the id is unknown. Safe for concurrent
+// use.
+func (m *Manager) PromptTemplateByID(id string) *prompt.Template {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if m.currentTemplateIndex == nil {
+		if id == "" {
+			return m.currentPrompt
+		}
+		return nil
+	}
+	if tmpl, ok := m.currentTemplateIndex[id]; ok {
+		return tmpl
+	}
+	return nil
 }
 
 // FilePath returns the base filename of the workflow file (e.g.
@@ -155,7 +192,7 @@ func (m *Manager) SetLogger(logger *slog.Logger) {
 // is retained and the error is returned. This supports the orchestrator's
 // defensive re-validation before dispatch. Safe for concurrent use.
 func (m *Manager) Reload() error {
-	cfg, tmpl, err := m.loadPipeline()
+	cfg, tmpl, index, err := m.loadPipeline()
 	if err != nil {
 		m.mu.Lock()
 		m.lastLoadErr = err
@@ -175,6 +212,7 @@ func (m *Manager) Reload() error {
 	m.mu.Lock()
 	m.currentConfig = cfg
 	m.currentPrompt = tmpl
+	m.currentTemplateIndex = index
 	m.lastLoadErr = nil
 	m.mu.Unlock()
 	return nil
@@ -267,7 +305,7 @@ func (m *Manager) watch(ctx context.Context) {
 
 func (m *Manager) reload() {
 	logger := m.currentLogger()
-	cfg, tmpl, err := m.loadPipeline()
+	cfg, tmpl, index, err := m.loadPipeline()
 	if err != nil {
 		logger.Error("workflow reload failed", slog.Any("error", err), slog.String("path", m.path))
 		m.mu.Lock()
@@ -290,27 +328,103 @@ func (m *Manager) reload() {
 	m.mu.Lock()
 	m.currentConfig = cfg
 	m.currentPrompt = tmpl
+	m.currentTemplateIndex = index
 	m.lastLoadErr = nil
 	m.mu.Unlock()
 	logger.Info("workflow reloaded", slog.String("path", m.path))
 }
 
-// loadPipeline runs the full Load → NewServiceConfig → Parse pipeline.
-func (m *Manager) loadPipeline() (config.ServiceConfig, *prompt.Template, error) {
+// loadPipeline runs the full Load -> NewServiceConfig -> dispatch
+// build -> Parse pipeline. Returns the parsed service config, the
+// body template, and the per-template index keyed by resolved
+// absolute path (empty key holds the body template). On any error
+// the caller retains the previous values and surfaces the error via
+// [Manager.LastLoadError].
+func (m *Manager) loadPipeline() (config.ServiceConfig, *prompt.Template, map[string]*prompt.Template, error) {
 	wf, err := Load(m.path)
 	if err != nil {
-		return config.ServiceConfig{}, nil, err
+		return config.ServiceConfig{}, nil, nil, err
 	}
 
 	cfg, err := config.NewServiceConfig(wf.Config)
 	if err != nil {
-		return config.ServiceConfig{}, nil, err
+		return config.ServiceConfig{}, nil, nil, err
 	}
+
+	probe := m.agentKindProbe
+	if probe == nil {
+		// Permissive default: callers without an orchestrator
+		// dependency (dryrun, tests) accept any agent kind. The
+		// startup preflight rejects unknown kinds as a second gate.
+		probe = func(string) bool { return true }
+	}
+
+	dispatchCfg, err := config.BuildDispatchConfig(wf.Config, filepath.Dir(m.path), probe)
+	if err != nil {
+		return config.ServiceConfig{}, nil, nil, err
+	}
+	cfg.SetDispatch(dispatchCfg)
 
 	tmpl, err := prompt.Parse(wf.PromptTemplate, m.path, wf.FrontMatterLines)
 	if err != nil {
-		return config.ServiceConfig{}, nil, err
+		return config.ServiceConfig{}, nil, nil, err
 	}
 
-	return cfg, tmpl, nil
+	index, err := loadPerRuleTemplates(dispatchCfg, tmpl)
+	if err != nil {
+		return config.ServiceConfig{}, nil, nil, err
+	}
+
+	return cfg, tmpl, index, nil
+}
+
+// loadPerRuleTemplates reads and parses every unique per-rule
+// template referenced by the dispatch config. The returned index is
+// keyed by resolved absolute path; the empty-string key holds the
+// already-parsed body template.
+func loadPerRuleTemplates(dispatchCfg config.DispatchConfig, body *prompt.Template) (map[string]*prompt.Template, error) {
+	index := map[string]*prompt.Template{"": body}
+
+	unique := make(map[string]struct{})
+	for _, rule := range dispatchCfg.Rules {
+		if rule.Selection.TemplateID == "" {
+			continue
+		}
+		unique[rule.Selection.TemplateID] = struct{}{}
+	}
+	if dispatchCfg.Default.TemplateID != "" {
+		unique[dispatchCfg.Default.TemplateID] = struct{}{}
+	}
+
+	for absPath := range unique {
+		bodyBytes, err := os.ReadFile(absPath) //nolint:gosec // path was resolved and validated by BuildDispatchConfig
+		if err != nil {
+			return nil, &prompt.TemplateError{
+				Kind:   prompt.ErrTemplateParse,
+				Source: absPath,
+				Err:    fmt.Errorf("read per-rule template: %w", err),
+			}
+		}
+		if hasFrontMatterMarker(bodyBytes) {
+			return nil, &prompt.TemplateError{
+				Kind:   prompt.ErrTemplateParse,
+				Source: absPath,
+				Err:    fmt.Errorf("per-rule templates must not carry front matter"),
+			}
+		}
+		parsed, err := prompt.Parse(string(bodyBytes), absPath, 0)
+		if err != nil {
+			return nil, err
+		}
+		index[absPath] = parsed
+	}
+
+	return index, nil
+}
+
+// hasFrontMatterMarker reports whether the byte buffer starts with
+// the YAML front matter delimiter, after skipping leading whitespace.
+func hasFrontMatterMarker(b []byte) bool {
+	trimmed := bytes.TrimLeft(b, " \t\r\n")
+	return bytes.HasPrefix(trimmed, []byte("---"))
 }

--- a/internal/workflow/manager.go
+++ b/internal/workflow/manager.go
@@ -423,8 +423,12 @@ func loadPerRuleTemplates(dispatchCfg config.DispatchConfig, body *prompt.Templa
 }
 
 // hasFrontMatterMarker reports whether the byte buffer starts with
-// the YAML front matter delimiter, after skipping leading whitespace.
+// the YAML front matter delimiter, after skipping a leading UTF-8 BOM
+// and any whitespace. The BOM is stripped first because Windows editors
+// frequently prepend it to UTF-8 files, and a delimiter check on the
+// raw bytes would otherwise miss the front matter on those inputs.
 func hasFrontMatterMarker(b []byte) bool {
-	trimmed := bytes.TrimLeft(b, " \t\r\n")
+	trimmed := bytes.TrimPrefix(b, []byte(utf8BOM))
+	trimmed = bytes.TrimLeft(trimmed, " \t\r\n")
 	return bytes.HasPrefix(trimmed, []byte("---"))
 }

--- a/internal/workflow/manager_test.go
+++ b/internal/workflow/manager_test.go
@@ -913,7 +913,14 @@ func TestManager_PromptTemplateByID_UnknownIDReturnsNil(t *testing.T) {
 func TestManager_PromptTemplateByID_KnownRuleTemplate(t *testing.T) {
 	t.Parallel()
 
-	dir := t.TempDir()
+	// Canonicalize the temp dir via EvalSymlinks so the expected key
+	// matches the resolved absolute path the manager registers (on
+	// Windows, t.TempDir() may return an 8.3 short name that the
+	// manager's symlink-evaluation step rewrites to the long form).
+	dir, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatalf("EvalSymlinks(t.TempDir()): %v", err)
+	}
 	content := workflowWithDispatch(t, dir)
 	path := filepath.Join(dir, "WORKFLOW.md")
 	mustWriteFile(t, path, content)
@@ -929,6 +936,52 @@ func TestManager_PromptTemplateByID_KnownRuleTemplate(t *testing.T) {
 	got := mgr.PromptTemplateByID(bugTmplAbs)
 	if got == nil {
 		t.Fatalf("PromptTemplateByID(%q) = nil, want non-nil", bugTmplAbs)
+	}
+}
+
+// TestManager_PromptTemplateByID_CanonicalKeyAcrossSymlinks locks the
+// invariant that the per-rule template index is keyed by the canonical,
+// EvalSymlinks-resolved absolute path, even when the workflow file is
+// reached through a symlinked workflow directory. Windows CI runners
+// surfaced this contract via 8.3 short-name paths (RUNNER~1 → long
+// form); creating an explicit symlink reproduces the same canonical-
+// vs-raw drift on Linux and macOS so the regression is caught on every
+// supported runner. Skips gracefully on hosts where os.Symlink is
+// unsupported or forbidden.
+func TestManager_PromptTemplateByID_CanonicalKeyAcrossSymlinks(t *testing.T) {
+	t.Parallel()
+
+	base, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatalf("EvalSymlinks(t.TempDir()) error = %v, want nil", err)
+	}
+	canonical := filepath.Join(base, "real")
+	if err := os.MkdirAll(canonical, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%q) error = %v, want nil", canonical, err)
+	}
+
+	via := filepath.Join(base, "via")
+	if err := os.Symlink(canonical, via); err != nil {
+		if errors.Is(err, errors.ErrUnsupported) {
+			t.Skipf("os.Symlink(%q -> %q) unsupported on this filesystem: %v", canonical, via, err)
+		}
+		t.Skipf("os.Symlink(%q -> %q) = %v (skipping symlink-based assertion)", canonical, via, err)
+	}
+
+	// Write the workflow and its template under the canonical
+	// directory so the on-disk layout is independent of which path
+	// (canonical or symlinked) the manager is asked to load from.
+	content := workflowWithDispatch(t, canonical)
+	mustWriteFile(t, filepath.Join(canonical, "WORKFLOW.md"), content)
+
+	mgr, err := NewManager(filepath.Join(via, "WORKFLOW.md"), testLogger())
+	if err != nil {
+		t.Fatalf("NewManager(via=%q) error = %v, want nil", via, err)
+	}
+
+	wantKey := filepath.Join(canonical, "prompts", "bug.md")
+	if got := mgr.PromptTemplateByID(wantKey); got == nil {
+		t.Fatalf("PromptTemplateByID(canonical=%q) = nil, want non-nil", wantKey)
 	}
 }
 

--- a/internal/workflow/manager_test.go
+++ b/internal/workflow/manager_test.go
@@ -841,3 +841,234 @@ func TestManager_SetLoggerConcurrentWithReload(t *testing.T) {
 	wg.Wait()
 	mgr.Stop()
 }
+
+// workflowWithDispatch returns WORKFLOW.md content with dispatch rules
+// that reference template files that exist under dir.
+func workflowWithDispatch(t *testing.T, dir string) []byte {
+	t.Helper()
+	tmplDir := filepath.Join(dir, "prompts")
+	if err := os.MkdirAll(tmplDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	bugTmpl := filepath.Join(tmplDir, "bug.md")
+	if err := os.WriteFile(bugTmpl, []byte("bug template {{ .issue.identifier }}"), 0o644); err != nil {
+		t.Fatalf("write bug.md: %v", err)
+	}
+	return []byte(`---
+polling:
+  interval_ms: 5000
+agent:
+  kind: mock
+dispatch:
+  rules:
+    - name: bug
+      match:
+        labels: ["bug"]
+      template: prompts/bug.md
+---
+You are assigned to {{ .issue.identifier }}.
+`)
+}
+
+func TestManager_PromptTemplateByID_EmptyIDReturnsBodyTemplate(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "WORKFLOW.md")
+	mustWriteFile(t, path, validWorkflow(5000))
+
+	mgr, err := NewManager(path, testLogger())
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+
+	got := mgr.PromptTemplateByID("")
+	if got == nil {
+		t.Fatal("PromptTemplateByID(\"\") = nil, want body template")
+	}
+	body := mgr.PromptTemplate()
+	if got != body {
+		t.Errorf("PromptTemplateByID(\"\") != PromptTemplate(): pointers differ")
+	}
+}
+
+func TestManager_PromptTemplateByID_UnknownIDReturnsNil(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "WORKFLOW.md")
+	mustWriteFile(t, path, validWorkflow(5000))
+
+	mgr, err := NewManager(path, testLogger())
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+
+	got := mgr.PromptTemplateByID("/nonexistent/path.md")
+	if got != nil {
+		t.Errorf("PromptTemplateByID(\"/nonexistent/path.md\") = non-nil, want nil")
+	}
+}
+
+func TestManager_PromptTemplateByID_KnownRuleTemplate(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	content := workflowWithDispatch(t, dir)
+	path := filepath.Join(dir, "WORKFLOW.md")
+	mustWriteFile(t, path, content)
+
+	mgr, err := NewManager(path, testLogger())
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+
+	// The template is registered under its resolved absolute path.
+	bugTmplAbs := filepath.Join(dir, "prompts", "bug.md")
+
+	got := mgr.PromptTemplateByID(bugTmplAbs)
+	if got == nil {
+		t.Fatalf("PromptTemplateByID(%q) = nil, want non-nil", bugTmplAbs)
+	}
+}
+
+func TestManager_WithAgentKindProbe_AcceptsKnownKind(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "WORKFLOW.md")
+	// Use a workflow with agent kind "mock" — probe accepts it.
+	mustWriteFile(t, path, []byte(`---
+polling:
+  interval_ms: 5000
+agent:
+  kind: mock
+dispatch:
+  rules:
+    - name: test
+      agent: mock
+---
+Prompt.
+`))
+
+	probe := func(kind string) bool { return kind == "mock" }
+	mgr, err := NewManager(path, testLogger(), WithAgentKindProbe(probe))
+	if err != nil {
+		t.Fatalf("NewManager with probe: %v", err)
+	}
+	if mgr == nil {
+		t.Fatal("NewManager returned nil manager")
+	}
+}
+
+func TestManager_WithAgentKindProbe_RejectsUnknownKind(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "WORKFLOW.md")
+	// Dispatch rule references "nonexistent-agent".
+	mustWriteFile(t, path, []byte(`---
+polling:
+  interval_ms: 5000
+agent:
+  kind: mock
+dispatch:
+  rules:
+    - name: bad
+      agent: nonexistent-agent
+---
+Prompt.
+`))
+
+	probe := func(kind string) bool { return kind == "mock" }
+	_, err := NewManager(path, testLogger(), WithAgentKindProbe(probe))
+	if err == nil {
+		t.Fatal("NewManager with rejecting probe = nil error, want error")
+	}
+}
+
+func TestManager_FailSafeReload_DispatchError(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "WORKFLOW.md")
+	mustWriteFile(t, path, validWorkflow(5000))
+
+	mgr, err := NewManager(path, testLogger())
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+
+	initialInterval := mgr.Config().Polling.IntervalMS
+	initialPrompt := mgr.PromptTemplate()
+
+	// Overwrite with an invalid dispatch glob that BuildDispatchConfig will reject.
+	mustWriteFile(t, path, []byte(`---
+polling:
+  interval_ms: 9999
+dispatch:
+  rules:
+    - name: bad-glob
+      match:
+        labels: ["[unclosed"]
+      agent: mock
+---
+Prompt.
+`))
+
+	err = mgr.Reload()
+	if err == nil {
+		t.Fatal("Reload() error = nil, want error for invalid dispatch config")
+	}
+
+	if mgr.Config().Polling.IntervalMS != initialInterval {
+		t.Errorf("after failed Reload: Polling.IntervalMS = %d, want %d (previous good value)",
+			mgr.Config().Polling.IntervalMS, initialInterval)
+	}
+	if mgr.PromptTemplate() != initialPrompt {
+		t.Errorf("after failed Reload: PromptTemplate pointer changed, want same previous good template")
+	}
+	if mgr.LastLoadError() == nil {
+		t.Error("after failed Reload: LastLoadError() = nil, want non-nil")
+	}
+}
+
+func TestManager_PerRuleTemplate_FrontMatterRejected(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+
+	// Write a per-rule template that has front matter — must be rejected.
+	tmplDir := filepath.Join(dir, "prompts")
+	if err := os.MkdirAll(tmplDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	tmplPath := filepath.Join(tmplDir, "with_fm.md")
+	if err := os.WriteFile(tmplPath, []byte("---\nkey: value\n---\nTemplate body."), 0o644); err != nil {
+		t.Fatalf("write template: %v", err)
+	}
+
+	path := filepath.Join(dir, "WORKFLOW.md")
+	mustWriteFile(t, path, []byte(`---
+polling:
+  interval_ms: 5000
+dispatch:
+  rules:
+    - name: with-fm
+      match:
+        labels: ["test"]
+      template: prompts/with_fm.md
+---
+Prompt.
+`))
+
+	_, err := NewManager(path, testLogger())
+	if err == nil {
+		t.Fatal("NewManager with front-matter template = nil error, want error")
+	}
+
+	errMsg := err.Error()
+	if !bytes.Contains([]byte(errMsg), []byte("front matter")) {
+		t.Errorf("error = %q, want to contain %q", errMsg, "front matter")
+	}
+}

--- a/testdata/workflow/dispatch_rules_absolute_path.md
+++ b/testdata/workflow/dispatch_rules_absolute_path.md
@@ -1,0 +1,23 @@
+---
+tracker:
+  kind: file
+  project: dispatch-fixture
+  active_states: [todo, in-progress]
+  terminal_states: [done]
+
+agent:
+  kind: mock
+  command: mock
+  max_turns: 1
+
+mock:
+  reply: noop
+
+dispatch:
+  rules:
+    - name: abs-path-rule
+      match:
+        labels: ["bug"]
+      template: /etc/hosts
+---
+You are an agent assigned to {{ .issue.identifier }}: {{ .issue.title }}.

--- a/testdata/workflow/dispatch_rules_invalid_globs.md
+++ b/testdata/workflow/dispatch_rules_invalid_globs.md
@@ -1,0 +1,23 @@
+---
+tracker:
+  kind: file
+  project: dispatch-fixture
+  active_states: [todo, in-progress]
+  terminal_states: [done]
+
+agent:
+  kind: mock
+  command: mock
+  max_turns: 1
+
+mock:
+  reply: noop
+
+dispatch:
+  rules:
+    - name: malformed
+      match:
+        labels: ["[unclosed"]
+      template: ./prompts/bug.md
+---
+You are an agent assigned to {{ .issue.identifier }}: {{ .issue.title }}.

--- a/testdata/workflow/dispatch_rules_minimal.md
+++ b/testdata/workflow/dispatch_rules_minimal.md
@@ -1,0 +1,30 @@
+---
+tracker:
+  kind: file
+  project: dispatch-fixture
+  active_states: [todo, in-progress]
+  terminal_states: [done]
+
+agent:
+  kind: mock
+  command: mock
+  max_turns: 1
+
+mock:
+  reply: noop
+
+dispatch:
+  rules:
+    - name: bug
+      match:
+        labels: ["bug"]
+      template: ./prompts/bug.md
+
+    - name: docs
+      match:
+        labels: ["docs"]
+      template: ./prompts/docs.md
+---
+You are an agent assigned to {{ .issue.identifier }}: {{ .issue.title }}.
+
+Use this fallback template when no dispatch rule matches.

--- a/testdata/workflow/dispatch_rules_missing_template.md
+++ b/testdata/workflow/dispatch_rules_missing_template.md
@@ -1,0 +1,23 @@
+---
+tracker:
+  kind: file
+  project: dispatch-fixture
+  active_states: [todo, in-progress]
+  terminal_states: [done]
+
+agent:
+  kind: mock
+  command: mock
+  max_turns: 1
+
+mock:
+  reply: noop
+
+dispatch:
+  rules:
+    - name: missing-tmpl-rule
+      match:
+        labels: ["bug"]
+      template: prompts/does_not_exist.md
+---
+You are an agent assigned to {{ .issue.identifier }}: {{ .issue.title }}.

--- a/testdata/workflow/dispatch_rules_tilde_path.md
+++ b/testdata/workflow/dispatch_rules_tilde_path.md
@@ -1,0 +1,23 @@
+---
+tracker:
+  kind: file
+  project: dispatch-fixture
+  active_states: [todo, in-progress]
+  terminal_states: [done]
+
+agent:
+  kind: mock
+  command: mock
+  max_turns: 1
+
+mock:
+  reply: noop
+
+dispatch:
+  rules:
+    - name: tilde-path-rule
+      match:
+        labels: ["bug"]
+      template: ~/templates/custom.md
+---
+You are an agent assigned to {{ .issue.identifier }}: {{ .issue.title }}.

--- a/testdata/workflow/dispatch_rules_unreachable.md
+++ b/testdata/workflow/dispatch_rules_unreachable.md
@@ -1,0 +1,26 @@
+---
+tracker:
+  kind: file
+  project: dispatch-fixture
+  active_states: [todo, in-progress]
+  terminal_states: [done]
+
+agent:
+  kind: mock
+  command: mock
+  max_turns: 1
+
+mock:
+  reply: noop
+
+dispatch:
+  rules:
+    - name: catch-all
+      template: ./prompts/bug.md
+
+    - name: bug
+      match:
+        labels: ["bug"]
+      template: ./prompts/bug.md
+---
+You are an agent assigned to {{ .issue.identifier }}: {{ .issue.title }}.

--- a/testdata/workflow/prompts/bug.md
+++ b/testdata/workflow/prompts/bug.md
@@ -1,0 +1,7 @@
+You are a bug-fixing agent assigned to {{ .issue.identifier }}.
+
+The issue title is: {{ .issue.title }}.
+
+Reproduce the bug, write a regression test that fails before the fix
+and passes after, then implement the minimum change required to make
+the test pass.

--- a/testdata/workflow/prompts/docs.md
+++ b/testdata/workflow/prompts/docs.md
@@ -1,0 +1,7 @@
+You are a documentation agent assigned to {{ .issue.identifier }}.
+
+The issue title is: {{ .issue.title }}.
+
+Update the relevant documentation so the change described in the
+issue is accurately reflected. Preserve the existing tone and
+heading structure.

--- a/testdata/workflow/prompts/with_frontmatter.md
+++ b/testdata/workflow/prompts/with_frontmatter.md
@@ -1,0 +1,4 @@
+---
+key: value
+---
+This template has front matter which is not permitted for per-rule templates.


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Feat

**Intent:** Sortie previously dispatched every issue using a single agent adapter and a single workflow template regardless of issue characteristics. This change adds a declarative rule system in WORKFLOW.md front matter that selects the agent adapter and prompt template based on issue metadata (labels, type, priority, identifier, assignee), with a configurable default block and a final workflow-wide fallback.

**Related Issues:** #435

### 🧭 Reviewer Guide

**Complexity:** High

#### Entry Point

Start with `internal/orchestrator/route.go`. It contains `ResolveRule`, the pure evaluation function that maps a `domain.Issue` against a `config.DispatchConfig` and returns a `DispatchResolution` with the frozen agent kind, template ID, rule name, and resolution layer. Understanding this function makes the rest of the wiring straightforward.

From there, trace how the resolution flows:

1. `internal/config/dispatch.go` — `BuildDispatchConfig` parses and validates the dispatch section at load time (rule key validation, template path containment, agent kind probing, catch-all position). `isUnderDirectory` now uses `filepath.IsLocal` instead of a manual `strings.Contains` check, which correctly handles filenames that contain `..` as a substring while still rejecting genuine path-escape segments.
2. `internal/workflow/manager.go` — `loadPipeline` now calls `BuildDispatchConfig`, attaches the result to `ServiceConfig` via `SetDispatch`, and builds the per-rule template index in `loadPerRuleTemplates`. `PromptTemplateByID` exposes the index to the orchestrator.
3. `internal/orchestrator/orchestrator.go` — `OrchestratorParams` gains `AgentAdapterByKind`; `cmd/sortie/main.go` wires the eagerly-built adapter cache via `buildAgentAdapterCache` and `makeAgentAdapterByKind`. `buildAgentAdapterCache` now returns `map[string]domain.AgentAdapter` directly — registry lookup and construction failures emit a warn log and skip the entry rather than aborting startup.
4. `internal/orchestrator/worker.go` — `WorkerDeps` replaces `PromptTemplateFunc` with `PromptTemplateByIDFunc` and carries the frozen `TemplateID` and `AgentKind`. `RunWorkerAttempt` uses them for template lookup, dispatch comment text, and `WorkerResult` recording.
5. Freeze propagation: `RunningEntry`, `RetryEntry`, and `PendingReaction` in `state.go` all carry the frozen triple (`AgentKind`, `RuleName`, `TemplateID`) and all retry/reaction paths in `exit.go`, `reconcile.go`, `ci_reconcile.go`, `review_reconcile.go`, and `retry.go` propagate them verbatim.

#### Sensitive Areas

- `internal/config/dispatch.go`: Template path containment logic in `resolveTemplatePath` and `isUnderDirectory`. Symlink resolution via `filepath.EvalSymlinks` must run before the prefix check. Reject absolute paths and tilde prefixes before any filesystem call.
- `internal/config/dispatch_test.go`: `mkDispatchDir` now canonicalizes via `filepath.EvalSymlinks` so expected paths match production output on Windows runners that return 8.3 short-name temp dirs. `TestBuildDispatchConfig_TemplateIDIsCanonicalAcrossSymlinks` explicitly creates a symlink to a canonical directory and asserts the returned template ID is the resolved path, not the symlinked one; skips gracefully where `os.Symlink` is unsupported.
- `internal/workflow/manager_test.go`: `TestManager_PromptTemplateByID_KnownRuleTemplate` applies the same `EvalSymlinks` canonicalization to its temp dir. `TestManager_PromptTemplateByID_CanonicalKeyAcrossSymlinks` mirrors the symlink fixture for the manager index; also skips gracefully when symlinks are unavailable.
- `internal/orchestrator/retry.go`: `HandleRetryTimer` now accepts a `DefaultAgentKind` field. Legacy retry rows with an empty `AgentKind` (persisted before this feature) coalesce to the workflow default before adapter resolution, worker construction, and the running-entry record. The error handling sequence on adapter lookup failure is: log, delete claim, delete retry row, release host, increment metric.
- `internal/orchestrator/recovery.go`: `PopulateRetries` now accepts a `*slog.Logger` and logs a one-shot audit entry for legacy rows that carry an empty `AgentKind`.
- `internal/server/metrics.go`: `IncDispatchRuleMatch` now normalizes an empty `rule` argument to `"<none>"` internally, preventing accidental emission of empty-label time series regardless of caller behavior.
- `internal/persistence/sql/010_dispatch_rule_routing.sql`: Adds `rule_name`, `template_id`, and `agent_kind` to `retry_entries` and `rule_name` to `run_history`. All columns default to empty string so existing rows are backward-compatible.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes. The dispatch section is optional; a WORKFLOW.md without it preserves the previous single-adapter, body-template behavior through the fallback path.
- **Migrations/State:** Migration 10 adds four columns with `NOT NULL DEFAULT ''` to two tables. SQLite `ALTER TABLE ADD COLUMN` is non-destructive; existing rows read back as empty string and are treated as legacy fallback dispatches.