### PR TITLE
feat(scm/gitlab): add read-side tracker adapter operations

### DIFF
--- a/cmd/sortie/main.go
+++ b/cmd/sortie/main.go
@@ -49,6 +49,7 @@ import (
 	_ "github.com/sortie-ai/sortie/internal/notify/webhook"
 	_ "github.com/sortie-ai/sortie/internal/scm/gitea"
 	_ "github.com/sortie-ai/sortie/internal/scm/github"
+	_ "github.com/sortie-ai/sortie/internal/scm/gitlab"
 	_ "github.com/sortie-ai/sortie/internal/tracker/file"
 	_ "github.com/sortie-ai/sortie/internal/tracker/jira"
 	_ "github.com/sortie-ai/sortie/internal/tracker/linear"

--- a/internal/registry/adapter_meta_test.go
+++ b/internal/registry/adapter_meta_test.go
@@ -12,6 +12,7 @@ import (
 	_ "github.com/sortie-ai/sortie/internal/agent/opencode"
 	_ "github.com/sortie-ai/sortie/internal/scm/gitea"
 	_ "github.com/sortie-ai/sortie/internal/scm/github"
+	_ "github.com/sortie-ai/sortie/internal/scm/gitlab"
 	_ "github.com/sortie-ai/sortie/internal/tracker/file"
 	_ "github.com/sortie-ai/sortie/internal/tracker/jira"
 	_ "github.com/sortie-ai/sortie/internal/tracker/linear"
@@ -49,6 +50,14 @@ func TestAdapterMeta_RealRegistrations(t *testing.T) {
 			{
 				name:         "gitea requires api_key and project and declares both state lists",
 				kind:         "gitea",
+				wantAPIKey:   true,
+				wantProject:  true,
+				wantActive:   []string{"backlog", "in-progress", "review"},
+				wantTerminal: []string{"done", "wontfix"},
+			},
+			{
+				name:         "gitlab requires api_key and project and declares both state lists",
+				kind:         "gitlab",
 				wantAPIKey:   true,
 				wantProject:  true,
 				wantActive:   []string{"backlog", "in-progress", "review"},

--- a/internal/scm/gitlab/client.go
+++ b/internal/scm/gitlab/client.go
@@ -1,0 +1,172 @@
+package gitlab
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/sortie-ai/sortie/internal/domain"
+	"github.com/sortie-ai/sortie/internal/httpkit"
+)
+
+// newGitLabClient builds an [httpkit.Client] for the GitLab REST API v4.
+// baseURL is the instance base URL already suffixed with /api/v4; the
+// token travels only in the PRIVATE-TOKEN header, never as a query
+// parameter.
+func newGitLabClient(baseURL, token, userAgent string) *httpkit.Client {
+	trimmedBaseURL := strings.TrimRight(baseURL, "/")
+
+	return httpkit.NewClient(httpkit.ClientOptions{
+		BaseURL: trimmedBaseURL,
+		Timeout: 30 * time.Second,
+		Authorize: func(req *http.Request) {
+			req.Header.Set("PRIVATE-TOKEN", token)
+			req.Header.Set("Accept", "application/json")
+			req.Header.Set("User-Agent", userAgent)
+		},
+		ClassifyError:     classifyHTTPError,
+		ClassifyTransport: classifyTransportError,
+	})
+}
+
+const maxErrorBody = 512
+
+// classifyHTTPError maps a non-2xx GitLab response to a
+// [*domain.TrackerError]. The message carries a bounded body snippet and
+// the request method and path, never the token, which this adapter sends
+// only in the PRIVATE-TOKEN header.
+func classifyHTTPError(resp *http.Response, method, path string) error {
+	snippet, _ := io.ReadAll(io.LimitReader(resp.Body, maxErrorBody))
+	_, _ = io.Copy(io.Discard, resp.Body)
+	detail := errorDetail(snippet)
+
+	switch {
+	case resp.StatusCode == http.StatusBadRequest:
+		return &domain.TrackerError{
+			Kind:    domain.ErrTrackerPayload,
+			Message: fmt.Sprintf("%s %s: bad request: %s", method, path, detail),
+		}
+
+	case resp.StatusCode == http.StatusUnauthorized:
+		return &domain.TrackerError{
+			Kind:    domain.ErrTrackerAuth,
+			Message: fmt.Sprintf("%s %s: invalid credentials: %s", method, path, detail),
+		}
+
+	case resp.StatusCode == http.StatusForbidden:
+		return &domain.TrackerError{
+			Kind:    domain.ErrTrackerAuth,
+			Message: fmt.Sprintf("%s %s: insufficient permissions: %s", method, path, detail),
+		}
+
+	case resp.StatusCode == http.StatusNotFound:
+		return &domain.TrackerError{
+			Kind:    domain.ErrTrackerNotFound,
+			Message: fmt.Sprintf("%s %s: not found: %s", method, path, detail),
+		}
+
+	case resp.StatusCode == http.StatusConflict:
+		return &domain.TrackerError{
+			Kind:    domain.ErrTrackerAPI,
+			Message: fmt.Sprintf("%s %s: conflict: %s", method, path, detail),
+		}
+
+	case resp.StatusCode == http.StatusRequestURITooLong:
+		return &domain.TrackerError{
+			Kind:    domain.ErrTrackerPayload,
+			Message: fmt.Sprintf("%s %s: request uri too large: %s", method, path, detail),
+		}
+
+	case resp.StatusCode == http.StatusUnprocessableEntity:
+		return &domain.TrackerError{
+			Kind:    domain.ErrTrackerPayload,
+			Message: fmt.Sprintf("%s %s: unprocessable entity: %s", method, path, detail),
+		}
+
+	case resp.StatusCode == http.StatusTooManyRequests:
+		// GitLab does not sleep on 429 itself; the orchestrator owns retry
+		// backoff through TrackerErrorKind.RetryClassification.
+		if retryAfter := resp.Header.Get("Retry-After"); retryAfter != "" {
+			slog.Default().Warn("rate limited", slog.String("retry_after", retryAfter))
+		}
+		return &domain.TrackerError{
+			Kind:    domain.ErrTrackerAPI,
+			Message: fmt.Sprintf("%s %s: rate limited: %s", method, path, detail),
+		}
+
+	case resp.StatusCode >= 500:
+		return &domain.TrackerError{
+			Kind:    domain.ErrTrackerTransport,
+			Message: fmt.Sprintf("%s %s: server error %d: %s", method, path, resp.StatusCode, detail),
+		}
+
+	default:
+		return &domain.TrackerError{
+			Kind:    domain.ErrTrackerAPI,
+			Message: fmt.Sprintf("%s %s: unexpected status %d: %s", method, path, resp.StatusCode, detail),
+		}
+	}
+}
+
+// classifyTransportError maps a transport or body-read failure to a
+// [*domain.TrackerError] of kind [domain.ErrTrackerTransport], preserving
+// the underlying error for the chain.
+func classifyTransportError(err error, method, path string) error {
+	return &domain.TrackerError{
+		Kind:    domain.ErrTrackerTransport,
+		Message: fmt.Sprintf("%s %s: transport error", method, path),
+		Err:     err,
+	}
+}
+
+// errorDetail extracts a diagnostic message from a bounded GitLab
+// error-body snippet, covering all four observed envelope shapes: a
+// string message, a non-string message, a bare error, and an error paired
+// with an error_description. It falls back to the raw snippet when the
+// body does not decode as JSON at all, because a 429 or 502 body may not
+// be JSON.
+func errorDetail(snippet []byte) string {
+	var body gitlabErrorBody
+	if err := json.Unmarshal(snippet, &body); err != nil {
+		return string(snippet)
+	}
+
+	base := ""
+	if len(body.Message) > 0 {
+		var text string
+		if err := json.Unmarshal(body.Message, &text); err == nil && text != "" {
+			base = text
+		} else {
+			base = compactJSON(body.Message)
+		}
+	}
+	if base == "" && body.Error != "" {
+		base = body.Error
+	}
+	if body.ErrorDescription != "" {
+		if base == "" {
+			base = body.ErrorDescription
+		} else {
+			base += ": " + body.ErrorDescription
+		}
+	}
+	if base == "" {
+		base = string(snippet)
+	}
+	return base
+}
+
+// compactJSON returns raw with insignificant whitespace removed, or the
+// raw bytes unchanged when they are not syntactically valid JSON.
+func compactJSON(raw json.RawMessage) string {
+	var buf bytes.Buffer
+	if err := json.Compact(&buf, raw); err != nil {
+		return string(raw)
+	}
+	return buf.String()
+}

--- a/internal/scm/gitlab/client_test.go
+++ b/internal/scm/gitlab/client_test.go
@@ -1,0 +1,226 @@
+package gitlab
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/sortie-ai/sortie/internal/domain"
+)
+
+func TestNewGitLabClient(t *testing.T) {
+	t.Parallel()
+
+	t.Run("sends PRIVATE-TOKEN, accept, and user-agent, never a query parameter", func(t *testing.T) {
+		t.Parallel()
+
+		var gotHeaders http.Header
+		var gotPath string
+		var gotRawQuery string
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotHeaders = r.Header.Clone()
+			gotPath = r.URL.Path
+			gotRawQuery = r.URL.RawQuery
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{}`)) //nolint:errcheck // test helper
+		}))
+		defer srv.Close()
+
+		client := newGitLabClient(srv.URL+"/api/v4", "secret-token", "sortie/test")
+		_, _, err := client.Get(context.Background(), "/projects/1", nil)
+		if err != nil {
+			t.Fatalf("Get: %v", err)
+		}
+
+		if got := gotHeaders.Get("PRIVATE-TOKEN"); got != "secret-token" {
+			t.Errorf("PRIVATE-TOKEN = %q, want %q", got, "secret-token")
+		}
+		if got := gotHeaders.Get("Accept"); got != "application/json" {
+			t.Errorf("Accept = %q, want %q", got, "application/json")
+		}
+		if got := gotHeaders.Get("User-Agent"); got != "sortie/test" {
+			t.Errorf("User-Agent = %q, want %q", got, "sortie/test")
+		}
+		if gotPath != "/api/v4/projects/1" {
+			t.Errorf("path = %q, want %q", gotPath, "/api/v4/projects/1")
+		}
+		if gotRawQuery != "" {
+			t.Errorf("raw query = %q, want empty (the token must never travel as a query parameter)", gotRawQuery)
+		}
+	})
+
+	t.Run("trims a trailing slash from baseURL", func(t *testing.T) {
+		t.Parallel()
+
+		var gotPath string
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotPath = r.URL.Path
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{}`)) //nolint:errcheck // test helper
+		}))
+		defer srv.Close()
+
+		client := newGitLabClient(srv.URL+"/api/v4/", "secret-token", "sortie/test")
+		_, _, err := client.Get(context.Background(), "/projects/1", nil)
+		if err != nil {
+			t.Fatalf("Get: %v", err)
+		}
+		if gotPath != "/api/v4/projects/1" {
+			t.Errorf("path = %q, want %q (no doubled slash)", gotPath, "/api/v4/projects/1")
+		}
+	})
+}
+
+func TestClassifyHTTPError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		status   int
+		fixture  string
+		headers  map[string]string
+		wantKind domain.TrackerErrorKind
+	}{
+		{"400 bad request, non-string message", http.StatusBadRequest, "error_400.json", nil, domain.ErrTrackerPayload},
+		{"401 unauthorized, string message", http.StatusUnauthorized, "error_401.json", nil, domain.ErrTrackerAuth},
+		{"403 forbidden, error plus error_description", http.StatusForbidden, "error_403.json", nil, domain.ErrTrackerAuth},
+		{"404 project not found", http.StatusNotFound, "error_404_project.json", nil, domain.ErrTrackerNotFound},
+		{"404 issue not found", http.StatusNotFound, "error_404_issue.json", nil, domain.ErrTrackerNotFound},
+		{"409 conflict", http.StatusConflict, "", nil, domain.ErrTrackerAPI},
+		{"414 request uri too long", http.StatusRequestURITooLong, "", nil, domain.ErrTrackerPayload},
+		{"422 unprocessable entity", http.StatusUnprocessableEntity, "", nil, domain.ErrTrackerPayload},
+		{"429 too many requests with Retry-After", http.StatusTooManyRequests, "", map[string]string{"Retry-After": "30"}, domain.ErrTrackerAPI},
+		{"500 server error, bare error shape", http.StatusInternalServerError, "error_500.json", nil, domain.ErrTrackerTransport},
+		{"502 bad gateway", http.StatusBadGateway, "", nil, domain.ErrTrackerTransport},
+		{"unexpected status", http.StatusTeapot, "", nil, domain.ErrTrackerAPI},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var body []byte
+			if tt.fixture != "" {
+				body = loadFixture(t, tt.fixture)
+			}
+			headers := make(http.Header)
+			for key, value := range tt.headers {
+				headers.Set(key, value)
+			}
+			resp := &http.Response{
+				StatusCode: tt.status,
+				Header:     headers,
+				Body:       io.NopCloser(bytes.NewReader(body)),
+			}
+			defer resp.Body.Close() //nolint:errcheck // NopCloser.Close always returns nil
+
+			err := classifyHTTPError(resp, http.MethodGet, "/projects/1/issues/1")
+			assertTrackerErrorKind(t, err, tt.wantKind)
+		})
+	}
+
+	t.Run("429 body is non-JSON and the message still carries the raw snippet", func(t *testing.T) {
+		t.Parallel()
+
+		resp := &http.Response{
+			StatusCode: http.StatusTooManyRequests,
+			Header:     http.Header{"Retry-After": {"30"}},
+			Body:       io.NopCloser(bytes.NewReader([]byte("Retry later"))),
+		}
+		defer resp.Body.Close() //nolint:errcheck // NopCloser.Close always returns nil
+
+		err := classifyHTTPError(resp, http.MethodGet, "/projects/1/issues")
+		assertTrackerErrorKind(t, err, domain.ErrTrackerAPI)
+
+		var te *domain.TrackerError
+		if !errors.As(err, &te) {
+			t.Fatalf("error type = %T, want *domain.TrackerError", err)
+		}
+		if !bytes.Contains([]byte(te.Message), []byte("Retry later")) {
+			t.Errorf("TrackerError.Message = %q, want it to contain the raw non-JSON snippet %q", te.Message, "Retry later")
+		}
+	})
+
+	t.Run("includes the decoded detail for diagnostics", func(t *testing.T) {
+		t.Parallel()
+
+		resp := &http.Response{
+			StatusCode: http.StatusForbidden,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(bytes.NewReader(loadFixture(t, "error_403.json"))),
+		}
+		defer resp.Body.Close() //nolint:errcheck // NopCloser.Close always returns nil
+
+		err := classifyHTTPError(resp, http.MethodGet, "/projects/1")
+		var te *domain.TrackerError
+		if !errors.As(err, &te) {
+			t.Fatalf("error type = %T, want *domain.TrackerError", err)
+		}
+		if !bytes.Contains([]byte(te.Message), []byte("insufficient_scope")) {
+			t.Errorf("TrackerError.Message = %q, want it to contain the decoded error body", te.Message)
+		}
+		if !bytes.Contains([]byte(te.Message), []byte("higher privileges")) {
+			t.Errorf("TrackerError.Message = %q, want it to contain the error_description", te.Message)
+		}
+	})
+
+	t.Run("never includes the request token", func(t *testing.T) {
+		t.Parallel()
+
+		resp := &http.Response{
+			StatusCode: http.StatusUnauthorized,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(bytes.NewReader(loadFixture(t, "error_401.json"))),
+		}
+		defer resp.Body.Close() //nolint:errcheck // NopCloser.Close always returns nil
+
+		err := classifyHTTPError(resp, http.MethodGet, "/projects/1")
+		if bytes.Contains([]byte(err.Error()), []byte("secret-token")) {
+			t.Errorf("classifyHTTPError error message unexpectedly contains a token-shaped value: %v", err)
+		}
+	})
+}
+
+func TestClassifyTransportError(t *testing.T) {
+	t.Parallel()
+
+	wrapped := errors.New("dial tcp: connection refused")
+	err := classifyTransportError(wrapped, http.MethodGet, "/projects/1")
+
+	assertTrackerErrorKind(t, err, domain.ErrTrackerTransport)
+	if !errors.Is(err, wrapped) {
+		t.Errorf("classifyTransportError(%v) chain missing wrapped error", wrapped)
+	}
+}
+
+func TestErrorDetail(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		snippet string
+		want    string
+	}{
+		{"string message", `{"message":"invalid state"}`, "invalid state"},
+		{"non-string message compacts to JSON", `{"message":["email is invalid","name is invalid"]}`, `["email is invalid","name is invalid"]`},
+		{"bare error", `{"error":"boom"}`, "boom"},
+		{"error with error_description", `{"error":"invalid_token","error_description":"token expired"}`, "invalid_token: token expired"},
+		{"non-JSON snippet falls back to the raw bytes", "not json at all", "not json at all"},
+		{"empty snippet", "", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := errorDetail([]byte(tt.snippet))
+			if got != tt.want {
+				t.Errorf("errorDetail(%q) = %q, want %q", tt.snippet, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/scm/gitlab/gitlab.go
+++ b/internal/scm/gitlab/gitlab.go
@@ -1,0 +1,629 @@
+// Package gitlab implements [domain.TrackerAdapter] for the GitLab REST API
+// v4. It talks to GitLab.com or a self-managed instance over the shared
+// HTTP transport with no third-party GitLab client library, normalizing
+// issue responses to domain types: IDs derived from the project-scoped iid
+// rather than the instance-global id, labels lowercased, priority always
+// nil (GitLab issues carry no priority field), parent always nil (GitLab
+// exposes no sub-issue relationship on this route), state derived from
+// labels against the configured active, terminal, and handoff lists, and
+// blocked_by always a non-nil empty slice (GitLab Community Edition has no
+// blocks relation type).
+//
+// The constructor runs a two-call preflight, an advisory token
+// introspection followed by an authoritative project check, that fails
+// construction on an unreachable project, so a misconfiguration surfaces
+// at startup rather than on the first poll. Registered under kind "gitlab"
+// via an init function.
+//
+// This package sits under the source-control adapter family, but this
+// stage implements only the tracker contract: the source-control and CI
+// roles the family's path implies are not implemented here.
+package gitlab
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/sortie-ai/sortie/internal/domain"
+	"github.com/sortie-ai/sortie/internal/httpkit"
+	"github.com/sortie-ai/sortie/internal/registry"
+	"github.com/sortie-ai/sortie/internal/trackermetrics"
+	"github.com/sortie-ai/sortie/internal/typeutil"
+)
+
+func init() {
+	registry.Trackers.RegisterWithMeta("gitlab", NewGitLabAdapter, registry.TrackerMeta{
+		RequiresProject:       true,
+		RequiresAPIKey:        true,
+		DefaultActiveStates:   defaultActiveStates,
+		DefaultTerminalStates: defaultTerminalStates,
+	})
+}
+
+// Compile-time interface satisfaction check.
+var _ domain.TrackerAdapter = (*GitLabAdapter)(nil)
+
+// maxPages is the upper bound on paginated fetches. At 100 items per page
+// this allows up to 20,000 results before the adapter stops and returns
+// what it has.
+const maxPages = 200
+
+// stateBatchSize is the number of distinct iids requested per iids[] batch
+// in the state-reconciliation routes. It is chosen to sit far below any
+// plausible front-end request-line limit rather than close to a measured
+// one.
+const stateBatchSize = 50
+
+// defaultActiveStates is applied when the config omits active_states.
+var defaultActiveStates = []string{"backlog", "in-progress", "review"}
+
+// defaultTerminalStates is applied when the config omits terminal_states.
+var defaultTerminalStates = []string{"done", "wontfix"}
+
+// GitLabAdapter implements [domain.TrackerAdapter] against the GitLab REST
+// API v4. All fields except metrics are set once at construction and never
+// mutated, so the adapter is safe for concurrent use.
+type GitLabAdapter struct {
+	client         *httpkit.Client
+	project        string
+	projectPath    string
+	activeStates   []string
+	terminalStates []string
+	handoffState   string
+	log            *slog.Logger
+	metrics        domain.Metrics
+}
+
+// NewGitLabAdapter creates a [GitLabAdapter] from adapter configuration and
+// runs a construction-time preflight against the instance.
+//
+// Required config keys: "api_key" (a GitLab access token) and "project" (a
+// numeric project ID or a namespace path such as "group/project").
+// Optional: "endpoint" (instance base URL, defaulting to
+// "https://gitlab.com"), "active_states", "terminal_states",
+// "handoff_state" (label names, lowercased), and "user_agent". A
+// non-empty "query_filter" is rejected, because this adapter does not
+// support it yet. A missing or malformed key, or a preflight failure
+// (invalid token or an unreachable project), returns a
+// [*domain.TrackerError] and blocks construction.
+func NewGitLabAdapter(config map[string]any) (domain.TrackerAdapter, error) {
+	apiKey, _ := config["api_key"].(string)
+	if apiKey == "" {
+		return nil, &domain.TrackerError{
+			Kind:    domain.ErrMissingTrackerAPIKey,
+			Message: "missing required config key: api_key",
+		}
+	}
+
+	projectRaw, _ := config["project"].(string)
+	project := strings.TrimSpace(projectRaw)
+	if project == "" {
+		return nil, &domain.TrackerError{
+			Kind:    domain.ErrMissingTrackerProject,
+			Message: "missing required config key: project",
+		}
+	}
+
+	queryFilterRaw, _ := config["query_filter"].(string)
+	if strings.TrimSpace(queryFilterRaw) != "" {
+		return nil, &domain.TrackerError{
+			Kind:    domain.ErrTrackerPayload,
+			Message: "gitlab: tracker.query_filter is not supported yet; remove the key or leave it empty",
+		}
+	}
+
+	endpointRaw, _ := config["endpoint"].(string)
+	endpoint := strings.TrimSpace(endpointRaw)
+	if endpoint == "" {
+		endpoint = "https://gitlab.com"
+	}
+	parsedEndpoint, err := url.Parse(endpoint)
+	if err != nil || (parsedEndpoint.Scheme != "http" && parsedEndpoint.Scheme != "https") || parsedEndpoint.Host == "" {
+		return nil, &domain.TrackerError{
+			Kind:    domain.ErrTrackerPayload,
+			Message: fmt.Sprintf("gitlab: tracker.endpoint %q is not a valid absolute http(s) url", endpoint),
+		}
+	}
+	baseURL := strings.TrimRight(endpoint, "/")
+	if !strings.HasSuffix(baseURL, "/api/v4") {
+		baseURL += "/api/v4"
+	}
+
+	activeRaw := typeutil.ExtractStringSlice(config["active_states"])
+	if len(activeRaw) == 0 {
+		activeRaw = defaultActiveStates
+	}
+	activeStates := make([]string, len(activeRaw))
+	for i, s := range activeRaw {
+		activeStates[i] = strings.ToLower(s)
+	}
+
+	terminalRaw := typeutil.ExtractStringSlice(config["terminal_states"])
+	if len(terminalRaw) == 0 {
+		terminalRaw = defaultTerminalStates
+	}
+	terminalStates := make([]string, len(terminalRaw))
+	for i, s := range terminalRaw {
+		terminalStates[i] = strings.ToLower(s)
+	}
+
+	handoffRaw, _ := config["handoff_state"].(string)
+	handoffState := strings.ToLower(strings.TrimSpace(handoffRaw))
+
+	userAgent, _ := config["user_agent"].(string)
+	if userAgent == "" {
+		userAgent = "sortie/dev"
+	}
+
+	projectPath := url.PathEscape(project)
+	client := newGitLabClient(baseURL, apiKey, userAgent)
+	log := slog.Default()
+
+	if err := runPreflight(context.Background(), client, projectPath, log); err != nil {
+		return nil, err
+	}
+
+	return &GitLabAdapter{
+		client:         client,
+		project:        project,
+		projectPath:    projectPath,
+		activeStates:   activeStates,
+		terminalStates: terminalStates,
+		handoffState:   handoffState,
+		log:            log,
+	}, nil
+}
+
+// SetMetrics configures the metrics recorder for tracker API call
+// instrumentation. When not called or called with nil, the adapter
+// operates without recording metrics. Safe to call before any adapter
+// operations. Not safe to call concurrently with adapter operations.
+func (a *GitLabAdapter) SetMetrics(m domain.Metrics) {
+	a.metrics = m
+}
+
+// paginateIssues fetches every page of an issue-array route through the
+// Link-header paginator and returns the accumulated raw issues. An absent
+// Link header, or a final page carrying no rel="next", is the normal end
+// of results, never a missing-cursor error, because GitLab exposes no
+// cursor the adapter carries itself.
+//
+// A decode failure returns [domain.ErrTrackerPayload].
+func (a *GitLabAdapter) paginateIssues(ctx context.Context, path string, params url.Values) ([]gitlabIssue, error) {
+	paginator := httpkit.NewLinkPaginator(a.client, path, params, func(body []byte) ([]gitlabIssue, error) {
+		var raw []gitlabIssue
+		if err := json.Unmarshal(body, &raw); err != nil {
+			return nil, &domain.TrackerError{
+				Kind:    domain.ErrTrackerPayload,
+				Message: "failed to parse issues response",
+				Err:     err,
+			}
+		}
+		return raw, nil
+	}, httpkit.PaginatorOptions{
+		MaxPages: maxPages,
+		OnLimitReached: func(limit int) {
+			a.log.Warn("pagination limit reached",
+				slog.Int("max_pages", limit),
+				slog.String("endpoint", path))
+		},
+	})
+
+	return paginator.All(ctx)
+}
+
+// paginateNotes fetches every page of a notes-array route through the
+// Link-header paginator and returns the accumulated raw notes. Unlike the
+// Gitea comments route, the GitLab notes route paginates and must be
+// routed through the paginator.
+//
+// A decode failure returns [domain.ErrTrackerPayload].
+func (a *GitLabAdapter) paginateNotes(ctx context.Context, path string, params url.Values) ([]gitlabNote, error) {
+	paginator := httpkit.NewLinkPaginator(a.client, path, params, func(body []byte) ([]gitlabNote, error) {
+		var raw []gitlabNote
+		if err := json.Unmarshal(body, &raw); err != nil {
+			return nil, &domain.TrackerError{
+				Kind:    domain.ErrTrackerPayload,
+				Message: "failed to parse notes response",
+				Err:     err,
+			}
+		}
+		return raw, nil
+	}, httpkit.PaginatorOptions{
+		MaxPages: maxPages,
+		OnLimitReached: func(limit int) {
+			a.log.Warn("pagination limit reached",
+				slog.Int("max_pages", limit),
+				slog.String("endpoint", path))
+		},
+	})
+
+	return paginator.All(ctx)
+}
+
+// parseIID parses raw as the shared identifier guard used identically by
+// the single-fetch, comment-fetch, and batch paths. It trims surrounding
+// whitespace, then accepts only a base-10, unsigned, non-fractional,
+// non-zero-padded positive integer; a bare "0" is rejected as well,
+// because no issue has iid 0. It issues no request; callers must check ok
+// before building a request path.
+func parseIID(raw string) (int, bool) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return 0, false
+	}
+	if trimmed[0] == '0' && len(trimmed) > 1 {
+		return 0, false
+	}
+	for _, r := range trimmed {
+		if r < '0' || r > '9' {
+			return 0, false
+		}
+	}
+
+	n, err := strconv.Atoi(trimmed)
+	if err != nil || n <= 0 {
+		return 0, false
+	}
+	return n, true
+}
+
+// listAndFilter paginates the issue-list route for the given native state
+// and returns issues whose derived state is in keep. Comments is nil on
+// every returned issue.
+//
+// State filtering stays client-side: the configured state labels are
+// never pushed into the labels query parameter, whose AND semantics and
+// lack of an OR filter make it unusable for correctness-critical
+// filtering.
+func (a *GitLabAdapter) listAndFilter(ctx context.Context, nativeState string, keep map[string]bool) ([]domain.Issue, error) {
+	path := "/projects/" + a.projectPath + "/issues"
+	params := url.Values{
+		"state":      {nativeState},
+		"issue_type": {"issue"},
+		"scope":      {"all"},
+		"per_page":   {"100"},
+		"order_by":   {"created_at"},
+		"sort":       {"asc"},
+	}
+
+	raw, err := a.paginateIssues(ctx, path, params)
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]domain.Issue, 0, len(raw))
+	for _, gi := range raw {
+		if gi.IssueType != "" && gi.IssueType != "issue" {
+			continue
+		}
+		issue := normalizeIssue(gi, a.project, a.activeStates, a.terminalStates, a.handoffState, a.log)
+		if !keep[issue.State] {
+			continue
+		}
+		issue.Comments = nil
+		out = append(out, issue)
+	}
+	return out, nil
+}
+
+// FetchCandidateIssues returns opened issues whose derived state is in the
+// configured active states, oldest-first as ordered by the server, with
+// Comments nil on every returned issue.
+func (a *GitLabAdapter) FetchCandidateIssues(ctx context.Context) ([]domain.Issue, error) {
+	issues := make([]domain.Issue, 0)
+	err := trackermetrics.Track(a.metrics, "fetch_candidates", func() error {
+		keep := make(map[string]bool, len(a.activeStates))
+		for _, s := range a.activeStates {
+			keep[s] = true
+		}
+
+		fetched, fetchErr := a.listAndFilter(ctx, "opened", keep)
+		if fetchErr != nil {
+			return fetchErr
+		}
+		issues = fetched
+		return nil
+	})
+	return issues, err
+}
+
+// FetchIssuesByStates returns issues whose derived state is in the
+// requested set. It returns an empty slice with no request when states is
+// empty.
+//
+// The requested states are partitioned by whether they are terminal: the
+// opened listing runs when any requested state is non-terminal, and the
+// closed listing runs when any requested state is terminal. Every opened
+// result precedes every closed result, and no merge sort is applied. This
+// method has no production caller; it exists to satisfy
+// [domain.TrackerAdapter].
+func (a *GitLabAdapter) FetchIssuesByStates(ctx context.Context, states []string) ([]domain.Issue, error) {
+	if len(states) == 0 {
+		return []domain.Issue{}, nil
+	}
+
+	requested := make(map[string]bool, len(states))
+	for _, s := range states {
+		requested[strings.ToLower(s)] = true
+	}
+
+	terminalSet := make(map[string]bool, len(a.terminalStates))
+	for _, s := range a.terminalStates {
+		terminalSet[s] = true
+	}
+
+	needOpened := false
+	needClosed := false
+	for s := range requested {
+		if terminalSet[s] {
+			needClosed = true
+		} else {
+			needOpened = true
+		}
+	}
+
+	issues := make([]domain.Issue, 0)
+	err := trackermetrics.Track(a.metrics, "fetch_by_states", func() error {
+		result := make([]domain.Issue, 0)
+
+		if needOpened {
+			opened, fetchErr := a.listAndFilter(ctx, "opened", requested)
+			if fetchErr != nil {
+				return fetchErr
+			}
+			result = append(result, opened...)
+		}
+
+		if needClosed {
+			closed, fetchErr := a.listAndFilter(ctx, "closed", requested)
+			if fetchErr != nil {
+				return fetchErr
+			}
+			result = append(result, closed...)
+		}
+
+		issues = result
+		return nil
+	})
+	return issues, err
+}
+
+// fetchComments returns comments for the issue identified by issueID,
+// which is guarded through [parseIID] before any request is issued. A
+// rejected issueID, or a 404 from the notes route, returns
+// [domain.ErrTrackerNotFound].
+func (a *GitLabAdapter) fetchComments(ctx context.Context, issueID string) ([]domain.Comment, error) {
+	n, ok := parseIID(issueID)
+	if !ok {
+		return nil, &domain.TrackerError{
+			Kind:    domain.ErrTrackerNotFound,
+			Message: fmt.Sprintf("issue not found: %s", issueID),
+		}
+	}
+
+	path := "/projects/" + a.projectPath + "/issues/" + strconv.Itoa(n) + "/notes"
+	params := url.Values{
+		"activity_filter": {"only_comments"},
+		"sort":            {"asc"},
+		"per_page":        {"100"},
+	}
+
+	raw, err := a.paginateNotes(ctx, path, params)
+	if err != nil {
+		return nil, err
+	}
+	return normalizeComments(raw), nil
+}
+
+// FetchIssueByID returns a fully populated issue including comments.
+// issueID is the issue iid as a decimal string, guarded through
+// [parseIID] before any request is issued. A rejected issueID, a missing
+// iid, or an entity whose issue_type is set and is not "issue" returns
+// [domain.ErrTrackerNotFound].
+//
+// Parent is always nil and BlockedBy a non-nil empty slice; no parent or
+// links request is issued.
+func (a *GitLabAdapter) FetchIssueByID(ctx context.Context, issueID string) (domain.Issue, error) {
+	var issue domain.Issue
+	err := trackermetrics.Track(a.metrics, "fetch_issue", func() error {
+		n, ok := parseIID(issueID)
+		if !ok {
+			return &domain.TrackerError{
+				Kind:    domain.ErrTrackerNotFound,
+				Message: fmt.Sprintf("issue not found: %s", issueID),
+			}
+		}
+		decimal := strconv.Itoa(n)
+
+		path := "/projects/" + a.projectPath + "/issues/" + decimal
+		body, _, getErr := a.client.Get(ctx, path, nil)
+		if getErr != nil {
+			if domain.IsNotFound(getErr) {
+				return &domain.TrackerError{
+					Kind:    domain.ErrTrackerNotFound,
+					Message: fmt.Sprintf("issue not found: %s", issueID),
+				}
+			}
+			return getErr
+		}
+
+		var gi gitlabIssue
+		if err := json.Unmarshal(body, &gi); err != nil {
+			return &domain.TrackerError{
+				Kind:    domain.ErrTrackerPayload,
+				Message: "failed to parse issue response",
+				Err:     err,
+			}
+		}
+		if gi.IssueType != "" && gi.IssueType != "issue" {
+			return &domain.TrackerError{
+				Kind:    domain.ErrTrackerNotFound,
+				Message: fmt.Sprintf("not an issue: %s", issueID),
+			}
+		}
+
+		fetched := normalizeIssue(gi, a.project, a.activeStates, a.terminalStates, a.handoffState, a.log)
+
+		comments, commentsErr := a.fetchComments(ctx, decimal)
+		if commentsErr != nil {
+			return commentsErr
+		}
+		fetched.Comments = comments
+
+		issue = fetched
+		return nil
+	})
+	return issue, err
+}
+
+// FetchIssueComments returns comments for the issue identified by
+// issueID, oldest-first with system notes excluded. It returns a non-nil
+// empty slice when the issue has none, and [domain.ErrTrackerNotFound]
+// when issueID fails the identifier guard or the issue does not exist.
+func (a *GitLabAdapter) FetchIssueComments(ctx context.Context, issueID string) ([]domain.Comment, error) {
+	comments := make([]domain.Comment, 0)
+	err := trackermetrics.Track(a.metrics, "fetch_comments", func() error {
+		fetched, fetchErr := a.fetchComments(ctx, issueID)
+		if fetchErr != nil {
+			return fetchErr
+		}
+		comments = fetched
+		return nil
+	})
+	return comments, err
+}
+
+// fetchStatesByIIDs returns the derived state for each requested iid
+// string, keyed by the requested value. It returns an empty non-nil map
+// with no request when requested is empty or when every value is empty or
+// unparseable.
+//
+// Distinct positive integers are batched into chunks of [stateBatchSize]
+// through the iids[] filter. A 404 on this route signals a lost project
+// and is returned rather than swallowed; an absent iid simply omits its
+// key from the result.
+func (a *GitLabAdapter) fetchStatesByIIDs(ctx context.Context, requested []string) (map[string]string, error) {
+	if len(requested) == 0 {
+		return map[string]string{}, nil
+	}
+
+	order := make([]int, 0, len(requested))
+	wanted := make(map[int][]string, len(requested))
+	for _, value := range requested {
+		n, ok := parseIID(value)
+		if !ok {
+			continue
+		}
+		if _, seen := wanted[n]; !seen {
+			order = append(order, n)
+		}
+		wanted[n] = append(wanted[n], value)
+	}
+	if len(order) == 0 {
+		return map[string]string{}, nil
+	}
+
+	states := make(map[string]string, len(requested))
+	for chunkStart := 0; chunkStart < len(order); chunkStart += stateBatchSize {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+
+		chunk := order[chunkStart:min(chunkStart+stateBatchSize, len(order))]
+
+		params := url.Values{
+			"state":    {"all"},
+			"scope":    {"all"},
+			"per_page": {"100"},
+		}
+		for _, n := range chunk {
+			params.Add("iids[]", strconv.Itoa(n))
+		}
+
+		raw, err := a.paginateIssues(ctx, "/projects/"+a.projectPath+"/issues", params)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, gi := range raw {
+			if gi.IssueType != "" && gi.IssueType != "issue" {
+				continue
+			}
+			keys, ok := wanted[gi.IID]
+			if !ok {
+				continue
+			}
+			derived := deriveState(gi.Labels, gi.State, a.activeStates, a.terminalStates, a.handoffState, strconv.Itoa(gi.IID), a.log)
+			for _, key := range keys {
+				states[key] = derived
+			}
+		}
+	}
+
+	return states, nil
+}
+
+// FetchIssueStatesByIDs returns the derived state for each requested iid,
+// keyed by the requested string. ID and Identifier are both the iid, so
+// this delegates to [GitLabAdapter.fetchStatesByIIDs].
+func (a *GitLabAdapter) FetchIssueStatesByIDs(ctx context.Context, issueIDs []string) (map[string]string, error) {
+	var states map[string]string
+	err := trackermetrics.Track(a.metrics, "fetch_states_by_ids", func() error {
+		fetched, fetchErr := a.fetchStatesByIIDs(ctx, issueIDs)
+		if fetchErr != nil {
+			return fetchErr
+		}
+		states = fetched
+		return nil
+	})
+	return states, err
+}
+
+// FetchIssueStatesByIdentifiers returns the derived state for each
+// requested iid, keyed by the requested string. ID and Identifier are
+// both the iid, so this delegates to [GitLabAdapter.fetchStatesByIIDs].
+func (a *GitLabAdapter) FetchIssueStatesByIdentifiers(ctx context.Context, identifiers []string) (map[string]string, error) {
+	var states map[string]string
+	err := trackermetrics.Track(a.metrics, "fetch_states_by_identifiers", func() error {
+		fetched, fetchErr := a.fetchStatesByIIDs(ctx, identifiers)
+		if fetchErr != nil {
+			return fetchErr
+		}
+		states = fetched
+		return nil
+	})
+	return states, err
+}
+
+// TransitionIssue returns [domain.ErrTrackerPayload] and issues no
+// request. The GitLab write path is not implemented yet.
+func (a *GitLabAdapter) TransitionIssue(_ context.Context, _, _ string) error {
+	return &domain.TrackerError{
+		Kind:    domain.ErrTrackerPayload,
+		Message: "gitlab: write path is not implemented yet",
+	}
+}
+
+// CommentIssue returns [domain.ErrTrackerPayload] and issues no request.
+// The GitLab write path is not implemented yet.
+func (a *GitLabAdapter) CommentIssue(_ context.Context, _, _ string) error {
+	return &domain.TrackerError{
+		Kind:    domain.ErrTrackerPayload,
+		Message: "gitlab: write path is not implemented yet",
+	}
+}
+
+// AddLabel returns [domain.ErrTrackerPayload] and issues no request. The
+// GitLab write path is not implemented yet.
+func (a *GitLabAdapter) AddLabel(_ context.Context, _, _ string) error {
+	return &domain.TrackerError{
+		Kind:    domain.ErrTrackerPayload,
+		Message: "gitlab: write path is not implemented yet",
+	}
+}

