### PR TITLE
feat: bound workspace retention by age

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   database can supply and warns which ones are missing, rather than
   failing outright.
   ([#274](https://github.com/sortie-ai/sortie/issues/274))
+- `workspace.retention_days`: an opt-in age bound that removes a swept
+  workspace whose latest recorded activity is older than the configured
+  window, independently of tracker state. Off by default (`0`); the
+  smallest permitted non-zero value is 30 days, matching the window
+  pending-reaction recovery honors after a restart, so a workspace the
+  bound removes is always one recovery would already treat as stale. The
+  periodic sweep now emits one summary record per pass, whether or not
+  it removed anything, reporting how many workspaces were excluded as
+  in-flight, removed as terminal, removed by age, retained inside the
+  window, retained for want of an activity record, or not yet evaluated.
+  ([#706](https://github.com/sortie-ai/sortie/issues/706))
+
+### Changed
+
+- A terminal issue whose pull request still carries a pending
+  `sortie:review` or `sortie:fix` label-command entry is now cleaned up
+  by the periodic workspace sweep like any other terminal issue, instead
+  of being retained forever. This reaches every deployment on upgrade
+  without an opt-in: previously, a pending label-command entry excluded
+  its workspace from cleanup even after the linked issue reached a
+  terminal tracker state; the label-command detection loop is unaffected
+  by the change, since it reads nothing from the workspace directory.
+  ([#706](https://github.com/sortie-ai/sortie/issues/706))
 
 ## [1.17.0] - 2026-08-06
 

--- a/cmd/sortie/validate_test.go
+++ b/cmd/sortie/validate_test.go
@@ -1834,6 +1834,51 @@ func TestValidateDispatch_ValidRulesPassThrough(t *testing.T) {
 	}
 }
 
+// TestValidateWorkspaceRetentionDaysOutOfRange covers R3: an out-of-range
+// workspace.retention_days value is reported as an error diagnostic with
+// check name config.workspace.retention_days, offline (the file tracker
+// makes no network call).
+func TestValidateWorkspaceRetentionDaysOutOfRange(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	content := []byte("---\n" +
+		"polling:\n  interval_ms: 30000\n" +
+		"tracker:\n  kind: file\n  active_states: [\"To Do\"]\n  terminal_states: [\"Done\"]\n" +
+		"agent:\n  kind: mock\n" +
+		"file:\n  path: issues.json\n" +
+		"workspace:\n  retention_days: 7\n" +
+		"---\nDo {{ .issue.title }}.\n")
+	wfPath := writeCustomWorkflowFile(t, dir, content)
+
+	var stdout, stderr bytes.Buffer
+	ctx := context.Background()
+
+	code := run(ctx, []string{"validate", "--format", "json", wfPath}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("run(validate) = %d, want 1; stderr: %s", code, stderr.String())
+	}
+
+	var out validateOutput
+	if err := json.Unmarshal(stdout.Bytes(), &out); err != nil {
+		t.Fatalf("json.Unmarshal(%q) error: %v", stdout.String(), err)
+	}
+	if out.Valid {
+		t.Errorf("validateOutput.Valid = true, want false")
+	}
+
+	found := false
+	for _, d := range out.Errors {
+		if d.Check == "config.workspace.retention_days" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("validateOutput.Errors = %v, want a diagnostic with check %q", out.Errors, "config.workspace.retention_days")
+	}
+}
+
 func TestValidateDispatch_ConfigErrorRouting(t *testing.T) {
 	t.Parallel()
 

--- a/docs/architecture/06-configuration-specification.md
+++ b/docs/architecture/06-configuration-specification.md
@@ -176,6 +176,13 @@ This section is intentionally redundant so a coding agent can implement the conf
   a validation advisory (`api_version: "2"`); supports `$VAR`
 - `polling.interval_ms`: integer, default `30000`
 - `workspace.root`: path, default `<system-temp>/sortie_workspaces`
+- `workspace.retention_days`: integer, default `0` (disabled); the maximum age in days of a swept
+  workspace's latest recorded activity before the periodic sweep removes it; `0` disables the
+  bound, a value from `1` to `29` is rejected, and `30` (`WorkspaceRetentionMinDays`) is the
+  smallest permitted non-zero value; expressed in days rather than milliseconds because every
+  other duration field is a sub-hour timing where the millisecond unit is proportionate to the
+  value, while a thirty-day window in milliseconds is unreadable and a dropped digit is
+  destructive; supports the `SORTIE_WORKSPACE_RETENTION_DAYS` environment override
 - `worker.ssh_hosts` (extension): list of SSH host strings, optional; when omitted, work runs
   locally
 - `worker.max_concurrent_agents_per_host` (extension): positive integer, optional; shared per-host

--- a/docs/architecture/08-polling-scheduling-and-reconciliation.md
+++ b/docs/architecture/08-polling-scheduling-and-reconciliation.md
@@ -112,10 +112,17 @@ Per-issue token budget (cost ceiling):
 
 Note:
 
-- Terminal-state workspace cleanup is handled by startup cleanup and active-run reconciliation
-  (including terminal transitions for currently running issues).
+- Terminal-state workspace cleanup is handled by three paths: startup cleanup, active-run
+  reconciliation (including terminal transitions for currently running issues), and the periodic
+  workspace sweep described below.
 - Retry handling mainly operates on active candidates and releases claims when the issue is absent,
   rather than performing terminal cleanup itself.
+- Within one periodic sweep pass, the terminal check always runs before the age bound (see
+  `workspace.retention_days` in the configuration specification), and a key the terminal check
+  removes is never re-evaluated by the age bound on that same pass. The age bound needs no answer
+  from the tracker: it is evaluated from the workspace listing and the persistence layer alone, so
+  it runs whether or not the tracker state read for that pass succeeded, and it still evaluates and
+  can remove eligible workspaces on a pass where that read failed.
 
 ### 8.5 Active Run Reconciliation
 

--- a/docs/architecture/09-workspace-management-and-safety.md
+++ b/docs/architecture/09-workspace-management-and-safety.md
@@ -16,6 +16,28 @@ Workspace persistence:
 - Workspaces are reused across runs for the same issue.
 - Successful runs do not auto-delete workspaces.
 
+Workspace cleanup runs through two mechanisms, ordered and non-overlapping in intent:
+
+- **The terminal gate** is the primary mechanism. It is always on and unconditional: whenever the
+  tracker reports an issue's state as a member of `tracker.terminal_states`, the workspace for that
+  issue is removed, whether that gate fires from startup cleanup, active-run reconciliation, or the
+  periodic sweep.
+- **The age bound** is a backstop for the population the terminal gate can never reach: an issue
+  parked in the workflow's handoff state with no external automation advancing it, an issue left
+  active after a permanent failure, an issue moved to a state the configuration does not name, or
+  an issue deleted from the tracker entirely. It is opt-in and off by default, configured by
+  `workspace.retention_days`, and evaluated only by the periodic sweep. A workspace is removable by
+  age when its latest recorded activity is older than the configured window. That activity is
+  anchored on the later of two timestamps: the most recent `completed_at` recorded in the run
+  history for the workspace's identifier, and the `pushed_at` value recorded in the workspace's
+  `.sortie/scm.json`. A workspace with neither a parseable completion nor a parseable recorded push
+  is retained regardless of how long it has sat on disk: absence of a record is absence of
+  evidence, not evidence of age.
+
+The age bound never fires on a workspace the terminal gate would have removed on the same pass,
+because the terminal check runs first. It applies only to the periodic sweep, not to startup
+cleanup or active-run reconciliation; see the polling and reconciliation material for why.
+
 ### 9.2 Workspace Creation and Reuse
 
 Input: `issue.identifier`
@@ -158,4 +180,19 @@ Invariant 3: Workspace key is sanitized.
 
 - Only `[A-Za-z0-9._-]` allowed in workspace directory names.
 - Replace all other characters with `_`.
+
+Invariant 4: A workspace key held by an entry in the running map or the retry map is never removed
+by the age bound, whatever its age. These exclusions are absolute; the age bound does not weaken
+them.
+
+Invariant 5: `workspace.retention_days` cannot be configured below its floor, and that floor in
+days equals the pending-reaction recovery lookback in days. Any workspace the age bound may remove
+is one that pending reaction recovery would already have skipped as stale, so removing it cannot
+silently break recovery for an issue recovery still regards as live.
+
+Invariant 6: The age bound performs no tracker write, no source-control write, no reaction
+fingerprint write, and no creation or deletion of a pending reaction entry. Reaction state is
+read-only to the age bound. Every removal it performs routes through the same workspace removal
+path as the terminal gate, so key sanitization, containment under the workspace root, and the
+`before_remove` hook apply unchanged. The age bound introduces no new way to reach the filesystem.
 

--- a/docs/architecture/18-logging-status-and-observability.md
+++ b/docs/architecture/18-logging-status-and-observability.md
@@ -18,6 +18,28 @@ Message formatting requirements:
 - Include concise failure reason when present.
 - Avoid logging large raw payloads unless necessary.
 
+The periodic workspace sweep emits exactly one summary record per pass, at `Info` level, message
+`"sweep: pass complete"`, on every pass that produced a candidate set, including a pass over zero
+keys, a pass whose tracker read failed, and a pass that removed nothing. This is deliberate: a
+sweep that finds nothing to remove and says nothing is indistinguishable from a sweep that is not
+running at all, which is the failure mode this record exists to close. The record carries thirteen
+attributes:
+
+- `candidates`, `excluded_running`, `excluded_retry`, `excluded_reaction`, `removed_terminal`,
+  `removed_age`, `retained_in_window`, `retained_no_activity`, `retained_not_evaluated`, and
+  `failed` are integer counts. The nine counters after `candidates` partition the candidate set, so
+  `candidates` equals their sum on every pass; `retained_not_evaluated` is what makes that identity
+  hold on a pass where the age bound did not evaluate anything.
+- `retention_days` is the configured `workspace.retention_days` value for that pass; `0` means the
+  bound is off.
+- `age_pass` is `"on"` when the age bound evaluated its candidates that pass, `"off"` when
+  `retention_days` is `0` or below the floor (`WorkspaceRetentionMinDays`), and `"unavailable"`
+  when the persistence read is not configured or its query failed.
+- `tracker_read` is `"ok"` or `"failed"`.
+
+Each workspace removed by the age bound also emits its own `Info` record, message `"sweep:
+removed expired workspace"`, carrying `workspace_key`, `last_activity` (RFC3339), and `age_days`.
+
 ### 13.2 Logging Outputs and Sinks
 
 Sortie does not prescribe where logs must go (stderr, file, remote sink, etc.).
@@ -320,7 +342,7 @@ Defined metrics (label sets and buckets are specified here; see ADR-0008 for his
 | `sortie_dispatches_total{outcome}` | Counter | Dispatch attempts, partitioned by outcome (`success`, `error`). |
 | `sortie_worker_exits_total{exit_type}` | Counter | Worker exits, partitioned by exit type (`normal`, `error`, `cancelled`). |
 | `sortie_retries_total{trigger}` | Counter | Retry schedule events, partitioned by trigger (`error`, `continuation`, `timer`, `stall`). |
-| `sortie_reconciliation_actions_total{action}` | Counter | Reconciliation outcomes per issue, partitioned by action (`stop`, `cleanup`, `keep`). |
+| `sortie_reconciliation_actions_total{action}` | Counter | Reconciliation outcomes per issue, partitioned by action (`stop`, `cleanup`, `keep`, `sweep_cleanup`, `sweep_expired`). |
 | `sortie_poll_cycles_total{result}` | Counter | Poll tick completions, partitioned by result (`success`, `error`, `skipped`). |
 | `sortie_tracker_requests_total{operation,result}` | Counter | Tracker adapter API calls, partitioned by operation (`fetch_candidates`, `fetch_issue`, `fetch_by_states`, `fetch_states_by_ids`, `fetch_states_by_identifiers`, `fetch_comments`, `transition`) and result (`success`, `error`). |
 | `sortie_tracker_comments_total{lifecycle,result}` | Counter | Tracker comment attempts, partitioned by lifecycle point (`dispatch`, `completion`, `failure`) and result (`success`, `error`). |

--- a/docs/architecture/19-failure-model-and-recovery-strategy.md
+++ b/docs/architecture/19-failure-model-and-recovery-strategy.md
@@ -75,6 +75,15 @@ Sortie uses SQLite persistence to improve restart recovery semantics:
 - Running sessions are not recoverable (agent subprocesses do not survive restart), but the
   orchestrator knows which issues were in-flight at shutdown and re-dispatches them immediately
   rather than waiting for the next polling cycle to discover them.
+- Pending reaction recovery reconstructs runtime reaction entries after a restart by reading each
+  candidate's workspace SCM metadata, and it considers only a candidate whose latest activity
+  falls inside its lookback window. `workspace.retention_days` and this recovery lookback are
+  coupled: the retention floor (`WorkspaceRetentionMinDays`) in days equals the recovery lookback
+  in days, so any workspace the periodic sweep's age bound is permitted to remove is one recovery
+  would already have skipped as stale. Changing either window without the other reintroduces the
+  defect the coupling prevents. A shorter retention floor would let the age bound remove a
+  workspace recovery still regards as live, silently breaking reaction recovery for that issue
+  after a restart.
 
 ### 14.4 Operator Intervention Points
 

--- a/docs/architecture/23-implementation-checklist.md
+++ b/docs/architecture/23-implementation-checklist.md
@@ -28,7 +28,7 @@ Use the same validation profiles as Section 17:
 - Exponential retry queue with continuation retries after normal exit
 - Configurable retry backoff cap (`agent.max_retry_backoff_ms`, default 5m)
 - Reconciliation that stops runs on terminal/non-active tracker states
-- Workspace cleanup for terminal issues (startup sweep + active transition)
+- Workspace cleanup for terminal issues (startup sweep + active transition + periodic sweep)
 - Structured logs with `issue_id`, `issue_identifier`, and `session_id`
 - Operator-visible observability (structured logs; optional snapshot/status surface)
 

--- a/docs/architecture/28-label-command-and-read-only-review-contract.md
+++ b/docs/architecture/28-label-command-and-read-only-review-contract.md
@@ -220,9 +220,12 @@ no branch. The read-only posture supplies exactly that:
 - **Scratch workspace, no hooks.** The session obtains a minimal per-issue scratch directory,
   containment-validated under the workspace root exactly as a normal dispatch (§9.6), but the
   operator `after_create`, `before_run`, and `after_run` hooks do not run. There is no clone, no
-  build, no branch, and no checkout. Because the directory is the reused per-issue workspace, a stale
-  `.sortie/status` from a prior session is cleared best-effort after creation so it cannot end the
-  review on turn one.
+  build, no branch, and no checkout. The directory is the per-issue workspace reused from an
+  earlier session when one still exists on disk, but its presence is not guaranteed: the periodic
+  sweep's age bound may have removed it since the pending entry was seeded (§11F.9). When absent,
+  the dispatch recreates the directory rather than fail, the same recreate step every dispatch
+  posture takes. Because the directory may carry state from a prior session, a stale
+  `.sortie/status` is cleared best-effort after creation so it cannot end the review on turn one.
 - **Fresh session.** The session starts with no resume identifier. It is a new session, not a
   continuation of a live one.
 - **Single selecting flag.** The posture is selected by one worker flag derived from the dispatch
@@ -400,6 +403,14 @@ restart (the journal is durable) for either command. The persisted mark is read 
 When the linked issue reaches a terminal state the reaction state is cleared with the rest of the
 issue's reactions by the issue-wide reaction cleanup, which removes the pending entry and the
 fingerprint row by issue id across every kind. Commands on such PRs are ignored thereafter.
+
+A pending `label-review` or `label-fix` entry no longer excludes its workspace from periodic-sweep
+candidacy, because neither kind carries an expiry. Detection is unaffected by that
+narrowing: the label-command reconcile pass polls the forge's label-event journal by PR number,
+owner, and repository, and compares the result against a high-water mark held in SQLite, reading
+nothing from the workspace directory. A workspace the sweep removes by age still leaves detection
+observing and dispatching commands for that pull request in the running process, and a dispatch
+after the removal recreates the directory rather than fail (§11F.6).
 
 ### 11F.10 Authorization posture
 

--- a/docs/workflow-reference.md
+++ b/docs/workflow-reference.md
@@ -17,7 +17,7 @@
   - [2.1 Top-Level Keys](#21-top-level-keys)
   - [2.2 `tracker` — Issue Tracker Configuration](#22-tracker--issue-tracker-configuration)
   - [2.3 `polling` — Poll Loop Timing](#23-polling--poll-loop-timing)
-  - [2.4 `workspace` — Workspace Root](#24-workspace--workspace-root)
+  - [2.4 `workspace` — Workspace Root and Retention](#24-workspace--workspace-root-and-retention)
   - [2.5 `hooks` — Workspace Lifecycle Hooks](#25-hooks--workspace-lifecycle-hooks)
   - [2.6 `agent` — Coding Agent Configuration](#26-agent--coding-agent-configuration)
   - [2.7 `db_path` — SQLite Database Path](#27-db_path--sqlite-database-path)
@@ -582,16 +582,18 @@ polling:
 
 ---
 
-### 2.4 `workspace` — Workspace Root
+### 2.4 `workspace` — Workspace Root and Retention
 
 ```yaml
 workspace:
   root: ~/workspace/sortie
+  retention_days: 30
 ```
 
-| Field  | Type                  | Required | Default                           | Dynamic Reload              | Description                              |
-| ------ | --------------------- | -------- | --------------------------------- | --------------------------- | ---------------------------------------- |
-| `root` | path string or `$VAR` | No       | `<system-temp>/sortie_workspaces` | Future workspace operations | Base directory for per-issue workspaces. |
+| Field            | Type    | Required | Default                           | Dynamic Reload               | Description                                                                                                                     |
+| ---------------- | ------- | -------- | ---------------------------------- | ----------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| `root`           | path string or `$VAR` | No | `<system-temp>/sortie_workspaces` | Future workspace operations | Base directory for per-issue workspaces. |
+| `retention_days` | integer | No       | `0` (disabled)                    | Applies on the next sweep pass | Maximum age in days of a swept workspace's latest recorded activity before the periodic sweep removes it. `0` disables the bound; `1`-`29` is rejected; `30` is the smallest permitted non-zero value. |
 
 **Path resolution:**
 
@@ -1537,9 +1539,10 @@ Each variable maps to exactly one config field. The naming convention is
 
 #### Workspace
 
-| Environment variable    | Config field     | Type   | Notes                                 |
-| ----------------------- | ---------------- | ------ | ------------------------------------- |
-| `SORTIE_WORKSPACE_ROOT` | `workspace.root` | string | `~` expansion applies; `$VAR` skipped |
+| Environment variable               | Config field              | Type    | Notes                                 |
+| ----------------------------------- | -------------------------- | ------- | -------------------------------------- |
+| `SORTIE_WORKSPACE_ROOT`             | `workspace.root`           | string  | `~` expansion applies; `$VAR` skipped |
+| `SORTIE_WORKSPACE_RETENTION_DAYS`   | `workspace.retention_days` | integer | No `~` expansion or `$VAR` handling   |
 
 #### Agent
 
@@ -1988,7 +1991,7 @@ are included alongside Sortie-specific metrics.
 | `sortie_dispatches_total`                       | Counter   | `outcome`                   | Dispatch attempts (`success`, `error`).                        |
 | `sortie_worker_exits_total`                     | Counter   | `exit_type`                 | Worker exits (`normal`, `error`, `cancelled`).                 |
 | `sortie_retries_total`                          | Counter   | `trigger`                   | Retry schedule events (`error`, `continuation`, `timer`, `stall`). |
-| `sortie_reconciliation_actions_total`           | Counter   | `action`                    | Reconciliation outcomes (`stop`, `cleanup`, `keep`).           |
+| `sortie_reconciliation_actions_total`           | Counter   | `action`                    | Reconciliation outcomes (`stop`, `cleanup`, `keep`, `sweep_cleanup`, `sweep_expired`). |
 | `sortie_poll_cycles_total`                      | Counter   | `result`                    | Poll tick completions (`success`, `error`, `skipped`).         |
 | `sortie_tracker_requests_total`                 | Counter   | `operation`, `result`       | Tracker adapter API calls by operation and result.             |
 | `sortie_handoff_transitions_total`              | Counter   | `result`                    | Handoff-state transition attempts (`success`, `error`, `skipped`). |
@@ -2935,6 +2938,7 @@ re-applies configuration and prompt template without restart.
 | `tracker.in_progress_state`            | Future dispatches, not in-flight sessions.                                                     |
 | `polling.interval_ms`                  | **Immediate** — affects future tick scheduling.                                                |
 | `workspace.root`                       | Future workspace operations.                                                                   |
+| `workspace.retention_days`             | Dynamic reload. Applies on the next sweep pass.                                                |
 | `hooks.*`                              | Future hook executions.                                                                        |
 | `hooks.timeout_ms`                     | Future hook executions.                                                                        |
 | `agent.kind`                           | Future dispatches.                                                                             |
@@ -3084,6 +3088,8 @@ Each error identifies the offending field path.
 | `config: tracker.in_progress_state: "<val>" is not in active_states...`            | `in_progress_state` is not in `active_states` (case-insensitive).            | Add the state to `active_states`, or use a state already in `active_states`.                                                         |
 | `config: tracker.in_progress_state: "<val>" collides with handoff_state "<state>"` | `in_progress_state` matches `handoff_state` (case-insensitive).              | Use different states for dispatch-time and exit-time transitions.                                                                    |
 | `config: workspace.root: cannot expand ~: <err>`                                | Home directory expansion failed.                                         | Check that the `HOME` environment variable is set.                                                                                   |
+| `config: workspace.retention_days: must not be negative`                        | Negative value for `retention_days`.                                     | Use `0` (disabled) or a positive integer of at least `30`.                                                                           |
+| `config: workspace.retention_days: must be 0 to disable or at least 30 days`    | `retention_days` is between `1` and `29` inclusive.                       | Use `0` to disable the bound, or a value of `30` or greater.                                                                         |
 | `config: db_path: expected string, got <type>`                                  | `db_path` is not a string value.                                         | Use a string path value, quoted if necessary.                                                                                        |
 | `config: db_path: resolved to empty (check environment variable)`               | `$VAR` reference resolved to empty.                                      | Set the environment variable or use a literal path.                                                                                  |
 | `config: ci_feedback.max_retries: invalid integer value: <val>`                 | Non-integer value for `max_retries`.                                     | Use a plain integer (e.g., `2`).                                                                                                     |
@@ -3146,6 +3152,7 @@ lists the `SORTIE_*` variable that overrides the field, or "—" if not overrida
 | `tracker.comments.on_failure`           | bool             | `false`                      | `SORTIE_TRACKER_COMMENTS_ON_FAILURE`     |                                                                                        |
 | `polling.interval_ms`                   | integer          | `30000`                      | `SORTIE_POLLING_INTERVAL_MS`             | Dynamic reload                                                                         |
 | `workspace.root`                        | path             | `<tmpdir>/sortie_workspaces` | `SORTIE_WORKSPACE_ROOT`                  | `~` expanded; `$VAR` skipped for env-sourced values                                    |
+| `workspace.retention_days`              | integer          | `0` (disabled)               | `SORTIE_WORKSPACE_RETENTION_DAYS`        | Floor `30`; `1`-`29` rejected; dynamic reload, applies on the next sweep pass          |
 | `hooks.after_create`                    | shell script     | _(null)_                     | —                                        | Fatal on failure                                                                       |
 | `hooks.before_run`                      | shell script     | _(null)_                     | —                                        | Fatal on failure                                                                       |
 | `hooks.after_run`                       | shell script     | _(null)_                     | —                                        | Failure ignored                                                                        |

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -118,10 +118,20 @@ type PollingConfig struct {
 	IntervalMS int
 }
 
-// WorkspaceConfig holds the workspace root path after expansion.
+// WorkspaceConfig holds the workspace root path after expansion and the
+// retention window.
 type WorkspaceConfig struct {
 	Root string
+
+	// RetentionDays is the maximum age in days of a swept workspace's
+	// latest recorded activity before the periodic sweep removes it.
+	// Zero disables the bound.
+	RetentionDays int
 }
+
+// WorkspaceRetentionMinDays is the smallest permitted non-zero value of
+// workspace.retention_days, in days.
+const WorkspaceRetentionMinDays = 30
 
 // HooksConfig holds workspace lifecycle hook scripts and their timeout.
 type HooksConfig struct {
@@ -437,7 +447,25 @@ func buildWorkspaceConfig(m map[string]any, envKeys map[string]bool) (WorkspaceC
 	if root == "" {
 		root = filepath.Join(os.TempDir(), "sortie_workspaces")
 	}
-	return WorkspaceConfig{Root: root}, nil
+
+	retentionDays, err := coerceIntField(m, "retention_days", "workspace.retention_days")
+	if err != nil {
+		return WorkspaceConfig{}, err
+	}
+	if retentionDays < 0 {
+		return WorkspaceConfig{}, &ConfigError{
+			Field:   "workspace.retention_days",
+			Message: "must not be negative",
+		}
+	}
+	if retentionDays > 0 && retentionDays < WorkspaceRetentionMinDays {
+		return WorkspaceConfig{}, &ConfigError{
+			Field:   "workspace.retention_days",
+			Message: "must be 0 to disable or at least 30 days",
+		}
+	}
+
+	return WorkspaceConfig{Root: root, RetentionDays: retentionDays}, nil
 }
 
 func buildHooksConfig(m map[string]any) HooksConfig {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2575,3 +2575,59 @@ func TestNewServiceConfigExtensions(t *testing.T) {
 		}
 	})
 }
+
+// --- buildWorkspaceConfig / workspace.retention_days tests ---
+
+func TestBuildWorkspaceConfig(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no retention_days key defaults to 0", func(t *testing.T) {
+		t.Parallel()
+
+		cfg, err := buildWorkspaceConfig(map[string]any{}, map[string]bool{})
+		if err != nil {
+			t.Fatalf("buildWorkspaceConfig: unexpected error: %v", err)
+		}
+		if cfg.RetentionDays != 0 {
+			t.Errorf("RetentionDays = %d, want 0", cfg.RetentionDays)
+		}
+	})
+
+	tests := []struct {
+		name      string
+		retention int
+		wantErr   bool
+	}{
+		{name: "negative rejected", retention: -1, wantErr: true},
+		{name: "zero accepted (disables the bound)", retention: 0, wantErr: false},
+		{name: "one rejected (below the floor)", retention: 1, wantErr: true},
+		{name: "twenty-nine rejected (below the floor)", retention: 29, wantErr: true},
+		{name: "thirty accepted (at the floor)", retention: 30, wantErr: false},
+		{name: "three-sixty-five accepted", retention: 365, wantErr: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg, err := buildWorkspaceConfig(map[string]any{"retention_days": tt.retention}, map[string]bool{})
+
+			if tt.wantErr {
+				var ce *ConfigError
+				if !errors.As(err, &ce) {
+					t.Fatalf("buildWorkspaceConfig(retention_days=%d) error type = %T, want *ConfigError", tt.retention, err)
+				}
+				if ce.Field != "workspace.retention_days" {
+					t.Errorf("ConfigError.Field = %q, want %q", ce.Field, "workspace.retention_days")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("buildWorkspaceConfig(retention_days=%d) unexpected error: %v", tt.retention, err)
+			}
+			if cfg.RetentionDays != tt.retention {
+				t.Errorf("RetentionDays = %d, want %d", cfg.RetentionDays, tt.retention)
+			}
+		})
+	}
+}

--- a/internal/config/envoverride.go
+++ b/internal/config/envoverride.go
@@ -67,6 +67,7 @@ var envOverrides = []envOverride{
 
 	// Workspace
 	{"SORTIE_WORKSPACE_ROOT", "workspace", "root", coerceString},
+	{"SORTIE_WORKSPACE_RETENTION_DAYS", "workspace", "retention_days", coerceEnvInt},
 
 	// Agent
 	{"SORTIE_AGENT_KIND", "agent", "kind", coerceString},

--- a/internal/config/envoverride_test.go
+++ b/internal/config/envoverride_test.go
@@ -463,6 +463,25 @@ func TestApplyEnvOverrides(t *testing.T) {
 		assertEnvOverrideError(t, err, "polling.interval_ms", "invalid integer value")
 	})
 
+	t.Run("workspace retention days override reaches RetentionDays with no YAML key", func(t *testing.T) {
+		t.Setenv("SORTIE_WORKSPACE_RETENTION_DAYS", "45")
+
+		cfg, err := NewServiceConfig(map[string]any{})
+		if err != nil {
+			t.Fatalf("NewServiceConfig: unexpected error: %v", err)
+		}
+		if cfg.Workspace.RetentionDays != 45 {
+			t.Errorf("Workspace.RetentionDays = %d, want 45", cfg.Workspace.RetentionDays)
+		}
+	})
+
+	t.Run("workspace retention days override invalid value fails config construction", func(t *testing.T) {
+		t.Setenv("SORTIE_WORKSPACE_RETENTION_DAYS", "abc")
+
+		_, err := NewServiceConfig(map[string]any{})
+		assertEnvOverrideError(t, err, "workspace.retention_days", "SORTIE_WORKSPACE_RETENTION_DAYS")
+	})
+
 	t.Run("top-level SORTIE_DB_PATH", func(t *testing.T) {
 		t.Setenv("SORTIE_DB_PATH", "/data/sortie.db")
 

--- a/internal/orchestrator/ci_reconcile_test.go
+++ b/internal/orchestrator/ci_reconcile_test.go
@@ -374,6 +374,38 @@ func TestReconcileCIStatus_Failing_UnderMaxRetries(t *testing.T) {
 	}
 }
 
+// TestReconcileCIStatus_Failing_RunHistoryCompletedAtIsUTC covers R9: the
+// CI-failure writer formats a UTC time with time.RFC3339, so the
+// persisted value ends in "Z" and parses back as RFC3339.
+func TestReconcileCIStatus_Failing_RunHistoryCompletedAtIsUTC(t *testing.T) {
+	t.Parallel()
+
+	state := stateWithPendingReaction(t, "ISS-CI-UTC", "feature/break", 1)
+	store := &ciReconcileStore{}
+	metrics := newCIMetricsSpy()
+	ci := &mockCIProvider{result: domain.CIResult{
+		Status:       domain.CIStatusFailing,
+		FailingCount: 1,
+		CheckRuns: []domain.CheckRun{
+			{Name: "lint", Status: domain.CheckRunStatusCompleted, Conclusion: domain.CheckConclusionFailure},
+		},
+	}}
+	params := ciParams(t, store, ci, nil)
+
+	reconcileCIStatus(state, params, discardLogger(), context.Background(), metrics)
+
+	if len(store.runHistories) != 1 {
+		t.Fatalf("AppendRunHistory call count = %d, want 1", len(store.runHistories))
+	}
+	completedAt := store.runHistories[0].CompletedAt
+	if !strings.HasSuffix(completedAt, "Z") {
+		t.Errorf("RunHistory.CompletedAt = %q, want suffix %q", completedAt, "Z")
+	}
+	if _, err := time.Parse(time.RFC3339, completedAt); err != nil {
+		t.Errorf("time.Parse(RFC3339, %q): %v", completedAt, err)
+	}
+}
+
 func TestReconcileCIStatus_Failing_ExceedsMaxRetries_Escalates(t *testing.T) {
 	t.Parallel()
 

--- a/internal/orchestrator/exit_test.go
+++ b/internal/orchestrator/exit_test.go
@@ -889,6 +889,38 @@ func TestHandleWorkerExit_RunHistoryFields(t *testing.T) {
 	}
 }
 
+// TestHandleWorkerExit_RunHistoryCompletedAtIsUTC covers R9: the
+// production writer formats a UTC time with time.RFC3339, so the
+// persisted value ends in "Z" and parses back as RFC3339. Unlike
+// TestHandleWorkerExit_RunHistoryFields, NowFunc is left nil so the
+// writer's own time.Now().UTC() call is exercised.
+func TestHandleWorkerExit_RunHistoryCompletedAtIsUTC(t *testing.T) {
+	t.Parallel()
+
+	store := &mockExitStore{}
+	state := exitState(t, "HIST-UTC", nil)
+	params := defaultExitParams(t, store)
+	params.NowFunc = nil
+
+	HandleWorkerExit(state, WorkerResult{
+		IssueID:      "HIST-UTC",
+		Identifier:   "HIST-UTC-ident",
+		ExitKind:     WorkerExitNormal,
+		AgentAdapter: "claude-code",
+	}, params)
+
+	if len(store.runHistories) != 1 {
+		t.Fatalf("AppendRunHistory called %d times, want 1", len(store.runHistories))
+	}
+	completedAt := store.runHistories[0].CompletedAt
+	if !strings.HasSuffix(completedAt, "Z") {
+		t.Errorf("RunHistory.CompletedAt = %q, want suffix %q", completedAt, "Z")
+	}
+	if _, err := time.Parse(time.RFC3339, completedAt); err != nil {
+		t.Errorf("time.Parse(RFC3339, %q): %v", completedAt, err)
+	}
+}
+
 func TestHandleWorkerExit_SessionMetadataPersisted(t *testing.T) {
 	t.Parallel()
 

--- a/internal/orchestrator/label_fix_reconcile_test.go
+++ b/internal/orchestrator/label_fix_reconcile_test.go
@@ -5,10 +5,12 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/sortie-ai/sortie/internal/config"
 	"github.com/sortie-ai/sortie/internal/domain"
 	"github.com/sortie-ai/sortie/internal/persistence"
 )
@@ -249,6 +251,61 @@ func TestReconcileLabelFixCommands_Dispatch(t *testing.T) {
 	if data.HighWaterMark != labelReviewMark(event) {
 		t.Errorf("LabelFixReactionData.HighWaterMark = %q, want %q (reuses the shared mark format)",
 			data.HighWaterMark, labelReviewMark(event))
+	}
+}
+
+// TestReconcileLabelFixCommands_ContinuesAfterAgeRemoval covers R31: after
+// the periodic sweep removes a workspace by age, the label-fix reconcile
+// pass still observes a matching label event and still schedules a retry
+// carrying ReactionKindLabelFix, re-enqueuing the pending entry. The
+// reconcile pass reads nothing from the workspace directory (R27), so its
+// removal has no bearing on detection.
+//
+// The recreate-through-dispatch property (workspace.Ensure/Prepare
+// returning CreatedNow == true so the read-only and read-write postures
+// each obtain a workspace directory again) is covered by
+// internal/workspace/workspace_test.go:279 (Ensure) and
+// internal/workspace/lifecycle_test.go:165 (Prepare re-running
+// after_create), not by this test.
+func TestReconcileLabelFixCommands_ContinuesAfterAgeRemoval(t *testing.T) {
+	t.Parallel()
+
+	const issueID = "LF-AGE1"
+	identifier := issueID + "-ident"
+	tmpDir := t.TempDir()
+	wsPath := filepath.Join(tmpDir, identifier)
+	mustMkdirSweep(t, wsPath)
+	writeSweepSCMMetadata(t, wsPath, oldSweepTimestamp())
+
+	state := stateWithLabelFixPending(t, issueID, 42, "feature/lf-age1")
+	rkey := ReactionKey(issueID, ReactionKindLabelFix)
+
+	sweepParams := defaultSweepParams(t, tmpDir, &sweepTracker{})
+	sweepParams.RetentionDays = config.WorkspaceRetentionMinDays
+	sweepParams.Store = &sweepStoreDouble{}
+	SweepWorkspaces(state, sweepParams)
+	assertSweepDirRemoved(t, wsPath)
+
+	if _, ok := state.PendingReactions[rkey]; !ok {
+		t.Fatal("PendingReactions entry removed by the sweep; want unaffected (test precondition)")
+	}
+
+	event := labelEvent("1", "sortie:fix", "alice", true, labelReviewBaseTime.Add(-1*time.Minute))
+	scm := &labelReviewSCMFake{events: []domain.LabelEvent{event}}
+	store := newLabelReviewFingerprintStore()
+	params := labelFixParams(store, scm)
+
+	reconcileLabelFixCommands(state, params, discardLogger(), context.Background(), &domain.NoopMetrics{})
+
+	retry, ok := state.RetryAttempts[issueID]
+	if !ok {
+		t.Fatal("retry not scheduled after age removal; want scheduled")
+	}
+	if retry.ReactionKind != ReactionKindLabelFix {
+		t.Errorf("RetryEntry.ReactionKind = %q, want %q", retry.ReactionKind, ReactionKindLabelFix)
+	}
+	if _, stillPending := state.PendingReactions[rkey]; !stillPending {
+		t.Error("PendingReactions entry removed after dispatch; want re-enqueued")
 	}
 }
 

--- a/internal/orchestrator/label_review_reconcile_test.go
+++ b/internal/orchestrator/label_review_reconcile_test.go
@@ -5,10 +5,12 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/sortie-ai/sortie/internal/config"
 	"github.com/sortie-ai/sortie/internal/domain"
 	"github.com/sortie-ai/sortie/internal/persistence"
 )
@@ -363,6 +365,64 @@ func TestReconcileLabelReviewCommands_Dispatch(t *testing.T) {
 	}
 	if data.HighWaterMark == "" {
 		t.Error("LabelReviewReactionData.HighWaterMark is empty, want advanced")
+	}
+}
+
+// TestReconcileLabelReviewCommands_ContinuesAfterAgeRemoval covers R31: after
+// the periodic sweep removes a workspace by age, the label-review reconcile
+// pass still observes a matching label event and still schedules a retry
+// carrying ReactionKindLabelReview, re-enqueuing the pending entry. The
+// reconcile pass reads nothing from the workspace directory (R27), so its
+// removal has no bearing on detection.
+//
+// The recreate-through-dispatch property (workspace.Ensure/Prepare
+// returning CreatedNow == true so the read-only and read-write postures
+// each obtain a workspace directory again) is covered by
+// internal/workspace/workspace_test.go:279 (Ensure) and
+// internal/workspace/lifecycle_test.go:165 (Prepare re-running
+// after_create), not by this test.
+func TestReconcileLabelReviewCommands_ContinuesAfterAgeRemoval(t *testing.T) {
+	t.Parallel()
+
+	const issueID = "LR-AGE1"
+	identifier := issueID + "-ident"
+	tmpDir := t.TempDir()
+	wsPath := filepath.Join(tmpDir, identifier)
+	mustMkdirSweep(t, wsPath)
+	writeSweepSCMMetadata(t, wsPath, oldSweepTimestamp())
+
+	state := stateWithLabelReviewPending(t, issueID, 42)
+	rkey := ReactionKey(issueID, ReactionKindLabelReview)
+
+	sweepParams := defaultSweepParams(t, tmpDir, &sweepTracker{})
+	sweepParams.RetentionDays = config.WorkspaceRetentionMinDays
+	sweepParams.Store = &sweepStoreDouble{}
+	SweepWorkspaces(state, sweepParams)
+	assertSweepDirRemoved(t, wsPath)
+
+	if _, ok := state.PendingReactions[rkey]; !ok {
+		t.Fatal("PendingReactions entry removed by the sweep; want unaffected (test precondition)")
+	}
+
+	scm := &labelReviewSCMFake{
+		events: []domain.LabelEvent{
+			labelEvent("1", "sortie:review", "alice", true, labelReviewBaseTime.Add(-1*time.Minute)),
+		},
+	}
+	store := newLabelReviewFingerprintStore()
+	params := labelReviewParams(store, scm)
+
+	reconcileLabelReviewCommands(state, params, discardLogger(), context.Background(), &domain.NoopMetrics{})
+
+	retry, ok := state.RetryAttempts[issueID]
+	if !ok {
+		t.Fatal("retry not scheduled after age removal; want scheduled")
+	}
+	if retry.ReactionKind != ReactionKindLabelReview {
+		t.Errorf("RetryEntry.ReactionKind = %q, want %q", retry.ReactionKind, ReactionKindLabelReview)
+	}
+	if _, stillPending := state.PendingReactions[rkey]; !stillPending {
+		t.Error("PendingReactions entry removed after dispatch; want re-enqueued")
 	}
 }
 

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -43,6 +43,7 @@ type OrchestratorStore interface {
 	GetReactionFingerprint(ctx context.Context, issueID, kind string) (fingerprint string, dispatched bool, err error)
 	MarkReactionDispatched(ctx context.Context, issueID, kind string) error
 	DeleteReactionFingerprint(ctx context.Context, issueID, kind string) error
+	LatestRunCompletionByIdentifier(ctx context.Context, identifiers []string) (map[string]string, error)
 }
 
 // Observer receives notifications when orchestrator state changes.
@@ -538,17 +539,20 @@ func (o *Orchestrator) handleTick(ctx context.Context) {
 		LabelFixReactionConfigured:      o.labelFixReactionConfigured,
 	})
 
-	// Sweep terminal workspaces periodically to catch issues that
-	// transitioned after their worker exited.
+	// Sweep workspaces periodically to catch issues that transitioned
+	// after their worker exited, or whose activity has aged past the
+	// configured retention window.
 	o.state.SweepTickCounter++
 	if o.state.SweepTickCounter >= sweepEveryNTicks {
 		o.state.SweepTickCounter = 0
-		SweepTerminalWorkspaces(o.state, SweepTerminalWorkspacesParams{
+		SweepWorkspaces(o.state, SweepWorkspacesParams{
 			WorkspaceRoot:    cfg.Workspace.Root,
 			TrackerAdapter:   o.trackerAdapter,
 			TerminalStates:   cfg.Tracker.TerminalStates,
 			BeforeRemoveHook: cfg.Hooks.BeforeRemove,
 			HookTimeoutMS:    cfg.Hooks.TimeoutMS,
+			RetentionDays:    cfg.Workspace.RetentionDays,
+			Store:            o.store,
 			Ctx:              ctx,
 			Logger:           o.logger,
 			Metrics:          o.metrics,

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -212,6 +212,10 @@ func (s *stubStore) DeleteReactionFingerprint(_ context.Context, _, _ string) er
 	return nil
 }
 
+func (s *stubStore) LatestRunCompletionByIdentifier(_ context.Context, _ []string) (map[string]string, error) {
+	return map[string]string{}, nil
+}
+
 // stubObserver implements [Observer] with an atomic call counter.
 type stubObserver struct {
 	calls atomic.Int64

--- a/internal/orchestrator/reconcile.go
+++ b/internal/orchestrator/reconcile.go
@@ -433,33 +433,256 @@ func reconcileTrackerState(state *State, params ReconcileParams, log *slog.Logge
 	}
 }
 
-// sweepEveryNTicks is the number of poll ticks between terminal workspace
-// sweeps. Running this sweep every 60 ticks is frequent enough for eventual
+// sweepEveryNTicks is the number of poll ticks between workspace sweeps.
+// Running this sweep every 60 ticks is frequent enough for eventual
 // consistency while avoiding unbounded tracker API load from orphaned
 // non-terminal workspaces.
 const sweepEveryNTicks = 60
 
-// SweepTerminalWorkspacesParams holds the dependencies for
-// [SweepTerminalWorkspaces]. All fields except Logger and Metrics are
-// required; nil Logger defaults to [slog.Default] and nil Metrics defaults
-// to [domain.NoopMetrics].
-type SweepTerminalWorkspacesParams struct {
+// SweepStore is the persistence interface required by [SweepWorkspaces].
+type SweepStore interface {
+	LatestRunCompletionByIdentifier(ctx context.Context, identifiers []string) (map[string]string, error)
+}
+
+// sweepSummary accumulates the per-pass outcome counts reported by
+// [emitSweepSummary]. The nine counters after candidates partition the
+// candidate set: candidates equals their sum on every pass.
+type sweepSummary struct {
+	candidates           int
+	excludedRunning      int
+	excludedRetry        int
+	excludedReaction     int
+	removedTerminal      int
+	removedAge           int
+	retainedInWindow     int
+	retainedNoActivity   int
+	retainedNotEvaluated int
+	failed               int
+	retentionDays        int
+	agePass              string // "on", "off", or "unavailable"
+	trackerRead          string // "ok" or "failed"
+}
+
+// emitSweepSummary logs the per-pass sweep outcome as a single Info
+// record. It is called unconditionally at the end of every pass that
+// produced a candidate set, including one that removed nothing.
+func emitSweepSummary(log *slog.Logger, summary sweepSummary) {
+	log.Info("sweep: pass complete",
+		slog.Int("candidates", summary.candidates),
+		slog.Int("excluded_running", summary.excludedRunning),
+		slog.Int("excluded_retry", summary.excludedRetry),
+		slog.Int("excluded_reaction", summary.excludedReaction),
+		slog.Int("removed_terminal", summary.removedTerminal),
+		slog.Int("removed_age", summary.removedAge),
+		slog.Int("retained_in_window", summary.retainedInWindow),
+		slog.Int("retained_no_activity", summary.retainedNoActivity),
+		slog.Int("retained_not_evaluated", summary.retainedNotEvaluated),
+		slog.Int("failed", summary.failed),
+		slog.Int("retention_days", summary.retentionDays),
+		slog.String("age_pass", summary.agePass),
+		slog.String("tracker_read", summary.trackerRead),
+	)
+}
+
+// activityAnchor returns the later of the two RFC3339 timestamps and
+// whether either parsed.
+//
+// An unparseable or empty value contributes nothing. A workspace whose
+// only timestamps are unparseable therefore has no anchor, the same
+// outcome as having no timestamps at all.
+func activityAnchor(completedAt, pushedAt string) (time.Time, bool) {
+	var best time.Time
+	found := false
+	for _, value := range [2]string{completedAt, pushedAt} {
+		if value == "" {
+			continue
+		}
+		parsed, err := time.Parse(time.RFC3339, value)
+		if err != nil {
+			continue
+		}
+		parsed = parsed.UTC()
+		if !found || parsed.After(best) {
+			best = parsed
+			found = true
+		}
+	}
+	return best, found
+}
+
+// buildSweepExclusions returns the map of workspace key to the reason it
+// is excluded from sweep candidacy: "running", "retry", or "reaction".
+//
+// Precedence is running, then retry, then reaction, so a key present in
+// more than one source is reported exactly once and the sweep's outcome
+// counters partition the candidate set.
+func buildSweepExclusions(state *State, log *slog.Logger) map[string]string {
+	out := make(map[string]string)
+
+	for _, entry := range state.Running {
+		key, err := workspace.SanitizeKey(entry.Identifier)
+		if err != nil {
+			log.Warn("sweep: failed to sanitize running identifier",
+				slog.String("identifier", entry.Identifier),
+				slog.Any("error", err),
+			)
+			continue
+		}
+		out[key] = "running"
+	}
+
+	for _, entry := range state.RetryAttempts {
+		key, err := workspace.SanitizeKey(entry.Identifier)
+		if err != nil {
+			log.Warn("sweep: failed to sanitize retry identifier",
+				slog.String("identifier", entry.Identifier),
+				slog.Any("error", err),
+			)
+			continue
+		}
+		if _, exists := out[key]; !exists {
+			out[key] = "retry"
+		}
+	}
+
+	for _, entry := range state.PendingReactions {
+		if !reactionKindPinsWorkspace(entry.Kind) {
+			continue
+		}
+		key, err := workspace.SanitizeKey(entry.Identifier)
+		if err != nil {
+			log.Warn("sweep: failed to sanitize pending reaction identifier",
+				slog.String("identifier", entry.Identifier),
+				slog.Any("error", err),
+			)
+			continue
+		}
+		if _, exists := out[key]; !exists {
+			out[key] = "reaction"
+		}
+	}
+
+	return out
+}
+
+// runAgePass evaluates every key in ageKeys against params.RetentionDays
+// and removes those whose latest recorded activity is older than that
+// window. Each early return credits every key in ageKeys to
+// summary.retainedNotEvaluated, so the pass never leaves a candidate
+// unaccounted for in the outcome partition.
+func runAgePass(params SweepWorkspacesParams, summary *sweepSummary, ageKeys []string, now time.Time, log *slog.Logger, metrics domain.Metrics) {
+	if params.RetentionDays < config.WorkspaceRetentionMinDays {
+		summary.retainedNotEvaluated += len(ageKeys)
+		return
+	}
+	if params.Store == nil {
+		summary.agePass = "unavailable"
+		summary.retainedNotEvaluated += len(ageKeys)
+		return
+	}
+
+	summary.agePass = "on"
+	retentionCutoff := now.UTC().Add(-time.Duration(params.RetentionDays) * 24 * time.Hour)
+
+	completions, err := params.Store.LatestRunCompletionByIdentifier(params.Ctx, ageKeys)
+	if err != nil {
+		log.Warn("sweep: failed to read run history activity",
+			slog.Any("error", err),
+		)
+		summary.agePass = "unavailable"
+		summary.retainedNotEvaluated += len(ageKeys)
+		return
+	}
+
+	for _, key := range ageKeys {
+		pathResult, pathErr := workspace.ComputePath(params.WorkspaceRoot, key)
+		if pathErr != nil {
+			log.Warn("sweep: failed to resolve workspace path",
+				slog.String("workspace_key", key),
+				slog.Any("error", pathErr),
+			)
+			summary.failed++
+			continue
+		}
+
+		meta := workspace.ReadSCMMetadata(pathResult.Path, log)
+		anchor, hasAnchor := activityAnchor(completions[key], meta.PushedAt)
+
+		if !hasAnchor {
+			summary.retainedNoActivity++
+			continue
+		}
+		if !anchor.Before(retentionCutoff) {
+			summary.retainedInWindow++
+			continue
+		}
+
+		cleanupErr := workspace.Cleanup(params.Ctx, workspace.CleanupParams{
+			Root:          params.WorkspaceRoot,
+			Identifier:    key,
+			IssueID:       key,
+			BeforeRemove:  params.BeforeRemoveHook,
+			HookTimeoutMS: params.HookTimeoutMS,
+			Logger:        log,
+		})
+		if cleanupErr != nil {
+			log.Warn("sweep: failed to remove expired workspace",
+				slog.String("workspace_key", key),
+				slog.Any("error", cleanupErr),
+			)
+			summary.failed++
+			continue
+		}
+
+		log.Info("sweep: removed expired workspace",
+			slog.String("workspace_key", key),
+			slog.String("last_activity", anchor.Format(time.RFC3339)),
+			slog.Int("age_days", int(now.UTC().Sub(anchor).Hours()/24)),
+		)
+		summary.removedAge++
+		metrics.IncReconciliationActions(actionSweepExpired)
+	}
+}
+
+// SweepWorkspacesParams holds the dependencies for [SweepWorkspaces]. All
+// fields except Logger and Metrics are required; nil Logger defaults to
+// [slog.Default] and nil Metrics defaults to [domain.NoopMetrics].
+type SweepWorkspacesParams struct {
 	WorkspaceRoot    string
 	TrackerAdapter   domain.TrackerAdapter
 	TerminalStates   []string
 	BeforeRemoveHook string
 	HookTimeoutMS    int
-	Ctx              context.Context
-	Logger           *slog.Logger
-	Metrics          domain.Metrics
+
+	// RetentionDays is the configured workspace.retention_days window.
+	// A value below [config.WorkspaceRetentionMinDays] disables the age
+	// pass, reported as agePass "off".
+	RetentionDays int
+
+	// Store resolves each age candidate's latest recorded activity. A
+	// nil Store disables the age pass, reported as agePass
+	// "unavailable".
+	Store SweepStore
+
+	// NowFunc returns the current time. If nil, time.Now is used.
+	NowFunc func() time.Time
+
+	Ctx     context.Context
+	Logger  *slog.Logger
+	Metrics domain.Metrics
 }
 
-// SweepTerminalWorkspaces removes workspace directories for issues that
-// transitioned to a terminal state after their worker exited. It lists
-// workspace keys on disk, excludes any that belong to in-flight entries,
-// queries the tracker for the remaining identifiers, and cleans up those
-// whose state is terminal.
-func SweepTerminalWorkspaces(state *State, params SweepTerminalWorkspacesParams) {
+// SweepWorkspaces removes workspace directories on two independent
+// grounds: the issue reached a terminal tracker state, or the
+// workspace's latest recorded activity is older than the configured
+// retention window. It lists workspace keys on disk, excludes any that
+// belong to in-flight work, queries the tracker for the state of the
+// rest, cleans up those reported terminal, and evaluates whatever
+// remains against the retention window.
+//
+// One summary record is emitted per pass that produced a candidate set,
+// whether or not anything was removed.
+func SweepWorkspaces(state *State, params SweepWorkspacesParams) {
 	log := params.Logger
 	if log == nil {
 		log = slog.Default()
@@ -470,6 +693,11 @@ func SweepTerminalWorkspaces(state *State, params SweepTerminalWorkspacesParams)
 		metrics = &domain.NoopMetrics{}
 	}
 
+	now := time.Now()
+	if params.NowFunc != nil {
+		now = params.NowFunc()
+	}
+
 	keys, err := workspace.ListWorkspaceKeys(params.WorkspaceRoot)
 	if err != nil {
 		log.Warn("sweep: failed to list workspace keys",
@@ -477,61 +705,39 @@ func SweepTerminalWorkspaces(state *State, params SweepTerminalWorkspacesParams)
 		)
 		return
 	}
-	if len(keys) == 0 {
-		return
+
+	summary := sweepSummary{
+		candidates:    len(keys),
+		retentionDays: params.RetentionDays,
+		trackerRead:   "ok",
+		agePass:       "off",
 	}
 
-	inFlightKeys := make(map[string]struct{})
-	for _, entry := range state.Running {
-		k, sErr := workspace.SanitizeKey(entry.Identifier)
-		if sErr != nil {
-			log.Warn("sweep: failed to sanitize running identifier",
-				slog.String("identifier", entry.Identifier),
-				slog.Any("error", sErr),
-			)
-			continue
-		}
-		inFlightKeys[k] = struct{}{}
-	}
-	for _, entry := range state.RetryAttempts {
-		k, sErr := workspace.SanitizeKey(entry.Identifier)
-		if sErr != nil {
-			log.Warn("sweep: failed to sanitize retry identifier",
-				slog.String("identifier", entry.Identifier),
-				slog.Any("error", sErr),
-			)
-			continue
-		}
-		inFlightKeys[k] = struct{}{}
-	}
-	for _, entry := range state.PendingReactions {
-		k, sErr := workspace.SanitizeKey(entry.Identifier)
-		if sErr != nil {
-			log.Warn("sweep: failed to sanitize pending reaction identifier",
-				slog.String("identifier", entry.Identifier),
-				slog.Any("error", sErr),
-			)
-			continue
-		}
-		inFlightKeys[k] = struct{}{}
-	}
-
-	unclaimedKeys := make([]string, 0, len(keys))
+	exclusions := buildSweepExclusions(state, log)
+	remaining := make([]string, 0, len(keys))
 	for _, key := range keys {
-		if _, ok := inFlightKeys[key]; !ok {
-			unclaimedKeys = append(unclaimedKeys, key)
+		switch exclusions[key] {
+		case "running":
+			summary.excludedRunning++
+		case "retry":
+			summary.excludedRetry++
+		case "reaction":
+			summary.excludedReaction++
+		default:
+			remaining = append(remaining, key)
 		}
 	}
-	if len(unclaimedKeys) == 0 {
-		return
-	}
 
-	statesByKey, err := params.TrackerAdapter.FetchIssueStatesByIdentifiers(params.Ctx, unclaimedKeys)
-	if err != nil {
-		log.Warn("sweep: failed to fetch issue states",
-			slog.Any("error", err),
-		)
-		return
+	statesByKey := map[string]string{}
+	if len(remaining) > 0 {
+		statesByKey, err = params.TrackerAdapter.FetchIssueStatesByIdentifiers(params.Ctx, remaining)
+		if err != nil {
+			log.Warn("sweep: failed to fetch issue states",
+				slog.Any("error", err),
+			)
+			statesByKey = map[string]string{}
+			summary.trackerRead = "failed"
+		}
 	}
 
 	terminalSet := make(map[string]struct{}, len(params.TerminalStates))
@@ -539,33 +745,37 @@ func SweepTerminalWorkspaces(state *State, params SweepTerminalWorkspacesParams)
 		terminalSet[strings.ToLower(s)] = struct{}{}
 	}
 
-	var toClean []string
-	for _, key := range unclaimedKeys {
-		stateName, ok := statesByKey[key]
-		if !ok {
+	terminalKeys := make([]string, 0, len(remaining))
+	ageKeys := make([]string, 0, len(remaining))
+	for _, key := range remaining {
+		stateName, known := statesByKey[key]
+		_, terminal := terminalSet[strings.ToLower(stateName)]
+		if known && terminal {
+			terminalKeys = append(terminalKeys, key)
 			continue
 		}
-		if _, terminal := terminalSet[strings.ToLower(stateName)]; terminal {
-			toClean = append(toClean, key)
+		ageKeys = append(ageKeys, key)
+	}
+
+	if len(terminalKeys) > 0 {
+		log.Info("sweep: cleaning terminal workspaces",
+			slog.Int("count", len(terminalKeys)),
+		)
+
+		result := workspace.CleanupTerminal(params.Ctx, workspace.CleanupTerminalParams{
+			Root:          params.WorkspaceRoot,
+			Identifiers:   terminalKeys,
+			BeforeRemove:  params.BeforeRemoveHook,
+			HookTimeoutMS: params.HookTimeoutMS,
+			Logger:        log,
+		})
+		summary.removedTerminal += len(result.Removed)
+		summary.failed += len(result.Errors)
+		for range result.Removed {
+			metrics.IncReconciliationActions(actionSweepCleanup)
 		}
 	}
-	if len(toClean) == 0 {
-		return
-	}
 
-	log.Info("sweep: cleaning terminal workspaces",
-		slog.Int("count", len(toClean)),
-	)
-
-	result := workspace.CleanupTerminal(params.Ctx, workspace.CleanupTerminalParams{
-		Root:          params.WorkspaceRoot,
-		Identifiers:   toClean,
-		BeforeRemove:  params.BeforeRemoveHook,
-		HookTimeoutMS: params.HookTimeoutMS,
-		Logger:        log,
-	})
-
-	for range result.Removed {
-		metrics.IncReconciliationActions(actionSweepCleanup)
-	}
+	runAgePass(params, &summary, ageKeys, now, log, metrics)
+	emitSweepSummary(log, summary)
 }

--- a/internal/orchestrator/reconcile_test.go
+++ b/internal/orchestrator/reconcile_test.go
@@ -3,14 +3,17 @@ package orchestrator
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 	"os"
 	"path/filepath"
 	"slices"
 	"sort"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/sortie-ai/sortie/internal/config"
 	"github.com/sortie-ai/sortie/internal/domain"
 	"github.com/sortie-ai/sortie/internal/persistence"
 )
@@ -108,7 +111,7 @@ func (m *mockReconcileTracker) AddLabel(context.Context, string, string) error {
 	panic("AddLabel must not be called by ReconcileRunningIssues")
 }
 
-// sweepTracker is a test double for [SweepTerminalWorkspaces]. Its
+// sweepTracker is a test double for [SweepWorkspaces]. Its
 // FetchIssueStatesByIdentifiers records the identifiers it receives and
 // returns the configured statesByKey map and fetchErr. All other methods
 // panic if called, matching the guard pattern in [mockReconcileTracker].
@@ -128,35 +131,35 @@ func (s *sweepTracker) FetchIssueStatesByIdentifiers(_ context.Context, ids []st
 }
 
 func (s *sweepTracker) FetchCandidateIssues(context.Context) ([]domain.Issue, error) {
-	panic("FetchCandidateIssues must not be called by SweepTerminalWorkspaces")
+	panic("FetchCandidateIssues must not be called by SweepWorkspaces")
 }
 
 func (s *sweepTracker) FetchIssueByID(context.Context, string) (domain.Issue, error) {
-	panic("FetchIssueByID must not be called by SweepTerminalWorkspaces")
+	panic("FetchIssueByID must not be called by SweepWorkspaces")
 }
 
 func (s *sweepTracker) FetchIssuesByStates(context.Context, []string) ([]domain.Issue, error) {
-	panic("FetchIssuesByStates must not be called by SweepTerminalWorkspaces")
+	panic("FetchIssuesByStates must not be called by SweepWorkspaces")
 }
 
 func (s *sweepTracker) FetchIssueStatesByIDs(context.Context, []string) (map[string]string, error) {
-	panic("FetchIssueStatesByIDs must not be called by SweepTerminalWorkspaces")
+	panic("FetchIssueStatesByIDs must not be called by SweepWorkspaces")
 }
 
 func (s *sweepTracker) FetchIssueComments(context.Context, string) ([]domain.Comment, error) {
-	panic("FetchIssueComments must not be called by SweepTerminalWorkspaces")
+	panic("FetchIssueComments must not be called by SweepWorkspaces")
 }
 
 func (s *sweepTracker) TransitionIssue(context.Context, string, string) error {
-	panic("TransitionIssue must not be called by SweepTerminalWorkspaces")
+	panic("TransitionIssue must not be called by SweepWorkspaces")
 }
 
 func (s *sweepTracker) CommentIssue(context.Context, string, string) error {
-	panic("CommentIssue must not be called by SweepTerminalWorkspaces")
+	panic("CommentIssue must not be called by SweepWorkspaces")
 }
 
 func (s *sweepTracker) AddLabel(context.Context, string, string) error {
-	panic("AddLabel must not be called by SweepTerminalWorkspaces")
+	panic("AddLabel must not be called by SweepWorkspaces")
 }
 
 // --- Test helpers ---
@@ -1060,14 +1063,14 @@ func TestReconcileStalled_WarnLogOnlyOnFirstTick(t *testing.T) {
 	}
 }
 
-// --- SweepTerminalWorkspaces helpers ---
+// --- SweepWorkspaces helpers ---
 
-// defaultSweepParams returns SweepTerminalWorkspacesParams with the given
+// defaultSweepParams returns SweepWorkspacesParams with the given
 // root and tracker. TerminalStates, Ctx, Logger, and Metrics use
 // test-suitable defaults.
-func defaultSweepParams(t *testing.T, root string, tracker *sweepTracker) SweepTerminalWorkspacesParams {
+func defaultSweepParams(t *testing.T, root string, tracker *sweepTracker) SweepWorkspacesParams {
 	t.Helper()
-	return SweepTerminalWorkspacesParams{
+	return SweepWorkspacesParams{
 		WorkspaceRoot:  root,
 		TrackerAdapter: tracker,
 		TerminalStates: []string{"Done"},
@@ -1101,9 +1104,9 @@ func assertSweepDirRemoved(t *testing.T, path string) {
 	}
 }
 
-// --- TestSweepTerminalWorkspaces ---
+// --- TestSweepWorkspaces ---
 
-func TestSweepTerminalWorkspaces(t *testing.T) {
+func TestSweepWorkspaces(t *testing.T) {
 	t.Parallel()
 
 	t.Run("EmptyWorkspaceRoot", func(t *testing.T) {
@@ -1111,7 +1114,7 @@ func TestSweepTerminalWorkspaces(t *testing.T) {
 
 		tracker := &sweepTracker{}
 		state := NewState(5000, 4, nil, AgentTotals{})
-		SweepTerminalWorkspaces(state, SweepTerminalWorkspacesParams{
+		SweepWorkspaces(state, SweepWorkspacesParams{
 			WorkspaceRoot:  "",
 			TrackerAdapter: tracker,
 			TerminalStates: []string{"Done"},
@@ -1132,7 +1135,7 @@ func TestSweepTerminalWorkspaces(t *testing.T) {
 		tracker := &sweepTracker{}
 		state := NewState(5000, 4, nil, AgentTotals{})
 
-		SweepTerminalWorkspaces(state, defaultSweepParams(t, tmpDir, tracker))
+		SweepWorkspaces(state, defaultSweepParams(t, tmpDir, tracker))
 
 		if tracker.calledWith != nil {
 			t.Errorf("FetchIssueStatesByIdentifiers called with %v, want not called", tracker.calledWith)
@@ -1149,7 +1152,7 @@ func TestSweepTerminalWorkspaces(t *testing.T) {
 		state := NewState(5000, 4, nil, AgentTotals{})
 		state.Running["id1"] = &RunningEntry{Identifier: "PROJ-1"}
 
-		SweepTerminalWorkspaces(state, defaultSweepParams(t, tmpDir, tracker))
+		SweepWorkspaces(state, defaultSweepParams(t, tmpDir, tracker))
 
 		if tracker.calledWith != nil {
 			t.Errorf("FetchIssueStatesByIdentifiers called with %v, want not called", tracker.calledWith)
@@ -1167,7 +1170,7 @@ func TestSweepTerminalWorkspaces(t *testing.T) {
 		state := NewState(5000, 4, nil, AgentTotals{})
 		state.RetryAttempts["id2"] = &RetryEntry{Identifier: "PROJ-2"}
 
-		SweepTerminalWorkspaces(state, defaultSweepParams(t, tmpDir, tracker))
+		SweepWorkspaces(state, defaultSweepParams(t, tmpDir, tracker))
 
 		if tracker.calledWith != nil {
 			t.Errorf("FetchIssueStatesByIdentifiers called with %v, want not called", tracker.calledWith)
@@ -1185,7 +1188,7 @@ func TestSweepTerminalWorkspaces(t *testing.T) {
 		state := NewState(5000, 4, nil, AgentTotals{})
 		state.PendingReactions["id3:ci"] = &PendingReaction{Identifier: "PROJ-3"}
 
-		SweepTerminalWorkspaces(state, defaultSweepParams(t, tmpDir, tracker))
+		SweepWorkspaces(state, defaultSweepParams(t, tmpDir, tracker))
 
 		if tracker.calledWith != nil {
 			t.Errorf("FetchIssueStatesByIdentifiers called with %v, want not called", tracker.calledWith)
@@ -1207,7 +1210,7 @@ func TestSweepTerminalWorkspaces(t *testing.T) {
 		state := NewState(5000, 4, nil, AgentTotals{})
 		state.Running["id1"] = &RunningEntry{Identifier: ""}
 
-		SweepTerminalWorkspaces(state, defaultSweepParams(t, tmpDir, tracker))
+		SweepWorkspaces(state, defaultSweepParams(t, tmpDir, tracker))
 
 		if tracker.calledWith == nil {
 			t.Fatal("FetchIssueStatesByIdentifiers not called, want called with [PROJ-4]")
@@ -1234,7 +1237,7 @@ func TestSweepTerminalWorkspaces(t *testing.T) {
 		state := NewState(5000, 4, nil, AgentTotals{})
 		state.Running["id5"] = &RunningEntry{Identifier: "PROJ-5"}
 
-		SweepTerminalWorkspaces(state, defaultSweepParams(t, tmpDir, tracker))
+		SweepWorkspaces(state, defaultSweepParams(t, tmpDir, tracker))
 
 		assertSweepDirExists(t, filepath.Join(tmpDir, "PROJ-5"))
 		assertSweepDirRemoved(t, filepath.Join(tmpDir, "PROJ-6"))
@@ -1255,7 +1258,7 @@ func TestSweepTerminalWorkspaces(t *testing.T) {
 		}
 		state := NewState(5000, 4, nil, AgentTotals{})
 
-		SweepTerminalWorkspaces(state, defaultSweepParams(t, tmpDir, tracker))
+		SweepWorkspaces(state, defaultSweepParams(t, tmpDir, tracker))
 
 		assertSweepDirRemoved(t, filepath.Join(tmpDir, "PROJ-7"))
 		assertSweepDirExists(t, filepath.Join(tmpDir, "PROJ-8"))
@@ -1272,7 +1275,7 @@ func TestSweepTerminalWorkspaces(t *testing.T) {
 		}
 		state := NewState(5000, 4, nil, AgentTotals{})
 
-		SweepTerminalWorkspaces(state, defaultSweepParams(t, tmpDir, tracker))
+		SweepWorkspaces(state, defaultSweepParams(t, tmpDir, tracker))
 
 		assertSweepDirExists(t, filepath.Join(tmpDir, "PROJ-9"))
 	})
@@ -1289,7 +1292,7 @@ func TestSweepTerminalWorkspaces(t *testing.T) {
 		}
 		state := NewState(5000, 4, nil, AgentTotals{})
 
-		SweepTerminalWorkspaces(state, defaultSweepParams(t, tmpDir, tracker))
+		SweepWorkspaces(state, defaultSweepParams(t, tmpDir, tracker))
 
 		assertSweepDirExists(t, filepath.Join(tmpDir, "PROJ-9"))
 	})
@@ -1309,7 +1312,7 @@ func TestSweepTerminalWorkspaces(t *testing.T) {
 		params := defaultSweepParams(t, tmpDir, tracker)
 		params.Metrics = spy
 
-		SweepTerminalWorkspaces(state, params)
+		SweepWorkspaces(state, params)
 
 		spy.mu.Lock()
 		acts := append([]string(nil), spy.reconciliationActs...)
@@ -1481,5 +1484,830 @@ func TestReconcileRunningIssues_ReactionInUnrelatedStateCancels(t *testing.T) {
 	}
 	if len(store.deletedIssueID) != 1 {
 		t.Fatalf("DeleteRetryEntry called %d times, want 1", len(store.deletedIssueID))
+	}
+}
+
+// --- Age pass (workspace.retention_days) test doubles and helpers ---
+
+// sweepStoreDouble is a test double for [SweepStore] returning a fixed
+// completions map or a fixed error.
+type sweepStoreDouble struct {
+	completions map[string]string
+	err         error
+}
+
+var _ SweepStore = (*sweepStoreDouble)(nil)
+
+func (s *sweepStoreDouble) LatestRunCompletionByIdentifier(_ context.Context, identifiers []string) (map[string]string, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	out := make(map[string]string, len(identifiers))
+	for _, id := range identifiers {
+		if v, ok := s.completions[id]; ok {
+			out[id] = v
+		}
+	}
+	return out, nil
+}
+
+// sweepRecord captures one slog record's message and attributes, keyed
+// by attribute name, for the age-pass summary and log assertions.
+type sweepRecord struct {
+	message string
+	attrs   map[string]any
+}
+
+// sweepLogHandler is a slog.Handler that captures every record it
+// receives for later inspection.
+type sweepLogHandler struct {
+	records []sweepRecord
+}
+
+func (h *sweepLogHandler) Enabled(_ context.Context, _ slog.Level) bool { return true }
+
+func (h *sweepLogHandler) Handle(_ context.Context, r slog.Record) error {
+	attrs := make(map[string]any, r.NumAttrs())
+	r.Attrs(func(a slog.Attr) bool {
+		attrs[a.Key] = a.Value.Any()
+		return true
+	})
+	h.records = append(h.records, sweepRecord{message: r.Message, attrs: attrs})
+	return nil
+}
+
+func (h *sweepLogHandler) WithAttrs(_ []slog.Attr) slog.Handler { return h }
+func (h *sweepLogHandler) WithGroup(_ string) slog.Handler      { return h }
+
+// countByMessage returns the number of captured records with the given message.
+func (h *sweepLogHandler) countByMessage(msg string) int {
+	n := 0
+	for _, r := range h.records {
+		if r.message == msg {
+			n++
+		}
+	}
+	return n
+}
+
+// findByMessage returns the first captured record with the given message.
+func (h *sweepLogHandler) findByMessage(msg string) (sweepRecord, bool) {
+	for _, r := range h.records {
+		if r.message == msg {
+			return r, true
+		}
+	}
+	return sweepRecord{}, false
+}
+
+// intAttr returns the record's attribute at key as an int, failing the
+// test if the attribute is absent or not an int64 value.
+func intAttr(t *testing.T, rec sweepRecord, key string) int {
+	t.Helper()
+	v, ok := rec.attrs[key]
+	if !ok {
+		t.Fatalf("record %q missing attribute %q", rec.message, key)
+	}
+	n, ok := v.(int64)
+	if !ok {
+		t.Fatalf("record %q attribute %q = %T, want int64", rec.message, key, v)
+	}
+	return int(n)
+}
+
+// stringAttr returns the record's attribute at key as a string, failing
+// the test if the attribute is absent or not a string value.
+func stringAttr(t *testing.T, rec sweepRecord, key string) string {
+	t.Helper()
+	v, ok := rec.attrs[key]
+	if !ok {
+		t.Fatalf("record %q missing attribute %q", rec.message, key)
+	}
+	s, ok := v.(string)
+	if !ok {
+		t.Fatalf("record %q attribute %q = %T, want string", rec.message, key, v)
+	}
+	return s
+}
+
+// assertSweepPartitionIdentity asserts that the summary record's
+// candidates attribute equals the sum of the other nine outcome
+// counters, the partition identity the summary record must hold on
+// every pass.
+func assertSweepPartitionIdentity(t *testing.T, rec sweepRecord) {
+	t.Helper()
+	candidates := intAttr(t, rec, "candidates")
+	sum := intAttr(t, rec, "excluded_running") +
+		intAttr(t, rec, "excluded_retry") +
+		intAttr(t, rec, "excluded_reaction") +
+		intAttr(t, rec, "removed_terminal") +
+		intAttr(t, rec, "removed_age") +
+		intAttr(t, rec, "retained_in_window") +
+		intAttr(t, rec, "retained_no_activity") +
+		intAttr(t, rec, "retained_not_evaluated") +
+		intAttr(t, rec, "failed")
+	if candidates != sum {
+		t.Errorf("sweep summary candidates = %d, want sum of other counters %d", candidates, sum)
+	}
+}
+
+// writeSweepSCMMetadata writes a minimal .sortie/scm.json under
+// workspacePath carrying pushedAt as the pushed_at field. Branch is set
+// to a fixed non-empty value because workspace.ReadSCMMetadata discards
+// the whole record when Branch is empty.
+func writeSweepSCMMetadata(t *testing.T, workspacePath, pushedAt string) {
+	t.Helper()
+	dotSortie := filepath.Join(workspacePath, ".sortie")
+	if err := os.MkdirAll(dotSortie, 0o755); err != nil {
+		t.Fatalf("os.MkdirAll(%q): %v", dotSortie, err)
+	}
+	meta := fmt.Sprintf(`{"branch":"feature/sweep-test","pushed_at":%q}`, pushedAt)
+	if err := os.WriteFile(filepath.Join(dotSortie, "scm.json"), []byte(meta), 0o644); err != nil {
+		t.Fatalf("os.WriteFile(scm.json): %v", err)
+	}
+}
+
+// oldSweepTimestamp returns an RFC3339 timestamp well outside a
+// [config.WorkspaceRetentionMinDays] window, for age-removal cases.
+func oldSweepTimestamp() string {
+	return time.Now().UTC().Add(-40 * 24 * time.Hour).Format(time.RFC3339)
+}
+
+// recentSweepTimestamp returns an RFC3339 timestamp inside a
+// [config.WorkspaceRetentionMinDays] window, for age-retention cases.
+func recentSweepTimestamp() string {
+	return time.Now().UTC().Add(-2 * 24 * time.Hour).Format(time.RFC3339)
+}
+
+// --- R6: the retention floor and the recovery lookback are coupled ---
+
+// TestWorkspaceRetentionFloorMatchesRecoveryLookback asserts the equality
+// [Spec-706 §3.3.5] relies on: the age pass never removes a workspace
+// pending-reaction recovery would not already have treated as stale.
+// Changing either constant without the other reintroduces that defect.
+func TestWorkspaceRetentionFloorMatchesRecoveryLookback(t *testing.T) {
+	t.Parallel()
+
+	floor := time.Duration(config.WorkspaceRetentionMinDays) * 24 * time.Hour
+	if floor != PendingReactionRecoveryLookback {
+		t.Errorf("WorkspaceRetentionMinDays as a duration = %v, want equal to PendingReactionRecoveryLookback %v",
+			floor, PendingReactionRecoveryLookback)
+	}
+}
+
+// --- R10: the narrowed pending-reaction exclusion ---
+
+func TestSweepWorkspaces_NarrowedReactionExclusion(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	mustMkdirSweep(t, filepath.Join(tmpDir, "PROJ-LR"))
+	mustMkdirSweep(t, filepath.Join(tmpDir, "PROJ-RV"))
+
+	tracker := &sweepTracker{statesByKey: map[string]string{"PROJ-LR": "In Progress"}}
+	state := NewState(5000, 4, nil, AgentTotals{})
+	state.PendingReactions["id-lr:label-review"] = &PendingReaction{Identifier: "PROJ-LR", Kind: ReactionKindLabelReview}
+	state.PendingReactions["id-rv:review"] = &PendingReaction{Identifier: "PROJ-RV", Kind: ReactionKindReview}
+
+	SweepWorkspaces(state, defaultSweepParams(t, tmpDir, tracker))
+
+	if !slices.Contains(tracker.calledWith, "PROJ-LR") {
+		t.Errorf("FetchIssueStatesByIdentifiers received %v, want to contain %q (label-review must not exclude)", tracker.calledWith, "PROJ-LR")
+	}
+	if slices.Contains(tracker.calledWith, "PROJ-RV") {
+		t.Errorf("FetchIssueStatesByIdentifiers received %v, want to omit %q (review must exclude)", tracker.calledWith, "PROJ-RV")
+	}
+}
+
+// --- R12: the summary partition identity across six pass shapes ---
+
+func TestSweepWorkspaces_SummaryPartitionIdentity(t *testing.T) {
+	t.Parallel()
+
+	t.Run("ZeroKeysOnDisk", func(t *testing.T) {
+		t.Parallel()
+
+		tmpDir := t.TempDir()
+		tracker := &sweepTracker{}
+		state := NewState(5000, 4, nil, AgentTotals{})
+		handler := &sweepLogHandler{}
+		params := defaultSweepParams(t, tmpDir, tracker)
+		params.Logger = slog.New(handler)
+
+		SweepWorkspaces(state, params)
+
+		if got := handler.countByMessage("sweep: pass complete"); got != 1 {
+			t.Fatalf(`"sweep: pass complete" logged %d times, want 1`, got)
+		}
+		rec, _ := handler.findByMessage("sweep: pass complete")
+		if got := intAttr(t, rec, "candidates"); got != 0 {
+			t.Errorf("candidates = %d, want 0", got)
+		}
+		assertSweepPartitionIdentity(t, rec)
+	})
+
+	t.Run("EveryListedKeyInFlight", func(t *testing.T) {
+		t.Parallel()
+
+		tmpDir := t.TempDir()
+		mustMkdirSweep(t, filepath.Join(tmpDir, "PROJ-RUN"))
+		mustMkdirSweep(t, filepath.Join(tmpDir, "PROJ-RETRY"))
+		mustMkdirSweep(t, filepath.Join(tmpDir, "PROJ-REACT"))
+
+		tracker := &sweepTracker{}
+		state := NewState(5000, 4, nil, AgentTotals{})
+		state.Running["id-run"] = &RunningEntry{Identifier: "PROJ-RUN"}
+		state.RetryAttempts["id-retry"] = &RetryEntry{Identifier: "PROJ-RETRY"}
+		state.PendingReactions["id-react:ci"] = &PendingReaction{Identifier: "PROJ-REACT", Kind: ReactionKindCI}
+		handler := &sweepLogHandler{}
+		params := defaultSweepParams(t, tmpDir, tracker)
+		params.Logger = slog.New(handler)
+
+		SweepWorkspaces(state, params)
+
+		if tracker.calledWith != nil {
+			t.Errorf("FetchIssueStatesByIdentifiers called with %v, want not called (nothing remains)", tracker.calledWith)
+		}
+		rec, _ := handler.findByMessage("sweep: pass complete")
+		if got := intAttr(t, rec, "candidates"); got != 3 {
+			t.Errorf("candidates = %d, want 3", got)
+		}
+		if got := intAttr(t, rec, "excluded_running"); got != 1 {
+			t.Errorf("excluded_running = %d, want 1", got)
+		}
+		if got := intAttr(t, rec, "excluded_retry"); got != 1 {
+			t.Errorf("excluded_retry = %d, want 1", got)
+		}
+		if got := intAttr(t, rec, "excluded_reaction"); got != 1 {
+			t.Errorf("excluded_reaction = %d, want 1", got)
+		}
+		assertSweepPartitionIdentity(t, rec)
+	})
+
+	t.Run("FailedTrackerRead", func(t *testing.T) {
+		t.Parallel()
+
+		tmpDir := t.TempDir()
+		mustMkdirSweep(t, filepath.Join(tmpDir, "PROJ-FAIL"))
+
+		tracker := &sweepTracker{fetchErr: errors.New("tracker unavailable")}
+		state := NewState(5000, 4, nil, AgentTotals{})
+		handler := &sweepLogHandler{}
+		params := defaultSweepParams(t, tmpDir, tracker)
+		params.Logger = slog.New(handler)
+
+		SweepWorkspaces(state, params)
+
+		rec, _ := handler.findByMessage("sweep: pass complete")
+		if got := stringAttr(t, rec, "tracker_read"); got != "failed" {
+			t.Errorf("tracker_read = %q, want %q", got, "failed")
+		}
+		if got := intAttr(t, rec, "retained_not_evaluated"); got != 1 {
+			t.Errorf("retained_not_evaluated = %d, want 1 (bound off by default)", got)
+		}
+		assertSweepPartitionIdentity(t, rec)
+	})
+
+	t.Run("BoundOffRetainsNotEvaluatedCount", func(t *testing.T) {
+		t.Parallel()
+
+		tmpDir := t.TempDir()
+		mustMkdirSweep(t, filepath.Join(tmpDir, "PROJ-EXCL"))
+		mustMkdirSweep(t, filepath.Join(tmpDir, "PROJ-CAND1"))
+		mustMkdirSweep(t, filepath.Join(tmpDir, "PROJ-CAND2"))
+
+		tracker := &sweepTracker{statesByKey: map[string]string{
+			"PROJ-CAND1": "In Progress",
+			"PROJ-CAND2": "In Progress",
+		}}
+		state := NewState(5000, 4, nil, AgentTotals{})
+		state.Running["id-excl"] = &RunningEntry{Identifier: "PROJ-EXCL"}
+		handler := &sweepLogHandler{}
+		params := defaultSweepParams(t, tmpDir, tracker) // RetentionDays zero value: bound off
+
+		params.Logger = slog.New(handler)
+
+		SweepWorkspaces(state, params)
+
+		rec, _ := handler.findByMessage("sweep: pass complete")
+		if got := stringAttr(t, rec, "age_pass"); got != "off" {
+			t.Errorf("age_pass = %q, want %q", got, "off")
+		}
+		if got := intAttr(t, rec, "retained_not_evaluated"); got != 2 {
+			t.Errorf("retained_not_evaluated = %d, want 2", got)
+		}
+		assertSweepPartitionIdentity(t, rec)
+	})
+
+	t.Run("BoundOnNilStore", func(t *testing.T) {
+		t.Parallel()
+
+		tmpDir := t.TempDir()
+		mustMkdirSweep(t, filepath.Join(tmpDir, "PROJ-NILSTORE"))
+
+		tracker := &sweepTracker{statesByKey: map[string]string{}}
+		state := NewState(5000, 4, nil, AgentTotals{})
+		handler := &sweepLogHandler{}
+		params := defaultSweepParams(t, tmpDir, tracker)
+		params.RetentionDays = config.WorkspaceRetentionMinDays
+		params.Store = nil
+		params.Logger = slog.New(handler)
+
+		SweepWorkspaces(state, params)
+
+		rec, _ := handler.findByMessage("sweep: pass complete")
+		if got := stringAttr(t, rec, "age_pass"); got != "unavailable" {
+			t.Errorf("age_pass = %q, want %q", got, "unavailable")
+		}
+		if got := intAttr(t, rec, "retained_not_evaluated"); got != 1 {
+			t.Errorf("retained_not_evaluated = %d, want 1", got)
+		}
+		assertSweepPartitionIdentity(t, rec)
+	})
+
+	t.Run("BoundOnStoreReadError", func(t *testing.T) {
+		t.Parallel()
+
+		tmpDir := t.TempDir()
+		mustMkdirSweep(t, filepath.Join(tmpDir, "PROJ-STOREERR"))
+
+		tracker := &sweepTracker{statesByKey: map[string]string{}}
+		state := NewState(5000, 4, nil, AgentTotals{})
+		handler := &sweepLogHandler{}
+		params := defaultSweepParams(t, tmpDir, tracker)
+		params.RetentionDays = config.WorkspaceRetentionMinDays
+		params.Store = &sweepStoreDouble{err: errors.New("db unavailable")}
+		params.Logger = slog.New(handler)
+
+		SweepWorkspaces(state, params)
+
+		rec, _ := handler.findByMessage("sweep: pass complete")
+		if got := stringAttr(t, rec, "age_pass"); got != "unavailable" {
+			t.Errorf("age_pass = %q, want %q", got, "unavailable")
+		}
+		if got := intAttr(t, rec, "retained_not_evaluated"); got != 1 {
+			t.Errorf("retained_not_evaluated = %d, want 1", got)
+		}
+		assertSweepPartitionIdentity(t, rec)
+	})
+}
+
+// --- R13: terminal-and-old is counted once, under removed_terminal ---
+
+func TestSweepWorkspaces_TerminalAndOldCountedOnceUnderTerminal(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	wsPath := filepath.Join(tmpDir, "PROJ-BOTH")
+	mustMkdirSweep(t, wsPath)
+	writeSweepSCMMetadata(t, wsPath, oldSweepTimestamp())
+
+	tracker := &sweepTracker{statesByKey: map[string]string{"PROJ-BOTH": "Done"}}
+	state := NewState(5000, 4, nil, AgentTotals{})
+	handler := &sweepLogHandler{}
+	params := defaultSweepParams(t, tmpDir, tracker)
+	params.RetentionDays = config.WorkspaceRetentionMinDays
+	params.Store = &sweepStoreDouble{}
+	params.Logger = slog.New(handler)
+
+	SweepWorkspaces(state, params)
+
+	assertSweepDirRemoved(t, wsPath)
+	rec, _ := handler.findByMessage("sweep: pass complete")
+	if got := intAttr(t, rec, "removed_terminal"); got != 1 {
+		t.Errorf("removed_terminal = %d, want 1", got)
+	}
+	if got := intAttr(t, rec, "removed_age"); got != 0 {
+		t.Errorf("removed_age = %d, want 0 (terminal check runs first and claims the key)", got)
+	}
+}
+
+// --- R14: Cleanup receives Identifier and IssueID both set to the key ---
+
+func TestSweepWorkspaces_AgeRemovalUsesIdentifierAndIssueIDAsKey(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	const key = "PROJ-HOOK"
+	wsPath := filepath.Join(tmpDir, key)
+	mustMkdirSweep(t, wsPath)
+	writeSweepSCMMetadata(t, wsPath, oldSweepTimestamp())
+
+	markerDir := t.TempDir()
+	envFile := filepath.Join(markerDir, "env.txt")
+	script := `printf "%s\n%s" "$SORTIE_ISSUE_ID" "$SORTIE_ISSUE_IDENTIFIER" > "` + envFile + `"`
+
+	tracker := &sweepTracker{statesByKey: map[string]string{}}
+	state := NewState(5000, 4, nil, AgentTotals{})
+	params := defaultSweepParams(t, tmpDir, tracker)
+	params.RetentionDays = config.WorkspaceRetentionMinDays
+	params.Store = &sweepStoreDouble{}
+	params.BeforeRemoveHook = script
+	params.HookTimeoutMS = 5000
+
+	SweepWorkspaces(state, params)
+
+	assertSweepDirRemoved(t, wsPath)
+	data, err := os.ReadFile(envFile)
+	if err != nil {
+		t.Fatalf("os.ReadFile(%q): %v", envFile, err)
+	}
+	lines := strings.Split(string(data), "\n")
+	if len(lines) != 2 || lines[0] != key || lines[1] != key {
+		t.Errorf("before_remove hook env (SORTIE_ISSUE_ID, SORTIE_ISSUE_IDENTIFIER) = %v, want both %q", lines, key)
+	}
+}
+
+// --- R15: the age pass removes eligible candidates on a failed tracker read ---
+
+func TestSweepWorkspaces_AgePassRemovesOnTrackerReadFailure(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	wsPath := filepath.Join(tmpDir, "PROJ-TRKFAIL")
+	mustMkdirSweep(t, wsPath)
+	writeSweepSCMMetadata(t, wsPath, oldSweepTimestamp())
+
+	tracker := &sweepTracker{fetchErr: errors.New("tracker unavailable")}
+	state := NewState(5000, 4, nil, AgentTotals{})
+	handler := &sweepLogHandler{}
+	params := defaultSweepParams(t, tmpDir, tracker)
+	params.RetentionDays = config.WorkspaceRetentionMinDays
+	params.Store = &sweepStoreDouble{}
+	params.Logger = slog.New(handler)
+
+	SweepWorkspaces(state, params)
+
+	assertSweepDirRemoved(t, wsPath)
+	rec, _ := handler.findByMessage("sweep: pass complete")
+	if got := intAttr(t, rec, "removed_age"); got != 1 {
+		t.Errorf("removed_age = %d, want 1", got)
+	}
+	if got := stringAttr(t, rec, "tracker_read"); got != "failed" {
+		t.Errorf("tracker_read = %q, want %q", got, "failed")
+	}
+}
+
+// --- R16: removal by age is independent of the issue's tracker condition ---
+
+func TestSweepWorkspaces_RemovedByAgeRegardlessOfTrackerCondition(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name      string
+		stateName string
+		absent    bool
+	}{
+		{name: "HandoffState", stateName: "Ready For Review"},
+		{name: "ActiveState", stateName: "In Progress"},
+		{name: "UnnamedState", stateName: "Some Other State"},
+		{name: "AbsentFromTrackerResponse", absent: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			tmpDir := t.TempDir()
+			key := "PROJ-" + tc.name
+			wsPath := filepath.Join(tmpDir, key)
+			mustMkdirSweep(t, wsPath)
+			writeSweepSCMMetadata(t, wsPath, oldSweepTimestamp())
+
+			statesByKey := map[string]string{}
+			if !tc.absent {
+				statesByKey[key] = tc.stateName
+			}
+			tracker := &sweepTracker{statesByKey: statesByKey}
+			state := NewState(5000, 4, nil, AgentTotals{})
+			params := defaultSweepParams(t, tmpDir, tracker)
+			params.RetentionDays = config.WorkspaceRetentionMinDays
+			params.Store = &sweepStoreDouble{}
+
+			SweepWorkspaces(state, params)
+
+			assertSweepDirRemoved(t, wsPath)
+		})
+	}
+}
+
+// --- R17: no parseable activity retains the workspace regardless of age ---
+
+func TestSweepWorkspaces_RetainedNoActivity(t *testing.T) {
+	t.Parallel()
+
+	t.Run("NoRunHistoryAndNoSCMMetadata", func(t *testing.T) {
+		t.Parallel()
+
+		tmpDir := t.TempDir()
+		wsPath := filepath.Join(tmpDir, "PROJ-NOACT")
+		mustMkdirSweep(t, wsPath)
+
+		tracker := &sweepTracker{}
+		state := NewState(5000, 4, nil, AgentTotals{})
+		handler := &sweepLogHandler{}
+		params := defaultSweepParams(t, tmpDir, tracker)
+		params.RetentionDays = config.WorkspaceRetentionMinDays
+		params.Store = &sweepStoreDouble{}
+		params.Logger = slog.New(handler)
+
+		SweepWorkspaces(state, params)
+
+		assertSweepDirExists(t, wsPath)
+		rec, _ := handler.findByMessage("sweep: pass complete")
+		if got := intAttr(t, rec, "retained_no_activity"); got != 1 {
+			t.Errorf("retained_no_activity = %d, want 1", got)
+		}
+	})
+
+	t.Run("UnparseableCompletion", func(t *testing.T) {
+		t.Parallel()
+
+		tmpDir := t.TempDir()
+		const key = "PROJ-BADTIME"
+		wsPath := filepath.Join(tmpDir, key)
+		mustMkdirSweep(t, wsPath)
+
+		tracker := &sweepTracker{}
+		state := NewState(5000, 4, nil, AgentTotals{})
+		handler := &sweepLogHandler{}
+		params := defaultSweepParams(t, tmpDir, tracker)
+		params.RetentionDays = config.WorkspaceRetentionMinDays
+		params.Store = &sweepStoreDouble{completions: map[string]string{key: "not-a-time"}}
+		params.Logger = slog.New(handler)
+
+		SweepWorkspaces(state, params)
+
+		assertSweepDirExists(t, wsPath)
+		rec, _ := handler.findByMessage("sweep: pass complete")
+		if got := intAttr(t, rec, "retained_no_activity"); got != 1 {
+			t.Errorf("retained_no_activity = %d, want 1", got)
+		}
+	})
+}
+
+// --- R18: the anchor is the later of the two parsed timestamps ---
+
+func TestSweepWorkspaces_AnchorIsLaterTimestamp(t *testing.T) {
+	t.Parallel()
+
+	t.Run("OldCompletionRecentPush_Retained", func(t *testing.T) {
+		t.Parallel()
+
+		tmpDir := t.TempDir()
+		const key = "PROJ-ANCHOR1"
+		wsPath := filepath.Join(tmpDir, key)
+		mustMkdirSweep(t, wsPath)
+		writeSweepSCMMetadata(t, wsPath, recentSweepTimestamp())
+
+		tracker := &sweepTracker{}
+		state := NewState(5000, 4, nil, AgentTotals{})
+		params := defaultSweepParams(t, tmpDir, tracker)
+		params.RetentionDays = config.WorkspaceRetentionMinDays
+		params.Store = &sweepStoreDouble{completions: map[string]string{key: oldSweepTimestamp()}}
+
+		SweepWorkspaces(state, params)
+
+		assertSweepDirExists(t, wsPath)
+	})
+
+	t.Run("RecentCompletionOldPush_Retained", func(t *testing.T) {
+		t.Parallel()
+
+		tmpDir := t.TempDir()
+		const key = "PROJ-ANCHOR2"
+		wsPath := filepath.Join(tmpDir, key)
+		mustMkdirSweep(t, wsPath)
+		writeSweepSCMMetadata(t, wsPath, oldSweepTimestamp())
+
+		tracker := &sweepTracker{}
+		state := NewState(5000, 4, nil, AgentTotals{})
+		params := defaultSweepParams(t, tmpDir, tracker)
+		params.RetentionDays = config.WorkspaceRetentionMinDays
+		params.Store = &sweepStoreDouble{completions: map[string]string{key: recentSweepTimestamp()}}
+
+		SweepWorkspaces(state, params)
+
+		assertSweepDirExists(t, wsPath)
+	})
+
+	t.Run("BothOld_Removed", func(t *testing.T) {
+		t.Parallel()
+
+		tmpDir := t.TempDir()
+		const key = "PROJ-ANCHOR3"
+		wsPath := filepath.Join(tmpDir, key)
+		mustMkdirSweep(t, wsPath)
+		writeSweepSCMMetadata(t, wsPath, oldSweepTimestamp())
+
+		tracker := &sweepTracker{}
+		state := NewState(5000, 4, nil, AgentTotals{})
+		params := defaultSweepParams(t, tmpDir, tracker)
+		params.RetentionDays = config.WorkspaceRetentionMinDays
+		params.Store = &sweepStoreDouble{completions: map[string]string{key: oldSweepTimestamp()}}
+
+		SweepWorkspaces(state, params)
+
+		assertSweepDirRemoved(t, wsPath)
+	})
+}
+
+// --- R19: running/retry precedence in the in-flight exclusion ---
+
+func TestSweepWorkspaces_InFlightPrecedence(t *testing.T) {
+	t.Parallel()
+
+	t.Run("RunningOnly", func(t *testing.T) {
+		t.Parallel()
+
+		tmpDir := t.TempDir()
+		mustMkdirSweep(t, filepath.Join(tmpDir, "PROJ-RUNONLY"))
+
+		tracker := &sweepTracker{}
+		state := NewState(5000, 4, nil, AgentTotals{})
+		state.Running["id-run"] = &RunningEntry{Identifier: "PROJ-RUNONLY"}
+		handler := &sweepLogHandler{}
+		params := defaultSweepParams(t, tmpDir, tracker)
+		params.Logger = slog.New(handler)
+
+		SweepWorkspaces(state, params)
+
+		rec, _ := handler.findByMessage("sweep: pass complete")
+		if got := intAttr(t, rec, "excluded_running"); got != 1 {
+			t.Errorf("excluded_running = %d, want 1", got)
+		}
+		if got := intAttr(t, rec, "excluded_retry"); got != 0 {
+			t.Errorf("excluded_retry = %d, want 0", got)
+		}
+	})
+
+	t.Run("RetryOnly", func(t *testing.T) {
+		t.Parallel()
+
+		tmpDir := t.TempDir()
+		mustMkdirSweep(t, filepath.Join(tmpDir, "PROJ-RETRYONLY"))
+
+		tracker := &sweepTracker{}
+		state := NewState(5000, 4, nil, AgentTotals{})
+		state.RetryAttempts["id-retry"] = &RetryEntry{Identifier: "PROJ-RETRYONLY"}
+		handler := &sweepLogHandler{}
+		params := defaultSweepParams(t, tmpDir, tracker)
+		params.Logger = slog.New(handler)
+
+		SweepWorkspaces(state, params)
+
+		rec, _ := handler.findByMessage("sweep: pass complete")
+		if got := intAttr(t, rec, "excluded_running"); got != 0 {
+			t.Errorf("excluded_running = %d, want 0", got)
+		}
+		if got := intAttr(t, rec, "excluded_retry"); got != 1 {
+			t.Errorf("excluded_retry = %d, want 1", got)
+		}
+	})
+
+	t.Run("RunningTakesPrecedenceOverRetry", func(t *testing.T) {
+		t.Parallel()
+
+		tmpDir := t.TempDir()
+		mustMkdirSweep(t, filepath.Join(tmpDir, "PROJ-BOTHFLIGHT"))
+
+		tracker := &sweepTracker{}
+		state := NewState(5000, 4, nil, AgentTotals{})
+		state.Running["id-run"] = &RunningEntry{Identifier: "PROJ-BOTHFLIGHT"}
+		state.RetryAttempts["id-retry"] = &RetryEntry{Identifier: "PROJ-BOTHFLIGHT"}
+		handler := &sweepLogHandler{}
+		params := defaultSweepParams(t, tmpDir, tracker)
+		params.Logger = slog.New(handler)
+
+		SweepWorkspaces(state, params)
+
+		rec, _ := handler.findByMessage("sweep: pass complete")
+		if got := intAttr(t, rec, "excluded_running"); got != 1 {
+			t.Errorf("excluded_running = %d, want 1 (running takes precedence)", got)
+		}
+		if got := intAttr(t, rec, "excluded_retry"); got != 0 {
+			t.Errorf("excluded_retry = %d, want 0 (already counted as running)", got)
+		}
+	})
+}
+
+// --- R20: the sweep performs no reaction- or fingerprint-state mutation ---
+
+func TestSweepWorkspaces_AgeRemovalLeavesPendingReactionsAndFingerprintsUnchanged(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	wsPath := filepath.Join(tmpDir, "PROJ-NOSIDEFX")
+	mustMkdirSweep(t, wsPath)
+	writeSweepSCMMetadata(t, wsPath, oldSweepTimestamp())
+
+	ctx := context.Background()
+	store := openInMemoryStore(t)
+	if err := store.UpsertReactionFingerprint(ctx, "issue-nosidefx", ReactionKindCI, "fp-nosidefx"); err != nil {
+		t.Fatalf("UpsertReactionFingerprint: %v", err)
+	}
+
+	state := NewState(5000, 4, nil, AgentTotals{})
+	state.PendingReactions["other:ci"] = &PendingReaction{Identifier: "OTHER-1", Kind: ReactionKindCI}
+
+	tracker := &sweepTracker{}
+	params := defaultSweepParams(t, tmpDir, tracker)
+	params.RetentionDays = config.WorkspaceRetentionMinDays
+	params.Store = store
+	params.Ctx = ctx
+
+	SweepWorkspaces(state, params)
+
+	assertSweepDirRemoved(t, wsPath)
+	if len(state.PendingReactions) != 1 {
+		t.Errorf("len(state.PendingReactions) = %d, want 1 (unchanged)", len(state.PendingReactions))
+	}
+	fp, dispatched, err := store.GetReactionFingerprint(ctx, "issue-nosidefx", ReactionKindCI)
+	if err != nil {
+		t.Fatalf("GetReactionFingerprint: %v", err)
+	}
+	if fp != "fp-nosidefx" || dispatched {
+		t.Errorf("GetReactionFingerprint = (%q, %v), want (%q, false)", fp, dispatched, "fp-nosidefx")
+	}
+}
+
+// --- R22: both removal mechanisms record their own metric in one pass ---
+
+func TestSweepWorkspaces_MetricsRecordBothMechanismsInSamePass(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	terminalWsPath := filepath.Join(tmpDir, "PROJ-METRIC-TERM")
+	mustMkdirSweep(t, terminalWsPath)
+	ageWsPath := filepath.Join(tmpDir, "PROJ-METRIC-AGE")
+	mustMkdirSweep(t, ageWsPath)
+	writeSweepSCMMetadata(t, ageWsPath, oldSweepTimestamp())
+
+	tracker := &sweepTracker{statesByKey: map[string]string{"PROJ-METRIC-TERM": "Done"}}
+	state := NewState(5000, 4, nil, AgentTotals{})
+	spy := &spyMetrics{}
+	params := defaultSweepParams(t, tmpDir, tracker)
+	params.Metrics = spy
+	params.RetentionDays = config.WorkspaceRetentionMinDays
+	params.Store = &sweepStoreDouble{}
+
+	SweepWorkspaces(state, params)
+
+	assertSweepDirRemoved(t, terminalWsPath)
+	assertSweepDirRemoved(t, ageWsPath)
+
+	spy.mu.Lock()
+	acts := append([]string(nil), spy.reconciliationActs...)
+	spy.mu.Unlock()
+
+	var cleanupCount, expiredCount int
+	for _, a := range acts {
+		switch a {
+		case actionSweepCleanup:
+			cleanupCount++
+		case actionSweepExpired:
+			expiredCount++
+		}
+	}
+	if cleanupCount != 1 {
+		t.Errorf("IncReconciliationActions(%q) called %d times, want 1", actionSweepCleanup, cleanupCount)
+	}
+	if expiredCount != 1 {
+		t.Errorf("IncReconciliationActions(%q) called %d times, want 1", actionSweepExpired, expiredCount)
+	}
+}
+
+// --- R23: an age removal log record carries the required attributes ---
+
+func TestSweepWorkspaces_AgeRemovalLogCarriesRequiredAttributes(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	const key = "PROJ-LOGATTRS"
+	wsPath := filepath.Join(tmpDir, key)
+	mustMkdirSweep(t, wsPath)
+	writeSweepSCMMetadata(t, wsPath, oldSweepTimestamp())
+
+	tracker := &sweepTracker{}
+	state := NewState(5000, 4, nil, AgentTotals{})
+	handler := &sweepLogHandler{}
+	params := defaultSweepParams(t, tmpDir, tracker)
+	params.RetentionDays = config.WorkspaceRetentionMinDays
+	params.Store = &sweepStoreDouble{}
+	params.Logger = slog.New(handler)
+
+	SweepWorkspaces(state, params)
+
+	rec, ok := handler.findByMessage("sweep: removed expired workspace")
+	if !ok {
+		t.Fatal(`"sweep: removed expired workspace" not logged`)
+	}
+	for _, attrKey := range []string{"workspace_key", "last_activity", "age_days"} {
+		if _, ok := rec.attrs[attrKey]; !ok {
+			t.Errorf("removed-workspace log missing attribute %q", attrKey)
+		}
+	}
+	if got := stringAttr(t, rec, "workspace_key"); got != key {
+		t.Errorf("workspace_key = %q, want %q", got, key)
 	}
 }

--- a/internal/orchestrator/reconcile_test.go
+++ b/internal/orchestrator/reconcile_test.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"runtime"
 	"slices"
 	"sort"
 	"strings"
@@ -1885,6 +1886,9 @@ func TestSweepWorkspaces_TerminalAndOldCountedOnceUnderTerminal(t *testing.T) {
 // --- R14: Cleanup receives Identifier and IssueID both set to the key ---
 
 func TestSweepWorkspaces_AgeRemovalUsesIdentifierAndIssueIDAsKey(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("probe hook uses printf and $VAR expansion, unavailable under cmd.exe")
+	}
 	t.Parallel()
 
 	tmpDir := t.TempDir()

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -37,6 +37,7 @@ const (
 	actionCleanup      = "cleanup"
 	actionKeep         = "keep"
 	actionSweepCleanup = "sweep_cleanup"
+	actionSweepExpired = "sweep_expired"
 
 	handoffSuccess = "success"
 	handoffError   = "error"
@@ -356,13 +357,39 @@ const ReactionKindLabelFix = "label-fix"
 // lifetime.
 const AutoMergePreflightRetryDelay time.Duration = 5 * time.Minute
 
+// reactionKindPins is the single registry of reaction kinds. A kind
+// present in the map is a known kind; its value reports whether a
+// pending entry of that kind pins its workspace against sweep
+// candidacy. Both [isKnownReactionKind] and [reactionKindPinsWorkspace]
+// read this map, so a kind cannot be recognized without carrying an
+// explicit pin classification.
+var reactionKindPins = map[string]bool{
+	ReactionKindCI:            true,
+	ReactionKindReview:        true,
+	ReactionKindBotReview:     true,
+	ReactionKindAutoMerge:     true,
+	ReactionKindMergeConflict: true,
+	ReactionKindLabelReview:   false,
+	ReactionKindLabelFix:      false,
+}
+
 func isKnownReactionKind(kind string) bool {
-	switch kind {
-	case ReactionKindCI, ReactionKindReview, ReactionKindBotReview, ReactionKindAutoMerge, ReactionKindMergeConflict, ReactionKindLabelReview, ReactionKindLabelFix:
+	_, known := reactionKindPins[kind]
+	return known
+}
+
+// reactionKindPinsWorkspace reports whether a pending reaction entry of
+// the given kind excludes its workspace from sweep candidacy.
+//
+// An unregistered kind returns true, the non-destructive default,
+// because retention rather than removal is the safe outcome for a kind
+// the rest of the system does not yet classify.
+func reactionKindPinsWorkspace(kind string) bool {
+	pins, known := reactionKindPins[kind]
+	if !known {
 		return true
-	default:
-		return false
 	}
+	return pins
 }
 
 // ReactionKey returns the composite map key for a pending reaction.
@@ -755,8 +782,8 @@ type State struct {
 	// fires at most once per issue per orchestrator lifetime.
 	AutoMergeAuthLogged map[string]struct{}
 
-	// SweepTickCounter tracks poll ticks since the last terminal workspace
-	// sweep. Incremented by handleTick; reset to zero when the sweep fires.
+	// SweepTickCounter tracks poll ticks since the last workspace sweep.
+	// Incremented by handleTick; reset to zero when the sweep fires.
 	// Runtime-only (not persisted).
 	SweepTickCounter int
 }

--- a/internal/orchestrator/state_test.go
+++ b/internal/orchestrator/state_test.go
@@ -1384,6 +1384,54 @@ func TestIsKnownReactionKind_AcceptsLabelReview(t *testing.T) {
 	}
 }
 
+// --- reactionKindPins / isKnownReactionKind / reactionKindPinsWorkspace ---
+
+// TestReactionKindPins covers R11: isKnownReactionKind and
+// reactionKindPinsWorkspace both derive from the single reactionKindPins
+// map, so the set of known kinds is asserted by iterating the map itself
+// rather than by a second hand-written list that could diverge from it.
+func TestReactionKindPins(t *testing.T) {
+	t.Parallel()
+
+	t.Run("isKnownReactionKind is true for exactly the registered kinds", func(t *testing.T) {
+		t.Parallel()
+
+		for kind := range reactionKindPins {
+			t.Run(kind, func(t *testing.T) {
+				t.Parallel()
+				if !isKnownReactionKind(kind) {
+					t.Errorf("isKnownReactionKind(%q) = false, want true (registered in reactionKindPins)", kind)
+				}
+			})
+		}
+
+		if isKnownReactionKind("merge-completion") {
+			t.Error(`isKnownReactionKind("merge-completion") = true, want false (unregistered kind)`)
+		}
+	})
+
+	t.Run("reactionKindPinsWorkspace returns the registered value for each of the seven kinds", func(t *testing.T) {
+		t.Parallel()
+
+		for kind, wantPins := range reactionKindPins {
+			t.Run(kind, func(t *testing.T) {
+				t.Parallel()
+				if got := reactionKindPinsWorkspace(kind); got != wantPins {
+					t.Errorf("reactionKindPinsWorkspace(%q) = %v, want %v", kind, got, wantPins)
+				}
+			})
+		}
+	})
+
+	t.Run("reactionKindPinsWorkspace returns true for an unregistered kind", func(t *testing.T) {
+		t.Parallel()
+
+		if got := reactionKindPinsWorkspace("merge-completion"); !got {
+			t.Error(`reactionKindPinsWorkspace("merge-completion") = false, want true (unregistered kind retains)`)
+		}
+	})
+}
+
 // --- BuildLabelReviewReactionConfig tests ---
 
 func TestBuildLabelReviewReactionConfig(t *testing.T) {

--- a/internal/persistence/run_history.go
+++ b/internal/persistence/run_history.go
@@ -342,6 +342,66 @@ func (s *Store) SumTotalTokensByIssue(ctx context.Context, issueID string) (sumT
 	return sumTotalTokens, sessionCount, nil
 }
 
+// latestRunCompletionChunkSize is the maximum number of identifiers
+// batched into a single IN (...) query. The on-disk workspace directory
+// count that feeds this lookup is unbounded by construction, unlike the
+// tracker-page-bounded inputs of the other IN (...) queries in this file.
+const latestRunCompletionChunkSize = 500
+
+// LatestRunCompletionByIdentifier returns the most recent completed_at
+// value for each of the given identifiers.
+//
+// Identifiers with no run_history rows are omitted from the result. An
+// empty input returns an empty non-nil map without querying. Identifiers
+// are queried in batches of at most [latestRunCompletionChunkSize] and
+// the per-batch results are merged.
+func (s *Store) LatestRunCompletionByIdentifier(ctx context.Context, identifiers []string) (map[string]string, error) {
+	result := make(map[string]string, len(identifiers))
+	if len(identifiers) == 0 {
+		return result, nil
+	}
+
+	for start := 0; start < len(identifiers); start += latestRunCompletionChunkSize {
+		end := min(start+latestRunCompletionChunkSize, len(identifiers))
+		chunk := identifiers[start:end]
+
+		placeholders := strings.Repeat("?,", len(chunk))
+		placeholders = placeholders[:len(placeholders)-1]
+
+		args := make([]any, len(chunk))
+		for i, id := range chunk {
+			args[i] = id
+		}
+
+		query := fmt.Sprintf( //nolint:gosec // placeholders is "?,?,..." built from len(chunk); no user data in format string
+			`SELECT identifier, MAX(completed_at) FROM run_history WHERE identifier IN (%s) GROUP BY identifier`,
+			placeholders,
+		)
+
+		rows, err := s.db.QueryContext(ctx, query, args...)
+		if err != nil {
+			return nil, fmt.Errorf("query latest run completion by identifier: %w", err)
+		}
+
+		scanErr := func() error {
+			defer rows.Close() //nolint:errcheck // read-only query; close error is non-actionable
+			for rows.Next() {
+				var identifier, completedAt string
+				if err := rows.Scan(&identifier, &completedAt); err != nil {
+					return fmt.Errorf("scan latest run completion by identifier: %w", err)
+				}
+				result[identifier] = completedAt
+			}
+			return rows.Err()
+		}()
+		if scanErr != nil {
+			return nil, fmt.Errorf("query latest run completion by identifier: %w", scanErr)
+		}
+	}
+
+	return result, nil
+}
+
 // QueryTokenExhaustedIssues returns issue IDs from candidateIDs whose
 // summed run_history total_tokens meet or exceed maxTokens. Returns an
 // empty non-nil slice when no issues qualify or candidateIDs is empty.

--- a/internal/persistence/run_history_test.go
+++ b/internal/persistence/run_history_test.go
@@ -2,6 +2,7 @@ package persistence
 
 import (
 	"context"
+	"fmt"
 	"slices"
 	"testing"
 	"time"
@@ -299,6 +300,99 @@ func TestQueryTokenExhaustedIssues(t *testing.T) {
 		}
 		if slices.Contains(aboveSum, "ISS-PARITY") {
 			t.Errorf("QueryTokenExhaustedIssues(maxTokens=%d) = %v, want ISS-PARITY absent", sum+1, aboveSum)
+		}
+	})
+}
+
+// completionRun returns a run_history row for identifier carrying
+// completedAt, with the remaining fields from newTestRun.
+func completionRun(i int, identifier, completedAt string) RunHistory {
+	run := newTestRun(i)
+	run.Identifier = identifier
+	run.IssueID = identifier
+	run.CompletedAt = completedAt
+	return run
+}
+
+func TestLatestRunCompletionByIdentifier(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns the later completion per identifier and omits identifiers with no rows", func(t *testing.T) {
+		t.Parallel()
+		s := openTestStore(t)
+		migrateOrFatal(t, s)
+
+		appendOrFatal(t, s, completionRun(1, "PROJ-A", "2026-01-01T00:00:00Z"))
+		appendOrFatal(t, s, completionRun(2, "PROJ-A", "2026-01-03T00:00:00Z"))
+		appendOrFatal(t, s, completionRun(3, "PROJ-B", "2026-02-01T00:00:00Z"))
+		appendOrFatal(t, s, completionRun(4, "PROJ-B", "2026-01-15T00:00:00Z"))
+		appendOrFatal(t, s, completionRun(5, "PROJ-C", "2026-03-01T00:00:00Z"))
+		appendOrFatal(t, s, completionRun(6, "PROJ-C", "2026-03-05T00:00:00Z"))
+
+		got, err := s.LatestRunCompletionByIdentifier(context.Background(), []string{"PROJ-A", "PROJ-B", "PROJ-C", "PROJ-D"})
+		if err != nil {
+			t.Fatalf("LatestRunCompletionByIdentifier: %v", err)
+		}
+		if len(got) != 3 {
+			t.Fatalf("len(result) = %d, want 3; result = %v", len(got), got)
+		}
+
+		want := map[string]string{
+			"PROJ-A": "2026-01-03T00:00:00Z",
+			"PROJ-B": "2026-02-01T00:00:00Z",
+			"PROJ-C": "2026-03-05T00:00:00Z",
+		}
+		for identifier, wantCompletedAt := range want {
+			if got[identifier] != wantCompletedAt {
+				t.Errorf("result[%q] = %q, want %q", identifier, got[identifier], wantCompletedAt)
+			}
+		}
+		if _, ok := got["PROJ-D"]; ok {
+			t.Error(`result["PROJ-D"] present, want omitted (no run_history rows)`)
+		}
+	})
+
+	t.Run("empty input returns empty non-nil map without querying", func(t *testing.T) {
+		t.Parallel()
+		s := openTestStore(t)
+		migrateOrFatal(t, s)
+
+		got, err := s.LatestRunCompletionByIdentifier(context.Background(), []string{})
+		if err != nil {
+			t.Fatalf("LatestRunCompletionByIdentifier: %v", err)
+		}
+		if got == nil {
+			t.Fatal("result = nil, want empty non-nil map")
+		}
+		if len(got) != 0 {
+			t.Errorf("result = %v, want empty map", got)
+		}
+	})
+
+	t.Run("batches identifiers at 500 per query and merges results", func(t *testing.T) {
+		t.Parallel()
+		s := openTestStore(t)
+		migrateOrFatal(t, s)
+
+		const total = 1200
+		identifiers := make([]string, total)
+		for i := range total {
+			id := fmt.Sprintf("PROJ-CHUNK-%d", i)
+			identifiers[i] = id
+			appendOrFatal(t, s, completionRun(i, id, "2026-01-01T00:00:00Z"))
+		}
+
+		got, err := s.LatestRunCompletionByIdentifier(context.Background(), identifiers)
+		if err != nil {
+			t.Fatalf("LatestRunCompletionByIdentifier: %v", err)
+		}
+		if len(got) != total {
+			t.Fatalf("len(result) = %d, want %d", len(got), total)
+		}
+		for _, id := range identifiers {
+			if _, ok := got[id]; !ok {
+				t.Fatalf("result missing identifier %q", id)
+			}
 		}
 	})
 }

--- a/internal/workflow/manager_test.go
+++ b/internal/workflow/manager_test.go
@@ -23,6 +23,12 @@ func validWorkflow(intervalMS int) []byte {
 	return fmt.Appendf(nil, "---\npolling:\n  interval_ms: %d\n---\nDo the task for {{ .issue.title }}.\n", intervalMS)
 }
 
+// retentionWorkflow returns a minimal WORKFLOW.md content with the given
+// workspace.retention_days value.
+func retentionWorkflow(days int) []byte {
+	return fmt.Appendf(nil, "---\npolling:\n  interval_ms: 5000\nworkspace:\n  retention_days: %d\n---\nDo the task for {{ .issue.title }}.\n", days)
+}
+
 func testLogger() *slog.Logger {
 	return slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 }
@@ -219,6 +225,40 @@ func TestManager_ReloadRetainsOnError(t *testing.T) {
 	}
 	if mgr.Config().Polling.IntervalMS != 5000 {
 		t.Errorf("after failed Reload: Polling.IntervalMS = %d, want 5000", mgr.Config().Polling.IntervalMS)
+	}
+	if mgr.LastLoadError() == nil {
+		t.Error("after failed Reload: LastLoadError() is nil, want non-nil")
+	}
+}
+
+// TestManager_ReloadRetainsOnInvalidRetentionDays covers R5: a reload whose
+// workspace.retention_days fails validation leaves the previously loaded
+// configuration in force rather than disabling the bound or terminating
+// the process.
+func TestManager_ReloadRetainsOnInvalidRetentionDays(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "WORKFLOW.md")
+	mustWriteFile(t, path, retentionWorkflow(30))
+
+	mgr, err := NewManager(path, testLogger())
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	if got := mgr.Config().Workspace.RetentionDays; got != 30 {
+		t.Fatalf("initial Config().Workspace.RetentionDays = %d, want 30", got)
+	}
+
+	// 5 is in the rejected 1-29 range.
+	mustWriteFile(t, path, retentionWorkflow(5))
+
+	err = mgr.Reload()
+	if err == nil {
+		t.Fatal("Reload() error = nil, want error")
+	}
+	if got := mgr.Config().Workspace.RetentionDays; got != 30 {
+		t.Errorf("after failed Reload: Config().Workspace.RetentionDays = %d, want 30 (retained)", got)
 	}
 	if mgr.LastLoadError() == nil {
 		t.Error("after failed Reload: LastLoadError() is nil, want non-nil")


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Feat

**Intent:** Cleanup was gated entirely on the issue reaching a terminal tracker state, which left deployments that configure a handoff state (and any deployment with a deleted, misplaced, or permanently-stuck issue) with workspace directories retained forever. This adds an opt-in `workspace.retention_days` age bound to the periodic sweep, anchored on the same activity signal pending-reaction recovery uses, so the backstop cannot break the feature it must not violate. Implements the decision recorded in ADR-0018 (bound workspace retention by age).

**Related Issues:** #706

### 🧭 Reviewer Guide

**Complexity:** High

#### Entry Point

`internal/orchestrator/reconcile.go` - `SweepWorkspaces` (renamed from `SweepTerminalWorkspaces`) is where the new age pass, the narrowed pending-reaction exclusion rule, and the per-pass summary log all live. The terminal-state check remains the primary, unconditional path and runs first; the age pass is the opt-in fallback for everything the terminal check does not remove.

#### Sensitive Areas

- `internal/orchestrator/reconcile.go`: workspace removal is destructive and irreversible, so the age pass's exclusion rule and activity-anchor computation deserve careful review.
- `internal/config/config.go`: the 30-day floor on `workspace.retention_days` is deliberately coupled to the pending-reaction recovery lookback; changing one without the other reintroduces the defect this PR fixes.
- `internal/persistence/run_history.go`: `LatestRunCompletionByIdentifier` batches identifiers into `IN (...)` queries against a table indexed on `issue_id`, not `identifier`, so the lookup scans rather than seeks.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes to the config surface (the new field defaults to `0`, off). One behavior change reaches every deployment on upgrade without an opt-in: a terminal issue holding a pending `label-review` or `label-fix` entry is now cleaned up by the sweep instead of retained forever. Label-command detection is unaffected, since it reads nothing from the workspace directory.
- **Migrations/State:** No database migrations. No manual operator action required; the age bound stays off until an operator sets `workspace.retention_days`.