### PR TITLE
feat(gitea): add config validation for sortie validate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#629](https://github.com/sortie-ai/sortie/issues/629),
   [#630](https://github.com/sortie-ai/sortie/issues/630),
   [#632](https://github.com/sortie-ai/sortie/issues/632))
+- `sortie validate` Gitea adapter config validation: emits offline
+  diagnostics for `tracker.kind: gitea` covering `tracker.endpoint`
+  presence and URL shape (required for a self-hosted instance, which has
+  no default host to fall back on), `tracker.project` as `owner/repo`, a
+  `$SORTIE_GITEA_TOKEN` environment-variable hint, empty state labels,
+  and active/terminal state overlap. Errors block dispatch; warnings are
+  advisory.
+  ([#631](https://github.com/sortie-ai/sortie/issues/631))
 
 ## [1.14.1] - 2026-07-13
 

--- a/internal/scm/gitea/gitea.go
+++ b/internal/scm/gitea/gitea.go
@@ -33,8 +33,9 @@ import (
 
 func init() {
 	registry.Trackers.RegisterWithMeta("gitea", NewGiteaAdapter, registry.TrackerMeta{
-		RequiresProject: true,
-		RequiresAPIKey:  true,
+		RequiresProject:       true,
+		RequiresAPIKey:        true,
+		ValidateTrackerConfig: validateConfig,
 	})
 }
 

--- a/internal/scm/gitea/validate.go
+++ b/internal/scm/gitea/validate.go
@@ -1,0 +1,238 @@
+package gitea
+
+import (
+	"fmt"
+	"net/url"
+	"os"
+	"slices"
+	"strings"
+
+	"github.com/sortie-ai/sortie/internal/registry"
+)
+
+// validateConfig checks Gitea-specific configuration constraints and
+// returns diagnostics for the sortie validate pipeline. It does not
+// construct an adapter instance or make network calls.
+func validateConfig(fields registry.TrackerConfigFields) []registry.ValidationDiag {
+	var diags []registry.ValidationDiag
+
+	diags = append(diags, validateEndpoint(fields.Endpoint)...)
+	diags = append(diags, validateProject(fields.Project)...)
+	diags = append(diags, validateAPIKeyHint(fields.APIKey)...)
+	diags = append(diags, validateStateLabels("tracker.active_states", fields.ActiveStates)...)
+	diags = append(diags, validateStateLabels("tracker.terminal_states", fields.TerminalStates)...)
+	diags = append(diags, validateStateOverlap(fields)...)
+
+	return diags
+}
+
+// containsWhitespace reports whether s contains any whitespace
+// characters.
+func containsWhitespace(s string) bool {
+	for _, r := range s {
+		if r == ' ' || r == '\t' || r == '\n' || r == '\r' {
+			return true
+		}
+	}
+	return false
+}
+
+// toLowerSet builds a set of lowercased strings from a slice.
+func toLowerSet(ss []string) map[string]struct{} {
+	m := make(map[string]struct{}, len(ss))
+	for _, s := range ss {
+		m[strings.ToLower(s)] = struct{}{}
+	}
+	return m
+}
+
+// validateEndpoint checks that tracker.endpoint is present and shaped
+// like an absolute http(s) URL with a host.
+//
+// A self-hosted Gitea instance has no default host, so an empty endpoint
+// is a blocking error and a value that does not parse to an absolute
+// http(s) URL with a host is a blocking error. A plain-http endpoint and
+// an endpoint already ending in /api/v1 each yield an advisory warning.
+// Messages never echo the raw value, which can embed userinfo credentials.
+func validateEndpoint(endpoint string) []registry.ValidationDiag {
+	if endpoint == "" {
+		return []registry.ValidationDiag{{
+			Severity: "error",
+			Check:    "tracker.endpoint.missing",
+			Message:  "tracker.endpoint is required for gitea; there is no default host",
+		}}
+	}
+
+	parsed, err := url.Parse(endpoint)
+	if err != nil ||
+		(strings.ToLower(parsed.Scheme) != "http" && strings.ToLower(parsed.Scheme) != "https") ||
+		parsed.Host == "" {
+		return []registry.ValidationDiag{{
+			Severity: "error",
+			Check:    "tracker.endpoint.invalid",
+			Message:  `tracker.endpoint must be an absolute http(s) URL with a host (e.g. "https://gitea.example.com")`,
+		}}
+	}
+
+	var diags []registry.ValidationDiag
+	if strings.ToLower(parsed.Scheme) == "http" {
+		diags = append(diags, registry.ValidationDiag{
+			Severity: "warning",
+			Check:    "tracker.endpoint.insecure",
+			Message:  "tracker.endpoint uses http; the token travels in cleartext, use https",
+		})
+	}
+	if strings.HasSuffix(strings.TrimRight(parsed.Path, "/"), "/api/v1") {
+		diags = append(diags, registry.ValidationDiag{
+			Severity: "warning",
+			Check:    "tracker.endpoint.api_suffix",
+			Message:  "tracker.endpoint already ends in /api/v1; the adapter appends it automatically",
+		})
+	}
+	return diags
+}
+
+// validateProject checks that tracker.project is in owner/repo format.
+// Empty project is skipped because the required-field check runs earlier
+// in the preflight pipeline. Whitespace in either half is flagged because
+// a Gitea owner or repository name cannot contain spaces and would fail
+// the online preflight.
+func validateProject(project string) []registry.ValidationDiag {
+	if project == "" {
+		return nil
+	}
+
+	if strings.Count(project, "/") != 1 {
+		return []registry.ValidationDiag{{
+			Severity: "error",
+			Check:    "tracker.project.format",
+			Message:  `tracker.project must be in owner/repo format (e.g. "sortie-ai/sortie")`,
+		}}
+	}
+
+	owner, repo, _ := strings.Cut(project, "/")
+
+	if owner == "" || repo == "" {
+		return []registry.ValidationDiag{{
+			Severity: "error",
+			Check:    "tracker.project.format",
+			Message:  `tracker.project must be in owner/repo format (e.g. "sortie-ai/sortie")`,
+		}}
+	}
+
+	if containsWhitespace(owner) || containsWhitespace(repo) {
+		return []registry.ValidationDiag{{
+			Severity: "error",
+			Check:    "tracker.project.format",
+			Message:  "tracker.project owner and repo must not contain whitespace",
+		}}
+	}
+
+	return nil
+}
+
+// validateAPIKeyHint produces advisory diagnostics for the resolved
+// tracker.api_key. An empty key hints about the SORTIE_GITEA_TOKEN
+// environment variable; a non-empty key surrounded by whitespace is
+// flagged because the key is sent verbatim in the Authorization header.
+// The key value is never logged or placed in a diagnostic message.
+func validateAPIKeyHint(apiKey string) []registry.ValidationDiag {
+	trimmed := strings.TrimSpace(apiKey)
+
+	if trimmed == "" {
+		if os.Getenv("SORTIE_GITEA_TOKEN") != "" {
+			return []registry.ValidationDiag{{
+				Severity: "warning",
+				Check:    "tracker.api_key.sortie_gitea_token_hint",
+				Message:  "tracker.api_key is empty but SORTIE_GITEA_TOKEN environment variable is set; consider using api_key: $SORTIE_GITEA_TOKEN",
+			}}
+		}
+
+		return []registry.ValidationDiag{{
+			Severity: "warning",
+			Check:    "tracker.api_key.sortie_gitea_token_missing",
+			Message:  "tracker.api_key is empty and SORTIE_GITEA_TOKEN environment variable is not set",
+		}}
+	}
+
+	if apiKey != trimmed {
+		return []registry.ValidationDiag{{
+			Severity: "warning",
+			Check:    "tracker.api_key.gitea_whitespace",
+			Message:  "tracker.api_key has leading or trailing whitespace; the key is sent verbatim in the Authorization: token header, so surrounding whitespace will fail authentication",
+		}}
+	}
+
+	return nil
+}
+
+// validateStateLabels checks for empty or whitespace-only elements in a
+// state label list.
+//
+// An empty element is a warning, not an error, because Gitea creates a
+// missing state label on demand, so the element is inert rather than fatal
+// at construction. An absent or wholly empty list yields no diagnostic
+// because the adapter applies defaults in that case.
+func validateStateLabels(field string, states []string) []registry.ValidationDiag {
+	var diags []registry.ValidationDiag
+	for i, s := range states {
+		if strings.TrimSpace(s) == "" {
+			diags = append(diags, registry.ValidationDiag{
+				Severity: "warning",
+				Check:    field + ".empty_element",
+				Message:  fmt.Sprintf("%s[%d]: empty state label will never match any issue", field, i),
+			})
+		}
+	}
+	return diags
+}
+
+// validateStateOverlap detects state names shared between active_states
+// and terminal_states, and a handoff_state that collides with either
+// list. All comparisons are case-insensitive. There is no
+// in_progress_state arm because in_progress_state is not a Gitea config
+// key.
+func validateStateOverlap(fields registry.TrackerConfigFields) []registry.ValidationDiag {
+	var diags []registry.ValidationDiag
+
+	activeSet := toLowerSet(fields.ActiveStates)
+	terminalSet := toLowerSet(fields.TerminalStates)
+
+	var overlap []string
+	for name := range activeSet {
+		if strings.TrimSpace(name) == "" {
+			continue
+		}
+		if _, ok := terminalSet[name]; ok {
+			overlap = append(overlap, name)
+		}
+	}
+	slices.Sort(overlap)
+	for _, name := range overlap {
+		diags = append(diags, registry.ValidationDiag{
+			Severity: "warning",
+			Check:    "tracker.states.overlap",
+			Message:  fmt.Sprintf("tracker.active_states and tracker.terminal_states overlap on %q; an issue in state %q would match both sets", name, name),
+		})
+	}
+
+	handoff := strings.TrimSpace(fields.HandoffState)
+	if hs := strings.ToLower(handoff); hs != "" {
+		if _, ok := activeSet[hs]; ok {
+			diags = append(diags, registry.ValidationDiag{
+				Severity: "warning",
+				Check:    "tracker.handoff_state.collision",
+				Message:  fmt.Sprintf("tracker.handoff_state %q must not appear in active_states (would cause immediate re-dispatch after handoff)", handoff),
+			})
+		}
+		if _, ok := terminalSet[hs]; ok {
+			diags = append(diags, registry.ValidationDiag{
+				Severity: "warning",
+				Check:    "tracker.handoff_state.collision",
+				Message:  fmt.Sprintf("tracker.handoff_state %q must not appear in terminal_states (handoff is not terminal)", handoff),
+			})
+		}
+	}
+
+	return diags
+}

--- a/internal/scm/gitea/validate_test.go
+++ b/internal/scm/gitea/validate_test.go
@@ -1,0 +1,472 @@
+package gitea
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/sortie-ai/sortie/internal/registry"
+)
+
+// --- Test helpers ---
+
+// hasDiagCheck reports whether any diag in the slice has the given check name.
+func hasDiagCheck(diags []registry.ValidationDiag, check string) bool {
+	for _, d := range diags {
+		if d.Check == check {
+			return true
+		}
+	}
+	return false
+}
+
+// diagsWithSeverity returns the subset of diags with the given severity.
+func diagsWithSeverity(diags []registry.ValidationDiag, severity string) []registry.ValidationDiag {
+	var out []registry.ValidationDiag
+	for _, d := range diags {
+		if d.Severity == severity {
+			out = append(out, d)
+		}
+	}
+	return out
+}
+
+// assertNoMessageContains fails the test if any diag's Message contains substr.
+func assertNoMessageContains(t *testing.T, diags []registry.ValidationDiag, substr string) {
+	t.Helper()
+	for i, d := range diags {
+		if strings.Contains(d.Message, substr) {
+			t.Errorf("diag[%d].Message = %q, must not contain %q", i, d.Message, substr)
+		}
+	}
+}
+
+// --- Tests ---
+
+func TestValidateEndpoint(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		endpoint     string
+		wantCount    int
+		wantCheck    string
+		wantSeverity string
+	}{
+		{
+			name:         "empty endpoint is missing",
+			endpoint:     "",
+			wantCount:    1,
+			wantCheck:    "tracker.endpoint.missing",
+			wantSeverity: "error",
+		},
+		{
+			name:         "no scheme is invalid",
+			endpoint:     "gitea.example.com",
+			wantCount:    1,
+			wantCheck:    "tracker.endpoint.invalid",
+			wantSeverity: "error",
+		},
+		{
+			name:         "non-http scheme is invalid",
+			endpoint:     "ftp://host",
+			wantCount:    1,
+			wantCheck:    "tracker.endpoint.invalid",
+			wantSeverity: "error",
+		},
+		{
+			name:         "empty host is invalid",
+			endpoint:     "https://",
+			wantCount:    1,
+			wantCheck:    "tracker.endpoint.invalid",
+			wantSeverity: "error",
+		},
+		{
+			name:      "https with subpath is valid",
+			endpoint:  "https://host/gitea",
+			wantCount: 0,
+		},
+		{
+			name:      "https with custom port is valid",
+			endpoint:  "https://host:3000",
+			wantCount: 0,
+		},
+		{
+			name:      "https with IPv6 literal is valid",
+			endpoint:  "https://[::1]:3000",
+			wantCount: 0,
+		},
+		{
+			name:      "clean https endpoint is valid",
+			endpoint:  "https://gitea.example.com",
+			wantCount: 0,
+		},
+		{
+			name:         "http scheme is insecure",
+			endpoint:     "http://host",
+			wantCount:    1,
+			wantCheck:    "tracker.endpoint.insecure",
+			wantSeverity: "warning",
+		},
+		{
+			name:         "api/v1 suffix is redundant",
+			endpoint:     "https://host/api/v1",
+			wantCount:    1,
+			wantCheck:    "tracker.endpoint.api_suffix",
+			wantSeverity: "warning",
+		},
+		{
+			name:         "api/v1 suffix with trailing slash is redundant",
+			endpoint:     "https://host/api/v1/",
+			wantCount:    1,
+			wantCheck:    "tracker.endpoint.api_suffix",
+			wantSeverity: "warning",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := validateEndpoint(tt.endpoint)
+
+			if len(got) != tt.wantCount {
+				t.Fatalf("validateEndpoint(%q) = %d diags, want %d; diags: %v", tt.endpoint, len(got), tt.wantCount, got)
+			}
+			if tt.wantCount == 0 {
+				return
+			}
+			if got[0].Check != tt.wantCheck {
+				t.Errorf("validateEndpoint(%q) diag[0].Check = %q, want %q", tt.endpoint, got[0].Check, tt.wantCheck)
+			}
+			if got[0].Severity != tt.wantSeverity {
+				t.Errorf("validateEndpoint(%q) diag[0].Severity = %q, want %q", tt.endpoint, got[0].Severity, tt.wantSeverity)
+			}
+		})
+	}
+
+	t.Run("userinfo in endpoint never leaks into a message", func(t *testing.T) {
+		t.Parallel()
+
+		got := validateEndpoint("https://user:secret@host")
+
+		if len(got) != 0 {
+			t.Fatalf("validateEndpoint(userinfo) = %d diags, want 0; diags: %v", len(got), got)
+		}
+		assertNoMessageContains(t, got, "secret")
+	})
+}
+
+func TestValidateProject(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		project   string
+		wantCount int
+	}{
+		{name: "empty project is skipped", project: "", wantCount: 0},
+		{name: "whitespace-only project is rejected", project: "  ", wantCount: 1},
+		{name: "no slash", project: "noslash", wantCount: 1},
+		{name: "multiple slashes", project: "a/b/c", wantCount: 1},
+		{name: "empty owner segment", project: "/repo", wantCount: 1},
+		{name: "empty repo segment", project: "owner/", wantCount: 1},
+		{name: "space within owner segment", project: "my org/repo", wantCount: 1},
+		{name: "space within repo segment", project: "owner/my repo", wantCount: 1},
+		{name: "leading outer space in owner", project: " owner/repo", wantCount: 1},
+		{name: "trailing outer space in repo", project: "owner/repo ", wantCount: 1},
+		{name: "valid owner/repo", project: "sortie-ai/sortie", wantCount: 0},
+		{name: "valid uppercase", project: "OWNER/REPO", wantCount: 0},
+		{name: "valid with hyphens dots and digits", project: "my-org/my.repo-v2", wantCount: 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := validateProject(tt.project)
+
+			if len(got) != tt.wantCount {
+				t.Fatalf("validateProject(%q) = %d diags, want %d; diags: %v", tt.project, len(got), tt.wantCount, got)
+			}
+			if tt.wantCount == 0 {
+				return
+			}
+			if got[0].Check != "tracker.project.format" {
+				t.Errorf("validateProject(%q) diag[0].Check = %q, want %q", tt.project, got[0].Check, "tracker.project.format")
+			}
+			if got[0].Severity != "error" {
+				t.Errorf("validateProject(%q) diag[0].Severity = %q, want %q", tt.project, got[0].Severity, "error")
+			}
+		})
+	}
+}
+
+func TestValidateAPIKeyHint(t *testing.T) {
+	// No t.Parallel(): subtests use t.Setenv to control SORTIE_GITEA_TOKEN.
+
+	t.Run("clean key produces no diagnostics", func(t *testing.T) {
+		got := validateAPIKeyHint("a1b2c3")
+
+		if len(got) != 0 {
+			t.Errorf("validateAPIKeyHint(%q) = %v, want empty", "a1b2c3", got)
+		}
+	})
+
+	t.Run("empty key with SORTIE_GITEA_TOKEN set reports hint warning", func(t *testing.T) {
+		t.Setenv("SORTIE_GITEA_TOKEN", "envTokenValue777")
+
+		got := validateAPIKeyHint("")
+
+		if len(got) != 1 {
+			t.Fatalf("validateAPIKeyHint(\"\") with SORTIE_GITEA_TOKEN set = %d diags, want 1; diags: %v", len(got), got)
+		}
+		if got[0].Check != "tracker.api_key.sortie_gitea_token_hint" {
+			t.Errorf("validateAPIKeyHint(\"\") diag[0].Check = %q, want %q", got[0].Check, "tracker.api_key.sortie_gitea_token_hint")
+		}
+		if got[0].Severity != "warning" {
+			t.Errorf("validateAPIKeyHint(\"\") diag[0].Severity = %q, want %q", got[0].Severity, "warning")
+		}
+		assertNoMessageContains(t, got, "envTokenValue777")
+	})
+
+	t.Run("empty key with SORTIE_GITEA_TOKEN unset reports missing warning", func(t *testing.T) {
+		t.Setenv("SORTIE_GITEA_TOKEN", "")
+
+		got := validateAPIKeyHint("")
+
+		if len(got) != 1 {
+			t.Fatalf("validateAPIKeyHint(\"\") with SORTIE_GITEA_TOKEN unset = %d diags, want 1; diags: %v", len(got), got)
+		}
+		if got[0].Check != "tracker.api_key.sortie_gitea_token_missing" {
+			t.Errorf("validateAPIKeyHint(\"\") diag[0].Check = %q, want %q", got[0].Check, "tracker.api_key.sortie_gitea_token_missing")
+		}
+		if got[0].Severity != "warning" {
+			t.Errorf("validateAPIKeyHint(\"\") diag[0].Severity = %q, want %q", got[0].Severity, "warning")
+		}
+	})
+
+	t.Run("whitespace-padded key reports whitespace warning", func(t *testing.T) {
+		t.Setenv("SORTIE_GITEA_TOKEN", "")
+
+		const padded = " zzzUniqueTokenValue999 "
+		got := validateAPIKeyHint(padded)
+
+		if len(got) != 1 {
+			t.Fatalf("validateAPIKeyHint(%q) = %d diags, want 1; diags: %v", padded, len(got), got)
+		}
+		if got[0].Check != "tracker.api_key.gitea_whitespace" {
+			t.Errorf("validateAPIKeyHint(%q) diag[0].Check = %q, want %q", padded, got[0].Check, "tracker.api_key.gitea_whitespace")
+		}
+		if got[0].Severity != "warning" {
+			t.Errorf("validateAPIKeyHint(%q) diag[0].Severity = %q, want %q", padded, got[0].Severity, "warning")
+		}
+		assertNoMessageContains(t, got, "zzzUniqueTokenValue999")
+	})
+
+	t.Run("no check name references a token prefix", func(t *testing.T) {
+		t.Setenv("SORTIE_GITEA_TOKEN", "some-token-value")
+
+		for _, apiKey := range []string{"", "a1b2c3", " tok "} {
+			for _, d := range validateAPIKeyHint(apiKey) {
+				if strings.Contains(d.Check, "prefix") {
+					t.Errorf("validateAPIKeyHint(%q) diag.Check = %q, must not contain %q", apiKey, d.Check, "prefix")
+				}
+			}
+		}
+	})
+}
+
+func TestValidateStateLabels(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		field     string
+		states    []string
+		wantCount int
+	}{
+		{name: "nil slice has no warnings", field: "tracker.active_states", states: nil, wantCount: 0},
+		{name: "all non-empty has no warnings", field: "tracker.active_states", states: []string{"backlog", "in-progress"}, wantCount: 0},
+		{name: "single empty at index 0", field: "tracker.active_states", states: []string{""}, wantCount: 1},
+		{name: "empty at index 1", field: "tracker.terminal_states", states: []string{"done", ""}, wantCount: 1},
+		{name: "whitespace-only element", field: "tracker.active_states", states: []string{"backlog", "  ", "done"}, wantCount: 1},
+		{name: "multiple empties", field: "tracker.active_states", states: []string{"", "backlog", ""}, wantCount: 2},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := validateStateLabels(tt.field, tt.states)
+
+			if len(got) != tt.wantCount {
+				t.Fatalf("validateStateLabels(%q, %v) = %d diags, want %d; diags: %v", tt.field, tt.states, len(got), tt.wantCount, got)
+			}
+
+			wantCheck := tt.field + ".empty_element"
+			for i, d := range got {
+				if d.Check != wantCheck {
+					t.Errorf("validateStateLabels(%q) diag[%d].Check = %q, want %q", tt.field, i, d.Check, wantCheck)
+				}
+				if d.Severity != "warning" {
+					t.Errorf("validateStateLabels(%q) diag[%d].Severity = %q, want %q", tt.field, i, d.Severity, "warning")
+				}
+			}
+		})
+	}
+}
+
+func TestValidateStateOverlap(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		fields        registry.TrackerConfigFields
+		wantChecks    []string
+		wantDiagCount int
+	}{
+		{
+			name: "no overlap",
+			fields: registry.TrackerConfigFields{
+				ActiveStates:   []string{"backlog", "in-progress"},
+				TerminalStates: []string{"done", "wontfix"},
+			},
+			wantDiagCount: 0,
+		},
+		{
+			name: "case-insensitive overlap on done",
+			fields: registry.TrackerConfigFields{
+				ActiveStates:   []string{"done"},
+				TerminalStates: []string{"Done"},
+			},
+			wantChecks:    []string{"tracker.states.overlap"},
+			wantDiagCount: 1,
+		},
+		{
+			name: "multiple overlaps are sorted",
+			fields: registry.TrackerConfigFields{
+				ActiveStates:   []string{"a", "b"},
+				TerminalStates: []string{"b", "c", "a"},
+			},
+			wantChecks:    []string{"tracker.states.overlap"},
+			wantDiagCount: 2,
+		},
+		{
+			name: "empty-string elements are skipped",
+			fields: registry.TrackerConfigFields{
+				ActiveStates:   []string{""},
+				TerminalStates: []string{""},
+			},
+			wantDiagCount: 0,
+		},
+		{
+			name: "handoff_state in active_states",
+			fields: registry.TrackerConfigFields{
+				ActiveStates:   []string{"review", "backlog"},
+				TerminalStates: []string{"done"},
+				HandoffState:   "review",
+			},
+			wantChecks:    []string{"tracker.handoff_state.collision"},
+			wantDiagCount: 1,
+		},
+		{
+			name: "handoff_state in terminal_states",
+			fields: registry.TrackerConfigFields{
+				ActiveStates:   []string{"backlog"},
+				TerminalStates: []string{"done"},
+				HandoffState:   "done",
+			},
+			wantChecks:    []string{"tracker.handoff_state.collision"},
+			wantDiagCount: 1,
+		},
+		{
+			name: "empty handoff_state is skipped",
+			fields: registry.TrackerConfigFields{
+				ActiveStates:   []string{"backlog"},
+				TerminalStates: []string{"done"},
+				HandoffState:   "",
+			},
+			wantDiagCount: 0,
+		},
+		{
+			name: "in_progress_state is not a Gitea concern",
+			fields: registry.TrackerConfigFields{
+				ActiveStates:    []string{"backlog"},
+				TerminalStates:  []string{"done", "closed"},
+				InProgressState: "closed",
+			},
+			wantDiagCount: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := validateStateOverlap(tt.fields)
+
+			if len(got) != tt.wantDiagCount {
+				t.Fatalf("validateStateOverlap() = %d diags, want %d; diags: %v", len(got), tt.wantDiagCount, got)
+			}
+			for _, check := range tt.wantChecks {
+				if !hasDiagCheck(got, check) {
+					t.Errorf("validateStateOverlap() missing diag with check %q; got: %v", check, got)
+				}
+			}
+			for i, d := range got {
+				if d.Severity != "warning" {
+					t.Errorf("validateStateOverlap() diag[%d].Severity = %q, want %q", i, d.Severity, "warning")
+				}
+				if strings.HasPrefix(d.Check, "tracker.in_progress_state") {
+					t.Errorf("validateStateOverlap() diag[%d].Check = %q, must not begin with %q", i, d.Check, "tracker.in_progress_state")
+				}
+			}
+		})
+	}
+}
+
+func TestValidateConfig(t *testing.T) {
+	// No t.Parallel(): subtests use t.Setenv to control SORTIE_GITEA_TOKEN.
+
+	t.Run("fully valid configuration produces zero diagnostics", func(t *testing.T) {
+		t.Setenv("SORTIE_GITEA_TOKEN", "")
+
+		fields := registry.TrackerConfigFields{
+			Kind:            "gitea",
+			Project:         "sortie-ai/sortie",
+			Endpoint:        "https://gitea.example.com",
+			APIKey:          "a1b2c3tokenvalue",
+			ActiveStates:    []string{"backlog", "in-progress"},
+			TerminalStates:  []string{"done", "wontfix"},
+			InProgressState: "done",
+		}
+
+		got := validateConfig(fields)
+
+		errs := diagsWithSeverity(got, "error")
+		warnings := diagsWithSeverity(got, "warning")
+		if len(errs) != 0 {
+			t.Errorf("validateConfig(valid) errors = %v, want empty", errs)
+		}
+		if len(warnings) != 0 {
+			t.Errorf("validateConfig(valid) warnings = %v, want empty", warnings)
+		}
+	})
+
+	t.Run("nil state lists produce zero diagnostics", func(t *testing.T) {
+		t.Setenv("SORTIE_GITEA_TOKEN", "")
+
+		fields := registry.TrackerConfigFields{
+			Kind:     "gitea",
+			Project:  "owner/repo",
+			Endpoint: "https://gitea.example.com",
+			APIKey:   "a1b2c3tokenvalue",
+		}
+
+		got := validateConfig(fields)
+
+		if len(got) != 0 {
+			t.Errorf("validateConfig(nil state lists) = %v, want empty", got)
+		}
+	})
+}


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Feat

**Intent:** Adds offline configuration validation for `tracker.kind: gitea` - consistent with the validation already provided for the Jira, GitHub, and Linear adapters. The validator runs without network access and feeds diagnostics into the `sortie validate` pipeline before dispatch.

**Related Issues:** #631

### 🧭 Reviewer Guide

**Complexity:** Medium

#### Entry Point

`internal/scm/gitea/validate.go` is the best place to start. It contains the six validation functions (`validateConfig`, `validateEndpoint`, `validateProject`, `validateAPIKeyHint`, `validateStateLabels`, `validateStateOverlap`) and their inline contracts. Start here to understand the full diagnostic surface, then look at `gitea.go` to see the single-field registration hook.

#### Sensitive Areas

- `internal/scm/gitea/validate.go`: `validateEndpoint` and `validateAPIKeyHint` handle URL and token material - both intentionally avoid echoing the raw endpoint (which can embed userinfo credentials) or the token/env var value in any diagnostic message. Confirm no secret or credential leakage paths exist.
- `internal/scm/gitea/gitea.go`: The `ValidateTrackerConfig` field wires the validator into the preflight pipeline registry. A wrong function reference here would silently skip all Gitea validation.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes
- **Migrations/State:** No migrations or state changes
