### PR TITLE
ci: wire Linear integration tests into release and nightly

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -28,6 +28,8 @@ jobs:
       SORTIE_JIRA_ENDPOINT: ${{ secrets.SORTIE_JIRA_ENDPOINT }}
       SORTIE_JIRA_API_KEY: ${{ secrets.SORTIE_JIRA_API_KEY }}
       SORTIE_JIRA_PROJECT: ${{ secrets.SORTIE_JIRA_PROJECT }}
+      SORTIE_LINEAR_API_KEY: ${{ secrets.SORTIE_LINEAR_API_KEY }}
+      SORTIE_LINEAR_TEAM_KEY: ${{ vars.SORTIE_LINEAR_TEAM_KEY }}
       SORTIE_GITHUB_TOKEN: ${{ secrets.SORTIE_GITHUB_TOKEN }}
       SORTIE_GITHUB_PROJECT: sortie-ai/sortie-test
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -109,6 +111,18 @@ jobs:
             install: ""
             version_cmd: ""
             source: "Jira Cloud REST API (remote service, no pinned client)"
+
+          - name: Linear
+            adapter: linear
+            kind: tracker
+            guard: SORTIE_LINEAR_TEST
+            run_filter: Integration
+            test_path: ./internal/tracker/linear/...
+            timeout: ""
+            node: false
+            install: ""
+            version_cmd: ""
+            source: "Linear GraphQL API (remote service, no pinned client)"
 
           - name: GitHub
             adapter: github

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -161,6 +161,38 @@ jobs:
       - name: Run integration tests
         run: go test -race -count=1 -v -run 'Integration' ./internal/scm/github/...
 
+  test-integration-linear:
+    name: "Integration: Linear"
+    needs: [lint, test-unit]
+    runs-on: ubuntu-latest
+    env:
+      SORTIE_LINEAR_TEST: "1"
+      SORTIE_LINEAR_API_KEY: ${{ secrets.SORTIE_LINEAR_API_KEY }}
+      SORTIE_LINEAR_TEAM_KEY: ${{ vars.SORTIE_LINEAR_TEAM_KEY }}
+    steps:
+      - name: Verify Linear credentials are configured
+        run: |
+          missing=()
+          [ -z "$SORTIE_LINEAR_API_KEY" ]  && missing+=("SORTIE_LINEAR_API_KEY (secret)")
+          [ -z "$SORTIE_LINEAR_TEAM_KEY" ] && missing+=("SORTIE_LINEAR_TEAM_KEY (variable)")
+          if [ ${#missing[@]} -ne 0 ]; then
+            echo "::error::Missing required Linear credentials: ${missing[*]}"
+            echo "Configure these in Settings → Secrets and variables → Actions"
+            exit 1
+          fi
+          echo "✓ Linear credentials are present"
+
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+
+      - name: Run integration tests
+        run: go test -race -count=1 -v -run 'Integration' ./internal/tracker/linear/...
+
   test-e2e-github:
     name: "E2E: GitHub orchestrator"
     needs: [lint, test-unit]
@@ -375,6 +407,7 @@ jobs:
       - test-unit
       - test-integration-jira
       - test-integration-github
+      - test-integration-linear
       - test-e2e-github
       - test-integration-claude
       - test-integration-copilot


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Chore

**Intent:** Wire the Linear tracker adapter integration tests into CI, matching the credential-preflight + guarded-run pattern used for Jira and GitHub. A release is now blocked on Linear adapter health, and the nightly workflow detects Linear API drift on a schedule.

**Related Issues:** #591

### 🧭 Reviewer Guide

**Complexity:** Low

#### Entry Point

`.github/workflows/release.yml` — the new `test-integration-linear` job is the primary change. It follows the same structure as `test-integration-jira`: a credential-preflight step that fails fast if secrets are missing, then checkout + Go setup + `go test -race -count=1 -v -run Integration ./internal/tracker/linear/...`. The job is added to the final release gate`s `needs` list, so a broken Linear adapter blocks a release.

#### Sensitive Areas

- `.github/workflows/release.yml` (final job `needs` list): `test-integration-linear` is now a hard dependency for the release gate. If the Linear credentials are not configured in repository secrets/variables, every release job will fail at the preflight step.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes
- **Migrations/State:** No migrations or state changes