### PR TITLE
test(gitea): add integration test suite and CI job

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -124,6 +124,19 @@ jobs:
             version_cmd: ""
             source: "Linear GraphQL API (remote service, no pinned client)"
 
+          - name: Gitea
+            adapter: gitea
+            kind: tracker
+            guard: SORTIE_GITEA_TEST
+            run_filter: Integration
+            test_path: ./internal/scm/gitea/...
+            timeout: ""
+            node: false
+            install: ""
+            version_cmd: printenv GITEA_IMAGE
+            source: "docker.gitea.com/gitea:1.27.0-rootless (pinned container image)"
+            container_image: docker.gitea.com/gitea:1.27.0-rootless
+
           - name: GitHub
             adapter: github
             kind: SCM
@@ -162,6 +175,10 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "24"
+
+      - name: Boot and provision Gitea
+        if: ${{ matrix.container_image != '' }}
+        run: scripts/gitea-integration-provision.sh "${{ matrix.container_image }}"
 
       - name: Run integration check
         id: check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -193,6 +193,27 @@ jobs:
       - name: Run integration tests
         run: go test -race -count=1 -v -run 'Integration' ./internal/tracker/linear/...
 
+  test-integration-gitea:
+    name: "Integration: Gitea"
+    needs: [lint, test-unit]
+    runs-on: ubuntu-latest
+    env:
+      SORTIE_GITEA_TEST: "1"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Set up Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version-file: go.mod
+
+      - name: Boot and provision Gitea
+        run: scripts/gitea-integration-provision.sh
+
+      - name: Run integration tests
+        run: go test -race -count=1 -v -run 'Integration' ./internal/scm/gitea/...
+
   test-e2e-github:
     name: "E2E: GitHub orchestrator"
     needs: [lint, test-unit]
@@ -408,6 +429,7 @@ jobs:
       - test-integration-jira
       - test-integration-github
       - test-integration-linear
+      - test-integration-gitea
       - test-e2e-github
       - test-integration-claude
       - test-integration-copilot

--- a/internal/scm/gitea/integration_test.go
+++ b/internal/scm/gitea/integration_test.go
@@ -64,6 +64,17 @@ func firstCandidate(t *testing.T, adapter domain.TrackerAdapter, ctx context.Con
 	return candidates[0]
 }
 
