### PR TITLE
feat: implement Linear tracker adapter write path

### DIFF
--- a/internal/tracker/linear/integration_test.go
+++ b/internal/tracker/linear/integration_test.go
@@ -21,6 +21,18 @@ func skipUnlessIntegration(t *testing.T) {
 	}
 }
 
+// skipUnlessWriteIntegration skips the current test unless both the read
+// integration gate (SORTIE_LINEAR_TEST=1) and the write opt-in
+// (SORTIE_LINEAR_WRITE_TEST=1) are set, so a default run reads but never
+// mutates the live workspace.
+func skipUnlessWriteIntegration(t *testing.T) {
+	t.Helper()
+	skipUnlessIntegration(t)
+	if os.Getenv("SORTIE_LINEAR_WRITE_TEST") != "1" {
+		t.Skip("skipping Linear write integration test: set SORTIE_LINEAR_WRITE_TEST=1 to enable")
+	}
+}
+
 // requireEnv reads an environment variable and fails the test when empty.
 func requireEnv(t *testing.T, key string) string {
 	t.Helper()
@@ -249,5 +261,70 @@ func TestIntegration_FetchIssueComments(t *testing.T) {
 			t.Errorf("comments not in ascending createdAt order at index %d: %q before %q",
 				i, comments[i-1].CreatedAt, comments[i].CreatedAt)
 		}
+	}
+}
+
+// firstCandidate returns the first candidate issue or skips when the team has
+// none, so a write test has a real issue to act on without mutating ordering.
+func firstCandidate(t *testing.T, adapter domain.TrackerAdapter, ctx context.Context) domain.Issue {
+	t.Helper()
+	candidates, err := adapter.FetchCandidateIssues(ctx)
+	if err != nil {
+		t.Fatalf("FetchCandidateIssues: %v", err)
+	}
+	if len(candidates) == 0 {
+		t.Skip("no candidate issues in team; cannot run write test")
+	}
+	return candidates[0]
+}
+
+func TestIntegration_TransitionIssue(t *testing.T) {
+	skipUnlessWriteIntegration(t)
+
+	adapter := newIntegrationAdapter(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	issue := firstCandidate(t, adapter, ctx)
+
+	if err := adapter.TransitionIssue(ctx, issue.Identifier, issue.State); err != nil {
+		t.Fatalf("TransitionIssue(%s, %q): %v", issue.Identifier, issue.State, err)
+	}
+}
+
+func TestIntegration_CommentIssue(t *testing.T) {
+	skipUnlessWriteIntegration(t)
+
+	adapter := newIntegrationAdapter(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	issue := firstCandidate(t, adapter, ctx)
+
+	body := "sortie write-path integration test comment at " + time.Now().UTC().Format(time.RFC3339)
+	if err := adapter.CommentIssue(ctx, issue.Identifier, body); err != nil {
+		t.Fatalf("CommentIssue(%s): %v", issue.Identifier, err)
+	}
+}
+
+func TestIntegration_AddLabel(t *testing.T) {
+	skipUnlessWriteIntegration(t)
+
+	adapter := newIntegrationAdapter(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	issue := firstCandidate(t, adapter, ctx)
+
+	label := os.Getenv("SORTIE_LINEAR_WRITE_LABEL")
+	if label == "" {
+		label = "needs-human"
+	}
+
+	if err := adapter.AddLabel(ctx, issue.Identifier, label); err != nil {
+		t.Fatalf("AddLabel(%s, %q): %v", issue.Identifier, label, err)
 	}
 }

--- a/internal/tracker/linear/linear.go
+++ b/internal/tracker/linear/linear.go
@@ -587,7 +587,7 @@ func (a *LinearAdapter) resolveLabelID(ctx context.Context, name string) (string
 	var hasWorkspace bool
 	for _, node := range resp.Data.IssueLabels.Nodes {
 		if node.Team != nil {
-			if node.Team.ID == a.project {
+			if node.Team.Key == a.project {
 				return node.ID, true, nil
 			}
 			continue
@@ -650,6 +650,12 @@ func (a *LinearAdapter) createLabel(ctx context.Context, teamID, name string) (s
 		"name":   name,
 	}, decode); err != nil {
 		return "", err
+	}
+	if labelID == "" {
+		return "", &domain.TrackerError{
+			Kind:    domain.ErrTrackerPayload,
+			Message: fmt.Sprintf("linear graphql: issueLabelCreate reported success but returned no label id for %q", name),
+		}
 	}
 	return labelID, nil
 }

--- a/internal/tracker/linear/linear.go
+++ b/internal/tracker/linear/linear.go
@@ -14,6 +14,7 @@ package linear
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strconv"
@@ -413,31 +414,263 @@ func (a *LinearAdapter) fetchStateBatch(ctx context.Context, query string, varia
 	return resp.Data.Issues.Nodes, nil
 }
 
-// TransitionIssue is a compile-satisfying stub for the read-only adapter. The
-// write path is implemented separately; this returns a typed error rather than
-// silently succeeding so a handoff transition is never falsely reported.
-func (a *LinearAdapter) TransitionIssue(_ context.Context, _, _ string) error {
-	return writePathNotImplemented("TransitionIssue")
-}
+// mutationDecoder extracts the errors array and the payload success boolean
+// from a mutation response body, returning a payload error only on JSON
+// unmarshal failure. It leaves the result policy to [runMutation].
+type mutationDecoder func(body []byte) (errs []graphQLError, success bool, err error)
 
-// CommentIssue is a compile-satisfying stub for the read-only adapter. See
-// [LinearAdapter.TransitionIssue] for the stub rationale.
-func (a *LinearAdapter) CommentIssue(_ context.Context, _, _ string) error {
-	return writePathNotImplemented("CommentIssue")
-}
-
-// AddLabel is a compile-satisfying stub for the read-only adapter. See
-// [LinearAdapter.TransitionIssue] for the stub rationale.
-func (a *LinearAdapter) AddLabel(_ context.Context, _, _ string) error {
-	return writePathNotImplemented("AddLabel")
-}
-
-// writePathNotImplemented builds the typed error returned by the write stubs.
-func writePathNotImplemented(operation string) error {
-	return &domain.TrackerError{
-		Kind:    domain.ErrTrackerPayload,
-		Message: fmt.Sprintf("linear write path not implemented: %s", operation),
+// runMutation submits a mutation and applies the per-mutation result policy. A
+// non-empty errors array is a failure regardless of the payload success value;
+// an empty errors array with success false maps to [domain.ErrTrackerAPI]. It
+// reuses the read-path transport, rate-limit recorder, and classifier, and does
+// not record metrics, so a public method that wraps it in
+// [trackermetrics.Track] emits one sample per logical write.
+func runMutation(ctx context.Context, client graphQLClient, log *slog.Logger, query string, variables map[string]any, decode mutationDecoder) error {
+	body, headers, err := client.Execute(ctx, query, variables)
+	if err != nil {
+		return err
 	}
+	recordRateLimit(headers, log)
+
+	errs, success, err := decode(body)
+	if err != nil {
+		return err
+	}
+	if classified := classifyGraphQLErrors(errs); classified != nil {
+		return classified
+	}
+	if !success {
+		return &domain.TrackerError{
+			Kind:    domain.ErrTrackerAPI,
+			Message: "linear graphql: mutation returned success: false",
+		}
+	}
+	return nil
+}
+
+// decodeIssueUpdateSuccess decodes an issueUpdate mutation response. It is
+// shared by the transition mutation and the label-attach mutation because both
+// return IssuePayload.success.
+func decodeIssueUpdateSuccess(body []byte) ([]graphQLError, bool, error) {
+	var resp graphQLResponse[issueUpdateData]
+	if err := unmarshal(body, &resp); err != nil {
+		return nil, false, err
+	}
+	return resp.Errors, resp.Data.IssueUpdate.Success, nil
+}
+
+// TransitionIssue moves an issue to the workflow state named targetState. It
+// resolves the state name to a team-scoped UUID with a case-insensitive filter,
+// then applies it; issueID and targetState are passed verbatim.
+//
+// A missing issue returns [domain.ErrTrackerNotFound]; a name that matches no
+// workflow state in the issue's team returns [domain.ErrTrackerPayload].
+func (a *LinearAdapter) TransitionIssue(ctx context.Context, issueID, targetState string) error {
+	return trackermetrics.Track(a.metrics, "transition", func() error {
+		body, headers, execErr := a.client.Execute(ctx, queryResolveStateID, map[string]any{
+			"issueId":   issueID,
+			"stateName": targetState,
+		})
+		if execErr != nil {
+			return execErr
+		}
+		recordRateLimit(headers, a.log)
+
+		var resp graphQLResponse[stateResolveData]
+		if err := unmarshal(body, &resp); err != nil {
+			return err
+		}
+		if classified := classifyGraphQLErrors(resp.Errors); classified != nil {
+			return classified
+		}
+		if resp.Data.Issue == nil {
+			return &domain.TrackerError{
+				Kind:    domain.ErrTrackerNotFound,
+				Message: fmt.Sprintf("issue not found: %s", issueID),
+			}
+		}
+		nodes := resp.Data.Issue.Team.States.Nodes
+		if len(nodes) == 0 {
+			return &domain.TrackerError{
+				Kind:    domain.ErrTrackerPayload,
+				Message: fmt.Sprintf("no workflow state named %q in the team of issue %s", targetState, issueID),
+			}
+		}
+
+		return runMutation(ctx, a.client, a.log, queryIssueUpdateState, map[string]any{
+			"id":      issueID,
+			"stateId": nodes[0].ID,
+		}, decodeIssueUpdateSuccess)
+	})
+}
+
+// CommentIssue posts text as a markdown comment on the issue. The body is sent
+// verbatim with no wrapping or escaping; issueID is passed verbatim.
+//
+// The method performs no internal retry because commentCreate is not
+// idempotent and the orchestrator owns retry policy.
+func (a *LinearAdapter) CommentIssue(ctx context.Context, issueID, text string) error {
+	return trackermetrics.Track(a.metrics, "comment", func() error {
+		return runMutation(ctx, a.client, a.log, queryCommentCreate, map[string]any{
+			"issueId": issueID,
+			"body":    text,
+		}, decodeCommentCreateSuccess)
+	})
+}
+
+// AddLabel attaches the named label to the issue, creating the label
+// team-scoped when it does not yet exist. The label is appended through
+// addedLabelIds, so the issue's other labels are preserved; label and issueID
+// are passed verbatim.
+//
+// A label-create forbidden for the key returns [domain.ErrTrackerAuth]. On any
+// payload-class create error the method re-resolves once, using a label that a
+// concurrent create produced; only a re-resolve that still finds nothing
+// surfaces the original create error.
+func (a *LinearAdapter) AddLabel(ctx context.Context, issueID, label string) error {
+	return trackermetrics.Track(a.metrics, "add_label", func() error {
+		labelID, found, err := a.resolveLabelID(ctx, label)
+		if err != nil {
+			return err
+		}
+
+		if !found {
+			teamID, teamErr := a.resolveTeamID(ctx, issueID)
+			if teamErr != nil {
+				return teamErr
+			}
+
+			created, createErr := a.createLabel(ctx, teamID, label)
+			switch {
+			case createErr == nil:
+				labelID = created
+			case isPayloadError(createErr):
+				labelID, found, err = a.resolveLabelID(ctx, label)
+				if err != nil {
+					return err
+				}
+				if !found {
+					return createErr
+				}
+			default:
+				return createErr
+			}
+		}
+
+		return runMutation(ctx, a.client, a.log, queryIssueAddLabel, map[string]any{
+			"id":       issueID,
+			"labelIds": []string{labelID},
+		}, decodeIssueUpdateSuccess)
+	})
+}
+
+// resolveLabelID resolves a label name to its UUID, preferring a label scoped
+// to the configured team over a workspace-scoped label. It reports found false
+// with a nil error when no label matches. The name is matched case-insensitively
+// and sent verbatim.
+func (a *LinearAdapter) resolveLabelID(ctx context.Context, name string) (string, bool, error) {
+	body, headers, err := a.client.Execute(ctx, queryResolveLabel, map[string]any{"name": name})
+	if err != nil {
+		return "", false, err
+	}
+	recordRateLimit(headers, a.log)
+
+	var resp graphQLResponse[labelResolveData]
+	if err := unmarshal(body, &resp); err != nil {
+		return "", false, err
+	}
+	if classified := classifyGraphQLErrors(resp.Errors); classified != nil {
+		return "", false, classified
+	}
+
+	var workspaceID string
+	var hasWorkspace bool
+	for _, node := range resp.Data.IssueLabels.Nodes {
+		if node.Team != nil {
+			if node.Team.ID == a.project {
+				return node.ID, true, nil
+			}
+			continue
+		}
+		if !hasWorkspace {
+			workspaceID = node.ID
+			hasWorkspace = true
+		}
+	}
+	if hasWorkspace {
+		return workspaceID, true, nil
+	}
+	return "", false, nil
+}
+
+// resolveTeamID resolves the UUID of the team that owns the issue. A missing
+// issue returns [domain.ErrTrackerNotFound]. issueID is passed verbatim.
+func (a *LinearAdapter) resolveTeamID(ctx context.Context, issueID string) (string, error) {
+	body, headers, err := a.client.Execute(ctx, queryResolveIssueTeam, map[string]any{"issueId": issueID})
+	if err != nil {
+		return "", err
+	}
+	recordRateLimit(headers, a.log)
+
+	var resp graphQLResponse[teamResolveData]
+	if err := unmarshal(body, &resp); err != nil {
+		return "", err
+	}
+	if classified := classifyGraphQLErrors(resp.Errors); classified != nil {
+		return "", classified
+	}
+	if resp.Data.Issue == nil {
+		return "", &domain.TrackerError{
+			Kind:    domain.ErrTrackerNotFound,
+			Message: fmt.Sprintf("issue not found: %s", issueID),
+		}
+	}
+	return resp.Data.Issue.Team.ID, nil
+}
+
+// createLabel creates a team-scoped label and returns its UUID. It always
+// passes teamId because workspace-scoped label management is more likely to
+// require elevated access. The name is sent verbatim. A forbidden create
+// surfaces as [domain.ErrTrackerAuth] through the shared classifier.
+func (a *LinearAdapter) createLabel(ctx context.Context, teamID, name string) (string, error) {
+	var labelID string
+	decode := func(body []byte) ([]graphQLError, bool, error) {
+		var resp graphQLResponse[labelCreateData]
+		if err := unmarshal(body, &resp); err != nil {
+			return nil, false, err
+		}
+		if resp.Data.IssueLabelCreate.IssueLabel != nil {
+			labelID = resp.Data.IssueLabelCreate.IssueLabel.ID
+		}
+		return resp.Errors, resp.Data.IssueLabelCreate.Success, nil
+	}
+
+	if err := runMutation(ctx, a.client, a.log, queryLabelCreate, map[string]any{
+		"teamId": teamID,
+		"name":   name,
+	}, decode); err != nil {
+		return "", err
+	}
+	return labelID, nil
+}
+
+// decodeCommentCreateSuccess decodes a commentCreate mutation response.
+func decodeCommentCreateSuccess(body []byte) ([]graphQLError, bool, error) {
+	var resp graphQLResponse[commentCreateData]
+	if err := unmarshal(body, &resp); err != nil {
+		return nil, false, err
+	}
+	return resp.Errors, resp.Data.CommentCreate.Success, nil
+}
+
+// isPayloadError reports whether err is a [*domain.TrackerError] of kind
+// [domain.ErrTrackerPayload].
+func isPayloadError(err error) bool {
+	var te *domain.TrackerError
+	if !errors.As(err, &te) {
+		return false
+	}
+	return te.Kind == domain.ErrTrackerPayload
 }
 
 // extractNumbers splits each identifier on the last hyphen and collects the

--- a/internal/tracker/linear/linear_test.go
+++ b/internal/tracker/linear/linear_test.go
@@ -762,6 +762,60 @@ func TestTransitionIssue(t *testing.T) {
 			t.Errorf("IssueUpdateState call count = %d, want 0 for a missing issue", len(calls))
 		}
 	})
+
+	t.Run("null issue with no errors on resolve is not found", func(t *testing.T) {
+		t.Parallel()
+
+		f := newFakeClient()
+		seedPreflight(f, t)
+		f.queueBody("ResolveStateID", loadFixture(t, "state_resolve_null_issue.json"))
+
+		adapter := newTestAdapter(t, f)
+
+		err := adapter.TransitionIssue(context.Background(), "SOR-999", "In Review")
+
+		assertTrackerErrorKind(t, err, domain.ErrTrackerNotFound)
+		if calls := f.callsFor("IssueUpdateState"); len(calls) != 0 {
+			t.Errorf("IssueUpdateState call count = %d, want 0 for a null issue", len(calls))
+		}
+	})
+
+	t.Run("transport error on resolve propagates and skips the mutation", func(t *testing.T) {
+		t.Parallel()
+
+		transportErr := &domain.TrackerError{Kind: domain.ErrTrackerTransport, Message: "dial tcp: timeout"}
+		f := newFakeClient()
+		seedPreflight(f, t)
+		f.queueResponse("ResolveStateID", fakeResponse{err: transportErr})
+
+		adapter := newTestAdapter(t, f)
+
+		err := adapter.TransitionIssue(context.Background(), "SOR-5", "In Review")
+
+		if !errors.Is(err, transportErr) {
+			t.Errorf("TransitionIssue resolve transport error = %v, want %v unchanged", err, transportErr)
+		}
+		if calls := f.callsFor("IssueUpdateState"); len(calls) != 0 {
+			t.Errorf("IssueUpdateState call count = %d, want 0 when the resolve fails", len(calls))
+		}
+	})
+
+	t.Run("malformed resolve body is a payload error and skips the mutation", func(t *testing.T) {
+		t.Parallel()
+
+		f := newFakeClient()
+		seedPreflight(f, t)
+		f.queueBody("ResolveStateID", []byte("{not json"))
+
+		adapter := newTestAdapter(t, f)
+
+		err := adapter.TransitionIssue(context.Background(), "SOR-5", "In Review")
+
+		assertTrackerErrorKind(t, err, domain.ErrTrackerPayload)
+		if calls := f.callsFor("IssueUpdateState"); len(calls) != 0 {
+			t.Errorf("IssueUpdateState call count = %d, want 0 when the resolve body is malformed", len(calls))
+		}
+	})
 }
 
 func TestCommentIssue(t *testing.T) {
@@ -1019,6 +1073,428 @@ func TestAddLabel(t *testing.T) {
 			t.Errorf("IssueAddLabel call count = %d, want 0 on a forbidden create", len(calls))
 		}
 	})
+
+	t.Run("create success with null label id is a payload error when re-resolve still misses", func(t *testing.T) {
+		t.Parallel()
+
+		f := newFakeClient()
+		seedPreflight(f, t)
+		f.queueBody("ResolveLabel", loadFixture(t, "label_resolve_miss.json"))
+		f.queueBody("ResolveLabel", loadFixture(t, "label_resolve_miss.json"))
+		f.queueBody("ResolveIssueTeam", loadFixture(t, "team_resolve_hit.json"))
+		f.queueBody("LabelCreate", loadFixture(t, "label_create_success_no_id.json"))
+
+		adapter := newTestAdapter(t, f)
+
+		err := adapter.AddLabel(context.Background(), "SOR-5", "needs-human")
+
+		assertTrackerErrorKind(t, err, domain.ErrTrackerPayload)
+
+		creates := f.callsFor("LabelCreate")
+		if len(creates) != 1 {
+			t.Fatalf("LabelCreate call count = %d, want 1", len(creates))
+		}
+		if resolves := f.callsFor("ResolveLabel"); len(resolves) != 2 {
+			t.Errorf("ResolveLabel call count = %d, want 2 (the empty-id payload error triggers one re-resolve)", len(resolves))
+		}
+		if calls := f.callsFor("IssueAddLabel"); len(calls) != 0 {
+			t.Errorf("IssueAddLabel call count = %d, want 0 when the create returns no id and re-resolve misses", len(calls))
+		}
+	})
+
+	t.Run("create success with null label id recovers via re-resolve and attaches the re-resolved id", func(t *testing.T) {
+		t.Parallel()
+
+		f := newFakeClient()
+		seedPreflight(f, t)
+		f.queueBody("ResolveLabel", loadFixture(t, "label_resolve_miss.json"))
+		f.queueBody("ResolveLabel", loadFixture(t, "label_resolve_hit.json"))
+		f.queueBody("ResolveIssueTeam", loadFixture(t, "team_resolve_hit.json"))
+		f.queueBody("LabelCreate", loadFixture(t, "label_create_success_no_id.json"))
+		f.queueBody("IssueAddLabel", loadFixture(t, "issue_add_label_success.json"))
+
+		adapter := newTestAdapter(t, f)
+
+		if err := adapter.AddLabel(context.Background(), "SOR-5", "needs-human"); err != nil {
+			t.Fatalf("AddLabel empty-id recovery path = %v, want nil (re-resolve recovers from the empty-id payload error)", err)
+		}
+
+		if resolves := f.callsFor("ResolveLabel"); len(resolves) != 2 {
+			t.Fatalf("ResolveLabel call count = %d, want 2 (empty-id payload error triggers one re-resolve)", len(resolves))
+		}
+
+		attaches := f.callsFor("IssueAddLabel")
+		if len(attaches) != 1 {
+			t.Fatalf("IssueAddLabel call count = %d, want 1", len(attaches))
+		}
+		labelIDs := attaches[0].variables["labelIds"].([]string)
+		want := []string{"label-team-needs-human"}
+		if !reflect.DeepEqual(labelIDs, want) {
+			t.Errorf("IssueAddLabel addedLabelIds = %v, want %v (re-resolved id after the empty-id create)", labelIDs, want)
+		}
+	})
+
+	t.Run("initial resolve transport error propagates and skips create and attach", func(t *testing.T) {
+		t.Parallel()
+
+		transportErr := &domain.TrackerError{Kind: domain.ErrTrackerTransport, Message: "dial tcp: timeout"}
+		f := newFakeClient()
+		seedPreflight(f, t)
+		f.queueResponse("ResolveLabel", fakeResponse{err: transportErr})
+
+		adapter := newTestAdapter(t, f)
+
+		err := adapter.AddLabel(context.Background(), "SOR-5", "needs-human")
+
+		if !errors.Is(err, transportErr) {
+			t.Errorf("AddLabel resolve transport error = %v, want %v unchanged", err, transportErr)
+		}
+		if calls := f.callsFor("ResolveIssueTeam"); len(calls) != 0 {
+			t.Errorf("ResolveIssueTeam call count = %d, want 0 when the initial resolve fails", len(calls))
+		}
+		if calls := f.callsFor("LabelCreate"); len(calls) != 0 {
+			t.Errorf("LabelCreate call count = %d, want 0 when the initial resolve fails", len(calls))
+		}
+		if calls := f.callsFor("IssueAddLabel"); len(calls) != 0 {
+			t.Errorf("IssueAddLabel call count = %d, want 0 when the initial resolve fails", len(calls))
+		}
+	})
+
+	t.Run("team resolve error on a missing label propagates and skips create and attach", func(t *testing.T) {
+		t.Parallel()
+
+		transportErr := &domain.TrackerError{Kind: domain.ErrTrackerTransport, Message: "dial tcp: timeout"}
+		f := newFakeClient()
+		seedPreflight(f, t)
+		f.queueBody("ResolveLabel", loadFixture(t, "label_resolve_miss.json"))
+		f.queueResponse("ResolveIssueTeam", fakeResponse{err: transportErr})
+
+		adapter := newTestAdapter(t, f)
+
+		err := adapter.AddLabel(context.Background(), "SOR-5", "needs-human")
+
+		if !errors.Is(err, transportErr) {
+			t.Errorf("AddLabel team resolve transport error = %v, want %v unchanged", err, transportErr)
+		}
+		if calls := f.callsFor("LabelCreate"); len(calls) != 0 {
+			t.Errorf("LabelCreate call count = %d, want 0 when the team resolve fails", len(calls))
+		}
+		if calls := f.callsFor("IssueAddLabel"); len(calls) != 0 {
+			t.Errorf("IssueAddLabel call count = %d, want 0 when the team resolve fails", len(calls))
+		}
+	})
+
+	t.Run("re-resolve transport error after a payload create error propagates", func(t *testing.T) {
+		t.Parallel()
+
+		transportErr := &domain.TrackerError{Kind: domain.ErrTrackerTransport, Message: "dial tcp: timeout"}
+		f := newFakeClient()
+		seedPreflight(f, t)
+		f.queueBody("ResolveLabel", loadFixture(t, "label_resolve_miss.json"))
+		f.queueResponse("ResolveLabel", fakeResponse{err: transportErr})
+		f.queueBody("ResolveIssueTeam", loadFixture(t, "team_resolve_hit.json"))
+		f.queueBody("LabelCreate", loadFixture(t, "label_create_conflict.json"))
+
+		adapter := newTestAdapter(t, f)
+
+		err := adapter.AddLabel(context.Background(), "SOR-5", "needs-human")
+
+		if !errors.Is(err, transportErr) {
+			t.Errorf("AddLabel re-resolve transport error = %v, want %v unchanged (re-resolve failure overrides the create error)", err, transportErr)
+		}
+		if resolves := f.callsFor("ResolveLabel"); len(resolves) != 2 {
+			t.Errorf("ResolveLabel call count = %d, want 2 (initial miss then failing re-resolve)", len(resolves))
+		}
+		if calls := f.callsFor("IssueAddLabel"); len(calls) != 0 {
+			t.Errorf("IssueAddLabel call count = %d, want 0 when the re-resolve fails", len(calls))
+		}
+	})
+
+	t.Run("missing label with no workspace fallback creates then attaches", func(t *testing.T) {
+		t.Parallel()
+
+		f := newFakeClient()
+		seedPreflight(f, t)
+		f.queueBody("ResolveLabel", loadFixture(t, "label_resolve_other_team.json"))
+		f.queueBody("ResolveIssueTeam", loadFixture(t, "team_resolve_hit.json"))
+		f.queueBody("LabelCreate", loadFixture(t, "label_create_success.json"))
+		f.queueBody("IssueAddLabel", loadFixture(t, "issue_add_label_success.json"))
+
+		adapter := newTestAdapter(t, f)
+
+		if err := adapter.AddLabel(context.Background(), "SOR-5", "needs-human"); err != nil {
+			t.Fatalf("AddLabel: %v", err)
+		}
+
+		if creates := f.callsFor("LabelCreate"); len(creates) != 1 {
+			t.Fatalf("LabelCreate call count = %d, want 1 (a label scoped to another team is not a match)", len(creates))
+		}
+		attaches := f.callsFor("IssueAddLabel")
+		if len(attaches) != 1 {
+			t.Fatalf("IssueAddLabel call count = %d, want 1", len(attaches))
+		}
+		labelIDs := attaches[0].variables["labelIds"].([]string)
+		want := []string{"label-created-needs-human"}
+		if !reflect.DeepEqual(labelIDs, want) {
+			t.Errorf("IssueAddLabel addedLabelIds = %v, want %v (created id; the other-team label is ignored)", labelIDs, want)
+		}
+	})
+}
+
+func TestResolveTeamID(t *testing.T) {
+	t.Parallel()
+
+	t.Run("transport error from Execute is returned unchanged", func(t *testing.T) {
+		t.Parallel()
+
+		transportErr := &domain.TrackerError{Kind: domain.ErrTrackerTransport, Message: "dial tcp: timeout"}
+		f := newFakeClient()
+		seedPreflight(f, t)
+		f.queueResponse("ResolveIssueTeam", fakeResponse{err: transportErr})
+
+		adapter := newTestAdapter(t, f)
+
+		_, err := adapter.resolveTeamID(context.Background(), "SOR-5")
+
+		if !errors.Is(err, transportErr) {
+			t.Errorf("resolveTeamID transport error = %v, want %v unchanged", err, transportErr)
+		}
+	})
+
+	t.Run("malformed body is a payload error", func(t *testing.T) {
+		t.Parallel()
+
+		f := newFakeClient()
+		seedPreflight(f, t)
+		f.queueBody("ResolveIssueTeam", []byte("{not json"))
+
+		adapter := newTestAdapter(t, f)
+
+		_, err := adapter.resolveTeamID(context.Background(), "SOR-5")
+
+		assertTrackerErrorKind(t, err, domain.ErrTrackerPayload)
+	})
+
+	t.Run("graphql errors array is classified", func(t *testing.T) {
+		t.Parallel()
+
+		f := newFakeClient()
+		seedPreflight(f, t)
+		f.queueBody("ResolveIssueTeam", loadFixture(t, "mutation_invalid_input.json"))
+
+		adapter := newTestAdapter(t, f)
+
+		_, err := adapter.resolveTeamID(context.Background(), "SOR-5")
+
+		assertTrackerErrorKind(t, err, domain.ErrTrackerPayload)
+	})
+
+	t.Run("null issue with no errors is not found", func(t *testing.T) {
+		t.Parallel()
+
+		f := newFakeClient()
+		seedPreflight(f, t)
+		f.queueBody("ResolveIssueTeam", loadFixture(t, "team_resolve_null_issue.json"))
+
+		adapter := newTestAdapter(t, f)
+
+		_, err := adapter.resolveTeamID(context.Background(), "SOR-999")
+
+		assertTrackerErrorKind(t, err, domain.ErrTrackerNotFound)
+	})
+
+	t.Run("resolves the owning team id verbatim", func(t *testing.T) {
+		t.Parallel()
+
+		f := newFakeClient()
+		seedPreflight(f, t)
+		f.queueBody("ResolveIssueTeam", loadFixture(t, "team_resolve_hit.json"))
+
+		adapter := newTestAdapter(t, f)
+
+		teamID, err := adapter.resolveTeamID(context.Background(), "SOR-5")
+		if err != nil {
+			t.Fatalf("resolveTeamID: %v", err)
+		}
+		if teamID != "team-uuid-sor" {
+			t.Errorf("resolveTeamID = %q, want %q", teamID, "team-uuid-sor")
+		}
+		if got := f.callsFor("ResolveIssueTeam")[0].variables["issueId"]; got != "SOR-5" {
+			t.Errorf("ResolveIssueTeam issueId = %v, want %q (verbatim)", got, "SOR-5")
+		}
+	})
+}
+
+func TestResolveLabelID(t *testing.T) {
+	t.Parallel()
+
+	t.Run("transport error from Execute is returned unchanged", func(t *testing.T) {
+		t.Parallel()
+
+		transportErr := &domain.TrackerError{Kind: domain.ErrTrackerTransport, Message: "dial tcp: timeout"}
+		f := newFakeClient()
+		seedPreflight(f, t)
+		f.queueResponse("ResolveLabel", fakeResponse{err: transportErr})
+
+		adapter := newTestAdapter(t, f)
+
+		_, _, err := adapter.resolveLabelID(context.Background(), "needs-human")
+
+		if !errors.Is(err, transportErr) {
+			t.Errorf("resolveLabelID transport error = %v, want %v unchanged", err, transportErr)
+		}
+	})
+
+	t.Run("malformed body is a payload error", func(t *testing.T) {
+		t.Parallel()
+
+		f := newFakeClient()
+		seedPreflight(f, t)
+		f.queueBody("ResolveLabel", []byte("{not json"))
+
+		adapter := newTestAdapter(t, f)
+
+		_, _, err := adapter.resolveLabelID(context.Background(), "needs-human")
+
+		assertTrackerErrorKind(t, err, domain.ErrTrackerPayload)
+	})
+
+	t.Run("graphql errors array is classified", func(t *testing.T) {
+		t.Parallel()
+
+		f := newFakeClient()
+		seedPreflight(f, t)
+		f.queueBody("ResolveLabel", loadFixture(t, "mutation_auth_error.json"))
+
+		adapter := newTestAdapter(t, f)
+
+		_, _, err := adapter.resolveLabelID(context.Background(), "needs-human")
+
+		assertTrackerErrorKind(t, err, domain.ErrTrackerAuth)
+	})
+
+	t.Run("a label scoped to a different team reports not found", func(t *testing.T) {
+		t.Parallel()
+
+		f := newFakeClient()
+		seedPreflight(f, t)
+		f.queueBody("ResolveLabel", loadFixture(t, "label_resolve_other_team.json"))
+
+		adapter := newTestAdapter(t, f)
+
+		labelID, found, err := adapter.resolveLabelID(context.Background(), "needs-human")
+		if err != nil {
+			t.Fatalf("resolveLabelID: %v", err)
+		}
+		if found {
+			t.Errorf("resolveLabelID found = %v, want false (the only match belongs to another team)", found)
+		}
+		if labelID != "" {
+			t.Errorf("resolveLabelID id = %q, want empty string", labelID)
+		}
+	})
+}
+
+func TestCreateLabel(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success with no label id is a payload error", func(t *testing.T) {
+		t.Parallel()
+
+		f := newFakeClient()
+		seedPreflight(f, t)
+		f.queueBody("LabelCreate", loadFixture(t, "label_create_success_no_id.json"))
+
+		adapter := newTestAdapter(t, f)
+
+		_, err := adapter.createLabel(context.Background(), "team-uuid-sor", "needs-human")
+
+		assertTrackerErrorKind(t, err, domain.ErrTrackerPayload)
+	})
+
+	t.Run("malformed body is a payload error", func(t *testing.T) {
+		t.Parallel()
+
+		f := newFakeClient()
+		seedPreflight(f, t)
+		f.queueBody("LabelCreate", []byte("{not json"))
+
+		adapter := newTestAdapter(t, f)
+
+		_, err := adapter.createLabel(context.Background(), "team-uuid-sor", "needs-human")
+
+		assertTrackerErrorKind(t, err, domain.ErrTrackerPayload)
+	})
+
+	t.Run("success returns the created label id", func(t *testing.T) {
+		t.Parallel()
+
+		f := newFakeClient()
+		seedPreflight(f, t)
+		f.queueBody("LabelCreate", loadFixture(t, "label_create_success.json"))
+
+		adapter := newTestAdapter(t, f)
+
+		labelID, err := adapter.createLabel(context.Background(), "team-uuid-sor", "needs-human")
+		if err != nil {
+			t.Fatalf("createLabel: %v", err)
+		}
+		if labelID != "label-created-needs-human" {
+			t.Errorf("createLabel = %q, want %q", labelID, "label-created-needs-human")
+		}
+	})
+}
+
+func TestDecodeCommentCreateSuccess(t *testing.T) {
+	t.Parallel()
+
+	t.Run("malformed body is a payload error", func(t *testing.T) {
+		t.Parallel()
+
+		_, _, err := decodeCommentCreateSuccess([]byte("{not json"))
+
+		assertTrackerErrorKind(t, err, domain.ErrTrackerPayload)
+	})
+
+	t.Run("well-formed success body reports success with no error", func(t *testing.T) {
+		t.Parallel()
+
+		errs, success, err := decodeCommentCreateSuccess(loadFixture(t, "comment_create_success.json"))
+		if err != nil {
+			t.Fatalf("decodeCommentCreateSuccess: %v", err)
+		}
+		if !success {
+			t.Errorf("decodeCommentCreateSuccess success = %v, want true", success)
+		}
+		if len(errs) != 0 {
+			t.Errorf("decodeCommentCreateSuccess errs = %v, want empty", errs)
+		}
+	})
+}
+
+func TestIsPayloadError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"payload tracker error", &domain.TrackerError{Kind: domain.ErrTrackerPayload}, true},
+		{"non-payload tracker error", &domain.TrackerError{Kind: domain.ErrTrackerAuth}, false},
+		{"plain error is not a payload error", errors.New("boom"), false},
+		{"nil error is not a payload error", nil, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := isPayloadError(tt.err); got != tt.want {
+				t.Errorf("isPayloadError(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
 }
 
 func TestWriteErrorMapping(t *testing.T) {

--- a/internal/tracker/linear/linear_test.go
+++ b/internal/tracker/linear/linear_test.go
@@ -1,6 +1,7 @@
 package linear
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"reflect"
@@ -577,36 +578,6 @@ func TestFetchIssueStatesByIdentifiers(t *testing.T) {
 	})
 }
 
-func TestWriteStubs(t *testing.T) {
-	t.Parallel()
-
-	f := newFakeClient()
-	seedPreflight(f, t)
-	adapter := newTestAdapter(t, f)
-	callsBefore := len(f.calls)
-
-	tests := []struct {
-		name string
-		call func() error
-	}{
-		{"TransitionIssue", func() error { return adapter.TransitionIssue(context.Background(), "SOR-5", "Done") }},
-		{"CommentIssue", func() error { return adapter.CommentIssue(context.Background(), "SOR-5", "hello") }},
-		{"AddLabel", func() error { return adapter.AddLabel(context.Background(), "SOR-5", "needs-human") }},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			err := tt.call()
-
-			assertTrackerErrorKind(t, err, domain.ErrTrackerPayload)
-		})
-	}
-
-	if len(f.calls) != callsBefore {
-		t.Errorf("write stubs issued %d GraphQL calls, want 0", len(f.calls)-callsBefore)
-	}
-}
-
 func TestSetMetricsAcceptsNil(t *testing.T) {
 	t.Parallel()
 
@@ -619,6 +590,465 @@ func TestSetMetricsAcceptsNil(t *testing.T) {
 
 	if _, err := adapter.FetchCandidateIssues(context.Background()); err != nil {
 		t.Fatalf("FetchCandidateIssues with nil metrics: %v", err)
+	}
+}
+
+func TestRunMutation(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success returns nil", func(t *testing.T) {
+		t.Parallel()
+
+		f := newFakeClient()
+		f.queueBody("IssueUpdateState", loadFixture(t, "issue_update_success.json"))
+
+		err := runMutation(context.Background(), f, newTextLogger(&bytes.Buffer{}),
+			queryIssueUpdateState, map[string]any{"id": "SOR-5", "stateId": "state-inreview"},
+			decodeIssueUpdateSuccess)
+		if err != nil {
+			t.Fatalf("runMutation success path = %v, want nil", err)
+		}
+	})
+
+	t.Run("non-empty errors array is a failure regardless of success", func(t *testing.T) {
+		t.Parallel()
+
+		f := newFakeClient()
+		f.queueBody("IssueUpdateState", loadFixture(t, "mutation_invalid_input.json"))
+
+		err := runMutation(context.Background(), f, newTextLogger(&bytes.Buffer{}),
+			queryIssueUpdateState, map[string]any{"id": "SOR-5", "stateId": "state-inreview"},
+			decodeIssueUpdateSuccess)
+
+		assertTrackerErrorKind(t, err, domain.ErrTrackerPayload)
+	})
+
+	t.Run("success false with no errors is API error", func(t *testing.T) {
+		t.Parallel()
+
+		f := newFakeClient()
+		f.queueBody("IssueUpdateState", loadFixture(t, "mutation_success_false.json"))
+
+		err := runMutation(context.Background(), f, newTextLogger(&bytes.Buffer{}),
+			queryIssueUpdateState, map[string]any{"id": "SOR-5", "stateId": "state-inreview"},
+			decodeIssueUpdateSuccess)
+
+		assertTrackerErrorKind(t, err, domain.ErrTrackerAPI)
+	})
+
+	t.Run("malformed body is a payload error", func(t *testing.T) {
+		t.Parallel()
+
+		f := newFakeClient()
+		f.queueBody("IssueUpdateState", []byte("{not json"))
+
+		err := runMutation(context.Background(), f, newTextLogger(&bytes.Buffer{}),
+			queryIssueUpdateState, map[string]any{"id": "SOR-5", "stateId": "state-inreview"},
+			decodeIssueUpdateSuccess)
+
+		assertTrackerErrorKind(t, err, domain.ErrTrackerPayload)
+	})
+
+	t.Run("transport error from Execute is returned unchanged", func(t *testing.T) {
+		t.Parallel()
+
+		transportErr := &domain.TrackerError{Kind: domain.ErrTrackerTransport, Message: "dial tcp: timeout"}
+		f := newFakeClient()
+		f.queueResponse("IssueUpdateState", fakeResponse{err: transportErr})
+
+		err := runMutation(context.Background(), f, newTextLogger(&bytes.Buffer{}),
+			queryIssueUpdateState, map[string]any{"id": "SOR-5", "stateId": "state-inreview"},
+			decodeIssueUpdateSuccess)
+
+		if !errors.Is(err, transportErr) {
+			t.Errorf("runMutation transport error = %v, want %v unchanged", err, transportErr)
+		}
+	})
+}
+
+func TestTransitionIssue(t *testing.T) {
+	t.Parallel()
+
+	t.Run("resolves target then applies the resolved state id", func(t *testing.T) {
+		t.Parallel()
+
+		f := newFakeClient()
+		seedPreflight(f, t)
+		f.queueBody("ResolveStateID", loadFixture(t, "state_resolve_hit.json"))
+		f.queueBody("IssueUpdateState", loadFixture(t, "issue_update_success.json"))
+
+		adapter := newTestAdapter(t, f)
+
+		if err := adapter.TransitionIssue(context.Background(), "SOR-5", "In Review"); err != nil {
+			t.Fatalf("TransitionIssue: %v", err)
+		}
+
+		resolves := f.callsFor("ResolveStateID")
+		if len(resolves) != 1 {
+			t.Fatalf("ResolveStateID call count = %d, want 1", len(resolves))
+		}
+		if got := resolves[0].variables["stateName"]; got != "In Review" {
+			t.Errorf("ResolveStateID stateName = %v, want %q (verbatim target)", got, "In Review")
+		}
+		if got := resolves[0].variables["issueId"]; got != "SOR-5" {
+			t.Errorf("ResolveStateID issueId = %v, want %q (verbatim)", got, "SOR-5")
+		}
+
+		mutations := f.callsFor("IssueUpdateState")
+		if len(mutations) != 1 {
+			t.Fatalf("IssueUpdateState call count = %d, want 1", len(mutations))
+		}
+		if got := mutations[0].variables["stateId"]; got != "state-inreview" {
+			t.Errorf("IssueUpdateState stateId = %v, want %q (resolved id)", got, "state-inreview")
+		}
+		if got := mutations[0].variables["id"]; got != "SOR-5" {
+			t.Errorf("IssueUpdateState id = %v, want %q (verbatim)", got, "SOR-5")
+		}
+	})
+
+	t.Run("handoff name resolves case-insensitively and returns nil", func(t *testing.T) {
+		t.Parallel()
+
+		f := newFakeClient()
+		seedPreflight(f, t)
+		f.queueBody("ResolveStateID", loadFixture(t, "state_resolve_hit.json"))
+		f.queueBody("IssueUpdateState", loadFixture(t, "issue_update_success.json"))
+
+		adapter := newTestAdapter(t, f)
+
+		if err := adapter.TransitionIssue(context.Background(), "SOR-5", "in review"); err != nil {
+			t.Fatalf("TransitionIssue handoff name: %v", err)
+		}
+
+		resolves := f.callsFor("ResolveStateID")
+		if len(resolves) != 1 {
+			t.Fatalf("ResolveStateID call count = %d, want 1", len(resolves))
+		}
+		if got := resolves[0].variables["stateName"]; got != "in review" {
+			t.Errorf("ResolveStateID stateName = %v, want %q (caller value sent verbatim, no casing cache)", got, "in review")
+		}
+	})
+
+	t.Run("empty states resolve is a payload error", func(t *testing.T) {
+		t.Parallel()
+
+		f := newFakeClient()
+		seedPreflight(f, t)
+		f.queueBody("ResolveStateID", loadFixture(t, "state_resolve_empty.json"))
+
+		adapter := newTestAdapter(t, f)
+
+		err := adapter.TransitionIssue(context.Background(), "SOR-5", "Nonexistent")
+
+		assertTrackerErrorKind(t, err, domain.ErrTrackerPayload)
+		if calls := f.callsFor("IssueUpdateState"); len(calls) != 0 {
+			t.Errorf("IssueUpdateState call count = %d, want 0 when no state resolves", len(calls))
+		}
+	})
+
+	t.Run("not found issue is not found", func(t *testing.T) {
+		t.Parallel()
+
+		f := newFakeClient()
+		seedPreflight(f, t)
+		f.queueBody("ResolveStateID", loadFixture(t, "issue_not_found.json"))
+
+		adapter := newTestAdapter(t, f)
+
+		err := adapter.TransitionIssue(context.Background(), "SOR-999", "In Review")
+
+		assertTrackerErrorKind(t, err, domain.ErrTrackerNotFound)
+		if calls := f.callsFor("IssueUpdateState"); len(calls) != 0 {
+			t.Errorf("IssueUpdateState call count = %d, want 0 for a missing issue", len(calls))
+		}
+	})
+}
+
+func TestCommentIssue(t *testing.T) {
+	t.Parallel()
+
+	t.Run("sends the markdown body verbatim and returns nil", func(t *testing.T) {
+		t.Parallel()
+
+		f := newFakeClient()
+		seedPreflight(f, t)
+		f.queueBody("CommentCreate", loadFixture(t, "comment_create_success.json"))
+
+		adapter := newTestAdapter(t, f)
+
+		body := "CI failed on `make test`.\n\n- step: build\n- see **logs** for details"
+		if err := adapter.CommentIssue(context.Background(), "SOR-5", body); err != nil {
+			t.Fatalf("CommentIssue: %v", err)
+		}
+
+		calls := f.callsFor("CommentCreate")
+		if len(calls) != 1 {
+			t.Fatalf("CommentCreate call count = %d, want 1", len(calls))
+		}
+		if got := calls[0].variables["body"]; got != body {
+			t.Errorf("CommentCreate body = %q, want %q (verbatim markdown, no ADF wrapping)", got, body)
+		}
+		if got := calls[0].variables["issueId"]; got != "SOR-5" {
+			t.Errorf("CommentCreate issueId = %v, want %q (verbatim)", got, "SOR-5")
+		}
+	})
+
+	t.Run("rejected create surfaces the classified error", func(t *testing.T) {
+		t.Parallel()
+
+		f := newFakeClient()
+		seedPreflight(f, t)
+		f.queueBody("CommentCreate", loadFixture(t, "mutation_auth_error.json"))
+
+		adapter := newTestAdapter(t, f)
+
+		err := adapter.CommentIssue(context.Background(), "SOR-5", "body")
+
+		assertTrackerErrorKind(t, err, domain.ErrTrackerAuth)
+	})
+}
+
+func TestAddLabel(t *testing.T) {
+	t.Parallel()
+
+	t.Run("existing label attaches without creating and never calls LabelCreate", func(t *testing.T) {
+		t.Parallel()
+
+		f := newFakeClient()
+		seedPreflight(f, t)
+		f.queueBody("ResolveLabel", loadFixture(t, "label_resolve_hit.json"))
+		f.queueBody("IssueAddLabel", loadFixture(t, "issue_add_label_success.json"))
+
+		adapter := newTestAdapter(t, f)
+
+		if err := adapter.AddLabel(context.Background(), "SOR-5", "needs-human"); err != nil {
+			t.Fatalf("AddLabel: %v", err)
+		}
+
+		if calls := f.callsFor("LabelCreate"); len(calls) != 0 {
+			t.Errorf("LabelCreate call count = %d, want 0 when the label already exists", len(calls))
+		}
+		if calls := f.callsFor("ResolveIssueTeam"); len(calls) != 0 {
+			t.Errorf("ResolveIssueTeam call count = %d, want 0 when the label already exists", len(calls))
+		}
+
+		attaches := f.callsFor("IssueAddLabel")
+		if len(attaches) != 1 {
+			t.Fatalf("IssueAddLabel call count = %d, want 1", len(attaches))
+		}
+		labelIDs, ok := attaches[0].variables["labelIds"].([]string)
+		if !ok {
+			t.Fatalf("IssueAddLabel labelIds type = %T, want []string", attaches[0].variables["labelIds"])
+		}
+		want := []string{"label-team-needs-human"}
+		if !reflect.DeepEqual(labelIDs, want) {
+			t.Errorf("IssueAddLabel addedLabelIds = %v, want %v (resolved id, append)", labelIDs, want)
+		}
+		if got := attaches[0].variables["id"]; got != "SOR-5" {
+			t.Errorf("IssueAddLabel id = %v, want %q (verbatim)", got, "SOR-5")
+		}
+	})
+
+	t.Run("prefers the team-scoped label over the workspace-scoped label", func(t *testing.T) {
+		t.Parallel()
+
+		f := newFakeClient()
+		seedPreflight(f, t)
+		f.queueBody("ResolveLabel", loadFixture(t, "label_resolve_team_preference.json"))
+		f.queueBody("IssueAddLabel", loadFixture(t, "issue_add_label_success.json"))
+
+		adapter := newTestAdapter(t, f)
+
+		if err := adapter.AddLabel(context.Background(), "SOR-5", "needs-human"); err != nil {
+			t.Fatalf("AddLabel: %v", err)
+		}
+
+		attaches := f.callsFor("IssueAddLabel")
+		if len(attaches) != 1 {
+			t.Fatalf("IssueAddLabel call count = %d, want 1", len(attaches))
+		}
+		labelIDs := attaches[0].variables["labelIds"].([]string)
+		want := []string{"label-team-needs-human"}
+		if !reflect.DeepEqual(labelIDs, want) {
+			t.Errorf("IssueAddLabel addedLabelIds = %v, want %v (team-scoped preferred over workspace)", labelIDs, want)
+		}
+	})
+
+	t.Run("falls back to the workspace-scoped label when no team-scoped label exists", func(t *testing.T) {
+		t.Parallel()
+
+		f := newFakeClient()
+		seedPreflight(f, t)
+		f.queueBody("ResolveLabel", loadFixture(t, "label_resolve_workspace_only.json"))
+		f.queueBody("IssueAddLabel", loadFixture(t, "issue_add_label_success.json"))
+
+		adapter := newTestAdapter(t, f)
+
+		if err := adapter.AddLabel(context.Background(), "SOR-5", "needs-human"); err != nil {
+			t.Fatalf("AddLabel: %v", err)
+		}
+
+		if calls := f.callsFor("LabelCreate"); len(calls) != 0 {
+			t.Errorf("LabelCreate call count = %d, want 0 when a workspace label exists", len(calls))
+		}
+		if calls := f.callsFor("ResolveIssueTeam"); len(calls) != 0 {
+			t.Errorf("ResolveIssueTeam call count = %d, want 0 when a workspace label exists", len(calls))
+		}
+
+		attaches := f.callsFor("IssueAddLabel")
+		if len(attaches) != 1 {
+			t.Fatalf("IssueAddLabel call count = %d, want 1", len(attaches))
+		}
+		labelIDs := attaches[0].variables["labelIds"].([]string)
+		want := []string{"label-workspace-needs-human"}
+		if !reflect.DeepEqual(labelIDs, want) {
+			t.Errorf("IssueAddLabel addedLabelIds = %v, want %v (workspace fallback)", labelIDs, want)
+		}
+	})
+
+	t.Run("missing label resolves team, creates, then attaches the created id", func(t *testing.T) {
+		t.Parallel()
+
+		f := newFakeClient()
+		seedPreflight(f, t)
+		f.queueBody("ResolveLabel", loadFixture(t, "label_resolve_miss.json"))
+		f.queueBody("ResolveIssueTeam", loadFixture(t, "team_resolve_hit.json"))
+		f.queueBody("LabelCreate", loadFixture(t, "label_create_success.json"))
+		f.queueBody("IssueAddLabel", loadFixture(t, "issue_add_label_success.json"))
+
+		adapter := newTestAdapter(t, f)
+
+		if err := adapter.AddLabel(context.Background(), "SOR-5", "needs-human"); err != nil {
+			t.Fatalf("AddLabel: %v", err)
+		}
+
+		creates := f.callsFor("LabelCreate")
+		if len(creates) != 1 {
+			t.Fatalf("LabelCreate call count = %d, want 1", len(creates))
+		}
+		if got := creates[0].variables["teamId"]; got != "team-uuid-sor" {
+			t.Errorf("LabelCreate teamId = %v, want %q (resolved team UUID)", got, "team-uuid-sor")
+		}
+		if got := creates[0].variables["name"]; got != "needs-human" {
+			t.Errorf("LabelCreate name = %v, want %q (verbatim)", got, "needs-human")
+		}
+
+		attaches := f.callsFor("IssueAddLabel")
+		if len(attaches) != 1 {
+			t.Fatalf("IssueAddLabel call count = %d, want 1", len(attaches))
+		}
+		labelIDs := attaches[0].variables["labelIds"].([]string)
+		want := []string{"label-created-needs-human"}
+		if !reflect.DeepEqual(labelIDs, want) {
+			t.Errorf("IssueAddLabel addedLabelIds = %v, want %v (created id)", labelIDs, want)
+		}
+	})
+
+	t.Run("concurrent create race re-resolves and attaches the re-resolved id", func(t *testing.T) {
+		t.Parallel()
+
+		f := newFakeClient()
+		seedPreflight(f, t)
+		f.queueBody("ResolveLabel", loadFixture(t, "label_resolve_miss.json"))
+		f.queueBody("ResolveLabel", loadFixture(t, "label_resolve_hit.json"))
+		f.queueBody("ResolveIssueTeam", loadFixture(t, "team_resolve_hit.json"))
+		f.queueBody("LabelCreate", loadFixture(t, "label_create_conflict.json"))
+		f.queueBody("IssueAddLabel", loadFixture(t, "issue_add_label_success.json"))
+
+		adapter := newTestAdapter(t, f)
+
+		if err := adapter.AddLabel(context.Background(), "SOR-5", "needs-human"); err != nil {
+			t.Fatalf("AddLabel race path = %v, want nil (re-resolve hides the spurious conflict)", err)
+		}
+
+		resolves := f.callsFor("ResolveLabel")
+		if len(resolves) != 2 {
+			t.Fatalf("ResolveLabel call count = %d, want 2 (initial miss then post-create re-resolve)", len(resolves))
+		}
+
+		attaches := f.callsFor("IssueAddLabel")
+		if len(attaches) != 1 {
+			t.Fatalf("IssueAddLabel call count = %d, want 1", len(attaches))
+		}
+		labelIDs := attaches[0].variables["labelIds"].([]string)
+		want := []string{"label-team-needs-human"}
+		if !reflect.DeepEqual(labelIDs, want) {
+			t.Errorf("IssueAddLabel addedLabelIds = %v, want %v (re-resolved id from the concurrent create)", labelIDs, want)
+		}
+	})
+
+	t.Run("payload create error that still resolves nothing surfaces the create error", func(t *testing.T) {
+		t.Parallel()
+
+		f := newFakeClient()
+		seedPreflight(f, t)
+		f.queueBody("ResolveLabel", loadFixture(t, "label_resolve_miss.json"))
+		f.queueBody("ResolveLabel", loadFixture(t, "label_resolve_miss.json"))
+		f.queueBody("ResolveIssueTeam", loadFixture(t, "team_resolve_hit.json"))
+		f.queueBody("LabelCreate", loadFixture(t, "label_create_conflict.json"))
+
+		adapter := newTestAdapter(t, f)
+
+		err := adapter.AddLabel(context.Background(), "SOR-5", "needs-human")
+
+		assertTrackerErrorKind(t, err, domain.ErrTrackerPayload)
+		if calls := f.callsFor("IssueAddLabel"); len(calls) != 0 {
+			t.Errorf("IssueAddLabel call count = %d, want 0 when the create error is genuine", len(calls))
+		}
+	})
+
+	t.Run("forbidden create is auth error and does not re-resolve", func(t *testing.T) {
+		t.Parallel()
+
+		f := newFakeClient()
+		seedPreflight(f, t)
+		f.queueBody("ResolveLabel", loadFixture(t, "label_resolve_miss.json"))
+		f.queueBody("ResolveIssueTeam", loadFixture(t, "team_resolve_hit.json"))
+		f.queueBody("LabelCreate", loadFixture(t, "mutation_forbidden.json"))
+
+		adapter := newTestAdapter(t, f)
+
+		err := adapter.AddLabel(context.Background(), "SOR-5", "needs-human")
+
+		assertTrackerErrorKind(t, err, domain.ErrTrackerAuth)
+
+		if calls := f.callsFor("ResolveLabel"); len(calls) != 1 {
+			t.Errorf("ResolveLabel call count = %d, want 1 (no re-resolve on a forbidden create)", len(calls))
+		}
+		if calls := f.callsFor("IssueAddLabel"); len(calls) != 0 {
+			t.Errorf("IssueAddLabel call count = %d, want 0 on a forbidden create", len(calls))
+		}
+	})
+}
+
+func TestWriteErrorMapping(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		fixture  string
+		wantKind domain.TrackerErrorKind
+	}{
+		{"authentication error maps to auth", "mutation_auth_error.json", domain.ErrTrackerAuth},
+		{"feature not accessible maps to auth", "mutation_forbidden.json", domain.ErrTrackerAuth},
+		{"invalid input maps to payload", "mutation_invalid_input.json", domain.ErrTrackerPayload},
+		{"ratelimited maps to API", "mutation_ratelimited.json", domain.ErrTrackerAPI},
+		{"success false with no errors maps to API", "mutation_success_false.json", domain.ErrTrackerAPI},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			f := newFakeClient()
+			f.queueBody("CommentCreate", loadFixture(t, tt.fixture))
+
+			err := runMutation(context.Background(), f, newTextLogger(&bytes.Buffer{}),
+				queryCommentCreate, map[string]any{"issueId": "SOR-5", "body": "x"},
+				decodeCommentCreateSuccess)
+
+			assertTrackerErrorKind(t, err, tt.wantKind)
+		})
 	}
 }
 

