### PR TITLE
docs(decisions): add ADRs 0013 and 0014, mark 0011 as accepted

### DIFF
--- a/docs/decisions/0011-dispatch-rule-configuration.md
+++ b/docs/decisions/0011-dispatch-rule-configuration.md
@@ -1,5 +1,5 @@
 ---
-status: proposed
+status: accepted
 date: 2026-05-18
 decision-makers: Serghei Iakovlev
 ---

--- a/docs/decisions/0013-agent-cost-budget.md
+++ b/docs/decisions/0013-agent-cost-budget.md
@@ -1,0 +1,260 @@
+---
+status: accepted
+date: 2026-06-09
+decision-makers: Serghei Iakovlev
+---
+
+# Use cumulative per-issue token counts for the agent cost budget
+
+## Context and Problem Statement
+
+Sortie runs autonomous coding agents, and every run drives LLM calls that consume tokens and
+bill real money. The orchestrator already bounds how often it will work an issue: the
+`agent.max_sessions` limit counts completed sessions and stops re-dispatching once the count
+is reached. That governs the number of attempts, not their cost. A single session can consume
+an unbounded number of tokens, so a handful of cheap retries are capped while one runaway
+session is not.
+
+The data needed to govern cost already flows through the orchestrator. Agent adapters
+normalize each provider's reporting into `input_tokens`, `output_tokens`, `total_tokens`, and
+`cache_read_tokens`, and the orchestrator accumulates these counts per session. Nothing acts
+on them. There is no ceiling on consumption, and an agent has no way to ask how much budget it
+has left.
+
+This decision adds a cost budget denominated in tokens, with two surfaces. The advisory
+surface is a tool the agent queries mid-session to decide whether to skip an expensive step,
+return partial work, or hand off. The enforcing surface is a hard ceiling the orchestrator
+applies before re-dispatch, refusing to re-run an issue whose budget is spent. Because this is
+the first cost-control plane in the system, it also settles the questions every later cost
+feature inherits: the unit of account, the configuration surface, where cumulative spend is
+stored, how the new ceiling coexists with the session ceiling, and what the tool and the
+refusal report.
+
+## Decision Drivers
+
+1. **A ceiling on cost, not only on attempts.** The session limit bounds retries; one session
+   can still spend without limit. Operators need a cap on what an issue is allowed to cost.
+2. **Token prices are an external moving target.** Providers set per-model prices and change
+   them on their own schedule. A budget denominated in money would tie Sortie's correctness to
+   a pricing surface it neither controls nor can predict.
+3. **No runtime dependencies.** Sortie ships as a single statically-linked binary that makes no
+   outbound calls for its own bookkeeping. Pricing in money would require a maintained
+   per-model price table, forcing either a table that rots between releases or a network fetch
+   the deployment model forbids.
+4. **One mental model for budgets.** The session limit is a bare integer where `0` means
+   unlimited. A token budget that copies that shape, enforced on the same dispatch path, asks
+   the operator to learn nothing new.
+5. **The advisory and the enforcing surface must agree.** If the agent's view of remaining
+   budget and the orchestrator's refusal can diverge, the agent self-regulates against one
+   number while the orchestrator blocks on another. Both must report the same spend and the
+   same reason.
+6. **Cumulative spend needs a home.** Deciding the budget without deciding where the per-issue
+   total lives would defer a persistence question to implementation, where it surfaces as a
+   stalled change rather than a recorded choice.
+
+## Considered Options
+
+- **Option A.** A budget denominated in tokens, accumulated cumulatively per issue from token
+  columns on `run_history`, read by a read-only `cost_budget` tool and enforced by a token
+  ceiling on the same pre-dispatch path as the session ceiling.
+- **Option B.** A budget denominated in money, backed by a per-model price table embedded in
+  the binary or fetched at runtime.
+- **Option C.** A budget scoped to a single session, with no cumulative per-issue accounting.
+- **Option D.** A cumulative per-issue budget backed by a new per-session token table rather
+  than columns on `run_history`.
+
+## Decision Outcome
+
+Chosen option: **Option A**, because it caps real consumption, copies the proven session-limit
+model end to end, and keeps the reading tool free of any external dependency. Option B is
+deferred rather than rejected; Options C and D are rejected.
+
+### Budget unit: tokens
+
+The unit is the cumulative `total_tokens` reported by the adapter. A money unit is deferred to
+a separate future decision.
+
+The budget reads `total_tokens` as the adapter reports it. `cache_read_tokens` is retained for
+information but is not a second budget axis, and the budget never recomputes `total_tokens`
+from its components. Sortie does not define `cache_read_tokens` as either included in
+`total_tokens` or disjoint from it; the orchestrator treats the adapter's `total_tokens` as
+authoritative and tracks `cache_read_tokens` in a separate accumulator. The budget inherits
+that treatment rather than inventing a competing one.
+
+### Configuration: `agent.max_tokens`
+
+A new integer field, `agent.max_tokens`, sits beside `agent.max_sessions`. `0`, the default,
+means unlimited. It mirrors the session limit in every mechanical respect: parsed as an
+integer, rejected when negative, overridable through the `SORTIE_AGENT_MAX_TOKENS` environment
+variable, and re-read on live reload so a change takes effect at the next retry evaluation. A
+single scalar does not warrant a dedicated configuration block.
+
+### Budget scope and storage: cumulative per issue, in `run_history`
+
+The budget covers cumulative spend per issue across every session. That is what an operator
+means by a cost cap, and it closes the gap a per-session view leaves open, where each retry
+starts a fresh allowance and total spend climbs without limit.
+
+This total was not stored in any existing structure. `run_history` held one row per completed
+session but no token counts. `session_metadata` kept a single row per issue and overwrote it
+at each session's end, remembering only the latest session rather than the sum.
+`aggregate_metrics` was cumulative but global, with no per-issue breakdown.
+
+The decision records per-session token totals on `run_history` and sums them per issue:
+
+- A forward-only migration adds token columns to `run_history`, at minimum `total_tokens` and
+  the per-component counts for parity with what `session_metadata` already stores. Rows written
+  before the migration read as zero.
+- The session-exit path, which already writes the run-history row, fills the new columns from
+  the totals it holds at that point.
+- A per-issue token sum and a batch "which of these issues are over budget" query are added,
+  mirroring the session-count query the session limit already uses.
+
+`run_history` is the right home because it is already the per-session, per-issue ledger: the
+session limit already counts its rows, an existing per-issue index already serves these
+aggregates, and recording token sums there lets both budgets read from one table.
+
+### Coexistence and precedence with the session limit
+
+Both budgets are independent hard ceilings evaluated before re-dispatch. A re-dispatch is
+blocked when either ceiling is reached, so whichever fills first across polling cycles is the
+one that fires. When a single evaluation finds both exhausted, the reported and logged reason
+names the token budget. That precedence affects only which reason is reported; the block
+itself is identical whichever ceiling triggered it.
+
+The token check sits beside the session check on the same pre-dispatch path. When
+`agent.max_tokens` is set and the issue's summed tokens reach it, the orchestrator marks the
+issue exhausted, releases its claim, drops its retry entry, and declines to re-dispatch,
+exactly as the session check does, logged with structured attributes for the used and budgeted
+token counts. A failed token query fails open, matching the session check, so a transient
+database error never silently strands an issue. Both checks feed the single exhausted-issue
+set the dispatcher already consults, and the per-tick rebuild of that set accounts for both
+ceilings.
+
+### Tool contract and refusal record
+
+`cost_budget` reads local state and makes no outbound calls, the same read-only class as the
+existing `workspace_history` tool, and it registers the same way. It reports domain problems,
+such as state that is missing or unreadable, inside its JSON result; a returned error is
+reserved for internal faults.
+
+The result reports both ceilings so the agent sees its whole budget picture:
+
+```json
+{
+  "used_tokens": 0,
+  "budget_tokens": 0,
+  "remaining_tokens": null,
+  "used_sessions": 0,
+  "budget_sessions": 0
+}
+```
+
+- `used_tokens`: cumulative `total_tokens` for the issue across completed sessions, plus the
+  session currently running (see Consequences).
+- `budget_tokens`: the configured `agent.max_tokens`, where `0` means unlimited.
+- `remaining_tokens`: `budget_tokens` minus `used_tokens`, floored at zero, or `null` when the
+  budget is unlimited, so the agent can distinguish "no limit" from "nothing left".
+- `used_sessions`: completed sessions for the issue. The running session is not counted,
+  matching how the session limit counts.
+- `budget_sessions`: the configured `agent.max_sessions`, where `0` means unlimited.
+
+`used_sessions` excludes the running session while `used_tokens` includes it. The asymmetry is
+deliberate: a session is a discrete unit that is either finished or not, whereas tokens accrue
+continuously, and an advisory reading that ignored the running session's spend would be
+useless exactly when the agent consults it.
+
+A hard refusal must leave the same account the advisory tool would show. When the orchestrator
+blocks a re-dispatch, it records a structured, machine-readable reason, naming which ceiling
+fired together with the used and budgeted tokens and sessions, rather than only a log line.
+The advisory reading and the enforced refusal then explain the same block in the same terms.
+
+### Considered Options in Detail
+
+**Option B, a money unit, deferred.** Money needs a per-model price table kept current against
+prices Sortie does not set. Embedding the table stales the binary between releases; fetching it
+at runtime is exactly the outbound dependency the single-binary model rejects. Money also needs
+per-model token attribution the system does not record: the orchestrator counts requests per
+model, not tokens per model, so money is a strictly larger change than tokens rather than a
+relabeling of one. Tokens, by contrast, are provider-neutral, already normalized at the adapter
+boundary, already accumulated, and already the unit operators know from the session limit.
+Money can return as its own decision once a pricing strategy and per-model token attribution
+exist to support it.
+
+**Option C, a per-session budget, rejected.** A per-session cap leaves cumulative spend
+unbounded: each retry begins a fresh allowance, so an issue can cost arbitrarily much across
+enough sessions. Bounding that is the entire purpose of this decision.
+
+**Option D, a separate per-session token table, rejected.** `run_history` is already the
+per-session, per-issue ledger, the session limit already counts its rows, and its per-issue
+index already serves these aggregates. A second table duplicates that ledger and splits the
+two budgets across two stores for nothing in return.
+
+A dedicated `cost` configuration block was also considered and rejected: a single integer does
+not justify it, and with money deferred there is no richer pricing structure to hold.
+
+## Consequences
+
+### Positive
+
+- A runaway session is bounded. The cost gap the session limit cannot reach is closed.
+- Operators carry one mental model across both budgets: a bare integer, `0` for unlimited,
+  enforced on the same dispatch path.
+- Both budgets read one table and feed one exhausted-issue set. No second store, no second gate.
+- The reading tool stays free of outbound calls, so the single-binary deployment is untouched.
+- The agent's advisory view and the orchestrator's enforcement report the same numbers and the
+  same reason.
+
+### Negative
+
+- **A schema migration is required.** The migration adds token columns to `run_history`, the
+  session-exit path must populate them, and restart recovery must tolerate rows that predate
+  the migration. Spend recorded before the migration reads as zero and is invisible to the
+  budget.
+- **The session-metadata write cadence changes.** This consequence carries the most weight. The
+  tool runs in a separate, read-only sidecar process with its own database connection and no
+  access to the orchestrator's memory, and `session_metadata` is written only when a session
+  ends. A tool reading only the database therefore cannot see the spend of the session
+  currently running; on a first session it would always read zero used tokens, which strips the
+  advisory surface of its purpose. The running session's spend must be made visible to the
+  tool. The intended mechanism writes `session_metadata` incrementally during the session,
+  throttled and driven by the usage events already arriving, so the tool can add the running
+  session's recorded total to the per-issue sum, keyed to the session identifier the tool
+  already receives so a stale earlier session is never added. No double count arises, because
+  the running session reaches `run_history` only when it ends. This turns `session_metadata`
+  from a written-once-at-exit record into a live one, a change to an existing write path rather
+  than an additive one.
+- **No exhaustion metric in the first version.** The session limit emits no metric when it
+  trips, and tool calls are already counted generically by `sortie_tool_calls_total`. For parity
+  and a smaller surface, the token budget emits no exhaustion metric either. If such a counter
+  is wanted later, it should be added for both budgets together, across the metric definitions,
+  the example dashboard, and its coverage test, so the two budgets stay symmetric.
+- **Documentation owes an update on acceptance.** Accepting this decision obliges edits to the
+  configuration reference for `agent.max_tokens`, the architecture specification covering the
+  effort budget, the persistence schema, and the agent-tool catalog, and the workflow
+  reference. The edits are mechanical, but skipping them leaves the specification contradicting
+  the code.
+
+## Confirmation
+
+The decision is satisfied when all of the following hold:
+
+1. `agent.max_tokens` parses as an integer, defaults to `0`, rejects negative values with a
+   configuration error that names the field, honors the `SORTIE_AGENT_MAX_TOKENS` override, and
+   re-applies on live reload.
+2. A forward-only migration adds the token column or columns to `run_history`, and the
+   session-exit path populates `total_tokens`, and the per-component counts when present, as it
+   writes the run-history row.
+3. A per-issue token sum and a batch over-budget query exist and mirror the session-count query
+   the session limit uses.
+4. Before re-dispatch, the orchestrator blocks an issue whose summed tokens have reached a
+   non-zero `agent.max_tokens`: it marks the issue exhausted, releases the claim, drops the
+   retry entry, and fails open on a query error. The per-tick rebuild of the exhausted-issue set
+   accounts for both ceilings.
+5. `cost_budget` reads only local state, makes no outbound calls, returns the five-field result
+   with `remaining_tokens` reported as `null` under an unlimited budget, and reports domain
+   problems inside the result rather than as a returned error.
+6. While a session is running and before its `run_history` row exists, the tool reports a
+   `used_tokens` value that includes the running session's spend.
+7. A server-side refusal records a machine-readable reason that matches the advisory reading,
+   and when both ceilings are exhausted in one evaluation the reason names the token budget.