--- a/internal/scm/gitlab/gitlab_test.go
+++ b/internal/scm/gitlab/gitlab_test.go
@@ -1,0 +1,1406 @@
+package gitlab
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"maps"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"slices"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/sortie-ai/sortie/internal/domain"
+	"github.com/sortie-ai/sortie/internal/registry"
+)
+
+const testProject = "acme/widgets"
+
+var testEscapedProject = url.PathEscape(testProject)
+
+func loadFixture(t *testing.T, name string) []byte {
+	t.Helper()
+	data, err := os.ReadFile("testdata/" + name)
+	if err != nil {
+		t.Fatalf("reading fixture %s: %v", name, err)
+	}
+	return data
+}
+
+func validConfig(project string) map[string]any {
+	return map[string]any{
+		"api_key": "test-token",
+		"project": project,
+	}
+}
+
+func assertTrackerErrorKind(t *testing.T, err error, want domain.TrackerErrorKind) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("expected error with kind %q, got nil", want)
+	}
+	var te *domain.TrackerError
+	if !errors.As(err, &te) {
+		t.Fatalf("error type = %T, want *domain.TrackerError", err)
+	}
+	if te.Kind != want {
+		t.Errorf("TrackerError.Kind = %q, want %q", te.Kind, want)
+	}
+}
+
+// assertQueryParams asserts got holds exactly the key/value pairs in want,
+// with no extra or missing keys, so a single call proves both that the
+// expected params merged in and that no unexpected param leaked in. label
+// identifies the request in a failure message.
+func assertQueryParams(t *testing.T, label string, got url.Values, want map[string]string) {
+	t.Helper()
+	wantValues := make(url.Values, len(want))
+	for key, val := range want {
+		wantValues[key] = []string{val}
+	}
+	if !maps.EqualFunc(got, wantValues, slices.Equal) {
+		t.Errorf("%s request query = %v, want exactly %v", label, got, wantValues)
+	}
+}
+
+// fakeServer is a minimal exact-match HTTP router keyed on method and the
+// escaped request path. A percent-encoded project segment (%2F) decodes to
+// a literal slash in [http.Request.URL.Path], which defeats [http.ServeMux]
+// pattern matching on a route containing a multi-segment project ID;
+// matching on [url.URL.EscapedPath] instead preserves the encoding exactly
+// as GitLab requires it. Any request with no matching route fails the test
+// loudly instead of receiving a silent 404, so a stray or unexpected call
+// (a write stub issuing a request, a second page beyond what a test
+// expects) is caught.
+type fakeServer struct {
+	t      *testing.T
+	routes map[string]http.HandlerFunc
+}
+
+func newFakeServer(t *testing.T) *fakeServer {
+	t.Helper()
+	return &fakeServer{t: t, routes: make(map[string]http.HandlerFunc)}
+}
+
+// handle registers fn for a GET request against escapedPath. Every route
+// this suite exercises is a GET; a non-GET request (a write stub issuing a
+// request it must not issue) falls through to ServeHTTP's unmatched-route
+// failure regardless.
+func (s *fakeServer) handle(escapedPath string, fn http.HandlerFunc) {
+	s.routes[http.MethodGet+" "+escapedPath] = fn
+}
+
+func (s *fakeServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	key := r.Method + " " + r.URL.EscapedPath()
+	if fn, ok := s.routes[key]; ok {
+		fn(w, r)
+		return
+	}
+	s.t.Errorf("unexpected request: %s", key)
+	w.WriteHeader(http.StatusNotFound)
+}
+
+// withPreflight registers the two construction-preflight routes for
+// project on s. Every test that constructs an adapter must install both
+// before the operation under test, because [NewGitLabAdapter] runs the
+// preflight synchronously.
+func withPreflight(t *testing.T, s *fakeServer, project string) {
+	t.Helper()
+	escaped := url.PathEscape(project)
+	s.handle("/api/v4/personal_access_tokens/self", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write(loadFixture(t, "token_self.json")) //nolint:errcheck // test helper
+	})
+	s.handle("/api/v4/projects/"+escaped, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{}`)) //nolint:errcheck // test helper
+	})
+}
+
+// newPreflightServer returns a [fakeServer] pre-registered with the two
+// construction-preflight routes for [testProject]. Callers register only
+// the routes their operation under test exercises.
+func newPreflightServer(t *testing.T) *fakeServer {
+	t.Helper()
+	s := newFakeServer(t)
+	withPreflight(t, s, testProject)
+	return s
+}
+
+// mustAdapter starts an httptest.Server for s and constructs a
+// [*GitLabAdapter] against it for [testProject], registering server
+// cleanup. s must already carry the two construction-preflight routes; see
+// [newPreflightServer].
+func mustAdapter(t *testing.T, s *fakeServer) *GitLabAdapter {
+	t.Helper()
+	srv := httptest.NewServer(s)
+	t.Cleanup(srv.Close)
+
+	cfg := validConfig(testProject)
+	cfg["endpoint"] = srv.URL
+	a, err := NewGitLabAdapter(cfg)
+	if err != nil {
+		t.Fatalf("NewGitLabAdapter: %v", err)
+	}
+	return a.(*GitLabAdapter)
+}
+
+// loweredStates returns a lowercased copy of states, matching the
+// normalization NewGitLabAdapter applies to every state list element.
+func loweredStates(states []string) []string {
+	out := make([]string, len(states))
+	for i, s := range states {
+		out[i] = strings.ToLower(s)
+	}
+	return out
+}
+
+// --- parseIID ---
+
+func TestParseIID(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		raw    string
+		want   int
+		wantOK bool
+	}{
+		{"simple positive", "42", 42, true},
+		{"leading and trailing whitespace trimmed", "  7  ", 7, true},
+		{"large value accepted", "999999", 999999, true},
+		{"zero rejected", "0", 0, false},
+		{"zero-padded rejected", "007", 0, false},
+		{"negative rejected", "-1", 0, false},
+		{"fractional rejected", "1.5", 0, false},
+		{"non-numeric rejected", "abc", 0, false},
+		{"whitespace-only rejected", " ", 0, false},
+		{"empty rejected", "", 0, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, ok := parseIID(tt.raw)
+			if ok != tt.wantOK {
+				t.Fatalf("parseIID(%q) ok = %v, want %v", tt.raw, ok, tt.wantOK)
+			}
+			if ok && got != tt.want {
+				t.Errorf("parseIID(%q) = %d, want %d", tt.raw, got, tt.want)
+			}
+		})
+	}
+}
+
+// --- Constructor ---
+
+func TestNewGitLabAdapter(t *testing.T) {
+	t.Parallel()
+
+	t.Run("config errors fail before any network call", func(t *testing.T) {
+		t.Parallel()
+
+		// endpoint points at a refused local port so an incorrect
+		// reordering of the validation checks in NewGitLabAdapter would
+		// fail this test with a network error instead of silently passing.
+		const unreachable = "http://127.0.0.1:1"
+
+		tests := []struct {
+			name     string
+			config   map[string]any
+			wantKind domain.TrackerErrorKind
+		}{
+			{"missing api_key", map[string]any{"project": testProject, "endpoint": unreachable}, domain.ErrMissingTrackerAPIKey},
+			{"empty api_key", map[string]any{"api_key": "", "project": testProject, "endpoint": unreachable}, domain.ErrMissingTrackerAPIKey},
+			{"missing project", map[string]any{"api_key": "tok", "endpoint": unreachable}, domain.ErrMissingTrackerProject},
+			{"empty project", map[string]any{"api_key": "tok", "project": "", "endpoint": unreachable}, domain.ErrMissingTrackerProject},
+			{"non-empty query_filter rejected", map[string]any{"api_key": "tok", "project": testProject, "query_filter": "scope=assigned_to_me", "endpoint": unreachable}, domain.ErrTrackerPayload},
+			{"malformed endpoint scheme", map[string]any{"api_key": "tok", "project": testProject, "endpoint": "ftp://example.com"}, domain.ErrTrackerPayload},
+			{"malformed endpoint no host", map[string]any{"api_key": "tok", "project": testProject, "endpoint": "http://"}, domain.ErrTrackerPayload},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+
+				a, err := NewGitLabAdapter(tt.config)
+				assertTrackerErrorKind(t, err, tt.wantKind)
+				if a != nil {
+					t.Error("adapter should be nil on error")
+				}
+			})
+		}
+	})
+
+	// validConfig omits both state keys, so the constructed adapter holds
+	// the fallback lists. They must stay the ones the registration
+	// declares, because the dispatch preflight rules on the declared lists.
+	t.Run("successful construction applies default state lists", func(t *testing.T) {
+		t.Parallel()
+
+		meta, ok := registry.Trackers.Meta("gitlab")
+		if !ok {
+			t.Fatal(`Trackers.Meta("gitlab") reported not registered`)
+		}
+		if len(meta.DefaultActiveStates) == 0 || len(meta.DefaultTerminalStates) == 0 {
+			t.Fatalf("Trackers.Meta(%q) declares DefaultActiveStates = %v, DefaultTerminalStates = %v, want both non-empty",
+				"gitlab", meta.DefaultActiveStates, meta.DefaultTerminalStates)
+		}
+		if !meta.RequiresProject || !meta.RequiresAPIKey {
+			t.Errorf("Trackers.Meta(%q) RequiresProject = %v, RequiresAPIKey = %v, want both true", "gitlab", meta.RequiresProject, meta.RequiresAPIKey)
+		}
+
+		a := mustAdapter(t, newPreflightServer(t))
+
+		if a.project != testProject {
+			t.Errorf("project = %q, want %q", a.project, testProject)
+		}
+		if a.projectPath != testEscapedProject {
+			t.Errorf("projectPath = %q, want %q", a.projectPath, testEscapedProject)
+		}
+		if want := loweredStates(meta.DefaultActiveStates); !slices.Equal(a.activeStates, want) {
+			t.Errorf("activeStates = %v, want %v", a.activeStates, want)
+		}
+		if want := loweredStates(meta.DefaultTerminalStates); !slices.Equal(a.terminalStates, want) {
+			t.Errorf("terminalStates = %v, want %v", a.terminalStates, want)
+		}
+		if a.handoffState != "" {
+			t.Errorf("handoffState = %q, want empty", a.handoffState)
+		}
+	})
+
+	t.Run("empty query_filter constructs normally", func(t *testing.T) {
+		t.Parallel()
+
+		s := newPreflightServer(t)
+		srv := httptest.NewServer(s)
+		defer srv.Close()
+
+		cfg := validConfig(testProject)
+		cfg["endpoint"] = srv.URL
+		cfg["query_filter"] = ""
+
+		a, err := NewGitLabAdapter(cfg)
+		if err != nil {
+			t.Fatalf("NewGitLabAdapter(query_filter=\"\"): %v", err)
+		}
+		if a == nil {
+			t.Fatal("adapter is nil, want a constructed adapter")
+		}
+	})
+
+	t.Run("api/v4 suffix is appended exactly once regardless of source form", func(t *testing.T) {
+		t.Parallel()
+
+		tests := []struct {
+			name  string
+			build func(base string) string
+		}{
+			{"bare host", func(base string) string { return base }},
+			{"trailing slash", func(base string) string { return base + "/" }},
+			{"already suffixed", func(base string) string { return base + "/api/v4" }},
+			{"already suffixed with trailing slash", func(base string) string { return base + "/api/v4/" }},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+
+				s := newPreflightServer(t)
+				srv := httptest.NewServer(s)
+				defer srv.Close()
+
+				cfg := validConfig(testProject)
+				cfg["endpoint"] = tt.build(srv.URL)
+				if _, err := NewGitLabAdapter(cfg); err != nil {
+					t.Fatalf("NewGitLabAdapter(endpoint=%q): %v", cfg["endpoint"], err)
+				}
+			})
+		}
+	})
+
+	t.Run("custom state lists are lowercased and handoff_state is trimmed", func(t *testing.T) {
+		t.Parallel()
+
+		s := newPreflightServer(t)
+		srv := httptest.NewServer(s)
+		defer srv.Close()
+
+		cfg := validConfig(testProject)
+		cfg["endpoint"] = srv.URL
+		cfg["active_states"] = []any{"Todo", "IN-PROGRESS"}
+		cfg["terminal_states"] = []string{"Done", "WONTFIX"}
+		cfg["handoff_state"] = "  Review  "
+
+		a, err := NewGitLabAdapter(cfg)
+		if err != nil {
+			t.Fatalf("NewGitLabAdapter: %v", err)
+		}
+		ga := a.(*GitLabAdapter)
+
+		if ga.activeStates[0] != "todo" || ga.activeStates[1] != "in-progress" {
+			t.Errorf("activeStates = %v, want [todo in-progress]", ga.activeStates)
+		}
+		if ga.terminalStates[0] != "done" || ga.terminalStates[1] != "wontfix" {
+			t.Errorf("terminalStates = %v, want [done wontfix]", ga.terminalStates)
+		}
+		if ga.handoffState != "review" {
+			t.Errorf("handoffState = %q, want %q (trimmed and lowercased)", ga.handoffState, "review")
+		}
+	})
+
+	t.Run("does not mutate caller-supplied state slices", func(t *testing.T) {
+		t.Parallel()
+
+		s := newPreflightServer(t)
+		srv := httptest.NewServer(s)
+		defer srv.Close()
+
+		cfg := validConfig(testProject)
+		cfg["endpoint"] = srv.URL
+		cfg["active_states"] = []string{"InProgress", "Review"}
+		cfg["terminal_states"] = []string{"Done", "WontFix"}
+
+		if _, err := NewGitLabAdapter(cfg); err != nil {
+			t.Fatalf("NewGitLabAdapter: %v", err)
+		}
+
+		active := cfg["active_states"].([]string)
+		if active[0] != "InProgress" || active[1] != "Review" {
+			t.Errorf("active_states mutated: got %v, want original casing preserved", active)
+		}
+		terminal := cfg["terminal_states"].([]string)
+		if terminal[0] != "Done" || terminal[1] != "WontFix" {
+			t.Errorf("terminal_states mutated: got %v, want original casing preserved", terminal)
+		}
+	})
+
+	t.Run("preflight failure blocks construction", func(t *testing.T) {
+		t.Parallel()
+
+		s := newFakeServer(t)
+		s.handle("/api/v4/personal_access_tokens/self", func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			w.Write(loadFixture(t, "token_self.json")) //nolint:errcheck // test helper
+		})
+		s.handle("/api/v4/projects/"+testEscapedProject, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+			w.Write(loadFixture(t, "error_401.json")) //nolint:errcheck // test helper
+		})
+		srv := httptest.NewServer(s)
+		defer srv.Close()
+
+		cfg := validConfig(testProject)
+		cfg["endpoint"] = srv.URL
+
+		a, err := NewGitLabAdapter(cfg)
+		assertTrackerErrorKind(t, err, domain.ErrTrackerAuth)
+		if a != nil {
+			t.Error("adapter should be nil when the preflight fails")
+		}
+	})
+}
+
+// --- Percent-encoded project path ---
+
+func TestProjectPathPercentEncoding(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nested subgroup produces two %2F and no bare slash in the project segment", func(t *testing.T) {
+		t.Parallel()
+
+		const nestedProject = "acme/subgroup/widgets"
+		escaped := url.PathEscape(nestedProject)
+
+		s := newFakeServer(t)
+		var gotPath string
+		s.handle("/api/v4/personal_access_tokens/self", func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			w.Write(loadFixture(t, "token_self.json")) //nolint:errcheck // test helper
+		})
+		s.handle("/api/v4/projects/"+escaped, func(w http.ResponseWriter, r *http.Request) {
+			gotPath = r.URL.EscapedPath()
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{}`)) //nolint:errcheck // test helper
+		})
+		srv := httptest.NewServer(s)
+		defer srv.Close()
+
+		cfg := validConfig(nestedProject)
+		cfg["endpoint"] = srv.URL
+		if _, err := NewGitLabAdapter(cfg); err != nil {
+			t.Fatalf("NewGitLabAdapter(project=%q): %v", nestedProject, err)
+		}
+
+		if gotPath == "" {
+			t.Fatal("project route was never called")
+		}
+		if got := strings.Count(gotPath, "%2F"); got != 2 {
+			t.Errorf("request path %q carries %d occurrences of %%2F, want 2", gotPath, got)
+		}
+		suffix := strings.TrimPrefix(gotPath, "/api/v4/projects/")
+		if strings.Contains(suffix, "/") {
+			t.Errorf("project segment %q contains a bare slash, want none (must stay percent-encoded)", suffix)
+		}
+	})
+
+	t.Run("single-segment project produces exactly one %2F", func(t *testing.T) {
+		t.Parallel()
+
+		a := mustAdapter(t, newPreflightServer(t))
+		if got := strings.Count(a.projectPath, "%2F"); got != 1 {
+			t.Errorf("projectPath = %q carries %d occurrences of %%2F, want 1", a.projectPath, got)
+		}
+	})
+
+	t.Run("numeric project ID requires no percent-encoding and still constructs", func(t *testing.T) {
+		t.Parallel()
+
+		const numericProject = "778899"
+
+		s := newFakeServer(t)
+		withPreflight(t, s, numericProject)
+		srv := httptest.NewServer(s)
+		defer srv.Close()
+
+		cfg := validConfig(numericProject)
+		cfg["endpoint"] = srv.URL
+		a, err := NewGitLabAdapter(cfg)
+		if err != nil {
+			t.Fatalf("NewGitLabAdapter(project=%q): %v", numericProject, err)
+		}
+		ga := a.(*GitLabAdapter)
+		if ga.projectPath != numericProject {
+			t.Errorf("projectPath = %q, want %q", ga.projectPath, numericProject)
+		}
+	})
+}
+
+// --- Registration ---
+
+func TestGitLabAdapterRegistration(t *testing.T) {
+	t.Parallel()
+
+	if !registry.Trackers.Has("gitlab") {
+		t.Fatal(`Trackers.Has("gitlab") = false, want true`)
+	}
+	if _, err := registry.Trackers.Get("gitlab"); err != nil {
+		t.Errorf(`Trackers.Get("gitlab") = %v, want registered constructor`, err)
+	}
+}
+
+// --- paginateIssues ---
+
+func TestPaginateIssues(t *testing.T) {
+	t.Parallel()
+
+	t.Run("follows Link headers across pages, ending on rel=first/rel=last with no rel=next", func(t *testing.T) {
+		t.Parallel()
+
+		page1 := loadFixture(t, "issues_paginate_page1.json") // 2 items
+		page2 := loadFixture(t, "issues_paginate_page2.json") // 2 items
+		page3 := loadFixture(t, "issues_paginate_page3.json") // 1 item
+
+		s := newPreflightServer(t)
+		var srvURL string
+		var calls atomic.Int32
+		basePath := "/api/v4/projects/" + testEscapedProject + "/issues"
+		s.handle(basePath, func(w http.ResponseWriter, r *http.Request) {
+			n := calls.Add(1)
+			first := fmt.Sprintf(`<%s%s?page=1>; rel="first"`, srvURL, basePath)
+			last := fmt.Sprintf(`<%s%s?page=3>; rel="last"`, srvURL, basePath)
+			switch n {
+			case 1:
+				next := fmt.Sprintf(`<%s%s?page=2>; rel="next"`, srvURL, basePath)
+				w.Header().Set("Link", strings.Join([]string{next, first, last}, ", "))
+				w.WriteHeader(http.StatusOK)
+				w.Write(page1) //nolint:errcheck // test helper
+			case 2:
+				next := fmt.Sprintf(`<%s%s?page=3>; rel="next"`, srvURL, basePath)
+				w.Header().Set("Link", strings.Join([]string{next, first, last}, ", "))
+				w.WriteHeader(http.StatusOK)
+				w.Write(page2) //nolint:errcheck // test helper
+			default:
+				w.Header().Set("Link", strings.Join([]string{first, last}, ", "))
+				w.WriteHeader(http.StatusOK)
+				w.Write(page3) //nolint:errcheck // test helper
+			}
+		})
+		srv := httptest.NewServer(s)
+		defer srv.Close()
+		srvURL = srv.URL
+
+		cfg := validConfig(testProject)
+		cfg["endpoint"] = srv.URL
+		a, err := NewGitLabAdapter(cfg)
+		if err != nil {
+			t.Fatalf("NewGitLabAdapter: %v", err)
+		}
+		ga := a.(*GitLabAdapter)
+
+		items, err := ga.paginateIssues(context.Background(), "/projects/"+testEscapedProject+"/issues", url.Values{"per_page": {"100"}})
+		if err != nil {
+			t.Fatalf("paginateIssues: %v", err)
+		}
+		if len(items) != 5 {
+			t.Fatalf("len = %d, want 5 across 3 pages", len(items))
+		}
+		if got := calls.Load(); got != 3 {
+			t.Errorf("call count = %d, want 3 (one per page)", got)
+		}
+	})
+
+	t.Run("single page with no Link header stops after one request", func(t *testing.T) {
+		t.Parallel()
+
+		var calls atomic.Int32
+		s := newPreflightServer(t)
+		s.handle("/api/v4/projects/"+testEscapedProject+"/issues", func(w http.ResponseWriter, r *http.Request) {
+			calls.Add(1)
+			w.WriteHeader(http.StatusOK)
+			w.Write(loadFixture(t, "issues_paginate_page3.json")) //nolint:errcheck // test helper
+		})
+		a := mustAdapter(t, s)
+
+		items, err := a.paginateIssues(context.Background(), "/projects/"+testEscapedProject+"/issues", url.Values{"per_page": {"100"}})
+		if err != nil {
+			t.Fatalf("paginateIssues: %v", err)
+		}
+		if len(items) != 1 {
+			t.Errorf("len = %d, want 1", len(items))
+		}
+		if got := calls.Load(); got != 1 {
+			t.Errorf("call count = %d, want 1 (no Link header means end of results)", got)
+		}
+	})
+
+	t.Run("decode failure returns ErrTrackerPayload", func(t *testing.T) {
+		t.Parallel()
+
+		s := newPreflightServer(t)
+		s.handle("/api/v4/projects/"+testEscapedProject+"/issues", func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`not json`)) //nolint:errcheck // test helper
+		})
+		a := mustAdapter(t, s)
+
+		_, err := a.paginateIssues(context.Background(), "/projects/"+testEscapedProject+"/issues", nil)
+		assertTrackerErrorKind(t, err, domain.ErrTrackerPayload)
+	})
+}
+
+// --- paginateNotes ---
+
+func TestPaginateNotes(t *testing.T) {
+	t.Parallel()
+
+	t.Run("follows Link headers across pages accumulating raw notes", func(t *testing.T) {
+		t.Parallel()
+
+		page1 := loadFixture(t, "notes_page1.json") // 2 notes
+		page2 := loadFixture(t, "notes_page2.json") // 2 notes, final
+
+		s := newPreflightServer(t)
+		var srvURL string
+		var calls atomic.Int32
+		basePath := "/api/v4/projects/" + testEscapedProject + "/issues/42/notes"
+		s.handle(basePath, func(w http.ResponseWriter, r *http.Request) {
+			n := calls.Add(1)
+			first := fmt.Sprintf(`<%s%s?page=1>; rel="first"`, srvURL, basePath)
+			last := fmt.Sprintf(`<%s%s?page=2>; rel="last"`, srvURL, basePath)
+			if n == 1 {
+				next := fmt.Sprintf(`<%s%s?page=2>; rel="next"`, srvURL, basePath)
+				w.Header().Set("Link", strings.Join([]string{next, first, last}, ", "))
+				w.WriteHeader(http.StatusOK)
+				w.Write(page1) //nolint:errcheck // test helper
+				return
+			}
+			w.Header().Set("Link", strings.Join([]string{first, last}, ", "))
+			w.WriteHeader(http.StatusOK)
+			w.Write(page2) //nolint:errcheck // test helper
+		})
+		srv := httptest.NewServer(s)
+		defer srv.Close()
+		srvURL = srv.URL
+
+		cfg := validConfig(testProject)
+		cfg["endpoint"] = srv.URL
+		a, err := NewGitLabAdapter(cfg)
+		if err != nil {
+			t.Fatalf("NewGitLabAdapter: %v", err)
+		}
+		ga := a.(*GitLabAdapter)
+
+		notes, err := ga.paginateNotes(context.Background(), "/projects/"+testEscapedProject+"/issues/42/notes", url.Values{"per_page": {"100"}})
+		if err != nil {
+			t.Fatalf("paginateNotes: %v", err)
+		}
+		if len(notes) != 4 {
+			t.Fatalf("len = %d, want 4 raw notes across 2 pages (before system-note filtering)", len(notes))
+		}
+		if got := calls.Load(); got != 2 {
+			t.Errorf("call count = %d, want 2 (one per page)", got)
+		}
+	})
+}
+
+// --- FetchCandidateIssues ---
+
+func TestFetchCandidateIssues(t *testing.T) {
+	t.Parallel()
+
+	t.Run("task filter, state derivation, terminal filter, and preserved order", func(t *testing.T) {
+		t.Parallel()
+
+		page1 := loadFixture(t, "issues_candidates_page1.json") // iid 8 (backlog), iid 6 (task, filtered)
+		page2 := loadFixture(t, "issues_candidates_page2.json") // iid 1,3,2,5,4,7
+
+		s := newPreflightServer(t)
+		var srvURL string
+		var calls atomic.Int32
+		basePath := "/api/v4/projects/" + testEscapedProject + "/issues"
+		s.handle(basePath, func(w http.ResponseWriter, r *http.Request) {
+			n := calls.Add(1)
+			if n == 1 {
+				assertQueryParams(t, "candidate", r.URL.Query(), map[string]string{
+					"state": "opened", "issue_type": "issue", "scope": "all",
+					"per_page": "100", "order_by": "created_at", "sort": "asc",
+				})
+				w.Header().Set("Link", fmt.Sprintf(`<%s%s?page=2>; rel="next", <%s%s?page=1>; rel="first", <%s%s?page=2>; rel="last"`, srvURL, basePath, srvURL, basePath, srvURL, basePath))
+				w.WriteHeader(http.StatusOK)
+				w.Write(page1) //nolint:errcheck // test helper
+				return
+			}
+			w.Header().Set("Link", fmt.Sprintf(`<%s%s?page=1>; rel="first", <%s%s?page=2>; rel="last"`, srvURL, basePath, srvURL, basePath))
+			w.WriteHeader(http.StatusOK)
+			w.Write(page2) //nolint:errcheck // test helper
+		})
+		srv := httptest.NewServer(s)
+		defer srv.Close()
+		srvURL = srv.URL
+
+		cfg := validConfig(testProject)
+		cfg["endpoint"] = srv.URL
+		a, err := NewGitLabAdapter(cfg)
+		if err != nil {
+			t.Fatalf("NewGitLabAdapter: %v", err)
+		}
+		ga := a.(*GitLabAdapter)
+
+		var buf bytes.Buffer
+		ga.log = slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+		issues, err := ga.FetchCandidateIssues(context.Background())
+		if err != nil {
+			t.Fatalf("FetchCandidateIssues: %v", err)
+		}
+
+		// iid 6 (task) is filtered before normalization; iid 3 and iid 4
+		// (both terminal, one from an explicit "done" label and one from
+		// the closed-native-state fallback) are filtered by the active-keep
+		// set; the remaining five are returned in server order.
+		wantOrder := []string{"8", "1", "2", "5", "7"}
+		if len(issues) != len(wantOrder) {
+			t.Fatalf("len = %d, want %d: got identifiers %v", len(issues), len(wantOrder), identifiersOf(issues))
+		}
+		for i, want := range wantOrder {
+			if issues[i].Identifier != want {
+				t.Errorf("issues[%d].Identifier = %q, want %q", i, issues[i].Identifier, want)
+			}
+		}
+		for _, iss := range issues {
+			if iss.Comments != nil {
+				t.Errorf("issue %s: Comments = %v, want nil", iss.Identifier, iss.Comments)
+			}
+		}
+		if got := calls.Load(); got != 2 {
+			t.Errorf("call count = %d, want 2 (two pages)", got)
+		}
+		if got := strings.Count(buf.String(), "kept first of multiple matching state labels"); got != 1 {
+			t.Errorf("multi-match WARN count = %d, want 1 (iid 7 carries both backlog and done labels)\noutput: %s", got, buf.String())
+		}
+		if !strings.Contains(buf.String(), "iid=7") {
+			t.Errorf("multi-match WARN missing iid=7\noutput: %s", buf.String())
+		}
+	})
+
+	t.Run("qualifies DisplayID when references.full is empty", func(t *testing.T) {
+		t.Parallel()
+
+		s := newPreflightServer(t)
+		s.handle("/api/v4/projects/"+testEscapedProject+"/issues", func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			w.Write(loadFixture(t, "issues_candidates_page2.json")) //nolint:errcheck // test helper
+		})
+		a := mustAdapter(t, s)
+
+		issues, err := a.FetchCandidateIssues(context.Background())
+		if err != nil {
+			t.Fatalf("FetchCandidateIssues: %v", err)
+		}
+		if len(issues) == 0 {
+			t.Fatal("issues is empty, want at least one active issue")
+		}
+		for _, iss := range issues {
+			want := testProject + "#" + iss.Identifier
+			if iss.DisplayID != want {
+				t.Errorf("issue %s: DisplayID = %q, want %q", iss.Identifier, iss.DisplayID, want)
+			}
+		}
+	})
+
+	t.Run("empty response returns non-nil empty slice", func(t *testing.T) {
+		t.Parallel()
+
+		s := newPreflightServer(t)
+		s.handle("/api/v4/projects/"+testEscapedProject+"/issues", func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte("[]")) //nolint:errcheck // test helper
+		})
+		a := mustAdapter(t, s)
+
+		issues, err := a.FetchCandidateIssues(context.Background())
+		if err != nil {
+			t.Fatalf("FetchCandidateIssues: %v", err)
+		}
+		if issues == nil {
+			t.Fatal("issues is nil, want non-nil empty slice")
+		}
+		if len(issues) != 0 {
+			t.Errorf("len = %d, want 0", len(issues))
+		}
+	})
+
+	t.Run("auth error propagates", func(t *testing.T) {
+		t.Parallel()
+
+		s := newPreflightServer(t)
+		s.handle("/api/v4/projects/"+testEscapedProject+"/issues", func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+			w.Write(loadFixture(t, "error_401.json")) //nolint:errcheck // test helper
+		})
+		a := mustAdapter(t, s)
+
+		_, err := a.FetchCandidateIssues(context.Background())
+		assertTrackerErrorKind(t, err, domain.ErrTrackerAuth)
+	})
+}
+
+func identifiersOf(issues []domain.Issue) []string {
+	out := make([]string, len(issues))
+	for i, iss := range issues {
+		out[i] = iss.Identifier
+	}
+	return out
+}
+
+// --- FetchIssuesByStates ---
+
+func TestFetchIssuesByStates(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty states short-circuits with no API call", func(t *testing.T) {
+		t.Parallel()
+
+		a := mustAdapter(t, newPreflightServer(t)) // no issues route registered; any call fails the test
+
+		issues, err := a.FetchIssuesByStates(context.Background(), []string{})
+		if err != nil {
+			t.Fatalf("FetchIssuesByStates: %v", err)
+		}
+		if issues == nil {
+			t.Fatal("issues is nil, want non-nil empty slice")
+		}
+		if len(issues) != 0 {
+			t.Errorf("len = %d, want 0", len(issues))
+		}
+	})
+
+	t.Run("requesting only an active state queries the opened listing only", func(t *testing.T) {
+		t.Parallel()
+
+		s := newPreflightServer(t)
+		var calls atomic.Int32
+		s.handle("/api/v4/projects/"+testEscapedProject+"/issues", func(w http.ResponseWriter, r *http.Request) {
+			calls.Add(1)
+			switch state := r.URL.Query().Get("state"); state {
+			case "opened":
+				w.WriteHeader(http.StatusOK)
+				w.Write(loadFixture(t, "issues_open_by_states.json")) //nolint:errcheck // test helper
+			default:
+				t.Errorf("unexpected state query param: %q", state)
+				w.WriteHeader(http.StatusBadRequest)
+			}
+		})
+		a := mustAdapter(t, s)
+
+		issues, err := a.FetchIssuesByStates(context.Background(), []string{"in-progress"})
+		if err != nil {
+			t.Fatalf("FetchIssuesByStates: %v", err)
+		}
+		if len(issues) != 1 {
+			t.Fatalf("len = %d, want 1 (only the in-progress issue)", len(issues))
+		}
+		if issues[0].Identifier != "10" {
+			t.Errorf("Identifier = %q, want %q", issues[0].Identifier, "10")
+		}
+		if got := calls.Load(); got != 1 {
+			t.Errorf("call count = %d, want 1 (exactly one opened-state query)", got)
+		}
+	})
+
+	t.Run("requesting only a terminal state queries the closed listing only", func(t *testing.T) {
+		t.Parallel()
+
+		s := newPreflightServer(t)
+		var calls atomic.Int32
+		s.handle("/api/v4/projects/"+testEscapedProject+"/issues", func(w http.ResponseWriter, r *http.Request) {
+			calls.Add(1)
+			switch state := r.URL.Query().Get("state"); state {
+			case "closed":
+				w.WriteHeader(http.StatusOK)
+				w.Write(loadFixture(t, "issues_closed_by_states.json")) //nolint:errcheck // test helper
+			default:
+				t.Errorf("unexpected state query param: %q", state)
+				w.WriteHeader(http.StatusBadRequest)
+			}
+		})
+		a := mustAdapter(t, s)
+
+		issues, err := a.FetchIssuesByStates(context.Background(), []string{"done"})
+		if err != nil {
+			t.Fatalf("FetchIssuesByStates: %v", err)
+		}
+		if len(issues) != 1 {
+			t.Fatalf("len = %d, want 1 (only the done issue)", len(issues))
+		}
+		if issues[0].Identifier != "20" {
+			t.Errorf("Identifier = %q, want %q", issues[0].Identifier, "20")
+		}
+		if got := calls.Load(); got != 1 {
+			t.Errorf("call count = %d, want 1 (exactly one closed-state query)", got)
+		}
+	})
+
+	t.Run("mixed request queries both the opened and closed listings", func(t *testing.T) {
+		t.Parallel()
+
+		s := newPreflightServer(t)
+		var gotOpened, gotClosed atomic.Bool
+		s.handle("/api/v4/projects/"+testEscapedProject+"/issues", func(w http.ResponseWriter, r *http.Request) {
+			switch state := r.URL.Query().Get("state"); state {
+			case "opened":
+				gotOpened.Store(true)
+				w.WriteHeader(http.StatusOK)
+				w.Write(loadFixture(t, "issues_open_by_states.json")) //nolint:errcheck // test helper
+			case "closed":
+				gotClosed.Store(true)
+				w.WriteHeader(http.StatusOK)
+				w.Write(loadFixture(t, "issues_closed_by_states.json")) //nolint:errcheck // test helper
+			default:
+				t.Errorf("unexpected state query param: %q", state)
+				w.WriteHeader(http.StatusBadRequest)
+			}
+		})
+		a := mustAdapter(t, s)
+
+		issues, err := a.FetchIssuesByStates(context.Background(), []string{"in-progress", "done"})
+		if err != nil {
+			t.Fatalf("FetchIssuesByStates: %v", err)
+		}
+		if len(issues) != 2 {
+			t.Fatalf("len = %d, want 2 (one from each listing)", len(issues))
+		}
+		if !gotOpened.Load() {
+			t.Error("opened state was not queried")
+		}
+		if !gotClosed.Load() {
+			t.Error("closed state was not queried")
+		}
+	})
+}
+
+// --- FetchIssueByID ---
+
+func TestFetchIssueByID(t *testing.T) {
+	t.Parallel()
+
+	t.Run("full population", func(t *testing.T) {
+		t.Parallel()
+
+		s := newPreflightServer(t)
+		s.handle("/api/v4/projects/"+testEscapedProject+"/issues/42", func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			w.Write(loadFixture(t, "issue_full.json")) //nolint:errcheck // test helper
+		})
+		var commentCalls atomic.Int32
+		s.handle("/api/v4/projects/"+testEscapedProject+"/issues/42/notes", func(w http.ResponseWriter, r *http.Request) {
+			commentCalls.Add(1)
+			w.WriteHeader(http.StatusOK)
+			w.Write(loadFixture(t, "notes_page1.json")) //nolint:errcheck // test helper
+		})
+		a := mustAdapter(t, s)
+
+		issue, err := a.FetchIssueByID(context.Background(), "42")
+		if err != nil {
+			t.Fatalf("FetchIssueByID: %v", err)
+		}
+
+		if issue.ID != "42" || issue.Identifier != "42" {
+			t.Errorf("ID/Identifier = %q/%q, want 42/42", issue.ID, issue.Identifier)
+		}
+		if issue.Parent != nil {
+			t.Errorf("Parent = %v, want nil", issue.Parent)
+		}
+		if len(issue.BlockedBy) != 0 {
+			t.Errorf("BlockedBy = %v, want empty", issue.BlockedBy)
+		}
+		if len(issue.Comments) != 1 {
+			t.Fatalf("Comments len = %d, want 1 (the system note dropped from notes_page1.json)", len(issue.Comments))
+		}
+		if issue.Comments[0].Author != "alice" {
+			t.Errorf("Comments[0].Author = %q, want %q", issue.Comments[0].Author, "alice")
+		}
+		if got := commentCalls.Load(); got != 1 {
+			t.Errorf("comments request count = %d, want 1", got)
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		t.Parallel()
+
+		s := newPreflightServer(t)
+		s.handle("/api/v4/projects/"+testEscapedProject+"/issues/999", func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+			w.Write(loadFixture(t, "error_404_issue.json")) //nolint:errcheck // test helper
+		})
+		a := mustAdapter(t, s)
+
+		_, err := a.FetchIssueByID(context.Background(), "999")
+		assertTrackerErrorKind(t, err, domain.ErrTrackerNotFound)
+	})
+
+	t.Run("non-issue entity maps to not found", func(t *testing.T) {
+		t.Parallel()
+
+		s := newPreflightServer(t)
+		s.handle("/api/v4/projects/"+testEscapedProject+"/issues/100", func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			w.Write(loadFixture(t, "issue_incident.json")) //nolint:errcheck // test helper
+		})
+		a := mustAdapter(t, s)
+
+		_, err := a.FetchIssueByID(context.Background(), "100")
+		assertTrackerErrorKind(t, err, domain.ErrTrackerNotFound)
+	})
+
+	t.Run("identifier guard rejects malformed input with no request issued", func(t *testing.T) {
+		t.Parallel()
+
+		tests := []string{"abc", "1.5", "-1", "0", " ", ""}
+
+		for _, raw := range tests {
+			t.Run(fmt.Sprintf("issueID=%q", raw), func(t *testing.T) {
+				t.Parallel()
+
+				a := mustAdapter(t, newPreflightServer(t)) // no issues route registered; any call fails the test
+
+				_, err := a.FetchIssueByID(context.Background(), raw)
+				assertTrackerErrorKind(t, err, domain.ErrTrackerNotFound)
+			})
+		}
+	})
+
+	t.Run("accepted value reaches the server as a canonical decimal path segment", func(t *testing.T) {
+		t.Parallel()
+
+		s := newPreflightServer(t)
+		s.handle("/api/v4/projects/"+testEscapedProject+"/issues/42", func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			w.Write(loadFixture(t, "issue_full.json")) //nolint:errcheck // test helper
+		})
+		s.handle("/api/v4/projects/"+testEscapedProject+"/issues/42/notes", func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte("[]")) //nolint:errcheck // test helper
+		})
+		a := mustAdapter(t, s)
+
+		if _, err := a.FetchIssueByID(context.Background(), "  42  "); err != nil {
+			t.Fatalf("FetchIssueByID(%q): %v (whitespace must be trimmed to a canonical decimal segment)", "  42  ", err)
+		}
+	})
+}
+
+// --- FetchIssueComments ---
+
+func TestFetchIssueComments(t *testing.T) {
+	t.Parallel()
+
+	t.Run("multi-page notes: system dropped, internal retained, ascending order", func(t *testing.T) {
+		t.Parallel()
+
+		s := newPreflightServer(t)
+		var srvURL string
+		var calls atomic.Int32
+		basePath := "/api/v4/projects/" + testEscapedProject + "/issues/55/notes"
+		s.handle(basePath, func(w http.ResponseWriter, r *http.Request) {
+			n := calls.Add(1)
+			if n == 1 {
+				// Only the first request carries the base params; the
+				// paginator follows subsequent pages via the absolute
+				// Link-header URL, which does not repeat them.
+				assertQueryParams(t, "notes", r.URL.Query(), map[string]string{
+					"activity_filter": "only_comments", "sort": "asc", "per_page": "100",
+				})
+			}
+			first := fmt.Sprintf(`<%s%s?page=1>; rel="first"`, srvURL, basePath)
+			last := fmt.Sprintf(`<%s%s?page=2>; rel="last"`, srvURL, basePath)
+			if n == 1 {
+				next := fmt.Sprintf(`<%s%s?page=2>; rel="next"`, srvURL, basePath)
+				w.Header().Set("Link", strings.Join([]string{next, first, last}, ", "))
+				w.WriteHeader(http.StatusOK)
+				w.Write(loadFixture(t, "notes_page1.json")) //nolint:errcheck // test helper
+				return
+			}
+			w.Header().Set("Link", strings.Join([]string{first, last}, ", "))
+			w.WriteHeader(http.StatusOK)
+			w.Write(loadFixture(t, "notes_page2.json")) //nolint:errcheck // test helper
+		})
+		srv := httptest.NewServer(s)
+		defer srv.Close()
+		srvURL = srv.URL
+
+		cfg := validConfig(testProject)
+		cfg["endpoint"] = srv.URL
+		a, err := NewGitLabAdapter(cfg)
+		if err != nil {
+			t.Fatalf("NewGitLabAdapter: %v", err)
+		}
+
+		comments, err := a.(*GitLabAdapter).FetchIssueComments(context.Background(), "55")
+		if err != nil {
+			t.Fatalf("FetchIssueComments: %v", err)
+		}
+		if len(comments) != 3 {
+			t.Fatalf("len = %d, want 3 (4 raw notes minus the one system note)", len(comments))
+		}
+		wantIDs := []string{"501", "503", "504"}
+		for i, want := range wantIDs {
+			if comments[i].ID != want {
+				t.Errorf("comments[%d].ID = %q, want %q", i, comments[i].ID, want)
+			}
+		}
+		if got := calls.Load(); got != 2 {
+			t.Errorf("call count = %d, want 2 (one per page)", got)
+		}
+	})
+
+	t.Run("empty result returns non-nil empty slice", func(t *testing.T) {
+		t.Parallel()
+
+		s := newPreflightServer(t)
+		s.handle("/api/v4/projects/"+testEscapedProject+"/issues/7/notes", func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte("[]")) //nolint:errcheck // test helper
+		})
+		a := mustAdapter(t, s)
+
+		comments, err := a.FetchIssueComments(context.Background(), "7")
+		if err != nil {
+			t.Fatalf("FetchIssueComments: %v", err)
+		}
+		if comments == nil {
+			t.Fatal("comments is nil, want non-nil empty slice")
+		}
+		if len(comments) != 0 {
+			t.Errorf("len = %d, want 0", len(comments))
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		t.Parallel()
+
+		s := newPreflightServer(t)
+		s.handle("/api/v4/projects/"+testEscapedProject+"/issues/999/notes", func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+			w.Write(loadFixture(t, "error_404_issue.json")) //nolint:errcheck // test helper
+		})
+		a := mustAdapter(t, s)
+
+		_, err := a.FetchIssueComments(context.Background(), "999")
+		assertTrackerErrorKind(t, err, domain.ErrTrackerNotFound)
+	})
+
+	t.Run("identifier guard rejects malformed input with no request issued", func(t *testing.T) {
+		t.Parallel()
+
+		tests := []string{"abc", "1.5", "-1", "0", " ", ""}
+
+		for _, raw := range tests {
+			t.Run(fmt.Sprintf("issueID=%q", raw), func(t *testing.T) {
+				t.Parallel()
+
+				a := mustAdapter(t, newPreflightServer(t)) // no notes route registered; any call fails the test
+
+				_, err := a.FetchIssueComments(context.Background(), raw)
+				assertTrackerErrorKind(t, err, domain.ErrTrackerNotFound)
+			})
+		}
+	})
+}
+
+// --- FetchIssueStatesByIDs / FetchIssueStatesByIdentifiers ---
+
+func TestFetchIssueStatesByIDs(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty input returns empty map with no request", func(t *testing.T) {
+		t.Parallel()
+
+		a := mustAdapter(t, newPreflightServer(t)) // no issues route registered; any call fails the test
+
+		states, err := a.FetchIssueStatesByIDs(context.Background(), nil)
+		if err != nil {
+			t.Fatalf("FetchIssueStatesByIDs: %v", err)
+		}
+		if states == nil {
+			t.Fatal("states is nil, want non-nil empty map")
+		}
+		if len(states) != 0 {
+			t.Errorf("len = %d, want 0", len(states))
+		}
+	})
+
+	t.Run("all-empty or unparseable values return empty map with no request", func(t *testing.T) {
+		t.Parallel()
+
+		a := mustAdapter(t, newPreflightServer(t)) // no issues route registered; any call fails the test
+
+		states, err := a.FetchIssueStatesByIDs(context.Background(), []string{"", " ", "abc", "0", "-1", "1.5"})
+		if err != nil {
+			t.Fatalf("FetchIssueStatesByIDs: %v", err)
+		}
+		if len(states) != 0 {
+			t.Errorf("len = %d, want 0 (no value survives the identifier filter)", len(states))
+		}
+	})
+
+	t.Run("unrequested response entry ignored, requested-but-absent entry omitted", func(t *testing.T) {
+		t.Parallel()
+
+		s := newPreflightServer(t)
+		s.handle("/api/v4/projects/"+testEscapedProject+"/issues", func(w http.ResponseWriter, r *http.Request) {
+			query := r.URL.Query()
+			if got, want := query.Get("state"), "all"; got != want {
+				t.Errorf("state = %q, want %q", got, want)
+			}
+			if got, want := query.Get("scope"), "all"; got != want {
+				t.Errorf("scope = %q, want %q", got, want)
+			}
+			if got, want := query.Get("per_page"), "100"; got != want {
+				t.Errorf("per_page = %q, want %q", got, want)
+			}
+			gotIIDs := query["iids[]"]
+			wantIIDs := []string{"10", "20", "30"}
+			if !slices.Equal(gotIIDs, wantIIDs) {
+				t.Errorf("iids[] = %v, want %v (one repeated value per requested iid, in request order)", gotIIDs, wantIIDs)
+			}
+			w.WriteHeader(http.StatusOK)
+			body := `[{"iid": 10, "state": "opened", "issue_type": "issue", "labels": ["in-progress"]},` +
+				`{"iid": 20, "state": "closed", "issue_type": "issue", "labels": ["done"]},` +
+				`{"iid": 999, "state": "opened", "issue_type": "issue", "labels": ["backlog"]}]`
+			w.Write([]byte(body)) //nolint:errcheck // test helper
+		})
+		a := mustAdapter(t, s)
+
+		states, err := a.FetchIssueStatesByIDs(context.Background(), []string{"10", "20", "30"})
+		if err != nil {
+			t.Fatalf("FetchIssueStatesByIDs: %v", err)
+		}
+		if len(states) != 2 {
+			t.Fatalf("len = %d, want 2: got %v", len(states), states)
+		}
+		if states["10"] != "in-progress" {
+			t.Errorf(`states["10"] = %q, want %q`, states["10"], "in-progress")
+		}
+		if states["20"] != "done" {
+			t.Errorf(`states["20"] = %q, want %q`, states["20"], "done")
+		}
+		if _, ok := states["30"]; ok {
+			t.Error(`states["30"] present, want absent (requested but not returned by the server)`)
+		}
+		if _, ok := states["999"]; ok {
+			t.Error(`states["999"] present, want absent (returned by the server but never requested)`)
+		}
+	})
+
+	t.Run("non-issue entity is filtered from the batch result", func(t *testing.T) {
+		t.Parallel()
+
+		s := newPreflightServer(t)
+		s.handle("/api/v4/projects/"+testEscapedProject+"/issues", func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			body := `[{"iid": 1, "state": "opened", "issue_type": "issue", "labels": ["backlog"]},` +
+				`{"iid": 2, "state": "opened", "issue_type": "task", "labels": ["backlog"]}]`
+			w.Write([]byte(body)) //nolint:errcheck // test helper
+		})
+		a := mustAdapter(t, s)
+
+		states, err := a.FetchIssueStatesByIDs(context.Background(), []string{"1", "2"})
+		if err != nil {
+			t.Fatalf("FetchIssueStatesByIDs: %v", err)
+		}
+		if len(states) != 1 {
+			t.Fatalf("len = %d, want 1: got %v", len(states), states)
+		}
+		if _, ok := states["1"]; !ok {
+			t.Error(`states["1"] absent, want present`)
+		}
+		if _, ok := states["2"]; ok {
+			t.Error(`states["2"] present, want absent (issue_type "task" is not an issue)`)
+		}
+	})
+
+	t.Run("a 60-value input chunks into exactly two requests at the boundary", func(t *testing.T) {
+		t.Parallel()
+
+		requested := make([]string, 60)
+		for i := range requested {
+			requested[i] = strconv.Itoa(i + 1)
+		}
+
+		var mu sync.Mutex
+		var queries [][]string
+
+		s := newPreflightServer(t)
+		s.handle("/api/v4/projects/"+testEscapedProject+"/issues", func(w http.ResponseWriter, r *http.Request) {
+			mu.Lock()
+			queries = append(queries, append([]string(nil), r.URL.Query()["iids[]"]...))
+			mu.Unlock()
+
+			items := make([]string, 0, len(r.URL.Query()["iids[]"]))
+			for _, raw := range r.URL.Query()["iids[]"] {
+				items = append(items, fmt.Sprintf(`{"iid": %s, "state": "opened", "issue_type": "issue", "labels": []}`, raw))
+			}
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte("[" + strings.Join(items, ",") + "]")) //nolint:errcheck // test helper
+		})
+		a := mustAdapter(t, s)
+
+		states, err := a.FetchIssueStatesByIDs(context.Background(), requested)
+		if err != nil {
+			t.Fatalf("FetchIssueStatesByIDs: %v", err)
+		}
+		if len(states) != 60 {
+			t.Fatalf("len = %d, want 60", len(states))
+		}
+
+		mu.Lock()
+		defer mu.Unlock()
+		if len(queries) != 2 {
+			t.Fatalf("request count = %d, want 2 (60 values chunked at 50)", len(queries))
+		}
+		if len(queries[0]) != 50 {
+			t.Errorf("first chunk size = %d, want 50", len(queries[0]))
+		}
+		if len(queries[1]) != 10 {
+			t.Errorf("second chunk size = %d, want 10", len(queries[1]))
+		}
+		if queries[0][0] != "1" || queries[0][len(queries[0])-1] != "50" {
+			t.Errorf("first chunk = %v, want to start at 1 and end at 50", queries[0])
+		}
+		if queries[1][0] != "51" || queries[1][len(queries[1])-1] != "60" {
+			t.Errorf("second chunk = %v, want to start at 51 and end at 60", queries[1])
+		}
+	})
+
+	t.Run("404 on the batch route is returned rather than swallowed", func(t *testing.T) {
+		t.Parallel()
+
+		s := newPreflightServer(t)
+		s.handle("/api/v4/projects/"+testEscapedProject+"/issues", func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+			w.Write(loadFixture(t, "error_404_project.json")) //nolint:errcheck // test helper
+		})
+		a := mustAdapter(t, s)
+
+		_, err := a.FetchIssueStatesByIDs(context.Background(), []string{"1"})
+		assertTrackerErrorKind(t, err, domain.ErrTrackerNotFound)
+	})
+}
+
+func TestFetchIssueStatesByIdentifiers(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns the same map as FetchIssueStatesByIDs for the same input", func(t *testing.T) {
+		t.Parallel()
+
+		s := newPreflightServer(t)
+		s.handle("/api/v4/projects/"+testEscapedProject+"/issues", func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`[{"iid": 10, "state": "opened", "issue_type": "issue", "labels": ["in-progress"]}]`)) //nolint:errcheck // test helper
+		})
+		a := mustAdapter(t, s)
+
+		states, err := a.FetchIssueStatesByIdentifiers(context.Background(), []string{"10"})
+		if err != nil {
+			t.Fatalf("FetchIssueStatesByIdentifiers: %v", err)
+		}
+		if len(states) != 1 || states["10"] != "in-progress" {
+			t.Errorf("states = %v, want {10: in-progress}", states)
+		}
+	})
+
+	t.Run("empty input returns empty map with no request", func(t *testing.T) {
+		t.Parallel()
+
+		a := mustAdapter(t, newPreflightServer(t)) // no issues route registered; any call fails the test
+
+		states, err := a.FetchIssueStatesByIdentifiers(context.Background(), []string{})
+		if err != nil {
+			t.Fatalf("FetchIssueStatesByIdentifiers: %v", err)
+		}
+		if states == nil {
+			t.Fatal("states is nil, want non-nil empty map")
+		}
+		if len(states) != 0 {
+			t.Errorf("len = %d, want 0", len(states))
+		}
+	})
+}
+
+// --- Write stubs ---
+
+func TestWriteStubs(t *testing.T) {
+	t.Parallel()
+
+	a := mustAdapter(t, newPreflightServer(t)) // no write route registered; any call fails the test
+
+	if err := a.TransitionIssue(context.Background(), "1", "done"); err == nil {
+		t.Error("TransitionIssue = nil, want ErrTrackerPayload")
+	} else {
+		assertTrackerErrorKind(t, err, domain.ErrTrackerPayload)
+	}
+
+	if err := a.CommentIssue(context.Background(), "1", "hello"); err == nil {
+		t.Error("CommentIssue = nil, want ErrTrackerPayload")
+	} else {
+		assertTrackerErrorKind(t, err, domain.ErrTrackerPayload)
+	}
+
+	if err := a.AddLabel(context.Background(), "1", "ci-failure"); err == nil {
+		t.Error("AddLabel = nil, want ErrTrackerPayload")
+	} else {
+		assertTrackerErrorKind(t, err, domain.ErrTrackerPayload)
+	}
+}