--- a/internal/tracker/linear/normalize.go
+++ b/internal/tracker/linear/normalize.go
@@ -245,14 +245,16 @@ type commentCreateData struct {
 
 // labelResolveData is the data payload for the label-resolve query. A node's
 // Team is a pointer so a workspace-scoped label (team null) is distinguishable
-// from a team-scoped label.
+// from a team-scoped label. Team.Key is the team key the configured project is
+// matched against; Team.ID is a UUID and is not the configured project value.
 type labelResolveData struct {
 	IssueLabels struct {
 		Nodes []struct {
 			ID   string `json:"id"`
 			Name string `json:"name"`
 			Team *struct {
-				ID string `json:"id"`
+				ID  string `json:"id"`
+				Key string `json:"key"`
 			} `json:"team"`
 		} `json:"nodes"`
 	} `json:"issueLabels"`

--- a/internal/tracker/linear/normalize.go
+++ b/internal/tracker/linear/normalize.go
@@ -197,6 +197,77 @@ type teamStatesData struct {
 	} `json:"teams"`
 }
 
+// stateResolveData is the data payload for the transition state-resolution
+// query. A nil Issue distinguishes a missing issue from a present issue with no
+// matching state.
+type stateResolveData struct {
+	Issue *struct {
+		ID   string `json:"id"`
+		Team struct {
+			States struct {
+				Nodes []struct {
+					ID   string `json:"id"`
+					Name string `json:"name"`
+				} `json:"nodes"`
+			} `json:"states"`
+		} `json:"team"`
+	} `json:"issue"`
+}
+
+// teamResolveData is the data payload for the team-resolve query. A nil Issue
+// distinguishes a missing issue from a present issue.
+type teamResolveData struct {
+	Issue *struct {
+		ID   string `json:"id"`
+		Team struct {
+			ID string `json:"id"`
+		} `json:"team"`
+	} `json:"issue"`
+}
+
+// issueUpdateData is the data payload for both issueUpdate mutations, the
+// transition and the label attach. Only the success boolean drives correctness.
+type issueUpdateData struct {
+	IssueUpdate struct {
+		Success bool `json:"success"`
+	} `json:"issueUpdate"`
+}
+
+// commentCreateData is the data payload for the commentCreate mutation.
+type commentCreateData struct {
+	CommentCreate struct {
+		Success bool `json:"success"`
+		Comment *struct {
+			ID string `json:"id"`
+		} `json:"comment"`
+	} `json:"commentCreate"`
+}
+
+// labelResolveData is the data payload for the label-resolve query. A node's
+// Team is a pointer so a workspace-scoped label (team null) is distinguishable
+// from a team-scoped label.
+type labelResolveData struct {
+	IssueLabels struct {
+		Nodes []struct {
+			ID   string `json:"id"`
+			Name string `json:"name"`
+			Team *struct {
+				ID string `json:"id"`
+			} `json:"team"`
+		} `json:"nodes"`
+	} `json:"issueLabels"`
+}
+
+// labelCreateData is the data payload for the issueLabelCreate mutation.
+type labelCreateData struct {
+	IssueLabelCreate struct {
+		Success    bool `json:"success"`
+		IssueLabel *struct {
+			ID string `json:"id"`
+		} `json:"issueLabel"`
+	} `json:"issueLabelCreate"`
+}
+
 // normalizeIssue maps a [linearIssue] to a [domain.Issue].
 //
 // Labels are lowercased, priority 0 maps to nil while 1..4 map to a non-nil

--- a/internal/tracker/linear/query.go
+++ b/internal/tracker/linear/query.go
@@ -120,3 +120,74 @@ const queryTeamStates = `query TeamStates($teamKey: String!) {
     }
   }
 }`
+
+// queryResolveStateID resolves a workflow-state name to its UUID within the
+// team that owns the issue. The eqIgnoreCase filter matches the name
+// case-insensitively, so the caller's target state is sent verbatim.
+const queryResolveStateID = `query ResolveStateID($issueId: String!, $stateName: String!) {
+  issue(id: $issueId) {
+    id
+    team {
+      states(filter: { name: { eqIgnoreCase: $stateName } }, first: 1) {
+        nodes { id name }
+      }
+    }
+  }
+}`
+
+// queryResolveIssueTeam resolves the UUID of the team that owns an issue. It is
+// the team source for the team-scoped label create, which never runs the
+// state-resolve query.
+const queryResolveIssueTeam = `query ResolveIssueTeam($issueId: String!) {
+  issue(id: $issueId) {
+    id
+    team { id }
+  }
+}`
+
+// queryIssueUpdateState moves an issue to a workflow state by UUID. The
+// IssueUpdateState operation name distinguishes it from the label-attach
+// issueUpdate mutation under a query-substring match.
+const queryIssueUpdateState = `mutation IssueUpdateState($id: String!, $stateId: String!) {
+  issueUpdate(id: $id, input: { stateId: $stateId }) {
+    success
+    issue { id state { name } }
+  }
+}`
+
+// queryCommentCreate posts a markdown comment body verbatim, with no ADF-style
+// wrapping.
+const queryCommentCreate = `mutation CommentCreate($issueId: String!, $body: String!) {
+  commentCreate(input: { issueId: $issueId, body: $body }) {
+    success
+    comment { id }
+  }
+}`
+
+// queryResolveLabel resolves a label name to its UUID, case-insensitively. Each
+// node carries its team so the resolver can prefer a team-scoped label over a
+// workspace-scoped one.
+const queryResolveLabel = `query ResolveLabel($name: String!) {
+  issueLabels(filter: { name: { eqIgnoreCase: $name } }, first: 50) {
+    nodes { id name team { id } }
+  }
+}`
+
+// queryLabelCreate creates a team-scoped label. It always passes teamId because
+// workspace-scoped label management is more likely to require elevated access.
+const queryLabelCreate = `mutation LabelCreate($teamId: String!, $name: String!) {
+  issueLabelCreate(input: { teamId: $teamId, name: $name }) {
+    success
+    issueLabel { id }
+  }
+}`
+
+// queryIssueAddLabel attaches labels through addedLabelIds (append), so the
+// issue's existing labels are preserved and no read-before-write of the label
+// set is required. The IssueAddLabel operation name distinguishes it from the
+// transition issueUpdate mutation under a query-substring match.
+const queryIssueAddLabel = `mutation IssueAddLabel($id: String!, $labelIds: [String!]!) {
+  issueUpdate(id: $id, input: { addedLabelIds: $labelIds }) {
+    success
+  }
+}`

--- a/internal/tracker/linear/query.go
+++ b/internal/tracker/linear/query.go
@@ -165,11 +165,11 @@ const queryCommentCreate = `mutation CommentCreate($issueId: String!, $body: Str
 }`
 
 // queryResolveLabel resolves a label name to its UUID, case-insensitively. Each
-// node carries its team so the resolver can prefer a team-scoped label over a
-// workspace-scoped one.
+// node carries its team key so the resolver can prefer a team-scoped label over
+// a workspace-scoped one; the configured project is a team key, not a team UUID.
 const queryResolveLabel = `query ResolveLabel($name: String!) {
   issueLabels(filter: { name: { eqIgnoreCase: $name } }, first: 50) {
-    nodes { id name team { id } }
+    nodes { id name team { id key } }
   }
 }`
 

--- a/internal/tracker/linear/testdata/comment_create_success.json
+++ b/internal/tracker/linear/testdata/comment_create_success.json
@@ -1,0 +1,8 @@
+{
+  "data": {
+    "commentCreate": {
+      "success": true,
+      "comment": { "id": "comment-9001" }
+    }
+  }
+}

--- a/internal/tracker/linear/testdata/issue_add_label_success.json
+++ b/internal/tracker/linear/testdata/issue_add_label_success.json
@@ -1,0 +1,7 @@
+{
+  "data": {
+    "issueUpdate": {
+      "success": true
+    }
+  }
+}

--- a/internal/tracker/linear/testdata/issue_update_success.json
+++ b/internal/tracker/linear/testdata/issue_update_success.json
@@ -1,0 +1,11 @@
+{
+  "data": {
+    "issueUpdate": {
+      "success": true,
+      "issue": {
+        "id": "a7c4f8e2-1b9d-4e3a-8f2c-6d5e4a3b2c1f",
+        "state": { "name": "In Review" }
+      }
+    }
+  }
+}

--- a/internal/tracker/linear/testdata/label_create_conflict.json
+++ b/internal/tracker/linear/testdata/label_create_conflict.json
@@ -1,0 +1,17 @@
+{
+  "errors": [
+    {
+      "message": "A label with this name already exists in the team",
+      "path": ["issueLabelCreate"],
+      "locations": [{ "line": 1, "column": 1 }],
+      "extensions": {
+        "type": "user error",
+        "code": "CONSTRAINT_VIOLATION",
+        "statusCode": 400,
+        "userError": true,
+        "userPresentableMessage": "A label with this name already exists."
+      }
+    }
+  ],
+  "data": null
+}

--- a/internal/tracker/linear/testdata/label_create_success.json
+++ b/internal/tracker/linear/testdata/label_create_success.json
@@ -1,0 +1,8 @@
+{
+  "data": {
+    "issueLabelCreate": {
+      "success": true,
+      "issueLabel": { "id": "label-created-needs-human" }
+    }
+  }
+}

--- a/internal/tracker/linear/testdata/label_create_success_no_id.json
+++ b/internal/tracker/linear/testdata/label_create_success_no_id.json
@@ -1,0 +1,8 @@
+{
+  "data": {
+    "issueLabelCreate": {
+      "success": true,
+      "issueLabel": null
+    }
+  }
+}

--- a/internal/tracker/linear/testdata/label_resolve_hit.json
+++ b/internal/tracker/linear/testdata/label_resolve_hit.json
@@ -1,0 +1,9 @@
+{
+  "data": {
+    "issueLabels": {
+      "nodes": [
+        { "id": "label-team-needs-human", "name": "needs-human", "team": { "id": "SOR" } }
+      ]
+    }
+  }
+}

--- a/internal/tracker/linear/testdata/label_resolve_hit.json
+++ b/internal/tracker/linear/testdata/label_resolve_hit.json
@@ -2,7 +2,7 @@
   "data": {
     "issueLabels": {
       "nodes": [
-        { "id": "label-team-needs-human", "name": "needs-human", "team": { "id": "SOR" } }
+        { "id": "label-team-needs-human", "name": "needs-human", "team": { "id": "11111111-1111-1111-1111-111111111111", "key": "SOR" } }
       ]
     }
   }

--- a/internal/tracker/linear/testdata/label_resolve_miss.json
+++ b/internal/tracker/linear/testdata/label_resolve_miss.json
@@ -1,0 +1,7 @@
+{
+  "data": {
+    "issueLabels": {
+      "nodes": []
+    }
+  }
+}

--- a/internal/tracker/linear/testdata/label_resolve_other_team.json
+++ b/internal/tracker/linear/testdata/label_resolve_other_team.json
@@ -1,0 +1,9 @@
+{
+  "data": {
+    "issueLabels": {
+      "nodes": [
+        { "id": "label-other-team-needs-human", "name": "needs-human", "team": { "id": "22222222-2222-2222-2222-222222222222", "key": "OPS" } }
+      ]
+    }
+  }
+}

--- a/internal/tracker/linear/testdata/label_resolve_team_preference.json
+++ b/internal/tracker/linear/testdata/label_resolve_team_preference.json
@@ -3,7 +3,7 @@
     "issueLabels": {
       "nodes": [
         { "id": "label-workspace-needs-human", "name": "needs-human", "team": null },
-        { "id": "label-team-needs-human", "name": "needs-human", "team": { "id": "SOR" } }
+        { "id": "label-team-needs-human", "name": "needs-human", "team": { "id": "11111111-1111-1111-1111-111111111111", "key": "SOR" } }
       ]
     }
   }

