### PR TITLE
feat(scm/gitlab): add write-side tracker adapter operations

### DIFF
--- a/internal/scm/gitlab/gitlab.go
+++ b/internal/scm/gitlab/gitlab.go
@@ -9,11 +9,14 @@
 // blocked_by always a non-nil empty slice (GitLab Community Edition has no
 // blocks relation type).
 //
-// The constructor runs a two-call preflight, an advisory token
-// introspection followed by an authoritative project check, that fails
-// construction on an unreachable project, so a misconfiguration surfaces
-// at startup rather than on the first poll. Registered under kind "gitlab"
-// via an init function.
+// The constructor runs a preflight of an advisory token introspection, an
+// authoritative project check, and, when any state label is configured, a
+// paginated project label catalog read that resolves the canonical stored
+// casing of every configured state label, so a write never attaches a
+// case variant of a label the project already holds. A failed project
+// check or a failed catalog read fails construction, so a misconfiguration
+// surfaces at startup rather than on the first poll. Registered under kind
+// "gitlab" via an init function.
 //
 // This package sits under the source-control adapter family, but this
 // stage implements only the tracker contract: the source-control and CI
@@ -21,11 +24,15 @@
 package gitlab
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"net/http"
 	"net/url"
+	"slices"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -77,6 +84,12 @@ type GitLabAdapter struct {
 	handoffState   string
 	log            *slog.Logger
 	metrics        domain.Metrics
+
+	// stateLabelCasing maps the lowercased form of each configured state
+	// label to the casing stored in the project, so a write never attaches a
+	// case variant of an existing label. A configured name absent from the
+	// project has no entry and is sent as configured, which creates it.
+	stateLabelCasing map[string]string
 }
 
 // NewGitLabAdapter creates a [GitLabAdapter] from adapter configuration and
