### PR TITLE
feat: add PowerShell installer and Authenticode signing for Windows

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -66,3 +66,4 @@ go.work.sum
 
 # Install script
 install.sh
+install.ps1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -404,25 +404,11 @@ jobs:
       - name: Install Syft
         uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
 
-      - name: Create and push tag
-        if: ${{ !inputs.dry_run }}
-        run: |
-          TAG='${{ inputs.version }}'
-          git config user.name  "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git tag -a "$TAG" -m "Release ${TAG}"
-          git push origin "$TAG"
-          echo "### Tagged \`${TAG}\`" >> "$GITHUB_STEP_SUMMARY"
-
-      - name: Create local tag (dry run)
-        if: ${{ inputs.dry_run }}
-        run: |
-          TAG='${{ inputs.version }}'
-          git config user.name  "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git tag -a "$TAG" -m "Dry run ${TAG}"
-
+      # Verify signing config and install the module before any repository
+      # mutation, so a misconfigured release fails fast without leaving an
+      # orphaned tag. Skipped on dry runs, which may run without credentials.
       - name: Verify SignPath configuration is present
+        if: ${{ !inputs.dry_run }}
         env:
           SIGNPATH_ORG_ID: ${{ vars.SIGNPATH_ORG_ID }}
           SIGNPATH_API_TOKEN: ${{ secrets.SIGNPATH_API_TOKEN }}
@@ -442,6 +428,24 @@ jobs:
         run: |
           Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
           Install-Module -Name SignPath -RequiredVersion 4.3.1 -Force -Scope CurrentUser -AcceptLicense
+
+      - name: Create and push tag
+        if: ${{ !inputs.dry_run }}
+        run: |
+          TAG='${{ inputs.version }}'
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -a "$TAG" -m "Release ${TAG}"
+          git push origin "$TAG"
+          echo "### Tagged \`${TAG}\`" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Create local tag (dry run)
+        if: ${{ inputs.dry_run }}
+        run: |
+          TAG='${{ inputs.version }}'
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -a "$TAG" -m "Dry run ${TAG}"
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7.2.2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -423,7 +423,10 @@ jobs:
           fi
           echo "✓ SignPath configuration is present"
 
+      # Only needed when signing is configured for this repo; skipped on forks
+      # and credential-less dry runs so they do not depend on PSGallery.
       - name: Install SignPath signing module
+        if: ${{ vars.SIGNPATH_ORG_ID != '' }}
         shell: pwsh
         run: |
           Set-PSRepository -Name PSGallery -InstallationPolicy Trusted

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -422,20 +422,20 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git tag -a "$TAG" -m "Dry run ${TAG}"
 
-      - name: Verify SignPath secrets are configured
+      - name: Verify SignPath configuration is present
         env:
-          SIGNPATH_ORG_ID: ${{ secrets.SIGNPATH_ORG_ID }}
+          SIGNPATH_ORG_ID: ${{ vars.SIGNPATH_ORG_ID }}
           SIGNPATH_API_TOKEN: ${{ secrets.SIGNPATH_API_TOKEN }}
         run: |
           missing=()
-          [ -z "$SIGNPATH_ORG_ID" ]    && missing+=("SIGNPATH_ORG_ID")
-          [ -z "$SIGNPATH_API_TOKEN" ] && missing+=("SIGNPATH_API_TOKEN")
+          [ -z "$SIGNPATH_ORG_ID" ]    && missing+=("SIGNPATH_ORG_ID (variable)")
+          [ -z "$SIGNPATH_API_TOKEN" ] && missing+=("SIGNPATH_API_TOKEN (secret)")
           if [ ${#missing[@]} -ne 0 ]; then
-            echo "::error::Missing required secrets: ${missing[*]}"
+            echo "::error::Missing required SignPath config: ${missing[*]}"
             echo "Configure these in Settings → Secrets and variables → Actions"
             exit 1
           fi
-          echo "✓ All SignPath secrets are present"
+          echo "✓ SignPath configuration is present"
 
       - name: Install SignPath signing module
         shell: pwsh
@@ -452,8 +452,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAP_GITHUB_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }}
-          SIGNPATH_ORG_ID: ${{ secrets.SIGNPATH_ORG_ID }}
+          SIGNPATH_ORG_ID: ${{ vars.SIGNPATH_ORG_ID }}
           SIGNPATH_API_TOKEN: ${{ secrets.SIGNPATH_API_TOKEN }}