--- a/internal/tracker/linear/testdata/label_resolve_team_preference.json
+++ b/internal/tracker/linear/testdata/label_resolve_team_preference.json
@@ -1,0 +1,10 @@
+{
+  "data": {
+    "issueLabels": {
+      "nodes": [
+        { "id": "label-workspace-needs-human", "name": "needs-human", "team": null },
+        { "id": "label-team-needs-human", "name": "needs-human", "team": { "id": "SOR" } }
+      ]
+    }
+  }
+}

--- a/internal/tracker/linear/testdata/label_resolve_workspace_only.json
+++ b/internal/tracker/linear/testdata/label_resolve_workspace_only.json
@@ -1,0 +1,9 @@
+{
+  "data": {
+    "issueLabels": {
+      "nodes": [
+        { "id": "label-workspace-needs-human", "name": "needs-human", "team": null }
+      ]
+    }
+  }
+}

--- a/internal/tracker/linear/testdata/mutation_auth_error.json
+++ b/internal/tracker/linear/testdata/mutation_auth_error.json
@@ -1,0 +1,16 @@
+{
+  "errors": [
+    {
+      "message": "Authentication required, not authenticated",
+      "path": ["commentCreate"],
+      "locations": [{ "line": 1, "column": 1 }],
+      "extensions": {
+        "type": "authentication error",
+        "code": "AUTHENTICATION_ERROR",
+        "statusCode": 401,
+        "userPresentableMessage": "You need to authenticate to perform this operation."
+      }
+    }
+  ],
+  "data": null
+}

