### PR TITLE
fix: recognize reaction continuation vars in template analyzer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `sortie validate` no longer reports `unknown template variable` for the
+  reaction continuation variables (`ci_failure`, `review_comments`,
+  `bot_review_comments`, `merge_conflict`, `label_review`, `label_fix`). A
+  mistyped sub-field of one of them is now reported as an unknown field with
+  the valid field list, and a reference to one of them from inside a
+  `{{ range }}` or `{{ with }}` body is now reported as dot-context misuse.
+  ([#696](https://github.com/sortie-ai/sortie/issues/696))
 - `sortie validate` and startup now reject a `tracker.handoff_state` or
   `tracker.in_progress_state` that collides with the tracker adapter's own
   fallback state list when the matching workflow list is empty. Leaving

--- a/cmd/sortie/sample_workflow_test.go
+++ b/cmd/sortie/sample_workflow_test.go
@@ -683,3 +683,39 @@ func TestSampleWorkflowConfigLoads(t *testing.T) {
 		})
 	}
 }
+
+// TestShippedWorkflowsProduceNoTemplateWarnings verifies that every
+// shipped WORKFLOW*.md produces zero template static-analysis warnings.
+// It calls the analyzer directly rather than the validate CLI, for the
+// same reason TestSampleWorkflowConfigLoads does: environment indirection
+// is deliberately left unresolved, so the CLI reports config errors on
+// these files and CLI-level assertions would not be hermetic.
+func TestShippedWorkflowsProduceNoTemplateWarnings(t *testing.T) {
+	t.Parallel()
+
+	for _, path := range shippedWorkflowPaths(t) {
+		name, err := filepath.Rel(repoRoot(t), path)
+		if err != nil {
+			name = filepath.Base(path)
+		}
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			wf, err := workflow.Load(path)
+			if err != nil {
+				t.Fatalf("workflow.Load: %v", err)
+			}
+			tmpl, err := prompt.Parse(wf.PromptTemplate, path, wf.FrontMatterLines)
+			if err != nil {
+				t.Fatalf("prompt.Parse: %v", err)
+			}
+			if warnings := prompt.AnalyzeTemplate(tmpl); len(warnings) != 0 {
+				for _, w := range warnings {
+					t.Errorf("AnalyzeTemplate warning: kind=%v node=%q message=%q", w.Kind, w.Node, w.Message)
+				}
+				t.Fatalf("prompt.AnalyzeTemplate returned %d warnings, want 0", len(warnings))
+			}
+		})
+	}
+}

--- a/cmd/sortie/validate_test.go
+++ b/cmd/sortie/validate_test.go
@@ -1098,6 +1098,89 @@ func TestValidateTemplateCleanNoWarnings(t *testing.T) {
 	}
 }
 
