### PR TITLE
feat: add bot-review reaction kind for automated review bots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Bot-review reaction kind: automated review-bot comments (linters,
-  static analyzers, security scanners, dependency bots) on a
+  static analyzers, security scanners, and AI reviewers) on a
   Sortie-created pull request are now detected separately from human
   review comments and routed back into the agent session as
   continuation turns. Enable it with a `reactions.bot_review` block in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Bot-review reaction kind: automated review-bot comments (linters,
+  static analyzers, security scanners, dependency bots) on a
+  Sortie-created pull request are now detected separately from human
+  review comments and routed back into the agent session as
+  continuation turns. Enable it with a `reactions.bot_review` block in
+  WORKFLOW.md: `provider` activates the kind (an empty provider leaves
+  it inactive), `bot_usernames` is an allowlist of bot login names,
+  `max_continuation_turns` caps continuation attempts (default 5),
+  `poll_interval_ms` sets the poll cadence (default 60000, minimum
+  30000), and `escalation` (`label` or `comment`, default `label`)
+  with `escalation_label` (default `needs-human`) controls handoff
+  once the budget is exhausted. Comments are classified as bot-authored
+  by the platform author type or the configured username allowlist,
+  never by comment content. Unlike human review comments, bot comments
+  dispatch immediately with no debounce window and carry an independent
+  retry budget, fingerprint, and escalation config, so the bot-review
+  and human-review kinds never interfere on the same pull request.
+  Visible on startup as a `bot review routing enabled` log line and via
+  the `sortie_bot_review_checks_total` and
+  `sortie_bot_review_escalations_total` metrics.
+  ([#415](https://github.com/sortie-ai/sortie/issues/415))
+
 ### Changed
 
 - Homebrew installs now use `brew install --cask sortie-ai/tap/sortie`.

--- a/cmd/sortie/main.go
+++ b/cmd/sortie/main.go
@@ -10,6 +10,7 @@
 package main
 
 import (
+	"cmp"
 	"context"
 	"errors"
 	"io"
@@ -120,6 +121,36 @@ func makeAgentAdapterByKind(cache map[string]domain.AgentAdapter) func(kind stri
 			Available: slices.Sorted(maps.Keys(cache)),
 		}
 	}
+}
+
+// scmReactionKind pairs an SCM reaction kind's WORKFLOW.md key with its
+// activation state and configured provider for the shared-provider check.
+type scmReactionKind struct {
+	name     string
+	active   bool
+	provider string
+}
+
+// scmProviderConflict reports the active SCM reaction kinds and their
+// distinct providers. A single SCMAdapter is shared by all active SCM
+// reaction reconcile passes, so every active kind must name the same
+// provider. The caller treats more than one distinct provider as fatal.
+//
+// The returned kinds slice lists the names of every active kind in the
+// input order; the providers slice lists the distinct non-empty provider
+// values, also in first-seen order. When fewer than two providers are
+// returned there is no conflict.
+func scmProviderConflict(kinds []scmReactionKind) (activeKinds, distinctProviders []string) {
+	for _, k := range kinds {
+		if !k.active {
+			continue
+		}
+		activeKinds = append(activeKinds, k.name)
+		if !slices.Contains(distinctProviders, k.provider) {
+			distinctProviders = append(distinctProviders, k.provider)
+		}
+	}
+	return activeKinds, distinctProviders
 }
 
 func main() {
@@ -337,25 +368,31 @@ func run(ctx context.Context, args []string, stdout io.Writer, stderr io.Writer)
 	var reviewConfig orchestrator.ReviewReactionConfig
 	var autoMergeConfig orchestrator.AutoMergeReactionConfig
 	var autoMergeConfigured bool
+	var botReviewConfig orchestrator.BotReviewReactionConfig
+	var botReviewConfigured bool
 
 	reviewRC, hasReview := br.cfg.Reactions["review_comments"]
 	autoMergeRC, hasAutoMerge := br.cfg.Reactions["auto_merge"]
+	botReviewRC, hasBotReview := br.cfg.Reactions["bot_review"]
 	reviewActive := hasReview && reviewRC.Provider != ""
 	autoMergeActive := hasAutoMerge && autoMergeRC.Provider != ""
+	botReviewActive := hasBotReview && botReviewRC.Provider != ""
 
-	if reviewActive && autoMergeActive && reviewRC.Provider != autoMergeRC.Provider {
-		br.logger.Error("unsupported: reactions.review_comments and reactions.auto_merge must use the same provider",
-			slog.String("review_provider", reviewRC.Provider),
-			slog.String("auto_merge_provider", autoMergeRC.Provider),
+	activeSCMKinds := []scmReactionKind{
+		{name: "review_comments", active: reviewActive, provider: reviewRC.Provider},
+		{name: "auto_merge", active: autoMergeActive, provider: autoMergeRC.Provider},
+		{name: "bot_review", active: botReviewActive, provider: botReviewRC.Provider},
+	}
+	if conflictKinds, conflictProviders := scmProviderConflict(activeSCMKinds); len(conflictProviders) > 1 {
+		br.logger.Error("unsupported: active SCM reaction kinds must use the same provider",
+			slog.String("kinds", strings.Join(conflictKinds, ", ")),
+			slog.String("providers", strings.Join(conflictProviders, ", ")),
 		)
 		return 1
 	}
 
-	if reviewActive || autoMergeActive {
-		provider := reviewRC.Provider
-		if provider == "" {
-			provider = autoMergeRC.Provider
-		}
+	if reviewActive || autoMergeActive || botReviewActive {
+		provider := cmp.Or(reviewRC.Provider, autoMergeRC.Provider, botReviewRC.Provider)
 		scmCtor, scmErr := registry.SCMAdapters.Get(provider)
 		if scmErr != nil {
 			br.logger.Error("unknown SCM adapter kind",
@@ -378,6 +415,13 @@ func run(ctx context.Context, args []string, stdout io.Writer, stderr io.Writer)
 		}
 		if autoMergeActive {
 			for k, v := range autoMergeRC.Extra {
+				if _, exists := adapterCfgMap[k]; !exists {
+					adapterCfgMap[k] = v
+				}
+			}
+		}
+		if botReviewActive {
+			for k, v := range botReviewRC.Extra {
 				if _, exists := adapterCfgMap[k]; !exists {
 					adapterCfgMap[k] = v
 				}
@@ -428,6 +472,21 @@ func run(ctx context.Context, args []string, stdout io.Writer, stderr io.Writer)
 				slog.Int("max_retries", autoMergeConfig.MaxRetries),
 			)
 		}
+
+		if botReviewActive {
+			botReviewConfig, scmErr = orchestrator.BuildBotReviewReactionConfig(botReviewRC)
+			if scmErr != nil {
+				br.logger.Error("invalid bot_review reaction config", slog.Any("error", scmErr))
+				return 1
+			}
+			botReviewConfigured = true
+
+			br.logger.Info("bot review routing enabled",
+				slog.String("provider", botReviewRC.Provider),
+				slog.Int("max_continuation_turns", botReviewConfig.MaxContinuationTurns),
+				slog.Int("poll_interval_ms", botReviewConfig.PollIntervalMS),
+			)
+		}
 	}
 
 	recoveryEnabled := br.cfg.Tracker.HandoffState != "" && (ciProvider != nil || scmAdapter != nil)
@@ -448,6 +507,7 @@ func run(ctx context.Context, args []string, stdout io.Writer, stderr io.Writer)
 				CIProvider:                  ciProvider,
 				SCMAdapter:                  scmAdapter,
 				AutoMergeReactionConfigured: autoMergeConfigured,
+				BotReviewReactionConfigured: botReviewConfigured,
 				RecoveryLookback:            recoveryLookback,
 				MaxCandidates:               orchestrator.PendingReactionRecoveryMaxCandidates,
 				NowFunc: func() time.Time {
@@ -465,6 +525,7 @@ func run(ctx context.Context, args []string, stdout io.Writer, stderr io.Writer)
 		slog.Int("review_recovered", recoveryOutcome.ReviewRecovered),
 		slog.Int("ci_recovered", recoveryOutcome.CIRecovered),
 		slog.Int("auto_merge_recovered", recoveryOutcome.AutoMergeRecovered),
+		slog.Int("bot_review_recovered", recoveryOutcome.BotReviewRecovered),
 		slog.Int("stale_skipped", recoveryOutcome.StaleSkipped),
 		slog.Int("skipped", recoveryOutcome.Skipped),
 	}
@@ -559,6 +620,8 @@ func run(ctx context.Context, args []string, stdout io.Writer, stderr io.Writer)
 		ReviewConfig:                reviewConfig,
 		AutoMergeConfig:             autoMergeConfig,
 		AutoMergeReactionConfigured: autoMergeConfigured,
+		BotReviewConfig:             botReviewConfig,
+		BotReviewConfigured:         botReviewConfigured,
 	})
 
 	var srv *server.Server

--- a/cmd/sortie/scmprovider_test.go
+++ b/cmd/sortie/scmprovider_test.go
@@ -1,0 +1,149 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestScmProviderConflict(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name                  string
+		kinds                 []scmReactionKind
+		wantActiveKinds       []string
+		wantDistinctProviders []string
+		wantConflict          bool
+	}{
+		{
+			name:                  "zero active kinds",
+			kinds:                 []scmReactionKind{},
+			wantActiveKinds:       nil,
+			wantDistinctProviders: nil,
+			wantConflict:          false,
+		},
+		{
+			name: "one active kind",
+			kinds: []scmReactionKind{
+				{name: "review_comments", active: true, provider: "github"},
+			},
+			wantActiveKinds:       []string{"review_comments"},
+			wantDistinctProviders: []string{"github"},
+			wantConflict:          false,
+		},
+		{
+			name: "two active kinds same provider",
+			kinds: []scmReactionKind{
+				{name: "review_comments", active: true, provider: "github"},
+				{name: "auto_merge", active: true, provider: "github"},
+			},
+			wantActiveKinds:       []string{"review_comments", "auto_merge"},
+			wantDistinctProviders: []string{"github"},
+			wantConflict:          false,
+		},
+		{
+			name: "three active kinds same provider",
+			kinds: []scmReactionKind{
+				{name: "review_comments", active: true, provider: "github"},
+				{name: "auto_merge", active: true, provider: "github"},
+				{name: "bot_review", active: true, provider: "github"},
+			},
+			wantActiveKinds:       []string{"review_comments", "auto_merge", "bot_review"},
+			wantDistinctProviders: []string{"github"},
+			wantConflict:          false,
+		},
+		{
+			name: "two active kinds differing providers",
+			kinds: []scmReactionKind{
+				{name: "review_comments", active: true, provider: "github"},
+				{name: "auto_merge", active: true, provider: "gitlab"},
+			},
+			wantActiveKinds:       []string{"review_comments", "auto_merge"},
+			wantDistinctProviders: []string{"github", "gitlab"},
+			wantConflict:          true,
+		},
+		{
+			name: "three active kinds differing providers",
+			kinds: []scmReactionKind{
+				{name: "review_comments", active: true, provider: "github"},
+				{name: "auto_merge", active: true, provider: "gitlab"},
+				{name: "bot_review", active: true, provider: "bitbucket"},
+			},
+			wantActiveKinds:       []string{"review_comments", "auto_merge", "bot_review"},
+			wantDistinctProviders: []string{"github", "gitlab", "bitbucket"},
+			wantConflict:          true,
+		},
+		{
+			name: "two active kinds one inactive with different provider",
+			kinds: []scmReactionKind{
+				{name: "review_comments", active: true, provider: "github"},
+				{name: "auto_merge", active: false, provider: "gitlab"},
+				{name: "bot_review", active: true, provider: "github"},
+			},
+			wantActiveKinds:       []string{"review_comments", "bot_review"},
+			wantDistinctProviders: []string{"github"},
+			wantConflict:          false,
+		},
+		{
+			name: "active kinds returned in input order on conflict",
+			kinds: []scmReactionKind{
+				{name: "bot_review", active: true, provider: "github"},
+				{name: "review_comments", active: true, provider: "gitlab"},
+			},
+			wantActiveKinds:       []string{"bot_review", "review_comments"},
+			wantDistinctProviders: []string{"github", "gitlab"},
+			wantConflict:          true,
+		},
+		{
+			name: "all inactive kinds",
+			kinds: []scmReactionKind{
+				{name: "review_comments", active: false, provider: "github"},
+				{name: "auto_merge", active: false, provider: "gitlab"},
+				{name: "bot_review", active: false, provider: "bitbucket"},
+			},
+			wantActiveKinds:       nil,
+			wantDistinctProviders: nil,
+			wantConflict:          false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			gotKinds, gotProviders := scmProviderConflict(tt.kinds)
+
+			// Verify conflict detection: more than one distinct provider == conflict.
+			gotConflict := len(gotProviders) > 1
+			if gotConflict != tt.wantConflict {
+				t.Errorf("scmProviderConflict(%v) conflict = %v, want %v (providers: %v)",
+					tt.kinds, gotConflict, tt.wantConflict, gotProviders)
+			}
+
+			// Verify active kinds list length and content.
+			if len(gotKinds) != len(tt.wantActiveKinds) {
+				t.Errorf("scmProviderConflict(%v) activeKinds = %v, want %v",
+					tt.kinds, gotKinds, tt.wantActiveKinds)
+			} else {
+				for i, want := range tt.wantActiveKinds {
+					if gotKinds[i] != want {
+						t.Errorf("scmProviderConflict activeKinds[%d] = %q, want %q",
+							i, gotKinds[i], want)
+					}
+				}
+			}
+
+			// Verify distinct providers list length and content.
+			if len(gotProviders) != len(tt.wantDistinctProviders) {
+				t.Errorf("scmProviderConflict(%v) distinctProviders = %v, want %v",
+					tt.kinds, gotProviders, tt.wantDistinctProviders)
+			} else {
+				for i, want := range tt.wantDistinctProviders {
+					if gotProviders[i] != want {
+						t.Errorf("scmProviderConflict distinctProviders[%d] = %q, want %q",
+							i, gotProviders[i], want)
+					}
+				}
+			}
+		})
+	}
+}

--- a/docs/architecture-digest.md
+++ b/docs/architecture-digest.md
@@ -18,7 +18,7 @@
 - **Status Surface.** Optional HTTP server exposing operator-readable runtime state. Not required for orchestrator correctness.
 - **Logging.** Structured logs (`log/slog`) routed to one or more sinks.
 - **CI Status Provider.** Read-only single-method (`FetchCIStatus`) adapter. Activated only when workflow front matter requests CI feedback.
-- **SCM Adapter.** Read-write multi-method adapter exposing six methods (`FetchPendingReviews`, `GetReviewDecision`, `GetCIStatus`, `GetMergeability`, `MergePR`, `DeleteBranch`). Activated when `reactions.review_comments.provider` or `reactions.auto_merge.provider` is configured.
+- **SCM Adapter.** Read-write multi-method adapter exposing seven methods (`FetchPendingReviews`, `FetchBotReviewComments`, `GetReviewDecision`, `GetCIStatus`, `GetMergeability`, `MergePR`, `DeleteBranch`). Activated when `reactions.review_comments.provider`, `reactions.auto_merge.provider`, or `reactions.bot_review.provider` is configured.
 - **Notifier Adapter.** Read-write single-method (`Send`) adapter family behind the `notify_operator` agent tool. Activated when the top-level `notifications` list configures at least one backend (`webhook`, `slack` today). Resolved in the `sortie mcp-server` sidecar, not the orchestrator process.
 
 ## 2. Abstraction layers (strict downward dependency)
@@ -77,6 +77,7 @@ Open [`docs/architecture.md`](architecture.md) when your feature touches one of 
 | §11A CI Feedback Contract                             | Wiring CI feedback (provider activation, log truncation, normalized result shape)                  |
 | §11B PR Review Comment Feedback Contract              | Wiring review-comment feedback (SCM provider activation, pending-review semantics)                 |
 | §11C Auto-merge Reaction Contract                     | Wiring auto-merge reactions, SCM write methods (`MergePR`, `DeleteBranch`), the startup token-scope preflight, or the merge fingerprint kind |
+| §11D Bot Review Comment Feedback Contract             | Wiring bot review-comment feedback (bot-author classification, the `bot-review` reaction kind, immediate non-debounced dispatch)             |
 | §12 Prompt Construction and Context Assembly          | Changing prompt rendering, FuncMap, or context fields supplied to the template                     |
 | §13 Logging, Status, and Observability                | Adding log fields, metrics, status endpoints, or dashboard surfaces                                |
 | §14 Failure Model and Recovery Strategy               | Changing retry/backoff, restart-recovery, or failure categorization                                |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -3006,6 +3006,162 @@ state owned by a different reaction kind. Specifically, these paths MUST NOT cal
 A failed auto-merge does NOT invalidate parallel `ci` or `review` reaction continuations on
 the same issue, so the auto-merge cleanup path is scoped to the `merge` kind only.
 
+## 11D. Bot Review Comment Feedback Contract
+
+The `review` contract in §11B routes human `CHANGES_REQUESTED` review comments and deliberately
+discards bot-authored comments. This section defines the complementary contract: the `bot-review`
+reaction kind surfaces the half §11B drops. It detects automated review-bot PR comments, dispatches
+them as agent continuation turns, and escalates under an independent budget. Like §11B it is a
+read-only integration; it never resolves, replies to, or dismisses comments on the platform.
+
+The two kinds run on the same PR without interference. Each owns a distinct `pending_reactions`
+entry, `reaction_fingerprints` row, and `reaction_attempts` counter, because every key is composed
+via `ReactionKey(issue_id, kind)` and the fingerprint table primary key is `(issue_id, kind)`.
+There is the same YAML-versus-runtime asymmetry §11C.4 documents for auto-merge: the operator sets
+`reactions.bot_review` in `WORKFLOW.md`, while the runtime and persisted kind discriminator is
+`bot-review`.
+
+### 11D.1 SCMAdapter interface
+
+Bot classification is an SCM-adapter concern. `FetchPendingReviews` (§11B.1) returns the human
+half; the `SCMAdapter` interface is widened with a sibling method that returns the bot half:
+
+```go
+FetchBotReviewComments(ctx context.Context, prNumber int, owner, repo string, botUsernames []string) ([]ReviewComment, error)
+```
+
+- `prNumber`, `owner`, and `repo` are sourced from `SCMMetadata` (`.sortie/scm.json`), never from
+  the tracker project configuration. `botUsernames` is the operator allowlist and MAY be empty.
+- Returns a non-nil (possibly empty) `[]ReviewComment` on success or a `*SCMError` (§11B.3) on
+  failure.
+- Implementations MUST be safe for concurrent use.
+
+The result reuses the `ReviewComment` shape from §11B.2 unchanged; the bot's login is carried in the
+`reviewer` field. No author-type field is added to `ReviewComment`, because classification is
+resolved inside the adapter before the struct is constructed. No platform field name (`user.type`,
+`position`) leaves the adapter package.
+
+### 11D.2 Classification predicate
+
+A review or comment is bot-authored when the platform reports `user.type == "Bot"` OR the author
+login matches a `botUsernames` entry under case-insensitive comparison. The two conditions are a
+union: either qualifies. The allowlist is the operator's escape hatch for bots that do not set the
+`Bot` user type. Classification reads only `user.type` and `user.login`; no comment-body content
+heuristic is used.
+
+This is the mirror image of the `FetchPendingReviews` selection, with one further difference: the
+bot path MUST NOT require a `CHANGES_REQUESTED` review state. Automated review tools commonly post
+`COMMENTED` reviews, so any review or comment passing the bot-author predicate is selected
+regardless of review state. Comments the platform marks outdated are returned with `outdated == true`
+for the caller to filter.
+
+### 11D.3 Reconcile loop integration
+
+Bot-review reconciliation runs after `review` reconciliation and before the auto-merge pass in the
+poll tick. It mirrors the `review` loop (§11B.4) with two omissions and one substitution: there is
+no debounce gate and no `LastEventAt` tracking, and it calls `FetchBotReviewComments` with the
+allowlist instead of `FetchPendingReviews`. The flow:
+
+1. Skip entirely when no `SCMAdapter` is constructed or when bot-review is not configured.
+2. For each `pending_reactions` entry with kind `bot-review`:
+   a. Remove the entry from the map (prevents reprocessing within the same tick).
+   b. Type-assert the kind data; on mismatch, log and skip without panicking.
+   c. Drop the entry when its age exceeds the pending TTL backstop.
+   d. Respect the `PendingRetryAt` poll throttle: if `now < PendingRetryAt`, re-enqueue and continue.
+   e. Check the continuation-turn cap: if `reaction_attempts[issue_id:bot-review]` reaches
+      `max_continuation_turns`, escalate (§11D.5) and continue.
+   f. Call `FetchBotReviewComments`. On error, increment backoff, set `PendingRetryAt`, re-enqueue,
+      count `sortie_bot_review_checks_total{result="error"}`, and continue.
+   g. Filter outdated comments. When none remain, re-enqueue with the poll-interval delay.
+   h. Compute the fingerprint (§11D.4) and upsert it. When the stored fingerprint matches and is
+      marked dispatched, re-enqueue with the poll-interval delay.
+   i. Dispatch immediately, with no debounce window: count
+      `sortie_bot_review_checks_total{result="dispatched"}`, cancel any in-flight first-turn retry
+      for the issue, schedule a continuation dispatch carrying the bot comments under the prompt key
+      `bot_review_comments`, and increment `reaction_attempts[issue_id:bot-review]`.
+
+Immediate dispatch is the defining runtime difference from `review`: bot comments arrive in bulk on
+push, so there is no reviewer-pacing window to wait out.
+
+### 11D.4 Fingerprint and independent tuning
+
+The fingerprint is the same deterministic hash §11B.7 defines, `sha256(sorted(comment_id, ...))`
+over the non-outdated comment IDs, stored in `reaction_fingerprints` with kind `bot-review`. Because
+each push from a deterministic bot re-emits a fresh comment-ID set, the bot-review fingerprint churns
+where the human-review fingerprint is sticky: a new push changes the set, the upsert resets the
+dispatched flag to 0, and the next tick dispatches again. The sibling `review` fingerprint is never
+touched.
+
+The kind carries its own validated configuration, independent of `review`:
+
+| Field | Default | Constraint |
+|-------|---------|------------|
+| `escalation` | `label` | `label` or `comment` |
+| `escalation_label` | `needs-human` | none |
+| `poll_interval_ms` | `60000` | `>= 30000` |
+| `max_continuation_turns` | `5` | positive |
+| `bot_usernames` | empty | list of strings |
+
+The poll-interval default is tighter than `review`'s `120000` and the retry budget larger than
+`review`'s `3`, because bot findings arrive in bulk and their fixes are mechanical. There is no
+`debounce_ms` field. A `bot_usernames` value that is not a list, or a list with a non-string
+element, is a startup configuration error.
+
+### 11D.5 Escalation and ownership
+
+When `reaction_attempts[issue_id:bot-review]` reaches `max_continuation_turns`, the orchestrator
+escalates. Escalation follows the auto-merge cross-kind isolation contract in §11C.10, not the
+`review` escalation path:
+
+- `escalation: label` (default): add `escalation_label` (default `needs-human`) to the tracker issue
+  via `TrackerAdapter.AddLabel`, in a detached goroutine with a 30-second timeout.
+- `escalation: comment`: post a plain-text comment naming the PR number and the number of
+  continuation turns attempted, under the same goroutine pattern.
+
+Cleanup is scoped to the `bot-review` slot only: delete `pending_reactions[issue_id:bot-review]` and
+the `bot-review` fingerprint row. The escalation path MUST NOT call `ClearReactionsForIssue`,
+`CancelRetry`, or `DeleteRetryEntry`, MUST NOT delete `state.Claimed[issue_id]`, and MUST NOT delete
+the residual `reaction_attempts[issue_id:bot-review]` counter. The issue claim and that residual
+counter are owned by whichever kind currently holds the claim (the first-turn dispatch, `review`, or
+`merge`); releasing them from the bot-review path would corrupt sibling-kind ownership. Because the
+pending entry is deleted, the kind stops polling and the residual counter is inert until terminal
+cleanup removes it. When the issue reaches a terminal tracker state, `ClearReactionsForIssue` (run
+by the tracker-reconcile path) removes the residual counter and the claim along with any sibling
+slots. This mirrors how `escalateAutoMergeFailure` leaves `reaction_attempts[issue_id:merge]` and
+`state.Claimed` to terminal-state cleanup.
+
+Escalation tracker-call failures are logged and counted
+(`sortie_bot_review_escalations_total{action="error"}`) but do not block the slot-scoped cleanup.
+
+### 11D.6 Seeding, recovery, and metadata validation
+
+The `bot-review` lifecycle can outlive active tracker states: a pending entry is seeded on normal
+worker exit while the issue is still claimed, and startup recovery recreates it for recent
+handoff-stage issues after the claim has been released. §11B.9 requires that any such kind define
+both restart recovery and kind-specific `.sortie/scm.json` metadata validation. Bot-review
+discharges both halves.
+
+Worker-exit seeding and startup recovery apply the same metadata predicate `review` uses: an entry
+is created only when `SCMMetadata` reports `pr_number > 0` and non-empty `owner`, `repo`, and
+`branch`. Bot-review introduces no metadata field beyond what `review` already validates. Recovery
+is gated on a configured-flag distinct from adapter presence, so a configured-but-providerless setup
+recovers no bot-review entries; the recovered count is surfaced in the startup recovery log.
+
+### 11D.7 State machine
+
+Per-issue `bot-review` reaction lifecycle (the `issue_id:bot-review` slot):
+
+| From | Event | To | Action |
+|------|-------|----|--------|
+| (none) | Worker exits normally, SCM adapter and bot-review configured, PR metadata present | pending | Seed the entry if absent. |
+| pending | Reconcile tick, `now < PendingRetryAt` | pending | Re-enqueue, no API call. |
+| pending | Reconcile tick, fetch error | pending | Increment backoff, set `PendingRetryAt`, re-enqueue, count error. |
+| pending | Reconcile tick, no actionable comments | pending | Re-enqueue at `now + poll_interval`. |
+| pending | Reconcile tick, fingerprint unchanged and dispatched | pending | Re-enqueue at `now + poll_interval`. |
+| pending | Reconcile tick, new actionable comments, attempts < cap | dispatched | Schedule continuation, increment attempts, count dispatched. |
+| pending | Reconcile tick, attempts reach cap | escalated | Apply escalation; clear ONLY the `bot-review` slot. MUST NOT release the claim or clear sibling slots (§11D.5). |
+| pending | Issue reaches terminal state (tracker reconcile) | (cleared) | `ClearReactionsForIssue` removes the slot, the residual counter, and the claim. |
+
 ## 12. Prompt Construction and Context Assembly
 
 ### 12.1 Inputs

--- a/docs/workflow-reference.md
+++ b/docs/workflow-reference.md
@@ -753,7 +753,7 @@ reactions:
 
 Automated review-bot comment routing. When configured, the orchestrator polls for
 PR comments authored by automated review tools (linters, static analyzers, security
-scanners, dependency bots) on Sortie-created PRs and dispatches continuation turns so
+scanners, and AI reviewers such as GitHub Copilot or CodeRabbit) on Sortie-created PRs and dispatches continuation turns so
 the agent can address them. This is the complement of `review_comments`, which routes
 only human `CHANGES_REQUESTED` comments and excludes bot-authored ones.
 
@@ -768,12 +768,14 @@ Additional fields (via Extra):
 **Activation:** The `reactions.bot_review` block is active when `provider` is present
 and non-empty, on its own, with no `reactions.review_comments` or `reactions.auto_merge`
 block required. When `provider` is absent or empty, the block is inactive. Agent-created
-PRs MUST write `pr_number` (positive integer), `owner`, `repo`, and `branch` (all
-non-empty) to `.sortie/scm.json` in the workspace for bot-review polling to activate.
+PRs MUST write `pr_number` (positive integer), `owner`, and `repo` (all non-empty)
+to `.sortie/scm.json` in the workspace for bot-review polling to activate.
 
 **Classification:** Bot detection is deterministic author-metadata matching, not a
 content heuristic. A comment is selected when the platform marks its author as a bot OR
-its author login matches a `bot_usernames` entry, case-insensitively. Unlike
+its author login matches a `bot_usernames` entry, case-insensitively. The `bot_usernames`
+allowlist covers review tools that comment under a regular user account (`user.type == "User"`)
+rather than a bot account, such as a linter posting through a CI service account's token. Unlike
 `review_comments`, no `CHANGES_REQUESTED` review state is required, because review bots
 commonly post comment-only reviews.
 
@@ -807,9 +809,8 @@ reactions:
     escalation_label: needs-human
     poll_interval_ms: 60000
     max_continuation_turns: 5
-    bot_usernames:
-      - dependabot[bot]
-      - renovate[bot]
+    bot_usernames:            # only for review tools that comment under a user account, not a bot account
+      - acme-lint-bot
 ```
 
 **Validation rules:**

--- a/docs/workflow-reference.md
+++ b/docs/workflow-reference.md
@@ -775,7 +775,7 @@ to `.sortie/scm.json` in the workspace for bot-review polling to activate.
 content heuristic. A comment is selected when the platform marks its author as a bot OR
 its author login matches a `bot_usernames` entry, case-insensitively. The `bot_usernames`
 allowlist covers review tools that comment under a regular user account (`user.type == "User"`)
-rather than a bot account, such as a linter posting through a CI service account's token. Unlike
+rather than a bot account, such as Hound (`houndci-bot`), which posts inline style comments under a regular user account. Unlike
 `review_comments`, no `CHANGES_REQUESTED` review state is required, because review bots
 commonly post comment-only reviews.
 
@@ -810,7 +810,7 @@ reactions:
     poll_interval_ms: 60000
     max_continuation_turns: 5
     bot_usernames:            # only for review tools that comment under a user account, not a bot account
-      - acme-lint-bot
+      - houndci-bot           # e.g. Hound (houndci.com), comments as a type:User account
 ```
 
 **Validation rules:**

--- a/docs/workflow-reference.md
+++ b/docs/workflow-reference.md
@@ -749,6 +749,69 @@ reactions:
     poll_interval_ms: 60000
 ```
 
+#### Reaction kind: `bot_review`
+
+Automated review-bot comment routing. When configured, the orchestrator polls for
+PR comments authored by automated review tools (linters, static analyzers, security
+scanners, dependency bots) on Sortie-created PRs and dispatches continuation turns so
+the agent can address them. This is the complement of `review_comments`, which routes
+only human `CHANGES_REQUESTED` comments and excludes bot-authored ones.
+
+Additional fields (via Extra):
+
+| Field                    | Type         | Default | Dynamic Reload    | Description                                                                                               |
+| ------------------------ | ------------ | ------- | ----------------- | --------------------------------------------------------------------------------------------------------- |
+| `bot_usernames`          | list[string] | _(empty)_ | Requires restart | Allowlist of bot logins. A comment is bot-authored when the platform reports a bot user type OR its author login matches an entry here (case-insensitive). |
+| `poll_interval_ms`       | integer      | `60000` | Future dispatches | Polling interval for bot comments. Minimum: `30000` (30 sec). The default is tighter than `review_comments` because bot comments arrive in bulk on push. |
+| `max_continuation_turns` | integer      | `5`     | Future dispatches | Maximum bot-fix continuation dispatches per issue before escalation. Must be positive. Higher than `review_comments` because bot fixes are mechanical.    |
+
+**Activation:** The `reactions.bot_review` block is active when `provider` is present
+and non-empty, on its own, with no `reactions.review_comments` or `reactions.auto_merge`
+block required. When `provider` is absent or empty, the block is inactive. Agent-created
+PRs MUST write `pr_number` (positive integer), `owner`, `repo`, and `branch` (all
+non-empty) to `.sortie/scm.json` in the workspace for bot-review polling to activate.
+
+**Classification:** Bot detection is deterministic author-metadata matching, not a
+content heuristic. A comment is selected when the platform marks its author as a bot OR
+its author login matches a `bot_usernames` entry, case-insensitively. Unlike
+`review_comments`, no `CHANGES_REQUESTED` review state is required, because review bots
+commonly post comment-only reviews.
+
+**No debounce:** Bot comments are dispatched immediately. There is no `debounce_ms`
+field; the debounce window that `review_comments` applies does not apply to `bot_review`,
+because bot comments arrive in bulk on push rather than at reviewer pace.
+
+**Fingerprint dedup:** The orchestrator computes a SHA-256 fingerprint from sorted
+non-outdated comment IDs and persists it in the `reaction_fingerprints` SQLite table
+under a kind distinct from `review_comments`. A new push that changes the bot comment-ID
+set changes the fingerprint and re-triggers dispatch; an unchanged dispatched fingerprint
+suppresses re-dispatch within the poll interval.
+
+**Cross-kind isolation:** `bot_review` and `review_comments` never interfere on the same
+PR; each owns its own pending entry, fingerprint row, and attempt counter. Escalation
+cleanup is scoped to the `bot_review` kind only and does not release the issue claim or
+clear sibling reaction kinds.
+
+**Escalation:** When `max_continuation_turns` is exhausted, the orchestrator applies the
+configured escalation action (`label` or `comment`, default `label`, with
+`escalation_label` defaulting to `needs-human`) and removes the pending bot-review entry.
+Other reaction kinds on the same issue are preserved.
+
+Example:
+
+```yaml
+reactions:
+  bot_review:
+    provider: github
+    escalation: label
+    escalation_label: needs-human
+    poll_interval_ms: 60000
+    max_continuation_turns: 5
+    bot_usernames:
+      - dependabot[bot]
+      - renovate[bot]
+```
+
 **Validation rules:**
 
 - Reaction kind keys must match `[a-z][a-z0-9_-]*`. Invalid keys are rejected with a
@@ -761,6 +824,9 @@ reactions:
 - `strategy` for `auto_merge` must be `"merge"`, `"squash"`, or `"rebase"`.
 - `require_ci` and `delete_branch` for `auto_merge` must be boolean.
 - `poll_interval_ms` must be >= `30000` for `auto_merge`.
+- `poll_interval_ms` must be >= `30000` for `bot_review`.
+- `max_continuation_turns` must be positive for `bot_review`.
+- `bot_usernames` for `bot_review` must be a list of strings.
 - When `provider` is absent or empty, all other fields in the kind sub-object are ignored.
 
 ---
@@ -1861,8 +1927,8 @@ template.New("prompt").
 ### 5.2 Template Input Variables
 
 The data map passed to `Execute` contains **three core top-level keys** (`issue`, `attempt`,
-`run`) plus **continuation context keys** (`ci_failure`, `review_comments`) that are `nil` by
-default and populated on reaction-triggered dispatches:
+`run`) plus **continuation context keys** (`ci_failure`, `review_comments`, `bot_review_comments`)
+that are `nil` by default and populated on reaction-triggered dispatches:
 
 #### `issue` — Normalized Issue Object
 
@@ -1949,6 +2015,41 @@ When `nil` (default on non-review dispatches), `{{ if .review_comments }}` evalu
 The following review comments were left on the PR. Address each one:
 
 {{ range .review_comments }}
+### {{ .reviewer }} on {{ .file }}{{ if .start_line }} (line {{ .start_line }}{{ if .end_line }}-{{ .end_line }}{{ end }}){{ end }}
+
+{{ .body }}
+
+{{ end }}
+{{ end }}
+```
+
+#### `bot_review_comments` — Bot Review Comment Context (continuation key)
+
+Non-nil only on turn 1 of a bot-review-fix continuation dispatch. Contains a list of
+comments authored by automated review bots (see `reactions.bot_review` in Section 2.10).
+The per-element shape is identical to `review_comments`:
+
+| Field (per element)               | Type    | Description                                              |
+| --------------------------------- | ------- | -------------------------------------------------------- |
+| `.bot_review_comments[].id`       | string  | SCM-platform comment identifier.                         |
+| `.bot_review_comments[].file`     | string  | File path (empty for PR-level comments).                 |
+| `.bot_review_comments[].start_line` | integer | First line of commented range (0 for non-inline).       |
+| `.bot_review_comments[].end_line` | integer | Last line of commented range (0 for single-line or non-inline). |
+| `.bot_review_comments[].reviewer` | string  | Login of the bot that authored the comment.             |
+| `.bot_review_comments[].body`     | string  | Comment text.                                            |
+
+When `nil` (default on non-bot-review dispatches), `{{ if .bot_review_comments }}`
+evaluates to `false`.
+
+**Template pattern for bot review comments:**
+
+```
+{{ if .bot_review_comments }}
+## Bot Review Comments to Address
+
+The following comments were left on the PR by automated review tools. Address each one:
+
+{{ range .bot_review_comments }}
 ### {{ .reviewer }} on {{ .file }}{{ if .start_line }} (line {{ .start_line }}{{ if .end_line }}-{{ .end_line }}{{ end }}){{ end }}
 
 {{ .body }}

--- a/docs/workflow-reference.md
+++ b/docs/workflow-reference.md
@@ -768,7 +768,7 @@ Additional fields (via Extra):
 **Activation:** The `reactions.bot_review` block is active when `provider` is present
 and non-empty, on its own, with no `reactions.review_comments` or `reactions.auto_merge`
 block required. When `provider` is absent or empty, the block is inactive. Agent-created
-PRs MUST write `pr_number` (positive integer), `owner`, and `repo` (all non-empty)
+PRs MUST write `pr_number` (positive integer), `owner`, `repo`, and `branch` (all non-empty)
 to `.sortie/scm.json` in the workspace for bot-review polling to activate.
 
 **Classification:** Bot detection is deterministic author-metadata matching, not a

--- a/internal/domain/metrics.go
+++ b/internal/domain/metrics.go
@@ -145,6 +145,16 @@ type Metrics interface {
 	// (sortie_review_escalations_total{action} counter).
 	IncReviewEscalations(action string)
 
+	// IncBotReviewChecks increments the bot review comment check counter.
+	// result is "dispatched", "error", or "skipped"
+	// (sortie_bot_review_checks_total{result} counter).
+	IncBotReviewChecks(result string)
+
+	// IncBotReviewEscalations increments the bot review escalation
+	// counter. action is "label", "comment", or "error"
+	// (sortie_bot_review_escalations_total{action} counter).
+	IncBotReviewEscalations(action string)
+
 	// IncAutoMergeReactions increments the auto-merge reaction outcome
 	// counter. result is "merged", "error", or "escalated"
 	// (sortie_reactions_auto_merge_total{result} counter).
@@ -194,6 +204,8 @@ func (*NoopMetrics) ObserveSelfReviewVerificationDuration(string, float64) {}
 func (*NoopMetrics) IncSelfReviewCapReached()                              {}
 func (*NoopMetrics) IncReviewChecks(string)                                {}
 func (*NoopMetrics) IncReviewEscalations(string)                           {}
+func (*NoopMetrics) IncBotReviewChecks(string)                             {}
+func (*NoopMetrics) IncBotReviewEscalations(string)                        {}
 func (*NoopMetrics) IncAutoMergeReactions(string)                          {}
 func (*NoopMetrics) IncDispatchRuleMatch(string, string)                   {}
 

--- a/internal/domain/metrics_test.go
+++ b/internal/domain/metrics_test.go
@@ -75,4 +75,14 @@ func TestNoopMetricsSatisfiesInterface(t *testing.T) {
 	m.ObserveWorkerDuration("normal", 300.5)
 	m.ObserveWorkerDuration("error", 10.0)
 	m.ObserveWorkerDuration("cancelled", 45.2)
+
+	// Counters — IncBotReviewChecks
+	m.IncBotReviewChecks("dispatched")
+	m.IncBotReviewChecks("error")
+	m.IncBotReviewChecks("skipped")
+
+	// Counters — IncBotReviewEscalations
+	m.IncBotReviewEscalations("label")
+	m.IncBotReviewEscalations("comment")
+	m.IncBotReviewEscalations("error")
 }

--- a/internal/domain/scm.go
+++ b/internal/domain/scm.go
@@ -116,6 +116,23 @@ type SCMAdapter interface {
 	// exist. Returns a [*SCMError] on failure.
 	FetchPendingReviews(ctx context.Context, prNumber int, owner, repo string) ([]ReviewComment, error)
 
+	// FetchBotReviewComments returns review comments authored by
+	// automated review bots on the given PR. A comment is bot-authored
+	// when the platform reports its author as an automated bot account
+	// OR when the author login matches an entry in botUsernames under a
+	// case-insensitive comparison. The two conditions form a union:
+	// either one qualifies. botUsernames may be nil or empty, in which
+	// case only the platform's bot-account signal selects comments.
+	//
+	// Unlike [SCMAdapter.FetchPendingReviews], selection does not require
+	// any particular review state. Comments marked as outdated by the
+	// platform are included with Outdated=true; the caller is responsible
+	// for filtering.
+	//
+	// Returns an empty non-nil slice when no bot review comments exist.
+	// Returns a [*SCMError] on failure.
+	FetchBotReviewComments(ctx context.Context, prNumber int, owner, repo string, botUsernames []string) ([]ReviewComment, error)
+
 	// GetReviewDecision returns the aggregated review decision for the
 	// given PR. Returns a [*SCMError] on failure.
 	GetReviewDecision(ctx context.Context, prNumber int, owner, repo string) (ReviewDecision, error)

--- a/internal/domain/scm_test.go
+++ b/internal/domain/scm_test.go
@@ -130,6 +130,10 @@ func (m *mockSCMAdapter) FetchPendingReviews(_ context.Context, _ int, _, _ stri
 	return nil, nil
 }
 
+func (m *mockSCMAdapter) FetchBotReviewComments(_ context.Context, _ int, _, _ string, _ []string) ([]ReviewComment, error) {
+	return nil, nil
+}
+
 func (m *mockSCMAdapter) GetReviewDecision(_ context.Context, _ int, _, _ string) (ReviewDecision, error) {
 	return "", nil
 }

--- a/internal/orchestrator/auto_merge_preflight_test.go
+++ b/internal/orchestrator/auto_merge_preflight_test.go
@@ -38,6 +38,9 @@ var _ domain.SCMAdapter = (*preflightSCMStub)(nil)
 func (s *preflightSCMStub) FetchPendingReviews(_ context.Context, _ int, _, _ string) ([]domain.ReviewComment, error) {
 	return nil, nil
 }
+func (s *preflightSCMStub) FetchBotReviewComments(_ context.Context, _ int, _, _ string, _ []string) ([]domain.ReviewComment, error) {
+	return []domain.ReviewComment{}, nil
+}
 func (s *preflightSCMStub) GetReviewDecision(_ context.Context, _ int, _, _ string) (domain.ReviewDecision, error) {
 	return domain.ReviewDecisionApproved, nil
 }
@@ -61,6 +64,9 @@ var _ domain.SCMAdapter = (*noVerifierSCMStub)(nil)
 
 func (s *noVerifierSCMStub) FetchPendingReviews(_ context.Context, _ int, _, _ string) ([]domain.ReviewComment, error) {
 	return nil, nil
+}
+func (s *noVerifierSCMStub) FetchBotReviewComments(_ context.Context, _ int, _, _ string, _ []string) ([]domain.ReviewComment, error) {
+	return []domain.ReviewComment{}, nil
 }
 func (s *noVerifierSCMStub) GetReviewDecision(_ context.Context, _ int, _, _ string) (domain.ReviewDecision, error) {
 	return domain.ReviewDecisionApproved, nil

--- a/internal/orchestrator/auto_merge_reconcile_test.go
+++ b/internal/orchestrator/auto_merge_reconcile_test.go
@@ -16,12 +16,13 @@ import (
 // controllable via function fields. Used by auto-merge reconcile tests that
 // need to simulate different combinations of API responses and errors.
 type controlledSCMAdapter struct {
-	fetchPendingReviewsFn func(ctx context.Context, prNumber int, owner, repo string) ([]domain.ReviewComment, error)
-	getReviewDecisionFn   func(ctx context.Context, prNumber int, owner, repo string) (domain.ReviewDecision, error)
-	getCIStatusFn         func(ctx context.Context, prNumber int, owner, repo string) (string, error)
-	getMergeabilityFn     func(ctx context.Context, prNumber int, owner, repo string) (domain.PRMergeStatus, error)
-	mergePRFn             func(ctx context.Context, prNumber int, owner, repo string, strategy domain.MergeStrategy, commitTitle, commitMessage, expectedHeadSHA string) (domain.MergeResult, error)
-	deleteBranchFn        func(ctx context.Context, owner, repo, branch string) error
+	fetchPendingReviewsFn    func(ctx context.Context, prNumber int, owner, repo string) ([]domain.ReviewComment, error)
+	fetchBotReviewCommentsFn func(ctx context.Context, prNumber int, owner, repo string, botUsernames []string) ([]domain.ReviewComment, error)
+	getReviewDecisionFn      func(ctx context.Context, prNumber int, owner, repo string) (domain.ReviewDecision, error)
+	getCIStatusFn            func(ctx context.Context, prNumber int, owner, repo string) (string, error)
+	getMergeabilityFn        func(ctx context.Context, prNumber int, owner, repo string) (domain.PRMergeStatus, error)
+	mergePRFn                func(ctx context.Context, prNumber int, owner, repo string, strategy domain.MergeStrategy, commitTitle, commitMessage, expectedHeadSHA string) (domain.MergeResult, error)
+	deleteBranchFn           func(ctx context.Context, owner, repo, branch string) error
 }
 
 var _ domain.SCMAdapter = (*controlledSCMAdapter)(nil)
@@ -29,6 +30,13 @@ var _ domain.SCMAdapter = (*controlledSCMAdapter)(nil)
 func (c *controlledSCMAdapter) FetchPendingReviews(ctx context.Context, prNumber int, owner, repo string) ([]domain.ReviewComment, error) {
 	if c.fetchPendingReviewsFn != nil {
 		return c.fetchPendingReviewsFn(ctx, prNumber, owner, repo)
+	}
+	return nil, nil
+}
+
+func (c *controlledSCMAdapter) FetchBotReviewComments(ctx context.Context, prNumber int, owner, repo string, botUsernames []string) ([]domain.ReviewComment, error) {
+	if c.fetchBotReviewCommentsFn != nil {
+		return c.fetchBotReviewCommentsFn(ctx, prNumber, owner, repo, botUsernames)
 	}
 	return nil, nil
 }
@@ -1156,6 +1164,13 @@ func (s *scopeVerifierAdapter) FetchPendingReviews(ctx context.Context, prNumber
 		return s.scm.FetchPendingReviews(ctx, prNumber, owner, repo)
 	}
 	return nil, nil
+}
+
+func (s *scopeVerifierAdapter) FetchBotReviewComments(ctx context.Context, prNumber int, owner, repo string, botUsernames []string) ([]domain.ReviewComment, error) {
+	if s.scm != nil {
+		return s.scm.FetchBotReviewComments(ctx, prNumber, owner, repo, botUsernames)
+	}
+	return []domain.ReviewComment{}, nil
 }
 
 func (s *scopeVerifierAdapter) GetReviewDecision(ctx context.Context, prNumber int, owner, repo string) (domain.ReviewDecision, error) {

--- a/internal/orchestrator/bot_review_reconcile.go
+++ b/internal/orchestrator/bot_review_reconcile.go
@@ -1,0 +1,260 @@
+package orchestrator
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/sortie-ai/sortie/internal/domain"
+	"github.com/sortie-ai/sortie/internal/logging"
+)
+
+// reconcileBotReviewComments polls bot-authored review comments for each
+// bot-review-kind entry in state.PendingReactions. Called from
+// [ReconcileRunningIssues] after [reconcileReviewComments] and before
+// [reconcileAutoMerge]. Skipped entirely when params.SCMAdapter is nil
+// or params.BotReviewConfigured is false.
+//
+// Unlike [reconcileReviewComments], there is no debounce gate: bot
+// comments arrive in bulk on push and dispatch on the same tick they are
+// detected.
+func reconcileBotReviewComments(state *State, params ReconcileParams, log *slog.Logger, ctx context.Context, metrics domain.Metrics) {
+	if params.SCMAdapter == nil {
+		return
+	}
+	if !params.BotReviewConfigured {
+		return
+	}
+
+	now := time.Now().UTC()
+	if params.NowFunc != nil {
+		now = params.NowFunc().UTC()
+	}
+
+	ttl := params.BotReviewPendingTTL
+	pollInterval := time.Duration(params.BotReviewConfig.PollIntervalMS) * time.Millisecond
+	if pollInterval <= 0 {
+		pollInterval = reviewPendingBackoffBase
+	}
+
+	for key, pending := range state.PendingReactions {
+		if pending.Kind != ReactionKindBotReview {
+			continue
+		}
+		delete(state.PendingReactions, key)
+
+		botReviewData, ok := pending.KindData.(*BotReviewReactionData)
+		if !ok {
+			log.ErrorContext(ctx, "unexpected KindData type for bot-review reaction",
+				slog.String("issue_id", pending.IssueID),
+				slog.String("type", fmt.Sprintf("%T", pending.KindData)),
+			)
+			continue
+		}
+
+		entryLog := logging.WithIssue(log, pending.IssueID, pending.Identifier)
+
+		// TTL enforcement.
+		if ttl > 0 && now.Sub(pending.CreatedAt) > ttl {
+			entryLog.Warn("bot review pending entry exceeded ttl, dropping",
+				slog.Int64("ttl_ms", int64(ttl/time.Millisecond)),
+				slog.Int64("age_ms", int64(now.Sub(pending.CreatedAt)/time.Millisecond)),
+			)
+			continue
+		}
+
+		// Poll throttle: respect PendingRetryAt.
+		if now.Before(pending.PendingRetryAt) {
+			state.PendingReactions[key] = pending
+			continue
+		}
+
+		// Continuation turn cap check.
+		rkey := ReactionKey(pending.IssueID, ReactionKindBotReview)
+		turnCount := state.ReactionAttempts[rkey]
+		if turnCount >= params.BotReviewConfig.MaxContinuationTurns {
+			escalateBotReviewFailure(state, params, pending, turnCount, botReviewData, entryLog, ctx, metrics)
+			continue
+		}
+
+		// Fetch bot review comments from SCM.
+		comments, err := params.SCMAdapter.FetchBotReviewComments(ctx, botReviewData.PRNumber, botReviewData.Owner, botReviewData.Repo, params.BotReviewConfig.BotUsernames)
+		if err != nil {
+			pending.PendingAttempts++
+			delay := max(computeReactionPendingDelay(pending.PendingAttempts), pollInterval)
+			pending.PendingRetryAt = now.Add(delay)
+			state.PendingReactions[key] = pending
+			entryLog.Warn("bot review fetch failed, retrying with backoff",
+				slog.Any("error", err),
+				slog.Int("pending_attempts", pending.PendingAttempts),
+				slog.Int64("retry_after_ms", int64(delay/time.Millisecond)),
+			)
+			metrics.IncBotReviewChecks("error")
+			continue
+		}
+
+		// Filter outdated comments.
+		var actionable []domain.ReviewComment
+		for _, c := range comments {
+			if !c.Outdated {
+				actionable = append(actionable, c)
+			}
+		}
+
+		// No actionable comments — re-enqueue with poll interval delay.
+		if len(actionable) == 0 {
+			pending.PendingRetryAt = now.Add(pollInterval)
+			state.PendingReactions[key] = pending
+			continue
+		}
+
+		// Build fingerprint from sorted actionable comment IDs.
+		fingerprint := buildReviewFingerprint(actionable)
+
+		// Dedup check via reaction_fingerprints table.
+		if err := params.Store.UpsertReactionFingerprint(ctx, pending.IssueID, ReactionKindBotReview, fingerprint); err != nil {
+			entryLog.Warn("failed to upsert bot review reaction fingerprint",
+				slog.Any("error", err),
+			)
+		}
+		storedFP, dispatched, fpErr := params.Store.GetReactionFingerprint(ctx, pending.IssueID, ReactionKindBotReview)
+		if fpErr != nil {
+			entryLog.Warn("failed to get bot review reaction fingerprint, proceeding without dedup",
+				slog.Any("error", fpErr),
+			)
+		} else if storedFP == fingerprint && dispatched {
+			// Already dispatched for this exact set of comments.
+			pending.PendingRetryAt = now.Add(pollInterval)
+			state.PendingReactions[key] = pending
+			entryLog.Debug("bot review comments already dispatched for this fingerprint")
+			continue
+		}
+
+		// Dispatch immediately: bot comments are not debounced.
+		metrics.IncBotReviewChecks("dispatched")
+
+		botContext := buildReviewTemplateMap(actionable)
+
+		CancelRetry(state, pending.IssueID)
+
+		ScheduleRetry(state, ScheduleRetryParams{
+			IssueID:     pending.IssueID,
+			Identifier:  pending.Identifier,
+			DisplayID:   pending.DisplayID,
+			Attempt:     pending.Attempt,
+			DelayMS:     continuationDelayMS,
+			LastSSHHost: pending.LastSSHHost,
+			ContinuationContext: map[string]any{
+				"bot_review_comments": botContext,
+			},
+			ReactionKind: ReactionKindBotReview,
+			AgentKind:    pending.AgentKind,
+			RuleName:     pending.RuleName,
+			TemplateID:   pending.TemplateID,
+		}, params.OnRetryFire)
+
+		state.ReactionAttempts[rkey]++
+
+		entryLog.Info("bot review comments detected, scheduling bot-review-fix dispatch",
+			slog.Int("comment_count", len(actionable)),
+			slog.Int("bot_review_fix_attempt", state.ReactionAttempts[rkey]),
+			slog.Int("max_continuation_turns", params.BotReviewConfig.MaxContinuationTurns),
+		)
+	}
+}
+
+// escalateBotReviewFailure handles the case where bot review continuation
+// turns are exhausted. It applies the configured escalation action, then
+// removes only the bot-review-kind pending entry and clears the
+// bot-review fingerprint. MUST NOT touch state.Claimed, the retry timer,
+// the persisted retry row, the residual ReactionAttempts counter, or any
+// other reaction kind's entries; those are owned by whichever kind holds
+// the claim and are released at terminal-state cleanup.
+func escalateBotReviewFailure(
+	state *State,
+	params ReconcileParams,
+	pending *PendingReaction,
+	turnCount int,
+	botReviewData *BotReviewReactionData,
+	log *slog.Logger,
+	ctx context.Context,
+	metrics domain.Metrics,
+) {
+	log.Warn("bot review continuation turns exhausted, escalating",
+		slog.Int("turn_count", turnCount),
+		slog.Int("max_continuation_turns", params.BotReviewConfig.MaxContinuationTurns),
+		slog.Int("pr_number", botReviewData.PRNumber),
+	)
+
+	switch params.BotReviewConfig.Escalation {
+	case "label":
+		label := params.BotReviewConfig.EscalationLabel
+		if label == "" {
+			label = "needs-human"
+		}
+		if params.TrackerAdapter != nil {
+			issueID := pending.IssueID
+			tracker := params.TrackerAdapter
+			m := metrics
+			escalLog := log
+
+			state.TrackerOpsWg.Go(func() {
+				dctx, cancel := context.WithTimeout(
+					context.WithoutCancel(ctx), 30*time.Second)
+				defer cancel()
+
+				if err := tracker.AddLabel(dctx, issueID, label); err != nil {
+					escalLog.Warn("bot review escalation label failed",
+						slog.Any("error", err),
+					)
+					m.IncBotReviewEscalations("error")
+				} else {
+					m.IncBotReviewEscalations("label")
+				}
+			})
+		}
+
+	case "comment", "":
+		commentText := buildBotReviewEscalationComment(botReviewData, turnCount)
+		if params.TrackerAdapter != nil {
+			issueID := pending.IssueID
+			tracker := params.TrackerAdapter
+			m := metrics
+			escalLog := log
+			ct := commentText
+
+			state.TrackerOpsWg.Go(func() {
+				dctx, cancel := context.WithTimeout(
+					context.WithoutCancel(ctx), 30*time.Second)
+				defer cancel()
+
+				if err := tracker.CommentIssue(dctx, issueID, ct); err != nil {
+					escalLog.Warn("bot review escalation comment failed",
+						slog.Any("error", err),
+					)
+					m.IncBotReviewEscalations("error")
+				} else {
+					m.IncBotReviewEscalations("comment")
+				}
+			})
+		}
+	}
+
+	delete(state.PendingReactions, ReactionKey(pending.IssueID, ReactionKindBotReview))
+	if err := params.Store.DeleteReactionFingerprint(ctx, pending.IssueID, ReactionKindBotReview); err != nil {
+		log.Warn("bot review fingerprint delete failed during escalation",
+			slog.Any("error", err),
+		)
+	}
+}
+
+// buildBotReviewEscalationComment returns the escalation comment used when
+// the bot review continuation turn budget is exhausted.
+func buildBotReviewEscalationComment(botReviewData *BotReviewReactionData, turnCount int) string {
+	return fmt.Sprintf(
+		"Sortie attempted %d bot-review continuation turn(s) and could not resolve the automated review comments for PR #%d. Remaining bot review comments require human attention.",
+		turnCount,
+		botReviewData.PRNumber,
+	)
+}

--- a/internal/orchestrator/bot_review_reconcile_test.go
+++ b/internal/orchestrator/bot_review_reconcile_test.go
@@ -127,7 +127,7 @@ func TestBuildBotReviewReactionConfig(t *testing.T) {
 			name: "well-formed bot_usernames coerces to []string",
 			rc: config.ReactionConfig{
 				Extra: map[string]any{
-					"bot_usernames": []any{"dependabot", "renovate-bot"},
+					"bot_usernames": []any{"acme-lint-bot", "ci-review-svc"},
 				},
 			},
 			want: BotReviewReactionConfig{
@@ -135,7 +135,7 @@ func TestBuildBotReviewReactionConfig(t *testing.T) {
 				EscalationLabel:      "needs-human",
 				PollIntervalMS:       60000,
 				MaxContinuationTurns: 5,
-				BotUsernames:         []string{"dependabot", "renovate-bot"},
+				BotUsernames:         []string{"acme-lint-bot", "ci-review-svc"},
 			},
 		},
 		{

--- a/internal/orchestrator/bot_review_reconcile_test.go
+++ b/internal/orchestrator/bot_review_reconcile_test.go
@@ -1,0 +1,920 @@
+package orchestrator
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/sortie-ai/sortie/internal/config"
+	"github.com/sortie-ai/sortie/internal/domain"
+)
+
+// --- bot-review metrics spy ---
+
+// botReviewMetricsSpy records bot-review-specific metric calls.
+type botReviewMetricsSpy struct {
+	domain.NoopMetrics
+	botReviewChecks      map[string]int
+	botReviewEscalations map[string]int
+}
+
+func newBotReviewMetricsSpy() *botReviewMetricsSpy {
+	return &botReviewMetricsSpy{
+		botReviewChecks:      make(map[string]int),
+		botReviewEscalations: make(map[string]int),
+	}
+}
+
+func (s *botReviewMetricsSpy) IncBotReviewChecks(result string) { s.botReviewChecks[result]++ }
+func (s *botReviewMetricsSpy) IncBotReviewEscalations(action string) {
+	s.botReviewEscalations[action]++
+}
+
+// --- bot-review test helpers ---
+
+// botReviewBaseTime is a fixed reference time for bot-review reconcile tests.
+var botReviewBaseTime = time.Date(2026, 4, 15, 10, 0, 0, 0, time.UTC)
+
+// makeBotReviewPendingEntry builds a PendingReaction for bot-review tests.
+func makeBotReviewPendingEntry(t *testing.T, issueID string, prNumber int) *PendingReaction {
+	t.Helper()
+	return &PendingReaction{
+		IssueID:    issueID,
+		Identifier: issueID + "-ident",
+		DisplayID:  issueID + "-ident",
+		Attempt:    1,
+		Kind:       ReactionKindBotReview,
+		CreatedAt:  botReviewBaseTime,
+		KindData: &BotReviewReactionData{
+			PRNumber: prNumber,
+			Owner:    "owner",
+			Repo:     "repo",
+			Branch:   "feature/bot-fix",
+			SHA:      "sha123",
+		},
+	}
+}
+
+// stateWithBotReviewReaction creates a State with one bot-review PendingReaction.
+func stateWithBotReviewReaction(t *testing.T, issueID string, prNumber int) *State {
+	t.Helper()
+	s := NewState(5000, 4, nil, AgentTotals{})
+	rkey := ReactionKey(issueID, ReactionKindBotReview)
+	s.PendingReactions[rkey] = makeBotReviewPendingEntry(t, issueID, prNumber)
+	s.Claimed[issueID] = struct{}{}
+	return s
+}
+
+// defaultBotReviewConfig returns a BotReviewReactionConfig with sensible defaults.
+func defaultBotReviewConfig() BotReviewReactionConfig {
+	return BotReviewReactionConfig{
+		Escalation:           "label",
+		EscalationLabel:      "needs-human",
+		PollIntervalMS:       60000,
+		MaxContinuationTurns: 5,
+	}
+}
+
+// botReviewParams returns ReconcileParams wired for bot-review reconcile tests.
+func botReviewParams(store *reviewReconcileStore, scm domain.SCMAdapter, tracker domain.TrackerAdapter) ReconcileParams {
+	return ReconcileParams{
+		TrackerAdapter:      tracker,
+		SCMAdapter:          scm,
+		BotReviewConfig:     defaultBotReviewConfig(),
+		BotReviewConfigured: true,
+		Store:               store,
+		OnRetryFire:         noopRetryFire,
+		Ctx:                 context.Background(),
+		Logger:              discardLogger(),
+		NowFunc:             func() time.Time { return botReviewBaseTime },
+	}
+}
+
+// --- BuildBotReviewReactionConfig tests (6.2 → R4) ---
+
+func TestBuildBotReviewReactionConfig(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		rc      config.ReactionConfig
+		want    BotReviewReactionConfig
+		wantErr bool
+	}{
+		{
+			name: "defaults: MaxContinuationTurns=5, PollIntervalMS=60000, Escalation=label, EscalationLabel=needs-human",
+			rc:   config.ReactionConfig{},
+			want: BotReviewReactionConfig{
+				Escalation:           "label",
+				EscalationLabel:      "needs-human",
+				PollIntervalMS:       60000,
+				MaxContinuationTurns: 5,
+				BotUsernames:         nil,
+			},
+		},
+		{
+			name: "explicit valid escalation comment",
+			rc:   config.ReactionConfig{Escalation: "comment"},
+			want: BotReviewReactionConfig{
+				Escalation:           "comment",
+				EscalationLabel:      "needs-human",
+				PollIntervalMS:       60000,
+				MaxContinuationTurns: 5,
+			},
+		},
+		{
+			name: "well-formed bot_usernames coerces to []string",
+			rc: config.ReactionConfig{
+				Extra: map[string]any{
+					"bot_usernames": []any{"dependabot", "renovate-bot"},
+				},
+			},
+			want: BotReviewReactionConfig{
+				Escalation:           "label",
+				EscalationLabel:      "needs-human",
+				PollIntervalMS:       60000,
+				MaxContinuationTurns: 5,
+				BotUsernames:         []string{"dependabot", "renovate-bot"},
+			},
+		},
+		{
+			name: "poll_interval_ms < 30000 errors",
+			rc: config.ReactionConfig{
+				Extra: map[string]any{"poll_interval_ms": 29999},
+			},
+			wantErr: true,
+		},
+		{
+			name: "poll_interval_ms exactly 30000 is valid",
+			rc: config.ReactionConfig{
+				Extra: map[string]any{"poll_interval_ms": 30000},
+			},
+			want: BotReviewReactionConfig{
+				Escalation:           "label",
+				EscalationLabel:      "needs-human",
+				PollIntervalMS:       30000,
+				MaxContinuationTurns: 5,
+			},
+		},
+		{
+			name: "max_continuation_turns <= 0 errors",
+			rc: config.ReactionConfig{
+				Extra: map[string]any{"max_continuation_turns": 0},
+			},
+			wantErr: true,
+		},
+		{
+			name: "max_continuation_turns negative errors",
+			rc: config.ReactionConfig{
+				Extra: map[string]any{"max_continuation_turns": -1},
+			},
+			wantErr: true,
+		},
+		{
+			name:    "bad escalation value errors",
+			rc:      config.ReactionConfig{Escalation: "webhook"},
+			wantErr: true,
+		},
+		{
+			name: "non-string bot_usernames element errors",
+			rc: config.ReactionConfig{
+				Extra: map[string]any{
+					"bot_usernames": []any{"valid-bot", 42},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "non-list value under bot_usernames errors",
+			rc: config.ReactionConfig{
+				Extra: map[string]any{
+					"bot_usernames": "not-a-list",
+				},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := BuildBotReviewReactionConfig(tt.rc)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("BuildBotReviewReactionConfig(%+v) = %+v, want error", tt.rc, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("BuildBotReviewReactionConfig(%+v) unexpected error: %v", tt.rc, err)
+			}
+			if got.MaxContinuationTurns != tt.want.MaxContinuationTurns {
+				t.Errorf("BuildBotReviewReactionConfig MaxContinuationTurns = %d, want %d",
+					got.MaxContinuationTurns, tt.want.MaxContinuationTurns)
+			}
+			if got.PollIntervalMS != tt.want.PollIntervalMS {
+				t.Errorf("BuildBotReviewReactionConfig PollIntervalMS = %d, want %d",
+					got.PollIntervalMS, tt.want.PollIntervalMS)
+			}
+			if got.Escalation != tt.want.Escalation {
+				t.Errorf("BuildBotReviewReactionConfig Escalation = %q, want %q",
+					got.Escalation, tt.want.Escalation)
+			}
+			if got.EscalationLabel != tt.want.EscalationLabel {
+				t.Errorf("BuildBotReviewReactionConfig EscalationLabel = %q, want %q",
+					got.EscalationLabel, tt.want.EscalationLabel)
+			}
+			if len(got.BotUsernames) != len(tt.want.BotUsernames) {
+				t.Errorf("BuildBotReviewReactionConfig BotUsernames = %v, want %v",
+					got.BotUsernames, tt.want.BotUsernames)
+			} else {
+				for i, name := range got.BotUsernames {
+					if name != tt.want.BotUsernames[i] {
+						t.Errorf("BuildBotReviewReactionConfig BotUsernames[%d] = %q, want %q",
+							i, name, tt.want.BotUsernames[i])
+					}
+				}
+			}
+		})
+	}
+}
+
+// TestBuildBotReviewReactionConfig_ReviewDefaultsUnchanged verifies that the bot-review
+// defaults (MaxContinuationTurns=5, PollIntervalMS=60000) are independent of the review
+// kind defaults (MaxContinuationTurns=3, PollIntervalMS=120000). R4.
+func TestBuildBotReviewReactionConfig_ReviewDefaultsUnchanged(t *testing.T) {
+	t.Parallel()
+
+	botGot, err := BuildBotReviewReactionConfig(config.ReactionConfig{})
+	if err != nil {
+		t.Fatalf("BuildBotReviewReactionConfig: %v", err)
+	}
+	reviewGot, err := BuildReviewReactionConfig(config.ReactionConfig{})
+	if err != nil {
+		t.Fatalf("BuildReviewReactionConfig: %v", err)
+	}
+
+	if botGot.MaxContinuationTurns != 5 {
+		t.Errorf("bot-review MaxContinuationTurns = %d, want 5", botGot.MaxContinuationTurns)
+	}
+	if botGot.PollIntervalMS != 60000 {
+		t.Errorf("bot-review PollIntervalMS = %d, want 60000", botGot.PollIntervalMS)
+	}
+	if reviewGot.MaxContinuationTurns != 3 {
+		t.Errorf("review MaxContinuationTurns = %d, want 3", reviewGot.MaxContinuationTurns)
+	}
+	if reviewGot.PollIntervalMS != 120000 {
+		t.Errorf("review PollIntervalMS = %d, want 120000", reviewGot.PollIntervalMS)
+	}
+}
+
+// --- reconcileBotReviewComments tests (6.3 → R5, R6) ---
+
+func TestReconcileBotReviewComments_NilAdapter(t *testing.T) {
+	t.Parallel()
+
+	state := stateWithBotReviewReaction(t, "BOT-1", 42)
+	store := &reviewReconcileStore{}
+	metrics := newBotReviewMetricsSpy()
+	params := botReviewParams(store, nil, nil)
+
+	reconcileBotReviewComments(state, params, discardLogger(), context.Background(), metrics)
+
+	rkey := ReactionKey("BOT-1", ReactionKindBotReview)
+	if _, ok := state.PendingReactions[rkey]; !ok {
+		t.Error("PendingReactions entry removed with nil SCMAdapter; want no-op")
+	}
+	if len(metrics.botReviewChecks) != 0 {
+		t.Error("IncBotReviewChecks called with nil adapter; want no calls")
+	}
+}
+
+func TestReconcileBotReviewComments_NotConfigured(t *testing.T) {
+	t.Parallel()
+
+	state := stateWithBotReviewReaction(t, "BOT-NC", 42)
+	store := &reviewReconcileStore{}
+	metrics := newBotReviewMetricsSpy()
+	scm := &mockSCMAdapter{}
+	params := botReviewParams(store, scm, nil)
+	params.BotReviewConfigured = false
+
+	reconcileBotReviewComments(state, params, discardLogger(), context.Background(), metrics)
+
+	rkey := ReactionKey("BOT-NC", ReactionKindBotReview)
+	if _, ok := state.PendingReactions[rkey]; !ok {
+		t.Error("PendingReactions entry removed when BotReviewConfigured=false; want no-op")
+	}
+	if scm.botCalls != 0 {
+		t.Errorf("FetchBotReviewComments calls = %d, want 0 (not configured)", scm.botCalls)
+	}
+}
+
+func TestReconcileBotReviewComments_PollThrottle(t *testing.T) {
+	t.Parallel()
+
+	state := stateWithBotReviewReaction(t, "BOT-THROTT", 10)
+	rkey := ReactionKey("BOT-THROTT", ReactionKindBotReview)
+	state.PendingReactions[rkey].PendingRetryAt = botReviewBaseTime.Add(5 * time.Minute)
+
+	store := &reviewReconcileStore{}
+	metrics := newBotReviewMetricsSpy()
+	scm := &mockSCMAdapter{}
+	params := botReviewParams(store, scm, nil)
+
+	reconcileBotReviewComments(state, params, discardLogger(), context.Background(), metrics)
+
+	if _, ok := state.PendingReactions[rkey]; !ok {
+		t.Error("PendingReactions entry dropped on poll throttle; want re-enqueued")
+	}
+	if scm.botCalls != 0 {
+		t.Errorf("FetchBotReviewComments calls = %d, want 0 (throttled)", scm.botCalls)
+	}
+}
+
+func TestReconcileBotReviewComments_SCMFetchError_ReEnqueues(t *testing.T) {
+	t.Parallel()
+
+	state := stateWithBotReviewReaction(t, "BOT-ERR", 10)
+	rkey := ReactionKey("BOT-ERR", ReactionKindBotReview)
+	store := &reviewReconcileStore{}
+	metrics := newBotReviewMetricsSpy()
+	scm := &mockSCMAdapter{botErr: errors.New("upstream timeout")}
+	params := botReviewParams(store, scm, nil)
+
+	reconcileBotReviewComments(state, params, discardLogger(), context.Background(), metrics)
+
+	entry, ok := state.PendingReactions[rkey]
+	if !ok {
+		t.Fatal("PendingReactions entry dropped on SCM fetch error; want re-enqueued")
+	}
+	if entry.PendingAttempts != 1 {
+		t.Errorf("PendingAttempts = %d, want 1 after first error", entry.PendingAttempts)
+	}
+	if !entry.PendingRetryAt.After(botReviewBaseTime) {
+		t.Error("PendingRetryAt not in future after SCM error; want backoff applied")
+	}
+	// PendingRetryAt must be >= max(backoff, pollInterval): the poll interval is 60s.
+	minExpected := botReviewBaseTime.Add(60 * time.Second)
+	if entry.PendingRetryAt.Before(minExpected) {
+		t.Errorf("PendingRetryAt = %v, want >= pollInterval from now (%v)",
+			entry.PendingRetryAt, minExpected)
+	}
+	if metrics.botReviewChecks["error"] != 1 {
+		t.Errorf(`IncBotReviewChecks("error") = %d, want 1`, metrics.botReviewChecks["error"])
+	}
+}
+
+func TestReconcileBotReviewComments_NoActionableComments(t *testing.T) {
+	t.Parallel()
+
+	state := stateWithBotReviewReaction(t, "BOT-NOACT", 10)
+	rkey := ReactionKey("BOT-NOACT", ReactionKindBotReview)
+	store := &reviewReconcileStore{}
+	metrics := newBotReviewMetricsSpy()
+	scm := &mockSCMAdapter{botComments: []domain.ReviewComment{}}
+	params := botReviewParams(store, scm, nil)
+
+	reconcileBotReviewComments(state, params, discardLogger(), context.Background(), metrics)
+
+	if _, ok := state.PendingReactions[rkey]; !ok {
+		t.Error("PendingReactions entry dropped with no actionable comments; want re-enqueued")
+	}
+	if _, ok := state.RetryAttempts["BOT-NOACT"]; ok {
+		t.Error("retry scheduled with no actionable comments; want none")
+	}
+}
+
+func TestReconcileBotReviewComments_AllCommentsOutdated(t *testing.T) {
+	t.Parallel()
+
+	state := stateWithBotReviewReaction(t, "BOT-OUT", 10)
+	rkey := ReactionKey("BOT-OUT", ReactionKindBotReview)
+	store := &reviewReconcileStore{}
+	metrics := newBotReviewMetricsSpy()
+	scm := &mockSCMAdapter{
+		botComments: []domain.ReviewComment{
+			{ID: "b1", Outdated: true},
+			{ID: "b2", Outdated: true},
+		},
+	}
+	params := botReviewParams(store, scm, nil)
+
+	reconcileBotReviewComments(state, params, discardLogger(), context.Background(), metrics)
+
+	if _, ok := state.PendingReactions[rkey]; !ok {
+		t.Error("PendingReactions entry dropped with all outdated comments; want re-enqueued")
+	}
+	if _, ok := state.RetryAttempts["BOT-OUT"]; ok {
+		t.Error("retry scheduled with all outdated comments; want none")
+	}
+}
+
+// TestReconcileBotReviewComments_ImmediateDispatch_NoDebounce verifies R5: bot-review
+// dispatches on the same tick it detects actionable comments, with no debounce gate.
+// The comment timestamp can be brand-new (seconds ago) and dispatch still happens.
+func TestReconcileBotReviewComments_ImmediateDispatch_NoDebounce(t *testing.T) {
+	t.Parallel()
+
+	state := stateWithBotReviewReaction(t, "BOT-IMM", 10)
+	rkey := ReactionKey("BOT-IMM", ReactionKindBotReview)
+
+	// Comment submitted just 2 seconds ago — within any plausible debounce window.
+	// The review path would NOT dispatch yet; the bot-review path MUST dispatch immediately.
+	freshComment := []domain.ReviewComment{
+		{ID: "bot-fresh", Body: "lint: line too long", SubmittedAt: botReviewBaseTime.Add(-2 * time.Second)},
+	}
+	store := &reviewReconcileStore{
+		getFingerprintResult:     "",
+		getFingerprintDispatched: false,
+	}
+	metrics := newBotReviewMetricsSpy()
+	scm := &mockSCMAdapter{botComments: freshComment}
+	params := botReviewParams(store, scm, nil)
+
+	reconcileBotReviewComments(state, params, discardLogger(), context.Background(), metrics)
+
+	// Must have dispatched: pending entry consumed.
+	if _, ok := state.PendingReactions[rkey]; ok {
+		t.Error("PendingReactions entry still present after dispatch; want consumed (no debounce)")
+	}
+	if _, ok := state.RetryAttempts["BOT-IMM"]; !ok {
+		t.Fatal("retry not scheduled after bot-review dispatch; want scheduled")
+	}
+	retry := state.RetryAttempts["BOT-IMM"]
+	if retry.ReactionKind != ReactionKindBotReview {
+		t.Errorf("RetryEntry.ReactionKind = %q, want %q", retry.ReactionKind, ReactionKindBotReview)
+	}
+	if retry.ContinuationContext == nil {
+		t.Error("RetryEntry.ContinuationContext is nil; want bot_review_comments map")
+	}
+	if _, ok := retry.ContinuationContext["bot_review_comments"]; !ok {
+		t.Error("ContinuationContext missing bot_review_comments key")
+	}
+	if state.ReactionAttempts[rkey] != 1 {
+		t.Errorf("ReactionAttempts[%s] = %d, want 1", rkey, state.ReactionAttempts[rkey])
+	}
+	if metrics.botReviewChecks["dispatched"] != 1 {
+		t.Errorf(`IncBotReviewChecks("dispatched") = %d, want 1`, metrics.botReviewChecks["dispatched"])
+	}
+}
+
+// TestReconcileBotReviewComments_FingerprintChurn verifies R6: changing the set of
+// actionable comment IDs produces a new fingerprint, resets the dispatched flag,
+// and triggers re-dispatch on the next tick.
+func TestReconcileBotReviewComments_FingerprintChurn(t *testing.T) {
+	t.Parallel()
+
+	// First tick: comment set {c1, c2}. Fingerprint stored and dispatched.
+	firstSet := []domain.ReviewComment{
+		{ID: "c1", Body: "fix 1"},
+		{ID: "c2", Body: "fix 2"},
+	}
+	firstFP := buildReviewFingerprint(firstSet)
+
+	// Second tick: comment set {c1, c2, c3} — churned.
+	secondSet := []domain.ReviewComment{
+		{ID: "c1", Body: "fix 1"},
+		{ID: "c2", Body: "fix 2"},
+		{ID: "c3", Body: "fix 3"},
+	}
+
+	// Store returns the OLD fingerprint as dispatched, but the new set produces a different one.
+	store := &reviewReconcileStore{
+		getFingerprintResult:     firstFP,
+		getFingerprintDispatched: true,
+	}
+
+	state := stateWithBotReviewReaction(t, "BOT-CHURN", 20)
+	rkey := ReactionKey("BOT-CHURN", ReactionKindBotReview)
+	metrics := newBotReviewMetricsSpy()
+	scm := &mockSCMAdapter{botComments: secondSet}
+	params := botReviewParams(store, scm, nil)
+
+	reconcileBotReviewComments(state, params, discardLogger(), context.Background(), metrics)
+
+	// New fingerprint != stored dispatched fingerprint → must dispatch.
+	if _, ok := state.PendingReactions[rkey]; ok {
+		t.Error("PendingReactions entry still present after fingerprint churn dispatch; want consumed")
+	}
+	if _, ok := state.RetryAttempts["BOT-CHURN"]; !ok {
+		t.Fatal("retry not scheduled after fingerprint churn; want scheduled")
+	}
+	if metrics.botReviewChecks["dispatched"] != 1 {
+		t.Errorf(`IncBotReviewChecks("dispatched") = %d, want 1 after fingerprint churn`,
+			metrics.botReviewChecks["dispatched"])
+	}
+}
+
+// TestReconcileBotReviewComments_UnchangedDispatchedFingerprint verifies that an unchanged
+// dispatched fingerprint causes re-enqueue WITHOUT dispatch.
+func TestReconcileBotReviewComments_UnchangedDispatchedFingerprint(t *testing.T) {
+	t.Parallel()
+
+	comments := []domain.ReviewComment{
+		{ID: "stable-1", Body: "fix this"},
+	}
+	fp := buildReviewFingerprint(comments)
+
+	store := &reviewReconcileStore{
+		getFingerprintResult:     fp,
+		getFingerprintDispatched: true,
+	}
+
+	state := stateWithBotReviewReaction(t, "BOT-SAME", 30)
+	rkey := ReactionKey("BOT-SAME", ReactionKindBotReview)
+	metrics := newBotReviewMetricsSpy()
+	scm := &mockSCMAdapter{botComments: comments}
+	params := botReviewParams(store, scm, nil)
+
+	reconcileBotReviewComments(state, params, discardLogger(), context.Background(), metrics)
+
+	// Same dispatched fingerprint → re-enqueue, no dispatch.
+	if _, ok := state.PendingReactions[rkey]; !ok {
+		t.Error("PendingReactions entry dropped for same dispatched fingerprint; want re-enqueued")
+	}
+	if _, ok := state.RetryAttempts["BOT-SAME"]; ok {
+		t.Error("retry scheduled for same dispatched fingerprint; want none")
+	}
+	if metrics.botReviewChecks["dispatched"] != 0 {
+		t.Errorf(`IncBotReviewChecks("dispatched") = %d, want 0 (same fingerprint)`,
+			metrics.botReviewChecks["dispatched"])
+	}
+}
+
+// TestReconcileBotReviewComments_KindDataTypeMismatch verifies that a KindData with
+// the wrong concrete type is skipped with an error log and does not panic.
+func TestReconcileBotReviewComments_KindDataTypeMismatch(t *testing.T) {
+	t.Parallel()
+
+	state := NewState(5000, 4, nil, AgentTotals{})
+	rkey := ReactionKey("BOT-MISMATCH", ReactionKindBotReview)
+	state.PendingReactions[rkey] = &PendingReaction{
+		IssueID:    "BOT-MISMATCH",
+		Identifier: "BOT-MISMATCH-ident",
+		Kind:       ReactionKindBotReview,
+		CreatedAt:  botReviewBaseTime,
+		KindData:   &ReviewReactionData{PRNumber: 1}, // wrong type
+	}
+
+	store := &reviewReconcileStore{}
+	metrics := newBotReviewMetricsSpy()
+	scm := &mockSCMAdapter{}
+	params := botReviewParams(store, scm, nil)
+
+	// Must not panic.
+	reconcileBotReviewComments(state, params, discardLogger(), context.Background(), metrics)
+
+	// Entry consumed (deleted, not re-enqueued) after type mismatch skip.
+	if _, ok := state.PendingReactions[rkey]; ok {
+		t.Error("PendingReactions entry still present after KindData mismatch; want skipped (deleted)")
+	}
+	if scm.botCalls != 0 {
+		t.Errorf("FetchBotReviewComments calls = %d, want 0 (mismatch short-circuits)", scm.botCalls)
+	}
+}
+
+// TestReconcileBotReviewComments_SkipsNonBotReviewEntries verifies that entries
+// for other reaction kinds are not processed by the bot-review reconcile pass.
+func TestReconcileBotReviewComments_SkipsNonBotReviewEntries(t *testing.T) {
+	t.Parallel()
+
+	state := NewState(5000, 4, nil, AgentTotals{})
+	// Add a review-kind entry that must remain untouched.
+	reviewKey := ReactionKey("BOT-CROSS", ReactionKindReview)
+	state.PendingReactions[reviewKey] = &PendingReaction{
+		IssueID:    "BOT-CROSS",
+		Identifier: "BOT-CROSS-ident",
+		Kind:       ReactionKindReview,
+		CreatedAt:  botReviewBaseTime,
+		KindData:   &ReviewReactionData{PRNumber: 5},
+	}
+
+	store := &reviewReconcileStore{}
+	metrics := newBotReviewMetricsSpy()
+	scm := &mockSCMAdapter{}
+	params := botReviewParams(store, scm, nil)
+
+	reconcileBotReviewComments(state, params, discardLogger(), context.Background(), metrics)
+
+	if _, ok := state.PendingReactions[reviewKey]; !ok {
+		t.Error("review PendingReactions entry removed by bot-review reconcile; want untouched")
+	}
+	if scm.botCalls != 0 {
+		t.Errorf("FetchBotReviewComments calls = %d, want 0 (no bot-review entries)", scm.botCalls)
+	}
+}
+
+// --- escalateBotReviewFailure tests (6.4 → R7, R10) ---
+
+// TestEscalateBotReviewFailure_CrossKindIsolation verifies R7 and R10:
+// a PR with both a review slot and a bot-review slot — after bot-review escalation:
+// - the bot-review PendingReaction is deleted
+// - the review slot remains untouched
+// - the merge slot remains untouched (if present)
+// - state.Claimed[issueID] is NOT cleared
+// - state.ReactionAttempts for bot-review is NOT reset.
+func TestEscalateBotReviewFailure_CrossKindIsolation(t *testing.T) {
+	t.Parallel()
+
+	issueID := "ISO-1"
+	state := NewState(5000, 4, nil, AgentTotals{})
+
+	// Seed: review slot.
+	reviewKey := ReactionKey(issueID, ReactionKindReview)
+	state.PendingReactions[reviewKey] = &PendingReaction{
+		IssueID:    issueID,
+		Identifier: issueID + "-ident",
+		Kind:       ReactionKindReview,
+		CreatedAt:  botReviewBaseTime,
+		KindData:   &ReviewReactionData{PRNumber: 77},
+	}
+
+	// Seed: merge (auto-merge) slot.
+	mergeKey := ReactionKey(issueID, ReactionKindAutoMerge)
+	state.PendingReactions[mergeKey] = &PendingReaction{
+		IssueID:    issueID,
+		Identifier: issueID + "-ident",
+		Kind:       ReactionKindAutoMerge,
+		CreatedAt:  botReviewBaseTime,
+		KindData:   &AutoMergeReactionData{PRNumber: 77},
+	}
+
+	// Seed: bot-review slot at cap.
+	botKey := ReactionKey(issueID, ReactionKindBotReview)
+	botPending := &PendingReaction{
+		IssueID:    issueID,
+		Identifier: issueID + "-ident",
+		DisplayID:  issueID,
+		Attempt:    1,
+		Kind:       ReactionKindBotReview,
+		CreatedAt:  botReviewBaseTime,
+		KindData: &BotReviewReactionData{
+			PRNumber: 77,
+			Owner:    "owner",
+			Repo:     "repo",
+			Branch:   "feature/iso",
+		},
+	}
+	state.PendingReactions[botKey] = botPending
+	state.Claimed[issueID] = struct{}{}
+	state.ReactionAttempts[botKey] = 5 // at cap
+
+	store := &reviewReconcileStore{}
+	metrics := newBotReviewMetricsSpy()
+	tracker := &reviewTrackerStub{}
+	params := botReviewParams(store, &mockSCMAdapter{}, tracker)
+	params.BotReviewConfig = BotReviewReactionConfig{
+		Escalation:           "label",
+		EscalationLabel:      "needs-human",
+		MaxContinuationTurns: 5,
+		PollIntervalMS:       60000,
+	}
+
+	botData := botPending.KindData.(*BotReviewReactionData)
+	escalateBotReviewFailure(state, params, botPending, 5, botData, discardLogger(), context.Background(), metrics)
+	state.TrackerOpsWg.Wait()
+
+	// bot-review slot deleted.
+	if _, ok := state.PendingReactions[botKey]; ok {
+		t.Error("bot-review PendingReactions entry still present after escalation; want deleted")
+	}
+	// review slot untouched.
+	if _, ok := state.PendingReactions[reviewKey]; !ok {
+		t.Error("review PendingReactions entry removed by bot-review escalation; want untouched")
+	}
+	// merge slot untouched.
+	if _, ok := state.PendingReactions[mergeKey]; !ok {
+		t.Error("merge PendingReactions entry removed by bot-review escalation; want untouched")
+	}
+	// Claim untouched.
+	if _, ok := state.Claimed[issueID]; !ok {
+		t.Error("state.Claimed[issueID] cleared by bot-review escalation; want untouched")
+	}
+	// ReactionAttempts counter for bot-review is NOT cleared.
+	if state.ReactionAttempts[botKey] != 5 {
+		t.Errorf("ReactionAttempts[%s] = %d, want 5 (residual counter preserved)", botKey, state.ReactionAttempts[botKey])
+	}
+	// Fingerprint delete was called.
+	if store.deleteFingerprintCalls != 1 {
+		t.Errorf("DeleteReactionFingerprint calls = %d, want 1", store.deleteFingerprintCalls)
+	}
+}
+
+// TestEscalateBotReviewFailure_LabelAction verifies the "label" escalation branch.
+func TestEscalateBotReviewFailure_LabelAction(t *testing.T) {
+	t.Parallel()
+
+	issueID := "ESC-LABEL-1"
+	state := NewState(5000, 4, nil, AgentTotals{})
+	botKey := ReactionKey(issueID, ReactionKindBotReview)
+	botPending := &PendingReaction{
+		IssueID:   issueID,
+		Kind:      ReactionKindBotReview,
+		CreatedAt: botReviewBaseTime,
+		KindData:  &BotReviewReactionData{PRNumber: 10, Owner: "o", Repo: "r"},
+	}
+	state.PendingReactions[botKey] = botPending
+	state.Claimed[issueID] = struct{}{}
+
+	store := &reviewReconcileStore{}
+	metrics := newBotReviewMetricsSpy()
+	tracker := &reviewTrackerStub{}
+	params := botReviewParams(store, &mockSCMAdapter{}, tracker)
+	params.BotReviewConfig = BotReviewReactionConfig{
+		Escalation:           "label",
+		EscalationLabel:      "needs-human",
+		MaxContinuationTurns: 5,
+		PollIntervalMS:       60000,
+	}
+
+	botData := botPending.KindData.(*BotReviewReactionData)
+	escalateBotReviewFailure(state, params, botPending, 5, botData, discardLogger(), context.Background(), metrics)
+	state.TrackerOpsWg.Wait()
+
+	if tracker.addLabelCalled != 1 {
+		t.Errorf("AddLabel calls = %d, want 1 for label escalation", tracker.addLabelCalled)
+	}
+	if tracker.commentIssueCalls != 0 {
+		t.Errorf("CommentIssue calls = %d, want 0 for label escalation", tracker.commentIssueCalls)
+	}
+	if metrics.botReviewEscalations["label"] != 1 {
+		t.Errorf(`IncBotReviewEscalations("label") = %d, want 1`, metrics.botReviewEscalations["label"])
+	}
+}
+
+// TestEscalateBotReviewFailure_CommentAction verifies the "comment" escalation branch.
+func TestEscalateBotReviewFailure_CommentAction(t *testing.T) {
+	t.Parallel()
+
+	issueID := "ESC-COMMENT-1"
+	state := NewState(5000, 4, nil, AgentTotals{})
+	botKey := ReactionKey(issueID, ReactionKindBotReview)
+	botPending := &PendingReaction{
+		IssueID:   issueID,
+		Kind:      ReactionKindBotReview,
+		CreatedAt: botReviewBaseTime,
+		KindData:  &BotReviewReactionData{PRNumber: 20, Owner: "o", Repo: "r"},
+	}
+	state.PendingReactions[botKey] = botPending
+
+	store := &reviewReconcileStore{}
+	metrics := newBotReviewMetricsSpy()
+	tracker := &reviewTrackerStub{}
+	params := botReviewParams(store, &mockSCMAdapter{}, tracker)
+	params.BotReviewConfig = BotReviewReactionConfig{
+		Escalation:           "comment",
+		EscalationLabel:      "needs-human",
+		MaxContinuationTurns: 5,
+		PollIntervalMS:       60000,
+	}
+
+	botData := botPending.KindData.(*BotReviewReactionData)
+	escalateBotReviewFailure(state, params, botPending, 5, botData, discardLogger(), context.Background(), metrics)
+	state.TrackerOpsWg.Wait()
+
+	if tracker.commentIssueCalls != 1 {
+		t.Errorf("CommentIssue calls = %d, want 1 for comment escalation", tracker.commentIssueCalls)
+	}
+	if tracker.addLabelCalled != 0 {
+		t.Errorf("AddLabel calls = %d, want 0 for comment escalation", tracker.addLabelCalled)
+	}
+	if metrics.botReviewEscalations["comment"] != 1 {
+		t.Errorf(`IncBotReviewEscalations("comment") = %d, want 1`, metrics.botReviewEscalations["comment"])
+	}
+}
+
+// TestEscalateBotReviewFailure_EmptyEscalation verifies that empty-string escalation
+// falls back to the comment action (same as "comment").
+func TestEscalateBotReviewFailure_EmptyEscalation(t *testing.T) {
+	t.Parallel()
+
+	issueID := "ESC-EMPTY-1"
+	state := NewState(5000, 4, nil, AgentTotals{})
+	botKey := ReactionKey(issueID, ReactionKindBotReview)
+	botPending := &PendingReaction{
+		IssueID:   issueID,
+		Kind:      ReactionKindBotReview,
+		CreatedAt: botReviewBaseTime,
+		KindData:  &BotReviewReactionData{PRNumber: 30, Owner: "o", Repo: "r"},
+	}
+	state.PendingReactions[botKey] = botPending
+
+	store := &reviewReconcileStore{}
+	metrics := newBotReviewMetricsSpy()
+	tracker := &reviewTrackerStub{}
+	params := botReviewParams(store, &mockSCMAdapter{}, tracker)
+	params.BotReviewConfig = BotReviewReactionConfig{
+		Escalation:           "", // empty → comment branch
+		MaxContinuationTurns: 5,
+		PollIntervalMS:       60000,
+	}
+
+	botData := botPending.KindData.(*BotReviewReactionData)
+	escalateBotReviewFailure(state, params, botPending, 5, botData, discardLogger(), context.Background(), metrics)
+	state.TrackerOpsWg.Wait()
+
+	if tracker.commentIssueCalls != 1 {
+		t.Errorf("CommentIssue calls = %d, want 1 for empty escalation (comment branch)", tracker.commentIssueCalls)
+	}
+}
+
+// TestEscalateBotReviewFailure_NilTrackerAdapter verifies the no-op path when
+// TrackerAdapter is nil: no panic, fingerprint still deleted.
+func TestEscalateBotReviewFailure_NilTrackerAdapter(t *testing.T) {
+	t.Parallel()
+
+	issueID := "ESC-NOTRACKER"
+	state := NewState(5000, 4, nil, AgentTotals{})
+	botKey := ReactionKey(issueID, ReactionKindBotReview)
+	botPending := &PendingReaction{
+		IssueID:   issueID,
+		Kind:      ReactionKindBotReview,
+		CreatedAt: botReviewBaseTime,
+		KindData:  &BotReviewReactionData{PRNumber: 40},
+	}
+	state.PendingReactions[botKey] = botPending
+
+	store := &reviewReconcileStore{}
+	metrics := newBotReviewMetricsSpy()
+	params := botReviewParams(store, nil, nil)
+	params.BotReviewConfig = BotReviewReactionConfig{
+		Escalation:           "label",
+		EscalationLabel:      "needs-human",
+		MaxContinuationTurns: 5,
+		PollIntervalMS:       60000,
+	}
+
+	botData := botPending.KindData.(*BotReviewReactionData)
+
+	// Must not panic with nil TrackerAdapter.
+	escalateBotReviewFailure(state, params, botPending, 5, botData, discardLogger(), context.Background(), metrics)
+	state.TrackerOpsWg.Wait()
+
+	// bot-review slot still removed.
+	if _, ok := state.PendingReactions[botKey]; ok {
+		t.Error("bot-review PendingReactions entry still present after nil-tracker escalation; want deleted")
+	}
+	// Fingerprint delete called.
+	if store.deleteFingerprintCalls != 1 {
+		t.Errorf("DeleteReactionFingerprint calls = %d, want 1", store.deleteFingerprintCalls)
+	}
+}
+
+// TestReconcileBotReviewComments_TurnCapEscalates verifies that when
+// ReactionAttempts >= MaxContinuationTurns, escalateBotReviewFailure is called
+// via the reconcile loop and ONLY the bot-review slot is cleaned up (R7, R10).
+func TestReconcileBotReviewComments_TurnCapEscalates(t *testing.T) {
+	t.Parallel()
+
+	issueID := "BOT-CAP"
+	state := NewState(5000, 4, nil, AgentTotals{})
+
+	// Sibling review slot that must survive.
+	reviewKey := ReactionKey(issueID, ReactionKindReview)
+	state.PendingReactions[reviewKey] = &PendingReaction{
+		IssueID:   issueID,
+		Kind:      ReactionKindReview,
+		CreatedAt: botReviewBaseTime,
+		KindData:  &ReviewReactionData{PRNumber: 99},
+	}
+
+	// bot-review slot at cap.
+	botKey := ReactionKey(issueID, ReactionKindBotReview)
+	state.PendingReactions[botKey] = makeBotReviewPendingEntry(t, issueID, 99)
+	state.Claimed[issueID] = struct{}{}
+	state.ReactionAttempts[botKey] = 5 // == MaxContinuationTurns
+
+	store := &reviewReconcileStore{}
+	metrics := newBotReviewMetricsSpy()
+	scm := &mockSCMAdapter{}
+	tracker := &reviewTrackerStub{}
+	params := botReviewParams(store, scm, tracker)
+
+	reconcileBotReviewComments(state, params, discardLogger(), context.Background(), metrics)
+	state.TrackerOpsWg.Wait()
+
+	// bot-review slot consumed.
+	if _, ok := state.PendingReactions[botKey]; ok {
+		t.Error("bot-review PendingReactions entry still present after turn cap; want deleted")
+	}
+	// SCM must not have been called (cap check before fetch).
+	if scm.botCalls != 0 {
+		t.Errorf("FetchBotReviewComments calls = %d, want 0 (cap check before fetch)", scm.botCalls)
+	}
+	// Claim must still be set (only terminal cleanup releases it).
+	if _, ok := state.Claimed[issueID]; !ok {
+		t.Error("state.Claimed[issueID] cleared by bot-review escalation; want preserved (R10)")
+	}
+	// Sibling review slot must be untouched.
+	if _, ok := state.PendingReactions[reviewKey]; !ok {
+		t.Error("review PendingReactions entry removed by bot-review escalation; want untouched (R7)")
+	}
+	// ReactionAttempts for bot-review is NOT cleared.
+	if state.ReactionAttempts[botKey] != 5 {
+		t.Errorf("ReactionAttempts[%s] = %d, want 5 (residual counter preserved, R10)", botKey, state.ReactionAttempts[botKey])
+	}
+}

--- a/internal/orchestrator/bot_review_reconcile_test.go
+++ b/internal/orchestrator/bot_review_reconcile_test.go
@@ -127,7 +127,7 @@ func TestBuildBotReviewReactionConfig(t *testing.T) {
 			name: "well-formed bot_usernames coerces to []string",
 			rc: config.ReactionConfig{
 				Extra: map[string]any{
-					"bot_usernames": []any{"acme-lint-bot", "ci-review-svc"},
+					"bot_usernames": []any{"houndci-bot"},
 				},
 			},
 			want: BotReviewReactionConfig{
@@ -135,7 +135,7 @@ func TestBuildBotReviewReactionConfig(t *testing.T) {
 				EscalationLabel:      "needs-human",
 				PollIntervalMS:       60000,
 				MaxContinuationTurns: 5,
-				BotUsernames:         []string{"acme-lint-bot", "ci-review-svc"},
+				BotUsernames:         []string{"houndci-bot"},
 			},
 		},
 		{

--- a/internal/orchestrator/bot_review_reconcile_test.go
+++ b/internal/orchestrator/bot_review_reconcile_test.go
@@ -3,6 +3,7 @@ package orchestrator
 import (
 	"context"
 	"errors"
+	"math"
 	"testing"
 	"time"
 
@@ -156,6 +157,70 @@ func TestBuildBotReviewReactionConfig(t *testing.T) {
 				PollIntervalMS:       30000,
 				MaxContinuationTurns: 5,
 			},
+		},
+		{
+			name: "poll_interval_ms as int64 is valid",
+			rc: config.ReactionConfig{
+				Extra: map[string]any{"poll_interval_ms": int64(45000)},
+			},
+			want: BotReviewReactionConfig{
+				Escalation:           "label",
+				EscalationLabel:      "needs-human",
+				PollIntervalMS:       45000,
+				MaxContinuationTurns: 5,
+			},
+		},
+		{
+			name: "poll_interval_ms as whole float64 is valid",
+			rc: config.ReactionConfig{
+				Extra: map[string]any{"poll_interval_ms": float64(90000)},
+			},
+			want: BotReviewReactionConfig{
+				Escalation:           "label",
+				EscalationLabel:      "needs-human",
+				PollIntervalMS:       90000,
+				MaxContinuationTurns: 5,
+			},
+		},
+		{
+			name: "poll_interval_ms non-numeric type errors",
+			rc: config.ReactionConfig{
+				Extra: map[string]any{"poll_interval_ms": "fast"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "poll_interval_ms fractional float64 errors",
+			rc: config.ReactionConfig{
+				Extra: map[string]any{"poll_interval_ms": float64(30000.5)},
+			},
+			wantErr: true,
+		},
+		{
+			name: "poll_interval_ms infinite float64 errors",
+			rc: config.ReactionConfig{
+				Extra: map[string]any{"poll_interval_ms": math.Inf(1)},
+			},
+			wantErr: true,
+		},
+		{
+			name: "max_continuation_turns valid override",
+			rc: config.ReactionConfig{
+				Extra: map[string]any{"max_continuation_turns": 8},
+			},
+			want: BotReviewReactionConfig{
+				Escalation:           "label",
+				EscalationLabel:      "needs-human",
+				PollIntervalMS:       60000,
+				MaxContinuationTurns: 8,
+			},
+		},
+		{
+			name: "max_continuation_turns non-numeric type errors",
+			rc: config.ReactionConfig{
+				Extra: map[string]any{"max_continuation_turns": "many"},
+			},
+			wantErr: true,
 		},
 		{
 			name: "max_continuation_turns <= 0 errors",
@@ -916,5 +981,330 @@ func TestReconcileBotReviewComments_TurnCapEscalates(t *testing.T) {
 	// ReactionAttempts for bot-review is NOT cleared.
 	if state.ReactionAttempts[botKey] != 5 {
 		t.Errorf("ReactionAttempts[%s] = %d, want 5 (residual counter preserved, R10)", botKey, state.ReactionAttempts[botKey])
+	}
+}
+
+// botReviewErrTrackerStub is a TrackerAdapter whose AddLabel and CommentIssue
+// return a configurable error, used to exercise the escalation error paths.
+type botReviewErrTrackerStub struct {
+	addLabelErr     error
+	commentErr      error
+	addLabelCalls   int
+	commentCalls    int
+	lastLabel       string
+	lastCommentText string
+}
+
+var _ domain.TrackerAdapter = (*botReviewErrTrackerStub)(nil)
+
+func (s *botReviewErrTrackerStub) FetchIssuesByStates(_ context.Context, _ []string) ([]domain.Issue, error) {
+	return nil, nil
+}
+func (s *botReviewErrTrackerStub) FetchCandidateIssues(_ context.Context) ([]domain.Issue, error) {
+	return nil, nil
+}
+func (s *botReviewErrTrackerStub) FetchIssueByID(_ context.Context, _ string) (domain.Issue, error) {
+	return domain.Issue{}, nil
+}
+func (s *botReviewErrTrackerStub) FetchIssueStatesByIDs(_ context.Context, _ []string) (map[string]string, error) {
+	return nil, nil
+}
+func (s *botReviewErrTrackerStub) FetchIssueStatesByIdentifiers(_ context.Context, _ []string) (map[string]string, error) {
+	return nil, nil
+}
+func (s *botReviewErrTrackerStub) FetchIssueComments(_ context.Context, _ string) ([]domain.Comment, error) {
+	return nil, nil
+}
+func (s *botReviewErrTrackerStub) TransitionIssue(_ context.Context, _, _ string) error {
+	return nil
+}
+func (s *botReviewErrTrackerStub) CommentIssue(_ context.Context, _, text string) error {
+	s.commentCalls++
+	s.lastCommentText = text
+	return s.commentErr
+}
+func (s *botReviewErrTrackerStub) AddLabel(_ context.Context, _, label string) error {
+	s.addLabelCalls++
+	s.lastLabel = label
+	return s.addLabelErr
+}
+
+// TestReconcileBotReviewComments_TTLDrop verifies that a bot-review pending
+// entry older than BotReviewPendingTTL is dropped without dispatch or fetch.
+func TestReconcileBotReviewComments_TTLDrop(t *testing.T) {
+	t.Parallel()
+
+	state := stateWithBotReviewReaction(t, "BOT-TTL", 10)
+	rkey := ReactionKey("BOT-TTL", ReactionKindBotReview)
+	// CreatedAt is botReviewBaseTime; advance now well past the TTL.
+	store := &reviewReconcileStore{}
+	metrics := newBotReviewMetricsSpy()
+	scm := &mockSCMAdapter{}
+	params := botReviewParams(store, scm, nil)
+	params.BotReviewPendingTTL = 1 * time.Minute
+	params.NowFunc = func() time.Time { return botReviewBaseTime.Add(2 * time.Minute) }
+
+	reconcileBotReviewComments(state, params, discardLogger(), context.Background(), metrics)
+
+	if _, ok := state.PendingReactions[rkey]; ok {
+		t.Error("PendingReactions entry present after TTL drop; want removed")
+	}
+	if scm.botCalls != 0 {
+		t.Errorf("FetchBotReviewComments calls = %d, want 0 (TTL drop before fetch)", scm.botCalls)
+	}
+	if _, ok := state.RetryAttempts["BOT-TTL"]; ok {
+		t.Error("retry scheduled after TTL drop; want none")
+	}
+}
+
+// TestReconcileBotReviewComments_ZeroPollIntervalUsesFallback verifies that a
+// zero PollIntervalMS falls back to the default backoff base when re-enqueuing
+// a pending entry with no actionable comments.
+func TestReconcileBotReviewComments_ZeroPollIntervalUsesFallback(t *testing.T) {
+	t.Parallel()
+
+	state := stateWithBotReviewReaction(t, "BOT-ZEROPOLL", 10)
+	rkey := ReactionKey("BOT-ZEROPOLL", ReactionKindBotReview)
+	store := &reviewReconcileStore{}
+	metrics := newBotReviewMetricsSpy()
+	scm := &mockSCMAdapter{botComments: []domain.ReviewComment{}}
+	params := botReviewParams(store, scm, nil)
+	params.BotReviewConfig.PollIntervalMS = 0 // forces fallback to reviewPendingBackoffBase
+
+	reconcileBotReviewComments(state, params, discardLogger(), context.Background(), metrics)
+
+	entry, ok := state.PendingReactions[rkey]
+	if !ok {
+		t.Fatal("PendingReactions entry dropped with zero poll interval; want re-enqueued")
+	}
+	wantRetryAt := botReviewBaseTime.Add(reviewPendingBackoffBase)
+	if !entry.PendingRetryAt.Equal(wantRetryAt) {
+		t.Errorf("PendingRetryAt = %v, want %v (fallback backoff base)", entry.PendingRetryAt, wantRetryAt)
+	}
+}
+
+// TestReconcileBotReviewComments_UpsertFingerprintError_StillDispatches verifies
+// that an UpsertReactionFingerprint failure is logged but does not prevent
+// dispatch when actionable comments exist.
+func TestReconcileBotReviewComments_UpsertFingerprintError_StillDispatches(t *testing.T) {
+	t.Parallel()
+
+	state := stateWithBotReviewReaction(t, "BOT-UPFP", 10)
+	rkey := ReactionKey("BOT-UPFP", ReactionKindBotReview)
+	store := &reviewReconcileStore{
+		upsertFingerprintErr: errors.New("upsert failed"),
+	}
+	metrics := newBotReviewMetricsSpy()
+	scm := &mockSCMAdapter{botComments: []domain.ReviewComment{{ID: "u1", Body: "fix me"}}}
+	params := botReviewParams(store, scm, nil)
+
+	reconcileBotReviewComments(state, params, discardLogger(), context.Background(), metrics)
+
+	if _, ok := state.PendingReactions[rkey]; ok {
+		t.Error("PendingReactions entry still present after dispatch despite upsert error; want consumed")
+	}
+	if _, ok := state.RetryAttempts["BOT-UPFP"]; !ok {
+		t.Error("retry not scheduled despite actionable comments; upsert error must not block dispatch")
+	}
+	if metrics.botReviewChecks["dispatched"] != 1 {
+		t.Errorf(`IncBotReviewChecks("dispatched") = %d, want 1`, metrics.botReviewChecks["dispatched"])
+	}
+}
+
+// TestReconcileBotReviewComments_GetFingerprintError_ProceedsWithoutDedup
+// verifies that a GetReactionFingerprint failure is logged but dispatch still
+// proceeds without the dedup short-circuit.
+func TestReconcileBotReviewComments_GetFingerprintError_ProceedsWithoutDedup(t *testing.T) {
+	t.Parallel()
+
+	state := stateWithBotReviewReaction(t, "BOT-GETFP", 10)
+	rkey := ReactionKey("BOT-GETFP", ReactionKindBotReview)
+	store := &reviewReconcileStore{
+		getFingerprintErr: errors.New("get failed"),
+	}
+	metrics := newBotReviewMetricsSpy()
+	scm := &mockSCMAdapter{botComments: []domain.ReviewComment{{ID: "g1", Body: "fix me"}}}
+	params := botReviewParams(store, scm, nil)
+
+	reconcileBotReviewComments(state, params, discardLogger(), context.Background(), metrics)
+
+	if _, ok := state.PendingReactions[rkey]; ok {
+		t.Error("PendingReactions entry still present after dispatch despite get-fingerprint error; want consumed")
+	}
+	if _, ok := state.RetryAttempts["BOT-GETFP"]; !ok {
+		t.Error("retry not scheduled; get-fingerprint error must fall through to dispatch")
+	}
+	if metrics.botReviewChecks["dispatched"] != 1 {
+		t.Errorf(`IncBotReviewChecks("dispatched") = %d, want 1`, metrics.botReviewChecks["dispatched"])
+	}
+}
+
+// TestEscalateBotReviewFailure_LabelDefaultsWhenEmpty verifies that the "label"
+// escalation uses the "needs-human" default when EscalationLabel is empty.
+func TestEscalateBotReviewFailure_LabelDefaultsWhenEmpty(t *testing.T) {
+	t.Parallel()
+
+	issueID := "ESC-LABEL-DEFAULT"
+	state := NewState(5000, 4, nil, AgentTotals{})
+	botKey := ReactionKey(issueID, ReactionKindBotReview)
+	botPending := &PendingReaction{
+		IssueID:   issueID,
+		Kind:      ReactionKindBotReview,
+		CreatedAt: botReviewBaseTime,
+		KindData:  &BotReviewReactionData{PRNumber: 10, Owner: "o", Repo: "r"},
+	}
+	state.PendingReactions[botKey] = botPending
+
+	store := &reviewReconcileStore{}
+	metrics := newBotReviewMetricsSpy()
+	tracker := &botReviewErrTrackerStub{}
+	params := botReviewParams(store, &mockSCMAdapter{}, tracker)
+	params.BotReviewConfig = BotReviewReactionConfig{
+		Escalation:           "label",
+		EscalationLabel:      "", // empty → defaults to needs-human
+		MaxContinuationTurns: 5,
+		PollIntervalMS:       60000,
+	}
+
+	botData := botPending.KindData.(*BotReviewReactionData)
+	escalateBotReviewFailure(state, params, botPending, 5, botData, discardLogger(), context.Background(), metrics)
+	state.TrackerOpsWg.Wait()
+
+	if tracker.addLabelCalls != 1 {
+		t.Fatalf("AddLabel calls = %d, want 1", tracker.addLabelCalls)
+	}
+	if tracker.lastLabel != "needs-human" {
+		t.Errorf("AddLabel label = %q, want %q (default)", tracker.lastLabel, "needs-human")
+	}
+	if metrics.botReviewEscalations["label"] != 1 {
+		t.Errorf(`IncBotReviewEscalations("label") = %d, want 1`, metrics.botReviewEscalations["label"])
+	}
+}
+
+// TestEscalateBotReviewFailure_LabelActionError verifies that a failing AddLabel
+// records the "error" escalation metric and still removes the bot-review slot.
+func TestEscalateBotReviewFailure_LabelActionError(t *testing.T) {
+	t.Parallel()
+
+	issueID := "ESC-LABEL-ERR"
+	state := NewState(5000, 4, nil, AgentTotals{})
+	botKey := ReactionKey(issueID, ReactionKindBotReview)
+	botPending := &PendingReaction{
+		IssueID:   issueID,
+		Kind:      ReactionKindBotReview,
+		CreatedAt: botReviewBaseTime,
+		KindData:  &BotReviewReactionData{PRNumber: 11, Owner: "o", Repo: "r"},
+	}
+	state.PendingReactions[botKey] = botPending
+
+	store := &reviewReconcileStore{}
+	metrics := newBotReviewMetricsSpy()
+	tracker := &botReviewErrTrackerStub{addLabelErr: errors.New("label api failed")}
+	params := botReviewParams(store, &mockSCMAdapter{}, tracker)
+	params.BotReviewConfig = BotReviewReactionConfig{
+		Escalation:           "label",
+		EscalationLabel:      "needs-human",
+		MaxContinuationTurns: 5,
+		PollIntervalMS:       60000,
+	}
+
+	botData := botPending.KindData.(*BotReviewReactionData)
+	escalateBotReviewFailure(state, params, botPending, 5, botData, discardLogger(), context.Background(), metrics)
+	state.TrackerOpsWg.Wait()
+
+	if tracker.addLabelCalls != 1 {
+		t.Fatalf("AddLabel calls = %d, want 1", tracker.addLabelCalls)
+	}
+	if metrics.botReviewEscalations["error"] != 1 {
+		t.Errorf(`IncBotReviewEscalations("error") = %d, want 1 on AddLabel failure`, metrics.botReviewEscalations["error"])
+	}
+	if metrics.botReviewEscalations["label"] != 0 {
+		t.Errorf(`IncBotReviewEscalations("label") = %d, want 0 on AddLabel failure`, metrics.botReviewEscalations["label"])
+	}
+	if _, ok := state.PendingReactions[botKey]; ok {
+		t.Error("bot-review slot still present after label-error escalation; want removed")
+	}
+}
+
+// TestEscalateBotReviewFailure_CommentActionError verifies that a failing
+// CommentIssue records the "error" escalation metric.
+func TestEscalateBotReviewFailure_CommentActionError(t *testing.T) {
+	t.Parallel()
+
+	issueID := "ESC-COMMENT-ERR"
+	state := NewState(5000, 4, nil, AgentTotals{})
+	botKey := ReactionKey(issueID, ReactionKindBotReview)
+	botPending := &PendingReaction{
+		IssueID:   issueID,
+		Kind:      ReactionKindBotReview,
+		CreatedAt: botReviewBaseTime,
+		KindData:  &BotReviewReactionData{PRNumber: 21, Owner: "o", Repo: "r"},
+	}
+	state.PendingReactions[botKey] = botPending
+
+	store := &reviewReconcileStore{}
+	metrics := newBotReviewMetricsSpy()
+	tracker := &botReviewErrTrackerStub{commentErr: errors.New("comment api failed")}
+	params := botReviewParams(store, &mockSCMAdapter{}, tracker)
+	params.BotReviewConfig = BotReviewReactionConfig{
+		Escalation:           "comment",
+		MaxContinuationTurns: 5,
+		PollIntervalMS:       60000,
+	}
+
+	botData := botPending.KindData.(*BotReviewReactionData)
+	escalateBotReviewFailure(state, params, botPending, 5, botData, discardLogger(), context.Background(), metrics)
+	state.TrackerOpsWg.Wait()
+
+	if tracker.commentCalls != 1 {
+		t.Fatalf("CommentIssue calls = %d, want 1", tracker.commentCalls)
+	}
+	if metrics.botReviewEscalations["error"] != 1 {
+		t.Errorf(`IncBotReviewEscalations("error") = %d, want 1 on CommentIssue failure`, metrics.botReviewEscalations["error"])
+	}
+	if metrics.botReviewEscalations["comment"] != 0 {
+		t.Errorf(`IncBotReviewEscalations("comment") = %d, want 0 on CommentIssue failure`, metrics.botReviewEscalations["comment"])
+	}
+}
+
+// TestEscalateBotReviewFailure_DeleteFingerprintError verifies that a failing
+// DeleteReactionFingerprint during escalation is logged but does not panic and
+// the bot-review slot is still removed.
+func TestEscalateBotReviewFailure_DeleteFingerprintError(t *testing.T) {
+	t.Parallel()
+
+	issueID := "ESC-DELFP-ERR"
+	state := NewState(5000, 4, nil, AgentTotals{})
+	botKey := ReactionKey(issueID, ReactionKindBotReview)
+	botPending := &PendingReaction{
+		IssueID:   issueID,
+		Kind:      ReactionKindBotReview,
+		CreatedAt: botReviewBaseTime,
+		KindData:  &BotReviewReactionData{PRNumber: 31, Owner: "o", Repo: "r"},
+	}
+	state.PendingReactions[botKey] = botPending
+
+	store := &reviewReconcileStore{deleteFingerprintErr: errors.New("delete failed")}
+	metrics := newBotReviewMetricsSpy()
+	tracker := &reviewTrackerStub{}
+	params := botReviewParams(store, &mockSCMAdapter{}, tracker)
+	params.BotReviewConfig = BotReviewReactionConfig{
+		Escalation:           "label",
+		EscalationLabel:      "needs-human",
+		MaxContinuationTurns: 5,
+		PollIntervalMS:       60000,
+	}
+
+	botData := botPending.KindData.(*BotReviewReactionData)
+
+	// Must not panic despite the delete error.
+	escalateBotReviewFailure(state, params, botPending, 5, botData, discardLogger(), context.Background(), metrics)
+	state.TrackerOpsWg.Wait()
+
+	if store.deleteFingerprintCalls != 1 {
+		t.Errorf("DeleteReactionFingerprint calls = %d, want 1", store.deleteFingerprintCalls)
+	}
+	if _, ok := state.PendingReactions[botKey]; ok {
+		t.Error("bot-review slot still present after delete-fingerprint error; want removed")
 	}
 }

--- a/internal/orchestrator/exit.go
+++ b/internal/orchestrator/exit.go
@@ -118,6 +118,11 @@ type HandleWorkerExitParams struct {
 	// is active for the current process. The enqueue path gates on
 	// this flag and the SCMAdapter being non-nil.
 	AutoMergeReactionConfigured bool
+
+	// BotReviewReactionConfigured marks whether the bot-review feature
+	// is active for the current process. The enqueue path gates on
+	// this flag and the SCMAdapter being non-nil.
+	BotReviewReactionConfigured bool
 }
 
 // HandleWorkerExit processes a worker's terminal outcome. It removes the
@@ -492,6 +497,45 @@ func HandleWorkerExit(state *State, workerResult WorkerResult, params HandleWork
 							LastSSHHost: workerResult.SSHHost,
 							CreatedAt:   nowReview,
 							KindData: &ReviewReactionData{
+								PRNumber: scm.PRNumber,
+								Owner:    scm.Owner,
+								Repo:     scm.Repo,
+								Branch:   scm.Branch,
+								SHA:      scm.SHA,
+							},
+							AgentKind:  entry.AgentKind,
+							RuleName:   entry.RuleName,
+							TemplateID: entry.TemplateID,
+						}
+					}
+				}
+			}
+		}
+
+		// Record a pending bot-review check when the SCM adapter is
+		// configured, bot-review is enabled, and the workspace has PR
+		// metadata with SCM repository identity. The bot-review enqueue
+		// is independent of the review-kind enqueue: both fire from the
+		// same worker exit.
+		if params.SCMAdapter != nil && params.BotReviewReactionConfigured && workerResult.WorkspacePath != "" {
+			if reactionEnqueueAllowed {
+				scm := workspace.ReadSCMMetadata(workerResult.WorkspacePath, log)
+				if scm.PRNumber > 0 && scm.Branch != "" && scm.Owner != "" && scm.Repo != "" {
+					nowBotReview := time.Now().UTC()
+					if params.NowFunc != nil {
+						nowBotReview = params.NowFunc().UTC()
+					}
+					rkey := ReactionKey(workerResult.IssueID, ReactionKindBotReview)
+					if _, exists := state.PendingReactions[rkey]; !exists {
+						state.PendingReactions[rkey] = &PendingReaction{
+							IssueID:     workerResult.IssueID,
+							Identifier:  workerResult.Identifier,
+							DisplayID:   entry.Issue.DisplayID,
+							Attempt:     normalizeAttempt(entry.RetryAttempt) + 1,
+							Kind:        ReactionKindBotReview,
+							LastSSHHost: workerResult.SSHHost,
+							CreatedAt:   nowBotReview,
+							KindData: &BotReviewReactionData{
 								PRNumber: scm.PRNumber,
 								Owner:    scm.Owner,
 								Repo:     scm.Repo,

--- a/internal/orchestrator/exit_test.go
+++ b/internal/orchestrator/exit_test.go
@@ -3843,3 +3843,305 @@ func TestHandleWorkerExit_AutoMergeEnqueueDoesNotOverwrite(t *testing.T) {
 		t.Errorf("AutoMergeReactionData.PRNumber = %d, want 77 (seeded value)", mergeData.PRNumber)
 	}
 }
+
+// --- Bot-review enqueue tests ---
+
+// TestHandleWorkerExit_BotReviewEnqueue_PopulatesPendingReaction verifies that
+// a complete PR metadata file causes HandleWorkerExit to populate the
+// bot-review PendingReaction on a normal exit when bot-review is configured.
+func TestHandleWorkerExit_BotReviewEnqueue_PopulatesPendingReaction(t *testing.T) {
+	t.Parallel()
+
+	wsPath := t.TempDir()
+	writePRSCMMetadata(t, wsPath, 55, "corp", "api", "feature/BR-1", "c0ffee")
+
+	store := &mockExitStore{}
+	state := exitState(t, "BR-1", nil)
+	params := defaultExitParams(t, store)
+	params.SCMAdapter = &scmAdapterStubExit{}
+	params.BotReviewReactionConfigured = true
+
+	HandleWorkerExit(state, WorkerResult{
+		IssueID:       "BR-1",
+		Identifier:    "BR-1-ident",
+		ExitKind:      WorkerExitNormal,
+		AgentAdapter:  "mock",
+		WorkspacePath: wsPath,
+	}, params)
+
+	rkey := ReactionKey("BR-1", ReactionKindBotReview)
+	pr, ok := state.PendingReactions[rkey]
+	if !ok {
+		t.Fatal("PendingReactions[BR-1:bot-review] missing after normal exit with PR metadata")
+	}
+	if pr.Kind != ReactionKindBotReview {
+		t.Errorf("PendingReaction.Kind = %q, want %q", pr.Kind, ReactionKindBotReview)
+	}
+	botData, ok := pr.KindData.(*BotReviewReactionData)
+	if !ok {
+		t.Fatalf("KindData type = %T, want *BotReviewReactionData", pr.KindData)
+	}
+	if botData.PRNumber != 55 {
+		t.Errorf("BotReviewReactionData.PRNumber = %d, want 55", botData.PRNumber)
+	}
+	if botData.Owner != "corp" {
+		t.Errorf("BotReviewReactionData.Owner = %q, want %q", botData.Owner, "corp")
+	}
+	if botData.Repo != "api" {
+		t.Errorf("BotReviewReactionData.Repo = %q, want %q", botData.Repo, "api")
+	}
+	if botData.Branch != "feature/BR-1" {
+		t.Errorf("BotReviewReactionData.Branch = %q, want %q", botData.Branch, "feature/BR-1")
+	}
+	if botData.SHA != "c0ffee" {
+		t.Errorf("BotReviewReactionData.SHA = %q, want %q", botData.SHA, "c0ffee")
+	}
+}
+
+// TestHandleWorkerExit_BotReviewEnqueueRequiresPRMetadata verifies that the
+// bot-review pending reaction is NOT created when the workspace SCM metadata
+// lacks any required field.
+func TestHandleWorkerExit_BotReviewEnqueueRequiresPRMetadata(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		content string
+	}{
+		{
+			name:    "missing pr_number",
+			content: `{"owner":"corp","repo":"api","branch":"feature/x","sha":"abc"}`,
+		},
+		{
+			name:    "missing owner",
+			content: `{"pr_number":10,"repo":"api","branch":"feature/x","sha":"abc"}`,
+		},
+		{
+			name:    "missing repo",
+			content: `{"pr_number":10,"owner":"corp","branch":"feature/x","sha":"abc"}`,
+		},
+		{
+			name:    "missing branch",
+			content: `{"pr_number":10,"owner":"corp","repo":"api","sha":"abc"}`,
+		},
+		{
+			name:    "empty scm file",
+			content: `{}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			wsPath := t.TempDir()
+			dotSortie := filepath.Join(wsPath, ".sortie")
+			if err := os.MkdirAll(dotSortie, 0o750); err != nil {
+				t.Fatalf("MkdirAll .sortie: %v", err)
+			}
+			if err := os.WriteFile(filepath.Join(dotSortie, "scm.json"), []byte(tt.content), 0o600); err != nil {
+				t.Fatalf("WriteFile scm.json: %v", err)
+			}
+
+			store := &mockExitStore{}
+			state := exitState(t, "BR-7", nil)
+			params := defaultExitParams(t, store)
+			params.SCMAdapter = &scmAdapterStubExit{}
+			params.BotReviewReactionConfigured = true
+
+			HandleWorkerExit(state, WorkerResult{
+				IssueID:       "BR-7",
+				Identifier:    "BR-7-ident",
+				ExitKind:      WorkerExitNormal,
+				AgentAdapter:  "mock",
+				WorkspacePath: wsPath,
+			}, params)
+
+			rkey := ReactionKey("BR-7", ReactionKindBotReview)
+			if _, ok := state.PendingReactions[rkey]; ok {
+				t.Errorf("PendingReactions[BR-7:bot-review] present despite incomplete SCM metadata (%s)", tt.name)
+			}
+		})
+	}
+}
+
+// TestHandleWorkerExit_BotReviewEnqueueRequiresConfigured verifies that the
+// bot-review pending reaction is NOT created when BotReviewReactionConfigured
+// is false, even with a valid SCM metadata file.
+func TestHandleWorkerExit_BotReviewEnqueueRequiresConfigured(t *testing.T) {
+	t.Parallel()
+
+	wsPath := t.TempDir()
+	writePRSCMMetadata(t, wsPath, 20, "corp", "api", "feature/BR-6", "deadbeef")
+
+	store := &mockExitStore{}
+	state := exitState(t, "BR-6", nil)
+	params := defaultExitParams(t, store)
+	params.SCMAdapter = &scmAdapterStubExit{}
+	params.BotReviewReactionConfigured = false
+
+	HandleWorkerExit(state, WorkerResult{
+		IssueID:       "BR-6",
+		Identifier:    "BR-6-ident",
+		ExitKind:      WorkerExitNormal,
+		AgentAdapter:  "mock",
+		WorkspacePath: wsPath,
+	}, params)
+
+	rkey := ReactionKey("BR-6", ReactionKindBotReview)
+	if _, ok := state.PendingReactions[rkey]; ok {
+		t.Error("PendingReactions[BR-6:bot-review] present despite BotReviewReactionConfigured=false")
+	}
+}
+
+// TestHandleWorkerExit_BotReviewEnqueueRequiresSCMAdapter verifies that the
+// bot-review pending reaction is NOT created when no SCM adapter is wired,
+// even when bot-review is configured.
+func TestHandleWorkerExit_BotReviewEnqueueRequiresSCMAdapter(t *testing.T) {
+	t.Parallel()
+
+	wsPath := t.TempDir()
+	writePRSCMMetadata(t, wsPath, 20, "corp", "api", "feature/BR-nil", "deadbeef")
+
+	store := &mockExitStore{}
+	state := exitState(t, "BR-nil", nil)
+	params := defaultExitParams(t, store)
+	params.SCMAdapter = nil
+	params.BotReviewReactionConfigured = true
+
+	HandleWorkerExit(state, WorkerResult{
+		IssueID:       "BR-nil",
+		Identifier:    "BR-nil-ident",
+		ExitKind:      WorkerExitNormal,
+		AgentAdapter:  "mock",
+		WorkspacePath: wsPath,
+	}, params)
+
+	rkey := ReactionKey("BR-nil", ReactionKindBotReview)
+	if _, ok := state.PendingReactions[rkey]; ok {
+		t.Error("PendingReactions[BR-nil:bot-review] present despite nil SCMAdapter")
+	}
+}
+
+// TestHandleWorkerExit_BotReviewEnqueueOnHandoff verifies that the bot-review
+// pending reaction is created after a successful handoff transition: the
+// reaction fires after the worker exits via the handoff path.
+func TestHandleWorkerExit_BotReviewEnqueueOnHandoff(t *testing.T) {
+	t.Parallel()
+
+	wsPath := t.TempDir()
+	writePRSCMMetadata(t, wsPath, 99, "corp", "api", "feature/BR-HO", "beefcafe")
+
+	store := &mockExitStore{}
+	tracker := &mockTrackerAdapter{}
+	state := exitStateWithIssue(t, "BR-HO", "In Progress")
+	params := defaultExitParams(t, store)
+	params.TrackerAdapter = tracker
+	params.HandoffState = "In Review"
+	params.ActiveStates = []string{"In Progress"}
+	params.SCMAdapter = &scmAdapterStubExit{}
+	params.BotReviewReactionConfigured = true
+
+	HandleWorkerExit(state, WorkerResult{
+		IssueID:       "BR-HO",
+		Identifier:    "BR-HO-ident",
+		ExitKind:      WorkerExitNormal,
+		AgentAdapter:  "mock",
+		WorkspacePath: wsPath,
+	}, params)
+
+	rkey := ReactionKey("BR-HO", ReactionKindBotReview)
+	pr, ok := state.PendingReactions[rkey]
+	if !ok {
+		t.Fatal("PendingReactions[BR-HO:bot-review] missing after handoff with PR metadata")
+	}
+	botData, ok := pr.KindData.(*BotReviewReactionData)
+	if !ok {
+		t.Fatalf("KindData type = %T, want *BotReviewReactionData", pr.KindData)
+	}
+	if botData.PRNumber != 99 {
+		t.Errorf("BotReviewReactionData.PRNumber = %d, want 99", botData.PRNumber)
+	}
+}
+
+// TestHandleWorkerExit_BotReviewEnqueueDoesNotOverwrite verifies the if-absent
+// guard: an existing bot-review pending reaction is not replaced on re-entry,
+// preserving in-progress debounce state.
+func TestHandleWorkerExit_BotReviewEnqueueDoesNotOverwrite(t *testing.T) {
+	t.Parallel()
+
+	wsPath := t.TempDir()
+	writePRSCMMetadata(t, wsPath, 10, "corp", "api", "feature/BR-DUP", "sha1")
+
+	store := &mockExitStore{}
+	state := exitState(t, "BR-DUP", nil)
+	params := defaultExitParams(t, store)
+	params.SCMAdapter = &scmAdapterStubExit{}
+	params.BotReviewReactionConfigured = true
+
+	existingEntry := &PendingReaction{
+		IssueID:    "BR-DUP",
+		Identifier: "BR-DUP-ident",
+		Kind:       ReactionKindBotReview,
+		KindData: &BotReviewReactionData{
+			PRNumber: 77,
+			Owner:    "original",
+			Repo:     "original",
+			Branch:   "original-branch",
+		},
+	}
+	rkey := ReactionKey("BR-DUP", ReactionKindBotReview)
+	state.PendingReactions[rkey] = existingEntry
+
+	HandleWorkerExit(state, WorkerResult{
+		IssueID:       "BR-DUP",
+		Identifier:    "BR-DUP-ident",
+		ExitKind:      WorkerExitNormal,
+		AgentAdapter:  "mock",
+		WorkspacePath: wsPath,
+	}, params)
+
+	got := state.PendingReactions[rkey]
+	if got != existingEntry {
+		t.Error("PendingReactions[BR-DUP:bot-review] was replaced; want existing entry preserved")
+	}
+	botData, ok := got.KindData.(*BotReviewReactionData)
+	if !ok {
+		t.Fatalf("KindData type = %T, want *BotReviewReactionData", got.KindData)
+	}
+	if botData.PRNumber != 77 {
+		t.Errorf("BotReviewReactionData.PRNumber = %d, want 77 (seeded value)", botData.PRNumber)
+	}
+}
+
+// TestHandleWorkerExit_BotReviewEnqueueSkippedWhenClaimReleased verifies that
+// the bot-review enqueue is gated on reactionEnqueueAllowed: a soft-stop
+// releases the claim before the enqueue check, so no pending reaction is
+// created even with complete PR metadata.
+func TestHandleWorkerExit_BotReviewEnqueueSkippedWhenClaimReleased(t *testing.T) {
+	t.Parallel()
+
+	wsPath := t.TempDir()
+	writePRSCMMetadata(t, wsPath, 12, "corp", "api", "feature/BR-SOFT", "sha999")
+
+	store := &mockExitStore{}
+	state := exitState(t, "BR-SOFT", nil)
+	params := defaultExitParams(t, store)
+	params.SCMAdapter = &scmAdapterStubExit{}
+	params.BotReviewReactionConfigured = true
+
+	HandleWorkerExit(state, WorkerResult{
+		IssueID:        "BR-SOFT",
+		Identifier:     "BR-SOFT-ident",
+		ExitKind:       WorkerExitNormal,
+		AgentAdapter:   "mock",
+		WorkspacePath:  wsPath,
+		SoftStop:       true,
+		SoftStopReason: "blocked",
+	}, params)
+
+	rkey := ReactionKey("BR-SOFT", ReactionKindBotReview)
+	if _, ok := state.PendingReactions[rkey]; ok {
+		t.Error("PendingReactions[BR-SOFT:bot-review] present after soft-stop; want absent (claim released before enqueue)")
+	}
+}

