### PR TITLE
docs: document Kiro CLI agent adapter in architecture and workflow ref

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -163,7 +163,7 @@ Sortie is organized into these layers:
    - API calls and normalization for tracker data; session lifecycle for agent runtimes; CI
      pipeline status queries; PR review comment fetching.
    - Multiple adapters per dimension: tracker adapters (Jira, GitHub, …), agent adapters
-     (Claude Code, Copilot CLI, Codex CLI, OpenCode CLI, …), CI status providers
+     (Claude Code, Copilot CLI, Codex CLI, OpenCode CLI, Kiro CLI, …), CI status providers
      (GitHub Checks, …), and SCM adapters
      (GitHub, …).
 
@@ -552,7 +552,7 @@ Fields:
 
 - `kind` (string)
   - Specifies which agent adapter to use. Default: `claude-code`.
-  - Other supported values: `copilot-cli`, `codex`, `opencode`, `http`, and any
+  - Other supported values: `copilot-cli`, `codex`, `opencode`, `kiro`, `http`, and any
     additionally registered adapter.
   - Parallels `tracker.kind`.
   - This is the default agent kind used when no `dispatch.rules` entry overrides it; see
@@ -592,8 +592,9 @@ Each adapter may define its own configuration fields in a sub-object named after
 value. These are pass-through values interpreted by the adapter and not by the orchestrator
 core. For example, a Codex adapter may accept `codex.approval_policy` and
 `codex.thread_sandbox`; a Claude Code adapter may accept `claude-code.permission_mode`; an
-OpenCode adapter may accept `opencode.variant` and `opencode.allowed_tools`. The
-orchestrator forwards the entire sub-object to the adapter without validation.
+OpenCode adapter may accept `opencode.variant` and `opencode.allowed_tools`; a Kiro adapter
+may accept `kiro.model` and `kiro.trust_tools`. The orchestrator forwards the entire
+sub-object to the adapter without validation.
 
 #### 5.3.6 `ci_feedback` (object, optional, **deprecated**)
 
@@ -1656,8 +1657,8 @@ An agent adapter must implement the following operations:
 
 Built-in agent adapter kinds:
 
-- `claude-code`, `copilot-cli`, `codex`, and `opencode` are built-in agent adapter kinds.
-- `claude-code`, `copilot-cli`, and `opencode` use one local subprocess per turn.
+- `claude-code`, `copilot-cli`, `codex`, `opencode`, and `kiro` are built-in agent adapter kinds.
+- `claude-code`, `copilot-cli`, `opencode`, and `kiro` use one local subprocess per turn.
 - `codex` uses one persistent local subprocess per session.
 
 Built-in adapter summary:
@@ -1668,6 +1669,7 @@ Built-in adapter summary:
 | `copilot-cli` | One subprocess per turn | Newline-delimited JSON from an abbreviated `copilot -p --output-format json -s --autopilot --no-ask-user ...` invocation | Uses `--resume <session_id>` when a session ID is known; falls back to `--continue` when a prior result omitted `sessionId` | The adapter always includes `--max-autopilot-continues` and includes `--allow-all` when no tool-scoping flags are configured; session identity is captured from the terminal `result` event rather than a start event. |
 | `codex` | One persistent `codex app-server` subprocess per session | JSON-RPC 2.0 over stdio | `ResumeSessionID` maps to `thread/resume`; otherwise the adapter starts a new thread; thread ID is the session ID | Turns are started inside the persistent session with `turn/start`; tool and approval handling are part of the app-server protocol. |
 | `opencode` | One subprocess per turn | Line-delimited JSON from `opencode run --format json --dir <workspace>` | `ResumeSessionID` maps to `--session <session_id>`; the first observed `sessionID` becomes the session ID; a mismatch is `turn_ended_with_error` | The adapter maps `opencode.model`, `opencode.agent`, `opencode.variant`, `opencode.thinking`, `opencode.pure`, and `opencode.dangerously_skip_permissions` to CLI flags; parses `step_start`, `text`, `reasoning`, `tool_use`, `step_finish`, and `error`; maps plain-text permission warnings to `notification` and unknown output to `malformed`; recovers final token usage with `opencode export --sanitize <session_id>`; maps logical `error` events to `turn_failed` even when the process exits with status `0`. |
