### PR TITLE
feat(scm/gitea): add CI status provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,17 +13,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   self-hosted Gitea instance (Forgejo and Codeberg included), at parity with
   the GitHub SCM provider. Set `provider: gitea` on a `reactions.auto_merge`,
   `reactions.review_comments`, `reactions.bot_review`,
-  `reactions.merge_conflicts`, or `reactions.label_commands` block to drive it
-  through Gitea: Sortie routes human and bot review comments back into the
-  agent session, reacts to merge conflicts and to the `sortie:review` /
-  `sortie:fix` label commands, and, with `reactions.auto_merge`, merges an
-  approved pull request once its review decision, CI status, and mergeability
-  satisfy the configured preconditions (sending the expected head SHA so a
-  moved head aborts the merge rather than merging stale work) and deletes the
-  merged branch. Auto-merge on Gitea requires the configured token's user to
-  hold repository write access; a token that cannot push is reported at
-  startup.
+  `reactions.merge_conflicts`, `reactions.ci_failure`, or
+  `reactions.label_commands` block to drive it through Gitea: Sortie routes
+  human and bot review comments back into the agent session, reacts to merge
+  conflicts, to a failing CI run on an agent's pull request (surfacing an
+  excerpt of the first failing check when available), and to the
+  `sortie:review` / `sortie:fix` label commands, and, with
+  `reactions.auto_merge`, merges an approved pull request once its review
+  decision, CI status, and mergeability satisfy the configured preconditions
+  (sending the expected head SHA so a moved head aborts the merge rather than
+  merging stale work) and deletes the merged branch. Auto-merge on Gitea
+  requires the configured token's user to hold repository write access; a
+  token that cannot push is reported at startup.
   ([#656](https://github.com/sortie-ai/sortie/issues/656),
+  [#657](https://github.com/sortie-ai/sortie/issues/657),
   [#658](https://github.com/sortie-ai/sortie/issues/658))
 
 ## [1.15.0] - 2026-07-16

--- a/internal/scm/gitea/ci.go
+++ b/internal/scm/gitea/ci.go
@@ -105,8 +105,9 @@ func NewGiteaCIProvider(maxLogLines int, adapterConfig map[string]any) (domain.C
 // and read directly, so no PR fetch or SHA resolution occurs. The aggregate is
 // computed from the per-status entries, never the top-level state, which Gitea
 // reports as pending for a commit with no CI. CheckRuns is a non-nil slice, empty
-// when the ref has no statuses. A failure maps to a [*domain.CIError]; context
-// cancellation and deadline errors are returned unwrapped.
+// when the ref has no statuses. A failure maps to a [*domain.CIError]; a
+// context cancellation or deadline error is returned without conversion to one,
+// so a caller can still match it with [errors.Is].
 func (p *GiteaCIProvider) FetchCIStatus(ctx context.Context, ref string) (domain.CIResult, error) {
 	path := fmt.Sprintf("/repos/%s/%s/commits/%s/status",
 		url.PathEscape(p.owner), url.PathEscape(p.repo), url.PathEscape(ref))
@@ -268,8 +269,9 @@ func stripANSI(s string) string {
 // giteaToCIError converts an error from the shared Gitea transport into a
 // [*domain.CIError] at the CI boundary.
 //
-// A context cancellation or deadline error is returned unwrapped. A
-// [*domain.TrackerError] is mapped by its Kind onto the matching CI kind,
+// A context cancellation or deadline error is returned as-is, without
+// conversion to a [*domain.CIError], so a caller can match it with [errors.Is].
+// A [*domain.TrackerError] is mapped by its Kind onto the matching CI kind,
 // preserving the chain; any other error becomes [domain.ErrCIAPI].
 func giteaToCIError(err error) error {
 	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {

--- a/internal/scm/gitea/ci.go
+++ b/internal/scm/gitea/ci.go
@@ -1,0 +1,305 @@
+package gitea
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/url"
+	"regexp"
+	"strings"
+
+	"github.com/sortie-ai/sortie/internal/domain"
+	"github.com/sortie-ai/sortie/internal/httpkit"
+	"github.com/sortie-ai/sortie/internal/registry"
+)
+
+func init() {
+	registry.CIProviders.Register("gitea", NewGiteaCIProvider)
+}
+
+// Compile-time interface satisfaction check.
+var _ domain.CIStatusProvider = (*GiteaCIProvider)(nil)
+
+// ansiPattern matches the ANSI escape sequences a CI-produced status
+// description may carry (CSI color and cursor codes, and OSC sequences).
+var ansiPattern = regexp.MustCompile(`\x1b\[[0-9;]*[a-zA-Z]|\x1b\][^\x1b]*\x1b\\|\x1b\].*?\a`)
+
+// GiteaCIProvider implements [domain.CIStatusProvider] for Gitea over the
+// combined commit-status route. All fields are set once at construction and
+// never mutated, so the provider is safe for concurrent use.
+type GiteaCIProvider struct {
+	client      *httpkit.Client
+	owner       string
+	repo        string
+	maxLogLines int
+}
+
+// NewGiteaCIProvider creates a [GiteaCIProvider] from the CI log-line budget and
+// the merged adapter config. maxLogLines caps the failing-status log excerpt; a
+// value of zero or less disables it.
+//
+// Required config keys: "api_key" (access token) and "project" (owner/repo).
+// "endpoint" (instance base URL) is required because Gitea has no default host;
+// it is right-trimmed of slashes and suffixed with "/api/v1" unless it already
+// ends in it. "user_agent" defaults to "sortie/dev". A missing "api_key" returns
+// a [*domain.CIError] of kind [domain.ErrCIAuth]; a missing or malformed
+// "project" or a missing "endpoint" returns one of kind [domain.ErrCIPayload].
+// Construction performs no network I/O: splitting the project is a string parse.
+// The token travels only in the Authorization header set by the shared client
+// and is never logged.
+func NewGiteaCIProvider(maxLogLines int, adapterConfig map[string]any) (domain.CIStatusProvider, error) {
+	apiKey, _ := adapterConfig["api_key"].(string)
+	if apiKey == "" {
+		return nil, &domain.CIError{
+			Kind:    domain.ErrCIAuth,
+			Message: "missing required config key: api_key",
+		}
+	}
+
+	project, _ := adapterConfig["project"].(string)
+	if project == "" {
+		return nil, &domain.CIError{
+			Kind:    domain.ErrCIPayload,
+			Message: "missing required config key: project",
+		}
+	}
+
+	owner, repo, ok := strings.Cut(project, "/")
+	if !ok || owner == "" || repo == "" || strings.Contains(repo, "/") {
+		return nil, &domain.CIError{
+			Kind:    domain.ErrCIPayload,
+			Message: "project must be in owner/repo format",
+		}
+	}
+
+	endpoint, _ := adapterConfig["endpoint"].(string)
+	if endpoint == "" {
+		return nil, &domain.CIError{
+			Kind:    domain.ErrCIPayload,
+			Message: "missing required config key: endpoint",
+		}
+	}
+	endpoint = strings.TrimRight(endpoint, "/")
+	if !strings.HasSuffix(endpoint, "/api/v1") {
+		endpoint += "/api/v1"
+	}
+
+	userAgent, _ := adapterConfig["user_agent"].(string)
+	if userAgent == "" {
+		userAgent = "sortie/dev"
+	}
+
+	return &GiteaCIProvider{
+		client:      newGiteaClient(endpoint, apiKey, userAgent),
+		owner:       owner,
+		repo:        repo,
+		maxLogLines: maxLogLines,
+	}, nil
+}
+
+// FetchCIStatus returns the aggregate CI status for the given git ref by reading
+// Gitea's combined commit status once and normalizing it to a [domain.CIResult].
+//
+// The ref is percent-encoded into GET /repos/{owner}/{repo}/commits/{ref}/status
+// and read directly, so no PR fetch or SHA resolution occurs. The aggregate is
+// computed from the per-status entries, never the top-level state, which Gitea
+// reports as pending for a commit with no CI. CheckRuns is a non-nil slice, empty
+// when the ref has no statuses. A failure maps to a [*domain.CIError]; context
+// cancellation and deadline errors are returned unwrapped.
+func (p *GiteaCIProvider) FetchCIStatus(ctx context.Context, ref string) (domain.CIResult, error) {
+	path := fmt.Sprintf("/repos/%s/%s/commits/%s/status",
+		url.PathEscape(p.owner), url.PathEscape(p.repo), url.PathEscape(ref))
+
+	body, _, err := p.client.Get(ctx, path, nil)
+	if err != nil {
+		return domain.CIResult{}, giteaToCIError(fmt.Errorf("fetching ci status for ref %q: %w", ref, err))
+	}
+
+	var combined giteaCombinedStatus
+	if jsonErr := json.Unmarshal(body, &combined); jsonErr != nil {
+		return domain.CIResult{}, &domain.CIError{
+			Kind:    domain.ErrCIPayload,
+			Message: "failed to parse combined status response",
+			Err:     jsonErr,
+		}
+	}
+
+	runs := make([]domain.CheckRun, len(combined.Statuses))
+	for i, s := range combined.Statuses {
+		runs[i] = domain.CheckRun{
+			Name:       s.Context,
+			Status:     mapRunStatus(s.Status),
+			Conclusion: mapConclusion(s.Status),
+			DetailsURL: s.TargetURL,
+		}
+	}
+
+	status := aggregateStatus(runs)
+
+	var logExcerpt string
+	if status == domain.CIStatusFailing {
+		logExcerpt = buildLogExcerpt(combined.Statuses, p.maxLogLines)
+	}
+
+	return domain.CIResult{
+		Status:       status,
+		CheckRuns:    runs,
+		LogExcerpt:   logExcerpt,
+		FailingCount: failingCount(runs),
+		Ref:          ref,
+	}, nil
+}
+
+// mapRunStatus maps a Gitea commit-status value to a [domain.CheckRunStatus],
+// lowercasing first so a differently-cased value classifies as it does on the
+// merge-gate read. A terminal value is completed; pending, unknown, and empty
+// defer to in progress rather than counting as passing.
+func mapRunStatus(status string) domain.CheckRunStatus {
+	switch strings.ToLower(status) {
+	case "success", "failure", "error", "warning":
+		return domain.CheckRunStatusCompleted
+	default:
+		return domain.CheckRunStatusInProgress
+	}
+}
+
+// mapConclusion maps a Gitea commit-status value to a [domain.CheckConclusion],
+// lowercasing first to match the merge-gate read. error folds to failure and
+// warning to neutral; pending, unknown, and empty defer to pending.
+func mapConclusion(status string) domain.CheckConclusion {
+	switch strings.ToLower(status) {
+	case "success":
+		return domain.CheckConclusionSuccess
+	case "failure", "error":
+		return domain.CheckConclusionFailure
+	case "warning":
+		return domain.CheckConclusionNeutral
+	default:
+		return domain.CheckConclusionPending
+	}
+}
+
+func aggregateStatus(runs []domain.CheckRun) domain.CIStatus {
+	if len(runs) == 0 {
+		return domain.CIStatusPending
+	}
+
+	anyFailed := false
+	allCompleted := true
+	for _, run := range runs {
+		if run.Status != domain.CheckRunStatusCompleted {
+			allCompleted = false
+		}
+		if run.Conclusion == domain.CheckConclusionFailure {
+			anyFailed = true
+		}
+	}
+
+	if anyFailed {
+		return domain.CIStatusFailing
+	}
+	if allCompleted {
+		return domain.CIStatusPassing
+	}
+	return domain.CIStatusPending
+}
+
+func failingCount(runs []domain.CheckRun) int {
+	count := 0
+	for _, run := range runs {
+		if run.Conclusion == domain.CheckConclusionFailure {
+			count++
+		}
+	}
+	return count
+}
+
+// buildLogExcerpt assembles a truncated excerpt from the first failing commit
+// status, drawing only on text already in the authenticated combined-status
+// response. It never fetches TargetURL, so an operator-configured or third-party
+// run URL cannot expand the request beyond the Gitea API. It returns the empty
+// string when log fetching is disabled (maxLogLines is zero or less), no status
+// is failing, or the failing status carries neither a description nor a target.
+func buildLogExcerpt(statuses []giteaCommitState, maxLogLines int) string {
+	if maxLogLines <= 0 {
+		return ""
+	}
+
+	for _, s := range statuses {
+		if mapConclusion(s.Status) != domain.CheckConclusionFailure {
+			continue
+		}
+		excerpt := strings.TrimSpace(s.Description)
+		if s.TargetURL != "" {
+			if excerpt == "" {
+				excerpt = s.TargetURL
+			} else {
+				excerpt += "\n" + s.TargetURL
+			}
+		}
+		if excerpt == "" {
+			return ""
+		}
+		return truncateLines(stripANSI(excerpt), maxLogLines)
+	}
+	return ""
+}
+
+func truncateLines(raw string, maxLines int) string {
+	if maxLines <= 0 {
+		return ""
+	}
+
+	lines := strings.Split(raw, "\n")
+	if len(lines) > maxLines {
+		lines = lines[len(lines)-maxLines:]
+	}
+	return strings.Join(lines, "\n")
+}
+
+func stripANSI(s string) string {
+	return ansiPattern.ReplaceAllString(s, "")
+}
+
+// giteaToCIError converts an error from the shared Gitea transport into a
+// [*domain.CIError] at the CI boundary.
+//
+// A context cancellation or deadline error is returned unwrapped. A
+// [*domain.TrackerError] is mapped by its Kind onto the matching CI kind,
+// preserving the chain; any other error becomes [domain.ErrCIAPI].
+func giteaToCIError(err error) error {
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return err
+	}
+
+	var te *domain.TrackerError
+	if errors.As(err, &te) {
+		var kind domain.CIErrorKind
+		switch te.Kind {
+		case domain.ErrTrackerTransport:
+			kind = domain.ErrCITransport
+		case domain.ErrTrackerAuth:
+			kind = domain.ErrCIAuth
+		case domain.ErrTrackerAPI:
+			kind = domain.ErrCIAPI
+		case domain.ErrTrackerNotFound:
+			kind = domain.ErrCINotFound
+		case domain.ErrTrackerPayload:
+			kind = domain.ErrCIPayload
+		default:
+			kind = domain.ErrCIAPI
+		}
+		return &domain.CIError{
+			Kind:    kind,
+			Message: te.Message,
+			Err:     err,
+		}
+	}
+
+	return &domain.CIError{
+		Kind:    domain.ErrCIAPI,
+		Message: err.Error(),
+		Err:     err,
+	}
+}

--- a/internal/scm/gitea/ci.go
+++ b/internal/scm/gitea/ci.go
@@ -274,6 +274,10 @@ func stripANSI(s string) string {
 // A [*domain.TrackerError] is mapped by its Kind onto the matching CI kind,
 // preserving the chain; any other error becomes [domain.ErrCIAPI].
 func giteaToCIError(err error) error {
+	if err == nil {
+		return nil
+	}
+
 	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 		return err
 	}

--- a/internal/scm/gitea/ci.go
+++ b/internal/scm/gitea/ci.go
@@ -252,6 +252,9 @@ func truncateLines(raw string, maxLines int) string {
 	}
 
 	lines := strings.Split(raw, "\n")
+	for i, line := range lines {
+		lines[i] = strings.TrimRight(line, "\r")
+	}
 	if len(lines) > maxLines {
 		lines = lines[len(lines)-maxLines:]
 	}

--- a/internal/scm/gitea/ci_test.go
+++ b/internal/scm/gitea/ci_test.go
@@ -446,6 +446,12 @@ func TestGiteaTruncateLines(t *testing.T) {
 			maxLines: 1,
 			want:     "https://ci.example.invalid/builds/10",
 		},
+		{
+			name:     "CRLF line endings have their trailing carriage return trimmed",
+			input:    "a\r\nb\r\nc",
+			maxLines: 5,
+			want:     "a\nb\nc",
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/scm/gitea/ci_test.go
+++ b/internal/scm/gitea/ci_test.go
@@ -666,6 +666,16 @@ func TestGiteaToCIError(t *testing.T) {
 	})
 }
 
+func TestGiteaToCIError_NilInput(t *testing.T) {
+	t.Parallel()
+
+	got := giteaToCIError(nil)
+
+	if got != nil {
+		t.Errorf("giteaToCIError(nil) = %v, want nil", got)
+	}
+}
+
 func TestGiteaToCIError_ContextCanceled(t *testing.T) {
 	t.Parallel()
 

--- a/internal/scm/gitea/ci_test.go
+++ b/internal/scm/gitea/ci_test.go
@@ -1,0 +1,908 @@
+package gitea
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/sortie-ai/sortie/internal/domain"
+	"github.com/sortie-ai/sortie/internal/registry"
+)
+
+// --- helpers ---
+
+// mustCIProvider constructs a *GiteaCIProvider against endpoint with a
+// throwaway token and maxLogLines, or fails the test.
+func mustCIProvider(t *testing.T, endpoint string, maxLogLines int) *GiteaCIProvider {
+	t.Helper()
+	p, err := NewGiteaCIProvider(maxLogLines, map[string]any{
+		"endpoint": endpoint,
+		"api_key":  "test-token",
+		"project":  testOwner + "/" + testRepo,
+	})
+	if err != nil {
+		t.Fatalf("NewGiteaCIProvider: %v", err)
+	}
+	return p.(*GiteaCIProvider)
+}
+
+func assertCIErrorKind(t *testing.T, err error, want domain.CIErrorKind) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("expected CIError with kind %q, got nil", want)
+	}
+	var ce *domain.CIError
+	if !errors.As(err, &ce) {
+		t.Fatalf("error type = %T, want *domain.CIError", err)
+	}
+	if ce.Kind != want {
+		t.Errorf("CIError.Kind = %q, want %q", ce.Kind, want)
+	}
+}
+
+// --- status and conclusion mapping ---
+
+func TestGiteaMapRunStatus(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input string
+		want  domain.CheckRunStatus
+	}{
+		{"success completes", "success", domain.CheckRunStatusCompleted},
+		{"failure completes", "failure", domain.CheckRunStatusCompleted},
+		{"error completes", "error", domain.CheckRunStatusCompleted},
+		{"warning completes", "warning", domain.CheckRunStatusCompleted},
+		{"pending is in progress", "pending", domain.CheckRunStatusInProgress},
+		{"unknown value defers to in progress", "unrecognized", domain.CheckRunStatusInProgress},
+		{"empty value defers to in progress", "", domain.CheckRunStatusInProgress},
+		{"uppercase input matches the lowercased case", "SUCCESS", domain.CheckRunStatusCompleted},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := mapRunStatus(tt.input)
+
+			if got != tt.want {
+				t.Errorf("mapRunStatus(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGiteaMapConclusion(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input string
+		want  domain.CheckConclusion
+	}{
+		{"success", "success", domain.CheckConclusionSuccess},
+		{"failure", "failure", domain.CheckConclusionFailure},
+		{"error folds to failure", "error", domain.CheckConclusionFailure},
+		{"warning folds to neutral", "warning", domain.CheckConclusionNeutral},
+		{"pending", "pending", domain.CheckConclusionPending},
+		{"unknown value defers to pending", "unrecognized", domain.CheckConclusionPending},
+		{"empty value defers to pending", "", domain.CheckConclusionPending},
+		{"uppercase input matches the lowercased case", "FAILURE", domain.CheckConclusionFailure},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := mapConclusion(tt.input)
+
+			if got != tt.want {
+				t.Errorf("mapConclusion(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+// --- aggregate status and failing count ---
+
+func TestGiteaAggregateStatus(t *testing.T) {
+	t.Parallel()
+
+	run := func(status domain.CheckRunStatus, conclusion domain.CheckConclusion) domain.CheckRun {
+		return domain.CheckRun{Status: status, Conclusion: conclusion}
+	}
+
+	tests := []struct {
+		name string
+		runs []domain.CheckRun
+		want domain.CIStatus
+	}{
+		{
+			name: "nil slice yields pending",
+			runs: nil,
+			want: domain.CIStatusPending,
+		},
+		{
+			name: "empty slice yields pending",
+			runs: []domain.CheckRun{},
+			want: domain.CIStatusPending,
+		},
+		{
+			name: "all success and completed yields passing",
+			runs: []domain.CheckRun{
+				run(domain.CheckRunStatusCompleted, domain.CheckConclusionSuccess),
+				run(domain.CheckRunStatusCompleted, domain.CheckConclusionSuccess),
+			},
+			want: domain.CIStatusPassing,
+		},
+		{
+			name: "a failure yields failing",
+			runs: []domain.CheckRun{
+				run(domain.CheckRunStatusCompleted, domain.CheckConclusionFailure),
+				run(domain.CheckRunStatusCompleted, domain.CheckConclusionSuccess),
+			},
+			want: domain.CIStatusFailing,
+		},
+		{
+			name: "an in-progress run with no failure yields pending",
+			runs: []domain.CheckRun{
+				run(domain.CheckRunStatusCompleted, domain.CheckConclusionSuccess),
+				run(domain.CheckRunStatusInProgress, domain.CheckConclusionPending),
+			},
+			want: domain.CIStatusPending,
+		},
+		{
+			name: "a failure alongside an in-progress run still yields failing",
+			runs: []domain.CheckRun{
+				run(domain.CheckRunStatusCompleted, domain.CheckConclusionFailure),
+				run(domain.CheckRunStatusInProgress, domain.CheckConclusionPending),
+			},
+			want: domain.CIStatusFailing,
+		},
+		{
+			name: "all completed with a neutral conclusion yields passing",
+			runs: []domain.CheckRun{
+				run(domain.CheckRunStatusCompleted, domain.CheckConclusionNeutral),
+				run(domain.CheckRunStatusCompleted, domain.CheckConclusionSuccess),
+			},
+			want: domain.CIStatusPassing,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := aggregateStatus(tt.runs)
+
+			if got != tt.want {
+				t.Errorf("aggregateStatus(%v) = %q, want %q", tt.runs, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGiteaFailingCount(t *testing.T) {
+	t.Parallel()
+
+	run := func(conclusion domain.CheckConclusion) domain.CheckRun {
+		return domain.CheckRun{Status: domain.CheckRunStatusCompleted, Conclusion: conclusion}
+	}
+
+	tests := []struct {
+		name string
+		runs []domain.CheckRun
+		want int
+	}{
+		{
+			name: "nil slice yields zero",
+			runs: nil,
+			want: 0,
+		},
+		{
+			name: "empty slice yields zero",
+			runs: []domain.CheckRun{},
+			want: 0,
+		},
+		{
+			name: "all passing yields zero",
+			runs: []domain.CheckRun{
+				run(domain.CheckConclusionSuccess),
+				run(domain.CheckConclusionNeutral),
+			},
+			want: 0,
+		},
+		{
+			name: "one failure",
+			runs: []domain.CheckRun{
+				run(domain.CheckConclusionFailure),
+				run(domain.CheckConclusionSuccess),
+			},
+			want: 1,
+		},
+		{
+			name: "counts only the failure conclusion, not cancelled or timed out",
+			runs: []domain.CheckRun{
+				run(domain.CheckConclusionFailure),
+				run(domain.CheckConclusionCancelled),
+				run(domain.CheckConclusionTimedOut),
+				run(domain.CheckConclusionSuccess),
+			},
+			want: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := failingCount(tt.runs)
+
+			if got != tt.want {
+				t.Errorf("failingCount(%v) = %d, want %d", tt.runs, got, tt.want)
+			}
+		})
+	}
+}
+
+// --- FetchCIStatus normalization ---
+
+func TestGiteaFetchCIStatus(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name             string
+		fixture          string
+		wantStatus       domain.CIStatus
+		wantFailingCount int
+		wantCheckRunLen  int
+	}{
+		{
+			name:             "all success statuses yield passing",
+			fixture:          "status_all_success.json",
+			wantStatus:       domain.CIStatusPassing,
+			wantFailingCount: 0,
+			wantCheckRunLen:  2,
+		},
+		{
+			name:             "a failure among successes yields failing",
+			fixture:          "status_has_failure.json",
+			wantStatus:       domain.CIStatusFailing,
+			wantFailingCount: 1,
+			wantCheckRunLen:  2,
+		},
+		{
+			name:             "no statuses yield pending from the empty slice",
+			fixture:          "status_no_checks.json",
+			wantStatus:       domain.CIStatusPending,
+			wantFailingCount: 0,
+			wantCheckRunLen:  0,
+		},
+		{
+			name:             "a pending status with no failure yields pending",
+			fixture:          "status_has_pending.json",
+			wantStatus:       domain.CIStatusPending,
+			wantFailingCount: 0,
+			wantCheckRunLen:  2,
+		},
+		{
+			name:             "a warning among successes yields passing",
+			fixture:          "status_warning_only.json",
+			wantStatus:       domain.CIStatusPassing,
+			wantFailingCount: 0,
+			wantCheckRunLen:  2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			fixture := loadFixture(t, tt.fixture)
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write(fixture)
+			}))
+			defer srv.Close()
+			provider := mustCIProvider(t, srv.URL, 50)
+
+			got, err := provider.FetchCIStatus(context.Background(), "main")
+
+			if err != nil {
+				t.Fatalf("FetchCIStatus: unexpected error: %v", err)
+			}
+			if got.Status != tt.wantStatus {
+				t.Errorf("FetchCIStatus().Status = %q, want %q", got.Status, tt.wantStatus)
+			}
+			if got.FailingCount != tt.wantFailingCount {
+				t.Errorf("FetchCIStatus().FailingCount = %d, want %d", got.FailingCount, tt.wantFailingCount)
+			}
+			if got.CheckRuns == nil {
+				t.Error("FetchCIStatus().CheckRuns = nil, want non-nil")
+			}
+			if len(got.CheckRuns) != tt.wantCheckRunLen {
+				t.Errorf("len(FetchCIStatus().CheckRuns) = %d, want %d", len(got.CheckRuns), tt.wantCheckRunLen)
+			}
+			if tt.wantStatus != domain.CIStatusFailing && got.LogExcerpt != "" {
+				t.Errorf("FetchCIStatus().LogExcerpt = %q, want empty for a non-failing status", got.LogExcerpt)
+			}
+			if got.Ref != "main" {
+				t.Errorf("FetchCIStatus().Ref = %q, want %q", got.Ref, "main")
+			}
+		})
+	}
+
+	t.Run("check run Name and DetailsURL map from context and target_url", func(t *testing.T) {
+		t.Parallel()
+
+		fixture := loadFixture(t, "status_all_success.json")
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(fixture)
+		}))
+		defer srv.Close()
+		provider := mustCIProvider(t, srv.URL, 50)
+
+		got, err := provider.FetchCIStatus(context.Background(), "main")
+
+		if err != nil {
+			t.Fatalf("FetchCIStatus: unexpected error: %v", err)
+		}
+		wantNames := []string{"ci/build", "ci/test"}
+		if len(got.CheckRuns) != len(wantNames) {
+			t.Fatalf("len(FetchCIStatus().CheckRuns) = %d, want %d", len(got.CheckRuns), len(wantNames))
+		}
+		for i, run := range got.CheckRuns {
+			if run.Name != wantNames[i] {
+				t.Errorf("CheckRuns[%d].Name = %q, want %q", i, run.Name, wantNames[i])
+			}
+			if run.DetailsURL != "" {
+				t.Errorf("CheckRuns[%d].DetailsURL = %q, want empty (fixture carries no target_url)", i, run.DetailsURL)
+			}
+		}
+	})
+}
+
+// --- log excerpt ---
+
+func TestGiteaStripANSI(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"plain text is unchanged", "unit tests failed", "unit tests failed"},
+		{"CSI color sequence is stripped", "\x1b[0;31mFAIL\x1b[0m", "FAIL"},
+		{"OSC sequence terminated by BEL is stripped", "\x1b]0;title\atext", "text"},
+		{"OSC sequence terminated by ST is stripped", "\x1b]0;title\x1b\\text", "text"},
+		{"empty string is unchanged", "", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := stripANSI(tt.input)
+
+			if got != tt.want {
+				t.Errorf("stripANSI(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGiteaTruncateLines(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    string
+		maxLines int
+		want     string
+	}{
+		{
+			name:     "zero maxLines yields empty",
+			input:    "a\nb\nc",
+			maxLines: 0,
+			want:     "",
+		},
+		{
+			name:     "negative maxLines yields empty",
+			input:    "a\nb\nc",
+			maxLines: -1,
+			want:     "",
+		},
+		{
+			name:     "empty input yields empty",
+			input:    "",
+			maxLines: 5,
+			want:     "",
+		},
+		{
+			name:     "input at or below maxLines is unchanged",
+			input:    "a\nb",
+			maxLines: 5,
+			want:     "a\nb",
+		},
+		{
+			name:     "input above maxLines keeps the tail",
+			input:    "a\nb\nc\nd",
+			maxLines: 2,
+			want:     "c\nd",
+		},
+		{
+			name:     "maxLines of one keeps only the last line",
+			input:    "unit tests failed\nhttps://ci.example.invalid/builds/10",
+			maxLines: 1,
+			want:     "https://ci.example.invalid/builds/10",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := truncateLines(tt.input, tt.maxLines)
+
+			if got != tt.want {
+				t.Errorf("truncateLines(%q, %d) = %q, want %q", tt.input, tt.maxLines, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGiteaCILogExcerpt(t *testing.T) {
+	t.Parallel()
+
+	t.Run("description and target_url from the first failing entry join into a non-empty excerpt", func(t *testing.T) {
+		t.Parallel()
+
+		fixture := loadFixture(t, "ci_status_failing_target.json")
+		var requestCount atomic.Int32
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			requestCount.Add(1)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(fixture)
+		}))
+		defer srv.Close()
+		provider := mustCIProvider(t, srv.URL, 10)
+
+		got, err := provider.FetchCIStatus(context.Background(), "main")
+
+		if err != nil {
+			t.Fatalf("FetchCIStatus: unexpected error: %v", err)
+		}
+		if got.Status != domain.CIStatusFailing {
+			t.Fatalf("FetchCIStatus().Status = %q, want %q", got.Status, domain.CIStatusFailing)
+		}
+		if !strings.Contains(got.LogExcerpt, "unit tests failed") {
+			t.Errorf("LogExcerpt = %q, want it to contain the first failing entry's description", got.LogExcerpt)
+		}
+		if !strings.Contains(got.LogExcerpt, "https://ci.example.invalid/builds/10") {
+			t.Errorf("LogExcerpt = %q, want it to contain the first failing entry's target_url", got.LogExcerpt)
+		}
+		if strings.Contains(got.LogExcerpt, "lint failed") {
+			t.Errorf("LogExcerpt = %q, want only the first failing entry, not a later one", got.LogExcerpt)
+		}
+		if n := requestCount.Load(); n != 1 {
+			t.Errorf("combined status endpoint received %d requests, want 1 (no network request for target_url)", n)
+		}
+	})
+
+	t.Run("maxLogLines zero disables the excerpt", func(t *testing.T) {
+		t.Parallel()
+
+		fixture := loadFixture(t, "ci_status_failing_target.json")
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(fixture)
+		}))
+		defer srv.Close()
+		provider := mustCIProvider(t, srv.URL, 0)
+
+		got, err := provider.FetchCIStatus(context.Background(), "main")
+
+		if err != nil {
+			t.Fatalf("FetchCIStatus: unexpected error: %v", err)
+		}
+		if got.LogExcerpt != "" {
+			t.Errorf("LogExcerpt = %q, want empty when maxLogLines is zero", got.LogExcerpt)
+		}
+	})
+
+	t.Run("a failing entry with empty description and empty target_url yields an empty excerpt", func(t *testing.T) {
+		t.Parallel()
+
+		const body = `{"state":"failure","total_count":1,"statuses":[{"id":20,"status":"failure","context":"ci/test"}]}`
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(body))
+		}))
+		defer srv.Close()
+		provider := mustCIProvider(t, srv.URL, 10)
+
+		got, err := provider.FetchCIStatus(context.Background(), "main")
+
+		if err != nil {
+			t.Fatalf("FetchCIStatus: unexpected error: %v", err)
+		}
+		if got.Status != domain.CIStatusFailing {
+			t.Fatalf("FetchCIStatus().Status = %q, want %q", got.Status, domain.CIStatusFailing)
+		}
+		if got.LogExcerpt != "" {
+			t.Errorf("LogExcerpt = %q, want empty when the failing entry has no description or target_url", got.LogExcerpt)
+		}
+	})
+
+	t.Run("a description-only failing entry still yields a non-empty excerpt", func(t *testing.T) {
+		t.Parallel()
+
+		fixture := loadFixture(t, "status_has_failure.json")
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(fixture)
+		}))
+		defer srv.Close()
+		provider := mustCIProvider(t, srv.URL, 50)
+
+		got, err := provider.FetchCIStatus(context.Background(), "main")
+
+		if err != nil {
+			t.Fatalf("FetchCIStatus: unexpected error: %v", err)
+		}
+		const want = "Tests failed"
+		if got.LogExcerpt != want {
+			t.Errorf("LogExcerpt = %q, want %q", got.LogExcerpt, want)
+		}
+	})
+
+	t.Run("a passing status yields an empty excerpt regardless of maxLogLines", func(t *testing.T) {
+		t.Parallel()
+
+		fixture := loadFixture(t, "status_all_success.json")
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(fixture)
+		}))
+		defer srv.Close()
+		provider := mustCIProvider(t, srv.URL, 50)
+
+		got, err := provider.FetchCIStatus(context.Background(), "main")
+
+		if err != nil {
+			t.Fatalf("FetchCIStatus: unexpected error: %v", err)
+		}
+		if got.LogExcerpt != "" {
+			t.Errorf("LogExcerpt = %q, want empty for a passing status", got.LogExcerpt)
+		}
+	})
+}
+
+// --- error mapping ---
+
+func TestGiteaToCIError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		statusCode int
+		fixture    string
+		wantKind   domain.CIErrorKind
+	}{
+		{
+			name:       "401 unauthorized maps to ErrCIAuth",
+			statusCode: http.StatusUnauthorized,
+			fixture:    "error_401.json",
+			wantKind:   domain.ErrCIAuth,
+		},
+		{
+			name:       "404 not found maps to ErrCINotFound",
+			statusCode: http.StatusNotFound,
+			fixture:    "error_404.json",
+			wantKind:   domain.ErrCINotFound,
+		},
+		{
+			name:       "5xx server error maps to ErrCITransport",
+			statusCode: http.StatusInternalServerError,
+			fixture:    "error_401.json",
+			wantKind:   domain.ErrCITransport,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			fixture := loadFixture(t, tt.fixture)
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(tt.statusCode)
+				_, _ = w.Write(fixture)
+			}))
+			defer srv.Close()
+			provider := mustCIProvider(t, srv.URL, 0)
+
+			_, err := provider.FetchCIStatus(context.Background(), "main")
+
+			assertCIErrorKind(t, err, tt.wantKind)
+		})
+	}
+
+	t.Run("malformed 2xx body maps to ErrCIPayload", func(t *testing.T) {
+		t.Parallel()
+
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{not valid json"))
+		}))
+		defer srv.Close()
+		provider := mustCIProvider(t, srv.URL, 0)
+
+		_, err := provider.FetchCIStatus(context.Background(), "main")
+
+		assertCIErrorKind(t, err, domain.ErrCIPayload)
+	})
+}
+
+func TestGiteaToCIError_ContextCanceled(t *testing.T) {
+	t.Parallel()
+
+	got := giteaToCIError(fmt.Errorf("fetching ci status: %w", context.Canceled))
+
+	if !errors.Is(got, context.Canceled) {
+		t.Errorf("giteaToCIError(context.Canceled) = %v, want context.Canceled passthrough", got)
+	}
+}
+
+func TestGiteaToCIError_DeadlineExceeded(t *testing.T) {
+	t.Parallel()
+
+	got := giteaToCIError(fmt.Errorf("fetching ci status: %w", context.DeadlineExceeded))
+
+	if !errors.Is(got, context.DeadlineExceeded) {
+		t.Errorf("giteaToCIError(context.DeadlineExceeded) = %v, want context.DeadlineExceeded passthrough", got)
+	}
+}
+
+func TestGiteaToCIError_TrackerKindMapping(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		trackerKind domain.TrackerErrorKind
+		wantKind    domain.CIErrorKind
+	}{
+		{"transport maps to ErrCITransport", domain.ErrTrackerTransport, domain.ErrCITransport},
+		{"auth maps to ErrCIAuth", domain.ErrTrackerAuth, domain.ErrCIAuth},
+		{"api maps to ErrCIAPI", domain.ErrTrackerAPI, domain.ErrCIAPI},
+		{"not found maps to ErrCINotFound", domain.ErrTrackerNotFound, domain.ErrCINotFound},
+		{"payload maps to ErrCIPayload", domain.ErrTrackerPayload, domain.ErrCIPayload},
+		{"an unrecognized kind defaults to ErrCIAPI", domain.TrackerErrorKind("unreachable_kind"), domain.ErrCIAPI},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			te := &domain.TrackerError{Kind: tt.trackerKind, Message: "boom"}
+
+			got := giteaToCIError(te)
+
+			var ce *domain.CIError
+			if !errors.As(got, &ce) {
+				t.Fatalf("giteaToCIError returned %T, want *domain.CIError", got)
+			}
+			if ce.Kind != tt.wantKind {
+				t.Errorf("CIError.Kind = %q, want %q", ce.Kind, tt.wantKind)
+			}
+			if ce.Message != te.Message {
+				t.Errorf("CIError.Message = %q, want %q", ce.Message, te.Message)
+			}
+			if !errors.Is(got, te) {
+				t.Error("giteaToCIError: underlying TrackerError not preserved in the error chain")
+			}
+		})
+	}
+}
+
+func TestGiteaToCIError_NonTrackerError(t *testing.T) {
+	t.Parallel()
+
+	base := errors.New("boom")
+
+	got := giteaToCIError(fmt.Errorf("wrapped: %w", base))
+
+	var ce *domain.CIError
+	if !errors.As(got, &ce) {
+		t.Fatalf("giteaToCIError returned %T, want *domain.CIError", got)
+	}
+	if ce.Kind != domain.ErrCIAPI {
+		t.Errorf("CIError.Kind = %q, want %q", ce.Kind, domain.ErrCIAPI)
+	}
+	if !errors.Is(got, base) {
+		t.Error("giteaToCIError: underlying error not preserved in the error chain")
+	}
+}
+
+// --- registration, request shape, and construction ---
+
+func TestGiteaCIRegistration(t *testing.T) {
+	t.Parallel()
+
+	if !registry.CIProviders.Has("gitea") {
+		t.Fatal(`CIProviders.Has("gitea") = false, want true`)
+	}
+
+	constructor, err := registry.CIProviders.Get("gitea")
+	if err != nil {
+		t.Fatalf(`CIProviders.Get("gitea") = %v, want registered constructor`, err)
+	}
+
+	provider, err := constructor(0, map[string]any{
+		"api_key":  "test-token",
+		"project":  testOwner + "/" + testRepo,
+		"endpoint": "http://gitea.invalid",
+	})
+
+	if err != nil {
+		t.Fatalf("registered gitea CI constructor(...) = %v, want nil error", err)
+	}
+	if _, ok := provider.(*GiteaCIProvider); !ok {
+		t.Errorf("registered gitea CI constructor(...) = %T, want *GiteaCIProvider", provider)
+	}
+	if !registry.Trackers.Has("gitea") {
+		t.Error(`Trackers.Has("gitea") = false, want true (CI registration must not disturb the tracker registration)`)
+	}
+	if !registry.SCMAdapters.Has("gitea") {
+		t.Error(`SCMAdapters.Has("gitea") = false, want true (CI registration must not disturb the SCM registration)`)
+	}
+}
+
+func TestGiteaCIRequestShape(t *testing.T) {
+	t.Parallel()
+
+	fixture := loadFixture(t, "status_no_checks.json")
+	var gotPath, gotQuery, gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotQuery = r.URL.RawQuery
+		gotAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(fixture)
+	}))
+	defer srv.Close()
+	const ref = "main"
+	provider := mustCIProvider(t, srv.URL, 0)
+
+	_, err := provider.FetchCIStatus(context.Background(), ref)
+
+	if err != nil {
+		t.Fatalf("FetchCIStatus: unexpected error: %v", err)
+	}
+	wantPath := fmt.Sprintf("/api/v1/repos/%s/%s/commits/%s/status", testOwner, testRepo, ref)
+	if gotPath != wantPath {
+		t.Errorf("request path = %q, want %q", gotPath, wantPath)
+	}
+	if gotQuery != "" {
+		t.Errorf("request query = %q, want empty (no access_token query parameter)", gotQuery)
+	}
+	const wantAuth = "token test-token"
+	if gotAuth != wantAuth {
+		t.Errorf("Authorization header = %q, want %q", gotAuth, wantAuth)
+	}
+}
+
+func TestNewGiteaCIProvider(t *testing.T) {
+	t.Parallel()
+
+	t.Run("missing api_key returns ErrCIAuth", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := NewGiteaCIProvider(0, map[string]any{
+			"project":  testOwner + "/" + testRepo,
+			"endpoint": "http://gitea.invalid",
+		})
+
+		assertCIErrorKind(t, err, domain.ErrCIAuth)
+	})
+
+	t.Run("missing project returns ErrCIPayload", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := NewGiteaCIProvider(0, map[string]any{
+			"api_key":  "test-token",
+			"endpoint": "http://gitea.invalid",
+		})
+
+		assertCIErrorKind(t, err, domain.ErrCIPayload)
+	})
+
+	t.Run("malformed project returns ErrCIPayload", func(t *testing.T) {
+		t.Parallel()
+
+		tests := []struct {
+			name    string
+			project string
+		}{
+			{"no slash", "noslash"},
+			{"empty owner", "/repo"},
+			{"empty repo", "owner/"},
+			{"too many slashes", "owner/repo/extra"},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+
+				_, err := NewGiteaCIProvider(0, map[string]any{
+					"api_key":  "test-token",
+					"project":  tt.project,
+					"endpoint": "http://gitea.invalid",
+				})
+
+				assertCIErrorKind(t, err, domain.ErrCIPayload)
+			})
+		}
+	})
+
+	t.Run("missing endpoint returns ErrCIPayload", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := NewGiteaCIProvider(0, map[string]any{
+			"api_key": "test-token",
+			"project": testOwner + "/" + testRepo,
+		})
+
+		assertCIErrorKind(t, err, domain.ErrCIPayload)
+	})
+
+	t.Run("endpoint already ending in /api/v1 is not double-suffixed", func(t *testing.T) {
+		t.Parallel()
+
+		fixture := loadFixture(t, "status_no_checks.json")
+		var gotPath string
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotPath = r.URL.Path
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(fixture)
+		}))
+		defer srv.Close()
+
+		provider, err := NewGiteaCIProvider(0, map[string]any{
+			"api_key":  "test-token",
+			"project":  testOwner + "/" + testRepo,
+			"endpoint": srv.URL + "/api/v1",
+		})
+		if err != nil {
+			t.Fatalf("NewGiteaCIProvider: %v", err)
+		}
+
+		_, err = provider.FetchCIStatus(context.Background(), "main")
+
+		if err != nil {
+			t.Fatalf("FetchCIStatus: unexpected error: %v", err)
+		}
+		wantPath := fmt.Sprintf("/api/v1/repos/%s/%s/commits/main/status", testOwner, testRepo)
+		if gotPath != wantPath {
+			t.Errorf("request path = %q, want %q (endpoint already suffixed with /api/v1 must not be doubled)", gotPath, wantPath)
+		}
+	})
+}

