### PR TITLE
docs: reconcile architecture spec with post-merge closure

### DIFF
--- a/docs/architecture/06-configuration-specification.md
+++ b/docs/architecture/06-configuration-specification.md
@@ -90,11 +90,12 @@ Validation checks:
 - `reactions.merge_completion.target_state`, checked once at construction against
   `tracker.handoff_state`, `tracker.active_states`, and `tracker.terminal_states`: required and
   non-empty when `reactions.merge_completion.provider` is set, must not equal
-  `tracker.handoff_state`, must not be a member of `tracker.active_states` (the tracker adapter's
-  fallback active-state list applies when that field is empty), and must be a member of
-  `tracker.terminal_states` exactly as written, with no adapter fallback. Reaction configuration
-  is not rebuilt on `WORKFLOW.md` reload (Section 6.4), so this check runs at startup and in
-  `sortie validate`, never on a dispatch tick.
+  `tracker.handoff_state` (case-insensitive), must not be a member of `tracker.active_states`
+  (case-insensitive; the tracker adapter's fallback active-state list applies when that field is
+  empty), and must be a member of `tracker.terminal_states` exactly as written in configuration
+  (case-insensitive), with no fallback to the adapter's default terminal-state list. Reaction
+  configuration is not rebuilt on `WORKFLOW.md` reload (Section 6.4), so this check runs at
+  startup and in `sortie validate`, never on a dispatch tick.
 
 Effort-budget and notification config are validated outside this preflight, by design:
 
@@ -170,7 +171,8 @@ This section is intentionally redundant so a coding agent can implement the conf
 - `tracker.terminal_states`: list of strings, defaults to empty; an empty value leaves the tracker
   adapter to apply its own internal fallback list; must be written non-empty in front matter when
   `reactions.merge_completion.provider` is set, because `target_state` is checked against the list
-  exactly as written, with no adapter fallback in that case
+  exactly as written in configuration (case-insensitive), with no fallback to the adapter's
+  default terminal-state list in that case
 - `tracker.query_filter`: string, optional, default empty (adapter-defined filter fragment)
 - `tracker.handoff_state`: string, optional, default absent; target state for
   orchestrator-initiated handoff after successful worker run; must not collide with
@@ -237,10 +239,11 @@ This section is intentionally redundant so a coding agent can implement the conf
 - `reactions.merge_completion.target_state`: string, required when
   `reactions.merge_completion.provider` is set, no default; the single tracker terminal state the
   linked issue moves to once its managed pull request merges; must not equal
-  `tracker.handoff_state`; must not be a member of `tracker.active_states` (falling back to the
-  tracker adapter's default active-state list when that field is empty); must be a member of
-  `tracker.terminal_states` exactly as written, with no adapter fallback; not rebuilt on
-  `WORKFLOW.md` reload; see §11G
+  `tracker.handoff_state` (case-insensitive); must not be a member of `tracker.active_states`
+  (case-insensitive, falling back to the tracker adapter's default active-state list when that
+  field is empty); must be a member of `tracker.terminal_states` exactly as written in
+  configuration (case-insensitive), with no fallback to the adapter's default terminal-state
+  list; not rebuilt on `WORKFLOW.md` reload; see §11G
 - `reactions.merge_completion.poll_interval_ms`: integer, default `60000` (1 minute); minimum
   `30000`
 - `dispatch.rules`: list of rule objects, optional; first-match-wins routing; see §5.3.10

--- a/docs/architecture/06-configuration-specification.md
+++ b/docs/architecture/06-configuration-specification.md
@@ -87,6 +87,14 @@ Validation checks:
   state lists. An empty `tracker.active_states` or `tracker.terminal_states` takes the tracker
   adapter's declared fallback list, so a collision the config layer cannot see (because it rules
   on the lists as written) is reported here.
+- `reactions.merge_completion.target_state`, checked once at construction against
+  `tracker.handoff_state`, `tracker.active_states`, and `tracker.terminal_states`: required and
+  non-empty when `reactions.merge_completion.provider` is set, must not equal
+  `tracker.handoff_state`, must not be a member of `tracker.active_states` (the tracker adapter's
+  fallback active-state list applies when that field is empty), and must be a member of
+  `tracker.terminal_states` exactly as written, with no adapter fallback. Reaction configuration
+  is not rebuilt on `WORKFLOW.md` reload (Section 6.4), so this check runs at startup and in
+  `sortie validate`, never on a dispatch tick.
 
 Effort-budget and notification config are validated outside this preflight, by design:
 
