### PR TITLE
feat: add notify_operator agent tool with Slack and webhook backends

### DIFF
--- a/cmd/sortie/main.go
+++ b/cmd/sortie/main.go
@@ -44,6 +44,8 @@ import (
 	_ "github.com/sortie-ai/sortie/internal/agent/kiro"
 	_ "github.com/sortie-ai/sortie/internal/agent/mock"
 	_ "github.com/sortie-ai/sortie/internal/agent/opencode"
+	_ "github.com/sortie-ai/sortie/internal/notify/slack"
+	_ "github.com/sortie-ai/sortie/internal/notify/webhook"
 	_ "github.com/sortie-ai/sortie/internal/scm/github"
 	_ "github.com/sortie-ai/sortie/internal/tracker/file"
 	_ "github.com/sortie-ai/sortie/internal/tracker/jira"

--- a/cmd/sortie/mcpserver.go
+++ b/cmd/sortie/mcpserver.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strconv"
 
 	"github.com/sortie-ai/sortie/internal/config"
 	"github.com/sortie-ai/sortie/internal/domain"
@@ -18,10 +19,16 @@ import (
 	"github.com/sortie-ai/sortie/internal/tool/budget"
 	"github.com/sortie-ai/sortie/internal/tool/history"
 	"github.com/sortie-ai/sortie/internal/tool/mcpserver"
+	"github.com/sortie-ai/sortie/internal/tool/notify"
 	"github.com/sortie-ai/sortie/internal/tool/status"
 	"github.com/sortie-ai/sortie/internal/tool/trackerapi"
 	"github.com/sortie-ai/sortie/internal/workflow"
 )
+
+// defaultMaxPerSession is the per-session notification cap selected when
+// no backend declares a non-zero max_per_session. 0 in config selects
+// this default; it never means unlimited.
+const defaultMaxPerSession = 20
 
 func runMCPServer(ctx context.Context, args []string, stdout io.Writer, stderr io.Writer) int {
 	if containsHelpFlag(args) {
@@ -117,6 +124,19 @@ func runMCPServer(ctx context.Context, args []string, stdout io.Writer, stderr i
 		}
 	}
 
+	// Register notify_operator only when at least one backend is
+	// configured. An invalid backend is a fatal startup error, never a
+	// partial registration, so the sidecar and main process agree on the
+	// advertised tool set.
+	notifyTool, notifyErr := buildNotifyTool(cfg.Notifications.Backends)
+	if notifyErr != nil {
+		logger.Error("failed to configure notify_operator", slog.Any("error", notifyErr))
+		return 1
+	}
+	if notifyTool != nil {
+		toolRegistry.Register(notifyTool)
+	}
+
 	srv := mcpserver.NewServer(toolRegistry, os.Stdin, stdout, logger, Version)
 	if err := srv.Serve(ctx); err != nil {
 		logger.Error("MCP server error", slog.Any("error", err))
@@ -124,6 +144,66 @@ func runMCPServer(ctx context.Context, args []string, stdout io.Writer, stderr i
 	}
 
 	return 0
+}
+
+// buildNotifyTool resolves the configured notifier backends and returns
+// the notify_operator tool. It returns (nil, nil) when no backend is
+// configured, so the caller skips registration. An unknown kind or a
+// constructor error (including a required secret that resolved to the
+// empty string) is fatal and returned as a non-nil error rather than a
+// partial registration. The envelope context is read from the sidecar
+// environment.
+func buildNotifyTool(configured []config.NotificationBackend) (domain.AgentTool, error) {
+	if len(configured) == 0 {
+		return nil, nil
+	}
+
+	backends := make([]domain.Notifier, 0, len(configured))
+	for _, entry := range configured {
+		ctor, err := registry.Notifiers.Get(entry.Kind)
+		if err != nil {
+			return nil, err
+		}
+		notifier, err := ctor(entry.Config)
+		if err != nil {
+			return nil, fmt.Errorf("notifier %q: %w", entry.Kind, err)
+		}
+		backends = append(backends, notifier)
+	}
+
+	var attempt *int
+	if raw := os.Getenv("SORTIE_ATTEMPT"); raw != "" {
+		if n, err := strconv.Atoi(raw); err == nil {
+			attempt = &n
+		}
+	}
+	envContext := notify.NotificationEnvelopeContext{
+		IssueID:    os.Getenv("SORTIE_ISSUE_ID"),
+		Identifier: os.Getenv("SORTIE_ISSUE_IDENTIFIER"),
+		SessionID:  os.Getenv("SORTIE_SESSION_ID"),
+		Attempt:    attempt,
+		Agent:      os.Getenv("SORTIE_SESSION_AGENT_KIND"),
+	}
+
+	return notify.New(backends, envContext, resolveNotificationCap(configured)), nil
+}
+
+// resolveNotificationCap selects the single per-session cap for the tool
+// from the configured backends. It returns the maximum non-zero
+// max_per_session across entries and falls back to defaultMaxPerSession
+// when every entry is 0 or unset. The cap counts notify_operator calls,
+// not per-backend sends, so it is a tool-level property.
+func resolveNotificationCap(backends []config.NotificationBackend) int {
+	maxCap := 0
+	for _, b := range backends {
+		if b.MaxPerSession > maxCap {
+			maxCap = b.MaxPerSession
+		}
+	}
+	if maxCap == 0 {
+		return defaultMaxPerSession
+	}
+	return maxCap
 }
 
 func buildBudgetQuery(store *persistence.Store) budget.BudgetQueryFunc {

--- a/cmd/sortie/mcpserver_test.go
+++ b/cmd/sortie/mcpserver_test.go
@@ -6,12 +6,15 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/sortie-ai/sortie/internal/config"
 	"github.com/sortie-ai/sortie/internal/domain"
 	"github.com/sortie-ai/sortie/internal/persistence"
 	"github.com/sortie-ai/sortie/internal/tool/mcpserver"
@@ -336,4 +339,227 @@ func TestBuildBudgetQuery(t *testing.T) {
 			t.Errorf("usage = %+v, want all-zero", usage)
 		}
 	})
+}
+
+func TestBuildNotifyTool_EmptyBackends_ReturnsNilNil(t *testing.T) {
+	t.Parallel()
+
+	tool, err := buildNotifyTool(nil)
+	if err != nil {
+		t.Fatalf("buildNotifyTool(nil) error = %v, want nil", err)
+	}
+	if tool != nil {
+		t.Errorf("buildNotifyTool(nil) tool = %v, want nil", tool)
+	}
+}
+
+func TestBuildNotifyTool_EmptySlice_ReturnsNilNil(t *testing.T) {
+	t.Parallel()
+
+	tool, err := buildNotifyTool([]config.NotificationBackend{})
+	if err != nil {
+		t.Fatalf("buildNotifyTool(empty) error = %v, want nil", err)
+	}
+	if tool != nil {
+		t.Errorf("buildNotifyTool(empty) tool = %v, want nil", tool)
+	}
+}
+
+func TestBuildNotifyTool_ValidWebhookBackend_ReturnsNonNilTool(t *testing.T) {
+	t.Parallel()
+
+	// Use a real httptest server so the webhook constructor does not
+	// reject the URL. The server URL is non-empty so construction succeeds.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	backends := []config.NotificationBackend{
+		{
+			Kind:   "webhook",
+			Config: map[string]any{"url": srv.URL},
+		},
+	}
+
+	tool, err := buildNotifyTool(backends)
+	if err != nil {
+		t.Fatalf("buildNotifyTool(webhook) error = %v, want nil", err)
+	}
+	if tool == nil {
+		t.Fatal("buildNotifyTool(webhook) tool = nil, want non-nil")
+	}
+	if tool.Name() != "notify_operator" {
+		t.Errorf("tool.Name() = %q, want %q", tool.Name(), "notify_operator")
+	}
+}
+
+func TestBuildNotifyTool_ValidSlackBackend_ReturnsNonNilTool(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	backends := []config.NotificationBackend{
+		{
+			Kind:   "slack",
+			Config: map[string]any{"webhook_url": srv.URL},
+		},
+	}
+
+	tool, err := buildNotifyTool(backends)
+	if err != nil {
+		t.Fatalf("buildNotifyTool(slack) error = %v, want nil", err)
+	}
+	if tool == nil {
+		t.Fatal("buildNotifyTool(slack) tool = nil, want non-nil")
+	}
+}
+
+func TestBuildNotifyTool_UnknownKind_ReturnsError(t *testing.T) {
+	t.Parallel()
+
+	backends := []config.NotificationBackend{
+		{
+			Kind:   "no-such-backend-kind-xyz",
+			Config: map[string]any{"url": "https://example.com"},
+		},
+	}
+
+	tool, err := buildNotifyTool(backends)
+	if err == nil {
+		t.Fatal("buildNotifyTool(unknown kind) error = nil, want non-nil error")
+	}
+	if tool != nil {
+		t.Errorf("buildNotifyTool(unknown kind) tool = %v, want nil on error", tool)
+	}
+}
+
+func TestBuildNotifyTool_EmptyRequiredSecret_ReturnsError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		kind   string
+		config map[string]any
+	}{
+		{
+			name:   "webhook empty url",
+			kind:   "webhook",
+			config: map[string]any{"url": ""},
+		},
+		{
+			name:   "slack empty webhook_url",
+			kind:   "slack",
+			config: map[string]any{"webhook_url": ""},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			backends := []config.NotificationBackend{
+				{Kind: tt.kind, Config: tt.config},
+			}
+
+			tool, err := buildNotifyTool(backends)
+			if err == nil {
+				t.Fatalf("buildNotifyTool(%q, empty secret) error = nil, want fatal constructor error", tt.kind)
+			}
+			if tool != nil {
+				t.Errorf("buildNotifyTool(%q, empty secret) tool = %v, want nil on error", tt.kind, tool)
+			}
+		})
+	}
+}
+
+func TestBuildNotifyTool_PartialFailureIsTotal(t *testing.T) {
+	t.Parallel()
+
+	// First backend valid, second backend has an unknown kind. The result
+	// must be an error, not a partial set of backends.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	backends := []config.NotificationBackend{
+		{Kind: "webhook", Config: map[string]any{"url": srv.URL}},
+		{Kind: "unknown-kind-for-partial-test", Config: map[string]any{"url": srv.URL}},
+	}
+
+	tool, err := buildNotifyTool(backends)
+	if err == nil {
+		t.Fatal("buildNotifyTool(partial failure) = nil error, want non-nil (no partial registration)")
+	}
+	if tool != nil {
+		t.Errorf("buildNotifyTool(partial failure) tool = %v, want nil", tool)
+	}
+}
+
+func TestResolveNotificationCap_AllZero_ReturnsDefault(t *testing.T) {
+	t.Parallel()
+
+	backends := []config.NotificationBackend{
+		{Kind: "webhook", MaxPerSession: 0},
+		{Kind: "slack", MaxPerSession: 0},
+	}
+
+	got := resolveNotificationCap(backends)
+	if got != defaultMaxPerSession {
+		t.Errorf("resolveNotificationCap(all-zero) = %d, want default %d", got, defaultMaxPerSession)
+	}
+}
+
+func TestResolveNotificationCap_EmptySlice_ReturnsDefault(t *testing.T) {
+	t.Parallel()
+
+	got := resolveNotificationCap(nil)
+	if got != defaultMaxPerSession {
+		t.Errorf("resolveNotificationCap(nil) = %d, want default %d", got, defaultMaxPerSession)
+	}
+}
+
+func TestResolveNotificationCap_SingleNonZero_ReturnsThatValue(t *testing.T) {
+	t.Parallel()
+
+	backends := []config.NotificationBackend{
+		{Kind: "webhook", MaxPerSession: 15},
+	}
+
+	got := resolveNotificationCap(backends)
+	if got != 15 {
+		t.Errorf("resolveNotificationCap({15}) = %d, want 15", got)
+	}
+}
+
+func TestResolveNotificationCap_MultipleNonZero_ReturnsMax(t *testing.T) {
+	t.Parallel()
+
+	backends := []config.NotificationBackend{
+		{Kind: "webhook", MaxPerSession: 5},
+		{Kind: "slack", MaxPerSession: 30},
+	}
+
+	got := resolveNotificationCap(backends)
+	if got != 30 {
+		t.Errorf("resolveNotificationCap({5,30}) = %d, want 30", got)
+	}
+}
+
+func TestResolveNotificationCap_MixedZeroAndNonZero_ReturnsNonZeroMax(t *testing.T) {
+	t.Parallel()
+
+	backends := []config.NotificationBackend{
+		{Kind: "webhook", MaxPerSession: 0},
+		{Kind: "slack", MaxPerSession: 10},
+	}
+
+	got := resolveNotificationCap(backends)
+	if got != 10 {
+		t.Errorf("resolveNotificationCap({0,10}) = %d, want 10", got)
+	}
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1829,6 +1829,7 @@ future SCM APIs) through network calls using orchestrator-managed credentials. T
 to transport failures, authentication errors, rate limits, and per-tool timeouts.
 
 - `tracker_api` (Section 10.4.5)
+- `notify_operator` (Section 10.4.5)
 
 Future tools follow the same classification.
 
@@ -1945,6 +1946,48 @@ session exit, so no window double counts.
 On failure the tool returns a JSON error object of the form `{"error": "<message>"}`. This
 happens when the budget query fails.
 
+**`notify_operator` (Tier 2)** sends a real-time notification to an operator-configured
+channel while a session runs. The agent uses it to escalate a decision it should not make
+alone, report progress on a long task, or flag a blocker, without terminating the session.
+The tool resolves the configured notifier backends and posts to them; it knows nothing about
+any specific channel.
+
+Availability: registered only when at least one valid notifier backend is configured in the
+`notifications` list (Section 5). The registration derives from the same workflow file the
+main process reads, so the sidecar and the main process agree on the tool set. When the list
+is empty or absent, the tool is not registered.
+
+The agent supplies only the message; the system owns the envelope and the agent cannot set
+or forge any envelope field. The input schema rejects unknown fields:
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `severity` | string | Yes | One of `info`, `warning`, `critical` |
+| `title` | string | Yes | Non-empty short summary |
+| `body` | string | Yes | Non-empty notification detail |
+| `category` | string | No | One of `decision_needed`, `progress`, `blocked`, `completed`, `other` |
+
+The system-owned envelope carries a generated notification id, an ISO-8601 UTC timestamp, a
+source (the hostname by default), the issue id and identifier, the session id, the attempt,
+and the dispatch-frozen agent kind. The envelope correlates the notification to a session for
+an operator and a machine consumer.
+
+Rate limiting: the tool enforces a per-session cap, `max_per_session`, where `0` selects the
+default rather than unlimited. A call past the cap returns `rate_limited` and sends nothing.
+An accepted call increments the counter once, after delivery, not once per backend.
+
+Result semantics: on success the tool returns `{"success": true, "delivered": <int>,
+"notification_id": "<id>"}`. On a domain failure it returns `{"success": false, "error":
+{"kind": "...", "message": "..."}}` with `error.kind` in the closed set below. The Go error
+return is reserved for an internal marshal failure.
+
+| `error.kind` | Condition |
+|---|---|
+| `invalid_input` | Input fails schema decode, carries unknown or trailing fields, has an out-of-enum `severity` or `category`, or has an empty `title` or `body` |
+| `rate_limited` | The per-session counter has reached `max_per_session` |
+| `send_failed` | A backend returned a transport failure, a non-2xx response, or an unparseable response. The message is a redacted category and never echoes the URL, request body, or response body |
+| `backend_unavailable` | No backend could be resolved at execution time (defensive; normal operation gates registration on a configured backend) |
+
 #### 10.4.6 Tools vs. agent-authored files
 
 The tool subsystem (this section) and the `.sortie/status` file protocol (Section 21) are
