### PR TITLE
refactor(scripts): port provisioning scripts to POSIX sh and lint them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
           fi
           [ -n "$changed" ] || exit 0
           printf '%s\n' "$changed"
-          printf '%s\n' "$changed" | xargs shellcheck -x
+          printf '%s\n' "$changed" | xargs -d '\n' -r shellcheck -x --
 
   test:
     name: Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,19 @@ jobs:
           # masquerade as new 'latest' findings. setup-go's caches are unaffected.
           skip-cache: true
 
+      - name: Lint shell scripts
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+        run: |
+          if git cat-file -e "${BASE_SHA}^{commit}" 2>/dev/null; then
+            changed=$(git diff --name-only --diff-filter=d "$BASE_SHA" HEAD -- '*.sh')
+          else
+            changed=$(git ls-files '*.sh')
+          fi
+          [ -n "$changed" ] || exit 0
+          printf '%s\n' "$changed"
+          printf '%s\n' "$changed" | xargs shellcheck -x
+
   test:
     name: Test
     runs-on: ubuntu-latest

--- a/install.sh
+++ b/install.sh
@@ -5,7 +5,7 @@
 #   curl -sSL https://get.sortie-ai.com/install.sh | sh
 #
 # Environment:
-#   SORTIE_VERSION      Pin a specific release tag (e.g. 1.14.0 or 0.0.7).
+#   SORTIE_VERSION      Pin a specific release tag (e.g. 1.17.0 or 0.0.7).
 #   SORTIE_INSTALL_DIR  Override install directory
 #                       (default: /usr/local/bin as root, ~/.local/bin otherwise).
 #   SORTIE_NO_VERIFY    Set to 1 to skip checksum verification.

--- a/scripts/gitea-integration-provision.sh
+++ b/scripts/gitea-integration-provision.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 # Boot and seed a throwaway containerized Gitea, then publish the coordinates
 # the gitea adapter integration suite reads.
 #
@@ -13,7 +13,11 @@
 #   eval "$(scripts/gitea-integration-provision.sh)"
 # works locally. Everything else goes to stderr, keeping stdout eval-parseable.
 
-set -euo pipefail
+set -eu
+
+SCRIPT_DIR=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)
+# shellcheck source=scripts/lib/provision.sh
+. "${SCRIPT_DIR}/lib/provision.sh"
 
 IMAGE="${1:-docker.gitea.com/gitea:1.27.0-rootless}"
 
@@ -32,63 +36,21 @@ PROJECT="${GITEA_USER}/${GITEA_REPO}"
 READINESS_TIMEOUT=90
 POLL_INTERVAL=2
 
-NEWLINE=$'\n'
-
-# Diagnostics go to stderr so stdout carries only the coordinate assignments.
-log() {
-	printf '%s\n' "$*" >&2
-}
-
-# Surface container logs on a non-zero exit. The container is left running: CI
-# discards the runner, and the next local run clears it.
-dump_logs_on_error() {
-	local code=$?
-	if [ "$code" -ne 0 ] && docker inspect "$CONTAINER_NAME" >/dev/null 2>&1; then
-		log "provisioning failed (exit ${code}); recent container logs follow:"
-		docker logs --tail 200 "$CONTAINER_NAME" >&2 || true
-	fi
-}
 trap dump_logs_on_error EXIT
 
-for tool in docker curl jq; do
-	if ! command -v "$tool" >/dev/null 2>&1; then
-		log "required command not found: ${tool}"
-		exit 1
-	fi
-done
+require_tools docker curl jq
 
-# Method, path, and auth mode are positional; the JSON body comes from stdin.
-# Auth mode is "token" or "basic" (the admin user and password). A non-2xx status
-# logs the response and fails, which set -e turns into an exit.
-#
-# Repository creation needs admin basic auth; everything else runs under the
-# token, so the run also proves the published scopes cover the whole fixture.
-# Reviews are the exception, see user_call.
+# Auth mode is "token" or "basic" (the admin user and password). Repository
+# creation needs basic auth; everything else runs under the token, so the run
+# also proves the published scopes cover the whole fixture. Reviews are the
+# exception, see user_call.
 gitea_call() {
-	local method="$1" path="$2" auth="$3" body response status
-	body=$(cat)
-	local auth_args=()
-	case "$auth" in
-	token) auth_args=(-H "Authorization: token ${TOKEN}") ;;
-	basic) auth_args=(-u "${GITEA_USER}:${GITEA_PASSWORD}") ;;
+	_gc_method=$1 _gc_path=$2 _gc_auth=$3
+	case "$_gc_auth" in
+	token) api_call "$_gc_method" "${ENDPOINT}/api/v1${_gc_path}" -H "Authorization: token ${TOKEN}" ;;
+	basic) api_call "$_gc_method" "${ENDPOINT}/api/v1${_gc_path}" -u "${GITEA_USER}:${GITEA_PASSWORD}" ;;
 	*)