+| `kiro` | One subprocess per turn | Plain-text human transcript from `kiro-cli chat --no-interactive`; stdout carries the assistant answer (ANSI-stripped), stderr carries the `▸ Credits: … • Time: …` trailer and warnings | Headless mode does not surface a session ID; `ResumeSessionID` is recorded but continuation relies on `--resume` against the cwd-scoped conversation store keyed by the workspace path | Headless Kiro emits no structured output and no token counts, so the adapter emits no `token_usage` events and leaves `TurnResult.Usage` zero; token-based budget enforcement does not apply and the turn timeout is the only backstop. Exit code 0 is ambiguous (success and invalid-credential failure both exit 0): success requires the credits trailer on stderr, and `Authentication failed.` on stderr with empty stdout maps to `turn_failed`. `StartSession` requires `KIRO_API_KEY` and runs a `kiro-cli whoami` canary to reject silently invalid keys before any turn; a missing credential would otherwise block headless `chat` indefinitely on an interactive device-login flow, which the credential preflight and the mandatory `agent.turn_timeout_ms` together defend against. MCP injection has no effect under `KIRO_API_KEY` auth (the backend profile gate disables MCP), so `MCPConfigPath` is ignored and `--require-mcp-startup` is unreachable. Permissions are controlled by `--trust-all-tools` or a `--trust-tools=<names>` allowlist; the two modes are mutually exclusive. The model is pinned per turn with `--model` because the `/model` slash command is unavailable headless. |
 
 ### 10.2 Session Lifecycle
 
@@ -1925,8 +1927,8 @@ Note:
 ### 10.7 Local Subprocess Launch Contract
 
 This subsection applies only to adapters that launch a local subprocess (e.g., Claude Code,
-Copilot CLI, OpenCode CLI, and the Codex app-server). HTTP-based and remote adapters define
-their own connection semantics.
+Copilot CLI, OpenCode CLI, Kiro CLI, and the Codex app-server). HTTP-based and remote
+adapters define their own connection semantics.
 
 When `agent.kind` requires a local subprocess:
 

--- a/docs/workflow-reference.md
+++ b/docs/workflow-reference.md
@@ -361,8 +361,8 @@ agent:
 
 | Field                            | Type                              | Required                            | Default         | Dynamic Reload                             | Description                                                                                                                                                                      |
 | -------------------------------- | --------------------------------- | ----------------------------------- | --------------- | ------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `kind`                           | string                            | No                                  | `claude-code`   | Future dispatches                          | Agent adapter identifier. This is the default kind used when no `dispatch.rules` entry (and no `dispatch.default.agent`) overrides it. Built-in adapters: `claude-code`, `copilot-cli`, `codex`, and `opencode`. Other kinds (for example, HTTP-based adapters) are available only if you register them separately. |
-| `command`                        | string (shell command)            | When adapter requires local process | Adapter-defined | Future dispatches                          | Shell command to launch the agent for adapters that run as a local subprocess (such as `claude-code` or `opencode`). Adapters that do not start a local process ignore this field. |
+| `kind`                           | string                            | No                                  | `claude-code`   | Future dispatches                          | Agent adapter identifier. This is the default kind used when no `dispatch.rules` entry (and no `dispatch.default.agent`) overrides it. Built-in adapters: `claude-code`, `copilot-cli`, `codex`, `opencode`, and `kiro`. Other kinds (for example, HTTP-based adapters) are available only if you register them separately. |
+| `command`                        | string (shell command)            | When adapter requires local process | Adapter-defined | Future dispatches                          | Shell command to launch the agent for adapters that run as a local subprocess (such as `claude-code`, `opencode`, or `kiro`). Adapters that do not start a local process ignore this field. |
 | `turn_timeout_ms`                | integer                           | No                                  | `3600000` (1h)  | Future worker attempts                     | Total timeout for a single agent turn.                                                                                                                                           |
 | `read_timeout_ms`                | integer                           | No                                  | `5000` (5s)     | Future worker attempts                     | Request/response timeout during startup and synchronous operations.                                                                                                              |
 | `stall_timeout_ms`               | integer                           | No                                  | `300000` (5m)   | Future worker attempts                     | Inactivity timeout based on event stream gaps. Set to `0` or negative to **disable** stall detection.                                                                            |