@@ -1997,6 +2040,56 @@ execution channel is unavailable (sidecar crash, agent lacks MCP support),
 the file-based advisory signal still functions. If the filesystem is read-only or the workspace
 is on a remote host with restricted write access, tool calls still function. Neither channel is
 a single point of failure for the other.
+
+#### 10.4.7 Notifier adapter family
+
+Operator notifications are an adapter family, the same shape as the tracker, agent, CI, and
+SCM families. The `notify_operator` tool (Section 10.4.5) is a thin Tier 2 wrapper over this
+family; a new channel is a new package behind the existing interface, not a tool rewrite.
+
+The family has four parts:
+
+- **The `domain.Notifier` interface** exposes one method, `Send(ctx, Notification) error`. A
+  single method keeps every backend interchangeable and lets any producer reuse the family.
+  An implementation applies a per-call timeout and never logs the endpoint URL, the request
+  body, or the response body.
+- **The normalized `domain.Notification`** has two layers. The envelope is system-owned and
+  carries the notification id, timestamp, source, issue id and identifier, session id,
+  attempt, and dispatch-frozen agent kind. The message is agent-supplied and carries
+  `severity`, `title`, `body`, and an optional `category`. The value is self-contained:
+  every field a backend needs rides in it, with no dependency on producer-only state, so a
+  future orchestrator producer can fill the envelope without an interface change.
+- **The `registry.Notifiers` registry** maps a `kind` string to a constructor. Backend
+  packages register in `init()`; the sidecar resolves backends by `kind` at runtime. This
+  mirrors `registry.SCMAdapters` exactly.
+- **The backend packages** live under `internal/notify/<kind>/`. v1 ships `webhook` (posts
+  the notification as a JSON object using generic field names) and `slack` (posts a
+  Slack-shaped body with a `text` field). Each builds on the shared HTTP client with its
+  configured endpoint as the base URL, applies a mandatory per-call timeout, and classifies
+  its own transport and non-2xx errors into a category that omits the URL and payload.
+
+The backend packages obey the adapter-family boundary rules: no cross-adapter imports, no
+orchestrator imports, normalization to the domain type at the boundary, and generic
+`notifier_*` vocabulary in the core, never `slack_*`.
+
+Backends register via the notifier registry using `init()` functions:
+
+```go
+func init() {
+    registry.Notifiers.Register("webhook", newNotifier)
+}
+```
+
+The `NotifierConstructor` signature is:
+
+```go
+type NotifierConstructor func(config map[string]any) (domain.Notifier, error)
+```
+
+The `config` parameter receives the per-backend fields from the matching `notifications`
+list entry, with `$VAR` references already resolved. A constructor rejects a missing required
+field or a secret that resolved to the empty string, which surfaces as a fatal sidecar
+startup error rather than a notification posted nowhere.
 
 ### 10.5 Timeouts and Error Mapping
 

--- a/docs/workflow-reference.md
+++ b/docs/workflow-reference.md
@@ -141,7 +141,7 @@ After parsing, the loader produces a struct with three fields:
 
 ### 2.1 Top-Level Keys
 
-The core schema recognizes ten top-level keys:
+The core schema recognizes eleven top-level keys:
 
 ```yaml
 tracker: # Issue tracker connection and query settings
@@ -154,6 +154,7 @@ ci_feedback: # CI failure feedback loop (deprecated; use reactions.ci_failure)
 reactions: # Reaction-based feedback loops (CI failure, review comments)
 self_review: # Self-review verification loop (optional)
 dispatch: # Rule-based dispatch routing
+notifications: # Operator notification backends (notify_operator tool)
 ```
 
 **Unknown top-level keys are ignored** by the core schema for forward compatibility. They
@@ -834,6 +835,58 @@ the terminal catch-all. Each rule carries a `template:` path that is relative to
 The design rationale is in `architecture.md` §5.3.10 and
 [ADR-0011](decisions/0011-dispatch-rule-configuration.md). Neither document is required
 to write a valid `dispatch` block; they explain why the feature is shaped as it is.
+
+---
+
+### 2.12 `notifications` (operator notification backends)
+
+```yaml
+notifications: # ordered list of notifier backends; optional
+  - kind: slack
+    webhook_url: $SORTIE_SLACK_WEBHOOK_URL # SORTIE_-prefixed reference (mandatory)
+    max_per_session: 20                     # optional; 0 selects the default (also 20)
+  - kind: webhook
+    url: $SORTIE_OPS_WEBHOOK_URL            # SORTIE_-prefixed reference (mandatory)
+```
+
+The `notifications` list configures the backends behind the `notify_operator` agent tool.
+While a session runs, the agent calls `notify_operator` to escalate a decision, report
+progress, or flag a blocker to a real-time channel. The tool is registered only when at
+least one valid backend is configured; an empty or absent list leaves it unregistered, so
+the agent is never offered a tool it cannot use.
+
+The value is a sequence, not a single object. A second channel is a second list entry. Each
+entry is a map carrying a required `kind` discriminator and that backend's own fields.
+
+| Field | Type | Required | Default | Description |
+| ----- | ---- | -------- | ------- | ----------- |
+| `kind` | string | Yes | _(none)_ | Backend discriminator. v1 backends are `webhook` and `slack`. |
+| `max_per_session` | int | No | `20` | Per-session notification cap. `0` selects the default (`20`); it never means unlimited. A negative value is rejected. |
+
+Per-backend fields depend on `kind` and are passed through to the backend untyped:
+
+| `kind` | Field | Description |
+| ------ | ----- | ----------- |
+| `webhook` | `url` | Endpoint that receives an HTTP POST of the notification as a JSON object using generic field names. |
+| `slack` | `webhook_url` | Slack incoming webhook URL that receives a Slack-shaped JSON body with a `text` field. |
+
+The `notifications` `webhook` backend is an outbound POST to an operator-supplied endpoint.
+It is unrelated to inbound tracker webhooks (§20 of `architecture.md`), which trigger
+reconciliation. The two share a name but not a direction.
+
+When the list configures more than one backend, the effective per-session cap is the
+maximum non-zero `max_per_session` across entries, falling back to the default when every
+entry is `0` or unset. The cap counts `notify_operator` calls, not per-backend sends.
+
+**`SORTIE_`-prefixed secret rule:**
+
+A backend secret MUST be given as a reference to a `SORTIE_`-prefixed environment variable,
+written as `$SORTIE_NAME` or `${SORTIE_NAME}`. The prefix is mandatory, not stylistic. The
+`notify_operator` tool runs in a separate `sortie mcp-server` process that receives only the
+workflow file path and the orchestrator's `SORTIE_`-prefixed variables. A reference without
+the `SORTIE_` prefix, or to an unset variable, resolves to an empty string in that process.
+The backend rejects an empty required secret, which surfaces as a fatal startup error rather
+than a notification posted nowhere. Name every notification secret with the `SORTIE_` prefix.
 
 ---
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -69,6 +69,12 @@ type ServiceConfig struct {
 	// after [NewServiceConfig] returns. Zero value selects the
 	// workflow-wide fallback for every issue.
 	Dispatch DispatchConfig
+
+	// Notifications carries the parsed notifier backend list. Populated
+	// inside [NewServiceConfig] so the MCP sidecar, which reaches config
+	// only through that constructor, can read it. Zero value (nil
+	// Backends) means no notifier backend is configured.
+	Notifications NotificationsConfig
 }
 
 // SetDispatch attaches a parsed [DispatchConfig] to the service
