### PR TITLE
Fix codex archive filename mismatch

### DIFF
--- a/examples/docker/codex.Dockerfile
+++ b/examples/docker/codex.Dockerfile
@@ -35,7 +35,7 @@ RUN set -eux; \
     *) echo "unsupported Codex architecture: ${debian_arch}" >&2; exit 1 ;; \
     esac; \
     curl -fsSL "https://github.com/openai/codex/releases/latest/download/codex-${codex_arch}.tar.gz" \
-    | tar -xz -C /usr/local/bin codex; \
+    | tar -xzO "codex-${codex_arch}" > /usr/local/bin/codex; \
     chmod +x /usr/local/bin/codex
 
 # Create a non-root user.


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Fix

**Intent:** Fix the Codex installation example so it extracts the correctly named architecture-specific binary from the release archive and installs it as `/usr/local/bin/codex`.

A matching embedded example exists in the separate `sortie-ai/docs` repository and will require the same correction in a follow-up documentation PR.

### 🧭 Reviewer Guide

**Complexity:** Low

#### Entry Point

`examples/docker/codex.Dockerfile`

This is the only file changed. Review the Codex download and extraction pipeline, particularly the archive member passed to `tar`.

#### Sensitive Areas

* `examples/docker/codex.Dockerfile`: The archive filename and the binary inside it both include the target architecture. The extraction command must select the exact `codex-${codex_arch}` member while preserving `/usr/local/bin/codex` as the installed executable name.

### ⚠️ Risk Assessment

* **Breaking Changes:** No breaking changes. This corrects an example Docker build that currently fails because the archive does not contain a member named only `codex`.
* **Migrations/State:** No migrations or state changes.