-		log "unknown auth mode: ${auth}"
-		return 1
-		;;
-	esac
-	response=$(curl -sS --max-time 30 -w "${NEWLINE}%{http_code}" \
-		"${auth_args[@]}" \
-		-H 'Content-Type: application/json' \
-		-X "$method" "${ENDPOINT}/api/v1${path}" \
-		-d "$body")
-	status=${response##*"$NEWLINE"}
-	response=${response%"$NEWLINE"*}
-	case "$status" in
-	2*)
-		printf '%s' "$response"
-		;;
-	*)
-		log "gitea API ${method} ${path} returned HTTP ${status}: ${response}"
+		log "unknown auth mode: ${_gc_auth}"
 		return 1
 		;;
 	esac
@@ -98,29 +60,11 @@ gitea_call() {
 # review needs a distinct author. Passwords travel over loopback and are never
 # echoed.
 user_call() {
-	local user="$1" password="$2" method="$3" path="$4" body response status
-	body=$(cat)
-	response=$(curl -sS --max-time 30 -w "${NEWLINE}%{http_code}" \
-		-u "${user}:${password}" \
-		-H 'Content-Type: application/json' \
-		-X "$method" "${ENDPOINT}/api/v1${path}" \
-		-d "$body")
-	status=${response##*"$NEWLINE"}
-	response=${response%"$NEWLINE"*}
-	case "$status" in
-	2*)
-		printf '%s' "$response"
-		;;
-	*)
-		log "gitea API ${method} ${path} (as ${user}) returned HTTP ${status}: ${response}"
-		return 1
-		;;
-	esac
+	_uc_user=$1 _uc_password=$2 _uc_method=$3 _uc_path=$4
+	api_call "$_uc_method" "${ENDPOINT}/api/v1${_uc_path}" -u "${_uc_user}:${_uc_password}"
 }
 
-# Remove a prior container of the fixed name so a repeat local run reclaims the
-# host port instead of failing to bind it.
-docker rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
+reclaim_container
 
 log "starting ${IMAGE} as ${CONTAINER_NAME} on host port ${HOST_PORT}"
 # INSTALL_LOCK skips the first-run wizard, without which the version route
@@ -133,22 +77,11 @@ docker run -d --name "$CONTAINER_NAME" \
 	"$IMAGE" >/dev/null
 
 log "waiting up to ${READINESS_TIMEOUT}s for ${ENDPOINT}/api/v1/version"
-deadline=$((SECONDS + READINESS_TIMEOUT))
-ready=false
-while [ "$SECONDS" -lt "$deadline" ]; do
-	status=$(curl -sS --max-time 5 -o /dev/null -w '%{http_code}' \
-		"${ENDPOINT}/api/v1/version" 2>/dev/null || true)
-	if [ "$status" = "200" ]; then
-		ready=true
-		break
-	fi
-	sleep "$POLL_INTERVAL"
-done
-if [ "$ready" != "true" ]; then
+if ! wait_for_http "${ENDPOINT}/api/v1/version" "200" "$READINESS_TIMEOUT" "$POLL_INTERVAL"; then
 	log "gitea did not become ready within ${READINESS_TIMEOUT}s"
 	exit 1
 fi
-log "gitea is ready"
+log "gitea ready after ${WAITED_SECONDS}s"
 
 # The --must-change-password=false flag is load-bearing: a fresh admin is
 # otherwise forced into a password-change state that blocks token creation.