@@ -142,16 +148,17 @@ type AgentConfig struct {
 // knownTopLevelKeys enumerates the front matter keys consumed by the
 // core schema. Anything else is collected into Extensions.
 var knownTopLevelKeys = map[string]bool{
-	"tracker":     true,
-	"polling":     true,
-	"workspace":   true,
-	"hooks":       true,
-	"agent":       true,
-	"db_path":     true,
-	"ci_feedback": true,
-	"self_review": true,
-	"reactions":   true,
-	"dispatch":    true,
+	"tracker":       true,
+	"polling":       true,
+	"workspace":     true,
+	"hooks":         true,
+	"agent":         true,
+	"db_path":       true,
+	"ci_feedback":   true,
+	"self_review":   true,
+	"reactions":     true,
+	"dispatch":      true,
+	"notifications": true,
 }
 
 // NewServiceConfig converts a raw front matter map into a validated
@@ -299,6 +306,11 @@ func NewServiceConfig(raw map[string]any) (ServiceConfig, error) {
 		delete(reactions, "ci_failure")
 	}
 
+	notifications, err := buildNotificationsConfig(raw)
+	if err != nil {
+		return ServiceConfig{}, err
+	}
+
 	extensions := make(map[string]any)
 	for k, v := range raw {
 		if !knownTopLevelKeys[k] {
@@ -320,6 +332,7 @@ func NewServiceConfig(raw map[string]any) (ServiceConfig, error) {
 		DBPath:                  dbPath,
 		Extensions:              extensions,
 		extensionsPreResolution: preResolution,
+		Notifications:           notifications,
 	}, nil
 }
 

--- a/internal/config/notifications.go
+++ b/internal/config/notifications.go
@@ -1,0 +1,128 @@
+package config
+
+import "fmt"
+
+// NotificationsConfig holds the parsed notifications list. The zero
+// value (nil Backends) means no backend is configured and the
+// notify_operator tool is not registered.
+type NotificationsConfig struct {
+	Backends []NotificationBackend
+}
+
+// NotificationBackend is one entry in the notifications list. Kind is
+// the registry discriminator; Config carries the entry's remaining keys
+// verbatim, with $VAR references resolved, for the backend constructor.
+type NotificationBackend struct {
+	// Kind is the required registry discriminator, resolved against the
+	// notifier registry at sidecar startup.
+	Kind string
+
+	// MaxPerSession is the per-session notification cap. 0 selects the
+	// default at cap selection time; it never means unlimited.
+	MaxPerSession int
+
+	// Config holds the entry's per-backend fields with $VAR references
+	// resolved. It is passed through to the backend constructor untyped.
+	Config map[string]any
+}
+
+// buildNotificationsConfig parses the top-level notifications sequence
+// into a [NotificationsConfig]. An absent section yields the zero value
+// and a nil error. The value must be a YAML sequence; each entry must
+// be a map carrying a non-empty string kind, and an optional
+// max_per_session must be a non-negative integer. Every other key is
+// copied into the entry's Config for pass-through, with $VAR and ${VAR}
+// references resolved on every string leaf. Returns the first
+// [*ConfigError] on a malformed section.
+func buildNotificationsConfig(raw map[string]any) (NotificationsConfig, error) {
+	value, ok := raw["notifications"]
+	if !ok || value == nil {
+		return NotificationsConfig{}, nil
+	}
+
+	seq, ok := value.([]any)
+	if !ok {
+		return NotificationsConfig{}, &ConfigError{
+			Field:   "notifications",
+			Message: fmt.Sprintf("expected sequence, got %T", value),
+		}
+	}
+
+	backends := make([]NotificationBackend, 0, len(seq))
+	for i, elem := range seq {
+		backend, err := parseNotificationBackend(i, elem)
+		if err != nil {
+			return NotificationsConfig{}, err
+		}
+		backends = append(backends, backend)
+	}
+
+	if len(backends) == 0 {
+		return NotificationsConfig{}, nil
+	}
+	return NotificationsConfig{Backends: backends}, nil
+}
+
+// parseNotificationBackend converts a single notifications entry into a
+// [NotificationBackend], resolving $VAR references on its pass-through
+// leaves.
+func parseNotificationBackend(index int, elem any) (NotificationBackend, error) {
+	field := fmt.Sprintf("notifications[%d]", index)
+
+	entry, ok := elem.(map[string]any)
+	if !ok {
+		return NotificationBackend{}, &ConfigError{
+			Field:   field,
+			Message: fmt.Sprintf("expected map, got %T", elem),
+		}
+	}
+
+	kind, _ := entry["kind"].(string)
+	if kind == "" {
+		return NotificationBackend{}, &ConfigError{
+			Field:   field + ".kind",
+			Message: "kind is required and must be a non-empty string",
+		}
+	}
+
+	maxPerSession := 0
+	if rawMax, exists := entry["max_per_session"]; exists && rawMax != nil {
+		n, err := coerceInt(rawMax)
+		if err != nil {
+			return NotificationBackend{}, &ConfigError{
+				Field:   field + ".max_per_session",
+				Message: fmt.Sprintf("invalid integer value: %v", rawMax),
+			}
+		}
+		if n < 0 {
+			return NotificationBackend{}, &ConfigError{
+				Field:   field + ".max_per_session",
+				Message: "must not be negative",
+			}
+		}
+		maxPerSession = n
+	}
+
+	passthrough := make(map[string]any, len(entry))
+	for key, val := range entry {
+		if key == "kind" || key == "max_per_session" {
+			continue
+		}
+		passthrough[key] = val
+	}
+
+	// A typed knownTopLevelKeys section is excluded from Extensions, and
+	// the only existing $VAR walker runs over Extensions, so resolve the
+	// entry leaves here. An unset reference resolves to the empty string,
+	// which the backend constructor then rejects as a missing secret.
+	var snapshot map[string]string
+	for key, val := range passthrough {
+		passthrough[key] = resolveExtensionEnvValue(key, val, &snapshot)
+	}
+
+	return NotificationBackend{
+		Kind:          kind,
+		MaxPerSession: maxPerSession,
+		Config:        passthrough,
+	}, nil
+}

--- a/internal/config/notifications_test.go
+++ b/internal/config/notifications_test.go
@@ -1,0 +1,319 @@
+package config
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestNotificationsConfig_AbsentSection(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := NewServiceConfig(map[string]any{})
+	if err != nil {
+		t.Fatalf("NewServiceConfig(empty map): %v", err)
+	}
+	if cfg.Notifications.Backends != nil {
+		t.Errorf("Notifications.Backends = %v, want nil when section absent", cfg.Notifications.Backends)
+	}
+}
+
+func TestNotificationsConfig_ValidTwoEntries(t *testing.T) {
+	t.Parallel()
+
+	raw := map[string]any{
+		"notifications": []any{
+			map[string]any{
+				"kind":            "webhook",
+				"url":             "https://example.com/hook",
+				"max_per_session": 10,
+			},
+			map[string]any{
+				"kind":            "slack",
+				"webhook_url":     "https://hooks.slack.com/T/B/SECRET",
+				"max_per_session": 0,
+			},
+		},
+	}
+
+	cfg, err := NewServiceConfig(raw)
+	if err != nil {
+		t.Fatalf("NewServiceConfig: %v", err)
+	}
+
+	if len(cfg.Notifications.Backends) != 2 {
+		t.Fatalf("Notifications.Backends len = %d, want 2", len(cfg.Notifications.Backends))
+	}
+
+	first := cfg.Notifications.Backends[0]
+	if first.Kind != "webhook" {
+		t.Errorf("Backends[0].Kind = %q, want %q", first.Kind, "webhook")
+	}
+	if first.MaxPerSession != 10 {
+		t.Errorf("Backends[0].MaxPerSession = %d, want 10", first.MaxPerSession)
+	}
+	if url, ok := first.Config["url"].(string); !ok || url != "https://example.com/hook" {
+		t.Errorf("Backends[0].Config[\"url\"] = %v, want %q", first.Config["url"], "https://example.com/hook")
+	}
+
+	second := cfg.Notifications.Backends[1]
+	if second.Kind != "slack" {
+		t.Errorf("Backends[1].Kind = %q, want %q", second.Kind, "slack")
+	}
+	if second.MaxPerSession != 0 {
+		t.Errorf("Backends[1].MaxPerSession = %d, want 0", second.MaxPerSession)
+	}
+	if wurl, ok := second.Config["webhook_url"].(string); !ok || wurl != "https://hooks.slack.com/T/B/SECRET" {
+		t.Errorf("Backends[1].Config[\"webhook_url\"] = %v, want non-empty", second.Config["webhook_url"])
+	}
+}
+
+func TestNotificationsConfig_MissingKind(t *testing.T) {
+	t.Parallel()
+
+	raw := map[string]any{
+		"notifications": []any{
+			map[string]any{
+				"webhook_url": "https://hooks.slack.com/T/B/SECRET",
+			},
+		},
+	}
+
+	_, err := NewServiceConfig(raw)
+	assertConfigErrorField(t, err, "notifications[0].kind")
+}
+
+func TestNotificationsConfig_EmptyKind(t *testing.T) {
+	t.Parallel()
+
+	raw := map[string]any{
+		"notifications": []any{
+			map[string]any{
+				"kind": "",
+			},
+		},
+	}
+
+	_, err := NewServiceConfig(raw)
+	assertConfigErrorField(t, err, "notifications[0].kind")
+}
+
+func TestNotificationsConfig_NonSequenceValue(t *testing.T) {
+	t.Parallel()
+
+	raw := map[string]any{
+		"notifications": "not-a-sequence",
+	}
+
+	_, err := NewServiceConfig(raw)
+	assertConfigErrorField(t, err, "notifications")
+}
+
+func TestNotificationsConfig_NonSequenceMapValue(t *testing.T) {
+	t.Parallel()
+
+	raw := map[string]any{
+		"notifications": map[string]any{
+			"kind": "webhook",
+		},
+	}
+
+	_, err := NewServiceConfig(raw)
+	assertConfigErrorField(t, err, "notifications")
+}
+
+func TestNotificationsConfig_NegativeMaxPerSession(t *testing.T) {
+	t.Parallel()
+
+	raw := map[string]any{
+		"notifications": []any{
+			map[string]any{
+				"kind":            "webhook",
+				"url":             "https://example.com/hook",
+				"max_per_session": -1,
+			},
+		},
+	}
+
+	_, err := NewServiceConfig(raw)
+	assertConfigErrorField(t, err, "notifications[0].max_per_session")
+}
+
+func TestNotificationsConfig_ZeroMaxPerSession_Valid(t *testing.T) {
+	t.Parallel()
+
+	raw := map[string]any{
+		"notifications": []any{
+			map[string]any{
+				"kind":            "webhook",
+				"url":             "https://example.com/hook",
+				"max_per_session": 0,
+			},
+		},
+	}
+
+	cfg, err := NewServiceConfig(raw)
+	if err != nil {
+		t.Fatalf("NewServiceConfig with max_per_session=0: %v", err)
+	}
+	if cfg.Notifications.Backends[0].MaxPerSession != 0 {
+		t.Errorf("MaxPerSession = %d, want 0", cfg.Notifications.Backends[0].MaxPerSession)
+	}
+}
+
+func TestNotificationsConfig_VarResolution_Set(t *testing.T) {
+	// t.Setenv is not compatible with t.Parallel.
+	t.Setenv("SORTIE_TEST_WEBHOOK_URL", "https://resolved.example.com/hook")
+
+	raw := map[string]any{
+		"notifications": []any{
+			map[string]any{
+				"kind": "webhook",
+				"url":  "$SORTIE_TEST_WEBHOOK_URL",
+			},
+		},
+	}
+
+	cfg, err := NewServiceConfig(raw)
+	if err != nil {
+		t.Fatalf("NewServiceConfig with $VAR url: %v", err)
+	}
+
+	if len(cfg.Notifications.Backends) != 1 {
+		t.Fatalf("Backends len = %d, want 1", len(cfg.Notifications.Backends))
+	}
+
+	got, ok := cfg.Notifications.Backends[0].Config["url"].(string)
+	if !ok {
+		t.Fatalf("Config[\"url\"] type = %T, want string", cfg.Notifications.Backends[0].Config["url"])
+	}
+	if got != "https://resolved.example.com/hook" {
+		t.Errorf("Config[\"url\"] = %q, want %q", got, "https://resolved.example.com/hook")
+	}
+}
+
+func TestNotificationsConfig_VarResolution_Unset(t *testing.T) {
+	// Ensure the variable is not set; t.Setenv with empty string
+	// sets it to empty but here we use an unset variable name.
+	raw := map[string]any{
+		"notifications": []any{
+			map[string]any{
+				"kind":        "slack",
+				"webhook_url": "$SORTIE_NOTIFICATIONS_TEST_UNSET_VARIABLE_XYZ",
+			},
+		},
+	}
+
+	cfg, err := NewServiceConfig(raw)
+	if err != nil {
+		t.Fatalf("NewServiceConfig with unset $VAR: %v", err)
+	}
+
+	got, ok := cfg.Notifications.Backends[0].Config["webhook_url"].(string)
+	if !ok {
+		t.Fatalf("Config[\"webhook_url\"] type = %T, want string", cfg.Notifications.Backends[0].Config["webhook_url"])
+	}
+	if got != "" {
+		t.Errorf("Config[\"webhook_url\"] = %q, want empty string for unset variable", got)
+	}
+}
+
+func TestNotificationsConfig_BraceVarResolution(t *testing.T) {
+	// t.Setenv is not compatible with t.Parallel.
+	t.Setenv("SORTIE_TEST_WEBHOOK_BRACE", "https://brace.example.com/hook")
+
+	raw := map[string]any{
+		"notifications": []any{
+			map[string]any{
+				"kind": "webhook",
+				"url":  "${SORTIE_TEST_WEBHOOK_BRACE}",
+			},
+		},
+	}
+
+	cfg, err := NewServiceConfig(raw)
+	if err != nil {
+		t.Fatalf("NewServiceConfig with ${VAR} url: %v", err)
+	}
+
+	got, ok := cfg.Notifications.Backends[0].Config["url"].(string)
+	if !ok {
+		t.Fatalf("Config[\"url\"] type = %T, want string", cfg.Notifications.Backends[0].Config["url"])
+	}
+	if got != "https://brace.example.com/hook" {
+		t.Errorf("Config[\"url\"] = %q, want %q", got, "https://brace.example.com/hook")
+	}
+}
+
+func TestNotificationsConfig_FrontMatterNoWarning(t *testing.T) {
+	t.Parallel()
+
+	raw := map[string]any{
+		"notifications": []any{
+			map[string]any{
+				"kind": "webhook",
+				"url":  "https://example.com/hook",
+			},
+		},
+	}
+
+	cfg, err := NewServiceConfig(raw)
+	if err != nil {
+		t.Fatalf("NewServiceConfig: %v", err)
+	}
+
+	warnings := ValidateFrontMatter(raw, cfg)
+	for _, w := range warnings {
+		if w.Field == "notifications" || (len(w.Field) > 13 && w.Field[:13] == "notifications") {
+			t.Errorf("unexpected front-matter warning for notifications: check=%q field=%q msg=%q",
+				w.Check, w.Field, w.Message)
+		}
+	}
+}
+
+func TestNotificationsConfig_KindNotPropagatedToConfig(t *testing.T) {
+	t.Parallel()
+
+	raw := map[string]any{
+		"notifications": []any{
+			map[string]any{
+				"kind":            "webhook",
+				"url":             "https://example.com/hook",
+				"max_per_session": 5,
+			},
+		},
+	}
+
+	cfg, err := NewServiceConfig(raw)
+	if err != nil {
+		t.Fatalf("NewServiceConfig: %v", err)
+	}
+
+	backend := cfg.Notifications.Backends[0]
+
+	if _, present := backend.Config["kind"]; present {
+		t.Error("Config map contains \"kind\"; it should be stripped into the Kind field")
+	}
+	if _, present := backend.Config["max_per_session"]; present {
+		t.Error("Config map contains \"max_per_session\"; it should be stripped into MaxPerSession")
+	}
+}
+
+func TestNotificationsConfig_ErrorIsPtrConfigError(t *testing.T) {
+	t.Parallel()
+
+	raw := map[string]any{
+		"notifications": []any{
+			map[string]any{"kind": ""},
+		},
+	}
+
+	_, err := NewServiceConfig(raw)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	var ce *ConfigError
+	if !errors.As(err, &ce) {
+		t.Fatalf("error type = %T, want *ConfigError", err)
+	}
+}

--- a/internal/domain/notify.go
+++ b/internal/domain/notify.go
@@ -1,0 +1,77 @@
+package domain
+
+import "context"
+
+// Notifier sends a normalized [Notification] to a single backend.
+// One method keeps every backend interchangeable and lets any producer
+// reuse the family.
+type Notifier interface {
+	// Send delivers the notification. It returns nil on a successful
+	// send and a classified error on transport failure, a non-2xx
+	// response, or an unparseable response. Implementations apply a
+	// per-call timeout and must not log the endpoint URL, the request
+	// body, or the response body.
+	Send(ctx context.Context, n Notification) error
+}
+
+// Notification is the normalized payload every notifier backend
+// consumes. The envelope is filled by the producer; the message is
+// supplied by the agent. The value is self-contained: every field a
+// backend needs rides in it, with no dependency on producer-only state.
+type Notification struct {
+	Envelope NotificationEnvelope
+	Message  NotificationMessage
+}
+
+// NotificationEnvelope carries system-owned session context. The agent
+// neither provides it nor can override it.
+type NotificationEnvelope struct {
+	// NotificationID is a generated unique id, such as a UUID.
+	NotificationID string
+
+	// Timestamp is the send time in ISO-8601 UTC, such as
+	// 2026-06-10T14:03:05Z.
+	Timestamp string
+
+	// Source identifies the Sortie instance and defaults to the
+	// hostname.
+	Source string
+
+	// IssueID is the tracker-internal issue id.
+	IssueID string
+
+	// Identifier is the human-readable issue key.
+	Identifier string
+
+	// SessionID is the agent session id. It may be empty early in a
+	// lifecycle.
+	SessionID string
+
+	// Attempt is the retry or continuation attempt. It is nil on the
+	// first run.
+	Attempt *int
+
+	// Agent is the dispatch-frozen agent kind, such as "claude-code".
+	// It may be empty when no agent kind is resolved.
+	Agent string
+}
+
+// NotificationMessage carries the agent-supplied content. Severity is
+// constrained to info, warning, or critical, and Category to
+// decision_needed, progress, blocked, completed, or other. The
+// constraints are documented here but enforced by the producing tool,
+// not by this type.
+type NotificationMessage struct {
+	// Severity is one of info, warning, or critical.
+	Severity string
+
+	// Title is a non-empty short summary.
+	Title string
+
+	// Body is the non-empty notification detail.
+	Body string
+
+	// Category is optional and, when set, is one of decision_needed,
+	// progress, blocked, completed, or other.
+	Category string
+}

--- a/internal/domain/notify_test.go
+++ b/internal/domain/notify_test.go
@@ -1,0 +1,121 @@
+package domain
+
+import (
+	"context"
+	"testing"
+)
+
+// stubNotifier is a minimal Notifier implementation for compile-time
+// interface assertion.
+type stubNotifier struct{}
+
+var _ Notifier = (*stubNotifier)(nil)
+
+func (s *stubNotifier) Send(_ context.Context, _ Notification) error { return nil }
+
+func TestNotifierInterface(t *testing.T) {
+	t.Parallel()
+
+	// The compile-time assertion (var _ Notifier = (*stubNotifier)(nil))
+	// verifies interface satisfaction. This test exercises the Send method
+	// to confirm the concrete type is callable via the interface.
+	var n Notifier = &stubNotifier{}
+	if err := n.Send(context.Background(), Notification{}); err != nil {
+		t.Errorf("Send() = %v, want nil", err)
+	}
+}
+
+func TestNotification_FieldRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	attempt := 3
+
+	n := Notification{
+		Envelope: NotificationEnvelope{
+			NotificationID: "uuid-1234",
+			Timestamp:      "2026-06-10T14:03:05Z",
+			Source:         "builder-host",
+			IssueID:        "issue-99",
+			Identifier:     "PROJ-99",
+			SessionID:      "sess-abc",
+			Attempt:        &attempt,
+			Agent:          "claude-code",
+		},
+		Message: NotificationMessage{
+			Severity: "warning",
+			Title:    "Review needed",
+			Body:     "Agent blocked on ambiguous requirements.",
+			Category: "decision_needed",
+		},
+	}
+
+	if got := n.Envelope.NotificationID; got != "uuid-1234" {
+		t.Errorf("Envelope.NotificationID = %q, want %q", got, "uuid-1234")
+	}
+	if got := n.Envelope.Timestamp; got != "2026-06-10T14:03:05Z" {
+		t.Errorf("Envelope.Timestamp = %q, want %q", got, "2026-06-10T14:03:05Z")
+	}
+	if got := n.Envelope.Source; got != "builder-host" {
+		t.Errorf("Envelope.Source = %q, want %q", got, "builder-host")
+	}
+	if got := n.Envelope.IssueID; got != "issue-99" {
+		t.Errorf("Envelope.IssueID = %q, want %q", got, "issue-99")
+	}
+	if got := n.Envelope.Identifier; got != "PROJ-99" {
+		t.Errorf("Envelope.Identifier = %q, want %q", got, "PROJ-99")
+	}
+	if got := n.Envelope.SessionID; got != "sess-abc" {
+		t.Errorf("Envelope.SessionID = %q, want %q", got, "sess-abc")
+	}
+	if n.Envelope.Attempt == nil {
+		t.Fatal("Envelope.Attempt = nil, want non-nil")
+	}
+	if got := *n.Envelope.Attempt; got != 3 {
+		t.Errorf("Envelope.Attempt = %d, want 3", got)
+	}
+	if got := n.Envelope.Agent; got != "claude-code" {
+		t.Errorf("Envelope.Agent = %q, want %q", got, "claude-code")
+	}
+	if got := n.Message.Severity; got != "warning" {
+		t.Errorf("Message.Severity = %q, want %q", got, "warning")
+	}
+	if got := n.Message.Title; got != "Review needed" {
+		t.Errorf("Message.Title = %q, want %q", got, "Review needed")
+	}
+	if got := n.Message.Body; got != "Agent blocked on ambiguous requirements." {
+		t.Errorf("Message.Body = %q, want %q", got, "Agent blocked on ambiguous requirements.")
+	}
+	if got := n.Message.Category; got != "decision_needed" {
+		t.Errorf("Message.Category = %q, want %q", got, "decision_needed")
+	}
+}
+
+func TestNotificationEnvelope_AttemptNilOnFirstRun(t *testing.T) {
+	t.Parallel()
+
+	n := Notification{
+		Envelope: NotificationEnvelope{
+			NotificationID: "id-1",
+			Attempt:        nil,
+		},
+	}
+
+	if n.Envelope.Attempt != nil {
+		t.Errorf("Envelope.Attempt = %v, want nil on first run", *n.Envelope.Attempt)
+	}
+}
+
+func TestNotification_SelfContained(t *testing.T) {
+	t.Parallel()
+
+	// A self-contained Notification holds all fields without referring to
+	// external state; creating a valid zero-field value compiles and
+	// round-trips its fields.
+	n := Notification{}
+	if n.Envelope.Agent != "" {
+		t.Errorf("zero Envelope.Agent = %q, want empty string", n.Envelope.Agent)
+	}
+	if n.Message.Category != "" {
+		t.Errorf("zero Message.Category = %q, want empty string", n.Message.Category)
+	}
+}

--- a/internal/notify/slack/errors.go
+++ b/internal/notify/slack/errors.go
@@ -1,0 +1,66 @@
+package slack
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+)
+
+// sendError is a classified notifier failure. It carries a category
+// (timeout, connection failure, an HTTP status class) and deliberately
+// omits the endpoint URL, the request body, and the response body so
+// the secret-bearing URL never reaches a log or an agent-visible result.
+type sendError struct {
+	Category string
+	Err      error
+}
+
+// Error returns the category only.
+func (e *sendError) Error() string { return e.Category }
+
+// Unwrap exposes the underlying transport error for [errors.Is] and
+// [errors.As] without surfacing its text into the category.
+func (e *sendError) Unwrap() error { return e.Err }
+
+// classifyHTTPError maps a non-2xx response to a [sendError] whose
+// category is the HTTP status class. The response body is drained and
+// discarded, never read into the error.
+func classifyHTTPError(resp *http.Response, _, _ string) error {
+	_, _ = io.Copy(io.Discard, resp.Body)
+
+	switch {
+	case resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden:
+		return &sendError{Category: fmt.Sprintf("unauthorized (HTTP %d)", resp.StatusCode)}
+	case resp.StatusCode == http.StatusTooManyRequests:
+		return &sendError{Category: "rate limited (HTTP 429)"}
+	case resp.StatusCode >= 500:
+		return &sendError{Category: fmt.Sprintf("server error (HTTP %d)", resp.StatusCode)}
+	default:
+		return &sendError{Category: fmt.Sprintf("unexpected response (HTTP %d)", resp.StatusCode)}
+	}
+}
+
+// classifyTransportError maps a request, network, or body-read failure
+// to a [sendError] with a transport category. The underlying error is
+// wrapped for chain inspection but is never rendered into the category,
+// so the host and URL it embeds stay out of logs and agent-visible
+// results.
+func classifyTransportError(err error, _, _ string) error {
+	return &sendError{Category: transportCategory(err), Err: err}
+}
+
+// transportCategory derives a redaction-safe category from a transport
+// error without rendering the error text, which embeds the host or URL.
+func transportCategory(err error) string {
+	if errors.Is(err, context.DeadlineExceeded) {
+		return "timeout"
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return "timeout"
+	}
+	return "connection failure"
+}

