### PR TITLE
feat: add shared BuildSessionToolRegistry for tool-set parity

### DIFF
--- a/cmd/sortie/main.go
+++ b/cmd/sortie/main.go
@@ -509,6 +509,36 @@ func run(ctx context.Context, args []string, stdout io.Writer, stderr io.Writer)
 		ms.SetMetrics(orchMetrics)
 	}
 
+	// sessionToolFunc builds the per-session tool registry the worker
+	// renders into the first-turn advertisement, so the advertised set
+	// matches the set the MCP sidecar serves over tools/list. It captures
+	// the session-invariant gating inputs and receives the late-bound
+	// inputs (issue id, workspace path, session id) at call time. The
+	// read-only store the builder opens to make the database-backed tools
+	// constructible is closed before the registry is returned: the worker
+	// reads only tool metadata, never executing the tools, so the
+	// connection is not needed beyond construction.
+	sessionToolFunc := func(ctx context.Context, issueID, workspacePath, sessionID string) (*domain.ToolRegistry, error) {
+		sessionTools, err := BuildSessionToolRegistry(ctx, br.logger, SessionToolParams{
+			TrackerAdapter: br.trackerAdapter,
+			Project:        br.cfg.Tracker.Project,
+			DBPath:         dbPath,
+			MaxTokens:      br.cfg.Agent.MaxTokens,
+			MaxSessions:    br.cfg.Agent.MaxSessions,
+			Notifications:  br.cfg.Notifications.Backends,
+			IssueID:        issueID,
+			WorkspacePath:  workspacePath,
+			SessionID:      sessionID,
+		})
+		if err != nil {
+			return nil, err
+		}
+		if sessionTools.Store != nil {
+			sessionTools.Store.Close() //nolint:errcheck,gosec // best-effort close after construction; tools are never executed in this path
+		}
+		return sessionTools.Registry, nil
+	}
+
 	o := orchestrator.NewOrchestrator(orchestrator.OrchestratorParams{
 		State:                       state,
 		Logger:                      br.logger,
@@ -520,6 +550,7 @@ func run(ctx context.Context, args []string, stdout io.Writer, stderr io.Writer)
 		PreflightParams:             br.preflightParams,
 		Metrics:                     orchMetrics,
 		ToolRegistry:                toolRegistry,
+		SessionToolRegistryFunc:     sessionToolFunc,
 		WorkflowFileFunc:            br.mgr.FilePath,
 		DBPath:                      dbPath,
 		CIProvider:                  ciProvider,

--- a/cmd/sortie/mcpserver.go
+++ b/cmd/sortie/mcpserver.go
@@ -20,8 +20,6 @@ import (
 	"github.com/sortie-ai/sortie/internal/tool/history"
 	"github.com/sortie-ai/sortie/internal/tool/mcpserver"
 	"github.com/sortie-ai/sortie/internal/tool/notify"
-	"github.com/sortie-ai/sortie/internal/tool/status"
-	"github.com/sortie-ai/sortie/internal/tool/trackerapi"
 	"github.com/sortie-ai/sortie/internal/workflow"
 )
 
@@ -100,44 +98,31 @@ func runMCPServer(ctx context.Context, args []string, stdout io.Writer, stderr i
 		trackerAdapter = adapter
 	}
 
-	// Build tool registry.
-	toolRegistry := domain.NewToolRegistry()
-	if trackerAdapter != nil && cfg.Tracker.Project != "" {
-		toolRegistry.Register(trackerapi.New(trackerAdapter, cfg.Tracker.Project))
-	}
-	if workspacePath := os.Getenv("SORTIE_WORKSPACE"); workspacePath != "" {
-		toolRegistry.Register(status.New(workspacePath))
-	}
-	if dbPath := os.Getenv("SORTIE_DB_PATH"); dbPath != "" {
-		if issueID := os.Getenv("SORTIE_ISSUE_ID"); issueID != "" {
-			store, storeErr := persistence.OpenReadOnly(ctx, dbPath)
-			if storeErr != nil {
-				logger.Warn("failed to open read-only db for workspace_history",
-					slog.String("db_path", dbPath),
-					slog.Any("error", storeErr))
-			} else {
-				defer store.Close() //nolint:errcheck // best-effort cleanup at shutdown
-				toolRegistry.Register(history.New(buildHistoryQuery(store), issueID))
-				runningSessionID := os.Getenv("SORTIE_SESSION_ID")
-				toolRegistry.Register(budget.New(buildBudgetQuery(store), issueID, runningSessionID, cfg.Agent.MaxTokens, cfg.Agent.MaxSessions))
-			}
-		}
-	}
-
-	// Register notify_operator only when at least one backend is
-	// configured. An invalid backend is a fatal startup error, never a
-	// partial registration, so the sidecar and main process agree on the
-	// advertised tool set.
-	notifyTool, notifyErr := buildNotifyTool(cfg.Notifications.Backends)
-	if notifyErr != nil {
-		logger.Error("failed to configure notify_operator", slog.Any("error", notifyErr))
+	// Build the per-session tool registry through the shared builder so
+	// the served tool set matches the set the worker advertises in the
+	// first-turn prompt. A notifier misconfiguration is fatal here, as
+	// before; a read-only DB-open failure is non-fatal and skips the two
+	// database-backed tools.
+	sessionTools, err := BuildSessionToolRegistry(ctx, logger, SessionToolParams{
+		TrackerAdapter: trackerAdapter,
+		Project:        cfg.Tracker.Project,
+		WorkspacePath:  os.Getenv("SORTIE_WORKSPACE"),
+		DBPath:         os.Getenv("SORTIE_DB_PATH"),
+		IssueID:        os.Getenv("SORTIE_ISSUE_ID"),
+		SessionID:      os.Getenv("SORTIE_SESSION_ID"),
+		MaxTokens:      cfg.Agent.MaxTokens,
+		MaxSessions:    cfg.Agent.MaxSessions,
+		Notifications:  cfg.Notifications.Backends,
+	})
+	if err != nil {
+		logger.Error("failed to build session tool registry", slog.Any("error", err))
 		return 1
 	}
-	if notifyTool != nil {
-		toolRegistry.Register(notifyTool)
+	if sessionTools.Store != nil {
+		defer sessionTools.Store.Close() //nolint:errcheck // best-effort cleanup at shutdown
 	}
 
-	srv := mcpserver.NewServer(toolRegistry, os.Stdin, stdout, logger, Version)
+	srv := mcpserver.NewServer(sessionTools.Registry, os.Stdin, stdout, logger, Version)
 	if err := srv.Serve(ctx); err != nil {
 		logger.Error("MCP server error", slog.Any("error", err))
 		return 1

--- a/cmd/sortie/mcpserver.go
+++ b/cmd/sortie/mcpserver.go
@@ -103,13 +103,22 @@ func runMCPServer(ctx context.Context, args []string, stdout io.Writer, stderr i
 	// first-turn prompt. A notifier misconfiguration is fatal here, as
 	// before; a read-only DB-open failure is non-fatal and skips the two
 	// database-backed tools.
+	var attempt *int
+	if raw := os.Getenv("SORTIE_ATTEMPT"); raw != "" {
+		if n, atoiErr := strconv.Atoi(raw); atoiErr == nil {
+			attempt = &n
+		}
+	}
 	sessionTools, err := BuildSessionToolRegistry(ctx, logger, SessionToolParams{
 		TrackerAdapter: trackerAdapter,
 		Project:        cfg.Tracker.Project,
 		WorkspacePath:  os.Getenv("SORTIE_WORKSPACE"),
 		DBPath:         os.Getenv("SORTIE_DB_PATH"),
 		IssueID:        os.Getenv("SORTIE_ISSUE_ID"),
+		Identifier:     os.Getenv("SORTIE_ISSUE_IDENTIFIER"),
 		SessionID:      os.Getenv("SORTIE_SESSION_ID"),
+		Attempt:        attempt,
+		AgentKind:      os.Getenv("SORTIE_SESSION_AGENT_KIND"),
 		MaxTokens:      cfg.Agent.MaxTokens,
 		MaxSessions:    cfg.Agent.MaxSessions,
 		Notifications:  cfg.Notifications.Backends,
@@ -136,9 +145,10 @@ func runMCPServer(ctx context.Context, args []string, stdout io.Writer, stderr i
 // configured, so the caller skips registration. An unknown kind or a
 // constructor error (including a required secret that resolved to the
 // empty string) is fatal and returned as a non-nil error rather than a
-// partial registration. The envelope context is read from the sidecar
-// environment.
-func buildNotifyTool(configured []config.NotificationBackend) (domain.AgentTool, error) {
+// partial registration. The caller supplies env: the function reads no
+// process environment itself, so the gating decision stays a pure
+// function of explicit inputs.
+func buildNotifyTool(configured []config.NotificationBackend, env notify.NotificationEnvelopeContext) (domain.AgentTool, error) {
 	if len(configured) == 0 {
 		return nil, nil
 	}
@@ -156,21 +166,7 @@ func buildNotifyTool(configured []config.NotificationBackend) (domain.AgentTool,
 		backends = append(backends, notifier)
 	}
 
-	var attempt *int
-	if raw := os.Getenv("SORTIE_ATTEMPT"); raw != "" {
-		if n, err := strconv.Atoi(raw); err == nil {
-			attempt = &n
-		}
-	}
-	envContext := notify.NotificationEnvelopeContext{
-		IssueID:    os.Getenv("SORTIE_ISSUE_ID"),
-		Identifier: os.Getenv("SORTIE_ISSUE_IDENTIFIER"),
-		SessionID:  os.Getenv("SORTIE_SESSION_ID"),
-		Attempt:    attempt,
-		Agent:      os.Getenv("SORTIE_SESSION_AGENT_KIND"),
-	}
-
-	return notify.New(backends, envContext, resolveNotificationCap(configured)), nil
+	return notify.New(backends, env, resolveNotificationCap(configured)), nil
 }
 
 // resolveNotificationCap selects the single per-session cap for the tool

--- a/cmd/sortie/mcpserver_test.go
+++ b/cmd/sortie/mcpserver_test.go
@@ -10,6 +10,8 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"slices"
+	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -562,5 +564,157 @@ func TestResolveNotificationCap_MixedZeroAndNonZero_ReturnsNonZeroMax(t *testing
 	got := resolveNotificationCap(backends)
 	if got != 10 {
 		t.Errorf("resolveNotificationCap({0,10}) = %d, want 10", got)
+	}
+}
+
+// mcpServerWorkflow returns a minimal WORKFLOW.md body suitable for
+// runMCPServer tests. No tracker section is included — only what is
+// required to pass workflow.Load and config.NewServiceConfig without
+// error. The notifications list is injected as an optional YAML block
+// so tests can control whether buildNotifyTool succeeds.
+func mcpServerWorkflow(notificationsYAML string) []byte {
+	base := "---\npolling:\n  interval_ms: 30000\nagent:\n  kind: mock\n"
+	if notificationsYAML != "" {
+		base += notificationsYAML + "\n"
+	}
+	base += "---\nDo something.\n"
+	return []byte(base)
+}
+
+// TestRunMCPServer_SuccessPath exercises the section of runMCPServer
+// starting at line 106: SORTIE_ATTEMPT parsing, env-to-SessionToolParams
+// mapping, BuildSessionToolRegistry call, and the final Serve invocation.
+// Under go test, os.Stdin is /dev/null so Serve returns on EOF and the
+// function exits 0.
+//
+// No t.Parallel: uses t.Setenv which is incompatible with t.Parallel.
+func TestRunMCPServer_SuccessPath_ReturnsZero(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	seedDB(t, dbPath)
+
+	wfPath := filepath.Join(dir, "WORKFLOW.md")
+	if err := os.WriteFile(wfPath, mcpServerWorkflow(""), 0o644); err != nil {
+		t.Fatalf("WriteFile WORKFLOW.md: %v", err)
+	}
+
+	// Wire all optional env vars so the covered block is fully exercised.
+	t.Setenv("SORTIE_ATTEMPT", "2")
+	t.Setenv("SORTIE_WORKSPACE", dir)
+	t.Setenv("SORTIE_DB_PATH", dbPath)
+	t.Setenv("SORTIE_ISSUE_ID", "issue-99")
+	t.Setenv("SORTIE_ISSUE_IDENTIFIER", "PROJ-99")
+	t.Setenv("SORTIE_SESSION_ID", "sess-99")
+	t.Setenv("SORTIE_SESSION_AGENT_KIND", "mock")
+
+	var stdout, stderr bytes.Buffer
+	code := runMCPServer(context.Background(), []string{"--workflow", wfPath}, &stdout, &stderr)
+	if code != 0 {
+		t.Errorf("runMCPServer(success) = %d, want 0; stderr: %s", code, stderr.String())
+	}
+}
+
+// TestRunMCPServer_BuilderError_ReturnsOne verifies that a misconfigured
+// notifier backend in the workflow causes BuildSessionToolRegistry to
+// return an error, which runMCPServer logs and returns 1 for.
+//
+// No t.Parallel: uses t.Setenv which is incompatible with t.Parallel.
+func TestRunMCPServer_BuilderError_ReturnsOne(t *testing.T) {
+	dir := t.TempDir()
+
+	badNotifications := `notifications:
+  - kind: no-such-backend-xyz
+    url: https://example.com`
+	wfPath := filepath.Join(dir, "WORKFLOW.md")
+	if err := os.WriteFile(wfPath, mcpServerWorkflow(badNotifications), 0o644); err != nil {
+		t.Fatalf("WriteFile WORKFLOW.md: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := runMCPServer(context.Background(), []string{"--workflow", wfPath}, &stdout, &stderr)
+	if code != 1 {
+		t.Errorf("runMCPServer(builder error) = %d, want 1; stderr: %s", code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "failed to build session tool registry") {
+		t.Errorf("runMCPServer(builder error) stderr = %q, want to contain %q",
+			stderr.String(), "failed to build session tool registry")
+	}
+}
+
+// TestRunMCPServer_AttemptEnvParsed verifies that a non-integer
+// SORTIE_ATTEMPT is silently ignored (attempt stays nil) rather than
+// causing an error, and runMCPServer still returns 0.
+//
+// No t.Parallel: uses t.Setenv which is incompatible with t.Parallel.
+func TestRunMCPServer_InvalidAttemptIgnored_ReturnsZero(t *testing.T) {
+	dir := t.TempDir()
+
+	wfPath := filepath.Join(dir, "WORKFLOW.md")
+	if err := os.WriteFile(wfPath, mcpServerWorkflow(""), 0o644); err != nil {
+		t.Fatalf("WriteFile WORKFLOW.md: %v", err)
+	}
+
+	t.Setenv("SORTIE_ATTEMPT", "not-a-number")
+
+	var stdout, stderr bytes.Buffer
+	code := runMCPServer(context.Background(), []string{"--workflow", wfPath}, &stdout, &stderr)
+	if code != 0 {
+		t.Errorf("runMCPServer(invalid attempt) = %d, want 0; stderr: %s", code, stderr.String())
+	}
+}
+
+// TestBuildSessionToolRegistry_EnvFree asserts that BuildSessionToolRegistry
+// returns an identical tool-name set whether or not SORTIE_* env vars are
+// set. The PR moved all env reads out of the builder; this test locks that
+// property.
+//
+// No t.Parallel: uses t.Setenv which is incompatible with t.Parallel.
+func TestBuildSessionToolRegistry_EnvFree(t *testing.T) {
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "envfree.db")
+	seedDB(t, dbPath)
+
+	params := SessionToolParams{
+		TrackerAdapter: &stubTrackerAdapter{},
+		Project:        "ENVFREE",
+		WorkspacePath:  tmpDir,
+		DBPath:         dbPath,
+		IssueID:        "issue-envfree",
+		SessionID:      "sess-envfree",
+		MaxTokens:      50000,
+		MaxSessions:    5,
+		Notifications:  []config.NotificationBackend{webhookBackend(t)},
+	}
+
+	// Build without any SORTIE_* vars in scope (they are not set here).
+	result1, err := BuildSessionToolRegistry(context.Background(), slog.New(slog.DiscardHandler), params)
+	if err != nil {
+		t.Fatalf("BuildSessionToolRegistry(no env) error = %v, want nil", err)
+	}
+	t.Cleanup(func() { closeResult(t, result1) })
+	names1 := toolNamesFromResult(result1)
+	sort.Strings(names1)
+
+	// Build again with a full complement of SORTIE_* vars. The result must
+	// be identical because the builder ignores the process environment.
+	t.Setenv("SORTIE_WORKSPACE", tmpDir)
+	t.Setenv("SORTIE_DB_PATH", dbPath)
+	t.Setenv("SORTIE_ISSUE_ID", "env-issue-override")
+	t.Setenv("SORTIE_ISSUE_IDENTIFIER", "ENV-1")
+	t.Setenv("SORTIE_SESSION_ID", "env-session-override")
+	t.Setenv("SORTIE_ATTEMPT", "3")
+	t.Setenv("SORTIE_SESSION_AGENT_KIND", "env-agent")
+
+	result2, err := BuildSessionToolRegistry(context.Background(), slog.New(slog.DiscardHandler), params)
+	if err != nil {
+		t.Fatalf("BuildSessionToolRegistry(with env) error = %v, want nil", err)
+	}
+	t.Cleanup(func() { closeResult(t, result2) })
+	names2 := toolNamesFromResult(result2)
+	sort.Strings(names2)
+
+	if !slices.Equal(names1, names2) {
+		t.Errorf("BuildSessionToolRegistry tool names differ when SORTIE_* env set:\n  no env: %v\n with env: %v",
+			names1, names2)
 	}
 }

--- a/cmd/sortie/mcpserver_test.go
+++ b/cmd/sortie/mcpserver_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/sortie-ai/sortie/internal/domain"
 	"github.com/sortie-ai/sortie/internal/persistence"
 	"github.com/sortie-ai/sortie/internal/tool/mcpserver"
+	"github.com/sortie-ai/sortie/internal/tool/notify"
 	"github.com/sortie-ai/sortie/internal/tool/status"
 )
 
@@ -344,7 +345,7 @@ func TestBuildBudgetQuery(t *testing.T) {
 func TestBuildNotifyTool_EmptyBackends_ReturnsNilNil(t *testing.T) {
 	t.Parallel()
 
-	tool, err := buildNotifyTool(nil)
+	tool, err := buildNotifyTool(nil, notify.NotificationEnvelopeContext{})
 	if err != nil {
 		t.Fatalf("buildNotifyTool(nil) error = %v, want nil", err)
 	}
@@ -356,7 +357,7 @@ func TestBuildNotifyTool_EmptyBackends_ReturnsNilNil(t *testing.T) {
 func TestBuildNotifyTool_EmptySlice_ReturnsNilNil(t *testing.T) {
 	t.Parallel()
 
-	tool, err := buildNotifyTool([]config.NotificationBackend{})
+	tool, err := buildNotifyTool([]config.NotificationBackend{}, notify.NotificationEnvelopeContext{})
 	if err != nil {
 		t.Fatalf("buildNotifyTool(empty) error = %v, want nil", err)
 	}
@@ -382,7 +383,7 @@ func TestBuildNotifyTool_ValidWebhookBackend_ReturnsNonNilTool(t *testing.T) {
 		},
 	}
 
-	tool, err := buildNotifyTool(backends)
+	tool, err := buildNotifyTool(backends, notify.NotificationEnvelopeContext{})
 	if err != nil {
 		t.Fatalf("buildNotifyTool(webhook) error = %v, want nil", err)
 	}
@@ -409,7 +410,7 @@ func TestBuildNotifyTool_ValidSlackBackend_ReturnsNonNilTool(t *testing.T) {
 		},
 	}
 
-	tool, err := buildNotifyTool(backends)
+	tool, err := buildNotifyTool(backends, notify.NotificationEnvelopeContext{})
 	if err != nil {
 		t.Fatalf("buildNotifyTool(slack) error = %v, want nil", err)
 	}
@@ -428,7 +429,7 @@ func TestBuildNotifyTool_UnknownKind_ReturnsError(t *testing.T) {
 		},
 	}
 
-	tool, err := buildNotifyTool(backends)
+	tool, err := buildNotifyTool(backends, notify.NotificationEnvelopeContext{})
 	if err == nil {
 		t.Fatal("buildNotifyTool(unknown kind) error = nil, want non-nil error")
 	}
@@ -465,7 +466,7 @@ func TestBuildNotifyTool_EmptyRequiredSecret_ReturnsError(t *testing.T) {
 				{Kind: tt.kind, Config: tt.config},
 			}
 
-			tool, err := buildNotifyTool(backends)
+			tool, err := buildNotifyTool(backends, notify.NotificationEnvelopeContext{})
 			if err == nil {
 				t.Fatalf("buildNotifyTool(%q, empty secret) error = nil, want fatal constructor error", tt.kind)
 			}
@@ -491,7 +492,7 @@ func TestBuildNotifyTool_PartialFailureIsTotal(t *testing.T) {
 		{Kind: "unknown-kind-for-partial-test", Config: map[string]any{"url": srv.URL}},
 	}
 
-	tool, err := buildNotifyTool(backends)
+	tool, err := buildNotifyTool(backends, notify.NotificationEnvelopeContext{})
 	if err == nil {
 		t.Fatal("buildNotifyTool(partial failure) = nil error, want non-nil (no partial registration)")
 	}

--- a/cmd/sortie/sessiontools.go
+++ b/cmd/sortie/sessiontools.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/sortie-ai/sortie/internal/config"
+	"github.com/sortie-ai/sortie/internal/domain"
+	"github.com/sortie-ai/sortie/internal/persistence"
+	"github.com/sortie-ai/sortie/internal/tool/budget"
+	"github.com/sortie-ai/sortie/internal/tool/history"
+	"github.com/sortie-ai/sortie/internal/tool/status"
+	"github.com/sortie-ai/sortie/internal/tool/trackerapi"
+)
+
+// SessionToolParams holds the per-session inputs that gate tool
+// registration. Both the sidecar startup path and the worker
+// prompt-advertisement path populate this from the same session
+// context so the advertised and served tool sets match.
+type SessionToolParams struct {
+	// TrackerAdapter is the configured tracker adapter, or nil when no
+	// tracker is configured. With Project, gates tracker_api.
+	TrackerAdapter domain.TrackerAdapter
+
+	// Project is the tracker project. Empty disables tracker_api.
+	Project string
+
+	// WorkspacePath gates sortie_status. Empty disables it.
+	WorkspacePath string
+
+	// DBPath is the SQLite database path. With IssueID, gates
+	// workspace_history and cost_budget.
+	DBPath string
+
+	// IssueID is the current issue identifier. With DBPath, gates
+	// workspace_history and cost_budget.
+	IssueID string
+
+	// SessionID is the running-session id used by cost_budget to add the
+	// live session's spend. It gates no tool's registration.
+	SessionID string
+
+	// MaxTokens is the agent.max_tokens ceiling reported by cost_budget.
+	MaxTokens int
+
+	// MaxSessions is the agent.max_sessions ceiling reported by
+	// cost_budget.
+	MaxSessions int
+
+	// Notifications are the configured notifier backends. At least one
+	// backend that resolves to a valid constructed backend gates
+	// notify_operator.
+	Notifications []config.NotificationBackend
+}
+
+// SessionToolRegistry pairs a built tool registry with the read-only
+// store opened to back its database tools. The caller owns Store and
+// must call its Close method when registry consumption is complete.
+// Store is nil when no database-backed tool was registered.
+type SessionToolRegistry struct {
+	// Registry is the gated tool set. Never nil on success; an empty
+	// registry is a valid result when no gate is satisfied.
+	Registry *domain.ToolRegistry
+
+	// Store is the read-only connection backing workspace_history and
+	// cost_budget, or nil when neither was registered. The caller closes
+	// it after consuming Registry.
+	Store *persistence.Store
+}
+
+// BuildSessionToolRegistry returns a registry containing exactly the
+// tools whose gating inputs are satisfied by params. It is the single
+// source of truth for the per-session tool set: the sortie mcp-server
+// subcommand serves the returned registry over tools/list, and the
+// orchestrator worker renders the same registry into the first-turn
+// prompt advertisement.
+//
+// On success the returned [SessionToolRegistry.Store] is non-nil only
+// when a database-backed tool was registered; the caller must close it
+// once registry consumption is complete. A read-only database open
+// failure is non-fatal: the two database-backed tools are skipped and a
+// warning is logged. A notifier construction failure is returned as a
+// non-nil error so the sidecar preserves its fatal-on-misconfiguration
+// behavior. The function does not read process environment variables;
+// callers resolve environment into params.
+func BuildSessionToolRegistry(ctx context.Context, logger *slog.Logger, params SessionToolParams) (SessionToolRegistry, error) {
+	if logger == nil {
+		logger = slog.Default()
+	}
+
+	reg := domain.NewToolRegistry()
+	var store *persistence.Store
+
+	if params.TrackerAdapter != nil && params.Project != "" {
+		reg.Register(trackerapi.New(params.TrackerAdapter, params.Project))
+	}
+
+	if params.WorkspacePath != "" {
+		reg.Register(status.New(params.WorkspacePath))
+	}
+
+	if params.DBPath != "" && params.IssueID != "" {
+		openedStore, err := persistence.OpenReadOnly(ctx, params.DBPath)
+		if err != nil {
+			logger.Warn("failed to open read-only db for workspace_history",
+				slog.String("db_path", params.DBPath),
+				slog.Any("error", err))
+		} else {
+			store = openedStore
+			reg.Register(history.New(buildHistoryQuery(store), params.IssueID))
+			reg.Register(budget.New(buildBudgetQuery(store), params.IssueID, params.SessionID, params.MaxTokens, params.MaxSessions))
+		}
+	}
+
+	notifyTool, err := buildNotifyTool(params.Notifications)
+	if err != nil {
+		if store != nil {
+			store.Close() //nolint:errcheck,gosec // best-effort cleanup on construction failure
+		}
+		return SessionToolRegistry{}, err
+	}
+	if notifyTool != nil {
+		reg.Register(notifyTool)
+	}
+
+	return SessionToolRegistry{Registry: reg, Store: store}, nil
+}

--- a/cmd/sortie/sessiontools.go
+++ b/cmd/sortie/sessiontools.go
@@ -121,7 +121,7 @@ func BuildSessionToolRegistry(ctx context.Context, logger *slog.Logger, params S
 	if params.DBPath != "" && params.IssueID != "" {
 		openedStore, err := persistence.OpenReadOnly(ctx, params.DBPath)
 		if err != nil {
-			logger.Warn("failed to open read-only db for workspace_history",
+			logger.Warn("failed to open read-only db for workspace_history and cost_budget",
 				slog.String("db_path", params.DBPath),
 				slog.Any("error", err))
 		} else {

--- a/cmd/sortie/sessiontools.go
+++ b/cmd/sortie/sessiontools.go
@@ -9,6 +9,7 @@ import (
 	"github.com/sortie-ai/sortie/internal/persistence"
 	"github.com/sortie-ai/sortie/internal/tool/budget"
 	"github.com/sortie-ai/sortie/internal/tool/history"
+	"github.com/sortie-ai/sortie/internal/tool/notify"
 	"github.com/sortie-ai/sortie/internal/tool/status"
 	"github.com/sortie-ai/sortie/internal/tool/trackerapi"
 )
@@ -32,13 +33,29 @@ type SessionToolParams struct {
 	// workspace_history and cost_budget.
 	DBPath string
 
-	// IssueID is the current issue identifier. With DBPath, gates
-	// workspace_history and cost_budget.
+	// IssueID is the tracker-internal issue ID (domain.Issue.ID, not the
+	// human-readable domain.Issue.Identifier). With DBPath, gates
+	// workspace_history and cost_budget, and is the key the two
+	// database-backed tools query by.
 	IssueID string
+
+	// Identifier is the human-readable issue key (domain.Issue.Identifier,
+	// e.g. "ABC-123"). It gates no tool's registration; it feeds the
+	// notify_operator envelope context only.
+	Identifier string
 
 	// SessionID is the running-session id used by cost_budget to add the
 	// live session's spend. It gates no tool's registration.
 	SessionID string
+
+	// Attempt is the retry or continuation attempt number for the
+	// notify_operator envelope context, or nil on the first run. It gates
+	// no tool's registration.
+	Attempt *int
+
+	// AgentKind is the dispatch-frozen agent kind for the notify_operator
+	// envelope context. It gates no tool's registration.
+	AgentKind string
 
 	// MaxTokens is the agent.max_tokens ceiling reported by cost_budget.
 	MaxTokens int
@@ -81,8 +98,10 @@ type SessionToolRegistry struct {
 // failure is non-fatal: the two database-backed tools are skipped and a
 // warning is logged. A notifier construction failure is returned as a
 // non-nil error so the sidecar preserves its fatal-on-misconfiguration
-// behavior. The function does not read process environment variables;
-// callers resolve environment into params.
+// behavior. The function reads no process environment variables; callers
+// resolve environment into params, including the notify_operator
+// envelope fields ([SessionToolParams.Identifier], [SessionToolParams.Attempt],
+// [SessionToolParams.AgentKind]).
 func BuildSessionToolRegistry(ctx context.Context, logger *slog.Logger, params SessionToolParams) (SessionToolRegistry, error) {
 	if logger == nil {
 		logger = slog.Default()
@@ -112,7 +131,13 @@ func BuildSessionToolRegistry(ctx context.Context, logger *slog.Logger, params S
 		}
 	}
 
-	notifyTool, err := buildNotifyTool(params.Notifications)
+	notifyTool, err := buildNotifyTool(params.Notifications, notify.NotificationEnvelopeContext{
+		IssueID:    params.IssueID,
+		Identifier: params.Identifier,
+		SessionID:  params.SessionID,
+		Attempt:    params.Attempt,
+		Agent:      params.AgentKind,
+	})
 	if err != nil {
 		if store != nil {
 			store.Close() //nolint:errcheck,gosec // best-effort cleanup on construction failure

--- a/cmd/sortie/sessiontools_test.go
+++ b/cmd/sortie/sessiontools_test.go
@@ -465,3 +465,61 @@ func TestBuildSessionToolRegistry_EmptyParamsEmptyRegistry(t *testing.T) {
 		t.Errorf("BuildSessionToolRegistry(empty) result.Store non-nil, want nil")
 	}
 }
+
+// TestBuildSessionToolRegistry_StoreOpenedThenNotifierError covers the
+// branch at sessiontools.go:142-144: the read-only store opens successfully
+// (DBPath+IssueID are valid) but buildNotifyTool returns an error due to a
+// misconfigured backend. The builder must close the open store and return
+// the zero-value SessionToolRegistry with a non-nil error so no store
+// connection is leaked.
+func TestBuildSessionToolRegistry_StoreOpenedThenNotifierError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		backend config.NotificationBackend
+	}{
+		{
+			name: "unknown notifier kind with open store",
+			backend: config.NotificationBackend{
+				Kind:   "no-such-backend-xyz",
+				Config: map[string]any{"url": "https://example.com"},
+			},
+		},
+		{
+			name: "webhook empty url with open store",
+			backend: config.NotificationBackend{
+				Kind:   "webhook",
+				Config: map[string]any{"url": ""},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			tmpDir := t.TempDir()
+			dbPath := filepath.Join(tmpDir, "storeopen.db")
+			seedDB(t, dbPath)
+
+			params := SessionToolParams{
+				DBPath:        dbPath,
+				IssueID:       "issue-storeopen",
+				Notifications: []config.NotificationBackend{tt.backend},
+			}
+
+			result, err := BuildSessionToolRegistry(context.Background(), slog.New(slog.DiscardHandler), params)
+			if err == nil {
+				t.Fatalf("BuildSessionToolRegistry(%q) error = nil, want non-nil", tt.name)
+			}
+			if result.Store != nil {
+				_ = result.Store.Close()
+				t.Errorf("BuildSessionToolRegistry(%q) result.Store non-nil on error, want nil (store leaked)", tt.name)
+			}
+			if result.Registry != nil {
+				t.Errorf("BuildSessionToolRegistry(%q) result.Registry non-nil on error, want nil", tt.name)
+			}
+		})
+	}
+}

--- a/cmd/sortie/sessiontools_test.go
+++ b/cmd/sortie/sessiontools_test.go
@@ -1,0 +1,467 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/sortie-ai/sortie/internal/config"
+	"github.com/sortie-ai/sortie/internal/domain"
+	"github.com/sortie-ai/sortie/internal/persistence"
+	"github.com/sortie-ai/sortie/internal/tool/mcpserver"
+)
+
+// --- Test helpers ---
+
+// webhookBackend returns a NotificationBackend pointing at a live httptest
+// server. The server is closed via t.Cleanup.
+func webhookBackend(t *testing.T) config.NotificationBackend {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+	return config.NotificationBackend{
+		Kind:   "webhook",
+		Config: map[string]any{"url": srv.URL},
+	}
+}
+
+// seedDB creates a minimal SQLite database at dbPath with the schema migrated.
+func seedDB(t *testing.T, dbPath string) {
+	t.Helper()
+	ctx := context.Background()
+	rw, err := persistence.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("seedDB: Open(%q): %v", dbPath, err)
+	}
+	if err := rw.Migrate(ctx); err != nil {
+		t.Fatalf("seedDB: Migrate: %v", err)
+	}
+	if err := rw.Close(); err != nil {
+		t.Fatalf("seedDB: Close: %v", err)
+	}
+}
+
+// closeResult closes result.Store if non-nil. Call via t.Cleanup.
+func closeResult(t *testing.T, result SessionToolRegistry) {
+	t.Helper()
+	if result.Store != nil {
+		if err := result.Store.Close(); err != nil {
+			t.Errorf("SessionToolRegistry.Store.Close: %v", err)
+		}
+	}
+}
+
+// toolNamesFromResult returns the tool names from the registry inside result.
+func toolNamesFromResult(result SessionToolRegistry) []string {
+	names := make([]string, 0, result.Registry.Len())
+	for _, tool := range result.Registry.List() {
+		names = append(names, tool.Name())
+	}
+	return names
+}
+
+// toolNamesFromMCPServer sends tools/list to an mcpserver.Server built from
+// result.Registry and returns the reported tool names.
+func toolNamesFromMCPServer(t *testing.T, result SessionToolRegistry) []string {
+	t.Helper()
+	req := buildMCPRequest(t, "tools/list", 1, nil)
+	logger := slog.New(slog.DiscardHandler)
+	var outBuf bytes.Buffer
+	srv := mcpserver.NewServer(result.Registry, strings.NewReader(req), &outBuf, logger, "test")
+	if err := srv.Serve(context.Background()); err != nil {
+		t.Fatalf("toolNamesFromMCPServer: Serve: %v", err)
+	}
+	resps := parseMCPResponses(t, outBuf.Bytes())
+	if len(resps) == 0 {
+		t.Fatal("toolNamesFromMCPServer: no response from MCP server")
+	}
+	if resps[0]["error"] != nil {
+		t.Fatalf("toolNamesFromMCPServer: JSON-RPC error: %v", resps[0]["error"])
+	}
+	rmap, ok := resps[0]["result"].(map[string]any)
+	if !ok {
+		t.Fatalf("toolNamesFromMCPServer: result is not an object: %v", resps[0]["result"])
+	}
+	tools, _ := rmap["tools"].([]any)
+	names := make([]string, 0, len(tools))
+	for _, tool := range tools {
+		if m, ok := tool.(map[string]any); ok {
+			if name, ok := m["name"].(string); ok {
+				names = append(names, name)
+			}
+		}
+	}
+	return names
+}
+
+// testLogger returns a slog.Logger that captures output at Debug level into buf.
+func testLogger(buf *bytes.Buffer) *slog.Logger {
+	return slog.New(slog.NewTextHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+}
+
+// assertContainsAll fails if any element of want is absent from got.
+func assertContainsAll(t *testing.T, label string, got, want []string) {
+	t.Helper()
+	for _, w := range want {
+		found := false
+		for _, g := range got {
+			if g == w {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("%s: missing %q; got %v", label, w, got)
+		}
+	}
+}
+
+// assertContainsNone fails if any element of absent is present in got.
+func assertContainsNone(t *testing.T, label string, got, absent []string) {
+	t.Helper()
+	for _, a := range absent {
+		for _, g := range got {
+			if g == a {
+				t.Errorf("%s: unexpected tool %q present; got %v", label, a, got)
+				break
+			}
+		}
+	}
+}
+
+// stubTrackerAdapter satisfies domain.TrackerAdapter for tests that only
+// require tracker_api registration without exercising any adapter methods.
+type stubTrackerAdapter struct{}
+
+var _ domain.TrackerAdapter = (*stubTrackerAdapter)(nil)
+
+func (s *stubTrackerAdapter) FetchCandidateIssues(_ context.Context) ([]domain.Issue, error) {
+	return nil, nil
+}
+func (s *stubTrackerAdapter) FetchIssueByID(_ context.Context, _ string) (domain.Issue, error) {
+	return domain.Issue{}, nil
+}
+func (s *stubTrackerAdapter) FetchIssuesByStates(_ context.Context, _ []string) ([]domain.Issue, error) {
+	return nil, nil
+}
+func (s *stubTrackerAdapter) FetchIssueStatesByIDs(_ context.Context, _ []string) (map[string]string, error) {
+	return nil, nil
+}
+func (s *stubTrackerAdapter) FetchIssueStatesByIdentifiers(_ context.Context, _ []string) (map[string]string, error) {
+	return nil, nil
+}
+func (s *stubTrackerAdapter) FetchIssueComments(_ context.Context, _ string) ([]domain.Comment, error) {
+	return nil, nil
+}
+func (s *stubTrackerAdapter) TransitionIssue(_ context.Context, _ string, _ string) error { return nil }
+func (s *stubTrackerAdapter) CommentIssue(_ context.Context, _ string, _ string) error    { return nil }
+func (s *stubTrackerAdapter) AddLabel(_ context.Context, _ string, _ string) error        { return nil }
+
+// --- Tests ---
+
+// TestBuildSessionToolRegistry_AllToolsPresent verifies AC-3 served-side parity:
+// all five expected tools appear in the built registry and in the names served
+// over tools/list for an equivalent session.
+func TestBuildSessionToolRegistry_AllToolsPresent(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "test.db")
+	seedDB(t, dbPath)
+
+	params := SessionToolParams{
+		TrackerAdapter: &stubTrackerAdapter{},
+		Project:        "TESTPROJ",
+		WorkspacePath:  tmpDir,
+		DBPath:         dbPath,
+		IssueID:        "issue-1",
+		SessionID:      "sess-1",
+		MaxTokens:      100000,
+		MaxSessions:    10,
+		Notifications:  []config.NotificationBackend{webhookBackend(t)},
+	}
+
+	result, err := BuildSessionToolRegistry(context.Background(), slog.New(slog.DiscardHandler), params)
+	if err != nil {
+		t.Fatalf("BuildSessionToolRegistry(full) error = %v, want nil", err)
+	}
+	t.Cleanup(func() { closeResult(t, result) })
+
+	want := []string{"tracker_api", "sortie_status", "workspace_history", "cost_budget", "notify_operator"}
+
+	registryNames := toolNamesFromResult(result)
+	assertContainsAll(t, "registry", registryNames, want)
+
+	// AC-3 cross-channel parity: tools/list must match the registry.
+	mcpNames := toolNamesFromMCPServer(t, result)
+	if len(mcpNames) != len(registryNames) {
+		t.Errorf("tools/list len = %d, registry.Len() = %d; want equal", len(mcpNames), len(registryNames))
+	}
+	assertContainsAll(t, "tools/list", mcpNames, want)
+}
+
+// TestBuildSessionToolRegistry_GatingPreserved verifies AC-2: unset gates
+// remove the corresponding tools from the built registry.
+func TestBuildSessionToolRegistry_GatingPreserved(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "gate.db")
+	seedDB(t, dbPath)
+
+	tests := []struct {
+		name        string
+		params      SessionToolParams
+		wantAbsent  []string
+		wantPresent []string
+	}{
+		{
+			name: "no project disables tracker_api",
+			params: SessionToolParams{
+				TrackerAdapter: &stubTrackerAdapter{},
+				Project:        "",
+				WorkspacePath:  tmpDir,
+			},
+			wantAbsent:  []string{"tracker_api"},
+			wantPresent: []string{"sortie_status"},
+		},
+		{
+			name: "nil tracker adapter disables tracker_api",
+			params: SessionToolParams{
+				TrackerAdapter: nil,
+				Project:        "PROJ",
+				WorkspacePath:  tmpDir,
+			},
+			wantAbsent:  []string{"tracker_api"},
+			wantPresent: []string{"sortie_status"},
+		},
+		{
+			name: "no notifications disables notify_operator",
+			params: SessionToolParams{
+				TrackerAdapter: &stubTrackerAdapter{},
+				Project:        "PROJ",
+				WorkspacePath:  tmpDir,
+				Notifications:  nil,
+			},
+			wantAbsent:  []string{"notify_operator"},
+			wantPresent: []string{"tracker_api", "sortie_status"},
+		},
+		{
+			name: "empty workspace path disables sortie_status",
+			params: SessionToolParams{
+				TrackerAdapter: &stubTrackerAdapter{},
+				Project:        "PROJ",
+				WorkspacePath:  "",
+			},
+			wantAbsent:  []string{"sortie_status"},
+			wantPresent: []string{"tracker_api"},
+		},
+		{
+			name: "missing dbpath disables db tools",
+			params: SessionToolParams{
+				TrackerAdapter: &stubTrackerAdapter{},
+				Project:        "PROJ",
+				WorkspacePath:  tmpDir,
+				DBPath:         "",
+				IssueID:        "issue-1",
+			},
+			wantAbsent:  []string{"workspace_history", "cost_budget"},
+			wantPresent: []string{"tracker_api", "sortie_status"},
+		},
+		{
+			name: "missing issue id disables db tools",
+			params: SessionToolParams{
+				TrackerAdapter: &stubTrackerAdapter{},
+				Project:        "PROJ",
+				WorkspacePath:  tmpDir,
+				DBPath:         dbPath,
+				IssueID:        "",
+			},
+			wantAbsent:  []string{"workspace_history", "cost_budget"},
+			wantPresent: []string{"tracker_api", "sortie_status"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			result, err := BuildSessionToolRegistry(context.Background(), slog.New(slog.DiscardHandler), tt.params)
+			if err != nil {
+				t.Fatalf("BuildSessionToolRegistry(%q) error = %v, want nil", tt.name, err)
+			}
+			t.Cleanup(func() { closeResult(t, result) })
+
+			names := toolNamesFromResult(result)
+			assertContainsNone(t, tt.name, names, tt.wantAbsent)
+			assertContainsAll(t, tt.name, names, tt.wantPresent)
+		})
+	}
+}
+
+// TestBuildSessionToolRegistry_MisconfiguredNotifier verifies AC-6: a
+// misconfigured notifier backend (E-1) causes BuildSessionToolRegistry to
+// return a non-nil error and no store is leaked.
+func TestBuildSessionToolRegistry_MisconfiguredNotifier(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		backend config.NotificationBackend
+	}{
+		{
+			name: "unknown notifier kind",
+			backend: config.NotificationBackend{
+				Kind:   "no-such-backend-xyz",
+				Config: map[string]any{"url": "https://example.com"},
+			},
+		},
+		{
+			name: "webhook empty url",
+			backend: config.NotificationBackend{
+				Kind:   "webhook",
+				Config: map[string]any{"url": ""},
+			},
+		},
+		{
+			name: "slack empty webhook_url",
+			backend: config.NotificationBackend{
+				Kind:   "slack",
+				Config: map[string]any{"webhook_url": ""},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			params := SessionToolParams{
+				Notifications: []config.NotificationBackend{tt.backend},
+			}
+
+			result, err := BuildSessionToolRegistry(context.Background(), slog.New(slog.DiscardHandler), params)
+			if err == nil {
+				t.Fatalf("BuildSessionToolRegistry(%q) error = nil, want non-nil", tt.name)
+			}
+			// Confirm no store connection is leaked on construction failure.
+			if result.Store != nil {
+				_ = result.Store.Close()
+				t.Errorf("BuildSessionToolRegistry(%q) result.Store non-nil on error, want nil", tt.name)
+			}
+		})
+	}
+}
+
+// TestBuildSessionToolRegistry_DBOpenDegradation verifies AC-7: a read-only
+// open failure (E-2) produces a degraded success — workspace_history and
+// cost_budget absent, result.Store nil, and the E-2 warning logged.
+func TestBuildSessionToolRegistry_DBOpenDegradation(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+
+	// Create a file that is not a valid SQLite database so OpenReadOnly fails.
+	garbagePath := filepath.Join(tmpDir, "garbage.db")
+	if err := os.WriteFile(garbagePath, []byte("this is not a valid sqlite database\x00\x01\x02"), 0o600); err != nil {
+		t.Fatalf("write garbage db: %v", err)
+	}
+
+	tests := []struct {
+		name    string
+		dbPath  string
+		issueID string
+	}{
+		{
+			name:    "nonexistent database file",
+			dbPath:  filepath.Join(tmpDir, "nonexistent", "no.db"),
+			issueID: "issue-1",
+		},
+		{
+			name:    "garbage database file",
+			dbPath:  garbagePath,
+			issueID: "issue-1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var logBuf bytes.Buffer
+			logger := testLogger(&logBuf)
+
+			params := SessionToolParams{
+				DBPath:  tt.dbPath,
+				IssueID: tt.issueID,
+			}
+
+			result, err := BuildSessionToolRegistry(context.Background(), logger, params)
+			if err != nil {
+				t.Fatalf("BuildSessionToolRegistry(%q) error = %v, want nil (degraded success)", tt.name, err)
+			}
+
+			// AC-7: no DB connection leaked.
+			if result.Store != nil {
+				_ = result.Store.Close()
+				t.Errorf("BuildSessionToolRegistry(%q) result.Store non-nil, want nil", tt.name)
+			}
+
+			// AC-7: DB-backed tools absent after open failure.
+			names := toolNamesFromResult(result)
+			assertContainsNone(t, tt.name, names, []string{"workspace_history", "cost_budget"})
+
+			// E-2 warning must have been emitted on the supplied logger.
+			if !strings.Contains(logBuf.String(), "failed to open read-only db") {
+				t.Errorf("BuildSessionToolRegistry(%q) E-2 warning not logged; got:\n%s", tt.name, logBuf.String())
+			}
+		})
+	}
+}
+
+// TestBuildSessionToolRegistry_NilLoggerDoesNotPanic confirms that passing a
+// nil logger is safe and falls back to slog.Default().
+func TestBuildSessionToolRegistry_NilLoggerDoesNotPanic(t *testing.T) {
+	t.Parallel()
+
+	result, err := BuildSessionToolRegistry(context.Background(), nil, SessionToolParams{})
+	if err != nil {
+		t.Fatalf("BuildSessionToolRegistry(nil logger) error = %v, want nil", err)
+	}
+	if result.Registry == nil {
+		t.Error("BuildSessionToolRegistry(nil logger) result.Registry = nil, want non-nil")
+	}
+	if result.Store != nil {
+		_ = result.Store.Close()
+	}
+}
+
+// TestBuildSessionToolRegistry_EmptyParamsEmptyRegistry confirms that empty
+// SessionToolParams produces an empty but non-nil registry with no error and
+// no store.
+func TestBuildSessionToolRegistry_EmptyParamsEmptyRegistry(t *testing.T) {
+	t.Parallel()
+
+	result, err := BuildSessionToolRegistry(context.Background(), slog.New(slog.DiscardHandler), SessionToolParams{})
+	if err != nil {
+		t.Fatalf("BuildSessionToolRegistry(empty) error = %v, want nil", err)
+	}
+	if result.Registry == nil {
+		t.Fatal("BuildSessionToolRegistry(empty) result.Registry = nil, want non-nil")
+	}
+	if result.Registry.Len() != 0 {
+		t.Errorf("BuildSessionToolRegistry(empty) registry.Len() = %d, want 0", result.Registry.Len())
+	}
+	if result.Store != nil {
+		_ = result.Store.Close()
+		t.Errorf("BuildSessionToolRegistry(empty) result.Store non-nil, want nil")
+	}
+}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -83,6 +83,12 @@ type OrchestratorParams struct {
 	ToolRegistry    *domain.ToolRegistry // may be nil
 	HostPool        *HostPool            // may be nil; defaults to local-mode pool
 
+	// SessionToolRegistryFunc builds the per-session tool registry for
+	// the first-turn advertisement so it matches the set the MCP sidecar
+	// serves. Threaded into WorkerDeps. May be nil, in which case the
+	// worker advertises from ToolRegistry instead.
+	SessionToolRegistryFunc SessionToolRegistryFunc
+
 	// WorkflowFileFunc returns the base filename of the active workflow
 	// file (e.g. "WORKFLOW.md"). Used for observability: recorded on
 	// RunningEntry and persisted in run_history. If nil, defaults to
@@ -153,6 +159,7 @@ type Orchestrator struct {
 	observers                   []Observer
 	drainTimeout                time.Duration
 	toolRegistry                *domain.ToolRegistry
+	sessionToolRegistryFunc     SessionToolRegistryFunc
 	preflightOK                 atomic.Bool
 	draining                    atomic.Bool
 	hostPool                    *HostPool
@@ -258,6 +265,7 @@ func NewOrchestrator(params OrchestratorParams) *Orchestrator {
 		observers:                   observers,
 		drainTimeout:                defaultDrainTimeout,
 		toolRegistry:                params.ToolRegistry,
+		sessionToolRegistryFunc:     params.SessionToolRegistryFunc,
 		hostPool:                    hostPool,
 		workflowFileFunc:            params.WorkflowFileFunc,
 		dbPath:                      params.DBPath,
@@ -637,6 +645,7 @@ func (o *Orchestrator) makeWorkerFn(resumeSessionID, sshHost, agentKind, templat
 			ResumeSessionID:          resumeSessionID,
 			Logger:                   logger,
 			ToolRegistry:             o.toolRegistry,
+			SessionToolRegistryFunc:  o.sessionToolRegistryFunc,
 			SSHHost:                  sshHost,
 			SSHStrictHostKeyChecking: strictHostKeyChecking,
 			Metrics:                  o.metrics,

--- a/internal/orchestrator/worker.go
+++ b/internal/orchestrator/worker.go
@@ -149,6 +149,16 @@ type WorkerResult struct {
 	StartedAt time.Time
 }
 
+// SessionToolRegistryFunc builds the per-session tool registry rendered
+// into the first-turn advertisement. issueID, workspacePath, and
+// sessionID are the gating inputs the worker resolves late: issueID per
+// dispatch, workspacePath after workspace preparation, and sessionID
+// after the agent session starts. The wiring layer has already captured
+// every session-invariant gating input. A nil value means no builder
+// was injected, in which case the worker falls back to the static
+// [WorkerDeps.ToolRegistry].
+type SessionToolRegistryFunc func(ctx context.Context, issueID, workspacePath, sessionID string) (*domain.ToolRegistry, error)
+
 // WorkerDeps holds the collaborators injected into the worker attempt
 // function. The orchestrator constructs this once and shares it
 // across all workers. All fields are required unless documented as
@@ -201,6 +211,14 @@ type WorkerDeps struct {
 	// ToolRegistry holds the tools available to agent sessions. May
 	// be nil when no tools are registered. Read-only after construction.
 	ToolRegistry *domain.ToolRegistry
+
+	// SessionToolRegistryFunc builds the per-session tool registry for
+	// the first-turn advertisement, so the advertised tool set matches
+	// the set the MCP sidecar serves for the same session. When non-nil,
+	// the first-turn advertisement renders from the registry it returns
+	// instead of from ToolRegistry. When nil, the worker falls back to
+	// ToolRegistry. Optional.
+	SessionToolRegistryFunc SessionToolRegistryFunc
 
 	// Logger is the structured logger with issue-scoped context fields
 	// already attached (issue_id, issue_identifier).
@@ -702,7 +720,14 @@ func RunWorkerAttempt(ctx context.Context, issue domain.Issue, attempt *int, dep
 		}
 
 		if turnNumber == 1 {
-			if deps.ToolRegistry != nil && deps.ToolRegistry.Len() > 0 {
+			if deps.SessionToolRegistryFunc != nil {
+				sessionReg, err := deps.SessionToolRegistryFunc(ctx, issue.ID, wsResult.Path, session.ID)
+				if err != nil {
+					logger.Warn("failed to build session tool advertisement", slog.Any("error", err))
+				} else if sessionReg != nil && sessionReg.Len() > 0 {
+					rendered += "\n\n" + buildToolAdvertisement(sessionReg, cfg.Tracker.Project)
+				}
+			} else if deps.ToolRegistry != nil && deps.ToolRegistry.Len() > 0 {
 				rendered += "\n\n" + buildToolAdvertisement(deps.ToolRegistry, cfg.Tracker.Project)
 			}
 			rendered += "\n\n" + prompt.RuntimeStatusSuffix

--- a/internal/orchestrator/worker_test.go
+++ b/internal/orchestrator/worker_test.go
@@ -3213,3 +3213,327 @@ func TestRunWorkerAttempt_PromptTemplateByIDFunc_NilTemplateExitsWithError(t *te
 		t.Error("WorkerResult.Error = nil, want non-nil error for nil template")
 	}
 }
+
+// TestRunWorkerAttempt_SessionToolRegistryFunc covers the injected
+// SessionToolRegistryFunc seam: AC-1 (all five tool headings in the first-turn
+// advertisement), AC-3 (advertised side extracted from the rendered string),
+// AC-5 (suffix ordering and continuation-turn omission preserved), and E-3
+// (builder error degrades without failing the attempt).
+func TestRunWorkerAttempt_SessionToolRegistryFunc(t *testing.T) {
+	t.Parallel()
+
+	// fakeAllToolsRegistry builds a registry containing all five expected
+	// per-session tools as stub entries. This satisfies AC-1 / AC-3.
+	fakeAllToolsRegistry := func() *domain.ToolRegistry {
+		reg := domain.NewToolRegistry()
+		for _, name := range []string{
+			"tracker_api",
+			"sortie_status",
+			"workspace_history",
+			"cost_budget",
+			"notify_operator",
+		} {
+			reg.Register(&stubAgentTool{toolName: name, desc: "stub description for " + name})
+		}
+		return reg
+	}
+
+	t.Run("injected_builder_all_five_tools_advertised", func(t *testing.T) {
+		// AC-1: the first-turn prompt contains a ### heading for each of the
+		// five per-session tools when the injected builder returns all five.
+		// AC-3 advertised side: names are extracted from the rendered string,
+		// not from registry.List(), so a buildToolAdvertisement regression
+		// would be caught here.
+		t.Parallel()
+
+		tmpDir := t.TempDir()
+		cfg := defaultWorkerConfig(tmpDir)
+		cfg.Agent.MaxTurns = 1
+		cfg.Tracker.Project = "TESTPROJ"
+
+		ec := newExitCapture()
+		var capturedPrompt string
+		var mu sync.Mutex
+
+		deps := WorkerDeps{
+			TrackerAdapter: &mockTrackerAdapter{},
+			AgentAdapter: &mockAgentAdapter{
+				runTurnFn: func(_ context.Context, session domain.Session, params domain.RunTurnParams) (domain.TurnResult, error) {
+					mu.Lock()
+					capturedPrompt = params.Prompt
+					mu.Unlock()
+					return domain.TurnResult{SessionID: session.ID, ExitReason: domain.EventTurnCompleted}, nil
+				},
+			},
+			ConfigFunc:             func() config.ServiceConfig { return cfg },
+			PromptTemplateByIDFunc: func(_ string) *prompt.Template { return mustParseTemplate(t, "work on {{ .issue.title }}") },
+			OnEvent:                func(_ string, _ domain.AgentEvent) {},
+			OnExit:                 ec.onExit,
+			Logger:                 discardLogger(),
+			SessionToolRegistryFunc: func(_ context.Context, _, _, _ string) (*domain.ToolRegistry, error) {
+				return fakeAllToolsRegistry(), nil
+			},
+		}
+
+		RunWorkerAttempt(context.Background(), workerTestIssue(), nil, deps)
+
+		result := ec.waitResult(t)
+		if result.ExitKind != WorkerExitNormal {
+			t.Fatalf("ExitKind = %q, want %q", result.ExitKind, WorkerExitNormal)
+		}
+
+		mu.Lock()
+		p := capturedPrompt
+		mu.Unlock()
+
+		wantHeadings := []string{
+			"### tracker_api",
+			"### sortie_status",
+			"### workspace_history",
+			"### cost_budget",
+			"### notify_operator",
+		}
+		for _, heading := range wantHeadings {
+			if !strings.Contains(p, heading) {
+				t.Errorf("first-turn prompt missing heading %q:\n%s", heading, p)
+			}
+		}
+
+		// Confirm the advertisement section header is present (AC-3 rendered
+		// string check).
+		if !strings.Contains(p, "## Available Sortie tools") {
+			t.Errorf("first-turn prompt missing advertisement header:\n%s", p)
+		}
+	})
+
+	t.Run("injected_builder_suffix_after_advertisement", func(t *testing.T) {
+		// AC-5: RuntimeStatusSuffix appears after the tool advertisement when
+		// SessionToolRegistryFunc is injected, preserving suffix ordering.
+		t.Parallel()
+
+		tmpDir := t.TempDir()
+		cfg := defaultWorkerConfig(tmpDir)
+		cfg.Agent.MaxTurns = 1
+		cfg.Tracker.Project = "TESTPROJ"
+
+		ec := newExitCapture()
+		var capturedPrompt string
+		var mu sync.Mutex
+
+		deps := WorkerDeps{
+			TrackerAdapter: &mockTrackerAdapter{},
+			AgentAdapter: &mockAgentAdapter{
+				runTurnFn: func(_ context.Context, session domain.Session, params domain.RunTurnParams) (domain.TurnResult, error) {
+					mu.Lock()
+					capturedPrompt = params.Prompt
+					mu.Unlock()
+					return domain.TurnResult{SessionID: session.ID, ExitReason: domain.EventTurnCompleted}, nil
+				},
+			},
+			ConfigFunc:             func() config.ServiceConfig { return cfg },
+			PromptTemplateByIDFunc: func(_ string) *prompt.Template { return mustParseTemplate(t, "work on {{ .issue.title }}") },
+			OnEvent:                func(_ string, _ domain.AgentEvent) {},
+			OnExit:                 ec.onExit,
+			Logger:                 discardLogger(),
+			SessionToolRegistryFunc: func(_ context.Context, _, _, _ string) (*domain.ToolRegistry, error) {
+				return fakeAllToolsRegistry(), nil
+			},
+		}
+
+		RunWorkerAttempt(context.Background(), workerTestIssue(), nil, deps)
+		ec.waitResult(t)
+
+		mu.Lock()
+		p := capturedPrompt
+		mu.Unlock()
+
+		advIdx := strings.Index(p, "## Available Sortie tools")
+		if advIdx < 0 {
+			t.Fatalf("first-turn prompt missing tool advertisement header:\n%s", p)
+		}
+		suffixIdx := strings.Index(p, prompt.RuntimeStatusSuffix)
+		if suffixIdx < 0 {
+			t.Fatalf("first-turn prompt missing RuntimeStatusSuffix:\n%s", p)
+		}
+		if suffixIdx <= advIdx {
+			t.Errorf("RuntimeStatusSuffix (idx=%d) must appear after advertisement (idx=%d)", suffixIdx, advIdx)
+		}
+	})
+
+	t.Run("injected_builder_no_advertisement_on_continuation_turns", func(t *testing.T) {
+		// AC-5: continuation turns still omit the advertisement when
+		// SessionToolRegistryFunc is injected.
+		t.Parallel()
+
+		tmpDir := t.TempDir()
+		cfg := defaultWorkerConfig(tmpDir)
+		cfg.Agent.MaxTurns = 3
+		cfg.Tracker.Project = "TESTPROJ"
+
+		ec := newExitCapture()
+		var capturedPrompts []string
+		var mu sync.Mutex
+
+		deps := WorkerDeps{
+			TrackerAdapter: &mockTrackerAdapter{},
+			AgentAdapter: &mockAgentAdapter{
+				runTurnFn: func(_ context.Context, session domain.Session, params domain.RunTurnParams) (domain.TurnResult, error) {
+					mu.Lock()
+					capturedPrompts = append(capturedPrompts, params.Prompt)
+					mu.Unlock()
+					return domain.TurnResult{SessionID: session.ID, ExitReason: domain.EventTurnCompleted}, nil
+				},
+			},
+			ConfigFunc:             func() config.ServiceConfig { return cfg },
+			PromptTemplateByIDFunc: func(_ string) *prompt.Template { return mustParseTemplate(t, "turn={{ .run.turn_number }}") },
+			OnEvent:                func(_ string, _ domain.AgentEvent) {},
+			OnExit:                 ec.onExit,
+			Logger:                 discardLogger(),
+			SessionToolRegistryFunc: func(_ context.Context, _, _, _ string) (*domain.ToolRegistry, error) {
+				return fakeAllToolsRegistry(), nil
+			},
+		}
+
+		RunWorkerAttempt(context.Background(), workerTestIssue(), nil, deps)
+
+		result := ec.waitResult(t)
+		if result.TurnsCompleted != 3 {
+			t.Fatalf("TurnsCompleted = %d, want 3", result.TurnsCompleted)
+		}
+
+		mu.Lock()
+		prompts := make([]string, len(capturedPrompts))
+		copy(prompts, capturedPrompts)
+		mu.Unlock()
+
+		if len(prompts) != 3 {
+			t.Fatalf("captured %d prompts, want 3", len(prompts))
+		}
+
+		// Turn 1 must have the advertisement.
+		if !strings.Contains(prompts[0], "## Available Sortie tools") {
+			t.Errorf("turn 1 prompt missing tool advertisement:\n%s", prompts[0])
+		}
+
+		// Turns 2 and 3 must NOT have the advertisement.
+		for i := 1; i < len(prompts); i++ {
+			if strings.Contains(prompts[i], "## Available Sortie tools") {
+				t.Errorf("turn %d prompt must not contain tool advertisement:\n%s", i+1, prompts[i])
+			}
+		}
+	})
+
+	t.Run("injected_builder_error_degrades_no_advertisement", func(t *testing.T) {
+		// E-3 degrade path: when SessionToolRegistryFunc returns an error the
+		// worker logs a Warn and renders no advertisement section, still appends
+		// RuntimeStatusSuffix, and does not fail the attempt.
+		t.Parallel()
+
+		tmpDir := t.TempDir()
+		cfg := defaultWorkerConfig(tmpDir)
+		cfg.Agent.MaxTurns = 1
+
+		ec := newExitCapture()
+		var capturedPrompt string
+		var mu sync.Mutex
+
+		var logBuf bytes.Buffer
+		logger := slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+		deps := WorkerDeps{
+			TrackerAdapter: &mockTrackerAdapter{},
+			AgentAdapter: &mockAgentAdapter{
+				runTurnFn: func(_ context.Context, session domain.Session, params domain.RunTurnParams) (domain.TurnResult, error) {
+					mu.Lock()
+					capturedPrompt = params.Prompt
+					mu.Unlock()
+					return domain.TurnResult{SessionID: session.ID, ExitReason: domain.EventTurnCompleted}, nil
+				},
+			},
+			ConfigFunc:             func() config.ServiceConfig { return cfg },
+			PromptTemplateByIDFunc: func(_ string) *prompt.Template { return mustParseTemplate(t, "work on {{ .issue.title }}") },
+			OnEvent:                func(_ string, _ domain.AgentEvent) {},
+			OnExit:                 ec.onExit,
+			Logger:                 logger,
+			SessionToolRegistryFunc: func(_ context.Context, _, _, _ string) (*domain.ToolRegistry, error) {
+				return nil, errors.New("simulated builder failure")
+			},
+		}
+
+		RunWorkerAttempt(context.Background(), workerTestIssue(), nil, deps)
+
+		result := ec.waitResult(t)
+
+		// E-3: attempt must not fail.
+		if result.ExitKind != WorkerExitNormal {
+			t.Errorf("ExitKind = %q, want %q (E-3: degrade not fail)", result.ExitKind, WorkerExitNormal)
+		}
+
+		mu.Lock()
+		p := capturedPrompt
+		mu.Unlock()
+
+		// E-3: no advertisement section rendered.
+		if strings.Contains(p, "## Available Sortie tools") {
+			t.Errorf("first-turn prompt must not contain tool advertisement after builder error:\n%s", p)
+		}
+
+		// RuntimeStatusSuffix must still be present.
+		if !strings.Contains(p, prompt.RuntimeStatusSuffix) {
+			t.Errorf("first-turn prompt missing RuntimeStatusSuffix after builder error:\n%s", p)
+		}
+
+		// E-3: Warn must have been logged.
+		if !strings.Contains(logBuf.String(), "failed to build session tool advertisement") {
+			t.Errorf("E-3: expected Warn log not found; got:\n%s", logBuf.String())
+		}
+	})
+
+	t.Run("nil_builder_falls_back_to_tool_registry", func(t *testing.T) {
+		// When SessionToolRegistryFunc is nil the worker falls back to the
+		// static ToolRegistry (existing behavior preserved).
+		t.Parallel()
+
+		tmpDir := t.TempDir()
+		cfg := defaultWorkerConfig(tmpDir)
+		cfg.Agent.MaxTurns = 1
+		cfg.Tracker.Project = "TESTPROJ"
+
+		ec := newExitCapture()
+		var capturedPrompt string
+		var mu sync.Mutex
+
+		reg := domain.NewToolRegistry()
+		reg.Register(&stubAgentTool{toolName: "tracker_api", desc: "fallback tool"})
+
+		deps := WorkerDeps{
+			TrackerAdapter: &mockTrackerAdapter{},
+			AgentAdapter: &mockAgentAdapter{
+				runTurnFn: func(_ context.Context, session domain.Session, params domain.RunTurnParams) (domain.TurnResult, error) {
+					mu.Lock()
+					capturedPrompt = params.Prompt
+					mu.Unlock()
+					return domain.TurnResult{SessionID: session.ID, ExitReason: domain.EventTurnCompleted}, nil
+				},
+			},
+			ConfigFunc:              func() config.ServiceConfig { return cfg },
+			PromptTemplateByIDFunc:  func(_ string) *prompt.Template { return mustParseTemplate(t, "work on {{ .issue.title }}") },
+			OnEvent:                 func(_ string, _ domain.AgentEvent) {},
+			OnExit:                  ec.onExit,
+			Logger:                  discardLogger(),
+			ToolRegistry:            reg,
+			SessionToolRegistryFunc: nil,
+		}
+
+		RunWorkerAttempt(context.Background(), workerTestIssue(), nil, deps)
+		ec.waitResult(t)
+
+		mu.Lock()
+		p := capturedPrompt
+		mu.Unlock()
+
+		if !strings.Contains(p, "### tracker_api") {
+			t.Errorf("first-turn prompt missing fallback tool heading \"### tracker_api\":\n%s", p)
+		}
+	})
+}


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Feat

**Intent:** The MCP sidecar and the orchestrator worker both need to know which per-session tools are available, but they previously built their tool registries independently. This PR introduces a single `BuildSessionToolRegistry` function that both paths call, ensuring the tool set served over `tools/list` and the set advertised in the first-turn prompt are always identical.

Related issue: #565 

### 🧭 Reviewer Guide

**Complexity:** Medium

#### Entry Point

`cmd/sortie/sessiontools.go` — the new `BuildSessionToolRegistry` function and its `SessionToolParams` / `SessionToolRegistry` types. All gating logic (tracker adapter + project, workspace path, DB path + issue ID, notifications) now lives here. Reading this file first gives a complete picture of what tools can be registered and under what conditions.

#### Sensitive Areas

- `cmd/sortie/mcpserver.go`: the inline registry-build block is replaced by a single `BuildSessionToolRegistry` call. A DB-open failure is still non-fatal (degraded success); a notifier misconfiguration is still fatal. Verify the `defer store.Close()` placement is correct relative to the new `sessionTools.Store` field.
- `internal/orchestrator/worker.go`: the first-turn advertisement branch now prefers `SessionToolRegistryFunc` when injected; it falls back to the static `ToolRegistry` when nil. The fallback preserves the existing behavior for callers that have not been updated.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes
- **Migrations/State:** No migrations or state changes