### PR TITLE
feat: implement Gitea tracker adapter read path

### DIFF
--- a/cmd/sortie/main.go
+++ b/cmd/sortie/main.go
@@ -47,6 +47,7 @@ import (
 	_ "github.com/sortie-ai/sortie/internal/agent/opencode"
 	_ "github.com/sortie-ai/sortie/internal/notify/slack"
 	_ "github.com/sortie-ai/sortie/internal/notify/webhook"
+	_ "github.com/sortie-ai/sortie/internal/scm/gitea"
 	_ "github.com/sortie-ai/sortie/internal/scm/github"
 	_ "github.com/sortie-ai/sortie/internal/tracker/file"
 	_ "github.com/sortie-ai/sortie/internal/tracker/jira"

--- a/internal/scm/gitea/client.go
+++ b/internal/scm/gitea/client.go
@@ -1,0 +1,133 @@
+package gitea
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/sortie-ai/sortie/internal/domain"
+	"github.com/sortie-ai/sortie/internal/httpkit"
+)
+
+// newGiteaClient builds an [httpkit.Client] for the Gitea REST API. baseURL is
+// the instance base URL already suffixed with /api/v1; the token travels only in
+// the Authorization header, never as a query parameter.
+func newGiteaClient(baseURL, token, userAgent string) *httpkit.Client {
+	trimmedBaseURL := strings.TrimRight(baseURL, "/")
+	authorization := "token " + token
+
+	return httpkit.NewClient(httpkit.ClientOptions{
+		BaseURL: trimmedBaseURL,
+		Timeout: 30 * time.Second,
+		Authorize: func(req *http.Request) {
+			req.Header.Set("Authorization", authorization)
+			req.Header.Set("Accept", "application/json")
+			req.Header.Set("User-Agent", userAgent)
+		},
+		ClassifyError:     classifyHTTPError,
+		ClassifyTransport: classifyTransportError,
+	})
+}
+
+const maxErrorBody = 512
+
+// classifyHTTPError maps a non-200 Gitea response to a [*domain.TrackerError].
+// It reads a bounded body snippet for the diagnostic message and never includes
+// the request URL, which carries the token in no scheme this adapter uses.
+func classifyHTTPError(resp *http.Response, method, path string) error {
+	snippet, _ := io.ReadAll(io.LimitReader(resp.Body, maxErrorBody))
+	_, _ = io.Copy(io.Discard, resp.Body)
+	detail := errorDetail(snippet)
+
+	switch {
+	case resp.StatusCode == http.StatusBadRequest:
+		return &domain.TrackerError{
+			Kind:    domain.ErrTrackerPayload,
+			Message: fmt.Sprintf("%s %s: bad request: %s", method, path, detail),
+		}
+
+	case resp.StatusCode == http.StatusUnauthorized:
+		return &domain.TrackerError{
+			Kind:    domain.ErrTrackerAuth,
+			Message: fmt.Sprintf("%s %s: invalid credentials", method, path),
+		}
+
+	case resp.StatusCode == http.StatusForbidden:
+		return &domain.TrackerError{
+			Kind:    domain.ErrTrackerAuth,
+			Message: fmt.Sprintf("%s %s: insufficient permissions: %s", method, path, detail),
+		}
+
+	case resp.StatusCode == http.StatusNotFound:
+		return &domain.TrackerError{
+			Kind:    domain.ErrTrackerNotFound,
+			Message: fmt.Sprintf("%s %s: not found", method, path),
+		}
+
+	case resp.StatusCode == http.StatusPreconditionFailed:
+		return &domain.TrackerError{
+			Kind:    domain.ErrTrackerPayload,
+			Message: fmt.Sprintf("%s %s: precondition failed: %s", method, path, detail),
+		}
+
+	case resp.StatusCode == http.StatusUnprocessableEntity:
+		return &domain.TrackerError{
+			Kind:    domain.ErrTrackerPayload,
+			Message: fmt.Sprintf("%s %s: validation failed: %s", method, path, detail),
+		}
+
+	case resp.StatusCode == http.StatusLocked:
+		return &domain.TrackerError{
+			Kind:    domain.ErrTrackerAPI,
+			Message: fmt.Sprintf("%s %s: locked: %s", method, path, detail),
+		}
+
+	case resp.StatusCode == http.StatusTooManyRequests:
+		// Gitea itself sends no 429; only a fronting proxy does. Surface the
+		// proxy's Retry-After but let the orchestrator own retry backoff.
+		if retryAfter := resp.Header.Get("Retry-After"); retryAfter != "" {
+			slog.Default().Warn("rate limited", slog.String("retry_after", retryAfter))
+		}
+		return &domain.TrackerError{
+			Kind:    domain.ErrTrackerAPI,
+			Message: fmt.Sprintf("%s %s: rate limited", method, path),
+		}
+
+	case resp.StatusCode >= 500:
+		return &domain.TrackerError{
+			Kind:    domain.ErrTrackerTransport,
+			Message: fmt.Sprintf("%s %s: server error %d: %s", method, path, resp.StatusCode, detail),
+		}
+
+	default:
+		return &domain.TrackerError{
+			Kind:    domain.ErrTrackerAPI,
+			Message: fmt.Sprintf("%s %s: unexpected status %d: %s", method, path, resp.StatusCode, detail),
+		}
+	}
+}
+
+// classifyTransportError maps a transport or body-read failure to a
+// [*domain.TrackerError] of kind [domain.ErrTrackerTransport], preserving the
+// underlying error for the chain.
+func classifyTransportError(err error, method, path string) error {
+	return &domain.TrackerError{
+		Kind:    domain.ErrTrackerTransport,
+		Message: fmt.Sprintf("%s %s: transport error", method, path),
+		Err:     err,
+	}
+}
+
+// errorDetail extracts the Gitea error envelope message from a bounded body
+// snippet, falling back to the raw snippet when it does not decode.
+func errorDetail(snippet []byte) string {
+	var body giteaErrorBody
+	if err := json.Unmarshal(snippet, &body); err == nil && body.Message != "" {
+		return body.Message
+	}
+	return string(snippet)
+}

--- a/internal/scm/gitea/client.go
+++ b/internal/scm/gitea/client.go
@@ -36,8 +36,8 @@ func newGiteaClient(baseURL, token, userAgent string) *httpkit.Client {
 const maxErrorBody = 512
 
 // classifyHTTPError maps a non-200 Gitea response to a [*domain.TrackerError].
-// It reads a bounded body snippet for the diagnostic message and never includes
-// the request URL, which carries the token in no scheme this adapter uses.
+// The message carries a bounded body snippet and the request path or URL, never
+// the token, which this adapter sends only in the Authorization header.
 func classifyHTTPError(resp *http.Response, method, path string) error {
 	snippet, _ := io.ReadAll(io.LimitReader(resp.Body, maxErrorBody))
 	_, _ = io.Copy(io.Discard, resp.Body)

--- a/internal/scm/gitea/client_test.go
+++ b/internal/scm/gitea/client_test.go
@@ -1,0 +1,179 @@
+package gitea
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/sortie-ai/sortie/internal/domain"
+)
+
+func TestNewGiteaClient(t *testing.T) {
+	t.Parallel()
+
+	t.Run("sends token header, accept, user-agent, and api/v1 path", func(t *testing.T) {
+		t.Parallel()
+
+		var gotHeaders http.Header
+		var gotPath string
+		var gotRawQuery string
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotHeaders = r.Header.Clone()
+			gotPath = r.URL.Path
+			gotRawQuery = r.URL.RawQuery
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"login":"sortie-bot"}`)) //nolint:errcheck // test helper
+		}))
+		defer srv.Close()
+
+		client := newGiteaClient(srv.URL+"/api/v1", "abc123", "sortie/test")
+		_, _, err := client.Get(context.Background(), "/user", nil)
+		if err != nil {
+			t.Fatalf("Get: %v", err)
+		}
+
+		if got := gotHeaders.Get("Authorization"); got != "token abc123" {
+			t.Errorf("Authorization = %q, want %q", got, "token abc123")
+		}
+		if got := gotHeaders.Get("Accept"); got != "application/json" {
+			t.Errorf("Accept = %q, want %q", got, "application/json")
+		}
+		if got := gotHeaders.Get("User-Agent"); got != "sortie/test" {
+			t.Errorf("User-Agent = %q, want %q", got, "sortie/test")
+		}
+		if gotPath != "/api/v1/user" {
+			t.Errorf("path = %q, want %q", gotPath, "/api/v1/user")
+		}
+		if gotRawQuery != "" {
+			t.Errorf("raw query = %q, want empty (token must never travel as a query parameter)", gotRawQuery)
+		}
+	})
+
+	t.Run("trims a trailing slash from baseURL", func(t *testing.T) {
+		t.Parallel()
+
+		var gotPath string
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotPath = r.URL.Path
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{}`)) //nolint:errcheck // test helper
+		}))
+		defer srv.Close()
+
+		client := newGiteaClient(srv.URL+"/api/v1/", "abc123", "sortie/test")
+		_, _, err := client.Get(context.Background(), "/user", nil)
+		if err != nil {
+			t.Fatalf("Get: %v", err)
+		}
+		if gotPath != "/api/v1/user" {
+			t.Errorf("path = %q, want %q (no doubled slash)", gotPath, "/api/v1/user")
+		}
+	})
+}
+
+func TestClassifyHTTPError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		status   int
+		fixture  string
+		headers  map[string]string
+		wantKind domain.TrackerErrorKind
+	}{
+		{"400 bad request", http.StatusBadRequest, "error_400.json", nil, domain.ErrTrackerPayload},
+		{"401 unauthorized", http.StatusUnauthorized, "error_401.json", nil, domain.ErrTrackerAuth},
+		{"403 forbidden", http.StatusForbidden, "error_403.json", nil, domain.ErrTrackerAuth},
+		{"404 not found", http.StatusNotFound, "error_404.json", nil, domain.ErrTrackerNotFound},
+		{"412 precondition failed", http.StatusPreconditionFailed, "error_412.json", nil, domain.ErrTrackerPayload},
+		{"422 unprocessable entity", http.StatusUnprocessableEntity, "error_422.json", nil, domain.ErrTrackerPayload},
+		{"423 locked", http.StatusLocked, "error_423.json", nil, domain.ErrTrackerAPI},
+		{"429 too many requests", http.StatusTooManyRequests, "", map[string]string{"Retry-After": "30"}, domain.ErrTrackerAPI},
+		{"500 server error", http.StatusInternalServerError, "", nil, domain.ErrTrackerTransport},
+		{"502 bad gateway", http.StatusBadGateway, "", nil, domain.ErrTrackerTransport},
+		{"unexpected status", http.StatusTeapot, "", nil, domain.ErrTrackerAPI},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var body []byte
+			if tt.fixture != "" {
+				body = loadFixture(t, tt.fixture)
+			}
+			headers := make(http.Header)
+			for key, value := range tt.headers {
+				headers.Set(key, value)
+			}
+			resp := &http.Response{
+				StatusCode: tt.status,
+				Header:     headers,
+				Body:       io.NopCloser(bytes.NewReader(body)),
+			}
+			defer resp.Body.Close() //nolint:errcheck // NopCloser.Close always returns nil
+
+			err := classifyHTTPError(resp, http.MethodGet, "/repos/acme/widgets/issues/1")
+			assertTrackerErrorKind(t, err, tt.wantKind)
+		})
+	}
+
+	t.Run("403 has no rate-limit-header branch", func(t *testing.T) {
+		t.Parallel()
+
+		// Gitea sends no X-Ratelimit-* headers (unlike GitHub); a 403 must
+		// classify as an auth error even if a header that looks rate-limit-like
+		// is present, proving no such branch exists in the classifier.
+		headers := make(http.Header)
+		headers.Set("X-Ratelimit-Remaining", "0")
+		resp := &http.Response{
+			StatusCode: http.StatusForbidden,
+			Header:     headers,
+			Body:       io.NopCloser(bytes.NewReader(loadFixture(t, "error_403.json"))),
+		}
+		defer resp.Body.Close() //nolint:errcheck // NopCloser.Close always returns nil
+
+		err := classifyHTTPError(resp, http.MethodGet, "/user")
+		assertTrackerErrorKind(t, err, domain.ErrTrackerAuth)
+	})
+
+	t.Run("includes the decoded gitea message for diagnostics", func(t *testing.T) {
+		t.Parallel()
+
+		// 403 is one of the branches that includes the decoded detail (401 and
+		// 404 use fixed messages instead, since the gitea body cannot add
+		// useful detail beyond the status itself for those two).
+		resp := &http.Response{
+			StatusCode: http.StatusForbidden,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(bytes.NewReader(loadFixture(t, "error_403.json"))),
+		}
+		defer resp.Body.Close() //nolint:errcheck // NopCloser.Close always returns nil
+
+		err := classifyHTTPError(resp, http.MethodGet, "/user")
+		var te *domain.TrackerError
+		if !errors.As(err, &te) {
+			t.Fatalf("error type = %T, want *domain.TrackerError", err)
+		}
+		if !strings.Contains(te.Message, "token does not have at least one of required scope(s)") {
+			t.Errorf("TrackerError.Message = %q, want it to contain the gitea error body message", te.Message)
+		}
+	})
+}
+
+func TestClassifyTransportError(t *testing.T) {
+	t.Parallel()
+
+	wrapped := errors.New("dial tcp: connection refused")
+	err := classifyTransportError(wrapped, http.MethodGet, "/user")
+
+	assertTrackerErrorKind(t, err, domain.ErrTrackerTransport)
+	if !errors.Is(err, wrapped) {
+		t.Errorf("classifyTransportError(%v) chain missing wrapped error", wrapped)
+	}
+}