+          SIGNPATH_PROJECT_SLUG: ${{ vars.SIGNPATH_PROJECT_SLUG }}
+          SIGNPATH_POLICY_SLUG: ${{ vars.SIGNPATH_POLICY_SLUG }}
 
       - name: Release summary
         if: ${{ !inputs.dry_run }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -422,6 +422,27 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git tag -a "$TAG" -m "Dry run ${TAG}"
 
+      - name: Verify SignPath secrets are configured
+        env:
+          SIGNPATH_ORG_ID: ${{ secrets.SIGNPATH_ORG_ID }}
+          SIGNPATH_API_TOKEN: ${{ secrets.SIGNPATH_API_TOKEN }}
+        run: |
+          missing=()
+          [ -z "$SIGNPATH_ORG_ID" ]    && missing+=("SIGNPATH_ORG_ID")
+          [ -z "$SIGNPATH_API_TOKEN" ] && missing+=("SIGNPATH_API_TOKEN")
+          if [ ${#missing[@]} -ne 0 ]; then
+            echo "::error::Missing required secrets: ${missing[*]}"
+            echo "Configure these in Settings → Secrets and variables → Actions"
+            exit 1
+          fi
+          echo "✓ All SignPath secrets are present"
+
+      - name: Install SignPath signing module
+        shell: pwsh
+        run: |
+          Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
+          Install-Module -Name SignPath -RequiredVersion 4.3.1 -Force -Scope CurrentUser -AcceptLicense
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7.2.2
         with:
@@ -431,6 +452,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAP_GITHUB_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }}
+          SIGNPATH_ORG_ID: ${{ secrets.SIGNPATH_ORG_ID }}
+          SIGNPATH_API_TOKEN: ${{ secrets.SIGNPATH_API_TOKEN }}
 
       - name: Release summary
         if: ${{ !inputs.dry_run }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -33,6 +33,14 @@ builds:
       - osusergo
       - netgo
     mod_timestamp: "{{ .CommitTimestamp }}"
+    hooks:
+      post:
+        # Authenticode-sign Windows binaries with SignPath before archiving, so
+        # the published archive and checksums cover the signed binary. The
+        # script no-ops on non-Windows targets and when SignPath credentials are
+        # absent (snapshots, pull requests, local builds).
+        - cmd: ./scripts/signpath-sign.sh "{{ .Path }}"
+          output: true
 
 archives:
   - id: default

--- a/cmd/sortie/main_test.go
+++ b/cmd/sortie/main_test.go
@@ -1472,7 +1472,12 @@ func TestRunAutoMerge_UnknownProvider(t *testing.T) {
 
 	var stdout bytes.Buffer
 	var stderr lockedBuf
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	// run() rejects the unknown SCM provider only after opening and
+	// migrating the database, so the timeout must outlast a slow DB open
+	// on a contended Windows runner. The startup error returns in
+	// milliseconds once reached, so the wider budget is a hang-guard
+	// only and never slows the happy path.
+	ctx, cancel := context.WithTimeout(context.Background(), runTestTimeout)
 	defer cancel()
 
 	code := run(ctx, []string{wfPath}, &stdout, &stderr)
@@ -1502,7 +1507,12 @@ func TestRunAutoMerge_MismatchedProviders(t *testing.T) {
 
 	var stdout bytes.Buffer
 	var stderr lockedBuf
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	// run() rejects the mismatched providers only after opening and
+	// migrating the database, so the timeout must outlast a slow DB open
+	// on a contended Windows runner. The startup error returns in
+	// milliseconds once reached, so the wider budget is a hang-guard
+	// only and never slows the happy path.
+	ctx, cancel := context.WithTimeout(context.Background(), runTestTimeout)
 	defer cancel()
 
 	code := run(ctx, []string{wfPath}, &stdout, &stderr)

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,316 @@
+<#
+.SYNOPSIS
+    Installer for sortie - spec-first agent orchestrator.
+
+.DESCRIPTION
+    Downloads the latest sortie release for Windows, verifies its checksum,
+    installs sortie.exe, and adds the install directory to the user PATH.
+
+    Usage:
+        irm 'https://get.sortie-ai.com/install.ps1' | iex
+
+    Environment:
+        SORTIE_VERSION      Pin a specific release tag (e.g. 1.11.0 or 0.0.7).
+        SORTIE_INSTALL_DIR  Override install directory
+                            (default: %LOCALAPPDATA%\Programs\sortie).
+        SORTIE_NO_VERIFY    Set to 1 to skip checksum verification.
+
+    Compatible with Windows PowerShell 5.1 and PowerShell 7+.
+#>
+
+#Requires -Version 5.1
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$Repo = 'sortie-ai/sortie'
+$Bin  = 'sortie'
+
+# ── Formatting ──────────────────────────────────────────────────────────────────
+
+# Mirror install.sh: info/ok use a ":: " prefix, err uses "error: ".
+function Write-Info { param([string]$Message) Write-Host ':: ' -ForegroundColor Cyan  -NoNewline; Write-Host $Message }
+function Write-Ok   { param([string]$Message) Write-Host ':: ' -ForegroundColor Green -NoNewline; Write-Host $Message }
+function Write-Err  { param([string]$Message) [Console]::Error.WriteLine("error: $Message") }
+
+# True when the console can render UTF-8 glyphs (ASCII art, spade).
+function Test-Utf8Console {
+    try {
+        $enc  = [Console]::OutputEncoding
+        $char = [char]0x2588  # █
+        return ($enc.GetString($enc.GetBytes($char)) -eq $char)
+    }
+    catch { return $false }
+}
+
+# ── Platform detection ──────────────────────────────────────────────────────────
+
+# Map the host processor architecture to a release arch token (amd64|arm64).
+function Get-Architecture {
+    # Prefer the .NET runtime view. Windows PowerShell 5.1 can hide members on
+    # RuntimeInformation, so any failure falls back to environment variables.
+    try {
+        $osArch = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString()
+        switch ($osArch) {
+            'X64'   { return 'amd64' }
+            'Arm64' { return 'arm64' }
+        }
+    }
+    catch {
+        # Fall through to the environment-variable probe below.
+    }
+
+    # PROCESSOR_ARCHITEW6432 is set when a 32-bit process runs on 64-bit Windows;
+    # it reports the true OS architecture. Otherwise PROCESSOR_ARCHITECTURE does.
+    $envArch = $env:PROCESSOR_ARCHITEW6432
+    if ([string]::IsNullOrEmpty($envArch)) { $envArch = $env:PROCESSOR_ARCHITECTURE }
+    switch ($envArch) {
+        'AMD64' { return 'amd64' }
+        'ARM64' { return 'arm64' }
+    }
+
+    throw "unsupported architecture: $envArch"
+}
+
+# ── HTTP helpers ────────────────────────────────────────────────────────────────
+
+# Download a URL to a file. -UseBasicParsing is required on 5.1 and harmless on 7.
+function Invoke-Download {
+    param(
+        [Parameter(Mandatory)][string]$Url,
+        [Parameter(Mandatory)][string]$OutFile
+    )
+    Invoke-WebRequest -Uri $Url -OutFile $OutFile -UseBasicParsing
+}
+
+# ── Version resolution ──────────────────────────────────────────────────────────
+
+# Use $env:SORTIE_VERSION when set, otherwise read the latest release tag from
+# the GitHub API. GitHub requires a User-Agent header.
+function Resolve-Tag {
+    if (-not [string]::IsNullOrEmpty($env:SORTIE_VERSION)) {
+        return $env:SORTIE_VERSION
+    }
+
+    $url = "https://api.github.com/repos/$Repo/releases/latest"
+    try {
+        $release = Invoke-RestMethod -Uri $url -UseBasicParsing `
+            -Headers @{ 'User-Agent' = 'sortie-installer' }
+    }
+    catch {
+        throw 'GitHub API request failed (rate-limited? set SORTIE_VERSION to skip)'
+    }
+
+    # StrictMode throws on a missing property, so probe before reading.
+    $tagProp = $release.PSObject.Properties['tag_name']
+    if ($null -eq $tagProp -or [string]::IsNullOrEmpty($tagProp.Value)) {
+        throw 'could not determine latest release'
+    }
+    return $tagProp.Value
+}
+
+# ── Checksum verification ────────────────────────────────────────────────────────
+
+# Verify the SHA-256 of $FilePath against the entry for its file name in
+# checksums.txt (each line: "<hex-sha256>  <filename>").
+function Test-Checksum {
+    param(
+        [Parameter(Mandatory)][string]$FilePath,
+        [Parameter(Mandatory)][string]$SumsPath
+    )
+    $name = Split-Path -Leaf $FilePath
+
+    $want = $null
+    foreach ($line in Get-Content -LiteralPath $SumsPath) {
+        # Split on whitespace; goreleaser uses two spaces between hash and name.
+        $fields = $line -split '\s+', 2
+        if ($fields.Count -eq 2 -and $fields[1].Trim() -eq $name) {
+            $want = $fields[0].Trim()
+            break
+        }
+    }
+    if ([string]::IsNullOrEmpty($want)) {
+        throw "no checksum entry for $name"
+    }
+
+    $got = (Get-FileHash -LiteralPath $FilePath -Algorithm SHA256).Hash
+    if ($want -ne $got) {
+        throw "checksum mismatch (expected $want, got $got)"
+    }
+}
+
+# ── Install directory resolution ──────────────────────────────────────────────────
+
+# $env:SORTIE_INSTALL_DIR when set, otherwise %LOCALAPPDATA%\Programs\sortie.
+# Never %ProgramFiles% by default - that would require elevation.
+function Resolve-InstallDir {
+    if (-not [string]::IsNullOrEmpty($env:SORTIE_INSTALL_DIR)) {
+        return $env:SORTIE_INSTALL_DIR
+    }
+    return (Join-Path $env:LOCALAPPDATA 'Programs\sortie')
+}
+
+# ── PATH update ──────────────────────────────────────────────────────────────────
+
+# Append $Dir to the User-scope PATH if absent (registry-backed, not the merged
+# process PATH). Returns $true when the variable was modified.
+function Add-ToUserPath {
+    param([Parameter(Mandatory)][string]$Dir)
+
+    $current = [Environment]::GetEnvironmentVariable('Path', 'User')
+    if ($null -eq $current) { $current = '' }
+
+    # Case-insensitive membership check, tolerating empty/stray entries.
+    # @(...) forces an array so += always appends (a bare pipeline assignment
+    # yields a scalar string for a single entry, which += would concatenate).
+    $entries = @($current -split ';' | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+    foreach ($entry in $entries) {
+        if ($entry.TrimEnd('\') -ieq $Dir.TrimEnd('\')) {
+            return $false
+        }
+    }
+
+    $entries += $Dir
+    $updated = ($entries -join ';')
+    [Environment]::SetEnvironmentVariable('Path', $updated, 'User')
+
+    # Make sortie usable in the current session without a restart.
+    $env:Path = "$Dir;$env:Path"
+    return $true
+}
+
+# ── Post-install summary ──────────────────────────────────────────────────────────
+
+# Mirror install.sh's summary block exactly (taglines, labels, ordering).
+function Show-Summary {
+    param(
+        [Parameter(Mandatory)][string]$Tag,
+        [Parameter(Mandatory)][string]$Version
+    )
+    $utf8 = Test-Utf8Console
+
+    Write-Host ''
+    if ($utf8) {
+        $art = @(
+            '  ███████╗ ██████╗ ██████╗ ████████╗██╗███████╗',
+            '  ██╔════╝██╔═══██╗██╔══██╗╚══██╔══╝██║██╔════╝',
+            '  ███████╗██║   ██║██████╔╝   ██║   ██║█████╗',
+            '  ╚════██║██║   ██║██╔══██╗   ██║   ██║██╔══╝',
+            '  ███████║╚██████╔╝██║  ██║   ██║   ██║███████╗',
+            '  ╚══════╝ ╚═════╝ ╚═╝  ╚═╝   ╚═╝   ╚═╝╚══════╝'
+        )
+        foreach ($line in $art) { Write-Host $line -ForegroundColor Cyan }
+    }
+    else {
+        Write-Host '  Sortie'
+    }
+
+    Write-Host '  Turns issue tickets into autonomous sessions.' -ForegroundColor DarkGray
+    Write-Host ''
+    Write-Host '  Docs:      ' -ForegroundColor Yellow -NoNewline
+    Write-Host ' https://docs.sortie-ai.com'
+    Write-Host '  Changelog: ' -ForegroundColor Yellow -NoNewline
+    Write-Host " https://docs.sortie-ai.com/changelog/#$Version"
+    Write-Host '  GitHub:    ' -ForegroundColor Yellow -NoNewline
+    Write-Host " https://github.com/$Repo"
+
+    Write-Host ''
+    if ($utf8) {
+        Write-Host '  Happy hacking! ' -NoNewline
+        Write-Host '♠' -ForegroundColor Cyan
+    }
+    else {
+        Write-Host '  Happy hacking!'
+    }
+    Write-Host ''
+}
+
+# ── Main ──────────────────────────────────────────────────────────────────────────
+
+function Invoke-Install {
+    # Force TLS 1.2 for PS 5.1 on older Windows; -bor keeps TLS 1.3 on PS 7.
+    [Net.ServicePointManager]::SecurityProtocol = `
+        [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
+
+    # The Invoke-WebRequest progress bar makes downloads very slow on PS 5.1.
+    $script:OldProgressPreference = $ProgressPreference
+    $ProgressPreference = 'SilentlyContinue'
+
+    $arch = Get-Architecture
+    Write-Info "Platform: windows/$arch"
+
+    $tag = Resolve-Tag
+    $version = $tag -replace '^v', ''
+    Write-Info "Release:  $tag"
+
+    $archive = "${Bin}_${version}_windows_${arch}.zip"
+    $base    = "https://github.com/$Repo/releases/download/$tag"
+
+    $tmpDir = Join-Path ([System.IO.Path]::GetTempPath()) ("sortie-install-" + (New-Guid).Guid)
+    New-Item -ItemType Directory -Path $tmpDir -Force | Out-Null
+
+    try {
+        $archivePath = Join-Path $tmpDir $archive
+
+        Write-Info "Downloading $archive"
+        try {
+            Invoke-Download -Url "$base/$archive" -OutFile $archivePath
+        }
+        catch {
+            throw "download failed - verify release $tag has asset for windows/$arch"
+        }
+
+        if ($env:SORTIE_NO_VERIFY -ne '1') {
+            $sumsPath = Join-Path $tmpDir 'checksums.txt'
+            try {
+                Invoke-Download -Url "$base/checksums.txt" -OutFile $sumsPath
+            }
+            catch {
+                throw 'failed to download checksums'
+            }
+            Test-Checksum -FilePath $archivePath -SumsPath $sumsPath
+            Write-Info 'Checksum verified'
+        }
+
+        # Extract into the temp dir; the real install happens only after this
+        # succeeds, so a failure never leaves files in the install directory.
+        $extractDir = Join-Path $tmpDir 'extracted'
+        Expand-Archive -Path $archivePath -DestinationPath $extractDir -Force
+
+        $exe = Get-ChildItem -Path $extractDir -Filter "$Bin.exe" -Recurse -File |
+            Select-Object -First 1
+        if ($null -eq $exe) {
+            throw "$Bin.exe not found in archive"
+        }
+
+        $dir = Resolve-InstallDir
+        New-Item -ItemType Directory -Path $dir -Force | Out-Null
+        $target = Join-Path $dir "$Bin.exe"
+        Move-Item -LiteralPath $exe.FullName -Destination $target -Force
+        Unblock-File -LiteralPath $target
+
+        Write-Ok "Installed $Bin $tag to $target"
+
+        if (Add-ToUserPath -Dir $dir) {
+            Write-Host ''
+            Write-Info "Added $dir to your PATH."
+            Write-Host '  Restart open shell sessions for the change to take effect.' -ForegroundColor DarkGray
+        }
+
+        Show-Summary -Tag $tag -Version $version
+    }
+    finally {
+        if (Test-Path -LiteralPath $tmpDir) {
+            Remove-Item -LiteralPath $tmpDir -Recurse -Force -ErrorAction SilentlyContinue
+        }
+        $ProgressPreference = $script:OldProgressPreference
+    }
+}
+
+try {
+    Invoke-Install
+}
+catch {
+    Write-Err $_.Exception.Message
+    exit 1
+}

--- a/install.sh
+++ b/install.sh
@@ -1,11 +1,11 @@
 #!/bin/sh
-# Installer for sortie — spec-first agent orchestrator.
+# Installer for sortie - spec-first agent orchestrator.
 #
 # Usage:
 #   curl -sSL https://get.sortie-ai.com/install.sh | sh
 #
 # Environment:
-#   SORTIE_VERSION      Pin a specific release tag (e.g. v1.0.0 or 0.0.7).
+#   SORTIE_VERSION      Pin a specific release tag (e.g. 1.11.0 or 0.0.7).
 #   SORTIE_INSTALL_DIR  Override install directory
 #                       (default: /usr/local/bin as root, ~/.local/bin otherwise).
 #   SORTIE_NO_VERIFY    Set to 1 to skip checksum verification.
@@ -164,7 +164,7 @@ main() {
 
     info "Downloading ${_archive}"
     fetch "${_base}/${_archive}" "${TMPDIR_INSTALL}/${_archive}" \
-        || die "download failed — verify release ${_tag} has asset for ${OS}/${ARCH}"
+        || die "download failed - verify release ${_tag} has asset for ${OS}/${ARCH}"
 
     if [ "${SORTIE_NO_VERIFY-}" != "1" ]; then
         fetch "${_base}/checksums.txt" "${TMPDIR_INSTALL}/checksums.txt" \
@@ -215,7 +215,7 @@ main() {
         fi
     fi
 
-    printf '  %bTurns issue tickets into autonomous sessions%b\n\n' "${DIM}" "${RESET}"
+    printf '  %bTurns issue tickets into autonomous sessions.%b\n\n' "${DIM}" "${RESET}"
     printf '\n  %bDocs:%b       https://docs.sortie-ai.com\n' "${BOLD}${YELLOW}" "${RESET}"
     printf '  %bChangelog:%b  https://docs.sortie-ai.com/changelog/#%s\n' "${BOLD}${YELLOW}" "${RESET}" "$_version"
     printf '  %bGitHub:%b     https://github.com/%s\n' "${BOLD}${YELLOW}" "${RESET}" "$REPO"

--- a/scripts/signpath-sign.sh
+++ b/scripts/signpath-sign.sh
@@ -1,0 +1,63 @@
+#!/bin/sh
+# Authenticode-sign a Windows binary with SignPath, in place.
+#
+# Invoked by GoReleaser's post-build hook once per build target. Only Windows
+# .exe artifacts are signed, and only when SignPath credentials are present, so
+# non-Windows targets and credential-less builds (snapshots, pull requests,
+# local builds) pass through untouched. Signing happens before archiving, so the
+# published .zip and checksums.txt cover the signed binary.
+#
+# Inputs (environment):
+#   SIGNPATH_ORG_ID        SignPath organization id        (required to sign)
+#   SIGNPATH_API_TOKEN     SignPath API token              (required to sign)
+#   SIGNPATH_PROJECT_SLUG  SignPath project slug           (default: sortie)
+#   SIGNPATH_POLICY_SLUG   SignPath signing policy slug    (default: release)
+
+set -eu
+
+artifact=${1:?usage: signpath-sign.sh <path-to-binary>}
+
+# Only Authenticode-sign Windows PE executables.
+case "$artifact" in
+    *.exe) ;;
+    *) exit 0 ;;
+esac
+
+# Skip when credentials are absent (snapshot / pull-request / local builds).
+if [ -z "${SIGNPATH_API_TOKEN:-}" ] || [ -z "${SIGNPATH_ORG_ID:-}" ]; then
+    echo "signpath-sign: SIGNPATH_ORG_ID/SIGNPATH_API_TOKEN not set; skipping ${artifact}" >&2
+    exit 0
+fi
+
+if ! command -v pwsh >/dev/null 2>&1; then
+    echo "signpath-sign: pwsh (PowerShell 7+) is required to sign ${artifact}" >&2
+    exit 1
+fi
+
+# Hand off to PowerShell; the SignPath module is PowerShell-only. The artifact
+# path is passed through the environment to avoid quoting ambiguity. The module
+# is expected to be pre-installed in CI (a guarded install covers local runs).
+# The single-quoted block holds PowerShell expressions, not shell ones.
+# shellcheck disable=SC2016
+SIGNPATH_ARTIFACT="$artifact" pwsh -NoProfile -Command '
+    Set-StrictMode -Version Latest
+    $ErrorActionPreference = "Stop"
+
+    if (-not (Get-Module -ListAvailable -Name SignPath)) {
+        Install-Module -Name SignPath -Force -Scope CurrentUser -AcceptLicense
+    }
+    Import-Module SignPath
+
+    $project = if ($env:SIGNPATH_PROJECT_SLUG) { $env:SIGNPATH_PROJECT_SLUG } else { "sortie" }
+    $policy  = if ($env:SIGNPATH_POLICY_SLUG)  { $env:SIGNPATH_POLICY_SLUG }  else { "release" }
+
+    Write-Host "signpath-sign: signing $($env:SIGNPATH_ARTIFACT) (project=$project policy=$policy)"
+    Submit-SigningRequest `
+        -OrganizationId     $env:SIGNPATH_ORG_ID `
+        -ProjectSlug        $project `
+        -SigningPolicySlug  $policy `
+        -InputArtifactPath  $env:SIGNPATH_ARTIFACT `
+        -OutputArtifactPath $env:SIGNPATH_ARTIFACT `
+        -ApiToken           $env:SIGNPATH_API_TOKEN `
+        -WaitForCompletion -Force
+'

--- a/scripts/signpath-sign.sh
+++ b/scripts/signpath-sign.sh
@@ -43,10 +43,13 @@ SIGNPATH_ARTIFACT="$artifact" pwsh -NoProfile -Command '
     Set-StrictMode -Version Latest
     $ErrorActionPreference = "Stop"
 
-    if (-not (Get-Module -ListAvailable -Name SignPath)) {
-        Install-Module -Name SignPath -Force -Scope CurrentUser -AcceptLicense
+    $moduleVersion = "4.3.1"
+    $installed = Get-Module -ListAvailable -Name SignPath |
+        Where-Object { $_.Version.ToString() -eq $moduleVersion }
+    if (-not $installed) {
+        Install-Module -Name SignPath -RequiredVersion $moduleVersion -Force -Scope CurrentUser -AcceptLicense
     }
-    Import-Module SignPath
+    Import-Module SignPath -RequiredVersion $moduleVersion
 
     $project = if ($env:SIGNPATH_PROJECT_SLUG) { $env:SIGNPATH_PROJECT_SLUG } else { "sortie" }
     $policy  = if ($env:SIGNPATH_POLICY_SLUG)  { $env:SIGNPATH_POLICY_SLUG }  else { "release" }


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Feat

**Intent:** Add a native Windows installer (`install.ps1`) so Windows users can install sortie with a single one-liner (`irm 'https://get.sortie-ai.com/install.ps1' | iex`) instead of manually downloading release archives and editing PATH. Authenticode signing of Windows binaries via SignPath is wired into the GoReleaser build so published archives contain signed executables.

**Related Issues:** #541

### 🧭 Reviewer Guide

**Complexity:** Medium

#### Entry Point

Start with `install.ps1`. It is the primary deliverable: a self-contained PowerShell 5.1-compatible installer that mirrors `install.sh` behavior - architecture detection, version resolution, archive download, SHA-256 checksum verification, extraction, install-directory resolution (`%LOCALAPPDATA%\Programs\sortie` by default), User-scope PATH update, and the standard post-install summary. The same three environment variables (`SORTIE_VERSION`, `SORTIE_INSTALL_DIR`, `SORTIE_NO_VERIFY`) are honored.

#### Sensitive Areas

- `scripts/signpath-sign.sh`: Invoked by GoReleaser as a post-build hook to Authenticode-sign Windows `.exe` artifacts before archiving. The script is a no-op when `SIGNPATH_ORG_ID` or `SIGNPATH_API_TOKEN` are absent, so it does not affect snapshots, pull request builds, or local builds. Worth verifying the credential-absent early-exit path.
- `.github/workflows/release.yml`: Two new steps added before GoReleaser runs - a shell step that fails the job with a clear error when SignPath secrets are missing, and a PowerShell step that installs the `SignPath` module at a pinned version (`4.3.1`). `SIGNPATH_ORG_ID` and `SIGNPATH_API_TOKEN` are also forwarded as env vars to the GoReleaser step.
- `.goreleaser.yaml`: A `hooks.post` entry is added under `builds` to invoke `scripts/signpath-sign.sh` for every build target. Non-Windows targets exit 0 immediately; Windows targets that lack credentials also exit 0.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes
- **Migrations/State:** No migrations or state changes