### PR TITLE
fix: apply uniform result envelope to all built-in tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   as absent, though `sortie validate` still advises quoting it.
   ([#549](https://github.com/sortie-ai/sortie/issues/549))
 
+### Changed
+
+- Agent tools: all five built-in tools (`sortie_status`,
+  `workspace_history`, `cost_budget`, `tracker_api`, `notify_operator`)
+  now return one uniform result envelope. On success a tool returns
+  `{"success": true, "data": <payload>}`; on a domain failure it returns
+  `{"success": false, "error": {"kind": "...", "message": "..."}}`. This
+  changes the result shape of four tools: the Tier 1 tools
+  (`sortie_status`, `workspace_history`, `cost_budget`) previously
+  returned a bare success object and a flat `{"error": "message"}`
+  failure, and `notify_operator` previously returned `delivered` and
+  `notification_id` as top-level fields, now nested under `data`. The
+  Tier 1 tools gain a closed `error.kind` set: `state_unavailable` and
+  `state_malformed` for `sortie_status`, and `query_failed` for
+  `workspace_history` and `cost_budget`. `tracker_api`'s output is
+  unchanged. Agent prompts or downstream consumers that parsed the
+  previous bare or flat shapes must now read the payload under `data`
+  and read failures as `error.kind` and `error.message`.
+  ([#567](https://github.com/sortie-ai/sortie/issues/567))
+
 ## [1.11.0] - 2026-05-29
 
 ### Added

--- a/cmd/sortie/mcpserver_test.go
+++ b/cmd/sortie/mcpserver_test.go
@@ -169,31 +169,36 @@ func TestMCPServer_StatusTool_Dispatch(t *testing.T) {
 		t.Fatalf("unmarshal status response %q: %v", text, err)
 	}
 
-	if got, ok := statusResp["turn_number"].(float64); !ok || int(got) != 7 {
-		t.Errorf("turn_number = %v, want 7", statusResp["turn_number"])
-	}
-	if got, ok := statusResp["max_turns"].(float64); !ok || int(got) != 10 {
-		t.Errorf("max_turns = %v, want 10", statusResp["max_turns"])
-	}
-	if got, ok := statusResp["turns_remaining"].(float64); !ok || int(got) != 3 {
-		t.Errorf("turns_remaining = %v, want 3", statusResp["turns_remaining"])
+	data, ok := statusResp["data"].(map[string]any)
+	if !ok {
+		t.Fatalf("statusResp[\"data\"] = %T %v, want map[string]any", statusResp["data"], statusResp["data"])
 	}
 
-	tokens, ok := statusResp["tokens"].(map[string]any)
+	if got, ok := data["turn_number"].(float64); !ok || int(got) != 7 {
+		t.Errorf("data.turn_number = %v, want 7", data["turn_number"])
+	}
+	if got, ok := data["max_turns"].(float64); !ok || int(got) != 10 {
+		t.Errorf("data.max_turns = %v, want 10", data["max_turns"])
+	}
+	if got, ok := data["turns_remaining"].(float64); !ok || int(got) != 3 {
+		t.Errorf("data.turns_remaining = %v, want 3", data["turns_remaining"])
+	}
+
+	tokens, ok := data["tokens"].(map[string]any)
 	if !ok {
-		t.Fatalf("tokens is not an object: %v", statusResp["tokens"])
+		t.Fatalf("data.tokens is not an object: %v", data["tokens"])
 	}
 	if got, ok := tokens["input_tokens"].(float64); !ok || got != 5000 {
-		t.Errorf("tokens.input_tokens = %v, want 5000", tokens["input_tokens"])
+		t.Errorf("data.tokens.input_tokens = %v, want 5000", tokens["input_tokens"])
 	}
 	if got, ok := tokens["output_tokens"].(float64); !ok || got != 1200 {
-		t.Errorf("tokens.output_tokens = %v, want 1200", tokens["output_tokens"])
+		t.Errorf("data.tokens.output_tokens = %v, want 1200", tokens["output_tokens"])
 	}
 	if got, ok := tokens["total_tokens"].(float64); !ok || got != 6200 {
-		t.Errorf("tokens.total_tokens = %v, want 6200", tokens["total_tokens"])
+		t.Errorf("data.tokens.total_tokens = %v, want 6200", tokens["total_tokens"])
 	}
 	if got, ok := tokens["cache_read_tokens"].(float64); !ok || got != 800 {
-		t.Errorf("tokens.cache_read_tokens = %v, want 800", tokens["cache_read_tokens"])
+		t.Errorf("data.tokens.cache_read_tokens = %v, want 800", tokens["cache_read_tokens"])
 	}
 }
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1871,9 +1871,17 @@ All tools that Sortie exposes to agents implement the `AgentTool` interface
 - `InputSchema() json.RawMessage` — JSON Schema describing the tool's expected input. Used for
   MCP tool registration and prompt-based documentation.
 - `Execute(ctx context.Context, input json.RawMessage) (json.RawMessage, error)` — runs the tool
-  and returns a structured JSON result. Domain-level errors (missing auth, API failures, invalid
-  input) are encoded in the JSON result with `success: false`. The Go `error` return is reserved
-  for internal failures (nil adapter, marshal failure) that indicate programming errors.
+  and returns a structured JSON result. The Go `error` return is reserved for internal failures
+  (nil adapter, marshal failure) that indicate programming errors.
+
+Every tool's `Execute` MUST return the uniform result envelope. On success it MUST return
+`{"success": true, "data": <payload>}`, where `<payload>` is the tool's success object. On a
+domain failure (missing auth, API failures, invalid input, unreadable local state) it MUST return
+`{"success": false, "error": {"kind": "<kind>", "message": "<message>"}}`, where `kind` is from the
+tool's documented closed set (Section 10.4.5) and `message` is a human-readable detail. A domain
+failure is carried in this envelope with a nil Go `error`; the non-nil Go `error` return signals
+only an internal marshal failure. All tools marshal both envelopes through one shared helper, so
+the two shapes are byte-identical at the top level across tools.
 
 #### 10.4.3 Tool registry
 
@@ -1897,9 +1905,11 @@ strategy, and failure characteristics.
 
 **Tier 1 — pure orchestrator state.** These tools read from local session state (a workspace
 state file or the SQLite database) with zero external calls. They are deterministic and fast.
-Beyond internal bugs, their only runtime failure mode is a tool-error response when the local
-state they read is missing or unreadable (for example, an absent or malformed state file, or a
-failed database query).
+Beyond internal bugs, their only runtime failure mode is the failure envelope of Section 10.4.2
+when the local state they read is missing or unreadable. Their `error.kind` values come from the
+closed Tier 1 set `state_unavailable`, `state_malformed`, and `query_failed`: an absent, symlinked,
+oversized, or unreadable state file is `state_unavailable`, a present but unparseable state file is
+`state_malformed`, and a failed database query is `query_failed`.
 
 - `sortie_status` (Section 10.4.5)
 - `workspace_history` (Section 10.4.5)
@@ -1946,13 +1956,20 @@ Tracker dispatch:
 The tool delegates to the configured `TrackerAdapter` implementation. Transport, input shape,
 and query semantics are adapter-defined.
 
-Result semantics:
+Result semantics: the tool returns the uniform envelope of Section 10.4.2. On success it returns
+`{"success": true, "data": <payload>}`, where `<payload>` is the per-operation response object. On
+a domain failure (API-level error, invalid input, missing auth, or transport failure) it returns
+`{"success": false, "error": {"kind": "<kind>", "message": "<message>"}}`. The `error.kind` comes
+from the closed set below.
 
-- Transport success + no API-level errors -> `success: true` with response payload.
-- API-level errors -> `success: false` with a normalized error envelope
-  `{"success": false, "error": {"kind": "...", "message": "..."}}`.
-- Invalid input, missing auth, or transport failure -> `success: false` with the same normalized
-  error envelope (`error.kind` indicates the failure category).
+| `error.kind` | Condition |
+|---|---|
+| `invalid_input` | Input fails schema decode, carries unknown or trailing fields, or omits a required field for the operation |
+| `unsupported_operation` | The requested operation is not one of the four supported operations |
+| `project_scope_violation` | The target issue is outside the configured project |
+| `tracker_transport_error` | The request was canceled or its deadline was exceeded |
+| `internal_error` | An unexpected error that the adapter did not classify |
+| `domain.TrackerError` kinds | The adapter returned a classified tracker error; its kind passes through verbatim |
 
 The response payload or error envelope is returned as structured JSON that the agent can inspect
 in-session.
@@ -1975,8 +1992,11 @@ Response fields:
 | `session_duration_seconds` | number | Wall-clock seconds since the session started |
 | `tokens` | object | `input_tokens`, `output_tokens`, `total_tokens`, and `cache_read_tokens` |
 
-On failure the tool returns a JSON error object of the form `{"error": "<message>"}`. This
-happens when the state file is absent, a symlink, oversized, or malformed.
+On success the tool returns the response object above under `data`, in the envelope
+`{"success": true, "data": {...}}` of Section 10.4.2. On failure it returns the failure envelope
+`{"success": false, "error": {"kind": "<kind>", "message": "<message>"}}`. An absent, symlinked,
+oversized, or unreadable state file yields `error.kind` `state_unavailable`; a present but
+unparseable state file, including an invalid `started_at`, yields `state_malformed`.
 
 **`workspace_history` (Tier 1)** returns the most recent completed run attempts for the current
 issue. It queries the `run_history` table (Section 19.2) through a read-only SQLite connection
@@ -1985,13 +2005,16 @@ and makes no external calls.
 Availability: registered when the database path and issue ID are present in the environment
 (`SORTIE_DB_PATH`, `SORTIE_ISSUE_ID`). The tool takes no input.
 
-The response is a JSON object `{issue_id, entries}`, where `entries` lists at most the 10 most
+On success the tool returns, under `data` in the envelope `{"success": true, "data": {...}}` of
+Section 10.4.2, a JSON object `{issue_id, entries}`, where `entries` lists at most the 10 most
 recent runs, newest first. Each entry has `attempt`, `agent_adapter`, `started_at`,
 `completed_at`, `status` (`succeeded`, `failed`, `timed_out`, `stalled`, or `cancelled`), and
-`error` (null unless the run failed).
+`error` (null unless the run failed). The per-entry `error` is the run's own error and is distinct
+from the envelope's `error` object.
 
-On failure the tool returns a JSON error object of the form `{"error": "<message>"}`. This
-happens when the history query fails.
+On failure the tool returns the failure envelope
+`{"success": false, "error": {"kind": "<kind>", "message": "<message>"}}` with `error.kind`
+`query_failed`. This happens when the history query fails.
 
 **`cost_budget` (Tier 1)** returns cumulative per-issue token spend and the remaining token
 budget so an agent can self-regulate before the orchestrator's token ceiling blocks a
@@ -2004,7 +2027,8 @@ Availability: registered when the database path and issue ID are present in the 
 (`SORTIE_DB_PATH`, `SORTIE_ISSUE_ID`), the same condition as `workspace_history`. The running
 session ID arrives through `SORTIE_SESSION_ID`. The tool takes no input.
 
-The response is a JSON object with five fields:
+On success the tool returns, under `data` in the envelope `{"success": true, "data": {...}}` of
+Section 10.4.2, a JSON object with five fields:
 
 - `used_tokens`: cumulative `total_tokens` across the issue's completed sessions, plus the
   running session's recorded `total_tokens` when a session is in flight. The running session's
@@ -2024,8 +2048,9 @@ exactly when the agent consults it. The running session's spend reaches `session
 through throttled incremental writes during the session and reaches `run_history` only at
 session exit, so no window double counts.
 
-On failure the tool returns a JSON error object of the form `{"error": "<message>"}`. This
-happens when the budget query fails.
+On failure the tool returns the failure envelope
+`{"success": false, "error": {"kind": "<kind>", "message": "<message>"}}` with `error.kind`
+`query_failed`. This happens when the budget query fails.
 
 **`notify_operator` (Tier 2)** sends a real-time notification to an operator-configured
 channel while a session runs. The agent uses it to escalate a decision it should not make
@@ -2057,10 +2082,10 @@ Rate limiting: the tool enforces a per-session cap, `max_per_session`, where `0`
 default rather than unlimited. A call past the cap returns `rate_limited` and sends nothing.
 An accepted call increments the counter once, after delivery, not once per backend.
 
-Result semantics: on success the tool returns `{"success": true, "delivered": <int>,
-"notification_id": "<id>"}`. On a domain failure it returns `{"success": false, "error":
-{"kind": "...", "message": "..."}}` with `error.kind` in the closed set below. The Go error
-return is reserved for an internal marshal failure.
+Result semantics: on success the tool returns `{"success": true, "data": {"delivered": <int>,
+"notification_id": "<id>"}}`, the uniform success envelope of Section 10.4.2. On a domain failure
+it returns `{"success": false, "error": {"kind": "...", "message": "..."}}` with `error.kind` in
+the closed set below. The Go error return is reserved for an internal marshal failure.
 
 | `error.kind` | Condition |
 |---|---|

--- a/internal/tool/budget/budget.go
+++ b/internal/tool/budget/budget.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 
 	"github.com/sortie-ai/sortie/internal/domain"
+	"github.com/sortie-ai/sortie/internal/tool/toolresult"
 )
 
 var _ domain.AgentTool = (*BudgetTool)(nil)
@@ -103,7 +104,7 @@ func (t *BudgetTool) InputSchema() json.RawMessage {
 func (t *BudgetTool) Execute(ctx context.Context, _ json.RawMessage) (json.RawMessage, error) {
 	usage, err := t.query(ctx, t.issueID, t.runningSessionID)
 	if err != nil {
-		return errorResponse(err.Error())
+		return toolresult.Failure("query_failed", err.Error())
 	}
 
 	usedTokens := usage.CompletedTotalTokens + usage.RunningTotalTokens
@@ -117,15 +118,11 @@ func (t *BudgetTool) Execute(ctx context.Context, _ json.RawMessage) (json.RawMe
 		remaining = &r
 	}
 
-	return json.Marshal(costBudgetResponse{
+	return toolresult.Success(costBudgetResponse{
 		UsedTokens:      usedTokens,
 		BudgetTokens:    int64(t.budgetTokens),
 		RemainingTokens: remaining,
 		UsedSessions:    usage.CompletedSessions,
 		BudgetSessions:  t.budgetSessions,
 	})
-}
-
-func errorResponse(msg string) (json.RawMessage, error) {
-	return json.Marshal(map[string]string{"error": msg})
 }

--- a/internal/tool/budget/budget_test.go
+++ b/internal/tool/budget/budget_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"strings"
 	"testing"
 )
 
@@ -14,17 +13,27 @@ var noopQuery BudgetQueryFunc = func(_ context.Context, _ string, _ string) (Bud
 	return BudgetUsage{}, nil
 }
 
+// executeOK calls Execute and fails on a non-nil Go error or unparseable JSON.
+// Returns the decoded data payload as a costBudgetResponse.
 func executeOK(t *testing.T, tool *BudgetTool) costBudgetResponse {
 	t.Helper()
 	out, err := tool.Execute(context.Background(), json.RawMessage(`{}`))
 	if err != nil {
 		t.Fatalf("Execute: unexpected Go error: %v", err)
 	}
-	var resp costBudgetResponse
-	if err := json.Unmarshal(out, &resp); err != nil {
-		t.Fatalf("Execute: unmarshal response %q: %v", out, err)
+
+	// Unwrap the {success, data} envelope.
+	var envelope struct {
+		Success bool               `json:"success"`
+		Data    costBudgetResponse `json:"data"`
 	}
-	return resp
+	if err := json.Unmarshal(out, &envelope); err != nil {
+		t.Fatalf("Execute: unmarshal envelope %q: %v", out, err)
+	}
+	if !envelope.Success {
+		t.Fatalf("Execute: envelope success = false, want true; raw: %s", out)
+	}
+	return envelope.Data
 }
 
 func int64Ptr(v int64) *int64 { return &v }
@@ -175,33 +184,33 @@ func TestBudgetTool_Execute(t *testing.T) {
 			resp := executeOK(t, tool)
 
 			if resp.UsedTokens != tt.wantUsedTokens {
-				t.Errorf("used_tokens = %d, want %d", resp.UsedTokens, tt.wantUsedTokens)
+				t.Errorf("data.used_tokens = %d, want %d", resp.UsedTokens, tt.wantUsedTokens)
 			}
 			if resp.BudgetTokens != tt.wantBudgetTokens {
-				t.Errorf("budget_tokens = %d, want %d", resp.BudgetTokens, tt.wantBudgetTokens)
+				t.Errorf("data.budget_tokens = %d, want %d", resp.BudgetTokens, tt.wantBudgetTokens)
 			}
 			if resp.UsedSessions != tt.wantUsedSessions {
-				t.Errorf("used_sessions = %d, want %d", resp.UsedSessions, tt.wantUsedSessions)
+				t.Errorf("data.used_sessions = %d, want %d", resp.UsedSessions, tt.wantUsedSessions)
 			}
 			if resp.BudgetSessions != tt.wantBudgetSessions {
-				t.Errorf("budget_sessions = %d, want %d", resp.BudgetSessions, tt.wantBudgetSessions)
+				t.Errorf("data.budget_sessions = %d, want %d", resp.BudgetSessions, tt.wantBudgetSessions)
 			}
 			switch {
 			case tt.wantRemaining == nil && resp.RemainingTokens != nil:
-				t.Errorf("remaining_tokens = %d, want null", *resp.RemainingTokens)
+				t.Errorf("data.remaining_tokens = %d, want null", *resp.RemainingTokens)
 			case tt.wantRemaining != nil && resp.RemainingTokens == nil:
-				t.Errorf("remaining_tokens = null, want %d", *tt.wantRemaining)
+				t.Errorf("data.remaining_tokens = null, want %d", *tt.wantRemaining)
 			case tt.wantRemaining != nil && *resp.RemainingTokens != *tt.wantRemaining:
-				t.Errorf("remaining_tokens = %d, want %d", *resp.RemainingTokens, *tt.wantRemaining)
+				t.Errorf("data.remaining_tokens = %d, want %d", *resp.RemainingTokens, *tt.wantRemaining)
 			}
 		})
 	}
 }
 
-// TestBudgetTool_Execute_FiveFieldShape pins the public JSON contract:
-// all five field names are present, and remaining_tokens is an explicit
-// null (not omitted) under an unlimited token budget.
-func TestBudgetTool_Execute_FiveFieldShape(t *testing.T) {
+// TestBudgetTool_Execute_SuccessEnvelopeShape pins the AC-1 contract:
+// top-level keys are exactly {success, data}, data carries the five fields,
+// and remaining_tokens is an explicit null when the budget is unlimited.
+func TestBudgetTool_Execute_SuccessEnvelopeShape(t *testing.T) {
 	t.Parallel()
 
 	query := func(_ context.Context, _ string, _ string) (BudgetUsage, error) {
@@ -214,24 +223,49 @@ func TestBudgetTool_Execute_FiveFieldShape(t *testing.T) {
 		t.Fatalf("Execute: unexpected Go error: %v", err)
 	}
 
-	var m map[string]any
-	if err := json.Unmarshal(out, &m); err != nil {
+	var top map[string]any
+	if err := json.Unmarshal(out, &top); err != nil {
 		t.Fatalf("unmarshal response %q: %v", out, err)
 	}
 
+	// Top-level keys must be exactly {success, data}.
+	if len(top) != 2 {
+		t.Errorf("Execute success top-level keys = %v, want exactly {success, data}", top)
+	}
+	if top["success"] != true {
+		t.Errorf("Execute success[\"success\"] = %v, want true", top["success"])
+	}
+	data, ok := top["data"].(map[string]any)
+	if !ok {
+		t.Fatalf("Execute success[\"data\"] = %T %v, want map", top["data"], top["data"])
+	}
+
+	// data must carry exactly the five budget fields.
 	for _, key := range []string{"used_tokens", "budget_tokens", "remaining_tokens", "used_sessions", "budget_sessions"} {
-		if _, ok := m[key]; !ok {
-			t.Errorf("response missing key %q: %s", key, out)
+		if _, ok := data[key]; !ok {
+			t.Errorf("data missing key %q: %s", key, out)
 		}
 	}
-	if len(m) != 5 {
-		t.Errorf("response has %d keys, want 5: %s", len(m), out)
+	if len(data) != 5 {
+		t.Errorf("data has %d keys, want 5: %s", len(data), out)
 	}
-	if got, ok := m["remaining_tokens"]; !ok || got != nil {
-		t.Errorf("remaining_tokens = %v, want explicit null", got)
+
+	// remaining_tokens must be explicit null under unlimited budget.
+	if got, ok := data["remaining_tokens"]; !ok || got != nil {
+		t.Errorf("data.remaining_tokens = %v, want explicit null", got)
+	}
+
+	// Payload fields must NOT appear at the top level.
+	for _, payloadKey := range []string{"used_tokens", "budget_tokens", "remaining_tokens", "used_sessions", "budget_sessions"} {
+		if _, exists := top[payloadKey]; exists {
+			t.Errorf("Execute success has payload key %q at top level, want it under data", payloadKey)
+		}
 	}
 }
 
+// TestBudgetTool_Execute_QueryError asserts that a query failure returns
+// success==false, error.kind=="query_failed", error.message equal to the query
+// error string, and a nil Go error (AC-2, AC-5).
 func TestBudgetTool_Execute_QueryError(t *testing.T) {
 	t.Parallel()
 
@@ -245,17 +279,63 @@ func TestBudgetTool_Execute_QueryError(t *testing.T) {
 		t.Fatalf("Execute: expected nil Go error on query failure, got: %v", err)
 	}
 
-	var m map[string]any
-	if err := json.Unmarshal(out, &m); err != nil {
+	var top map[string]any
+	if err := json.Unmarshal(out, &top); err != nil {
 		t.Fatalf("unmarshal error response %q: %v", out, err)
 	}
 
-	errStr, ok := m["error"].(string)
-	if !ok {
-		t.Fatalf("error value is not a string: %T %v", m["error"], m["error"])
+	if top["success"] != false {
+		t.Errorf("Execute failure[\"success\"] = %v, want false", top["success"])
 	}
-	if !strings.Contains(errStr, "database is locked") {
-		t.Errorf("error value = %q, want to contain %q", errStr, "database is locked")
+
+	errObj, ok := top["error"].(map[string]any)
+	if !ok {
+		t.Fatalf("Execute failure[\"error\"] = %T %v, want map", top["error"], top["error"])
+	}
+	if got, _ := errObj["kind"].(string); got != "query_failed" {
+		t.Errorf("error.kind = %q, want %q", got, "query_failed")
+	}
+	msg, ok := errObj["message"].(string)
+	if !ok {
+		t.Fatalf("error.message is not a string: %T %v", errObj["message"], errObj["message"])
+	}
+	if msg != "database is locked" {
+		t.Errorf("error.message = %q, want %q", msg, "database is locked")
+	}
+}
+
+// TestBudgetTool_Execute_FailureEnvelopeShape pins the AC-2 contract: the
+// failure response has top-level keys exactly {success, error} with error
+// carrying {kind, message}.
+func TestBudgetTool_Execute_FailureEnvelopeShape(t *testing.T) {
+	t.Parallel()
+
+	query := func(_ context.Context, _ string, _ string) (BudgetUsage, error) {
+		return BudgetUsage{}, fmt.Errorf("disk full")
+	}
+	tool := New(query, "10042", "sess-1", 0, 0)
+	out, err := tool.Execute(context.Background(), json.RawMessage(`{}`))
+	if err != nil {
+		t.Fatalf("Execute: unexpected Go error: %v", err)
+	}
+
+	var top map[string]any
+	if err := json.Unmarshal(out, &top); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+
+	if len(top) != 2 {
+		t.Errorf("Execute failure top-level keys = %v, want exactly {success, error}", top)
+	}
+	if top["success"] != false {
+		t.Errorf("Execute failure[\"success\"] = %v, want false", top["success"])
+	}
+	errObj, ok := top["error"].(map[string]any)
+	if !ok {
+		t.Fatalf("Execute failure[\"error\"] = %T %v, want map", top["error"], top["error"])
+	}
+	if len(errObj) != 2 {
+		t.Errorf("error object keys = %v, want exactly {kind, message}", errObj)
 	}
 }
 

--- a/internal/tool/history/history.go
+++ b/internal/tool/history/history.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 
 	"github.com/sortie-ai/sortie/internal/domain"
+	"github.com/sortie-ai/sortie/internal/tool/toolresult"
 )
 
 var _ domain.AgentTool = (*HistoryTool)(nil)
@@ -94,11 +95,7 @@ func (t *HistoryTool) InputSchema() json.RawMessage {
 func (t *HistoryTool) Execute(ctx context.Context, _ json.RawMessage) (json.RawMessage, error) {
 	results, err := t.query(ctx, t.issueID, maxEntries)
 	if err != nil {
-		resp, marshalErr := json.Marshal(map[string]string{"error": err.Error()})
-		if marshalErr != nil {
-			return nil, marshalErr
-		}
-		return resp, nil
+		return toolresult.Failure("query_failed", err.Error())
 	}
 
 	entries := make([]historyEntry, len(results))
@@ -111,7 +108,7 @@ func (t *HistoryTool) Execute(ctx context.Context, _ json.RawMessage) (json.RawM
 		entries = []historyEntry{}
 	}
 
-	return json.Marshal(historyResponse{
+	return toolresult.Success(historyResponse{
 		IssueID: t.issueID,
 		Entries: entries,
 	})

--- a/internal/tool/history/history_test.go
+++ b/internal/tool/history/history_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"strings"
 	"testing"
 )
 
@@ -14,6 +13,8 @@ var noopQuery QueryFunc = func(_ context.Context, _ string, _ int) ([]Entry, err
 	return []Entry{}, nil
 }
 
+// executeOK calls Execute and fails the test if either the Go error is
+// non-nil or the JSON cannot be parsed. Returns the decoded envelope map.
 func executeOK(t *testing.T, tool *HistoryTool) map[string]any {
 	t.Helper()
 	out, err := tool.Execute(context.Background(), json.RawMessage(`{}`))
@@ -25,6 +26,43 @@ func executeOK(t *testing.T, tool *HistoryTool) map[string]any {
 		t.Fatalf("Execute: unmarshal response %q: %v", out, err)
 	}
 	return m
+}
+
+// assertSuccessEnvelope checks that m has success==true and a "data" key.
+func assertSuccessEnvelope(t *testing.T, m map[string]any) {
+	t.Helper()
+	if m["success"] != true {
+		t.Errorf("envelope[\"success\"] = %v, want true", m["success"])
+	}
+	if _, ok := m["data"]; !ok {
+		t.Error("envelope missing key \"data\"")
+	}
+}
+
+// dataFields extracts the "data" map from an envelope.
+func dataFields(t *testing.T, m map[string]any) map[string]any {
+	t.Helper()
+	d, ok := m["data"].(map[string]any)
+	if !ok {
+		t.Fatalf("envelope[\"data\"] = %T %v, want map[string]any", m["data"], m["data"])
+	}
+	return d
+}
+
+// assertFailureEnvelope checks success==false and the error object's kind.
+func assertFailureEnvelope(t *testing.T, m map[string]any, wantKind string) map[string]any {
+	t.Helper()
+	if m["success"] != false {
+		t.Errorf("envelope[\"success\"] = %v, want false", m["success"])
+	}
+	errObj, ok := m["error"].(map[string]any)
+	if !ok {
+		t.Fatalf("envelope[\"error\"] = %T %v, want map[string]any", m["error"], m["error"])
+	}
+	if got, _ := errObj["kind"].(string); got != wantKind {
+		t.Errorf("error.kind = %q, want %q", got, wantKind)
+	}
+	return errObj
 }
 
 // --- Tests ---
@@ -86,6 +124,37 @@ func TestHistoryTool_InputSchema_DefensiveCopy(t *testing.T) {
 	}
 }
 
+// TestHistoryTool_Execute_SuccessEnvelopeShape asserts that a success response
+// has top-level keys {success, data} and that data carries issue_id and entries
+// (AC-1).
+func TestHistoryTool_Execute_SuccessEnvelopeShape(t *testing.T) {
+	t.Parallel()
+
+	tool := New(noopQuery, "10042")
+	out, err := tool.Execute(context.Background(), json.RawMessage(`{}`))
+	if err != nil {
+		t.Fatalf("Execute: unexpected Go error: %v", err)
+	}
+
+	var top map[string]any
+	if err := json.Unmarshal(out, &top); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+
+	if len(top) != 2 {
+		t.Errorf("Execute success top-level keys = %v, want exactly {success, data}", top)
+	}
+	assertSuccessEnvelope(t, top)
+	d := dataFields(t, top)
+
+	if _, ok := d["issue_id"]; !ok {
+		t.Error("data missing key \"issue_id\"")
+	}
+	if _, ok := d["entries"]; !ok {
+		t.Error("data missing key \"entries\"")
+	}
+}
+
 func TestHistoryTool_Execute_EntriesReturned(t *testing.T) {
 	t.Parallel()
 
@@ -101,44 +170,48 @@ func TestHistoryTool_Execute_EntriesReturned(t *testing.T) {
 
 	tool := New(query, "10042")
 	m := executeOK(t, tool)
+	assertSuccessEnvelope(t, m)
+	d := dataFields(t, m)
 
-	if got, ok := m["issue_id"].(string); !ok || got != "10042" {
-		t.Errorf("issue_id = %v, want %q", m["issue_id"], "10042")
+	if got, ok := d["issue_id"].(string); !ok || got != "10042" {
+		t.Errorf("data.issue_id = %v, want %q", d["issue_id"], "10042")
 	}
 
-	rawEntries, ok := m["entries"].([]any)
+	rawEntries, ok := d["entries"].([]any)
 	if !ok {
-		t.Fatalf("entries is not an array: %T %v", m["entries"], m["entries"])
+		t.Fatalf("data.entries is not an array: %T %v", d["entries"], d["entries"])
 	}
 	if len(rawEntries) != 3 {
-		t.Fatalf("len(entries) = %d, want 3", len(rawEntries))
+		t.Fatalf("len(data.entries) = %d, want 3", len(rawEntries))
 	}
 
 	// entries[0]: succeeded, nil error → JSON null.
 	e0, ok := rawEntries[0].(map[string]any)
 	if !ok {
-		t.Fatalf("entries[0] is not an object: %T", rawEntries[0])
+		t.Fatalf("data.entries[0] is not an object: %T", rawEntries[0])
 	}
 	if got, _ := e0["status"].(string); got != "succeeded" {
-		t.Errorf("entries[0].status = %q, want %q", got, "succeeded")
+		t.Errorf("data.entries[0].status = %q, want %q", got, "succeeded")
 	}
 	if e0["error"] != nil {
-		t.Errorf("entries[0].error = %v, want null", e0["error"])
+		t.Errorf("data.entries[0].error = %v, want null", e0["error"])
 	}
 
-	// entries[1]: failed, non-nil error → JSON string.
+	// entries[1]: failed, non-nil error → JSON string under data.entries[i].error.
 	e1, ok := rawEntries[1].(map[string]any)
 	if !ok {
-		t.Fatalf("entries[1] is not an object: %T", rawEntries[1])
+		t.Fatalf("data.entries[1] is not an object: %T", rawEntries[1])
 	}
 	if got, _ := e1["status"].(string); got != "failed" {
-		t.Errorf("entries[1].status = %q, want %q", got, "failed")
+		t.Errorf("data.entries[1].status = %q, want %q", got, "failed")
 	}
 	if got, ok := e1["error"].(string); !ok || got != "agent crashed" {
-		t.Errorf("entries[1].error = %v, want %q", e1["error"], "agent crashed")
+		t.Errorf("data.entries[1].error = %v, want %q", e1["error"], "agent crashed")
 	}
 }
 
+// TestHistoryTool_Execute_EmptyEntries asserts that an empty history returns
+// data.entries as [] (not null) (AC-1).
 func TestHistoryTool_Execute_EmptyEntries(t *testing.T) {
 	t.Parallel()
 
@@ -156,14 +229,16 @@ func TestHistoryTool_Execute_EmptyEntries(t *testing.T) {
 	if err := json.Unmarshal(out, &m); err != nil {
 		t.Fatalf("unmarshal response: %v", err)
 	}
+	assertSuccessEnvelope(t, m)
+	d := dataFields(t, m)
 
-	// entries must be a JSON array ([]), not null.
-	entries, ok := m["entries"].([]any)
+	// data.entries must be a JSON array ([]), not null.
+	entries, ok := d["entries"].([]any)
 	if !ok {
-		t.Fatalf("entries is not an array: %T %v", m["entries"], m["entries"])
+		t.Fatalf("data.entries is not an array: %T %v", d["entries"], d["entries"])
 	}
 	if len(entries) != 0 {
-		t.Errorf("len(entries) = %d, want 0", len(entries))
+		t.Errorf("len(data.entries) = %d, want 0", len(entries))
 	}
 }
 
@@ -185,19 +260,24 @@ func TestHistoryTool_Execute_LimitPassthrough(t *testing.T) {
 
 	tool := New(query, "10042")
 	m := executeOK(t, tool)
+	assertSuccessEnvelope(t, m)
+	d := dataFields(t, m)
 
 	if !called {
 		t.Fatal("QueryFunc was not called")
 	}
-	rawEntries, ok := m["entries"].([]any)
+	rawEntries, ok := d["entries"].([]any)
 	if !ok {
-		t.Fatalf("entries is not an array: %T %v", m["entries"], m["entries"])
+		t.Fatalf("data.entries is not an array: %T %v", d["entries"], d["entries"])
 	}
 	if len(rawEntries) != maxEntries {
-		t.Errorf("len(entries) = %d, want %d", len(rawEntries), maxEntries)
+		t.Errorf("len(data.entries) = %d, want %d", len(rawEntries), maxEntries)
 	}
 }
 
+// TestHistoryTool_Execute_QueryError asserts that a query failure returns
+// success==false, error.kind=="query_failed", error.message equal to the query
+// error string, and a nil Go error (AC-2, AC-5).
 func TestHistoryTool_Execute_QueryError(t *testing.T) {
 	t.Parallel()
 
@@ -216,15 +296,85 @@ func TestHistoryTool_Execute_QueryError(t *testing.T) {
 		t.Fatalf("unmarshal error response %q: %v", out, err)
 	}
 
-	if _, ok := m["error"]; !ok {
-		t.Fatal(`response missing "error" key`)
-	}
-	errStr, ok := m["error"].(string)
+	errObj := assertFailureEnvelope(t, m, "query_failed")
+
+	msg, ok := errObj["message"].(string)
 	if !ok {
-		t.Fatalf("error value is not a string: %T %v", m["error"], m["error"])
+		t.Fatalf("error.message is not a string: %T %v", errObj["message"], errObj["message"])
 	}
-	if !strings.Contains(errStr, "database is locked") {
-		t.Errorf("error value = %q, want to contain %q", errStr, "database is locked")
+	if msg != "database is locked" {
+		t.Errorf("error.message = %q, want %q", msg, "database is locked")
+	}
+}
+
+// TestHistoryTool_Execute_FailureEnvelopeShape pins the AC-2 contract: the
+// failure response has top-level keys exactly {success, error} with error
+// carrying {kind, message}, and no "data" key.
+func TestHistoryTool_Execute_FailureEnvelopeShape(t *testing.T) {
+	t.Parallel()
+
+	query := func(_ context.Context, _ string, _ int) ([]Entry, error) {
+		return nil, fmt.Errorf("connection reset")
+	}
+
+	tool := New(query, "10042")
+	out, err := tool.Execute(context.Background(), json.RawMessage(`{}`))
+	if err != nil {
+		t.Fatalf("Execute: unexpected Go error: %v", err)
+	}
+
+	var top map[string]any
+	if err := json.Unmarshal(out, &top); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+
+	if len(top) != 2 {
+		t.Errorf("Execute failure top-level keys = %v, want exactly {success, error}", top)
+	}
+	if top["success"] != false {
+		t.Errorf("Execute failure[\"success\"] = %v, want false", top["success"])
+	}
+	errObj, ok := top["error"].(map[string]any)
+	if !ok {
+		t.Fatalf("Execute failure[\"error\"] = %T %v, want map", top["error"], top["error"])
+	}
+	if len(errObj) != 2 {
+		t.Errorf("error object keys = %v, want exactly {kind, message}", errObj)
+	}
+}
+
+// TestHistoryTool_Execute_PerEntryErrorIsUnderData asserts that the per-entry
+// error field is under data.entries[i].error and not conflated with the
+// envelope error (AC-1 note on per-entry error).
+func TestHistoryTool_Execute_PerEntryErrorIsUnderData(t *testing.T) {
+	t.Parallel()
+
+	errMsg := "syntax error near line 12"
+	query := func(_ context.Context, _ string, _ int) ([]Entry, error) {
+		return []Entry{
+			{Attempt: 1, Status: "failed", Error: &errMsg},
+		}, nil
+	}
+
+	tool := New(query, "10042")
+	m := executeOK(t, tool)
+	assertSuccessEnvelope(t, m)
+	d := dataFields(t, m)
+
+	entries, ok := d["entries"].([]any)
+	if !ok || len(entries) == 0 {
+		t.Fatalf("data.entries = %v, want non-empty array", d["entries"])
+	}
+	e0, ok := entries[0].(map[string]any)
+	if !ok {
+		t.Fatalf("data.entries[0] is not an object: %T", entries[0])
+	}
+	if got, ok := e0["error"].(string); !ok || got != errMsg {
+		t.Errorf("data.entries[0].error = %v, want %q", e0["error"], errMsg)
+	}
+	// The envelope must NOT have an "error" key at the top level.
+	if _, hasErr := m["error"]; hasErr {
+		t.Error("envelope has top-level \"error\" key on success path, want absent")
 	}
 }
 

--- a/internal/tool/notify/notify.go
+++ b/internal/tool/notify/notify.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/sortie-ai/sortie/internal/domain"
+	"github.com/sortie-ai/sortie/internal/tool/toolresult"
 )
 
 var _ domain.AgentTool = (*NotifyTool)(nil)
@@ -138,28 +139,28 @@ func (t *NotifyTool) Execute(ctx context.Context, input json.RawMessage) (json.R
 	dec := json.NewDecoder(bytes.NewReader(input))
 	dec.DisallowUnknownFields()
 	if err := dec.Decode(&in); err != nil {
-		return errorResult("invalid_input", fmt.Sprintf("failed to parse input: %s", err))
+		return toolresult.Failure("invalid_input", fmt.Sprintf("failed to parse input: %s", err))
 	}
 	if dec.More() {
-		return errorResult("invalid_input", "unexpected trailing content after JSON object")
+		return toolresult.Failure("invalid_input", "unexpected trailing content after JSON object")
 	}
 
 	if !validSeverities[in.Severity] {
-		return errorResult("invalid_input", "severity must be info, warning, or critical")
+		return toolresult.Failure("invalid_input", "severity must be info, warning, or critical")
 	}
 	if in.Category != "" && !validCategories[in.Category] {
-		return errorResult("invalid_input", "category is not a recognized value")
+		return toolresult.Failure("invalid_input", "category is not a recognized value")
 	}
 	if in.Title == "" || in.Body == "" {
-		return errorResult("invalid_input", "title and body must be non-empty")
+		return toolresult.Failure("invalid_input", "title and body must be non-empty")
 	}
 
 	if len(t.backends) == 0 {
-		return errorResult("backend_unavailable", "no notification backend is configured")
+		return toolresult.Failure("backend_unavailable", "no notification backend is configured")
 	}
 
 	if t.count >= t.maxPerSession {
-		return errorResult("rate_limited", "per-session notification cap reached")
+		return toolresult.Failure("rate_limited", "per-session notification cap reached")
 	}
 
 	notification := domain.Notification{
@@ -175,13 +176,16 @@ func (t *NotifyTool) Execute(ctx context.Context, input json.RawMessage) (json.R
 	delivered := 0
 	for _, backend := range t.backends {
 		if err := backend.Send(ctx, notification); err != nil {
-			return errorResult("send_failed", fmt.Sprintf("notification delivery failed: %s", err))
+			return toolresult.Failure("send_failed", fmt.Sprintf("notification delivery failed: %s", err))
 		}
 		delivered++
 	}
 
 	t.count++
-	return successResult(delivered, notification.Envelope.NotificationID)
+	return toolresult.Success(map[string]any{
+		"delivered":       delivered,
+		"notification_id": notification.Envelope.NotificationID,
+	})
 }
 
 // buildEnvelope generates the notification id and timestamp at call time
@@ -205,28 +209,6 @@ func (t *NotifyTool) buildEnvelope() domain.NotificationEnvelope {
 		Attempt:        t.env.Attempt,
 		Agent:          t.env.Agent,
 	}
-}
-
-// successResult marshals the success envelope.
-func successResult(delivered int, notificationID string) (json.RawMessage, error) {
-	return json.Marshal(map[string]any{
-		"success":         true,
-		"delivered":       delivered,
-		"notification_id": notificationID,
-	})
-}
-
-// errorResult marshals the failure envelope with a closed-set kind and a
-// redacted message. The kind is one of invalid_input, rate_limited,
-// send_failed, or backend_unavailable.
-func errorResult(kind, message string) (json.RawMessage, error) {
-	return json.Marshal(map[string]any{
-		"success": false,
-		"error": map[string]string{
-			"kind":    kind,
-			"message": message,
-		},
-	})
 }
 
 // newUUID generates a random v4 UUID string using crypto/rand. Panics if

--- a/internal/tool/notify/notify_test.go
+++ b/internal/tool/notify/notify_test.go
@@ -269,11 +269,22 @@ func TestExecute_SuccessResultShape(t *testing.T) {
 	m := executeJSON(t, tool, `{"severity":"info","title":"Hi","body":"Body"}`)
 	assertSuccess(t, m)
 
-	if _, ok := m["delivered"]; !ok {
-		t.Error("result missing \"delivered\" field")
+	data, ok := m["data"].(map[string]any)
+	if !ok {
+		t.Fatalf("result[\"data\"] = %T %v, want map[string]any", m["data"], m["data"])
 	}
-	if _, ok := m["notification_id"]; !ok {
-		t.Error("result missing \"notification_id\" field")
+	if _, ok := data["delivered"]; !ok {
+		t.Error("result[\"data\"] missing \"delivered\" field")
+	}
+	if _, ok := data["notification_id"]; !ok {
+		t.Error("result[\"data\"] missing \"notification_id\" field")
+	}
+	// Payload fields must NOT appear at the top level.
+	if _, exists := m["delivered"]; exists {
+		t.Error("result has \"delivered\" at top level, want it under data")
+	}
+	if _, exists := m["notification_id"]; exists {
+		t.Error("result has \"notification_id\" at top level, want it under data")
 	}
 }
 
@@ -552,8 +563,12 @@ func TestExecute_MultipleBackends_AllReceiveNotification(t *testing.T) {
 	if len(mock2.received) != 1 {
 		t.Errorf("backend 2 Send called %d times, want 1", len(mock2.received))
 	}
-	if got := m["delivered"]; got != float64(2) {
-		t.Errorf("delivered = %v, want 2", got)
+	data, ok := m["data"].(map[string]any)
+	if !ok {
+		t.Fatalf("result[\"data\"] = %T %v, want map[string]any", m["data"], m["data"])
+	}
+	if got := data["delivered"]; got != float64(2) {
+		t.Errorf("data.delivered = %v, want 2", got)
 	}
 }
 

--- a/internal/tool/status/status.go
+++ b/internal/tool/status/status.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/sortie-ai/sortie/internal/domain"
+	"github.com/sortie-ai/sortie/internal/tool/toolresult"
 )
 
 var _ domain.AgentTool = (*StatusTool)(nil)
@@ -100,28 +101,28 @@ func (t *StatusTool) InputSchema() json.RawMessage {
 func (t *StatusTool) Execute(_ context.Context, _ json.RawMessage) (json.RawMessage, error) {
 	fi, err := os.Lstat(t.stateFilePath)
 	if err != nil {
-		return errorResponse("state file unavailable: " + err.Error())
+		return toolresult.Failure("state_unavailable", "state file unavailable: "+err.Error())
 	}
 	if fi.Mode()&os.ModeSymlink != 0 {
-		return errorResponse("state file is a symlink")
+		return toolresult.Failure("state_unavailable", "state file is a symlink")
 	}
 	if fi.Size() > maxStateFileBytes {
-		return errorResponse("state file exceeds size limit")
+		return toolresult.Failure("state_unavailable", "state file exceeds size limit")
 	}
 
 	data, err := os.ReadFile(t.stateFilePath)
 	if err != nil {
-		return errorResponse("state file unavailable: " + err.Error())
+		return toolresult.Failure("state_unavailable", "state file unavailable: "+err.Error())
 	}
 
 	var sf stateFile
 	if err := json.Unmarshal(data, &sf); err != nil {
-		return errorResponse("state file malformed: " + err.Error())
+		return toolresult.Failure("state_malformed", "state file malformed: "+err.Error())
 	}
 
 	startedAt, err := time.Parse(time.RFC3339Nano, sf.StartedAt)
 	if err != nil {
-		return errorResponse("state file has invalid started_at: " + err.Error())
+		return toolresult.Failure("state_malformed", "state file has invalid started_at: "+err.Error())
 	}
 
 	turnsRemaining := sf.MaxTurns - sf.TurnNumber
@@ -145,9 +146,5 @@ func (t *StatusTool) Execute(_ context.Context, _ json.RawMessage) (json.RawMess
 		},
 	}
 
-	return json.Marshal(resp)
-}
-
-func errorResponse(msg string) (json.RawMessage, error) {
-	return json.Marshal(map[string]string{"error": msg})
+	return toolresult.Success(resp)
 }

--- a/internal/tool/status/status_test.go
+++ b/internal/tool/status/status_test.go
@@ -28,7 +28,7 @@ func writeStateFile(t *testing.T, dir string, sf stateFile) {
 }
 
 // executeOK calls Execute and fails the test if either the Go error is
-// non-nil or the JSON cannot be parsed. Returns the decoded map.
+// non-nil or the JSON cannot be parsed. Returns the decoded envelope map.
 func executeOK(t *testing.T, tool *StatusTool) map[string]any {
 	t.Helper()
 	out, err := tool.Execute(context.Background(), json.RawMessage(`{}`))
@@ -38,6 +38,61 @@ func executeOK(t *testing.T, tool *StatusTool) map[string]any {
 	var m map[string]any
 	if err := json.Unmarshal(out, &m); err != nil {
 		t.Fatalf("Execute: unmarshal response %q: %v", out, err)
+	}
+	return m
+}
+
+// dataFields extracts the "data" field from an envelope map and asserts it is
+// a JSON object. Returns the decoded data map.
+func dataFields(t *testing.T, m map[string]any) map[string]any {
+	t.Helper()
+	d, ok := m["data"].(map[string]any)
+	if !ok {
+		t.Fatalf("envelope[\"data\"] = %T %v, want map[string]any", m["data"], m["data"])
+	}
+	return d
+}
+
+// assertSuccessEnvelope asserts that m has success==true and a "data" key, and
+// that no payload field is present at the top level.
+func assertSuccessEnvelope(t *testing.T, m map[string]any) {
+	t.Helper()
+	if m["success"] != true {
+		t.Errorf("envelope[\"success\"] = %v, want true", m["success"])
+	}
+	if _, ok := m["data"]; !ok {
+		t.Error("envelope missing key \"data\"")
+	}
+}
+
+// assertFailureEnvelope asserts that m has success==false, an "error" object
+// with the expected kind, and returns the error object.
+func assertFailureEnvelope(t *testing.T, m map[string]any, wantKind string) map[string]any {
+	t.Helper()
+	if m["success"] != false {
+		t.Errorf("envelope[\"success\"] = %v, want false", m["success"])
+	}
+	errObj, ok := m["error"].(map[string]any)
+	if !ok {
+		t.Fatalf("envelope[\"error\"] = %T %v, want map[string]any", m["error"], m["error"])
+	}
+	if got, _ := errObj["kind"].(string); got != wantKind {
+		t.Errorf("error.kind = %q, want %q", got, wantKind)
+	}
+	return errObj
+}
+
+// executeFailure calls Execute, asserts a nil Go error, and returns the
+// decoded envelope. Does not assert on success/failure shape.
+func executeFailure(t *testing.T, tool *StatusTool) map[string]any {
+	t.Helper()
+	out, err := tool.Execute(context.Background(), json.RawMessage(`{}`))
+	if err != nil {
+		t.Fatalf("Execute: unexpected Go error: %v", err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(out, &m); err != nil {
+		t.Fatalf("unmarshal response %q: %v", out, err)
 	}
 	return m
 }
@@ -65,38 +120,40 @@ func TestStatusTool_CorrectTurnAndBudget(t *testing.T) {
 
 	tool := New(dir)
 	m := executeOK(t, tool)
+	assertSuccessEnvelope(t, m)
+	d := dataFields(t, m)
 
-	if got, ok := m["turn_number"].(float64); !ok || int(got) != 3 {
-		t.Errorf("turn_number = %v, want 3", m["turn_number"])
+	if got, ok := d["turn_number"].(float64); !ok || int(got) != 3 {
+		t.Errorf("data.turn_number = %v, want 3", d["turn_number"])
 	}
-	if got, ok := m["max_turns"].(float64); !ok || int(got) != 20 {
-		t.Errorf("max_turns = %v, want 20", m["max_turns"])
+	if got, ok := d["max_turns"].(float64); !ok || int(got) != 20 {
+		t.Errorf("data.max_turns = %v, want 20", d["max_turns"])
 	}
-	if got, ok := m["turns_remaining"].(float64); !ok || int(got) != 17 {
-		t.Errorf("turns_remaining = %v, want 17", m["turns_remaining"])
+	if got, ok := d["turns_remaining"].(float64); !ok || int(got) != 17 {
+		t.Errorf("data.turns_remaining = %v, want 17", d["turns_remaining"])
 	}
 
 	// nil Attempt → JSON null: key present but value nil.
-	if attempt, exists := m["attempt"]; !exists {
-		t.Error("attempt key missing from response")
+	if attempt, exists := d["attempt"]; !exists {
+		t.Error("data.attempt key missing from response")
 	} else if attempt != nil {
-		t.Errorf("attempt = %v, want null (nil)", attempt)
+		t.Errorf("data.attempt = %v, want null (nil)", attempt)
 	}
 
-	dur, ok := m["session_duration_seconds"].(float64)
+	dur, ok := d["session_duration_seconds"].(float64)
 	if !ok {
-		t.Fatalf("session_duration_seconds is not a float64: %v", m["session_duration_seconds"])
+		t.Fatalf("data.session_duration_seconds is not a float64: %v", d["session_duration_seconds"])
 	}
 	if dur < 0 {
-		t.Errorf("session_duration_seconds = %f, want >= 0", dur)
+		t.Errorf("data.session_duration_seconds = %f, want >= 0", dur)
 	}
 
-	tokens, ok := m["tokens"].(map[string]any)
+	tokens, ok := d["tokens"].(map[string]any)
 	if !ok {
-		t.Fatalf("tokens is not an object: %v", m["tokens"])
+		t.Fatalf("data.tokens is not an object: %v", d["tokens"])
 	}
 	if got, _ := tokens["input_tokens"].(float64); got != 0 {
-		t.Errorf("tokens.input_tokens = %v, want 0", tokens["input_tokens"])
+		t.Errorf("data.tokens.input_tokens = %v, want 0", tokens["input_tokens"])
 	}
 }
 
@@ -113,10 +170,12 @@ func TestStatusTool_AttemptNullAndInteger(t *testing.T) {
 			StartedAt:  time.Now().UTC().Format(time.RFC3339Nano),
 		})
 		m := executeOK(t, New(dir))
-		if attempt, exists := m["attempt"]; !exists {
-			t.Error("attempt key missing, want null")
+		assertSuccessEnvelope(t, m)
+		d := dataFields(t, m)
+		if attempt, exists := d["attempt"]; !exists {
+			t.Error("data.attempt key missing, want null")
 		} else if attempt != nil {
-			t.Errorf("attempt = %v, want null", attempt)
+			t.Errorf("data.attempt = %v, want null", attempt)
 		}
 	})
 
@@ -131,12 +190,14 @@ func TestStatusTool_AttemptNullAndInteger(t *testing.T) {
 			StartedAt:  time.Now().UTC().Format(time.RFC3339Nano),
 		})
 		m := executeOK(t, New(dir))
-		got, ok := m["attempt"].(float64)
+		assertSuccessEnvelope(t, m)
+		d := dataFields(t, m)
+		got, ok := d["attempt"].(float64)
 		if !ok {
-			t.Fatalf("attempt = %v (%T), want float64", m["attempt"], m["attempt"])
+			t.Fatalf("data.attempt = %v (%T), want float64", d["attempt"], d["attempt"])
 		}
 		if int(got) != 2 {
-			t.Errorf("attempt = %v, want 2", got)
+			t.Errorf("data.attempt = %v, want 2", got)
 		}
 	})
 }
@@ -157,10 +218,12 @@ func TestStatusTool_TokenCounts(t *testing.T) {
 
 	tool := New(dir)
 	m := executeOK(t, tool)
+	assertSuccessEnvelope(t, m)
+	d := dataFields(t, m)
 
-	tokens, ok := m["tokens"].(map[string]any)
+	tokens, ok := d["tokens"].(map[string]any)
 	if !ok {
-		t.Fatalf("tokens is not an object: %v", m["tokens"])
+		t.Fatalf("data.tokens is not an object: %v", d["tokens"])
 	}
 
 	checks := map[string]float64{
@@ -172,11 +235,11 @@ func TestStatusTool_TokenCounts(t *testing.T) {
 	for field, want := range checks {
 		got, ok := tokens[field].(float64)
 		if !ok {
-			t.Errorf("tokens.%s = %v (%T), want float64", field, tokens[field], tokens[field])
+			t.Errorf("data.tokens.%s = %v (%T), want float64", field, tokens[field], tokens[field])
 			continue
 		}
 		if got != want {
-			t.Errorf("tokens.%s = %v, want %v", field, got, want)
+			t.Errorf("data.tokens.%s = %v, want %v", field, got, want)
 		}
 	}
 }
@@ -193,38 +256,82 @@ func TestStatusTool_TurnsRemainingFloor(t *testing.T) {
 
 	tool := New(dir)
 	m := executeOK(t, tool)
+	assertSuccessEnvelope(t, m)
+	d := dataFields(t, m)
 
-	remaining, ok := m["turns_remaining"].(float64)
+	remaining, ok := d["turns_remaining"].(float64)
 	if !ok {
-		t.Fatalf("turns_remaining = %v (%T), want float64", m["turns_remaining"], m["turns_remaining"])
+		t.Fatalf("data.turns_remaining = %v (%T), want float64", d["turns_remaining"], d["turns_remaining"])
 	}
 	if remaining < 0 {
-		t.Errorf("turns_remaining = %v, want >= 0 (floored at zero)", remaining)
+		t.Errorf("data.turns_remaining = %v, want >= 0 (floored at zero)", remaining)
 	}
 	if remaining != 0 {
-		t.Errorf("turns_remaining = %v, want 0 when turn_number > max_turns", remaining)
+		t.Errorf("data.turns_remaining = %v, want 0 when turn_number > max_turns", remaining)
 	}
 }
 
+// TestStatusTool_SuccessEnvelopeShape pins the AC-1 contract: top-level keys
+// are exactly {success, data}, payload fields are absent at the top level.
+func TestStatusTool_SuccessEnvelopeShape(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	writeStateFile(t, dir, stateFile{
+		TurnNumber: 1,
+		MaxTurns:   5,
+		StartedAt:  time.Now().UTC().Format(time.RFC3339Nano),
+	})
+
+	tool := New(dir)
+	out, err := tool.Execute(context.Background(), json.RawMessage(`{}`))
+	if err != nil {
+		t.Fatalf("Execute: unexpected Go error: %v", err)
+	}
+
+	var top map[string]any
+	if err := json.Unmarshal(out, &top); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+
+	if len(top) != 2 {
+		t.Errorf("Execute success top-level keys = %v, want exactly {success, data}", top)
+	}
+	if top["success"] != true {
+		t.Errorf("Execute success[\"success\"] = %v, want true", top["success"])
+	}
+	if _, ok := top["data"]; !ok {
+		t.Error("Execute success missing key \"data\"")
+	}
+	// Payload fields must NOT appear at the top level.
+	for _, payloadKey := range []string{"turn_number", "max_turns", "turns_remaining", "tokens", "session_duration_seconds"} {
+		if _, exists := top[payloadKey]; exists {
+			t.Errorf("Execute success has payload key %q at top level, want it under data", payloadKey)
+		}
+	}
+}
+
+// TestStatusTool_MissingStateFile asserts that a missing state file returns
+// success==false, error.kind=="state_unavailable", a non-empty error.message,
+// and a nil Go error (AC-2, AC-5).
 func TestStatusTool_MissingStateFile(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
 	tool := New(dir)
 
-	out, err := tool.Execute(context.Background(), json.RawMessage(`{}`))
-	if err != nil {
-		t.Fatalf("Execute: unexpected Go error: %v", err)
-	}
-	var m map[string]any
-	if err := json.Unmarshal(out, &m); err != nil {
-		t.Fatalf("unmarshal response %q: %v", out, err)
-	}
-	if _, hasErr := m["error"]; !hasErr {
-		t.Errorf("response = %v, want 'error' key for missing state file", m)
+	m := executeFailure(t, tool)
+	errObj := assertFailureEnvelope(t, m, "state_unavailable")
+
+	msg, _ := errObj["message"].(string)
+	if msg == "" {
+		t.Error("error.message is empty for missing state file, want non-empty")
 	}
 }
 
+// TestStatusTool_MalformedJSON asserts that malformed state JSON returns
+// success==false, error.kind=="state_malformed", and a nil Go error
+// (AC-2, AC-5).
 func TestStatusTool_MalformedJSON(t *testing.T) {
 	t.Parallel()
 
@@ -238,19 +345,185 @@ func TestStatusTool_MalformedJSON(t *testing.T) {
 	}
 
 	tool := New(dir)
+	m := executeFailure(t, tool)
+	errObj := assertFailureEnvelope(t, m, "state_malformed")
+
+	msg, _ := errObj["message"].(string)
+	if msg == "" {
+		t.Error("error.message is empty for malformed JSON, want non-empty")
+	}
+}
+
+// TestStatusTool_InvalidStartedAt asserts that a state file whose started_at
+// cannot be parsed returns success==false, error.kind=="state_malformed", and
+// a nil Go error (AC-2, AC-5).
+func TestStatusTool_InvalidStartedAt(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	dotSortie := filepath.Join(dir, ".sortie")
+	if err := os.MkdirAll(dotSortie, 0o750); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	state := []byte(`{"turn_number":1,"max_turns":10,"started_at":"not-a-timestamp"}`)
+	if err := os.WriteFile(filepath.Join(dotSortie, "state.json"), state, 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	tool := New(dir)
+	m := executeFailure(t, tool)
+	errObj := assertFailureEnvelope(t, m, "state_malformed")
+
+	msg, _ := errObj["message"].(string)
+	if msg == "" {
+		t.Error("error.message is empty for invalid started_at, want non-empty")
+	}
+}
+
+// TestStatusTool_OversizedStateFile asserts that a state file that exceeds the
+// size limit returns success==false, error.kind=="state_unavailable", and a nil
+// Go error (AC-2, AC-5).
+func TestStatusTool_OversizedStateFile(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	dotSortie := filepath.Join(dir, ".sortie")
+	if err := os.MkdirAll(dotSortie, 0o750); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+
+	bigContent := make([]byte, maxStateFileBytes+1)
+	if err := os.WriteFile(filepath.Join(dotSortie, "state.json"), bigContent, 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	tool := New(dir)
+	m := executeFailure(t, tool)
+	assertFailureEnvelope(t, m, "state_unavailable")
+}
+
+// TestStatusTool_FailureEnvelopeShape pins the AC-2 contract: top-level keys
+// are exactly {success, error}, with error carrying {kind, message}.
+func TestStatusTool_FailureEnvelopeShape(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	tool := New(dir) // no state file → state_unavailable failure
+
 	out, err := tool.Execute(context.Background(), json.RawMessage(`{}`))
 	if err != nil {
 		t.Fatalf("Execute: unexpected Go error: %v", err)
 	}
-	var m map[string]any
-	if err := json.Unmarshal(out, &m); err != nil {
-		t.Fatalf("unmarshal response %q: %v", out, err)
+
+	var top map[string]any
+	if err := json.Unmarshal(out, &top); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
 	}
-	if _, hasErr := m["error"]; !hasErr {
-		t.Errorf("response = %v, want 'error' key for malformed JSON", m)
+
+	if len(top) != 2 {
+		t.Errorf("Execute failure top-level keys = %v, want exactly {success, error}", top)
+	}
+	if top["success"] != false {
+		t.Errorf("Execute failure[\"success\"] = %v, want false", top["success"])
+	}
+	errObj, ok := top["error"].(map[string]any)
+	if !ok {
+		t.Fatalf("Execute failure[\"error\"] = %T %v, want map", top["error"], top["error"])
+	}
+	if len(errObj) != 2 {
+		t.Errorf("error object keys = %v, want exactly {kind, message}", errObj)
+	}
+	if _, ok := errObj["kind"]; !ok {
+		t.Error("error object missing key \"kind\"")
+	}
+	if _, ok := errObj["message"]; !ok {
+		t.Error("error object missing key \"message\"")
 	}
 }
 
+// TestStatusTool_ErrorMessageExactStrings asserts that every failure site
+// emits the exact message string the tool produced before this change (AC-2
+// message invariant).
+func TestStatusTool_ErrorMessageExactStrings(t *testing.T) {
+	t.Parallel()
+
+	t.Run("missing_file_message", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		tool := New(dir)
+		m := executeFailure(t, tool)
+		errObj := assertFailureEnvelope(t, m, "state_unavailable")
+		msg, _ := errObj["message"].(string)
+		want := "state file unavailable: "
+		if len(msg) < len(want) || msg[:len(want)] != want {
+			t.Errorf("error.message = %q, want prefix %q", msg, want)
+		}
+	})
+
+	t.Run("malformed_json_message", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		dotSortie := filepath.Join(dir, ".sortie")
+		if err := os.MkdirAll(dotSortie, 0o750); err != nil {
+			t.Fatalf("MkdirAll: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(dotSortie, "state.json"), []byte(`{bad`), 0o600); err != nil {
+			t.Fatalf("WriteFile: %v", err)
+		}
+		tool := New(dir)
+		m := executeFailure(t, tool)
+		errObj := assertFailureEnvelope(t, m, "state_malformed")
+		msg, _ := errObj["message"].(string)
+		want := "state file malformed: "
+		if len(msg) < len(want) || msg[:len(want)] != want {
+			t.Errorf("error.message = %q, want prefix %q", msg, want)
+		}
+	})
+
+	t.Run("oversized_message", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		dotSortie := filepath.Join(dir, ".sortie")
+		if err := os.MkdirAll(dotSortie, 0o750); err != nil {
+			t.Fatalf("MkdirAll: %v", err)
+		}
+		bigContent := make([]byte, maxStateFileBytes+1)
+		if err := os.WriteFile(filepath.Join(dotSortie, "state.json"), bigContent, 0o600); err != nil {
+			t.Fatalf("WriteFile: %v", err)
+		}
+		tool := New(dir)
+		m := executeFailure(t, tool)
+		errObj := assertFailureEnvelope(t, m, "state_unavailable")
+		msg, _ := errObj["message"].(string)
+		if msg != "state file exceeds size limit" {
+			t.Errorf("error.message = %q, want %q", msg, "state file exceeds size limit")
+		}
+	})
+
+	t.Run("invalid_started_at_message", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		dotSortie := filepath.Join(dir, ".sortie")
+		if err := os.MkdirAll(dotSortie, 0o750); err != nil {
+			t.Fatalf("MkdirAll: %v", err)
+		}
+		state := []byte(`{"turn_number":1,"max_turns":10,"started_at":"not-valid"}`)
+		if err := os.WriteFile(filepath.Join(dotSortie, "state.json"), state, 0o600); err != nil {
+			t.Fatalf("WriteFile: %v", err)
+		}
+		tool := New(dir)
+		m := executeFailure(t, tool)
+		errObj := assertFailureEnvelope(t, m, "state_malformed")
+		msg, _ := errObj["message"].(string)
+		want := "state file has invalid started_at: "
+		if len(msg) < len(want) || msg[:len(want)] != want {
+			t.Errorf("error.message = %q, want prefix %q", msg, want)
+		}
+	})
+}
+
+// TestStatusTool_EmptyJSONInput asserts that {} input with a valid state file
+// succeeds and data carries turn_number (AC-1, AC-5).
 func TestStatusTool_EmptyJSONInput(t *testing.T) {
 	t.Parallel()
 
@@ -270,14 +543,17 @@ func TestStatusTool_EmptyJSONInput(t *testing.T) {
 	if err := json.Unmarshal(out, &m); err != nil {
 		t.Fatalf("unmarshal response %q: %v", out, err)
 	}
-	if _, hasErr := m["error"]; hasErr {
-		t.Errorf("response = %v, want no 'error' key for empty JSON input", m)
-	}
-	if _, ok := m["turn_number"]; !ok {
-		t.Error("turn_number missing from success response")
+
+	assertSuccessEnvelope(t, m)
+	d := dataFields(t, m)
+
+	if _, ok := d["turn_number"]; !ok {
+		t.Error("data.turn_number missing from success response")
 	}
 }
 
+// TestStatusTool_NullInput asserts that null input with a valid state file
+// succeeds and data carries turn_number (AC-1, AC-5).
 func TestStatusTool_NullInput(t *testing.T) {
 	t.Parallel()
 
@@ -297,10 +573,11 @@ func TestStatusTool_NullInput(t *testing.T) {
 	if err := json.Unmarshal(out, &m); err != nil {
 		t.Fatalf("unmarshal response %q: %v", out, err)
 	}
-	if _, hasErr := m["error"]; hasErr {
-		t.Errorf("response = %v, want no 'error' key for null input", m)
-	}
-	if _, ok := m["turn_number"]; !ok {
-		t.Error("turn_number missing from success response")
+
+	assertSuccessEnvelope(t, m)
+	d := dataFields(t, m)
+
+	if _, ok := d["turn_number"]; !ok {
+		t.Error("data.turn_number missing from success response")
 	}
 }

--- a/internal/tool/toolresult/toolresult.go
+++ b/internal/tool/toolresult/toolresult.go
@@ -1,0 +1,34 @@
+// Package toolresult marshals the uniform result envelope every built-in
+// tool returns. On success a tool returns {"success": true, "data": ...};
+// on a domain failure it returns
+// {"success": false, "error": {"kind": "...", "message": "..."}}. Both
+// marshalers are pure and safe for concurrent use; the non-nil Go error is
+// reserved for an internal marshal failure.
+package toolresult
+
+import "encoding/json"
+
+// Success marshals the success envelope {"success": true, "data": data}.
+//
+// It returns a non-nil error only when data fails to marshal.
+func Success(data any) (json.RawMessage, error) {
+	return json.Marshal(map[string]any{
+		"success": true,
+		"data":    data,
+	})
+}
+
+// Failure marshals the failure envelope
+// {"success": false, "error": {"kind": kind, "message": message}}.
+//
+// It returns a non-nil error only on an internal marshal failure, which
+// cannot occur for string inputs.
+func Failure(kind, message string) (json.RawMessage, error) {
+	return json.Marshal(map[string]any{
+		"success": false,
+		"error": map[string]string{
+			"kind":    kind,
+			"message": message,
+		},
+	})
+}

--- a/internal/tool/toolresult/toolresult_test.go
+++ b/internal/tool/toolresult/toolresult_test.go
@@ -243,21 +243,8 @@ func TestSuccess_ByteShapeMatchesPriorSuccessResult(t *testing.T) {
 		t.Fatalf("marshal want: %v", err)
 	}
 
-	var gotM, wantM map[string]any
-	if err := json.Unmarshal(got, &gotM); err != nil {
-		t.Fatalf("unmarshal got: %v", err)
-	}
-	if err := json.Unmarshal(want, &wantM); err != nil {
-		t.Fatalf("unmarshal want: %v", err)
-	}
-
-	gotData, _ := json.Marshal(gotM["data"])
-	wantData, _ := json.Marshal(wantM["data"])
-	if string(gotData) != string(wantData) {
-		t.Errorf("Success(payload) data = %s, want %s", gotData, wantData)
-	}
-	if gotM["success"] != wantM["success"] {
-		t.Errorf("Success(payload) success = %v, want %v", gotM["success"], wantM["success"])
+	if string(got) != string(want) {
+		t.Errorf("Success(payload) = %s, want %s", got, want)
 	}
 }
 
@@ -302,21 +289,8 @@ func TestFailure_ByteShapeMatchesPriorErrorResult(t *testing.T) {
 				t.Fatalf("marshal want: %v", err)
 			}
 
-			var gotM, wantM map[string]any
-			if err := json.Unmarshal(got, &gotM); err != nil {
-				t.Fatalf("unmarshal got: %v", err)
-			}
-			if err := json.Unmarshal(want, &wantM); err != nil {
-				t.Fatalf("unmarshal want: %v", err)
-			}
-
-			if gotM["success"] != wantM["success"] {
-				t.Errorf("Failure success = %v, want %v", gotM["success"], wantM["success"])
-			}
-			gotErr, _ := json.Marshal(gotM["error"])
-			wantErr, _ := json.Marshal(wantM["error"])
-			if string(gotErr) != string(wantErr) {
-				t.Errorf("Failure(%q, %q) error = %s, want %s", tt.kind, tt.message, gotErr, wantErr)
+			if string(got) != string(want) {
+				t.Errorf("Failure(%q, %q) = %s, want %s", tt.kind, tt.message, got, want)
 			}
 		})
 	}

--- a/internal/tool/toolresult/toolresult_test.go
+++ b/internal/tool/toolresult/toolresult_test.go
@@ -222,6 +222,19 @@ func TestFailure_GoErrorNilForStringInputs(t *testing.T) {
 	}
 }
 
+// TestSuccess_GoErrorOnUnmarshalablePayload asserts that Success returns a
+// non-nil Go error when given a payload that encoding/json cannot marshal,
+// and does not panic.
+func TestSuccess_GoErrorOnUnmarshalablePayload(t *testing.T) {
+	t.Parallel()
+
+	_, err := Success(func() {})
+
+	if err == nil {
+		t.Errorf("Success(func(){}) Go error = nil, want non-nil marshal error")
+	}
+}
+
 // TestSuccess_ByteShapeMatchesPriorSuccessResult asserts that Success(payload)
 // produces identical bytes to the historic per-tool successResult pattern
 // ({"success": true, "data": payload}) for a representative payload.

--- a/internal/tool/toolresult/toolresult_test.go
+++ b/internal/tool/toolresult/toolresult_test.go
@@ -1,0 +1,331 @@
+package toolresult
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// decodeTop unmarshals raw into a map of raw JSON values keyed by field name.
+func decodeTop(t *testing.T, raw json.RawMessage) map[string]json.RawMessage {
+	t.Helper()
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &m); err != nil {
+		t.Fatalf("decodeTop: unmarshal %q: %v", raw, err)
+	}
+	return m
+}
+
+// decodeBool unmarshals a JSON boolean.
+func decodeBool(t *testing.T, raw json.RawMessage) bool {
+	t.Helper()
+	var v bool
+	if err := json.Unmarshal(raw, &v); err != nil {
+		t.Fatalf("decodeBool: %v (raw=%q)", err, raw)
+	}
+	return v
+}
+
+// decodeString unmarshals a JSON string.
+func decodeString(t *testing.T, raw json.RawMessage) string {
+	t.Helper()
+	var v string
+	if err := json.Unmarshal(raw, &v); err != nil {
+		t.Fatalf("decodeString: %v (raw=%q)", err, raw)
+	}
+	return v
+}
+
+// TestSuccess_TopLevelShape asserts that Success produces an object whose
+// top-level keys are exactly {success, data} with success == true.
+func TestSuccess_TopLevelShape(t *testing.T) {
+	t.Parallel()
+
+	payload := map[string]any{"foo": "bar", "n": 42}
+
+	raw, err := Success(payload)
+	if err != nil {
+		t.Fatalf("Success(payload) Go error = %v, want nil", err)
+	}
+
+	top := decodeTop(t, raw)
+
+	if len(top) != 2 {
+		t.Errorf("Success top-level keys = %v, want exactly {success, data}", keysOf(top))
+	}
+	if _, ok := top["success"]; !ok {
+		t.Error("Success result missing key \"success\"")
+	}
+	if _, ok := top["data"]; !ok {
+		t.Error("Success result missing key \"data\"")
+	}
+	if !decodeBool(t, top["success"]) {
+		t.Errorf("Success result[\"success\"] = false, want true")
+	}
+}
+
+// TestSuccess_DataCarriesPayload asserts that the value under data equals the
+// supplied payload.
+func TestSuccess_DataCarriesPayload(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		payload any
+	}{
+		{"string value", "hello"},
+		{"int value", 42},
+		{"bool value", true},
+		{"nil value", nil},
+		{"object", map[string]any{"a": 1, "b": "two"}},
+		{"array", []int{1, 2, 3}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			raw, err := Success(tt.payload)
+			if err != nil {
+				t.Fatalf("Success(%v) Go error = %v, want nil", tt.payload, err)
+			}
+
+			top := decodeTop(t, raw)
+			wantData, _ := json.Marshal(tt.payload)
+			if string(top["data"]) != string(wantData) {
+				t.Errorf("Success(%v) data = %s, want %s", tt.payload, top["data"], wantData)
+			}
+		})
+	}
+}
+
+// TestSuccess_GoErrorNilForJSONSafeInputs asserts that JSON-safe payloads
+// never produce a non-nil Go error.
+func TestSuccess_GoErrorNilForJSONSafeInputs(t *testing.T) {
+	t.Parallel()
+
+	inputs := []any{
+		nil,
+		"",
+		0,
+		true,
+		map[string]any{},
+		[]any{},
+		map[string]any{"turn_number": 3, "max_turns": 20, "turns_remaining": 17},
+	}
+
+	for _, in := range inputs {
+		_, err := Success(in)
+		if err != nil {
+			t.Errorf("Success(%T) Go error = %v, want nil", in, err)
+		}
+	}
+}
+
+// TestFailure_TopLevelShape asserts that Failure produces an object whose
+// top-level keys are exactly {success, error} with success == false, and that
+// error carries {kind, message}.
+func TestFailure_TopLevelShape(t *testing.T) {
+	t.Parallel()
+
+	raw, err := Failure("state_unavailable", "state file is a symlink")
+	if err != nil {
+		t.Fatalf("Failure(kind, msg) Go error = %v, want nil", err)
+	}
+
+	top := decodeTop(t, raw)
+
+	if len(top) != 2 {
+		t.Errorf("Failure top-level keys = %v, want exactly {success, error}", keysOf(top))
+	}
+	if _, ok := top["success"]; !ok {
+		t.Error("Failure result missing key \"success\"")
+	}
+	if _, ok := top["error"]; !ok {
+		t.Error("Failure result missing key \"error\"")
+	}
+	if decodeBool(t, top["success"]) {
+		t.Errorf("Failure result[\"success\"] = true, want false")
+	}
+
+	errFields := decodeTop(t, top["error"])
+	if len(errFields) != 2 {
+		t.Errorf("Failure error keys = %v, want exactly {kind, message}", keysOf(errFields))
+	}
+	if _, ok := errFields["kind"]; !ok {
+		t.Error("Failure error object missing key \"kind\"")
+	}
+	if _, ok := errFields["message"]; !ok {
+		t.Error("Failure error object missing key \"message\"")
+	}
+}
+
+// TestFailure_KindAndMessagePreserved asserts that the kind and message are
+// propagated verbatim.
+func TestFailure_KindAndMessagePreserved(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		kind    string
+		message string
+	}{
+		{"state_unavailable", "state_unavailable", "state file unavailable: no such file or directory"},
+		{"state_unavailable symlink", "state_unavailable", "state file is a symlink"},
+		{"state_unavailable oversized", "state_unavailable", "state file exceeds size limit"},
+		{"state_malformed", "state_malformed", "state file malformed: unexpected end of JSON input"},
+		{"state_malformed started_at", "state_malformed", "state file has invalid started_at: parsing time ..."},
+		{"query_failed", "query_failed", "database is locked"},
+		{"send_failed", "send_failed", "notification delivery failed: connection failure"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			raw, goErr := Failure(tt.kind, tt.message)
+			if goErr != nil {
+				t.Fatalf("Failure(%q, %q) Go error = %v, want nil", tt.kind, tt.message, goErr)
+			}
+
+			top := decodeTop(t, raw)
+			errFields := decodeTop(t, top["error"])
+
+			if got := decodeString(t, errFields["kind"]); got != tt.kind {
+				t.Errorf("Failure(%q, ...) error.kind = %q, want %q", tt.kind, got, tt.kind)
+			}
+			if got := decodeString(t, errFields["message"]); got != tt.message {
+				t.Errorf("Failure(%q, %q) error.message = %q, want %q", tt.kind, tt.message, got, tt.message)
+			}
+		})
+	}
+}
+
+// TestFailure_GoErrorNilForStringInputs asserts that string-only inputs never
+// produce a non-nil Go error (strings are always JSON-safe).
+func TestFailure_GoErrorNilForStringInputs(t *testing.T) {
+	t.Parallel()
+
+	pairs := [][2]string{
+		{"query_failed", "database is locked"},
+		{"state_unavailable", "state file unavailable: open /x: permission denied"},
+		{"state_malformed", "state file malformed: unexpected EOF"},
+		{"send_failed", "notification delivery failed: timeout"},
+		{"", ""},
+	}
+
+	for _, p := range pairs {
+		_, err := Failure(p[0], p[1])
+		if err != nil {
+			t.Errorf("Failure(%q, %q) Go error = %v, want nil", p[0], p[1], err)
+		}
+	}
+}
+
+// TestSuccess_ByteShapeMatchesPriorSuccessResult asserts that Success(payload)
+// produces identical bytes to the historic per-tool successResult pattern
+// ({"success": true, "data": payload}) for a representative payload.
+// This guards AC-4a: the shared helper is byte-compatible with tracker_api's
+// former local helper.
+func TestSuccess_ByteShapeMatchesPriorSuccessResult(t *testing.T) {
+	t.Parallel()
+
+	payload := map[string]any{"transitioned": true}
+
+	got, err := Success(payload)
+	if err != nil {
+		t.Fatalf("Success(payload) error = %v", err)
+	}
+
+	// Reconstruct what tracker_api's former successResult produced.
+	want, err := json.Marshal(map[string]any{"success": true, "data": payload})
+	if err != nil {
+		t.Fatalf("marshal want: %v", err)
+	}
+
+	var gotM, wantM map[string]any
+	if err := json.Unmarshal(got, &gotM); err != nil {
+		t.Fatalf("unmarshal got: %v", err)
+	}
+	if err := json.Unmarshal(want, &wantM); err != nil {
+		t.Fatalf("unmarshal want: %v", err)
+	}
+
+	gotData, _ := json.Marshal(gotM["data"])
+	wantData, _ := json.Marshal(wantM["data"])
+	if string(gotData) != string(wantData) {
+		t.Errorf("Success(payload) data = %s, want %s", gotData, wantData)
+	}
+	if gotM["success"] != wantM["success"] {
+		t.Errorf("Success(payload) success = %v, want %v", gotM["success"], wantM["success"])
+	}
+}
+
+// TestFailure_ByteShapeMatchesPriorErrorResult asserts that Failure(kind, msg)
+// produces identical bytes to the historic per-tool errorResult pattern
+// ({"success": false, "error": {"kind": ..., "message": ...}}) for a
+// representative set of inputs.
+// This guards AC-4a: the shared helper is byte-compatible with the former
+// Tier 2 local errorResult helpers.
+func TestFailure_ByteShapeMatchesPriorErrorResult(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		kind    string
+		message string
+	}{
+		{"invalid_input", "failed to parse input: unexpected EOF"},
+		{"rate_limited", "per-session notification cap reached"},
+		{"send_failed", "notification delivery failed: connection failure"},
+		{"tracker_not_found", "issue not found"},
+		{"internal_error", "unexpected nil"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.kind, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := Failure(tt.kind, tt.message)
+			if err != nil {
+				t.Fatalf("Failure(%q, %q) error = %v", tt.kind, tt.message, err)
+			}
+
+			// Reconstruct what the former per-tool errorResult produced.
+			want, err := json.Marshal(map[string]any{
+				"success": false,
+				"error": map[string]string{
+					"kind":    tt.kind,
+					"message": tt.message,
+				},
+			})
+			if err != nil {
+				t.Fatalf("marshal want: %v", err)
+			}
+
+			var gotM, wantM map[string]any
+			if err := json.Unmarshal(got, &gotM); err != nil {
+				t.Fatalf("unmarshal got: %v", err)
+			}
+			if err := json.Unmarshal(want, &wantM); err != nil {
+				t.Fatalf("unmarshal want: %v", err)
+			}
+
+			if gotM["success"] != wantM["success"] {
+				t.Errorf("Failure success = %v, want %v", gotM["success"], wantM["success"])
+			}
+			gotErr, _ := json.Marshal(gotM["error"])
+			wantErr, _ := json.Marshal(wantM["error"])
+			if string(gotErr) != string(wantErr) {
+				t.Errorf("Failure(%q, %q) error = %s, want %s", tt.kind, tt.message, gotErr, wantErr)
+			}
+		})
+	}
+}
+
+// keysOf returns the keys of a map[string]json.RawMessage as a sorted slice.
+func keysOf(m map[string]json.RawMessage) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return keys
+}

--- a/internal/tool/toolresult/toolresult_test.go
+++ b/internal/tool/toolresult/toolresult_test.go
@@ -2,6 +2,7 @@ package toolresult
 
 import (
 	"encoding/json"
+	"sort"
 	"testing"
 )
 
@@ -327,5 +328,6 @@ func keysOf(m map[string]json.RawMessage) []string {
 	for k := range m {
 		keys = append(keys, k)
 	}
+	sort.Strings(keys)
 	return keys
 }

--- a/internal/tool/trackerapi/trackerapi.go
+++ b/internal/tool/trackerapi/trackerapi.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 
 	"github.com/sortie-ai/sortie/internal/domain"
+	"github.com/sortie-ai/sortie/internal/tool/toolresult"
 )
 
 // Compile-time interface check.
@@ -96,26 +97,26 @@ func (t *TrackerAPITool) Execute(ctx context.Context, input json.RawMessage) (js
 	dec := json.NewDecoder(bytes.NewReader(input))
 	dec.DisallowUnknownFields()
 	if err := dec.Decode(&in); err != nil {
-		return errorResult("invalid_input", fmt.Sprintf("failed to parse input: %s", err)), nil
+		return toolresult.Failure("invalid_input", fmt.Sprintf("failed to parse input: %s", err))
 	}
 	if dec.More() {
-		return errorResult("invalid_input", "unexpected trailing content after JSON object"), nil
+		return toolresult.Failure("invalid_input", "unexpected trailing content after JSON object")
 	}
 
 	if in.Operation == "" {
-		return errorResult("invalid_input", "operation is required"), nil
+		return toolresult.Failure("invalid_input", "operation is required")
 	}
 
 	switch in.Operation {
 	case "fetch_issue":
 		if in.IssueID == "" {
-			return errorResult("invalid_input", "issue_id is required for fetch_issue"), nil
+			return toolresult.Failure("invalid_input", "issue_id is required for fetch_issue")
 		}
 		return t.fetchIssue(ctx, in.IssueID)
 
 	case "fetch_comments":
 		if in.IssueID == "" {
-			return errorResult("invalid_input", "issue_id is required for fetch_comments"), nil
+			return toolresult.Failure("invalid_input", "issue_id is required for fetch_comments")
 		}
 		return t.fetchComments(ctx, in.IssueID)
 
@@ -124,47 +125,47 @@ func (t *TrackerAPITool) Execute(ctx context.Context, input json.RawMessage) (js
 
 	case "transition_issue":
 		if in.IssueID == "" {
-			return errorResult("invalid_input", "issue_id is required for transition_issue"), nil
+			return toolresult.Failure("invalid_input", "issue_id is required for transition_issue")
 		}
 		if in.TargetState == "" {
-			return errorResult("invalid_input", "target_state is required for transition_issue"), nil
+			return toolresult.Failure("invalid_input", "target_state is required for transition_issue")
 		}
 		return t.transitionIssue(ctx, in.IssueID, in.TargetState)
 
 	default:
-		return errorResult("unsupported_operation", fmt.Sprintf("unknown operation: %s", in.Operation)), nil
+		return toolresult.Failure("unsupported_operation", fmt.Sprintf("unknown operation: %s", in.Operation))
 	}
 }
 
 func (t *TrackerAPITool) fetchIssue(ctx context.Context, issueID string) (json.RawMessage, error) {
 	issue, err := t.adapter.FetchIssueByID(ctx, issueID)
 	if err != nil {
-		return mapTrackerError(err), nil
+		return mapTrackerError(err)
 	}
 
 	if !t.isInProject(issue.Identifier) {
-		return errorResult("project_scope_violation",
-			fmt.Sprintf("issue %s is not in project %s", issue.Identifier, t.project)), nil
+		return toolresult.Failure("project_scope_violation",
+			fmt.Sprintf("issue %s is not in project %s", issue.Identifier, t.project))
 	}
 
-	return successResult(issue.ToTemplateMap()), nil
+	return toolresult.Success(issue.ToTemplateMap())
 }
 
 func (t *TrackerAPITool) fetchComments(ctx context.Context, issueID string) (json.RawMessage, error) {
 	// Fetch issue first for project scope validation (defense-in-depth).
 	issue, err := t.adapter.FetchIssueByID(ctx, issueID)
 	if err != nil {
-		return mapTrackerError(err), nil
+		return mapTrackerError(err)
 	}
 
 	if !t.isInProject(issue.Identifier) {
-		return errorResult("project_scope_violation",
-			fmt.Sprintf("issue %s is not in project %s", issue.Identifier, t.project)), nil
+		return toolresult.Failure("project_scope_violation",
+			fmt.Sprintf("issue %s is not in project %s", issue.Identifier, t.project))
 	}
 
 	comments, err := t.adapter.FetchIssueComments(ctx, issueID)
 	if err != nil {
-		return mapTrackerError(err), nil
+		return mapTrackerError(err)
 	}
 
 	commentMaps := make([]map[string]any, len(comments))
@@ -177,13 +178,13 @@ func (t *TrackerAPITool) fetchComments(ctx context.Context, issueID string) (jso
 		}
 	}
 
-	return successResult(commentMaps), nil
+	return toolresult.Success(commentMaps)
 }
 
 func (t *TrackerAPITool) searchIssues(ctx context.Context) (json.RawMessage, error) {
 	issues, err := t.adapter.FetchCandidateIssues(ctx)
 	if err != nil {
-		return mapTrackerError(err), nil
+		return mapTrackerError(err)
 	}
 
 	issueMaps := make([]map[string]any, len(issues))
@@ -191,26 +192,26 @@ func (t *TrackerAPITool) searchIssues(ctx context.Context) (json.RawMessage, err
 		issueMaps[i] = issues[i].ToTemplateMap()
 	}
 
-	return successResult(issueMaps), nil
+	return toolresult.Success(issueMaps)
 }
 
 func (t *TrackerAPITool) transitionIssue(ctx context.Context, issueID, targetState string) (json.RawMessage, error) {
 	// Fetch issue first for project scope validation (defense-in-depth).
 	issue, err := t.adapter.FetchIssueByID(ctx, issueID)
 	if err != nil {
-		return mapTrackerError(err), nil
+		return mapTrackerError(err)
 	}
 
 	if !t.isInProject(issue.Identifier) {
-		return errorResult("project_scope_violation",
-			fmt.Sprintf("issue %s is not in project %s", issue.Identifier, t.project)), nil
+		return toolresult.Failure("project_scope_violation",
+			fmt.Sprintf("issue %s is not in project %s", issue.Identifier, t.project))
 	}
 
 	if err := t.adapter.TransitionIssue(ctx, issueID, targetState); err != nil {
-		return mapTrackerError(err), nil
+		return mapTrackerError(err)
 	}
 
-	return successResult(map[string]any{"transitioned": true}), nil
+	return toolresult.Success(map[string]any{"transitioned": true})
 }
 
 // isInProject is a defense-in-depth check using identifier prefix.
@@ -239,52 +240,23 @@ func (t *TrackerAPITool) isInProject(identifier string) bool {
 	return strings.EqualFold(prefix, t.project)
 }
 
-// mapTrackerError converts a tracker error into a structured JSON
-// error response. Context cancellation and deadline exceeded are
-// mapped to tracker_transport_error. TrackerError kinds map directly.
-// Unknown errors become internal_error.
-func mapTrackerError(err error) json.RawMessage {
+// mapTrackerError converts a tracker error into the failure envelope.
+// Context cancellation and deadline exceeded are mapped to
+// tracker_transport_error. TrackerError kinds map directly. Unknown
+// errors become internal_error. The Go error return is reserved for an
+// internal marshal failure.
+func mapTrackerError(err error) (json.RawMessage, error) {
 	if errors.Is(err, context.Canceled) {
-		return errorResult("tracker_transport_error", "request canceled")
+		return toolresult.Failure("tracker_transport_error", "request canceled")
 	}
 	if errors.Is(err, context.DeadlineExceeded) {
-		return errorResult("tracker_transport_error", "deadline exceeded")
+		return toolresult.Failure("tracker_transport_error", "deadline exceeded")
 	}
 
 	var te *domain.TrackerError
 	if errors.As(err, &te) {
-		return errorResult(string(te.Kind), te.Message)
+		return toolresult.Failure(string(te.Kind), te.Message)
 	}
 
-	return errorResult("internal_error", "an unexpected internal error occurred")
-}
-
-// successResult marshals a success response envelope. Panics on
-// marshal failure (programming error — only called with JSON-safe
-// map values).
-func successResult(data any) json.RawMessage {
-	raw, err := json.Marshal(map[string]any{
-		"success": true,
-		"data":    data,
-	})
-	if err != nil {
-		panic(fmt.Sprintf("trackerapi: marshal success result: %v", err))
-	}
-	return raw
-}
-
-// errorResult marshals an error response envelope. Panics on marshal
-// failure (should never happen with string inputs).
-func errorResult(kind, message string) json.RawMessage {
-	raw, err := json.Marshal(map[string]any{
-		"success": false,
-		"error": map[string]string{
-			"kind":    kind,
-			"message": message,
-		},
-	})
-	if err != nil {
-		panic(fmt.Sprintf("trackerapi: marshal error result: %v", err))
-	}
-	return raw
+	return toolresult.Failure("internal_error", "an unexpected internal error occurred")
 }

--- a/internal/tool/trackerapi/trackerapi_test.go
+++ b/internal/tool/trackerapi/trackerapi_test.go
@@ -3,7 +3,6 @@ package trackerapi
 import (
 	"context"
 	"encoding/json"
-	"math"
 	"strings"
 	"testing"
 
@@ -643,25 +642,4 @@ func TestTrailingJSONContent(t *testing.T) {
 	}
 	assertErrorKind(t, result, "invalid_input")
 	assertErrorContains(t, result, "trailing")
-}
-
-func TestSuccessResultPanicsOnUnmarshalable(t *testing.T) {
-	t.Parallel()
-
-	defer func() {
-		r := recover()
-		if r == nil {
-			t.Fatal("successResult did not panic on unmarshalable input")
-		}
-		msg, ok := r.(string)
-		if !ok {
-			t.Fatalf("panic value type = %T, want string", r)
-		}
-		if !strings.Contains(msg, "marshal success result") {
-			t.Errorf("panic message = %q, want it to contain %q", msg, "marshal success result")
-		}
-	}()
-
-	// math.Inf produces a float64 value that json.Marshal cannot encode.
-	successResult(math.Inf(1))
 }


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Fix

**Intent:** All five built-in agent tools now return the same `{"success": true, "data": ...}` / `{"success": false, "error": {"kind": "...", "message": "..."}}` envelope, matching what the first-turn tool advertisement tells agents to expect. Previously the Tier 1 tools returned bare payloads on success and `{"error": "<msg>"}` on failure, while only `tracker_api` followed the documented shape.

**Related Issues:** #567

### 🧭 Reviewer Guide

**Complexity:** Medium

#### Entry Point

`internal/tool/toolresult/toolresult.go` - new shared package that owns both envelope marshalers (`Success` and `Failure`). Every built-in tool now delegates to these two helpers, so the envelope bytes are identical at the top level across all tools. Start here to understand the shape, then check each tool file to see how per-tool private marshaling functions were removed.

#### Sensitive Areas

- `internal/tool/trackerapi/trackerapi.go`: `mapTrackerError` previously returned `json.RawMessage` (nil Go error); it now returns `(json.RawMessage, error)` to propagate an internal marshal failure from `toolresult.Failure`. Callers in the same file were updated accordingly.
- `internal/tool/notify/notify.go`: the success payload was previously returned with `delivered` and `notification_id` at the top level alongside `success: true`; it is now nested under `data`, matching the envelope contract.
- `docs/architecture.md`: Section 10.4.2 and Section 10.4.5 were revised to define the now-uniform envelope and the closed `error.kind` sets per tier.

### ⚠️ Risk Assessment

- **Breaking Changes:** Yes - agents that parsed `sortie_status` or `workspace_history` success responses by reading fields at the top level must now read them under `data`. The `notify_operator` `delivered` and `notification_id` fields also moved under `data`.
- **Migrations/State:** No migrations or state changes.