### PR TITLE
fix(config): recognize workspace.retention_days as known field

### DIFF
--- a/cmd/sortie/validate_test.go
+++ b/cmd/sortie/validate_test.go
@@ -1879,6 +1879,82 @@ func TestValidateWorkspaceRetentionDaysOutOfRange(t *testing.T) {
 	}
 }
 
+// TestValidateWorkspaceRetentionDaysValid covers R1 and R5: an in-range
+// workspace.retention_days value in the front matter is recognized by
+// the schema and produces no warnings, offline (the file tracker makes
+// no network call).
+func TestValidateWorkspaceRetentionDaysValid(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	content := []byte("---\n" +
+		"polling:\n  interval_ms: 30000\n" +
+		"tracker:\n  kind: file\n  active_states: [\"To Do\"]\n  terminal_states: [\"Done\"]\n" +
+		"agent:\n  kind: mock\n" +
+		"file:\n  path: issues.json\n" +
+		"workspace:\n  retention_days: 30\n" +
+		"---\nDo {{ .issue.title }}.\n")
+	wfPath := writeCustomWorkflowFile(t, dir, content)
+
+	var stdout, stderr bytes.Buffer
+	ctx := context.Background()
+
+	code := run(ctx, []string{"validate", "--format", "json", wfPath}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("run(validate) = %d, want 0; stderr: %s", code, stderr.String())
+	}
+
+	var out validateOutput
+	if err := json.Unmarshal(stdout.Bytes(), &out); err != nil {
+		t.Fatalf("json.Unmarshal(%q) error: %v", stdout.String(), err)
+	}
+	if !out.Valid {
+		t.Errorf("validateOutput.Valid = false, want true; errors: %v", out.Errors)
+	}
+	if len(out.Warnings) != 0 {
+		t.Errorf("validateOutput.Warnings = %v, want empty", out.Warnings)
+	}
+}
+
+// TestValidateWorkspaceRetentionDaysFromEnvOverride covers R1, R5, and
+// R9: a workspace.retention_days value supplied only through
+// SORTIE_WORKSPACE_RETENTION_DAYS, with no retention_days line in the
+// front matter, is recognized by the schema and produces no warnings.
+//
+// t.Setenv panics when called from a parallel test, so this test does
+// not call t.Parallel.
+func TestValidateWorkspaceRetentionDaysFromEnvOverride(t *testing.T) {
+	t.Setenv("SORTIE_WORKSPACE_RETENTION_DAYS", "30")
+
+	dir := t.TempDir()
+	content := []byte("---\n" +
+		"polling:\n  interval_ms: 30000\n" +
+		"tracker:\n  kind: file\n  active_states: [\"To Do\"]\n  terminal_states: [\"Done\"]\n" +
+		"agent:\n  kind: mock\n" +
+		"file:\n  path: issues.json\n" +
+		"---\nDo {{ .issue.title }}.\n")
+	wfPath := writeCustomWorkflowFile(t, dir, content)
+
+	var stdout, stderr bytes.Buffer
+	ctx := context.Background()
+
+	code := run(ctx, []string{"validate", "--format", "json", wfPath}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("run(validate) = %d, want 0; stderr: %s", code, stderr.String())
+	}
+
+	var out validateOutput
+	if err := json.Unmarshal(stdout.Bytes(), &out); err != nil {
+		t.Fatalf("json.Unmarshal(%q) error: %v", stdout.String(), err)
+	}
+	if !out.Valid {
+		t.Errorf("validateOutput.Valid = false, want true; errors: %v", out.Errors)
+	}
+	if len(out.Warnings) != 0 {
+		t.Errorf("validateOutput.Warnings = %v, want empty", out.Warnings)
+	}
+}
+
 func TestValidateDispatch_ConfigErrorRouting(t *testing.T) {
 	t.Parallel()
 

--- a/docs/architecture/05-workflow-specification.md
+++ b/docs/architecture/05-workflow-specification.md
@@ -141,6 +141,11 @@ Fields:
   - `~` and strings containing path separators are expanded.
   - Bare strings without path separators are preserved as-is (relative roots are allowed but
     discouraged).
+- `retention_days` (integer or string integer, optional)
+  - Default: `0` (disables the bound).
+  - A value from `1` to `29` and any negative value are rejected when the configuration is
+    parsed.
+  - The window is evaluated by the periodic workspace sweep.
 
 #### 5.3.4 `hooks` (object)
 

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -68,6 +68,7 @@ var knownFieldsRegistry = map[string]SectionSchema{
 	"workspace": {
 		Fields: []FieldDef{
 			{Name: "root", Type: FieldString},
+			{Name: "retention_days", Type: FieldInt},
 		},
 	},
 	"hooks": {

--- a/internal/config/schema_retention_days_test.go
+++ b/internal/config/schema_retention_days_test.go
@@ -1,0 +1,126 @@
+package config
+
+import "testing"
+
+// TestValidateFrontMatter_RetentionDays verifies the schema recognizes
+// workspace.retention_days as a known FieldInt: bare integers,
+// string-encoded integers, zero, and nil values draw no warning, a
+// non-coercible value draws a single type_mismatch advisory, and a
+// genuinely unrecognized workspace sub-key still draws unknown_sub_key.
+func TestValidateFrontMatter_RetentionDays(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		raw        map[string]any
+		wantCount  int
+		wantChecks []string
+		wantFields []string
+	}{
+		{
+			name: "bare integer draws no warning",
+			raw: map[string]any{
+				"workspace": map[string]any{"root": "/tmp/ws", "retention_days": 30},
+			},
+			wantCount: 0,
+		},
+		{
+			name: "string-encoded integer draws no warning",
+			raw: map[string]any{
+				"workspace": map[string]any{"root": "/tmp/ws", "retention_days": "30"},
+			},
+			wantCount: 0,
+		},
+		{
+			name: "zero draws no warning",
+			raw: map[string]any{
+				"workspace": map[string]any{"root": "/tmp/ws", "retention_days": 0},
+			},
+			wantCount: 0,
+		},
+		{
+			name: "nil value draws no warning",
+			raw: map[string]any{
+				"workspace": map[string]any{"root": "/tmp/ws", "retention_days": nil},
+			},
+			wantCount: 0,
+		},
+		{
+			name: "non-coercible value draws a single type_mismatch advisory",
+			raw: map[string]any{
+				"workspace": map[string]any{"root": "/tmp/ws", "retention_days": true},
+			},
+			wantCount:  1,
+			wantChecks: []string{"type_mismatch"},
+			wantFields: []string{"workspace.retention_days"},
+		},
+		{
+			name: "unrecognized workspace key still draws unknown_sub_key",
+			raw: map[string]any{
+				"workspace": map[string]any{"root": "/tmp/ws", "retention_days": 30, "retention_dayz": 5},
+			},
+			wantCount:  1,
+			wantChecks: []string{"unknown_sub_key"},
+			wantFields: []string{"workspace.retention_dayz"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := ValidateFrontMatter(tt.raw, ServiceConfig{})
+
+			if len(got) != tt.wantCount {
+				t.Fatalf("ValidateFrontMatter() returned %d warnings, want %d\nwarnings: %+v", len(got), tt.wantCount, got)
+			}
+			for i, wantCheck := range tt.wantChecks {
+				if got[i].Check != wantCheck {
+					t.Errorf("warnings[%d].Check = %q, want %q", i, got[i].Check, wantCheck)
+				}
+			}
+			for i, wantField := range tt.wantFields {
+				if got[i].Field != wantField {
+					t.Errorf("warnings[%d].Field = %q, want %q", i, got[i].Field, wantField)
+				}
+			}
+		})
+	}
+}
+
+// TestValidateFrontMatter_RetentionDaysNotUnknownKey is a focused guard:
+// retention_days must never surface as an unknown_sub_key.
+func TestValidateFrontMatter_RetentionDaysNotUnknownKey(t *testing.T) {
+	t.Parallel()
+
+	raw := map[string]any{
+		"workspace": map[string]any{"root": "/tmp/ws", "retention_days": 30},
+	}
+	for _, w := range ValidateFrontMatter(raw, ServiceConfig{}) {
+		if w.Check == "unknown_sub_key" && w.Field == "workspace.retention_days" {
+			t.Errorf("retention_days reported as unknown_sub_key: %+v", w)
+		}
+	}
+}
+
+// TestValidateFrontMatter_RetentionDaysFromEnvOverride verifies that a
+// value written into the raw map by applyEnvOverrides (rather than
+// present in the front matter itself) is recognized the same way as a
+// literal value, drawing no warning.
+//
+// t.Setenv panics when called from a parallel test, so neither this
+// test nor any subtest it defines calls t.Parallel.
+func TestValidateFrontMatter_RetentionDaysFromEnvOverride(t *testing.T) {
+	t.Setenv("SORTIE_WORKSPACE_RETENTION_DAYS", "30")
+
+	raw := map[string]any{}
+	cfg, err := NewServiceConfig(raw)
+	if err != nil {
+		t.Fatalf("NewServiceConfig: %v", err)
+	}
+
+	got := ValidateFrontMatter(raw, cfg)
+	if len(got) != 0 {
+		t.Fatalf("ValidateFrontMatter() returned %d warnings, want 0\nwarnings: %+v", len(got), got)
+	}
+}


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Fix

**Intent:** `sortie validate` reported the supported `workspace.retention_days` key as an unknown sub-key, even though the field is parsed, range-validated, and honored by the periodic workspace sweep. The known-fields registry that drives the unknown-key sweep listed only `root` under `workspace`, so it was never updated when `retention_days` was added. This narrows the check by adding the missing entry, rather than weakening the unknown-key sweep itself.

**Related Issues:** #750

### 🧭 Reviewer Guide

**Complexity:** Low

#### Entry Point

`internal/config/schema.go` - the `knownFieldsRegistry` map drives `ValidateFrontMatter`'s unknown-sub-key sweep. The fix adds `{Name: "retention_days", Type: FieldInt}` to the `workspace` section's field list, matching how `tracker.api_version` and other fields are already registered.

#### Sensitive Areas

- `internal/config/schema.go`: single-line addition to a static registry; the parser (`buildWorkspaceConfig`) and the environment-override registry (`SORTIE_WORKSPACE_RETENTION_DAYS`) were already correct, so this only affects the static-analysis warning path.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes
- **Migrations/State:** No migrations or state changes