@@ -160,12 +168,15 @@ This section is intentionally redundant so a coding agent can implement the conf
 - `tracker.active_states`: list of strings, defaults to empty; an empty value leaves the tracker
   adapter to apply its own internal fallback list
 - `tracker.terminal_states`: list of strings, defaults to empty; an empty value leaves the tracker
-  adapter to apply its own internal fallback list
+  adapter to apply its own internal fallback list; must be written non-empty in front matter when
+  `reactions.merge_completion.provider` is set, because `target_state` is checked against the list
+  exactly as written, with no adapter fallback in that case
 - `tracker.query_filter`: string, optional, default empty (adapter-defined filter fragment)
 - `tracker.handoff_state`: string, optional, default absent; target state for
   orchestrator-initiated handoff after successful worker run; must not collide with
   `active_states` or `terminal_states`, evaluated against the effective lists, so the tracker
-  adapter's fallback participates whenever the matching field is empty; supports `$VAR`
+  adapter's fallback participates whenever the matching field is empty; required, non-empty, when
+  `reactions.merge_completion.provider` is set; supports `$VAR`
 - `tracker.in_progress_state`: string, optional, default absent; target state for
   dispatch-time transition at the start of each worker attempt; must be in `active_states`,
   must not collide with `terminal_states` or `handoff_state`, and the `terminal_states` rule is
@@ -223,6 +234,15 @@ This section is intentionally redundant so a coding agent can implement the conf
 - `reactions.auto_merge.require_ci`: boolean, default `true`
 - `reactions.auto_merge.delete_branch`: boolean, default `true`
 - `reactions.auto_merge.poll_interval_ms`: integer, default `60000` (1 minute); minimum `30000`
