### PR TITLE
fix(workspace): drain hook job before returning on Windows

### DIFF
--- a/internal/workspace/hook_windows.go
+++ b/internal/workspace/hook_windows.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"log/slog"
 	"os/exec"
-	"sync"
 	"syscall"
 	"time"
 	"unsafe"
@@ -25,7 +24,10 @@ const statusControlCExit uint32 = 0xC000013A
 // RunHook executes a hook script via cmd.exe on Windows, enforcing a
 // timeout and capturing output. The subprocess is placed in a Job
 // Object with KILL_ON_JOB_CLOSE so that the entire process tree is
-// terminated on timeout or context cancellation.
+// terminated on timeout or context cancellation. Before returning,
+// RunHook terminates any process remaining in the job and waits for
+// the job to drain, so no descendant still holds a handle into the
+// hook directory when the caller proceeds to clean it up.
 //
 // On success (exit code 0), returns a [HookResult] with truncated
 // output. On failure, returns a [*HookError] with Op indicating the
@@ -73,27 +75,30 @@ func RunHook(ctx context.Context, params HookParams) (HookResult, error) {
 	}
 
 	if job != 0 {
-		var closeJob sync.Once
-		closeHandle := func() {
-			closeJob.Do(func() { windows.CloseHandle(job) })
-		}
 		cmd.Cancel = func() error {
-			// On cancellation/timeout, actively terminate the tree
-			// before closing the handle.
-			err := windows.TerminateJobObject(job, statusControlCExit)
-			closeHandle()
-			return err
+			// On cancellation/timeout, actively terminate the tree.
+			// The handle stays open so the post-Wait drain can observe
+			// the job; the deferred close releases it on every path.
+			return windows.TerminateJobObject(job, statusControlCExit)
 		}
-		// On the happy path, just close the handle.
-		// KILL_ON_JOB_CLOSE ensures any stray background children
-		// are still cleaned up when the handle is released.
-		defer closeHandle()
+		defer windows.CloseHandle(job)
 	}
 
 	cmd.WaitDelay = 3 * time.Second
 
 	err := cmd.Wait()
 	output := buf.String()
+
+	// Job process termination is asynchronous: TerminateJobObject and
+	// KILL_ON_JOB_CLOSE both return before the dying processes release
+	// their handles. A descendant still holding the hook directory as
+	// its working directory makes the caller's directory cleanup fail
+	// with a sharing violation, so terminate any survivors explicitly
+	// and wait until the job reports zero active processes.
+	if job != 0 {
+		_ = windows.TerminateJobObject(job, statusControlCExit)
+		waitJobDrained(job)
+	}
 
 	if err == nil {
 		return HookResult{Output: output}, nil
@@ -183,4 +188,51 @@ func createHookJobObject(pid int) (windows.Handle, error) {
 	}
 
 	return job, nil
+}
+
+// jobObjectBasicAccountingInformation mirrors the Win32
+// JOBOBJECT_BASIC_ACCOUNTING_INFORMATION layout consumed by
+// QueryInformationJobObject; x/sys/windows does not define the type.
+type jobObjectBasicAccountingInformation struct {
+	TotalUserTime             int64
+	TotalKernelTime           int64
+	ThisPeriodTotalUserTime   int64
+	ThisPeriodTotalKernelTime int64
+	TotalPageFaultCount       uint32
+	TotalProcesses            uint32
+	ActiveProcesses           uint32
+	TotalTerminatedProcesses  uint32
+}
+
+// waitJobDrained polls the job accounting counters until no process in
+// the job remains active or the deadline expires. Termination initiated
+// by TerminateJobObject completes asynchronously, so returning before
+// the active count reaches zero would let a dying child briefly outlive
+// RunHook with its working-directory handle still open.
+func waitJobDrained(job windows.Handle) {
+	const (
+		pollInterval = 5 * time.Millisecond
+		drainTimeout = 2 * time.Second
+	)
+
+	deadline := time.Now().Add(drainTimeout)
+	for {
+		var info jobObjectBasicAccountingInformation
+		err := windows.QueryInformationJobObject(
+			job,
+			windows.JobObjectBasicAccountingInformation,
+			uintptr(unsafe.Pointer(&info)),
+			uint32(unsafe.Sizeof(info)),
+			nil,
+		)
+		if err != nil || info.ActiveProcesses == 0 {
+			return
+		}
+		if time.Now().After(deadline) {
+			slog.Warn("hook job processes still active after drain deadline",
+				slog.Int64("active_processes", int64(info.ActiveProcesses)))
+			return
+		}
+		time.Sleep(pollInterval)
+	}
 }