--- a/internal/notify/slack/slack.go
+++ b/internal/notify/slack/slack.go
@@ -1,0 +1,86 @@
+// Package slack implements [domain.Notifier] for a Slack incoming
+// webhook. A Slack incoming webhook is itself an HTTP POST of JSON, so
+// this backend differs from the generic webhook backend only in how it
+// renders the body: it posts a Slack-shaped object with a text field.
+//
+// The package builds on [httpkit.Client] with a mandatory per-call
+// timeout, classifies its own transport and non-2xx errors, and never
+// logs the endpoint URL, request body, or response body.
+package slack
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/sortie-ai/sortie/internal/domain"
+	"github.com/sortie-ai/sortie/internal/httpkit"
+	"github.com/sortie-ai/sortie/internal/registry"
+)
+
+var _ domain.Notifier = (*notifier)(nil)
+
+// sendTimeout bounds each outbound POST so a slow endpoint cannot stall
+// the agent turn.
+const sendTimeout = 10 * time.Second
+
+func init() {
+	registry.Notifiers.Register("slack", newNotifier)
+}
+
+// notifier posts notifications to a configured Slack incoming webhook.
+type notifier struct {
+	client *httpkit.Client
+}
+
+// newNotifier constructs a slack [domain.Notifier] from the entry's
+// pass-through config. It requires a non-empty webhook_url; an absent or
+// empty value (including a secret reference that resolved to the empty
+// string) is rejected.
+func newNotifier(config map[string]any) (domain.Notifier, error) {
+	rawURL, _ := config["webhook_url"].(string)
+	endpoint := strings.TrimSpace(rawURL)
+	if endpoint == "" {
+		return nil, fmt.Errorf("slack notifier: webhook_url is required")
+	}
+
+	client := httpkit.NewClient(httpkit.ClientOptions{
+		BaseURL:           endpoint,
+		Timeout:           sendTimeout,
+		ClassifyError:     classifyHTTPError,
+		ClassifyTransport: classifyTransportError,
+	})
+	return &notifier{client: client}, nil
+}
+
+// slackPayload is the body posted to a Slack incoming webhook. The text
+// field renders the severity, title, and body.
+type slackPayload struct {
+	Text string `json:"text"`
+}
+
+// Send posts a Slack-shaped body and returns nil on any 2xx response.
+// A non-2xx response or a transport failure yields a classified error
+// that omits the URL, request body, and response body.
+func (n *notifier) Send(ctx context.Context, notification domain.Notification) error {
+	encoded, err := json.Marshal(slackPayload{Text: renderText(notification)})
+	if err != nil {
+		return fmt.Errorf("slack notifier: encode payload: %w", err)
+	}
+
+	if _, err := n.client.Send(ctx, http.MethodPost, "", bytes.NewReader(encoded)); err != nil {
+		return err
+	}
+	return nil
+}
+
+// renderText composes the Slack message text from the message severity,
+// title, and body.
+func renderText(notification domain.Notification) string {
+	severity := strings.ToUpper(notification.Message.Severity)
+	return fmt.Sprintf("[%s] %s\n%s", severity, notification.Message.Title, notification.Message.Body)
+}

--- a/internal/notify/slack/slack_test.go
+++ b/internal/notify/slack/slack_test.go
@@ -1,0 +1,290 @@
+package slack
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/sortie-ai/sortie/internal/domain"
+)
+
+// captureServer starts an httptest.Server that records the last request
+// body and returns the given status code.
+func captureServer(t *testing.T, statusCode int) (server *httptest.Server, body func() []byte) {
+	t.Helper()
+	var captured []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("captureServer: read body: %v", err)
+		}
+		captured = b
+		w.WriteHeader(statusCode)
+	}))
+	t.Cleanup(srv.Close)
+	return srv, func() []byte { return captured }
+}
+
+// slogCapture returns a slog.Logger backed by a bytes.Buffer at Debug
+// level and a function that retrieves the captured output.
+func slogCapture() (*slog.Logger, func() string) {
+	var buf bytes.Buffer
+	h := slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})
+	return slog.New(h), func() string { return buf.String() }
+}
+
+// makeNotification builds a test Notification with recognizable field
+// values.
+func makeNotification() domain.Notification {
+	attempt := 1
+	return domain.Notification{
+		Envelope: domain.NotificationEnvelope{
+			NotificationID: "notif-slack-001",
+			Timestamp:      "2026-06-10T15:00:00Z",
+			Source:         "slack-test-host",
+			IssueID:        "issue-8",
+			Identifier:     "PROJ-8",
+			SessionID:      "sess-slack",
+			Attempt:        &attempt,
+			Agent:          "claude-code",
+		},
+		Message: domain.NotificationMessage{
+			Severity: "critical",
+			Title:    "Blocker found",
+			Body:     "Agent cannot proceed without operator input.",
+			Category: "blocked",
+		},
+	}
+}
+
+func TestSlack_NewNotifier_MissingWebhookURL(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		config map[string]any
+	}{
+		{name: "absent webhook_url key", config: map[string]any{}},
+		{name: "empty string webhook_url", config: map[string]any{"webhook_url": ""}},
+		{name: "whitespace only webhook_url", config: map[string]any{"webhook_url": "   "}},
+		{name: "nil webhook_url value", config: map[string]any{"webhook_url": nil}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := newNotifier(tt.config)
+			if err == nil {
+				t.Fatalf("newNotifier(%v) = nil error, want constructor error for missing webhook_url", tt.config)
+			}
+		})
+	}
+}
+
+func TestSlack_NewNotifier_ValidWebhookURL(t *testing.T) {
+	t.Parallel()
+
+	srv, _ := captureServer(t, http.StatusOK)
+
+	n, err := newNotifier(map[string]any{"webhook_url": srv.URL})
+	if err != nil {
+		t.Fatalf("newNotifier(valid webhook_url) = %v, want nil", err)
+	}
+	if n == nil {
+		t.Fatal("newNotifier(valid webhook_url) returned nil notifier")
+	}
+}
+
+func TestSlack_Send_PostsSlackShapedBody(t *testing.T) {
+	t.Parallel()
+
+	srv, getBody := captureServer(t, http.StatusOK)
+
+	n, err := newNotifier(map[string]any{"webhook_url": srv.URL})
+	if err != nil {
+		t.Fatalf("newNotifier: %v", err)
+	}
+
+	notif := makeNotification()
+	if err := n.Send(context.Background(), notif); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+
+	raw := getBody()
+	if len(raw) == 0 {
+		t.Fatal("Send posted empty body, want non-empty JSON")
+	}
+
+	var m map[string]any
+	if err := json.Unmarshal(raw, &m); err != nil {
+		t.Fatalf("Send body unmarshal: %v", err)
+	}
+
+	text, ok := m["text"].(string)
+	if !ok || text == "" {
+		t.Fatalf("body[\"text\"] = %v, want non-empty string", m["text"])
+	}
+
+	if !strings.Contains(text, notif.Message.Title) {
+		t.Errorf("text %q does not contain title %q", text, notif.Message.Title)
+	}
+	if !strings.Contains(text, notif.Message.Body) {
+		t.Errorf("text %q does not contain body %q", text, notif.Message.Body)
+	}
+	// Severity should appear in some form in the text field.
+	severityUpper := strings.ToUpper(notif.Message.Severity)
+	if !strings.Contains(strings.ToUpper(text), severityUpper) {
+		t.Errorf("text %q does not contain severity %q (case-insensitive)", text, notif.Message.Severity)
+	}
+}
+
+func TestSlack_Send_Non2xxReturnsClassifiedError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		statusCode int
+	}{
+		{name: "401 unauthorized", statusCode: http.StatusUnauthorized},
+		{name: "403 forbidden", statusCode: http.StatusForbidden},
+		{name: "429 rate limited", statusCode: http.StatusTooManyRequests},
+		{name: "500 server error", statusCode: http.StatusInternalServerError},
+		{name: "404 client error", statusCode: http.StatusNotFound},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			srv, _ := captureServer(t, tt.statusCode)
+
+			n, err := newNotifier(map[string]any{"webhook_url": srv.URL})
+			if err != nil {
+				t.Fatalf("newNotifier: %v", err)
+			}
+
+			err = n.Send(context.Background(), makeNotification())
+			if err == nil {
+				t.Fatalf("Send(status %d) = nil, want error", tt.statusCode)
+			}
+
+			var se *sendError
+			if !errors.As(err, &se) {
+				t.Fatalf("Send error type = %T, want *sendError", err)
+			}
+			if se.Category == "" {
+				t.Error("sendError.Category is empty, want a non-empty category string")
+			}
+		})
+	}
+}
+
+func TestSlack_Send_TransportFailureReturnsClassifiedError(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	srv.Close()
+
+	n, err := newNotifier(map[string]any{"webhook_url": srv.URL})
+	if err != nil {
+		t.Fatalf("newNotifier: %v", err)
+	}
+
+	err = n.Send(context.Background(), makeNotification())
+	if err == nil {
+		t.Fatal("Send(closed server) = nil, want transport error")
+	}
+
+	var se *sendError
+	if !errors.As(err, &se) {
+		t.Fatalf("Send error type = %T, want *sendError", err)
+	}
+	if se.Category == "" {
+		t.Error("sendError.Category is empty")
+	}
+}
+
+func TestSlack_Send_ContextCancellationReturnsError(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	t.Cleanup(srv.Close)
+
+	n, err := newNotifier(map[string]any{"webhook_url": srv.URL})
+	if err != nil {
+		t.Fatalf("newNotifier: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err = n.Send(ctx, makeNotification())
+	if err == nil {
+		t.Fatal("Send(cancelled ctx) = nil, want error")
+	}
+}
+
+func TestSlack_ErrorRedaction_URLAbsentFromError(t *testing.T) {
+	t.Parallel()
+
+	srv, _ := captureServer(t, http.StatusInternalServerError)
+	const secretToken = "XXXX_SECRET"
+	webhookURL := srv.URL + "/" + secretToken
+
+	n, err := newNotifier(map[string]any{"webhook_url": webhookURL})
+	if err != nil {
+		t.Fatalf("newNotifier: %v", err)
+	}
+
+	sendErr := n.Send(context.Background(), makeNotification())
+	if sendErr == nil {
+		t.Fatal("Send(500 response) = nil, want error")
+	}
+
+	errText := sendErr.Error()
+	if strings.Contains(errText, webhookURL) {
+		t.Errorf("error message contains URL %q: %q", webhookURL, errText)
+	}
+	if strings.Contains(errText, secretToken) {
+		t.Errorf("error message contains secret token: %q", errText)
+	}
+}
+
+func TestSlack_ErrorRedaction_URLAbsentFromLog(t *testing.T) {
+	t.Parallel()
+
+	srv, _ := captureServer(t, http.StatusUnauthorized)
+	const secretToken = "SECRET_TOKEN"
+	webhookURL := srv.URL + "/" + secretToken
+
+	logger, getLog := slogCapture()
+
+	n, err := newNotifier(map[string]any{"webhook_url": webhookURL})
+	if err != nil {
+		t.Fatalf("newNotifier: %v", err)
+	}
+
+	sendErr := n.Send(context.Background(), makeNotification())
+	if sendErr == nil {
+		t.Fatal("Send(401 response) = nil, want error")
+	}
+
+	logger.Error("send failed", slog.Any("error", sendErr))
+	logOutput := getLog()
+	if strings.Contains(logOutput, webhookURL) {
+		t.Errorf("log output contains URL %q: %q", webhookURL, logOutput)
+	}
+	if strings.Contains(logOutput, secretToken) {
+		t.Errorf("log output contains secret token: %q", logOutput)
+	}
+}

--- a/internal/notify/webhook/errors.go
+++ b/internal/notify/webhook/errors.go
@@ -1,0 +1,66 @@
+package webhook
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+)
+
+// sendError is a classified notifier failure. It carries a category
+// (timeout, connection failure, an HTTP status class) and deliberately
+// omits the endpoint URL, the request body, and the response body so
+// the secret-bearing URL never reaches a log or an agent-visible result.
+type sendError struct {
+	Category string
+	Err      error
+}
+
+// Error returns the category only.
+func (e *sendError) Error() string { return e.Category }
+
+// Unwrap exposes the underlying transport error for [errors.Is] and
+// [errors.As] without surfacing its text into the category.
+func (e *sendError) Unwrap() error { return e.Err }
+
+// classifyHTTPError maps a non-2xx response to a [sendError] whose
+// category is the HTTP status class. The response body is drained and
+// discarded, never read into the error.
+func classifyHTTPError(resp *http.Response, _, _ string) error {
+	_, _ = io.Copy(io.Discard, resp.Body)
+
+	switch {
+	case resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden:
+		return &sendError{Category: fmt.Sprintf("unauthorized (HTTP %d)", resp.StatusCode)}
+	case resp.StatusCode == http.StatusTooManyRequests:
+		return &sendError{Category: "rate limited (HTTP 429)"}
+	case resp.StatusCode >= 500:
+		return &sendError{Category: fmt.Sprintf("server error (HTTP %d)", resp.StatusCode)}
+	default:
+		return &sendError{Category: fmt.Sprintf("unexpected response (HTTP %d)", resp.StatusCode)}
+	}
+}
+
+// classifyTransportError maps a request, network, or body-read failure
+// to a [sendError] with a transport category. The underlying error is
+// wrapped for chain inspection but is never rendered into the category,
+// so the host and URL it embeds stay out of logs and agent-visible
+// results.
+func classifyTransportError(err error, _, _ string) error {
+	return &sendError{Category: transportCategory(err), Err: err}
+}
+
+// transportCategory derives a redaction-safe category from a transport
+// error without rendering the error text, which embeds the host or URL.
+func transportCategory(err error) string {
+	if errors.Is(err, context.DeadlineExceeded) {
+		return "timeout"
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return "timeout"
+	}
+	return "connection failure"
+}

--- a/internal/notify/webhook/webhook.go
+++ b/internal/notify/webhook/webhook.go
@@ -1,0 +1,107 @@
+// Package webhook implements [domain.Notifier] for a generic outbound
+// HTTP webhook. It posts a normalized notification as a JSON object to
+// an operator-configured URL, using the generic notifier vocabulary so
+// the body is backend-neutral. This is an outbound POST backend and is
+// distinct from inbound tracker webhook ingress.
+//
+// The package builds on [httpkit.Client] with a mandatory per-call
+// timeout, classifies its own transport and non-2xx errors, and never
+// logs the endpoint URL, request body, or response body.
+package webhook
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/sortie-ai/sortie/internal/domain"
+	"github.com/sortie-ai/sortie/internal/httpkit"
+	"github.com/sortie-ai/sortie/internal/registry"
+)
+
+var _ domain.Notifier = (*notifier)(nil)
+
+// sendTimeout bounds each outbound POST so a slow endpoint cannot stall
+// the agent turn.
+const sendTimeout = 10 * time.Second
+
+func init() {
+	registry.Notifiers.Register("webhook", newNotifier)
+}
+
+// notifier posts notifications to a configured webhook URL.
+type notifier struct {
+	client *httpkit.Client
+}
+
+// newNotifier constructs a webhook [domain.Notifier] from the entry's
+// pass-through config. It requires a non-empty url; an absent or empty
+// value (including a secret reference that resolved to the empty string)
+// is rejected.
+func newNotifier(config map[string]any) (domain.Notifier, error) {
+	rawURL, _ := config["url"].(string)
+	endpoint := strings.TrimSpace(rawURL)
+	if endpoint == "" {
+		return nil, fmt.Errorf("webhook notifier: url is required")
+	}
+
+	client := httpkit.NewClient(httpkit.ClientOptions{
+		BaseURL:           endpoint,
+		Timeout:           sendTimeout,
+		ClassifyError:     classifyHTTPError,
+		ClassifyTransport: classifyTransportError,
+	})
+	return &notifier{client: client}, nil
+}
+
+// wirePayload is the JSON object posted to the webhook endpoint. Field
+// names use the generic notifier vocabulary so any machine consumer can
+// correlate and route without backend-specific knowledge.
+type wirePayload struct {
+	NotificationID string `json:"notification_id"`
+	Timestamp      string `json:"timestamp"`
+	Source         string `json:"source"`
+	IssueID        string `json:"issue_id"`
+	Identifier     string `json:"identifier"`
+	SessionID      string `json:"session_id"`
+	Attempt        *int   `json:"attempt"`
+	Agent          string `json:"agent"`
+	Severity       string `json:"severity"`
+	Title          string `json:"title"`
+	Body           string `json:"body"`
+	Category       string `json:"category,omitempty"`
+}
+
+// Send posts the notification as a JSON object and returns nil on any
+// 2xx response. A non-2xx response or a transport failure yields a
+// classified error that omits the URL, request body, and response body.
+func (n *notifier) Send(ctx context.Context, notification domain.Notification) error {
+	payload := wirePayload{
+		NotificationID: notification.Envelope.NotificationID,
+		Timestamp:      notification.Envelope.Timestamp,
+		Source:         notification.Envelope.Source,
+		IssueID:        notification.Envelope.IssueID,
+		Identifier:     notification.Envelope.Identifier,
+		SessionID:      notification.Envelope.SessionID,
+		Attempt:        notification.Envelope.Attempt,
+		Agent:          notification.Envelope.Agent,
+		Severity:       notification.Message.Severity,
+		Title:          notification.Message.Title,
+		Body:           notification.Message.Body,
+		Category:       notification.Message.Category,
+	}
+
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("webhook notifier: encode payload: %w", err)
+	}
+
+	if _, err := n.client.Send(ctx, http.MethodPost, "", bytes.NewReader(encoded)); err != nil {
+		return err
+	}
+	return nil
+}