@@ -179,9 +112,9 @@ jq -nc --arg name "$GITEA_REPO" '{name: $name, private: false, auto_init: true}'
 
 # The five workflow-state and category labels the fixture assigns to its issues.
 create_label() {
-	local name="$1"
-	jq -nc --arg name "$name" '{name: $name, color: "#cccccc"}' |
-		gitea_call POST "/repos/${PROJECT}/labels" token | jq -er '.id'
+	_cl_out=$(jq -nc --arg name "$1" '{name: $name, color: "#cccccc"}' |
+		gitea_call POST "/repos/${PROJECT}/labels" token)
+	printf '%s' "$_cl_out" | jq -er '.id'
 }
 log "creating labels"
 label_backlog=$(create_label "backlog")
@@ -192,10 +125,10 @@ label_bug=$(create_label "bug")
 
 # Echoes the new issue's repo index.
 create_issue() {
-	local title="$1" labels="$2"
-	jq -nc --arg title "$title" --argjson labels "$labels" \
+	_ci_out=$(jq -nc --arg title "$1" --argjson labels "$2" \
 		'{title: $title, body: "Seed issue for the gitea adapter integration fixture.", labels: $labels}' |
-		gitea_call POST "/repos/${PROJECT}/issues" token | jq -er '.number'
+		gitea_call POST "/repos/${PROJECT}/issues" token)
+	printf '%s' "$_ci_out" | jq -er '.number'
 }
 
 # The earliest-created issue owns the comments and the blocker relationship, so
@@ -264,9 +197,10 @@ jq -nc '{permission: "write"}' |
 
 # Resolved rather than assumed to be "main", so a changed instance default does
 # not break the PR base.
-default_branch=$(curl -sS --max-time 30 \
+repo_response=$(curl -sS --max-time 30 \
 	-H "Authorization: token ${TOKEN}" \
-	"${ENDPOINT}/api/v1/repos/${PROJECT}" | jq -er '.default_branch')
+	"${ENDPOINT}/api/v1/repos/${PROJECT}")
+default_branch=$(printf '%s' "$repo_response" | jq -er '.default_branch')
 
 log "creating branch ${FEATURE_BRANCH} and committing the sentinel file"
 jq -nc --arg new "$FEATURE_BRANCH" --arg old "$default_branch" \
@@ -275,14 +209,16 @@ jq -nc --arg new "$FEATURE_BRANCH" --arg old "$default_branch" \
 # A NEW multi-line file: every line is an added diff line, so an inline comment
 # anchored to line 1 reads back with position > 0 (Outdated == false).
 sentinel_content=$(printf 'sentinel line 1\nsentinel line 2\nsentinel line 3\nsentinel line 4\nsentinel line 5\n' | base64 | tr -d '\n')
-head_sha=$(jq -nc --arg content "$sentinel_content" --arg branch "$FEATURE_BRANCH" \
+sentinel_response=$(jq -nc --arg content "$sentinel_content" --arg branch "$FEATURE_BRANCH" \
 	'{content: $content, branch: $branch, message: "Add review sentinel file"}' |
-	gitea_call POST "/repos/${PROJECT}/contents/${SENTINEL_PATH}" token | jq -er '.commit.sha')
+	gitea_call POST "/repos/${PROJECT}/contents/${SENTINEL_PATH}" token)
+head_sha=$(printf '%s' "$sentinel_response" | jq -er '.commit.sha')
 
 log "opening the review pull request"
-pr_index=$(jq -nc --arg head "$FEATURE_BRANCH" --arg base "$default_branch" \
+pr_response=$(jq -nc --arg head "$FEATURE_BRANCH" --arg base "$default_branch" \
 	'{head: $head, base: $base, title: "Review fixture pull request", body: "Seed PR for the gitea SCM adapter integration fixture."}' |
-	gitea_call POST "/repos/${PROJECT}/pulls" token | jq -er '.number')
+	gitea_call POST "/repos/${PROJECT}/pulls" token)
+pr_index=$(printf '%s' "$pr_response" | jq -er '.number')
 
 log "submitting the human REQUEST_CHANGES review as ${REVIEWER_USER}"
 jq -nc --arg path "$SENTINEL_PATH" \
@@ -310,14 +246,17 @@ jq -nc --arg new "$PROBE_BRANCH" --arg old "$default_branch" \
 	'{new_branch_name: $new, old_branch_name: $old}' |
 	gitea_call POST "/repos/${PROJECT}/branches" token >/dev/null
 probe_content=$(printf 'status pagination probe commit\n' | base64 | tr -d '\n')