--- a/internal/workspace/hook_windows.go
+++ b/internal/workspace/hook_windows.go
@@ -96,7 +96,10 @@ func RunHook(ctx context.Context, params HookParams) (HookResult, error) {
 	// with a sharing violation, so terminate any survivors explicitly
 	// and wait until the job reports zero active processes.
 	if job != 0 {
-		_ = windows.TerminateJobObject(job, statusControlCExit)
+		if termErr := windows.TerminateJobObject(job, statusControlCExit); termErr != nil {
+			slog.Warn("hook job termination after wait failed; drain may not settle",
+				slog.Any("error", termErr))
+		}
 		waitJobDrained(job)
 	}
 
@@ -225,7 +228,12 @@ func waitJobDrained(job windows.Handle) {
 			uint32(unsafe.Sizeof(info)),
 			nil,
 		)
-		if err != nil || info.ActiveProcesses == 0 {
+		if err != nil {
+			slog.Warn("hook job accounting query failed; drain skipped",
+				slog.Any("error", err))
+			return
+		}
+		if info.ActiveProcesses == 0 {
 			return
 		}
 		if time.Now().After(deadline) {

--- a/internal/workspace/hook_windows_test.go
+++ b/internal/workspace/hook_windows_test.go
@@ -5,6 +5,7 @@ package workspace
 import (
 	"context"
 	"errors"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -137,10 +138,11 @@ func TestRunHook_ProcessTreeKill(t *testing.T) {
 	// Job Object when the timeout fires.
 	script := "start /b ping.exe -n 30 127.0.0.1 & ping -n 30 127.0.0.1"
 
+	dir := t.TempDir()
 	start := time.Now()
 	_, err := RunHook(context.Background(), HookParams{
 		Script:    script,
-		Dir:       t.TempDir(),
+		Dir:       dir,
 		Env:       map[string]string{},
 		TimeoutMS: 300,
 	})
@@ -155,5 +157,13 @@ func TestRunHook_ProcessTreeKill(t *testing.T) {
 	elapsed := time.Since(start)
 	if elapsed > 5*time.Second {
 		t.Errorf("RunHook took %v after timeout; expected prompt return (< 5s)", elapsed)
+	}
+
+	// The drain guarantee: when RunHook returns, no descendant still holds
+	// a handle into the hook directory, so removal must succeed on the
+	// first immediate attempt. Before the drain this failed intermittently
+	// with a sharing violation raised by the dying background child.
+	if err := os.RemoveAll(dir); err != nil {
+		t.Errorf("hook dir removal immediately after RunHook = %v, want success", err)
 	}
 }


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Fix

**Intent:** On Windows, `TerminateJobObject` and `KILL_ON_JOB_CLOSE` both return before dying child processes release their handles. A descendant still holding the hook working directory open causes the caller's cleanup to fail with a sharing violation. This change terminates any survivors explicitly after `cmd.Wait` returns and polls until the job's active-process count reaches zero, so no descendant outlives `RunHook` with a directory handle still open.

### 🧭 Reviewer Guide

**Complexity:** Medium

#### Entry Point

`internal/workspace/hook_windows.go` - This is the only changed file. Focus on the post-`Wait` block that calls `TerminateJobObject` unconditionally and then `waitJobDrained`, and on the new `waitJobDrained` helper that polls `QueryInformationJobObject` until `ActiveProcesses == 0` or the 2-second deadline expires.

#### Sensitive Areas

- `internal/workspace/hook_windows.go`: The drain loop uses a 5 ms poll interval and a 2-second hard deadline. If the deadline is exceeded it logs a warning and continues rather than hard-failing, to avoid blocking the orchestrator indefinitely on a misbehaving hook.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes
- **Migrations/State:** No migrations or state changes