### PR TITLE
feat(scm/gitlab): add sortie validate checks for tracker.kind: gitlab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#676](https://github.com/sortie-ai/sortie/issues/676),
   [#677](https://github.com/sortie-ai/sortie/issues/677),
   [#679](https://github.com/sortie-ai/sortie/issues/679))
+- `sortie validate` GitLab adapter config validation: emits offline
+  diagnostics for `tracker.kind: gitlab` covering `tracker.endpoint` URL
+  shape (flagging a cleartext `http` scheme and a base URL that already
+  ends in `/api/v4`), `tracker.project` as a `group/project` path or a
+  numeric project ID, a `$SORTIE_GITLAB_TOKEN` environment-variable
+  hint, `tracker.query_filter` syntax and adapter-owned keys, and empty,
+  untrimmed, or overlapping active/terminal state labels. Errors block
+  dispatch; warnings are advisory.
+  ([#678](https://github.com/sortie-ai/sortie/issues/678))
 
 ## [1.16.1] - 2026-08-03
 

--- a/internal/orchestrator/preflight.go
+++ b/internal/orchestrator/preflight.go
@@ -162,6 +162,7 @@ func ValidateDispatchConfig(params PreflightParams) PreflightResult {
 				TerminalStates:  cfg.Tracker.TerminalStates,
 				HandoffState:    cfg.Tracker.HandoffState,
 				InProgressState: cfg.Tracker.InProgressState,
+				QueryFilter:     cfg.Tracker.QueryFilter,
 			}
 			for _, d := range trackerMeta.ValidateTrackerConfig(fields) {
 				switch d.Severity {

--- a/internal/orchestrator/preflight_test.go
+++ b/internal/orchestrator/preflight_test.go
@@ -553,6 +553,91 @@ func TestValidateDispatchConfig(t *testing.T) {
 	}
 }
 
+// TestValidateDispatchConfig_QueryFilterPropagation covers the one
+// generic-layer plumbing addition: registry.TrackerConfigFields.QueryFilter
+// must reach the tracker hook populated from cfg.Tracker.QueryFilter, and a
+// validator that never reads it must see no change in its diagnostics.
+func TestValidateDispatchConfig_QueryFilterPropagation(t *testing.T) {
+	t.Parallel()
+
+	t.Run("hook receives the configured QueryFilter", func(t *testing.T) {
+		t.Parallel()
+
+		var captured registry.TrackerConfigFields
+		params := validPreflightParams()
+		params.ConfigFunc = func() config.ServiceConfig {
+			return config.ServiceConfig{
+				Tracker: config.TrackerConfig{
+					Kind:        "test-tracker",
+					APIKey:      "secret",
+					QueryFilter: "scope=assigned_to_me",
+				},
+				Agent: config.AgentConfig{
+					Kind:    "test-agent",
+					Command: "/usr/bin/agent",
+				},
+			}
+		}
+		params.TrackerRegistry = &stubTrackerRegistry{
+			getFunc: func(string) (registry.TrackerConstructor, error) { return nil, nil },
+			metaFunc: func(string) (registry.TrackerMeta, bool) {
+				return registry.TrackerMeta{
+					ValidateTrackerConfig: func(fields registry.TrackerConfigFields) []registry.ValidationDiag {
+						captured = fields
+						return nil
+					},
+				}, true
+			},
+		}
+
+		result := ValidateDispatchConfig(params)
+
+		if !result.OK() {
+			t.Fatalf("ValidateDispatchConfig() OK = false, want true; errors: %v", result.Errors)
+		}
+		if captured.QueryFilter != "scope=assigned_to_me" {
+			t.Errorf("ValidateDispatchConfig() captured fields.QueryFilter = %q, want %q",
+				captured.QueryFilter, "scope=assigned_to_me")
+		}
+	})
+
+	t.Run("a validator that ignores QueryFilter emits identical diagnostics regardless of its value", func(t *testing.T) {
+		t.Parallel()
+
+		validate := func(_ registry.TrackerConfigFields) []registry.ValidationDiag { return nil }
+
+		for _, queryFilter := range []string{"", "scope=assigned_to_me"} {
+			params := validPreflightParams()
+			params.ConfigFunc = func() config.ServiceConfig {
+				return config.ServiceConfig{
+					Tracker: config.TrackerConfig{
+						Kind:        "test-tracker",
+						APIKey:      "secret",
+						QueryFilter: queryFilter,
+					},
+					Agent: config.AgentConfig{
+						Kind:    "test-agent",
+						Command: "/usr/bin/agent",
+					},
+				}
+			}
+			params.TrackerRegistry = &stubTrackerRegistry{
+				getFunc: func(string) (registry.TrackerConstructor, error) { return nil, nil },
+				metaFunc: func(string) (registry.TrackerMeta, bool) {
+					return registry.TrackerMeta{ValidateTrackerConfig: validate}, true
+				},
+			}
+
+			result := ValidateDispatchConfig(params)
+
+			if !result.OK() || len(result.Warnings) != 0 {
+				t.Errorf("ValidateDispatchConfig() with QueryFilter=%q = OK:%v warnings:%v, want OK with no diagnostics",
+					queryFilter, result.OK(), result.Warnings)
+			}
+		}
+	})
+}
+
 // TestValidateDispatchConfig_DefaultedTrackerStates covers the collision
 // rules re-run against the effective state lists, the ones a tracker
 // adapter fills from its own fallback when the workflow list is empty.

--- a/internal/registry/adapter_meta_test.go
+++ b/internal/registry/adapter_meta_test.go
@@ -153,4 +153,16 @@ func TestAdapterMeta_RealRegistrations(t *testing.T) {
 			t.Error(`Trackers.Meta("github").ValidateTrackerConfig = nil, want non-nil`)
 		}
 	})
+
+	t.Run("gitlab exposes ValidateTrackerConfig", func(t *testing.T) {
+		t.Parallel()
+
+		meta, ok := registry.Trackers.Meta("gitlab")
+		if !ok {
+			t.Fatal(`Trackers.Meta("gitlab") reported not registered`)
+		}
+		if meta.ValidateTrackerConfig == nil {
+			t.Error(`Trackers.Meta("gitlab").ValidateTrackerConfig = nil, want non-nil`)
+		}
+	})
 }

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -88,6 +88,11 @@ type TrackerConfigFields struct {
 	TerminalStates  []string
 	HandoffState    string
 	InProgressState string
+
+	// QueryFilter is the resolved tracker.query_filter value. An adapter
+	// that interprets the key checks its shape here; an adapter that
+	// ignores the key leaves the field unread.
+	QueryFilter string
 }
 
 // ValidationDiag is a single diagnostic produced by adapter config

--- a/internal/scm/gitlab/gitlab.go
+++ b/internal/scm/gitlab/gitlab.go
@@ -53,6 +53,7 @@ func init() {
 		RequiresAPIKey:        true,
 		DefaultActiveStates:   defaultActiveStates,
 		DefaultTerminalStates: defaultTerminalStates,
+		ValidateTrackerConfig: validateConfig,
 	})
 }
 