-probe_sha=$(jq -nc --arg content "$probe_content" --arg branch "$PROBE_BRANCH" \
+probe_response=$(jq -nc --arg content "$probe_content" --arg branch "$PROBE_BRANCH" \
 	'{content: $content, branch: $branch, message: "Add status probe file"}' |
-	gitea_call POST "/repos/${PROJECT}/contents/status-probe.txt" token | jq -er '.commit.sha')
+	gitea_call POST "/repos/${PROJECT}/contents/status-probe.txt" token)
+probe_sha=$(printf '%s' "$probe_response" | jq -er '.commit.sha')
 
 log "seeding ${PROBE_STATUS_COUNT} distinct-context statuses on the probe commit"
-for ((i = 1; i <= PROBE_STATUS_COUNT; i++)); do
+i=1
+while [ "$i" -le "$PROBE_STATUS_COUNT" ]; do
 	jq -nc --arg ctx "ci/probe-${i}" '{state: "success", context: $ctx}' |
 		gitea_call POST "/repos/${PROJECT}/statuses/${probe_sha}" token >/dev/null
+	i=$((i + 1))
 done
 
 # One add-and-remove pair on the PR timeline (PRs share the issue index space)
@@ -327,20 +266,7 @@ jq -nc --argjson id "$label_review" '{labels: [$id]}' |
 	gitea_call POST "/repos/${PROJECT}/issues/${pr_index}/labels" token >/dev/null
 gitea_call DELETE "/repos/${PROJECT}/issues/${pr_index}/labels/${label_review}" token </dev/null >/dev/null
 
-# $GITHUB_ENV takes a bare KEY=VALUE; stdout takes an export statement, so an
-# eval'd coordinate is inherited by the test process rather than merely set.
-emit() {
-	if [ -n "${GITHUB_ENV:-}" ] && [ -w "${GITHUB_ENV}" ]; then
-		printf '%s=%s\n' "$1" "$2" >>"$GITHUB_ENV"
-	fi
-	printf "export %s='%s'\n" "$1" "$2"
-}
-
-# Mask before the token is echoed anywhere. Only under Actions: locally this
-# would pollute eval's stdout.
-if [ "${GITHUB_ACTIONS:-}" = "true" ]; then
-	printf '::add-mask::%s\n' "$TOKEN"
-fi
+mask_secret "$TOKEN"
 
 log "provisioning complete; publishing coordinates"
 emit SORTIE_GITEA_ENDPOINT "$ENDPOINT"

--- a/scripts/gitlab-integration-provision.sh
+++ b/scripts/gitlab-integration-provision.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 # Boot and seed a throwaway containerized GitLab Community Edition instance,
 # then publish the coordinates the gitlab adapter integration suite reads.
 #
@@ -18,7 +18,11 @@
 # 4 CPUs and 16 GB, the documented ubuntu-latest shape); the headroom covers a
 # hosted runner's disk throughput, which that constraint does not reproduce.
 
-set -euo pipefail
+set -eu
+
+SCRIPT_DIR=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)
+# shellcheck source=scripts/lib/provision.sh
+. "${SCRIPT_DIR}/lib/provision.sh"
 
 IMAGE="${1:-gitlab/gitlab-ce:19.2.1-ce.0}"
 
@@ -36,57 +40,16 @@ GROUP_NAME="sortie-gitlab-integration"
 PRIMARY_PROJECT_NAME="primary"
 SIBLING_PROJECT_NAME="sibling"
 
-NEWLINE=$'\n'
-
-# Diagnostics go to stderr so stdout carries only the coordinate assignments.
-log() {
-	printf '%s\n' "$*" >&2
-}
-
-# Surface container logs on a non-zero exit. The container is left running: CI
-# discards the runner, and the next local run clears it.
-dump_logs_on_error() {
-	local code=$?
-	if [ "$code" -ne 0 ] && docker inspect "$CONTAINER_NAME" >/dev/null 2>&1; then
-		log "provisioning failed (exit ${code}); recent container logs follow:"
-		docker logs --tail 200 "$CONTAINER_NAME" >&2 || true
-	fi
-}
 trap dump_logs_on_error EXIT
 
-for tool in docker curl jq; do
-	if ! command -v "$tool" >/dev/null 2>&1; then
-		log "required command not found: ${tool}"
-		exit 1
-	fi
-done
+require_tools docker curl jq
 
