### PR TITLE
feat: add merge-conflict reaction kind for automatic rebase dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,27 +9,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Bot-review reaction kind: automated review-bot comments (linters,
-  static analyzers, security scanners, and AI reviewers) on a
-  Sortie-created pull request are now detected separately from human
-  review comments and routed back into the agent session as
-  continuation turns. Enable it with a `reactions.bot_review` block in
-  WORKFLOW.md: `provider` activates the kind (an empty provider leaves
-  it inactive), `bot_usernames` is an allowlist of bot login names,
-  `max_continuation_turns` caps continuation attempts (default 5),
-  `poll_interval_ms` sets the poll cadence (default 60000, minimum
-  30000), and `escalation` (`label` or `comment`, default `label`)
-  with `escalation_label` (default `needs-human`) controls handoff
-  once the budget is exhausted. Comments are classified as bot-authored
-  by the platform author type or the configured username allowlist,
-  never by comment content. Unlike human review comments, bot comments
-  dispatch immediately with no debounce window and carry an independent
-  retry budget, fingerprint, and escalation config, so the bot-review
-  and human-review kinds never interfere on the same pull request.
-  Visible on startup as a `bot review routing enabled` log line and via
-  the `sortie_bot_review_checks_total` and
-  `sortie_bot_review_escalations_total` metrics.
+- Bot-review reaction kind: review-bot comments (linters, static
+  analyzers, security scanners, and AI reviewers) on a Sortie-created
+  pull request are now detected and routed back into the agent session
+  as continuation turns, separately from human review comments.
+  Configure it with a `reactions.bot_review` block in WORKFLOW.md, where
+  `provider` activates the kind, `bot_usernames` allowlists bot logins,
+  and `max_continuation_turns`, `poll_interval_ms`, and `escalation`
+  tune the retry budget, poll cadence, and handoff. A comment is
+  classified as bot-authored by its platform author type or the
+  allowlist, never by its content; bot comments dispatch immediately
+  with no debounce window and own an independent retry budget,
+  fingerprint, and escalation, so the bot-review and human-review kinds
+  never interfere on the same pull request.
   ([#415](https://github.com/sortie-ai/sortie/issues/415))
+
+- Merge-conflict reaction kind: the orchestrator now polls mergeability
+  on every open Sortie-managed PR each reconcile cycle. When a PR
+  transitions from no-conflict to conflict a single continuation turn is
+  dispatched, instructing the agent to rebase the PR head branch onto
+  the real base branch and resolve the conflicts on the existing
+  workspace. Configure it with a `reactions.merge_conflicts` block in
+  WORKFLOW.md, where `provider` activates the kind,
+  `max_retries` caps rebase attempts (default 1, lower than other kinds
+  because conflict resolution is less likely to succeed on retry),
+  `poll_interval_ms` sets the poll cadence (default 60000, minimum
+  30000), and `escalation` (`label` or `comment`, default `label`) with
+  `escalation_label` (default `needs-human`) controls handoff once the
+  budget is exhausted. Conflict tracking is episodic: resolving a
+  conflict closes the episode and resets the counter, so a later
+  independent conflict opens a fresh retry budget. Tracked via
+  `sortie_merge_conflict_checks_total` and
+  `sortie_merge_conflict_escalations_total` metrics.
+  ([#416](https://github.com/sortie-ai/sortie/issues/416))
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,22 +25,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#415](https://github.com/sortie-ai/sortie/issues/415))
 
 - Merge-conflict reaction kind: the orchestrator now polls mergeability
-  on every open Sortie-managed PR each reconcile cycle. When a PR
-  transitions from no-conflict to conflict a single continuation turn is
-  dispatched, instructing the agent to rebase the PR head branch onto
-  the real base branch and resolve the conflicts on the existing
-  workspace. Configure it with a `reactions.merge_conflicts` block in
-  WORKFLOW.md, where `provider` activates the kind,
-  `max_retries` caps rebase attempts (default 1, lower than other kinds
-  because conflict resolution is less likely to succeed on retry),
-  `poll_interval_ms` sets the poll cadence (default 60000, minimum
-  30000), and `escalation` (`label` or `comment`, default `label`) with
-  `escalation_label` (default `needs-human`) controls handoff once the
-  budget is exhausted. Conflict tracking is episodic: resolving a
-  conflict closes the episode and resets the counter, so a later
-  independent conflict opens a fresh retry budget. Tracked via
-  `sortie_merge_conflict_checks_total` and
-  `sortie_merge_conflict_escalations_total` metrics.
+  of each open Sortie-managed pull request per reconcile cycle and, on a
+  no-conflict-to-conflict transition, dispatches a single continuation
+  turn that rebases the PR branch onto its base and resolves the
+  conflicts on the existing workspace. Configure it with a
+  `reactions.merge_conflicts` block in WORKFLOW.md, where `provider`
+  activates the kind and `max_retries`, `poll_interval_ms`, and
+  `escalation` tune the retry budget, poll cadence, and handoff; the
+  retry budget defaults lower than other reaction kinds because conflict
+  resolution rarely succeeds on retry. Tracking is episodic: resolving a
+  conflict resets the budget, so a later independent conflict gets a
+  fresh attempt rather than immediate escalation.
   ([#416](https://github.com/sortie-ai/sortie/issues/416))
 
 ### Changed

--- a/cmd/sortie/main.go
+++ b/cmd/sortie/main.go
@@ -370,18 +370,23 @@ func run(ctx context.Context, args []string, stdout io.Writer, stderr io.Writer)
 	var autoMergeConfigured bool
 	var botReviewConfig orchestrator.BotReviewReactionConfig
 	var botReviewConfigured bool
+	var mergeConflictConfig orchestrator.MergeConflictReactionConfig
+	var mergeConflictConfigured bool
 
 	reviewRC, hasReview := br.cfg.Reactions["review_comments"]
 	autoMergeRC, hasAutoMerge := br.cfg.Reactions["auto_merge"]
 	botReviewRC, hasBotReview := br.cfg.Reactions["bot_review"]
+	mergeConflictRC, hasMergeConflict := br.cfg.Reactions["merge_conflicts"]
 	reviewActive := hasReview && reviewRC.Provider != ""
 	autoMergeActive := hasAutoMerge && autoMergeRC.Provider != ""
 	botReviewActive := hasBotReview && botReviewRC.Provider != ""
+	mergeConflictActive := hasMergeConflict && mergeConflictRC.Provider != ""
 
 	activeSCMKinds := []scmReactionKind{
 		{name: "review_comments", active: reviewActive, provider: reviewRC.Provider},
 		{name: "auto_merge", active: autoMergeActive, provider: autoMergeRC.Provider},
 		{name: "bot_review", active: botReviewActive, provider: botReviewRC.Provider},
+		{name: "merge_conflicts", active: mergeConflictActive, provider: mergeConflictRC.Provider},
 	}
 	if conflictKinds, conflictProviders := scmProviderConflict(activeSCMKinds); len(conflictProviders) > 1 {
 		br.logger.Error("unsupported: active SCM reaction kinds must use the same provider",
@@ -391,8 +396,8 @@ func run(ctx context.Context, args []string, stdout io.Writer, stderr io.Writer)
 		return 1
 	}
 
-	if reviewActive || autoMergeActive || botReviewActive {
-		provider := cmp.Or(reviewRC.Provider, autoMergeRC.Provider, botReviewRC.Provider)
+	if reviewActive || autoMergeActive || botReviewActive || mergeConflictActive {
+		provider := cmp.Or(reviewRC.Provider, autoMergeRC.Provider, botReviewRC.Provider, mergeConflictRC.Provider)
 		scmCtor, scmErr := registry.SCMAdapters.Get(provider)
 		if scmErr != nil {
 			br.logger.Error("unknown SCM adapter kind",
@@ -422,6 +427,13 @@ func run(ctx context.Context, args []string, stdout io.Writer, stderr io.Writer)
 		}
 		if botReviewActive {
 			for k, v := range botReviewRC.Extra {
+				if _, exists := adapterCfgMap[k]; !exists {
+					adapterCfgMap[k] = v
+				}
+			}
+		}
+		if mergeConflictActive {
+			for k, v := range mergeConflictRC.Extra {
 				if _, exists := adapterCfgMap[k]; !exists {
 					adapterCfgMap[k] = v
 				}
@@ -487,6 +499,21 @@ func run(ctx context.Context, args []string, stdout io.Writer, stderr io.Writer)
 				slog.Int("poll_interval_ms", botReviewConfig.PollIntervalMS),
 			)
 		}
+
+		if mergeConflictActive {
+			mergeConflictConfig, scmErr = orchestrator.BuildMergeConflictReactionConfig(mergeConflictRC)
+			if scmErr != nil {
+				br.logger.Error("invalid merge_conflicts reaction config", slog.Any("error", scmErr))
+				return 1
+			}
+			mergeConflictConfigured = true
+
+			br.logger.Info("merge conflict reaction enabled",
+				slog.String("provider", mergeConflictRC.Provider),
+				slog.Int("poll_interval_ms", mergeConflictConfig.PollIntervalMS),
+				slog.Int("max_retries", mergeConflictConfig.MaxRetries),
+			)
+		}
 	}
 
 	recoveryEnabled := br.cfg.Tracker.HandoffState != "" && (ciProvider != nil || scmAdapter != nil)
@@ -500,16 +527,17 @@ func run(ctx context.Context, args []string, stdout io.Writer, stderr io.Writer)
 		recoveryRuns, recoveryErr = store.LoadLatestSuccessfulRunsForReactionRecovery(ctx, recoveryCutoff, orchestrator.PendingReactionRecoveryMaxCandidates)
 		if recoveryErr == nil {
 			recoveryOutcome, recoveryErr = orchestrator.RecoverPendingReactions(ctx, state, recoveryRuns, orchestrator.PendingReactionRecoveryParams{
-				WorkspaceRoot:               br.cfg.Workspace.Root,
-				TrackerAdapter:              br.trackerAdapter,
-				HandoffState:                br.cfg.Tracker.HandoffState,
-				TerminalStates:              br.cfg.Tracker.TerminalStates,
-				CIProvider:                  ciProvider,
-				SCMAdapter:                  scmAdapter,
-				AutoMergeReactionConfigured: autoMergeConfigured,
-				BotReviewReactionConfigured: botReviewConfigured,
-				RecoveryLookback:            recoveryLookback,
-				MaxCandidates:               orchestrator.PendingReactionRecoveryMaxCandidates,
+				WorkspaceRoot:                   br.cfg.Workspace.Root,
+				TrackerAdapter:                  br.trackerAdapter,
+				HandoffState:                    br.cfg.Tracker.HandoffState,
+				TerminalStates:                  br.cfg.Tracker.TerminalStates,
+				CIProvider:                      ciProvider,
+				SCMAdapter:                      scmAdapter,
+				AutoMergeReactionConfigured:     autoMergeConfigured,
+				BotReviewReactionConfigured:     botReviewConfigured,
+				MergeConflictReactionConfigured: mergeConflictConfigured,
+				RecoveryLookback:                recoveryLookback,
+				MaxCandidates:                   orchestrator.PendingReactionRecoveryMaxCandidates,
 				NowFunc: func() time.Time {
 					return recoveryNow
 				},
@@ -526,6 +554,7 @@ func run(ctx context.Context, args []string, stdout io.Writer, stderr io.Writer)
 		slog.Int("ci_recovered", recoveryOutcome.CIRecovered),
 		slog.Int("auto_merge_recovered", recoveryOutcome.AutoMergeRecovered),
 		slog.Int("bot_review_recovered", recoveryOutcome.BotReviewRecovered),
+		slog.Int("merge_conflict_recovered", recoveryOutcome.MergeConflictRecovered),
 		slog.Int("stale_skipped", recoveryOutcome.StaleSkipped),
 		slog.Int("skipped", recoveryOutcome.Skipped),
 	}
@@ -602,26 +631,28 @@ func run(ctx context.Context, args []string, stdout io.Writer, stderr io.Writer)
 	}
 
 	o := orchestrator.NewOrchestrator(orchestrator.OrchestratorParams{
-		State:                       state,
-		Logger:                      br.logger,
-		TrackerAdapter:              br.trackerAdapter,
-		AgentAdapter:                agentAdapter,
-		AgentAdapterByKind:          agentAdapterByKind,
-		WorkflowManager:             br.mgr,
-		Store:                       store,
-		PreflightParams:             br.preflightParams,
-		Metrics:                     orchMetrics,
-		ToolRegistry:                toolRegistry,
-		SessionToolRegistryFunc:     sessionToolFunc,
-		WorkflowFileFunc:            br.mgr.FilePath,
-		DBPath:                      dbPath,
-		CIProvider:                  ciProvider,
-		SCMAdapter:                  scmAdapter,
-		ReviewConfig:                reviewConfig,
-		AutoMergeConfig:             autoMergeConfig,
-		AutoMergeReactionConfigured: autoMergeConfigured,
-		BotReviewConfig:             botReviewConfig,
-		BotReviewConfigured:         botReviewConfigured,
+		State:                           state,
+		Logger:                          br.logger,
+		TrackerAdapter:                  br.trackerAdapter,
+		AgentAdapter:                    agentAdapter,
+		AgentAdapterByKind:              agentAdapterByKind,
+		WorkflowManager:                 br.mgr,
+		Store:                           store,
+		PreflightParams:                 br.preflightParams,
+		Metrics:                         orchMetrics,
+		ToolRegistry:                    toolRegistry,
+		SessionToolRegistryFunc:         sessionToolFunc,
+		WorkflowFileFunc:                br.mgr.FilePath,
+		DBPath:                          dbPath,
+		CIProvider:                      ciProvider,
+		SCMAdapter:                      scmAdapter,
+		ReviewConfig:                    reviewConfig,
+		AutoMergeConfig:                 autoMergeConfig,
+		AutoMergeReactionConfigured:     autoMergeConfigured,
+		BotReviewConfig:                 botReviewConfig,
+		BotReviewConfigured:             botReviewConfigured,
+		MergeConflictConfig:             mergeConflictConfig,
+		MergeConflictReactionConfigured: mergeConflictConfigured,
 	})
 
 	var srv *server.Server

--- a/cmd/sortie/sample_workflow_test.go
+++ b/cmd/sortie/sample_workflow_test.go
@@ -191,6 +191,68 @@ func TestSampleWorkflowRender(t *testing.T) {
 	}
 }
 
+// shippedExampleWorkflows are the operator-facing templates that carry a
+// continuation region and a {{ if .merge_conflict }} branch. WORKFLOW.test.md
+// is excluded: it is a minimal single-block fixture with no continuation
+// region.
+var shippedExampleWorkflows = []string{
+	"WORKFLOW.md",
+	"WORKFLOW.codex.md",
+	"WORKFLOW.copilot.md",
+	"WORKFLOW.opencode.md",
+	"WORKFLOW.linear.md",
+	"WORKFLOW.kiro.md",
+}
+
+// TestSampleWorkflowMergeConflictBranch verifies AC13: each shipped example
+// workflow renders under missingkey=error both when merge_conflict is nil (the
+// branch is skipped, no error) and when it is populated (the branch renders and
+// the output carries the real base named by .merge_conflict.base).
+func TestSampleWorkflowMergeConflictBranch(t *testing.T) {
+	t.Parallel()
+
+	for _, file := range shippedExampleWorkflows {
+		t.Run(file, func(t *testing.T) {
+			t.Parallel()
+
+			tmpl := loadSampleWorkflow(t, file)
+
+			// merge_conflict nil: the branch is skipped, render must not error
+			// under missingkey=error.
+			rc := prompt.RunContext{TurnNumber: 1, MaxTurns: 15, IsContinuation: false}
+			nilOut, err := tmpl.Render(fullIssue(), nil, rc)
+			if err != nil {
+				t.Fatalf("Render(%s, merge_conflict=nil): %v", file, err)
+			}
+			if strings.Contains(nilOut, "release/2.0") {
+				t.Errorf("Render(%s, merge_conflict=nil) leaked base %q; want branch skipped", file, "release/2.0")
+			}
+
+			// merge_conflict populated: the branch renders and the output must
+			// contain the real base value, not a hardcoded default.
+			mergeConflict := map[string]any{
+				"pr_number": 99,
+				"branch":    "feature/conflict",
+				"head_sha":  "deadbeef",
+				"base":      "release/2.0",
+			}
+			contRC := prompt.RunContext{TurnNumber: 3, MaxTurns: 15, IsContinuation: true}
+			gotOut, err := tmpl.Render(fullIssue(), nil, contRC,
+				prompt.WithContinuationContext(map[string]any{"merge_conflict": mergeConflict}),
+			)
+			if err != nil {
+				t.Fatalf("Render(%s, merge_conflict populated): %v", file, err)
+			}
+			if !strings.Contains(gotOut, "release/2.0") {
+				t.Errorf("Render(%s, merge_conflict populated) output missing base %q (want .merge_conflict.base interpolated)", file, "release/2.0")
+			}
+			if !strings.Contains(gotOut, "feature/conflict") {
+				t.Errorf("Render(%s, merge_conflict populated) output missing head branch %q", file, "feature/conflict")
+			}
+		})
+	}
+}
+
 func TestSampleWorkflowContinuationShorter(t *testing.T) {
 	t.Parallel()
 

--- a/docs/architecture-digest.md
+++ b/docs/architecture-digest.md
@@ -18,7 +18,7 @@
 - **Status Surface.** Optional HTTP server exposing operator-readable runtime state. Not required for orchestrator correctness.
 - **Logging.** Structured logs (`log/slog`) routed to one or more sinks.
 - **CI Status Provider.** Read-only single-method (`FetchCIStatus`) adapter. Activated only when workflow front matter requests CI feedback.
-- **SCM Adapter.** Read-write multi-method adapter exposing seven methods (`FetchPendingReviews`, `FetchBotReviewComments`, `GetReviewDecision`, `GetCIStatus`, `GetMergeability`, `MergePR`, `DeleteBranch`). Activated when `reactions.review_comments.provider`, `reactions.auto_merge.provider`, or `reactions.bot_review.provider` is configured.
+- **SCM Adapter.** Read-write multi-method adapter exposing seven methods (`FetchPendingReviews`, `FetchBotReviewComments`, `GetReviewDecision`, `GetCIStatus`, `GetMergeability`, `MergePR`, `DeleteBranch`). Activated when `reactions.review_comments.provider`, `reactions.auto_merge.provider`, `reactions.bot_review.provider`, or `reactions.merge_conflicts.provider` is configured.
 - **Notifier Adapter.** Read-write single-method (`Send`) adapter family behind the `notify_operator` agent tool. Activated when the top-level `notifications` list configures at least one backend (`webhook`, `slack` today). Resolved in the `sortie mcp-server` sidecar, not the orchestrator process.
 
 ## 2. Abstraction layers (strict downward dependency)
@@ -41,7 +41,7 @@ Existing adapter dimensions:
 - **Tracker adapters** — Jira, GitHub, Linear.
 - **Agent adapters** — Claude Code, Codex, Copilot.
 - **CI status providers** — GitHub Checks (only when `ci_feedback.kind: github` or `reactions.ci_failure.provider: github`).
-- **SCM adapters** — GitHub (only when `reactions.review_comments.provider: github` or `reactions.auto_merge.provider: github`).
+- **SCM adapters** — GitHub (only when `reactions.review_comments.provider: github`, `reactions.auto_merge.provider: github`, `reactions.bot_review.provider: github`, or `reactions.merge_conflicts.provider: github`).
 - **Notifier adapters** — webhook, Slack (only when the `notifications` list configures a backend of that `kind`). Registered via `init()` into `registry.Notifiers`; resolved by the MCP sidecar.
 
 ## 4. Hard constraints (memory refresh)
@@ -78,6 +78,7 @@ Open [`docs/architecture.md`](architecture.md) when your feature touches one of 
 | §11B PR Review Comment Feedback Contract              | Wiring review-comment feedback (SCM provider activation, pending-review semantics)                 |
 | §11C Auto-merge Reaction Contract                     | Wiring auto-merge reactions, SCM write methods (`MergePR`, `DeleteBranch`), the startup token-scope preflight, or the merge fingerprint kind |
 | §11D Bot Review Comment Feedback Contract             | Wiring bot review-comment feedback (bot-author classification, the `bot-review` reaction kind, immediate non-debounced dispatch)             |
+| §11E Merge Conflict Reaction Contract                 | Wiring merge-conflict reactions, `PRMergeStatus.BaseBranch`, episodic retry/escalation, or the `merge-conflict` fingerprint kind             |
 | §12 Prompt Construction and Context Assembly          | Changing prompt rendering, FuncMap, or context fields supplied to the template                     |
 | §13 Logging, Status, and Observability                | Adding log fields, metrics, status endpoints, or dashboard surfaces                                |
 | §14 Failure Model and Recovery Strategy               | Changing retry/backoff, restart-recovery, or failure categorization                                |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -3162,6 +3162,212 @@ Per-issue `bot-review` reaction lifecycle (the `issue_id:bot-review` slot):
 | pending | Reconcile tick, attempts reach cap | escalated | Apply escalation; clear ONLY the `bot-review` slot. MUST NOT release the claim or clear sibling slots (§11D.5). |
 | pending | Issue reaches terminal state (tracker reconcile) | (cleared) | `ClearReactionsForIssue` removes the slot, the residual counter, and the claim. |
 
+## 11E. Merge Conflict Reaction Contract
+
+The `auto-merge` contract in §11C defers indefinitely when `Mergeability == dirty` (§11C.5); it
+does not act on the conflict. This section defines the complementary contract: the `merge-conflict`
+reaction kind detects that a managed open PR has merge conflicts, dispatches a single rebase-and-resolve
+continuation turn per no-conflict-to-conflict transition, and escalates under an independent episodic
+budget. Like §11B and §11D it is a read-only integration; it never calls `MergePR` or modifies the
+SCM platform state directly.
+
+The two kinds coexist on the same PR without interference. Each owns a distinct `pending_reactions`
+entry, `reaction_fingerprints` row, and `reaction_attempts` counter, because every key is composed
+via `ReactionKey(issue_id, kind)` and the fingerprint table primary key is `(issue_id, kind)`.
+There is the same YAML-versus-runtime asymmetry §11C.4 documents for auto-merge: the operator sets
+`reactions.merge_conflicts` in `WORKFLOW.md`, while the runtime and persisted kind discriminator is
+`merge-conflict`.
+
+### 11E.1 SCMAdapter interface
+
+Conflict detection reuses the existing `GetMergeability` read. No new method is added to the
+`SCMAdapter` interface. The interface's `PRMergeStatus` return type gains one additive field:
+
+```go
+// PRMergeStatus addition (internal/domain/scm.go):
+BaseBranch string
+```
+
+`BaseBranch` carries the PR target (base) branch name, for example `"main"` or `"develop"`. The
+GitHub adapter populates it from the `base.ref` field of the PR object that `GetMergeability`
+already fetches, at no additional request cost. Other callers of `GetMergeability` (the auto-merge
+reconcile pass) ignore the new field. Platform-specific field names do not leave the adapter
+package; the orchestrator reads only the domain field.
+
+### 11E.2 Detection rule
+
+A PR is conflicted when `status.Mergeability == MergeabilityDirty`. `MergeabilityUnknown` is a
+deferral condition (the provider is still computing), not a conflict. The two values MUST NOT be
+conflated: `MergeabilityUnknown` defers at the poll interval without touching the fingerprint or
+the attempt counter, exactly as auto-merge handles it (§11C.5).
+
+### 11E.3 Reconcile loop integration
+
+The merge-conflict reconcile pass runs after `reconcileBotReviewComments` and before
+`reconcileAutoMerge` in each poll tick. It is skipped entirely when no `SCMAdapter` is constructed
+or when merge-conflict is not configured.
+
+The state machine mirrors `reconcileCIStatus` (§11A), not the bot-review or auto-merge loops. The
+defining property: there is no retry-budget check before the `GetMergeability` read. The read runs
+on every due tick so the not-dirty branch (N1, which resets the per-episode attempt counter) is
+always reachable. The budget check and the attempt increment live inside the dirty branch (D1), after
+the precondition guards and the head-SHA dedup. The comparison is strict over-limit
+(`attempts > MaxRetries`), matching `handleCIFailure`.
+
+Loop body per `ReactionKindMergeConflict` entry in `state.PendingReactions`:
+
+1. Delete the entry from the map (prevents reprocessing within the same tick).
+2. Type-assert `KindData` to `*MergeConflictReactionData`; on mismatch, log and skip.
+3. Drop the entry when its age exceeds `MergeConflictPendingTTL` (TTL backstop).
+4. Respect the `PendingRetryAt` poll throttle: if `now < PendingRetryAt`, re-enqueue and continue.
+5. Call `GetMergeability`. On error, increment the pending-backoff counter, set `PendingRetryAt`,
+   re-enqueue, count `sortie_merge_conflict_checks_total{result="error"}`, and continue.
+6. Switch on `status.Mergeability`:
+   - `MergeabilityUnknown` (U1): re-enqueue at `now + poll_interval`; count `"unknown"`; do not
+     touch the fingerprint or the attempt counter.
+   - `MergeabilityDirty` (D1): apply the dirty-branch logic described in §11E.4 and §11E.5.
+   - All other values (`clean`, `unstable`, `blocked`) (N1): delete the fingerprint row; delete the
+     per-episode attempt counter (`delete(state.ReactionAttempts, rkey)`); re-enqueue at
+     `now + poll_interval`; count `"clear"`. This closes the episode.
+
+### 11E.4 Fingerprint and deduplication
+
+Before any dispatch, the dirty branch applies two precondition guards. Both run before any counter
+increment, so a deferral never burns an attempt:
+
+- **D1a**: if `status.HeadSHA == ""`, defer at poll interval (no rebase anchor).
+- **D1b**: if `status.BaseBranch == ""`, defer at poll interval (no rebase target). This is
+  defense-in-depth: the GitHub adapter always populates `BaseBranch` from `base.ref`, so D1b is a
+  safety net rather than a normal-operation path for the only wired provider.
+
+After both guards pass, the fingerprint is computed as `sha256(headSHA)` and upserted into
+`reaction_fingerprints` with `kind = "merge-conflict"`. The reaction reuses the existing table;
+no migration is required. The fingerprint key `(issue_id, "merge-conflict")` is independent of
+the `"merge"` fingerprint the auto-merge reaction maintains.
+
+When the stored fingerprint matches the computed value and is marked dispatched, the entry is
+re-enqueued at `now + poll_interval` with no increment and no dispatch. This dedup prevents a
+persistent same-head observation from firing multiple continuations while the rebase is in flight.
+
+The fingerprint churns on each new push: a new head SHA produces a new fingerprint with
+`dispatched = 0`, so a conflict that persists across a rebase re-arms a new attempt. The N1 branch
+deletes the row entirely when the PR is not dirty, so the first subsequent dirty observation always
+finds `dispatched = 0` and dispatches.
+
+### 11E.5 Escalation and episode exits
+
+When the fingerprint dedup passes, the per-episode counter increments and the strict over-limit cap
+is checked:
+
+- `state.ReactionAttempts[rkey]++`; `attempts = state.ReactionAttempts[rkey]`
+- If `attempts > MaxRetries` (default 1): invoke `escalateMergeConflictFailure`.
+- Otherwise: invoke `dispatchMergeConflictContinuation`.
+
+`escalateMergeConflictFailure` applies the configured escalation action (label or comment) in a
+detached `TrackerOpsWg` goroutine with a 30-second timeout, then performs the episode-exit cleanup:
+
+- `escalation: label` (default): add `escalation_label` (default `needs-human`) to the tracker
+  issue via `TrackerAdapter.AddLabel`.
+- `escalation: comment`: post a plain-text comment naming the PR number and the number of attempts,
+  via `TrackerAdapter.CommentIssue`.
+
+Episode-exit cleanup is identical for both escalation postures. After the action:
+
+```
+delete(state.PendingReactions,    ReactionKey(issueID, "merge-conflict"))
+DeleteReactionFingerprint(issueID, "merge-conflict")
+delete(state.ReactionAttempts,    ReactionKey(issueID, "merge-conflict"))
+```
+
+The counter reset is the scoped per-kind delete, NOT the issue-wide `ClearReactionsForIssue`. This
+makes both episode exits symmetric: the N1 branch and the escalation exit each leave the counter
+deleted, so a later independent conflict always opens a fresh episode at `attempts = 1` regardless of
+which exit closed the prior episode.
+
+Cross-kind isolation: `escalateMergeConflictFailure` MUST scope all deletions to the `merge-conflict`
+kind only. It MUST NOT call `CancelRetry`, `DeleteRetryEntry`, `ClearReactionsForIssue`, or
+`delete state.Claimed[issue_id]`. A failed merge-conflict resolution MUST NOT invalidate parallel
+`ci`, `review`, `bot-review`, or `merge` reactions on the same issue. Escalation tracker-call
+failures are logged and counted (`sortie_merge_conflict_escalations_total{action="error"}`) but do
+not block the slot-scoped cleanup.
+
+### 11E.6 Continuation data
+
+`dispatchMergeConflictContinuation` calls `CancelRetry`, then schedules a continuation turn via
+`ScheduleRetry` with the prompt key `merge_conflict`. The continuation map contains:
+
+| Key | Value |
+|-----|-------|
+| `pr_number` | PR number from `MergeConflictReactionData` |
+| `branch` | PR head branch (the branch the agent rebases) |
+| `head_sha` | `status.HeadSHA` at dispatch time |
+| `base` | `status.BaseBranch`, the PR's real target branch, read live from `GetMergeability` on this tick |
+
+`base` is always the PR object's actual base ref, not an assumed default branch. The orchestrator
+already holds the PR object and cannot diverge from the platform's view; the agent does not
+re-derive the base independently. `MarkReactionDispatched` is called on the same tick the
+continuation is scheduled; this is the marker the D1 dedup branch reads in subsequent ticks.
+
+The `merge_conflict` key MUST be registered in `prompt.continuationKeys` and seeded to nil in the
+template data map so `Option("missingkey=error")` does not reject templates that reference the
+field when no conflict continuation is active.
+
+### 11E.7 Seeding and recovery
+
+Worker-exit seeding applies the same metadata predicate `review` and `bot-review` use: an entry is
+created only when `SCMMetadata` reports `pr_number > 0` and non-empty `owner`, `repo`, and
+`branch`. The seeding block runs in the `WorkerExitNormal` branch of `HandleWorkerExit`, after the
+existing auto-merge enqueue block, guarded on `params.SCMAdapter != nil &&
+params.MergeConflictReactionConfigured`. A "create only if absent" guard preserves an in-progress
+pending entry across re-exits, matching the review, bot-review, and auto-merge kinds.
+
+Startup recovery re-seeds a `merge-conflict` pending entry for recent handoff-stage issues when
+`SCMMetadata` passes the same predicate. The recovered count is surfaced in the startup recovery
+log. Recovery is gated on the configured flag, so a configured-but-providerless setup recovers no
+entries, matching the §11D.6 pattern for bot-review.
+
+### 11E.8 Config and observability
+
+Activation requires `reactions.merge_conflicts.provider` to be non-empty in `WORKFLOW.md`,
+mirroring the `reactions.auto_merge.provider` activation pattern documented in §11C.4. The operator
+omits the block to disable the reaction entirely.
+
+Configuration fields:
+
+| Field | Default | Constraint |
+|-------|---------|------------|
+| `max_retries` | `1` | non-negative; `0` means escalate on first detection |
+| `escalation` | `label` | `label` or `comment` |
+| `escalation_label` | `needs-human` | none |
+| `poll_interval_ms` | `60000` | `>= 30000` |
+
+The `max_retries` default of 1 is lower than other reaction kinds (which default to 2) because
+merge-conflict resolution by a coding agent is less likely to succeed on a second attempt.
+
+Two metrics counters:
+
+- `sortie_merge_conflict_checks_total{result}`: incremented on every reconcile-loop outcome for a
+  due entry. Label values: `dispatched`, `error`, `unknown`, `clear`.
+- `sortie_merge_conflict_escalations_total{action}`: incremented inside the escalation goroutine.
+  Label values: `label`, `comment`, `error`.
+
+### 11E.9 State machine
+
+Per-issue `merge-conflict` reaction lifecycle (the `issue_id:merge-conflict` slot):
+
+| From | Event | To | Action |
+|------|-------|----|--------|
+| (none) | Worker exits normally, SCM adapter and merge-conflict configured, PR metadata present | pending | Seed the entry if absent. |
+| pending | Reconcile tick, `now < PendingRetryAt` | pending | Re-enqueue, no API call. |
+| pending | Reconcile tick, fetch error | pending | Increment backoff, set `PendingRetryAt`, re-enqueue, count error. |
+| pending | Reconcile tick, `Mergeability == unknown` | pending | Re-enqueue at `now + poll_interval`; do not touch fingerprint or counter. |
+| pending | Reconcile tick, `Mergeability != dirty` | pending | Delete fingerprint; delete per-episode counter; re-enqueue. Episode closes. |
+| pending | Reconcile tick, `Mergeability == dirty`, precondition guard fails (empty HeadSHA or BaseBranch) | pending | Re-enqueue at `now + poll_interval`; do not increment counter. |
+| pending | Reconcile tick, `Mergeability == dirty`, fingerprint dispatched for this head | pending | Re-enqueue at `now + poll_interval`; do not increment counter. |
+| pending | Reconcile tick, `Mergeability == dirty`, new head, `attempts <= MaxRetries` | dispatched | Increment per-episode counter; schedule continuation; mark dispatched; count dispatched. |
+| pending | Reconcile tick, `Mergeability == dirty`, new head, `attempts > MaxRetries` | escalated | Increment per-episode counter; apply escalation; delete slot, fingerprint, and per-episode counter. MUST NOT release the claim or clear sibling slots (§11E.5). |
+| pending | Issue reaches terminal state (tracker reconcile) | (cleared) | `ClearReactionsForIssue` removes the slot, the residual counter, and the claim. |
+
 ## 12. Prompt Construction and Context Assembly
 
 ### 12.1 Inputs

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -3346,8 +3346,10 @@ merge-conflict resolution by a coding agent is less likely to succeed on a secon
 
 Two metrics counters:
 
-- `sortie_merge_conflict_checks_total{result}`: incremented on every reconcile-loop outcome for a
-  due entry. Label values: `dispatched`, `error`, `unknown`, `clear`.
+- `sortie_merge_conflict_checks_total{result}`: incremented once per counted reconcile-loop outcome
+  for a due entry. Label values: `dispatched`, `error`, `unknown`, `clear`. Dirty-branch deferrals
+  (empty head SHA, empty base branch, or the same-head dedup early-return) and the escalation path do
+  not increment this counter.
 - `sortie_merge_conflict_escalations_total{action}`: incremented inside the escalation goroutine.
   Label values: `label`, `comment`, `error`.
 

--- a/docs/workflow-reference.md
+++ b/docs/workflow-reference.md
@@ -2148,8 +2148,8 @@ PR identity and the rebase target read live from the PR object (see
 
 The `base` value is the PR's actual base ref, not an assumed default branch, so the agent
 rebases onto the correct target for PRs that target a release branch, a GitFlow `develop`,
-or a stacked-PR parent. `base` is empty only when the provider omits the base ref (rare);
-the template author handles that case.
+or a stacked-PR parent. The orchestrator defers the continuation while the base ref is
+unavailable, so `base` is always a populated branch name when this context is emitted.
 
 When `nil` (default on non-merge-conflict dispatches), `{{ if .merge_conflict }}` evaluates
 to `false`.

--- a/docs/workflow-reference.md
+++ b/docs/workflow-reference.md
@@ -611,6 +611,16 @@ under `reactions` identifies a reaction kind.
 | `escalation`       | string  | No                    | `label`       | Future dispatches | Action when retries are exhausted. Valid: `"label"`, `"comment"`.                                |
 | `escalation_label` | string  | No                    | `needs-human` | Future dispatches | Label applied when `escalation` is `"label"`.                                                    |
 
+**Escalation recurrence:** `escalation: label` is idempotent (re-applying a
+present label is a no-op); `escalation: comment` posts a new comment each time
+it fires. For kinds whose escalation releases the issue claim (`ci_failure`,
+`review_comments`), escalation fires once and the reaction stops. For kinds
+whose escalation is scoped and keeps the claim (`auto_merge`, `bot_review`), the
+reaction re-arms if its condition recurs and escalates again, so on a long-lived
+PR `escalation: comment` can accumulate repeated comments while `escalation:
+label` stays a single mark. Prefer `label` for kinds that may escalate
+repeatedly.
+
 Remaining keys within a kind sub-object are kind-specific and collected into an `Extra` map.
 
 #### Reaction kind: `ci_failure`
@@ -813,6 +823,68 @@ reactions:
       - houndci-bot           # e.g. Hound (houndci.com), comments as a type:User account
 ```
 
+#### Reaction kind: `merge_conflicts`
+
+Merge-conflict detection and resolution. When configured, the orchestrator polls
+mergeability on Sortie-created open PRs each reconcile cycle and dispatches one
+rebase-and-resolve continuation turn each time a PR transitions from no-conflict to
+conflict. The continuation carries the PR's real base branch so the agent rebases the PR
+head branch onto the correct target and resolves the conflicts on the existing workspace.
+
+Retry semantics are episodic: a resolved conflict closes the episode and resets the
+attempt counter, so a later independent conflict opens a fresh episode rather than
+counting against the prior budget. The default `max_retries` is `1`, lower than the other
+kinds, because merge-conflict resolution is less likely to succeed on retry than a CI fix.
+
+Fields:
+
+| Field              | Type    | Default       | Dynamic Reload    | Description                                                                                              |
+| ------------------ | ------- | ------------- | ----------------- | -------------------------------------------------------------------------------------------------------- |
+| `provider`         | string  | _(required)_  | Requires restart  | SCM adapter kind. Must match the provider of every other active SCM reaction. Activates the kind.        |
+| `max_retries`      | integer | `1`           | Future dispatches | Per-episode rebase attempts before escalation. `0` escalates on first detection without a rebase attempt. |
+| `escalation`       | string  | `label`       | Future dispatches | Escalation action when retries are exhausted. One of `label` or `comment`.                               |
+| `escalation_label` | string  | `needs-human` | Future dispatches | Label applied when `escalation` is `label`.                                                              |
+| `poll_interval_ms` | integer | `60000`       | Future dispatches | Polling interval for the conflict-detection state machine. Minimum: `30000` (30 sec).                    |
+
+**Activation:** The `reactions.merge_conflicts` block is active when `provider` is present
+and non-empty, on its own, with no other `reactions` block required. Agent-created PRs MUST
+write `pr_number` (positive integer), `owner`, `repo`, and `branch` (all non-empty) to
+`.sortie/scm.json` in the workspace for merge-conflict polling to activate. To disable the
+reaction, omit the `merge_conflicts` block; setting `max_retries: 0` does not disable it but
+escalates on the first detected conflict.
+
+**Fingerprint dedup:** The fingerprint is the SHA-256 of the PR head SHA, persisted in the
+`reaction_fingerprints` SQLite table under a kind distinct from the other reactions. A
+single conflicted head dispatches exactly one rebase turn; after the agent rebases and
+pushes a new head, the new head produces a new fingerprint, so a conflict that persists
+across the rebase re-arms a new attempt bounded by `max_retries`. When the conflict clears,
+the row is deleted, so the next conflict observation dispatches again.
+
+**Cross-kind isolation:** Merge-conflict detection runs independently of every other
+reaction kind; each owns its own pending entry, fingerprint row, and attempt counter.
+Escalation cleanup is scoped to the `merge-conflict` kind only and does not release the
+issue claim or clear sibling reaction kinds. Auto-merge and merge-conflict coexist on the
+same PR: auto-merge defers while a PR is conflicted, and merge-conflict drives the
+resolution, after which auto-merge proceeds once the PR is clean and approved.
+
+**Escalation:** When `max_retries` is exhausted within an episode (a new conflicting head
+pushes the attempt count strictly over the budget), the orchestrator applies the configured
+escalation action (`label` or `comment`, default `label`, with `escalation_label`
+defaulting to `needs-human`) and removes the pending merge-conflict entry and its attempt
+counter. Other reaction kinds on the same issue are preserved.
+
+Example:
+
+```yaml
+reactions:
+  merge_conflicts:
+    provider: github
+    max_retries: 1
+    escalation: label
+    escalation_label: needs-human
+    poll_interval_ms: 60000
+```
+
 **Validation rules:**
 
 - Reaction kind keys must match `[a-z][a-z0-9_-]*`. Invalid keys are rejected with a
@@ -828,6 +900,8 @@ reactions:
 - `poll_interval_ms` must be >= `30000` for `bot_review`.
 - `max_continuation_turns` must be positive for `bot_review`.
 - `bot_usernames` for `bot_review` must be a list of strings.
+- `poll_interval_ms` must be >= `30000` for `merge_conflicts`.
+- `max_retries` for `merge_conflicts` defaults to `1` rather than `2`; an explicit value overrides.
 - When `provider` is absent or empty, all other fields in the kind sub-object are ignored.
 
 ---
@@ -2056,6 +2130,43 @@ The following comments were left on the PR by automated review tools. Address ea
 {{ .body }}
 
 {{ end }}
+{{ end }}
+```
+
+#### `merge_conflict` — Merge Conflict Context (continuation key)
+
+Non-nil only on turn 1 of a merge-conflict-resolution continuation dispatch. Contains the
+PR identity and the rebase target read live from the PR object (see
+`reactions.merge_conflicts` in Section 2.10):
+
+| Field                      | Type    | Description                                                                 |
+| -------------------------- | ------- | --------------------------------------------------------------------------- |
+| `.merge_conflict.pr_number` | integer | Pull request number.                                                        |
+| `.merge_conflict.branch`   | string  | PR head branch the agent rebases.                                           |
+| `.merge_conflict.head_sha` | string  | Latest commit SHA on the PR head branch.                                    |
+| `.merge_conflict.base`     | string  | PR's real target (base) branch, read live from the PR object. The rebase target. |
+
+The `base` value is the PR's actual base ref, not an assumed default branch, so the agent
+rebases onto the correct target for PRs that target a release branch, a GitFlow `develop`,
+or a stacked-PR parent. `base` is empty only when the provider omits the base ref (rare);
+the template author handles that case.
+
+When `nil` (default on non-merge-conflict dispatches), `{{ if .merge_conflict }}` evaluates
+to `false`.
+
+**Template pattern for merge conflicts:**
+
+```
+{{ if .merge_conflict }}
+## Resolve Merge Conflicts
+
+PR #{{ .merge_conflict.pr_number }} ({{ .merge_conflict.branch }}) has merge conflicts with
+its base branch {{ .merge_conflict.base }}. Resolve them:
+
+1. Fetch the latest {{ .merge_conflict.base }}.
+2. Rebase {{ .merge_conflict.branch }} onto {{ .merge_conflict.base }}.
+3. Resolve every conflict, keeping both the intent of the PR and the base changes.
+4. Push the rebased branch.
 {{ end }}
 ```
 

--- a/examples/WORKFLOW.codex.md
+++ b/examples/WORKFLOW.codex.md
@@ -124,6 +124,19 @@ Review the current state of the workspace - check test output, lint results, and
 partial changes. Do not repeat work already completed. Proceed with the next step.
 {{ end }}
 
+{{ if .merge_conflict }}
+
+## Resolve Merge Conflicts
+
+PR #{{ .merge_conflict.pr_number }} ({{ .merge_conflict.branch }}) has merge conflicts with
+its base branch {{ .merge_conflict.base }}. Resolve them now:
+
+1. Fetch the latest {{ .merge_conflict.base }} from the remote.
+2. Rebase {{ .merge_conflict.branch }} onto {{ .merge_conflict.base }}.
+3. Resolve every conflict, preserving both the intent of this PR and the base changes.
+4. Push the rebased branch.
+{{ end }}
+
 {{ if .attempt }}
 
 ## Retry

--- a/examples/WORKFLOW.copilot.md
+++ b/examples/WORKFLOW.copilot.md
@@ -114,6 +114,19 @@ Review the current state of the workspace, check test output, lint results, and 
 partial changes. Do not repeat work already completed. Proceed with the next step.
 {{ end }}
 
+{{ if .merge_conflict }}
+
+## Resolve Merge Conflicts
+
+PR #{{ .merge_conflict.pr_number }} ({{ .merge_conflict.branch }}) has merge conflicts with
+its base branch {{ .merge_conflict.base }}. Resolve them now:
+
+1. Fetch the latest {{ .merge_conflict.base }} from the remote.
+2. Rebase {{ .merge_conflict.branch }} onto {{ .merge_conflict.base }}.
+3. Resolve every conflict, preserving both the intent of this PR and the base changes.
+4. Push the rebased branch.
+{{ end }}
+
 {{ if .attempt }}
 
 ## Retry

--- a/examples/WORKFLOW.kiro.md
+++ b/examples/WORKFLOW.kiro.md
@@ -141,6 +141,19 @@ Review the current state of the workspace, check test output, lint results, and 
 partial changes. Do not repeat work already completed. Proceed with the next step.
 {{ end }}
 
+{{ if .merge_conflict }}
+
+## Resolve Merge Conflicts
+
+PR #{{ .merge_conflict.pr_number }} ({{ .merge_conflict.branch }}) has merge conflicts with
+its base branch {{ .merge_conflict.base }}. Resolve them now:
+
+1. Fetch the latest {{ .merge_conflict.base }} from the remote.
+2. Rebase {{ .merge_conflict.branch }} onto {{ .merge_conflict.base }}.
+3. Resolve every conflict, preserving both the intent of this PR and the base changes.
+4. Push the rebased branch.
+{{ end }}
+
 {{ if .attempt }}
 
 ## Retry

--- a/examples/WORKFLOW.linear.md
+++ b/examples/WORKFLOW.linear.md
@@ -117,6 +117,19 @@ Review the current state of the workspace - check test output, lint results, and
 partial changes. Do not repeat work already completed. Proceed with the next step.
 {{ end }}
 
+{{ if .merge_conflict }}
+
+## Resolve Merge Conflicts
+
+PR #{{ .merge_conflict.pr_number }} ({{ .merge_conflict.branch }}) has merge conflicts with
+its base branch {{ .merge_conflict.base }}. Resolve them now:
+
+1. Fetch the latest {{ .merge_conflict.base }} from the remote.
+2. Rebase {{ .merge_conflict.branch }} onto {{ .merge_conflict.base }}.
+3. Resolve every conflict, preserving both the intent of this PR and the base changes.
+4. Push the rebased branch.
+{{ end }}
+
 {{ if .attempt }}
 
 ## Retry

--- a/examples/WORKFLOW.md
+++ b/examples/WORKFLOW.md
@@ -114,6 +114,19 @@ Review the current state of the workspace - check test output, lint results, and
 partial changes. Do not repeat work already completed. Proceed with the next step.
 {{ end }}
 
+{{ if .merge_conflict }}
+
+## Resolve Merge Conflicts
+
+PR #{{ .merge_conflict.pr_number }} ({{ .merge_conflict.branch }}) has merge conflicts with
+its base branch {{ .merge_conflict.base }}. Resolve them now:
+
+1. Fetch the latest {{ .merge_conflict.base }} from the remote.
+2. Rebase {{ .merge_conflict.branch }} onto {{ .merge_conflict.base }}.
+3. Resolve every conflict, preserving both the intent of this PR and the base changes.
+4. Push the rebased branch.
+{{ end }}
+
 {{ if .attempt }}
 
 ## Retry

--- a/examples/WORKFLOW.opencode.md
+++ b/examples/WORKFLOW.opencode.md
@@ -131,6 +131,19 @@ Review the current state of the workspace - check test output, lint results, and
 partial changes. Do not repeat work already completed. Proceed with the next step.
 {{ end }}
 
+{{ if .merge_conflict }}
+
+## Resolve Merge Conflicts
+
+PR #{{ .merge_conflict.pr_number }} ({{ .merge_conflict.branch }}) has merge conflicts with
+its base branch {{ .merge_conflict.base }}. Resolve them now:
+
+1. Fetch the latest {{ .merge_conflict.base }} from the remote.
+2. Rebase {{ .merge_conflict.branch }} onto {{ .merge_conflict.base }}.
+3. Resolve every conflict, preserving both the intent of this PR and the base changes.
+4. Push the rebased branch.
+{{ end }}
+
 {{ if .attempt }}
 
 ## Retry

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1185,7 +1185,14 @@ func buildReactionsConfig(m map[string]any) (map[string]ReactionConfig, error) {
 			}
 		}
 
+		// Merge-conflict resolution is less likely to succeed on retry
+		// than CI or review fixes, so it defaults to a single attempt;
+		// every other kind keeps the default of two. An operator-set
+		// value below still wins.
 		maxRetries := 2
+		if k == "merge_conflicts" {
+			maxRetries = 1
+		}
 		if raw, exists := vm["max_retries"]; exists && raw != nil {
 			parsed, parseErr := coerceInt(raw)
 			if parseErr != nil {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -920,6 +920,63 @@ func TestNewServiceConfig(t *testing.T) {
 		assertStringEqual(t, "Reactions[ci].EscalationLabel", "needs-human", rc.EscalationLabel)
 	})
 
+	t.Run("Reactions/MergeConflictsDefaultMaxRetriesOne", func(t *testing.T) {
+		t.Parallel()
+		cfg, err := NewServiceConfig(map[string]any{
+			"reactions": map[string]any{
+				"merge_conflicts": map[string]any{},
+			},
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		rc := cfg.Reactions["merge_conflicts"]
+		assertIntEqual(t, "Reactions[merge_conflicts].MaxRetries", 1, rc.MaxRetries)
+		assertStringEqual(t, "Reactions[merge_conflicts].Escalation", "label", rc.Escalation)
+		assertStringEqual(t, "Reactions[merge_conflicts].EscalationLabel", "needs-human", rc.EscalationLabel)
+	})
+
+	t.Run("Reactions/MergeConflictsExplicitMaxRetriesOverrides", func(t *testing.T) {
+		t.Parallel()
+		cfg, err := NewServiceConfig(map[string]any{
+			"reactions": map[string]any{
+				"merge_conflicts": map[string]any{
+					"max_retries": 3,
+					"escalation":  "comment",
+				},
+			},
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		rc := cfg.Reactions["merge_conflicts"]
+		assertIntEqual(t, "Reactions[merge_conflicts].MaxRetries", 3, rc.MaxRetries)
+		assertStringEqual(t, "Reactions[merge_conflicts].Escalation", "comment", rc.Escalation)
+	})
+
+	t.Run("Reactions/MergeConflictsDefaultLeavesOtherKindsUnchanged", func(t *testing.T) {
+		t.Parallel()
+		// The per-kind default-of-1 switch must apply ONLY to merge_conflicts.
+		// Every sibling kind keeps its current effective default of 2.
+		cfg, err := NewServiceConfig(map[string]any{
+			"reactions": map[string]any{
+				"merge_conflicts": map[string]any{},
+				"ci_failure":      map[string]any{"provider": "github"},
+				"review_comments": map[string]any{},
+				"auto_merge":      map[string]any{"provider": "github"},
+				"bot_review":      map[string]any{"provider": "github"},
+			},
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		assertIntEqual(t, "Reactions[merge_conflicts].MaxRetries", 1, cfg.Reactions["merge_conflicts"].MaxRetries)
+		assertIntEqual(t, "Reactions[review_comments].MaxRetries", 2, cfg.Reactions["review_comments"].MaxRetries)
+		assertIntEqual(t, "Reactions[auto_merge].MaxRetries", 2, cfg.Reactions["auto_merge"].MaxRetries)
+		assertIntEqual(t, "Reactions[bot_review].MaxRetries", 2, cfg.Reactions["bot_review"].MaxRetries)
+	})
+
 	t.Run("Reactions/UnknownKeyStoredInExtra", func(t *testing.T) {
 		t.Parallel()
 		cfg, err := NewServiceConfig(map[string]any{

--- a/internal/domain/metrics.go
+++ b/internal/domain/metrics.go
@@ -160,6 +160,16 @@ type Metrics interface {
 	// (sortie_reactions_auto_merge_total{result} counter).
 	IncAutoMergeReactions(result string)
 
+	// IncMergeConflictChecks increments the merge-conflict check counter.
+	// result is "dispatched", "error", "unknown", or "clear"
+	// (sortie_merge_conflict_checks_total{result} counter).
+	IncMergeConflictChecks(result string)
+
+	// IncMergeConflictEscalations increments the merge-conflict
+	// escalation counter. action is "label", "comment", or "error"
+	// (sortie_merge_conflict_escalations_total{action} counter).
+	IncMergeConflictEscalations(action string)
+
 	// IncDispatchRuleMatch increments the dispatch rule match counter.
 	// layer is one of "rule", "default", or "fallback" identifying
 	// which resolution layer produced the selection. rule is the
@@ -207,6 +217,8 @@ func (*NoopMetrics) IncReviewEscalations(string)                           {}
 func (*NoopMetrics) IncBotReviewChecks(string)                             {}
 func (*NoopMetrics) IncBotReviewEscalations(string)                        {}
 func (*NoopMetrics) IncAutoMergeReactions(string)                          {}
+func (*NoopMetrics) IncMergeConflictChecks(string)                         {}
+func (*NoopMetrics) IncMergeConflictEscalations(string)                    {}
 func (*NoopMetrics) IncDispatchRuleMatch(string, string)                   {}
 
 // MetricsSetter is implemented by adapters that accept a [Metrics]

--- a/internal/domain/scm.go
+++ b/internal/domain/scm.go
@@ -90,6 +90,11 @@ type PRMergeStatus struct {
 
 	// BranchName is the source branch name (PR head).
 	BranchName string
+
+	// BaseBranch is the PR target (base) branch name, e.g. "main" or
+	// "develop". Populated by GetMergeability from the same PR object it
+	// already fetches; empty only when the provider omits the base ref.
+	BaseBranch string
 }
 
 // MergeResult carries the outcome of a successful merge call.

--- a/internal/orchestrator/exit.go
+++ b/internal/orchestrator/exit.go
@@ -123,6 +123,11 @@ type HandleWorkerExitParams struct {
 	// is active for the current process. The enqueue path gates on
 	// this flag and the SCMAdapter being non-nil.
 	BotReviewReactionConfigured bool
+
+	// MergeConflictReactionConfigured marks whether the merge-conflict
+	// feature is active for the current process. The enqueue path gates
+	// on this flag and the SCMAdapter being non-nil.
+	MergeConflictReactionConfigured bool
 }
 
 // HandleWorkerExit processes a worker's terminal outcome. It removes the
@@ -574,6 +579,44 @@ func HandleWorkerExit(state *State, workerResult WorkerResult, params HandleWork
 							LastSSHHost: workerResult.SSHHost,
 							CreatedAt:   nowMerge,
 							KindData: &AutoMergeReactionData{
+								PRNumber: scm.PRNumber,
+								Owner:    scm.Owner,
+								Repo:     scm.Repo,
+								Branch:   scm.Branch,
+								SHA:      scm.SHA,
+							},
+							AgentKind:  entry.AgentKind,
+							RuleName:   entry.RuleName,
+							TemplateID: entry.TemplateID,
+						}
+					}
+				}
+			}
+		}
+
+		// Record a pending merge-conflict entry when the SCM adapter
+		// is configured, merge-conflict is enabled, and the workspace
+		// has PR metadata. The merge-conflict enqueue is independent
+		// of the other kinds: all fire from the same worker exit.
+		if params.SCMAdapter != nil && params.MergeConflictReactionConfigured && workerResult.WorkspacePath != "" {
+			if reactionEnqueueAllowed {
+				scm := workspace.ReadSCMMetadata(workerResult.WorkspacePath, log)
+				if scm.PRNumber > 0 && scm.Branch != "" && scm.Owner != "" && scm.Repo != "" {
+					nowMergeConflict := time.Now().UTC()
+					if params.NowFunc != nil {
+						nowMergeConflict = params.NowFunc().UTC()
+					}
+					rkey := ReactionKey(workerResult.IssueID, ReactionKindMergeConflict)
+					if _, exists := state.PendingReactions[rkey]; !exists {
+						state.PendingReactions[rkey] = &PendingReaction{
+							IssueID:     workerResult.IssueID,
+							Identifier:  workerResult.Identifier,
+							DisplayID:   entry.Issue.DisplayID,
+							Attempt:     normalizeAttempt(entry.RetryAttempt) + 1,
+							Kind:        ReactionKindMergeConflict,
+							LastSSHHost: workerResult.SSHHost,
+							CreatedAt:   nowMergeConflict,
+							KindData: &MergeConflictReactionData{
 								PRNumber: scm.PRNumber,
 								Owner:    scm.Owner,
 								Repo:     scm.Repo,

--- a/internal/orchestrator/exit_test.go
+++ b/internal/orchestrator/exit_test.go
@@ -4145,3 +4145,229 @@ func TestHandleWorkerExit_BotReviewEnqueueSkippedWhenClaimReleased(t *testing.T)
 		t.Error("PendingReactions[BR-SOFT:bot-review] present after soft-stop; want absent (claim released before enqueue)")
 	}
 }
+
+// --- merge-conflict enqueue tests ---
+
+func TestHandleWorkerExit_MergeConflictEnqueue_PopulatesPendingReaction(t *testing.T) {
+	t.Parallel()
+
+	wsPath := t.TempDir()
+	writePRSCMMetadata(t, wsPath, 55, "corp", "api", "feature/MC-1", "c0ffee")
+
+	store := &mockExitStore{}
+	state := exitState(t, "MC-1", nil)
+	params := defaultExitParams(t, store)
+	params.SCMAdapter = &scmAdapterStubExit{}
+	params.MergeConflictReactionConfigured = true
+
+	HandleWorkerExit(state, WorkerResult{
+		IssueID:       "MC-1",
+		Identifier:    "MC-1-ident",
+		ExitKind:      WorkerExitNormal,
+		AgentAdapter:  "mock",
+		WorkspacePath: wsPath,
+	}, params)
+
+	rkey := ReactionKey("MC-1", ReactionKindMergeConflict)
+	pr, ok := state.PendingReactions[rkey]
+	if !ok {
+		t.Fatal("PendingReactions[MC-1:merge-conflict] missing after normal exit with PR metadata")
+	}
+	if pr.Kind != ReactionKindMergeConflict {
+		t.Errorf("PendingReaction.Kind = %q, want %q", pr.Kind, ReactionKindMergeConflict)
+	}
+	mcData, ok := pr.KindData.(*MergeConflictReactionData)
+	if !ok {
+		t.Fatalf("KindData type = %T, want *MergeConflictReactionData", pr.KindData)
+	}
+	if mcData.PRNumber != 55 {
+		t.Errorf("MergeConflictReactionData.PRNumber = %d, want 55", mcData.PRNumber)
+	}
+	if mcData.Owner != "corp" {
+		t.Errorf("MergeConflictReactionData.Owner = %q, want %q", mcData.Owner, "corp")
+	}
+	if mcData.Repo != "api" {
+		t.Errorf("MergeConflictReactionData.Repo = %q, want %q", mcData.Repo, "api")
+	}
+	if mcData.Branch != "feature/MC-1" {
+		t.Errorf("MergeConflictReactionData.Branch = %q, want %q", mcData.Branch, "feature/MC-1")
+	}
+	if mcData.SHA != "c0ffee" {
+		t.Errorf("MergeConflictReactionData.SHA = %q, want %q", mcData.SHA, "c0ffee")
+	}
+}
+
+// TestHandleWorkerExit_MergeConflictEnqueueRequiresPRMetadata verifies that the
+// merge-conflict pending reaction is NOT created when the workspace SCM
+// metadata lacks any required field.
+func TestHandleWorkerExit_MergeConflictEnqueueRequiresPRMetadata(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		content string
+	}{
+		{
+			name:    "missing pr_number",
+			content: `{"owner":"corp","repo":"api","branch":"feature/x","sha":"abc"}`,
+		},
+		{
+			name:    "missing owner",
+			content: `{"pr_number":10,"repo":"api","branch":"feature/x","sha":"abc"}`,
+		},
+		{
+			name:    "missing repo",
+			content: `{"pr_number":10,"owner":"corp","branch":"feature/x","sha":"abc"}`,
+		},
+		{
+			name:    "missing branch",
+			content: `{"pr_number":10,"owner":"corp","repo":"api","sha":"abc"}`,
+		},
+		{
+			name:    "empty scm file",
+			content: `{}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			wsPath := t.TempDir()
+			dotSortie := filepath.Join(wsPath, ".sortie")
+			if err := os.MkdirAll(dotSortie, 0o750); err != nil {
+				t.Fatalf("MkdirAll .sortie: %v", err)
+			}
+			if err := os.WriteFile(filepath.Join(dotSortie, "scm.json"), []byte(tt.content), 0o600); err != nil {
+				t.Fatalf("WriteFile scm.json: %v", err)
+			}
+
+			store := &mockExitStore{}
+			state := exitState(t, "MC-7", nil)
+			params := defaultExitParams(t, store)
+			params.SCMAdapter = &scmAdapterStubExit{}
+			params.MergeConflictReactionConfigured = true
+
+			HandleWorkerExit(state, WorkerResult{
+				IssueID:       "MC-7",
+				Identifier:    "MC-7-ident",
+				ExitKind:      WorkerExitNormal,
+				AgentAdapter:  "mock",
+				WorkspacePath: wsPath,
+			}, params)
+
+			rkey := ReactionKey("MC-7", ReactionKindMergeConflict)
+			if _, ok := state.PendingReactions[rkey]; ok {
+				t.Errorf("PendingReactions[MC-7:merge-conflict] present despite incomplete SCM metadata (%s)", tt.name)
+			}
+		})
+	}
+}
+
+// TestHandleWorkerExit_MergeConflictEnqueueRequiresConfigured verifies that the
+// merge-conflict pending reaction is NOT created when
+// MergeConflictReactionConfigured is false, even with valid PR metadata.
+func TestHandleWorkerExit_MergeConflictEnqueueRequiresConfigured(t *testing.T) {
+	t.Parallel()
+
+	wsPath := t.TempDir()
+	writePRSCMMetadata(t, wsPath, 20, "corp", "api", "feature/MC-6", "deadbeef")
+
+	store := &mockExitStore{}
+	state := exitState(t, "MC-6", nil)
+	params := defaultExitParams(t, store)
+	params.SCMAdapter = &scmAdapterStubExit{}
+	params.MergeConflictReactionConfigured = false
+
+	HandleWorkerExit(state, WorkerResult{
+		IssueID:       "MC-6",
+		Identifier:    "MC-6-ident",
+		ExitKind:      WorkerExitNormal,
+		AgentAdapter:  "mock",
+		WorkspacePath: wsPath,
+	}, params)
+
+	rkey := ReactionKey("MC-6", ReactionKindMergeConflict)
+	if _, ok := state.PendingReactions[rkey]; ok {
+		t.Error("PendingReactions[MC-6:merge-conflict] present despite MergeConflictReactionConfigured=false")
+	}
+}
+
+// TestHandleWorkerExit_MergeConflictEnqueueRequiresSCMAdapter verifies that the
+// merge-conflict pending reaction is NOT created when no SCM adapter is wired,
+// even when merge-conflict is configured.
+func TestHandleWorkerExit_MergeConflictEnqueueRequiresSCMAdapter(t *testing.T) {
+	t.Parallel()
+
+	wsPath := t.TempDir()
+	writePRSCMMetadata(t, wsPath, 20, "corp", "api", "feature/MC-nil", "deadbeef")
+
+	store := &mockExitStore{}
+	state := exitState(t, "MC-nil", nil)
+	params := defaultExitParams(t, store)
+	params.SCMAdapter = nil
+	params.MergeConflictReactionConfigured = true
+
+	HandleWorkerExit(state, WorkerResult{
+		IssueID:       "MC-nil",
+		Identifier:    "MC-nil-ident",
+		ExitKind:      WorkerExitNormal,
+		AgentAdapter:  "mock",
+		WorkspacePath: wsPath,
+	}, params)
+
+	rkey := ReactionKey("MC-nil", ReactionKindMergeConflict)
+	if _, ok := state.PendingReactions[rkey]; ok {
+		t.Error("PendingReactions[MC-nil:merge-conflict] present despite nil SCMAdapter")
+	}
+}
+
+// TestHandleWorkerExit_MergeConflictEnqueueDoesNotOverwrite verifies the
+// if-absent guard: an existing merge-conflict pending reaction is not replaced
+// on re-entry, preserving in-progress episode state.
+func TestHandleWorkerExit_MergeConflictEnqueueDoesNotOverwrite(t *testing.T) {
+	t.Parallel()
+
+	wsPath := t.TempDir()
+	writePRSCMMetadata(t, wsPath, 10, "corp", "api", "feature/MC-DUP", "sha1")
+
+	store := &mockExitStore{}
+	state := exitState(t, "MC-DUP", nil)
+	params := defaultExitParams(t, store)
+	params.SCMAdapter = &scmAdapterStubExit{}
+	params.MergeConflictReactionConfigured = true
+
+	existingEntry := &PendingReaction{
+		IssueID:    "MC-DUP",
+		Identifier: "MC-DUP-ident",
+		Kind:       ReactionKindMergeConflict,
+		KindData: &MergeConflictReactionData{
+			PRNumber: 77,
+			Owner:    "original",
+			Repo:     "original",
+			Branch:   "original-branch",
+		},
+	}
+	rkey := ReactionKey("MC-DUP", ReactionKindMergeConflict)
+	state.PendingReactions[rkey] = existingEntry
+
+	HandleWorkerExit(state, WorkerResult{
+		IssueID:       "MC-DUP",
+		Identifier:    "MC-DUP-ident",
+		ExitKind:      WorkerExitNormal,
+		AgentAdapter:  "mock",
+		WorkspacePath: wsPath,
+	}, params)
+
+	got := state.PendingReactions[rkey]
+	if got != existingEntry {
+		t.Error("PendingReactions[MC-DUP:merge-conflict] was replaced; want existing entry preserved")
+	}
+	mcData, ok := got.KindData.(*MergeConflictReactionData)
+	if !ok {
+		t.Fatalf("KindData type = %T, want *MergeConflictReactionData", got.KindData)
+	}
+	if mcData.PRNumber != 77 {
+		t.Errorf("MergeConflictReactionData.PRNumber = %d, want 77 (seeded value preserved)", mcData.PRNumber)
+	}
+}

--- a/internal/orchestrator/integration_merge_conflict_test.go
+++ b/internal/orchestrator/integration_merge_conflict_test.go
@@ -1,0 +1,415 @@
+package orchestrator
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sortie-ai/sortie/internal/domain"
+	"github.com/sortie-ai/sortie/internal/registry"
+
+	_ "github.com/sortie-ai/sortie/internal/scm/github"
+)
+
+// skipUnlessGitHubE2EMergeConflict skips the test when the GitHub E2E gate is
+// absent or the required credentials are not set. Mirrors the auto-merge E2E
+// gate: a single SORTIE_GITHUB_E2E gate plus the token and project, never a
+// per-operation env var. The test must skip cleanly — never fail — when the
+// gate is unset.
+func skipUnlessGitHubE2EMergeConflict(t *testing.T) {
+	t.Helper()
+	if testing.Short() {
+		t.Skip("skipping merge-conflict E2E test in short mode")
+	}
+	if os.Getenv("SORTIE_GITHUB_E2E") != "1" {
+		t.Skip("skipping merge-conflict E2E test: set SORTIE_GITHUB_E2E=1, SORTIE_GITHUB_TOKEN, SORTIE_GITHUB_PROJECT")
+	}
+	if os.Getenv("SORTIE_GITHUB_TOKEN") == "" {
+		t.Skip("skipping merge-conflict E2E test: SORTIE_GITHUB_TOKEN not set")
+	}
+	if os.Getenv("SORTIE_GITHUB_PROJECT") == "" {
+		t.Skip("skipping merge-conflict E2E test: SORTIE_GITHUB_PROJECT not set")
+	}
+}
+
+// mergeConflictAPIClient is a minimal GitHub REST client used only for test
+// setup and teardown in the merge-conflict E2E test. It is intentionally
+// separate from the auto-merge and tracker E2E clients so the tests can run
+// independently without coupling.
+type mergeConflictAPIClient struct {
+	token      string
+	baseURL    string
+	httpClient *http.Client
+}
+
+func newMergeConflictAPIClient(t *testing.T) *mergeConflictAPIClient {
+	t.Helper()
+	return &mergeConflictAPIClient{
+		token:      os.Getenv("SORTIE_GITHUB_TOKEN"),
+		baseURL:    "https://api.github.com",
+		httpClient: &http.Client{Timeout: 30 * time.Second},
+	}
+}
+
+// doRequest executes a GitHub REST API request and returns the raw body. It
+// calls t.Fatalf on network or non-2xx response errors.
+func (c *mergeConflictAPIClient) doRequest(t *testing.T, method, path string, body any) []byte {
+	t.Helper()
+
+	var bodyReader io.Reader
+	if body != nil {
+		data, err := json.Marshal(body)
+		if err != nil {
+			t.Fatalf("marshal request body for %s %s: %v", method, path, err)
+		}
+		bodyReader = bytes.NewReader(data)
+	}
+
+	req, err := http.NewRequestWithContext(context.Background(), method, c.baseURL+path, bodyReader)
+	if err != nil {
+		t.Fatalf("build request %s %s: %v", method, path, err)
+	}
+	req.Header.Set("Authorization", "Bearer "+c.token)
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("X-GitHub-Api-Version", "2026-03-10")
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		t.Fatalf("%s %s: %v", method, path, err)
+	}
+	defer resp.Body.Close() //nolint:errcheck // test helper; best-effort cleanup
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read response body for %s %s: %v", method, path, err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		t.Fatalf("%s %s returned %d: %s", method, path, resp.StatusCode, string(respBody))
+	}
+	return respBody
+}
+
+// doRequestIgnoreStatus executes a request and returns the status code without
+// failing on non-2xx. Used by cleanup helpers that tolerate 404/422.
+func (c *mergeConflictAPIClient) doRequestIgnoreStatus(method, path string, body any) (int, error) {
+	var bodyReader io.Reader
+	if body != nil {
+		data, err := json.Marshal(body)
+		if err != nil {
+			return 0, fmt.Errorf("marshal body: %w", err)
+		}
+		bodyReader = bytes.NewReader(data)
+	}
+
+	req, err := http.NewRequestWithContext(context.Background(), method, c.baseURL+path, bodyReader)
+	if err != nil {
+		return 0, fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+c.token)
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("X-GitHub-Api-Version", "2026-03-10")
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return 0, err
+	}
+	defer resp.Body.Close()        //nolint:errcheck // cleanup helper
+	io.Copy(io.Discard, resp.Body) //nolint:errcheck // drain to reuse connection
+	return resp.StatusCode, nil
+}
+
+// defaultBranchSHA returns the repository's default branch name and the SHA at
+// its tip.
+func (c *mergeConflictAPIClient) defaultBranchSHA(t *testing.T, owner, repo string) (defaultBranch, sha string) {
+	t.Helper()
+	repoResp := c.doRequest(t, "GET", fmt.Sprintf("/repos/%s/%s", owner, repo), nil)
+	var repoInfo struct {
+		DefaultBranch string `json:"default_branch"`
+	}
+	if err := json.Unmarshal(repoResp, &repoInfo); err != nil {
+		t.Fatalf("unmarshal repo info: %v", err)
+	}
+	if repoInfo.DefaultBranch == "" {
+		repoInfo.DefaultBranch = "main"
+	}
+
+	refResp := c.doRequest(t, "GET", fmt.Sprintf("/repos/%s/%s/git/ref/heads/%s", owner, repo, repoInfo.DefaultBranch), nil)
+	var refInfo struct {
+		Object struct {
+			SHA string `json:"sha"`
+		} `json:"object"`
+	}
+	if err := json.Unmarshal(refResp, &refInfo); err != nil {
+		t.Fatalf("unmarshal ref info: %v", err)
+	}
+	if refInfo.Object.SHA == "" {
+		t.Fatalf("could not resolve HEAD SHA for %s/%s", repoInfo.DefaultBranch, repo)
+	}
+	return repoInfo.DefaultBranch, refInfo.Object.SHA
+}
+
+// putFile creates or updates a file on the given branch via the Contents API.
+func (c *mergeConflictAPIClient) putFile(t *testing.T, owner, repo, branch, path, content, message string) {
+	t.Helper()
+	c.doRequest(t, "PUT", fmt.Sprintf("/repos/%s/%s/contents/%s", owner, repo, path), map[string]any{
+		"message": message,
+		"content": encodeBase64([]byte(content)),
+		"branch":  branch,
+	})
+}
+
+// createConflictingPR opens a PR whose head branch edits the same file as a
+// subsequent commit on the base branch, guaranteeing a merge conflict. Returns
+// the PR number and the base branch name.
+func (c *mergeConflictAPIClient) createConflictingPR(t *testing.T, owner, repo, branch, prTitle string) (prNumber int, baseBranch string) {
+	t.Helper()
+
+	defaultBranch, baseSHA := c.defaultBranchSHA(t, owner, repo)
+
+	// Create the head branch from the default branch tip.
+	c.doRequest(t, "POST", fmt.Sprintf("/repos/%s/%s/git/refs", owner, repo), map[string]any{
+		"ref": "refs/heads/" + branch,
+		"sha": baseSHA,
+	})
+
+	// Seed a shared file on the head branch.
+	conflictFile := fmt.Sprintf("e2e/merge-conflict-%s.txt", branch)
+	c.putFile(t, owner, repo, branch, conflictFile,
+		"head branch content\n", "test: seed conflict file on head")
+
+	// Edit the SAME file on the base (default) branch so the head branch can no
+	// longer merge cleanly.
+	c.putFile(t, owner, repo, defaultBranch, conflictFile,
+		"base branch content\n", "test: seed conflicting change on base")
+
+	// Open the PR from the head branch into the default branch.
+	prResp := c.doRequest(t, "POST", fmt.Sprintf("/repos/%s/%s/pulls", owner, repo), map[string]any{
+		"title": prTitle,
+		"head":  branch,
+		"base":  defaultBranch,
+		"body":  "Merge-conflict E2E test PR — safe to close",
+	})
+	var pr struct {
+		Number int `json:"number"`
+	}
+	if err := json.Unmarshal(prResp, &pr); err != nil {
+		t.Fatalf("unmarshal create PR response: %v", err)
+	}
+	t.Logf("opened conflicting PR #%d (branch %q → %s)", pr.Number, branch, defaultBranch)
+	return pr.Number, defaultBranch
+}
+
+// createMergeConflictIssue creates a GitHub issue and returns its number and ID.
+func (c *mergeConflictAPIClient) createMergeConflictIssue(t *testing.T, owner, repo, title string) (issueNumber int, issueID string) {
+	t.Helper()
+	resp := c.doRequest(t, "POST", fmt.Sprintf("/repos/%s/%s/issues", owner, repo), map[string]any{
+		"title": title,
+		"body":  "E2E merge-conflict test issue — safe to close",
+	})
+	var parsed struct {
+		Number int `json:"number"`
+	}
+	if err := json.Unmarshal(resp, &parsed); err != nil {
+		t.Fatalf("unmarshal create issue response: %v", err)
+	}
+	return parsed.Number, fmt.Sprintf("%d", parsed.Number)
+}
+
+func (c *mergeConflictAPIClient) closeIssue(t *testing.T, owner, repo string, issueNumber int) {
+	t.Helper()
+	status, err := c.doRequestIgnoreStatus("PATCH", fmt.Sprintf("/repos/%s/%s/issues/%d", owner, repo, issueNumber), map[string]any{
+		"state":        "closed",
+		"state_reason": "not_planned",
+	})
+	if err != nil || status >= 300 {
+		t.Logf("cleanup: close issue #%d returned status=%d err=%v (tolerated)", issueNumber, status, err)
+	}
+}
+
+func (c *mergeConflictAPIClient) closePR(t *testing.T, owner, repo string, prNumber int) {
+	t.Helper()
+	status, err := c.doRequestIgnoreStatus("PATCH", fmt.Sprintf("/repos/%s/%s/pulls/%d", owner, repo, prNumber), map[string]any{
+		"state": "closed",
+	})
+	if err != nil || (status >= 300 && status != http.StatusUnprocessableEntity) {
+		t.Logf("cleanup: close PR #%d returned status=%d err=%v (tolerated)", prNumber, status, err)
+	}
+}
+
+func (c *mergeConflictAPIClient) deleteBranch(t *testing.T, owner, repo, branch string) {
+	t.Helper()
+	status, err := c.doRequestIgnoreStatus("DELETE", fmt.Sprintf("/repos/%s/%s/git/refs/heads/%s", owner, repo, branch), nil)
+	if err != nil || (status >= 300 && status != http.StatusNotFound) {
+		t.Logf("cleanup: delete branch %q returned status=%d err=%v (tolerated)", branch, status, err)
+	}
+}
+
+// TestReconcileMergeConflict_LiveAPI_E2E exercises reconcileMergeConflicts
+// against the live GitHub API. It creates an issue and a PR that genuinely
+// conflicts with its base branch, wires the real SCM adapter, and drives the
+// reconcile pass until one rebase continuation is dispatched. It asserts the
+// dispatched merge_conflict continuation carries the PR's real base branch
+// (not a hardcoded default).
+//
+// Required environment variables:
+//
+//	SORTIE_GITHUB_E2E=1
+//	SORTIE_GITHUB_TOKEN=ghp_...   PAT with issues:write, pull_requests:write, contents:write
+//	SORTIE_GITHUB_PROJECT=sortie-ai/sortie-test
+//
+// No t.Parallel — the test mutates shared state in a live repository.
+func TestReconcileMergeConflict_LiveAPI_E2E(t *testing.T) {
+	skipUnlessGitHubE2EMergeConflict(t)
+
+	ctx := context.Background()
+
+	project := os.Getenv("SORTIE_GITHUB_PROJECT")
+	parts := strings.SplitN(project, "/", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		t.Fatalf("SORTIE_GITHUB_PROJECT=%q must be owner/repo", project)
+	}
+	owner, repo := parts[0], parts[1]
+
+	ghClient := newMergeConflictAPIClient(t)
+
+	branch := fmt.Sprintf("merge-conflict-test-%d-%s", time.Now().UnixNano(), randomHex(4))
+	prTitle := fmt.Sprintf("sortie-e2e-merge-conflict %s", branch)
+	issueTitle := fmt.Sprintf("sortie-e2e-merge-conflict-issue %s", branch)
+
+	issueNumber, issueID := ghClient.createMergeConflictIssue(t, owner, repo, issueTitle)
+	prNumber, baseBranch := ghClient.createConflictingPR(t, owner, repo, branch, prTitle)
+
+	t.Cleanup(func() {
+		ghClient.closeIssue(t, owner, repo, issueNumber)
+		ghClient.closePR(t, owner, repo, prNumber)
+		ghClient.deleteBranch(t, owner, repo, branch)
+	})
+
+	scmFactory, err := registry.SCMAdapters.Get("github")
+	if err != nil {
+		t.Fatalf("registry.SCMAdapters.Get(%q): %v", "github", err)
+	}
+	scmAdapter, err := scmFactory(map[string]any{
+		"api_key": os.Getenv("SORTIE_GITHUB_TOKEN"),
+	})
+	if err != nil {
+		t.Fatalf("NewGitHubSCMAdapter: %v", err)
+	}
+
+	store := openInMemoryStore(t)
+	metrics := newMergeConflictMetricsSpy()
+
+	state := NewState(5000, 4, nil, AgentTotals{})
+	rkey := ReactionKey(issueID, ReactionKindMergeConflict)
+	state.PendingReactions[rkey] = &PendingReaction{
+		IssueID:    issueID,
+		Identifier: issueID,
+		Attempt:    1,
+		Kind:       ReactionKindMergeConflict,
+		CreatedAt:  time.Now().UTC(),
+		KindData: &MergeConflictReactionData{
+			PRNumber: prNumber,
+			Owner:    owner,
+			Repo:     repo,
+			Branch:   branch,
+		},
+	}
+
+	params := ReconcileParams{
+		SCMAdapter:                      scmAdapter,
+		MergeConflictConfig:             defaultMergeConflictConfig(),
+		MergeConflictReactionConfigured: true,
+		MergeConflictPendingTTL:         mergeConflictPendingDefaultTTL,
+		Store:                           store,
+		OnRetryFire:                     noopRetryFire,
+		Ctx:                             ctx,
+		Logger:                          discardLogger(),
+	}
+
+	// GitHub computes mergeability asynchronously; the PR may initially return
+	// mergeable_state=unknown and needs a few ticks before it reports dirty.
+	const maxTicks = 8
+	for range maxTicks {
+		if _, present := state.PendingReactions[rkey]; !present {
+			break
+		}
+
+		reconcileMergeConflicts(state, params, discardLogger(), ctx, metrics)
+
+		if metrics.checks["dispatched"] > 0 {
+			t.Logf("merge-conflict continuation dispatched; exiting tick loop")
+			break
+		}
+
+		// Clear the deferral so the next tick re-evaluates mergeability.
+		if pending, present := state.PendingReactions[rkey]; present {
+			pending.PendingRetryAt = time.Time{}
+			state.PendingReactions[rkey] = pending
+		}
+
+		time.Sleep(2 * time.Second)
+	}
+
+	// Exactly one continuation dispatched for the conflicted PR.
+	if metrics.checks["dispatched"] != 1 {
+		t.Fatalf(`IncMergeConflictChecks("dispatched") = %d, want 1`, metrics.checks["dispatched"])
+	}
+	if metrics.escalations["label"] != 0 || metrics.escalations["comment"] != 0 {
+		t.Errorf("escalations = %v, want none on first dirty observation", metrics.escalations)
+	}
+
+	// The dispatched continuation carries the PR's real base branch.
+	retry, ok := state.RetryAttempts[issueID]
+	if !ok {
+		t.Fatal("retry not scheduled after dirty dispatch; want scheduled")
+	}
+	raw, ok := retry.ContinuationContext["merge_conflict"]
+	if !ok {
+		t.Fatal(`ContinuationContext missing "merge_conflict" key`)
+	}
+	mergeContext, ok := raw.(map[string]any)
+	if !ok {
+		t.Fatalf("merge_conflict context type = %T, want map[string]any", raw)
+	}
+	if mergeContext["base"] != baseBranch {
+		t.Errorf("ContinuationContext[merge_conflict][base] = %v, want %q (the PR's real base, not a hardcoded default)",
+			mergeContext["base"], baseBranch)
+	}
+
+	// Confirm the adapter independently reports the same base branch.
+	status, err := scmAdapter.GetMergeability(ctx, prNumber, owner, repo)
+	if err != nil {
+		t.Fatalf("GetMergeability: %v", err)
+	}
+	if status.Mergeability != domain.MergeabilityDirty {
+		t.Errorf("GetMergeability().Mergeability = %q, want %q", status.Mergeability, domain.MergeabilityDirty)
+	}
+	if status.BaseBranch != baseBranch {
+		t.Errorf("GetMergeability().BaseBranch = %q, want %q", status.BaseBranch, baseBranch)
+	}
+
+	// The fingerprint row was written and marked dispatched for this head.
+	fp, dispatched, fpErr := store.GetReactionFingerprint(ctx, issueID, ReactionKindMergeConflict)
+	if fpErr != nil {
+		t.Fatalf("GetReactionFingerprint: %v", fpErr)
+	}
+	if fp == "" {
+		t.Error("GetReactionFingerprint returned empty fingerprint after dispatch; want set")
+	}
+	if !dispatched {
+		t.Error("GetReactionFingerprint dispatched = false after dispatch; want true")
+	}
+}

--- a/internal/orchestrator/merge_conflict_reconcile.go
+++ b/internal/orchestrator/merge_conflict_reconcile.go
@@ -11,9 +11,10 @@ import (
 	"github.com/sortie-ai/sortie/internal/logging"
 )
 
-// mergeConflictPendingBackoffBase is the base interval for merge-conflict
-// pending exponential backoff and the floor for the configured poll
-// interval.
+// mergeConflictPendingBackoffBase is the floor for the merge-conflict poll
+// interval and, through it, for the per-tick deferral and fetch-error
+// backoff delays. The exponential backoff itself is computed by
+// [computeReactionPendingDelay]; this constant only bounds it from below.
 const mergeConflictPendingBackoffBase = 10 * time.Second
 
 // mergeConflictPendingDefaultTTL is the default lifetime of a
@@ -387,9 +388,14 @@ func escalateMergeConflictFailure(
 // comment used when the per-episode retry budget is exhausted. Plain text
 // is used so the comment renders consistently across all tracker adapters.
 func buildMergeConflictEscalationComment(data *MergeConflictReactionData, attempts int) string {
+	// The observation that trips the retry cap dispatches no continuation, so
+	// the number of resolution turns actually dispatched is attempts-1. At
+	// max_retries 0 this is 0: the reaction escalates on first detection
+	// without attempting a rebase.
+	dispatched := attempts - 1
 	return fmt.Sprintf(
 		"Sortie attempted %d merge-conflict resolution turn(s) and could not clear the conflicts for PR #%d. Manual rebase required.",
-		attempts,
+		dispatched,
 		data.PRNumber,
 	)
 }

--- a/internal/orchestrator/merge_conflict_reconcile.go
+++ b/internal/orchestrator/merge_conflict_reconcile.go
@@ -1,0 +1,395 @@
+package orchestrator
+
+import (
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/sortie-ai/sortie/internal/domain"
+	"github.com/sortie-ai/sortie/internal/logging"
+)
+
+// mergeConflictPendingBackoffBase is the base interval for merge-conflict
+// pending exponential backoff and the floor for the configured poll
+// interval.
+const mergeConflictPendingBackoffBase = 10 * time.Second
+
+// mergeConflictPendingDefaultTTL is the default lifetime of a
+// merge-conflict PendingReaction entry. Entries older than this are
+// dropped on the next reconcile tick.
+const mergeConflictPendingDefaultTTL = 30 * time.Minute
+
+// reconcileMergeConflicts polls mergeability for each merge-conflict-kind
+// entry in state.PendingReactions and dispatches a rebase-and-resolve
+// continuation on each no-conflict-to-conflict transition. Called from
+// [ReconcileRunningIssues] after [reconcileBotReviewComments] and before
+// [reconcileAutoMerge]. Skipped entirely when params.SCMAdapter is nil or
+// params.MergeConflictReactionConfigured is false.
+//
+// The state machine mirrors [reconcileCIStatus]: the mergeability read
+// runs on every due tick with no retry-budget check before it, so the
+// not-dirty branch (which resets the per-episode attempt counter) is
+// always reachable. The per-episode counter is incremented only inside the
+// dirty branch on a new conflicting head, and the cap is strict
+// over-limit, matching [handleCIFailure].
+func reconcileMergeConflicts(state *State, params ReconcileParams, log *slog.Logger, ctx context.Context, metrics domain.Metrics) {
+	if params.SCMAdapter == nil {
+		return
+	}
+	if !params.MergeConflictReactionConfigured {
+		return
+	}
+
+	now := time.Now().UTC()
+	if params.NowFunc != nil {
+		now = params.NowFunc().UTC()
+	}
+
+	ttl := params.MergeConflictPendingTTL
+	pollInterval := max(time.Duration(params.MergeConflictConfig.PollIntervalMS)*time.Millisecond, mergeConflictPendingBackoffBase)
+
+	for key, pending := range state.PendingReactions {
+		if pending.Kind != ReactionKindMergeConflict {
+			continue
+		}
+		delete(state.PendingReactions, key)
+
+		data, ok := pending.KindData.(*MergeConflictReactionData)
+		if !ok {
+			log.ErrorContext(ctx, "unexpected KindData type for merge-conflict reaction",
+				slog.String("issue_id", pending.IssueID),
+				slog.String("type", fmt.Sprintf("%T", pending.KindData)),
+			)
+			continue
+		}
+
+		entryLog := logging.WithIssue(log, pending.IssueID, pending.Identifier)
+
+		if ttl > 0 && now.Sub(pending.CreatedAt) > ttl {
+			entryLog.Warn("merge conflict pending entry exceeded ttl, dropping",
+				slog.Int64("ttl_ms", int64(ttl/time.Millisecond)),
+				slog.Int64("age_ms", int64(now.Sub(pending.CreatedAt)/time.Millisecond)),
+			)
+			continue
+		}
+
+		if now.Before(pending.PendingRetryAt) {
+			state.PendingReactions[key] = pending
+			continue
+		}
+
+		// The mergeability read runs every due tick with no cap before
+		// it, so the not-dirty branch stays reachable and a resolved
+		// conflict resets the counter rather than escalating.
+		status, err := params.SCMAdapter.GetMergeability(ctx, data.PRNumber, data.Owner, data.Repo)
+		if err != nil {
+			pending.PendingAttempts++
+			delay := max(computeReactionPendingDelay(pending.PendingAttempts), pollInterval)
+			pending.PendingRetryAt = now.Add(delay)
+			state.PendingReactions[key] = pending
+			entryLog.Warn("merge conflict mergeability fetch failed, retrying with backoff",
+				slog.Any("error", err),
+				slog.Int("pending_attempts", pending.PendingAttempts),
+				slog.Int64("retry_after_ms", int64(delay/time.Millisecond)),
+			)
+			metrics.IncMergeConflictChecks("error")
+			continue
+		}
+
+		rkey := ReactionKey(pending.IssueID, ReactionKindMergeConflict)
+
+		switch status.Mergeability {
+		case domain.MergeabilityUnknown:
+			pending.PendingRetryAt = now.Add(pollInterval)
+			state.PendingReactions[key] = pending
+			metrics.IncMergeConflictChecks("unknown")
+			entryLog.Debug("merge conflict deferred: mergeability unknown",
+				slog.Int("pr_number", data.PRNumber),
+			)
+
+		case domain.MergeabilityDirty:
+			handleMergeConflictDirty(state, params, key, pending, data, status, rkey, now, pollInterval, entryLog, ctx, metrics)
+
+		default:
+			// Clean, unstable, or blocked: the episode closes. Clear the
+			// dedup fingerprint, reset the per-episode counter, and
+			// re-enqueue. Mirrors the CIStatusPassing branch.
+			if delErr := params.Store.DeleteReactionFingerprint(ctx, pending.IssueID, ReactionKindMergeConflict); delErr != nil {
+				entryLog.Warn("failed to delete merge conflict reaction fingerprint",
+					slog.Any("error", delErr),
+				)
+			}
+			delete(state.ReactionAttempts, rkey)
+			pending.PendingRetryAt = now.Add(pollInterval)
+			state.PendingReactions[key] = pending
+			metrics.IncMergeConflictChecks("clear")
+			entryLog.Debug("merge conflict not present, tracking reset",
+				slog.Int("pr_number", data.PRNumber),
+				slog.String("state", string(status.Mergeability)),
+			)
+		}
+	}
+}
+
+// handleMergeConflictDirty processes a PR that the provider reports as
+// conflicted. It applies the precondition guards (empty head SHA, empty
+// base branch), deduplicates on the head SHA, increments the per-episode
+// attempt counter, and either dispatches a rebase continuation or
+// escalates when the new conflicting head pushes the episode strictly over
+// the retry budget. The increment-then-strict-over-limit ordering mirrors
+// [handleCIFailure].
+func handleMergeConflictDirty(
+	state *State,
+	params ReconcileParams,
+	key string,
+	pending *PendingReaction,
+	data *MergeConflictReactionData,
+	status domain.PRMergeStatus,
+	rkey string,
+	now time.Time,
+	pollInterval time.Duration,
+	log *slog.Logger,
+	ctx context.Context,
+	metrics domain.Metrics,
+) {
+	// An empty head provides no rebase anchor. Defer without burning an
+	// attempt: a deferral is not a resolution attempt.
+	if status.HeadSHA == "" {
+		pending.PendingRetryAt = now.Add(pollInterval)
+		state.PendingReactions[key] = pending
+		log.Debug("merge conflict deferred: empty head sha, no rebase anchor",
+			slog.Int("pr_number", data.PRNumber),
+		)
+		return
+	}
+
+	// An empty base provides no rebase target. This is defense-in-depth,
+	// symmetric to the empty-head guard: the agent is never handed a
+	// rebase against an empty target. GitHub always populates base.ref, so
+	// this guard rarely fires for the only wired provider. It runs before
+	// the increment for the same reason: a deferral must not burn an
+	// attempt.
+	if status.BaseBranch == "" {
+		pending.PendingRetryAt = now.Add(pollInterval)
+		state.PendingReactions[key] = pending
+		log.Debug("merge conflict deferred: empty base branch, no rebase target",
+			slog.Int("pr_number", data.PRNumber),
+		)
+		return
+	}
+
+	fingerprint := buildMergeConflictFingerprint(status.HeadSHA)
+	if err := params.Store.UpsertReactionFingerprint(ctx, pending.IssueID, ReactionKindMergeConflict, fingerprint); err != nil {
+		log.Warn("failed to upsert merge conflict reaction fingerprint",
+			slog.Any("error", err),
+		)
+	}
+
+	// Head-SHA dedup before the increment so a same-head re-observation
+	// never re-increments the per-episode counter.
+	storedFP, dispatched, fpErr := params.Store.GetReactionFingerprint(ctx, pending.IssueID, ReactionKindMergeConflict)
+	if fpErr != nil {
+		log.Warn("failed to get merge conflict reaction fingerprint, proceeding without dedup",
+			slog.Any("error", fpErr),
+		)
+	} else if storedFP == fingerprint && dispatched {
+		pending.PendingRetryAt = now.Add(pollInterval)
+		state.PendingReactions[key] = pending
+		log.Debug("merge conflict already dispatched for this head, skipping",
+			slog.Int("pr_number", data.PRNumber),
+		)
+		return
+	}
+
+	// Per-episode increment for this new conflicting head, then the strict
+	// over-limit cap. The increment happens before the cap so the new
+	// conflicting head is what pushes the episode over budget, and the
+	// escalation reports attempts == MaxRetries + 1.
+	state.ReactionAttempts[rkey]++
+	attempts := state.ReactionAttempts[rkey]
+	if attempts > params.MergeConflictConfig.MaxRetries {
+		escalateMergeConflictFailure(state, params, pending, attempts, data, log, ctx, metrics)
+		return
+	}
+
+	dispatchMergeConflictContinuation(state, params, pending, data, status, log, ctx)
+	metrics.IncMergeConflictChecks("dispatched")
+}
+
+// buildMergeConflictFingerprint computes the SHA-256 hex digest of the PR
+// head SHA. An empty head SHA returns the empty string; the dirty branch
+// guards the empty case before reaching this helper, so the empty-string
+// return is a backstop rather than a relied-on path.
+func buildMergeConflictFingerprint(headSHA string) string {
+	if headSHA == "" {
+		return ""
+	}
+	h := sha256.Sum256([]byte(headSHA))
+	return fmt.Sprintf("%x", h)
+}
+
+// dispatchMergeConflictContinuation schedules a rebase-and-resolve
+// continuation turn carrying the PR's real base branch and marks the
+// merge-conflict fingerprint dispatched on the same tick. The continuation
+// reuses the same workspace identifier (no new workspace key).
+func dispatchMergeConflictContinuation(
+	state *State,
+	params ReconcileParams,
+	pending *PendingReaction,
+	data *MergeConflictReactionData,
+	status domain.PRMergeStatus,
+	log *slog.Logger,
+	ctx context.Context,
+) {
+	mergeContext := buildMergeConflictTemplateMap(data, status)
+
+	CancelRetry(state, pending.IssueID)
+
+	ScheduleRetry(state, ScheduleRetryParams{
+		IssueID:     pending.IssueID,
+		Identifier:  pending.Identifier,
+		DisplayID:   pending.DisplayID,
+		Attempt:     pending.Attempt,
+		DelayMS:     continuationDelayMS,
+		LastSSHHost: pending.LastSSHHost,
+		ContinuationContext: map[string]any{
+			"merge_conflict": mergeContext,
+		},
+		ReactionKind: ReactionKindMergeConflict,
+		AgentKind:    pending.AgentKind,
+		RuleName:     pending.RuleName,
+		TemplateID:   pending.TemplateID,
+	}, params.OnRetryFire)
+
+	if markErr := params.Store.MarkReactionDispatched(ctx, pending.IssueID, ReactionKindMergeConflict); markErr != nil {
+		log.Warn("failed to mark merge conflict dispatched",
+			slog.Any("error", markErr),
+		)
+	}
+
+	log.Info("merge conflict detected, scheduling rebase dispatch",
+		slog.Int("pr_number", data.PRNumber),
+		slog.String("base", status.BaseBranch),
+		slog.Int("merge_conflict_attempt", state.ReactionAttempts[ReactionKey(pending.IssueID, ReactionKindMergeConflict)]),
+		slog.Int("max_retries", params.MergeConflictConfig.MaxRetries),
+	)
+}
+
+// buildMergeConflictTemplateMap builds the continuation template context
+// injected under the key "merge_conflict". The base value is the PR
+// object's real base ref read live from GetMergeability on this tick (the
+// rebase target), threaded so the agent rebases onto the PR's current
+// target rather than a value snapshotted at enqueue time. The base key is
+// always present so templates can reference .merge_conflict.base under
+// missingkey=error.
+func buildMergeConflictTemplateMap(data *MergeConflictReactionData, status domain.PRMergeStatus) map[string]any {
+	return map[string]any{
+		"pr_number": data.PRNumber,
+		"branch":    data.Branch,
+		"head_sha":  status.HeadSHA,
+		"base":      status.BaseBranch,
+	}
+}
+
+// escalateMergeConflictFailure applies the configured escalation action
+// (label or comment) after the per-episode retry budget is exhausted, then
+// removes the merge-conflict slot, fingerprint, and per-episode attempt
+// counter. The attempts value is captured at the call boundary, so the
+// scoped counter delete below cannot disturb the reported count.
+//
+// Unlike the bot-review and auto-merge escalations, this resets the
+// per-episode attempt counter via a scoped delete because the
+// merge-conflict counter is episodic, mirroring the CI reaction. The reset
+// is the scoped per-kind delete (not the issue-wide ClearReactionsForIssue)
+// so sibling reactions' counters and state.Claimed are never touched.
+func escalateMergeConflictFailure(
+	state *State,
+	params ReconcileParams,
+	pending *PendingReaction,
+	attempts int,
+	data *MergeConflictReactionData,
+	log *slog.Logger,
+	ctx context.Context,
+	metrics domain.Metrics,
+) {
+	log.Warn("merge conflict resolution attempts exhausted, escalating",
+		slog.Int("attempts", attempts),
+		slog.Int("max_retries", params.MergeConflictConfig.MaxRetries),
+		slog.Int("pr_number", data.PRNumber),
+	)
+
+	switch params.MergeConflictConfig.Escalation {
+	case "label":
+		label := params.MergeConflictConfig.EscalationLabel
+		if label == "" {
+			label = "needs-human"
+		}
+		if params.TrackerAdapter != nil {
+			issueID := pending.IssueID
+			tracker := params.TrackerAdapter
+			m := metrics
+			escalLog := log
+
+			state.TrackerOpsWg.Go(func() {
+				dctx, cancel := context.WithTimeout(
+					context.WithoutCancel(ctx), 30*time.Second)
+				defer cancel()
+
+				if err := tracker.AddLabel(dctx, issueID, label); err != nil {
+					escalLog.Warn("merge conflict escalation label failed",
+						slog.Any("error", err),
+					)
+					m.IncMergeConflictEscalations("error")
+				} else {
+					m.IncMergeConflictEscalations("label")
+				}
+			})
+		}
+
+	case "comment", "":
+		commentText := buildMergeConflictEscalationComment(data, attempts)
+		if params.TrackerAdapter != nil {
+			issueID := pending.IssueID
+			tracker := params.TrackerAdapter
+			m := metrics
+			escalLog := log
+			ct := commentText
+
+			state.TrackerOpsWg.Go(func() {
+				dctx, cancel := context.WithTimeout(
+					context.WithoutCancel(ctx), 30*time.Second)
+				defer cancel()
+
+				if err := tracker.CommentIssue(dctx, issueID, ct); err != nil {
+					escalLog.Warn("merge conflict escalation comment failed",
+						slog.Any("error", err),
+					)
+					m.IncMergeConflictEscalations("error")
+				} else {
+					m.IncMergeConflictEscalations("comment")
+				}
+			})
+		}
+	}
+
+	delete(state.PendingReactions, ReactionKey(pending.IssueID, ReactionKindMergeConflict))
+	if err := params.Store.DeleteReactionFingerprint(ctx, pending.IssueID, ReactionKindMergeConflict); err != nil {
+		log.Warn("merge conflict fingerprint delete failed during escalation",
+			slog.Any("error", err),
+		)
+	}
+	delete(state.ReactionAttempts, ReactionKey(pending.IssueID, ReactionKindMergeConflict))
+}
+
+// buildMergeConflictEscalationComment returns the plain-text escalation
+// comment used when the per-episode retry budget is exhausted. Plain text
+// is used so the comment renders consistently across all tracker adapters.
+func buildMergeConflictEscalationComment(data *MergeConflictReactionData, attempts int) string {
+	return fmt.Sprintf(
+		"Sortie attempted %d merge-conflict resolution turn(s) and could not clear the conflicts for PR #%d. Manual rebase required.",
+		attempts,
+		data.PRNumber,
+	)
+}

--- a/internal/orchestrator/merge_conflict_reconcile_test.go
+++ b/internal/orchestrator/merge_conflict_reconcile_test.go
@@ -934,6 +934,49 @@ func TestBuildMergeConflictTemplateMap(t *testing.T) {
 	}
 }
 
+// --- buildMergeConflictEscalationComment reports dispatched turns (attempts-1) ---
+
+func TestBuildMergeConflictEscalationComment(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		data     *MergeConflictReactionData
+		attempts int
+		want     string
+	}{
+		{
+			name:     "one dispatched turn at max_retries 1",
+			data:     &MergeConflictReactionData{PRNumber: 42},
+			attempts: 2,
+			want:     "Sortie attempted 1 merge-conflict resolution turn(s) and could not clear the conflicts for PR #42. Manual rebase required.",
+		},
+		{
+			name:     "zero dispatched turns at max_retries 0 (escalates without a rebase)",
+			data:     &MergeConflictReactionData{PRNumber: 7},
+			attempts: 1,
+			want:     "Sortie attempted 0 merge-conflict resolution turn(s) and could not clear the conflicts for PR #7. Manual rebase required.",
+		},
+		{
+			name:     "three dispatched turns at max_retries 3",
+			data:     &MergeConflictReactionData{PRNumber: 99},
+			attempts: 4,
+			want:     "Sortie attempted 3 merge-conflict resolution turn(s) and could not clear the conflicts for PR #99. Manual rebase required.",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := buildMergeConflictEscalationComment(tt.data, tt.attempts)
+			if got != tt.want {
+				t.Errorf("buildMergeConflictEscalationComment(attempts=%d) =\n  %q\nwant:\n  %q", tt.attempts, got, tt.want)
+			}
+		})
+	}
+}
+
 // --- 5.1.13 Dispatch carries real base (AC6b orchestrator side) ---
 
 func TestReconcileMergeConflicts_DispatchCarriesRealBase(t *testing.T) {

--- a/internal/orchestrator/merge_conflict_reconcile_test.go
+++ b/internal/orchestrator/merge_conflict_reconcile_test.go
@@ -1,0 +1,1081 @@
+package orchestrator
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/sortie-ai/sortie/internal/domain"
+	"github.com/sortie-ai/sortie/internal/persistence"
+)
+
+// --- Test doubles ---
+
+// mergeConflictMetricsSpy records merge-conflict-specific metric calls while
+// delegating every other method to NoopMetrics.
+type mergeConflictMetricsSpy struct {
+	domain.NoopMetrics
+	checks      map[string]int
+	escalations map[string]int
+}
+
+func newMergeConflictMetricsSpy() *mergeConflictMetricsSpy {
+	return &mergeConflictMetricsSpy{
+		checks:      make(map[string]int),
+		escalations: make(map[string]int),
+	}
+}
+
+func (s *mergeConflictMetricsSpy) IncMergeConflictChecks(result string) { s.checks[result]++ }
+func (s *mergeConflictMetricsSpy) IncMergeConflictEscalations(action string) {
+	s.escalations[action]++
+}
+
+// mergeabilitySCM is a controllable SCMAdapter whose GetMergeability return
+// value is supplied per call by a function field, so episodic tests can
+// advance the head SHA between reconcile ticks. The call count lets tests
+// assert that the mergeability read runs exactly once per due tick.
+type mergeabilitySCM struct {
+	fn    func() (domain.PRMergeStatus, error)
+	calls int
+}
+
+var _ domain.SCMAdapter = (*mergeabilitySCM)(nil)
+
+func (m *mergeabilitySCM) GetMergeability(_ context.Context, _ int, _, _ string) (domain.PRMergeStatus, error) {
+	m.calls++
+	if m.fn != nil {
+		return m.fn()
+	}
+	return domain.PRMergeStatus{}, nil
+}
+
+func (m *mergeabilitySCM) FetchPendingReviews(_ context.Context, _ int, _, _ string) ([]domain.ReviewComment, error) {
+	return nil, nil
+}
+func (m *mergeabilitySCM) FetchBotReviewComments(_ context.Context, _ int, _, _ string, _ []string) ([]domain.ReviewComment, error) {
+	return nil, nil
+}
+func (m *mergeabilitySCM) GetReviewDecision(_ context.Context, _ int, _, _ string) (domain.ReviewDecision, error) {
+	return "", nil
+}
+func (m *mergeabilitySCM) GetCIStatus(_ context.Context, _ int, _, _ string) (string, error) {
+	return "", nil
+}
+func (m *mergeabilitySCM) MergePR(_ context.Context, _ int, _, _ string, _ domain.MergeStrategy, _, _, _ string) (domain.MergeResult, error) {
+	return domain.MergeResult{}, nil
+}
+func (m *mergeabilitySCM) DeleteBranch(_ context.Context, _, _, _ string) error {
+	return nil
+}
+
+// statefulFingerprintStore is a ReconcileStore that genuinely persists the
+// per-(issue,kind) fingerprint and dispatched flag, so the head-SHA dedup
+// across consecutive ticks is exercised against real stored state rather
+// than canned values. Only the fingerprint methods carry behavior; the rest
+// satisfy the interface.
+type statefulFingerprintStore struct {
+	fingerprints map[string]fingerprintRecord
+
+	upsertCalls         int
+	getCalls            int
+	markDispatchedCalls int
+	deleteCalls         int
+
+	upsertErr error
+	getErr    error
+	markErr   error
+	deleteErr error
+}
+
+type fingerprintRecord struct {
+	fingerprint string
+	dispatched  bool
+}
+
+var _ ReconcileStore = (*statefulFingerprintStore)(nil)
+
+func newStatefulFingerprintStore() *statefulFingerprintStore {
+	return &statefulFingerprintStore{fingerprints: make(map[string]fingerprintRecord)}
+}
+
+func (s *statefulFingerprintStore) SaveRetryEntry(_ context.Context, _ persistence.RetryEntry) error {
+	return nil
+}
+
+func (s *statefulFingerprintStore) UpsertReactionFingerprint(_ context.Context, issueID, kind, fingerprint string) error {
+	s.upsertCalls++
+	if s.upsertErr != nil {
+		return s.upsertErr
+	}
+	key := issueID + ":" + kind
+	rec := s.fingerprints[key]
+	// A changed fingerprint resets the dispatched flag, mirroring the
+	// persistence-layer upsert contract.
+	if rec.fingerprint != fingerprint {
+		rec.dispatched = false
+	}
+	rec.fingerprint = fingerprint
+	s.fingerprints[key] = rec
+	return nil
+}
+
+func (s *statefulFingerprintStore) GetReactionFingerprint(_ context.Context, issueID, kind string) (string, bool, error) {
+	s.getCalls++
+	if s.getErr != nil {
+		return "", false, s.getErr
+	}
+	rec := s.fingerprints[issueID+":"+kind]
+	return rec.fingerprint, rec.dispatched, nil
+}
+
+func (s *statefulFingerprintStore) MarkReactionDispatched(_ context.Context, issueID, kind string) error {
+	s.markDispatchedCalls++
+	if s.markErr != nil {
+		return s.markErr
+	}
+	key := issueID + ":" + kind
+	rec := s.fingerprints[key]
+	rec.dispatched = true
+	s.fingerprints[key] = rec
+	return nil
+}
+
+func (s *statefulFingerprintStore) DeleteReactionFingerprint(_ context.Context, issueID, kind string) error {
+	s.deleteCalls++
+	if s.deleteErr != nil {
+		return s.deleteErr
+	}
+	delete(s.fingerprints, issueID+":"+kind)
+	return nil
+}
+
+func (s *statefulFingerprintStore) DeleteRetryEntry(_ context.Context, _ string) error { return nil }
+func (s *statefulFingerprintStore) AppendRunHistory(_ context.Context, run persistence.RunHistory) (persistence.RunHistory, error) {
+	return run, nil
+}
+func (s *statefulFingerprintStore) DeleteReactionFingerprintsByIssue(_ context.Context, _ string) error {
+	return nil
+}
+
+// has reports whether a fingerprint row exists for the issue+kind.
+func (s *statefulFingerprintStore) has(issueID, kind string) bool {
+	_, ok := s.fingerprints[issueID+":"+kind]
+	return ok
+}
+
+// --- Test helpers ---
+
+// mcBaseTime is a fixed reference time for merge-conflict reconcile tests.
+var mcBaseTime = time.Date(2026, 6, 1, 9, 0, 0, 0, time.UTC)
+
+// newMergeConflictPending builds a PendingReaction with
+// Kind=ReactionKindMergeConflict.
+func newMergeConflictPending(issueID string, prNumber int) *PendingReaction {
+	return &PendingReaction{
+		IssueID:    issueID,
+		Identifier: issueID + "-ident",
+		DisplayID:  issueID + "-ident",
+		Attempt:    1,
+		Kind:       ReactionKindMergeConflict,
+		CreatedAt:  mcBaseTime,
+		KindData: &MergeConflictReactionData{
+			PRNumber: prNumber,
+			Owner:    "owner",
+			Repo:     "repo",
+			Branch:   "feature/" + issueID,
+			SHA:      "seed-sha",
+		},
+	}
+}
+
+// stateWithMergeConflict creates a State with one merge-conflict
+// PendingReaction entry.
+func stateWithMergeConflict(t *testing.T, issueID string, prNumber int) *State {
+	t.Helper()
+	s := NewState(5000, 4, nil, AgentTotals{})
+	rkey := ReactionKey(issueID, ReactionKindMergeConflict)
+	s.PendingReactions[rkey] = newMergeConflictPending(issueID, prNumber)
+	s.Claimed[issueID] = struct{}{}
+	return s
+}
+
+// defaultMergeConflictConfig returns a MergeConflictReactionConfig at the
+// issue-mandated default max_retries: 1 with label escalation.
+func defaultMergeConflictConfig() MergeConflictReactionConfig {
+	return MergeConflictReactionConfig{
+		Escalation:      "label",
+		EscalationLabel: "needs-human",
+		PollIntervalMS:  60000,
+		MaxRetries:      1,
+	}
+}
+
+// mergeConflictParams returns ReconcileParams wired for merge-conflict
+// reconcile unit tests.
+func mergeConflictParams(store ReconcileStore, scm domain.SCMAdapter, tracker domain.TrackerAdapter) ReconcileParams {
+	return ReconcileParams{
+		TrackerAdapter:                  tracker,
+		SCMAdapter:                      scm,
+		MergeConflictConfig:             defaultMergeConflictConfig(),
+		MergeConflictReactionConfigured: true,
+		Store:                           store,
+		OnRetryFire:                     noopRetryFire,
+		Ctx:                             context.Background(),
+		Logger:                          discardLogger(),
+		NowFunc:                         func() time.Time { return mcBaseTime },
+	}
+}
+
+// dirtyStatus builds a dirty PRMergeStatus with the given head SHA and base
+// branch.
+func dirtyStatus(headSHA, base string) domain.PRMergeStatus {
+	return domain.PRMergeStatus{
+		Mergeability: domain.MergeabilityDirty,
+		HeadSHA:      headSHA,
+		BranchName:   "feature/branch",
+		BaseBranch:   base,
+	}
+}
+
+// --- reconcileMergeConflicts guard tests ---
+
+func TestReconcileMergeConflicts_NilAdapter(t *testing.T) {
+	t.Parallel()
+
+	state := stateWithMergeConflict(t, "MC-NA", 10)
+	store := newStatefulFingerprintStore()
+	metrics := newMergeConflictMetricsSpy()
+	params := mergeConflictParams(store, nil, nil)
+
+	reconcileMergeConflicts(state, params, discardLogger(), context.Background(), metrics)
+
+	rkey := ReactionKey("MC-NA", ReactionKindMergeConflict)
+	if _, ok := state.PendingReactions[rkey]; !ok {
+		t.Error("PendingReactions entry removed with nil SCMAdapter; want no-op")
+	}
+	if len(metrics.checks) != 0 {
+		t.Errorf("IncMergeConflictChecks called with nil adapter = %v, want no calls", metrics.checks)
+	}
+}
+
+func TestReconcileMergeConflicts_NotConfigured(t *testing.T) {
+	t.Parallel()
+
+	state := stateWithMergeConflict(t, "MC-NC", 10)
+	store := newStatefulFingerprintStore()
+	metrics := newMergeConflictMetricsSpy()
+	scm := &mergeabilitySCM{}
+	params := mergeConflictParams(store, scm, nil)
+	params.MergeConflictReactionConfigured = false
+
+	reconcileMergeConflicts(state, params, discardLogger(), context.Background(), metrics)
+
+	rkey := ReactionKey("MC-NC", ReactionKindMergeConflict)
+	if _, ok := state.PendingReactions[rkey]; !ok {
+		t.Error("PendingReactions entry removed when MergeConflictReactionConfigured=false; want no-op")
+	}
+	if scm.calls != 0 {
+		t.Errorf("GetMergeability calls = %d, want 0 (not configured)", scm.calls)
+	}
+}
+
+// --- 5.1.1 Dispatch (AC1) ---
+
+func TestReconcileMergeConflicts_Dispatch(t *testing.T) {
+	t.Parallel()
+
+	state := stateWithMergeConflict(t, "MC-D1", 42)
+	rkey := ReactionKey("MC-D1", ReactionKindMergeConflict)
+	store := newStatefulFingerprintStore()
+	metrics := newMergeConflictMetricsSpy()
+	scm := &mergeabilitySCM{fn: func() (domain.PRMergeStatus, error) {
+		return dirtyStatus("head-1", "main"), nil
+	}}
+	params := mergeConflictParams(store, scm, nil)
+
+	reconcileMergeConflicts(state, params, discardLogger(), context.Background(), metrics)
+
+	if scm.calls != 1 {
+		t.Errorf("GetMergeability calls = %d, want 1 (one read per due tick)", scm.calls)
+	}
+	if _, ok := state.PendingReactions[rkey]; ok {
+		t.Error("PendingReactions entry still present after dispatch; want consumed")
+	}
+	retry, ok := state.RetryAttempts["MC-D1"]
+	if !ok {
+		t.Fatal("retry not scheduled after dirty dispatch; want scheduled")
+	}
+	if retry.ReactionKind != ReactionKindMergeConflict {
+		t.Errorf("RetryEntry.ReactionKind = %q, want %q", retry.ReactionKind, ReactionKindMergeConflict)
+	}
+	if retry.ContinuationContext == nil {
+		t.Fatal("RetryEntry.ContinuationContext is nil; want merge_conflict map")
+	}
+	if _, ok := retry.ContinuationContext["merge_conflict"]; !ok {
+		t.Error(`ContinuationContext missing "merge_conflict" key`)
+	}
+	if state.ReactionAttempts[rkey] != 1 {
+		t.Errorf("ReactionAttempts[%s] = %d, want 1 (1 > 1 false at default max_retries: 1)", rkey, state.ReactionAttempts[rkey])
+	}
+	if metrics.checks["dispatched"] != 1 {
+		t.Errorf(`IncMergeConflictChecks("dispatched") = %d, want 1`, metrics.checks["dispatched"])
+	}
+	if metrics.escalations["label"] != 0 {
+		t.Errorf("IncMergeConflictEscalations called = %v, want none on first dirty head", metrics.escalations)
+	}
+	if store.markDispatchedCalls != 1 {
+		t.Errorf("MarkReactionDispatched calls = %d, want 1 (marked on dispatch tick)", store.markDispatchedCalls)
+	}
+}
+
+// --- 5.1.2 Unknown defers (AC12) ---
+
+func TestReconcileMergeConflicts_UnknownDefers(t *testing.T) {
+	t.Parallel()
+
+	state := stateWithMergeConflict(t, "MC-U1", 10)
+	rkey := ReactionKey("MC-U1", ReactionKindMergeConflict)
+	store := newStatefulFingerprintStore()
+	metrics := newMergeConflictMetricsSpy()
+	scm := &mergeabilitySCM{fn: func() (domain.PRMergeStatus, error) {
+		return domain.PRMergeStatus{Mergeability: domain.MergeabilityUnknown, HeadSHA: "head-u"}, nil
+	}}
+	params := mergeConflictParams(store, scm, nil)
+
+	reconcileMergeConflicts(state, params, discardLogger(), context.Background(), metrics)
+
+	entry, ok := state.PendingReactions[rkey]
+	if !ok {
+		t.Fatal("PendingReactions entry dropped on mergeability unknown; want re-enqueued")
+	}
+	wantRetryAt := mcBaseTime.Add(60 * time.Second)
+	if !entry.PendingRetryAt.Equal(wantRetryAt) {
+		t.Errorf("PendingRetryAt = %v, want %v (poll interval defer)", entry.PendingRetryAt, wantRetryAt)
+	}
+	if _, ok := state.RetryAttempts["MC-U1"]; ok {
+		t.Error("retry scheduled on mergeability unknown; want none (no dispatch)")
+	}
+	if _, ok := state.ReactionAttempts[rkey]; ok {
+		t.Error("ReactionAttempts touched on mergeability unknown; want untouched")
+	}
+	if store.upsertCalls != 0 || store.deleteCalls != 0 {
+		t.Errorf("fingerprint touched on mergeability unknown (upsert=%d, delete=%d); want neither", store.upsertCalls, store.deleteCalls)
+	}
+	if metrics.checks["unknown"] != 1 {
+		t.Errorf(`IncMergeConflictChecks("unknown") = %d, want 1`, metrics.checks["unknown"])
+	}
+}
+
+// --- 5.1.3 Not-dirty resets (AC8 branch N1) ---
+
+func TestReconcileMergeConflicts_NotDirtyResets(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		state domain.MergeabilityState
+	}{
+		{"clean", domain.MergeabilityClean},
+		{"unstable", domain.MergeabilityUnstable},
+		{"blocked", domain.MergeabilityBlocked},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			state := stateWithMergeConflict(t, "MC-N1", 10)
+			rkey := ReactionKey("MC-N1", ReactionKindMergeConflict)
+			state.ReactionAttempts[rkey] = 1 // pre-seeded prior-episode counter
+			store := newStatefulFingerprintStore()
+			store.fingerprints[rkey] = fingerprintRecord{fingerprint: "old-fp", dispatched: true}
+			metrics := newMergeConflictMetricsSpy()
+			scm := &mergeabilitySCM{fn: func() (domain.PRMergeStatus, error) {
+				return domain.PRMergeStatus{Mergeability: tt.state, HeadSHA: "head-clean", BaseBranch: "main"}, nil
+			}}
+			params := mergeConflictParams(store, scm, nil)
+
+			reconcileMergeConflicts(state, params, discardLogger(), context.Background(), metrics)
+
+			if scm.calls != 1 {
+				t.Errorf("GetMergeability calls = %d, want 1 (read runs every due tick, no cap before read)", scm.calls)
+			}
+			entry, ok := state.PendingReactions[rkey]
+			if !ok {
+				t.Fatal("PendingReactions entry dropped on not-dirty; want re-enqueued")
+			}
+			wantRetryAt := mcBaseTime.Add(60 * time.Second)
+			if !entry.PendingRetryAt.Equal(wantRetryAt) {
+				t.Errorf("PendingRetryAt = %v, want %v (poll interval defer)", entry.PendingRetryAt, wantRetryAt)
+			}
+			if store.deleteCalls != 1 {
+				t.Errorf("DeleteReactionFingerprint calls = %d, want 1 on not-dirty (episode close)", store.deleteCalls)
+			}
+			if store.has("MC-N1", ReactionKindMergeConflict) {
+				t.Error("fingerprint row still present after not-dirty; want deleted")
+			}
+			if _, ok := state.ReactionAttempts[rkey]; ok {
+				t.Error("ReactionAttempts not reset after not-dirty; want deleted (episode close)")
+			}
+			if metrics.checks["clear"] != 1 {
+				t.Errorf(`IncMergeConflictChecks("clear") = %d, want 1`, metrics.checks["clear"])
+			}
+		})
+	}
+}
+
+// --- 5.1.4 Dedup same head (AC7) ---
+
+func TestReconcileMergeConflicts_DedupSameHead(t *testing.T) {
+	t.Parallel()
+
+	state := stateWithMergeConflict(t, "MC-DEDUP", 10)
+	rkey := ReactionKey("MC-DEDUP", ReactionKindMergeConflict)
+	store := newStatefulFingerprintStore()
+	metrics := newMergeConflictMetricsSpy()
+	scm := &mergeabilitySCM{fn: func() (domain.PRMergeStatus, error) {
+		return dirtyStatus("head-same", "main"), nil
+	}}
+	params := mergeConflictParams(store, scm, nil)
+
+	// Tick 1: dispatch for head-same.
+	reconcileMergeConflicts(state, params, discardLogger(), context.Background(), metrics)
+	if metrics.checks["dispatched"] != 1 {
+		t.Fatalf(`after tick 1: IncMergeConflictChecks("dispatched") = %d, want 1`, metrics.checks["dispatched"])
+	}
+	if state.ReactionAttempts[rkey] != 1 {
+		t.Fatalf("after tick 1: ReactionAttempts[%s] = %d, want 1", rkey, state.ReactionAttempts[rkey])
+	}
+
+	// The dispatch consumes the slot; the worker exit would re-seed it. The
+	// same-head re-observation must hit the dedup branch, so re-seed the slot
+	// to model the next reconcile pass over a still-pending entry.
+	state.PendingReactions[rkey] = newMergeConflictPending("MC-DEDUP", 10)
+
+	// Tick 2: same head, already dispatched → dedup branch, no re-dispatch,
+	// no re-increment.
+	reconcileMergeConflicts(state, params, discardLogger(), context.Background(), metrics)
+
+	if metrics.checks["dispatched"] != 1 {
+		t.Errorf(`after tick 2: IncMergeConflictChecks("dispatched") = %d, want 1 (same head deduped)`, metrics.checks["dispatched"])
+	}
+	if state.ReactionAttempts[rkey] != 1 {
+		t.Errorf("after tick 2: ReactionAttempts[%s] = %d, want 1 (dedup must not re-increment)", rkey, state.ReactionAttempts[rkey])
+	}
+	if _, ok := state.PendingReactions[rkey]; !ok {
+		t.Error("PendingReactions entry dropped on same-head dedup; want re-enqueued")
+	}
+	if metrics.escalations["label"] != 0 {
+		t.Errorf("IncMergeConflictEscalations = %v, want none on same-head dedup", metrics.escalations)
+	}
+	rec := store.fingerprints[rkey]
+	if rec.fingerprint != buildMergeConflictFingerprint("head-same") {
+		t.Errorf("stored fingerprint = %q, want digest of head-same", rec.fingerprint)
+	}
+}
+
+// --- 5.1.5 Episodic re-arm with intervening clean tick (AC8) ---
+
+func TestReconcileMergeConflicts_EpisodicReArm(t *testing.T) {
+	t.Parallel()
+
+	state := stateWithMergeConflict(t, "MC-REARM", 10)
+	rkey := ReactionKey("MC-REARM", ReactionKindMergeConflict)
+	store := newStatefulFingerprintStore()
+	metrics := newMergeConflictMetricsSpy()
+
+	var head string
+	now := mcBaseTime
+	scm := &mergeabilitySCM{fn: func() (domain.PRMergeStatus, error) {
+		switch head {
+		case "H2-clean":
+			return domain.PRMergeStatus{Mergeability: domain.MergeabilityClean, HeadSHA: head, BaseBranch: "main"}, nil
+		default:
+			return dirtyStatus(head, "main"), nil
+		}
+	}}
+	params := mergeConflictParams(store, scm, nil)
+	params.NowFunc = func() time.Time { return now }
+
+	// Tick 1: head H1 dirty → dispatch, attempts becomes 1.
+	head = "H1"
+	reconcileMergeConflicts(state, params, discardLogger(), context.Background(), metrics)
+	if metrics.checks["dispatched"] != 1 {
+		t.Fatalf("after tick 1: dispatched = %d, want 1", metrics.checks["dispatched"])
+	}
+	if state.ReactionAttempts[rkey] != 1 {
+		t.Fatalf("after tick 1: ReactionAttempts = %d, want 1", state.ReactionAttempts[rkey])
+	}
+
+	// Tick 2: head H2 clean → branch N1 resets the episode. A worker exit
+	// re-seeds the slot; advance the clock past the poll interval so the
+	// re-enqueued entry is due.
+	head = "H2-clean"
+	now = now.Add(2 * time.Minute)
+	state.PendingReactions[rkey] = newMergeConflictPending("MC-REARM", 10)
+	reconcileMergeConflicts(state, params, discardLogger(), context.Background(), metrics)
+	if metrics.checks["clear"] != 1 {
+		t.Fatalf("after tick 2: clear = %d, want 1", metrics.checks["clear"])
+	}
+	if _, ok := state.ReactionAttempts[rkey]; ok {
+		t.Fatal("after tick 2: ReactionAttempts present, want deleted (episode close)")
+	}
+	if store.has("MC-REARM", ReactionKindMergeConflict) {
+		t.Fatal("after tick 2: fingerprint present, want deleted")
+	}
+
+	// Tick 3: head H3 dirty (a new independent conflict) on a later poll of
+	// the N1-re-enqueued entry → fresh dispatch, attempts becomes 1 again.
+	head = "H3"
+	now = now.Add(2 * time.Minute)
+	reconcileMergeConflicts(state, params, discardLogger(), context.Background(), metrics)
+
+	if metrics.checks["dispatched"] != 2 {
+		t.Errorf("after tick 3: dispatched = %d, want 2 (re-armed)", metrics.checks["dispatched"])
+	}
+	if state.ReactionAttempts[rkey] != 1 {
+		t.Errorf("after tick 3: ReactionAttempts = %d, want 1 (fresh episode after counter reset)", state.ReactionAttempts[rkey])
+	}
+	if len(metrics.escalations) != 0 {
+		t.Errorf("escalations = %v, want none across the re-arm episode", metrics.escalations)
+	}
+}
+
+// --- 5.1.6 Escalate on strict over-limit (AC10) ---
+
+func TestReconcileMergeConflicts_Escalate(t *testing.T) {
+	t.Parallel()
+
+	issueID := "MC-ESC"
+	state := stateWithMergeConflict(t, issueID, 77)
+	rkey := ReactionKey(issueID, ReactionKindMergeConflict)
+	store := newStatefulFingerprintStore()
+	metrics := newMergeConflictMetricsSpy()
+	tracker := &ciTrackerStub{}
+
+	var head string
+	scm := &mergeabilitySCM{fn: func() (domain.PRMergeStatus, error) {
+		return dirtyStatus(head, "main"), nil
+	}}
+	params := mergeConflictParams(store, scm, tracker)
+
+	// Tick 1: head H1 dirty → dispatch, attempts == 1 (1 > 1 false).
+	head = "H1"
+	reconcileMergeConflicts(state, params, discardLogger(), context.Background(), metrics)
+	if state.ReactionAttempts[rkey] != 1 {
+		t.Fatalf("after tick 1: ReactionAttempts = %d, want 1", state.ReactionAttempts[rkey])
+	}
+	if metrics.checks["dispatched"] != 1 {
+		t.Fatalf("after tick 1: dispatched = %d, want 1", metrics.checks["dispatched"])
+	}
+
+	// The agent rebased to a NEW head H2 that is still dirty. Re-seed the slot
+	// (a worker exit would do this) and run tick 2.
+	head = "H2"
+	state.PendingReactions[rkey] = newMergeConflictPending(issueID, 77)
+
+	reconcileMergeConflicts(state, params, discardLogger(), context.Background(), metrics)
+	state.TrackerOpsWg.Wait()
+
+	if scm.calls != 2 {
+		t.Errorf("GetMergeability calls = %d, want 2 (read NOT skipped on tick 2)", scm.calls)
+	}
+	// Strict over-limit: attempts 2, 2 > 1 true → escalate. The counter is
+	// deleted on the escalation exit (episodic reset), so it is ABSENT.
+	if _, ok := state.ReactionAttempts[rkey]; ok {
+		t.Errorf("ReactionAttempts[%s] present after escalation = %d, want absent (episodic reset)", rkey, state.ReactionAttempts[rkey])
+	}
+	if _, ok := state.PendingReactions[rkey]; ok {
+		t.Error("merge-conflict slot still present after escalation; want deleted")
+	}
+	if metrics.escalations["label"] != 1 {
+		t.Errorf(`IncMergeConflictEscalations("label") = %d, want 1 (exactly one escalation)`, metrics.escalations["label"])
+	}
+	if tracker.addLabelCalled != 1 {
+		t.Errorf("AddLabel calls = %d, want 1", tracker.addLabelCalled)
+	}
+	// No second dispatch on the escalation tick.
+	if metrics.checks["dispatched"] != 1 {
+		t.Errorf(`IncMergeConflictChecks("dispatched") = %d, want 1 (no dispatch on escalation tick)`, metrics.checks["dispatched"])
+	}
+	if store.deleteCalls != 1 {
+		t.Errorf("DeleteReactionFingerprint calls = %d, want 1 during escalation", store.deleteCalls)
+	}
+	// Claim must NOT be released by escalation.
+	if _, ok := state.Claimed[issueID]; !ok {
+		t.Error("state.Claimed cleared by merge-conflict escalation; want preserved")
+	}
+}
+
+// --- 5.1.7 Escalation resets counter, re-arm with NO clean tick (AC15) ---
+
+func TestReconcileMergeConflicts_EscalationResetsCounterReArm(t *testing.T) {
+	t.Parallel()
+
+	issueID := "MC-AC15"
+	state := stateWithMergeConflict(t, issueID, 88)
+	rkey := ReactionKey(issueID, ReactionKindMergeConflict)
+	store := newStatefulFingerprintStore()
+	metrics := newMergeConflictMetricsSpy()
+	tracker := &ciTrackerStub{}
+
+	var head string
+	scm := &mergeabilitySCM{fn: func() (domain.PRMergeStatus, error) {
+		return dirtyStatus(head, "main"), nil
+	}}
+	params := mergeConflictParams(store, scm, tracker)
+
+	// Tick 1: H1 dirty → dispatch, attempts 1.
+	head = "H1"
+	reconcileMergeConflicts(state, params, discardLogger(), context.Background(), metrics)
+	if state.ReactionAttempts[rkey] != 1 {
+		t.Fatalf("after tick 1: ReactionAttempts = %d, want 1", state.ReactionAttempts[rkey])
+	}
+
+	// Tick 2: still-dirty new head H2 → attempts 2, 2 > 1 → escalate, counter
+	// deleted.
+	head = "H2"
+	state.PendingReactions[rkey] = newMergeConflictPending(issueID, 88)
+	reconcileMergeConflicts(state, params, discardLogger(), context.Background(), metrics)
+	state.TrackerOpsWg.Wait()
+	if _, ok := state.ReactionAttempts[rkey]; ok {
+		t.Fatalf("after tick 2: ReactionAttempts present, want absent (escalation reset)")
+	}
+	if metrics.escalations["label"] != 1 {
+		t.Fatalf("after tick 2: escalations[label] = %d, want 1", metrics.escalations["label"])
+	}
+
+	// A normal worker exit re-seeds the merge-conflict slot. There is NO clean
+	// (N1) observation between the escalation and the next conflict.
+	state.PendingReactions[rkey] = newMergeConflictPending(issueID, 88)
+
+	// Tick 3: a NEW dirty head H3 → because the escalation reset the counter,
+	// attempts goes to 1 (not 2), 1 > 1 is false, so the orchestrator
+	// DISPATCHES fresh rather than escalating. Without the escalation-time
+	// counter reset, the counter would still read 2 and H3 would escalate at
+	// attempts 3 with zero rebase dispatches.
+	head = "H3"
+	reconcileMergeConflicts(state, params, discardLogger(), context.Background(), metrics)
+	state.TrackerOpsWg.Wait()
+
+	if state.ReactionAttempts[rkey] != 1 {
+		t.Errorf("after tick 3: ReactionAttempts = %d, want 1 (fresh episode, no intervening clean tick)", state.ReactionAttempts[rkey])
+	}
+	if metrics.checks["dispatched"] != 2 {
+		t.Errorf("after tick 3: dispatched = %d, want 2 (fresh dispatch, not escalation)", metrics.checks["dispatched"])
+	}
+	if metrics.escalations["label"] != 1 {
+		t.Errorf("after tick 3: escalations[label] = %d, want 1 (no second escalation)", metrics.escalations["label"])
+	}
+	if _, ok := state.PendingReactions[rkey]; ok {
+		t.Error("after tick 3: slot still present, want consumed by fresh dispatch")
+	}
+}
+
+// --- 5.1.8 Cross-kind isolation (AC2) ---
+
+func TestReconcileMergeConflicts_CrossKindIsolation(t *testing.T) {
+	t.Parallel()
+
+	issueID := "MC-ISO"
+	state := NewState(5000, 4, nil, AgentTotals{})
+
+	ciKey := ReactionKey(issueID, ReactionKindCI)
+	state.PendingReactions[ciKey] = &PendingReaction{
+		IssueID: issueID, Identifier: issueID + "-ident", Kind: ReactionKindCI,
+		CreatedAt: mcBaseTime, KindData: &CIReactionData{Branch: "feature/iso"},
+	}
+	state.ReactionAttempts[ciKey] = 3
+
+	reviewKey := ReactionKey(issueID, ReactionKindReview)
+	state.PendingReactions[reviewKey] = &PendingReaction{
+		IssueID: issueID, Identifier: issueID + "-ident", Kind: ReactionKindReview,
+		CreatedAt: mcBaseTime, KindData: &ReviewReactionData{PRNumber: 5},
+	}
+	state.ReactionAttempts[reviewKey] = 2
+
+	botKey := ReactionKey(issueID, ReactionKindBotReview)
+	state.PendingReactions[botKey] = &PendingReaction{
+		IssueID: issueID, Identifier: issueID + "-ident", Kind: ReactionKindBotReview,
+		CreatedAt: mcBaseTime, KindData: &BotReviewReactionData{PRNumber: 5},
+	}
+	state.ReactionAttempts[botKey] = 4
+
+	mergeKey := ReactionKey(issueID, ReactionKindAutoMerge)
+	state.PendingReactions[mergeKey] = &PendingReaction{
+		IssueID: issueID, Identifier: issueID + "-ident", Kind: ReactionKindAutoMerge,
+		CreatedAt: mcBaseTime, KindData: &AutoMergeReactionData{PRNumber: 5},
+	}
+	state.ReactionAttempts[mergeKey] = 1
+
+	mcKey := ReactionKey(issueID, ReactionKindMergeConflict)
+	state.PendingReactions[mcKey] = newMergeConflictPending(issueID, 5)
+	state.Claimed[issueID] = struct{}{}
+
+	store := newStatefulFingerprintStore()
+	store.fingerprints[ciKey] = fingerprintRecord{fingerprint: "ci-fp", dispatched: true}
+	store.fingerprints[reviewKey] = fingerprintRecord{fingerprint: "review-fp", dispatched: true}
+	metrics := newMergeConflictMetricsSpy()
+	scm := &mergeabilitySCM{fn: func() (domain.PRMergeStatus, error) {
+		return dirtyStatus("head-iso", "main"), nil
+	}}
+	params := mergeConflictParams(store, scm, nil)
+
+	reconcileMergeConflicts(state, params, discardLogger(), context.Background(), metrics)
+
+	// merge-conflict dispatched.
+	if metrics.checks["dispatched"] != 1 {
+		t.Fatalf(`IncMergeConflictChecks("dispatched") = %d, want 1`, metrics.checks["dispatched"])
+	}
+
+	// All four sibling slots survive untouched.
+	for _, sib := range []struct {
+		name string
+		key  string
+	}{
+		{"ci", ciKey}, {"review", reviewKey}, {"bot-review", botKey}, {"merge", mergeKey},
+	} {
+		if _, ok := state.PendingReactions[sib.key]; !ok {
+			t.Errorf("%s PendingReaction slot removed by merge-conflict dispatch; want untouched", sib.name)
+		}
+	}
+
+	// Sibling counters untouched.
+	if state.ReactionAttempts[ciKey] != 3 {
+		t.Errorf("ReactionAttempts[ci] = %d, want 3 (untouched)", state.ReactionAttempts[ciKey])
+	}
+	if state.ReactionAttempts[reviewKey] != 2 {
+		t.Errorf("ReactionAttempts[review] = %d, want 2 (untouched)", state.ReactionAttempts[reviewKey])
+	}
+	if state.ReactionAttempts[botKey] != 4 {
+		t.Errorf("ReactionAttempts[bot-review] = %d, want 4 (untouched)", state.ReactionAttempts[botKey])
+	}
+	if state.ReactionAttempts[mergeKey] != 1 {
+		t.Errorf("ReactionAttempts[merge] = %d, want 1 (untouched)", state.ReactionAttempts[mergeKey])
+	}
+
+	// Sibling fingerprints untouched (merge-conflict only deletes its own
+	// kind on N1/escalation, and this tick dispatches, deleting none).
+	if !store.has(issueID, ReactionKindCI) {
+		t.Error("ci fingerprint deleted by merge-conflict dispatch; want untouched")
+	}
+	if !store.has(issueID, ReactionKindReview) {
+		t.Error("review fingerprint deleted by merge-conflict dispatch; want untouched")
+	}
+}
+
+// --- 5.1.9 Fetch error backs off (E1) ---
+
+func TestReconcileMergeConflicts_FetchErrorBacksOff(t *testing.T) {
+	t.Parallel()
+
+	state := stateWithMergeConflict(t, "MC-ERR", 10)
+	rkey := ReactionKey("MC-ERR", ReactionKindMergeConflict)
+	store := newStatefulFingerprintStore()
+	metrics := newMergeConflictMetricsSpy()
+	scm := &mergeabilitySCM{fn: func() (domain.PRMergeStatus, error) {
+		return domain.PRMergeStatus{}, errors.New("upstream timeout")
+	}}
+	params := mergeConflictParams(store, scm, nil)
+
+	reconcileMergeConflicts(state, params, discardLogger(), context.Background(), metrics)
+
+	entry, ok := state.PendingReactions[rkey]
+	if !ok {
+		t.Fatal("PendingReactions entry dropped on fetch error; want re-enqueued")
+	}
+	if entry.PendingAttempts != 1 {
+		t.Errorf("PendingAttempts = %d, want 1 after first error", entry.PendingAttempts)
+	}
+	// Backoff floored at the poll interval (60s).
+	minExpected := mcBaseTime.Add(60 * time.Second)
+	if entry.PendingRetryAt.Before(minExpected) {
+		t.Errorf("PendingRetryAt = %v, want >= %v (floored at poll interval)", entry.PendingRetryAt, minExpected)
+	}
+	if metrics.checks["error"] != 1 {
+		t.Errorf(`IncMergeConflictChecks("error") = %d, want 1`, metrics.checks["error"])
+	}
+	// A fetch error is not a resolution attempt: the per-episode counter must
+	// not increment, and nothing escalates.
+	if _, ok := state.ReactionAttempts[rkey]; ok {
+		t.Error("ReactionAttempts incremented on fetch error; want untouched")
+	}
+	if len(metrics.escalations) != 0 {
+		t.Errorf("escalations = %v, want none on fetch error", metrics.escalations)
+	}
+}
+
+// --- 5.1.10 Empty head SHA does not dispatch (D1a) ---
+
+func TestReconcileMergeConflicts_EmptyHeadDoesNotDispatch(t *testing.T) {
+	t.Parallel()
+
+	state := stateWithMergeConflict(t, "MC-NOHEAD", 10)
+	rkey := ReactionKey("MC-NOHEAD", ReactionKindMergeConflict)
+	store := newStatefulFingerprintStore()
+	metrics := newMergeConflictMetricsSpy()
+	scm := &mergeabilitySCM{fn: func() (domain.PRMergeStatus, error) {
+		return dirtyStatus("", "main"), nil // dirty but empty head
+	}}
+	params := mergeConflictParams(store, scm, nil)
+
+	reconcileMergeConflicts(state, params, discardLogger(), context.Background(), metrics)
+
+	entry, ok := state.PendingReactions[rkey]
+	if !ok {
+		t.Fatal("PendingReactions entry dropped on empty head SHA; want re-enqueued (deferred)")
+	}
+	wantRetryAt := mcBaseTime.Add(60 * time.Second)
+	if !entry.PendingRetryAt.Equal(wantRetryAt) {
+		t.Errorf("PendingRetryAt = %v, want %v (poll interval defer)", entry.PendingRetryAt, wantRetryAt)
+	}
+	if _, ok := state.ReactionAttempts[rkey]; ok {
+		t.Error("ReactionAttempts incremented on empty head SHA; want untouched (deferral burns no attempt)")
+	}
+	if _, ok := state.RetryAttempts["MC-NOHEAD"]; ok {
+		t.Error("retry scheduled on empty head SHA; want none (no dispatch)")
+	}
+	if store.upsertCalls != 0 {
+		t.Errorf("UpsertReactionFingerprint calls = %d, want 0 (guard precedes fingerprint)", store.upsertCalls)
+	}
+	if len(metrics.checks) != 0 {
+		t.Errorf("IncMergeConflictChecks called = %v, want none on empty-head defer", metrics.checks)
+	}
+}
+
+// --- 5.1.11 Empty base branch defers (AC16, D1b) ---
+
+func TestReconcileMergeConflicts_EmptyBaseDefers(t *testing.T) {
+	t.Parallel()
+
+	state := stateWithMergeConflict(t, "MC-NOBASE", 10)
+	rkey := ReactionKey("MC-NOBASE", ReactionKindMergeConflict)
+	store := newStatefulFingerprintStore()
+	metrics := newMergeConflictMetricsSpy()
+	scm := &mergeabilitySCM{fn: func() (domain.PRMergeStatus, error) {
+		return dirtyStatus("head-ok", ""), nil // dirty, head present, base empty
+	}}
+	params := mergeConflictParams(store, scm, nil)
+
+	reconcileMergeConflicts(state, params, discardLogger(), context.Background(), metrics)
+
+	entry, ok := state.PendingReactions[rkey]
+	if !ok {
+		t.Fatal("PendingReactions entry dropped on empty base branch; want re-enqueued (deferred)")
+	}
+	wantRetryAt := mcBaseTime.Add(60 * time.Second)
+	if !entry.PendingRetryAt.Equal(wantRetryAt) {
+		t.Errorf("PendingRetryAt = %v, want %v (poll interval defer)", entry.PendingRetryAt, wantRetryAt)
+	}
+	if _, ok := state.ReactionAttempts[rkey]; ok {
+		t.Error("ReactionAttempts incremented on empty base branch; want untouched (deferral burns no attempt)")
+	}
+	if _, ok := state.RetryAttempts["MC-NOBASE"]; ok {
+		t.Error("retry scheduled on empty base branch; want none (no dispatch)")
+	}
+	if len(metrics.escalations) != 0 {
+		t.Errorf("escalations = %v, want none on empty-base defer", metrics.escalations)
+	}
+	if len(metrics.checks) != 0 {
+		t.Errorf("IncMergeConflictChecks called = %v, want none on empty-base defer", metrics.checks)
+	}
+}
+
+// --- 5.1.12 Template map (AC6) ---
+
+func TestBuildMergeConflictTemplateMap(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		data     *MergeConflictReactionData
+		status   domain.PRMergeStatus
+		wantBase string
+	}{
+		{
+			name:     "develop base",
+			data:     &MergeConflictReactionData{PRNumber: 42, Branch: "feature/x"},
+			status:   domain.PRMergeStatus{HeadSHA: "abc123", BaseBranch: "develop"},
+			wantBase: "develop",
+		},
+		{
+			name:     "release base not hardcoded default",
+			data:     &MergeConflictReactionData{PRNumber: 7, Branch: "feature/y"},
+			status:   domain.PRMergeStatus{HeadSHA: "def456", BaseBranch: "release/2.0"},
+			wantBase: "release/2.0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := buildMergeConflictTemplateMap(tt.data, tt.status)
+
+			if got["pr_number"] != tt.data.PRNumber {
+				t.Errorf("buildMergeConflictTemplateMap()[pr_number] = %v, want %d", got["pr_number"], tt.data.PRNumber)
+			}
+			if got["branch"] != tt.data.Branch {
+				t.Errorf("buildMergeConflictTemplateMap()[branch] = %v, want %q", got["branch"], tt.data.Branch)
+			}
+			if got["head_sha"] != tt.status.HeadSHA {
+				t.Errorf("buildMergeConflictTemplateMap()[head_sha] = %v, want %q", got["head_sha"], tt.status.HeadSHA)
+			}
+			base, ok := got["base"]
+			if !ok {
+				t.Fatal("buildMergeConflictTemplateMap() missing base key; want present for missingkey=error")
+			}
+			if base != tt.wantBase {
+				t.Errorf("buildMergeConflictTemplateMap()[base] = %v, want %q (the real base, not a hardcoded default)", base, tt.wantBase)
+			}
+		})
+	}
+}
+
+// --- 5.1.13 Dispatch carries real base (AC6b orchestrator side) ---
+
+func TestReconcileMergeConflicts_DispatchCarriesRealBase(t *testing.T) {
+	t.Parallel()
+
+	state := stateWithMergeConflict(t, "MC-BASE", 10)
+	store := newStatefulFingerprintStore()
+	metrics := newMergeConflictMetricsSpy()
+	scm := &mergeabilitySCM{fn: func() (domain.PRMergeStatus, error) {
+		return dirtyStatus("head-rel", "release/2.0"), nil
+	}}
+	params := mergeConflictParams(store, scm, nil)
+
+	reconcileMergeConflicts(state, params, discardLogger(), context.Background(), metrics)
+
+	retry, ok := state.RetryAttempts["MC-BASE"]
+	if !ok {
+		t.Fatal("retry not scheduled; want dispatch carrying the real base")
+	}
+	raw, ok := retry.ContinuationContext["merge_conflict"]
+	if !ok {
+		t.Fatal(`ContinuationContext missing "merge_conflict" key`)
+	}
+	mergeContext, ok := raw.(map[string]any)
+	if !ok {
+		t.Fatalf("merge_conflict context type = %T, want map[string]any", raw)
+	}
+	if mergeContext["base"] != "release/2.0" {
+		t.Errorf("ContinuationContext[merge_conflict][base] = %v, want %q (equals status.BaseBranch, no hardcoded default)",
+			mergeContext["base"], "release/2.0")
+	}
+}
+
+// --- 5.1.14 Coexists with auto-merge on the same tick (AC3) ---
+
+func TestReconcileMergeConflicts_Coexists(t *testing.T) {
+	t.Parallel()
+
+	issueID := "MC-COEXIST"
+	state := NewState(5000, 4, nil, AgentTotals{})
+
+	// An auto-merge slot for the same PR, alongside the merge-conflict slot.
+	mergeKey := ReactionKey(issueID, ReactionKindAutoMerge)
+	state.PendingReactions[mergeKey] = newAutoMergePending(issueID, 5)
+
+	mcKey := ReactionKey(issueID, ReactionKindMergeConflict)
+	state.PendingReactions[mcKey] = newMergeConflictPending(issueID, 5)
+	state.Claimed[issueID] = struct{}{}
+
+	store := newStatefulFingerprintStore()
+	mcMetrics := newMergeConflictMetricsSpy()
+	amMetrics := newAutoMergeMetricsSpy()
+
+	// Dirty for both passes: auto-merge defers on dirty (no merge),
+	// merge-conflict dispatches.
+	scm := &controlledSCMAdapter{
+		getMergeabilityFn: func(_ context.Context, _ int, _, _ string) (domain.PRMergeStatus, error) {
+			return dirtyStatus("head-coexist", "main"), nil
+		},
+		mergePRFn: func(_ context.Context, _ int, _, _ string, _ domain.MergeStrategy, _, _, _ string) (domain.MergeResult, error) {
+			t.Error("MergePR called while PR is dirty; auto-merge must defer, not merge")
+			return domain.MergeResult{}, nil
+		},
+	}
+
+	params := mergeConflictParams(store, scm, nil)
+	params.AutoMergeConfig = defaultAutoMergeConfig()
+	params.AutoMergeReactionConfigured = true
+
+	// Run the merge-conflict pass then the auto-merge pass on the same tick,
+	// in the wired order.
+	reconcileMergeConflicts(state, params, discardLogger(), context.Background(), mcMetrics)
+	reconcileAutoMerge(state, params, discardLogger(), context.Background(), amMetrics)
+
+	// merge-conflict dispatched its continuation.
+	if mcMetrics.checks["dispatched"] != 1 {
+		t.Errorf(`IncMergeConflictChecks("dispatched") = %d, want 1`, mcMetrics.checks["dispatched"])
+	}
+	if _, ok := state.RetryAttempts[issueID]; !ok {
+		t.Error("merge-conflict continuation not scheduled on coexist tick; want scheduled")
+	}
+	// auto-merge deferred (its slot survives, no merge happened).
+	if _, ok := state.PendingReactions[mergeKey]; !ok {
+		t.Error("auto-merge slot consumed; want re-enqueued (deferred on dirty)")
+	}
+	if amMetrics.autoMerge["merged"] != 0 {
+		t.Errorf(`IncAutoMergeReactions("merged") = %d, want 0 (no double action on dirty PR)`, amMetrics.autoMerge["merged"])
+	}
+}
+
+// --- ReconcileRunningIssues wiring (AC5) ---
+
+// TestReconcileRunningIssues_MergeConflictOrdering verifies that
+// reconcileMergeConflicts is wired into ReconcileRunningIssues: a due
+// merge-conflict entry triggers exactly one GetMergeability call per tick,
+// and a not-yet-due entry triggers none.
+func TestReconcileRunningIssues_MergeConflictOrdering(t *testing.T) {
+	t.Parallel()
+
+	t.Run("DueEntryTriggersOneRead", func(t *testing.T) {
+		t.Parallel()
+
+		state := stateWithMergeConflict(t, "MC-WIRE", 10)
+		store := newStatefulFingerprintStore()
+		metrics := newMergeConflictMetricsSpy()
+		scm := &mergeabilitySCM{fn: func() (domain.PRMergeStatus, error) {
+			return dirtyStatus("head-wire", "main"), nil
+		}}
+		params := mergeConflictParams(store, scm, nil)
+		params.Metrics = metrics
+
+		ReconcileRunningIssues(state, params)
+
+		if scm.calls != 1 {
+			t.Errorf("GetMergeability calls = %d, want 1 (one read per tick via ReconcileRunningIssues)", scm.calls)
+		}
+		if metrics.checks["dispatched"] != 1 {
+			t.Errorf(`IncMergeConflictChecks("dispatched") = %d, want 1 (reconcileMergeConflicts wired in)`, metrics.checks["dispatched"])
+		}
+	})
+
+	t.Run("NotYetDueEntryTriggersNoRead", func(t *testing.T) {
+		t.Parallel()
+
+		state := stateWithMergeConflict(t, "MC-NOTDUE", 10)
+		rkey := ReactionKey("MC-NOTDUE", ReactionKindMergeConflict)
+		state.PendingReactions[rkey].PendingRetryAt = mcBaseTime.Add(5 * time.Minute)
+		store := newStatefulFingerprintStore()
+		metrics := newMergeConflictMetricsSpy()
+		scm := &mergeabilitySCM{fn: func() (domain.PRMergeStatus, error) {
+			return dirtyStatus("head-notdue", "main"), nil
+		}}
+		params := mergeConflictParams(store, scm, nil)
+		params.Metrics = metrics
+
+		ReconcileRunningIssues(state, params)
+
+		if scm.calls != 0 {
+			t.Errorf("GetMergeability calls = %d, want 0 (entry not yet due)", scm.calls)
+		}
+		if _, ok := state.PendingReactions[rkey]; !ok {
+			t.Error("PendingReactions entry dropped while not due; want re-enqueued")
+		}
+	})
+}

--- a/internal/orchestrator/metrics_test.go
+++ b/internal/orchestrator/metrics_test.go
@@ -205,6 +205,10 @@ func (s *spyMetrics) IncBotReviewEscalations(_ string) {}
 
 func (s *spyMetrics) IncAutoMergeReactions(_ string) {}
 
+func (s *spyMetrics) IncMergeConflictChecks(_ string) {}
+
+func (s *spyMetrics) IncMergeConflictEscalations(_ string) {}
+
 func (s *spyMetrics) IncDispatchRuleMatch(_ string, _ string) {}
 
 // --- Tests ---

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -131,6 +131,16 @@ type OrchestratorParams struct {
 	// HandleWorkerExitParams, and the recovery params.
 	BotReviewConfigured bool
 
+	// MergeConflictConfig holds validated merge-conflict reaction
+	// configuration. Zero value when MergeConflictReactionConfigured is
+	// false.
+	MergeConflictConfig MergeConflictReactionConfig
+
+	// MergeConflictReactionConfigured marks whether the merge-conflict
+	// feature is active for this process. Threaded into ReconcileParams,
+	// HandleWorkerExitParams, and the recovery params.
+	MergeConflictReactionConfigured bool
+
 	// AgentAdapterByKind resolves the agent adapter for the given
 	// kind. Constructed once at startup from the eagerly-built
 	// per-kind adapter cache. When nil, the orchestrator falls back
@@ -164,23 +174,25 @@ type Orchestrator struct {
 	snapshotCh   chan snapshotRequest
 	refreshCh    chan struct{}
 
-	preflightParams             PreflightParams
-	observers                   []Observer
-	drainTimeout                time.Duration
-	toolRegistry                *domain.ToolRegistry
-	sessionToolRegistryFunc     SessionToolRegistryFunc
-	preflightOK                 atomic.Bool
-	draining                    atomic.Bool
-	hostPool                    *HostPool
-	workflowFileFunc            func() string
-	dbPath                      string
-	ciProvider                  domain.CIStatusProvider
-	scmAdapter                  domain.SCMAdapter
-	reviewConfig                ReviewReactionConfig
-	autoMergeConfig             AutoMergeReactionConfig
-	autoMergeReactionConfigured bool
-	botReviewConfig             BotReviewReactionConfig
-	botReviewReactionConfigured bool
+	preflightParams                 PreflightParams
+	observers                       []Observer
+	drainTimeout                    time.Duration
+	toolRegistry                    *domain.ToolRegistry
+	sessionToolRegistryFunc         SessionToolRegistryFunc
+	preflightOK                     atomic.Bool
+	draining                        atomic.Bool
+	hostPool                        *HostPool
+	workflowFileFunc                func() string
+	dbPath                          string
+	ciProvider                      domain.CIStatusProvider
+	scmAdapter                      domain.SCMAdapter
+	reviewConfig                    ReviewReactionConfig
+	autoMergeConfig                 AutoMergeReactionConfig
+	autoMergeReactionConfigured     bool
+	botReviewConfig                 BotReviewReactionConfig
+	botReviewReactionConfigured     bool
+	mergeConflictConfig             MergeConflictReactionConfig
+	mergeConflictReactionConfigured bool
 
 	// sshStrictHostKeyChecking is the current effective OpenSSH
 	// StrictHostKeyChecking value. Written by handleTick on every
@@ -258,35 +270,37 @@ func NewOrchestrator(params OrchestratorParams) *Orchestrator {
 	}
 
 	o := &Orchestrator{
-		state:                       params.State,
-		logger:                      logger,
-		trackerAdapter:              params.TrackerAdapter,
-		agentAdapter:                params.AgentAdapter,
-		agentAdapterByKind:          agentAdapterByKind,
-		workflowManager:             params.WorkflowManager,
-		store:                       params.Store,
-		metrics:                     metrics,
-		workerExitCh:                make(chan WorkerResult, exitBuf),
-		retryTimerCh:                make(chan string, retryBuf),
-		agentEventCh:                make(chan agentEventMsg, eventBuf),
-		selfReviewCh:                make(chan selfReviewProgressMsg, eventBuf),
-		snapshotCh:                  make(chan snapshotRequest, 4),
-		refreshCh:                   make(chan struct{}, 1),
-		preflightParams:             params.PreflightParams,
-		observers:                   observers,
-		drainTimeout:                defaultDrainTimeout,
-		toolRegistry:                params.ToolRegistry,
-		sessionToolRegistryFunc:     params.SessionToolRegistryFunc,
-		hostPool:                    hostPool,
-		workflowFileFunc:            params.WorkflowFileFunc,
-		dbPath:                      params.DBPath,
-		ciProvider:                  params.CIProvider,
-		scmAdapter:                  params.SCMAdapter,
-		reviewConfig:                params.ReviewConfig,
-		autoMergeConfig:             params.AutoMergeConfig,
-		autoMergeReactionConfigured: params.AutoMergeReactionConfigured,
-		botReviewConfig:             params.BotReviewConfig,
-		botReviewReactionConfigured: params.BotReviewConfigured,
+		state:                           params.State,
+		logger:                          logger,
+		trackerAdapter:                  params.TrackerAdapter,
+		agentAdapter:                    params.AgentAdapter,
+		agentAdapterByKind:              agentAdapterByKind,
+		workflowManager:                 params.WorkflowManager,
+		store:                           params.Store,
+		metrics:                         metrics,
+		workerExitCh:                    make(chan WorkerResult, exitBuf),
+		retryTimerCh:                    make(chan string, retryBuf),
+		agentEventCh:                    make(chan agentEventMsg, eventBuf),
+		selfReviewCh:                    make(chan selfReviewProgressMsg, eventBuf),
+		snapshotCh:                      make(chan snapshotRequest, 4),
+		refreshCh:                       make(chan struct{}, 1),
+		preflightParams:                 params.PreflightParams,
+		observers:                       observers,
+		drainTimeout:                    defaultDrainTimeout,
+		toolRegistry:                    params.ToolRegistry,
+		sessionToolRegistryFunc:         params.SessionToolRegistryFunc,
+		hostPool:                        hostPool,
+		workflowFileFunc:                params.WorkflowFileFunc,
+		dbPath:                          params.DBPath,
+		ciProvider:                      params.CIProvider,
+		scmAdapter:                      params.SCMAdapter,
+		reviewConfig:                    params.ReviewConfig,
+		autoMergeConfig:                 params.AutoMergeConfig,
+		autoMergeReactionConfigured:     params.AutoMergeReactionConfigured,
+		botReviewConfig:                 params.BotReviewConfig,
+		botReviewReactionConfigured:     params.BotReviewConfigured,
+		mergeConflictConfig:             params.MergeConflictConfig,
+		mergeConflictReactionConfigured: params.MergeConflictReactionConfigured,
 	}
 	// Startup preflight must have passed for the orchestrator to be
 	// constructed, so the initial value is true.
@@ -325,23 +339,24 @@ func (o *Orchestrator) Run(ctx context.Context) {
 		case workerExit := <-o.workerExitCh:
 			cfg := o.workflowManager.Config()
 			HandleWorkerExit(o.state, workerExit, HandleWorkerExitParams{
-				Store:                       o.store,
-				MaxRetryBackoffMS:           cfg.Agent.MaxRetryBackoffMS,
-				OnRetryFire:                 o.onRetryFire,
-				Ctx:                         ctx,
-				Logger:                      o.logger,
-				BeforeRemoveHook:            cfg.Hooks.BeforeRemove,
-				HookTimeoutMS:               cfg.Hooks.TimeoutMS,
-				TrackerAdapter:              o.trackerAdapter,
-				HandoffState:                cfg.Tracker.HandoffState,
-				ActiveStates:                cfg.Tracker.ActiveStates,
-				Metrics:                     o.metrics,
-				HostPool:                    o.hostPool,
-				CommentsConfig:              cfg.Tracker.Comments,
-				CIProvider:                  o.ciProvider,
-				SCMAdapter:                  o.scmAdapter,
-				AutoMergeReactionConfigured: o.autoMergeReactionConfigured,
-				BotReviewReactionConfigured: o.botReviewReactionConfigured,
+				Store:                           o.store,
+				MaxRetryBackoffMS:               cfg.Agent.MaxRetryBackoffMS,
+				OnRetryFire:                     o.onRetryFire,
+				Ctx:                             ctx,
+				Logger:                          o.logger,
+				BeforeRemoveHook:                cfg.Hooks.BeforeRemove,
+				HookTimeoutMS:                   cfg.Hooks.TimeoutMS,
+				TrackerAdapter:                  o.trackerAdapter,
+				HandoffState:                    cfg.Tracker.HandoffState,
+				ActiveStates:                    cfg.Tracker.ActiveStates,
+				Metrics:                         o.metrics,
+				HostPool:                        o.hostPool,
+				CommentsConfig:                  cfg.Tracker.Comments,
+				CIProvider:                      o.ciProvider,
+				SCMAdapter:                      o.scmAdapter,
+				AutoMergeReactionConfigured:     o.autoMergeReactionConfigured,
+				BotReviewReactionConfigured:     o.botReviewReactionConfigured,
+				MergeConflictReactionConfigured: o.mergeConflictReactionConfigured,
 			})
 			o.updateGauges(time.Now())
 			o.notifyObservers()
@@ -461,29 +476,32 @@ func (o *Orchestrator) handleTick(ctx context.Context) {
 	// Reconcile running issues unconditionally so in-flight workers
 	// are monitored even when dispatch is skipped.
 	ReconcileRunningIssues(o.state, ReconcileParams{
-		TrackerAdapter:              o.trackerAdapter,
-		ActiveStates:                cfg.Tracker.ActiveStates,
-		TerminalStates:              cfg.Tracker.TerminalStates,
-		HandoffState:                cfg.Tracker.HandoffState,
-		StallTimeoutMS:              cfg.Agent.StallTimeoutMS,
-		MaxRetryBackoffMS:           cfg.Agent.MaxRetryBackoffMS,
-		Store:                       o.store,
-		OnRetryFire:                 o.onRetryFire,
-		Ctx:                         ctx,
-		Logger:                      o.logger,
-		Metrics:                     o.metrics,
-		CIProvider:                  o.ciProvider,
-		CIFeedback:                  cfg.CIFeedback,
-		CIPendingTTL:                ciPendingDefaultTTL,
-		SCMAdapter:                  o.scmAdapter,
-		ReviewConfig:                o.reviewConfig,
-		ReviewPendingTTL:            reviewPendingDefaultTTL,
-		AutoMergeConfig:             o.autoMergeConfig,
-		AutoMergePendingTTL:         autoMergePendingDefaultTTL,
-		AutoMergeReactionConfigured: o.autoMergeReactionConfigured,
-		BotReviewConfig:             o.botReviewConfig,
-		BotReviewPendingTTL:         reviewPendingDefaultTTL,
-		BotReviewConfigured:         o.botReviewReactionConfigured,
+		TrackerAdapter:                  o.trackerAdapter,
+		ActiveStates:                    cfg.Tracker.ActiveStates,
+		TerminalStates:                  cfg.Tracker.TerminalStates,
+		HandoffState:                    cfg.Tracker.HandoffState,
+		StallTimeoutMS:                  cfg.Agent.StallTimeoutMS,
+		MaxRetryBackoffMS:               cfg.Agent.MaxRetryBackoffMS,
+		Store:                           o.store,
+		OnRetryFire:                     o.onRetryFire,
+		Ctx:                             ctx,
+		Logger:                          o.logger,
+		Metrics:                         o.metrics,
+		CIProvider:                      o.ciProvider,
+		CIFeedback:                      cfg.CIFeedback,
+		CIPendingTTL:                    ciPendingDefaultTTL,
+		SCMAdapter:                      o.scmAdapter,
+		ReviewConfig:                    o.reviewConfig,
+		ReviewPendingTTL:                reviewPendingDefaultTTL,
+		AutoMergeConfig:                 o.autoMergeConfig,
+		AutoMergePendingTTL:             autoMergePendingDefaultTTL,
+		AutoMergeReactionConfigured:     o.autoMergeReactionConfigured,
+		BotReviewConfig:                 o.botReviewConfig,
+		BotReviewPendingTTL:             reviewPendingDefaultTTL,
+		BotReviewConfigured:             o.botReviewReactionConfigured,
+		MergeConflictConfig:             o.mergeConflictConfig,
+		MergeConflictPendingTTL:         mergeConflictPendingDefaultTTL,
+		MergeConflictReactionConfigured: o.mergeConflictReactionConfigured,
 	})
 
 	// Sweep terminal workspaces periodically to catch issues that
@@ -879,23 +897,24 @@ func (o *Orchestrator) drainRunningWorkers() {
 		case workerExit := <-o.workerExitCh:
 			cfg := o.workflowManager.Config()
 			HandleWorkerExit(o.state, workerExit, HandleWorkerExitParams{
-				Store:                       o.store,
-				MaxRetryBackoffMS:           cfg.Agent.MaxRetryBackoffMS,
-				OnRetryFire:                 func(string) {}, // no-op: prevent retry fire events from reaching the event loop during drain
-				Ctx:                         drainCtx,
-				Logger:                      o.logger,
-				BeforeRemoveHook:            cfg.Hooks.BeforeRemove,
-				HookTimeoutMS:               cfg.Hooks.TimeoutMS,
-				TrackerAdapter:              o.trackerAdapter,
-				HandoffState:                cfg.Tracker.HandoffState,
-				ActiveStates:                cfg.Tracker.ActiveStates,
-				Metrics:                     o.metrics,
-				HostPool:                    o.hostPool,
-				CommentsConfig:              cfg.Tracker.Comments,
-				CIProvider:                  o.ciProvider,
-				SCMAdapter:                  o.scmAdapter,
-				AutoMergeReactionConfigured: o.autoMergeReactionConfigured,
-				BotReviewReactionConfigured: o.botReviewReactionConfigured,
+				Store:                           o.store,
+				MaxRetryBackoffMS:               cfg.Agent.MaxRetryBackoffMS,
+				OnRetryFire:                     func(string) {}, // no-op: prevent retry fire events from reaching the event loop during drain
+				Ctx:                             drainCtx,
+				Logger:                          o.logger,
+				BeforeRemoveHook:                cfg.Hooks.BeforeRemove,
+				HookTimeoutMS:                   cfg.Hooks.TimeoutMS,
+				TrackerAdapter:                  o.trackerAdapter,
+				HandoffState:                    cfg.Tracker.HandoffState,
+				ActiveStates:                    cfg.Tracker.ActiveStates,
+				Metrics:                         o.metrics,
+				HostPool:                        o.hostPool,
+				CommentsConfig:                  cfg.Tracker.Comments,
+				CIProvider:                      o.ciProvider,
+				SCMAdapter:                      o.scmAdapter,
+				AutoMergeReactionConfigured:     o.autoMergeReactionConfigured,
+				BotReviewReactionConfigured:     o.botReviewReactionConfigured,
+				MergeConflictReactionConfigured: o.mergeConflictReactionConfigured,
 			})
 			o.updateGauges(time.Now())
 			o.notifyObservers()

--- a/internal/orchestrator/reconcile.go
+++ b/internal/orchestrator/reconcile.go
@@ -132,6 +132,20 @@ type ReconcileParams struct {
 	// independently of SCMAdapter presence, since a single SCM adapter
 	// may be shared with the review and auto-merge kinds.
 	BotReviewConfigured bool
+
+	// MergeConflictConfig holds merge-conflict reaction configuration.
+	// Only read when MergeConflictReactionConfigured is true.
+	MergeConflictConfig MergeConflictReactionConfig
+
+	// MergeConflictPendingTTL is the maximum age of a merge-conflict
+	// PendingReaction entry before it is dropped. Zero disables TTL
+	// enforcement.
+	MergeConflictPendingTTL time.Duration
+
+	// MergeConflictReactionConfigured marks whether the merge-conflict
+	// feature is active for the current process. Reconcile, enqueue, and
+	// recovery paths gate on this flag.
+	MergeConflictReactionConfigured bool
 }
 
 // ReconcileRunningIssues detects stalled workers and refreshes tracker
@@ -184,6 +198,12 @@ func ReconcileRunningIssues(state *State, params ReconcileParams) {
 	// bot-review reactions. Runs after the human review pass and before
 	// auto-merge.
 	reconcileBotReviewComments(state, params, log, ctx, metrics)
+
+	// Detect merge conflicts on managed open PRs. Runs before auto-merge
+	// so a freshly observed conflict is acted on (a rebase continuation
+	// scheduled) before auto-merge re-confirms its existing dirty
+	// deferral on the same tick.
+	reconcileMergeConflicts(state, params, log, ctx, metrics)
 
 	// Poll auto-merge preconditions for issues with pending merge
 	// reactions. Runs LAST so the CI and review reconcile passes have

--- a/internal/orchestrator/recovery.go
+++ b/internal/orchestrator/recovery.go
@@ -84,32 +84,34 @@ type ReactionRecoveryRunStore interface {
 
 // PendingReactionRecoveryParams holds all inputs for [RecoverPendingReactions].
 type PendingReactionRecoveryParams struct {
-	WorkspaceRoot               string
-	TrackerAdapter              domain.TrackerAdapter
-	HandoffState                string
-	TerminalStates              []string
-	CIProvider                  domain.CIStatusProvider
-	SCMAdapter                  domain.SCMAdapter
-	AutoMergeReactionConfigured bool
-	BotReviewReactionConfigured bool
-	RecoveryLookback            time.Duration
-	MaxCandidates               int
-	NowFunc                     func() time.Time
-	Logger                      *slog.Logger
+	WorkspaceRoot                   string
+	TrackerAdapter                  domain.TrackerAdapter
+	HandoffState                    string
+	TerminalStates                  []string
+	CIProvider                      domain.CIStatusProvider
+	SCMAdapter                      domain.SCMAdapter
+	AutoMergeReactionConfigured     bool
+	BotReviewReactionConfigured     bool
+	MergeConflictReactionConfigured bool
+	RecoveryLookback                time.Duration
+	MaxCandidates                   int
+	NowFunc                         func() time.Time
+	Logger                          *slog.Logger
 }
 
 // PendingReactionRecoveryResult reports outcome counts from a single
 // [RecoverPendingReactions] call.
 type PendingReactionRecoveryResult struct {
-	Candidates         int
-	CapSkipped         int
-	StateChecked       int
-	ReviewRecovered    int
-	CIRecovered        int
-	AutoMergeRecovered int
-	BotReviewRecovered int
-	StaleSkipped       int
-	Skipped            int
+	Candidates             int
+	CapSkipped             int
+	StateChecked           int
+	ReviewRecovered        int
+	CIRecovered            int
+	AutoMergeRecovered     int
+	BotReviewRecovered     int
+	MergeConflictRecovered int
+	StaleSkipped           int
+	Skipped                int
 }
 
 // RecoverPendingReactions reconstructs runtime pending reaction entries from
@@ -383,6 +385,32 @@ func recoverPendingReactionKinds(
 				TemplateID: run.TemplateID,
 			}
 			outcome.AutoMergeRecovered++
+			added++
+		}
+	}
+
+	if params.SCMAdapter != nil && params.MergeConflictReactionConfigured && meta.PRNumber > 0 && meta.Owner != "" && meta.Repo != "" && meta.Branch != "" {
+		key := ReactionKey(run.IssueID, ReactionKindMergeConflict)
+		if _, exists := state.PendingReactions[key]; !exists {
+			state.PendingReactions[key] = &PendingReaction{
+				IssueID:    run.IssueID,
+				Identifier: run.Identifier,
+				DisplayID:  run.DisplayID,
+				Attempt:    run.Attempt,
+				Kind:       ReactionKindMergeConflict,
+				CreatedAt:  now,
+				KindData: &MergeConflictReactionData{
+					PRNumber: meta.PRNumber,
+					Owner:    meta.Owner,
+					Repo:     meta.Repo,
+					Branch:   meta.Branch,
+					SHA:      meta.SHA,
+				},
+				AgentKind:  run.AgentAdapter,
+				RuleName:   run.RuleName,
+				TemplateID: run.TemplateID,
+			}
+			outcome.MergeConflictRecovered++
 			added++
 		}
 	}

--- a/internal/orchestrator/recovery_test.go
+++ b/internal/orchestrator/recovery_test.go
@@ -1581,3 +1581,104 @@ func TestRecoverPendingReactions_BotReviewMissingBranch(t *testing.T) {
 		t.Error("bot-review PendingReactions entry created with empty Branch; want absent")
 	}
 }
+
+// --- merge-conflict recovery tests ---
+
+func TestRecoverPendingReactions_MergeConflict(t *testing.T) {
+	t.Parallel()
+
+	wsRoot := t.TempDir()
+	writeRecoverySCM(t, wsRoot, "PROJ-MC1", domain.SCMMetadata{
+		Branch:   "feature/mc-fix",
+		SHA:      "facefeed",
+		PushedAt: freshSCMTime(1),
+		PRNumber: 55,
+		Owner:    "mcowner",
+		Repo:     "mcrepo",
+	})
+
+	tracker := &recoveryTrackerStub{states: map[string]string{"ISS-MC1": "In Review"}}
+	state := NewState(5000, 4, nil, AgentTotals{})
+	run := freshRun("ISS-MC1", "PROJ-MC1", "mcowner/mcrepo#55", 3)
+	params := defaultRecoveryParams(wsRoot, tracker)
+	params.MergeConflictReactionConfigured = true
+
+	result, err := RecoverPendingReactions(context.Background(), state, []persistence.RunHistory{run}, params)
+	if err != nil {
+		t.Fatalf("RecoverPendingReactions: %v", err)
+	}
+	if result.MergeConflictRecovered != 1 {
+		t.Errorf("MergeConflictRecovered = %d, want 1", result.MergeConflictRecovered)
+	}
+
+	rkey := ReactionKey("ISS-MC1", ReactionKindMergeConflict)
+	pr, ok := state.PendingReactions[rkey]
+	if !ok {
+		t.Fatalf("PendingReactions[%q] missing, want present", rkey)
+	}
+	if pr.Kind != ReactionKindMergeConflict {
+		t.Errorf("PendingReaction.Kind = %q, want %q", pr.Kind, ReactionKindMergeConflict)
+	}
+	if pr.Attempt != 3 {
+		t.Errorf("PendingReaction.Attempt = %d, want 3", pr.Attempt)
+	}
+	mcd, ok := pr.KindData.(*MergeConflictReactionData)
+	if !ok {
+		t.Fatalf("KindData type = %T, want *MergeConflictReactionData", pr.KindData)
+	}
+	if mcd.PRNumber != 55 {
+		t.Errorf("MergeConflictReactionData.PRNumber = %d, want 55", mcd.PRNumber)
+	}
+	if mcd.Owner != "mcowner" {
+		t.Errorf("MergeConflictReactionData.Owner = %q, want %q", mcd.Owner, "mcowner")
+	}
+	if mcd.Repo != "mcrepo" {
+		t.Errorf("MergeConflictReactionData.Repo = %q, want %q", mcd.Repo, "mcrepo")
+	}
+	if mcd.Branch != "feature/mc-fix" {
+		t.Errorf("MergeConflictReactionData.Branch = %q, want %q", mcd.Branch, "feature/mc-fix")
+	}
+	if mcd.SHA != "facefeed" {
+		t.Errorf("MergeConflictReactionData.SHA = %q, want %q", mcd.SHA, "facefeed")
+	}
+	// Issue must not be claimed by recovery.
+	if _, claimed := state.Claimed["ISS-MC1"]; claimed {
+		t.Error("ISS-MC1 found in state.Claimed after recovery, want not claimed")
+	}
+}
+
+// TestRecoverPendingReactions_MergeConflictNotRecoveredWhenFlagFalse verifies
+// that MergeConflictReactionConfigured=false reconstructs no merge-conflict
+// entry, even with full PR metadata present.
+func TestRecoverPendingReactions_MergeConflictNotRecoveredWhenFlagFalse(t *testing.T) {
+	t.Parallel()
+
+	wsRoot := t.TempDir()
+	writeRecoverySCM(t, wsRoot, "PROJ-MC2", domain.SCMMetadata{
+		Branch:   "feature/mc-disabled",
+		SHA:      "abc",
+		PushedAt: freshSCMTime(1),
+		PRNumber: 10,
+		Owner:    "o",
+		Repo:     "r",
+	})
+
+	tracker := &recoveryTrackerStub{states: map[string]string{"ISS-MC2": "In Review"}}
+	state := NewState(5000, 4, nil, AgentTotals{})
+	run := freshRun("ISS-MC2", "PROJ-MC2", "", 1)
+	params := defaultRecoveryParams(wsRoot, tracker)
+	params.MergeConflictReactionConfigured = false // not configured
+
+	result, err := RecoverPendingReactions(context.Background(), state, []persistence.RunHistory{run}, params)
+	if err != nil {
+		t.Fatalf("RecoverPendingReactions: %v", err)
+	}
+	if result.MergeConflictRecovered != 0 {
+		t.Errorf("MergeConflictRecovered = %d, want 0 when flag is false", result.MergeConflictRecovered)
+	}
+
+	rkey := ReactionKey("ISS-MC2", ReactionKindMergeConflict)
+	if _, ok := state.PendingReactions[rkey]; ok {
+		t.Error("merge-conflict PendingReactions entry created with MergeConflictReactionConfigured=false; want absent")
+	}
+}

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -330,6 +330,12 @@ const ReactionKindBotReview = "bot-review"
 // short form lives here as the runtime and persisted discriminator.
 const ReactionKindAutoMerge = "merge"
 
+// ReactionKindMergeConflict is the reaction kind constant for
+// merge-conflict reactions. The user-facing YAML key is
+// reactions.merge_conflicts; the short form lives here as the runtime
+// and persisted discriminator.
+const ReactionKindMergeConflict = "merge-conflict"
+
 // AutoMergePreflightRetryDelay is the delay between the initial
 // auto-merge preflight failure (transport-class) and its single
 // scheduled retry. The retry runs at most once per orchestrator
@@ -338,7 +344,7 @@ const AutoMergePreflightRetryDelay time.Duration = 5 * time.Minute
 
 func isKnownReactionKind(kind string) bool {
 	switch kind {
-	case ReactionKindCI, ReactionKindReview, ReactionKindBotReview, ReactionKindAutoMerge:
+	case ReactionKindCI, ReactionKindReview, ReactionKindBotReview, ReactionKindAutoMerge, ReactionKindMergeConflict:
 		return true
 	default:
 		return false
@@ -527,6 +533,44 @@ type AutoMergeReactionConfig struct {
 	PollIntervalMS  int
 	Escalation      string
 	EscalationLabel string
+	MaxRetries      int
+}
+
+// MergeConflictReactionData holds merge-conflict-specific fields for a
+// pending merge-conflict reaction. Stored in [PendingReaction.KindData]
+// for reactions with Kind == [ReactionKindMergeConflict]. PRNumber,
+// Owner, Repo, and Branch are sourced from [domain.SCMMetadata] (written
+// by the agent to scm.json), never from the tracker project
+// configuration.
+//
+// The rebase base branch is not stored here. It is read live from
+// [domain.PRMergeStatus.BaseBranch] on each reconcile tick and threaded
+// into the continuation data, so the agent always rebases onto the PR's
+// current target rather than a value snapshotted at enqueue time.
+type MergeConflictReactionData struct {
+	// PRNumber is the pull request number.
+	PRNumber int
+
+	// Owner is the repository owner.
+	Owner string
+
+	// Repo is the repository name.
+	Repo string
+
+	// Branch is the PR head branch (the branch the agent rebases).
+	Branch string
+
+	// SHA is the git commit SHA at the last known push; carried for
+	// logging and parity with the sibling reaction data.
+	SHA string
+}
+
+// MergeConflictReactionConfig holds validated merge-conflict-specific
+// configuration extracted from [config.ReactionConfig] at startup.
+type MergeConflictReactionConfig struct {
+	Escalation      string
+	EscalationLabel string
+	PollIntervalMS  int
 	MaxRetries      int
 }
 
@@ -1119,6 +1163,46 @@ func BuildAutoMergeReactionConfig(rc config.ReactionConfig) (AutoMergeReactionCo
 		}
 		if n < 30000 {
 			return AutoMergeReactionConfig{}, fmt.Errorf("poll_interval_ms must be >= 30000, got %d", n)
+		}
+		cfg.PollIntervalMS = n
+	}
+
+	return cfg, nil
+}
+
+// BuildMergeConflictReactionConfig extracts and validates
+// merge-conflict-specific configuration from a [config.ReactionConfig].
+// Returns an error for invalid values.
+//
+// rc.MaxRetries is consumed verbatim; the per-kind default of 1 for
+// merge_conflicts is applied earlier in config parsing, so this builder
+// reads the already-coerced, non-negative value without re-applying it.
+func BuildMergeConflictReactionConfig(rc config.ReactionConfig) (MergeConflictReactionConfig, error) {
+	cfg := MergeConflictReactionConfig{
+		Escalation:      rc.Escalation,
+		EscalationLabel: rc.EscalationLabel,
+		PollIntervalMS:  60000,
+		MaxRetries:      rc.MaxRetries,
+	}
+
+	if cfg.Escalation == "" {
+		cfg.Escalation = "label"
+	}
+	if cfg.Escalation != "label" && cfg.Escalation != "comment" {
+		return MergeConflictReactionConfig{}, fmt.Errorf("invalid escalation %q: must be \"label\" or \"comment\"", cfg.Escalation)
+	}
+
+	if cfg.EscalationLabel == "" {
+		cfg.EscalationLabel = "needs-human"
+	}
+
+	if v, ok := rc.Extra["poll_interval_ms"]; ok {
+		n, err := toInt(v)
+		if err != nil {
+			return MergeConflictReactionConfig{}, fmt.Errorf("invalid poll_interval_ms: %w", err)
+		}
+		if n < 30000 {
+			return MergeConflictReactionConfig{}, fmt.Errorf("poll_interval_ms must be >= 30000, got %d", n)
 		}
 		cfg.PollIntervalMS = n
 	}

--- a/internal/orchestrator/state_test.go
+++ b/internal/orchestrator/state_test.go
@@ -1192,3 +1192,164 @@ func TestRuntimeSnapshot_SelfReviewFields(t *testing.T) {
 		})
 	}
 }
+
+// --- isKnownReactionKind merge-conflict case ---
+
+func TestIsKnownReactionKind_AcceptsMergeConflict(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		kind string
+		want bool
+	}{
+		{ReactionKindMergeConflict, true},
+		{"merge-conflict", true},
+		{ReactionKindBotReview, true},
+		{ReactionKindAutoMerge, true},
+		{"merge_conflicts", false}, // the YAML key, not the runtime discriminator
+		{"merge_conflict", false},  // the template variable, not the discriminator
+		{"unknown", false},
+		{"", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.kind, func(t *testing.T) {
+			t.Parallel()
+			if got := isKnownReactionKind(tt.kind); got != tt.want {
+				t.Errorf("isKnownReactionKind(%q) = %v, want %v", tt.kind, got, tt.want)
+			}
+		})
+	}
+}
+
+// --- BuildMergeConflictReactionConfig tests ---
+
+func TestBuildMergeConflictReactionConfig(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		rc      config.ReactionConfig
+		want    MergeConflictReactionConfig
+		wantErr bool
+	}{
+		{
+			name: "all defaults",
+			rc:   config.ReactionConfig{MaxRetries: 1},
+			want: MergeConflictReactionConfig{
+				Escalation:      "label",
+				EscalationLabel: "needs-human",
+				PollIntervalMS:  60000,
+				MaxRetries:      1,
+			},
+		},
+		{
+			name: "max_retries consumed verbatim from rc",
+			rc:   config.ReactionConfig{MaxRetries: 3},
+			want: MergeConflictReactionConfig{
+				Escalation:      "label",
+				EscalationLabel: "needs-human",
+				PollIntervalMS:  60000,
+				MaxRetries:      3,
+			},
+		},
+		{
+			name: "max_retries zero is consumed verbatim (no default re-application)",
+			rc:   config.ReactionConfig{MaxRetries: 0},
+			want: MergeConflictReactionConfig{
+				Escalation:      "label",
+				EscalationLabel: "needs-human",
+				PollIntervalMS:  60000,
+				MaxRetries:      0,
+			},
+		},
+		{
+			name: "explicit comment escalation",
+			rc:   config.ReactionConfig{Escalation: "comment", MaxRetries: 1},
+			want: MergeConflictReactionConfig{
+				Escalation:      "comment",
+				EscalationLabel: "needs-human",
+				PollIntervalMS:  60000,
+				MaxRetries:      1,
+			},
+		},
+		{
+			name: "custom escalation label",
+			rc:   config.ReactionConfig{Escalation: "label", EscalationLabel: "conflict-stuck", MaxRetries: 1},
+			want: MergeConflictReactionConfig{
+				Escalation:      "label",
+				EscalationLabel: "conflict-stuck",
+				PollIntervalMS:  60000,
+				MaxRetries:      1,
+			},
+		},
+		{
+			name: "poll_interval_ms override above floor",
+			rc:   config.ReactionConfig{MaxRetries: 1, Extra: map[string]any{"poll_interval_ms": 120000}},
+			want: MergeConflictReactionConfig{
+				Escalation:      "label",
+				EscalationLabel: "needs-human",
+				PollIntervalMS:  120000,
+				MaxRetries:      1,
+			},
+		},
+		{
+			name: "poll_interval_ms exactly at floor is valid",
+			rc:   config.ReactionConfig{MaxRetries: 1, Extra: map[string]any{"poll_interval_ms": 30000}},
+			want: MergeConflictReactionConfig{
+				Escalation:      "label",
+				EscalationLabel: "needs-human",
+				PollIntervalMS:  30000,
+				MaxRetries:      1,
+			},
+		},
+		{
+			name:    "poll_interval_ms below floor errors",
+			rc:      config.ReactionConfig{Extra: map[string]any{"poll_interval_ms": 29999}},
+			wantErr: true,
+		},
+		{
+			name:    "invalid escalation value errors",
+			rc:      config.ReactionConfig{Escalation: "webhook"},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := BuildMergeConflictReactionConfig(tt.rc)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("BuildMergeConflictReactionConfig(%+v) = %+v, want error", tt.rc, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("BuildMergeConflictReactionConfig(%+v) unexpected error: %v", tt.rc, err)
+			}
+			if got != tt.want {
+				t.Errorf("BuildMergeConflictReactionConfig(%+v) = %+v, want %+v", tt.rc, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestBuildMergeConflictReactionConfig_EmptyEscalationDefaultsToLabel verifies
+// that an empty escalation defaults to "label" (the direct-call safety net,
+// independent of the config-layer default).
+func TestBuildMergeConflictReactionConfig_EmptyEscalationDefaultsToLabel(t *testing.T) {
+	t.Parallel()
+
+	got, err := BuildMergeConflictReactionConfig(config.ReactionConfig{MaxRetries: 1})
+	if err != nil {
+		t.Fatalf("BuildMergeConflictReactionConfig: %v", err)
+	}
+	if got.Escalation != "label" {
+		t.Errorf("Escalation = %q, want %q (empty defaults to label)", got.Escalation, "label")
+	}
+	if got.EscalationLabel != "needs-human" {
+		t.Errorf("EscalationLabel = %q, want %q (empty defaults to needs-human)", got.EscalationLabel, "needs-human")
+	}
+}

--- a/internal/prompt/prompt.go
+++ b/internal/prompt/prompt.go
@@ -126,7 +126,7 @@ type RenderOption func(m map[string]any)
 // reaction continuation context. Each key receives a nil default in
 // [Template.Render] so templates using missingkey=error do not reject
 // references to absent reaction types.
-var continuationKeys = []string{"ci_failure", "review_comments", "bot_review_comments"}
+var continuationKeys = []string{"ci_failure", "review_comments", "bot_review_comments", "merge_conflict"}
 
 // isContinuationKey reports whether key is a registered continuation
 // template variable name.
@@ -153,7 +153,8 @@ func WithContinuationContext(data map[string]any) RenderOption {
 // Render executes the template with the given inputs and returns the
 // rendered prompt string. The data map contains the top-level keys
 // "issue", "attempt", and "run", plus every key in [continuationKeys]
-// (currently "ci_failure", "review_comments", "bot_review_comments").
+// (currently "ci_failure", "review_comments", "bot_review_comments",
+// "merge_conflict").
 // Continuation keys default to nil when no [RenderOption] overrides them,
 // ensuring missingkey=error does not reject templates that reference these
 // fields.

--- a/internal/prompt/prompt_test.go
+++ b/internal/prompt/prompt_test.go
@@ -661,3 +661,88 @@ func TestRender_WithContinuationContext(t *testing.T) {
 		}
 	})
 }
+
+func TestRender_MergeConflict(t *testing.T) {
+	t.Parallel()
+
+	issue := map[string]any{"title": "Resolve conflicts"}
+	run := RunContext{TurnNumber: 2, MaxTurns: 5, IsContinuation: true}
+
+	mergeConflict := map[string]any{
+		"pr_number": 142,
+		"branch":    "feature/x",
+		"head_sha":  "abc123",
+		"base":      "release/2.0",
+	}
+
+	t.Run("MergeConflict_RendersWithoutMissingKeyError", func(t *testing.T) {
+		t.Parallel()
+
+		tmpl, err := Parse(`{{ if .merge_conflict }}has-conflict{{ end }}`, "WORKFLOW.md", 0)
+		if err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+
+		got, err := tmpl.Render(issue, nil, run,
+			WithContinuationContext(map[string]any{"merge_conflict": mergeConflict}),
+		)
+		if err != nil {
+			t.Fatalf("Render with merge_conflict: %v", err)
+		}
+		if got != "has-conflict" {
+			t.Errorf("Render() = %q, want %q", got, "has-conflict")
+		}
+	})
+
+	t.Run("MergeConflict_DefaultNilNoError", func(t *testing.T) {
+		t.Parallel()
+
+		// The key is seeded to nil by Render, so a template referencing it
+		// under missingkey=error must not error and must evaluate as falsy.
+		tmpl, err := Parse(`{{ if .merge_conflict }}FAIL{{ end }}`, "WORKFLOW.md", 0)
+		if err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+
+		got, err := tmpl.Render(issue, nil, run)
+		if err != nil {
+			t.Fatalf("Render with default merge_conflict=nil: %v", err)
+		}
+		if got != "" {
+			t.Errorf("Render() = %q, want empty string when merge_conflict is nil", got)
+		}
+	})
+
+	t.Run("MergeConflict_FieldsRenderIncludingRealBase", func(t *testing.T) {
+		t.Parallel()
+
+		tmpl, err := Parse(
+			`{{ with .merge_conflict }}{{ .pr_number }}:{{ .branch }}:{{ .head_sha }}:{{ .base }}{{ end }}`,
+			"WORKFLOW.md", 0,
+		)
+		if err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+
+		got, err := tmpl.Render(issue, nil, run,
+			WithContinuationContext(map[string]any{"merge_conflict": mergeConflict}),
+		)
+		if err != nil {
+			t.Fatalf("Render with merge_conflict fields: %v", err)
+		}
+		want := "142:feature/x:abc123:release/2.0"
+		if got != want {
+			t.Errorf("Render() = %q, want %q (real base, not a hardcoded default)", got, want)
+		}
+	})
+
+	t.Run("WithContinuationContext_AcceptsMergeConflictKey", func(t *testing.T) {
+		t.Parallel()
+
+		// WithContinuationContext must not panic for the registered key.
+		opt := WithContinuationContext(map[string]any{"merge_conflict": mergeConflict})
+		if opt == nil {
+			t.Error("WithContinuationContext returned nil for registered key merge_conflict")
+		}
+	})
+}

--- a/internal/scm/github/merge.go
+++ b/internal/scm/github/merge.go
@@ -61,6 +61,9 @@ type pullRequestResponse struct {
 		SHA string `json:"sha"`
 		Ref string `json:"ref"`
 	} `json:"head"`
+	Base struct {
+		Ref string `json:"ref"`
+	} `json:"base"`
 }
 
 // fetchPullRequest issues GET /repos/{owner}/{repo}/pulls/{prNumber}
@@ -196,6 +199,7 @@ func (a *GitHubSCMAdapter) GetMergeability(ctx context.Context, prNumber int, ow
 		Mergeability: mergeability,
 		HeadSHA:      pr.Head.SHA,
 		BranchName:   pr.Head.Ref,
+		BaseBranch:   pr.Base.Ref,
 	}, nil
 }
 

--- a/internal/scm/github/merge_test.go
+++ b/internal/scm/github/merge_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/sortie-ai/sortie/internal/domain"
@@ -572,6 +573,43 @@ func TestGetMergeability_Draft(t *testing.T) {
 	}
 	if !status.Draft {
 		t.Error("GetMergeability().Draft = false, want true for draft PR")
+	}
+}
+
+// TestGetMergeability_BaseBranch verifies that GetMergeability reads the PR's
+// real base branch from the base.ref field of the single pull-request object
+// it already fetches, issuing no second HTTP request for the base.
+func TestGetMergeability_BaseBranch(t *testing.T) {
+	t.Parallel()
+
+	var requests atomic.Int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		if !strings.Contains(r.URL.Path, "/pulls/") {
+			t.Errorf("unexpected request path %q; GetMergeability must only fetch the PR object", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"head":{"sha":"head-rel","ref":"feature/conflict"},"base":{"ref":"release/2.0"},"draft":false,"mergeable_state":"dirty"}`))
+	}))
+	defer srv.Close()
+
+	a := newTestSCMAdapter(t, srv.URL)
+	status, err := a.GetMergeability(t.Context(), 1, "owner", "repo")
+	if err != nil {
+		t.Fatalf("GetMergeability: %v", err)
+	}
+
+	if status.BaseBranch != "release/2.0" {
+		t.Errorf("GetMergeability().BaseBranch = %q, want %q", status.BaseBranch, "release/2.0")
+	}
+	if status.Mergeability != domain.MergeabilityDirty {
+		t.Errorf("GetMergeability().Mergeability = %q, want %q", status.Mergeability, domain.MergeabilityDirty)
+	}
+	if status.HeadSHA != "head-rel" {
+		t.Errorf("GetMergeability().HeadSHA = %q, want %q", status.HeadSHA, "head-rel")
+	}
+	if got := requests.Load(); got != 1 {
+		t.Errorf("HTTP request count = %d, want 1 (base ref rides the existing PR fetch, no second request)", got)
 	}
 }
 

--- a/internal/server/metrics.go
+++ b/internal/server/metrics.go
@@ -20,26 +20,28 @@ type PromMetrics struct {
 	slotsAvailable        prometheus.Gauge
 	activeSessionsElapsed prometheus.Gauge
 
-	tokensTotal               *prometheus.CounterVec
-	agentRuntimeTotal         prometheus.Counter
-	dispatchesTotal           *prometheus.CounterVec
-	workerExitsTotal          *prometheus.CounterVec
-	retriesTotal              *prometheus.CounterVec
-	reconciliationActions     *prometheus.CounterVec
-	pollCyclesTotal           *prometheus.CounterVec
-	trackerRequestsTotal      *prometheus.CounterVec
-	handoffTransitions        *prometheus.CounterVec
-	dispatchTransitions       *prometheus.CounterVec
-	trackerCommentsTotal      *prometheus.CounterVec
-	toolCallsTotal            *prometheus.CounterVec
-	ciStatusChecksTotal       *prometheus.CounterVec
-	ciEscalationsTotal        *prometheus.CounterVec
-	reviewChecksTotal         *prometheus.CounterVec
-	reviewEscalationsTotal    *prometheus.CounterVec
-	botReviewChecksTotal      *prometheus.CounterVec
-	botReviewEscalationsTotal *prometheus.CounterVec
-	autoMergeReactionsTotal   *prometheus.CounterVec
-	dispatchRuleMatchTotal    *prometheus.CounterVec
+	tokensTotal                   *prometheus.CounterVec
+	agentRuntimeTotal             prometheus.Counter
+	dispatchesTotal               *prometheus.CounterVec
+	workerExitsTotal              *prometheus.CounterVec
+	retriesTotal                  *prometheus.CounterVec
+	reconciliationActions         *prometheus.CounterVec
+	pollCyclesTotal               *prometheus.CounterVec
+	trackerRequestsTotal          *prometheus.CounterVec
+	handoffTransitions            *prometheus.CounterVec
+	dispatchTransitions           *prometheus.CounterVec
+	trackerCommentsTotal          *prometheus.CounterVec
+	toolCallsTotal                *prometheus.CounterVec
+	ciStatusChecksTotal           *prometheus.CounterVec
+	ciEscalationsTotal            *prometheus.CounterVec
+	reviewChecksTotal             *prometheus.CounterVec
+	reviewEscalationsTotal        *prometheus.CounterVec
+	botReviewChecksTotal          *prometheus.CounterVec
+	botReviewEscalationsTotal     *prometheus.CounterVec
+	autoMergeReactionsTotal       *prometheus.CounterVec
+	mergeConflictChecksTotal      *prometheus.CounterVec
+	mergeConflictEscalationsTotal *prometheus.CounterVec
+	dispatchRuleMatchTotal        *prometheus.CounterVec
 
 	selfReviewIterationsTotal      *prometheus.CounterVec
 	selfReviewSessionsTotal        *prometheus.CounterVec
@@ -231,6 +233,18 @@ func NewPromMetrics(version, goVersion string) *PromMetrics {
 		Help:      "Auto-merge reaction outcomes by result.",
 	}, []string{"result"})
 
+	mergeConflictChecksTotal := prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "sortie",
+		Name:      "merge_conflict_checks_total",
+		Help:      "Merge-conflict reaction check outcomes.",
+	}, []string{"result"})
+
+	mergeConflictEscalationsTotal := prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "sortie",
+		Name:      "merge_conflict_escalations_total",
+		Help:      "Merge-conflict reaction escalation outcomes.",
+	}, []string{"action"})
+
 	dispatchRuleMatchTotal := prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "sortie",
 		Name:      "dispatch_rule_match_total",
@@ -290,6 +304,8 @@ func NewPromMetrics(version, goVersion string) *PromMetrics {
 		botReviewChecksTotal,
 		botReviewEscalationsTotal,
 		autoMergeReactionsTotal,
+		mergeConflictChecksTotal,
+		mergeConflictEscalationsTotal,
 		dispatchRuleMatchTotal,
 		selfReviewIterationsTotal,
 		selfReviewSessionsTotal,
@@ -325,6 +341,8 @@ func NewPromMetrics(version, goVersion string) *PromMetrics {
 		botReviewChecksTotal:           botReviewChecksTotal,
 		botReviewEscalationsTotal:      botReviewEscalationsTotal,
 		autoMergeReactionsTotal:        autoMergeReactionsTotal,
+		mergeConflictChecksTotal:       mergeConflictChecksTotal,
+		mergeConflictEscalationsTotal:  mergeConflictEscalationsTotal,
 		dispatchRuleMatchTotal:         dispatchRuleMatchTotal,
 		selfReviewIterationsTotal:      selfReviewIterationsTotal,
 		selfReviewSessionsTotal:        selfReviewSessionsTotal,
@@ -472,6 +490,18 @@ func (p *PromMetrics) IncBotReviewChecks(result string) {
 // IncBotReviewEscalations increments the bot review escalation action counter.
 func (p *PromMetrics) IncBotReviewEscalations(action string) {
 	p.botReviewEscalationsTotal.WithLabelValues(action).Inc()
+}
+
+// IncMergeConflictChecks increments the merge-conflict reaction check
+// outcome counter.
+func (p *PromMetrics) IncMergeConflictChecks(result string) {
+	p.mergeConflictChecksTotal.WithLabelValues(result).Inc()
+}
+
+// IncMergeConflictEscalations increments the merge-conflict escalation
+// action counter.
+func (p *PromMetrics) IncMergeConflictEscalations(action string) {
+	p.mergeConflictEscalationsTotal.WithLabelValues(action).Inc()
 }
 
 // IncAutoMergeReactions increments the auto-merge reaction outcome

--- a/internal/server/metrics_test.go
+++ b/internal/server/metrics_test.go
@@ -894,3 +894,57 @@ func TestPromMetrics_BotReviewCounters(t *testing.T) {
 		}
 	})
 }
+
+func TestPromMetrics_MergeConflictCounters(t *testing.T) {
+	t.Parallel()
+
+	t.Run("IncMergeConflictChecks_AllFourResults_Independent", func(t *testing.T) {
+		t.Parallel()
+		m := newTestMetrics(t)
+		m.IncMergeConflictChecks("dispatched")
+		m.IncMergeConflictChecks("dispatched")
+		m.IncMergeConflictChecks("error")
+		m.IncMergeConflictChecks("unknown")
+		m.IncMergeConflictChecks("unknown")
+		m.IncMergeConflictChecks("unknown")
+		m.IncMergeConflictChecks("clear")
+		families := gatherFamilies(t, m)
+
+		want := map[string]float64{
+			"dispatched": 2,
+			"error":      1,
+			"unknown":    3,
+			"clear":      1,
+		}
+		for result, wantCount := range want {
+			got := counterValue(t, families, "sortie_merge_conflict_checks_total", map[string]string{"result": result})
+			if got != wantCount {
+				t.Errorf("sortie_merge_conflict_checks_total{result=%s} = %v, want %v", result, got, wantCount)
+			}
+		}
+	})
+
+	t.Run("IncMergeConflictEscalations_AllThreeActions_Independent", func(t *testing.T) {
+		t.Parallel()
+		m := newTestMetrics(t)
+		m.IncMergeConflictEscalations("label")
+		m.IncMergeConflictEscalations("comment")
+		m.IncMergeConflictEscalations("comment")
+		m.IncMergeConflictEscalations("error")
+		m.IncMergeConflictEscalations("error")
+		m.IncMergeConflictEscalations("error")
+		families := gatherFamilies(t, m)
+
+		want := map[string]float64{
+			"label":   1,
+			"comment": 2,
+			"error":   3,
+		}
+		for action, wantCount := range want {
+			got := counterValue(t, families, "sortie_merge_conflict_escalations_total", map[string]string{"action": action})
+			if got != wantCount {
+				t.Errorf("sortie_merge_conflict_escalations_total{action=%s} = %v, want %v", action, got, wantCount)
+			}
+		}
+	})
+}


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Feat

**Intent:** Introduces the `merge-conflict` reaction kind (`reactions.merge_conflicts` in WORKFLOW.md) so Sortie automatically detects when one of its managed PRs becomes unmergeable and dispatches a rebase-and-resolve continuation turn, closing the gap in the autonomous PR lifecycle.

**Related Issues:** #416

### 🧭 Reviewer Guide

**Complexity:** High

#### Entry Point

`internal/orchestrator/merge_conflict_reconcile.go` is the new state machine. It follows the same pattern as `ci_reconcile.go` and `bot_review_reconcile.go`: a top-level `reconcileMergeConflicts` function called from `ReconcileRunningIssues`, per-episode fingerprinting via `reaction_fingerprints`, and escalation after a configurable retry budget. Start there, then trace outward to `state.go` for the data structures and `exit.go` for the enqueue path.

#### Sensitive Areas

- `internal/orchestrator/state.go`: adds `ReactionKindMergeConflict`, `MergeConflictReactionData`, `MergeConflictReactionConfig`, and extends `isKnownReactionKind`. A mistake here silently drops reactions or misroutes them on recovery.
- `internal/orchestrator/exit.go`: the merge-conflict `PendingReaction` is enqueued on worker exit; the `reactionEnqueueAllowed` guard and a valid PR number in SCM metadata must both be satisfied — a silent no-op otherwise.
- `internal/orchestrator/recovery.go`: `MergeConflictReactionConfigured` must be wired correctly in `RecoverPendingReactions` or pending entries are skipped silently on process restart.
- `internal/domain/scm.go`: adds `BaseBranch` to `PRMergeStatus` so the reconciler can pass the real rebase target branch without a second API round-trip.

### ⚠️ Risk Assessment

- **Breaking Changes:** `Metrics` interface gains `IncMergeConflictChecks` and `IncMergeConflictEscalations`; out-of-tree implementations must add them. `PRMergeStatus` gains `BaseBranch` (additive, no break).
- **Migrations/State:** No database schema changes. The new `PendingReaction` kind (`merge-conflict`) round-trips cleanly through the existing JSON store; unknown kinds from an older binary are silently skipped on upgrade and newly written entries are ignored on downgrade.