--- a/internal/orchestrator/exit_test.go
+++ b/internal/orchestrator/exit_test.go
@@ -3201,6 +3201,10 @@ func (s *scmAdapterStubExit) FetchPendingReviews(_ context.Context, _ int, _, _ 
 	panic("FetchPendingReviews must not be called by HandleWorkerExit")
 }
 
+func (s *scmAdapterStubExit) FetchBotReviewComments(_ context.Context, _ int, _, _ string, _ []string) ([]domain.ReviewComment, error) {
+	panic("FetchBotReviewComments must not be called by HandleWorkerExit")
+}
+
 func (s *scmAdapterStubExit) GetReviewDecision(_ context.Context, _ int, _, _ string) (domain.ReviewDecision, error) {
 	panic("GetReviewDecision must not be called by HandleWorkerExit")
 }

--- a/internal/orchestrator/metrics_test.go
+++ b/internal/orchestrator/metrics_test.go
@@ -199,6 +199,10 @@ func (s *spyMetrics) IncReviewChecks(_ string) {}
 
 func (s *spyMetrics) IncReviewEscalations(_ string) {}
 
+func (s *spyMetrics) IncBotReviewChecks(_ string) {}
+
+func (s *spyMetrics) IncBotReviewEscalations(_ string) {}
+
 func (s *spyMetrics) IncAutoMergeReactions(_ string) {}
 
 func (s *spyMetrics) IncDispatchRuleMatch(_ string, _ string) {}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -122,6 +122,15 @@ type OrchestratorParams struct {
 	// HandleWorkerExitParams, and the recovery params.
 	AutoMergeReactionConfigured bool
 
+	// BotReviewConfig holds validated bot-review reaction
+	// configuration. Zero value when BotReviewConfigured is false.
+	BotReviewConfig BotReviewReactionConfig
+
+	// BotReviewConfigured marks whether the bot-review feature is
+	// active for this process. Threaded into ReconcileParams,
+	// HandleWorkerExitParams, and the recovery params.
+	BotReviewConfigured bool
+
 	// AgentAdapterByKind resolves the agent adapter for the given
 	// kind. Constructed once at startup from the eagerly-built
 	// per-kind adapter cache. When nil, the orchestrator falls back
@@ -170,6 +179,8 @@ type Orchestrator struct {
 	reviewConfig                ReviewReactionConfig
 	autoMergeConfig             AutoMergeReactionConfig
 	autoMergeReactionConfigured bool
+	botReviewConfig             BotReviewReactionConfig
+	botReviewReactionConfigured bool
 
 	// sshStrictHostKeyChecking is the current effective OpenSSH
 	// StrictHostKeyChecking value. Written by handleTick on every
@@ -274,6 +285,8 @@ func NewOrchestrator(params OrchestratorParams) *Orchestrator {
 		reviewConfig:                params.ReviewConfig,
 		autoMergeConfig:             params.AutoMergeConfig,
 		autoMergeReactionConfigured: params.AutoMergeReactionConfigured,
+		botReviewConfig:             params.BotReviewConfig,
+		botReviewReactionConfigured: params.BotReviewConfigured,
 	}
 	// Startup preflight must have passed for the orchestrator to be
 	// constructed, so the initial value is true.
@@ -328,6 +341,7 @@ func (o *Orchestrator) Run(ctx context.Context) {
 				CIProvider:                  o.ciProvider,
 				SCMAdapter:                  o.scmAdapter,
 				AutoMergeReactionConfigured: o.autoMergeReactionConfigured,
+				BotReviewReactionConfigured: o.botReviewReactionConfigured,
 			})
 			o.updateGauges(time.Now())
 			o.notifyObservers()
@@ -467,6 +481,9 @@ func (o *Orchestrator) handleTick(ctx context.Context) {
 		AutoMergeConfig:             o.autoMergeConfig,
 		AutoMergePendingTTL:         autoMergePendingDefaultTTL,
 		AutoMergeReactionConfigured: o.autoMergeReactionConfigured,
+		BotReviewConfig:             o.botReviewConfig,
+		BotReviewPendingTTL:         reviewPendingDefaultTTL,
+		BotReviewConfigured:         o.botReviewReactionConfigured,
 	})
 
 	// Sweep terminal workspaces periodically to catch issues that
