### PR TITLE
feat: add Kiro CLI agent adapter

### DIFF
--- a/cmd/sortie/main.go
+++ b/cmd/sortie/main.go
@@ -41,6 +41,7 @@ import (
 	_ "github.com/sortie-ai/sortie/internal/agent/claude"
 	_ "github.com/sortie-ai/sortie/internal/agent/codex"
 	_ "github.com/sortie-ai/sortie/internal/agent/copilot"
+	_ "github.com/sortie-ai/sortie/internal/agent/kiro"
 	_ "github.com/sortie-ai/sortie/internal/agent/mock"
 	_ "github.com/sortie-ai/sortie/internal/agent/opencode"
 	_ "github.com/sortie-ai/sortie/internal/scm/github"

--- a/internal/agent/kiro/command.go
+++ b/internal/agent/kiro/command.go
@@ -1,0 +1,92 @@
+package kiro
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/sortie-ai/sortie/internal/agent/sshutil"
+	"github.com/sortie-ai/sortie/internal/typeutil"
+)
+
+// passthroughConfig holds Kiro-specific settings extracted from the
+// "kiro" sub-object in WORKFLOW.md. All fields are optional; the zero
+// value means "not configured".
+type passthroughConfig struct {
+	// Model is pinned with --model on every turn because the /model slash
+	// command is unavailable headless.
+	Model string
+
+	// TrustAllTools passes --trust-all-tools when true. Mutually exclusive
+	// with TrustTools.
+	TrustAllTools bool
+
+	// TrustTools is the allowlist passed as --trust-tools=<names>. An empty
+	// slice with TrustAllTools false trusts nothing.
+	TrustTools []string
+
+	// Agent is the optional custom-agent selector passed as --agent.
+	Agent string
+}
+
+// parsePassthroughConfig extracts Kiro-specific settings from the raw
+// config map. Missing or wrong-typed keys use zero-value defaults.
+//
+// It returns a non-nil error when both trust_all_tools is true and
+// trust_tools is non-empty, because the two trust modes are mutually
+// exclusive.
+func parsePassthroughConfig(config map[string]any) (passthroughConfig, error) {
+	pt := passthroughConfig{
+		Model:         typeutil.StringFrom(config, "model"),
+		TrustAllTools: typeutil.BoolFrom(config, "trust_all_tools", false),
+		TrustTools:    slices.Clone(typeutil.ExtractStringSlice(config["trust_tools"])),
+		Agent:         typeutil.StringFrom(config, "agent"),
+	}
+
+	if pt.TrustAllTools && len(pt.TrustTools) > 0 {
+		return passthroughConfig{}, fmt.Errorf("trust_all_tools and trust_tools are mutually exclusive")
+	}
+
+	return pt, nil
+}
+
+// buildArgs constructs the CLI argument slice for one headless Kiro turn.
+// The arguments are passed directly to exec.Command, avoiding shell
+// interpolation. The prompt is passed after a -- separator as a single
+// positional argument.
+func buildArgs(state *sessionState, turn int, prompt string, pt passthroughConfig) []string { //nolint:unparam // turn mirrors the ForkPerTurnHooks.BuildArgs signature; kiro decides resume via state.resumeRequested
+	args := []string{"chat", "--no-interactive", "--wrap", "never"}
+
+	if pt.Model != "" {
+		args = append(args, "--model", pt.Model)
+	}
+
+	if pt.TrustAllTools {
+		args = append(args, "--trust-all-tools")
+	} else {
+		args = append(args, "--trust-tools="+strings.Join(pt.TrustTools, ","))
+	}
+
+	if pt.Agent != "" {
+		args = append(args, "--agent", pt.Agent)
+	}
+
+	if state.resumeRequested {
+		args = append(args, "--resume")
+	}
+
+	args = append(args, "--", prompt)
+	return args
+}
+
+// buildSSHRemoteCmd returns the remote command string for SSH mode.
+// When apiKey is non-empty, KIRO_API_KEY is prepended and the value is
+// shell-quoted, because OpenSSH drops the orchestrator's local environment
+// and a key containing shell metacharacters would otherwise be misparsed by
+// the remote shell.
+func buildSSHRemoteCmd(remoteCommand, apiKey string) string {
+	if apiKey == "" {
+		return remoteCommand
+	}
+	return "KIRO_API_KEY=" + sshutil.ShellQuote(apiKey) + " " + remoteCommand
+}