--- a/internal/scm/gitlab/normalize.go
+++ b/internal/scm/gitlab/normalize.go
@@ -1,0 +1,126 @@
+package gitlab
+
+import (
+	"encoding/json"
+	"log/slog"
+	"strconv"
+
+	"github.com/sortie-ai/sortie/internal/domain"
+	"github.com/sortie-ai/sortie/internal/issuekit"
+)
+
+// gitlabIssue is one issue from the GitLab REST v4 issue routes. The read
+// path decodes only the fields it consumes; unmodeled wire fields are
+// ignored.
+type gitlabIssue struct {
+	IID         int              `json:"iid"`
+	Title       string           `json:"title"`
+	Description string           `json:"description"`
+	State       string           `json:"state"`
+	IssueType   string           `json:"issue_type"`
+	WebURL      string           `json:"web_url"`
+	Labels      []string         `json:"labels"`
+	Assignees   []gitlabUser     `json:"assignees"`
+	References  gitlabReferences `json:"references"`
+	CreatedAt   string           `json:"created_at"`
+	UpdatedAt   string           `json:"updated_at"`
+}
+
+// gitlabReferences carries the qualified display forms GitLab computes for
+// an issue.
+type gitlabReferences struct {
+	Full string `json:"full"`
+}
+
+// gitlabUser carries the username used for an issue assignee and a note
+// author.
+type gitlabUser struct {
+	Username string `json:"username"`
+}
+
+// gitlabNote is one note from the issue notes route. System is the
+// authoritative marker distinguishing a journal entry from a human
+// comment.
+type gitlabNote struct {
+	ID        int64      `json:"id"`
+	Author    gitlabUser `json:"author"`
+	Body      string     `json:"body"`
+	CreatedAt string     `json:"created_at"`
+	System    bool       `json:"system"`
+}
+
+// gitlabTokenInfo is the token-introspection record the construction
+// preflight decodes. It never carries the token value itself.
+type gitlabTokenInfo struct {
+	Scopes    []string `json:"scopes"`
+	Active    bool     `json:"active"`
+	Revoked   bool     `json:"revoked"`
+	ExpiresAt string   `json:"expires_at"`
+}
+
+// gitlabErrorBody covers the four error envelopes GitLab returns on a
+// non-2xx response. Message is raw because GitLab may send a non-string
+// value there.
+type gitlabErrorBody struct {
+	Message          json.RawMessage `json:"message"`
+	Error            string          `json:"error"`
+	ErrorDescription string          `json:"error_description"`
+}
+
+// normalizeIssue maps a gitlabIssue to a [domain.Issue]. ID and Identifier
+// are both the decimal iid; the instance-global id is never read.
+// DisplayID falls back to "<project>#<iid>" when the server-provided
+// reference is empty. Priority, Parent, and BranchName are always nil,
+// nil, and empty; BlockedBy is a non-nil empty slice.
+//
+// Comments is left nil; callers that fetch comments assign them
+// afterwards.
+func normalizeIssue(gi gitlabIssue, project string, activeStates, terminalStates []string, handoffState string, log *slog.Logger) domain.Issue {
+	iid := strconv.Itoa(gi.IID)
+
+	displayID := gi.References.Full
+	if displayID == "" {
+		displayID = project + "#" + iid
+	}
+
+	assignee := ""
+	if len(gi.Assignees) > 0 {
+		assignee = gi.Assignees[0].Username
+	}
+
+	return domain.Issue{
+		ID:          iid,
+		Identifier:  iid,
+		DisplayID:   displayID,
+		Title:       gi.Title,
+		Description: gi.Description,
+		State:       deriveState(gi.Labels, gi.State, activeStates, terminalStates, handoffState, iid, log),
+		URL:         gi.WebURL,
+		Labels:      issuekit.NormalizeLabels(gi.Labels),
+		Assignee:    assignee,
+		IssueType:   gi.IssueType,
+		BlockedBy:   []domain.BlockerRef{},
+		CreatedAt:   gi.CreatedAt,
+		UpdatedAt:   gi.UpdatedAt,
+	}
+}
+
+// normalizeComments maps GitLab notes to [domain.Comment] values, dropping
+// any note whose System flag is true. A note carrying internal: true
+// passes through, because it is a genuine human comment rather than a
+// journal entry. Returns a non-nil empty slice when raw is empty.
+func normalizeComments(raw []gitlabNote) []domain.Comment {
+	staged := make([]issuekit.SourceComment, 0, len(raw))
+	for _, n := range raw {
+		if n.System {
+			continue
+		}
+		staged = append(staged, issuekit.SourceComment{
+			ID:        strconv.FormatInt(n.ID, 10),
+			Author:    n.Author.Username,
+			Body:      n.Body,
+			CreatedAt: n.CreatedAt,
+		})
+	}
+	return issuekit.NormalizeComments(staged)
+}

