### PR TITLE
test(scm/gitlab): add integration test suite and CI wiring

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -136,6 +136,34 @@ jobs:
             version_cmd: printenv GITEA_IMAGE
             source: "docker.gitea.com/gitea:1.27.0-rootless (pinned container image)"
             container_image: docker.gitea.com/gitea:1.27.0-rootless
+            provision_script: scripts/gitea-integration-provision.sh
+
+          - name: GitLab
+            adapter: gitlab
+            kind: tracker
+            guard: SORTIE_GITLAB_TEST
+            run_filter: Integration
+            test_path: ./internal/scm/gitlab/...
+            timeout: ""
+            node: false
+            install: ""
+            version_cmd: printenv GITLAB_IMAGE
+            source: "gitlab/gitlab-ce:19.2.1-ce.0 (pinned container image)"
+            container_image: gitlab/gitlab-ce:19.2.1-ce.0
+            provision_script: scripts/gitlab-integration-provision.sh
+
+          - name: GitLab.com
+            adapter: gitlab-saas
+            kind: tracker
+            guard: SORTIE_GITLAB_TEST
+            run_filter: Integration
+            test_path: ./internal/scm/gitlab/...
+            timeout: ""
+            node: false
+            install: ""
+            version_cmd: ""
+            source: "GitLab.com REST API v4 (remote service, no pinned version)"
+            hosted: true
 
           - name: GitHub
             adapter: github
@@ -176,9 +204,38 @@ jobs:
         with:
           node-version: "24"
 
-      - name: Boot and provision Gitea
-        if: ${{ matrix.container_image != '' }}
-        run: scripts/gitea-integration-provision.sh "${{ matrix.container_image }}"
+      - name: Publish hosted GitLab coordinates
+        if: ${{ matrix.hosted }}
+        env:
+          HOSTED_TOKEN: ${{ secrets.SORTIE_GITLAB_TOKEN }}
+          HOSTED_ENDPOINT: ${{ vars.SORTIE_GITLAB_ENDPOINT }}
+          HOSTED_PROJECT: ${{ vars.SORTIE_GITLAB_PROJECT }}
+        run: |
+          if [ -z "${HOSTED_TOKEN}" ]; then
+            echo "::warning::SORTIE_GITLAB_TOKEN secret is not configured"
+          fi
+          if [ -z "${HOSTED_ENDPOINT}" ]; then
+            echo "::warning::SORTIE_GITLAB_ENDPOINT variable is not configured"
+          fi
+          if [ -z "${HOSTED_PROJECT}" ]; then
+            echo "::warning::SORTIE_GITLAB_PROJECT variable is not configured"
+          fi
+
+          if [ -n "${HOSTED_TOKEN}" ]; then
+            echo "::add-mask::${HOSTED_TOKEN}"
+          fi
+
+          {
+            echo "SORTIE_GITLAB_ENDPOINT=${HOSTED_ENDPOINT}"
+            echo "SORTIE_GITLAB_TOKEN=${HOSTED_TOKEN}"
+            echo "SORTIE_GITLAB_PROJECT=${HOSTED_PROJECT}"
+          } >> "$GITHUB_ENV"
+
+          exit 0
+
+      - name: Boot and provision the containerized instance
+        if: ${{ matrix.provision_script != '' }}
+        run: ${{ matrix.provision_script }} "${{ matrix.container_image }}"
 
       - name: Run integration check
         id: check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -214,6 +214,27 @@ jobs:
       - name: Run integration tests
         run: go test -race -count=1 -v -run 'Integration' ./internal/scm/gitea/...
 
+  test-integration-gitlab:
+    name: "Integration: GitLab"
+    needs: [lint, test-unit]
+    runs-on: ubuntu-latest
+    env:
+      SORTIE_GITLAB_TEST: "1"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+
+      - name: Boot and provision GitLab
+        run: scripts/gitlab-integration-provision.sh
+
+      - name: Run integration tests
+        run: go test -race -count=1 -v -run 'Integration' ./internal/scm/gitlab/...
+
   test-e2e-github:
     name: "E2E: GitHub orchestrator"
     needs: [lint, test-unit]
@@ -430,6 +451,7 @@ jobs:
       - test-integration-github
       - test-integration-linear
       - test-integration-gitea
+      - test-integration-gitlab
       - test-e2e-github
       - test-integration-claude
       - test-integration-copilot

--- a/docs/gitlab-adapter-notes.md
+++ b/docs/gitlab-adapter-notes.md
@@ -5,8 +5,11 @@
 > 2026-08-04. Community Edition is the compatibility floor: the adapter depends only on what
 > it provides. A second live instance, **GitLab.com** (version `19.3.0-pre`, revision
 > `7725732be39`, `enterprise: true`, namespace subscription plan `free`), was used solely for
-> the self-managed-versus-SaaS comparison. Reference for implementing the GitLab
-> `TrackerAdapter`.
+> the self-managed-versus-SaaS comparison. A second live pass on 2026-08-05 re-verified the
+> pinned container image `gitlab/gitlab-ce:19.2.1-ce.0` (version `19.2.1`, revision
+> `f4d029d2da8`, matching the self-managed lab) and GitLab.com, whose revision had moved to
+> `6f59ad3485c` as a continuously deployed instance does. Reference for implementing the
+> GitLab `TrackerAdapter`.
 >
 > Self-managed GitLab has no fixed host, so the instance base URL is part of every
 > self-managed configuration, and instances differ in version and settings. Facts hold for
@@ -19,8 +22,8 @@ Every statement below carries one of five tags. Nothing is asserted without one.
 
 | Tag | Meaning |
 | --- | --- |