+// allContinuationKeysWorkflow returns a workflow whose prompt references all
+// six reaction continuation keys under top-level {{ if }} guards, one
+// documented sub-field of each of the four map-shaped keys, one element
+// field of each of the two list-shaped keys inside {{ range }}, and exactly
+// one unrecognized name, .not_a_reaction. The front matter configures no
+// reaction block, so a clean result here also demonstrates that the
+// recognized set does not depend on which reactions are configured.
+func allContinuationKeysWorkflow() []byte {
+	return []byte(`---
+tracker:
+  kind: file
+  active_states:
+    - To Do
+  terminal_states:
+    - Done
+agent:
+  kind: mock
+---
+{{ if .ci_failure }}x{{ end }}
+{{ if .review_comments }}x{{ end }}
+{{ if .bot_review_comments }}x{{ end }}
+{{ if .merge_conflict }}x{{ end }}
+{{ if .label_review }}x{{ end }}
+{{ if .label_fix }}x{{ end }}
+{{ .ci_failure.status }}
+{{ .merge_conflict.base }}
+{{ .label_review.actor }}
+{{ .label_fix.branch }}
+{{ range .review_comments }}{{ .body }}{{ end }}
+{{ range .bot_review_comments }}{{ .body }}{{ end }}
+{{ .not_a_reaction }}
+`)
+}
+
+// TestValidateTemplateContinuationKeysCleanJSON verifies that sortie
+// validate reports no unknown_var, unknown_field, or dot_context warning
+// for any of the six reaction continuation keys or their documented
+// fields, while an unrelated unrecognized name still produces exactly one
+// unknown_var warning naming the full enumerated set of recognized names.
+func TestValidateTemplateContinuationKeysCleanJSON(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	wfPath := writeCustomWorkflowFile(t, dir, allContinuationKeysWorkflow())
+
+	var stdout, stderr bytes.Buffer
+	code := run(context.Background(), []string{"validate", "--format", "json", wfPath}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("run(validate --format json) = %d, want 0; stderr: %s", code, stderr.String())
+	}
+
+	var out validateOutput
+	if err := json.Unmarshal(stdout.Bytes(), &out); err != nil {
+		t.Fatalf("json.Unmarshal(%q): %v", stdout.String(), err)
+	}
+	if !out.Valid {
+		t.Errorf("validateOutput.Valid = false, want true")
+	}
+
+	const wantMessage = `unknown template variable ".not_a_reaction"; valid top-level variables are: .issue, .attempt, .run, .ci_failure, .review_comments, .bot_review_comments, .merge_conflict, .label_review, .label_fix`
+
+	var unknownVarWarnings []validateDiag
+	for _, w := range out.Warnings {
+		switch w.Check {
+		case "unknown_var":
+			unknownVarWarnings = append(unknownVarWarnings, w)
+		case "unknown_field", "dot_context":
+			t.Errorf("validateOutput.Warnings contains check=%q: %v, want no %q or %q warnings for the continuation keys and their documented fields",
+				w.Check, w, "unknown_field", "dot_context")
+		}
+	}
+	if len(unknownVarWarnings) != 1 {
+		t.Fatalf("validateOutput.Warnings has %d unknown_var entries, want exactly 1: %v", len(unknownVarWarnings), unknownVarWarnings)
+	}
+	got := unknownVarWarnings[0]
+	if !strings.Contains(got.Message, ".not_a_reaction") {
+		t.Errorf("unknown_var warning message = %q, want to contain %q", got.Message, ".not_a_reaction")
+	}
+	if got.Message != wantMessage {
+		t.Errorf("unknown_var warning message = %q, want %q", got.Message, wantMessage)
+	}
+}
+
 // --- writeJSON / emitDiags error-path tests ---
 
 // --- writeJSON / emitDiags error-path tests ---

--- a/docs/workflow-reference.md
+++ b/docs/workflow-reference.md
@@ -2230,8 +2230,9 @@ template.New("prompt").
 ### 5.2 Template Input Variables
 
 The data map passed to `Execute` contains **three core top-level keys** (`issue`, `attempt`,
-`run`) plus **continuation context keys** (`ci_failure`, `review_comments`, `bot_review_comments`)
-that are `nil` by default and populated on reaction-triggered dispatches:
+`run`) plus **continuation context keys** (`ci_failure`, `review_comments`, `bot_review_comments`,
+`merge_conflict`, `label_review`, `label_fix`) that are `nil` by default and populated on
+reaction-triggered dispatches:
 
 #### `issue` — Normalized Issue Object
 