--- a/internal/notify/webhook/webhook_test.go
+++ b/internal/notify/webhook/webhook_test.go
@@ -1,0 +1,313 @@
+package webhook
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/sortie-ai/sortie/internal/domain"
+)
+
+// captureServer starts an httptest.Server that records the last request
+// body and returns the given status code.
+func captureServer(t *testing.T, statusCode int) (server *httptest.Server, body func() []byte) {
+	t.Helper()
+	var captured []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("captureServer: read body: %v", err)
+		}
+		captured = b
+		w.WriteHeader(statusCode)
+	}))
+	t.Cleanup(srv.Close)
+	return srv, func() []byte { return captured }
+}
+
+// slogCapture returns a slog.Logger backed by a bytes.Buffer at Debug
+// level and a function that retrieves the captured output.
+func slogCapture() (*slog.Logger, func() string) {
+	var buf bytes.Buffer
+	h := slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})
+	return slog.New(h), func() string { return buf.String() }
+}
+
+// makeNotification builds a test Notification with recognizable field
+// values that can be checked in the posted body.
+func makeNotification() domain.Notification {
+	attempt := 2
+	return domain.Notification{
+		Envelope: domain.NotificationEnvelope{
+			NotificationID: "notif-uuid-001",
+			Timestamp:      "2026-06-10T14:00:00Z",
+			Source:         "test-host",
+			IssueID:        "issue-7",
+			Identifier:     "PROJ-7",
+			SessionID:      "sess-xyz",
+			Attempt:        &attempt,
+			Agent:          "claude-code",
+		},
+		Message: domain.NotificationMessage{
+			Severity: "warning",
+			Title:    "Needs review",
+			Body:     "Agent paused for human decision.",
+			Category: "decision_needed",
+		},
+	}
+}
+
+func TestWebhook_NewNotifier_MissingURL(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		config map[string]any
+	}{
+		{name: "absent url key", config: map[string]any{}},
+		{name: "empty string url", config: map[string]any{"url": ""}},
+		{name: "whitespace only url", config: map[string]any{"url": "   "}},
+		{name: "nil url value", config: map[string]any{"url": nil}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := newNotifier(tt.config)
+			if err == nil {
+				t.Fatalf("newNotifier(%v) = nil error, want constructor error for missing url", tt.config)
+			}
+		})
+	}
+}
+
+func TestWebhook_NewNotifier_ValidURL(t *testing.T) {
+	t.Parallel()
+
+	srv, _ := captureServer(t, http.StatusOK)
+
+	n, err := newNotifier(map[string]any{"url": srv.URL})
+	if err != nil {
+		t.Fatalf("newNotifier(valid url) = %v, want nil", err)
+	}
+	if n == nil {
+		t.Fatal("newNotifier(valid url) returned nil notifier")
+	}
+}
+
+func TestWebhook_Send_PostsEnvelopeAndMessage(t *testing.T) {
+	t.Parallel()
+
+	srv, getBody := captureServer(t, http.StatusOK)
+
+	n, err := newNotifier(map[string]any{"url": srv.URL})
+	if err != nil {
+		t.Fatalf("newNotifier: %v", err)
+	}
+
+	notif := makeNotification()
+	if err := n.Send(context.Background(), notif); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+
+	raw := getBody()
+	if len(raw) == 0 {
+		t.Fatal("Send posted empty body, want non-empty JSON")
+	}
+
+	var m map[string]any
+	if err := json.Unmarshal(raw, &m); err != nil {
+		t.Fatalf("Send body unmarshal: %v", err)
+	}
+
+	fields := map[string]string{
+		"notification_id": "notif-uuid-001",
+		"timestamp":       "2026-06-10T14:00:00Z",
+		"source":          "test-host",
+		"issue_id":        "issue-7",
+		"identifier":      "PROJ-7",
+		"session_id":      "sess-xyz",
+		"agent":           "claude-code",
+		"severity":        "warning",
+		"title":           "Needs review",
+		"body":            "Agent paused for human decision.",
+		"category":        "decision_needed",
+	}
+	for key, want := range fields {
+		got, ok := m[key].(string)
+		if !ok {
+			t.Errorf("body[%q] missing or wrong type: %v", key, m[key])
+			continue
+		}
+		if got != want {
+			t.Errorf("body[%q] = %q, want %q", key, got, want)
+		}
+	}
+
+	if attemptRaw, ok := m["attempt"]; !ok {
+		t.Error("body[\"attempt\"] missing")
+	} else if attempt, ok := attemptRaw.(float64); !ok || int(attempt) != 2 {
+		t.Errorf("body[\"attempt\"] = %v, want 2", attemptRaw)
+	}
+}
+
+func TestWebhook_Send_Non2xxReturnsClassifiedError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		statusCode int
+	}{
+		{name: "401 unauthorized", statusCode: http.StatusUnauthorized},
+		{name: "403 forbidden", statusCode: http.StatusForbidden},
+		{name: "429 rate limited", statusCode: http.StatusTooManyRequests},
+		{name: "500 server error", statusCode: http.StatusInternalServerError},
+		{name: "404 client error", statusCode: http.StatusNotFound},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			srv, _ := captureServer(t, tt.statusCode)
+
+			n, err := newNotifier(map[string]any{"url": srv.URL})
+			if err != nil {
+				t.Fatalf("newNotifier: %v", err)
+			}
+
+			err = n.Send(context.Background(), makeNotification())
+			if err == nil {
+				t.Fatalf("Send(status %d) = nil, want error", tt.statusCode)
+			}
+
+			var se *sendError
+			if !errors.As(err, &se) {
+				t.Fatalf("Send error type = %T, want *sendError", err)
+			}
+			if se.Category == "" {
+				t.Error("sendError.Category is empty, want a non-empty category string")
+			}
+		})
+	}
+}
+
+func TestWebhook_Send_TransportFailureReturnsClassifiedError(t *testing.T) {
+	t.Parallel()
+
+	// Use a server that is immediately closed so the transport fails.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	srv.Close()
+
+	n, err := newNotifier(map[string]any{"url": srv.URL})
+	if err != nil {
+		t.Fatalf("newNotifier: %v", err)
+	}
+
+	err = n.Send(context.Background(), makeNotification())
+	if err == nil {
+		t.Fatal("Send(closed server) = nil, want transport error")
+	}
+
+	var se *sendError
+	if !errors.As(err, &se) {
+		t.Fatalf("Send error type = %T, want *sendError", err)
+	}
+	if se.Category == "" {
+		t.Error("sendError.Category is empty")
+	}
+}
+
+func TestWebhook_Send_ContextCancellationReturnsError(t *testing.T) {
+	t.Parallel()
+
+	// A server that closes the connection immediately after accepting, so
+	// the client's Do() returns a transport error fast without waiting for
+	// the handler to complete.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Hijack and close so the client sees a connection reset quickly.
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	t.Cleanup(srv.Close)
+
+	n, err := newNotifier(map[string]any{"url": srv.URL})
+	if err != nil {
+		t.Fatalf("newNotifier: %v", err)
+	}
+
+	// Cancel the context before sending.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err = n.Send(ctx, makeNotification())
+	if err == nil {
+		t.Fatal("Send(cancelled ctx) = nil, want error")
+	}
+}
+
+func TestWebhook_ErrorRedaction_URLAbsentFromError(t *testing.T) {
+	t.Parallel()
+
+	// Use a real httptest server that returns a non-2xx response. The
+	// classified sendError must not echo the server URL or any secret.
+	srv, _ := captureServer(t, http.StatusInternalServerError)
+	const secretToken = "token123"
+	webhookURL := srv.URL + "/" + secretToken
+
+	n, err := newNotifier(map[string]any{"url": webhookURL})
+	if err != nil {
+		t.Fatalf("newNotifier: %v", err)
+	}
+
+	sendErr := n.Send(context.Background(), makeNotification())
+	if sendErr == nil {
+		t.Fatal("Send(500 response) = nil, want error")
+	}
+
+	errText := sendErr.Error()
+	if strings.Contains(errText, webhookURL) {
+		t.Errorf("error message contains URL %q: %q", webhookURL, errText)
+	}
+	if strings.Contains(errText, secretToken) {
+		t.Errorf("error message contains secret token: %q", errText)
+	}
+}
+
+func TestWebhook_ErrorRedaction_URLAbsentFromLog(t *testing.T) {
+	t.Parallel()
+
+	srv, _ := captureServer(t, http.StatusUnauthorized)
+	const secretToken = "token456"
+	webhookURL := srv.URL + "/" + secretToken
+
+	logger, getLog := slogCapture()
+
+	n, err := newNotifier(map[string]any{"url": webhookURL})
+	if err != nil {
+		t.Fatalf("newNotifier: %v", err)
+	}
+
+	sendErr := n.Send(context.Background(), makeNotification())
+	if sendErr == nil {
+		t.Fatal("Send(401 response) = nil, want error")
+	}
+
+	// Simulate what the sidecar does: log the classified error. The
+	// message field must not embed the URL.
+	logger.Error("send failed", slog.Any("error", sendErr))
+	logOutput := getLog()
+	if strings.Contains(logOutput, webhookURL) {
+		t.Errorf("log output contains URL %q: %q", webhookURL, logOutput)
+	}
+	if strings.Contains(logOutput, secretToken) {
+		t.Errorf("log output contains secret token: %q", logOutput)
+	}
+}

