### PR TITLE
docs: correct reaction contract drift against orchestrator code

### DIFF
--- a/docs/architecture/08-polling-scheduling-and-reconciliation.md
+++ b/docs/architecture/08-polling-scheduling-and-reconciliation.md
@@ -119,7 +119,7 @@ Note:
 
 ### 8.5 Active Run Reconciliation
 
-Reconciliation runs every tick and has four parts.
+Reconciliation runs every tick and has nine parts, run in this order.
 
 Part A: Stall detection
 
@@ -167,7 +167,26 @@ Part D: Review comment reconciliation (when `reactions.review_comments` is confi
   - Otherwise: mark dispatched in `reaction_fingerprints`, cancel existing retry, schedule a
     review-fix dispatch with review comment context, increment `reaction_attempts`.
 
-Part E: Auto-merge reconciliation (when `reactions.auto_merge` is configured)
+Part E: Bot review comment reconciliation (when `reactions.bot_review` is configured)
+
+- Skip entirely when no SCM adapter is configured.
+- Mirrors Part D's reconcile loop for the `bot-review` kind, but with no debounce gate and no
+  `LastEventAt` tracking, and it calls `SCMAdapter.FetchBotReviewComments` (allowlisted bot
+  authors) instead of `FetchPendingReviews`.
+- Dispatches immediately on a confirmed comment set, with no debounce window, because bot
+  comments arrive in bulk on push rather than trickling in from a human reviewer.
+- See Section 11D for the full contract.
+
+Part F: Merge conflict detection (when `reactions.merge_conflicts` is configured)
+
+- Skip entirely when no SCM adapter is configured.
+- For each `pending_reactions` entry with kind `merge-conflict`, call
+  `SCMAdapter.GetMergeability` on every due tick (no retry-budget check gates the read). A
+  dirty result runs the escalation-bearing conflict-resolution path; any other result closes
+  the episode and clears its fingerprint and attempt counter.
+- See Section 11E for the full contract.
+
+Part G: Auto-merge reconciliation (when `reactions.auto_merge` is configured)
 
 Activation gate: `reactions.auto_merge.provider` non-empty AND
 `state.AutoMergePreflightFailed == false`.
@@ -180,9 +199,12 @@ For each entry in `pending_reactions` with kind `merge`:
 
 1. Remove the entry from the `pending_reactions` map.
 2. Drop with a WARN log when `state.AutoMergePreflightFailed == true`.
-3. Drop when the entry has exceeded the configured TTL.
+3. Drop when the entry has exceeded the TTL backstop; the TTL is a fixed internal constant
+   (30 minutes), not operator-configurable.
 4. Re-enqueue when `now < pending.PendingRetryAt`.
-5. Escalate when `reaction_attempts[issue_id:merge] >= MaxRetries`.
+5. Escalate when `MaxRetries > 0` and `reaction_attempts[issue_id:merge] >= MaxRetries`; a
+   configured `MaxRetries` of `0` disables count-based escalation instead of firing it
+   immediately (Section 11C.6).
 6. Fetch mergeability via `SCMAdapter.GetMergeability`; re-enqueue on transport error or
    `MergeabilityUnknown`; re-enqueue with poll interval on `Draft`, `Dirty`, or `Blocked`.
 7. Fetch review decision via `SCMAdapter.GetReviewDecision`; re-enqueue when not `APPROVED`
@@ -205,12 +227,34 @@ Error dispositions:
 - On `ErrSCMConflict` (head SHA mismatch or branch-protection refusal): re-enqueue with
   poll interval; the next tick observes the new SHA via a refreshed fingerprint.
 - On `ErrSCMAuth` on the merge call: escalate immediately (do not re-enqueue).
-- On other transient errors: re-enqueue with backoff; escalate after `MaxRetries`.
+- On other transient errors: re-enqueue with backoff; escalate per the guard in item 5.
 
 Cross-kind isolation: the success and escalation paths MUST scope cleanup to `kind = "merge"`
 only. They MUST NOT mutate `ci` or `review` reaction state (full invariant in §11C.10).
 
-Part E runs after Part D so the precondition reads observe the most current per-kind state.
+Part G runs after Parts C through F (CI, review, bot review, and merge conflict) so its
+precondition reads observe the most current per-kind state. It runs before the label-command
+passes (Parts H and I); that relative order does not affect correctness because those passes
+are fully cross-kind isolated (Section 11F.4).
+
+Part H: Label review command detection (when `reactions.label_commands.review_label` is
+configured)
+
+- Skip entirely when no SCM adapter is configured or the `label_commands` block is absent.
+- For each Sortie-managed PR, read the label-event journal past its stored high-water mark via
+  `SCMAdapter.ListLabelEvents`; a confirmed `review_label` command dispatches a read-only,
+  no-clone review session and removes the label.
+- Ordering relative to the other parts does not affect correctness: the pass is fully
+  cross-kind isolated. See Section 11F for the full contract.
+
+Part I: Label fix command detection (when `reactions.label_commands.fix_label` is configured)
+
+- Structurally identical to Part H, scoped to the `fix_label` command and the `label-fix`
+  reaction kind.
+- A confirmed command dispatches a read-write, clone-and-checkout fix session instead of the
+  read-only review session.
+- Ordering relative to the other parts does not affect correctness: the pass is fully
+  cross-kind isolated. See Section 11F for the full contract.
 
 ### 8.6 Startup Terminal Workspace Cleanup
 

--- a/docs/architecture/08-polling-scheduling-and-reconciliation.md
+++ b/docs/architecture/08-polling-scheduling-and-reconciliation.md
@@ -141,10 +141,14 @@ Part B: Tracker state refresh
 Part C: CI status reconciliation (when `ci_feedback.kind` or `reactions.ci_failure` is configured)
 
 - For each entry in `pending_reactions` with kind `ci`:
+  - Deduplicate before fetching: a stored fingerprint equal to the current ref and already
+    marked dispatched drops the entry for this pass (§11A.5).
   - Call `CIStatusProvider.FetchCIStatus` with the SCM ref (SHA preferred, branch as fallback).
-  - If the call fails: log a warning, re-enqueue the entry, and continue to the next entry.
-  - If status is `passing`: clear reaction attempts for the issue and kind.
-  - If status is `pending`: re-enqueue the entry for the next tick.
+  - If the call fails: log a warning, re-enqueue with an exponential backoff delay derived from
+    the poll interval and the pending attempt count, and continue to the next entry.
+  - If status is `passing`: clear reaction attempts for the issue and kind, and delete the
+    fingerprint row.
+  - If status is `pending`: re-enqueue with the same exponential backoff as the fetch-error path.
   - If status is `failing`: handle as a CI failure (see Section 7.3, "CI Status Failing").
 
 Part D: Review comment reconciliation (when `reactions.review_comments` is configured)

--- a/docs/architecture/08-polling-scheduling-and-reconciliation.md
+++ b/docs/architecture/08-polling-scheduling-and-reconciliation.md
@@ -162,7 +162,8 @@ Part D: Review comment reconciliation (when `reactions.review_comments` is confi
   - Filter out outdated comments. Compute max timestamp for debounce gating.
   - If no actionable comments: re-enqueue with poll interval delay.
   - Build fingerprint from sorted non-outdated comment IDs (SHA-256 hash).
-  - Check `reaction_fingerprints` table: if fingerprint matches and is marked dispatched, skip.
+  - Check `reaction_fingerprints` table: if the fingerprint matches and is marked dispatched,
+    re-enqueue with the poll interval delay and continue.
   - If within debounce window (`now - LastEventAt < debounce_ms`): defer and re-enqueue.
   - Otherwise: cancel existing retry, schedule a review-fix dispatch with review comment
     context, increment `reaction_attempts`. The fingerprint is marked dispatched later, when

--- a/docs/architecture/08-polling-scheduling-and-reconciliation.md
+++ b/docs/architecture/08-polling-scheduling-and-reconciliation.md
@@ -164,8 +164,9 @@ Part D: Review comment reconciliation (when `reactions.review_comments` is confi
   - Build fingerprint from sorted non-outdated comment IDs (SHA-256 hash).
   - Check `reaction_fingerprints` table: if fingerprint matches and is marked dispatched, skip.
   - If within debounce window (`now - LastEventAt < debounce_ms`): defer and re-enqueue.
-  - Otherwise: mark dispatched in `reaction_fingerprints`, cancel existing retry, schedule a
-    review-fix dispatch with review comment context, increment `reaction_attempts`.
+  - Otherwise: cancel existing retry, schedule a review-fix dispatch with review comment
+    context, increment `reaction_attempts`. The fingerprint is marked dispatched later, when
+    the scheduled retry fires and dispatch succeeds, not during this pass.
 
 Part E: Bot review comment reconciliation (when `reactions.bot_review` is configured)
 

--- a/docs/architecture/08-polling-scheduling-and-reconciliation.md
+++ b/docs/architecture/08-polling-scheduling-and-reconciliation.md
@@ -228,6 +228,8 @@ Error dispositions:
 - On `ErrSCMConflict` (head SHA mismatch or branch-protection refusal): re-enqueue with
   poll interval; the next tick observes the new SHA via a refreshed fingerprint.
 - On `ErrSCMAuth` on the merge call: escalate immediately (do not re-enqueue).
+- On `ErrSCMPayload` on the merge call: escalate immediately (do not re-enqueue), the same
+  disposition as `ErrSCMAuth`.
 - On other transient errors: re-enqueue with backoff; escalate per the guard in item 5.
 
 Cross-kind isolation: the success and escalation paths MUST scope cleanup to `kind = "merge"`

--- a/docs/architecture/12-ci-feedback-contract.md
+++ b/docs/architecture/12-ci-feedback-contract.md
@@ -106,10 +106,12 @@ state refresh. The flow is:
    b. Determine the ref (SHA preferred, branch as fallback) and apply fingerprint deduplication
       (Section 11A.5). Entries already dispatched for this exact ref are dropped for this tick.
    c. Call `CIStatusProvider.FetchCIStatus` with the ref.
-   d. On fetch error: re-enqueue the entry; continue.
+   d. On fetch error: re-enqueue the entry with an exponential backoff delay derived from the
+      poll interval and the pending attempt count; continue.
    e. On `passing`: clear `reaction_attempts` for the issue and kind, and delete the fingerprint
       row.
-   f. On `pending`: re-enqueue the entry.
+   f. On `pending`: re-enqueue the entry with the same exponential backoff as the fetch-error
+      path.
    g. On `failing`: handle CI failure (see Section 11A.6).
 
 ### 11A.5 Fingerprint and deduplication

--- a/docs/architecture/12-ci-feedback-contract.md
+++ b/docs/architecture/12-ci-feedback-contract.md
@@ -103,19 +103,47 @@ state refresh. The flow is:
    (no `CIStatusProvider` constructed).
 2. For each entry in `pending_reactions` with kind `ci`:
    a. Remove the entry from the map (prevents reprocessing within the same tick).
-   b. Call `CIStatusProvider.FetchCIStatus` with the SCM ref (SHA preferred, branch as fallback).
-   c. On fetch error: re-enqueue the entry; continue.
-   d. On `passing`: clear `reaction_attempts` for the issue and kind.
-   e. On `pending`: re-enqueue the entry.
-   f. On `failing`: handle CI failure (see Section 11A.5).
+   b. Determine the ref (SHA preferred, branch as fallback) and apply fingerprint deduplication
+      (Section 11A.5). Entries already dispatched for this exact ref are dropped for this tick.
+   c. Call `CIStatusProvider.FetchCIStatus` with the ref.
+   d. On fetch error: re-enqueue the entry; continue.
+   e. On `passing`: clear `reaction_attempts` for the issue and kind, and delete the fingerprint
+      row.
+   f. On `pending`: re-enqueue the entry.
+   g. On `failing`: handle CI failure (see Section 11A.6).
 
-### 11A.5 CI failure handling
+### 11A.5 Fingerprint and deduplication
+
+Before calling `FetchCIStatus`, the reconcile pass deduplicates against the same ref. The
+fingerprint value is the ref itself (`CIReactionData.SHA`, falling back to `CIReactionData.Branch`),
+the identical string passed to the status fetch. Unlike the merge-conflict (Section 11E.4) and
+review (Section 11B.7) fingerprints, which each hash their input with SHA-256, the CI fingerprint
+is stored as the raw ref string with no hashing.
+
+The pass upserts the ref into `reaction_fingerprints` (kind `ci`) and reads the row back. The
+upsert resets `dispatched` to false whenever the stored fingerprint differs from the ref being
+upserted, so a new SHA (or a branch ref that has moved to a new SHA) always re-arms the entry for a
+fresh CI-fix dispatch. When the read-back fingerprint matches the current ref and `dispatched` is
+already true, the entry is dropped for this tick rather than re-enqueued: CI status is not polled
+again for that ref until a later worker exit or startup recovery creates a new pending entry.
+Fingerprint read or write errors are logged and treated as non-fatal; the pass proceeds to
+`FetchCIStatus` without dedup rather than dropping the entry.
+
+The `dispatched` flag is not set anywhere in this reconcile pass. `handleCIFailure` (Section 11A.6)
+schedules the CI-fix continuation through the shared retry machinery with `ReactionKind` set to
+`ci`; the flag is marked only once that continuation retry actually fires and dispatches, in the
+shared retry-dispatch path, not in the CI reconcile pass itself.
+
+The fingerprint row is deleted, not merely left stale, when the episode closes: on a `passing`
+result (Section 11A.4) and during escalation (Section 11A.7).
+
+### 11A.6 CI failure handling
 
 When CI status is `failing`:
 
 1. Persist a CI-failure run history entry (`status: ci_failed`).
 2. Increment `reaction_attempts[issue_id:ci]`.
-3. If `reaction_attempts[issue_id:ci]` exceeds `ci_feedback.max_retries`: escalate (Section 11A.6).
+3. If `reaction_attempts[issue_id:ci]` exceeds `ci_feedback.max_retries`: escalate (Section 11A.7).
 4. Otherwise:
    a. Convert `CIResult` to a template map via `ToTemplateMap()`.
    b. Cancel the existing continuation retry for the issue.
@@ -126,7 +154,7 @@ When CI status is `failing`:
 CI-fix dispatches count toward the regular retry machinery but use a fixed delay rather than
 exponential backoff.
 
-### 11A.6 Escalation behavior
+### 11A.7 Escalation behavior
 
 When `reaction_attempts[issue_id:ci]` exceeds `ci_feedback.max_retries`:
 
@@ -143,11 +171,12 @@ After escalation:
 - Delete the persisted retry entry from SQLite.
 - Release the claim (`delete claimed[issue_id]`).
 - Clear all `reaction_attempts` and `pending_reactions` entries for the issue.
+- Delete the reaction fingerprint row for kind `ci`.
 
 Escalation failures are logged and counted (`sortie_ci_escalations_total{action="error"}`) but do
 not block claim release.
 
-### 11A.7 Adapter registration
+### 11A.8 Adapter registration
 
 CI status providers register via the CI provider registry using `init()` functions, following the
 same pattern as tracker and agent adapters:

--- a/docs/architecture/12-ci-feedback-contract.md
+++ b/docs/architecture/12-ci-feedback-contract.md
@@ -126,8 +126,10 @@ upserted, so a new SHA (or a branch ref that has moved to a new SHA) always re-a
 fresh CI-fix dispatch. When the read-back fingerprint matches the current ref and `dispatched` is
 already true, the entry is dropped for this tick rather than re-enqueued: CI status is not polled
 again for that ref until a later worker exit or startup recovery creates a new pending entry.
-Fingerprint read or write errors are logged and treated as non-fatal; the pass proceeds to
-`FetchCIStatus` without dedup rather than dropping the entry.
+Fingerprint errors are logged and treated as non-fatal, but the two directions differ. A failed
+upsert does not disable dedup: the read-back still runs, so a stored row matching the current ref
+and already marked dispatched still drops the entry. Only a failed read-back skips dedup entirely,
+and the pass then proceeds to `FetchCIStatus` rather than dropping the entry.
 
 The `dispatched` flag is not set anywhere in this reconcile pass. `handleCIFailure` (Section 11A.6)
 schedules the CI-fix continuation through the shared retry machinery with `ReactionKind` set to

--- a/docs/architecture/13-pr-review-comment-feedback-contract.md
+++ b/docs/architecture/13-pr-review-comment-feedback-contract.md
@@ -100,11 +100,11 @@ CI status reconciliation. The flow is:
       matches and is marked dispatched: skip, re-enqueue with poll interval delay.
    j. If `now - LastEventAt < debounce_ms`: set `PendingRetryAt = LastEventAt + debounce_ms`,
       re-enqueue.
-   k. Mark dispatched in `reaction_fingerprints` synchronously (prevents duplicate dispatch on
-      entry recreation by concurrent worker exit).
-   l. Cancel existing retry for the issue.
-   m. Schedule review-fix dispatch with `ContinuationContext{"review_comments": [...]}`.
-   n. Increment `reaction_attempts[issue_id:review]`.
+   k. Cancel existing retry for the issue.
+   l. Schedule review-fix dispatch with `ContinuationContext{"review_comments": [...]}`.
+   m. Increment `reaction_attempts[issue_id:review]`.
+   n. The fingerprint is marked dispatched in `reaction_fingerprints` later, in
+      `HandleRetryTimer`, after the scheduled retry fires and dispatch succeeds.
 
 ### 11B.5 Review comment handling
 
@@ -189,9 +189,9 @@ provider match.
 
 Review comment reconciliation only processes PRs created by Sortie:
 
-1. `SCMMetadata.pr_number > 0` — only workspaces where the agent created a PR have this field.
-   Since `.sortie/scm.json` is written by the agent inside a Sortie-managed workspace, this is
-   inherently scoped.
+1. An entry is created only when `SCMMetadata` reports `pr_number > 0` and non-empty `owner`,
+   `repo`, and `branch`. Since `.sortie/scm.json` is written by the agent inside a Sortie-managed
+   workspace, this is inherently scoped.
 2. Runtime scope: review polling processes entries in `pending_reactions`. Normal worker exit can
   create those entries while the issue is still claimed, and startup recovery can recreate them for
   recent handoff-stage issues after the claim has been released.

--- a/docs/architecture/14-auto-merge-reaction-contract.md
+++ b/docs/architecture/14-auto-merge-reaction-contract.md
@@ -2,9 +2,11 @@
 
 The auto-merge reaction is default-off; enablement requires `reactions.auto_merge.provider` to be
 non-empty in `WORKFLOW.md`. The merge operation is irreversible: the orchestrator does NOT roll back
-on partial-failure tail operations (branch delete, tracker comment). The reaction runs as the last
-reconcile pass in the tick (after CI and review-comment reconciliation) so the precondition reads
-observe the most current per-kind state.
+on partial-failure tail operations (branch delete, tracker comment). The reaction runs after the CI,
+review-comment, bot-review-comment, and merge-conflict reconcile passes in the tick, so the
+precondition reads observe the most current per-kind state; it runs before the label-review and
+label-fix passes, whose relative ordering does not affect correctness because each of those two is
+fully cross-kind isolated.
 
 ### 11C.1 SCMAdapter write surface
 
@@ -58,7 +60,7 @@ observes the new SHA via a refreshed fingerprint. The full disposition table is 
 
 ### 11C.4 Reconcile loop integration
 
-The auto-merge reconcile loop runs as Part E of active run reconciliation (see §8.5 Part E for
+The auto-merge reconcile loop runs as Part G of active run reconciliation (see §8.5 Part G for
 the algorithm). The loop processes entries from `pending_reactions` whose kind discriminator is
 `"merge"`.
 
@@ -90,6 +92,7 @@ The auto-merge reconcile loop evaluates the merge preconditions reported by `Get
 | Merging | `ErrSCMConflict` ("already merged") | Done | Treat as idempotent success; same actions as merge succeeded. |
 | Merging | `ErrSCMConflict` (head SHA mismatch) | Pending | Re-enqueue with poll interval; next tick refreshes fingerprint. |
 | Merging | `ErrSCMAuth` | Escalated | Escalate immediately; do not re-enqueue. |
+| Merging | `ErrSCMPayload` | Escalated | Escalate immediately; do not re-enqueue. |
 | Merging | Other transient error | Pending | Re-enqueue with backoff; escalate after `MaxRetries`. |
 
 **Gitea auto-merge reads.** The Gitea adapter has no aggregate review-decision field and no
@@ -104,9 +107,22 @@ interval as a transient state.
 
 ### 11C.6 Escalation behavior
 
-When `reaction_attempts[issue_id:merge] >= MaxRetries` or when `ErrSCMAuth` is returned on
-`MergePR`, the orchestrator escalates the issue. Two escalation postures are available, set by
-the operator in `WORKFLOW.md`:
+The count-based escalation check guards the comparison with `MaxRetries > 0`: the orchestrator
+escalates the issue when `MaxRetries > 0` and `reaction_attempts[issue_id:merge] >= MaxRetries`,
+or immediately when `ErrSCMAuth` or `ErrSCMPayload` is returned on `MergePR` (both paths invoke
+the escalation directly, bypassing the `MaxRetries` check). `MaxRetries` defaults to `2`.
+
+A configured `MaxRetries` of `0` disables count-based escalation rather than triggering it on the
+first attempt: the `> 0` guard keeps the comparison false no matter how large
+`reaction_attempts[issue_id:merge]` grows, so a `merge`-kind entry with no retry budget keeps
+retrying transient failures instead of escalating on them. This is the opposite of the sibling
+merge-conflict reaction, whose comparison (`attempts > MaxRetries`, §11E.5) carries no such guard,
+so a merge-conflict `MaxRetries` of `0` escalates on the first conflict detection (§11E.8). The
+same `0` literal therefore carries two incompatible meanings across these two adjacent
+`WORKFLOW.md` configuration blocks. An `ErrSCMAuth` or `ErrSCMPayload` failure still escalates
+immediately regardless of the configured `MaxRetries`, including when it is `0`.
+
+Two escalation postures are available, set by the operator in `WORKFLOW.md`:
 
 - `label`: applies the `needs-human` label to the tracker issue via `TrackerAdapter.AddLabel`.
   This is the default posture.

--- a/docs/architecture/14-auto-merge-reaction-contract.md
+++ b/docs/architecture/14-auto-merge-reaction-contract.md
@@ -93,7 +93,7 @@ The auto-merge reconcile loop evaluates the merge preconditions reported by `Get
 | Merging | `ErrSCMConflict` (head SHA mismatch) | Pending | Re-enqueue with poll interval; next tick refreshes fingerprint. |
 | Merging | `ErrSCMAuth` | Escalated | Escalate immediately; do not re-enqueue. |
 | Merging | `ErrSCMPayload` | Escalated | Escalate immediately; do not re-enqueue. |
-| Merging | Other transient error | Pending | Re-enqueue with backoff; escalate after `MaxRetries`. |
+| Merging | Other transient error | Pending | Re-enqueue with backoff; escalate on a later tick when `MaxRetries > 0` and the attempt count reaches it (§11C.6). |
 
 **Gitea auto-merge reads.** The Gitea adapter has no aggregate review-decision field and no
 `mergeable_state` string, so it composes both preconditions itself. `GetReviewDecision` folds the


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Docs

**Intent:** Bring the reaction contracts and the active run reconciliation section back in line with what the orchestrator actually does. The specification is the contract implementation work is expected to follow, so a section that describes a guarantee the code does not provide, or omits half the reconcile passes, becomes tomorrow's defect rather than a cosmetic blemish. Every corrected claim was verified against the code before the wording changed.

### 🧭 Reviewer Guide

**Complexity:** Medium

Documentation only, but the largest change re-letters a lettered list that other documents cross-reference, so the review is about reference integrity as much as prose.

#### Entry Point

`docs/architecture/08-polling-scheduling-and-reconciliation.md` - the active run reconciliation section listed five of the nine reconcile passes that `ReconcileRunningIssues` runs. Bot review, merge conflict detection, and both label command passes appeared nowhere, and the intro line claimed four parts while listing five. The four missing passes are restored in their true positions with a pointer to the contract that owns each, rather than a restatement of it.

The remaining three files are smaller corrections of the same class:

- `docs/architecture/14-auto-merge-reaction-contract.md`: the escalation rule was stated without the `MaxRetries > 0` guard, so the document promised that a zero retry budget escalates on the first attempt when the code does the opposite and switches count-based escalation off. The sibling merge-conflict reaction reads the same field with the opposite meaning, which the corrected text now says outright. Adds the missing error-table row for the payload class, which escalates immediately without consuming retries.
- `docs/architecture/13-pr-review-comment-feedback-contract.md`: removes a step claiming the fingerprint is marked dispatched synchronously to prevent duplicate dispatch. No such write exists in the review reconcile pass; the mark happens later, after the scheduled retry actually dispatches. The correction states where the mark happens and makes no claim about whether a duplicate dispatch is possible, because that was not established.
- `docs/architecture/12-ci-feedback-contract.md`: documents the deduplication step the CI pass performs but the contract never mentioned, including that this kind stores a plain ref where its siblings store a digest.

#### Sensitive Areas

- `docs/architecture/08-polling-scheduling-and-reconciliation.md`: inserting the four missing passes shifted the part letters, moving auto-merge from Part E to Part G. The cross-reference in the auto-merge contract was updated to match. The references from the CI and review contracts point at Parts C and D and are unaffected, and no other document or site page references these letters.
- `docs/architecture/14-auto-merge-reaction-contract.md`: the zero-budget paragraph is the one place where a reader could be led to configure a value that silently disables escalation. Worth confirming against the guard in `internal/orchestrator/auto_merge_reconcile.go` and against the sibling comparison in `internal/orchestrator/merge_conflict_reconcile.go`.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes
- **Migrations/State:** No migrations or state changes

The public documentation site carries a companion correction to the same zero-budget claim. That page lives in the separate documentation repository and is not part of this pull request.