--- a/internal/scm/gitea/gitea.go
+++ b/internal/scm/gitea/gitea.go
@@ -1,0 +1,546 @@
+// Package gitea implements [domain.TrackerAdapter] for the Gitea REST API v1.
+// It talks to a self-hosted Gitea instance over the shared HTTP transport with
+// no third-party Gitea client library, normalizing issue responses to domain
+// types: labels lowercased, priority always nil (Gitea exposes no priority
+// field), parent always nil (Gitea has no sub-issue concept), state derived
+// from labels against the configured active, terminal, and handoff lists, and
+// blocker refs read from the issue dependencies route.
+//
+// The constructor runs a two-call preflight (GET /user and GET
+// /repos/{owner}/{repo}) that fails construction on an invalid token or a
+// mistyped project, so a misconfiguration surfaces at startup rather than on
+// the first poll. Registered under kind "gitea" via an init function.
+package gitea
+
+import (
+	"cmp"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/url"
+	"slices"
+	"strings"
+
+	"github.com/sortie-ai/sortie/internal/domain"
+	"github.com/sortie-ai/sortie/internal/httpkit"
+	"github.com/sortie-ai/sortie/internal/registry"
+	"github.com/sortie-ai/sortie/internal/trackermetrics"
+	"github.com/sortie-ai/sortie/internal/typeutil"
+)
+
+func init() {
+	registry.Trackers.RegisterWithMeta("gitea", NewGiteaAdapter, registry.TrackerMeta{
+		RequiresProject: true,
+		RequiresAPIKey:  true,
+	})
+}
+
+// Compile-time interface satisfaction check.
+var _ domain.TrackerAdapter = (*GiteaAdapter)(nil)
+
+// maxPages is the upper bound on paginated fetches. At 50 items per page this
+// allows up to 10,000 results before the adapter stops and returns what it has.
+const maxPages = 200
+
+// defaultActiveStates is applied when the config omits active_states.
+var defaultActiveStates = []string{"backlog", "in-progress", "review"}
+
+// defaultTerminalStates is applied when the config omits terminal_states.
+var defaultTerminalStates = []string{"done", "wontfix"}
+
+// GiteaAdapter implements [domain.TrackerAdapter] against the Gitea REST API v1.
+// All fields except metrics are set once at construction and never mutated, so
+// the adapter is safe for concurrent use.
+type GiteaAdapter struct {
+	client         *httpkit.Client
+	owner          string
+	repo           string
+	activeStates   []string
+	terminalStates []string
+	handoffState   string
+	log            *slog.Logger
+	metrics        domain.Metrics
+}
+
+// NewGiteaAdapter creates a [GiteaAdapter] from adapter configuration and runs a
+// construction-time preflight against the instance.
+//
+// Required config keys: "api_key" (access token), "project" (owner/repo), and
+// "endpoint" (instance base URL; there is no default host). Optional:
+// "active_states", "terminal_states", "handoff_state" (label names, lowercased),
+// and "user_agent". A missing or malformed key, or a preflight failure (invalid
+// token or unknown repository), returns a [*domain.TrackerError] and blocks
+// construction.
+func NewGiteaAdapter(config map[string]any) (domain.TrackerAdapter, error) {
+	apiKey, _ := config["api_key"].(string)
+	if apiKey == "" {
+		return nil, &domain.TrackerError{
+			Kind:    domain.ErrMissingTrackerAPIKey,
+			Message: "missing required config key: api_key",
+		}
+	}
+
+	project, _ := config["project"].(string)
+	if project == "" {
+		return nil, &domain.TrackerError{
+			Kind:    domain.ErrMissingTrackerProject,
+			Message: "missing required config key: project",
+		}
+	}
+
+	owner, repo, ok := strings.Cut(project, "/")
+	if !ok || owner == "" || repo == "" || strings.Contains(repo, "/") {
+		return nil, &domain.TrackerError{
+			Kind:    domain.ErrTrackerPayload,
+			Message: "project must be in owner/repo format",
+		}
+	}
+
+	endpoint, _ := config["endpoint"].(string)
+	if endpoint == "" {
+		return nil, &domain.TrackerError{
+			Kind:    domain.ErrTrackerPayload,
+			Message: "tracker.endpoint is required for gitea",
+		}
+	}
+	baseURL := strings.TrimRight(endpoint, "/")
+	if !strings.HasSuffix(baseURL, "/api/v1") {
+		baseURL += "/api/v1"
+	}
+
+	activeRaw := typeutil.ExtractStringSlice(config["active_states"])
+	if len(activeRaw) == 0 {
+		activeRaw = defaultActiveStates
+	}
+	activeStates := make([]string, len(activeRaw))
+	for i, s := range activeRaw {
+		activeStates[i] = strings.ToLower(s)
+	}
+
+	terminalRaw := typeutil.ExtractStringSlice(config["terminal_states"])
+	if len(terminalRaw) == 0 {
+		terminalRaw = defaultTerminalStates
+	}
+	terminalStates := make([]string, len(terminalRaw))
+	for i, s := range terminalRaw {
+		terminalStates[i] = strings.ToLower(s)
+	}
+
+	handoffRaw, _ := config["handoff_state"].(string)
+	handoffState := strings.ToLower(strings.TrimSpace(handoffRaw))
+
+	userAgent, _ := config["user_agent"].(string)
+	if userAgent == "" {
+		userAgent = "sortie/dev"
+	}
+
+	client := newGiteaClient(baseURL, apiKey, userAgent)
+
+	if err := runPreflight(context.Background(), client, owner, repo); err != nil {
+		return nil, err
+	}
+
+	return &GiteaAdapter{
+		client:         client,
+		owner:          owner,
+		repo:           repo,
+		activeStates:   activeStates,
+		terminalStates: terminalStates,
+		handoffState:   handoffState,
+		log:            slog.Default(),
+	}, nil
+}
+
+// SetMetrics configures the metrics recorder for tracker API call
+// instrumentation. When not called or called with nil, the adapter operates
+// without recording metrics. Safe to call before any adapter operations. Not
+// safe to call concurrently with adapter operations.
+func (a *GiteaAdapter) SetMetrics(m domain.Metrics) {
+	a.metrics = m
+}
+
+// FetchCandidateIssues returns open issues whose derived state is in the
+// configured active states, sorted ascending by creation time. Pull requests
+// are skipped and Comments is nil on every returned issue.
+//
+// Gitea lists newest-first and offers no sort parameter, so the adapter
+// re-sorts client-side to hand the orchestrator the same ascending order the
+// other trackers produce.
+func (a *GiteaAdapter) FetchCandidateIssues(ctx context.Context) ([]domain.Issue, error) {
+	issues := make([]domain.Issue, 0)
+	err := trackermetrics.Track(a.metrics, "fetch_candidates", func() error {
+		activeSet := make(map[string]struct{}, len(a.activeStates))
+		for _, s := range a.activeStates {
+			activeSet[s] = struct{}{}
+		}
+
+		candidates, fetchErr := a.listAndFilter(ctx, "open", activeSet)
+		if fetchErr != nil {
+			return fetchErr
+		}
+
+		slices.SortFunc(candidates, func(x, y domain.Issue) int {
+			return cmp.Compare(x.CreatedAt, y.CreatedAt)
+		})
+
+		issues = candidates
+		return nil
+	})
+	return issues, err
+}
+
+// FetchIssuesByStates returns issues whose derived state is in the requested
+// set. It returns an empty slice with no API call when states is empty.
+//
+// The requested states are partitioned by whether they are terminal: the open
+// listing runs when any requested state is non-terminal, and the closed listing
+// runs when any requested state is terminal. Open and closed sets are disjoint,
+// so no cross-fetch deduplication is needed. Comments is nil on every issue.
+func (a *GiteaAdapter) FetchIssuesByStates(ctx context.Context, states []string) ([]domain.Issue, error) {
+	if len(states) == 0 {
+		return []domain.Issue{}, nil
+	}
+
+	requested := make(map[string]struct{}, len(states))
+	for _, s := range states {
+		requested[strings.ToLower(s)] = struct{}{}
+	}
+
+	terminalSet := make(map[string]struct{}, len(a.terminalStates))
+	for _, s := range a.terminalStates {
+		terminalSet[s] = struct{}{}
+	}
+
+	needOpen := false
+	needClosed := false
+	for s := range requested {
+		if _, ok := terminalSet[s]; ok {
+			needClosed = true
+		} else {
+			needOpen = true
+		}
+	}
+
+	issues := make([]domain.Issue, 0)
+	err := trackermetrics.Track(a.metrics, "fetch_by_states", func() error {
+		result := make([]domain.Issue, 0)
+
+		if needOpen {
+			open, err := a.listAndFilter(ctx, "open", requested)
+			if err != nil {
+				return err
+			}
+			result = append(result, open...)
+		}
+
+		if needClosed {
+			closed, err := a.listAndFilter(ctx, "closed", requested)
+			if err != nil {
+				return err
+			}
+			result = append(result, closed...)
+		}
+
+		issues = result
+		return nil
+	})
+	return issues, err
+}
+
+// listAndFilter paginates the issue-list route for the given native state and
+// returns issues whose derived state is in keep. Pull requests are skipped,
+// DisplayID is qualified to owner/repo#N, and Comments is nil on every issue.
+//
+// State filtering is client-side; the configured labels are never pushed into
+// the Gitea labels query parameter, whose AND semantics and silent drop on an
+// unresolvable name make it unusable for correctness-critical filtering.
+func (a *GiteaAdapter) listAndFilter(ctx context.Context, nativeState string, keep map[string]struct{}) ([]domain.Issue, error) {
+	path := "/repos/" + a.owner + "/" + a.repo + "/issues"
+	params := url.Values{
+		"state": {nativeState},
+		"type":  {"issues"},
+		"limit": {"50"},
+	}
+
+	raw, err := a.paginateIssues(ctx, path, params)
+	if err != nil {
+		return nil, err
+	}
+
+	filtered := make([]domain.Issue, 0, len(raw))
+	for _, gi := range raw {
+		if isPullRequest(gi) {
+			continue
+		}
+		issue := normalizeIssue(gi, a.activeStates, a.terminalStates, a.handoffState, a.log)
+		setDisplayID(&issue, a.owner, a.repo)
+		if _, ok := keep[issue.State]; !ok {
+			continue
+		}
+		issue.Comments = nil
+		filtered = append(filtered, issue)
+	}
+	return filtered, nil
+}
+
+// paginateIssues fetches every page of an issue-array route through the
+// Link-header paginator and returns the accumulated raw issues. It serves both
+// the issue-list routes and the dependencies route, which return JSON arrays of
+// full issue objects.
+//
+// A decode failure returns [domain.ErrTrackerPayload]. An absent Link header is
+// the normal end of results, never a missing-cursor error, because Gitea uses
+// no cursors.
+func (a *GiteaAdapter) paginateIssues(ctx context.Context, path string, params url.Values) ([]giteaIssue, error) {
+	paginator := httpkit.NewLinkPaginator(a.client, path, params, func(body []byte) ([]giteaIssue, error) {
+		var raw []giteaIssue
+		if err := json.Unmarshal(body, &raw); err != nil {
+			return nil, &domain.TrackerError{
+				Kind:    domain.ErrTrackerPayload,
+				Message: "failed to parse issues response",
+				Err:     err,
+			}
+		}
+		return raw, nil
+	}, httpkit.PaginatorOptions{
+		MaxPages: maxPages,
+		OnLimitReached: func(limit int) {
+			a.log.Warn("pagination limit reached",
+				slog.Int("max_pages", limit),
+				slog.String("endpoint", path))
+		},
+	})
+
+	return paginator.All(ctx)
+}
+
+// FetchIssueByID returns a fully populated issue including comments and
+// blockers. issueID is the repo-scoped index. A 404, or an index that resolves
+// to a pull request, returns [domain.ErrTrackerNotFound].
+//
+// Parent is always nil and no parent request is issued: Gitea has no parent or
+// sub-issue route.
+func (a *GiteaAdapter) FetchIssueByID(ctx context.Context, issueID string) (domain.Issue, error) {
+	var issue domain.Issue
+	err := trackermetrics.Track(a.metrics, "fetch_issue", func() error {
+		path := "/repos/" + a.owner + "/" + a.repo + "/issues/" + url.PathEscape(issueID)
+
+		body, _, err := a.client.Get(ctx, path, nil)
+		if err != nil {
+			if domain.IsNotFound(err) {
+				return &domain.TrackerError{
+					Kind:    domain.ErrTrackerNotFound,
+					Message: fmt.Sprintf("issue not found: %s", issueID),
+				}
+			}
+			return err
+		}
+
+		var gi giteaIssue
+		if err := json.Unmarshal(body, &gi); err != nil {
+			return &domain.TrackerError{
+				Kind:    domain.ErrTrackerPayload,
+				Message: "failed to parse issue response",
+				Err:     err,
+			}
+		}
+
+		if isPullRequest(gi) {
+			return &domain.TrackerError{
+				Kind:    domain.ErrTrackerNotFound,
+				Message: fmt.Sprintf("resource is a pull request, not an issue: %s", issueID),
+			}
+		}
+
+		fetched := normalizeIssue(gi, a.activeStates, a.terminalStates, a.handoffState, a.log)
+		setDisplayID(&fetched, a.owner, a.repo)
+
+		blockers, err := a.fetchBlockers(ctx, issueID)
+		if err != nil {
+			return err
+		}
+		fetched.BlockedBy = blockers
+
+		comments, err := a.fetchComments(ctx, issueID)
+		if err != nil {
+			return err
+		}
+		fetched.Comments = comments
+
+		issue = fetched
+		return nil
+	})
+	return issue, err
+}
+
+// fetchBlockers returns the issues blocking the given issue, read from the
+// dependencies route through the Link paginator. A 404 is tolerated and yields
+// a non-nil empty slice.
+func (a *GiteaAdapter) fetchBlockers(ctx context.Context, index string) ([]domain.BlockerRef, error) {
+	path := "/repos/" + a.owner + "/" + a.repo + "/issues/" + url.PathEscape(index) + "/dependencies"
+	params := url.Values{"limit": {"50"}}
+
+	raw, err := a.paginateIssues(ctx, path, params)
+	if err != nil {
+		if domain.IsNotFound(err) {
+			return []domain.BlockerRef{}, nil
+		}
+		return nil, err
+	}
+
+	return normalizeBlockers(raw, a.activeStates, a.terminalStates, a.handoffState, a.log), nil
+}
+
+// FetchIssueComments returns all comments for the issue. It returns a non-nil
+// empty slice when the issue has no comments and [domain.ErrTrackerNotFound]
+// when the index does not exist.
+func (a *GiteaAdapter) FetchIssueComments(ctx context.Context, issueID string) ([]domain.Comment, error) {
+	comments := make([]domain.Comment, 0)
+	err := trackermetrics.Track(a.metrics, "fetch_comments", func() error {
+		fetched, fetchErr := a.fetchComments(ctx, issueID)
+		if fetchErr != nil {
+			return fetchErr
+		}
+		comments = fetched
+		return nil
+	})
+	return comments, err
+}
+
+// fetchComments fetches all comments for an issue in a single request. The
+// Gitea comments route is unpaginated and returns the complete list in one
+// response, so it is never routed through the Link paginator. A 404 maps to
+// [domain.ErrTrackerNotFound]; an issue with no comments yields a non-nil empty
+// slice.
+func (a *GiteaAdapter) fetchComments(ctx context.Context, index string) ([]domain.Comment, error) {
+	path := "/repos/" + a.owner + "/" + a.repo + "/issues/" + url.PathEscape(index) + "/comments"
+
+	body, _, err := a.client.Get(ctx, path, nil)
+	if err != nil {
+		if domain.IsNotFound(err) {
+			return nil, &domain.TrackerError{
+				Kind:    domain.ErrTrackerNotFound,
+				Message: fmt.Sprintf("issue not found: %s", index),
+			}
+		}
+		return nil, err
+	}
+
+	var raw []giteaComment
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return nil, &domain.TrackerError{
+			Kind:    domain.ErrTrackerPayload,
+			Message: "failed to parse comments response",
+			Err:     err,
+		}
+	}
+
+	return normalizeComments(raw), nil
+}
+
+// FetchIssueStatesByIDs returns the derived state for each requested issue
+// index, keyed by the requested value. ID and Identifier are both the index, so
+// this delegates to [GiteaAdapter.fetchStatesByIndexes].
+func (a *GiteaAdapter) FetchIssueStatesByIDs(ctx context.Context, ids []string) (map[string]string, error) {
+	var states map[string]string
+	err := trackermetrics.Track(a.metrics, "fetch_states_by_ids", func() error {
+		fetched, fetchErr := a.fetchStatesByIndexes(ctx, ids)
+		if fetchErr != nil {
+			return fetchErr
+		}
+		states = fetched
+		return nil
+	})
+	return states, err
+}
+
+// FetchIssueStatesByIdentifiers returns the derived state for each requested
+// issue index, keyed by the requested value. ID and Identifier are both the
+// index, so this delegates to [GiteaAdapter.fetchStatesByIndexes].
+func (a *GiteaAdapter) FetchIssueStatesByIdentifiers(ctx context.Context, ids []string) (map[string]string, error) {
+	var states map[string]string
+	err := trackermetrics.Track(a.metrics, "fetch_states_by_identifiers", func() error {
+		fetched, fetchErr := a.fetchStatesByIndexes(ctx, ids)
+		if fetchErr != nil {
+			return fetchErr
+		}
+		states = fetched
+		return nil
+	})
+	return states, err
+}
+
+// fetchStatesByIndexes fetches each issue by index and derives its state,
+// keying the result by the requested value. It returns an empty map with no
+// request when indexes is empty.
+//
+// A 404 or a pull-request entry omits that index from the result rather than
+// failing. Cancellation is checked before each request. No conditional-request
+// cache is used because Gitea sends no ETag.
+func (a *GiteaAdapter) fetchStatesByIndexes(ctx context.Context, indexes []string) (map[string]string, error) {
+	if len(indexes) == 0 {
+		return map[string]string{}, nil
+	}
+
+	states := make(map[string]string, len(indexes))
+	for _, index := range indexes {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+
+		path := "/repos/" + a.owner + "/" + a.repo + "/issues/" + url.PathEscape(index)
+		body, _, err := a.client.Get(ctx, path, nil)
+		if err != nil {
+			if domain.IsNotFound(err) {
+				continue
+			}
+			return nil, err
+		}
+
+		var gi giteaIssue
+		if err := json.Unmarshal(body, &gi); err != nil {
+			return nil, &domain.TrackerError{
+				Kind:    domain.ErrTrackerPayload,
+				Message: "failed to parse issue response",
+				Err:     err,
+			}
+		}
+		if isPullRequest(gi) {
+			continue
+		}
+
+		states[index] = deriveState(gi.Labels, gi.State, a.activeStates, a.terminalStates, a.handoffState, index, a.log)
+	}
+
+	return states, nil
+}
+
+// TransitionIssue is not yet implemented; the Gitea write path is a separate
+// task. It returns [domain.ErrTrackerPayload] and issues no request, so the
+// orchestrator never mistakes a missing transition for a completed one.
+func (a *GiteaAdapter) TransitionIssue(ctx context.Context, issueID, targetState string) error {
+	return &domain.TrackerError{
+		Kind:    domain.ErrTrackerPayload,
+		Message: "gitea: TransitionIssue is not yet implemented",
+	}
+}
+
+// CommentIssue is not yet implemented; the Gitea write path is a separate task.
+// It returns [domain.ErrTrackerPayload] and issues no request.
+func (a *GiteaAdapter) CommentIssue(ctx context.Context, issueID, text string) error {
+	return &domain.TrackerError{
+		Kind:    domain.ErrTrackerPayload,
+		Message: "gitea: CommentIssue is not yet implemented",
+	}
+}
+
+// AddLabel is not yet implemented; the Gitea write path is a separate task. It
+// returns [domain.ErrTrackerPayload] and issues no request, so a silently
+// ignored label attach cannot masquerade as success.
+func (a *GiteaAdapter) AddLabel(ctx context.Context, issueID, label string) error {
+	return &domain.TrackerError{
+		Kind:    domain.ErrTrackerPayload,
+		Message: "gitea: AddLabel is not yet implemented",
+	}
+}