@@ -1502,6 +1502,10 @@ currently running sessions. Keys are agent adapter kind strings (e.g., `"claude-
 When `token_rates` is absent or empty, the dashboard shows raw token counts without
 cost estimates.
 
+The `kiro` adapter reports no token counts on the headless path, so a `token_rates.kiro`
+entry has no effect. Cost is surfaced only through the abstract credits figure in the
+`kiro-cli` stderr trailer, which the orchestrator does not aggregate.
+
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
 | `token_rates` | map | _(absent)_ | Top-level extension key. Keys are agent adapter kind strings. |
@@ -1635,6 +1639,57 @@ known.
 - The adapter always removes any inherited `OPENCODE_PERMISSION` value before
   launching OpenCode. If either tool list is non-empty, it replaces that value
   with the adapter-managed JSON policy.
+
+**Kiro adapter:**
+
+```yaml
+agent:
+  kind: kiro
+  command: kiro-cli
+  turn_timeout_ms: 3600000
+
+kiro:
+  model: claude-sonnet-4.6
+  trust_tools:
+    - read
+    - grep
+    - glob
+  agent: my-context-profile
+```
+
+The `kiro` block is forwarded to the Kiro adapter, which runs
+`kiro-cli chat --no-interactive --wrap never` once per turn and adds `--resume`
+on continuation turns to attach to the cwd-scoped conversation. The Kiro CLI
+is the rebranded Amazon Q Developer CLI; the binary is `kiro-cli`.
+
+| Field | Type | Default | Description |
+| --- | --- | --- | --- |
+| `kiro.model` | string | _(absent)_ | Forwarded to `kiro-cli chat --model`. The `/model` slash command is unavailable headless, so the model MUST be pinned per turn (here or via `kiro-cli settings chat.defaultModel`). Use `kiro-cli chat --list-models --format json` to enumerate the account-specific model set. |
+| `kiro.trust_all_tools` | boolean | `false` | Adds `--trust-all-tools`, auto-approving every tool call. Use only inside a hardened sandbox. Mutually exclusive with `kiro.trust_tools`. |
+| `kiro.trust_tools` | list of strings | `[]` | Adds `--trust-tools=<names>` with the comma-joined list. An empty list trusts nothing (the adapter still passes `--trust-tools=`, which is the explicit no-trust mode). Mutually exclusive with `kiro.trust_all_tools`. Tool names include `read`, `write`, `glob`, `grep`, `shell`, `aws`, `web_search`, `web_fetch`, `code`, and `report`. |
+| `kiro.agent` | string | _(absent)_ | Forwarded to `kiro-cli chat --agent` to select a named Kiro context profile (custom agent). |
+
+**Validation rules:**
+
+- `kiro.trust_all_tools: true` and a non-empty `kiro.trust_tools` list MUST NOT
+  be set together. The adapter rejects this combination at construction time.
+
+**Environment variables consumed by the adapter:**
+
+| Variable | Required | Description |
+| --- | --- | --- |
+| `KIRO_API_KEY` | Yes (local mode) | Headless credential. Requires a Kiro Pro, Pro+, or Power subscription. The adapter rejects a missing key in `StartSession` and runs a `kiro-cli whoami` canary to reject a present-but-invalid key, because headless `chat` with no credential blocks on an interactive device-login flow with no self-timeout. In SSH mode the orchestrator forwards `KIRO_API_KEY` from its environment into the remote command. |
+
+**Token usage and budgets:** The Kiro adapter emits no token-usage events.
+`kiro-cli` does not report token counts on the headless path (only an abstract
+credits figure on stderr), so `TurnResult.Usage` is the zero value and
+`token_rates.kiro` produces no cost estimate. Token-based budget enforcement
+does not apply to Kiro; the `agent.turn_timeout_ms` is the only effective
+backstop and is mandatory because `kiro-cli` has no native per-turn timeout.
+
+**MCP:** Under `KIRO_API_KEY` authentication the backend `GetProfile` gate
+disables MCP. A workspace `mcp.json` is not loaded and `--require-mcp-startup`
+is unreachable, so MCP-dependent workflows cannot run on the API-key path.
 
 **Custom or future adapters (illustrative example):**
 


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Docs

**Intent:** Add Kiro CLI as a documented built-in agent adapter in the two canonical in-repo references (`docs/architecture.md` and `docs/workflow-reference.md`), so both stay in sync with the registered adapter set and a reader can understand and configure the Kiro adapter from each file independently.

**Related Issues:** Closes #519

### 🧭 Reviewer Guide

**Complexity:** Low

#### Entry Point

`docs/workflow-reference.md` - the new `kiro` extension block (around line 1640) is the most self-contained addition and shows all user-facing configuration fields, trust-tool modes, environment variables, and the token-budget caveat. Start there to understand the surface, then cross-check against the adapter table rows added in `docs/architecture.md`.

#### Sensitive Areas

- `docs/architecture.md`: the adapter table row for `kiro` describes exit-code-0 ambiguity, credential preflight, MCP unavailability under `KIRO_API_KEY`, and the absence of token-usage events - each sentence must accurately reflect the adapter implementation.
- `docs/workflow-reference.md`: the `kiro.trust_all_tools` / `kiro.trust_tools` mutual-exclusion rule and the `KIRO_API_KEY` required-in-local-mode note are security-relevant; verify they match the adapter source.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes
- **Migrations/State:** No migrations or state changes