--- a/internal/agent/kiro/command_test.go
+++ b/internal/agent/kiro/command_test.go
@@ -1,0 +1,376 @@
+package kiro
+
+import (
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/sortie-ai/sortie/internal/registry"
+)
+
+// assertHasArgPair fails if flag and value do not appear as consecutive
+// elements in args.
+func assertHasArgPair(t *testing.T, args []string, flag, value string) {
+	t.Helper()
+	for i := range len(args) - 1 {
+		if args[i] == flag && args[i+1] == value {
+			return
+		}
+	}
+	t.Errorf("buildArgs() missing %q %q in [%s]", flag, value, strings.Join(args, " "))
+}
+
+// assertHasToken fails if token does not appear anywhere in args.
+func assertHasToken(t *testing.T, args []string, token string) {
+	t.Helper()
+	if !slices.Contains(args, token) {
+		t.Errorf("buildArgs() missing token %q in [%s]", token, strings.Join(args, " "))
+	}
+}
+
+// assertNoToken fails if token appears anywhere in args.
+func assertNoToken(t *testing.T, args []string, token string) {
+	t.Helper()
+	if slices.Contains(args, token) {
+		t.Errorf("buildArgs() unexpectedly contains token %q in [%s]", token, strings.Join(args, " "))
+	}
+}
+
+// countToken returns how many times token appears in args.
+func countToken(args []string, token string) int {
+	n := 0
+	for _, a := range args {
+		if a == token {
+			n++
+		}
+	}
+	return n
+}
+
+func TestNewKiroAdapter_TrustModeConflict(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		config  map[string]any
+		wantErr bool
+	}{
+		{
+			name: "trust_all_tools with non-empty trust_tools conflicts",
+			config: map[string]any{
+				"trust_all_tools": true,
+				"trust_tools":     []any{"read", "grep"},
+			},
+			wantErr: true,
+		},
+		{
+			name:    "trust_all_tools alone is valid",
+			config:  map[string]any{"trust_all_tools": true},
+			wantErr: false,
+		},
+		{
+			name:    "trust_tools alone is valid",
+			config:  map[string]any{"trust_tools": []any{"read", "grep"}},
+			wantErr: false,
+		},
+		{
+			name: "trust_all_tools with empty trust_tools is valid",
+			config: map[string]any{
+				"trust_all_tools": true,
+				"trust_tools":     []any{},
+			},
+			wantErr: false,
+		},
+		{
+			name:    "empty config is valid",
+			config:  map[string]any{},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			adapter, err := NewKiroAdapter(tt.config)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("NewKiroAdapter(%v) error = nil, want error", tt.config)
+				}
+				if adapter != nil {
+					t.Errorf("NewKiroAdapter(%v) adapter = %v, want nil on conflict", tt.config, adapter)
+				}
+				if !strings.Contains(err.Error(), "trust_all_tools") || !strings.Contains(err.Error(), "trust_tools") {
+					t.Errorf("NewKiroAdapter(%v) error = %q, want it to name both trust_all_tools and trust_tools", tt.config, err.Error())
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("NewKiroAdapter(%v) error = %v, want nil", tt.config, err)
+			}
+			if adapter == nil {
+				t.Fatalf("NewKiroAdapter(%v) adapter = nil, want non-nil", tt.config)
+			}
+		})
+	}
+}
+
+func TestParsePassthroughConfig_Fields(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		config map[string]any
+		want   passthroughConfig
+	}{
+		{
+			name:   "empty config yields zero-value defaults",
+			config: map[string]any{},
+			want:   passthroughConfig{},
+		},
+		{
+			name:   "nil config yields zero-value defaults",
+			config: nil,
+			want:   passthroughConfig{},
+		},
+		{
+			name: "allowlist fields extracted",
+			config: map[string]any{
+				"model":       "claude-sonnet-4.6",
+				"trust_tools": []any{"read", "grep", "glob"},
+				"agent":       "my-agent",
+			},
+			want: passthroughConfig{
+				Model:      "claude-sonnet-4.6",
+				TrustTools: []string{"read", "grep", "glob"},
+				Agent:      "my-agent",
+			},
+		},
+		{
+			name:   "trust_all_tools flag extracted",
+			config: map[string]any{"trust_all_tools": true},
+			want:   passthroughConfig{TrustAllTools: true},
+		},
+		{
+			name:   "only model set",
+			config: map[string]any{"model": "claude-opus-4.7"},
+			want:   passthroughConfig{Model: "claude-opus-4.7"},
+		},
+		{
+			name:   "wrong-typed model takes zero-value default",
+			config: map[string]any{"model": 42},
+			want:   passthroughConfig{},
+		},
+		{
+			name:   "wrong-typed trust_all_tools takes false default",
+			config: map[string]any{"trust_all_tools": "yes"},
+			want:   passthroughConfig{},
+		},
+		{
+			name:   "wrong-typed trust_tools yields nil slice",
+			config: map[string]any{"trust_tools": "read,grep"},
+			want:   passthroughConfig{},
+		},
+		{
+			name:   "non-string trust_tools elements are skipped",
+			config: map[string]any{"trust_tools": []any{"read", 7, "grep"}},
+			want:   passthroughConfig{TrustTools: []string{"read", "grep"}},
+		},
+		{
+			name:   "wrong-typed agent takes zero-value default",
+			config: map[string]any{"agent": true},
+			want:   passthroughConfig{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := parsePassthroughConfig(tt.config)
+			if err != nil {
+				t.Fatalf("parsePassthroughConfig(%v) error = %v, want nil", tt.config, err)
+			}
+
+			if got.Model != tt.want.Model {
+				t.Errorf("parsePassthroughConfig(%v).Model = %q, want %q", tt.config, got.Model, tt.want.Model)
+			}
+			if got.TrustAllTools != tt.want.TrustAllTools {
+				t.Errorf("parsePassthroughConfig(%v).TrustAllTools = %v, want %v", tt.config, got.TrustAllTools, tt.want.TrustAllTools)
+			}
+			if !slices.Equal(got.TrustTools, tt.want.TrustTools) {
+				t.Errorf("parsePassthroughConfig(%v).TrustTools = %v, want %v", tt.config, got.TrustTools, tt.want.TrustTools)
+			}
+			if got.Agent != tt.want.Agent {
+				t.Errorf("parsePassthroughConfig(%v).Agent = %q, want %q", tt.config, got.Agent, tt.want.Agent)
+			}
+		})
+	}
+}
+
+// TestParsePassthroughConfig_ClonesTrustTools verifies the parsed slice does
+// not alias the caller's input slice, so later mutation of the source map
+// cannot corrupt adapter state.
+func TestParsePassthroughConfig_ClonesTrustTools(t *testing.T) {
+	t.Parallel()
+
+	source := []any{"read", "grep"}
+	pt, err := parsePassthroughConfig(map[string]any{"trust_tools": source})
+	if err != nil {
+		t.Fatalf("parsePassthroughConfig() error = %v", err)
+	}
+
+	source[0] = "mutated"
+
+	if pt.TrustTools[0] != "read" {
+		t.Errorf("TrustTools[0] = %q, want %q (parsed slice must not alias source)", pt.TrustTools[0], "read")
+	}
+}
+
+func TestBuildArgs_FirstTurn(t *testing.T) {
+	t.Parallel()
+
+	state := &sessionState{resumeRequested: false}
+	pt := passthroughConfig{
+		Model:      "claude-sonnet-4.6",
+		TrustTools: []string{"read", "grep"},
+	}
+
+	args := buildArgs(state, 1, "implement the fix", pt)
+
+	wantPrefix := []string{"chat", "--no-interactive", "--wrap", "never"}
+	if len(args) < len(wantPrefix) || !slices.Equal(args[:len(wantPrefix)], wantPrefix) {
+		t.Errorf("buildArgs() prefix = %v, want %v", args, wantPrefix)
+	}
+
+	assertHasArgPair(t, args, "--model", "claude-sonnet-4.6")
+	assertHasToken(t, args, "--trust-tools=read,grep")
+
+	if got := args[len(args)-2]; got != "--" {
+		t.Errorf("buildArgs() second-to-last token = %q, want %q", got, "--")
+	}
+	if got := args[len(args)-1]; got != "implement the fix" {
+		t.Errorf("buildArgs() last token = %q, want the prompt %q", got, "implement the fix")
+	}
+
+	assertNoToken(t, args, "--resume")
+	assertNoToken(t, args, "--require-mcp-startup")
+	assertNoToken(t, args, "--mcp-config")
+}
+
+func TestBuildArgs_ExactlyOneTrustMode(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		pt        passthroughConfig
+		wantToken string
+		absent    string
+	}{
+		{
+			name:      "trust_all_tools emits the all-tools flag only",
+			pt:        passthroughConfig{TrustAllTools: true},
+			wantToken: "--trust-all-tools",
+			absent:    "--trust-tools=",
+		},
+		{
+			name:      "trust_tools allowlist emits the joined token only",
+			pt:        passthroughConfig{TrustTools: []string{"read", "grep"}},
+			wantToken: "--trust-tools=read,grep",
+			absent:    "--trust-all-tools",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			args := buildArgs(&sessionState{}, 1, "p", tt.pt)
+			assertHasToken(t, args, tt.wantToken)
+			assertNoToken(t, args, tt.absent)
+		})
+	}
+}
+
+// TestBuildArgs_TrustToolsEmpty verifies that an empty trust_tools list with
+// trust_all_tools false yields the single bare token "--trust-tools=", which
+// trusts nothing.
+func TestBuildArgs_TrustToolsEmpty(t *testing.T) {
+	t.Parallel()
+
+	args := buildArgs(&sessionState{}, 1, "p", passthroughConfig{})
+
+	assertHasToken(t, args, "--trust-tools=")
+	assertNoToken(t, args, "--trust-all-tools")
+}
+
+// TestBuildArgs_OptionalFlags verifies that model and agent flags appear only
+// when configured.
+func TestBuildArgs_OptionalFlags(t *testing.T) {
+	t.Parallel()
+
+	t.Run("agent flag present when configured", func(t *testing.T) {
+		t.Parallel()
+		args := buildArgs(&sessionState{}, 1, "p", passthroughConfig{Agent: "my-agent"})
+		assertHasArgPair(t, args, "--agent", "my-agent")
+	})
+
+	t.Run("no model and no agent when unset", func(t *testing.T) {
+		t.Parallel()
+		args := buildArgs(&sessionState{}, 1, "p", passthroughConfig{})
+		assertNoToken(t, args, "--model")
+		assertNoToken(t, args, "--agent")
+	})
+}
+
+// TestBuildArgs_ResumeFollowsState verifies the resume decision reads
+// state.resumeRequested rather than the turn index: turn 1 with the flag set
+// still emits --resume, and a later turn with the flag clear does not.
+func TestBuildArgs_ResumeFollowsState(t *testing.T) {
+	t.Parallel()
+
+	t.Run("resume flag emitted once when requested", func(t *testing.T) {
+		t.Parallel()
+		args := buildArgs(&sessionState{resumeRequested: true}, 2, "p", passthroughConfig{})
+		if n := countToken(args, "--resume"); n != 1 {
+			t.Errorf("buildArgs() --resume count = %d, want 1 in [%s]", n, strings.Join(args, " "))
+		}
+		assertNoToken(t, args, "--resume-id")
+	})
+
+	t.Run("no resume flag when not requested", func(t *testing.T) {
+		t.Parallel()
+		args := buildArgs(&sessionState{resumeRequested: false}, 5, "p", passthroughConfig{})
+		assertNoToken(t, args, "--resume")
+	})
+}
+
+func TestKiroRegistered(t *testing.T) {
+	t.Parallel()
+
+	if !registry.Agents.Has("kiro") {
+		t.Fatal(`registry.Agents.Has("kiro") = false, want true after package init`)
+	}
+
+	meta, ok := registry.Agents.Meta("kiro")
+	if !ok {
+		t.Fatal(`registry.Agents.Meta("kiro") reported not registered`)
+	}
+	if !meta.RequiresCommand {
+		t.Error("AgentMeta.RequiresCommand = false, want true")
+	}
+
+	factory, err := registry.Agents.Get("kiro")
+	if err != nil {
+		t.Fatalf(`registry.Agents.Get("kiro") error = %v`, err)
+	}
+	adapter, err := factory(map[string]any{})
+	if err != nil {
+		t.Fatalf("factory(empty config) error = %v", err)
+	}
+	if _, ok := adapter.(*KiroAdapter); !ok {
+		t.Errorf("factory() type = %T, want *KiroAdapter", adapter)
+	}
+}

