### PR TITLE
feat: add cost_budget agent tool and token budget enforcement

### DIFF
--- a/cmd/sortie/mcpserver.go
+++ b/cmd/sortie/mcpserver.go
@@ -15,6 +15,7 @@ import (
 	"github.com/sortie-ai/sortie/internal/logging"
 	"github.com/sortie-ai/sortie/internal/persistence"
 	"github.com/sortie-ai/sortie/internal/registry"
+	"github.com/sortie-ai/sortie/internal/tool/budget"
 	"github.com/sortie-ai/sortie/internal/tool/history"
 	"github.com/sortie-ai/sortie/internal/tool/mcpserver"
 	"github.com/sortie-ai/sortie/internal/tool/status"
@@ -110,6 +111,8 @@ func runMCPServer(ctx context.Context, args []string, stdout io.Writer, stderr i
 			} else {
 				defer store.Close() //nolint:errcheck // best-effort cleanup at shutdown
 				toolRegistry.Register(history.New(buildHistoryQuery(store), issueID))
+				runningSessionID := os.Getenv("SORTIE_SESSION_ID")
+				toolRegistry.Register(budget.New(buildBudgetQuery(store), issueID, runningSessionID, cfg.Agent.MaxTokens, cfg.Agent.MaxSessions))
 			}
 		}
 	}
@@ -121,6 +124,36 @@ func runMCPServer(ctx context.Context, args []string, stdout io.Writer, stderr i
 	}
 
 	return 0
+}
+
+func buildBudgetQuery(store *persistence.Store) budget.BudgetQueryFunc {
+	return func(ctx context.Context, issueID string, runningSessionID string) (budget.BudgetUsage, error) {
+		completedTotal, completedSessions, err := store.SumTotalTokensByIssue(ctx, issueID)
+		if err != nil {
+			return budget.BudgetUsage{}, err
+		}
+
+		usage := budget.BudgetUsage{
+			CompletedTotalTokens: completedTotal,
+			CompletedSessions:    completedSessions,
+		}
+
+		// The running session's recorded spend lives in session_metadata,
+		// which survives session exit. Add it only when the stored
+		// session ID matches the live session ID supplied out of band, so
+		// a stale earlier session's row is never double counted.
+		if runningSessionID == "" {
+			return usage, nil
+		}
+		meta, found, err := store.LoadSessionMetadata(ctx, issueID)
+		if err != nil {
+			return budget.BudgetUsage{}, err
+		}
+		if found && meta.SessionID == runningSessionID {
+			usage.RunningTotalTokens = meta.TotalTokens
+		}
+		return usage, nil
+	}
 }
 
 func buildHistoryQuery(store *persistence.Store) history.QueryFunc {

--- a/cmd/sortie/mcpserver_test.go
+++ b/cmd/sortie/mcpserver_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -12,6 +13,7 @@ import (
 	"time"
 
 	"github.com/sortie-ai/sortie/internal/domain"
+	"github.com/sortie-ai/sortie/internal/persistence"
 	"github.com/sortie-ai/sortie/internal/tool/mcpserver"
 	"github.com/sortie-ai/sortie/internal/tool/status"
 )
@@ -203,4 +205,135 @@ func TestMCPServerShortHelp(t *testing.T) {
 	if stderr.Len() != 0 {
 		t.Errorf("runMCPServer([-h]) stderr = %q, want empty", stderr.String())
 	}
+}
+
+// seedBudgetStore creates a migrated SQLite database with two completed
+// run_history rows (400 + 200 total tokens) for issue "iss-1" and a
+// session_metadata row for the live session "sess-live" carrying 150 total
+// tokens, then reopens it read-only as the sidecar does.
+func seedBudgetStore(t *testing.T) *persistence.Store {
+	t.Helper()
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "budget.db")
+
+	rw, err := persistence.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("Open(%q): %v", dbPath, err)
+	}
+	if err := rw.Migrate(ctx); err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+
+	for i, total := range []int64{400, 200} {
+		run := persistence.RunHistory{
+			IssueID:      "iss-1",
+			Identifier:   "PROJ-1",
+			Attempt:      i + 1,
+			AgentAdapter: "mock",
+			Workspace:    "/tmp/ws/PROJ-1",
+			StartedAt:    fmt.Sprintf("2026-03-19T10:%02d:00Z", i),
+			CompletedAt:  fmt.Sprintf("2026-03-19T10:%02d:30Z", i),
+			Status:       "succeeded",
+			TotalTokens:  total,
+		}
+		if _, err := rw.AppendRunHistory(ctx, run); err != nil {
+			t.Fatalf("AppendRunHistory(attempt %d): %v", i+1, err)
+		}
+	}
+
+	meta := persistence.SessionMetadata{
+		IssueID:     "iss-1",
+		SessionID:   "sess-live",
+		TotalTokens: 150,
+		UpdatedAt:   "2026-03-19T10:02:00Z",
+	}
+	if err := rw.UpsertSessionMetadata(ctx, meta); err != nil {
+		t.Fatalf("UpsertSessionMetadata: %v", err)
+	}
+
+	if err := rw.Close(); err != nil {
+		t.Fatalf("Close read-write store: %v", err)
+	}
+
+	ro, err := persistence.OpenReadOnly(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("OpenReadOnly(%q): %v", dbPath, err)
+	}
+	t.Cleanup(func() {
+		if err := ro.Close(); err != nil {
+			t.Errorf("Close read-only store: %v", err)
+		}
+	})
+	return ro
+}
+
+func TestBuildBudgetQuery(t *testing.T) {
+	t.Parallel()
+
+	t.Run("matching running session id adds running total", func(t *testing.T) {
+		t.Parallel()
+
+		query := buildBudgetQuery(seedBudgetStore(t))
+
+		usage, err := query(context.Background(), "iss-1", "sess-live")
+		if err != nil {
+			t.Fatalf("buildBudgetQuery query: %v", err)
+		}
+		if usage.CompletedTotalTokens != 600 {
+			t.Errorf("CompletedTotalTokens = %d, want 600", usage.CompletedTotalTokens)
+		}
+		if usage.CompletedSessions != 2 {
+			t.Errorf("CompletedSessions = %d, want 2", usage.CompletedSessions)
+		}
+		if usage.RunningTotalTokens != 150 {
+			t.Errorf("RunningTotalTokens = %d, want 150 (session_id matches)", usage.RunningTotalTokens)
+		}
+	})
+
+	t.Run("stale session row with different id is excluded", func(t *testing.T) {
+		t.Parallel()
+
+		query := buildBudgetQuery(seedBudgetStore(t))
+
+		// The stored row belongs to "sess-live"; the live session is a
+		// newer one, so the stale row must not be double counted.
+		usage, err := query(context.Background(), "iss-1", "sess-new")
+		if err != nil {
+			t.Fatalf("buildBudgetQuery query: %v", err)
+		}
+		if usage.CompletedTotalTokens != 600 {
+			t.Errorf("CompletedTotalTokens = %d, want 600", usage.CompletedTotalTokens)
+		}
+		if usage.RunningTotalTokens != 0 {
+			t.Errorf("RunningTotalTokens = %d, want 0 (stale session row)", usage.RunningTotalTokens)
+		}
+	})
+
+	t.Run("empty running session id contributes zero", func(t *testing.T) {
+		t.Parallel()
+
+		query := buildBudgetQuery(seedBudgetStore(t))
+
+		usage, err := query(context.Background(), "iss-1", "")
+		if err != nil {
+			t.Fatalf("buildBudgetQuery query: %v", err)
+		}
+		if usage.RunningTotalTokens != 0 {
+			t.Errorf("RunningTotalTokens = %d, want 0 (no running session id)", usage.RunningTotalTokens)
+		}
+	})
+
+	t.Run("issue with no history returns zero usage", func(t *testing.T) {
+		t.Parallel()
+
+		query := buildBudgetQuery(seedBudgetStore(t))
+
+		usage, err := query(context.Background(), "iss-none", "sess-live")
+		if err != nil {
+			t.Fatalf("buildBudgetQuery query: %v", err)
+		}
+		if usage.CompletedTotalTokens != 0 || usage.CompletedSessions != 0 || usage.RunningTotalTokens != 0 {
+			t.Errorf("usage = %+v, want all-zero", usage)
+		}
+	})
 }

