### PR TITLE
feat(jira): add Jira Server/Data Center support via api_version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Jira adapter: Jira Server and Data Center support via a new optional
+  `tracker.api_version` field. The default `"3"` targets Jira Cloud
+  (REST v3) and leaves existing configurations unchanged; `"2"` targets
+  Server / Data Center (REST v2), switching to `/rest/api/2` endpoints,
+  offset-based search pagination, and raw issue and comment bodies in
+  Jira wiki markup (the v3 ADF-to-text flattening does not run on v2, so
+  descriptions reach prompts as markup rather than plain text). On v2 the
+  `api_key` shape selects authentication: a colon-free value is sent as a
+  Personal Access Token (`Authorization: Bearer`), while a `user:password`
+  value uses HTTP Basic; Cloud v3 continues to use Basic `email:token`.
+  Comment creation posts a raw `{"body": ...}` payload on v2 instead of an
+  ADF document. A construction-time guard rejects inconsistent
+  configuration at startup: a Cloud (`*.atlassian.net`) endpoint combined
+  with `api_version: 2`, or an endpoint that is not a URL with a scheme and
+  host; it also warns when a self-hosted endpoint is left on the default
+  v3. A bare YAML integer (`api_version: 2`) is coerced rather than treated
+  as absent, though `sortie validate` still advises quoting it.
+  ([#549](https://github.com/sortie-ai/sortie/issues/549))
+
 ## [1.11.0] - 2026-05-29
 
 ### Added

--- a/cmd/sortie/resolve.go
+++ b/cmd/sortie/resolve.go
@@ -35,6 +35,7 @@ func trackerConfigMap(tc config.TrackerConfig) map[string]any {
 		"query_filter":      tc.QueryFilter,
 		"handoff_state":     tc.HandoffState,
 		"in_progress_state": tc.InProgressState,
+		"api_version":       tc.APIVersion,
 		"comments": map[string]any{
 			"on_dispatch":   tc.Comments.OnDispatch,
 			"on_completion": tc.Comments.OnCompletion,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1059,6 +1059,9 @@ This section is intentionally redundant so a coding agent can implement the conf
 - `tracker.in_progress_state`: string, optional, default absent; target state for
   dispatch-time transition at the start of each worker attempt; must be in `active_states`,
   must not collide with `terminal_states` or `handoff_state`; supports `$VAR`
+- `tracker.api_version`: string (`"2"` or `"3"`), optional, default `"3"`; selects
+  Jira REST API v3 (Cloud) or v2 (Server / Data Center); quote the value to avoid
+  a validation advisory (`api_version: "2"`); supports `$VAR`
 - `polling.interval_ms`: integer, default `30000`
 - `workspace.root`: path, default `<system-temp>/sortie_workspaces`
 - `worker.ssh_hosts` (extension): list of SSH host strings, optional; when omitted, work runs

--- a/docs/jira-adapter-notes.md
+++ b/docs/jira-adapter-notes.md
@@ -62,8 +62,9 @@ Encoding `email:token` in a single field follows curl convention (`-u email:toke
 adding Jira-specific config keys to the core schema. The value may be provided via environment
 variable indirection (e.g. `$JIRA_API_KEY`) if the config layer supports it.
 
-**Construction-time host/version guard:** A `.atlassian.net` endpoint combined with
-`api_version: "2"` is rejected at startup (`ErrTrackerPayload`). A non-`.atlassian.net`
+**Construction-time host/version guard:** An `endpoint` that is not a URL with a scheme
+and host is rejected at startup (`ErrTrackerPayload`). A `.atlassian.net` endpoint combined
+with `api_version: "2"` is rejected at startup (`ErrTrackerPayload`). A non-`.atlassian.net`
 endpoint combined with `api_version: "3"` emits a warning and proceeds, except for a
 loopback IP or `localhost` endpoint, which is a test or local-dev target and does not
 warn.

--- a/docs/jira-adapter-notes.md
+++ b/docs/jira-adapter-notes.md
@@ -36,19 +36,35 @@ PATs act as a secure alternative to Basic Auth passwords, behaving like bearer t
 - Header: `Authorization: Bearer <your_pat>`
 - Available in Jira Data Center and Server.
 
-Relevant only if Sortie adds Data Center support in the future.
+Sortie supports PAT authentication when `tracker.api_version: "2"` is set. The adapter
+selects the auth mode from the `tracker.api_key` value using a presence-of-colon rule:
+
+- `api_key` contains a colon (`user:password`): Basic auth, `Authorization: Basic
+  base64(user:password)`. Both sides of the colon must be non-empty; an empty user
+  (`":password"`) or empty secret (`"user:"`) is rejected at construction time with
+  `ErrTrackerAuth`.
+- `api_key` has no colon (a colon-free token string): Bearer auth, `Authorization:
+  Bearer <token>`. This is the PAT path for Server and Data Center.
+
+Under `api_version: "3"` (Cloud), a colon-free `api_key` is always rejected because
+Cloud requires `email:token` format.
 
 ### Config mapping
 
-| Config field       | Value                                          |
-| ------------------ | ---------------------------------------------- |
-| `tracker.endpoint` | `https://<site>.atlassian.net` (no trailing /) |
-| `tracker.api_key`  | `email:api_token`; adapter splits on first `:` |
-| `tracker.project`  | Jira project key, e.g. `SORT`                  |
+| Config field            | Cloud (v3)                                           | Server / DC (v2)                                   |
+| ----------------------- | ---------------------------------------------------- | -------------------------------------------------- |
+| `tracker.endpoint`      | `https://<site>.atlassian.net` (no trailing /)       | `https://jira.internal.example.com` (no trailing /) |
+| `tracker.api_key`       | `email:api_token`; splits on first `:`               | `user:password` (Basic) or PAT token (Bearer)      |
+| `tracker.project`       | Jira project key, e.g. `SORT`                        | Same                                               |
+| `tracker.api_version`   | `"3"` (default, may be omitted)                      | `"2"` (required for Server / DC)                   |
 
 Encoding `email:token` in a single field follows curl convention (`-u email:token`) and avoids
 adding Jira-specific config keys to the core schema. The value may be provided via environment
 variable indirection (e.g. `$JIRA_API_KEY`) if the config layer supports it.
+
+**Construction-time host/version guard:** A `.atlassian.net` endpoint combined with
+`api_version: "2"` is rejected at startup (`ErrTrackerPayload`). A non-`.atlassian.net`
+endpoint combined with `api_version: "3"` emits a warning and proceeds.
 
 **CAPTCHA caveat:** After several failed logins Jira triggers CAPTCHA and returns
 `X-Seraph-LoginReason: AUTHENTICATION_DENIED`. The adapter should detect this header and
@@ -58,7 +74,34 @@ return `tracker_auth_error`.
 
 ## Endpoints
 
-Each `TrackerAdapter` operation maps to a Jira REST v3 endpoint.
+Each `TrackerAdapter` operation maps to a Jira REST endpoint. The base path is
+`/rest/api/3` when `api_version` is `"3"` (default) and `/rest/api/2` when
+`api_version` is `"2"`. The table below shows the v3 paths; substitute `/rest/api/2`
+for v2. The one exception is the search resource: v3 uses `/rest/api/3/search/jql`
+whereas v2 uses `/rest/api/2/search` (no `/jql` segment).
+
+### v2 body format
+
+On v2, `description` and comment `body` fields are returned as a **raw string in Jira
+wiki markup** (for example `h2. Heading`, `*bold*`, `{code}...{code}`). The adapter
+reads this string verbatim; it does not flatten or translate markup tokens. Downstream
+consumers (prompt templates, agents) therefore see wiki markup rather than clean prose
+when `api_version: "2"` is set. The v3 path returns ADF, which the adapter flattens to
+text before storing in `domain.Issue.Description` and `domain.Comment.Body`.
+
+Comment creation on v2 sends a raw-string body:
+
+```json
+{"body": "<text>"}
+```
+
+Comment creation on v3 sends an ADF document (see ADF flattening section below).
+
+### v2 search pagination
+
+The v2 search endpoint (`GET /rest/api/2/search`) uses offset-based pagination
+(`startAt` / `total`). The adapter loops until `startAt + page_count >= total` or the
+page is empty. Page size is 50 for both versions.
 
 ### 1. `FetchCandidateIssues` → `GET /rest/api/3/search/jql`
 
@@ -154,7 +197,7 @@ operations.
 | `ID`                 | `id` (string)                     | Numeric ID as string                    |
 | `Identifier`         | `key` (string)                    | e.g. `"PROJ-123"`                       |
 | `Title`              | `fields.summary`                  |                                         |
-| `Description`        | `fields.description` (ADF)        | Flatten ADF → plain text                |
+| `Description`        | `fields.description`              | v3: ADF flattened to text. v2: raw string (wiki markup). |
 | `Priority`           | `fields.priority.id` (string)     | e.g. `"3"` → int 3; use `id` not `name` |
 | `State`              | `fields.status.name`              | Preserve original casing                |
 | `BranchName`         | —                                 | See dev-status note below               |
@@ -163,7 +206,7 @@ operations.
 | `Assignee`           | `fields.assignee.displayName`     | Nil → empty string                      |
 | `IssueType`          | `fields.issuetype.name`           |                                         |
 | `Parent`             | `fields.parent.id`, `.parent.key` | Nil when absent                         |
-| `Comments`           | Separate endpoint                 | ADF → plain text                        |
+| `Comments`           | Separate endpoint                 | v3: ADF flattened to text. v2: raw string (wiki markup). |
 | `BlockedBy`          | `fields.issuelinks[]` (filtered)  | See blocker extraction below            |
 | `CreatedAt`          | `fields.created` (ISO-8601)       |                                         |
 | `UpdatedAt`          | `fields.updated` (ISO-8601)       |                                         |
@@ -223,16 +266,16 @@ Jira v3 returns `description` and comment `body` as ADF JSON:
 The adapter must recursively walk the tree and extract all `text` node values, joining
 paragraphs with newlines. Without this, `Description` and comment `Body` would be raw JSON.
 
-**v2 API alternative:** The v2 API (`/rest/api/2/...`) returns `description` and comment
-`body` as rendered HTML or plain text instead of ADF. If ADF flattening proves too complex,
-the adapter could use v2 endpoints for these fields. However, v3 is the current API and
-ADF flattening gives the adapter full control over text extraction.
+**v2 bodies are not ADF:** When `api_version: "2"`, `description` and comment `body` are
+JSON strings containing Jira wiki markup, not ADF objects. The adapter reads them verbatim
+with a JSON string unquote, not ADF flattening. Rendered HTML (`expand=renderedBody`) is
+not requested and not in scope.
 
 ---
 
 ## Pagination
 
-### Search endpoint (`GET /rest/api/3/search/jql`), cursor-based
+### v3 search endpoint (`GET /rest/api/3/search/jql`), cursor-based
 
 - First request: omit `nextPageToken`, set `maxResults` (recommend `50`).
 - Subsequent requests: pass the `nextPageToken` from the previous response.
@@ -243,6 +286,17 @@ ADF flattening gives the adapter full control over text extraction.
 
 `POST /rest/api/3/search/jql` uses offset-based (`startAt`/`total`) pagination but is
 deprecated for new integrations. Prefer `GET` with cursor-based pagination.
+
+### v2 search endpoint (`GET /rest/api/2/search`), offset-based
+
+The v2 endpoint uses offset-based pagination. The adapter maintains a `startAt` counter
+and advances it by the number of results returned per page.
+
+- First request: `startAt=0`, `maxResults=50`.
+- Subsequent requests: `startAt += len(page.issues)`.
+- Stop when `len(page.issues) == 0` or `startAt + len(page.issues) >= total`.
+
+This mirrors the comment pagination loop already used by both v2 and v3.
 
 ### Comment endpoint, offset-based
 

--- a/docs/jira-adapter-notes.md
+++ b/docs/jira-adapter-notes.md
@@ -64,7 +64,9 @@ variable indirection (e.g. `$JIRA_API_KEY`) if the config layer supports it.
 
 **Construction-time host/version guard:** A `.atlassian.net` endpoint combined with
 `api_version: "2"` is rejected at startup (`ErrTrackerPayload`). A non-`.atlassian.net`
-endpoint combined with `api_version: "3"` emits a warning and proceeds.
+endpoint combined with `api_version: "3"` emits a warning and proceeds, except for a
+loopback IP or `localhost` endpoint, which is a test or local-dev target and does not
+warn.
 
 **CAPTCHA caveat:** After several failed logins Jira triggers CAPTCHA and returns
 `X-Seraph-LoginReason: AUTHENTICATION_DENIED`. The adapter should detect this header and

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -89,6 +89,7 @@ type TrackerConfig struct {
 	QueryFilter     string
 	HandoffState    string
 	InProgressState string
+	APIVersion      string
 	Comments        TrackerCommentsConfig
 }
 
@@ -351,6 +352,11 @@ func buildTrackerConfig(m map[string]any, envKeys map[string]bool) TrackerConfig
 		inProgressState = resolveEnvRef(inProgressState)
 	}
 
+	apiVersion := extractString(m, "api_version")
+	if !envKeys["tracker.api_version"] {
+		apiVersion = resolveEnvRef(apiVersion)
+	}
+
 	return TrackerConfig{
 		Kind:            extractString(m, "kind"),
 		Endpoint:        endpoint,
@@ -361,6 +367,7 @@ func buildTrackerConfig(m map[string]any, envKeys map[string]bool) TrackerConfig
 		QueryFilter:     queryFilter,
 		HandoffState:    handoffState,
 		InProgressState: inProgressState,
+		APIVersion:      apiVersion,
 		Comments: TrackerCommentsConfig{
 			OnDispatch:   coerceBool(commentsMap, "on_dispatch"),
 			OnCompletion: coerceBool(commentsMap, "on_completion"),

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -353,6 +353,15 @@ func buildTrackerConfig(m map[string]any, envKeys map[string]bool) TrackerConfig
 	}
 
 	apiVersion := extractString(m, "api_version")
+	if apiVersion == "" {
+		// A bare YAML integer (api_version: 2) is not a string, so
+		// extractString yields ""; coerce a whole-number value to its
+		// decimal form so a Server/DC config written as api_version: 2 is
+		// not silently treated as absent and defaulted to v3.
+		if n, err := coerceInt(mapVal(m, "api_version")); err == nil {
+			apiVersion = strconv.Itoa(n)
+		}
+	}
 	if !envKeys["tracker.api_version"] {
 		apiVersion = resolveEnvRef(apiVersion)
 	}

--- a/internal/config/config_api_version_test.go
+++ b/internal/config/config_api_version_test.go
@@ -18,12 +18,18 @@ func TestBuildTrackerConfig_APIVersion(t *testing.T) {
 		assertStringEqual(t, "TrackerConfig.APIVersion", "", tc.APIVersion)
 	})
 
-	t.Run("non-string yields empty", func(t *testing.T) {
+	t.Run("bare integer coerced to string", func(t *testing.T) {
 		t.Parallel()
-		// extractString flattens a non-string to ""; the adapter applies
-		// the "3" default for an empty value.
+		// A bare YAML integer (api_version: 2) is coerced to its decimal
+		// string form so a Server/DC config is not silently defaulted to v3.
 		tc := buildTrackerConfig(map[string]any{"api_version": 2}, nil)
-		assertStringEqual(t, "TrackerConfig.APIVersion", "", tc.APIVersion)
+		assertStringEqual(t, "TrackerConfig.APIVersion", "2", tc.APIVersion)
+	})
+
+	t.Run("bare whole float coerced to string", func(t *testing.T) {
+		t.Parallel()
+		tc := buildTrackerConfig(map[string]any{"api_version": float64(2)}, nil)
+		assertStringEqual(t, "TrackerConfig.APIVersion", "2", tc.APIVersion)
 	})
 
 	t.Run("VAR indirection resolved", func(t *testing.T) {
@@ -70,16 +76,16 @@ func TestNewServiceConfig_APIVersion(t *testing.T) {
 		assertStringEqual(t, "Tracker.APIVersion", "2", cfg.Tracker.APIVersion)
 	})
 
-	t.Run("bare YAML integer loads without fatal error", func(t *testing.T) {
+	t.Run("bare YAML integer coerced and loads", func(t *testing.T) {
 		t.Parallel()
-		// A bare integer is accepted (flattened to "" here; the adapter
-		// applies its own coercion). Loading must not fail.
+		// A bare integer (api_version: 2) is coerced to "2" so a Server/DC
+		// config is not silently defaulted to v3. Loading must not fail.
 		cfg, err := NewServiceConfig(map[string]any{
 			"tracker": map[string]any{"kind": "jira", "api_version": 2},
 		})
 		if err != nil {
 			t.Fatalf("NewServiceConfig with bare integer api_version: %v", err)
 		}
-		assertStringEqual(t, "Tracker.APIVersion", "", cfg.Tracker.APIVersion)
+		assertStringEqual(t, "Tracker.APIVersion", "2", cfg.Tracker.APIVersion)
 	})
 }

--- a/internal/config/config_api_version_test.go
+++ b/internal/config/config_api_version_test.go
@@ -1,0 +1,85 @@
+package config
+
+import "testing"
+
+// TestBuildTrackerConfig_APIVersion verifies the tracker config builder
+// carries api_version through and resolves $VAR indirection, mirroring
+// the handling of the other optional tracker string fields.
+func TestBuildTrackerConfig_APIVersion(t *testing.T) {
+	t.Run("string value", func(t *testing.T) {
+		t.Parallel()
+		tc := buildTrackerConfig(map[string]any{"api_version": "2"}, nil)
+		assertStringEqual(t, "TrackerConfig.APIVersion", "2", tc.APIVersion)
+	})
+
+	t.Run("absent yields empty", func(t *testing.T) {
+		t.Parallel()
+		tc := buildTrackerConfig(map[string]any{}, nil)
+		assertStringEqual(t, "TrackerConfig.APIVersion", "", tc.APIVersion)
+	})
+
+	t.Run("non-string yields empty", func(t *testing.T) {
+		t.Parallel()
+		// extractString flattens a non-string to ""; the adapter applies
+		// the "3" default for an empty value.
+		tc := buildTrackerConfig(map[string]any{"api_version": 2}, nil)
+		assertStringEqual(t, "TrackerConfig.APIVersion", "", tc.APIVersion)
+	})
+
+	t.Run("VAR indirection resolved", func(t *testing.T) {
+		t.Setenv("TEST_API_VERSION", "2")
+		tc := buildTrackerConfig(map[string]any{"api_version": "$TEST_API_VERSION"}, nil)
+		assertStringEqual(t, "TrackerConfig.APIVersion", "2", tc.APIVersion)
+	})
+
+	t.Run("VAR indirection skipped when env-override guard set", func(t *testing.T) {
+		t.Setenv("TEST_API_VERSION", "2")
+		// When the SORTIE_* override path already populated the value, the
+		// $VAR guard must leave the literal untouched, exactly as the other
+		// tracker string fields behave.
+		tc := buildTrackerConfig(
+			map[string]any{"api_version": "$TEST_API_VERSION"},
+			map[string]bool{"tracker.api_version": true},
+		)
+		assertStringEqual(t, "TrackerConfig.APIVersion", "$TEST_API_VERSION", tc.APIVersion)
+	})
+}
+
+// TestNewServiceConfig_APIVersion exercises the same resolution through
+// the public entry point so the value reaches TrackerConfig end to end.
+func TestNewServiceConfig_APIVersion(t *testing.T) {
+	t.Run("string value loads", func(t *testing.T) {
+		t.Parallel()
+		cfg, err := NewServiceConfig(map[string]any{
+			"tracker": map[string]any{"kind": "jira", "api_version": "2"},
+		})
+		if err != nil {
+			t.Fatalf("NewServiceConfig: %v", err)
+		}
+		assertStringEqual(t, "Tracker.APIVersion", "2", cfg.Tracker.APIVersion)
+	})
+
+	t.Run("env var resolved", func(t *testing.T) {
+		t.Setenv("TEST_SVC_API_VERSION", "2")
+		cfg, err := NewServiceConfig(map[string]any{
+			"tracker": map[string]any{"kind": "jira", "api_version": "$TEST_SVC_API_VERSION"},
+		})
+		if err != nil {
+			t.Fatalf("NewServiceConfig: %v", err)
+		}
+		assertStringEqual(t, "Tracker.APIVersion", "2", cfg.Tracker.APIVersion)
+	})
+
+	t.Run("bare YAML integer loads without fatal error", func(t *testing.T) {
+		t.Parallel()
+		// A bare integer is accepted (flattened to "" here; the adapter
+		// applies its own coercion). Loading must not fail.
+		cfg, err := NewServiceConfig(map[string]any{
+			"tracker": map[string]any{"kind": "jira", "api_version": 2},
+		})
+		if err != nil {
+			t.Fatalf("NewServiceConfig with bare integer api_version: %v", err)
+		}
+		assertStringEqual(t, "Tracker.APIVersion", "", cfg.Tracker.APIVersion)
+	})
+}

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -51,6 +51,7 @@ var knownFieldsRegistry = map[string]SectionSchema{
 			{Name: "query_filter", Type: FieldString},
 			{Name: "handoff_state", Type: FieldString},
 			{Name: "in_progress_state", Type: FieldString},
+			{Name: "api_version", Type: FieldString},
 			{Name: "comments", Type: FieldMap, Nested: []FieldDef{
 				{Name: "on_dispatch", Type: FieldBool},
 				{Name: "on_completion", Type: FieldBool},

--- a/internal/config/schema_api_version_test.go
+++ b/internal/config/schema_api_version_test.go
@@ -1,0 +1,73 @@
+package config
+
+import "testing"
+
+// TestValidateFrontMatter_APIVersion verifies the schema recognizes
+// tracker.api_version as a known FieldString: a quoted string draws no
+// warning, while a bare YAML integer draws a single non-fatal
+// type_mismatch advisory.
+func TestValidateFrontMatter_APIVersion(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		raw        map[string]any
+		wantCount  int
+		wantChecks []string
+		wantFields []string
+	}{
+		{
+			name: "quoted string value is recognized, no warning",
+			raw: map[string]any{
+				"tracker": map[string]any{"kind": "jira", "api_version": "2"},
+			},
+			wantCount: 0,
+		},
+		{
+			name: "bare integer draws a single type_mismatch advisory",
+			raw: map[string]any{
+				"tracker": map[string]any{"kind": "jira", "api_version": 2},
+			},
+			wantCount:  1,
+			wantChecks: []string{"type_mismatch"},
+			wantFields: []string{"tracker.api_version"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := ValidateFrontMatter(tt.raw, ServiceConfig{Tracker: TrackerConfig{Kind: "jira"}})
+
+			if len(got) != tt.wantCount {
+				t.Fatalf("ValidateFrontMatter() returned %d warnings, want %d\nwarnings: %+v", len(got), tt.wantCount, got)
+			}
+			for i, wantCheck := range tt.wantChecks {
+				if got[i].Check != wantCheck {
+					t.Errorf("warnings[%d].Check = %q, want %q", i, got[i].Check, wantCheck)
+				}
+			}
+			for i, wantField := range tt.wantFields {
+				if got[i].Field != wantField {
+					t.Errorf("warnings[%d].Field = %q, want %q", i, got[i].Field, wantField)
+				}
+			}
+		})
+	}
+}
+
+// TestValidateFrontMatter_APIVersionNotUnknownKey is a focused guard:
+// api_version must never surface as an unknown_sub_key.
+func TestValidateFrontMatter_APIVersionNotUnknownKey(t *testing.T) {
+	t.Parallel()
+
+	raw := map[string]any{
+		"tracker": map[string]any{"kind": "jira", "api_version": "3"},
+	}
+	for _, w := range ValidateFrontMatter(raw, ServiceConfig{Tracker: TrackerConfig{Kind: "jira"}}) {
+		if w.Check == "unknown_sub_key" && w.Field == "tracker.api_version" {
+			t.Errorf("api_version reported as unknown_sub_key: %+v", w)
+		}
+	}
+}

--- a/internal/tracker/jira/client.go
+++ b/internal/tracker/jira/client.go
@@ -1,7 +1,6 @@
 package jira
 
 import (
-	"encoding/base64"
 	"fmt"
 	"io"
 	"net/http"
@@ -12,10 +11,11 @@ import (
 	"github.com/sortie-ai/sortie/internal/httpkit"
 )
 
-// newJiraClient constructs the shared Jira transport.
-func newJiraClient(baseURL, email, token, userAgent string) *httpkit.Client {
+// newJiraClient constructs the shared Jira transport. The authHeader is
+// the fully-formed Authorization value (Basic or Bearer) set on every
+// request.
+func newJiraClient(baseURL, authHeader, userAgent string) *httpkit.Client {
 	trimmedBaseURL := strings.TrimRight(baseURL, "/")
-	authHeader := "Basic " + base64.StdEncoding.EncodeToString([]byte(email+":"+token))
 
 	return httpkit.NewClient(httpkit.ClientOptions{
 		BaseURL: trimmedBaseURL,

--- a/internal/tracker/jira/client_test.go
+++ b/internal/tracker/jira/client_test.go
@@ -2,6 +2,7 @@ package jira
 
 import (
 	"context"
+	"encoding/base64"
 	"errors"
 	"io"
 	"net/http"
@@ -16,7 +17,8 @@ import (
 
 func newTestJiraClient(t *testing.T, baseURL, email, token string) *httpkit.Client {
 	t.Helper()
-	return newJiraClient(baseURL, email, token, "sortie/test")
+	authHeader := "Basic " + base64.StdEncoding.EncodeToString([]byte(email+":"+token))
+	return newJiraClient(baseURL, authHeader, "sortie/test")
 }
 
 func assertClientTrackerErrorKind(t *testing.T, err error, want domain.TrackerErrorKind) {

--- a/internal/tracker/jira/jira.go
+++ b/internal/tracker/jira/jira.go
@@ -1,17 +1,23 @@
-// Package jira implements [domain.TrackerAdapter] for Atlassian Jira
-// Cloud REST API v3. Issues are fetched via JQL search, normalized to
-// domain types with ADF descriptions flattened to plain text, labels
-// lowercased, integer-only priority (non-integers become nil), and
-// blocker refs extracted from inward "Blocks" issuelinks. Registered
-// under kind "jira" via an init function.
+// Package jira implements [domain.TrackerAdapter] for Atlassian Jira.
+// It targets the Cloud REST API v3 by default and the Server / Data
+// Center REST API v2 when api_version is "2". Issues are fetched via
+// JQL search and normalized to domain types: labels lowercased,
+// integer-only priority (non-integers become nil), and blocker refs
+// extracted from inward "Blocks" issuelinks. Descriptions and comment
+// bodies are flattened from ADF on v3 and preserved as raw wiki markup
+// on v2. Registered under kind "jira" via an init function.
 package jira
 
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"log/slog"
+	"math"
 	"net/url"
+	"strconv"
 	"strings"
 
 	"github.com/sortie-ai/sortie/internal/domain"
@@ -48,21 +54,32 @@ const maxCommentResults = 50
 // to keep GET URLs within safe URI length limits.
 const batchSize = 40
 
-// JiraAdapter implements [domain.TrackerAdapter] against Jira Cloud
-// REST API v3. Safe for concurrent use.
+// JiraAdapter implements [domain.TrackerAdapter] against Atlassian
+// Jira. The selected API version and the base path derived from it are
+// immutable after construction. Safe for concurrent use.
 type JiraAdapter struct {
 	client       *httpkit.Client
 	project      string
 	activeStates []string
 	endpoint     string
 	queryFilter  string
+	apiVersion   string
+	basePath     string
 	metrics      domain.Metrics // nil-safe: check before calling
 }
 
 // NewJiraAdapter creates a [JiraAdapter] from adapter configuration.
-// Required config keys: "endpoint", "api_key" (email:token format),
-// "project". Optional: "active_states" (defaults to Backlog, Selected
-// for Development, In Progress), "query_filter" (raw JQL fragment).
+// Required config keys: "endpoint", "api_key", "project". Optional:
+// "active_states" (defaults to Backlog, Selected for Development, In
+// Progress), "query_filter" (raw JQL fragment), "api_version" ("2" or
+// "3", default "3").
+//
+// On version "3" the api_key must be email:token and authenticates
+// with Basic. On version "2" a colon-free api_key is a Personal Access
+// Token and authenticates with Bearer, while a user:password api_key
+// authenticates with Basic. An api_version other than "2" or "3", a
+// malformed api_key, or a Cloud endpoint combined with api_version "2"
+// returns a [*domain.TrackerError] and blocks construction.
 func NewJiraAdapter(config map[string]any) (domain.TrackerAdapter, error) {
 	endpoint, _ := config["endpoint"].(string)
 	if endpoint == "" {
@@ -79,6 +96,15 @@ func NewJiraAdapter(config map[string]any) (domain.TrackerAdapter, error) {
 		}
 	}
 
+	apiVersion, err := normalizeAPIVersion(config["api_version"])
+	if err != nil {
+		return nil, err
+	}
+
+	if err := checkHostVersion(endpoint, apiVersion); err != nil {
+		return nil, err
+	}
+
 	apiKey, _ := config["api_key"].(string)
 	if apiKey == "" {
 		return nil, &domain.TrackerError{
@@ -87,15 +113,10 @@ func NewJiraAdapter(config map[string]any) (domain.TrackerAdapter, error) {
 		}
 	}
 
-	idx := strings.Index(apiKey, ":")
-	if idx < 1 || idx == len(apiKey)-1 {
-		return nil, &domain.TrackerError{
-			Kind:    domain.ErrTrackerAuth,
-			Message: "api_key must be in email:token format",
-		}
+	authHeader, err := resolveAuth(apiVersion, apiKey)
+	if err != nil {
+		return nil, err
 	}
-	email := apiKey[:idx]
-	token := apiKey[idx+1:]
 
 	project, _ := config["project"].(string)
 	if project == "" {
@@ -118,12 +139,120 @@ func NewJiraAdapter(config map[string]any) (domain.TrackerAdapter, error) {
 	}
 
 	return &JiraAdapter{
-		client:       newJiraClient(endpoint, email, token, userAgent),
+		client:       newJiraClient(endpoint, authHeader, userAgent),
 		project:      project,
 		activeStates: activeStates,
 		endpoint:     endpoint,
 		queryFilter:  queryFilter,
+		apiVersion:   apiVersion,
+		basePath:     basePath(apiVersion),
 	}, nil
+}
+
+// normalizeAPIVersion coerces a raw config value to a validated Jira
+// REST API version. It accepts a string, an int, or a whole-number
+// float64, trims surrounding whitespace, and resolves an absent or
+// empty value to "3". A value other than "2" or "3" returns a
+// [*domain.TrackerError] of kind [domain.ErrTrackerPayload].
+func normalizeAPIVersion(raw any) (string, error) {
+	var v string
+	switch n := raw.(type) {
+	case nil:
+		v = ""
+	case string:
+		v = n
+	case int:
+		v = strconv.Itoa(n)
+	case float64:
+		if n != math.Trunc(n) {
+			return "", &domain.TrackerError{
+				Kind:    domain.ErrTrackerPayload,
+				Message: fmt.Sprintf(`tracker.api_version must be "2" or "3", got %v`, raw),
+			}
+		}
+		v = strconv.Itoa(int(n))
+	default:
+		return "", &domain.TrackerError{
+			Kind:    domain.ErrTrackerPayload,
+			Message: fmt.Sprintf(`tracker.api_version must be "2" or "3", got %v`, raw),
+		}
+	}
+
+	v = strings.TrimSpace(v)
+	switch v {
+	case "":
+		return "3", nil
+	case "2", "3":
+		return v, nil
+	default:
+		return "", &domain.TrackerError{
+			Kind:    domain.ErrTrackerPayload,
+			Message: fmt.Sprintf(`tracker.api_version must be "2" or "3", got %q`, v),
+		}
+	}
+}
+
+// basePath returns the Jira REST API base path for the given version.
+func basePath(apiVersion string) string {
+	return "/rest/api/" + apiVersion
+}
+
+// resolveAuth selects the Authorization header value from the API
+// version and api_key. A key containing a colon is parsed as
+// user:secret and produces a Basic header on both versions; an empty
+// user or empty secret returns [domain.ErrTrackerAuth]. A colon-free
+// key produces a Bearer header on version "2" and returns
+// [domain.ErrTrackerAuth] on version "3". The api_key is never empty:
+// the caller rejects an empty value earlier.
+func resolveAuth(apiVersion, apiKey string) (string, error) {
+	idx := strings.Index(apiKey, ":")
+	if idx >= 0 {
+		if idx < 1 || idx == len(apiKey)-1 {
+			return "", &domain.TrackerError{
+				Kind:    domain.ErrTrackerAuth,
+				Message: "api_key must be in email:token format",
+			}
+		}
+		return "Basic " + base64.StdEncoding.EncodeToString([]byte(apiKey)), nil
+	}
+
+	if apiVersion == "2" {
+		return "Bearer " + apiKey, nil
+	}
+
+	return "", &domain.TrackerError{
+		Kind:    domain.ErrTrackerAuth,
+		Message: "api_key must be in email:token format",
+	}
+}
+
+// checkHostVersion runs a static consistency check between the endpoint
+// host and the API version. It performs no network I/O. A Cloud host
+// (one ending in .atlassian.net) combined with version "2" returns a
+// [*domain.TrackerError] of kind [domain.ErrTrackerPayload]. A
+// non-Cloud host combined with version "3" logs a warning and returns
+// nil so construction proceeds. All other combinations return nil.
+func checkHostVersion(endpoint, apiVersion string) error {
+	parsed, err := url.Parse(endpoint)
+	if err != nil {
+		return nil
+	}
+	host := strings.ToLower(parsed.Hostname())
+	isCloud := strings.HasSuffix(host, ".atlassian.net")
+
+	if isCloud && apiVersion == "2" {
+		return &domain.TrackerError{
+			Kind:    domain.ErrTrackerPayload,
+			Message: fmt.Sprintf("tracker.api_version 2 targets Jira Server / Data Center; endpoint %s is Jira Cloud, which requires api_version 3", host),
+		}
+	}
+
+	if !isCloud && apiVersion == "3" {
+		slog.Warn("tracker.api_version 3 against non-cloud endpoint will return 404",
+			slog.String("host", host))
+	}
+
+	return nil
 }
 
 // FetchCandidateIssues returns issues in configured active states
@@ -146,7 +275,7 @@ func (a *JiraAdapter) FetchIssueByID(ctx context.Context, issueID string) (domai
 	var issue domain.Issue
 	err := trackermetrics.Track(a.metrics, "fetch_issue", func() error {
 		params := url.Values{"fields": {searchFields}}
-		body, _, err := a.client.Get(ctx, "/rest/api/3/issue/"+url.PathEscape(issueID), params)
+		body, _, err := a.client.Get(ctx, a.basePath+"/issue/"+url.PathEscape(issueID), params)
 		if err != nil {
 			if domain.IsNotFound(err) {
 				return &domain.TrackerError{
@@ -166,7 +295,7 @@ func (a *JiraAdapter) FetchIssueByID(ctx context.Context, issueID string) (domai
 			}
 		}
 
-		fetchedIssue := normalizeSearchIssue(a.endpoint, ji)
+		fetchedIssue := normalizeSearchIssue(a.apiVersion, a.endpoint, ji)
 
 		comments, err := a.fetchComments(ctx, issueID)
 		if err != nil {
@@ -290,7 +419,7 @@ func (a *JiraAdapter) FetchIssueComments(ctx context.Context, issueID string) ([
 // name (case-insensitive, first match), then executed via POST.
 func (a *JiraAdapter) TransitionIssue(ctx context.Context, issueID string, targetState string) error {
 	return trackermetrics.Track(a.metrics, "transition", func() error {
-		path := "/rest/api/3/issue/" + url.PathEscape(issueID) + "/transitions"
+		path := a.basePath + "/issue/" + url.PathEscape(issueID) + "/transitions"
 
 		body, _, err := a.client.Get(ctx, path, nil)
 		if err != nil {
@@ -343,14 +472,14 @@ func (a *JiraAdapter) TransitionIssue(ctx context.Context, issueID string, targe
 	})
 }
 
-// CommentIssue posts a plain-text comment on the specified Jira issue.
-// The text is split by newlines into ADF paragraph nodes before
-// submission to the Jira v3 REST API.
+// CommentIssue posts a comment on the specified Jira issue. On version
+// "3" the text is split by newlines into ADF paragraph nodes. On
+// version "2" the text is sent verbatim as a raw wiki-markup body.
 func (a *JiraAdapter) CommentIssue(ctx context.Context, issueID string, text string) error {
 	return trackermetrics.Track(a.metrics, "comment", func() error {
-		path := "/rest/api/3/issue/" + url.PathEscape(issueID) + "/comment"
+		path := a.basePath + "/issue/" + url.PathEscape(issueID) + "/comment"
 
-		body := buildADFComment(text)
+		body := commentPayload(a.apiVersion, text)
 		payload, err := json.Marshal(body)
 		if err != nil {
 			return &domain.TrackerError{
@@ -363,6 +492,16 @@ func (a *JiraAdapter) CommentIssue(ctx context.Context, issueID string, text str
 		_, err = a.client.Send(ctx, "POST", path, bytes.NewReader(payload))
 		return err
 	})
+}
+
+// commentPayload builds the comment-create request body for the given
+// API version. On version "2" it returns a raw wiki-markup string body;
+// on any other version it returns an ADF document.
+func commentPayload(apiVersion, text string) any {
+	if apiVersion == "2" {
+		return map[string]any{"body": text}
+	}
+	return buildADFComment(text)
 }
 
 // SetMetrics configures the metrics recorder for tracker API call
@@ -378,7 +517,7 @@ func (a *JiraAdapter) SetMetrics(m domain.Metrics) {
 // Returns an error if the request fails; the orchestrator treats AddLabel
 // errors as non-fatal.
 func (a *JiraAdapter) AddLabel(ctx context.Context, issueID string, label string) error {
-	path := "/rest/api/3/issue/" + url.PathEscape(issueID)
+	path := a.basePath + "/issue/" + url.PathEscape(issueID)
 
 	payload, err := json.Marshal(map[string]any{
 		"update": map[string]any{
@@ -411,16 +550,21 @@ func (a *JiraAdapter) incTrackerRequest(operation, result string) {
 	}
 }
 
-// paginatedSearch executes a cursor-based paginated JQL search and
-// returns all normalized issues. Comments are set to nil.
+// paginatedSearch executes a paginated JQL search and returns all
+// normalized issues. Comments are set to nil. Version "2" uses an
+// offset loop; any other version uses cursor pagination.
 func (a *JiraAdapter) paginatedSearch(ctx context.Context, jql, fields string) ([]domain.Issue, error) {
+	if a.apiVersion == "2" {
+		return a.paginatedSearchV2(ctx, jql, fields)
+	}
+
 	params := url.Values{
 		"jql":        {jql},
 		"fields":     {fields},
 		"maxResults": {maxSearchResults},
 	}
 
-	paginator := httpkit.NewTokenPaginator(a.client, "/rest/api/3/search/jql", params, "nextPageToken", func(body []byte) ([]domain.Issue, string, error) {
+	paginator := httpkit.NewTokenPaginator(a.client, a.basePath+"/search/jql", params, "nextPageToken", func(body []byte) ([]domain.Issue, string, error) {
 		var sr searchResponse
 		if err := json.Unmarshal(body, &sr); err != nil {
 			return nil, "", &domain.TrackerError{
@@ -432,7 +576,7 @@ func (a *JiraAdapter) paginatedSearch(ctx context.Context, jql, fields string) (
 
 		issues := make([]domain.Issue, 0, len(sr.Issues))
 		for _, ji := range sr.Issues {
-			issue := normalizeSearchIssue(a.endpoint, ji)
+			issue := normalizeSearchIssue(a.apiVersion, a.endpoint, ji)
 			issue.Comments = nil
 			issues = append(issues, issue)
 		}
@@ -440,6 +584,55 @@ func (a *JiraAdapter) paginatedSearch(ctx context.Context, jql, fields string) (
 	}, httpkit.PaginatorOptions{})
 
 	return paginator.All(ctx)
+}
+
+// paginatedSearchV2 executes an offset-paginated JQL search against the
+// v2 search endpoint and returns all normalized issues. Comments are
+// set to nil. The loop terminates on an empty page or when the cursor
+// reaches the reported total, mirroring the comment-pagination loop.
+func (a *JiraAdapter) paginatedSearchV2(ctx context.Context, jql, fields string) ([]domain.Issue, error) {
+	issues := make([]domain.Issue, 0)
+	startAt := 0
+
+	for {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+
+		params := url.Values{
+			"jql":        {jql},
+			"fields":     {fields},
+			"maxResults": {maxSearchResults},
+			"startAt":    {strconv.Itoa(startAt)},
+		}
+
+		body, _, err := a.client.Get(ctx, a.basePath+"/search", params)
+		if err != nil {
+			return nil, err
+		}
+
+		var sr searchResponseV2
+		if err := json.Unmarshal(body, &sr); err != nil {
+			return nil, &domain.TrackerError{
+				Kind:    domain.ErrTrackerPayload,
+				Message: "failed to parse search response",
+				Err:     err,
+			}
+		}
+
+		for _, ji := range sr.Issues {
+			issue := normalizeSearchIssue(a.apiVersion, a.endpoint, ji)
+			issue.Comments = nil
+			issues = append(issues, issue)
+		}
+
+		if len(sr.Issues) == 0 || startAt+len(sr.Issues) >= sr.Total {
+			break
+		}
+		startAt += len(sr.Issues)
+	}
+
+	return issues, nil
 }
 
 // fetchComments retrieves all comments for an issue using offset-based
@@ -459,7 +652,7 @@ func (a *JiraAdapter) fetchComments(ctx context.Context, issueID string) ([]doma
 			"startAt":    {fmt.Sprintf("%d", startAt)},
 		}
 
-		body, _, err := a.client.Get(ctx, "/rest/api/3/issue/"+url.PathEscape(issueID)+"/comment", params)
+		body, _, err := a.client.Get(ctx, a.basePath+"/issue/"+url.PathEscape(issueID)+"/comment", params)
 		if err != nil {
 			if domain.IsNotFound(err) {
 				return nil, &domain.TrackerError{
@@ -490,5 +683,5 @@ func (a *JiraAdapter) fetchComments(ctx context.Context, issueID string) ([]doma
 	if len(allComments) == 0 {
 		return []domain.Comment{}, nil
 	}
-	return normalizeComments(allComments), nil
+	return normalizeComments(a.apiVersion, allComments), nil
 }

--- a/internal/tracker/jira/jira.go
+++ b/internal/tracker/jira/jira.go
@@ -15,7 +15,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
-	"math"
 	"net/url"
 	"strconv"
 	"strings"
@@ -164,7 +163,7 @@ func normalizeAPIVersion(raw any) (string, error) {
 	case int:
 		v = strconv.Itoa(n)
 	case float64:
-		if n != math.Trunc(n) {
+		if n != 2 && n != 3 {
 			return "", &domain.TrackerError{
 				Kind:    domain.ErrTrackerPayload,
 				Message: fmt.Sprintf(`tracker.api_version must be "2" or "3", got %v`, raw),
@@ -208,10 +207,7 @@ func resolveAuth(apiVersion, apiKey string) (string, error) {
 	idx := strings.Index(apiKey, ":")
 	if idx >= 0 {
 		if idx < 1 || idx == len(apiKey)-1 {
-			return "", &domain.TrackerError{
-				Kind:    domain.ErrTrackerAuth,
-				Message: "api_key must be in email:token format",
-			}
+			return "", authFormatError(apiVersion)
 		}
 		return "Basic " + base64.StdEncoding.EncodeToString([]byte(apiKey)), nil
 	}
@@ -220,9 +216,22 @@ func resolveAuth(apiVersion, apiKey string) (string, error) {
 		return "Bearer " + apiKey, nil
 	}
 
-	return "", &domain.TrackerError{
+	return "", authFormatError(apiVersion)
+}
+
+// authFormatError reports an invalid api_key shape for the given API
+// version. Version 2 accepts a personal access token or user:password
+// Basic credentials; version 3 requires email:token Basic credentials.
+func authFormatError(apiVersion string) error {
+	if apiVersion == "2" {
+		return &domain.TrackerError{
+			Kind:    domain.ErrTrackerAuth,
+			Message: "api_key for api_version 2 must be a personal access token or in user:password format",
+		}
+	}
+	return &domain.TrackerError{
 		Kind:    domain.ErrTrackerAuth,
-		Message: "api_key must be in email:token format",
+		Message: "api_key for api_version 3 must be in email:token format",
 	}
 }
 

--- a/internal/tracker/jira/jira.go
+++ b/internal/tracker/jira/jira.go
@@ -15,6 +15,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"net"
 	"net/url"
 	"strconv"
 	"strings"
@@ -240,7 +241,10 @@ func authFormatError(apiVersion string) error {
 // (one ending in .atlassian.net) combined with version "2" returns a
 // [*domain.TrackerError] of kind [domain.ErrTrackerPayload]. A
 // non-Cloud host combined with version "3" logs a warning and returns
-// nil so construction proceeds. All other combinations return nil.
+// nil so construction proceeds, except for a loopback or localhost host,
+// which is a test or local-dev endpoint and never a real Server / Data
+// Center instance, so it is not warned. All other combinations return
+// nil.
 func checkHostVersion(endpoint, apiVersion string) error {
 	parsed, err := url.Parse(endpoint)
 	if err != nil {
@@ -256,12 +260,24 @@ func checkHostVersion(endpoint, apiVersion string) error {
 		}
 	}
 
-	if !isCloud && apiVersion == "3" {
-		slog.Warn("tracker.api_version 3 against non-cloud endpoint will return 404",
+	if !isCloud && apiVersion == "3" && !isLocalEndpoint(host) {
+		slog.Warn("api_version 3 against non-cloud endpoint will return 404; set tracker.api_version 2 for jira server or data center",
 			slog.String("host", host))
 	}
 
 	return nil
+}
+
+// isLocalEndpoint reports whether host is a test or local-dev endpoint:
+// the literal "localhost" or a loopback IP address. Private IPs and
+// internal FQDNs are not local, since real Server / Data Center
+// instances commonly live on those.
+func isLocalEndpoint(host string) bool {
+	if host == "localhost" {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
 }
 
 // FetchCandidateIssues returns issues in configured active states

--- a/internal/tracker/jira/jira.go
+++ b/internal/tracker/jira/jira.go
@@ -237,7 +237,8 @@ func authFormatError(apiVersion string) error {
 }
 
 // checkHostVersion runs a static consistency check between the endpoint
-// host and the API version. It performs no network I/O. A Cloud host
+// host and the API version. It also rejects an endpoint that is not a URL
+// with a scheme and host. It performs no network I/O. A Cloud host
 // (one ending in .atlassian.net) combined with version "2" returns a
 // [*domain.TrackerError] of kind [domain.ErrTrackerPayload]. A
 // non-Cloud host combined with version "3" logs a warning and returns
@@ -247,8 +248,11 @@ func authFormatError(apiVersion string) error {
 // nil.
 func checkHostVersion(endpoint, apiVersion string) error {
 	parsed, err := url.Parse(endpoint)
-	if err != nil {
-		return nil
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return &domain.TrackerError{
+			Kind:    domain.ErrTrackerPayload,
+			Message: fmt.Sprintf("endpoint %q must be a URL with a scheme and host", endpoint),
+		}
 	}
 	host := strings.ToLower(parsed.Hostname())
 	isCloud := strings.HasSuffix(host, ".atlassian.net")
@@ -520,8 +524,9 @@ func (a *JiraAdapter) CommentIssue(ctx context.Context, issueID string, text str
 }
 
 // commentPayload builds the comment-create request body for the given
-// API version. On version "2" it returns a raw wiki-markup string body;
-// on any other version it returns an ADF document.
+// API version. On version "2" it returns a {"body": <text>} object whose
+// body field carries the raw wiki-markup string; on any other version it
+// returns an ADF document.
 func commentPayload(apiVersion, text string) any {
 	if apiVersion == "2" {
 		return map[string]any{"body": text}

--- a/internal/tracker/jira/jira_v2_test.go
+++ b/internal/tracker/jira/jira_v2_test.go
@@ -1,0 +1,780 @@
+package jira
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/sortie-ai/sortie/internal/domain"
+)
+
+// v2Config returns a baseline v2 adapter config against endpoint with a
+// colon-free PAT (Bearer) credential and a non-Cloud host.
+func v2Config(endpoint string) map[string]any {
+	return map[string]any{
+		"endpoint":    endpoint,
+		"api_key":     "pat_token_abc",
+		"project":     "SRV",
+		"api_version": "2",
+	}
+}
+
+// --- api_version normalization at the constructor (AC6, AC7) ---
+
+func TestNewJiraAdapter_APIVersion(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		apiVersion  any // omitted when nil and present=false
+		present     bool
+		wantVersion string
+		wantBase    string
+		wantErr     bool
+		wantKind    domain.TrackerErrorKind
+		wantMsgSubs []string
+	}{
+		{name: "absent defaults to 3", present: false, wantVersion: "3", wantBase: "/rest/api/3"},
+		{name: "empty string defaults to 3", apiVersion: "", present: true, wantVersion: "3", wantBase: "/rest/api/3"},
+		{name: "whitespace-only defaults to 3", apiVersion: "  ", present: true, wantVersion: "3", wantBase: "/rest/api/3"},
+		{name: "explicit 3", apiVersion: "3", present: true, wantVersion: "3", wantBase: "/rest/api/3"},
+		{name: "explicit 2", apiVersion: "2", present: true, wantVersion: "2", wantBase: "/rest/api/2"},
+		{name: "trimmed 2", apiVersion: " 2 ", present: true, wantVersion: "2", wantBase: "/rest/api/2"},
+		{name: "bare int 2 coerced", apiVersion: 2, present: true, wantVersion: "2", wantBase: "/rest/api/2"},
+		{name: "bare int 3 coerced", apiVersion: 3, present: true, wantVersion: "3", wantBase: "/rest/api/3"},
+		{name: "float64 whole 2 coerced", apiVersion: float64(2), present: true, wantVersion: "2", wantBase: "/rest/api/2"},
+		{
+			name: "invalid string value", apiVersion: "4", present: true,
+			wantErr: true, wantKind: domain.ErrTrackerPayload,
+			wantMsgSubs: []string{`"4"`, `"2"`, `"3"`},
+		},
+		{
+			name: "invalid int value", apiVersion: 1, present: true,
+			wantErr: true, wantKind: domain.ErrTrackerPayload,
+			wantMsgSubs: []string{"1", `"2"`, `"3"`},
+		},
+		{
+			name: "fractional float rejected", apiVersion: 2.5, present: true,
+			wantErr: true, wantKind: domain.ErrTrackerPayload,
+			wantMsgSubs: []string{`"2"`, `"3"`},
+		},
+		{
+			name: "non-coercible type rejected", apiVersion: []any{"2"}, present: true,
+			wantErr: true, wantKind: domain.ErrTrackerPayload,
+			wantMsgSubs: []string{`"2"`, `"3"`},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			// A colon-free key is only valid under v2; for the v3 default
+			// cases use the Basic email:token form so the only variable
+			// under test is api_version.
+			cfg := map[string]any{
+				"endpoint": "https://jira.internal.example.com",
+				"api_key":  "user@test.com:tok",
+				"project":  "SRV",
+			}
+			if tt.present {
+				cfg["api_version"] = tt.apiVersion
+			}
+
+			a, err := NewJiraAdapter(cfg)
+			if tt.wantErr {
+				assertTrackerErrorKind(t, err, tt.wantKind)
+				var te *domain.TrackerError
+				asTrackerError(t, err, &te)
+				for _, sub := range tt.wantMsgSubs {
+					if !strings.Contains(te.Message, sub) {
+						t.Errorf("TrackerError.Message = %q, want to contain %q", te.Message, sub)
+					}
+				}
+				if a != nil {
+					t.Error("adapter should be nil on error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("NewJiraAdapter(api_version=%v) unexpected error: %v", tt.apiVersion, err)
+			}
+			ja := a.(*JiraAdapter)
+			if ja.apiVersion != tt.wantVersion {
+				t.Errorf("apiVersion = %q, want %q", ja.apiVersion, tt.wantVersion)
+			}
+			if ja.basePath != tt.wantBase {
+				t.Errorf("basePath = %q, want %q", ja.basePath, tt.wantBase)
+			}
+		})
+	}
+}
+
+// asTrackerError populates target with the *domain.TrackerError from the
+// error chain or fails the test.
+func asTrackerError(t *testing.T, err error, target **domain.TrackerError) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.As(err, target) {
+		t.Fatalf("error type = %T, want *domain.TrackerError", err)
+	}
+}
+
+// --- resolveAuth matrix (AC4, AC6) ---
+
+func TestResolveAuth(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		apiVersion string
+		apiKey     string
+		wantHeader string // exact header when non-empty and no error
+		wantPrefix string // header prefix when the secret should not be matched verbatim
+		wantErr    bool
+	}{
+		{
+			name: "v3 email:token to Basic", apiVersion: "3", apiKey: "user@test.com:tok123",
+			wantHeader: "Basic " + base64.StdEncoding.EncodeToString([]byte("user@test.com:tok123")),
+		},
+		{name: "v3 colon-free rejected", apiVersion: "3", apiKey: "patnocolon", wantErr: true},
+		{name: "v3 empty user rejected", apiVersion: "3", apiKey: ":tok", wantErr: true},
+		{name: "v3 empty secret rejected", apiVersion: "3", apiKey: "email:", wantErr: true},
+		{
+			name: "v2 user:password to Basic", apiVersion: "2", apiKey: "svcuser:s3cret",
+			wantHeader: "Basic " + base64.StdEncoding.EncodeToString([]byte("svcuser:s3cret")),
+		},
+		{name: "v2 empty user rejected", apiVersion: "2", apiKey: ":password", wantErr: true},
+		{name: "v2 empty secret rejected (trailing colon)", apiVersion: "2", apiKey: "user:", wantErr: true},
+		{
+			name: "v2 colon-free to Bearer", apiVersion: "2", apiKey: "pat_token_abc",
+			wantHeader: "Bearer pat_token_abc",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := resolveAuth(tt.apiVersion, tt.apiKey)
+			if tt.wantErr {
+				assertTrackerErrorKind(t, err, domain.ErrTrackerAuth)
+				if got != "" {
+					t.Errorf("resolveAuth(%q, %q) = %q, want empty header on error", tt.apiVersion, tt.apiKey, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("resolveAuth(%q, %q) unexpected error: %v", tt.apiVersion, tt.apiKey, err)
+			}
+			if tt.wantHeader != "" && got != tt.wantHeader {
+				t.Errorf("resolveAuth(%q, %q) = %q, want %q", tt.apiVersion, tt.apiKey, got, tt.wantHeader)
+			}
+			if tt.wantPrefix != "" && !strings.HasPrefix(got, tt.wantPrefix) {
+				t.Errorf("resolveAuth(%q, %q) = %q, want prefix %q", tt.apiVersion, tt.apiKey, got, tt.wantPrefix)
+			}
+		})
+	}
+}
+
+// TestResolveAuth_GuardRelaxesOnlyForV2ColonFree asserts the relaxation
+// is confined to the v2 colon-free shape: the same colon-free key is
+// rejected on v3, and a malformed Basic shape is rejected on both
+// versions identically.
+func TestResolveAuth_GuardRelaxesOnlyForV2ColonFree(t *testing.T) {
+	t.Parallel()
+
+	const colonFree = "pat_token_abc"
+
+	if _, err := resolveAuth("3", colonFree); err == nil {
+		t.Errorf("resolveAuth(3, colon-free) = nil error, want ErrTrackerAuth")
+	}
+	if h, err := resolveAuth("2", colonFree); err != nil || h != "Bearer "+colonFree {
+		t.Errorf("resolveAuth(2, colon-free) = (%q, %v), want (Bearer ..., nil)", h, err)
+	}
+
+	for _, version := range []string{"2", "3"} {
+		if _, err := resolveAuth(version, "user:"); err == nil {
+			t.Errorf("resolveAuth(%s, trailing-colon) = nil error, want ErrTrackerAuth (guard must not relax for Basic)", version)
+		}
+	}
+}
+
+// --- Host / version consistency guard, reject arm (AC11) ---
+
+func TestNewJiraAdapter_HostVersionGuard_RejectCloudV2(t *testing.T) {
+	t.Parallel()
+
+	cfg := map[string]any{
+		"endpoint":    "https://acme.atlassian.net",
+		"api_key":     "user@test.com:tok",
+		"project":     "P",
+		"api_version": "2",
+	}
+
+	a, err := NewJiraAdapter(cfg)
+	assertTrackerErrorKind(t, err, domain.ErrTrackerPayload)
+	if a != nil {
+		t.Error("adapter should be nil when a Cloud host is combined with api_version 2")
+	}
+
+	var te *domain.TrackerError
+	asTrackerError(t, err, &te)
+	if !strings.Contains(te.Message, "acme.atlassian.net") {
+		t.Errorf("TrackerError.Message = %q, want to name the host", te.Message)
+	}
+}
+
+// TestNewJiraAdapter_HostVersionGuard_ConsistentCombos verifies the two
+// consistent (host, version) pairs construct successfully.
+func TestNewJiraAdapter_HostVersionGuard_ConsistentCombos(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		endpoint string
+		apiKey   string
+		version  string
+	}{
+		{name: "cloud host plus v3", endpoint: "https://acme.atlassian.net", apiKey: "user@test.com:tok", version: "3"},
+		{name: "self-hosted host plus v2", endpoint: "https://jira.internal.example.com", apiKey: "pat_token_abc", version: "2"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := map[string]any{
+				"endpoint":    tt.endpoint,
+				"api_key":     tt.apiKey,
+				"project":     "P",
+				"api_version": tt.version,
+			}
+			if _, err := NewJiraAdapter(cfg); err != nil {
+				t.Fatalf("NewJiraAdapter(%s) unexpected error: %v", tt.name, err)
+			}
+		})
+	}
+}
+
+// TestNewJiraAdapter_HostVersionGuard_WarnArm covers the warn arm: a
+// non-Cloud host with api_version 3 constructs successfully and emits a
+// single warning that carries the host attribute and never the api_key.
+// It mutates the default slog logger, so it must not run in parallel and
+// must restore the prior default.
+func TestNewJiraAdapter_HostVersionGuard_WarnArm(t *testing.T) {
+	prev := slog.Default()
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	var buf bytes.Buffer
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+
+	cfg := map[string]any{
+		"endpoint":    "https://jira.internal.example.com",
+		"api_key":     "user@test.com:secret_tok",
+		"project":     "P",
+		"api_version": "3",
+	}
+
+	a, err := NewJiraAdapter(cfg)
+	if err != nil {
+		t.Fatalf("NewJiraAdapter (warn arm) unexpected error: %v", err)
+	}
+	if a == nil {
+		t.Fatal("adapter is nil; warn arm must not block construction")
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "level=WARN") {
+		t.Errorf("log output = %q, want a WARN line", output)
+	}
+	if !strings.Contains(output, "host=") {
+		t.Errorf("log output = %q, want a host attribute", output)
+	}
+	if !strings.Contains(output, "jira.internal.example.com") {
+		t.Errorf("log output = %q, want the endpoint host", output)
+	}
+	if strings.Contains(output, "secret_tok") {
+		t.Errorf("log output leaked api_key: %q", output)
+	}
+}
+
+// TestNewJiraAdapter_HostVersionGuard_NoWarnForConsistent verifies the
+// consistent combos emit no warn line. Serialized for the same reason as
+// the warn-arm test.
+func TestNewJiraAdapter_HostVersionGuard_NoWarnForConsistent(t *testing.T) {
+	prev := slog.Default()
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	tests := []struct {
+		name     string
+		endpoint string
+		apiKey   string
+		version  string
+	}{
+		{name: "cloud host plus v3", endpoint: "https://acme.atlassian.net", apiKey: "user@test.com:tok", version: "3"},
+		{name: "self-hosted host plus v2", endpoint: "https://jira.internal.example.com", apiKey: "pat_token_abc", version: "2"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+
+			cfg := map[string]any{
+				"endpoint":    tt.endpoint,
+				"api_key":     tt.apiKey,
+				"project":     "P",
+				"api_version": tt.version,
+			}
+			if _, err := NewJiraAdapter(cfg); err != nil {
+				t.Fatalf("NewJiraAdapter(%s) unexpected error: %v", tt.name, err)
+			}
+			if strings.Contains(buf.String(), "level=WARN") {
+				t.Errorf("log output = %q, want no WARN line for a consistent combo", buf.String())
+			}
+		})
+	}
+}
+
+// --- v2 offset search pagination (AC1, AC3) ---
+
+func TestPaginatedSearchV2_SinglePage(t *testing.T) {
+	t.Parallel()
+
+	var gotPath string
+	var gotStartAt string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotStartAt = r.URL.Query().Get("startAt")
+		w.Write(loadFixture(t, "search_v2_single_page.json")) //nolint:errcheck // test helper
+	}))
+	defer srv.Close()
+
+	a := mustAdapter(t, v2Config(srv.URL))
+	issues, err := a.FetchCandidateIssues(context.Background())
+	if err != nil {
+		t.Fatalf("FetchCandidateIssues (v2): %v", err)
+	}
+	if len(issues) != 2 {
+		t.Fatalf("len = %d, want 2", len(issues))
+	}
+	if gotPath != "/rest/api/2/search" {
+		t.Errorf("request path = %q, want /rest/api/2/search", gotPath)
+	}
+	if gotStartAt != "0" {
+		t.Errorf("startAt = %q, want 0 on first request", gotStartAt)
+	}
+	if issues[0].Identifier != "SRV-1" {
+		t.Errorf("issues[0].Identifier = %q, want SRV-1", issues[0].Identifier)
+	}
+	if issues[0].Comments != nil {
+		t.Error("Comments should be nil for v2 search results")
+	}
+}
+
+func TestPaginatedSearchV2_MultiPage(t *testing.T) {
+	t.Parallel()
+
+	page1 := loadFixture(t, "search_v2_multi_page_1.json")
+	page2 := loadFixture(t, "search_v2_multi_page_2.json")
+
+	var (
+		callCount   int32
+		seenStartAt []string
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&callCount, 1)
+		seenStartAt = append(seenStartAt, r.URL.Query().Get("startAt"))
+		if r.URL.Path != "/rest/api/2/search" {
+			t.Errorf("request path = %q, want /rest/api/2/search", r.URL.Path)
+		}
+		if n == 1 {
+			w.Write(page1) //nolint:errcheck // test helper
+		} else {
+			w.Write(page2) //nolint:errcheck // test helper
+		}
+	}))
+	defer srv.Close()
+
+	a := mustAdapter(t, v2Config(srv.URL))
+	issues, err := a.FetchCandidateIssues(context.Background())
+	if err != nil {
+		t.Fatalf("FetchCandidateIssues (v2 multi-page): %v", err)
+	}
+	if len(issues) != 3 {
+		t.Fatalf("len = %d, want 3 across 2 pages", len(issues))
+	}
+	if got := atomic.LoadInt32(&callCount); got != 2 {
+		t.Errorf("request count = %d, want 2", got)
+	}
+	wantIDs := []string{"SRV-11", "SRV-12", "SRV-13"}
+	for i, want := range wantIDs {
+		if issues[i].Identifier != want {
+			t.Errorf("issues[%d].Identifier = %q, want %q", i, issues[i].Identifier, want)
+		}
+	}
+	// startAt must advance from 0 to the first page length (2), proving
+	// the offset cursor moves and the loop terminates on the partial page.
+	if len(seenStartAt) != 2 || seenStartAt[0] != "0" || seenStartAt[1] != "2" {
+		t.Errorf("startAt sequence = %v, want [0 2]", seenStartAt)
+	}
+}
+
+// TestPaginatedSearchV2_FinalFullPageTerminates guards against an
+// infinite loop when the last page is exactly full: total equals the
+// number of issues returned, so startAt + len >= total must terminate.
+func TestPaginatedSearchV2_FinalFullPageTerminates(t *testing.T) {
+	t.Parallel()
+
+	// total == 2 and the single page returns 2 issues: startAt(0)+2 >= 2.
+	var callCount int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&callCount, 1)
+		w.Write(loadFixture(t, "search_v2_single_page.json")) //nolint:errcheck // test helper
+	}))
+	defer srv.Close()
+
+	a := mustAdapter(t, v2Config(srv.URL))
+	issues, err := a.FetchCandidateIssues(context.Background())
+	if err != nil {
+		t.Fatalf("FetchCandidateIssues: %v", err)
+	}
+	if len(issues) != 2 {
+		t.Fatalf("len = %d, want 2", len(issues))
+	}
+	if got := atomic.LoadInt32(&callCount); got != 1 {
+		t.Errorf("request count = %d, want 1 (loop must terminate on a full final page)", got)
+	}
+}
+
+// TestPaginatedSearchV2_DecodeError maps a malformed v2 search body to
+// ErrTrackerPayload.
+func TestPaginatedSearchV2_DecodeError(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{invalid json`)) //nolint:errcheck // test helper
+	}))
+	defer srv.Close()
+
+	a := mustAdapter(t, v2Config(srv.URL))
+	_, err := a.FetchCandidateIssues(context.Background())
+	assertTrackerErrorKind(t, err, domain.ErrTrackerPayload)
+}
+
+// --- v2 comment write (AC5) ---
+
+func TestCommentIssue_V2RawStringBody(t *testing.T) {
+	t.Parallel()
+
+	var (
+		gotMethod string
+		gotPath   string
+		gotBody   []byte
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		gotBody, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer srv.Close()
+
+	a := mustAdapter(t, v2Config(srv.URL))
+	const text = "h2. Heading\n\n*bold* body"
+	if err := a.CommentIssue(context.Background(), "SRV-1", text); err != nil {
+		t.Fatalf("CommentIssue (v2): %v", err)
+	}
+
+	if gotMethod != "POST" {
+		t.Errorf("method = %q, want POST", gotMethod)
+	}
+	if gotPath != "/rest/api/2/issue/SRV-1/comment" {
+		t.Errorf("path = %q, want /rest/api/2/issue/SRV-1/comment", gotPath)
+	}
+
+	// The v2 body is a raw string under "body", not an ADF document.
+	var payload struct {
+		Body json.RawMessage `json:"body"`
+	}
+	if err := json.Unmarshal(gotBody, &payload); err != nil {
+		t.Fatalf("unmarshal request body: %v", err)
+	}
+	var bodyStr string
+	if err := json.Unmarshal(payload.Body, &bodyStr); err != nil {
+		t.Fatalf("v2 body should be a raw JSON string, got %s: %v", payload.Body, err)
+	}
+	if bodyStr != text {
+		t.Errorf("body = %q, want verbatim %q", bodyStr, text)
+	}
+}
+
+// TestCommentPayload_ByVersion asserts the payload shape selector
+// directly: v2 yields a raw-string body, v3 yields an ADF document.
+func TestCommentPayload_ByVersion(t *testing.T) {
+	t.Parallel()
+
+	v2 := commentPayload("2", "hello")
+	m, ok := v2.(map[string]any)
+	if !ok {
+		t.Fatalf("commentPayload(2) type = %T, want map[string]any", v2)
+	}
+	if m["body"] != "hello" {
+		t.Errorf("commentPayload(2)[body] = %v, want %q", m["body"], "hello")
+	}
+
+	// v3 must produce an ADF document, never a raw-string body.
+	v3 := commentPayload("3", "hello")
+	raw, err := json.Marshal(v3)
+	if err != nil {
+		t.Fatalf("marshal v3 payload: %v", err)
+	}
+	if !strings.Contains(string(raw), `"type":"doc"`) {
+		t.Errorf("commentPayload(3) = %s, want an ADF document with type doc", raw)
+	}
+}
+
+// --- Transport auth header and no-secret-logging (AC4, AC10) ---
+
+func TestV2Transport_AuthHeader(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		apiKey     string
+		wantHeader string
+		secret     string // must never appear raw in a header beyond the encoded/bearer form check
+	}{
+		{name: "colon-free PAT to Bearer", apiKey: "pat_token_abc", wantHeader: "Bearer pat_token_abc", secret: "pat_token_abc"},
+		{
+			name:       "user:password to Basic",
+			apiKey:     "svcuser:s3cret",
+			wantHeader: "Basic " + base64.StdEncoding.EncodeToString([]byte("svcuser:s3cret")),
+			secret:     "s3cret",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var gotAuth string
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotAuth = r.Header.Get("Authorization")
+				w.Write(loadFixture(t, "search_v2_single_page.json")) //nolint:errcheck // test helper
+			}))
+			defer srv.Close()
+
+			cfg := v2Config(srv.URL)
+			cfg["api_key"] = tt.apiKey
+			a := mustAdapter(t, cfg)
+			if _, err := a.FetchCandidateIssues(context.Background()); err != nil {
+				t.Fatalf("FetchCandidateIssues: %v", err)
+			}
+
+			if gotAuth != tt.wantHeader {
+				t.Errorf("Authorization = %q, want %q", gotAuth, tt.wantHeader)
+			}
+			// For Basic, the raw password must be base64-encoded, never
+			// present in cleartext in the header.
+			if strings.HasPrefix(tt.wantHeader, "Basic ") && strings.Contains(gotAuth, tt.secret) {
+				t.Errorf("Authorization header leaked the raw secret: %q", gotAuth)
+			}
+		})
+	}
+}
+
+// TestV2Transport_NoSecretInLogs runs a full v2 fetch under a captured
+// default logger and asserts neither the api_key nor the constructed
+// Authorization header is logged anywhere.
+func TestV2Transport_NoSecretInLogs(t *testing.T) {
+	prev := slog.Default()
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	var buf bytes.Buffer
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write(loadFixture(t, "search_v2_single_page.json")) //nolint:errcheck // test helper
+	}))
+	defer srv.Close()
+
+	const secret = "pat_secret_value_xyz"
+	cfg := v2Config(srv.URL)
+	cfg["api_key"] = secret
+	a := mustAdapter(t, cfg)
+	if _, err := a.FetchCandidateIssues(context.Background()); err != nil {
+		t.Fatalf("FetchCandidateIssues: %v", err)
+	}
+
+	output := buf.String()
+	if strings.Contains(output, secret) {
+		t.Errorf("log output leaked the api_key %q: %q", secret, output)
+	}
+	if strings.Contains(output, "Bearer "+secret) {
+		t.Errorf("log output leaked the Authorization header: %q", output)
+	}
+}
+
+// --- v2 HTTP error category mapping (AC8) ---
+
+func TestV2_HTTPErrorMapping(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		status   int
+		wantKind domain.TrackerErrorKind
+	}{
+		{"401 unauthorized to auth", http.StatusUnauthorized, domain.ErrTrackerAuth},
+		{"403 forbidden to auth", http.StatusForbidden, domain.ErrTrackerAuth},
+		{"500 server error to transport", http.StatusInternalServerError, domain.ErrTrackerTransport},
+		{"503 server error to transport", http.StatusServiceUnavailable, domain.ErrTrackerTransport},
+		{"429 rate limited to API", http.StatusTooManyRequests, domain.ErrTrackerAPI},
+		{"404 not found to not-found", http.StatusNotFound, domain.ErrTrackerNotFound},
+		{"400 bad request to payload", http.StatusBadRequest, domain.ErrTrackerPayload},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(tt.status)
+			}))
+			defer srv.Close()
+
+			a := mustAdapter(t, v2Config(srv.URL))
+			_, err := a.FetchCandidateIssues(context.Background())
+			assertTrackerErrorKind(t, err, tt.wantKind)
+		})
+	}
+}
+
+// --- v3 regression: a config without api_version keeps v3 behavior (AC6) ---
+
+func TestV3Regression_NoAPIVersion(t *testing.T) {
+	t.Parallel()
+
+	var (
+		gotSearchPath string
+		gotAuth       string
+		gotToken      atomic.Int32
+	)
+	page1 := loadFixture(t, "search_multi_page_1.json") // carries nextPageToken=cursor_abc
+	page2 := loadFixture(t, "search_multi_page_2.json")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotSearchPath = r.URL.Path
+		gotAuth = r.Header.Get("Authorization")
+		if r.URL.Query().Get("nextPageToken") == "cursor_abc" {
+			gotToken.Add(1)
+			w.Write(page2) //nolint:errcheck // test helper
+			return
+		}
+		w.Write(page1) //nolint:errcheck // test helper
+	}))
+	defer srv.Close()
+
+	// validConfig uses email:token (Basic) and omits api_version entirely.
+	a := mustAdapter(t, validConfig(srv.URL))
+
+	if a.apiVersion != "3" {
+		t.Errorf("apiVersion = %q, want default 3", a.apiVersion)
+	}
+	if a.basePath != "/rest/api/3" {
+		t.Errorf("basePath = %q, want /rest/api/3", a.basePath)
+	}
+
+	issues, err := a.FetchCandidateIssues(context.Background())
+	if err != nil {
+		t.Fatalf("FetchCandidateIssues: %v", err)
+	}
+
+	// Cursor pagination: the second page is reached via nextPageToken.
+	if len(issues) != 2 {
+		t.Fatalf("len = %d, want 2 across 2 cursor pages", len(issues))
+	}
+	if gotToken.Load() != 1 {
+		t.Errorf("nextPageToken follow-up requests = %d, want 1 (cursor pagination)", gotToken.Load())
+	}
+	if gotSearchPath != "/rest/api/3/search/jql" {
+		t.Errorf("search path = %q, want /rest/api/3/search/jql", gotSearchPath)
+	}
+	wantAuth := "Basic " + base64.StdEncoding.EncodeToString([]byte("user@test.com:api_token_123"))
+	if gotAuth != wantAuth {
+		t.Errorf("Authorization = %q, want Basic email:token", gotAuth)
+	}
+}
+
+// TestV3Regression_ADFFlattening confirms the v3 default path flattens
+// the ADF description rather than carrying raw structure.
+func TestV3Regression_ADFFlattening(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/comment") {
+			w.Write(loadFixture(t, "comments_empty.json")) //nolint:errcheck // test helper
+			return
+		}
+		w.Write(loadFixture(t, "issue_detail.json")) //nolint:errcheck // test helper
+	}))
+	defer srv.Close()
+
+	a := mustAdapter(t, validConfig(srv.URL))
+	issue, err := a.FetchIssueByID(context.Background(), "PROJ-5")
+	if err != nil {
+		t.Fatalf("FetchIssueByID: %v", err)
+	}
+	if strings.Contains(issue.Description, `"type"`) || strings.Contains(issue.Description, `"content"`) {
+		t.Errorf("Description = %q, want flattened ADF text without raw JSON structure", issue.Description)
+	}
+	if !strings.Contains(issue.Description, "Refactor the persistence layer:") {
+		t.Errorf("Description = %q, want flattened ADF prose", issue.Description)
+	}
+}
+
+// TestV3Regression_ColonGuardPreserved confirms the v3 colon guard still
+// rejects email: and :token at construction (AC6).
+func TestV3Regression_ColonGuardPreserved(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		apiKey string
+	}{
+		{name: "trailing colon (empty token)", apiKey: "email:"},
+		{name: "leading colon (empty user)", apiKey: ":token"},
+		{name: "colon-free on v3", apiKey: "noatsign"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := map[string]any{
+				"endpoint": "https://x.atlassian.net",
+				"api_key":  tt.apiKey,
+				"project":  "P",
+				// api_version omitted: defaults to v3.
+			}
+			a, err := NewJiraAdapter(cfg)
+			assertTrackerErrorKind(t, err, domain.ErrTrackerAuth)
+			if a != nil {
+				t.Error("adapter should be nil on a malformed v3 credential")
+			}
+		})
+	}
+}

--- a/internal/tracker/jira/jira_v2_test.go
+++ b/internal/tracker/jira/jira_v2_test.go
@@ -274,10 +274,11 @@ func TestNewJiraAdapter_HostVersionGuard_ConsistentCombos(t *testing.T) {
 }
 
 // TestNewJiraAdapter_HostVersionGuard_WarnArm covers the warn arm: a
-// non-Cloud host with api_version 3 constructs successfully and emits a
-// single warning that carries the host attribute and never the api_key.
-// It mutates the default slog logger, so it must not run in parallel and
-// must restore the prior default.
+// non-Cloud, non-loopback host with api_version 3 constructs
+// successfully and emits a single warning that carries the host
+// attribute and never the api_key. It mutates the default slog logger,
+// so it must not run in parallel (no t.Parallel anywhere in its chain)
+// and must restore the prior default.
 func TestNewJiraAdapter_HostVersionGuard_WarnArm(t *testing.T) {
 	prev := slog.Default()
 	t.Cleanup(func() { slog.SetDefault(prev) })
@@ -304,14 +305,65 @@ func TestNewJiraAdapter_HostVersionGuard_WarnArm(t *testing.T) {
 	if !strings.Contains(output, "level=WARN") {
 		t.Errorf("log output = %q, want a WARN line", output)
 	}
-	if !strings.Contains(output, "host=") {
-		t.Errorf("log output = %q, want a host attribute", output)
-	}
-	if !strings.Contains(output, "jira.internal.example.com") {
-		t.Errorf("log output = %q, want the endpoint host", output)
+	if !strings.Contains(output, "host=jira.internal.example.com") {
+		t.Errorf("log output = %q, want the host attribute carrying the endpoint host", output)
 	}
 	if strings.Contains(output, "secret_tok") {
 		t.Errorf("log output leaked api_key: %q", output)
+	}
+}
+
+// TestNewJiraAdapter_HostVersionGuard_WarnArmLocalSuppressed covers the
+// warn-arm exception: a loopback or localhost endpoint with api_version
+// 3 is a test or local-dev target, never a real Server / Data Center
+// instance, so construction succeeds and emits no warn line. It mutates
+// the default slog logger, so it must not run in parallel (no t.Parallel
+// anywhere in its chain) and must restore the prior default.
+func TestNewJiraAdapter_HostVersionGuard_WarnArmLocalSuppressed(t *testing.T) {
+	prev := slog.Default()
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	tests := []struct {
+		name     string
+		endpoint string
+	}{
+		{name: "loopback IP", endpoint: srv.URL},
+		{name: "localhost", endpoint: "http://localhost:8080"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+
+			cfg := map[string]any{
+				"endpoint":    tt.endpoint,
+				"api_key":     "user@test.com:secret_tok",
+				"project":     "P",
+				"api_version": "3",
+			}
+
+			a, err := NewJiraAdapter(cfg)
+			if err != nil {
+				t.Fatalf("NewJiraAdapter (local endpoint) unexpected error: %v", err)
+			}
+			if a == nil {
+				t.Fatal("adapter is nil; a local endpoint must not block construction")
+			}
+
+			output := buf.String()
+			if strings.Contains(output, "level=WARN") {
+				t.Errorf("log output = %q, want no WARN line for a local endpoint", output)
+			}
+			if strings.Contains(output, "secret_tok") {
+				t.Errorf("log output leaked api_key: %q", output)
+			}
+		})
 	}
 }
 

--- a/internal/tracker/jira/jira_v2_test.go
+++ b/internal/tracker/jira/jira_v2_test.go
@@ -68,6 +68,11 @@ func TestNewJiraAdapter_APIVersion(t *testing.T) {
 			wantMsgSubs: []string{`"2"`, `"3"`},
 		},
 		{
+			name: "out-of-range whole float rejected", apiVersion: 1e20, present: true,
+			wantErr: true, wantKind: domain.ErrTrackerPayload,
+			wantMsgSubs: []string{`"2"`, `"3"`},
+		},
+		{
 			name: "non-coercible type rejected", apiVersion: []any{"2"}, present: true,
 			wantErr: true, wantKind: domain.ErrTrackerPayload,
 			wantMsgSubs: []string{`"2"`, `"3"`},

--- a/internal/tracker/jira/jira_v2_test.go
+++ b/internal/tracker/jira/jira_v2_test.go
@@ -241,6 +241,44 @@ func TestNewJiraAdapter_HostVersionGuard_RejectCloudV2(t *testing.T) {
 	}
 }
 
+// TestNewJiraAdapter_HostVersionGuard_RejectUnparseableEndpoint verifies
+// that an endpoint without a scheme and host is rejected at construction
+// with ErrTrackerPayload and a nil adapter. The guard runs for both API
+// versions, so the cases cover v2 and v3.
+func TestNewJiraAdapter_HostVersionGuard_RejectUnparseableEndpoint(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		endpoint string
+		apiKey   string
+		version  string
+	}{
+		{name: "scheme-less host on v3", endpoint: "not-a-url", apiKey: "user@test.com:tok", version: "3"},
+		{name: "scheme-less host on v2", endpoint: "not-a-url", apiKey: "pat_token_abc", version: "2"},
+		{name: "malformed scheme on v3", endpoint: "://bad", apiKey: "user@test.com:tok", version: "3"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := map[string]any{
+				"endpoint":    tt.endpoint,
+				"api_key":     tt.apiKey,
+				"project":     "P",
+				"api_version": tt.version,
+			}
+
+			a, err := NewJiraAdapter(cfg)
+			assertTrackerErrorKind(t, err, domain.ErrTrackerPayload)
+			if a != nil {
+				t.Error("adapter should be nil when the endpoint is not a URL with a scheme and host")
+			}
+		})
+	}
+}
+
 // TestNewJiraAdapter_HostVersionGuard_ConsistentCombos verifies the two
 // consistent (host, version) pairs construct successfully.
 func TestNewJiraAdapter_HostVersionGuard_ConsistentCombos(t *testing.T) {

--- a/internal/tracker/jira/normalize.go
+++ b/internal/tracker/jira/normalize.go
@@ -12,10 +12,18 @@ import (
 // inwardIssue produce a BlockerRef.
 const blockerLinkTypeName = "Blocks"
 
-// searchResponse represents GET /rest/api/3/search/jql response.
+// searchResponse represents the cursor-paginated search response.
 type searchResponse struct {
 	Issues        []jiraIssue `json:"issues"`
 	NextPageToken string      `json:"nextPageToken,omitempty"`
+}
+
+// searchResponseV2 represents the offset-paginated search response.
+type searchResponseV2 struct {
+	StartAt    int         `json:"startAt"`
+	MaxResults int         `json:"maxResults"`
+	Total      int         `json:"total"`
+	Issues     []jiraIssue `json:"issues"`
 }
 
 // jiraIssue represents a single issue in a search or issue-detail response.
@@ -99,13 +107,15 @@ type jiraComment struct {
 // normalizeSearchIssue maps a Jira API issue to a domain.Issue. The
 // endpoint is used to construct the browse URL. Labels are lowercased,
 // priority parsed as integer (nil on failure), and blocker refs
-// extracted from issuelinks.
-func normalizeSearchIssue(endpoint string, ji jiraIssue) domain.Issue {
+// extracted from issuelinks. The description body is extracted per
+// apiVersion: ADF is flattened on "3", the raw wiki-markup string is
+// preserved on "2".
+func normalizeSearchIssue(apiVersion, endpoint string, ji jiraIssue) domain.Issue {
 	issue := domain.Issue{
 		ID:          ji.ID,
 		Identifier:  ji.Key,
 		Title:       ji.Fields.Summary,
-		Description: flattenADF(unmarshalADF(ji.Fields.Description)),
+		Description: extractBody(apiVersion, ji.Fields.Description),
 		URL:         endpoint + "/browse/" + ji.Key,
 		CreatedAt:   ji.Fields.Created,
 		UpdatedAt:   ji.Fields.Updated,
@@ -162,14 +172,15 @@ func extractBlockers(links []jiraIssueLink) []domain.BlockerRef {
 }
 
 // normalizeComments maps Jira comment objects to domain.Comment
-// values. ADF bodies are flattened to plain text. Nil author fields
-// produce an empty author string.
-func normalizeComments(comments []jiraComment) []domain.Comment {
+// values. Comment bodies are extracted per apiVersion: ADF is
+// flattened on "3", the raw wiki-markup string is preserved on "2".
+// Nil author fields produce an empty author string.
+func normalizeComments(apiVersion string, comments []jiraComment) []domain.Comment {
 	source := make([]issuekit.SourceComment, len(comments))
 	for i, c := range comments {
 		source[i] = issuekit.SourceComment{
 			ID:        c.ID,
-			Body:      flattenADF(unmarshalADF(c.Body)),
+			Body:      extractBody(apiVersion, c.Body),
 			CreatedAt: c.Created,
 		}
 		if c.Author != nil {
@@ -177,6 +188,26 @@ func normalizeComments(comments []jiraComment) []domain.Comment {
 		}
 	}
 	return issuekit.NormalizeComments(source)
+}
+
+// extractBody returns the body text for a description or comment field
+// according to the API version. On version "2" the raw message is a
+// quoted JSON string carrying Jira wiki markup; it is decoded and
+// returned verbatim, with no markup translation. On any other version
+// the raw message is an ADF document, which is flattened to text.
+// Empty or invalid input yields an empty string.
+func extractBody(apiVersion string, raw json.RawMessage) string {
+	if apiVersion == "2" {
+		if len(raw) == 0 {
+			return ""
+		}
+		var s string
+		if err := json.Unmarshal(raw, &s); err != nil {
+			return ""
+		}
+		return s
+	}
+	return flattenADF(unmarshalADF(raw))
 }
 
 // unmarshalADF decodes a json.RawMessage into an any value suitable

--- a/internal/tracker/jira/normalize_test.go
+++ b/internal/tracker/jira/normalize_test.go
@@ -32,7 +32,7 @@ func TestNormalizeSearchIssue_AllFields(t *testing.T) {
 		},
 	}
 
-	issue := normalizeSearchIssue("https://test.atlassian.net", ji)
+	issue := normalizeSearchIssue("3", "https://test.atlassian.net", ji)
 
 	if issue.ID != "10001" {
 		t.Errorf("ID = %q, want %q", issue.ID, "10001")
@@ -99,7 +99,7 @@ func TestNormalizeSearchIssue_NilFields(t *testing.T) {
 		},
 	}
 
-	issue := normalizeSearchIssue("https://test.atlassian.net", ji)
+	issue := normalizeSearchIssue("3", "https://test.atlassian.net", ji)
 
 	if issue.State != "" {
 		t.Errorf("State = %q, want empty (nil status)", issue.State)
@@ -145,7 +145,7 @@ func TestNormalizeSearchIssue_NonIntegerPriority(t *testing.T) {
 			Priority: &jiraPriority{ID: "high"},
 		},
 	}
-	issue := normalizeSearchIssue("https://x.atlassian.net", ji)
+	issue := normalizeSearchIssue("3", "https://x.atlassian.net", ji)
 	if issue.Priority != nil {
 		t.Errorf("Priority = %v, want nil for non-integer id", issue.Priority)
 	}
@@ -187,7 +187,7 @@ func TestNormalizeSearchIssue_BlockerExtraction(t *testing.T) {
 		},
 	}
 
-	issue := normalizeSearchIssue("https://x.atlassian.net", ji)
+	issue := normalizeSearchIssue("3", "https://x.atlassian.net", ji)
 
 	if len(issue.BlockedBy) != 2 {
 		t.Fatalf("BlockedBy len = %d, want 2", len(issue.BlockedBy))
@@ -214,7 +214,7 @@ func TestNormalizeComments(t *testing.T) {
 				Created: "2025-01-01T00:00:00.000+0000",
 			},
 		}
-		result := normalizeComments(comments)
+		result := normalizeComments("3", comments)
 		if len(result) != 1 {
 			t.Fatalf("len = %d, want 1", len(result))
 		}
@@ -243,7 +243,7 @@ func TestNormalizeComments(t *testing.T) {
 				Created: "2025-01-01T00:00:00.000+0000",
 			},
 		}
-		result := normalizeComments(comments)
+		result := normalizeComments("3", comments)
 		if result[0].Author != "" {
 			t.Errorf("Author = %q, want empty for nil author", result[0].Author)
 		}
@@ -252,7 +252,7 @@ func TestNormalizeComments(t *testing.T) {
 	t.Run("empty list", func(t *testing.T) {
 		t.Parallel()
 
-		result := normalizeComments([]jiraComment{})
+		result := normalizeComments("3", []jiraComment{})
 		if result == nil {
 			t.Error("result is nil, want non-nil empty slice")
 		}
@@ -314,7 +314,7 @@ func TestNormalizeSearchIssue_EmptyLabelsSlice(t *testing.T) {
 			Labels: []string{},
 		},
 	}
-	issue := normalizeSearchIssue("https://x.atlassian.net", ji)
+	issue := normalizeSearchIssue("3", "https://x.atlassian.net", ji)
 	if issue.Labels == nil {
 		t.Error("Labels is nil, want non-nil empty slice")
 	}

--- a/internal/tracker/jira/normalize_v2_test.go
+++ b/internal/tracker/jira/normalize_v2_test.go
@@ -1,0 +1,225 @@
+package jira
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestExtractBody_V2 verifies the v2 branch returns the unquoted JSON
+// string verbatim and yields "" on empty or invalid input.
+func TestExtractBody_V2(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		raw  json.RawMessage
+		want string
+	}{
+		{name: "wiki markup verbatim", raw: json.RawMessage(`"h2. Title\n\n*bold* and {code}x{code}"`), want: "h2. Title\n\n*bold* and {code}x{code}"},
+		{name: "plain string verbatim", raw: json.RawMessage(`"just text"`), want: "just text"},
+		{name: "empty json string", raw: json.RawMessage(`""`), want: ""},
+		{name: "nil raw", raw: nil, want: ""},
+		{name: "empty raw", raw: json.RawMessage{}, want: ""},
+		{name: "non-string json object is invalid", raw: json.RawMessage(`{"type":"doc"}`), want: ""},
+		{name: "malformed json", raw: json.RawMessage(`"unterminated`), want: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := extractBody("2", tt.raw); got != tt.want {
+				t.Errorf("extractBody(2, %s) = %q, want %q", tt.raw, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestNormalizeSearchIssue_V2WikiMarkupRoundTrip is the binding AC2
+// assertion: a v2 description carrying wiki-markup tokens normalizes
+// into domain.Issue.Description byte-for-byte, not stripped to clean
+// prose.
+func TestNormalizeSearchIssue_V2WikiMarkupRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	const wiki = "h2. Goal\n\nMigrate the *auth* layer.\n\n{code}config.set(\"ldap\")\n{code}"
+	rawBody, err := json.Marshal(wiki)
+	if err != nil {
+		t.Fatalf("marshal wiki body: %v", err)
+	}
+
+	ji := jiraIssue{
+		ID:  "20001",
+		Key: "SRV-1",
+		Fields: jiraFields{
+			Summary:     "Migrate to LDAP auth",
+			Description: rawBody,
+		},
+	}
+
+	issue := normalizeSearchIssue("2", "https://jira.internal.example.com", ji)
+
+	if issue.Description != wiki {
+		t.Errorf("Description = %q, want verbatim wiki markup %q", issue.Description, wiki)
+	}
+	// Markup tokens must survive: the v2 path does not run ADF flattening.
+	for _, token := range []string{"h2.", "*auth*", "{code}"} {
+		if !strings.Contains(issue.Description, token) {
+			t.Errorf("Description = %q, want to retain wiki token %q", issue.Description, token)
+		}
+	}
+}
+
+// TestNormalizeComments_V2WikiMarkupRoundTrip mirrors the AC2 assertion
+// for comment bodies.
+func TestNormalizeComments_V2WikiMarkupRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	const wiki = "h3. Review\n\nLooks good. See {code}main.go{code} and *ship it*."
+	rawBody, err := json.Marshal(wiki)
+	if err != nil {
+		t.Fatalf("marshal wiki body: %v", err)
+	}
+
+	comments := []jiraComment{
+		{
+			ID:      "40001",
+			Author:  &jiraUser{DisplayName: "Bob Server"},
+			Body:    rawBody,
+			Created: "2025-02-05T10:00:00.000+0000",
+		},
+	}
+
+	result := normalizeComments("2", comments)
+	if len(result) != 1 {
+		t.Fatalf("len = %d, want 1", len(result))
+	}
+	if result[0].Body != wiki {
+		t.Errorf("Body = %q, want verbatim wiki markup %q", result[0].Body, wiki)
+	}
+	if result[0].Author != "Bob Server" {
+		t.Errorf("Author = %q, want Bob Server", result[0].Author)
+	}
+}
+
+// TestNormalizeSearchIssue_VersionIndependentFields asserts that
+// non-body normalization (labels, priority, blockers, timestamps,
+// parent, assignee, browse URL) is identical for v2 and v3 inputs.
+func TestNormalizeSearchIssue_VersionIndependentFields(t *testing.T) {
+	t.Parallel()
+
+	// v3 description is an ADF doc; v2 description is a raw string. Every
+	// other field is identical so the comparison isolates body handling.
+	makeIssue := func() jiraIssue {
+		return jiraIssue{
+			ID:  "10001",
+			Key: "PROJ-1",
+			Fields: jiraFields{
+				Summary:   "Test issue",
+				Status:    &jiraStatus{Name: "To Do"},
+				Priority:  &jiraPriority{ID: "2"},
+				Labels:    []string{"Feature", "Auth"},
+				Assignee:  &jiraUser{DisplayName: "Alice"},
+				IssueType: &jiraIssueType{Name: "Story"},
+				Parent:    &jiraParent{ID: "10000", Key: "PROJ-0"},
+				IssueLinks: []jiraIssueLink{
+					{
+						Type:        jiraLinkType{Name: "Blocks", Inward: "is blocked by"},
+						InwardIssue: &jiraLinkedIssue{ID: "10010", Key: "PROJ-10", Fields: &jiraLinkedIssueFields{Status: &jiraStatus{Name: "In Progress"}}},
+					},
+				},
+				Created: "2025-01-15T10:30:00.000+0000",
+				Updated: "2025-01-16T14:00:00.000+0000",
+			},
+		}
+	}
+
+	const endpoint = "https://test.example.com"
+
+	v3Issue := makeIssue()
+	v3Issue.Fields.Description = json.RawMessage(`{"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"ignored"}]}]}`)
+	v3 := normalizeSearchIssue("3", endpoint, v3Issue)
+
+	v2Issue := makeIssue()
+	v2Issue.Fields.Description = json.RawMessage(`"ignored"`)
+	v2 := normalizeSearchIssue("2", endpoint, v2Issue)
+
+	if v2.State != v3.State {
+		t.Errorf("State: v2 = %q, v3 = %q", v2.State, v3.State)
+	}
+	if (v2.Priority == nil) != (v3.Priority == nil) || (v2.Priority != nil && *v2.Priority != *v3.Priority) {
+		t.Errorf("Priority: v2 = %v, v3 = %v", v2.Priority, v3.Priority)
+	}
+	if v2.IssueType != v3.IssueType {
+		t.Errorf("IssueType: v2 = %q, v3 = %q", v2.IssueType, v3.IssueType)
+	}
+	if v2.Assignee != v3.Assignee {
+		t.Errorf("Assignee: v2 = %q, v3 = %q", v2.Assignee, v3.Assignee)
+	}
+	if v2.URL != v3.URL {
+		t.Errorf("URL: v2 = %q, v3 = %q", v2.URL, v3.URL)
+	}
+	if v2.CreatedAt != v3.CreatedAt || v2.UpdatedAt != v3.UpdatedAt {
+		t.Errorf("timestamps: v2 = (%q,%q), v3 = (%q,%q)", v2.CreatedAt, v2.UpdatedAt, v3.CreatedAt, v3.UpdatedAt)
+	}
+
+	if len(v2.Labels) != len(v3.Labels) {
+		t.Fatalf("Labels len: v2 = %d, v3 = %d", len(v2.Labels), len(v3.Labels))
+	}
+	for i := range v3.Labels {
+		if v2.Labels[i] != v3.Labels[i] {
+			t.Errorf("Labels[%d]: v2 = %q, v3 = %q", i, v2.Labels[i], v3.Labels[i])
+		}
+	}
+	if len(v2.BlockedBy) != len(v3.BlockedBy) {
+		t.Fatalf("BlockedBy len: v2 = %d, v3 = %d", len(v2.BlockedBy), len(v3.BlockedBy))
+	}
+	for i := range v3.BlockedBy {
+		if v2.BlockedBy[i] != v3.BlockedBy[i] {
+			t.Errorf("BlockedBy[%d]: v2 = %+v, v3 = %+v", i, v2.BlockedBy[i], v3.BlockedBy[i])
+		}
+	}
+	if (v2.Parent == nil) != (v3.Parent == nil) {
+		t.Fatalf("Parent presence: v2 = %v, v3 = %v", v2.Parent, v3.Parent)
+	}
+	if v2.Parent != nil && *v2.Parent != *v3.Parent {
+		t.Errorf("Parent: v2 = %+v, v3 = %+v", *v2.Parent, *v3.Parent)
+	}
+}
+
+// TestSearchResponseV2_Decode verifies the v2 search envelope decodes
+// its offset-pagination fields and inner issues.
+func TestSearchResponseV2_Decode(t *testing.T) {
+	t.Parallel()
+
+	raw := []byte(`{
+		"startAt": 50,
+		"maxResults": 50,
+		"total": 137,
+		"issues": [
+			{"id": "1", "key": "SRV-1", "fields": {"summary": "one"}},
+			{"id": "2", "key": "SRV-2", "fields": {"summary": "two"}}
+		]
+	}`)
+
+	var sr searchResponseV2
+	if err := json.Unmarshal(raw, &sr); err != nil {
+		t.Fatalf("unmarshal searchResponseV2: %v", err)
+	}
+	if sr.StartAt != 50 {
+		t.Errorf("StartAt = %d, want 50", sr.StartAt)
+	}
+	if sr.MaxResults != 50 {
+		t.Errorf("MaxResults = %d, want 50", sr.MaxResults)
+	}
+	if sr.Total != 137 {
+		t.Errorf("Total = %d, want 137", sr.Total)
+	}
+	if len(sr.Issues) != 2 {
+		t.Fatalf("Issues len = %d, want 2", len(sr.Issues))
+	}
+	if sr.Issues[0].Key != "SRV-1" || sr.Issues[1].Key != "SRV-2" {
+		t.Errorf("Issues keys = [%q %q], want [SRV-1 SRV-2]", sr.Issues[0].Key, sr.Issues[1].Key)
+	}
+}

--- a/internal/tracker/jira/testdata/comments_v2.json
+++ b/internal/tracker/jira/testdata/comments_v2.json
@@ -1,0 +1,19 @@
+{
+  "startAt": 0,
+  "maxResults": 50,
+  "total": 2,
+  "comments": [
+    {
+      "id": "40001",
+      "author": { "displayName": "Bob Server" },
+      "body": "h3. Review\n\nLooks good. See {code}main.go{code} and *ship it*.",
+      "created": "2025-02-05T10:00:00.000+0000"
+    },
+    {
+      "id": "40002",
+      "author": null,
+      "body": "Automated update: build passed.",
+      "created": "2025-02-05T12:00:00.000+0000"
+    }
+  ]
+}

--- a/internal/tracker/jira/testdata/search_v2_multi_page_1.json
+++ b/internal/tracker/jira/testdata/search_v2_multi_page_1.json
@@ -1,0 +1,33 @@
+{
+  "startAt": 0,
+  "maxResults": 2,
+  "total": 3,
+  "issues": [
+    {
+      "id": "21001",
+      "key": "SRV-11",
+      "fields": {
+        "summary": "First page issue one",
+        "status": { "name": "To Do" },
+        "labels": [],
+        "issuelinks": [],
+        "description": "",
+        "created": "2025-02-10T08:00:00.000+0000",
+        "updated": "2025-02-10T08:00:00.000+0000"
+      }
+    },
+    {
+      "id": "21002",
+      "key": "SRV-12",
+      "fields": {
+        "summary": "First page issue two",
+        "status": { "name": "To Do" },
+        "labels": [],
+        "issuelinks": [],
+        "description": "",
+        "created": "2025-02-10T09:00:00.000+0000",
+        "updated": "2025-02-10T09:00:00.000+0000"
+      }
+    }
+  ]
+}

--- a/internal/tracker/jira/testdata/search_v2_multi_page_2.json
+++ b/internal/tracker/jira/testdata/search_v2_multi_page_2.json
@@ -1,0 +1,20 @@
+{
+  "startAt": 2,
+  "maxResults": 2,
+  "total": 3,
+  "issues": [
+    {
+      "id": "21003",
+      "key": "SRV-13",
+      "fields": {
+        "summary": "Final partial page issue",
+        "status": { "name": "In Progress" },
+        "labels": [],
+        "issuelinks": [],
+        "description": "",
+        "created": "2025-02-10T10:00:00.000+0000",
+        "updated": "2025-02-10T10:00:00.000+0000"
+      }
+    }
+  ]
+}

--- a/internal/tracker/jira/testdata/search_v2_single_page.json
+++ b/internal/tracker/jira/testdata/search_v2_single_page.json
@@ -1,0 +1,50 @@
+{
+  "startAt": 0,
+  "maxResults": 50,
+  "total": 2,
+  "issues": [
+    {
+      "id": "20001",
+      "key": "SRV-1",
+      "fields": {
+        "summary": "Migrate to LDAP auth",
+        "status": { "name": "To Do" },
+        "priority": { "id": "2" },
+        "labels": ["Backend", "Auth"],
+        "assignee": { "displayName": "Bob Server" },
+        "issuetype": { "name": "Story" },
+        "parent": { "id": "20000", "key": "SRV-0" },
+        "issuelinks": [
+          {
+            "type": { "name": "Blocks", "inward": "is blocked by" },
+            "inwardIssue": {
+              "id": "20010",
+              "key": "SRV-10",
+              "fields": { "status": { "name": "In Progress" } }
+            }
+          }
+        ],
+        "description": "h2. Goal\n\nMigrate the *auth* layer.\n\n{code}config.set(\"ldap\")\n{code}",
+        "created": "2025-02-01T08:00:00.000+0000",
+        "updated": "2025-02-02T09:30:00.000+0000"
+      }
+    },
+    {
+      "id": "20002",
+      "key": "SRV-2",
+      "fields": {
+        "summary": "Fix offset pagination",
+        "status": { "name": "In Progress" },
+        "priority": { "id": "1" },
+        "labels": [],
+        "assignee": null,
+        "issuetype": { "name": "Bug" },
+        "parent": null,
+        "issuelinks": [],
+        "description": "",
+        "created": "2025-02-03T10:00:00.000+0000",
+        "updated": "2025-02-04T11:30:00.000+0000"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Feat

**Intent:** Extend the Jira adapter to support Jira Server and Data Center in addition to Jira Cloud. A new optional `tracker.api_version` config field (`"2"` or `"3"`, default `"3"`) selects the REST API variant at adapter construction time, enabling users running self-hosted Jira to connect without any adapter code changes.

**Related Issues:** #549

### 🧭 Reviewer Guide

**Complexity:** High

#### Entry Point

Start with `internal/tracker/jira/jira.go`. This file contains all the new construction logic: `normalizeAPIVersion`, `resolveAuth`, `checkHostVersion`, `isLocalEndpoint`, `basePath`, `paginatedSearchV2`, and `commentPayload`. The adapter struct gains `apiVersion` and `basePath` fields that drive every request path and body-format decision downstream.

#### Sensitive Areas

- `internal/tracker/jira/jira.go`: Auth header selection (`resolveAuth`) decides between Basic and Bearer based on the presence of a colon in `api_key` and the API version. The v2 colon-free path must produce `Bearer <token>` and must be rejected on v3. The host/version guard (`checkHostVersion`) blocks Cloud endpoints combined with `api_version "2"` and warns on non-Cloud, non-loopback endpoints combined with `"3"`. The new `isLocalEndpoint` helper suppresses the warning for `localhost` and loopback IPs since those are test/local-dev targets, not real Server/DC instances.
- `internal/tracker/jira/normalize.go`: `extractBody` switches between ADF flattening (v3) and raw JSON-string unquoting (v2). An incorrect branch here would pass raw ADF JSON or stripped wiki markup to the prompt template.
- `internal/config/config.go`: `buildTrackerConfig` now coerces bare YAML integers (e.g. `api_version: 2` without quotes) to their decimal string form via `coerceInt`. Without this, a Server/DC config written without quotes would reach the adapter as an empty string and be silently defaulted to v3.
- `internal/config/schema.go`: The `api_version` field follows the same `extractString` / `resolveEnvRef` / env-key-guard pattern as `in_progress_state`.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes. `api_version` defaults to `"3"`, preserving all existing Cloud behavior. Existing configs without the field are unaffected.
- **Migrations/State:** No migrations or state changes.