--- a/internal/orchestrator/mcpconfig.go
+++ b/internal/orchestrator/mcpconfig.go
@@ -37,6 +37,12 @@ type MCPConfigParams struct {
 	// When non-nil, written to the env block as SORTIE_ATTEMPT.
 	Attempt *int
 
+	// AgentKind is the dispatch-frozen agent kind for this session.
+	// Written to the env block as SORTIE_SESSION_AGENT_KIND so the
+	// notify_operator envelope can record the agent that actually ran
+	// the session. Empty when no agent kind is resolved.
+	AgentKind string
+
 	// OperatorMCPConfigPath is the path to the operator-provided MCP
 	// config file. Empty when no operator config is specified.
 	OperatorMCPConfigPath string
@@ -63,7 +69,7 @@ func GenerateMCPConfig(params MCPConfigParams) (string, error) {
 	// Build the env block with a two-layer merge: process-level SORTIE_*
 	// variables first (lower precedence), then per-session variables
 	// (higher precedence, always win).
-	env := make(map[string]string, len(params.ProcessEnv)+5)
+	env := make(map[string]string, len(params.ProcessEnv)+6)
 	for k, v := range params.ProcessEnv {
 		env[k] = v
 	}
@@ -72,6 +78,7 @@ func GenerateMCPConfig(params MCPConfigParams) (string, error) {
 	env["SORTIE_WORKSPACE"] = params.WorkspacePath
 	env["SORTIE_DB_PATH"] = params.DBPath
 	env["SORTIE_SESSION_ID"] = params.SessionID
+	env["SORTIE_SESSION_AGENT_KIND"] = params.AgentKind
 	if params.Attempt != nil {
 		env["SORTIE_ATTEMPT"] = strconv.Itoa(*params.Attempt)
 	}

--- a/internal/orchestrator/mcpconfig_test.go
+++ b/internal/orchestrator/mcpconfig_test.go
@@ -125,19 +125,20 @@ func TestGenerateMCPConfig(t *testing.T) {
 		}
 
 		checks := map[string]string{
-			"SORTIE_ISSUE_ID":         p.IssueID,
-			"SORTIE_ISSUE_IDENTIFIER": p.Identifier,
-			"SORTIE_WORKSPACE":        p.WorkspacePath,
-			"SORTIE_DB_PATH":          p.DBPath,
-			"SORTIE_SESSION_ID":       p.SessionID,
+			"SORTIE_ISSUE_ID":           p.IssueID,
+			"SORTIE_ISSUE_IDENTIFIER":   p.Identifier,
+			"SORTIE_WORKSPACE":          p.WorkspacePath,
+			"SORTIE_DB_PATH":            p.DBPath,
+			"SORTIE_SESSION_ID":         p.SessionID,
+			"SORTIE_SESSION_AGENT_KIND": p.AgentKind,
 		}
 		for k, want := range checks {
 			if got, ok := env[k].(string); !ok || got != want {
 				t.Errorf("env[%q] = %q, want %q", k, env[k], want)
 			}
 		}
-		if len(env) != 5 {
-			t.Errorf("env key count = %d, want 5: %v", len(env), env)
+		if len(env) != 6 {
+			t.Errorf("env key count = %d, want 6: %v", len(env), env)
 		}
 	})
 
@@ -337,20 +338,21 @@ func TestGenerateMCPConfig(t *testing.T) {
 
 		// Per-session vars are also present and correct.
 		for k, want := range map[string]string{
-			"SORTIE_ISSUE_ID":         p.IssueID,
-			"SORTIE_ISSUE_IDENTIFIER": p.Identifier,
-			"SORTIE_WORKSPACE":        p.WorkspacePath,
-			"SORTIE_DB_PATH":          p.DBPath,
-			"SORTIE_SESSION_ID":       p.SessionID,
+			"SORTIE_ISSUE_ID":           p.IssueID,
+			"SORTIE_ISSUE_IDENTIFIER":   p.Identifier,
+			"SORTIE_WORKSPACE":          p.WorkspacePath,
+			"SORTIE_DB_PATH":            p.DBPath,
+			"SORTIE_SESSION_ID":         p.SessionID,
+			"SORTIE_SESSION_AGENT_KIND": p.AgentKind,
 		} {
 			if got, _ := env[k].(string); got != want {
 				t.Errorf("env[%q] = %q, want %q", k, got, want)
 			}
 		}
 
-		// 5 per-session + 2 process-level.
-		if len(env) != 7 {
-			t.Errorf("env key count = %d, want 7: %v", len(env), env)
+		// 6 per-session + 2 process-level.
+		if len(env) != 8 {
+			t.Errorf("env key count = %d, want 8: %v", len(env), env)
 		}
 	})
 
@@ -380,9 +382,9 @@ func TestGenerateMCPConfig(t *testing.T) {
 			t.Errorf("SORTIE_SESSION_ID = %q, want %q (per-session wins)", got, p.SessionID)
 		}
 
-		// Overwritten keys do not inflate the map; count stays at 5.
-		if len(env) != 5 {
-			t.Errorf("env key count = %d, want 5: %v", len(env), env)
+		// Overwritten keys do not inflate the map; count stays at 6.
+		if len(env) != 6 {
+			t.Errorf("env key count = %d, want 6: %v", len(env), env)
 		}
 	})
 
@@ -468,8 +470,8 @@ func TestGenerateMCPConfig_Attempt(t *testing.T) {
 		if got, ok := env["SORTIE_ATTEMPT"].(string); !ok || got != "2" {
 			t.Errorf("env[%q] = %q, want %q", "SORTIE_ATTEMPT", env["SORTIE_ATTEMPT"], "2")
 		}
-		if len(env) != 6 {
-			t.Errorf("env key count = %d, want 6: %v", len(env), env)
+		if len(env) != 7 {
+			t.Errorf("env key count = %d, want 7: %v", len(env), env)
 		}
 	})
 
@@ -492,6 +494,116 @@ func TestGenerateMCPConfig_Attempt(t *testing.T) {
 
 		if _, present := env["SORTIE_ATTEMPT"]; present {
 			t.Errorf("env[%q] = %v, want key absent when Attempt is nil", "SORTIE_ATTEMPT", env["SORTIE_ATTEMPT"])
+		}
+	})
+}
+
+func TestGenerateMCPConfig_AgentKind(t *testing.T) {
+	t.Parallel()
+
+	t.Run("SORTIE_SESSION_AGENT_KIND_written_with_AgentKind_value", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		p := mcpParams(dir)
+		p.AgentKind = "claude-code"
+
+		_, err := GenerateMCPConfig(p)
+		if err != nil {
+			t.Fatalf("GenerateMCPConfig: %v", err)
+		}
+
+		env, ok := sortieEntry(t, readMCPConfig(t, dir))["env"].(map[string]any)
+		if !ok {
+			t.Fatal("env is not an object")
+		}
+
+		got, ok := env["SORTIE_SESSION_AGENT_KIND"].(string)
+		if !ok {
+			t.Fatalf("env[%q] missing or wrong type: %v", "SORTIE_SESSION_AGENT_KIND", env["SORTIE_SESSION_AGENT_KIND"])
+		}
+		if got != "claude-code" {
+			t.Errorf("env[%q] = %q, want %q", "SORTIE_SESSION_AGENT_KIND", got, "claude-code")
+		}
+	})
+
+	t.Run("per_session_AgentKind_overrides_ProcessEnv", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		p := mcpParams(dir)
+		p.AgentKind = "codex"
+		p.ProcessEnv = map[string]string{
+			"SORTIE_SESSION_AGENT_KIND": "stale-kind-from-process",
+		}
+
+		_, err := GenerateMCPConfig(p)
+		if err != nil {
+			t.Fatalf("GenerateMCPConfig: %v", err)
+		}
+
+		env, ok := sortieEntry(t, readMCPConfig(t, dir))["env"].(map[string]any)
+		if !ok {
+			t.Fatal("env is not an object")
+		}
+
+		got, ok := env["SORTIE_SESSION_AGENT_KIND"].(string)
+		if !ok {
+			t.Fatalf("env[%q] missing or wrong type", "SORTIE_SESSION_AGENT_KIND")
+		}
+		if got != "codex" {
+			t.Errorf("env[%q] = %q (per-session), want %q; per-session write must win over ProcessEnv", "SORTIE_SESSION_AGENT_KIND", got, "codex")
+		}
+	})
+
+	t.Run("SORTIE_SESSION_AGENT_KIND_distinct_from_SORTIE_AGENT_KIND", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		p := mcpParams(dir)
+		p.AgentKind = "mock-agent"
+
+		_, err := GenerateMCPConfig(p)
+		if err != nil {
+			t.Fatalf("GenerateMCPConfig: %v", err)
+		}
+
+		env, ok := sortieEntry(t, readMCPConfig(t, dir))["env"].(map[string]any)
+		if !ok {
+			t.Fatal("env is not an object")
+		}
+
+		// The per-session agent kind must be written as SORTIE_SESSION_AGENT_KIND.
+		if _, present := env["SORTIE_SESSION_AGENT_KIND"]; !present {
+			t.Error("env[\"SORTIE_SESSION_AGENT_KIND\"] absent; per-session agent kind not written")
+		}
+		// SORTIE_AGENT_KIND is the config-override variable. It must NOT be
+		// written by GenerateMCPConfig; writing it would collide with the
+		// env-override registry and rewrite the workflow default agent.kind.
+		if _, present := env["SORTIE_AGENT_KIND"]; present {
+			t.Error("env[\"SORTIE_AGENT_KIND\"] present; GenerateMCPConfig must not write the override variable")
+		}
+	})
+
+	t.Run("empty_AgentKind_writes_empty_string", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		p := mcpParams(dir)
+		p.AgentKind = ""
+
+		_, err := GenerateMCPConfig(p)
+		if err != nil {
+			t.Fatalf("GenerateMCPConfig: %v", err)
+		}
+
+		env, ok := sortieEntry(t, readMCPConfig(t, dir))["env"].(map[string]any)
+		if !ok {
+			t.Fatal("env is not an object")
+		}
+
+		got, ok := env["SORTIE_SESSION_AGENT_KIND"].(string)
+		if !ok {
+			t.Fatalf("env[%q] missing or wrong type: %v", "SORTIE_SESSION_AGENT_KIND", env["SORTIE_SESSION_AGENT_KIND"])
+		}
+		if got != "" {
+			t.Errorf("env[%q] = %q, want empty string when AgentKind is empty", "SORTIE_SESSION_AGENT_KIND", got)
 		}
 	})
 }

--- a/internal/orchestrator/worker.go
+++ b/internal/orchestrator/worker.go
@@ -559,6 +559,7 @@ func RunWorkerAttempt(ctx context.Context, issue domain.Issue, attempt *int, dep
 			DBPath:                deps.DBPath,
 			SessionID:             "",
 			Attempt:               attempt,
+			AgentKind:             agentKind,
 			OperatorMCPConfigPath: operatorPath,
 			ProcessEnv:            CollectSortieEnv(),
 		})

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -65,6 +65,17 @@ type SCMAdapterConstructor func(adapterConfig map[string]any) (domain.SCMAdapter
 // the orchestrator resolves adapters via [Registry.Get] at runtime.
 var SCMAdapters = NewRegistry[SCMAdapterConstructor, struct{}]("scm")
 
+// NotifierConstructor creates a [domain.Notifier] from the backend
+// entry's pass-through config map. Implementations validate their
+// config and return an error when a required field is missing or a
+// referenced secret resolved to an empty string.
+type NotifierConstructor func(config map[string]any) (domain.Notifier, error)
+
+// Notifiers is the default notifier adapter registry. Backend packages
+// register themselves via [Registry.Register] in their init functions;
+// the sidecar resolves backends via [Registry.Get] at runtime.
+var Notifiers = NewRegistry[NotifierConstructor, struct{}]("notifier")
+
 // TrackerConfigFields holds the config values passed to adapter
 // validation functions. This is a plain data struct that avoids
 // coupling the registry package to the config package.

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -381,6 +381,12 @@ func TestRegistryError_Error(t *testing.T) {
 
 // --- Type-specific constructor tests ---
 
+var _ domain.Notifier = (*stubNotifier)(nil)
+
+type stubNotifier struct{}
+
+func (s *stubNotifier) Send(_ context.Context, _ domain.Notification) error { return nil }
+
 var _ domain.TrackerAdapter = (*mockTrackerAdapter)(nil)
 
 type mockTrackerAdapter struct{}
@@ -518,6 +524,82 @@ func TestPackageLevelRegistries(t *testing.T) {
 		}
 		if kinds := CIProviders.Kinds(); kinds == nil {
 			t.Fatal("CIProviders.Kinds() returned nil, want non-nil slice")
+		}
+	})
+
+	t.Run("Notifiers", func(t *testing.T) {
+		t.Parallel()
+
+		if Notifiers == nil {
+			t.Fatal("Notifiers is nil")
+		}
+		if kinds := Notifiers.Kinds(); kinds == nil {
+			t.Fatal("Notifiers.Kinds() returned nil, want non-nil slice")
+		}
+	})
+}
+
+func TestNotifiersRegistry(t *testing.T) {
+	t.Parallel()
+
+	t.Run("register and resolve stub kind", func(t *testing.T) {
+		t.Parallel()
+
+		r := NewRegistry[NotifierConstructor, struct{}]("notifier")
+		r.Register("test-notifier-stub", func(_ map[string]any) (domain.Notifier, error) {
+			return &stubNotifier{}, nil
+		})
+
+		ctor, err := r.Get("test-notifier-stub")
+		if err != nil {
+			t.Fatalf("Get(%q) unexpected error: %v", "test-notifier-stub", err)
+		}
+
+		notifier, err := ctor(nil)
+		if err != nil {
+			t.Fatalf("NotifierConstructor() unexpected error: %v", err)
+		}
+		if notifier == nil {
+			t.Fatal("NotifierConstructor() returned nil, want non-nil Notifier")
+		}
+	})
+
+	t.Run("unknown kind returns RegistryError", func(t *testing.T) {
+		t.Parallel()
+
+		r := NewRegistry[NotifierConstructor, struct{}]("notifier")
+
+		_, err := r.Get("nonexistent-notifier-kind")
+		if err == nil {
+			t.Fatal("Get(unknown kind) = nil, want *RegistryError")
+		}
+
+		var re *RegistryError
+		if !errors.As(err, &re) {
+			t.Fatalf("Get(unknown kind) error type = %T, want *RegistryError", err)
+		}
+		if re.Dimension != "notifier" {
+			t.Errorf("RegistryError.Dimension = %q, want %q", re.Dimension, "notifier")
+		}
+		if re.Kind != "nonexistent-notifier-kind" {
+			t.Errorf("RegistryError.Kind = %q, want %q", re.Kind, "nonexistent-notifier-kind")
+		}
+	})
+
+	t.Run("package-level Notifiers uses notifier dimension", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := Notifiers.Get("no-such-kind-xyz")
+		if err == nil {
+			t.Fatal("Notifiers.Get(unknown) = nil, want error")
+		}
+
+		var re *RegistryError
+		if !errors.As(err, &re) {
+			t.Fatalf("error type = %T, want *RegistryError", err)
+		}
+		if re.Dimension != "notifier" {
+			t.Errorf("Notifiers dimension = %q, want %q", re.Dimension, "notifier")
 		}
 	})
 }

--- a/internal/tool/notify/notify.go
+++ b/internal/tool/notify/notify.go
@@ -2,8 +2,9 @@
 // tool. The tool fills a system-owned envelope from session context the
 // agent cannot forge, validates the agent-supplied message, enforces a
 // per-session cap, and delivers a normalized [domain.Notification] to