--- a/cmd/sortie/resolve_test.go
+++ b/cmd/sortie/resolve_test.go
@@ -373,6 +373,7 @@ func TestAgentConfigMapCompleteness(t *testing.T) {
 		"MaxRetryBackoffMS":    true,
 		"MaxConcurrentByState": true,
 		"MaxSessions":          true,
+		"MaxTokens":            true,
 	}
 
 	for _, field := range reflect.VisibleFields(rt) {
@@ -409,6 +410,7 @@ func TestAgentConfigMapExcludesOrchestratorFields(t *testing.T) {
 		"max_retry_backoff_ms",
 		"max_concurrent_agents_by_state",
 		"max_sessions",
+		"max_tokens",
 	}
 	for _, key := range excluded {
 		if _, ok := m[key]; ok {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -585,6 +585,14 @@ Fields:
   - When the count reaches `max_sessions`, the claim is released and a warning is logged.
   - `0` disables the budget (unlimited retries).
   - Changes are re-applied at runtime and affect future retry timer evaluations.
+- `max_tokens` (integer)
+  - Default: `0` (unlimited; no token budget enforced).
+  - Cumulative per-issue token ceiling. The orchestrator sums `total_tokens` across the
+    issue's `run_history` entries and stops re-dispatching once the sum reaches `max_tokens`.
+  - When the sum reaches `max_tokens`, the claim is released and a warning is logged, exactly
+    as `max_sessions` does. A failed token query fails open: dispatch proceeds.
+  - Overridable through `SORTIE_AGENT_MAX_TOKENS`. `0` disables the budget.
+  - Changes are re-applied at runtime and affect future retry timer evaluations.
 
 Adapter-specific pass-through config:
 
@@ -1083,6 +1091,7 @@ This section is intentionally redundant so a coding agent can implement the conf
 - `agent.max_retry_backoff_ms`: integer, default `300000` (5m)
 - `agent.max_concurrent_agents_by_state`: map of positive integers, default `{}`
 - `agent.max_sessions`: integer, default `0` (unlimited)
+- `agent.max_tokens`: integer, default `0` (unlimited)
 - `ci_feedback.kind`: string, optional, **deprecated**; identifies the CI status provider adapter;
   presence activates CI feedback; use `reactions.ci_failure` instead
 - `ci_feedback.max_retries`: integer, default `2`; CI-fix continuation attempts before escalation
@@ -1362,6 +1371,25 @@ Per-issue effort budget (defense-in-depth):
 - If the count query fails, the budget check is skipped (fail-open) and dispatch proceeds
   normally.
 - `max_sessions = 0` (default) disables the budget entirely.
+
+Per-issue token budget (cost ceiling):
+
+- When `agent.max_tokens > 0`, the retry handler sums `total_tokens` across the issue's
+  `run_history` entries on the same pre-dispatch path, after the session check.
+- If the sum reaches `max_tokens`, the claim is released and a warning is logged instead of
+  re-dispatching, identical in mechanism to the session ceiling.
+- The session and token ceilings are independent hard ceilings. A re-dispatch is blocked when
+  either is reached, so whichever fills first across polling cycles is the one that fires. When
+  a single evaluation finds both exhausted, the reported and logged reason names the token
+  budget; the block itself is identical regardless of which ceiling triggered it.
+- The per-tick rebuild of the exhausted-issue set accounts for both ceilings: it runs the
+  session-count batch query when `max_sessions > 0` and the token-sum batch query when
+  `max_tokens > 0`, and unions the results. Each blocked issue carries a machine-readable
+  reason (`token_budget` or `session_budget`, token taking precedence) surfaced in the runtime
+  snapshot beside the exhausted set.
+- If the token query fails, the check fails open and dispatch proceeds, matching the session
+  check. A token sum recorded before the token columns were added reads as zero.
+- `max_tokens = 0` (default) disables the budget entirely.
 
 Note:
 
@@ -1794,6 +1822,7 @@ failed database query).
 
 - `sortie_status` (Section 10.4.5)
 - `workspace_history` (Section 10.4.5)
+- `cost_budget` (Section 10.4.5)
 
 **Tier 2 — external dependencies.** These tools interact with external services (tracker APIs,
 future SCM APIs) through network calls using orchestrator-managed credentials. They are subject
@@ -1881,6 +1910,40 @@ recent runs, newest first. Each entry has `attempt`, `agent_adapter`, `started_a
 
 On failure the tool returns a JSON error object of the form `{"error": "<message>"}`. This
 happens when the history query fails.
+
+**`cost_budget` (Tier 1)** returns cumulative per-issue token spend and the remaining token
+budget so an agent can self-regulate before the orchestrator's token ceiling blocks a
+re-dispatch. It sums `total_tokens` across the issue's `run_history` rows and adds the running
+session's recorded `total_tokens` from `session_metadata`, then makes no external calls. It is
+the advisory counterpart to the `agent.max_tokens` enforcement on the dispatch path; both read
+the same summed `total_tokens`, so the advisory reading and the refusal agree.
+
+Availability: registered when the database path and issue ID are present in the environment
+(`SORTIE_DB_PATH`, `SORTIE_ISSUE_ID`), the same condition as `workspace_history`. The running
+session ID arrives through `SORTIE_SESSION_ID`. The tool takes no input.
+
+The response is a JSON object with five fields:
+
+- `used_tokens`: cumulative `total_tokens` across the issue's completed sessions, plus the
+  running session's recorded `total_tokens` when a session is in flight. The running session's
+  spend is added only when the `session_metadata` row's session ID matches the live session ID,
+  so a stale earlier session is never counted twice.
+- `budget_tokens`: the configured `agent.max_tokens`. `0` means unlimited.
+- `remaining_tokens`: `budget_tokens - used_tokens`, floored at `0`; `null` when the budget is
+  unlimited, so the agent distinguishes "no limit" from "nothing left".
+- `used_sessions`: completed sessions for the issue. The running session is not counted,
+  matching how `agent.max_sessions` counts.
+- `budget_sessions`: the configured `agent.max_sessions`. `0` means unlimited.
+
+The asymmetry between `used_tokens` (includes the running session) and `used_sessions`
+(excludes it) is deliberate: a session is discrete and either finished or not, whereas tokens
+accrue continuously, so an advisory reading that ignored in-flight spend would be useless
+exactly when the agent consults it. The running session's spend reaches `session_metadata`
+through throttled incremental writes during the session and reaches `run_history` only at
+session exit, so no window double counts.
+
+On failure the tool returns a JSON error object of the form `{"error": "<message>"}`. This
+happens when the budget query fails.
 
 #### 10.4.6 Tools vs. agent-authored files
 
@@ -2778,6 +2841,10 @@ Token accounting rules:
   `input_tokens` / `output_tokens`.
 - `api_request_count` is incremented monotonically per `token_usage` event.
 - Accumulate aggregate totals in orchestrator state (`agent_totals`).
+- At session exit, the session's token totals are written to the `run_history` row alongside
+  the aggregate update. The per-issue token budget (`agent.max_tokens`) sums `run_history`
+  `total_tokens` per issue; the `cost_budget` tool reads the same sum plus the running
+  session's recorded total.
 
 Timing accounting rules:
 
@@ -3918,6 +3985,17 @@ Note: `timer_handle` is runtime-only and is not stored.
 | `status`          | TEXT    | Terminal status (succeeded, failed, etc.) |
 | `error`           | TEXT    | Error message if failed, may be null      |
 | `review_metadata` | TEXT    | JSON-encoded self-review metadata, may be null (migration 007) |
+| `input_tokens`      | INTEGER | Accumulated input tokens, 0 for pre-migration rows (migration 011) |
+| `output_tokens`     | INTEGER | Accumulated output tokens, 0 for pre-migration rows (migration 011) |
+| `total_tokens`      | INTEGER | Accumulated total tokens, 0 for pre-migration rows (migration 011) |
+| `cache_read_tokens` | INTEGER | Accumulated cache-read tokens, 0 for pre-migration rows (migration 011) |
+
+The token columns mirror those on `session_metadata`. The per-issue token budget
+(`agent.max_tokens`) sums `total_tokens` here; the other three are recorded for parity and
+future use. The `session_metadata` write cadence changed to throttled-incremental during a
+running session (at most one write per issue per two seconds, on the orchestrator event loop)
+so the `cost_budget` tool can read in-flight spend before the session's `run_history` row
+exists.
 
 **`session_metadata`** — last known session metadata per issue (for observability and debug)
 

--- a/docs/workflow-reference.md
+++ b/docs/workflow-reference.md
@@ -371,6 +371,7 @@ agent:
 | `max_retry_backoff_ms`           | integer or string integer         | No                                  | `300000` (5m)   | **Yes** — affects future retry scheduling  | Maximum delay cap for exponential backoff on retries.                                                                                                                            |
 | `max_concurrent_agents_by_state` | map of `state → positive integer` | No                                  | `{}` (empty)    | **Yes** — affects subsequent dispatch      | Per-state concurrency limits. State keys are normalized to lowercase for lookup. Non-positive or non-numeric entries are silently ignored.                                       |
 | `max_sessions`                   | integer                           | No                                  | `0` (unlimited) | **Yes** — affects future retry evaluations | Maximum completed worker sessions per issue before the orchestrator stops re-dispatching. Counted from run history. `0` disables the budget (unlimited). Must be non-negative.   |
+| `max_tokens`                     | integer                           | No                                  | `0` (unlimited) | **Yes** — affects future retry evaluations | Cumulative per-issue token ceiling. The orchestrator sums `total_tokens` across the issue's run history and stops re-dispatching once the sum reaches the limit. `0` disables the budget (unlimited). Must be non-negative. |
 
 **Orchestrator vs adapter fields:** The fields above are consumed by the orchestrator
 for scheduling, concurrency, and retry decisions. They are **not** passed through to the
@@ -907,6 +908,7 @@ Each variable maps to exactly one config field. The naming convention is
 | `SORTIE_AGENT_MAX_TURNS`             | `agent.max_turns`             | int    |       |
 | `SORTIE_AGENT_MAX_RETRY_BACKOFF_MS`  | `agent.max_retry_backoff_ms`  | int    |       |
 | `SORTIE_AGENT_MAX_SESSIONS`          | `agent.max_sessions`          | int    |       |
+| `SORTIE_AGENT_MAX_TOKENS`            | `agent.max_tokens`            | int    |       |
 
 #### Top-level
 
@@ -2132,6 +2134,7 @@ re-applies configuration and prompt template without restart.
 | `agent.max_retry_backoff_ms`           | **Immediate** — affects future retry scheduling.                                               |
 | `agent.max_concurrent_agents_by_state` | **Immediate** — affects subsequent dispatch decisions.                                         |
 | `agent.max_sessions`                   | **Immediate** — affects future retry timer evaluations.                                        |
+| `agent.max_tokens`                     | **Immediate** — affects future retry timer evaluations.                                        |
 | `db_path`                              | **No effect** — requires restart. In-memory config updated, but database connection unchanged. |
 | `ci_feedback.kind`                     | **No effect** — requires restart. CI provider is created once at process start.                |
 | `ci_feedback.max_retries`              | Future dispatches.                                                                             |
@@ -2225,6 +2228,7 @@ Each error identifies the offending field path.
 | `config: agent.max_concurrent_agents: invalid integer value: <val>`             | Same as above, for any integer field.                                    | Same fix as above.                                                                                                                   |
 | `config: agent.stall_timeout_ms: invalid integer value: <val>`                  | Same as above.                                                           | Same fix.                                                                                                                            |
 | `config: agent.max_sessions: must be non-negative`                              | Negative value for `max_sessions`.                                       | Use `0` (unlimited) or a positive integer.                                                                                           |
+| `config: agent.max_tokens: must be non-negative`                                | Negative value for `max_tokens`.                                         | Use `0` (unlimited) or a positive integer.                                                                                           |
 | `config: tracker.handoff_state: expected string, got <type>`                    | `handoff_state` is not a string (e.g., integer, boolean, list).          | Ensure the value is a string, quoted if necessary.                                                                                   |
 | `config: tracker.handoff_state: must not be empty`                              | `handoff_state` is set to an explicit empty string.                      | Provide a valid state name, or omit the field entirely to disable handoff.                                                           |
 | `config: tracker.handoff_state: resolved to empty (check environment variable)` | `$VAR` reference resolved to an empty string (variable unset or empty).  | Set the referenced environment variable to a valid state name.                                                                       |
@@ -2313,6 +2317,7 @@ lists the `SORTIE_*` variable that overrides the field, or "—" if not overrida
 | `agent.max_retry_backoff_ms`            | integer          | `300000`                     | `SORTIE_AGENT_MAX_RETRY_BACKOFF_MS`      | 5 min; dynamic reload                                                                  |
 | `agent.max_concurrent_agents_by_state`  | `map[string]int` | `{}`                         | —                                        | Keys lowercased; dynamic reload                                                        |
 | `agent.max_sessions`                    | integer          | `0`                          | `SORTIE_AGENT_MAX_SESSIONS`              | Unlimited; dynamic reload                                                              |
+| `agent.max_tokens`                      | integer          | `0`                          | `SORTIE_AGENT_MAX_TOKENS`                | Unlimited; dynamic reload                                                              |
 | `db_path`                               | path             | `.sortie.db`                 | `SORTIE_DB_PATH`                         | Restart required; `$VAR` skipped for env-sourced values                                |
 | `ci_feedback.kind`                      | string           | _(absent)_                   | —                                        | **Deprecated;** absent = disabled; restart required                                    |
 | `ci_feedback.max_retries`               | integer          | `2`                          | —                                        | **Deprecated;** `0` = escalate immediately; non-negative                               |

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -133,6 +133,10 @@ type AgentConfig struct {
 	MaxRetryBackoffMS    int
 	MaxConcurrentByState map[string]int
 	MaxSessions          int
+
+	// MaxTokens is the cumulative per-issue token ceiling enforced at
+	// dispatch preflight. 0 means unlimited.
+	MaxTokens int
 }
 
 // knownTopLevelKeys enumerates the front matter keys consumed by the
@@ -533,6 +537,17 @@ func buildAgentConfig(m map[string]any) (AgentConfig, error) {
 		}
 	}
 
+	maxTokens, err := coerceIntField(m, "max_tokens", "agent.max_tokens")
+	if err != nil {
+		return AgentConfig{}, err
+	}
+	if maxTokens < 0 {
+		return AgentConfig{}, &ConfigError{
+			Field:   "agent.max_tokens",
+			Message: "must be non-negative",
+		}
+	}
+
 	return AgentConfig{
 		Kind:                 kind,
 		Command:              command,
@@ -544,6 +559,7 @@ func buildAgentConfig(m map[string]any) (AgentConfig, error) {
 		MaxRetryBackoffMS:    maxRetryBackoff,
 		MaxConcurrentByState: byState,
 		MaxSessions:          maxSessions,
+		MaxTokens:            maxTokens,
 	}, nil
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -706,6 +706,56 @@ func TestNewServiceConfig(t *testing.T) {
 		assertConfigErrorField(t, err, "agent.max_sessions")
 	})
 
+	t.Run("MaxTokens/DefaultIsZero", func(t *testing.T) {
+		t.Parallel()
+		cfg, err := NewServiceConfig(map[string]any{})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		assertIntEqual(t, "Agent.MaxTokens", 0, cfg.Agent.MaxTokens)
+	})
+
+	t.Run("MaxTokens/ExplicitZero", func(t *testing.T) {
+		t.Parallel()
+		cfg, err := NewServiceConfig(map[string]any{
+			"agent": map[string]any{"max_tokens": 0},
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		assertIntEqual(t, "Agent.MaxTokens", 0, cfg.Agent.MaxTokens)
+	})
+
+	t.Run("MaxTokens/PositiveInteger", func(t *testing.T) {
+		t.Parallel()
+		cfg, err := NewServiceConfig(map[string]any{
+			"agent": map[string]any{"max_tokens": 500000},
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		assertIntEqual(t, "Agent.MaxTokens", 500000, cfg.Agent.MaxTokens)
+	})
+
+	t.Run("MaxTokens/StringCoercion", func(t *testing.T) {
+		t.Parallel()
+		cfg, err := NewServiceConfig(map[string]any{
+			"agent": map[string]any{"max_tokens": "500000"},
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		assertIntEqual(t, "Agent.MaxTokens", 500000, cfg.Agent.MaxTokens)
+	})
+
+	t.Run("MaxTokens/NegativeRejected", func(t *testing.T) {
+		t.Parallel()
+		_, err := NewServiceConfig(map[string]any{
+			"agent": map[string]any{"max_tokens": -1},
+		})
+		assertConfigErrorField(t, err, "agent.max_tokens")
+	})
+
 	// --- InProgressState subtests ---
 
 	t.Run("InProgressState/Absent", func(t *testing.T) {
@@ -1291,6 +1341,7 @@ func TestNewServiceConfigEnvOverrides(t *testing.T) {
 		t.Setenv("SORTIE_AGENT_MAX_TURNS", "15")
 		t.Setenv("SORTIE_AGENT_MAX_RETRY_BACKOFF_MS", "99999")
 		t.Setenv("SORTIE_AGENT_MAX_SESSIONS", "3")
+		t.Setenv("SORTIE_AGENT_MAX_TOKENS", "750000")
 
 		cfg, err := NewServiceConfig(map[string]any{})
 		if err != nil {
@@ -1303,6 +1354,49 @@ func TestNewServiceConfigEnvOverrides(t *testing.T) {
 		assertIntEqual(t, "Agent.MaxTurns", 15, cfg.Agent.MaxTurns)
 		assertIntEqual(t, "Agent.MaxRetryBackoffMS", 99999, cfg.Agent.MaxRetryBackoffMS)
 		assertIntEqual(t, "Agent.MaxSessions", 3, cfg.Agent.MaxSessions)
+		assertIntEqual(t, "Agent.MaxTokens", 750000, cfg.Agent.MaxTokens)
+	})
+
+	t.Run("MaxTokensOverrideBeatsFrontMatter", func(t *testing.T) {
+		t.Setenv("SORTIE_AGENT_MAX_TOKENS", "200000")
+		cfg, err := NewServiceConfig(map[string]any{
+			"agent": map[string]any{"max_tokens": 100000},
+		})
+		if err != nil {
+			t.Fatalf("NewServiceConfig: %v", err)
+		}
+		assertIntEqual(t, "Agent.MaxTokens", 200000, cfg.Agent.MaxTokens)
+	})
+
+	t.Run("MaxTokensDynamicReload", func(t *testing.T) {
+		// First parse with one front-matter value.
+		cfg1, err := NewServiceConfig(map[string]any{
+			"agent": map[string]any{"max_tokens": 100000},
+		})
+		if err != nil {
+			t.Fatalf("first NewServiceConfig: %v", err)
+		}
+		assertIntEqual(t, "Agent.MaxTokens (1st)", 100000, cfg1.Agent.MaxTokens)
+
+		// Simulate dynamic reload: the re-parsed front matter carries a
+		// new value, which must be re-applied.
+		cfg2, err := NewServiceConfig(map[string]any{
+			"agent": map[string]any{"max_tokens": 250000},
+		})
+		if err != nil {
+			t.Fatalf("second NewServiceConfig: %v", err)
+		}
+		assertIntEqual(t, "Agent.MaxTokens (2nd)", 250000, cfg2.Agent.MaxTokens)
+
+		// An env override set between reloads applies on the next re-parse.
+		t.Setenv("SORTIE_AGENT_MAX_TOKENS", "300000")
+		cfg3, err := NewServiceConfig(map[string]any{
+			"agent": map[string]any{"max_tokens": 250000},
+		})
+		if err != nil {
+			t.Fatalf("third NewServiceConfig: %v", err)
+		}
+		assertIntEqual(t, "Agent.MaxTokens (3rd)", 300000, cfg3.Agent.MaxTokens)
 	})
 
 	t.Run("TrackerStringOverridesAllFields", func(t *testing.T) {

--- a/internal/config/envoverride.go
+++ b/internal/config/envoverride.go
@@ -78,6 +78,7 @@ var envOverrides = []envOverride{
 	{"SORTIE_AGENT_MAX_TURNS", "agent", "max_turns", coerceEnvInt},
 	{"SORTIE_AGENT_MAX_RETRY_BACKOFF_MS", "agent", "max_retry_backoff_ms", coerceEnvInt},
 	{"SORTIE_AGENT_MAX_SESSIONS", "agent", "max_sessions", coerceEnvInt},
+	{"SORTIE_AGENT_MAX_TOKENS", "agent", "max_tokens", coerceEnvInt},
 
 	// Top-level
 	{"SORTIE_DB_PATH", "", "db_path", coerceString},

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -91,6 +91,7 @@ var knownFieldsRegistry = map[string]SectionSchema{
 			{Name: "max_retry_backoff_ms", Type: FieldInt},
 			{Name: "max_concurrent_agents_by_state", Type: FieldMap},
 			{Name: "max_sessions", Type: FieldInt},
+			{Name: "max_tokens", Type: FieldInt},
 		},
 		AllowAdapterPassthrough: true,
 	},

--- a/internal/orchestrator/exit.go
+++ b/internal/orchestrator/exit.go
@@ -216,20 +216,24 @@ func HandleWorkerExit(state *State, workerResult WorkerResult, params HandleWork
 	// first retry = 2, etc. normalizeAttempt returns the 0-based retry
 	// counter (nil → 0), so add 1 for the overall run attempt number.
 	runHistory := persistence.RunHistory{
-		IssueID:        workerResult.IssueID,
-		Identifier:     workerResult.Identifier,
-		DisplayID:      entry.Issue.DisplayID,
-		Attempt:        normalizeAttempt(entry.RetryAttempt) + 1,
-		AgentAdapter:   workerResult.AgentAdapter,
-		Workspace:      workerResult.WorkspacePath,
-		StartedAt:      entry.StartedAt.Format(time.RFC3339),
-		CompletedAt:    now.Format(time.RFC3339),
-		Status:         status,
-		Error:          errorStringPtr(workerResult.Error),
-		WorkflowFile:   entry.WorkflowFile,
-		TurnsCompleted: workerResult.TurnsCompleted,
-		RuleName:       entry.RuleName,
-		TemplateID:     entry.TemplateID,
+		IssueID:         workerResult.IssueID,
+		Identifier:      workerResult.Identifier,
+		DisplayID:       entry.Issue.DisplayID,
+		Attempt:         normalizeAttempt(entry.RetryAttempt) + 1,
+		AgentAdapter:    workerResult.AgentAdapter,
+		Workspace:       workerResult.WorkspacePath,
+		StartedAt:       entry.StartedAt.Format(time.RFC3339),
+		CompletedAt:     now.Format(time.RFC3339),
+		Status:          status,
+		Error:           errorStringPtr(workerResult.Error),
+		WorkflowFile:    entry.WorkflowFile,
+		TurnsCompleted:  workerResult.TurnsCompleted,
+		RuleName:        entry.RuleName,
+		TemplateID:      entry.TemplateID,
+		InputTokens:     entry.AgentInputTokens,
+		OutputTokens:    entry.AgentOutputTokens,
+		TotalTokens:     entry.AgentTotalTokens,
+		CacheReadTokens: entry.CacheReadTokens,
 	}
 	if workerResult.ReviewMetadata != nil {
 		data, marshalErr := json.Marshal(workerResult.ReviewMetadata)

--- a/internal/orchestrator/exit_test.go
+++ b/internal/orchestrator/exit_test.go
@@ -303,6 +303,55 @@ func TestHandleWorkerExit_NormalExit(t *testing.T) {
 	}
 }
 
+// TestHandleWorkerExit_RunHistoryTokenColumns verifies the exit path copies
+// the running entry's accumulated token counters into the run_history row,
+// matching the totals it writes to session_metadata.
+func TestHandleWorkerExit_RunHistoryTokenColumns(t *testing.T) {
+	t.Parallel()
+
+	store := &mockExitStore{}
+	state := exitState(t, "ISSUE-TOK", nil)
+	entry := state.Running["ISSUE-TOK"]
+	entry.AgentInputTokens = 100
+	entry.AgentOutputTokens = 200
+	entry.AgentTotalTokens = 300
+	entry.CacheReadTokens = 40
+
+	HandleWorkerExit(state, WorkerResult{
+		IssueID:       "ISSUE-TOK",
+		Identifier:    "ISSUE-TOK-ident",
+		ExitKind:      WorkerExitNormal,
+		AgentAdapter:  "mock",
+		WorkspacePath: "/tmp/ws",
+	}, defaultExitParams(t, store))
+
+	if len(store.runHistories) != 1 {
+		t.Fatalf("AppendRunHistory called %d times, want 1", len(store.runHistories))
+	}
+	run := store.runHistories[0]
+	if run.InputTokens != 100 {
+		t.Errorf("RunHistory.InputTokens = %d, want 100", run.InputTokens)
+	}
+	if run.OutputTokens != 200 {
+		t.Errorf("RunHistory.OutputTokens = %d, want 200", run.OutputTokens)
+	}
+	if run.TotalTokens != 300 {
+		t.Errorf("RunHistory.TotalTokens = %d, want 300", run.TotalTokens)
+	}
+	if run.CacheReadTokens != 40 {
+		t.Errorf("RunHistory.CacheReadTokens = %d, want 40", run.CacheReadTokens)
+	}
+
+	// The same totals reach session_metadata at exit (advisory parity).
+	if len(store.sessionMetadata) != 1 {
+		t.Fatalf("UpsertSessionMetadata called %d times, want 1", len(store.sessionMetadata))
+	}
+	meta := store.sessionMetadata[0]
+	if meta.TotalTokens != run.TotalTokens {
+		t.Errorf("SessionMetadata.TotalTokens = %d, want %d (parity with run_history)", meta.TotalTokens, run.TotalTokens)
+	}
+}
+
 func TestHandleWorkerExit_RetryableError(t *testing.T) {
 	t.Parallel()
 

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -752,9 +752,10 @@ func (o *Orchestrator) maybeWriteIncrementalMetadata(ctx context.Context, issueI
 // map once per tick from run_history, as the union of the session-count
 // and token-sum budgets scoped to the candidate set. An issue blocked on
 // either budget is in the rebuilt set; an issue blocked on both reports
-// the token budget. On a query error for one axis, the entire prior set
-// is folded in for that axis so a transient error never drops an issue
-// mid-tick. Must be called from the event loop goroutine.
+// the token budget. On a query error for one axis, the prior entries
+// attributed to that axis are folded back in so a transient error never
+// drops an issue mid-tick, while the other axis keeps its fresh result.
+// Must be called from the event loop goroutine.
 func (o *Orchestrator) rebuildBudgetExhausted(ctx context.Context, cfg config.ServiceConfig, sorted []domain.Issue) {
 	if cfg.Agent.MaxSessions == 0 && cfg.Agent.MaxTokens == 0 {
 		o.state.BudgetExhausted = make(map[string]struct{})
@@ -779,8 +780,11 @@ func (o *Orchestrator) rebuildBudgetExhausted(ctx context.Context, cfg config.Se
 				slog.Any("error", qErr),
 			)
 			for id := range prior {
+				if priorReason[id] != budgetReasonSession {
+					continue
+				}
 				fresh[id] = struct{}{}
-				freshReason[id] = priorReason[id]
+				freshReason[id] = budgetReasonSession
 			}
 		} else {
 			for _, id := range sessionExhausted {
@@ -797,10 +801,11 @@ func (o *Orchestrator) rebuildBudgetExhausted(ctx context.Context, cfg config.Se
 				slog.Any("error", qErr),
 			)
 			for id := range prior {
-				fresh[id] = struct{}{}
-				if _, ok := freshReason[id]; !ok {
-					freshReason[id] = priorReason[id]
+				if priorReason[id] != budgetReasonToken {
+					continue
 				}
+				fresh[id] = struct{}{}
+				freshReason[id] = budgetReasonToken
 			}
 		} else {
 			for _, id := range tokenExhausted {

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -35,7 +35,9 @@ type OrchestratorStore interface {
 	SaveRetryEntry(ctx context.Context, entry persistence.RetryEntry) error
 	DeleteRetryEntry(ctx context.Context, issueID string) error
 	CountRunHistoryByIssue(ctx context.Context, issueID string) (int, error)
+	SumTotalTokensByIssue(ctx context.Context, issueID string) (int64, int, error)
 	QueryBudgetExhaustedIssues(ctx context.Context, candidateIDs []string, maxSessions int) ([]string, error)
+	QueryTokenExhaustedIssues(ctx context.Context, candidateIDs []string, maxTokens int) ([]string, error)
 	DeleteReactionFingerprintsByIssue(ctx context.Context, issueID string) error
 	UpsertReactionFingerprint(ctx context.Context, issueID, kind, fingerprint string) error
 	GetReactionFingerprint(ctx context.Context, issueID, kind string) (fingerprint string, dispatched bool, err error)
@@ -338,6 +340,7 @@ func (o *Orchestrator) Run(ctx context.Context) {
 				Ctx:                ctx,
 				Logger:             o.logger,
 				MaxSessions:        cfg.Agent.MaxSessions,
+				MaxTokens:          cfg.Agent.MaxTokens,
 				Metrics:            o.metrics,
 				HostPool:           o.hostPool,
 				WorkflowFile:       o.workflowFile(),
@@ -347,6 +350,7 @@ func (o *Orchestrator) Run(ctx context.Context) {
 
 		case msg := <-o.agentEventCh:
 			HandleAgentEvent(o.state, msg.IssueID, msg.Event, o.logger, o.metrics)
+			o.maybeWriteIncrementalMetadata(ctx, msg.IssueID, msg.Event)
 
 		case msg := <-o.selfReviewCh:
 			if entry, ok := o.state.Running[msg.IssueID]; ok {
@@ -498,28 +502,7 @@ func (o *Orchestrator) handleTick(ctx context.Context) {
 
 	sorted := SortForDispatch(issues)
 
-	// Rebuild the BudgetExhausted set from run_history. One batch
-	// query per tick, scoped to the candidate set.
-	if cfg.Agent.MaxSessions > 0 && len(sorted) > 0 {
-		candidateIDs := make([]string, len(sorted))
-		for i, issue := range sorted {
-			candidateIDs[i] = issue.ID
-		}
-		exhaustedIDs, qErr := o.store.QueryBudgetExhaustedIssues(ctx, candidateIDs, cfg.Agent.MaxSessions)
-		if qErr != nil {
-			o.logger.Warn("budget exhaustion query failed, retaining previous set",
-				slog.Any("error", qErr),
-			)
-		} else {
-			fresh := make(map[string]struct{}, len(exhaustedIDs))
-			for _, id := range exhaustedIDs {
-				fresh[id] = struct{}{}
-			}
-			o.state.BudgetExhausted = fresh
-		}
-	} else if cfg.Agent.MaxSessions == 0 {
-		o.state.BudgetExhausted = make(map[string]struct{})
-	}
+	o.rebuildBudgetExhausted(ctx, cfg, sorted)
 
 	// Pre-build state sets once for the dispatch loop.
 	activeSet := stateSet(cfg.Tracker.ActiveStates)
@@ -716,6 +699,121 @@ func (o *Orchestrator) activateReconstructedRetries() {
 // running workers to exit during graceful shutdown.
 const defaultDrainTimeout = 30 * time.Second
 
+// sessionMetadataWriteInterval bounds how often the event loop writes an
+// in-flight session's token totals to session_metadata. At most one
+// incremental write per issue per interval, so the advisory cost reading
+// trails live spend by at most one interval plus whatever accrued since
+// the last token_usage event.
+const sessionMetadataWriteInterval = 2 * time.Second
+
+// maybeWriteIncrementalMetadata persists the running session's current
+// token totals to session_metadata when a token_usage event arrives and
+// the per-issue throttle interval has elapsed. It is a no-op for other
+// event types, for unknown issues, and while throttled. Must be called
+// from the orchestrator's single-writer event loop so it shares the one
+// SQLite writer and the running entry it mutates.
+func (o *Orchestrator) maybeWriteIncrementalMetadata(ctx context.Context, issueID string, event domain.AgentEvent) {
+	if event.Type != domain.EventTokenUsage {
+		return
+	}
+	entry := o.state.Running[issueID]
+	if entry == nil {
+		return
+	}
+	now := time.Now().UTC()
+	if !entry.LastMetadataWrite.IsZero() && now.Sub(entry.LastMetadataWrite) < sessionMetadataWriteInterval {
+		return
+	}
+
+	meta := persistence.SessionMetadata{
+		IssueID:         issueID,
+		SessionID:       entry.SessionID,
+		InputTokens:     entry.AgentInputTokens,
+		OutputTokens:    entry.AgentOutputTokens,
+		TotalTokens:     entry.AgentTotalTokens,
+		CacheReadTokens: entry.CacheReadTokens,
+		ModelName:       entry.ModelName,
+		APIRequestCount: entry.APIRequestCount,
+		UpdatedAt:       now.Format(time.RFC3339),
+	}
+	if entry.AgentPID != "" {
+		meta.AgentPID = &entry.AgentPID
+	}
+	if err := o.store.UpsertSessionMetadata(ctx, meta); err != nil {
+		o.logger.Error("failed to persist incremental session metadata",
+			slog.Any("error", err),
+		)
+		return
+	}
+	entry.LastMetadataWrite = now
+}
+
+// rebuildBudgetExhausted replaces the BudgetExhausted set and its reason
+// map once per tick from run_history, as the union of the session-count
+// and token-sum budgets scoped to the candidate set. An issue blocked on
+// either budget is in the rebuilt set; an issue blocked on both reports
+// the token budget. On a query error for one axis, the entire prior set
+// is folded in for that axis so a transient error never drops an issue
+// mid-tick. Must be called from the event loop goroutine.
+func (o *Orchestrator) rebuildBudgetExhausted(ctx context.Context, cfg config.ServiceConfig, sorted []domain.Issue) {
+	if cfg.Agent.MaxSessions == 0 && cfg.Agent.MaxTokens == 0 {
+		o.state.BudgetExhausted = make(map[string]struct{})
+		o.state.BudgetExhaustedReason = make(map[string]string)
+		return
+	}
+
+	candidateIDs := make([]string, len(sorted))
+	for i, issue := range sorted {
+		candidateIDs[i] = issue.ID
+	}
+
+	prior := o.state.BudgetExhausted
+	priorReason := o.state.BudgetExhaustedReason
+	fresh := make(map[string]struct{})
+	freshReason := make(map[string]string)
+
+	if cfg.Agent.MaxSessions > 0 {
+		sessionExhausted, qErr := o.store.QueryBudgetExhaustedIssues(ctx, candidateIDs, cfg.Agent.MaxSessions)
+		if qErr != nil {
+			o.logger.Warn("budget exhaustion query failed, retaining previous set",
+				slog.Any("error", qErr),
+			)
+			for id := range prior {
+				fresh[id] = struct{}{}
+				freshReason[id] = priorReason[id]
+			}
+		} else {
+			for _, id := range sessionExhausted {
+				fresh[id] = struct{}{}
+				freshReason[id] = budgetReasonSession
+			}
+		}
+	}
+
+	if cfg.Agent.MaxTokens > 0 {
+		tokenExhausted, qErr := o.store.QueryTokenExhaustedIssues(ctx, candidateIDs, cfg.Agent.MaxTokens)
+		if qErr != nil {
+			o.logger.Warn("token budget exhaustion query failed, retaining previous set",
+				slog.Any("error", qErr),
+			)
+			for id := range prior {
+				fresh[id] = struct{}{}
+				if _, ok := freshReason[id]; !ok {
+					freshReason[id] = priorReason[id]
+				}
+			}
+		} else {
+			for _, id := range tokenExhausted {
+				fresh[id] = struct{}{}
+				freshReason[id] = budgetReasonToken
+			}
+		}
+	}
+
+	o.state.BudgetExhausted = fresh
+	o.state.BudgetExhaustedReason = freshReason
+}
+
 // drainRunningWorkers cancels all running worker contexts and waits for
 // them to exit, processing each [WorkerResult] through [HandleWorkerExit]
 // for clean persistence. Agent events are processed through
@@ -772,6 +870,7 @@ func (o *Orchestrator) drainRunningWorkers() {
 
 		case msg := <-o.agentEventCh:
 			HandleAgentEvent(o.state, msg.IssueID, msg.Event, o.logger, o.metrics)
+			o.maybeWriteIncrementalMetadata(drainCtx, msg.IssueID, msg.Event)
 
 		case req := <-o.snapshotCh:
 			snap := RuntimeSnapshot(o.state, time.Now())

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -102,9 +102,17 @@ type stubStore struct {
 	sessions        []persistence.SessionMetadata
 	savedRetries    []persistence.RetryEntry
 	deletedRetryIDs []string
-	// Budget exhaustion query configuration (Rule 4b / per-tick rebuild).
+	// Budget exhaustion query configuration (per-tick rebuild).
 	budgetExhaustedIDs []string
 	budgetExhaustedErr error
+
+	// Token budget query configuration (per-tick rebuild and single-issue gate).
+	tokenExhaustedIDs []string
+	tokenExhaustedErr error
+	tokenSum          int64
+	tokenSessionCount int
+
+	upsertSessionMetadataErr error
 }
 
 func (s *stubStore) AppendRunHistory(_ context.Context, run persistence.RunHistory) (persistence.RunHistory, error) {
@@ -126,7 +134,16 @@ func (s *stubStore) UpsertSessionMetadata(_ context.Context, m persistence.Sessi
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.sessions = append(s.sessions, m)
-	return nil
+	return s.upsertSessionMetadataErr
+}
+
+// sessionWrites returns a copy of the captured session metadata writes.
+func (s *stubStore) sessionWrites() []persistence.SessionMetadata {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]persistence.SessionMetadata, len(s.sessions))
+	copy(out, s.sessions)
+	return out
 }
 
 func (s *stubStore) SaveRetryEntry(_ context.Context, entry persistence.RetryEntry) error {
@@ -147,6 +164,12 @@ func (s *stubStore) CountRunHistoryByIssue(_ context.Context, _ string) (int, er
 	return 0, nil
 }
 
+func (s *stubStore) SumTotalTokensByIssue(_ context.Context, _ string) (int64, int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.tokenSum, s.tokenSessionCount, nil
+}
+
 func (s *stubStore) QueryBudgetExhaustedIssues(_ context.Context, _ []string, _ int) ([]string, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -155,6 +178,17 @@ func (s *stubStore) QueryBudgetExhaustedIssues(_ context.Context, _ []string, _ 
 	}
 	result := make([]string, len(s.budgetExhaustedIDs))
 	copy(result, s.budgetExhaustedIDs)
+	return result, nil
+}
+
+func (s *stubStore) QueryTokenExhaustedIssues(_ context.Context, _ []string, _ int) ([]string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.tokenExhaustedErr != nil {
+		return nil, s.tokenExhaustedErr
+	}
+	result := make([]string, len(s.tokenExhaustedIDs))
+	copy(result, s.tokenExhaustedIDs)
 	return result, nil
 }
 
@@ -3549,7 +3583,7 @@ func TestHandleTick_BudgetExhaustionRebuildsState(t *testing.T) {
 		}
 	})
 
-	t.Run("empty candidate list skips query and retains previous set", func(t *testing.T) {
+	t.Run("empty candidate list with budget enabled clears stale set", func(t *testing.T) {
 		t.Parallel()
 
 		wm := budgetTickConfig(3)
@@ -3563,11 +3597,422 @@ func TestHandleTick_BudgetExhaustionRebuildsState(t *testing.T) {
 
 		budgetOrchestrator(state, wm, store, tracker).handleTick(context.Background())
 
-		// No candidates → query skipped → previous set retained.
-		if _, ok := state.BudgetExhausted[issue.ID]; !ok {
-			t.Errorf("BudgetExhausted[%s] cleared on empty candidate list, want retained", issue.ID)
+		// With a budget enabled, the rebuild scopes its batch queries to the
+		// candidate set and assigns the fresh result. An empty candidate set
+		// yields an empty result, so a stale entry is dropped. There are no
+		// candidates to dispatch this tick, so the set is repopulated from
+		// run_history on the next tick that has candidates.
+		if _, ok := state.BudgetExhausted[issue.ID]; ok {
+			t.Errorf("BudgetExhausted[%s] retained on empty candidate list, want cleared", issue.ID)
 		}
 	})
+}
+
+// budgetTickConfigTokens returns a workflow manager configured with both
+// per-issue ceilings for per-tick rebuild tests.
+func budgetTickConfigTokens(maxSessions, maxTokens int) *stubWorkflowManager {
+	wm := budgetTickConfig(maxSessions)
+	wm.config.Agent.MaxTokens = maxTokens
+	return wm
+}
+
+// TestHandleTick_TokenBudgetRebuild covers the per-tick union rebuild of
+// BudgetExhausted across the session and token ceilings, with per-issue
+// reason attribution, token precedence, lockstep pruning, and the
+// per-axis fail-open that folds the prior set in on a query error.
+func TestHandleTick_TokenBudgetRebuild(t *testing.T) {
+	t.Parallel()
+
+	issueA := domain.Issue{ID: "iss-a", Identifier: "TEST-A", Title: "title", State: "To Do"}
+	issueB := domain.Issue{ID: "iss-b", Identifier: "TEST-B", Title: "title", State: "To Do"}
+
+	candidates := func(issues ...domain.Issue) *candidateTrackerAdapter {
+		return &candidateTrackerAdapter{
+			mockTrackerAdapter: &mockTrackerAdapter{},
+			fetchCandidatesFn:  func(_ context.Context) ([]domain.Issue, error) { return issues, nil },
+		}
+	}
+
+	t.Run("token ceiling alone populates set with token reason", func(t *testing.T) {
+		t.Parallel()
+
+		wm := budgetTickConfigTokens(0, 1000)
+		store := &stubStore{tokenExhaustedIDs: []string{issueA.ID}}
+		state := NewState(60000, 10, nil, AgentTotals{})
+
+		budgetOrchestrator(state, wm, store, candidates(issueA)).handleTick(context.Background())
+
+		if _, ok := state.BudgetExhausted[issueA.ID]; !ok {
+			t.Errorf("BudgetExhausted[%s] missing after tick, want present (token ceiling)", issueA.ID)
+		}
+		if got := state.BudgetExhaustedReason[issueA.ID]; got != budgetReasonToken {
+			t.Errorf("BudgetExhaustedReason[%s] = %q, want %q", issueA.ID, got, budgetReasonToken)
+		}
+		if _, running := state.Running[issueA.ID]; running {
+			t.Errorf("Running[%s] present, want absent (token budget exhausted)", issueA.ID)
+		}
+	})
+
+	t.Run("issue exhausted on both axes reports token budget", func(t *testing.T) {
+		t.Parallel()
+
+		wm := budgetTickConfigTokens(3, 1000)
+		store := &stubStore{
+			budgetExhaustedIDs: []string{issueA.ID},
+			tokenExhaustedIDs:  []string{issueA.ID},
+		}
+		state := NewState(60000, 10, nil, AgentTotals{})
+
+		budgetOrchestrator(state, wm, store, candidates(issueA)).handleTick(context.Background())
+
+		if _, ok := state.BudgetExhausted[issueA.ID]; !ok {
+			t.Fatalf("BudgetExhausted[%s] missing after tick, want present", issueA.ID)
+		}
+		if got := state.BudgetExhaustedReason[issueA.ID]; got != budgetReasonToken {
+			t.Errorf("BudgetExhaustedReason[%s] = %q, want %q (token precedence)", issueA.ID, got, budgetReasonToken)
+		}
+	})
+
+	t.Run("every issue in the rebuilt set carries a reason and stale entries are pruned", func(t *testing.T) {
+		t.Parallel()
+
+		wm := budgetTickConfigTokens(3, 1000)
+		store := &stubStore{
+			budgetExhaustedIDs: []string{issueA.ID},
+			tokenExhaustedIDs:  []string{issueB.ID},
+		}
+		state := NewState(60000, 10, nil, AgentTotals{})
+		// Stale entry from a previous tick: must be pruned from both
+		// structures in lockstep.
+		state.BudgetExhausted["iss-stale"] = struct{}{}
+		state.BudgetExhaustedReason["iss-stale"] = budgetReasonSession
+
+		budgetOrchestrator(state, wm, store, candidates(issueA, issueB)).handleTick(context.Background())
+
+		if got := state.BudgetExhaustedReason[issueA.ID]; got != budgetReasonSession {
+			t.Errorf("BudgetExhaustedReason[%s] = %q, want %q", issueA.ID, got, budgetReasonSession)
+		}
+		if got := state.BudgetExhaustedReason[issueB.ID]; got != budgetReasonToken {
+			t.Errorf("BudgetExhaustedReason[%s] = %q, want %q", issueB.ID, got, budgetReasonToken)
+		}
+		if _, ok := state.BudgetExhausted["iss-stale"]; ok {
+			t.Error("BudgetExhausted[iss-stale] survived the rebuild, want pruned")
+		}
+		if got, ok := state.BudgetExhaustedReason["iss-stale"]; ok {
+			t.Errorf("BudgetExhaustedReason[iss-stale] = %q, want pruned in lockstep", got)
+		}
+		// Total coverage: the reason map carries exactly the set's issues.
+		if len(state.BudgetExhaustedReason) != len(state.BudgetExhausted) {
+			t.Errorf("reason map has %d entries, set has %d, want equal",
+				len(state.BudgetExhaustedReason), len(state.BudgetExhausted))
+		}
+		for id := range state.BudgetExhausted {
+			if _, ok := state.BudgetExhaustedReason[id]; !ok {
+				t.Errorf("BudgetExhaustedReason[%s] missing, want a reason for every exhausted issue", id)
+			}
+		}
+	})
+
+	t.Run("token query failure folds prior set after session query would drop the issue", func(t *testing.T) {
+		t.Parallel()
+
+		wm := budgetTickConfigTokens(3, 1000)
+		// Session query succeeds and returns nothing (would drop the issue);
+		// token query fails: the prior set must be folded in for the token
+		// axis so the issue stays blocked this tick.
+		store := &stubStore{
+			budgetExhaustedIDs: []string{},
+			tokenExhaustedErr:  fmt.Errorf("db error"),
+		}
+		state := NewState(60000, 10, nil, AgentTotals{})
+		state.BudgetExhausted[issueA.ID] = struct{}{}
+		state.BudgetExhaustedReason[issueA.ID] = budgetReasonToken
+
+		budgetOrchestrator(state, wm, store, candidates(issueA)).handleTick(context.Background())
+
+		if _, ok := state.BudgetExhausted[issueA.ID]; !ok {
+			t.Errorf("BudgetExhausted[%s] dropped on token query error, want retained (prior set folded)", issueA.ID)
+		}
+		if got := state.BudgetExhaustedReason[issueA.ID]; got != budgetReasonToken {
+			t.Errorf("BudgetExhaustedReason[%s] = %q, want %q (prior reason carried)", issueA.ID, got, budgetReasonToken)
+		}
+		if _, running := state.Running[issueA.ID]; running {
+			t.Errorf("Running[%s] present, want absent (issue stays blocked this tick)", issueA.ID)
+		}
+	})
+
+	t.Run("session query failure folds prior set with carried reasons", func(t *testing.T) {
+		t.Parallel()
+
+		wm := budgetTickConfigTokens(3, 0)
+		store := &stubStore{budgetExhaustedErr: fmt.Errorf("db error")}
+		state := NewState(60000, 10, nil, AgentTotals{})
+		state.BudgetExhausted[issueA.ID] = struct{}{}
+		state.BudgetExhaustedReason[issueA.ID] = budgetReasonSession
+
+		budgetOrchestrator(state, wm, store, candidates(issueA)).handleTick(context.Background())
+
+		if _, ok := state.BudgetExhausted[issueA.ID]; !ok {
+			t.Errorf("BudgetExhausted[%s] dropped on session query error, want retained", issueA.ID)
+		}
+		if got := state.BudgetExhaustedReason[issueA.ID]; got != budgetReasonSession {
+			t.Errorf("BudgetExhaustedReason[%s] = %q, want %q (prior reason carried)", issueA.ID, got, budgetReasonSession)
+		}
+	})
+
+	t.Run("both ceilings zero clears set and reason map", func(t *testing.T) {
+		t.Parallel()
+
+		wm := budgetTickConfigTokens(0, 0)
+		store := &stubStore{}
+		state := NewState(60000, 10, nil, AgentTotals{})
+		state.BudgetExhausted[issueA.ID] = struct{}{}
+		state.BudgetExhaustedReason[issueA.ID] = budgetReasonToken
+
+		budgetOrchestrator(state, wm, store, candidates(issueA)).handleTick(context.Background())
+
+		if len(state.BudgetExhausted) != 0 {
+			t.Errorf("BudgetExhausted = %v, want empty with both ceilings disabled", state.BudgetExhausted)
+		}
+		if len(state.BudgetExhaustedReason) != 0 {
+			t.Errorf("BudgetExhaustedReason = %v, want empty with both ceilings disabled", state.BudgetExhaustedReason)
+		}
+	})
+
+	t.Run("empty candidate list clears set and reason map in lockstep", func(t *testing.T) {
+		t.Parallel()
+
+		wm := budgetTickConfigTokens(3, 1000)
+		store := &stubStore{}
+		state := NewState(60000, 10, nil, AgentTotals{})
+		state.BudgetExhausted[issueA.ID] = struct{}{}
+		state.BudgetExhaustedReason[issueA.ID] = budgetReasonToken
+
+		budgetOrchestrator(state, wm, store, candidates()).handleTick(context.Background())
+
+		// Both batch queries return empty for an empty candidate list, so
+		// the rebuild assigns an empty fresh set; the issue is re-blocked on
+		// the next tick that has candidates, from the run_history ledger.
+		if len(state.BudgetExhausted) != 0 {
+			t.Errorf("BudgetExhausted = %v, want cleared on empty candidate list", state.BudgetExhausted)
+		}
+		if len(state.BudgetExhaustedReason) != 0 {
+			t.Errorf("BudgetExhaustedReason = %v, want cleared in lockstep", state.BudgetExhaustedReason)
+		}
+	})
+}
+
+// --- Incremental session_metadata write tests ---
+
+// tokenUsageEvent returns a token_usage agent event with cumulative counters.
+func tokenUsageEvent(input, output, total, cacheRead int64) domain.AgentEvent {
+	return domain.AgentEvent{
+		Type:      domain.EventTokenUsage,
+		Timestamp: time.Now().UTC(),
+		Usage: domain.TokenUsage{
+			InputTokens:     input,
+			OutputTokens:    output,
+			TotalTokens:     total,
+			CacheReadTokens: cacheRead,
+		},
+	}
+}
+
+// incrementalWriteOrchestrator builds an orchestrator with a running entry
+// whose accumulated token counters are pre-set, for driving
+// maybeWriteIncrementalMetadata directly.
+func incrementalWriteOrchestrator(t *testing.T, store *stubStore) (*Orchestrator, *RunningEntry) {
+	t.Helper()
+	state := NewState(60000, 10, nil, AgentTotals{})
+	entry := &RunningEntry{
+		Identifier:        "MT-1",
+		Issue:             domain.Issue{ID: "id-1", Identifier: "MT-1", State: "In Progress"},
+		StartedAt:         time.Now().UTC(),
+		SessionID:         "sess-1",
+		AgentInputTokens:  10,
+		AgentOutputTokens: 20,
+		AgentTotalTokens:  30,
+		CacheReadTokens:   5,
+		ModelName:         "test-model",
+		APIRequestCount:   2,
+	}
+	state.Running["id-1"] = entry
+	tracker := &candidateTrackerAdapter{mockTrackerAdapter: &mockTrackerAdapter{}}
+	return budgetOrchestrator(state, budgetTickConfig(0), store, tracker), entry
+}
+
+func TestMaybeWriteIncrementalMetadata(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	t.Run("first token usage event writes immediately", func(t *testing.T) {
+		t.Parallel()
+
+		store := &stubStore{}
+		o, entry := incrementalWriteOrchestrator(t, store)
+
+		o.maybeWriteIncrementalMetadata(ctx, "id-1", tokenUsageEvent(10, 20, 30, 5))
+
+		writes := store.sessionWrites()
+		if len(writes) != 1 {
+			t.Fatalf("UpsertSessionMetadata calls = %d, want 1", len(writes))
+		}
+		meta := writes[0]
+		if meta.IssueID != "id-1" {
+			t.Errorf("SessionMetadata.IssueID = %q, want %q", meta.IssueID, "id-1")
+		}
+		if meta.SessionID != "sess-1" {
+			t.Errorf("SessionMetadata.SessionID = %q, want %q", meta.SessionID, "sess-1")
+		}
+		if meta.InputTokens != 10 || meta.OutputTokens != 20 || meta.TotalTokens != 30 || meta.CacheReadTokens != 5 {
+			t.Errorf("SessionMetadata tokens = (%d, %d, %d, %d), want (10, 20, 30, 5)",
+				meta.InputTokens, meta.OutputTokens, meta.TotalTokens, meta.CacheReadTokens)
+		}
+		if meta.ModelName != "test-model" {
+			t.Errorf("SessionMetadata.ModelName = %q, want %q", meta.ModelName, "test-model")
+		}
+		if entry.LastMetadataWrite.IsZero() {
+			t.Error("RunningEntry.LastMetadataWrite still zero after successful write")
+		}
+	})
+
+	t.Run("second event within interval is throttled", func(t *testing.T) {
+		t.Parallel()
+
+		store := &stubStore{}
+		o, _ := incrementalWriteOrchestrator(t, store)
+
+		o.maybeWriteIncrementalMetadata(ctx, "id-1", tokenUsageEvent(10, 20, 30, 5))
+		o.maybeWriteIncrementalMetadata(ctx, "id-1", tokenUsageEvent(11, 21, 33, 5))
+
+		if writes := store.sessionWrites(); len(writes) != 1 {
+			t.Errorf("UpsertSessionMetadata calls = %d, want 1 (second event throttled)", len(writes))
+		}
+	})
+
+	t.Run("event after interval elapses writes again", func(t *testing.T) {
+		t.Parallel()
+
+		store := &stubStore{}
+		o, entry := incrementalWriteOrchestrator(t, store)
+
+		o.maybeWriteIncrementalMetadata(ctx, "id-1", tokenUsageEvent(10, 20, 30, 5))
+		// Backdate the last write past the throttle interval.
+		entry.LastMetadataWrite = time.Now().UTC().Add(-sessionMetadataWriteInterval - time.Second)
+		o.maybeWriteIncrementalMetadata(ctx, "id-1", tokenUsageEvent(11, 21, 33, 6))
+
+		if writes := store.sessionWrites(); len(writes) != 2 {
+			t.Errorf("UpsertSessionMetadata calls = %d, want 2 (interval elapsed)", len(writes))
+		}
+	})
+
+	t.Run("non token_usage event is ignored", func(t *testing.T) {
+		t.Parallel()
+
+		store := &stubStore{}
+		o, _ := incrementalWriteOrchestrator(t, store)
+
+		o.maybeWriteIncrementalMetadata(ctx, "id-1", domain.AgentEvent{
+			Type:      domain.EventTurnCompleted,
+			Timestamp: time.Now().UTC(),
+		})
+
+		if writes := store.sessionWrites(); len(writes) != 0 {
+			t.Errorf("UpsertSessionMetadata calls = %d, want 0 (non-token event)", len(writes))
+		}
+	})
+
+	t.Run("unknown issue is ignored", func(t *testing.T) {
+		t.Parallel()
+
+		store := &stubStore{}
+		o, _ := incrementalWriteOrchestrator(t, store)
+
+		o.maybeWriteIncrementalMetadata(ctx, "id-unknown", tokenUsageEvent(10, 20, 30, 5))
+
+		if writes := store.sessionWrites(); len(writes) != 0 {
+			t.Errorf("UpsertSessionMetadata calls = %d, want 0 (unknown issue)", len(writes))
+		}
+	})
+
+	t.Run("store error does not advance the throttle timestamp", func(t *testing.T) {
+		t.Parallel()
+
+		store := &stubStore{upsertSessionMetadataErr: fmt.Errorf("disk full")}
+		o, entry := incrementalWriteOrchestrator(t, store)
+
+		o.maybeWriteIncrementalMetadata(ctx, "id-1", tokenUsageEvent(10, 20, 30, 5))
+
+		if !entry.LastMetadataWrite.IsZero() {
+			t.Error("RunningEntry.LastMetadataWrite advanced after failed write, want zero")
+		}
+		// The next event retries immediately because the timestamp did not move.
+		o.maybeWriteIncrementalMetadata(ctx, "id-1", tokenUsageEvent(11, 21, 33, 6))
+		if writes := store.sessionWrites(); len(writes) != 2 {
+			t.Errorf("UpsertSessionMetadata calls = %d, want 2 (failed write not throttled)", len(writes))
+		}
+	})
+}
+
+// TestDrainRunningWorkers_TokenUsageEventTriggersIncrementalWrite delivers a
+// token_usage event on the drain-loop agentEventCh site and asserts an
+// incremental session_metadata write occurs before the worker exits, so the
+// advisory staleness bound holds during graceful drain.
+func TestDrainRunningWorkers_TokenUsageEventTriggersIncrementalWrite(t *testing.T) {
+	t.Parallel()
+
+	state := NewState(60000, 1, nil, AgentTotals{})
+	state.Running["id-1"] = &RunningEntry{
+		Identifier: "MT-1",
+		Issue:      domain.Issue{ID: "id-1", Identifier: "MT-1", State: "In Progress"},
+		StartedAt:  time.Now().UTC(),
+		SessionID:  "sess-1",
+		CancelFunc: func() {},
+	}
+	store := &stubStore{}
+	tracker := &candidateTrackerAdapter{mockTrackerAdapter: &mockTrackerAdapter{}}
+	o := budgetOrchestrator(state, budgetTickConfig(0), store, tracker)
+
+	// Run never starts: the drain loop is the only consumer of
+	// agentEventCh, so the event below is processed at the drain site.
+	done := make(chan struct{})
+	go func() {
+		o.drainRunningWorkers()
+		close(done)
+	}()
+
+	o.agentEventCh <- agentEventMsg{IssueID: "id-1", Event: tokenUsageEvent(10, 20, 30, 5)}
+
+	// The incremental write must land before the worker exit is delivered;
+	// the exit-path metadata write cannot have happened yet.
+	deadline := time.After(10 * time.Second)
+	for len(store.sessionWrites()) == 0 {
+		select {
+		case <-deadline:
+			t.Fatal("timed out waiting for incremental session_metadata write during drain")
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+
+	meta := store.sessionWrites()[0]
+	if meta.IssueID != "id-1" {
+		t.Errorf("SessionMetadata.IssueID = %q, want %q", meta.IssueID, "id-1")
+	}
+	if meta.SessionID != "sess-1" {
+		t.Errorf("SessionMetadata.SessionID = %q, want %q", meta.SessionID, "sess-1")
+	}
+	if meta.TotalTokens != 30 {
+		t.Errorf("SessionMetadata.TotalTokens = %d, want 30", meta.TotalTokens)
+	}
+
+	// Let the drain complete.
+	o.workerExitCh <- WorkerResult{IssueID: "id-1", Identifier: "MT-1"}
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("drainRunningWorkers did not return within 10 seconds")
+	}
 }
 
 // TestBudgetExhaustionPreventsRedispatch verifies that an issue whose budget is

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -3551,6 +3551,7 @@ func TestHandleTick_BudgetExhaustionRebuildsState(t *testing.T) {
 		store := &stubStore{budgetExhaustedErr: fmt.Errorf("db error")}
 		state := NewState(60000, 10, nil, AgentTotals{})
 		state.BudgetExhausted[issue.ID] = struct{}{} // pre-populated
+		state.BudgetExhaustedReason[issue.ID] = budgetReasonSession
 		tracker := &candidateTrackerAdapter{
 			mockTrackerAdapter: &mockTrackerAdapter{},
 			fetchCandidatesFn:  func(_ context.Context) ([]domain.Issue, error) { return []domain.Issue{issue}, nil },
@@ -3757,6 +3758,76 @@ func TestHandleTick_TokenBudgetRebuild(t *testing.T) {
 		}
 		if got := state.BudgetExhaustedReason[issueA.ID]; got != budgetReasonSession {
 			t.Errorf("BudgetExhaustedReason[%s] = %q, want %q (prior reason carried)", issueA.ID, got, budgetReasonSession)
+		}
+	})
+
+	t.Run("session query failure carries only session-attributed entries", func(t *testing.T) {
+		t.Parallel()
+
+		wm := budgetTickConfigTokens(3, 1000)
+		// Session query fails while the token query succeeds and reports
+		// the issue back under budget. The session-axis fold must not
+		// resurrect an entry attributed to the token budget.
+		store := &stubStore{budgetExhaustedErr: fmt.Errorf("db error")}
+		state := NewState(60000, 10, nil, AgentTotals{})
+		state.BudgetExhausted[issueA.ID] = struct{}{}
+		state.BudgetExhaustedReason[issueA.ID] = budgetReasonToken
+
+		budgetOrchestrator(state, wm, store, candidates(issueA)).handleTick(context.Background())
+
+		if _, ok := state.BudgetExhausted[issueA.ID]; ok {
+			t.Errorf("BudgetExhausted[%s] retained by session-axis fold, want dropped (fresh token result cleared it)", issueA.ID)
+		}
+		if got, ok := state.BudgetExhaustedReason[issueA.ID]; ok {
+			t.Errorf("BudgetExhaustedReason[%s] = %q, want pruned in lockstep", issueA.ID, got)
+		}
+	})
+
+	t.Run("token query failure carries only token-attributed entries when session ceiling disabled", func(t *testing.T) {
+		t.Parallel()
+
+		wm := budgetTickConfigTokens(0, 1000)
+		// With the session ceiling disabled, a prior session-attributed
+		// entry has no axis to survive on: the token-axis fold must not
+		// carry it forward.
+		store := &stubStore{tokenExhaustedErr: fmt.Errorf("db error")}
+		state := NewState(60000, 10, nil, AgentTotals{})
+		state.BudgetExhausted[issueA.ID] = struct{}{}
+		state.BudgetExhaustedReason[issueA.ID] = budgetReasonSession
+
+		budgetOrchestrator(state, wm, store, candidates(issueA)).handleTick(context.Background())
+
+		if _, ok := state.BudgetExhausted[issueA.ID]; ok {
+			t.Errorf("BudgetExhausted[%s] retained by token-axis fold, want dropped (session ceiling disabled)", issueA.ID)
+		}
+		if got, ok := state.BudgetExhaustedReason[issueA.ID]; ok {
+			t.Errorf("BudgetExhaustedReason[%s] = %q, want pruned in lockstep", issueA.ID, got)
+		}
+	})
+
+	t.Run("token query failure reports token reason when session query also finds the issue", func(t *testing.T) {
+		t.Parallel()
+
+		wm := budgetTickConfigTokens(3, 1000)
+		// Session query succeeds and blocks the issue; the token query
+		// fails and folds the prior token-attributed entry back in. The
+		// carried entry reports the token budget, matching the precedence
+		// the success path applies when both axes block an issue.
+		store := &stubStore{
+			budgetExhaustedIDs: []string{issueA.ID},
+			tokenExhaustedErr:  fmt.Errorf("db error"),
+		}
+		state := NewState(60000, 10, nil, AgentTotals{})
+		state.BudgetExhausted[issueA.ID] = struct{}{}
+		state.BudgetExhaustedReason[issueA.ID] = budgetReasonToken
+
+		budgetOrchestrator(state, wm, store, candidates(issueA)).handleTick(context.Background())
+
+		if _, ok := state.BudgetExhausted[issueA.ID]; !ok {
+			t.Fatalf("BudgetExhausted[%s] missing after tick, want present (blocked on both axes)", issueA.ID)
+		}
+		if got := state.BudgetExhaustedReason[issueA.ID]; got != budgetReasonToken {
+			t.Errorf("BudgetExhaustedReason[%s] = %q, want %q (token precedence on carried entry)", issueA.ID, got, budgetReasonToken)
 		}
 	})
 

--- a/internal/orchestrator/retry.go
+++ b/internal/orchestrator/retry.go
@@ -19,6 +19,7 @@ type RetryTimerStore interface {
 	SaveRetryEntry(ctx context.Context, entry persistence.RetryEntry) error
 	DeleteRetryEntry(ctx context.Context, issueID string) error
 	CountRunHistoryByIssue(ctx context.Context, issueID string) (int, error)
+	SumTotalTokensByIssue(ctx context.Context, issueID string) (int64, int, error)
 	MarkReactionDispatched(ctx context.Context, issueID, kind string) error
 }
 
@@ -95,6 +96,13 @@ type HandleRetryTimerParams struct {
 	// the claim instead of dispatching if the count has reached the
 	// budget. When 0, no budget is enforced.
 	MaxSessions int
+
+	// MaxTokens is the configured per-issue token budget (from
+	// config.Agent.MaxTokens). When > 0, HandleRetryTimer sums
+	// run_history total_tokens for the issue and releases the claim
+	// instead of dispatching if the sum has reached the budget. When 0,
+	// no token budget is enforced.
+	MaxTokens int
 
 	// Metrics records instrumentation counters for retry timer events.
 	// If nil, defaults to [domain.NoopMetrics].
@@ -197,6 +205,27 @@ func HandleRetryTimer(state *State, issueID string, params HandleRetryTimerParam
 		return
 	}
 
+	// blockBudget releases the claim and drops the retry entry for an issue
+	// whose budget is exhausted, recording the firing ceiling's reason. The
+	// block is identical whichever ceiling triggers it; only the recorded
+	// reason differs. The token gate may call this after the session gate
+	// already did, overwriting the reason with the token budget so an issue
+	// exhausted on both axes reports the token budget.
+	blocked := false
+	blockBudget := func(reason string) {
+		state.BudgetExhausted[issueID] = struct{}{}
+		state.BudgetExhaustedReason[issueID] = reason
+		delete(state.Claimed, issueID)
+		if !blocked {
+			if err := params.Store.DeleteRetryEntry(ctx, issueID); err != nil {
+				log.Error("failed to delete retry entry after budget exhaustion",
+					slog.Any("error", err),
+				)
+			}
+		}
+		blocked = true
+	}
+
 	// Effort budget gate: when max_sessions > 0, count completed sessions
 	// for this issue and release the claim if the budget is exhausted.
 	// Runs before the tracker fetch to avoid a wasted network call.
@@ -211,15 +240,36 @@ func HandleRetryTimer(state *State, issueID string, params HandleRetryTimerParam
 				slog.Int("count", count),
 				slog.Int("max_sessions", params.MaxSessions),
 			)
-			state.BudgetExhausted[issueID] = struct{}{}
-			delete(state.Claimed, issueID)
-			if err := params.Store.DeleteRetryEntry(ctx, issueID); err != nil {
-				log.Error("failed to delete retry entry after budget exhaustion",
-					slog.Any("error", err),
-				)
-			}
-			return
+			blockBudget(budgetReasonSession)
 		}
+	}
+
+	// Token budget gate: when max_tokens > 0, sum completed-session tokens
+	// for this issue and release the claim if the budget is exhausted.
+	// Evaluated after the session gate so that an issue exhausted on both
+	// axes reports the token budget. A token-query error fails open on the
+	// token axis only: a session block already recorded above still holds.
+	// Runs before the tracker fetch.
+	if params.MaxTokens > 0 {
+		sumTokens, sessionCount, sumErr := params.Store.SumTotalTokensByIssue(ctx, issueID)
+		if sumErr != nil {
+			log.Warn("token budget check failed, proceeding with dispatch",
+				slog.Any("error", sumErr),
+			)
+		} else if sumTokens >= int64(params.MaxTokens) {
+			log.Warn("token budget exhausted, blocking re-dispatch",
+				slog.String("reason", budgetReasonToken),
+				slog.Int64("used_tokens", sumTokens),
+				slog.Int("budget_tokens", params.MaxTokens),
+				slog.Int("used_sessions", sessionCount),
+				slog.Int("budget_sessions", params.MaxSessions),
+			)
+			blockBudget(budgetReasonToken)
+		}
+	}
+
+	if blocked {
+		return
 	}
 
 	// Re-validate the issue with a single tracker API call instead of a

--- a/internal/orchestrator/retry_test.go
+++ b/internal/orchestrator/retry_test.go
@@ -1,9 +1,11 @@
 package orchestrator
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"log/slog"
+	"strings"
 	"testing"
 	"time"
 
@@ -24,6 +26,11 @@ type mockRetryStore struct {
 	runHistoryCount           int
 	countRunHistoryByIssueErr error
 	countedIssueIDs           []string
+
+	tokenSum                 int64
+	tokenSessionCount        int
+	sumTotalTokensByIssueErr error
+	summedTokenIssueIDs      []string
 
 	markDispatchedCalls   int
 	markDispatchedIssueID string
@@ -46,6 +53,11 @@ func (m *mockRetryStore) DeleteRetryEntry(_ context.Context, issueID string) err
 func (m *mockRetryStore) CountRunHistoryByIssue(_ context.Context, issueID string) (int, error) {
 	m.countedIssueIDs = append(m.countedIssueIDs, issueID)
 	return m.runHistoryCount, m.countRunHistoryByIssueErr
+}
+
+func (m *mockRetryStore) SumTotalTokensByIssue(_ context.Context, issueID string) (int64, int, error) {
+	m.summedTokenIssueIDs = append(m.summedTokenIssueIDs, issueID)
+	return m.tokenSum, m.tokenSessionCount, m.sumTotalTokensByIssueErr
 }
 
 func (m *mockRetryStore) AppendRunHistory(_ context.Context, run persistence.RunHistory) (persistence.RunHistory, error) {
@@ -185,6 +197,7 @@ func TestHandleRetryTimer(t *testing.T) {
 		tracker func(issueID string) *mockRetryTracker
 		// overrides applied after defaultRetryParams
 		maxSessions int
+		maxTokens   int
 		workerFn    func(ch chan<- struct{}) WorkerFunc
 		// assertions
 		check func(t *testing.T, issueID string, state *State, store *mockRetryStore, tracker *mockRetryTracker, workerCalled bool)
@@ -890,6 +903,271 @@ func TestHandleRetryTimer(t *testing.T) {
 			},
 		},
 		{
+			name:      "token budget exhausted blocks dispatch and records reason",
+			issueID:   "ISS-TOK",
+			maxTokens: 1000,
+			state: func(t *testing.T, id string) *State {
+				t.Helper()
+				return retryState(t, id, "PROJ-TOK", 2)
+			},
+			store: func() *mockRetryStore {
+				return &mockRetryStore{tokenSum: 1000, tokenSessionCount: 2}
+			},
+			tracker: func(_ string) *mockRetryTracker {
+				return &mockRetryTracker{}
+			},
+			check: func(t *testing.T, id string, state *State, store *mockRetryStore, tracker *mockRetryTracker, _ bool) {
+				t.Helper()
+				// Claim released.
+				if _, claimed := state.Claimed[id]; claimed {
+					t.Errorf("Claimed[%s] still present, want released (token budget exhausted)", id)
+				}
+				// Not dispatched.
+				if _, running := state.Running[id]; running {
+					t.Errorf("Running[%s] present, want absent (token budget exhausted)", id)
+				}
+				// BudgetExhausted set must contain this issue with the token reason.
+				if _, exhausted := state.BudgetExhausted[id]; !exhausted {
+					t.Errorf("BudgetExhausted[%s] missing, want present after token budget exhaustion", id)
+				}
+				if got := state.BudgetExhaustedReason[id]; got != budgetReasonToken {
+					t.Errorf("BudgetExhaustedReason[%s] = %q, want %q", id, got, budgetReasonToken)
+				}
+				// The dispatcher gate must refuse the issue.
+				if ShouldDispatch(candidateIssue(id, "PROJ-TOK", "To Do"), state, []string{"To Do", "In Progress"}, []string{"Done"}) {
+					t.Errorf("ShouldDispatch(%s) = true, want false (token budget exhausted)", id)
+				}
+				// Tracker never called — budget checks run before fetch.
+				if tracker.fetchCount != 0 {
+					t.Errorf("FetchIssueByID call count = %d, want 0", tracker.fetchCount)
+				}
+				// DeleteRetryEntry called.
+				if len(store.deletedIssueID) != 1 || store.deletedIssueID[0] != id {
+					t.Errorf("DeleteRetryEntry calls = %v, want [%s]", store.deletedIssueID, id)
+				}
+				// SumTotalTokensByIssue was called with the correct ID.
+				if len(store.summedTokenIssueIDs) != 1 || store.summedTokenIssueIDs[0] != id {
+					t.Errorf("SumTotalTokensByIssue calls = %v, want [%s]", store.summedTokenIssueIDs, id)
+				}
+			},
+		},
+		{
+			name:      "token budget under limit allows dispatch",
+			issueID:   "ISS-TOK-UNDER",
+			maxTokens: 1000,
+			state: func(t *testing.T, id string) *State {
+				t.Helper()
+				return retryState(t, id, "PROJ-TOK-UNDER", 1)
+			},
+			store: func() *mockRetryStore {
+				return &mockRetryStore{tokenSum: 999, tokenSessionCount: 3}
+			},
+			tracker: func(id string) *mockRetryTracker {
+				return &mockRetryTracker{
+					fetchedIssue: candidateIssue(id, "PROJ-TOK-UNDER", "To Do"),
+				}
+			},
+			workerFn: func(ch chan<- struct{}) WorkerFunc {
+				return func(_ context.Context, _ domain.Issue, _ *int) {
+					ch <- struct{}{}
+				}
+			},
+			check: func(t *testing.T, id string, state *State, store *mockRetryStore, tracker *mockRetryTracker, workerCalled bool) {
+				t.Helper()
+				// Budget was checked.
+				if len(store.summedTokenIssueIDs) != 1 || store.summedTokenIssueIDs[0] != id {
+					t.Errorf("SumTotalTokensByIssue calls = %v, want [%s]", store.summedTokenIssueIDs, id)
+				}
+				// Tracker called and issue dispatched.
+				if tracker.fetchCount != 1 {
+					t.Errorf("FetchIssueByID call count = %d, want 1", tracker.fetchCount)
+				}
+				if _, ok := state.Running[id]; !ok {
+					t.Fatalf("Running[%s] missing after dispatch, want present", id)
+				}
+				if !workerCalled {
+					t.Error("worker function not invoked, want invoked")
+				}
+				// No reason recorded for a dispatched issue.
+				if got, ok := state.BudgetExhaustedReason[id]; ok {
+					t.Errorf("BudgetExhaustedReason[%s] = %q, want absent", id, got)
+				}
+			},
+		},
+		{
+			name:    "max_tokens zero skips token check",
+			issueID: "ISS-TOK-NOLIMIT",
+			state: func(t *testing.T, id string) *State {
+				t.Helper()
+				return retryState(t, id, "PROJ-TOK-NOLIMIT", 1)
+			},
+			store: func() *mockRetryStore {
+				return &mockRetryStore{tokenSum: 99999}
+			},
+			tracker: func(id string) *mockRetryTracker {
+				return &mockRetryTracker{
+					fetchedIssue: candidateIssue(id, "PROJ-TOK-NOLIMIT", "To Do"),
+				}
+			},
+			workerFn: func(ch chan<- struct{}) WorkerFunc {
+				return func(_ context.Context, _ domain.Issue, _ *int) {
+					ch <- struct{}{}
+				}
+			},
+			check: func(t *testing.T, id string, state *State, store *mockRetryStore, tracker *mockRetryTracker, workerCalled bool) {
+				t.Helper()
+				// SumTotalTokensByIssue never called — MaxTokens is 0.
+				if len(store.summedTokenIssueIDs) != 0 {
+					t.Errorf("SumTotalTokensByIssue calls = %v, want empty (MaxTokens=0)", store.summedTokenIssueIDs)
+				}
+				if tracker.fetchCount != 1 {
+					t.Errorf("FetchIssueByID call count = %d, want 1", tracker.fetchCount)
+				}
+				if _, ok := state.Running[id]; !ok {
+					t.Fatalf("Running[%s] missing after dispatch, want present", id)
+				}
+				if !workerCalled {
+					t.Error("worker function not invoked, want invoked")
+				}
+			},
+		},
+		{
+			name:      "token sum store error is fail-open",
+			issueID:   "ISS-TOK-FAIL",
+			maxTokens: 1000,
+			state: func(t *testing.T, id string) *State {
+				t.Helper()
+				return retryState(t, id, "PROJ-TOK-FAIL", 1)
+			},
+			store: func() *mockRetryStore {
+				return &mockRetryStore{
+					tokenSum:                 99999,
+					sumTotalTokensByIssueErr: errors.New("database locked"),
+				}
+			},
+			tracker: func(id string) *mockRetryTracker {
+				return &mockRetryTracker{
+					fetchedIssue: candidateIssue(id, "PROJ-TOK-FAIL", "To Do"),
+				}
+			},
+			workerFn: func(ch chan<- struct{}) WorkerFunc {
+				return func(_ context.Context, _ domain.Issue, _ *int) {
+					ch <- struct{}{}
+				}
+			},
+			check: func(t *testing.T, id string, state *State, store *mockRetryStore, tracker *mockRetryTracker, workerCalled bool) {
+				t.Helper()
+				// Sum was attempted.
+				if len(store.summedTokenIssueIDs) != 1 || store.summedTokenIssueIDs[0] != id {
+					t.Errorf("SumTotalTokensByIssue calls = %v, want [%s]", store.summedTokenIssueIDs, id)
+				}
+				// Tracker called — fail-open.
+				if tracker.fetchCount != 1 {
+					t.Errorf("FetchIssueByID call count = %d, want 1 (fail-open)", tracker.fetchCount)
+				}
+				// Issue dispatched despite sum error — never stranded.
+				if _, ok := state.Running[id]; !ok {
+					t.Fatalf("Running[%s] missing after dispatch, want present (fail-open)", id)
+				}
+				if !workerCalled {
+					t.Error("worker function not invoked, want invoked (fail-open)")
+				}
+				if _, exhausted := state.BudgetExhausted[id]; exhausted {
+					t.Errorf("BudgetExhausted[%s] present after fail-open, want absent", id)
+				}
+				// Claim preserved (issue is running).
+				if _, claimed := state.Claimed[id]; !claimed {
+					t.Errorf("Claimed[%s] missing, want claimed", id)
+				}
+			},
+		},
+		{
+			name:        "both budgets exhausted records token budget reason",
+			issueID:     "ISS-BOTH",
+			maxSessions: 3,
+			maxTokens:   1000,
+			state: func(t *testing.T, id string) *State {
+				t.Helper()
+				return retryState(t, id, "PROJ-BOTH", 2)
+			},
+			store: func() *mockRetryStore {
+				return &mockRetryStore{
+					runHistoryCount:   3,
+					tokenSum:          1500,
+					tokenSessionCount: 3,
+				}
+			},
+			tracker: func(_ string) *mockRetryTracker {
+				return &mockRetryTracker{}
+			},
+			check: func(t *testing.T, id string, state *State, store *mockRetryStore, tracker *mockRetryTracker, _ bool) {
+				t.Helper()
+				// Blocked either way: claim released, not dispatched.
+				if _, claimed := state.Claimed[id]; claimed {
+					t.Errorf("Claimed[%s] still present, want released (both budgets exhausted)", id)
+				}
+				if tracker.fetchCount != 0 {
+					t.Errorf("FetchIssueByID call count = %d, want 0", tracker.fetchCount)
+				}
+				if _, exhausted := state.BudgetExhausted[id]; !exhausted {
+					t.Errorf("BudgetExhausted[%s] missing, want present after exhaustion", id)
+				}
+				// A single evaluation that finds both ceilings exhausted must
+				// report the token budget.
+				if got := state.BudgetExhaustedReason[id]; got != budgetReasonToken {
+					t.Errorf("BudgetExhaustedReason[%s] = %q, want %q (token precedence)", id, got, budgetReasonToken)
+				}
+			},
+		},
+		{
+			name:        "both budgets exhausted with token sum error keeps session reason",
+			issueID:     "ISS-BOTH-TOK-FAIL",
+			maxSessions: 3,
+			maxTokens:   1000,
+			state: func(t *testing.T, id string) *State {
+				t.Helper()
+				return retryState(t, id, "PROJ-BOTH-TOK-FAIL", 2)
+			},
+			store: func() *mockRetryStore {
+				return &mockRetryStore{
+					runHistoryCount:          3,
+					tokenSum:                 1500,
+					tokenSessionCount:        3,
+					sumTotalTokensByIssueErr: errors.New("database locked"),
+				}
+			},
+			tracker: func(_ string) *mockRetryTracker {
+				return &mockRetryTracker{}
+			},
+			check: func(t *testing.T, id string, state *State, store *mockRetryStore, tracker *mockRetryTracker, _ bool) {
+				t.Helper()
+				// The session ceiling's block holds even though the token
+				// axis failed open: claim released, issue not dispatched.
+				if _, claimed := state.Claimed[id]; claimed {
+					t.Errorf("Claimed[%s] still present, want released (session budget exhausted)", id)
+				}
+				if _, exhausted := state.BudgetExhausted[id]; !exhausted {
+					t.Errorf("BudgetExhausted[%s] missing, want present after session exhaustion", id)
+				}
+				// The errored token gate must not overwrite the session reason.
+				if got := state.BudgetExhaustedReason[id]; got != budgetReasonSession {
+					t.Errorf("BudgetExhaustedReason[%s] = %q, want %q (token axis failed open)", id, got, budgetReasonSession)
+				}
+				// Token sum was attempted before failing open.
+				if len(store.summedTokenIssueIDs) != 1 || store.summedTokenIssueIDs[0] != id {
+					t.Errorf("SumTotalTokensByIssue calls = %v, want [%s]", store.summedTokenIssueIDs, id)
+				}
+				// Tracker never called — the session block short-circuits the fetch.
+				if tracker.fetchCount != 0 {
+					t.Errorf("FetchIssueByID call count = %d, want 0", tracker.fetchCount)
+				}
+				// DeleteRetryEntry called exactly once, by the session block.
+				if len(store.deletedIssueID) != 1 || store.deletedIssueID[0] != id {
+					t.Errorf("DeleteRetryEntry calls = %v, want [%s]", store.deletedIssueID, id)
+				}
+			},
+		},
+		{
 			name:    "ErrTrackerNotFound releases claim",
 			issueID: "ISS-X",
 			state: func(t *testing.T, id string) *State {
@@ -1099,6 +1377,7 @@ func TestHandleRetryTimer(t *testing.T) {
 			tracker := tt.tracker(id)
 			params := defaultRetryParams(t, store, tracker)
 			params.MaxSessions = tt.maxSessions
+			params.MaxTokens = tt.maxTokens
 
 			var workerCalled bool
 			if tt.workerFn != nil {
@@ -1118,6 +1397,83 @@ func TestHandleRetryTimer(t *testing.T) {
 
 			tt.check(t, id, state, store, tracker, workerCalled)
 		})
+	}
+}
+
+// TestHandleRetryTimer_TokenBudgetLogLine asserts the structured refusal
+// log line carries the typed attributes the token gate emits.
+func TestHandleRetryTimer_TokenBudgetLogLine(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	store := &mockRetryStore{tokenSum: 1500, tokenSessionCount: 2}
+	tracker := &mockRetryTracker{}
+	state := retryState(t, "ISS-TOK-LOG", "PROJ-TOK-LOG", 1)
+
+	params := defaultRetryParams(t, store, tracker)
+	params.MaxTokens = 1000
+	params.Logger = logger
+
+	HandleRetryTimer(state, "ISS-TOK-LOG", params)
+
+	output := buf.String()
+	if !strings.Contains(output, "token budget exhausted, blocking re-dispatch") {
+		t.Fatalf("log output = %q, want to contain the token refusal message", output)
+	}
+	for _, attr := range []string{
+		"reason=token_budget",
+		"used_tokens=1500",
+		"budget_tokens=1000",
+		"used_sessions=2",
+		"budget_sessions=0",
+		"issue_id=ISS-TOK-LOG",
+	} {
+		if !strings.Contains(output, attr) {
+			t.Errorf("log output missing attribute %q: %q", attr, output)
+		}
+	}
+}
+
+// TestHandleRetryTimer_TokenBudgetFailOpenLogsWarning asserts the fail-open
+// path logs a warning instead of stranding the issue silently.
+func TestHandleRetryTimer_TokenBudgetFailOpenLogsWarning(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	store := &mockRetryStore{sumTotalTokensByIssueErr: errors.New("database locked")}
+	tracker := &mockRetryTracker{
+		fetchedIssue: candidateIssue("ISS-TOK-WARN", "PROJ-TOK-WARN", "To Do"),
+	}
+	state := retryState(t, "ISS-TOK-WARN", "PROJ-TOK-WARN", 1)
+
+	dispatched := make(chan struct{}, 1)
+	params := defaultRetryParams(t, store, tracker)
+	params.MaxTokens = 1000
+	params.Logger = logger
+	params.MakeWorkerFn = func(_, _, _, _ string, _ domain.AgentAdapter) WorkerFunc {
+		return func(_ context.Context, _ domain.Issue, _ *int) {
+			dispatched <- struct{}{}
+		}
+	}
+
+	HandleRetryTimer(state, "ISS-TOK-WARN", params)
+
+	select {
+	case <-dispatched:
+	case <-time.After(time.Second):
+		t.Fatal("worker not dispatched within 1 second (fail-open must dispatch)")
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "token budget check failed, proceeding with dispatch") {
+		t.Errorf("log output = %q, want to contain the fail-open warning", output)
+	}
+	if !strings.Contains(output, "error=") {
+		t.Errorf("log output missing error attribute: %q", output)
 	}
 }
 

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -43,6 +43,14 @@ const (
 	handoffSkipped = "skipped"
 )
 
+// Budget reason values recorded in [State.BudgetExhaustedReason] and the
+// runtime snapshot. budgetReasonToken takes precedence when both budgets
+// are exhausted for one issue.
+const (
+	budgetReasonToken   = "token_budget"
+	budgetReasonSession = "session_budget"
+)
+
 // AgentTotals holds cumulative token and runtime counters across all ended
 // agent sessions. These values are persisted to SQLite (aggregate_metrics
 // table, key "agent_totals") and restored on startup.
@@ -234,6 +242,13 @@ type RunningEntry struct {
 	// Used by the worker to look up the parsed template via the
 	// workflow manager's per-ID index.
 	TemplateID string
+
+	// LastMetadataWrite is the UTC time of the most recent incremental
+	// session_metadata write for this issue. Owned by the single-writer
+	// event loop and used to throttle in-session metadata writes. Zero
+	// means no incremental write has occurred, so the first token_usage
+	// event writes immediately.
+	LastMetadataWrite time.Time
 }
 
 // RetryEntry holds the runtime state for a pending retry. The persisted
@@ -523,12 +538,21 @@ type State struct {
 	Completed map[string]struct{}
 
 	// BudgetExhausted is the set of issue IDs whose run_history count
-	// has reached or exceeded the configured max_sessions budget.
-	// Rebuilt from a batch SQLite query at the start of each poll tick
-	// when max_sessions > 0. Updated inline by [HandleRetryTimer] on
-	// budget exhaustion. [ShouldDispatch] checks this set as a dispatch
-	// gate. Cleared when max_sessions is 0.
+	// has reached or exceeded the configured max_sessions budget, or
+	// whose summed run_history total_tokens has reached or exceeded the
+	// configured max_tokens budget. Rebuilt from batch SQLite queries at
+	// the start of each poll tick when either budget is enabled. Updated
+	// inline by [HandleRetryTimer] on budget exhaustion. [ShouldDispatch]
+	// checks this set as a dispatch gate. Cleared when both budgets are 0.
 	BudgetExhausted map[string]struct{}
+
+	// BudgetExhaustedReason maps issue ID to the budget that fired for
+	// that issue, either "token_budget" or "session_budget". It is kept
+	// in lockstep with BudgetExhausted: every issue in BudgetExhausted
+	// has a reason entry, and no entry survives for an issue that leaves
+	// the set. When both budgets are exhausted for one issue the reason
+	// is "token_budget". Owned by the single-writer event loop.
+	BudgetExhaustedReason map[string]string
 
 	// AgentTotals holds aggregate token counts and cumulative runtime seconds
 	// across all ended sessions. Active session elapsed time is computed at
@@ -635,18 +659,19 @@ func NewState(pollIntervalMS, maxConcurrentAgents int, maxConcurrentByState map[
 		maxConcurrentByState = make(map[string]int)
 	}
 	return &State{
-		PollIntervalMS:       pollIntervalMS,
-		MaxConcurrentAgents:  maxConcurrentAgents,
-		MaxConcurrentByState: maxConcurrentByState,
-		Running:              make(map[string]*RunningEntry),
-		Claimed:              make(map[string]struct{}),
-		RetryAttempts:        make(map[string]*RetryEntry),
-		Completed:            make(map[string]struct{}),
-		BudgetExhausted:      make(map[string]struct{}),
-		AgentTotals:          totals,
-		ReactionAttempts:     make(map[string]int),
-		PendingReactions:     make(map[string]*PendingReaction),
-		AutoMergeAuthLogged:  make(map[string]struct{}),
+		PollIntervalMS:        pollIntervalMS,
+		MaxConcurrentAgents:   maxConcurrentAgents,
+		MaxConcurrentByState:  maxConcurrentByState,
+		Running:               make(map[string]*RunningEntry),
+		Claimed:               make(map[string]struct{}),
+		RetryAttempts:         make(map[string]*RetryEntry),
+		Completed:             make(map[string]struct{}),
+		BudgetExhausted:       make(map[string]struct{}),
+		BudgetExhaustedReason: make(map[string]string),
+		AgentTotals:           totals,
+		ReactionAttempts:      make(map[string]int),
+		PendingReactions:      make(map[string]*PendingReaction),
+		AutoMergeAuthLogged:   make(map[string]struct{}),
 	}
 }
 
@@ -723,13 +748,14 @@ type SnapshotAgentTotals struct {
 // RuntimeSnapshotResult is a point-in-time capture of the orchestrator's
 // runtime state for observability consumers. Produced by [RuntimeSnapshot].
 type RuntimeSnapshotResult struct {
-	GeneratedAt          time.Time              `json:"generated_at"`
-	Running              []SnapshotRunningEntry `json:"running"`
-	Retrying             []SnapshotRetryEntry   `json:"retrying"`
-	AgentTotals          SnapshotAgentTotals    `json:"agent_totals"`
-	RateLimits           map[string]any         `json:"rate_limits"`
-	BudgetExhaustedCount int                    `json:"budget_exhausted_count"`
-	BudgetExhausted      []string               `json:"budget_exhausted,omitempty"`
+	GeneratedAt           time.Time              `json:"generated_at"`
+	Running               []SnapshotRunningEntry `json:"running"`
+	Retrying              []SnapshotRetryEntry   `json:"retrying"`
+	AgentTotals           SnapshotAgentTotals    `json:"agent_totals"`
+	RateLimits            map[string]any         `json:"rate_limits"`
+	BudgetExhaustedCount  int                    `json:"budget_exhausted_count"`
+	BudgetExhausted       []string               `json:"budget_exhausted,omitempty"`
+	BudgetExhaustedReason map[string]string      `json:"budget_exhausted_reason,omitempty"`
 }
 
 // ActiveElapsedSeconds returns the sum of wall-clock elapsed seconds
@@ -849,6 +875,12 @@ func RuntimeSnapshot(state *State, now time.Time) RuntimeSnapshotResult {
 		}
 		slices.Sort(ids)
 		snap.BudgetExhausted = ids
+
+		reasons := make(map[string]string, len(state.BudgetExhausted))
+		for _, id := range ids {
+			reasons[id] = state.BudgetExhaustedReason[id]
+		}
+		snap.BudgetExhaustedReason = reasons
 	}
 
 	if state.AgentRateLimits != nil {

--- a/internal/orchestrator/state_test.go
+++ b/internal/orchestrator/state_test.go
@@ -738,6 +738,67 @@ func TestRuntimeSnapshot(t *testing.T) {
 		}
 	})
 
+	t.Run("BudgetExhaustedReason projected for every exhausted issue", func(t *testing.T) {
+		t.Parallel()
+
+		state := NewState(5000, 10, nil, AgentTotals{})
+		state.BudgetExhausted["ISS-A"] = struct{}{}
+		state.BudgetExhaustedReason["ISS-A"] = budgetReasonToken
+		state.BudgetExhausted["ISS-B"] = struct{}{}
+		state.BudgetExhaustedReason["ISS-B"] = budgetReasonSession
+
+		result := RuntimeSnapshot(state, fixedNow)
+
+		if got := result.BudgetExhaustedReason["ISS-A"]; got != budgetReasonToken {
+			t.Errorf("BudgetExhaustedReason[ISS-A] = %q, want %q", got, budgetReasonToken)
+		}
+		if got := result.BudgetExhaustedReason["ISS-B"]; got != budgetReasonSession {
+			t.Errorf("BudgetExhaustedReason[ISS-B] = %q, want %q", got, budgetReasonSession)
+		}
+		// Total coverage: the projected reason map carries exactly the
+		// issues in the projected set.
+		if len(result.BudgetExhaustedReason) != len(result.BudgetExhausted) {
+			t.Errorf("len(BudgetExhaustedReason) = %d, want %d (one reason per exhausted issue)",
+				len(result.BudgetExhaustedReason), len(result.BudgetExhausted))
+		}
+		for _, id := range result.BudgetExhausted {
+			if _, ok := result.BudgetExhaustedReason[id]; !ok {
+				t.Errorf("BudgetExhaustedReason missing entry for %q", id)
+			}
+		}
+	})
+
+	t.Run("BudgetExhaustedReason omits issues outside the exhausted set", func(t *testing.T) {
+		t.Parallel()
+
+		state := NewState(5000, 10, nil, AgentTotals{})
+		state.BudgetExhausted["ISS-A"] = struct{}{}
+		state.BudgetExhaustedReason["ISS-A"] = budgetReasonToken
+		// A stray reason without a set entry must not be projected.
+		state.BudgetExhaustedReason["ISS-GONE"] = budgetReasonSession
+
+		result := RuntimeSnapshot(state, fixedNow)
+
+		if got, ok := result.BudgetExhaustedReason["ISS-GONE"]; ok {
+			t.Errorf("BudgetExhaustedReason[ISS-GONE] = %q, want absent (not in BudgetExhausted)", got)
+		}
+		if len(result.BudgetExhaustedReason) != 1 {
+			t.Errorf("len(BudgetExhaustedReason) = %d, want 1", len(result.BudgetExhaustedReason))
+		}
+	})
+
+	t.Run("empty BudgetExhausted omits the reason map", func(t *testing.T) {
+		t.Parallel()
+
+		state := NewState(5000, 10, nil, AgentTotals{})
+
+		result := RuntimeSnapshot(state, fixedNow)
+
+		if result.BudgetExhaustedReason != nil {
+			t.Errorf("BudgetExhaustedReason = %v, want nil for an empty exhausted set", result.BudgetExhaustedReason)
+		}
+	})
+
 	t.Run("DisplayID propagated from Issue.DisplayID to running snapshot", func(t *testing.T) {
 		t.Parallel()
 

--- a/internal/persistence/migrate_test.go
+++ b/internal/persistence/migrate_test.go
@@ -204,6 +204,10 @@ func TestMigrate_ColumnCorrectness(t *testing.T) {
 				{"review_metadata", "TEXT", false, 0},
 				{"rule_name", "TEXT", true, 0},
 				{"template_id", "TEXT", true, 0},
+				{"input_tokens", "INTEGER", true, 0},
+				{"output_tokens", "INTEGER", true, 0},
+				{"total_tokens", "INTEGER", true, 0},
+				{"cache_read_tokens", "INTEGER", true, 0},
 			},
 		},
 		{

--- a/internal/persistence/migrations.go
+++ b/internal/persistence/migrations.go
@@ -41,6 +41,9 @@ var migration009SQL string
 //go:embed sql/010_dispatch_rule_routing.sql
 var migration010SQL string
 
+//go:embed sql/011_run_history_token_columns.sql
+var migration011SQL string
+
 var migrations = []Migration{
 	{Version: 1, Description: "core persistence tables", SQL: migration001SQL},
 	{Version: 2, Description: "extended token metrics", SQL: migration002SQL},
@@ -52,4 +55,5 @@ var migrations = []Migration{
 	{Version: 8, Description: "reaction fingerprints for cross-restart dedup", SQL: migration008SQL},
 	{Version: 9, Description: "session ID in retry entries for cross-retry resume", SQL: migration009SQL},
 	{Version: 10, Description: "dispatch rule routing columns on retry_entries and run_history", SQL: migration010SQL},
+	{Version: 11, Description: "run_history token columns", SQL: migration011SQL},
 }

--- a/internal/persistence/run_history.go
+++ b/internal/persistence/run_history.go
@@ -30,6 +30,11 @@ type RunHistory struct {
 	ReviewMetadata *string // JSON-serialized ReviewMetadata; nil when self-review did not run.
 	RuleName       string  // Dispatch rule name frozen at initial dispatch; empty for legacy rows and fallback dispatches.
 	TemplateID     string  // Resolved template path frozen at initial dispatch; empty for legacy rows and the workflow body template.
+
+	InputTokens     int64 // Accumulated input tokens for the run; 0 for pre-migration rows.
+	OutputTokens    int64 // Accumulated output tokens for the run; 0 for pre-migration rows.
+	TotalTokens     int64 // Accumulated total tokens for the run; 0 for pre-migration rows.
+	CacheReadTokens int64 // Accumulated cache-read tokens for the run; 0 for pre-migration rows.
 }
 
 // AppendRunHistory inserts a completed run attempt into run_history. The ID
@@ -58,11 +63,12 @@ func (s *Store) AppendRunHistory(ctx context.Context, run RunHistory) (RunHistor
 
 	res, err := s.db.ExecContext(ctx,
 		`INSERT INTO run_history
-			(issue_id, identifier, display_identifier, attempt, agent_adapter, workspace, started_at, completed_at, status, error, workflow_file, turns_completed, review_metadata, rule_name, template_id)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			(issue_id, identifier, display_identifier, attempt, agent_adapter, workspace, started_at, completed_at, status, error, workflow_file, turns_completed, review_metadata, rule_name, template_id, input_tokens, output_tokens, total_tokens, cache_read_tokens)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		run.IssueID, run.Identifier, dispIDVal, run.Attempt, run.AgentAdapter,
 		run.Workspace, run.StartedAt, run.CompletedAt, run.Status, errVal, wfVal,
 		run.TurnsCompleted, reviewMetaVal, run.RuleName, run.TemplateID,
+		run.InputTokens, run.OutputTokens, run.TotalTokens, run.CacheReadTokens,
 	)
 	if err != nil {
 		return RunHistory{}, fmt.Errorf("append run history for %q: %w", run.IssueID, err)
@@ -82,7 +88,8 @@ func (s *Store) AppendRunHistory(ctx context.Context, run RunHistory) (RunHistor
 func (s *Store) QueryRunHistoryByIssue(ctx context.Context, issueID string) ([]RunHistory, error) {
 	rows, err := s.db.QueryContext(ctx,
 		`SELECT id, issue_id, identifier, display_identifier, attempt, agent_adapter, workspace,
-			started_at, completed_at, status, error, workflow_file, turns_completed, review_metadata, rule_name, template_id
+			started_at, completed_at, status, error, workflow_file, turns_completed, review_metadata, rule_name, template_id,
+			input_tokens, output_tokens, total_tokens, cache_read_tokens
 		FROM run_history
 		WHERE issue_id = ?
 		ORDER BY id DESC`, issueID)
@@ -99,6 +106,7 @@ func (s *Store) QueryRunHistoryByIssue(ctx context.Context, issueID string) ([]R
 			&r.ID, &r.IssueID, &r.Identifier, &dispIDVal, &r.Attempt, &r.AgentAdapter,
 			&r.Workspace, &r.StartedAt, &r.CompletedAt, &r.Status, &errVal, &wfVal,
 			&r.TurnsCompleted, &reviewMetaVal, &r.RuleName, &r.TemplateID,
+			&r.InputTokens, &r.OutputTokens, &r.TotalTokens, &r.CacheReadTokens,
 		); err != nil {
 			return nil, fmt.Errorf("scan run history: %w", err)
 		}
@@ -153,7 +161,8 @@ func (s *Store) LoadLatestSuccessfulRunsForReactionRecovery(ctx context.Context,
 		)
 		SELECT r.id, r.issue_id, r.identifier, r.display_identifier, r.attempt, r.agent_adapter,
 			r.workspace, r.started_at, r.completed_at, r.status, r.error, r.workflow_file,
-			r.turns_completed, r.review_metadata, r.rule_name, r.template_id
+			r.turns_completed, r.review_metadata, r.rule_name, r.template_id,
+			r.input_tokens, r.output_tokens, r.total_tokens, r.cache_read_tokens
 		FROM run_history AS r
 		JOIN bounded ON bounded.latest_id = r.id
 		ORDER BY r.id DESC`, completedAfter.UTC().Format(time.RFC3339), limit)
@@ -170,6 +179,7 @@ func (s *Store) LoadLatestSuccessfulRunsForReactionRecovery(ctx context.Context,
 			&run.ID, &run.IssueID, &run.Identifier, &dispIDVal, &run.Attempt, &run.AgentAdapter,
 			&run.Workspace, &run.StartedAt, &run.CompletedAt, &run.Status, &errVal, &wfVal,
 			&run.TurnsCompleted, &reviewMetaVal, &run.RuleName, &run.TemplateID,
+			&run.InputTokens, &run.OutputTokens, &run.TotalTokens, &run.CacheReadTokens,
 		); err != nil {
 			return nil, fmt.Errorf("load recovery runs: %w", err)
 		}
@@ -210,7 +220,8 @@ func (s *Store) QueryRecentRunHistory(ctx context.Context, limit int, afterID in
 	if afterID > 0 {
 		rows, err = s.db.QueryContext(ctx,
 			`SELECT id, issue_id, identifier, display_identifier, attempt, agent_adapter, workspace,
-				started_at, completed_at, status, error, workflow_file, turns_completed, review_metadata, rule_name, template_id
+				started_at, completed_at, status, error, workflow_file, turns_completed, review_metadata, rule_name, template_id,
+				input_tokens, output_tokens, total_tokens, cache_read_tokens
 			FROM run_history
 			WHERE id < ?
 			ORDER BY id DESC
@@ -218,7 +229,8 @@ func (s *Store) QueryRecentRunHistory(ctx context.Context, limit int, afterID in
 	} else {
 		rows, err = s.db.QueryContext(ctx,
 			`SELECT id, issue_id, identifier, display_identifier, attempt, agent_adapter, workspace,
-				started_at, completed_at, status, error, workflow_file, turns_completed, review_metadata, rule_name, template_id
+				started_at, completed_at, status, error, workflow_file, turns_completed, review_metadata, rule_name, template_id,
+				input_tokens, output_tokens, total_tokens, cache_read_tokens
 			FROM run_history
 			ORDER BY id DESC
 			LIMIT ?`, limit)
@@ -236,6 +248,7 @@ func (s *Store) QueryRecentRunHistory(ctx context.Context, limit int, afterID in
 			&r.ID, &r.IssueID, &r.Identifier, &dispIDVal, &r.Attempt, &r.AgentAdapter,
 			&r.Workspace, &r.StartedAt, &r.CompletedAt, &r.Status, &errVal, &wfVal,
 			&r.TurnsCompleted, &reviewMetaVal, &r.RuleName, &r.TemplateID,
+			&r.InputTokens, &r.OutputTokens, &r.TotalTokens, &r.CacheReadTokens,
 		); err != nil {
 			return nil, fmt.Errorf("scan run history: %w", err)
 		}
@@ -312,6 +325,61 @@ func (s *Store) QueryBudgetExhaustedIssues(ctx context.Context, candidateIDs []s
 	}
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("query budget exhausted issues: %w", err)
+	}
+	return exhaustedIDs, nil
+}
+
+// SumTotalTokensByIssue returns the sum of total_tokens across all
+// run_history rows for the issue and the count of those rows. Returns
+// (0, 0, nil) when no rows exist.
+func (s *Store) SumTotalTokensByIssue(ctx context.Context, issueID string) (sumTotalTokens int64, sessionCount int, err error) {
+	row := s.db.QueryRowContext(ctx,
+		`SELECT COALESCE(SUM(total_tokens), 0), COUNT(*) FROM run_history WHERE issue_id = ?`, issueID,
+	)
+	if err := row.Scan(&sumTotalTokens, &sessionCount); err != nil {
+		return 0, 0, fmt.Errorf("sum total tokens by issue %q: %w", issueID, err)
+	}
+	return sumTotalTokens, sessionCount, nil
+}
+
+// QueryTokenExhaustedIssues returns issue IDs from candidateIDs whose
+// summed run_history total_tokens meet or exceed maxTokens. Returns an
+// empty non-nil slice when no issues qualify or candidateIDs is empty.
+func (s *Store) QueryTokenExhaustedIssues(ctx context.Context, candidateIDs []string, maxTokens int) ([]string, error) {
+	if len(candidateIDs) == 0 {
+		return []string{}, nil
+	}
+
+	placeholders := strings.Repeat("?,", len(candidateIDs))
+	placeholders = placeholders[:len(placeholders)-1]
+
+	args := make([]any, 0, len(candidateIDs)+1)
+	for _, id := range candidateIDs {
+		args = append(args, id)
+	}
+	args = append(args, maxTokens)
+
+	query := fmt.Sprintf( //nolint:gosec // placeholders is "?,?,..." built from len(candidateIDs); no user data in format string
+		`SELECT issue_id FROM run_history WHERE issue_id IN (%s) GROUP BY issue_id HAVING SUM(total_tokens) >= ?`,
+		placeholders,
+	)
+
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("query token exhausted issues: %w", err)
+	}
+	defer rows.Close() //nolint:errcheck // read-only query; close error is non-actionable
+
+	exhaustedIDs := []string{}
+	for rows.Next() {
+		var issueID string
+		if err := rows.Scan(&issueID); err != nil {
+			return nil, fmt.Errorf("scan token exhausted issue: %w", err)
+		}
+		exhaustedIDs = append(exhaustedIDs, issueID)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("query token exhausted issues: %w", err)
 	}
 	return exhaustedIDs, nil
 }

--- a/internal/persistence/run_history_test.go
+++ b/internal/persistence/run_history_test.go
@@ -1,0 +1,304 @@
+package persistence
+
+import (
+	"context"
+	"slices"
+	"testing"
+	"time"
+)
+
+// tokenRun returns a run_history row for the given issue carrying the
+// given total_tokens, with the remaining fields from newTestRun.
+func tokenRun(i int, issueID string, totalTokens int64) RunHistory {
+	run := newTestRun(i)
+	run.IssueID = issueID
+	run.TotalTokens = totalTokens
+	return run
+}
+
+// assertTokenFields verifies the four token counters of a RunHistory row.
+func assertTokenFields(t *testing.T, reader string, got RunHistory, wantIn, wantOut, wantTotal, wantCache int64) {
+	t.Helper()
+	if got.InputTokens != wantIn {
+		t.Errorf("%s InputTokens = %d, want %d", reader, got.InputTokens, wantIn)
+	}
+	if got.OutputTokens != wantOut {
+		t.Errorf("%s OutputTokens = %d, want %d", reader, got.OutputTokens, wantOut)
+	}
+	if got.TotalTokens != wantTotal {
+		t.Errorf("%s TotalTokens = %d, want %d", reader, got.TotalTokens, wantTotal)
+	}
+	if got.CacheReadTokens != wantCache {
+		t.Errorf("%s CacheReadTokens = %d, want %d", reader, got.CacheReadTokens, wantCache)
+	}
+}
+
+// TestRunHistoryTokenColumns_RoundTrip writes one row with non-zero token
+// counters and reads it back through every reader. A token column missed
+// in one reader's SELECT or Scan list compiles cleanly and fails only at
+// runtime, so each reader is asserted explicitly.
+func TestRunHistoryTokenColumns_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	s := openTestStore(t)
+	migrateOrFatal(t, s)
+	ctx := context.Background()
+
+	run := newTestRun(1)
+	run.InputTokens = 1100
+	run.OutputTokens = 2200
+	run.TotalTokens = 3300
+	run.CacheReadTokens = 440
+	inserted := appendOrFatal(t, s, run)
+
+	assertTokenFields(t, "AppendRunHistory", inserted, 1100, 2200, 3300, 440)
+
+	byIssue, err := s.QueryRunHistoryByIssue(ctx, run.IssueID)
+	if err != nil {
+		t.Fatalf("QueryRunHistoryByIssue: %v", err)
+	}
+	if len(byIssue) != 1 {
+		t.Fatalf("QueryRunHistoryByIssue returned %d entries, want 1", len(byIssue))
+	}
+	assertTokenFields(t, "QueryRunHistoryByIssue", byIssue[0], 1100, 2200, 3300, 440)
+
+	recent, err := s.QueryRecentRunHistory(ctx, 1, 0)
+	if err != nil {
+		t.Fatalf("QueryRecentRunHistory: %v", err)
+	}
+	if len(recent) != 1 {
+		t.Fatalf("QueryRecentRunHistory returned %d entries, want 1", len(recent))
+	}
+	assertTokenFields(t, "QueryRecentRunHistory", recent[0], 1100, 2200, 3300, 440)
+
+	// The paginated branch of QueryRecentRunHistory uses a separate SELECT;
+	// exercise it with a cursor past the inserted row.
+	paginated, err := s.QueryRecentRunHistory(ctx, 1, inserted.ID+1)
+	if err != nil {
+		t.Fatalf("QueryRecentRunHistory(afterID): %v", err)
+	}
+	if len(paginated) != 1 {
+		t.Fatalf("QueryRecentRunHistory(afterID) returned %d entries, want 1", len(paginated))
+	}
+	assertTokenFields(t, "QueryRecentRunHistory(afterID)", paginated[0], 1100, 2200, 3300, 440)
+
+	recovery, err := s.LoadLatestSuccessfulRunsForReactionRecovery(ctx, time.Time{}, 10)
+	if err != nil {
+		t.Fatalf("LoadLatestSuccessfulRunsForReactionRecovery: %v", err)
+	}
+	if len(recovery) != 1 {
+		t.Fatalf("LoadLatestSuccessfulRunsForReactionRecovery returned %d entries, want 1", len(recovery))
+	}
+	assertTokenFields(t, "LoadLatestSuccessfulRunsForReactionRecovery", recovery[0], 1100, 2200, 3300, 440)
+}
+
+// TestRunHistoryTokenColumns_LegacyRowsReadZero verifies that rows written
+// without token values (matching pre-migration rows, which rely on the
+// NOT NULL DEFAULT 0 column definition) scan as zero.
+func TestRunHistoryTokenColumns_LegacyRowsReadZero(t *testing.T) {
+	t.Parallel()
+
+	s := openTestStore(t)
+	migrateOrFatal(t, s)
+	ctx := context.Background()
+
+	if _, err := s.db.ExecContext(ctx,
+		`INSERT INTO run_history (issue_id, identifier, attempt, agent_adapter, workspace, started_at, completed_at, status)
+		 VALUES ('ISS-LEGACY', 'PROJ-LEGACY', 1, 'mock', '/tmp/ws', '2026-03-19T10:00:00Z', '2026-03-19T10:30:00Z', 'succeeded')`); err != nil {
+		t.Fatalf("insert legacy row: %v", err)
+	}
+
+	entries, err := s.QueryRunHistoryByIssue(ctx, "ISS-LEGACY")
+	if err != nil {
+		t.Fatalf("QueryRunHistoryByIssue: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("QueryRunHistoryByIssue returned %d entries, want 1", len(entries))
+	}
+	assertTokenFields(t, "QueryRunHistoryByIssue(legacy)", entries[0], 0, 0, 0, 0)
+}
+
+func TestSumTotalTokensByIssue(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no rows returns zero sum and zero count", func(t *testing.T) {
+		t.Parallel()
+		s := openTestStore(t)
+		migrateOrFatal(t, s)
+
+		sum, count, err := s.SumTotalTokensByIssue(context.Background(), "ISS-NONE")
+		if err != nil {
+			t.Fatalf("SumTotalTokensByIssue(ISS-NONE) unexpected error: %v", err)
+		}
+		if sum != 0 || count != 0 {
+			t.Errorf("SumTotalTokensByIssue(ISS-NONE) = (%d, %d), want (0, 0)", sum, count)
+		}
+	})
+
+	t.Run("sums total_tokens and counts rows for the issue only", func(t *testing.T) {
+		t.Parallel()
+		s := openTestStore(t)
+		migrateOrFatal(t, s)
+
+		appendOrFatal(t, s, tokenRun(1, "ISS-SUM", 100))
+		appendOrFatal(t, s, tokenRun(2, "ISS-SUM", 200))
+		appendOrFatal(t, s, tokenRun(3, "ISS-SUM", 300))
+		appendOrFatal(t, s, tokenRun(4, "ISS-OTHER", 5000))
+
+		sum, count, err := s.SumTotalTokensByIssue(context.Background(), "ISS-SUM")
+		if err != nil {
+			t.Fatalf("SumTotalTokensByIssue(ISS-SUM) unexpected error: %v", err)
+		}
+		if sum != 600 {
+			t.Errorf("SumTotalTokensByIssue(ISS-SUM) sum = %d, want 600", sum)
+		}
+		if count != 3 {
+			t.Errorf("SumTotalTokensByIssue(ISS-SUM) count = %d, want 3", count)
+		}
+	})
+}
+
+func TestQueryTokenExhaustedIssues(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty candidateIDs returns empty non-nil slice", func(t *testing.T) {
+		t.Parallel()
+		s := openTestStore(t)
+		migrateOrFatal(t, s)
+
+		result, err := s.QueryTokenExhaustedIssues(context.Background(), []string{}, 1000)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if result == nil {
+			t.Fatal("result = nil, want empty non-nil slice")
+		}
+		if len(result) != 0 {
+			t.Errorf("result = %v, want empty slice", result)
+		}
+	})
+
+	t.Run("candidate with sum below maxTokens not returned", func(t *testing.T) {
+		t.Parallel()
+		s := openTestStore(t)
+		migrateOrFatal(t, s)
+
+		appendOrFatal(t, s, tokenRun(1, "ISS-UNDER", 400))
+		appendOrFatal(t, s, tokenRun(2, "ISS-UNDER", 500))
+
+		result, err := s.QueryTokenExhaustedIssues(context.Background(), []string{"ISS-UNDER"}, 1000)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(result) != 0 {
+			t.Errorf("result = %v, want empty (sum 900 < maxTokens 1000)", result)
+		}
+	})
+
+	t.Run("candidate with sum equal to maxTokens is returned", func(t *testing.T) {
+		t.Parallel()
+		s := openTestStore(t)
+		migrateOrFatal(t, s)
+
+		appendOrFatal(t, s, tokenRun(1, "ISS-EXACT", 600))
+		appendOrFatal(t, s, tokenRun(2, "ISS-EXACT", 400))
+
+		result, err := s.QueryTokenExhaustedIssues(context.Background(), []string{"ISS-EXACT"}, 1000)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(result) != 1 || result[0] != "ISS-EXACT" {
+			t.Errorf("result = %v, want [ISS-EXACT]", result)
+		}
+	})
+
+	t.Run("candidate with sum exceeding maxTokens is returned", func(t *testing.T) {
+		t.Parallel()
+		s := openTestStore(t)
+		migrateOrFatal(t, s)
+
+		appendOrFatal(t, s, tokenRun(1, "ISS-OVER", 900))
+		appendOrFatal(t, s, tokenRun(2, "ISS-OVER", 900))
+
+		result, err := s.QueryTokenExhaustedIssues(context.Background(), []string{"ISS-OVER"}, 1000)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(result) != 1 || result[0] != "ISS-OVER" {
+			t.Errorf("result = %v, want [ISS-OVER]", result)
+		}
+	})
+
+	t.Run("mixed candidates only qualifying ones returned", func(t *testing.T) {
+		t.Parallel()
+		s := openTestStore(t)
+		migrateOrFatal(t, s)
+
+		// ISS-HOT: 1200 tokens (exhausted), ISS-COLD: 300 (not), ISS-NONE: no rows.
+		appendOrFatal(t, s, tokenRun(1, "ISS-HOT", 700))
+		appendOrFatal(t, s, tokenRun(2, "ISS-HOT", 500))
+		appendOrFatal(t, s, tokenRun(3, "ISS-COLD", 300))
+
+		result, err := s.QueryTokenExhaustedIssues(
+			context.Background(),
+			[]string{"ISS-HOT", "ISS-COLD", "ISS-NONE"},
+			1000,
+		)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(result) != 1 || result[0] != "ISS-HOT" {
+			t.Errorf("result = %v, want [ISS-HOT]", result)
+		}
+	})
+
+	t.Run("non-candidate issues are not returned", func(t *testing.T) {
+		t.Parallel()
+		s := openTestStore(t)
+		migrateOrFatal(t, s)
+
+		appendOrFatal(t, s, tokenRun(1, "ISS-OUTSIDE", 9000))
+
+		result, err := s.QueryTokenExhaustedIssues(context.Background(), []string{"ISS-INSIDE"}, 1000)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(result) != 0 {
+			t.Errorf("result = %v, want empty (exhausted issue not in candidate list)", result)
+		}
+	})
+
+	// The advisory tool reads SumTotalTokensByIssue while enforcement reads
+	// QueryTokenExhaustedIssues; both must agree on the same ledger value.
+	t.Run("completed-session sum matches enforcement threshold", func(t *testing.T) {
+		t.Parallel()
+		s := openTestStore(t)
+		migrateOrFatal(t, s)
+		ctx := context.Background()
+
+		appendOrFatal(t, s, tokenRun(1, "ISS-PARITY", 123))
+		appendOrFatal(t, s, tokenRun(2, "ISS-PARITY", 456))
+		appendOrFatal(t, s, tokenRun(3, "ISS-PARITY", 789))
+
+		sum, _, err := s.SumTotalTokensByIssue(ctx, "ISS-PARITY")
+		if err != nil {
+			t.Fatalf("SumTotalTokensByIssue(ISS-PARITY) unexpected error: %v", err)
+		}
+
+		atSum, err := s.QueryTokenExhaustedIssues(ctx, []string{"ISS-PARITY"}, int(sum))
+		if err != nil {
+			t.Fatalf("QueryTokenExhaustedIssues(maxTokens=%d) unexpected error: %v", sum, err)
+		}
+		if !slices.Contains(atSum, "ISS-PARITY") {
+			t.Errorf("QueryTokenExhaustedIssues(maxTokens=%d) = %v, want to contain ISS-PARITY", sum, atSum)
+		}
+
+		aboveSum, err := s.QueryTokenExhaustedIssues(ctx, []string{"ISS-PARITY"}, int(sum)+1)
+		if err != nil {
+			t.Fatalf("QueryTokenExhaustedIssues(maxTokens=%d) unexpected error: %v", sum+1, err)
+		}
+		if slices.Contains(aboveSum, "ISS-PARITY") {
+			t.Errorf("QueryTokenExhaustedIssues(maxTokens=%d) = %v, want ISS-PARITY absent", sum+1, aboveSum)
+		}
+	})
+}

