### PR TITLE
feat(gitlab): add sample WORKFLOW.gitlab.md to examples

### DIFF
--- a/cmd/sortie/sample_workflow_test.go
+++ b/cmd/sortie/sample_workflow_test.go
@@ -107,6 +107,11 @@ func TestSampleWorkflowLoad(t *testing.T) {
 			file:     "WORKFLOW.gitea.md",
 			wantKeys: []string{"tracker", "polling", "workspace", "hooks", "agent", "claude-code", "server"},
 		},
+		{
+			name:     "WORKFLOW.gitlab.md loads with expected config keys",
+			file:     "WORKFLOW.gitlab.md",
+			wantKeys: []string{"tracker", "polling", "workspace", "hooks", "agent", "claude-code", "server"},
+		},
 	}
 
 	for _, tt := range tests {
@@ -188,6 +193,16 @@ func TestSampleWorkflowRender(t *testing.T) {
 			file:  "WORKFLOW.gitea.md",
 			issue: minimalIssue(),
 		},
+		{
+			name:  "WORKFLOW.gitlab.md full issue",
+			file:  "WORKFLOW.gitlab.md",
+			issue: fullIssue(),
+		},
+		{
+			name:  "WORKFLOW.gitlab.md minimal issue",
+			file:  "WORKFLOW.gitlab.md",
+			issue: minimalIssue(),
+		},
 	}
 
 	for _, tt := range tests {
@@ -219,6 +234,7 @@ var shippedExampleWorkflows = []string{
 	"WORKFLOW.linear.md",
 	"WORKFLOW.kiro.md",
 	"WORKFLOW.gitea.md",
+	"WORKFLOW.gitlab.md",
 }
 
 // TestSampleWorkflowMergeConflictBranch verifies AC13: each shipped example
@@ -447,7 +463,7 @@ func TestSampleWorkflowTestFilePathConfig(t *testing.T) {
 func TestSampleWorkflowNoHTMLComments(t *testing.T) {
 	t.Parallel()
 
-	files := []string{"WORKFLOW.md", "WORKFLOW.test.md", "WORKFLOW.opencode.md", "WORKFLOW.linear.md", "WORKFLOW.gitea.md"}
+	files := []string{"WORKFLOW.md", "WORKFLOW.test.md", "WORKFLOW.opencode.md", "WORKFLOW.linear.md", "WORKFLOW.gitea.md", "WORKFLOW.gitlab.md"}
 	for _, name := range files {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -621,6 +637,41 @@ func TestSampleWorkflowGiteaEnvVarIndirection(t *testing.T) {
 		{"endpoint", "$SORTIE_GITEA_ENDPOINT"},
 		{"api_key", "$SORTIE_GITEA_TOKEN"},
 		{"project", "$SORTIE_GITEA_PROJECT"},
+	}
+	for _, c := range checks {
+		got, _ := tracker[c.key].(string)
+		if got != c.want {
+			t.Errorf("tracker.%s = %q, want %q", c.key, got, c.want)
+		}
+	}
+}
+
+func TestSampleWorkflowGitLabEnvVarIndirection(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(repoRoot(t), "examples", "WORKFLOW.gitlab.md")
+	wf, err := workflow.Load(path)
+	if err != nil {
+		t.Fatalf("workflow.Load(WORKFLOW.gitlab.md): %v", err)
+	}
+
+	tracker, ok := wf.Config["tracker"].(map[string]any)
+	if !ok {
+		t.Fatal("WORKFLOW.gitlab.md config missing tracker map")
+	}
+
+	if kind, _ := tracker["kind"].(string); kind != "gitlab" {
+		t.Errorf("tracker.kind = %q, want %q", kind, "gitlab")
+	}
+
+	// Connection fields must use $SORTIE_* indirection.
+	checks := []struct {
+		key  string
+		want string
+	}{
+		{"endpoint", "$SORTIE_GITLAB_ENDPOINT"},
+		{"api_key", "$SORTIE_GITLAB_TOKEN"},
+		{"project", "$SORTIE_GITLAB_PROJECT"},
 	}
 	for _, c := range checks {
 		got, _ := tracker[c.key].(string)

--- a/examples/WORKFLOW.gitlab.md
+++ b/examples/WORKFLOW.gitlab.md
@@ -1,0 +1,200 @@
+---
+tracker:
+  kind: gitlab
+  endpoint: $SORTIE_GITLAB_ENDPOINT
+  api_key: $SORTIE_GITLAB_TOKEN
+  project: $SORTIE_GITLAB_PROJECT
+  active_states:
+    - backlog
+    - in-progress
+  in_progress_state: in-progress
+  terminal_states:
+    - done
+    - wontfix
+  handoff_state: review
+
+polling:
+  interval_ms: 45000
+
+workspace:
+  root: $SORTIE_WORKSPACE_ROOT
+
+hooks:
+  after_create: |
+    git clone --depth 1 $SORTIE_REPO_URL .
+    go mod download
+  before_run: |
+    git fetch origin main
+    git checkout -B "sortie/$SORTIE_ISSUE_IDENTIFIER" origin/main
+  after_run: |
+    make fmt 2>/dev/null || true
+    git add -A
+    git diff --cached --quiet || git commit -m "sortie($SORTIE_ISSUE_IDENTIFIER): automated changes"
+  before_remove: |
+    git push origin --delete "sortie/$SORTIE_ISSUE_IDENTIFIER" 2>/dev/null || true
+  timeout_ms: 120000
+
+agent:
+  kind: claude-code
+  command: claude
+  max_turns: 15
+  max_concurrent_agents: 4
+  turn_timeout_ms: 3600000
+  read_timeout_ms: 5000
+  stall_timeout_ms: 300000
+  max_retry_backoff_ms: 300000
+  max_concurrent_agents_by_state:
+    in-progress: 3
+    backlog: 1
+
+claude-code:
+  permission_mode: bypassPermissions
+  model: claude-sonnet-4-6
+  max_turns: 50
+  max_budget_usd: 5
+
+server:
+  port: 8642
+---
+
+{{/* Sortie sample workflow, GitLab + Claude Code.
+     Required env vars:
+       SORTIE_GITLAB_TOKEN    GitLab access token (personal, project, or group), api scope
+       SORTIE_GITLAB_PROJECT  Target project as group/project (e.g. group/project) or
+                              its numeric project id
+       SORTIE_REPO_URL        Git clone URL for the repository
+     Optional:
+       SORTIE_GITLAB_ENDPOINT Self-hosted instance base URL (e.g. https://gitlab.example.com);
+                              leave unset for GitLab.com, which the adapter uses by default
+       SORTIE_WORKSPACE_ROOT  Base directory for per-issue workspaces
+                              (defaults to system temp) */}}
+You are a senior engineer. Your work is tracked by an automated orchestrator (Sortie)
+that manages your session, retries failures, and monitors progress.
+
+## Your task
+
+**{{ .issue.identifier }}**: {{ .issue.title }}
+
+{{ if .issue.description }}
+
+### Description
+
+{{ .issue.description }}
+{{ end }}
+
+## Context
+
+Before making changes, read:
+
+- `CLAUDE.md` for build commands and project boundaries
+- `docs/architecture.md` for the relevant specification section
+- Any existing tests in the area you are modifying
+
+## Rules
+
+1. Run the project's lint and test commands before finishing. All checks must pass.
+2. Do not modify protected files (architecture docs, ADRs, LICENSE) unless the task
+   explicitly requires it.
+3. Write table-driven tests. Cover edge cases, not just the happy path.
+4. If you encounter a problem outside the scope of this task, write `blocked` to
+   `.sortie/status` and stop.
+5. Keep changes minimal - implement exactly what the task requires.
+
+{{ if not .run.is_continuation }}
+
+## Approach
+
+1. Read the relevant documentation and existing code before writing anything.
+2. Implement the minimal change that satisfies the task requirements.
+3. Write or update tests to cover the new behavior.
+4. Run verification commands and fix any failures.
+5. If the task is complete, confirm by reviewing your changes.
+   {{ end }}
+
+{{ if .run.is_continuation }}
+
+## Continuation
+
+You are resuming work on this task (turn {{ .run.turn_number }} of {{ .run.max_turns }}).
+Review the current state of the workspace - check test output, lint results, and any
+partial changes. Do not repeat work already completed. Proceed with the next step.
+{{ end }}
+
+{{ if .merge_conflict }}
+
+## Resolve Merge Conflicts
+
+PR #{{ .merge_conflict.pr_number }} ({{ .merge_conflict.branch }}) has merge conflicts with
+its base branch {{ .merge_conflict.base }}. Resolve them now:
+
+1. Fetch the latest {{ .merge_conflict.base }} from the remote.
+2. Rebase {{ .merge_conflict.branch }} onto {{ .merge_conflict.base }}.
+3. Resolve every conflict, preserving both the intent of this PR and the base changes.
+4. Push the rebased branch.
+{{ end }}
+
+{{ if .label_review }}
+
+## Review This Pull Request
+
+Produce a code review of pull request #{{ .label_review.pr_number }} in
+{{ .label_review.owner }}/{{ .label_review.repo }}, requested by {{ .label_review.actor }}.
+
+1. Fetch the diff for this PR using your SCM tooling.
+2. Review the changes for correctness, clarity, and regressions.
+3. Post your review comments on the PR. Do not modify the branch or push commits.
+{{ end }}
+
+{{ if .label_fix }}
+
+## Fix This Pull Request
+
+Check out {{ .label_fix.branch }} for pull request #{{ .label_fix.pr_number }} in
+{{ .label_fix.owner }}/{{ .label_fix.repo }}, requested by {{ .label_fix.actor }}.
+
+1. Fetch the outstanding review comments for this PR using your SCM tooling.
+2. Address the feedback and push the fixes to {{ .label_fix.branch }}.
+3. Post a summary comment on the PR describing the changes you made.
+4. Write `needs-human-review` to `.sortie/status` to signal completion.
+{{ end }}
+
+{{ if .attempt }}
+
+## Retry
+
+This is retry attempt {{ .attempt }}. A previous run failed or timed out. Check the
+workspace for partial work and do not start from scratch. Review any error output from
+the previous attempt if visible in the workspace.
+{{ end }}
+
+{{ if .issue.url }}
+
+## Reference
+
+Ticket: {{ .issue.url }}
+{{ end }}
+
+{{ if .issue.labels }}
+
+## Labels
+
+{{ .issue.labels | join ", " }}
+{{ end }}
+
+{{ if .issue.parent }}
+
+## Parent issue
+
+{{ .issue.parent.identifier }}
+{{ end }}
+
+{{ if .issue.blocked_by }}
+
+## Blockers
+
+The following issues block this task. If any are unresolved, focus on preparation work
+that does not depend on the blocked functionality (tests, scaffolding, documentation).
+
+{{ range .issue.blocked_by }}- **{{ .identifier }}**{{ if .state }} ({{ .state }}){{ end }}
+{{ end }}
+{{ end }}


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Feat

**Intent:** Adds a ready-to-use `examples/WORKFLOW.gitlab.md` that demonstrates the GitLab tracker adapter paired with the Claude Code agent. A developer adopting Sortie with GitLab only needs to substitute the endpoint, token, and project to get a validating, runnable workflow.

**Related Issues:** #682

### 🧭 Reviewer Guide

**Complexity:** Medium

#### Entry Point

`examples/WORKFLOW.gitlab.md` - the new sample file. It sets `tracker.kind: gitlab`, uses `$SORTIE_GITLAB_ENDPOINT` (with a note that it may be omitted for GitLab.com), `$SORTIE_GITLAB_TOKEN`, and `$SORTIE_GITLAB_PROJECT` for env-var indirection, sets `tracker.project` to a `group/project` shape, maps active/terminal/handoff states, and includes a prompt template covering all issue-context variables the orchestrator injects.

#### Sensitive Areas

- `cmd/sortie/sample_workflow_test.go`: the new `TestSampleWorkflowGitLabEnvVarIndirection` test asserts the exact field names (`endpoint`, `api_key`, `project`) and indirection strings (`$SORTIE_GITLAB_ENDPOINT`, `$SORTIE_GITLAB_TOKEN`, `$SORTIE_GITLAB_PROJECT`) used by the GitLab adapter. If the adapter config shape changes, this test is the first signal.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes
- **Migrations/State:** No migrations or state changes