-// each configured backend. It knows nothing about Slack or HTTP;
-// backends arrive as a resolved slice of [domain.Notifier].
+// the configured backends in configuration order, stopping at the first
+// backend that fails. It knows nothing about Slack or HTTP; backends
+// arrive as a resolved slice of [domain.Notifier].
 package notify
 
 import (
@@ -126,10 +127,12 @@ type toolInput struct {
 }
 
 // Execute validates the message, enforces the per-session cap, and
-// delivers one [domain.Notification] to each configured backend in
-// order. Domain failures are encoded in the JSON result with
-// success: false and a nil Go error. The Go error return is reserved
-// for a result-marshal failure.
+// delivers one [domain.Notification] to the configured backends in
+// configuration order. The first backend that fails short-circuits the
+// loop and yields a send_failed result; partial delivery across
+// backends is not reported in this version. Domain failures are encoded
+// in the JSON result with success: false and a nil Go error. The Go
+// error return is reserved for a result-marshal failure.
 func (t *NotifyTool) Execute(ctx context.Context, input json.RawMessage) (json.RawMessage, error) {
 	var in toolInput
 	dec := json.NewDecoder(bytes.NewReader(input))

--- a/internal/tool/notify/notify.go
+++ b/internal/tool/notify/notify.go
@@ -1,0 +1,240 @@
+// Package notify implements [domain.AgentTool] for the notify_operator
+// tool. The tool fills a system-owned envelope from session context the
+// agent cannot forge, validates the agent-supplied message, enforces a
+// per-session cap, and delivers a normalized [domain.Notification] to
+// each configured backend. It knows nothing about Slack or HTTP;
+// backends arrive as a resolved slice of [domain.Notifier].
+package notify
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"encoding/json"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/sortie-ai/sortie/internal/domain"
+)
+
+var _ domain.AgentTool = (*NotifyTool)(nil)
+
+var inputSchema = json.RawMessage(`{
+  "type": "object",
+  "properties": {
+    "severity": { "type": "string", "enum": ["info", "warning", "critical"] },
+    "title":    { "type": "string", "minLength": 1 },
+    "body":     { "type": "string", "minLength": 1 },
+    "category": { "type": "string", "enum": ["decision_needed", "progress", "blocked", "completed", "other"] }
+  },
+  "required": ["severity", "title", "body"],
+  "additionalProperties": false
+}`)
+
+// validSeverities is the closed set of accepted severity values.
+var validSeverities = map[string]bool{
+	"info":     true,
+	"warning":  true,
+	"critical": true,
+}
+
+// validCategories is the closed set of accepted optional category values.
+var validCategories = map[string]bool{
+	"decision_needed": true,
+	"progress":        true,
+	"blocked":         true,
+	"completed":       true,
+	"other":           true,
+}
+
+// NotificationEnvelopeContext carries the system-owned envelope inputs
+// read from the sidecar environment. The agent supplies none of these.
+type NotificationEnvelopeContext struct {
+	// IssueID is the tracker-internal issue id.
+	IssueID string
+
+	// Identifier is the human-readable issue key.
+	Identifier string
+
+	// SessionID is the agent session id; may be empty.
+	SessionID string
+
+	// Attempt is the retry or continuation attempt; nil on the first run.
+	Attempt *int
+
+	// Agent is the dispatch-frozen agent kind; may be empty.
+	Agent string
+
+	// Source identifies the Sortie instance. When empty, the tool
+	// defaults it to the hostname at send time.
+	Source string
+}
+
+// NotifyTool implements [domain.AgentTool] for notify_operator.
+// Construct via [New] with the resolved backends and the session
+// envelope context.
+type NotifyTool struct {
+	backends      []domain.Notifier
+	env           NotificationEnvelopeContext
+	maxPerSession int
+	count         int
+}
+
+// New returns a [NotifyTool]. backends is the ordered set of resolved
+// notifiers; the caller gates registration on a configured backend, so
+// New panics when backends is empty (programming error). env carries
+// the system-owned envelope context, and maxPerSession is the effective
+// per-session cap after default resolution.
+func New(backends []domain.Notifier, env NotificationEnvelopeContext, maxPerSession int) *NotifyTool {
+	if len(backends) == 0 {
+		panic("notify.New: backends must not be empty")
+	}
+	return &NotifyTool{
+		backends:      backends,
+		env:           env,
+		maxPerSession: maxPerSession,
+	}
+}
+
+// Name returns "notify_operator".
+func (t *NotifyTool) Name() string { return "notify_operator" }
+
+// Description returns a human-readable summary of the tool.
+func (t *NotifyTool) Description() string {
+	return "Send a real-time notification to the operator's configured channel. " +
+		"Use this to escalate a decision you should not make alone, report progress " +
+		"on a long task, or flag a blocker, without terminating the session. The " +
+		"issue, session, and agent context is attached automatically."
+}
+
+// InputSchema returns the JSON Schema for notify_operator input. The
+// agent supplies only the message; the envelope is system-owned and
+// absent from the schema. The returned slice is a defensive copy.
+func (t *NotifyTool) InputSchema() json.RawMessage {
+	out := make(json.RawMessage, len(inputSchema))
+	copy(out, inputSchema)
+	return out
+}
+
+// toolInput is the agent-supplied message decoded from the tool call.
+type toolInput struct {
+	Severity string `json:"severity"`
+	Title    string `json:"title"`
+	Body     string `json:"body"`
+	Category string `json:"category,omitempty"`
+}
+
+// Execute validates the message, enforces the per-session cap, and
+// delivers one [domain.Notification] to each configured backend in
+// order. Domain failures are encoded in the JSON result with
+// success: false and a nil Go error. The Go error return is reserved
+// for a result-marshal failure.
+func (t *NotifyTool) Execute(ctx context.Context, input json.RawMessage) (json.RawMessage, error) {
+	var in toolInput
+	dec := json.NewDecoder(bytes.NewReader(input))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&in); err != nil {
+		return errorResult("invalid_input", fmt.Sprintf("failed to parse input: %s", err))
+	}
+	if dec.More() {
+		return errorResult("invalid_input", "unexpected trailing content after JSON object")
+	}
+
+	if !validSeverities[in.Severity] {
+		return errorResult("invalid_input", "severity must be info, warning, or critical")
+	}
+	if in.Category != "" && !validCategories[in.Category] {
+		return errorResult("invalid_input", "category is not a recognized value")
+	}
+	if in.Title == "" || in.Body == "" {
+		return errorResult("invalid_input", "title and body must be non-empty")
+	}
+
+	if len(t.backends) == 0 {
+		return errorResult("backend_unavailable", "no notification backend is configured")
+	}
+
+	if t.count >= t.maxPerSession {
+		return errorResult("rate_limited", "per-session notification cap reached")
+	}
+
+	notification := domain.Notification{
+		Envelope: t.buildEnvelope(),
+		Message: domain.NotificationMessage{
+			Severity: in.Severity,
+			Title:    in.Title,
+			Body:     in.Body,
+			Category: in.Category,
+		},
+	}
+
+	delivered := 0
+	for _, backend := range t.backends {
+		if err := backend.Send(ctx, notification); err != nil {
+			return errorResult("send_failed", fmt.Sprintf("notification delivery failed: %s", err))
+		}
+		delivered++
+	}
+
+	t.count++
+	return successResult(delivered, notification.Envelope.NotificationID)
+}
+
+// buildEnvelope generates the notification id and timestamp at call time
+// and copies the session context from the stored envelope context. The
+// agent cannot set any envelope field.
+func (t *NotifyTool) buildEnvelope() domain.NotificationEnvelope {
+	source := t.env.Source
+	if source == "" {
+		if host, err := os.Hostname(); err == nil {
+			source = host
+		}
+	}
+
+	return domain.NotificationEnvelope{
+		NotificationID: newUUID(),
+		Timestamp:      time.Now().UTC().Format(time.RFC3339),
+		Source:         source,
+		IssueID:        t.env.IssueID,
+		Identifier:     t.env.Identifier,
+		SessionID:      t.env.SessionID,
+		Attempt:        t.env.Attempt,
+		Agent:          t.env.Agent,
+	}
+}
+
+// successResult marshals the success envelope.
+func successResult(delivered int, notificationID string) (json.RawMessage, error) {
+	return json.Marshal(map[string]any{
+		"success":         true,
+		"delivered":       delivered,
+		"notification_id": notificationID,
+	})
+}
+
+// errorResult marshals the failure envelope with a closed-set kind and a
+// redacted message. The kind is one of invalid_input, rate_limited,
+// send_failed, or backend_unavailable.
+func errorResult(kind, message string) (json.RawMessage, error) {
+	return json.Marshal(map[string]any{
+		"success": false,
+		"error": map[string]string{
+			"kind":    kind,
+			"message": message,
+		},
+	})
+}
+
+// newUUID generates a random v4 UUID string using crypto/rand. Panics if
+// the system random source is unavailable.
+func newUUID() string {
+	var buf [16]byte
+	if _, err := rand.Read(buf[:]); err != nil {
+		panic(fmt.Sprintf("notify: crypto/rand unavailable: %v", err))
+	}
+	buf[6] = (buf[6] & 0x0f) | 0x40
+	buf[8] = (buf[8] & 0x3f) | 0x80
+	return fmt.Sprintf("%08x-%04x-%04x-%04x-%012x",
+		buf[0:4], buf[4:6], buf[6:8], buf[8:10], buf[10:16])
+}