--- a/internal/persistence/sql/011_run_history_token_columns.sql
+++ b/internal/persistence/sql/011_run_history_token_columns.sql
@@ -1,0 +1,5 @@
+-- Migration 11: Add token columns to run_history for per-issue cost budgeting
+ALTER TABLE run_history ADD COLUMN input_tokens INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE run_history ADD COLUMN output_tokens INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE run_history ADD COLUMN total_tokens INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE run_history ADD COLUMN cache_read_tokens INTEGER NOT NULL DEFAULT 0;

--- a/internal/tool/budget/budget.go
+++ b/internal/tool/budget/budget.go
@@ -1,0 +1,131 @@
+// Package budget implements [domain.AgentTool] for the cost_budget tool.
+// It reports cumulative per-issue token spend and the remaining token
+// budget so agents can self-regulate before the orchestrator's hard
+// token ceiling blocks a re-dispatch.
+package budget
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/sortie-ai/sortie/internal/domain"
+)
+
+var _ domain.AgentTool = (*BudgetTool)(nil)
+
+var inputSchema = json.RawMessage(`{
+  "type": "object",
+  "properties": {},
+  "additionalProperties": false
+}`)
+
+// BudgetQueryFunc returns the per-issue completed-session token sum, the
+// completed-session count, and the running session's recorded token total.
+// The running-session total is taken from session_metadata only when its
+// stored session ID matches runningSessionID; otherwise it is 0.
+// Implementations make no external calls.
+type BudgetQueryFunc func(ctx context.Context, issueID string, runningSessionID string) (BudgetUsage, error)
+
+// BudgetUsage is the per-issue token accounting returned by a
+// [BudgetQueryFunc].
+type BudgetUsage struct {
+	CompletedTotalTokens int64 // SUM(total_tokens) over run_history rows for the issue.
+	CompletedSessions    int   // COUNT(*) of run_history rows for the issue.
+	RunningTotalTokens   int64 // session_metadata.total_tokens when session_id matches; else 0.
+}
+
+// BudgetTool implements [domain.AgentTool] for the cost_budget tool.
+// Construct via [New]; safe for concurrent use after construction.
+type BudgetTool struct {
+	query            BudgetQueryFunc
+	issueID          string
+	runningSessionID string
+	budgetTokens     int
+	budgetSessions   int
+}
+
+// costBudgetResponse is the JSON result of the cost_budget tool. The field
+// names and null semantics are part of the tool's public contract.
+type costBudgetResponse struct {
+	UsedTokens      int64  `json:"used_tokens"`
+	BudgetTokens    int64  `json:"budget_tokens"`
+	RemainingTokens *int64 `json:"remaining_tokens"` // null when budget is unlimited.
+	UsedSessions    int    `json:"used_sessions"`
+	BudgetSessions  int    `json:"budget_sessions"`
+}
+
+// New returns a [BudgetTool] for the given issue and running session.
+//
+// budgetTokens and budgetSessions are the configured agent ceilings,
+// where 0 means unlimited. runningSessionID is the live session ID
+// delivered to the sidecar out of band; an empty value contributes no
+// running-session spend. New panics if query is nil or issueID is empty
+// (programming errors).
+func New(query BudgetQueryFunc, issueID string, runningSessionID string, budgetTokens int, budgetSessions int) *BudgetTool {
+	if query == nil {
+		panic("budget.New: query must not be nil")
+	}
+	if issueID == "" {
+		panic("budget.New: issueID must not be empty")
+	}
+	return &BudgetTool{
+		query:            query,
+		issueID:          issueID,
+		runningSessionID: runningSessionID,
+		budgetTokens:     budgetTokens,
+		budgetSessions:   budgetSessions,
+	}
+}
+
+// Name returns "cost_budget".
+func (t *BudgetTool) Name() string { return "cost_budget" }
+
+// Description returns a human-readable summary of the tool.
+func (t *BudgetTool) Description() string {
+	return "Returns cumulative token spend for the current issue and the remaining token " +
+		"budget. Use this to decide whether to skip an expensive step, return partial work, " +
+		"or hand off before the orchestrator blocks further sessions on the token ceiling."
+}
+
+// InputSchema returns the JSON Schema for cost_budget input.
+// The tool accepts no parameters; the schema is an empty object.
+// The returned slice is a defensive copy.
+func (t *BudgetTool) InputSchema() json.RawMessage {
+	out := make(json.RawMessage, len(inputSchema))
+	copy(out, inputSchema)
+	return out
+}
+
+// Execute computes the five-field budget result for the current issue.
+//
+// Query failures are returned as a JSON error response with a nil Go
+// error. Only internal marshal failures produce a non-nil Go error.
+func (t *BudgetTool) Execute(ctx context.Context, _ json.RawMessage) (json.RawMessage, error) {
+	usage, err := t.query(ctx, t.issueID, t.runningSessionID)
+	if err != nil {
+		return errorResponse(err.Error())
+	}
+
+	usedTokens := usage.CompletedTotalTokens + usage.RunningTotalTokens
+
+	var remaining *int64
+	if t.budgetTokens > 0 {
+		r := int64(t.budgetTokens) - usedTokens
+		if r < 0 {
+			r = 0
+		}
+		remaining = &r
+	}
+
+	return json.Marshal(costBudgetResponse{
+		UsedTokens:      usedTokens,
+		BudgetTokens:    int64(t.budgetTokens),
+		RemainingTokens: remaining,
+		UsedSessions:    usage.CompletedSessions,
+		BudgetSessions:  t.budgetSessions,
+	})
+}
+
+func errorResponse(msg string) (json.RawMessage, error) {
+	return json.Marshal(map[string]string{"error": msg})
+}