@@ -164,19 +177,44 @@ func NewGitLabAdapter(config map[string]any) (domain.TrackerAdapter, error) {
 	client := newGitLabClient(baseURL, apiKey, userAgent)
 	log := slog.Default()
 
-	if err := runPreflight(context.Background(), client, projectPath, log); err != nil {
+	configuredStates := configuredStateNames(activeStates, terminalStates, handoffState)
+	stateLabelCasing, err := runPreflight(context.Background(), client, projectPath, configuredStates, log)
+	if err != nil {
 		return nil, err
 	}
 
 	return &GitLabAdapter{
-		client:         client,
-		project:        project,
-		projectPath:    projectPath,
-		activeStates:   activeStates,
-		terminalStates: terminalStates,
-		handoffState:   handoffState,
-		log:            log,
+		client:           client,
+		project:          project,
+		projectPath:      projectPath,
+		activeStates:     activeStates,
+		terminalStates:   terminalStates,
+		handoffState:     handoffState,
+		log:              log,
+		stateLabelCasing: stateLabelCasing,
 	}, nil
+}
+
+// configuredStateNames returns the union of activeStates, terminalStates,
+// and a non-empty handoffState, in that order, for the preflight's
+// label-catalog resolution. Callers already lowercase every element.
+func configuredStateNames(activeStates, terminalStates []string, handoffState string) []string {
+	names := make([]string, 0, len(activeStates)+len(terminalStates)+1)
+	names = append(names, activeStates...)
+	names = append(names, terminalStates...)
+	if handoffState != "" {
+		names = append(names, handoffState)
+	}
+	return names
+}
+
+// canonicalLabel returns the stored casing of lowered when
+// stateLabelCasing knows it, else lowered unchanged.
+func (a *GitLabAdapter) canonicalLabel(lowered string) string {
+	if casing, ok := a.stateLabelCasing[lowered]; ok {
+		return casing
+	}
+	return lowered
 }
 
 // SetMetrics configures the metrics recorder for tracker API call
@@ -601,29 +639,249 @@ func (a *GitLabAdapter) FetchIssueStatesByIdentifiers(ctx context.Context, ident
 	return states, err
 }
 
-// TransitionIssue returns [domain.ErrTrackerPayload] and issues no
-// request. The GitLab write path is not implemented yet.
-func (a *GitLabAdapter) TransitionIssue(_ context.Context, _, _ string) error {
-	return &domain.TrackerError{
-		Kind:    domain.ErrTrackerPayload,
-		Message: "gitlab: write path is not implemented yet",
-	}
+// gitlabIssueUpdate is the JSON body of the one issue-update route a
+// transition and a label attach both use. A zero field is omitted, which
+// is what lets [GitLabAdapter.TransitionIssue] send only the fields a
+// given transition actually changes. The field order matches the wire
+// examples this adapter's tests assert against.
+type gitlabIssueUpdate struct {
+	StateEvent   string   `json:"state_event,omitempty"`
+	AddLabels    []string `json:"add_labels,omitempty"`
+	RemoveLabels []string `json:"remove_labels,omitempty"`
 }
 
-// CommentIssue returns [domain.ErrTrackerPayload] and issues no request.
-// The GitLab write path is not implemented yet.
-func (a *GitLabAdapter) CommentIssue(_ context.Context, _, _ string) error {
-	return &domain.TrackerError{
-		Kind:    domain.ErrTrackerPayload,
-		Message: "gitlab: write path is not implemented yet",
-	}
+// TransitionIssue moves an issue to targetState by swapping its state
+// label and reconciling the native open/closed status in one PUT request.
+// targetState is compared case-insensitively against the configured
+// active, terminal, and handoff states; a value matching none of them, or
+// an empty string, returns [domain.ErrTrackerPayload] before any request.
+// issueID is guarded through [parseIID] before the GET; a rejected value,
+// a missing iid, or an entity whose issue_type is set and is not "issue"
+// returns [domain.ErrTrackerNotFound].
+//
+// Every case variant of the label being replaced, and any pre-existing
+// variant of the label being attached, is cleared in the same request, so
+// a project already holding a case-duplicate label does not accumulate
+// state labels on every transition. A transition that is already
+// converged issues no PUT and returns nil.
+func (a *GitLabAdapter) TransitionIssue(ctx context.Context, issueID, targetState string) error {
+	return trackermetrics.Track(a.metrics, "transition", func() error {
+		targetLower := strings.ToLower(targetState)
+		isHandoffTarget := a.handoffState != "" && targetLower == a.handoffState
+		if !slices.Contains(a.activeStates, targetLower) &&
+			!slices.Contains(a.terminalStates, targetLower) &&
+			!isHandoffTarget {
+			return &domain.TrackerError{
+				Kind:    domain.ErrTrackerPayload,
+				Message: fmt.Sprintf("invalid target state: %q is not a configured active, terminal, or handoff state", targetState),
+			}
+		}
+
+		n, ok := parseIID(issueID)
+		if !ok {
+			return &domain.TrackerError{
+				Kind:    domain.ErrTrackerNotFound,
+				Message: fmt.Sprintf("issue not found: %s", issueID),
+			}
+		}
+		path := "/projects/" + a.projectPath + "/issues/" + strconv.Itoa(n)
+
+		body, _, err := a.client.Get(ctx, path, nil)
+		if err != nil {
+			if domain.IsNotFound(err) {
+				return &domain.TrackerError{
+					Kind:    domain.ErrTrackerNotFound,
+					Message: fmt.Sprintf("issue not found: %s", issueID),
+				}
+			}
+			return err
+		}
+
+		var gi gitlabIssue
+		if err := json.Unmarshal(body, &gi); err != nil {
+			return &domain.TrackerError{
+				Kind:    domain.ErrTrackerPayload,
+				Message: "failed to parse issue response",
+				Err:     err,
+			}
+		}
+		if gi.IssueType != "" && gi.IssueType != "issue" {
+			return &domain.TrackerError{
+				Kind:    domain.ErrTrackerNotFound,
+				Message: fmt.Sprintf("not an issue: %s", issueID),
+			}
+		}
+
+		currentLower := findCurrentStateLabel(gi.Labels, a.activeStates, a.terminalStates, a.handoffState)
+
+		var addLabels, removeLabels []string
+		if currentLower != targetLower {
+			target := a.canonicalLabel(targetLower)
+			addLabels = []string{target}
+			if currentLower != "" {
+				removeLabels = append(removeLabels, labelVariants(gi.Labels, currentLower)...)
+			}
+			for _, variant := range labelVariants(gi.Labels, targetLower) {
+				if variant != target {
+					removeLabels = append(removeLabels, variant)
+				}
+			}
+		}
+
+		stateEvent := ""
+		switch {
+		case slices.Contains(a.terminalStates, targetLower) && gi.State == "opened":
+			stateEvent = "close"
+		case slices.Contains(a.activeStates, targetLower) && gi.State == "closed":
+			stateEvent = "reopen"
+		}
+
+		if len(addLabels) == 0 && len(removeLabels) == 0 && stateEvent == "" {
+			return nil
+		}
+
+		payload, err := json.Marshal(gitlabIssueUpdate{
+			StateEvent:   stateEvent,
+			AddLabels:    addLabels,
+			RemoveLabels: removeLabels,
+		})
+		if err != nil {
+			return &domain.TrackerError{
+				Kind:    domain.ErrTrackerPayload,
+				Message: "failed to marshal transition payload",
+				Err:     err,
+			}
+		}
+
+		_, err = a.client.Send(ctx, http.MethodPut, path, bytes.NewReader(payload))
+		return err
+	})
 }
 
-// AddLabel returns [domain.ErrTrackerPayload] and issues no request. The
-// GitLab write path is not implemented yet.
-func (a *GitLabAdapter) AddLabel(_ context.Context, _, _ string) error {
-	return &domain.TrackerError{
-		Kind:    domain.ErrTrackerPayload,
-		Message: "gitlab: write path is not implemented yet",
-	}
+// CommentIssue posts text verbatim as a new issue note. No Markdown
+// conversion, no escaping, and no truncation are applied. issueID is
+// guarded through [parseIID] before any request; a rejected value or a
+// missing iid returns [domain.ErrTrackerNotFound].
+//
+// GitLab executes a recognized slash command found at the start of a
+// line in the note body as a quick action. When the body was consumed
+// entirely as quick actions, GitLab creates no note and this method
+// returns [domain.ErrTrackerPayload] rather than reporting a false
+// success. Whenever GitLab executed one or more quick actions, whether or
+// not a note was also created, the executed command keys are logged at
+// WARN; the note text itself is never logged.
+func (a *GitLabAdapter) CommentIssue(ctx context.Context, issueID, text string) error {
+	return trackermetrics.Track(a.metrics, "comment", func() error {
+		n, ok := parseIID(issueID)
+		if !ok {
+			return &domain.TrackerError{
+				Kind:    domain.ErrTrackerNotFound,
+				Message: fmt.Sprintf("issue not found: %s", issueID),
+			}
+		}
+		path := "/projects/" + a.projectPath + "/issues/" + strconv.Itoa(n) + "/notes"
+
+		payload, err := json.Marshal(map[string]string{"body": text})
+		if err != nil {
+			return &domain.TrackerError{
+				Kind:    domain.ErrTrackerPayload,
+				Message: "failed to marshal comment payload",
+				Err:     err,
+			}
+		}
+
+		respBody, err := a.client.Send(ctx, http.MethodPost, path, bytes.NewReader(payload))
+		if err != nil {
+			return err
+		}
+
+		var created gitlabNoteCreated
+		if err := json.Unmarshal(respBody, &created); err != nil {
+			return &domain.TrackerError{
+				Kind:    domain.ErrTrackerPayload,
+				Message: "failed to parse note-creation response",
+				Err:     err,
+			}
+		}
+
+		if len(created.CommandsChanges) > 0 {
+			keys := make([]string, 0, len(created.CommandsChanges))
+			for key := range created.CommandsChanges {
+				keys = append(keys, key)
+			}
+			sort.Strings(keys)
+			a.log.Warn("gitlab executed quick actions in a comment body",
+				slog.String("iid", strconv.Itoa(n)),
+				slog.Any("commands", keys))
+		}
+
+		if created.ID == nil {
+			return &domain.TrackerError{
+				Kind:    domain.ErrTrackerPayload,
+				Message: fmt.Sprintf("gitlab created no note for issue %s: the comment body was consumed as quick actions", issueID),
+			}
+		}
+		return nil
+	})
+}
+
+// AddLabel attaches label to the issue, resolving its canonical stored
+// casing against the project label catalog first. issueID is guarded
+// through [parseIID] before any request; a rejected value or a missing
+// iid returns [domain.ErrTrackerNotFound]. An empty or whitespace-only
+// label attaches nothing, issues no request, returns nil, and logs a
+// WARN, so a caller reading nil as a successful escalation is not the
+// only record of the condition.
+//
+// The catalog is read fresh on every call, never from the
+// construction-time casing map, because an escalation label is not a
+// tracker-config value the constructor ever saw. A catalog read failure
+// does not fail the attach: the adapter logs a WARN and proceeds with the
+// label as given, because a missed escalation is worse than a cosmetic
+// duplicate. The label is never lowercased: GitLab resolves case
+// mismatches through the catalog, and lowercasing here would itself
+// create the case-variant duplicate the catalog resolution exists to
+// prevent. The attach is additive and may create the label as a
+// server-side side effect when it does not already exist.
+func (a *GitLabAdapter) AddLabel(ctx context.Context, issueID, label string) error {
+	return trackermetrics.Track(a.metrics, "add_label", func() error {
+		n, ok := parseIID(issueID)
+		if !ok {
+			return &domain.TrackerError{
+				Kind:    domain.ErrTrackerNotFound,
+				Message: fmt.Sprintf("issue not found: %s", issueID),
+			}
+		}
+
+		name := strings.TrimSpace(label)
+		if name == "" {
+			a.log.Warn("gitlab add_label received an empty label; nothing attached",
+				slog.String("iid", strconv.Itoa(n)))
+			return nil
+		}
+
+		catalog, err := fetchProjectLabels(ctx, a.client, a.projectPath, a.log)
+		if err != nil {
+			a.log.Warn("gitlab label catalog unavailable; attaching the configured spelling",
+				slog.Any("error", err))
+		} else {
+			casing := resolveCasing(catalog, []string{strings.ToLower(name)})
+			if stored, ok := casing[strings.ToLower(name)]; ok {
+				name = stored
+			}
+		}
+
+		path := "/projects/" + a.projectPath + "/issues/" + strconv.Itoa(n)
+		payload, err := json.Marshal(gitlabIssueUpdate{AddLabels: []string{name}})
+		if err != nil {
+			return &domain.TrackerError{
+				Kind:    domain.ErrTrackerPayload,
+				Message: "failed to marshal add-label payload",
+				Err:     err,
+			}
+		}
+
+		_, err = a.client.Send(ctx, http.MethodPut, path, bytes.NewReader(payload))
+		return err
+	})
 }

--- a/internal/scm/gitlab/gitlab.go
+++ b/internal/scm/gitlab/gitlab.go
@@ -865,7 +865,7 @@ func (a *GitLabAdapter) AddLabel(ctx context.Context, issueID, label string) err
 			a.log.Warn("gitlab label catalog unavailable; attaching the configured spelling",
 				slog.Any("error", err))
 		} else {
-			casing := resolveCasing(catalog, []string{strings.ToLower(name)})
+			casing := resolveCasing(catalog, []string{name})
 			if stored, ok := casing[strings.ToLower(name)]; ok {
 				name = stored
 			}

--- a/internal/scm/gitlab/gitlab_test.go
+++ b/internal/scm/gitlab/gitlab_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"maps"
 	"net/http"
@@ -90,12 +91,17 @@ func newFakeServer(t *testing.T) *fakeServer {
 	return &fakeServer{t: t, routes: make(map[string]http.HandlerFunc)}
 }
 
-// handle registers fn for a GET request against escapedPath. Every route
-// this suite exercises is a GET; a non-GET request (a write stub issuing a
-// request it must not issue) falls through to ServeHTTP's unmatched-route
-// failure regardless.
+// handleMethod registers fn for a request matching method against
+// escapedPath, so a PUT or POST route registers and dispatches exactly
+// like a GET route.
+func (s *fakeServer) handleMethod(method, escapedPath string, fn http.HandlerFunc) {
+	s.routes[method+" "+escapedPath] = fn
+}
+
+// handle registers fn for a GET request against escapedPath, the
+// shorthand every read-path test uses.
 func (s *fakeServer) handle(escapedPath string, fn http.HandlerFunc) {
-	s.routes[http.MethodGet+" "+escapedPath] = fn
+	s.handleMethod(http.MethodGet, escapedPath, fn)
 }
 
 func (s *fakeServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -108,10 +114,11 @@ func (s *fakeServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNotFound)
 }
 
-// withPreflight registers the two construction-preflight routes for
-// project on s. Every test that constructs an adapter must install both
-// before the operation under test, because [NewGitLabAdapter] runs the
-// preflight synchronously.
+// withPreflight registers the three construction-preflight routes for
+// project on s. Every test that constructs an adapter must install all
+// three before the operation under test, because [NewGitLabAdapter] runs
+// the preflight synchronously and, with the stock default state lists in
+// effect, always performs the label-catalog read.
 func withPreflight(t *testing.T, s *fakeServer, project string) {
 	t.Helper()
 	escaped := url.PathEscape(project)
@@ -124,9 +131,13 @@ func withPreflight(t *testing.T, s *fakeServer, project string) {
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte(`{}`)) //nolint:errcheck // test helper
 	})
+	s.handle("/api/v4/projects/"+escaped+"/labels", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`[]`)) //nolint:errcheck // test helper
+	})
 }
 