--- a/internal/scm/gitea/gitea.go
+++ b/internal/scm/gitea/gitea.go
@@ -522,7 +522,7 @@ func (a *GiteaAdapter) fetchStatesByIndexes(ctx context.Context, indexes []strin
 func (a *GiteaAdapter) TransitionIssue(ctx context.Context, issueID, targetState string) error {
 	return &domain.TrackerError{
 		Kind:    domain.ErrTrackerPayload,
-		Message: "gitea: TransitionIssue is not yet implemented",
+		Message: "gitea: transitioning issues is not yet implemented",
 	}
 }
 
@@ -531,7 +531,7 @@ func (a *GiteaAdapter) TransitionIssue(ctx context.Context, issueID, targetState
 func (a *GiteaAdapter) CommentIssue(ctx context.Context, issueID, text string) error {
 	return &domain.TrackerError{
 		Kind:    domain.ErrTrackerPayload,
-		Message: "gitea: CommentIssue is not yet implemented",
+		Message: "gitea: commenting on issues is not yet implemented",
 	}
 }
 
@@ -541,6 +541,6 @@ func (a *GiteaAdapter) CommentIssue(ctx context.Context, issueID, text string) e
 func (a *GiteaAdapter) AddLabel(ctx context.Context, issueID, label string) error {
 	return &domain.TrackerError{
 		Kind:    domain.ErrTrackerPayload,
-		Message: "gitea: AddLabel is not yet implemented",
+		Message: "gitea: adding labels is not yet implemented",
 	}
 }

--- a/internal/scm/gitea/gitea_test.go
+++ b/internal/scm/gitea/gitea_test.go
@@ -1,0 +1,1040 @@
+package gitea
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/sortie-ai/sortie/internal/domain"
+	"github.com/sortie-ai/sortie/internal/registry"
+)
+
+const (
+	testOwner = "acme"
+	testRepo  = "widgets"
+)
+
+func loadFixture(t *testing.T, name string) []byte {
+	t.Helper()
+	data, err := os.ReadFile("testdata/" + name)
+	if err != nil {
+		t.Fatalf("reading fixture %s: %v", name, err)
+	}
+	return data
+}
+
+func validConfig(endpoint string) map[string]any {
+	return map[string]any{
+		"endpoint": endpoint,
+		"api_key":  "test-token",
+		"project":  testOwner + "/" + testRepo,
+	}
+}
+
+func assertTrackerErrorKind(t *testing.T, err error, want domain.TrackerErrorKind) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("expected error with kind %q, got nil", want)
+	}
+	var te *domain.TrackerError
+	if !errors.As(err, &te) {
+		t.Fatalf("error type = %T, want *domain.TrackerError", err)
+	}
+	if te.Kind != want {
+		t.Errorf("TrackerError.Kind = %q, want %q", te.Kind, want)
+	}
+}
+
+// newPreflightMux returns a ServeMux pre-registered with the two
+// construction-preflight routes (GET /api/v1/user, GET
+// /api/v1/repos/{owner}/{repo}) plus a catch-all that fails the test on any
+// unregistered request. Callers register only the routes their operation
+// under test exercises; an unexpected call (a write stub issuing a request, a
+// parent lookup that must never happen, or a stray second page) fails loudly
+// instead of receiving a silent 404.
+func newPreflightMux(t *testing.T) *http.ServeMux {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/v1/user", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write(loadFixture(t, "user.json")) //nolint:errcheck // test helper
+	})
+	mux.HandleFunc("GET /api/v1/repos/"+testOwner+"/"+testRepo, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{}`)) //nolint:errcheck // test helper
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+		w.WriteHeader(http.StatusNotFound)
+	})
+	return mux
+}
+
+// mustAdapter starts an httptest.Server for mux and constructs a
+// *GiteaAdapter against it, registering server cleanup. mux must already
+// carry the two construction-preflight routes; see [newPreflightMux].
+func mustAdapter(t *testing.T, mux *http.ServeMux) *GiteaAdapter {
+	t.Helper()
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	a, err := NewGiteaAdapter(validConfig(srv.URL))
+	if err != nil {
+		t.Fatalf("NewGiteaAdapter: %v", err)
+	}
+	return a.(*GiteaAdapter)
+}
+
+// buildBulkComments returns a JSON array of n gitea comment objects, ascending
+// by id and created_at, modeling the verified 60-comment single-response
+// shape without hand-authoring a repetitive fixture file.
+func buildBulkComments(t *testing.T, n int) []byte {
+	t.Helper()
+	comments := make([]map[string]any, n)
+	for i := range n {
+		comments[i] = map[string]any{
+			"id":         9000 + i,
+			"user":       map[string]string{"login": fmt.Sprintf("user%d", i)},
+			"body":       fmt.Sprintf("comment %d", i),
+			"created_at": fmt.Sprintf("2026-01-01T%02d:00:00Z", i%24),
+		}
+	}
+	data, err := json.Marshal(comments)
+	if err != nil {
+		t.Fatalf("marshal bulk comments: %v", err)
+	}
+	return data
+}
+
+// --- Constructor ---
+
+func TestNewGiteaAdapter(t *testing.T) {
+	t.Parallel()
+
+	t.Run("config errors fail before any network call", func(t *testing.T) {
+		t.Parallel()
+
+		tests := []struct {
+			name     string
+			config   map[string]any
+			wantKind domain.TrackerErrorKind
+		}{
+			{"missing api_key", map[string]any{"project": "acme/widgets", "endpoint": "http://localhost"}, domain.ErrMissingTrackerAPIKey},
+			{"empty api_key", map[string]any{"api_key": "", "project": "acme/widgets", "endpoint": "http://localhost"}, domain.ErrMissingTrackerAPIKey},
+			{"missing project", map[string]any{"api_key": "tok", "endpoint": "http://localhost"}, domain.ErrMissingTrackerProject},
+			{"empty project", map[string]any{"api_key": "tok", "project": "", "endpoint": "http://localhost"}, domain.ErrMissingTrackerProject},
+			{"project with no slash", map[string]any{"api_key": "tok", "project": "acmewidgets", "endpoint": "http://localhost"}, domain.ErrTrackerPayload},
+			{"project with two slashes", map[string]any{"api_key": "tok", "project": "acme/widgets/extra", "endpoint": "http://localhost"}, domain.ErrTrackerPayload},
+			{"project with empty owner", map[string]any{"api_key": "tok", "project": "/widgets", "endpoint": "http://localhost"}, domain.ErrTrackerPayload},
+			{"project with empty repo", map[string]any{"api_key": "tok", "project": "acme/", "endpoint": "http://localhost"}, domain.ErrTrackerPayload},
+			{"missing endpoint", map[string]any{"api_key": "tok", "project": "acme/widgets"}, domain.ErrTrackerPayload},
+			{"empty endpoint", map[string]any{"api_key": "tok", "project": "acme/widgets", "endpoint": ""}, domain.ErrTrackerPayload},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+
+				a, err := NewGiteaAdapter(tt.config)
+				assertTrackerErrorKind(t, err, tt.wantKind)
+				if a != nil {
+					t.Error("adapter should be nil on error")
+				}
+			})
+		}
+	})
+
+	t.Run("successful construction applies default state lists", func(t *testing.T) {
+		t.Parallel()
+
+		a := mustAdapter(t, newPreflightMux(t))
+
+		if a.owner != testOwner {
+			t.Errorf("owner = %q, want %q", a.owner, testOwner)
+		}
+		if a.repo != testRepo {
+			t.Errorf("repo = %q, want %q", a.repo, testRepo)
+		}
+		if len(a.activeStates) != 3 || a.activeStates[0] != "backlog" {
+			t.Errorf("activeStates = %v, want defaults starting with backlog", a.activeStates)
+		}
+		if len(a.terminalStates) != 2 || a.terminalStates[0] != "done" {
+			t.Errorf("terminalStates = %v, want defaults starting with done", a.terminalStates)
+		}
+		if a.handoffState != "" {
+			t.Errorf("handoffState = %q, want empty", a.handoffState)
+		}
+	})
+
+	t.Run("api/v1 suffix is appended exactly once regardless of source form", func(t *testing.T) {
+		t.Parallel()
+
+		tests := []struct {
+			name  string
+			build func(base string) string
+		}{
+			{"bare host", func(base string) string { return base }},
+			{"trailing slash", func(base string) string { return base + "/" }},
+			{"already suffixed", func(base string) string { return base + "/api/v1" }},
+			{"already suffixed with trailing slash", func(base string) string { return base + "/api/v1/" }},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+
+				srv := httptest.NewServer(newPreflightMux(t))
+				defer srv.Close()
+
+				cfg := validConfig(tt.build(srv.URL))
+				if _, err := NewGiteaAdapter(cfg); err != nil {
+					t.Fatalf("NewGiteaAdapter(endpoint=%q): %v", cfg["endpoint"], err)
+				}
+			})
+		}
+	})
+
+	t.Run("custom state lists are lowercased and handoff_state is trimmed", func(t *testing.T) {
+		t.Parallel()
+
+		srv := httptest.NewServer(newPreflightMux(t))
+		defer srv.Close()
+
+		cfg := validConfig(srv.URL)
+		cfg["active_states"] = []any{"Todo", "IN-PROGRESS"}
+		cfg["terminal_states"] = []string{"Done", "WONTFIX"}
+		cfg["handoff_state"] = "  Review  "
+
+		a, err := NewGiteaAdapter(cfg)
+		if err != nil {
+			t.Fatalf("NewGiteaAdapter: %v", err)
+		}
+		ga := a.(*GiteaAdapter)
+
+		if ga.activeStates[0] != "todo" || ga.activeStates[1] != "in-progress" {
+			t.Errorf("activeStates = %v, want [todo in-progress]", ga.activeStates)
+		}
+		if ga.terminalStates[0] != "done" || ga.terminalStates[1] != "wontfix" {
+			t.Errorf("terminalStates = %v, want [done wontfix]", ga.terminalStates)
+		}
+		if ga.handoffState != "review" {
+			t.Errorf("handoffState = %q, want %q (trimmed and lowercased)", ga.handoffState, "review")
+		}
+	})
+
+	t.Run("does not mutate caller-supplied state slices", func(t *testing.T) {
+		t.Parallel()
+
+		srv := httptest.NewServer(newPreflightMux(t))
+		defer srv.Close()
+
+		cfg := validConfig(srv.URL)
+		cfg["active_states"] = []string{"InProgress", "Review"}
+		cfg["terminal_states"] = []string{"Done", "WontFix"}
+
+		if _, err := NewGiteaAdapter(cfg); err != nil {
+			t.Fatalf("NewGiteaAdapter: %v", err)
+		}
+
+		active := cfg["active_states"].([]string)
+		if active[0] != "InProgress" || active[1] != "Review" {
+			t.Errorf("active_states mutated: got %v, want original casing preserved", active)
+		}
+		terminal := cfg["terminal_states"].([]string)
+		if terminal[0] != "Done" || terminal[1] != "WontFix" {
+			t.Errorf("terminal_states mutated: got %v, want original casing preserved", terminal)
+		}
+	})
+
+	t.Run("preflight failure blocks construction", func(t *testing.T) {
+		t.Parallel()
+
+		mux := http.NewServeMux()
+		mux.HandleFunc("GET /api/v1/user", func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+			w.Write(loadFixture(t, "error_401.json")) //nolint:errcheck // test helper
+		})
+		srv := httptest.NewServer(mux)
+		defer srv.Close()
+
+		a, err := NewGiteaAdapter(validConfig(srv.URL))
+		assertTrackerErrorKind(t, err, domain.ErrTrackerAuth)
+		if a != nil {
+			t.Error("adapter should be nil when the preflight fails")
+		}
+	})
+}
+
+// --- Registration ---
+
+func TestGiteaAdapterRegistration(t *testing.T) {
+	t.Parallel()
+
+	if !registry.Trackers.Has("gitea") {
+		t.Fatal(`Trackers.Has("gitea") = false, want true`)
+	}
+	if _, err := registry.Trackers.Get("gitea"); err != nil {
+		t.Errorf(`Trackers.Get("gitea") = %v, want registered constructor`, err)
+	}
+}
+
+// --- paginateIssues ---
+
+func TestPaginateIssues(t *testing.T) {
+	t.Parallel()
+
+	t.Run("follows Link headers across pages below the requested cap", func(t *testing.T) {
+		t.Parallel()
+
+		page1 := loadFixture(t, "issues_paginate_page1.json") // 2 items
+		page2 := loadFixture(t, "issues_paginate_page2.json") // 2 items
+		page3 := loadFixture(t, "issues_paginate_page3.json") // 1 item
+
+		var srvURL string
+		var calls atomic.Int32
+		mux := newPreflightMux(t)
+		basePath := "/api/v1/repos/" + testOwner + "/" + testRepo + "/issues"
+		mux.HandleFunc("GET "+basePath, func(w http.ResponseWriter, r *http.Request) {
+			n := calls.Add(1)
+			switch n {
+			case 1:
+				w.Header().Set("Link", fmt.Sprintf(`<%s%s?page=2>; rel="next"`, srvURL, basePath))
+				w.WriteHeader(http.StatusOK)
+				w.Write(page1) //nolint:errcheck // test helper
+			case 2:
+				w.Header().Set("Link", fmt.Sprintf(`<%s%s?page=3>; rel="next"`, srvURL, basePath))
+				w.WriteHeader(http.StatusOK)
+				w.Write(page2) //nolint:errcheck // test helper
+			default:
+				w.WriteHeader(http.StatusOK)
+				w.Write(page3) //nolint:errcheck // test helper
+			}
+		})
+		srv := httptest.NewServer(mux)
+		defer srv.Close()
+		srvURL = srv.URL
+
+		a, err := NewGiteaAdapter(validConfig(srv.URL))
+		if err != nil {
+			t.Fatalf("NewGiteaAdapter: %v", err)
+		}
+		ga := a.(*GiteaAdapter)
+
+		items, err := ga.paginateIssues(context.Background(), "/repos/"+testOwner+"/"+testRepo+"/issues", url.Values{"limit": {"50"}})
+		if err != nil {
+			t.Fatalf("paginateIssues: %v", err)
+		}
+		if len(items) != 5 {
+			t.Fatalf("len = %d, want 5 across 3 pages, each well below the requested limit=50", len(items))
+		}
+		if got := calls.Load(); got != 3 {
+			t.Errorf("call count = %d, want 3 (one per page)", got)
+		}
+	})
+
+	t.Run("single page with no Link header stops after one request", func(t *testing.T) {
+		t.Parallel()
+
+		var calls atomic.Int32
+		mux := newPreflightMux(t)
+		mux.HandleFunc("GET /api/v1/repos/"+testOwner+"/"+testRepo+"/issues", func(w http.ResponseWriter, r *http.Request) {
+			calls.Add(1)
+			w.WriteHeader(http.StatusOK)
+			w.Write(loadFixture(t, "issues_paginate_page3.json")) //nolint:errcheck // test helper
+		})
+		a := mustAdapter(t, mux)
+
+		items, err := a.paginateIssues(context.Background(), "/repos/"+testOwner+"/"+testRepo+"/issues", url.Values{"limit": {"50"}})
+		if err != nil {
+			t.Fatalf("paginateIssues: %v", err)
+		}
+		if len(items) != 1 {
+			t.Errorf("len = %d, want 1", len(items))
+		}
+		if got := calls.Load(); got != 1 {
+			t.Errorf("call count = %d, want 1 (no Link header means end of results)", got)
+		}
+	})
+
+	t.Run("max pages guard stops early and logs a warning", func(t *testing.T) {
+		t.Parallel()
+
+		var srvURL string
+		var calls atomic.Int32
+		mux := newPreflightMux(t)
+		basePath := "/api/v1/repos/" + testOwner + "/" + testRepo + "/issues"
+		mux.HandleFunc("GET "+basePath, func(w http.ResponseWriter, r *http.Request) {
+			n := calls.Add(1)
+			w.Header().Set("Link", fmt.Sprintf(`<%s%s?page=%d>; rel="next"`, srvURL, basePath, n+1))
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`[{"number":1,"state":"open","labels":[{"name":"backlog"}]}]`)) //nolint:errcheck // test helper
+		})
+		srv := httptest.NewServer(mux)
+		defer srv.Close()
+		srvURL = srv.URL
+
+		a, err := NewGiteaAdapter(validConfig(srv.URL))
+		if err != nil {
+			t.Fatalf("NewGiteaAdapter: %v", err)
+		}
+		ga := a.(*GiteaAdapter)
+
+		var buf bytes.Buffer
+		ga.log = slog.New(slog.NewTextHandler(&buf, nil))
+
+		items, err := ga.paginateIssues(context.Background(), "/repos/"+testOwner+"/"+testRepo+"/issues", url.Values{"limit": {"50"}})
+		if err != nil {
+			t.Fatalf("paginateIssues: %v", err)
+		}
+		if len(items) != maxPages {
+			t.Errorf("len = %d, want %d (maxPages cap)", len(items), maxPages)
+		}
+		if got := calls.Load(); int(got) != maxPages {
+			t.Errorf("call count = %d, want %d", got, maxPages)
+		}
+		if !strings.Contains(buf.String(), "pagination limit reached") {
+			t.Errorf("expected a WARN for the pagination limit\noutput: %s", buf.String())
+		}
+	})
+}
+
+// --- FetchCandidateIssues ---
+
+func TestFetchCandidateIssues(t *testing.T) {
+	t.Parallel()
+
+	t.Run("pagination to exhaustion, PR guard, terminal filter, and ascending resort", func(t *testing.T) {
+		t.Parallel()
+
+		page1 := loadFixture(t, "issues_candidates_page1.json") // #8 backlog, #6 PR
+		page2 := loadFixture(t, "issues_candidates_page2.json") // #1 backlog, #3 done, #2 in-progress
+
+		var srvURL string
+		var calls atomic.Int32
+		mux := newPreflightMux(t)
+		basePath := "/api/v1/repos/" + testOwner + "/" + testRepo + "/issues"
+		mux.HandleFunc("GET "+basePath, func(w http.ResponseWriter, r *http.Request) {
+			n := calls.Add(1)
+			if n == 1 {
+				w.Header().Set("Link", fmt.Sprintf(`<%s%s?page=2>; rel="next"`, srvURL, basePath))
+				w.WriteHeader(http.StatusOK)
+				w.Write(page1) //nolint:errcheck // test helper
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+			w.Write(page2) //nolint:errcheck // test helper
+		})
+		srv := httptest.NewServer(mux)
+		defer srv.Close()
+		srvURL = srv.URL
+
+		a, err := NewGiteaAdapter(validConfig(srv.URL))
+		if err != nil {
+			t.Fatalf("NewGiteaAdapter: %v", err)
+		}
+
+		issues, err := a.FetchCandidateIssues(context.Background())
+		if err != nil {
+			t.Fatalf("FetchCandidateIssues: %v", err)
+		}
+
+		// #6 (pull request) and #3 (done, terminal) are filtered out; #8, #1,
+		// #2 remain, re-sorted ascending by CreatedAt regardless of page order.
+		if len(issues) != 3 {
+			t.Fatalf("len = %d, want 3 (pull request and terminal issue filtered)", len(issues))
+		}
+		wantOrder := []string{"1", "2", "8"}
+		for i, want := range wantOrder {
+			if issues[i].Identifier != want {
+				t.Errorf("issues[%d].Identifier = %q, want %q (ascending CreatedAt order)", i, issues[i].Identifier, want)
+			}
+		}
+		if got := calls.Load(); got != 2 {
+			t.Errorf("call count = %d, want 2 (two pages)", got)
+		}
+	})
+
+	t.Run("qualifies DisplayID and nils Comments", func(t *testing.T) {
+		t.Parallel()
+
+		mux := newPreflightMux(t)
+		mux.HandleFunc("GET /api/v1/repos/"+testOwner+"/"+testRepo+"/issues", func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			w.Write(loadFixture(t, "issues_candidates_page2.json")) //nolint:errcheck // test helper
+		})
+		a := mustAdapter(t, mux)
+
+		issues, err := a.FetchCandidateIssues(context.Background())
+		if err != nil {
+			t.Fatalf("FetchCandidateIssues: %v", err)
+		}
+		if len(issues) == 0 {
+			t.Fatal("issues is empty, want at least one active issue")
+		}
+		for _, iss := range issues {
+			if iss.Comments != nil {
+				t.Errorf("issue %s: Comments = %v, want nil", iss.Identifier, iss.Comments)
+			}
+			want := testOwner + "/" + testRepo + "#" + iss.Identifier
+			if iss.DisplayID != want {
+				t.Errorf("issue %s: DisplayID = %q, want %q", iss.Identifier, iss.DisplayID, want)
+			}
+		}
+	})
+
+	t.Run("empty response returns non-nil empty slice", func(t *testing.T) {
+		t.Parallel()
+
+		mux := newPreflightMux(t)
+		mux.HandleFunc("GET /api/v1/repos/"+testOwner+"/"+testRepo+"/issues", func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte("[]")) //nolint:errcheck // test helper
+		})
+		a := mustAdapter(t, mux)
+
+		issues, err := a.FetchCandidateIssues(context.Background())
+		if err != nil {
+			t.Fatalf("FetchCandidateIssues: %v", err)
+		}
+		if issues == nil {
+			t.Fatal("issues is nil, want non-nil empty slice")
+		}
+		if len(issues) != 0 {
+			t.Errorf("len = %d, want 0", len(issues))
+		}
+	})
+
+	t.Run("auth error propagates", func(t *testing.T) {
+		t.Parallel()
+
+		mux := newPreflightMux(t)
+		mux.HandleFunc("GET /api/v1/repos/"+testOwner+"/"+testRepo+"/issues", func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+			w.Write(loadFixture(t, "error_401.json")) //nolint:errcheck // test helper
+		})
+		a := mustAdapter(t, mux)
+
+		_, err := a.FetchCandidateIssues(context.Background())
+		assertTrackerErrorKind(t, err, domain.ErrTrackerAuth)
+	})
+}
+
+// --- FetchIssuesByStates ---
+
+func TestFetchIssuesByStates(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty states short-circuits with no API call", func(t *testing.T) {
+		t.Parallel()
+
+		a := mustAdapter(t, newPreflightMux(t)) // no issues route registered; any call fails the test
+
+		issues, err := a.FetchIssuesByStates(context.Background(), []string{})
+		if err != nil {
+			t.Fatalf("FetchIssuesByStates: %v", err)
+		}
+		if issues == nil {
+			t.Fatal("issues is nil, want non-nil empty slice")
+		}
+		if len(issues) != 0 {
+			t.Errorf("len = %d, want 0", len(issues))
+		}
+	})
+
+	t.Run("requesting only an active state queries the open listing only", func(t *testing.T) {
+		t.Parallel()
+
+		mux := newPreflightMux(t)
+		var gotStates []string
+		mux.HandleFunc("GET /api/v1/repos/"+testOwner+"/"+testRepo+"/issues", func(w http.ResponseWriter, r *http.Request) {
+			state := r.URL.Query().Get("state")
+			gotStates = append(gotStates, state)
+			switch state {
+			case "open":
+				w.WriteHeader(http.StatusOK)
+				w.Write(loadFixture(t, "issues_open_by_states.json")) //nolint:errcheck // test helper
+			default:
+				t.Errorf("unexpected state query param: %q", state)
+				w.WriteHeader(http.StatusBadRequest)
+			}
+		})
+		a := mustAdapter(t, mux)
+
+		issues, err := a.FetchIssuesByStates(context.Background(), []string{"in-progress"})
+		if err != nil {
+			t.Fatalf("FetchIssuesByStates: %v", err)
+		}
+		if len(issues) != 1 {
+			t.Fatalf("len = %d, want 1 (only the in-progress issue)", len(issues))
+		}
+		if issues[0].Identifier != "10" {
+			t.Errorf("Identifier = %q, want %q", issues[0].Identifier, "10")
+		}
+		if len(gotStates) != 1 || gotStates[0] != "open" {
+			t.Errorf("state queries = %v, want exactly one open query", gotStates)
+		}
+	})
+
+	t.Run("requesting only a terminal state queries the closed listing only", func(t *testing.T) {
+		t.Parallel()
+
+		mux := newPreflightMux(t)
+		var gotStates []string
+		mux.HandleFunc("GET /api/v1/repos/"+testOwner+"/"+testRepo+"/issues", func(w http.ResponseWriter, r *http.Request) {
+			state := r.URL.Query().Get("state")
+			gotStates = append(gotStates, state)
+			switch state {
+			case "closed":
+				w.WriteHeader(http.StatusOK)
+				w.Write(loadFixture(t, "issues_closed_by_states.json")) //nolint:errcheck // test helper
+			default:
+				t.Errorf("unexpected state query param: %q", state)
+				w.WriteHeader(http.StatusBadRequest)
+			}
+		})
+		a := mustAdapter(t, mux)
+
+		issues, err := a.FetchIssuesByStates(context.Background(), []string{"done"})
+		if err != nil {
+			t.Fatalf("FetchIssuesByStates: %v", err)
+		}
+		if len(issues) != 1 {
+			t.Fatalf("len = %d, want 1 (only the done issue)", len(issues))
+		}
+		if issues[0].Identifier != "20" {
+			t.Errorf("Identifier = %q, want %q", issues[0].Identifier, "20")
+		}
+		if len(gotStates) != 1 || gotStates[0] != "closed" {
+			t.Errorf("state queries = %v, want exactly one closed query", gotStates)
+		}
+	})
+
+	t.Run("mixed request queries both the open and closed listings", func(t *testing.T) {
+		t.Parallel()
+
+		mux := newPreflightMux(t)
+		gotStates := make(map[string]bool)
+		mux.HandleFunc("GET /api/v1/repos/"+testOwner+"/"+testRepo+"/issues", func(w http.ResponseWriter, r *http.Request) {
+			state := r.URL.Query().Get("state")
+			gotStates[state] = true
+			switch state {
+			case "open":
+				w.WriteHeader(http.StatusOK)
+				w.Write(loadFixture(t, "issues_open_by_states.json")) //nolint:errcheck // test helper
+			case "closed":
+				w.WriteHeader(http.StatusOK)
+				w.Write(loadFixture(t, "issues_closed_by_states.json")) //nolint:errcheck // test helper
+			default:
+				t.Errorf("unexpected state query param: %q", state)
+				w.WriteHeader(http.StatusBadRequest)
+			}
+		})
+		a := mustAdapter(t, mux)
+
+		issues, err := a.FetchIssuesByStates(context.Background(), []string{"in-progress", "done"})
+		if err != nil {
+			t.Fatalf("FetchIssuesByStates: %v", err)
+		}
+		if len(issues) != 2 {
+			t.Fatalf("len = %d, want 2 (one from each listing)", len(issues))
+		}
+		if !gotStates["open"] || !gotStates["closed"] {
+			t.Errorf("state queries = %v, want both open and closed", gotStates)
+		}
+	})
+}
+
+// --- FetchIssueByID ---
+
+func TestFetchIssueByID(t *testing.T) {
+	t.Parallel()
+
+	t.Run("full population", func(t *testing.T) {
+		t.Parallel()
+
+		mux := newPreflightMux(t)
+		mux.HandleFunc("GET /api/v1/repos/"+testOwner+"/"+testRepo+"/issues/{index}", func(w http.ResponseWriter, r *http.Request) {
+			if got := r.PathValue("index"); got != "42" {
+				t.Errorf("unexpected issue index: %s", got)
+				w.WriteHeader(http.StatusNotFound)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+			w.Write(loadFixture(t, "issue_full.json")) //nolint:errcheck // test helper
+		})
+		mux.HandleFunc("GET /api/v1/repos/"+testOwner+"/"+testRepo+"/issues/42/dependencies", func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			w.Write(loadFixture(t, "dependencies_one.json")) //nolint:errcheck // test helper
+		})
+		var commentCalls atomic.Int32
+		mux.HandleFunc("GET /api/v1/repos/"+testOwner+"/"+testRepo+"/issues/42/comments", func(w http.ResponseWriter, r *http.Request) {
+			commentCalls.Add(1)
+			if r.URL.RawQuery != "" {
+				t.Errorf("comments request carried a query string %q, want none (unpaginated route)", r.URL.RawQuery)
+			}
+			w.WriteHeader(http.StatusOK)
+			w.Write(loadFixture(t, "comments_two.json")) //nolint:errcheck // test helper
+		})
+		mux.HandleFunc("GET /api/v1/repos/"+testOwner+"/"+testRepo+"/issues/42/parent", func(w http.ResponseWriter, r *http.Request) {
+			t.Error("parent request must not be issued: gitea has no parent concept")
+			w.WriteHeader(http.StatusNotFound)
+		})
+
+		a := mustAdapter(t, mux)
+		issue, err := a.FetchIssueByID(context.Background(), "42")
+		if err != nil {
+			t.Fatalf("FetchIssueByID: %v", err)
+		}
+
+		if issue.ID != "42" || issue.Identifier != "42" {
+			t.Errorf("ID/Identifier = %q/%q, want 42/42", issue.ID, issue.Identifier)
+		}
+		if want := testOwner + "/" + testRepo + "#42"; issue.DisplayID != want {
+			t.Errorf("DisplayID = %q, want %q", issue.DisplayID, want)
+		}
+		if issue.Parent != nil {
+			t.Errorf("Parent = %v, want nil", issue.Parent)
+		}
+		if len(issue.BlockedBy) != 1 || issue.BlockedBy[0].Identifier != "1" {
+			t.Errorf("BlockedBy = %v, want one blocker with Identifier 1", issue.BlockedBy)
+		}
+		if len(issue.Comments) != 2 {
+			t.Fatalf("Comments len = %d, want 2", len(issue.Comments))
+		}
+		if issue.Comments[0].Author != "alice" {
+			t.Errorf("Comments[0].Author = %q, want %q", issue.Comments[0].Author, "alice")
+		}
+		if got := commentCalls.Load(); got != 1 {
+			t.Errorf("comments request count = %d, want 1 (unpaginated, single request)", got)
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		t.Parallel()
+
+		mux := newPreflightMux(t)
+		mux.HandleFunc("GET /api/v1/repos/"+testOwner+"/"+testRepo+"/issues/{index}", func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+			w.Write(loadFixture(t, "error_404.json")) //nolint:errcheck // test helper
+		})
+		a := mustAdapter(t, mux)
+
+		_, err := a.FetchIssueByID(context.Background(), "999")
+		assertTrackerErrorKind(t, err, domain.ErrTrackerNotFound)
+	})
+
+	t.Run("pull request index maps to not found", func(t *testing.T) {
+		t.Parallel()
+
+		mux := newPreflightMux(t)
+		mux.HandleFunc("GET /api/v1/repos/"+testOwner+"/"+testRepo+"/issues/{index}", func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			w.Write(loadFixture(t, "issue_pr.json")) //nolint:errcheck // test helper
+		})
+		a := mustAdapter(t, mux)
+
+		_, err := a.FetchIssueByID(context.Background(), "6")
+		assertTrackerErrorKind(t, err, domain.ErrTrackerNotFound)
+	})
+}
+
+// --- FetchIssueComments ---
+
+func TestFetchIssueComments(t *testing.T) {
+	t.Parallel()
+
+	t.Run("single unpaginated request returns comments in order", func(t *testing.T) {
+		t.Parallel()
+
+		mux := newPreflightMux(t)
+		var calls atomic.Int32
+		mux.HandleFunc("GET /api/v1/repos/"+testOwner+"/"+testRepo+"/issues/42/comments", func(w http.ResponseWriter, r *http.Request) {
+			calls.Add(1)
+			if r.URL.RawQuery != "" {
+				t.Errorf("unexpected query string %q on the unpaginated comments route", r.URL.RawQuery)
+			}
+			w.WriteHeader(http.StatusOK)
+			w.Write(loadFixture(t, "comments_two.json")) //nolint:errcheck // test helper
+		})
+		a := mustAdapter(t, mux)
+
+		comments, err := a.FetchIssueComments(context.Background(), "42")
+		if err != nil {
+			t.Fatalf("FetchIssueComments: %v", err)
+		}
+		if len(comments) != 2 {
+			t.Fatalf("len = %d, want 2", len(comments))
+		}
+		if comments[0].Author != "alice" || comments[1].Author != "bob" {
+			t.Errorf("authors = [%s %s], want [alice bob]", comments[0].Author, comments[1].Author)
+		}
+		if got := calls.Load(); got != 1 {
+			t.Errorf("request count = %d, want 1 (comments route must never be followed for a second page)", got)
+		}
+	})
+
+	t.Run("60-comment response returns all comments from one request", func(t *testing.T) {
+		t.Parallel()
+
+		bulk := buildBulkComments(t, 60)
+		mux := newPreflightMux(t)
+		var calls atomic.Int32
+		mux.HandleFunc("GET /api/v1/repos/"+testOwner+"/"+testRepo+"/issues/5/comments", func(w http.ResponseWriter, r *http.Request) {
+			calls.Add(1)
+			w.Header().Set("X-Total-Count", "60")
+			w.WriteHeader(http.StatusOK)
+			w.Write(bulk) //nolint:errcheck // test helper
+		})
+		a := mustAdapter(t, mux)
+
+		comments, err := a.FetchIssueComments(context.Background(), "5")
+		if err != nil {
+			t.Fatalf("FetchIssueComments: %v", err)
+		}
+		if len(comments) != 60 {
+			t.Fatalf("len = %d, want 60", len(comments))
+		}
+		if got := calls.Load(); got != 1 {
+			t.Errorf("request count = %d, want 1 (no Link header, no pagination)", got)
+		}
+	})
+
+	t.Run("empty is a non-nil slice", func(t *testing.T) {
+		t.Parallel()
+
+		mux := newPreflightMux(t)
+		mux.HandleFunc("GET /api/v1/repos/"+testOwner+"/"+testRepo+"/issues/42/comments", func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte("[]")) //nolint:errcheck // test helper
+		})
+		a := mustAdapter(t, mux)
+
+		comments, err := a.FetchIssueComments(context.Background(), "42")
+		if err != nil {
+			t.Fatalf("FetchIssueComments: %v", err)
+		}
+		if comments == nil {
+			t.Fatal("comments is nil, want non-nil empty slice")
+		}
+		if len(comments) != 0 {
+			t.Errorf("len = %d, want 0", len(comments))
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		t.Parallel()
+
+		mux := newPreflightMux(t)
+		mux.HandleFunc("GET /api/v1/repos/"+testOwner+"/"+testRepo+"/issues/999/comments", func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+			w.Write(loadFixture(t, "error_404.json")) //nolint:errcheck // test helper
+		})
+		a := mustAdapter(t, mux)
+
+		_, err := a.FetchIssueComments(context.Background(), "999")
+		assertTrackerErrorKind(t, err, domain.ErrTrackerNotFound)
+	})
+}
+
+// --- FetchIssueStatesByIDs / FetchIssueStatesByIdentifiers ---
+
+func TestFetchIssueStatesByIDs(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty input returns empty map with no request", func(t *testing.T) {
+		t.Parallel()
+
+		a := mustAdapter(t, newPreflightMux(t))
+
+		states, err := a.FetchIssueStatesByIDs(context.Background(), []string{})
+		if err != nil {
+			t.Fatalf("FetchIssueStatesByIDs: %v", err)
+		}
+		if states == nil {
+			t.Fatal("states is nil, want non-nil empty map")
+		}
+		if len(states) != 0 {
+			t.Errorf("len = %d, want 0", len(states))
+		}
+	})
+
+	t.Run("404 and pull-request entries are omitted, found entries keep the derived state", func(t *testing.T) {
+		t.Parallel()
+
+		mux := newPreflightMux(t)
+		mux.HandleFunc("GET /api/v1/repos/"+testOwner+"/"+testRepo+"/issues/{index}", func(w http.ResponseWriter, r *http.Request) {
+			switch r.PathValue("index") {
+			case "1":
+				w.WriteHeader(http.StatusOK)
+				w.Write(loadFixture(t, "issue_full.json")) //nolint:errcheck // test helper (in-progress label)
+			case "6":
+				w.WriteHeader(http.StatusOK)
+				w.Write(loadFixture(t, "issue_pr.json")) //nolint:errcheck // test helper
+			default:
+				w.WriteHeader(http.StatusNotFound)
+				w.Write(loadFixture(t, "error_404.json")) //nolint:errcheck // test helper
+			}
+		})
+		a := mustAdapter(t, mux)
+
+		states, err := a.FetchIssueStatesByIDs(context.Background(), []string{"1", "6", "999"})
+		if err != nil {
+			t.Fatalf("FetchIssueStatesByIDs: %v", err)
+		}
+		if got, want := states["1"], "in-progress"; got != want {
+			t.Errorf(`states["1"] = %q, want %q`, got, want)
+		}
+		if _, ok := states["6"]; ok {
+			t.Error(`states["6"] present, want omitted (pull request)`)
+		}
+		if _, ok := states["999"]; ok {
+			t.Error(`states["999"] present, want omitted (not found)`)
+		}
+		if len(states) != 1 {
+			t.Errorf("len = %d, want 1", len(states))
+		}
+	})
+
+	t.Run("context cancellation between requests returns ctx.Err", func(t *testing.T) {
+		t.Parallel()
+
+		started := make(chan struct{})
+		mux := newPreflightMux(t)
+		mux.HandleFunc("GET /api/v1/repos/"+testOwner+"/"+testRepo+"/issues/{index}", func(w http.ResponseWriter, r *http.Request) {
+			close(started)
+			<-r.Context().Done()
+		})
+		a := mustAdapter(t, mux)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		errCh := make(chan error, 1)
+		go func() {
+			_, err := a.FetchIssueStatesByIDs(ctx, []string{"1", "2"})
+			errCh <- err
+		}()
+
+		<-started
+		cancel()
+
+		err := <-errCh
+		if !errors.Is(err, context.Canceled) {
+			t.Errorf("error = %v, want context.Canceled", err)
+		}
+	})
+}
+
+func TestFetchIssueStatesByIdentifiers(t *testing.T) {
+	t.Parallel()
+
+	// FetchIssueStatesByIdentifiers delegates to the same fetchStatesByIndexes
+	// helper as FetchIssueStatesByIDs (ID and Identifier are both the index);
+	// this proves the delegation rather than repeating every case above.
+	mux := newPreflightMux(t)
+	mux.HandleFunc("GET /api/v1/repos/"+testOwner+"/"+testRepo+"/issues/7", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"number":7,"state":"open","labels":[{"name":"review"}]}`)) //nolint:errcheck // test helper
+	})
+	a := mustAdapter(t, mux)
+
+	states, err := a.FetchIssueStatesByIdentifiers(context.Background(), []string{"7"})
+	if err != nil {
+		t.Fatalf("FetchIssueStatesByIdentifiers: %v", err)
+	}
+	if got, want := states["7"], "review"; got != want {
+		t.Errorf(`states["7"] = %q, want %q`, got, want)
+	}
+}
+
+// --- fetchBlockers ---
+
+func TestFetchBlockers(t *testing.T) {
+	t.Parallel()
+
+	t.Run("extracts blockers from the dependencies route", func(t *testing.T) {
+		t.Parallel()
+
+		mux := newPreflightMux(t)
+		mux.HandleFunc("GET /api/v1/repos/"+testOwner+"/"+testRepo+"/issues/42/dependencies", func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			w.Write(loadFixture(t, "dependencies_one.json")) //nolint:errcheck // test helper
+		})
+		a := mustAdapter(t, mux)
+
+		blockers, err := a.fetchBlockers(context.Background(), "42")
+		if err != nil {
+			t.Fatalf("fetchBlockers: %v", err)
+		}
+		if len(blockers) != 1 {
+			t.Fatalf("len = %d, want 1", len(blockers))
+		}
+		if blockers[0].ID != "1" || blockers[0].Identifier != "1" {
+			t.Errorf("blockers[0] ID/Identifier = %q/%q, want 1/1", blockers[0].ID, blockers[0].Identifier)
+		}
+		if blockers[0].State != "in-progress" {
+			t.Errorf("blockers[0].State = %q, want %q", blockers[0].State, "in-progress")
+		}
+	})
+
+	t.Run("404 is tolerated and returns a non-nil empty slice", func(t *testing.T) {
+		t.Parallel()
+
+		mux := newPreflightMux(t)
+		mux.HandleFunc("GET /api/v1/repos/"+testOwner+"/"+testRepo+"/issues/42/dependencies", func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+			w.Write(loadFixture(t, "error_404.json")) //nolint:errcheck // test helper
+		})
+		a := mustAdapter(t, mux)
+
+		blockers, err := a.fetchBlockers(context.Background(), "42")
+		if err != nil {
+			t.Fatalf("fetchBlockers should tolerate 404: %v", err)
+		}
+		if blockers == nil {
+			t.Fatal("blockers is nil, want non-nil empty slice")
+		}
+		if len(blockers) != 0 {
+			t.Errorf("len = %d, want 0", len(blockers))
+		}
+	})
+}
+
+// --- Write-path stubs ---
+
+func TestWriteStubs(t *testing.T) {
+	t.Parallel()
+
+	t.Run("TransitionIssue", func(t *testing.T) {
+		t.Parallel()
+
+		a := mustAdapter(t, newPreflightMux(t)) // no write routes registered; any call fails the test
+		err := a.TransitionIssue(context.Background(), "1", "done")
+		assertTrackerErrorKind(t, err, domain.ErrTrackerPayload)
+	})
+
+	t.Run("CommentIssue", func(t *testing.T) {
+		t.Parallel()
+
+		a := mustAdapter(t, newPreflightMux(t))
+		err := a.CommentIssue(context.Background(), "1", "hello")
+		assertTrackerErrorKind(t, err, domain.ErrTrackerPayload)
+	})
+
+	t.Run("AddLabel", func(t *testing.T) {
+		t.Parallel()
+
+		a := mustAdapter(t, newPreflightMux(t))
+		err := a.AddLabel(context.Background(), "1", "bug")
+		assertTrackerErrorKind(t, err, domain.ErrTrackerPayload)
+	})
+}