--- a/internal/tool/budget/budget_test.go
+++ b/internal/tool/budget/budget_test.go
@@ -1,0 +1,305 @@
+package budget
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// --- Helpers ---
+
+var noopQuery BudgetQueryFunc = func(_ context.Context, _ string, _ string) (BudgetUsage, error) {
+	return BudgetUsage{}, nil
+}
+
+func executeOK(t *testing.T, tool *BudgetTool) costBudgetResponse {
+	t.Helper()
+	out, err := tool.Execute(context.Background(), json.RawMessage(`{}`))
+	if err != nil {
+		t.Fatalf("Execute: unexpected Go error: %v", err)
+	}
+	var resp costBudgetResponse
+	if err := json.Unmarshal(out, &resp); err != nil {
+		t.Fatalf("Execute: unmarshal response %q: %v", out, err)
+	}
+	return resp
+}
+
+func int64Ptr(v int64) *int64 { return &v }
+
+// --- Tests ---
+
+func TestBudgetTool_Name(t *testing.T) {
+	t.Parallel()
+
+	tool := New(noopQuery, "10042", "sess-1", 0, 0)
+	if got := tool.Name(); got != "cost_budget" {
+		t.Errorf("Name() = %q, want %q", got, "cost_budget")
+	}
+}
+
+func TestBudgetTool_Description(t *testing.T) {
+	t.Parallel()
+
+	tool := New(noopQuery, "10042", "sess-1", 0, 0)
+	if got := tool.Description(); got == "" {
+		t.Error(`Description() = "", want non-empty`)
+	}
+}
+
+func TestBudgetTool_InputSchema_ValidJSON(t *testing.T) {
+	t.Parallel()
+
+	tool := New(noopQuery, "10042", "sess-1", 0, 0)
+	schema := tool.InputSchema()
+
+	var m map[string]any
+	if err := json.Unmarshal(schema, &m); err != nil {
+		t.Fatalf("InputSchema() unmarshal: %v", err)
+	}
+
+	if got, _ := m["type"].(string); got != "object" {
+		t.Errorf("schema type = %v, want %q", m["type"], "object")
+	}
+	v, ok := m["additionalProperties"]
+	if !ok {
+		t.Fatal("additionalProperties key missing from schema")
+	}
+	if v != false {
+		t.Errorf("additionalProperties = %v, want false", v)
+	}
+}
+
+func TestBudgetTool_InputSchema_DefensiveCopy(t *testing.T) {
+	t.Parallel()
+
+	tool := New(noopQuery, "10042", "sess-1", 0, 0)
+	schema1 := tool.InputSchema()
+
+	// Overwrite every byte of the first copy.
+	for i := range schema1 {
+		schema1[i] = 'X'
+	}
+
+	// The second call must still return valid JSON.
+	schema2 := tool.InputSchema()
+	var m map[string]any
+	if err := json.Unmarshal(schema2, &m); err != nil {
+		t.Fatalf("InputSchema() after mutation: unmarshal: %v", err)
+	}
+}
+
+func TestBudgetTool_Execute(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		usage          BudgetUsage
+		budgetTokens   int
+		budgetSessions int
+
+		wantUsedTokens     int64
+		wantBudgetTokens   int64
+		wantRemaining      *int64 // nil means JSON null (unlimited budget)
+		wantUsedSessions   int
+		wantBudgetSessions int
+	}{
+		{
+			name:               "used tokens sums completed and running, used sessions counts completed only",
+			usage:              BudgetUsage{CompletedTotalTokens: 600, CompletedSessions: 3, RunningTotalTokens: 150},
+			budgetTokens:       1000,
+			budgetSessions:     5,
+			wantUsedTokens:     750,
+			wantBudgetTokens:   1000,
+			wantRemaining:      int64Ptr(250),
+			wantUsedSessions:   3,
+			wantBudgetSessions: 5,
+		},
+		{
+			name:               "remaining floored at zero when over budget",
+			usage:              BudgetUsage{CompletedTotalTokens: 900, CompletedSessions: 2, RunningTotalTokens: 200},
+			budgetTokens:       1000,
+			budgetSessions:     0,
+			wantUsedTokens:     1100,
+			wantBudgetTokens:   1000,
+			wantRemaining:      int64Ptr(0),
+			wantUsedSessions:   2,
+			wantBudgetSessions: 0,
+		},
+		{
+			name:               "remaining zero at exact budget consumption",
+			usage:              BudgetUsage{CompletedTotalTokens: 1000, CompletedSessions: 4},
+			budgetTokens:       1000,
+			budgetSessions:     4,
+			wantUsedTokens:     1000,
+			wantBudgetTokens:   1000,
+			wantRemaining:      int64Ptr(0),
+			wantUsedSessions:   4,
+			wantBudgetSessions: 4,
+		},
+		{
+			name:               "unlimited token budget reports null remaining",
+			usage:              BudgetUsage{CompletedTotalTokens: 600, CompletedSessions: 3, RunningTotalTokens: 150},
+			budgetTokens:       0,
+			budgetSessions:     5,
+			wantUsedTokens:     750,
+			wantBudgetTokens:   0,
+			wantRemaining:      nil,
+			wantUsedSessions:   3,
+			wantBudgetSessions: 5,
+		},
+		{
+			name:               "zero usage under unlimited budgets",
+			usage:              BudgetUsage{},
+			budgetTokens:       0,
+			budgetSessions:     0,
+			wantUsedTokens:     0,
+			wantBudgetTokens:   0,
+			wantRemaining:      nil,
+			wantUsedSessions:   0,
+			wantBudgetSessions: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			query := func(_ context.Context, _ string, _ string) (BudgetUsage, error) {
+				return tt.usage, nil
+			}
+			tool := New(query, "10042", "sess-1", tt.budgetTokens, tt.budgetSessions)
+
+			resp := executeOK(t, tool)
+
+			if resp.UsedTokens != tt.wantUsedTokens {
+				t.Errorf("used_tokens = %d, want %d", resp.UsedTokens, tt.wantUsedTokens)
+			}
+			if resp.BudgetTokens != tt.wantBudgetTokens {
+				t.Errorf("budget_tokens = %d, want %d", resp.BudgetTokens, tt.wantBudgetTokens)
+			}
+			if resp.UsedSessions != tt.wantUsedSessions {
+				t.Errorf("used_sessions = %d, want %d", resp.UsedSessions, tt.wantUsedSessions)
+			}
+			if resp.BudgetSessions != tt.wantBudgetSessions {
+				t.Errorf("budget_sessions = %d, want %d", resp.BudgetSessions, tt.wantBudgetSessions)
+			}
+			switch {
+			case tt.wantRemaining == nil && resp.RemainingTokens != nil:
+				t.Errorf("remaining_tokens = %d, want null", *resp.RemainingTokens)
+			case tt.wantRemaining != nil && resp.RemainingTokens == nil:
+				t.Errorf("remaining_tokens = null, want %d", *tt.wantRemaining)
+			case tt.wantRemaining != nil && *resp.RemainingTokens != *tt.wantRemaining:
+				t.Errorf("remaining_tokens = %d, want %d", *resp.RemainingTokens, *tt.wantRemaining)
+			}
+		})
+	}
+}
+
+// TestBudgetTool_Execute_FiveFieldShape pins the public JSON contract:
+// all five field names are present, and remaining_tokens is an explicit
+// null (not omitted) under an unlimited token budget.
+func TestBudgetTool_Execute_FiveFieldShape(t *testing.T) {
+	t.Parallel()
+
+	query := func(_ context.Context, _ string, _ string) (BudgetUsage, error) {
+		return BudgetUsage{CompletedTotalTokens: 10, CompletedSessions: 1}, nil
+	}
+	tool := New(query, "10042", "", 0, 0)
+
+	out, err := tool.Execute(context.Background(), json.RawMessage(`{}`))
+	if err != nil {
+		t.Fatalf("Execute: unexpected Go error: %v", err)
+	}
+
+	var m map[string]any
+	if err := json.Unmarshal(out, &m); err != nil {
+		t.Fatalf("unmarshal response %q: %v", out, err)
+	}
+
+	for _, key := range []string{"used_tokens", "budget_tokens", "remaining_tokens", "used_sessions", "budget_sessions"} {
+		if _, ok := m[key]; !ok {
+			t.Errorf("response missing key %q: %s", key, out)
+		}
+	}
+	if len(m) != 5 {
+		t.Errorf("response has %d keys, want 5: %s", len(m), out)
+	}
+	if got, ok := m["remaining_tokens"]; !ok || got != nil {
+		t.Errorf("remaining_tokens = %v, want explicit null", got)
+	}
+}
+
+func TestBudgetTool_Execute_QueryError(t *testing.T) {
+	t.Parallel()
+
+	query := func(_ context.Context, _ string, _ string) (BudgetUsage, error) {
+		return BudgetUsage{}, fmt.Errorf("database is locked")
+	}
+
+	tool := New(query, "10042", "sess-1", 1000, 5)
+	out, err := tool.Execute(context.Background(), json.RawMessage(`{}`))
+	if err != nil {
+		t.Fatalf("Execute: expected nil Go error on query failure, got: %v", err)
+	}
+
+	var m map[string]any
+	if err := json.Unmarshal(out, &m); err != nil {
+		t.Fatalf("unmarshal error response %q: %v", out, err)
+	}
+
+	errStr, ok := m["error"].(string)
+	if !ok {
+		t.Fatalf("error value is not a string: %T %v", m["error"], m["error"])
+	}
+	if !strings.Contains(errStr, "database is locked") {
+		t.Errorf("error value = %q, want to contain %q", errStr, "database is locked")
+	}
+}
+
+// TestBudgetTool_Execute_PassesIdentity verifies the tool forwards its
+// construction-time issue ID and running session ID to the query.
+func TestBudgetTool_Execute_PassesIdentity(t *testing.T) {
+	t.Parallel()
+
+	var gotIssueID, gotSessionID string
+	query := func(_ context.Context, issueID string, runningSessionID string) (BudgetUsage, error) {
+		gotIssueID = issueID
+		gotSessionID = runningSessionID
+		return BudgetUsage{}, nil
+	}
+
+	tool := New(query, "10042", "sess-live", 0, 0)
+	executeOK(t, tool)
+
+	if gotIssueID != "10042" {
+		t.Errorf("query issueID = %q, want %q", gotIssueID, "10042")
+	}
+	if gotSessionID != "sess-live" {
+		t.Errorf("query runningSessionID = %q, want %q", gotSessionID, "sess-live")
+	}
+}
+
+func TestNew_PanicsOnNilQuery(t *testing.T) {
+	t.Parallel()
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error(`New(nil, "10042", ...) did not panic`)
+		}
+	}()
+	New(nil, "10042", "sess-1", 0, 0)
+}
+
+func TestNew_PanicsOnEmptyIssueID(t *testing.T) {
+	t.Parallel()
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error(`New(noopQuery, "", ...) did not panic`)
+		}
+	}()
+	New(noopQuery, "", "sess-1", 0, 0)
+}


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Feat / Fix