+// parseCreatedAt parses a comment's CreatedAt so ordering checks compare
+// chronological order rather than lexicographic string order.
+func parseCreatedAt(t *testing.T, raw string) time.Time {
+	t.Helper()
+	parsed, err := time.Parse(time.RFC3339, raw)
+	if err != nil {
+		t.Fatalf("CreatedAt %q is not a valid RFC 3339 timestamp: %v", raw, err)
+	}
+	return parsed
+}
+
 func TestIntegration_TransitionIssue(t *testing.T) {
 	skipUnlessIntegration(t)
 
@@ -174,12 +185,12 @@ func TestIntegration_FetchIssueByID(t *testing.T) {
 
 	issue := firstCandidate(t, adapter, ctx)
 
-	fetched, err := adapter.FetchIssueByID(ctx, issue.Identifier)
+	fetched, err := adapter.FetchIssueByID(ctx, issue.ID)
 	if err != nil {
-		t.Fatalf("FetchIssueByID(%s): %v", issue.Identifier, err)
+		t.Fatalf("FetchIssueByID(%s): %v", issue.ID, err)
 	}
-	if fetched.Identifier != issue.Identifier {
-		t.Errorf("Identifier = %q, want %q", fetched.Identifier, issue.Identifier)
+	if fetched.ID != issue.ID {
+		t.Errorf("ID = %q, want %q", fetched.ID, issue.ID)
 	}
 	if fetched.Comments == nil {
 		t.Error("Comments is nil, want non-nil slice for fully populated issue")
@@ -316,16 +327,18 @@ func TestIntegration_FetchIssueComments(t *testing.T) {
 
 	issue := firstCandidate(t, adapter, ctx)
 
-	comments, err := adapter.FetchIssueComments(ctx, issue.Identifier)
+	comments, err := adapter.FetchIssueComments(ctx, issue.ID)
 	if err != nil {
-		t.Fatalf("FetchIssueComments(%s): %v", issue.Identifier, err)
+		t.Fatalf("FetchIssueComments(%s): %v", issue.ID, err)
 	}
 	if comments == nil {
 		t.Fatal("comments is nil, want non-nil slice")
 	}
 
 	for i := 1; i < len(comments); i++ {
-		if comments[i-1].CreatedAt > comments[i].CreatedAt {
+		prev := parseCreatedAt(t, comments[i-1].CreatedAt)
+		curr := parseCreatedAt(t, comments[i].CreatedAt)
+		if prev.After(curr) {
 			t.Errorf("comments not in ascending createdAt order at index %d: %q before %q",
 				i, comments[i-1].CreatedAt, comments[i].CreatedAt)
 		}

--- a/internal/scm/gitea/integration_test.go
+++ b/internal/scm/gitea/integration_test.go
@@ -2,6 +2,7 @@ package gitea
 
 import (
 	"context"
+	"errors"
 	"os"
 	"testing"
 	"time"
@@ -130,5 +131,203 @@ func TestIntegration_FetchCandidateIssues_QueryFilter(t *testing.T) {
 
 	if _, err := adapter.FetchCandidateIssues(ctx); err != nil {
 		t.Fatalf("FetchCandidateIssues with query_filter: %v", err)
+	}
+}
+
+func TestIntegration_FetchCandidateIssues(t *testing.T) {
+	skipUnlessIntegration(t)
+
+	adapter := newIntegrationAdapter(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	issues, err := adapter.FetchCandidateIssues(ctx)
+	if err != nil {
+		t.Fatalf("FetchCandidateIssues: %v", err)
+	}
+	t.Logf("FetchCandidateIssues returned %d issues", len(issues))
+
+	for _, iss := range issues {
+		if iss.ID == "" {
+			t.Errorf("issue %q: ID is empty", iss.Identifier)
+		}
+		if iss.Labels == nil {
+			t.Errorf("issue %s: Labels is nil, want non-nil slice", iss.Identifier)
+		}
+		if iss.BlockedBy == nil {
+			t.Errorf("issue %s: BlockedBy is nil, want non-nil slice", iss.Identifier)
+		}
+		if iss.Comments != nil {
+			t.Errorf("issue %s: Comments should be nil for candidate fetch", iss.Identifier)
+		}
+	}
+}
+
+func TestIntegration_FetchIssueByID(t *testing.T) {
+	skipUnlessIntegration(t)
+
+	adapter := newIntegrationAdapter(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	issue := firstCandidate(t, adapter, ctx)
+
+	fetched, err := adapter.FetchIssueByID(ctx, issue.Identifier)
+	if err != nil {
+		t.Fatalf("FetchIssueByID(%s): %v", issue.Identifier, err)
+	}
+	if fetched.Identifier != issue.Identifier {
+		t.Errorf("Identifier = %q, want %q", fetched.Identifier, issue.Identifier)
+	}
+	if fetched.Comments == nil {
+		t.Error("Comments is nil, want non-nil slice for fully populated issue")
+	}
+	if fetched.BlockedBy == nil {
+		t.Error("BlockedBy is nil, want non-nil slice for fully populated issue")
+	}
+}
+
+func TestIntegration_FetchIssueByID_NotFound(t *testing.T) {
+	skipUnlessIntegration(t)
+
+	adapter := newIntegrationAdapter(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := adapter.FetchIssueByID(ctx, "999999")
+	if err == nil {
+		t.Fatal("expected error for nonexistent issue, got nil")
+	}
+
+	var te *domain.TrackerError
+	if !errors.As(err, &te) {
+		t.Fatalf("error type = %T, want *domain.TrackerError", err)
+	}
+	if te.Kind != domain.ErrTrackerNotFound {
+		t.Errorf("TrackerError.Kind = %q, want %q", te.Kind, domain.ErrTrackerNotFound)
+	}
+}
+
+func TestIntegration_FetchIssuesByStates_Empty(t *testing.T) {
+	skipUnlessIntegration(t)
+
+	adapter := newIntegrationAdapter(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	issues, err := adapter.FetchIssuesByStates(ctx, []string{})
+	if err != nil {
+		t.Fatalf("FetchIssuesByStates(empty): %v", err)
+	}
+	if len(issues) != 0 {
+		t.Errorf("FetchIssuesByStates(empty) returned %d issues, want 0", len(issues))
+	}
+}
+
+func TestIntegration_FetchIssuesByStates(t *testing.T) {
+	skipUnlessIntegration(t)
+
+	adapter := newIntegrationAdapter(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	candidates, err := adapter.FetchCandidateIssues(ctx)
+	if err != nil {
+		t.Fatalf("FetchCandidateIssues: %v", err)
+	}
+	if len(candidates) == 0 {
+		t.Skip("no candidate issues in repository; cannot test FetchIssuesByStates")
+	}
+
+	requested := make(map[string]struct{})
+	states := make([]string, 0, len(candidates))
+	for _, c := range candidates {
+		if _, ok := requested[c.State]; ok {
+			continue
+		}
+		requested[c.State] = struct{}{}
+		states = append(states, c.State)
+	}
+
+	issues, err := adapter.FetchIssuesByStates(ctx, states)
+	if err != nil {
+		t.Fatalf("FetchIssuesByStates(%v): %v", states, err)
+	}
+	if issues == nil {
+		t.Fatal("FetchIssuesByStates returned nil, want non-nil slice")
+	}
+	for _, iss := range issues {
+		if _, ok := requested[iss.State]; !ok {
+			t.Errorf("FetchIssuesByStates(%v): issue %s State = %q, want one of %v", states, iss.Identifier, iss.State, states)
+		}
+	}
+}
+
+func TestIntegration_FetchIssueStatesByIDs(t *testing.T) {
+	skipUnlessIntegration(t)
+
+	adapter := newIntegrationAdapter(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	issue := firstCandidate(t, adapter, ctx)
+
+	stateMap, err := adapter.FetchIssueStatesByIDs(ctx, []string{issue.ID})
+	if err != nil {
+		t.Fatalf("FetchIssueStatesByIDs: %v", err)
+	}
+	if stateMap[issue.ID] == "" {
+		t.Errorf("state for %s is empty or missing", issue.ID)
+	}
+}
+
+func TestIntegration_FetchIssueStatesByIdentifiers(t *testing.T) {
+	skipUnlessIntegration(t)
+
+	adapter := newIntegrationAdapter(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	issue := firstCandidate(t, adapter, ctx)
+
+	stateMap, err := adapter.FetchIssueStatesByIdentifiers(ctx, []string{issue.Identifier})
+	if err != nil {
+		t.Fatalf("FetchIssueStatesByIdentifiers: %v", err)
+	}
+	if stateMap[issue.Identifier] == "" {
+		t.Errorf("state for %s is empty or missing", issue.Identifier)
+	}
+}
+
+func TestIntegration_FetchIssueComments(t *testing.T) {
+	skipUnlessIntegration(t)
+
+	adapter := newIntegrationAdapter(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	issue := firstCandidate(t, adapter, ctx)
+
+	comments, err := adapter.FetchIssueComments(ctx, issue.Identifier)
+	if err != nil {
+		t.Fatalf("FetchIssueComments(%s): %v", issue.Identifier, err)
+	}
+	if comments == nil {
+		t.Fatal("comments is nil, want non-nil slice")
+	}
+
+	for i := 1; i < len(comments); i++ {
+		if comments[i-1].CreatedAt > comments[i].CreatedAt {
+			t.Errorf("comments not in ascending createdAt order at index %d: %q before %q",
+				i, comments[i-1].CreatedAt, comments[i].CreatedAt)
+		}
 	}
 }

--- a/scripts/gitea-integration-provision.sh
+++ b/scripts/gitea-integration-provision.sh
@@ -84,6 +84,10 @@ gitea_call() {
 	case "$auth" in
 	token) auth_args=(-H "Authorization: token ${TOKEN}") ;;
 	basic) auth_args=(-u "${GITEA_USER}:${GITEA_PASSWORD}") ;;
+	*)
+		log "unknown auth mode: ${auth}"
+		return 1
+		;;
 	esac
 	response=$(curl -sS --max-time 30 -w "${NEWLINE}%{http_code}" \
 		"${auth_args[@]}" \

--- a/scripts/gitea-integration-provision.sh
+++ b/scripts/gitea-integration-provision.sh
@@ -1,0 +1,242 @@
+#!/usr/bin/env bash
+# Boot and seed a throwaway containerized Gitea, then publish the coordinates
+# the gitea adapter integration suite reads.
+#
+# The instance is ephemeral: the access token is generated in-job against a
+# loopback container, so nothing long-lived is stored and no repository secret
+# is needed. In CI the runner is discarded after the job; locally the script
+# removes any prior container of its fixed name before booting, so a repeat run
+# does not collide on the host port.
+#
+# Output contract. Four coordinates are published two ways. They are appended as
+# bare KEY=VALUE lines to the file named by $GITHUB_ENV when it is set and
+# writable, which Actions exports to successor CI steps. They are also printed to
+# stdout as export statements, so a developer can run
+#   eval "$(scripts/gitea-integration-provision.sh)"
+# and get them exported into the current shell. Everything else goes to stderr,
+# keeping stdout parseable by eval.
+#
+# Prerequisites, all present on ubuntu-latest and expected locally: docker (a
+# running daemon), curl, and jq.
+#
+# Usage: gitea-integration-provision.sh [IMAGE]
+#   IMAGE defaults to the pinned tag below, which is the authoritative version
+#   for the release path. Rolling the pinned version is a deliberate edit here.
+
+set -euo pipefail
+
+IMAGE="${1:-docker.gitea.com/gitea:1.27.0-rootless}"
+
+CONTAINER_NAME="sortie-gitea-integration"
+HOST_PORT=3000
+ENDPOINT="http://localhost:${HOST_PORT}"
+
+GITEA_USER="sortie"
+GITEA_PASSWORD="Sortie-Integration-Pw1"
+GITEA_EMAIL="sortie@example.com"
+GITEA_REPO="adapter-lab"
+PROJECT="${GITEA_USER}/${GITEA_REPO}"
+
+# The rootless image boots quickly; poll on a short interval and give up well
+# inside the nightly job budget rather than hang a stuck boot.
+READINESS_TIMEOUT=90
+POLL_INTERVAL=2
+
+NEWLINE=$'\n'
+
+# Diagnostics go to stderr so stdout carries only the coordinate assignments.
+log() {
+	printf '%s\n' "$*" >&2
+}
+
+# On a non-zero exit after the container exists, surface its logs so a boot,
+# readiness, or provisioning failure is diagnosable. The container is never
+# removed here: CI discards the runner, and the next local run clears it.
+dump_logs_on_error() {
+	local code=$?
+	if [ "$code" -ne 0 ] && docker inspect "$CONTAINER_NAME" >/dev/null 2>&1; then
+		log "provisioning failed (exit ${code}); recent container logs follow:"
+		docker logs --tail 200 "$CONTAINER_NAME" >&2 || true
+	fi
+}
+trap dump_logs_on_error EXIT
+
+for tool in docker curl jq; do
+	if ! command -v "$tool" >/dev/null 2>&1; then
+		log "required command not found: ${tool}"
+		exit 1
+	fi
+done
+
+# A Gitea API call. Method, path, and auth mode are positional; the JSON request
+# body is read from stdin. Auth mode is "token" (the generated access token) or
+# "basic" (the admin user and password). On any non-2xx status the response body
+# is logged and the call fails, so set -e stops the script and the trap dumps
+# the container logs.
+#
+# Repository creation needs a scope the published token deliberately omits, so
+# that one call runs under basic auth; every issue-scoped call runs under the
+# token, exercising that the published scopes cover the fixture's issue writes.
+gitea_call() {
+	local method="$1" path="$2" auth="$3" body response status
+	body=$(cat)
+	local auth_args=()
+	case "$auth" in
+	token) auth_args=(-H "Authorization: token ${TOKEN}") ;;
+	basic) auth_args=(-u "${GITEA_USER}:${GITEA_PASSWORD}") ;;
+	esac
+	response=$(curl -sS --max-time 30 -w "${NEWLINE}%{http_code}" \
+		"${auth_args[@]}" \
+		-H 'Content-Type: application/json' \
+		-X "$method" "${ENDPOINT}/api/v1${path}" \
+		-d "$body")
+	status=${response##*"$NEWLINE"}
+	response=${response%"$NEWLINE"*}
+	case "$status" in
+	2*)
+		printf '%s' "$response"
+		;;
+	*)
+		log "gitea API ${method} ${path} returned HTTP ${status}: ${response}"
+		return 1
+		;;
+	esac
+}
+
+# Remove a prior container of the fixed name so a repeat local run reclaims the
+# host port instead of failing to bind it.
+docker rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
+
+log "starting ${IMAGE} as ${CONTAINER_NAME} on host port ${HOST_PORT}"
+# INSTALL_LOCK skips the first-run install wizard and DISABLE_REGISTRATION turns
+# off open signup; without the lock the version route answers before the
+# instance can create a user or a token.
+docker run -d --name "$CONTAINER_NAME" \
+	-p "${HOST_PORT}:3000" \
+	-e GITEA__security__INSTALL_LOCK=true \
+	-e GITEA__service__DISABLE_REGISTRATION=true \
+	"$IMAGE" >/dev/null
+
+log "waiting up to ${READINESS_TIMEOUT}s for ${ENDPOINT}/api/v1/version"
+deadline=$((SECONDS + READINESS_TIMEOUT))
+ready=false
+while [ "$SECONDS" -lt "$deadline" ]; do
+	status=$(curl -sS --max-time 5 -o /dev/null -w '%{http_code}' \
+		"${ENDPOINT}/api/v1/version" 2>/dev/null || true)
+	if [ "$status" = "200" ]; then
+		ready=true
+		break
+	fi
+	sleep "$POLL_INTERVAL"
+done
+if [ "$ready" != "true" ]; then
+	log "gitea did not become ready within ${READINESS_TIMEOUT}s"
+	exit 1
+fi
+log "gitea is ready"
+
+# The --must-change-password=false flag is load-bearing: a fresh admin is
+# otherwise forced into a password-change state that blocks token creation.
+log "creating admin user ${GITEA_USER}"
+docker exec "$CONTAINER_NAME" gitea admin user create \
+	--username "$GITEA_USER" \
+	--password "$GITEA_PASSWORD" \
+	--email "$GITEA_EMAIL" \
+	--admin \
+	--must-change-password=false >/dev/null
+
+# Mint the token under basic auth. The scope set is the minimum that covers
+# every operation the suite exercises plus the two construction preflights.
+log "creating access token"
+token_response=$(curl -sS --max-time 30 \
+	-u "${GITEA_USER}:${GITEA_PASSWORD}" \
+	-H 'Content-Type: application/json' \
+	-X POST "${ENDPOINT}/api/v1/users/${GITEA_USER}/tokens" \
+	-d '{"name":"sortie-integration","scopes":["write:issue","read:user","read:repository"]}')
+TOKEN=$(printf '%s' "$token_response" | jq -er '.sha1') || {
+	log "token creation failed: $(printf '%s' "$token_response" | jq -r '.message // .')"
+	exit 1
+}
+
+log "creating repository ${PROJECT}"
+jq -nc --arg name "$GITEA_REPO" '{name: $name, private: false, auto_init: true}' |
+	gitea_call POST "/user/repos" basic >/dev/null
+
+# The five workflow-state and category labels the fixture assigns to its issues.
+create_label() {
+	local name="$1"
+	jq -nc --arg name "$name" '{name: $name, color: "#cccccc"}' |
+		gitea_call POST "/repos/${PROJECT}/labels" token | jq -er '.id'
+}
+log "creating labels"
+label_backlog=$(create_label "backlog")
+label_in_progress=$(create_label "in-progress")
+label_review=$(create_label "review")
+label_done=$(create_label "done")
+label_bug=$(create_label "bug")
+
+# Create an issue with the given title and label ids and echo its repo index.
+create_issue() {
+	local title="$1" labels="$2"
+	jq -nc --arg title "$title" --argjson labels "$labels" \
+		'{title: $title, body: "Seed issue for the gitea adapter integration fixture.", labels: $labels}' |
+		gitea_call POST "/repos/${PROJECT}/issues" token | jq -er '.number'
+}
+
+# The earliest-created issue owns the comments and the blocker relationship, so
+# the candidate ordering (ascending by creation time) puts it first. A short
+# pause between creations keeps the second-precision timestamps strictly
+# ordered, so the first candidate is deterministic.
+log "creating seed issues"
+index_backlog=$(create_issue "Backlog seed issue" "[${label_backlog}]")
+sleep 1
+index_in_progress=$(create_issue "In-progress seed issue" "[${label_in_progress}, ${label_bug}]")
+sleep 1
+# The review issue only needs to exist as a third open candidate; its index is
+# not referenced again, so it is not captured.
+create_issue "Review seed issue" "[${label_review}]" >/dev/null
+sleep 1
+index_done=$(create_issue "Done seed issue" "[${label_done}]")
+
+log "adding comments to issue ${index_backlog}"
+jq -nc '{body: "First seed comment."}' |
+	gitea_call POST "/repos/${PROJECT}/issues/${index_backlog}/comments" token >/dev/null
+jq -nc '{body: "Second seed comment."}' |
+	gitea_call POST "/repos/${PROJECT}/issues/${index_backlog}/comments" token >/dev/null
+
+# Record that the backlog issue blocks the in-progress issue. Gitea reads the
+# blocker from the body and the blocked issue from the path, and it needs the
+# full owner/repo/index triple, not the index alone.
+log "linking issue ${index_backlog} as a blocker of ${index_in_progress}"
+jq -nc --argjson index "$index_backlog" --arg owner "$GITEA_USER" --arg repo "$GITEA_REPO" \
+	'{index: $index, owner: $owner, repo: $repo}' |
+	gitea_call POST "/repos/${PROJECT}/issues/${index_in_progress}/dependencies" token >/dev/null
+
+log "closing issue ${index_done} into its terminal state"
+jq -nc '{state: "closed"}' |
+	gitea_call PATCH "/repos/${PROJECT}/issues/${index_done}" token >/dev/null
+
+# Publish one coordinate to $GITHUB_ENV (when writable) and to stdout. The
+# $GITHUB_ENV file takes a bare KEY=VALUE line, which Actions exports to
+# successor steps. Stdout takes an export statement, so a developer running
+# eval "$(...)" gets the coordinate exported into the shell and inherited by the
+# test process, not merely set as a non-exported shell variable.
+emit() {
+	if [ -n "${GITHUB_ENV:-}" ] && [ -w "${GITHUB_ENV}" ]; then
+		printf '%s=%s\n' "$1" "$2" >>"$GITHUB_ENV"
+	fi
+	printf "export %s='%s'\n" "$1" "$2"
+}
+
+# Register the token as a masked value so it is redacted from the CI log. The
+# mask directive is emitted only under Actions; locally it would pollute the
+# stdout that eval consumes.
+if [ "${GITHUB_ACTIONS:-}" = "true" ]; then
+	printf '::add-mask::%s\n' "$TOKEN"
+fi
+
+log "provisioning complete; publishing coordinates"
+emit SORTIE_GITEA_ENDPOINT "$ENDPOINT"
+emit SORTIE_GITEA_TOKEN "$TOKEN"
+emit SORTIE_GITEA_PROJECT "$PROJECT"
+emit GITEA_IMAGE "$IMAGE"


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Chore | Test

**Intent:** Add the remaining `SORTIE_GITEA_TEST`-gated integration tests for the Gitea adapter's read path and wire them into CI (release gate and nightly drift monitor), matching the pattern already used for the Jira, GitHub, and Linear adapters. Because Gitea is self-hosted, a new provisioning script boots and seeds a pinned containerized instance so the suite runs without an external account or long-lived secret.

**Related Issues:** #633

### 🧭 Reviewer Guide

**Complexity:** Medium

#### Entry Point

`scripts/gitea-integration-provision.sh` - the highest-risk new file. It boots a pinned Gitea container, creates an admin user and access token, and seeds a repository with labels, issues, comments, and a blocker relationship via the live Gitea REST API. The fixture it creates (label set, issue ordering, comment order, the backlog-blocks-in-progress relationship) is what the new tests in `internal/scm/gitea/integration_test.go` assert against, so the two files should be read together.

#### Sensitive Areas

- `scripts/gitea-integration-provision.sh`: mutates a real Docker container and a live Gitea REST API (admin user creation, token minting, repository and issue creation). The `dump_logs_on_error` trap and the `gitea_call` auth-mode switch (token vs. basic) are worth double-checking, since a silent failure here would surface as a confusing test failure rather than a provisioning error.
- `.github/workflows/release.yml`: the new `test-integration-gitea` job is added to the final release gate's `needs` list - a mistake here could block releases unnecessarily or let a broken adapter ship.
- `.github/workflows/nightly.yml`: the new Gitea matrix entry pins `docker.gitea.com/gitea:1.27.0-rootless`; rolling this version is meant to be a deliberate, reviewed edit rather than automatic drift.
- `internal/scm/gitea/integration_test.go`: several assertions (non-nil slice contracts, ascending comment order, state-set membership) depend on the fixture shape the provisioning script seeds - changing one without the other will break the suite.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes.
- **Migrations/State:** No migrations or persistent state changes. The provisioned Gitea container is ephemeral - ephemeral in CI (the runner is discarded after the job) and reclaimed locally (the script removes any prior container of its fixed name before booting).