@@ -878,6 +895,7 @@ func (o *Orchestrator) drainRunningWorkers() {
 				CIProvider:                  o.ciProvider,
 				SCMAdapter:                  o.scmAdapter,
 				AutoMergeReactionConfigured: o.autoMergeReactionConfigured,
+				BotReviewReactionConfigured: o.botReviewReactionConfigured,
 			})
 			o.updateGauges(time.Now())
 			o.notifyObservers()

--- a/internal/orchestrator/reconcile.go
+++ b/internal/orchestrator/reconcile.go
@@ -117,6 +117,21 @@ type ReconcileParams struct {
 	// is active for the current process. Reconcile, enqueue, and
 	// recovery paths gate on this flag.
 	AutoMergeReactionConfigured bool
+
+	// BotReviewConfig holds bot-review reaction configuration. Only read
+	// when BotReviewConfigured is true.
+	BotReviewConfig BotReviewReactionConfig
+
+	// BotReviewPendingTTL is the maximum age of a bot-review
+	// PendingReaction entry before it is dropped. Zero disables TTL
+	// enforcement.
+	BotReviewPendingTTL time.Duration
+
+	// BotReviewConfigured marks whether the bot-review feature is active
+	// for the current process. The reconcile pass gates on this flag
+	// independently of SCMAdapter presence, since a single SCM adapter
+	// may be shared with the review and auto-merge kinds.
+	BotReviewConfigured bool
 }
 
 // ReconcileRunningIssues detects stalled workers and refreshes tracker
