### PR TITLE
docs: add dispatch rules section to workflow reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.10.0] - 2026-05-27
+
 ### Added
 
 - Auto-merge reaction for Sortie-created PRs: a new opt-in
@@ -89,7 +91,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Existing rows read back as empty strings and are treated as legacy
   fallback dispatches.
 
-## [1.9.1] - 2026-04-14
+## [1.9.1] - 2026-05-14
 
 ### Fixed
 
@@ -877,7 +879,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   execution via GitHub Actions.
 - Architecture Decision Records (ADR-0001 through ADR-0005).
 
-[Unreleased]: https://github.com/sortie-ai/sortie/compare/1.9.1...HEAD
+[Unreleased]: https://github.com/sortie-ai/sortie/compare/1.10.0...HEAD
+[1.10.0]: https://github.com/sortie-ai/sortie/compare/1.9.1...1.10.0
 [1.9.1]: https://github.com/sortie-ai/sortie/compare/1.9.0...1.9.1
 [1.9.0]: https://github.com/sortie-ai/sortie/compare/1.8.0...1.9.0
 [1.8.0]: https://github.com/sortie-ai/sortie/compare/1.7.1...1.8.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Auto-merge reaction for Sortie-created PRs: a new opt-in
+  `reactions.auto_merge` block in `WORKFLOW.md` instructs the
+  orchestrator to merge an agent-created pull request directly through
+  the SCM adapter once review decision, CI conclusion, draft state,
+  and mergeability all satisfy the configured preconditions. The
+  reconcile loop polls every `poll_interval_ms` (default 60 s,
+  minimum 30 s), calls `MergePR` with the expected head SHA to close
+  the TOCTOU window, and treats an "already merged" 409 response as
+  success. Merge strategy (`squash` default, also `merge` or
+  `rebase`), `require_ci` (default `true`), `delete_branch` (default
+  `true`), and the standard `max_retries` / `escalation` /
+  `escalation_label` fields are configurable. At startup the
+  orchestrator runs a one-shot scope preflight against the SCM
+  provider; an auth-class failure sets a sticky
+  `auto_merge_preflight_failed` flag that disables merge attempts for
+  the process lifetime, while a transport-class failure schedules a
+  single retry after 5 minutes. `reactions.review_comments` and
+  `reactions.auto_merge` must declare the same SCM provider; a
+  mismatch or an unknown provider fails startup. Workflows without an
+  `auto_merge` block are unaffected. The `SCMAdapter` interface gains
+  five write methods (`GetReviewDecision`, `GetCIStatus`,
+  `GetMergeability`, `MergePR`, `DeleteBranch`) and a new
+  `ErrSCMConflict` error kind; see
+  [ADR-0012](https://github.com/sortie-ai/sortie/blob/main/docs/decisions/0012-auto-merge-reaction.md).
+  ([#417](https://github.com/sortie-ai/sortie/issues/417))
 - Extension `$VAR` resolution: every string leaf inside top-level
   front matter keys outside the core schema (for example
   `github.api_key`, `worker.ssh_hosts[0]`, `server.host`) now resolves

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,11 +6,11 @@ Sortie follows [Semantic Versioning](https://semver.org/). Security fixes are ap
 
 | Version | Supported |
 |---------|-----------|
-| 1.9.x | Yes (1.9.1 recommended) |
-| 1.8.x | Security patches until 26 Jul 2026 |
-| < 1.8 | No |
+| 1.10.x | Yes (1.10.0 recommended) |
+| 1.9.x | Security patches until 27 Aug 2026 |
+| < 1.9 | No |
 
-When a new minor version ships (e.g., 1.9.0), the immediately preceding minor (e.g., 1.8.x) enters a 3-month security-maintenance window. During that window, only critical and high severity patches are backported; all other fixes ship only on the current minor. After the window ends, only the current minor release of the latest major version is supported; all older versions are unsupported.
+When a new minor version ships (e.g., 1.10.0), the immediately preceding minor (e.g., 1.9.x) enters a 3-month security-maintenance window. During that window, only critical and high severity patches are backported; all other fixes ship only on the current minor. After the window ends, only the current minor release of the latest major version is supported; all older versions are unsupported.
 
 ## Reporting a Vulnerability
 

--- a/docs/workflow-reference.md
+++ b/docs/workflow-reference.md
@@ -24,7 +24,7 @@
   - [2.8 `ci_feedback` — CI Feedback Loop (deprecated)](#28-ci_feedback--ci-feedback-loop-deprecated)
   - [2.9 `self_review` — Self-Review Configuration](#29-self_review--self-review-configuration)
   - [2.10 `reactions` — Reaction-Based Feedback Loops](#210-reactions--reaction-based-feedback-loops)
-  - [2.11 `dispatch` – Rule-based Routing](#211-dispatch--rule-based-routing)
+  - [2.11 `dispatch` — Rule-based Routing](#211-dispatch--rule-based-routing)
 - [3. Environment Variable Overrides](#3-environment-variable-overrides)
   - [3.1 Source Precedence](#31-source-precedence)
   - [3.2 Curated Variable List](#32-curated-variable-list)
@@ -687,7 +687,7 @@ reactions:
 
 ---
 
-### 2.11 `dispatch` – Rule-based Routing
+### 2.11 `dispatch` — Rule-based Routing
 
 ```yaml
 dispatch:

--- a/docs/workflow-reference.md
+++ b/docs/workflow-reference.md
@@ -2136,12 +2136,14 @@ skipped for that tick, reconciliation remains active, and an error is emitted.
 | Every referenced `agent` kind registered | `dispatch.rules[*].agent` or `dispatch.default.agent` names an unregistered adapter. |
 | Every per-rule template path resolvable and parseable | Path is absolute, `~`-prefixed, escapes the workflow tree, is not a regular file, is unreadable, or fails template parse. |
 
-**Advisory warnings vs. configuration errors:** Unknown keys under `dispatch`,
-`dispatch.rules[*]`, and `dispatch.default` produce `unknown_sub_key` advisory
-warnings; they do not block dispatch. Unknown keys inside a `match` block are
-rejected as configuration errors. The asymmetry matters: a typo like `lables:` inside
-`match` is caught as an error so it cannot silently disable a rule, while a typo at
-the `dispatch` or rule level is flagged as a warning without preventing startup.
+**Advisory warnings vs. configuration errors:** An unknown key placed directly
+under `dispatch` (alongside `rules` and `default`) produces an `unknown_sub_key`
+advisory warning and does not block startup. Unknown keys nested deeper are
+rejected as configuration errors that fail the load: an unrecognized key inside a
+rule map (`dispatch.rules[*]`), inside `dispatch.default`, or inside a `match`
+block. The asymmetry matters: a typo like `lables:` inside `match`, or a stray key
+on a rule, is caught as an error so it cannot silently disable a rule, while a typo
+at the top `dispatch` level is flagged as a warning without preventing startup.
 
 ---
 

--- a/docs/workflow-reference.md
+++ b/docs/workflow-reference.md
@@ -24,6 +24,7 @@
   - [2.8 `ci_feedback` — CI Feedback Loop (deprecated)](#28-ci_feedback--ci-feedback-loop-deprecated)
   - [2.9 `self_review` — Self-Review Configuration](#29-self_review--self-review-configuration)
   - [2.10 `reactions` — Reaction-Based Feedback Loops](#210-reactions--reaction-based-feedback-loops)
+  - [2.11 `dispatch` – Rule-based Routing](#211-dispatch--rule-based-routing)
 - [3. Environment Variable Overrides](#3-environment-variable-overrides)
   - [3.1 Source Precedence](#31-source-precedence)
   - [3.2 Curated Variable List](#32-curated-variable-list)
@@ -140,7 +141,7 @@ After parsing, the loader produces a struct with three fields:
 
 ### 2.1 Top-Level Keys
 
-The core schema recognizes nine top-level keys:
+The core schema recognizes ten top-level keys:
 
 ```yaml
 tracker: # Issue tracker connection and query settings
@@ -152,6 +153,7 @@ db_path: # SQLite database file path
 ci_feedback: # CI failure feedback loop (deprecated; use reactions.ci_failure)
 reactions: # Reaction-based feedback loops (CI failure, review comments)
 self_review: # Self-review verification loop (optional)
+dispatch: # Rule-based dispatch routing
 ```
 
 **Unknown top-level keys are ignored** by the core schema for forward compatibility. They
@@ -359,7 +361,7 @@ agent:
 
 | Field                            | Type                              | Required                            | Default         | Dynamic Reload                             | Description                                                                                                                                                                      |
 | -------------------------------- | --------------------------------- | ----------------------------------- | --------------- | ------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `kind`                           | string                            | No                                  | `claude-code`   | Future dispatches                          | Agent adapter identifier. Built-in adapters: `claude-code`, `copilot-cli`, `codex`, and `opencode`. Other kinds (for example, HTTP-based adapters) are available only if you register them separately. |
+| `kind`                           | string                            | No                                  | `claude-code`   | Future dispatches                          | Agent adapter identifier. This is the default kind used when no `dispatch.rules` entry (and no `dispatch.default.agent`) overrides it. Built-in adapters: `claude-code`, `copilot-cli`, `codex`, and `opencode`. Other kinds (for example, HTTP-based adapters) are available only if you register them separately. |
 | `command`                        | string (shell command)            | When adapter requires local process | Adapter-defined | Future dispatches                          | Shell command to launch the agent for adapters that run as a local subprocess (such as `claude-code` or `opencode`). Adapters that do not start a local process ignore this field. |
 | `turn_timeout_ms`                | integer                           | No                                  | `3600000` (1h)  | Future worker attempts                     | Total timeout for a single agent turn.                                                                                                                                           |
 | `read_timeout_ms`                | integer                           | No                                  | `5000` (5s)     | Future worker attempts                     | Request/response timeout during startup and synchronous operations.                                                                                                              |
@@ -682,6 +684,155 @@ reactions:
 - `require_ci` and `delete_branch` for `auto_merge` must be boolean.
 - `poll_interval_ms` must be >= `30000` for `auto_merge`.
 - When `provider` is absent or empty, all other fields in the kind sub-object are ignored.
+
+---
+
+### 2.11 `dispatch` – Rule-based Routing
+
+```yaml
+dispatch:
+  rules: # ordered list; first-match-wins; optional
+    - name: <rule-name> # optional; must match ^[a-z][a-z0-9_-]*$; used in logs
+      match: # optional; absent or empty match block matches every issue (catch-all)
+        labels: ["bug", "p0-*"]  # string or list; glob; OR within key
+        issue_type: ["Bug"]      # string or list; case-insensitive equality
+        priority: { lte: 2 }    # predicate object; exactly one of eq, in, lt, lte, gt, gte
+        identifier: ["FE-*"]    # string or list; glob; matched against issue.identifier
+        assignee: ["alice"]     # string or list; case-insensitive equality
+      agent: <kind>    # optional; overrides the agent kind for matching issues
+      template: ./prompts/bug.md # optional; path relative to the WORKFLOW.md directory
+  default: # optional
+    agent: <kind>     # optional; defaults to top-level agent.kind
+    template: <path>  # optional; defaults to the WORKFLOW.md Markdown body
+```
+
+#### Dispatch rules
+
+| Field | Type | Required | Default | Description |
+| ----- | ---- | -------- | ------- | ----------- |
+| `rules` | list of rule objects | No | _(none)_ | Ordered dispatch rules; first-match-wins. Evaluated in YAML order. |
+| `default` | map | No | _(none)_ | Fallback selection when no rule matches. Keys: `agent`, `template`. |
+
+Each rule in `dispatch.rules` is a map with the following keys (all other keys are unrecognized):
+
+| Field | Type | Required | Default | Description |
+| ----- | ---- | -------- | ------- | ----------- |
+| `name` | string | No | _(absent)_ | Operator-supplied identifier used in logs. Must match `^[a-z][a-z0-9_-]*$` when present. |
+| `match` | map | No | _(absent)_ | Predicate block. An absent or empty block matches every issue (catch-all). |
+| `agent` | string | No | _(fallback)_ | Agent adapter kind for matching issues. Falls through to `dispatch.default.agent`, then to `agent.kind`. |
+| `template` | string | No | _(fallback)_ | Prompt template path (relative to `WORKFLOW.md` directory). Falls through to `dispatch.default.template`, then to the Markdown body. |
+
+The `match` block accepts only these keys:
+
+| Field | Type | Matching | Description |
+| ----- | ---- | -------- | ----------- |
+| `labels` | string or list | Glob (any element) | Matches when the issue carries at least one label matching any pattern. Patterns use `path.Match` glob syntax (e.g., `bug/*`, `*-urgent`). Matched against the adapter-normalized lowercase label set. |
+| `issue_type` | string or list | Case-insensitive equality (any element) | Matches when the issue type equals any list entry. |
+| `priority` | predicate object | Numeric comparison | Single-operator predicate. See Priority predicates below. An issue with no priority never matches. |
+| `identifier` | string or list | Glob (any element) | Matches when `issue.identifier` glob-matches any pattern, in the case the adapter produced. |
+| `assignee` | string or list | Case-insensitive equality (any element) | Matches when the issue assignee equals any list entry. |
+
+The `dispatch.default` block accepts only `agent` and `template`, with the same types and
+fallback behavior as the per-rule fields.
+
+#### Matching semantics
+
+Evaluation applies AND logic across keys and OR logic within a single key:
+
+- A `match` block succeeds only when every present key is satisfied.
+- A key whose value is a list succeeds when any element matches.
+- An absent or empty `match` block always succeeds (catch-all).
+
+String-valued keys (`labels`, `issue_type`, `identifier`, `assignee`) accept either a
+single string or a list of strings. A scalar is treated as a one-element list.
+
+#### Priority predicates
+
+The `priority` key takes a predicate object with exactly one operator key:
+
+| Operator | Meaning |
+| -------- | ------- |
+| `eq` | Priority equals value |
+| `in` | Priority is in the list of values |
+| `lt` | Priority is less than value |
+| `lte` | Priority is less than or equal to value |
+| `gt` | Priority is greater than value |
+| `gte` | Priority is greater than or equal to value |
+
+For `in`, the value is a list of integers (e.g., `{ in: [1, 2] }`). For all other
+operators, the value is a single integer. An issue with no priority never matches a
+`priority` predicate.
+
+#### Fallback resolution chain
+
+Rules evaluate in YAML order. The first rule whose `match` block succeeds is selected;
+later rules are not consulted. For each selected rule, `agent` and `template` may each be
+omitted independently. Missing fields fall through in order:
+
+1. The matched rule's `agent` / `template`.
+2. `dispatch.default.agent` / `dispatch.default.template`.
+3. Top-level `agent.kind` (for agent) or the `WORKFLOW.md` Markdown body (for template).
+   See [Section 2.6](#26-agent--coding-agent-configuration) for the top-level `agent.kind`
+   default.
+
+When no rule matches and `dispatch.default` supplies an agent or template, the default is
+applied with the same fallback chain for any unset field.
+
+#### Freeze-on-dispatch
+
+The resolved `(agent_kind, template_id, rule_name)` is recorded at the initial dispatch
+and reused by retries and reaction-driven continuations for the same claim. Rules are
+re-evaluated only after the claim is released.
+
+A changed rule set from a `WORKFLOW.md` reload applies to future claims only. In-flight
+issues keep their frozen selection.
+
+#### Per-rule template paths
+
+Template paths for rules and `dispatch.default` resolve relative to the directory
+containing `WORKFLOW.md` (`filepath.Dir(workflow_path)`). The following paths are rejected
+at load time:
+
+- Absolute paths (starting with `/`).
+- `~`-prefixed paths.
+- Paths that resolve, after symlink evaluation, outside the workflow directory tree.
+
+An empty `template` field falls through to the Markdown body (the same behavior as
+omitting the field).
+
+#### Example
+
+```yaml
+dispatch:
+  rules:
+    - name: bug-fix
+      match:
+        labels: ["bug", "bug/*"]
+        priority: { lte: 2 }
+      agent: claude-code
+      template: ./prompts/bug.md
+    - name: docs-update
+      match:
+        issue_type: ["Documentation", "Docs"]
+      agent: codex
+      template: ./prompts/docs.md
+    - name: catch-all
+      agent: claude-code
+      template: ./prompts/default.md
+  default:
+    agent: claude-code
+    template: ./prompts/default.md
+```
+
+The two named rules carry `match` blocks. The third rule has no `match` block and acts as
+the terminal catch-all. Each rule carries a `template:` path that is relative to the
+`WORKFLOW.md` directory and uses forward-slash separators.
+
+#### Further reading (optional)
+
+The design rationale is in `architecture.md` §5.3.10 and
+[ADR-0011](decisions/0011-dispatch-rule-configuration.md). Neither document is required
+to write a valid `dispatch` block; they explain why the feature is shaped as it is.
 
 ---
 
@@ -1974,6 +2125,23 @@ skipped for that tick, reconciliation remains active, and an error is emitted.
 | `agent.command` present and non-empty          | Missing when `agent.kind` requires a local command.         |
 | Tracker adapter registered and available       | No adapter registered for the configured `tracker.kind`.    |
 | Agent adapter registered and available         | No adapter registered for the configured `agent.kind`.      |
+| `dispatch` is a map; `dispatch.rules` is a sequence; `dispatch.default` is a map | Wrong YAML node type for `dispatch`, `dispatch.rules`, or `dispatch.default`. |
+| Each rule has at least one of `match`, `agent`, `template` | A rule map carries none of the three. |
+| Rule `name`, when present, matches `^[a-z][a-z0-9_-]*$` | Malformed rule name. |
+| No duplicate rule name | Two rules share the same non-empty `name`. |
+| No non-final catch-all (`unreachable_rules`) | A rule with no `match` block precedes another rule. |
+| Every `match` key recognized | A `match` key is not one of `labels`, `issue_type`, `priority`, `identifier`, `assignee`. |
+| `priority` predicate has exactly one operator | Zero or more than one of `eq`, `in`, `lt`, `lte`, `gt`, `gte`. |
+| Glob patterns syntactically valid | A `labels` or `identifier` pattern fails `path.Match`. |
+| Every referenced `agent` kind registered | `dispatch.rules[*].agent` or `dispatch.default.agent` names an unregistered adapter. |
+| Every per-rule template path resolvable and parseable | Path is absolute, `~`-prefixed, escapes the workflow tree, is not a regular file, is unreadable, or fails template parse. |
+
+**Advisory warnings vs. configuration errors:** Unknown keys under `dispatch`,
+`dispatch.rules[*]`, and `dispatch.default` produce `unknown_sub_key` advisory
+warnings; they do not block dispatch. Unknown keys inside a `match` block are
+rejected as configuration errors. The asymmetry matters: a typo like `lables:` inside
+`match` is caught as an error so it cannot silently disable a rule, while a typo at
+the `dispatch` or rule level is flagged as a warning without preventing startup.
 
 ---
 


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Docs

**Intent:** Documents the `dispatch` block schema in `docs/workflow-reference.md` so operators can write valid `dispatch.rules` entries using only the user-facing reference, without reading the architecture doc or ADRs.

**Related Issues:** #537

### 🧭 Reviewer Guide

**Complexity:** Low

#### Entry Point

`docs/workflow-reference.md` - the new Section 2.11 is the core addition. Review the field tables, matching semantics prose, fallback resolution chain, freeze-on-dispatch note, template path resolution rules, and the preflight validation table additions in Section 8. The TOC entry (2.11), Section 2.1 top-level keys list, and the Section 2.6 `agent.kind` description are minor touch-points that round out the change.

#### Sensitive Areas

- `docs/workflow-reference.md`: The preflight validation table in Section 8 must stay accurate relative to the implemented loader validation - any drift is a correctness bug for operators.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes
- **Migrations/State:** No migrations or state changes