### PR TITLE
feat(examples): add Kiro CLI sample workflow and align comment style

### DIFF
--- a/examples/WORKFLOW.codex.md
+++ b/examples/WORKFLOW.codex.md
@@ -56,22 +56,22 @@ server:
   port: 8642
 ---
 
-{{/* Sortie sample workflow — Jira + Codex CLI (OpenAI).
+{{/* Sortie sample workflow, Jira + Codex CLI (OpenAI).
 
      The Codex adapter uses a persistent app-server subprocess launched
      once per session. Turns are JSON-RPC requests on the same thread,
      so no --resume flag is needed between turns.
 
      Required env vars:
-       SORTIE_JIRA_ENDPOINT  — Jira Cloud base URL (e.g. https://mycompany.atlassian.net)
-       SORTIE_JIRA_API_KEY   — Jira API token
-       SORTIE_JIRA_PROJECT   — Jira project key (e.g. PROJ)
-       SORTIE_REPO_URL       — Git clone URL for the repository
-       CODEX_API_KEY         — OpenAI API key for Codex CLI
+       SORTIE_JIRA_ENDPOINT Jira Cloud base URL (e.g. https://mycompany.atlassian.net)
+       SORTIE_JIRA_API_KEY  Jira API token
+       SORTIE_JIRA_PROJECT  Jira project key (e.g. PROJ)
+       SORTIE_REPO_URL      Git clone URL for the repository
+       CODEX_API_KEY        OpenAI API key for Codex CLI
 
      Optional:
-       SORTIE_WORKSPACE_ROOT — Base directory for per-issue workspaces
-                               (defaults to system temp) */}}
+       SORTIE_WORKSPACE_ROOT Base directory for per-issue workspaces
+                             (defaults to system temp) */}}
 You are a senior engineer. Your work is tracked by an automated orchestrator (Sortie)
 that manages your session, retries failures, and monitors progress.
 

--- a/examples/WORKFLOW.copilot.md
+++ b/examples/WORKFLOW.copilot.md
@@ -51,20 +51,19 @@ server:
   port: 8642
 ---
 
-{{/* Sortie sample workflow — GitHub Issues + Copilot CLI.
-     Fully GitHub-native: no Jira, no Claude Code.
+{{/* Sortie sample workflow, GitHub Issues + Copilot CLI.
 
      Required env vars:
-       GITHUB_TOKEN          — Fine-grained PAT with Issues read/write + Copilot
-                               Requests permissions. Serves double duty: the tracker
-                               reads it via $GITHUB_TOKEN expansion and the Copilot
-                               CLI picks it up from the process environment.
-       SORTIE_GITHUB_PROJECT — Repository in owner/repo format
-       SORTIE_REPO_URL       — Git clone URL for the repository
+       GITHUB_TOKEN          Fine-grained PAT with Issues read/write + Copilot
+                             Requests permissions. Serves double duty: the tracker
+                             reads it via $GITHUB_TOKEN expansion and the Copilot
+                             CLI picks it up from the process environment.
+       SORTIE_GITHUB_PROJECT Repository in owner/repo format
+       SORTIE_REPO_URL       Git clone URL for the repository
 
      Optional:
-       SORTIE_WORKSPACE_ROOT — Base directory for per-issue workspaces
-                               (defaults to system temp) */}}
+       SORTIE_WORKSPACE_ROOT Base directory for per-issue workspaces
+                             (defaults to system temp) */}}
 You are a senior engineer. Your work is tracked by an automated orchestrator (Sortie)
 that manages your session, retries failures, and monitors progress.
 
@@ -91,7 +90,7 @@ Before making changes, read:
 
 1. Run the project's lint and test commands before finishing. All checks must pass.
 2. Do not modify protected files (LICENSE, CODEOWNERS) unless the task explicitly requires it.
-3. Keep changes minimal — implement exactly what the task requires.
+3. Keep changes minimal, implement exactly what the task requires.
 4. Write tests for new functionality. Cover edge cases, not just the happy path.
 5. If you encounter a problem outside the scope of this task, stop and explain what blocked you.
 
@@ -111,7 +110,7 @@ Before making changes, read:
 ## Continuation
 
 You are resuming work on this task (turn {{ .run.turn_number }} of {{ .run.max_turns }}).
-Review the current state of the workspace — check test output, lint results, and any
+Review the current state of the workspace, check test output, lint results, and any
 partial changes. Do not repeat work already completed. Proceed with the next step.
 {{ end }}
 

