### PR TITLE
refactor: drop shadowed handoff_state collision checks

### DIFF
--- a/cmd/sortie/sample_workflow_test.go
+++ b/cmd/sortie/sample_workflow_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/sortie-ai/sortie/internal/config"
 	"github.com/sortie-ai/sortie/internal/prompt"
 	"github.com/sortie-ai/sortie/internal/workflow"
 )
@@ -626,5 +627,59 @@ func TestSampleWorkflowGiteaEnvVarIndirection(t *testing.T) {
 		if got != c.want {
 			t.Errorf("tracker.%s = %q, want %q", c.key, got, c.want)
 		}
+	}
+}
+
+// shippedWorkflowPaths returns every WORKFLOW*.md the repository ships:
+// the examples directory plus the two files at the repository root.
+func shippedWorkflowPaths(t *testing.T) []string {
+	t.Helper()
+
+	root := repoRoot(t)
+	var paths []string
+	for _, pattern := range []string{
+		filepath.Join(root, "examples", "WORKFLOW*.md"),
+		filepath.Join(root, "WORKFLOW*.md"),
+	} {
+		matches, err := filepath.Glob(pattern)
+		if err != nil {
+			t.Fatalf("filepath.Glob(%q): %v", pattern, err)
+		}
+		paths = append(paths, matches...)
+	}
+	if len(paths) == 0 {
+		t.Fatalf("no WORKFLOW*.md found under %s; the subtests below would assert nothing", root)
+	}
+	return paths
+}
+
+// TestSampleWorkflowConfigLoads verifies that every shipped WORKFLOW.md
+// survives the config loader. The loader owns the tracker state rules,
+// among them the one that forbids a handoff_state shared with
+// active_states or terminal_states, so an example that violates any of
+// them fails here instead of on a user's first run. Environment
+// indirection is left unresolved on purpose: unset $VAR references become
+// empty strings, which the loader accepts and the online preflight
+// rejects, so this test stays hermetic.
+func TestSampleWorkflowConfigLoads(t *testing.T) {
+	t.Parallel()
+
+	for _, path := range shippedWorkflowPaths(t) {
+		name, err := filepath.Rel(repoRoot(t), path)
+		if err != nil {
+			name = filepath.Base(path)
+		}
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			wf, err := workflow.Load(path)
+			if err != nil {
+				t.Fatalf("workflow.Load: %v", err)
+			}
+			if _, err := config.NewServiceConfig(wf.Config); err != nil {
+				t.Fatalf("config.NewServiceConfig: %v", err)
+			}
+		})
 	}
 }

--- a/cmd/sortie/validate_test.go
+++ b/cmd/sortie/validate_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/sortie-ai/sortie/internal/config"
+	"github.com/sortie-ai/sortie/internal/registry"
 )
 
 // errWriter is a test double that always returns a fixed error from Write.