--- a/internal/orchestrator/continuation_template_schema_test.go
+++ b/internal/orchestrator/continuation_template_schema_test.go
@@ -1,0 +1,74 @@
+package orchestrator
+
+import (
+	"testing"
+	"time"
+
+	"github.com/sortie-ai/sortie/internal/domain"
+	"github.com/sortie-ai/sortie/internal/prompt"
+)
+
+// TestContinuationBuilderFieldsMatchSchema verifies that every field the
+// three map-shaped continuation builders owned by this package emit is
+// accepted by the template analyzer as a known sub-field of its top-level
+// key. It reaches the analyzer only through the exported prompt.Parse and
+// prompt.AnalyzeTemplate surface, so it fails when a builder gains or
+// renames a field the analyzer's schema does not carry.
+//
+// review_comments and bot_review_comments are excluded: their builder
+// returns a list, so element fields are addressed inside {{ range }},
+// where the analyzer does not validate field names — a generated check on
+// them would assert nothing. ci_failure is excluded because its builder
+// lives in internal/domain, covered instead by
+// TestTemplateFieldSchemaMatchesDomain in internal/prompt.
+func TestContinuationBuilderFieldsMatchSchema(t *testing.T) {
+	t.Parallel()
+
+	requestedAt := time.Date(2026, 7, 9, 12, 30, 0, 0, time.UTC)
+
+	tests := []struct {
+		topKey string
+		fields map[string]any
+	}{
+		{
+			topKey: "merge_conflict",
+			fields: buildMergeConflictTemplateMap(
+				&MergeConflictReactionData{PRNumber: 42, Branch: "feature/x"},
+				domain.PRMergeStatus{HeadSHA: "abc123", BaseBranch: "develop"},
+			),
+		},
+		{
+			topKey: "label_review",
+			fields: buildLabelReviewMap(
+				&LabelReviewReactionData{PRNumber: 99, Owner: "acme", Repo: "widgets"},
+				"alice",
+				requestedAt,
+			),
+		},
+		{
+			topKey: "label_fix",
+			fields: buildLabelFixMap(
+				&LabelFixReactionData{PRNumber: 99, Owner: "acme", Repo: "widgets", Branch: "feature/99"},
+				"alice",
+				requestedAt,
+			),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.topKey, func(t *testing.T) {
+			t.Parallel()
+
+			for field := range tt.fields {
+				body := "{{ ." + tt.topKey + "." + field + " }}"
+				tmpl, err := prompt.Parse(body, "test.md", 0)
+				if err != nil {
+					t.Fatalf("prompt.Parse(%q): %v", body, err)
+				}
+				if warnings := prompt.AnalyzeTemplate(tmpl); len(warnings) != 0 {
+					t.Errorf("prompt.AnalyzeTemplate(%q) = %v, want no warnings", body, warnings)
+				}
+			}
+		})
+	}
+}

