### PR TITLE
feat(config): resolve $VAR refs in extension string leaves

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,11 +4,11 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Release version (semver, e.g. 1.0.0 or 1.0.0-rc.1 — no 'v' prefix)"
+        description: "Release version (semver, e.g. 1.0.0 or 1.0.0-rc.1 - no 'v' prefix)"
         required: true
         type: string
       dry_run:
-        description: "Dry run — run all steps but skip tag creation and release publish"
+        description: "Dry run - run all steps but skip tag creation and release publish"
         required: false
         type: boolean
         default: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Extension `$VAR` resolution: every string leaf inside top-level
+  front matter keys outside the core schema (for example
+  `github.api_key`, `worker.ssh_hosts[0]`, `server.host`) now resolves
+  `$VAR` and `${VAR}` environment indirection in a single pass during
+  `NewServiceConfig`, after `SORTIE_*` overrides are applied. Nested
+  maps and lists are traversed recursively; non-string leaves
+  (integers, booleans, floats, timestamps, nil) are returned
+  unchanged. `sortie validate` now emits a new advisory
+  `unresolved_extension_var` warning naming the field path and the
+  unset variable name when a referenced variable is absent from the
+  process environment; the variable's resolved value never appears in
+  any warning, log, or error. Exit code remains 0 and `valid` remains
+  `true` when only this advisory warning is present. Operators of
+  cross-platform setups (for example a Jira tracker paired with a
+  GitHub SCM adapter) may now reference secrets such as
+  `$SORTIE_GITHUB_TOKEN` directly inside the adapter extension block
+  without an external `envsubst` step.
+  ([#512](https://github.com/sortie-ai/sortie/issues/512))
 - Dispatch rule routing: a new optional `dispatch:` block in
   `WORKFLOW.md` front matter routes each issue to a specific agent
   kind and prompt template based on issue metadata. Rules match

--- a/cmd/sortie/validate_test.go
+++ b/cmd/sortie/validate_test.go
@@ -1786,3 +1786,148 @@ func TestValidateDispatch_ConfigErrorRouting(t *testing.T) {
 		t.Errorf("validateOutput.Errors = %v, want a diagnostic with check prefixed 'config.dispatch'", out.Errors)
 	}
 }
+
+// --- unresolved_extension_var end-to-end validate tests ---
+
+// unresolvedExtVarWorkflow returns a workflow YAML containing an extension block
+// whose api_key references varName, which must be unset when the test runs.
+func unresolvedExtVarWorkflow(varName string) []byte {
+	return []byte("---\n" +
+		"tracker:\n  kind: file\n  active_states:\n    - To Do\n  terminal_states:\n    - Done\n" +
+		"agent:\n  kind: mock\n" +
+		"myext:\n  api_key: \"$" + varName + "\"\n" +
+		"---\nDo {{ .issue.title }}.\n")
+}
+
+// TestValidateUnresolvedExtensionVar covers AC-4, AC-6, and AC-7 end-to-end.
+func TestValidateUnresolvedExtensionVar(t *testing.T) {
+	// The variable must resolve to empty. Use a name that is unique to this
+	// test suite; explicitly clear it so the resolved value is "".
+	const missingVar = "SORTIE_TEST_512_E2E_MISSING"
+
+	t.Run("TextMode", func(t *testing.T) {
+		// No t.Parallel: uses t.Setenv.
+		t.Setenv(missingVar, "")
+
+		dir := t.TempDir()
+		wfPath := writeCustomWorkflowFile(t, dir, unresolvedExtVarWorkflow(missingVar))
+
+		var stdout, stderr bytes.Buffer
+		ctx := context.Background()
+
+		code := run(ctx, []string{"validate", wfPath}, &stdout, &stderr)
+
+		// AC-6: exit code must be 0 (advisory warning).
+		if code != 0 {
+			t.Fatalf("run(validate) = %d, want 0 (warning is advisory); stderr: %s", code, stderr.String())
+		}
+		// Text mode: no output on stdout.
+		if stdout.Len() != 0 {
+			t.Errorf("stdout = %q, want empty (text mode)", stdout.String())
+		}
+		got := stderr.String()
+		// AC-4 text: warning must appear on stderr.
+		if !strings.Contains(got, "warning:") {
+			t.Errorf("stderr = %q, want to contain %q", got, "warning:")
+		}
+		if !strings.Contains(got, "unresolved_extension_var") {
+			t.Errorf("stderr = %q, want to contain %q", got, "unresolved_extension_var")
+		}
+		// Field path must appear (prefixed onto the message by emitDiags).
+		if !strings.Contains(got, "myext.api_key") {
+			t.Errorf("stderr = %q, want to contain field path %q", got, "myext.api_key")
+		}
+		// AC-7: variable name must appear, resolved value (empty) must not add noise.
+		if !strings.Contains(got, missingVar) {
+			t.Errorf("stderr = %q, want to contain variable name %q", got, missingVar)
+		}
+	})
+
+	t.Run("JSONMode", func(t *testing.T) {
+		// No t.Parallel: uses t.Setenv.
+		t.Setenv(missingVar, "")
+
+		dir := t.TempDir()
+		wfPath := writeCustomWorkflowFile(t, dir, unresolvedExtVarWorkflow(missingVar))
+
+		var stdout, stderr bytes.Buffer
+		ctx := context.Background()
+
+		code := run(ctx, []string{"validate", "--format", "json", wfPath}, &stdout, &stderr)
+
+		// AC-6: exit code 0.
+		if code != 0 {
+			t.Fatalf("run(validate --format json) = %d, want 0; stderr: %s", code, stderr.String())
+		}
+		// JSON mode: stderr must be empty.
+		if stderr.Len() != 0 {
+			t.Errorf("stderr = %q, want empty (JSON mode)", stderr.String())
+		}
+
+		var out validateOutput
+		if err := json.Unmarshal(stdout.Bytes(), &out); err != nil {
+			t.Fatalf("json.Unmarshal(%q) error: %v", stdout.String(), err)
+		}
+		// AC-6: valid=true.
+		if !out.Valid {
+			t.Errorf("validateOutput.Valid = false, want true")
+		}
+		// No errors.
+		if len(out.Errors) != 0 {
+			t.Errorf("validateOutput.Errors = %v, want empty", out.Errors)
+		}
+
+		// AC-4 JSON: the warnings array must contain the unresolved_extension_var entry.
+		var found *validateDiag
+		for i := range out.Warnings {
+			if out.Warnings[i].Check == "unresolved_extension_var" {
+				w := out.Warnings[i]
+				found = &w
+				break
+			}
+		}
+		if found == nil {
+			t.Fatalf("validateOutput.Warnings = %v, want at least one unresolved_extension_var entry", out.Warnings)
+		}
+		if found.Severity != "warning" {
+			t.Errorf("warning.Severity = %q, want %q", found.Severity, "warning")
+		}
+		// Field path must be prefixed in the message.
+		if !strings.Contains(found.Message, "myext.api_key") {
+			t.Errorf("warning.Message = %q, want field path %q", found.Message, "myext.api_key")
+		}
+		// AC-7: variable name appears in the message.
+		if !strings.Contains(found.Message, missingVar) {
+			t.Errorf("warning.Message = %q, want variable name %q", found.Message, missingVar)
+		}
+		// AC-7: resolved value (empty string "") must not appear as a meaningful token.
+		// The message must not contain any resolved credential value; since the value is
+		// empty here the key assertion is that the variable name (not the value) is shown.
+	})
+
+	t.Run("ValidTrueExitZero", func(t *testing.T) {
+		// No t.Parallel: uses t.Setenv.
+		// Extra confirmation that valid:true and exit code 0 hold even when
+		// the only warning present is an unresolved extension variable.
+		t.Setenv(missingVar, "")
+
+		dir := t.TempDir()
+		wfPath := writeCustomWorkflowFile(t, dir, unresolvedExtVarWorkflow(missingVar))
+
+		var stdout, stderr bytes.Buffer
+		ctx := context.Background()
+
+		code := run(ctx, []string{"validate", "--format", "json", wfPath}, &stdout, &stderr)
+		if code != 0 {
+			t.Fatalf("run(validate --format json) = %d, want 0", code)
+		}
+
+		var out validateOutput
+		if err := json.Unmarshal(stdout.Bytes(), &out); err != nil {
+			t.Fatalf("json.Unmarshal: %v", err)
+		}
+		if !out.Valid {
+			t.Errorf("validateOutput.Valid = false, want true")
+		}
+	})
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -56,6 +56,14 @@ type ServiceConfig struct {
 	// via map lookup. Never nil after construction.
 	Extensions map[string]any
 
+	// extensionsPreResolution maps a dotted-and-indexed extension field
+	// path (for example "github.api_key" or "worker.ssh_hosts[0]") to
+	// the pre-resolution literal value for every string leaf that
+	// contained at least one $VAR or ${VAR} reference. The field is
+	// internal to the validation pathway, never read by adapters, and
+	// never serialized.
+	extensionsPreResolution map[string]string
+
 	// Dispatch carries the parsed dispatch rule configuration. The
 	// workflow manager stitches this in via [ServiceConfig.SetDispatch]
 	// after [NewServiceConfig] returns. Zero value selects the
@@ -293,17 +301,20 @@ func NewServiceConfig(raw map[string]any) (ServiceConfig, error) {
 		}
 	}
 
+	preResolution := resolveExtensionEnvRefs(extensions)
+
 	return ServiceConfig{
-		Tracker:    tracker,
-		Polling:    polling,
-		Workspace:  workspace,
-		Hooks:      hooks,
-		Agent:      agent,
-		CIFeedback: ciFeedback,
-		SelfReview: selfReview,
-		Reactions:  reactions,
-		DBPath:     dbPath,
-		Extensions: extensions,
+		Tracker:                 tracker,
+		Polling:                 polling,
+		Workspace:               workspace,
+		Hooks:                   hooks,
+		Agent:                   agent,
+		CIFeedback:              ciFeedback,
+		SelfReview:              selfReview,
+		Reactions:               reactions,
+		DBPath:                  dbPath,
+		Extensions:              extensions,
+		extensionsPreResolution: preResolution,
 	}, nil
 }
 
@@ -786,6 +797,63 @@ func validateInProgressState(inProgressState string, activeStates, terminalState
 		}
 	}
 	return nil