--- a/internal/tool/notify/notify_test.go
+++ b/internal/tool/notify/notify_test.go
@@ -1,0 +1,612 @@
+package notify
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/sortie-ai/sortie/internal/domain"
+)
+
+// mockNotifier is a test double for domain.Notifier that records calls
+// and optionally returns a configured error.
+type mockNotifier struct {
+	received []domain.Notification
+	err      error
+}
+
+var _ domain.Notifier = (*mockNotifier)(nil)
+
+func (m *mockNotifier) Send(_ context.Context, n domain.Notification) error {
+	m.received = append(m.received, n)
+	return m.err
+}
+
+// testEnv returns a NotificationEnvelopeContext with recognizable test
+// values.
+func testEnv() NotificationEnvelopeContext {
+	attempt := 2
+	return NotificationEnvelopeContext{
+		IssueID:    "issue-42",
+		Identifier: "PROJ-42",
+		SessionID:  "sess-001",
+		Attempt:    &attempt,
+		Agent:      "claude-code",
+		Source:     "test-host",
+	}
+}
+
+// executeJSON runs Execute with the given JSON input and unmarshals the
+// result into a map.
+func executeJSON(t *testing.T, tool *NotifyTool, input string) map[string]any {
+	t.Helper()
+	raw, err := tool.Execute(context.Background(), json.RawMessage(input))
+	if err != nil {
+		t.Fatalf("Execute returned non-nil Go error: %v", err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(raw, &m); err != nil {
+		t.Fatalf("Execute result unmarshal: %v", err)
+	}
+	return m
+}
+
+func assertSuccess(t *testing.T, m map[string]any) {
+	t.Helper()
+	if m["success"] != true {
+		t.Errorf("result[\"success\"] = %v, want true", m["success"])
+	}
+}
+
+func assertFailureKind(t *testing.T, m map[string]any, wantKind string) {
+	t.Helper()
+	if m["success"] != false {
+		t.Errorf("result[\"success\"] = %v, want false", m["success"])
+	}
+	errObj, ok := m["error"].(map[string]any)
+	if !ok {
+		t.Fatalf("result[\"error\"] = %v (%T), want map", m["error"], m["error"])
+	}
+	if got := errObj["kind"].(string); got != wantKind {
+		t.Errorf("error.kind = %q, want %q", got, wantKind)
+	}
+}
+
+// --- Tool identity tests ---
+
+func TestNotifyTool_Name(t *testing.T) {
+	t.Parallel()
+
+	tool := New([]domain.Notifier{&mockNotifier{}}, testEnv(), 10)
+	if got := tool.Name(); got != "notify_operator" {
+		t.Errorf("Name() = %q, want %q", got, "notify_operator")
+	}
+}
+
+func TestNotifyTool_Description(t *testing.T) {
+	t.Parallel()
+
+	tool := New([]domain.Notifier{&mockNotifier{}}, testEnv(), 10)
+	if got := tool.Description(); got == "" {
+		t.Error(`Description() = "", want non-empty`)
+	}
+}
+
+func TestNotifyTool_InputSchema_ValidJSON(t *testing.T) {
+	t.Parallel()
+
+	tool := New([]domain.Notifier{&mockNotifier{}}, testEnv(), 10)
+	schema := tool.InputSchema()
+
+	var m map[string]any
+	if err := json.Unmarshal(schema, &m); err != nil {
+		t.Fatalf("InputSchema() unmarshal: %v", err)
+	}
+
+	if got, _ := m["type"].(string); got != "object" {
+		t.Errorf("schema type = %v, want %q", m["type"], "object")
+	}
+
+	v, ok := m["additionalProperties"]
+	if !ok {
+		t.Fatal("additionalProperties key missing from schema")
+	}
+	if v != false {
+		t.Errorf("additionalProperties = %v, want false", v)
+	}
+
+	props, ok := m["properties"].(map[string]any)
+	if !ok {
+		t.Fatal("properties missing from schema")
+	}
+	for _, key := range []string{"severity", "title", "body", "category"} {
+		if _, ok := props[key]; !ok {
+			t.Errorf("schema properties missing key %q", key)
+		}
+	}
+}
+
+func TestNotifyTool_InputSchema_DefensiveCopy(t *testing.T) {
+	t.Parallel()
+
+	tool := New([]domain.Notifier{&mockNotifier{}}, testEnv(), 10)
+	schema1 := tool.InputSchema()
+	for i := range schema1 {
+		schema1[i] = 'X'
+	}
+
+	schema2 := tool.InputSchema()
+	var m map[string]any
+	if err := json.Unmarshal(schema2, &m); err != nil {
+		t.Fatalf("InputSchema() after mutation: %v", err)
+	}
+}
+
+// --- New panic tests ---
+
+func TestNew_PanicsOnEmptyBackends(t *testing.T) {
+	t.Parallel()
+
+	defer func() {
+		v := recover()
+		if v == nil {
+			t.Fatal("New(empty backends) did not panic, want panic")
+		}
+		msg := fmt.Sprint(v)
+		if !strings.Contains(msg, "backends") {
+			t.Errorf("panic message = %q, want to contain %q", msg, "backends")
+		}
+	}()
+
+	New([]domain.Notifier{}, testEnv(), 10)
+}
+
+func TestNew_PanicsOnNilBackends(t *testing.T) {
+	t.Parallel()
+
+	defer func() {
+		v := recover()
+		if v == nil {
+			t.Fatal("New(nil backends) did not panic, want panic")
+		}
+	}()
+
+	New(nil, testEnv(), 10)
+}
+
+// --- Execute dispatch and delivery tests ---
+
+func TestExecute_ValidCallDispatchesToBackend(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockNotifier{}
+	tool := New([]domain.Notifier{mock}, testEnv(), 10)
+
+	m := executeJSON(t, tool, `{"severity":"info","title":"Hello","body":"World"}`)
+	assertSuccess(t, m)
+
+	if len(mock.received) != 1 {
+		t.Fatalf("backend Send called %d times, want 1", len(mock.received))
+	}
+}
+
+func TestExecute_EnvelopeCarriesSessionContext(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockNotifier{}
+	env := testEnv()
+	tool := New([]domain.Notifier{mock}, env, 10)
+
+	executeJSON(t, tool, `{"severity":"warning","title":"Check","body":"Details"}`)
+
+	if len(mock.received) != 1 {
+		t.Fatalf("Send called %d times, want 1", len(mock.received))
+	}
+	n := mock.received[0]
+
+	if n.Envelope.IssueID != env.IssueID {
+		t.Errorf("Envelope.IssueID = %q, want %q", n.Envelope.IssueID, env.IssueID)
+	}
+	if n.Envelope.Identifier != env.Identifier {
+		t.Errorf("Envelope.Identifier = %q, want %q", n.Envelope.Identifier, env.Identifier)
+	}
+	if n.Envelope.SessionID != env.SessionID {
+		t.Errorf("Envelope.SessionID = %q, want %q", n.Envelope.SessionID, env.SessionID)
+	}
+	if n.Envelope.Agent != env.Agent {
+		t.Errorf("Envelope.Agent = %q, want %q", n.Envelope.Agent, env.Agent)
+	}
+	if n.Envelope.Attempt == nil {
+		t.Fatal("Envelope.Attempt = nil, want non-nil")
+	}
+	if *n.Envelope.Attempt != *env.Attempt {
+		t.Errorf("Envelope.Attempt = %d, want %d", *n.Envelope.Attempt, *env.Attempt)
+	}
+	if n.Envelope.NotificationID == "" {
+		t.Error("Envelope.NotificationID is empty, want generated ID")
+	}
+	if n.Envelope.Timestamp == "" {
+		t.Error("Envelope.Timestamp is empty, want ISO-8601 UTC timestamp")
+	}
+}
+
+func TestExecute_MessageCarriesAgentFields(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockNotifier{}
+	tool := New([]domain.Notifier{mock}, testEnv(), 10)
+
+	executeJSON(t, tool, `{"severity":"critical","title":"Urgent","body":"Stop now","category":"blocked"}`)
+
+	if len(mock.received) != 1 {
+		t.Fatalf("Send called %d times, want 1", len(mock.received))
+	}
+	msg := mock.received[0].Message
+
+	if msg.Severity != "critical" {
+		t.Errorf("Message.Severity = %q, want %q", msg.Severity, "critical")
+	}
+	if msg.Title != "Urgent" {
+		t.Errorf("Message.Title = %q, want %q", msg.Title, "Urgent")
+	}
+	if msg.Body != "Stop now" {
+		t.Errorf("Message.Body = %q, want %q", msg.Body, "Stop now")
+	}
+	if msg.Category != "blocked" {
+		t.Errorf("Message.Category = %q, want %q", msg.Category, "blocked")
+	}
+}
+
+func TestExecute_SuccessResultShape(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockNotifier{}
+	tool := New([]domain.Notifier{mock}, testEnv(), 10)
+
+	m := executeJSON(t, tool, `{"severity":"info","title":"Hi","body":"Body"}`)
+	assertSuccess(t, m)
+
+	if _, ok := m["delivered"]; !ok {
+		t.Error("result missing \"delivered\" field")
+	}
+	if _, ok := m["notification_id"]; !ok {
+		t.Error("result missing \"notification_id\" field")
+	}
+}
+
+// --- Validation error tests ---
+
+func TestExecute_InvalidInput_UnknownField(t *testing.T) {
+	t.Parallel()
+
+	tool := New([]domain.Notifier{&mockNotifier{}}, testEnv(), 10)
+
+	m := executeJSON(t, tool, `{"severity":"info","title":"T","body":"B","unknown_field":"x"}`)
+	assertFailureKind(t, m, "invalid_input")
+}
+
+func TestExecute_InvalidInput_BadSeverity(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		severity string
+	}{
+		{name: "empty severity", severity: ""},
+		{name: "unknown severity", severity: "debug"},
+		{name: "uppercase severity", severity: "INFO"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			tool := New([]domain.Notifier{&mockNotifier{}}, testEnv(), 10)
+			input := fmt.Sprintf(`{"severity":%q,"title":"T","body":"B"}`, tt.severity)
+			m := executeJSON(t, tool, input)
+			assertFailureKind(t, m, "invalid_input")
+		})
+	}
+}
+
+func TestExecute_InvalidInput_BadCategory(t *testing.T) {
+	t.Parallel()
+
+	tool := New([]domain.Notifier{&mockNotifier{}}, testEnv(), 10)
+	m := executeJSON(t, tool, `{"severity":"info","title":"T","body":"B","category":"not_valid"}`)
+	assertFailureKind(t, m, "invalid_input")
+}
+
+func TestExecute_InvalidInput_EmptyTitle(t *testing.T) {
+	t.Parallel()
+
+	tool := New([]domain.Notifier{&mockNotifier{}}, testEnv(), 10)
+	m := executeJSON(t, tool, `{"severity":"info","title":"","body":"B"}`)
+	assertFailureKind(t, m, "invalid_input")
+}
+
+func TestExecute_InvalidInput_EmptyBody(t *testing.T) {
+	t.Parallel()
+
+	tool := New([]domain.Notifier{&mockNotifier{}}, testEnv(), 10)
+	m := executeJSON(t, tool, `{"severity":"info","title":"T","body":""}`)
+	assertFailureKind(t, m, "invalid_input")
+}
+
+func TestExecute_InvalidInput_MalformedJSON(t *testing.T) {
+	t.Parallel()
+
+	tool := New([]domain.Notifier{&mockNotifier{}}, testEnv(), 10)
+	m := executeJSON(t, tool, `{bad json}`)
+	assertFailureKind(t, m, "invalid_input")
+}
+
+func TestExecute_InvalidInput_GoErrorIsNil(t *testing.T) {
+	t.Parallel()
+
+	tool := New([]domain.Notifier{&mockNotifier{}}, testEnv(), 10)
+	// Unknown field triggers invalid_input; the Go error must be nil.
+	_, goErr := tool.Execute(context.Background(), json.RawMessage(`{"severity":"info","title":"T","body":"B","extra":1}`))
+	if goErr != nil {
+		t.Errorf("Execute(invalid input) Go error = %v, want nil", goErr)
+	}
+}
+
+// --- Rate limiting tests ---
+
+func TestExecute_RateLimited_PastCap(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockNotifier{}
+	const cap = 3
+	tool := New([]domain.Notifier{mock}, testEnv(), cap)
+
+	input := `{"severity":"info","title":"T","body":"B"}`
+	for range cap {
+		m := executeJSON(t, tool, input)
+		assertSuccess(t, m)
+	}
+
+	// The (cap+1)-th call must be rate_limited.
+	m := executeJSON(t, tool, input)
+	assertFailureKind(t, m, "rate_limited")
+}
+
+func TestExecute_RateLimited_SendNotCalledWhenCapped(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockNotifier{}
+	tool := New([]domain.Notifier{mock}, testEnv(), 1)
+
+	input := `{"severity":"info","title":"T","body":"B"}`
+	executeJSON(t, tool, input) // consumes the cap
+
+	before := len(mock.received)
+	executeJSON(t, tool, input) // should be rate_limited, Send not called
+	after := len(mock.received)
+
+	if after != before {
+		t.Errorf("mock.Send call count changed from %d to %d after rate_limited; want no additional call", before, after)
+	}
+}
+
+func TestExecute_AcceptedCallIncrementsCounterOnce(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockNotifier{}
+	tool := New([]domain.Notifier{mock}, testEnv(), 10)
+
+	input := `{"severity":"info","title":"T","body":"B"}`
+	executeJSON(t, tool, input)
+	executeJSON(t, tool, input)
+	executeJSON(t, tool, input)
+
+	if mock.received != nil && len(mock.received) != 3 {
+		t.Errorf("Send called %d times, want 3 for 3 accepted calls", len(mock.received))
+	}
+	if tool.count != 3 {
+		t.Errorf("internal counter = %d, want 3", tool.count)
+	}
+}
+
+func TestExecute_RejectedCallDoesNotIncrementCounter(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockNotifier{}
+	tool := New([]domain.Notifier{mock}, testEnv(), 10)
+
+	// Validation failure — counter must not increment.
+	executeJSON(t, tool, `{"severity":"bad","title":"T","body":"B"}`)
+	if tool.count != 0 {
+		t.Errorf("counter = %d after rejected call, want 0", tool.count)
+	}
+}
+
+// --- Send failure tests ---
+
+func TestExecute_SendFailed_ReturnsCorrectKind(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockNotifier{err: errors.New("connection failure")}
+	tool := New([]domain.Notifier{mock}, testEnv(), 10)
+
+	m := executeJSON(t, tool, `{"severity":"info","title":"T","body":"B"}`)
+	assertFailureKind(t, m, "send_failed")
+}
+
+func TestExecute_SendFailed_GoErrorIsNil(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockNotifier{err: errors.New("transport error")}
+	tool := New([]domain.Notifier{mock}, testEnv(), 10)
+
+	_, goErr := tool.Execute(context.Background(), json.RawMessage(`{"severity":"info","title":"T","body":"B"}`))
+	if goErr != nil {
+		t.Errorf("Execute(send failure) Go error = %v, want nil", goErr)
+	}
+}
+
+// classifiedSendError simulates a backend-classified error that carries
+// only a category, never the URL or secret.
+type classifiedSendError struct {
+	Category string
+}
+
+func (e *classifiedSendError) Error() string { return e.Category }
+
+func TestExecute_SendFailed_MessageRedacted(t *testing.T) {
+	t.Parallel()
+
+	// A real backend (webhook/slack) returns a *sendError whose Error()
+	// returns only a category string (e.g. "connection failure"), never
+	// the URL or secret. The tool should propagate that category.
+	const secretURL = "https://secret-endpoint.example.com/tok"
+	mock := &mockNotifier{err: &classifiedSendError{Category: "connection failure"}}
+	tool := New([]domain.Notifier{mock}, testEnv(), 10)
+
+	m := executeJSON(t, tool, `{"severity":"info","title":"T","body":"B"}`)
+	assertFailureKind(t, m, "send_failed")
+
+	errObj, ok := m["error"].(map[string]any)
+	if !ok {
+		t.Fatal("error field missing or wrong type")
+	}
+	msg, _ := errObj["message"].(string)
+	if strings.Contains(msg, secretURL) {
+		t.Errorf("send_failed message contains URL %q: %q", secretURL, msg)
+	}
+	// The message should contain the classified category.
+	if !strings.Contains(msg, "connection failure") {
+		t.Errorf("send_failed message = %q, want to contain %q", msg, "connection failure")
+	}
+}
+
+// --- Valid severity and category acceptance ---
+
+func TestExecute_AllValidSeverities(t *testing.T) {
+	t.Parallel()
+
+	for _, sev := range []string{"info", "warning", "critical"} {
+		t.Run(sev, func(t *testing.T) {
+			t.Parallel()
+
+			mock := &mockNotifier{}
+			tool := New([]domain.Notifier{mock}, testEnv(), 10)
+			input := fmt.Sprintf(`{"severity":%q,"title":"T","body":"B"}`, sev)
+			m := executeJSON(t, tool, input)
+			assertSuccess(t, m)
+		})
+	}
+}
+
+func TestExecute_AllValidCategories(t *testing.T) {
+	t.Parallel()
+
+	for _, cat := range []string{"decision_needed", "progress", "blocked", "completed", "other"} {
+		t.Run(cat, func(t *testing.T) {
+			t.Parallel()
+
+			mock := &mockNotifier{}
+			tool := New([]domain.Notifier{mock}, testEnv(), 10)
+			input := fmt.Sprintf(`{"severity":"info","title":"T","body":"B","category":%q}`, cat)
+			m := executeJSON(t, tool, input)
+			assertSuccess(t, m)
+		})
+	}
+}
+
+func TestExecute_OptionalCategoryAbsent(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockNotifier{}
+	tool := New([]domain.Notifier{mock}, testEnv(), 10)
+	m := executeJSON(t, tool, `{"severity":"info","title":"T","body":"B"}`)
+	assertSuccess(t, m)
+
+	if len(mock.received) != 1 {
+		t.Fatalf("Send called %d times, want 1", len(mock.received))
+	}
+	if mock.received[0].Message.Category != "" {
+		t.Errorf("Message.Category = %q, want empty when category absent", mock.received[0].Message.Category)
+	}
+}
+
+// --- Multi-backend tests ---
+
+func TestExecute_MultipleBackends_AllReceiveNotification(t *testing.T) {
+	t.Parallel()
+
+	mock1 := &mockNotifier{}
+	mock2 := &mockNotifier{}
+	tool := New([]domain.Notifier{mock1, mock2}, testEnv(), 10)
+
+	m := executeJSON(t, tool, `{"severity":"info","title":"T","body":"B"}`)
+	assertSuccess(t, m)
+
+	if len(mock1.received) != 1 {
+		t.Errorf("backend 1 Send called %d times, want 1", len(mock1.received))
+	}
+	if len(mock2.received) != 1 {
+		t.Errorf("backend 2 Send called %d times, want 1", len(mock2.received))
+	}
+	if got := m["delivered"]; got != float64(2) {
+		t.Errorf("delivered = %v, want 2", got)
+	}
+}
+
+func TestExecute_MultipleBackends_FirstErrorShortCircuits(t *testing.T) {
+	t.Parallel()
+
+	mock1 := &mockNotifier{err: errors.New("first backend error")}
+	mock2 := &mockNotifier{}
+	tool := New([]domain.Notifier{mock1, mock2}, testEnv(), 10)
+
+	m := executeJSON(t, tool, `{"severity":"info","title":"T","body":"B"}`)
+	assertFailureKind(t, m, "send_failed")
+
+	if len(mock2.received) != 0 {
+		t.Errorf("backend 2 was called %d times after first backend failed, want 0", len(mock2.received))
+	}
+}
+
+// --- Envelope source field ---
+
+func TestExecute_SourceFromEnvContext(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockNotifier{}
+	env := testEnv()
+	env.Source = "custom-source"
+	tool := New([]domain.Notifier{mock}, env, 10)
+
+	executeJSON(t, tool, `{"severity":"info","title":"T","body":"B"}`)
+
+	if len(mock.received) != 1 {
+		t.Fatalf("Send called %d times, want 1", len(mock.received))
+	}
+	if got := mock.received[0].Envelope.Source; got != "custom-source" {
+		t.Errorf("Envelope.Source = %q, want %q", got, "custom-source")
+	}
+}
+
+func TestExecute_EmptyAgentFieldIsNotError(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockNotifier{}
+	env := testEnv()
+	env.Agent = ""
+	tool := New([]domain.Notifier{mock}, env, 10)
+
+	m := executeJSON(t, tool, `{"severity":"info","title":"T","body":"B"}`)
+	assertSuccess(t, m)
+
+	if len(mock.received) != 1 {
+		t.Fatalf("Send called %d times, want 1", len(mock.received))
+	}
+	if got := mock.received[0].Envelope.Agent; got != "" {
+		t.Errorf("Envelope.Agent = %q, want empty when Agent is unset", got)
+	}
+}


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Feat

**Intent:** Implements the `notify_operator` Tier 2 MCP tool, giving agents a structured way to send real-time notifications to operator-configured channels (Slack or generic webhook) during a session - for escalating decisions, reporting progress on long-running tasks, or flagging blockers - without terminating the session.

**Related Issues:** #242

### 🧭 Reviewer Guide

**Complexity:** High

#### Entry Point

Start with `internal/tool/notify/notify.go`. This is the `AgentTool` implementation: it owns the per-session rate limiter, the system-owned envelope construction, multi-backend dispatch, and the closed-set error kinds (`invalid_input`, `rate_limited`, `send_failed`, `backend_unavailable`). Understanding this file makes the rest of the changes legible.

From there, review:

- `internal/domain/notify.go` - the `Notifier` interface, `Notification` value (envelope + message layers), and the `domain.NotificationMessage` / `domain.NotificationEnvelope` split that keeps the agent from forging envelope fields.
- `internal/config/notifications.go` - parsing and validation for the new `notifications` WORKFLOW.md top-level key, including the `$SORTIE_`-prefix secret rule and rejection of negative `max_per_session`.
- `cmd/sortie/mcpserver.go` (`buildNotifyTool`, `resolveNotificationCap`) - how the sidecar resolves backend constructors from the registry, builds the tool, and picks the per-session cap at startup.
- `internal/notify/slack/` and `internal/notify/webhook/` - the two v1 backend packages, each registering via `init()`, applying a per-call timeout, and classifying transport / non-2xx errors into a redacted category (no URL or payload in error messages).
- `internal/registry/registry.go` - the new `Notifiers` registry and `NotifierConstructor` type, following the same pattern as `SCMAdapters`.
- `internal/orchestrator/mcpconfig.go` - addition of `SORTIE_SESSION_AGENT_KIND` to the MCP env block so the notify envelope can record the dispatch-frozen agent kind.

#### Sensitive Areas

- `cmd/sortie/mcpserver.go`: Invalid backend config surfaces as a fatal sidecar startup error rather than a partial registration. The "all-or-nothing" invariant (enforced in `buildNotifyTool`) means the sidecar and main process always agree on the advertised tool set.
- `internal/tool/notify/notify.go`: Envelope fields (issue id, session id, attempt, agent kind) are injected at construction time from `SORTIE_*` env vars and are not controllable by the agent. Any change here could let an agent forge envelope metadata.
- `internal/notify/slack/slack.go`, `internal/notify/webhook/webhook.go`: Error paths must not echo the endpoint URL, request body, or response body. Both backends classify errors into a redacted category string.
- `internal/config/notifications.go`: The `$SORTIE_`-prefix validation for backend secrets is a security boundary - a missing prefix means the secret is invisible to the sidecar process.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes. The `notifications` key is a new optional WORKFLOW.md section; existing configs without it are unaffected and the tool is simply not registered.
- **Migrations/State:** No database migrations or state changes required.