@@ -2536,5 +2537,100 @@ func TestValidateShadowedEscalation(t *testing.T) {
 		if d := diagWithCheck(out.Errors, shadowed); d != nil {
 			t.Errorf("validateOutput.Errors contains shadowed check %q = %v, want absent (config layer must exit first)", shadowed, d)
 		}
+	}
+}
+
+// handoffStateWorkflow renders a minimal workflow for the given tracker
+// kind. Credentials and project are omitted deliberately: the state
+// collision is rejected by the config loader, which runs before any
+// adapter or preflight check, so validate never reaches those fields.
+func handoffStateWorkflow(kind, handoff string) []byte {
+	return fmt.Appendf(nil, `---
+polling:
+  interval_ms: 30000
+tracker:
+  kind: %s
+  active_states:
+    - "In Review"
+  terminal_states:
+    - "Done"
+  handoff_state: %q
+agent:
+  kind: mock
+---
+Do {{ .issue.title }}.
+`, kind, handoff)
+}
+
+// TestValidateHandoffStateCollisionEveryTrackerKind verifies that a
+// handoff_state colliding with active_states or terminal_states is a hard
+// error for every registered tracker kind. The rule is enforced by the
+// config loader rather than by adapter validation hooks, so no adapter can
+// opt out of it or downgrade it to a warning. The kind list comes from the
+// registry so a newly registered adapter is covered without editing this
+// test.
+func TestValidateHandoffStateCollisionEveryTrackerKind(t *testing.T) {
+	t.Parallel()
+
+	kinds := registry.Trackers.Kinds()
+	if len(kinds) == 0 {
+		t.Fatal("registry.Trackers.Kinds() is empty; the subtests below would assert nothing")
+	}
+
+	collisions := []struct {
+		name    string
+		handoff string
+		wantMsg string
+	}{
+		{
+			name:    "active state",
+			handoff: "In Review",
+			wantMsg: `config.tracker.handoff_state: "In Review" collides with active state "In Review"`,
+		},
+		{
+			name:    "terminal state",
+			handoff: "Done",
+			wantMsg: `config.tracker.handoff_state: "Done" collides with terminal state "Done"`,
+		},
+		{
+			name:    "terminal state, different casing",
+			handoff: "done",
+			wantMsg: `config.tracker.handoff_state: "done" collides with terminal state "Done"`,
+		},
+	}
+
+	for _, kind := range kinds {
+		for _, tc := range collisions {
+			t.Run(kind+"/"+tc.name, func(t *testing.T) {
+				t.Parallel()
+
+				wfPath := writeCustomWorkflowFile(t, t.TempDir(), handoffStateWorkflow(kind, tc.handoff))
+
+				var stdout, stderr bytes.Buffer
+				code := run(context.Background(), []string{"validate", wfPath}, &stdout, &stderr)
+				if code != 1 {
+					t.Fatalf("run(validate) = %d, want 1; stderr: %s", code, stderr.String())
+				}
+				if !strings.Contains(stderr.String(), tc.wantMsg) {
+					t.Errorf("stderr = %q, want to contain %q", stderr.String(), tc.wantMsg)
+				}
+			})
+		}
+
+		t.Run(kind+"/no collision", func(t *testing.T) {
+			t.Parallel()
+
+			wfPath := writeCustomWorkflowFile(t, t.TempDir(), handoffStateWorkflow(kind, "Awaiting Human"))
+
+			var stdout, stderr bytes.Buffer
+			run(context.Background(), []string{"validate", wfPath}, &stdout, &stderr)
+
+			// The exit code is unconstrained: kinds that require an api_key or
+			// project still fail preflight on this minimal workflow. What must
+			// not appear is the collision diagnostic.
+			if strings.Contains(stderr.String(), "config.tracker.handoff_state") {
+				t.Errorf("stderr = %q, want no handoff_state diagnostic for a non-colliding state", stderr.String())
+			}
+		})
 	}
 }

--- a/docs/workflow-reference.md
+++ b/docs/workflow-reference.md
@@ -2875,8 +2875,10 @@ advisory and does not block startup. The Linear adapter (`kind: linear`) emits:
 | `tracker.active_states.empty_element` / `tracker.terminal_states.empty_element` | error | `tracker.active_states[<i>]: empty state name can never match a team state` (same shape for `terminal_states`)               |
 | `tracker.active_states.untrimmed_element` / `tracker.terminal_states.untrimmed_element` | error | `tracker.active_states[<i>]: state name has leading or trailing whitespace and can never match a team state` (same shape for `terminal_states`) |
 | `tracker.states.overlap`                         | warning  | `tracker.active_states and tracker.terminal_states overlap on "<name>"; an issue in state "<name>" would match both sets`                           |