-// newPreflightServer returns a [fakeServer] pre-registered with the two
+// newPreflightServer returns a [fakeServer] pre-registered with the three
 // construction-preflight routes for [testProject]. Callers register only
 // the routes their operation under test exercises.
 func newPreflightServer(t *testing.T) *fakeServer {
@@ -138,8 +149,8 @@ func newPreflightServer(t *testing.T) *fakeServer {
 
 // mustAdapter starts an httptest.Server for s and constructs a
 // [*GitLabAdapter] against it for [testProject], registering server
-// cleanup. s must already carry the two construction-preflight routes; see
-// [newPreflightServer].
+// cleanup. s must already carry the three construction-preflight routes;
+// see [newPreflightServer].
 func mustAdapter(t *testing.T, s *fakeServer) *GitLabAdapter {
 	t.Helper()
 	srv := httptest.NewServer(s)
@@ -152,6 +163,36 @@ func mustAdapter(t *testing.T, s *fakeServer) *GitLabAdapter {
 		t.Fatalf("NewGitLabAdapter: %v", err)
 	}
 	return a.(*GitLabAdapter)
+}
+
+// mustAdapterWithConfig behaves like [mustAdapter] but merges overrides
+// onto [validConfig] before construction, letting a test customize state
+// lists, handoff_state, or any other adapter config key. s must already
+// carry the three construction-preflight routes.
+func mustAdapterWithConfig(t *testing.T, s *fakeServer, overrides map[string]any) *GitLabAdapter {
+	t.Helper()
+	srv := httptest.NewServer(s)
+	t.Cleanup(srv.Close)
+
+	cfg := validConfig(testProject)
+	cfg["endpoint"] = srv.URL
+	maps.Copy(cfg, overrides)
+	a, err := NewGitLabAdapter(cfg)
+	if err != nil {
+		t.Fatalf("NewGitLabAdapter: %v", err)
+	}
+	return a.(*GitLabAdapter)
+}
+
+// readRequestBody reads and returns r's full body, failing the test if the
+// read itself fails.
+func readRequestBody(t *testing.T, r *http.Request) []byte {
+	t.Helper()
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		t.Fatalf("reading request body: %v", err)
+	}
+	return body
 }
 
 // loweredStates returns a lowercased copy of states, matching the
@@ -432,6 +473,10 @@ func TestProjectPathPercentEncoding(t *testing.T) {
 			gotPath = r.URL.EscapedPath()
 			w.WriteHeader(http.StatusOK)
 			w.Write([]byte(`{}`)) //nolint:errcheck // test helper
+		})
+		s.handle("/api/v4/projects/"+escaped+"/labels", func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`[]`)) //nolint:errcheck // test helper
 		})
 		srv := httptest.NewServer(s)
 		defer srv.Close()
@@ -1379,28 +1424,561 @@ func TestFetchIssueStatesByIdentifiers(t *testing.T) {
 	})
 }
 
-// --- Write stubs ---
+// --- TransitionIssue ---
 