--- a/docs/decisions/0014-operator-notifications.md
+++ b/docs/decisions/0014-operator-notifications.md
@@ -1,0 +1,274 @@
+---
+status: accepted
+date: 2026-06-09
+decision-makers: Serghei Iakovlev
+---
+
+# Use an adapter family for operator notifications
+
+## Context and Problem Statement
+
+While an agent runs, it cannot reach a human in real time. Its existing outbound surfaces
+both travel to the orchestrator, not to a person: it can write a line to a `.sortie/status`
+file that the orchestrator reads after a turn, and it can emit a normalized `notification`
+event that the orchestrator logs. Both surface only when someone inspects the logs or state.
+An agent that hits a decision it should not make alone, or wants to flag progress or a
+blocker, has no way to raise a hand while the work is happening. This decision adds that
+missing surface: a real-time channel from the agent to a human operator, exposed as a
+`notify_operator` tool.
+
+The narrow way to build it is to give the tool a Slack call, and perhaps a generic HTTP
+call. That framing asks "which backends do we support," and it is a trap: a fixed set baked
+into the tool means every later channel (email, Discord, PagerDuty, SMS) reopens the tool and
+reopens this decision. Sortie already integrates every external dimension (issue trackers,
+coding agents, CI providers, source-control backends) as an adapter family: a domain
+interface, implementations in their own packages that register themselves under a `kind`
+string, and a registry the core resolves through. Adding a tracker or an agent is a new
+package, never a core change. Notifications take the same shape, so the real decision is the
+contract for a notification adapter family, not a list of channels.
+
+A second fact constrains the design. Agent tools do not run inside the orchestrator. They run
+in a separate `sortie mcp-server` process that the agent runtime launches for the session and
+that exits when its input closes. That process receives exactly two things from the
+orchestrator: the path to the workflow file, and the orchestrator's `SORTIE_`-prefixed
+environment variables. Any configuration the tool needs must arrive through the workflow file,
+and any secret must arrive through a `SORTIE_`-prefixed variable. A separate configuration
+file has nowhere to land.
+
+## Decision Drivers
+
+1. **The agent has no real-time channel to a human.** The status file and the notification
+   event reach the orchestrator and surface only on inspection, so an agent cannot escalate a
+   decision or raise a blocker mid-session.
+2. **New channels must be additive.** Adding email, Discord, PagerDuty, or SMS later must be a
+   new package behind an existing interface, not a rewrite of the tool and not a fresh
+   architecture decision. This is the extensibility the tracker and agent families already
+   provide.
+3. **The tool runs in a separate, per-session process.** It receives only the workflow file
+   path and the orchestrator's `SORTIE_`-prefixed variables, then dies when the session ends.
+   Configuration and secrets must travel by those two channels.
+4. **This decision introduces Sortie's first arbitrary outbound HTTP.** Posting to an
+   operator-supplied URL carrying a secret is a new egress and secret-handling surface, and
+   Sortie has no facility for redacting secrets from its logs.
+5. **A notification must be correlatable.** A bare severity-title-body message cannot tell an
+   operator which issue or session it concerns, nor can a machine consumer route it. The
+   payload must carry session context the agent cannot forge.
+6. **An adjacent output surface already exists.** The orchestrator already posts lifecycle
+   comments to a tracker issue. The notification design must not collide with it and must
+   leave a future merge additive.
+
+## Considered Options
+
+- **Option A.** Model notifications as an adapter family: a `Notifier` domain interface,
+  backends in `internal/notify/<kind>/` packages that self-register into a
+  `registry.Notifiers`, and a thin Tier 2 `notify_operator` tool that resolves the configured
+  backends and calls `Send`. v1 ships a `webhook` backend and a `slack` backend.
+- **Option B.** Hardcode the backends (Slack, generic HTTP) inside the `notify_operator` tool.
+- **Option C.** Load notification backends as dynamic plugins.
+
+## Decision Outcome
+
+Chosen option: **Option A**, because it makes every future channel an additive package behind
+a stable interface, reuses the registry and conditional-registration patterns the tracker and
+agent families already prove, and keeps the agent-facing tool ignorant of any specific
+backend. Options B and C are rejected below.
+
+### Notifications are an adapter family
+
+A domain interface `Notifier` exposes one method, `Send(ctx, Notification) error`. Each
+backend is a package under `internal/notify/<kind>/` that implements `Notifier` and registers
+itself in `init()` into a process-global `registry.Notifiers` under its `kind` string, exactly
+as the tracker, agent, CI, and source-control families register. These packages obey the same
+boundary rules as the other families: no cross-adapter imports, no orchestrator imports,
+normalization to the domain type at the boundary, and generic vocabulary in the core
+(`notifier_*`, never `slack_*`).
+
+The `notify_operator` tool is a thin Tier 2 wrapper. It resolves the configured backends from
+the registry by `kind` and calls `Send`; it knows nothing about Slack or HTTP. Fixing this
+contract once, the interface, the registry, the normalized `Notification`, the tool, and the
+configuration shape, makes a new channel a new package plus its `init()` registration, with no
+change to the tool, the core, or this decision.
+
+### Configuration: a `notifications` list in the workflow file
+
+Backends are configured by a top-level `notifications` section in the workflow file, a list of
+entries, each carrying a `kind` discriminator and that backend's own fields. The workflow file
+is the only configuration channel that reaches the sidecar, so the section lives there.
+
+The section is a list, not a single object, so a second channel is a second list entry rather
+than a change to the section's shape. Reshaping a populated configuration section is the
+breaking rewrite this design exists to avoid; the existing `dispatch.rules` list is the
+precedent. Per-backend fields pass through the same adapter-passthrough mechanism the tracker
+and agent sections already use, rather than being enumerated in the core configuration schema,
+so a new backend's fields (an SMTP host, a routing key) need no core-schema change.
+
+A backend secret is given as a reference to a `SORTIE_`-prefixed environment variable, the same
+`$VAR` resolution the tracker API key uses. The prefix is mandatory, not stylistic: the sidecar
+re-resolves the workflow file in its own process, and only `SORTIE_`-prefixed variables reach
+it, so a reference without the prefix resolves to an empty string there and posts nowhere.
+
+### v1 backends: `webhook` and `slack`
+
+v1 ships two members of the family. `webhook` posts the notification as JSON to a configured
+URL. `slack` posts the same content shaped for a Slack incoming webhook. A Slack incoming
+webhook is itself an HTTP POST of JSON, so the two share almost all of their code and differ
+only in how they render the body; shipping both is nearly free and immediately covers Discord,
+Teams, and custom endpoints through `webhook`. Each backend builds on the shared HTTP client
+with its configured endpoint as the base URL, classifies its own transport and API errors, and
+applies a mandatory per-call timeout, which a Tier 2 tool requires.
+
+Email and other transports are deliberately out of v1. Email is a different transport (SMTP,
+TLS, MIME) with no precedent in the code, and the adapter family makes it a later additive
+package rather than a question this decision must answer.
+
+### Notification payload: an envelope plus a message
+
+The normalized `Notification` has two layers, and every backend consumes the same shape.
+
+The envelope is filled by the tool from the session context; the agent neither provides it nor
+can override it. It carries the issue identifier and internal id, the session id, the attempt
+number, the agent kind, a generated unique id, an ISO-8601 UTC timestamp, and a configurable
+`source` identifying the Sortie instance, defaulting to the hostname. The message is supplied
+by the agent: a `severity` (`info`, `warning`, or `critical`), a `title`, a `body`, and an
+optional `category` (`decision_needed`, `progress`, `blocked`, `completed`, or `other`).
+
+A severity-title-body message alone is not enough. A "blocked, need a decision" notification
+with no issue identifier or session id is nearly useless to an operator and uncorrelatable to a
+machine consumer. The session context already lives in the sidecar's environment, so the tool
+fills the envelope from it rather than trusting the agent to repeat it; a system-owned envelope
+also stops an agent from attributing a notification to another issue. Carrying the whole known
+session context from the start, rather than a flat message that later needs correlation bolted
+on, keeps foreseeable additions (an issue URL, severity-based routing) additive fields rather
+than a schema change.
+
+### Rate limiting: a per-session in-memory cap
+
+The tool enforces a per-session ceiling on the number of notifications, a configurable
+`max_per_session` with a sane default. Exceeding it is a domain error in the JSON result
+(`rate_limited`), not a transport failure. The counter lives in memory in the tool instance:
+the sidecar exists for exactly one session, so an in-memory counter needs neither persistence
+nor cross-process coordination. A value of `0` selects the default, not unlimited, so the spam
+guard cannot be disabled by omission.
+
+### No configured backend, no tool
+
+If the `notifications` section is empty or absent, `notify_operator` is not registered, the
+same gate the tracker tool uses when no project is configured. An unregistered tool never
+appears in the agent's tool listing or its prompt, so the agent is never offered a tool it
+cannot use. The registration is derived from the workflow file so that the sidecar's tool set
+matches what the main process advertises.
+
+### Boundary with orchestrator lifecycle comments
+
+Sortie already has an outbound, opt-in surface: the orchestrator posts plain-text comments to a
+tracker issue on dispatch, completion, and failure, and during CI, review, and auto-merge
+reconciliation, gated by `tracker.comments.*`. It shares a genus with notifications, an
+outbound, opt-in, stakeholder-addressed message about a session, but differs on every
+operational axis. The orchestrator initiates it, not the agent; it runs in the main process,
+not the sidecar; deterministic lifecycle events trigger it, not agent discretion; and it
+targets a tracker already behind an adapter.
+
+v1 does not merge the two. Tracker comments are working code outside this decision's scope,
+their surface is broader than notifications, and folding a tracker that is already an adapter
+into a notifier now is coupling without payoff. Premature unification, before the second
+mechanism even exists, is itself the anti-pattern.
+
+The design does keep the merge additive. `Notifier.Send` takes a self-contained `Notification`:
+the whole context rides in the envelope, with no dependency on state available only in the
+sidecar. The producer fills the envelope. In the sidecar the tool fills it from the
+environment; a future orchestrator producer would fill it from its own state. Because the
+registry is process-global, both processes resolve backends identically. The target picture,
+left to a later decision, is notifiers as a single egress with two producers, the agent through
+`notify_operator` and the orchestrator through lifecycle events, at which point a tracker
+comment becomes one more notifier. Binding `Send` to sidecar-only context now would foreclose
+that, so the interface is defined to forbid it. This convergence is an explicit non-goal for
+v1.
+
+### Considered Options in Detail
+
+**Option B (hardcode backends in the tool).** Embedding Slack and HTTP inside `notify_operator`
+works for v1, but every later channel reopens the tool, and, since this decision sets the
+precedent for notification backends, reopens the architecture decision too. That is precisely
+the rewrite-per-channel cost the adapter family removes. The literal "which backends" framing
+produces this option; treating backends as a family dissolves the question.
+
+**Option C (dynamic plugins).** Loading backends as plugins keeps the core untouched but
+reintroduces the fragility the adapter families were chosen to avoid: a brittle binary
+interface, platform limits, and a break in the single statically-linked binary Sortie ships.
+Compile-time adapters give the same extensibility without the operational cost.
+
+**A flat message with no envelope** was rejected as the payload: it drops correlation, leaving
+notifications useless to operators and uncorrelatable to machines, and pushes formatting onto
+the agent. **A single configuration object** instead of a list was rejected because a second
+channel would force a breaking reshape. **A separate configuration file** was rejected because
+nothing delivers it to the sidecar.
+
+## Consequences
+
+### Positive
+
+- A new channel is a new package plus an `init()` registration. The contract is fixed once,
+  and neither the tool nor the core changes.
+- The tool reuses proven patterns: the adapter registry, conditional registration only when
+  configured, and the Tier 2 error contract that encodes domain failures in the result.
+- Notifications are correlatable: the system-owned envelope carries issue, session, and attempt
+  context the agent cannot forge.
+- Convergence with the orchestrator's lifecycle comments stays additive, because `Notifier.Send`
+  consumes a self-contained `Notification` that either process can produce.
+
+### Negative
+
+- **Secrets must be `SORTIE_`-prefixed.** A backend secret named without the prefix resolves to
+  an empty string in the sidecar and posts nowhere. This is a framework constraint, not a
+  preference, and belongs in the workflow reference beside the `notifications` section.
+- **First arbitrary outbound HTTP.** The tool posts to an operator-supplied URL carrying a
+  secret. Sortie has no secret-redaction facility in its logging, so the backends MUST NOT log
+  webhook URLs, request bodies, or responses, and each call MUST carry a timeout. The operator
+  URL is trusted, but the egress is real: the sidecar reaches the network with the agent's
+  access.
+- **The agent kind needs one additive propagation.** The sidecar's per-session environment
+  carries the issue id and identifier, the session id, the workspace, the database path, and
+  the attempt, but not the agent kind. The envelope's agent kind requires adding the session's
+  agent to that environment, and the value MUST be the agent frozen at dispatch (the one
+  actually running the session), not the workflow's default, because a routing rule can select
+  a different agent.
+- **The rate-limit counter is per-process.** If the agent runtime restarts the sidecar
+  mid-session, the in-memory counter resets. This is a rare edge and an accepted limit of a
+  per-session in-memory guard.
+- **A naming clash to keep apart.** "Webhook" already names the inbound tracker webhooks that
+  trigger reconciliation. The `webhook` notification backend is an outbound POST and is a
+  distinct concept; documentation must not conflate them.
+- **Documentation owes updates on acceptance.** The workflow reference gains the `notifications`
+  section and the `SORTIE_`-prefixed secret rule; the architecture specification gains one
+  section describing the notifier family (interface, registry, normalized type, tool); and the
+  tool catalog gains `notify_operator`.
+- **No new metric in v1.** Tool calls, notification sends included, are already counted by the
+  existing per-tool counter with a success-or-error result label, so a delivery failure already
+  shows up. A dedicated counter, if wanted later, should be added with its dashboard and
+  coverage in one change.
+
+## Confirmation
+
+The decision is satisfied when all of the following hold:
+
+1. A `Notifier` interface and a normalized `Notification` type live in the domain package, and
+   `registry.Notifiers` registers backends by `kind`, mirroring the other adapter families.
+2. `internal/notify/webhook` and `internal/notify/slack` each implement `Notifier`,
+   self-register in `init()`, build on the shared HTTP client with the configured endpoint as
+   base URL, classify their own errors, and apply a per-call timeout.
+3. A top-level `notifications` list parses from the workflow file with a required `kind` per
+   entry and per-backend fields carried through adapter passthrough rather than the core schema.
+4. `notify_operator` validates its input against a schema that rejects unknown fields, fills the
+   envelope from session context the agent cannot set, validates `severity` and `category`
+   against their enums, requires a non-empty `title` and `body`, and encodes domain failures
+   (`invalid_input`, `rate_limited`, `send_failed`, `backend_unavailable`) in the JSON result
+   rather than as a Go error.
+5. `notify_operator` is registered only when at least one valid backend is configured, and the
+   registration is derived from the workflow file so the sidecar and the main process agree on
+   the tool set.
+6. A secret referenced without the `SORTIE_` prefix is documented as unsupported, and no backend
+   logs URLs, request bodies, or responses.
+7. The per-session notification count is capped by `max_per_session`, where `0` selects the
+   default rather than unlimited.
+8. `Notifier.Send` takes a self-contained `Notification` whose envelope is filled by the
+   producer, so a future orchestrator producer can reuse the family without an interface change.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -5,16 +5,19 @@ This directory contains architecturally significant decisions for Sortie, docume
 
 ## Decisions
 