-# Method, path, and token are positional; the JSON body comes from stdin. A
-# non-2xx status logs the response and fails, which set -e turns into an exit.
 gitlab_call() {
-	local method="$1" path="$2" token="$3" body response status
-	body=$(cat)
-	response=$(curl -sS --max-time 30 -w "${NEWLINE}%{http_code}" \
-		-H "PRIVATE-TOKEN: ${token}" \
-		-H 'Content-Type: application/json' \
-		-X "$method" "${ENDPOINT}/api/v4${path}" \
-		-d "$body")
-	status=${response##*"$NEWLINE"}
-	response=${response%"$NEWLINE"*}
-	case "$status" in
-	2*)
-		printf '%s' "$response"
-		;;
-	*)
-		log "gitlab API ${method} ${path} returned HTTP ${status}: ${response}"
-		return 1
-		;;
-	esac
+	_gl_method=$1 _gl_path=$2 _gl_token=$3
+	api_call "$_gl_method" "${ENDPOINT}/api/v4${_gl_path}" -H "PRIVATE-TOKEN: ${_gl_token}"
 }
 
-# Remove a prior container of the fixed name so a repeat local run reclaims
-# the host port instead of failing to bind it.
-docker rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
+reclaim_container
 
 # Released Community Edition images live only on Docker Hub, pulled anonymously.
 # Keeping the pull its own step separates a registry failure from a boot one.
@@ -105,35 +68,19 @@ log "starting ${IMAGE} as ${CONTAINER_NAME} on host port ${HOST_PORT}"
 # grafana['enable'], fails gitlab-ctl reconfigure and exits the container
 # within seconds.
 docker run -d --name "$CONTAINER_NAME" \
-	-p "${HOST_PORT}:8929" \
+	-p "${HOST_PORT}:${HOST_PORT}" \
 	--shm-size=256m \
 	-e GITLAB_OMNIBUS_CONFIG="external_url 'http://localhost:${HOST_PORT}'; puma['worker_processes'] = 0; sidekiq['concurrency'] = 1; prometheus_monitoring['enable'] = false; registry['enable'] = false; gitlab_kas['enable'] = false;" \
 	"$IMAGE" >/dev/null
 
+# 401 counts as ready: the route answers before any credential exists.
 log "waiting up to ${READINESS_TIMEOUT_SECONDS}s for ${ENDPOINT}/api/v4/version"
-SECONDS=0
-ready=false
-while [ "$SECONDS" -lt "$READINESS_TIMEOUT_SECONDS" ]; do
-	if [ "$(docker inspect -f '{{.State.Running}}' "$CONTAINER_NAME" 2>/dev/null || true)" != "true" ]; then
-		log "container exited before readiness; a boot-configuration failure is the usual cause"
-		exit 1
-	fi
-
-	status=$(curl -sS --max-time 5 -o /dev/null -w '%{http_code}' "${ENDPOINT}/api/v4/version" 2>/dev/null || true)
-	case "$status" in
-	200 | 401)
-		ready=true
-		break
-		;;
-	esac
-
-	sleep "$POLL_INTERVAL_SECONDS"
-done
-if [ "$ready" != "true" ]; then
+if ! wait_for_http "${ENDPOINT}/api/v4/version" "200 401" \
+	"$READINESS_TIMEOUT_SECONDS" "$POLL_INTERVAL_SECONDS"; then
 	log "gitlab did not become ready within ${READINESS_TIMEOUT_SECONDS}s"
 	exit 1
 fi
-log "gitlab ready after ${SECONDS}s"
+log "gitlab ready after ${WAITED_SECONDS}s"
 
 # No resource-owner password grant at this version, so the first token comes
 # from inside the container. The expiry is read off the instance clock: a date
@@ -196,31 +143,20 @@ PUBLISHED_TOKEN=$(printf '%s' "$published_response" | jq -er '.token')
 # until the authorization refresh commits. Gate on the project being visible
 # to the token itself, or every fixture below races that refresh.
 log "waiting up to ${AUTHORIZATION_TIMEOUT_SECONDS}s for the published token's project authorization"
