### PR TITLE
feat(validate): catch malformed SCM/CI reaction config offline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#656](https://github.com/sortie-ai/sortie/issues/656),
   [#657](https://github.com/sortie-ai/sortie/issues/657),
   [#658](https://github.com/sortie-ai/sortie/issues/658))
+- `sortie validate` reaction and CI feedback checks: before dispatch,
+  `sortie validate` now reports a reaction or `ci_feedback` block that
+  names an SCM or CI provider Sortie does not recognize, active reactions
+  that disagree on the SCM provider, a `bot_review` `bot_usernames`
+  allowlist that is not a list of names, and an `auto_merge` `strategy`
+  that is not `merge`, `squash`, or `rebase`. These faults block dispatch,
+  and apply to every SCM provider including the new Gitea one.
+  ([#659](https://github.com/sortie-ai/sortie/issues/659))
 
 ## [1.15.0] - 2026-07-16
 

--- a/cmd/sortie/validate.go
+++ b/cmd/sortie/validate.go
@@ -124,8 +124,30 @@ func runValidate(_ context.Context, args []string, stdout io.Writer, stderr io.W
 		})
 	}
 
-	if !validation.OK() {
-		emitDiags(stdout, stderr, *format, mapPreflightErrors(validation.Errors), warningDiags)
+	// Fold the offline forge diagnostics into the same exit decision as
+	// the preflight errors. A reaction- or activation-only fault must
+	// block dispatch even when the dispatch preflight passes, so both the
+	// exit code and the JSON valid flag key on the union of preflight,
+	// reaction, and activation errors.
+	var forgeDiags []validateDiag
+	for _, rd := range orchestrator.ValidateReactionConfigs(cfg) {
+		forgeDiags = append(forgeDiags, validateDiag{Severity: rd.Severity, Check: rd.Check, Message: rd.Message})
+	}
+	forgeDiags = append(forgeDiags, activationChecks(cfg)...)
+
+	var forgeErrors []validateDiag
+	for _, fd := range forgeDiags {
+		if fd.Severity == "warning" {
+			warningDiags = append(warningDiags, fd)
+			continue
+		}
+		forgeErrors = append(forgeErrors, fd)
+	}
+
+	combinedErrors := mapPreflightErrors(validation.Errors)
+	combinedErrors = append(combinedErrors, forgeErrors...)
+	if len(combinedErrors) > 0 {
+		emitDiags(stdout, stderr, *format, combinedErrors, warningDiags)
 		return 1
 	}
 
@@ -204,6 +226,56 @@ func mapPreflightErrors(errs []orchestrator.PreflightError) []validateDiag {
 	for i, e := range errs {
 		diags[i] = validateDiag{Severity: "error", Check: e.Check, Message: e.Message}
 	}
+	return diags
+}
+
+// activationChecks reports the offline-decidable SCM and CI activation
+// faults in the resolved config: an active SCM reaction naming an
+// unregistered provider, active SCM reactions disagreeing on the provider,
+// and a ci_feedback.kind naming no registered CI provider. It reuses
+// scmProviderConflict and the adapter registries the runtime consults at
+// construction, so it constructs no adapter and opens no socket.
+func activationChecks(cfg config.ServiceConfig) []validateDiag {
+	var diags []validateDiag
+
+	reviewRC := cfg.Reactions["review_comments"]
+	autoMergeRC := cfg.Reactions["auto_merge"]
+	botReviewRC := cfg.Reactions["bot_review"]
+	mergeConflictRC := cfg.Reactions["merge_conflicts"]
+	labelReviewActive := cfg.LabelCommands.Provider != "" && cfg.LabelCommands.ReviewLabel != ""
+	labelFixActive := cfg.LabelCommands.Provider != "" && cfg.LabelCommands.FixLabel != ""
+
+	activeSCMKinds := []scmReactionKind{
+		{name: "review_comments", active: reviewRC.Provider != "", provider: reviewRC.Provider},
+		{name: "auto_merge", active: autoMergeRC.Provider != "", provider: autoMergeRC.Provider},
+		{name: "bot_review", active: botReviewRC.Provider != "", provider: botReviewRC.Provider},
+		{name: "merge_conflicts", active: mergeConflictRC.Provider != "", provider: mergeConflictRC.Provider},
+		{name: "label_commands", active: labelReviewActive || labelFixActive, provider: cfg.LabelCommands.Provider},
+	}
+
+	activeKinds, providers := scmProviderConflict(activeSCMKinds)
+	if len(providers) > 1 {
+		diags = append(diags, validateDiag{
+			Severity: "error",
+			Check:    "reactions.scm_provider_conflict",
+			Message:  fmt.Sprintf("active SCM reactions %v must use a single provider, found %v", activeKinds, providers),
+		})
+	} else if len(providers) == 1 && !registry.SCMAdapters.Has(providers[0]) {
+		diags = append(diags, validateDiag{
+			Severity: "error",
+			Check:    "scm_adapter",
+			Message:  fmt.Sprintf("SCM adapter kind %q named by active reactions is not registered", providers[0]),
+		})
+	}
+
+	if cfg.CIFeedback.Kind != "" && !registry.CIProviders.Has(cfg.CIFeedback.Kind) {
+		diags = append(diags, validateDiag{
+			Severity: "error",
+			Check:    "ci_provider",
+			Message:  fmt.Sprintf("CI provider kind %q is not registered", cfg.CIFeedback.Kind),
+		})
+	}
+
 	return diags
 }
 

--- a/cmd/sortie/validate.go
+++ b/cmd/sortie/validate.go
@@ -264,7 +264,7 @@ func activationChecks(cfg config.ServiceConfig) []validateDiag {
 		diags = append(diags, validateDiag{
 			Severity: "error",
 			Check:    "scm_adapter",
-			Message:  fmt.Sprintf("SCM adapter kind %q named by active reactions is not registered", providers[0]),
+			Message:  fmt.Sprintf("no registered SCM adapter for kind %q named by active reactions", providers[0]),
 		})
 	}
 
@@ -272,7 +272,7 @@ func activationChecks(cfg config.ServiceConfig) []validateDiag {
 		diags = append(diags, validateDiag{
 			Severity: "error",
 			Check:    "ci_provider",
-			Message:  fmt.Sprintf("CI provider kind %q is not registered", cfg.CIFeedback.Kind),
+			Message:  fmt.Sprintf("no registered CI provider for kind %q", cfg.CIFeedback.Kind),
 		})
 	}
 

--- a/cmd/sortie/validate_test.go
+++ b/cmd/sortie/validate_test.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/sortie-ai/sortie/internal/config"
 )
 
 // errWriter is a test double that always returns a fixed error from Write.
@@ -1963,7 +1965,8 @@ Do {{ .issue.title }}.
 
 // labelCommandsUnregisteredProviderWorkflow returns a workflow whose
 // label_commands.provider names an SCM adapter that is not registered.
-// Provider validity is deferred to construction, not checked offline.
+// activationChecks reports this offline as an scm_adapter error, the
+// same registry lookup failure that already blocks construction.
 func labelCommandsUnregisteredProviderWorkflow() []byte {
 	return []byte(`---
 tracker:
@@ -2025,10 +2028,11 @@ func TestRunValidate_LabelCommandsBothLabelsEmpty(t *testing.T) {
 	}
 }
 
-// TestRunValidate_LabelCommandsUnregisteredProviderNotRejected is the
-// companion case: an unregistered provider value is NOT a validate error,
-// since provider validity is deferred to adapter construction.
-func TestRunValidate_LabelCommandsUnregisteredProviderNotRejected(t *testing.T) {
+// TestRunValidate_LabelCommandsUnregisteredProviderRejected is the
+// companion case: an unregistered provider value named by an active
+// label_commands reaction is a validate-time scm_adapter error, the
+// same registry lookup failure that already blocks construction.
+func TestRunValidate_LabelCommandsUnregisteredProviderRejected(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
@@ -2038,9 +2042,20 @@ func TestRunValidate_LabelCommandsUnregisteredProviderNotRejected(t *testing.T) 
 	var stdout, stderr bytes.Buffer
 	ctx := context.Background()
 
-	code := run(ctx, []string{"validate", wfPath}, &stdout, &stderr)
-	if code != 0 {
-		t.Fatalf("run(validate) = %d, want 0 (provider validity is deferred to construction); stderr: %s", code, stderr.String())
+	code := run(ctx, []string{"validate", "--format", "json", wfPath}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("run(validate --format json) = %d, want 1; stderr: %s", code, stderr.String())
+	}
+
+	var out validateOutput
+	if err := json.Unmarshal(stdout.Bytes(), &out); err != nil {
+		t.Fatalf("json.Unmarshal(%q) error: %v", stdout.String(), err)
+	}
+	if out.Valid {
+		t.Errorf("validateOutput.Valid = true, want false")
+	}
+	if d := diagWithCheck(out.Errors, "scm_adapter"); d == nil {
+		t.Errorf("validateOutput.Errors = %v, want a diagnostic with check %q", out.Errors, "scm_adapter")
 	}
 }
 
@@ -2098,5 +2113,428 @@ func TestRunValidate_LabelCommandsFixOnlyValid(t *testing.T) {
 	}
 	if !out.Valid {
 		t.Errorf("validateOutput.Valid = false, want true; errors: %v", out.Errors)
+	}
+}
+
+// --- Gitea forge validate checks ---
+
+// diagWithCheck returns a pointer to the first diag in diags whose Check
+// matches want, or nil if none match.
+func diagWithCheck(diags []validateDiag, want string) *validateDiag {
+	for i := range diags {
+		if diags[i].Check == want {
+			return &diags[i]
+		}
+	}
+	return nil
+}
+
+// forgeCheckKeys lists every check key this feature can emit: the two
+// reaction-config diagnostics plus the three activation diagnostics.
+var forgeCheckKeys = []string{
+	"reactions.bot_review",
+	"reactions.auto_merge",
+	"scm_adapter",
+	"ci_provider",
+	"reactions.scm_provider_conflict",
+}
+
+// giteaForgeWorkflow returns a WORKFLOW.md whose front matter sets a
+// fully valid gitea tracker and agent so preflight passes cleanly;
+// extraYAML is appended before the closing front-matter delimiter to
+// vary the reactions/ci_feedback block under test.
+func giteaForgeWorkflow(extraYAML string) []byte {
+	return []byte(`---
+tracker:
+  kind: gitea
+  endpoint: "https://gitea.example.com"
+  api_key: "gitea-forge-test-token"
+  project: "acme/widgets"
+  active_states:
+    - backlog
+  terminal_states:
+    - done
+agent:
+  kind: mock
+` + extraYAML + `---
+Do {{ .issue.title }}.
+`)
+}
+
+// forgeFaultWorkflow returns a WORKFLOW.md with a minimal valid tracker
+// (file) and agent, so ValidateDispatchConfig passes cleanly, with
+// extraYAML appended to introduce exactly one forge-only fault.
+func forgeFaultWorkflow(extraYAML string) []byte {
+	return []byte(`---
+tracker:
+  kind: file
+  active_states:
+    - To Do
+  terminal_states:
+    - Done
+agent:
+  kind: mock
+` + extraYAML + `---
+Do {{ .issue.title }}.
+`)
+}
+
+// TestActivationChecks covers activationChecks directly with hand-built
+// config.ServiceConfig literals, bypassing config.NewServiceConfig.
+func TestActivationChecks(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		cfg        config.ServiceConfig
+		wantChecks []string
+	}{
+		{
+			name: "unregistered SCM provider",
+			cfg: config.ServiceConfig{
+				Reactions: map[string]config.ReactionConfig{
+					"bot_review": {Provider: "gitea-scm"},
+				},
+			},
+			wantChecks: []string{"scm_adapter"},
+		},
+		{
+			name: "unregistered CI provider",
+			cfg: config.ServiceConfig{
+				CIFeedback: config.CIFeedbackConfig{Kind: "gitea-ci"},
+			},
+			wantChecks: []string{"ci_provider"},
+		},
+		{
+			name: "two active reactions naming different providers",
+			cfg: config.ServiceConfig{
+				Reactions: map[string]config.ReactionConfig{
+					"bot_review": {Provider: "gitea"},
+					"auto_merge": {Provider: "github"},
+				},
+			},
+			wantChecks: []string{"reactions.scm_provider_conflict"},
+		},
+		{
+			name: "all gitea is clean",
+			cfg: config.ServiceConfig{
+				Reactions: map[string]config.ReactionConfig{
+					"bot_review": {Provider: "gitea"},
+					"auto_merge": {Provider: "gitea"},
+				},
+				CIFeedback: config.CIFeedbackConfig{Kind: "gitea"},
+			},
+			wantChecks: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := activationChecks(tt.cfg)
+
+			if len(got) != len(tt.wantChecks) {
+				t.Fatalf("activationChecks(cfg) = %v, want %d diag(s) with checks %v", got, len(tt.wantChecks), tt.wantChecks)
+			}
+			for i, wantCheck := range tt.wantChecks {
+				if got[i].Check != wantCheck {
+					t.Errorf("activationChecks(cfg) diag[%d].Check = %q, want %q", i, got[i].Check, wantCheck)
+				}
+				if got[i].Severity != "error" {
+					t.Errorf("activationChecks(cfg) diag[%d].Severity = %q, want %q", i, got[i].Severity, "error")
+				}
+			}
+		})
+	}
+}
+
+// TestValidateGiteaForge exercises the fold point end-to-end through
+// runValidate for a tracker.kind: gitea workflow, varying the reactions
+// and ci_feedback blocks to isolate one forge fault per case.
+func TestValidateGiteaForge(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		extraYAML string
+		wantCheck string
+		wantCode  int
+	}{
+		{
+			name: "bot_review bare string bot_usernames",
+			extraYAML: `reactions:
+  bot_review:
+    provider: gitea
+    bot_usernames: alice
+`,
+			wantCheck: "reactions.bot_review",
+			wantCode:  1,
+		},
+		{
+			name: "auto_merge strategy rebase-merge",
+			extraYAML: `reactions:
+  auto_merge:
+    provider: gitea
+    strategy: rebase-merge
+`,
+			wantCheck: "reactions.auto_merge",
+			wantCode:  1,
+		},
+		{
+			name: "unregistered SCM provider",
+			extraYAML: `reactions:
+  bot_review:
+    provider: gitea-scm
+`,
+			wantCheck: "scm_adapter",
+			wantCode:  1,
+		},
+		{
+			name: "unregistered CI provider",
+			extraYAML: `ci_feedback:
+  kind: gitea-ci
+`,
+			wantCheck: "ci_provider",
+			wantCode:  1,
+		},
+		{
+			name: "active reactions naming different providers",
+			extraYAML: `reactions:
+  bot_review:
+    provider: gitea
+  auto_merge:
+    provider: github
+`,
+			wantCheck: "reactions.scm_provider_conflict",
+			wantCode:  1,
+		},
+		{
+			name: "fully valid gitea forge configuration",
+			extraYAML: `reactions:
+  bot_review:
+    provider: gitea
+    bot_usernames:
+      - sortie-bot
+  auto_merge:
+    provider: gitea
+    strategy: squash
+ci_feedback:
+  kind: gitea
+`,
+			wantCheck: "",
+			wantCode:  0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			dir := t.TempDir()
+			wfPath := writeCustomWorkflowFile(t, dir, giteaForgeWorkflow(tt.extraYAML))
+
+			var stdout, stderr bytes.Buffer
+			code := run(context.Background(), []string{"validate", "--format", "json", wfPath}, &stdout, &stderr)
+			if code != tt.wantCode {
+				t.Fatalf("run(validate) = %d, want %d; stderr: %s", code, tt.wantCode, stderr.String())
+			}
+
+			var out validateOutput
+			if err := json.Unmarshal(stdout.Bytes(), &out); err != nil {
+				t.Fatalf("json.Unmarshal(%q) error: %v", stdout.String(), err)
+			}
+
+			if tt.wantCheck == "" {
+				if !out.Valid {
+					t.Errorf("validateOutput.Valid = false, want true; errors: %v", out.Errors)
+				}
+				for _, key := range forgeCheckKeys {
+					if d := diagWithCheck(out.Errors, key); d != nil {
+						t.Errorf("validateOutput.Errors contains forge diagnostic %q = %v, want none", key, d)
+					}
+					if d := diagWithCheck(out.Warnings, key); d != nil {
+						t.Errorf("validateOutput.Warnings contains forge diagnostic %q = %v, want none", key, d)
+					}
+				}
+				return
+			}
+
+			if out.Valid {
+				t.Errorf("validateOutput.Valid = true, want false")
+			}
+			d := diagWithCheck(out.Errors, tt.wantCheck)
+			if d == nil {
+				t.Fatalf("validateOutput.Errors = %v, want a diagnostic with check %q", out.Errors, tt.wantCheck)
+			}
+			if d.Severity != "error" {
+				t.Errorf("validateOutput.Errors[%q].Severity = %q, want %q", tt.wantCheck, d.Severity, "error")
+			}
+		})
+	}
+
+	t.Run("messages never leak the tracker api key", func(t *testing.T) {
+		t.Parallel()
+
+		const apiKey = "gitea-forge-test-token"
+
+		dir := t.TempDir()
+		wfPath := writeCustomWorkflowFile(t, dir, giteaForgeWorkflow(`reactions:
+  bot_review:
+    provider: gitea
+    bot_usernames: not-a-list
+  auto_merge:
+    provider: gitea
+    strategy: rebase-merge
+`))
+
+		var stdout, stderr bytes.Buffer
+		code := run(context.Background(), []string{"validate", "--format", "json", wfPath}, &stdout, &stderr)
+		if code != 1 {
+			t.Fatalf("run(validate) = %d, want 1; stderr: %s", code, stderr.String())
+		}
+
+		var out validateOutput
+		if err := json.Unmarshal(stdout.Bytes(), &out); err != nil {
+			t.Fatalf("json.Unmarshal(%q) error: %v", stdout.String(), err)
+		}
+		for _, d := range out.Errors {
+			if strings.Contains(d.Message, apiKey) {
+				t.Errorf("validateOutput.Errors contains message %q with the tracker api key", d.Message)
+			}
+		}
+	})
+}
+
+// TestValidateForgeFoldPointJSON guards the fold point: a forge-only
+// error with no preflight error must not be masked by an otherwise
+// passing preflight, in both JSON and text output modes.
+func TestValidateForgeFoldPointJSON(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		extraYAML string
+		wantCheck string
+	}{
+		{
+			name: "auto_merge invalid strategy, no preflight error",
+			extraYAML: `reactions:
+  auto_merge:
+    provider: gitea
+    strategy: rebase-merge
+`,
+			wantCheck: "reactions.auto_merge",
+		},
+		{
+			name: "unregistered SCM provider, no preflight error",
+			extraYAML: `reactions:
+  bot_review:
+    provider: gitea-scm
+`,
+			wantCheck: "scm_adapter",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			dir := t.TempDir()
+			wfPath := writeCustomWorkflowFile(t, dir, forgeFaultWorkflow(tt.extraYAML))
+
+			var stdout, stderr bytes.Buffer
+			code := run(context.Background(), []string{"validate", "--format", "json", wfPath}, &stdout, &stderr)
+			if code != 1 {
+				t.Fatalf("run(validate --format json) = %d, want 1; stderr: %s", code, stderr.String())
+			}
+
+			var out validateOutput
+			if err := json.Unmarshal(stdout.Bytes(), &out); err != nil {
+				t.Fatalf("json.Unmarshal(%q) error: %v", stdout.String(), err)
+			}
+			if out.Valid {
+				t.Errorf("validateOutput.Valid = true, want false (forge-only error must not be masked by a passing preflight)")
+			}
+			if d := diagWithCheck(out.Errors, tt.wantCheck); d == nil {
+				t.Errorf("validateOutput.Errors = %v, want a diagnostic with check %q", out.Errors, tt.wantCheck)
+			}
+		})
+	}
+
+	t.Run("text format also exits 1 with no preflight error", func(t *testing.T) {
+		t.Parallel()
+
+		dir := t.TempDir()
+		wfPath := writeCustomWorkflowFile(t, dir, forgeFaultWorkflow(`reactions:
+  auto_merge:
+    provider: gitea
+    strategy: rebase-merge
+`))
+
+		var stdout, stderr bytes.Buffer
+		code := run(context.Background(), []string{"validate", wfPath}, &stdout, &stderr)
+		if code != 1 {
+			t.Fatalf("run(validate) = %d, want 1; stderr: %s", code, stderr.String())
+		}
+	})
+}
+
+// giteaShadowedEscalationWorkflow returns a WORKFLOW.md whose bot_review
+// reaction sets an invalid escalation value. buildReactionsConfig rejects
+// this at the config layer before orchestrator.ValidateReactionConfigs
+// ever runs.
+func giteaShadowedEscalationWorkflow() []byte {
+	return []byte(`---
+tracker:
+  kind: file
+  active_states:
+    - To Do
+  terminal_states:
+    - Done
+agent:
+  kind: mock
+reactions:
+  bot_review:
+    provider: gitea
+    escalation: bogus
+---
+Do {{ .issue.title }}.
+`)
+}
+
+// TestValidateShadowedEscalation proves that a malformed reaction
+// escalation is reported and exits before ValidateReactionConfigs runs,
+// so no reactions.bot_review or reactions.auto_merge diagnostic ever
+// appears end-to-end for this fault.
+func TestValidateShadowedEscalation(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	wfPath := writeCustomWorkflowFile(t, dir, giteaShadowedEscalationWorkflow())
+
+	var stdout, stderr bytes.Buffer
+	code := run(context.Background(), []string{"validate", "--format", "json", wfPath}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("run(validate --format json) = %d, want 1; stderr: %s", code, stderr.String())
+	}
+
+	var out validateOutput
+	if err := json.Unmarshal(stdout.Bytes(), &out); err != nil {
+		t.Fatalf("json.Unmarshal(%q) error: %v", stdout.String(), err)
+	}
+	if out.Valid {
+		t.Errorf("validateOutput.Valid = true, want false")
+	}
+
+	const wantCheck = "config.reactions.bot_review.escalation"
+	if d := diagWithCheck(out.Errors, wantCheck); d == nil {
+		t.Errorf("validateOutput.Errors = %v, want a diagnostic with check %q", out.Errors, wantCheck)
+	}
+
+	for _, shadowed := range []string{"reactions.bot_review", "reactions.auto_merge"} {
+		if d := diagWithCheck(out.Errors, shadowed); d != nil {
+			t.Errorf("validateOutput.Errors contains shadowed check %q = %v, want absent (config layer must exit first)", shadowed, d)
+		}
 	}
 }

--- a/internal/orchestrator/reaction_validate.go
+++ b/internal/orchestrator/reaction_validate.go
@@ -1,0 +1,41 @@
+package orchestrator
+
+import (
+	"github.com/sortie-ai/sortie/internal/config"
+	"github.com/sortie-ai/sortie/internal/registry"
+)
+
+// ValidateReactionConfigs checks the reaction configuration that the
+// orchestrator would build at construction and returns a diagnostic for
+// each active reaction whose configuration would fail. It constructs no
+// adapter and makes no network call.
+//
+// Only the bot_review and auto_merge reactions are inspected, the two
+// carrying the review-bot allowlist and the merge strategy. Each is
+// validated with the same builder the orchestrator runs at construction,
+// so the offline verdict cannot diverge from the construction verdict.
+func ValidateReactionConfigs(cfg config.ServiceConfig) []registry.ValidationDiag {
+	var diags []registry.ValidationDiag
+
+	if rc, ok := cfg.Reactions["bot_review"]; ok && rc.Provider != "" {
+		if _, err := BuildBotReviewReactionConfig(rc); err != nil {
+			diags = append(diags, registry.ValidationDiag{
+				Severity: "error",
+				Check:    "reactions.bot_review",
+				Message:  err.Error(),
+			})
+		}
+	}
+
+	if rc, ok := cfg.Reactions["auto_merge"]; ok && rc.Provider != "" {
+		if _, err := BuildAutoMergeReactionConfig(rc); err != nil {
+			diags = append(diags, registry.ValidationDiag{
+				Severity: "error",
+				Check:    "reactions.auto_merge",
+				Message:  err.Error(),
+			})
+		}
+	}
+
+	return diags
+}

--- a/internal/orchestrator/reaction_validate_test.go
+++ b/internal/orchestrator/reaction_validate_test.go
@@ -1,0 +1,194 @@
+package orchestrator
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/sortie-ai/sortie/internal/config"
+	"github.com/sortie-ai/sortie/internal/registry"
+)
+
+// --- Test helpers ---
+
+// assertNoMessageContains fails the test if any diag's Message contains substr.
+func assertNoMessageContains(t *testing.T, diags []registry.ValidationDiag, substr string) {
+	t.Helper()
+	for i, d := range diags {
+		if strings.Contains(d.Message, substr) {
+			t.Errorf("diag[%d].Message = %q, must not contain %q", i, d.Message, substr)
+		}
+	}
+}
+
+// --- Tests ---
+
+func TestValidateReactionConfigs(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		cfg        config.ServiceConfig
+		wantChecks []string
+	}{
+		{
+			name: "bot_review bare string bot_usernames",
+			cfg: config.ServiceConfig{
+				Reactions: map[string]config.ReactionConfig{
+					"bot_review": {Provider: "gitea", Extra: map[string]any{"bot_usernames": "alice"}},
+				},
+			},
+			wantChecks: []string{"reactions.bot_review"},
+		},
+		{
+			name: "bot_review non-string element in bot_usernames list",
+			cfg: config.ServiceConfig{
+				Reactions: map[string]config.ReactionConfig{
+					"bot_review": {Provider: "gitea", Extra: map[string]any{"bot_usernames": []any{"alice", 42}}},
+				},
+			},
+			wantChecks: []string{"reactions.bot_review"},
+		},
+		{
+			name: "auto_merge strategy out of enum",
+			cfg: config.ServiceConfig{
+				Reactions: map[string]config.ReactionConfig{
+					"auto_merge": {Provider: "gitea", Extra: map[string]any{"strategy": "rebase-merge"}},
+				},
+			},
+			wantChecks: []string{"reactions.auto_merge"},
+		},
+		{
+			name: "auto_merge strategy non-string",
+			cfg: config.ServiceConfig{
+				Reactions: map[string]config.ReactionConfig{
+					"auto_merge": {Provider: "gitea", Extra: map[string]any{"strategy": 123}},
+				},
+			},
+			wantChecks: []string{"reactions.auto_merge"},
+		},
+		{
+			// buildReactionsConfig hard-errors on a malformed escalation
+			// before ValidateReactionConfigs ever runs, so this arm is
+			// reachable ONLY through this direct call, never through
+			// runValidate. See TestValidateShadowedEscalation in cmd/sortie
+			// for the end-to-end proof that the config layer fires first.
+			name: "bot_review shadowed escalation reachable only by direct call",
+			cfg: config.ServiceConfig{
+				Reactions: map[string]config.ReactionConfig{
+					"bot_review": {Provider: "gitea", Escalation: "bogus"},
+				},
+			},
+			wantChecks: []string{"reactions.bot_review"},
+		},
+		{
+			name: "auto_merge shadowed escalation reachable only by direct call",
+			cfg: config.ServiceConfig{
+				Reactions: map[string]config.ReactionConfig{
+					"auto_merge": {Provider: "gitea", Escalation: "bogus"},
+				},
+			},
+			wantChecks: []string{"reactions.auto_merge"},
+		},
+		{
+			name: "both reactions invalid accumulate in order",
+			cfg: config.ServiceConfig{
+				Reactions: map[string]config.ReactionConfig{
+					"bot_review": {Provider: "gitea", Extra: map[string]any{"bot_usernames": "alice"}},
+					"auto_merge": {Provider: "gitea", Extra: map[string]any{"strategy": "bad"}},
+				},
+			},
+			wantChecks: []string{"reactions.bot_review", "reactions.auto_merge"},
+		},
+		{
+			name: "clean bot_review and auto_merge produce no diags",
+			cfg: config.ServiceConfig{
+				Reactions: map[string]config.ReactionConfig{
+					"bot_review": {Provider: "gitea", Extra: map[string]any{"bot_usernames": []any{"alice", "bob"}}},
+					"auto_merge": {Provider: "gitea", Extra: map[string]any{"strategy": "squash"}},
+				},
+			},
+			wantChecks: nil,
+		},
+		{
+			name:       "absent reactions map",
+			cfg:        config.ServiceConfig{},
+			wantChecks: nil,
+		},
+		{
+			name: "inactive reactions with empty provider are skipped",
+			cfg: config.ServiceConfig{
+				Reactions: map[string]config.ReactionConfig{
+					"bot_review": {Provider: "", Extra: map[string]any{"bot_usernames": "not-a-list"}},
+					"auto_merge": {Provider: "", Extra: map[string]any{"strategy": "bogus"}},
+				},
+			},
+			wantChecks: nil,
+		},
+		{
+			name: "nil Extra tolerated with defaults applied",
+			cfg: config.ServiceConfig{
+				Reactions: map[string]config.ReactionConfig{
+					"bot_review": {Provider: "gitea"},
+					"auto_merge": {Provider: "gitea"},
+				},
+			},
+			wantChecks: nil,
+		},
+		{
+			// Only bot_review and auto_merge are dispatched; a malformed
+			// review_comments or merge_conflicts Extra field must never
+			// surface a diagnostic here.
+			name: "review_comments and merge_conflicts are never inspected",
+			cfg: config.ServiceConfig{
+				Reactions: map[string]config.ReactionConfig{
+					"review_comments":  {Provider: "gitea", Extra: map[string]any{"poll_interval_ms": "not-an-int"}},
+					"merge_conflicts":  {Provider: "gitea", Extra: map[string]any{"debounce_ms": "bad"}},
+					"label_commands":   {Provider: "gitea", Extra: map[string]any{"anything": "goes"}},
+					"unknown_reaction": {Provider: "gitea", Extra: map[string]any{"anything": "goes"}},
+				},
+			},
+			wantChecks: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := ValidateReactionConfigs(tt.cfg)
+
+			if len(got) != len(tt.wantChecks) {
+				t.Fatalf("ValidateReactionConfigs(cfg) = %v, want %d diag(s) with checks %v", got, len(tt.wantChecks), tt.wantChecks)
+			}
+			for i, wantCheck := range tt.wantChecks {
+				if got[i].Check != wantCheck {
+					t.Errorf("ValidateReactionConfigs(cfg) diag[%d].Check = %q, want %q", i, got[i].Check, wantCheck)
+				}
+				if got[i].Severity != "error" {
+					t.Errorf("ValidateReactionConfigs(cfg) diag[%d].Severity = %q, want %q", i, got[i].Severity, "error")
+				}
+			}
+		})
+	}
+
+	t.Run("messages never leak a secret value", func(t *testing.T) {
+		t.Parallel()
+
+		const secret = "sortie-secret-token-9f3ac1" //nolint:gosec // test fixture value, not a real credential
+
+		cfg := config.ServiceConfig{
+			Tracker: config.TrackerConfig{APIKey: secret},
+			Reactions: map[string]config.ReactionConfig{
+				"bot_review": {Provider: "gitea", Extra: map[string]any{"bot_usernames": "not-a-list"}},
+				"auto_merge": {Provider: "gitea", Extra: map[string]any{"strategy": "rebase-merge"}},
+			},
+		}
+
+		got := ValidateReactionConfigs(cfg)
+
+		if len(got) != 2 {
+			t.Fatalf("ValidateReactionConfigs(cfg) = %v, want 2 diags", got)
+		}
+		assertNoMessageContains(t, got, secret)
+	})
+}


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Feat

**Intent:** Extend `sortie validate` to catch malformed forge-related reaction and CI configuration offline, before the orchestrator dispatches an issue, so a deployment learns of a broken reaction or CI setup at validate time rather than at dispatch. The checks are provider-agnostic, so they apply to every SCM/CI provider, including the new Gitea adapter.

**Related Issues:** #659

### 🧭 Reviewer Guide

**Complexity:** Medium

#### Entry Point

`cmd/sortie/validate.go` - `activationChecks` is the new function to start with. `runValidate` folds its diagnostics, together with `orchestrator.ValidateReactionConfigs`, into the same exit-code and JSON `valid` decision it already uses for preflight errors, so a reaction- or activation-only fault now blocks dispatch even when preflight passes.

#### Sensitive Areas

- `cmd/sortie/validate.go`: changes the fold point that decides `runValidate`'s exit code and JSON `valid` flag - worth confirming preflight-only failures still behave exactly as before.
- `internal/orchestrator/reaction_validate.go`: `ValidateReactionConfigs` reuses `BuildBotReviewReactionConfig` and `BuildAutoMergeReactionConfig`, the same builders the orchestrator calls at construction, so the offline verdict tracks those builders rather than duplicating their rules.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes to the `sortie validate` CLI contract (flags, output format, exit code semantics). Validate is stricter now: a workflow config naming an unregistered SCM/CI provider, disagreeing across active reactions on the SCM provider, or setting a malformed `bot_review.bot_usernames` / `auto_merge.strategy` now fails validate instead of only failing at adapter construction.
- **Migrations/State:** No migrations or state changes.
