### PR TITLE
docs: document gitea scm adapter and ci provider in reference docs

### DIFF
--- a/docs/architecture/12-ci-feedback-contract.md
+++ b/docs/architecture/12-ci-feedback-contract.md
@@ -169,3 +169,13 @@ comes from the `extensions` sub-object keyed by `ci_feedback.kind`. Startup merg
 credentials (API key, project, endpoint) into that config only when `tracker.kind` and
 `ci_feedback.kind` match.
 
+**Gitea provider.** A Gitea CI status provider registers under kind `gitea`, at parity with the
+GitHub provider. Gitea exposes no check-runs API, so the provider reads the combined commit status
+as the single source and maps each status entry to a `CheckRun`. It computes the aggregate from
+those entries, not from the combined status's top-level state, which Gitea reports as `pending` for
+a commit that carries no CI at all. The empty case is detected by a zero status count, so a no-CI
+ref reports `pending` from an empty check set rather than a false `passing` or `failing`. A
+`warning` status is treated as non-failing. The failing-check log excerpt is drawn only from the
+status description and target URL already present in the authenticated response; the provider never
+fetches the target URL, so the trust boundary stays at the Gitea API.
+

--- a/docs/architecture/13-pr-review-comment-feedback-contract.md
+++ b/docs/architecture/13-pr-review-comment-feedback-contract.md
@@ -28,6 +28,14 @@ type SCMAdapter interface {
 - Only comments from `CHANGES_REQUESTED` reviews are returned. Approved reviews, comment-only
   reviews, and bot comments (`user.type == "Bot"`) are excluded.
 
+**Gitea adapter.** A Gitea SCM adapter registers under kind `gitea`, at parity with the GitHub
+adapter. It normalizes Gitea's native `REQUEST_CHANGES` review state to the `CHANGES_REQUESTED`
+decision this contract uses, skips dismissed reviews, and deduplicates comments by identifier.
+Gitea users carry no `type: Bot` marker, so `FetchPendingReviews` on Gitea cannot exclude a
+bot-authored changes-requested review the way the GitHub adapter's platform-marker check does;
+automated-reviewer feedback is separated instead through the bot-review reaction's username
+allowlist (§11D).
+
 ### 11B.2 ReviewComment structure
 
 ```text

--- a/docs/architecture/14-auto-merge-reaction-contract.md
+++ b/docs/architecture/14-auto-merge-reaction-contract.md
@@ -92,6 +92,15 @@ The auto-merge reconcile loop evaluates the merge preconditions reported by `Get
 | Merging | `ErrSCMAuth` | Escalated | Escalate immediately; do not re-enqueue. |
 | Merging | Other transient error | Pending | Re-enqueue with backoff; escalate after `MaxRetries`. |
 
+**Gitea auto-merge reads.** The Gitea adapter has no aggregate review-decision field and no
+`mergeable_state` string, so it composes both preconditions itself. `GetReviewDecision` folds the
+per-review list, taking the latest `APPROVED` or `CHANGES_REQUESTED` per reviewer and combining it
+with the PR's requested-reviewers signal into one decision. `GetMergeability` maps Gitea's single
+`mergeable` boolean to `clean` (mergeable and not a draft), `blocked` (draft), or `unknown`
+(anything else), and never yields `dirty` or `unstable`. Gitea cannot distinguish a merge conflict
+from an in-progress recheck, so both present as `unknown`, which this table re-enqueues on the poll
+interval as a transient state.
+
 ### 11C.6 Escalation behavior
 
 When `reaction_attempts[issue_id:merge] >= MaxRetries` or when `ErrSCMAuth` is returned on

--- a/docs/architecture/14-auto-merge-reaction-contract.md
+++ b/docs/architecture/14-auto-merge-reaction-contract.md
@@ -94,8 +94,9 @@ The auto-merge reconcile loop evaluates the merge preconditions reported by `Get
 
 **Gitea auto-merge reads.** The Gitea adapter has no aggregate review-decision field and no
 `mergeable_state` string, so it composes both preconditions itself. `GetReviewDecision` folds the
-per-review list, taking the latest `APPROVED` or `CHANGES_REQUESTED` per reviewer and combining it
-with the PR's requested-reviewers signal into one decision. `GetMergeability` maps Gitea's single
+per-review list, taking each reviewer's latest approving or changes-requested review, normalizing
+Gitea's native `REQUEST_CHANGES` review state to this contract's `CHANGES_REQUESTED`, and combining
+the result with the PR's requested-reviewers signal into one decision. `GetMergeability` maps Gitea's single
 `mergeable` boolean to `clean` (mergeable and not a draft), `blocked` (draft), or `unknown`
 (anything else), and never yields `dirty` or `unstable`. Gitea cannot distinguish a merge conflict
 from an in-progress recheck, so both present as `unknown`, which this table re-enqueues on the poll

--- a/docs/gitea-adapter-notes.md
+++ b/docs/gitea-adapter-notes.md
@@ -410,7 +410,7 @@ Sketch, verified end-to-end by this research's provisioning sequence:
 
 ## SCM read surface
 
-The tracker adapter package also implements the SCM read methods `GetReviewDecision`, `GetMergeability`, `GetCIStatus`, `FetchPendingReviews`, `FetchBotReviewComments`, and `ListLabelEvents` (`domain.SCMAdapter`, `internal/domain/scm.go`). Gitea exposes no GraphQL API and no aggregate review-decision or check-runs endpoint, so each read is composed from REST routes under `/api/v1`. Every route below was reached live against the localhost Gitea 1.27.0 lab instance and returned HTTP 200; where the lab PR carried no data to populate a response, the object shape is schema-inferred from the instance OpenAPI description and marked for reconciliation against a captured live fixture in the env-gated integration tests (#660).
+The tracker adapter package also implements the SCM read methods `GetReviewDecision`, `GetMergeability`, `GetCIStatus`, `FetchPendingReviews`, `FetchBotReviewComments`, and `ListLabelEvents` (`domain.SCMAdapter`, `internal/domain/scm.go`). Gitea exposes no GraphQL API and no aggregate review-decision or check-runs endpoint, so each read is composed from REST routes under `/api/v1`. Every route below was reached live against the localhost Gitea 1.27.0 lab instance and returned HTTP 200; where the lab PR carried no data to populate a response, the object shape is schema-inferred from the instance OpenAPI description and marked for reconciliation against a captured live fixture in the env-gated integration tests (issue #660).
 
 | Method | Gitea route(s) |
 | --- | --- |
@@ -431,7 +431,7 @@ GET /repos/{owner}/{repo}/pulls/{index}/reviews
 - Each review carries `dismissed` (an operator nullified the review), `official`, `stale`, `body`, `submitted_at`, `user.login`, and `id`. Dismissed reviews are skipped by every read.
 - `FetchPendingReviews` returns the comments of non-bot `REQUEST_CHANGES` reviews; `FetchBotReviewComments` returns the comments of reviews whose author matches a bot-username allowlist, with no review-state filter. Gitea users carry no `type: Bot` marker, so bot classification is the allowlist alone (see [Bot classification](#bot-classification)).
 - Paginated by page number, not the `Link` header (see [SCM read pagination](#scm-read-pagination)).
-- The route was reached live (HTTP 200); the lab PR carried zero reviews, so the populated `PullReview` object shape is schema-inferred and MUST be reconciled against a captured live review-list fixture (#660).
+- The route was reached live (HTTP 200); the lab PR carried zero reviews, so the populated `PullReview` object shape is schema-inferred and MUST be reconciled against a captured live review-list fixture (issue #660).
 
 ### Review comments
 
@@ -441,7 +441,7 @@ GET /repos/{owner}/{repo}/pulls/{index}/reviews/{id}/comments
 
 - Each comment carries `path`, `body`, `position`, `original_position`, `created_at`, `id`, and `user.login`. There is no `line`, `start_line`, or `end_line` field, so review comments are single-line and `EndLine` normalizes to 0.
 - `position` is the line on the current diff; `position: 0` marks a comment whose anchor a later push removed, in which case `original_position` holds the line it was written against and the comment normalizes with `Outdated` true.
-- The route is present in the instance OpenAPI; the lab PR carried no review comments, so the `position`/`original_position` semantics and the outdated derivation are schema-inferred and MUST be reconciled against a captured live review-comment fixture (#660).
+- The route is present in the instance OpenAPI; the lab PR carried no review comments, so the `position`/`original_position` semantics and the outdated derivation are schema-inferred and MUST be reconciled against a captured live review-comment fixture (issue #660).
 
 ### Review decision
 
@@ -469,7 +469,7 @@ GET /repos/{owner}/{repo}/commits/{sha}/status
 - Returns `{state, sha, statuses, total_count}`. The top-level `state` is the aggregate; each entry in the `statuses` array carries its own `status`. The two field names differ and MUST NOT be conflated.
 - Empty detection keys on `total_count == 0`: a commit with no CI returns `total_count: 0`, `statuses: null`, and a spurious top-level `state: "pending"` (verified). Trusting the top-level `state` would report `pending` for a no-CI commit and wrongly hold auto-merge, so the aggregate is read from the per-status entries instead.
 - Per-status `status` values are `success`, `failure`, `error`, `warning`, and `pending`. `failure` and `error` are failing; `warning` and `success` are non-failing; `pending` is pending. Each entry also carries `context` (the check name), `target_url`, and `description`.
-- The per-status `target_url` field name is authored from the Gitea `CommitStatus` swagger and was absent from the lab data, and whether this route paginates for a many-status commit is unverified; both are deferred to the env-gated integration tests (#660).
+- The per-status `target_url` field name is authored from the Gitea `CommitStatus` swagger and was absent from the lab data, and whether this route paginates for a many-status commit is unverified; both are deferred to the env-gated integration tests (issue #660).
 
 ### Label event timeline
 
@@ -503,7 +503,7 @@ GET /repos/{owner}/{repo}/commits/{ref}/status
 - Each per-status entry becomes a `CheckRun`: `context` is the check name, `status` maps to the run status and conclusion (`success` to success, `failure` and `error` to failure, `warning` to neutral, everything else to pending), and `target_url` is the details URL.
 - The aggregate is computed from the per-status entries, never the top-level `state` (the same spurious-`pending`-on-empty trap as the SCM read). An empty status set yields a pending result with an empty, non-nil check-run slice.
 - The failing-status log excerpt is assembled from the first failing entry's `description` and `target_url`, both already in the authenticated combined-status response. The provider never fetches `target_url`, so an operator-configured or third-party run URL cannot expand the request beyond the Gitea API. ANSI escape sequences are stripped and the excerpt is truncated to `max_log_lines`; a zero budget, or a failing entry with neither field, omits the excerpt.
-- The `target_url` field name and the route's pagination behavior carry the same deferred verification (#660) as the combined-status SCM read.
+- The `target_url` field name and the route's pagination behavior carry the same deferred verification (issue #660) as the combined-status SCM read.
 
 ---
 

--- a/docs/gitea-adapter-notes.md
+++ b/docs/gitea-adapter-notes.md
@@ -1,6 +1,6 @@
 # Gitea REST API: Adapter research notes
 
-> Gitea REST API v1, researched July 2026 and pinned to **Gitea 1.27.0**. Route surface taken from the instance's own OpenAPI description (`GET /swagger.v1.json`), cross-checked against docs.gitea.com, then **verified live** against a local Gitea 1.27.0 instance on 2026-07-14. Forgejo compatibility checked against Codeberg's published swagger and version endpoint on the same date. Reference for implementing the Gitea `TrackerAdapter` and `SCMAdapter`. The [SCM write surface](#scm-write-surface) covers merge, branch delete, label removal, and the auto-merge preflight.
+> Gitea REST API v1, researched July 2026 and pinned to **Gitea 1.27.0**. Route surface taken from the instance's own OpenAPI description (`GET /swagger.v1.json`), cross-checked against docs.gitea.com, then **verified live** against a local Gitea 1.27.0 instance on 2026-07-14. Forgejo compatibility checked against Codeberg's published swagger and version endpoint on the same date. Reference for implementing the Gitea `TrackerAdapter`, `SCMAdapter`, and `CIStatusProvider`. The [SCM read surface](#scm-read-surface) covers review decisions, mergeability, CI status, review comments, and label events; the [SCM write surface](#scm-write-surface) covers merge, branch delete, label removal, and the auto-merge preflight; the [CI status provider](#ci-status-provider) reads combined-status CI feedback.
 >
 > Gitea is self-hosted: there is no fixed default host, so the instance base URL is part of every configuration, and instances differ in version and settings. Facts below hold for 1.27.0 defaults unless marked otherwise. Gitea exposes no GraphQL API; the REST surface under `/api/v1` is the whole contract.
 
@@ -408,6 +408,105 @@ Sketch, verified end-to-end by this research's provisioning sequence:
 
 ---
 
+## SCM read surface
+
+The tracker adapter package also implements the SCM read methods `GetReviewDecision`, `GetMergeability`, `GetCIStatus`, `FetchPendingReviews`, `FetchBotReviewComments`, and `ListLabelEvents` (`domain.SCMAdapter`, `internal/domain/scm.go`). Gitea exposes no GraphQL API and no aggregate review-decision or check-runs endpoint, so each read is composed from REST routes under `/api/v1`. Every route below was reached live against the localhost Gitea 1.27.0 lab instance and returned HTTP 200; where the lab PR carried no data to populate a response, the object shape is schema-inferred from the instance OpenAPI description and marked for reconciliation against a captured live fixture in the env-gated integration tests (#660).
+
+| Method | Gitea route(s) |
+| --- | --- |
+| `GetReviewDecision` | `GET .../pulls/{index}/reviews` + `GET .../pulls/{index}` |
+| `GetMergeability` | `GET .../pulls/{index}` |
+| `GetCIStatus` | `GET .../pulls/{index}` + `GET .../commits/{sha}/status` |
+| `FetchPendingReviews` | `GET .../pulls/{index}/reviews` + `GET .../pulls/{index}/reviews/{id}/comments` |
+| `FetchBotReviewComments` | Same routes as `FetchPendingReviews`, filtered by a bot-username allowlist |
+| `ListLabelEvents` | `GET .../issues/{index}/timeline` |
+
+### Pull request reviews
+
+```
+GET /repos/{owner}/{repo}/pulls/{index}/reviews
+```
+
+- Returns a JSON array of review objects. The `state` field is an enum: `APPROVED`, `PENDING`, `COMMENT`, `REQUEST_CHANGES`, `REQUEST_REVIEW`. Gitea spells the changes-requested state `REQUEST_CHANGES`, not GitHub's `CHANGES_REQUESTED`; a state filter copied verbatim from the GitHub adapter matches nothing.
+- Each review carries `dismissed` (an operator nullified the review), `official`, `stale`, `body`, `submitted_at`, `user.login`, and `id`. Dismissed reviews are skipped by every read.
+- `FetchPendingReviews` returns the comments of non-bot `REQUEST_CHANGES` reviews; `FetchBotReviewComments` returns the comments of reviews whose author matches a bot-username allowlist, with no review-state filter. Gitea users carry no `type: Bot` marker, so bot classification is the allowlist alone (see [Bot classification](#bot-classification)).
+- Paginated by page number, not the `Link` header (see [SCM read pagination](#scm-read-pagination)).
+- The route was reached live (HTTP 200); the lab PR carried zero reviews, so the populated `PullReview` object shape is schema-inferred and MUST be reconciled against a captured live review-list fixture (#660).
+
+### Review comments
+
+```
+GET /repos/{owner}/{repo}/pulls/{index}/reviews/{id}/comments
+```
+
+- Each comment carries `path`, `body`, `position`, `original_position`, `created_at`, `id`, and `user.login`. There is no `line`, `start_line`, or `end_line` field, so review comments are single-line and `EndLine` normalizes to 0.
+- `position` is the line on the current diff; `position: 0` marks a comment whose anchor a later push removed, in which case `original_position` holds the line it was written against and the comment normalizes with `Outdated` true.
+- The route is present in the instance OpenAPI; the lab PR carried no review comments, so the `position`/`original_position` semantics and the outdated derivation are schema-inferred and MUST be reconciled against a captured live review-comment fixture (#660).
+
+### Review decision
+
+Gitea has no aggregate review-decision field; the GitHub adapter reads one from GraphQL, which Gitea does not offer. `GetReviewDecision` folds the review list together with the PR object's `requested_reviewers` signal:
+
+- Reviews are ordered by `submitted_at` then `id`, so the latest `APPROVED` or `REQUEST_CHANGES` per reviewer supersedes that reviewer's earlier reviews. `COMMENT`, `PENDING`, and `REQUEST_REVIEW` are not decisions, and dismissed reviews do not contribute.
+- Any standing `REQUEST_CHANGES` yields changes-requested; otherwise any `APPROVED` yields approved; otherwise a non-empty `requested_reviewers` yields review-required; otherwise not-required.
+
+### Mergeability
+
+```
+GET /repos/{owner}/{repo}/pulls/{index}
+```
+
+- The PR object carries `mergeable` (a plain bool, verified `true` on the lab PR), `merged`, `draft`, `head.sha`, `head.ref`, `base.ref`, and a `requested_reviewers` array. There is no `mergeable_state` string and no tri-state "computing" field (verified absent).
+- The boolean is the only mergeability signal, so the mapping to `MergeabilityState` is lossy: a draft maps to `blocked`, a mergeable non-draft to `clean`, and any other state to `unknown`. Gitea never yields `dirty` or `unstable`; a merge conflict and an in-progress recheck both collapse to `unknown`, which the auto-merge state machine re-enqueues rather than treating as a hard conflict.
+- The same read supplies `head.sha` (the CI ref for `GetCIStatus`), `head.ref` (the branch), and `base.ref` (the base branch the merge-conflict reaction needs).
+
+### Combined commit status
+
+```
+GET /repos/{owner}/{repo}/commits/{sha}/status
+```
+
+- Returns `{state, sha, statuses, total_count}`. The top-level `state` is the aggregate; each entry in the `statuses` array carries its own `status`. The two field names differ and MUST NOT be conflated.
+- Empty detection keys on `total_count == 0`: a commit with no CI returns `total_count: 0`, `statuses: null`, and a spurious top-level `state: "pending"` (verified). Trusting the top-level `state` would report `pending` for a no-CI commit and wrongly hold auto-merge, so the aggregate is read from the per-status entries instead.
+- Per-status `status` values are `success`, `failure`, `error`, `warning`, and `pending`. `failure` and `error` are failing; `warning` and `success` are non-failing; `pending` is pending. Each entry also carries `context` (the check name), `target_url`, and `description`.
+- The per-status `target_url` field name is authored from the Gitea `CommitStatus` swagger and was absent from the lab data, and whether this route paginates for a many-status commit is unverified; both are deferred to the env-gated integration tests (#660).
+
+### Label event timeline
+
+```
+GET /repos/{owner}/{repo}/issues/{index}/timeline
+```
+
+- Pull requests share the issue timeline route (a PR at index 6 is served at `/issues/6/timeline`). The route returns a JSON array of typed entries; verified types include `label`, `comment`, `add_dependency`, and `pull_push`.
+- A `label` entry carries `type`, a numeric `id`, `body`, `label.name`, `user.login`, and `created_at`. `body` is `"1"` for a label add and `""` for a label remove (verified live on lab issue #4, which round-trips both). The label name keeps Gitea's original casing (for example `Bug`, `REVIEW`) and is lowercased on normalization.
+- Entries arrive oldest-first (verified), so the accumulated slice needs no re-sort. The numeric timeline id is zero-padded to a fixed width so `(timestamp, id)` string ordering matches journal order for entries sharing a timestamp.
+
+### Bot classification
+
+Gitea users carry no `type: Bot` marker (verified: the review `user` object has no bot-type field), so the platform half of the bot-author predicate is always false. `FetchBotReviewComments` classifies solely by a case-insensitive match against the configured bot-username allowlist; a nil or empty allowlist selects nothing. `FetchPendingReviews` passes no allowlist, so its non-bot filter cannot exclude a bot-authored `REQUEST_CHANGES` review, unlike the GitHub adapter's platform-marker exclusion.
+
+### SCM read pagination
+
+The reviews, review-comments, and timeline routes paginate by page number, not by the `Link` header the tracker issue routes use. The timeline route was verified live to emit no `Link` header and an unreliable `X-Total-Count` (it returns the page size, not the grand total), so `httpkit.NewLinkPaginator` MUST NOT drive these reads: it stops at the first response with no `Link` header, which would truncate a multi-page timeline to page one. A package-local page-number paginator with a max-page guard drives all three reads. Because the timeline is oldest-first and read forward to the cap, an unusually long timeline truncates its newest entries, where a label command lives; the adapter logs a WARN on reaching the cap.
+
+---
+
+## CI status provider
+
+The package registers a CI status provider under kind `gitea` (`domain.CIStatusProvider`, `internal/domain/ci.go`) alongside the tracker and SCM adapters. It drives the CI-failure reaction, the role the GitHub provider fills for GitHub-backed deployments.
+
+```
+GET /repos/{owner}/{repo}/commits/{ref}/status
+```
+
+- `FetchCIStatus(ref)` reads the combined commit status directly by ref, with no PR fetch or SHA resolution, and normalizes it to a `CIResult`.
+- Each per-status entry becomes a `CheckRun`: `context` is the check name, `status` maps to the run status and conclusion (`success` to success, `failure` and `error` to failure, `warning` to neutral, everything else to pending), and `target_url` is the details URL.
+- The aggregate is computed from the per-status entries, never the top-level `state` (the same spurious-`pending`-on-empty trap as the SCM read). An empty status set yields a pending result with an empty, non-nil check-run slice.
+- The failing-status log excerpt is assembled from the first failing entry's `description` and `target_url`, both already in the authenticated combined-status response. The provider never fetches `target_url`, so an operator-configured or third-party run URL cannot expand the request beyond the Gitea API. ANSI escape sequences are stripped and the excerpt is truncated to `max_log_lines`; a zero budget, or a failing entry with neither field, omits the excerpt.
+- The `target_url` field name and the route's pagination behavior carry the same deferred verification (#660) as the combined-status SCM read.
+
+---
+
 ## SCM write surface
 
 The tracker adapter package also implements the SCM write methods `MergePR`, `DeleteBranch`, and `RemoveLabel` (`domain.SCMAdapter`, `internal/domain/scm.go`), plus the auto-merge scope preflight `VerifyAutoMergeScopes`. The route facts below were verified live against a local Gitea instance.
@@ -461,18 +560,9 @@ Gitea exposes no scope-introspection surface: there is no `/rate_limit` endpoint
 
 ---
 
-## Out of scope: remaining pull request reaction surface
+## Out of scope: webhooks
 
-The SCM write surface above (merge, branch delete, label removal) and the auto-merge scope preflight are implemented. The remaining PR-reaction surface below, review decisions, mergeability, CI status, bot-review filtering, and label-command event detection, has no adapter implementation; the gap map records what that surface would build on. Route facts come from the 1.27.0 swagger; none were exercised beyond the notes given.
-
-| SCM surface (GitHub adapter today) | Gitea 1.27 equivalent | Gap notes |
-| --- | --- | --- |
-| `GetReviewDecision` via GraphQL `reviewDecision` | No GraphQL API. `GET /repos/{owner}/{repo}/pulls/{index}/reviews` returns per-review states (`APPROVED`, `PENDING`, `COMMENT`, `REQUEST_CHANGES`, `REQUEST_REVIEW`) | No aggregate decision field anywhere; the adapter must fold the review list (and branch-protection approval requirements) into a decision itself |
-| `GetMergeability` via `mergeable_state` string taxonomy | PR object carries boolean `mergeable`, plus `merged`, `draft`, `head.sha` (verified live) | Boolean collapses GitHub's `clean`/`behind`/`blocked`/`dirty`/`unstable` distinctions; mapping to `MergeabilityState` is lossy and needs supplementary signals |
-| `GetCIStatus` via combined status plus check runs | `GET /repos/{owner}/{repo}/commits/{ref}/status` (combined) and `.../statuses/{sha}`; Gitea Actions reports through commit statuses | No check-runs API; single-source aggregation |
-| `FetchPendingReviews`, `FetchBotReviewComments` | `GET .../pulls/{index}/reviews` and review-comment routes | Gitea users carry no `type: Bot` marker; bot classification needs an allowlist rather than a platform predicate |
-| `ListLabelEvents` via issue events API | No events route; `GET .../issues/{index}/timeline` returns typed entries (verified types include `label`, `comment`, `add_dependency`) with `since`/`before` and paging | Label-command detection would re-derive the journal from timeline entries |
-| Webhooks (future push-based reactivity) | `POST /repos/{owner}/{repo}/hooks`, standard Gitea webhooks | Aligns with the webhook-ingress future extension |
+Webhooks are the only PR-reaction surface with no adapter implementation. Gitea serves standard webhooks at `POST /repos/{owner}/{repo}/hooks`; wiring them aligns with the webhook-ingress future extension rather than the poll-based reads above. These route facts come from the 1.27.0 swagger and were not exercised.
 
 ---
 

--- a/docs/workflow-reference.md
+++ b/docs/workflow-reference.md
@@ -731,6 +731,14 @@ repeatedly.
 
 Remaining keys within a kind sub-object are kind-specific and collected into an `Extra` map.
 
+**SCM and CI provider selection.** The reaction `provider` field (and the deprecated
+`ci_feedback.kind`) names a registered SCM adapter or CI provider kind: `github` or `gitea`. The
+reaction kinds are provider-agnostic. Setting `provider: gitea` activates the Gitea adapter for
+that reaction, which inherits the `tracker:` block's `endpoint`, `api_key`, and `project` when
+`tracker.kind` is `gitea`. Gitea has no default host, so a Gitea reaction resolves only when the
+Gitea tracker supplies the instance `endpoint`. Every active SCM reaction in one workflow names the
+same provider.
+
 #### Reaction kind: `ci_failure`
 
 Equivalent to the deprecated `ci_feedback` section. Configures the CI failure feedback
@@ -832,13 +840,21 @@ and non-empty. Agent-created PRs MUST write `pr_number` (positive integer), `own
 auto-merge to activate. Recovery on restart additionally consults `pushed_at` (when
 present) to skip stale PRs older than the recovery lookback window.
 
-**Token scopes required:** the configured GitHub token must carry `pull_requests:write`
-for the merge endpoint, and when `delete_branch` is not `false`, also `contents:write`
-for the branch delete endpoint. The classic `repo` scope is a superset that covers both.
-The orchestrator validates scopes once at startup; failure emits an ERROR log with the
-missing scope and disables auto-merge for the process lifetime. A transport-class
-startup failure (network outage) schedules a single bounded retry on the next reconcile
-tick before disabling auto-merge.
+**Token scopes required:** for a GitHub provider the configured token must carry
+`pull_requests:write` for the merge endpoint, and when `delete_branch` is not `false`, also
+`contents:write` for the branch delete endpoint. The classic `repo` scope is a superset that
+covers both. The orchestrator validates scopes once at startup; failure emits an ERROR log with
+the missing scope and disables auto-merge for the process lifetime. A transport-class startup
+failure (network outage) schedules a single bounded retry on the next reconcile tick before
+disabling auto-merge.
+
+For a Gitea provider the scope model differs: Gitea has one coarse `write:repository` scope
+covering both the merge and branch-delete routes, and it exposes no scope-introspection surface.
+The startup check substitutes a user-role gate, reading the repository's `permissions.push` field
+and disabling auto-merge when the token's user lacks repository write access. A read-scoped token
+whose user has write access passes that gate and surfaces the missing scope only at runtime, as a
+403 on the first merge or branch delete that the adapter rewrites to name `write:repository`.
+Grant the token's user repository write access and the token the `write:repository` scope.
 
 **Fingerprint dedup:** The fingerprint is the SHA-256 of the PR head SHA concatenated
 with the review decision. A new push or a change in review decision invalidates the

--- a/docs/workflow-reference.md
+++ b/docs/workflow-reference.md
@@ -739,7 +739,7 @@ pass-through block ([Section 4.5](#45-adapter-specific-pass-through-config)); wh
 is also `gitea`, any of the three left unset in that block falls back to the matching `tracker:`
 value. A Gitea reaction can therefore pair with a non-Gitea tracker, as long as the `gitea:` block
 supplies the credentials, including the instance `endpoint` Gitea always requires. Every active
-SCM reaction in one workflow names the same provider.
+SCM reaction in one workflow MUST name the same provider.
 
 #### Reaction kind: `ci_failure`
 

--- a/docs/workflow-reference.md
+++ b/docs/workflow-reference.md
@@ -734,10 +734,12 @@ Remaining keys within a kind sub-object are kind-specific and collected into an 
 **SCM and CI provider selection.** The reaction `provider` field (and the deprecated
 `ci_feedback.kind`) names a registered SCM adapter or CI provider kind: `github` or `gitea`. The
 reaction kinds are provider-agnostic. Setting `provider: gitea` activates the Gitea adapter for
-that reaction, which inherits the `tracker:` block's `endpoint`, `api_key`, and `project` when
-`tracker.kind` is `gitea`. Gitea has no default host, so a Gitea reaction resolves only when the
-Gitea tracker supplies the instance `endpoint`. Every active SCM reaction in one workflow names the
-same provider.
+that reaction. Its `endpoint`, `api_key`, and `project` come from the top-level `gitea:`
+pass-through block ([Section 4.5](#45-adapter-specific-pass-through-config)); when `tracker.kind`
+is also `gitea`, any of the three left unset in that block falls back to the matching `tracker:`
+value. A Gitea reaction can therefore pair with a non-Gitea tracker, as long as the `gitea:` block
+supplies the credentials, including the instance `endpoint` Gitea always requires. Every active
+SCM reaction in one workflow names the same provider.
 
 #### Reaction kind: `ci_failure`
 


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Docs

**Intent:** Document the Gitea SCM adapter and CI status provider in the reference docs, alongside the existing GitHub documentation, now that the read (#656), write (#658), and CI-status (#657) routes are implemented.

**Related Issues:** #661

### 🧭 Reviewer Guide

**Complexity:** Low

#### Entry Point

`docs/gitea-adapter-notes.md` - the largest addition. New "SCM read surface" and "CI status provider" sections document the live-verified route facts for review decisions, mergeability, combined commit status, review comments, and label events, replacing the former swagger-only gap table with a single remaining entry for webhooks. `docs/architecture/12-ci-feedback-contract.md`, `13-pr-review-comment-feedback-contract.md`, and `14-auto-merge-reaction-contract.md` each gain a short Gitea paragraph describing how the adapter composes the contract interface from Gitea's REST routes, and `docs/workflow-reference.md` documents the `provider` field's github/gitea selection and the Gitea auto-merge token-scope model.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes
- **Migrations/State:** No migrations or state changes