--- a/internal/tracker/linear/testdata/mutation_forbidden.json
+++ b/internal/tracker/linear/testdata/mutation_forbidden.json
@@ -1,0 +1,16 @@
+{
+  "errors": [
+    {
+      "message": "Label management is restricted to workspace admins",
+      "path": ["issueLabelCreate"],
+      "locations": [{ "line": 1, "column": 1 }],
+      "extensions": {
+        "type": "feature not accessible",
+        "code": "FEATURE_NOT_ACCESSIBLE",
+        "statusCode": 403,
+        "userPresentableMessage": "You do not have permission to create labels in this team."
+      }
+    }
+  ],
+  "data": null
+}

--- a/internal/tracker/linear/testdata/mutation_invalid_input.json
+++ b/internal/tracker/linear/testdata/mutation_invalid_input.json
@@ -1,0 +1,17 @@
+{
+  "errors": [
+    {
+      "message": "Argument Validation Error",
+      "path": ["issueUpdate"],
+      "locations": [{ "line": 1, "column": 1 }],
+      "extensions": {
+        "type": "invalid input",
+        "code": "INVALID_INPUT",
+        "statusCode": 400,
+        "userError": true,
+        "userPresentableMessage": "The state you supplied is not valid for this issue."
+      }
+    }
+  ],
+  "data": null
+}