--- a/internal/agent/kiro/integration_test.go
+++ b/internal/agent/kiro/integration_test.go
@@ -1,0 +1,95 @@
+package kiro_test
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	_ "github.com/sortie-ai/sortie/internal/agent/kiro"
+	"github.com/sortie-ai/sortie/internal/domain"
+	"github.com/sortie-ai/sortie/internal/registry"
+)
+
+// skipIfNotEnabled skips the test unless SORTIE_KIRO_TEST=1, and again unless
+// KIRO_API_KEY is set. Without a credential a headless kiro-cli chat blocks on
+// interactive device login indefinitely, so the second guard prevents a hang.
+func skipIfNotEnabled(t *testing.T) {
+	t.Helper()
+	if os.Getenv("SORTIE_KIRO_TEST") != "1" {
+		t.Skip("set SORTIE_KIRO_TEST=1 to run kiro integration tests")
+	}
+	if os.Getenv("KIRO_API_KEY") == "" {
+		t.Skip("set KIRO_API_KEY to run kiro integration tests")
+	}
+}
+
+// integrationCommand returns the kiro-cli binary path, defaulting to "kiro-cli".
+func integrationCommand() string {
+	if cmd := os.Getenv("SORTIE_KIRO_COMMAND"); cmd != "" {
+		return cmd
+	}
+	return "kiro-cli"
+}
+
+// mustNewAdapter constructs the registered kiro adapter or fatals.
+func mustNewAdapter(t *testing.T) domain.AgentAdapter {
+	t.Helper()
+	factory, err := registry.Agents.Get("kiro")
+	if err != nil {
+		t.Fatalf("registry.Agents.Get(kiro): %v", err)
+	}
+	cfg := map[string]any{}
+	if model := os.Getenv("SORTIE_KIRO_MODEL"); model != "" {
+		cfg["model"] = model
+	}
+	a, err := factory(cfg)
+	if err != nil {
+		t.Fatalf("factory(): %v", err)
+	}
+	return a
+}
+
+func TestKiroAdapter_Integration(t *testing.T) {
+	skipIfNotEnabled(t)
+
+	adapter := mustNewAdapter(t)
+
+	startCtx, startCancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer startCancel()
+
+	session, err := adapter.StartSession(startCtx, domain.StartSessionParams{
+		WorkspacePath: t.TempDir(),
+		AgentConfig:   domain.AgentConfig{Command: integrationCommand()},
+	})
+	if err != nil {
+		t.Fatalf("StartSession(): %v", err)
+	}
+	t.Cleanup(func() { _ = adapter.StopSession(context.Background(), session) })
+
+	// The turn timeout is the mandatory backstop against the login hang.
+	turnCtx, turnCancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	defer turnCancel()
+
+	var events []domain.AgentEvent
+	result, err := adapter.RunTurn(turnCtx, session, domain.RunTurnParams{
+		Prompt: "Reply with exactly: PONG",
+		OnEvent: func(e domain.AgentEvent) {
+			events = append(events, e)
+		},
+	})
+	if err != nil {
+		t.Fatalf("RunTurn(): %v", err)
+	}
+
+	if result.ExitReason != domain.EventTurnCompleted {
+		t.Errorf("result.ExitReason = %q, want %q", result.ExitReason, domain.EventTurnCompleted)
+	}
+	if len(events) == 0 {
+		t.Error("no events reached the OnEvent callback, want at least one")
+	}
+
+	if err := adapter.StopSession(context.Background(), session); err != nil {
+		t.Errorf("StopSession(): %v", err)
+	}
+}

--- a/internal/agent/kiro/kiro.go
+++ b/internal/agent/kiro/kiro.go
@@ -215,9 +215,16 @@ func (a *KiroAdapter) StartSession(ctx context.Context, params domain.StartSessi
 }
 
 // checkCredential verifies that KIRO_API_KEY is present and usable before
