### PR TITLE
chore: tidy release config, ignores, and Homebrew cask

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,8 +1,7 @@
-# Build artifacts
-dist/
-sortie
-sortie.exe
+# Test data
 *.test
+
+# Code coverage profiles and other test artifacts.
 *.out
 coverage.*
 *.coverprofile
@@ -11,6 +10,7 @@ profile.cov
 # Git
 .git
 .gitignore
+.gitattributes
 
 # IDE
 .zed
@@ -19,6 +19,7 @@ profile.cov
 docs/
 blog/
 website/
+kb/
 *.md
 
 # CI and project config
@@ -33,9 +34,6 @@ codecov.yml
 .sortie.db-shm
 .sortie.db-wal
 
-# Git config and attributes
-.gitattributes
-
 # Build tools and configs
 .tool-versions
 Makefile
@@ -47,6 +45,11 @@ default.mk
 # Environment files
 .env
 .env.*
+
+# Build artifacts
+dist/
+sortie
+sortie.exe
 
 # Test fixtures and examples
 examples/

--- a/.gitignore
+++ b/.gitignore
@@ -25,9 +25,10 @@ go.work.sum
 /.env
 /.env.*
 
-# Build output
+# Build artifacts
 /sortie
 /sortie.exe
+/dist
 
 .sortie.db
 .sortie.db-shm

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -62,25 +62,28 @@ checksum:
 sboms:
   - artifacts: archive
 
-brews:
+homebrew_casks:
   - name: sortie
     repository:
       owner: sortie-ai
       name: homebrew-tap
       branch: main
       token: "{{ .Env.TAP_GITHUB_TOKEN }}"
-    directory: Formula
     commit_author:
       name: goreleaserbot
       email: goreleaserbot@users.noreply.github.com
-    commit_msg_template: "chore(formula): update {{ .ProjectName }} to {{ .Tag }}"
+    commit_msg_template: "chore(cask): update {{ .ProjectName }} to {{ .Tag }}"
     homepage: "https://github.com/sortie-ai/sortie"
     description: "Spec-first orchestration service for coding agents"
     license: "Apache-2.0"
-    install: |
-      bin.install "sortie"
-    test: |
-      assert_match version.to_s, shell_output("#{bin}/sortie --version")
+    hooks:
+      post:
+        # macOS binaries are not notarized, so Gatekeeper would quarantine the
+        # cask and block first run; drop the attribute on install.
+        install: |
+          if OS.mac?
+            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/sortie"]
+          end
     skip_upload: "auto"
 
 changelog:
@@ -101,11 +104,13 @@ changelog:
   filters:
     exclude:
       - "(?i)^docs[:(]"
-      - "(?i)^test[:(]"
+      - "(?i)^tests?[:(]"
       - "(?i)^chore[:(]"
       - "(?i)^ci[:(]"
       - "(?i)^style[:(]"
       - "(?i)^refactor[:(]"
+      - "(?i)^Merge pull request #"
+      - "(?i)^Merge (remote-tracking )?branch '"
 
 release:
   github:


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Chore

**Intent:** Migrate the Homebrew tap from a Formula to a Cask with a quarantine-strip post-install hook so un-notarized macOS binaries aren't blocked by Gatekeeper on first run. Tighten changelog filters and reorganise ignore files for consistency.

### 🧭 Reviewer Guide

**Complexity:** Low

#### Entry Point

`.goreleaser.yaml` is the most significant change. The `brews` key is replaced by `homebrew_casks`, the `directory: Formula` line is removed, and a `hooks.post.install` script is added that runs `xattr -dr com.apple.quarantine` on macOS. The changelog `filters.exclude` list gains patterns for merge commits and broadens the test filter to `tests?`.

#### Sensitive Areas

- `.goreleaser.yaml`: The cask hook runs an `xattr` system command as part of cask installation on the end-user's machine; verify the `if OS.mac?` guard and argument escaping are correct.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes
- **Migrations/State:** No migrations or state changes