### PR TITLE
feat(linear): add tracker.query_filter support

### DIFF
--- a/internal/tracker/linear/fake_test.go
+++ b/internal/tracker/linear/fake_test.go
@@ -130,11 +130,20 @@ func seedPreflight(f *fakeGraphQLClient, t *testing.T) {
 }
 
 // newTestAdapter constructs a [LinearAdapter] through the offline seam with the
-// default team-SOR config and a nil logger, failing the test on a construction
-// error.
+// default team-SOR config, no operator filter, and a nil logger, failing the
+// test on a construction error.
 func newTestAdapter(t *testing.T, f *fakeGraphQLClient) *LinearAdapter {
 	t.Helper()
-	a, err := newAdapter(f, "SOR", defaultActiveStates, defaultTerminalStates, "In Review", nil)
+	return newTestAdapterWithFilter(t, f, nil)
+}
+
+// newTestAdapterWithFilter constructs a [LinearAdapter] through the offline seam
+// with the default team-SOR config carrying the supplied parsed query filter and
+// a nil logger, failing the test on a construction error. A nil queryFilter
+// reproduces the unset passthrough behavior.
+func newTestAdapterWithFilter(t *testing.T, f *fakeGraphQLClient, queryFilter map[string]any) *LinearAdapter {
+	t.Helper()
+	a, err := newAdapter(f, "SOR", defaultActiveStates, defaultTerminalStates, "In Review", queryFilter, nil)
 	if err != nil {
 		t.Fatalf("newAdapter: %v", err)
 	}

--- a/internal/tracker/linear/integration_test.go
+++ b/internal/tracker/linear/integration_test.go
@@ -276,7 +276,7 @@ func TestIntegration_TransitionIssue(t *testing.T) {
 
 	issue := firstCandidate(t, adapter, ctx)
 
-	if err := adapter.TransitionIssue(ctx, issue.Identifier, issue.State); err != nil {
+	if err := adapter.TransitionIssue(ctx, issue.ID, issue.State); err != nil {
 		t.Fatalf("TransitionIssue(%s, %q): %v", issue.Identifier, issue.State, err)
 	}
 }
@@ -292,7 +292,7 @@ func TestIntegration_CommentIssue(t *testing.T) {
 	issue := firstCandidate(t, adapter, ctx)
 
 	body := "sortie write-path integration test comment at " + time.Now().UTC().Format(time.RFC3339)
-	if err := adapter.CommentIssue(ctx, issue.Identifier, body); err != nil {
+	if err := adapter.CommentIssue(ctx, issue.ID, body); err != nil {
 		t.Fatalf("CommentIssue(%s): %v", issue.Identifier, err)
 	}
 }
@@ -309,7 +309,7 @@ func TestIntegration_AddLabel(t *testing.T) {
 
 	label := "needs-human"
 
-	if err := adapter.AddLabel(ctx, issue.Identifier, label); err != nil {
+	if err := adapter.AddLabel(ctx, issue.ID, label); err != nil {
 		t.Fatalf("AddLabel(%s, %q): %v", issue.Identifier, label, err)
 	}
 }

--- a/internal/tracker/linear/integration_test.go
+++ b/internal/tracker/linear/integration_test.go
@@ -21,18 +21,6 @@ func skipUnlessIntegration(t *testing.T) {
 	}
 }
 
-// skipUnlessWriteIntegration skips the current test unless both the read
-// integration gate (SORTIE_LINEAR_TEST=1) and the write opt-in
-// (SORTIE_LINEAR_WRITE_TEST=1) are set, so a default run reads but never
-// mutates the live workspace.
-func skipUnlessWriteIntegration(t *testing.T) {
-	t.Helper()
-	skipUnlessIntegration(t)
-	if os.Getenv("SORTIE_LINEAR_WRITE_TEST") != "1" {
-		t.Skip("skipping Linear write integration test: set SORTIE_LINEAR_WRITE_TEST=1 to enable")
-	}
-}
-
 // requireEnv reads an environment variable and fails the test when empty.
 func requireEnv(t *testing.T, key string) string {
 	t.Helper()
@@ -279,7 +267,7 @@ func firstCandidate(t *testing.T, adapter domain.TrackerAdapter, ctx context.Con
 }
 
 func TestIntegration_TransitionIssue(t *testing.T) {
-	skipUnlessWriteIntegration(t)
+	skipUnlessIntegration(t)
 
 	adapter := newIntegrationAdapter(t)
 
@@ -294,7 +282,7 @@ func TestIntegration_TransitionIssue(t *testing.T) {
 }
 
 func TestIntegration_CommentIssue(t *testing.T) {
-	skipUnlessWriteIntegration(t)
+	skipUnlessIntegration(t)
 
 	adapter := newIntegrationAdapter(t)
 
@@ -310,7 +298,7 @@ func TestIntegration_CommentIssue(t *testing.T) {
 }
 
 func TestIntegration_AddLabel(t *testing.T) {
-	skipUnlessWriteIntegration(t)
+	skipUnlessIntegration(t)
 
 	adapter := newIntegrationAdapter(t)
 
@@ -319,10 +307,7 @@ func TestIntegration_AddLabel(t *testing.T) {
 
 	issue := firstCandidate(t, adapter, ctx)
 
-	label := os.Getenv("SORTIE_LINEAR_WRITE_LABEL")
-	if label == "" {
-		label = "needs-human"
-	}
+	label := "needs-human"
 
 	if err := adapter.AddLabel(ctx, issue.Identifier, label); err != nil {
 		t.Fatalf("AddLabel(%s, %q): %v", issue.Identifier, label, err)

--- a/internal/tracker/linear/linear.go
+++ b/internal/tracker/linear/linear.go
@@ -61,6 +61,7 @@ type LinearAdapter struct {
 	activeStates   []string
 	terminalStates []string
 	handoffState   string
+	queryFilter    map[string]any
 	casingCache    map[string]string
 	log            *slog.Logger
 	metrics        domain.Metrics
@@ -106,19 +107,25 @@ func NewLinearAdapter(config map[string]any) (domain.TrackerAdapter, error) {
 	}
 	handoffState, _ := config["handoff_state"].(string)
 
+	rawQueryFilter, _ := config["query_filter"].(string)
+	queryFilter, err := parseQueryFilter(rawQueryFilter)
+	if err != nil {
+		return nil, err
+	}
+
 	userAgent, _ := config["user_agent"].(string)
 	if userAgent == "" {
 		userAgent = "sortie/dev"
 	}
 
 	client := newLinearClient(endpoint, apiKey, userAgent)
-	return newAdapter(client, project, activeStates, terminalStates, handoffState, slog.Default())
+	return newAdapter(client, project, activeStates, terminalStates, handoffState, queryFilter, slog.Default())
 }
 
 // newAdapter runs the preflight through client and assembles the adapter with
 // canonical-cased state lists. It is the seam shared by the production
 // constructor and offline tests.
-func newAdapter(client graphQLClient, project string, active, terminal []string, handoff string, log *slog.Logger) (domain.TrackerAdapter, error) {
+func newAdapter(client graphQLClient, project string, active, terminal []string, handoff string, queryFilter map[string]any, log *slog.Logger) (domain.TrackerAdapter, error) {
 	casingCache, err := runPreflight(context.Background(), client, project, active, terminal, handoff, log)
 	if err != nil {
 		return nil, err
@@ -130,9 +137,52 @@ func newAdapter(client graphQLClient, project string, active, terminal []string,
 		activeStates:   canonicalize(active, casingCache),
 		terminalStates: canonicalize(terminal, casingCache),
 		handoffState:   canonicalOne(handoff, casingCache),
+		queryFilter:    queryFilter,
 		casingCache:    casingCache,
 		log:            log,
 	}, nil
+}
+
+// parseQueryFilter decodes the operator-supplied query_filter into an
+// IssueFilter fragment. It returns nil with a nil error when raw is empty.
+//
+// A value that does not parse as JSON, parses as a non-object, or carries a
+// top-level reserved key returns a [*domain.TrackerError] of kind
+// [domain.ErrTrackerPayload]. The reserved-key check inspects "team" before
+// "state" so a fragment naming both always reports "team", keeping the error
+// message stable. The returned map is stored and merged into the fetch filter,
+// so the value travels in the GraphQL variables object, never the query text.
+func parseQueryFilter(raw string) (map[string]any, error) {
+	if raw == "" {
+		return nil, nil
+	}
+
+	var decoded any
+	if err := json.Unmarshal([]byte(raw), &decoded); err != nil {
+		return nil, &domain.TrackerError{
+			Kind:    domain.ErrTrackerPayload,
+			Message: fmt.Sprintf("linear: tracker.query_filter is not valid json: %v", err),
+		}
+	}
+
+	filter, ok := decoded.(map[string]any)
+	if !ok {
+		return nil, &domain.TrackerError{
+			Kind:    domain.ErrTrackerPayload,
+			Message: "linear: tracker.query_filter must be a json object",
+		}
+	}
+
+	for _, reserved := range []string{"team", "state"} {
+		if _, present := filter[reserved]; present {
+			return nil, &domain.TrackerError{
+				Kind:    domain.ErrTrackerPayload,
+				Message: fmt.Sprintf("linear: tracker.query_filter must not contain a reserved key %q", reserved),
+			}
+		}
+	}
+
+	return filter, nil
 }
 
 // canonicalize maps each configured name to its canonical casing from the
@@ -203,13 +253,32 @@ func (a *LinearAdapter) FetchIssuesByStates(ctx context.Context, states []string
 	return issues, err
 }
 
+// buildFetchFilter constructs the IssueFilter object for a single fetch from the
+// configured team, the supplied states, and the operator filter.
+//
+// It allocates a fresh map on every call and never writes into operatorFilter,
+// so concurrent fetches do not share or rewrite the stored fragment. The team
+// and state constraints are always set by the adapter; the reserved-key guard in
+// [parseQueryFilter] guarantees operatorFilter cannot overwrite them, and the
+// shallow copy leaves nested operator objects intact because Linear ANDs sibling
+// IssueFilter fields.
+func buildFetchFilter(teamKey string, states []string, operatorFilter map[string]any) map[string]any {
+	filter := map[string]any{
+		"team":  map[string]any{"key": map[string]any{"eq": teamKey}},
+		"state": map[string]any{"name": map[string]any{"in": states}},
+	}
+	for key, value := range operatorFilter {
+		filter[key] = value
+	}
+	return filter
+}
+
 // fetchIssues paginates the issues connection for the given query and states,
 // normalizing each node with Comments left nil.
 func (a *LinearAdapter) fetchIssues(ctx context.Context, query string, states []string) ([]domain.Issue, error) {
 	variables := map[string]any{
-		"teamKey": a.project,
-		"states":  states,
-		"first":   topLevelPageSize,
+		"filter": buildFetchFilter(a.project, states, a.queryFilter),
+		"first":  topLevelPageSize,
 	}
 
 	nodes, err := paginate(ctx, a.client, query, variables, decodeIssuesPage, a.log)

--- a/internal/tracker/linear/linear_test.go
+++ b/internal/tracker/linear/linear_test.go
@@ -4,7 +4,10 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"maps"
 	"reflect"
+	"slices"
+	"strings"
 	"testing"
 
 	"github.com/sortie-ai/sortie/internal/domain"
@@ -67,7 +70,7 @@ func TestNewAdapterSuccess(t *testing.T) {
 	f := newFakeClient()
 	seedPreflight(f, t)
 
-	got, err := newAdapter(f, "SOR", defaultActiveStates, defaultTerminalStates, "in review", nil)
+	got, err := newAdapter(f, "SOR", defaultActiveStates, defaultTerminalStates, "in review", nil, nil)
 	if err != nil {
 		t.Fatalf("newAdapter: %v", err)
 	}
@@ -83,6 +86,92 @@ func TestNewAdapterSuccess(t *testing.T) {
 	if !reflect.DeepEqual(adapter.activeStates, wantActive) {
 		t.Errorf("activeStates = %v, want %v", adapter.activeStates, wantActive)
 	}
+}
+
+func TestParseQueryFilter(t *testing.T) {
+	t.Parallel()
+
+	t.Run("rejects malformed and reserved filters as payload errors", func(t *testing.T) {
+		t.Parallel()
+
+		tests := []struct {
+			name        string
+			raw         string
+			wantKeyword string
+		}{
+			{"non-json string", "not json", ""},
+			{"json array", `["a", "b"]`, ""},
+			{"json number", "42", ""},
+			{"json string", `"backend"`, ""},
+			{"json boolean", "true", ""},
+			{"json null", "null", ""},
+			{"reserved team key", `{"team": {"key": {"eq": "ENG"}}}`, "team"},
+			{"reserved state key", `{"state": {"name": {"in": ["Done"]}}}`, "state"},
+			{"both reserved keys report team first", `{"team": {}, "state": {}}`, "team"},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+
+				got, err := parseQueryFilter(tt.raw)
+
+				if got != nil {
+					t.Errorf("parseQueryFilter(%q) = %v, want nil map on error", tt.raw, got)
+				}
+				assertTrackerErrorKind(t, err, domain.ErrTrackerPayload)
+				if tt.wantKeyword != "" {
+					var te *domain.TrackerError
+					if errors.As(err, &te) && !strings.Contains(te.Message, tt.wantKeyword) {
+						t.Errorf("parseQueryFilter(%q) message = %q, want it to name %q", tt.raw, te.Message, tt.wantKeyword)
+					}
+				}
+			})
+		}
+	})
+
+	t.Run("empty string is the unset passthrough", func(t *testing.T) {
+		t.Parallel()
+
+		got, err := parseQueryFilter("")
+		if err != nil {
+			t.Fatalf("parseQueryFilter(%q) = %v, want nil error", "", err)
+		}
+		if got != nil {
+			t.Errorf("parseQueryFilter(%q) = %v, want nil map", "", got)
+		}
+	})
+
+	t.Run("valid object is returned decoded", func(t *testing.T) {
+		t.Parallel()
+
+		raw := `{"labels": {"some": {"name": {"eq": "backend"}}}}`
+		got, err := parseQueryFilter(raw)
+		if err != nil {
+			t.Fatalf("parseQueryFilter(%q) = %v, want nil error", raw, err)
+		}
+		want := map[string]any{
+			"labels": map[string]any{"some": map[string]any{"name": map[string]any{"eq": "backend"}}},
+		}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("parseQueryFilter(%q) = %v, want %v", raw, got, want)
+		}
+	})
+
+	t.Run("empty object is a valid no-op map", func(t *testing.T) {
+		t.Parallel()
+
+		got, err := parseQueryFilter("{}")
+		if err != nil {
+			t.Fatalf("parseQueryFilter(%q) = %v, want nil error", "{}", err)
+		}
+		if got == nil {
+			t.Fatalf("parseQueryFilter(%q) = nil, want non-nil empty map", "{}")
+		}
+		if len(got) != 0 {
+			t.Errorf("parseQueryFilter(%q) = %v, want empty map", "{}", got)
+		}
+	})
 }
 
 func TestFetchCandidateIssues(t *testing.T) {
@@ -148,7 +237,7 @@ func TestFetchCandidateIssues(t *testing.T) {
 		}
 	})
 
-	t.Run("sends configured active states", func(t *testing.T) {
+	t.Run("sends configured active states inside the merged filter", func(t *testing.T) {
 		t.Parallel()
 
 		f := newFakeClient()
@@ -162,17 +251,124 @@ func TestFetchCandidateIssues(t *testing.T) {
 		}
 
 		call := f.callsFor("query CandidateIssues")[0]
-		states, ok := call.variables["states"].([]string)
-		if !ok {
-			t.Fatalf("states variable type = %T, want []string", call.variables["states"])
+		filter := assertFilterVar(t, call)
+		assertTeamFilter(t, filter)
+		assertStateFilter(t, filter, []string{"Backlog", "Todo", "In Progress"})
+		assertNoTopLevelVar(t, call, "teamKey")
+		assertNoTopLevelVar(t, call, "states")
+	})
+
+	t.Run("operator filter merges with team and state and returns the fixture issues", func(t *testing.T) {
+		t.Parallel()
+
+		f := newFakeClient()
+		seedPreflight(f, t)
+		f.queueBody("query CandidateIssues", loadFixture(t, "candidates_filtered.json"))
+
+		operatorFilter := map[string]any{
+			"labels": map[string]any{"some": map[string]any{"name": map[string]any{"eq": "backend"}}},
 		}
-		want := []string{"Backlog", "Todo", "In Progress"}
-		if !reflect.DeepEqual(states, want) {
-			t.Errorf("states = %v, want %v", states, want)
+		adapter := newTestAdapterWithFilter(t, f, operatorFilter)
+
+		issues, err := adapter.FetchCandidateIssues(context.Background())
+		if err != nil {
+			t.Fatalf("FetchCandidateIssues: %v", err)
 		}
-		if call.variables["teamKey"] != "SOR" {
-			t.Errorf("teamKey = %v, want %q", call.variables["teamKey"], "SOR")
+
+		gotOrder := identifiers(issues)
+		wantOrder := []string{"SOR-7", "SOR-5"}
+		if !reflect.DeepEqual(gotOrder, wantOrder) {
+			t.Errorf("FetchCandidateIssues order = %v, want %v (exactly the fixture issues)", gotOrder, wantOrder)
 		}
+
+		call := f.callsFor("query CandidateIssues")[0]
+		filter := assertFilterVar(t, call)
+		assertTeamFilter(t, filter)
+		assertStateFilter(t, filter, []string{"Backlog", "Todo", "In Progress"})
+		if !reflect.DeepEqual(filter["labels"], operatorFilter["labels"]) {
+			t.Errorf("filter[labels] = %v, want %v (operator fragment copied verbatim)", filter["labels"], operatorFilter["labels"])
+		}
+		assertFilterKeys(t, filter, []string{"team", "state", "labels"})
+	})
+
+	t.Run("unset filter passes through exactly team and state", func(t *testing.T) {
+		t.Parallel()
+
+		f := newFakeClient()
+		seedPreflight(f, t)
+		f.queueBody("query CandidateIssues", loadFixture(t, "issues_empty.json"))
+
+		adapter := newTestAdapterWithFilter(t, f, nil)
+
+		if _, err := adapter.FetchCandidateIssues(context.Background()); err != nil {
+			t.Fatalf("FetchCandidateIssues: %v", err)
+		}
+
+		call := f.callsFor("query CandidateIssues")[0]
+		filter := assertFilterVar(t, call)
+		assertTeamFilter(t, filter)
+		assertStateFilter(t, filter, []string{"Backlog", "Todo", "In Progress"})
+		assertFilterKeys(t, filter, []string{"team", "state"})
+	})
+
+	t.Run("empty-object filter is a no-op equal to the passthrough object", func(t *testing.T) {
+		t.Parallel()
+
+		f := newFakeClient()
+		seedPreflight(f, t)
+		f.queueBody("query CandidateIssues", loadFixture(t, "issues_empty.json"))
+
+		parsed, err := parseQueryFilter("{}")
+		if err != nil {
+			t.Fatalf("parseQueryFilter(%q) = %v, want nil error", "{}", err)
+		}
+		adapter := newTestAdapterWithFilter(t, f, parsed)
+
+		if _, err := adapter.FetchCandidateIssues(context.Background()); err != nil {
+			t.Fatalf("FetchCandidateIssues: %v", err)
+		}
+
+		call := f.callsFor("query CandidateIssues")[0]
+		filter := assertFilterVar(t, call)
+		assertTeamFilter(t, filter)
+		assertStateFilter(t, filter, []string{"Backlog", "Todo", "In Progress"})
+		assertFilterKeys(t, filter, []string{"team", "state"})
+	})
+
+	t.Run("multi-page filtered fetch carries the cursor and the same filter on page two", func(t *testing.T) {
+		t.Parallel()
+
+		f := newFakeClient()
+		seedPreflight(f, t)
+		f.queueBody("query CandidateIssues", loadFixture(t, "candidates_page1.json"))
+		f.queueBody("query CandidateIssues", loadFixture(t, "candidates_page2.json"))
+
+		operatorFilter := map[string]any{
+			"assignee": map[string]any{"isMe": map[string]any{"eq": true}},
+		}
+		adapter := newTestAdapterWithFilter(t, f, operatorFilter)
+
+		if _, err := adapter.FetchCandidateIssues(context.Background()); err != nil {
+			t.Fatalf("FetchCandidateIssues: %v", err)
+		}
+
+		calls := f.callsFor("query CandidateIssues")
+		if len(calls) != 2 {
+			t.Fatalf("CandidateIssues call count = %d, want 2 (one per page)", len(calls))
+		}
+
+		wantCursor := "eyJrZXkiOiJiMmQ5ZTRhMS0zYzdmLTRiOGUtOWQyYS0xZjZjNWI0ZTNhMmQiLCJjcmVhdGVkQXQiOiIyMDI2LTA2LTA5In0="
+		if got := calls[1].variables["after"]; got != wantCursor {
+			t.Errorf("second page after = %v, want %q (page-1 end cursor)", got, wantCursor)
+		}
+
+		filter := assertFilterVar(t, calls[1])
+		assertTeamFilter(t, filter)
+		assertStateFilter(t, filter, []string{"Backlog", "Todo", "In Progress"})
+		if !reflect.DeepEqual(filter["assignee"], operatorFilter["assignee"]) {
+			t.Errorf("second page filter[assignee] = %v, want %v (filter reused across pages)", filter["assignee"], operatorFilter["assignee"])
+		}
+		assertFilterKeys(t, filter, []string{"team", "state", "assignee"})
 	})
 }
 
@@ -198,7 +394,7 @@ func TestFetchIssuesByStates(t *testing.T) {
 		}
 	})
 
-	t.Run("canonical-cases supplied states and omits sort", func(t *testing.T) {
+	t.Run("canonical-cases supplied states inside the merged filter", func(t *testing.T) {
 		t.Parallel()
 
 		f := newFakeClient()
@@ -215,14 +411,40 @@ func TestFetchIssuesByStates(t *testing.T) {
 		if len(calls) != 1 {
 			t.Fatalf("IssuesByStates call count = %d, want 1", len(calls))
 		}
-		states, ok := calls[0].variables["states"].([]string)
-		if !ok {
-			t.Fatalf("states variable type = %T, want []string", calls[0].variables["states"])
+		filter := assertFilterVar(t, calls[0])
+		assertTeamFilter(t, filter)
+		assertStateFilter(t, filter, []string{"Done", "Canceled"})
+		assertNoTopLevelVar(t, calls[0], "states")
+		assertNoTopLevelVar(t, calls[0], "teamKey")
+	})
+
+	t.Run("operator filter merges with team and supplied states", func(t *testing.T) {
+		t.Parallel()
+
+		f := newFakeClient()
+		seedPreflight(f, t)
+		f.queueBody("query IssuesByStates", loadFixture(t, "issues_empty.json"))
+
+		operatorFilter := map[string]any{
+			"labels": map[string]any{"some": map[string]any{"name": map[string]any{"eq": "backend"}}},
 		}
-		want := []string{"Done", "Canceled"}
-		if !reflect.DeepEqual(states, want) {
-			t.Errorf("states = %v, want %v (canonical casing)", states, want)
+		adapter := newTestAdapterWithFilter(t, f, operatorFilter)
+
+		if _, err := adapter.FetchIssuesByStates(context.Background(), []string{"done", "CANCELED"}); err != nil {
+			t.Fatalf("FetchIssuesByStates: %v", err)
 		}
+
+		calls := f.callsFor("query IssuesByStates")
+		if len(calls) != 1 {
+			t.Fatalf("IssuesByStates call count = %d, want 1", len(calls))
+		}
+		filter := assertFilterVar(t, calls[0])
+		assertTeamFilter(t, filter)
+		assertStateFilter(t, filter, []string{"Done", "Canceled"})
+		if !reflect.DeepEqual(filter["labels"], operatorFilter["labels"]) {
+			t.Errorf("filter[labels] = %v, want %v (operator fragment copied verbatim)", filter["labels"], operatorFilter["labels"])
+		}
+		assertFilterKeys(t, filter, []string{"team", "state", "labels"})
 	})
 }
 
@@ -464,6 +686,26 @@ func TestFetchIssueStatesByIDs(t *testing.T) {
 		}
 	})
 
+	t.Run("a configured filter introduces no filter variable", func(t *testing.T) {
+		t.Parallel()
+
+		f := newFakeClient()
+		seedPreflight(f, t)
+		f.queueBody("query IssueStatesByIDs", loadFixture(t, "states_by_ids.json"))
+
+		operatorFilter := map[string]any{
+			"labels": map[string]any{"some": map[string]any{"name": map[string]any{"eq": "backend"}}},
+		}
+		adapter := newTestAdapterWithFilter(t, f, operatorFilter)
+
+		if _, err := adapter.FetchIssueStatesByIDs(context.Background(), []string{"a7c4f8e2-1b9d-4e3a-8f2c-6d5e4a3b2c1f"}); err != nil {
+			t.Fatalf("FetchIssueStatesByIDs: %v", err)
+		}
+
+		call := f.callsFor("query IssueStatesByIDs")[0]
+		assertVarKeys(t, call, []string{"ids", "first"})
+	})
+
 	t.Run("checks context cancellation before each chunk", func(t *testing.T) {
 		t.Parallel()
 
@@ -536,6 +778,29 @@ func TestFetchIssueStatesByIdentifiers(t *testing.T) {
 		wantNumbers := []float64{5, 7, 99999}
 		if !reflect.DeepEqual(numbers, wantNumbers) {
 			t.Errorf("numbers = %v, want %v", numbers, wantNumbers)
+		}
+	})
+
+	t.Run("a configured filter introduces no filter variable and keeps teamKey", func(t *testing.T) {
+		t.Parallel()
+
+		f := newFakeClient()
+		seedPreflight(f, t)
+		f.queueBody("query IssueStatesByNumbers", loadFixture(t, "states_by_numbers.json"))
+
+		operatorFilter := map[string]any{
+			"labels": map[string]any{"some": map[string]any{"name": map[string]any{"eq": "backend"}}},
+		}
+		adapter := newTestAdapterWithFilter(t, f, operatorFilter)
+
+		if _, err := adapter.FetchIssueStatesByIdentifiers(context.Background(), []string{"SOR-5", "SOR-7"}); err != nil {
+			t.Fatalf("FetchIssueStatesByIdentifiers: %v", err)
+		}
+
+		call := f.callsFor("query IssueStatesByNumbers")[0]
+		assertVarKeys(t, call, []string{"teamKey", "numbers", "first"})
+		if call.variables["teamKey"] != "SOR" {
+			t.Errorf("teamKey = %v, want %q (reconciliation query is unchanged)", call.variables["teamKey"], "SOR")
 		}
 	})
 
@@ -1529,6 +1794,91 @@ func TestWriteErrorMapping(t *testing.T) {
 }
 
 // --- local helpers ---
+
+// assertFilterVar returns the recorded filter operation variable as a map,
+// failing the test when it is absent or not a map.
+func assertFilterVar(t *testing.T, call recordedCall) map[string]any {
+	t.Helper()
+	filter, ok := call.variables["filter"].(map[string]any)
+	if !ok {
+		t.Fatalf("filter variable type = %T, want map[string]any", call.variables["filter"])
+	}
+	return filter
+}
+
+// assertTeamFilter asserts the adapter-owned team constraint nested as
+// team.key.eq inside the merged filter. The offline harness always configures
+// team SOR, so the expected key is fixed.
+func assertTeamFilter(t *testing.T, filter map[string]any) {
+	t.Helper()
+	const wantKey = "SOR"
+	team, ok := filter["team"].(map[string]any)
+	if !ok {
+		t.Fatalf("filter[team] type = %T, want map[string]any", filter["team"])
+	}
+	key, ok := team["key"].(map[string]any)
+	if !ok {
+		t.Fatalf("filter[team][key] type = %T, want map[string]any", team["key"])
+	}
+	if key["eq"] != wantKey {
+		t.Errorf("filter[team][key][eq] = %v, want %q", key["eq"], wantKey)
+	}
+}
+
+// assertStateFilter asserts the adapter-owned state constraint nested as
+// state.name.in inside the merged filter. The in value is the canonical-cased
+// Go []string the adapter builds, not a []any.
+func assertStateFilter(t *testing.T, filter map[string]any, wantStates []string) {
+	t.Helper()
+	state, ok := filter["state"].(map[string]any)
+	if !ok {
+		t.Fatalf("filter[state] type = %T, want map[string]any", filter["state"])
+	}
+	name, ok := state["name"].(map[string]any)
+	if !ok {
+		t.Fatalf("filter[state][name] type = %T, want map[string]any", state["name"])
+	}
+	in, ok := name["in"].([]string)
+	if !ok {
+		t.Fatalf("filter[state][name][in] type = %T, want []string", name["in"])
+	}
+	if !reflect.DeepEqual(in, wantStates) {
+		t.Errorf("filter[state][name][in] = %v, want %v", in, wantStates)
+	}
+}
+
+// assertFilterKeys asserts the merged filter has exactly the expected top-level
+// keys and no others.
+func assertFilterKeys(t *testing.T, filter map[string]any, want []string) {
+	t.Helper()
+	got := slices.Sorted(maps.Keys(filter))
+	wantSorted := slices.Clone(want)
+	slices.Sort(wantSorted)
+	if !reflect.DeepEqual(got, wantSorted) {
+		t.Errorf("filter top-level keys = %v, want %v", got, wantSorted)
+	}
+}
+
+// assertVarKeys asserts a recorded call's variable map has exactly the expected
+// keys and no others, so a stray filter variable is caught.
+func assertVarKeys(t *testing.T, call recordedCall, want []string) {
+	t.Helper()
+	got := slices.Sorted(maps.Keys(call.variables))
+	wantSorted := slices.Clone(want)
+	slices.Sort(wantSorted)
+	if !reflect.DeepEqual(got, wantSorted) {
+		t.Errorf("variable keys = %v, want %v", got, wantSorted)
+	}
+}
+
+// assertNoTopLevelVar asserts the named variable is absent from the recorded
+// call, used to confirm the folded teamKey/states no longer travel top-level.
+func assertNoTopLevelVar(t *testing.T, call recordedCall, name string) {
+	t.Helper()
+	if _, present := call.variables[name]; present {
+		t.Errorf("variable %q present = %v, want absent (folded into filter)", name, call.variables[name])
+	}
+}
 
 func identifiers(issues []domain.Issue) []string {
 	out := make([]string, len(issues))

--- a/internal/tracker/linear/preflight_test.go
+++ b/internal/tracker/linear/preflight_test.go
@@ -121,7 +121,7 @@ func TestRunPreflight(t *testing.T) {
 		f := newFakeClient()
 		f.queueBody("query Me", loadFixture(t, "auth_error.json"))
 
-		_, err := newAdapter(f, "SOR", defaultActiveStates, defaultTerminalStates, "", nil)
+		_, err := newAdapter(f, "SOR", defaultActiveStates, defaultTerminalStates, "", nil, nil)
 
 		assertTrackerErrorKind(t, err, domain.ErrTrackerAuth)
 	})

--- a/internal/tracker/linear/query.go
+++ b/internal/tracker/linear/query.go
@@ -3,11 +3,11 @@ package linear
 // queryCandidateIssues fetches issues in the configured team and active states,
 // ordered by the server sort hint. The client re-sorts results by normalized
 // priority, so the sort argument is only a coarse stable order for the fetch.
-const queryCandidateIssues = `query CandidateIssues($teamKey: String!, $states: [String!]!, $first: Int!, $after: String) {
+const queryCandidateIssues = `query CandidateIssues($filter: IssueFilter!, $first: Int!, $after: String) {
   issues(
     first: $first
     after: $after
-    filter: { team: { key: { eq: $teamKey } }, state: { name: { in: $states } } }
+    filter: $filter
     sort: [{ priority: { order: Ascending, noPriorityFirst: false } }, { createdAt: { order: Ascending } }]
   ) {
     nodes {
@@ -24,11 +24,11 @@ const queryCandidateIssues = `query CandidateIssues($teamKey: String!, $states: 
 
 // queryIssuesByStates is the candidate query without the sort argument, used
 // for terminal cleanup where dispatch order is irrelevant.
-const queryIssuesByStates = `query IssuesByStates($teamKey: String!, $states: [String!]!, $first: Int!, $after: String) {
+const queryIssuesByStates = `query IssuesByStates($filter: IssueFilter!, $first: Int!, $after: String) {
   issues(
     first: $first
     after: $after
-    filter: { team: { key: { eq: $teamKey } }, state: { name: { in: $states } } }
+    filter: $filter
   ) {
     nodes {
       id identifier title description priority branchName url createdAt updatedAt

--- a/internal/tracker/linear/testdata/candidates_filtered.json
+++ b/internal/tracker/linear/testdata/candidates_filtered.json
@@ -1,0 +1,65 @@
+{
+  "data": {
+    "issues": {
+      "nodes": [
+        {
+          "id": "a7c4f8e2-1b9d-4e3a-8f2c-6d5e4a3b2c1f",
+          "identifier": "SOR-5",
+          "title": "Implement the read path",
+          "description": "First issue body in **markdown**.",
+          "priority": 2,
+          "branchName": "tasks/sor-5-implement-the-read-path",
+          "url": "https://linear.app/sortie-ai/issue/SOR-5/implement-the-read-path",
+          "createdAt": "2026-06-10T09:00:00.000Z",
+          "updatedAt": "2026-06-12T14:30:00.000Z",
+          "state": { "name": "Todo" },
+          "assignee": { "displayName": "Ada Lovelace", "name": "ada", "email": "ada@example.com" },
+          "parent": null,
+          "labels": {
+            "nodes": [{ "name": "Feature" }, { "name": "Backend" }],
+            "pageInfo": { "hasNextPage": false }
+          },
+          "inverseRelations": {
+            "nodes": [],
+            "pageInfo": { "hasNextPage": false }
+          }
+        },
+        {
+          "id": "c3e0f5b2-4d8a-4c9f-ae3b-2a7d6c5f4b3e",
+          "identifier": "SOR-7",
+          "title": "Blocked, urgent priority",
+          "description": "Blocked by SOR-5.",
+          "priority": 1,
+          "branchName": "tasks/sor-7-blocked",
+          "url": "https://linear.app/sortie-ai/issue/SOR-7/blocked",
+          "createdAt": "2026-06-11T10:00:00.000Z",
+          "updatedAt": "2026-06-12T11:00:00.000Z",
+          "state": { "name": "Backlog" },
+          "assignee": { "displayName": "", "name": "grace", "email": "grace@example.com" },
+          "parent": null,
+          "labels": {
+            "nodes": [{ "name": "Bug" }],
+            "pageInfo": { "hasNextPage": false }
+          },
+          "inverseRelations": {
+            "nodes": [
+              {
+                "type": "blocks",
+                "issue": {
+                  "id": "a7c4f8e2-1b9d-4e3a-8f2c-6d5e4a3b2c1f",
+                  "identifier": "SOR-5",
+                  "state": { "name": "Todo" }
+                }
+              }
+            ],
+            "pageInfo": { "hasNextPage": false }
+          }
+        }
+      ],
+      "pageInfo": {
+        "hasNextPage": false,
+        "endCursor": "eyJrZXkiOiJjM2UwZjViMi00ZDhhLTRjOWYtYWUzYi0yYTdkNmM1ZjRiM2UifQ=="
+      }
+    }
+  }
+}


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Feat

**Intent:** Add `tracker.query_filter` support to the Linear adapter so operators can narrow the candidate issue set by supplying a JSON IssueFilter fragment alongside the adapter-owned team and state constraints, matching the filtering capability already available in the Jira and GitHub adapters.

**Related Issues:** Closes #599

### 🧭 Reviewer Guide

**Complexity:** Medium

#### Entry Point

Start with `internal/tracker/linear/linear.go`. `parseQueryFilter` decodes and validates the operator-supplied JSON fragment at construction time, and `buildFetchFilter` merges it with the adapter-owned team and state constraints on every fetch. The two fetch queries in `internal/tracker/linear/query.go` were refactored from separate `$teamKey`/`$states` variables to a single `$filter: IssueFilter!` variable to enable the merge.

#### Sensitive Areas

- `internal/tracker/linear/linear.go` (`parseQueryFilter`): Reserved-key check inspects `"team"` before `"state"`, so a fragment containing both always reports `"team"`. This is intentional for stable error messages.
- `internal/tracker/linear/linear.go` (`buildFetchFilter`): Operator keys are copied into the filter map after the adapter sets `team` and `state`. The reserved-key guard in `parseQueryFilter` prevents an operator overwriting those keys; confirm the shallow copy does not allow overwrite via a nested path.
- `internal/tracker/linear/query.go`: Both `queryCandidateIssues` and `queryIssuesByStates` now pass a single `$filter` variable. The GraphQL variable is constructed in `buildFetchFilter` - verify the adapter constraints cannot be shadowed.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes. The `query_filter` config key already existed in the shared schema; the Linear adapter now consumes it. The `newAdapter` internal constructor signature changed (added `queryFilter` parameter) but it is package-private.
- **Migrations/State:** No migrations or state changes.