+}
+
+// resolveExtensionEnvRefs walks the Extensions subtree and resolves
+// $VAR references on every string leaf using [os.ExpandEnv]. Nested
+// map[string]any and []any values are traversed; non-string leaves are
+// returned unchanged. The function mutates the input map in place.
+//
+// The returned map captures the pre-resolution literal value for every
+// leaf whose value contained at least one $ reference, keyed by the
+// dotted-and-indexed field path starting at the extension-block key.
+// Literals without a $ reference are not recorded. The walker is safe
+// to call with a nil map and returns a nil snapshot in that case.
+func resolveExtensionEnvRefs(extensions map[string]any) map[string]string {
+	if extensions == nil {
+		return nil
+	}
+	var snapshot map[string]string
+	for k, v := range extensions {
+		extensions[k] = resolveExtensionEnvValue(k, v, &snapshot)
+	}
+	return snapshot
+}
+
+// resolveExtensionEnvValue recursively resolves $VAR references on
+// string leaves under v. Maps and slices are mutated in place; non-
+// string leaves are returned unchanged. Recorded entries are written
+// into *snapshot using dotted (for nested maps) and bracketed (for
+// slice elements) path notation.
+//
+// The type switch is exhaustive over the closed set of yaml.v3-decoded
+// leaf types (string, map[string]any, []any, scalars, nil, time.Time).
+// Every other Go type takes the default arm and round-trips unchanged
+// without panic.
+func resolveExtensionEnvValue(path string, v any, snapshot *map[string]string) any {
+	switch typed := v.(type) {
+	case string:
+		if !strings.Contains(typed, "$") {
+			return typed
+		}
+		if *snapshot == nil {
+			*snapshot = make(map[string]string)
+		}
+		(*snapshot)[path] = typed
+		return os.ExpandEnv(typed)
+	case map[string]any:
+		for k, child := range typed {
+			typed[k] = resolveExtensionEnvValue(path+"."+k, child, snapshot)
+		}
+		return typed
+	case []any:
+		for i, child := range typed {
+			typed[i] = resolveExtensionEnvValue(path+"["+strconv.Itoa(i)+"]", child, snapshot)
+		}
+		return typed
+	default:
+		return v
+	}
 }
 
 func resolveEnv(s string) string {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestNewServiceConfig(t *testing.T) {
@@ -1933,5 +1934,293 @@ func TestCIFailureMigration(t *testing.T) {
 			t.Fatal("Reactions[\"review_comments\"] missing")
 		}
 		assertStringEqual(t, "Reactions[review_comments].Provider", "github", rc.Provider)
+	})
+}
+
+// TestResolveExtensionEnvRefs covers the recursive walker at the unit level:
+// nested maps, slices of strings, slices of maps, non-string leaves, nil map,
+// the braced ${VAR} form, and the $$ -> "" contract.
+func TestResolveExtensionEnvRefs(t *testing.T) {
+	t.Run("NilMap", func(t *testing.T) {
+		t.Parallel()
+		snapshot := resolveExtensionEnvRefs(nil)
+		if snapshot != nil {
+			t.Errorf("resolveExtensionEnvRefs(nil) = %v, want nil", snapshot)
+		}
+	})
+
+	t.Run("NestedMap", func(t *testing.T) {
+		t.Setenv("SORTIE_TEST_512_NESTED_A", "tok-abc")
+
+		ext := map[string]any{
+			"myext": map[string]any{
+				"api_key": "$SORTIE_TEST_512_NESTED_A",
+				"host":    "literal-host",
+			},
+		}
+		snapshot := resolveExtensionEnvRefs(ext)
+
+		inner, ok := ext["myext"].(map[string]any)
+		if !ok {
+			t.Fatal("ext[myext] is not a map")
+		}
+		assertStringEqual(t, "myext.api_key resolved", "tok-abc", inner["api_key"].(string))
+		assertStringEqual(t, "myext.host unchanged", "literal-host", inner["host"].(string))
+
+		if snapshot == nil {
+			t.Fatal("snapshot is nil, want non-nil")
+		}
+		if _, ok := snapshot["myext.api_key"]; !ok {
+			t.Error("snapshot missing key myext.api_key")
+		}
+		if _, ok := snapshot["myext.host"]; ok {
+			t.Error("snapshot must not record literal (no $) values")
+		}
+	})
+
+	t.Run("SliceOfStrings", func(t *testing.T) {
+		t.Setenv("SORTIE_TEST_512_HOST", "deploy.example.com")
+
+		ext := map[string]any{
+			"worker": map[string]any{
+				"ssh_hosts": []any{"$SORTIE_TEST_512_HOST", "literal-host"},
+			},
+		}
+		snapshot := resolveExtensionEnvRefs(ext)
+
+		worker := ext["worker"].(map[string]any)
+		hosts := worker["ssh_hosts"].([]any)
+		assertStringEqual(t, "ssh_hosts[0] resolved", "deploy.example.com", hosts[0].(string))
+		assertStringEqual(t, "ssh_hosts[1] literal unchanged", "literal-host", hosts[1].(string))
+
+		if snapshot == nil {
+			t.Fatal("snapshot is nil")
+		}
+		if _, ok := snapshot["worker.ssh_hosts[0]"]; !ok {
+			t.Error("snapshot missing key worker.ssh_hosts[0]")
+		}
+		if _, ok := snapshot["worker.ssh_hosts[1]"]; ok {
+			t.Error("snapshot must not record literal (no $) element")
+		}
+	})
+
+	t.Run("SliceOfMaps", func(t *testing.T) {
+		t.Setenv("SORTIE_TEST_512_SMAP_KEY", "nested-value")
+
+		ext := map[string]any{
+			"myext": map[string]any{
+				"servers": []any{
+					map[string]any{"key": "$SORTIE_TEST_512_SMAP_KEY"},
+					map[string]any{"key": "plain"},
+				},
+			},
+		}
+		snapshot := resolveExtensionEnvRefs(ext)
+
+		inner := ext["myext"].(map[string]any)
+		servers := inner["servers"].([]any)
+		first := servers[0].(map[string]any)
+		second := servers[1].(map[string]any)
+		assertStringEqual(t, "servers[0].key resolved", "nested-value", first["key"].(string))
+		assertStringEqual(t, "servers[1].key literal", "plain", second["key"].(string))
+
+		if snapshot == nil {
+			t.Fatal("snapshot is nil")
+		}
+		if _, ok := snapshot["myext.servers[0].key"]; !ok {
+			t.Error("snapshot missing myext.servers[0].key")
+		}
+		if _, ok := snapshot["myext.servers[1].key"]; ok {
+			t.Error("snapshot must not record literal value")
+		}
+	})
+
+	t.Run("NonStringLeavesUntouched", func(t *testing.T) {
+		t.Parallel()
+
+		ts := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+		ext := map[string]any{
+			"myext": map[string]any{
+				"port":    8080,
+				"ratio":   float64(3.14),
+				"enabled": true,
+				"limit":   int64(100),
+				"ts":      ts,
+				"nothing": nil,
+			},
+		}
+		snapshot := resolveExtensionEnvRefs(ext)
+
+		inner := ext["myext"].(map[string]any)
+		if inner["port"] != 8080 {
+			t.Errorf("port = %v, want 8080", inner["port"])
+		}
+		if inner["ratio"] != float64(3.14) {
+			t.Errorf("ratio = %v, want 3.14", inner["ratio"])
+		}
+		if inner["enabled"] != true {
+			t.Errorf("enabled = %v, want true", inner["enabled"])
+		}
+		if inner["limit"] != int64(100) {
+			t.Errorf("limit = %v, want int64(100)", inner["limit"])
+		}
+		if inner["ts"] != ts {
+			t.Errorf("ts = %v, want %v", inner["ts"], ts)
+		}
+		if inner["nothing"] != nil {
+			t.Errorf("nothing = %v, want nil", inner["nothing"])
+		}
+		if snapshot != nil {
+			t.Errorf("snapshot = %v, want nil (no $ leaves)", snapshot)
+		}
+	})
+
+	t.Run("LiteralsWithoutDollar", func(t *testing.T) {
+		t.Parallel()
+
+		ext := map[string]any{
+			"logging": map[string]any{"level": "debug"},
+		}
+		snapshot := resolveExtensionEnvRefs(ext)
+
+		inner := ext["logging"].(map[string]any)
+		assertStringEqual(t, "logging.level unchanged", "debug", inner["level"].(string))
+		if snapshot != nil {
+			t.Errorf("snapshot = %v, want nil (no $ in any leaf)", snapshot)
+		}
+	})
+
+	t.Run("BracedForm", func(t *testing.T) {
+		t.Setenv("SORTIE_TEST_512_BRACE", "braced-value")
+
+		ext := map[string]any{
+			"myext": map[string]any{"key": "${SORTIE_TEST_512_BRACE}"},
+		}
+		snapshot := resolveExtensionEnvRefs(ext)
+
+		inner := ext["myext"].(map[string]any)
+		assertStringEqual(t, "myext.key resolved via ${}", "braced-value", inner["key"].(string))
+		if snapshot == nil {
+			t.Fatal("snapshot is nil")
+		}
+		if _, ok := snapshot["myext.key"]; !ok {
+			t.Error("snapshot missing myext.key for ${VAR} form")
+		}
+	})
+
+	t.Run("DollarDollar", func(t *testing.T) {
+		t.Parallel()
+		// os.ExpandEnv("$$") returns "" — the $$ sequence is consumed
+		// and maps to an empty variable name which expands to empty.
+		// This is the documented behavior (no custom $$ escape).
+		ext := map[string]any{"myext": map[string]any{"val": "$$"}}
+		resolveExtensionEnvRefs(ext)
+
+		inner := ext["myext"].(map[string]any)
+		assertStringEqual(t, "myext.val after $$ expansion", "", inner["val"].(string))
+	})
+}
+
+// TestNewServiceConfigExtensions covers extension-walker integration through
+// NewServiceConfig: SORTIE_* precedence, unknown leaf types, and slice-of-strings.
+func TestNewServiceConfigExtensions(t *testing.T) {
+	t.Run("SortiePrecedence", func(t *testing.T) {
+		// SORTIE_TRACKER_API_KEY overrides the YAML value for the core field;
+		// a sibling extension $VAR is resolved against the same environment.
+		t.Setenv("SORTIE_TRACKER_API_KEY", "from-env-override")
+		t.Setenv("SORTIE_TEST_512_EXT_KEY", "ext-resolved-value")
+
+		cfg, err := NewServiceConfig(map[string]any{
+			"tracker": map[string]any{
+				"kind":    "file",
+				"api_key": "$SORTIE_TEST_512_EXT_KEY",
+			},
+			"myext": map[string]any{
+				"api_key": "$SORTIE_TEST_512_EXT_KEY",
+			},
+		})
+		if err != nil {
+			t.Fatalf("NewServiceConfig: %v", err)
+		}
+		// Core field: the SORTIE_* override wins.
+		assertStringEqual(t, "Tracker.APIKey", "from-env-override", cfg.Tracker.APIKey)
+		// Extension field: $VAR resolved against process environment.
+		extMap, ok := cfg.Extensions["myext"].(map[string]any)
+		if !ok {
+			t.Fatal("cfg.Extensions[myext] not a map")
+		}
+		assertStringEqual(t, "myext.api_key resolved", "ext-resolved-value", extMap["api_key"].(string))
+	})
+
+	t.Run("NestedSliceOfStrings", func(t *testing.T) {
+		t.Setenv("SORTIE_TEST_512_DEPLOY", "prod.example.com")
+
+		cfg, err := NewServiceConfig(map[string]any{
+			"worker": map[string]any{
+				"ssh_hosts": []any{"$SORTIE_TEST_512_DEPLOY", "literal-host"},
+			},
+		})
+		if err != nil {
+			t.Fatalf("NewServiceConfig: %v", err)
+		}
+		workerExt, ok := cfg.Extensions["worker"].(map[string]any)
+		if !ok {
+			t.Fatal("cfg.Extensions[worker] not a map")
+		}
+		hosts, ok := workerExt["ssh_hosts"].([]any)
+		if !ok {
+			t.Fatal("worker.ssh_hosts not a []any")
+		}
+		assertStringEqual(t, "ssh_hosts[0] resolved", "prod.example.com", hosts[0].(string))
+		assertStringEqual(t, "ssh_hosts[1] literal", "literal-host", hosts[1].(string))
+	})
+
+	t.Run("NoPanicOnUnexpectedLeafType", func(t *testing.T) {
+		t.Parallel()
+		// An int32 value is not produced by yaml.v3 decode-to-any but can
+		// appear in Go-constructed test maps. The walker MUST NOT panic.
+		raw := map[string]any{
+			"myext": map[string]any{
+				"count": int32(42),
+				"name":  "literal",
+			},
+		}
+		// Verify no panic.
+		cfg, err := NewServiceConfig(raw)
+		if err != nil {
+			t.Fatalf("NewServiceConfig with int32 leaf: %v", err)
+		}
+		extMap, ok := cfg.Extensions["myext"].(map[string]any)
+		if !ok {
+			t.Fatal("cfg.Extensions[myext] not a map")
+		}
+		if extMap["count"] != int32(42) {
+			t.Errorf("myext.count = %v (%T), want int32(42)", extMap["count"], extMap["count"])
+		}
+	})
+
+	t.Run("WalkerPanicFreeOnUnknownLeafType", func(t *testing.T) {
+		t.Parallel()
+		// A func() value is definitely not a yaml.v3 leaf type.
+		// The walker default arm must return it unchanged without panicking.
+		fn := func() {}
+		ext := map[string]any{
+			"myext": map[string]any{
+				"callback": fn,
+				"name":     "plain",
+			},
+		}
+		// Must not panic.
+		snapshot := resolveExtensionEnvRefs(ext)
+
+		inner := ext["myext"].(map[string]any)
+		// callback must be returned unchanged (non-nil, same function value).
+		if inner["callback"] == nil {
+			t.Error("callback became nil; want original func value preserved")
+		}
+		// No snapshot entry for non-string leaves.
+		if snapshot != nil {
+			t.Errorf("snapshot = %v, want nil for non-string ext with no $ leaves", snapshot)
+		}
 	})
 }

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"math"
+	"os"
 	"strconv"
 	"strings"
 