@@ -164,6 +179,11 @@ func ReconcileRunningIssues(state *State, params ReconcileParams) {
 
 	// Poll review comments for issues with pending review reactions.
 	reconcileReviewComments(state, params, log, ctx, metrics)
+
+	// Poll bot-authored review comments for issues with pending
+	// bot-review reactions. Runs after the human review pass and before
+	// auto-merge.
+	reconcileBotReviewComments(state, params, log, ctx, metrics)
 
 	// Poll auto-merge preconditions for issues with pending merge
 	// reactions. Runs LAST so the CI and review reconcile passes have

--- a/internal/orchestrator/recovery.go
+++ b/internal/orchestrator/recovery.go
@@ -91,6 +91,7 @@ type PendingReactionRecoveryParams struct {
 	CIProvider                  domain.CIStatusProvider
 	SCMAdapter                  domain.SCMAdapter
 	AutoMergeReactionConfigured bool
+	BotReviewReactionConfigured bool
 	RecoveryLookback            time.Duration
 	MaxCandidates               int
 	NowFunc                     func() time.Time
@@ -106,6 +107,7 @@ type PendingReactionRecoveryResult struct {
 	ReviewRecovered    int
 	CIRecovered        int
 	AutoMergeRecovered int
+	BotReviewRecovered int
 	StaleSkipped       int
 	Skipped            int
 }
@@ -306,6 +308,32 @@ func recoverPendingReactionKinds(
 				TemplateID: run.TemplateID,
 			}
 			outcome.ReviewRecovered++
+			added++
+		}
+	}
+
+	if params.BotReviewReactionConfigured && meta.PRNumber > 0 && meta.Owner != "" && meta.Repo != "" && meta.Branch != "" {
+		key := ReactionKey(run.IssueID, ReactionKindBotReview)
+		if _, exists := state.PendingReactions[key]; !exists {
+			state.PendingReactions[key] = &PendingReaction{
+				IssueID:    run.IssueID,
+				Identifier: run.Identifier,
+				DisplayID:  run.DisplayID,
+				Attempt:    run.Attempt,
+				Kind:       ReactionKindBotReview,
+				CreatedAt:  now,
+				KindData: &BotReviewReactionData{
+					PRNumber: meta.PRNumber,
+					Owner:    meta.Owner,
+					Repo:     meta.Repo,
+					Branch:   meta.Branch,
+					SHA:      meta.SHA,
+				},
+				AgentKind:  run.AgentAdapter,
+				RuleName:   run.RuleName,
+				TemplateID: run.TemplateID,
+			}
+			outcome.BotReviewRecovered++
 			added++
 		}
 	}