+- `reactions.merge_completion.target_state`: string, required when
+  `reactions.merge_completion.provider` is set, no default; the single tracker terminal state the
+  linked issue moves to once its managed pull request merges; must not equal
+  `tracker.handoff_state`; must not be a member of `tracker.active_states` (falling back to the
+  tracker adapter's default active-state list when that field is empty); must be a member of
+  `tracker.terminal_states` exactly as written, with no adapter fallback; not rebuilt on
+  `WORKFLOW.md` reload; see §11G
+- `reactions.merge_completion.poll_interval_ms`: integer, default `60000` (1 minute); minimum
+  `30000`
 - `dispatch.rules`: list of rule objects, optional; first-match-wins routing; see §5.3.10
 - `dispatch.default.agent`: string, optional; default agent kind when no rule matches; falls through to top-level `agent.kind`
 - `dispatch.default.template`: path, optional; default template when no rule matches; falls through to the Markdown body

--- a/docs/architecture/07-orchestration-state-machine.md
+++ b/docs/architecture/07-orchestration-state-machine.md
@@ -124,6 +124,22 @@ Distinct terminal reasons are important because retry logic and logs differ.
   - If continuation turns exhausted: escalate (add label or post comment per escalation
     config), cancel retry, release claim.
 
+- `Merge Completion Observed`
+  - Observed on the reconcile tick for an issue still parked in `tracker.handoff_state` and not
+    currently claimed by the orchestrator.
+  - Latch idempotency on the merge commit identifier; a commit already latched and dispatched is
+    dropped without a transition.
+  - Transition the issue to `reactions.merge_completion.target_state`, the last
+    orchestrator-driven tracker-state write in an issue's life, after the optional dispatch-time
+    in-progress transition and the handoff transition on worker exit (§11G).
+  - On failure, route by tracker error kind (§11G.5): a transport or API failure, or any other
+    kind, retries with backoff bounded by `reactions.merge_completion.max_retries`, then
+    escalates; an auth or payload failure escalates immediately, consuming no retry budget; a
+    not-found issue stops, marks the fingerprint dispatched, and logs a warning, with no
+    escalation.
+  - No orchestration-state transition occurs: the claim was already released when the issue
+    entered the handoff state.
+
 ### 7.4 Idempotency and Recovery Rules
 
 - The orchestrator serializes state mutations through one authority to avoid duplicate dispatch.
@@ -135,14 +151,18 @@ Distinct terminal reasons are important because retry logic and logs differ.
 - Startup pending reaction recovery uses `run_history`, tracker state, and `.sortie/scm.json` to
   reconstruct runtime `pending_reactions` for recent handoff-stage runs before the first poll tick.
   The scan is bounded by `PendingReactionRecoveryLookback` and a fixed candidate cap.
-- Startup terminal cleanup removes stale workspaces for issues already in terminal states.
+- Startup terminal cleanup maps existing workspace directories to issue identifiers, queries the
+  tracker for the states of those specific issues, and removes the ones in terminal states. An
+  issue that reaches a terminal state through the merge-completion transition (§11G) becomes
+  eligible for this same cleanup without a human relabeling it first.
 
 #### Startup Recovery Sequence (SQLite)
 
 1. Open or create the SQLite database and run schema migrations.
 2. Load persisted retry entries from SQLite.
 3. Reconstruct retry timers from persisted `due_at` timestamps.
-4. Query tracker for terminal-state issues and clean corresponding workspaces.
+4. Map existing workspace directories to issue identifiers, query the tracker for the states of
+   those specific issues, and clean the ones in terminal states.
 5. Construct reaction providers and call `RecoverPendingReactions` to restore eligible CI and
   review pending entries for handoff-stage issues.
 6. Query tracker for active issues and reconcile with persisted state.

--- a/docs/architecture/11-issue-tracker-integration-contract.md
+++ b/docs/architecture/11-issue-tracker-integration-contract.md
@@ -12,7 +12,15 @@ A tracker adapter must support these operations:
      pre-dispatch revalidation and prompt rendering.
 
 3. `fetch_issues_by_states(state_names)`
-   - Used for startup terminal cleanup.
+   - Return issues in the specified states. The GitHub, Gitea, GitLab, and file adapters compare
+     state names case-insensitively in process. The Jira adapter sends each name verbatim into a
+     JQL `status IN (...)` clause, leaving matching to the server. The Linear adapter resolves
+     each name against the canonical casing of the team's workflow states, read once at
+     construction: a name matching one of those states resolves case-insensitively, and a name
+     matching none is sent as written and compared case-sensitively (§11.6.1).
+   - No orchestrator caller and no agent tool invokes this operation. Adapters implement it to
+     satisfy the `TrackerAdapter` interface; removing it would be an interface change, not an
+     adapter change.
 
 4. `fetch_issue_states_by_ids(issue_ids)`
    - Used for active-run reconciliation.
@@ -73,16 +81,41 @@ Orchestrator behavior on tracker errors:
 
 ### 11.5 Tracker Writes (Important Boundary)
 
-Sortie does not require first-class tracker write APIs in the orchestrator.
+The orchestrator writes tracker state at exactly three points in an issue's life, each one a
+single named state drawn from configuration, each one corresponding to an event the orchestrator
+itself observed:
 
-- Ticket mutations (state transitions, comments, PR metadata) are typically handled by the coding
-  agent using tools defined by the workflow prompt.
-- Sortie remains a scheduler/runner and tracker reader.
-- Workflow-specific success often means "reached the next handoff state" (for example
-  `Human Review`) rather than tracker terminal state `Done`.
-- The agent tool subsystem (Section 10.4) is part of the agent toolchain rather than
-  orchestrator business logic. `tracker_api` executes tracker operations through agent-initiated
-  tool calls, not orchestrator-driven writes.
+- The in-progress state (`tracker.in_progress_state`), at dispatch, when that field is
+  configured and the dispatch drives issue state (§11F excludes the read-only and read-write
+  label-command postures).
+- The handoff state (`tracker.handoff_state`), on a normal worker exit with the issue still in an
+  active tracker state and not a blocked soft stop, when that field is configured and the
+  dispatch drives issue state.
+- The merge-completion target state (`reactions.merge_completion.target_state`), when a
+  Sortie-managed pull request merges while the linked issue is still parked in
+  `tracker.handoff_state`, independently of who or what performed the merge. Active only when
+  `reactions.merge_completion.provider` is configured. See §11G for the full contract.
+
+The orchestrator writes no other tracker state. Beyond these three writes, it posts tracker
+comments and applies escalation labels, none of which carries state semantics: the dispatch
+comment (`tracker.comments.on_dispatch`), the worker-exit completion and failure comments
+(`tracker.comments.on_completion`, `tracker.comments.on_failure`), the auto-merge success comment
+(§11C), and a reaction escalation label or comment when a reaction's retry budget is exhausted or
+a non-retryable error occurs. None of these is a state transition.
+
+Free-form ticket mutation falls outside these three writes and stays with the coding agent, which
+mutates tickets through the `tracker_api` tool subsystem (Section 10.4), part of the agent
+toolchain rather than orchestrator business logic.
+
+The distinction that governs this boundary is not between reading and writing. It is between a
+write that reports an event the orchestrator observed and a write that expresses a judgment
+about the work. The orchestrator makes only the first kind: a case that requires judgment, such
+as choosing between a completion state and an abandonment state for a pull request closed
+unmerged, falls outside all three writes above and remains the operator's or the coding agent's
+to make.
+
+Workflow-specific success often means "reached the next handoff state" (for example
+`Human Review`) rather than tracker terminal state `Done`.
 
 ### 11.6 Implemented Tracker Adapters
 
@@ -123,11 +156,12 @@ immutable category (`triage`, `backlog`, `unstarted`, `started`, `completed`, `c
 `handoff_state`; the adapter treats the names as opaque strings and preserves their original
 casing in `Issue.state`, consistent with the other adapters. The category drives no candidate
 selection. At construction the adapter fetches the team's states once, fails when a configured
-name is absent from the team, caches the canonical casing of each configured name (the GraphQL
-`name: { in: [...] }` filter is case-sensitive), and emits a WARN when a configured `active_states`
-entry resolves to a terminal category or a `terminal_states` entry resolves to a non-terminal
-category. When `active_states` or `terminal_states` is omitted, the adapter applies the stock
-defaults `["Backlog", "Todo", "In Progress"]` and `["Done", "Canceled", "Duplicate"]`.
+name is absent from the team, caches the canonical casing of every workflow state the team
+defines (the GraphQL `name: { in: [...] }` filter is case-sensitive), and emits a WARN when a
+configured `active_states` entry resolves to a terminal category or a `terminal_states` entry
+resolves to a non-terminal category. When `active_states` or `terminal_states` is omitted, the
+adapter applies the stock defaults `["Backlog", "Todo", "In Progress"]` and
+`["Done", "Canceled", "Duplicate"]`.
 
 **Normalization specifics.** Beyond the shared rules in Section 11.3:
 


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Chore

**Intent:** The post-merge issue closure capability (#705-#707) shipped ahead of the architecture specification that describes it. This closes that gap: the three sections that state the orchestrator's tracker-writes boundary, the tracker configuration surface, and the startup workspace cleanup trigger now describe the amended behavior instead of the pre-#705 boundary.

**Related Issues:** #729

### 🧭 Reviewer Guide

**Complexity:** Low

#### Entry Point

`docs/architecture/11-issue-tracker-integration-contract.md` is the natural starting point. Section 11.5 previously stated that Sortie does not require first-class tracker write APIs and that ticket mutations are left to the coding agent; it now names the three events the orchestrator itself writes tracker state for (dispatch-time in-progress, worker-exit handoff, and merge-completion target), draws the line between an event report and a judgment call, and leaves free-form mutation with the coding agent as before.

#### Sensitive Areas

- `docs/architecture/07-orchestration-state-machine.md`: corrects the startup terminal cleanup description, which stated a direct tracker query for terminal-state issues that no code performs; the actual mechanism maps existing workspace directories to issue identifiers and queries the tracker for those specific issues, worth checking against `internal/orchestrator/reconcile.go`.
- `docs/architecture/06-configuration-specification.md`: adds `reactions.merge_completion.target_state` and its validation against `tracker.handoff_state`, `tracker.active_states`, and `tracker.terminal_states`, worth checking that the validation rules match the accepted decision for #705/#707.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes
- **Migrations/State:** No migrations or state changes