@@ -160,7 +161,7 @@ var staticKnownExtensionKeys = map[string]bool{
 // FrontMatterWarning represents a single advisory diagnostic from
 // front matter static analysis. These do not affect runtime behavior.
 type FrontMatterWarning struct {
-	Check   string // "unknown_key", "unknown_sub_key", or "type_mismatch"
+	Check   string // "unknown_key", "unknown_sub_key", "type_mismatch", or "unresolved_extension_var"
 	Field   string // dotted path to the offending key
 	Message string // operator-friendly description
 }
@@ -354,7 +355,221 @@ func ValidateFrontMatter(raw map[string]any, cfg ServiceConfig) []FrontMatterWar
 	warnings = checkHooksTimeoutSemantic(warnings, raw)
 	warnings = checkByStateSemantic(warnings, raw)
 
+	// Surface unresolved $VAR references in Extensions by replaying the
+	// snapshot captured during NewServiceConfig. A non-empty resolved
+	// leaf indicates the variable was set; a resolved empty leaf is the
+	// warning trigger.
+	warnings = checkUnresolvedExtensionVars(warnings, cfg)
+
 	return warnings
+}
+
+// checkUnresolvedExtensionVars iterates the pre-resolution snapshot
+// captured by [resolveExtensionEnvRefs] and emits one warning per
+// extension leaf that contains a $VAR reference whose current value
+// is unset or empty. The warning fires regardless of whether the
+// resolved string is otherwise non-empty: a field like
+// "https://$HOST:$PORT/path" still warns about PORT when only HOST is
+// set. Entries whose extracted variable name is empty (e.g. the $$
+// literal) are excluded.
+func checkUnresolvedExtensionVars(warnings []FrontMatterWarning, cfg ServiceConfig) []FrontMatterWarning {
+	if len(cfg.extensionsPreResolution) == 0 {
+		return warnings
+	}
+	paths := maputil.SortedKeys(cfg.extensionsPreResolution)
+	for _, path := range paths {
+		before := cfg.extensionsPreResolution[path]
+		_, ok := lookupExtensionValue(cfg.Extensions, path)
+		if !ok {
+			continue
+		}
+		unsetNames := extractUnsetExtensionVars(before)
+		if len(unsetNames) == 0 {
+			continue
+		}
+		warnings = append(warnings, FrontMatterWarning{
+			Check:   "unresolved_extension_var",
+			Field:   path,
+			Message: formatUnresolvedExtensionVarMessage(unsetNames),
+		})
+	}
+	return warnings
+}
+
+// extractUnsetExtensionVars scans before for every $NAME and ${NAME}
+// reference in declaration order and returns the distinct variable
+// names (without the leading $ or wrapping braces) whose current
+// [os.Getenv] value is empty. The first occurrence of a repeated name
+// is preserved; later duplicates are dropped. Returns nil when every
+// reference resolves to a non-empty value or when no extractable name
+// is present.
+func extractUnsetExtensionVars(before string) []string {
+	var unset []string
+	seen := make(map[string]bool)
+	for i := 0; i < len(before); i++ {
+		if before[i] != '$' {
+			continue
+		}
+		name, consumed := readShellName(before[i+1:])
+		i += consumed
+		if name == "" {
+			continue
+		}
+		if seen[name] {
+			continue
+		}
+		seen[name] = true
+		if os.Getenv(name) != "" {
+			continue
+		}
+		unset = append(unset, name)
+	}
+	return unset
+}
+
+// readShellName parses a variable reference following a leading $ byte
+// and returns the extracted name and the number of bytes consumed from
+// s (excluding the leading $). The braced form ${NAME} consumes the
+// closing brace; the bare form $NAME consumes only the identifier
+// bytes. An empty name (no identifier or empty braces) returns the
+// number of bytes that should be skipped past the malformed reference.
+func readShellName(s string) (name string, consumed int) {
+	if len(s) == 0 {
+		return "", 0
+	}
+	if s[0] == '{' {
+		end := strings.IndexByte(s, '}')
+		if end < 0 {
+			return "", 0
+		}
+		return s[1:end], end + 1
+	}
+	if !isShellNameByte(s[0], true) {
+		return "", 0
+	}
+	end := 1
+	for end < len(s) && isShellNameByte(s[end], false) {
+		end++
+	}
+	return s[:end], end
+}
+
+// isShellNameByte reports whether b is a valid byte for a shell-style
+// identifier. When start is true, digits are not permitted.
+func isShellNameByte(b byte, start bool) bool {
+	if b == '_' {
+		return true
+	}
+	if b >= 'A' && b <= 'Z' {
+		return true
+	}
+	if b >= 'a' && b <= 'z' {
+		return true
+	}
+	if !start && b >= '0' && b <= '9' {
+		return true
+	}
+	return false
+}
+
+// formatUnresolvedExtensionVarMessage returns the operator-facing
+// message for the unresolved_extension_var warning. The variable name
+// is rendered via the %q verb so a name such as SORTIE_GITHUB_TOKEN
+// prints surrounded by double quotes. The message is byte-stable
+// across calls with the same input so operators can alert on it.
+func formatUnresolvedExtensionVarMessage(unsetNames []string) string {
+	switch len(unsetNames) {
+	case 0:
+		return ""
+	case 1:
+		return fmt.Sprintf("unresolved $VAR reference: variable %q is unset or empty", unsetNames[0])
+	case 2:
+		return fmt.Sprintf("unresolved $VAR reference: variables %q and %q are unset or empty", unsetNames[0], unsetNames[1]) //nolint:gosec // G602: case 2 guarantees len(unsetNames) == 2
+	}
+	var b strings.Builder
+	b.WriteString("unresolved $VAR reference: variables ")
+	for i, name := range unsetNames {
+		if i == len(unsetNames)-1 {
+			b.WriteString("and ")
+			fmt.Fprintf(&b, "%q", name)
+			continue
+		}
+		fmt.Fprintf(&b, "%q, ", name)
+	}
+	b.WriteString(" are unset or empty")
+	return b.String()
+}
+
+// lookupExtensionValue walks the dotted-and-indexed path produced by
+// [resolveExtensionEnvRefs] under extensions and returns the resolved
+// string at that path. Returns (value, true) when the path lands on a
+// string leaf; returns ("", false) when any intermediate segment fails
+// to type-assert or when the final leaf is not a string. Two-result
+// type assertions guarantee the helper never panics on a malformed
+// path.
+func lookupExtensionValue(extensions map[string]any, path string) (string, bool) {
+	if extensions == nil || path == "" {
+		return "", false
+	}
+	var current any = extensions
+	for path != "" {
+		segment, rest, _ := strings.Cut(path, ".")
+		path = rest
+		name, indices := splitPathIndices(segment)
+		m, ok := current.(map[string]any)
+		if !ok {
+			return "", false
+		}
+		current, ok = m[name]
+		if !ok {
+			return "", false
+		}
+		for _, idx := range indices {
+			slice, ok := current.([]any)
+			if !ok {
+				return "", false
+			}
+			if idx < 0 || idx >= len(slice) {
+				return "", false
+			}
+			current = slice[idx]
+		}
+	}
+	s, ok := current.(string)
+	if !ok {
+		return "", false
+	}
+	return s, true
+}
+
+// splitPathIndices separates a path segment into its name and any
+// trailing [index] suffixes. For example "ssh_hosts[0][1]" returns
+// ("ssh_hosts", [0, 1]). Malformed suffixes return the original
+// segment with no indices.
+func splitPathIndices(segment string) (string, []int) {
+	openIdx := strings.IndexByte(segment, '[')
+	if openIdx < 0 {
+		return segment, nil
+	}
+	name := segment[:openIdx]
+	rest := segment[openIdx:]
+	var indices []int
+	for rest != "" {
+		if rest[0] != '[' {
+			return segment, nil
+		}
+		closeIdx := strings.IndexByte(rest, ']')
+		if closeIdx < 0 {
+			return segment, nil
+		}
+		n, err := strconv.Atoi(rest[1:closeIdx])
+		if err != nil {
+			return segment, nil
+		}
+		indices = append(indices, n)
+		rest = rest[closeIdx+1:]
+	}
+	return name, indices
 }
 
 // checkStringListElements appends type_mismatch warnings for non-string