--- a/internal/scm/gitea/normalize.go
+++ b/internal/scm/gitea/normalize.go
@@ -1,0 +1,135 @@
+package gitea
+
+import (
+	"log/slog"
+	"strconv"
+
+	"github.com/sortie-ai/sortie/internal/domain"
+	"github.com/sortie-ai/sortie/internal/issuekit"
+)
+
+// giteaIssue is one issue from the Gitea REST API issue routes. The read path
+// decodes only the fields it consumes; unmodeled wire fields are ignored.
+type giteaIssue struct {
+	Number      int          `json:"number"`
+	Title       string       `json:"title"`
+	Body        string       `json:"body"`
+	State       string       `json:"state"`
+	Ref         string       `json:"ref"`
+	HTMLURL     string       `json:"html_url"`
+	Labels      []giteaLabel `json:"labels"`
+	Assignees   []giteaUser  `json:"assignees"`
+	PullRequest *giteaPR     `json:"pull_request"`
+	CreatedAt   string       `json:"created_at"`
+	UpdatedAt   string       `json:"updated_at"`
+}
+
+// giteaLabel carries the label name the read path consumes.
+type giteaLabel struct {
+	Name string `json:"name"`
+}
+
+// giteaUser carries the login used for assignee, comment author, and the
+// credential-check identity.
+type giteaUser struct {
+	Login string `json:"login"`
+}
+
+// giteaComment is one comment from the issue comments route.
+type giteaComment struct {
+	ID        int64     `json:"id"`
+	User      giteaUser `json:"user"`
+	Body      string    `json:"body"`
+	CreatedAt string    `json:"created_at"`
+}
+
+// giteaPR is a marker: a non-nil pointer identifies a pull request rather than
+// an issue.
+type giteaPR struct{}
+
+// giteaErrorBody is the uniform Gitea API error envelope.
+type giteaErrorBody struct {
+	Message string `json:"message"`
+}
+
+// normalizeIssue maps a Gitea API issue response to a [domain.Issue]. ID and
+// Identifier are both set to the repo-scoped index; the global id is never used.
+// Parent and Comments remain nil; BlockedBy is a non-nil empty slice.
+//
+// DisplayID is left empty; callers apply [setDisplayID] after normalization.
+// The state lists and log are threaded to [deriveState].
+func normalizeIssue(gi giteaIssue, activeStates, terminalStates []string, handoffState string, log *slog.Logger) domain.Issue {
+	num := strconv.Itoa(gi.Number)
+
+	labelNames := make([]string, 0, len(gi.Labels))
+	for _, l := range gi.Labels {
+		labelNames = append(labelNames, l.Name)
+	}
+
+	assignee := ""
+	if len(gi.Assignees) > 0 {
+		assignee = gi.Assignees[0].Login
+	}
+
+	return domain.Issue{
+		ID:          num,
+		Identifier:  num,
+		Title:       gi.Title,
+		Description: gi.Body,
+		State:       deriveState(gi.Labels, gi.State, activeStates, terminalStates, handoffState, num, log),
+		BranchName:  gi.Ref,
+		URL:         gi.HTMLURL,
+		Labels:      issuekit.NormalizeLabels(labelNames),
+		Assignee:    assignee,
+		BlockedBy:   []domain.BlockerRef{},
+		CreatedAt:   gi.CreatedAt,
+		UpdatedAt:   gi.UpdatedAt,
+	}
+}
+
+// setDisplayID sets issue.DisplayID to "owner/repo#N" so dashboard and API
+// consumers see a fully qualified reference. It is idempotent: an
+// already-qualified DisplayID is not overwritten.
+func setDisplayID(issue *domain.Issue, owner, repo string) {
+	if issue.DisplayID != "" {
+		return
+	}
+	issue.DisplayID = owner + "/" + repo + "#" + issue.Identifier
+}
+
+// normalizeComments converts Gitea comment responses to [domain.Comment]
+// values. Returns a non-nil empty slice when input is empty.
+func normalizeComments(raw []giteaComment) []domain.Comment {
+	source := make([]issuekit.SourceComment, len(raw))
+	for i, c := range raw {
+		source[i] = issuekit.SourceComment{
+			ID:        strconv.FormatInt(c.ID, 10),
+			Author:    c.User.Login,
+			Body:      c.Body,
+			CreatedAt: c.CreatedAt,
+		}
+	}
+	return issuekit.NormalizeComments(source)
+}
+
+// normalizeBlockers converts blocker issue responses to [domain.BlockerRef]
+// values. Returns a non-nil empty slice when input is empty. Each blocker's
+// state is derived from its labels and native state.
+func normalizeBlockers(blockers []giteaIssue, activeStates, terminalStates []string, handoffState string, log *slog.Logger) []domain.BlockerRef {
+	refs := make([]domain.BlockerRef, 0, len(blockers))
+	for _, b := range blockers {
+		num := strconv.Itoa(b.Number)
+		refs = append(refs, domain.BlockerRef{
+			ID:         num,
+			Identifier: num,
+			State:      deriveState(b.Labels, b.State, activeStates, terminalStates, handoffState, num, log),
+		})
+	}
+	return refs
+}
+
+// isPullRequest reports whether the Gitea API entry represents a pull request
+// rather than an issue.
+func isPullRequest(gi giteaIssue) bool {
+	return gi.PullRequest != nil
+}