-func TestWriteStubs(t *testing.T) {
+func TestTransitionIssue(t *testing.T) {
 	t.Parallel()
 
-	a := mustAdapter(t, newPreflightServer(t)) // no write route registered; any call fails the test
+	t.Run("active to terminal transition swaps the state label and closes the issue", func(t *testing.T) {
+		t.Parallel()
 
-	if err := a.TransitionIssue(context.Background(), "1", "done"); err == nil {
-		t.Error("TransitionIssue = nil, want ErrTrackerPayload")
-	} else {
+		s := newPreflightServer(t)
+		var getCalls, putCalls atomic.Int32
+		var putBody []byte
+		s.handle("/api/v4/projects/"+testEscapedProject+"/issues/42", func(w http.ResponseWriter, r *http.Request) {
+			getCalls.Add(1)
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"iid":42,"state":"opened","issue_type":"issue","labels":["review"]}`)) //nolint:errcheck // test helper
+		})
+		s.handleMethod(http.MethodPut, "/api/v4/projects/"+testEscapedProject+"/issues/42", func(w http.ResponseWriter, r *http.Request) {
+			putCalls.Add(1)
+			putBody = readRequestBody(t, r)
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{}`)) //nolint:errcheck // test helper
+		})
+		a := mustAdapter(t, s)
+
+		if err := a.TransitionIssue(context.Background(), "42", "done"); err != nil {
+			t.Fatalf("TransitionIssue: %v", err)
+		}
+		if got := getCalls.Load(); got != 1 {
+			t.Errorf("GET call count = %d, want 1", got)
+		}
+		if got := putCalls.Load(); got != 1 {
+			t.Errorf("PUT call count = %d, want 1", got)
+		}
+		want := `{"state_event":"close","add_labels":["done"],"remove_labels":["review"]}`
+		if string(putBody) != want {
+			t.Errorf("PUT body = %s, want %s", putBody, want)
+		}
+	})
+
+	t.Run("handoff target also configured active leaves native state untouched", func(t *testing.T) {
+		t.Parallel()
+
+		s := newPreflightServer(t)
+		var putBody []byte
+		s.handle("/api/v4/projects/"+testEscapedProject+"/issues/7", func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"iid":7,"state":"opened","issue_type":"issue","labels":["backlog"]}`)) //nolint:errcheck // test helper
+		})
+		s.handleMethod(http.MethodPut, "/api/v4/projects/"+testEscapedProject+"/issues/7", func(w http.ResponseWriter, r *http.Request) {
+			putBody = readRequestBody(t, r)
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{}`)) //nolint:errcheck // test helper
+		})
+		a := mustAdapterWithConfig(t, s, map[string]any{"handoff_state": "review"})
+
+		if err := a.TransitionIssue(context.Background(), "7", "review"); err != nil {
+			t.Fatalf("TransitionIssue: %v", err)
+		}
+		want := `{"add_labels":["review"],"remove_labels":["backlog"]}`
+		if string(putBody) != want {
+			t.Errorf("PUT body = %s, want %s (no state_event: review is also an active state and the issue is already open)", putBody, want)
+		}
+	})
+
+	t.Run("handoff target outside both lists leaves a closed issue closed", func(t *testing.T) {
+		t.Parallel()
+
+		s := newPreflightServer(t)
+		var putBody []byte
+		s.handle("/api/v4/projects/"+testEscapedProject+"/issues/9", func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"iid":9,"state":"closed","issue_type":"issue","labels":["done"]}`)) //nolint:errcheck // test helper
+		})
+		s.handleMethod(http.MethodPut, "/api/v4/projects/"+testEscapedProject+"/issues/9", func(w http.ResponseWriter, r *http.Request) {
+			putBody = readRequestBody(t, r)
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{}`)) //nolint:errcheck // test helper
+		})
+		a := mustAdapterWithConfig(t, s, map[string]any{
+			"active_states":   []string{"backlog", "in-progress"},
+			"terminal_states": []string{"done", "wontfix"},
+			"handoff_state":   "needs-review",
+		})
+
+		if err := a.TransitionIssue(context.Background(), "9", "needs-review"); err != nil {
+			t.Fatalf("TransitionIssue: %v", err)
+		}
+		want := `{"add_labels":["needs-review"],"remove_labels":["done"]}`
+		if string(putBody) != want {
+			t.Errorf("PUT body = %s, want %s (no state_event: a handoff-only target never drives native state, and the issue stays closed)", putBody, want)
+		}
+	})
+
+	t.Run("invalid target state rejected before any request", func(t *testing.T) {
+		t.Parallel()
+
+		tests := []string{"", "not-a-configured-state"}
+		for _, target := range tests {
+			t.Run(fmt.Sprintf("target=%q", target), func(t *testing.T) {
+				t.Parallel()
+
+				a := mustAdapter(t, newPreflightServer(t)) // no issues route registered; any request fails the test
+
+				err := a.TransitionIssue(context.Background(), "1", target)
+				assertTrackerErrorKind(t, err, domain.ErrTrackerPayload)
+			})
+		}
+	})
+
+	t.Run("non-issue work item rejected before any write", func(t *testing.T) {
+		t.Parallel()
+
+		s := newPreflightServer(t)
+		s.handle("/api/v4/projects/"+testEscapedProject+"/issues/100", func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"iid":100,"state":"opened","issue_type":"task","labels":["review"]}`)) //nolint:errcheck // test helper
+		})
+		a := mustAdapter(t, s) // no PUT route registered; a PUT would fail the test
+
+		err := a.TransitionIssue(context.Background(), "100", "done")
+		assertTrackerErrorKind(t, err, domain.ErrTrackerNotFound)
+	})
+
+	t.Run("a converged transition issues no request", func(t *testing.T) {
+		t.Parallel()
+
+		tests := []struct {
+			name   string
+			labels string
+		}{
+			{"exact casing match", `["done"]`},
+			{"issue holds a different stored casing of the same state", `["Done"]`},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+
+				s := newPreflightServer(t)
+				var getCalls atomic.Int32
+				s.handle("/api/v4/projects/"+testEscapedProject+"/issues/5", func(w http.ResponseWriter, r *http.Request) {
+					getCalls.Add(1)
+					w.WriteHeader(http.StatusOK)
+					w.Write(fmt.Appendf(nil, `{"iid":5,"state":"closed","issue_type":"issue","labels":%s}`, tt.labels)) //nolint:errcheck // test helper
+				})
+				a := mustAdapter(t, s) // no PUT route registered; a PUT would fail the test
+
+				if err := a.TransitionIssue(context.Background(), "5", "done"); err != nil {
+					t.Fatalf("TransitionIssue: %v", err)
+				}
+				if got := getCalls.Load(); got != 1 {
+					t.Errorf("GET call count = %d, want 1", got)
+				}
+			})
+		}
+	})
+
+	t.Run("the target label is sent in its canonical stored casing", func(t *testing.T) {
+		t.Parallel()
+
+		s := newPreflightServer(t)
+		s.handle("/api/v4/projects/"+testEscapedProject+"/labels", func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`[{"name":"Review"},{"name":"Done"}]`)) //nolint:errcheck // test helper
+		})
+		var putBody []byte
+		s.handle("/api/v4/projects/"+testEscapedProject+"/issues/3", func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"iid":3,"state":"opened","issue_type":"issue","labels":["review"]}`)) //nolint:errcheck // test helper
+		})
+		s.handleMethod(http.MethodPut, "/api/v4/projects/"+testEscapedProject+"/issues/3", func(w http.ResponseWriter, r *http.Request) {
+			putBody = readRequestBody(t, r)
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{}`)) //nolint:errcheck // test helper
+		})
+		a := mustAdapter(t, s)
+
+		if err := a.TransitionIssue(context.Background(), "3", "done"); err != nil {
+			t.Fatalf("TransitionIssue: %v", err)
+		}
+		want := `{"state_event":"close","add_labels":["Done"],"remove_labels":["review"]}`
+		if string(putBody) != want {
+			t.Errorf("PUT body = %s, want %s (add_labels must carry the catalog's stored casing, not the configured spelling)", putBody, want)
+		}
+	})
+
+	t.Run("every case variant of the outgoing state label is removed in the same request", func(t *testing.T) {
+		t.Parallel()
+
+		s := newPreflightServer(t)
+		var putBody []byte
+		var putCalls atomic.Int32
+		s.handle("/api/v4/projects/"+testEscapedProject+"/issues/11", func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"iid":11,"state":"opened","issue_type":"issue","labels":["REVIEW","review"]}`)) //nolint:errcheck // test helper
+		})
+		s.handleMethod(http.MethodPut, "/api/v4/projects/"+testEscapedProject+"/issues/11", func(w http.ResponseWriter, r *http.Request) {
+			putCalls.Add(1)
+			putBody = readRequestBody(t, r)
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{}`)) //nolint:errcheck // test helper
+		})
+		a := mustAdapter(t, s)
+
+		if err := a.TransitionIssue(context.Background(), "11", "done"); err != nil {
+			t.Fatalf("TransitionIssue: %v", err)
+		}
+		if got := putCalls.Load(); got != 1 {
+			t.Errorf("PUT call count = %d, want 1", got)
+		}
+		want := `{"state_event":"close","add_labels":["done"],"remove_labels":["REVIEW","review"]}`
+		if string(putBody) != want {
+			t.Errorf("PUT body = %s, want %s (both case variants removed, in issue-label order)", putBody, want)
+		}
+	})
+
+	t.Run("a pre-existing case variant of the incoming label is removed without cancelling the attach", func(t *testing.T) {
+		t.Parallel()
+
+		s := newPreflightServer(t)
+		var putBody []byte
+		s.handle("/api/v4/projects/"+testEscapedProject+"/issues/13", func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"iid":13,"state":"opened","issue_type":"issue","labels":["backlog","DONE"]}`)) //nolint:errcheck // test helper
+		})
+		s.handleMethod(http.MethodPut, "/api/v4/projects/"+testEscapedProject+"/issues/13", func(w http.ResponseWriter, r *http.Request) {
+			putBody = readRequestBody(t, r)
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{}`)) //nolint:errcheck // test helper
+		})
+		a := mustAdapter(t, s)
+
+		if err := a.TransitionIssue(context.Background(), "13", "done"); err != nil {
+			t.Fatalf("TransitionIssue: %v", err)
+		}
+		want := `{"state_event":"close","add_labels":["done"],"remove_labels":["backlog","DONE"]}`
+		if string(putBody) != want {
+			t.Errorf("PUT body = %s, want %s (remove_labels must not carry the byte-identical done, which would cancel the attach)", putBody, want)
+		}
+	})
+}
+
+// --- CommentIssue ---
+
+func TestCommentIssue(t *testing.T) {
+	t.Parallel()
+
+	t.Run("posts the note verbatim including newlines", func(t *testing.T) {
+		t.Parallel()
+
+		const text = "Automated check failed.\nSee the CI log for detail."
+
+		s := newPreflightServer(t)
+		var postBody []byte
+		var postCalls atomic.Int32
+		s.handleMethod(http.MethodPost, "/api/v4/projects/"+testEscapedProject+"/issues/1/notes", func(w http.ResponseWriter, r *http.Request) {
+			postCalls.Add(1)
+			postBody = readRequestBody(t, r)
+			w.WriteHeader(http.StatusCreated)
+			w.Write(loadFixture(t, "note_created.json")) //nolint:errcheck // test helper
+		})
+		a := mustAdapter(t, s)
+
+		if err := a.CommentIssue(context.Background(), "1", text); err != nil {
+			t.Fatalf("CommentIssue: %v", err)
+		}
+		if got := postCalls.Load(); got != 1 {
+			t.Errorf("POST call count = %d, want 1", got)
+		}
+		want := `{"body":` + strconv.Quote(text) + `}`
+		if string(postBody) != want {
+			t.Errorf("POST body = %s, want %s (text must pass through byte-identical, including newlines)", postBody, want)
+		}
+	})
+
+	t.Run("a 2xx that created no note reports ErrTrackerPayload", func(t *testing.T) {
+		t.Parallel()
+
+		s := newPreflightServer(t)
+		s.handleMethod(http.MethodPost, "/api/v4/projects/"+testEscapedProject+"/issues/2/notes", func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusAccepted)
+			w.Write(loadFixture(t, "note_quick_action.json")) //nolint:errcheck // test helper
+		})
+		a := mustAdapter(t, s)
+
+		err := a.CommentIssue(context.Background(), "2", "/close")
 		assertTrackerErrorKind(t, err, domain.ErrTrackerPayload)
+	})
+
+	t.Run("a note that also executed quick actions logs a WARN naming the command keys", func(t *testing.T) {
+		t.Parallel()
+
+		s := newPreflightServer(t)
+		s.handleMethod(http.MethodPost, "/api/v4/projects/"+testEscapedProject+"/issues/3/notes", func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusCreated)
+			w.Write([]byte(`{"id":900,"body":"","commands_changes":{"add_label_ids":[5]}}`)) //nolint:errcheck // test helper
+		})
+		a := mustAdapter(t, s)
+
+		var buf bytes.Buffer
+		a.log = slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+		if err := a.CommentIssue(context.Background(), "3", "/close\nSome text"); err != nil {
+			t.Fatalf("CommentIssue: %v", err)
+		}
+		output := buf.String()
+		if !strings.Contains(output, "gitlab executed quick actions in a comment body") {
+			t.Errorf("log output missing the quick-action WARN\noutput: %s", output)
+		}
+		if !strings.Contains(output, "add_label_ids") {
+			t.Errorf("log output missing the executed command key add_label_ids\noutput: %s", output)
+		}
+	})
+}
+
+// --- AddLabel ---
+
+func TestAddLabel(t *testing.T) {
+	t.Parallel()
+
+	t.Run("additive attach preserving existing labels sends only add_labels", func(t *testing.T) {
+		t.Parallel()
+
+		s := newPreflightServer(t) // labels catalog route returns an empty array; no issue-read route registered
+		var putBody []byte
+		var putCalls atomic.Int32
+		s.handleMethod(http.MethodPut, "/api/v4/projects/"+testEscapedProject+"/issues/4", func(w http.ResponseWriter, r *http.Request) {
+			putCalls.Add(1)
+			putBody = readRequestBody(t, r)
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{}`)) //nolint:errcheck // test helper
+		})
+		a := mustAdapter(t, s)
+
+		if err := a.AddLabel(context.Background(), "4", "needs-human"); err != nil {
+			t.Fatalf("AddLabel: %v", err)
+		}
+		if got := putCalls.Load(); got != 1 {
+			t.Errorf("PUT call count = %d, want 1", got)
+		}
+		want := `{"add_labels":["needs-human"]}`
+		if string(putBody) != want {
+			t.Errorf("PUT body = %s, want %s (no labels key, no remove_labels key)", putBody, want)
+		}
+	})
+
+	t.Run("empty or whitespace-only label attaches nothing and warns", func(t *testing.T) {
+		t.Parallel()
+
+		tests := []string{"", "  "}
+		for _, label := range tests {
+			t.Run(fmt.Sprintf("label=%q", label), func(t *testing.T) {
+				t.Parallel()
+
+				s := newFakeServer(t)
+				withPreflight(t, s, testProject)
+				var labelCalls atomic.Int32
+				s.handle("/api/v4/projects/"+testEscapedProject+"/labels", func(w http.ResponseWriter, r *http.Request) {
+					labelCalls.Add(1)
+					w.WriteHeader(http.StatusOK)
+					w.Write([]byte(`[]`)) //nolint:errcheck // test helper
+				})
+				a := mustAdapter(t, s) // no PUT route registered; a PUT would fail the test
+
+				afterConstruction := labelCalls.Load()
+
+				var buf bytes.Buffer
+				a.log = slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+				if err := a.AddLabel(context.Background(), "1", label); err != nil {
+					t.Fatalf("AddLabel: %v", err)
+				}
+				if got := labelCalls.Load(); got != afterConstruction {
+					t.Errorf("labels-route call count = %d, want %d (no catalog read for an empty label)", got, afterConstruction)
+				}
+				if !strings.Contains(buf.String(), "gitlab add_label received an empty label; nothing attached") {
+					t.Errorf("log output missing the empty-label WARN\noutput: %s", buf.String())
+				}
+			})
+		}
+	})
+}
+
+// --- Label catalog pagination (multi-page regression) ---
+
+func TestLabelCatalogPagination(t *testing.T) {
+	t.Parallel()
+
+	t.Run("construction resolves a state label defined only on page two", func(t *testing.T) {
+		t.Parallel()
+
+		s := newFakeServer(t)
+		s.handle("/api/v4/personal_access_tokens/self", func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			w.Write(loadFixture(t, "token_self.json")) //nolint:errcheck // test helper
+		})
+		s.handle("/api/v4/projects/"+testEscapedProject, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{}`)) //nolint:errcheck // test helper
+		})
+
+		var srvURL string
+		var calls atomic.Int32
+		basePath := "/api/v4/projects/" + testEscapedProject + "/labels"
+		s.handle(basePath, func(w http.ResponseWriter, r *http.Request) {
+			n := calls.Add(1)
+			if n == 1 {
+				next := fmt.Sprintf(`<%s%s?page=2>; rel="next"`, srvURL, basePath)
+				w.Header().Set("Link", next)
+				w.WriteHeader(http.StatusOK)
+				w.Write(loadFixture(t, "labels_page1.json")) //nolint:errcheck // test helper
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+			w.Write(loadFixture(t, "labels_page2.json")) //nolint:errcheck // test helper
+		})
+
+		srv := httptest.NewServer(s)
+		defer srv.Close()
+		srvURL = srv.URL
+
+		cfg := validConfig(testProject)
+		cfg["endpoint"] = srv.URL
+		adapter, err := NewGitLabAdapter(cfg)
+		if err != nil {
+			t.Fatalf("NewGitLabAdapter: %v", err)
+		}
+		a := adapter.(*GitLabAdapter)
+
+		if got := calls.Load(); got != 2 {
+			t.Errorf("labels-route call count = %d, want 2 (page one plus page two)", got)
+		}
+		if got := a.stateLabelCasing["review"]; got != "Review" {
+			t.Errorf(`stateLabelCasing["review"] = %q, want %q (page two carries the stored casing)`, got, "Review")
+		}
+	})
+
+	t.Run("AddLabel sends page two's stored casing on the attach", func(t *testing.T) {
+		t.Parallel()
+
+		s := newFakeServer(t)
+		withPreflight(t, s, testProject) // construction consumes the default empty-array catalog once
+
+		var putBody []byte
+		s.handleMethod(http.MethodPut, "/api/v4/projects/"+testEscapedProject+"/issues/6", func(w http.ResponseWriter, r *http.Request) {
+			putBody = readRequestBody(t, r)
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{}`)) //nolint:errcheck // test helper
+		})
+
+		srv := httptest.NewServer(s)
+		defer srv.Close()
+		srvURL := srv.URL
+
+		cfg := validConfig(testProject)
+		cfg["endpoint"] = srv.URL
+		adapter, err := NewGitLabAdapter(cfg)
+		if err != nil {
+			t.Fatalf("NewGitLabAdapter: %v", err)
+		}
+		a := adapter.(*GitLabAdapter)
+
+		// Re-registered only after construction, so the two-page catalog
+		// below is exercised by AddLabel's own fresh call, not by the
+		// preflight's earlier, already-consumed empty-array read.
+		var calls atomic.Int32
+		basePath := "/api/v4/projects/" + testEscapedProject + "/labels"
+		s.handle(basePath, func(w http.ResponseWriter, r *http.Request) {
+			n := calls.Add(1)
+			if n == 1 {
+				next := fmt.Sprintf(`<%s%s?page=2>; rel="next"`, srvURL, basePath)
+				w.Header().Set("Link", next)
+				w.WriteHeader(http.StatusOK)
+				w.Write(loadFixture(t, "labels_page1.json")) //nolint:errcheck // test helper
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+			w.Write(loadFixture(t, "labels_page2.json")) //nolint:errcheck // test helper
+		})
+
+		if err := a.AddLabel(context.Background(), "6", "review"); err != nil {
+			t.Fatalf("AddLabel: %v", err)
+		}
+		if got := calls.Load(); got != 2 {
+			t.Errorf("labels-route call count = %d, want 2 (page one plus page two)", got)
+		}
+		want := `{"add_labels":["Review"]}`
+		if string(putBody) != want {
+			t.Errorf("PUT body = %s, want %s (the attach must use page two's stored casing)", putBody, want)
+		}
+	})
+}
+
+// --- Error-category mapping for a rejected write ---
+
+func TestWriteErrorMapping(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		status   int
+		fixture  string
+		inline   string
+		wantKind domain.TrackerErrorKind
+	}{
+		{"400 bad request", http.StatusBadRequest, "error_400.json", "", domain.ErrTrackerPayload},
+		{"401 unauthorized", http.StatusUnauthorized, "error_401.json", "", domain.ErrTrackerAuth},
+		{"403 insufficient scope", http.StatusForbidden, "error_403.json", "", domain.ErrTrackerAuth},
+		{"404 issue not found", http.StatusNotFound, "error_404_issue.json", "", domain.ErrTrackerNotFound},
+		{"404 project not found", http.StatusNotFound, "error_404_project.json", "", domain.ErrTrackerNotFound},
+		{"429 rate limited", http.StatusTooManyRequests, "", "{}", domain.ErrTrackerAPI},
+		{"500 server error", http.StatusInternalServerError, "error_500.json", "", domain.ErrTrackerTransport},
 	}
 
