### PR TITLE
refactor: apply Go modernize idioms across codebase

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,20 +6,20 @@ run:
 linters:
   default: standard
   enable:
+    - bodyclose
     - copyloopvar
     - errcheck
+    - gosec
     - govet
     - ineffassign
-    - staticcheck
-    - unused
     - misspell
+    - modernize
+    - noctx
+    - sloglint
+    - staticcheck
     - unconvert
     - unparam
-    - sloglint
-    - bodyclose
-    - noctx
-    - gosec
-    - modernize
+    - unused
   settings:
     sloglint:
       attr-only: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,11 +19,18 @@ linters:
     - bodyclose
     - noctx
     - gosec
+    - modernize
   settings:
     sloglint:
       attr-only: true
       static-msg: true
       key-naming-case: snake
+    modernize:
+      disable:
+        # omitempty -> omitzero changes JSON marshaling on struct-typed fields.
+        - omitzero
+        # new(expr) rewrites leave //go:fix inline wrappers and mixed call sites.
+        - newexpr
   exclusions:
     rules:
       - path: _test\.go

--- a/cmd/sortie/main_test.go
+++ b/cmd/sortie/main_test.go
@@ -291,7 +291,7 @@ func TestRunPortFlagLogged(t *testing.T) {
 }
 
 func quickStartWorkflow(issuesPath, workspaceRoot string) []byte {
-	return []byte(fmt.Sprintf(`---
+	return fmt.Appendf(nil, `---
 tracker:
   kind: file
   project: DEMO
@@ -318,7 +318,7 @@ Fix the following issue.
 **{{ .issue.identifier }}**: {{ .issue.title }}
 
 {{ .issue.description }}
-`, issuesPath, workspaceRoot))
+`, issuesPath, workspaceRoot)
 }
 
 // quickStartIssues returns issues.json content matching the
@@ -569,8 +569,8 @@ func TestRunServerShutdownError(t *testing.T) {
 	deadline := time.Now().Add(startWait)
 	for time.Now().Before(deadline) {
 		if log := stderr.String(); strings.Contains(log, "http server listening") {
-			if i := strings.Index(log, "addr="); i >= 0 {
-				rest := log[i+5:]
+			if _, after, ok := strings.Cut(log, "addr="); ok {
+				rest := after
 				if end := strings.IndexAny(rest, " \t\n\r"); end >= 0 {
 					addr = rest[:end]
 				} else {
@@ -667,7 +667,7 @@ func TestRunReadOnlyWorkflowDir(t *testing.T) {
 }
 
 func minimalWorkflowWithLogLevel(level string) []byte {
-	return []byte(fmt.Sprintf(`---
+	return fmt.Appendf(nil, `---
 polling:
   interval_ms: 30000
 tracker:
@@ -686,7 +686,7 @@ logging:
   level: %s
 ---
 Do {{ .issue.title }}.
-`, level))
+`, level)
 }
 
 // writeWorkflowFileWithContent writes the given content as WORKFLOW.md
@@ -994,7 +994,7 @@ func TestRunInvalidHost(t *testing.T) {
 }
 
 func minimalWorkflowWithLogFormat(format string) []byte {
-	return []byte(fmt.Sprintf(`---
+	return fmt.Appendf(nil, `---
 polling:
   interval_ms: 30000
 tracker:
@@ -1013,7 +1013,7 @@ logging:
   format: %s
 ---
 Do {{ .issue.title }}.
-`, format))
+`, format)
 }
 
 func TestRunLogFormatJSON(t *testing.T) {
@@ -1029,7 +1029,7 @@ func TestRunLogFormatJSON(t *testing.T) {
 	}
 
 	foundStarting := false
-	for _, line := range strings.Split(stderr.String(), "\n") {
+	for line := range strings.SplitSeq(stderr.String(), "\n") {
 		if line == "" {
 			continue
 		}
@@ -1064,7 +1064,7 @@ func TestRunLogFormatText(t *testing.T) {
 	if !strings.Contains(stderr.String(), "level=INFO") {
 		t.Errorf("stderr = %q, want to contain %q", stderr.String(), "level=INFO")
 	}
-	for _, line := range strings.Split(stderr.String(), "\n") {
+	for line := range strings.SplitSeq(stderr.String(), "\n") {
 		if line != "" {
 			if strings.HasPrefix(line, "{") {
 				t.Errorf("first non-empty stderr line %q starts with '{', expected text format", line)
@@ -1089,7 +1089,7 @@ func TestRunLogFormatDefault(t *testing.T) {
 	if !strings.Contains(stderr.String(), "level=INFO") {
 		t.Errorf("stderr = %q, want to contain %q", stderr.String(), "level=INFO")
 	}
-	for _, line := range strings.Split(stderr.String(), "\n") {
+	for line := range strings.SplitSeq(stderr.String(), "\n") {
 		if line != "" {
 			if strings.HasPrefix(line, "{") {
 				t.Errorf("first non-empty stderr line %q starts with '{', want text format by default", line)
@@ -1137,7 +1137,7 @@ func TestRunLogFormatCaseInsensitive(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("exit code = %d, want 0; stderr: %s", code, stderr.String())
 	}
-	for _, line := range strings.Split(stderr.String(), "\n") {
+	for line := range strings.SplitSeq(stderr.String(), "\n") {
 		if line == "" {
 			continue
 		}
@@ -1162,7 +1162,7 @@ func TestRunLogFormatFromExtension(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("exit code = %d, want 0; stderr: %s", code, stderr.String())
 	}
-	for _, line := range strings.Split(stderr.String(), "\n") {
+	for line := range strings.SplitSeq(stderr.String(), "\n") {
 		if line == "" {
 			continue
 		}
@@ -1191,7 +1191,7 @@ func TestRunLogFormatFlagOverridesExtension(t *testing.T) {
 	if !strings.Contains(stderr.String(), "level=INFO") {
 		t.Errorf("stderr = %q, want to contain %q (flag wins over extension)", stderr.String(), "level=INFO")
 	}
-	for _, line := range strings.Split(stderr.String(), "\n") {
+	for line := range strings.SplitSeq(stderr.String(), "\n") {
 		if line != "" {
 			if strings.HasPrefix(line, "{") {
 				t.Errorf("first non-empty stderr line %q starts with '{', want text format (flag wins)", line)
@@ -1327,7 +1327,7 @@ func TestRunLongHelp(t *testing.T) {
 // reactions.auto_merge but an empty provider, so the auto-merge feature is
 // disabled and no SCM adapter initialization is attempted.
 func autoMergeWorkflowNoProvider(issuesPath, workspaceRoot string) []byte {
-	return []byte(fmt.Sprintf(`---
+	return fmt.Appendf(nil, `---
 tracker:
   kind: file
   project: DEMO
@@ -1354,13 +1354,13 @@ reactions:
 ---
 
 Fix issue {{ .issue.identifier }}.
-`, issuesPath, workspaceRoot))
+`, issuesPath, workspaceRoot)
 }
 
 // autoMergeWorkflowUnknownProvider returns a WORKFLOW.md with an unknown SCM
 // provider, which should cause startup to fail with exit code 1.
 func autoMergeWorkflowUnknownProvider(issuesPath, workspaceRoot string) []byte {
-	return []byte(fmt.Sprintf(`---
+	return fmt.Appendf(nil, `---
 tracker:
   kind: file
   project: DEMO
@@ -1387,14 +1387,14 @@ reactions:
 ---
 
 Fix issue {{ .issue.identifier }}.
-`, issuesPath, workspaceRoot))
+`, issuesPath, workspaceRoot)
 }
 
 // autoMergeWorkflowMismatchedProviders returns a WORKFLOW.md where
 // review_comments and auto_merge use different SCM providers, which should
 // cause startup to fail with exit code 1.
 func autoMergeWorkflowMismatchedProviders(issuesPath, workspaceRoot string) []byte {
-	return []byte(fmt.Sprintf(`---
+	return fmt.Appendf(nil, `---
 tracker:
   kind: file
   project: DEMO
@@ -1423,7 +1423,7 @@ reactions:
 ---
 
 Fix issue {{ .issue.identifier }}.
-`, issuesPath, workspaceRoot))
+`, issuesPath, workspaceRoot)
 }
 
 // TestRunAutoMerge_EmptyProvider verifies that when reactions.auto_merge.provider

--- a/cmd/sortie/mcpserver_test.go
+++ b/cmd/sortie/mcpserver_test.go
@@ -97,7 +97,7 @@ func buildMCPRequest(t *testing.T, method string, id any, params any) string {
 func parseMCPResponses(t *testing.T, data []byte) []map[string]any {
 	t.Helper()
 	var results []map[string]any
-	for _, line := range bytes.Split(data, []byte("\n")) {
+	for line := range bytes.SplitSeq(data, []byte("\n")) {
 		line = bytes.TrimSpace(line)
 		if len(line) == 0 {
 			continue

--- a/cmd/sortie/resolve_test.go
+++ b/cmd/sortie/resolve_test.go
@@ -344,7 +344,7 @@ func TestTrackerConfigMapCompleteness(t *testing.T) {
 	t.Parallel()
 
 	m := trackerConfigMap(config.TrackerConfig{})
-	rt := reflect.TypeOf(config.TrackerConfig{})
+	rt := reflect.TypeFor[config.TrackerConfig]()
 
 	for _, field := range reflect.VisibleFields(rt) {
 		if !field.IsExported() {
@@ -361,7 +361,7 @@ func TestAgentConfigMapCompleteness(t *testing.T) {
 	t.Parallel()
 
 	m := agentConfigMap(config.AgentConfig{})
-	rt := reflect.TypeOf(config.AgentConfig{})
+	rt := reflect.TypeFor[config.AgentConfig]()
 
 	// Orchestrator-only fields are intentionally excluded from the
 	// adapter config map. They are consumed by the orchestrator via

--- a/cmd/sortie/sessiontools_test.go
+++ b/cmd/sortie/sessiontools_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 
@@ -111,13 +112,7 @@ func testLogger(buf *bytes.Buffer) *slog.Logger {
 func assertContainsAll(t *testing.T, label string, got, want []string) {
 	t.Helper()
 	for _, w := range want {
-		found := false
-		for _, g := range got {
-			if g == w {
-				found = true
-				break
-			}
-		}
+		found := slices.Contains(got, w)
 		if !found {
 			t.Errorf("%s: missing %q; got %v", label, w, got)
 		}
@@ -128,11 +123,8 @@ func assertContainsAll(t *testing.T, label string, got, want []string) {
 func assertContainsNone(t *testing.T, label string, got, absent []string) {
 	t.Helper()
 	for _, a := range absent {
-		for _, g := range got {
-			if g == a {
-				t.Errorf("%s: unexpected tool %q present; got %v", label, a, got)
-				break
-			}
+		if slices.Contains(got, a) {
+			t.Errorf("%s: unexpected tool %q present; got %v", label, a, got)
 		}
 	}
 }

--- a/internal/agent/agentcore/tooltracker.go
+++ b/internal/agent/agentcore/tooltracker.go
@@ -44,9 +44,6 @@ func (t *ToolTracker) End(id string) (name string, durationMS int64, ok bool) {
 		return "", 0, false
 	}
 	delete(t.entries, id)
-	ms := time.Since(entry.ts).Milliseconds()
-	if ms <= 0 {
-		ms = 0
-	}
+	ms := max(time.Since(entry.ts).Milliseconds(), 0)
 	return entry.name, ms, true
 }

--- a/internal/agent/agenttest/logspy.go
+++ b/internal/agent/agenttest/logspy.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"strings"
 	"sync"
 	"testing"
 )
@@ -103,12 +104,12 @@ func formatEntries(entries []LogSpyEntry) string {
 	if len(entries) == 0 {
 		return "(none)"
 	}
-	var s string
+	var s strings.Builder
 	for i, e := range entries {
 		if i > 0 {
-			s += ", "
+			s.WriteString(", ")
 		}
-		s += fmt.Sprintf("{%s %q line=%q}", e.Level, e.Msg, e.Line)
+		fmt.Fprintf(&s, "{%s %q line=%q}", e.Level, e.Msg, e.Line)
 	}
-	return s
+	return s.String()
 }

--- a/internal/agent/claude/claude.go
+++ b/internal/agent/claude/claude.go
@@ -443,17 +443,17 @@ func truncateToolError(s string, maxLen int) string {
 	if len(s) <= maxLen {
 		return s
 	}
-	nlPos := strings.IndexByte(s, '\n')
-	if nlPos == -1 {
+	before, after, ok := strings.Cut(s, "\n")
+	if !ok {
 		return tailBytes(s, maxLen)
 	}
-	firstLine := s[:nlPos]
+	firstLine := before
 	const sep = "\n...\n"
 	tailBudget := maxLen - len(firstLine) - len(sep)
 	if tailBudget <= 0 {
 		return tailBytes(s, maxLen)
 	}
-	tail := tailBytes(s[nlPos+1:], tailBudget)
+	tail := tailBytes(after, tailBudget)
 	return firstLine + sep + tail
 }
 

--- a/internal/agent/claude/claude_test.go
+++ b/internal/agent/claude/claude_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -351,7 +352,7 @@ func TestBuildArgs(t *testing.T) {
 
 			for i := 0; i < len(tt.wantArgs); i++ {
 				found := false
-				for j := 0; j < len(got); j++ {
+				for j := range got {
 					if got[j] == tt.wantArgs[i] {
 						// Check value arg too if there's a pair.
 						if i+1 < len(tt.wantArgs) && j+1 < len(got) && got[j+1] == tt.wantArgs[i+1] {
@@ -372,11 +373,8 @@ func TestBuildArgs(t *testing.T) {
 			}
 
 			for _, absent := range tt.wantAbsent {
-				for _, a := range got {
-					if a == absent {
-						t.Errorf("unexpected arg %q in: %s", absent, argStr)
-						break
-					}
+				if slices.Contains(got, absent) {
+					t.Errorf("unexpected arg %q in: %s", absent, argStr)
 				}
 			}
 		})
@@ -389,13 +387,7 @@ func TestBuildArgs_AlwaysPresent(t *testing.T) {
 	got := buildArgs(&sessionState{claudeSessionID: "x"}, 1, "p", passthroughConfig{SessionPersistence: true})
 	required := []string{"-p", "--output-format", "--verbose"}
 	for _, r := range required {
-		found := false
-		for _, a := range got {
-			if a == r {
-				found = true
-				break
-			}
-		}
+		found := slices.Contains(got, r)
 		if !found {
 			t.Errorf("required flag %q missing in %v", r, got)
 		}

--- a/internal/agent/claude/command_test.go
+++ b/internal/agent/claude/command_test.go
@@ -1,6 +1,7 @@
 package claude
 
 import (
+	"slices"
 	"strings"
 	"testing"
 )
@@ -20,11 +21,9 @@ func assertHasArgPair(t *testing.T, args []string, flag, value string) {
 // assertNoFlag fails if flag appears anywhere in args.
 func assertNoFlag(t *testing.T, args []string, flag string) {
 	t.Helper()
-	for _, a := range args {
-		if a == flag {
-			t.Errorf("buildArgs() unexpectedly contains flag %q in [%s]", flag, strings.Join(args, " "))
-			return
-		}
+	if slices.Contains(args, flag) {
+		t.Errorf("buildArgs() unexpectedly contains flag %q in [%s]", flag, strings.Join(args, " "))
+		return
 	}
 }
 

--- a/internal/agent/codex/codex.go
+++ b/internal/agent/codex/codex.go
@@ -686,9 +686,7 @@ func (a *CodexAdapter) handleToolCall(ctx context.Context, state *sessionState, 
 		}
 	}
 
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		start := time.Now()
 		result, execErr := tool.Execute(ctx, tc.Arguments)
 
@@ -717,7 +715,7 @@ func (a *CodexAdapter) handleToolCall(ctx context.Context, state *sessionState, 
 				ToolDurationMS: time.Since(start).Milliseconds(),
 			}
 		}
-	}()
+	})
 	return nil
 }
 

--- a/internal/agent/codex/protocol.go
+++ b/internal/agent/codex/protocol.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"maps"
 	"os"
 	"time"
 
@@ -437,9 +438,7 @@ func buildSandboxPolicy(state *sessionState, pt passthroughConfig) map[string]an
 	}
 
 	if pt.TurnSandboxPolicy != nil {
-		for k, v := range pt.TurnSandboxPolicy {
-			policy[k] = v
-		}
+		maps.Copy(policy, pt.TurnSandboxPolicy)
 	}
 	return policy
 }

--- a/internal/agent/copilot/command_test.go
+++ b/internal/agent/copilot/command_test.go
@@ -1,6 +1,7 @@
 package copilot
 
 import (
+	"slices"
 	"strings"
 	"testing"
 )
@@ -20,10 +21,8 @@ func assertHasArgPair(t *testing.T, args []string, flag, value string) {
 // assertHasFlag fails if flag does not appear anywhere in args.
 func assertHasFlag(t *testing.T, args []string, flag string) {
 	t.Helper()
-	for _, a := range args {
-		if a == flag {
-			return
-		}
+	if slices.Contains(args, flag) {
+		return
 	}
 	t.Errorf("buildArgs() missing flag %q in [%s]", flag, strings.Join(args, " "))
 }
@@ -31,11 +30,9 @@ func assertHasFlag(t *testing.T, args []string, flag string) {
 // assertNoFlag fails if flag appears anywhere in args.
 func assertNoFlag(t *testing.T, args []string, flag string) {
 	t.Helper()
-	for _, a := range args {
-		if a == flag {
-			t.Errorf("buildArgs() unexpectedly contains flag %q in [%s]", flag, strings.Join(args, " "))
-			return
-		}
+	if slices.Contains(args, flag) {
+		t.Errorf("buildArgs() unexpectedly contains flag %q in [%s]", flag, strings.Join(args, " "))
+		return
 	}
 }
 

--- a/internal/agent/opencode/command_test.go
+++ b/internal/agent/opencode/command_test.go
@@ -2,6 +2,7 @@ package opencode
 
 import (
 	"encoding/json"
+	"slices"
 	"strings"
 	"testing"
 
@@ -12,8 +13,8 @@ import (
 func envLookup(env []string, key string) (string, bool) {
 	prefix := key + "="
 	for _, e := range env {
-		if strings.HasPrefix(e, prefix) {
-			return strings.TrimPrefix(e, prefix), true
+		if after, ok := strings.CutPrefix(e, prefix); ok {
+			return after, true
 		}
 	}
 	return "", false
@@ -55,10 +56,8 @@ func assertHasArgPair(t *testing.T, args []string, flag, value string) {
 // assertHasFlag fails if flag does not appear in args.
 func assertHasFlag(t *testing.T, args []string, flag string) {
 	t.Helper()
-	for _, a := range args {
-		if a == flag {
-			return
-		}
+	if slices.Contains(args, flag) {
+		return
 	}
 	t.Errorf("buildRunArgs() missing flag %q in [%s]", flag, strings.Join(args, " "))
 }
@@ -66,11 +65,9 @@ func assertHasFlag(t *testing.T, args []string, flag string) {
 // assertNoFlag fails if flag appears anywhere in args.
 func assertNoFlag(t *testing.T, args []string, flag string) {
 	t.Helper()
-	for _, a := range args {
-		if a == flag {
-			t.Errorf("buildRunArgs() unexpected flag %q in [%s]", flag, strings.Join(args, " "))
-			return
-		}
+	if slices.Contains(args, flag) {
+		t.Errorf("buildRunArgs() unexpected flag %q in [%s]", flag, strings.Join(args, " "))
+		return
 	}
 }
 

--- a/internal/agent/opencode/opencode_test.go
+++ b/internal/agent/opencode/opencode_test.go
@@ -908,8 +908,7 @@ func TestRunTurn_StopSessionUnblocksReader(t *testing.T) {
 	testCtx, testCancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer testCancel()
 
-	runCtx, runCancel := context.WithCancel(context.Background())
-	defer runCancel()
+	runCtx := t.Context()
 
 	tmpDir := t.TempDir()
 	// Script: emit one JSON event on a run call, then block until killed.

--- a/internal/agent/opencode/parse.go
+++ b/internal/agent/opencode/parse.go
@@ -293,8 +293,8 @@ func parseExportOutput(data []byte, sessionID string) exportUsage {
 	if !ok {
 		return exportUsage{}
 	}
-	for i := len(messages) - 1; i >= 0; i-- {
-		message, ok := messages[i].(map[string]any)
+	for _, v := range slices.Backward(messages) {
+		message, ok := v.(map[string]any)
 		if !ok {
 			continue
 		}

--- a/internal/agent/procutil/procutil_test.go
+++ b/internal/agent/procutil/procutil_test.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"os/exec"
 	"runtime"
+	"slices"
 	"strings"
 	"testing"
 )
@@ -260,13 +261,7 @@ func TestStderrCollector_LineCap(t *testing.T) {
 				}
 			}
 			wantMarkerStr := fmt.Sprintf(droppedMarkerFmt, tt.wantDrop)
-			hasMarker := false
-			for _, line := range got {
-				if line == wantMarkerStr {
-					hasMarker = true
-					break
-				}
-			}
+			hasMarker := slices.Contains(got, wantMarkerStr)
 			if hasMarker != tt.wantMarker {
 				t.Errorf("marker %q present = %v, want %v", wantMarkerStr, hasMarker, tt.wantMarker)
 			}

--- a/internal/agent/sshutil/sshutil_test.go
+++ b/internal/agent/sshutil/sshutil_test.go
@@ -1,6 +1,7 @@
 package sshutil
 
 import (
+	"slices"
 	"strings"
 	"testing"
 )
@@ -154,13 +155,7 @@ func TestBuildSSHArgs(t *testing.T) {
 			cmd:       "cmd",
 			check: func(t *testing.T, args []string) {
 				t.Helper()
-				found := false
-				for _, a := range args {
-					if a == "--" {
-						found = true
-						break
-					}
-				}
+				found := slices.Contains(args, "--")
 				if !found {
 					t.Errorf("BuildSSHArgs() args = %v: missing '--' separator", args)
 				}

--- a/internal/config/schema_test.go
+++ b/internal/config/schema_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"slices"
 	"strings"
 	"testing"
 )
@@ -162,13 +163,7 @@ func TestDerivePassThroughKindsFromRaw(t *testing.T) {
 				return
 			}
 			for _, want := range tt.wantIn {
-				found := false
-				for _, k := range got {
-					if k == want {
-						found = true
-						break
-					}
-				}
+				found := slices.Contains(got, want)
 				if !found {
 					t.Errorf("derivePassThroughKindsFromRaw() = %v, want to contain %q", got, want)
 				}

--- a/internal/httpkit/paginator.go
+++ b/internal/httpkit/paginator.go
@@ -163,7 +163,7 @@ func parseLinkNext(header string) string {
 		return ""
 	}
 
-	for _, segment := range strings.Split(header, ",") {
+	for segment := range strings.SplitSeq(header, ",") {
 		parts := strings.Split(segment, ";")
 		if len(parts) < 2 {
 			continue

--- a/internal/logging/logging_test.go
+++ b/internal/logging/logging_test.go
@@ -353,7 +353,7 @@ func TestSetupJSON(t *testing.T) {
 	// slog.Default() must also write JSON to the same buf.
 	buf.Reset()
 	slog.Default().Info("from slog.Default")
-	for _, line := range strings.Split(buf.String(), "\n") {
+	for line := range strings.SplitSeq(buf.String(), "\n") {
 		if line == "" {
 			continue
 		}

--- a/internal/orchestrator/auto_merge_reconcile.go
+++ b/internal/orchestrator/auto_merge_reconcile.go
@@ -51,10 +51,7 @@ func reconcileAutoMerge(state *State, params ReconcileParams, log *slog.Logger, 
 		now = params.NowFunc().UTC()
 	}
 
-	pollInterval := time.Duration(params.AutoMergeConfig.PollIntervalMS) * time.Millisecond
-	if pollInterval < 30*time.Second {
-		pollInterval = 30 * time.Second
-	}
+	pollInterval := max(time.Duration(params.AutoMergeConfig.PollIntervalMS)*time.Millisecond, 30*time.Second)
 	ttl := params.AutoMergePendingTTL
 
 	// Consume a scheduled preflight retry at the top of the function
@@ -286,10 +283,7 @@ func reconcileAutoMerge(state *State, params ReconcileParams, log *slog.Logger, 
 // log it emits at its own (stable, literal) message.
 func applyAutoMergeBackoff(state *State, key string, pending *PendingReaction, now time.Time, pollInterval time.Duration) time.Duration {
 	pending.PendingAttempts++
-	delay := computeAutoMergePendingDelay(pending.PendingAttempts)
-	if delay < pollInterval {
-		delay = pollInterval
-	}
+	delay := max(computeAutoMergePendingDelay(pending.PendingAttempts), pollInterval)
 	pending.PendingRetryAt = now.Add(delay)
 	state.PendingReactions[key] = pending
 	return delay
@@ -342,9 +336,7 @@ func postAutoMergeSuccess(state *State, params ReconcileParams, pending *Pending
 		adapter := params.SCMAdapter
 		branchLog := log
 
-		state.TrackerOpsWg.Add(1)
-		go func() {
-			defer state.TrackerOpsWg.Done()
+		state.TrackerOpsWg.Go(func() {
 			dctx, cancel := context.WithTimeout(
 				context.WithoutCancel(ctx), 30*time.Second)
 			defer cancel()
@@ -362,7 +354,7 @@ func postAutoMergeSuccess(state *State, params ReconcileParams, pending *Pending
 					slog.Any("error", err),
 				)
 			}
-		}()
+		})
 	}
 
 	if params.TrackerAdapter != nil {
@@ -371,9 +363,7 @@ func postAutoMergeSuccess(state *State, params ReconcileParams, pending *Pending
 		tracker := params.TrackerAdapter
 		commentLog := log
 
-		state.TrackerOpsWg.Add(1)
-		go func() {
-			defer state.TrackerOpsWg.Done()
+		state.TrackerOpsWg.Go(func() {
 			dctx, cancel := context.WithTimeout(
 				context.WithoutCancel(ctx), 30*time.Second)
 			defer cancel()
@@ -383,7 +373,7 @@ func postAutoMergeSuccess(state *State, params ReconcileParams, pending *Pending
 					slog.Any("error", err),
 				)
 			}
-		}()
+		})
 	}
 
 	if err := params.Store.DeleteReactionFingerprint(ctx, pending.IssueID, ReactionKindAutoMerge); err != nil {
@@ -511,9 +501,7 @@ func escalateAutoMergeFailure(state *State, params ReconcileParams, pending *Pen
 			tracker := params.TrackerAdapter
 			escalLog := log
 
-			state.TrackerOpsWg.Add(1)
-			go func() {
-				defer state.TrackerOpsWg.Done()
+			state.TrackerOpsWg.Go(func() {
 				dctx, cancel := context.WithTimeout(
 					context.WithoutCancel(ctx), 30*time.Second)
 				defer cancel()
@@ -523,7 +511,7 @@ func escalateAutoMergeFailure(state *State, params ReconcileParams, pending *Pen
 						slog.Any("error", err),
 					)
 				}
-			}()
+			})
 		}
 
 	case "comment", "":
@@ -533,9 +521,7 @@ func escalateAutoMergeFailure(state *State, params ReconcileParams, pending *Pen
 			tracker := params.TrackerAdapter
 			escalLog := log
 
-			state.TrackerOpsWg.Add(1)
-			go func() {
-				defer state.TrackerOpsWg.Done()
+			state.TrackerOpsWg.Go(func() {
 				dctx, cancel := context.WithTimeout(
 					context.WithoutCancel(ctx), 30*time.Second)
 				defer cancel()
@@ -545,7 +531,7 @@ func escalateAutoMergeFailure(state *State, params ReconcileParams, pending *Pen
 						slog.Any("error", err),
 					)
 				}
-			}()
+			})
 		}
 	}
 

--- a/internal/orchestrator/ci_reconcile.go
+++ b/internal/orchestrator/ci_reconcile.go
@@ -286,9 +286,7 @@ func escalateCIFailure(
 			escalLog := log
 			escalAction := params.CIFeedback.Escalation
 
-			state.TrackerOpsWg.Add(1)
-			go func() {
-				defer state.TrackerOpsWg.Done()
+			state.TrackerOpsWg.Go(func() {
 				dctx, cancel := context.WithTimeout(
 					context.WithoutCancel(ctx), 30*time.Second)
 				defer cancel()
@@ -301,7 +299,7 @@ func escalateCIFailure(
 				} else {
 					m.IncCIEscalations(escalAction)
 				}
-			}()
+			})
 		}
 
 	case "comment", "":
@@ -317,9 +315,7 @@ func escalateCIFailure(
 				escalAction = "comment"
 			}
 
-			state.TrackerOpsWg.Add(1)
-			go func() {
-				defer state.TrackerOpsWg.Done()
+			state.TrackerOpsWg.Go(func() {
 				dctx, cancel := context.WithTimeout(
 					context.WithoutCancel(ctx), 30*time.Second)
 				defer cancel()
@@ -332,7 +328,7 @@ func escalateCIFailure(
 				} else {
 					m.IncCIEscalations(escalAction)
 				}
-			}()
+			})
 		}
 	}
 

--- a/internal/orchestrator/dispatch.go
+++ b/internal/orchestrator/dispatch.go
@@ -271,10 +271,7 @@ func ScheduleRetry(state *State, params ScheduleRetryParams, onFire func(issueID
 
 	CancelRetry(state, params.IssueID)
 
-	delayMS := params.DelayMS
-	if delayMS < 0 {
-		delayMS = 0
-	}
+	delayMS := max(params.DelayMS, 0)
 
 	dueAtMS := time.Now().UnixMilli() + delayMS
 
@@ -349,9 +346,7 @@ func DispatchIssue(ctx context.Context, state *State, issue domain.Issue, attemp
 
 	CancelRetry(state, issue.ID)
 
-	state.WorkerWg.Add(1)
-	go func() {
-		defer state.WorkerWg.Done()
+	state.WorkerWg.Go(func() {
 		workerFn(workerCtx, issue, attemptCopy)
-	}()
+	})
 }

--- a/internal/orchestrator/exit.go
+++ b/internal/orchestrator/exit.go
@@ -627,10 +627,7 @@ func HandleWorkerExit(state *State, workerResult WorkerResult, params HandleWork
 	if sessionID == "" {
 		sessionID = entry.SessionID
 	}
-	runDuration := now.Sub(entry.StartedAt)
-	if runDuration < 0 {
-		runDuration = 0
-	}
+	runDuration := max(now.Sub(entry.StartedAt), 0)
 
 	switch workerResult.ExitKind {
 	case WorkerExitNormal:
@@ -659,9 +656,7 @@ func HandleWorkerExit(state *State, workerResult WorkerResult, params HandleWork
 		lc := lifecycle
 		ct := commentText
 
-		state.TrackerOpsWg.Add(1)
-		go func() {
-			defer state.TrackerOpsWg.Done()
+		state.TrackerOpsWg.Go(func() {
 			dctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
 			defer cancel()
 
@@ -677,7 +672,7 @@ func HandleWorkerExit(state *State, workerResult WorkerResult, params HandleWork
 				)
 				m.IncTrackerComments(lc, "success")
 			}
-		}()
+		})
 	}
 
 }

--- a/internal/orchestrator/exit_test.go
+++ b/internal/orchestrator/exit_test.go
@@ -1827,7 +1827,7 @@ func TestHandleWorkerExit_RetryableErrorLogsWarn(t *testing.T) {
 	}
 
 	// No "worker run failed" at ERROR level.
-	for _, line := range strings.Split(out, "\n") {
+	for line := range strings.SplitSeq(out, "\n") {
 		if strings.Contains(line, "level=ERROR") && strings.Contains(line, "worker run failed") {
 			t.Errorf("unexpected ERROR log with 'worker run failed':\n%s", line)
 		}
@@ -1866,7 +1866,7 @@ func TestHandleWorkerExit_NonRetryableErrorLogsError(t *testing.T) {
 	}
 
 	// No "worker run failed" at WARN level.
-	for _, line := range strings.Split(out, "\n") {
+	for line := range strings.SplitSeq(out, "\n") {
 		if strings.Contains(line, "level=WARN") && strings.Contains(line, "worker run failed") {
 			t.Errorf("unexpected WARN log with 'worker run failed':\n%s", line)
 		}

--- a/internal/orchestrator/hostpool.go
+++ b/internal/orchestrator/hostpool.go
@@ -2,6 +2,7 @@ package orchestrator
 
 import (
 	"log/slog"
+	"maps"
 	"slices"
 	"strings"
 )
@@ -103,12 +104,7 @@ func (hp *HostPool) HasCapacity() bool {
 	if len(hp.hosts) == 0 {
 		return true
 	}
-	for _, h := range hp.hosts {
-		if hp.hasHostCapacity(h) {
-			return true
-		}
-	}
-	return false
+	return slices.ContainsFunc(hp.hosts, hp.hasHostCapacity)
 }
 
 // Update replaces the host list and per-host cap from a new config
@@ -152,9 +148,7 @@ func (hp *HostPool) Update(hosts []string, maxPerHost int) {
 // Snapshot returns a copy of the usage map for observability.
 func (hp *HostPool) Snapshot() map[string]int {
 	snap := make(map[string]int, len(hp.usage))
-	for h, c := range hp.usage {
-		snap[h] = c
-	}
+	maps.Copy(snap, hp.usage)
 	return snap
 }
 

--- a/internal/orchestrator/mcpconfig.go
+++ b/internal/orchestrator/mcpconfig.go
@@ -3,6 +3,7 @@ package orchestrator
 import (
 	"encoding/json"
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -70,9 +71,7 @@ func GenerateMCPConfig(params MCPConfigParams) (string, error) {
 	// variables first (lower precedence), then per-session variables
 	// (higher precedence, always win).
 	env := make(map[string]string, len(params.ProcessEnv)+6)
-	for k, v := range params.ProcessEnv {
-		env[k] = v
-	}
+	maps.Copy(env, params.ProcessEnv)
 	env["SORTIE_ISSUE_ID"] = params.IssueID
 	env["SORTIE_ISSUE_IDENTIFIER"] = params.Identifier
 	env["SORTIE_WORKSPACE"] = params.WorkspacePath

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -4890,7 +4890,7 @@ func TestHandleTickSweepThrottle(t *testing.T) {
 	ctx := context.Background()
 
 	// Ticks 1 through sweepEveryNTicks-1: sweep must not fire.
-	for i := 0; i < sweepEveryNTicks-1; i++ {
+	for range sweepEveryNTicks - 1 {
 		o.handleTick(ctx)
 	}
 	if got := tracker.callCount(); got != 0 {

--- a/internal/orchestrator/review_reconcile.go
+++ b/internal/orchestrator/review_reconcile.go
@@ -90,10 +90,7 @@ func reconcileReviewComments(state *State, params ReconcileParams, log *slog.Log
 		comments, err := params.SCMAdapter.FetchPendingReviews(ctx, reviewData.PRNumber, reviewData.Owner, reviewData.Repo)
 		if err != nil {
 			pending.PendingAttempts++
-			delay := computeReviewPendingDelay(pending.PendingAttempts)
-			if delay < pollInterval {
-				delay = pollInterval
-			}
+			delay := max(computeReviewPendingDelay(pending.PendingAttempts), pollInterval)
 			pending.PendingRetryAt = now.Add(delay)
 			state.PendingReactions[key] = pending
 			entryLog.Warn("review fetch failed, retrying with backoff",
@@ -245,9 +242,7 @@ func escalateReviewFailure(
 			escalLog := log
 			escalAction := params.ReviewConfig.Escalation
 
-			state.TrackerOpsWg.Add(1)
-			go func() {
-				defer state.TrackerOpsWg.Done()
+			state.TrackerOpsWg.Go(func() {
 				dctx, cancel := context.WithTimeout(
 					context.WithoutCancel(ctx), 30*time.Second)
 				defer cancel()
@@ -260,7 +255,7 @@ func escalateReviewFailure(
 				} else {
 					m.IncReviewEscalations(escalAction)
 				}
-			}()
+			})
 		} else {
 			metrics.IncReviewEscalations(params.ReviewConfig.Escalation)
 		}
@@ -278,9 +273,7 @@ func escalateReviewFailure(
 				escalAction = "comment"
 			}
 
-			state.TrackerOpsWg.Add(1)
-			go func() {
-				defer state.TrackerOpsWg.Done()
+			state.TrackerOpsWg.Go(func() {
 				dctx, cancel := context.WithTimeout(
 					context.WithoutCancel(ctx), 30*time.Second)
 				defer cancel()
@@ -293,7 +286,7 @@ func escalateReviewFailure(
 				} else {
 					m.IncReviewEscalations(escalAction)
 				}
-			}()
+			})
 		} else {
 			action := params.ReviewConfig.Escalation
 			if action == "" {

--- a/internal/orchestrator/self_review.go
+++ b/internal/orchestrator/self_review.go
@@ -54,10 +54,7 @@ type cappedWriter struct {
 
 func (w *cappedWriter) Write(p []byte) (int, error) {
 	if w.buf.Len() < w.max {
-		remaining := w.max - w.buf.Len()
-		if remaining > len(p) {
-			remaining = len(p)
-		}
+		remaining := min(w.max-w.buf.Len(), len(p))
 		w.buf.Write(p[:remaining])
 	}
 	return len(p), nil

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -806,9 +806,7 @@ func RuntimeSnapshot(state *State, now time.Time) RuntimeSnapshotResult {
 		var modelRequests map[string]int
 		if entry.RequestsByModel != nil {
 			modelRequests = make(map[string]int, len(entry.RequestsByModel))
-			for k, v := range entry.RequestsByModel {
-				modelRequests[k] = v
-			}
+			maps.Copy(modelRequests, entry.RequestsByModel)
 		}
 		snap.Running = append(snap.Running, SnapshotRunningEntry{
 			IssueID:             entry.Issue.ID,

--- a/internal/persistence/migrate.go
+++ b/internal/persistence/migrate.go
@@ -109,7 +109,7 @@ func (s *Store) applyMigration(ctx context.Context, m Migration) error {
 // literals. This is safe for DDL statements (CREATE TABLE, CREATE INDEX) but
 // would mis-split DML containing literal semicolons.
 func execStatements(ctx context.Context, tx *sql.Tx, rawSQL string) error {
-	for _, stmt := range strings.Split(rawSQL, ";") {
+	for stmt := range strings.SplitSeq(rawSQL, ";") {
 		stmt = strings.TrimSpace(stmt)
 		if stmt == "" {
 			continue

--- a/internal/persistence/retry.go
+++ b/internal/persistence/retry.go
@@ -126,10 +126,7 @@ func (s *Store) LoadRetryEntriesForRecovery(ctx context.Context, nowMs int64) ([
 
 	pending := make([]PendingRetry, len(entries))
 	for i, e := range entries {
-		remaining := e.DueAtMs - nowMs
-		if remaining < 0 {
-			remaining = 0
-		}
+		remaining := max(e.DueAtMs-nowMs, 0)
 		pending[i] = PendingRetry{Entry: e, RemainingMs: remaining}
 	}
 	return pending, nil

--- a/internal/prompt/prompt.go
+++ b/internal/prompt/prompt.go
@@ -9,7 +9,9 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 	"text/template"
@@ -129,12 +131,7 @@ var continuationKeys = []string{"ci_failure", "review_comments"}
 // isContinuationKey reports whether key is a registered continuation
 // template variable name.
 func isContinuationKey(key string) bool {
-	for _, k := range continuationKeys {
-		if k == key {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(continuationKeys, key)
 }
 
 // WithContinuationContext returns a [RenderOption] that merges each
@@ -149,9 +146,7 @@ func WithContinuationContext(data map[string]any) RenderOption {
 		}
 	}
 	return func(m map[string]any) {
-		for k, v := range data {
-			m[k] = v
-		}
+		maps.Copy(m, data)
 	}
 }
 

--- a/internal/prompt/prompt_test.go
+++ b/internal/prompt/prompt_test.go
@@ -465,9 +465,7 @@ func TestRender_Concurrent(t *testing.T) {
 
 	var wg sync.WaitGroup
 	for i := range 50 {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			issue := map[string]any{"title": "concurrent test"}
 			_, renderErr := tmpl.Render(issue, nil, RunContext{
 				TurnNumber: i + 1,
@@ -476,7 +474,7 @@ func TestRender_Concurrent(t *testing.T) {
 			if renderErr != nil {
 				t.Errorf("concurrent render %d failed: %v", i, renderErr)
 			}
-		}()
+		})
 	}
 	wg.Wait()
 }

--- a/internal/scm/github/etag_cache_test.go
+++ b/internal/scm/github/etag_cache_test.go
@@ -186,7 +186,7 @@ func TestETagCache_ConcurrentAccess(t *testing.T) {
 
 	var wg sync.WaitGroup
 	wg.Add(goroutines)
-	for i := 0; i < goroutines; i++ {
+	for i := range goroutines {
 		go func(i int) {
 			defer wg.Done()
 			path := fmt.Sprintf("/path/%d", i%5) // shared paths to stress lock contention

--- a/internal/scm/github/tracker_test.go
+++ b/internal/scm/github/tracker_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"slices"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -452,9 +453,9 @@ func TestFetchCandidateIssues_Pagination(t *testing.T) {
 	page2 := loadFixture(t, "issues_page2.json") // issue 5 (review)
 
 	var srvURL string
-	var callCount int32
+	var callCount atomic.Int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		n := atomic.AddInt32(&callCount, 1)
+		n := callCount.Add(1)
 		if n == 1 {
 			// First page: set Link header pointing to page 2.
 			w.Header().Set("Link", fmt.Sprintf(`<%s/repos/owner/repo/issues?page=2>; rel="next"`, srvURL))
@@ -478,7 +479,7 @@ func TestFetchCandidateIssues_Pagination(t *testing.T) {
 	if len(issues) != 3 {
 		t.Fatalf("len = %d, want 3 across 2 pages", len(issues))
 	}
-	if got := atomic.LoadInt32(&callCount); got != 2 {
+	if got := callCount.Load(); got != 2 {
 		t.Errorf("call count = %d, want 2", got)
 	}
 }
@@ -487,9 +488,9 @@ func TestFetchCandidateIssues_MaxPagesGuard(t *testing.T) {
 	t.Parallel()
 
 	// Server always returns a Link header, forcing the guard to trigger.
-	var callCount int32
+	var callCount atomic.Int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		n := atomic.AddInt32(&callCount, 1)
+		n := callCount.Add(1)
 		nextURL := fmt.Sprintf("http://%s/repos/owner/repo/issues?p=%d", r.Host, n+1)
 		w.Header().Set("Link", fmt.Sprintf(`<%s>; rel="next"`, nextURL))
 		w.WriteHeader(http.StatusOK)
@@ -507,7 +508,7 @@ func TestFetchCandidateIssues_MaxPagesGuard(t *testing.T) {
 		t.Fatalf("FetchCandidateIssues: %v", err)
 	}
 
-	got := int(atomic.LoadInt32(&callCount))
+	got := int(callCount.Load())
 	if got > maxPages {
 		t.Errorf("call count = %d, exceeded maxPages = %d", got, maxPages)
 	}
@@ -971,9 +972,9 @@ func TestFetchIssueStatesByIDs_NotFoundOmitted(t *testing.T) {
 	t.Parallel()
 
 	// First issue found, second returns 404 (omit from map).
-	var callNum int32
+	var callNum atomic.Int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		n := atomic.AddInt32(&callNum, 1)
+		n := callNum.Add(1)
 		if n == 1 {
 			w.WriteHeader(http.StatusOK)
 			w.Write([]byte(issueJSON(1, "backlog", "open"))) //nolint:errcheck // test helper
@@ -1109,9 +1110,9 @@ func TestFetchIssueComments_Pagination(t *testing.T) {
 	page2 := `[{"id":9999,"user":{"login":"charlie"},"body":"Third comment.","created_at":"2026-01-17T09:00:00Z"}]`
 
 	var srvURL string
-	var callCount int32
+	var callCount atomic.Int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		n := atomic.AddInt32(&callCount, 1)
+		n := callCount.Add(1)
 		if n == 1 {
 			w.Header().Set("Link", fmt.Sprintf(`<%s/repos/owner/repo/issues/42/comments?page=2>; rel="next"`, srvURL))
 			w.WriteHeader(http.StatusOK)
@@ -1157,9 +1158,9 @@ func TestFetchIssueComments_NotFound(t *testing.T) {
 // state operations for TransitionIssue. It tracks which API calls were made.
 type transitionServer struct {
 	srv            *httptest.Server
-	deleteCount    int32
-	postCount      int32
-	patchCount     int32
+	deleteCount    atomic.Int32
+	postCount      atomic.Int32
+	patchCount     atomic.Int32
 	deleteFailWith int // if non-zero, respond with this status on DELETE
 	postFailWith   int // if non-zero, respond with this status on POST labels
 	patchFailWith  int // if non-zero, respond with this status on PATCH
@@ -1179,7 +1180,7 @@ func newTransitionServer(t *testing.T, number int, currentLabel, nativeState str
 				w.WriteHeader(ts.patchFailWith)
 				return
 			}
-			atomic.AddInt32(&ts.patchCount, 1)
+			ts.patchCount.Add(1)
 			w.WriteHeader(http.StatusOK)
 			body, _ := io.ReadAll(r.Body)
 			w.Write(body) //nolint:errcheck // test helper
@@ -1195,7 +1196,7 @@ func newTransitionServer(t *testing.T, number int, currentLabel, nativeState str
 			w.WriteHeader(ts.deleteFailWith)
 			return
 		}
-		atomic.AddInt32(&ts.deleteCount, 1)
+		ts.deleteCount.Add(1)
 		w.WriteHeader(http.StatusOK)
 	})
 	// POST labels
@@ -1204,7 +1205,7 @@ func newTransitionServer(t *testing.T, number int, currentLabel, nativeState str
 			w.WriteHeader(ts.postFailWith)
 			return
 		}
-		atomic.AddInt32(&ts.postCount, 1)
+		ts.postCount.Add(1)
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte(`[]`)) //nolint:errcheck // test helper
 	})
@@ -1226,13 +1227,13 @@ func TestTransitionIssue_LabelSwap(t *testing.T) {
 		t.Fatalf("TransitionIssue: %v", err)
 	}
 
-	if got := atomic.LoadInt32(&ts.deleteCount); got != 1 {
+	if got := ts.deleteCount.Load(); got != 1 {
 		t.Errorf("DELETE count = %d, want 1", got)
 	}
-	if got := atomic.LoadInt32(&ts.postCount); got != 1 {
+	if got := ts.postCount.Load(); got != 1 {
 		t.Errorf("POST count = %d, want 1", got)
 	}
-	if got := atomic.LoadInt32(&ts.patchCount); got != 0 {
+	if got := ts.patchCount.Load(); got != 0 {
 		t.Errorf("PATCH count = %d, want 0 (no native state change needed)", got)
 	}
 }
@@ -1249,13 +1250,13 @@ func TestTransitionIssue_CloseOnTerminal(t *testing.T) {
 		t.Fatalf("TransitionIssue: %v", err)
 	}
 
-	if got := atomic.LoadInt32(&ts.deleteCount); got != 1 {
+	if got := ts.deleteCount.Load(); got != 1 {
 		t.Errorf("DELETE count = %d, want 1", got)
 	}
-	if got := atomic.LoadInt32(&ts.postCount); got != 1 {
+	if got := ts.postCount.Load(); got != 1 {
 		t.Errorf("POST count = %d, want 1", got)
 	}
-	if got := atomic.LoadInt32(&ts.patchCount); got != 1 {
+	if got := ts.patchCount.Load(); got != 1 {
 		t.Errorf("PATCH count = %d, want 1 (close issue)", got)
 	}
 }
@@ -1272,13 +1273,13 @@ func TestTransitionIssue_ReopenOnActive(t *testing.T) {
 		t.Fatalf("TransitionIssue: %v", err)
 	}
 
-	if got := atomic.LoadInt32(&ts.deleteCount); got != 1 {
+	if got := ts.deleteCount.Load(); got != 1 {
 		t.Errorf("DELETE count = %d, want 1", got)
 	}
-	if got := atomic.LoadInt32(&ts.postCount); got != 1 {
+	if got := ts.postCount.Load(); got != 1 {
 		t.Errorf("POST count = %d, want 1", got)
 	}
-	if got := atomic.LoadInt32(&ts.patchCount); got != 1 {
+	if got := ts.patchCount.Load(); got != 1 {
 		t.Errorf("PATCH count = %d, want 1 (reopen issue)", got)
 	}
 }
@@ -1294,10 +1295,10 @@ func TestTransitionIssue_IdempotentNoOp(t *testing.T) {
 		t.Fatalf("TransitionIssue idempotent: %v", err)
 	}
 
-	if got := atomic.LoadInt32(&ts.deleteCount); got != 0 {
+	if got := ts.deleteCount.Load(); got != 0 {
 		t.Errorf("DELETE count = %d, want 0", got)
 	}
-	if got := atomic.LoadInt32(&ts.postCount); got != 0 {
+	if got := ts.postCount.Load(); got != 0 {
 		t.Errorf("POST count = %d, want 0", got)
 	}
 }
@@ -1314,7 +1315,7 @@ func TestTransitionIssue_PartialFailure_AddLabel(t *testing.T) {
 	err := a.TransitionIssue(context.Background(), "2", "review")
 	assertTrackerErrorKind(t, err, domain.ErrTrackerTransport)
 
-	if got := atomic.LoadInt32(&ts.deleteCount); got != 1 {
+	if got := ts.deleteCount.Load(); got != 1 {
 		t.Errorf("DELETE count = %d, want 1 (delete succeeded before add failed)", got)
 	}
 }
@@ -1345,13 +1346,13 @@ func TestTransitionIssue_HandoffToActive(t *testing.T) {
 		t.Fatalf("TransitionIssue: %v", err)
 	}
 
-	if got := atomic.LoadInt32(&ts.deleteCount); got != 1 {
+	if got := ts.deleteCount.Load(); got != 1 {
 		t.Errorf("DELETE count = %d, want 1 (stale handoff label must be removed)", got)
 	}
-	if got := atomic.LoadInt32(&ts.postCount); got != 1 {
+	if got := ts.postCount.Load(); got != 1 {
 		t.Errorf("POST count = %d, want 1 (active label must be added)", got)
 	}
-	if got := atomic.LoadInt32(&ts.patchCount); got != 0 {
+	if got := ts.patchCount.Load(); got != 0 {
 		t.Errorf("PATCH count = %d, want 0 (issue already open, no native state change)", got)
 	}
 }
@@ -1376,13 +1377,13 @@ func TestTransitionIssue_HandoffAsTarget(t *testing.T) {
 		t.Fatalf("TransitionIssue: %v", err)
 	}
 
-	if got := atomic.LoadInt32(&ts.deleteCount); got != 1 {
+	if got := ts.deleteCount.Load(); got != 1 {
 		t.Errorf("DELETE count = %d, want 1 (active label must be removed)", got)
 	}
-	if got := atomic.LoadInt32(&ts.postCount); got != 1 {
+	if got := ts.postCount.Load(); got != 1 {
 		t.Errorf("POST count = %d, want 1 (handoff label must be added)", got)
 	}
-	if got := atomic.LoadInt32(&ts.patchCount); got != 0 {
+	if got := ts.patchCount.Load(); got != 0 {
 		t.Errorf("PATCH count = %d, want 0 (handoff state never changes native open/closed)", got)
 	}
 }
@@ -1413,10 +1414,10 @@ func TestTransitionIssue_PartialFailure_Close(t *testing.T) {
 	err := a.TransitionIssue(context.Background(), "6", "done")
 	assertTrackerErrorKind(t, err, domain.ErrTrackerTransport)
 
-	if got := atomic.LoadInt32(&ts.deleteCount); got != 1 {
+	if got := ts.deleteCount.Load(); got != 1 {
 		t.Errorf("DELETE count = %d, want 1", got)
 	}
-	if got := atomic.LoadInt32(&ts.postCount); got != 1 {
+	if got := ts.postCount.Load(); got != 1 {
 		t.Errorf("POST count = %d, want 1", got)
 	}
 }
@@ -1522,13 +1523,7 @@ func TestSetMetrics_RecordsOperations(t *testing.T) {
 		t.Fatalf("FetchCandidateIssues: %v", err)
 	}
 
-	found := false
-	for _, call := range spy.calls {
-		if call == "fetch_candidates:success" {
-			found = true
-			break
-		}
-	}
+	found := slices.Contains(spy.calls, "fetch_candidates:success")
 	if !found {
 		t.Errorf("metrics calls = %v, want fetch_candidates:success recorded", spy.calls)
 	}
@@ -1563,9 +1558,9 @@ func TestFetchCandidateIssues_SearchPagination(t *testing.T) {
 	page2 := `{"total_count":2,"incomplete_results":false,"items":[{"id":20,"number":20,"title":"T20","body":null,"state":"open","html_url":"u","labels":[{"name":"backlog"}],"assignees":[],"type":null,"pull_request":null,"created_at":"2026-01-01T00:00:00Z","updated_at":"2026-01-01T00:00:00Z"}]}`
 
 	var srvURL string
-	var callCount int32
+	var callCount atomic.Int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		n := atomic.AddInt32(&callCount, 1)
+		n := callCount.Add(1)
 		if n == 1 {
 			w.Header().Set("Link", fmt.Sprintf(`<%s/search/issues?q=...&page=2>; rel="next"`, srvURL))
 			w.WriteHeader(http.StatusOK)
@@ -1703,9 +1698,9 @@ func TestFetchIssuesByStates_OpenPagination(t *testing.T) {
 	page2 := loadFixture(t, "issues_page2.json")
 
 	var srvURL string
-	var callCount int32
+	var callCount atomic.Int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		n := atomic.AddInt32(&callCount, 1)
+		n := callCount.Add(1)
 		if n == 1 {
 			w.Header().Set("Link", fmt.Sprintf(`<%s/repos/owner/repo/issues?state=open&page=2>; rel="next"`, srvURL))
 			w.WriteHeader(http.StatusOK)
@@ -1738,9 +1733,9 @@ func TestFetchIssuesByStates_ClosedSearchPagination(t *testing.T) {
 	page2 := `{"total_count":2,"incomplete_results":false,"items":[{"id":200,"number":200,"title":"D2","body":null,"state":"closed","html_url":"u","labels":[{"name":"done"}],"assignees":[],"type":null,"pull_request":null,"created_at":"2026-01-01T00:00:00Z","updated_at":"2026-01-01T00:00:00Z"}]}`
 
 	var srvURL string
-	var callCount int32
+	var callCount atomic.Int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		n := atomic.AddInt32(&callCount, 1)
+		n := callCount.Add(1)
 		if n == 1 {
 			w.Header().Set("Link", fmt.Sprintf(`<%s/search/issues?q=...&page=2>; rel="next"`, srvURL))
 			w.WriteHeader(http.StatusOK)
@@ -1815,9 +1810,9 @@ func TestFetchIssuesByStates_ContextCancelledDuringTerminal(t *testing.T) {
 	// Two terminal states: first search succeeds, context is cancelled before
 	// the second search, exercising the ctx.Err() guard between iterations.
 	started := make(chan struct{}, 1)
-	var callCount int32
+	var callCount atomic.Int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		n := atomic.AddInt32(&callCount, 1)
+		n := callCount.Add(1)
 		if n == 1 {
 			w.WriteHeader(http.StatusOK)
 			w.Write([]byte(`{"total_count":0,"incomplete_results":false,"items":[]}`)) //nolint:errcheck // test helper
@@ -1925,7 +1920,7 @@ func TestTransitionIssue_DeleteLabelIsNotFound(t *testing.T) {
 	t.Parallel()
 
 	// DELETE existing label returns 404 (already removed) → treated as no-op; POST still executes.
-	var postCount int32
+	var postCount atomic.Int32
 	mux := http.NewServeMux()
 	mux.HandleFunc("/repos/owner/repo/issues/1", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodPatch {
@@ -1941,7 +1936,7 @@ func TestTransitionIssue_DeleteLabelIsNotFound(t *testing.T) {
 		w.WriteHeader(http.StatusNotFound)
 	})
 	mux.HandleFunc("/repos/owner/repo/issues/1/labels", func(w http.ResponseWriter, r *http.Request) {
-		atomic.AddInt32(&postCount, 1)
+		postCount.Add(1)
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte("[]")) //nolint:errcheck // test helper
 	})
@@ -1953,7 +1948,7 @@ func TestTransitionIssue_DeleteLabelIsNotFound(t *testing.T) {
 	if err := a.TransitionIssue(context.Background(), "1", "review"); err != nil {
 		t.Fatalf("TransitionIssue 404-on-delete: %v", err)
 	}
-	if got := atomic.LoadInt32(&postCount); got != 1 {
+	if got := postCount.Load(); got != 1 {
 		t.Errorf("POST count = %d, want 1 (add-label must still execute)", got)
 	}
 }
@@ -2030,9 +2025,9 @@ func TestNewGitHubAdapter_ETagCacheSizeNegative(t *testing.T) {
 func TestFetchIssueStatesByIDs_ConditionalRequest_304(t *testing.T) {
 	t.Parallel()
 
-	var callCount int32
+	var callCount atomic.Int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		n := atomic.AddInt32(&callCount, 1)
+		n := callCount.Add(1)
 		if n == 1 {
 			w.Header().Set("ETag", `"etag-v1"`)
 			w.WriteHeader(http.StatusOK)
@@ -2067,7 +2062,7 @@ func TestFetchIssueStatesByIDs_ConditionalRequest_304(t *testing.T) {
 	if result2["42"] != "in-progress" {
 		t.Errorf("second call result[\"42\"] = %q, want in-progress (304 hit)", result2["42"])
 	}
-	if n := atomic.LoadInt32(&callCount); n != 2 {
+	if n := callCount.Load(); n != 2 {
 		t.Errorf("server call count = %d, want 2", n)
 	}
 }
@@ -2075,9 +2070,9 @@ func TestFetchIssueStatesByIDs_ConditionalRequest_304(t *testing.T) {
 func TestFetchIssueStatesByIDs_ConditionalRequest_200_UpdatesCache(t *testing.T) {
 	t.Parallel()
 
-	var callCount int32
+	var callCount atomic.Int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		n := atomic.AddInt32(&callCount, 1)
+		n := callCount.Add(1)
 		switch n {
 		case 1:
 			w.Header().Set("ETag", `"etag-v1"`)
@@ -2132,9 +2127,9 @@ func TestFetchIssueStatesByIDs_ConditionalRequest_200_UpdatesCache(t *testing.T)
 func TestFetchIssueStatesByIDs_NoETagHeader_NoCacheEntry(t *testing.T) {
 	t.Parallel()
 
-	var callCount int32
+	var callCount atomic.Int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		n := atomic.AddInt32(&callCount, 1)
+		n := callCount.Add(1)
 		// Server intentionally omits the ETag header.
 		if h := r.Header.Get("If-None-Match"); h != "" {
 			t.Errorf("call %d: unexpected If-None-Match = %q (no ETag was ever returned)", n, h)
@@ -2149,12 +2144,12 @@ func TestFetchIssueStatesByIDs_NoETagHeader_NoCacheEntry(t *testing.T) {
 	a := mustAdapter(t, cfg)
 
 	// Both calls must be unconditional because the server never returns an ETag.
-	for i := 0; i < 2; i++ {
+	for i := range 2 {
 		if _, err := a.FetchIssueStatesByIDs(context.Background(), []string{"10"}); err != nil {
 			t.Fatalf("call %d: %v", i+1, err)
 		}
 	}
-	if n := atomic.LoadInt32(&callCount); n != 2 {
+	if n := callCount.Load(); n != 2 {
 		t.Errorf("server call count = %d, want 2 (no caching when ETag absent)", n)
 	}
 }
@@ -2231,9 +2226,9 @@ func TestFetchIssueStatesByIDs_304_CachedStateUsedAfterEviction(t *testing.T) {
 func TestFetchIssueStatesByIDs_CacheDisabled_ZeroSize(t *testing.T) {
 	t.Parallel()
 
-	var callCount int32
+	var callCount atomic.Int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		n := atomic.AddInt32(&callCount, 1)
+		n := callCount.Add(1)
 		if h := r.Header.Get("If-None-Match"); h != "" {
 			t.Errorf("call %d: unexpected If-None-Match = %q (cache disabled)", n, h)
 		}
@@ -2247,12 +2242,12 @@ func TestFetchIssueStatesByIDs_CacheDisabled_ZeroSize(t *testing.T) {
 	cfg["etag_cache_size"] = 0 // caching disabled
 	a := mustAdapter(t, cfg)
 
-	for i := 0; i < 2; i++ {
+	for i := range 2 {
 		if _, err := a.FetchIssueStatesByIDs(context.Background(), []string{"20"}); err != nil {
 			t.Fatalf("call %d: %v", i+1, err)
 		}
 	}
-	if n := atomic.LoadInt32(&callCount); n != 2 {
+	if n := callCount.Load(); n != 2 {
 		t.Errorf("server call count = %d, want 2 (cache disabled, all requests unconditional)", n)
 	}
 }
@@ -2260,9 +2255,9 @@ func TestFetchIssueStatesByIDs_CacheDisabled_ZeroSize(t *testing.T) {
 func TestFetchIssueStatesByIDs_NetworkError_CachePreserved(t *testing.T) {
 	t.Parallel()
 
-	var callCount int32
+	var callCount atomic.Int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		n := atomic.AddInt32(&callCount, 1)
+		n := callCount.Add(1)
 		switch n {
 		case 1:
 			w.Header().Set("ETag", `"etag-v1"`)

--- a/internal/server/dashboard.go
+++ b/internal/server/dashboard.go
@@ -187,18 +187,12 @@ func buildDashboardData(
 
 	available := 0
 	if slotFunc != nil {
-		available = slotFunc() - runningCount
-		if available < 0 {
-			available = 0
-		}
+		available = max(slotFunc()-runningCount, 0)
 	}
 
 	uptimeDur := time.Duration(0)
 	if !startedAt.IsZero() {
-		uptimeDur = now.Sub(startedAt)
-		if uptimeDur < 0 {
-			uptimeDur = 0
-		}
+		uptimeDur = max(now.Sub(startedAt), 0)
 	}
 
 	data := dashboardData{
@@ -227,10 +221,7 @@ func buildDashboardData(
 	var aggregateCost float64
 	aggregateCostSet := false
 	for i, e := range sortedRunning {
-		dur := snap.GeneratedAt.Sub(e.StartedAt)
-		if dur < 0 {
-			dur = 0
-		}
+		dur := max(snap.GeneratedAt.Sub(e.StartedAt), 0)
 		if e.SSHHost != "" {
 			hasSSH = true
 		}

--- a/internal/server/grafana_coverage_test.go
+++ b/internal/server/grafana_coverage_test.go
@@ -52,8 +52,8 @@ var knownSortieMetrics = []string{
 // registered family name sortie_worker_duration_seconds.
 func stripHistogramSuffix(name string) string {
 	for _, sfx := range []string{"_bucket", "_sum", "_count"} {
-		if strings.HasSuffix(name, sfx) {
-			return strings.TrimSuffix(name, sfx)
+		if before, ok := strings.CutSuffix(name, sfx); ok {
+			return before
 		}
 	}
 	return name

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -471,10 +471,7 @@ func (s *Server) handleLivez(w http.ResponseWriter, _ *http.Request) {
 func (s *Server) handleReadyz(w http.ResponseWriter, r *http.Request) {
 	var uptime float64
 	if !s.startedAt.IsZero() {
-		d := time.Since(s.startedAt)
-		if d < 0 {
-			d = 0
-		}
+		d := max(time.Since(s.startedAt), 0)
 		uptime = d.Seconds()
 	}
 

--- a/internal/tool/budget/budget.go
+++ b/internal/tool/budget/budget.go
@@ -111,10 +111,7 @@ func (t *BudgetTool) Execute(ctx context.Context, _ json.RawMessage) (json.RawMe
 
 	var remaining *int64
 	if t.budgetTokens > 0 {
-		r := int64(t.budgetTokens) - usedTokens
-		if r < 0 {
-			r = 0
-		}
+		r := max(int64(t.budgetTokens)-usedTokens, 0)
 		remaining = &r
 	}
 

--- a/internal/tool/mcpserver/mcpserver_test.go
+++ b/internal/tool/mcpserver/mcpserver_test.go
@@ -49,7 +49,7 @@ func buildNotification(t *testing.T, method string) string {
 func parseResponses(t *testing.T, data []byte) []map[string]any {
 	t.Helper()
 	var results []map[string]any
-	for _, line := range bytes.Split(data, []byte("\n")) {
+	for line := range bytes.SplitSeq(data, []byte("\n")) {
 		line = bytes.TrimSpace(line)
 		if len(line) == 0 {
 			continue

--- a/internal/tool/status/status.go
+++ b/internal/tool/status/status.go
@@ -125,10 +125,7 @@ func (t *StatusTool) Execute(_ context.Context, _ json.RawMessage) (json.RawMess
 		return toolresult.Failure("state_malformed", "state file has invalid started_at: "+err.Error())
 	}
 
-	turnsRemaining := sf.MaxTurns - sf.TurnNumber
-	if turnsRemaining < 0 {
-		turnsRemaining = 0
-	}
+	turnsRemaining := max(sf.MaxTurns-sf.TurnNumber, 0)
 
 	durationSeconds := math.Round(time.Since(startedAt).Seconds()*1000) / 1000
 

--- a/internal/tracker/jira/integration_test.go
+++ b/internal/tracker/jira/integration_test.go
@@ -354,13 +354,10 @@ func TestIntegration_FetchIssueStatesByIDs(t *testing.T) {
 		t.Skip("no candidate issues in project")
 	}
 
-	limit := 5
-	if len(candidates) < limit {
-		limit = len(candidates)
-	}
+	limit := min(len(candidates), 5)
 	ids := make([]string, limit)
 	candidateStates := make(map[string]string, limit)
-	for i := 0; i < limit; i++ {
+	for i := range limit {
 		ids[i] = candidates[i].ID
 		candidateStates[candidates[i].ID] = candidates[i].State
 	}

--- a/internal/tracker/jira/jira_test.go
+++ b/internal/tracker/jira/jira_test.go
@@ -275,9 +275,9 @@ func TestFetchCandidateIssues_MultiPage(t *testing.T) {
 	page1 := loadFixture(t, "search_multi_page_1.json")
 	page2 := loadFixture(t, "search_multi_page_2.json")
 
-	var callCount int32
+	var callCount atomic.Int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		n := atomic.AddInt32(&callCount, 1)
+		n := callCount.Add(1)
 		if n == 1 {
 			w.Write(page1) //nolint:errcheck // test helper
 		} else {
@@ -448,11 +448,11 @@ func TestFetchCandidateIssues_NoQueryFilter(t *testing.T) {
 		t.Fatalf("FetchCandidateIssues: %v", err)
 	}
 	// Should not have dangling AND before ORDER BY
-	idx := strings.Index(receivedJQL, "ORDER BY")
-	if idx < 0 {
+	before0, _, ok := strings.Cut(receivedJQL, "ORDER BY")
+	if !ok {
 		t.Fatalf("JQL missing ORDER BY: %q", receivedJQL)
 	}
-	before := receivedJQL[:idx]
+	before := before0
 	if strings.HasSuffix(strings.TrimSpace(before), "AND") {
 		t.Errorf("JQL has trailing AND before ORDER BY: %q", receivedJQL)
 	}
@@ -748,19 +748,19 @@ func TestFetchIssueStatesByIDs_SingleBatch(t *testing.T) {
 func TestFetchIssueStatesByIDs_MultiBatch(t *testing.T) {
 	t.Parallel()
 
-	var requestCount int32
+	var requestCount atomic.Int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		atomic.AddInt32(&requestCount, 1)
+		requestCount.Add(1)
 		jql := r.URL.Query().Get("jql")
 		if !strings.Contains(jql, "id IN") {
 			t.Errorf("JQL = %q, should use id IN", jql)
 		}
 
 		// Verify the batch does not exceed 40 IDs.
-		if start := strings.Index(jql, "id IN ("); start != -1 {
-			inner := jql[start+len("id IN ("):]
-			if end := strings.Index(inner, ")"); end != -1 {
-				idCount := len(strings.Split(strings.TrimSpace(inner[:end]), ","))
+		if _, after, ok := strings.Cut(jql, "id IN ("); ok {
+			inner := after
+			if before, _, ok := strings.Cut(inner, ")"); ok {
+				idCount := len(strings.Split(strings.TrimSpace(before), ","))
 				if idCount > 40 {
 					t.Errorf("batch has %d IDs, max allowed 40", idCount)
 				}
@@ -790,7 +790,7 @@ func TestFetchIssueStatesByIDs_MultiBatch(t *testing.T) {
 		t.Fatalf("FetchIssueStatesByIDs: %v", err)
 	}
 
-	if got := atomic.LoadInt32(&requestCount); got != 2 {
+	if got := requestCount.Load(); got != 2 {
 		t.Errorf("request count = %d, want 2 batches", got)
 	}
 }
@@ -938,9 +938,9 @@ func TestFetchIssueStatesByIdentifiers_SingleBatch(t *testing.T) {
 func TestFetchIssueStatesByIdentifiers_MultiBatch(t *testing.T) {
 	t.Parallel()
 
-	var requestCount int32
+	var requestCount atomic.Int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		atomic.AddInt32(&requestCount, 1)
+		requestCount.Add(1)
 		jql := r.URL.Query().Get("jql")
 		keyCount := strings.Count(jql, `"PROJ-`)
 		if keyCount > batchSize {
@@ -968,7 +968,7 @@ func TestFetchIssueStatesByIdentifiers_MultiBatch(t *testing.T) {
 		t.Fatalf("FetchIssueStatesByIdentifiers: %v", err)
 	}
 
-	if got := atomic.LoadInt32(&requestCount); got != 2 {
+	if got := requestCount.Load(); got != 2 {
 		t.Errorf("request count = %d, want 2 batches", got)
 	}
 }

--- a/internal/tracker/jira/jira_v2_test.go
+++ b/internal/tracker/jira/jira_v2_test.go
@@ -486,11 +486,11 @@ func TestPaginatedSearchV2_MultiPage(t *testing.T) {
 	page2 := loadFixture(t, "search_v2_multi_page_2.json")
 
 	var (
-		callCount   int32
+		callCount   atomic.Int32
 		seenStartAt []string
 	)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		n := atomic.AddInt32(&callCount, 1)
+		n := callCount.Add(1)
 		seenStartAt = append(seenStartAt, r.URL.Query().Get("startAt"))
 		if r.URL.Path != "/rest/api/2/search" {
 			t.Errorf("request path = %q, want /rest/api/2/search", r.URL.Path)
@@ -511,7 +511,7 @@ func TestPaginatedSearchV2_MultiPage(t *testing.T) {
 	if len(issues) != 3 {
 		t.Fatalf("len = %d, want 3 across 2 pages", len(issues))
 	}
-	if got := atomic.LoadInt32(&callCount); got != 2 {
+	if got := callCount.Load(); got != 2 {
 		t.Errorf("request count = %d, want 2", got)
 	}
 	wantIDs := []string{"SRV-11", "SRV-12", "SRV-13"}
@@ -534,9 +534,9 @@ func TestPaginatedSearchV2_FinalFullPageTerminates(t *testing.T) {
 	t.Parallel()
 
 	// total == 2 and the single page returns 2 issues: startAt(0)+2 >= 2.
-	var callCount int32
+	var callCount atomic.Int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		atomic.AddInt32(&callCount, 1)
+		callCount.Add(1)
 		w.Write(loadFixture(t, "search_v2_single_page.json")) //nolint:errcheck // test helper
 	}))
 	defer srv.Close()
@@ -549,7 +549,7 @@ func TestPaginatedSearchV2_FinalFullPageTerminates(t *testing.T) {
 	if len(issues) != 2 {
 		t.Fatalf("len = %d, want 2", len(issues))
 	}
-	if got := atomic.LoadInt32(&callCount); got != 1 {
+	if got := callCount.Load(); got != 1 {
 		t.Errorf("request count = %d, want 1 (loop must terminate on a full final page)", got)
 	}
 }

--- a/internal/tracker/linear/fake_test.go
+++ b/internal/tracker/linear/fake_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"io"
 	"log/slog"
+	"maps"
 	"net/http"
 	"os"
 	"strings"
@@ -93,9 +94,7 @@ func cloneVars(in map[string]any) map[string]any {
 		return nil
 	}
 	out := make(map[string]any, len(in))
-	for k, v := range in {
-		out[k] = v
-	}
+	maps.Copy(out, in)
 	return out
 }
 

--- a/internal/tracker/linear/linear.go
+++ b/internal/tracker/linear/linear.go
@@ -17,6 +17,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"maps"
 	"strconv"
 	"strings"
 
@@ -267,9 +268,7 @@ func buildFetchFilter(teamKey string, states []string, operatorFilter map[string
 		"team":  map[string]any{"key": map[string]any{"eq": teamKey}},
 		"state": map[string]any{"name": map[string]any{"in": states}},
 	}
-	for key, value := range operatorFilter {
-		filter[key] = value
-	}
+	maps.Copy(filter, operatorFilter)
 	return filter
 }
 

--- a/internal/workflow/loader.go
+++ b/internal/workflow/loader.go
@@ -52,15 +52,13 @@ func Load(path string) (Workflow, error) {
 	// Check whether the first line is a front matter opening delimiter.
 	// Allow optional trailing whitespace on the delimiter line, consistent
 	// with closing delimiter handling.
-	firstNL := strings.IndexByte(content, '\n')
-	if firstNL == -1 || strings.TrimRight(content[:firstNL], " \t") != "---" {
+	firstLine, rest, hasNL := strings.Cut(content, "\n")
+	if !hasNL || strings.TrimRight(firstLine, " \t") != "---" {
 		return Workflow{
 			Config:         make(map[string]any),
 			PromptTemplate: strings.TrimSpace(content),
 		}, nil
 	}
-
-	rest := content[firstNL+1:] // skip opening delimiter line
 
 	fmBytes, promptBody, closingFound := splitAtClosingDelimiter(rest)
 

--- a/internal/workflow/manager_test.go
+++ b/internal/workflow/manager_test.go
@@ -20,7 +20,7 @@ import (
 // validWorkflow returns a minimal valid WORKFLOW.md content with the
 // given polling interval.
 func validWorkflow(intervalMS int) []byte {
-	return []byte(fmt.Sprintf("---\npolling:\n  interval_ms: %d\n---\nDo the task for {{ .issue.title }}.\n", intervalMS))
+	return fmt.Appendf(nil, "---\npolling:\n  interval_ms: %d\n---\nDo the task for {{ .issue.title }}.\n", intervalMS)
 }
 
 func testLogger() *slog.Logger {
@@ -239,8 +239,7 @@ func TestManager_WatchPicksUpChange(t *testing.T) {
 		t.Fatalf("NewManager: %v", err)
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	if err := mgr.Start(ctx); err != nil {
 		t.Fatalf("Start: %v", err)
 	}
@@ -274,8 +273,7 @@ func TestManager_WatchInvalidRetainsGood(t *testing.T) {
 		t.Fatalf("NewManager: %v", err)
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	if err := mgr.Start(ctx); err != nil {
 		t.Fatalf("Start: %v", err)
 	}
@@ -313,8 +311,7 @@ func TestManager_ConcurrentReadSafety(t *testing.T) {
 		t.Fatalf("NewManager: %v", err)
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	if err := mgr.Start(ctx); err != nil {
 		t.Fatalf("Start: %v", err)
 	}
@@ -329,15 +326,13 @@ func TestManager_ConcurrentReadSafety(t *testing.T) {
 	const readers = 10
 
 	for range readers {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			for !reloaded.Load() {
 				_ = mgr.Config()
 				_ = mgr.PromptTemplate()
 				_ = mgr.LastLoadError()
 			}
-		}()
+		})
 	}
 
 	writeWorkflow(t, path, validWorkflow(7777))
@@ -368,8 +363,7 @@ func TestManager_DebounceCoalescence(t *testing.T) {
 		t.Fatalf("NewManager: %v", err)
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	if err := mgr.Start(ctx); err != nil {
 		t.Fatalf("Start: %v", err)
 	}
@@ -406,8 +400,7 @@ func TestManager_DeleteAndRecreate(t *testing.T) {
 		t.Fatalf("NewManager: %v", err)
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	if err := mgr.Start(ctx); err != nil {
 		t.Fatalf("Start: %v", err)
 	}
@@ -486,8 +479,7 @@ func TestManager_StopIdempotent(t *testing.T) {
 		t.Fatalf("NewManager: %v", err)
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	if err := mgr.Start(ctx); err != nil {
 		t.Fatalf("Start: %v", err)
 	}
@@ -509,8 +501,7 @@ func TestManager_RecoverAfterInvalidReload(t *testing.T) {
 		t.Fatalf("NewManager: %v", err)
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	if err := mgr.Start(ctx); err != nil {
 		t.Fatalf("Start: %v", err)
 	}
@@ -546,22 +537,22 @@ func TestManager_RecoverAfterInvalidReload(t *testing.T) {
 // active and terminal state lists. An empty slice results in the key being
 // absent from the front matter.
 func workflowWithStates(active, terminal []string) []byte {
-	var s string
-	s += "---\npolling:\n  interval_ms: 5000\ntracker:\n"
+	var s strings.Builder
+	s.WriteString("---\npolling:\n  interval_ms: 5000\ntracker:\n")
 	if len(active) > 0 {
-		s += "  active_states:\n"
+		s.WriteString("  active_states:\n")
 		for _, st := range active {
-			s += fmt.Sprintf("    - %s\n", st)
+			fmt.Fprintf(&s, "    - %s\n", st)
 		}
 	}
 	if len(terminal) > 0 {
-		s += "  terminal_states:\n"
+		s.WriteString("  terminal_states:\n")
 		for _, st := range terminal {
-			s += fmt.Sprintf("    - %s\n", st)
+			fmt.Fprintf(&s, "    - %s\n", st)
 		}
 	}
-	s += "---\nDo the task for {{ .issue.title }}.\n"
-	return []byte(s)
+	s.WriteString("---\nDo the task for {{ .issue.title }}.\n")
+	return []byte(s.String())
 }
 
 // rejectBothEmpty is a ValidateFunc that rejects configs where both
@@ -729,8 +720,7 @@ func TestManager_SetLogger(t *testing.T) {
 
 	mgr.SetLogger(loggerB)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	if err := mgr.Start(ctx); err != nil {
 		t.Fatalf("Start: %v", err)
 	}
@@ -777,8 +767,7 @@ func TestManager_SetLoggerNil(t *testing.T) {
 
 	mgr.SetLogger(nil)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	if err := mgr.Start(ctx); err != nil {
 		t.Fatalf("Start: %v", err)
 	}
@@ -814,8 +803,7 @@ func TestManager_SetLoggerConcurrentWithReload(t *testing.T) {
 		t.Fatalf("NewManager: %v", err)
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	if err := mgr.Start(ctx); err != nil {
 		t.Fatalf("Start: %v", err)
 	}
@@ -824,13 +812,11 @@ func TestManager_SetLoggerConcurrentWithReload(t *testing.T) {
 
 	var stop atomic.Bool
 	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		for !stop.Load() {
 			mgr.SetLogger(testLogger())
 		}
-	}()
+	})
 
 	for i := range 5 {
 		writeWorkflow(t, path, validWorkflow(5000+i))


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Refactor

**Intent:** Apply idiomatic Go patterns enforced by the newly enabled `modernize` linter, reducing boilerplate and replacing manual patterns with standard-library equivalents introduced in recent Go versions.

### 🧭 Reviewer Guide

**Complexity:** Medium

#### Entry Point

`internal/orchestrator/auto_merge_reconcile.go` is the best starting point. It shows the two primary transformation patterns in context: `wg.Go(func() { ... })` replacing the `wg.Add(1); go func() { defer wg.Done(); ... }()` idiom, and `max(a, b)` replacing if-guard assignments. The same two patterns repeat across every other orchestrator, persistence, server, and tool file.

#### Sensitive Areas

- `internal/orchestrator/dispatch.go`, `internal/orchestrator/exit.go`, `internal/orchestrator/ci_reconcile.go`, `internal/orchestrator/review_reconcile.go`, `internal/orchestrator/auto_merge_reconcile.go`: goroutine launch sites migrated from `wg.Add(1)/go func()/defer wg.Done()` to `wg.Go(func())` — semantics are identical but worth a careful read since these are the live worker and tracker-ops fire-and-forget paths.
- `.golangci.yml`: `omitzero` and `newexpr` sub-rules are explicitly disabled. `omitzero` is suppressed because `omitempty`→`omitzero` changes JSON marshaling behaviour on struct-typed fields; `newexpr` because it leaves inline wrapper functions and mixed call sites in a broken state.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes
- **Migrations/State:** No migrations or state changes