-// any chat turn. It returns nil on success, an [domain.AgentError] with
-// [domain.ErrResponseError] when the key is absent or rejected, and
-// [domain.ErrAgentNotFound] when the whoami canary cannot run.
+// any chat turn. It returns nil on success and a [domain.AgentError] with
+// [domain.ErrResponseError] when the key is absent, when the whoami canary
+// times out or exits non-zero, or when the canary output shows the key is
+// invalid.
+//
+// The canary binary is already resolved by [agentcore.ResolveLaunchTarget]
+// before this runs, so a canary execution failure means the present binary
+// could not confirm the credential (a timeout or non-zero exit), not that
+// the agent is missing. It is classified as a retryable credential problem
+// rather than the non-retryable [domain.ErrAgentNotFound].
 func checkCredential(ctx context.Context, command string) *domain.AgentError {
 	if strings.TrimSpace(os.Getenv("KIRO_API_KEY")) == "" {
 		return &domain.AgentError{
@@ -232,8 +239,8 @@ func checkCredential(ctx context.Context, command string) *domain.AgentError {
 	out, canaryErr := exec.CommandContext(canaryCtx, command, "whoami").CombinedOutput() //nolint:gosec // command resolved by ResolveLaunchTarget via LookPath
 	if canaryErr != nil {
 		return &domain.AgentError{
-			Kind:    domain.ErrAgentNotFound,
-			Message: "kiro-cli whoami canary failed to run",
+			Kind:    domain.ErrResponseError,
+			Message: "kiro-cli whoami canary timed out or exited non-zero",
 			Err:     canaryErr,
 		}
 	}

--- a/internal/agent/kiro/kiro.go
+++ b/internal/agent/kiro/kiro.go
@@ -1,0 +1,294 @@
+// Package kiro implements [domain.AgentAdapter] for the Kiro CLI (the
+// rebranded Amazon Q Developer CLI). It launches one
+// "kiro-cli chat --no-interactive" subprocess per turn, captures the
+// human-readable transcript from stdout (ANSI stripped) into notification
+// events, and classifies the turn outcome from the process exit status and
+// stderr because headless Kiro emits no structured output. Registered under
+// kind "kiro" via an init function.
+//
+// Kiro is a no-token-accounting adapter: the headless path reports only an
+// abstract credits figure, never token counts, so it emits no token-usage
+// events and leaves [domain.TurnResult] Usage at the zero value. Token-based
+// budget enforcement is therefore inert; only the turn timeout applies.
+//
+// MCP injection has no effect under KIRO_API_KEY authentication: the backend
+// profile gate disables MCP, so [domain.StartSessionParams] MCPConfigPath is
+// ignored and no MCP startup flag is passed.
+//
+// Safe for concurrent use across sessions: callers may invoke
+// [KiroAdapter.RunTurn] concurrently for different [domain.Session]
+// instances, but turns for a single session must be serialized.
+package kiro
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/sortie-ai/sortie/internal/agent/agentcore"
+	"github.com/sortie-ai/sortie/internal/domain"
+	"github.com/sortie-ai/sortie/internal/logging"
+	"github.com/sortie-ai/sortie/internal/registry"
+	"github.com/sortie-ai/sortie/internal/typeutil"
+)
+
+func init() {
+	registry.Agents.RegisterWithMeta("kiro", NewKiroAdapter, registry.AgentMeta{
+		RequiresCommand: true,
+	})
+}
+
+// Compile-time interface satisfaction check.
+var _ domain.AgentAdapter = (*KiroAdapter)(nil)
+
+// whoamiSuccessMarker is the line "kiro-cli whoami" prints when the API key
+// is valid. Its absence from the canary output marks a present-but-unusable
+// credential, which the adapter rejects before any turn runs.
+const whoamiSuccessMarker = "Authenticated with API key"
+
+// KiroAdapter satisfies [domain.AgentAdapter] by managing Kiro CLI
+// subprocesses. One adapter instance serves all concurrent sessions;
+// per-session state is held in [sessionState] via the [domain.Session]
+// Internal field.
+type KiroAdapter struct {
+	passthrough passthroughConfig
+}
+
+// sessionState is adapter-internal state stored in [domain.Session]
+// Internal. It owns the workspace launch target and the fork-per-turn
+// subprocess lifecycle. No long-lived process is started in StartSession.
+type sessionState struct {
+	target      agentcore.LaunchTarget
+	agentConfig domain.AgentConfig
+	passthrough passthroughConfig
+	baseLogger  *slog.Logger
+
+	// sessionID is set from params.ResumeSessionID and is the value the
+	// GetSessionID hook closes over. The headless path reports no session
+	// ID of its own, so this is the only identity the adapter carries.
+	sessionID string
+
+	// forkSession owns the subprocess lifecycle for this session.
+	forkSession *agentcore.ForkPerTurnSession
+
+	// resumeRequested becomes true after the first turn runs successfully,
+	// so turn 2+ adds --resume for cwd-scoped continuation.
+	resumeRequested bool
+
+	// turnStdout accumulates ANSI-stripped stdout for the active turn.
+	// Reset at the top of each RunTurn before delegating to forkSession.
+	turnStdout *strings.Builder
+}
+
+func (s *sessionState) logger() *slog.Logger {
+	if s.sessionID == "" {
+		return s.baseLogger
+	}
+	return logging.WithSession(s.baseLogger, s.sessionID)
+}
+
+// NewKiroAdapter creates a [KiroAdapter] from adapter configuration. The
+// config parameter is the raw map from the "kiro" sub-object in WORKFLOW.md.
+//
+// It returns a non-nil error when the passthrough config sets both
+// trust_all_tools and a non-empty trust_tools list. Command resolution is
+// deferred to [KiroAdapter.StartSession].
+func NewKiroAdapter(config map[string]any) (domain.AgentAdapter, error) {
+	pt, err := parsePassthroughConfig(config)
+	if err != nil {
+		return nil, err
+	}
+	return &KiroAdapter{passthrough: pt}, nil
+}
+
+// StartSession validates the workspace path, resolves the kiro-cli binary,
+// verifies the credential, and initializes per-session state. No subprocess
+// is spawned; that happens in [KiroAdapter.RunTurn].
+//
+// In local mode it confirms KIRO_API_KEY is present and runs a "kiro-cli
+// whoami" canary, because a missing credential makes headless chat hang on
+// interactive login and an invalid credential exits 0 with empty output. In
+// SSH mode the credential preflight is skipped and KIRO_API_KEY is injected
+// inline into the remote command.
+func (a *KiroAdapter) StartSession(ctx context.Context, params domain.StartSessionParams) (domain.Session, error) {
+	target, agentErr := agentcore.ResolveLaunchTarget(params, "kiro-cli")
+	if agentErr != nil {
+		return domain.Session{}, agentErr
+	}
+
+	if target.RemoteCommand == "" {
+		if authErr := checkCredential(ctx, target.Command); authErr != nil {
+			return domain.Session{}, authErr
+		}
+	} else {
+		target.RemoteCommand = buildSSHRemoteCmd(target.RemoteCommand, os.Getenv("KIRO_API_KEY"))
+	}
+
+	state := &sessionState{
+		target:      target,
+		agentConfig: params.AgentConfig,
+		passthrough: a.passthrough,
+		baseLogger:  slog.Default().With(slog.String("component", "kiro-adapter")),
+		sessionID:   params.ResumeSessionID,
+		turnStdout:  &strings.Builder{},
+	}
+
+	hooks := agentcore.ForkPerTurnHooks{
+		BuildArgs: func(turn int, prompt string) []string {
+			return buildArgs(state, turn, prompt, a.passthrough)
+		},
+		ParseLine: func(line []byte, emit func(domain.AgentEvent), pid string) (any, error) {
+			text := stripANSI(string(line))
+			state.turnStdout.WriteString(text)
+			if text != "" {
+				emit(domain.AgentEvent{
+					Type:      domain.EventNotification,
+					Timestamp: time.Now().UTC(),
+					Message:   typeutil.TruncateRunes(text, 500),
+					AgentPID:  pid,
+				})
+			}
+			return nil, nil
+		},
+		GetUsage:     func() domain.TokenUsage { return domain.TokenUsage{} },
+		GetSessionID: func() string { return state.sessionID },
+		OnFinalize: func(emit func(domain.AgentEvent), _ any, exitCode int, stderrLines []string) (domain.TurnResult, *domain.AgentError) {
+			creditsSeen, authFailed := classifyStderr(stderrLines)
+			zero := domain.TokenUsage{}
+
+			if exitCode == 0 && creditsSeen {
+				state.resumeRequested = true
+				agentcore.EmitTurnCompleted(emit, "", 0)
+				return domain.TurnResult{
+					SessionID:  state.sessionID,
+					ExitReason: domain.EventTurnCompleted,
+					Usage:      zero,
+				}, nil
+			}
+
+			if exitCode == 0 && authFailed && state.turnStdout.Len() == 0 {
+				agentcore.EmitTurnFailed(emit, "kiro authentication failed", 0)
+				return domain.TurnResult{
+						SessionID:  state.sessionID,
+						ExitReason: domain.EventTurnFailed,
+						Usage:      zero,
+					}, &domain.AgentError{
+						Kind:    domain.ErrResponseError,
+						Message: "kiro authentication failed",
+					}
+			}
+
+			if exitCode == 0 {
+				agentcore.EmitTurnFailed(emit, "kiro exited without a credits trailer", 0)
+				return domain.TurnResult{
+						SessionID:  state.sessionID,
+						ExitReason: domain.EventTurnFailed,
+						Usage:      zero,
+					}, &domain.AgentError{
+						Kind:    domain.ErrTurnFailed,
+						Message: "kiro exited without a credits trailer",
+					}
+			}
+
+			agentcore.EmitTurnFailed(emit, "kiro exited with a non-zero status", 0)
+			return domain.TurnResult{
+					SessionID:  state.sessionID,
+					ExitReason: domain.EventTurnFailed,
+					Usage:      zero,
+				}, &domain.AgentError{
+					Kind:    domain.ErrPortExit,
+					Message: "kiro exited with a non-zero status",
+				}
+		},
+	}
+
+	state.forkSession = agentcore.NewForkPerTurnSession(&state.target, hooks, state.logger())
+
+	return domain.Session{
+		ID:       state.sessionID,
+		AgentPID: "",
+		Internal: state,
+	}, nil
+}
+
+// checkCredential verifies that KIRO_API_KEY is present and usable before
+// any chat turn. It returns nil on success, an [domain.AgentError] with
+// [domain.ErrResponseError] when the key is absent or rejected, and
+// [domain.ErrAgentNotFound] when the whoami canary cannot run.
+func checkCredential(ctx context.Context, command string) *domain.AgentError {
+	if strings.TrimSpace(os.Getenv("KIRO_API_KEY")) == "" {
+		return &domain.AgentError{
+			Kind:    domain.ErrResponseError,
+			Message: "KIRO_API_KEY is not set",
+		}
+	}
+
+	canaryCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	out, canaryErr := exec.CommandContext(canaryCtx, command, "whoami").CombinedOutput() //nolint:gosec // command resolved by ResolveLaunchTarget via LookPath
+	if canaryErr != nil {
+		return &domain.AgentError{
+			Kind:    domain.ErrAgentNotFound,
+			Message: "kiro-cli whoami canary failed to run",
+			Err:     canaryErr,
+		}
+	}
+
+	output := string(out)
+	if strings.Contains(output, authFailedMarker) || !strings.Contains(output, whoamiSuccessMarker) {
+		return &domain.AgentError{
+			Kind:    domain.ErrResponseError,
+			Message: "KIRO_API_KEY is invalid or expired",
+		}
+	}
+
+	return nil
+}
+
+// RunTurn executes one agent turn by delegating to the session's
+// [agentcore.ForkPerTurnSession]. The per-turn stdout accumulator is reset
+// before delegation so each turn starts clean.
+func (a *KiroAdapter) RunTurn(ctx context.Context, session domain.Session, params domain.RunTurnParams) (domain.TurnResult, error) {
+	if params.OnEvent == nil {
+		panic("kiro: OnEvent must be non-nil")
+	}
+
+	state, ok := session.Internal.(*sessionState)
+	if !ok {
+		return domain.TurnResult{}, &domain.AgentError{
+			Kind:    domain.ErrResponseError,
+			Message: "unexpected session internal type",
+		}
+	}
+
+	state.turnStdout = &strings.Builder{}
+
+	return state.forkSession.RunTurn(ctx, params.Prompt, params.OnEvent)
+}
+
+// StopSession terminates a running Kiro CLI subprocess gracefully by
+// delegating to the session's [agentcore.ForkPerTurnSession]. It is a no-op
+// when no subprocess is active and is safe to call after a failed RunTurn.
+func (a *KiroAdapter) StopSession(ctx context.Context, session domain.Session) error {
+	state, ok := session.Internal.(*sessionState)
+	if !ok {
+		return &domain.AgentError{
+			Kind:    domain.ErrResponseError,
+			Message: "unexpected session internal type",
+		}
+	}
+	if state.forkSession == nil {
+		return nil
+	}
+	return state.forkSession.Stop(ctx)
+}
+
+// EventStream returns nil. The Kiro CLI adapter delivers events
+// synchronously via the [domain.RunTurnParams] OnEvent callback.
+func (a *KiroAdapter) EventStream() <-chan domain.AgentEvent {
+	return nil
+}

--- a/internal/agent/kiro/kiro_test.go
+++ b/internal/agent/kiro/kiro_test.go
@@ -382,6 +382,35 @@ func TestStartSession_InvalidCredential(t *testing.T) {
 	requireAgentError(t, err, domain.ErrResponseError)
 }
 
+// TestStartSession_CanaryNonZeroExitIsResponseError locks the classification of
+// the whoami-canary failure arm: when the canary binary resolves but its whoami
+// invocation exits non-zero, the credential preflight returns ErrResponseError
+// (a retryable credential/runtime problem), never ErrAgentNotFound. The binary
+// here is already on PATH and resolvable, so a missing-agent classification
+// would be wrong. The fake's whoami arm exits 1 to drive the canaryErr != nil
+// branch; the 5s timeout path is intentionally not exercised.
+func TestStartSession_CanaryNonZeroExitIsResponseError(t *testing.T) {
+	// t.Setenv is incompatible with t.Parallel.
+	setValidAPIKey(t)
+
+	dir := t.TempDir()
+	bin := agenttest.WriteScript(t, dir, "kiro-cli", `if [ "$1" = "whoami" ]; then
+  exit 1
+fi
+exit 0`)
+
+	adapter, err := NewKiroAdapter(map[string]any{})
+	if err != nil {
+		t.Fatalf("NewKiroAdapter: %v", err)
+	}
+
+	_, err = adapter.StartSession(context.Background(), domain.StartSessionParams{
+		WorkspacePath: t.TempDir(),
+		AgentConfig:   domain.AgentConfig{Command: bin},
+	})
+	requireAgentError(t, err, domain.ErrResponseError)
+}
+
 func TestStartSession_BinaryNotFound(t *testing.T) {
 	t.Parallel()
 

--- a/internal/agent/kiro/kiro_test.go
+++ b/internal/agent/kiro/kiro_test.go
@@ -1,0 +1,486 @@
+//go:build unix
+
+package kiro
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/sortie-ai/sortie/internal/agent/agenttest"
+	"github.com/sortie-ai/sortie/internal/domain"
+)
+
+// fakeChatScript is the body of a fake kiro-cli that answers the StartSession
+// "whoami" canary and, for any other invocation (the "chat" turn), replays a
+// fixed stdout/stderr pair and exit code. Driving the real
+// agentcore.ForkPerTurnSession with this binary exercises the adapter's
+// OnFinalize and ParseLine closures end to end without a live kiro-cli.
+//
+// stdoutBody and stderrBody are written verbatim (no trailing newline added),
+// preserving the exact bytes the fixtures specify.
+func fakeChatScript(t *testing.T, dir, stdoutBody, stderrBody string, chatExit int) string {
+	t.Helper()
+	outFile := filepath.Join(dir, "chat_stdout")
+	errFile := filepath.Join(dir, "chat_stderr")
+	if err := os.WriteFile(outFile, []byte(stdoutBody), 0o644); err != nil {
+		t.Fatalf("writing chat stdout fixture: %v", err)
+	}
+	if err := os.WriteFile(errFile, []byte(stderrBody), 0o644); err != nil {
+		t.Fatalf("writing chat stderr fixture: %v", err)
+	}
+
+	body := fmt.Sprintf(`if [ "$1" = "whoami" ]; then
+  printf '%%s\n' 'Authenticated with API key'
+  exit 0
+fi
+cat '%s'
+cat '%s' >&2
+exit %d
+`, outFile, errFile, chatExit)
+
+	return agenttest.WriteScript(t, dir, "kiro-cli", body)
+}
+
+// setValidAPIKey sets a usable KIRO_API_KEY for the test. It is incompatible
+// with t.Parallel because t.Setenv mutates process state.
+func setValidAPIKey(t *testing.T) {
+	t.Helper()
+	t.Setenv("KIRO_API_KEY", "kiro-test-key")
+}
+
+// mustStartSession starts a Kiro session against the given fake binary and
+// returns the adapter, the session, and the adapter-internal state. The caller
+// must have set a valid KIRO_API_KEY so the whoami canary passes.
+func mustStartSession(t *testing.T, command string) (domain.AgentAdapter, domain.Session, *sessionState) {
+	t.Helper()
+	adapter, err := NewKiroAdapter(map[string]any{})
+	if err != nil {
+		t.Fatalf("NewKiroAdapter: %v", err)
+	}
+	session, err := adapter.StartSession(context.Background(), domain.StartSessionParams{
+		WorkspacePath: t.TempDir(),
+		AgentConfig:   domain.AgentConfig{Command: command},
+	})
+	if err != nil {
+		t.Fatalf("StartSession: %v", err)
+	}
+	state, ok := session.Internal.(*sessionState)
+	if !ok {
+		t.Fatalf("session.Internal type = %T, want *sessionState", session.Internal)
+	}
+	return adapter, session, state
+}
+
+// runChatTurn runs a single turn and returns the collected events and result.
+func runChatTurn(t *testing.T, adapter domain.AgentAdapter, session domain.Session, prompt string) ([]domain.AgentEvent, domain.TurnResult, error) {
+	t.Helper()
+	var events []domain.AgentEvent
+	result, err := adapter.RunTurn(context.Background(), session, domain.RunTurnParams{
+		Prompt: prompt,
+		OnEvent: func(e domain.AgentEvent) {
+			events = append(events, e)
+		},
+	})
+	return events, result, err
+}
+
+// requireAgentError asserts err is a *domain.AgentError with the given Kind.
+func requireAgentError(t *testing.T, err error, wantKind domain.AgentErrorKind) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("expected error with kind %q, got nil", wantKind)
+	}
+	var ae *domain.AgentError
+	if !errors.As(err, &ae) {
+		t.Fatalf("error type = %T, want *domain.AgentError", err)
+	}
+	if ae.Kind != wantKind {
+		t.Errorf("AgentError.Kind = %q, want %q", ae.Kind, wantKind)
+	}
+}
+
+// hasEventType reports whether any event in events matches typ.
+func hasEventType(events []domain.AgentEvent, typ domain.AgentEventType) bool {
+	for _, e := range events {
+		if e.Type == typ {
+			return true
+		}
+	}
+	return false
+}
+
+// The observed success trailer and auth-failure line use the exact literals
+// from the adapter research notes: stderr carries "▸ Credits: … • Time: …" on
+// a turn that ran, and "Authentication failed." on an invalid-credential turn.
+const (
+	creditsLine  = "▸ Credits: 0.01 • Time: 1s\n"
+	authFailLine = "Authentication failed. Your API key may be invalid or expired.\n"
+)
+
+func TestOnFinalize_SuccessWithCredits(t *testing.T) {
+	// t.Setenv is incompatible with t.Parallel.
+	setValidAPIKey(t)
+
+	bin := fakeChatScript(t, t.TempDir(), "\x1b[38;5;141m> \x1b[0mPONG", creditsLine, 0)
+	adapter, session, state := mustStartSession(t, bin)
+
+	events, result, err := runChatTurn(t, adapter, session, "ping")
+	if err != nil {
+		t.Fatalf("RunTurn() error = %v, want nil", err)
+	}
+	if result.ExitReason != domain.EventTurnCompleted {
+		t.Errorf("result.ExitReason = %q, want %q", result.ExitReason, domain.EventTurnCompleted)
+	}
+	if result.Usage != (domain.TokenUsage{}) {
+		t.Errorf("result.Usage = %+v, want zero TokenUsage", result.Usage)
+	}
+	if !hasEventType(events, domain.EventTurnCompleted) {
+		t.Error("EventTurnCompleted not delivered")
+	}
+	if !state.resumeRequested {
+		t.Error("state.resumeRequested = false, want true after a turn with the credits trailer")
+	}
+}
+
+func TestOnFinalize_AuthFailed(t *testing.T) {
+	// t.Setenv is incompatible with t.Parallel.
+	setValidAPIKey(t)
+
+	bin := fakeChatScript(t, t.TempDir(), "", authFailLine, 0)
+	adapter, session, state := mustStartSession(t, bin)
+
+	events, result, err := runChatTurn(t, adapter, session, "ping")
+
+	if result.ExitReason != domain.EventTurnFailed {
+		t.Errorf("result.ExitReason = %q, want %q", result.ExitReason, domain.EventTurnFailed)
+	}
+	requireAgentError(t, err, domain.ErrResponseError)
+	if !hasEventType(events, domain.EventTurnFailed) {
+		t.Error("EventTurnFailed not delivered for auth failure")
+	}
+	if result.Usage != (domain.TokenUsage{}) {
+		t.Errorf("result.Usage = %+v, want zero TokenUsage", result.Usage)
+	}
+	if state.resumeRequested {
+		t.Error("state.resumeRequested = true, want false after an auth-failed turn")
+	}
+}
+
+func TestOnFinalize_ExitZeroNoSignal(t *testing.T) {
+	// t.Setenv is incompatible with t.Parallel.
+	setValidAPIKey(t)
+
+	// Exit 0 with neither the credits trailer nor the auth-failure line: a
+	// bare exit 0 is never a success.
+	bin := fakeChatScript(t, t.TempDir(), "some transcript text", "a warning with no markers\n", 0)
+	adapter, session, state := mustStartSession(t, bin)
+
+	events, result, err := runChatTurn(t, adapter, session, "ping")
+
+	if result.ExitReason != domain.EventTurnFailed {
+		t.Errorf("result.ExitReason = %q, want %q", result.ExitReason, domain.EventTurnFailed)
+	}
+	requireAgentError(t, err, domain.ErrTurnFailed)
+	if !hasEventType(events, domain.EventTurnFailed) {
+		t.Error("EventTurnFailed not delivered for bare exit 0")
+	}
+	if state.resumeRequested {
+		t.Error("state.resumeRequested = true, want false after a no-credits turn")
+	}
+}
+
+func TestOnFinalize_NonZeroExit(t *testing.T) {
+	// t.Setenv is incompatible with t.Parallel.
+	setValidAPIKey(t)
+
+	bin := fakeChatScript(t, t.TempDir(), "", "kiro: internal error\n", 1)
+	adapter, session, _ := mustStartSession(t, bin)
+
+	events, result, err := runChatTurn(t, adapter, session, "ping")
+
+	if result.ExitReason != domain.EventTurnFailed {
+		t.Errorf("result.ExitReason = %q, want %q", result.ExitReason, domain.EventTurnFailed)
+	}
+	requireAgentError(t, err, domain.ErrPortExit)
+	if !hasEventType(events, domain.EventTurnFailed) {
+		t.Error("EventTurnFailed not delivered for non-zero exit")
+	}
+}
+
+// TestOnFinalize_AuthLineWithStdoutIsNotAuthError verifies the auth-failure arm
+// requires empty stdout: an auth line accompanied by transcript text falls
+// through to the bare-exit-0 arm (ErrTurnFailed), not the auth arm.
+func TestOnFinalize_AuthLineWithStdoutIsNotAuthError(t *testing.T) {
+	// t.Setenv is incompatible with t.Parallel.
+	setValidAPIKey(t)
+
+	bin := fakeChatScript(t, t.TempDir(), "partial answer", authFailLine, 0)
+	adapter, session, _ := mustStartSession(t, bin)
+
+	_, result, err := runChatTurn(t, adapter, session, "ping")
+
+	if result.ExitReason != domain.EventTurnFailed {
+		t.Errorf("result.ExitReason = %q, want %q", result.ExitReason, domain.EventTurnFailed)
+	}
+	requireAgentError(t, err, domain.ErrTurnFailed)
+}
+
+// TestOnFinalize_NoTokenEvent verifies that across every owned OnFinalize row,
+// TurnResult.Usage stays zero and no EventTokenUsage is ever emitted.
+func TestOnFinalize_NoTokenEvent(t *testing.T) {
+	// t.Setenv is incompatible with t.Parallel.
+	setValidAPIKey(t)
+
+	tests := []struct {
+		name       string
+		stdoutBody string
+		stderrBody string
+		chatExit   int
+	}{
+		{"success with credits", "\x1b[0mPONG", creditsLine, 0},
+		{"auth failed", "", authFailLine, 0},
+		{"exit zero no signal", "transcript", "noise\n", 0},
+		{"non-zero exit", "", "boom\n", 2},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// No t.Parallel(): the shared KIRO_API_KEY env is process-global.
+			bin := fakeChatScript(t, t.TempDir(), tt.stdoutBody, tt.stderrBody, tt.chatExit)
+			adapter, session, _ := mustStartSession(t, bin)
+
+			events, result, _ := runChatTurn(t, adapter, session, "ping")
+
+			if result.Usage != (domain.TokenUsage{}) {
+				t.Errorf("result.Usage = %+v, want zero TokenUsage", result.Usage)
+			}
+			if hasEventType(events, domain.EventTokenUsage) {
+				t.Error("EventTokenUsage emitted, want none for a no-token-accounting adapter")
+			}
+			for _, e := range events {
+				if e.Usage != (domain.TokenUsage{}) {
+					t.Errorf("event %q carried non-zero Usage %+v, want zero", e.Type, e.Usage)
+				}
+			}
+		})
+	}
+}
+
+func TestEventStream_Nil(t *testing.T) {
+	t.Parallel()
+
+	adapter, err := NewKiroAdapter(map[string]any{})
+	if err != nil {
+		t.Fatalf("NewKiroAdapter: %v", err)
+	}
+	if ch := adapter.EventStream(); ch != nil {
+		t.Errorf("EventStream() = non-nil channel, want nil (synchronous adapter)")
+	}
+}
+
+func TestRunTurn_NilOnEventPanics(t *testing.T) {
+	t.Parallel()
+
+	adapter, err := NewKiroAdapter(map[string]any{})
+	if err != nil {
+		t.Fatalf("NewKiroAdapter: %v", err)
+	}
+
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("RunTurn with nil OnEvent did not panic")
+		}
+		if msg, ok := r.(string); !ok || !strings.Contains(msg, "kiro") {
+			t.Errorf("panic value = %v, want a kiro-prefixed message", r)
+		}
+	}()
+
+	_, _ = adapter.RunTurn(context.Background(), domain.Session{Internal: &sessionState{}}, domain.RunTurnParams{OnEvent: nil})
+}
+
+func TestRunTurn_WrongInternalType(t *testing.T) {
+	t.Parallel()
+
+	adapter, err := NewKiroAdapter(map[string]any{})
+	if err != nil {
+		t.Fatalf("NewKiroAdapter: %v", err)
+	}
+
+	_, err = adapter.RunTurn(context.Background(), domain.Session{Internal: "not a sessionState"}, domain.RunTurnParams{
+		OnEvent: func(domain.AgentEvent) {},
+	})
+	requireAgentError(t, err, domain.ErrResponseError)
+}
+
+func TestStopSession_WrongInternalType(t *testing.T) {
+	t.Parallel()
+
+	adapter, err := NewKiroAdapter(map[string]any{})
+	if err != nil {
+		t.Fatalf("NewKiroAdapter: %v", err)
+	}
+
+	err = adapter.StopSession(context.Background(), domain.Session{Internal: 123})
+	requireAgentError(t, err, domain.ErrResponseError)
+}
+
+func TestStopSession_NilForkSession(t *testing.T) {
+	t.Parallel()
+
+	adapter, err := NewKiroAdapter(map[string]any{})
+	if err != nil {
+		t.Fatalf("NewKiroAdapter: %v", err)
+	}
+
+	session := domain.Session{Internal: &sessionState{}}
+	if err := adapter.StopSession(context.Background(), session); err != nil {
+		t.Errorf("StopSession(nil forkSession) error = %v, want nil", err)
+	}
+}
+
+func TestStartSession_MissingCredential(t *testing.T) {
+	// t.Setenv is incompatible with t.Parallel.
+	t.Setenv("KIRO_API_KEY", "")
+
+	bin := fakeChatScript(t, t.TempDir(), "", "", 0)
+	adapter, err := NewKiroAdapter(map[string]any{})
+	if err != nil {
+		t.Fatalf("NewKiroAdapter: %v", err)
+	}
+
+	_, err = adapter.StartSession(context.Background(), domain.StartSessionParams{
+		WorkspacePath: t.TempDir(),
+		AgentConfig:   domain.AgentConfig{Command: bin},
+	})
+	requireAgentError(t, err, domain.ErrResponseError)
+}
+
+func TestStartSession_InvalidCredential(t *testing.T) {
+	// t.Setenv is incompatible with t.Parallel.
+	t.Setenv("KIRO_API_KEY", "kiro-test-key")
+
+	// whoami reports the auth-failure marker, so the canary must reject the key.
+	dir := t.TempDir()
+	bin := agenttest.WriteScript(t, dir, "kiro-cli", "printf '%s\\n' 'Authentication failed.'\nexit 0")
+
+	adapter, err := NewKiroAdapter(map[string]any{})
+	if err != nil {
+		t.Fatalf("NewKiroAdapter: %v", err)
+	}
+
+	_, err = adapter.StartSession(context.Background(), domain.StartSessionParams{
+		WorkspacePath: t.TempDir(),
+		AgentConfig:   domain.AgentConfig{Command: bin},
+	})
+	requireAgentError(t, err, domain.ErrResponseError)
+}
+
+func TestStartSession_BinaryNotFound(t *testing.T) {
+	t.Parallel()
+
+	adapter, err := NewKiroAdapter(map[string]any{})
+	if err != nil {
+		t.Fatalf("NewKiroAdapter: %v", err)
+	}
+
+	_, err = adapter.StartSession(context.Background(), domain.StartSessionParams{
+		WorkspacePath: t.TempDir(),
+		AgentConfig:   domain.AgentConfig{Command: "sortie-nonexistent-kiro-12345"},
+	})
+	requireAgentError(t, err, domain.ErrAgentNotFound)
+}
+
+func TestStartSession_InvalidWorkspace(t *testing.T) {
+	t.Parallel()
+
+	adapter, err := NewKiroAdapter(map[string]any{})
+	if err != nil {
+		t.Fatalf("NewKiroAdapter: %v", err)
+	}
+
+	_, err = adapter.StartSession(context.Background(), domain.StartSessionParams{
+		WorkspacePath: "/nonexistent/sortie-kiro-test-path-12345",
+		AgentConfig:   domain.AgentConfig{Command: "/bin/sh"},
+	})
+	requireAgentError(t, err, domain.ErrInvalidWorkspaceCwd)
+}
+
+func TestBuildSSHRemoteCmd(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		remoteCommand string
+		apiKey        string
+		want          string
+	}{
+		{
+			name:          "empty key returns command unchanged",
+			remoteCommand: "kiro-cli",
+			apiKey:        "",
+			want:          "kiro-cli",
+		},
+		{
+			name:          "key is prepended and shell-quoted",
+			remoteCommand: "kiro-cli",
+			apiKey:        "abc123",
+			want:          "KIRO_API_KEY='abc123' kiro-cli",
+		},
+		{
+			name:          "key with single quote is escaped",
+			remoteCommand: "kiro-cli",
+			apiKey:        "a'b",
+			want:          `KIRO_API_KEY='a'\''b' kiro-cli`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := buildSSHRemoteCmd(tt.remoteCommand, tt.apiKey)
+			if got != tt.want {
+				t.Errorf("buildSSHRemoteCmd(%q, %q) = %q, want %q", tt.remoteCommand, tt.apiKey, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestStartSession_SSHModeInjectsKey verifies SSH mode skips the credential
+// canary and injects KIRO_API_KEY inline into the remote command.
+func TestStartSession_SSHModeInjectsKey(t *testing.T) {
+	// t.Setenv is incompatible with t.Parallel.
+	t.Setenv("KIRO_API_KEY", "ssh-key-value")
+
+	if _, err := exec.LookPath("ssh"); err != nil {
+		t.Skip("ssh not available on PATH")
+	}
+
+	adapter, err := NewKiroAdapter(map[string]any{})
+	if err != nil {
+		t.Fatalf("NewKiroAdapter: %v", err)
+	}
+
+	session, err := adapter.StartSession(context.Background(), domain.StartSessionParams{
+		WorkspacePath: t.TempDir(),
+		AgentConfig:   domain.AgentConfig{Command: "kiro-cli"},
+		SSHHost:       "dev-host.example.com",
+	})
+	if err != nil {
+		t.Fatalf("StartSession() (SSH mode) error = %v", err)
+	}
+
+	state := session.Internal.(*sessionState)
+	if !strings.Contains(state.target.RemoteCommand, "KIRO_API_KEY='ssh-key-value'") {
+		t.Errorf("state.target.RemoteCommand = %q, want it to inject the API key inline", state.target.RemoteCommand)
+	}
+	if !strings.Contains(state.target.RemoteCommand, "kiro-cli") {
+		t.Errorf("state.target.RemoteCommand = %q, want it to retain the kiro-cli command", state.target.RemoteCommand)
+	}
+}

--- a/internal/agent/kiro/parse.go
+++ b/internal/agent/kiro/parse.go
@@ -1,0 +1,48 @@
+package kiro
+
+import (
+	"regexp"
+	"strings"
+)
+
+const (
+	// creditsMarker is the stderr cost-trailer prefix that headless Kiro
+	// emits only after a turn actually executed. Matched as a substring
+	// because the numeric credit and time values vary; the prefix shape is
+	// the stable contract.
+	creditsMarker = "▸ Credits:" //nolint:gosec // G101: stderr cost-trailer prefix, not a credential
+
+	// authFailedMarker is the stderr line headless Kiro emits when the
+	// credential is present but invalid. Matched as a substring because the
+	// trailing detail text after the marker is not contracted.
+	authFailedMarker = "Authentication failed."
+)
+
+// ansiEscapeRE matches the ANSI color and style escape sequences that
+// headless Kiro leaves in stdout (for example "\x1b[38;5;141m> \x1b[0m").
+// Compiled once at package load. With --wrap never there is no width-based
+// wrapping, so only color and style escapes remain to strip.
+var ansiEscapeRE = regexp.MustCompile(`\x1b\[[0-9;]*[a-zA-Z]`)
+
+// stripANSI removes ANSI color and style escape sequences from s and
+// returns the cleaned text.
+func stripANSI(s string) string {
+	return ansiEscapeRE.ReplaceAllString(s, "")
+}
+
+// classifyStderr scans the collected stderr lines for the two headless
+// Kiro signals. creditsSeen is true when any line contains the cost-trailer
+// marker, the one positive proof that a turn ran. authFailed is true when
+// any line contains the authentication-failure marker. Both are matched by
+// substring containment, never by the numeric values that follow them.
+func classifyStderr(stderrLines []string) (creditsSeen bool, authFailed bool) {
+	for _, line := range stderrLines {
+		if strings.Contains(line, creditsMarker) {
+			creditsSeen = true
+		}
+		if strings.Contains(line, authFailedMarker) {
+			authFailed = true
+		}
+	}
+	return creditsSeen, authFailed
+}

--- a/internal/agent/kiro/parse_test.go
+++ b/internal/agent/kiro/parse_test.go
@@ -1,0 +1,213 @@
+//go:build unix
+
+package kiro
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/sortie-ai/sortie/internal/domain"
+)
+
+func TestStripANSI(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "observed colorized prompt marker",
+			input: "\x1b[38;5;141m> \x1b[0mPONG",
+			want:  "> PONG",
+		},
+		{
+			name:  "plain text passes through unchanged",
+			input: "just an answer",
+			want:  "just an answer",
+		},
+		{
+			name:  "empty string stays empty",
+			input: "",
+			want:  "",
+		},
+		{
+			name:  "reset-only sequence stripped",
+			input: "\x1b[0mhello",
+			want:  "hello",
+		},
+		{
+			name:  "multiple escapes in one line",
+			input: "\x1b[1m\x1b[31mERROR\x1b[0m: failed",
+			want:  "ERROR: failed",
+		},
+		{
+			name:  "text with no escapes but bracket chars",
+			input: "result [ok] (done)",
+			want:  "result [ok] (done)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := stripANSI(tt.input)
+			if got != tt.want {
+				t.Errorf("stripANSI(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestClassifyStderr(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		lines          []string
+		wantCredits    bool
+		wantAuthFailed bool
+	}{
+		{
+			name:           "credits trailer present",
+			lines:          []string{"some warning", "▸ Credits: 0.01 • Time: 1s"},
+			wantCredits:    true,
+			wantAuthFailed: false,
+		},
+		{
+			name:           "different credit and time values still match",
+			lines:          []string{"▸ Credits: 0.05 • Time: 6s"},
+			wantCredits:    true,
+			wantAuthFailed: false,
+		},
+		{
+			name:           "authentication failure present",
+			lines:          []string{"Authentication failed. Your API key may be invalid or expired."},
+			wantCredits:    false,
+			wantAuthFailed: true,
+		},
+		{
+			name:           "neither marker present",
+			lines:          []string{"Failed to retrieve MCP settings; MCP functionality disabled"},
+			wantCredits:    false,
+			wantAuthFailed: false,
+		},
+		{
+			name:           "empty lines",
+			lines:          nil,
+			wantCredits:    false,
+			wantAuthFailed: false,
+		},
+		{
+			name:           "credits trailer embedded mid-line",
+			lines:          []string{"trailing noise ▸ Credits: 1.20 • Time: 12s done"},
+			wantCredits:    true,
+			wantAuthFailed: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			gotCredits, gotAuthFailed := classifyStderr(tt.lines)
+			if gotCredits != tt.wantCredits {
+				t.Errorf("classifyStderr(%v) creditsSeen = %v, want %v", tt.lines, gotCredits, tt.wantCredits)
+			}
+			if gotAuthFailed != tt.wantAuthFailed {
+				t.Errorf("classifyStderr(%v) authFailed = %v, want %v", tt.lines, gotAuthFailed, tt.wantAuthFailed)
+			}
+		})
+	}
+}
+
+func TestParseLine_EmitsNotification(t *testing.T) {
+	// t.Setenv is incompatible with t.Parallel.
+	setValidAPIKey(t)
+
+	// stdout is the observed colorized marker; stderr carries the credits
+	// trailer so the turn completes cleanly. Splitting requires a newline so
+	// the skeleton's line scanner reads exactly one stdout line.
+	bin := fakeChatScript(t, t.TempDir(), "\x1b[38;5;141m> \x1b[0mPONG\n", creditsLine, 0)
+	adapter, session, state := mustStartSession(t, bin)
+
+	events, _, err := runChatTurn(t, adapter, session, "ping")
+	if err != nil {
+		t.Fatalf("RunTurn() error = %v", err)
+	}
+
+	var notifications []domain.AgentEvent
+	for _, e := range events {
+		if e.Type == domain.EventNotification {
+			notifications = append(notifications, e)
+		}
+		if e.Type == domain.EventToolResult {
+			t.Errorf("ParseLine emitted EventToolResult %+v, want only EventNotification for transcript lines", e)
+		}
+	}
+
+	if len(notifications) != 1 {
+		t.Fatalf("EventNotification count = %d, want 1; events = %+v", len(notifications), events)
+	}
+	n := notifications[0]
+	if n.Message != "> PONG" {
+		t.Errorf("notification.Message = %q, want stripped text %q", n.Message, "> PONG")
+	}
+	if n.AgentPID == "" {
+		t.Error("notification.AgentPID is empty, want the subprocess PID")
+	}
+
+	if got := state.turnStdout.String(); !strings.Contains(got, "> PONG") {
+		t.Errorf("state.turnStdout = %q, want it to contain the stripped line %q", got, "> PONG")
+	}
+}
+
+// TestResumePath verifies the resume contract: --resume is absent on turn 1,
+// becomes present on turn 2 only after a turn-1 OnFinalize that saw the credits
+// trailer, and stays absent when turn 1 fails.
+func TestResumePath(t *testing.T) {
+	t.Run("resume enabled after a successful turn 1", func(t *testing.T) {
+		// t.Setenv is incompatible with t.Parallel.
+		setValidAPIKey(t)
+
+		bin := fakeChatScript(t, t.TempDir(), "answer", creditsLine, 0)
+		adapter, session, state := mustStartSession(t, bin)
+
+		turn1Args := buildArgs(state, 1, "first", state.passthrough)
+		assertNoToken(t, turn1Args, "--resume")
+
+		_, result, err := runChatTurn(t, adapter, session, "first")
+		if err != nil {
+			t.Fatalf("turn 1 RunTurn() error = %v", err)
+		}
+		if result.ExitReason != domain.EventTurnCompleted {
+			t.Fatalf("turn 1 ExitReason = %q, want completed", result.ExitReason)
+		}
+		if !state.resumeRequested {
+			t.Fatal("state.resumeRequested = false after successful turn 1, want true")
+		}
+
+		turn2Args := buildArgs(state, 2, "second", state.passthrough)
+		assertHasToken(t, turn2Args, "--resume")
+	})
+
+	t.Run("resume not enabled after a failed turn 1", func(t *testing.T) {
+		// t.Setenv is incompatible with t.Parallel.
+		setValidAPIKey(t)
+
+		// Turn 1 fails (non-zero exit), so resumeRequested must stay false.
+		bin := fakeChatScript(t, t.TempDir(), "", "boom\n", 1)
+		adapter, session, state := mustStartSession(t, bin)
+
+		_, result, _ := runChatTurn(t, adapter, session, "first")
+		if result.ExitReason != domain.EventTurnFailed {
+			t.Fatalf("turn 1 ExitReason = %q, want failed", result.ExitReason)
+		}
+		if state.resumeRequested {
+			t.Fatal("state.resumeRequested = true after a failed turn 1, want false")
+		}
+
+		turn2Args := buildArgs(state, 2, "second", state.passthrough)
+		assertNoToken(t, turn2Args, "--resume")
+	})
+}


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Feat

**Intent:** Add the Kiro CLI (rebranded Amazon Q Developer CLI) as a supported agent adapter, enabling Sortie workflows to delegate coding turns to `kiro-cli` headless chat subprocesses under the existing `domain.AgentAdapter` interface.

**Related Issues:** #515

### 🧭 Reviewer Guide

**Complexity:** Medium

#### Entry Point

`internal/agent/kiro/kiro.go` - the adapter core. Start here to understand `StartSession` (binary resolution, credential preflight, per-session state initialization), the `ForkPerTurnHooks` closures (stdout accumulation, `OnFinalize` turn-outcome classification), and `RunTurn`/`StopSession`. The `OnFinalize` hook is the trickiest part: headless Kiro emits no structured JSON, so turn success is inferred from exit code combined with the presence of a stderr credits-trailer (`▸ Credits:`).

#### Sensitive Areas

- `internal/agent/kiro/kiro.go`: `checkCredential` runs a `kiro-cli whoami` canary to detect absent or expired `KIRO_API_KEY` before any turn, avoiding a silent hang on interactive login. `buildSSHRemoteCmd` in `internal/agent/kiro/command.go` shell-quotes the API key before prepending it to the remote command, which is the only place user-supplied credentials are composed into a shell string.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes
- **Migrations/State:** No migrations or state changes