--- a/internal/config/schema_test.go
+++ b/internal/config/schema_test.go
@@ -614,6 +614,237 @@ func TestValidateFrontMatter(t *testing.T) {
 	}
 }
 
+// --- unresolved_extension_var warning tests ---
+
+// buildCfgWithExtension is a helper that constructs a ServiceConfig with an
+// extension block populated after env resolution so ValidateFrontMatter can
+// operate on a realistic snapshot.
+func buildCfgWithExtension(t *testing.T, extKey string, extVal map[string]any) ServiceConfig {
+	t.Helper()
+	raw := map[string]any{extKey: extVal}
+	cfg, err := NewServiceConfig(raw)
+	if err != nil {
+		t.Fatalf("NewServiceConfig: %v", err)
+	}
+	return cfg
+}
+
+// TestValidateFrontMatter_UnresolvedExtensionVar covers the new
+// unresolved_extension_var warning class: bare form, braced form, nested paths,
+// slice-index paths, set variables, multi-ref fields, $$ non-flagging,
+// deduplication of repeated variable names, and message stability.
+func TestValidateFrontMatter_UnresolvedExtensionVar(t *testing.T) {
+	t.Run("EmitsWarningOnUnset", func(t *testing.T) {
+		// An empty value is treated as unset by extractUnsetExtensionVars.
+		t.Setenv("SORTIE_TEST_512_MISSING_BARE", "")
+
+		raw := map[string]any{
+			"myext": map[string]any{"api_key": "$SORTIE_TEST_512_MISSING_BARE"},
+		}
+		cfg := buildCfgWithExtension(t, "myext", map[string]any{"api_key": "$SORTIE_TEST_512_MISSING_BARE"})
+
+		got := ValidateFrontMatter(raw, cfg)
+
+		found := findUnresolvedExtVarWarning(got)
+		if found == nil {
+			t.Fatalf("ValidateFrontMatter() no unresolved_extension_var warning; warnings: %+v", got)
+		}
+		if found.Field != "myext.api_key" {
+			t.Errorf("warning.Field = %q, want %q", found.Field, "myext.api_key")
+		}
+		if !strings.Contains(found.Message, "SORTIE_TEST_512_MISSING_BARE") {
+			t.Errorf("warning.Message = %q, want to contain variable name", found.Message)
+		}
+	})
+
+	t.Run("NoWarningWhenVariableSet", func(t *testing.T) {
+		t.Setenv("SORTIE_TEST_512_SET_VAR", "resolved-token")
+
+		raw := map[string]any{
+			"myext": map[string]any{"api_key": "$SORTIE_TEST_512_SET_VAR"},
+		}
+		cfg := buildCfgWithExtension(t, "myext", map[string]any{"api_key": "$SORTIE_TEST_512_SET_VAR"})
+
+		got := ValidateFrontMatter(raw, cfg)
+
+		for _, w := range got {
+			if w.Check == "unresolved_extension_var" {
+				t.Errorf("unexpected unresolved_extension_var warning when variable is set: %+v", w)
+			}
+		}
+	})
+
+	t.Run("BracedForm", func(t *testing.T) {
+		// An empty value is treated as unset by extractUnsetExtensionVars.
+		t.Setenv("SORTIE_TEST_512_BRACED_UNSET", "")
+
+		raw := map[string]any{
+			"myext": map[string]any{"token": "${SORTIE_TEST_512_BRACED_UNSET}"},
+		}
+		cfg := buildCfgWithExtension(t, "myext", map[string]any{"token": "${SORTIE_TEST_512_BRACED_UNSET}"})
+
+		got := ValidateFrontMatter(raw, cfg)
+
+		found := findUnresolvedExtVarWarning(got)
+		if found == nil {
+			t.Fatalf("ValidateFrontMatter() no unresolved_extension_var warning for ${VAR}; warnings: %+v", got)
+		}
+		if found.Field != "myext.token" {
+			t.Errorf("warning.Field = %q, want %q", found.Field, "myext.token")
+		}
+		// Variable name without braces must appear in the message.
+		if !strings.Contains(found.Message, "SORTIE_TEST_512_BRACED_UNSET") {
+			t.Errorf("warning.Message = %q, want variable name without braces", found.Message)
+		}
+	})
+
+	t.Run("SliceIndexPath", func(t *testing.T) {
+		// An empty value is treated as unset by extractUnsetExtensionVars.
+		t.Setenv("SORTIE_TEST_512_SLICE_HOST", "")
+
+		raw := map[string]any{
+			"worker": map[string]any{
+				"ssh_hosts": []any{"literal-host", "literal2", "$SORTIE_TEST_512_SLICE_HOST"},
+			},
+		}
+		cfg := buildCfgWithExtension(t, "worker", map[string]any{
+			"ssh_hosts": []any{"literal-host", "literal2", "$SORTIE_TEST_512_SLICE_HOST"},
+		})
+
+		got := ValidateFrontMatter(raw, cfg)
+
+		found := findUnresolvedExtVarWarning(got)
+		if found == nil {
+			t.Fatalf("no unresolved_extension_var warning for slice element; warnings: %+v", got)
+		}
+		if found.Field != "worker.ssh_hosts[2]" {
+			t.Errorf("warning.Field = %q, want %q", found.Field, "worker.ssh_hosts[2]")
+		}
+	})
+
+	t.Run("MultipleRefsOneUnset", func(t *testing.T) {
+		t.Setenv("SORTIE_TEST_512_MULTI_HOST", "example.com")
+		// An empty value is treated as unset by extractUnsetExtensionVars.
+		t.Setenv("SORTIE_TEST_512_MULTI_PORT", "")
+
+		raw := map[string]any{
+			"myext": map[string]any{
+				"url": "https://$SORTIE_TEST_512_MULTI_HOST:$SORTIE_TEST_512_MULTI_PORT/path",
+			},
+		}
+		cfg := buildCfgWithExtension(t, "myext", map[string]any{
+			"url": "https://$SORTIE_TEST_512_MULTI_HOST:$SORTIE_TEST_512_MULTI_PORT/path",
+		})
+
+		got := ValidateFrontMatter(raw, cfg)
+
+		var found []*FrontMatterWarning
+		for i := range got {
+			if got[i].Check == "unresolved_extension_var" {
+				w := got[i]
+				found = append(found, &w)
+			}
+		}
+		if len(found) != 1 {
+			t.Fatalf("ValidateFrontMatter() returned %d unresolved_extension_var warnings, want exactly 1; got %+v", len(found), got)
+		}
+		// Message must name only the unset variable.
+		if !strings.Contains(found[0].Message, "SORTIE_TEST_512_MULTI_PORT") {
+			t.Errorf("warning.Message = %q, want to contain PORT variable name", found[0].Message)
+		}
+		if strings.Contains(found[0].Message, "SORTIE_TEST_512_MULTI_HOST") {
+			t.Errorf("warning.Message = %q, must not contain the set HOST variable name", found[0].Message)
+		}
+		// The resolved value must not appear.
+		if strings.Contains(found[0].Message, "example.com") {
+			t.Errorf("warning.Message = %q, must not contain the resolved value", found[0].Message)
+		}
+	})
+
+	t.Run("DedupRepeatedVar", func(t *testing.T) {
+		// An empty value is treated as unset by extractUnsetExtensionVars.
+		t.Setenv("SORTIE_TEST_512_DEDUP_HOST", "")
+
+		raw := map[string]any{
+			"myext": map[string]any{
+				"url": "https://$SORTIE_TEST_512_DEDUP_HOST:80/$SORTIE_TEST_512_DEDUP_HOST/path",
+			},
+		}
+		cfg := buildCfgWithExtension(t, "myext", map[string]any{
+			"url": "https://$SORTIE_TEST_512_DEDUP_HOST:80/$SORTIE_TEST_512_DEDUP_HOST/path",
+		})
+
+		got := ValidateFrontMatter(raw, cfg)
+
+		found := findUnresolvedExtVarWarning(got)
+		if found == nil {
+			t.Fatalf("no unresolved_extension_var warning for dedup case; warnings: %+v", got)
+		}
+		// The variable name must appear exactly once in the message.
+		count := strings.Count(found.Message, "SORTIE_TEST_512_DEDUP_HOST")
+		if count != 1 {
+			t.Errorf("warning.Message = %q, variable name appears %d times, want exactly 1 (dedup contract)", found.Message, count)
+		}
+		// Singular form: "variable ... is unset or empty"
+		if !strings.Contains(found.Message, "variable") {
+			t.Errorf("warning.Message = %q, want singular 'variable' form", found.Message)
+		}
+	})
+
+	t.Run("DollarDollarNotFlagged", func(t *testing.T) {
+		t.Parallel()
+		// os.ExpandEnv("$$") -> ""; the resolved value is empty but the
+		// variable name extracted by readShellName is "" so no warning fires.
+		raw := map[string]any{
+			"myext": map[string]any{"val": "$$"},
+		}
+		cfg := buildCfgWithExtension(t, "myext", map[string]any{"val": "$$"})
+
+		got := ValidateFrontMatter(raw, cfg)
+
+		for _, w := range got {
+			if w.Check == "unresolved_extension_var" {
+				t.Errorf("unexpected unresolved_extension_var warning for $$ literal: %+v", w)
+			}
+		}
+	})
+
+	t.Run("MessageStability", func(t *testing.T) {
+		t.Parallel()
+		// Verify formatUnresolvedExtensionVarMessage produces the exact
+		// fixed-shape strings the spec mandates.
+		one := formatUnresolvedExtensionVarMessage([]string{"MY_VAR"})
+		wantOne := `unresolved $VAR reference: variable "MY_VAR" is unset or empty`
+		if one != wantOne {
+			t.Errorf("1-name: got %q, want %q", one, wantOne)
+		}
+
+		two := formatUnresolvedExtensionVarMessage([]string{"VAR_A", "VAR_B"})
+		wantTwo := `unresolved $VAR reference: variables "VAR_A" and "VAR_B" are unset or empty`
+		if two != wantTwo {
+			t.Errorf("2-name: got %q, want %q", two, wantTwo)
+		}
+
+		three := formatUnresolvedExtensionVarMessage([]string{"VAR_A", "VAR_B", "VAR_C"})
+		wantThree := `unresolved $VAR reference: variables "VAR_A", "VAR_B", and "VAR_C" are unset or empty`
+		if three != wantThree {
+			t.Errorf("3-name: got %q, want %q", three, wantThree)
+		}
+	})
+}
+
+// findUnresolvedExtVarWarning returns the first FrontMatterWarning with
+// Check == "unresolved_extension_var", or nil when none exists.
+func findUnresolvedExtVarWarning(warnings []FrontMatterWarning) *FrontMatterWarning {
+	for i := range warnings {
+		if warnings[i].Check == "unresolved_extension_var" {
+			w := warnings[i]
+			return &w
+		}
+	}
+	return nil
+}
+
 // TestValidateFrontMatterReactions verifies that the reactions section with
 // AllowDynamicKeys=true never emits unknown_sub_key warnings for any reaction
 // kind keys, while still emitting type_mismatch when the top-level value is


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Feat