--- a/internal/tracker/linear/testdata/mutation_ratelimited.json
+++ b/internal/tracker/linear/testdata/mutation_ratelimited.json
@@ -1,0 +1,16 @@
+{
+  "errors": [
+    {
+      "message": "Ratelimit exceeded for this operation",
+      "path": ["issueUpdate"],
+      "locations": [{ "line": 1, "column": 1 }],
+      "extensions": {
+        "type": "invalid input",
+        "code": "RATELIMITED",
+        "statusCode": 400,
+        "userPresentableMessage": "You have been rate limited. Please retry shortly."
+      }
+    }
+  ],
+  "data": null
+}

--- a/internal/tracker/linear/testdata/mutation_success_false.json
+++ b/internal/tracker/linear/testdata/mutation_success_false.json
@@ -1,0 +1,7 @@
+{
+  "data": {
+    "issueUpdate": {
+      "success": false
+    }
+  }
+}

--- a/internal/tracker/linear/testdata/state_resolve_empty.json
+++ b/internal/tracker/linear/testdata/state_resolve_empty.json
@@ -1,0 +1,12 @@
+{
+  "data": {
+    "issue": {
+      "id": "a7c4f8e2-1b9d-4e3a-8f2c-6d5e4a3b2c1f",
+      "team": {
+        "states": {
+          "nodes": []
+        }
+      }
+    }
+  }
+}

