### PR TITLE
fix(scm/gitea): paginate combined commit-status reads

### DIFF
--- a/internal/scm/gitea/ci.go
+++ b/internal/scm/gitea/ci.go
@@ -5,8 +5,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/url"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/sortie-ai/sortie/internal/domain"
@@ -99,7 +101,8 @@ func NewGiteaCIProvider(maxLogLines int, adapterConfig map[string]any) (domain.C
 }
 
 // FetchCIStatus returns the aggregate CI status for the given git ref by reading
-// Gitea's combined commit status once and normalizing it to a [domain.CIResult].
+// every page of Gitea's combined commit status and normalizing it to a
+// [domain.CIResult].
 //
 // The ref is percent-encoded into GET /repos/{owner}/{repo}/commits/{ref}/status
 // and read directly, so no PR fetch or SHA resolution occurs. The aggregate is
@@ -112,22 +115,48 @@ func (p *GiteaCIProvider) FetchCIStatus(ctx context.Context, ref string) (domain
 	path := fmt.Sprintf("/repos/%s/%s/commits/%s/status",
 		url.PathEscape(p.owner), url.PathEscape(p.repo), url.PathEscape(ref))
 
-	body, _, err := p.client.Get(ctx, path, nil)
-	if err != nil {
-		return domain.CIResult{}, giteaToCIError(fmt.Errorf("fetching ci status for ref %q: %w", ref, err))
-	}
+	const limit = 50
+	statuses := make([]giteaCommitState, 0)
+	page := 1
+	for {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return domain.CIResult{}, giteaToCIError(fmt.Errorf("fetching ci status for ref %q: %w", ref, ctxErr))
+		}
 
-	var combined giteaCombinedStatus
-	if jsonErr := json.Unmarshal(body, &combined); jsonErr != nil {
-		return domain.CIResult{}, &domain.CIError{
-			Kind:    domain.ErrCIPayload,
-			Message: "failed to parse combined status response",
-			Err:     jsonErr,
+		params := url.Values{
+			"page":  {strconv.Itoa(page)},
+			"limit": {strconv.Itoa(limit)},
+		}
+		body, _, err := p.client.Get(ctx, path, params)
+		if err != nil {
+			return domain.CIResult{}, giteaToCIError(fmt.Errorf("fetching ci status for ref %q: %w", ref, err))
+		}
+
+		var combined giteaCombinedStatus
+		if jsonErr := json.Unmarshal(body, &combined); jsonErr != nil {
+			return domain.CIResult{}, &domain.CIError{
+				Kind:    domain.ErrCIPayload,
+				Message: "failed to parse combined status response",
+				Err:     jsonErr,
+			}
+		}
+
+		statuses = append(statuses, combined.Statuses...)
+		if len(combined.Statuses) < limit {
+			break
+		}
+
+		page++
+		if page > scmMaxPages {
+			slog.WarnContext(ctx, "response truncated at page limit",
+				slog.String("path", path),
+				slog.Int("max_pages", scmMaxPages))
+			break
 		}
 	}
 
-	runs := make([]domain.CheckRun, len(combined.Statuses))
-	for i, s := range combined.Statuses {
+	runs := make([]domain.CheckRun, len(statuses))
+	for i, s := range statuses {
 		runs[i] = domain.CheckRun{
 			Name:       s.Context,
 			Status:     mapRunStatus(s.Status),
@@ -140,7 +169,7 @@ func (p *GiteaCIProvider) FetchCIStatus(ctx context.Context, ref string) (domain
 
 	var logExcerpt string
 	if status == domain.CIStatusFailing {
-		logExcerpt = buildLogExcerpt(combined.Statuses, p.maxLogLines)
+		logExcerpt = buildLogExcerpt(statuses, p.maxLogLines)
 	}
 
 	return domain.CIResult{

--- a/internal/scm/gitea/ci_test.go
+++ b/internal/scm/gitea/ci_test.go
@@ -761,6 +761,30 @@ func TestGiteaToCIError(t *testing.T) {
 
 		assertCIErrorKind(t, err, domain.ErrCIPayload)
 	})
+
+	t.Run("a cancelled context is returned as-is, not converted to a CIError", func(t *testing.T) {
+		t.Parallel()
+
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"state":"success","total_count":0,"statuses":[]}`))
+		}))
+		defer srv.Close()
+		provider := mustCIProvider(t, srv.URL, 0)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		_, err := provider.FetchCIStatus(ctx, "main")
+
+		if !errors.Is(err, context.Canceled) {
+			t.Errorf("FetchCIStatus(cancelled context) = %v, want context.Canceled in the chain", err)
+		}
+		var ciErr *domain.CIError
+		if errors.As(err, &ciErr) {
+			t.Errorf("FetchCIStatus(cancelled context) = %v, want the context error without CIError conversion", ciErr)
+		}
+	})
 }
 
 func TestGiteaToCIError_NilInput(t *testing.T) {

--- a/internal/scm/gitea/ci_test.go
+++ b/internal/scm/gitea/ci_test.go
@@ -47,17 +47,19 @@ func assertCIErrorKind(t *testing.T, err error, want domain.CIErrorKind) {
 }
 
 // buildStatusPage returns the JSON body of a combined-status page carrying n
-// statuses of the given status value, each a distinct context, so a
-// multi-page test can synthesize a full page without committing a
-// fixture of that size. total_count is set to n, matching the wire fact that
-// the per-page count equals the page length rather than the grand total.
-func buildStatusPage(t *testing.T, status string, n int) []byte {
+// statuses of the given status value, with contexts numbered from start, so a
+// multi-page test can synthesize pages whose contexts stay distinct across the
+// whole walk without committing a fixture of that size. Distinct contexts match
+// the route's wire shape, which reports one entry per context. total_count is
+// set to n, matching the wire fact that the per-page count equals the page
+// length rather than the grand total.
+func buildStatusPage(t *testing.T, status string, start, n int) []byte {
 	t.Helper()
 	statuses := make([]map[string]string, n)
 	for i := range n {
 		statuses[i] = map[string]string{
 			"status":  status,
-			"context": fmt.Sprintf("ci/check-%d", i),
+			"context": fmt.Sprintf("ci/check-%d", start+i),
 		}
 	}
 	body, err := json.Marshal(map[string]any{
@@ -405,8 +407,8 @@ func TestGiteaFetchCIStatusPagination(t *testing.T) {
 	t.Run("a failing status on page two flips the aggregate to failing", func(t *testing.T) {
 		t.Parallel()
 
-		page1 := buildStatusPage(t, "success", 50)
-		page2 := buildStatusPage(t, "failure", 1)
+		page1 := buildStatusPage(t, "success", 0, 50)
+		page2 := buildStatusPage(t, "failure", 50, 1)
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)

--- a/internal/scm/gitea/ci_test.go
+++ b/internal/scm/gitea/ci_test.go
@@ -2,6 +2,7 @@ package gitea
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -43,6 +44,31 @@ func assertCIErrorKind(t *testing.T, err error, want domain.CIErrorKind) {
 	if ce.Kind != want {
 		t.Errorf("CIError.Kind = %q, want %q", ce.Kind, want)
 	}
+}
+
+// buildStatusPage returns the JSON body of a combined-status page carrying n
+// statuses of the given status value, each a distinct context, so a
+// multi-page test can synthesize a full page without committing a
+// fixture of that size. total_count is set to n, matching the wire fact that
+// the per-page count equals the page length rather than the grand total.
+func buildStatusPage(t *testing.T, status string, n int) []byte {
+	t.Helper()
+	statuses := make([]map[string]string, n)
+	for i := range n {
+		statuses[i] = map[string]string{
+			"status":  status,
+			"context": fmt.Sprintf("ci/check-%d", i),
+		}
+	}
+	body, err := json.Marshal(map[string]any{
+		"state":       status,
+		"total_count": n,
+		"statuses":    statuses,
+	})
+	if err != nil {
+		t.Fatalf("marshal status page: %v", err)
+	}
+	return body
 }
 
 // --- status and conclusion mapping ---
@@ -367,6 +393,77 @@ func TestGiteaFetchCIStatus(t *testing.T) {
 			if run.DetailsURL != "" {
 				t.Errorf("CheckRuns[%d].DetailsURL = %q, want empty (fixture carries no target_url)", i, run.DetailsURL)
 			}
+		}
+	})
+}
+
+// --- FetchCIStatus pagination ---
+
+func TestGiteaFetchCIStatusPagination(t *testing.T) {
+	t.Parallel()
+
+	t.Run("a failing status on page two flips the aggregate to failing", func(t *testing.T) {
+		t.Parallel()
+
+		page1 := buildStatusPage(t, "success", 50)
+		page2 := buildStatusPage(t, "failure", 1)
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			switch r.URL.Query().Get("page") {
+			case "2":
+				_, _ = w.Write(page2)
+			default:
+				_, _ = w.Write(page1)
+			}
+		}))
+		defer srv.Close()
+		provider := mustCIProvider(t, srv.URL, 0)
+
+		got, err := provider.FetchCIStatus(context.Background(), "main")
+
+		if err != nil {
+			t.Fatalf("FetchCIStatus: unexpected error: %v", err)
+		}
+		if got.Status != domain.CIStatusFailing {
+			t.Errorf("FetchCIStatus().Status = %q, want %q", got.Status, domain.CIStatusFailing)
+		}
+		if got.FailingCount < 1 {
+			t.Errorf("FetchCIStatus().FailingCount = %d, want >= 1", got.FailingCount)
+		}
+		const wantLen = 51
+		if len(got.CheckRuns) != wantLen {
+			t.Errorf("len(FetchCIStatus().CheckRuns) = %d, want %d", len(got.CheckRuns), wantLen)
+		}
+	})
+
+	t.Run("a single short page issues exactly one combined status request", func(t *testing.T) {
+		t.Parallel()
+
+		fixture := loadFixture(t, "status_all_success.json")
+		var requestCount atomic.Int32
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			requestCount.Add(1)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(fixture)
+		}))
+		defer srv.Close()
+		provider := mustCIProvider(t, srv.URL, 0)
+
+		got, err := provider.FetchCIStatus(context.Background(), "main")
+
+		if err != nil {
+			t.Fatalf("FetchCIStatus: unexpected error: %v", err)
+		}
+		if got.Status != domain.CIStatusPassing {
+			t.Errorf("FetchCIStatus().Status = %q, want %q", got.Status, domain.CIStatusPassing)
+		}
+		if len(got.CheckRuns) != 2 {
+			t.Errorf("len(FetchCIStatus().CheckRuns) = %d, want %d", len(got.CheckRuns), 2)
+		}
+		if n := requestCount.Load(); n != 1 {
+			t.Errorf("combined status request count = %d, want 1", n)
 		}
 	})
 }
@@ -816,8 +913,8 @@ func TestGiteaCIRequestShape(t *testing.T) {
 	if gotPath != wantPath {
 		t.Errorf("request path = %q, want %q", gotPath, wantPath)
 	}
-	if gotQuery != "" {
-		t.Errorf("request query = %q, want empty (no access_token query parameter)", gotQuery)
+	if strings.Contains(gotQuery, "access_token") {
+		t.Errorf("request query = %q, want no access_token query parameter", gotQuery)
 	}
 	const wantAuth = "token test-token"
 	if gotAuth != wantAuth {

--- a/internal/scm/gitea/integration_scm_test.go
+++ b/internal/scm/gitea/integration_scm_test.go
@@ -305,15 +305,8 @@ func TestIntegration_FetchCIStatus_ManyStatuses(t *testing.T) {
 	if err != nil {
 		t.Fatalf("FetchCIStatus(%q): %v", sha, err)
 	}
-	// Gitea's combined-status route paginates at the default page size (30), but
-	// FetchCIStatus reads it with a single un-paginated GET, so a commit carrying
-	// more than 30 statuses is truncated. Until the adapter paginates that read,
-	// the completeness shortfall is a skip naming the follow-up rather than a
-	// failure, so the release and nightly gates stay green; the assertion passes
-	// once the adapter returns every seeded status.
 	if len(result.CheckRuns) != manyStatusCount {
-		t.Skipf("gitea combined-status pagination follow-up: FetchCIStatus(%q) returned %d of %d seeded statuses; the single-GET combined-status read truncates at DEFAULT_PAGING_NUM=30 and must follow the route's pagination to return every status",
-			sha, len(result.CheckRuns), manyStatusCount)
+		t.Errorf("len(FetchCIStatus(%q).CheckRuns) = %d, want %d", sha, len(result.CheckRuns), manyStatusCount)
 	}
 }
 

--- a/internal/scm/gitea/scm_merge.go
+++ b/internal/scm/gitea/scm_merge.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"net/url"
+	"strconv"
 	"strings"
 
 	"github.com/sortie-ai/sortie/internal/domain"
@@ -31,8 +33,8 @@ type giteaPullRequest struct {
 
 // giteaCombinedStatus is the combined commit-status response. Gitea reports a
 // zero total_count with a null statuses array and a spurious "pending" state
-// when a commit has no CI, so the empty case is detected by total_count, not
-// state.
+// when a commit has no CI, so the empty case is detected by the accumulated
+// status count, not total_count or state.
 type giteaCombinedStatus struct {
 	State      string             `json:"state"`
 	TotalCount int                `json:"total_count"`
@@ -111,9 +113,9 @@ func mapMergeability(pr giteaPullRequest) domain.MergeabilityState {
 // of "success", "failing", or "pending", or an empty string when the head
 // commit carries no statuses.
 //
-// The empty case is detected by a zero total_count, not the top-level state,
-// which Gitea reports as "pending" even for a commit with no CI. A failure or
-// error status makes the result failing; otherwise a pending status makes it
+// The empty case is detected by the accumulated status count, not the top-level
+// state, which Gitea reports as "pending" even for a commit with no CI. A failure
+// or error status makes the result failing; otherwise a pending status makes it
 // pending; success and warning are non-failing. Returns a [*domain.SCMError] on
 // failure, including [domain.ErrSCMPayload] when the PR response omits the head
 // SHA.
@@ -131,27 +133,54 @@ func (a *GiteaSCMAdapter) GetCIStatus(ctx context.Context, prNumber int, owner, 
 
 	statusPath := fmt.Sprintf("/repos/%s/%s/commits/%s/status",
 		url.PathEscape(owner), url.PathEscape(repo), url.PathEscape(pr.Head.SHA))
-	body, _, statusErr := a.client.Get(ctx, statusPath, nil)
-	if statusErr != nil {
-		return "", giteaToSCMError(statusErr)
-	}
 
-	var combined giteaCombinedStatus
-	if jsonErr := json.Unmarshal(body, &combined); jsonErr != nil {
-		return "", &domain.SCMError{
-			Kind:    domain.ErrSCMPayload,
-			Message: "failed to parse combined status response",
-			Err:     jsonErr,
+	const limit = 50
+	statuses := make([]giteaCommitState, 0)
+	page := 1
+	for {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return "", giteaToSCMError(ctxErr)
+		}
+
+		params := url.Values{
+			"page":  {strconv.Itoa(page)},
+			"limit": {strconv.Itoa(limit)},
+		}
+		body, _, statusErr := a.client.Get(ctx, statusPath, params)
+		if statusErr != nil {
+			return "", giteaToSCMError(statusErr)
+		}
+
+		var combined giteaCombinedStatus
+		if jsonErr := json.Unmarshal(body, &combined); jsonErr != nil {
+			return "", &domain.SCMError{
+				Kind:    domain.ErrSCMPayload,
+				Message: "failed to parse combined status response",
+				Err:     jsonErr,
+			}
+		}
+
+		statuses = append(statuses, combined.Statuses...)
+		if len(combined.Statuses) < limit {
+			break
+		}
+
+		page++
+		if page > scmMaxPages {
+			slog.WarnContext(ctx, "response truncated at page limit",
+				slog.String("path", statusPath),
+				slog.Int("max_pages", scmMaxPages))
+			break
 		}
 	}
 
-	if combined.TotalCount == 0 {
+	if len(statuses) == 0 {
 		return "", nil
 	}
 
 	anyFailing := false
 	anyPending := false
-	for _, s := range combined.Statuses {
+	for _, s := range statuses {
 		switch strings.ToLower(s.Status) {
 		case "failure", "error":
 			anyFailing = true

--- a/internal/scm/gitea/scm_merge_test.go
+++ b/internal/scm/gitea/scm_merge_test.go
@@ -218,6 +218,31 @@ func TestGiteaSCMGetCIStatus(t *testing.T) {
 		assertSCMErrorKind(t, err, domain.ErrSCMPayload)
 	})
 
+	t.Run("a combined status transport failure maps to a transport error", func(t *testing.T) {
+		t.Parallel()
+
+		prFixture := loadFixture(t, "pr_clean.json")
+		errFixture := loadFixture(t, "error_401.json")
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			switch {
+			case strings.Contains(r.URL.Path, "/status"):
+				w.WriteHeader(http.StatusInternalServerError)
+				_, _ = w.Write(errFixture)
+			case strings.Contains(r.URL.Path, "/pulls/"):
+				_, _ = w.Write(prFixture)
+			default:
+				t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+				w.WriteHeader(http.StatusNotFound)
+			}
+		}))
+		defer srv.Close()
+
+		adapter := mustSCMAdapter(t, srv.URL)
+		_, err := adapter.GetCIStatus(context.Background(), 6, testOwner, testRepo)
+		assertSCMErrorKind(t, err, domain.ErrSCMTransport)
+	})
+
 	t.Run("a single short page issues exactly one combined status request", func(t *testing.T) {
 		t.Parallel()
 

--- a/internal/scm/gitea/scm_merge_test.go
+++ b/internal/scm/gitea/scm_merge_test.go
@@ -159,6 +159,98 @@ func TestGiteaSCMGetCIStatus(t *testing.T) {
 		_, err := adapter.GetCIStatus(context.Background(), 6, testOwner, testRepo)
 		assertSCMErrorKind(t, err, domain.ErrSCMPayload)
 	})
+
+	t.Run("a failing status on page two flips the verdict to failing", func(t *testing.T) {
+		t.Parallel()
+
+		prFixture := loadFixture(t, "pr_clean.json")
+		page1 := buildStatusPage(t, "success", 50)
+		page2 := buildStatusPage(t, "failure", 1)
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			switch {
+			case strings.Contains(r.URL.Path, "/status"):
+				switch r.URL.Query().Get("page") {
+				case "2":
+					_, _ = w.Write(page2)
+				default:
+					_, _ = w.Write(page1)
+				}
+			case strings.Contains(r.URL.Path, "/pulls/"):
+				_, _ = w.Write(prFixture)
+			default:
+				t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+				w.WriteHeader(http.StatusNotFound)
+			}
+		}))
+		defer srv.Close()
+
+		adapter := mustSCMAdapter(t, srv.URL)
+		got, err := adapter.GetCIStatus(context.Background(), 6, testOwner, testRepo)
+		if err != nil {
+			t.Fatalf("GetCIStatus: unexpected error: %v", err)
+		}
+		if got != "failing" {
+			t.Errorf("GetCIStatus() = %q, want %q", got, "failing")
+		}
+	})
+
+	t.Run("a malformed combined status body after a valid PR read is a payload error, not transport", func(t *testing.T) {
+		t.Parallel()
+
+		prFixture := loadFixture(t, "pr_clean.json")
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			switch {
+			case strings.Contains(r.URL.Path, "/status"):
+				_, _ = w.Write([]byte("{not valid json"))
+			case strings.Contains(r.URL.Path, "/pulls/"):
+				_, _ = w.Write(prFixture)
+			default:
+				t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+				w.WriteHeader(http.StatusNotFound)
+			}
+		}))
+		defer srv.Close()
+
+		adapter := mustSCMAdapter(t, srv.URL)
+		_, err := adapter.GetCIStatus(context.Background(), 6, testOwner, testRepo)
+		assertSCMErrorKind(t, err, domain.ErrSCMPayload)
+	})
+
+	t.Run("a single short page issues exactly one combined status request", func(t *testing.T) {
+		t.Parallel()
+
+		prFixture := loadFixture(t, "pr_clean.json")
+		statusFixture := loadFixture(t, "status_all_success.json")
+		var statusRequests atomic.Int32
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			switch {
+			case strings.Contains(r.URL.Path, "/status"):
+				statusRequests.Add(1)
+				_, _ = w.Write(statusFixture)
+			case strings.Contains(r.URL.Path, "/pulls/"):
+				_, _ = w.Write(prFixture)
+			default:
+				t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+				w.WriteHeader(http.StatusNotFound)
+			}
+		}))
+		defer srv.Close()
+
+		adapter := mustSCMAdapter(t, srv.URL)
+		got, err := adapter.GetCIStatus(context.Background(), 6, testOwner, testRepo)
+		if err != nil {
+			t.Fatalf("GetCIStatus: unexpected error: %v", err)
+		}
+		if got != "success" {
+			t.Errorf("GetCIStatus() = %q, want %q", got, "success")
+		}
+		if n := statusRequests.Load(); n != 1 {
+			t.Errorf("combined status request count = %d, want 1", n)
+		}
+	})
 }
 
 // --- MergePR ---

--- a/internal/scm/gitea/scm_merge_test.go
+++ b/internal/scm/gitea/scm_merge_test.go
@@ -164,8 +164,8 @@ func TestGiteaSCMGetCIStatus(t *testing.T) {
 		t.Parallel()
 
 		prFixture := loadFixture(t, "pr_clean.json")
-		page1 := buildStatusPage(t, "success", 50)
-		page2 := buildStatusPage(t, "failure", 1)
+		page1 := buildStatusPage(t, "success", 0, 50)
+		page2 := buildStatusPage(t, "failure", 50, 1)
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
 			switch {


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Fix

**Intent:** The Gitea SCM adapter reads a commit's combined status with a single, un-paginated request, so a commit carrying more statuses than the instance's page size silently yields only the first page and the aggregate CI verdict is computed from an incomplete set. A failing status ordered onto a later page can be missed entirely, letting the CI-failure reaction and the auto-merge CI gate treat a failing commit as passing.

**Related Issues:** #671

### 🧭 Reviewer Guide

**Complexity:** Medium

#### Entry Point

`internal/scm/gitea/ci.go` - `FetchCIStatus` is where the pagination loop is introduced: it now follows the combined-status route's `page`/`limit` query parameters until a short page is returned, capped at the existing `scmMaxPages` guard (already used elsewhere in the package via `internal/scm/gitea/scm_pagination.go`), logging a warning if the cap is hit before completion. `GetCIStatus` in `internal/scm/gitea/scm_merge.go` mirrors the identical loop against the same route, so reviewing one clarifies the other.

#### Sensitive Areas

- `internal/scm/gitea/scm_merge.go`: the empty-result check moved from `combined.TotalCount == 0` to `len(statuses) == 0`, since Gitea's `total_count` field reflects only the current page's length, not the grand total. Worth confirming this still correctly distinguishes a commit with no CI from one with statuses, given Gitea's spurious "pending" top-level state on the empty case.
- `internal/scm/gitea/ci.go` and `internal/scm/gitea/scm_merge.go`: both loops cap at `scmMaxPages` and log a warning rather than erroring when the cap is reached, matching the package's existing pagination convention - confirm that silent truncation is the intended failure mode for a CI-gating read.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes.
- **Migrations/State:** No migrations or state changes.
