### PR TITLE
feat(linear): add sample WORKFLOW.linear.md to examples

### DIFF
--- a/cmd/sortie/sample_workflow_test.go
+++ b/cmd/sortie/sample_workflow_test.go
@@ -96,6 +96,11 @@ func TestSampleWorkflowLoad(t *testing.T) {
 			file:     "WORKFLOW.opencode.md",
 			wantKeys: []string{"tracker", "polling", "workspace", "hooks", "agent", "opencode", "server"},
 		},
+		{
+			name:     "WORKFLOW.linear.md loads with expected config keys",
+			file:     "WORKFLOW.linear.md",
+			wantKeys: []string{"tracker", "polling", "workspace", "hooks", "agent", "claude-code", "server"},
+		},
 	}
 
 	for _, tt := range tests {
@@ -155,6 +160,16 @@ func TestSampleWorkflowRender(t *testing.T) {
 		{
 			name:  "WORKFLOW.opencode.md minimal issue",
 			file:  "WORKFLOW.opencode.md",
+			issue: minimalIssue(),
+		},
+		{
+			name:  "WORKFLOW.linear.md full issue",
+			file:  "WORKFLOW.linear.md",
+			issue: fullIssue(),
+		},
+		{
+			name:  "WORKFLOW.linear.md minimal issue",
+			file:  "WORKFLOW.linear.md",
 			issue: minimalIssue(),
 		},
 	}
@@ -297,7 +312,7 @@ func TestSampleWorkflowTestFilePathConfig(t *testing.T) {
 func TestSampleWorkflowNoHTMLComments(t *testing.T) {
 	t.Parallel()
 
-	files := []string{"WORKFLOW.md", "WORKFLOW.test.md", "WORKFLOW.opencode.md"}
+	files := []string{"WORKFLOW.md", "WORKFLOW.test.md", "WORKFLOW.opencode.md", "WORKFLOW.linear.md"}
 	for _, name := range files {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -402,6 +417,40 @@ func TestSampleWorkflowEnvVarIndirection(t *testing.T) {
 		{"endpoint", "$SORTIE_JIRA_ENDPOINT"},
 		{"api_key", "$SORTIE_JIRA_API_KEY"},
 		{"project", "$SORTIE_JIRA_PROJECT"},
+	}
+	for _, c := range checks {
+		got, _ := tracker[c.key].(string)
+		if got != c.want {
+			t.Errorf("tracker.%s = %q, want %q", c.key, got, c.want)
+		}
+	}
+}
+
+func TestSampleWorkflowLinearEnvVarIndirection(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(repoRoot(t), "examples", "WORKFLOW.linear.md")
+	wf, err := workflow.Load(path)
+	if err != nil {
+		t.Fatalf("workflow.Load(WORKFLOW.linear.md): %v", err)
+	}
+
+	tracker, ok := wf.Config["tracker"].(map[string]any)
+	if !ok {
+		t.Fatal("WORKFLOW.linear.md config missing tracker map")
+	}
+
+	if kind, _ := tracker["kind"].(string); kind != "linear" {
+		t.Errorf("tracker.kind = %q, want %q", kind, "linear")
+	}
+
+	// Credential and project fields must use $SORTIE_* indirection.
+	checks := []struct {
+		key  string
+		want string
+	}{
+		{"api_key", "$SORTIE_LINEAR_API_KEY"},
+		{"project", "$SORTIE_LINEAR_TEAM_KEY"},
 	}
 	for _, c := range checks {
 		got, _ := tracker[c.key].(string)

--- a/examples/WORKFLOW.linear.md
+++ b/examples/WORKFLOW.linear.md
@@ -1,0 +1,159 @@
+---
+tracker:
+  kind: linear
+  api_key: $SORTIE_LINEAR_API_KEY
+  project: $SORTIE_LINEAR_TEAM_KEY
+  query_filter: '{ "labels": { "name": { "eq": "agent-ready" } } }'
+  active_states:
+    - Todo
+    - In Progress
+  terminal_states:
+    - Done
+    - Canceled
+    - Duplicate
+  handoff_state: In Review
+
+polling:
+  interval_ms: 45000
+
+workspace:
+  root: $SORTIE_WORKSPACE_ROOT
+
+hooks:
+  after_create: |
+    git clone --depth 1 $SORTIE_REPO_URL .
+    go mod download
+  before_run: |
+    git fetch origin main
+    git checkout -B "sortie/$SORTIE_ISSUE_IDENTIFIER" origin/main
+  after_run: |
+    make fmt 2>/dev/null || true
+    git add -A
+    git diff --cached --quiet || git commit -m "sortie($SORTIE_ISSUE_IDENTIFIER): automated changes"
+  before_remove: |
+    git push origin --delete "sortie/$SORTIE_ISSUE_IDENTIFIER" 2>/dev/null || true
+  timeout_ms: 120000
+
+agent:
+  kind: claude-code
+  command: claude
+  max_turns: 15
+  max_concurrent_agents: 4
+  turn_timeout_ms: 3600000
+  read_timeout_ms: 5000
+  stall_timeout_ms: 300000
+  max_retry_backoff_ms: 300000
+  max_concurrent_agents_by_state:
+    in progress: 3
+    to do: 1
+
+claude-code:
+  permission_mode: bypassPermissions
+  model: claude-sonnet-4-6
+  max_turns: 50
+  max_budget_usd: 5
+
+server:
+  port: 8642
+---
+
+{{/* Sortie sample workflow, Linear + Claude Code.
+     Required env vars:
+       SORTIE_LINEAR_API_KEY  Linear personal API key (lin_api_...)
+       SORTIE_LINEAR_TEAM_KEY Linear team key (e.g. ENG)
+       SORTIE_REPO_URL        Git clone URL for the repository
+     Optional:
+       SORTIE_WORKSPACE_ROOT  Base directory for per-issue workspaces
+                              (defaults to system temp) */}}
+You are a senior engineer. Your work is tracked by an automated orchestrator (Sortie)
+that manages your session, retries failures, and monitors progress.
+
+## Your task
+
+**{{ .issue.identifier }}**: {{ .issue.title }}
+
+{{ if .issue.description }}
+
+### Description
+
+{{ .issue.description }}
+{{ end }}
+
+## Context
+
+Before making changes, read:
+
+- `CLAUDE.md` for build commands and project boundaries
+- `docs/architecture.md` for the relevant specification section
+- Any existing tests in the area you are modifying
+
+## Rules
+
+1. Run the project's lint and test commands before finishing. All checks must pass.
+2. Do not modify protected files (architecture docs, ADRs, LICENSE) unless the task
+   explicitly requires it.
+3. Write table-driven tests. Cover edge cases, not just the happy path.
+4. If you encounter a problem outside the scope of this task, write `blocked` to
+   `.sortie/status` and stop.
+5. Keep changes minimal - implement exactly what the task requires.
+
+{{ if not .run.is_continuation }}
+
+## Approach
+
+1. Read the relevant documentation and existing code before writing anything.
+2. Implement the minimal change that satisfies the task requirements.
+3. Write or update tests to cover the new behavior.
+4. Run verification commands and fix any failures.
+5. If the task is complete, confirm by reviewing your changes.
+   {{ end }}
+
+{{ if .run.is_continuation }}
+
+## Continuation
+
+You are resuming work on this task (turn {{ .run.turn_number }} of {{ .run.max_turns }}).
+Review the current state of the workspace - check test output, lint results, and any
+partial changes. Do not repeat work already completed. Proceed with the next step.
+{{ end }}
+
+{{ if .attempt }}
+
+## Retry
+
+This is retry attempt {{ .attempt }}. A previous run failed or timed out. Check the
+workspace for partial work and do not start from scratch. Review any error output from
+the previous attempt if visible in the workspace.
+{{ end }}
+
+{{ if .issue.url }}
+
+## Reference
+
+Ticket: {{ .issue.url }}
+{{ end }}
+
+{{ if .issue.labels }}
+
+## Labels
+
+{{ .issue.labels | join ", " }}
+{{ end }}
+
+{{ if .issue.parent }}
+
+## Parent issue
+
+{{ .issue.parent.identifier }}
+{{ end }}
+
+{{ if .issue.blocked_by }}
+
+## Blockers
+
+The following issues block this task. If any are unresolved, focus on preparation work
+that does not depend on the blocked functionality (tests, scaffolding, documentation).
+
+{{ range .issue.blocked_by }}- **{{ .identifier }}**{{ if .state }} ({{ .state }}){{ end }}
+{{ end }}
+{{ end }}

--- a/examples/WORKFLOW.md
+++ b/examples/WORKFLOW.md
@@ -50,7 +50,7 @@ agent:
 
 claude-code:
   permission_mode: bypassPermissions
-  model: claude-sonnet-4-20250514
+  model: claude-sonnet-4-6
   max_turns: 50
   max_budget_usd: 5
 

--- a/examples/WORKFLOW.opencode.md
+++ b/examples/WORKFLOW.opencode.md
@@ -46,7 +46,7 @@ agent:
   max_retry_backoff_ms: 300000
 
 opencode:
-  model: anthropic/claude-sonnet-4-5
+  model: anthropic/claude-sonnet-4-6
   dangerously_skip_permissions: true
   disable_autocompact: true
   allowed_tools:


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Feat

**Intent:** Adds a ready-to-use `examples/WORKFLOW.linear.md` that demonstrates the Linear tracker adapter paired with the Claude Code agent. A developer adopting Sortie with Linear only needs to substitute their API key and team key to get a validating, runnable workflow.

**Related Issues:** #593

### 🧭 Reviewer Guide

**Complexity:** Medium

#### Entry Point

`examples/WORKFLOW.linear.md` - the new sample file. It sets `tracker.kind: linear`, uses `$SORTIE_LINEAR_API_KEY` and `$SORTIE_LINEAR_TEAM_KEY` for env-var indirection, maps Linear state labels to active/terminal/handoff buckets, and includes a prompt template covering all issue-context variables the orchestrator injects.

#### Sensitive Areas

- `cmd/sortie/sample_workflow_test.go`: the new `TestSampleWorkflowLinearEnvVarIndirection` test asserts the exact field names (`api_key`, `project`) and indirection strings (`$SORTIE_LINEAR_API_KEY`, `$SORTIE_LINEAR_TEAM_KEY`) used by the Linear adapter. If the adapter config shape changes, this test is the first signal.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes
- **Migrations/State:** No migrations or state changes