--- a/internal/orchestrator/recovery_test.go
+++ b/internal/orchestrator/recovery_test.go
@@ -508,6 +508,10 @@ func (p *panicSCMAdapter) FetchPendingReviews(_ context.Context, _ int, _, _ str
 	panic("FetchPendingReviews must not be called during RecoverPendingReactions")
 }
 
+func (p *panicSCMAdapter) FetchBotReviewComments(_ context.Context, _ int, _, _ string, _ []string) ([]domain.ReviewComment, error) {
+	panic("FetchBotReviewComments must not be called during RecoverPendingReactions")
+}
+
 func (p *panicSCMAdapter) GetReviewDecision(_ context.Context, _ int, _, _ string) (domain.ReviewDecision, error) {
 	panic("GetReviewDecision must not be called during RecoverPendingReactions")
 }
@@ -545,6 +549,10 @@ var _ domain.SCMAdapter = (*stubSCMForRecovery)(nil)
 
 func (s *stubSCMForRecovery) FetchPendingReviews(_ context.Context, _ int, _, _ string) ([]domain.ReviewComment, error) {
 	return nil, nil
+}
+
+func (s *stubSCMForRecovery) FetchBotReviewComments(_ context.Context, _ int, _, _ string, _ []string) ([]domain.ReviewComment, error) {
+	return []domain.ReviewComment{}, nil
 }
 
 func (s *stubSCMForRecovery) GetReviewDecision(_ context.Context, _ int, _, _ string) (domain.ReviewDecision, error) {
@@ -1323,5 +1331,253 @@ func TestRecoverPendingReactions_SkipsAutoMergeWhenMissingPRMetadata(t *testing.
 	rkey := ReactionKey("ISS-AM3", ReactionKindAutoMerge)
 	if _, ok := state.PendingReactions[rkey]; ok {
 		t.Error("PendingReactions[ISS-AM3:merge] present despite missing PR metadata")
+	}
+}
+
+// --- bot-review startup recovery tests (6.6 → R11) ---
+
+// TestRecoverPendingReactions_RecreatesBotReviewAfterRestart verifies R11:
+// a run_history row plus SCMMetadata with full PR identity and
+// BotReviewReactionConfigured=true reconstructs a bot-review PendingReaction
+// and increments BotReviewRecovered.
+func TestRecoverPendingReactions_RecreatesBotReviewAfterRestart(t *testing.T) {
+	t.Parallel()
+
+	wsRoot := t.TempDir()
+	writeRecoverySCM(t, wsRoot, "PROJ-BR1", domain.SCMMetadata{
+		Branch:   "feature/bot-fix",
+		SHA:      "deadcafe",
+		PushedAt: freshSCMTime(1),
+		PRNumber: 55,
+		Owner:    "botowner",
+		Repo:     "botrepo",
+	})
+
+	tracker := &recoveryTrackerStub{states: map[string]string{"ISS-BR1": "In Review"}}
+	state := NewState(5000, 4, nil, AgentTotals{})
+	run := freshRun("ISS-BR1", "PROJ-BR1", "botowner/botrepo#55", 3)
+	params := defaultRecoveryParams(wsRoot, tracker)
+	params.BotReviewReactionConfigured = true
+
+	result, err := RecoverPendingReactions(context.Background(), state, []persistence.RunHistory{run}, params)
+	if err != nil {
+		t.Fatalf("RecoverPendingReactions: %v", err)
+	}
+	if result.BotReviewRecovered != 1 {
+		t.Errorf("BotReviewRecovered = %d, want 1", result.BotReviewRecovered)
+	}
+
+	rkey := ReactionKey("ISS-BR1", ReactionKindBotReview)
+	pr, ok := state.PendingReactions[rkey]
+	if !ok {
+		t.Fatalf("PendingReactions[%q] missing, want present", rkey)
+	}
+	if pr.Kind != ReactionKindBotReview {
+		t.Errorf("PendingReaction.Kind = %q, want %q", pr.Kind, ReactionKindBotReview)
+	}
+	if pr.IssueID != "ISS-BR1" {
+		t.Errorf("PendingReaction.IssueID = %q, want %q", pr.IssueID, "ISS-BR1")
+	}
+	if pr.Attempt != 3 {
+		t.Errorf("PendingReaction.Attempt = %d, want 3", pr.Attempt)
+	}
+	brd, ok := pr.KindData.(*BotReviewReactionData)
+	if !ok {
+		t.Fatalf("KindData type = %T, want *BotReviewReactionData", pr.KindData)
+	}
+	if brd.PRNumber != 55 {
+		t.Errorf("BotReviewReactionData.PRNumber = %d, want 55", brd.PRNumber)
+	}
+	if brd.Owner != "botowner" {
+		t.Errorf("BotReviewReactionData.Owner = %q, want %q", brd.Owner, "botowner")
+	}
+	if brd.Repo != "botrepo" {
+		t.Errorf("BotReviewReactionData.Repo = %q, want %q", brd.Repo, "botrepo")
+	}
+	if brd.Branch != "feature/bot-fix" {
+		t.Errorf("BotReviewReactionData.Branch = %q, want %q", brd.Branch, "feature/bot-fix")
+	}
+	if brd.SHA != "deadcafe" {
+		t.Errorf("BotReviewReactionData.SHA = %q, want %q", brd.SHA, "deadcafe")
+	}
+	// Issue must not be claimed.
+	if _, claimed := state.Claimed["ISS-BR1"]; claimed {
+		t.Error("ISS-BR1 found in state.Claimed after recovery, want not claimed")
+	}
+}
+
+// TestRecoverPendingReactions_BotReviewNotRecoveredWhenFlagFalse verifies R11:
+// BotReviewReactionConfigured=false → no bot-review entry is reconstructed, even
+// with full PR metadata present.
+func TestRecoverPendingReactions_BotReviewNotRecoveredWhenFlagFalse(t *testing.T) {
+	t.Parallel()
+
+	wsRoot := t.TempDir()
+	writeRecoverySCM(t, wsRoot, "PROJ-BR2", domain.SCMMetadata{
+		Branch:   "feature/bot-disabled",
+		SHA:      "abc",
+		PushedAt: freshSCMTime(1),
+		PRNumber: 10,
+		Owner:    "o",
+		Repo:     "r",
+	})
+
+	tracker := &recoveryTrackerStub{states: map[string]string{"ISS-BR2": "In Review"}}
+	state := NewState(5000, 4, nil, AgentTotals{})
+	run := freshRun("ISS-BR2", "PROJ-BR2", "", 1)
+	params := defaultRecoveryParams(wsRoot, tracker)
+	params.BotReviewReactionConfigured = false // not configured
+
+	result, err := RecoverPendingReactions(context.Background(), state, []persistence.RunHistory{run}, params)
+	if err != nil {
+		t.Fatalf("RecoverPendingReactions: %v", err)
+	}
+	if result.BotReviewRecovered != 0 {
+		t.Errorf("BotReviewRecovered = %d, want 0 when flag is false", result.BotReviewRecovered)
+	}
+
+	rkey := ReactionKey("ISS-BR2", ReactionKindBotReview)
+	if _, ok := state.PendingReactions[rkey]; ok {
+		t.Error("bot-review PendingReactions entry created with BotReviewReactionConfigured=false; want absent")
+	}
+}
+
+// TestRecoverPendingReactions_BotReviewMissingPRNumber verifies R11: a row missing
+// PRNumber (zero) recovers no bot-review entry even when BotReviewReactionConfigured=true.
+func TestRecoverPendingReactions_BotReviewMissingPRNumber(t *testing.T) {
+	t.Parallel()
+
+	wsRoot := t.TempDir()
+	writeRecoverySCM(t, wsRoot, "PROJ-BRNPR", domain.SCMMetadata{
+		Branch:   "feature/no-pr",
+		SHA:      "abc",
+		PushedAt: freshSCMTime(1),
+		// PRNumber intentionally zero.
+		Owner: "o",
+		Repo:  "r",
+	})
+
+	tracker := &recoveryTrackerStub{states: map[string]string{"ISS-BRNPR": "In Review"}}
+	state := NewState(5000, 4, nil, AgentTotals{})
+	run := freshRun("ISS-BRNPR", "PROJ-BRNPR", "", 1)
+	params := defaultRecoveryParams(wsRoot, tracker)
+	params.BotReviewReactionConfigured = true
+
+	result, err := RecoverPendingReactions(context.Background(), state, []persistence.RunHistory{run}, params)
+	if err != nil {
+		t.Fatalf("RecoverPendingReactions: %v", err)
+	}
+	if result.BotReviewRecovered != 0 {
+		t.Errorf("BotReviewRecovered = %d, want 0 for missing PRNumber", result.BotReviewRecovered)
+	}
+
+	rkey := ReactionKey("ISS-BRNPR", ReactionKindBotReview)
+	if _, ok := state.PendingReactions[rkey]; ok {
+		t.Error("bot-review PendingReactions entry created with zero PRNumber; want absent")
+	}
+}
+
+// TestRecoverPendingReactions_BotReviewMissingOwner verifies R11: a row missing
+// Owner recovers no bot-review entry.
+func TestRecoverPendingReactions_BotReviewMissingOwner(t *testing.T) {
+	t.Parallel()
+
+	wsRoot := t.TempDir()
+	writeRecoverySCM(t, wsRoot, "PROJ-BRNOWN", domain.SCMMetadata{
+		Branch:   "feature/no-owner",
+		SHA:      "abc",
+		PushedAt: freshSCMTime(1),
+		PRNumber: 5,
+		// Owner intentionally empty.
+		Repo: "r",
+	})
+
+	tracker := &recoveryTrackerStub{states: map[string]string{"ISS-BRNOWN": "In Review"}}
+	state := NewState(5000, 4, nil, AgentTotals{})
+	run := freshRun("ISS-BRNOWN", "PROJ-BRNOWN", "", 1)
+	params := defaultRecoveryParams(wsRoot, tracker)
+	params.BotReviewReactionConfigured = true
+
+	result, err := RecoverPendingReactions(context.Background(), state, []persistence.RunHistory{run}, params)
+	if err != nil {
+		t.Fatalf("RecoverPendingReactions: %v", err)
+	}
+	if result.BotReviewRecovered != 0 {
+		t.Errorf("BotReviewRecovered = %d, want 0 for missing Owner", result.BotReviewRecovered)
+	}
+
+	rkey := ReactionKey("ISS-BRNOWN", ReactionKindBotReview)
+	if _, ok := state.PendingReactions[rkey]; ok {
+		t.Error("bot-review PendingReactions entry created with empty Owner; want absent")
+	}
+}
+
+// TestRecoverPendingReactions_BotReviewMissingRepo verifies R11: a row missing
+// Repo recovers no bot-review entry.
+func TestRecoverPendingReactions_BotReviewMissingRepo(t *testing.T) {
+	t.Parallel()
+
+	wsRoot := t.TempDir()
+	writeRecoverySCM(t, wsRoot, "PROJ-BRNREP", domain.SCMMetadata{
+		Branch:   "feature/no-repo",
+		SHA:      "abc",
+		PushedAt: freshSCMTime(1),
+		PRNumber: 5,
+		Owner:    "o",
+		// Repo intentionally empty.
+	})
+
+	tracker := &recoveryTrackerStub{states: map[string]string{"ISS-BRNREP": "In Review"}}
+	state := NewState(5000, 4, nil, AgentTotals{})
+	run := freshRun("ISS-BRNREP", "PROJ-BRNREP", "", 1)
+	params := defaultRecoveryParams(wsRoot, tracker)
+	params.BotReviewReactionConfigured = true
+
+	result, err := RecoverPendingReactions(context.Background(), state, []persistence.RunHistory{run}, params)
+	if err != nil {
+		t.Fatalf("RecoverPendingReactions: %v", err)
+	}
+	if result.BotReviewRecovered != 0 {
+		t.Errorf("BotReviewRecovered = %d, want 0 for missing Repo", result.BotReviewRecovered)
+	}
+
+	rkey := ReactionKey("ISS-BRNREP", ReactionKindBotReview)
+	if _, ok := state.PendingReactions[rkey]; ok {
+		t.Error("bot-review PendingReactions entry created with empty Repo; want absent")
+	}
+}
+
+// TestRecoverPendingReactions_BotReviewMissingBranch verifies R11: a row missing
+// Branch recovers no bot-review entry.
+func TestRecoverPendingReactions_BotReviewMissingBranch(t *testing.T) {
+	t.Parallel()
+
+	wsRoot := t.TempDir()
+	writeRecoverySCM(t, wsRoot, "PROJ-BRNBRA", domain.SCMMetadata{
+		// Branch intentionally empty.
+		SHA:      "abc",
+		PushedAt: freshSCMTime(1),
+		PRNumber: 5,
+		Owner:    "o",
+		Repo:     "r",
+	})
+
+	tracker := &recoveryTrackerStub{states: map[string]string{"ISS-BRNBRA": "In Review"}}
+	state := NewState(5000, 4, nil, AgentTotals{})
+	run := freshRun("ISS-BRNBRA", "PROJ-BRNBRA", "", 1)
+	params := defaultRecoveryParams(wsRoot, tracker)
+	params.BotReviewReactionConfigured = true
+
+	result, err := RecoverPendingReactions(context.Background(), state, []persistence.RunHistory{run}, params)
+	if err != nil {
+		t.Fatalf("RecoverPendingReactions: %v", err)
+	}
+	if result.BotReviewRecovered != 0 {
+		t.Errorf("BotReviewRecovered = %d, want 0 for missing Branch", result.BotReviewRecovered)
+	}
+
+	rkey := ReactionKey("ISS-BRNBRA", ReactionKindBotReview)
+	if _, ok := state.PendingReactions[rkey]; ok {
+		t.Error("bot-review PendingReactions entry created with empty Branch; want absent")
 	}
 }

--- a/internal/orchestrator/review_reconcile.go
+++ b/internal/orchestrator/review_reconcile.go
@@ -90,7 +90,7 @@ func reconcileReviewComments(state *State, params ReconcileParams, log *slog.Log
 		comments, err := params.SCMAdapter.FetchPendingReviews(ctx, reviewData.PRNumber, reviewData.Owner, reviewData.Repo)
 		if err != nil {
 			pending.PendingAttempts++
-			delay := max(computeReviewPendingDelay(pending.PendingAttempts), pollInterval)
+			delay := max(computeReactionPendingDelay(pending.PendingAttempts), pollInterval)
 			pending.PendingRetryAt = now.Add(delay)
 			state.PendingReactions[key] = pending
 			entryLog.Warn("review fetch failed, retrying with backoff",
@@ -191,12 +191,13 @@ func reconcileReviewComments(state *State, params ReconcileParams, log *slog.Log
 	}
 }
 
-// computeReviewPendingDelay returns the backoff delay for a review
+// computeReactionPendingDelay returns the backoff delay for a reaction
 // pending re-check at the given attempt count. Attempt 0 returns zero
 // (immediate). Each subsequent attempt returns
 // reviewPendingBackoffBase * 2^attempts, capped at
-// [reviewPendingBackoffCap].
-func computeReviewPendingDelay(attempts int) time.Duration {
+// [reviewPendingBackoffCap]. Shared by the review and bot-review
+// reconcile passes for fetch-error backoff.
+func computeReactionPendingDelay(attempts int) time.Duration {
 	if attempts <= 0 {
 		return 0
 	}

--- a/internal/orchestrator/review_reconcile_test.go
+++ b/internal/orchestrator/review_reconcile_test.go
@@ -18,6 +18,10 @@ type mockSCMAdapter struct {
 	comments []domain.ReviewComment
 	err      error
 	calls    int
+
+	botComments []domain.ReviewComment
+	botErr      error
+	botCalls    int
 }
 
 var _ domain.SCMAdapter = (*mockSCMAdapter)(nil)
@@ -28,6 +32,14 @@ func (m *mockSCMAdapter) FetchPendingReviews(_ context.Context, _ int, _, _ stri
 		return nil, m.err
 	}
 	return m.comments, nil
+}
+
+func (m *mockSCMAdapter) FetchBotReviewComments(_ context.Context, _ int, _, _ string, _ []string) ([]domain.ReviewComment, error) {
+	m.botCalls++
+	if m.botErr != nil {
+		return nil, m.botErr
+	}
+	return m.botComments, nil
 }
 
 func (m *mockSCMAdapter) GetReviewDecision(_ context.Context, _ int, _, _ string) (domain.ReviewDecision, error) {
@@ -973,9 +985,9 @@ func TestComputeReviewPendingDelay(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			got := computeReviewPendingDelay(tt.attempts)
+			got := computeReactionPendingDelay(tt.attempts)
 			if got < tt.wantMin || got > tt.wantMax {
-				t.Errorf("computeReviewPendingDelay(%d) = %v, want in [%v, %v]",
+				t.Errorf("computeReactionPendingDelay(%d) = %v, want in [%v, %v]",
 					tt.attempts, got, tt.wantMin, tt.wantMax)
 			}
 		})

--- a/internal/orchestrator/review_reconcile_test.go
+++ b/internal/orchestrator/review_reconcile_test.go
@@ -81,6 +81,7 @@ type reviewReconcileStore struct {
 	getFingerprintErr        error
 	upsertFingerprintErr     error
 	markDispatchedErr        error
+	deleteFingerprintErr     error
 }
 
 var _ ReconcileStore = (*reviewReconcileStore)(nil)
@@ -121,7 +122,7 @@ func (s *reviewReconcileStore) MarkReactionDispatched(_ context.Context, _, _ st
 
 func (s *reviewReconcileStore) DeleteReactionFingerprint(_ context.Context, _, _ string) error {
 	s.deleteFingerprintCalls++
-	return nil
+	return s.deleteFingerprintErr
 }
 
 // reviewTrackerStub satisfies domain.TrackerAdapter for escalation tests.

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -319,6 +319,12 @@ const ReactionKindCI = "ci"
 // reactions.
 const ReactionKindReview = "review"
 
+// ReactionKindBotReview is the reaction kind constant for automated
+// review bot PR comment reactions. The user-facing YAML key is
+// reactions.bot_review; the short form lives here as the runtime and
+// persisted discriminator.
+const ReactionKindBotReview = "bot-review"
+
 // ReactionKindAutoMerge is the reaction kind constant for auto-merge
 // reactions. The user-facing YAML key is reactions.auto_merge; the
 // short form lives here as the runtime and persisted discriminator.
@@ -332,7 +338,7 @@ const AutoMergePreflightRetryDelay time.Duration = 5 * time.Minute
 
 func isKnownReactionKind(kind string) bool {
 	switch kind {
-	case ReactionKindCI, ReactionKindReview, ReactionKindAutoMerge:
+	case ReactionKindCI, ReactionKindReview, ReactionKindBotReview, ReactionKindAutoMerge:
 		return true
 	default:
 		return false
@@ -453,6 +459,41 @@ type ReviewReactionConfig struct {
 	PollIntervalMS       int
 	DebounceMS           int
 	MaxContinuationTurns int
+}
+
+// BotReviewReactionData holds bot-review-specific fields for a pending
+// bot-review reaction. Stored in [PendingReaction.KindData] for reactions
+// with Kind == [ReactionKindBotReview]. Owner, Repo, Branch, and SHA are
+// sourced from [domain.SCMMetadata] (written by the agent to scm.json),
+// never from the tracker project configuration.
+//
+// Unlike [ReviewReactionData], there is no debounce timestamp: bot-review
+// dispatches immediately.
+type BotReviewReactionData struct {
+	// PRNumber is the pull request number.
+	PRNumber int
+
+	// Owner is the repository owner.
+	Owner string
+
+	// Repo is the repository name.
+	Repo string
+
+	// Branch is the git branch name (PR head).
+	Branch string
+
+	// SHA is the git commit SHA at the last known push.
+	SHA string
+}
+
+// BotReviewReactionConfig holds validated bot-review-specific
+// configuration extracted from [config.ReactionConfig] at startup.
+type BotReviewReactionConfig struct {
+	Escalation           string
+	EscalationLabel      string
+	PollIntervalMS       int
+	MaxContinuationTurns int
+	BotUsernames         []string
 }
 
 // AutoMergeReactionData holds auto-merge-specific fields for a pending
@@ -942,6 +983,74 @@ func BuildReviewReactionConfig(rc config.ReactionConfig) (ReviewReactionConfig, 
 			return ReviewReactionConfig{}, fmt.Errorf("max_continuation_turns must be positive, got %d", n)
 		}
 		cfg.MaxContinuationTurns = n
+	}
+
+	return cfg, nil
+}
+
+// BuildBotReviewReactionConfig extracts and validates bot-review-specific
+// configuration from a [config.ReactionConfig]. Returns an error for
+// invalid values.
+//
+// The poll-interval and continuation-turn defaults differ from
+// [BuildReviewReactionConfig]: bot comments arrive in bulk on push and are
+// dispatched immediately, so the poll cadence is tighter and the retry
+// budget larger. No debounce field is read.
+func BuildBotReviewReactionConfig(rc config.ReactionConfig) (BotReviewReactionConfig, error) {
+	cfg := BotReviewReactionConfig{
+		Escalation:           rc.Escalation,
+		EscalationLabel:      rc.EscalationLabel,
+		PollIntervalMS:       60000,
+		MaxContinuationTurns: 5,
+	}
+
+	if cfg.Escalation == "" {
+		cfg.Escalation = "label"
+	}
+	if cfg.Escalation != "label" && cfg.Escalation != "comment" {
+		return BotReviewReactionConfig{}, fmt.Errorf("invalid escalation %q: must be \"label\" or \"comment\"", cfg.Escalation)
+	}
+
+	if cfg.EscalationLabel == "" {
+		cfg.EscalationLabel = "needs-human"
+	}
+
+	if v, ok := rc.Extra["poll_interval_ms"]; ok {
+		n, err := toInt(v)
+		if err != nil {
+			return BotReviewReactionConfig{}, fmt.Errorf("invalid poll_interval_ms: %w", err)
+		}
+		if n < 30000 {
+			return BotReviewReactionConfig{}, fmt.Errorf("poll_interval_ms must be >= 30000, got %d", n)
+		}
+		cfg.PollIntervalMS = n
+	}
+
+	if v, ok := rc.Extra["max_continuation_turns"]; ok {
+		n, err := toInt(v)
+		if err != nil {
+			return BotReviewReactionConfig{}, fmt.Errorf("invalid max_continuation_turns: %w", err)
+		}
+		if n <= 0 {
+			return BotReviewReactionConfig{}, fmt.Errorf("max_continuation_turns must be positive, got %d", n)
+		}
+		cfg.MaxContinuationTurns = n
+	}
+
+	if v, ok := rc.Extra["bot_usernames"]; ok {
+		list, lok := v.([]any)
+		if !lok {
+			return BotReviewReactionConfig{}, fmt.Errorf("invalid bot_usernames: expected list, got %T", v)
+		}
+		names := make([]string, 0, len(list))
+		for i, elem := range list {
+			s, sok := elem.(string)
+			if !sok {
+				return BotReviewReactionConfig{}, fmt.Errorf("invalid bot_usernames[%d]: expected string, got %T", i, elem)
+			}
+			names = append(names, s)
+		}
+		cfg.BotUsernames = names
 	}
 
 	return cfg, nil

--- a/internal/prompt/prompt.go
+++ b/internal/prompt/prompt.go
@@ -126,7 +126,7 @@ type RenderOption func(m map[string]any)
 // reaction continuation context. Each key receives a nil default in
 // [Template.Render] so templates using missingkey=error do not reject
 // references to absent reaction types.
-var continuationKeys = []string{"ci_failure", "review_comments"}
+var continuationKeys = []string{"ci_failure", "review_comments", "bot_review_comments"}
 
 // isContinuationKey reports whether key is a registered continuation
 // template variable name.
@@ -153,9 +153,10 @@ func WithContinuationContext(data map[string]any) RenderOption {
 // Render executes the template with the given inputs and returns the
 // rendered prompt string. The data map contains the top-level keys
 // "issue", "attempt", and "run", plus every key in [continuationKeys]
-// (currently "ci_failure", "review_comments"). Continuation keys default
-// to nil when no [RenderOption] overrides them, ensuring missingkey=error
-// does not reject templates that reference these fields.
+// (currently "ci_failure", "review_comments", "bot_review_comments").
+// Continuation keys default to nil when no [RenderOption] overrides them,
+// ensuring missingkey=error does not reject templates that reference these
+// fields.
 // Returns a [*TemplateError] with Kind [ErrTemplateRender] on failure,
 // with line numbers adjusted to WORKFLOW.md-relative positions.
 func (t *Template) Render(issue map[string]any, attempt any, run RunContext, opts ...RenderOption) (string, error) {

--- a/internal/prompt/prompt_test.go
+++ b/internal/prompt/prompt_test.go
@@ -479,6 +479,93 @@ func TestRender_Concurrent(t *testing.T) {
 	wg.Wait()
 }
 
+func TestRender_BotReviewComments(t *testing.T) {
+	t.Parallel()
+
+	issue := map[string]any{"title": "Fix linter findings"}
+	run := RunContext{TurnNumber: 2, MaxTurns: 5, IsContinuation: true}
+
+	botComments := []map[string]any{
+		{
+			"id":         "501",
+			"file":       "internal/handler.go",
+			"start_line": 20,
+			"end_line":   22,
+			"reviewer":   "golangci-lint[bot]",
+			"body":       "Error return value of `doWork` is not checked.",
+		},
+	}
+
+	t.Run("BotReviewComments_RendersWithoutMissingKeyError", func(t *testing.T) {
+		t.Parallel()
+
+		tmpl, err := Parse(`{{ if .bot_review_comments }}has-bot-comments{{ end }}`, "WORKFLOW.md", 0)
+		if err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+
+		got, err := tmpl.Render(issue, nil, run,
+			WithContinuationContext(map[string]any{"bot_review_comments": botComments}),
+		)
+		if err != nil {
+			t.Fatalf("Render with bot_review_comments: %v", err)
+		}
+		if got != "has-bot-comments" {
+			t.Errorf("Render() = %q, want %q", got, "has-bot-comments")
+		}
+	})
+
+	t.Run("BotReviewComments_DefaultNilNoError", func(t *testing.T) {
+		t.Parallel()
+
+		tmpl, err := Parse(`{{ if .bot_review_comments }}FAIL{{ end }}`, "WORKFLOW.md", 0)
+		if err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+
+		got, err := tmpl.Render(issue, nil, run)
+		if err != nil {
+			t.Fatalf("Render with default bot_review_comments=nil: %v", err)
+		}
+		if got != "" {
+			t.Errorf("Render() = %q, want empty string when bot_review_comments is nil", got)
+		}
+	})
+
+	t.Run("BotReviewComments_PerCommentShapeMatchesReviewComments", func(t *testing.T) {
+		t.Parallel()
+
+		tmpl, err := Parse(
+			`{{ range .bot_review_comments }}{{ index . "id" }}:{{ index . "file" }}:{{ index . "start_line" }}:{{ index . "end_line" }}:{{ index . "reviewer" }}:{{ index . "body" }}{{ end }}`,
+			"WORKFLOW.md", 0,
+		)
+		if err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+
+		got, err := tmpl.Render(issue, nil, run,
+			WithContinuationContext(map[string]any{"bot_review_comments": botComments}),
+		)
+		if err != nil {
+			t.Fatalf("Render with bot_review_comments shape: %v", err)
+		}
+		want := "501:internal/handler.go:20:22:golangci-lint[bot]:Error return value of `doWork` is not checked."
+		if got != want {
+			t.Errorf("Render() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("WithContinuationContext_AcceptsBotReviewCommentsKey", func(t *testing.T) {
+		t.Parallel()
+
+		// WithContinuationContext must not panic when passed bot_review_comments.
+		opt := WithContinuationContext(map[string]any{"bot_review_comments": botComments})
+		if opt == nil {
+			t.Error("WithContinuationContext returned nil for registered key bot_review_comments")
+		}
+	})
+}
+
 func TestWithContinuationContext_UnregisteredKeyPanics(t *testing.T) {
 	t.Parallel()
 

--- a/internal/scm/github/review.go
+++ b/internal/scm/github/review.go
@@ -177,6 +177,112 @@ func (a *GitHubSCMAdapter) FetchPendingReviews(ctx context.Context, prNumber int
 	return result, nil
 }
 
+// FetchBotReviewComments returns review comments authored by automated
+// review bots on the given PR. A review or comment is bot-authored when
+// its user.type is "Bot" or its author login matches a botUsernames entry
+// case-insensitively. Outdated comments (where GitHub reports position as
+// null) have Outdated=true. Returns an empty non-nil slice when no bot
+// comments exist.
+//
+// Unlike [GitHubSCMAdapter.FetchPendingReviews], no review-state filter is
+// applied: review bots commonly post COMMENTED reviews, so requiring
+// CHANGES_REQUESTED would drop most bot findings.
+func (a *GitHubSCMAdapter) FetchBotReviewComments(ctx context.Context, prNumber int, owner, repo string, botUsernames []string) ([]domain.ReviewComment, error) {
+	reviews, err := a.fetchAllReviews(ctx, prNumber, owner, repo)
+	if err != nil {
+		return nil, err
+	}
+
+	seen := make(map[string]struct{})
+	var result []domain.ReviewComment
+
+	for _, review := range reviews {
+		if !isBotAuthor(review.User.Login, review.User.Type, botUsernames) {
+			continue
+		}
+
+		// Include non-empty review body as a PR-level comment.
+		body := strings.TrimSpace(review.Body)
+		if body != "" {
+			prCommentID := fmt.Sprintf("review-%d", review.ID)
+			if _, dup := seen[prCommentID]; !dup {
+				seen[prCommentID] = struct{}{}
+				submittedAt, _ := time.Parse(time.RFC3339, review.SubmittedAt)
+				result = append(result, domain.ReviewComment{
+					ID:          prCommentID,
+					Reviewer:    review.User.Login,
+					Body:        body,
+					SubmittedAt: submittedAt,
+				})
+			}
+		}
+
+		// Fetch inline comments for this review.
+		comments, fetchErr := a.fetchReviewComments(ctx, prNumber, owner, repo, review.ID)
+		if fetchErr != nil {
+			return nil, fetchErr
+		}
+
+		for _, c := range comments {
+			if !isBotAuthor(c.User.Login, c.User.Type, botUsernames) {
+				continue
+			}
+
+			commentID := strconv.FormatInt(c.ID, 10)
+			if _, dup := seen[commentID]; dup {
+				continue
+			}
+			seen[commentID] = struct{}{}
+
+			startLine := 0
+			if c.StartLine != nil {
+				startLine = *c.StartLine
+			} else if c.Line != nil {
+				startLine = *c.Line
+			}
+
+			endLine := 0
+			if c.Line != nil && *c.Line != startLine {
+				endLine = *c.Line
+			}
+
+			createdAt, _ := time.Parse(time.RFC3339, c.CreatedAt)
+
+			result = append(result, domain.ReviewComment{
+				ID:          commentID,
+				FilePath:    c.Path,
+				StartLine:   startLine,
+				EndLine:     endLine,
+				Reviewer:    c.User.Login,
+				Body:        c.Body,
+				SubmittedAt: createdAt,
+				Outdated:    c.Position == nil,
+			})
+		}
+	}
+
+	if result == nil {
+		result = []domain.ReviewComment{}
+	}
+	return result, nil
+}
+
+// isBotAuthor reports whether an author is an automated review bot. The
+// author qualifies when userType is "Bot" (case-insensitive) or when login
+// matches an allowlist entry case-insensitively. The two conditions form a
+// union: either qualifies.
+func isBotAuthor(login, userType string, allowlist []string) bool {
+	if strings.EqualFold(userType, "Bot") {
+		return true
+	}
+	for _, name := range allowlist {
+		if strings.EqualFold(login, name) {
+			return true
+		}
+	}
+	return false
+}
+
 func (a *GitHubSCMAdapter) fetchAllReviews(ctx context.Context, prNumber int, owner, repo string) ([]githubReview, error) {
 	path := fmt.Sprintf("/repos/%s/%s/pulls/%d/reviews", url.PathEscape(owner), url.PathEscape(repo), prNumber)
 	params := url.Values{"per_page": {"100"}}

--- a/internal/scm/github/review_test.go
+++ b/internal/scm/github/review_test.go
@@ -538,13 +538,13 @@ func TestFetchBotReviewComments_BotExcludedByFetchPendingReviews(t *testing.T) {
 // review authored by a user with user.type == "User" whose login matches a
 // botUsernames entry case-insensitively is returned by FetchBotReviewComments.
 // The test uses a fixture where both the review and its inline comment carry
-// user.type == "User" with login "Dependabot[bot]", so the only selection path
+// user.type == "User" with login "acme-lint-bot", so the only selection path
 // is the allowlist union arm.
 func TestFetchBotReviewComments_AllowlistMatchCaseInsensitive(t *testing.T) {
 	t.Parallel()
 
-	// reviews_user_allowlisted.json: user.type == "User", login "Dependabot[bot]", empty body.
-	// comments_user_allowlisted.json: user.type == "User", login "Dependabot[bot]".
+	// reviews_user_allowlisted.json: user.type == "User", login "acme-lint-bot", empty body.
+	// comments_user_allowlisted.json: user.type == "User", login "acme-lint-bot".
 	reviewsFixture := loadFixture(t, "reviews_user_allowlisted.json")
 	commentsFixture := loadFixture(t, "comments_user_allowlisted.json")
 	srv := httptest.NewServer(reviewsAndCommentsHandler(t, reviewsFixture, commentsFixture))
@@ -558,26 +558,26 @@ func TestFetchBotReviewComments_AllowlistMatchCaseInsensitive(t *testing.T) {
 		t.Fatalf("FetchBotReviewComments (no allowlist): %v", err)
 	}
 	for _, c := range gotNoAllowlist {
-		if strings.EqualFold(c.Reviewer, "dependabot[bot]") {
+		if strings.EqualFold(c.Reviewer, "acme-lint-bot") {
 			t.Errorf("FetchBotReviewComments with no allowlist: reviewer %q must not appear without allowlist", c.Reviewer)
 		}
 	}
 
 	// With a differently-cased allowlist entry, the inline comment must be returned.
-	allowlist := []string{"DEPENDABOT[BOT]"}
+	allowlist := []string{"ACME-LINT-BOT"}
 	gotWithAllowlist, err := adapter.FetchBotReviewComments(context.Background(), 1, "owner", "repo", allowlist)
 	if err != nil {
 		t.Fatalf("FetchBotReviewComments (with allowlist): %v", err)
 	}
 	found := false
 	for _, c := range gotWithAllowlist {
-		if strings.EqualFold(c.Reviewer, "dependabot[bot]") {
+		if strings.EqualFold(c.Reviewer, "acme-lint-bot") {
 			found = true
 		}
 	}
 	if !found {
 		t.Errorf("FetchBotReviewComments(allowlist=%v): reviewer %q not found, want case-insensitive match",
-			allowlist, "Dependabot[bot]")
+			allowlist, "acme-lint-bot")
 	}
 }
 
@@ -749,23 +749,23 @@ func TestIsBotAuthor(t *testing.T) {
 		},
 		{
 			name:      "user.type User in allowlist exact match",
-			login:     "dependabot[bot]",
+			login:     "acme-lint-bot",
 			userType:  "User",
-			allowlist: []string{"dependabot[bot]"},
+			allowlist: []string{"acme-lint-bot"},
 			want:      true,
 		},
 		{
 			name:      "user.type User in allowlist case-insensitive",
-			login:     "Dependabot[bot]",
+			login:     "acme-lint-bot",
 			userType:  "User",
-			allowlist: []string{"DEPENDABOT[BOT]"},
+			allowlist: []string{"ACME-LINT-BOT"},
 			want:      true,
 		},
 		{
 			name:      "user.type User not in populated allowlist",
 			login:     "bob",
 			userType:  "User",
-			allowlist: []string{"dependabot[bot]", "golangci-lint[bot]"},
+			allowlist: []string{"acme-lint-bot", "golangci-lint[bot]"},
 			want:      false,
 		},
 		{

--- a/internal/scm/github/review_test.go
+++ b/internal/scm/github/review_test.go
@@ -538,13 +538,13 @@ func TestFetchBotReviewComments_BotExcludedByFetchPendingReviews(t *testing.T) {
 // review authored by a user with user.type == "User" whose login matches a
 // botUsernames entry case-insensitively is returned by FetchBotReviewComments.
 // The test uses a fixture where both the review and its inline comment carry
-// user.type == "User" with login "acme-lint-bot", so the only selection path
+// user.type == "User" with login "houndci-bot", so the only selection path
 // is the allowlist union arm.
 func TestFetchBotReviewComments_AllowlistMatchCaseInsensitive(t *testing.T) {
 	t.Parallel()
 
-	// reviews_user_allowlisted.json: user.type == "User", login "acme-lint-bot", empty body.
-	// comments_user_allowlisted.json: user.type == "User", login "acme-lint-bot".
+	// reviews_user_allowlisted.json: user.type == "User", login "houndci-bot", empty body.
+	// comments_user_allowlisted.json: user.type == "User", login "houndci-bot".
 	reviewsFixture := loadFixture(t, "reviews_user_allowlisted.json")
 	commentsFixture := loadFixture(t, "comments_user_allowlisted.json")
 	srv := httptest.NewServer(reviewsAndCommentsHandler(t, reviewsFixture, commentsFixture))
@@ -558,26 +558,26 @@ func TestFetchBotReviewComments_AllowlistMatchCaseInsensitive(t *testing.T) {
 		t.Fatalf("FetchBotReviewComments (no allowlist): %v", err)
 	}
 	for _, c := range gotNoAllowlist {
-		if strings.EqualFold(c.Reviewer, "acme-lint-bot") {
+		if strings.EqualFold(c.Reviewer, "houndci-bot") {
 			t.Errorf("FetchBotReviewComments with no allowlist: reviewer %q must not appear without allowlist", c.Reviewer)
 		}
 	}
 
 	// With a differently-cased allowlist entry, the inline comment must be returned.
-	allowlist := []string{"ACME-LINT-BOT"}
+	allowlist := []string{"HOUNDCI-BOT"}
 	gotWithAllowlist, err := adapter.FetchBotReviewComments(context.Background(), 1, "owner", "repo", allowlist)
 	if err != nil {
 		t.Fatalf("FetchBotReviewComments (with allowlist): %v", err)
 	}
 	found := false
 	for _, c := range gotWithAllowlist {
-		if strings.EqualFold(c.Reviewer, "acme-lint-bot") {
+		if strings.EqualFold(c.Reviewer, "houndci-bot") {
 			found = true
 		}
 	}
 	if !found {
 		t.Errorf("FetchBotReviewComments(allowlist=%v): reviewer %q not found, want case-insensitive match",
-			allowlist, "acme-lint-bot")
+			allowlist, "houndci-bot")
 	}
 }
 
@@ -749,23 +749,23 @@ func TestIsBotAuthor(t *testing.T) {
 		},
 		{
 			name:      "user.type User in allowlist exact match",
-			login:     "acme-lint-bot",
+			login:     "houndci-bot",
 			userType:  "User",
-			allowlist: []string{"acme-lint-bot"},
+			allowlist: []string{"houndci-bot"},
 			want:      true,
 		},
 		{
 			name:      "user.type User in allowlist case-insensitive",
-			login:     "acme-lint-bot",
+			login:     "houndci-bot",
 			userType:  "User",
-			allowlist: []string{"ACME-LINT-BOT"},
+			allowlist: []string{"HOUNDCI-BOT"},
 			want:      true,
 		},
 		{
 			name:      "user.type User not in populated allowlist",
 			login:     "bob",
 			userType:  "User",
-			allowlist: []string{"acme-lint-bot", "golangci-lint[bot]"},
+			allowlist: []string{"houndci-bot", "golangci-lint[bot]"},
 			want:      false,
 		},
 		{

--- a/internal/scm/github/review_test.go
+++ b/internal/scm/github/review_test.go
@@ -712,6 +712,85 @@ func TestFetchBotReviewComments_NoReviews(t *testing.T) {
 	}
 }
 
+// TestFetchBotReviewComments_ReviewsFetchError verifies that an error fetching
+// the reviews list propagates as an SCMError from FetchBotReviewComments.
+func TestFetchBotReviewComments_ReviewsFetchError(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`not valid json {{{`))
+	}))
+	defer srv.Close()
+
+	adapter := newTestSCMAdapter(t, srv.URL)
+	_, err := adapter.FetchBotReviewComments(context.Background(), 1, "owner", "repo", nil)
+	assertSCMErrorKind(t, err, domain.ErrSCMPayload)
+}
+
+// TestFetchBotReviewComments_CommentsFetchError verifies that an error fetching
+// a bot review's inline comments propagates from FetchBotReviewComments even
+// when the reviews list itself was fetched successfully.
+func TestFetchBotReviewComments_CommentsFetchError(t *testing.T) {
+	t.Parallel()
+
+	reviewsFixture := loadFixture(t, "reviews_bot.json")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case strings.Contains(r.URL.Path, "/comments"):
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`not valid json {{{`))
+		case strings.HasSuffix(r.URL.Path, "/reviews"):
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(reviewsFixture)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"message":"not found"}`))
+		}
+	}))
+	defer srv.Close()
+
+	adapter := newTestSCMAdapter(t, srv.URL)
+	_, err := adapter.FetchBotReviewComments(context.Background(), 1, "owner", "repo", nil)
+	assertSCMErrorKind(t, err, domain.ErrSCMPayload)
+}
+
+// TestFetchBotReviewComments_SkipsNonBotInlineComment verifies that an inline
+// comment authored by a non-bot, non-allowlisted user is excluded from the
+// results while bot-authored inline comments are kept.
+func TestFetchBotReviewComments_SkipsNonBotInlineComment(t *testing.T) {
+	t.Parallel()
+
+	// reviews_bot.json: one bot review (user.type "Bot").
+	// comments_bot_mixed.json: a bot comment (id 700), a non-bot comment
+	// (id 701, user.type "User", not allowlisted), and a duplicate of id 700.
+	reviewsFixture := loadFixture(t, "reviews_bot.json")
+	commentsFixture := loadFixture(t, "comments_bot_mixed.json")
+	srv := httptest.NewServer(reviewsAndCommentsHandler(t, reviewsFixture, commentsFixture))
+	defer srv.Close()
+
+	adapter := newTestSCMAdapter(t, srv.URL)
+	got, err := adapter.FetchBotReviewComments(context.Background(), 1, "owner", "repo", nil)
+	if err != nil {
+		t.Fatalf("FetchBotReviewComments: %v", err)
+	}
+
+	var botInlineCount int
+	for _, c := range got {
+		if c.ID == "701" {
+			t.Error("non-bot inline comment id 701 returned; want excluded")
+		}
+		if c.ID == "700" {
+			botInlineCount++
+		}
+	}
+	if botInlineCount != 1 {
+		t.Errorf("bot inline comment id 700 appeared %d time(s); want exactly 1 (deduped)", botInlineCount)
+	}
+}
+
 // TestIsBotAuthor verifies the isBotAuthor predicate covers all union branches.
 func TestIsBotAuthor(t *testing.T) {
 	t.Parallel()

--- a/internal/scm/github/review_test.go
+++ b/internal/scm/github/review_test.go
@@ -470,6 +470,332 @@ func TestFetchPendingReviews_JSONPayloadError(t *testing.T) {
 	assertSCMErrorKind(t, err, domain.ErrSCMPayload)
 }
 
+// --- FetchBotReviewComments tests ---
+
+// TestFetchBotReviewComments_BotTypeReturned verifies R1: a review authored by
+// a user with user.type == "Bot" is returned by FetchBotReviewComments.
+func TestFetchBotReviewComments_BotTypeReturned(t *testing.T) {
+	t.Parallel()
+
+	reviewsFixture := loadFixture(t, "reviews_bot.json")
+	commentsFixture := loadFixture(t, "comments_bot_inline.json")
+	srv := httptest.NewServer(reviewsAndCommentsHandler(t, reviewsFixture, commentsFixture))
+	defer srv.Close()
+
+	adapter := newTestSCMAdapter(t, srv.URL)
+	got, err := adapter.FetchBotReviewComments(context.Background(), 1, "owner", "repo", nil)
+	if err != nil {
+		t.Fatalf("FetchBotReviewComments: unexpected error: %v", err)
+	}
+	if len(got) == 0 {
+		t.Fatal("FetchBotReviewComments returned empty slice, want at least 1 comment from bot")
+	}
+
+	// The bot review has a non-empty body, so it must appear as a PR-level comment.
+	found := false
+	for _, c := range got {
+		if c.Reviewer == "github-actions[bot]" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("FetchBotReviewComments: reviewer %q not found in results", "github-actions[bot]")
+	}
+}
+
+// TestFetchBotReviewComments_BotExcludedByFetchPendingReviews verifies R1: the
+// same bot fixture that FetchBotReviewComments returns is excluded by
+// FetchPendingReviews.
+func TestFetchBotReviewComments_BotExcludedByFetchPendingReviews(t *testing.T) {
+	t.Parallel()
+
+	reviewsFixture := loadFixture(t, "reviews_bot.json")
+	srv := httptest.NewServer(reviewsAndCommentsHandler(t, reviewsFixture, loadFixture(t, "comments_empty.json")))
+	defer srv.Close()
+
+	adapter := newTestSCMAdapter(t, srv.URL)
+
+	// FetchPendingReviews must exclude the bot review entirely.
+	human, err := adapter.FetchPendingReviews(context.Background(), 1, "owner", "repo")
+	if err != nil {
+		t.Fatalf("FetchPendingReviews: %v", err)
+	}
+	if len(human) != 0 {
+		t.Errorf("FetchPendingReviews with bot fixture: len = %d, want 0 (bot must be excluded)", len(human))
+	}
+
+	// FetchBotReviewComments must include the same bot review.
+	bot, err := adapter.FetchBotReviewComments(context.Background(), 1, "owner", "repo", nil)
+	if err != nil {
+		t.Fatalf("FetchBotReviewComments: %v", err)
+	}
+	if len(bot) == 0 {
+		t.Error("FetchBotReviewComments with bot fixture: len = 0, want > 0")
+	}
+}
+
+// TestFetchBotReviewComments_AllowlistMatchCaseInsensitive verifies R2: a
+// review authored by a user with user.type == "User" whose login matches a
+// botUsernames entry case-insensitively is returned by FetchBotReviewComments.
+// The test uses a fixture where both the review and its inline comment carry
+// user.type == "User" with login "Dependabot[bot]", so the only selection path
+// is the allowlist union arm.
+func TestFetchBotReviewComments_AllowlistMatchCaseInsensitive(t *testing.T) {
+	t.Parallel()
+
+	// reviews_user_allowlisted.json: user.type == "User", login "Dependabot[bot]", empty body.
+	// comments_user_allowlisted.json: user.type == "User", login "Dependabot[bot]".
+	reviewsFixture := loadFixture(t, "reviews_user_allowlisted.json")
+	commentsFixture := loadFixture(t, "comments_user_allowlisted.json")
+	srv := httptest.NewServer(reviewsAndCommentsHandler(t, reviewsFixture, commentsFixture))
+	defer srv.Close()
+
+	adapter := newTestSCMAdapter(t, srv.URL)
+
+	// Without the allowlist the "User" type review/comment must be excluded entirely.
+	gotNoAllowlist, err := adapter.FetchBotReviewComments(context.Background(), 1, "owner", "repo", nil)
+	if err != nil {
+		t.Fatalf("FetchBotReviewComments (no allowlist): %v", err)
+	}
+	for _, c := range gotNoAllowlist {
+		if strings.EqualFold(c.Reviewer, "dependabot[bot]") {
+			t.Errorf("FetchBotReviewComments with no allowlist: reviewer %q must not appear without allowlist", c.Reviewer)
+		}
+	}
+
+	// With a differently-cased allowlist entry, the inline comment must be returned.
+	allowlist := []string{"DEPENDABOT[BOT]"}
+	gotWithAllowlist, err := adapter.FetchBotReviewComments(context.Background(), 1, "owner", "repo", allowlist)
+	if err != nil {
+		t.Fatalf("FetchBotReviewComments (with allowlist): %v", err)
+	}
+	found := false
+	for _, c := range gotWithAllowlist {
+		if strings.EqualFold(c.Reviewer, "dependabot[bot]") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("FetchBotReviewComments(allowlist=%v): reviewer %q not found, want case-insensitive match",
+			allowlist, "Dependabot[bot]")
+	}
+}
+
+// TestFetchBotReviewComments_CommentedReviewIncluded verifies Open Question 2
+// (Option A): a bot review with state COMMENTED (not CHANGES_REQUESTED) is
+// still returned by FetchBotReviewComments.
+func TestFetchBotReviewComments_CommentedReviewIncluded(t *testing.T) {
+	t.Parallel()
+
+	// reviews_bot_commented.json has state == "COMMENTED" and user.type == "Bot".
+	reviewsFixture := loadFixture(t, "reviews_bot_commented.json")
+	srv := httptest.NewServer(reviewsAndCommentsHandler(t, reviewsFixture, loadFixture(t, "comments_empty.json")))
+	defer srv.Close()
+
+	adapter := newTestSCMAdapter(t, srv.URL)
+	got, err := adapter.FetchBotReviewComments(context.Background(), 1, "owner", "repo", nil)
+	if err != nil {
+		t.Fatalf("FetchBotReviewComments: %v", err)
+	}
+	if len(got) == 0 {
+		t.Error("FetchBotReviewComments with COMMENTED bot review: len = 0, want > 0 (no review-state filter)")
+	}
+}
+
+// TestFetchBotReviewComments_SelectionIgnoresBody verifies R3: classification
+// reads only user.login and user.type; the body content does not affect
+// selection. A bot with empty body is still classified as bot (no PR-level
+// comment), and its inline comments are returned.
+func TestFetchBotReviewComments_SelectionIgnoresBody(t *testing.T) {
+	t.Parallel()
+
+	// reviews_changes_requested_no_body.json has user.type == "User" (not a bot).
+	// We need a bot review with empty body to confirm body doesn't affect selection.
+	// Use a bot review + inline comment; the bot is selected by user.type, not body.
+	reviewsFixture := loadFixture(t, "reviews_bot.json")
+	// Provide a bot inline comment — body content is irrelevant to selection.
+	commentsFixture := loadFixture(t, "comments_bot_inline.json")
+	srv := httptest.NewServer(reviewsAndCommentsHandler(t, reviewsFixture, commentsFixture))
+	defer srv.Close()
+
+	adapter := newTestSCMAdapter(t, srv.URL)
+	got, err := adapter.FetchBotReviewComments(context.Background(), 1, "owner", "repo", nil)
+	if err != nil {
+		t.Fatalf("FetchBotReviewComments: %v", err)
+	}
+	// Selection must have occurred regardless of comment body content.
+	// The inline comment (id 501) must appear in results.
+	found := false
+	for _, c := range got {
+		if c.ID == "501" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("FetchBotReviewComments: inline bot comment id %q not returned; selection must use user.type only", "501")
+	}
+}
+
+// TestFetchBotReviewComments_EmptyResultNonNil verifies that when no bot
+// comments match, the result is a non-nil empty slice.
+func TestFetchBotReviewComments_EmptyResultNonNil(t *testing.T) {
+	t.Parallel()
+
+	// reviews_approved.json has user.type == "User" and is not in any allowlist.
+	reviewsFixture := loadFixture(t, "reviews_approved.json")
+	srv := httptest.NewServer(reviewsAndCommentsHandler(t, reviewsFixture, loadFixture(t, "comments_empty.json")))
+	defer srv.Close()
+
+	adapter := newTestSCMAdapter(t, srv.URL)
+	got, err := adapter.FetchBotReviewComments(context.Background(), 1, "owner", "repo", nil)
+	if err != nil {
+		t.Fatalf("FetchBotReviewComments: %v", err)
+	}
+	if got == nil {
+		t.Error("FetchBotReviewComments with no bot matches: returned nil, want non-nil empty slice")
+	}
+	if len(got) != 0 {
+		t.Errorf("FetchBotReviewComments with no bot matches: len = %d, want 0", len(got))
+	}
+}
+
+// TestFetchBotReviewComments_OutdatedCommentFlag verifies that a bot inline
+// comment with null position carries Outdated == true.
+func TestFetchBotReviewComments_OutdatedCommentFlag(t *testing.T) {
+	t.Parallel()
+
+	// Use the COMMENTED bot review (user.type == "Bot") with an outdated inline
+	// comment (position == null).
+	reviewsFixture := loadFixture(t, "reviews_bot_commented.json")
+	commentsFixture := loadFixture(t, "comments_bot_outdated.json")
+	srv := httptest.NewServer(reviewsAndCommentsHandler(t, reviewsFixture, commentsFixture))
+	defer srv.Close()
+
+	adapter := newTestSCMAdapter(t, srv.URL)
+	got, err := adapter.FetchBotReviewComments(context.Background(), 1, "owner", "repo", nil)
+	if err != nil {
+		t.Fatalf("FetchBotReviewComments: %v", err)
+	}
+
+	foundOutdated := false
+	for _, c := range got {
+		if c.ID == "500" {
+			foundOutdated = true
+			if !c.Outdated {
+				t.Errorf("FetchBotReviewComments: comment id %q Outdated = false, want true (position is null)", c.ID)
+			}
+		}
+	}
+	if !foundOutdated {
+		t.Errorf("FetchBotReviewComments: outdated bot comment id %q not found in results", "500")
+	}
+}
+
+// TestFetchBotReviewComments_NoReviews verifies that when the PR has no
+// reviews at all, the result is a non-nil empty slice.
+func TestFetchBotReviewComments_NoReviews(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(reviewsAndCommentsHandler(t, loadFixture(t, "reviews_empty.json"), loadFixture(t, "comments_empty.json")))
+	defer srv.Close()
+
+	adapter := newTestSCMAdapter(t, srv.URL)
+	got, err := adapter.FetchBotReviewComments(context.Background(), 1, "owner", "repo", nil)
+	if err != nil {
+		t.Fatalf("FetchBotReviewComments with empty reviews: %v", err)
+	}
+	if got == nil {
+		t.Error("FetchBotReviewComments with empty reviews: returned nil, want non-nil empty slice")
+	}
+	if len(got) != 0 {
+		t.Errorf("FetchBotReviewComments with empty reviews: len = %d, want 0", len(got))
+	}
+}
+
+// TestIsBotAuthor verifies the isBotAuthor predicate covers all union branches.
+func TestIsBotAuthor(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		login     string
+		userType  string
+		allowlist []string
+		want      bool
+	}{
+		{
+			name:     "user.type Bot (exact case)",
+			login:    "golangci-lint[bot]",
+			userType: "Bot",
+			want:     true,
+		},
+		{
+			name:     "user.type bot (lower case)",
+			login:    "golangci-lint[bot]",
+			userType: "bot",
+			want:     true,
+		},
+		{
+			name:     "user.type BOT (upper case)",
+			login:    "golangci-lint[bot]",
+			userType: "BOT",
+			want:     true,
+		},
+		{
+			name:     "user.type User not in allowlist",
+			login:    "alice",
+			userType: "User",
+			want:     false,
+		},
+		{
+			name:      "user.type User in allowlist exact match",
+			login:     "dependabot[bot]",
+			userType:  "User",
+			allowlist: []string{"dependabot[bot]"},
+			want:      true,
+		},
+		{
+			name:      "user.type User in allowlist case-insensitive",
+			login:     "Dependabot[bot]",
+			userType:  "User",
+			allowlist: []string{"DEPENDABOT[BOT]"},
+			want:      true,
+		},
+		{
+			name:      "user.type User not in populated allowlist",
+			login:     "bob",
+			userType:  "User",
+			allowlist: []string{"dependabot[bot]", "golangci-lint[bot]"},
+			want:      false,
+		},
+		{
+			name:      "empty allowlist and non-bot type",
+			login:     "carol",
+			userType:  "User",
+			allowlist: []string{},
+			want:      false,
+		},
+		{
+			name:     "nil allowlist and non-bot type",
+			login:    "carol",
+			userType: "User",
+			want:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := isBotAuthor(tt.login, tt.userType, tt.allowlist)
+			if got != tt.want {
+				t.Errorf("isBotAuthor(%q, %q, %v) = %v, want %v",
+					tt.login, tt.userType, tt.allowlist, got, tt.want)
+			}
+		})
+	}
+}
+
 // --- TestToSCMError ---
 
 func TestToSCMError(t *testing.T) {

--- a/internal/scm/github/testdata/comments_bot_inline.json
+++ b/internal/scm/github/testdata/comments_bot_inline.json
@@ -1,0 +1,15 @@
+[
+  {
+    "id": 501,
+    "path": "internal/handler.go",
+    "start_line": 20,
+    "line": 22,
+    "position": 3,
+    "body": "Error return value of `doWork` is not checked.",
+    "user": {
+      "login": "golangci-lint[bot]",
+      "type": "Bot"
+    },
+    "created_at": "2026-04-01T10:10:00Z"
+  }
+]

--- a/internal/scm/github/testdata/comments_bot_mixed.json
+++ b/internal/scm/github/testdata/comments_bot_mixed.json
@@ -1,0 +1,41 @@
+[
+  {
+    "id": 700,
+    "path": "internal/handler.go",
+    "start_line": 10,
+    "line": 12,
+    "position": 4,
+    "body": "Bot finding: unchecked error.",
+    "user": {
+      "login": "golangci-lint[bot]",
+      "type": "Bot"
+    },
+    "created_at": "2026-04-01T10:10:00Z"
+  },
+  {
+    "id": 701,
+    "path": "internal/handler.go",
+    "start_line": 15,
+    "line": 15,
+    "position": 5,
+    "body": "Human reviewer note, not a bot.",
+    "user": {
+      "login": "alice",
+      "type": "User"
+    },
+    "created_at": "2026-04-01T10:11:00Z"
+  },
+  {
+    "id": 700,
+    "path": "internal/handler.go",
+    "start_line": 10,
+    "line": 12,
+    "position": 4,
+    "body": "Bot finding: unchecked error.",
+    "user": {
+      "login": "golangci-lint[bot]",
+      "type": "Bot"
+    },
+    "created_at": "2026-04-01T10:10:00Z"
+  }
+]

--- a/internal/scm/github/testdata/comments_bot_outdated.json
+++ b/internal/scm/github/testdata/comments_bot_outdated.json
@@ -1,0 +1,15 @@
+[
+  {
+    "id": 500,
+    "path": "internal/auth.go",
+    "start_line": null,
+    "line": 42,
+    "position": null,
+    "body": "Unused variable detected by linter.",
+    "user": {
+      "login": "golangci-lint[bot]",
+      "type": "Bot"
+    },
+    "created_at": "2026-04-01T10:05:00Z"
+  }
+]

--- a/internal/scm/github/testdata/comments_user_allowlisted.json
+++ b/internal/scm/github/testdata/comments_user_allowlisted.json
@@ -5,9 +5,9 @@
     "start_line": 5,
     "line": 7,
     "position": 2,
-    "body": "Exported function `Handler` should have a doc comment.",
+    "body": "Trailing whitespace detected.",
     "user": {
-      "login": "acme-lint-bot",
+      "login": "houndci-bot",
       "type": "User"
     },
     "created_at": "2026-04-01T11:05:00Z"

--- a/internal/scm/github/testdata/comments_user_allowlisted.json
+++ b/internal/scm/github/testdata/comments_user_allowlisted.json
@@ -1,0 +1,15 @@
+[
+  {
+    "id": 600,
+    "path": "internal/security.go",
+    "start_line": 5,
+    "line": 7,
+    "position": 2,
+    "body": "Dependency `lodash` has a known vulnerability.",
+    "user": {
+      "login": "Dependabot[bot]",
+      "type": "User"
+    },
+    "created_at": "2026-04-01T11:05:00Z"
+  }
+]

--- a/internal/scm/github/testdata/comments_user_allowlisted.json
+++ b/internal/scm/github/testdata/comments_user_allowlisted.json
@@ -1,13 +1,13 @@
 [
   {
     "id": 600,
-    "path": "internal/security.go",
+    "path": "internal/handler.go",
     "start_line": 5,
     "line": 7,
     "position": 2,
-    "body": "Dependency `lodash` has a known vulnerability.",
+    "body": "Exported function `Handler` should have a doc comment.",
     "user": {
-      "login": "Dependabot[bot]",
+      "login": "acme-lint-bot",
       "type": "User"
     },
     "created_at": "2026-04-01T11:05:00Z"

--- a/internal/scm/github/testdata/reviews_bot_commented.json
+++ b/internal/scm/github/testdata/reviews_bot_commented.json
@@ -1,0 +1,12 @@
+[
+  {
+    "id": 50,
+    "state": "COMMENTED",
+    "body": "Found 2 issues: unused import, missing error check.",
+    "user": {
+      "login": "golangci-lint[bot]",
+      "type": "Bot"
+    },
+    "submitted_at": "2026-04-01T10:00:00Z"
+  }
+]

--- a/internal/scm/github/testdata/reviews_user_allowlisted.json
+++ b/internal/scm/github/testdata/reviews_user_allowlisted.json
@@ -4,7 +4,7 @@
     "state": "CHANGES_REQUESTED",
     "body": "",
     "user": {
-      "login": "Dependabot[bot]",
+      "login": "acme-lint-bot",
       "type": "User"
     },
     "submitted_at": "2026-04-01T11:00:00Z"

--- a/internal/scm/github/testdata/reviews_user_allowlisted.json
+++ b/internal/scm/github/testdata/reviews_user_allowlisted.json
@@ -1,0 +1,12 @@
+[
+  {
+    "id": 60,
+    "state": "CHANGES_REQUESTED",
+    "body": "",
+    "user": {
+      "login": "Dependabot[bot]",
+      "type": "User"
+    },
+    "submitted_at": "2026-04-01T11:00:00Z"
+  }
+]

--- a/internal/scm/github/testdata/reviews_user_allowlisted.json
+++ b/internal/scm/github/testdata/reviews_user_allowlisted.json
@@ -4,7 +4,7 @@
     "state": "CHANGES_REQUESTED",
     "body": "",
     "user": {
-      "login": "acme-lint-bot",
+      "login": "houndci-bot",
       "type": "User"
     },
     "submitted_at": "2026-04-01T11:00:00Z"

--- a/internal/server/metrics.go
+++ b/internal/server/metrics.go
@@ -20,24 +20,26 @@ type PromMetrics struct {
 	slotsAvailable        prometheus.Gauge
 	activeSessionsElapsed prometheus.Gauge
 
-	tokensTotal             *prometheus.CounterVec
-	agentRuntimeTotal       prometheus.Counter
-	dispatchesTotal         *prometheus.CounterVec
-	workerExitsTotal        *prometheus.CounterVec
-	retriesTotal            *prometheus.CounterVec
-	reconciliationActions   *prometheus.CounterVec
-	pollCyclesTotal         *prometheus.CounterVec
-	trackerRequestsTotal    *prometheus.CounterVec
-	handoffTransitions      *prometheus.CounterVec
-	dispatchTransitions     *prometheus.CounterVec
-	trackerCommentsTotal    *prometheus.CounterVec
-	toolCallsTotal          *prometheus.CounterVec
-	ciStatusChecksTotal     *prometheus.CounterVec
-	ciEscalationsTotal      *prometheus.CounterVec
-	reviewChecksTotal       *prometheus.CounterVec
-	reviewEscalationsTotal  *prometheus.CounterVec
-	autoMergeReactionsTotal *prometheus.CounterVec
-	dispatchRuleMatchTotal  *prometheus.CounterVec
+	tokensTotal               *prometheus.CounterVec
+	agentRuntimeTotal         prometheus.Counter
+	dispatchesTotal           *prometheus.CounterVec
+	workerExitsTotal          *prometheus.CounterVec
+	retriesTotal              *prometheus.CounterVec
+	reconciliationActions     *prometheus.CounterVec
+	pollCyclesTotal           *prometheus.CounterVec
+	trackerRequestsTotal      *prometheus.CounterVec
+	handoffTransitions        *prometheus.CounterVec
+	dispatchTransitions       *prometheus.CounterVec
+	trackerCommentsTotal      *prometheus.CounterVec
+	toolCallsTotal            *prometheus.CounterVec
+	ciStatusChecksTotal       *prometheus.CounterVec
+	ciEscalationsTotal        *prometheus.CounterVec
+	reviewChecksTotal         *prometheus.CounterVec
+	reviewEscalationsTotal    *prometheus.CounterVec
+	botReviewChecksTotal      *prometheus.CounterVec
+	botReviewEscalationsTotal *prometheus.CounterVec
+	autoMergeReactionsTotal   *prometheus.CounterVec
+	dispatchRuleMatchTotal    *prometheus.CounterVec
 
 	selfReviewIterationsTotal      *prometheus.CounterVec
 	selfReviewSessionsTotal        *prometheus.CounterVec
@@ -211,6 +213,18 @@ func NewPromMetrics(version, goVersion string) *PromMetrics {
 		Help:      "Review reaction escalation outcomes.",
 	}, []string{"action"})
 
+	botReviewChecksTotal := prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "sortie",
+		Name:      "bot_review_checks_total",
+		Help:      "Bot review comment check outcomes.",
+	}, []string{"result"})
+
+	botReviewEscalationsTotal := prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "sortie",
+		Name:      "bot_review_escalations_total",
+		Help:      "Bot review reaction escalation outcomes.",
+	}, []string{"action"})
+
 	autoMergeReactionsTotal := prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "sortie",
 		Name:      "reactions_auto_merge_total",
@@ -273,6 +287,8 @@ func NewPromMetrics(version, goVersion string) *PromMetrics {
 		ciEscalationsTotal,
 		reviewChecksTotal,
 		reviewEscalationsTotal,
+		botReviewChecksTotal,
+		botReviewEscalationsTotal,
 		autoMergeReactionsTotal,
 		dispatchRuleMatchTotal,
 		selfReviewIterationsTotal,
@@ -306,6 +322,8 @@ func NewPromMetrics(version, goVersion string) *PromMetrics {
 		ciEscalationsTotal:             ciEscalationsTotal,
 		reviewChecksTotal:              reviewChecksTotal,
 		reviewEscalationsTotal:         reviewEscalationsTotal,
+		botReviewChecksTotal:           botReviewChecksTotal,
+		botReviewEscalationsTotal:      botReviewEscalationsTotal,
 		autoMergeReactionsTotal:        autoMergeReactionsTotal,
 		dispatchRuleMatchTotal:         dispatchRuleMatchTotal,
 		selfReviewIterationsTotal:      selfReviewIterationsTotal,
@@ -444,6 +462,16 @@ func (p *PromMetrics) IncReviewChecks(result string) {
 // IncReviewEscalations increments the review escalation action counter.
 func (p *PromMetrics) IncReviewEscalations(action string) {
 	p.reviewEscalationsTotal.WithLabelValues(action).Inc()
+}
+
+// IncBotReviewChecks increments the bot review comment check outcome counter.
+func (p *PromMetrics) IncBotReviewChecks(result string) {
+	p.botReviewChecksTotal.WithLabelValues(result).Inc()
+}
+
+// IncBotReviewEscalations increments the bot review escalation action counter.
+func (p *PromMetrics) IncBotReviewEscalations(action string) {
+	p.botReviewEscalationsTotal.WithLabelValues(action).Inc()
 }
 
 // IncAutoMergeReactions increments the auto-merge reaction outcome

--- a/internal/server/metrics_test.go
+++ b/internal/server/metrics_test.go
@@ -133,6 +133,8 @@ func TestNewPromMetrics(t *testing.T) {
 	m.IncCIEscalations("label")
 	m.IncReviewChecks("dispatched")
 	m.IncReviewEscalations("label")
+	m.IncBotReviewChecks("dispatched")
+	m.IncBotReviewEscalations("label")
 	m.IncAutoMergeReactions("merged")
 	m.IncDispatchRuleMatch("rule", "bug-rule")
 	m.IncSelfReviewIterations("pass")
@@ -821,6 +823,74 @@ func TestPromMetrics_AutoMergeCounter(t *testing.T) {
 		}
 		if got := counterValue(t, families, "sortie_reactions_auto_merge_total", map[string]string{"result": "escalated"}); got != 1 {
 			t.Errorf("sortie_reactions_auto_merge_total{result=escalated} = %v, want 1", got)
+		}
+	})
+}
+
+func TestPromMetrics_BotReviewCounters(t *testing.T) {
+	t.Parallel()
+
+	t.Run("IncBotReviewChecks_Dispatched", func(t *testing.T) {
+		t.Parallel()
+		m := newTestMetrics(t)
+		m.IncBotReviewChecks("dispatched")
+		families := gatherFamilies(t, m)
+		got := counterValue(t, families, "sortie_bot_review_checks_total", map[string]string{"result": "dispatched"})
+		if got != 1 {
+			t.Errorf("sortie_bot_review_checks_total{result=dispatched} = %v, want 1", got)
+		}
+	})
+
+	t.Run("IncBotReviewChecks_Error_Twice", func(t *testing.T) {
+		t.Parallel()
+		m := newTestMetrics(t)
+		m.IncBotReviewChecks("error")
+		m.IncBotReviewChecks("error")
+		families := gatherFamilies(t, m)
+		got := counterValue(t, families, "sortie_bot_review_checks_total", map[string]string{"result": "error"})
+		if got != 2 {
+			t.Errorf("sortie_bot_review_checks_total{result=error} = %v, want 2", got)
+		}
+	})
+
+	t.Run("IncBotReviewChecks_MultipleLabels_Independent", func(t *testing.T) {
+		t.Parallel()
+		m := newTestMetrics(t)
+		m.IncBotReviewChecks("dispatched")
+		m.IncBotReviewChecks("dispatched")
+		m.IncBotReviewChecks("error")
+		families := gatherFamilies(t, m)
+		if got := counterValue(t, families, "sortie_bot_review_checks_total", map[string]string{"result": "dispatched"}); got != 2 {
+			t.Errorf("sortie_bot_review_checks_total{result=dispatched} = %v, want 2", got)
+		}
+		if got := counterValue(t, families, "sortie_bot_review_checks_total", map[string]string{"result": "error"}); got != 1 {
+			t.Errorf("sortie_bot_review_checks_total{result=error} = %v, want 1", got)
+		}
+	})
+
+	t.Run("IncBotReviewEscalations_Label", func(t *testing.T) {
+		t.Parallel()
+		m := newTestMetrics(t)
+		m.IncBotReviewEscalations("label")
+		families := gatherFamilies(t, m)
+		got := counterValue(t, families, "sortie_bot_review_escalations_total", map[string]string{"action": "label"})
+		if got != 1 {
+			t.Errorf("sortie_bot_review_escalations_total{action=label} = %v, want 1", got)
+		}
+	})
+
+	t.Run("IncBotReviewEscalations_CommentAndError_Independent", func(t *testing.T) {
+		t.Parallel()
+		m := newTestMetrics(t)
+		m.IncBotReviewEscalations("comment")
+		m.IncBotReviewEscalations("error")
+		m.IncBotReviewEscalations("error")
+		families := gatherFamilies(t, m)
+		if got := counterValue(t, families, "sortie_bot_review_escalations_total", map[string]string{"action": "comment"}); got != 1 {
+			t.Errorf("sortie_bot_review_escalations_total{action=comment} = %v, want 1", got)
+		}
+		if got := counterValue(t, families, "sortie_bot_review_escalations_total", map[string]string{"action": "error"}); got != 2 {
+			t.Errorf("sortie_bot_review_escalations_total{action=error} = %v, want 2", got)
 		}
 	})
 }


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Feat

**Intent:** Automated review tools (linters, static analyzers, security scanners) post PR comments with different semantics and cadence than human reviewers. This adds a dedicated `bot-review` reaction kind that detects those comments and routes them to the agent as an independent continuation turn, separate from the existing human review comment path.

**Related Issues:** #415

### 🧭 Reviewer Guide

**Complexity:** High

#### Entry Point

Start with `internal/orchestrator/bot_review_reconcile.go`. It is the new reconcile pass and contains the full bot-review polling loop — TTL enforcement, poll throttle, turn-cap check, `FetchBotReviewComments` call, outdated-comment filtering, fingerprint upsert, immediate dispatch, and escalation. The design mirrors `review_reconcile.go` but omits the debounce gate and calls `FetchBotReviewComments` with the operator allowlist instead.

#### Sensitive Areas

- `internal/orchestrator/state.go`: adds `ReactionKindBotReview`, `BotReviewReactionData`, `BotReviewReactionConfig`, and `BuildBotReviewReactionConfig`. The `isKnownReactionKind` switch now includes `"bot-review"` — missing this would silently drop recovered entries.
- `internal/orchestrator/exit.go`: seeds the `bot-review` pending entry on worker exit. Mirrors the existing review and auto-merge seeding blocks. Gated on `BotReviewReactionConfigured` and a pre-existing `reactionEnqueueAllowed` guard.
- `internal/orchestrator/recovery.go`: recovers `bot-review` pending entries at startup for recent handoff-stage runs. Adds `BotReviewRecovered` to the outcome struct for the startup log.
- `internal/scm/github/review.go`: implements `FetchBotReviewComments` and the `isBotAuthor` predicate. Bot classification reads only `user.type` and `user.login`; no comment-body heuristics.
- `cmd/sortie/main.go`: generalises the two-way SCM provider conflict check (`review_comments` vs `auto_merge`) into `scmProviderConflict`, which now also covers `bot_review`. A single `SCMAdapter` instance is shared across all three kinds.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes. `FetchBotReviewComments` is a new method on `SCMAdapter`; any non-GitHub adapter stub will need a no-op implementation to satisfy the interface.
- **Migrations/State:** No database migrations. The `bot-review` kind is recognised by the existing `isKnownReactionKind` guard, so persisted entries written by this build are ignored cleanly by older builds (unknown kind → dropped on recovery).