--- a/internal/scm/gitlab/normalize_test.go
+++ b/internal/scm/gitlab/normalize_test.go
@@ -1,0 +1,207 @@
+package gitlab
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestNormalizeIssue_AllFields(t *testing.T) {
+	t.Parallel()
+
+	raw := loadFixture(t, "issue_full.json")
+	var gi gitlabIssue
+	if err := json.Unmarshal(raw, &gi); err != nil {
+		t.Fatalf("json.Unmarshal(issue_full.json): %v", err)
+	}
+
+	active := []string{"backlog", "in-progress", "review"}
+	terminal := []string{"done", "wontfix"}
+
+	got := normalizeIssue(gi, "acme/widgets", active, terminal, "", nil)
+
+	// issue_full.json carries iid=42 and a distinct global id=91042; the
+	// global id must never surface in ID, Identifier, or DisplayID.
+	if got.ID != "42" {
+		t.Errorf("ID = %q, want %q (from iid, never the global id)", got.ID, "42")
+	}
+	if got.Identifier != "42" {
+		t.Errorf("Identifier = %q, want %q", got.Identifier, "42")
+	}
+	if got.DisplayID != "acme/widgets#42" {
+		t.Errorf("DisplayID = %q, want the server-provided references.full value %q", got.DisplayID, "acme/widgets#42")
+	}
+	if got.Title != "Add dark mode support" {
+		t.Errorf("Title = %q, want %q", got.Title, "Add dark mode support")
+	}
+	if got.Description != "Users want a **dark mode** option." {
+		t.Errorf("Description = %q, want %q", got.Description, "Users want a **dark mode** option.")
+	}
+	if got.Priority != nil {
+		t.Errorf("Priority = %v, want nil (gitlab issues carry no priority field)", got.Priority)
+	}
+	if got.State != "in-progress" {
+		t.Errorf("State = %q, want %q", got.State, "in-progress")
+	}
+	if got.BranchName != "" {
+		t.Errorf("BranchName = %q, want empty (gitlab issues carry no branch field)", got.BranchName)
+	}
+	if got.URL != "https://gitlab.example.com/acme/widgets/-/issues/42" {
+		t.Errorf("URL = %q, want the web_url value", got.URL)
+	}
+	if len(got.Labels) != 2 || got.Labels[0] != "in-progress" || got.Labels[1] != "ui" {
+		t.Errorf("Labels = %v, want [in-progress ui] (lowercased)", got.Labels)
+	}
+	if got.Assignee != "alice" {
+		t.Errorf("Assignee = %q, want %q (from assignees[0], never the deprecated singular assignee field %q)", got.Assignee, "alice", "carol")
+	}
+	if got.IssueType != "issue" {
+		t.Errorf("IssueType = %q, want %q", got.IssueType, "issue")
+	}
+	if got.Parent != nil {
+		t.Errorf("Parent = %v, want nil", got.Parent)
+	}
+	if got.Comments != nil {
+		t.Errorf("Comments = %v, want nil (normalizeIssue never fetches comments)", got.Comments)
+	}
+	if got.BlockedBy == nil {
+		t.Error("BlockedBy is nil, want non-nil empty slice")
+	}
+	if len(got.BlockedBy) != 0 {
+		t.Errorf("BlockedBy len = %d, want 0", len(got.BlockedBy))
+	}
+	if got.CreatedAt != "2026-01-01T00:00:00.000+02:00" {
+		t.Errorf("CreatedAt = %q, want %q", got.CreatedAt, "2026-01-01T00:00:00.000+02:00")
+	}
+	if got.UpdatedAt != "2026-01-02T00:00:00.000+02:00" {
+		t.Errorf("UpdatedAt = %q, want %q", got.UpdatedAt, "2026-01-02T00:00:00.000+02:00")
+	}
+}
+
+func TestNormalizeIssue_DisplayIDFallback(t *testing.T) {
+	t.Parallel()
+
+	gi := gitlabIssue{IID: 7, State: "opened"}
+	got := normalizeIssue(gi, "acme/subgroup/widgets", nil, nil, "", nil)
+
+	if want := "acme/subgroup/widgets#7"; got.DisplayID != want {
+		t.Errorf("DisplayID = %q, want %q when references.full is empty", got.DisplayID, want)
+	}
+}
+
+func TestNormalizeIssue_NonNilEmptyLabels(t *testing.T) {
+	t.Parallel()
+
+	gi := gitlabIssue{IID: 1, State: "opened", Labels: nil}
+	got := normalizeIssue(gi, "acme/widgets", nil, nil, "", nil)
+
+	if got.Labels == nil {
+		t.Error("Labels is nil, want non-nil empty slice")
+	}
+	if len(got.Labels) != 0 {
+		t.Errorf("Labels len = %d, want 0", len(got.Labels))
+	}
+}
+
+func TestNormalizeIssue_EmptyAssignees(t *testing.T) {
+	t.Parallel()
+
+	gi := gitlabIssue{IID: 1, State: "opened", Assignees: nil}
+	got := normalizeIssue(gi, "acme/widgets", nil, nil, "", nil)
+
+	if got.Assignee != "" {
+		t.Errorf("Assignee = %q, want empty string for no assignees", got.Assignee)
+	}
+}
+
+func TestNormalizeIssue_MultipleAssignees(t *testing.T) {
+	t.Parallel()
+
+	gi := gitlabIssue{
+		IID:       1,
+		State:     "opened",
+		Assignees: []gitlabUser{{Username: "alice"}, {Username: "bob"}},
+	}
+	got := normalizeIssue(gi, "acme/widgets", nil, nil, "", nil)
+
+	if got.Assignee != "alice" {
+		t.Errorf("Assignee = %q, want the first assignee %q", got.Assignee, "alice")
+	}
+}
+
+func TestNormalizeIssue_BlockedByAlwaysNonNilEmpty(t *testing.T) {
+	t.Parallel()
+
+	gi := gitlabIssue{IID: 1, State: "opened"}
+	got := normalizeIssue(gi, "acme/widgets", nil, nil, "", nil)
+
+	if got.BlockedBy == nil {
+		t.Error("BlockedBy is nil, want non-nil empty slice")
+	}
+	if len(got.BlockedBy) != 0 {
+		t.Errorf("BlockedBy len = %d, want 0 (gitlab community edition has no blocks relation type)", len(got.BlockedBy))
+	}
+}
+
+func TestNormalizeIssue_NullDescriptionDecodesToEmptyString(t *testing.T) {
+	t.Parallel()
+
+	var gi gitlabIssue
+	if err := json.Unmarshal([]byte(`{"iid":1,"state":"opened","description":null}`), &gi); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+	if gi.Description != "" {
+		t.Errorf("Description = %q, want empty string for a JSON null description", gi.Description)
+	}
+}
+
+func TestNormalizeComments_SystemDroppedInternalRetained(t *testing.T) {
+	t.Parallel()
+
+	raw := []gitlabNote{
+		{ID: 501, Author: gitlabUser{Username: "alice"}, Body: "Started investigating.", CreatedAt: "2026-01-10T09:00:00Z", System: false},
+		{ID: 502, Author: gitlabUser{Username: "sortie-bot"}, Body: "changed the description", CreatedAt: "2026-01-10T09:05:00Z", System: true},
+		{ID: 503, Author: gitlabUser{Username: "bob"}, Body: "Confidential rollback details.", CreatedAt: "2026-01-10T10:00:00Z", System: false},
+	}
+
+	got := normalizeComments(raw)
+
+	if len(got) != 2 {
+		t.Fatalf("normalizeComments len = %d, want 2 (the system note dropped)", len(got))
+	}
+	if got[0].ID != "501" || got[0].Author != "alice" {
+		t.Errorf("got[0] = %+v, want ID=501 Author=alice", got[0])
+	}
+	if got[1].ID != "503" || got[1].Author != "bob" {
+		t.Errorf("got[1] = %+v, want ID=503 Author=bob (system note at index 1 removed, order preserved)", got[1])
+	}
+}
+
+func TestNormalizeComments_InternalFlagDoesNotFilter(t *testing.T) {
+	t.Parallel()
+
+	var raw []gitlabNote
+	if err := json.Unmarshal([]byte(`[{"id":900,"body":"internal note","author":{"username":"bob"},"created_at":"2026-01-01T00:00:00Z","system":false,"internal":true}]`), &raw); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+
+	got := normalizeComments(raw)
+	if len(got) != 1 {
+		t.Fatalf("normalizeComments len = %d, want 1 (internal:true must not be dropped)", len(got))
+	}
+	if got[0].Body != "internal note" {
+		t.Errorf("got[0].Body = %q, want %q", got[0].Body, "internal note")
+	}
+}
+
+func TestNormalizeComments_EmptyReturnsNonNilSlice(t *testing.T) {
+	t.Parallel()
+
+	got := normalizeComments(nil)
+
+	if got == nil {
+		t.Error("normalizeComments(nil) returned nil, want non-nil empty slice")
+	}
+	if len(got) != 0 {
+		t.Errorf("len = %d, want 0", len(got))
+	}
+}