--- a/internal/scm/gitlab/validate.go
+++ b/internal/scm/gitlab/validate.go
@@ -1,0 +1,302 @@
+package gitlab
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"os"
+	"slices"
+	"strings"
+
+	"github.com/sortie-ai/sortie/internal/domain"
+	"github.com/sortie-ai/sortie/internal/registry"
+)
+
+// validateConfig checks GitLab-specific configuration constraints and
+// returns diagnostics for the sortie validate pipeline. It does not
+// construct an adapter instance or make network calls.
+func validateConfig(fields registry.TrackerConfigFields) []registry.ValidationDiag {
+	var diags []registry.ValidationDiag
+
+	diags = append(diags, validateEndpoint(fields.Endpoint)...)
+	diags = append(diags, validateProject(fields.Project)...)
+	diags = append(diags, validateAPIKeyHint(fields.APIKey)...)
+	diags = append(diags, validateStateLabels("tracker.active_states", fields.ActiveStates)...)
+	diags = append(diags, validateStateLabels("tracker.terminal_states", fields.TerminalStates)...)
+	diags = append(diags, validateStateOverlap(fields)...)
+	diags = append(diags, validateQueryFilter(fields.QueryFilter)...)
+
+	return diags
+}
+
+// containsWhitespace reports whether s contains any whitespace
+// characters.
+func containsWhitespace(s string) bool {
+	for _, r := range s {
+		if r == ' ' || r == '\t' || r == '\n' || r == '\r' {
+			return true
+		}
+	}
+	return false
+}
+
+// toLowerSet builds a set of lowercased strings from a slice.
+func toLowerSet(ss []string) map[string]struct{} {
+	m := make(map[string]struct{}, len(ss))
+	for _, s := range ss {
+		m[strings.ToLower(s)] = struct{}{}
+	}
+	return m
+}
+
+// containsFold reports whether s contains substr, comparing
+// case-insensitively.
+func containsFold(s, substr string) bool {
+	return strings.Contains(strings.ToLower(s), strings.ToLower(substr))
+}
+
+// isAllASCIIDigits reports whether every byte of s is an ASCII digit.
+// It returns false for an empty string, a signed value such as "+42",
+// and any non-digit byte, and true for a digit string too long to fit
+// an int.
+func isAllASCIIDigits(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+// validateEndpoint checks the shape of tracker.endpoint when present.
+//
+// GitLab defaults to the GitLab.com host, so an empty or whitespace-only
+// endpoint yields no diagnostic; [NewGitLabAdapter] substitutes
+// https://gitlab.com for that case. A present value that does not parse
+// to an absolute http(s) URL with a host is a blocking error, matching
+// the shape [NewGitLabAdapter] rejects before any network call. A plain
+// http endpoint and a redundant /api/v4 suffix each yield an advisory
+// warning. Messages never echo the raw value, which can embed userinfo
+// credentials.
+func validateEndpoint(endpoint string) []registry.ValidationDiag {
+	trimmed := strings.TrimSpace(endpoint)
+	if trimmed == "" {
+		return nil
+	}
+
+	parsed, err := url.Parse(trimmed)
+	if err != nil || (parsed.Scheme != "http" && parsed.Scheme != "https") || parsed.Host == "" {
+		return []registry.ValidationDiag{{
+			Severity: "error",
+			Check:    "tracker.endpoint.invalid",
+			Message:  `tracker.endpoint must be an absolute http(s) URL with a host (e.g. "https://gitlab.example.com")`,
+		}}
+	}
+
+	var diags []registry.ValidationDiag
+	if parsed.Scheme == "http" {
+		diags = append(diags, registry.ValidationDiag{
+			Severity: "warning",
+			Check:    "tracker.endpoint.insecure",
+			Message:  "tracker.endpoint uses http; the access token travels in cleartext in the PRIVATE-TOKEN header, use https",
+		})
+	}
+	if strings.HasSuffix(strings.TrimRight(parsed.Path, "/"), "/api/v4") {
+		diags = append(diags, registry.ValidationDiag{
+			Severity: "warning",
+			Check:    "tracker.endpoint.api_suffix",
+			Message:  "tracker.endpoint already ends in /api/v4; the adapter appends it automatically",
+		})
+	}
+	return diags
+}
+
+// validateProject checks that tracker.project is a numeric project id or
+// a namespace path.
+//
+// Empty project is skipped because the generic required-field check runs
+// earlier in the preflight pipeline. GitLab subgroup paths nest to any
+// depth, so this helper carries no exactly-one-slash rule, unlike the
+// owner/repo grammar the GitHub and Gitea validators enforce.
+func validateProject(project string) []registry.ValidationDiag {
+	if project == "" {
+		return nil
+	}
+
+	trimmed := strings.TrimSpace(project)
+	if trimmed == "" {
+		return []registry.ValidationDiag{{
+			Severity: "error",
+			Check:    "tracker.project.format",
+			Message:  `tracker.project is whitespace only; set a numeric project id or a namespace path such as "group/project"`,
+		}}
+	}
+
+	if isAllASCIIDigits(trimmed) {
+		return nil
+	}
+
+	if containsWhitespace(trimmed) {
+		return []registry.ValidationDiag{{
+			Severity: "error",
+			Check:    "tracker.project.format",
+			Message:  "tracker.project must not contain whitespace",
+		}}
+	}
+
+	if containsFold(trimmed, "%2f") {
+		return []registry.ValidationDiag{{
+			Severity: "error",
+			Check:    "tracker.project.format",
+			Message:  `tracker.project must not be percent-encoded; write "group/project" and let the adapter encode it`,
+		}}
+	}
+
+	if !strings.Contains(trimmed, "/") {
+		return []registry.ValidationDiag{{
+			Severity: "error",
+			Check:    "tracker.project.format",
+			Message:  `tracker.project must be a namespace path such as "group/project" or "group/subgroup/project", or a numeric project id`,
+		}}
+	}
+
+	if slices.Contains(strings.Split(trimmed, "/"), "") {
+		return []registry.ValidationDiag{{
+			Severity: "error",
+			Check:    "tracker.project.format",
+			Message:  "tracker.project must not contain an empty path segment or a leading or trailing slash",
+		}}
+	}
+
+	return nil
+}
+
+// validateAPIKeyHint produces advisory diagnostics for the resolved
+// tracker.api_key. An empty key hints about the SORTIE_GITLAB_TOKEN
+// environment variable; a non-empty key surrounded by whitespace is
+// flagged because the key is sent verbatim in the PRIVATE-TOKEN header.
+// There is no token-prefix or token-length check, because the prefix is
+// an administrator-writable application setting. The key value is never
+// logged or placed in a diagnostic message.
+func validateAPIKeyHint(apiKey string) []registry.ValidationDiag {
+	trimmed := strings.TrimSpace(apiKey)
+
+	if trimmed == "" {
+		if os.Getenv("SORTIE_GITLAB_TOKEN") != "" {
+			return []registry.ValidationDiag{{
+				Severity: "warning",
+				Check:    "tracker.api_key.sortie_gitlab_token_hint",
+				Message:  "tracker.api_key is empty but SORTIE_GITLAB_TOKEN environment variable is set; consider using api_key: $SORTIE_GITLAB_TOKEN",
+			}}
+		}
+
+		return []registry.ValidationDiag{{
+			Severity: "warning",
+			Check:    "tracker.api_key.sortie_gitlab_token_missing",
+			Message:  "tracker.api_key is empty and SORTIE_GITLAB_TOKEN environment variable is not set",
+		}}
+	}
+
+	if apiKey != trimmed {
+		return []registry.ValidationDiag{{
+			Severity: "warning",
+			Check:    "tracker.api_key.gitlab_whitespace",
+			Message:  "tracker.api_key has leading or trailing whitespace; the value is sent verbatim in the PRIVATE-TOKEN header and a server that does not strip it will reject the credential",
+		}}
+	}
+
+	return nil
+}
+
+// validateStateLabels checks for empty or untrimmed elements in a state
+// label list.
+//
+// Both fault classes are warnings, never errors, because [NewGitLabAdapter]
+// substitutes its default state lists for an omitted or wholly empty list
+// and the online preflight treats an absent configured label as the
+// operator's intended new label rather than an error. The untrimmed arm is
+// carried, unlike the sibling GitHub and Gitea validators, because GitLab
+// lowercases configured states without trimming, so a padded label can
+// never match a normalized issue label.
+func validateStateLabels(field string, states []string) []registry.ValidationDiag {
+	var diags []registry.ValidationDiag
+	for i, s := range states {
+		trimmed := strings.TrimSpace(s)
+		if trimmed == "" {
+			diags = append(diags, registry.ValidationDiag{
+				Severity: "warning",
+				Check:    field + ".empty_element",
+				Message:  fmt.Sprintf("%s[%d]: empty state label never matches an issue label", field, i),
+			})
+			continue
+		}
+		if trimmed != s {
+			diags = append(diags, registry.ValidationDiag{
+				Severity: "warning",
+				Check:    field + ".untrimmed_element",
+				Message: fmt.Sprintf(
+					"%s[%d]: state label has leading or trailing whitespace; it never matches a normalized issue label, and a write would create a padded label", field, i),
+			})
+		}
+	}
+	return diags
+}
+
+// validateStateOverlap detects state names shared between active_states
+// and terminal_states, compared case-insensitively. Collisions involving
+// handoff_state or in_progress_state are rejected by the generic config
+// validation before this hook runs, and in_progress_state is not a
+// GitLab config key at all, so there are no arms for either here.
+func validateStateOverlap(fields registry.TrackerConfigFields) []registry.ValidationDiag {
+	var diags []registry.ValidationDiag
+
+	activeSet := toLowerSet(fields.ActiveStates)
+	terminalSet := toLowerSet(fields.TerminalStates)
+
+	var overlap []string
+	for name := range activeSet {
+		if strings.TrimSpace(name) == "" {
+			continue
+		}
+		if _, ok := terminalSet[name]; ok {
+			overlap = append(overlap, name)
+		}
+	}
+	slices.Sort(overlap)
+	for _, name := range overlap {
+		diags = append(diags, registry.ValidationDiag{
+			Severity: "warning",
+			Check:    "tracker.states.overlap",
+			Message: fmt.Sprintf(
+				"tracker.active_states and tracker.terminal_states overlap on %q; an issue in state %q would match both sets", name, name),
+		})
+	}
+
+	return diags
+}
+
+// validateQueryFilter checks the shape of tracker.query_filter by
+// reusing [parseQueryFilter], the same grammar [NewGitLabAdapter] enforces
+// at construction, so the offline verdict cannot drift from the
+// construction verdict.
+func validateQueryFilter(raw string) []registry.ValidationDiag {
+	_, err := parseQueryFilter(raw)
+	if err == nil {
+		return nil
+	}
+
+	message := err.Error()
+	var trackerErr *domain.TrackerError
+	if errors.As(err, &trackerErr) {
+		message = trackerErr.Message
+	}
+
+	return []registry.ValidationDiag{{
+		Severity: "error",
+		Check:    "tracker.query_filter.invalid",
+		Message:  message,
+	}}
+}

--- a/internal/scm/gitlab/validate_test.go
+++ b/internal/scm/gitlab/validate_test.go
@@ -1,0 +1,633 @@
+package gitlab
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/sortie-ai/sortie/internal/domain"
+	"github.com/sortie-ai/sortie/internal/registry"
+)
+
+// --- Test helpers ---
+
+// hasDiagCheck reports whether any diag in the slice has the given check name.
+func hasDiagCheck(diags []registry.ValidationDiag, check string) bool {
+	for _, d := range diags {
+		if d.Check == check {
+			return true
+		}
+	}
+	return false
+}
+
+// diagsWithSeverity returns the subset of diags with the given severity.
+func diagsWithSeverity(diags []registry.ValidationDiag, severity string) []registry.ValidationDiag {
+	var out []registry.ValidationDiag
+	for _, d := range diags {
+		if d.Severity == severity {
+			out = append(out, d)
+		}
+	}
+	return out
+}
+
+// assertNoMessageContains fails the test if any diag's Message contains substr.
+func assertNoMessageContains(t *testing.T, diags []registry.ValidationDiag, substr string) {
+	t.Helper()
+	for i, d := range diags {
+		if strings.Contains(d.Message, substr) {
+			t.Errorf("diag[%d].Message = %q, must not contain %q", i, d.Message, substr)
+		}
+	}
+}
+
+// --- Tests ---
+
+func TestValidateEndpoint(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		endpoint     string
+		wantCount    int
+		wantCheck    string
+		wantSeverity string
+	}{
+		{name: "empty endpoint is clean", endpoint: "", wantCount: 0},
+		{name: "whitespace-only endpoint is clean", endpoint: "   ", wantCount: 0},
+		{
+			name:         "no scheme is invalid",
+			endpoint:     "gitlab.example.com",
+			wantCount:    1,
+			wantCheck:    "tracker.endpoint.invalid",
+			wantSeverity: "error",
+		},
+		{
+			name:         "non-http scheme is invalid",
+			endpoint:     "ftp://host",
+			wantCount:    1,
+			wantCheck:    "tracker.endpoint.invalid",
+			wantSeverity: "error",
+		},
+		{
+			name:         "empty host is invalid",
+			endpoint:     "https://",
+			wantCount:    1,
+			wantCheck:    "tracker.endpoint.invalid",
+			wantSeverity: "error",
+		},
+		{name: "https with subpath is valid", endpoint: "https://host/gitlab", wantCount: 0},
+		{name: "https with custom port is valid", endpoint: "https://host:8443", wantCount: 0},
+		{name: "https with IPv6 literal is valid", endpoint: "https://[::1]:8443", wantCount: 0},
+		{name: "https with trailing slash is valid", endpoint: "https://host/", wantCount: 0},
+		{
+			name:         "http scheme is insecure",
+			endpoint:     "http://gitlab.example.com",
+			wantCount:    1,
+			wantCheck:    "tracker.endpoint.insecure",
+			wantSeverity: "warning",
+		},
+		{
+			name:         "api/v4 suffix is redundant",
+			endpoint:     "https://gitlab.example.com/api/v4",
+			wantCount:    1,
+			wantCheck:    "tracker.endpoint.api_suffix",
+			wantSeverity: "warning",
+		},
+		{
+			name:         "api/v4 suffix with trailing slash is redundant",
+			endpoint:     "https://gitlab.example.com/api/v4/",
+			wantCount:    1,
+			wantCheck:    "tracker.endpoint.api_suffix",
+			wantSeverity: "warning",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := validateEndpoint(tt.endpoint)
+
+			if len(got) != tt.wantCount {
+				t.Fatalf("validateEndpoint(%q) = %d diags, want %d; diags: %v", tt.endpoint, len(got), tt.wantCount, got)
+			}
+			if tt.wantCount == 0 {
+				return
+			}
+			if got[0].Check != tt.wantCheck {
+				t.Errorf("validateEndpoint(%q) diag[0].Check = %q, want %q", tt.endpoint, got[0].Check, tt.wantCheck)
+			}
+			if got[0].Severity != tt.wantSeverity {
+				t.Errorf("validateEndpoint(%q) diag[0].Severity = %q, want %q", tt.endpoint, got[0].Severity, tt.wantSeverity)
+			}
+		})
+	}
+
+	t.Run("userinfo in endpoint never leaks into a message", func(t *testing.T) {
+		t.Parallel()
+
+		got := validateEndpoint("https://user:secret@host")
+
+		assertNoMessageContains(t, got, "secret")
+		assertNoMessageContains(t, got, "user:secret@host")
+	})
+}
+
+func TestValidateProject(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		project   string
+		wantCount int
+	}{
+		{name: "empty project is skipped", project: "", wantCount: 0},
+		{name: "whitespace-only project is rejected", project: "   ", wantCount: 1},
+		{name: "whitespace within value is rejected", project: "my project", wantCount: 1},
+		{name: "pre-encoded slash lowercase is rejected", project: "group%2fproject", wantCount: 1},
+		{name: "pre-encoded slash uppercase is rejected", project: "group%2Fproject", wantCount: 1},
+		{name: "single segment non-numeric is rejected", project: "project", wantCount: 1},
+		{name: "leading slash empty segment is rejected", project: "/group/project", wantCount: 1},
+		{name: "trailing slash empty segment is rejected", project: "group/project/", wantCount: 1},
+		{name: "doubled slash empty segment is rejected", project: "group//project", wantCount: 1},
+		{name: "namespace path is valid", project: "group/project", wantCount: 0},
+		{name: "nested subgroup path is valid", project: "group/subgroup/project", wantCount: 0},
+		{name: "numeric project id is valid", project: "42", wantCount: 0},
+		{name: "padded numeric project id is valid", project: " 42 ", wantCount: 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := validateProject(tt.project)
+
+			if len(got) != tt.wantCount {
+				t.Fatalf("validateProject(%q) = %d diags, want %d; diags: %v", tt.project, len(got), tt.wantCount, got)
+			}
+			if tt.wantCount == 0 {
+				return
+			}
+			if got[0].Check != "tracker.project.format" {
+				t.Errorf("validateProject(%q) diag[0].Check = %q, want %q", tt.project, got[0].Check, "tracker.project.format")
+			}
+			if got[0].Severity != "error" {
+				t.Errorf("validateProject(%q) diag[0].Severity = %q, want %q", tt.project, got[0].Severity, "error")
+			}
+		})
+	}
+}
+
+func TestValidateAPIKeyHint(t *testing.T) {
+	// No t.Parallel(): subtests use t.Setenv to control SORTIE_GITLAB_TOKEN.
+
+	t.Run("clean key produces no diagnostics", func(t *testing.T) {
+		t.Setenv("SORTIE_GITLAB_TOKEN", "")
+
+		got := validateAPIKeyHint("glpat-a1b2c3")
+
+		if len(got) != 0 {
+			t.Errorf("validateAPIKeyHint(%q) = %v, want empty", "glpat-a1b2c3", got)
+		}
+	})
+
+	t.Run("empty key with SORTIE_GITLAB_TOKEN set reports hint warning", func(t *testing.T) {
+		t.Setenv("SORTIE_GITLAB_TOKEN", "envTokenValue777")
+
+		got := validateAPIKeyHint("")
+
+		if len(got) != 1 {
+			t.Fatalf("validateAPIKeyHint(\"\") with SORTIE_GITLAB_TOKEN set = %d diags, want 1; diags: %v", len(got), got)
+		}
+		if got[0].Check != "tracker.api_key.sortie_gitlab_token_hint" {
+			t.Errorf("validateAPIKeyHint(\"\") diag[0].Check = %q, want %q",
+				got[0].Check, "tracker.api_key.sortie_gitlab_token_hint")
+		}
+		if got[0].Severity != "warning" {
+			t.Errorf("validateAPIKeyHint(\"\") diag[0].Severity = %q, want %q", got[0].Severity, "warning")
+		}
+		assertNoMessageContains(t, got, "envTokenValue777")
+	})
+
+	t.Run("empty key with SORTIE_GITLAB_TOKEN unset reports missing warning", func(t *testing.T) {
+		t.Setenv("SORTIE_GITLAB_TOKEN", "")
+
+		got := validateAPIKeyHint("")
+
+		if len(got) != 1 {
+			t.Fatalf("validateAPIKeyHint(\"\") with SORTIE_GITLAB_TOKEN unset = %d diags, want 1; diags: %v", len(got), got)
+		}
+		if got[0].Check != "tracker.api_key.sortie_gitlab_token_missing" {
+			t.Errorf("validateAPIKeyHint(\"\") diag[0].Check = %q, want %q",
+				got[0].Check, "tracker.api_key.sortie_gitlab_token_missing")
+		}
+		if got[0].Severity != "warning" {
+			t.Errorf("validateAPIKeyHint(\"\") diag[0].Severity = %q, want %q", got[0].Severity, "warning")
+		}
+	})
+
+	t.Run("whitespace-padded key reports whitespace warning", func(t *testing.T) {
+		t.Setenv("SORTIE_GITLAB_TOKEN", "")
+
+		const padded = " zzzUniqueTokenValue999 "
+		got := validateAPIKeyHint(padded)
+
+		if len(got) != 1 {
+			t.Fatalf("validateAPIKeyHint(%q) = %d diags, want 1; diags: %v", padded, len(got), got)
+		}
+		if got[0].Check != "tracker.api_key.gitlab_whitespace" {
+			t.Errorf("validateAPIKeyHint(%q) diag[0].Check = %q, want %q", padded, got[0].Check, "tracker.api_key.gitlab_whitespace")
+		}
+		if got[0].Severity != "warning" {
+			t.Errorf("validateAPIKeyHint(%q) diag[0].Severity = %q, want %q", padded, got[0].Severity, "warning")
+		}
+		assertNoMessageContains(t, got, "zzzUniqueTokenValue999")
+	})
+
+	t.Run("no check name references a token prefix or length", func(t *testing.T) {
+		t.Setenv("SORTIE_GITLAB_TOKEN", "glpat-some-token-value")
+
+		for _, apiKey := range []string{"", "glpat-a1b2c3", " glpat-tok "} {
+			for _, d := range validateAPIKeyHint(apiKey) {
+				if strings.Contains(d.Check, "prefix") {
+					t.Errorf("validateAPIKeyHint(%q) diag.Check = %q, must not contain %q", apiKey, d.Check, "prefix")
+				}
+				if strings.Contains(d.Check, "length") {
+					t.Errorf("validateAPIKeyHint(%q) diag.Check = %q, must not contain %q", apiKey, d.Check, "length")
+				}
+			}
+		}
+	})
+}
+
+func TestValidateStateLabels(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		field     string
+		states    []string
+		wantCount int
+		wantCheck string
+	}{
+		{name: "nil slice has no diagnostics", field: "tracker.active_states", states: nil, wantCount: 0},
+		{name: "empty slice has no diagnostics", field: "tracker.active_states", states: []string{}, wantCount: 0},
+		{
+			name: "all clean has no diagnostics", field: "tracker.active_states",
+			states: []string{"backlog", "in-progress"}, wantCount: 0,
+		},
+		{
+			name: "single empty element", field: "tracker.active_states", states: []string{""},
+			wantCount: 1, wantCheck: "tracker.active_states.empty_element",
+		},
+		{
+			name: "whitespace-only element", field: "tracker.terminal_states", states: []string{"done", "   "},
+			wantCount: 1, wantCheck: "tracker.terminal_states.empty_element",
+		},
+		{
+			name: "non-empty padded element", field: "tracker.active_states", states: []string{" review"},
+			wantCount: 1, wantCheck: "tracker.active_states.untrimmed_element",
+		},
+		{
+			name: "trailing padded element", field: "tracker.terminal_states", states: []string{"done "},
+			wantCount: 1, wantCheck: "tracker.terminal_states.untrimmed_element",
+		},
+		{
+			name: "multiple empties", field: "tracker.active_states", states: []string{"", "backlog", ""},
+			wantCount: 2, wantCheck: "tracker.active_states.empty_element",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := validateStateLabels(tt.field, tt.states)
+
+			if len(got) != tt.wantCount {
+				t.Fatalf("validateStateLabels(%q, %v) = %d diags, want %d; diags: %v",
+					tt.field, tt.states, len(got), tt.wantCount, got)
+			}
+			for i, d := range got {
+				if d.Severity != "warning" {
+					t.Errorf("validateStateLabels(%q) diag[%d].Severity = %q, want %q", tt.field, i, d.Severity, "warning")
+				}
+			}
+			if tt.wantCount == 0 {
+				return
+			}
+			if got[0].Check != tt.wantCheck {
+				t.Errorf("validateStateLabels(%q) diag[0].Check = %q, want %q", tt.field, got[0].Check, tt.wantCheck)
+			}
+		})
+	}
+}
+
+func TestValidateStateOverlap(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		fields        registry.TrackerConfigFields
+		wantChecks    []string
+		wantDiagCount int
+	}{
+		{
+			name: "no overlap",
+			fields: registry.TrackerConfigFields{
+				ActiveStates:   []string{"backlog", "in-progress"},
+				TerminalStates: []string{"done", "wontfix"},
+			},
+			wantDiagCount: 0,
+		},
+		{
+			name: "case-insensitive overlap on done",
+			fields: registry.TrackerConfigFields{
+				ActiveStates:   []string{"done"},
+				TerminalStates: []string{"Done"},
+			},
+			wantChecks:    []string{"tracker.states.overlap"},
+			wantDiagCount: 1,
+		},
+		{
+			name: "multiple overlaps are sorted",
+			fields: registry.TrackerConfigFields{
+				ActiveStates:   []string{"a", "b"},
+				TerminalStates: []string{"b", "c", "a"},
+			},
+			wantChecks:    []string{"tracker.states.overlap"},
+			wantDiagCount: 2,
+		},
+		{
+			name: "empty-string elements are skipped",
+			fields: registry.TrackerConfigFields{
+				ActiveStates:   []string{""},
+				TerminalStates: []string{""},
+			},
+			wantDiagCount: 0,
+		},
+		{
+			name: "handoff_state and in_progress_state are not this hook's concern",
+			fields: registry.TrackerConfigFields{
+				ActiveStates:    []string{"backlog"},
+				TerminalStates:  []string{"done"},
+				HandoffState:    "done",
+				InProgressState: "done",
+			},
+			wantDiagCount: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := validateStateOverlap(tt.fields)
+
+			if len(got) != tt.wantDiagCount {
+				t.Fatalf("validateStateOverlap() = %d diags, want %d; diags: %v", len(got), tt.wantDiagCount, got)
+			}
+			for _, check := range tt.wantChecks {
+				if !hasDiagCheck(got, check) {
+					t.Errorf("validateStateOverlap() missing diag with check %q; got: %v", check, got)
+				}
+			}
+			for i, d := range got {
+				if d.Severity != "warning" {
+					t.Errorf("validateStateOverlap() diag[%d].Severity = %q, want %q", i, d.Severity, "warning")
+				}
+				if strings.HasPrefix(d.Check, "tracker.handoff_state") {
+					t.Errorf("validateStateOverlap() diag[%d].Check = %q, must not begin with %q",
+						i, d.Check, "tracker.handoff_state")
+				}
+				if strings.HasPrefix(d.Check, "tracker.in_progress_state") {
+					t.Errorf("validateStateOverlap() diag[%d].Check = %q, must not begin with %q",
+						i, d.Check, "tracker.in_progress_state")
+				}
+			}
+		})
+	}
+}
+
+func TestValidateQueryFilter(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		raw       string
+		wantCount int
+	}{
+		{name: "unset filter is clean", raw: "", wantCount: 0},
+		{name: "whitespace-only filter is clean", raw: "   ", wantCount: 0},
+		{name: "valid filter is clean", raw: "scope=assigned_to_me&not[labels]=needs-triage", wantCount: 0},
+		{name: "reserved key is rejected", raw: "state=closed", wantCount: 1},
+		{name: "unknown key is rejected", raw: "labelz=backlog", wantCount: 1},
+		{name: "empty comma segment is rejected", raw: "labels=bug,", wantCount: 1},
+		{name: "repeated non-array key is rejected", raw: "scope=all&scope=assigned_to_me", wantCount: 1},
+		{name: "colliding spellings are rejected", raw: "labels=a&labels[]=b", wantCount: 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := validateQueryFilter(tt.raw)
+
+			if len(got) != tt.wantCount {
+				t.Fatalf("validateQueryFilter(%q) = %d diags, want %d; diags: %v", tt.raw, len(got), tt.wantCount, got)
+			}
+			if tt.wantCount == 0 {
+				return
+			}
+
+			if got[0].Check != "tracker.query_filter.invalid" {
+				t.Errorf("validateQueryFilter(%q) diag[0].Check = %q, want %q",
+					tt.raw, got[0].Check, "tracker.query_filter.invalid")
+			}
+			if got[0].Severity != "error" {
+				t.Errorf("validateQueryFilter(%q) diag[0].Severity = %q, want %q", tt.raw, got[0].Severity, "error")
+			}
+
+			// The diagnostic message must equal, byte for byte, the
+			// *domain.TrackerError.Message parseQueryFilter returns for the
+			// same input, never err.Error(), so the tracker: wrapper and any
+			// wrapped url.ParseQuery text stay out of operator output.
+			_, err := parseQueryFilter(tt.raw)
+			if err == nil {
+				t.Fatalf("parseQueryFilter(%q) unexpected nil error", tt.raw)
+			}
+			var trackerErr *domain.TrackerError
+			if !errors.As(err, &trackerErr) {
+				t.Fatalf("parseQueryFilter(%q) error type = %T, want *domain.TrackerError", tt.raw, err)
+			}
+			if got[0].Message != trackerErr.Message {
+				t.Errorf("validateQueryFilter(%q) diag[0].Message = %q, want %q (parseQueryFilter Message, verbatim)",
+					tt.raw, got[0].Message, trackerErr.Message)
+			}
+			if !strings.HasPrefix(got[0].Message, "gitlab: ") {
+				t.Errorf("validateQueryFilter(%q) diag[0].Message = %q, want prefix %q", tt.raw, got[0].Message, "gitlab: ")
+			}
+			if strings.Contains(got[0].Message, "tracker: ") {
+				t.Errorf("validateQueryFilter(%q) diag[0].Message = %q, must not contain the TrackerError.Error wrapper %q",
+					tt.raw, got[0].Message, "tracker: ")
+			}
+		})
+	}
+}
+
+func TestValidateConfig(t *testing.T) {
+	// No t.Parallel(): subtests use t.Setenv to control SORTIE_GITLAB_TOKEN.
+
+	t.Run("fully valid configuration produces zero diagnostics", func(t *testing.T) {
+		t.Setenv("SORTIE_GITLAB_TOKEN", "")
+
+		fields := registry.TrackerConfigFields{
+			Kind:           "gitlab",
+			Project:        "group/project",
+			Endpoint:       "https://gitlab.example.com",
+			APIKey:         "glpat-a1b2c3tokenvalue",
+			ActiveStates:   []string{"backlog", "in-progress"},
+			TerminalStates: []string{"done", "wontfix"},
+			QueryFilter:    "scope=assigned_to_me",
+		}
+
+		got := validateConfig(fields)
+
+		errs := diagsWithSeverity(got, "error")
+		warnings := diagsWithSeverity(got, "warning")
+		if len(errs) != 0 {
+			t.Errorf("validateConfig(valid) errors = %v, want empty", errs)
+		}
+		if len(warnings) != 0 {
+			t.Errorf("validateConfig(valid) warnings = %v, want empty", warnings)
+		}
+	})
+
+	t.Run("nil endpoint, one state list, and no query filter produce zero diagnostics", func(t *testing.T) {
+		t.Setenv("SORTIE_GITLAB_TOKEN", "")
+
+		fields := registry.TrackerConfigFields{
+			Kind:         "gitlab",
+			Project:      "42",
+			APIKey:       "glpat-a1b2c3tokenvalue",
+			ActiveStates: []string{"backlog", "in-progress"},
+		}
+
+		got := validateConfig(fields)
+
+		if len(got) != 0 {
+			t.Errorf("validateConfig(minimal valid) = %v, want empty", got)
+		}
+	})
+
+	t.Run("both state lists empty produces no state-element or overlap diagnostic", func(t *testing.T) {
+		t.Setenv("SORTIE_GITLAB_TOKEN", "glpat-clean-token-value")
+
+		// Asserted at the unit level only: orchestrator.ValidateConfigForPromotion
+		// rejects a workflow whose active_states and terminal_states are both
+		// empty before sortie validate ever reaches this hook, so no end-to-end
+		// command-level assertion exists for this input.
+		fields := registry.TrackerConfigFields{
+			Kind:    "gitlab",
+			Project: "group/project",
+			APIKey:  "glpat-clean-token-value",
+		}
+
+		got := validateConfig(fields)
+
+		for _, d := range got {
+			if strings.Contains(d.Check, "active_states") || strings.Contains(d.Check, "terminal_states") ||
+				d.Check == "tracker.states.overlap" {
+				t.Errorf("validateConfig(both state lists empty) unexpected diag %v", d)
+			}
+		}
+	})
+
+	t.Run("opens no socket even when the endpoint targets a live listener", func(t *testing.T) {
+		t.Setenv("SORTIE_GITLAB_TOKEN", "")
+
+		srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+			t.Fatal("validateConfig must not issue any HTTP request")
+		}))
+		defer srv.Close()
+
+		fields := registry.TrackerConfigFields{
+			Kind:           "gitlab",
+			Project:        "not a valid project",
+			Endpoint:       srv.URL,
+			APIKey:         "",
+			ActiveStates:   []string{"done"},
+			TerminalStates: []string{"Done"},
+			QueryFilter:    "state=closed",
+		}
+
+		got := validateConfig(fields)
+
+		if len(got) == 0 {
+			t.Fatal("validateConfig(multi-fault input) = empty, want at least one diagnostic")
+		}
+	})
+
+	t.Run("deterministic order across repeated calls", func(t *testing.T) {
+		t.Setenv("SORTIE_GITLAB_TOKEN", "")
+
+		fields := registry.TrackerConfigFields{
+			Kind:           "gitlab",
+			Project:        "my project",
+			Endpoint:       "ftp://host",
+			APIKey:         " padded-key ",
+			ActiveStates:   []string{"", "done"},
+			TerminalStates: []string{"Done"},
+			QueryFilter:    "state=closed",
+		}
+
+		first := validateConfig(fields)
+		second := validateConfig(fields)
+
+		wantChecks := []string{
+			"tracker.endpoint.invalid",
+			"tracker.project.format",
+			"tracker.api_key.gitlab_whitespace",
+			"tracker.active_states.empty_element",
+			"tracker.states.overlap",
+			"tracker.query_filter.invalid",
+		}
+
+		if len(first) != len(wantChecks) {
+			t.Fatalf("validateConfig() = %d diags, want %d; diags: %v", len(first), len(wantChecks), first)
+		}
+		for i, want := range wantChecks {
+			if first[i].Check != want {
+				t.Errorf("validateConfig() diag[%d].Check = %q, want %q", i, first[i].Check, want)
+			}
+		}
+		if len(second) != len(first) {
+			t.Fatalf("validateConfig() second call = %d diags, want %d (same as first call)", len(second), len(first))
+		}
+		for i := range first {
+			if second[i] != first[i] {
+				t.Errorf("validateConfig() second call diag[%d] = %v, want %v (identical to first call)", i, second[i], first[i])
+			}
+		}
+	})
+
+	t.Run("secret values never appear in any message", func(t *testing.T) {
+		t.Setenv("SORTIE_GITLAB_TOKEN", "")
+
+		const key = "supersecrettokenvalue"
+		fields := registry.TrackerConfigFields{
+			Kind:     "gitlab",
+			Project:  "group/project",
+			Endpoint: "https://user:supersecrettokenvalue@host",
+			APIKey:   " " + key + " ",
+		}
+
+		got := validateConfig(fields)
+
+		assertNoMessageContains(t, got, key)
+	})
+}


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Feat