--- a/examples/WORKFLOW.kiro.md
+++ b/examples/WORKFLOW.kiro.md
@@ -1,0 +1,183 @@
+---
+tracker:
+  kind: github
+  api_key: $GITHUB_TOKEN
+  project: $SORTIE_GITHUB_PROJECT
+  query_filter: "label:backlog"
+  active_states:
+    - backlog
+    - in-progress
+  in_progress_state: in-progress
+  handoff_state: review
+  terminal_states:
+    - done
+    - wontfix
+
+polling:
+  interval_ms: 120000
+
+workspace:
+  root: $SORTIE_WORKSPACE_ROOT
+
+hooks:
+  after_create: |
+    git clone --depth 1 $SORTIE_REPO_URL .
+  before_run: |
+    git fetch origin main
+    git checkout -B "sortie/$SORTIE_ISSUE_IDENTIFIER" origin/main
+  after_run: |
+    git add -A
+    git diff --cached --quiet || \
+      git commit -m "sortie($SORTIE_ISSUE_IDENTIFIER): automated changes"
+    git push origin "sortie/$SORTIE_ISSUE_IDENTIFIER" --force-with-lease
+  before_remove: |
+    git push origin --delete "sortie/$SORTIE_ISSUE_IDENTIFIER" 2>/dev/null || true
+  timeout_ms: 120000
+
+agent:
+  kind: kiro
+  command: kiro-cli
+  max_turns: 5
+  max_concurrent_agents: 4
+  # Kiro has no native per-turn timeout switch; this orchestrator-side
+  # deadline is the only backstop on a stuck headless turn.
+  turn_timeout_ms: 1800000
+  stall_timeout_ms: 300000
+  max_retry_backoff_ms: 300000
+
+kiro:
+  # The model MUST be pinned here because Kiro's /model slash command is
+  # unavailable in headless mode; the adapter passes --model on every turn.
+  # Run "kiro-cli chat --list-models --format json" to see the live list.
+  model: claude-sonnet-4.6
+  # Least-privilege tool allowlist. The read-only profile (read, grep, glob)
+  # is the safe starting point; add "write" and "shell" only when the
+  # workflow requires file edits or command execution.
+  trust_tools:
+    - read
+    - grep
+    - glob
+
+server:
+  port: 8642
+---
+
+{{/* Sortie sample workflow, GitHub Issues + Kiro CLI.
+
+     The Kiro adapter launches one "kiro-cli chat --no-interactive"
+     subprocess per turn. Headless Kiro emits no structured output, so
+     budget enforcement is time-based: the turn_timeout_ms above is the
+     only backstop and no token-usage events are emitted.
+
+     Required env vars:
+       GITHUB_TOKEN          Fine-grained PAT with Issues read/write
+                             permission for the tracker adapter.
+       SORTIE_GITHUB_PROJECT Repository in owner/repo format.
+       SORTIE_REPO_URL       Git clone URL for the repository.
+       KIRO_API_KEY          API key for the Kiro CLI. Requires a Kiro
+                             Pro, Pro+, or Power subscription; the
+                             headless path is gated behind that tier.
+
+     Optional:
+       SORTIE_WORKSPACE_ROOT Base directory for per-issue workspaces
+                             (defaults to system temp).
+
+     Kiro-specific constraints (see docs/kiro-adapter-notes.md):
+       1. KIRO_API_KEY is required and the account needs a Kiro Pro,
+          Pro+, or Power subscription.
+       2. The model is pinned through the "model" field above because
+          Kiro has no headless model switch.
+       3. Budget enforcement is time-based only; the headless path
+          reports no token counts.
+       4. MCP is not available on the API-key path; MCPConfigPath is
+          ignored and no MCP startup flag is passed. */}}
+You are a senior engineer. Your work is tracked by an automated orchestrator (Sortie)
+that manages your session, retries failures, and monitors progress.
+
+## Your task
+
+**#{{ .issue.identifier }}**: {{ .issue.title }}
+
+{{ if .issue.description }}
+
+### Description
+
+{{ .issue.description }}
+{{ end }}
+
+## Context
+
+Before making changes, read:
+
+- `CLAUDE.md` or `CONTRIBUTING.md` for build commands and project conventions
+- Any existing tests in the area you are modifying
+- Related source files to understand current patterns
+
+## Rules
+
+1. Run the project's lint and test commands before finishing. All checks must pass.
+2. Do not modify protected files (LICENSE, CODEOWNERS) unless the task explicitly requires it.
+3. Keep changes minimal, implement exactly what the task requires.
+4. Write tests for new functionality. Cover edge cases, not just the happy path.
+5. If you encounter a problem outside the scope of this task, stop and explain what blocked you.
+
+{{ if not .run.is_continuation }}
+
+## Approach
+
+1. Read the relevant documentation and existing code before writing anything.
+2. Implement the minimal change that satisfies the task requirements.
+3. Write or update tests to cover the new behavior.
+4. Run verification commands and fix any failures.
+5. If the task is complete, confirm by reviewing your changes.
+{{ end }}
+
+{{ if .run.is_continuation }}
+
+## Continuation
+
+You are resuming work on this task (turn {{ .run.turn_number }} of {{ .run.max_turns }}).
+Review the current state of the workspace, check test output, lint results, and any
+partial changes. Do not repeat work already completed. Proceed with the next step.
+{{ end }}
+
+{{ if .attempt }}
+
+## Retry
+
+This is retry attempt {{ .attempt }}. A previous run failed or timed out. Check the
+workspace for partial work and do not start from scratch. Review any error output from
+the previous attempt if visible in the workspace.
+{{ end }}
+
+{{ if .issue.url }}
+
+## Reference
+
+Ticket: {{ .issue.url }}
+{{ end }}
+
+{{ if .issue.labels }}
+
+## Labels
+
+{{ .issue.labels | join ", " }}
+{{ end }}
+
+{{ if .issue.parent }}
+
+## Parent issue
+
+{{ .issue.parent.identifier }}
+{{ end }}
+
+{{ if .issue.blocked_by }}
+
+## Blockers
+
+The following issues block this task. If any are unresolved, focus on preparation work
+that does not depend on the blocked functionality (tests, scaffolding, documentation).
+
+{{ range .issue.blocked_by }}- **{{ .identifier }}**{{ if .state }} ({{ .state }}){{ end }}
+{{ end }}
+{{ end }}