-	if err := a.CommentIssue(context.Background(), "1", "hello"); err == nil {
-		t.Error("CommentIssue = nil, want ErrTrackerPayload")
-	} else {
-		assertTrackerErrorKind(t, err, domain.ErrTrackerPayload)
-	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-	if err := a.AddLabel(context.Background(), "1", "ci-failure"); err == nil {
-		t.Error("AddLabel = nil, want ErrTrackerPayload")
-	} else {
-		assertTrackerErrorKind(t, err, domain.ErrTrackerPayload)
+			s := newPreflightServer(t)
+			s.handleMethod(http.MethodPut, "/api/v4/projects/"+testEscapedProject+"/issues/1", func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tt.status)
+				if tt.fixture != "" {
+					w.Write(loadFixture(t, tt.fixture)) //nolint:errcheck // test helper
+					return
+				}
+				w.Write([]byte(tt.inline)) //nolint:errcheck // test helper
+			})
+			a := mustAdapter(t, s)
+
+			err := a.AddLabel(context.Background(), "1", "needs-human")
+			assertTrackerErrorKind(t, err, tt.wantKind)
+		})
+	}
+}
+
+// --- Identifier guard across all three writes ---
+
+func TestWriteIdentifierGuard(t *testing.T) {
+	t.Parallel()
+
+	tests := []string{"abc", "1.5", "-1", "0", "01", " ", ""}
+
+	for _, raw := range tests {
+		t.Run(fmt.Sprintf("issueID=%q", raw), func(t *testing.T) {
+			t.Parallel()
+
+			a := mustAdapter(t, newPreflightServer(t)) // no write route registered; any request fails the test
+
+			err := a.TransitionIssue(context.Background(), raw, "done")
+			assertTrackerErrorKind(t, err, domain.ErrTrackerNotFound)
+
+			err = a.CommentIssue(context.Background(), raw, "text")
+			assertTrackerErrorKind(t, err, domain.ErrTrackerNotFound)
+
+			err = a.AddLabel(context.Background(), raw, "needs-human")
+			assertTrackerErrorKind(t, err, domain.ErrTrackerNotFound)
+		})
 	}
 }