**Intent:** Add offline `sortie validate` diagnostics for `tracker.kind: gitlab`, matching the validation already provided for the Jira, GitHub, Linear, and Gitea adapters, so a malformed GitLab tracker config is caught before dispatch rather than at adapter construction.

**Related Issues:** #678

### 🧭 Reviewer Guide

**Complexity:** Medium

#### Entry Point

`internal/scm/gitlab/validate.go` is the new adapter validator. `validateConfig` is registered as the GitLab adapter's `ValidateTrackerConfig` hook and runs entirely offline (no credential resolution, no API calls). It checks `tracker.endpoint` URL shape, `tracker.project` as a numeric id or `group/project` namespace path, a `SORTIE_GITLAB_TOKEN` environment-variable hint plus whitespace around `tracker.api_key`, empty/untrimmed/overlapping active and terminal state labels, and `tracker.query_filter` shape by reusing the adapter's own `parseQueryFilter`, so the offline verdict cannot drift from the construction-time verdict.

#### Sensitive Areas

- `internal/registry/registry.go`: adds a `QueryFilter` field to the shared `TrackerConfigFields` struct so any adapter's validator can inspect the resolved `tracker.query_filter` value; this is a cross-adapter type, so double-check it doesn't change behavior for adapters that don't read the new field.
- `internal/orchestrator/preflight.go`: wires `cfg.Tracker.QueryFilter` into the `TrackerConfigFields` passed to `ValidateTrackerConfig` during dispatch preflight.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes
- **Migrations/State:** No migrations or state changes