**Intent:** Gives agents cost awareness during a session by exposing a `cost_budget` MCP tool that reports cumulative token spend and remaining budget, and enforces a hard per-issue token ceiling on the orchestrator dispatch path that complements the existing `max_sessions` limit. Includes a follow-up fix to `rebuildBudgetExhausted` that scopes the error-fallback fold to the failing axis only, preventing cross-axis contamination of stale reason labels.

**Related Issues:** #240

### 🧭 Reviewer Guide

**Complexity:** High

#### Entry Point

Start with `internal/orchestrator/orchestrator.go`. The two new methods, `rebuildBudgetExhausted` and `maybeWriteIncrementalMetadata`, show how the token budget enforcement integrates into the existing per-tick dispatch loop and the agent event loop respectively. `rebuildBudgetExhausted` replaces the inline session-exhaustion block that was previously embedded in `handleTick`, unifying session-count and token-sum budget enforcement into one place.

On a query error for one axis, the corrected fold carries only the entries whose prior reason matches the failing axis; entries attributed to the other axis are left for that axis to resolve from its own fresh result. The previous implementation folded all prior entries unconditionally, which could resurrect cross-axis entries with stale reason labels.

#### Sensitive Areas

- `internal/orchestrator/retry.go`: the `blockBudget` closure ensures a single retry entry deletion even when both budgets are exhausted on the same evaluation; the ordering (session gate first, token gate second, token taking precedence in the recorded reason) is part of the observable contract.
- `internal/orchestrator/state.go`: `BudgetExhaustedReason` is a new field kept in strict lockstep with `BudgetExhausted`; any code that writes one must write the other. The runtime snapshot exposes this map to observability consumers.
- `cmd/sortie/mcpserver.go` / `buildBudgetQuery`: the running-session double-count guard (session ID match against `session_metadata`) is the critical correctness invariant for the advisory token reading; the tests in `mcpserver_test.go` exercise all four session-ID scenarios.
- `internal/persistence/run_history.go`: four token columns are projected in every SELECT across all read paths; a missed scan target compiles cleanly and silently returns zeros at runtime. The round-trip test in `run_history_test.go` exercises all readers.
- `internal/persistence/sql/011_run_history_token_columns.sql`: `NOT NULL DEFAULT 0` ensures pre-migration rows read as zero without back-filling, consistent with the documented legacy-row behavior.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes. `agent.max_tokens` defaults to `0` (unlimited), leaving existing deployments unchanged. The new `BudgetExhaustedReason` field is additive to the runtime snapshot JSON.
- **Migrations/State:** Migration 011 adds four `NOT NULL DEFAULT 0` columns to `run_history` via `ALTER TABLE`. SQLite applies the default to all pre-existing rows without a table rewrite; no data loss or manual steps required.