-| **[live-CE]** | Observed directly against the self-managed Community Edition 19.2.1 instance on 2026-08-04. The strongest evidence for Community Edition behavior. |
-| **[live-SaaS]** | Observed directly against GitLab.com (`19.3.0-pre`, `enterprise: true`, plan `free`) on 2026-08-04. Evidence about GitLab.com only, never about self-managed. |
+| **[live-CE]** | Observed directly against the self-managed Community Edition 19.2.1 instance on 2026-08-04, and again on 2026-08-05 against the pinned container image `gitlab/gitlab-ce:19.2.1-ce.0` (version `19.2.1`, revision `f4d029d2da8`, matching the lab). The strongest evidence for Community Edition behavior. |
+| **[live-SaaS]** | Observed directly against GitLab.com (`19.3.0-pre`, `enterprise: true`, plan `free`) on 2026-08-04, and again on 2026-08-05 at revision `6f59ad3485c`, moved from the previously recorded `7725732be39` as a continuously deployed instance does. Evidence about GitLab.com only, never about self-managed. |
 | **[docs]** | First-party GitLab documentation, cited by URL. |
 | **[source]** | Upstream source in `gitlab-org/gitlab`, cited by path at ref `v19.2.1-ee` (the tag matching the researched Community Edition version; the `-ee` tag carries both the Community Edition code and the `ee/` tree, which is how a route's edition gating is proved). |
 | **[unknown]** | Not settled by this research. Listed with the evidence that would settle it. |
@@ -195,13 +198,20 @@ recognize a leak by shape.
 | Token type | Identity returned by `GET /user` | Access scope | Suitability |
 | --- | --- | --- | --- |
 | Personal access token | The owning human user, `bot: false` **[live-CE]** | Everything that user can reach | Works. Couples automation to a person's account and their whole project set |
-| **Project access token** | A generated bot user, `bot: true` **[live-CE]** | Exactly one project. A sibling project in the same group returns `404 {"message":"404 Project Not Found"}` **[live-CE]** | **Recommended for a single-project workflow.** Least privilege, and the containment is enforced by the server |
-| Group access token | A generated bot user, `bot: true` **[live-CE]** | Every project in the group, plus `GET /groups/:id/issues` **[live-CE]** | Appropriate when one workflow spans a group |
+| **Project access token** | A generated bot user, `bot: true` **[live-CE]** | Exactly one project. A sibling project in the same group returns `404 {"message":"404 Project Not Found"}` **[live-CE]** | **Recommended for a single-project workflow** on self-managed Community Edition, which has this token type at any license. On GitLab.com it requires a Premium or Ultimate subscription [[docs]](https://docs.gitlab.com/user/project/settings/project_access_tokens/), so a Free namespace can only use a personal access token. Least privilege, and the containment is enforced by the server |
+| Group access token | A generated bot user, `bot: true` **[live-CE]** | Every project in the group, plus `GET /groups/:id/issues` **[live-CE]** | Appropriate when one workflow spans a group, on self-managed Community Edition at any license. On GitLab.com it requires the same Premium or Ultimate subscription as the project access token [[docs]](https://docs.gitlab.com/user/group/settings/group_access_tokens/) |
 | OAuth 2.0 access token | The authorizing user | The granted scopes | Not used. Sortie runs as a headless service and implements no interactive authorization-code flow or callback, the same reasoning the Jira integration applies |
 
 Project and group access tokens are created with an `access_level`; the level must permit
 issue writes for the write operations. A `Developer`-level token performed every write in
 this research **[live-CE]**.
+
+`POST /projects/:id/access_tokens` also requires `expires_at`, and the accepted window is
+bounded at both ends by the run date: a date more than one year ahead returns
+`400 {"message":"400 Bad request - Expiration date must be before <one year from the run
+date>"}`, and a date in the past returns **201** carrying `"active": false`, whose token then
+fails every call with `401 {"error":"invalid_token"}` **[live-CE]**. The ceiling moves daily,
+so automation MUST derive the value at run time rather than carry a literal.
 
 The generated bot usernames take the form `project_<id>_bot_<hex>` and
 `group_<id>_bot_<hex>` **[live-CE]**. That matters for identity-based filtering: the
@@ -226,7 +236,9 @@ model. `read_api` is enough for a read-only deployment.
 GitLab also offers *granular* personal access tokens. The GitLab.com token used here was
 granular, and `GET /personal_access_tokens/self` reported `"scopes": ["granular"]` with
 `"granular": true` **[live-SaaS]**: the scopes array is opaque for granular tokens
-and carries no usable permission detail. Whether self-managed Community Edition 19.2.1
+and carries no usable permission detail. A granular GitLab.com token that reads successfully
+fails a note create with a bare `403 {"message":"403 Forbidden"}` carrying no
+`insufficient_scope` marker **[live-SaaS]**. Whether self-managed Community Edition 19.2.1
 supports granular tokens, and what its introspection reports, is **[unknown]**: both
 Community Edition tokens observed here reported `"granular": false`. Creating a granular
 token on a self-managed Community Edition instance and reading `/personal_access_tokens/self`
@@ -249,7 +261,10 @@ One request validates the credential and returns its lifecycle state. Observed s
 This is strictly better than a bare identity call: it reports `scopes`, `active`, `revoked`,
 and `expires_at`, so the constructor can fail with an actionable diagnostic (wrong scope,
 revoked, expired) instead of a generic 401. It works at `read_api` **[live-CE]** and works
-for project and group access tokens, returning the token record **[live-CE]**.
+for project and group access tokens, returning the token record **[live-CE]**. The
+actionable-diagnostic guarantee holds for classic tokens; for a granular token the scopes
+array is opaque (`["granular"]`), so no scope-based diagnostic is possible and the write
+failure arrives as a bare 403 **[live-SaaS]**.
 
 The three credential failure classes are distinguishable **[live-CE]**:
 
@@ -684,6 +699,11 @@ pre-provisioning and there is no silent no-op to guard against.
 
 The case-collision rule applies here too: the adapter MUST send the canonical casing when the
 label already exists in a different case, or the project grows a duplicate.
+
+GitLab performs no concurrency control on issue updates: two simultaneous `PUT`s carrying
+opposing `add_labels` and `remove_labels` both returned 200, with no 409 and no conflict
+signal, and their label deltas interleaved nondeterministically **[live-CE]**. Two concurrent
+writers against one project silently corrupt each other's state.
 
 Label errors remain non-fatal to the orchestrator.
 
@@ -1224,9 +1244,13 @@ times slower to become usable. Three consequences shape the recommendation:
   **The correct external gate is `GET /api/v4/version` returning any status other than a
   gateway error.** It returns `401 {"message":"401 Unauthorized"}` before provisioning
   **[live, measured]**, and a 401 is a positive signal: it proves the application is routing
-  and authenticating. Polling until the status is neither `000` nor `502` is the precise
-  condition. A job that must use a health endpoint has to run the poll *inside* the container
-  so the request originates from loopback.
+  and authenticating. Readiness is a positive set: the first HTTP 200 or 401 response from
+  this route is the precise condition **[live-CE]**, not the absence of the two transient
+  statuses observed during boot, because a negative set misreads any unlisted transient as
+  readiness. The poll MUST also abort as soon as the container is no longer running rather
+  than wait out its budget, because a boot failure exits the container within 8 s
+  **[live-CE]**. A job that must use a health endpoint has to run the poll *inside* the
+  container so the request originates from loopback.
 
 ### Why the container still wins on correctness
 
@@ -1238,7 +1262,14 @@ risk:
   is an Enterprise Edition codebase; a test suite green against GitLab.com proves nothing
   about Community Edition, and this research found four places where the two differ in
   observable behavior (`link_type`, `weight`, `epic_id`, `assignee_username` cardinality). A
-  GitLab.com-only strategy would have silently accepted every one of them.
+  GitLab.com-only strategy would have silently accepted every one of them. All four are
+  unobservable through `domain.TrackerAdapter` as implemented: `normalizeIssue` sets
+  `BlockedBy` empty unconditionally and the adapter creates no issue link, so `link_type`
+  behavior is unreachable; `gitlabIssue` decodes neither `weight` nor `epic_id` and
+  `gitlabIssueUpdate` sends neither; `assignee_username` reaches the wire only through an
+  operator-written `query_filter` **[live-CE]**. What a GitLab.com job buys is forward-version
+  drift detection against a continuously deployed instance, not product-divergence coverage.
+  The compatibility-floor argument for the container is unaffected.
 - No repository secrets: the token is generated inside the job.
 - No shared mutable state between runs, and no cross-fork secret exposure.
 - Exact version pinning to the researched release, and local reproducibility.
@@ -1247,19 +1278,33 @@ risk:
 
 - Image: `gitlab/gitlab-ce:<version>-ce.0`, pinned. The Community Edition image is the
   correct choice precisely because it is *not* Enterprise Edition.
-- Reduce boot cost with an `GITLAB_OMNIBUS_CONFIG` that disables Prometheus monitoring and
-  lowers Puma workers and Sidekiq concurrency; the instance only serves API calls. This
-  research booted with exactly that configuration.
-- Provisioning: set the initial root password through `GITLAB_OMNIBUS_CONFIG`, create a token,
-  then create the project, labels, and issues through the API. Every provisioning call this
-  research made is a plain REST request, so the fixture is fully scriptable.
+- Reduce boot cost with a `GITLAB_OMNIBUS_CONFIG` limited to the verified-minimal key set:
+  `external_url`, `puma['worker_processes']`, `sidekiq['concurrency']`,
+  `prometheus_monitoring['enable']`, `registry['enable']`, and `gitlab_kas['enable']`; the
+  instance only serves API calls. `grafana['enable']` is **not** a supported key at 19.2.1:
+  `gitlab-ctl reconfigure` fails with `Mixlib::Config::UnknownConfigOptionError: Reading
+  unsupported config value grafana` and the container exits within 8 s **[live-CE]**. This
+  research booted with exactly the verified-minimal key set.
+- Provisioning: a token cannot be minted from credentials over HTTP: `POST /oauth/token` with
+  `grant_type=password` returns `400 {"error":"unsupported_grant_type"}` **[live-CE]**. The
+  bootstrap token instead comes from one Rails runner invocation inside the container,
+  measured at 24 s, and no initial root password is needed; the project, labels, and issues
+  are then created through the API. Every provisioning call this research made is a plain
+  REST request, so the fixture is fully scriptable.
 - Gate: `SORTIE_GITLAB_TEST=1`, with `SORTIE_GITLAB_ENDPOINT`, `SORTIE_GITLAB_TOKEN`, and
   `SORTIE_GITLAB_PROJECT` supplied by the job, following the sibling adapters' single-gate
   convention and their variable naming. Without the gate the tests MUST skip cleanly, never
   fail.
-- Supplement: a small GitLab.com job behind the same gate pattern, asserting only the handful
-  of behaviors where SaaS diverges (rate-limit headers present, note-creation limit lower).
-  It is a compatibility canary, not the primary suite.
+- Supplement: a GitLab.com job behind the same gate pattern, a compatibility canary rather
+  than the primary suite. Keeping it alive costs one access token with issue write, an
+  endpoint, and a project coordinate held as repository configuration; a hosted project
+  seeded with the state labels, the non-state label the label test attaches, at least four
+  open candidates, one closed terminal issue, and two ordered comments; a token expiry
+  bounded at one year **[live-SaaS]**, so the row fails on expiry; and a shared mutable
+  fixture whose open-candidate count is the maintenance obligation.
+
+This recommendation is implemented as `scripts/gitlab-integration-provision.sh` plus the two
+GitLab nightly matrix rows.
 
 ### Fixture blueprint
 
@@ -1269,9 +1314,12 @@ load-bearing rather than incidental:
 - **Two projects, not one.** A single-project instance makes `iid` and global `id` numerically
   identical for every issue, so a test suite cannot catch code that confuses them. The second
   project's first issue had `iid: 1` and global `id: 7` **[live-CE]**, which is the assertion
-  that pins the distinction. The second project also supplies the negative control for
-  authorization masking: a token that is a member of the first project only receives
-  `404 {"message":"404 Project Not Found"}` for the second **[live-CE]**.
+  that pins the distinction. The divergence requires seeding the sibling project's issues
+  before the primary project's: with two issues seeded in the sibling project first, the
+  primary project's first issue carried `iid: 1` and global `id: 3` **[live-CE]**. The second
+  project also supplies the negative control for authorization masking: a token that is a
+  member of the first project only receives `404 {"message":"404 Project Not Found"}` for the
+  second **[live-CE]**.
 - **A non-administrator identity.** An administrator token cannot observe the authorization
   failures a real deployment hits. Every probe reported here was run with a project
   Developer token; the administrator token was used only for provisioning.
@@ -1279,9 +1327,11 @@ load-bearing rather than incidental:
   is readable and attachable on a project issue **[live-CE]**.
 - Issues covering: open with a state label, open with two labels, closed with a terminal
   label, one **assigned** to the automation identity, one **mentioning** it in the
-  description, one carrying comments and an issue link. A bulk-comment issue (55 notes) to
-  assert note pagination, and one non-`issue` work item to assert the `issue_type=issue`
-  exclusion.
+  description, one carrying comments and an issue link. A bulk-comment issue (at least 101
+  notes, verified to produce `X-Total: 101`, `X-Total-Pages: 2`, `X-Next-Page: 2`, and a
+  `rel="next"` link, with exactly 100 entries on page one, because the adapter sends
+  `per_page=100` **[live-CE]**) to assert note pagination, and one non-`issue` work item to
+  assert the `issue_type=issue` exclusion.
 
 ---
 

--- a/internal/scm/gitlab/integration_test.go
+++ b/internal/scm/gitlab/integration_test.go
@@ -1,0 +1,845 @@
+package gitlab
+
+import (
+	"context"
+	"errors"
+	"os"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sortie-ai/sortie/internal/domain"
+)
+
+// skipUnlessIntegration skips the current test when SORTIE_GITLAB_TEST is
+// not "1", so disabled integration tests report as skipped rather than
+// passing silently or hitting the network.
+func skipUnlessIntegration(t *testing.T) {
+	t.Helper()
+	if os.Getenv("SORTIE_GITLAB_TEST") != "1" {
+		t.Skip("skipping GitLab integration test: set SORTIE_GITLAB_TEST=1 to enable")
+	}
+}
+
+// requireEnv reads an environment variable and fails the test when empty.
+func requireEnv(t *testing.T, key string) string {
+	t.Helper()
+	v := os.Getenv(key)
+	if v == "" {
+		t.Fatalf("required environment variable %s is not set", key)
+	}
+	return v
+}
+
+// optionalEnv reads an environment variable and skips the test when empty,
+// naming the variable and the fixture it gates. It is a precondition helper,
+// not a second integration gate: it never reads SORTIE_GITLAB_TEST.
+func optionalEnv(t *testing.T, key string) string {
+	t.Helper()
+	v := os.Getenv(key)
+	if v == "" {
+		t.Skipf("optional environment variable %s is not set; skipping the fixture it gates", key)
+	}
+	return v
+}
+
+// activeStates returns the SORTIE_GITLAB_ACTIVE_STATES override when set,
+// else the adapter's own defaultActiveStates, so a change to the adapter's
+// defaults cannot silently desynchronize the suite.
+func activeStates(t *testing.T) []string {
+	t.Helper()
+	if raw := os.Getenv("SORTIE_GITLAB_ACTIVE_STATES"); raw != "" {
+		return splitStates(raw)
+	}
+	return defaultActiveStates
+}
+
+// terminalStates returns the SORTIE_GITLAB_TERMINAL_STATES override when
+// set, else the adapter's own defaultTerminalStates.
+func terminalStates(t *testing.T) []string {
+	t.Helper()
+	if raw := os.Getenv("SORTIE_GITLAB_TERMINAL_STATES"); raw != "" {
+		return splitStates(raw)
+	}
+	return defaultTerminalStates
+}
+
+// splitStates parses a comma-separated state list into a trimmed, non-empty
+// string slice.
+func splitStates(raw string) []string {
+	parts := strings.Split(raw, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if v := strings.TrimSpace(p); v != "" {
+			out = append(out, v)
+		}
+	}
+	return out
+}
+
+// integrationConfig builds the adapter config from the integration env
+// vars.
+func integrationConfig(t *testing.T) map[string]any {
+	t.Helper()
+	return map[string]any{
+		"api_key":         requireEnv(t, "SORTIE_GITLAB_TOKEN"),
+		"project":         requireEnv(t, "SORTIE_GITLAB_PROJECT"),
+		"endpoint":        requireEnv(t, "SORTIE_GITLAB_ENDPOINT"),
+		"active_states":   activeStates(t),
+		"terminal_states": terminalStates(t),
+	}
+}
+
+// newIntegrationAdapter constructs a live adapter, running the real
+// preflight.
+func newIntegrationAdapter(t *testing.T) domain.TrackerAdapter {
+	t.Helper()
+	adapter, err := NewGitLabAdapter(integrationConfig(t))
+	if err != nil {
+		t.Fatalf("NewGitLabAdapter: %v", err)
+	}
+	return adapter
+}
+
+// firstCandidate returns the first candidate issue or skips when the
+// project has none, so a write test has a real issue to act on.
+func firstCandidate(t *testing.T, ctx context.Context, adapter domain.TrackerAdapter) domain.Issue {
+	t.Helper()
+	candidates, err := adapter.FetchCandidateIssues(ctx)
+	if err != nil {
+		t.Fatalf("FetchCandidateIssues: %v", err)
+	}
+	if len(candidates) == 0 {
+		t.Skip("no candidate issues in project; cannot run write test")
+	}
+	return candidates[0]
+}
+
+// parseCreatedAt parses a comment's CreatedAt so ordering checks compare
+// chronological order rather than lexicographic string order.
+func parseCreatedAt(t *testing.T, raw string) time.Time {
+	t.Helper()
+	parsed, err := time.Parse(time.RFC3339, raw)
+	if err != nil {
+		t.Fatalf("CreatedAt %q is not a valid RFC 3339 timestamp: %v", raw, err)
+	}
+	return parsed
+}
+
+func TestIntegration_FetchCandidateIssues(t *testing.T) {
+	skipUnlessIntegration(t)
+
+	adapter := newIntegrationAdapter(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	issues, err := adapter.FetchCandidateIssues(ctx)
+	if err != nil {
+		t.Fatalf("FetchCandidateIssues: %v", err)
+	}
+
+	for _, issue := range issues {
+		if issue.ID == "" {
+			t.Errorf("issue %q: ID is empty", issue.Identifier)
+		}
+		if issue.Identifier != issue.ID {
+			t.Errorf("issue %s: Identifier = %q, want %q", issue.ID, issue.Identifier, issue.ID)
+		}
+		if issue.Labels == nil {
+			t.Errorf("issue %s: Labels is nil, want non-nil slice", issue.Identifier)
+		}
+		if issue.BlockedBy == nil || len(issue.BlockedBy) != 0 {
+			t.Errorf("issue %s: BlockedBy = %v, want non-nil empty slice", issue.Identifier, issue.BlockedBy)
+		}
+		if issue.Comments != nil {
+			t.Errorf("issue %s: Comments = %v, want nil", issue.Identifier, issue.Comments)
+		}
+		if issue.IssueType != "issue" {
+			t.Errorf("issue %s: IssueType = %q, want %q", issue.Identifier, issue.IssueType, "issue")
+		}
+		if issue.Priority != nil {
+			t.Errorf("issue %s: Priority = %v, want nil", issue.Identifier, *issue.Priority)
+		}
+		if issue.Parent != nil {
+			t.Errorf("issue %s: Parent = %v, want nil", issue.Identifier, issue.Parent)
+		}
+	}
+
+	for i := 1; i < len(issues); i++ {
+		prev := parseCreatedAt(t, issues[i-1].CreatedAt)
+		curr := parseCreatedAt(t, issues[i].CreatedAt)
+		if prev.After(curr) {
+			t.Errorf("issues not in non-descending CreatedAt order at index %d: %q before %q",
+				i, issues[i-1].CreatedAt, issues[i].CreatedAt)
+		}
+	}
+}
+
+func TestIntegration_FetchCandidateIssues_FixtureFloor(t *testing.T) {
+	skipUnlessIntegration(t)
+
+	adapter := newIntegrationAdapter(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	issues, err := adapter.FetchCandidateIssues(ctx)
+	if err != nil {
+		t.Fatalf("FetchCandidateIssues: %v", err)
+	}
+
+	const floor = 2
+	if len(issues) < floor {
+		t.Fatalf("FetchCandidateIssues returned %d candidates, want at least %d; the fixture is depleted, seed another open issue carrying an active-state label to restore it",
+			len(issues), floor)
+	}
+}
+
+func TestIntegration_FetchIssueByID(t *testing.T) {
+	skipUnlessIntegration(t)
+
+	adapter := newIntegrationAdapter(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	candidate := firstCandidate(t, ctx, adapter)
+
+	fetched, err := adapter.FetchIssueByID(ctx, candidate.ID)
+	if err != nil {
+		t.Fatalf("FetchIssueByID(%s): %v", candidate.ID, err)
+	}
+	if fetched.Identifier != candidate.Identifier {
+		t.Errorf("FetchIssueByID(%s) Identifier = %q, want %q", candidate.ID, fetched.Identifier, candidate.Identifier)
+	}
+	if fetched.Title != candidate.Title {
+		t.Errorf("FetchIssueByID(%s) Title = %q, want %q", candidate.ID, fetched.Title, candidate.Title)
+	}
+	if fetched.Comments == nil {
+		t.Error("Comments is nil, want non-nil slice for fully populated issue")
+	}
+	if fetched.BlockedBy == nil || len(fetched.BlockedBy) != 0 {
+		t.Errorf("BlockedBy = %v, want non-nil empty slice", fetched.BlockedBy)
+	}
+}
+
+func TestIntegration_FetchIssueByID_NotFound(t *testing.T) {
+	skipUnlessIntegration(t)
+
+	adapter := newIntegrationAdapter(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := adapter.FetchIssueByID(ctx, "999999")
+	if err == nil {
+		t.Fatal("FetchIssueByID(999999) = nil error, want error")
+	}
+
+	var te *domain.TrackerError
+	if !errors.As(err, &te) {
+		t.Fatalf("error type = %T, want *domain.TrackerError", err)
+	}
+	if te.Kind != domain.ErrTrackerNotFound {
+		t.Errorf("TrackerError.Kind = %q, want %q", te.Kind, domain.ErrTrackerNotFound)
+	}
+}
+
+func TestIntegration_FetchIssueByID_WorkItem(t *testing.T) {
+	skipUnlessIntegration(t)
+
+	taskIID := optionalEnv(t, "SORTIE_GITLAB_TASK_IID")
+
+	adapter := newIntegrationAdapter(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := adapter.FetchIssueByID(ctx, taskIID)
+	if err == nil {
+		t.Fatalf("FetchIssueByID(%s) = nil error, want error", taskIID)
+	}
+
+	var te *domain.TrackerError
+	if !errors.As(err, &te) {
+		t.Fatalf("error type = %T, want *domain.TrackerError", err)
+	}
+	if te.Kind != domain.ErrTrackerNotFound {
+		t.Errorf("TrackerError.Kind = %q, want %q", te.Kind, domain.ErrTrackerNotFound)
+	}
+}
+
+func TestIntegration_FetchIssuesByStates_Empty(t *testing.T) {
+	skipUnlessIntegration(t)
+
+	adapter := newIntegrationAdapter(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	issues, err := adapter.FetchIssuesByStates(ctx, []string{})
+	if err != nil {
+		t.Fatalf("FetchIssuesByStates(empty): %v", err)
+	}
+	if len(issues) != 0 {
+		t.Errorf("FetchIssuesByStates(empty) returned %d issues, want 0", len(issues))
+	}
+}
+
+func TestIntegration_FetchIssuesByStates_Active(t *testing.T) {
+	skipUnlessIntegration(t)
+
+	adapter := newIntegrationAdapter(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	candidates, err := adapter.FetchCandidateIssues(ctx)
+	if err != nil {
+		t.Fatalf("FetchCandidateIssues: %v", err)
+	}
+	if len(candidates) == 0 {
+		t.Skip("no candidate issues in project; cannot determine requested active states")
+	}
+
+	requested := make(map[string]struct{})
+	states := make([]string, 0, len(candidates))
+	for _, c := range candidates {
+		if _, ok := requested[c.State]; ok {
+			continue
+		}
+		requested[c.State] = struct{}{}
+		states = append(states, c.State)
+	}
+
+	issues, err := adapter.FetchIssuesByStates(ctx, states)
+	if err != nil {
+		t.Fatalf("FetchIssuesByStates(%v): %v", states, err)
+	}
+	if issues == nil {
+		t.Fatal("FetchIssuesByStates returned nil, want non-nil slice")
+	}
+	for _, issue := range issues {
+		if _, ok := requested[issue.State]; !ok {
+			t.Errorf("FetchIssuesByStates(%v): issue %s State = %q, want one of %v", states, issue.Identifier, issue.State, states)
+		}
+	}
+}
+
+func TestIntegration_FetchIssuesByStates_Terminal(t *testing.T) {
+	skipUnlessIntegration(t)
+
+	adapter := newIntegrationAdapter(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	candidates, err := adapter.FetchCandidateIssues(ctx)
+	if err != nil {
+		t.Fatalf("FetchCandidateIssues: %v", err)
+	}
+	candidateIDs := make(map[string]struct{}, len(candidates))
+	for _, c := range candidates {
+		candidateIDs[c.ID] = struct{}{}
+	}
+
+	states := terminalStates(t)
+	requested := make(map[string]struct{}, len(states))
+	for _, s := range states {
+		requested[s] = struct{}{}
+	}
+
+	issues, err := adapter.FetchIssuesByStates(ctx, states)
+	if err != nil {
+		t.Fatalf("FetchIssuesByStates(%v): %v", states, err)
+	}
+	if issues == nil {
+		t.Fatal("FetchIssuesByStates returned nil, want non-nil slice")
+	}
+	for _, issue := range issues {
+		if _, ok := requested[issue.State]; !ok {
+			t.Errorf("FetchIssuesByStates(%v): issue %s State = %q, want one of %v", states, issue.Identifier, issue.State, states)
+		}
+		if _, ok := candidateIDs[issue.ID]; ok {
+			t.Errorf("FetchIssuesByStates(%v): issue %s also appears in the active candidate set", states, issue.Identifier)
+		}
+	}
+}
+
+func TestIntegration_FetchIssueStatesByIDs(t *testing.T) {
+	skipUnlessIntegration(t)
+
+	adapter := newIntegrationAdapter(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	candidates, err := adapter.FetchCandidateIssues(ctx)
+	if err != nil {
+		t.Fatalf("FetchCandidateIssues: %v", err)
+	}
+	if len(candidates) == 0 {
+		t.Skip("no candidate issues in project; cannot test FetchIssueStatesByIDs")
+	}
+
+	ids := make([]string, 0, len(candidates)+1)
+	for _, c := range candidates {
+		ids = append(ids, c.ID)
+	}
+	ids = append(ids, "999999")
+
+	states, err := adapter.FetchIssueStatesByIDs(ctx, ids)
+	if err != nil {
+		t.Fatalf("FetchIssueStatesByIDs: %v", err)
+	}
+	for _, c := range candidates {
+		got, ok := states[c.ID]
+		if !ok {
+			t.Errorf("FetchIssueStatesByIDs: candidate %s missing from result", c.ID)
+			continue
+		}
+		if got != c.State {
+			t.Errorf("FetchIssueStatesByIDs: state[%s] = %q, want %q", c.ID, got, c.State)
+		}
+	}
+	if _, ok := states["999999"]; ok {
+		t.Error("FetchIssueStatesByIDs: nonexistent id 999999 present in result, want absent")
+	}
+}
+
+func TestIntegration_FetchIssueStatesByIdentifiers(t *testing.T) {
+	skipUnlessIntegration(t)
+
+	adapter := newIntegrationAdapter(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	candidates, err := adapter.FetchCandidateIssues(ctx)
+	if err != nil {
+		t.Fatalf("FetchCandidateIssues: %v", err)
+	}
+	if len(candidates) == 0 {
+		t.Skip("no candidate issues in project; cannot test FetchIssueStatesByIdentifiers")
+	}
+
+	identifiers := make([]string, 0, len(candidates)+1)
+	for _, c := range candidates {
+		identifiers = append(identifiers, c.Identifier)
+	}
+	identifiers = append(identifiers, "999999")
+
+	states, err := adapter.FetchIssueStatesByIdentifiers(ctx, identifiers)
+	if err != nil {
+		t.Fatalf("FetchIssueStatesByIdentifiers: %v", err)
+	}
+	for _, c := range candidates {
+		got, ok := states[c.Identifier]
+		if !ok {
+			t.Errorf("FetchIssueStatesByIdentifiers: candidate %s missing from result", c.Identifier)
+			continue
+		}
+		if got != c.State {
+			t.Errorf("FetchIssueStatesByIdentifiers: state[%s] = %q, want %q", c.Identifier, got, c.State)
+		}
+	}
+	if _, ok := states["999999"]; ok {
+		t.Error("FetchIssueStatesByIdentifiers: nonexistent identifier 999999 present in result, want absent")
+	}
+}
+
+func TestIntegration_FetchIssueComments(t *testing.T) {
+	skipUnlessIntegration(t)
+
+	adapter := newIntegrationAdapter(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	candidate := firstCandidate(t, ctx, adapter)
+
+	comments, err := adapter.FetchIssueComments(ctx, candidate.ID)
+	if err != nil {
+		t.Fatalf("FetchIssueComments(%s): %v", candidate.ID, err)
+	}
+	if comments == nil {
+		t.Fatal("comments is nil, want non-nil slice")
+	}
+
+	for _, c := range comments {
+		if c.ID == "" {
+			t.Error("comment ID is empty")
+		}
+		if c.Author == "" {
+			t.Errorf("comment %s: Author is empty", c.ID)
+		}
+		if c.Body == "" {
+			t.Errorf("comment %s: Body is empty", c.ID)
+		}
+	}
+
+	for i := 1; i < len(comments); i++ {
+		prev := parseCreatedAt(t, comments[i-1].CreatedAt)
+		curr := parseCreatedAt(t, comments[i].CreatedAt)
+		if prev.After(curr) {
+			t.Errorf("comments not in non-descending CreatedAt order at index %d: %q before %q",
+				i, comments[i-1].CreatedAt, comments[i].CreatedAt)
+		}
+	}
+}
+
+func TestIntegration_FetchIssueComments_SystemNotesExcluded(t *testing.T) {
+	skipUnlessIntegration(t)
+
+	systemIID := optionalEnv(t, "SORTIE_GITLAB_SYSTEM_NOTES_IID")
+
+	adapter := newIntegrationAdapter(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	comments, err := adapter.FetchIssueComments(ctx, systemIID)
+	if err != nil {
+		t.Fatalf("FetchIssueComments(%s): %v", systemIID, err)
+	}
+	if comments == nil {
+		t.Fatal("comments is nil, want non-nil slice")
+	}
+	if len(comments) != 0 {
+		t.Errorf("FetchIssueComments(%s) returned %d comments, want 0 (system notes only)", systemIID, len(comments))
+	}
+}
+
+func TestIntegration_FetchIssueComments_Paginated(t *testing.T) {
+	skipUnlessIntegration(t)
+
+	manyIID := optionalEnv(t, "SORTIE_GITLAB_MANY_NOTES_IID")
+
+	adapter := newIntegrationAdapter(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	comments, err := adapter.FetchIssueComments(ctx, manyIID)
+	if err != nil {
+		t.Fatalf("FetchIssueComments(%s): %v", manyIID, err)
+	}
+
+	const minComments = 101
+	if len(comments) < minComments {
+		t.Errorf("FetchIssueComments(%s) returned %d comments, want at least %d", manyIID, len(comments), minComments)
+	}
+
+	seen := make(map[string]struct{}, len(comments))
+	for _, c := range comments {
+		if _, ok := seen[c.ID]; ok {
+			t.Errorf("FetchIssueComments(%s): duplicate comment ID %s", manyIID, c.ID)
+		}
+		seen[c.ID] = struct{}{}
+	}
+
+	for i := 1; i < len(comments); i++ {
+		prev := parseCreatedAt(t, comments[i-1].CreatedAt)
+		curr := parseCreatedAt(t, comments[i].CreatedAt)
+		if prev.After(curr) {
+			t.Errorf("comments not in non-descending CreatedAt order at index %d: %q before %q",
+				i, comments[i-1].CreatedAt, comments[i].CreatedAt)
+		}
+	}
+}
+
+func TestIntegration_TransitionIssue_SameState(t *testing.T) {
+	skipUnlessIntegration(t)
+
+	adapter := newIntegrationAdapter(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	candidate := firstCandidate(t, ctx, adapter)
+
+	if err := adapter.TransitionIssue(ctx, candidate.ID, candidate.State); err != nil {
+		t.Fatalf("TransitionIssue(%s, %q): %v", candidate.Identifier, candidate.State, err)
+	}
+
+	fetched, err := adapter.FetchIssueByID(ctx, candidate.ID)
+	if err != nil {
+		t.Fatalf("FetchIssueByID(%s): %v", candidate.ID, err)
+	}
+	if fetched.State != candidate.State {
+		t.Errorf("State after same-state transition = %q, want %q", fetched.State, candidate.State)
+	}
+}
+
+func TestIntegration_TransitionIssue_RoundTrip(t *testing.T) {
+	skipUnlessIntegration(t)
+
+	adapter := newIntegrationAdapter(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	candidate := firstCandidate(t, ctx, adapter)
+
+	var target string
+	for _, s := range activeStates(t) {
+		if s != candidate.State {
+			target = s
+			break
+		}
+	}
+	if target == "" {
+		t.Skip("no configured active state distinct from the candidate's current state")
+	}
+
+	originalState := candidate.State
+	originalLabels := slices.Clone(candidate.Labels)
+
+	t.Cleanup(func() {
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cleanupCancel()
+		if err := adapter.TransitionIssue(cleanupCtx, candidate.ID, originalState); err != nil {
+			t.Errorf("cleanup TransitionIssue(%s, %q): %v", candidate.Identifier, originalState, err)
+		}
+	})
+
+	if err := adapter.TransitionIssue(ctx, candidate.ID, target); err != nil {
+		t.Fatalf("TransitionIssue(%s, %q): %v", candidate.Identifier, target, err)
+	}
+
+	fetched, err := adapter.FetchIssueByID(ctx, candidate.ID)
+	if err != nil {
+		t.Fatalf("FetchIssueByID(%s): %v", candidate.ID, err)
+	}
+	if fetched.State != target {
+		t.Errorf("State after transition = %q, want %q", fetched.State, target)
+	}
+	if slices.Contains(fetched.Labels, originalState) {
+		t.Errorf("Labels = %v, still contains previous state label %q", fetched.Labels, originalState)
+	}
+
+	if err := adapter.TransitionIssue(ctx, candidate.ID, originalState); err != nil {
+		t.Fatalf("TransitionIssue back to %q: %v", originalState, err)
+	}
+
+	restored, err := adapter.FetchIssueByID(ctx, candidate.ID)
+	if err != nil {
+		t.Fatalf("FetchIssueByID(%s) after restore: %v", candidate.ID, err)
+	}
+	if restored.State != originalState {
+		t.Errorf("State after restore = %q, want %q", restored.State, originalState)
+	}
+	for _, label := range originalLabels {
+		if !slices.Contains(restored.Labels, label) {
+			t.Errorf("Labels after restore = %v, missing original label %q", restored.Labels, label)
+		}
+	}
+}
+
+func TestIntegration_TransitionIssue_TerminalAndBack(t *testing.T) {
+	skipUnlessIntegration(t)
+
+	adapter := newIntegrationAdapter(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	candidate := firstCandidate(t, ctx, adapter)
+
+	terminal := terminalStates(t)
+	if len(terminal) == 0 {
+		t.Skip("no configured terminal state")
+	}
+	target := terminal[0]
+	originalState := candidate.State
+
+	t.Cleanup(func() {
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cleanupCancel()
+		if err := adapter.TransitionIssue(cleanupCtx, candidate.ID, originalState); err != nil {
+			t.Errorf("cleanup TransitionIssue(%s, %q): %v", candidate.Identifier, originalState, err)
+		}
+	})
+
+	if err := adapter.TransitionIssue(ctx, candidate.ID, target); err != nil {
+		t.Fatalf("TransitionIssue(%s, %q): %v", candidate.Identifier, target, err)
+	}
+
+	fetched, err := adapter.FetchIssueByID(ctx, candidate.ID)
+	if err != nil {
+		t.Fatalf("FetchIssueByID(%s): %v", candidate.ID, err)
+	}
+	if fetched.State != target {
+		t.Errorf("State after terminal transition = %q, want %q", fetched.State, target)
+	}
+
+	afterClose, err := adapter.FetchCandidateIssues(ctx)
+	if err != nil {
+		t.Fatalf("FetchCandidateIssues after terminal transition: %v", err)
+	}
+	if slices.ContainsFunc(afterClose, func(i domain.Issue) bool { return i.ID == candidate.ID }) {
+		t.Errorf("candidate %s still present in FetchCandidateIssues after transitioning to terminal state %q", candidate.Identifier, target)
+	}
+
+	if err := adapter.TransitionIssue(ctx, candidate.ID, originalState); err != nil {
+		t.Fatalf("TransitionIssue back to %q: %v", originalState, err)
+	}
+
+	restored, err := adapter.FetchIssueByID(ctx, candidate.ID)
+	if err != nil {
+		t.Fatalf("FetchIssueByID(%s) after restore: %v", candidate.ID, err)
+	}
+	if restored.State != originalState {
+		t.Errorf("State after restore = %q, want %q", restored.State, originalState)
+	}
+
+	afterReopen, err := adapter.FetchCandidateIssues(ctx)
+	if err != nil {
+		t.Fatalf("FetchCandidateIssues after restore: %v", err)
+	}
+	if !slices.ContainsFunc(afterReopen, func(i domain.Issue) bool { return i.ID == candidate.ID }) {
+		t.Errorf("candidate %s absent from FetchCandidateIssues after transitioning back to %q", candidate.Identifier, originalState)
+	}
+}
+
+func TestIntegration_TransitionIssue_InvalidTarget(t *testing.T) {
+	skipUnlessIntegration(t)
+
+	adapter := newIntegrationAdapter(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	candidate := firstCandidate(t, ctx, adapter)
+
+	const invalidTarget = "not-a-configured-state"
+	err := adapter.TransitionIssue(ctx, candidate.ID, invalidTarget)
+	if err == nil {
+		t.Fatalf("TransitionIssue(%s, %q) = nil, want error", candidate.Identifier, invalidTarget)
+	}
+
+	var te *domain.TrackerError
+	if !errors.As(err, &te) {
+		t.Fatalf("error type = %T, want *domain.TrackerError", err)
+	}
+	if te.Kind != domain.ErrTrackerPayload {
+		t.Errorf("TrackerError.Kind = %q, want %q", te.Kind, domain.ErrTrackerPayload)
+	}
+}
+
+func TestIntegration_CommentIssue(t *testing.T) {
+	skipUnlessIntegration(t)
+
+	adapter := newIntegrationAdapter(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	candidate := firstCandidate(t, ctx, adapter)
+
+	body := "sortie write-path integration test comment at " + time.Now().UTC().Format(time.RFC3339)
+	if err := adapter.CommentIssue(ctx, candidate.ID, body); err != nil {
+		t.Fatalf("CommentIssue(%s): %v", candidate.Identifier, err)
+	}
+
+	comments, err := adapter.FetchIssueComments(ctx, candidate.ID)
+	if err != nil {
+		t.Fatalf("FetchIssueComments(%s): %v", candidate.ID, err)
+	}
+	if !slices.ContainsFunc(comments, func(c domain.Comment) bool { return c.Body == body }) {
+		t.Errorf("FetchIssueComments(%s) does not contain the posted comment %q", candidate.ID, body)
+	}
+}
+
+func TestIntegration_AddLabel(t *testing.T) {
+	skipUnlessIntegration(t)
+
+	adapter := newIntegrationAdapter(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	candidate := firstCandidate(t, ctx, adapter)
+	originalLabels := slices.Clone(candidate.Labels)
+
+	const newLabel = "needs-human"
+	if err := adapter.AddLabel(ctx, candidate.ID, newLabel); err != nil {
+		t.Fatalf("AddLabel(%s, %q): %v", candidate.Identifier, newLabel, err)
+	}
+
+	fetched, err := adapter.FetchIssueByID(ctx, candidate.ID)
+	if err != nil {
+		t.Fatalf("FetchIssueByID(%s): %v", candidate.ID, err)
+	}
+	if !slices.Contains(fetched.Labels, newLabel) {
+		t.Errorf("Labels = %v, want to contain %q", fetched.Labels, newLabel)
+	}
+	for _, label := range originalLabels {
+		if !slices.Contains(fetched.Labels, label) {
+			t.Errorf("Labels = %v, missing previously recorded label %q", fetched.Labels, label)
+		}
+	}
+}
+
+func TestIntegration_NewGitLabAdapter_ForeignProject(t *testing.T) {
+	skipUnlessIntegration(t)
+
+	foreign := optionalEnv(t, "SORTIE_GITLAB_FOREIGN_PROJECT")
+
+	cfg := integrationConfig(t)
+	cfg["project"] = foreign
+
+	_, err := NewGitLabAdapter(cfg)
+	if err == nil {
+		t.Fatalf("NewGitLabAdapter(project=%q) = nil error, want error", foreign)
+	}
+
+	var te *domain.TrackerError
+	if !errors.As(err, &te) {
+		t.Fatalf("error type = %T, want *domain.TrackerError", err)
+	}
+	if te.Kind != domain.ErrTrackerNotFound {
+		t.Errorf("TrackerError.Kind = %q, want %q", te.Kind, domain.ErrTrackerNotFound)
+	}
+}
+
+func TestIntegration_FetchCandidateIssues_QueryFilter(t *testing.T) {
+	skipUnlessIntegration(t)
+
+	unfiltered := newIntegrationAdapter(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	baseline, err := unfiltered.FetchCandidateIssues(ctx)
+	if err != nil {
+		t.Fatalf("FetchCandidateIssues (unfiltered): %v", err)
+	}
+	baselineIDs := make(map[string]struct{}, len(baseline))
+	for _, issue := range baseline {
+		baselineIDs[issue.ID] = struct{}{}
+	}
+
+	cfg := integrationConfig(t)
+	cfg["query_filter"] = "scope=assigned_to_me"
+	filtered, err := NewGitLabAdapter(cfg)
+	if err != nil {
+		t.Fatalf("NewGitLabAdapter with query_filter: %v", err)
+	}
+
+	issues, err := filtered.FetchCandidateIssues(ctx)
+	if err != nil {
+		t.Fatalf("FetchCandidateIssues (filtered): %v", err)
+	}
+
+	for _, issue := range issues {
+		if _, ok := baselineIDs[issue.ID]; !ok {
+			t.Errorf("FetchCandidateIssues (filtered) returned issue %s not present in the unfiltered candidate set", issue.Identifier)
+		}
+		if issue.Assignee == "" {
+			t.Errorf("issue %s: Assignee is empty, want non-empty under scope=assigned_to_me", issue.Identifier)
+		}
+	}
+}

--- a/scripts/gitlab-integration-provision.sh
+++ b/scripts/gitlab-integration-provision.sh
@@ -1,0 +1,320 @@
+#!/usr/bin/env bash
+# Boot and seed a throwaway containerized GitLab Community Edition instance,
+# then publish the coordinates the gitlab adapter integration suite reads.
+#
+# Usage: gitlab-integration-provision.sh [IMAGE]
+#   IMAGE defaults to the pinned tag below, which is the authoritative version
+#   for the release path. Rolling the pinned version is a deliberate edit
+#   here.
+#
+# The instance is ephemeral: both access tokens are generated in-job against
+# a loopback container, so nothing long-lived is stored and no repository
+# secret is needed. In CI the runner is discarded after the job; locally the
+# script removes any prior container of its fixed name before booting, so a
+# repeat run does not collide on the host port. A single local run leaves a
+# multi-gigabyte container resident; reclaim it with:
+#   docker rm -f sortie-gitlab-integration
+#
+# Output contract. Eight coordinates are published two ways. They are
+# appended as bare KEY=VALUE lines to the file named by $GITHUB_ENV when it
+# is set and writable, which Actions exports to successor CI steps. They are
+# also printed to stdout as export statements, so a developer can run
+#   eval "$(scripts/gitlab-integration-provision.sh)"
+# and get them exported into the current shell. Everything else goes to
+# stderr, keeping stdout parseable by eval.
+#
+# Prerequisites, all present on ubuntu-latest and expected locally: docker (a
+# running daemon), curl, and jq.
+#
+# Readiness bound provenance. Two boots of the pinned image, constrained to 4
+# CPUs and 16 GB of memory (the shape GitHub documents for a standard
+# ubuntu-latest runner on a public repository), both reached the first HTTP
+# 200 or 401 from GET /api/v4/version at 111 seconds. READINESS_TIMEOUT_SECONDS
+# below is set to 600, which is 5.4 times that figure and covers the one
+# dimension the constraint approximates rather than reproduces: a hosted
+# runner's disk throughput. The script logs the elapsed readiness seconds on
+# every run; the first shard that runs on a GitHub-hosted runner supplies the
+# matching hosted-runner figure, which has not yet been measured and should
+# be recorded here beside the local baseline once logged.
+
+set -euo pipefail
+
+IMAGE="${1:-gitlab/gitlab-ce:19.2.1-ce.0}"
+
+CONTAINER_NAME="sortie-gitlab-integration"
+HOST_PORT=8929
+ENDPOINT="http://localhost:${HOST_PORT}"
+
+READINESS_TIMEOUT_SECONDS=600
+POLL_INTERVAL_SECONDS=10
+PULL_RETRY_DELAY_SECONDS=10
+
+GROUP_NAME="sortie-gitlab-integration"
+PRIMARY_PROJECT_NAME="primary"
+SIBLING_PROJECT_NAME="sibling"
+
+NEWLINE=$'\n'
+
+# Diagnostics go to stderr so stdout carries only the coordinate assignments.
+log() {
+	printf '%s\n' "$*" >&2
+}
+
+# On a non-zero exit after the container exists, surface its logs so a boot,
+# readiness, token, or fixture failure is diagnosable. The container is
+# never removed here: CI discards the runner, and the next local run clears
+# it.
+dump_logs_on_error() {
+	local code=$?
+	if [ "$code" -ne 0 ] && docker inspect "$CONTAINER_NAME" >/dev/null 2>&1; then
+		log "provisioning failed (exit ${code}); recent container logs follow:"
+		docker logs --tail 200 "$CONTAINER_NAME" >&2 || true
+	fi
+}
+trap dump_logs_on_error EXIT
+
+for tool in docker curl jq; do
+	if ! command -v "$tool" >/dev/null 2>&1; then
+		log "required command not found: ${tool}"
+		exit 1
+	fi
+done
+
+# A GitLab API call. Method, path, and the bearer token are positional; the
+# JSON request body is read from stdin. On any non-2xx status the response
+# body is logged and the call fails, so set -e stops the script and the trap
+# dumps the container logs.
+gitlab_call() {
+	local method="$1" path="$2" token="$3" body response status
+	body=$(cat)
+	response=$(curl -sS --max-time 30 -w "${NEWLINE}%{http_code}" \
+		-H "PRIVATE-TOKEN: ${token}" \
+		-H 'Content-Type: application/json' \
+		-X "$method" "${ENDPOINT}/api/v4${path}" \
+		-d "$body")
+	status=${response##*"$NEWLINE"}
+	response=${response%"$NEWLINE"*}
+	case "$status" in
+	2*)
+		printf '%s' "$response"
+		;;
+	*)
+		log "gitlab API ${method} ${path} returned HTTP ${status}: ${response}"
+		return 1
+		;;
+	esac
+}
+
+# Remove a prior container of the fixed name so a repeat local run reclaims
+# the host port instead of failing to bind it.
+docker rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
+
+# The pull is a step of its own, distinguishable from a boot failure. GitLab
+# publishes its released Community Edition images only to Docker Hub, pulled
+# anonymously here.
+log "pulling ${IMAGE} from Docker Hub"
+if ! docker pull "$IMAGE" >/dev/null; then
+	log "initial pull of ${IMAGE} from Docker Hub failed; retrying in ${PULL_RETRY_DELAY_SECONDS}s"
+	sleep "$PULL_RETRY_DELAY_SECONDS"
+	if ! docker pull "$IMAGE" >/dev/null; then
+		log "failed to pull ${IMAGE} from Docker Hub after two attempts"
+		exit 1
+	fi
+fi
+
+log "starting ${IMAGE} as ${CONTAINER_NAME} on host port ${HOST_PORT}"
+# Limited to the verified-minimal key set: any other key, in particular
+# grafana['enable'], fails gitlab-ctl reconfigure and exits the container
+# within seconds.
+docker run -d --name "$CONTAINER_NAME" \
+	-p "${HOST_PORT}:8929" \
+	--shm-size=256m \
+	-e GITLAB_OMNIBUS_CONFIG="external_url 'http://localhost:${HOST_PORT}'; puma['worker_processes'] = 0; sidekiq['concurrency'] = 1; prometheus_monitoring['enable'] = false; registry['enable'] = false; gitlab_kas['enable'] = false;" \
+	"$IMAGE" >/dev/null
+
+log "waiting up to ${READINESS_TIMEOUT_SECONDS}s for ${ENDPOINT}/api/v4/version"
+SECONDS=0
+ready=false
+while [ "$SECONDS" -lt "$READINESS_TIMEOUT_SECONDS" ]; do
+	if [ "$(docker inspect -f '{{.State.Running}}' "$CONTAINER_NAME" 2>/dev/null || true)" != "true" ]; then
+		log "container exited before readiness; a boot-configuration failure is the usual cause"
+		exit 1
+	fi
+
+	status=$(curl -sS --max-time 5 -o /dev/null -w '%{http_code}' "${ENDPOINT}/api/v4/version" 2>/dev/null || true)
+	case "$status" in
+	200 | 401)
+		ready=true
+		break
+		;;
+	esac
+
+	sleep "$POLL_INTERVAL_SECONDS"
+done
+if [ "$ready" != "true" ]; then
+	log "gitlab did not become ready within ${READINESS_TIMEOUT_SECONDS}s"
+	exit 1
+fi
+log "gitlab ready after ${SECONDS}s"
+
+# The resource-owner password grant is unavailable at this version, so the
+# bootstrap token comes from exactly one invocation inside the container
+# rather than an HTTP token request. The expiry is computed from the
+# instance's own clock so the script contains no date literal: the accepted
+# window is bounded at both ends by the run date, and a literal expiry mints
+# a token that fails once the calendar moves past it.
+log "minting bootstrap administrator token"
+bootstrap_runner_script='
+user = User.find_by(username: "root")
+expiry = Date.today + 1
+token = user.personal_access_tokens.create!(name: "sortie-integration-bootstrap", scopes: ["api"], expires_at: expiry)
+puts "SORTIE_EXPIRY=#{expiry.iso8601}"
+puts "SORTIE_BOOTSTRAP_TOKEN=#{token.token}"
+'
+runner_output=$(docker exec "$CONTAINER_NAME" gitlab-rails runner "$bootstrap_runner_script")
+
+EXPIRY=$(printf '%s\n' "$runner_output" | sed -n 's/^SORTIE_EXPIRY=//p')
+BOOTSTRAP_TOKEN=$(printf '%s\n' "$runner_output" | sed -n 's/^SORTIE_BOOTSTRAP_TOKEN=//p')
+if [ -z "$EXPIRY" ] || [ -z "$BOOTSTRAP_TOKEN" ]; then
+	log "bootstrap token minting produced unparseable output"
+	exit 1
+fi
+
+# Under the bootstrap token: the group, both projects, and the published
+# token. A Developer-level project access token cannot create a project, so
+# these four calls are the only ones this identity makes.
+log "creating group ${GROUP_NAME}"
+group_response=$(jq -nc --arg name "$GROUP_NAME" --arg path "$GROUP_NAME" \
+	'{name: $name, path: $path, visibility: "private"}' |
+	gitlab_call POST "/groups" "$BOOTSTRAP_TOKEN")
+GROUP_ID=$(printf '%s' "$group_response" | jq -er '.id')
+
+log "creating sibling project ${SIBLING_PROJECT_NAME}"
+sibling_response=$(jq -nc --arg name "$SIBLING_PROJECT_NAME" --argjson namespace_id "$GROUP_ID" \
+	'{name: $name, namespace_id: $namespace_id, visibility: "private"}' |
+	gitlab_call POST "/projects" "$BOOTSTRAP_TOKEN")
+SIBLING_ID=$(printf '%s' "$sibling_response" | jq -er '.id')
+SIBLING_PATH=$(printf '%s' "$sibling_response" | jq -er '.path_with_namespace')
+
+log "creating primary project ${PRIMARY_PROJECT_NAME}"
+primary_response=$(jq -nc --arg name "$PRIMARY_PROJECT_NAME" --argjson namespace_id "$GROUP_ID" \
+	'{name: $name, namespace_id: $namespace_id, visibility: "private"}' |
+	gitlab_call POST "/projects" "$BOOTSTRAP_TOKEN")
+PRIMARY_ID=$(printf '%s' "$primary_response" | jq -er '.id')
+PRIMARY_PATH=$(printf '%s' "$primary_response" | jq -er '.path_with_namespace')
+
+# Seeding the sibling project's issues before the primary project's is what
+# makes the primary project's first issue's iid diverge from its
+# instance-global id.
+log "seeding sibling project issues"
+jq -nc '{title: "Sibling seed issue 1"}' |
+	gitlab_call POST "/projects/${SIBLING_ID}/issues" "$BOOTSTRAP_TOKEN" >/dev/null
+jq -nc '{title: "Sibling seed issue 2"}' |
+	gitlab_call POST "/projects/${SIBLING_ID}/issues" "$BOOTSTRAP_TOKEN" >/dev/null
+
+log "creating published project access token"
+published_response=$(jq -nc --arg name "sortie-integration-published" --arg expires_at "$EXPIRY" \
+	'{name: $name, scopes: ["api"], access_level: 30, expires_at: $expires_at}' |
+	gitlab_call POST "/projects/${PRIMARY_ID}/access_tokens" "$BOOTSTRAP_TOKEN")
+PUBLISHED_TOKEN=$(printf '%s' "$published_response" | jq -er '.token')
+
+PUBLISHED_USER_ID=$(curl -sS --max-time 30 -H "PRIVATE-TOKEN: ${PUBLISHED_TOKEN}" "${ENDPOINT}/api/v4/user" | jq -er '.id')
+
+# Every fixture object inside the primary project, from here on, is created
+# under the published Developer-level token: it demonstrably covers the
+# whole surface the suite exercises.
+log "creating project labels"
+primary_labels=(backlog in-progress review "done" needs-human)
+for label in "${primary_labels[@]}"; do
+	jq -nc --arg name "$label" '{name: $name, color: "#cccccc"}' |
+		gitlab_call POST "/projects/${PRIMARY_ID}/labels" "$PUBLISHED_TOKEN" >/dev/null
+done
+
+# create_primary_issue creates one issue in the primary project under the
+# published token and echoes its iid. A short pause between the ascending
+# creations keeps their timestamps strictly ordered, so the first candidate
+# and the earliest-created issue are deterministic.
+create_primary_issue() {
+	local title="$1" labels_json="$2" extra_json="${3:-{}}"
+	jq -nc --arg title "$title" --argjson labels "$labels_json" --argjson extra "$extra_json" \
+		'{title: $title, labels: $labels} + $extra' |
+		gitlab_call POST "/projects/${PRIMARY_ID}/issues" "$PUBLISHED_TOKEN" | jq -er '.iid'
+}
+
+add_comment() {
+	local iid="$1" body="$2"
+	jq -nc --arg body "$body" '{body: $body}' |
+		gitlab_call POST "/projects/${PRIMARY_ID}/issues/${iid}/notes" "$PUBLISHED_TOKEN" >/dev/null
+}
+
+log "creating seed issues in ascending time order"
+issue_backlog_1=$(create_primary_issue "Backlog seed issue" '["backlog"]')
+sleep 1
+issue_inprogress=$(create_primary_issue "In-progress seed issue" '["in-progress"]')
+sleep 1
+issue_review=$(create_primary_issue "Review seed issue" '["review"]')
+sleep 1
+issue_backlog_2=$(create_primary_issue "Second backlog seed issue" '["backlog"]')
+sleep 1
+issue_bulk=$(create_primary_issue "Bulk comment seed issue" '["backlog"]')
+sleep 1
+issue_linktarget=$(create_primary_issue "Link target seed issue" '["in-progress"]')
+sleep 1
+issue_done=$(create_primary_issue "Done seed issue" '["done"]')
+log "seeded open candidates ${issue_backlog_1}, ${issue_inprogress}, ${issue_review}, ${issue_backlog_2}, ${issue_bulk}, ${issue_linktarget} and terminal candidate ${issue_done}"
+
+log "assigning issue ${issue_inprogress} to the published token's own identity"
+jq -nc --argjson id "$PUBLISHED_USER_ID" '{assignee_ids: [$id]}' |
+	gitlab_call PUT "/projects/${PRIMARY_ID}/issues/${issue_inprogress}" "$PUBLISHED_TOKEN" >/dev/null
+
+log "adding two ordered comments to the earliest-created issue ${issue_backlog_1}"
+add_comment "$issue_backlog_1" "First seed comment."
+add_comment "$issue_backlog_1" "Second seed comment."
+
+log "seeding at least 101 comments on issue ${issue_bulk}"
+for i in $(seq 1 101); do
+	add_comment "$issue_bulk" "Bulk seed comment ${i}."
+done
+
+log "linking issue ${issue_bulk} to ${issue_linktarget}, which carries no human comment"
+jq -nc --argjson target_project_id "$PRIMARY_ID" --argjson target_issue_iid "$issue_linktarget" \
+	'{target_project_id: $target_project_id, target_issue_iid: $target_issue_iid}' |
+	gitlab_call POST "/projects/${PRIMARY_ID}/issues/${issue_bulk}/links" "$PUBLISHED_TOKEN" >/dev/null
+
+log "creating one non-issue work item"
+issue_task=$(jq -nc --arg title "Task work item" '{title: $title, issue_type: "task"}' |
+	gitlab_call POST "/projects/${PRIMARY_ID}/issues" "$PUBLISHED_TOKEN" | jq -er '.iid')
+
+log "closing issue ${issue_done} into its terminal state"
+jq -nc '{state_event: "close"}' |
+	gitlab_call PUT "/projects/${PRIMARY_ID}/issues/${issue_done}" "$PUBLISHED_TOKEN" >/dev/null
+
+# Publish each coordinate to $GITHUB_ENV (when writable) and to stdout. The
+# $GITHUB_ENV file takes a bare KEY=VALUE line, which Actions exports to
+# successor steps. Stdout takes an export statement, so a developer running
+# eval "$(...)" gets the coordinate exported into the shell and inherited by
+# the test process, not merely set as a non-exported shell variable.
+emit() {
+	if [ -n "${GITHUB_ENV:-}" ] && [ -w "${GITHUB_ENV}" ]; then
+		printf '%s=%s\n' "$1" "$2" >>"$GITHUB_ENV"
+	fi
+	printf "export %s='%s'\n" "$1" "$2"
+}
+
+# Register the published token as a masked value so it is redacted from the
+# CI log, before it is echoed anywhere. The bootstrap token is never
+# registered, never emitted, and never echoed. The mask directive is emitted
+# only under Actions; locally it would pollute the stdout that eval consumes.
+if [ "${GITHUB_ACTIONS:-}" = "true" ]; then
+	printf '::add-mask::%s\n' "$PUBLISHED_TOKEN"
+fi
+
+log "provisioning complete; publishing coordinates"
+emit SORTIE_GITLAB_ENDPOINT "$ENDPOINT"
+emit SORTIE_GITLAB_TOKEN "$PUBLISHED_TOKEN"
+emit SORTIE_GITLAB_PROJECT "$PRIMARY_PATH"
+emit SORTIE_GITLAB_MANY_NOTES_IID "$issue_bulk"
+emit SORTIE_GITLAB_SYSTEM_NOTES_IID "$issue_linktarget"
+emit SORTIE_GITLAB_TASK_IID "$issue_task"
+emit SORTIE_GITLAB_FOREIGN_PROJECT "$SIBLING_PATH"
+emit GITLAB_IMAGE "$IMAGE"


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Test

**Intent:** Add a `SORTIE_GITLAB_TEST`-gated live integration suite for the GitLab tracker adapter and wire it into the release and nightly CI workflows, matching the pattern already established for the Jira, GitHub, Linear, and Gitea adapters.

**Related Issues:** #680

### 🧭 Reviewer Guide

**Complexity:** Medium

#### Entry Point

`scripts/gitlab-integration-provision.sh` is where to start. It boots a pinned `gitlab/gitlab-ce` container, mints an administrator token via `gitlab-rails runner` (the resource-owner password grant is unavailable at this version), and seeds a group with a primary and sibling project, labels, and issues covering every fixture `internal/scm/gitlab/integration_test.go` exercises, then publishes the resulting coordinates as `SORTIE_GITLAB_*` environment variables. The seed order (sibling project before primary) is what makes the primary project's first issue's `iid` diverge from its instance-global `id`, which the suite depends on.

`internal/scm/gitlab/integration_test.go` covers candidate fetch, single-issue fetch (found, not-found, and non-issue work item), fetch by states (empty, active, terminal), state reconciliation by id and by identifier, comment fetch (system-note exclusion, pagination), state transitions (same-state, round-trip, terminal-and-back, invalid target), comment creation, label addition, `query_filter` scoping, and the foreign-project construction failure. Every test gates behind `SORTIE_GITLAB_TEST` and skips cleanly without it.

#### Sensitive Areas

- `.github/workflows/nightly.yml`: adds a two-row GitLab matrix entry (the pinned container image and a GitLab.com canary) and generalizes the existing single-adapter "Boot and provision Gitea" step into a matrix-driven `provision_script` field so it also serves GitLab's provisioning script.
- `.github/workflows/release.yml`: adds a guarded `test-integration-gitlab` job and lists it as a dependency of the release-gating job, alongside the other tracker integration jobs.
- `docs/gitlab-adapter-notes.md`: records a second live verification pass against both the self-managed container and GitLab.com, capturing the facts (token minting constraints, the verified-minimal `GITLAB_OMNIBUS_CONFIG` key set, the readiness poll's positive-match condition, granular-token write-failure behavior, lack of concurrency control on label updates) that the provisioning script and tests in this PR are built from.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes.
- **Migrations/State:** No migrations. The GitLab.com canary row in `nightly.yml` reads `SORTIE_GITLAB_TOKEN` (secret), `SORTIE_GITLAB_ENDPOINT`, and `SORTIE_GITLAB_PROJECT` (repository variables); these must be configured in the repository for that row to run. When one is missing, the coordinate step emits a per-item `::warning::` and still exits 0 so the reporting step is reached; the run itself then fails through `requireEnv` and files a failure issue naming the missing variable. Only the GitLab.com row is affected — the release job and the containerized `GitLab` row mint their own credentials in-job and need no repository configuration.