--- a/internal/scm/gitlab/label.go
+++ b/internal/scm/gitlab/label.go
@@ -1,0 +1,93 @@
+package gitlab
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/url"
+	"slices"
+	"strings"
+
+	"github.com/sortie-ai/sortie/internal/domain"
+	"github.com/sortie-ai/sortie/internal/httpkit"
+)
+
+// gitlabLabel is one entry of the project label catalog. Only Name is
+// consumed: GitLab's add_labels and remove_labels parameters address
+// labels by name, so the catalog exists solely to recover the stored
+// casing of a configured label name.
+type gitlabLabel struct {
+	Name string `json:"name"`
+}
+
+// fetchProjectLabels pages GET /projects/{projectPath}/labels to
+// exhaustion through [httpkit.NewLinkPaginator] and returns every label
+// name the project can see, project-level and group-level alike. A
+// group-level state label is attachable and filterable exactly like a
+// project label, so omitting it would send the configured spelling for a
+// label whose stored spelling differs.
+//
+// A page decode failure returns [domain.ErrTrackerPayload].
+func fetchProjectLabels(ctx context.Context, client *httpkit.Client, projectPath string, log *slog.Logger) ([]gitlabLabel, error) {
+	path := "/projects/" + projectPath + "/labels"
+	params := url.Values{"per_page": {"100"}}
+
+	paginator := httpkit.NewLinkPaginator(client, path, params, func(body []byte) ([]gitlabLabel, error) {
+		var raw []gitlabLabel
+		if err := json.Unmarshal(body, &raw); err != nil {
+			return nil, &domain.TrackerError{
+				Kind:    domain.ErrTrackerPayload,
+				Message: "failed to parse labels response",
+				Err:     err,
+			}
+		}
+		return raw, nil
+	}, httpkit.PaginatorOptions{
+		MaxPages: maxPages,
+		OnLimitReached: func(limit int) {
+			log.Warn("pagination limit reached",
+				slog.Int("max_pages", limit),
+				slog.String("endpoint", path))
+		},
+	})
+
+	return paginator.All(ctx)
+}
+
+// resolveCasing returns a lowercased-name to stored-casing map for the
+// subset of wanted that appears in catalog. A name that matches no
+// catalog entry case-insensitively is omitted.
+//
+// The result does not depend on catalog order. When two or more catalog
+// entries share a lowercased name, the entry byte-identical to the
+// wanted spelling wins; otherwise the byte-wise smallest matching name
+// wins, which only matters when the project already holds a duplicate.
+func resolveCasing(catalog []gitlabLabel, wanted []string) map[string]string {
+	byLower := make(map[string][]string, len(catalog))
+	for _, l := range catalog {
+		lowered := strings.ToLower(l.Name)
+		byLower[lowered] = append(byLower[lowered], l.Name)
+	}
+
+	result := make(map[string]string, len(wanted))
+	for _, name := range wanted {
+		lowered := strings.ToLower(name)
+		variants, ok := byLower[lowered]
+		if !ok {
+			continue
+		}
+		result[lowered] = pickCasing(variants, name)
+	}
+	return result
+}
+
+// pickCasing chooses the winning stored casing among variants, all of
+// which share the same lowercased form as wanted. The entry
+// byte-identical to wanted wins outright; otherwise the byte-wise
+// smallest variant wins.
+func pickCasing(variants []string, wanted string) string {
+	if slices.Contains(variants, wanted) {
+		return wanted
+	}
+	return slices.Min(variants)
+}

--- a/internal/scm/gitlab/normalize.go
+++ b/internal/scm/gitlab/normalize.go
@@ -49,6 +49,16 @@ type gitlabNote struct {
 	System    bool       `json:"system"`
 }
 