-| ADR                                              | Title                                                            | Status   |
-| ------------------------------------------------ | ---------------------------------------------------------------- | -------- |
-| [0001](0001-use-go-as-core-runtime.md)           | Use Go as core runtime                                           | Accepted |
-| [0002](0002-use-sqlite-for-persistence.md)       | Use SQLite for persistence                                       | Accepted |
-| [0003](0003-adapter-based-integration.md)        | Use adapter interfaces for integration extensibility             | Accepted |
-| [0004](0004-workflow-file-format.md)             | Use YAML Front Matter for Workflow Files                         | Accepted |
-| [0005](0005-prompt-template-engine.md)           | Use Go text/template for Prompt Rendering                        | Accepted |
-| [0006](0006-use-fsnotify-for-file-watching.md)   | Use fsnotify for Filesystem Event Watching                       | Accepted |
-| [0007](0007-handoff-state-and-tracker-writes.md) | Use Handoff State Transitions to Signal Agent Completion         | Accepted |
-| [0008](0008-observability-model.md)              | Use Embedded Dashboard with Prometheus Metrics for Observability | Accepted |
-| [0009](0009-mcp-stdio-sidecar-for-tool-execution.md) | Use MCP stdio sidecar for agent tool execution               | Accepted |
-| [0010](0010-keep-tracker-adapter-unified.md)         | Keep TrackerAdapter as a Unified Interface                    | Accepted |
-| [0011](0011-dispatch-rule-configuration.md)          | Use First-Match-Wins Dispatch Rules in WORKFLOW.md Front Matter | Proposed |
+| ADR                                                  | Title                                                             | Status   |
+| ---------------------------------------------------- | ----------------------------------------------------------------- | -------- |
+| [0001](0001-use-go-as-core-runtime.md)               | Use Go as core runtime                                            | Accepted |
+| [0002](0002-use-sqlite-for-persistence.md)           | Use SQLite for persistence                                        | Accepted |
+| [0003](0003-adapter-based-integration.md)            | Use adapter interfaces for integration extensibility              | Accepted |
+| [0004](0004-workflow-file-format.md)                 | Use YAML Front Matter for Workflow Files                          | Accepted |
+| [0005](0005-prompt-template-engine.md)               | Use Go `text/template` for Prompt Rendering                       | Accepted |
+| [0006](0006-use-fsnotify-for-file-watching.md)       | Use `fsnotify` for Filesystem Event Watching                      | Accepted |
+| [0007](0007-handoff-state-and-tracker-writes.md)     | Use Handoff State Transitions to Signal Agent Completion          | Accepted |
+| [0008](0008-observability-model.md)                  | Use Embedded Dashboard with Prometheus Metrics for Observability  | Accepted |
+| [0009](0009-mcp-stdio-sidecar-for-tool-execution.md) | Use MCP stdio sidecar for agent tool execution                    | Accepted |
+| [0010](0010-keep-tracker-adapter-unified.md)         | Keep TrackerAdapter as a Unified Interface                        | Accepted |
+| [0011](0011-dispatch-rule-configuration.md)          | Use First-Match-Wins Dispatch Rules in `WORKFLOW.md` Front Matter | Accepted |
+| [0012](0012-auto-merge-reaction.md)                  | Extend `SCMAdapter` with Write Methods for Auto-Merge Reactions   | Accepted |
+| [0013](0013-agent-cost-budget.md)                    | Use cumulative per-issue token counts for the agent cost budget   | Accepted |
+| [0014](0014-operator-notifications.md)               | Use an adapter family for operator notifications                  | Accepted |


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Chore