--- a/internal/tracker/linear/testdata/state_resolve_hit.json
+++ b/internal/tracker/linear/testdata/state_resolve_hit.json
@@ -1,0 +1,12 @@
+{
+  "data": {
+    "issue": {
+      "id": "a7c4f8e2-1b9d-4e3a-8f2c-6d5e4a3b2c1f",
+      "team": {
+        "states": {
+          "nodes": [{ "id": "state-inreview", "name": "In Review" }]
+        }
+      }
+    }
+  }
+}

--- a/internal/tracker/linear/testdata/state_resolve_null_issue.json
+++ b/internal/tracker/linear/testdata/state_resolve_null_issue.json
@@ -1,0 +1,5 @@
+{
+  "data": {
+    "issue": null
+  }
+}

--- a/internal/tracker/linear/testdata/team_resolve_hit.json
+++ b/internal/tracker/linear/testdata/team_resolve_hit.json
@@ -1,0 +1,8 @@
+{
+  "data": {
+    "issue": {
+      "id": "a7c4f8e2-1b9d-4e3a-8f2c-6d5e4a3b2c1f",
+      "team": { "id": "team-uuid-sor" }
+    }
+  }
+}

--- a/internal/tracker/linear/testdata/team_resolve_null_issue.json
+++ b/internal/tracker/linear/testdata/team_resolve_null_issue.json
@@ -1,0 +1,5 @@
+{
+  "data": {
+    "issue": null
+  }
+}


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Feat