**Intent:** Closes the asymmetry where `tracker.*` fields resolved `$VAR` environment references but extension blocks (e.g. `github.api_key`, `worker.ssh_hosts`) passed literal strings to adapters unchanged, causing opaque authentication failures at runtime.

**Related Issues:** #512

### 🧭 Reviewer Guide

**Complexity:** Medium

#### Entry Point

`internal/config/config.go` - `resolveExtensionEnvRefs` and `resolveExtensionEnvValue` are the new recursive walker. They run once at the end of `NewServiceConfig`, after `applyEnvOverrides`, so `SORTIE_*` overrides still take precedence. The walker mutates `Extensions` in place and captures a pre-resolution snapshot used by the validation pathway.

#### Sensitive Areas

- `internal/config/schema.go`: `checkUnresolvedExtensionVars` replays the pre-resolution snapshot at validate time and emits the new `unresolved_extension_var` advisory warning. The resolved credential value is never included in any warning, log, or error output - only the variable name and field path are shown.
- `internal/config/config.go`: `extensionsPreResolution` is an unexported field on `ServiceConfig`. It exists solely for the validation pathway and is never serialized or exposed to adapters.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes. A string value previously stored as a literal `$something` inside an extension block is now resolved against the environment. When the referenced variable is absent the field becomes empty string, which is the same error adapters already surfaced - and which `sortie validate` now flags before deployment via the advisory warning.
- **Migrations/State:** No migrations or state changes.