--- a/internal/prompt/analyze.go
+++ b/internal/prompt/analyze.go
@@ -19,8 +19,9 @@ const (
 	// the current element.
 	WarnDotContext WarnKind = iota + 1
 
-	// WarnUnknownVar flags a top-level variable reference not in the
-	// template data contract {issue, attempt, run}.
+	// WarnUnknownVar flags a top-level variable reference outside the
+	// recognized set. The recognized set is exactly the top-level keys
+	// the renderer registers: [Template.Render] seeds them.
 	WarnUnknownVar
 
 	// WarnUnknownField flags a sub-field of a known top-level variable
@@ -36,19 +37,45 @@ type TemplateWarning struct {
 	Message string
 }
 
-// topLevelKeys is the set of recognized top-level template variables.
-var topLevelKeys = map[string]struct{}{
-	"issue":      {},
-	"attempt":    {},
-	"run":        {},
-	"ci_failure": {},
-}
+// coreKeys lists the top-level template variables [Template.Render]
+// always populates, independent of [continuationKeys].
+var coreKeys = []string{"issue", "attempt", "run"}
+
+// topLevelOrder is coreKeys followed by every entry of continuationKeys,
+// in that order. It fixes the enumeration order used by topLevelList.
+var topLevelOrder = func() []string {
+	order := make([]string, 0, len(coreKeys)+len(continuationKeys))
+	order = append(order, coreKeys...)
+	order = append(order, continuationKeys...)
+	return order
+}()
+
+// topLevelKeys is the set of recognized top-level template variables,
+// derived from topLevelOrder so a name registered with the renderer is
+// recognized without a second edit here.
+var topLevelKeys = func() map[string]struct{} {
+	keys := make(map[string]struct{}, len(topLevelOrder))
+	for _, k := range topLevelOrder {
+		keys[k] = struct{}{}
+	}
+	return keys
+}()
+
+// topLevelList is every entry of topLevelOrder prefixed with "." and
+// joined with ", ", for use in the unknown_var advisory message.
+var topLevelList = func() string {
+	names := make([]string, len(topLevelOrder))
+	for i, k := range topLevelOrder {
+		names[i] = "." + k
+	}
+	return strings.Join(names, ", ")
+}()
 
 // templateFieldSchema defines valid sub-fields for each top-level
-// template variable. A nil value means the variable is a scalar (no
-// sub-fields are valid). A map value enumerates the known child fields;
-// a nil entry in the child map means the child is a scalar, a non-nil
-// entry means nested fields are valid.
+// template variable. A nil value means the variable carries no
+// addressable sub-fields, whether it is a scalar or a list. A map value
+// enumerates the known child fields; a nil entry in the child map means
+// the child is a scalar, a non-nil entry means nested fields are valid.
 var templateFieldSchema = map[string]map[string]map[string]bool{
 	"issue": {
 		"id":          nil,
@@ -80,6 +107,29 @@ var templateFieldSchema = map[string]map[string]map[string]bool{
 		"log_excerpt":   nil,
 		"failing_count": nil,
 		"ref":           nil,
+	},
+	"review_comments":     nil,
+	"bot_review_comments": nil,
+	"merge_conflict": {
+		"pr_number": nil,
+		"branch":    nil,
+		"head_sha":  nil,
+		"base":      nil,
+	},
+	"label_review": {
+		"pr_number":    nil,
+		"owner":        nil,
+		"repo":         nil,
+		"actor":        nil,
+		"requested_at": nil,
+	},
+	"label_fix": {
+		"pr_number":    nil,
+		"owner":        nil,
+		"repo":         nil,
+		"branch":       nil,
+		"actor":        nil,
+		"requested_at": nil,
 	},
 }
 
@@ -189,7 +239,7 @@ func (a *analyzer) checkFieldNode(ident []string, scopeDepth int) {
 		a.warnings = append(a.warnings, TemplateWarning{
 			Kind:    WarnUnknownVar,
 			Node:    expr,
-			Message: fmt.Sprintf("unknown template variable %q; valid top-level variables are: .issue, .attempt, .run", expr),
+			Message: fmt.Sprintf("unknown template variable %q; valid top-level variables are: %s", expr, topLevelList),
 		})
 		return
 	}
@@ -213,7 +263,7 @@ func (a *analyzer) checkVariableNode(ident []string, scopeDepth int) {
 		a.warnings = append(a.warnings, TemplateWarning{
 			Kind:    WarnUnknownVar,
 			Node:    expr,
-			Message: fmt.Sprintf("unknown template variable %q; valid top-level variables are: .issue, .attempt, .run", expr),
+			Message: fmt.Sprintf("unknown template variable %q; valid top-level variables are: %s", expr, topLevelList),
 		})
 		return
 	}

--- a/internal/prompt/analyze_test.go
+++ b/internal/prompt/analyze_test.go
@@ -23,11 +23,12 @@ func TestAnalyzeTemplate(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name      string
-		body      string
-		wantCount int
-		wantKind  WarnKind // checked only when wantCount > 0
-		wantNode  string   // checked only when non-empty
+		name            string
+		body            string
+		wantCount       int
+		wantKind        WarnKind // checked only when wantCount > 0
+		wantNode        string   // checked only when non-empty
+		wantMsgContains string   // checked only when non-empty
 	}{
 		// Dot-context misuse inside range/with.
 		{
@@ -94,6 +95,23 @@ func TestAnalyzeTemplate(t *testing.T) {
 			wantCount: 1,
 			wantKind:  WarnUnknownVar,
 			wantNode:  "$.config",
+		},
+		// A continuation-era unrecognized name must still warn, and its
+		// message must enumerate the full recognized set.
+		{
+			name:            "UnrecognizedContinuationLikeName",
+			body:            `{{ .not_a_reaction }}`,
+			wantCount:       1,
+			wantKind:        WarnUnknownVar,
+			wantNode:        ".not_a_reaction",
+			wantMsgContains: topLevelList,
+		},
+		{
+			name:      "UnrecognizedContinuationLikeNameDollar",
+			body:      `{{ $.not_a_reaction }}`,
+			wantCount: 1,
+			wantKind:  WarnUnknownVar,
+			wantNode:  "$.not_a_reaction",
 		},
 		// All three top-level keys are valid — no warning.
 		{
@@ -259,6 +277,10 @@ func TestAnalyzeTemplate(t *testing.T) {
 					t.Errorf("AnalyzeTemplate(%q)[0].Node = %q, want %q",
 						tt.body, warnings[0].Node, tt.wantNode)
 				}
+				if tt.wantMsgContains != "" && !strings.Contains(warnings[0].Message, tt.wantMsgContains) {
+					t.Errorf("AnalyzeTemplate(%q)[0].Message = %q, want to contain %q",
+						tt.body, warnings[0].Message, tt.wantMsgContains)
+				}
 			}
 		})
 	}
@@ -331,18 +353,6 @@ func TestAnalyzeTemplateNestedRangeAllWarnings(t *testing.T) {
 func TestTemplateFieldSchemaMatchesDomain(t *testing.T) {
 	t.Parallel()
 
-	// Verify templateFieldSchema has exactly the four expected top-level keys.
-	wantTopLevel := []string{"issue", "attempt", "run", "ci_failure"}
-	if len(templateFieldSchema) != len(wantTopLevel) {
-		t.Errorf("templateFieldSchema has %d top-level keys, want %d (%v)",
-			len(templateFieldSchema), len(wantTopLevel), wantTopLevel)
-	}
-	for _, key := range wantTopLevel {
-		if _, ok := templateFieldSchema[key]; !ok {
-			t.Errorf("templateFieldSchema missing top-level key %q", key)
-		}
-	}
-
 	// Cross-check issue fields: every key returned by ToTemplateMap must be
 	// present in templateFieldSchema["issue"].
 	issueSchema := templateFieldSchema["issue"]
@@ -360,6 +370,178 @@ func TestTemplateFieldSchemaMatchesDomain(t *testing.T) {
 	for k := range runMap {
 		if _, ok := runSchema[k]; !ok {
 			t.Errorf("runContextToMap() key %q not present in templateFieldSchema[\"run\"]", k)
+		}
+	}
+
+	// Cross-check ci_failure fields: every key returned by
+	// CIResult.ToTemplateMap must be present in
+	// templateFieldSchema["ci_failure"].
+	ciFailureSchema := templateFieldSchema["ci_failure"]
+	ciFailureMap := (&domain.CIResult{}).ToTemplateMap()
+	for k := range ciFailureMap {
+		if _, ok := ciFailureSchema[k]; !ok {
+			t.Errorf("CIResult.ToTemplateMap() key %q not present in templateFieldSchema[\"ci_failure\"]", k)
+		}
+	}
+}
+
+// TestTemplateFieldSchemaCoversRecognizedKeys verifies that
+// templateFieldSchema carries exactly one entry per recognized top-level
+// key, computed as coreKeys plus continuationKeys, with no missing entry,
+// no extra entry, and no shadowing between the two source lists.
+func TestTemplateFieldSchemaCoversRecognizedKeys(t *testing.T) {
+	t.Parallel()
+
+	want := make(map[string]struct{}, len(coreKeys)+len(continuationKeys))
+	for _, k := range coreKeys {
+		want[k] = struct{}{}
+	}
+	for _, k := range continuationKeys {
+		want[k] = struct{}{}
+	}
+
+	for k := range want {
+		if _, ok := templateFieldSchema[k]; !ok {
+			t.Errorf("templateFieldSchema is missing an entry for recognized key %q; add a field schema for it", k)
+		}
+	}
+	for k := range templateFieldSchema {
+		if _, ok := want[k]; !ok {
+			t.Errorf("templateFieldSchema has entry %q, which is not in coreKeys or continuationKeys", k)
+		}
+	}
+	if got, wantLen := len(want), len(coreKeys)+len(continuationKeys); got != wantLen {
+		t.Errorf("len(coreKeys)+len(continuationKeys) = %d, but the computed recognized set has %d entries; a continuation key duplicates another entry or shadows a core key",
+			wantLen, got)
+	}
+}
+
+// TestContinuationKeysRecognizedBare verifies that every entry of
+// continuationKeys is recognized by AnalyzeTemplate as a bare top-level
+// reference, both in its plain and its $-qualified form.
+func TestContinuationKeysRecognizedBare(t *testing.T) {
+	t.Parallel()
+
+	for _, key := range continuationKeys {
+		t.Run(key, func(t *testing.T) {
+			t.Parallel()
+
+			for _, body := range []string{
+				"{{ if ." + key + " }}x{{ end }}",
+				"{{ if $." + key + " }}x{{ end }}",
+			} {
+				tmpl := mustParseAnalyze(t, body)
+				if warnings := AnalyzeTemplate(tmpl); len(warnings) != 0 {
+					t.Errorf("AnalyzeTemplate(%q) = %v, want no warnings", body, warnings)
+				}
+			}
+		})
+	}
+}
+
+// TestContinuationKeySubFieldBehavior verifies per-key sub-field behavior
+// for every continuation key: a map-shaped key accepts each of its
+// documented fields and flags an invented field name with the real field
+// list; a list-shaped key accepts an element field inside {{ range }} and
+// flags direct sub-field access as unknown.
+func TestContinuationKeySubFieldBehavior(t *testing.T) {
+	t.Parallel()
+
+	mapShaped := []struct {
+		key    string
+		fields []string
+	}{
+		{"ci_failure", []string{"status", "check_runs", "log_excerpt", "failing_count", "ref"}},
+		{"merge_conflict", []string{"pr_number", "branch", "head_sha", "base"}},
+		{"label_review", []string{"pr_number", "owner", "repo", "actor", "requested_at"}},
+		{"label_fix", []string{"pr_number", "owner", "repo", "branch", "actor", "requested_at"}},
+	}
+
+	for _, tt := range mapShaped {
+		t.Run(tt.key, func(t *testing.T) {
+			t.Parallel()
+
+			for _, field := range tt.fields {
+				body := "{{ ." + tt.key + "." + field + " }}"
+				tmpl := mustParseAnalyze(t, body)
+				if warnings := AnalyzeTemplate(tmpl); len(warnings) != 0 {
+					t.Errorf("AnalyzeTemplate(%q) = %v, want no warnings", body, warnings)
+				}
+			}
+
+			body := "{{ ." + tt.key + ".not_a_field }}"
+			tmpl := mustParseAnalyze(t, body)
+			warnings := AnalyzeTemplate(tmpl)
+			if len(warnings) != 1 {
+				t.Fatalf("AnalyzeTemplate(%q) returned %d warnings, want 1: %v", body, len(warnings), warnings)
+			}
+			if warnings[0].Kind != WarnUnknownField {
+				t.Errorf("AnalyzeTemplate(%q)[0].Kind = %v, want WarnUnknownField", body, warnings[0].Kind)
+			}
+			for _, field := range tt.fields {
+				if !strings.Contains(warnings[0].Message, field) {
+					t.Errorf("AnalyzeTemplate(%q)[0].Message = %q, want to contain field %q", body, warnings[0].Message, field)
+				}
+			}
+		})
+	}
+
+	listShaped := []string{"review_comments", "bot_review_comments"}
+	for _, key := range listShaped {
+		t.Run(key, func(t *testing.T) {
+			t.Parallel()
+
+			rangeBody := "{{ range ." + key + " }}{{ .body }}{{ end }}"
+			tmpl := mustParseAnalyze(t, rangeBody)
+			if warnings := AnalyzeTemplate(tmpl); len(warnings) != 0 {
+				t.Errorf("AnalyzeTemplate(%q) = %v, want no warnings", rangeBody, warnings)
+			}
+
+			subFieldBody := "{{ ." + key + ".body }}"
+			tmpl = mustParseAnalyze(t, subFieldBody)
+			warnings := AnalyzeTemplate(tmpl)
+			if len(warnings) != 1 {
+				t.Fatalf("AnalyzeTemplate(%q) returned %d warnings, want 1: %v", subFieldBody, len(warnings), warnings)
+			}
+			if warnings[0].Kind != WarnUnknownField {
+				t.Errorf("AnalyzeTemplate(%q)[0].Kind = %v, want WarnUnknownField", subFieldBody, warnings[0].Kind)
+			}
+		})
+	}
+}
+
+// TestTopLevelKeysMatchRendererSeededKeys anchors the recognized set on
+// what Template.Render actually seeds, rather than on the same two
+// literals the analyzer derives topLevelKeys from. It renders a template
+// that enumerates the data map with no RenderOption applied and compares
+// the resulting key set against topLevelKeys in both directions.
+func TestTopLevelKeysMatchRendererSeededKeys(t *testing.T) {
+	t.Parallel()
+
+	const sep = "\x00"
+	tmpl := mustParseAnalyze(t, "{{ range $k, $v := . }}{{ $k }}"+sep+"{{ end }}")
+
+	rendered, err := tmpl.Render(map[string]any{}, nil, RunContext{})
+	if err != nil {
+		t.Fatalf("Template.Render: %v", err)
+	}
+
+	seeded := make(map[string]struct{})
+	for k := range strings.SplitSeq(rendered, sep) {
+		if k == "" {
+			continue
+		}
+		seeded[k] = struct{}{}
+	}
+
+	for k := range seeded {
+		if _, ok := topLevelKeys[k]; !ok {
+			t.Errorf("Template.Render seeds top-level key %q, which topLevelKeys does not recognize", k)
+		}
+	}
+	for k := range topLevelKeys {
+		if _, ok := seeded[k]; !ok {
+			t.Errorf("topLevelKeys recognizes %q, but Template.Render does not seed it", k)
 		}
 	}
 }


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Fix

**Intent:** The prompt renderer reserves six top-level template variables for reaction continuation context (`ci_failure`, `review_comments`, `bot_review_comments`, `merge_conflict`, `label_review`, `label_fix`), but the template static analyzer behind `sortie validate` recognized only one of them (`ci_failure`). Its recognized-name list was a hand-maintained literal that drifted from the renderer's own `continuationKeys` as new keys were added, so any workflow referencing one of the five missing variables drew a spurious `unknown template variable` warning even though the renderer seeds it. This derives the analyzer's recognized set from the renderer's list instead of a second literal, so `sortie validate` stops reporting `unknown template variable` for valid reaction-context references, and adds regression coverage that fails if the two lists drift again.

**Related Issues:** Fixes #696

### 🧭 Reviewer Guide

**Complexity:** Medium

#### Entry Point

`internal/prompt/analyze.go` is where the fix lives. `topLevelKeys` and the `unknown_var` advisory message are now derived from `coreKeys` (`issue`, `attempt`, `run`) plus `prompt.continuationKeys`, instead of a separate literal set. `templateFieldSchema` also gains sub-field entries for `merge_conflict`, `label_review`, and `label_fix` (`review_comments` and `bot_review_comments` are registered with a nil sub-field set, since they are lists addressed via `{{ range }}`, where the analyzer does not validate field names).

#### Sensitive Areas

- `internal/prompt/analyze.go`: the `unknown_var` warning message text changed from enumerating three names (`.issue, .attempt, .run`) to all nine recognized names - any tooling that parses that message verbatim should be checked.
- `cmd/sortie/sample_workflow_test.go`: adds a test asserting every shipped `WORKFLOW*.md` produces zero analyzer warnings, which will now fail if a future example introduces a genuine template typo.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes.
- **Migrations/State:** No migrations or state changes.

