### PR TITLE
feat(cli): add sortie stats subcommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `sortie stats` subcommand: summarizes how past runs went and what they
+  cost, opening the database read-only so it never blocks a running
+  orchestrator. `--format text|json` selects the output; `--since` and
+  `--until` bound the report by when a run finished, accepting an exact
+  timestamp, a `YYYY-MM-DD` date, or an age such as `24h`. The report
+  breaks runs down by outcome, by coding agent, by dispatch rule, and by
+  prompt template, with run counts, success rate, p50/p95/mean duration,
+  mean turns, and token totals for each. When the workflow configures
+  `token_rates`, USD cost is derived through the same formula and
+  renderers the dashboard uses, reported as total spend and as spend per
+  succeeded run; without `token_rates` the report shows token counts and
+  no cost figures rather than zeros. Against a database written by an
+  older binary the command still works: it reports the figures that
+  database can supply and warns which ones are missing, rather than
+  failing outright.
+  ([#274](https://github.com/sortie-ai/sortie/issues/274))
+
 ## [1.17.0] - 2026-08-06
 
 ### Added

--- a/cmd/sortie/boot.go
+++ b/cmd/sortie/boot.go
@@ -59,6 +59,9 @@ func boot(ctx context.Context, p bootParams) (bootResult, int) {
 	if len(p.args) > 0 && p.args[0] == "validate" {
 		return bootResult{}, runValidate(ctx, p.args[1:], p.stdout, p.stderr)
 	}
+	if len(p.args) > 0 && p.args[0] == "stats" {
+		return bootResult{}, runStats(ctx, p.args[1:], p.stdout, p.stderr)
+	}
 	if len(p.args) > 0 && p.args[0] == "mcp-server" {
 		return bootResult{}, runMCPServer(ctx, p.args[1:], p.stdout, p.stderr)
 	}

--- a/cmd/sortie/stats.go
+++ b/cmd/sortie/stats.go
@@ -561,28 +561,45 @@ func (a *statsAggregator) selfReviewReport() *statsSelfReview {
 	return sr
 }
 
-// degradedSchemaWarning names the figures caps cannot supply and states
-// the remedy. It names only the groups whose flag is false, because a
-// partly migrated database is the common case and a fixed sentence would
-// disclaim figures the database can in fact supply.
+// degradedSchemaWarning names the figures the report leaves out and states
+// the remedy. It MUST NOT be called when caps is full.
+//
+// A partly migrated database is the common case, and on it the two lists
+// differ: the report falls back to the basic figures wholesale, so it drops
+// groups this database does carry as well as the ones it never recorded.
+// Naming only the unrecorded groups would let a reader conclude the
+// remaining figures are present when they are not.
 func degradedSchemaWarning(caps persistence.RunHistoryCapabilities) string {
-	var missing []string
-	if !caps.HasTurnsCompleted {
-		missing = append(missing, "turns")
+	groups := []struct {
+		recorded bool
+		name     string
+	}{
+		{caps.HasTurnsCompleted, "turns"},
+		{caps.HasReviewMetadata, "self-review results"},
+		{caps.HasRuleRouting, "dispatch-rule routing"},
+		{caps.HasTokens, "tokens and cost"},
 	}
-	if !caps.HasReviewMetadata {
-		missing = append(missing, "self-review results")
+
+	var unrecorded, dropped []string
+	for _, g := range groups {
+		if g.recorded {
+			dropped = append(dropped, g.name)
+		} else {
+			unrecorded = append(unrecorded, g.name)
+		}
 	}
-	if !caps.HasRuleRouting {
-		missing = append(missing, "dispatch-rule routing")
-	}
-	if !caps.HasTokens {
-		missing = append(missing, "tokens and cost")
+
+	if len(dropped) == 0 {
+		return fmt.Sprintf(
+			"this database was written before sortie recorded %s, so the report leaves them out. "+
+				"Run sortie once with this workflow to add them.",
+			strings.Join(unrecorded, ", "))
 	}
 	return fmt.Sprintf(
-		"this database was written before sortie recorded %s, so the report leaves them out. "+
-			"Run sortie once with this workflow to add them.",
-		strings.Join(missing, ", "))
+		"this database was written before sortie recorded %s. The report falls back to run counts and "+
+			"durations, so it also leaves out %s, which this database does carry. "+
+			"Run sortie once with this workflow to get the full report.",
+		strings.Join(unrecorded, ", "), strings.Join(dropped, ", "))
 }
 
 // formatShare renders a 0..1 fraction as a one-decimal percentage.

--- a/cmd/sortie/stats.go
+++ b/cmd/sortie/stats.go
@@ -856,7 +856,16 @@ func renderStatsText(stdout, stderr io.Writer, report statsReport) {
 // same "warning: " prefix emitDiags uses, so a warning is never mistaken
 // for part of the report. The prefix belongs to the rendering rather than
 // to the message, keeping the JSON envelope's warnings field clean.
+//
+// A blank line opens the block so the warnings do not run into the report's
+// last line when both streams share a terminal. It is written to stderr
+// alongside the warnings it separates rather than to stdout, so a report
+// with nothing to warn about does not end in a stray blank line.
 func writeStatsWarnings(stderr io.Writer, warnings []string) {
+	if len(warnings) == 0 {
+		return
+	}
+	fmt.Fprintln(stderr) //nolint:errcheck // stderr write failure is unrecoverable
 	for _, w := range warnings {
 		fmt.Fprintf(stderr, "warning: %s\n", w) //nolint:errcheck // stderr write failure is unrecoverable
 	}

--- a/cmd/sortie/stats.go
+++ b/cmd/sortie/stats.go
@@ -1,0 +1,948 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"math"
+	"path/filepath"
+	"slices"
+	"strconv"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/sortie-ai/sortie/internal/config"
+	"github.com/sortie-ai/sortie/internal/domain"
+	"github.com/sortie-ai/sortie/internal/persistence"
+	"github.com/sortie-ai/sortie/internal/server"
+	"github.com/sortie-ai/sortie/internal/workflow"
+)
+
+// statsNow follows the serverShutdownTimeout precedent for a
+// test-overridable package variable, so a test can pin generated_at and
+// any relative --since or --until bound.
+var statsNow = time.Now
+
+// statsReport is the "sortie stats --format json" envelope. Every slice
+// field is never nil; every pointer field is null when the figure it
+// carries is unavailable.
+type statsReport struct {
+	GeneratedAt  string           `json:"generated_at"`
+	WorkflowPath string           `json:"workflow_path"`
+	DBPath       string           `json:"db_path"`
+	Since        *string          `json:"since"`
+	Until        *string          `json:"until"`
+	SchemaTier   string           `json:"schema_tier"`
+	Warnings     []string         `json:"warnings"`
+	Summary      statsSummary     `json:"summary"`
+	ByStatus     []statsGroup     `json:"by_status"`
+	ByAdapter    []statsGroup     `json:"by_adapter"`
+	ByRule       []statsGroup     `json:"by_rule"`
+	ByTemplate   []statsGroup     `json:"by_template"`
+	SelfReview   *statsSelfReview `json:"self_review"`
+}
+
+// statsSummary reports the report-wide figures. MeanTurnsSucceeded,
+// Tokens, CostUSD, and CostPerSucceededRunUSD are null on the base
+// schema tier; CostUSD and CostPerSucceededRunUSD are also null when
+// no priced run exists in range.
+type statsSummary struct {
+	Runs                   int           `json:"runs"`
+	Succeeded              int           `json:"succeeded"`
+	SuccessRate            float64       `json:"success_rate"`
+	Duration               statsDuration `json:"duration_seconds"`
+	MeanTurnsSucceeded     *float64      `json:"mean_turns_succeeded"`
+	Tokens                 *statsTokens  `json:"tokens"`
+	CostUSD                *float64      `json:"cost_usd"`
+	CostPerSucceededRunUSD *float64      `json:"cost_per_succeeded_run_usd"`
+	ZeroDurationRuns       int           `json:"zero_duration_runs"`
+	DurationExcludedRuns   int           `json:"duration_excluded_runs"`
+	CostUnpricedRuns       int           `json:"cost_unpriced_runs"`
+}
+
+// statsDuration reports p50, p95, and the arithmetic mean over a sample
+// population, in seconds. All three are null when Samples is 0.
+type statsDuration struct {
+	P50     *float64 `json:"p50"`
+	P95     *float64 `json:"p95"`
+	Mean    *float64 `json:"mean"`
+	Samples int      `json:"samples"`
+}
+
+// statsTokens reports the four token sums as stored, never recomputed.
+type statsTokens struct {
+	Input     int64 `json:"input"`
+	Output    int64 `json:"output"`
+	Total     int64 `json:"total"`
+	CacheRead int64 `json:"cache_read"`
+}
+
+// statsGroup is one row of a by_status, by_adapter, by_rule, or
+// by_template breakdown. MeanTurns, Tokens, CostUSD, and
+// CostPerSucceededRunUSD are null on the base schema tier; CostUSD and
+// CostPerSucceededRunUSD are also null when the group holds no priced
+// run. In by_status, Succeeded and SuccessRate are structural rather
+// than informative: the "succeeded" row necessarily reports Succeeded
+// equal to Runs.
+type statsGroup struct {
+	Name                   string        `json:"name"`
+	Runs                   int           `json:"runs"`
+	Succeeded              int           `json:"succeeded"`
+	SuccessRate            float64       `json:"success_rate"`
+	Share                  float64       `json:"share"`
+	Duration               statsDuration `json:"duration_seconds"`
+	MeanTurns              *float64      `json:"mean_turns"`
+	Tokens                 *statsTokens  `json:"tokens"`
+	CostUSD                *float64      `json:"cost_usd"`
+	CostPerSucceededRunUSD *float64      `json:"cost_per_succeeded_run_usd"`
+}
+
+// statsSelfReview reports the self-review aggregation. MeanIterations is
+// null when RunsWithMetadata is 0. Present only on the full schema tier.
+type statsSelfReview struct {
+	RunsWithMetadata int                 `json:"runs_with_metadata"`
+	ByFinalVerdict   []statsVerdictCount `json:"by_final_verdict"`
+	CapReachedRuns   int                 `json:"cap_reached_runs"`
+	MeanIterations   *float64            `json:"mean_iterations"`
+	UnparsedRuns     int                 `json:"unparsed_runs"`
+}
+
+// statsVerdictCount is one entry of statsSelfReview.ByFinalVerdict.
+type statsVerdictCount struct {
+	Verdict string `json:"verdict"`
+	Runs    int    `json:"runs"`
+}
+
+// tier reports the report's schema_tier label for caps.
+func tier(caps persistence.RunHistoryCapabilities) string {
+	if caps.Full() {
+		return "full"
+	}
+	return "base"
+}
+
+// label maps an empty dimension value to the sentinel a reader sees for
+// a run that carries no adapter, rule, template, or (in principle) status.
+func label(v string) string {
+	if v == "" {
+		return "<none>"
+	}
+	return v
+}
+
+// duration computes row's duration in seconds from its stored RFC3339
+// timestamps. ok is false when either timestamp fails to parse or the
+// resulting difference is negative.
+func duration(row persistence.RunStatsRow) (seconds float64, ok bool) {
+	started, err := time.Parse(time.RFC3339, row.StartedAt)
+	if err != nil {
+		return 0, false
+	}
+	completed, err := time.Parse(time.RFC3339, row.CompletedAt)
+	if err != nil {
+		return 0, false
+	}
+	diff := completed.Sub(started).Seconds()
+	if diff < 0 {
+		return 0, false
+	}
+	return diff, true
+}
+
+// percentile returns the nearest-rank percentile p over sorted, which
+// MUST already be sorted ascending. No interpolation is performed.
+func percentile(sorted []float64, p float64) float64 {
+	n := len(sorted)
+	idx := int(math.Ceil(p/100*float64(n))) - 1
+	idx = max(0, min(idx, n-1))
+	return sorted[idx]
+}
+
+// priceOf returns the estimated USD cost for row under rates, or nil
+// when row's agent adapter has no rate entry.
+func priceOf(row persistence.RunStatsRow, rates server.TokenRates) *float64 {
+	rc, ok := rates[row.AgentAdapter]
+	if !ok {
+		return nil
+	}
+	return server.EstimateCost(row.InputTokens, row.OutputTokens, row.CacheReadTokens, &rc)
+}
+
+// statsSelfReviewAccum accumulates the self-review folding state across
+// every row that carries non-nil review metadata.
+type statsSelfReviewAccum struct {
+	runsWithMetadata int
+	byVerdict        map[string]int
+	capReachedRuns   int
+	iterationSum     int
+	unparsedRuns     int
+}
+
+// foldSelfReview unmarshals raw into a [domain.ReviewMetadata] and folds
+// the result into acc. A value that fails to unmarshal increments acc's
+// unparsed count and contributes to nothing else.
+func foldSelfReview(raw string, acc *statsSelfReviewAccum) {
+	var metadata domain.ReviewMetadata
+	if err := json.Unmarshal([]byte(raw), &metadata); err != nil {
+		acc.unparsedRuns++
+		return
+	}
+
+	acc.runsWithMetadata++
+	verdict := metadata.FinalVerdict
+	if verdict == "" {
+		verdict = "none"
+	}
+	acc.byVerdict[verdict]++
+	if metadata.CapReached {
+		acc.capReachedRuns++
+	}
+	acc.iterationSum += metadata.TotalIterations
+}
+
+// parseRangeBound parses a --since or --until flag value into a UTC
+// time bound. An empty string returns nil, nil, meaning the bound is
+// absent. raw MUST be an RFC3339 timestamp, a YYYY-MM-DD date (read as
+// 00:00:00Z on that date), or a positive Go duration (read as
+// statsNow() minus that duration); any other input, including a zero
+// or negative duration, is a usage error.
+func parseRangeBound(raw string) (*time.Time, error) {
+	if raw == "" {
+		return nil, nil
+	}
+	if t, err := time.Parse(time.RFC3339, raw); err == nil {
+		bound := t.UTC()
+		return &bound, nil
+	}
+	if t, err := time.Parse("2006-01-02", raw); err == nil {
+		bound := t.UTC()
+		return &bound, nil
+	}
+	if d, err := time.ParseDuration(raw); err == nil && d > 0 {
+		bound := statsNow().UTC().Add(-d)
+		return &bound, nil
+	}
+	return nil, fmt.Errorf(
+		"invalid range bound %q: accepts an RFC3339 timestamp (2026-07-01T00:00:00Z), "+
+			"a date (2026-07-01), or a positive duration (24h)", raw)
+}
+
+// statsGroupAccum accumulates the folding state for one statsGroup row
+// before the derived figures are computed in statsAggregator.report.
+type statsGroupAccum struct {
+	name            string
+	runs            int
+	succeeded       int
+	turnSum         int
+	tokens          statsTokens
+	costUSD         float64
+	pricedRuns      int
+	durationSamples []float64
+}
+
+// statsTotalAccum accumulates the report-wide folding state.
+type statsTotalAccum struct {
+	runs                 int
+	succeeded            int
+	succeededTurns       int
+	tokens               statsTokens
+	costUSD              float64
+	pricedRuns           int
+	costUnpricedRuns     int
+	zeroDurationRuns     int
+	durationExcludedRuns int
+	succeededSamples     []float64
+}
+
+// statsAggregator folds a stream of [persistence.RunStatsRow] values,
+// via [statsAggregator.add], into the totals and per-dimension groups
+// [statsAggregator.report] renders into a [statsReport]. add touches no
+// [persistence.Store] method, as [persistence.Store.ScanRunHistoryRange]'s
+// visit callback requires.
+type statsAggregator struct {
+	caps            persistence.RunHistoryCapabilities
+	rates           server.TokenRates
+	ratesConfigured bool
+	tierLabel       string
+
+	total statsTotalAccum
+
+	byStatus   map[string]*statsGroupAccum
+	byAdapter  map[string]*statsGroupAccum
+	byRule     map[string]*statsGroupAccum
+	byTemplate map[string]*statsGroupAccum
+
+	selfReview statsSelfReviewAccum
+}
+
+// newStatsAggregator constructs a statsAggregator for caps and rates.
+// It derives the schema tier and whether rates are configured once,
+// from caps.Full and from rates holding at least one entry.
+func newStatsAggregator(caps persistence.RunHistoryCapabilities, rates server.TokenRates) *statsAggregator {
+	return &statsAggregator{
+		caps:            caps,
+		rates:           rates,
+		ratesConfigured: len(rates) > 0,
+		tierLabel:       tier(caps),
+		byStatus:        make(map[string]*statsGroupAccum),
+		byAdapter:       make(map[string]*statsGroupAccum),
+		byRule:          make(map[string]*statsGroupAccum),
+		byTemplate:      make(map[string]*statsGroupAccum),
+		selfReview:      statsSelfReviewAccum{byVerdict: make(map[string]int)},
+	}
+}
+
+// bumpStatsGroup returns groups' entry for name, creating it on first
+// use, and increments its run count and, when isSucceeded, its
+// succeeded count.
+func bumpStatsGroup(groups map[string]*statsGroupAccum, name string, isSucceeded bool) *statsGroupAccum {
+	g, ok := groups[name]
+	if !ok {
+		g = &statsGroupAccum{name: name}
+		groups[name] = g
+	}
+	g.runs++
+	if isSucceeded {
+		g.succeeded++
+	}
+	return g
+}
+
+// add folds one row into the aggregator. It is the visit callback
+// [persistence.Store.ScanRunHistoryRange] calls once per row; it calls
+// no Store method and always returns nil.
+func (a *statsAggregator) add(row persistence.RunStatsRow) error {
+	isSucceeded := row.Status == "succeeded"
+	a.total.runs++
+	if isSucceeded {
+		a.total.succeeded++
+	}
+
+	bumped := []*statsGroupAccum{
+		bumpStatsGroup(a.byStatus, label(row.Status), isSucceeded),
+		bumpStatsGroup(a.byAdapter, label(row.AgentAdapter), isSucceeded),
+	}
+
+	full := a.caps.Full()
+	if full {
+		bumped = append(bumped,
+			bumpStatsGroup(a.byRule, label(row.RuleName), isSucceeded),
+			bumpStatsGroup(a.byTemplate, label(row.TemplateID), isSucceeded),
+		)
+
+		for _, g := range bumped {
+			g.tokens.Input += row.InputTokens
+			g.tokens.Output += row.OutputTokens
+			g.tokens.Total += row.TotalTokens
+			g.tokens.CacheRead += row.CacheReadTokens
+			g.turnSum += row.TurnsCompleted
+		}
+		a.total.tokens.Input += row.InputTokens
+		a.total.tokens.Output += row.OutputTokens
+		a.total.tokens.Total += row.TotalTokens
+		a.total.tokens.CacheRead += row.CacheReadTokens
+		if isSucceeded {
+			a.total.succeededTurns += row.TurnsCompleted
+		}
+
+		if a.ratesConfigured {
+			cost := priceOf(row, a.rates)
+			if cost == nil {
+				a.total.costUnpricedRuns++
+			} else {
+				a.total.costUSD += *cost
+				a.total.pricedRuns++
+				for _, g := range bumped {
+					g.costUSD += *cost
+					g.pricedRuns++
+				}
+			}
+		}
+
+		if row.ReviewMetadata != nil {
+			foldSelfReview(*row.ReviewMetadata, &a.selfReview)
+		}
+	}
+
+	seconds, ok := duration(row)
+	if !ok {
+		a.total.durationExcludedRuns++
+		return nil
+	}
+	if seconds == 0 {
+		a.total.zeroDurationRuns++
+	}
+	for _, g := range bumped {
+		g.durationSamples = append(g.durationSamples, seconds)
+	}
+	if isSucceeded {
+		a.total.succeededSamples = append(a.total.succeededSamples, seconds)
+	}
+
+	return nil
+}
+
+// round1, round2, and round4 round v to the named number of decimal
+// places so the JSON report is byte-stable.
+func round1(v float64) float64 { return math.Round(v*10) / 10 }
+func round2(v float64) float64 { return math.Round(v*100) / 100 }
+func round4(v float64) float64 { return math.Round(v*10000) / 10000 }
+
+// durationStats computes p50, p95, and the mean over samples, in
+// seconds. All three are null when samples is empty. samples is sorted
+// in place by a copy so the caller's slice is unmodified.
+func durationStats(samples []float64) statsDuration {
+	d := statsDuration{Samples: len(samples)}
+	if len(samples) == 0 {
+		return d
+	}
+
+	sorted := slices.Clone(samples)
+	slices.Sort(sorted)
+
+	var sum float64
+	for _, s := range sorted {
+		sum += s
+	}
+
+	p50 := percentile(sorted, 50)
+	p95 := percentile(sorted, 95)
+	mean := round1(sum / float64(len(sorted)))
+	d.P50 = &p50
+	d.P95 = &p95
+	d.Mean = &mean
+	return d
+}
+
+// report computes every derived figure exactly once from a's folded
+// state and returns the complete statsReport. warnings are folded into
+// the envelope's Warnings field verbatim.
+func (a *statsAggregator) report(
+	generatedAt time.Time,
+	workflowPath, dbPath string,
+	since, until *time.Time,
+	warnings []string,
+) statsReport {
+	full := a.caps.Full()
+
+	rpt := statsReport{
+		GeneratedAt:  generatedAt.Format(time.RFC3339),
+		WorkflowPath: workflowPath,
+		DBPath:       dbPath,
+		SchemaTier:   a.tierLabel,
+		Warnings:     append([]string{}, warnings...),
+		Summary:      a.summary(full),
+		ByStatus:     a.groupSlice(a.byStatus, full),
+		ByAdapter:    a.groupSlice(a.byAdapter, full),
+		ByRule:       []statsGroup{},
+		ByTemplate:   []statsGroup{},
+	}
+	if since != nil {
+		s := since.UTC().Format(time.RFC3339)
+		rpt.Since = &s
+	}
+	if until != nil {
+		u := until.UTC().Format(time.RFC3339)
+		rpt.Until = &u
+	}
+	if full {
+		rpt.ByRule = a.groupSlice(a.byRule, full)
+		rpt.ByTemplate = a.groupSlice(a.byTemplate, full)
+		rpt.SelfReview = a.selfReviewReport()
+	}
+
+	return rpt
+}
+
+// summary computes the report-wide statsSummary.
+func (a *statsAggregator) summary(full bool) statsSummary {
+	s := statsSummary{
+		Runs:                 a.total.runs,
+		Succeeded:            a.total.succeeded,
+		Duration:             durationStats(a.total.succeededSamples),
+		ZeroDurationRuns:     a.total.zeroDurationRuns,
+		DurationExcludedRuns: a.total.durationExcludedRuns,
+		CostUnpricedRuns:     a.total.costUnpricedRuns,
+	}
+	if s.Runs > 0 {
+		s.SuccessRate = round4(float64(s.Succeeded) / float64(s.Runs))
+	}
+	if full && s.Succeeded > 0 {
+		mean := round2(float64(a.total.succeededTurns) / float64(s.Succeeded))
+		s.MeanTurnsSucceeded = &mean
+	}
+	if full {
+		tokens := a.total.tokens
+		s.Tokens = &tokens
+	}
+	if full && a.total.pricedRuns > 0 {
+		cost := round2(a.total.costUSD)
+		s.CostUSD = &cost
+		if s.Succeeded > 0 {
+			perRun := round2(cost / float64(s.Succeeded))
+			s.CostPerSucceededRunUSD = &perRun
+		}
+	}
+	return s
+}
+
+// groupSlice converts groups into a statsGroup slice, sorted by
+// descending runs with ties broken by ascending name under byte
+// comparison.
+func (a *statsAggregator) groupSlice(groups map[string]*statsGroupAccum, full bool) []statsGroup {
+	out := make([]statsGroup, 0, len(groups))
+	for _, g := range groups {
+		out = append(out, a.groupStat(g, full))
+	}
+	slices.SortFunc(out, func(x, y statsGroup) int {
+		if x.Runs != y.Runs {
+			return y.Runs - x.Runs
+		}
+		return strings.Compare(x.Name, y.Name)
+	})
+	return out
+}
+
+// groupStat computes the derived statsGroup figures for one accumulated
+// group.
+func (a *statsAggregator) groupStat(g *statsGroupAccum, full bool) statsGroup {
+	stat := statsGroup{
+		Name:      g.name,
+		Runs:      g.runs,
+		Succeeded: g.succeeded,
+		Duration:  durationStats(g.durationSamples),
+	}
+	if g.runs > 0 {
+		stat.SuccessRate = round4(float64(g.succeeded) / float64(g.runs))
+	}
+	if a.total.runs > 0 {
+		stat.Share = round4(float64(g.runs) / float64(a.total.runs))
+	}
+	if full {
+		mean := round2(float64(g.turnSum) / float64(g.runs))
+		stat.MeanTurns = &mean
+		tokens := g.tokens
+		stat.Tokens = &tokens
+		if g.pricedRuns > 0 {
+			cost := round2(g.costUSD)
+			stat.CostUSD = &cost
+			if g.succeeded > 0 {
+				perRun := round2(cost / float64(g.succeeded))
+				stat.CostPerSucceededRunUSD = &perRun
+			}
+		}
+	}
+	return stat
+}
+
+// selfReviewReport computes the derived statsSelfReview from a's folded
+// self-review state. by_final_verdict is sorted by ascending verdict.
+func (a *statsAggregator) selfReviewReport() *statsSelfReview {
+	sr := &statsSelfReview{
+		RunsWithMetadata: a.selfReview.runsWithMetadata,
+		ByFinalVerdict:   make([]statsVerdictCount, 0, len(a.selfReview.byVerdict)),
+		CapReachedRuns:   a.selfReview.capReachedRuns,
+		UnparsedRuns:     a.selfReview.unparsedRuns,
+	}
+	if a.selfReview.runsWithMetadata > 0 {
+		mean := round2(float64(a.selfReview.iterationSum) / float64(a.selfReview.runsWithMetadata))
+		sr.MeanIterations = &mean
+	}
+	for verdict, count := range a.selfReview.byVerdict {
+		sr.ByFinalVerdict = append(sr.ByFinalVerdict, statsVerdictCount{Verdict: verdict, Runs: count})
+	}
+	slices.SortFunc(sr.ByFinalVerdict, func(x, y statsVerdictCount) int {
+		return strings.Compare(x.Verdict, y.Verdict)
+	})
+	return sr
+}
+
+// degradedSchemaWarning names the figures caps cannot supply and states
+// the remedy. It names only the groups whose flag is false, because a
+// partly migrated database is the common case and a fixed sentence would
+// disclaim figures the database can in fact supply.
+func degradedSchemaWarning(caps persistence.RunHistoryCapabilities) string {
+	var missing []string
+	if !caps.HasTurnsCompleted {
+		missing = append(missing, "turns")
+	}
+	if !caps.HasReviewMetadata {
+		missing = append(missing, "self-review results")
+	}
+	if !caps.HasRuleRouting {
+		missing = append(missing, "dispatch-rule routing")
+	}
+	if !caps.HasTokens {
+		missing = append(missing, "tokens and cost")
+	}
+	return fmt.Sprintf(
+		"this database was written before sortie recorded %s, so the report leaves them out. "+
+			"Run sortie once with this workflow to add them.",
+		strings.Join(missing, ", "))
+}
+
+// formatShare renders a 0..1 fraction as a one-decimal percentage.
+func formatShare(v float64) string {
+	return fmt.Sprintf("%.1f%%", v*100)
+}
+
+// formatFloatDash renders a nullable float64 with format, or "-" when v
+// is nil.
+func formatFloatDash(v *float64, format string) string {
+	if v == nil {
+		return "-"
+	}
+	return fmt.Sprintf(format, *v)
+}
+
+// formatCostDash renders a nullable USD figure with [server.FormatCost],
+// or "-" when v is nil.
+func formatCostDash(v *float64) string {
+	if v == nil {
+		return "-"
+	}
+	return server.FormatCost(*v)
+}
+
+// formatSecondsDash renders a nullable seconds figure with
+// [server.FormatDuration], or "-" when v is nil.
+func formatSecondsDash(v *float64) string {
+	if v == nil {
+		return "-"
+	}
+	return server.FormatDuration(time.Duration(*v * float64(time.Second)))
+}
+
+// formatStatsDuration renders a statsDuration's p50, p95, mean, and
+// sample count on one line.
+func formatStatsDuration(d statsDuration) string {
+	return fmt.Sprintf("p50 %s   p95 %s   mean %s   samples %d",
+		formatSecondsDash(d.P50), formatSecondsDash(d.P95), formatSecondsDash(d.Mean), d.Samples)
+}
+
+// formatStatsTokens renders a statsTokens's four sums on one line, or
+// "-" when t is nil.
+func formatStatsTokens(t *statsTokens) string {
+	if t == nil {
+		return "-"
+	}
+	return fmt.Sprintf("input %s   output %s   total %s   cache read %s",
+		server.FormatInt(t.Input), server.FormatInt(t.Output), server.FormatInt(t.Total), server.FormatInt(t.CacheRead))
+}
+
+// formatTokensTotalDash renders only t's Total field, or "-" when t is
+// nil, for the "total tokens" group table column.
+func formatTokensTotalDash(t *statsTokens) string {
+	if t == nil {
+		return "-"
+	}
+	return server.FormatInt(t.Total)
+}
+
+// renderStatsGroupTable prints one section of the text report: the
+// section title, a header row, and one row per group. isOutcomeTable
+// selects the "share" column for the outcome breakdown; every other
+// breakdown carries "succeeded" and "success rate" instead. full selects
+// the turns, total tokens, and cost columns.
+//
+// Cells are tab-separated and flushed through a tabwriter so every column
+// lines up at the width of its widest cell. A row is never written
+// directly to w.
+func renderStatsGroupTable(w io.Writer, title, dimLabel string, groups []statsGroup, full, isOutcomeTable bool) {
+	fmt.Fprintln(w, title) //nolint:errcheck // stdout write failure is unrecoverable
+
+	header := []string{dimLabel, "runs"}
+	if isOutcomeTable {
+		header = append(header, "share")
+	} else {
+		header = append(header, "succeeded", "success rate")
+	}
+	header = append(header, "p50", "p95", "mean")
+	if full {
+		header = append(header, "turns", "total tokens", "cost")
+	}
+
+	table := newStatsTable(w)
+	writeStatsRow(table, upperAll(header))
+
+	for _, g := range groups {
+		row := []string{g.Name, strconv.Itoa(g.Runs)}
+		if isOutcomeTable {
+			row = append(row, formatShare(g.Share))
+		} else {
+			row = append(row, strconv.Itoa(g.Succeeded), formatShare(g.SuccessRate))
+		}
+		row = append(row,
+			formatSecondsDash(g.Duration.P50), formatSecondsDash(g.Duration.P95), formatSecondsDash(g.Duration.Mean))
+		if full {
+			row = append(row,
+				formatFloatDash(g.MeanTurns, "%.1f"),
+				formatTokensTotalDash(g.Tokens),
+				formatCostDash(g.CostUSD))
+		}
+		writeStatsRow(table, row)
+	}
+	table.Flush() //nolint:errcheck,gosec // stdout write failure is unrecoverable
+}
+
+// newStatsTable returns a tabwriter that indents every row by two spaces
+// and separates columns by two spaces, so a table reads as a block
+// belonging to the section title above it.
+func newStatsTable(w io.Writer) *tabwriter.Writer {
+	return tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+}
+
+// writeStatsRow writes one tab-separated, two-space-indented row to a
+// tabwriter.
+func writeStatsRow(table *tabwriter.Writer, cells []string) {
+	fmt.Fprintf(table, "  %s\n", strings.Join(cells, "\t")) //nolint:errcheck // stdout write failure is unrecoverable
+}
+
+// upperAll returns cells with every element upper-cased, for a table
+// header row.
+func upperAll(cells []string) []string {
+	upper := make([]string, len(cells))
+	for i, c := range cells {
+		upper[i] = strings.ToUpper(c)
+	}
+	return upper
+}
+
+// renderStatsSelfReview prints the "self review" section.
+func renderStatsSelfReview(w io.Writer, sr *statsSelfReview) {
+	fmt.Fprintln(w, "self review") //nolint:errcheck // stdout write failure is unrecoverable
+	if sr == nil {
+		return
+	}
+
+	parts := []string{fmt.Sprintf("runs reviewed %d", sr.RunsWithMetadata)}
+	for _, vc := range sr.ByFinalVerdict {
+		parts = append(parts, fmt.Sprintf("%s %d", vc.Verdict, vc.Runs))
+	}
+	parts = append(parts,
+		fmt.Sprintf("hit iteration cap %d", sr.CapReachedRuns),
+		fmt.Sprintf("mean iterations %s", formatFloatDash(sr.MeanIterations, "%.2f")))
+	fmt.Fprintf(w, "  %s\n", strings.Join(parts, "   ")) //nolint:errcheck // stdout write failure is unrecoverable
+}
+
+// statsFootnotes returns one line per non-zero disclosure counter in s,
+// naming the counter's value and its cause.
+func statsFootnotes(s statsSummary) []string {
+	var lines []string
+	if s.ZeroDurationRuns > 0 {
+		lines = append(lines, fmt.Sprintf(
+			"note: %d of these runs took no measurable time. A run that a CI result closed out carries the same start and finish time.",
+			s.ZeroDurationRuns))
+	}
+	if s.DurationExcludedRuns > 0 {
+		lines = append(lines, fmt.Sprintf(
+			"note: the duration figures skip %d of these runs, whose recorded start and finish times were unusable.",
+			s.DurationExcludedRuns))
+	}
+	if s.CostUnpricedRuns > 0 {
+		lines = append(lines, fmt.Sprintf(
+			"note: the cost figures skip %d of these runs, because token_rates has no price for the coding agent behind them.",
+			s.CostUnpricedRuns))
+	}
+	return lines
+}
+
+// formatStatsRange describes the reported range in prose. An absent bound
+// is named as such rather than shown as a sentinel, so a first-time reader
+// is not left to interpret one.
+func formatStatsRange(since, until *string) string {
+	switch {
+	case since == nil && until == nil:
+		return "every run on record"
+	case until == nil:
+		return *since + " onward"
+	case since == nil:
+		return "the start of the record until " + *until
+	default:
+		return *since + " until " + *until
+	}
+}
+
+// emptyRangeMessage states that nothing matched, distinguishing an empty
+// database from a range that happens to hold no run.
+func emptyRangeMessage(since, until *string) string {
+	if since == nil && until == nil {
+		return "No runs on record yet. sortie adds one each time an agent session finishes."
+	}
+	return "No runs finished in this range."
+}
+
+// renderStatsText writes report to stdout in text form and writes
+// report.Warnings, one per line, to stderr.
+func renderStatsText(stdout, stderr io.Writer, report statsReport) {
+	fmt.Fprintf(stdout, "workflow:  %s\n", report.WorkflowPath)                          //nolint:errcheck // stdout write failure is unrecoverable
+	fmt.Fprintf(stdout, "database:  %s\n", report.DBPath)                                //nolint:errcheck // stdout write failure is unrecoverable
+	fmt.Fprintf(stdout, "covering:  %s\n", formatStatsRange(report.Since, report.Until)) //nolint:errcheck // stdout write failure is unrecoverable
+	fmt.Fprintf(stdout, "generated: %s\n", report.GeneratedAt)                           //nolint:errcheck // stdout write failure is unrecoverable
+	fmt.Fprintln(stdout)                                                                 //nolint:errcheck // stdout write failure is unrecoverable
+
+	if report.Summary.Runs == 0 {
+		fmt.Fprintln(stdout, emptyRangeMessage(report.Since, report.Until)) //nolint:errcheck // stdout write failure is unrecoverable
+		writeStatsWarnings(stderr, report.Warnings)
+		return
+	}
+
+	full := report.SchemaTier == "full"
+
+	fmt.Fprintf(stdout, "runs %d   succeeded %d (%s)\n", //nolint:errcheck // stdout write failure is unrecoverable
+		report.Summary.Runs, report.Summary.Succeeded, formatShare(report.Summary.SuccessRate))
+	fmt.Fprintf(stdout, "duration (succeeded)    %s\n", formatStatsDuration(report.Summary.Duration)) //nolint:errcheck // stdout write failure is unrecoverable
+	if full {
+		fmt.Fprintf(stdout, "turns (succeeded)       %s\n", //nolint:errcheck // stdout write failure is unrecoverable
+			formatFloatDash(report.Summary.MeanTurnsSucceeded, "%.1f"))
+		fmt.Fprintf(stdout, "tokens (all runs)       %s\n", formatStatsTokens(report.Summary.Tokens)) //nolint:errcheck // stdout write failure is unrecoverable
+		switch {
+		case report.Summary.CostUSD != nil:
+			fmt.Fprintf(stdout, "cost (all runs)         %s   per succeeded run %s\n", //nolint:errcheck // stdout write failure is unrecoverable
+				server.FormatCost(*report.Summary.CostUSD), formatCostDash(report.Summary.CostPerSucceededRunUSD))
+		case report.Summary.CostUnpricedRuns == 0:
+			fmt.Fprintln(stdout, //nolint:errcheck // stdout write failure is unrecoverable
+				"cost                    not estimated; set token_rates in the workflow to price these runs")
+		default:
+			fmt.Fprintln(stdout, "cost (all runs)         -   per succeeded run -") //nolint:errcheck // stdout write failure is unrecoverable
+		}
+	}
+	fmt.Fprintln(stdout) //nolint:errcheck // stdout write failure is unrecoverable
+
+	renderStatsGroupTable(stdout, "by outcome", "outcome", report.ByStatus, full, true)
+	fmt.Fprintln(stdout) //nolint:errcheck // stdout write failure is unrecoverable
+	renderStatsGroupTable(stdout, "by coding agent", "agent", report.ByAdapter, full, false)
+	if full {
+		fmt.Fprintln(stdout) //nolint:errcheck // stdout write failure is unrecoverable
+		renderStatsGroupTable(stdout, "by dispatch rule", "rule", report.ByRule, full, false)
+		fmt.Fprintln(stdout) //nolint:errcheck // stdout write failure is unrecoverable
+		renderStatsGroupTable(stdout, "by prompt template", "template", report.ByTemplate, full, false)
+		fmt.Fprintln(stdout) //nolint:errcheck // stdout write failure is unrecoverable
+		renderStatsSelfReview(stdout, report.SelfReview)
+	}
+
+	if footnotes := statsFootnotes(report.Summary); len(footnotes) > 0 {
+		fmt.Fprintln(stdout) //nolint:errcheck // stdout write failure is unrecoverable
+		for _, note := range footnotes {
+			fmt.Fprintln(stdout, note) //nolint:errcheck // stdout write failure is unrecoverable
+		}
+	}
+
+	writeStatsWarnings(stderr, report.Warnings)
+}
+
+// writeStatsWarnings writes warnings to stderr, one line each, under the
+// same "warning: " prefix emitDiags uses, so a warning is never mistaken
+// for part of the report. The prefix belongs to the rendering rather than
+// to the message, keeping the JSON envelope's warnings field clean.
+func writeStatsWarnings(stderr io.Writer, warnings []string) {
+	for _, w := range warnings {
+		fmt.Fprintf(stderr, "warning: %s\n", w) //nolint:errcheck // stderr write failure is unrecoverable
+	}
+}
+
+// runStats implements the "sortie stats" subcommand: it opens the
+// database read-only, aggregates run_history over the requested range,
+// and renders the result to stdout in text or JSON form.
+func runStats(ctx context.Context, args []string, stdout io.Writer, stderr io.Writer) int {
+	if containsHelpFlag(args) {
+		printStatsHelp(stdout)
+		return 0
+	}
+
+	fs := flag.NewFlagSet("sortie stats", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	format := fs.String("format", "text", `Output format: "text" or "json"`)
+	sinceRaw := fs.String("since", "", "Count only runs that finished at or after this point")
+	untilRaw := fs.String("until", "", "Count only runs that finished before this point")
+
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			printStatsHelp(stdout)
+			return 0
+		}
+		fmt.Fprintf(stderr, "sortie stats: %s\n", err) //nolint:errcheck // stderr write failure is unrecoverable
+		return 1
+	}
+
+	if *format != "text" && *format != "json" {
+		fmt.Fprintf(stderr, "sortie stats: invalid --format value %q: must be \"text\" or \"json\"\n", *format) //nolint:errcheck // stderr write failure is unrecoverable
+		return 1
+	}
+
+	since, err := parseRangeBound(*sinceRaw)
+	if err != nil {
+		fmt.Fprintf(stderr, "sortie stats: --since: %s\n", err) //nolint:errcheck // stderr write failure is unrecoverable
+		return 1
+	}
+	until, err := parseRangeBound(*untilRaw)
+	if err != nil {
+		fmt.Fprintf(stderr, "sortie stats: --until: %s\n", err) //nolint:errcheck // stderr write failure is unrecoverable
+		return 1
+	}
+	if since != nil && until != nil && !since.Before(*until) {
+		fmt.Fprintln(stderr, "sortie stats: --since must be strictly before --until") //nolint:errcheck // stderr write failure is unrecoverable
+		return 1
+	}
+
+	path, err := resolveWorkflowPath(fs.Args())
+	if err != nil {
+		fmt.Fprintf(stderr, "sortie stats: %s\n", err) //nolint:errcheck // stderr write failure is unrecoverable
+		return 1
+	}
+
+	wf, err := workflow.Load(path)
+	if err != nil {
+		emitDiags(stdout, stderr, "text", mapManagerError(err), nil)
+		return 1
+	}
+	cfg, err := config.NewServiceConfig(wf.Config)
+	if err != nil {
+		emitDiags(stdout, stderr, "text", mapManagerError(err), nil)
+		return 1
+	}
+
+	dbPath := resolveDBPath(cfg.DBPath, filepath.Dir(path))
+	store, err := persistence.OpenReadOnly(ctx, dbPath)
+	if err != nil {
+		fmt.Fprintf(stderr, "sortie stats: open database %s: %s\n", dbPath, err) //nolint:errcheck // stderr write failure is unrecoverable
+		return 1
+	}
+	defer store.Close() //nolint:errcheck,gosec // read-only handle; close error is non-actionable
+
+	caps, err := store.RunHistoryCapabilities(ctx)
+	if err != nil {
+		fmt.Fprintf(stderr, "sortie stats: %s\n", err) //nolint:errcheck // stderr write failure is unrecoverable
+		return 1
+	}
+
+	rates, rateWarnings := server.ParseTokenRates(cfg.Extensions)
+
+	agg := newStatsAggregator(caps, rates)
+	if err := store.ScanRunHistoryRange(ctx, caps, since, until, agg.add); err != nil {
+		fmt.Fprintf(stderr, "sortie stats: %s\n", err) //nolint:errcheck // stderr write failure is unrecoverable
+		return 1
+	}
+
+	warnings := rateWarnings
+	if !caps.Full() {
+		warnings = append([]string{degradedSchemaWarning(caps)}, warnings...)
+	}
+
+	report := agg.report(statsNow().UTC(), path, dbPath, since, until, warnings)
+
+	if *format == "json" {
+		if err := writeJSON(stdout, report); err != nil {
+			fmt.Fprintf(stderr, "sortie stats: %s\n", err) //nolint:errcheck // stderr write failure is unrecoverable
+			return 1
+		}
+		return 0
+	}
+
+	renderStatsText(stdout, stderr, report)
+	return 0
+}

--- a/cmd/sortie/stats_test.go
+++ b/cmd/sortie/stats_test.go
@@ -163,6 +163,22 @@ func createLegacyStatsDB(t *testing.T, dbPath string) {
 	}
 }
 
+// newStatsWorkspace creates a temp directory holding a minimal
+// WORKFLOW.md and a database built by build, and returns the workflow
+// path.
+//
+// Every caller gets its own directory, so parallel subtests never share
+// one database file. Two read-only opens of the same file race to recover
+// its write-ahead log, and the loser gets SQLITE_BUSY; on Linux the race
+// is almost always won in time, on Windows it is not.
+func newStatsWorkspace(t *testing.T, build func(t *testing.T, dbPath string)) string {
+	t.Helper()
+	dir := t.TempDir()
+	wfPath := writeCustomWorkflowFile(t, dir, statsWorkflow(""))
+	build(t, filepath.Join(dir, ".sortie.db"))
+	return wfPath
+}
+
 // pinStatsNow overrides the package-level statsNow for the life of the
 // calling test, following the serverShutdownTimeout precedent. A test
 // that calls this must not also call t.Parallel().
@@ -580,17 +596,20 @@ func TestRunStatsJSON(t *testing.T) {
 func TestRunStatsEmptyRange(t *testing.T) {
 	t.Parallel()
 
-	dir := t.TempDir()
-	wfPath := writeCustomWorkflowFile(t, dir, statsWorkflow(""))
-	dbPath := filepath.Join(dir, ".sortie.db")
-	createStatsDB(t, dbPath, persistence.RunHistory{
-		IssueID: "ISS-1", Identifier: "PROJ-1", Attempt: 1, AgentAdapter: "mock", Workspace: "/tmp/ws",
-		StartedAt: "2026-01-01T00:00:00Z", CompletedAt: "2026-01-01T00:10:00Z", Status: "succeeded",
-	})
+	newWorkspace := func(t *testing.T) string {
+		t.Helper()
+		return newStatsWorkspace(t, func(t *testing.T, dbPath string) {
+			createStatsDB(t, dbPath, persistence.RunHistory{
+				IssueID: "ISS-1", Identifier: "PROJ-1", Attempt: 1, AgentAdapter: "mock", Workspace: "/tmp/ws",
+				StartedAt: "2026-01-01T00:00:00Z", CompletedAt: "2026-01-01T00:10:00Z", Status: "succeeded",
+			})
+		})
+	}
 
 	t.Run("text", func(t *testing.T) {
 		t.Parallel()
 
+		wfPath := newWorkspace(t)
 		var stdout, stderr bytes.Buffer
 		code := run(context.Background(), []string{"stats", "--since", "2099-01-01T00:00:00Z", wfPath}, &stdout, &stderr)
 		if code != 0 {
@@ -614,6 +633,7 @@ func TestRunStatsEmptyRange(t *testing.T) {
 	t.Run("json", func(t *testing.T) {
 		t.Parallel()
 
+		wfPath := newWorkspace(t)
 		var stdout, stderr bytes.Buffer
 		code := run(context.Background(), []string{"stats", "--format", "json", "--since", "2099-01-01T00:00:00Z", wfPath}, &stdout, &stderr)
 		if code != 0 {
@@ -764,14 +784,10 @@ func TestRunStatsAgainstLiveWriter(t *testing.T) {
 func TestRunStatsDegradedSchema(t *testing.T) {
 	t.Parallel()
 
-	dir := t.TempDir()
-	wfPath := writeCustomWorkflowFile(t, dir, statsWorkflow(""))
-	dbPath := filepath.Join(dir, ".sortie.db")
-	createLegacyStatsDB(t, dbPath)
-
 	t.Run("text", func(t *testing.T) {
 		t.Parallel()
 
+		wfPath := newStatsWorkspace(t, createLegacyStatsDB)
 		var stdout, stderr bytes.Buffer
 		code := run(context.Background(), []string{"stats", wfPath}, &stdout, &stderr)
 		if code != 0 {
@@ -791,6 +807,7 @@ func TestRunStatsDegradedSchema(t *testing.T) {
 	t.Run("json", func(t *testing.T) {
 		t.Parallel()
 
+		wfPath := newStatsWorkspace(t, createLegacyStatsDB)
 		var stdout, stderr bytes.Buffer
 		code := run(context.Background(), []string{"stats", "--format", "json", wfPath}, &stdout, &stderr)
 		if code != 0 {

--- a/cmd/sortie/stats_test.go
+++ b/cmd/sortie/stats_test.go
@@ -1,0 +1,979 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"maps"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sortie-ai/sortie/internal/domain"
+	"github.com/sortie-ai/sortie/internal/persistence"
+	"github.com/sortie-ai/sortie/internal/server"
+)
+
+// fullCaps reports every optional run_history column group present, so
+// the "full" projection and every summary and group figure are computed.
+var fullCaps = persistence.RunHistoryCapabilities{
+	HasTurnsCompleted: true,
+	HasReviewMetadata: true,
+	HasRuleRouting:    true,
+	HasTokens:         true,
+}
+
+// fixedNow is a deterministic generatedAt value for aggregator-level
+// tests that call statsAggregator.report directly.
+var fixedNow = time.Date(2026, 8, 7, 9, 15, 0, 0, time.UTC)
+
+func floatPtr(v float64) *float64 { return &v }
+func strPtr(v string) *string     { return &v }
+
+// rangeFloats returns the ascending integers from lo to hi inclusive, as
+// float64, for the worked nearest-rank percentile examples.
+func rangeFloats(lo, hi int) []float64 {
+	out := make([]float64, 0, hi-lo+1)
+	for i := lo; i <= hi; i++ {
+		out = append(out, float64(i))
+	}
+	return out
+}
+
+// addRows folds each row into agg via statsAggregator.add, failing the
+// test immediately on an unexpected error (add always returns nil).
+func addRows(t *testing.T, agg *statsAggregator, rows ...persistence.RunStatsRow) {
+	t.Helper()
+	for _, r := range rows {
+		if err := agg.add(r); err != nil {
+			t.Fatalf("statsAggregator.add(%+v): %v", r, err)
+		}
+	}
+}
+
+// findGroup returns the statsGroup named name in groups, failing the
+// test when no such group exists.
+func findGroup(t *testing.T, groups []statsGroup, name string) statsGroup {
+	t.Helper()
+	for _, g := range groups {
+		if g.Name == name {
+			return g
+		}
+	}
+	t.Fatalf("group %q not found in %+v", name, groups)
+	return statsGroup{}
+}
+
+// reviewMetaPtr marshals m and returns a pointer to the resulting JSON,
+// matching the shape ScanRunHistoryRange returns for a non-NULL
+// review_metadata column.
+func reviewMetaPtr(t *testing.T, m domain.ReviewMetadata) *string {
+	t.Helper()
+	b, err := json.Marshal(m)
+	if err != nil {
+		t.Fatalf("json.Marshal(%+v): %v", m, err)
+	}
+	s := string(b)
+	return &s
+}
+
+// statsWorkflow returns a minimal WORKFLOW.md whose front matter is
+// extended with extra, for stats tests that need a specific top-level
+// key such as db_path without a full tracker/agent configuration.
+func statsWorkflow(extra string) []byte {
+	return fmt.Appendf(nil, `---
+tracker:
+  kind: file
+  active_states:
+    - To Do
+  terminal_states:
+    - Done
+agent:
+  kind: mock
+%s---
+Do {{ .issue.title }}.
+`, extra)
+}
+
+// createStatsDB creates a fully migrated SQLite database at dbPath and
+// appends each of runs, then closes the store so a later read-only open
+// sees committed data.
+func createStatsDB(t *testing.T, dbPath string, runs ...persistence.RunHistory) {
+	t.Helper()
+	ctx := context.Background()
+	store, err := persistence.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("persistence.Open(%q): %v", dbPath, err)
+	}
+	if err := store.Migrate(ctx); err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+	for _, r := range runs {
+		if _, err := store.AppendRunHistory(ctx, r); err != nil {
+			t.Fatalf("AppendRunHistory: %v", err)
+		}
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+}
+
+// createLegacyStatsDB creates dbPath with only the migration-001
+// run_history columns (no schema_migrations tracking) and inserts one
+// row, matching a database written by a pre-migration-010 binary. The
+// modernc.org/sqlite driver is already registered process-wide via
+// internal/persistence's import.
+func createLegacyStatsDB(t *testing.T, dbPath string) {
+	t.Helper()
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("sql.Open(%q): %v", dbPath, err)
+	}
+	t.Cleanup(func() {
+		if err := db.Close(); err != nil {
+			t.Errorf("db.Close: %v", err)
+		}
+	})
+
+	ctx := context.Background()
+	if _, err := db.ExecContext(ctx, `CREATE TABLE run_history (
+		id            INTEGER PRIMARY KEY AUTOINCREMENT,
+		issue_id      TEXT    NOT NULL,
+		identifier    TEXT    NOT NULL,
+		attempt       INTEGER NOT NULL,
+		agent_adapter TEXT    NOT NULL,
+		workspace     TEXT    NOT NULL,
+		started_at    TEXT    NOT NULL,
+		completed_at  TEXT    NOT NULL,
+		status        TEXT    NOT NULL,
+		error         TEXT
+	)`); err != nil {
+		t.Fatalf("create migration-001 run_history table: %v", err)
+	}
+	if _, err := db.ExecContext(ctx,
+		`INSERT INTO run_history (issue_id, identifier, attempt, agent_adapter, workspace, started_at, completed_at, status)
+		 VALUES ('ISS-1', 'PROJ-1', 1, 'mock', '/tmp/ws', '2026-01-01T00:00:00Z', '2026-01-01T00:10:00Z', 'succeeded')`,
+	); err != nil {
+		t.Fatalf("insert legacy row: %v", err)
+	}
+}
+
+// pinStatsNow overrides the package-level statsNow for the life of the
+// calling test, following the serverShutdownTimeout precedent. A test
+// that calls this must not also call t.Parallel().
+func pinStatsNow(t *testing.T, now time.Time) {
+	t.Helper()
+	orig := statsNow
+	statsNow = func() time.Time { return now }
+	t.Cleanup(func() { statsNow = orig })
+}
+
+// --- percentile/mean worked examples and summary normalization ---
+
+func TestStatsSummaryFormulas(t *testing.T) {
+	t.Parallel()
+
+	t.Run("percentile and mean over the worked sample sets", func(t *testing.T) {
+		t.Parallel()
+
+		tests := []struct {
+			name     string
+			samples  []float64
+			wantP50  float64
+			wantP95  float64
+			wantMean float64
+		}{
+			{name: "single sample", samples: []float64{7}, wantP50: 7, wantP95: 7, wantMean: 7},
+			{name: "four samples", samples: []float64{10, 20, 30, 40}, wantP50: 20, wantP95: 40, wantMean: 25},
+			{name: "twenty samples", samples: rangeFloats(1, 20), wantP50: 10, wantP95: 19, wantMean: 10.5},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+
+				got := durationStats(tt.samples)
+
+				if got.Samples != len(tt.samples) {
+					t.Fatalf("durationStats(%v).Samples = %d, want %d", tt.samples, got.Samples, len(tt.samples))
+				}
+				if got.P50 == nil || *got.P50 != tt.wantP50 {
+					t.Errorf("durationStats(%v).P50 = %v, want %v", tt.samples, got.P50, tt.wantP50)
+				}
+				if got.P95 == nil || *got.P95 != tt.wantP95 {
+					t.Errorf("durationStats(%v).P95 = %v, want %v", tt.samples, got.P95, tt.wantP95)
+				}
+				if got.Mean == nil || *got.Mean != tt.wantMean {
+					t.Errorf("durationStats(%v).Mean = %v, want %v", tt.samples, got.Mean, tt.wantMean)
+				}
+			})
+		}
+	})
+
+	t.Run("duration and turns normalize on succeeded rows; cost per succeeded run divides all spend", func(t *testing.T) {
+		t.Parallel()
+
+		rates := server.TokenRates{"mock": server.TokenRateConfig{InputPerMtok: floatPtr(10)}}
+		agg := newStatsAggregator(fullCaps, rates)
+
+		addRows(t, agg,
+			persistence.RunStatsRow{
+				Status: "succeeded", AgentAdapter: "mock", TurnsCompleted: 4,
+				StartedAt: "2026-01-01T00:00:00Z", CompletedAt: "2026-01-01T00:10:00Z",
+				InputTokens: 1_000_000,
+			},
+			persistence.RunStatsRow{
+				Status: "failed", AgentAdapter: "mock", TurnsCompleted: 8,
+				StartedAt: "2026-01-01T00:00:00Z", CompletedAt: "2026-01-01T01:00:00Z",
+				InputTokens: 500_000,
+			},
+		)
+
+		report := agg.report(fixedNow, "/wf", "/db", nil, nil, nil)
+
+		if report.Summary.Duration.Samples != 1 {
+			t.Fatalf("Summary.Duration.Samples = %d, want 1 (succeeded rows only)", report.Summary.Duration.Samples)
+		}
+		if got, want := *report.Summary.Duration.P50, 600.0; got != want {
+			t.Errorf("Summary.Duration.P50 = %v, want %v", got, want)
+		}
+		if report.Summary.MeanTurnsSucceeded == nil || *report.Summary.MeanTurnsSucceeded != 4 {
+			t.Errorf("Summary.MeanTurnsSucceeded = %v, want 4 (succeeded rows only)", report.Summary.MeanTurnsSucceeded)
+		}
+		if report.Summary.CostUSD == nil || *report.Summary.CostUSD != 15 {
+			t.Fatalf("Summary.CostUSD = %v, want 15 (all rows: $10 + $5)", report.Summary.CostUSD)
+		}
+		if report.Summary.CostPerSucceededRunUSD == nil || *report.Summary.CostPerSucceededRunUSD != 15 {
+			t.Errorf("Summary.CostPerSucceededRunUSD = %v, want 15 (cost_usd / succeeded, not succeeded-only spend / succeeded)",
+				report.Summary.CostPerSucceededRunUSD)
+		}
+	})
+}
+
+// --- ci_failed row disclosure ---
+
+func TestStatsGroupDisclosure(t *testing.T) {
+	t.Parallel()
+
+	rates := server.TokenRates{"mock": server.TokenRateConfig{InputPerMtok: floatPtr(10)}}
+	agg := newStatsAggregator(fullCaps, rates)
+
+	addRows(t, agg, persistence.RunStatsRow{
+		Status:      "ci_failed",
+		StartedAt:   "2026-01-01T00:00:00Z",
+		CompletedAt: "2026-01-01T00:00:00Z",
+	})
+
+	report := agg.report(fixedNow, "/wf", "/db", nil, nil, nil)
+
+	adapterGroup := findGroup(t, report.ByAdapter, "<none>")
+	if adapterGroup.Duration.Samples != 1 {
+		t.Errorf("<none> adapter group Duration.Samples = %d, want 1", adapterGroup.Duration.Samples)
+	}
+	if adapterGroup.Duration.P50 == nil || *adapterGroup.Duration.P50 != 0 {
+		t.Errorf("<none> adapter group Duration.P50 = %v, want 0 (zero-duration sample)", adapterGroup.Duration.P50)
+	}
+	if adapterGroup.Tokens == nil || adapterGroup.Tokens.Total != 0 {
+		t.Errorf("<none> adapter group Tokens = %v, want Total 0", adapterGroup.Tokens)
+	}
+	if adapterGroup.CostUSD != nil {
+		t.Errorf("<none> adapter group CostUSD = %v, want nil (no rate entry for an empty agent_adapter)", *adapterGroup.CostUSD)
+	}
+	if got := formatCostDash(adapterGroup.CostUSD); got != "-" {
+		t.Errorf("formatCostDash(nil) = %q, want %q", got, "-")
+	}
+
+	ruleGroup := findGroup(t, report.ByRule, "<none>")
+	if ruleGroup.Runs != 1 {
+		t.Errorf("<none> rule group Runs = %d, want 1", ruleGroup.Runs)
+	}
+	templateGroup := findGroup(t, report.ByTemplate, "<none>")
+	if templateGroup.Runs != 1 {
+		t.Errorf("<none> template group Runs = %d, want 1", templateGroup.Runs)
+	}
+
+	if report.Summary.ZeroDurationRuns != 1 {
+		t.Errorf("Summary.ZeroDurationRuns = %d, want 1", report.Summary.ZeroDurationRuns)
+	}
+}
+
+// --- cost derivation across three rate configurations ---
+
+func TestStatsCostDerivation(t *testing.T) {
+	t.Parallel()
+
+	makeRow := func(adapter string, input int64) persistence.RunStatsRow {
+		return persistence.RunStatsRow{
+			Status: "succeeded", AgentAdapter: adapter,
+			StartedAt: "2026-01-01T00:00:00Z", CompletedAt: "2026-01-01T00:10:00Z",
+			InputTokens: input,
+		}
+	}
+
+	t.Run("every adapter priced", func(t *testing.T) {
+		t.Parallel()
+
+		rates := server.TokenRates{
+			"claude-code": server.TokenRateConfig{InputPerMtok: floatPtr(10)},
+			"codex":       server.TokenRateConfig{InputPerMtok: floatPtr(20)},
+		}
+		agg := newStatsAggregator(fullCaps, rates)
+		addRows(t, agg, makeRow("claude-code", 1_000_000), makeRow("codex", 1_000_000))
+
+		report := agg.report(fixedNow, "/wf", "/db", nil, nil, nil)
+
+		if report.Summary.CostUnpricedRuns != 0 {
+			t.Errorf("Summary.CostUnpricedRuns = %d, want 0", report.Summary.CostUnpricedRuns)
+		}
+		if report.Summary.CostUSD == nil || *report.Summary.CostUSD != 30 {
+			t.Fatalf("Summary.CostUSD = %v, want 30", report.Summary.CostUSD)
+		}
+		if footnotes := statsFootnotes(report.Summary); len(footnotes) != 0 {
+			t.Errorf("statsFootnotes = %v, want none", footnotes)
+		}
+	})
+
+	t.Run("one adapter priced, one not", func(t *testing.T) {
+		t.Parallel()
+
+		rates := server.TokenRates{
+			"claude-code": server.TokenRateConfig{InputPerMtok: floatPtr(10)},
+		}
+		agg := newStatsAggregator(fullCaps, rates)
+		addRows(t, agg, makeRow("claude-code", 1_000_000), makeRow("codex", 1_000_000))
+
+		report := agg.report(fixedNow, "/wf", "/db", nil, nil, nil)
+
+		if report.Summary.CostUnpricedRuns != 1 {
+			t.Errorf("Summary.CostUnpricedRuns = %d, want 1", report.Summary.CostUnpricedRuns)
+		}
+		if report.Summary.CostUSD == nil || *report.Summary.CostUSD != 10 {
+			t.Fatalf("Summary.CostUSD = %v, want 10 (priced row only)", report.Summary.CostUSD)
+		}
+		footnotes := statsFootnotes(report.Summary)
+		found := slices.ContainsFunc(footnotes, func(f string) bool {
+			return strings.Contains(f, "the cost figures skip 1 of these runs")
+		})
+		if !found {
+			t.Errorf("statsFootnotes = %v, want an unpriced-run footnote", footnotes)
+		}
+	})
+
+	t.Run("no token_rates configured at all", func(t *testing.T) {
+		t.Parallel()
+
+		agg := newStatsAggregator(fullCaps, nil)
+		addRows(t, agg, makeRow("claude-code", 1_000_000), makeRow("codex", 1_000_000))
+
+		report := agg.report(fixedNow, "/wf", "/db", nil, nil, nil)
+
+		if report.Summary.CostUSD != nil {
+			t.Errorf("Summary.CostUSD = %v, want nil", *report.Summary.CostUSD)
+		}
+		if report.Summary.CostPerSucceededRunUSD != nil {
+			t.Errorf("Summary.CostPerSucceededRunUSD = %v, want nil", *report.Summary.CostPerSucceededRunUSD)
+		}
+		if report.Summary.CostUnpricedRuns != 0 {
+			t.Errorf("Summary.CostUnpricedRuns = %d, want 0 even though the range holds rows", report.Summary.CostUnpricedRuns)
+		}
+		if footnotes := statsFootnotes(report.Summary); len(footnotes) != 0 {
+			t.Errorf("statsFootnotes = %v, want none (the cost column is already dropped)", footnotes)
+		}
+
+		var stdout, stderr bytes.Buffer
+		renderStatsText(&stdout, &stderr, report)
+		out := stdout.String()
+		if !strings.Contains(out, "not estimated; set token_rates in the workflow") {
+			t.Errorf("renderStatsText stdout = %q, want the not-estimated line", out)
+		}
+		if strings.Contains(out, "the cost figures skip") {
+			t.Errorf("renderStatsText stdout = %q, want no unpriced disclosure", out)
+		}
+	})
+}
+
+// --- stored total_tokens is reported unchanged ---
+
+func TestStatsTokenReporting(t *testing.T) {
+	t.Parallel()
+
+	agg := newStatsAggregator(fullCaps, nil)
+	addRows(t, agg, persistence.RunStatsRow{
+		Status: "succeeded", AgentAdapter: "mock",
+		StartedAt: "2026-01-01T00:00:00Z", CompletedAt: "2026-01-01T00:10:00Z",
+		InputTokens: 100, OutputTokens: 50, CacheReadTokens: 10,
+		TotalTokens: 999, // deliberately inconsistent with input+output+cache_read = 160
+	})
+
+	report := agg.report(fixedNow, "/wf", "/db", nil, nil, nil)
+
+	if report.Summary.Tokens == nil || report.Summary.Tokens.Total != 999 {
+		t.Errorf("Summary.Tokens.Total = %v, want 999 (stored total, never recomputed)", report.Summary.Tokens)
+	}
+	adapterGroup := findGroup(t, report.ByAdapter, "mock")
+	if adapterGroup.Tokens == nil || adapterGroup.Tokens.Total != 999 {
+		t.Errorf("by_adapter[mock].Tokens.Total = %v, want 999", adapterGroup.Tokens)
+	}
+}
+
+// --- self-review aggregation ---
+
+func TestStatsSelfReview(t *testing.T) {
+	t.Parallel()
+
+	agg := newStatsAggregator(fullCaps, nil)
+	addRows(t, agg,
+		persistence.RunStatsRow{
+			Status: "succeeded", StartedAt: "2026-01-01T00:00:00Z", CompletedAt: "2026-01-01T00:01:00Z",
+			ReviewMetadata: reviewMetaPtr(t, domain.ReviewMetadata{FinalVerdict: "pass", TotalIterations: 1}),
+		},
+		persistence.RunStatsRow{
+			Status: "failed", StartedAt: "2026-01-01T00:00:00Z", CompletedAt: "2026-01-01T00:01:00Z",
+			ReviewMetadata: reviewMetaPtr(t, domain.ReviewMetadata{FinalVerdict: "iterate", TotalIterations: 3, CapReached: true}),
+		},
+		persistence.RunStatsRow{
+			Status: "failed", StartedAt: "2026-01-01T00:00:00Z", CompletedAt: "2026-01-01T00:01:00Z",
+			ReviewMetadata: reviewMetaPtr(t, domain.ReviewMetadata{FinalVerdict: "", TotalIterations: 2}),
+		},
+		persistence.RunStatsRow{
+			Status: "failed", StartedAt: "2026-01-01T00:00:00Z", CompletedAt: "2026-01-01T00:01:00Z",
+			ReviewMetadata: strPtr("{not-json"),
+		},
+	)
+
+	report := agg.report(fixedNow, "/wf", "/db", nil, nil, nil)
+
+	sr := report.SelfReview
+	if sr == nil {
+		t.Fatal("SelfReview = nil, want non-nil on the full tier")
+	}
+	if sr.RunsWithMetadata != 3 {
+		t.Errorf("RunsWithMetadata = %d, want 3", sr.RunsWithMetadata)
+	}
+	if sr.UnparsedRuns != 1 {
+		t.Errorf("UnparsedRuns = %d, want 1", sr.UnparsedRuns)
+	}
+	if sr.CapReachedRuns != 1 {
+		t.Errorf("CapReachedRuns = %d, want 1", sr.CapReachedRuns)
+	}
+	if sr.MeanIterations == nil || *sr.MeanIterations != 2 {
+		t.Errorf("MeanIterations = %v, want 2 ((1+3+2)/3)", sr.MeanIterations)
+	}
+
+	wantVerdicts := map[string]int{"iterate": 1, "none": 1, "pass": 1}
+	gotVerdicts := make(map[string]int, len(sr.ByFinalVerdict))
+	var verdictOrder []string
+	for _, vc := range sr.ByFinalVerdict {
+		gotVerdicts[vc.Verdict] = vc.Runs
+		verdictOrder = append(verdictOrder, vc.Verdict)
+	}
+	if !maps.Equal(gotVerdicts, wantVerdicts) {
+		t.Errorf("ByFinalVerdict = %v, want %v", gotVerdicts, wantVerdicts)
+	}
+	if !slices.IsSorted(verdictOrder) {
+		t.Errorf("ByFinalVerdict order = %v, want ascending by verdict", verdictOrder)
+	}
+}
+
+// --- data-driven status set and group ordering ---
+
+func TestStatsStatusOrdering(t *testing.T) {
+	t.Parallel()
+
+	agg := newStatsAggregator(fullCaps, nil)
+	for _, status := range []string{"weird_status", "succeeded", "succeeded", "failed", "cancelled"} {
+		addRows(t, agg, persistence.RunStatsRow{
+			Status: status, StartedAt: "2026-01-01T00:00:00Z", CompletedAt: "2026-01-01T00:01:00Z",
+		})
+	}
+
+	report := agg.report(fixedNow, "/wf", "/db", nil, nil, nil)
+
+	// "cancelled", "failed", and "weird_status" all have runs=1; ties break
+	// ascending by byte comparison: "cancelled" < "failed" < "weird_status".
+	want := []string{"succeeded", "cancelled", "failed", "weird_status"}
+	var got []string
+	for _, g := range report.ByStatus {
+		got = append(got, g.Name)
+	}
+	if !slices.Equal(got, want) {
+		t.Errorf("ByStatus order = %v, want %v", got, want)
+	}
+
+	weird := findGroup(t, report.ByStatus, "weird_status")
+	if weird.Runs != 1 {
+		t.Errorf("weird_status group Runs = %d, want 1 (status set must not be hard-coded)", weird.Runs)
+	}
+}
+
+// --- JSON report contract and byte-stability ---
+
+func TestRunStatsJSON(t *testing.T) {
+	// No t.Parallel: pinStatsNow mutates the package-level statsNow.
+	pinStatsNow(t, time.Date(2026, 8, 7, 9, 15, 0, 0, time.UTC))
+
+	dir := t.TempDir()
+	wfPath := writeCustomWorkflowFile(t, dir, statsWorkflow(""))
+	dbPath := filepath.Join(dir, ".sortie.db")
+	createStatsDB(t, dbPath,
+		persistence.RunHistory{
+			IssueID: "ISS-1", Identifier: "PROJ-1", Attempt: 1, AgentAdapter: "mock", Workspace: "/tmp/ws",
+			StartedAt: "2026-01-01T00:00:00Z", CompletedAt: "2026-01-01T00:10:00Z", Status: "succeeded", TurnsCompleted: 3,
+		},
+		persistence.RunHistory{
+			IssueID: "ISS-2", Identifier: "PROJ-2", Attempt: 1, AgentAdapter: "mock", Workspace: "/tmp/ws",
+			StartedAt: "2026-01-01T00:00:00Z", CompletedAt: "2026-01-01T00:20:00Z", Status: "failed", TurnsCompleted: 5,
+		},
+	)
+
+	var stdout1, stderr1 bytes.Buffer
+	code := run(context.Background(), []string{"stats", "--format", "json", wfPath}, &stdout1, &stderr1)
+	if code != 0 {
+		t.Fatalf("run(stats --format json) = %d, want 0; stderr: %s", code, stderr1.String())
+	}
+	if stderr1.Len() != 0 {
+		t.Errorf("stderr = %q, want empty on the success path", stderr1.String())
+	}
+
+	var report statsReport
+	if err := json.Unmarshal(stdout1.Bytes(), &report); err != nil {
+		t.Fatalf("json.Unmarshal(%q): %v", stdout1.String(), err)
+	}
+	if report.SchemaTier != "full" {
+		t.Errorf("SchemaTier = %q, want %q", report.SchemaTier, "full")
+	}
+	if report.WorkflowPath != wfPath {
+		t.Errorf("WorkflowPath = %q, want %q", report.WorkflowPath, wfPath)
+	}
+	if report.DBPath != dbPath {
+		t.Errorf("DBPath = %q, want %q", report.DBPath, dbPath)
+	}
+	if report.Summary.Runs != 2 {
+		t.Errorf("Summary.Runs = %d, want 2", report.Summary.Runs)
+	}
+	if report.ByStatus == nil || report.ByAdapter == nil || report.ByRule == nil || report.ByTemplate == nil || report.Warnings == nil {
+		t.Errorf("report slices must never be nil: ByStatus=%v ByAdapter=%v ByRule=%v ByTemplate=%v Warnings=%v",
+			report.ByStatus, report.ByAdapter, report.ByRule, report.ByTemplate, report.Warnings)
+	}
+	if !strings.Contains(stdout1.String(), `"warnings":[]`) {
+		t.Errorf("stdout = %q, want %q", stdout1.String(), `"warnings":[]`)
+	}
+
+	var stdout2, stderr2 bytes.Buffer
+	code2 := run(context.Background(), []string{"stats", "--format", "json", wfPath}, &stdout2, &stderr2)
+	if code2 != 0 {
+		t.Fatalf("second run(stats --format json) = %d, want 0; stderr: %s", code2, stderr2.String())
+	}
+	if stdout1.String() != stdout2.String() {
+		t.Errorf("stats --format json output is not byte-stable across two runs:\nfirst:  %q\nsecond: %q",
+			stdout1.String(), stdout2.String())
+	}
+}
+
+// --- empty range ---
+
+func TestRunStatsEmptyRange(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	wfPath := writeCustomWorkflowFile(t, dir, statsWorkflow(""))
+	dbPath := filepath.Join(dir, ".sortie.db")
+	createStatsDB(t, dbPath, persistence.RunHistory{
+		IssueID: "ISS-1", Identifier: "PROJ-1", Attempt: 1, AgentAdapter: "mock", Workspace: "/tmp/ws",
+		StartedAt: "2026-01-01T00:00:00Z", CompletedAt: "2026-01-01T00:10:00Z", Status: "succeeded",
+	})
+
+	t.Run("text", func(t *testing.T) {
+		t.Parallel()
+
+		var stdout, stderr bytes.Buffer
+		code := run(context.Background(), []string{"stats", "--since", "2099-01-01T00:00:00Z", wfPath}, &stdout, &stderr)
+		if code != 0 {
+			t.Fatalf("run(stats) = %d, want 0; stderr: %s", code, stderr.String())
+		}
+		for _, want := range []string{
+			"covering:  2099-01-01T00:00:00Z onward",
+			"No runs finished in this range.",
+		} {
+			if !strings.Contains(stdout.String(), want) {
+				t.Errorf("stdout = %q, want to contain %q", stdout.String(), want)
+			}
+		}
+		for _, absent := range []string{"by outcome", "by coding agent", "note:"} {
+			if strings.Contains(stdout.String(), absent) {
+				t.Errorf("stdout contains %q, want no breakdown or footnote for an empty range", absent)
+			}
+		}
+	})
+
+	t.Run("json", func(t *testing.T) {
+		t.Parallel()
+
+		var stdout, stderr bytes.Buffer
+		code := run(context.Background(), []string{"stats", "--format", "json", "--since", "2099-01-01T00:00:00Z", wfPath}, &stdout, &stderr)
+		if code != 0 {
+			t.Fatalf("run(stats --format json) = %d, want 0; stderr: %s", code, stderr.String())
+		}
+
+		var report statsReport
+		if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
+			t.Fatalf("json.Unmarshal(%q): %v", stdout.String(), err)
+		}
+		if report.Summary.Runs != 0 {
+			t.Errorf("Summary.Runs = %d, want 0", report.Summary.Runs)
+		}
+		if report.Summary.Duration.Samples != 0 || report.Summary.Duration.P50 != nil {
+			t.Errorf("Summary.Duration = %+v, want zero samples and null figures", report.Summary.Duration)
+		}
+		if report.Summary.MeanTurnsSucceeded != nil {
+			t.Errorf("Summary.MeanTurnsSucceeded = %v, want nil", *report.Summary.MeanTurnsSucceeded)
+		}
+		if report.Summary.CostUSD != nil {
+			t.Errorf("Summary.CostUSD = %v, want nil", *report.Summary.CostUSD)
+		}
+		for name, got := range map[string][]statsGroup{
+			"ByStatus": report.ByStatus, "ByAdapter": report.ByAdapter,
+			"ByRule": report.ByRule, "ByTemplate": report.ByTemplate,
+		} {
+			if got == nil || len(got) != 0 {
+				t.Errorf("%s = %v, want a non-nil empty slice", name, got)
+			}
+		}
+		if report.SelfReview == nil {
+			t.Fatal("SelfReview = nil, want non-nil on the full tier even with zero rows")
+		}
+		if report.SelfReview.RunsWithMetadata != 0 {
+			t.Errorf("SelfReview.RunsWithMetadata = %d, want 0", report.SelfReview.RunsWithMetadata)
+		}
+		if report.SelfReview.ByFinalVerdict == nil {
+			t.Error("SelfReview.ByFinalVerdict = nil, want a non-nil empty slice")
+		}
+	})
+}
+
+// --- usage errors ---
+
+func TestRunStatsUsageErrors(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	wfPath := writeCustomWorkflowFile(t, dir, statsWorkflow(""))
+
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{name: "invalid format", args: []string{"--format", "xml", wfPath}},
+		{name: "since zero duration", args: []string{"--since", "0h", wfPath}},
+		{name: "since negative duration", args: []string{"--since", "-1h", wfPath}},
+		{name: "since bare number without unit", args: []string{"--since", "24", wfPath}},
+		{name: "since timestamp without offset", args: []string{"--since", "2026-07-01T00:00:00", wfPath}},
+		{name: "since not before until", args: []string{"--since", "2026-07-02T00:00:00Z", "--until", "2026-07-01T00:00:00Z", wfPath}},
+		{name: "too many positional arguments", args: []string{wfPath, wfPath}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var stdout, stderr bytes.Buffer
+			args := append([]string{"stats"}, tt.args...)
+			code := run(context.Background(), args, &stdout, &stderr)
+
+			if code != 1 {
+				t.Fatalf("run(stats %v) = %d, want 1; stderr: %s", tt.args, code, stderr.String())
+			}
+			if stdout.Len() != 0 {
+				t.Errorf("run(stats %v) stdout = %q, want empty", tt.args, stdout.String())
+			}
+			lines := strings.Split(strings.TrimRight(stderr.String(), "\n"), "\n")
+			if len(lines) != 1 || lines[0] == "" {
+				t.Errorf("run(stats %v) stderr = %q, want exactly one line", tt.args, stderr.String())
+			}
+		})
+	}
+}
+
+// --- concurrent read against a live writable store ---
+
+func TestRunStatsAgainstLiveWriter(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	wfPath := writeCustomWorkflowFile(t, dir, statsWorkflow(""))
+	dbPath := filepath.Join(dir, ".sortie.db")
+
+	ctx := context.Background()
+	store, err := persistence.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("persistence.Open(%q): %v", dbPath, err)
+	}
+	t.Cleanup(func() {
+		if err := store.Close(); err != nil {
+			t.Errorf("store.Close: %v", err)
+		}
+	})
+	if err := store.Migrate(ctx); err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+	if _, err := store.AppendRunHistory(ctx, persistence.RunHistory{
+		IssueID: "ISS-1", Identifier: "PROJ-1", Attempt: 1, AgentAdapter: "mock", Workspace: "/tmp/ws",
+		StartedAt: "2026-01-01T00:00:00Z", CompletedAt: "2026-01-01T00:10:00Z", Status: "succeeded",
+	}); err != nil {
+		t.Fatalf("AppendRunHistory: %v", err)
+	}
+
+	before, err := os.Stat(dbPath)
+	if err != nil {
+		t.Fatalf("os.Stat(%q): %v", dbPath, err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := run(ctx, []string{"stats", "--format", "json", wfPath}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("run(stats) against a live writable store = %d, want 0; stderr: %s", code, stderr.String())
+	}
+
+	var report statsReport
+	if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
+		t.Fatalf("json.Unmarshal(%q): %v", stdout.String(), err)
+	}
+	if report.Summary.Runs != 1 {
+		t.Errorf("Summary.Runs = %d, want 1", report.Summary.Runs)
+	}
+
+	after, err := os.Stat(dbPath)
+	if err != nil {
+		t.Fatalf("os.Stat(%q): %v", dbPath, err)
+	}
+	if before.Size() != after.Size() {
+		t.Errorf("database file size changed across the invocation: before %d, after %d", before.Size(), after.Size())
+	}
+	if !before.ModTime().Equal(after.ModTime()) {
+		t.Errorf("database file mtime changed across the invocation: before %v, after %v", before.ModTime(), after.ModTime())
+	}
+}
+
+// --- degraded schema tier ---
+
+func TestRunStatsDegradedSchema(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	wfPath := writeCustomWorkflowFile(t, dir, statsWorkflow(""))
+	dbPath := filepath.Join(dir, ".sortie.db")
+	createLegacyStatsDB(t, dbPath)
+
+	t.Run("text", func(t *testing.T) {
+		t.Parallel()
+
+		var stdout, stderr bytes.Buffer
+		code := run(context.Background(), []string{"stats", wfPath}, &stdout, &stderr)
+		if code != 0 {
+			t.Fatalf("run(stats) = %d, want 0; stderr: %s", code, stderr.String())
+		}
+		if !strings.Contains(stderr.String(), "was written before sortie recorded") {
+			t.Errorf("stderr = %q, want a degraded-schema warning", stderr.String())
+		}
+		out := stdout.String()
+		for _, absent := range []string{"by dispatch rule", "by prompt template", "self review", "turns (succeeded)", "tokens (all runs)"} {
+			if strings.Contains(out, absent) {
+				t.Errorf("stdout contains %q, want it absent on the base tier", absent)
+			}
+		}
+	})
+
+	t.Run("json", func(t *testing.T) {
+		t.Parallel()
+
+		var stdout, stderr bytes.Buffer
+		code := run(context.Background(), []string{"stats", "--format", "json", wfPath}, &stdout, &stderr)
+		if code != 0 {
+			t.Fatalf("run(stats --format json) = %d, want 0; stderr: %s", code, stderr.String())
+		}
+		if stderr.Len() != 0 {
+			t.Errorf("stderr = %q, want empty in JSON mode (warnings travel in the envelope)", stderr.String())
+		}
+
+		var report statsReport
+		if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
+			t.Fatalf("json.Unmarshal(%q): %v", stdout.String(), err)
+		}
+		if report.SchemaTier != "base" {
+			t.Errorf("SchemaTier = %q, want %q", report.SchemaTier, "base")
+		}
+		found := slices.ContainsFunc(report.Warnings, func(w string) bool {
+			return strings.Contains(w, "was written before sortie recorded")
+		})
+		if !found {
+			t.Errorf("Warnings = %v, want a degraded-schema warning", report.Warnings)
+		}
+		if len(report.ByRule) != 0 {
+			t.Errorf("ByRule = %v, want empty on the base tier", report.ByRule)
+		}
+		if len(report.ByTemplate) != 0 {
+			t.Errorf("ByTemplate = %v, want empty on the base tier", report.ByTemplate)
+		}
+		if report.SelfReview != nil {
+			t.Errorf("SelfReview = %v, want nil on the base tier", report.SelfReview)
+		}
+		if report.Summary.Tokens != nil {
+			t.Errorf("Summary.Tokens = %v, want nil on the base tier", report.Summary.Tokens)
+		}
+		if report.Summary.CostUSD != nil {
+			t.Errorf("Summary.CostUSD = %v, want nil on the base tier", *report.Summary.CostUSD)
+		}
+	})
+}
+
+// --- config-resolution errors ---
+
+func TestRunStatsConfigErrors(t *testing.T) {
+	t.Parallel()
+
+	t.Run("missing workflow file", func(t *testing.T) {
+		t.Parallel()
+
+		var stdout, stderr bytes.Buffer
+		code := run(context.Background(), []string{"stats", "/nonexistent/sortie-test-workflow.md"}, &stdout, &stderr)
+		if code != 1 {
+			t.Fatalf("run(stats) = %d, want 1; stderr: %s", code, stderr.String())
+		}
+		if stdout.Len() != 0 {
+			t.Errorf("stdout = %q, want empty", stdout.String())
+		}
+		if !strings.Contains(stderr.String(), "workflow") {
+			t.Errorf("stderr = %q, want to contain %q", stderr.String(), "workflow")
+		}
+	})
+
+	t.Run("front matter value config.NewServiceConfig rejects", func(t *testing.T) {
+		t.Parallel()
+
+		dir := t.TempDir()
+		wfPath := writeCustomWorkflowFile(t, dir, statsWorkflow("db_path: 42\n"))
+
+		var stdout, stderr bytes.Buffer
+		code := run(context.Background(), []string{"stats", wfPath}, &stdout, &stderr)
+		if code != 1 {
+			t.Fatalf("run(stats) = %d, want 1; stderr: %s", code, stderr.String())
+		}
+		if stdout.Len() != 0 {
+			t.Errorf("stdout = %q, want empty", stdout.String())
+		}
+		if !strings.Contains(stderr.String(), "db_path") {
+			t.Errorf("stderr = %q, want to contain %q", stderr.String(), "db_path")
+		}
+	})
+
+	t.Run("missing database file", func(t *testing.T) {
+		t.Parallel()
+
+		dir := t.TempDir()
+		wfPath := writeCustomWorkflowFile(t, dir, statsWorkflow(""))
+
+		var stdout, stderr bytes.Buffer
+		code := run(context.Background(), []string{"stats", wfPath}, &stdout, &stderr)
+		if code != 1 {
+			t.Fatalf("run(stats) = %d, want 1; stderr: %s", code, stderr.String())
+		}
+		if stdout.Len() != 0 {
+			t.Errorf("stdout = %q, want empty", stdout.String())
+		}
+		if !strings.Contains(stderr.String(), "sortie stats:") {
+			t.Errorf("stderr = %q, want the %q diagnostic prefix", stderr.String(), "sortie stats:")
+		}
+	})
+}
+
+// --- db_path resolution ---
+
+func TestRunStatsDBPathResolution(t *testing.T) {
+	// No t.Parallel: the SORTIE_DB_PATH subtest uses t.Setenv, which
+	// requires the calling test and every ancestor to be non-parallel.
+
+	oneRun := func(t *testing.T) []persistence.RunHistory {
+		t.Helper()
+		return []persistence.RunHistory{{
+			IssueID: "ISS-1", Identifier: "PROJ-1", Attempt: 1, AgentAdapter: "mock", Workspace: "/tmp/ws",
+			StartedAt: "2026-01-01T00:00:00Z", CompletedAt: "2026-01-01T00:10:00Z", Status: "succeeded",
+		}}
+	}
+
+	t.Run("absolute db_path", func(t *testing.T) {
+		t.Parallel()
+
+		dir := t.TempDir()
+		dbDir := t.TempDir()
+		dbPath := filepath.Join(dbDir, "custom.db")
+		createStatsDB(t, dbPath, oneRun(t)...)
+		wfPath := writeCustomWorkflowFile(t, dir, statsWorkflow(fmt.Sprintf("db_path: %q\n", dbPath)))
+
+		var stdout, stderr bytes.Buffer
+		code := run(context.Background(), []string{"stats", "--format", "json", wfPath}, &stdout, &stderr)
+		if code != 0 {
+			t.Fatalf("run(stats) = %d, want 0; stderr: %s", code, stderr.String())
+		}
+		var report statsReport
+		if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
+			t.Fatalf("json.Unmarshal(%q): %v", stdout.String(), err)
+		}
+		if report.DBPath != dbPath {
+			t.Errorf("DBPath = %q, want %q", report.DBPath, dbPath)
+		}
+		if report.Summary.Runs != 1 {
+			t.Errorf("Summary.Runs = %d, want 1", report.Summary.Runs)
+		}
+	})
+
+	t.Run("relative db_path resolves against the workflow directory", func(t *testing.T) {
+		t.Parallel()
+
+		dir := t.TempDir()
+		dbPath := filepath.Join(dir, "custom.db")
+		createStatsDB(t, dbPath, oneRun(t)...)
+		wfPath := writeCustomWorkflowFile(t, dir, statsWorkflow("db_path: custom.db\n"))
+
+		var stdout, stderr bytes.Buffer
+		code := run(context.Background(), []string{"stats", "--format", "json", wfPath}, &stdout, &stderr)
+		if code != 0 {
+			t.Fatalf("run(stats) = %d, want 0; stderr: %s", code, stderr.String())
+		}
+		var report statsReport
+		if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
+			t.Fatalf("json.Unmarshal(%q): %v", stdout.String(), err)
+		}
+		if report.DBPath != dbPath {
+			t.Errorf("DBPath = %q, want %q (resolved against the workflow directory)", report.DBPath, dbPath)
+		}
+	})
+
+	t.Run("SORTIE_DB_PATH environment override", func(t *testing.T) {
+		// No t.Parallel: t.Setenv requires a sequential test.
+
+		dir := t.TempDir()
+		dbDir := t.TempDir()
+		dbPath := filepath.Join(dbDir, "env-override.db")
+		createStatsDB(t, dbPath, oneRun(t)...)
+		t.Setenv("SORTIE_DB_PATH", dbPath)
+		wfPath := writeCustomWorkflowFile(t, dir, statsWorkflow(""))
+
+		var stdout, stderr bytes.Buffer
+		code := run(context.Background(), []string{"stats", "--format", "json", wfPath}, &stdout, &stderr)
+		if code != 0 {
+			t.Fatalf("run(stats) = %d, want 0; stderr: %s", code, stderr.String())
+		}
+		var report statsReport
+		if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
+			t.Fatalf("json.Unmarshal(%q): %v", stdout.String(), err)
+		}
+		if report.DBPath != dbPath {
+			t.Errorf("DBPath = %q, want %q (from SORTIE_DB_PATH)", report.DBPath, dbPath)
+		}
+	})
+}

--- a/cmd/sortie/stats_test.go
+++ b/cmd/sortie/stats_test.go
@@ -781,6 +781,66 @@ func TestRunStatsAgainstLiveWriter(t *testing.T) {
 
 // --- degraded schema tier ---
 
+func TestDegradedSchemaWarning(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		caps   persistence.RunHistoryCapabilities
+		want   []string
+		absent []string
+	}{
+		{
+			name: "nothing recorded names every group once",
+			caps: persistence.RunHistoryCapabilities{},
+			want: []string{
+				"before sortie recorded turns, self-review results, dispatch-rule routing, tokens and cost",
+				"Run sortie once with this workflow to add them.",
+			},
+			absent: []string{"does carry", "falls back"},
+		},
+		{
+			// The shape this repository's own database has: turns and
+			// self-review are stored, rule routing and tokens are not. The
+			// report still drops all four, so the warning must say so.
+			name: "partly migrated discloses the figures it drops anyway",
+			caps: persistence.RunHistoryCapabilities{HasTurnsCompleted: true, HasReviewMetadata: true},
+			want: []string{
+				"before sortie recorded dispatch-rule routing, tokens and cost",
+				"also leaves out turns, self-review results, which this database does carry",
+			},
+		},
+		{
+			name: "only tokens absent still discloses the other three",
+			caps: persistence.RunHistoryCapabilities{
+				HasTurnsCompleted: true, HasReviewMetadata: true, HasRuleRouting: true,
+			},
+			want: []string{
+				"before sortie recorded tokens and cost",
+				"also leaves out turns, self-review results, dispatch-rule routing, which this database does carry",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := degradedSchemaWarning(tt.caps)
+			for _, want := range tt.want {
+				if !strings.Contains(got, want) {
+					t.Errorf("degradedSchemaWarning(%+v) = %q, want to contain %q", tt.caps, got, want)
+				}
+			}
+			for _, absent := range tt.absent {
+				if strings.Contains(got, absent) {
+					t.Errorf("degradedSchemaWarning(%+v) = %q, want it not to contain %q", tt.caps, got, absent)
+				}
+			}
+		})
+	}
+}
+
 func TestRunStatsDegradedSchema(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/sortie/stats_test.go
+++ b/cmd/sortie/stats_test.go
@@ -856,6 +856,14 @@ func TestRunStatsDegradedSchema(t *testing.T) {
 		if !strings.Contains(stderr.String(), "was written before sortie recorded") {
 			t.Errorf("stderr = %q, want a degraded-schema warning", stderr.String())
 		}
+		if !strings.HasPrefix(stderr.String(), "\nwarning: ") {
+			t.Errorf("stderr = %q, want a blank line before the first warning so it does not run into the report",
+				stderr.String())
+		}
+		if !strings.HasSuffix(stdout.String(), "\n") || strings.HasSuffix(stdout.String(), "\n\n") {
+			t.Errorf("stdout = %q, want exactly one trailing newline: the separator belongs to stderr",
+				stdout.String())
+		}
 		out := stdout.String()
 		for _, absent := range []string{"by dispatch rule", "by prompt template", "self review", "turns (succeeded)", "tokens (all runs)"} {
 			if strings.Contains(out, absent) {

--- a/cmd/sortie/testdata/help.txt
+++ b/cmd/sortie/testdata/help.txt
@@ -6,6 +6,7 @@ Usage:
 
 Commands:
   validate                  Validate a workflow file without running it
+  stats                     Summarize past runs: outcomes, duration, and cost
   mcp-server                Start the MCP stdio server for agent-to-orchestrator communication
 
 Flags:
@@ -25,6 +26,7 @@ Examples:
   sortie WORKFLOW.md                     Run orchestrator with a workflow
   sortie --dry-run WORKFLOW.md           Validate config and poll once without side effects
   sortie validate --format json w.md     Check workflow syntax, output as JSON
+  sortie stats --since 24h               Summarize the last 24 hours of runs
 
 Learn more:
   https://docs.sortie-ai.com

--- a/cmd/sortie/usage.go
+++ b/cmd/sortie/usage.go
@@ -15,6 +15,7 @@ Usage:
 
 Commands:
   validate                  Validate a workflow file without running it
+  stats                     Summarize past runs: outcomes, duration, and cost
   mcp-server                Start the MCP stdio server for agent-to-orchestrator communication
 
 Flags:
@@ -34,6 +35,7 @@ Examples:
   sortie WORKFLOW.md                     Run orchestrator with a workflow
   sortie --dry-run WORKFLOW.md           Validate config and poll once without side effects
   sortie validate --format json w.md     Check workflow syntax, output as JSON
+  sortie stats --since 24h               Summarize the last 24 hours of runs
 
 Learn more:
   https://docs.sortie-ai.com
@@ -62,6 +64,44 @@ Examples:
 `)
 }
 
+func printStatsHelp(w io.Writer) {
+	fmt.Fprint(w, //nolint:errcheck // help output write failure is unrecoverable
+		`Summarize how past runs went and what they cost.
+
+Each time an agent session finishes, sortie records the outcome. This
+command reads that history back and reports how many runs there were, how
+many succeeded, how long they took, and, when the workflow sets
+token_rates, what they cost. The same figures are broken down by outcome,
+by coding agent, by dispatch rule, and by prompt template.
+
+The database is opened read-only, so this is safe to run while the
+orchestrator is working.
+
+Usage:
+  sortie stats [flags] [workflow-path]
+
+Flags:
+  --format FORMAT   Output format: text, json (default: text)
+  --since VALUE     Count only runs that finished at or after this point
+                    (default: no limit)
+  --until VALUE     Count only runs that finished before this point
+                    (default: no limit)
+
+--since and --until each accept one of:
+  an exact timestamp        2026-07-01T00:00:00Z
+  a calendar date           2026-07-01
+  an age counted from now   24h, or 90m (hours and minutes only)
+
+Global flags:
+  -h, --help        Print this help message and quit
+
+Examples:
+  sortie stats                           Summarize every recorded run
+  sortie stats --since 24h               Summarize the last 24 hours
+  sortie stats --since 2026-07-01 --format json WORKFLOW.md
+`)
+}
+
 func printMCPServerHelp(w io.Writer) {
 	fmt.Fprint(w, //nolint:errcheck // help output write failure is unrecoverable
 		`Start the MCP stdio server for agent-to-orchestrator communication.
@@ -86,7 +126,7 @@ Global flags:
 // tokens and the POSIX "--" terminator stop the scan immediately.
 func interceptShortFlags(args []string) string {
 	for _, arg := range args {
-		if arg == "validate" || arg == "mcp-server" {
+		if arg == "validate" || arg == "stats" || arg == "mcp-server" {
 			return ""
 		}
 		if arg == "--" {

--- a/cmd/sortie/usage.go
+++ b/cmd/sortie/usage.go
@@ -90,7 +90,7 @@ Flags:
 --since and --until each accept one of:
   an exact timestamp        2026-07-01T00:00:00Z
   a calendar date           2026-07-01
-  an age counted from now   24h, or 90m (hours and minutes only)
+  an age counted from now   24h, 90m, or 45s (any Go duration)
 
 Global flags:
   -h, --help        Print this help message and quit

--- a/cmd/sortie/usage_test.go
+++ b/cmd/sortie/usage_test.go
@@ -2,7 +2,9 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"os"
+	"strings"
 	"testing"
 )
 
@@ -91,6 +93,30 @@ func TestInterceptShortFlags(t *testing.T) {
 				t.Errorf("interceptShortFlags(%v) = %q, want %q", tt.args, action, tt.wantAction)
 			}
 		})
+	}
+}
+
+func TestStatsHelpRouting(t *testing.T) {
+	t.Parallel()
+
+	var stdout, stderr bytes.Buffer
+	code := run(context.Background(), []string{"stats", "-h"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("run(stats -h) = %d, want 0", code)
+	}
+
+	got := stdout.String()
+	if strings.Contains(got, "Turn issue tracker tickets into autonomous coding agent sessions.") {
+		t.Errorf("run(stats -h) stdout = %q, want the stats help, not the global help", got)
+	}
+	if !strings.Contains(got, "Summarize how past runs went and what they cost.") {
+		t.Errorf("run(stats -h) stdout = %q, want the stats help text", got)
+	}
+
+	var helpBuf bytes.Buffer
+	printHelp(&helpBuf)
+	if !strings.Contains(helpBuf.String(), "stats") {
+		t.Errorf("printHelp() output = %q, want to contain %q", helpBuf.String(), "stats")
 	}
 }
 

--- a/internal/persistence/run_stats.go
+++ b/internal/persistence/run_stats.go
@@ -1,0 +1,179 @@
+package persistence
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+)
+
+// RunHistoryCapabilities reports which optional run_history columns a
+// database carries, so a read-only caller can pick a projection the schema
+// supports. A field the underlying table does not carry holds its zero
+// value in every [RunStatsRow] the read returns.
+type RunHistoryCapabilities struct {
+	HasTurnsCompleted bool // migration 005
+	HasReviewMetadata bool // migration 007
+	HasRuleRouting    bool // migration 010: rule_name, template_id
+	HasTokens         bool // migration 011: the four token columns
+}
+
+// Full reports whether the database carries every optional run_history
+// column group. It is the single owner of the capability tier decision:
+// [Store.ScanRunHistoryRange] selects its projection from this predicate and
+// no caller may re-derive the conjunction or branch on an individual flag,
+// because a database migrated only partway is the common case rather than
+// an exceptional one.
+func (c RunHistoryCapabilities) Full() bool {
+	return c.HasTurnsCompleted && c.HasReviewMetadata && c.HasRuleRouting && c.HasTokens
+}
+
+// RunStatsRow is the narrow run_history projection the aggregate read
+// returns. A field the schema does not carry holds its zero value.
+type RunStatsRow struct {
+	Status          string
+	AgentAdapter    string
+	RuleName        string
+	TemplateID      string
+	StartedAt       string // ISO-8601 as stored
+	CompletedAt     string // ISO-8601 as stored
+	TurnsCompleted  int
+	ReviewMetadata  *string // nil when the column is NULL or absent
+	InputTokens     int64
+	OutputTokens    int64
+	TotalTokens     int64
+	CacheReadTokens int64
+}
+
+// runStatsSelectFull projects every RunStatsRow field. It is used when
+// RunHistoryCapabilities.Full reports true.
+const runStatsSelectFull = `SELECT status, agent_adapter, rule_name, template_id, started_at, completed_at,
+	turns_completed, review_metadata, input_tokens, output_tokens, total_tokens, cache_read_tokens
+FROM run_history`
+
+// runStatsSelectBase projects only the base columns every schema version
+// carries. It is used when RunHistoryCapabilities.Full reports false.
+const runStatsSelectBase = `SELECT status, agent_adapter, started_at, completed_at FROM run_history`
+
+// RunHistoryCapabilities reports which optional run_history column groups
+// this store's database carries, by reading the table's live column set
+// with PRAGMA table_info rather than assuming a fixed schema version.
+//
+// RunHistoryCapabilities returns a non-nil error, naming run_history, when
+// the table is absent or lacks any of the base columns status,
+// agent_adapter, started_at, or completed_at, so the caller can report that
+// the file is not a Sortie database without inspecting the error further.
+func (s *Store) RunHistoryCapabilities(ctx context.Context) (RunHistoryCapabilities, error) {
+	rows, err := s.db.QueryContext(ctx, "PRAGMA table_info(run_history)")
+	if err != nil {
+		return RunHistoryCapabilities{}, fmt.Errorf("read run_history schema: %w", err)
+	}
+	defer rows.Close() //nolint:errcheck // read-only pragma; close error is non-actionable
+
+	columns := make(map[string]bool)
+	for rows.Next() {
+		var cid, pk int
+		var name, colType string
+		var notNull int
+		var dflt sql.NullString
+		if err := rows.Scan(&cid, &name, &colType, &notNull, &dflt, &pk); err != nil {
+			return RunHistoryCapabilities{}, fmt.Errorf("scan run_history schema: %w", err)
+		}
+		columns[name] = true
+	}
+	if err := rows.Err(); err != nil {
+		return RunHistoryCapabilities{}, fmt.Errorf("read run_history schema: %w", err)
+	}
+
+	if len(columns) == 0 || !columns["status"] || !columns["agent_adapter"] ||
+		!columns["started_at"] || !columns["completed_at"] {
+		return RunHistoryCapabilities{}, fmt.Errorf("run_history table not found or missing base columns")
+	}
+
+	return RunHistoryCapabilities{
+		HasTurnsCompleted: columns["turns_completed"],
+		HasReviewMetadata: columns["review_metadata"],
+		HasRuleRouting:    columns["rule_name"] && columns["template_id"],
+		HasTokens: columns["input_tokens"] && columns["output_tokens"] &&
+			columns["total_tokens"] && columns["cache_read_tokens"],
+	}, nil
+}
+
+// ScanRunHistoryRange issues one SELECT over run_history bounded by a
+// half-open completed_at range and calls visit once per row in ascending
+// id order. caps selects the projection through [RunHistoryCapabilities.Full];
+// a nil since or until omits its predicate rather than substituting a
+// sentinel. since is compared with >= and until with <, both formatted as
+// since.UTC().Format(time.RFC3339). A non-nil error returned by visit
+// aborts iteration and is returned unmodified, so the caller can compare it
+// with errors.Is.
+//
+// visit MUST NOT call any Store method. The scan holds the store's single
+// pooled connection for the duration of iteration, because OpenReadOnly
+// caps the pool at one connection; a second query issued from visit would
+// block until the context is cancelled, since only this scan's completion
+// can release that connection.
+func (s *Store) ScanRunHistoryRange(
+	ctx context.Context,
+	caps RunHistoryCapabilities,
+	since, until *time.Time,
+	visit func(RunStatsRow) error,
+) error {
+	full := caps.Full()
+	query := runStatsSelectBase
+	if full {
+		query = runStatsSelectFull
+	}
+
+	var args []any
+	where := ""
+	if since != nil {
+		where += " WHERE completed_at >= ?"
+		args = append(args, since.UTC().Format(time.RFC3339))
+	}
+	if until != nil {
+		if where == "" {
+			where += " WHERE completed_at < ?"
+		} else {
+			where += " AND completed_at < ?"
+		}
+		args = append(args, until.UTC().Format(time.RFC3339))
+	}
+	query += where + " ORDER BY id ASC"
+
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return fmt.Errorf("scan run history range: %w", err)
+	}
+	defer rows.Close() //nolint:errcheck // read-only query; close error is non-actionable
+
+	for rows.Next() {
+		var row RunStatsRow
+		var reviewMeta sql.NullString
+		if full {
+			if err := rows.Scan(
+				&row.Status, &row.AgentAdapter, &row.RuleName, &row.TemplateID,
+				&row.StartedAt, &row.CompletedAt, &row.TurnsCompleted, &reviewMeta,
+				&row.InputTokens, &row.OutputTokens, &row.TotalTokens, &row.CacheReadTokens,
+			); err != nil {
+				return fmt.Errorf("scan run history range: %w", err)
+			}
+			if reviewMeta.Valid {
+				metadata := reviewMeta.String
+				row.ReviewMetadata = &metadata
+			}
+		} else {
+			if err := rows.Scan(&row.Status, &row.AgentAdapter, &row.StartedAt, &row.CompletedAt); err != nil {
+				return fmt.Errorf("scan run history range: %w", err)
+			}
+		}
+
+		if err := visit(row); err != nil {
+			return err
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("scan run history range: %w", err)
+	}
+	return nil
+}

--- a/internal/persistence/run_stats_test.go
+++ b/internal/persistence/run_stats_test.go
@@ -1,0 +1,314 @@
+package persistence
+
+import (
+	"context"
+	"errors"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+)
+
+// createLegacyRunHistoryTable creates a run_history table carrying only
+// the migration-001 columns, with no schema_migrations tracking and none
+// of the optional column groups.
+func createLegacyRunHistoryTable(t *testing.T, s *Store) {
+	t.Helper()
+	if _, err := s.db.ExecContext(context.Background(), `CREATE TABLE run_history (
+		id            INTEGER PRIMARY KEY AUTOINCREMENT,
+		issue_id      TEXT    NOT NULL,
+		identifier    TEXT    NOT NULL,
+		attempt       INTEGER NOT NULL,
+		agent_adapter TEXT    NOT NULL,
+		workspace     TEXT    NOT NULL,
+		started_at    TEXT    NOT NULL,
+		completed_at  TEXT    NOT NULL,
+		status        TEXT    NOT NULL,
+		error         TEXT
+	)`); err != nil {
+		t.Fatalf("create migration-001 run_history table: %v", err)
+	}
+}
+
+// createPartialRunHistoryTable creates a run_history table carrying
+// turns_completed and review_metadata but neither rule_name/template_id
+// nor the four token columns, matching this repository's own .sortie.db
+// shape (schema version 9).
+func createPartialRunHistoryTable(t *testing.T, s *Store) {
+	t.Helper()
+	createLegacyRunHistoryTable(t, s)
+	ctx := context.Background()
+	for _, stmt := range []string{
+		"ALTER TABLE run_history ADD COLUMN turns_completed INTEGER NOT NULL DEFAULT 0",
+		"ALTER TABLE run_history ADD COLUMN review_metadata TEXT",
+	} {
+		if _, err := s.db.ExecContext(ctx, stmt); err != nil {
+			t.Fatalf("alter run_history (%s): %v", stmt, err)
+		}
+	}
+}
+
+func TestRunHistoryCapabilities(t *testing.T) {
+	t.Parallel()
+
+	t.Run("fully migrated store reports all four flags true", func(t *testing.T) {
+		t.Parallel()
+
+		s := openTestStore(t)
+		migrateOrFatal(t, s)
+
+		caps, err := s.RunHistoryCapabilities(context.Background())
+		if err != nil {
+			t.Fatalf("RunHistoryCapabilities: %v", err)
+		}
+		if !caps.HasTurnsCompleted || !caps.HasReviewMetadata || !caps.HasRuleRouting || !caps.HasTokens {
+			t.Errorf("RunHistoryCapabilities() = %+v, want all four flags true", caps)
+		}
+		if !caps.Full() {
+			t.Errorf("Full() = false, want true for a fully migrated store")
+		}
+	})
+
+	t.Run("migration-001-only table reports all four flags false", func(t *testing.T) {
+		t.Parallel()
+
+		s := openTestStore(t)
+		createLegacyRunHistoryTable(t, s)
+
+		caps, err := s.RunHistoryCapabilities(context.Background())
+		if err != nil {
+			t.Fatalf("RunHistoryCapabilities: %v", err)
+		}
+		if caps.HasTurnsCompleted || caps.HasReviewMetadata || caps.HasRuleRouting || caps.HasTokens {
+			t.Errorf("RunHistoryCapabilities() = %+v, want all four flags false", caps)
+		}
+		if caps.Full() {
+			t.Errorf("Full() = true, want false for a migration-001-only table")
+		}
+	})
+
+	t.Run("turns and review metadata present, rule routing and tokens absent", func(t *testing.T) {
+		t.Parallel()
+
+		s := openTestStore(t)
+		createPartialRunHistoryTable(t, s)
+
+		caps, err := s.RunHistoryCapabilities(context.Background())
+		if err != nil {
+			t.Fatalf("RunHistoryCapabilities: %v", err)
+		}
+		if !caps.HasTurnsCompleted {
+			t.Errorf("HasTurnsCompleted = false, want true")
+		}
+		if !caps.HasReviewMetadata {
+			t.Errorf("HasReviewMetadata = false, want true")
+		}
+		if caps.HasRuleRouting {
+			t.Errorf("HasRuleRouting = true, want false")
+		}
+		if caps.HasTokens {
+			t.Errorf("HasTokens = true, want false")
+		}
+		if caps.Full() {
+			t.Errorf("Full() = true, want false for the mixed-migration shape")
+		}
+	})
+
+	t.Run("no run_history table names run_history in the error", func(t *testing.T) {
+		t.Parallel()
+
+		s := openTestStore(t)
+
+		_, err := s.RunHistoryCapabilities(context.Background())
+		if err == nil {
+			t.Fatal("RunHistoryCapabilities() error = nil, want an error naming run_history")
+		}
+		if !strings.Contains(err.Error(), "run_history") {
+			t.Errorf("RunHistoryCapabilities() error = %q, want to contain %q", err.Error(), "run_history")
+		}
+	})
+}
+
+// runAt returns a minimal RunHistory whose StartedAt and CompletedAt are
+// both completedAt, for tests that only care about the completed_at
+// range filter.
+func runAt(id, completedAt string) RunHistory {
+	return RunHistory{
+		IssueID:      id,
+		Identifier:   id,
+		Attempt:      1,
+		AgentAdapter: "mock",
+		Workspace:    "/tmp/ws",
+		StartedAt:    completedAt,
+		CompletedAt:  completedAt,
+		Status:       "succeeded",
+	}
+}
+
+func TestScanRunHistoryRange(t *testing.T) {
+	t.Parallel()
+
+	t.Run("half-open range: since inclusive, until exclusive", func(t *testing.T) {
+		t.Parallel()
+
+		s := openTestStore(t)
+		migrateOrFatal(t, s)
+		ctx := context.Background()
+
+		appendOrFatal(t, s, runAt("before", "2026-01-01T00:05:00Z"))
+		appendOrFatal(t, s, runAt("at-since", "2026-01-02T00:05:00Z"))
+		appendOrFatal(t, s, runAt("at-until", "2026-01-03T00:05:00Z"))
+		appendOrFatal(t, s, runAt("after", "2026-01-04T00:05:00Z"))
+
+		caps, err := s.RunHistoryCapabilities(ctx)
+		if err != nil {
+			t.Fatalf("RunHistoryCapabilities: %v", err)
+		}
+
+		since, err := time.Parse(time.RFC3339, "2026-01-02T00:05:00Z")
+		if err != nil {
+			t.Fatalf("time.Parse(since): %v", err)
+		}
+		until, err := time.Parse(time.RFC3339, "2026-01-03T00:05:00Z")
+		if err != nil {
+			t.Fatalf("time.Parse(until): %v", err)
+		}
+
+		var visited []string
+		if err := s.ScanRunHistoryRange(ctx, caps, &since, &until, func(row RunStatsRow) error {
+			visited = append(visited, row.CompletedAt)
+			return nil
+		}); err != nil {
+			t.Fatalf("ScanRunHistoryRange: %v", err)
+		}
+
+		want := []string{"2026-01-02T00:05:00Z"}
+		if !slices.Equal(visited, want) {
+			t.Errorf("ScanRunHistoryRange(since=%s, until=%s) visited = %v, want %v",
+				since.Format(time.RFC3339), until.Format(time.RFC3339), visited, want)
+		}
+	})
+
+	t.Run("both bounds unbounded returns every row", func(t *testing.T) {
+		t.Parallel()
+
+		s := openTestStore(t)
+		migrateOrFatal(t, s)
+		ctx := context.Background()
+
+		appendOrFatal(t, s, runAt("r1", "2026-01-01T00:00:00Z"))
+		appendOrFatal(t, s, runAt("r2", "2026-01-02T00:00:00Z"))
+		appendOrFatal(t, s, runAt("r3", "2026-01-03T00:00:00Z"))
+
+		caps, err := s.RunHistoryCapabilities(ctx)
+		if err != nil {
+			t.Fatalf("RunHistoryCapabilities: %v", err)
+		}
+
+		var count int
+		if err := s.ScanRunHistoryRange(ctx, caps, nil, nil, func(RunStatsRow) error {
+			count++
+			return nil
+		}); err != nil {
+			t.Fatalf("ScanRunHistoryRange: %v", err)
+		}
+		if count != 3 {
+			t.Errorf("ScanRunHistoryRange(nil, nil) visited %d rows, want 3", count)
+		}
+	})
+
+	t.Run("rows visited in ascending id order; a visit error aborts and is returned unmodified", func(t *testing.T) {
+		t.Parallel()
+
+		s := openTestStore(t)
+		migrateOrFatal(t, s)
+		ctx := context.Background()
+
+		for _, tag := range []string{"order-1", "order-2", "order-3"} {
+			appendOrFatal(t, s, RunHistory{
+				IssueID: tag, Identifier: tag, Attempt: 1, AgentAdapter: "mock", Workspace: "/tmp/ws",
+				StartedAt: "2026-01-01T00:00:00Z", CompletedAt: "2026-01-01T00:01:00Z", Status: tag,
+			})
+		}
+
+		caps, err := s.RunHistoryCapabilities(ctx)
+		if err != nil {
+			t.Fatalf("RunHistoryCapabilities: %v", err)
+		}
+
+		sentinelErr := errors.New("stop at second row")
+		var visited []string
+		err = s.ScanRunHistoryRange(ctx, caps, nil, nil, func(row RunStatsRow) error {
+			visited = append(visited, row.Status)
+			if row.Status == "order-2" {
+				return sentinelErr
+			}
+			return nil
+		})
+
+		if !errors.Is(err, sentinelErr) {
+			t.Fatalf("ScanRunHistoryRange() error = %v, want errors.Is match on %v", err, sentinelErr)
+		}
+		want := []string{"order-1", "order-2"}
+		if !slices.Equal(visited, want) {
+			t.Errorf("ScanRunHistoryRange visited = %v, want %v (ascending id order, aborted after the error)", visited, want)
+		}
+	})
+
+	t.Run("base projection against the legacy table leaves optional fields zero", func(t *testing.T) {
+		t.Parallel()
+
+		s := openTestStore(t)
+		createLegacyRunHistoryTable(t, s)
+		ctx := context.Background()
+
+		if _, err := s.db.ExecContext(ctx,
+			`INSERT INTO run_history (issue_id, identifier, attempt, agent_adapter, workspace, started_at, completed_at, status)
+			 VALUES ('ISS-1', 'PROJ-1', 1, 'mock', '/tmp/ws', '2026-01-01T00:00:00Z', '2026-01-01T00:05:00Z', 'succeeded')`,
+		); err != nil {
+			t.Fatalf("insert legacy row: %v", err)
+		}
+
+		caps, err := s.RunHistoryCapabilities(ctx)
+		if err != nil {
+			t.Fatalf("RunHistoryCapabilities: %v", err)
+		}
+		if caps.Full() {
+			t.Fatalf("caps.Full() = true, want false for the legacy table")
+		}
+
+		var rows []RunStatsRow
+		if err := s.ScanRunHistoryRange(ctx, caps, nil, nil, func(row RunStatsRow) error {
+			rows = append(rows, row)
+			return nil
+		}); err != nil {
+			t.Fatalf("ScanRunHistoryRange: %v", err)
+		}
+		if len(rows) != 1 {
+			t.Fatalf("ScanRunHistoryRange visited %d rows, want 1", len(rows))
+		}
+
+		got := rows[0]
+		if got.Status != "succeeded" {
+			t.Errorf("RunStatsRow.Status = %q, want %q", got.Status, "succeeded")
+		}
+		if got.AgentAdapter != "mock" {
+			t.Errorf("RunStatsRow.AgentAdapter = %q, want %q", got.AgentAdapter, "mock")
+		}
+		if got.TurnsCompleted != 0 {
+			t.Errorf("RunStatsRow.TurnsCompleted = %d, want 0 (base projection)", got.TurnsCompleted)
+		}
+		if got.ReviewMetadata != nil {
+			t.Errorf("RunStatsRow.ReviewMetadata = %v, want nil (base projection)", *got.ReviewMetadata)
+		}
+		if got.RuleName != "" {
+			t.Errorf("RunStatsRow.RuleName = %q, want empty (base projection)", got.RuleName)
+		}
+		if got.TemplateID != "" {
+			t.Errorf("RunStatsRow.TemplateID = %q, want empty (base projection)", got.TemplateID)
+		}
+		if got.InputTokens != 0 || got.OutputTokens != 0 || got.TotalTokens != 0 || got.CacheReadTokens != 0 {
+			t.Errorf("RunStatsRow token fields = %+v, want all zero (base projection)", got)
+		}
+	})
+}

--- a/internal/server/dashboard.go
+++ b/internal/server/dashboard.go
@@ -90,8 +90,8 @@ type dashboardRunHistoryEntry struct {
 	Error        string
 }
 
-// fmtInt formats an int64 with comma thousand separators.
-func fmtInt(v int64) string {
+// FormatInt formats an int64 with comma thousand separators.
+func FormatInt(v int64) string {
 	// Format first to avoid negation overflow on math.MinInt64.
 	s := strconv.FormatInt(v, 10)
 
@@ -126,10 +126,10 @@ func fmtInt(v int64) string {
 	return string(buf)
 }
 
-// formatDuration formats a duration as a human-readable string with at
+// FormatDuration formats a duration as a human-readable string with at
 // most three components. When days are present, seconds are dropped.
 // Negative durations return "0s".
-func formatDuration(d time.Duration) string {
+func FormatDuration(d time.Duration) string {
 	if d <= 0 {
 		return "0s"
 	}
@@ -166,7 +166,7 @@ func formatRelativeTime(dueAtMS int64, now time.Time) string {
 		}
 		return "overdue"
 	}
-	return "in " + formatDuration(diff)
+	return "in " + FormatDuration(diff)
 }
 
 // buildDashboardData maps a [orchestrator.RuntimeSnapshotResult] into
@@ -197,13 +197,13 @@ func buildDashboardData(
 
 	data := dashboardData{
 		Version:         version,
-		Uptime:          formatDuration(uptimeDur),
+		Uptime:          FormatDuration(uptimeDur),
 		GeneratedAt:     snap.GeneratedAt,
 		RunningCount:    runningCount,
 		RetryingCount:   len(snap.Retrying),
 		AvailableSlots:  available,
 		TotalTokens:     snap.AgentTotals.TotalTokens,
-		RuntimeDisplay:  formatDuration(time.Duration(snap.AgentTotals.SecondsRunning * float64(time.Second))),
+		RuntimeDisplay:  FormatDuration(time.Duration(snap.AgentTotals.SecondsRunning * float64(time.Second))),
 		InputTokens:     snap.AgentTotals.InputTokens,
 		OutputTokens:    snap.AgentTotals.OutputTokens,
 		CacheReadTokens: snap.AgentTotals.CacheReadTokens,
@@ -246,8 +246,8 @@ func buildDashboardData(
 		var entryCostStr string
 		if hasRates && e.AgentKind != "" {
 			if rc, ok := tokenRates[e.AgentKind]; ok {
-				if c := estimateCost(e.AgentInputTokens, e.AgentOutputTokens, e.CacheReadTokens, &rc); c != nil {
-					entryCostStr = fmtCost(*c)
+				if c := EstimateCost(e.AgentInputTokens, e.AgentOutputTokens, e.CacheReadTokens, &rc); c != nil {
+					entryCostStr = FormatCost(*c)
 					aggregateCost += *c
 					aggregateCostSet = true
 				}
@@ -258,7 +258,7 @@ func buildDashboardData(
 			Identifier:       displayID,
 			State:            e.State,
 			TurnCount:        e.TurnCount,
-			Duration:         formatDuration(dur),
+			Duration:         FormatDuration(dur),
 			LastEvent:        string(e.LastAgentEvent),
 			TotalTokens:      e.AgentTotalTokens,
 			CacheReadTokens:  e.CacheReadTokens,
@@ -279,7 +279,7 @@ func buildDashboardData(
 		data.EstimatedCostLabel = "Active Est. Cost (USD)"
 	}
 	if aggregateCostSet {
-		s := fmtCost(aggregateCost)
+		s := FormatCost(aggregateCost)
 		data.EstimatedCostUSD = &s
 	}
 
@@ -319,7 +319,7 @@ func mapRunHistoryEntries(runs []RunHistoryEntry) []dashboardRunHistoryEntry {
 		startT, errS := time.Parse(time.RFC3339, r.StartedAt)
 		endT, errE := time.Parse(time.RFC3339, r.CompletedAt)
 		if errS == nil && errE == nil {
-			dur = formatDuration(endT.Sub(startT))
+			dur = FormatDuration(endT.Sub(startT))
 		}
 
 		errMsg := ""

--- a/internal/server/dashboard_test.go
+++ b/internal/server/dashboard_test.go
@@ -519,9 +519,9 @@ func TestFormatDuration(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			got := formatDuration(tt.d)
+			got := FormatDuration(tt.d)
 			if got != tt.want {
-				t.Errorf("formatDuration(%v) = %q, want %q", tt.d, got, tt.want)
+				t.Errorf("FormatDuration(%v) = %q, want %q", tt.d, got, tt.want)
 			}
 		})
 	}
@@ -557,7 +557,7 @@ func TestFormatRelativeTime(t *testing.T) {
 	}
 }
 
-func TestFmtInt(t *testing.T) {
+func TestFormatInt(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -579,9 +579,9 @@ func TestFmtInt(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			got := fmtInt(tt.input)
+			got := FormatInt(tt.input)
 			if got != tt.want {
-				t.Errorf("fmtInt(%d) = %q, want %q", tt.input, got, tt.want)
+				t.Errorf("FormatInt(%d) = %q, want %q", tt.input, got, tt.want)
 			}
 		})
 	}

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -189,7 +189,7 @@ func toStateResponse(snap orchestrator.RuntimeSnapshotResult, tokenRates TokenRa
 				continue
 			}
 			if rc, ok := tokenRates[e.AgentKind]; ok {
-				if c := estimateCost(e.AgentInputTokens, e.AgentOutputTokens, e.CacheReadTokens, &rc); c != nil {
+				if c := EstimateCost(e.AgentInputTokens, e.AgentOutputTokens, e.CacheReadTokens, &rc); c != nil {
 					total += *c
 					anySet = true
 				}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -172,8 +172,8 @@ func New(params Params) *Server {
 
 	tmpl := template.Must(
 		template.New("dashboard").Funcs(template.FuncMap{
-			"fmtInt":  fmtInt,
-			"fmtCost": fmtCost,
+			"fmtInt":  FormatInt,
+			"fmtCost": FormatCost,
 			"even":    func(i int) bool { return i%2 == 0 },
 		}).Parse(dashboardHTML),
 	)

--- a/internal/server/token_rates.go
+++ b/internal/server/token_rates.go
@@ -104,9 +104,9 @@ func extractRate(m map[string]any, key, kind string) (*float64, string) {
 	return &f, ""
 }
 
-// estimateCost computes estimated USD cost from token counts and a rate
+// EstimateCost computes estimated USD cost from token counts and a rate
 // config. Returns nil when rates is nil or all rate fields are nil.
-func estimateCost(input, output, cacheRead int64, rates *TokenRateConfig) *float64 {
+func EstimateCost(input, output, cacheRead int64, rates *TokenRateConfig) *float64 {
 	if rates == nil {
 		return nil
 	}
@@ -133,16 +133,16 @@ func estimateCost(input, output, cacheRead int64, rates *TokenRateConfig) *float
 	return &cost
 }
 
-// fmtCost formats a USD cost value as a string with two decimal places.
+// FormatCost formats a USD cost value as a string with two decimal places.
 // Values >= 1000 receive comma thousand separators (e.g. "$1,234.56").
 // Rounding is performed on the integer-cents representation to avoid
 // float splitting artifacts near boundaries (e.g. 999.999 → "$1,000.00").
-func fmtCost(v float64) string {
+func FormatCost(v float64) string {
 	cents := int64(math.Round(v * 100))
 	dollars := cents / 100
 	remainder := cents % 100
 	if dollars >= 1000 {
-		return fmt.Sprintf("$%s.%02d", fmtInt(dollars), remainder)
+		return fmt.Sprintf("$%s.%02d", FormatInt(dollars), remainder)
 	}
 	return fmt.Sprintf("$%d.%02d", dollars, remainder)
 }

--- a/internal/server/token_rates_test.go
+++ b/internal/server/token_rates_test.go
@@ -252,7 +252,7 @@ func assertRateField(t *testing.T, kind, field string, got, want *float64) {
 	}
 }
 
-// --- estimateCost ---
+// --- EstimateCost ---
 
 func TestEstimateCost(t *testing.T) {
 	t.Parallel()
@@ -335,31 +335,31 @@ func TestEstimateCost(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			got := estimateCost(tt.input, tt.output, tt.cacheRead, tt.rates)
+			got := EstimateCost(tt.input, tt.output, tt.cacheRead, tt.rates)
 
 			if tt.wantNil {
 				if got != nil {
-					t.Errorf("estimateCost = %v, want nil", *got)
+					t.Errorf("EstimateCost = %v, want nil", *got)
 				}
 				return
 			}
 
 			if got == nil {
-				t.Fatal("estimateCost = nil, want non-nil")
+				t.Fatal("EstimateCost = nil, want non-nil")
 			}
 			if math.IsInf(*got, 0) || math.IsNaN(*got) {
-				t.Fatalf("estimateCost = %v, want finite number", *got)
+				t.Fatalf("EstimateCost = %v, want finite number", *got)
 			}
 			if diff := *got - tt.wantResult; diff > 1e-9 || diff < -1e-9 {
-				t.Errorf("estimateCost = %.10f, want %.10f", *got, tt.wantResult)
+				t.Errorf("EstimateCost = %.10f, want %.10f", *got, tt.wantResult)
 			}
 		})
 	}
 }
 
-// --- fmtCost ---
+// --- FormatCost ---
 
-func TestFmtCost(t *testing.T) {
+func TestFormatCost(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -382,9 +382,9 @@ func TestFmtCost(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			got := fmtCost(tt.input)
+			got := FormatCost(tt.input)
 			if got != tt.want {
-				t.Errorf("fmtCost(%v) = %q, want %q", tt.input, got, tt.want)
+				t.Errorf("FormatCost(%v) = %q, want %q", tt.input, got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Feat

**Intent:** `run_history` accumulates one row per completed run and nothing reads it in aggregate, so an operator who wants to know which dispatch rules and prompt templates produce finished work, and at what cost, has to open the SQLite file by hand. This adds a `sortie stats` subcommand that reports those aggregates from data the orchestrator already persists.

**Related Issues:** #274

### 🧭 Reviewer Guide

**Complexity:** Medium

#### Entry Point

`cmd/sortie/stats.go` is where to start. It resolves the workflow's `db_path` and `token_rates`, opens the database read-only, aggregates `internal/persistence.RunStatsRow` values into totals plus four breakdowns (run counts, success rate, p50/p95/mean duration, mean turns, token totals), and renders the result as text or JSON. The breakdowns are keyed on status, agent adapter, rule name, and template ID; the report labels them `by outcome`, `by coding agent`, `by dispatch rule`, and `by prompt template`, because a persisted column name is not something a first-time reader can interpret.

#### Sensitive Areas

- `internal/persistence/run_stats.go`: `RunHistoryCapabilities` reads the live `run_history` column set via `PRAGMA table_info` rather than assuming a fixed schema version, so a database written by an older binary still produces a report instead of failing. `ScanRunHistoryRange` streams rows over the store's single read-only pooled connection - the `visit` callback must not call any other `Store` method or it will deadlock.
- `cmd/sortie/stats.go`: a `ci_failed` row (written by the CI reconcile path) carries no adapter, rule, template, turns, or tokens, and its start and finish timestamps are equal. It is counted in the totals and in every breakdown, falling into the `<none>` bucket of each dimension it lacks, and its zero duration is disclosed by a footnote rather than dropped. So a reader who sees an average move can find out why instead of guessing.
- `cmd/sortie/stats.go`, `cmd/sortie/usage.go`: every string a user reads was written to be readable without knowledge of the schema. No report label, flag description, warning, or footnote names a persisted table or column, or an internal code path; `token_rates` is named deliberately, because it is a key the operator writes in their own workflow and must act on. Breakdown rows go through a `text/tabwriter` so columns align - nothing may be written to the target writer outside `writeStatsRow`, or the alignment breaks. Counted sentences are phrased to read correctly for one and for many, without a pluralization helper.
- `internal/server/*.go`: `fmtInt`, `fmtCost`, `formatDuration`, and `estimateCost` are renamed to exported names (`FormatInt`, `FormatCost`, `FormatDuration`, `EstimateCost`) so `stats.go` reuses the dashboard's cost formula and renderers instead of duplicating them. No behavior change in this package.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes. The renamed `internal/server` helpers were unexported and had no external callers.
- **Migrations/State:** No migrations. The command opens the database read-only through the existing `persistence.OpenReadOnly` path and degrades gracefully against a database missing the token or dispatch-routing columns.