--- a/internal/scm/gitlab/preflight.go
+++ b/internal/scm/gitlab/preflight.go
@@ -27,6 +27,9 @@ var preflightBackoff = []time.Duration{time.Second, 2 * time.Second, 4 * time.Se
 // informs the message on a not-found project error. The token never
 // appears in a log record.
 func runPreflight(ctx context.Context, client *httpkit.Client, projectPath string, log *slog.Logger) error {
+	if log == nil {
+		log = slog.Default()
+	}
 	tokenValid := false
 
 	body, _, err := client.Get(ctx, "/personal_access_tokens/self", nil)
@@ -37,7 +40,7 @@ func runPreflight(ctx context.Context, client *httpkit.Client, projectPath strin
 		if err := json.Unmarshal(body, &info); err != nil {
 			log.Debug("gitlab token introspection unavailable", slog.Any("error", err))
 		} else {
-			tokenValid = true
+			tokenValid = info.Active && !info.Revoked
 			log.Debug("gitlab token introspected",
 				slog.Any("scopes", info.Scopes),
 				slog.Bool("active", info.Active),

--- a/internal/scm/gitlab/preflight.go
+++ b/internal/scm/gitlab/preflight.go
@@ -1,0 +1,112 @@
+package gitlab
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/sortie-ai/sortie/internal/domain"
+	"github.com/sortie-ai/sortie/internal/httpkit"
+)
+
+// preflightBackoff is the bounded exponential backoff applied to
+// transient preflight failures. A config error fails construction
+// immediately with no retry; these delays absorb a brief outage before
+// construction fails.
+var preflightBackoff = []time.Duration{time.Second, 2 * time.Second, 4 * time.Second}
+
+// runPreflight validates the credential and the configured project before
+// the first poll. It calls GET /personal_access_tokens/self once, with no
+// retry, as an advisory introspection, then GET /projects/{projectPath}
+// through [withRetry] as the authoritative gate.
+//
+// Token introspection failure never blocks construction; its result only
+// informs the message on a not-found project error. The token never
+// appears in a log record.
+func runPreflight(ctx context.Context, client *httpkit.Client, projectPath string, log *slog.Logger) error {
+	tokenValid := false
+
+	body, _, err := client.Get(ctx, "/personal_access_tokens/self", nil)
+	if err != nil {
+		log.Debug("gitlab token introspection unavailable", slog.Any("error", err))
+	} else {
+		var info gitlabTokenInfo
+		if err := json.Unmarshal(body, &info); err != nil {
+			log.Debug("gitlab token introspection unavailable", slog.Any("error", err))
+		} else {
+			tokenValid = true
+			log.Debug("gitlab token introspected",
+				slog.Any("scopes", info.Scopes),
+				slog.Bool("active", info.Active),
+				slog.Bool("revoked", info.Revoked),
+				slog.String("expires_at", info.ExpiresAt))
+			if info.Revoked || !info.Active {
+				log.Warn("gitlab token reports revoked or inactive")
+			}
+		}
+	}
+
+	projectErr := withRetry(ctx, func() error {
+		_, _, getErr := client.Get(ctx, "/projects/"+projectPath, nil)
+		return getErr
+	})
+	if projectErr != nil {
+		if domain.IsNotFound(projectErr) {
+			return &domain.TrackerError{
+				Kind: domain.ErrTrackerNotFound,
+				Message: fmt.Sprintf(
+					"gitlab: project not found or not accessible with the configured credential (token authenticated: %t)",
+					tokenValid),
+			}
+		}
+		return projectErr
+	}
+	return nil
+}
+
+// withRetry runs fn, retrying transient tracker errors with the bounded
+// [preflightBackoff] schedule. Config errors return immediately without a
+// retry.
+//
+// The backoff wait honors ctx: a cancellation during a backoff returns
+// ctx.Err() without waiting for the delay to elapse.
+func withRetry(ctx context.Context, fn func() error) error {
+	err := fn()
+	for attempt := 0; err != nil && attempt < len(preflightBackoff); attempt++ {
+		if !isRetryable(err) {
+			return err
+		}
+		if waitErr := sleepContext(ctx, preflightBackoff[attempt]); waitErr != nil {
+			return waitErr
+		}
+		err = fn()
+	}
+	return err
+}
+
+// sleepContext blocks for d or until ctx is cancelled, whichever comes
+// first. It returns ctx.Err() on cancellation and nil once the full delay
+// elapses.
+func sleepContext(ctx context.Context, d time.Duration) error {
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+// isRetryable reports whether err is a tracker error whose kind is
+// retryable.
+func isRetryable(err error) bool {
+	var te *domain.TrackerError
+	if !errors.As(err, &te) {
+		return false
+	}
+	return te.Kind.RetryClassification().Retryable
+}

--- a/internal/scm/gitlab/preflight_test.go
+++ b/internal/scm/gitlab/preflight_test.go
@@ -1,0 +1,315 @@
+package gitlab
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/sortie-ai/sortie/internal/domain"
+)
+
+// fastPreflightBackoff replaces the package-level preflightBackoff with
+// near-zero delays for the duration of a test so a retry path does not
+// sleep for seconds, restoring the original schedule on cleanup.
+//
+// preflightBackoff is package-global, so no test that calls this (or any
+// test that otherwise reads or writes preflightBackoff) may run in parallel
+// with another such test: doing so races the shared slice under -race.
+func fastPreflightBackoff(t *testing.T) {
+	t.Helper()
+	original := preflightBackoff
+	preflightBackoff = []time.Duration{time.Microsecond, time.Microsecond, time.Microsecond}
+	t.Cleanup(func() { preflightBackoff = original })
+}
+
+func TestSleepContext(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns nil once the delay elapses", func(t *testing.T) {
+		t.Parallel()
+
+		if err := sleepContext(context.Background(), time.Microsecond); err != nil {
+			t.Fatalf("sleepContext(_, 1us) = %v, want nil", err)
+		}
+	})
+
+	t.Run("returns ctx.Err on cancellation without waiting the delay", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		err := sleepContext(ctx, time.Hour)
+		if !errors.Is(err, context.Canceled) {
+			t.Errorf("sleepContext(cancelled, 1h) = %v, want context.Canceled", err)
+		}
+	})
+}
+
+func TestIsRetryable(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"transport error is retryable", &domain.TrackerError{Kind: domain.ErrTrackerTransport}, true},
+		{"api error is retryable", &domain.TrackerError{Kind: domain.ErrTrackerAPI}, true},
+		{"auth error is not retryable", &domain.TrackerError{Kind: domain.ErrTrackerAuth}, false},
+		{"not found error is not retryable", &domain.TrackerError{Kind: domain.ErrTrackerNotFound}, false},
+		{"payload error is not retryable", &domain.TrackerError{Kind: domain.ErrTrackerPayload}, false},
+		{"non-tracker error is not retryable", errors.New("boom"), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := isRetryable(tt.err)
+			if got != tt.want {
+				t.Errorf("isRetryable(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestWithRetry and TestRunPreflight below all touch the package-level
+// preflightBackoff (directly or through withRetry's internal read of its
+// length), so none of their subtests call t.Parallel(); they run serially
+// by default, avoiding any race on the shared slice.
+
+func TestWithRetry(t *testing.T) {
+	t.Run("succeeds on first try", func(t *testing.T) {
+		var calls int
+		err := withRetry(context.Background(), func() error {
+			calls++
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("withRetry: %v", err)
+		}
+		if calls != 1 {
+			t.Errorf("call count = %d, want 1", calls)
+		}
+	})
+
+	t.Run("non-retryable error returns immediately without retry", func(t *testing.T) {
+		var calls int
+		err := withRetry(context.Background(), func() error {
+			calls++
+			return &domain.TrackerError{Kind: domain.ErrTrackerAuth, Message: "bad token"}
+		})
+		assertTrackerErrorKind(t, err, domain.ErrTrackerAuth)
+		if calls != 1 {
+			t.Errorf("call count = %d, want 1 (non-retryable must not retry)", calls)
+		}
+	})
+
+	t.Run("retryable error retries the full schedule then fails", func(t *testing.T) {
+		fastPreflightBackoff(t)
+
+		var calls int
+		err := withRetry(context.Background(), func() error {
+			calls++
+			return &domain.TrackerError{Kind: domain.ErrTrackerTransport, Message: "boom"}
+		})
+		assertTrackerErrorKind(t, err, domain.ErrTrackerTransport)
+
+		wantCalls := len(preflightBackoff) + 1
+		if calls != wantCalls {
+			t.Errorf("call count = %d, want %d (initial + one per backoff entry)", calls, wantCalls)
+		}
+	})
+
+	t.Run("retryable error then success recovers", func(t *testing.T) {
+		fastPreflightBackoff(t)
+
+		var calls int
+		err := withRetry(context.Background(), func() error {
+			calls++
+			if calls < 2 {
+				return &domain.TrackerError{Kind: domain.ErrTrackerAPI, Message: "rate limited"}
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("withRetry should recover after one transient failure: %v", err)
+		}
+		if calls != 2 {
+			t.Errorf("call count = %d, want 2 (one retry then success)", calls)
+		}
+	})
+
+	t.Run("cancellation during backoff returns ctx.Err without waiting the schedule", func(t *testing.T) {
+		// Uses the production backoff schedule deliberately: the context is
+		// already cancelled before the call, so sleepContext returns
+		// immediately regardless of the configured delay.
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		var calls int
+		err := withRetry(ctx, func() error {
+			calls++
+			return &domain.TrackerError{Kind: domain.ErrTrackerTransport, Message: "boom"}
+		})
+		if !errors.Is(err, context.Canceled) {
+			t.Errorf("withRetry error = %v, want context.Canceled", err)
+		}
+		if calls != 1 {
+			t.Errorf("call count = %d, want 1 (cancellation must stop before a retry)", calls)
+		}
+	})
+}
+
+// preflightServer builds an httptest.Server simulating the two preflight
+// routes, with independently controllable status codes and atomic call
+// counters for the token and project checks.
+type preflightServer struct {
+	srv           *httptest.Server
+	tokenStatus   atomic.Int32
+	projectStatus atomic.Int32
+	tokenCalls    atomic.Int32
+	projectCalls  atomic.Int32
+}
+
+func newRawPreflightServer(t *testing.T) *preflightServer {
+	t.Helper()
+	ps := &preflightServer{}
+	ps.tokenStatus.Store(http.StatusOK)
+	ps.projectStatus.Store(http.StatusOK)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/personal_access_tokens/self", func(w http.ResponseWriter, r *http.Request) {
+		ps.tokenCalls.Add(1)
+		status := int(ps.tokenStatus.Load())
+		w.WriteHeader(status)
+		if status == http.StatusOK {
+			w.Write(loadFixture(t, "token_self.json")) //nolint:errcheck // test helper
+		}
+	})
+	mux.HandleFunc("/projects/"+testEscapedProject, func(w http.ResponseWriter, r *http.Request) {
+		ps.projectCalls.Add(1)
+		status := int(ps.projectStatus.Load())
+		w.WriteHeader(status)
+		if status == http.StatusNotFound {
+			w.Write(loadFixture(t, "error_404_project.json")) //nolint:errcheck // test helper
+		}
+	})
+
+	ps.srv = httptest.NewServer(mux)
+	t.Cleanup(ps.srv.Close)
+	return ps
+}
+
+func TestRunPreflight(t *testing.T) {
+	t.Run("succeeds when both routes return 200", func(t *testing.T) {
+		ps := newRawPreflightServer(t)
+		client := newGitLabClient(ps.srv.URL, "test-token", "sortie/test")
+
+		if err := runPreflight(context.Background(), client, testEscapedProject, slog.Default()); err != nil {
+			t.Fatalf("runPreflight: %v", err)
+		}
+		if got := ps.tokenCalls.Load(); got != 1 {
+			t.Errorf("token calls = %d, want 1", got)
+		}
+		if got := ps.projectCalls.Load(); got != 1 {
+			t.Errorf("project calls = %d, want 1", got)
+		}
+	})
+
+	t.Run("introspection failure alone does not block construction", func(t *testing.T) {
+		ps := newRawPreflightServer(t)
+		ps.tokenStatus.Store(http.StatusInternalServerError)
+		client := newGitLabClient(ps.srv.URL, "test-token", "sortie/test")
+
+		if err := runPreflight(context.Background(), client, testEscapedProject, slog.Default()); err != nil {
+			t.Fatalf("runPreflight: %v (introspection failure must not block a healthy project check)", err)
+		}
+		if got := ps.projectCalls.Load(); got != 1 {
+			t.Errorf("project calls = %d, want 1", got)
+		}
+	})
+
+	t.Run("401 on project check is a non-retryable auth error", func(t *testing.T) {
+		ps := newRawPreflightServer(t)
+		ps.projectStatus.Store(http.StatusUnauthorized)
+		client := newGitLabClient(ps.srv.URL, "test-token", "sortie/test")
+
+		err := runPreflight(context.Background(), client, testEscapedProject, slog.Default())
+		assertTrackerErrorKind(t, err, domain.ErrTrackerAuth)
+
+		if got := ps.projectCalls.Load(); got != 1 {
+			t.Errorf("project calls = %d, want 1 (auth error must not retry)", got)
+		}
+	})
+
+	t.Run("404 on project check is a non-retryable not-found error naming the introspection outcome", func(t *testing.T) {
+		ps := newRawPreflightServer(t)
+		ps.projectStatus.Store(http.StatusNotFound)
+		client := newGitLabClient(ps.srv.URL, "test-token", "sortie/test")
+
+		err := runPreflight(context.Background(), client, testEscapedProject, slog.Default())
+		assertTrackerErrorKind(t, err, domain.ErrTrackerNotFound)
+
+		if got := ps.projectCalls.Load(); got != 1 {
+			t.Errorf("project calls = %d, want 1 (not-found error must not retry)", got)
+		}
+	})
+
+	t.Run("transient error on project check retries then fails", func(t *testing.T) {
+		fastPreflightBackoff(t)
+
+		ps := newRawPreflightServer(t)
+		ps.projectStatus.Store(http.StatusInternalServerError)
+		client := newGitLabClient(ps.srv.URL, "test-token", "sortie/test")
+
+		err := runPreflight(context.Background(), client, testEscapedProject, slog.Default())
+		assertTrackerErrorKind(t, err, domain.ErrTrackerTransport)
+
+		wantCalls := int32(len(preflightBackoff) + 1)
+		if got := ps.projectCalls.Load(); got != wantCalls {
+			t.Errorf("project calls = %d, want %d (initial + one per backoff entry)", got, wantCalls)
+		}
+	})
+
+	t.Run("pre-cancelled context fails immediately with no request issued", func(t *testing.T) {
+		ps := newRawPreflightServer(t)
+		ps.projectStatus.Store(http.StatusInternalServerError)
+		client := newGitLabClient(ps.srv.URL, "test-token", "sortie/test")
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		err := runPreflight(ctx, client, testEscapedProject, slog.Default())
+		if !errors.Is(err, context.Canceled) {
+			t.Errorf("runPreflight error = %v, want context.Canceled", err)
+		}
+		if got := ps.projectCalls.Load(); got != 0 {
+			t.Errorf("project calls = %d, want 0 (a pre-cancelled context must not reach the network)", got)
+		}
+	})
+
+	t.Run("does not log the token", func(t *testing.T) {
+		ps := newRawPreflightServer(t)
+		ps.tokenStatus.Store(http.StatusInternalServerError)
+		client := newGitLabClient(ps.srv.URL, "super-secret-token", "sortie/test")
+
+		var buf bytes.Buffer
+		log := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+		if err := runPreflight(context.Background(), client, testEscapedProject, log); err != nil {
+			t.Fatalf("runPreflight: %v", err)
+		}
+		if strings.Contains(buf.String(), "super-secret-token") {
+			t.Errorf("runPreflight logged the token\noutput: %s", buf.String())
+		}
+	})
+}

--- a/internal/scm/gitlab/state.go
+++ b/internal/scm/gitlab/state.go
@@ -1,0 +1,64 @@
+package gitlab
+
+import (
+	"log/slog"
+	"strings"
+)
+
+// deriveState resolves the Sortie state from a GitLab issue's labels by
+// scanning the configured active, terminal, and handoff states in config
+// order. The first label match wins. When no state label is present, it
+// falls back to the first configured state matching the native
+// opened/closed status, or passes the native state through unchanged.
+//
+// The scan collects every matching state label before returning so an
+// issue carrying more than one configured state label is observable:
+// deriveState logs a WARN naming iid and the matched labels, then keeps
+// the first. If log is nil, [slog.Default] is used. Label comparison is
+// case-insensitive; activeStates, terminalStates, and handoffState are
+// expected already lowercased.
+func deriveState(labels []string, nativeState string, activeStates, terminalStates []string, handoffState, iid string, log *slog.Logger) string {
+	if log == nil {
+		log = slog.Default()
+	}
+
+	present := make(map[string]struct{}, len(labels))
+	for _, l := range labels {
+		present[strings.ToLower(l)] = struct{}{}
+	}
+
+	matched := make([]string, 0, len(activeStates)+len(terminalStates)+1)
+	for _, s := range activeStates {
+		if _, ok := present[s]; ok {
+			matched = append(matched, s)
+		}
+	}
+	for _, s := range terminalStates {
+		if _, ok := present[s]; ok {
+			matched = append(matched, s)
+		}
+	}
+	if handoffState != "" {
+		if _, ok := present[handoffState]; ok {
+			matched = append(matched, handoffState)
+		}
+	}
+
+	if len(matched) > 1 {
+		log.Warn("kept first of multiple matching state labels",
+			slog.String("iid", iid),
+			slog.Any("matched_labels", matched))
+	}
+	if len(matched) > 0 {
+		return matched[0]
+	}
+
+	if nativeState == "opened" && len(activeStates) > 0 {
+		return activeStates[0]
+	}
+	if nativeState == "closed" && len(terminalStates) > 0 {
+		return terminalStates[0]
+	}
+
+	return nativeState
+}

--- a/internal/scm/gitlab/state_test.go
+++ b/internal/scm/gitlab/state_test.go
@@ -1,0 +1,190 @@
+package gitlab
+
+import (
+	"bytes"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+func TestDeriveState(t *testing.T) {
+	t.Parallel()
+
+	active := []string{"backlog", "in-progress", "review"}
+	terminal := []string{"done", "wontfix"}
+
+	tests := []struct {
+		name           string
+		labels         []string
+		nativeState    string
+		activeStates   []string
+		terminalStates []string
+		handoffState   string
+		want           string
+	}{
+		{
+			name:           "single active label match",
+			labels:         []string{"in-progress"},
+			nativeState:    "opened",
+			activeStates:   active,
+			terminalStates: terminal,
+			want:           "in-progress",
+		},
+		{
+			name:           "single terminal label match",
+			labels:         []string{"done"},
+			nativeState:    "closed",
+			activeStates:   active,
+			terminalStates: terminal,
+			want:           "done",
+		},
+		{
+			// "backlog" precedes "review" in config order; backlog wins even
+			// though "review" appears first in the label slice.
+			name:           "multiple active labels first config-order wins",
+			labels:         []string{"review", "backlog"},
+			nativeState:    "opened",
+			activeStates:   active,
+			terminalStates: terminal,
+			want:           "backlog",
+		},
+		{
+			// Active-state scan runs before the terminal-state scan.
+			name:           "active label beats terminal label",
+			labels:         []string{"done", "backlog"},
+			nativeState:    "opened",
+			activeStates:   active,
+			terminalStates: terminal,
+			want:           "backlog",
+		},
+		{
+			name:           "no state label opened issue falls back to first active",
+			labels:         []string{"bug"},
+			nativeState:    "opened",
+			activeStates:   active,
+			terminalStates: terminal,
+			want:           "backlog",
+		},
+		{
+			name:           "no state label closed issue falls back to first terminal",
+			labels:         []string{"bug"},
+			nativeState:    "closed",
+			activeStates:   active,
+			terminalStates: terminal,
+			want:           "done",
+		},
+		{
+			name:           "empty config opened passes native state through",
+			labels:         nil,
+			nativeState:    "opened",
+			activeStates:   nil,
+			terminalStates: nil,
+			want:           "opened",
+		},
+		{
+			name:           "empty config closed passes native state through",
+			labels:         nil,
+			nativeState:    "closed",
+			activeStates:   nil,
+			terminalStates: nil,
+			want:           "closed",
+		},
+		{
+			name:           "uppercase label matches lowercase config",
+			labels:         []string{"IN-PROGRESS"},
+			nativeState:    "opened",
+			activeStates:   active,
+			terminalStates: terminal,
+			want:           "in-progress",
+		},
+		{
+			// A handoff label on an open issue must return the handoff
+			// state, not activeStates[0], so a handed-off issue is not
+			// re-dispatched as a fresh candidate.
+			name:           "handoff label only on an open issue",
+			labels:         []string{"review"},
+			nativeState:    "opened",
+			activeStates:   []string{"backlog", "in-progress"},
+			terminalStates: []string{"done"},
+			handoffState:   "review",
+			want:           "review",
+		},
+		{
+			name:           "handoff not configured falls back to active",
+			labels:         []string{"review"},
+			nativeState:    "opened",
+			activeStates:   []string{"backlog", "in-progress"},
+			terminalStates: []string{"done"},
+			handoffState:   "",
+			want:           "backlog",
+		},
+		{
+			// Active-state scan happens before the handoff check regardless
+			// of label order in the response.
+			name:           "active label beats handoff when both present",
+			labels:         []string{"in-progress", "review"},
+			nativeState:    "opened",
+			activeStates:   []string{"backlog", "in-progress"},
+			terminalStates: []string{"done"},
+			handoffState:   "review",
+			want:           "in-progress",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := deriveState(tt.labels, tt.nativeState, tt.activeStates, tt.terminalStates, tt.handoffState, "1", nil)
+			if got != tt.want {
+				t.Errorf("deriveState(%v, %q) = %q, want %q", tt.labels, tt.nativeState, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDeriveState_MultiMatchLogsWarning(t *testing.T) {
+	t.Parallel()
+
+	// Two distinct configured labels on one issue (an active label and a
+	// terminal label), not a handoff overlap: this is the config-drift
+	// case the WARN exists to surface.
+	labels := []string{"backlog", "done"}
+	active := []string{"backlog", "in-progress"}
+	terminal := []string{"done", "wontfix"}
+
+	var buf bytes.Buffer
+	log := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	got := deriveState(labels, "opened", active, terminal, "", "77", log)
+
+	// Active states are scanned before terminal states, so "backlog" is
+	// the first match and wins despite "done" also matching.
+	if got != "backlog" {
+		t.Errorf("deriveState(multi-match) = %q, want %q (first match by scan order)", got, "backlog")
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "kept first of multiple matching state labels") {
+		t.Errorf("log output missing multi-match WARN message\noutput: %s", output)
+	}
+	if !strings.Contains(output, "iid=77") {
+		t.Errorf("log output missing iid=77\noutput: %s", output)
+	}
+	if !strings.Contains(output, "backlog") || !strings.Contains(output, "done") {
+		t.Errorf("log output should name both matched labels (backlog, done)\noutput: %s", output)
+	}
+}
+
+func TestDeriveState_NilLoggerUsesDefaultWithoutPanic(t *testing.T) {
+	t.Parallel()
+
+	// A multi-match scenario with log=nil must fall back to slog.Default()
+	// rather than panic on a nil receiver.
+	labels := []string{"backlog", "done"}
+
+	got := deriveState(labels, "opened", []string{"backlog"}, []string{"done"}, "", "1", nil)
+	if got != "backlog" {
+		t.Errorf("deriveState(nil logger) = %q, want %q", got, "backlog")
+	}
+}

--- a/internal/scm/gitlab/testdata/error_400.json
+++ b/internal/scm/gitlab/testdata/error_400.json
@@ -1,0 +1,1 @@
+{"message": ["state does not have a valid value (opened, closed)"]}

--- a/internal/scm/gitlab/testdata/error_401.json
+++ b/internal/scm/gitlab/testdata/error_401.json
@@ -1,0 +1,1 @@
+{"message": "401 Unauthorized"}

--- a/internal/scm/gitlab/testdata/error_403.json
+++ b/internal/scm/gitlab/testdata/error_403.json
@@ -1,0 +1,1 @@
+{"error": "insufficient_scope", "error_description": "The request requires higher privileges than provided by the access token."}

--- a/internal/scm/gitlab/testdata/error_404_issue.json
+++ b/internal/scm/gitlab/testdata/error_404_issue.json
@@ -1,0 +1,1 @@
+{"message": "404 Not found"}

--- a/internal/scm/gitlab/testdata/error_404_project.json
+++ b/internal/scm/gitlab/testdata/error_404_project.json
@@ -1,0 +1,1 @@
+{"message": "404 Project Not Found"}

--- a/internal/scm/gitlab/testdata/error_500.json
+++ b/internal/scm/gitlab/testdata/error_500.json
@@ -1,0 +1,1 @@
+{"error": "Internal Server Error"}

--- a/internal/scm/gitlab/testdata/issue_full.json
+++ b/internal/scm/gitlab/testdata/issue_full.json
@@ -1,0 +1,20 @@
+{
+  "id": 91042,
+  "iid": 42,
+  "project_id": 5,
+  "title": "Add dark mode support",
+  "description": "Users want a **dark mode** option.",
+  "state": "opened",
+  "type": "ISSUE",
+  "issue_type": "issue",
+  "web_url": "https://gitlab.example.com/acme/widgets/-/issues/42",
+  "labels": ["In-Progress", "UI"],
+  "assignees": [
+    {"id": 11, "username": "alice", "name": "Alice Smith"},
+    {"id": 12, "username": "bob", "name": "Bob Jones"}
+  ],
+  "assignee": {"id": 13, "username": "carol", "name": "Carol White"},
+  "references": {"short": "#42", "relative": "#42", "full": "acme/widgets#42"},
+  "created_at": "2026-01-01T00:00:00.000+02:00",
+  "updated_at": "2026-01-02T00:00:00.000+02:00"
+}

--- a/internal/scm/gitlab/testdata/issue_incident.json
+++ b/internal/scm/gitlab/testdata/issue_incident.json
@@ -1,0 +1,16 @@
+{
+  "id": 91100,
+  "iid": 100,
+  "title": "Investigate production outage",
+  "description": "",
+  "state": "opened",
+  "type": "INCIDENT",
+  "issue_type": "incident",
+  "web_url": "https://gitlab.example.com/acme/widgets/-/issues/100",
+  "labels": [],
+  "assignees": [],
+  "assignee": null,
+  "references": {"short": "#100", "relative": "#100", "full": "acme/widgets#100"},
+  "created_at": "2026-01-05T00:00:00.000Z",
+  "updated_at": "2026-01-05T00:00:00.000Z"
+}

--- a/internal/scm/gitlab/testdata/issues_candidates_page1.json
+++ b/internal/scm/gitlab/testdata/issues_candidates_page1.json
@@ -1,0 +1,30 @@
+[
+  {
+    "id": 90008,
+    "iid": 8,
+    "title": "Fix pagination cache",
+    "description": "",
+    "state": "opened",
+    "web_url": "https://gitlab.example.com/acme/widgets/-/issues/8",
+    "labels": ["backlog"],
+    "assignees": [{"id": 21, "username": "dana"}],
+    "assignee": null,
+    "references": {},
+    "created_at": "2026-01-03T00:00:00.000Z",
+    "updated_at": "2026-01-03T00:00:00.000Z"
+  },
+  {
+    "id": 90006,
+    "iid": 6,
+    "title": "Investigate flaky pipeline",
+    "description": "",
+    "state": "opened",
+    "issue_type": "task",
+    "web_url": "https://gitlab.example.com/acme/widgets/-/issues/6",
+    "labels": [],
+    "assignees": [],
+    "references": {},
+    "created_at": "2026-01-03T00:05:00.000Z",
+    "updated_at": "2026-01-03T00:05:00.000Z"
+  }
+]

--- a/internal/scm/gitlab/testdata/issues_candidates_page2.json
+++ b/internal/scm/gitlab/testdata/issues_candidates_page2.json
@@ -1,0 +1,81 @@
+[
+  {
+    "id": 90001,
+    "iid": 1,
+    "title": "Add search filter",
+    "state": "opened",
+    "issue_type": "issue",
+    "web_url": "https://gitlab.example.com/acme/widgets/-/issues/1",
+    "labels": ["backlog"],
+    "assignees": [{"id": 22, "username": "erin"}],
+    "references": {},
+    "created_at": "2026-01-04T00:00:00.000Z",
+    "updated_at": "2026-01-04T00:00:00.000Z"
+  },
+  {
+    "id": 90003,
+    "iid": 3,
+    "title": "Fix logo alignment",
+    "state": "closed",
+    "issue_type": "issue",
+    "web_url": "https://gitlab.example.com/acme/widgets/-/issues/3",
+    "labels": ["done"],
+    "assignees": [],
+    "references": {},
+    "created_at": "2026-01-04T00:10:00.000Z",
+    "updated_at": "2026-01-04T00:10:00.000Z"
+  },
+  {
+    "id": 90002,
+    "iid": 2,
+    "title": "Improve error messages",
+    "state": "opened",
+    "issue_type": "issue",
+    "web_url": "https://gitlab.example.com/acme/widgets/-/issues/2",
+    "labels": ["in-progress"],
+    "assignees": [],
+    "references": {},
+    "created_at": "2026-01-04T00:20:00.000Z",
+    "updated_at": "2026-01-04T00:20:00.000Z"
+  },
+  {
+    "id": 90005,
+    "iid": 5,
+    "title": "Update dependency versions",
+    "state": "opened",
+    "issue_type": "issue",
+    "web_url": "https://gitlab.example.com/acme/widgets/-/issues/5",
+    "labels": [],
+    "assignees": [],
+    "references": {},
+    "created_at": "2026-01-04T00:30:00.000Z",
+    "updated_at": "2026-01-04T00:30:00.000Z"
+  },
+  {
+    "id": 90004,
+    "iid": 4,
+    "title": "Archive old exports",
+    "state": "closed",
+    "issue_type": "issue",
+    "web_url": "https://gitlab.example.com/acme/widgets/-/issues/4",
+    "labels": [],
+    "assignees": [],
+    "references": {},
+    "created_at": "2026-01-04T00:40:00.000Z",
+    "updated_at": "2026-01-04T00:40:00.000Z"
+  },
+  {
+    "id": 90007,
+    "iid": 7,
+    "title": "Consolidate config loader",
+    "state": "opened",
+    "issue_type": "issue",
+    "web_url": "https://gitlab.example.com/acme/widgets/-/issues/7",
+    "labels": ["backlog", "done"],
+    "assignees": [{"id": 23, "username": "frank"}],
+    "assignee": {"id": 24, "username": "gina"},
+    "references": {},
+    "created_at": "2026-01-04T00:50:00.000Z",
+    "updated_at": "2026-01-04T00:50:00.000Z"
+  }
+]

--- a/internal/scm/gitlab/testdata/issues_closed_by_states.json
+++ b/internal/scm/gitlab/testdata/issues_closed_by_states.json
@@ -1,0 +1,3 @@
+[
+  {"id": 91020, "iid": 20, "title": "Retire legacy export", "state": "closed", "issue_type": "issue", "web_url": "https://gitlab.example.com/acme/widgets/-/issues/20", "labels": ["done"], "assignees": [], "references": {"full": "acme/widgets#20"}, "created_at": "2026-01-07T00:00:00.000Z", "updated_at": "2026-01-07T00:00:00.000Z"}
+]

--- a/internal/scm/gitlab/testdata/issues_open_by_states.json
+++ b/internal/scm/gitlab/testdata/issues_open_by_states.json
@@ -1,0 +1,3 @@
+[
+  {"id": 91010, "iid": 10, "title": "Improve login flow", "state": "opened", "issue_type": "issue", "web_url": "https://gitlab.example.com/acme/widgets/-/issues/10", "labels": ["in-progress"], "assignees": [], "references": {"full": "acme/widgets#10"}, "created_at": "2026-01-06T00:00:00.000Z", "updated_at": "2026-01-06T00:00:00.000Z"}
+]

--- a/internal/scm/gitlab/testdata/issues_paginate_page1.json
+++ b/internal/scm/gitlab/testdata/issues_paginate_page1.json
@@ -1,0 +1,4 @@
+[
+  {"id": 80101, "iid": 101, "title": "Paginate item A", "state": "opened", "issue_type": "issue", "web_url": "https://gitlab.example.com/acme/widgets/-/issues/101", "labels": [], "assignees": [], "references": {"full": "acme/widgets#101"}, "created_at": "2026-02-01T00:00:00.000Z", "updated_at": "2026-02-01T00:00:00.000Z"},
+  {"id": 80102, "iid": 102, "title": "Paginate item B", "state": "opened", "issue_type": "issue", "web_url": "https://gitlab.example.com/acme/widgets/-/issues/102", "labels": [], "assignees": [], "references": {"full": "acme/widgets#102"}, "created_at": "2026-02-01T00:01:00.000Z", "updated_at": "2026-02-01T00:01:00.000Z"}
+]

--- a/internal/scm/gitlab/testdata/issues_paginate_page2.json
+++ b/internal/scm/gitlab/testdata/issues_paginate_page2.json
@@ -1,0 +1,4 @@
+[
+  {"id": 80103, "iid": 103, "title": "Paginate item C", "state": "opened", "issue_type": "issue", "web_url": "https://gitlab.example.com/acme/widgets/-/issues/103", "labels": [], "assignees": [], "references": {"full": "acme/widgets#103"}, "created_at": "2026-02-01T00:02:00.000Z", "updated_at": "2026-02-01T00:02:00.000Z"},
+  {"id": 80104, "iid": 104, "title": "Paginate item D", "state": "opened", "issue_type": "issue", "web_url": "https://gitlab.example.com/acme/widgets/-/issues/104", "labels": [], "assignees": [], "references": {"full": "acme/widgets#104"}, "created_at": "2026-02-01T00:03:00.000Z", "updated_at": "2026-02-01T00:03:00.000Z"}
+]

--- a/internal/scm/gitlab/testdata/issues_paginate_page3.json
+++ b/internal/scm/gitlab/testdata/issues_paginate_page3.json
@@ -1,0 +1,3 @@
+[
+  {"id": 80105, "iid": 105, "title": "Paginate item E", "state": "opened", "issue_type": "issue", "web_url": "https://gitlab.example.com/acme/widgets/-/issues/105", "labels": [], "assignees": [], "references": {"full": "acme/widgets#105"}, "created_at": "2026-02-01T00:04:00.000Z", "updated_at": "2026-02-01T00:04:00.000Z"}
+]

--- a/internal/scm/gitlab/testdata/notes_page1.json
+++ b/internal/scm/gitlab/testdata/notes_page1.json
@@ -1,0 +1,26 @@
+[
+  {
+    "id": 501,
+    "type": null,
+    "body": "Started investigating the failure.",
+    "author": {"id": 11, "username": "alice", "name": "Alice Smith"},
+    "created_at": "2026-01-10T09:00:00.000Z",
+    "updated_at": "2026-01-10T09:00:00.000Z",
+    "system": false,
+    "internal": false,
+    "noteable_type": "Issue",
+    "resolvable": false
+  },
+  {
+    "id": 502,
+    "type": null,
+    "body": "changed the description",
+    "author": {"id": 99, "username": "sortie-bot", "name": "Sortie Bot"},
+    "created_at": "2026-01-10T09:05:00.000Z",
+    "updated_at": "2026-01-10T09:05:00.000Z",
+    "system": true,
+    "internal": false,
+    "noteable_type": "Issue",
+    "resolvable": false
+  }
+]

--- a/internal/scm/gitlab/testdata/notes_page2.json
+++ b/internal/scm/gitlab/testdata/notes_page2.json
@@ -1,0 +1,26 @@
+[
+  {
+    "id": 503,
+    "type": null,
+    "body": "Confidential rollback details for the fix.",
+    "author": {"id": 12, "username": "bob", "name": "Bob Jones"},
+    "created_at": "2026-01-10T10:00:00.000Z",
+    "updated_at": "2026-01-10T10:00:00.000Z",
+    "system": false,
+    "internal": true,
+    "noteable_type": "Issue",
+    "resolvable": false
+  },
+  {
+    "id": 504,
+    "type": null,
+    "body": "Looks good, merging soon.",
+    "author": {"id": 11, "username": "alice", "name": "Alice Smith"},
+    "created_at": "2026-01-10T10:15:00.000Z",
+    "updated_at": "2026-01-10T10:15:00.000Z",
+    "system": false,
+    "internal": false,
+    "noteable_type": "Issue",
+    "resolvable": false
+  }
+]

--- a/internal/scm/gitlab/testdata/token_self.json
+++ b/internal/scm/gitlab/testdata/token_self.json
@@ -1,0 +1,10 @@
+{
+  "id": 7,
+  "name": "sortie-ci",
+  "revoked": false,
+  "created_at": "2026-01-01T00:00:00.000Z",
+  "scopes": ["api", "read_api"],
+  "user_id": 3,
+  "active": true,
+  "expires_at": "2027-01-01"
+}


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Feat

**Intent:** Add the read path of a GitLab tracker adapter so sortie can poll GitLab.com or a self-managed GitLab instance for candidate issues, single issues, state reconciliation, and comments, using the same `domain.TrackerAdapter` contract as the Jira, Linear, GitHub, and Gitea adapters.

**Related Issues:** #676

### 🧭 Reviewer Guide

**Complexity:** Medium

#### Entry Point

Start with `internal/scm/gitlab/gitlab.go`. It defines `GitLabAdapter`, the `init()` registration under kind `"gitlab"`, and the six read methods required by `domain.TrackerAdapter`: `FetchCandidateIssues`, `FetchIssueByID`, `FetchIssuesByStates`, `FetchIssueStatesByIDs`, `FetchIssueStatesByIdentifiers`, and `FetchIssueComments`. It ties together the REST client (`client.go`), response normalization (`normalize.go`), state derivation from labels (`state.go`), and the constructor preflight (`preflight.go`).

#### Sensitive Areas

- `internal/scm/gitlab/preflight.go`: runs the two-call startup check (advisory token introspection, then an authoritative project lookup) that fails adapter construction on an unreachable project - misconfiguration should surface at startup, not on the first poll.
- `internal/scm/gitlab/normalize.go`: derives issue identity from the project-scoped `iid` rather than the instance-global `id`, and fills fields GitLab has no equivalent for (priority, parent, blocked_by) with adapter-defined defaults rather than nulls.
- `internal/scm/gitlab/client.go`: the only place issuing HTTP requests; separates the client interface from the transport so the adapter is testable without network access, and reuses the shared `httpkit` paginator for GitLab's pagination.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes.
- **Migrations/State:** No migrations or state changes.