**Intent:** Record two architecture decisions produced by the research task for the cost-budget and operator-notification features, and advance ADR-0011 from proposed to accepted now that dispatch-rule configuration is implemented.

**Related Issues:** #556, #240, #242

### 🧭 Reviewer Guide

**Complexity:** Low

#### Entry Point

`docs/decisions/0013-agent-cost-budget.md` - The most consequential new record. It defines the unit of account (`total_tokens`), the `agent.max_tokens` configuration field, where cumulative spend is stored (`run_history` columns), the `cost_budget` tool contract, and how the token ceiling coexists with the existing session ceiling. Read this before `0014`.

#### Sensitive Areas

- `docs/decisions/0013-agent-cost-budget.md`: Specifies a schema migration (new columns on `run_history`), a write-path change to `session_metadata` (incremental writes during a session), and the exact JSON shape the `cost_budget` tool must return - all correctness-critical for the follow-on implementation.
- `docs/decisions/0014-operator-notifications.md`: Introduces the first arbitrary outbound HTTP from the sidecar. The constraints on secret naming (`SORTIE_`-prefix mandatory), backend logging prohibitions, and per-call timeouts are security-relevant.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes
- **Migrations/State:** No migrations or state changes (ADR-0013 records that a migration will be required in the implementing PR, not here)