+// gitlabNoteCreated is the note-creation response. ID is a pointer so
+// that an absent id, which GitLab returns when the body was consumed
+// entirely as quick actions, is distinguishable from id zero.
+// CommandsChanges is non-empty when GitLab executed one or more quick
+// actions found in the body.
+type gitlabNoteCreated struct {
+	ID              *int64         `json:"id"`
+	CommandsChanges map[string]any `json:"commands_changes"`
+}
+
 // gitlabTokenInfo is the token-introspection record the construction
 // preflight decodes. It never carries the token value itself.
 type gitlabTokenInfo struct {

--- a/internal/scm/gitlab/preflight.go
+++ b/internal/scm/gitlab/preflight.go
@@ -18,15 +18,20 @@ import (
 // construction fails.
 var preflightBackoff = []time.Duration{time.Second, 2 * time.Second, 4 * time.Second}
 
-// runPreflight validates the credential and the configured project before
-// the first poll. It calls GET /personal_access_tokens/self once, with no
-// retry, as an advisory introspection, then GET /projects/{projectPath}
-// through [withRetry] as the authoritative gate.
+// runPreflight validates the credential, the configured project, and the
+// canonical casing of every configured state label before the first
+// poll. It calls GET /personal_access_tokens/self once, with no retry, as
+// an advisory introspection, then GET /projects/{projectPath} through
+// [withRetry] as the authoritative gate, then, when configuredStates is
+// non-empty, pages the project label catalog through [withRetry] to
+// resolve the stored casing of each configured name.
 //
 // Token introspection failure never blocks construction; its result only
 // informs the message on a not-found project error. The token never
-// appears in a log record.
-func runPreflight(ctx context.Context, client *httpkit.Client, projectPath string, log *slog.Logger) error {
+// appears in a log record. A configured state label absent from the
+// catalog is not an error: it is the operator's intended new label,
+// created on the first add_labels write.
+func runPreflight(ctx context.Context, client *httpkit.Client, projectPath string, configuredStates []string, log *slog.Logger) (map[string]string, error) {
 	if log == nil {
 		log = slog.Default()
 	}
@@ -58,16 +63,40 @@ func runPreflight(ctx context.Context, client *httpkit.Client, projectPath strin
 	})
 	if projectErr != nil {
 		if domain.IsNotFound(projectErr) {
-			return &domain.TrackerError{
+			return nil, &domain.TrackerError{
 				Kind: domain.ErrTrackerNotFound,
 				Message: fmt.Sprintf(
 					"gitlab: project not found or not accessible with the configured credential (token authenticated: %t)",
 					tokenValid),
 			}
 		}
-		return projectErr
+		return nil, projectErr
 	}
-	return nil
+
+	if len(configuredStates) == 0 {
+		return map[string]string{}, nil
+	}
+
+	var catalog []gitlabLabel
+	catalogErr := withRetry(ctx, func() error {
+		fetched, fetchErr := fetchProjectLabels(ctx, client, projectPath, log)
+		if fetchErr != nil {
+			return fetchErr
+		}
+		catalog = fetched
+		return nil
+	})
+	if catalogErr != nil {
+		return nil, catalogErr
+	}
+
+	casing := resolveCasing(catalog, configuredStates)
+	for _, name := range configuredStates {
+		if _, ok := casing[name]; !ok {
+			log.Debug("configured state label absent from project", slog.String("label", name))
+		}
+	}
+	return casing, nil
 }
 
 // withRetry runs fn, retrying transient tracker errors with the bounded

--- a/internal/scm/gitlab/preflight_test.go
+++ b/internal/scm/gitlab/preflight_test.go
@@ -169,15 +169,20 @@ func TestWithRetry(t *testing.T) {
 	})
 }
 
-// preflightServer builds an httptest.Server simulating the two preflight
+// preflightServer builds an httptest.Server simulating the three preflight
 // routes, with independently controllable status codes and atomic call
-// counters for the token and project checks.
+// counters for the token, project, and label-catalog checks. labelsFlaky,
+// when set, makes the labels route fail once with a 500 and succeed with
+// an empty catalog on every call after, regardless of labelsStatus.
 type preflightServer struct {
 	srv           *httptest.Server
 	tokenStatus   atomic.Int32
 	projectStatus atomic.Int32
+	labelsStatus  atomic.Int32
+	labelsFlaky   atomic.Bool
 	tokenCalls    atomic.Int32
 	projectCalls  atomic.Int32
+	labelsCalls   atomic.Int32
 }
 
 func newRawPreflightServer(t *testing.T) *preflightServer {
@@ -185,6 +190,7 @@ func newRawPreflightServer(t *testing.T) *preflightServer {
 	ps := &preflightServer{}
 	ps.tokenStatus.Store(http.StatusOK)
 	ps.projectStatus.Store(http.StatusOK)
+	ps.labelsStatus.Store(http.StatusOK)
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/personal_access_tokens/self", func(w http.ResponseWriter, r *http.Request) {
@@ -203,6 +209,21 @@ func newRawPreflightServer(t *testing.T) *preflightServer {
 			w.Write(loadFixture(t, "error_404_project.json")) //nolint:errcheck // test helper
 		}
 	})
+	mux.HandleFunc("/projects/"+testEscapedProject+"/labels", func(w http.ResponseWriter, r *http.Request) {
+		n := ps.labelsCalls.Add(1)
+		if ps.labelsFlaky.Load() && n == 1 {
+			w.WriteHeader(http.StatusInternalServerError)
+			w.Write(loadFixture(t, "error_500.json")) //nolint:errcheck // test helper
+			return
+		}
+		status := int(ps.labelsStatus.Load())
+		w.WriteHeader(status)
+		if status == http.StatusOK {
+			w.Write([]byte(`[]`)) //nolint:errcheck // test helper
+			return
+		}
+		w.Write(loadFixture(t, "error_500.json")) //nolint:errcheck // test helper
+	})
 
 	ps.srv = httptest.NewServer(mux)
 	t.Cleanup(ps.srv.Close)
@@ -214,7 +235,7 @@ func TestRunPreflight(t *testing.T) {
 		ps := newRawPreflightServer(t)
 		client := newGitLabClient(ps.srv.URL, "test-token", "sortie/test")
 
-		if err := runPreflight(context.Background(), client, testEscapedProject, slog.Default()); err != nil {
+		if _, err := runPreflight(context.Background(), client, testEscapedProject, nil, slog.Default()); err != nil {
 			t.Fatalf("runPreflight: %v", err)
 		}
 		if got := ps.tokenCalls.Load(); got != 1 {
@@ -230,7 +251,7 @@ func TestRunPreflight(t *testing.T) {
 		ps.tokenStatus.Store(http.StatusInternalServerError)
 		client := newGitLabClient(ps.srv.URL, "test-token", "sortie/test")
 
-		if err := runPreflight(context.Background(), client, testEscapedProject, slog.Default()); err != nil {
+		if _, err := runPreflight(context.Background(), client, testEscapedProject, nil, slog.Default()); err != nil {
 			t.Fatalf("runPreflight: %v (introspection failure must not block a healthy project check)", err)
 		}
 		if got := ps.projectCalls.Load(); got != 1 {
@@ -243,7 +264,7 @@ func TestRunPreflight(t *testing.T) {
 		ps.projectStatus.Store(http.StatusUnauthorized)
 		client := newGitLabClient(ps.srv.URL, "test-token", "sortie/test")
 
-		err := runPreflight(context.Background(), client, testEscapedProject, slog.Default())
+		_, err := runPreflight(context.Background(), client, testEscapedProject, nil, slog.Default())
 		assertTrackerErrorKind(t, err, domain.ErrTrackerAuth)
 
 		if got := ps.projectCalls.Load(); got != 1 {
@@ -256,7 +277,7 @@ func TestRunPreflight(t *testing.T) {
 		ps.projectStatus.Store(http.StatusNotFound)
 		client := newGitLabClient(ps.srv.URL, "test-token", "sortie/test")
 
-		err := runPreflight(context.Background(), client, testEscapedProject, slog.Default())
+		_, err := runPreflight(context.Background(), client, testEscapedProject, nil, slog.Default())
 		assertTrackerErrorKind(t, err, domain.ErrTrackerNotFound)
 
 		if got := ps.projectCalls.Load(); got != 1 {
@@ -271,7 +292,7 @@ func TestRunPreflight(t *testing.T) {
 		ps.projectStatus.Store(http.StatusInternalServerError)
 		client := newGitLabClient(ps.srv.URL, "test-token", "sortie/test")
 
-		err := runPreflight(context.Background(), client, testEscapedProject, slog.Default())
+		_, err := runPreflight(context.Background(), client, testEscapedProject, nil, slog.Default())
 		assertTrackerErrorKind(t, err, domain.ErrTrackerTransport)
 
 		wantCalls := int32(len(preflightBackoff) + 1)
@@ -288,7 +309,7 @@ func TestRunPreflight(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
 
-		err := runPreflight(ctx, client, testEscapedProject, slog.Default())
+		_, err := runPreflight(ctx, client, testEscapedProject, nil, slog.Default())
 		if !errors.Is(err, context.Canceled) {
 			t.Errorf("runPreflight error = %v, want context.Canceled", err)
 		}
@@ -305,11 +326,80 @@ func TestRunPreflight(t *testing.T) {
 		var buf bytes.Buffer
 		log := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
 
-		if err := runPreflight(context.Background(), client, testEscapedProject, log); err != nil {
+		if _, err := runPreflight(context.Background(), client, testEscapedProject, nil, log); err != nil {
 			t.Fatalf("runPreflight: %v", err)
 		}
 		if strings.Contains(buf.String(), "super-secret-token") {
 			t.Errorf("runPreflight logged the token\noutput: %s", buf.String())
+		}
+	})
+
+	t.Run("catalog read failing on every retry fails construction", func(t *testing.T) {
+		fastPreflightBackoff(t)
+
+		ps := newRawPreflightServer(t)
+		ps.labelsStatus.Store(http.StatusInternalServerError)
+		client := newGitLabClient(ps.srv.URL, "super-secret-token", "sortie/test")
+
+		var buf bytes.Buffer
+		log := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+		_, err := runPreflight(context.Background(), client, testEscapedProject, []string{"review", "done"}, log)
+		assertTrackerErrorKind(t, err, domain.ErrTrackerTransport)
+
+		wantCalls := int32(len(preflightBackoff) + 1)
+		if got := ps.labelsCalls.Load(); got != wantCalls {
+			t.Errorf("labels calls = %d, want %d (initial + one per backoff entry)", got, wantCalls)
+		}
+		if strings.Contains(buf.String(), "super-secret-token") {
+			t.Errorf("runPreflight logged the token\noutput: %s", buf.String())
+		}
+	})
+
+	t.Run("catalog read succeeding after one transient failure succeeds", func(t *testing.T) {
+		fastPreflightBackoff(t)
+
+		ps := newRawPreflightServer(t)
+		ps.labelsFlaky.Store(true)
+		client := newGitLabClient(ps.srv.URL, "super-secret-token", "sortie/test")
+
+		var buf bytes.Buffer
+		log := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+		if _, err := runPreflight(context.Background(), client, testEscapedProject, []string{"review", "done"}, log); err != nil {
+			t.Fatalf("runPreflight: %v (a single transient catalog failure must be absorbed by withRetry)", err)
+		}
+		if got := ps.labelsCalls.Load(); got != 2 {
+			t.Errorf("labels calls = %d, want 2 (one failure then one success, bounded by preflightBackoff)", got)
+		}
+		if strings.Contains(buf.String(), "super-secret-token") {
+			t.Errorf("runPreflight logged the token\noutput: %s", buf.String())
+		}
+	})
+
+	t.Run("a configured state label absent from the catalog does not fail construction and emits no WARN", func(t *testing.T) {
+		ps := newRawPreflightServer(t)
+		client := newGitLabClient(ps.srv.URL, "super-secret-token", "sortie/test")
+
+		var buf bytes.Buffer
+		log := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+		casing, err := runPreflight(context.Background(), client, testEscapedProject, []string{"review", "done"}, log)
+		if err != nil {
+			t.Fatalf("runPreflight: %v", err)
+		}
+		if len(casing) != 0 {
+			t.Errorf("casing = %v, want empty (the empty catalog resolves neither configured label)", casing)
+		}
+		output := buf.String()
+		if strings.Contains(output, "level=WARN") {
+			t.Errorf("runPreflight logged a WARN for an absent configured label, want none\noutput: %s", output)
+		}
+		if !strings.Contains(output, "configured state label absent from project") {
+			t.Errorf("log output missing the absent-label Debug message\noutput: %s", output)
+		}
+		if strings.Contains(output, "super-secret-token") {
+			t.Errorf("runPreflight logged the token\noutput: %s", output)
 		}
 	})
 }

--- a/internal/scm/gitlab/state.go
+++ b/internal/scm/gitlab/state.go
@@ -62,3 +62,46 @@ func deriveState(labels []string, nativeState string, activeStates, terminalStat
 
 	return nativeState
 }
+
+// findCurrentStateLabel returns the lowercased name of the first
+// configured state label present on labels, scanning activeStates then
+// terminalStates then handoffState in config order, or "" when the issue
+// carries none. Unlike [deriveState] it reports only the first match and
+// never falls back to the native state, because the transition flow uses
+// it to locate the single state label being replaced.
+func findCurrentStateLabel(labels []string, activeStates, terminalStates []string, handoffState string) string {
+	present := make(map[string]struct{}, len(labels))
+	for _, l := range labels {
+		present[strings.ToLower(l)] = struct{}{}
+	}
+
+	for _, s := range activeStates {
+		if _, ok := present[s]; ok {
+			return s
+		}
+	}
+	for _, s := range terminalStates {
+		if _, ok := present[s]; ok {
+			return s
+		}
+	}
+	if handoffState != "" {
+		if _, ok := present[handoffState]; ok {
+			return handoffState
+		}
+	}
+	return ""
+}
+
+// labelVariants returns every entry of labels whose lowercased form
+// equals lowered, in input order. It is how the transition removes a
+// case-variant residue in the same request that applies the swap.
+func labelVariants(labels []string, lowered string) []string {
+	var out []string
+	for _, l := range labels {
+		if strings.ToLower(l) == lowered {
+			out = append(out, l)
+		}
+	}
+	return out
+}

--- a/internal/scm/gitlab/state_test.go
+++ b/internal/scm/gitlab/state_test.go
@@ -3,6 +3,7 @@ package gitlab
 import (
 	"bytes"
 	"log/slog"
+	"slices"
 	"strings"
 	"testing"
 )
@@ -186,5 +187,64 @@ func TestDeriveState_NilLoggerUsesDefaultWithoutPanic(t *testing.T) {
 	got := deriveState(labels, "opened", []string{"backlog"}, []string{"done"}, "", "1", nil)
 	if got != "backlog" {
 		t.Errorf("deriveState(nil logger) = %q, want %q", got, "backlog")
+	}
+}
+
+func TestFindCurrentStateLabel(t *testing.T) {
+	t.Parallel()
+
+	active := []string{"backlog", "in-progress", "review"}
+	terminal := []string{"done", "wontfix"}
+
+	tests := []struct {
+		name         string
+		labels       []string
+		handoffState string
+		want         string
+	}{
+		{"active match", []string{"in-progress"}, "", "in-progress"},
+		{"terminal match", []string{"done"}, "", "done"},
+		{"handoff match", []string{"needs-review"}, "needs-review", "needs-review"},
+		{"config-order precedence: active beats terminal", []string{"done", "backlog"}, "", "backlog"},
+		{"config-order precedence: active beats handoff", []string{"review", "in-progress"}, "review", "in-progress"},
+		{"no configured label present", []string{"bug"}, "", ""},
+		{"empty labels", nil, "", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := findCurrentStateLabel(tt.labels, active, terminal, tt.handoffState)
+			if got != tt.want {
+				t.Errorf("findCurrentStateLabel(%v, handoff=%q) = %q, want %q", tt.labels, tt.handoffState, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLabelVariants(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		labels  []string
+		lowered string
+		want    []string
+	}{
+		{"no matches", []string{"bug", "documentation"}, "review", nil},
+		{"single match", []string{"backlog", "review"}, "review", []string{"review"}},
+		{"multiple case-variant matches preserve input order", []string{"REVIEW", "bug", "review", "Review"}, "review", []string{"REVIEW", "review", "Review"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := labelVariants(tt.labels, tt.lowered)
+			if !slices.Equal(got, tt.want) {
+				t.Errorf("labelVariants(%v, %q) = %v, want %v", tt.labels, tt.lowered, got, tt.want)
+			}
+		})
 	}
 }

--- a/internal/scm/gitlab/testdata/labels_page1.json
+++ b/internal/scm/gitlab/testdata/labels_page1.json
@@ -1,0 +1,4 @@
+[
+  {"id": 10, "name": "bug", "color": "#d9534f", "text_color": "#FFFFFF", "description": "Something isn't working"},
+  {"id": 11, "name": "documentation", "color": "#5bc0de", "text_color": "#FFFFFF", "description": null}
+]

--- a/internal/scm/gitlab/testdata/labels_page2.json
+++ b/internal/scm/gitlab/testdata/labels_page2.json
@@ -1,0 +1,4 @@
+[
+  {"id": 12, "name": "Review", "color": "#f0ad4e", "text_color": "#FFFFFF", "description": "Needs review"},
+  {"id": 13, "name": "URGENT", "color": "#d9534f", "text_color": "#FFFFFF", "description": "Escalated"}
+]

--- a/internal/scm/gitlab/testdata/note_created.json
+++ b/internal/scm/gitlab/testdata/note_created.json
@@ -1,0 +1,15 @@
+{
+  "id": 501,
+  "author": {
+    "id": 7,
+    "username": "sortie-bot",
+    "name": "Sortie Bot"
+  },
+  "body": "Handoff complete: moving to review.",
+  "created_at": "2026-08-04T12:00:00.000Z",
+  "updated_at": "2026-08-04T12:00:00.000Z",
+  "system": false,
+  "noteable_id": 91042,
+  "noteable_type": "Issue",
+  "noteable_iid": 42
+}

--- a/internal/scm/gitlab/testdata/note_quick_action.json
+++ b/internal/scm/gitlab/testdata/note_quick_action.json
@@ -1,0 +1,7 @@
+{
+  "id": null,
+  "body": null,
+  "commands_changes": {
+    "state_event": "close"
+  }
+}


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Feat

**Intent:** Complete `domain.TrackerAdapter` for the GitLab package by implementing the write-side operations - `TransitionIssue`, `CommentIssue`, and `AddLabel` - against the GitLab REST API v4, replacing the compile-satisfying stubs left by the read-path work. This lets a GitLab-backed deployment perform handoff transitions, post lifecycle comments, and escalate CI failures by label, on par with the Jira, GitHub, Linear, and Gitea adapters.

**Related Issues:** #677

### 🧭 Reviewer Guide

**Complexity:** Medium

#### Entry Point

Start with `internal/scm/gitlab/gitlab.go`. `TransitionIssue` resolves the target state against the configured active/terminal/handoff states, fetches the issue to find its current state label, and issues a single `PUT` that swaps the state label and reconciles the native open/closed status via `state_event`. It also clears any case-variant residue of both the outgoing and incoming label in the same request. `CommentIssue` and `AddLabel` follow in the same file.

#### Sensitive Areas

- `internal/scm/gitlab/gitlab.go`: `TransitionIssue`'s label-swap logic and state-event derivation is the most intricate piece - it must not accumulate case-duplicate state labels across repeated transitions, and must issue no request when a transition is already converged.
- `internal/scm/gitlab/preflight.go`: the construction preflight now also pages the project's label catalog when any state label is configured, so a misconfigured or unreachable label endpoint now fails adapter construction rather than only affecting later writes.
- `internal/scm/gitlab/label.go`: `resolveCasing` decides which stored label casing wins when a project holds a case-duplicate label; the tie-break (byte-identical match, else byte-wise smallest) only matters in that edge case.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes.
- **Migrations/State:** No migrations or state changes.
