### PR TITLE
feat(scm/gitlab): honor tracker.query_filter for candidate polling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- GitLab tracker adapter: set `tracker.kind: gitlab` to run Sortie
+  against GitLab.com or a self-managed instance, with `tracker.project`
+  the target project as a `group/project` path or numeric project ID,
+  `tracker.api_key` a GitLab access token, and `tracker.endpoint` the
+  instance base URL (optional; defaults to `https://gitlab.com`, and
+  `/api/v4` is appended when absent). It runs the same autonomous
+  workflow as the Jira, GitHub, Linear, and Gitea adapters: candidate
+  polling, handoff transitions, lifecycle comments, and CI-failure
+  escalation labels. State is label-driven through `active_states`,
+  `terminal_states`, and `handoff_state`; a transition to a terminal
+  state closes the issue and a transition back to an active state
+  reopens it, escalation labels are attached without disturbing the
+  issue's other labels, and a state label the project does not yet hold
+  is created on first use. At startup the adapter checks the project and
+  reads its label catalog, so a bad token, a wrong project, or an
+  unreachable instance fails before the first poll. Because GitLab
+  issues carry no priority field and Community Edition has no blocking
+  relationship, `issue.priority` and `issue.blocked_by` are always empty
+  in prompt templates. `tracker.query_filter` takes a GitLab issue-list
+  query fragment (for example
+  `assignee_username=review-bot&labels=ready`, `not[...]` negation
+  included) to scope candidate polling to matching issues; the
+  adapter-owned keys `state`, `issue_type`, `order_by`, `sort`, `page`,
+  `per_page`, `pagination`, and `with_labels_details` are rejected, as
+  is any key GitLab's issue list does not support, so a typo fails at
+  startup instead of being silently ignored.
+  ([#676](https://github.com/sortie-ai/sortie/issues/676),
+  [#677](https://github.com/sortie-ai/sortie/issues/677),
+  [#679](https://github.com/sortie-ai/sortie/issues/679))
+
 ## [1.16.1] - 2026-08-03
 
 ### Fixed

--- a/internal/scm/gitlab/gitlab.go
+++ b/internal/scm/gitlab/gitlab.go
@@ -423,7 +423,8 @@ func (a *GitLabAdapter) canonicalLabel(lowered string) string {
 // for example a comma-separated duplicate or an array key carrying the
 // same value twice, still produces exactly one WARN; the negated and
 // non-negated forms are distinct names for this purpose, so the same
-// text under labels and under not[labels] each warn once.
+// text under labels and under not[labels] each warn once, distinguished
+// in the log record by a "negated" attribute.
 //
 // It returns without reading the label catalog when the filter names no
 // label, and never fails construction: a catalog read failure is logged
@@ -477,7 +478,7 @@ func (a *GitLabAdapter) warnUnresolvedFilterLabels(ctx context.Context) {
 			}
 			warned[name] = struct{}{}
 			a.log.Warn("gitlab query_filter names a label absent from the project catalog",
-				slog.String("label", segment))
+				slog.String("label", segment), slog.Bool("negated", k.negated))
 		}
 	}
 }

--- a/internal/scm/gitlab/gitlab.go
+++ b/internal/scm/gitlab/gitlab.go
@@ -144,13 +144,18 @@ type filterIdentity struct {
 //
 // canonical is key with one optional trailing "[]" suffix removed and,
 // when what remains both starts with "not[" and ends with "]", the inner
-// name with one further optional trailing "[]" suffix removed; negated is
-// true in that case and false otherwise. ok is false when key is empty,
-// when what remains after stripping a trailing "[]" starts with "not["
-// but does not end with "]", or when the inner name is empty. A key that
-// merely contains a bracket without an opening "not[", for example
-// "or[label_name][]", returns ok true with canonical "or[label_name]" and
-// negated false, leaving the allowlist to refuse it.
+// name between them; negated is true in that case and false otherwise. ok
+// is false when key is empty, when what remains after stripping a
+// trailing "[]" starts with "not[" but does not end with "]", when the
+// inner name is empty, or when the inner name itself contains a "[" or
+// "]". That last case rejects a key such as "not[labels[]]": GitLab's
+// Rack-based query parser does not fold a bracket nested inside the
+// not[...] hash into the enclosed name the way it folds the array marker
+// on "not[labels][]", so the two spellings are not equivalent and must
+// not canonicalize to the same identity. A key that merely contains a
+// bracket without an opening "not[", for example "or[label_name][]",
+// returns ok true with canonical "or[label_name]" and negated false,
+// leaving the allowlist to refuse it.
 func classifyFilterKey(key string) (canonical string, negated bool, ok bool) {
 	if key == "" {
 		return "", false, false
@@ -165,10 +170,10 @@ func classifyFilterKey(key string) (canonical string, negated bool, ok bool) {
 	}
 
 	inner := stripped[len("not[") : len(stripped)-1]
-	if inner == "" {
+	if inner == "" || strings.ContainsAny(inner, "[]") {
 		return "", false, false
 	}
-	return strings.TrimSuffix(inner, "[]"), true, true
+	return inner, true, true
 }
 
 // filterValueSegments returns every comma-separated segment of every

--- a/internal/scm/gitlab/gitlab.go
+++ b/internal/scm/gitlab/gitlab.go
@@ -13,10 +13,13 @@
 // authoritative project check, and, when any state label is configured, a
 // paginated project label catalog read that resolves the canonical stored
 // casing of every configured state label, so a write never attaches a
-// case variant of a label the project already holds. A failed project
-// check or a failed catalog read fails construction, so a misconfiguration
-// surfaces at startup rather than on the first poll. Registered under kind
-// "gitlab" via an init function.
+// case variant of a label the project already holds. An invalid
+// tracker.query_filter, a failed project check, or a failed preflight
+// catalog read fails construction, so a misconfiguration surfaces at
+// startup rather than on the first poll. A configured query_filter naming
+// a label triggers a second, diagnostic catalog read whose failure is
+// logged and does not fail construction. Registered under kind "gitlab"
+// via an init function.
 //
 // This package sits under the source-control adapter family, but this
 // stage implements only the tracker contract: the source-control and CI
@@ -29,6 +32,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"maps"
 	"net/http"
 	"net/url"
 	"slices"
@@ -85,11 +89,196 @@ type GitLabAdapter struct {
 	log            *slog.Logger
 	metrics        domain.Metrics
 
+	// queryFilter holds the validated tracker.query_filter parameters, or
+	// nil when the key is unset. Never mutated after construction.
+	queryFilter url.Values
+
 	// stateLabelCasing maps the lowercased form of each configured state
 	// label to the casing stored in the project, so a write never attaches a
 	// case variant of an existing label. A configured name absent from the
 	// project has no entry and is sent as configured, which creates it.
 	stateLabelCasing map[string]string
+}
+
+// reservedFilterKeys are the issue-list parameters this adapter owns. An
+// operator override changes correctness rather than scope, so the presence
+// of any of these fails construction. Iterated in this fixed slice order so
+// a fragment naming several of them always reports the same one.
+var reservedFilterKeys = []string{
+	"state", "issue_type", "order_by", "sort",
+	"page", "per_page", "pagination", "with_labels_details",
+}
+
+// allowedFilterKeys are the issue-list filter parameters the compatibility
+// floor declares and honors. A key outside this set is refused, because
+// GitLab silently ignores an unrecognized parameter.
+var allowedFilterKeys = map[string]struct{}{
+	"assignee_id": {}, "assignee_username": {}, "author_id": {},
+	"author_username": {}, "confidential": {}, "created_after": {},
+	"created_before": {}, "due_date": {}, "iids": {}, "in": {},
+	"labels": {}, "milestone": {}, "milestone_id": {},
+	"my_reaction_emoji": {}, "scope": {}, "search": {},
+	"updated_after": {}, "updated_before": {},
+}
+
+// negatableFilterKeys are the sub-keys the not[...] negation hash honors.
+// It is a strict subset of allowedFilterKeys: the excluded members parse
+// without error and then have no effect.
+var negatableFilterKeys = map[string]struct{}{
+	"assignee_id": {}, "assignee_username": {}, "author_id": {},
+	"author_username": {}, "iids": {}, "labels": {},
+	"milestone": {}, "milestone_id": {},
+}
+
+// filterIdentity identifies one query_filter parameter regardless of which
+// spelling named it, so labels and not[labels] are distinct identities
+// while labels and labels[] collide.
+type filterIdentity struct {
+	canonical string
+	negated   bool
+}
+
+// classifyFilterKey classifies one parsed query_filter key. canonical is
+// the name the key sets are looked up by; negated reports whether the key
+// arrived inside the not[...] hash.
+//
+// canonical is key with one optional trailing "[]" suffix removed and,
+// when what remains both starts with "not[" and ends with "]", the inner
+// name with one further optional trailing "[]" suffix removed; negated is
+// true in that case and false otherwise. ok is false when key is empty,
+// when what remains after stripping a trailing "[]" starts with "not["
+// but does not end with "]", or when the inner name is empty. A key that
+// merely contains a bracket without an opening "not[", for example
+// "or[label_name][]", returns ok true with canonical "or[label_name]" and
+// negated false, leaving the allowlist to refuse it.
+func classifyFilterKey(key string) (canonical string, negated bool, ok bool) {
+	if key == "" {
+		return "", false, false
+	}
+
+	stripped := strings.TrimSuffix(key, "[]")
+	if !strings.HasPrefix(stripped, "not[") {
+		return stripped, false, true
+	}
+	if !strings.HasSuffix(stripped, "]") {
+		return "", false, false
+	}
+
+	inner := stripped[len("not[") : len(stripped)-1]
+	if inner == "" {
+		return "", false, false
+	}
+	return strings.TrimSuffix(inner, "[]"), true, true
+}
+
+// filterValueSegments returns every comma-separated segment of every
+// string in values, in order, each trimmed of surrounding whitespace. An
+// empty segment is preserved rather than dropped, because an empty
+// segment is what parseQueryFilter refuses and what
+// warnUnresolvedFilterLabels never sees past that refusal.
+func filterValueSegments(values []string) []string {
+	segments := make([]string, 0, len(values))
+	for _, value := range values {
+		for part := range strings.SplitSeq(value, ",") {
+			segments = append(segments, strings.TrimSpace(part))
+		}
+	}
+	return segments
+}
+
+// parseQueryFilter parses the operator tracker.query_filter into
+// url.Values. It returns (nil, nil) when raw is empty or whitespace only.
+//
+// It returns a *domain.TrackerError of kind domain.ErrTrackerPayload when
+// raw does not parse as a URL query, names a key this adapter owns, names
+// a key GitLab does not honor on the issue-list route, carries a value
+// with an empty comma-separated segment, repeats a key whose name does
+// not end in "[]", or names one parameter under two spellings. It issues
+// no request and reads no package state beyond the key sets, so it is
+// safe to call from an offline configuration check.
+func parseQueryFilter(raw string) (url.Values, error) {
+	if strings.TrimSpace(raw) == "" {
+		return nil, nil
+	}
+
+	values, err := url.ParseQuery(raw)
+	if err != nil {
+		return nil, &domain.TrackerError{
+			Kind:    domain.ErrTrackerPayload,
+			Message: "gitlab: tracker.query_filter is not a valid url query fragment",
+			Err:     err,
+		}
+	}
+
+	sortedKeys := slices.Sorted(maps.Keys(values))
+
+	for _, reserved := range reservedFilterKeys {
+		for _, key := range sortedKeys {
+			canonical, negated, ok := classifyFilterKey(key)
+			if ok && !negated && canonical == reserved {
+				return nil, &domain.TrackerError{
+					Kind: domain.ErrTrackerPayload,
+					Message: fmt.Sprintf(
+						"gitlab: tracker.query_filter key %q is owned by the adapter and cannot be overridden", key),
+				}
+			}
+		}
+	}
+
+	unknownKeyMessage := func(key string) error {
+		return &domain.TrackerError{
+			Kind: domain.ErrTrackerPayload,
+			Message: fmt.Sprintf(
+				"gitlab: tracker.query_filter key %q is not a parameter gitlab's issue-list route honors; an unrecognized key is silently ignored rather than applied", key),
+		}
+	}
+	for _, key := range sortedKeys {
+		canonical, negated, ok := classifyFilterKey(key)
+		if !ok {
+			return nil, unknownKeyMessage(key)
+		}
+		if negated {
+			if _, allowed := negatableFilterKeys[canonical]; !allowed {
+				return nil, unknownKeyMessage(key)
+			}
+			continue
+		}
+		if _, allowed := allowedFilterKeys[canonical]; !allowed {
+			return nil, unknownKeyMessage(key)
+		}
+	}
+
+	claimed := make(map[filterIdentity]string, len(sortedKeys))
+	for _, key := range sortedKeys {
+		if slices.Contains(filterValueSegments(values[key]), "") {
+			return nil, &domain.TrackerError{
+				Kind: domain.ErrTrackerPayload,
+				Message: fmt.Sprintf(
+					"gitlab: tracker.query_filter key %q carries a value with an empty comma-separated segment", key),
+			}
+		}
+
+		if !strings.HasSuffix(key, "[]") && len(values[key]) > 1 {
+			return nil, &domain.TrackerError{
+				Kind: domain.ErrTrackerPayload,
+				Message: fmt.Sprintf(
+					"gitlab: tracker.query_filter key %q repeats a non-array parameter; repeat semantics are not portable across gitlab versions, so exactly one value is required", key),
+			}
+		}
+
+		canonical, negated, _ := classifyFilterKey(key)
+		identity := filterIdentity{canonical: canonical, negated: negated}
+		if first, seen := claimed[identity]; seen {
+			return nil, &domain.TrackerError{
+				Kind: domain.ErrTrackerPayload,
+				Message: fmt.Sprintf(
+					"gitlab: tracker.query_filter keys %q and %q name the same parameter under different spellings", first, key),
+			}
+		}
+		claimed[identity] = key
+	}
+
+	return values, nil
 }
 
 // NewGitLabAdapter creates a [GitLabAdapter] from adapter configuration and
@@ -99,11 +288,13 @@ type GitLabAdapter struct {
 // numeric project ID or a namespace path such as "group/project").
 // Optional: "endpoint" (instance base URL, defaulting to
 // "https://gitlab.com"), "active_states", "terminal_states",
-// "handoff_state" (label names, lowercased), and "user_agent". A
-// non-empty "query_filter" is rejected, because this adapter does not
-// support it yet. A missing or malformed key, or a preflight failure
-// (invalid token or an unreachable project), returns a
-// [*domain.TrackerError] and blocks construction.
+// "handoff_state" (label names, lowercased), "user_agent", and
+// "query_filter" (a URL query fragment merged into opened-issue
+// listings). A non-empty "query_filter" is parsed and validated against
+// the adapter's reserved and allowed key sets before any network call; a
+// value that fails validation blocks construction. A missing or malformed
+// key, or a preflight failure (invalid token or an unreachable project),
+// returns a [*domain.TrackerError] and blocks construction.
 func NewGitLabAdapter(config map[string]any) (domain.TrackerAdapter, error) {
 	apiKey, _ := config["api_key"].(string)
 	if apiKey == "" {
@@ -123,11 +314,9 @@ func NewGitLabAdapter(config map[string]any) (domain.TrackerAdapter, error) {
 	}
 
 	queryFilterRaw, _ := config["query_filter"].(string)
-	if strings.TrimSpace(queryFilterRaw) != "" {
-		return nil, &domain.TrackerError{
-			Kind:    domain.ErrTrackerPayload,
-			Message: "gitlab: tracker.query_filter is not supported yet; remove the key or leave it empty",
-		}
+	queryFilter, err := parseQueryFilter(queryFilterRaw)
+	if err != nil {
+		return nil, err
 	}
 
 	endpointRaw, _ := config["endpoint"].(string)
@@ -183,7 +372,7 @@ func NewGitLabAdapter(config map[string]any) (domain.TrackerAdapter, error) {
 		return nil, err
 	}
 
-	return &GitLabAdapter{
+	adapter := &GitLabAdapter{
 		client:           client,
 		project:          project,
 		projectPath:      projectPath,
@@ -191,8 +380,11 @@ func NewGitLabAdapter(config map[string]any) (domain.TrackerAdapter, error) {
 		terminalStates:   terminalStates,
 		handoffState:     handoffState,
 		log:              log,
+		queryFilter:      queryFilter,
 		stateLabelCasing: stateLabelCasing,
-	}, nil
+	}
+	adapter.warnUnresolvedFilterLabels(context.Background())
+	return adapter, nil
 }
 
 // configuredStateNames returns the union of activeStates, terminalStates,
@@ -215,6 +407,59 @@ func (a *GitLabAdapter) canonicalLabel(lowered string) string {
 		return casing
 	}
 	return lowered
+}
+
+// warnUnresolvedFilterLabels warns once for each label name in the
+// configured query_filter that no project or group label matches by
+// exact, case-sensitive comparison. GitLab reserves "none" and "any" as
+// wildcards on the non-negated labels parameter, so a segment naming one
+// of those is skipped there and compared under not[labels], where GitLab
+// treats it as a literal name.
+//
+// It returns without reading the label catalog when the filter names no
+// label, and never fails construction: a catalog read failure is logged
+// at WARN and the method returns.
+func (a *GitLabAdapter) warnUnresolvedFilterLabels(ctx context.Context) {
+	type labelsKey struct {
+		raw     string
+		negated bool
+	}
+	var keys []labelsKey
+	for key := range a.queryFilter {
+		canonical, negated, ok := classifyFilterKey(key)
+		if ok && canonical == "labels" {
+			keys = append(keys, labelsKey{raw: key, negated: negated})
+		}
+	}
+	if len(keys) == 0 {
+		return
+	}
+
+	catalog, err := fetchProjectLabels(ctx, a.client, a.projectPath, a.log)
+	if err != nil {
+		a.log.Warn("gitlab query_filter labels catalog unavailable; label names were not validated",
+			slog.Any("error", err))
+		return
+	}
+	known := make(map[string]struct{}, len(catalog))
+	for _, l := range catalog {
+		known[l.Name] = struct{}{}
+	}
+
+	for _, k := range keys {
+		for _, segment := range filterValueSegments(a.queryFilter[k.raw]) {
+			if !k.negated {
+				switch strings.ToLower(segment) {
+				case "none", "any":
+					continue
+				}
+			}
+			if _, ok := known[segment]; !ok {
+				a.log.Warn("gitlab query_filter names a label absent from the project catalog",
+					slog.String("label", segment))
+			}
+		}
+	}
 }
 
 // SetMetrics configures the metrics recorder for tracker API call
@@ -318,8 +563,11 @@ func parseIID(raw string) (int, bool) {
 // State filtering stays client-side: the configured state labels are
 // never pushed into the labels query parameter, whose AND semantics and
 // lack of an OR filter make it unusable for correctness-critical
-// filtering.
-func (a *GitLabAdapter) listAndFilter(ctx context.Context, nativeState string, keep map[string]bool) ([]domain.Issue, error) {
+// filtering. When applyFilter is true and a tracker.query_filter is
+// configured, its parameters replace the adapter's own value for any
+// matching key before the request is issued; when applyFilter is false
+// the request carries only the adapter-owned parameters.
+func (a *GitLabAdapter) listAndFilter(ctx context.Context, nativeState string, keep map[string]bool, applyFilter bool) ([]domain.Issue, error) {
 	path := "/projects/" + a.projectPath + "/issues"
 	params := url.Values{
 		"state":      {nativeState},
@@ -328,6 +576,11 @@ func (a *GitLabAdapter) listAndFilter(ctx context.Context, nativeState string, k
 		"per_page":   {"100"},
 		"order_by":   {"created_at"},
 		"sort":       {"asc"},
+	}
+	if applyFilter && len(a.queryFilter) > 0 {
+		for key, vals := range a.queryFilter {
+			params[key] = slices.Clone(vals)
+		}
 	}
 
 	raw, err := a.paginateIssues(ctx, path, params)
@@ -361,7 +614,7 @@ func (a *GitLabAdapter) FetchCandidateIssues(ctx context.Context) ([]domain.Issu
 			keep[s] = true
 		}
 
-		fetched, fetchErr := a.listAndFilter(ctx, "opened", keep)
+		fetched, fetchErr := a.listAndFilter(ctx, "opened", keep, true)
 		if fetchErr != nil {
 			return fetchErr
 		}
@@ -411,7 +664,7 @@ func (a *GitLabAdapter) FetchIssuesByStates(ctx context.Context, states []string
 		result := make([]domain.Issue, 0)
 
 		if needOpened {
-			opened, fetchErr := a.listAndFilter(ctx, "opened", requested)
+			opened, fetchErr := a.listAndFilter(ctx, "opened", requested, true)
 			if fetchErr != nil {
 				return fetchErr
 			}
@@ -419,7 +672,7 @@ func (a *GitLabAdapter) FetchIssuesByStates(ctx context.Context, states []string
 		}
 
 		if needClosed {
-			closed, fetchErr := a.listAndFilter(ctx, "closed", requested)
+			closed, fetchErr := a.listAndFilter(ctx, "closed", requested, false)
 			if fetchErr != nil {
 				return fetchErr
 			}

--- a/internal/scm/gitlab/gitlab.go
+++ b/internal/scm/gitlab/gitlab.go
@@ -414,12 +414,16 @@ func (a *GitLabAdapter) canonicalLabel(lowered string) string {
 	return lowered
 }
 
-// warnUnresolvedFilterLabels warns once for each label name in the
-// configured query_filter that no project or group label matches by
+// warnUnresolvedFilterLabels warns once for each distinct label name in
+// the configured query_filter that no project or group label matches by
 // exact, case-sensitive comparison. GitLab reserves "none" and "any" as
 // wildcards on the non-negated labels parameter, so a segment naming one
 // of those is skipped there and compared under not[labels], where GitLab
-// treats it as a literal name.
+// treats it as a literal name. A name repeated across several segments,
+// for example a comma-separated duplicate or an array key carrying the
+// same value twice, still produces exactly one WARN; the negated and
+// non-negated forms are distinct names for this purpose, so the same
+// text under labels and under not[labels] each warn once.
 //
 // It returns without reading the label catalog when the filter names no
 // label, and never fails construction: a catalog read failure is logged
@@ -451,6 +455,11 @@ func (a *GitLabAdapter) warnUnresolvedFilterLabels(ctx context.Context) {
 		known[l.Name] = struct{}{}
 	}
 
+	type warnedName struct {
+		name    string
+		negated bool
+	}
+	warned := make(map[warnedName]struct{})
 	for _, k := range keys {
 		for _, segment := range filterValueSegments(a.queryFilter[k.raw]) {
 			if !k.negated {
@@ -459,10 +468,16 @@ func (a *GitLabAdapter) warnUnresolvedFilterLabels(ctx context.Context) {
 					continue
 				}
 			}
-			if _, ok := known[segment]; !ok {
-				a.log.Warn("gitlab query_filter names a label absent from the project catalog",
-					slog.String("label", segment))
+			if _, ok := known[segment]; ok {
+				continue
 			}
+			name := warnedName{name: segment, negated: k.negated}
+			if _, ok := warned[name]; ok {
+				continue
+			}
+			warned[name] = struct{}{}
+			a.log.Warn("gitlab query_filter names a label absent from the project catalog",
+				slog.String("label", segment))
 		}
 	}
 }

--- a/internal/scm/gitlab/gitlab_test.go
+++ b/internal/scm/gitlab/gitlab_test.go
@@ -361,6 +361,7 @@ func TestNewGitLabAdapter(t *testing.T) {
 			{"query_filter reserved name inside not[] falls through to the unknown-key rejection", map[string]any{"api_key": "tok", "project": testProject, "endpoint": unreachable, "query_filter": "not[state]=opened"}, domain.ErrTrackerPayload, "not[state]"},
 			{"query_filter bare not key", map[string]any{"api_key": "tok", "project": testProject, "endpoint": unreachable, "query_filter": "not=x"}, domain.ErrTrackerPayload, "not"},
 			{"query_filter unclosed not[", map[string]any{"api_key": "tok", "project": testProject, "endpoint": unreachable, "query_filter": "not[=x"}, domain.ErrTrackerPayload, "not["},
+			{"query_filter bracket nested inside not[] instead of after it", map[string]any{"api_key": "tok", "project": testProject, "endpoint": unreachable, "query_filter": "not[labels[]]=x"}, domain.ErrTrackerPayload, "not[labels[]]"},
 			{"query_filter empty key", map[string]any{"api_key": "tok", "project": testProject, "endpoint": unreachable, "query_filter": "=x"}, domain.ErrTrackerPayload, ""},
 			{"query_filter multiple unknown keys reports the lexicographically smaller one", map[string]any{"api_key": "tok", "project": testProject, "endpoint": unreachable, "query_filter": "zzz_unknown=1&aaa_unknown=2"}, domain.ErrTrackerPayload, "aaa_unknown"},
 

--- a/internal/scm/gitlab/gitlab_test.go
+++ b/internal/scm/gitlab/gitlab_test.go
@@ -2461,13 +2461,19 @@ func TestQueryFilterLabelsDiagnostic(t *testing.T) {
 
 	t.Run("a name repeated across segments warns once per negation family", func(t *testing.T) {
 		tests := []struct {
-			name          string
-			filter        string
-			wantWarnCount int
+			name             string
+			filter           string
+			wantWarnCount    int
+			wantNegatedAttrs []string
 		}{
-			{"comma-separated duplicate dedupes to one warn", "labels=needs-triage,needs-triage", 1},
-			{"repeated array key with the same value dedupes to one warn", "labels[]=needs-triage&labels[]=needs-triage", 1},
-			{"the same text under labels and not[labels] each warn once", "labels=needs-triage&not[labels]=needs-triage", 2},
+			{"comma-separated duplicate dedupes to one warn", "labels=needs-triage,needs-triage", 1, []string{"negated=false"}},
+			{"repeated array key with the same value dedupes to one warn", "labels[]=needs-triage&labels[]=needs-triage", 1, []string{"negated=false"}},
+			{
+				"the same text under labels and not[labels] each warn once, distinguished by the negated attribute",
+				"labels=needs-triage&not[labels]=needs-triage",
+				2,
+				[]string{"negated=false", "negated=true"},
+			},
 		}
 
 		for _, tt := range tests {
@@ -2492,6 +2498,11 @@ func TestQueryFilterLabelsDiagnostic(t *testing.T) {
 
 				if got := strings.Count(buf.String(), labelAbsentFromCatalogMessage); got != tt.wantWarnCount {
 					t.Errorf("WARN count for %q = %d, want %d\noutput: %s", tt.filter, got, tt.wantWarnCount, buf.String())
+				}
+				for _, attr := range tt.wantNegatedAttrs {
+					if !strings.Contains(buf.String(), attr) {
+						t.Errorf("WARN output missing %q\noutput: %s", attr, buf.String())
+					}
 				}
 			})
 		}

--- a/internal/scm/gitlab/gitlab_test.go
+++ b/internal/scm/gitlab/gitlab_test.go
@@ -221,18 +221,17 @@ func loweredStates(states []string) []string {
 }
 
 // registerTokenAndProject installs only the token and project preflight
-// routes on s for project, leaving the labels route for the caller to
-// register. Unlike [withPreflight] it installs no default empty-array
+// routes on s for [testProject], leaving the labels route for the caller
+// to register. Unlike [withPreflight] it installs no default empty-array
 // labels catalog, so a test can substitute its own labels handler.
-func registerTokenAndProject(t *testing.T, s *fakeServer, project string) {
+func registerTokenAndProject(t *testing.T, s *fakeServer) {
 	t.Helper()
-	escaped := url.PathEscape(project)
 	s.handle("/api/v4/personal_access_tokens/self", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		w.Write(loadFixture(t, "token_self.json")) //nolint:errcheck // test helper
 	})
-	s.handle("/api/v4/projects/"+escaped, func(w http.ResponseWriter, r *http.Request) {
+	s.handle("/api/v4/projects/"+testEscapedProject, func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte(`{}`)) //nolint:errcheck // test helper
 	})
@@ -2374,7 +2373,7 @@ func TestQueryFilterLabelsDiagnostic(t *testing.T) {
 
 				s := newFakeServer(t)
 				var srvURL string
-				registerTokenAndProject(t, s, testProject)
+				registerTokenAndProject(t, s)
 				registerPagedLabels(t, s, &srvURL)
 				var gotLabelsParam string
 				s.handle("/api/v4/projects/"+testEscapedProject+"/issues", func(w http.ResponseWriter, r *http.Request) {
@@ -2434,7 +2433,7 @@ func TestQueryFilterLabelsDiagnostic(t *testing.T) {
 
 				s := newFakeServer(t)
 				var srvURL string
-				registerTokenAndProject(t, s, testProject)
+				registerTokenAndProject(t, s)
 				registerPagedLabels(t, s, &srvURL)
 				srv := httptest.NewServer(s)
 				defer srv.Close()
@@ -2460,12 +2459,50 @@ func TestQueryFilterLabelsDiagnostic(t *testing.T) {
 		}
 	})
 
+	t.Run("a name repeated across segments warns once per negation family", func(t *testing.T) {
+		tests := []struct {
+			name          string
+			filter        string
+			wantWarnCount int
+		}{
+			{"comma-separated duplicate dedupes to one warn", "labels=needs-triage,needs-triage", 1},
+			{"repeated array key with the same value dedupes to one warn", "labels[]=needs-triage&labels[]=needs-triage", 1},
+			{"the same text under labels and not[labels] each warn once", "labels=needs-triage&not[labels]=needs-triage", 2},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				buf := swapDefaultLogger(t)
+
+				s := newFakeServer(t)
+				var srvURL string
+				registerTokenAndProject(t, s)
+				registerPagedLabels(t, s, &srvURL)
+				srv := httptest.NewServer(s)
+				defer srv.Close()
+				srvURL = srv.URL
+
+				cfg := validConfig(testProject)
+				cfg["endpoint"] = srv.URL
+				cfg["query_filter"] = tt.filter
+
+				if _, err := NewGitLabAdapter(cfg); err != nil {
+					t.Fatalf("NewGitLabAdapter(query_filter=%q): %v", tt.filter, err)
+				}
+
+				if got := strings.Count(buf.String(), labelAbsentFromCatalogMessage); got != tt.wantWarnCount {
+					t.Errorf("WARN count for %q = %d, want %d\noutput: %s", tt.filter, got, tt.wantWarnCount, buf.String())
+				}
+			})
+		}
+	})
+
 	t.Run("a failed catalog read during the diagnostic does not fail construction", func(t *testing.T) {
 		buf := swapDefaultLogger(t)
 
 		s := newFakeServer(t)
 		var srvURL string
-		registerTokenAndProject(t, s, testProject)
+		registerTokenAndProject(t, s)
 		basePath := "/api/v4/projects/" + testEscapedProject + "/labels"
 		var rootCalls atomic.Int32
 		s.handle(basePath, func(w http.ResponseWriter, r *http.Request) {

--- a/internal/scm/gitlab/gitlab_test.go
+++ b/internal/scm/gitlab/gitlab_test.go
@@ -57,6 +57,21 @@ func assertTrackerErrorKind(t *testing.T, err error, want domain.TrackerErrorKin
 	}
 }
 
+// assertTrackerErrorMessageContains asserts err unwraps to a
+// *domain.TrackerError whose Message contains want. Tests use this to pin
+// the offending key's presence in a rejection message rather than its
+// exact wording, which is free to change without breaking the test.
+func assertTrackerErrorMessageContains(t *testing.T, err error, want string) {
+	t.Helper()
+	var te *domain.TrackerError
+	if !errors.As(err, &te) {
+		t.Fatalf("error type = %T, want *domain.TrackerError", err)
+	}
+	if !strings.Contains(te.Message, want) {
+		t.Errorf("TrackerError.Message = %q, want substring %q", te.Message, want)
+	}
+}
+
 // assertQueryParams asserts got holds exactly the key/value pairs in want,
 // with no extra or missing keys, so a single call proves both that the
 // expected params merged in and that no unexpected param leaked in. label
@@ -205,6 +220,62 @@ func loweredStates(states []string) []string {
 	return out
 }
 
+// registerTokenAndProject installs only the token and project preflight
+// routes on s for project, leaving the labels route for the caller to
+// register. Unlike [withPreflight] it installs no default empty-array
+// labels catalog, so a test can substitute its own labels handler.
+func registerTokenAndProject(t *testing.T, s *fakeServer, project string) {
+	t.Helper()
+	escaped := url.PathEscape(project)
+	s.handle("/api/v4/personal_access_tokens/self", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write(loadFixture(t, "token_self.json")) //nolint:errcheck // test helper
+	})
+	s.handle("/api/v4/projects/"+escaped, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{}`)) //nolint:errcheck // test helper
+	})
+}
+
+// registerPagedLabels installs a two-page project label catalog (page one
+// "bug"/"documentation", page two "Review"/"URGENT") on s at the labels
+// route for [testProject]. It routes on the request's own "page" query
+// parameter rather than on call order, so two independent fetches within
+// one construction (the preflight's state-casing read and the
+// query_filter diagnostic's read) each see the complete two-page catalog.
+func registerPagedLabels(t *testing.T, s *fakeServer, srvURL *string) {
+	t.Helper()
+	basePath := "/api/v4/projects/" + testEscapedProject + "/labels"
+	s.handle(basePath, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("page") == "2" {
+			w.WriteHeader(http.StatusOK)
+			w.Write(loadFixture(t, "labels_page2.json")) //nolint:errcheck // test helper
+			return
+		}
+		w.Header().Set("Link", fmt.Sprintf(`<%s%s?page=2>; rel="next"`, *srvURL, basePath))
+		w.WriteHeader(http.StatusOK)
+		w.Write(loadFixture(t, "labels_page1.json")) //nolint:errcheck // test helper
+	})
+}
+
+// swapDefaultLogger installs a buffer-backed slog default logger and
+// restores the prior default in cleanup, returning the buffer.
+// NewGitLabAdapter takes its logger from [slog.Default] and offers no
+// injection parameter, so this is the only way to capture its diagnostic
+// output. The default logger is process-global: a test calling this
+// helper, and every one of its subtests, must not call t.Parallel(), or
+// its logging assertions and any concurrently running test's adapter
+// construction can observe each other's logger.
+func swapDefaultLogger(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	var buf bytes.Buffer
+	prior := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	t.Cleanup(func() { slog.SetDefault(prior) })
+	return &buf
+}
+
 // --- parseIID ---
 
 func TestParseIID(t *testing.T) {
@@ -257,17 +328,53 @@ func TestNewGitLabAdapter(t *testing.T) {
 		const unreachable = "http://127.0.0.1:1"
 
 		tests := []struct {
-			name     string
-			config   map[string]any
-			wantKind domain.TrackerErrorKind
+			name                string
+			config              map[string]any
+			wantKind            domain.TrackerErrorKind
+			wantMessageContains string
 		}{
-			{"missing api_key", map[string]any{"project": testProject, "endpoint": unreachable}, domain.ErrMissingTrackerAPIKey},
-			{"empty api_key", map[string]any{"api_key": "", "project": testProject, "endpoint": unreachable}, domain.ErrMissingTrackerAPIKey},
-			{"missing project", map[string]any{"api_key": "tok", "endpoint": unreachable}, domain.ErrMissingTrackerProject},
-			{"empty project", map[string]any{"api_key": "tok", "project": "", "endpoint": unreachable}, domain.ErrMissingTrackerProject},
-			{"non-empty query_filter rejected", map[string]any{"api_key": "tok", "project": testProject, "query_filter": "scope=assigned_to_me", "endpoint": unreachable}, domain.ErrTrackerPayload},
-			{"malformed endpoint scheme", map[string]any{"api_key": "tok", "project": testProject, "endpoint": "ftp://example.com"}, domain.ErrTrackerPayload},
-			{"malformed endpoint no host", map[string]any{"api_key": "tok", "project": testProject, "endpoint": "http://"}, domain.ErrTrackerPayload},
+			{"missing api_key", map[string]any{"project": testProject, "endpoint": unreachable}, domain.ErrMissingTrackerAPIKey, ""},
+			{"empty api_key", map[string]any{"api_key": "", "project": testProject, "endpoint": unreachable}, domain.ErrMissingTrackerAPIKey, ""},
+			{"missing project", map[string]any{"api_key": "tok", "endpoint": unreachable}, domain.ErrMissingTrackerProject, ""},
+			{"empty project", map[string]any{"api_key": "tok", "project": "", "endpoint": unreachable}, domain.ErrMissingTrackerProject, ""},
+			{"malformed endpoint scheme", map[string]any{"api_key": "tok", "project": testProject, "endpoint": "ftp://example.com"}, domain.ErrTrackerPayload, ""},
+			{"malformed endpoint no host", map[string]any{"api_key": "tok", "project": testProject, "endpoint": "http://"}, domain.ErrTrackerPayload, ""},
+
+			{"query_filter malformed percent-encoding", map[string]any{"api_key": "tok", "project": testProject, "endpoint": unreachable, "query_filter": "labels=%zz"}, domain.ErrTrackerPayload, ""},
+			{"query_filter semicolon separator", map[string]any{"api_key": "tok", "project": testProject, "endpoint": unreachable, "query_filter": "a=1;b=2"}, domain.ErrTrackerPayload, ""},
+
+			{"query_filter reserved key state", map[string]any{"api_key": "tok", "project": testProject, "endpoint": unreachable, "query_filter": "state=closed"}, domain.ErrTrackerPayload, "state"},
+			{"query_filter reserved key issue_type", map[string]any{"api_key": "tok", "project": testProject, "endpoint": unreachable, "query_filter": "issue_type=incident"}, domain.ErrTrackerPayload, "issue_type"},
+			{"query_filter reserved key order_by", map[string]any{"api_key": "tok", "project": testProject, "endpoint": unreachable, "query_filter": "order_by=updated_at"}, domain.ErrTrackerPayload, "order_by"},
+			{"query_filter reserved key sort", map[string]any{"api_key": "tok", "project": testProject, "endpoint": unreachable, "query_filter": "sort=desc"}, domain.ErrTrackerPayload, "sort"},
+			{"query_filter reserved key page", map[string]any{"api_key": "tok", "project": testProject, "endpoint": unreachable, "query_filter": "page=2"}, domain.ErrTrackerPayload, "page"},
+			{"query_filter reserved key per_page", map[string]any{"api_key": "tok", "project": testProject, "endpoint": unreachable, "query_filter": "per_page=50"}, domain.ErrTrackerPayload, "per_page"},
+			{"query_filter reserved key pagination", map[string]any{"api_key": "tok", "project": testProject, "endpoint": unreachable, "query_filter": "pagination=keyset"}, domain.ErrTrackerPayload, "pagination"},
+			{"query_filter reserved key with_labels_details", map[string]any{"api_key": "tok", "project": testProject, "endpoint": unreachable, "query_filter": "with_labels_details=true"}, domain.ErrTrackerPayload, "with_labels_details"},
+			{"query_filter multiple reserved keys reports the first in fixed slice order", map[string]any{"api_key": "tok", "project": testProject, "endpoint": unreachable, "query_filter": "sort=desc&per_page=10&state=closed"}, domain.ErrTrackerPayload, "state"},
+
+			{"query_filter unknown key mentioned_by", map[string]any{"api_key": "tok", "project": testProject, "endpoint": unreachable, "query_filter": "mentioned_by=bot"}, domain.ErrTrackerPayload, "mentioned_by"},
+			{"query_filter unknown key assignee", map[string]any{"api_key": "tok", "project": testProject, "endpoint": unreachable, "query_filter": "assignee=bot"}, domain.ErrTrackerPayload, "assignee"},
+			{"query_filter unknown nested key or[label_name][]", map[string]any{"api_key": "tok", "project": testProject, "endpoint": unreachable, "query_filter": "or[label_name][]=x"}, domain.ErrTrackerPayload, "or[label_name][]"},
+			{"query_filter unknown not[] subkey search", map[string]any{"api_key": "tok", "project": testProject, "endpoint": unreachable, "query_filter": "not[search]=x"}, domain.ErrTrackerPayload, "not[search]"},
+			{"query_filter unknown not[] subkey bogus", map[string]any{"api_key": "tok", "project": testProject, "endpoint": unreachable, "query_filter": "not[bogus]=x"}, domain.ErrTrackerPayload, "not[bogus]"},
+			{"query_filter reserved name inside not[] falls through to the unknown-key rejection", map[string]any{"api_key": "tok", "project": testProject, "endpoint": unreachable, "query_filter": "not[state]=opened"}, domain.ErrTrackerPayload, "not[state]"},
+			{"query_filter bare not key", map[string]any{"api_key": "tok", "project": testProject, "endpoint": unreachable, "query_filter": "not=x"}, domain.ErrTrackerPayload, "not"},
+			{"query_filter unclosed not[", map[string]any{"api_key": "tok", "project": testProject, "endpoint": unreachable, "query_filter": "not[=x"}, domain.ErrTrackerPayload, "not["},
+			{"query_filter empty key", map[string]any{"api_key": "tok", "project": testProject, "endpoint": unreachable, "query_filter": "=x"}, domain.ErrTrackerPayload, ""},
+			{"query_filter multiple unknown keys reports the lexicographically smaller one", map[string]any{"api_key": "tok", "project": testProject, "endpoint": unreachable, "query_filter": "zzz_unknown=1&aaa_unknown=2"}, domain.ErrTrackerPayload, "aaa_unknown"},
+
+			{"query_filter labels value empty", map[string]any{"api_key": "tok", "project": testProject, "endpoint": unreachable, "query_filter": "labels="}, domain.ErrTrackerPayload, "labels"},
+			{"query_filter labels bare key with no value", map[string]any{"api_key": "tok", "project": testProject, "endpoint": unreachable, "query_filter": "labels"}, domain.ErrTrackerPayload, "labels"},
+			{"query_filter labels whitespace-only value", map[string]any{"api_key": "tok", "project": testProject, "endpoint": unreachable, "query_filter": "labels=%20"}, domain.ErrTrackerPayload, "labels"},
+			{"query_filter labels single comma value", map[string]any{"api_key": "tok", "project": testProject, "endpoint": unreachable, "query_filter": "labels=,"}, domain.ErrTrackerPayload, "labels"},
+			{"query_filter labels doubled comma value", map[string]any{"api_key": "tok", "project": testProject, "endpoint": unreachable, "query_filter": "labels=,,"}, domain.ErrTrackerPayload, "labels"},
+			{"query_filter labels leading comma", map[string]any{"api_key": "tok", "project": testProject, "endpoint": unreachable, "query_filter": "labels=,backlog"}, domain.ErrTrackerPayload, "labels"},
+			{"query_filter labels trailing comma", map[string]any{"api_key": "tok", "project": testProject, "endpoint": unreachable, "query_filter": "labels=backlog,"}, domain.ErrTrackerPayload, "labels"},
+			{"query_filter negated labels trailing comma", map[string]any{"api_key": "tok", "project": testProject, "endpoint": unreachable, "query_filter": "not[labels]=review,"}, domain.ErrTrackerPayload, "not[labels]"},
+
+			{"query_filter repeated non-array key scope", map[string]any{"api_key": "tok", "project": testProject, "endpoint": unreachable, "query_filter": "scope=all&scope=assigned_to_me"}, domain.ErrTrackerPayload, "scope"},
+			{"query_filter repeated non-array key labels", map[string]any{"api_key": "tok", "project": testProject, "endpoint": unreachable, "query_filter": "labels=a&labels=b"}, domain.ErrTrackerPayload, "labels"},
 		}
 
 		for _, tt := range tests {
@@ -279,7 +386,92 @@ func TestNewGitLabAdapter(t *testing.T) {
 				if a != nil {
 					t.Error("adapter should be nil on error")
 				}
+				if tt.wantMessageContains != "" {
+					assertTrackerErrorMessageContains(t, err, tt.wantMessageContains)
+				}
 			})
+		}
+	})
+
+	t.Run("query_filter colliding spellings name both keys and are order-independent", func(t *testing.T) {
+		t.Parallel()
+
+		const unreachable = "http://127.0.0.1:1"
+
+		tests := []struct {
+			name    string
+			filterA string
+			filterB string
+			keyOne  string
+			keyTwo  string
+		}{
+			{"labels vs labels[]", "labels=a&labels[]=b", "labels[]=b&labels=a", "labels", "labels[]"},
+			{"not[labels] vs not[labels][]", "not[labels]=x&not[labels][]=y", "not[labels][]=y&not[labels]=x", "not[labels]", "not[labels][]"},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+
+				cfgA := map[string]any{"api_key": "tok", "project": testProject, "endpoint": unreachable, "query_filter": tt.filterA}
+				cfgB := map[string]any{"api_key": "tok", "project": testProject, "endpoint": unreachable, "query_filter": tt.filterB}
+
+				_, errA := NewGitLabAdapter(cfgA)
+				_, errB := NewGitLabAdapter(cfgB)
+
+				assertTrackerErrorKind(t, errA, domain.ErrTrackerPayload)
+				assertTrackerErrorKind(t, errB, domain.ErrTrackerPayload)
+				assertTrackerErrorMessageContains(t, errA, tt.keyOne)
+				assertTrackerErrorMessageContains(t, errA, tt.keyTwo)
+
+				var teA, teB *domain.TrackerError
+				if !errors.As(errA, &teA) || !errors.As(errB, &teB) {
+					t.Fatalf("error type = %T / %T, want *domain.TrackerError for both orderings", errA, errB)
+				}
+				if teA.Message != teB.Message {
+					t.Errorf("colliding-spelling message depends on fragment order: %q vs %q", teA.Message, teB.Message)
+				}
+			})
+		}
+	})
+
+	t.Run("query_filter labels value with commas but no empty segment constructs and reaches the request verbatim", func(t *testing.T) {
+		t.Parallel()
+
+		s := newPreflightServer(t)
+		var gotLabels string
+		s.handle("/api/v4/projects/"+testEscapedProject+"/issues", func(w http.ResponseWriter, r *http.Request) {
+			gotLabels = r.URL.Query().Get("labels")
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte("[]")) //nolint:errcheck // test helper
+		})
+		a := mustAdapterWithConfig(t, s, map[string]any{"query_filter": "labels=bug,documentation"})
+
+		if _, err := a.FetchCandidateIssues(context.Background()); err != nil {
+			t.Fatalf("FetchCandidateIssues: %v", err)
+		}
+		if gotLabels != "bug,documentation" {
+			t.Errorf("labels param = %q, want %q", gotLabels, "bug,documentation")
+		}
+	})
+
+	t.Run("query_filter iids[] array key with multiple values constructs and both reach the wire", func(t *testing.T) {
+		t.Parallel()
+
+		s := newPreflightServer(t)
+		var gotIIDs []string
+		s.handle("/api/v4/projects/"+testEscapedProject+"/issues", func(w http.ResponseWriter, r *http.Request) {
+			gotIIDs = r.URL.Query()["iids[]"]
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte("[]")) //nolint:errcheck // test helper
+		})
+		a := mustAdapterWithConfig(t, s, map[string]any{"query_filter": "iids[]=1&iids[]=3"})
+
+		if _, err := a.FetchCandidateIssues(context.Background()); err != nil {
+			t.Fatalf("FetchCandidateIssues: %v", err)
+		}
+		if want := []string{"1", "3"}; !slices.Equal(gotIIDs, want) {
+			t.Errorf("iids[] = %v, want %v", gotIIDs, want)
 		}
 	})
 
@@ -337,6 +529,9 @@ func TestNewGitLabAdapter(t *testing.T) {
 		}
 		if a == nil {
 			t.Fatal("adapter is nil, want a constructed adapter")
+		}
+		if ga := a.(*GitLabAdapter); ga.queryFilter != nil {
+			t.Errorf("queryFilter = %v, want nil", ga.queryFilter)
 		}
 	})
 
@@ -450,6 +645,58 @@ func TestNewGitLabAdapter(t *testing.T) {
 			t.Error("adapter should be nil when the preflight fails")
 		}
 	})
+}
+
+// --- parseQueryFilter ---
+
+func TestParseQueryFilter(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		raw        string
+		wantErr    bool
+		wantKind   domain.TrackerErrorKind
+		wantValues url.Values
+	}{
+		{"empty fragment returns nil values and no error", "", false, "", nil},
+		{"whitespace-only fragment returns nil values and no error", "   ", false, "", nil},
+		{"malformed percent-encoding is rejected", "labels=%zz", true, domain.ErrTrackerPayload, nil},
+		{"semicolon separator is rejected", "a=1;b=2", true, domain.ErrTrackerPayload, nil},
+		{"a reserved key is rejected", "state=closed", true, domain.ErrTrackerPayload, nil},
+		{"an unknown key is rejected", "mentioned_by=bot", true, domain.ErrTrackerPayload, nil},
+		{"an empty comma segment is rejected", "labels=backlog,", true, domain.ErrTrackerPayload, nil},
+		{"a repeated non-array key is rejected", "scope=all&scope=assigned_to_me", true, domain.ErrTrackerPayload, nil},
+		{"colliding spellings of one parameter are rejected", "labels=a&labels[]=b", true, domain.ErrTrackerPayload, nil},
+		{
+			"a valid fragment is accepted",
+			"scope=assigned_to_me&not[labels]=needs-triage",
+			false, "",
+			url.Values{"scope": {"assigned_to_me"}, "not[labels]": {"needs-triage"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			values, err := parseQueryFilter(tt.raw)
+
+			if tt.wantErr {
+				assertTrackerErrorKind(t, err, tt.wantKind)
+				if values != nil {
+					t.Errorf("parseQueryFilter(%q) values = %v, want nil on error", tt.raw, values)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseQueryFilter(%q) unexpected error: %v", tt.raw, err)
+			}
+			if !maps.EqualFunc(values, tt.wantValues, slices.Equal) {
+				t.Errorf("parseQueryFilter(%q) = %v, want %v", tt.raw, values, tt.wantValues)
+			}
+		})
+	}
 }
 
 // --- Percent-encoded project path ---
@@ -839,6 +1086,96 @@ func TestFetchCandidateIssues(t *testing.T) {
 		_, err := a.FetchCandidateIssues(context.Background())
 		assertTrackerErrorKind(t, err, domain.ErrTrackerAuth)
 	})
+
+	t.Run("query_filter merges into the request and the returned set matches active-state filtering", func(t *testing.T) {
+		t.Parallel()
+
+		s := newPreflightServer(t)
+		var gotQuery url.Values
+		s.handle("/api/v4/projects/"+testEscapedProject+"/issues", func(w http.ResponseWriter, r *http.Request) {
+			gotQuery = r.URL.Query()
+			w.WriteHeader(http.StatusOK)
+			w.Write(loadFixture(t, "issues_candidates_page2.json")) //nolint:errcheck // test helper
+		})
+		a := mustAdapterWithConfig(t, s, map[string]any{"query_filter": "scope=assigned_to_me&not[labels]=needs-triage"})
+
+		issues, err := a.FetchCandidateIssues(context.Background())
+		if err != nil {
+			t.Fatalf("FetchCandidateIssues: %v", err)
+		}
+
+		assertQueryParams(t, "candidate", gotQuery, map[string]string{
+			"state": "opened", "issue_type": "issue", "per_page": "100",
+			"order_by": "created_at", "sort": "asc",
+			"scope": "assigned_to_me", "not[labels]": "needs-triage",
+		})
+		wantOrder := []string{"1", "2", "5", "7"}
+		if len(issues) != len(wantOrder) {
+			t.Fatalf("len = %d, want %d: got identifiers %v", len(issues), len(wantOrder), identifiersOf(issues))
+		}
+		for i, want := range wantOrder {
+			if issues[i].Identifier != want {
+				t.Errorf("issues[%d].Identifier = %q, want %q", i, issues[i].Identifier, want)
+			}
+		}
+	})
+
+	t.Run("unset query_filter produces exactly the six adapter-owned params", func(t *testing.T) {
+		t.Parallel()
+
+		s := newPreflightServer(t)
+		var gotQuery url.Values
+		s.handle("/api/v4/projects/"+testEscapedProject+"/issues", func(w http.ResponseWriter, r *http.Request) {
+			gotQuery = r.URL.Query()
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte("[]")) //nolint:errcheck // test helper
+		})
+		a := mustAdapter(t, s)
+
+		if _, err := a.FetchCandidateIssues(context.Background()); err != nil {
+			t.Fatalf("FetchCandidateIssues: %v", err)
+		}
+
+		assertQueryParams(t, "candidate", gotQuery, map[string]string{
+			"state": "opened", "issue_type": "issue", "scope": "all",
+			"per_page": "100", "order_by": "created_at", "sort": "asc",
+		})
+		if a.queryFilter != nil {
+			t.Errorf("queryFilter = %v, want nil", a.queryFilter)
+		}
+	})
+
+	t.Run("query_filter is not mutated across two sequential fetches", func(t *testing.T) {
+		t.Parallel()
+
+		s := newPreflightServer(t)
+		var queries []url.Values
+		s.handle("/api/v4/projects/"+testEscapedProject+"/issues", func(w http.ResponseWriter, r *http.Request) {
+			queries = append(queries, r.URL.Query())
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte("[]")) //nolint:errcheck // test helper
+		})
+		a := mustAdapterWithConfig(t, s, map[string]any{"query_filter": "scope=assigned_to_me&not[labels]=needs-triage"})
+
+		before := maps.Clone(a.queryFilter)
+
+		if _, err := a.FetchCandidateIssues(context.Background()); err != nil {
+			t.Fatalf("FetchCandidateIssues (first): %v", err)
+		}
+		if _, err := a.FetchCandidateIssues(context.Background()); err != nil {
+			t.Fatalf("FetchCandidateIssues (second): %v", err)
+		}
+
+		if len(queries) != 2 {
+			t.Fatalf("request count = %d, want 2", len(queries))
+		}
+		if !maps.EqualFunc(queries[0], queries[1], slices.Equal) {
+			t.Errorf("sequential fetches produced different queries: %v vs %v", queries[0], queries[1])
+		}
+		if !maps.EqualFunc(a.queryFilter, before, slices.Equal) {
+			t.Errorf("queryFilter mutated across fetches: got %v, want %v", a.queryFilter, before)
+		}
+	})
 }
 
 func identifiersOf(issues []domain.Issue) []string {
@@ -972,6 +1309,43 @@ func TestFetchIssuesByStates(t *testing.T) {
 		if !gotClosed.Load() {
 			t.Error("closed state was not queried")
 		}
+	})
+
+	t.Run("query_filter merges into the opened half and leaves the closed half untouched", func(t *testing.T) {
+		t.Parallel()
+
+		s := newPreflightServer(t)
+		var openedQuery, closedQuery url.Values
+		s.handle("/api/v4/projects/"+testEscapedProject+"/issues", func(w http.ResponseWriter, r *http.Request) {
+			switch state := r.URL.Query().Get("state"); state {
+			case "opened":
+				openedQuery = r.URL.Query()
+				w.WriteHeader(http.StatusOK)
+				w.Write(loadFixture(t, "issues_open_by_states.json")) //nolint:errcheck // test helper
+			case "closed":
+				closedQuery = r.URL.Query()
+				w.WriteHeader(http.StatusOK)
+				w.Write(loadFixture(t, "issues_closed_by_states.json")) //nolint:errcheck // test helper
+			default:
+				t.Errorf("unexpected state query param: %q", state)
+				w.WriteHeader(http.StatusBadRequest)
+			}
+		})
+		a := mustAdapterWithConfig(t, s, map[string]any{"query_filter": "scope=assigned_to_me&not[labels]=needs-triage"})
+
+		if _, err := a.FetchIssuesByStates(context.Background(), []string{"in-progress", "done"}); err != nil {
+			t.Fatalf("FetchIssuesByStates: %v", err)
+		}
+
+		assertQueryParams(t, "opened-state", openedQuery, map[string]string{
+			"state": "opened", "issue_type": "issue", "per_page": "100",
+			"order_by": "created_at", "sort": "asc",
+			"scope": "assigned_to_me", "not[labels]": "needs-triage",
+		})
+		assertQueryParams(t, "closed-state", closedQuery, map[string]string{
+			"state": "closed", "issue_type": "issue", "scope": "all",
+			"per_page": "100", "order_by": "created_at", "sort": "asc",
+		})
 	})
 }
 
@@ -1382,6 +1756,39 @@ func TestFetchIssueStatesByIDs(t *testing.T) {
 		_, err := a.FetchIssueStatesByIDs(context.Background(), []string{"1"})
 		assertTrackerErrorKind(t, err, domain.ErrTrackerNotFound)
 	})
+
+	t.Run("query_filter is configured but never merged into the batch request", func(t *testing.T) {
+		t.Parallel()
+
+		s := newPreflightServer(t)
+		var gotQuery url.Values
+		s.handle("/api/v4/projects/"+testEscapedProject+"/issues", func(w http.ResponseWriter, r *http.Request) {
+			gotQuery = r.URL.Query()
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`[{"iid": 10, "state": "opened", "issue_type": "issue", "labels": ["in-progress"]}]`)) //nolint:errcheck // test helper
+		})
+		a := mustAdapterWithConfig(t, s, map[string]any{"query_filter": "scope=assigned_to_me&not[labels]=needs-triage"})
+
+		if _, err := a.FetchIssueStatesByIDs(context.Background(), []string{"10"}); err != nil {
+			t.Fatalf("FetchIssueStatesByIDs: %v", err)
+		}
+
+		if got, want := gotQuery.Get("state"), "all"; got != want {
+			t.Errorf("state = %q, want %q", got, want)
+		}
+		if got, want := gotQuery.Get("scope"), "all"; got != want {
+			t.Errorf("scope = %q, want %q (query_filter must not reach the batch route)", got, want)
+		}
+		if got, want := gotQuery.Get("per_page"), "100"; got != want {
+			t.Errorf("per_page = %q, want %q", got, want)
+		}
+		if want := []string{"10"}; !slices.Equal(gotQuery["iids[]"], want) {
+			t.Errorf("iids[] = %v, want %v", gotQuery["iids[]"], want)
+		}
+		if len(gotQuery) != 4 {
+			t.Errorf("batch request query = %v, want exactly 4 keys (state, scope, per_page, iids[]), no operator parameter", gotQuery)
+		}
+	})
 }
 
 func TestFetchIssueStatesByIdentifiers(t *testing.T) {
@@ -1420,6 +1827,30 @@ func TestFetchIssueStatesByIdentifiers(t *testing.T) {
 		}
 		if len(states) != 0 {
 			t.Errorf("len = %d, want 0", len(states))
+		}
+	})
+
+	t.Run("query_filter is configured but never merged into the batch request", func(t *testing.T) {
+		t.Parallel()
+
+		s := newPreflightServer(t)
+		var gotQuery url.Values
+		s.handle("/api/v4/projects/"+testEscapedProject+"/issues", func(w http.ResponseWriter, r *http.Request) {
+			gotQuery = r.URL.Query()
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`[{"iid": 10, "state": "opened", "issue_type": "issue", "labels": ["in-progress"]}]`)) //nolint:errcheck // test helper
+		})
+		a := mustAdapterWithConfig(t, s, map[string]any{"query_filter": "scope=assigned_to_me&not[labels]=needs-triage"})
+
+		if _, err := a.FetchIssueStatesByIdentifiers(context.Background(), []string{"10"}); err != nil {
+			t.Fatalf("FetchIssueStatesByIdentifiers: %v", err)
+		}
+
+		if got, want := gotQuery.Get("scope"), "all"; got != want {
+			t.Errorf("scope = %q, want %q (query_filter must not reach the batch route)", got, want)
+		}
+		if len(gotQuery) != 4 {
+			t.Errorf("batch request query = %v, want exactly 4 keys (state, scope, per_page, iids[]), no operator parameter", gotQuery)
 		}
 	})
 }
@@ -1912,6 +2343,162 @@ func TestLabelCatalogPagination(t *testing.T) {
 		want := `{"add_labels":["Review"]}`
 		if string(putBody) != want {
 			t.Errorf("PUT body = %s, want %s (the attach must use page two's stored casing)", putBody, want)
+		}
+	})
+}
+
+// --- query_filter labels diagnostic (W1, W2, wildcard exemptions) ---
+//
+// NewGitLabAdapter takes its logger from slog.Default(), so every subtest
+// here calls swapDefaultLogger and none of them, nor this function itself,
+// calls t.Parallel(): the process-global default logger must not be
+// swapped concurrently with another test's adapter construction.
+
+const labelAbsentFromCatalogMessage = "gitlab query_filter names a label absent from the project catalog"
+
+func TestQueryFilterLabelsDiagnostic(t *testing.T) {
+	t.Run("a name absent from the catalog logs one WARN and the filter still reaches the request", func(t *testing.T) {
+		tests := []struct {
+			name   string
+			filter string
+			label  string
+		}{
+			{"catalog holds a different case", "labels=review", "review"},
+			{"catalog holds no such name", "labels=needs-triage", "needs-triage"},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				buf := swapDefaultLogger(t)
+
+				s := newFakeServer(t)
+				var srvURL string
+				registerTokenAndProject(t, s, testProject)
+				registerPagedLabels(t, s, &srvURL)
+				var gotLabelsParam string
+				s.handle("/api/v4/projects/"+testEscapedProject+"/issues", func(w http.ResponseWriter, r *http.Request) {
+					gotLabelsParam = r.URL.Query().Get("labels")
+					w.WriteHeader(http.StatusOK)
+					w.Write([]byte("[]")) //nolint:errcheck // test helper
+				})
+				srv := httptest.NewServer(s)
+				defer srv.Close()
+				srvURL = srv.URL
+
+				cfg := validConfig(testProject)
+				cfg["endpoint"] = srv.URL
+				cfg["query_filter"] = tt.filter
+
+				adapter, err := NewGitLabAdapter(cfg)
+				if err != nil {
+					t.Fatalf("NewGitLabAdapter(query_filter=%q): %v", tt.filter, err)
+				}
+				ga := adapter.(*GitLabAdapter)
+
+				if got := strings.Count(buf.String(), labelAbsentFromCatalogMessage); got != 1 {
+					t.Errorf("WARN count for %q = %d, want 1\noutput: %s", tt.filter, got, buf.String())
+				}
+				if want := "label=" + tt.label; !strings.Contains(buf.String(), want) {
+					t.Errorf("WARN output missing %q\noutput: %s", want, buf.String())
+				}
+
+				if _, err := ga.FetchCandidateIssues(context.Background()); err != nil {
+					t.Fatalf("FetchCandidateIssues: %v", err)
+				}
+				if gotLabelsParam != tt.label {
+					t.Errorf("candidate request labels param = %q, want %q", gotLabelsParam, tt.label)
+				}
+			})
+		}
+	})
+
+	t.Run("wildcard exemptions", func(t *testing.T) {
+		tests := []struct {
+			name           string
+			filter         string
+			wantWarnLabels []string
+		}{
+			{"bare None is exempt", "labels=None", nil},
+			{"bare Any is exempt", "labels=Any", nil},
+			{"lowercase any is exempt", "labels=any", nil},
+			{"array-form None is exempt", "labels[]=None", nil},
+			{"None exempt alongside a real name", "labels=documentation,None", nil},
+			{"negated Any is a literal name", "not[labels]=Any", []string{"Any"}},
+			{"negated None is a literal name", "not[labels]=None", []string{"None"}},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				buf := swapDefaultLogger(t)
+
+				s := newFakeServer(t)
+				var srvURL string
+				registerTokenAndProject(t, s, testProject)
+				registerPagedLabels(t, s, &srvURL)
+				srv := httptest.NewServer(s)
+				defer srv.Close()
+				srvURL = srv.URL
+
+				cfg := validConfig(testProject)
+				cfg["endpoint"] = srv.URL
+				cfg["query_filter"] = tt.filter
+
+				if _, err := NewGitLabAdapter(cfg); err != nil {
+					t.Fatalf("NewGitLabAdapter(query_filter=%q): %v", tt.filter, err)
+				}
+
+				if got := strings.Count(buf.String(), labelAbsentFromCatalogMessage); got != len(tt.wantWarnLabels) {
+					t.Errorf("WARN count for %q = %d, want %d\noutput: %s", tt.filter, got, len(tt.wantWarnLabels), buf.String())
+				}
+				for _, label := range tt.wantWarnLabels {
+					if want := "label=" + label; !strings.Contains(buf.String(), want) {
+						t.Errorf("WARN output missing %q\noutput: %s", want, buf.String())
+					}
+				}
+			})
+		}
+	})
+
+	t.Run("a failed catalog read during the diagnostic does not fail construction", func(t *testing.T) {
+		buf := swapDefaultLogger(t)
+
+		s := newFakeServer(t)
+		var srvURL string
+		registerTokenAndProject(t, s, testProject)
+		basePath := "/api/v4/projects/" + testEscapedProject + "/labels"
+		var rootCalls atomic.Int32
+		s.handle(basePath, func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Query().Get("page") == "2" {
+				w.WriteHeader(http.StatusOK)
+				w.Write(loadFixture(t, "labels_page2.json")) //nolint:errcheck // test helper
+				return
+			}
+			if rootCalls.Add(1) > 1 {
+				w.WriteHeader(http.StatusInternalServerError)
+				w.Write([]byte(`{"message":"internal server error"}`)) //nolint:errcheck // test helper
+				return
+			}
+			w.Header().Set("Link", fmt.Sprintf(`<%s%s?page=2>; rel="next"`, srvURL, basePath))
+			w.WriteHeader(http.StatusOK)
+			w.Write(loadFixture(t, "labels_page1.json")) //nolint:errcheck // test helper
+		})
+		srv := httptest.NewServer(s)
+		defer srv.Close()
+		srvURL = srv.URL
+
+		cfg := validConfig(testProject)
+		cfg["endpoint"] = srv.URL
+		cfg["query_filter"] = "labels=review"
+
+		if _, err := NewGitLabAdapter(cfg); err != nil {
+			t.Fatalf("NewGitLabAdapter: unexpected error from a failed diagnostic catalog read: %v", err)
+		}
+
+		if got := strings.Count(buf.String(), "gitlab query_filter labels catalog unavailable; label names were not validated"); got != 1 {
+			t.Errorf("W2 WARN count = %d, want 1\noutput: %s", got, buf.String())
+		}
+		if !strings.Contains(buf.String(), "error=") {
+			t.Errorf("W2 WARN missing an \"error\" attribute\noutput: %s", buf.String())
 		}
 	})
 }


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Feat

**Intent:** Let a GitLab workflow narrow candidate polling with `tracker.query_filter`, matching the behavior already available on the Jira, GitHub, Linear, and Gitea tracker adapters. The motivating scenario is a shared GitLab instance where candidates should be scoped to issues assigned to, or mentioning, the automation identity.

**Related Issues:** #679

### 🧭 Reviewer Guide

**Complexity:** Medium

#### Entry Point

`internal/scm/gitlab/gitlab.go` - `parseQueryFilter` is where the operator-supplied `tracker.query_filter` string is parsed into `url.Values` and validated at construction time, before any network call. It rejects adapter-owned keys (`state`, `issue_type`, `order_by`, `sort`, `page`, `per_page`, `pagination`, `with_labels_details`), keys outside GitLab's documented issue-list parameters, repeated non-array keys, empty comma-separated segments, and a parameter named under two spellings (e.g. `labels` and `labels[]`). The `not[...]` negation hash is honored for the subset of keys GitLab negates. `listAndFilter` then merges the validated filter into the opened-issue list request used by `FetchCandidateIssues` and the opened half of `FetchIssuesByStates`; the closed-issue lookup never applies the filter, since terminal-state reconciliation must see every closed issue regardless of the operator's polling scope.

#### Sensitive Areas

- `internal/scm/gitlab/gitlab.go`: `classifyFilterKey` and the reserved/allowed/negatable key sets are the correctness boundary between operator input and adapter-owned request parameters; a gap here would let a filter silently override adapter state handling.
- `internal/scm/gitlab/gitlab.go`: `warnUnresolvedFilterLabels` performs a best-effort, non-failing catalog read at construction to warn about label names the filter references that the project does not hold - it must never fail construction on a catalog-read error.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes. `tracker.query_filter` was previously rejected outright for `tracker.kind: gitlab`; it is now accepted and validated. Behavior is unchanged when the key is unset.
- **Migrations/State:** No migrations or state changes.