--- a/examples/WORKFLOW.md
+++ b/examples/WORKFLOW.md
@@ -58,7 +58,7 @@ server:
   port: 8642
 ---
 
-{{/* Sortie sample workflow — E2E testing and documentation reference.
+{{/* Sortie sample workflow, E2E testing and documentation reference.
      Required env vars: SORTIE_JIRA_ENDPOINT, SORTIE_JIRA_API_KEY,
      SORTIE_JIRA_PROJECT, SORTIE_REPO_URL.
      Optional: SORTIE_WORKSPACE_ROOT (defaults to system temp). */}}

--- a/examples/WORKFLOW.opencode.md
+++ b/examples/WORKFLOW.opencode.md
@@ -60,7 +60,7 @@ server:
   port: 8642
 ---
 
-{{/* Sortie sample workflow — Jira + OpenCode CLI (Anthropic).
+{{/* Sortie sample workflow, Jira + OpenCode CLI (Anthropic).
 
      The OpenCode adapter launches one `opencode run` subprocess per
      turn. Session IDs are preserved across turns, so continuation uses
@@ -70,15 +70,15 @@ server:
      not fall back to its permissive default tool policy.
 
      Required env vars:
-       SORTIE_JIRA_ENDPOINT  — Jira Cloud base URL (e.g. https://mycompany.atlassian.net)
-       SORTIE_JIRA_API_KEY   — Jira API token
-       SORTIE_JIRA_PROJECT   — Jira project key (e.g. PROJ)
-       SORTIE_REPO_URL       — Git clone URL for the repository
-       ANTHROPIC_API_KEY     — Anthropic API key for OpenCode
+       SORTIE_JIRA_ENDPOINT  Jira Cloud base URL (e.g. https://mycompany.atlassian.net)
+       SORTIE_JIRA_API_KEY   Jira API token
+       SORTIE_JIRA_PROJECT   Jira project key (e.g. PROJ)
+       SORTIE_REPO_URL       Git clone URL for the repository
+       ANTHROPIC_API_KEY     Anthropic API key for OpenCode
 
      Optional:
-       SORTIE_WORKSPACE_ROOT — Base directory for per-issue workspaces
-                               (defaults to system temp) */}}
+       SORTIE_WORKSPACE_ROOT Base directory for per-issue workspaces
+                             (defaults to system temp) */}}
 You are a senior engineer. Your work is tracked by an automated orchestrator (Sortie)
 that manages your session, retries failures, and monitors progress.
 

--- a/examples/WORKFLOW.test.md
+++ b/examples/WORKFLOW.test.md
@@ -24,6 +24,7 @@ agent:
 
 {{/* Offline validation workflow using file tracker and mock agent.
      Run from repo root: go run ./cmd/sortie examples/WORKFLOW.test.md */}}
+
 **{{ .issue.identifier }}**: {{ .issue.title }}
 
 {{ if .issue.description }}{{ .issue.description }}{{ end }}


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Feat

**Intent:** Add a runnable sample workflow that pairs GitHub Issues with the Kiro CLI agent so users have a copy-paste starting point for headless Kiro runs. The accompanying style commit removes em-dashes from the five sibling sample workflows so every example shares the same comment style.

**Related Issues:** Closes #518

### 🧭 Reviewer Guide

**Complexity:** Low

#### Entry Point

`examples/WORKFLOW.kiro.md` is the new sample. It pairs `tracker.kind: github` with `agent.kind: kiro`, pins `model: claude-sonnet-4.6` because Kiro has no headless model switch, configures a read-only `trust_tools: [read, grep, glob]` allowlist, and documents the four Kiro-specific constraints inline: `KIRO_API_KEY` with a Kiro Pro, Pro+, or Power subscription requirement; model pinning required because `/model` is unavailable headless; time-only budget enforcement because the headless path reports no token counts; and MCP unavailability on the API-key path.

#### Sensitive Areas

- `examples/WORKFLOW.md`, `examples/WORKFLOW.codex.md`, `examples/WORKFLOW.copilot.md`, `examples/WORKFLOW.opencode.md`, `examples/WORKFLOW.test.md`: the style commit replaces em-dashes with commas in the Go-template comment blocks. Verify the diff carries no semantic changes - only punctuation inside `{{/* */}}` blocks, never inside the rendered prompt body.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes
- **Migrations/State:** No migrations or state changes
