### PR TITLE
build: migrate Homebrew distribution from formula to cask

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -62,26 +62,32 @@ checksum:
 sboms:
   - artifacts: archive
 
-brews:
+homebrew_casks:
   - name: sortie
+    binaries:
+      - sortie
     repository:
       owner: sortie-ai
       name: homebrew-tap
       branch: main
       token: "{{ .Env.TAP_GITHUB_TOKEN }}"
-    directory: Formula
+    directory: Casks
     commit_author:
       name: goreleaserbot
       email: goreleaserbot@users.noreply.github.com
-    commit_msg_template: "chore(formula): update {{ .ProjectName }} to {{ .Tag }}"
+    commit_msg_template: "chore(cask): update {{ .ProjectName }} to {{ .Tag }}"
     homepage: "https://github.com/sortie-ai/sortie"
     description: "Spec-first orchestration service for coding agents"
-    license: "Apache-2.0"
-    install: |
-      bin.install "sortie"
-    test: |
-      assert_match version.to_s, shell_output("#{bin}/sortie --version")
     skip_upload: "auto"
+    url:
+      verified: "github.com/sortie-ai/sortie/"
+    hooks:
+      post:
+        install: |
+          if OS.mac?
+            system_command "/usr/bin/xattr",
+              args: ["-dr", "com.apple.quarantine", "#{staged_path}/sortie"]
+          end
 
 changelog:
   sort: asc

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -86,7 +86,8 @@ homebrew_casks:
         install: |
           if OS.mac?
             system_command "/usr/bin/xattr",
-              args: ["-dr", "com.apple.quarantine", "#{staged_path}/sortie"]
+              args: ["-dr", "com.apple.quarantine", "#{staged_path}/sortie"],
+              must_succeed: false
           end
 
 changelog:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Homebrew installs now use `brew install --cask sortie-ai/tap/sortie`.
+  The tap distributes a Homebrew cask covering both macOS and Linux,
+  replacing the previous formula.
+  ([#613](https://github.com/sortie-ai/sortie/issues/613))
+
 ## [1.13.0] - 2026-06-15
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Sortie assumes your coding agent already produces useful results when you run it
 curl -sSL https://get.sortie-ai.com/install.sh | sh
 ```
 
-Or via Homebrew: `brew install sortie-ai/tap/sortie`
+Or via Homebrew: `brew install --cask sortie-ai/tap/sortie`
 
 ## The Problem
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -27,7 +27,7 @@ Sortie 假定你的编程智能体在手动运行时已经能够产出有价值�
 curl -sSL https://get.sortie-ai.com/install.sh | sh
 ```
 
-或通过 Homebrew 安装：`brew install sortie-ai/tap/sortie`
+或通过 Homebrew 安装：`brew install --cask sortie-ai/tap/sortie`
 
 ## 要解决的问题
 


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Chore

**Intent:** GoReleaser soft-deprecated `brews` in v2.10 and will hard-remove it in v2.16. Migrating to `homebrew_casks` now keeps the Homebrew tap working on both macOS and Linux once the deprecation window closes.

**Related Issues:** #613

### 🧭 Reviewer Guide

**Complexity:** Low

#### Entry Point

`.goreleaser.yaml` - the `brews` block is replaced with `homebrew_casks`. The new block adds a `binaries` declaration, moves the tap output to the `Casks/` directory, sets `url.verified`, and adds a post-install hook that strips the macOS quarantine attribute via `xattr -dr com.apple.quarantine`. No other source files are affected.

#### Sensitive Areas

- `.goreleaser.yaml`: Release pipeline config - a misconfigured cask block would silently produce a macOS-only cask, dropping Linux support. Confirm `binaries`, `url.verified`, and the hook guard (`OS.mac?`) are all present.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes to the binary or its behaviour. The Homebrew install command changes from `brew install` to `brew install --cask`; README (EN + zh-CN) and CHANGELOG are updated accordingly.
- **Migrations/State:** No migrations or state changes