**Intent:** Replaces the three compile-satisfying stubs in the Linear tracker adapter (`TransitionIssue`, `CommentIssue`, `AddLabel`) with working implementations, completing the `TrackerAdapter` interface so a Linear-backed deployment can perform handoff transitions, post lifecycle comments, and attach escalation labels on par with the Jira and GitHub adapters.

**Related Issues:** #589

### 🧭 Reviewer Guide

**Complexity:** Medium

#### Entry Point

`internal/tracker/linear/linear.go` - this is where all three methods are implemented. `TransitionIssue` resolves a state name to a team-scoped UUID then applies it via `issueUpdate`; `CommentIssue` posts markdown verbatim via `commentCreate`; `AddLabel` resolves or creates a team-scoped label then appends it through `addedLabelIds`. A new `runMutation` helper (same file) centralises transport, rate-limit recording, and error classification across all three mutations.

#### Sensitive Areas

- `internal/tracker/linear/linear.go` (`AddLabel`): the label attach uses `addedLabelIds` (append) rather than a full-set replace, which is the key correctness invariant - switching to a replace-style mutation would silently drop the issue's existing labels.
- `internal/tracker/linear/linear.go` (`AddLabel`): the concurrent-create conflict path re-resolves once on a payload-class error; any change to the `isPayloadError` predicate affects that branch.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes
- **Migrations/State:** No migrations or state changes