-SECONDS=0
-authorized=false
-while [ "$SECONDS" -lt "$AUTHORIZATION_TIMEOUT_SECONDS" ]; do
-	status=$(curl -sS --max-time 10 -o /dev/null -w '%{http_code}' \
-		-H "PRIVATE-TOKEN: ${PUBLISHED_TOKEN}" \
-		"${ENDPOINT}/api/v4/projects/${PRIMARY_ID}" 2>/dev/null || true)
-	if [ "$status" = "200" ]; then
-		authorized=true
-		break
-	fi
-	sleep "$AUTHORIZATION_POLL_INTERVAL_SECONDS"
-done
-if [ "$authorized" != "true" ]; then
-	log "published token never saw project ${PRIMARY_ID} within ${AUTHORIZATION_TIMEOUT_SECONDS}s; last status ${status}"
+if ! wait_for_http "${ENDPOINT}/api/v4/projects/${PRIMARY_ID}" "200" \
+	"$AUTHORIZATION_TIMEOUT_SECONDS" "$AUTHORIZATION_POLL_INTERVAL_SECONDS" \
+	-H "PRIVATE-TOKEN: ${PUBLISHED_TOKEN}"; then
+	log "published token never saw project ${PRIMARY_ID} within ${AUTHORIZATION_TIMEOUT_SECONDS}s; last status ${WAIT_STATUS}"
 	exit 1
 fi
-log "published token authorized after ${SECONDS}s"
+log "published token authorized after ${WAITED_SECONDS}s"
 
 PUBLISHED_USER_ID=$(curl -sS --max-time 30 -H "PRIVATE-TOKEN: ${PUBLISHED_TOKEN}" "${ENDPOINT}/api/v4/user" | jq -er '.id')
 
 # Every fixture below is created under the published Developer-level token, so
 # the suite runs against objects its own identity could have made.
 log "creating project labels"
-primary_labels=(backlog in-progress review "done" needs-human)
-for label in "${primary_labels[@]}"; do
+for label in backlog in-progress review 'done' needs-human; do
 	jq -nc --arg name "$label" '{name: $name, color: "#cccccc"}' |
 		gitlab_call POST "/projects/${PRIMARY_ID}/labels" "$PUBLISHED_TOKEN" >/dev/null
 done
@@ -229,16 +165,16 @@ done
 # timestamps strictly ordered, which is what makes "first candidate" and
 # "earliest-created" deterministic.
 create_primary_issue() {
-	local title="$1" labels_json="$2" extra_json="${3:-{}}"
-	jq -nc --arg title "$title" --argjson labels "$labels_json" --argjson extra "$extra_json" \
+	_cpi_extra=${3:-\{\}}
+	_cpi_out=$(jq -nc --arg title "$1" --argjson labels "$2" --argjson extra "$_cpi_extra" \
 		'{title: $title, labels: $labels} + $extra' |
-		gitlab_call POST "/projects/${PRIMARY_ID}/issues" "$PUBLISHED_TOKEN" | jq -er '.iid'
+		gitlab_call POST "/projects/${PRIMARY_ID}/issues" "$PUBLISHED_TOKEN")
+	printf '%s' "$_cpi_out" | jq -er '.iid'
 }
 
 add_comment() {
-	local iid="$1" body="$2"
-	jq -nc --arg body "$body" '{body: $body}' |
-		gitlab_call POST "/projects/${PRIMARY_ID}/issues/${iid}/notes" "$PUBLISHED_TOKEN" >/dev/null
+	jq -nc --arg body "$2" '{body: $body}' |
+		gitlab_call POST "/projects/${PRIMARY_ID}/issues/${1}/notes" "$PUBLISHED_TOKEN" >/dev/null
 }
 
 log "creating seed issues in ascending time order"
@@ -266,8 +202,10 @@ add_comment "$issue_backlog_1" "First seed comment."
 add_comment "$issue_backlog_1" "Second seed comment."
 
 log "seeding at least 101 comments on issue ${issue_bulk}"
-for i in $(seq 1 101); do
+i=1
+while [ "$i" -le 101 ]; do
 	add_comment "$issue_bulk" "Bulk seed comment ${i}."
+	i=$((i + 1))
 done
 
 log "linking issue ${issue_bulk} to ${issue_linktarget}, which carries no human comment"
@@ -276,27 +214,16 @@ jq -nc --argjson target_project_id "$PRIMARY_ID" --argjson target_issue_iid "$is
 	gitlab_call POST "/projects/${PRIMARY_ID}/issues/${issue_bulk}/links" "$PUBLISHED_TOKEN" >/dev/null
 
 log "creating one non-issue work item"