--- a/internal/scm/gitea/scm_merge.go
+++ b/internal/scm/gitea/scm_merge.go
@@ -39,9 +39,15 @@ type giteaCombinedStatus struct {
 	Statuses   []giteaCommitState `json:"statuses"`
 }
 
-// giteaCommitState is one entry of the combined status statuses array.
+// giteaCommitState is one entry of the combined status statuses array. Status is
+// the per-entry outcome read by GetCIStatus; Context, TargetURL, and Description
+// are consumed by the CI status provider, which maps each entry to a check run
+// and draws the failing-status log excerpt from Description and TargetURL.
 type giteaCommitState struct {
-	Status string `json:"status"`
+	Status      string `json:"status"`
+	Context     string `json:"context"`
+	TargetURL   string `json:"target_url"`
+	Description string `json:"description"`
 }
 
 // fetchPullRequest issues GET /repos/{owner}/{repo}/pulls/{prNumber} and decodes

--- a/internal/scm/gitea/testdata/ci_status_failing_target.json
+++ b/internal/scm/gitea/testdata/ci_status_failing_target.json
@@ -1,0 +1,10 @@
+{
+  "state": "failure",
+  "sha": "sha-clean-001",
+  "total_count": 3,
+  "statuses": [
+    { "id": 9, "status": "success", "context": "ci/build", "description": "Build passed" },
+    { "id": 10, "status": "failure", "context": "ci/test", "description": "unit tests failed: 3 assertions", "target_url": "https://ci.example.invalid/builds/10" },
+    { "id": 11, "status": "failure", "context": "ci/lint", "description": "lint failed: 2 warnings", "target_url": "https://ci.example.invalid/builds/11" }
+  ]
+}


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Feat

