### PR TITLE
fix(orchestrator): release reaction state on terminal issue

### DIFF
--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: code-review
+description: "Reviews pull requests in this repository for the defect classes a mechanical checklist misses: documentation that outlived the code it describes, reaction and retry state that leaks or clobbers a sibling, contract widenings that leave test doubles silently asserting nothing, kind-keyed maps missing a new entry, configuration literals that mean opposite things in adjacent blocks, error-taxonomy routing gaps, and wire assumptions that break on pagination. Use on every pull request review in addition to the coding standards in copilot-instructions.md. Covers Go orchestrator code, adapter packages, the architecture specification under docs/architecture/, accepted decision records, and operator-facing strings."
+license: MIT
+---
+
+# Reviewing sortie pull requests
+
+`.github/copilot-instructions.md` covers the mechanical checks: layering, concurrency, path containment, SQLite rules, error wrapping, resource lifecycle, adapter boundaries, style. Do not repeat them. This skill covers what those checks cannot see: defects that are locally correct and globally wrong.
+
+Two rules govern every finding.
+
+**Verify before flagging.** Open the file and read the line. A finding that cites a line that says something else costs the maintainer more than silence. State the evidence inline: file, symbol, and what it actually does.
+
+**One grounded finding beats five speculative ones.** Uncertain findings are noise. If a check below needs a fact you cannot establish from the diff plus the files it touches, say what you could not verify instead of guessing.
+
+## Start from the pull request description
+
+`.github/pull_request_template.md` makes the author declare Intent, Sensitive Areas, Breaking Changes, and Migrations. Treat each as a claim to audit, not as context to absorb.
+
+- **Intent says opt-in or default-off.** Find the branch that makes it inert when unconfigured, and confirm nothing outside it changed behavior. An opt-in feature that alters a default path is the failure this claim hides.
+- **Sensitive Areas names a file.** Review it first and hardest. An empty Sensitive Areas on a diff that touches orchestrator state, an adapter boundary, or workspace removal is itself a finding.
+- **Breaking Changes says none.** Check exported signatures, domain struct fields consumed by adapters, config field names and defaults, and log or metric names an operator may depend on.
+- **Migrations says none.** Check `internal/persistence/sql/` and any new column read.
+
+## Documentation is part of the change
+
+The specification under `docs/architecture/` is the contract implementation follows, so drift is a defect, not a nicety. For any behavior change, find the section that describes that behavior and confirm the PR updates it.
+
+- **A documented guarantee with no enforcing line.** When a document claims a safety property ("marked dispatched synchronously, which prevents duplicate dispatch"), locate the code that provides it. If the code does it later, elsewhere, or not at all, the document is wrong and the PR that touched the area should fix it.
+- **Absolute claims.** "No path releases X", "the only mechanism", "always", "never". One counterexample falsifies these permanently, and they rot silently. Ask whether the diff introduces a second path that makes an existing absolute false.
+- **Counts in prose.** "has nine parts", "three tables", "two packages implement". A new pass, table, or implementation makes them false and nobody notices. Flag the count, and propose a formulation that states the ordering or the property instead.
+- **Enumerations that must grow.** Adapter lists, reaction kind lists, supported-forge tables. If the PR adds a member, every enumeration of that set is a review target.
+- **Operator-visible surface, separate repository.** The docs site lives outside this repository. A PR adding a config field, environment variable, CLI flag, or reaction kind cannot update it here. Flag the gap so it is tracked; do not ask for a file this repository does not hold.
+- **Accepted decision records are immutable.** `docs/decisions/` records what was decided and why. Do not propose adding issue numbers, section numbers, or line numbers to one; do not re-litigate a decision recorded there. If the code contradicts an accepted record, that is the finding.
+
+## Orchestrator state: the defects that survive unit tests
+
+State lives in maps keyed by issue and reaction kind, mutated across passes that run in a fixed order each tick. Locally correct edits break neighbors.
+
+- **The retry slot is one per issue.** `ScheduleRetry` cancels any queued retry for that issue first. Any pass that schedules a retry discards whatever another kind had queued, along with its continuation context. When a diff adds or moves a `ScheduleRetry` call, ask what it displaces and whether the victim can re-detect its own work.
+- **Cleanup must be scoped to the escalating kind.** An issue-wide clear takes sibling reactions' entries, counters, and fingerprint rows with it. A kind parked in a handoff state has no worker exit left to reseed it, so the loss is permanent until restart.
+- **Every pending entry needs a release path.** For a new or modified reaction kind, establish who seeds the entry, what drops it (age, terminal state, or its own completion), and what happens across a restart. A kind with no expiry and no terminal check leaks the entry and polls the forge forever.
+- **Claim and counter are not the entry.** `state.Claimed`, `state.ReactionAttempts`, and `state.PendingReactions` have independent lifetimes. A change that releases one is not evidence the others are released.
+- **Kind-keyed maps must gain the new member.** A new reaction kind needs an entry wherever kinds are enumerated: pinning behavior, TTL wiring, recovery seeding, validation, metrics labels. Grep the kind constant across the package; a missing entry usually means a silent default, not a compile error.
+- **The fingerprint protocol has an order.** Upsert the fingerprint, read it back, act, and mark dispatched only after the action succeeded. Marking before the action loses the retry on a transient failure; deleting the row on success re-arms the same observation on the next tick; retaining it blocks a legitimate second episode. Judge which of the three the diff wants, then check it does that.
+
+## Adapter contracts
+
+- **Widening a domain type reaches every implementation and every double.** A new field on a shared struct must be populated by each adapter and by each fake in tests. A double that leaves it at the zero value asserts the negative case forever: a bool stays false, a string stays empty, and the test passes while covering nothing.
+- **Fixtures must match the live wire shape.** Response fixtures built from a hand-written guess hide real bugs: a dropped cursor field, a team key placed in a UUID field, a status list that arrives paginated. Prefer a fixture derived from a recorded response.
+- **Pagination is not optional.** A single `GET` against a route that paginates silently truncates at the page size. Any new list read needs the pagination walk, and the review question is what the route's default page size is.
+- **Text-sniffing a message is a wire dependency.** Matching on a substring of an error body works until the forge rewrites the sentence. Flag it when introduced; when it already exists, flag only if the diff extends it.
+- **Adapters normalize at the boundary.** A forge-specific field name, status string, or flag reaching orchestrator code is a leak even when it compiles.
+
+## Configuration and validation
+
+- **The same literal can mean opposite things.** A zero budget disables count-based escalation in one reaction and escalates on first detection in its sibling. When a diff adds a numeric field, compare its semantics against the adjacent block that shares the name.
+- **Two environment mechanisms, never conflated.** The override registry maps one `SORTIE_*` variable to one config field and replaces the YAML value. `$VAR` indirection is a workflow-authored reference expanded at load. A change to one is not a change to the other, and documentation that credits the wrong one is a finding.
+- **Offline validation versus construction.** `sortie validate` performs config-shape checks without network access. Credential, project, and state resolution happen when the adapter is constructed. A check placed in the wrong layer either fails offline or never runs.
+- **An earlier error can shadow a later arm.** If the config layer rejects a combination before the adapter validator sees it, that validator arm is unreachable end to end. Flag a test that claims to cover it through the full path.
+- **Durations end in `_ms` here.** A field measured in another unit needs a stated reason, because the reader will assume milliseconds.
+
+## Error handling beyond wrapping
+
+- **Route every class.** Transport and API errors back off and retry; auth and payload errors are deterministic and escalate without consuming the retry budget; not-found stops. A new call site that collapses these into one branch spends the budget proving a permission error is permanent.
+- **A silent early return blinds the operator.** A pass that returns without a log leaves no way to tell "working, nothing to do" from "misconfigured, doing nothing". Periodic passes that remove or dispatch nothing should still report why.
+- **Degrade-to-continue needs somewhere to continue to.** A failure posture copied from a path that has a retry loop is wrong on a path that has none.
+
+## Tests
+
+- **A regression test must fail without the fix.** For a bug fix, look for the assertion that the old code would violate. A test that passes both ways documents behavior; it does not lock the fix.
+- **Zero-value doubles.** See the contract-widening note above: this is the most common way a sortie test passes while asserting nothing.
+- **Env-gated integration tests skip cleanly.** Without `SORTIE_<ADAPTER>_TEST=1` they must skip, never fail.
+
+## Operator-facing strings
+
+Help text, warnings, and report output are read by operators who never see the schema. A message naming a table, a column, or a code path is a finding. Configuration keys the operator writes are fine.
+
+## Do not raise these
+
+- **Go version idioms.** The module targets a modern Go release. Range-over-int, per-iteration loop variables, and the standard library added in recent releases compile. Do not claim otherwise; CI is the arbiter.
+- **Deliberate decisions recorded in `docs/decisions/`.** Disagreeing with an accepted record is not a review comment.
+- **Established patterns repeated correctly.** A new pass that mirrors its five siblings is not a finding because you would have written it differently.
+- **Equivalent rewrites.** Style preferences with no behavioral difference.
+
+## Severity
+
+Use the ladder at the end of `.github/copilot-instructions.md`. Two additions specific to this skill: documentation that states a guarantee the code does not provide is Major, not Minor, because the next implementer builds on it; a leaked or clobbered state entry is Major even when no test fails, because its symptom is a workflow that never completes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   escalation no longer silently ends `reactions.merge_completion`
   observation (or any other sibling reaction) for that issue.
   ([#707](https://github.com/sortie-ai/sortie/issues/707))
+- An issue reaching a terminal tracker state now stops all of its
+  reaction polling immediately, including for a `sortie:review` or
+  `sortie:fix` label-command entry, which previously kept polling the
+  pull request's label journal for the life of the orchestrator process
+  even after the issue closed. This applies whether or not a worker is
+  still running for the issue, and it releases the issue for a fresh
+  dispatch as soon as it is reopened into an active state, rather than
+  after a pending retry happens to fire.
+  ([#741](https://github.com/sortie-ai/sortie/issues/741))
 
 ### Changed
 

--- a/docs/architecture/08-polling-scheduling-and-reconciliation.md
+++ b/docs/architecture/08-polling-scheduling-and-reconciliation.md
@@ -138,12 +138,19 @@ Part A: Stall detection
 
 Part B: Tracker state refresh
 
-- Fetch current issue states for all running issue IDs.
+- Fetch current issue states for the deduplicated union of all running issue IDs and every issue
+  ID holding a pending reaction entry; skip the call entirely when that union is empty or no
+  tracker adapter is configured.
 - For each running issue:
   - If tracker state is terminal: terminate worker and clean workspace.
   - If tracker state is still active: update the in-memory issue snapshot.
   - If tracker state is neither active nor terminal: terminate worker without workspace cleanup.
-- If state refresh fails, keep workers running and try again on the next tick.
+- For an issue reported terminal, whether or not it has a running worker: release the issue's
+  pending reaction entries, reaction attempt counters, pending retry, and dispatch claim, leaving
+  `reaction_fingerprints` intact. An issue with no running worker and no terminal state is left
+  untouched.
+- If state refresh fails, keep workers running and try again on the next tick, and release
+  nothing.
 
 Part C: CI status reconciliation (when `ci_feedback.kind` or `reactions.ci_failure` is configured)
 

--- a/docs/architecture/14-auto-merge-reaction-contract.md
+++ b/docs/architecture/14-auto-merge-reaction-contract.md
@@ -212,7 +212,8 @@ state owned by a different reaction kind. Specifically, these paths MUST NOT cal
 
 - `CancelRetry`
 - `DeleteRetryEntry`
-- `ClearReactionsForIssue`
+- a clear that ranges over every pending entry, attempt counter, or `reaction_fingerprints` row an
+  issue holds
 - `delete state.Claimed[issue_id]`
 
 A failed auto-merge does NOT invalidate parallel `ci` or `review` reaction continuations on

--- a/docs/architecture/15-bot-review-comment-feedback-contract.md
+++ b/docs/architecture/15-bot-review-comment-feedback-contract.md
@@ -111,18 +111,19 @@ escalates. Escalation follows the auto-merge cross-kind isolation contract in §
   continuation turns attempted, under the same goroutine pattern.
 
 Cleanup is scoped to the `bot-review` slot only: delete `pending_reactions[issue_id:bot-review]` and
-the `bot-review` fingerprint row. The escalation path MUST NOT call `ClearReactionsForIssue`,
-`CancelRetry`, or `DeleteRetryEntry`, MUST NOT delete `state.Claimed[issue_id]`, and MUST NOT delete
-the residual `reaction_attempts[issue_id:bot-review]` counter. The issue claim and that residual
+the `bot-review` fingerprint row. The escalation path MUST NOT clear any sibling kind's slot, MUST
+NOT call `CancelRetry` or `DeleteRetryEntry`, MUST NOT delete `state.Claimed[issue_id]`, and MUST NOT
+delete the residual `reaction_attempts[issue_id:bot-review]` counter. The issue claim and that residual
 counter are owned by whichever kind currently holds the claim (the first-turn dispatch, `review`, or
 `merge`); releasing them from the bot-review path would corrupt sibling-kind ownership. Because the
-pending entry is deleted, the kind stops polling, but the residual counter and the claim are not
-released by any path in the current implementation. `ClearReactionsForIssue` clears an issue's
-residual `reaction_attempts` counters and `pending_reactions` entries, but it does not touch
-`state.Claimed`, and no path, including the tracker-reconcile terminal-state path, calls it in
-production. The residual counter and the claim persist for the life of the orchestrator process.
-This mirrors how `escalateAutoMergeFailure` leaves `reaction_attempts[issue_id:merge]` and
-`state.Claimed` uncleaned after a merge-kind escalation.
+pending entry is deleted, the kind stops polling, but the residual counter is not released by any
+path scoped to bot-review. The residual counter and the claim are released together, whole-issue,
+once the tracker reports the issue terminal: the tracker-reconcile pass drops every pending entry
+and every attempt counter the issue holds, cancels its pending retry, and releases
+`state.Claimed[issue_id]`, leaving `reaction_fingerprints` untouched. This mirrors how
+`escalateAutoMergeFailure` leaves `reaction_attempts[issue_id:merge]` and `state.Claimed` uncleaned
+after a merge-kind escalation; that residue, too, is released once the issue reaches a terminal
+state.
 
 Escalation tracker-call failures are logged and counted
 (`sortie_bot_review_escalations_total{action="error"}`) but do not block the slot-scoped cleanup.
@@ -154,5 +155,5 @@ Per-issue `bot-review` reaction lifecycle (the `issue_id:bot-review` slot):
 | pending | Reconcile tick, fingerprint unchanged and dispatched | pending | Re-enqueue at `now + poll_interval`. |
 | pending | Reconcile tick, new actionable comments, attempts < cap | dispatched | Schedule continuation, increment attempts, count dispatched. |
 | pending | Reconcile tick, attempts reach cap | escalated | Apply escalation; clear ONLY the `bot-review` slot. MUST NOT release the claim or clear sibling slots (§11D.5). |
-| pending | Issue reaches terminal state (tracker reconcile) | pending | No effect: the tracker-reconcile terminal-state path does not call `ClearReactionsForIssue`. The slot keeps re-enqueuing until the TTL backstop drops it; the residual counter and the claim are not released by any path. |
+| pending | Issue reaches terminal state (tracker reconcile) | (none) | Drop the `bot-review` pending entry and its attempt counter, cancel and delete the issue's retry, and release the claim; `reaction_fingerprints` is left intact. |
 

--- a/docs/architecture/16-merge-conflict-reaction-contract.md
+++ b/docs/architecture/16-merge-conflict-reaction-contract.md
@@ -115,17 +115,17 @@ DeleteReactionFingerprint(issueID, "merge-conflict")
 delete(state.ReactionAttempts,    ReactionKey(issueID, "merge-conflict"))
 ```
 
-The counter reset is the scoped per-kind delete, NOT the issue-wide `ClearReactionsForIssue`. This
-makes both episode exits symmetric: the N1 branch and the escalation exit each leave the counter
-deleted, so a later independent conflict always opens a fresh episode at `attempts = 1` regardless of
-which exit closed the prior episode.
+The counter reset is scoped to this kind's own slot, not an issue-wide clear. This makes both
+episode exits symmetric: the N1 branch and the escalation exit each leave the counter deleted, so a
+later independent conflict always opens a fresh episode at `attempts = 1` regardless of which exit
+closed the prior episode.
 
 Cross-kind isolation: `escalateMergeConflictFailure` MUST scope all deletions to the `merge-conflict`
-kind only. It MUST NOT call `CancelRetry`, `DeleteRetryEntry`, `ClearReactionsForIssue`, or
-`delete state.Claimed[issue_id]`. A failed merge-conflict resolution MUST NOT invalidate parallel
-`ci`, `review`, `bot-review`, or `merge` reactions on the same issue. Escalation tracker-call
-failures are logged and counted (`sortie_merge_conflict_escalations_total{action="error"}`) but do
-not block the slot-scoped cleanup.
+kind only. It MUST NOT call `CancelRetry` or `DeleteRetryEntry`, MUST NOT clear any sibling kind's
+slot, and MUST NOT `delete state.Claimed[issue_id]`. A failed merge-conflict resolution MUST NOT
+invalidate parallel `ci`, `review`, `bot-review`, or `merge` reactions on the same issue. Escalation
+tracker-call failures are logged and counted
+(`sortie_merge_conflict_escalations_total{action="error"}`) but do not block the slot-scoped cleanup.
 
 ### 11E.6 Continuation data
 
@@ -204,5 +204,5 @@ Per-issue `merge-conflict` reaction lifecycle (the `issue_id:merge-conflict` slo
 | pending | Reconcile tick, `Mergeability == dirty`, fingerprint dispatched for this head | pending | Re-enqueue at `now + poll_interval`; do not increment counter. |
 | pending | Reconcile tick, `Mergeability == dirty`, new head, `attempts <= MaxRetries` | dispatched | Increment per-episode counter; schedule continuation; mark dispatched; count dispatched. |
 | pending | Reconcile tick, `Mergeability == dirty`, new head, `attempts > MaxRetries` | escalated | Increment per-episode counter; apply escalation; delete slot, fingerprint, and per-episode counter. MUST NOT release the claim or clear sibling slots (§11E.5). |
-| pending | Issue reaches terminal state (tracker reconcile) | pending | No effect: the tracker-reconcile terminal-state path does not call `ClearReactionsForIssue`. The slot keeps re-enqueuing until the TTL backstop drops it; the residual counter and the claim are not released by any path. |
+| pending | Issue reaches terminal state (tracker reconcile) | (none) | Drop the `merge-conflict` pending entry and its per-episode counter, cancel and delete the issue's retry, and release the claim; `reaction_fingerprints` is left intact. |
 

--- a/docs/architecture/28-label-command-and-read-only-review-contract.md
+++ b/docs/architecture/28-label-command-and-read-only-review-contract.md
@@ -400,10 +400,10 @@ guard seeding uses, so a label applied while Sortie was down is detected on the 
 restart (the journal is durable) for either command. The persisted mark is read back from
 `reaction_fingerprints` for each kind, so recovery does not reset deduplication state.
 
-When the linked issue reaches a terminal state, no path removes the `label-review` or `label-fix`
-reaction state: the tracker-reconcile terminal-state path does not call the issue-wide
-`ClearReactionsForIssue` cleanup, and neither kind carries a TTL to drop its own entry with age. A
-pending entry keeps polling the label-event journal after the issue closes.
+When the linked issue reaches a terminal state, the tracker-reconcile terminal-state path removes
+the `label-review` or `label-fix` pending entry, whether or not the entry carries a TTL of its own;
+neither kind carries an attempt counter to release alongside it. The label-journal poll stops on the
+next reconcile tick.
 
 A pending `label-review` or `label-fix` entry no longer excludes its workspace from periodic-sweep
 candidacy, because neither kind carries an expiry. Detection is unaffected by that
@@ -458,7 +458,7 @@ Per-issue `label-review` reaction lifecycle (the `issue_id:label-review` slot):
 | pending | Reconcile tick, new events but no confirmed command (retraction, foreign or unlabeled only, or collapse into an outstanding command) | pending | Advance the mark; re-enqueue at the poll interval; no dispatch. |
 | pending | Reconcile tick, confirmed command, none queued or running | dispatched | Advance the mark; schedule the read-only dispatch; remove the label best-effort; re-enqueue at the poll interval. |
 | pending | Reconcile tick, confirmed command, a `label-review` command already queued or running | pending | Advance the mark; re-enqueue; the gesture collapses into the outstanding command. |
-| pending | Issue reaches terminal state (tracker reconcile) | pending | No effect: the tracker-reconcile terminal-state path does not call `ClearReactionsForIssue`, and this kind carries no TTL to drop the entry on its own. Detection keeps polling. |
+| pending | Issue reaches terminal state (tracker reconcile) | (none) | Drop the pending entry; cancel and delete the issue's retry; release the claim. Detection stops polling on the next tick. |
 
 Per-issue `label-fix` reaction lifecycle (the `issue_id:label-fix` slot) follows the same three
 states, differing only in the seeding and recovery guard and in which dispatch the confirmed-command
@@ -474,7 +474,7 @@ transition schedules:
 | pending | Reconcile tick, new events but no confirmed command (retraction, foreign or unlabeled only, or collapse into an outstanding command) | pending | Advance the mark; re-enqueue at the poll interval; no dispatch. |
 | pending | Reconcile tick, confirmed command, none queued or running | dispatched | Advance the mark; schedule the fix dispatch (§11F.13); remove the label best-effort; re-enqueue at the poll interval. |
 | pending | Reconcile tick, confirmed command, a `label-fix` command already queued or running | pending | Advance the mark; re-enqueue; the gesture collapses into the outstanding command. |
-| pending | Issue reaches terminal state (tracker reconcile) | pending | No effect: the tracker-reconcile terminal-state path does not call `ClearReactionsForIssue`, and this kind carries no TTL to drop the entry on its own. Detection keeps polling. |
+| pending | Issue reaches terminal state (tracker reconcile) | (none) | Drop the pending entry; cancel and delete the issue's retry; release the claim. Detection stops polling on the next tick. |
 
 A PR record whose head branch is empty seeds and recovers no `label-fix` entry at all: the slot
 stays absent rather than entering `pending`, because a fix session with nothing to check out is

--- a/docs/gitea-adapter-notes.md
+++ b/docs/gitea-adapter-notes.md
@@ -207,7 +207,7 @@ The GitHub adapter serves the terminal half through the search endpoint with a s
 
 ### 4. `FetchIssueStatesByIDs` and 5. `FetchIssueStatesByIdentifiers`
 
-Gitea has no bulk state-by-ids route. The adapter loops `GET .../issues/{index}` per requested id, skipping 404s (issues not found are omitted from the map, per the interface contract) and skipping PR entries. Both methods share one implementation because ID and Identifier are the same value. Conditional requests are not worth wiring: Gitea sends no `ETag` on API responses (verified), so the GitHub adapter's ETag cache pattern has nothing to key on. Reconciliation touches only the handful of currently running issues per tick, and the instance applies no rate limits, so the per-issue loop is acceptable as-is.
+Gitea has no bulk state-by-ids route. The adapter loops `GET .../issues/{index}` per requested id, skipping 404s (issues not found are omitted from the map, per the interface contract) and skipping PR entries. Both methods share one implementation because ID and Identifier are the same value. Conditional requests are not worth wiring: Gitea sends no `ETag` on API responses (verified), so the GitHub adapter's ETag cache pattern has nothing to key on. Reconciliation requests the running issues plus every issue holding a pending reaction entry per tick, and the instance applies no rate limits, so the per-issue loop is acceptable as-is.
 
 ### 6. `FetchIssueComments`
 

--- a/internal/orchestrator/auto_merge_reconcile.go
+++ b/internal/orchestrator/auto_merge_reconcile.go
@@ -99,6 +99,7 @@ func reconcileAutoMerge(state *State, params ReconcileParams, log *slog.Logger, 
 		}
 
 		if ttl > 0 && now.Sub(pending.CreatedAt) > ttl {
+			delete(state.ReactionAttempts, ReactionKey(pending.IssueID, ReactionKindAutoMerge))
 			entryLog.Warn("auto_merge pending entry exceeded ttl, dropping",
 				slog.Int64("ttl_ms", int64(ttl/time.Millisecond)),
 				slog.Int64("age_ms", int64(now.Sub(pending.CreatedAt)/time.Millisecond)),

--- a/internal/orchestrator/auto_merge_reconcile_test.go
+++ b/internal/orchestrator/auto_merge_reconcile_test.go
@@ -1019,6 +1019,60 @@ func TestReconcileAutoMerge_TTLExpiry(t *testing.T) {
 	}
 }
 
+// TestReconcileAutoMerge_DropOnAgeReleasesCounter verifies that the
+// drop-on-age branch also deletes the merge reaction attempt counter,
+// leaves a sibling kind's counter and the claim untouched, and performs
+// no retry or fingerprint store call.
+func TestReconcileAutoMerge_DropOnAgeReleasesCounter(t *testing.T) {
+	t.Parallel()
+
+	issueID := "AM-AGE-1"
+	state := stateWithAutoMergePending(t, issueID, 20)
+	mergeKey := ReactionKey(issueID, ReactionKindAutoMerge)
+	state.ReactionAttempts[mergeKey] = 3
+	state.PendingReactions[mergeKey].CreatedAt = autoMergeBaseTime.Add(-40 * time.Minute)
+	ciKey := ReactionKey(issueID, ReactionKindCI)
+	state.ReactionAttempts[ciKey] = 6
+
+	store := &reviewReconcileStore{}
+	metrics := newAutoMergeMetricsSpy()
+
+	var mergeCalled bool
+	scm := &controlledSCMAdapter{
+		mergePRFn: func(_ context.Context, _ int, _, _ string, _ domain.MergeStrategy, _, _, _ string) (domain.MergeResult, error) {
+			mergeCalled = true
+			return domain.MergeResult{}, nil
+		},
+	}
+	params := autoMergeParams(store, scm, nil)
+	params.AutoMergePendingTTL = 30 * time.Minute
+
+	reconcileAutoMerge(state, params, discardLogger(), context.Background(), metrics)
+
+	if mergeCalled {
+		t.Error("MergePR called for TTL-expired entry; want dropped before fetch")
+	}
+	if _, ok := state.PendingReactions[mergeKey]; ok {
+		t.Error("PendingReactions[merge] present after drop-on-age; want removed")
+	}
+	if _, ok := state.ReactionAttempts[mergeKey]; ok {
+		t.Error("ReactionAttempts[merge] present after drop-on-age; want removed")
+	}
+	if state.ReactionAttempts[ciKey] != 6 {
+		t.Errorf("ReactionAttempts[ci] = %d, want 6 (untouched)", state.ReactionAttempts[ciKey])
+	}
+	if _, ok := state.Claimed[issueID]; ok {
+		t.Error("Claimed present after drop-on-age; want absent")
+	}
+	if len(store.deletedIssueIDs) != 0 {
+		t.Errorf("DeleteRetryEntry calls = %d, want 0", len(store.deletedIssueIDs))
+	}
+	if store.upsertFingerprintCalls != 0 || store.getFingerprintCalls != 0 || store.deleteFingerprintCalls != 0 {
+		t.Errorf("fingerprint calls = upsert:%d get:%d delete:%d, want all 0",
+			store.upsertFingerprintCalls, store.getFingerprintCalls, store.deleteFingerprintCalls)
+	}
+}
+
 // --- Pure function tests ---
 
 // TestBuildAutoMergeFingerprint verifies the SHA-256 hex fingerprint builder.

--- a/internal/orchestrator/bot_review_reconcile.go
+++ b/internal/orchestrator/bot_review_reconcile.go
@@ -57,6 +57,7 @@ func reconcileBotReviewComments(state *State, params ReconcileParams, log *slog.
 
 		// TTL enforcement.
 		if ttl > 0 && now.Sub(pending.CreatedAt) > ttl {
+			delete(state.ReactionAttempts, ReactionKey(pending.IssueID, ReactionKindBotReview))
 			entryLog.Warn("bot review pending entry exceeded ttl, dropping",
 				slog.Int64("ttl_ms", int64(ttl/time.Millisecond)),
 				slog.Int64("age_ms", int64(now.Sub(pending.CreatedAt)/time.Millisecond)),

--- a/internal/orchestrator/bot_review_reconcile_test.go
+++ b/internal/orchestrator/bot_review_reconcile_test.go
@@ -1057,6 +1057,54 @@ func TestReconcileBotReviewComments_TTLDrop(t *testing.T) {
 	}
 }
 
+// TestReconcileBotReviewComments_DropOnAgeReleasesCounter verifies that the
+// drop-on-age branch also deletes the bot-review reaction attempt counter,
+// leaves a sibling kind's counter and the claim untouched, and performs
+// no retry or fingerprint store call.
+func TestReconcileBotReviewComments_DropOnAgeReleasesCounter(t *testing.T) {
+	t.Parallel()
+
+	issueID := "BOT-AGE-1"
+	state := stateWithBotReviewReaction(t, issueID, 10)
+	botKey := ReactionKey(issueID, ReactionKindBotReview)
+	state.ReactionAttempts[botKey] = 2
+	reviewKey := ReactionKey(issueID, ReactionKindReview)
+	state.ReactionAttempts[reviewKey] = 9
+	delete(state.Claimed, issueID)
+
+	store := &reviewReconcileStore{}
+	metrics := newBotReviewMetricsSpy()
+	scm := &mockSCMAdapter{}
+	params := botReviewParams(store, scm, nil)
+	params.BotReviewPendingTTL = 1 * time.Minute
+	params.NowFunc = func() time.Time { return botReviewBaseTime.Add(2 * time.Minute) }
+
+	reconcileBotReviewComments(state, params, discardLogger(), context.Background(), metrics)
+
+	if _, ok := state.PendingReactions[botKey]; ok {
+		t.Error("PendingReactions[bot-review] present after drop-on-age; want removed")
+	}
+	if _, ok := state.ReactionAttempts[botKey]; ok {
+		t.Error("ReactionAttempts[bot-review] present after drop-on-age; want removed")
+	}
+	if state.ReactionAttempts[reviewKey] != 9 {
+		t.Errorf("ReactionAttempts[review] = %d, want 9 (untouched)", state.ReactionAttempts[reviewKey])
+	}
+	if _, ok := state.Claimed[issueID]; ok {
+		t.Error("Claimed present after drop-on-age; want absent")
+	}
+	if len(store.deletedIssueIDs) != 0 {
+		t.Errorf("DeleteRetryEntry calls = %d, want 0", len(store.deletedIssueIDs))
+	}
+	if store.upsertFingerprintCalls != 0 || store.getFingerprintCalls != 0 || store.deleteFingerprintCalls != 0 {
+		t.Errorf("fingerprint calls = upsert:%d get:%d delete:%d, want all 0",
+			store.upsertFingerprintCalls, store.getFingerprintCalls, store.deleteFingerprintCalls)
+	}
+	if scm.botCalls != 0 {
+		t.Errorf("FetchBotReviewComments calls = %d, want 0 (TTL drop before fetch)", scm.botCalls)
+	}
+}
+
 // TestReconcileBotReviewComments_ZeroPollIntervalUsesFallback verifies that a
 // zero PollIntervalMS falls back to the default backoff base when re-enqueuing
 // a pending entry with no actionable comments.

--- a/internal/orchestrator/ci_reconcile.go
+++ b/internal/orchestrator/ci_reconcile.go
@@ -83,6 +83,7 @@ func reconcileCIStatus(state *State, params ReconcileParams, log *slog.Logger, c
 		entryLog := logging.WithIssue(log, pending.IssueID, pending.Identifier)
 
 		if ttl > 0 && now.Sub(pending.CreatedAt) > ttl {
+			delete(state.ReactionAttempts, ReactionKey(pending.IssueID, ReactionKindCI))
 			entryLog.Warn("ci pending entry exceeded ttl, dropping",
 				slog.Int64("ttl_ms", int64(ttl/time.Millisecond)),
 				slog.Int64("age_ms", int64(now.Sub(pending.CreatedAt)/time.Millisecond)),
@@ -344,9 +345,9 @@ func escalateCIFailure(
 
 	delete(state.Claimed, pending.IssueID)
 
-	// Scoped per-kind delete (not the issue-wide ClearReactionsForIssue)
-	// so sibling reactions' pending entries, counters, and fingerprints
-	// for the same issue survive a CI-only escalation.
+	// Scoped to this kind's own slot: a sibling reaction's pending
+	// entry, counter, and fingerprint for the same issue survive a
+	// CI-only escalation.
 	delete(state.PendingReactions, ReactionKey(pending.IssueID, ReactionKindCI))
 	delete(state.ReactionAttempts, ReactionKey(pending.IssueID, ReactionKindCI))
 	if err := params.Store.DeleteReactionFingerprint(ctx, pending.IssueID, ReactionKindCI); err != nil {

--- a/internal/orchestrator/ci_reconcile_test.go
+++ b/internal/orchestrator/ci_reconcile_test.go
@@ -36,17 +36,15 @@ type ciReconcileStore struct {
 	deletedIssueIDs []string
 	runHistories    []persistence.RunHistory
 
-	saveRetryEntryErr                    error
-	deleteRetryEntryErr                  error
-	appendRunHistoryErr                  error
-	deleteReactionFingerprintsByIssueErr error
+	saveRetryEntryErr   error
+	deleteRetryEntryErr error
+	appendRunHistoryErr error
 
 	// Fingerprint dedup fields.
 	upsertFingerprintCalls int
 	getFingerprintCalls    int
 	markDispatchedCalls    int
 	deleteFingerprintCalls int
-	deleteFPByIssueCalls   int
 
 	upsertFingerprintErr     error
 	getFingerprintResult     string
@@ -71,11 +69,6 @@ func (s *ciReconcileStore) DeleteRetryEntry(_ context.Context, issueID string) e
 func (s *ciReconcileStore) AppendRunHistory(_ context.Context, run persistence.RunHistory) (persistence.RunHistory, error) {
 	s.runHistories = append(s.runHistories, run)
 	return run, s.appendRunHistoryErr
-}
-
-func (s *ciReconcileStore) DeleteReactionFingerprintsByIssue(_ context.Context, _ string) error {
-	s.deleteFPByIssueCalls++
-	return s.deleteReactionFingerprintsByIssueErr
 }
 
 func (s *ciReconcileStore) UpsertReactionFingerprint(_ context.Context, _, _, _ string) error {
@@ -1042,6 +1035,54 @@ func TestReconcileCIStatus_TTLExpiry(t *testing.T) {
 	}
 }
 
+// TestReconcileCIStatus_DropOnAgeReleasesCounter verifies that the
+// drop-on-age branch also deletes the ci reaction attempt counter, leaves
+// a sibling kind's counter and the claim untouched, and performs no retry
+// or fingerprint store call.
+func TestReconcileCIStatus_DropOnAgeReleasesCounter(t *testing.T) {
+	t.Parallel()
+
+	issueID := "CI-AGE-1"
+	state := stateWithPendingReaction(t, issueID, "main", 1)
+	ciKey := ReactionKey(issueID, ReactionKindCI)
+	state.ReactionAttempts[ciKey] = 2
+	reviewKey := ReactionKey(issueID, ReactionKindReview)
+	state.ReactionAttempts[reviewKey] = 4
+	delete(state.Claimed, issueID)
+
+	store := &ciReconcileStore{}
+	metrics := newCIMetricsSpy()
+	ci := &mockCIProvider{result: domain.CIResult{Status: domain.CIStatusPending}}
+	params := ciParams(t, store, ci, nil)
+	params.CIPendingTTL = 30 * time.Minute
+	params.NowFunc = func() time.Time { return ciBaseTime.Add(31 * time.Minute) }
+
+	reconcileCIStatus(state, params, discardLogger(), context.Background(), metrics)
+
+	if _, ok := state.PendingReactions[ciKey]; ok {
+		t.Error("PendingReactions[ci] present after drop-on-age; want removed")
+	}
+	if _, ok := state.ReactionAttempts[ciKey]; ok {
+		t.Error("ReactionAttempts[ci] present after drop-on-age; want removed")
+	}
+	if state.ReactionAttempts[reviewKey] != 4 {
+		t.Errorf("ReactionAttempts[review] = %d, want 4 (untouched)", state.ReactionAttempts[reviewKey])
+	}
+	if _, ok := state.Claimed[issueID]; ok {
+		t.Error("Claimed present after drop-on-age; want absent")
+	}
+	if len(store.deletedIssueIDs) != 0 {
+		t.Errorf("DeleteRetryEntry calls = %d, want 0", len(store.deletedIssueIDs))
+	}
+	if store.upsertFingerprintCalls != 0 || store.getFingerprintCalls != 0 || store.deleteFingerprintCalls != 0 {
+		t.Errorf("fingerprint calls = upsert:%d get:%d delete:%d, want all 0",
+			store.upsertFingerprintCalls, store.getFingerprintCalls, store.deleteFingerprintCalls)
+	}
+	if ci.calls != 0 {
+		t.Errorf("FetchCIStatus calls = %d, want 0 (TTL exceeded before fetch)", ci.calls)
+	}
+}
+
 // --- Fingerprint dedup tests ---
 
 // TestReconcileCIStatus_DedupSkip verifies that when GetReactionFingerprint
@@ -1296,8 +1337,7 @@ func TestEscalateCIFailure_DeletesFingerprint(t *testing.T) {
 // that CI escalation clears only the CI reaction's own pending entry,
 // counter, and fingerprint. A sibling merge-completion entry parked on the
 // same issue (seeded from the same worker exit as the CI reaction) must
-// survive: the escalation must not call the issue-wide
-// DeleteReactionFingerprintsByIssue.
+// survive: the escalation must not clear it.
 func TestReconcileCIStatus_Failing_ExceedsMaxRetries_CrossKindIsolation(t *testing.T) {
 	t.Parallel()
 
@@ -1329,9 +1369,6 @@ func TestReconcileCIStatus_Failing_ExceedsMaxRetries_CrossKindIsolation(t *testi
 	}
 	if state.ReactionAttempts[ReactionKey(issueID, ReactionKindMergeCompletion)] != 1 {
 		t.Error("sibling merge-completion ReactionAttempts counter altered by CI escalation; want untouched")
-	}
-	if store.deleteFPByIssueCalls != 0 {
-		t.Errorf("DeleteReactionFingerprintsByIssue calls = %d, want 0 (escalation must be scoped to CI)", store.deleteFPByIssueCalls)
 	}
 	if store.deleteFingerprintCalls != 1 {
 		t.Errorf("DeleteReactionFingerprint calls = %d, want 1 (the CI kind's own fingerprint)", store.deleteFingerprintCalls)

--- a/internal/orchestrator/dispatch_test.go
+++ b/internal/orchestrator/dispatch_test.go
@@ -353,6 +353,37 @@ func TestShouldDispatch(t *testing.T) {
 	}
 }
 
+// TestShouldDispatch_ReopenAfterTerminalRelease verifies that releasing an
+// issue's claim through [releaseTerminalIssueState] makes it dispatchable
+// again once the tracker reports it back in an active state, and that the
+// same evaluation returns false beforehand while the claim is still held.
+func TestShouldDispatch_ReopenAfterTerminalRelease(t *testing.T) {
+	t.Parallel()
+
+	active := []string{"To Do"}
+	terminal := []string{"Done"}
+	issue := domain.Issue{ID: "REOPEN-1", Identifier: "REOPEN-1", Title: "T", State: "To Do"}
+
+	state := NewState(1000, 10, nil, AgentTotals{})
+	state.Claimed[issue.ID] = struct{}{}
+
+	if ShouldDispatch(issue, state, active, terminal) {
+		t.Fatal("ShouldDispatch = true while the claim is still held before release; want false")
+	}
+
+	store := &mockReconcileStore{}
+	releaseTerminalIssueState(context.Background(), state, store, issue.ID, discardLogger())
+
+	if len(state.Running) != 0 || len(state.RetryAttempts) != 0 || len(state.BudgetExhausted) != 0 {
+		t.Fatalf("state not empty after release: running=%d retry=%d budget=%d",
+			len(state.Running), len(state.RetryAttempts), len(state.BudgetExhausted))
+	}
+
+	if !ShouldDispatch(issue, state, active, terminal) {
+		t.Error("ShouldDispatch = false after terminal release and reopen into an active state; want true")
+	}
+}
+
 func TestIsBlockedByNonTerminal(t *testing.T) {
 	t.Parallel()
 

--- a/internal/orchestrator/label_fix_reconcile_test.go
+++ b/internal/orchestrator/label_fix_reconcile_test.go
@@ -51,10 +51,6 @@ func (s *labelFixDispatchedFlagStore) AppendRunHistory(_ context.Context, run pe
 	return run, nil
 }
 
-func (s *labelFixDispatchedFlagStore) DeleteReactionFingerprintsByIssue(_ context.Context, _ string) error {
-	return nil
-}
-
 func (s *labelFixDispatchedFlagStore) MarkReactionDispatched(_ context.Context, _, _ string) error {
 	return nil
 }

--- a/internal/orchestrator/label_review_reconcile_test.go
+++ b/internal/orchestrator/label_review_reconcile_test.go
@@ -167,10 +167,6 @@ func (s *labelReviewFingerprintStore) AppendRunHistory(_ context.Context, run pe
 	return run, nil
 }
 
-func (s *labelReviewFingerprintStore) DeleteReactionFingerprintsByIssue(_ context.Context, _ string) error {
-	return nil
-}
-
 func (s *labelReviewFingerprintStore) MarkReactionDispatched(_ context.Context, _, _ string) error {
 	return nil
 }
@@ -947,6 +943,56 @@ func TestReconcileLabelReviewCommands_JournalSubstrateNotSnapshot(t *testing.T) 
 
 	if _, ok := state.RetryAttempts[issueID]; !ok {
 		t.Error("dispatch did not fire; want scheduled using only ListLabelEvents/RemoveLabel")
+	}
+}
+
+// TestReconcileLabelCommands_StopPollingAfterTerminal covers both label
+// kinds together: neither has a TTL of its own, so the terminal-state
+// release inside reconcileTrackerState is the only mechanism that ever
+// stops their journal polling. Uses the labelReviewSCMFake and
+// labelReviewFingerprintStore declared above, shared with
+// label_fix_reconcile_test.go, since neither double is label-review- or
+// label-fix-specific.
+func TestReconcileLabelCommands_StopPollingAfterTerminal(t *testing.T) {
+	t.Parallel()
+
+	const issueID = "LBL-TERM"
+	state := stateWithLabelReviewPending(t, issueID, 42)
+	fixKey := ReactionKey(issueID, ReactionKindLabelFix)
+	state.PendingReactions[fixKey] = newLabelFixPending(issueID, 42, "feature/lbl-term")
+
+	store := newLabelReviewFingerprintStore()
+	scm := &labelReviewSCMFake{}
+	tracker := &mockReconcileTracker{states: map[string]string{issueID: "Done"}}
+
+	params := ReconcileParams{
+		TrackerAdapter:                tracker,
+		ActiveStates:                  []string{"In Progress"},
+		TerminalStates:                []string{"Done"},
+		SCMAdapter:                    scm,
+		LabelReviewConfig:             defaultLabelReviewConfig(),
+		LabelReviewReactionConfigured: true,
+		LabelFixConfig:                defaultLabelFixConfig(),
+		LabelFixReactionConfigured:    true,
+		Store:                         store,
+		OnRetryFire:                   noopRetryFire,
+		Ctx:                           context.Background(),
+		Logger:                        discardLogger(),
+		NowFunc:                       func() time.Time { return labelReviewBaseTime },
+	}
+
+	ReconcileRunningIssues(state, params)
+	ReconcileRunningIssues(state, params)
+
+	if scm.listCalls != 0 {
+		t.Errorf("ListLabelEvents calls = %d, want 0 across both ticks", scm.listCalls)
+	}
+	reviewKey := ReactionKey(issueID, ReactionKindLabelReview)
+	if _, ok := state.PendingReactions[reviewKey]; ok {
+		t.Error("PendingReactions[label-review] present after terminal release; want removed")
+	}
+	if _, ok := state.PendingReactions[fixKey]; ok {
+		t.Error("PendingReactions[label-fix] present after terminal release; want removed")
 	}
 }
 

--- a/internal/orchestrator/merge_completion_reconcile_test.go
+++ b/internal/orchestrator/merge_completion_reconcile_test.go
@@ -150,10 +150,11 @@ type mgcStoreFake struct {
 	getErr    error
 	markErr   error
 
-	upsertCalls        int
-	getCalls           int
-	markCalls          int
-	deleteByIssueCalls int
+	upsertCalls      int
+	getCalls         int
+	markCalls        int
+	deleteCalls      int
+	deleteRetryCalls int
 }
 
 var _ ReconcileStore = (*mgcStoreFake)(nil)
@@ -163,20 +164,12 @@ func newMGCStore() *mgcStoreFake {
 }
 
 func (s *mgcStoreFake) SaveRetryEntry(context.Context, persistence.RetryEntry) error { return nil }
-func (s *mgcStoreFake) DeleteRetryEntry(context.Context, string) error               { return nil }
+func (s *mgcStoreFake) DeleteRetryEntry(context.Context, string) error {
+	s.deleteRetryCalls++
+	return nil
+}
 func (s *mgcStoreFake) AppendRunHistory(_ context.Context, run persistence.RunHistory) (persistence.RunHistory, error) {
 	return run, nil
-}
-
-func (s *mgcStoreFake) DeleteReactionFingerprintsByIssue(_ context.Context, issueID string) error {
-	s.deleteByIssueCalls++
-	prefix := issueID + ":"
-	for key := range s.fingerprints {
-		if strings.HasPrefix(key, prefix) {
-			delete(s.fingerprints, key)
-		}
-	}
-	return nil
 }
 
 func (s *mgcStoreFake) UpsertReactionFingerprint(_ context.Context, issueID, kind, fingerprint string) error {
@@ -216,6 +209,7 @@ func (s *mgcStoreFake) MarkReactionDispatched(_ context.Context, issueID, kind s
 }
 
 func (s *mgcStoreFake) DeleteReactionFingerprint(_ context.Context, issueID, kind string) error {
+	s.deleteCalls++
 	delete(s.fingerprints, issueID+":"+kind)
 	return nil
 }
@@ -676,8 +670,8 @@ func TestReconcileMergeCompletion_NotFoundStopsWithoutEscalating(t *testing.T) {
 }
 
 // Escalation dispatches AddLabel for "label" and CommentIssue for
-// "comment", never touches ClearReactionsForIssue-scoped state, and a
-// sibling CI pending entry for the same issue survives.
+// "comment", never touches an issue-wide reaction slot, and a sibling CI
+// pending entry for the same issue survives.
 
 func TestReconcileMergeCompletion_EscalationDispatchesConfiguredAction(t *testing.T) {
 	t.Parallel()
@@ -717,9 +711,6 @@ func TestReconcileMergeCompletion_EscalationDispatchesConfiguredAction(t *testin
 		}
 		if _, claimed := state.Claimed[issueID]; claimed {
 			t.Error("state.Claimed gained an entry from merge-completion escalation; want untouched")
-		}
-		if store.deleteByIssueCalls != 0 {
-			t.Errorf("DeleteReactionFingerprintsByIssue calls = %d, want 0 (escalation never clears issue-wide)", store.deleteByIssueCalls)
 		}
 	})
 
@@ -878,90 +869,6 @@ func TestReconcileMergeCompletion_MarkDispatchedFailureIsAcceptedResidue(t *test
 	}
 }
 
-// An issue-wide clear (the mechanism the CI and review escalations
-// call) removes both the merge-completion and a sibling CI entry and
-// deletes the merge-completion fingerprint row; the next tick performs
-// no forge call; a following recovery pass re-creates the entry.
-
-func TestReconcileMergeCompletion_ClearReactionsForIssueCrossKindInteraction(t *testing.T) {
-	t.Parallel()
-
-	issueID := "MGC-23"
-	identifier := "PROJ-MGC23"
-	state := mgcStateWithPending(issueID, 26)
-
-	ciKey := ReactionKey(issueID, ReactionKindCI)
-	state.PendingReactions[ciKey] = &PendingReaction{
-		IssueID: issueID, Identifier: identifier, Kind: ReactionKindCI,
-		CreatedAt: mgcBaseTime, KindData: &CIReactionData{Branch: "feature/mgc23"},
-	}
-
-	store := newMGCStore()
-	mcKey := ReactionKey(issueID, ReactionKindMergeCompletion)
-	store.fingerprints[mcKey] = mgcFingerprintRecord{fingerprint: "sha-23", dispatched: false}
-
-	ClearReactionsForIssue(context.Background(), state, store, issueID, discardLogger())
-
-	if _, ok := state.PendingReactions[mcKey]; ok {
-		t.Error("merge-completion PendingReactions entry survived ClearReactionsForIssue, want removed")
-	}
-	if _, ok := state.PendingReactions[ciKey]; ok {
-		t.Error("CI PendingReactions entry survived ClearReactionsForIssue, want removed")
-	}
-	if _, ok := store.has(issueID); ok {
-		t.Error("merge-completion fingerprint row survived ClearReactionsForIssue, want deleted")
-	}
-
-	tracker := &mgcTrackerFake{states: map[string]string{issueID: "In Review"}}
-	scm := &mgcSCMFake{}
-	params := mgcParams(store, scm, tracker)
-
-	reconcileMergeCompletion(state, params, discardLogger(), context.Background(), &domain.NoopMetrics{})
-
-	if got := scm.calls.Load(); got != 0 {
-		t.Errorf("GetMergeability calls = %d, want 0 (no pending entry survives the clear)", got)
-	}
-	if len(tracker.transitionCalls) != 0 {
-		t.Errorf("TransitionIssue calls = %d, want 0", len(tracker.transitionCalls))
-	}
-
-	// A recovery pass over run history, with the tracker reporting the
-	// handoff state and the workspace metadata intact, re-creates the
-	// merge-completion entry.
-	wsRoot := t.TempDir()
-	writeRecoverySCM(t, wsRoot, identifier, domain.SCMMetadata{
-		Branch:   "feature/mgc23",
-		SHA:      "headsha",
-		PushedAt: freshSCMTime(1),
-		PRNumber: 26,
-		Owner:    "owner",
-		Repo:     "repo",
-	})
-	run := freshRun(issueID, identifier, "owner/repo#26", 1)
-	recoverParams := PendingReactionRecoveryParams{
-		WorkspaceRoot:                     wsRoot,
-		TrackerAdapter:                    tracker,
-		HandoffState:                      "In Review",
-		TerminalStates:                    []string{"Done"},
-		SCMAdapter:                        scm,
-		MergeCompletionReactionConfigured: true,
-		RecoveryLookback:                  PendingReactionRecoveryLookback,
-		MaxCandidates:                     PendingReactionRecoveryMaxCandidates,
-		NowFunc:                           func() time.Time { return recoveryNow },
-		Logger:                            discardLogger(),
-	}
-	result, err := RecoverPendingReactions(context.Background(), state, []persistence.RunHistory{run}, recoverParams)
-	if err != nil {
-		t.Fatalf("RecoverPendingReactions: %v", err)
-	}
-	if result.MergeCompletionRecovered != 1 {
-		t.Errorf("MergeCompletionRecovered = %d, want 1", result.MergeCompletionRecovered)
-	}
-	if _, ok := state.PendingReactions[mcKey]; !ok {
-		t.Error("merge-completion PendingReactions entry not re-created by recovery")
-	}
-}
-
 // SweepWorkspaces collects a workspace as terminal only when the
 // tracker-reported state is a member of the written TerminalStates
 // list, not a defaulted one.
@@ -1066,5 +973,55 @@ func TestReconcileMergeCompletion_TerminalDriftWarningFiresOncePerOnset(t *testi
 
 	if out := tick(nil); !strings.Contains(out, driftMessage) {
 		t.Errorf("tick 4 (second onset) log = %q, want a second WARN", out)
+	}
+}
+
+// TestReconcileTrackerState_TerminalReleasePreservesFingerprints verifies
+// that releasing a merge-completion pending entry through the terminal
+// tracker-state path performs no reaction_fingerprints read or write,
+// leaving a dispatched fingerprint row byte-identical.
+func TestReconcileTrackerState_TerminalReleasePreservesFingerprints(t *testing.T) {
+	t.Parallel()
+
+	issueID := "MGC-TERM"
+	state := mgcStateWithPending(issueID, 10)
+	state.Claimed[issueID] = struct{}{}
+
+	store := newMGCStore()
+	if err := store.UpsertReactionFingerprint(context.Background(), issueID, ReactionKindMergeCompletion, "sha-abc123"); err != nil {
+		t.Fatalf("seed UpsertReactionFingerprint: %v", err)
+	}
+	if err := store.MarkReactionDispatched(context.Background(), issueID, ReactionKindMergeCompletion); err != nil {
+		t.Fatalf("seed MarkReactionDispatched: %v", err)
+	}
+	before, ok := store.has(issueID)
+	if !ok {
+		t.Fatal("fingerprint row not seeded")
+	}
+	store.upsertCalls = 0
+	store.getCalls = 0
+	store.markCalls = 0
+	store.deleteCalls = 0
+
+	tracker := &mgcTrackerFake{states: map[string]string{issueID: "Done"}}
+	scm := &mgcSCMFake{}
+	params := mgcParams(store, scm, tracker)
+
+	reconcileTrackerState(state, params, discardLogger(), context.Background(), &domain.NoopMetrics{})
+
+	if store.upsertCalls != 0 || store.getCalls != 0 || store.markCalls != 0 || store.deleteCalls != 0 {
+		t.Errorf("fingerprint store calls = upsert:%d get:%d mark:%d delete:%d, want all 0",
+			store.upsertCalls, store.getCalls, store.markCalls, store.deleteCalls)
+	}
+	after, ok := store.has(issueID)
+	if !ok {
+		t.Fatal("fingerprint row deleted by terminal release; want preserved")
+	}
+	if after != before {
+		t.Errorf("fingerprint row = %+v, want unchanged %+v", after, before)
+	}
+	rkey := ReactionKey(issueID, ReactionKindMergeCompletion)
+	if _, ok := state.PendingReactions[rkey]; ok {
+		t.Error("PendingReactions entry survived terminal release; want removed")
 	}
 }

--- a/internal/orchestrator/merge_conflict_reconcile.go
+++ b/internal/orchestrator/merge_conflict_reconcile.go
@@ -69,6 +69,7 @@ func reconcileMergeConflicts(state *State, params ReconcileParams, log *slog.Log
 		entryLog := logging.WithIssue(log, pending.IssueID, pending.Identifier)
 
 		if ttl > 0 && now.Sub(pending.CreatedAt) > ttl {
+			delete(state.ReactionAttempts, ReactionKey(pending.IssueID, ReactionKindMergeConflict))
 			entryLog.Warn("merge conflict pending entry exceeded ttl, dropping",
 				slog.Int64("ttl_ms", int64(ttl/time.Millisecond)),
 				slog.Int64("age_ms", int64(now.Sub(pending.CreatedAt)/time.Millisecond)),
@@ -303,8 +304,8 @@ func buildMergeConflictTemplateMap(data *MergeConflictReactionData, status domai
 // Unlike the bot-review and auto-merge escalations, this resets the
 // per-episode attempt counter via a scoped delete because the
 // merge-conflict counter is episodic, mirroring the CI reaction. The reset
-// is the scoped per-kind delete (not the issue-wide ClearReactionsForIssue)
-// so sibling reactions' counters and state.Claimed are never touched.
+// is scoped to this kind's own slot, so sibling reactions' counters and
+// state.Claimed are never touched.
 func escalateMergeConflictFailure(
 	state *State,
 	params ReconcileParams,

--- a/internal/orchestrator/merge_conflict_reconcile_test.go
+++ b/internal/orchestrator/merge_conflict_reconcile_test.go
@@ -88,6 +88,7 @@ type statefulFingerprintStore struct {
 	getCalls            int
 	markDispatchedCalls int
 	deleteCalls         int
+	deleteRetryCalls    int
 
 	upsertErr error
 	getErr    error
@@ -157,12 +158,12 @@ func (s *statefulFingerprintStore) DeleteReactionFingerprint(_ context.Context, 
 	return nil
 }
 
-func (s *statefulFingerprintStore) DeleteRetryEntry(_ context.Context, _ string) error { return nil }
+func (s *statefulFingerprintStore) DeleteRetryEntry(_ context.Context, _ string) error {
+	s.deleteRetryCalls++
+	return nil
+}
 func (s *statefulFingerprintStore) AppendRunHistory(_ context.Context, run persistence.RunHistory) (persistence.RunHistory, error) {
 	return run, nil
-}
-func (s *statefulFingerprintStore) DeleteReactionFingerprintsByIssue(_ context.Context, _ string) error {
-	return nil
 }
 
 // has reports whether a fingerprint row exists for the issue+kind.
@@ -886,6 +887,54 @@ func TestReconcileMergeConflicts_EmptyBaseDefers(t *testing.T) {
 	}
 	if len(metrics.checks) != 0 {
 		t.Errorf("IncMergeConflictChecks called = %v, want none on empty-base defer", metrics.checks)
+	}
+}
+
+// TestReconcileMergeConflicts_DropOnAgeReleasesCounter verifies that the
+// drop-on-age branch also deletes the merge-conflict reaction attempt
+// counter, leaves a sibling kind's counter and the claim untouched, and
+// performs no retry or fingerprint store call.
+func TestReconcileMergeConflicts_DropOnAgeReleasesCounter(t *testing.T) {
+	t.Parallel()
+
+	issueID := "MC-AGE-1"
+	state := stateWithMergeConflict(t, issueID, 30)
+	mcKey := ReactionKey(issueID, ReactionKindMergeConflict)
+	state.ReactionAttempts[mcKey] = 2
+	state.PendingReactions[mcKey].CreatedAt = mcBaseTime.Add(-40 * time.Minute)
+	ciKey := ReactionKey(issueID, ReactionKindCI)
+	state.ReactionAttempts[ciKey] = 5
+	delete(state.Claimed, issueID)
+
+	store := newStatefulFingerprintStore()
+	metrics := newMergeConflictMetricsSpy()
+	scm := &mergeabilitySCM{}
+	params := mergeConflictParams(store, scm, nil)
+	params.MergeConflictPendingTTL = 30 * time.Minute
+
+	reconcileMergeConflicts(state, params, discardLogger(), context.Background(), metrics)
+
+	if scm.calls != 0 {
+		t.Errorf("GetMergeability calls = %d, want 0 (TTL exceeded before fetch)", scm.calls)
+	}
+	if _, ok := state.PendingReactions[mcKey]; ok {
+		t.Error("PendingReactions[merge-conflict] present after drop-on-age; want removed")
+	}
+	if _, ok := state.ReactionAttempts[mcKey]; ok {
+		t.Error("ReactionAttempts[merge-conflict] present after drop-on-age; want removed")
+	}
+	if state.ReactionAttempts[ciKey] != 5 {
+		t.Errorf("ReactionAttempts[ci] = %d, want 5 (untouched)", state.ReactionAttempts[ciKey])
+	}
+	if _, ok := state.Claimed[issueID]; ok {
+		t.Error("Claimed present after drop-on-age; want absent")
+	}
+	if store.deleteRetryCalls != 0 {
+		t.Errorf("DeleteRetryEntry calls = %d, want 0", store.deleteRetryCalls)
+	}
+	if store.upsertCalls != 0 || store.getCalls != 0 || store.deleteCalls != 0 {
+		t.Errorf("fingerprint calls = upsert:%d get:%d delete:%d, want all 0",
+			store.upsertCalls, store.getCalls, store.deleteCalls)
 	}
 }
 

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -38,7 +38,6 @@ type OrchestratorStore interface {
 	SumTotalTokensByIssue(ctx context.Context, issueID string) (int64, int, error)
 	QueryBudgetExhaustedIssues(ctx context.Context, candidateIDs []string, maxSessions int) ([]string, error)
 	QueryTokenExhaustedIssues(ctx context.Context, candidateIDs []string, maxTokens int) ([]string, error)
-	DeleteReactionFingerprintsByIssue(ctx context.Context, issueID string) error
 	UpsertReactionFingerprint(ctx context.Context, issueID, kind, fingerprint string) error
 	GetReactionFingerprint(ctx context.Context, issueID, kind string) (fingerprint string, dispatched bool, err error)
 	MarkReactionDispatched(ctx context.Context, issueID, kind string) error

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -192,10 +192,6 @@ func (s *stubStore) QueryTokenExhaustedIssues(_ context.Context, _ []string, _ i
 	return result, nil
 }
 
-func (s *stubStore) DeleteReactionFingerprintsByIssue(_ context.Context, _ string) error {
-	return nil
-}
-
 func (s *stubStore) UpsertReactionFingerprint(_ context.Context, _, _, _ string) error {
 	return nil
 }

--- a/internal/orchestrator/reconcile.go
+++ b/internal/orchestrator/reconcile.go
@@ -20,7 +20,6 @@ type ReconcileStore interface {
 	SaveRetryEntry(ctx context.Context, entry persistence.RetryEntry) error
 	DeleteRetryEntry(ctx context.Context, issueID string) error
 	AppendRunHistory(ctx context.Context, run persistence.RunHistory) (persistence.RunHistory, error)
-	DeleteReactionFingerprintsByIssue(ctx context.Context, issueID string) error
 	UpsertReactionFingerprint(ctx context.Context, issueID, kind, fingerprint string) error
 	GetReactionFingerprint(ctx context.Context, issueID, kind string) (fingerprint string, dispatched bool, err error)
 	MarkReactionDispatched(ctx context.Context, issueID, kind string) error
@@ -359,19 +358,114 @@ func reconcileStalled(state *State, params ReconcileParams, log *slog.Logger, ct
 	}
 }
 
-// reconcileTrackerState fetches current issue states for all running IDs
-// and cancels workers whose issues are terminal or no longer active.
+// trackerObservationIDs returns the deduplicated issue ids whose tracker
+// state [reconcileTrackerState] must refresh: every id in state.Running
+// plus every issue id carried by an entry in state.PendingReactions.
+//
+// Returns nil when both inputs are empty; callers must treat that as "make
+// no tracker call".
+func trackerObservationIDs(state *State) []string {
+	seen := make(map[string]struct{}, len(state.Running)+len(state.PendingReactions))
+	for id := range state.Running {
+		seen[id] = struct{}{}
+	}
+	for _, entry := range state.PendingReactions {
+		seen[entry.IssueID] = struct{}{}
+	}
+
+	ids := make([]string, 0, len(seen))
+	for id := range seen {
+		ids = append(ids, id)
+	}
+	return ids
+}
+
+// pendingReactionIdentifier returns the Identifier field of any
+// state.PendingReactions entry whose IssueID equals issueID, or the empty
+// string when none exists. Every pending entry for one issue carries the
+// same identifier, so the first match found is sufficient.
+func pendingReactionIdentifier(state *State, issueID string) string {
+	for _, entry := range state.PendingReactions {
+		if entry.IssueID == issueID {
+			return entry.Identifier
+		}
+	}
+	return ""
+}
+
+// terminalReleaseCounts reports one [releaseTerminalIssueState] call's
+// outcome, so the caller can log a single record and suppress it when
+// nothing was released.
+type terminalReleaseCounts struct {
+	PendingReleased  int
+	AttemptsReleased int
+	ClaimReleased    bool
+	RetryCancelled   bool
+}
+
+// releaseTerminalIssueState drops one issue's runtime reaction bookkeeping
+// and its dispatch claim: every pending reaction entry, every reaction
+// attempt counter, the pending retry, and the claim. It performs no
+// tracker call, no source-control call, no reaction-fingerprint read or
+// write, and no workspace removal.
+//
+// entryLog must already carry issue_id and issue_identifier, derived by
+// the caller before this function deletes the entries that hold the
+// identifier. Calling releaseTerminalIssueState twice for the same issue
+// is safe: the second call returns a zero-valued [terminalReleaseCounts].
+func releaseTerminalIssueState(ctx context.Context, state *State, store ReconcileStore, issueID string, entryLog *slog.Logger) terminalReleaseCounts {
+	prefix := issueID + ":"
+
+	var counts terminalReleaseCounts
+	for key := range state.PendingReactions {
+		if strings.HasPrefix(key, prefix) {
+			delete(state.PendingReactions, key)
+			counts.PendingReleased++
+		}
+	}
+	for key := range state.ReactionAttempts {
+		if strings.HasPrefix(key, prefix) {
+			delete(state.ReactionAttempts, key)
+			counts.AttemptsReleased++
+		}
+	}
+
+	if _, exists := state.RetryAttempts[issueID]; exists {
+		CancelRetry(state, issueID)
+		counts.RetryCancelled = true
+	}
+	// Deleted unconditionally: a persisted row can outlive its in-memory
+	// entry across a restart.
+	if err := store.DeleteRetryEntry(ctx, issueID); err != nil {
+		entryLog.Error("failed to delete retry entry for terminal issue",
+			slog.Any("error", err),
+		)
+	}
+
+	if _, exists := state.Claimed[issueID]; exists {
+		delete(state.Claimed, issueID)
+		counts.ClaimReleased = true
+	}
+
+	return counts
+}
+
+// reconcileTrackerState fetches current issue states for every running
+// issue and every issue holding a pending reaction entry, cancels workers
+// whose issues are terminal or no longer active, and releases the runtime
+// reaction bookkeeping of any issue the tracker reports terminal, whether
+// or not that issue has a running worker.
 func reconcileTrackerState(state *State, params ReconcileParams, log *slog.Logger, ctx context.Context, metrics domain.Metrics) {
-	if len(state.Running) == 0 {
+	if params.TrackerAdapter == nil {
 		return
 	}
 
-	runningIDs := make([]string, 0, len(state.Running))
-	for id := range state.Running {
-		runningIDs = append(runningIDs, id)
+	ids := trackerObservationIDs(state)
+	if len(ids) == 0 {
+		return
 	}
 
-	refreshed, err := params.TrackerAdapter.FetchIssueStatesByIDs(ctx, runningIDs)
+	refreshed, err := params.TrackerAdapter.FetchIssueStatesByIDs(ctx, ids)
 	if err != nil {
 		log.Warn("tracker state refresh failed, keeping workers running",
 			slog.Any("error", err),
@@ -383,35 +477,53 @@ func reconcileTrackerState(state *State, params ReconcileParams, log *slog.Logge
 	terminalSet := stateSet(params.TerminalStates)
 
 	for issueID, stateName := range refreshed {
-		entry, ok := state.Running[issueID]
-		if !ok {
-			continue
-		}
-
-		entryLog := logging.WithIssue(log, issueID, entry.Identifier)
+		entry := state.Running[issueID]
 
 		normalized := strings.ToLower(stateName)
 
 		if _, terminal := terminalSet[normalized]; terminal {
-			if entry.PendingCleanup {
+			identifier := pendingReactionIdentifier(state, issueID)
+			if entry != nil {
+				identifier = entry.Identifier
+			}
+			entryLog := logging.WithIssue(log, issueID, identifier)
+
+			if entry != nil && entry.PendingCleanup {
 				continue
 			}
-			if entry.CancelFunc != nil {
-				entry.CancelFunc()
+
+			var counts terminalReleaseCounts
+			if entry != nil {
+				if entry.CancelFunc != nil {
+					entry.CancelFunc()
+				}
+				counts = releaseTerminalIssueState(ctx, state, params.Store, issueID, entryLog)
+				entry.PendingCleanup = true
+				metrics.IncReconciliationActions(actionCleanup)
+				entryLog.Info("stopping worker for terminal issue",
+					slog.String("state", stateName),
+				)
+			} else {
+				counts = releaseTerminalIssueState(ctx, state, params.Store, issueID, entryLog)
 			}
-			CancelRetry(state, issueID)
-			if err := params.Store.DeleteRetryEntry(ctx, issueID); err != nil {
-				entryLog.Error("failed to delete retry entry for terminal issue",
-					slog.Any("error", err),
+
+			if counts.PendingReleased > 0 || counts.AttemptsReleased > 0 || counts.ClaimReleased || counts.RetryCancelled {
+				entryLog.Info("released reaction state for terminal issue",
+					slog.String("state", stateName),
+					slog.Int("pending_released", counts.PendingReleased),
+					slog.Int("attempts_released", counts.AttemptsReleased),
+					slog.Bool("claim_released", counts.ClaimReleased),
+					slog.Bool("retry_cancelled", counts.RetryCancelled),
 				)
 			}
-			entry.PendingCleanup = true
-			metrics.IncReconciliationActions(actionCleanup)
-			entryLog.Info("stopping worker for terminal issue",
-				slog.String("state", stateName),
-			)
 			continue
 		}
+
+		if entry == nil {
+			continue
+		}
+
+		entryLog := logging.WithIssue(log, issueID, entry.Identifier)
 
 		if _, active := activeSet[normalized]; active {
 			entry.Issue.State = stateName

--- a/internal/orchestrator/reconcile.go
+++ b/internal/orchestrator/reconcile.go
@@ -362,8 +362,8 @@ func reconcileStalled(state *State, params ReconcileParams, log *slog.Logger, ct
 // state [reconcileTrackerState] must refresh: every id in state.Running
 // plus every issue id carried by an entry in state.PendingReactions.
 //
-// Returns nil when both inputs are empty; callers must treat that as "make
-// no tracker call".
+// Returns an empty slice when both inputs are empty; callers must treat
+// that as "make no tracker call".
 func trackerObservationIDs(state *State) []string {
 	seen := make(map[string]struct{}, len(state.Running)+len(state.PendingReactions))
 	for id := range state.Running {

--- a/internal/orchestrator/reconcile_test.go
+++ b/internal/orchestrator/reconcile_test.go
@@ -29,6 +29,11 @@ type mockReconcileStore struct {
 
 	saveRetryEntryErr   error
 	deleteRetryEntryErr error
+
+	upsertFingerprintCalls int
+	getFingerprintCalls    int
+	markDispatchedCalls    int
+	deleteFingerprintCalls int
 }
 
 var _ ReconcileStore = (*mockReconcileStore)(nil)
@@ -47,23 +52,23 @@ func (m *mockReconcileStore) AppendRunHistory(_ context.Context, run persistence
 	return run, nil
 }
 
-func (m *mockReconcileStore) DeleteReactionFingerprintsByIssue(_ context.Context, _ string) error {
-	return nil
-}
-
 func (m *mockReconcileStore) UpsertReactionFingerprint(_ context.Context, _, _, _ string) error {
+	m.upsertFingerprintCalls++
 	return nil
 }
 
 func (m *mockReconcileStore) GetReactionFingerprint(_ context.Context, _, _ string) (string, bool, error) {
+	m.getFingerprintCalls++
 	return "", false, nil
 }
 
 func (m *mockReconcileStore) MarkReactionDispatched(_ context.Context, _, _ string) error {
+	m.markDispatchedCalls++
 	return nil
 }
 
 func (m *mockReconcileStore) DeleteReactionFingerprint(_ context.Context, _, _ string) error {
+	m.deleteFingerprintCalls++
 	return nil
 }
 
@@ -72,11 +77,18 @@ func (m *mockReconcileStore) DeleteReactionFingerprint(_ context.Context, _, _ s
 type mockReconcileTracker struct {
 	states   map[string]string
 	fetchErr error
+
+	calls      int
+	calledWith []string // copy of the ids passed to the most recent FetchIssueStatesByIDs call
 }
 
 var _ domain.TrackerAdapter = (*mockReconcileTracker)(nil)
 
-func (m *mockReconcileTracker) FetchIssueStatesByIDs(_ context.Context, _ []string) (map[string]string, error) {
+func (m *mockReconcileTracker) FetchIssueStatesByIDs(_ context.Context, ids []string) (map[string]string, error) {
+	m.calls++
+	cp := make([]string, len(ids))
+	copy(cp, ids)
+	m.calledWith = cp
 	return m.states, m.fetchErr
 }
 
@@ -163,6 +175,58 @@ func (s *sweepTracker) AddLabel(context.Context, string, string) error {
 	panic("AddLabel must not be called by SweepWorkspaces")
 }
 
+// panicOnAnySCMAdapter panics on every domain.SCMAdapter method. Used to
+// prove that a terminal-issue release triggers no SCM call of any kind.
+type panicOnAnySCMAdapter struct{}
+
+var _ domain.SCMAdapter = panicOnAnySCMAdapter{}
+
+func (panicOnAnySCMAdapter) FetchPendingReviews(context.Context, int, string, string) ([]domain.ReviewComment, error) {
+	panic("FetchPendingReviews must not be called after a terminal release")
+}
+
+func (panicOnAnySCMAdapter) FetchBotReviewComments(context.Context, int, string, string, []string) ([]domain.ReviewComment, error) {
+	panic("FetchBotReviewComments must not be called after a terminal release")
+}
+
+func (panicOnAnySCMAdapter) GetReviewDecision(context.Context, int, string, string) (domain.ReviewDecision, error) {
+	panic("GetReviewDecision must not be called after a terminal release")
+}
+
+func (panicOnAnySCMAdapter) GetCIStatus(context.Context, int, string, string) (string, error) {
+	panic("GetCIStatus must not be called after a terminal release")
+}
+
+func (panicOnAnySCMAdapter) GetMergeability(context.Context, int, string, string) (domain.PRMergeStatus, error) {
+	panic("GetMergeability must not be called after a terminal release")
+}
+
+func (panicOnAnySCMAdapter) MergePR(context.Context, int, string, string, domain.MergeStrategy, string, string, string) (domain.MergeResult, error) {
+	panic("MergePR must not be called after a terminal release")
+}
+
+func (panicOnAnySCMAdapter) DeleteBranch(context.Context, string, string, string) error {
+	panic("DeleteBranch must not be called after a terminal release")
+}
+
+func (panicOnAnySCMAdapter) ListLabelEvents(context.Context, int, string, string) ([]domain.LabelEvent, error) {
+	panic("ListLabelEvents must not be called after a terminal release")
+}
+
+func (panicOnAnySCMAdapter) RemoveLabel(context.Context, int, string, string, string) error {
+	panic("RemoveLabel must not be called after a terminal release")
+}
+
+// panicOnAnyCIProvider panics on every domain.CIStatusProvider method. Used
+// to prove that a terminal-issue release triggers no CI status read.
+type panicOnAnyCIProvider struct{}
+
+var _ domain.CIStatusProvider = panicOnAnyCIProvider{}
+
+func (panicOnAnyCIProvider) FetchCIStatus(context.Context, string) (domain.CIResult, error) {
+	panic("FetchCIStatus must not be called after a terminal release")
+}
+
 // --- Test helpers ---
 
 // reconcileBaseTime is a fixed reference for reconcile tests.
@@ -193,6 +257,49 @@ type cancelCounter struct {
 
 func (c *cancelCounter) cancel() {
 	c.count++
+}
+
+// terminalReleaseIssueID is the issue id used by the terminal-release test
+// fixture shared across the running-issue, fetch-failure, and
+// no-side-effects release tests.
+const terminalReleaseIssueID = "REL-1"
+
+// terminalReleaseFixtureKinds are the reaction kinds seeded on the shared
+// terminal-release fixture, one non-expiring (label-review) and two
+// expiring (ci, review), so the release is proven to span both shapes.
+var terminalReleaseFixtureKinds = []string{ReactionKindCI, ReactionKindReview, ReactionKindLabelReview}
+
+// stateWithTerminalReleaseFixture builds a State with a running entry for
+// [terminalReleaseIssueID] backed by cc, a live retry, a claim, and a
+// pending entry plus a non-zero attempt counter for each kind in
+// [terminalReleaseFixtureKinds].
+func stateWithTerminalReleaseFixture(t *testing.T, cc *cancelCounter) *State {
+	t.Helper()
+
+	state := NewState(5000, 4, nil, AgentTotals{})
+	state.Running[terminalReleaseIssueID] = &RunningEntry{
+		Identifier: terminalReleaseIssueID + "-ident",
+		StartedAt:  reconcileBaseTime,
+		CancelFunc: cc.cancel,
+		Issue:      domain.Issue{State: "In Progress"},
+	}
+	state.Claimed[terminalReleaseIssueID] = struct{}{}
+	state.RetryAttempts[terminalReleaseIssueID] = &RetryEntry{
+		IssueID:    terminalReleaseIssueID,
+		Identifier: terminalReleaseIssueID + "-ident",
+		Attempt:    1,
+	}
+	for _, kind := range terminalReleaseFixtureKinds {
+		key := ReactionKey(terminalReleaseIssueID, kind)
+		state.PendingReactions[key] = &PendingReaction{
+			IssueID:    terminalReleaseIssueID,
+			Identifier: terminalReleaseIssueID + "-ident",
+			Kind:       kind,
+			CreatedAt:  reconcileBaseTime,
+		}
+		state.ReactionAttempts[key] = 2
+	}
+	return state
 }
 
 // --- Part A: Stall detection tests ---
@@ -726,6 +833,305 @@ func TestReconcileTrackerState_DeleteRetryEntryError(t *testing.T) {
 	}
 	if len(store.deletedIssueID) != 1 {
 		t.Errorf("DeleteRetryEntry called %d times, want 1", len(store.deletedIssueID))
+	}
+}
+
+func TestReconcileTrackerState_RunningIssueReleasesReactionState(t *testing.T) {
+	t.Parallel()
+
+	cc := &cancelCounter{}
+	state := stateWithTerminalReleaseFixture(t, cc)
+
+	store := &mockReconcileStore{}
+	tracker := &mockReconcileTracker{states: map[string]string{terminalReleaseIssueID: "Done"}}
+	params := defaultReconcileParams(t, store, tracker)
+	params.StallTimeoutMS = 0
+
+	ReconcileRunningIssues(state, params)
+
+	for _, kind := range terminalReleaseFixtureKinds {
+		key := ReactionKey(terminalReleaseIssueID, kind)
+		if _, ok := state.PendingReactions[key]; ok {
+			t.Errorf("PendingReactions[%q] present after terminal release; want removed", key)
+		}
+		if _, ok := state.ReactionAttempts[key]; ok {
+			t.Errorf("ReactionAttempts[%q] present after terminal release; want removed", key)
+		}
+	}
+	if _, ok := state.Claimed[terminalReleaseIssueID]; ok {
+		t.Error("Claimed entry present after terminal release; want removed")
+	}
+	if _, ok := state.RetryAttempts[terminalReleaseIssueID]; ok {
+		t.Error("RetryAttempts entry present after terminal release; want removed")
+	}
+	if len(store.deletedIssueID) != 1 || store.deletedIssueID[0] != terminalReleaseIssueID {
+		t.Errorf("DeleteRetryEntry calls = %v, want exactly one call for %q", store.deletedIssueID, terminalReleaseIssueID)
+	}
+	if !state.Running[terminalReleaseIssueID].PendingCleanup {
+		t.Error("PendingCleanup not set for terminal running issue")
+	}
+}
+
+func TestReconcileTrackerState_PendingOnlyIssueReleasesReactionState(t *testing.T) {
+	t.Parallel()
+
+	issueID := "REL-2"
+	store := &mockReconcileStore{}
+	tracker := &mockReconcileTracker{states: map[string]string{issueID: "Done"}}
+
+	log, buf := logCapture()
+
+	params := defaultReconcileParams(t, store, tracker)
+	params.StallTimeoutMS = 0
+	params.Logger = log
+
+	state := NewState(5000, 4, nil, AgentTotals{})
+	key := ReactionKey(issueID, ReactionKindCI)
+	state.PendingReactions[key] = &PendingReaction{
+		IssueID:    issueID,
+		Identifier: issueID + "-ident",
+		Kind:       ReactionKindCI,
+		CreatedAt:  reconcileBaseTime,
+	}
+	state.ReactionAttempts[key] = 1
+	state.Claimed[issueID] = struct{}{}
+
+	ReconcileRunningIssues(state, params)
+
+	if tracker.calls != 1 {
+		t.Fatalf("FetchIssueStatesByIDs calls = %d, want 1", tracker.calls)
+	}
+	if !slices.Contains(tracker.calledWith, issueID) {
+		t.Errorf("FetchIssueStatesByIDs called with %v, want it to contain %q", tracker.calledWith, issueID)
+	}
+	if _, ok := state.PendingReactions[key]; ok {
+		t.Error("PendingReactions entry present after terminal release; want removed")
+	}
+	if _, ok := state.ReactionAttempts[key]; ok {
+		t.Error("ReactionAttempts entry present after terminal release; want removed")
+	}
+	if _, ok := state.Claimed[issueID]; ok {
+		t.Error("Claimed entry present after terminal release; want removed")
+	}
+	if len(store.deletedIssueID) != 1 || store.deletedIssueID[0] != issueID {
+		t.Errorf("DeleteRetryEntry calls = %v, want exactly one call for %q", store.deletedIssueID, issueID)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "released reaction state for terminal issue") {
+		t.Fatalf("log output = %q, want the terminal-release message", out)
+	}
+	if !strings.Contains(out, "issue_identifier="+issueID+"-ident") {
+		t.Errorf("log output = %q, want issue_identifier=%s-ident", out, issueID)
+	}
+}
+
+func TestTrackerObservationIDs_DeduplicatedUnion(t *testing.T) {
+	t.Parallel()
+
+	state := NewState(5000, 4, nil, AgentTotals{})
+
+	state.Running["I1"] = &RunningEntry{Identifier: "I1-ident"}
+	state.PendingReactions[ReactionKey("I1", ReactionKindCI)] = &PendingReaction{IssueID: "I1", Identifier: "I1-ident", Kind: ReactionKindCI}
+	state.PendingReactions[ReactionKey("I1", ReactionKindReview)] = &PendingReaction{IssueID: "I1", Identifier: "I1-ident", Kind: ReactionKindReview}
+
+	state.PendingReactions[ReactionKey("I2", ReactionKindCI)] = &PendingReaction{IssueID: "I2", Identifier: "I2-ident", Kind: ReactionKindCI}
+	state.PendingReactions[ReactionKey("I2", ReactionKindLabelReview)] = &PendingReaction{IssueID: "I2", Identifier: "I2-ident", Kind: ReactionKindLabelReview}
+
+	state.Running["I3"] = &RunningEntry{Identifier: "I3-ident"}
+
+	got := trackerObservationIDs(state)
+	slices.Sort(got)
+
+	want := []string{"I1", "I2", "I3"}
+	if !slices.Equal(got, want) {
+		t.Errorf("trackerObservationIDs(state) sorted = %v, want %v", got, want)
+	}
+}
+
+func TestReconcileTrackerState_FetchFailureReleasesNothing(t *testing.T) {
+	t.Parallel()
+
+	cc := &cancelCounter{}
+	state := stateWithTerminalReleaseFixture(t, cc)
+
+	store := &mockReconcileStore{}
+	tracker := &mockReconcileTracker{fetchErr: errors.New("connection timeout")}
+	params := defaultReconcileParams(t, store, tracker)
+	params.StallTimeoutMS = 0
+
+	ReconcileRunningIssues(state, params)
+
+	for _, kind := range terminalReleaseFixtureKinds {
+		key := ReactionKey(terminalReleaseIssueID, kind)
+		if _, ok := state.PendingReactions[key]; !ok {
+			t.Errorf("PendingReactions[%q] missing after fetch failure; want unchanged", key)
+		}
+		if state.ReactionAttempts[key] != 2 {
+			t.Errorf("ReactionAttempts[%q] = %d, want 2 (unchanged)", key, state.ReactionAttempts[key])
+		}
+	}
+	if _, ok := state.Claimed[terminalReleaseIssueID]; !ok {
+		t.Error("Claimed entry missing after fetch failure; want unchanged")
+	}
+	if _, ok := state.RetryAttempts[terminalReleaseIssueID]; !ok {
+		t.Error("RetryAttempts entry missing after fetch failure; want unchanged")
+	}
+	if len(store.deletedIssueID) != 0 {
+		t.Errorf("DeleteRetryEntry calls = %d, want 0", len(store.deletedIssueID))
+	}
+}
+
+func TestReconcileTrackerState_NonTerminalPendingOnlyReleasesNothing(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		state string
+	}{
+		{"active state", "In Progress"},
+		{"handoff state", "In Review"},
+		{"state named in no list", "Backlog"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			issueID := "REL-NONTERM"
+			store := &mockReconcileStore{}
+			tracker := &mockReconcileTracker{states: map[string]string{issueID: tt.state}}
+			params := defaultReconcileParams(t, store, tracker)
+			params.StallTimeoutMS = 0
+			params.HandoffState = "In Review"
+
+			state := NewState(5000, 4, nil, AgentTotals{})
+			key := ReactionKey(issueID, ReactionKindCI)
+			state.PendingReactions[key] = &PendingReaction{
+				IssueID:    issueID,
+				Identifier: issueID + "-ident",
+				Kind:       ReactionKindCI,
+				CreatedAt:  reconcileBaseTime,
+			}
+			state.ReactionAttempts[key] = 1
+			state.Claimed[issueID] = struct{}{}
+
+			ReconcileRunningIssues(state, params)
+
+			if _, ok := state.PendingReactions[key]; !ok {
+				t.Error("PendingReactions entry removed for a non-terminal pending-only issue; want unchanged")
+			}
+			if state.ReactionAttempts[key] != 1 {
+				t.Errorf("ReactionAttempts[%q] = %d, want 1 (unchanged)", key, state.ReactionAttempts[key])
+			}
+			if _, ok := state.Claimed[issueID]; !ok {
+				t.Error("Claimed entry removed for a non-terminal pending-only issue; want unchanged")
+			}
+		})
+	}
+}
+
+func TestReleaseTerminalIssueState_IssueIsolation(t *testing.T) {
+	t.Parallel()
+
+	state := NewState(5000, 4, nil, AgentTotals{})
+
+	keyI := ReactionKey("I", ReactionKindCI)
+	state.PendingReactions[keyI] = &PendingReaction{IssueID: "I", Identifier: "I-ident", Kind: ReactionKindCI, CreatedAt: reconcileBaseTime}
+	state.ReactionAttempts[keyI] = 3
+	state.Claimed["I"] = struct{}{}
+
+	keyI2 := ReactionKey("I2", ReactionKindCI)
+	state.PendingReactions[keyI2] = &PendingReaction{IssueID: "I2", Identifier: "I2-ident", Kind: ReactionKindCI, CreatedAt: reconcileBaseTime}
+	state.ReactionAttempts[keyI2] = 5
+	state.Claimed["I2"] = struct{}{}
+
+	store := &mockReconcileStore{}
+	releaseTerminalIssueState(context.Background(), state, store, "I", discardLogger())
+
+	if _, ok := state.PendingReactions[keyI]; ok {
+		t.Error("PendingReactions[I] present after its own release; want removed")
+	}
+	if _, ok := state.PendingReactions[keyI2]; !ok {
+		t.Error("PendingReactions[I2] removed by the release of I; want untouched")
+	}
+	if state.ReactionAttempts[keyI2] != 5 {
+		t.Errorf("ReactionAttempts[I2] = %d, want 5 (untouched)", state.ReactionAttempts[keyI2])
+	}
+	if _, ok := state.Claimed["I2"]; !ok {
+		t.Error("Claimed[I2] removed by the release of I; want untouched")
+	}
+}
+
+func TestReleaseTerminalIssueState_NoSideEffects(t *testing.T) {
+	t.Parallel()
+
+	cc := &cancelCounter{}
+	state := stateWithTerminalReleaseFixture(t, cc)
+
+	store := &mockReconcileStore{}
+	tracker := &mockReconcileTracker{states: map[string]string{terminalReleaseIssueID: "Done"}}
+	params := defaultReconcileParams(t, store, tracker)
+	params.StallTimeoutMS = 0
+	params.SCMAdapter = panicOnAnySCMAdapter{}
+	params.CIProvider = panicOnAnyCIProvider{}
+	params.LabelReviewReactionConfigured = true
+
+	ReconcileRunningIssues(state, params)
+
+	if store.upsertFingerprintCalls != 0 || store.getFingerprintCalls != 0 ||
+		store.markDispatchedCalls != 0 || store.deleteFingerprintCalls != 0 {
+		t.Errorf("fingerprint store calls = upsert:%d get:%d mark:%d delete:%d, want all 0",
+			store.upsertFingerprintCalls, store.getFingerprintCalls, store.markDispatchedCalls, store.deleteFingerprintCalls)
+	}
+	if len(store.savedEntries) != 0 {
+		t.Errorf("SaveRetryEntry calls = %d, want 0", len(store.savedEntries))
+	}
+	if len(store.deletedIssueID) != 1 {
+		t.Errorf("DeleteRetryEntry calls = %d, want 1", len(store.deletedIssueID))
+	}
+}
+
+func TestReconcileTrackerState_NilTrackerAdapterPendingOnly(t *testing.T) {
+	t.Parallel()
+
+	issueID := "REL-NIL"
+	state := NewState(5000, 4, nil, AgentTotals{})
+	key := ReactionKey(issueID, ReactionKindCI)
+	state.PendingReactions[key] = &PendingReaction{
+		IssueID:    issueID,
+		Identifier: issueID + "-ident",
+		Kind:       ReactionKindCI,
+		CreatedAt:  reconcileBaseTime,
+	}
+	state.ReactionAttempts[key] = 1
+	state.Claimed[issueID] = struct{}{}
+
+	store := &mockReconcileStore{}
+	params := ReconcileParams{
+		TrackerAdapter: nil,
+		ActiveStates:   []string{"In Progress", "In Review"},
+		TerminalStates: []string{"Done", "Closed"},
+		Store:          store,
+		OnRetryFire:    noopRetryFire,
+		NowFunc:        func() time.Time { return reconcileBaseTime },
+		Ctx:            context.Background(),
+		Logger:         discardLogger(),
+	}
+
+	reconcileTrackerState(state, params, discardLogger(), context.Background(), &domain.NoopMetrics{})
+
+	if _, ok := state.PendingReactions[key]; !ok {
+		t.Error("PendingReactions entry removed despite nil TrackerAdapter; want unchanged")
+	}
+	if state.ReactionAttempts[key] != 1 {
+		t.Errorf("ReactionAttempts[%q] = %d, want 1 (unchanged)", key, state.ReactionAttempts[key])
+	}
+	if _, ok := state.Claimed[issueID]; !ok {
+		t.Error("Claimed entry removed despite nil TrackerAdapter; want unchanged")
+	}
+	if len(store.deletedIssueID) != 0 {
+		t.Errorf("DeleteRetryEntry calls = %d, want 0", len(store.deletedIssueID))
 	}
 }
 

--- a/internal/orchestrator/retry_test.go
+++ b/internal/orchestrator/retry_test.go
@@ -64,10 +64,6 @@ func (m *mockRetryStore) AppendRunHistory(_ context.Context, run persistence.Run
 	return run, nil
 }
 
-func (m *mockRetryStore) DeleteReactionFingerprintsByIssue(_ context.Context, _ string) error {
-	return nil
-}
-
 func (m *mockRetryStore) UpsertReactionFingerprint(_ context.Context, _, _, _ string) error {
 	return nil
 }

--- a/internal/orchestrator/review_reconcile.go
+++ b/internal/orchestrator/review_reconcile.go
@@ -65,6 +65,7 @@ func reconcileReviewComments(state *State, params ReconcileParams, log *slog.Log
 
 		// TTL enforcement.
 		if ttl > 0 && now.Sub(pending.CreatedAt) > ttl {
+			delete(state.ReactionAttempts, ReactionKey(pending.IssueID, ReactionKindReview))
 			entryLog.Warn("review pending entry exceeded ttl, dropping",
 				slog.Int64("ttl_ms", int64(ttl/time.Millisecond)),
 				slog.Int64("age_ms", int64(now.Sub(pending.CreatedAt)/time.Millisecond)),
@@ -309,9 +310,9 @@ func escalateReviewFailure(
 
 	delete(state.Claimed, pending.IssueID)
 
-	// Scoped per-kind delete (not the issue-wide ClearReactionsForIssue)
-	// so sibling reactions' pending entries, counters, and fingerprints
-	// for the same issue survive a review-only escalation.
+	// Scoped to this kind's own slot: a sibling reaction's pending
+	// entry, counter, and fingerprint for the same issue survive a
+	// review-only escalation.
 	delete(state.PendingReactions, ReactionKey(pending.IssueID, ReactionKindReview))
 	delete(state.ReactionAttempts, ReactionKey(pending.IssueID, ReactionKindReview))
 	if err := params.Store.DeleteReactionFingerprint(ctx, pending.IssueID, ReactionKindReview); err != nil {

--- a/internal/orchestrator/review_reconcile_test.go
+++ b/internal/orchestrator/review_reconcile_test.go
@@ -82,7 +82,6 @@ type reviewReconcileStore struct {
 	getFingerprintCalls    int
 	markDispatchedCalls    int
 	deleteFingerprintCalls int
-	deleteFPByIssueCalls   int
 
 	getFingerprintResult     string
 	getFingerprintDispatched bool
@@ -106,11 +105,6 @@ func (s *reviewReconcileStore) DeleteRetryEntry(_ context.Context, issueID strin
 
 func (s *reviewReconcileStore) AppendRunHistory(_ context.Context, run persistence.RunHistory) (persistence.RunHistory, error) {
 	return run, nil
-}
-
-func (s *reviewReconcileStore) DeleteReactionFingerprintsByIssue(_ context.Context, _ string) error {
-	s.deleteFPByIssueCalls++
-	return nil
 }
 
 func (s *reviewReconcileStore) UpsertReactionFingerprint(_ context.Context, _, _, _ string) error {
@@ -340,6 +334,54 @@ func TestReconcileReviewComments_TTLExpired(t *testing.T) {
 	}
 	if scm.calls != 0 {
 		t.Errorf("FetchPendingReviews calls = %d, want 0 (TTL exceeded)", scm.calls)
+	}
+}
+
+// TestReconcileReviewComments_DropOnAgeReleasesCounter verifies that the
+// drop-on-age branch also deletes the review reaction attempt counter,
+// leaves a sibling kind's counter and the claim untouched, and performs
+// no retry or fingerprint store call.
+func TestReconcileReviewComments_DropOnAgeReleasesCounter(t *testing.T) {
+	t.Parallel()
+
+	issueID := "REV-AGE-1"
+	state := stateWithReviewReaction(t, issueID, 10)
+	reviewKey := ReactionKey(issueID, ReactionKindReview)
+	state.ReactionAttempts[reviewKey] = 3
+	state.PendingReactions[reviewKey].CreatedAt = reviewBaseTime.Add(-31 * time.Minute)
+	ciKey := ReactionKey(issueID, ReactionKindCI)
+	state.ReactionAttempts[ciKey] = 7
+	delete(state.Claimed, issueID)
+
+	store := &reviewReconcileStore{}
+	metrics := newReviewMetricsSpy()
+	scm := &mockSCMAdapter{}
+	params := reviewParams(store, scm, nil)
+	params.ReviewPendingTTL = 30 * time.Minute
+
+	reconcileReviewComments(state, params, discardLogger(), context.Background(), metrics)
+
+	if _, ok := state.PendingReactions[reviewKey]; ok {
+		t.Error("PendingReactions[review] present after drop-on-age; want removed")
+	}
+	if _, ok := state.ReactionAttempts[reviewKey]; ok {
+		t.Error("ReactionAttempts[review] present after drop-on-age; want removed")
+	}
+	if state.ReactionAttempts[ciKey] != 7 {
+		t.Errorf("ReactionAttempts[ci] = %d, want 7 (untouched)", state.ReactionAttempts[ciKey])
+	}
+	if _, ok := state.Claimed[issueID]; ok {
+		t.Error("Claimed present after drop-on-age; want absent")
+	}
+	if len(store.deletedIssueIDs) != 0 {
+		t.Errorf("DeleteRetryEntry calls = %d, want 0", len(store.deletedIssueIDs))
+	}
+	if store.upsertFingerprintCalls != 0 || store.getFingerprintCalls != 0 || store.deleteFingerprintCalls != 0 {
+		t.Errorf("fingerprint calls = upsert:%d get:%d delete:%d, want all 0",
+			store.upsertFingerprintCalls, store.getFingerprintCalls, store.deleteFingerprintCalls)
+	}
+	if scm.calls != 0 {
+		t.Errorf("FetchPendingReviews calls = %d, want 0 (TTL exceeded before fetch)", scm.calls)
 	}
 }
 
@@ -608,8 +650,7 @@ func TestReconcileReviewComments_TurnCapExceeded_Escalates(t *testing.T) {
 // that review escalation clears only the review reaction's own pending
 // entry, counter, and fingerprint. A sibling merge-completion entry parked
 // on the same issue (seeded from the same worker exit as the review
-// reaction) must survive: the escalation must not call the issue-wide
-// DeleteReactionFingerprintsByIssue.
+// reaction) must survive: the escalation must not clear it.
 func TestReconcileReviewComments_TurnCapExceeded_CrossKindIsolation(t *testing.T) {
 	t.Parallel()
 
@@ -642,9 +683,6 @@ func TestReconcileReviewComments_TurnCapExceeded_CrossKindIsolation(t *testing.T
 	}
 	if state.ReactionAttempts[ReactionKey(issueID, ReactionKindMergeCompletion)] != 1 {
 		t.Error("sibling merge-completion ReactionAttempts counter altered by review escalation; want untouched")
-	}
-	if store.deleteFPByIssueCalls != 0 {
-		t.Errorf("DeleteReactionFingerprintsByIssue calls = %d, want 0 (escalation must be scoped to review)", store.deleteFPByIssueCalls)
 	}
 	if store.deleteFingerprintCalls != 1 {
 		t.Errorf("DeleteReactionFingerprint calls = %d, want 1 (the review kind's own fingerprint)", store.deleteFingerprintCalls)

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -3,7 +3,6 @@ package orchestrator
 import (
 	"context"
 	"fmt"
-	"log/slog"
 	"maps"
 	"math"
 	"slices"
@@ -854,34 +853,6 @@ func WithContinuationContext(ctx context.Context, data map[string]any) context.C
 func ContinuationFromContext(ctx context.Context) map[string]any {
 	v, _ := ctx.Value(continuationCtxKey{}).(map[string]any)
 	return v
-}
-
-// ClearReactionsForIssue removes all PendingReactions and
-// ReactionAttempts entries whose key starts with the given issue ID
-// prefix, and deletes the corresponding reaction_fingerprints rows from
-// SQLite. The SQLite call is best-effort: a failure is logged at warn
-// level but does not block the caller.
-func ClearReactionsForIssue(ctx context.Context, state *State, store ReconcileStore, issueID string, log *slog.Logger) {
-	prefix := issueID + ":"
-	for key := range state.PendingReactions {
-		if strings.HasPrefix(key, prefix) {
-			delete(state.PendingReactions, key)
-		}
-	}
-	for key := range state.ReactionAttempts {
-		if strings.HasPrefix(key, prefix) {
-			delete(state.ReactionAttempts, key)
-		}
-	}
-	if err := store.DeleteReactionFingerprintsByIssue(ctx, issueID); err != nil {
-		if log == nil {
-			log = slog.Default()
-		}
-		log.WarnContext(ctx, "failed to delete reaction fingerprints",
-			slog.String("issue_id", issueID),
-			slog.Any("error", err),
-		)
-	}
 }
 
 // NewState creates an initialized [State] with empty collections and the

--- a/internal/orchestrator/state_test.go
+++ b/internal/orchestrator/state_test.go
@@ -1,7 +1,6 @@
 package orchestrator
 
 import (
-	"context"
 	"math"
 	"strings"
 	"testing"
@@ -1737,58 +1736,5 @@ func TestBuildLabelFixReactionConfig(t *testing.T) {
 	}
 	if got != want {
 		t.Errorf("BuildLabelFixReactionConfig(%+v) = %+v, want %+v", cfg, got, want)
-	}
-}
-
-// --- ClearReactionsForIssue cross-kind tests ---
-
-// TestClearReactionsForIssue verifies that clearing an issue's reactions on
-// a terminal transition removes every sibling kind's PendingReactions entry,
-// including label-review, alongside the reaction_fingerprints deletion,
-// while leaving another issue's entries untouched.
-func TestClearReactionsForIssue(t *testing.T) {
-	t.Parallel()
-
-	const issueID = "ISS-CLEAR"
-	const otherIssueID = "ISS-OTHER"
-
-	state := NewState(5000, 4, nil, AgentTotals{})
-	kinds := []string{
-		ReactionKindCI,
-		ReactionKindReview,
-		ReactionKindBotReview,
-		ReactionKindAutoMerge,
-		ReactionKindMergeConflict,
-		ReactionKindLabelReview,
-	}
-	for _, kind := range kinds {
-		state.PendingReactions[ReactionKey(issueID, kind)] = &PendingReaction{IssueID: issueID, Kind: kind}
-	}
-	state.ReactionAttempts[ReactionKey(issueID, ReactionKindReview)] = 2
-
-	// A sibling issue's label-review entry must survive.
-	state.PendingReactions[ReactionKey(otherIssueID, ReactionKindLabelReview)] = &PendingReaction{
-		IssueID: otherIssueID,
-		Kind:    ReactionKindLabelReview,
-	}
-
-	store := &reviewReconcileStore{}
-
-	ClearReactionsForIssue(context.Background(), state, store, issueID, discardLogger())
-
-	for _, kind := range kinds {
-		key := ReactionKey(issueID, kind)
-		if _, ok := state.PendingReactions[key]; ok {
-			t.Errorf("PendingReactions[%s] survived ClearReactionsForIssue, want removed", key)
-		}
-	}
-	if _, ok := state.ReactionAttempts[ReactionKey(issueID, ReactionKindReview)]; ok {
-		t.Error("ReactionAttempts entry survived ClearReactionsForIssue, want removed")
-	}
-	if _, ok := state.PendingReactions[ReactionKey(otherIssueID, ReactionKindLabelReview)]; !ok {
-		t.Error("sibling issue's label-review PendingReaction removed by ClearReactionsForIssue, want untouched")
-	}
-	if store.deleteFPByIssueCalls != 1 {
-		t.Errorf("DeleteReactionFingerprintsByIssue calls = %d, want 1", store.deleteFPByIssueCalls)
 	}
 }


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Fix

**Intent:** Release an issue's reaction bookkeeping - pending reaction entries, reaction attempt counters, pending retry, and dispatch claim - as soon as the tracker reports the issue terminal, whether or not a worker is still running for it. Previously that release never happened, which for the two label-command kinds (`label-review`, `label-fix`) meant permanent polling of the PR label journal after the issue closed, since neither kind carries a TTL of its own.

**Related Issues:** #741

### 🧭 Reviewer Guide

**Complexity:** Medium

#### Entry Point

`internal/orchestrator/reconcile.go` - `reconcileTrackerState` now fetches tracker state for the deduplicated union of running issue IDs and pending-reaction issue IDs (via the new `trackerObservationIDs` helper), instead of running issues only. Its terminal branch calls the new `releaseTerminalIssueState`, which drops every pending entry and attempt counter for the issue, cancels and deletes its retry, and releases its dispatch claim - independent of whether `state.Running` holds an entry for it. `reaction_fingerprints` is left untouched.

#### Sensitive Areas

- `internal/orchestrator/reconcile.go`: core dispatch-gating logic; a bug here could either leave stale claims in place (repeating the original issue) or release claims too eagerly (double-dispatch risk).
- `internal/orchestrator/state.go`: removes the now-unused `ClearReactionsForIssue` helper, which had no production caller; behavior is fully replaced by the scoped release in `reconcile.go`.
- `internal/orchestrator/orchestrator.go`: drops `DeleteReactionFingerprintsByIssue` from the `ReconcileStore`/`OrchestratorStore` interfaces since no orchestrator path calls it anymore.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes.
- **Migrations/State:** No migrations or state changes.