-issue_task=$(jq -nc --arg title "Task work item" '{title: $title, issue_type: "task"}' |
-	gitlab_call POST "/projects/${PRIMARY_ID}/issues" "$PUBLISHED_TOKEN" | jq -er '.iid')
+task_response=$(jq -nc --arg title "Task work item" '{title: $title, issue_type: "task"}' |
+	gitlab_call POST "/projects/${PRIMARY_ID}/issues" "$PUBLISHED_TOKEN")
+issue_task=$(printf '%s' "$task_response" | jq -er '.iid')
 
 log "closing issue ${issue_done} into its terminal state"
 jq -nc '{state_event: "close"}' |
 	gitlab_call PUT "/projects/${PRIMARY_ID}/issues/${issue_done}" "$PUBLISHED_TOKEN" >/dev/null
 
-# $GITHUB_ENV takes a bare KEY=VALUE; stdout takes an export statement, so an
-# eval'd coordinate is inherited by the test process rather than merely set.
-emit() {
-	if [ -n "${GITHUB_ENV:-}" ] && [ -w "${GITHUB_ENV}" ]; then
-		printf '%s=%s\n' "$1" "$2" >>"$GITHUB_ENV"
-	fi
-	printf "export %s='%s'\n" "$1" "$2"
-}
-
-# Mask before the token is echoed anywhere. The bootstrap token is never
-# emitted at all. Only under Actions: locally this would pollute eval's stdout.
-if [ "${GITHUB_ACTIONS:-}" = "true" ]; then
-	printf '::add-mask::%s\n' "$PUBLISHED_TOKEN"
-fi
+# The bootstrap token is never emitted, so only this one needs masking.
+mask_secret "$PUBLISHED_TOKEN"
 
 log "provisioning complete; publishing coordinates"
 emit SORTIE_GITLAB_ENDPOINT "$ENDPOINT"