--- a/internal/scm/gitea/normalize.go
+++ b/internal/scm/gitea/normalize.go
@@ -88,8 +88,8 @@ func normalizeIssue(gi giteaIssue, activeStates, terminalStates []string, handof
 }
 
 // setDisplayID sets issue.DisplayID to "owner/repo#N" so dashboard and API
-// consumers see a fully qualified reference. It is idempotent: an
-// already-qualified DisplayID is not overwritten.
+// consumers see a fully qualified reference. It is idempotent: a DisplayID
+// that is already set is not overwritten.
 func setDisplayID(issue *domain.Issue, owner, repo string) {
 	if issue.DisplayID != "" {
 		return

--- a/internal/scm/gitea/normalize_test.go
+++ b/internal/scm/gitea/normalize_test.go
@@ -1,0 +1,312 @@
+package gitea
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/sortie-ai/sortie/internal/domain"
+)
+
+func TestNormalizeIssue_AllFields(t *testing.T) {
+	t.Parallel()
+
+	raw := loadFixture(t, "issue_full.json")
+	var gi giteaIssue
+	if err := json.Unmarshal(raw, &gi); err != nil {
+		t.Fatalf("json.Unmarshal(issue_full.json): %v", err)
+	}
+
+	active := []string{"backlog", "in-progress", "review"}
+	terminal := []string{"done", "wontfix"}
+
+	got := normalizeIssue(gi, active, terminal, "", nil)
+
+	// issue_full.json carries number=42 and a distinct global id=9042; the
+	// global id must never surface in ID, Identifier, or DisplayID.
+	if got.ID != "42" {
+		t.Errorf("ID = %q, want %q (from number, never the global id)", got.ID, "42")
+	}
+	if got.Identifier != "42" {
+		t.Errorf("Identifier = %q, want %q", got.Identifier, "42")
+	}
+	if got.Title != "Add dark mode support" {
+		t.Errorf("Title = %q, want %q", got.Title, "Add dark mode support")
+	}
+	if got.Description != "Users want a **dark mode** option." {
+		t.Errorf("Description = %q, want %q", got.Description, "Users want a **dark mode** option.")
+	}
+	if got.Priority != nil {
+		t.Errorf("Priority = %v, want nil (gitea has no priority field)", got.Priority)
+	}
+	if got.State != "in-progress" {
+		t.Errorf("State = %q, want %q", got.State, "in-progress")
+	}
+	if got.BranchName != "feature/dark-mode" {
+		t.Errorf("BranchName = %q, want %q", got.BranchName, "feature/dark-mode")
+	}
+	if got.URL != "https://git.example.com/acme/widgets/issues/42" {
+		t.Errorf("URL = %q, want the html_url value", got.URL)
+	}
+	if len(got.Labels) != 2 || got.Labels[0] != "in-progress" || got.Labels[1] != "ui" {
+		t.Errorf("Labels = %v, want [in-progress ui]", got.Labels)
+	}
+	if got.Assignee != "alice" {
+		t.Errorf("Assignee = %q, want %q (from assignees[0], never the deprecated singular field)", got.Assignee, "alice")
+	}
+	if got.IssueType != "" {
+		t.Errorf("IssueType = %q, want empty (gitea has no issue-type concept)", got.IssueType)
+	}
+	if got.Parent != nil {
+		t.Errorf("Parent = %v, want nil", got.Parent)
+	}
+	if got.Comments != nil {
+		t.Errorf("Comments = %v, want nil (normalizeIssue never fetches comments)", got.Comments)
+	}
+	if got.BlockedBy == nil {
+		t.Error("BlockedBy is nil, want non-nil empty slice")
+	}
+	if len(got.BlockedBy) != 0 {
+		t.Errorf("BlockedBy len = %d, want 0", len(got.BlockedBy))
+	}
+	if got.CreatedAt != "2026-01-01T00:00:00Z" {
+		t.Errorf("CreatedAt = %q, want %q", got.CreatedAt, "2026-01-01T00:00:00Z")
+	}
+	if got.UpdatedAt != "2026-01-02T00:00:00Z" {
+		t.Errorf("UpdatedAt = %q, want %q", got.UpdatedAt, "2026-01-02T00:00:00Z")
+	}
+	if got.DisplayID != "" {
+		t.Errorf("DisplayID = %q, want empty (callers apply setDisplayID)", got.DisplayID)
+	}
+}
+
+func TestGiteaIssue_NullBodyDecodesToEmptyString(t *testing.T) {
+	t.Parallel()
+
+	var gi giteaIssue
+	if err := json.Unmarshal([]byte(`{"number":1,"state":"open","body":null}`), &gi); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+	if gi.Body != "" {
+		t.Errorf("Body = %q, want empty string for a JSON null body", gi.Body)
+	}
+}
+
+func TestNormalizeIssue_LabelsLowercased(t *testing.T) {
+	t.Parallel()
+
+	gi := giteaIssue{
+		Number: 1,
+		State:  "open",
+		Labels: []giteaLabel{{Name: "BACKLOG"}, {Name: "Priority-High"}},
+	}
+	got := normalizeIssue(gi, []string{"backlog"}, nil, "", nil)
+
+	if len(got.Labels) != 2 {
+		t.Fatalf("Labels len = %d, want 2", len(got.Labels))
+	}
+	if got.Labels[0] != "backlog" {
+		t.Errorf("Labels[0] = %q, want %q", got.Labels[0], "backlog")
+	}
+	if got.Labels[1] != "priority-high" {
+		t.Errorf("Labels[1] = %q, want %q", got.Labels[1], "priority-high")
+	}
+}
+
+func TestNormalizeIssue_NonNilEmptyLabels(t *testing.T) {
+	t.Parallel()
+
+	gi := giteaIssue{Number: 1, State: "open", Labels: nil}
+	got := normalizeIssue(gi, nil, nil, "", nil)
+
+	if got.Labels == nil {
+		t.Error("Labels is nil, want non-nil empty slice")
+	}
+	if len(got.Labels) != 0 {
+		t.Errorf("Labels len = %d, want 0", len(got.Labels))
+	}
+}
+
+func TestNormalizeIssue_EmptyAssignees(t *testing.T) {
+	t.Parallel()
+
+	gi := giteaIssue{Number: 1, State: "open", Assignees: nil}
+	got := normalizeIssue(gi, nil, nil, "", nil)
+
+	if got.Assignee != "" {
+		t.Errorf("Assignee = %q, want empty string for no assignees", got.Assignee)
+	}
+}
+
+func TestNormalizeIssue_MultipleAssignees(t *testing.T) {
+	t.Parallel()
+
+	gi := giteaIssue{
+		Number:    1,
+		State:     "open",
+		Assignees: []giteaUser{{Login: "alice"}, {Login: "bob"}},
+	}
+	got := normalizeIssue(gi, nil, nil, "", nil)
+
+	if got.Assignee != "alice" {
+		t.Errorf("Assignee = %q, want first assignee %q", got.Assignee, "alice")
+	}
+}
+
+func TestNormalizeIssue_NilPriority(t *testing.T) {
+	t.Parallel()
+
+	gi := giteaIssue{Number: 1, State: "open"}
+	got := normalizeIssue(gi, nil, nil, "", nil)
+
+	if got.Priority != nil {
+		t.Errorf("Priority = %v, want nil (gitea has no priority field)", got.Priority)
+	}
+}
+
+func TestSetDisplayID(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		owner  string
+		repo   string
+		before string
+		want   string
+	}{
+		{"standard owner/repo#N format", "acme", "widgets", "", "acme/widgets#9"},
+		{"dotted repo name", "sortie-ai", "sortie.test", "", "sortie-ai/sortie.test#9"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			issue := domain.Issue{ID: "9", Identifier: "9", DisplayID: tt.before}
+			setDisplayID(&issue, tt.owner, tt.repo)
+
+			if issue.DisplayID != tt.want {
+				t.Errorf("setDisplayID(owner=%q, repo=%q) DisplayID = %q, want %q", tt.owner, tt.repo, issue.DisplayID, tt.want)
+			}
+		})
+	}
+
+	t.Run("idempotent: does not overwrite an already-qualified DisplayID", func(t *testing.T) {
+		t.Parallel()
+
+		issue := domain.Issue{ID: "9", Identifier: "9", DisplayID: "already/qualified#9"}
+		setDisplayID(&issue, "acme", "widgets")
+
+		if issue.DisplayID != "already/qualified#9" {
+			t.Errorf("setDisplayID overwrote an existing DisplayID: got %q, want %q", issue.DisplayID, "already/qualified#9")
+		}
+	})
+}
+
+func TestNormalizeComments_NonEmpty(t *testing.T) {
+	t.Parallel()
+
+	comments := []giteaComment{
+		{ID: 9001, User: giteaUser{Login: "alice"}, Body: "Looks good!", CreatedAt: "2026-01-15T10:00:00Z"},
+		{ID: 9002, User: giteaUser{Login: "bob"}, Body: "Fix indentation.", CreatedAt: "2026-01-16T11:30:00Z"},
+	}
+
+	got := normalizeComments(comments)
+
+	if len(got) != 2 {
+		t.Fatalf("normalizeComments len = %d, want 2", len(got))
+	}
+	if got[0].ID != "9001" {
+		t.Errorf("got[0].ID = %q, want %q", got[0].ID, "9001")
+	}
+	if got[0].Author != "alice" {
+		t.Errorf("got[0].Author = %q, want %q", got[0].Author, "alice")
+	}
+	if got[0].Body != "Looks good!" {
+		t.Errorf("got[0].Body = %q", got[0].Body)
+	}
+	if got[0].CreatedAt != "2026-01-15T10:00:00Z" {
+		t.Errorf("got[0].CreatedAt = %q", got[0].CreatedAt)
+	}
+	if got[1].ID != "9002" {
+		t.Errorf("got[1].ID = %q, want %q", got[1].ID, "9002")
+	}
+}
+
+func TestNormalizeComments_EmptyReturnsNonNilSlice(t *testing.T) {
+	t.Parallel()
+
+	got := normalizeComments(nil)
+
+	if got == nil {
+		t.Error("normalizeComments(nil) returned nil, want non-nil empty slice")
+	}
+	if len(got) != 0 {
+		t.Errorf("len = %d, want 0", len(got))
+	}
+}
+
+func TestNormalizeBlockers_NonEmpty(t *testing.T) {
+	t.Parallel()
+
+	blockers := []giteaIssue{
+		{Number: 5, State: "open", Labels: []giteaLabel{{Name: "in-progress"}}},
+		{Number: 6, State: "closed", Labels: []giteaLabel{{Name: "done"}}},
+	}
+	active := []string{"backlog", "in-progress", "review"}
+	terminal := []string{"done", "wontfix"}
+
+	got := normalizeBlockers(blockers, active, terminal, "", nil)
+
+	if len(got) != 2 {
+		t.Fatalf("normalizeBlockers len = %d, want 2", len(got))
+	}
+	if got[0].ID != "5" || got[0].Identifier != "5" {
+		t.Errorf("got[0] ID/Identifier = %q/%q, want 5/5", got[0].ID, got[0].Identifier)
+	}
+	if got[0].State != "in-progress" {
+		t.Errorf("got[0].State = %q, want %q", got[0].State, "in-progress")
+	}
+	if got[1].ID != "6" {
+		t.Errorf("got[1].ID = %q, want %q", got[1].ID, "6")
+	}
+	if got[1].State != "done" {
+		t.Errorf("got[1].State = %q, want %q", got[1].State, "done")
+	}
+}
+
+func TestNormalizeBlockers_EmptyReturnsNonNilSlice(t *testing.T) {
+	t.Parallel()
+
+	got := normalizeBlockers(nil, nil, nil, "", nil)
+
+	if got == nil {
+		t.Error("normalizeBlockers(nil) returned nil, want non-nil empty slice")
+	}
+	if len(got) != 0 {
+		t.Errorf("len = %d, want 0", len(got))
+	}
+}
+
+func TestIsPullRequest(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		gi   giteaIssue
+		want bool
+	}{
+		{"pull_request field set is a PR", giteaIssue{Number: 1, PullRequest: &giteaPR{}}, true},
+		{"pull_request field nil is an issue", giteaIssue{Number: 2, PullRequest: nil}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := isPullRequest(tt.gi)
+			if got != tt.want {
+				t.Errorf("isPullRequest(%v) = %v, want %v", tt.gi, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/scm/gitea/preflight.go
+++ b/internal/scm/gitea/preflight.go
@@ -21,8 +21,9 @@ var preflightBackoff = []time.Duration{time.Second, 2 * time.Second, 4 * time.Se
 //
 // A config error (401 or 403 auth, 404 not found) fails construction
 // immediately; a transient error (5xx or transport) is retried with the bounded
-// backoff. The returned user login is not consumed on the read path. It returns
-// a classified [*domain.TrackerError], never a raw error.
+// backoff. The returned user login is not consumed on the read path. Failures
+// return a classified [*domain.TrackerError], except that a context cancellation
+// or deadline surfaces as the context error.
 func runPreflight(ctx context.Context, client *httpkit.Client, owner, repo string) error {
 	if err := withRetry(ctx, func() error {
 		body, _, err := client.Get(ctx, "/user", nil)

--- a/internal/scm/gitea/preflight.go
+++ b/internal/scm/gitea/preflight.go
@@ -1,0 +1,91 @@
+package gitea
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"time"
+
+	"github.com/sortie-ai/sortie/internal/domain"
+	"github.com/sortie-ai/sortie/internal/httpkit"
+)
+
+// preflightBackoff is the bounded exponential backoff applied to transient
+// preflight failures. A config error fails construction immediately with no
+// retry; these delays absorb a brief outage before construction fails.
+var preflightBackoff = []time.Duration{time.Second, 2 * time.Second, 4 * time.Second}
+
+// runPreflight validates the token and the configured repository before the
+// first poll. It runs GET /user (credential check) and GET /repos/{owner}/{repo}
+// (project check) through the same client the read methods use.
+//
+// A config error (401 or 403 auth, 404 not found) fails construction
+// immediately; a transient error (5xx or transport) is retried with the bounded
+// backoff. The returned user login is not consumed on the read path. It returns
+// a classified [*domain.TrackerError], never a raw error.
+func runPreflight(ctx context.Context, client *httpkit.Client, owner, repo string) error {
+	if err := withRetry(ctx, func() error {
+		body, _, err := client.Get(ctx, "/user", nil)
+		if err != nil {
+			return err
+		}
+		var user giteaUser
+		if err := json.Unmarshal(body, &user); err != nil {
+			return &domain.TrackerError{
+				Kind:    domain.ErrTrackerPayload,
+				Message: "failed to decode gitea user response",
+				Err:     err,
+			}
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	repoPath := "/repos/" + owner + "/" + repo
+	return withRetry(ctx, func() error {
+		_, _, err := client.Get(ctx, repoPath, nil)
+		return err
+	})
+}
+
+// withRetry runs fn, retrying transient tracker errors with the bounded
+// preflight backoff. Config errors return immediately without a retry.
+//
+// The backoff wait honors ctx: a cancellation during a backoff returns
+// ctx.Err() without waiting for the delay to elapse.
+func withRetry(ctx context.Context, fn func() error) error {
+	err := fn()
+	for attempt := 0; err != nil && attempt < len(preflightBackoff); attempt++ {
+		if !isRetryable(err) {
+			return err
+		}
+		if waitErr := sleepContext(ctx, preflightBackoff[attempt]); waitErr != nil {
+			return waitErr
+		}
+		err = fn()
+	}
+	return err
+}
+
+// sleepContext blocks for d or until ctx is cancelled, whichever comes first.
+// It returns ctx.Err() on cancellation and nil once the full delay elapses.
+func sleepContext(ctx context.Context, d time.Duration) error {
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+// isRetryable reports whether err is a tracker error whose kind is retryable.
+func isRetryable(err error) bool {
+	var te *domain.TrackerError
+	if !errors.As(err, &te) {
+		return false
+	}
+	return te.Kind.RetryClassification().Retryable
+}

--- a/internal/scm/gitea/preflight_test.go
+++ b/internal/scm/gitea/preflight_test.go
@@ -1,0 +1,316 @@
+package gitea
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/sortie-ai/sortie/internal/domain"
+)
+
+// fastPreflightBackoff replaces the package-level preflightBackoff with
+// near-zero delays for the duration of a test so a retry path does not sleep
+// for seconds, restoring the original schedule on cleanup.
+//
+// preflightBackoff is package-global, so no test that calls this (or any test
+// that otherwise reads or writes preflightBackoff) may run in parallel with
+// another such test: doing so races the shared slice under -race.
+func fastPreflightBackoff(t *testing.T) {
+	t.Helper()
+	original := preflightBackoff
+	preflightBackoff = []time.Duration{time.Microsecond, time.Microsecond, time.Microsecond}
+	t.Cleanup(func() { preflightBackoff = original })
+}
+
+func TestSleepContext(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns nil once the delay elapses", func(t *testing.T) {
+		t.Parallel()
+
+		if err := sleepContext(context.Background(), time.Microsecond); err != nil {
+			t.Fatalf("sleepContext(_, 1us) = %v, want nil", err)
+		}
+	})
+
+	t.Run("returns ctx.Err on cancellation without waiting the delay", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		err := sleepContext(ctx, time.Hour)
+		if !errors.Is(err, context.Canceled) {
+			t.Errorf("sleepContext(cancelled, 1h) = %v, want context.Canceled", err)
+		}
+	})
+}
+
+func TestIsRetryable(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"transport error is retryable", &domain.TrackerError{Kind: domain.ErrTrackerTransport}, true},
+		{"api error is retryable", &domain.TrackerError{Kind: domain.ErrTrackerAPI}, true},
+		{"auth error is not retryable", &domain.TrackerError{Kind: domain.ErrTrackerAuth}, false},
+		{"not found error is not retryable", &domain.TrackerError{Kind: domain.ErrTrackerNotFound}, false},
+		{"payload error is not retryable", &domain.TrackerError{Kind: domain.ErrTrackerPayload}, false},
+		{"non-tracker error is not retryable", errors.New("boom"), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := isRetryable(tt.err)
+			if got != tt.want {
+				t.Errorf("isRetryable(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestWithRetry and TestRunPreflight below all touch the package-level
+// preflightBackoff (directly or through withRetry's internal read of its
+// length), so none of their subtests call t.Parallel(); they run serially by
+// default, avoiding any race on the shared slice.
+
+func TestWithRetry(t *testing.T) {
+	t.Run("succeeds on first try", func(t *testing.T) {
+		var calls int
+		err := withRetry(context.Background(), func() error {
+			calls++
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("withRetry: %v", err)
+		}
+		if calls != 1 {
+			t.Errorf("call count = %d, want 1", calls)
+		}
+	})
+
+	t.Run("non-retryable error returns immediately without retry", func(t *testing.T) {
+		var calls int
+		err := withRetry(context.Background(), func() error {
+			calls++
+			return &domain.TrackerError{Kind: domain.ErrTrackerAuth, Message: "bad token"}
+		})
+		assertTrackerErrorKind(t, err, domain.ErrTrackerAuth)
+		if calls != 1 {
+			t.Errorf("call count = %d, want 1 (non-retryable must not retry)", calls)
+		}
+	})
+
+	t.Run("retryable error retries the full schedule then fails", func(t *testing.T) {
+		fastPreflightBackoff(t)
+
+		var calls int
+		err := withRetry(context.Background(), func() error {
+			calls++
+			return &domain.TrackerError{Kind: domain.ErrTrackerTransport, Message: "boom"}
+		})
+		assertTrackerErrorKind(t, err, domain.ErrTrackerTransport)
+
+		wantCalls := len(preflightBackoff) + 1
+		if calls != wantCalls {
+			t.Errorf("call count = %d, want %d (initial + one per backoff entry)", calls, wantCalls)
+		}
+	})
+
+	t.Run("retryable error then success recovers", func(t *testing.T) {
+		fastPreflightBackoff(t)
+
+		var calls int
+		err := withRetry(context.Background(), func() error {
+			calls++
+			if calls < 2 {
+				return &domain.TrackerError{Kind: domain.ErrTrackerAPI, Message: "rate limited"}
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("withRetry should recover after one transient failure: %v", err)
+		}
+		if calls != 2 {
+			t.Errorf("call count = %d, want 2 (one retry then success)", calls)
+		}
+	})
+
+	t.Run("cancellation during backoff returns ctx.Err without waiting the schedule", func(t *testing.T) {
+		// Uses the production backoff schedule deliberately: the context is
+		// already cancelled before the call, so sleepContext returns
+		// immediately regardless of the configured delay.
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		var calls int
+		err := withRetry(ctx, func() error {
+			calls++
+			return &domain.TrackerError{Kind: domain.ErrTrackerTransport, Message: "boom"}
+		})
+		if !errors.Is(err, context.Canceled) {
+			t.Errorf("withRetry error = %v, want context.Canceled", err)
+		}
+		if calls != 1 {
+			t.Errorf("call count = %d, want 1 (cancellation must stop before a retry)", calls)
+		}
+	})
+}
+
+// preflightServer builds an httptest.Server simulating the two preflight
+// routes, with independently controllable status codes and atomic call
+// counters for the user and repo checks.
+//
+// userSucceedFromCall, when set to a positive N, makes the user route ignore
+// userStatus and return 200 starting with the Nth call, so a transient-then-
+// recovers scenario is deterministic: no goroutine or timing race is needed
+// to "catch" the request between a failing attempt and a healthy retry.
+type preflightServer struct {
+	srv                 *httptest.Server
+	userStatus          atomic.Int32
+	repoStatus          atomic.Int32
+	userCalls           atomic.Int32
+	repoCalls           atomic.Int32
+	userSucceedFromCall atomic.Int32
+}
+
+func newPreflightServer(t *testing.T) *preflightServer {
+	t.Helper()
+	ps := &preflightServer{}
+	ps.userStatus.Store(http.StatusOK)
+	ps.repoStatus.Store(http.StatusOK)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/user", func(w http.ResponseWriter, r *http.Request) {
+		n := ps.userCalls.Add(1)
+		if threshold := ps.userSucceedFromCall.Load(); threshold > 0 && n >= threshold {
+			w.WriteHeader(http.StatusOK)
+			w.Write(loadFixture(t, "user.json")) //nolint:errcheck // test helper
+			return
+		}
+		status := int(ps.userStatus.Load())
+		w.WriteHeader(status)
+		if status == http.StatusOK {
+			w.Write(loadFixture(t, "user.json")) //nolint:errcheck // test helper
+		}
+	})
+	mux.HandleFunc("/repos/"+testOwner+"/"+testRepo, func(w http.ResponseWriter, r *http.Request) {
+		ps.repoCalls.Add(1)
+		w.WriteHeader(int(ps.repoStatus.Load()))
+	})
+
+	ps.srv = httptest.NewServer(mux)
+	t.Cleanup(ps.srv.Close)
+	return ps
+}
+
+func TestRunPreflight(t *testing.T) {
+	t.Run("succeeds when both routes return 200", func(t *testing.T) {
+		ps := newPreflightServer(t)
+		client := newGiteaClient(ps.srv.URL, "test-token", "sortie/test")
+
+		if err := runPreflight(context.Background(), client, testOwner, testRepo); err != nil {
+			t.Fatalf("runPreflight: %v", err)
+		}
+		if got := ps.userCalls.Load(); got != 1 {
+			t.Errorf("user calls = %d, want 1", got)
+		}
+		if got := ps.repoCalls.Load(); got != 1 {
+			t.Errorf("repo calls = %d, want 1", got)
+		}
+	})
+
+	t.Run("401 on user check is a non-retryable auth error", func(t *testing.T) {
+		ps := newPreflightServer(t)
+		ps.userStatus.Store(http.StatusUnauthorized)
+		client := newGiteaClient(ps.srv.URL, "test-token", "sortie/test")
+
+		err := runPreflight(context.Background(), client, testOwner, testRepo)
+		assertTrackerErrorKind(t, err, domain.ErrTrackerAuth)
+
+		if got := ps.userCalls.Load(); got != 1 {
+			t.Errorf("user calls = %d, want 1 (auth error must not retry)", got)
+		}
+		if got := ps.repoCalls.Load(); got != 0 {
+			t.Errorf("repo calls = %d, want 0 (repo check must not run after a failed user check)", got)
+		}
+	})
+
+	t.Run("404 on repo check is a non-retryable not-found error", func(t *testing.T) {
+		ps := newPreflightServer(t)
+		ps.repoStatus.Store(http.StatusNotFound)
+		client := newGiteaClient(ps.srv.URL, "test-token", "sortie/test")
+
+		err := runPreflight(context.Background(), client, testOwner, testRepo)
+		assertTrackerErrorKind(t, err, domain.ErrTrackerNotFound)
+
+		if got := ps.userCalls.Load(); got != 1 {
+			t.Errorf("user calls = %d, want 1", got)
+		}
+		if got := ps.repoCalls.Load(); got != 1 {
+			t.Errorf("repo calls = %d, want 1 (not-found error must not retry)", got)
+		}
+	})
+
+	t.Run("transient error on user check retries then fails", func(t *testing.T) {
+		fastPreflightBackoff(t)
+
+		ps := newPreflightServer(t)
+		ps.userStatus.Store(http.StatusInternalServerError)
+		client := newGiteaClient(ps.srv.URL, "test-token", "sortie/test")
+
+		err := runPreflight(context.Background(), client, testOwner, testRepo)
+		assertTrackerErrorKind(t, err, domain.ErrTrackerTransport)
+
+		wantCalls := int32(len(preflightBackoff) + 1)
+		if got := ps.userCalls.Load(); got != wantCalls {
+			t.Errorf("user calls = %d, want %d (initial + one per backoff entry)", got, wantCalls)
+		}
+	})
+
+	t.Run("transient error then success recovers", func(t *testing.T) {
+		fastPreflightBackoff(t)
+
+		ps := newPreflightServer(t)
+		ps.userStatus.Store(http.StatusServiceUnavailable)
+		ps.userSucceedFromCall.Store(2) // fails call 1, succeeds from call 2 onward
+		client := newGiteaClient(ps.srv.URL, "test-token", "sortie/test")
+
+		if err := runPreflight(context.Background(), client, testOwner, testRepo); err != nil {
+			t.Fatalf("runPreflight should recover after a transient failure: %v", err)
+		}
+		if got := ps.userCalls.Load(); got != 2 {
+			t.Errorf("user calls = %d, want 2 (one retry then success)", got)
+		}
+	})
+
+	t.Run("pre-cancelled context fails immediately with no request issued", func(t *testing.T) {
+		// A context cancelled before runPreflight is even called fails at the
+		// underlying http.Client.Do call itself, before any request reaches
+		// the server; cancellation mid-backoff (between a real attempt and
+		// its retry) is covered at the withRetry level in TestWithRetry.
+		ps := newPreflightServer(t)
+		ps.userStatus.Store(http.StatusInternalServerError)
+		client := newGiteaClient(ps.srv.URL, "test-token", "sortie/test")
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		err := runPreflight(ctx, client, testOwner, testRepo)
+		if !errors.Is(err, context.Canceled) {
+			t.Errorf("runPreflight error = %v, want context.Canceled", err)
+		}
+		if got := ps.userCalls.Load(); got != 0 {
+			t.Errorf("user calls = %d, want 0 (a pre-cancelled context must not reach the network)", got)
+		}
+	})
+}

--- a/internal/scm/gitea/state.go
+++ b/internal/scm/gitea/state.go
@@ -1,0 +1,63 @@
+package gitea
+
+import (
+	"log/slog"
+	"strings"
+)
+
+// deriveState resolves the Sortie state from a Gitea issue's labels by scanning
+// the configured active, terminal, and handoff states in config order. The
+// first label match wins. When no state label is present, it falls back to the
+// first configured state matching the native open/closed status, or passes the
+// native state through unchanged.
+//
+// The scan collects every matching state label before returning so an issue
+// carrying more than one configured state label is observable: deriveState logs
+// a WARN naming issueIndex and the matched labels, then keeps the first. If log
+// is nil, [slog.Default] is used. Label comparison is case-insensitive;
+// activeStates, terminalStates, and handoffState are expected already lowercased.
+func deriveState(labels []giteaLabel, nativeState string, activeStates, terminalStates []string, handoffState, issueIndex string, log *slog.Logger) string {
+	if log == nil {
+		log = slog.Default()
+	}
+
+	lowerSet := make(map[string]struct{}, len(labels))
+	for _, l := range labels {
+		lowerSet[strings.ToLower(l.Name)] = struct{}{}
+	}
+
+	matched := make([]string, 0, len(activeStates)+len(terminalStates)+1)
+	for _, s := range activeStates {
+		if _, ok := lowerSet[s]; ok {
+			matched = append(matched, s)
+		}
+	}
+	for _, s := range terminalStates {
+		if _, ok := lowerSet[s]; ok {
+			matched = append(matched, s)
+		}
+	}
+	if handoffState != "" {
+		if _, ok := lowerSet[handoffState]; ok {
+			matched = append(matched, handoffState)
+		}
+	}
+
+	if len(matched) > 1 {
+		log.Warn("kept first of multiple matching state labels",
+			slog.String("issue_index", issueIndex),
+			slog.Any("matched_labels", matched))
+	}
+	if len(matched) > 0 {
+		return matched[0]
+	}
+
+	if nativeState == "open" && len(activeStates) > 0 {
+		return activeStates[0]
+	}
+	if nativeState == "closed" && len(terminalStates) > 0 {
+		return terminalStates[0]
+	}
+
+	return nativeState
+}

--- a/internal/scm/gitea/state_test.go
+++ b/internal/scm/gitea/state_test.go
@@ -1,0 +1,199 @@
+package gitea
+
+import (
+	"bytes"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+func TestDeriveState(t *testing.T) {
+	t.Parallel()
+
+	active := []string{"backlog", "in-progress", "review"}
+	terminal := []string{"done", "wontfix"}
+
+	tests := []struct {
+		name           string
+		labels         []giteaLabel
+		nativeState    string
+		activeStates   []string
+		terminalStates []string
+		handoffState   string
+		want           string
+	}{
+		{
+			name:           "single active label match",
+			labels:         []giteaLabel{{Name: "in-progress"}},
+			nativeState:    "open",
+			activeStates:   active,
+			terminalStates: terminal,
+			want:           "in-progress",
+		},
+		{
+			name:           "single terminal label match",
+			labels:         []giteaLabel{{Name: "done"}},
+			nativeState:    "closed",
+			activeStates:   active,
+			terminalStates: terminal,
+			want:           "done",
+		},
+		{
+			// "backlog" precedes "review" in config order; backlog wins even
+			// though "review" appears first in the label slice.
+			name:           "multiple active labels first config-order wins",
+			labels:         []giteaLabel{{Name: "review"}, {Name: "backlog"}},
+			nativeState:    "open",
+			activeStates:   active,
+			terminalStates: terminal,
+			want:           "backlog",
+		},
+		{
+			// Active-state scan runs before the terminal-state scan.
+			name:           "active label beats terminal label",
+			labels:         []giteaLabel{{Name: "done"}, {Name: "backlog"}},
+			nativeState:    "open",
+			activeStates:   active,
+			terminalStates: terminal,
+			want:           "backlog",
+		},
+		{
+			name:           "no state labels open issue fallback first active",
+			labels:         []giteaLabel{{Name: "bug"}},
+			nativeState:    "open",
+			activeStates:   active,
+			terminalStates: terminal,
+			want:           "backlog",
+		},
+		{
+			name:           "no state labels closed issue fallback first terminal",
+			labels:         []giteaLabel{{Name: "bug"}},
+			nativeState:    "closed",
+			activeStates:   active,
+			terminalStates: terminal,
+			want:           "done",
+		},
+		{
+			name:           "empty config open passthrough native",
+			labels:         nil,
+			nativeState:    "open",
+			activeStates:   nil,
+			terminalStates: nil,
+			want:           "open",
+		},
+		{
+			name:           "empty config closed passthrough native",
+			labels:         nil,
+			nativeState:    "closed",
+			activeStates:   nil,
+			terminalStates: nil,
+			want:           "closed",
+		},
+		{
+			name:           "uppercase label matches lowercase config",
+			labels:         []giteaLabel{{Name: "IN-PROGRESS"}},
+			nativeState:    "open",
+			activeStates:   active,
+			terminalStates: terminal,
+			want:           "in-progress",
+		},
+		{
+			// A handoff label on an open issue must return the handoff
+			// state, not activeStates[0], so a handed-off issue is not
+			// re-dispatched as a fresh candidate.
+			name:           "handoff label only open issue",
+			labels:         []giteaLabel{{Name: "review"}},
+			nativeState:    "open",
+			activeStates:   []string{"backlog", "in-progress"},
+			terminalStates: []string{"done"},
+			handoffState:   "review",
+			want:           "review",
+		},
+		{
+			name:           "handoff label uppercase open issue",
+			labels:         []giteaLabel{{Name: "REVIEW"}},
+			nativeState:    "open",
+			activeStates:   []string{"backlog", "in-progress"},
+			terminalStates: []string{"done"},
+			handoffState:   "review",
+			want:           "review",
+		},
+		{
+			name:           "handoff not configured falls back to active",
+			labels:         []giteaLabel{{Name: "review"}},
+			nativeState:    "open",
+			activeStates:   []string{"backlog", "in-progress"},
+			terminalStates: []string{"done"},
+			handoffState:   "",
+			want:           "backlog",
+		},
+		{
+			// Active-state scan happens before the handoff check regardless
+			// of label order in the response.
+			name:           "active label beats handoff when both present",
+			labels:         []giteaLabel{{Name: "in-progress"}, {Name: "review"}},
+			nativeState:    "open",
+			activeStates:   []string{"backlog", "in-progress"},
+			terminalStates: []string{"done"},
+			handoffState:   "review",
+			want:           "in-progress",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := deriveState(tt.labels, tt.nativeState, tt.activeStates, tt.terminalStates, tt.handoffState, "1", nil)
+			if got != tt.want {
+				t.Errorf("deriveState(%v, %q) = %q, want %q", tt.labels, tt.nativeState, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDeriveState_MultiMatchLogsWarning(t *testing.T) {
+	t.Parallel()
+
+	// Two distinct configured labels on one issue (an active label and a
+	// terminal label), not a handoff overlap: this is the config-drift case
+	// the WARN exists to surface.
+	labels := []giteaLabel{{Name: "backlog"}, {Name: "done"}}
+	active := []string{"backlog", "in-progress"}
+	terminal := []string{"done", "wontfix"}
+
+	var buf bytes.Buffer
+	log := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	got := deriveState(labels, "open", active, terminal, "", "77", log)
+
+	// Active states are scanned before terminal states, so "backlog" is the
+	// first match and wins despite "done" also matching.
+	if got != "backlog" {
+		t.Errorf("deriveState(multi-match) = %q, want %q (first match by scan order)", got, "backlog")
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "kept first of multiple matching state labels") {
+		t.Errorf("log output missing multi-match WARN message\noutput: %s", output)
+	}
+	if !strings.Contains(output, "issue_index=77") {
+		t.Errorf("log output missing issue_index=77\noutput: %s", output)
+	}
+	if !strings.Contains(output, "backlog") || !strings.Contains(output, "done") {
+		t.Errorf("log output should name both matched labels (backlog, done)\noutput: %s", output)
+	}
+}
+
+func TestDeriveState_NilLoggerUsesDefaultWithoutPanic(t *testing.T) {
+	t.Parallel()
+
+	// A multi-match scenario with log=nil must fall back to slog.Default()
+	// rather than panic on a nil receiver.
+	labels := []giteaLabel{{Name: "backlog"}, {Name: "done"}}
+
+	got := deriveState(labels, "open", []string{"backlog"}, []string{"done"}, "", "1", nil)
+	if got != "backlog" {
+		t.Errorf("deriveState(nil logger) = %q, want %q", got, "backlog")
+	}
+}

--- a/internal/scm/gitea/testdata/comments_two.json
+++ b/internal/scm/gitea/testdata/comments_two.json
@@ -1,0 +1,16 @@
+[
+  {
+    "id": 9001,
+    "user": { "login": "alice" },
+    "body": "Looks good, please proceed.",
+    "created_at": "2026-01-15T10:00:00Z",
+    "updated_at": "2026-01-15T10:00:00Z"
+  },
+  {
+    "id": 9002,
+    "user": { "login": "bob" },
+    "body": "Please fix the indentation.",
+    "created_at": "2026-01-16T11:30:00Z",
+    "updated_at": "2026-01-16T11:30:00Z"
+  }
+]

--- a/internal/scm/gitea/testdata/dependencies_one.json
+++ b/internal/scm/gitea/testdata/dependencies_one.json
@@ -1,0 +1,16 @@
+[
+  {
+    "id": 500,
+    "number": 1,
+    "title": "Blocking dependency",
+    "body": null,
+    "state": "open",
+    "ref": "",
+    "html_url": "https://git.example.com/acme/widgets/issues/1",
+    "labels": [{ "id": 3, "name": "in-progress", "color": "00ff00" }],
+    "assignees": [],
+    "pull_request": null,
+    "created_at": "2025-12-01T00:00:00Z",
+    "updated_at": "2025-12-01T00:00:00Z"
+  }
+]

--- a/internal/scm/gitea/testdata/error_400.json
+++ b/internal/scm/gitea/testdata/error_400.json
@@ -1,0 +1,4 @@
+{
+  "message": "request body is invalid",
+  "url": "https://git.example.com/api/swagger"
+}

--- a/internal/scm/gitea/testdata/error_401.json
+++ b/internal/scm/gitea/testdata/error_401.json
@@ -1,0 +1,4 @@
+{
+  "message": "invalid username, password or token",
+  "url": "https://git.example.com/api/swagger"
+}

--- a/internal/scm/gitea/testdata/error_403.json
+++ b/internal/scm/gitea/testdata/error_403.json
@@ -1,0 +1,4 @@
+{
+  "message": "token does not have at least one of required scope(s), required=[read:user], token scope=write:issue",
+  "url": "https://git.example.com/api/swagger"
+}

--- a/internal/scm/gitea/testdata/error_404.json
+++ b/internal/scm/gitea/testdata/error_404.json
@@ -1,0 +1,4 @@
+{
+  "message": "not found",
+  "url": "https://git.example.com/api/swagger"
+}

--- a/internal/scm/gitea/testdata/error_412.json
+++ b/internal/scm/gitea/testdata/error_412.json
@@ -1,0 +1,4 @@
+{
+  "message": "unknown state: bogus",
+  "url": "https://git.example.com/api/swagger"
+}

--- a/internal/scm/gitea/testdata/error_422.json
+++ b/internal/scm/gitea/testdata/error_422.json
@@ -1,0 +1,4 @@
+{
+  "message": "[Title]: Required",
+  "url": "https://git.example.com/api/swagger"
+}

--- a/internal/scm/gitea/testdata/error_423.json
+++ b/internal/scm/gitea/testdata/error_423.json
@@ -1,0 +1,4 @@
+{
+  "message": "repo is archived",
+  "url": "https://git.example.com/api/swagger"
+}

--- a/internal/scm/gitea/testdata/issue_full.json
+++ b/internal/scm/gitea/testdata/issue_full.json
@@ -1,0 +1,18 @@
+{
+  "id": 9042,
+  "number": 42,
+  "title": "Add dark mode support",
+  "body": "Users want a **dark mode** option.",
+  "state": "open",
+  "ref": "feature/dark-mode",
+  "html_url": "https://git.example.com/acme/widgets/issues/42",
+  "labels": [
+    { "id": 3, "name": "in-progress", "color": "00ff00" },
+    { "id": 9, "name": "ui", "color": "0000ff" }
+  ],
+  "assignee": { "login": "wrong-user-deprecated-field" },
+  "assignees": [{ "login": "alice" }, { "login": "bob" }],
+  "pull_request": null,
+  "created_at": "2026-01-01T00:00:00Z",
+  "updated_at": "2026-01-02T00:00:00Z"
+}

--- a/internal/scm/gitea/testdata/issue_pr.json
+++ b/internal/scm/gitea/testdata/issue_pr.json
@@ -1,0 +1,14 @@
+{
+  "id": 601,
+  "number": 6,
+  "title": "Implement dark mode toggle",
+  "body": "Closes #42.",
+  "state": "open",
+  "ref": "feature-x",
+  "html_url": "https://git.example.com/acme/widgets/pulls/6",
+  "labels": [],
+  "assignees": [],
+  "pull_request": {},
+  "created_at": "2026-01-05T00:00:00Z",
+  "updated_at": "2026-01-05T00:00:00Z"
+}

--- a/internal/scm/gitea/testdata/issues_candidates_page1.json
+++ b/internal/scm/gitea/testdata/issues_candidates_page1.json
@@ -1,0 +1,30 @@
+[
+  {
+    "id": 8008,
+    "number": 8,
+    "title": "Backlog item created later",
+    "body": null,
+    "state": "open",
+    "ref": "",
+    "html_url": "https://git.example.com/acme/widgets/issues/8",
+    "labels": [{ "id": 1, "name": "backlog", "color": "cccccc" }],
+    "assignees": [],
+    "pull_request": null,
+    "created_at": "2026-01-04T00:00:00Z",
+    "updated_at": "2026-01-04T00:00:00Z"
+  },
+  {
+    "id": 601,
+    "number": 6,
+    "title": "Implement dark mode toggle",
+    "body": "Closes #42.",
+    "state": "open",
+    "ref": "feature-x",
+    "html_url": "https://git.example.com/acme/widgets/pulls/6",
+    "labels": [],
+    "assignees": [],
+    "pull_request": {},
+    "created_at": "2026-01-05T00:00:00Z",
+    "updated_at": "2026-01-05T00:00:00Z"
+  }
+]

--- a/internal/scm/gitea/testdata/issues_candidates_page2.json
+++ b/internal/scm/gitea/testdata/issues_candidates_page2.json
@@ -1,0 +1,44 @@
+[
+  {
+    "id": 8001,
+    "number": 1,
+    "title": "Backlog item created first",
+    "body": null,
+    "state": "open",
+    "ref": "",
+    "html_url": "https://git.example.com/acme/widgets/issues/1",
+    "labels": [{ "id": 1, "name": "backlog", "color": "cccccc" }],
+    "assignees": [],
+    "pull_request": null,
+    "created_at": "2026-01-01T00:00:00Z",
+    "updated_at": "2026-01-01T00:00:00Z"
+  },
+  {
+    "id": 8003,
+    "number": 3,
+    "title": "Already done, should be filtered",
+    "body": null,
+    "state": "open",
+    "ref": "",
+    "html_url": "https://git.example.com/acme/widgets/issues/3",
+    "labels": [{ "id": 4, "name": "done", "color": "00ff00" }],
+    "assignees": [],
+    "pull_request": null,
+    "created_at": "2026-01-02T00:00:00Z",
+    "updated_at": "2026-01-02T00:00:00Z"
+  },
+  {
+    "id": 8002,
+    "number": 2,
+    "title": "In progress item",
+    "body": null,
+    "state": "open",
+    "ref": "",
+    "html_url": "https://git.example.com/acme/widgets/issues/2",
+    "labels": [{ "id": 3, "name": "in-progress", "color": "00ff00" }],
+    "assignees": [{ "login": "bob" }],
+    "pull_request": null,
+    "created_at": "2026-01-03T00:00:00Z",
+    "updated_at": "2026-01-03T00:00:00Z"
+  }
+]

--- a/internal/scm/gitea/testdata/issues_closed_by_states.json
+++ b/internal/scm/gitea/testdata/issues_closed_by_states.json
@@ -1,0 +1,30 @@
+[
+  {
+    "id": 8020,
+    "number": 20,
+    "title": "Done, requested",
+    "body": null,
+    "state": "closed",
+    "ref": "",
+    "html_url": "https://git.example.com/acme/widgets/issues/20",
+    "labels": [{ "id": 4, "name": "done", "color": "00ff00" }],
+    "assignees": [],
+    "pull_request": null,
+    "created_at": "2026-01-20T00:00:00Z",
+    "updated_at": "2026-01-20T00:00:00Z"
+  },
+  {
+    "id": 8021,
+    "number": 21,
+    "title": "Wontfix, not requested",
+    "body": null,
+    "state": "closed",
+    "ref": "",
+    "html_url": "https://git.example.com/acme/widgets/issues/21",
+    "labels": [{ "id": 5, "name": "wontfix", "color": "ff0000" }],
+    "assignees": [],
+    "pull_request": null,
+    "created_at": "2026-01-21T00:00:00Z",
+    "updated_at": "2026-01-21T00:00:00Z"
+  }
+]

--- a/internal/scm/gitea/testdata/issues_open_by_states.json
+++ b/internal/scm/gitea/testdata/issues_open_by_states.json
@@ -1,0 +1,30 @@
+[
+  {
+    "id": 8010,
+    "number": 10,
+    "title": "In progress, requested",
+    "body": null,
+    "state": "open",
+    "ref": "",
+    "html_url": "https://git.example.com/acme/widgets/issues/10",
+    "labels": [{ "id": 3, "name": "in-progress", "color": "00ff00" }],
+    "assignees": [],
+    "pull_request": null,
+    "created_at": "2026-01-10T00:00:00Z",
+    "updated_at": "2026-01-10T00:00:00Z"
+  },
+  {
+    "id": 8011,
+    "number": 11,
+    "title": "Backlog, not requested",
+    "body": null,
+    "state": "open",
+    "ref": "",
+    "html_url": "https://git.example.com/acme/widgets/issues/11",
+    "labels": [{ "id": 1, "name": "backlog", "color": "cccccc" }],
+    "assignees": [],
+    "pull_request": null,
+    "created_at": "2026-01-11T00:00:00Z",
+    "updated_at": "2026-01-11T00:00:00Z"
+  }
+]

--- a/internal/scm/gitea/testdata/issues_paginate_page1.json
+++ b/internal/scm/gitea/testdata/issues_paginate_page1.json
@@ -1,0 +1,30 @@
+[
+  {
+    "id": 7001,
+    "number": 101,
+    "title": "Paginate item 1",
+    "body": null,
+    "state": "open",
+    "ref": "",
+    "html_url": "https://git.example.com/acme/widgets/issues/101",
+    "labels": [{ "id": 1, "name": "backlog", "color": "cccccc" }],
+    "assignees": [],
+    "pull_request": null,
+    "created_at": "2026-02-01T00:00:00Z",
+    "updated_at": "2026-02-01T00:00:00Z"
+  },
+  {
+    "id": 7002,
+    "number": 102,
+    "title": "Paginate item 2",
+    "body": null,
+    "state": "open",
+    "ref": "",
+    "html_url": "https://git.example.com/acme/widgets/issues/102",
+    "labels": [{ "id": 1, "name": "backlog", "color": "cccccc" }],
+    "assignees": [],
+    "pull_request": null,
+    "created_at": "2026-02-02T00:00:00Z",
+    "updated_at": "2026-02-02T00:00:00Z"
+  }
+]

--- a/internal/scm/gitea/testdata/issues_paginate_page2.json
+++ b/internal/scm/gitea/testdata/issues_paginate_page2.json
@@ -1,0 +1,30 @@
+[
+  {
+    "id": 7003,
+    "number": 103,
+    "title": "Paginate item 3",
+    "body": null,
+    "state": "open",
+    "ref": "",
+    "html_url": "https://git.example.com/acme/widgets/issues/103",
+    "labels": [{ "id": 1, "name": "backlog", "color": "cccccc" }],
+    "assignees": [],
+    "pull_request": null,
+    "created_at": "2026-02-03T00:00:00Z",
+    "updated_at": "2026-02-03T00:00:00Z"
+  },
+  {
+    "id": 7004,
+    "number": 104,
+    "title": "Paginate item 4",
+    "body": null,
+    "state": "open",
+    "ref": "",
+    "html_url": "https://git.example.com/acme/widgets/issues/104",
+    "labels": [{ "id": 1, "name": "backlog", "color": "cccccc" }],
+    "assignees": [],
+    "pull_request": null,
+    "created_at": "2026-02-04T00:00:00Z",
+    "updated_at": "2026-02-04T00:00:00Z"
+  }
+]

--- a/internal/scm/gitea/testdata/issues_paginate_page3.json
+++ b/internal/scm/gitea/testdata/issues_paginate_page3.json
@@ -1,0 +1,16 @@
+[
+  {
+    "id": 7005,
+    "number": 105,
+    "title": "Paginate item 5",
+    "body": null,
+    "state": "open",
+    "ref": "",
+    "html_url": "https://git.example.com/acme/widgets/issues/105",
+    "labels": [{ "id": 1, "name": "backlog", "color": "cccccc" }],
+    "assignees": [],
+    "pull_request": null,
+    "created_at": "2026-02-05T00:00:00Z",
+    "updated_at": "2026-02-05T00:00:00Z"
+  }
+]

--- a/internal/scm/gitea/testdata/user.json
+++ b/internal/scm/gitea/testdata/user.json
@@ -1,0 +1,7 @@
+{
+  "id": 1,
+  "login": "sortie-bot",
+  "full_name": "Sortie Automation",
+  "email": "sortie-bot@example.com",
+  "is_admin": false
+}


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Feat

**Intent:** Implements the read-only fetch path of `domain.TrackerAdapter` for Gitea, registered under kind `"gitea"` in the adapter registry. This is the foundation for milestone M26: the REST client, response normalization, and error-category mapping that the write path (issue transitions, comments, label attach) builds on in a separate task.

**Related Issues:** #629

### 🧭 Reviewer Guide

**Complexity:** High

#### Entry Point

Start with `internal/scm/gitea/gitea.go`. It is the adapter struct that wires together all the pieces: construction with preflight validation, the six read operations (`FetchCandidateIssues`, `FetchIssueByID`, `FetchIssuesByStates`, `FetchIssueStatesByIDs`, `FetchIssueStatesByIdentifiers`, `FetchIssueComments`), the write-path stubs, and how state derivation and pagination compose.

#### Sensitive Areas

- `internal/scm/gitea/state.go`: `deriveState` scans issue labels against the configured active/terminal/handoff state lists in order, since Gitea has no native workflow-state field. Worth checking the precedence rule and the multi-match warning behavior.
- `internal/scm/gitea/gitea.go`: `listAndFilter` filters candidate and by-state issues client-side rather than via Gitea's `labels` query parameter, which has AND semantics and silently drops an unresolvable label name. Worth confirming this tradeoff and the pull-request skip logic.
- `internal/scm/gitea/preflight.go`: `runPreflight` and `withRetry` gate adapter construction with a bounded 1s/2s/4s backoff that must retry only transient errors (5xx, transport) and never config errors (401, 403, 404).
- `internal/scm/gitea/client.go`: `classifyHTTPError` reads a bounded error-body snippet and deliberately never includes the request URL, since Gitea also accepts a query-parameter token scheme this adapter must never let leak into logs.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes. Adds a new adapter under a new tracker kind (`gitea`); no existing adapters or callers are affected.
- **Migrations/State:** No migrations or state changes. The adapter registers itself via `init` and is only instantiated when `tracker.kind: gitea` appears in a workflow config.