-| `tracker.handoff_state.collision`                | warning  | `tracker.handoff_state "<name>" must not appear in active_states (would cause immediate re-dispatch after handoff)`                                 |
-| `tracker.handoff_state.collision`                | warning  | `tracker.handoff_state "<name>" must not appear in terminal_states (handoff is not terminal)`                                                       |
+
+A `handoff_state` or `in_progress_state` that collides with `active_states` or
+`terminal_states` is not an adapter diagnostic. The generic config validation rejects it for
+every `tracker.kind` before the adapter hook runs, reporting it as a `config.tracker.*` error.
 
 These offline checks never contact Linear and never log the API key value. State-name existence
 against the team and credential validity are checked by the online preflight at adapter

--- a/internal/orchestrator/github_integration_test.go
+++ b/internal/orchestrator/github_integration_test.go
@@ -199,7 +199,7 @@ func (c *githubAPIClient) restoreIssueState(t *testing.T, number string) {
 
 // TestGitHubIntegration_FullDispatchCycle verifies the full orchestrator
 // dispatch cycle with the real GitHub adapter: poll → dispatch mock agent →
-// handoff transition (label swap + close).
+// handoff transition (label swap, issue left open).
 func TestGitHubIntegration_FullDispatchCycle(t *testing.T) {
 	skipUnlessGitHubE2E(t)
 
@@ -213,20 +213,28 @@ func TestGitHubIntegration_FullDispatchCycle(t *testing.T) {
 	issueNumber := ghClient.createTestIssue(t, issueTitle, []string{"backlog"})
 	t.Cleanup(func() { ghClient.restoreIssueState(t, issueNumber) })
 
+	// One tracker map feeds both the adapter and the orchestrator config, so
+	// the state sets the adapter derives from cannot drift away from the ones
+	// the orchestrator dispatches on. The lists are []any because that is what
+	// a YAML decode produces, and the config loader accepts nothing else.
+	trackerCfg := map[string]any{
+		"kind":            "github",
+		"api_key":         os.Getenv("SORTIE_GITHUB_TOKEN"),
+		"project":         os.Getenv("SORTIE_GITHUB_PROJECT"),
+		"active_states":   []any{"backlog", "in-progress"},
+		"terminal_states": []any{"done", "wontfix"},
+		"handoff_state":   "review",
+		// Scope fetches to this test's issue only so concurrent test runs
+		// cannot dispatch one another's issues.
+		"query_filter": issueTitle + " in:title",
+	}
+
 	// --- Setup: real GitHub tracker adapter via registry ---
 	trackerFactory, err := registry.Trackers.Get("github")
 	if err != nil {
 		t.Fatalf("registry.Trackers.Get(%q): %v", "github", err)
 	}
-	trackerAdapter, err := trackerFactory(map[string]any{
-		"api_key":         os.Getenv("SORTIE_GITHUB_TOKEN"),
-		"project":         os.Getenv("SORTIE_GITHUB_PROJECT"),
-		"active_states":   []string{"backlog", "in-progress", "review"},
-		"terminal_states": []string{"done", "wontfix"},
-		// Scope fetches to this test's issue only so concurrent test runs
-		// cannot dispatch one another's issues.
-		"query_filter": issueTitle + " in:title",
-	})
+	trackerAdapter, err := trackerFactory(trackerCfg)
 	if err != nil {
 		t.Fatalf("NewGitHubAdapter: %v", err)
 	}
@@ -259,26 +267,23 @@ func TestGitHubIntegration_FullDispatchCycle(t *testing.T) {
 	}
 
 	// --- Setup: config and workflow manager ---
+	// Built through the loader rather than as a struct literal, so this test
+	// can only ever run a configuration an operator could also write.
 	workspaceRoot := t.TempDir()
-	cfg := config.ServiceConfig{
-		Tracker: config.TrackerConfig{
-			Kind:           "github",
-			APIKey:         os.Getenv("SORTIE_GITHUB_TOKEN"),
-			Project:        os.Getenv("SORTIE_GITHUB_PROJECT"),
-			ActiveStates:   []string{"backlog", "in-progress", "review"},
-			TerminalStates: []string{"done", "wontfix"},
-			HandoffState:   "done",
+	cfg, err := config.NewServiceConfig(map[string]any{
+		"tracker":   trackerCfg,
+		"polling":   map[string]any{"interval_ms": 5000},
+		"workspace": map[string]any{"root": workspaceRoot},
+		"hooks":     map[string]any{"timeout_ms": 5000},
+		"agent": map[string]any{
+			"kind":                  "mock",
+			"max_concurrent_agents": 1,
+			"max_turns":             1,
+			"read_timeout_ms":       1000,
 		},
-		Polling:   config.PollingConfig{IntervalMS: 5000},
-		Workspace: config.WorkspaceConfig{Root: workspaceRoot},
-		Hooks:     config.HooksConfig{TimeoutMS: 5000},
-		Agent: config.AgentConfig{
-			Kind:                "mock",
-			MaxConcurrentAgents: 1,
-			MaxTurns:            1,
-			ReadTimeoutMS:       1000,
-		},
-		Extensions: map[string]any{},
+	})
+	if err != nil {
+		t.Fatalf("config.NewServiceConfig: %v", err)
 	}
 
 	tmpl, err := prompt.Parse("work on {{ .issue.identifier }}", "test", 0)
@@ -335,20 +340,20 @@ func TestGitHubIntegration_FullDispatchCycle(t *testing.T) {
 		case <-deadline:
 			orchCancel()
 			<-done
-			t.Fatalf("timed out waiting for issue #%s to transition to 'done'", issueNumber)
+			t.Fatalf("timed out waiting for issue #%s to transition to 'review'", issueNumber)
 		default:
 		}
 
 		issue = ghClient.fetchIssue(t, issueNumber)
-		hasDone := false
+		hasReview := false
 		for _, l := range issue.Labels {
-			if strings.EqualFold(l.Name, "done") {
-				hasDone = true
+			if strings.EqualFold(l.Name, "review") {
+				hasReview = true
 				break
 			}
 		}
-		if hasDone && issue.State == "closed" {
-			t.Logf("issue #%s transitioned: state=%q, labels include 'done'", issueNumber, issue.State)
+		if hasReview {
+			t.Logf("issue #%s transitioned: state=%q, labels include 'review'", issueNumber, issue.State)
 			break
 		}
 		time.Sleep(2 * time.Second)
@@ -362,12 +367,12 @@ func TestGitHubIntegration_FullDispatchCycle(t *testing.T) {
 		t.Fatal("orchestrator did not shut down within 15 seconds")
 	}
 
-	// handoff_state="done" is terminal → issue should be closed.
-	if issue.State != "closed" {
-		t.Errorf("issue state = %q, want %q", issue.State, "closed")
+	// handoff_state="review" is neither active nor terminal, so the handoff
+	// parks the issue for a reviewer instead of closing it.
+	if issue.State != "open" {
+		t.Errorf("issue state = %q, want %q", issue.State, "open")
 	}
 
-	// Issue should have the "done" label.
 	hasLabel := func(name string) bool {
 		for _, l := range issue.Labels {
 			if strings.EqualFold(l.Name, name) {
@@ -376,15 +381,15 @@ func TestGitHubIntegration_FullDispatchCycle(t *testing.T) {
 		}
 		return false
 	}
-	if !hasLabel("done") {
+	if !hasLabel("review") {
 		labels := make([]string, len(issue.Labels))
 		for i, l := range issue.Labels {
 			labels[i] = l.Name
 		}
-		t.Errorf("issue labels = %v, want 'done' present", labels)
+		t.Errorf("issue labels = %v, want 'review' present", labels)
 	}
 	if hasLabel("backlog") {
-		t.Error("issue still has 'backlog' label after handoff to 'done'")
+		t.Error("issue still has 'backlog' label after handoff to 'review'")
 	}
 
 	// --- Verification: run history in SQLite ---

--- a/internal/scm/gitea/validate.go
+++ b/internal/scm/gitea/validate.go
@@ -188,10 +188,10 @@ func validateStateLabels(field string, states []string) []registry.ValidationDia
 }
 
 // validateStateOverlap detects state names shared between active_states
-// and terminal_states, and a handoff_state that collides with either
-// list. All comparisons are case-insensitive. There is no
-// in_progress_state arm because in_progress_state is not a Gitea config
-// key.
+// and terminal_states. All comparisons are case-insensitive. Collisions
+// involving handoff_state or in_progress_state are rejected by the
+// generic config validation before this hook runs, so there are no arms
+// for them here.
 func validateStateOverlap(fields registry.TrackerConfigFields) []registry.ValidationDiag {
 	var diags []registry.ValidationDiag
 
@@ -214,24 +214,6 @@ func validateStateOverlap(fields registry.TrackerConfigFields) []registry.Valida
 			Check:    "tracker.states.overlap",
 			Message:  fmt.Sprintf("tracker.active_states and tracker.terminal_states overlap on %q; an issue in state %q would match both sets", name, name),
 		})
-	}
-
-	handoff := strings.TrimSpace(fields.HandoffState)
-	if hs := strings.ToLower(handoff); hs != "" {
-		if _, ok := activeSet[hs]; ok {
-			diags = append(diags, registry.ValidationDiag{
-				Severity: "warning",
-				Check:    "tracker.handoff_state.collision",
-				Message:  fmt.Sprintf("tracker.handoff_state %q must not appear in active_states (would cause immediate re-dispatch after handoff)", handoff),
-			})
-		}
-		if _, ok := terminalSet[hs]; ok {
-			diags = append(diags, registry.ValidationDiag{
-				Severity: "warning",
-				Check:    "tracker.handoff_state.collision",
-				Message:  fmt.Sprintf("tracker.handoff_state %q must not appear in terminal_states (handoff is not terminal)", handoff),
-			})
-		}
 	}
 
 	return diags

--- a/internal/scm/gitea/validate_test.go
+++ b/internal/scm/gitea/validate_test.go
@@ -360,40 +360,12 @@ func TestValidateStateOverlap(t *testing.T) {
 			wantDiagCount: 0,
 		},
 		{
-			name: "handoff_state in active_states",
-			fields: registry.TrackerConfigFields{
-				ActiveStates:   []string{"review", "backlog"},
-				TerminalStates: []string{"done"},
-				HandoffState:   "review",
-			},
-			wantChecks:    []string{"tracker.handoff_state.collision"},
-			wantDiagCount: 1,
-		},
-		{
-			name: "handoff_state in terminal_states",
-			fields: registry.TrackerConfigFields{
-				ActiveStates:   []string{"backlog"},
-				TerminalStates: []string{"done"},
-				HandoffState:   "done",
-			},
-			wantChecks:    []string{"tracker.handoff_state.collision"},
-			wantDiagCount: 1,
-		},
-		{
-			name: "empty handoff_state is skipped",
-			fields: registry.TrackerConfigFields{
-				ActiveStates:   []string{"backlog"},
-				TerminalStates: []string{"done"},
-				HandoffState:   "",
-			},
-			wantDiagCount: 0,
-		},
-		{
-			name: "in_progress_state is not a Gitea concern",
+			name: "handoff_state and in_progress_state are not this hook's concern",
 			fields: registry.TrackerConfigFields{
 				ActiveStates:    []string{"backlog"},
-				TerminalStates:  []string{"done", "closed"},
-				InProgressState: "closed",
+				TerminalStates:  []string{"done"},
+				HandoffState:    "done",
+				InProgressState: "done",
 			},
 			wantDiagCount: 0,
 		},

--- a/internal/scm/github/validate.go
+++ b/internal/scm/github/validate.go
@@ -100,8 +100,10 @@ func validateStateLabels(field string, states []string) []registry.ValidationDia
 	return diags
 }
 
-// validateStateOverlap detects collisions between active_states,
-// terminal_states, handoff_state, and in_progress_state.
+// validateStateOverlap detects labels shared between active_states and
+// terminal_states. Collisions involving handoff_state or
+// in_progress_state are rejected by the generic config validation before
+// this hook runs, so there are no arms for them here.
 func validateStateOverlap(fields registry.TrackerConfigFields) []registry.ValidationDiag {
 	var diags []registry.ValidationDiag
 
@@ -125,43 +127,6 @@ func validateStateOverlap(fields registry.TrackerConfigFields) []registry.Valida
 			Check:    "tracker.states.overlap",
 			Message:  fmt.Sprintf("tracker.active_states and tracker.terminal_states overlap on %q; an issue in state %q would match both sets", label, label),
 		})
-	}
-
-	// Handoff state must not overlap with active or terminal sets.
-	if hs := strings.ToLower(strings.TrimSpace(fields.HandoffState)); hs != "" {
-		if _, ok := activeSet[hs]; ok {
-			diags = append(diags, registry.ValidationDiag{
-				Severity: "warning",
-				Check:    "tracker.handoff_state.collision",
-				Message:  fmt.Sprintf("tracker.handoff_state %q must not appear in active_states (would cause immediate re-dispatch after handoff)", fields.HandoffState),
-			})
-		}
-		if _, ok := terminalSet[hs]; ok {
-			diags = append(diags, registry.ValidationDiag{
-				Severity: "warning",
-				Check:    "tracker.handoff_state.collision",
-				Message:  fmt.Sprintf("tracker.handoff_state %q must not appear in terminal_states (handoff is not terminal)", fields.HandoffState),
-			})
-		}
-	}
-
-	// In-progress state must not collide with terminal or handoff states.
-	if ips := strings.ToLower(strings.TrimSpace(fields.InProgressState)); ips != "" {
-		if _, ok := terminalSet[ips]; ok {
-			diags = append(diags, registry.ValidationDiag{
-				Severity: "warning",
-				Check:    "tracker.in_progress_state.collision",
-				Message:  fmt.Sprintf("tracker.in_progress_state %q must not appear in terminal_states", fields.InProgressState),
-			})
-		}
-		hs := strings.ToLower(strings.TrimSpace(fields.HandoffState))
-		if hs != "" && ips == hs {
-			diags = append(diags, registry.ValidationDiag{
-				Severity: "warning",
-				Check:    "tracker.in_progress_state.collision",
-				Message:  fmt.Sprintf("tracker.in_progress_state must not collide with tracker.handoff_state (%q)", fields.HandoffState),
-			})
-		}
 	}
 
 	return diags

--- a/internal/scm/github/validate_test.go
+++ b/internal/scm/github/validate_test.go
@@ -343,61 +343,12 @@ func TestValidateStateOverlap(t *testing.T) {
 			wantDiagCount: 0,
 		},
 		{
-			name: "handoff_state in active_states",
-			fields: registry.TrackerConfigFields{
-				ActiveStates:   []string{"review", "backlog"},
-				TerminalStates: []string{"done"},
-				HandoffState:   "review",
-			},
-			wantChecks:    []string{"tracker.handoff_state.collision"},
-			wantDiagCount: 1,
-		},
-		{
-			name: "handoff_state in terminal_states",
-			fields: registry.TrackerConfigFields{
-				ActiveStates:   []string{"backlog"},
-				TerminalStates: []string{"done"},
-				HandoffState:   "done",
-			},
-			wantChecks:    []string{"tracker.handoff_state.collision"},
-			wantDiagCount: 1,
-		},
-		{
-			name: "in_progress_state in terminal_states",
-			fields: registry.TrackerConfigFields{
-				ActiveStates:    []string{"backlog"},
-				TerminalStates:  []string{"done", "closed"},
-				InProgressState: "closed",
-			},
-			wantChecks:    []string{"tracker.in_progress_state.collision"},
-			wantDiagCount: 1,
-		},
-		{
-			name: "in_progress_state collides with handoff_state",
+			name: "handoff_state and in_progress_state are not this hook's concern",
 			fields: registry.TrackerConfigFields{
 				ActiveStates:    []string{"backlog"},
 				TerminalStates:  []string{"done"},
-				HandoffState:    "review",
-				InProgressState: "review",
-			},
-			wantChecks:    []string{"tracker.in_progress_state.collision"},
-			wantDiagCount: 1,
-		},
-		{
-			name: "empty handoff_state is skipped",
-			fields: registry.TrackerConfigFields{
-				ActiveStates:   []string{"backlog"},
-				TerminalStates: []string{"done"},
-				HandoffState:   "",
-			},
-			wantDiagCount: 0,
-		},
-		{
-			name: "empty in_progress_state is skipped",
-			fields: registry.TrackerConfigFields{
-				ActiveStates:    []string{"backlog"},
-				TerminalStates:  []string{"done"},
-				InProgressState: "",
+				HandoffState:    "done",
+				InProgressState: "done",
 			},
 			wantDiagCount: 0,
 		},

--- a/internal/tracker/linear/validate.go
+++ b/internal/tracker/linear/validate.go
@@ -130,10 +130,10 @@ func validateStateLabels(field string, states []string) []registry.ValidationDia
 }
 
 // validateStateOverlap detects state names shared between active_states
-// and terminal_states, and a handoff_state that collides with either
-// list. All comparisons are case-insensitive. There is no
-// in_progress_state arm because in_progress_state is not a Linear config
-// key.
+// and terminal_states. All comparisons are case-insensitive. Collisions
+// involving handoff_state or in_progress_state are rejected by the
+// generic config validation before this hook runs, so there are no arms
+// for them here.
 func validateStateOverlap(fields registry.TrackerConfigFields) []registry.ValidationDiag {
 	var diags []registry.ValidationDiag
 
@@ -156,24 +156,6 @@ func validateStateOverlap(fields registry.TrackerConfigFields) []registry.Valida
 			Check:    "tracker.states.overlap",
 			Message:  fmt.Sprintf("tracker.active_states and tracker.terminal_states overlap on %q; an issue in state %q would match both sets", name, name),
 		})
-	}
-
-	handoff := strings.TrimSpace(fields.HandoffState)
-	if hs := strings.ToLower(handoff); hs != "" {
-		if _, ok := activeSet[hs]; ok {
-			diags = append(diags, registry.ValidationDiag{
-				Severity: "warning",
-				Check:    "tracker.handoff_state.collision",
-				Message:  fmt.Sprintf("tracker.handoff_state %q must not appear in active_states (would cause immediate re-dispatch after handoff)", handoff),
-			})
-		}
-		if _, ok := terminalSet[hs]; ok {
-			diags = append(diags, registry.ValidationDiag{
-				Severity: "warning",
-				Check:    "tracker.handoff_state.collision",
-				Message:  fmt.Sprintf("tracker.handoff_state %q must not appear in terminal_states (handoff is not terminal)", handoff),
-			})
-		}
 	}
 
 	return diags

--- a/internal/tracker/linear/validate_test.go
+++ b/internal/tracker/linear/validate_test.go
@@ -408,60 +408,12 @@ func TestValidateStateOverlap(t *testing.T) {
 			wantDiagCount: 0,
 		},
 		{
-			name: "handoff_state present in active_states – collision warning",
-			fields: registry.TrackerConfigFields{
-				ActiveStates:   []string{"review", "backlog"},
-				TerminalStates: []string{"Done"},
-				HandoffState:   "review",
-			},
-			wantDiagCount: 1,
-			wantChecks:    []string{"tracker.handoff_state.collision"},
-		},
-		{
-			name: "handoff_state present in terminal_states – collision warning",
-			fields: registry.TrackerConfigFields{
-				ActiveStates:   []string{"backlog"},
-				TerminalStates: []string{"done", "canceled"},
-				HandoffState:   "done",
-			},
-			wantDiagCount: 1,
-			wantChecks:    []string{"tracker.handoff_state.collision"},
-		},
-		{
-			name: "handoff_state case-insensitive match in active_states",
-			fields: registry.TrackerConfigFields{
-				ActiveStates:   []string{"Review"},
-				TerminalStates: []string{"Done"},
-				HandoffState:   "REVIEW",
-			},
-			wantDiagCount: 1,
-			wantChecks:    []string{"tracker.handoff_state.collision"},
-		},
-		{
-			name: "empty handoff_state is skipped",
-			fields: registry.TrackerConfigFields{
-				ActiveStates:   []string{"backlog"},
-				TerminalStates: []string{"done"},
-				HandoffState:   "",
-			},
-			wantDiagCount: 0,
-		},
-		// InProgressState populated but must generate no in_progress_state diag.
-		{
-			name: "in_progress_state populated – no in_progress_state diagnostic emitted",
+			name: "handoff_state and in_progress_state are not this hook's concern",
 			fields: registry.TrackerConfigFields{
 				ActiveStates:    []string{"backlog"},
 				TerminalStates:  []string{"done"},
-				InProgressState: "in progress",
-			},
-			wantDiagCount: 0,
-		},
-		{
-			name: "in_progress_state in terminal_states – no in_progress_state diagnostic",
-			fields: registry.TrackerConfigFields{
-				ActiveStates:    []string{"backlog"},
-				TerminalStates:  []string{"done", "in progress"},
-				InProgressState: "in progress",
+				HandoffState:    "done",
+				InProgressState: "done",
 			},
 			wantDiagCount: 0,
 		},


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Refactor

**Intent:** `internal/config/config.go` already rejects a `handoff_state` or `in_progress_state` that collides with `active_states` or `terminal_states` as a hard `config.tracker.*` error, and it runs before any adapter validate hook. The GitHub, Gitea, and Linear adapters each carried their own warning-level collision checks for the exact same rule, so those checks were dead code that could never fire. This removes the shadowed checks, adds regression coverage that locks the config-layer behavior in for every registered tracker kind, and fixes an integration test and a docs table that both assumed the old adapter-level behavior.

**Related Issues:** #694

### 🧭 Reviewer Guide

**Complexity:** Medium

#### Entry Point

Start with `internal/scm/github/validate.go`. `validateStateOverlap` previously emitted `tracker.handoff_state.collision` and `tracker.in_progress_state.collision` warnings that duplicated a check already enforced as an error earlier in the config-loading path. The same pattern repeats in `internal/scm/gitea/validate.go` and `internal/tracker/linear/validate.go`, each trimmed down to only the `active_states`/`terminal_states` overlap check that remains their concern.

#### Sensitive Areas

- `internal/orchestrator/github_integration_test.go`: this real-adapter, env-gated test previously configured `handoff_state: "done"` colliding with `terminal_states`, which the config loader would now reject outright. Updated to `handoff_state: "review"` and to build the config through `config.NewServiceConfig` instead of a struct literal, so the test can only ever exercise a configuration an operator could actually write.
- `cmd/sortie/validate_test.go`: adds `TestValidateHandoffStateCollisionEveryTrackerKind`, which drives every kind returned by `registry.Trackers.Kinds()` through the CLI to confirm the collision is a hard error everywhere, not something an individual adapter could opt out of.
- `cmd/sortie/sample_workflow_test.go`: adds `TestSampleWorkflowConfigLoads`, which loads every shipped `WORKFLOW*.md` through the real config loader so a future example that reintroduces this collision fails in CI instead of on a user's first run.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes. The `handoff_state`/`in_progress_state` collision was already a hard error at the config layer before this change; the adapter-level warnings being removed were unreachable.
- **Migrations/State:** No migrations or state changes.