--- a/scripts/lib/provision.sh
+++ b/scripts/lib/provision.sh
@@ -1,0 +1,118 @@
+# shellcheck shell=sh
+# Shared helpers for the containerized tracker provisioning scripts. Sourced,
+# never executed. The caller sets CONTAINER_NAME before anything that touches
+# the container.
+#
+# POSIX sh, so no pipefail: a pipeline reports only its last command. Callers
+# must capture a helper's output into a variable and check that status before
+# piping it onward, or a failed call is masked by a jq that exits 0 on empty
+# input.
+
+# A literal newline. $'\n' is a bashism.
+NEWLINE='
+'
+
+# Diagnostics go to stderr so stdout carries only the coordinate assignments.
+log() {
+	printf '%s\n' "$*" >&2
+}
+
+require_tools() {
+	for _rt_tool in "$@"; do
+		if ! command -v "$_rt_tool" >/dev/null 2>&1; then
+			log "required command not found: ${_rt_tool}"
+			return 1
+		fi
+	done
+}
+
+# Surface container logs on a non-zero exit. The container is left running: CI
+# discards the runner, and the next local run clears it.
+dump_logs_on_error() {
+	_dl_code=$?
+	if [ "$_dl_code" -ne 0 ] && docker inspect "$CONTAINER_NAME" >/dev/null 2>&1; then
+		log "provisioning failed (exit ${_dl_code}); recent container logs follow:"
+		docker logs --tail 200 "$CONTAINER_NAME" >&2 || true
+	fi
+}
+
+# Remove a prior container of the fixed name so a repeat local run reclaims the
+# host port instead of failing to bind it.
+reclaim_container() {
+	docker rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
+}
+
+container_running() {
+	[ "$(docker inspect -f '{{.State.Running}}' "$CONTAINER_NAME" 2>/dev/null || true)" = "true" ]
+}
+
+# wait_for_http URL ACCEPTED_STATUSES TIMEOUT INTERVAL [curl args...]
+#
+# Polls until the URL answers with one of the space-separated accepted statuses.
+# Sets WAITED_SECONDS and WAIT_STATUS. A container that exits mid-wait fails fast
+# instead of burning the whole budget.
+wait_for_http() {
+	_wh_url=$1 _wh_accept=$2 _wh_timeout=$3 _wh_interval=$4
+	shift 4
+	_wh_start=$(date +%s)
+	while :; do
+		if ! container_running; then
+			log "container exited before readiness; a boot-configuration failure is the usual cause"
+			return 1
+		fi
+
+		WAIT_STATUS=$(curl -sS --max-time 5 -o /dev/null -w '%{http_code}' "$@" "$_wh_url" 2>/dev/null || true)
+		case " ${_wh_accept} " in
+		*" ${WAIT_STATUS} "*)
+			WAITED_SECONDS=$(($(date +%s) - _wh_start))
+			return 0
+			;;
+		esac
+
+		WAITED_SECONDS=$(($(date +%s) - _wh_start))
+		[ "$WAITED_SECONDS" -lt "$_wh_timeout" ] || return 1
+		sleep "$_wh_interval"
+	done
+}
+
+# api_call METHOD URL [curl args...]
+#
+# The JSON body comes from stdin. A non-2xx status logs the response and fails.
+api_call() {
+	_ac_method=$1 _ac_url=$2
+	shift 2
+	_ac_body=$(cat)
+	_ac_response=$(curl -sS --max-time 30 -w "${NEWLINE}%{http_code}" \
+		-H 'Content-Type: application/json' \
+		"$@" \
+		-X "$_ac_method" "$_ac_url" \
+		-d "$_ac_body")
+	_ac_status=${_ac_response##*"$NEWLINE"}
+	_ac_response=${_ac_response%"$NEWLINE"*}
+	case "$_ac_status" in
+	2*)
+		printf '%s' "$_ac_response"
+		;;
+	*)
+		log "api ${_ac_method} ${_ac_url} returned HTTP ${_ac_status}: ${_ac_response}"
+		return 1
+		;;
+	esac
+}
+
+# $GITHUB_ENV takes a bare KEY=VALUE; stdout takes an export statement, so an
+# eval'd coordinate is inherited by the test process rather than merely set.
+emit() {
+	if [ -n "${GITHUB_ENV:-}" ] && [ -w "${GITHUB_ENV}" ]; then
+		printf '%s=%s\n' "$1" "$2" >>"$GITHUB_ENV"
+	fi
+	printf "export %s='%s'\n" "$1" "$2"
+}
+
+# Mask before the secret is echoed anywhere. Only under Actions: locally this
+# would pollute eval's stdout.
+mask_secret() {
+	if [ "${GITHUB_ACTIONS:-}" = "true" ]; then
+		printf '::add-mask::%s\n' "$1"
+	fi
+}

--- a/scripts/signpath-sign.sh
+++ b/scripts/signpath-sign.sh
@@ -17,6 +17,7 @@ set -eu
 
 artifact=${1:?usage: signpath-sign.sh <path-to-binary>}
 
+
 # Only Authenticode-sign Windows PE executables.
 case "$artifact" in
     *.exe) ;;


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Refactor

**Intent:** Port the gitea and gitlab integration-provisioning scripts from bash to plain POSIX `sh`, deduplicate their shared helpers into `scripts/lib/provision.sh`, and add a CI job that runs shellcheck over changed shell scripts so this class of portability issue is caught automatically going forward.

### 🧭 Reviewer Guide

**Complexity:** Medium

#### Entry Point

`scripts/lib/provision.sh` is new and is the file to read first - it centralizes `log`, `dump_logs_on_error`, `require_tools`, `reclaim_container`, `wait_for_http`, `api_call`, `emit`, and `mask_secret`, which `scripts/gitea-integration-provision.sh` and `scripts/gitlab-integration-provision.sh` both sourced duplicated copies of before this change. Bash-only constructs (arrays, `local`, `$('\n')`, `for ((...))`, bare `$SECONDS`) are replaced with POSIX-portable equivalents throughout.

#### Sensitive Areas

- `scripts/gitea-integration-provision.sh` and `scripts/gitlab-integration-provision.sh`: these seed throwaway containers for the gitea/gitlab adapter integration test suites; behavior must stay identical even though every function body changed shape.
- `.github/workflows/ci.yml`: new "Lint shell scripts" step gates the whole CI job on shellcheck passing over touched `*.sh` files.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes. The scripts' external contract (arguments, emitted `SORTIE_*` env vars, stdout/stderr split) is unchanged.
- **Migrations/State:** No migrations or state changes.