**Intent:** Implements `domain.CIStatusProvider` for Gitea by reading the combined commit status endpoint and normalizing it to `domain.CIResult`, so Sortie can escalate CI failures on an agent's pull request for a Gitea-backed deployment at parity with the GitHub CI status provider.

**Related Issues:** #657

### 🧭 Reviewer Guide

**Complexity:** Medium

#### Entry Point

`internal/scm/gitea/ci.go` defines `GiteaCIProvider` and its `FetchCIStatus` method, registered under kind `gitea` in `registry.CIProviders`. `FetchCIStatus` reads Gitea's combined commit status once, maps each status entry to a `domain.CheckRun`, and computes the aggregate `domain.CIStatus` from the per-entry results rather than the response's top-level `state` field.

#### Sensitive Areas

- `internal/scm/gitea/ci.go`: `aggregateStatus` treats a commit with no statuses as pending rather than passing, and a single failing status anywhere in the set as failing even alongside in-progress runs - worth confirming this matches the semantics the escalation caller expects.
- `internal/scm/gitea/ci.go`: `buildLogExcerpt` draws the failing-status excerpt only from `description` and `target_url` already present in the authenticated combined-status response, and never dereferences `target_url` over the network, so an operator-configured or third-party CI URL cannot expand the request surface.
- `internal/scm/gitea/scm_merge.go`: `giteaCommitState` gains `Context`, `TargetURL`, and `Description` fields shared with the existing merge-gate read in `GetCIStatus`.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes
- **Migrations/State:** No migrations or state changes