### PR TITLE
feat(orchestrator): close tracker issue on managed PR merge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   in-flight, removed as terminal, removed by age, retained inside the
   window, retained for want of an activity record, or not yet evaluated.
   ([#706](https://github.com/sortie-ai/sortie/issues/706))
+- `reactions.merge_completion`: an opt-in, default-off reaction that
+  observes the merge of a Sortie-managed pull request, whether performed
+  by the orchestrator, by a human, or by a forge automation rule, and
+  transitions the linked issue to a single configured terminal state
+  exactly once. Requires `tracker.handoff_state` and a written
+  `tracker.terminal_states` list; `sortie validate` reports a
+  misconfigured target state, an unset prerequisite, or a poll interval
+  below the floor before a run begins.
+  ([#707](https://github.com/sortie-ai/sortie/issues/707))
+
+### Fixed
+
+- `reactions.ci_failure` and `reactions.review_comments` escalation now
+  clears only its own kind's pending entry, attempt counter, and
+  fingerprint instead of every reaction on the issue, so an unrelated
+  escalation no longer silently ends `reactions.merge_completion`
+  observation (or any other sibling reaction) for that issue.
+  ([#707](https://github.com/sortie-ai/sortie/issues/707))
 
 ### Changed
 

--- a/cmd/sortie/main.go
+++ b/cmd/sortie/main.go
@@ -378,15 +378,19 @@ func run(ctx context.Context, args []string, stdout io.Writer, stderr io.Writer)
 	var labelReviewConfigured bool
 	var labelFixConfig orchestrator.LabelFixReactionConfig
 	var labelFixConfigured bool
+	var mergeCompletionConfig orchestrator.MergeCompletionReactionConfig
+	var mergeCompletionConfigured bool
 
 	reviewRC, hasReview := br.cfg.Reactions["review_comments"]
 	autoMergeRC, hasAutoMerge := br.cfg.Reactions["auto_merge"]
 	botReviewRC, hasBotReview := br.cfg.Reactions["bot_review"]
 	mergeConflictRC, hasMergeConflict := br.cfg.Reactions["merge_conflicts"]
+	mergeCompletionRC, hasMergeCompletion := br.cfg.Reactions["merge_completion"]
 	reviewActive := hasReview && reviewRC.Provider != ""
 	autoMergeActive := hasAutoMerge && autoMergeRC.Provider != ""
 	botReviewActive := hasBotReview && botReviewRC.Provider != ""
 	mergeConflictActive := hasMergeConflict && mergeConflictRC.Provider != ""
+	mergeCompletionActive := hasMergeCompletion && mergeCompletionRC.Provider != ""
 	// label_commands parses through its own dedicated field, never the
 	// Reactions map; it activates when a provider and a review label are set.
 	labelReviewActive := br.cfg.LabelCommands.Provider != "" && br.cfg.LabelCommands.ReviewLabel != ""
@@ -401,6 +405,7 @@ func run(ctx context.Context, args []string, stdout io.Writer, stderr io.Writer)
 		{name: "bot_review", active: botReviewActive, provider: botReviewRC.Provider},
 		{name: "merge_conflicts", active: mergeConflictActive, provider: mergeConflictRC.Provider},
 		{name: "label_commands", active: labelReviewActive || labelFixActive, provider: br.cfg.LabelCommands.Provider},
+		{name: "merge_completion", active: mergeCompletionActive, provider: mergeCompletionRC.Provider},
 	}
 	if conflictKinds, conflictProviders := scmProviderConflict(activeSCMKinds); len(conflictProviders) > 1 {
 		br.logger.Error("unsupported: active SCM reaction kinds must use the same provider",
@@ -410,8 +415,8 @@ func run(ctx context.Context, args []string, stdout io.Writer, stderr io.Writer)
 		return 1
 	}
 
-	if reviewActive || autoMergeActive || botReviewActive || mergeConflictActive || labelReviewActive || labelFixActive {
-		provider := cmp.Or(reviewRC.Provider, autoMergeRC.Provider, botReviewRC.Provider, mergeConflictRC.Provider, br.cfg.LabelCommands.Provider)
+	if reviewActive || autoMergeActive || botReviewActive || mergeConflictActive || labelReviewActive || labelFixActive || mergeCompletionActive {
+		provider := cmp.Or(reviewRC.Provider, autoMergeRC.Provider, botReviewRC.Provider, mergeConflictRC.Provider, br.cfg.LabelCommands.Provider, mergeCompletionRC.Provider)
 		scmCtor, scmErr := registry.SCMAdapters.Get(provider)
 		if scmErr != nil {
 			br.logger.Error("unknown SCM adapter kind",
@@ -453,6 +458,10 @@ func run(ctx context.Context, args []string, stdout io.Writer, stderr io.Writer)
 				}
 			}
 		}
+		// merge_completion's Extra keys (target_state, poll_interval_ms)
+		// are orchestrator settings, not adapter settings, so unlike the
+		// sibling blocks above, its Extra map is never merged in, matching
+		// the label_commands precedent.
 		scmAdapter, scmErr = scmCtor(adapterCfgMap)
 		if scmErr != nil {
 			br.logger.Error("failed to construct SCM adapter",
@@ -555,6 +564,23 @@ func run(ctx context.Context, args []string, stdout io.Writer, stderr io.Writer)
 			// gates detection or dispatch, so the result is discarded.
 			_, _, _ = orchestrator.RunLabelFixScopePreflight(ctx, scmAdapter, br.logger)
 		}
+
+		if mergeCompletionActive {
+			trackerMeta, _ := registry.Trackers.Meta(br.cfg.Tracker.Kind)
+			var mcErr error
+			mergeCompletionConfig, mcErr = orchestrator.BuildMergeCompletionReactionConfig(mergeCompletionRC, br.cfg.Tracker, trackerMeta)
+			if mcErr != nil {
+				br.logger.Error("invalid merge_completion reaction config", slog.Any("error", mcErr))
+				return 1
+			}
+			mergeCompletionConfigured = true
+
+			br.logger.Info("merge completion reaction enabled",
+				slog.String("provider", mergeCompletionRC.Provider),
+				slog.String("target_state", mergeCompletionConfig.TargetState),
+				slog.Int("poll_interval_ms", mergeCompletionConfig.PollIntervalMS),
+			)
+		}
 	}
 
 	recoveryEnabled := br.cfg.Tracker.HandoffState != "" && (ciProvider != nil || scmAdapter != nil)
@@ -568,19 +594,20 @@ func run(ctx context.Context, args []string, stdout io.Writer, stderr io.Writer)
 		recoveryRuns, recoveryErr = store.LoadLatestSuccessfulRunsForReactionRecovery(ctx, recoveryCutoff, orchestrator.PendingReactionRecoveryMaxCandidates)
 		if recoveryErr == nil {
 			recoveryOutcome, recoveryErr = orchestrator.RecoverPendingReactions(ctx, state, recoveryRuns, orchestrator.PendingReactionRecoveryParams{
-				WorkspaceRoot:                   br.cfg.Workspace.Root,
-				TrackerAdapter:                  br.trackerAdapter,
-				HandoffState:                    br.cfg.Tracker.HandoffState,
-				TerminalStates:                  br.cfg.Tracker.TerminalStates,
-				CIProvider:                      ciProvider,
-				SCMAdapter:                      scmAdapter,
-				AutoMergeReactionConfigured:     autoMergeConfigured,
-				BotReviewReactionConfigured:     botReviewConfigured,
-				MergeConflictReactionConfigured: mergeConflictConfigured,
-				LabelReviewReactionConfigured:   labelReviewConfigured,
-				LabelFixReactionConfigured:      labelFixConfigured,
-				RecoveryLookback:                recoveryLookback,
-				MaxCandidates:                   orchestrator.PendingReactionRecoveryMaxCandidates,
+				WorkspaceRoot:                     br.cfg.Workspace.Root,
+				TrackerAdapter:                    br.trackerAdapter,
+				HandoffState:                      br.cfg.Tracker.HandoffState,
+				TerminalStates:                    br.cfg.Tracker.TerminalStates,
+				CIProvider:                        ciProvider,
+				SCMAdapter:                        scmAdapter,
+				AutoMergeReactionConfigured:       autoMergeConfigured,
+				BotReviewReactionConfigured:       botReviewConfigured,
+				MergeConflictReactionConfigured:   mergeConflictConfigured,
+				LabelReviewReactionConfigured:     labelReviewConfigured,
+				LabelFixReactionConfigured:        labelFixConfigured,
+				MergeCompletionReactionConfigured: mergeCompletionConfigured,
+				RecoveryLookback:                  recoveryLookback,
+				MaxCandidates:                     orchestrator.PendingReactionRecoveryMaxCandidates,
 				NowFunc: func() time.Time {
 					return recoveryNow
 				},
@@ -600,6 +627,7 @@ func run(ctx context.Context, args []string, stdout io.Writer, stderr io.Writer)
 		slog.Int("merge_conflict_recovered", recoveryOutcome.MergeConflictRecovered),
 		slog.Int("label_review_recovered", recoveryOutcome.LabelReviewRecovered),
 		slog.Int("label_fix_recovered", recoveryOutcome.LabelFixRecovered),
+		slog.Int("merge_completion_recovered", recoveryOutcome.MergeCompletionRecovered),
 		slog.Int("stale_skipped", recoveryOutcome.StaleSkipped),
 		slog.Int("skipped", recoveryOutcome.Skipped),
 	}
@@ -676,32 +704,34 @@ func run(ctx context.Context, args []string, stdout io.Writer, stderr io.Writer)
 	}
 
 	o := orchestrator.NewOrchestrator(orchestrator.OrchestratorParams{
-		State:                           state,
-		Logger:                          br.logger,
-		TrackerAdapter:                  br.trackerAdapter,
-		AgentAdapter:                    agentAdapter,
-		AgentAdapterByKind:              agentAdapterByKind,
-		WorkflowManager:                 br.mgr,
-		Store:                           store,
-		PreflightParams:                 br.preflightParams,
-		Metrics:                         orchMetrics,
-		ToolRegistry:                    toolRegistry,
-		SessionToolRegistryFunc:         sessionToolFunc,
-		WorkflowFileFunc:                br.mgr.FilePath,
-		DBPath:                          dbPath,
-		CIProvider:                      ciProvider,
-		SCMAdapter:                      scmAdapter,
-		ReviewConfig:                    reviewConfig,
-		AutoMergeConfig:                 autoMergeConfig,
-		AutoMergeReactionConfigured:     autoMergeConfigured,
-		BotReviewConfig:                 botReviewConfig,
-		BotReviewConfigured:             botReviewConfigured,
-		MergeConflictConfig:             mergeConflictConfig,
-		MergeConflictReactionConfigured: mergeConflictConfigured,
-		LabelReviewConfig:               labelReviewConfig,
-		LabelReviewReactionConfigured:   labelReviewConfigured,
-		LabelFixConfig:                  labelFixConfig,
-		LabelFixReactionConfigured:      labelFixConfigured,
+		State:                             state,
+		Logger:                            br.logger,
+		TrackerAdapter:                    br.trackerAdapter,
+		AgentAdapter:                      agentAdapter,
+		AgentAdapterByKind:                agentAdapterByKind,
+		WorkflowManager:                   br.mgr,
+		Store:                             store,
+		PreflightParams:                   br.preflightParams,
+		Metrics:                           orchMetrics,
+		ToolRegistry:                      toolRegistry,
+		SessionToolRegistryFunc:           sessionToolFunc,
+		WorkflowFileFunc:                  br.mgr.FilePath,
+		DBPath:                            dbPath,
+		CIProvider:                        ciProvider,
+		SCMAdapter:                        scmAdapter,
+		ReviewConfig:                      reviewConfig,
+		AutoMergeConfig:                   autoMergeConfig,
+		AutoMergeReactionConfigured:       autoMergeConfigured,
+		BotReviewConfig:                   botReviewConfig,
+		BotReviewConfigured:               botReviewConfigured,
+		MergeConflictConfig:               mergeConflictConfig,
+		MergeConflictReactionConfigured:   mergeConflictConfigured,
+		LabelReviewConfig:                 labelReviewConfig,
+		LabelReviewReactionConfigured:     labelReviewConfigured,
+		LabelFixConfig:                    labelFixConfig,
+		LabelFixReactionConfigured:        labelFixConfigured,
+		MergeCompletionConfig:             mergeCompletionConfig,
+		MergeCompletionReactionConfigured: mergeCompletionConfigured,
 	})
 
 	var srv *server.Server

--- a/cmd/sortie/validate.go
+++ b/cmd/sortie/validate.go
@@ -129,8 +129,10 @@ func runValidate(_ context.Context, args []string, stdout io.Writer, stderr io.W
 	// block dispatch even when the dispatch preflight passes, so both the
 	// exit code and the JSON valid flag key on the union of preflight,
 	// reaction, and activation errors.
+	trackerMeta, _ := registry.Trackers.Meta(cfg.Tracker.Kind)
+
 	var forgeDiags []validateDiag
-	for _, rd := range orchestrator.ValidateReactionConfigs(cfg) {
+	for _, rd := range orchestrator.ValidateReactionConfigs(cfg, trackerMeta) {
 		forgeDiags = append(forgeDiags, validateDiag{Severity: rd.Severity, Check: rd.Check, Message: rd.Message})
 	}
 	forgeDiags = append(forgeDiags, activationChecks(cfg)...)
@@ -242,6 +244,7 @@ func activationChecks(cfg config.ServiceConfig) []validateDiag {
 	autoMergeRC := cfg.Reactions["auto_merge"]
 	botReviewRC := cfg.Reactions["bot_review"]
 	mergeConflictRC := cfg.Reactions["merge_conflicts"]
+	mergeCompletionRC := cfg.Reactions["merge_completion"]
 	labelReviewActive := cfg.LabelCommands.Provider != "" && cfg.LabelCommands.ReviewLabel != ""
 	labelFixActive := cfg.LabelCommands.Provider != "" && cfg.LabelCommands.FixLabel != ""
 
@@ -251,6 +254,7 @@ func activationChecks(cfg config.ServiceConfig) []validateDiag {
 		{name: "bot_review", active: botReviewRC.Provider != "", provider: botReviewRC.Provider},
 		{name: "merge_conflicts", active: mergeConflictRC.Provider != "", provider: mergeConflictRC.Provider},
 		{name: "label_commands", active: labelReviewActive || labelFixActive, provider: cfg.LabelCommands.Provider},
+		{name: "merge_completion", active: mergeCompletionRC.Provider != "", provider: mergeCompletionRC.Provider},
 	}
 
 	activeKinds, providers := scmProviderConflict(activeSCMKinds)

--- a/cmd/sortie/validate_test.go
+++ b/cmd/sortie/validate_test.go
@@ -2355,6 +2355,40 @@ func TestActivationChecks(t *testing.T) {
 			},
 			wantChecks: nil,
 		},
+		{
+			// A configuration with no merge_completion block must leave the
+			// pre-existing diagnostic set unchanged: a single active
+			// reaction on one provider produces no diagnostic. This is the
+			// regression an implementer who wires merge_completion into
+			// activeSCMKinds unconditionally (ignoring its empty provider)
+			// would introduce as a spurious provider-conflict diagnostic.
+			name: "no merge_completion block leaves a single active reaction clean",
+			cfg: config.ServiceConfig{
+				Reactions: map[string]config.ReactionConfig{
+					"bot_review": {Provider: "gitea"},
+				},
+			},
+			wantChecks: nil,
+		},
+		{
+			name: "merge_completion as the sole active SCM reaction constructs an adapter path",
+			cfg: config.ServiceConfig{
+				Reactions: map[string]config.ReactionConfig{
+					"merge_completion": {Provider: "gitea"},
+				},
+			},
+			wantChecks: nil,
+		},
+		{
+			name: "merge_completion provider disagreement with another active SCM reaction",
+			cfg: config.ServiceConfig{
+				Reactions: map[string]config.ReactionConfig{
+					"merge_completion": {Provider: "github"},
+					"bot_review":       {Provider: "gitea"},
+				},
+			},
+			wantChecks: []string{"reactions.scm_provider_conflict"},
+		},
 	}
 
 	for _, tt := range tests {
@@ -2375,6 +2409,61 @@ func TestActivationChecks(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// mergeCompletionFaultWorkflow returns a WORKFLOW.md with a minimal valid
+// tracker (file) and agent plus a handoff_state, so ValidateDispatchConfig
+// passes cleanly, with a reactions.merge_completion block whose
+// target_state names an active rather than a terminal state.
+func mergeCompletionFaultWorkflow() []byte {
+	return []byte(`---
+tracker:
+  kind: file
+  active_states:
+    - To Do
+  terminal_states:
+    - Done
+  handoff_state: In Review
+agent:
+  kind: mock
+reactions:
+  merge_completion:
+    provider: gitea
+    target_state: To Do
+---
+Do {{ .issue.title }}.
+`)
+}
+
+// TestValidateMergeCompletionNonTerminalTargetState verifies that
+// "sortie validate --format json" on a workflow whose merge_completion
+// block sets a non-terminal target_state reports valid: false with an
+// error diagnostic whose check is reactions.merge_completion, and exits
+// 1, with no network access (the tracker is the offline file adapter).
+func TestValidateMergeCompletionNonTerminalTargetState(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	wfPath := writeCustomWorkflowFile(t, dir, mergeCompletionFaultWorkflow())
+
+	var stdout, stderr bytes.Buffer
+	code := run(context.Background(), []string{"validate", "--format", "json", wfPath}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("run(validate --format json) = %d, want 1; stderr: %s", code, stderr.String())
+	}
+
+	var out validateOutput
+	if err := json.Unmarshal(stdout.Bytes(), &out); err != nil {
+		t.Fatalf("json.Unmarshal(%q) error: %v", stdout.String(), err)
+	}
+	if out.Valid {
+		t.Errorf("validateOutput.Valid = true, want false")
+	}
+	if d := diagWithCheck(out.Errors, "reactions.merge_completion"); d == nil {
+		t.Errorf("validateOutput.Errors = %v, want a diagnostic with check %q", out.Errors, "reactions.merge_completion")
+	} else if d.Severity != "error" {
+		t.Errorf("reactions.merge_completion diagnostic severity = %q, want %q", d.Severity, "error")
 	}
 }
 

--- a/docs/architecture/03-system-overview.md
+++ b/docs/architecture/03-system-overview.md
@@ -69,8 +69,9 @@
     - Read-write, multi-method contract (`FetchPendingReviews`, `GetReviewDecision`, `GetCIStatus`,
       `GetMergeability`, `MergePR`, `DeleteBranch`). Write methods are exercised only by the
       auto-merge reaction.
-    - Surfaces a sixth error kind, `ErrSCMConflict`, for HTTP 405 and HTTP 409 responses from
-      the merge endpoint (precondition raced, branch protection refused, or PR already merged).
+    - Surfaces an additional error kind, `ErrSCMConflict`, for HTTP 405 and HTTP 409 responses
+      from the merge endpoint (precondition raced, branch protection refused, or PR already
+      merged).
     - Activated by `reactions.review_comments.provider` or `reactions.auto_merge.provider`
       presence in workflow front matter. Auto-merge activation requires the provider token to
       carry `pull_requests:write` and, when branch deletion is enabled, `contents:write`.

--- a/docs/architecture/08-polling-scheduling-and-reconciliation.md
+++ b/docs/architecture/08-polling-scheduling-and-reconciliation.md
@@ -112,9 +112,9 @@ Per-issue token budget (cost ceiling):
 
 Note:
 
-- Terminal-state workspace cleanup is handled by three paths: startup cleanup, active-run
-  reconciliation (including terminal transitions for currently running issues), and the periodic
-  workspace sweep described below.
+- Terminal-state workspace cleanup is handled by startup cleanup, active-run reconciliation
+  (including terminal transitions for currently running issues), and the periodic workspace
+  sweep described below.
 - Retry handling mainly operates on active candidates and releases claims when the issue is absent,
   rather than performing terminal cleanup itself.
 - Within one periodic sweep pass, the terminal check always runs before the age bound (see
@@ -126,7 +126,7 @@ Note:
 
 ### 8.5 Active Run Reconciliation
 
-Reconciliation runs every tick and has nine parts, run in this order.
+Reconciliation runs every tick, in the order below.
 
 Part A: Stall detection
 
@@ -270,6 +270,33 @@ Part I: Label fix command detection (when `reactions.label_commands.fix_label` i
   read-only review session.
 - Ordering relative to the other parts does not affect correctness: the pass is fully
   cross-kind isolated. See Section 11F for the full contract.
+
+Part J: Merge completion reconciliation (when `reactions.merge_completion` is configured)
+
+- Skip entirely when no SCM adapter or tracker adapter is configured.
+- Before examining any entry, check once whether the configured `target_state` is still a
+  member of the runtime terminal-state list; log one warning per onset of drift, suppressed
+  while the condition persists.
+- For each due entry in `pending_reactions` with kind `merge-completion`, fetch tracker state
+  for the linked issues in one batched read.
+- Drop an entry whose issue is missing from the response or already terminal. Defer an entry
+  whose issue is currently claimed. Stop an entry whose issue has left the configured handoff
+  state.
+- Fetch mergeability via `SCMAdapter.GetMergeability`; re-enqueue with backoff on a transport
+  error, and re-enqueue on the poll interval while the pull request is not yet reported merged
+  or reports no merge commit identifier.
+- Upsert the merge commit identifier into `reaction_fingerprints` under kind
+  `merge-completion`; skip an entry already latched to that identifier.
+- Call `TrackerAdapter.TransitionIssue` to the configured `target_state`. Route a failure by
+  the tracker error taxonomy: retry with backoff up to `max_retries` then escalate for
+  transport and API failures, escalate immediately for auth and payload failures, and stop
+  without escalating for a not-found issue.
+- Unlike every other kind in this list, a pending entry of this kind carries no expiry: a
+  merge can wait on human review for days, so the entry is bounded instead by the issue
+  leaving the handoff state and by the pending-reaction recovery lookback.
+- Placed last so a merge the orchestrator performed earlier in the same tick, in Part G, is
+  observed on this same pass.
+- See ADR-0017 for the full contract.
 
 ### 8.6 Startup Terminal Workspace Cleanup
 

--- a/docs/architecture/09-workspace-management-and-safety.md
+++ b/docs/architecture/09-workspace-management-and-safety.md
@@ -16,7 +16,7 @@ Workspace persistence:
 - Workspaces are reused across runs for the same issue.
 - Successful runs do not auto-delete workspaces.
 
-Workspace cleanup runs through two mechanisms, ordered and non-overlapping in intent:
+Workspace cleanup runs through the following mechanisms, ordered and non-overlapping in intent:
 
 - **The terminal gate** is the primary mechanism. It is always on and unconditional: whenever the
   tracker reports an issue's state as a member of `tracker.terminal_states`, the workspace for that

--- a/docs/architecture/10-agent-adapter-contract.md
+++ b/docs/architecture/10-agent-adapter-contract.md
@@ -282,7 +282,7 @@ Availability: registered when the database path and issue ID are present in the 
 session ID arrives through `SORTIE_SESSION_ID`. The tool takes no input.
 
 On success the tool returns, under `data` in the envelope `{"success": true, "data": {...}}` of
-Section 10.4.2, a JSON object with five fields:
+Section 10.4.2, a JSON object with the following fields:
 
 - `used_tokens`: cumulative `total_tokens` across the issue's completed sessions, plus the
   running session's recorded `total_tokens` when a session is in flight. The running session's
@@ -419,7 +419,7 @@ Operator notifications are an adapter family, the same shape as the tracker, age
 SCM families. The `notify_operator` tool (Section 10.4.5) is a thin Tier 2 wrapper over this
 family; a new channel is a new package behind the existing interface, not a tool rewrite.
 
-The family has four parts:
+The family has the following parts:
 
 - **The `domain.Notifier` interface** exposes one method, `Send(ctx, Notification) error`. A
   single method keeps every backend interchangeable and lets any producer reuse the family.

--- a/docs/architecture/14-auto-merge-reaction-contract.md
+++ b/docs/architecture/14-auto-merge-reaction-contract.md
@@ -11,11 +11,11 @@ fully cross-kind isolated.
 ### 11C.1 SCMAdapter write surface
 
 The `SCMAdapter` interface, introduced in §11B.1 for review-comment fetching, is widened by the
-read-write surface defined by the interface-surface section of the auto-merge ADR. The full
-interface now exposes six methods:
+read-write surface defined by the interface-surface section of the auto-merge ADR. The methods
+this reaction depends on are:
 
 ```text
-SCMAdapter:
+SCMAdapter (auto-merge surface):
   FetchPendingReviews(ctx, prNumber, owner, repo) ([]ReviewComment, error)
   GetReviewDecision(ctx, prNumber, owner, repo)   (ReviewDecision, error)
   GetCIStatus(ctx, prNumber, owner, repo)         (string, error)
@@ -24,13 +24,14 @@ SCMAdapter:
   DeleteBranch(ctx, owner, repo, branch)          error
 ```
 
-`FetchPendingReviews` is the original read-only method documented in §11B.1. The five new methods
-provide the write surface needed by the auto-merge reconcile loop. All implementations MUST be safe
-for concurrent use.
+`FetchPendingReviews` is the original read-only method documented in §11B.1. The remaining
+methods are the write surface the auto-merge reaction added. The interface has since widened
+further for other reaction kinds; see §11D for `FetchBotReviewComments` and §11F for
+`ListLabelEvents` and `RemoveLabel`. All implementations MUST be safe for concurrent use.
 
 ### 11C.2 Domain types
 
-The auto-merge reaction introduces five domain types:
+The auto-merge reaction introduces the following domain types:
 
 - `MergeStrategy`: merge strategy for `MergePR`. One of `merge`, `squash`, `rebase`.
 - `ReviewDecision`: normalized review status. One of `APPROVED`, `CHANGES_REQUESTED`,
@@ -39,8 +40,11 @@ The auto-merge reaction introduces five domain types:
   `dirty`, `unknown` (lowercase string values).
 - `PRMergeStatus`: struct carrying the merge precondition state. Fields: `ReviewDecision`,
   `CIConclusion`, `Draft` (bool, separate from `Mergeability`), `Mergeability`
-  (`MergeabilityState`), `HeadSHA`, `BranchName`. `ReviewDecision` and `CIConclusion` are unset
-  by `GetMergeability`; callers obtain those from dedicated reads.
+  (`MergeabilityState`), `HeadSHA`, `BranchName`, `BaseBranch` (the PR's target branch, added for
+  merge-conflict detection, §11E.1), `Merged` (bool reporting whether the pull request has
+  merged, added for the post-merge closure reaction, ADR-0017), and `MergeCommitSHA` (the merge
+  commit identifier, set only when `Merged` is true, added by the same reaction). `ReviewDecision`
+  and `CIConclusion` are unset by `GetMergeability`; callers obtain those from dedicated reads.
 - `MergeResult`: struct carrying `SHA` (merge commit SHA), `Merged` (bool reporting whether the
   merge completed), and `Message` (provider-supplied status text). The already-merged case is
   NOT signaled on this struct; it is signaled via `*SCMError` with kind `ErrSCMConflict` and the
@@ -49,8 +53,9 @@ The auto-merge reaction introduces five domain types:
 
 ### 11C.3 Error kind
 
-`ErrSCMConflict` is the sixth `SCMErrorKind` value. Its HTTP semantics (405 method-not-allowed
-and 409 conflict from the merge endpoint) are documented in the §11B.3 table.
+`ErrSCMConflict` is an `SCMErrorKind` value alongside the transport, auth, API, not-found, and
+payload categories already defined for review-comment fetching (§11B.3). Its HTTP semantics (405
+method-not-allowed and 409 conflict from the merge endpoint) are documented in the §11B.3 table.
 
 The auto-merge reconcile loop imposes merge-specific dispositions on this kind. A 409 response
 with an "already merged" body is treated as idempotent success. A 405 or a 409 with a head-SHA

--- a/docs/architecture/15-bot-review-comment-feedback-contract.md
+++ b/docs/architecture/15-bot-review-comment-feedback-contract.md
@@ -116,11 +116,13 @@ the `bot-review` fingerprint row. The escalation path MUST NOT call `ClearReacti
 the residual `reaction_attempts[issue_id:bot-review]` counter. The issue claim and that residual
 counter are owned by whichever kind currently holds the claim (the first-turn dispatch, `review`, or
 `merge`); releasing them from the bot-review path would corrupt sibling-kind ownership. Because the
-pending entry is deleted, the kind stops polling and the residual counter is inert until terminal
-cleanup removes it. When the issue reaches a terminal tracker state, `ClearReactionsForIssue` (run
-by the tracker-reconcile path) removes the residual counter and the claim along with any sibling
-slots. This mirrors how `escalateAutoMergeFailure` leaves `reaction_attempts[issue_id:merge]` and
-`state.Claimed` to terminal-state cleanup.
+pending entry is deleted, the kind stops polling, but the residual counter and the claim are not
+released by any path in the current implementation. `ClearReactionsForIssue` clears an issue's
+residual `reaction_attempts` counters and `pending_reactions` entries, but it does not touch
+`state.Claimed`, and no path, including the tracker-reconcile terminal-state path, calls it in
+production. The residual counter and the claim persist for the life of the orchestrator process.
+This mirrors how `escalateAutoMergeFailure` leaves `reaction_attempts[issue_id:merge]` and
+`state.Claimed` uncleaned after a merge-kind escalation.
 
 Escalation tracker-call failures are logged and counted
 (`sortie_bot_review_escalations_total{action="error"}`) but do not block the slot-scoped cleanup.
@@ -152,5 +154,5 @@ Per-issue `bot-review` reaction lifecycle (the `issue_id:bot-review` slot):
 | pending | Reconcile tick, fingerprint unchanged and dispatched | pending | Re-enqueue at `now + poll_interval`. |
 | pending | Reconcile tick, new actionable comments, attempts < cap | dispatched | Schedule continuation, increment attempts, count dispatched. |
 | pending | Reconcile tick, attempts reach cap | escalated | Apply escalation; clear ONLY the `bot-review` slot. MUST NOT release the claim or clear sibling slots (§11D.5). |
-| pending | Issue reaches terminal state (tracker reconcile) | (cleared) | `ClearReactionsForIssue` removes the slot, the residual counter, and the claim. |
+| pending | Issue reaches terminal state (tracker reconcile) | pending | No effect: the tracker-reconcile terminal-state path does not call `ClearReactionsForIssue`. The slot keeps re-enqueuing until the TTL backstop drops it; the residual counter and the claim are not released by any path. |
 

--- a/docs/architecture/16-merge-conflict-reaction-contract.md
+++ b/docs/architecture/16-merge-conflict-reaction-contract.md
@@ -204,5 +204,5 @@ Per-issue `merge-conflict` reaction lifecycle (the `issue_id:merge-conflict` slo
 | pending | Reconcile tick, `Mergeability == dirty`, fingerprint dispatched for this head | pending | Re-enqueue at `now + poll_interval`; do not increment counter. |
 | pending | Reconcile tick, `Mergeability == dirty`, new head, `attempts <= MaxRetries` | dispatched | Increment per-episode counter; schedule continuation; mark dispatched; count dispatched. |
 | pending | Reconcile tick, `Mergeability == dirty`, new head, `attempts > MaxRetries` | escalated | Increment per-episode counter; apply escalation; delete slot, fingerprint, and per-episode counter. MUST NOT release the claim or clear sibling slots (§11E.5). |
-| pending | Issue reaches terminal state (tracker reconcile) | (cleared) | `ClearReactionsForIssue` removes the slot, the residual counter, and the claim. |
+| pending | Issue reaches terminal state (tracker reconcile) | pending | No effect: the tracker-reconcile terminal-state path does not call `ClearReactionsForIssue`. The slot keeps re-enqueuing until the TTL backstop drops it; the residual counter and the claim are not released by any path. |
 

--- a/docs/architecture/28-label-command-and-read-only-review-contract.md
+++ b/docs/architecture/28-label-command-and-read-only-review-contract.md
@@ -400,9 +400,10 @@ guard seeding uses, so a label applied while Sortie was down is detected on the 
 restart (the journal is durable) for either command. The persisted mark is read back from
 `reaction_fingerprints` for each kind, so recovery does not reset deduplication state.
 
-When the linked issue reaches a terminal state the reaction state is cleared with the rest of the
-issue's reactions by the issue-wide reaction cleanup, which removes the pending entry and the
-fingerprint row by issue id across every kind. Commands on such PRs are ignored thereafter.
+When the linked issue reaches a terminal state, no path removes the `label-review` or `label-fix`
+reaction state: the tracker-reconcile terminal-state path does not call the issue-wide
+`ClearReactionsForIssue` cleanup, and neither kind carries a TTL to drop its own entry with age. A
+pending entry keeps polling the label-event journal after the issue closes.
 
 A pending `label-review` or `label-fix` entry no longer excludes its workspace from periodic-sweep
 candidacy, because neither kind carries an expiry. Detection is unaffected by that
@@ -457,7 +458,7 @@ Per-issue `label-review` reaction lifecycle (the `issue_id:label-review` slot):
 | pending | Reconcile tick, new events but no confirmed command (retraction, foreign or unlabeled only, or collapse into an outstanding command) | pending | Advance the mark; re-enqueue at the poll interval; no dispatch. |
 | pending | Reconcile tick, confirmed command, none queued or running | dispatched | Advance the mark; schedule the read-only dispatch; remove the label best-effort; re-enqueue at the poll interval. |
 | pending | Reconcile tick, confirmed command, a `label-review` command already queued or running | pending | Advance the mark; re-enqueue; the gesture collapses into the outstanding command. |
-| pending | Issue reaches terminal state (tracker reconcile) | (cleared) | Issue-wide reaction cleanup removes the slot and the fingerprint row. |
+| pending | Issue reaches terminal state (tracker reconcile) | pending | No effect: the tracker-reconcile terminal-state path does not call `ClearReactionsForIssue`, and this kind carries no TTL to drop the entry on its own. Detection keeps polling. |
 
 Per-issue `label-fix` reaction lifecycle (the `issue_id:label-fix` slot) follows the same three
 states, differing only in the seeding and recovery guard and in which dispatch the confirmed-command
@@ -473,7 +474,7 @@ transition schedules:
 | pending | Reconcile tick, new events but no confirmed command (retraction, foreign or unlabeled only, or collapse into an outstanding command) | pending | Advance the mark; re-enqueue at the poll interval; no dispatch. |
 | pending | Reconcile tick, confirmed command, none queued or running | dispatched | Advance the mark; schedule the fix dispatch (§11F.13); remove the label best-effort; re-enqueue at the poll interval. |
 | pending | Reconcile tick, confirmed command, a `label-fix` command already queued or running | pending | Advance the mark; re-enqueue; the gesture collapses into the outstanding command. |
-| pending | Issue reaches terminal state (tracker reconcile) | (cleared) | Issue-wide reaction cleanup removes the slot and the fingerprint row. |
+| pending | Issue reaches terminal state (tracker reconcile) | pending | No effect: the tracker-reconcile terminal-state path does not call `ClearReactionsForIssue`, and this kind carries no TTL to drop the entry on its own. Detection keeps polling. |
 
 A PR record whose head branch is empty seeds and recovers no `label-fix` entry at all: the slot
 stays absent rather than entering `pending`, because a fix session with nothing to check out is

--- a/docs/decisions/0017-close-tracker-issue-on-managed-pr-merge.md
+++ b/docs/decisions/0017-close-tracker-issue-on-managed-pr-merge.md
@@ -124,8 +124,19 @@ Using the merge commit identifier rather than the pull request number is deliber
 reaction correctly when an issue legitimately produces a second merge, and it refuses to fire when
 the forge has not reported a merge commit, since an empty fingerprint is treated as no observation
 rather than as an observation of nothing. On a successful transition the row is marked dispatched and
-retained; it is not deleted, because deleting it would let the next poll tick observe the same merge
-as new.
+retained by this reaction; it is not deleted here, because deleting it would let the next poll tick
+observe the same merge as new.
+
+The latch is this reaction's alone to keep. An escalation that releases an issue after a retry
+budget is exhausted clears the escalating kind's own pending entry, attempt counter, and
+`reaction_fingerprints` row, and nothing else the issue holds, so a sibling kind escalating on the
+same issue leaves this reaction's entry and row intact. That scoping is what makes the
+once-per-merge property unconditional. A clear ranging over every pending entry and every
+`reaction_fingerprints` row an issue holds would take this reaction's entry and row with it and
+leave the same merge observable as new, so per-kind scope is an invariant of the escalation paths
+rather than a detail of any one of them. A second guard sits behind the latch: recovery rebuilds an
+entry only for an issue still parked in the handoff state, and an issue this reaction has already
+closed is no longer parked there.
 
 ### Failure posture
 
@@ -417,8 +428,9 @@ The decision is validated when all of the following hold:
    by a forge automation rule.
 2. A deployment that omits the reaction block behaves identically to one running without this
    change, performing no additional tracker write and no additional forge request.
-3. The transition fires exactly once per merge. Repeated poll ticks and a process restart between
-   the merge and the transition each produce one transition in total.
+3. The transition fires exactly once per merge. Repeated poll ticks, a process restart between the
+   merge and the transition, and an escalation of another reaction kind on the same issue each
+   produce one transition in total.
 4. The reaction transitions only to the state named by `target_state`, never to another member of
    the terminal-state list.
 5. Offline validation rejects a missing target state, a target that is not terminal, a target equal

--- a/docs/decisions/0018-bound-workspace-retention-by-age.md
+++ b/docs/decisions/0018-bound-workspace-retention-by-age.md
@@ -186,11 +186,15 @@ On a normal worker exit, when a source-control adapter is configured, a label co
 and the workspace metadata names a pull request with an owner and a repository, the orchestrator
 seeds a pending reaction entry for that label command. Two reaction kinds are seeded this way,
 `label-review` and `label-fix`. Neither carries an expiry, deliberately: a human label gesture stays
-actionable regardless of age, so unlike the five kinds that do expire at thirty minutes, `ci`,
-`review`, `bot-review`, `merge`, and `merge-conflict`, the label-command kinds have no drop-on-age
-branch. Their reconcile passes re-enqueue the entry on every outcome, so once seeded the entry
-persists for the life of the process, and after a restart recovery rebuilds it for any issue still
-parked in the handoff state inside the lookback.
+actionable regardless of age, so unlike the kinds whose entry is dropped at thirty minutes, the
+label-command kinds have no drop-on-age branch. They are not the only kinds without one, and the set
+is not fixed. A kind carries an expiry only where the signal it waits on either arrives shortly
+after the agent finishes or does not arrive at all, which is what makes dropping the entry a bound
+on pointless polling; a kind that waits on a human keeps its entry, and the narrowing below is
+written against that property rather than against a list of kinds. The label-command reconcile
+passes re-enqueue the entry on every outcome, so once seeded the entry persists for the life of the
+process, and after a restart recovery rebuilds it for any issue still parked in the handoff state
+inside the lookback.
 
 The sweep excluded every key holding an entry in the running map, the retry map, or the pending
 reaction map. Composing those facts: in a deployment that configures label commands, every completed
@@ -211,10 +215,20 @@ the bound cannot tolerate.
 
 One genuine dependency remains, and the floor is what disarms it. Across a restart the runtime
 entry is gone and recovery rebuilds it from `.sortie/scm.json` in the workspace, so a removed
-directory ends label-command detection for that pull request. Because the window may not be set
-below the recovery lookback, a workspace the bound may remove is one whose latest activity already
-falls outside the window recovery honors, and recovery would have skipped it regardless. Nothing
-reachable is lost.
+directory ends detection for that pull request. Because the window may not be set below the recovery
+lookback, a workspace the bound may remove is one whose latest activity already falls outside the
+window recovery honors, and recovery would have skipped it regardless. Nothing reachable is lost.
+
+That dependency binds the merge-completion reaction hardest, because it is the kind whose issue is
+meant to sit still. Its entry carries no expiry and so does not pin, its issue is parked in the
+handoff state for as long as its pull request waits on review, and no orchestrator path moves that
+issue until the merge is observed. Its workspace is therefore an ordinary age candidate while the
+merge is still unobserved, and once the directory is gone no restart rebuilds the entry that would
+have observed it. The floor is the whole of the protection here, and it is sufficient: a pull
+request that outlives the window sits in a workspace whose latest activity recovery had already
+stopped honoring, so the removal ends an observation that would not have survived a restart in any
+case. Carrying that observation further would mean moving the floor and the recovery lookback
+together, which is the coupling stated above read from the other side.
 
 The alternative, redefining the pin as a property of the reaction so that the entry outlives the
 directory it was seeded from, was considered and rejected. It requires promoting pending reaction
@@ -346,11 +360,11 @@ For those, waiting is not a strategy, and the disk is consumed by work that fini
   for a post-mortem, leaves no trace in the run history and no push timestamp. If its last recorded
   activity is outside the window, it is removed. The floor makes this unlikely rather than
   impossible, and no signal short of an explicit marker file would make it impossible.
-- **Label-command detection ends at a restart for any workspace the bound removed.** Detection
-  continues in the running process, since it needs nothing from disk, but recovery cannot rebuild
-  the entry without `.sortie/scm.json`. The floor guarantees recovery would have skipped that
-  candidate anyway, so nothing reachable is lost, but the two windows are now coupled and a future
-  change to either silently changes the other.
+- **Detection by a reaction that does not pin ends at a restart for any workspace the bound
+  removed.** Detection continues in the running process, since it needs nothing from disk, but
+  recovery cannot rebuild the entry without `.sortie/scm.json`. The floor guarantees recovery would
+  have skipped that candidate anyway, so nothing reachable is lost, but the two windows are now
+  coupled and a future change to either silently changes the other.
 - **A label-fix session dispatched after removal pays a fresh checkout.** The workspace is recreated
   and the `after_create` hook runs again, which is where the clone happens. This applies only to
   issues idle beyond the window, and it costs time and bandwidth rather than correctness.

--- a/docs/gitea-adapter-notes.md
+++ b/docs/gitea-adapter-notes.md
@@ -459,6 +459,7 @@ GET /repos/{owner}/{repo}/pulls/{index}
 - The PR object carries `mergeable` (a plain bool, verified `true` on the lab PR), `merged`, `draft`, `head.sha`, `head.ref`, `base.ref`, and a `requested_reviewers` array. There is no `mergeable_state` string and no tri-state "computing" field (verified absent).
 - The boolean is the only mergeability signal, so the mapping to `MergeabilityState` is lossy: a draft maps to `blocked`, a mergeable non-draft to `clean`, and any other state to `unknown`. Gitea never yields `dirty` or `unstable`; a merge conflict and an in-progress recheck both collapse to `unknown`, which the auto-merge state machine re-enqueues rather than treating as a hard conflict.
 - The same read supplies `head.sha` (the CI ref for `GetCIStatus`), `head.ref` (the branch), and `base.ref` (the base branch the merge-conflict reaction needs).
+- The PR object also carries `merge_commit_sha`, serialized from the `MergedCommitID *string` field in `modules/structs/pull.go` at the Gitea `v1.27.0` tag this project pins. This is upstream-source provenance, not a live-verification claim: the lab PR carried no merged pull request to populate the field, so its presence and JSON key name are read from the upstream model rather than observed on the wire.
 
 ### Combined commit status
 

--- a/docs/github-adapter-notes.md
+++ b/docs/github-adapter-notes.md
@@ -614,8 +614,10 @@ GET /repos/{owner}/{repo}/pulls/{prNumber}
 Response subset:
 
 ```json
-{ "draft": false, "mergeable_state": "clean",
-  "head": { "sha": "<headSHA>", "ref": "<branch>" } }
+{ "draft": false, "mergeable_state": "clean", "merged": false,
+  "merge_commit_sha": "<shaOfATestMerge>",
+  "head": { "sha": "<headSHA>", "ref": "<branch>" },
+  "base": { "ref": "<baseBranch>" } }
 ```
 
 The adapter maps `mergeable_state` to `domain.MergeabilityState`:
@@ -628,11 +630,17 @@ The adapter maps `mergeable_state` to `domain.MergeabilityState`:
 | `dirty`                  | `MergeabilityDirty`        |
 | anything else (including the empty string) | `MergeabilityUnknown` |
 
-The returned `PRMergeStatus` populates `Draft`, `Mergeability`, `HeadSHA`,
-and `BranchName`. `ReviewDecision` and `CIConclusion` are left unset:
-callers obtain those values from the dedicated reads (see §1 and §2 above).
-GitHub computes `mergeable_state` asynchronously after a push, so callers
-treat `MergeabilityUnknown` as a deferral condition per [§11C.5](architecture/14-auto-merge-reaction-contract.md#11c5-merge-precondition-state-machine).
+The returned `PRMergeStatus` populates `Draft`, `Mergeability`, `HeadSHA`, `BranchName`,
+`BaseBranch` (from `base.ref`), `Merged` (from `merged`), and `MergeCommitSHA`.
+`ReviewDecision` and `CIConclusion` are left unset: callers obtain those values from the
+dedicated reads (see §1 and §2 above). GitHub computes `mergeable_state` asynchronously after
+a push, so callers treat `MergeabilityUnknown` as a deferral condition per
+[§11C.5](architecture/14-auto-merge-reaction-contract.md#11c5-merge-precondition-state-machine).
+
+GitHub populates `merge_commit_sha` on an open, unmerged pull request with a preview of the
+commit a merge would produce, not a record that a merge happened. The adapter reads
+`merge_commit_sha` into `MergeCommitSHA` only when `merged` is true, so the field is never
+populated for a pull request that has not actually merged.
 
 Idempotent and read-only.
 

--- a/docs/workflow-reference.md
+++ b/docs/workflow-reference.md
@@ -1260,6 +1260,101 @@ reactions:
     poll_interval_ms: 60000
 ```
 
+#### Reaction kind: `merge_completion`
+
+Merge-completion detection. When configured, the orchestrator observes the merge state of
+Sortie-managed pull requests independently of who performs the merge, and transitions the
+linked issue to a single configured terminal state exactly once. The reaction is off by
+default: a deployment that omits the block behaves exactly as one running without it, and
+enabling it grants the tracker credential write authority it did not need before.
+
+Fields:
+
+| Field              | Type    | Default       | Dynamic Reload    | Description                                                                                    |
+| ------------------ | ------- | ------------- | ------------------ | ------------------------------------------------------------------------------------------------ |
+| `provider`         | string  | _(required)_  | Requires restart  | SCM adapter kind. Must match the provider of every other active SCM reaction. Activates the kind. |
+| `target_state`     | string  | _(required)_  | Requires restart  | The single terminal state the linked issue moves to once its pull request merges. Never inferred. |
+| `poll_interval_ms` | integer | `60000`       | Requires restart  | Polling interval for the merge-observation state machine. Minimum `30000` (30 sec).               |
+| `max_retries`      | integer | `2`           | Requires restart  | Retryable transition attempts before escalation. `0` escalates on the first failed attempt.       |
+| `escalation`       | string  | `label`       | Requires restart  | Escalation action when retries are exhausted. One of `label` or `comment`.                        |
+| `escalation_label` | string  | `needs-human` | Requires restart  | Label applied when `escalation` is `label`.                                                       |
+
+**Tracker prerequisites:** two `tracker` fields must be set before this block activates, and
+each is enforced offline. `tracker.handoff_state` must be non-empty: it is the state a merge
+waits in, and pending-reaction recovery across a restart is disabled entirely without it.
+`tracker.terminal_states` must be written out in front matter rather than left to the tracker
+adapter's default list: the reconcile pass and the terminal workspace sweep both read the
+list exactly as configured, with no fallback to an adapter default, so a defaulted list would
+let the validator accept a `target_state` the runtime never treats as terminal.
+
+**Activation:** The `reactions.merge_completion` block is active when `provider` is present
+and non-empty, on its own, with no other `reactions` block required. Agent-created PRs MUST
+write `pr_number` (positive integer), `owner`, and `repo` (all non-empty) to
+`.sortie/scm.json` in the workspace for merge-completion polling to activate; unlike the
+checkout-bearing kinds, no `branch` is required because the reaction performs no checkout.
+
+**Target-state rule and irreversibility:** the target is never inferred from the terminal
+list; the operator names it explicitly, and it is applied verbatim once the merge is
+observed. The transition is not reversible by the orchestrator: naming an abandonment state
+where a completion state was meant closes finished work under the wrong label, and no
+validator can detect that mistake, because it is a judgement about the issue rather than a
+configuration shape.
+
+**Idempotency key:** the fingerprint is the merge commit identifier reported by the
+provider, not the pull request number, persisted in the `reaction_fingerprints` SQLite table
+under a kind distinct from every other reaction. A row is created on the first observed
+merge, retained (never deleted) once the transition succeeds, and re-armed only when a later
+merge reports a different commit identifier. `Merged: true` with no reported commit
+identifier is treated as no observation rather than as a failure.
+
+**Failure matrix:**
+
+| Transition outcome            | Posture                                                     |
+| ------------------------------ | ------------------------------------------------------------ |
+| Transport or API failure       | Retry with backoff, bounded by `max_retries`, then escalate  |
+| Authentication failure         | Escalate immediately, no retry                                |
+| Payload failure (target state unreachable) | Escalate immediately, no retry                    |
+| Issue not found                | Stop, mark the fingerprint dispatched, log a warning, no escalation |
+
+**Restart-to-apply:** reaction configuration, including `target_state`, is captured once at
+orchestrator construction and is not rebuilt on a workflow reload. A change to this block, or
+to the two tracker prerequisites, takes effect only on the next restart; `sortie validate`
+compares the same configuration a restart would build, so the offline verdict and the
+construction verdict cannot diverge. Environment indirection through `$VAR` is not supported
+for any field in this block, matching every other reaction kind.
+
+**Request cost:** each parked issue costs one tracker issue-state read and one pull-request
+read per poll interval, plus one tracker write per observed merge. On a forge tracker the
+tracker and the SCM adapter share one credential against one host, so the steady-state cost
+approaches two requests per parked issue per poll interval. A deployment with many
+simultaneously parked issues SHOULD raise `poll_interval_ms` above the default rather than
+accept it.
+
+**Cross-kind isolation:** CI-failure and review escalations are scoped to their own kind:
+each clears only its own pending entry, attempt counter, and fingerprint, so merge-completion
+tracking for that issue survives an unrelated escalation. Other reaction kinds on the same
+issue are unaffected by a merge-completion transition or escalation, and vice versa.
+
+**Configuration drift on a running process:** editing `tracker.terminal_states` while the
+process runs does not update the `target_state` a running orchestrator already captured. When
+the two disagree, the reaction logs one warning naming both values and keeps transitioning
+issues to the frozen target; the terminal workspace sweep stops collecting the workspaces of
+issues this reaction closes until the two lists agree again. A restart re-validates the edited
+file offline and rejects the same drifted configuration before the process starts.
+
+Example:
+
+```yaml
+reactions:
+  merge_completion:
+    provider: github
+    target_state: done
+    poll_interval_ms: 60000
+    max_retries: 2
+    escalation: label
+    escalation_label: needs-human
+```
+
 **Validation rules:**
 
 - Reaction kind keys must match `[a-z][a-z0-9_-]*`. Invalid keys are rejected with a
@@ -1280,6 +1375,9 @@ reactions:
 - `review_label` and `fix_label` for `label_commands` must be strings; each defaults to a non-empty value, and an explicit `""` disables that command.
 - `poll_interval_ms` below `30000` for `label_commands` is clamped up to `30000` with a warning, not rejected.
 - For `label_commands`, setting `provider` while both `review_label` and `fix_label` are `""` is a configuration error surfaced offline by `sortie validate`.
+- `target_state` for `merge_completion` is required, must not equal `tracker.handoff_state`, must not be a member of `tracker.active_states` (falling back to the tracker adapter's default active states when that list is empty), and must be a member of `tracker.terminal_states` as written, with no fallback to the adapter's default terminal states.
+- `tracker.handoff_state` must be set and `tracker.terminal_states` must be non-empty in front matter when `reactions.merge_completion.provider` is set; each is reported as a configuration error naming the tracker field.
+- `poll_interval_ms` must be >= `30000` for `merge_completion`.
 - When `provider` is absent or empty, all other fields in the kind sub-object are ignored.
 
 ---

--- a/internal/domain/scm.go
+++ b/internal/domain/scm.go
@@ -96,6 +96,13 @@ type PRMergeStatus struct {
 	// "develop". Populated by GetMergeability from the same PR object it
 	// already fetches; empty only when the provider omits the base ref.
 	BaseBranch string
+
+	// Merged reports whether the pull request has been merged.
+	Merged bool
+
+	// MergeCommitSHA is the merge commit identifier reported by the
+	// provider. Set only when Merged is true.
+	MergeCommitSHA string
 }
 
 // MergeResult carries the outcome of a successful merge call.

--- a/internal/orchestrator/ci_reconcile.go
+++ b/internal/orchestrator/ci_reconcile.go
@@ -255,7 +255,9 @@ func handleCIFailure(
 
 // escalateCIFailure handles the case where CI fix retries are exhausted.
 // It applies the configured escalation action (label or comment), cancels
-// the retry, and releases the claim.
+// the retry, releases the claim, and clears the CI reaction's own pending
+// entry, counter, and fingerprint. Sibling reaction kinds for the same
+// issue are left untouched.
 func escalateCIFailure(
 	state *State,
 	params ReconcileParams,
@@ -341,8 +343,12 @@ func escalateCIFailure(
 	}
 
 	delete(state.Claimed, pending.IssueID)
-	ClearReactionsForIssue(ctx, state, params.Store, pending.IssueID, log)
 
+	// Scoped per-kind delete (not the issue-wide ClearReactionsForIssue)
+	// so sibling reactions' pending entries, counters, and fingerprints
+	// for the same issue survive a CI-only escalation.
+	delete(state.PendingReactions, ReactionKey(pending.IssueID, ReactionKindCI))
+	delete(state.ReactionAttempts, ReactionKey(pending.IssueID, ReactionKindCI))
 	if err := params.Store.DeleteReactionFingerprint(ctx, pending.IssueID, ReactionKindCI); err != nil {
 		log.Warn("failed to delete reaction fingerprint during CI escalation",
 			slog.Any("error", err),

--- a/internal/orchestrator/ci_reconcile_test.go
+++ b/internal/orchestrator/ci_reconcile_test.go
@@ -46,6 +46,7 @@ type ciReconcileStore struct {
 	getFingerprintCalls    int
 	markDispatchedCalls    int
 	deleteFingerprintCalls int
+	deleteFPByIssueCalls   int
 
 	upsertFingerprintErr     error
 	getFingerprintResult     string
@@ -73,6 +74,7 @@ func (s *ciReconcileStore) AppendRunHistory(_ context.Context, run persistence.R
 }
 
 func (s *ciReconcileStore) DeleteReactionFingerprintsByIssue(_ context.Context, _ string) error {
+	s.deleteFPByIssueCalls++
 	return s.deleteReactionFingerprintsByIssueErr
 }
 
@@ -1287,5 +1289,51 @@ func TestEscalateCIFailure_DeletesFingerprint(t *testing.T) {
 	// Claim must be released.
 	if _, ok := state.Claimed["ISS-FP-6"]; ok {
 		t.Error("claim not released after escalation")
+	}
+}
+
+// TestReconcileCIStatus_Failing_ExceedsMaxRetries_CrossKindIsolation verifies
+// that CI escalation clears only the CI reaction's own pending entry,
+// counter, and fingerprint. A sibling merge-completion entry parked on the
+// same issue (seeded from the same worker exit as the CI reaction) must
+// survive: the escalation must not call the issue-wide
+// DeleteReactionFingerprintsByIssue.
+func TestReconcileCIStatus_Failing_ExceedsMaxRetries_CrossKindIsolation(t *testing.T) {
+	t.Parallel()
+
+	issueID := "ISS-CI-ISO"
+	state := stateWithPendingReaction(t, issueID, "feature/broken", 3)
+	state.ReactionAttempts[ReactionKey(issueID, ReactionKindCI)] = 2
+
+	mcKey := ReactionKey(issueID, ReactionKindMergeCompletion)
+	state.PendingReactions[mcKey] = &PendingReaction{
+		IssueID:    issueID,
+		Identifier: issueID + "-ident",
+		Kind:       ReactionKindMergeCompletion,
+		CreatedAt:  ciBaseTime,
+		KindData:   &MergeCompletionReactionData{PRNumber: 42, Owner: "owner", Repo: "repo"},
+	}
+	state.ReactionAttempts[ReactionKey(issueID, ReactionKindMergeCompletion)] = 1
+
+	store := &ciReconcileStore{}
+	metrics := newCIMetricsSpy()
+	tracker := &ciTrackerStub{}
+	ci := &mockCIProvider{result: domain.CIResult{Status: domain.CIStatusFailing, FailingCount: 1}}
+	params := ciParams(t, store, ci, tracker)
+
+	reconcileCIStatus(state, params, discardLogger(), context.Background(), metrics)
+	state.TrackerOpsWg.Wait()
+
+	if _, ok := state.PendingReactions[mcKey]; !ok {
+		t.Error("sibling merge-completion PendingReactions entry removed by CI escalation; want untouched")
+	}
+	if state.ReactionAttempts[ReactionKey(issueID, ReactionKindMergeCompletion)] != 1 {
+		t.Error("sibling merge-completion ReactionAttempts counter altered by CI escalation; want untouched")
+	}
+	if store.deleteFPByIssueCalls != 0 {
+		t.Errorf("DeleteReactionFingerprintsByIssue calls = %d, want 0 (escalation must be scoped to CI)", store.deleteFPByIssueCalls)
+	}
+	if store.deleteFingerprintCalls != 1 {
+		t.Errorf("DeleteReactionFingerprint calls = %d, want 1 (the CI kind's own fingerprint)", store.deleteFingerprintCalls)
 	}
 }

--- a/internal/orchestrator/exit.go
+++ b/internal/orchestrator/exit.go
@@ -138,6 +138,11 @@ type HandleWorkerExitParams struct {
 	// active for the current process. The enqueue path gates on this flag
 	// and the SCMAdapter being non-nil.
 	LabelFixReactionConfigured bool
+
+	// MergeCompletionReactionConfigured marks whether the
+	// merge-completion feature is active for the current process. The
+	// enqueue path gates on this flag and the SCMAdapter being non-nil.
+	MergeCompletionReactionConfigured bool
 }
 
 // HandleWorkerExit processes a worker's terminal outcome. It removes the
@@ -721,6 +726,43 @@ func HandleWorkerExit(state *State, workerResult WorkerResult, params HandleWork
 								Owner:    scm.Owner,
 								Repo:     scm.Repo,
 								Branch:   scm.Branch,
+							},
+							AgentKind:  entry.AgentKind,
+							RuleName:   entry.RuleName,
+							TemplateID: entry.TemplateID,
+						}
+					}
+				}
+			}
+		}
+
+		// Record a pending merge-completion entry when the SCM adapter
+		// is configured, merge-completion is enabled, and the workspace
+		// has PR metadata. Unlike the checkout-bearing kinds this
+		// requires no branch: the pass performs no checkout and reads
+		// no branch.
+		if params.SCMAdapter != nil && params.MergeCompletionReactionConfigured && workerResult.WorkspacePath != "" {
+			if reactionEnqueueAllowed {
+				scm := workspace.ReadSCMMetadata(workerResult.WorkspacePath, log)
+				if scm.PRNumber > 0 && scm.Owner != "" && scm.Repo != "" {
+					nowMergeCompletion := time.Now().UTC()
+					if params.NowFunc != nil {
+						nowMergeCompletion = params.NowFunc().UTC()
+					}
+					rkey := ReactionKey(workerResult.IssueID, ReactionKindMergeCompletion)
+					if _, exists := state.PendingReactions[rkey]; !exists {
+						state.PendingReactions[rkey] = &PendingReaction{
+							IssueID:     workerResult.IssueID,
+							Identifier:  workerResult.Identifier,
+							DisplayID:   entry.Issue.DisplayID,
+							Attempt:     normalizeAttempt(entry.RetryAttempt) + 1,
+							Kind:        ReactionKindMergeCompletion,
+							LastSSHHost: workerResult.SSHHost,
+							CreatedAt:   nowMergeCompletion,
+							KindData: &MergeCompletionReactionData{
+								PRNumber: scm.PRNumber,
+								Owner:    scm.Owner,
+								Repo:     scm.Repo,
 							},
 							AgentKind:  entry.AgentKind,
 							RuleName:   entry.RuleName,

--- a/internal/orchestrator/exit_test.go
+++ b/internal/orchestrator/exit_test.go
@@ -4421,13 +4421,10 @@ func TestHandleWorkerExit_MergeConflictEnqueueDoesNotOverwrite(t *testing.T) {
 // nil, or PR metadata is incomplete.
 //
 // The fixture includes a branch even though the label-review enqueue
-// clause itself imposes no branch requirement: workspace.ReadSCMMetadata
-// unconditionally returns a zero value whenever the decoded branch is
-// empty (internal/workspace/scm.go), which also zeroes PRNumber/Owner/Repo
-// before the label-review clause ever inspects them. A workspace's scm.json
-// is written only by a normal (non-read-only) session, and such a session
-// always operates on a branch, so this reflects the only reachable
-// production case.
+// clause itself imposes no branch requirement: a workspace's scm.json is
+// written only by a normal (non-read-only) session, and such a session
+// always operates on a branch, so this reflects the common production
+// case rather than a requirement of the enqueue clause or the reader.
 func TestHandleWorkerExit_LabelReviewEnqueue(t *testing.T) {
 	t.Parallel()
 
@@ -5010,11 +5007,8 @@ func TestHandleWorkerExit_LabelFixExit_ErrorStillRetries(t *testing.T) {
 // carrying the expected *MergeCompletionReactionData; and that nothing is
 // seeded when the reaction is not configured. The enqueue clause itself
 // imposes no branch requirement, unlike the checkout-bearing sibling
-// kinds; the fixtures below still carry a branch because
-// workspace.ReadSCMMetadata unconditionally returns a zero value whenever
-// the decoded branch is empty, which would zero PRNumber/Owner/Repo before
-// the merge-completion clause ever inspects them (see the label-review
-// enqueue test for the same precedent).
+// kinds; the fixtures below still carry a branch because that is the
+// common production case, not because the reader requires one.
 func TestHandleWorkerExit_MergeCompletionEnqueue(t *testing.T) {
 	t.Parallel()
 

--- a/internal/orchestrator/exit_test.go
+++ b/internal/orchestrator/exit_test.go
@@ -5000,3 +5000,202 @@ func TestHandleWorkerExit_LabelFixExit_ErrorStillRetries(t *testing.T) {
 		t.Errorf("RetryEntry.ReactionKind = %q, want %q (propagated from the exiting entry)", retry.ReactionKind, ReactionKindLabelFix)
 	}
 }
+
+// --- merge-completion enqueue tests ---
+
+// TestHandleWorkerExit_MergeCompletionEnqueue verifies that a normal exit
+// with the SCM adapter present, the reaction configured, and workspace SCM
+// metadata naming a pull request with owner and repo creates exactly one
+// pending entry keyed by ReactionKey(issueID, ReactionKindMergeCompletion)
+// carrying the expected *MergeCompletionReactionData; and that nothing is
+// seeded when the reaction is not configured. The enqueue clause itself
+// imposes no branch requirement, unlike the checkout-bearing sibling
+// kinds; the fixtures below still carry a branch because
+// workspace.ReadSCMMetadata unconditionally returns a zero value whenever
+// the decoded branch is empty, which would zero PRNumber/Owner/Repo before
+// the merge-completion clause ever inspects them (see the label-review
+// enqueue test for the same precedent).
+func TestHandleWorkerExit_MergeCompletionEnqueue(t *testing.T) {
+	t.Parallel()
+
+	t.Run("populates pending reaction with no branch check of its own", func(t *testing.T) {
+		t.Parallel()
+
+		wsPath := t.TempDir()
+		writePRSCMMetadata(t, wsPath, 42, "corp", "api", "feature/MGC-1", "c0ffee")
+
+		store := &mockExitStore{}
+		state := exitState(t, "MGC-1", nil)
+		params := defaultExitParams(t, store)
+		params.SCMAdapter = &scmAdapterStubExit{}
+		params.MergeCompletionReactionConfigured = true
+
+		HandleWorkerExit(state, WorkerResult{
+			IssueID:       "MGC-1",
+			Identifier:    "MGC-1-ident",
+			ExitKind:      WorkerExitNormal,
+			AgentAdapter:  "mock",
+			WorkspacePath: wsPath,
+		}, params)
+
+		rkey := ReactionKey("MGC-1", ReactionKindMergeCompletion)
+		pr, ok := state.PendingReactions[rkey]
+		if !ok {
+			t.Fatal("PendingReactions[MGC-1:merge-completion] missing after normal exit with PR metadata")
+		}
+		if pr.Kind != ReactionKindMergeCompletion {
+			t.Errorf("PendingReaction.Kind = %q, want %q", pr.Kind, ReactionKindMergeCompletion)
+		}
+		mcData, ok := pr.KindData.(*MergeCompletionReactionData)
+		if !ok {
+			t.Fatalf("KindData type = %T, want *MergeCompletionReactionData", pr.KindData)
+		}
+		if mcData.PRNumber != 42 {
+			t.Errorf("MergeCompletionReactionData.PRNumber = %d, want 42", mcData.PRNumber)
+		}
+		if mcData.Owner != "corp" {
+			t.Errorf("MergeCompletionReactionData.Owner = %q, want %q", mcData.Owner, "corp")
+		}
+		if mcData.Repo != "api" {
+			t.Errorf("MergeCompletionReactionData.Repo = %q, want %q", mcData.Repo, "api")
+		}
+	})
+
+	t.Run("not seeded when not configured", func(t *testing.T) {
+		t.Parallel()
+
+		wsPath := t.TempDir()
+		writePRSCMMetadata(t, wsPath, 43, "corp", "api", "feature/MGC-NC", "deadbeef")
+
+		store := &mockExitStore{}
+		state := exitState(t, "MGC-NC", nil)
+		params := defaultExitParams(t, store)
+		params.SCMAdapter = &scmAdapterStubExit{}
+		params.MergeCompletionReactionConfigured = false
+
+		HandleWorkerExit(state, WorkerResult{
+			IssueID:       "MGC-NC",
+			Identifier:    "MGC-NC-ident",
+			ExitKind:      WorkerExitNormal,
+			AgentAdapter:  "mock",
+			WorkspacePath: wsPath,
+		}, params)
+
+		rkey := ReactionKey("MGC-NC", ReactionKindMergeCompletion)
+		if _, ok := state.PendingReactions[rkey]; ok {
+			t.Error("PendingReactions[MGC-NC:merge-completion] present despite MergeCompletionReactionConfigured=false")
+		}
+	})
+
+	t.Run("not seeded when SCM adapter is nil", func(t *testing.T) {
+		t.Parallel()
+
+		wsPath := t.TempDir()
+		writePRSCMMetadata(t, wsPath, 44, "corp", "api", "feature/MGC-nil", "deadbeef")
+
+		store := &mockExitStore{}
+		state := exitState(t, "MGC-nil", nil)
+		params := defaultExitParams(t, store)
+		params.SCMAdapter = nil
+		params.MergeCompletionReactionConfigured = true
+
+		HandleWorkerExit(state, WorkerResult{
+			IssueID:       "MGC-nil",
+			Identifier:    "MGC-nil-ident",
+			ExitKind:      WorkerExitNormal,
+			AgentAdapter:  "mock",
+			WorkspacePath: wsPath,
+		}, params)
+
+		rkey := ReactionKey("MGC-nil", ReactionKindMergeCompletion)
+		if _, ok := state.PendingReactions[rkey]; ok {
+			t.Error("PendingReactions[MGC-nil:merge-completion] present despite nil SCMAdapter")
+		}
+	})
+
+	t.Run("does not overwrite an existing entry", func(t *testing.T) {
+		t.Parallel()
+
+		wsPath := t.TempDir()
+		writePRSCMMetadata(t, wsPath, 45, "corp", "api", "feature/MGC-DUP", "sha1")
+
+		store := &mockExitStore{}
+		state := exitState(t, "MGC-DUP", nil)
+		params := defaultExitParams(t, store)
+		params.SCMAdapter = &scmAdapterStubExit{}
+		params.MergeCompletionReactionConfigured = true
+
+		existingEntry := &PendingReaction{
+			IssueID: "MGC-DUP",
+			Kind:    ReactionKindMergeCompletion,
+			KindData: &MergeCompletionReactionData{
+				PRNumber: 99,
+				Owner:    "original",
+				Repo:     "original",
+			},
+		}
+		rkey := ReactionKey("MGC-DUP", ReactionKindMergeCompletion)
+		state.PendingReactions[rkey] = existingEntry
+
+		HandleWorkerExit(state, WorkerResult{
+			IssueID:       "MGC-DUP",
+			Identifier:    "MGC-DUP-ident",
+			ExitKind:      WorkerExitNormal,
+			AgentAdapter:  "mock",
+			WorkspacePath: wsPath,
+		}, params)
+
+		got := state.PendingReactions[rkey]
+		if got != existingEntry {
+			t.Error("PendingReactions[MGC-DUP:merge-completion] was replaced; want existing entry preserved")
+		}
+	})
+
+	t.Run("not seeded when PR metadata is incomplete", func(t *testing.T) {
+		t.Parallel()
+
+		tests := []struct {
+			name    string
+			content string
+		}{
+			{name: "missing pr_number", content: `{"branch":"feature/x","owner":"corp","repo":"api"}`},
+			{name: "missing owner", content: `{"branch":"feature/x","pr_number":10,"repo":"api"}`},
+			{name: "missing repo", content: `{"branch":"feature/x","pr_number":10,"owner":"corp"}`},
+			{name: "empty scm file", content: `{}`},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+
+				wsPath := t.TempDir()
+				dotSortie := filepath.Join(wsPath, ".sortie")
+				if err := os.MkdirAll(dotSortie, 0o750); err != nil {
+					t.Fatalf("MkdirAll .sortie: %v", err)
+				}
+				if err := os.WriteFile(filepath.Join(dotSortie, "scm.json"), []byte(tt.content), 0o600); err != nil {
+					t.Fatalf("WriteFile scm.json: %v", err)
+				}
+
+				store := &mockExitStore{}
+				state := exitState(t, "MGC-INC", nil)
+				params := defaultExitParams(t, store)
+				params.SCMAdapter = &scmAdapterStubExit{}
+				params.MergeCompletionReactionConfigured = true
+
+				HandleWorkerExit(state, WorkerResult{
+					IssueID:       "MGC-INC",
+					Identifier:    "MGC-INC-ident",
+					ExitKind:      WorkerExitNormal,
+					AgentAdapter:  "mock",
+					WorkspacePath: wsPath,
+				}, params)
+
+				rkey := ReactionKey("MGC-INC", ReactionKindMergeCompletion)
+				if _, ok := state.PendingReactions[rkey]; ok {
+					t.Errorf("PendingReactions[MGC-INC:merge-completion] present despite incomplete SCM metadata (%s)", tt.name)
+				}
+			})
+		}
+	})
+}

--- a/internal/orchestrator/merge_completion_reconcile.go
+++ b/internal/orchestrator/merge_completion_reconcile.go
@@ -1,0 +1,390 @@
+package orchestrator
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/sortie-ai/sortie/internal/domain"
+	"github.com/sortie-ai/sortie/internal/logging"
+)
+
+// mergeCompletionPendingBackoffBase is the floor for the merge-completion
+// poll interval and, through it, for the per-tick deferral and
+// fetch-error backoff delays. The exponential backoff itself is computed
+// by [computeReactionPendingDelay]; this constant only bounds it from
+// below.
+const mergeCompletionPendingBackoffBase = 10 * time.Second
+
+// mergeCompletionDueEntry is a pending merge-completion entry that has
+// passed its retry-delay check and is ready for this tick's tracker
+// state read.
+type mergeCompletionDueEntry struct {
+	key     string
+	pending *PendingReaction
+	data    *MergeCompletionReactionData
+}
+
+// reconcileMergeCompletion observes the merge state of managed pull
+// requests for pending merge-completion entries, latches on the merge
+// commit identifier, and transitions the linked issue to the configured
+// target state exactly once per merge.
+//
+// Called from [ReconcileRunningIssues] last, after
+// [reconcileLabelFixCommands]. Skipped entirely when params.SCMAdapter or
+// params.TrackerAdapter is nil, or params.MergeCompletionReactionConfigured
+// is false.
+func reconcileMergeCompletion(state *State, params ReconcileParams, log *slog.Logger, ctx context.Context, _ domain.Metrics) {
+	if params.SCMAdapter == nil || params.TrackerAdapter == nil {
+		return
+	}
+	if !params.MergeCompletionReactionConfigured {
+		return
+	}
+
+	now := time.Now().UTC()
+	if params.NowFunc != nil {
+		now = params.NowFunc().UTC()
+	}
+
+	warnMergeCompletionTerminalDrift(state, params, log)
+
+	pollInterval := max(time.Duration(params.MergeCompletionConfig.PollIntervalMS)*time.Millisecond, mergeCompletionPendingBackoffBase)
+
+	var due []mergeCompletionDueEntry
+	for key, pending := range state.PendingReactions {
+		if pending.Kind != ReactionKindMergeCompletion {
+			continue
+		}
+		delete(state.PendingReactions, key)
+
+		data, ok := pending.KindData.(*MergeCompletionReactionData)
+		if !ok {
+			log.ErrorContext(ctx, "unexpected KindData type for merge_completion reaction",
+				slog.String("issue_id", pending.IssueID),
+				slog.String("type", fmt.Sprintf("%T", pending.KindData)),
+			)
+			continue
+		}
+
+		if now.Before(pending.PendingRetryAt) {
+			state.PendingReactions[key] = pending
+			continue
+		}
+
+		due = append(due, mergeCompletionDueEntry{key: key, pending: pending, data: data})
+	}
+	if len(due) == 0 {
+		return
+	}
+
+	issueIDs := make([]string, 0, len(due))
+	for _, entry := range due {
+		issueIDs = append(issueIDs, entry.pending.IssueID)
+	}
+
+	statesByID, err := params.TrackerAdapter.FetchIssueStatesByIDs(ctx, issueIDs)
+	if err != nil {
+		for _, entry := range due {
+			backoffMergeCompletionReenqueue(state, entry.key, entry.pending, now, pollInterval)
+		}
+		log.Warn("merge_completion issue state read failed",
+			slog.Any("error", err),
+		)
+		return
+	}
+
+	terminalSet := stateSet(params.TerminalStates)
+
+	for _, entry := range due {
+		processMergeCompletionEntry(state, params, entry, statesByID, terminalSet, now, pollInterval, log, ctx)
+	}
+}
+
+// warnMergeCompletionTerminalDrift tests, once per pass and before any
+// pending entry is examined, whether the target state captured at
+// construction is still a member of the runtime terminal-state list. A
+// reloaded tracker.terminal_states that no longer contains the target
+// state emits one WARN per onset, suppressed by
+// [State.MergeCompletionTerminalDriftLogged] while the condition
+// persists. The check never blocks a transition, changes an entry's
+// disposition, or reads whether any entry is due.
+func warnMergeCompletionTerminalDrift(state *State, params ReconcileParams, log *slog.Logger) {
+	_, terminal := stateSet(params.TerminalStates)[strings.ToLower(params.MergeCompletionConfig.TargetState)]
+	if terminal {
+		state.MergeCompletionTerminalDriftLogged = false
+		return
+	}
+	if state.MergeCompletionTerminalDriftLogged {
+		return
+	}
+	log.Warn("merge_completion target state is not in the configured terminal states",
+		slog.String("target_state", params.MergeCompletionConfig.TargetState),
+		slog.Any("terminal_states", params.TerminalStates),
+	)
+	state.MergeCompletionTerminalDriftLogged = true
+}
+
+// processMergeCompletionEntry evaluates one due entry against the
+// tracker state read already performed for the whole due set: it drops
+// an entry whose issue is gone, terminal, or has left the handoff state;
+// defers one still claimed by the orchestrator; and otherwise observes
+// the merge, latches on the merge commit identifier, and performs the
+// transition.
+func processMergeCompletionEntry(
+	state *State,
+	params ReconcileParams,
+	entry mergeCompletionDueEntry,
+	statesByID map[string]string,
+	terminalSet map[string]struct{},
+	now time.Time,
+	pollInterval time.Duration,
+	log *slog.Logger,
+	ctx context.Context,
+) {
+	key, pending, data := entry.key, entry.pending, entry.data
+	entryLog := logging.WithIssue(log, pending.IssueID, pending.Identifier)
+
+	stateName, known := statesByID[pending.IssueID]
+	if !known {
+		entryLog.Warn("merge_completion issue not found in tracker state response, dropping")
+		return
+	}
+	if _, terminal := terminalSet[strings.ToLower(stateName)]; terminal {
+		entryLog.Info("merge_completion issue already terminal, dropping",
+			slog.String("state", stateName),
+		)
+		return
+	}
+	if _, claimed := state.Claimed[pending.IssueID]; claimed {
+		pending.PendingRetryAt = now.Add(pollInterval)
+		state.PendingReactions[key] = pending
+		return
+	}
+	if !strings.EqualFold(stateName, params.HandoffState) {
+		entryLog.Info("merge_completion stopped: issue left the handoff state",
+			slog.String("state", stateName),
+		)
+		return
+	}
+
+	status, mergeErr := params.SCMAdapter.GetMergeability(ctx, data.PRNumber, data.Owner, data.Repo)
+	if mergeErr != nil {
+		var scmErr *domain.SCMError
+		if errors.As(mergeErr, &scmErr) && scmErr.Kind == domain.ErrSCMNotFound {
+			entryLog.Warn("merge_completion pull request not found, dropping",
+				slog.Int("pr_number", data.PRNumber),
+			)
+			return
+		}
+		backoffMergeCompletionReenqueue(state, key, pending, now, pollInterval)
+		entryLog.Warn("merge_completion mergeability fetch failed, retrying with backoff",
+			slog.Any("error", mergeErr),
+			slog.Int("pending_attempts", pending.PendingAttempts),
+		)
+		return
+	}
+
+	if !status.Merged {
+		pending.PendingRetryAt = now.Add(pollInterval)
+		state.PendingReactions[key] = pending
+		return
+	}
+	if status.MergeCommitSHA == "" {
+		pending.PendingRetryAt = now.Add(pollInterval)
+		state.PendingReactions[key] = pending
+		entryLog.Warn("merge_completion merged pull request reported no merge commit",
+			slog.Int("pr_number", data.PRNumber),
+		)
+		return
+	}
+
+	if upsertErr := params.Store.UpsertReactionFingerprint(ctx, pending.IssueID, ReactionKindMergeCompletion, status.MergeCommitSHA); upsertErr != nil {
+		backoffMergeCompletionReenqueue(state, key, pending, now, pollInterval)
+		entryLog.Warn("failed to upsert merge_completion reaction fingerprint",
+			slog.Any("error", upsertErr),
+		)
+		return
+	}
+	storedFP, dispatched, fpErr := params.Store.GetReactionFingerprint(ctx, pending.IssueID, ReactionKindMergeCompletion)
+	if fpErr != nil {
+		backoffMergeCompletionReenqueue(state, key, pending, now, pollInterval)
+		entryLog.Warn("failed to read merge_completion reaction fingerprint",
+			slog.Any("error", fpErr),
+		)
+		return
+	}
+	if storedFP == status.MergeCommitSHA && dispatched {
+		entryLog.Debug("merge_completion already transitioned for this merge",
+			slog.String("merge_commit_sha", status.MergeCommitSHA),
+		)
+		return
+	}
+
+	rkey := ReactionKey(pending.IssueID, ReactionKindMergeCompletion)
+	transitionErr := params.TrackerAdapter.TransitionIssue(ctx, pending.IssueID, params.MergeCompletionConfig.TargetState)
+	state.ReactionAttempts[rkey]++
+
+	if transitionErr != nil {
+		routeTransitionFailure(state, params, key, pending, data, transitionErr, now, pollInterval, entryLog, ctx)
+		return
+	}
+
+	markErr := params.Store.MarkReactionDispatched(ctx, pending.IssueID, ReactionKindMergeCompletion)
+	delete(state.ReactionAttempts, rkey)
+	if markErr != nil {
+		entryLog.Warn("merge_completion dispatched mark failed",
+			slog.String("merge_commit_sha", status.MergeCommitSHA),
+			slog.Any("error", markErr),
+		)
+		return
+	}
+	entryLog.Info("merge_completion transitioned issue to terminal state",
+		slog.String("target_state", params.MergeCompletionConfig.TargetState),
+		slog.Int("pr_number", data.PRNumber),
+		slog.String("merge_commit_sha", status.MergeCommitSHA),
+	)
+}
+
+// backoffMergeCompletionReenqueue increments the pending entry's attempt
+// counter, applies exponential backoff floored at pollInterval, and
+// reinserts the entry into state.PendingReactions.
+func backoffMergeCompletionReenqueue(state *State, key string, pending *PendingReaction, now time.Time, pollInterval time.Duration) {
+	pending.PendingAttempts++
+	delay := max(computeReactionPendingDelay(pending.PendingAttempts), pollInterval)
+	pending.PendingRetryAt = now.Add(delay)
+	state.PendingReactions[key] = pending
+}
+
+// routeTransitionFailure routes a failing TransitionIssue call: a
+// not-found issue stops without escalating, an auth or payload failure
+// escalates immediately consuming no retry budget, and a transport,
+// API, or unclassified failure retries with backoff until the call
+// count exceeds MaxRetries, then escalates. An unclassified error (not
+// a [*domain.TrackerError]) routes with the retryable kinds, the
+// non-destructive default.
+func routeTransitionFailure(
+	state *State,
+	params ReconcileParams,
+	key string,
+	pending *PendingReaction,
+	data *MergeCompletionReactionData,
+	err error,
+	now time.Time,
+	pollInterval time.Duration,
+	log *slog.Logger,
+	ctx context.Context,
+) {
+	rkey := ReactionKey(pending.IssueID, ReactionKindMergeCompletion)
+
+	var trackerErr *domain.TrackerError
+	kind := domain.ErrTrackerTransport
+	if errors.As(err, &trackerErr) {
+		kind = trackerErr.Kind
+	}
+
+	switch kind {
+	case domain.ErrTrackerNotFound:
+		if markErr := params.Store.MarkReactionDispatched(ctx, pending.IssueID, ReactionKindMergeCompletion); markErr != nil {
+			log.Warn("failed to mark merge_completion dispatched on not-found stop",
+				slog.Any("error", markErr),
+			)
+		}
+		delete(state.ReactionAttempts, rkey)
+		log.Warn("merge_completion issue not found, stopping",
+			slog.Any("error", err),
+		)
+
+	case domain.ErrTrackerAuth, domain.ErrTrackerPayload:
+		log.Error("merge_completion transition failed, escalating",
+			slog.Any("error", err),
+		)
+		escalateMergeCompletion(state, params, pending, data, state.ReactionAttempts[rkey], log, ctx)
+
+	default:
+		attempts := state.ReactionAttempts[rkey]
+		if attempts > params.MergeCompletionConfig.MaxRetries {
+			log.Warn("merge_completion transition attempts exhausted, escalating",
+				slog.Int("attempts", attempts),
+				slog.Int("max_retries", params.MergeCompletionConfig.MaxRetries),
+			)
+			escalateMergeCompletion(state, params, pending, data, attempts, log, ctx)
+			return
+		}
+		backoffMergeCompletionReenqueue(state, key, pending, now, pollInterval)
+		log.Warn("merge_completion transition failed, retrying with backoff",
+			slog.Any("error", err),
+			slog.Int("pending_attempts", pending.PendingAttempts),
+		)
+	}
+}
+
+// escalateMergeCompletion dispatches the configured escalation action
+// (label or comment) asynchronously through [State.TrackerOpsWg] and
+// clears the transition call counter. The pending entry is already
+// removed by the caller; the fingerprint row is left undispatched, the
+// accepted residue of an escalated merge-completion attempt.
+func escalateMergeCompletion(
+	state *State,
+	params ReconcileParams,
+	pending *PendingReaction,
+	data *MergeCompletionReactionData,
+	attempts int,
+	log *slog.Logger,
+	ctx context.Context,
+) {
+	issueID := pending.IssueID
+	tracker := params.TrackerAdapter
+	escalLog := log
+
+	switch params.MergeCompletionConfig.Escalation {
+	case "label":
+		label := params.MergeCompletionConfig.EscalationLabel
+
+		state.TrackerOpsWg.Go(func() {
+			dctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
+			defer cancel()
+
+			if err := tracker.AddLabel(dctx, issueID, label); err != nil {
+				escalLog.Warn("merge_completion escalation label failed",
+					slog.Any("error", err),
+				)
+			}
+		})
+
+	case "comment":
+		commentText := buildMergeCompletionEscalationComment(data, params.MergeCompletionConfig.TargetState, attempts)
+
+		state.TrackerOpsWg.Go(func() {
+			dctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
+			defer cancel()
+
+			if err := tracker.CommentIssue(dctx, issueID, commentText); err != nil {
+				escalLog.Warn("merge_completion escalation comment failed",
+					slog.Any("error", err),
+				)
+			}
+		})
+	}
+
+	delete(state.ReactionAttempts, ReactionKey(pending.IssueID, ReactionKindMergeCompletion))
+}
+
+// buildMergeCompletionEscalationComment returns the plain-text escalation
+// comment used when a merge-completion transition cannot be performed.
+// It names the pull request number, repository, configured target
+// state, and the number of transition calls made, and no internal
+// symbol, table, or file path.
+func buildMergeCompletionEscalationComment(data *MergeCompletionReactionData, targetState string, attempts int) string {
+	return fmt.Sprintf(
+		"Sortie attempted %d time(s) and could not transition the issue to %q after PR #%d (%s/%s) merged. Manual transition required.",
+		attempts,
+		targetState,
+		data.PRNumber,
+		data.Owner,
+		data.Repo,
+	)
+}

--- a/internal/orchestrator/merge_completion_reconcile_test.go
+++ b/internal/orchestrator/merge_completion_reconcile_test.go
@@ -1,0 +1,1070 @@
+package orchestrator
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/sortie-ai/sortie/internal/domain"
+	"github.com/sortie-ai/sortie/internal/persistence"
+)
+
+// --- Test doubles ---
+
+// mgcTransitionCall records one TransitionIssue invocation.
+type mgcTransitionCall struct {
+	issueID string
+	target  string
+}
+
+// mgcLabelCall records one AddLabel invocation.
+type mgcLabelCall struct {
+	issueID string
+	label   string
+}
+
+// mgcCommentCall records one CommentIssue invocation.
+type mgcCommentCall struct {
+	issueID string
+	text    string
+}
+
+// mgcTrackerFake is a fully controllable domain.TrackerAdapter for
+// merge-completion reconcile tests: FetchIssueStatesByIDs returns a
+// canned map or error, TransitionIssue returns a canned or per-call
+// error, and AddLabel/CommentIssue record every escalation call.
+type mgcTrackerFake struct {
+	states    map[string]string
+	statesErr error
+
+	statesCalls atomic.Int32
+
+	transitionErr   error
+	transitionErrFn func(callNum int) error
+	transitionCalls []mgcTransitionCall
+
+	addLabelCalls []mgcLabelCall
+	commentCalls  []mgcCommentCall
+}
+
+var _ domain.TrackerAdapter = (*mgcTrackerFake)(nil)
+
+func (f *mgcTrackerFake) FetchIssuesByStates(context.Context, []string) ([]domain.Issue, error) {
+	return nil, nil
+}
+func (f *mgcTrackerFake) FetchCandidateIssues(context.Context) ([]domain.Issue, error) {
+	return nil, nil
+}
+func (f *mgcTrackerFake) FetchIssueByID(context.Context, string) (domain.Issue, error) {
+	return domain.Issue{}, nil
+}
+func (f *mgcTrackerFake) FetchIssueStatesByIdentifiers(context.Context, []string) (map[string]string, error) {
+	return nil, nil
+}
+func (f *mgcTrackerFake) FetchIssueComments(context.Context, string) ([]domain.Comment, error) {
+	return nil, nil
+}
+
+func (f *mgcTrackerFake) FetchIssueStatesByIDs(_ context.Context, _ []string) (map[string]string, error) {
+	f.statesCalls.Add(1)
+	if f.statesErr != nil {
+		return nil, f.statesErr
+	}
+	return f.states, nil
+}
+
+func (f *mgcTrackerFake) TransitionIssue(_ context.Context, issueID, target string) error {
+	f.transitionCalls = append(f.transitionCalls, mgcTransitionCall{issueID: issueID, target: target})
+	if f.transitionErrFn != nil {
+		return f.transitionErrFn(len(f.transitionCalls))
+	}
+	return f.transitionErr
+}
+
+func (f *mgcTrackerFake) CommentIssue(_ context.Context, issueID, text string) error {
+	f.commentCalls = append(f.commentCalls, mgcCommentCall{issueID: issueID, text: text})
+	return nil
+}
+
+func (f *mgcTrackerFake) AddLabel(_ context.Context, issueID, label string) error {
+	f.addLabelCalls = append(f.addLabelCalls, mgcLabelCall{issueID: issueID, label: label})
+	return nil
+}
+
+// mgcSCMFake is a controllable domain.SCMAdapter whose GetMergeability
+// return value is supplied by a function field, so tests can vary the
+// observed merge state per call.
+type mgcSCMFake struct {
+	fn    func(prNumber int, owner, repo string) (domain.PRMergeStatus, error)
+	calls atomic.Int32
+}
+
+var _ domain.SCMAdapter = (*mgcSCMFake)(nil)
+
+func (m *mgcSCMFake) GetMergeability(_ context.Context, prNumber int, owner, repo string) (domain.PRMergeStatus, error) {
+	m.calls.Add(1)
+	if m.fn != nil {
+		return m.fn(prNumber, owner, repo)
+	}
+	return domain.PRMergeStatus{}, nil
+}
+func (m *mgcSCMFake) FetchPendingReviews(context.Context, int, string, string) ([]domain.ReviewComment, error) {
+	return nil, nil
+}
+func (m *mgcSCMFake) FetchBotReviewComments(context.Context, int, string, string, []string) ([]domain.ReviewComment, error) {
+	return nil, nil
+}
+func (m *mgcSCMFake) GetReviewDecision(context.Context, int, string, string) (domain.ReviewDecision, error) {
+	return "", nil
+}
+func (m *mgcSCMFake) GetCIStatus(context.Context, int, string, string) (string, error) {
+	return "", nil
+}
+func (m *mgcSCMFake) MergePR(context.Context, int, string, string, domain.MergeStrategy, string, string, string) (domain.MergeResult, error) {
+	return domain.MergeResult{}, nil
+}
+func (m *mgcSCMFake) DeleteBranch(context.Context, string, string, string) error { return nil }
+func (m *mgcSCMFake) ListLabelEvents(context.Context, int, string, string) ([]domain.LabelEvent, error) {
+	return nil, nil
+}
+func (m *mgcSCMFake) RemoveLabel(context.Context, int, string, string, string) error { return nil }
+
+// mgcFingerprintRecord is one stored (issue, kind) fingerprint row.
+type mgcFingerprintRecord struct {
+	fingerprint string
+	dispatched  bool
+}
+
+// mgcStoreFake is a ReconcileStore that genuinely persists the
+// per-(issue,kind) fingerprint and dispatched flag, and deletes by
+// issue prefix for real, so the exactly-once latch and the
+// cross-kind-clear interaction are exercised against real stored
+// state rather than canned values.
+type mgcStoreFake struct {
+	fingerprints map[string]mgcFingerprintRecord
+
+	upsertErr error
+	getErr    error
+	markErr   error
+
+	upsertCalls        int
+	getCalls           int
+	markCalls          int
+	deleteByIssueCalls int
+}
+
+var _ ReconcileStore = (*mgcStoreFake)(nil)
+
+func newMGCStore() *mgcStoreFake {
+	return &mgcStoreFake{fingerprints: make(map[string]mgcFingerprintRecord)}
+}
+
+func (s *mgcStoreFake) SaveRetryEntry(context.Context, persistence.RetryEntry) error { return nil }
+func (s *mgcStoreFake) DeleteRetryEntry(context.Context, string) error               { return nil }
+func (s *mgcStoreFake) AppendRunHistory(_ context.Context, run persistence.RunHistory) (persistence.RunHistory, error) {
+	return run, nil
+}
+
+func (s *mgcStoreFake) DeleteReactionFingerprintsByIssue(_ context.Context, issueID string) error {
+	s.deleteByIssueCalls++
+	prefix := issueID + ":"
+	for key := range s.fingerprints {
+		if strings.HasPrefix(key, prefix) {
+			delete(s.fingerprints, key)
+		}
+	}
+	return nil
+}
+
+func (s *mgcStoreFake) UpsertReactionFingerprint(_ context.Context, issueID, kind, fingerprint string) error {
+	s.upsertCalls++
+	if s.upsertErr != nil {
+		return s.upsertErr
+	}
+	key := issueID + ":" + kind
+	rec := s.fingerprints[key]
+	if rec.fingerprint != fingerprint {
+		rec.dispatched = false
+	}
+	rec.fingerprint = fingerprint
+	s.fingerprints[key] = rec
+	return nil
+}
+
+func (s *mgcStoreFake) GetReactionFingerprint(_ context.Context, issueID, kind string) (string, bool, error) {
+	s.getCalls++
+	if s.getErr != nil {
+		return "", false, s.getErr
+	}
+	rec := s.fingerprints[issueID+":"+kind]
+	return rec.fingerprint, rec.dispatched, nil
+}
+
+func (s *mgcStoreFake) MarkReactionDispatched(_ context.Context, issueID, kind string) error {
+	s.markCalls++
+	if s.markErr != nil {
+		return s.markErr
+	}
+	key := issueID + ":" + kind
+	rec := s.fingerprints[key]
+	rec.dispatched = true
+	s.fingerprints[key] = rec
+	return nil
+}
+
+func (s *mgcStoreFake) DeleteReactionFingerprint(_ context.Context, issueID, kind string) error {
+	delete(s.fingerprints, issueID+":"+kind)
+	return nil
+}
+
+// has reports the fingerprint record for the issue's merge-completion
+// row, the only kind this test file's store ever populates.
+func (s *mgcStoreFake) has(issueID string) (mgcFingerprintRecord, bool) {
+	rec, ok := s.fingerprints[issueID+":"+ReactionKindMergeCompletion]
+	return rec, ok
+}
+
+// --- Test helpers ---
+
+// mgcBaseTime is a fixed reference time for merge-completion reconcile
+// tests.
+var mgcBaseTime = time.Date(2026, 7, 1, 9, 0, 0, 0, time.UTC)
+
+// mgcTransportError builds a retryable *domain.TrackerError for tests
+// that only need a transport-class failure, not a specific message.
+func mgcTransportError() error {
+	return &domain.TrackerError{Kind: domain.ErrTrackerTransport, Message: "unavailable"}
+}
+
+// newMGCPending builds a PendingReaction with Kind=ReactionKindMergeCompletion,
+// due immediately (zero PendingRetryAt).
+func newMGCPending(issueID string, prNumber int) *PendingReaction {
+	return &PendingReaction{
+		IssueID:    issueID,
+		Identifier: issueID + "-ident",
+		DisplayID:  issueID + "-ident",
+		Attempt:    1,
+		Kind:       ReactionKindMergeCompletion,
+		CreatedAt:  mgcBaseTime,
+		KindData: &MergeCompletionReactionData{
+			PRNumber: prNumber,
+			Owner:    "owner",
+			Repo:     "repo",
+		},
+	}
+}
+
+// mgcStateWithPending creates a State with one merge-completion
+// PendingReaction entry, not claimed.
+func mgcStateWithPending(issueID string, prNumber int) *State {
+	s := NewState(5000, 4, nil, AgentTotals{})
+	rkey := ReactionKey(issueID, ReactionKindMergeCompletion)
+	s.PendingReactions[rkey] = newMGCPending(issueID, prNumber)
+	return s
+}
+
+// defaultMGCConfig returns a MergeCompletionReactionConfig with the
+// ADR defaults except MaxRetries, which the failure-routing tests
+// override per case.
+func defaultMGCConfig() MergeCompletionReactionConfig {
+	return MergeCompletionReactionConfig{
+		TargetState:     "done",
+		PollIntervalMS:  60000,
+		Escalation:      "label",
+		EscalationLabel: "needs-human",
+		MaxRetries:      2,
+	}
+}
+
+// mgcParams returns ReconcileParams wired for merge-completion reconcile
+// unit tests: the tracker reports the issue in the handoff state, the
+// target state is a member of TerminalStates, and NowFunc is fixed at
+// mgcBaseTime.
+func mgcParams(store ReconcileStore, scm domain.SCMAdapter, tracker domain.TrackerAdapter) ReconcileParams {
+	return ReconcileParams{
+		TrackerAdapter:                    tracker,
+		SCMAdapter:                        scm,
+		HandoffState:                      "In Review",
+		TerminalStates:                    []string{"Done"},
+		MergeCompletionConfig:             defaultMGCConfig(),
+		MergeCompletionReactionConfigured: true,
+		Store:                             store,
+		OnRetryFire:                       noopRetryFire,
+		Ctx:                               context.Background(),
+		NowFunc:                           func() time.Time { return mgcBaseTime },
+	}
+}
+
+// mergedStatus returns a PRMergeStatus reporting a completed merge with
+// the given commit identifier.
+func mergedStatus(sha string) domain.PRMergeStatus {
+	return domain.PRMergeStatus{Merged: true, MergeCommitSHA: sha}
+}
+
+// Merge observed: one reconcile tick with a merged PR and a matching
+// handoff-state issue transitions exactly once, marks the fingerprint
+// dispatched, removes the pending entry, and posts no comment.
+
+func TestReconcileMergeCompletion_MergedTransitionsOnce(t *testing.T) {
+	t.Parallel()
+
+	issueID := "MGC-1"
+	state := mgcStateWithPending(issueID, 10)
+	store := newMGCStore()
+	tracker := &mgcTrackerFake{states: map[string]string{issueID: "In Review"}}
+	scm := &mgcSCMFake{fn: func(int, string, string) (domain.PRMergeStatus, error) { return mergedStatus("sha-1"), nil }}
+	params := mgcParams(store, scm, tracker)
+
+	reconcileMergeCompletion(state, params, discardLogger(), context.Background(), &domain.NoopMetrics{})
+
+	if len(tracker.transitionCalls) != 1 {
+		t.Fatalf("TransitionIssue calls = %d, want 1", len(tracker.transitionCalls))
+	}
+	if tracker.transitionCalls[0].target != "done" {
+		t.Errorf("TransitionIssue target = %q, want %q", tracker.transitionCalls[0].target, "done")
+	}
+	rec, ok := store.has(issueID)
+	if !ok || !rec.dispatched || rec.fingerprint != "sha-1" {
+		t.Errorf("fingerprint record = %+v, ok=%v, want dispatched=true fingerprint=sha-1", rec, ok)
+	}
+	rkey := ReactionKey(issueID, ReactionKindMergeCompletion)
+	if _, exists := state.PendingReactions[rkey]; exists {
+		t.Error("PendingReactions entry still present after successful transition, want removed")
+	}
+	if len(tracker.commentCalls) != 0 {
+		t.Errorf("CommentIssue calls = %d, want 0 (no comment on a successful transition)", len(tracker.commentCalls))
+	}
+}
+
+// An unmerged PR performs no transition and re-enqueues at the poll
+// interval.
+
+func TestReconcileMergeCompletion_UnmergedReenqueues(t *testing.T) {
+	t.Parallel()
+
+	issueID := "MGC-2"
+	state := mgcStateWithPending(issueID, 11)
+	store := newMGCStore()
+	tracker := &mgcTrackerFake{states: map[string]string{issueID: "In Review"}}
+	scm := &mgcSCMFake{fn: func(int, string, string) (domain.PRMergeStatus, error) {
+		return domain.PRMergeStatus{Merged: false}, nil
+	}}
+	params := mgcParams(store, scm, tracker)
+
+	reconcileMergeCompletion(state, params, discardLogger(), context.Background(), &domain.NoopMetrics{})
+
+	if len(tracker.transitionCalls) != 0 {
+		t.Errorf("TransitionIssue calls = %d, want 0", len(tracker.transitionCalls))
+	}
+	rkey := ReactionKey(issueID, ReactionKindMergeCompletion)
+	pending, ok := state.PendingReactions[rkey]
+	if !ok {
+		t.Fatal("PendingReactions entry missing, want present (re-enqueued)")
+	}
+	wantNotBefore := mgcBaseTime.Add(time.Duration(params.MergeCompletionConfig.PollIntervalMS) * time.Millisecond)
+	if pending.PendingRetryAt.Before(wantNotBefore) {
+		t.Errorf("PendingRetryAt = %v, want at least one poll interval after %v", pending.PendingRetryAt, mgcBaseTime)
+	}
+}
+
+// Three consecutive ticks, with the entry re-seeded before each by a
+// simulated worker exit, transition exactly once in total because the
+// stored fingerprint equals the observed merge commit and is dispatched.
+
+func TestReconcileMergeCompletion_RepeatTicksTransitionOnce(t *testing.T) {
+	t.Parallel()
+
+	issueID := "MGC-3"
+	state := mgcStateWithPending(issueID, 12)
+	store := newMGCStore()
+	tracker := &mgcTrackerFake{states: map[string]string{issueID: "In Review"}}
+	scm := &mgcSCMFake{fn: func(int, string, string) (domain.PRMergeStatus, error) { return mergedStatus("sha-3"), nil }}
+	params := mgcParams(store, scm, tracker)
+
+	reconcileMergeCompletion(state, params, discardLogger(), context.Background(), &domain.NoopMetrics{})
+	if len(tracker.transitionCalls) != 1 {
+		t.Fatalf("after tick 1: TransitionIssue calls = %d, want 1", len(tracker.transitionCalls))
+	}
+
+	// A worker re-runs on the same issue (e.g. after a human comment) and
+	// exits normally, re-seeding the pending entry each time.
+	for i := 2; i <= 3; i++ {
+		rkey := ReactionKey(issueID, ReactionKindMergeCompletion)
+		state.PendingReactions[rkey] = newMGCPending(issueID, 12)
+		reconcileMergeCompletion(state, params, discardLogger(), context.Background(), &domain.NoopMetrics{})
+		if len(tracker.transitionCalls) != 1 {
+			t.Fatalf("after tick %d: TransitionIssue calls = %d, want 1 (dedup by fingerprint latch)", i, len(tracker.transitionCalls))
+		}
+	}
+}
+
+// A restart recovery pass over an already-dispatched fingerprint row,
+// followed by a reconcile tick observing the same merge commit,
+// transitions zero times.
+
+func TestReconcileMergeCompletion_RecoveryOverDispatchedFingerprintNoTransition(t *testing.T) {
+	t.Parallel()
+
+	issueID := "MGC-4"
+	identifier := "PROJ-MGC4"
+	wsRoot := t.TempDir()
+	writeRecoverySCM(t, wsRoot, identifier, domain.SCMMetadata{
+		Branch:   "feature/mgc4",
+		SHA:      "headsha",
+		PushedAt: freshSCMTime(1),
+		PRNumber: 13,
+		Owner:    "owner",
+		Repo:     "repo",
+	})
+
+	store := newMGCStore()
+	store.fingerprints[issueID+":"+ReactionKindMergeCompletion] = mgcFingerprintRecord{fingerprint: "sha-4", dispatched: true}
+
+	tracker := &mgcTrackerFake{states: map[string]string{issueID: "In Review"}}
+	state := NewState(5000, 4, nil, AgentTotals{})
+	run := freshRun(issueID, identifier, "owner/repo#13", 1)
+
+	recoverParams := PendingReactionRecoveryParams{
+		WorkspaceRoot:                     wsRoot,
+		TrackerAdapter:                    tracker,
+		HandoffState:                      "In Review",
+		TerminalStates:                    []string{"Done"},
+		SCMAdapter:                        &mgcSCMFake{},
+		MergeCompletionReactionConfigured: true,
+		RecoveryLookback:                  PendingReactionRecoveryLookback,
+		MaxCandidates:                     PendingReactionRecoveryMaxCandidates,
+		NowFunc:                           func() time.Time { return recoveryNow },
+		Logger:                            discardLogger(),
+	}
+	result, err := RecoverPendingReactions(context.Background(), state, []persistence.RunHistory{run}, recoverParams)
+	if err != nil {
+		t.Fatalf("RecoverPendingReactions: %v", err)
+	}
+	if result.MergeCompletionRecovered != 1 {
+		t.Fatalf("MergeCompletionRecovered = %d, want 1", result.MergeCompletionRecovered)
+	}
+
+	scm := &mgcSCMFake{fn: func(int, string, string) (domain.PRMergeStatus, error) { return mergedStatus("sha-4"), nil }}
+	params := mgcParams(store, scm, tracker)
+
+	reconcileMergeCompletion(state, params, discardLogger(), context.Background(), &domain.NoopMetrics{})
+
+	if len(tracker.transitionCalls) != 0 {
+		t.Errorf("TransitionIssue calls = %d, want 0 (fingerprint already dispatched for this merge commit)", len(tracker.transitionCalls))
+	}
+}
+
+// A new merge commit identifier resets the dispatched flag through the
+// existing upsert and produces exactly one further transition.
+
+func TestReconcileMergeCompletion_NewMergeCommitResetsLatch(t *testing.T) {
+	t.Parallel()
+
+	issueID := "MGC-5"
+	state := mgcStateWithPending(issueID, 14)
+	store := newMGCStore()
+	store.fingerprints[issueID+":"+ReactionKindMergeCompletion] = mgcFingerprintRecord{fingerprint: "sha-old", dispatched: true}
+
+	tracker := &mgcTrackerFake{states: map[string]string{issueID: "In Review"}}
+	scm := &mgcSCMFake{fn: func(int, string, string) (domain.PRMergeStatus, error) { return mergedStatus("sha-new"), nil }}
+	params := mgcParams(store, scm, tracker)
+
+	reconcileMergeCompletion(state, params, discardLogger(), context.Background(), &domain.NoopMetrics{})
+
+	if len(tracker.transitionCalls) != 1 {
+		t.Fatalf("TransitionIssue calls = %d, want 1 (a different merge commit re-arms the latch)", len(tracker.transitionCalls))
+	}
+	rec, ok := store.has(issueID)
+	if !ok || rec.fingerprint != "sha-new" || !rec.dispatched {
+		t.Errorf("fingerprint record = %+v, ok=%v, want fingerprint=sha-new dispatched=true", rec, ok)
+	}
+}
+
+// A merged PR reporting no merge commit identifier performs no
+// transition, re-enqueues at the poll interval, and emits a WARN.
+
+func TestReconcileMergeCompletion_MergedNoCommitSHAWarns(t *testing.T) {
+	t.Parallel()
+
+	issueID := "MGC-6"
+	state := mgcStateWithPending(issueID, 15)
+	store := newMGCStore()
+	tracker := &mgcTrackerFake{states: map[string]string{issueID: "In Review"}}
+	scm := &mgcSCMFake{fn: func(int, string, string) (domain.PRMergeStatus, error) {
+		return domain.PRMergeStatus{Merged: true, MergeCommitSHA: ""}, nil
+	}}
+	params := mgcParams(store, scm, tracker)
+
+	log, buf := logCapture()
+	reconcileMergeCompletion(state, params, log, context.Background(), &domain.NoopMetrics{})
+
+	if len(tracker.transitionCalls) != 0 {
+		t.Errorf("TransitionIssue calls = %d, want 0", len(tracker.transitionCalls))
+	}
+	rkey := ReactionKey(issueID, ReactionKindMergeCompletion)
+	if _, ok := state.PendingReactions[rkey]; !ok {
+		t.Error("PendingReactions entry missing, want present (re-enqueued)")
+	}
+	if !strings.Contains(buf.String(), "merge_completion merged pull request reported no merge commit") {
+		t.Errorf("log output = %q, want a WARN naming the empty merge commit condition", buf.String())
+	}
+}
+
+// A tracker state-read failure performs no forge call and backs off
+// every due entry with an increased PendingAttempts.
+
+func TestReconcileMergeCompletion_StateReadFailureBacksOffWithoutForgeCall(t *testing.T) {
+	t.Parallel()
+
+	issueID := "MGC-7"
+	state := mgcStateWithPending(issueID, 16)
+	store := newMGCStore()
+	tracker := &mgcTrackerFake{statesErr: mgcTransportError()}
+	scm := &mgcSCMFake{}
+	params := mgcParams(store, scm, tracker)
+
+	reconcileMergeCompletion(state, params, discardLogger(), context.Background(), &domain.NoopMetrics{})
+
+	if got := scm.calls.Load(); got != 0 {
+		t.Errorf("GetMergeability calls = %d, want 0 (state read failed before any forge call)", got)
+	}
+	if len(tracker.transitionCalls) != 0 {
+		t.Errorf("TransitionIssue calls = %d, want 0", len(tracker.transitionCalls))
+	}
+	rkey := ReactionKey(issueID, ReactionKindMergeCompletion)
+	pending, ok := state.PendingReactions[rkey]
+	if !ok {
+		t.Fatal("PendingReactions entry missing after a state-read failure, want re-enqueued")
+	}
+	if pending.PendingAttempts != 1 {
+		t.Errorf("PendingAttempts = %d, want 1", pending.PendingAttempts)
+	}
+}
+
+// A transport-error transition retries with backoff while the call
+// count stays within max_retries, then escalates exactly once after
+// the count exceeds it.
+
+func TestReconcileMergeCompletion_TransportErrorRetriesThenEscalates(t *testing.T) {
+	t.Parallel()
+
+	issueID := "MGC-8"
+	state := mgcStateWithPending(issueID, 17)
+	store := newMGCStore()
+	tracker := &mgcTrackerFake{
+		states:        map[string]string{issueID: "In Review"},
+		transitionErr: mgcTransportError(),
+	}
+	scm := &mgcSCMFake{fn: func(int, string, string) (domain.PRMergeStatus, error) { return mergedStatus("sha-8"), nil }}
+	params := mgcParams(store, scm, tracker)
+	params.MergeCompletionConfig.MaxRetries = 2
+
+	now := mgcBaseTime
+	params.NowFunc = func() time.Time { return now }
+
+	reconcileMergeCompletion(state, params, discardLogger(), context.Background(), &domain.NoopMetrics{})
+	if len(tracker.transitionCalls) != 1 {
+		t.Fatalf("after tick 1: TransitionIssue calls = %d, want 1", len(tracker.transitionCalls))
+	}
+	if len(tracker.addLabelCalls) != 0 {
+		t.Fatalf("after tick 1: AddLabel calls = %d, want 0 (no escalation before max_retries is exceeded)", len(tracker.addLabelCalls))
+	}
+
+	now = now.Add(10 * time.Minute)
+	reconcileMergeCompletion(state, params, discardLogger(), context.Background(), &domain.NoopMetrics{})
+	if len(tracker.transitionCalls) != 2 {
+		t.Fatalf("after tick 2: TransitionIssue calls = %d, want 2", len(tracker.transitionCalls))
+	}
+	if len(tracker.addLabelCalls) != 0 {
+		t.Fatalf("after tick 2: AddLabel calls = %d, want 0", len(tracker.addLabelCalls))
+	}
+
+	now = now.Add(10 * time.Minute)
+	reconcileMergeCompletion(state, params, discardLogger(), context.Background(), &domain.NoopMetrics{})
+	state.TrackerOpsWg.Wait()
+	if len(tracker.transitionCalls) != 3 {
+		t.Fatalf("after tick 3: TransitionIssue calls = %d, want 3", len(tracker.transitionCalls))
+	}
+	if len(tracker.addLabelCalls) != 1 {
+		t.Errorf("after tick 3: AddLabel calls = %d, want 1 (escalation once attempts exceed max_retries)", len(tracker.addLabelCalls))
+	}
+}
+
+// Auth and payload transition failures escalate immediately, consuming
+// no retry budget and leaving no re-enqueued entry.
+
+func TestReconcileMergeCompletion_AuthAndPayloadEscalateImmediately(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		kind domain.TrackerErrorKind
+	}{
+		{"auth error", domain.ErrTrackerAuth},
+		{"payload error", domain.ErrTrackerPayload},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			issueID := "MGC-9-" + string(tt.kind)
+			state := mgcStateWithPending(issueID, 18)
+			store := newMGCStore()
+			tracker := &mgcTrackerFake{
+				states:        map[string]string{issueID: "In Review"},
+				transitionErr: &domain.TrackerError{Kind: tt.kind, Message: "denied"},
+			}
+			scm := &mgcSCMFake{fn: func(int, string, string) (domain.PRMergeStatus, error) { return mergedStatus("sha-9"), nil }}
+			params := mgcParams(store, scm, tracker)
+
+			reconcileMergeCompletion(state, params, discardLogger(), context.Background(), &domain.NoopMetrics{})
+			state.TrackerOpsWg.Wait()
+
+			if len(tracker.transitionCalls) != 1 {
+				t.Errorf("TransitionIssue calls = %d, want 1", len(tracker.transitionCalls))
+			}
+			if len(tracker.addLabelCalls) != 1 {
+				t.Errorf("AddLabel calls = %d, want 1 (immediate escalation)", len(tracker.addLabelCalls))
+			}
+			rkey := ReactionKey(issueID, ReactionKindMergeCompletion)
+			if _, ok := state.PendingReactions[rkey]; ok {
+				t.Error("PendingReactions entry present after escalation, want dropped (no re-enqueue)")
+			}
+			if _, ok := state.ReactionAttempts[rkey]; ok {
+				t.Error("ReactionAttempts counter present after escalation, want cleared")
+			}
+		})
+	}
+}
+
+// A not-found transition stops without escalating, marks the
+// fingerprint dispatched, and drops the entry.
+
+func TestReconcileMergeCompletion_NotFoundStopsWithoutEscalating(t *testing.T) {
+	t.Parallel()
+
+	issueID := "MGC-11"
+	state := mgcStateWithPending(issueID, 19)
+	store := newMGCStore()
+	tracker := &mgcTrackerFake{
+		states:        map[string]string{issueID: "In Review"},
+		transitionErr: &domain.TrackerError{Kind: domain.ErrTrackerNotFound, Message: "gone"},
+	}
+	scm := &mgcSCMFake{fn: func(int, string, string) (domain.PRMergeStatus, error) { return mergedStatus("sha-11"), nil }}
+	params := mgcParams(store, scm, tracker)
+
+	reconcileMergeCompletion(state, params, discardLogger(), context.Background(), &domain.NoopMetrics{})
+
+	if len(tracker.transitionCalls) != 1 {
+		t.Errorf("TransitionIssue calls = %d, want 1", len(tracker.transitionCalls))
+	}
+	if len(tracker.addLabelCalls) != 0 || len(tracker.commentCalls) != 0 {
+		t.Errorf("escalation calls (label=%d, comment=%d), want 0", len(tracker.addLabelCalls), len(tracker.commentCalls))
+	}
+	rec, ok := store.has(issueID)
+	if !ok || !rec.dispatched {
+		t.Errorf("fingerprint record = %+v, ok=%v, want dispatched=true", rec, ok)
+	}
+	rkey := ReactionKey(issueID, ReactionKindMergeCompletion)
+	if _, ok := state.PendingReactions[rkey]; ok {
+		t.Error("PendingReactions entry present after not-found stop, want dropped")
+	}
+}
+
+// Escalation dispatches AddLabel for "label" and CommentIssue for
+// "comment", never touches ClearReactionsForIssue-scoped state, and a
+// sibling CI pending entry for the same issue survives.
+
+func TestReconcileMergeCompletion_EscalationDispatchesConfiguredAction(t *testing.T) {
+	t.Parallel()
+
+	t.Run("label escalation calls AddLabel with the configured label", func(t *testing.T) {
+		t.Parallel()
+
+		issueID := "MGC-12-LABEL"
+		state := mgcStateWithPending(issueID, 20)
+		ciKey := ReactionKey(issueID, ReactionKindCI)
+		state.PendingReactions[ciKey] = &PendingReaction{
+			IssueID: issueID, Identifier: issueID + "-ident", Kind: ReactionKindCI,
+			CreatedAt: mgcBaseTime, KindData: &CIReactionData{Branch: "feature/x"},
+		}
+
+		store := newMGCStore()
+		tracker := &mgcTrackerFake{
+			states:        map[string]string{issueID: "In Review"},
+			transitionErr: &domain.TrackerError{Kind: domain.ErrTrackerAuth, Message: "denied"},
+		}
+		scm := &mgcSCMFake{fn: func(int, string, string) (domain.PRMergeStatus, error) { return mergedStatus("sha-12"), nil }}
+		params := mgcParams(store, scm, tracker)
+		params.MergeCompletionConfig.Escalation = "label"
+		params.MergeCompletionConfig.EscalationLabel = "needs-human"
+
+		reconcileMergeCompletion(state, params, discardLogger(), context.Background(), &domain.NoopMetrics{})
+		state.TrackerOpsWg.Wait()
+
+		if len(tracker.addLabelCalls) != 1 || tracker.addLabelCalls[0].label != "needs-human" {
+			t.Fatalf("AddLabel calls = %+v, want one call with label %q", tracker.addLabelCalls, "needs-human")
+		}
+		if len(tracker.commentCalls) != 0 {
+			t.Errorf("CommentIssue calls = %d, want 0", len(tracker.commentCalls))
+		}
+		if _, ok := state.PendingReactions[ciKey]; !ok {
+			t.Error("sibling CI PendingReaction removed by merge-completion escalation; want untouched")
+		}
+		if _, claimed := state.Claimed[issueID]; claimed {
+			t.Error("state.Claimed gained an entry from merge-completion escalation; want untouched")
+		}
+		if store.deleteByIssueCalls != 0 {
+			t.Errorf("DeleteReactionFingerprintsByIssue calls = %d, want 0 (escalation never clears issue-wide)", store.deleteByIssueCalls)
+		}
+	})
+
+	t.Run("comment escalation calls CommentIssue naming the PR and target state", func(t *testing.T) {
+		t.Parallel()
+
+		issueID := "MGC-12-COMMENT"
+		state := mgcStateWithPending(issueID, 21)
+		store := newMGCStore()
+		tracker := &mgcTrackerFake{
+			states:        map[string]string{issueID: "In Review"},
+			transitionErr: &domain.TrackerError{Kind: domain.ErrTrackerPayload, Message: "no transition"},
+		}
+		scm := &mgcSCMFake{fn: func(int, string, string) (domain.PRMergeStatus, error) { return mergedStatus("sha-13"), nil }}
+		params := mgcParams(store, scm, tracker)
+		params.MergeCompletionConfig.Escalation = "comment"
+
+		reconcileMergeCompletion(state, params, discardLogger(), context.Background(), &domain.NoopMetrics{})
+		state.TrackerOpsWg.Wait()
+
+		if len(tracker.commentCalls) != 1 {
+			t.Fatalf("CommentIssue calls = %d, want 1", len(tracker.commentCalls))
+		}
+		text := tracker.commentCalls[0].text
+		if !strings.Contains(text, "#21") {
+			t.Errorf("escalation comment = %q, want it to name PR #21", text)
+		}
+		if !strings.Contains(text, "done") {
+			t.Errorf("escalation comment = %q, want it to name the target state %q", text, "done")
+		}
+		if len(tracker.addLabelCalls) != 0 {
+			t.Errorf("AddLabel calls = %d, want 0", len(tracker.addLabelCalls))
+		}
+	})
+}
+
+// Drop conditions: a non-handoff non-terminal state drops the entry
+// with no forge call; a terminal state drops it with a distinct log
+// message; a claimed issue re-enqueues without a forge call.
+
+func TestReconcileMergeCompletion_DropConditions(t *testing.T) {
+	t.Parallel()
+
+	t.Run("non-handoff non-terminal state drops with no forge call", func(t *testing.T) {
+		t.Parallel()
+
+		issueID := "MGC-13-STALE"
+		state := mgcStateWithPending(issueID, 22)
+		store := newMGCStore()
+		tracker := &mgcTrackerFake{states: map[string]string{issueID: "Backlog"}}
+		scm := &mgcSCMFake{}
+		params := mgcParams(store, scm, tracker)
+
+		reconcileMergeCompletion(state, params, discardLogger(), context.Background(), &domain.NoopMetrics{})
+
+		if got := scm.calls.Load(); got != 0 {
+			t.Errorf("GetMergeability calls = %d, want 0", got)
+		}
+		rkey := ReactionKey(issueID, ReactionKindMergeCompletion)
+		if _, ok := state.PendingReactions[rkey]; ok {
+			t.Error("PendingReactions entry present, want dropped (state differs from handoff)")
+		}
+	})
+
+	t.Run("terminal state drops with the terminal-specific log message", func(t *testing.T) {
+		t.Parallel()
+
+		issueID := "MGC-13-TERMINAL"
+		state := mgcStateWithPending(issueID, 23)
+		store := newMGCStore()
+		tracker := &mgcTrackerFake{states: map[string]string{issueID: "Done"}}
+		scm := &mgcSCMFake{}
+		params := mgcParams(store, scm, tracker)
+
+		log, buf := logCapture()
+		reconcileMergeCompletion(state, params, log, context.Background(), &domain.NoopMetrics{})
+
+		if got := scm.calls.Load(); got != 0 {
+			t.Errorf("GetMergeability calls = %d, want 0", got)
+		}
+		rkey := ReactionKey(issueID, ReactionKindMergeCompletion)
+		if _, ok := state.PendingReactions[rkey]; ok {
+			t.Error("PendingReactions entry present, want dropped (issue already terminal)")
+		}
+		if !strings.Contains(buf.String(), "merge_completion issue already terminal, dropping") {
+			t.Errorf("log output = %q, want the terminal-specific message", buf.String())
+		}
+		if strings.Contains(buf.String(), "left the handoff state") {
+			t.Errorf("log output = %q, want the terminal message, not the left-the-handoff-state message", buf.String())
+		}
+	})
+
+	t.Run("a claimed issue re-enqueues without a forge call", func(t *testing.T) {
+		t.Parallel()
+
+		issueID := "MGC-13-CLAIMED"
+		state := mgcStateWithPending(issueID, 24)
+		state.Claimed[issueID] = struct{}{}
+		store := newMGCStore()
+		tracker := &mgcTrackerFake{states: map[string]string{issueID: "In Review"}}
+		scm := &mgcSCMFake{}
+		params := mgcParams(store, scm, tracker)
+
+		reconcileMergeCompletion(state, params, discardLogger(), context.Background(), &domain.NoopMetrics{})
+
+		if got := scm.calls.Load(); got != 0 {
+			t.Errorf("GetMergeability calls = %d, want 0", got)
+		}
+		rkey := ReactionKey(issueID, ReactionKindMergeCompletion)
+		if _, ok := state.PendingReactions[rkey]; !ok {
+			t.Error("PendingReactions entry missing, want re-enqueued while claimed")
+		}
+	})
+}
+
+// A MarkReactionDispatched failure drops the entry without a
+// re-enqueue; a re-seeded second tick performs a second transition,
+// the stated residue of this posture.
+
+func TestReconcileMergeCompletion_MarkDispatchedFailureIsAcceptedResidue(t *testing.T) {
+	t.Parallel()
+
+	issueID := "MGC-22"
+	state := mgcStateWithPending(issueID, 25)
+	store := newMGCStore()
+	store.markErr = mgcTransportError()
+	tracker := &mgcTrackerFake{states: map[string]string{issueID: "In Review"}}
+	scm := &mgcSCMFake{fn: func(int, string, string) (domain.PRMergeStatus, error) { return mergedStatus("sha-22"), nil }}
+	params := mgcParams(store, scm, tracker)
+
+	log, buf := logCapture()
+	reconcileMergeCompletion(state, params, log, context.Background(), &domain.NoopMetrics{})
+
+	if len(tracker.transitionCalls) != 1 {
+		t.Fatalf("after tick 1: TransitionIssue calls = %d, want 1", len(tracker.transitionCalls))
+	}
+	rkey := ReactionKey(issueID, ReactionKindMergeCompletion)
+	if _, ok := state.PendingReactions[rkey]; ok {
+		t.Error("PendingReactions entry present after a mark-dispatched failure, want dropped (not re-enqueued)")
+	}
+	if _, ok := state.ReactionAttempts[rkey]; ok {
+		t.Error("ReactionAttempts counter present after a mark-dispatched failure, want cleared")
+	}
+	if !strings.Contains(buf.String(), "merge_completion dispatched mark failed") || !strings.Contains(buf.String(), "sha-22") {
+		t.Errorf("log output = %q, want a WARN naming the merge commit sha-22", buf.String())
+	}
+
+	// A re-seeded second tick (a simulated worker exit) performs a second
+	// transition: the accepted residue of this posture, since the row was
+	// never durably marked dispatched.
+	state.PendingReactions[rkey] = newMGCPending(issueID, 25)
+	reconcileMergeCompletion(state, params, discardLogger(), context.Background(), &domain.NoopMetrics{})
+
+	if len(tracker.transitionCalls) != 2 {
+		t.Errorf("after tick 2: TransitionIssue calls = %d, want 2 (the accepted residue)", len(tracker.transitionCalls))
+	}
+}
+
+// An issue-wide clear (the mechanism the CI and review escalations
+// call) removes both the merge-completion and a sibling CI entry and
+// deletes the merge-completion fingerprint row; the next tick performs
+// no forge call; a following recovery pass re-creates the entry.
+
+func TestReconcileMergeCompletion_ClearReactionsForIssueCrossKindInteraction(t *testing.T) {
+	t.Parallel()
+
+	issueID := "MGC-23"
+	identifier := "PROJ-MGC23"
+	state := mgcStateWithPending(issueID, 26)
+
+	ciKey := ReactionKey(issueID, ReactionKindCI)
+	state.PendingReactions[ciKey] = &PendingReaction{
+		IssueID: issueID, Identifier: identifier, Kind: ReactionKindCI,
+		CreatedAt: mgcBaseTime, KindData: &CIReactionData{Branch: "feature/mgc23"},
+	}
+
+	store := newMGCStore()
+	mcKey := ReactionKey(issueID, ReactionKindMergeCompletion)
+	store.fingerprints[mcKey] = mgcFingerprintRecord{fingerprint: "sha-23", dispatched: false}
+
+	ClearReactionsForIssue(context.Background(), state, store, issueID, discardLogger())
+
+	if _, ok := state.PendingReactions[mcKey]; ok {
+		t.Error("merge-completion PendingReactions entry survived ClearReactionsForIssue, want removed")
+	}
+	if _, ok := state.PendingReactions[ciKey]; ok {
+		t.Error("CI PendingReactions entry survived ClearReactionsForIssue, want removed")
+	}
+	if _, ok := store.has(issueID); ok {
+		t.Error("merge-completion fingerprint row survived ClearReactionsForIssue, want deleted")
+	}
+
+	tracker := &mgcTrackerFake{states: map[string]string{issueID: "In Review"}}
+	scm := &mgcSCMFake{}
+	params := mgcParams(store, scm, tracker)
+
+	reconcileMergeCompletion(state, params, discardLogger(), context.Background(), &domain.NoopMetrics{})
+
+	if got := scm.calls.Load(); got != 0 {
+		t.Errorf("GetMergeability calls = %d, want 0 (no pending entry survives the clear)", got)
+	}
+	if len(tracker.transitionCalls) != 0 {
+		t.Errorf("TransitionIssue calls = %d, want 0", len(tracker.transitionCalls))
+	}
+
+	// A recovery pass over run history, with the tracker reporting the
+	// handoff state and the workspace metadata intact, re-creates the
+	// merge-completion entry.
+	wsRoot := t.TempDir()
+	writeRecoverySCM(t, wsRoot, identifier, domain.SCMMetadata{
+		Branch:   "feature/mgc23",
+		SHA:      "headsha",
+		PushedAt: freshSCMTime(1),
+		PRNumber: 26,
+		Owner:    "owner",
+		Repo:     "repo",
+	})
+	run := freshRun(issueID, identifier, "owner/repo#26", 1)
+	recoverParams := PendingReactionRecoveryParams{
+		WorkspaceRoot:                     wsRoot,
+		TrackerAdapter:                    tracker,
+		HandoffState:                      "In Review",
+		TerminalStates:                    []string{"Done"},
+		SCMAdapter:                        scm,
+		MergeCompletionReactionConfigured: true,
+		RecoveryLookback:                  PendingReactionRecoveryLookback,
+		MaxCandidates:                     PendingReactionRecoveryMaxCandidates,
+		NowFunc:                           func() time.Time { return recoveryNow },
+		Logger:                            discardLogger(),
+	}
+	result, err := RecoverPendingReactions(context.Background(), state, []persistence.RunHistory{run}, recoverParams)
+	if err != nil {
+		t.Fatalf("RecoverPendingReactions: %v", err)
+	}
+	if result.MergeCompletionRecovered != 1 {
+		t.Errorf("MergeCompletionRecovered = %d, want 1", result.MergeCompletionRecovered)
+	}
+	if _, ok := state.PendingReactions[mcKey]; !ok {
+		t.Error("merge-completion PendingReactions entry not re-created by recovery")
+	}
+}
+
+// SweepWorkspaces collects a workspace as terminal only when the
+// tracker-reported state is a member of the written TerminalStates
+// list, not a defaulted one.
+
+func TestReconcileMergeCompletion_SweepCollectsOnlyTheWrittenTerminalList(t *testing.T) {
+	t.Parallel()
+
+	t.Run("target_state present in terminal_states is collected as terminal", func(t *testing.T) {
+		t.Parallel()
+
+		tmpDir := t.TempDir()
+		mustMkdirSweep(t, filepath.Join(tmpDir, "PROJ-MGC-SWEEP-1"))
+		tracker := &sweepTracker{statesByKey: map[string]string{"PROJ-MGC-SWEEP-1": "done"}}
+		state := NewState(5000, 4, nil, AgentTotals{})
+
+		SweepWorkspaces(state, SweepWorkspacesParams{
+			WorkspaceRoot:  tmpDir,
+			TrackerAdapter: tracker,
+			TerminalStates: []string{"done"},
+			Ctx:            context.Background(),
+			Logger:         discardLogger(),
+			Metrics:        &domain.NoopMetrics{},
+		})
+
+		assertSweepDirRemoved(t, filepath.Join(tmpDir, "PROJ-MGC-SWEEP-1"))
+	})
+
+	t.Run("the same state with terminal_states emptied is treated as non-terminal", func(t *testing.T) {
+		t.Parallel()
+
+		tmpDir := t.TempDir()
+		mustMkdirSweep(t, filepath.Join(tmpDir, "PROJ-MGC-SWEEP-2"))
+		tracker := &sweepTracker{statesByKey: map[string]string{"PROJ-MGC-SWEEP-2": "done"}}
+		state := NewState(5000, 4, nil, AgentTotals{})
+
+		SweepWorkspaces(state, SweepWorkspacesParams{
+			WorkspaceRoot:  tmpDir,
+			TrackerAdapter: tracker,
+			TerminalStates: nil,
+			Ctx:            context.Background(),
+			Logger:         discardLogger(),
+			Metrics:        &domain.NoopMetrics{},
+		})
+
+		assertSweepDirExists(t, filepath.Join(tmpDir, "PROJ-MGC-SWEEP-2"))
+	})
+}
+
+// A reloaded terminal-states list that drops the configured target
+// state produces exactly one WARN per onset, suppressed while the
+// condition persists and cleared once the target is present again, with
+// no change to any entry's disposition.
+
+func TestReconcileMergeCompletion_TerminalDriftWarningFiresOncePerOnset(t *testing.T) {
+	t.Parallel()
+
+	issueID := "MGC-25"
+	store := newMGCStore()
+	tracker := &mgcTrackerFake{states: map[string]string{issueID: "In Review"}}
+	scm := &mgcSCMFake{fn: func(int, string, string) (domain.PRMergeStatus, error) {
+		return domain.PRMergeStatus{Merged: false}, nil
+	}}
+
+	state := mgcStateWithPending(issueID, 27)
+	now := mgcBaseTime
+
+	const driftMessage = "merge_completion target state is not in the configured terminal states"
+
+	tick := func(terminalStates []string) string {
+		rkey := ReactionKey(issueID, ReactionKindMergeCompletion)
+		if _, ok := state.PendingReactions[rkey]; !ok {
+			state.PendingReactions[rkey] = newMGCPending(issueID, 27)
+		} else {
+			state.PendingReactions[rkey].PendingRetryAt = time.Time{}
+		}
+
+		params := mgcParams(store, scm, tracker)
+		params.TerminalStates = terminalStates
+		params.NowFunc = func() time.Time { return now }
+
+		log, buf := logCapture()
+		reconcileMergeCompletion(state, params, log, context.Background(), &domain.NoopMetrics{})
+		now = now.Add(10 * time.Minute)
+		return buf.String()
+	}
+
+	if out := tick(nil); !strings.Contains(out, driftMessage) {
+		t.Fatalf("tick 1 (drift onset) log = %q, want one WARN naming the drift", out)
+	}
+	rkey := ReactionKey(issueID, ReactionKindMergeCompletion)
+	if _, ok := state.PendingReactions[rkey]; !ok {
+		t.Fatal("PendingReactions entry missing after tick 1, want unchanged disposition (re-enqueued)")
+	}
+
+	if out := tick(nil); strings.Contains(out, driftMessage) {
+		t.Errorf("tick 2 (same drift) log = %q, want no further WARN (suppressed)", out)
+	}
+
+	if out := tick([]string{"done"}); strings.Contains(out, driftMessage) {
+		t.Errorf("tick 3 (drift cleared) log = %q, want no WARN", out)
+	}
+
+	if out := tick(nil); !strings.Contains(out, driftMessage) {
+		t.Errorf("tick 4 (second onset) log = %q, want a second WARN", out)
+	}
+}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -162,6 +162,16 @@ type OrchestratorParams struct {
 	// HandleWorkerExitParams, and the recovery params.
 	LabelFixReactionConfigured bool
 
+	// MergeCompletionConfig holds validated merge-completion reaction
+	// configuration. Zero value when MergeCompletionReactionConfigured
+	// is false.
+	MergeCompletionConfig MergeCompletionReactionConfig
+
+	// MergeCompletionReactionConfigured marks whether the
+	// merge-completion feature is active for this process. Threaded
+	// into ReconcileParams and HandleWorkerExitParams.
+	MergeCompletionReactionConfigured bool
+
 	// AgentAdapterByKind resolves the agent adapter for the given
 	// kind. Constructed once at startup from the eagerly-built
 	// per-kind adapter cache. When nil, the orchestrator falls back
@@ -195,29 +205,31 @@ type Orchestrator struct {
 	snapshotCh   chan snapshotRequest
 	refreshCh    chan struct{}
 
-	preflightParams                 PreflightParams
-	observers                       []Observer
-	drainTimeout                    time.Duration
-	toolRegistry                    *domain.ToolRegistry
-	sessionToolRegistryFunc         SessionToolRegistryFunc
-	preflightOK                     atomic.Bool
-	draining                        atomic.Bool
-	hostPool                        *HostPool
-	workflowFileFunc                func() string
-	dbPath                          string
-	ciProvider                      domain.CIStatusProvider
-	scmAdapter                      domain.SCMAdapter
-	reviewConfig                    ReviewReactionConfig
-	autoMergeConfig                 AutoMergeReactionConfig
-	autoMergeReactionConfigured     bool
-	botReviewConfig                 BotReviewReactionConfig
-	botReviewReactionConfigured     bool
-	mergeConflictConfig             MergeConflictReactionConfig
-	mergeConflictReactionConfigured bool
-	labelReviewConfig               LabelReviewReactionConfig
-	labelReviewReactionConfigured   bool
-	labelFixConfig                  LabelFixReactionConfig
-	labelFixReactionConfigured      bool
+	preflightParams                   PreflightParams
+	observers                         []Observer
+	drainTimeout                      time.Duration
+	toolRegistry                      *domain.ToolRegistry
+	sessionToolRegistryFunc           SessionToolRegistryFunc
+	preflightOK                       atomic.Bool
+	draining                          atomic.Bool
+	hostPool                          *HostPool
+	workflowFileFunc                  func() string
+	dbPath                            string
+	ciProvider                        domain.CIStatusProvider
+	scmAdapter                        domain.SCMAdapter
+	reviewConfig                      ReviewReactionConfig
+	autoMergeConfig                   AutoMergeReactionConfig
+	autoMergeReactionConfigured       bool
+	botReviewConfig                   BotReviewReactionConfig
+	botReviewReactionConfigured       bool
+	mergeConflictConfig               MergeConflictReactionConfig
+	mergeConflictReactionConfigured   bool
+	labelReviewConfig                 LabelReviewReactionConfig
+	labelReviewReactionConfigured     bool
+	labelFixConfig                    LabelFixReactionConfig
+	labelFixReactionConfigured        bool
+	mergeCompletionConfig             MergeCompletionReactionConfig
+	mergeCompletionReactionConfigured bool
 
 	// sshStrictHostKeyChecking is the current effective OpenSSH
 	// StrictHostKeyChecking value. Written by handleTick on every
@@ -295,41 +307,43 @@ func NewOrchestrator(params OrchestratorParams) *Orchestrator {
 	}
 
 	o := &Orchestrator{
-		state:                           params.State,
-		logger:                          logger,
-		trackerAdapter:                  params.TrackerAdapter,
-		agentAdapter:                    params.AgentAdapter,
-		agentAdapterByKind:              agentAdapterByKind,
-		workflowManager:                 params.WorkflowManager,
-		store:                           params.Store,
-		metrics:                         metrics,
-		workerExitCh:                    make(chan WorkerResult, exitBuf),
-		retryTimerCh:                    make(chan string, retryBuf),
-		agentEventCh:                    make(chan agentEventMsg, eventBuf),
-		selfReviewCh:                    make(chan selfReviewProgressMsg, eventBuf),
-		snapshotCh:                      make(chan snapshotRequest, 4),
-		refreshCh:                       make(chan struct{}, 1),
-		preflightParams:                 params.PreflightParams,
-		observers:                       observers,
-		drainTimeout:                    defaultDrainTimeout,
-		toolRegistry:                    params.ToolRegistry,
-		sessionToolRegistryFunc:         params.SessionToolRegistryFunc,
-		hostPool:                        hostPool,
-		workflowFileFunc:                params.WorkflowFileFunc,
-		dbPath:                          params.DBPath,
-		ciProvider:                      params.CIProvider,
-		scmAdapter:                      params.SCMAdapter,
-		reviewConfig:                    params.ReviewConfig,
-		autoMergeConfig:                 params.AutoMergeConfig,
-		autoMergeReactionConfigured:     params.AutoMergeReactionConfigured,
-		botReviewConfig:                 params.BotReviewConfig,
-		botReviewReactionConfigured:     params.BotReviewConfigured,
-		mergeConflictConfig:             params.MergeConflictConfig,
-		mergeConflictReactionConfigured: params.MergeConflictReactionConfigured,
-		labelReviewConfig:               params.LabelReviewConfig,
-		labelReviewReactionConfigured:   params.LabelReviewReactionConfigured,
-		labelFixConfig:                  params.LabelFixConfig,
-		labelFixReactionConfigured:      params.LabelFixReactionConfigured,
+		state:                             params.State,
+		logger:                            logger,
+		trackerAdapter:                    params.TrackerAdapter,
+		agentAdapter:                      params.AgentAdapter,
+		agentAdapterByKind:                agentAdapterByKind,
+		workflowManager:                   params.WorkflowManager,
+		store:                             params.Store,
+		metrics:                           metrics,
+		workerExitCh:                      make(chan WorkerResult, exitBuf),
+		retryTimerCh:                      make(chan string, retryBuf),
+		agentEventCh:                      make(chan agentEventMsg, eventBuf),
+		selfReviewCh:                      make(chan selfReviewProgressMsg, eventBuf),
+		snapshotCh:                        make(chan snapshotRequest, 4),
+		refreshCh:                         make(chan struct{}, 1),
+		preflightParams:                   params.PreflightParams,
+		observers:                         observers,
+		drainTimeout:                      defaultDrainTimeout,
+		toolRegistry:                      params.ToolRegistry,
+		sessionToolRegistryFunc:           params.SessionToolRegistryFunc,
+		hostPool:                          hostPool,
+		workflowFileFunc:                  params.WorkflowFileFunc,
+		dbPath:                            params.DBPath,
+		ciProvider:                        params.CIProvider,
+		scmAdapter:                        params.SCMAdapter,
+		reviewConfig:                      params.ReviewConfig,
+		autoMergeConfig:                   params.AutoMergeConfig,
+		autoMergeReactionConfigured:       params.AutoMergeReactionConfigured,
+		botReviewConfig:                   params.BotReviewConfig,
+		botReviewReactionConfigured:       params.BotReviewConfigured,
+		mergeConflictConfig:               params.MergeConflictConfig,
+		mergeConflictReactionConfigured:   params.MergeConflictReactionConfigured,
+		labelReviewConfig:                 params.LabelReviewConfig,
+		labelReviewReactionConfigured:     params.LabelReviewReactionConfigured,
+		labelFixConfig:                    params.LabelFixConfig,
+		labelFixReactionConfigured:        params.LabelFixReactionConfigured,
+		mergeCompletionConfig:             params.MergeCompletionConfig,
+		mergeCompletionReactionConfigured: params.MergeCompletionReactionConfigured,
 	}
 	// Startup preflight must have passed for the orchestrator to be
 	// constructed, so the initial value is true.
@@ -368,26 +382,27 @@ func (o *Orchestrator) Run(ctx context.Context) {
 		case workerExit := <-o.workerExitCh:
 			cfg := o.workflowManager.Config()
 			HandleWorkerExit(o.state, workerExit, HandleWorkerExitParams{
-				Store:                           o.store,
-				MaxRetryBackoffMS:               cfg.Agent.MaxRetryBackoffMS,
-				OnRetryFire:                     o.onRetryFire,
-				Ctx:                             ctx,
-				Logger:                          o.logger,
-				BeforeRemoveHook:                cfg.Hooks.BeforeRemove,
-				HookTimeoutMS:                   cfg.Hooks.TimeoutMS,
-				TrackerAdapter:                  o.trackerAdapter,
-				HandoffState:                    cfg.Tracker.HandoffState,
-				ActiveStates:                    cfg.Tracker.ActiveStates,
-				Metrics:                         o.metrics,
-				HostPool:                        o.hostPool,
-				CommentsConfig:                  cfg.Tracker.Comments,
-				CIProvider:                      o.ciProvider,
-				SCMAdapter:                      o.scmAdapter,
-				AutoMergeReactionConfigured:     o.autoMergeReactionConfigured,
-				BotReviewReactionConfigured:     o.botReviewReactionConfigured,
-				MergeConflictReactionConfigured: o.mergeConflictReactionConfigured,
-				LabelReviewReactionConfigured:   o.labelReviewReactionConfigured,
-				LabelFixReactionConfigured:      o.labelFixReactionConfigured,
+				Store:                             o.store,
+				MaxRetryBackoffMS:                 cfg.Agent.MaxRetryBackoffMS,
+				OnRetryFire:                       o.onRetryFire,
+				Ctx:                               ctx,
+				Logger:                            o.logger,
+				BeforeRemoveHook:                  cfg.Hooks.BeforeRemove,
+				HookTimeoutMS:                     cfg.Hooks.TimeoutMS,
+				TrackerAdapter:                    o.trackerAdapter,
+				HandoffState:                      cfg.Tracker.HandoffState,
+				ActiveStates:                      cfg.Tracker.ActiveStates,
+				Metrics:                           o.metrics,
+				HostPool:                          o.hostPool,
+				CommentsConfig:                    cfg.Tracker.Comments,
+				CIProvider:                        o.ciProvider,
+				SCMAdapter:                        o.scmAdapter,
+				AutoMergeReactionConfigured:       o.autoMergeReactionConfigured,
+				BotReviewReactionConfigured:       o.botReviewReactionConfigured,
+				MergeConflictReactionConfigured:   o.mergeConflictReactionConfigured,
+				LabelReviewReactionConfigured:     o.labelReviewReactionConfigured,
+				LabelFixReactionConfigured:        o.labelFixReactionConfigured,
+				MergeCompletionReactionConfigured: o.mergeCompletionReactionConfigured,
 			})
 			o.updateGauges(time.Now())
 			o.notifyObservers()
@@ -507,36 +522,38 @@ func (o *Orchestrator) handleTick(ctx context.Context) {
 	// Reconcile running issues unconditionally so in-flight workers
 	// are monitored even when dispatch is skipped.
 	ReconcileRunningIssues(o.state, ReconcileParams{
-		TrackerAdapter:                  o.trackerAdapter,
-		ActiveStates:                    cfg.Tracker.ActiveStates,
-		TerminalStates:                  cfg.Tracker.TerminalStates,
-		HandoffState:                    cfg.Tracker.HandoffState,
-		StallTimeoutMS:                  cfg.Agent.StallTimeoutMS,
-		MaxRetryBackoffMS:               cfg.Agent.MaxRetryBackoffMS,
-		Store:                           o.store,
-		OnRetryFire:                     o.onRetryFire,
-		Ctx:                             ctx,
-		Logger:                          o.logger,
-		Metrics:                         o.metrics,
-		CIProvider:                      o.ciProvider,
-		CIFeedback:                      cfg.CIFeedback,
-		CIPendingTTL:                    ciPendingDefaultTTL,
-		SCMAdapter:                      o.scmAdapter,
-		ReviewConfig:                    o.reviewConfig,
-		ReviewPendingTTL:                reviewPendingDefaultTTL,
-		AutoMergeConfig:                 o.autoMergeConfig,
-		AutoMergePendingTTL:             autoMergePendingDefaultTTL,
-		AutoMergeReactionConfigured:     o.autoMergeReactionConfigured,
-		BotReviewConfig:                 o.botReviewConfig,
-		BotReviewPendingTTL:             reviewPendingDefaultTTL,
-		BotReviewConfigured:             o.botReviewReactionConfigured,
-		MergeConflictConfig:             o.mergeConflictConfig,
-		MergeConflictPendingTTL:         mergeConflictPendingDefaultTTL,
-		MergeConflictReactionConfigured: o.mergeConflictReactionConfigured,
-		LabelReviewConfig:               o.labelReviewConfig,
-		LabelReviewReactionConfigured:   o.labelReviewReactionConfigured,
-		LabelFixConfig:                  o.labelFixConfig,
-		LabelFixReactionConfigured:      o.labelFixReactionConfigured,
+		TrackerAdapter:                    o.trackerAdapter,
+		ActiveStates:                      cfg.Tracker.ActiveStates,
+		TerminalStates:                    cfg.Tracker.TerminalStates,
+		HandoffState:                      cfg.Tracker.HandoffState,
+		StallTimeoutMS:                    cfg.Agent.StallTimeoutMS,
+		MaxRetryBackoffMS:                 cfg.Agent.MaxRetryBackoffMS,
+		Store:                             o.store,
+		OnRetryFire:                       o.onRetryFire,
+		Ctx:                               ctx,
+		Logger:                            o.logger,
+		Metrics:                           o.metrics,
+		CIProvider:                        o.ciProvider,
+		CIFeedback:                        cfg.CIFeedback,
+		CIPendingTTL:                      ciPendingDefaultTTL,
+		SCMAdapter:                        o.scmAdapter,
+		ReviewConfig:                      o.reviewConfig,
+		ReviewPendingTTL:                  reviewPendingDefaultTTL,
+		AutoMergeConfig:                   o.autoMergeConfig,
+		AutoMergePendingTTL:               autoMergePendingDefaultTTL,
+		AutoMergeReactionConfigured:       o.autoMergeReactionConfigured,
+		BotReviewConfig:                   o.botReviewConfig,
+		BotReviewPendingTTL:               reviewPendingDefaultTTL,
+		BotReviewConfigured:               o.botReviewReactionConfigured,
+		MergeConflictConfig:               o.mergeConflictConfig,
+		MergeConflictPendingTTL:           mergeConflictPendingDefaultTTL,
+		MergeConflictReactionConfigured:   o.mergeConflictReactionConfigured,
+		LabelReviewConfig:                 o.labelReviewConfig,
+		LabelReviewReactionConfigured:     o.labelReviewReactionConfigured,
+		LabelFixConfig:                    o.labelFixConfig,
+		LabelFixReactionConfigured:        o.labelFixReactionConfigured,
+		MergeCompletionConfig:             o.mergeCompletionConfig,
+		MergeCompletionReactionConfigured: o.mergeCompletionReactionConfigured,
 	})
 
 	// Sweep workspaces periodically to catch issues that transitioned
@@ -939,26 +956,27 @@ func (o *Orchestrator) drainRunningWorkers() {
 		case workerExit := <-o.workerExitCh:
 			cfg := o.workflowManager.Config()
 			HandleWorkerExit(o.state, workerExit, HandleWorkerExitParams{
-				Store:                           o.store,
-				MaxRetryBackoffMS:               cfg.Agent.MaxRetryBackoffMS,
-				OnRetryFire:                     func(string) {}, // no-op: prevent retry fire events from reaching the event loop during drain
-				Ctx:                             drainCtx,
-				Logger:                          o.logger,
-				BeforeRemoveHook:                cfg.Hooks.BeforeRemove,
-				HookTimeoutMS:                   cfg.Hooks.TimeoutMS,
-				TrackerAdapter:                  o.trackerAdapter,
-				HandoffState:                    cfg.Tracker.HandoffState,
-				ActiveStates:                    cfg.Tracker.ActiveStates,
-				Metrics:                         o.metrics,
-				HostPool:                        o.hostPool,
-				CommentsConfig:                  cfg.Tracker.Comments,
-				CIProvider:                      o.ciProvider,
-				SCMAdapter:                      o.scmAdapter,
-				AutoMergeReactionConfigured:     o.autoMergeReactionConfigured,
-				BotReviewReactionConfigured:     o.botReviewReactionConfigured,
-				MergeConflictReactionConfigured: o.mergeConflictReactionConfigured,
-				LabelReviewReactionConfigured:   o.labelReviewReactionConfigured,
-				LabelFixReactionConfigured:      o.labelFixReactionConfigured,
+				Store:                             o.store,
+				MaxRetryBackoffMS:                 cfg.Agent.MaxRetryBackoffMS,
+				OnRetryFire:                       func(string) {}, // no-op: prevent retry fire events from reaching the event loop during drain
+				Ctx:                               drainCtx,
+				Logger:                            o.logger,
+				BeforeRemoveHook:                  cfg.Hooks.BeforeRemove,
+				HookTimeoutMS:                     cfg.Hooks.TimeoutMS,
+				TrackerAdapter:                    o.trackerAdapter,
+				HandoffState:                      cfg.Tracker.HandoffState,
+				ActiveStates:                      cfg.Tracker.ActiveStates,
+				Metrics:                           o.metrics,
+				HostPool:                          o.hostPool,
+				CommentsConfig:                    cfg.Tracker.Comments,
+				CIProvider:                        o.ciProvider,
+				SCMAdapter:                        o.scmAdapter,
+				AutoMergeReactionConfigured:       o.autoMergeReactionConfigured,
+				BotReviewReactionConfigured:       o.botReviewReactionConfigured,
+				MergeConflictReactionConfigured:   o.mergeConflictReactionConfigured,
+				LabelReviewReactionConfigured:     o.labelReviewReactionConfigured,
+				LabelFixReactionConfigured:        o.labelFixReactionConfigured,
+				MergeCompletionReactionConfigured: o.mergeCompletionReactionConfigured,
 			})
 			o.updateGauges(time.Now())
 			o.notifyObservers()

--- a/internal/orchestrator/reaction_validate.go
+++ b/internal/orchestrator/reaction_validate.go
@@ -10,11 +10,13 @@ import (
 // each active reaction whose configuration would fail. It constructs no
 // adapter and makes no network call.
 //
-// Only the bot_review and auto_merge reactions are inspected, the two
-// carrying the review-bot allowlist and the merge strategy. Each is
-// validated with the same builder the orchestrator runs at construction,
-// so the offline verdict cannot diverge from the construction verdict.
-func ValidateReactionConfigs(cfg config.ServiceConfig) []registry.ValidationDiag {
+// Only the bot_review, auto_merge, and merge_completion reactions are
+// inspected: the review-bot allowlist, the merge strategy, and the
+// tracker-terminal-state target. Each is validated with the same builder
+// the orchestrator runs at construction, so the offline verdict cannot
+// diverge from the construction verdict. trackerMeta MUST come from the
+// tracker registry's Meta(cfg.Tracker.Kind) lookup.
+func ValidateReactionConfigs(cfg config.ServiceConfig, trackerMeta registry.TrackerMeta) []registry.ValidationDiag {
 	var diags []registry.ValidationDiag
 
 	if rc, ok := cfg.Reactions["bot_review"]; ok && rc.Provider != "" {
@@ -32,6 +34,16 @@ func ValidateReactionConfigs(cfg config.ServiceConfig) []registry.ValidationDiag
 			diags = append(diags, registry.ValidationDiag{
 				Severity: "error",
 				Check:    "reactions.auto_merge",
+				Message:  err.Error(),
+			})
+		}
+	}
+
+	if rc, ok := cfg.Reactions["merge_completion"]; ok && rc.Provider != "" {
+		if _, err := BuildMergeCompletionReactionConfig(rc, cfg.Tracker, trackerMeta); err != nil {
+			diags = append(diags, registry.ValidationDiag{
+				Severity: "error",
+				Check:    "reactions.merge_completion",
 				Message:  err.Error(),
 			})
 		}

--- a/internal/orchestrator/reaction_validate_test.go
+++ b/internal/orchestrator/reaction_validate_test.go
@@ -149,13 +149,48 @@ func TestValidateReactionConfigs(t *testing.T) {
 			},
 			wantChecks: nil,
 		},
+		{
+			name: "merge_completion invalid target_state produces a diagnostic",
+			cfg: config.ServiceConfig{
+				Tracker: config.TrackerConfig{
+					HandoffState:   "in-review",
+					TerminalStates: []string{"done"},
+				},
+				Reactions: map[string]config.ReactionConfig{
+					"merge_completion": {Provider: "gitea", Extra: map[string]any{"target_state": "in-review"}},
+				},
+			},
+			wantChecks: []string{"reactions.merge_completion"},
+		},
+		{
+			name: "merge_completion valid block produces no diagnostic",
+			cfg: config.ServiceConfig{
+				Tracker: config.TrackerConfig{
+					HandoffState:   "in-review",
+					TerminalStates: []string{"done"},
+				},
+				Reactions: map[string]config.ReactionConfig{
+					"merge_completion": {Provider: "gitea", Extra: map[string]any{"target_state": "done"}},
+				},
+			},
+			wantChecks: nil,
+		},
+		{
+			name: "no merge_completion block produces no diagnostic of that check",
+			cfg: config.ServiceConfig{
+				Reactions: map[string]config.ReactionConfig{
+					"bot_review": {Provider: "gitea", Extra: map[string]any{"bot_usernames": []any{"alice"}}},
+				},
+			},
+			wantChecks: nil,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			got := ValidateReactionConfigs(tt.cfg)
+			got := ValidateReactionConfigs(tt.cfg, registry.TrackerMeta{})
 
 			if len(got) != len(tt.wantChecks) {
 				t.Fatalf("ValidateReactionConfigs(cfg) = %v, want %d diag(s) with checks %v", got, len(tt.wantChecks), tt.wantChecks)
@@ -184,7 +219,7 @@ func TestValidateReactionConfigs(t *testing.T) {
 			},
 		}
 
-		got := ValidateReactionConfigs(cfg)
+		got := ValidateReactionConfigs(cfg, registry.TrackerMeta{})
 
 		if len(got) != 2 {
 			t.Fatalf("ValidateReactionConfigs(cfg) = %v, want 2 diags", got)

--- a/internal/orchestrator/reconcile.go
+++ b/internal/orchestrator/reconcile.go
@@ -170,6 +170,17 @@ type ReconcileParams struct {
 	// active for the current process. Reconcile, enqueue, and recovery
 	// paths gate on this flag.
 	LabelFixReactionConfigured bool
+
+	// MergeCompletionConfig holds merge-completion reaction
+	// configuration. Only read when MergeCompletionReactionConfigured
+	// is true. Unlike every expiring sibling kind there is no
+	// accompanying MergeCompletionPendingTTL: this kind has no expiry.
+	MergeCompletionConfig MergeCompletionReactionConfig
+
+	// MergeCompletionReactionConfigured marks whether the
+	// merge-completion feature is active for the current process.
+	// Reconcile, enqueue, and recovery paths gate on this flag.
+	MergeCompletionReactionConfigured bool
 }
 
 // ReconcileRunningIssues detects stalled workers and refreshes tracker
@@ -243,6 +254,12 @@ func ReconcileRunningIssues(state *State, params ReconcileParams) {
 	// fix sessions. Ordering does not affect correctness: the pass is fully
 	// cross-kind isolated, mutating only label-fix state.
 	reconcileLabelFixCommands(state, params, log, ctx, metrics)
+
+	// Observe the merge state of managed pull requests and transition
+	// the linked issue to the configured terminal state exactly once.
+	// Placed last so a merge the orchestrator performed earlier in the
+	// same tick can be observed on this pass.
+	reconcileMergeCompletion(state, params, log, ctx, metrics)
 }
 
 // reconcileStalled cancels running entries whose last activity exceeds the

--- a/internal/orchestrator/recovery.go
+++ b/internal/orchestrator/recovery.go
@@ -84,38 +84,40 @@ type ReactionRecoveryRunStore interface {
 
 // PendingReactionRecoveryParams holds all inputs for [RecoverPendingReactions].
 type PendingReactionRecoveryParams struct {
-	WorkspaceRoot                   string
-	TrackerAdapter                  domain.TrackerAdapter
-	HandoffState                    string
-	TerminalStates                  []string
-	CIProvider                      domain.CIStatusProvider
-	SCMAdapter                      domain.SCMAdapter
-	AutoMergeReactionConfigured     bool
-	BotReviewReactionConfigured     bool
-	MergeConflictReactionConfigured bool
-	LabelReviewReactionConfigured   bool
-	LabelFixReactionConfigured      bool
-	RecoveryLookback                time.Duration
-	MaxCandidates                   int
-	NowFunc                         func() time.Time
-	Logger                          *slog.Logger
+	WorkspaceRoot                     string
+	TrackerAdapter                    domain.TrackerAdapter
+	HandoffState                      string
+	TerminalStates                    []string
+	CIProvider                        domain.CIStatusProvider
+	SCMAdapter                        domain.SCMAdapter
+	AutoMergeReactionConfigured       bool
+	BotReviewReactionConfigured       bool
+	MergeConflictReactionConfigured   bool
+	LabelReviewReactionConfigured     bool
+	LabelFixReactionConfigured        bool
+	MergeCompletionReactionConfigured bool
+	RecoveryLookback                  time.Duration
+	MaxCandidates                     int
+	NowFunc                           func() time.Time
+	Logger                            *slog.Logger
 }
 
 // PendingReactionRecoveryResult reports outcome counts from a single
 // [RecoverPendingReactions] call.
 type PendingReactionRecoveryResult struct {
-	Candidates             int
-	CapSkipped             int
-	StateChecked           int
-	ReviewRecovered        int
-	CIRecovered            int
-	AutoMergeRecovered     int
-	BotReviewRecovered     int
-	MergeConflictRecovered int
-	LabelReviewRecovered   int
-	LabelFixRecovered      int
-	StaleSkipped           int
-	Skipped                int
+	Candidates               int
+	CapSkipped               int
+	StateChecked             int
+	ReviewRecovered          int
+	CIRecovered              int
+	AutoMergeRecovered       int
+	BotReviewRecovered       int
+	MergeConflictRecovered   int
+	LabelReviewRecovered     int
+	LabelFixRecovered        int
+	MergeCompletionRecovered int
+	StaleSkipped             int
+	Skipped                  int
 }
 
 // RecoverPendingReactions reconstructs runtime pending reaction entries from
@@ -469,6 +471,33 @@ func recoverPendingReactionKinds(
 				TemplateID: run.TemplateID,
 			}
 			outcome.LabelFixRecovered++
+			added++
+		}
+	}
+
+	// The merge-completion reaction has no checkout and requires no
+	// branch, so unlike the checkout-bearing kinds its guard omits the
+	// meta.Branch != "" clause, matching label-review.
+	if params.SCMAdapter != nil && params.MergeCompletionReactionConfigured && meta.PRNumber > 0 && meta.Owner != "" && meta.Repo != "" {
+		key := ReactionKey(run.IssueID, ReactionKindMergeCompletion)
+		if _, exists := state.PendingReactions[key]; !exists {
+			state.PendingReactions[key] = &PendingReaction{
+				IssueID:    run.IssueID,
+				Identifier: run.Identifier,
+				DisplayID:  run.DisplayID,
+				Attempt:    run.Attempt,
+				Kind:       ReactionKindMergeCompletion,
+				CreatedAt:  now,
+				KindData: &MergeCompletionReactionData{
+					PRNumber: meta.PRNumber,
+					Owner:    meta.Owner,
+					Repo:     meta.Repo,
+				},
+				AgentKind:  run.AgentAdapter,
+				RuleName:   run.RuleName,
+				TemplateID: run.TemplateID,
+			}
+			outcome.MergeCompletionRecovered++
 			added++
 		}
 	}

--- a/internal/orchestrator/recovery_test.go
+++ b/internal/orchestrator/recovery_test.go
@@ -2035,3 +2035,144 @@ func TestRecoverPendingReactions_LabelFixMissingPRMetadata(t *testing.T) {
 		})
 	}
 }
+
+// TestRecoverPendingReactions_MergeCompletion verifies that a handoff-state
+// issue whose recovered SCM metadata carries a PR number, owner, and repo
+// (no branch requirement) recovers one merge-completion entry, carrying the
+// frozen dispatch fields, and increments MergeCompletionRecovered.
+func TestRecoverPendingReactions_MergeCompletion(t *testing.T) {
+	t.Parallel()
+
+	wsRoot := t.TempDir()
+	writeRecoverySCM(t, wsRoot, "PROJ-MGC1", domain.SCMMetadata{
+		Branch:   "feature/mgc-fix",
+		SHA:      "cafef00d",
+		PushedAt: freshSCMTime(1),
+		PRNumber: 66,
+		Owner:    "mgcowner",
+		Repo:     "mgcrepo",
+	})
+
+	tracker := &recoveryTrackerStub{states: map[string]string{"ISS-MGC1": "In Review"}}
+	state := NewState(5000, 4, nil, AgentTotals{})
+	run := freshRun("ISS-MGC1", "PROJ-MGC1", "mgcowner/mgcrepo#66", 3)
+	params := defaultRecoveryParams(wsRoot, tracker)
+	params.MergeCompletionReactionConfigured = true
+
+	result, err := RecoverPendingReactions(context.Background(), state, []persistence.RunHistory{run}, params)
+	if err != nil {
+		t.Fatalf("RecoverPendingReactions: %v", err)
+	}
+	if result.MergeCompletionRecovered != 1 {
+		t.Errorf("MergeCompletionRecovered = %d, want 1", result.MergeCompletionRecovered)
+	}
+
+	rkey := ReactionKey("ISS-MGC1", ReactionKindMergeCompletion)
+	pr, ok := state.PendingReactions[rkey]
+	if !ok {
+		t.Fatalf("PendingReactions[%q] missing, want present", rkey)
+	}
+	if pr.Kind != ReactionKindMergeCompletion {
+		t.Errorf("PendingReaction.Kind = %q, want %q", pr.Kind, ReactionKindMergeCompletion)
+	}
+	if pr.Attempt != 3 {
+		t.Errorf("PendingReaction.Attempt = %d, want 3", pr.Attempt)
+	}
+	if pr.AgentKind != run.AgentAdapter {
+		t.Errorf("PendingReaction.AgentKind = %q, want %q (frozen from the recovered run)", pr.AgentKind, run.AgentAdapter)
+	}
+	mcd, ok := pr.KindData.(*MergeCompletionReactionData)
+	if !ok {
+		t.Fatalf("KindData type = %T, want *MergeCompletionReactionData", pr.KindData)
+	}
+	if mcd.PRNumber != 66 {
+		t.Errorf("MergeCompletionReactionData.PRNumber = %d, want 66", mcd.PRNumber)
+	}
+	if mcd.Owner != "mgcowner" {
+		t.Errorf("MergeCompletionReactionData.Owner = %q, want %q", mcd.Owner, "mgcowner")
+	}
+	if mcd.Repo != "mgcrepo" {
+		t.Errorf("MergeCompletionReactionData.Repo = %q, want %q", mcd.Repo, "mgcrepo")
+	}
+	if _, claimed := state.Claimed["ISS-MGC1"]; claimed {
+		t.Error("ISS-MGC1 found in state.Claimed after recovery, want not claimed")
+	}
+}
+
+// TestRecoverPendingReactions_MergeCompletionNotRecoveredWhenFlagFalse
+// verifies that MergeCompletionReactionConfigured=false reconstructs no
+// merge-completion entry, even with full PR metadata present.
+func TestRecoverPendingReactions_MergeCompletionNotRecoveredWhenFlagFalse(t *testing.T) {
+	t.Parallel()
+
+	wsRoot := t.TempDir()
+	writeRecoverySCM(t, wsRoot, "PROJ-MGC2", domain.SCMMetadata{
+		Branch:   "feature/mgc-disabled",
+		SHA:      "abc",
+		PushedAt: freshSCMTime(1),
+		PRNumber: 10,
+		Owner:    "o",
+		Repo:     "r",
+	})
+
+	tracker := &recoveryTrackerStub{states: map[string]string{"ISS-MGC2": "In Review"}}
+	state := NewState(5000, 4, nil, AgentTotals{})
+	run := freshRun("ISS-MGC2", "PROJ-MGC2", "", 1)
+	params := defaultRecoveryParams(wsRoot, tracker)
+	params.MergeCompletionReactionConfigured = false
+
+	result, err := RecoverPendingReactions(context.Background(), state, []persistence.RunHistory{run}, params)
+	if err != nil {
+		t.Fatalf("RecoverPendingReactions: %v", err)
+	}
+	if result.MergeCompletionRecovered != 0 {
+		t.Errorf("MergeCompletionRecovered = %d, want 0 when flag is false", result.MergeCompletionRecovered)
+	}
+
+	rkey := ReactionKey("ISS-MGC2", ReactionKindMergeCompletion)
+	if _, ok := state.PendingReactions[rkey]; ok {
+		t.Error("merge-completion PendingReactions entry created with MergeCompletionReactionConfigured=false; want absent")
+	}
+}
+
+// TestRecoverPendingReactions_MergeCompletionSkipsWhenHandoffStateUnset
+// verifies that recovery reconstructs no merge-completion entry, and no
+// other reaction kind's entry, when tracker.handoff_state is unset: the
+// prerequisite the config builder requires disables the whole recovery
+// pass, per the recoveryEnabled gate cmd/sortie/main.go computes from it.
+func TestRecoverPendingReactions_MergeCompletionSkipsWhenHandoffStateUnset(t *testing.T) {
+	t.Parallel()
+
+	wsRoot := t.TempDir()
+	writeRecoverySCM(t, wsRoot, "PROJ-MGC3", domain.SCMMetadata{
+		Branch:   "feature/mgc-nohandoff",
+		SHA:      "abc",
+		PushedAt: freshSCMTime(1),
+		PRNumber: 20,
+		Owner:    "o",
+		Repo:     "r",
+	})
+
+	tracker := &recoveryTrackerStub{states: map[string]string{"ISS-MGC3": "In Review"}}
+	state := NewState(5000, 4, nil, AgentTotals{})
+	run := freshRun("ISS-MGC3", "PROJ-MGC3", "", 1)
+	params := defaultRecoveryParams(wsRoot, tracker)
+	params.HandoffState = ""
+	params.MergeCompletionReactionConfigured = true
+
+	result, err := RecoverPendingReactions(context.Background(), state, []persistence.RunHistory{run}, params)
+	if err != nil {
+		t.Fatalf("RecoverPendingReactions: %v", err)
+	}
+	if result.MergeCompletionRecovered != 0 {
+		t.Errorf("MergeCompletionRecovered = %d, want 0 when tracker.handoff_state is unset", result.MergeCompletionRecovered)
+	}
+	if result != (PendingReactionRecoveryResult{}) {
+		t.Errorf("RecoverPendingReactions(...) result = %+v, want the zero value (unset handoff_state disables recovery entirely)", result)
+	}
+
+	rkey := ReactionKey("ISS-MGC3", ReactionKindMergeCompletion)
+	if _, ok := state.PendingReactions[rkey]; ok {
+		t.Error("merge-completion PendingReactions entry created despite unset tracker.handoff_state")
+	}
+}

--- a/internal/orchestrator/recovery_test.go
+++ b/internal/orchestrator/recovery_test.go
@@ -1706,13 +1706,11 @@ func TestRecoverPendingReactions_MergeConflictNotRecoveredWhenFlagFalse(t *testi
 //
 // The fixture includes a branch even though the label-review recovery
 // clause itself imposes no branch requirement (recovery.go's per-kind
-// clause omits the meta.Branch != "" guard the sibling kinds carry):
-// workspace.ReadSCMMetadata unconditionally returns a zero value whenever
-// the decoded branch is empty, and RecoverPendingReactions skips the whole
-// run when that zero value comes back, before any per-kind clause runs. A
+// clause omits the meta.Branch != "" guard the sibling kinds carry): a
 // workspace's scm.json is written only by a normal (non-read-only)
 // session, and such a session always operates on a branch, so this
-// reflects the only reachable production case.
+// reflects the common production case rather than a requirement of the
+// recovery clause or the reader.
 func TestRecoverPendingReactions_LabelReview(t *testing.T) {
 	t.Parallel()
 

--- a/internal/orchestrator/review_reconcile.go
+++ b/internal/orchestrator/review_reconcile.go
@@ -214,7 +214,9 @@ func computeReactionPendingDelay(attempts int) time.Duration {
 
 // escalateReviewFailure handles the case where review fix continuation
 // turns are exhausted. It applies the configured escalation action,
-// cancels the retry, and releases the claim.
+// cancels the retry, releases the claim, and clears the review reaction's
+// own pending entry, counter, and fingerprint. Sibling reaction kinds for
+// the same issue are left untouched.
 func escalateReviewFailure(
 	state *State,
 	params ReconcileParams,
@@ -306,7 +308,17 @@ func escalateReviewFailure(
 	}
 
 	delete(state.Claimed, pending.IssueID)
-	ClearReactionsForIssue(ctx, state, params.Store, pending.IssueID, log)
+
+	// Scoped per-kind delete (not the issue-wide ClearReactionsForIssue)
+	// so sibling reactions' pending entries, counters, and fingerprints
+	// for the same issue survive a review-only escalation.
+	delete(state.PendingReactions, ReactionKey(pending.IssueID, ReactionKindReview))
+	delete(state.ReactionAttempts, ReactionKey(pending.IssueID, ReactionKindReview))
+	if err := params.Store.DeleteReactionFingerprint(ctx, pending.IssueID, ReactionKindReview); err != nil {
+		log.Warn("failed to delete reaction fingerprint during review escalation",
+			slog.Any("error", err),
+		)
+	}
 }
 
 // buildReviewEscalationComment builds a plain-text escalation comment

--- a/internal/orchestrator/review_reconcile_test.go
+++ b/internal/orchestrator/review_reconcile_test.go
@@ -604,6 +604,53 @@ func TestReconcileReviewComments_TurnCapExceeded_Escalates(t *testing.T) {
 	}
 }
 
+// TestReconcileReviewComments_TurnCapExceeded_CrossKindIsolation verifies
+// that review escalation clears only the review reaction's own pending
+// entry, counter, and fingerprint. A sibling merge-completion entry parked
+// on the same issue (seeded from the same worker exit as the review
+// reaction) must survive: the escalation must not call the issue-wide
+// DeleteReactionFingerprintsByIssue.
+func TestReconcileReviewComments_TurnCapExceeded_CrossKindIsolation(t *testing.T) {
+	t.Parallel()
+
+	issueID := "ISS-R-ISO"
+	state := stateWithReviewReaction(t, issueID, 10)
+	rkey := ReactionKey(issueID, ReactionKindReview)
+	state.ReactionAttempts[rkey] = 3
+
+	mcKey := ReactionKey(issueID, ReactionKindMergeCompletion)
+	state.PendingReactions[mcKey] = &PendingReaction{
+		IssueID:    issueID,
+		Identifier: issueID + "-ident",
+		Kind:       ReactionKindMergeCompletion,
+		CreatedAt:  reviewBaseTime,
+		KindData:   &MergeCompletionReactionData{PRNumber: 42, Owner: "owner", Repo: "repo"},
+	}
+	state.ReactionAttempts[ReactionKey(issueID, ReactionKindMergeCompletion)] = 1
+
+	store := &reviewReconcileStore{}
+	metrics := newReviewMetricsSpy()
+	tracker := &reviewTrackerStub{}
+	scm := &mockSCMAdapter{}
+	params := reviewParams(store, scm, tracker)
+
+	reconcileReviewComments(state, params, discardLogger(), context.Background(), metrics)
+	state.TrackerOpsWg.Wait()
+
+	if _, ok := state.PendingReactions[mcKey]; !ok {
+		t.Error("sibling merge-completion PendingReactions entry removed by review escalation; want untouched")
+	}
+	if state.ReactionAttempts[ReactionKey(issueID, ReactionKindMergeCompletion)] != 1 {
+		t.Error("sibling merge-completion ReactionAttempts counter altered by review escalation; want untouched")
+	}
+	if store.deleteFPByIssueCalls != 0 {
+		t.Errorf("DeleteReactionFingerprintsByIssue calls = %d, want 0 (escalation must be scoped to review)", store.deleteFPByIssueCalls)
+	}
+	if store.deleteFingerprintCalls != 1 {
+		t.Errorf("DeleteReactionFingerprint calls = %d, want 1 (the review kind's own fingerprint)", store.deleteFingerprintCalls)
+	}
+}
+
 // --- buildReviewFingerprint tests ---
 
 func TestBuildReviewFingerprint_EmptyInput(t *testing.T) {

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/sortie-ai/sortie/internal/config"
 	"github.com/sortie-ai/sortie/internal/domain"
+	"github.com/sortie-ai/sortie/internal/registry"
 )
 
 // Label value constants for metric instrumentation. Unexported; used as
@@ -351,6 +352,13 @@ const ReactionKindLabelReview = "label-review"
 // asymmetry the sibling kinds document.
 const ReactionKindLabelFix = "label-fix"
 
+// ReactionKindMergeCompletion is the reaction kind constant for the
+// merge-completion reaction. The user-facing YAML key is
+// reactions.merge_completion; the short form lives here as the runtime
+// and persisted discriminator, matching the YAML-versus-runtime
+// asymmetry the sibling kinds document.
+const ReactionKindMergeCompletion = "merge-completion"
+
 // AutoMergePreflightRetryDelay is the delay between the initial
 // auto-merge preflight failure (transport-class) and its single
 // scheduled retry. The retry runs at most once per orchestrator
@@ -364,13 +372,14 @@ const AutoMergePreflightRetryDelay time.Duration = 5 * time.Minute
 // read this map, so a kind cannot be recognized without carrying an
 // explicit pin classification.
 var reactionKindPins = map[string]bool{
-	ReactionKindCI:            true,
-	ReactionKindReview:        true,
-	ReactionKindBotReview:     true,
-	ReactionKindAutoMerge:     true,
-	ReactionKindMergeConflict: true,
-	ReactionKindLabelReview:   false,
-	ReactionKindLabelFix:      false,
+	ReactionKindCI:              true,
+	ReactionKindReview:          true,
+	ReactionKindBotReview:       true,
+	ReactionKindAutoMerge:       true,
+	ReactionKindMergeConflict:   true,
+	ReactionKindLabelReview:     false,
+	ReactionKindLabelFix:        false,
+	ReactionKindMergeCompletion: false,
 }
 
 func isKnownReactionKind(kind string) bool {
@@ -676,6 +685,37 @@ type LabelFixReactionConfig struct {
 	PollIntervalMS int
 }
 
+// MergeCompletionReactionData holds merge-completion-specific fields for
+// a pending merge-completion reaction. Stored in [PendingReaction.KindData]
+// for reactions with Kind == [ReactionKindMergeCompletion]. PRNumber,
+// Owner, and Repo are sourced from [domain.SCMMetadata] (written by the
+// agent to scm.json), never from the tracker project configuration.
+//
+// Unlike the checkout-bearing sibling kinds, no branch or commit SHA is
+// carried: the pass performs no checkout and fingerprints on the merge
+// commit identifier observed live, not on a value snapshotted at
+// enqueue time.
+type MergeCompletionReactionData struct {
+	// PRNumber is the pull request number.
+	PRNumber int
+
+	// Owner is the repository owner.
+	Owner string
+
+	// Repo is the repository name.
+	Repo string
+}
+
+// MergeCompletionReactionConfig holds validated merge-completion-specific
+// configuration extracted from [config.ReactionConfig] at startup.
+type MergeCompletionReactionConfig struct {
+	TargetState     string
+	PollIntervalMS  int
+	Escalation      string
+	EscalationLabel string
+	MaxRetries      int
+}
+
 // State is the single authoritative runtime state owned by the orchestrator.
 // The running map and claimed set are in-memory for performance. The
 // agent_totals and completed set are backed by SQLite and survive restarts.
@@ -781,6 +821,14 @@ type State struct {
 	// MergePR has already produced a structured ERROR log, so the log
 	// fires at most once per issue per orchestrator lifetime.
 	AutoMergeAuthLogged map[string]struct{}
+
+	// MergeCompletionTerminalDriftLogged suppresses the reload-drift
+	// warning emitted when the configured merge-completion target state
+	// is no longer a member of the runtime terminal-state list. Set on
+	// the onset of the condition and cleared once the target is present
+	// again, so a later onset produces a further warning. Runtime-only;
+	// mutated only by the reconcile pass on the event-loop goroutine.
+	MergeCompletionTerminalDriftLogged bool
 
 	// SweepTickCounter tracks poll ticks since the last workspace sweep.
 	// Incremented by handleTick; reset to zero when the sweep fires.
@@ -1336,6 +1384,81 @@ func BuildLabelFixReactionConfig(cfg config.LabelCommandsConfig) LabelFixReactio
 		FixLabel:       cfg.FixLabel,
 		PollIntervalMS: cfg.PollIntervalMS,
 	}
+}
+
+// BuildMergeCompletionReactionConfig extracts and validates
+// merge-completion-specific configuration from a [config.ReactionConfig].
+// Returns an error naming the offending field for invalid values.
+//
+// meta resolves the default active-state list only; the terminal list is
+// read from tracker as written, with no fallback to
+// [registry.TrackerMeta.DefaultTerminalStates], so the offline validator
+// and the runtime terminal drop agree on what "terminal" means. The
+// function performs no I/O and no network call.
+func BuildMergeCompletionReactionConfig(rc config.ReactionConfig, tracker config.TrackerConfig, meta registry.TrackerMeta) (MergeCompletionReactionConfig, error) {
+	cfg := MergeCompletionReactionConfig{
+		PollIntervalMS:  60000,
+		Escalation:      rc.Escalation,
+		EscalationLabel: rc.EscalationLabel,
+		MaxRetries:      rc.MaxRetries,
+	}
+
+	if cfg.Escalation == "" {
+		cfg.Escalation = "label"
+	}
+	if cfg.Escalation != "label" && cfg.Escalation != "comment" {
+		return MergeCompletionReactionConfig{}, fmt.Errorf("invalid escalation %q: must be \"label\" or \"comment\"", cfg.Escalation)
+	}
+
+	if cfg.EscalationLabel == "" {
+		cfg.EscalationLabel = "needs-human"
+	}
+
+	if tracker.HandoffState == "" {
+		return MergeCompletionReactionConfig{}, fmt.Errorf("tracker.handoff_state is required when reactions.merge_completion is configured")
+	}
+	if len(tracker.TerminalStates) == 0 {
+		return MergeCompletionReactionConfig{}, fmt.Errorf("tracker.terminal_states must be written when reactions.merge_completion is configured")
+	}
+
+	if raw, ok := rc.Extra["target_state"]; ok {
+		s, sok := raw.(string)
+		if !sok {
+			return MergeCompletionReactionConfig{}, fmt.Errorf("invalid target_state: expected string, got %T", raw)
+		}
+		cfg.TargetState = s
+	}
+	if cfg.TargetState == "" {
+		return MergeCompletionReactionConfig{}, fmt.Errorf("target_state is required")
+	}
+
+	effectiveActive := tracker.ActiveStates
+	if len(effectiveActive) == 0 {
+		effectiveActive = meta.DefaultActiveStates
+	}
+
+	if strings.EqualFold(cfg.TargetState, tracker.HandoffState) {
+		return MergeCompletionReactionConfig{}, fmt.Errorf("invalid target_state %q: must not equal tracker.handoff_state", cfg.TargetState)
+	}
+	if _, active := stateSet(effectiveActive)[strings.ToLower(cfg.TargetState)]; active {
+		return MergeCompletionReactionConfig{}, fmt.Errorf("invalid target_state %q: must not be a member of tracker.active_states", cfg.TargetState)
+	}
+	if _, terminal := stateSet(tracker.TerminalStates)[strings.ToLower(cfg.TargetState)]; !terminal {
+		return MergeCompletionReactionConfig{}, fmt.Errorf("invalid target_state %q: must be a member of tracker.terminal_states", cfg.TargetState)
+	}
+
+	if v, ok := rc.Extra["poll_interval_ms"]; ok {
+		n, err := toInt(v)
+		if err != nil {
+			return MergeCompletionReactionConfig{}, fmt.Errorf("invalid poll_interval_ms: %w", err)
+		}
+		if n < 30000 {
+			return MergeCompletionReactionConfig{}, fmt.Errorf("poll_interval_ms must be >= 30000, got %d", n)
+		}
+		cfg.PollIntervalMS = n
+	}
+
+	return cfg, nil
 }
 
 // toInt converts a YAML-decoded value (typically int or float64) to int.

--- a/internal/orchestrator/state_test.go
+++ b/internal/orchestrator/state_test.go
@@ -3,11 +3,13 @@ package orchestrator
 import (
 	"context"
 	"math"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/sortie-ai/sortie/internal/config"
 	"github.com/sortie-ai/sortie/internal/domain"
+	"github.com/sortie-ai/sortie/internal/registry"
 )
 
 func TestNewState(t *testing.T) {
@@ -1405,12 +1407,12 @@ func TestReactionKindPins(t *testing.T) {
 			})
 		}
 
-		if isKnownReactionKind("merge-completion") {
-			t.Error(`isKnownReactionKind("merge-completion") = true, want false (unregistered kind)`)
+		if isKnownReactionKind("totally-unregistered-kind") {
+			t.Error(`isKnownReactionKind("totally-unregistered-kind") = true, want false (unregistered kind)`)
 		}
 	})
 
-	t.Run("reactionKindPinsWorkspace returns the registered value for each of the seven kinds", func(t *testing.T) {
+	t.Run("reactionKindPinsWorkspace returns the registered value for each registered kind", func(t *testing.T) {
 		t.Parallel()
 
 		for kind, wantPins := range reactionKindPins {
@@ -1426,8 +1428,8 @@ func TestReactionKindPins(t *testing.T) {
 	t.Run("reactionKindPinsWorkspace returns true for an unregistered kind", func(t *testing.T) {
 		t.Parallel()
 
-		if got := reactionKindPinsWorkspace("merge-completion"); !got {
-			t.Error(`reactionKindPinsWorkspace("merge-completion") = false, want true (unregistered kind retains)`)
+		if got := reactionKindPinsWorkspace("totally-unregistered-kind"); !got {
+			t.Error(`reactionKindPinsWorkspace("totally-unregistered-kind") = false, want true (unregistered kind retains)`)
 		}
 	})
 }
@@ -1482,6 +1484,236 @@ func TestIsKnownReactionKind_AcceptsLabelFix(t *testing.T) {
 			}
 		})
 	}
+}
+
+// --- isKnownReactionKind merge-completion case ---
+
+// TestIsKnownReactionKind_AcceptsMergeCompletion verifies that the kind is
+// registered in reactionKindPins, and that reactionKindPinsWorkspace reports
+// false for it so a pending entry of this kind does not exclude its
+// workspace from sweep candidacy.
+func TestIsKnownReactionKind_AcceptsMergeCompletion(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		kind string
+		want bool
+	}{
+		{ReactionKindMergeCompletion, true},
+		{"merge-completion", true},
+		{"reactions.merge_completion", false}, // the YAML key, not the runtime discriminator
+		{"merge_completion", false},           // the template variable, not the discriminator
+		{"unknown", false},
+		{"", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.kind, func(t *testing.T) {
+			t.Parallel()
+			if got := isKnownReactionKind(tt.kind); got != tt.want {
+				t.Errorf("isKnownReactionKind(%q) = %v, want %v", tt.kind, got, tt.want)
+			}
+		})
+	}
+
+	if got := reactionKindPinsWorkspace(ReactionKindMergeCompletion); got {
+		t.Errorf("reactionKindPinsWorkspace(%q) = %v, want false", ReactionKindMergeCompletion, got)
+	}
+}
+
+// --- BuildMergeCompletionReactionConfig tests ---
+
+// TestBuildMergeCompletionReactionConfig covers the nine validation
+// failures of the stated evaluation order, the ADR-default success case,
+// and the two escalation edge cases asserted against a hand-built
+// config.ReactionConfig only.
+func TestBuildMergeCompletionReactionConfig(t *testing.T) {
+	t.Parallel()
+
+	validTracker := config.TrackerConfig{
+		HandoffState:   "in-review",
+		ActiveStates:   []string{"doing"},
+		TerminalStates: []string{"done"},
+	}
+
+	tests := []struct {
+		name        string
+		rc          config.ReactionConfig
+		tracker     config.TrackerConfig
+		meta        registry.TrackerMeta
+		want        MergeCompletionReactionConfig
+		wantErr     bool
+		wantErrText string
+	}{
+		{
+			name:        "unset tracker.handoff_state errors naming the field",
+			rc:          config.ReactionConfig{Extra: map[string]any{"target_state": "done"}},
+			tracker:     config.TrackerConfig{TerminalStates: []string{"done"}},
+			wantErr:     true,
+			wantErrText: "tracker.handoff_state",
+		},
+		{
+			name:        "empty tracker.terminal_states errors naming the field",
+			rc:          config.ReactionConfig{Extra: map[string]any{"target_state": "done"}},
+			tracker:     config.TrackerConfig{HandoffState: "in-review"},
+			wantErr:     true,
+			wantErrText: "tracker.terminal_states",
+		},
+		{
+			name:        "absent target_state errors",
+			rc:          config.ReactionConfig{},
+			tracker:     validTracker,
+			wantErr:     true,
+			wantErrText: "target_state is required",
+		},
+		{
+			name:        "non-string target_state errors naming the type",
+			rc:          config.ReactionConfig{Extra: map[string]any{"target_state": 123}},
+			tracker:     validTracker,
+			wantErr:     true,
+			wantErrText: "invalid target_state",
+		},
+		{
+			name:        "target_state equal to handoff_state errors",
+			rc:          config.ReactionConfig{Extra: map[string]any{"target_state": "in-review"}},
+			tracker:     validTracker,
+			wantErr:     true,
+			wantErrText: "must not equal tracker.handoff_state",
+		},
+		{
+			name:        "target_state present in active_states errors",
+			rc:          config.ReactionConfig{Extra: map[string]any{"target_state": "doing"}},
+			tracker:     validTracker,
+			wantErr:     true,
+			wantErrText: "must not be a member of tracker.active_states",
+		},
+		{
+			name:        "target_state absent from terminal_states errors",
+			rc:          config.ReactionConfig{Extra: map[string]any{"target_state": "wontfix"}},
+			tracker:     validTracker,
+			wantErr:     true,
+			wantErrText: "must be a member of tracker.terminal_states",
+		},
+		{
+			name: "non-integer poll_interval_ms errors",
+			rc: config.ReactionConfig{Extra: map[string]any{
+				"target_state":     "done",
+				"poll_interval_ms": "soon",
+			}},
+			tracker:     validTracker,
+			wantErr:     true,
+			wantErrText: "invalid poll_interval_ms",
+		},
+		{
+			name: "poll_interval_ms below floor errors",
+			rc: config.ReactionConfig{Extra: map[string]any{
+				"target_state":     "done",
+				"poll_interval_ms": 29999,
+			}},
+			tracker:     validTracker,
+			wantErr:     true,
+			wantErrText: "poll_interval_ms must be >= 30000",
+		},
+		{
+			name:    "ADR defaults with only target_state set",
+			rc:      config.ReactionConfig{Extra: map[string]any{"target_state": "done"}},
+			tracker: validTracker,
+			want: MergeCompletionReactionConfig{
+				TargetState:     "done",
+				PollIntervalMS:  60000,
+				Escalation:      "label",
+				EscalationLabel: "needs-human",
+			},
+		},
+		{
+			name: "invalid escalation errors against a hand-built config with no tracker set",
+			rc:   config.ReactionConfig{Escalation: "webhook"},
+			// tracker is the zero value: the escalation check runs before
+			// any tracker prerequisite, so this is a unit-level assertion
+			// only, not an end-to-end one.
+			wantErr:     true,
+			wantErrText: "invalid escalation",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := BuildMergeCompletionReactionConfig(tt.rc, tt.tracker, tt.meta)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("BuildMergeCompletionReactionConfig(%+v, %+v) = %+v, want error", tt.rc, tt.tracker, got)
+				}
+				if tt.wantErrText != "" && !strings.Contains(err.Error(), tt.wantErrText) {
+					t.Errorf("BuildMergeCompletionReactionConfig(%+v, %+v) error = %q, want substring %q", tt.rc, tt.tracker, err.Error(), tt.wantErrText)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("BuildMergeCompletionReactionConfig(%+v, %+v) unexpected error: %v", tt.rc, tt.tracker, err)
+			}
+			if got != tt.want {
+				t.Errorf("BuildMergeCompletionReactionConfig(%+v, %+v) = %+v, want %+v", tt.rc, tt.tracker, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestBuildMergeCompletionReactionConfig_StateListFallbackAsymmetry
+// verifies that the terminal list never falls back to registry.TrackerMeta
+// defaults, while the active list does, and the fallback only ever makes
+// the active check stricter.
+func TestBuildMergeCompletionReactionConfig_StateListFallbackAsymmetry(t *testing.T) {
+	t.Parallel()
+
+	t.Run("terminal defaults never fill in an empty written list", func(t *testing.T) {
+		t.Parallel()
+
+		rc := config.ReactionConfig{Extra: map[string]any{"target_state": "done"}}
+		tracker := config.TrackerConfig{HandoffState: "in-review"}
+		meta := registry.TrackerMeta{DefaultTerminalStates: []string{"done"}}
+
+		_, err := BuildMergeCompletionReactionConfig(rc, tracker, meta)
+		if err == nil {
+			t.Fatal("BuildMergeCompletionReactionConfig(...) = nil error, want error (terminal defaults must not fill in)")
+		}
+		if !strings.Contains(err.Error(), "tracker.terminal_states") {
+			t.Errorf("BuildMergeCompletionReactionConfig(...) error = %q, want substring %q", err.Error(), "tracker.terminal_states")
+		}
+	})
+
+	t.Run("active defaults fill in and reject a target drawn from them", func(t *testing.T) {
+		t.Parallel()
+
+		rc := config.ReactionConfig{Extra: map[string]any{"target_state": "doing"}}
+		tracker := config.TrackerConfig{HandoffState: "in-review", TerminalStates: []string{"doing", "done"}}
+		meta := registry.TrackerMeta{DefaultActiveStates: []string{"doing"}}
+
+		_, err := BuildMergeCompletionReactionConfig(rc, tracker, meta)
+		if err == nil {
+			t.Fatal("BuildMergeCompletionReactionConfig(...) = nil error, want error (active defaults must fill in and reject)")
+		}
+		if !strings.Contains(err.Error(), "tracker.active_states") {
+			t.Errorf("BuildMergeCompletionReactionConfig(...) error = %q, want substring %q", err.Error(), "tracker.active_states")
+		}
+	})
+
+	t.Run("a target outside the active defaults and inside the written terminal list validates", func(t *testing.T) {
+		t.Parallel()
+
+		rc := config.ReactionConfig{Extra: map[string]any{"target_state": "done"}}
+		tracker := config.TrackerConfig{HandoffState: "in-review", TerminalStates: []string{"done"}}
+		meta := registry.TrackerMeta{DefaultActiveStates: []string{"doing"}}
+
+		got, err := BuildMergeCompletionReactionConfig(rc, tracker, meta)
+		if err != nil {
+			t.Fatalf("BuildMergeCompletionReactionConfig(...) unexpected error: %v", err)
+		}
+		if got.TargetState != "done" {
+			t.Errorf("BuildMergeCompletionReactionConfig(...).TargetState = %q, want %q", got.TargetState, "done")
+		}
+	})
 }
 
 // --- BuildLabelFixReactionConfig tests ---

--- a/internal/scm/gitea/integration_merge_test.go
+++ b/internal/scm/gitea/integration_merge_test.go
@@ -307,6 +307,22 @@ func TestIntegration_SCMMergeFlow(t *testing.T) {
 		t.Skip("MergePR_HappyPath subtest failed; skipping dependent subtests")
 	}
 
+	t.Run("GetMergeability_AfterMerge", func(t *testing.T) {
+		status, err := adapter.GetMergeability(ctx, prNumber, owner, repo)
+		if err != nil {
+			t.Fatalf("GetMergeability(PR #%d) after merge: %v", prNumber, err)
+		}
+		if !status.Merged {
+			t.Errorf("GetMergeability(PR #%d).Merged = false, want true after the happy-path merge", prNumber)
+		}
+		if status.MergeCommitSHA == "" {
+			t.Errorf("GetMergeability(PR #%d).MergeCommitSHA = %q, want non-empty after the happy-path merge", prNumber, status.MergeCommitSHA)
+		}
+	})
+	if t.Failed() {
+		t.Skip("GetMergeability_AfterMerge subtest failed; skipping dependent subtests")
+	}
+
 	t.Run("MergePR_AlreadyMerged", func(t *testing.T) {
 		// Gitea returns HTTP 405 "already merged" on a second merge, unlike the
 		// GitHub sibling's idempotent success.

--- a/internal/scm/gitea/scm_merge.go
+++ b/internal/scm/gitea/scm_merge.go
@@ -20,6 +20,7 @@ import (
 type giteaPullRequest struct {
 	Mergeable          bool        `json:"mergeable"`
 	Merged             bool        `json:"merged"`
+	MergeCommitSHA     *string     `json:"merge_commit_sha"`
 	Draft              bool        `json:"draft"`
 	RequestedReviewers []giteaUser `json:"requested_reviewers"`
 	Head               struct {
@@ -85,12 +86,23 @@ func (a *GiteaSCMAdapter) GetMergeability(ctx context.Context, prNumber int, own
 		return domain.PRMergeStatus{}, err
 	}
 
+	// The upstream field is a nullable pointer, so an unmerged PR
+	// serializes it as null or omits it; the value is also gated on
+	// Merged so a stale or misreported commit id on an open PR is never
+	// asserted as a merge.
+	var mergeCommitSHA string
+	if pr.Merged && pr.MergeCommitSHA != nil {
+		mergeCommitSHA = *pr.MergeCommitSHA
+	}
+
 	return domain.PRMergeStatus{
-		Draft:        pr.Draft,
-		Mergeability: mapMergeability(pr),
-		HeadSHA:      pr.Head.SHA,
-		BranchName:   pr.Head.Ref,
-		BaseBranch:   pr.Base.Ref,
+		Draft:          pr.Draft,
+		Mergeability:   mapMergeability(pr),
+		HeadSHA:        pr.Head.SHA,
+		BranchName:     pr.Head.Ref,
+		BaseBranch:     pr.Base.Ref,
+		Merged:         pr.Merged,
+		MergeCommitSHA: mergeCommitSHA,
 	}, nil
 }
 

--- a/internal/scm/gitea/scm_merge_test.go
+++ b/internal/scm/gitea/scm_merge_test.go
@@ -14,17 +14,24 @@ import (
 
 // --- GetMergeability ---
 
+// pr_merged.json is schema-inferred from the upstream MergedCommitID
+// *string field in modules/structs/pull.go at the Gitea v1.27.0 tag this
+// project pins (JSON key merge_commit_sha), the same provenance marker
+// docs/gitea-adapter-notes.md records for this field: the lab instance
+// carried no merged pull request to populate it live.
 func TestGiteaSCMGetMergeability(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name           string
-		fixture        string
-		wantMergeable  domain.MergeabilityState
-		wantDraft      bool
-		wantHeadSHA    string
-		wantBranchName string
-		wantBaseBranch string
+		name               string
+		fixture            string
+		wantMergeable      domain.MergeabilityState
+		wantDraft          bool
+		wantHeadSHA        string
+		wantBranchName     string
+		wantBaseBranch     string
+		wantMerged         bool
+		wantMergeCommitSHA string
 	}{
 		{
 			name:           "mergeable true maps to clean",
@@ -52,6 +59,17 @@ func TestGiteaSCMGetMergeability(t *testing.T) {
 			wantHeadSHA:    "sha-conflict-003",
 			wantBranchName: "feature/conflict",
 			wantBaseBranch: "develop",
+		},
+		{
+			name:               "merged true populates Merged and MergeCommitSHA",
+			fixture:            "pr_merged.json",
+			wantMergeable:      domain.MergeabilityUnknown,
+			wantDraft:          false,
+			wantHeadSHA:        "sha-clean-001",
+			wantBranchName:     "feature/gitea-scm-reads",
+			wantBaseBranch:     "main",
+			wantMerged:         true,
+			wantMergeCommitSHA: "9f3c1a2e4b5d6c7a8e9f0b1c2d3e4f5a6b7c8d9e",
 		},
 	}
 
@@ -92,6 +110,12 @@ func TestGiteaSCMGetMergeability(t *testing.T) {
 			}
 			if got.CIConclusion != "" {
 				t.Errorf("GetMergeability().CIConclusion = %q, want empty (left unset)", got.CIConclusion)
+			}
+			if got.Merged != tt.wantMerged {
+				t.Errorf("GetMergeability().Merged = %v, want %v", got.Merged, tt.wantMerged)
+			}
+			if got.MergeCommitSHA != tt.wantMergeCommitSHA {
+				t.Errorf("GetMergeability().MergeCommitSHA = %q, want %q", got.MergeCommitSHA, tt.wantMergeCommitSHA)
 			}
 		})
 	}

--- a/internal/scm/gitea/testdata/pr_merged.json
+++ b/internal/scm/gitea/testdata/pr_merged.json
@@ -1,0 +1,18 @@
+{
+  "id": 500007,
+  "number": 6,
+  "title": "Add Gitea SCM merge-completion read",
+  "state": "closed",
+  "mergeable": false,
+  "merged": true,
+  "merged_at": "2026-07-18T10:15:00Z",
+  "merge_commit_sha": "9f3c1a2e4b5d6c7a8e9f0b1c2d3e4f5a6b7c8d9e",
+  "draft": false,
+  "user": { "login": "alice" },
+  "requested_reviewers": [],
+  "head": { "sha": "sha-clean-001", "ref": "feature/gitea-scm-reads" },
+  "base": { "ref": "main" },
+  "html_url": "https://git.example.com/acme/widgets/pulls/6",
+  "created_at": "2026-07-10T08:00:00Z",
+  "updated_at": "2026-07-18T10:15:00Z"
+}

--- a/internal/scm/github/merge.go
+++ b/internal/scm/github/merge.go
@@ -57,6 +57,8 @@ func (a *GitHubSCMAdapter) GetReviewDecision(ctx context.Context, prNumber int, 
 type pullRequestResponse struct {
 	Draft          bool   `json:"draft"`
 	MergeableState string `json:"mergeable_state"`
+	Merged         bool   `json:"merged"`
+	MergeCommitSHA string `json:"merge_commit_sha"`
 	Head           struct {
 		SHA string `json:"sha"`
 		Ref string `json:"ref"`
@@ -194,12 +196,22 @@ func (a *GitHubSCMAdapter) GetMergeability(ctx context.Context, prNumber int, ow
 
 	mergeability := mapMergeableState(pr.MergeableState)
 
+	// GitHub reports a test-merge commit in merge_commit_sha for an open
+	// PR, so the value is gated on Merged to avoid asserting a merge
+	// that has not happened.
+	var mergeCommitSHA string
+	if pr.Merged {
+		mergeCommitSHA = pr.MergeCommitSHA
+	}
+
 	return domain.PRMergeStatus{
-		Draft:        pr.Draft,
-		Mergeability: mergeability,
-		HeadSHA:      pr.Head.SHA,
-		BranchName:   pr.Head.Ref,
-		BaseBranch:   pr.Base.Ref,
+		Draft:          pr.Draft,
+		Mergeability:   mergeability,
+		HeadSHA:        pr.Head.SHA,
+		BranchName:     pr.Head.Ref,
+		BaseBranch:     pr.Base.Ref,
+		Merged:         pr.Merged,
+		MergeCommitSHA: mergeCommitSHA,
 	}, nil
 }
 

--- a/internal/scm/github/merge_test.go
+++ b/internal/scm/github/merge_test.go
@@ -613,6 +613,57 @@ func TestGetMergeability_BaseBranch(t *testing.T) {
 	}
 }
 
+// TestGetMergeability_Merged verifies that a merged pull request populates
+// Merged and MergeCommitSHA from the single pull-request object the adapter
+// already fetches.
+func TestGetMergeability_Merged(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"head":{"sha":"sha-merged"},"draft":false,"mergeable_state":"clean","merged":true,"merge_commit_sha":"abc123merged"}`))
+	}))
+	defer srv.Close()
+
+	a := newTestSCMAdapter(t, srv.URL)
+	status, err := a.GetMergeability(t.Context(), 1, "owner", "repo")
+	if err != nil {
+		t.Fatalf("GetMergeability: %v", err)
+	}
+	if !status.Merged {
+		t.Error("GetMergeability().Merged = false, want true")
+	}
+	if status.MergeCommitSHA != "abc123merged" {
+		t.Errorf("GetMergeability().MergeCommitSHA = %q, want %q", status.MergeCommitSHA, "abc123merged")
+	}
+}
+
+// TestGetMergeability_UnmergedIgnoresTestMergeCommit verifies that an open
+// pull request reporting a populated merge_commit_sha (GitHub's test-merge
+// value) is not mistaken for a merge: Merged stays false and MergeCommitSHA
+// stays empty.
+func TestGetMergeability_UnmergedIgnoresTestMergeCommit(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"head":{"sha":"sha-open"},"draft":false,"mergeable_state":"clean","merged":false,"merge_commit_sha":"test-merge-commit-sha"}`))
+	}))
+	defer srv.Close()
+
+	a := newTestSCMAdapter(t, srv.URL)
+	status, err := a.GetMergeability(t.Context(), 1, "owner", "repo")
+	if err != nil {
+		t.Fatalf("GetMergeability: %v", err)
+	}
+	if status.Merged {
+		t.Error("GetMergeability().Merged = true, want false for an open PR")
+	}
+	if status.MergeCommitSHA != "" {
+		t.Errorf("GetMergeability().MergeCommitSHA = %q, want empty (test-merge value must be gated on Merged)", status.MergeCommitSHA)
+	}
+}
+
 // --- mapMergeableState tests ---
 
 func TestMapMergeableState(t *testing.T) {

--- a/internal/workspace/scm.go
+++ b/internal/workspace/scm.go
@@ -65,10 +65,12 @@ func rejectSCMSymlinks(workspacePath string, logger *slog.Logger) bool {
 // <workspacePath>/.sortie/scm.json.
 //
 // Returns a zero-value [domain.SCMMetadata] when the file is absent,
-// unreadable, oversized, malformed, when the decoded metadata has an
-// empty or missing branch, or when either .sortie/ or scm.json is a
-// symbolic link. Read errors are logged at warn level; the function
-// never returns an error to the caller.
+// unreadable, oversized, malformed, or when either .sortie/ or
+// scm.json is a symbolic link. Read errors are logged at warn level;
+// the function never returns an error to the caller. Branch may be
+// empty in the returned value: some reaction kinds require no
+// checkout and therefore no branch, so validating Branch is the
+// caller's responsibility, not this reader's.
 func ReadSCMMetadata(workspacePath string, logger *slog.Logger) domain.SCMMetadata {
 	if logger == nil {
 		logger = slog.Default()
@@ -115,10 +117,6 @@ func ReadSCMMetadata(workspacePath string, logger *slog.Logger) domain.SCMMetada
 			slog.String("workspace", workspacePath),
 			slog.Any("error", err),
 		)
-		return domain.SCMMetadata{}
-	}
-
-	if meta.Branch == "" {
 		return domain.SCMMetadata{}
 	}
 

--- a/internal/workspace/scm_test.go
+++ b/internal/workspace/scm_test.go
@@ -109,12 +109,15 @@ func TestReadSCMMetadata_EmptyBranchField(t *testing.T) {
 	t.Parallel()
 
 	wsPath := t.TempDir()
-	writeSCMFile(t, wsPath, []byte(`{"branch":"","sha":"abc"}`))
+	writeSCMFile(t, wsPath, []byte(`{"branch":"","sha":"abc","pr_number":7,"owner":"acme","repo":"widgets"}`))
 
 	got := ReadSCMMetadata(wsPath, slog.Default())
 
-	if got != (domain.SCMMetadata{}) {
-		t.Errorf("ReadSCMMetadata(empty branch) = %+v, want zero value", got)
+	if got.Branch != "" {
+		t.Errorf("ReadSCMMetadata(empty branch).Branch = %q, want empty", got.Branch)
+	}
+	if got.PRNumber != 7 || got.Owner != "acme" || got.Repo != "widgets" {
+		t.Errorf("ReadSCMMetadata(empty branch) = %+v, want PR fields preserved despite empty branch", got)
 	}
 }
 


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Feat

**Intent:** Once a Sortie-managed pull request merges, the linked tracker issue should reach a configured terminal state without a human remembering to do it and without an external automation watching for the merge. This adds an opt-in `reactions.merge_completion` capability that observes the merge live and transitions the issue exactly once, closing the issue-to-PR-to-merge loop on the tracker.

**Related Issues:** #707

### 🧭 Reviewer Guide

**Complexity:** Medium

#### Entry Point

`internal/orchestrator/merge_completion_reconcile.go` is the new reconcile pass: it observes the merge via the SCM adapter and fingerprints on the merge commit identifier (not the PR number) so the same merge is recognized across poll ticks and a process restart, guaranteeing the transition fires exactly once. `internal/orchestrator/state.go` (`BuildMergeCompletionReactionConfig`) validates `target_state` against `tracker.handoff_state`, `tracker.active_states`, and `tracker.terminal_states` at startup.

#### Sensitive Areas

- `internal/orchestrator/exit.go`: seeds the pending merge-completion entry from workspace SCM metadata on worker exit; gated on the SCM adapter and the reaction being configured.
- `internal/orchestrator/reaction_validate.go`, `internal/orchestrator/state.go`: narrows escalation on `ci_failure` and `review_comments` to clear only the escalating kind's own pending entry, attempt counter, and fingerprint, so an unrelated escalation no longer ends a sibling reaction's observation on the same issue.
- `internal/scm/github/merge.go`, `internal/scm/gitea/scm_merge.go`: extended to surface the merge commit SHA needed for fingerprinting.
- `docs/decisions/0017-close-tracker-issue-on-managed-pr-merge.md`, `docs/decisions/0018-bound-workspace-retention-by-age.md`: amended (not new) to state how the escalation-scope invariant and the retention-floor coupling interact with this capability.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes. The capability is opt-in and default-off: a deployment that omits `reactions.merge_completion` performs no additional tracker write and no additional forge request, matching prior behavior byte for byte.
- **Migrations/State:** No migrations or state changes.
