### PR TITLE
fix(orchestrator): resolve retry-slot displacement across reactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Follow-up work already queued for an issue is no longer discarded
+  when a second kind of follow-up becomes due for the same issue.
+  Sortie keeps one queued continuation per issue and the last writer
+  won silently, so a queued CI fix, review fix, bot-review fix,
+  post-merge-conflict rebase, or `sortie:review` / `sortie:fix` label
+  command could be dropped and never run, and a dropped continuation
+  could reappear after a restart. The losing side now waits and runs on
+  a later poll once the queued work has been dispatched; a label
+  command keeps its label on the pull request until it actually starts,
+  so an unremoved label means the command is accepted but not yet
+  running; and a worker finishing normally no longer cancels work
+  queued while it was running. Two cases that could otherwise hold the
+  queue indefinitely are now bounded and reported: a reaction for an
+  issue parked outside every configured state is dropped after 30
+  minutes with a warning naming the reaction kind and the issue state,
+  instead of retrying at the backoff ceiling for the life of the
+  process and blocking that issue's other reactions, and a retry whose
+  timer event was lost under load is re-armed on a later poll instead
+  of stalling.
+  ([#743](https://github.com/sortie-ai/sortie/issues/743))
+
 ## [1.18.0] - 2026-08-09
 
 ### Added

--- a/docs/architecture/07-orchestration-state-machine.md
+++ b/docs/architecture/07-orchestration-state-machine.md
@@ -86,19 +86,30 @@ Distinct terminal reasons are important because retry logic and logs differ.
        made about this issue; overwriting it with the handoff state would undo it.
     3. A handoff state is configured, the issue is still in an active state, the exit is not a
        blocked soft stop, and the dispatch drives issue state. Perform the handoff transition
-       (Section 11.5) and release the claim. On transition failure, a soft-stop exit releases the
-       claim and a non-soft-stop exit schedules the continuation retry instead.
+       (Section 11.5). On a successful transition, release the claim, unless the retry slot
+       (Section 7.5) is occupied by an incumbent, in which case the incumbent is kept and the
+       claim stays so the poll loop cannot clear it. On transition failure, a soft-stop exit
+       releases the claim; a non-soft-stop exit schedules the continuation retry instead, unless
+       the retry slot is already occupied, in which case the exit defers to the incumbent.
     4. Any other soft stop. Suppress the continuation retry, cancel any pending retry, and release
        the claim. An unrecognized soft-stop reason is logged before taking this path.
     5. The issue is still in an active state and the dispatch drives issue state. Schedule the
        continuation retry (attempt `1`) so the next tick can re-check whether the issue needs
-       another worker session.
+       another worker session, unless the retry slot is already occupied, in which case the exit
+       defers to the incumbent instead.
     6. Otherwise the issue is no longer in an active state. Cancel any pending retry and release
-       the claim.
+       the claim, unless the retry slot is occupied by a foreign incumbent, in which case the
+       incumbent is kept and the claim stays to protect it — this is exactly the population
+       mid-session-queued retries need protected, since the issue may have left the active states
+       while a sibling reaction was still queued for it.
   - Reaction entries are enqueued only when the issue was claimed at the moment of exit, the exit
     either took the handoff disposition or left the issue still claimed, and the exit was not
-    suppressed by a terminal observation. A label-command dispatch never satisfies this predicate,
-    because it is excluded from the handoff disposition and releases its claim.
+    suppressed by a terminal observation. Because dispositions 3 and 6 can now retain the claim
+    solely to protect a foreign retry-slot incumbent, the predicate is evaluated as if that claim
+    had been released whenever it is retained for that reason alone, so protecting an incumbent
+    never widens which reaction kinds a later exit seeds. A label-command dispatch still never
+    satisfies this predicate: it takes disposition 6, and under this rule its retained claim
+    counts as released for the predicate's purposes exactly as an ordinary released claim would.
   - Subject to that predicate, each configured reaction kind records its own pending entry when
     the workspace SCM metadata (§9.5) satisfies that kind's field requirements. The kinds are
     independent: several fire from one exit. Every kind except the CI kind creates its entry only
@@ -109,7 +120,8 @@ Distinct terminal reasons are important because retry logic and logs differ.
   - Remove running entry.
   - Update aggregate runtime totals.
   - Persist completed run attempt to SQLite.
-  - Schedule exponential-backoff retry.
+  - Schedule an exponential-backoff retry when the retry slot (Section 7.5) is free; defer to the
+    incumbent already occupying it otherwise, keeping the claim.
 
 - `Agent Update Event`
   - Update live session fields, token counters, and rate limits.
@@ -121,14 +133,16 @@ Distinct terminal reasons are important because retry logic and logs differ.
   - Stop runs whose issue states are terminal or no longer active.
 
 - `Stall Timeout`
-  - Kill worker and schedule retry.
+  - Kill the worker unconditionally, then either schedule an exponential-backoff retry when the
+    retry slot (Section 7.5) is free, or defer to the incumbent already occupying it.
 
 - `CI Status Failing`
   - Persist CI failure run history.
   - Increment CI fix attempt counter.
-  - If within `ci_feedback.max_retries` (or `reactions.ci_failure.max_retries`): cancel the
-    existing continuation retry, schedule a CI-fix dispatch with failure context injected into
-    the prompt.
+  - If within `ci_feedback.max_retries` (or `reactions.ci_failure.max_retries`) and the retry slot
+    is free: schedule a CI-fix dispatch with failure context injected into the prompt. If the slot
+    is occupied by an incumbent, defer instead (Section 7.5): the run-history row is still
+    appended and the attempt counter still increments, but nothing is scheduled.
   - If retries exhausted: escalate (add label or post comment per escalation config),
     cancel retry, release claim.
 
@@ -136,9 +150,9 @@ Distinct terminal reasons are important because retry logic and logs differ.
   - Compute fingerprint from non-outdated review comment IDs.
   - If fingerprint is unchanged and already dispatched: skip.
   - If within debounce window: defer to next tick.
-  - If within `reactions.review_comments.max_continuation_turns`: cancel the existing
-    continuation retry, schedule a review-fix dispatch with review comment context injected
-    into the prompt.
+  - If within `reactions.review_comments.max_continuation_turns` and the retry slot is free:
+    schedule a review-fix dispatch with review comment context injected into the prompt. If the
+    slot is occupied by an incumbent, defer instead (Section 7.5).
   - If continuation turns exhausted: escalate (add label or post comment per escalation
     config), cancel retry, release claim.
 
@@ -185,4 +199,34 @@ Distinct terminal reasons are important because retry logic and logs differ.
   review pending entries for handoff-stage issues.
 6. Query tracker for active issues and reconcile with persisted state.
 7. Begin normal polling loop.
+
+### 7.5 Retry-Slot Arbitration
+
+`retry_attempts` holds at most one entry per issue: the retry slot. The entry's reaction kind
+records the owner, with the empty string meaning the orchestrator's own continuation lane. Every
+code path that wants to schedule a retry for an issue (a challenger) checks whether the slot is
+occupied before writing. A non-nil occupant (the incumbent) means another unit of work already
+owns the issue's next dispatch; the challenger defers instead of overwriting it, leaving the
+incumbent untouched and making no other state mutation. The rule keys on occupancy alone: it does
+not compare owners, rank reaction kinds, or preempt.
+
+Only two writers are exempt from checking first, because each frees the slot itself immediately
+before writing back into it: the retry-timer handler's inner reschedule, which pops and deletes
+the entry it is replacing before rescheduling it, and the overdue-retry re-arm pass (below), which
+cancels the same entry before re-arming it with a zero delay. Every other writer is admitted only
+into a free slot.
+
+Two liveness bounds keep an arbitrated slot from being held for the process lifetime:
+
+- A reaction retry that the issue's own current state does not permit to dispatch is rescheduled
+  with backoff, but only for as long as it has been pausing consecutively for that reason. Once
+  that dwell reaches 30 minutes, the entry is dropped instead of rescheduled, its persisted row
+  deleted, the claim released, and a warning logged naming the kind and how long it had paused.
+  The dwell resets whenever the entry is held for any other reason, so an otherwise healthy retry
+  is never penalized for an unrelated pause.
+- A retry entry whose timer event was dropped (Section 8.4) never fires again on its own. A
+  reconcile pass detects any entry whose due time is more than 60 seconds in the past and still
+  carries an active timer handle, and re-arms it with a zero delay, changing nothing about the
+  entry but its timer. A retry reconstructed at startup and still awaiting its first activation is
+  excluded from this pass, so a restart alone never produces the re-arm warning.
 

--- a/docs/architecture/07-orchestration-state-machine.md
+++ b/docs/architecture/07-orchestration-state-machine.md
@@ -137,12 +137,12 @@ Distinct terminal reasons are important because retry logic and logs differ.
     retry slot (Section 7.5) is free, or defer to the incumbent already occupying it.
 
 - `CI Status Failing`
-  - Persist CI failure run history.
-  - Increment CI fix attempt counter.
-  - If within `ci_feedback.max_retries` (or `reactions.ci_failure.max_retries`) and the retry slot
-    is free: schedule a CI-fix dispatch with failure context injected into the prompt. If the slot
-    is occupied by an incumbent, defer instead (Section 7.5): the run-history row is still
-    appended and the attempt counter still increments, but nothing is scheduled.
+  - Consult the retry slot (Section 7.5) first. If an incumbent occupies it, defer: re-enqueue the
+    pending entry with a refreshed `CreatedAt` and take none of the actions below on this tick —
+    no run-history row, no counter increment, no dispatch, and no escalation.
+  - On a free slot: persist CI failure run history and increment the CI fix attempt counter.
+  - If within `ci_feedback.max_retries` (or `reactions.ci_failure.max_retries`): schedule a CI-fix
+    dispatch with failure context injected into the prompt.
   - If retries exhausted: escalate (add label or post comment per escalation config),
     cancel retry, release claim.
 

--- a/docs/architecture/08-polling-scheduling-and-reconciliation.md
+++ b/docs/architecture/08-polling-scheduling-and-reconciliation.md
@@ -68,7 +68,9 @@ Optional SSH host limit:
 
 Retry entry creation:
 
-- Cancel any existing retry timer for the same issue.
+- The caller checks the retry slot first (Section 7.5): a challenger consults the slot and
+  schedules only when it is free. The cancellation the primitive performs internally is a
+  backstop for a call site that skipped the check, not the primitive's own contract.
 - Store `attempt`, `identifier`, `error`, `due_at_ms`, `session_id` (continuation retries propagate the session ID from the exiting worker; error and reaction retries leave it null), and new timer handle.
 
 Backoff formula:
@@ -86,6 +88,13 @@ Retry handling behavior:
    - Dispatch if slots are available.
    - Otherwise requeue with error `no available orchestrator slots`.
 5. If found but no longer active, release claim.
+6. A reaction retry the issue's own current state does not permit to dispatch is rescheduled with
+   backoff, but only for as long as it has been pausing consecutively for that reason; past 30
+   minutes of consecutive pausing it is dropped instead, its persisted row deleted and its claim
+   released, with a warning naming the kind and the dwell (Section 7.5).
+7. A retry entry whose timer event was never delivered is re-armed with a zero delay once its due
+   time is more than 60 seconds in the past, so a dropped timer event self-heals within a few
+   ticks instead of holding its slot for the process lifetime (Section 7.5).
 
 Per-issue effort budget (defense-in-depth):
 
@@ -140,7 +149,9 @@ Part A: Stall detection
 - For each running issue, compute `elapsed_ms` since:
   - `last_agent_timestamp` if any event has been seen, else
   - `started_at`
-- If `elapsed_ms > agent.stall_timeout_ms`, terminate the worker and queue a retry.
+- If `elapsed_ms > agent.stall_timeout_ms`, terminate the worker unconditionally, then queue a
+  retry when the retry slot is free or defer to the incumbent already occupying it, re-emitting
+  the cancellation warning on every stalled tick either way (Section 7.5).
 - If `stall_timeout_ms <= 0`, skip stall detection entirely.
 
 Part B: Tracker state refresh
@@ -151,7 +162,11 @@ Part B: Tracker state refresh
 - For each running issue:
   - If tracker state is terminal: terminate worker and clean workspace.
   - If tracker state is still active: update the in-memory issue snapshot.
-  - If tracker state is neither active nor terminal: terminate worker without workspace cleanup.
+  - If tracker state is neither active nor terminal: terminate the worker without workspace
+    cleanup, then cancel the pending retry and delete its persisted row, unless the retry slot is
+    occupied by an incumbent, in which case both are skipped together so the in-memory entry and
+    the persisted row stay in agreement and the incumbent survives (Section 7.5). This population
+    is exactly the mid-session-queued retries the design depends on protecting.
 - For an issue reported terminal, whether or not it has a running worker: release the issue's
   pending reaction entries, reaction attempt counters, pending retry, and dispatch claim, leaving
   `reaction_fingerprints` intact. An issue with no running worker and no terminal state is left
@@ -170,7 +185,8 @@ Part C: CI status reconciliation (when `ci_feedback.kind` or `reactions.ci_failu
   - If status is `passing`: clear reaction attempts for the issue and kind, and delete the
     fingerprint row.
   - If status is `pending`: re-enqueue with the same exponential backoff as the fetch-error path.
-  - If status is `failing`: handle as a CI failure (see Section 7.3, "CI Status Failing").
+  - If status is `failing`: consult the retry slot before handling as a CI failure; a non-nil
+    incumbent defers instead of dispatching (Section 7.5, Section 7.3 "CI Status Failing").
 
 Part D: Review comment reconciliation (when `reactions.review_comments` is configured)
 
@@ -190,9 +206,11 @@ Part D: Review comment reconciliation (when `reactions.review_comments` is confi
   - Check `reaction_fingerprints` table: if the fingerprint matches and is marked dispatched,
     re-enqueue with the poll interval delay and continue.
   - If within debounce window (`now - LastEventAt < debounce_ms`): defer and re-enqueue.
-  - Otherwise: cancel existing retry, schedule a review-fix dispatch with review comment
-    context, increment `reaction_attempts`. The fingerprint is marked dispatched later, when
-    the scheduled retry fires and dispatch succeeds, not during this pass.
+  - Otherwise: consult the retry slot (Section 7.5). A non-nil incumbent means the pass defers,
+    re-enqueuing the entry unchanged rather than dispatching. A free slot schedules a review-fix
+    dispatch with review comment context and increments `reaction_attempts`. The fingerprint is
+    marked dispatched later, when the scheduled retry fires and dispatch succeeds, not during
+    this pass.
 
 Part E: Bot review comment reconciliation (when `reactions.bot_review` is configured)
 
@@ -202,6 +220,8 @@ Part E: Bot review comment reconciliation (when `reactions.bot_review` is config
   authors) instead of `FetchPendingReviews`.
 - Dispatches immediately on a confirmed comment set, with no debounce window, because bot
   comments arrive in bulk on push rather than trickling in from a human reviewer.
+- Consults the retry slot before dispatching, exactly as Part D: a non-nil incumbent defers
+  instead (Section 7.5).
 - See Section 11D for the full contract.
 
 Part F: Merge conflict detection (when `reactions.merge_conflicts` is configured)
@@ -211,6 +231,8 @@ Part F: Merge conflict detection (when `reactions.merge_conflicts` is configured
   `SCMAdapter.GetMergeability` on every due tick (no retry-budget check gates the read). A
   dirty result runs the escalation-bearing conflict-resolution path; any other result closes
   the episode and clears its fingerprint and attempt counter.
+- The dirty branch consults the retry slot before its other guards (Section 7.5); a non-nil
+  incumbent defers the whole branch, re-enqueuing the entry unchanged.
 - See Section 11E for the full contract.
 
 Part G: Auto-merge reconciliation (when `reactions.auto_merge` is configured)
@@ -271,7 +293,10 @@ configured)
 
 - Skip entirely when no SCM adapter is configured or the `label_commands` block is absent.
 - For each Sortie-managed PR, read the label-event journal past its stored high-water mark via
-  `SCMAdapter.ListLabelEvents`; a confirmed `review_label` command dispatches a read-only,
+  `SCMAdapter.ListLabelEvents`. A confirmed `review_label` command is decided in this order: a
+  foreign-kind incumbent occupying the retry slot defers (Section 7.5), leaving the label and the
+  high-water mark untouched; a same-kind incumbent or a running worker of this kind collapses,
+  advancing the mark without a second dispatch; otherwise the pass dispatches a read-only,
   no-clone review session and removes the label.
 - Ordering relative to the other parts does not affect correctness: the pass is fully
   cross-kind isolated. See Section 11F for the full contract.
@@ -279,7 +304,7 @@ configured)
 Part I: Label fix command detection (when `reactions.label_commands.fix_label` is configured)
 
 - Structurally identical to Part H, scoped to the `fix_label` command and the `label-fix`
-  reaction kind.
+  reaction kind, including the same three-way retry-slot decision (Section 7.5).
 - A confirmed command dispatches a read-write, clone-and-checkout fix session instead of the
   read-only review session.
 - Ordering relative to the other parts does not affect correctness: the pass is fully

--- a/docs/architecture/12-ci-feedback-contract.md
+++ b/docs/architecture/12-ci-feedback-contract.md
@@ -143,17 +143,21 @@ result (Section 11A.4) and during escalation (Section 11A.7).
 
 ### 11A.6 CI failure handling
 
-When CI status is `failing`:
+When CI status is `failing`, the pass first consults the retry slot (Section 7.5). A non-nil
+incumbent means the pass defers: it re-enqueues the pending entry unchanged except for a
+refreshed `CreatedAt`, and none of the steps below run for this tick — no run-history row is
+appended, no counter increments, and escalation is not evaluated.
+
+On a free slot:
 
 1. Persist a CI-failure run history entry (`status: ci_failed`).
 2. Increment `reaction_attempts[issue_id:ci]`.
 3. If `reaction_attempts[issue_id:ci]` exceeds `ci_feedback.max_retries`: escalate (Section 11A.7).
 4. Otherwise:
    a. Convert `CIResult` to a template map via `ToTemplateMap()`.
-   b. Cancel the existing continuation retry for the issue.
-   c. Schedule a CI-fix dispatch carrying the CI failure context. The retry entry's
+   b. Schedule a CI-fix dispatch carrying the CI failure context. The retry entry's
       `ContinuationContext` field carries the map through the timer to the worker goroutine.
-   d. The worker injects the context into the prompt on turn 1 via `prompt.WithContinuationContext`.
+   c. The worker injects the context into the prompt on turn 1 via `prompt.WithContinuationContext`.
 
 CI-fix dispatches count toward the regular retry machinery but use a fixed delay rather than
 exponential backoff.

--- a/docs/architecture/13-pr-review-comment-feedback-contract.md
+++ b/docs/architecture/13-pr-review-comment-feedback-contract.md
@@ -100,8 +100,10 @@ CI status reconciliation. The flow is:
       matches and is marked dispatched: skip, re-enqueue with poll interval delay.
    j. If `now - LastEventAt < debounce_ms`: set `PendingRetryAt = LastEventAt + debounce_ms`,
       re-enqueue.
-   k. Cancel existing retry for the issue.
-   l. Schedule review-fix dispatch with `ContinuationContext{"review_comments": [...]}`.
+   k. Consult the retry slot (Section 7.5). A non-nil incumbent means the pass defers,
+      re-enqueuing the entry unchanged rather than dispatching.
+   l. On a free slot: schedule review-fix dispatch with
+      `ContinuationContext{"review_comments": [...]}`.
    m. Increment `reaction_attempts[issue_id:review]`.
    n. The fingerprint is marked dispatched in `reaction_fingerprints` later, in
       `HandleRetryTimer`, after the scheduled retry fires and dispatch succeeds.
@@ -111,8 +113,10 @@ CI status reconciliation. The flow is:
 When actionable review comments are detected and debounce has elapsed:
 
 1. Build a template map from actionable comments (Section 12.1).
-2. Cancel existing continuation retry for the issue.
-3. Schedule a review-fix dispatch carrying the review comment context via `ContinuationContext`.
+2. Consult the retry slot (Section 7.5). A non-nil incumbent means the pass defers instead of
+   dispatching, leaving the incumbent untouched.
+3. On a free slot: schedule a review-fix dispatch carrying the review comment context via
+   `ContinuationContext`.
 4. The worker injects the context into the prompt on turn 1 via `prompt.WithContinuationContext`.
 
 Review-fix dispatches count toward the regular retry machinery but use a fixed delay rather than

--- a/docs/architecture/15-bot-review-comment-feedback-contract.md
+++ b/docs/architecture/15-bot-review-comment-feedback-contract.md
@@ -67,10 +67,12 @@ allowlist instead of `FetchPendingReviews`. The flow:
    g. Filter outdated comments. When none remain, re-enqueue with the poll-interval delay.
    h. Compute the fingerprint (§11D.4) and upsert it. When the stored fingerprint matches and is
       marked dispatched, re-enqueue with the poll-interval delay.
-   i. Dispatch immediately, with no debounce window: count
-      `sortie_bot_review_checks_total{result="dispatched"}`, cancel any in-flight first-turn retry
-      for the issue, schedule a continuation dispatch carrying the bot comments under the prompt key
-      `bot_review_comments`, and increment `reaction_attempts[issue_id:bot-review]`.
+   i. Consult the retry slot (Section 7.5). A non-nil incumbent means the pass defers,
+      re-enqueuing the entry unchanged rather than dispatching.
+   j. On a free slot, dispatch immediately, with no debounce window: count
+      `sortie_bot_review_checks_total{result="dispatched"}`, schedule a continuation dispatch
+      carrying the bot comments under the prompt key `bot_review_comments`, and increment
+      `reaction_attempts[issue_id:bot-review]`.
 
 Immediate dispatch is the defining runtime difference from `review`: bot comments arrive in bulk on
 push, so there is no reviewer-pacing window to wait out.

--- a/docs/architecture/16-merge-conflict-reaction-contract.md
+++ b/docs/architecture/16-merge-conflict-reaction-contract.md
@@ -68,9 +68,13 @@ Loop body per `ReactionKindMergeConflict` entry in `state.PendingReactions`:
 
 ### 11E.4 Fingerprint and deduplication
 
-Before any dispatch, the dirty branch applies two precondition guards. Both run before any counter
-increment, so a deferral never burns an attempt:
+Before any dispatch, the dirty branch applies three precondition guards, in order. All three run
+before any counter increment, so a deferral never burns an attempt:
 
+- **Retry-slot guard**: consult the retry slot (Section 7.5) first, ahead of every other guard. A
+  non-nil incumbent means the branch defers as a whole, re-enqueuing the pending entry unchanged
+  except for a refreshed `CreatedAt` and returning without touching the fingerprint, the counter,
+  or `sortie_merge_conflict_checks_total`.
 - **D1a**: if `status.HeadSHA == ""`, defer at poll interval (no rebase anchor).
 - **D1b**: if `status.BaseBranch == ""`, defer at poll interval (no rebase target). This is
   defense-in-depth: the GitHub adapter always populates `BaseBranch` from `base.ref`, so D1b is a
@@ -129,8 +133,13 @@ tracker-call failures are logged and counted
 
 ### 11E.6 Continuation data
 
-`dispatchMergeConflictContinuation` calls `CancelRetry`, then schedules a continuation turn via
-`ScheduleRetry` with the prompt key `merge_conflict`. The continuation map contains:
+The retry-slot guard in Section 11E.4 is unaffected by anything in this section: a deferral
+returns before `dispatchMergeConflictContinuation` is ever called, so the `MarkReactionDispatched`
+timing this section describes only ever runs on a tick that actually dispatches.
+
+`dispatchMergeConflictContinuation` schedules a continuation turn via `ScheduleRetry` with the
+prompt key `merge_conflict`, admitted into the slot the guard above already confirmed is free. The
+continuation map contains:
 
 | Key | Value |
 |-----|-------|

--- a/docs/architecture/21-reference-algorithms.md
+++ b/docs/architecture/21-reference-algorithms.md
@@ -381,11 +381,14 @@ on_worker_exit(issue_id, reason, state):
       notify_observers()
       return state
 
-    state = schedule_retry(state, issue_id, 1, {
-      identifier: running_entry.identifier,
-      delay_type: continuation,
-      session_id: running_entry.session_id
-    })
+    if retry_slot_incumbent(state, issue_id) is nil:
+      state = schedule_retry(state, issue_id, 1, {
+        identifier: running_entry.identifier,
+        delay_type: continuation,
+        session_id: running_entry.session_id
+      })
+    # else: the retry slot (Section 7.5) is occupied, so this exit defers
+    # to the incumbent instead of scheduling a continuation.
 
     # Enqueue CI check when provider is configured and workspace has SCM metadata
     if ci_provider is not nil and workspace_path is not empty:
@@ -413,10 +416,13 @@ on_worker_exit(issue_id, reason, state):
               branch: scm.branch, sha: scm.sha
             }
   else:
-    state = schedule_retry(state, issue_id, next_attempt_from(running_entry), {
-      identifier: running_entry.identifier,
-      error: format("worker exited: %reason")
-    })
+    if retry_slot_incumbent(state, issue_id) is nil:
+      state = schedule_retry(state, issue_id, next_attempt_from(running_entry), {
+        identifier: running_entry.identifier,
+        error: format("worker exited: %reason")
+      })
+    # else: the retry slot (Section 7.5) is occupied, so this exit defers
+    # to the incumbent instead of scheduling a backoff retry.
 
   notify_observers()
   return state

--- a/docs/architecture/28-label-command-and-read-only-review-contract.md
+++ b/docs/architecture/28-label-command-and-read-only-review-contract.md
@@ -164,18 +164,26 @@ Loop body per `label-review` entry in `pending_reactions`:
    unchanged.
 7. Compute the newest examined position. Collapse matching `labeled` events to at most one command
    and evaluate the retraction check.
-8. When a command is confirmed and no command of this kind is already queued or running: persist the
-   newest mark, then cancel any existing retry and schedule a fresh read-only dispatch carrying the
-   PR coordinates, then remove the label best-effort, then re-enqueue the entry at the next poll
-   interval.
-9. Otherwise (retraction, foreign labels, unlabeled-only, or collapse into an outstanding command):
-   persist the newest mark and re-enqueue at the poll interval without dispatching.
+8. When a command is confirmed, decide in this order:
+   a. A foreign-kind incumbent occupies the retry slot (Section 7.5): defer. Re-enqueue the entry
+      with the mark unchanged and `CreatedAt` refreshed to the tick's `now`; do not upsert the
+      mark, do not advance the high-water mark, and do not remove the label.
+   b. A same-kind incumbent occupies the slot, or a `label-review` worker is already running:
+      collapse. Persist the newest mark and re-enqueue at the poll interval without dispatching.
+   c. Otherwise: dispatch. Persist the newest mark, schedule a fresh read-only dispatch carrying
+      the PR coordinates into the slot the check above already confirmed free, remove the label
+      best-effort, and re-enqueue the entry at the next poll interval.
+9. When a command is not confirmed (retraction, foreign labels, or unlabeled-only): persist the
+   newest mark and re-enqueue at the poll interval without dispatching. This arm does not consult
+   the retry slot.
 
-The re-enqueue at step 8 is the property the sibling passes lack. Worker-exit seeding (§11F.9)
-cannot re-arm detection after a review completes, because a read-only exit never passes the
-reaction-enqueue gate. The pass instead keeps the detection entry alive across its own dispatch,
-carrying the PR identity in the entry's kind data, so a re-applied label after a completed review
-is detected on a later tick without a process restart.
+The re-enqueue at step 8c is the property the sibling passes lack. Worker-exit seeding (§11F.9)
+cannot re-arm detection after a review completes, because a read-only exit's claim, even when
+retained solely to protect a foreign retry-slot incumbent, is evaluated as released for the
+reaction-enqueue gate (Section 7.5), so a label-command dispatch never seeds any reaction kind.
+The pass instead keeps the detection entry alive across its own dispatch, carrying the PR identity
+in the entry's kind data, so a re-applied label after a completed review is detected on a later
+tick without a process restart.
 
 Cross-kind isolation: the pass MUST scope every `pending_reactions` and `reaction_fingerprints`
 mutation to `kind = "label-review"`. It MUST NOT read or write any other kind's entry, fingerprint,
@@ -455,9 +463,10 @@ Per-issue `label-review` reaction lifecycle (the `issue_id:label-review` slot):
 | pending | Reconcile tick, `now < PendingRetryAt` | pending | Re-enqueue, no journal read. |
 | pending | Reconcile tick, journal fetch error | pending | Increment backoff, set `PendingRetryAt`, re-enqueue. |
 | pending | Reconcile tick, no events past the mark | pending | Re-enqueue at the poll interval; mark unchanged. |
-| pending | Reconcile tick, new events but no confirmed command (retraction, foreign or unlabeled only, or collapse into an outstanding command) | pending | Advance the mark; re-enqueue at the poll interval; no dispatch. |
-| pending | Reconcile tick, confirmed command, none queued or running | dispatched | Advance the mark; schedule the read-only dispatch; remove the label best-effort; re-enqueue at the poll interval. |
+| pending | Reconcile tick, new events but no confirmed command (retraction, foreign or unlabeled only) | pending | Advance the mark; re-enqueue at the poll interval; no dispatch. |
+| pending | Reconcile tick, confirmed command, a foreign-kind incumbent occupies the retry slot (Section 7.5) | pending | Defer: re-enqueue with the mark unchanged and `CreatedAt` refreshed; no mark advance, no dispatch, no label removal. |
 | pending | Reconcile tick, confirmed command, a `label-review` command already queued or running | pending | Advance the mark; re-enqueue; the gesture collapses into the outstanding command. |
+| pending | Reconcile tick, confirmed command, retry slot free | dispatched | Advance the mark; schedule the read-only dispatch; remove the label best-effort; re-enqueue at the poll interval. |
 | pending | Issue reaches terminal state (tracker reconcile) | (none) | Drop the pending entry; cancel and delete the issue's retry; release the claim. Detection stops polling on the next tick. |
 
 Per-issue `label-fix` reaction lifecycle (the `issue_id:label-fix` slot) follows the same three
@@ -471,9 +480,10 @@ transition schedules:
 | pending | Reconcile tick, `now < PendingRetryAt` | pending | Re-enqueue, no journal read. |
 | pending | Reconcile tick, journal fetch error | pending | Increment backoff, set `PendingRetryAt`, re-enqueue. |
 | pending | Reconcile tick, no events past the mark | pending | Re-enqueue at the poll interval; mark unchanged. |
-| pending | Reconcile tick, new events but no confirmed command (retraction, foreign or unlabeled only, or collapse into an outstanding command) | pending | Advance the mark; re-enqueue at the poll interval; no dispatch. |
-| pending | Reconcile tick, confirmed command, none queued or running | dispatched | Advance the mark; schedule the fix dispatch (§11F.13); remove the label best-effort; re-enqueue at the poll interval. |
+| pending | Reconcile tick, new events but no confirmed command (retraction, foreign or unlabeled only) | pending | Advance the mark; re-enqueue at the poll interval; no dispatch. |
+| pending | Reconcile tick, confirmed command, a foreign-kind incumbent occupies the retry slot (Section 7.5) | pending | Defer: re-enqueue with the mark unchanged and `CreatedAt` refreshed; no mark advance, no dispatch, no label removal. |
 | pending | Reconcile tick, confirmed command, a `label-fix` command already queued or running | pending | Advance the mark; re-enqueue; the gesture collapses into the outstanding command. |
+| pending | Reconcile tick, confirmed command, retry slot free | dispatched | Advance the mark; schedule the fix dispatch (§11F.13); remove the label best-effort; re-enqueue at the poll interval. |
 | pending | Issue reaches terminal state (tracker reconcile) | (none) | Drop the pending entry; cancel and delete the issue's retry; release the claim. Detection stops polling on the next tick. |
 
 A PR record whose head branch is empty seeds and recovers no `label-fix` entry at all: the slot

--- a/internal/orchestrator/bot_review_reconcile.go
+++ b/internal/orchestrator/bot_review_reconcile.go
@@ -132,12 +132,18 @@ func reconcileBotReviewComments(state *State, params ReconcileParams, log *slog.
 			continue
 		}
 
+		// Arbitrate the retry slot before dispatching.
+		if incumbent := retrySlotIncumbent(state, pending.IssueID); incumbent != nil {
+			logRetrySlotDeferral(entryLog, ReactionKindBotReview, incumbent)
+			pending.CreatedAt = now
+			state.PendingReactions[key] = pending
+			continue
+		}
+
 		// Dispatch immediately: bot comments are not debounced.
 		metrics.IncBotReviewChecks("dispatched")
 
 		botContext := buildReviewTemplateMap(actionable)
-
-		CancelRetry(state, pending.IssueID)
 
 		ScheduleRetry(state, ScheduleRetryParams{
 			IssueID:     pending.IssueID,
@@ -153,6 +159,7 @@ func reconcileBotReviewComments(state *State, params ReconcileParams, log *slog.
 			AgentKind:    pending.AgentKind,
 			RuleName:     pending.RuleName,
 			TemplateID:   pending.TemplateID,
+			Logger:       entryLog,
 		}, params.OnRetryFire)
 
 		state.ReactionAttempts[rkey]++

--- a/internal/orchestrator/bot_review_reconcile_test.go
+++ b/internal/orchestrator/bot_review_reconcile_test.go
@@ -1366,11 +1366,10 @@ func TestEscalateBotReviewFailure_DeleteFingerprintError(t *testing.T) {
 // The per-kind tracking state stays independent: each pass advances only its
 // own fingerprint row and attempt counter and consumes only its own pending
 // slot. The retry slot is shared: RetryAttempts is keyed by issue ID alone,
-// so the later bot-review pass overwrites the review pass's retry and only the
-// bot-review continuation survives the cycle. That overwrite does not strand
-// the review continuation, because its fingerprint stays undispatched and its
-// pending slot is recreated on the next worker exit, so it re-dispatches on a
-// later tick.
+// so the later bot-review pass finds the review retry occupying the slot and
+// defers to it instead of overwriting it. The deferral leaves the review
+// continuation as the incumbent and re-enqueues the bot-review pending entry
+// unconsumed, so bot-review re-detects on the next tick once the slot frees.
 func TestReconcileBotReviewComments_CoexistsWithReview(t *testing.T) {
 	t.Parallel()
 
@@ -1408,8 +1407,7 @@ func TestReconcileBotReviewComments_CoexistsWithReview(t *testing.T) {
 	reconcileReviewComments(state, params, discardLogger(), context.Background(), reviewMetrics)
 
 	// The review pass schedules its continuation retry in the issue-ID-keyed
-	// slot. Capture it to prove the bot-review pass overwrites it below, not to
-	// claim both retries survive the cycle.
+	// slot, becoming the incumbent the bot-review pass defers to below.
 	reviewRetry, reviewScheduled := state.RetryAttempts[issueID]
 	if !reviewScheduled {
 		t.Fatal("retry not scheduled after review dispatch; want scheduled")
@@ -1420,61 +1418,65 @@ func TestReconcileBotReviewComments_CoexistsWithReview(t *testing.T) {
 	if _, ok := reviewRetry.ContinuationContext["review_comments"]; !ok {
 		t.Error("review RetryEntry.ContinuationContext missing review_comments key")
 	}
+	reviewAttempt := reviewRetry.Attempt
 
 	reconcileBotReviewComments(state, params, discardLogger(), context.Background(), botMetrics)
 
-	// ScheduleRetry cancels the prior entry, so the bot-review pass replaces the
-	// review retry in the shared slot: only the bot-review continuation remains.
-	botRetry, botScheduled := state.RetryAttempts[issueID]
-	if !botScheduled {
-		t.Fatal("retry not scheduled after bot-review dispatch; want scheduled")
+	// The retry slot still holds the review incumbent, untouched by the
+	// deferring bot-review pass.
+	botRetry, stillScheduled := state.RetryAttempts[issueID]
+	if !stillScheduled {
+		t.Fatal("retry entry removed from slot; want review incumbent preserved")
 	}
-	if botRetry.ReactionKind != ReactionKindBotReview {
-		t.Errorf("bot-review RetryEntry.ReactionKind = %q, want %q", botRetry.ReactionKind, ReactionKindBotReview)
+	if botRetry != reviewRetry {
+		t.Error("RetryAttempts[issueID] replaced; want the original review entry preserved")
 	}
-	if _, ok := botRetry.ContinuationContext["bot_review_comments"]; !ok {
-		t.Error("bot-review RetryEntry.ContinuationContext missing bot_review_comments key")
+	if botRetry.ReactionKind != ReactionKindReview {
+		t.Errorf("RetryAttempts[issueID].ReactionKind = %q, want %q (review incumbent survives)", botRetry.ReactionKind, ReactionKindReview)
 	}
-	if botRetry == reviewRetry {
-		t.Error("RetryAttempts[issueID] = review entry, want bot-review entry (review retry overwritten)")
+	if botRetry.Attempt != reviewAttempt {
+		t.Errorf("RetryAttempts[issueID].Attempt = %d, want %d (unchanged by deferral)", botRetry.Attempt, reviewAttempt)
 	}
 	if len(state.RetryAttempts) != 1 {
-		t.Errorf("len(RetryAttempts) = %d, want 1 (review and bot-review share one issue-ID slot)", len(state.RetryAttempts))
+		t.Errorf("len(RetryAttempts) = %d, want 1 (bot-review defers instead of taking a second slot)", len(state.RetryAttempts))
 	}
 
 	if reviewMetrics.reviewChecks["dispatched"] != 1 {
 		t.Errorf(`IncReviewChecks("dispatched") = %d, want 1`, reviewMetrics.reviewChecks["dispatched"])
 	}
-	if botMetrics.botReviewChecks["dispatched"] != 1 {
-		t.Errorf(`IncBotReviewChecks("dispatched") = %d, want 1`, botMetrics.botReviewChecks["dispatched"])
+	if botMetrics.botReviewChecks["dispatched"] != 0 {
+		t.Errorf(`IncBotReviewChecks("dispatched") = %d, want 0 (deferred, not dispatched)`, botMetrics.botReviewChecks["dispatched"])
 	}
 	if state.ReactionAttempts[reviewKey] != 1 {
 		t.Errorf("ReactionAttempts[%s] = %d, want 1", reviewKey, state.ReactionAttempts[reviewKey])
 	}
-	if state.ReactionAttempts[botKey] != 1 {
-		t.Errorf("ReactionAttempts[%s] = %d, want 1", botKey, state.ReactionAttempts[botKey])
+	if _, ok := state.ReactionAttempts[botKey]; ok {
+		t.Errorf("ReactionAttempts[%s] present, want absent (deferral does not advance the counter)", botKey)
 	}
 
 	if _, ok := state.PendingReactions[reviewKey]; ok {
 		t.Error("review PendingReactions entry still present; want consumed by its own dispatch")
 	}
-	if _, ok := state.PendingReactions[botKey]; ok {
-		t.Error("bot-review PendingReactions entry still present; want consumed by its own dispatch")
+	botPending, botReenqueued := state.PendingReactions[botKey]
+	if !botReenqueued {
+		t.Fatal("bot-review PendingReactions entry missing; want re-enqueued by the deferral")
+	}
+	if botPending.CreatedAt != botReviewBaseTime {
+		t.Errorf("bot-review PendingReactions.CreatedAt = %v, want %v (refreshed to the tick's now)", botPending.CreatedAt, botReviewBaseTime)
 	}
 
 	reviewFingerprint := store.fingerprints[reviewKey].fingerprint
-	botFingerprint := store.fingerprints[botKey].fingerprint
 	if reviewFingerprint == "" {
 		t.Error("review fingerprint row is empty; want a non-empty hash after review dispatch")
 	}
-	if botFingerprint == "" {
-		t.Error("bot-review fingerprint row is empty; want a non-empty hash after bot-review dispatch")
-	}
-	if reviewFingerprint == botFingerprint {
-		t.Errorf("review and bot-review fingerprints both equal %q; want distinct values scoped to each kind", reviewFingerprint)
+	// The fingerprint upsert is per-tick bookkeeping that runs before the
+	// arbitration decision, so it still records the observed comment set;
+	// only the dispatched flag distinguishes a deferral from a dispatch.
+	if store.fingerprints[botKey].dispatched {
+		t.Error("bot-review fingerprint marked dispatched; want undispatched after a deferral")
 	}
 
 	if _, ok := state.Claimed[issueID]; !ok {
-		t.Error("state.Claimed[issueID] cleared during coexistence dispatch; want preserved")
+		t.Error("state.Claimed[issueID] cleared during deferral; want preserved")
 	}
 }

--- a/internal/orchestrator/ci_reconcile.go
+++ b/internal/orchestrator/ci_reconcile.go
@@ -165,7 +165,13 @@ func reconcileCIStatus(state *State, params ReconcileParams, log *slog.Logger, c
 			)
 
 		case domain.CIStatusFailing:
-			handleCIFailure(state, params, pending, result, ref, entryLog, ctx, metrics)
+			if incumbent := retrySlotIncumbent(state, pending.IssueID); incumbent != nil {
+				logRetrySlotDeferral(entryLog, ReactionKindCI, incumbent)
+				pending.CreatedAt = now
+				state.PendingReactions[key] = pending
+			} else {
+				handleCIFailure(state, params, pending, result, ref, entryLog, ctx, metrics)
+			}
 
 		default:
 			entryLog.Warn("CI status provider returned unrecognized status, re-enqueueing",
@@ -224,8 +230,6 @@ func handleCIFailure(
 
 	ciContext := result.ToTemplateMap()
 
-	CancelRetry(state, pending.IssueID)
-
 	nextAttempt := pending.Attempt
 
 	ScheduleRetry(state, ScheduleRetryParams{
@@ -243,6 +247,7 @@ func handleCIFailure(
 		AgentKind:    pending.AgentKind,
 		RuleName:     pending.RuleName,
 		TemplateID:   pending.TemplateID,
+		Logger:       log,
 	}, params.OnRetryFire)
 	metrics.IncRetries(triggerCIFix)
 

--- a/internal/orchestrator/ci_reconcile_test.go
+++ b/internal/orchestrator/ci_reconcile_test.go
@@ -1374,3 +1374,116 @@ func TestReconcileCIStatus_Failing_ExceedsMaxRetries_CrossKindIsolation(t *testi
 		t.Errorf("DeleteReactionFingerprint calls = %d, want 1 (the CI kind's own fingerprint)", store.deleteFingerprintCalls)
 	}
 }
+
+// --- Retry-slot arbitration tests ---
+
+// TestReconcileCIStatus_Failing_DeferralLeavesNoOrphanedRow seeds a
+// persisted retry row and a matching in-memory continuation entry, then
+// drives the CI pass with a failing status for the same issue. The
+// continuation entry must stay the incumbent, no ci retry may replace
+// it, and the persisted row must be left exactly as seeded: a
+// displacement that cancelled the in-memory entry without deleting its
+// persisted row would leave an orphan, which this test would catch via
+// LoadRetryEntries.
+func TestReconcileCIStatus_Failing_DeferralLeavesNoOrphanedRow(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store := openInMemoryStore(t)
+
+	const issueID = "ISS-CI-ORPHAN"
+	seeded := persistence.RetryEntry{
+		IssueID:    issueID,
+		Identifier: issueID + "-ident",
+		Attempt:    5,
+		DueAtMs:    ciBaseTime.UnixMilli() + 60_000,
+	}
+	if err := store.SaveRetryEntry(ctx, seeded); err != nil {
+		t.Fatalf("SaveRetryEntry: %v", err)
+	}
+
+	state := stateWithPendingReaction(t, issueID, "feature/orphan", 1)
+	state.RetryAttempts[issueID] = &RetryEntry{
+		IssueID:    issueID,
+		Identifier: issueID + "-ident",
+		Attempt:    5,
+		DueAtMS:    seeded.DueAtMs,
+		// ReactionKind empty marks a continuation incumbent.
+	}
+
+	metrics := newCIMetricsSpy()
+	ci := &mockCIProvider{result: domain.CIResult{Status: domain.CIStatusFailing, FailingCount: 1}}
+	params := ReconcileParams{
+		CIProvider:     ci,
+		CIFeedback:     defaultCIFeedback(),
+		Store:          store,
+		OnRetryFire:    noopRetryFire,
+		Ctx:            ctx,
+		Logger:         discardLogger(),
+		ActiveStates:   []string{"In Progress"},
+		TerminalStates: []string{"Done"},
+	}
+
+	reconcileCIStatus(state, params, discardLogger(), ctx, metrics)
+
+	incumbent, ok := state.RetryAttempts[issueID]
+	if !ok {
+		t.Fatal("RetryAttempts entry removed while a continuation incumbent occupied the slot; want preserved")
+	}
+	if incumbent.ReactionKind != "" {
+		t.Errorf("RetryAttempts.ReactionKind = %q, want empty (continuation entry unchanged)", incumbent.ReactionKind)
+	}
+	if incumbent.Attempt != 5 {
+		t.Errorf("RetryAttempts.Attempt = %d, want 5 (unchanged)", incumbent.Attempt)
+	}
+
+	rows, err := store.LoadRetryEntries(ctx)
+	if err != nil {
+		t.Fatalf("LoadRetryEntries: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("LoadRetryEntries returned %d rows, want 1", len(rows))
+	}
+	if rows[0].IssueID != issueID {
+		t.Errorf("persisted row IssueID = %q, want %q", rows[0].IssueID, issueID)
+	}
+	if rows[0].Attempt != seeded.Attempt {
+		t.Errorf("persisted row Attempt = %d, want %d (unchanged)", rows[0].Attempt, seeded.Attempt)
+	}
+	if rows[0].DueAtMs != seeded.DueAtMs {
+		t.Errorf("persisted row DueAtMs = %d, want %d (unchanged)", rows[0].DueAtMs, seeded.DueAtMs)
+	}
+}
+
+// TestReconcileCIStatus_Pending_LeavesCreatedAtUnchanged covers the
+// negative side of the CreatedAt refresh rule: the CIStatusPending arm
+// is the pass's own transient backoff, not an arbitration deferral, so
+// it must not touch CreatedAt even though PendingAttempts advances.
+func TestReconcileCIStatus_Pending_LeavesCreatedAtUnchanged(t *testing.T) {
+	t.Parallel()
+
+	const issueID = "ISS-CI-TTL-NEG"
+	state := stateWithPendingReaction(t, issueID, "feature/ttl", 1)
+	rkey := ReactionKey(issueID, ReactionKindCI)
+	seededCreatedAt := ciBaseTime.Add(-5 * time.Minute)
+	state.PendingReactions[rkey].CreatedAt = seededCreatedAt
+
+	store := &ciReconcileStore{}
+	metrics := newCIMetricsSpy()
+	ci := &mockCIProvider{result: domain.CIResult{Status: domain.CIStatusPending}}
+	params := ciParams(t, store, ci, nil)
+	params.NowFunc = func() time.Time { return ciBaseTime }
+
+	reconcileCIStatus(state, params, discardLogger(), context.Background(), metrics)
+
+	entry, ok := state.PendingReactions[rkey]
+	if !ok {
+		t.Fatal("PendingReactions entry dropped on CI pending; want re-enqueued")
+	}
+	if !entry.CreatedAt.Equal(seededCreatedAt) {
+		t.Errorf("CreatedAt = %v, want unchanged %v", entry.CreatedAt, seededCreatedAt)
+	}
+	if entry.PendingAttempts != 1 {
+		t.Errorf("PendingAttempts = %d, want 1 (the tick ran)", entry.PendingAttempts)
+	}
+}

--- a/internal/orchestrator/dispatch.go
+++ b/internal/orchestrator/dispatch.go
@@ -3,6 +3,7 @@ package orchestrator
 import (
 	"cmp"
 	"context"
+	"log/slog"
 	"slices"
 	"strings"
 	"time"
@@ -216,6 +217,38 @@ func CancelRetry(state *State, issueID string) {
 	delete(state.RetryAttempts, issueID)
 }
 
+// retrySlotIncumbent returns the retry entry occupying the issue's retry
+// slot, or nil when the slot is free. The retry slot holds at most one
+// entry per issue; a non-nil result means another unit of work already
+// owns the issue's next dispatch.
+func retrySlotIncumbent(state *State, issueID string) *RetryEntry {
+	return state.RetryAttempts[issueID]
+}
+
+// retrySlotOwnerLabel returns the reaction kind reported in a retry-slot
+// log record, substituting the literal "continuation" for the empty
+// reaction kind that marks the orchestrator's own continuation lane.
+func retrySlotOwnerLabel(reactionKind string) string {
+	if reactionKind == "" {
+		return "continuation"
+	}
+	return reactionKind
+}
+
+// logRetrySlotDeferral records that a challenger left the retry slot to
+// its incumbent.
+func logRetrySlotDeferral(log *slog.Logger, challenger string, incumbent *RetryEntry) {
+	if log == nil {
+		log = slog.Default()
+	}
+	log.Debug("retry slot occupied, deferring",
+		slog.String("challenger_kind", challenger),
+		slog.String("incumbent_kind", retrySlotOwnerLabel(incumbent.ReactionKind)),
+		slog.Int("incumbent_attempt", incumbent.Attempt),
+		slog.Int64("incumbent_due_at_ms", incumbent.DueAtMS),
+	)
+}
+
 // ScheduleRetryParams holds the inputs for [ScheduleRetry].
 type ScheduleRetryParams struct {
 	IssueID     string
@@ -226,6 +259,10 @@ type ScheduleRetryParams struct {
 	Error       string
 	LastSSHHost string // Runtime-only: SSH host from previous attempt for retry affinity.
 	SessionID   string // Session identifier from previous attempt for cross-retry resume.
+
+	// Logger receives the displacement warning when ScheduleRetry finds
+	// the retry slot occupied. Nil selects slog.Default().
+	Logger *slog.Logger
 
 	// ContinuationContext carries reaction continuation data to inject
 	// into the prompt template on the first turn of the retry worker.
@@ -253,10 +290,17 @@ type ScheduleRetryParams struct {
 	TemplateID string
 }
 
-// ScheduleRetry cancels any existing retry for the issue, creates a new
-// timer, and stores a [RetryEntry] in the state's retry map. The onFire
-// callback is invoked when the timer expires; the caller provides the
-// retry-timer handler. The claim on the issue is preserved.
+// ScheduleRetry creates a new timer and stores a [RetryEntry] in the
+// state's retry map. The onFire callback is invoked when the timer
+// expires; the caller provides the retry-timer handler. The claim on the
+// issue is preserved.
+//
+// Callers MUST consult [retrySlotIncumbent] for the issue and call
+// ScheduleRetry only when it returns nil, so the write always lands in a
+// free slot. HandleRetryTimer's inner reschedule closure is the one
+// exception: it pops and deletes the entry it is rescheduling before
+// calling ScheduleRetry, so it always writes back into the slot it just
+// freed.
 //
 // Concurrency note: [time.Timer.Stop] does not guarantee the callback
 // will not fire if the timer goroutine has already been scheduled. The
@@ -269,6 +313,22 @@ func ScheduleRetry(state *State, params ScheduleRetryParams, onFire func(issueID
 		panic("ScheduleRetry: nil onFire callback")
 	}
 
+	if incumbent := retrySlotIncumbent(state, params.IssueID); incumbent != nil {
+		log := params.Logger
+		if log == nil {
+			log = slog.Default()
+		}
+		log.Warn("retry slot displaced",
+			slog.String("challenger_kind", retrySlotOwnerLabel(params.ReactionKind)),
+			slog.String("incumbent_kind", retrySlotOwnerLabel(incumbent.ReactionKind)),
+			slog.Int("incumbent_attempt", incumbent.Attempt),
+		)
+	}
+
+	// Callers check the slot first, so this call never displaces an
+	// entry in practice. It stays as a backstop that frees the slot on
+	// the rare call site that skips the check, and it is what the Warn
+	// above reports when that happens.
 	CancelRetry(state, params.IssueID)
 
 	delayMS := max(params.DelayMS, 0)

--- a/internal/orchestrator/dispatch_test.go
+++ b/internal/orchestrator/dispatch_test.go
@@ -1,7 +1,10 @@
 package orchestrator
 
 import (
+	"bytes"
 	"context"
+	"log/slog"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -703,17 +706,23 @@ func TestScheduleRetry(t *testing.T) {
 		s := newTestState()
 		oldTimer := time.AfterFunc(time.Hour, func() {})
 		s.RetryAttempts["ISS-1"] = &RetryEntry{
-			IssueID:     "ISS-1",
-			Attempt:     1,
-			TimerHandle: oldTimer,
+			IssueID:      "ISS-1",
+			Attempt:      1,
+			ReactionKind: ReactionKindCI,
+			TimerHandle:  oldTimer,
 		}
 
+		var buf bytes.Buffer
+		log := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
 		ScheduleRetry(s, ScheduleRetryParams{
-			IssueID:    "ISS-1",
-			Identifier: "ISS-1",
-			Attempt:    2,
-			DelayMS:    1000,
-			Error:      "retry again",
+			IssueID:      "ISS-1",
+			Identifier:   "ISS-1",
+			Attempt:      2,
+			DelayMS:      1000,
+			Error:        "retry again",
+			ReactionKind: ReactionKindReview,
+			Logger:       log,
 		}, func(_ string) {})
 
 		entry := s.RetryAttempts["ISS-1"]
@@ -724,6 +733,24 @@ func TestScheduleRetry(t *testing.T) {
 		if oldTimer.Stop() {
 			t.Error("old timer was not stopped by ScheduleRetry")
 		}
+
+		output := buf.String()
+		if !strings.Contains(output, "level=WARN") {
+			t.Errorf("log output = %q, want a Warn-level record", output)
+		}
+		if !strings.Contains(output, "retry slot displaced") {
+			t.Errorf("log output = %q, want message %q", output, "retry slot displaced")
+		}
+		if !strings.Contains(output, "challenger_kind=review") {
+			t.Errorf("log output = %q, want challenger_kind=review", output)
+		}
+		if !strings.Contains(output, "incumbent_kind=ci") {
+			t.Errorf("log output = %q, want incumbent_kind=ci", output)
+		}
+		if !strings.Contains(output, "incumbent_attempt=1") {
+			t.Errorf("log output = %q, want incumbent_attempt=1", output)
+		}
+
 		// Clean up new timer.
 		entry.TimerHandle.Stop()
 	})
@@ -780,6 +807,97 @@ func TestScheduleRetry(t *testing.T) {
 			}
 		case <-time.After(time.Second):
 			t.Error("zero-delay timer did not fire within 1 second")
+		}
+	})
+}
+
+// --- Tests for retrySlotIncumbent ---
+
+func TestRetrySlotIncumbent(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil on free slot", func(t *testing.T) {
+		t.Parallel()
+
+		s := newTestState()
+
+		got := retrySlotIncumbent(s, "ISS-FREE")
+
+		if got != nil {
+			t.Errorf("retrySlotIncumbent(free slot) = %v, want nil", got)
+		}
+	})
+
+	t.Run("returns the stored entry on an occupied slot", func(t *testing.T) {
+		t.Parallel()
+
+		s := newTestState()
+		entry := &RetryEntry{IssueID: "ISS-1", Attempt: 3, ReactionKind: ReactionKindCI}
+		s.RetryAttempts["ISS-1"] = entry
+
+		got := retrySlotIncumbent(s, "ISS-1")
+
+		if got != entry {
+			t.Errorf("retrySlotIncumbent(occupied slot) = %v, want %v (the stored entry)", got, entry)
+		}
+	})
+}
+
+// --- Tests for logRetrySlotDeferral ---
+
+func TestLogRetrySlotDeferral(t *testing.T) {
+	t.Parallel()
+
+	t.Run("emits one Debug record with the expected attributes", func(t *testing.T) {
+		t.Parallel()
+
+		var buf bytes.Buffer
+		log := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+		incumbent := &RetryEntry{ReactionKind: ReactionKindCI, Attempt: 4, DueAtMS: 123456}
+
+		logRetrySlotDeferral(log, "review", incumbent)
+
+		output := buf.String()
+		if !strings.Contains(output, "level=DEBUG") {
+			t.Errorf("log output = %q, want a Debug-level record", output)
+		}
+		if !strings.Contains(output, "retry slot occupied, deferring") {
+			t.Errorf("log output = %q, want message %q", output, "retry slot occupied, deferring")
+		}
+		if !strings.Contains(output, "challenger_kind=review") {
+			t.Errorf("log output = %q, want challenger_kind=review", output)
+		}
+		if !strings.Contains(output, "incumbent_kind=ci") {
+			t.Errorf("log output = %q, want incumbent_kind=ci", output)
+		}
+		if !strings.Contains(output, "incumbent_attempt=4") {
+			t.Errorf("log output = %q, want incumbent_attempt=4", output)
+		}
+		if !strings.Contains(output, "incumbent_due_at_ms=123456") {
+			t.Errorf("log output = %q, want incumbent_due_at_ms=123456", output)
+		}
+	})
+
+	t.Run("nil logger falls back to slog.Default without panicking", func(t *testing.T) {
+		t.Parallel()
+
+		incumbent := &RetryEntry{ReactionKind: ReactionKindCI, Attempt: 1}
+
+		logRetrySlotDeferral(nil, "review", incumbent)
+	})
+
+	t.Run("empty incumbent reaction kind reports the literal continuation", func(t *testing.T) {
+		t.Parallel()
+
+		var buf bytes.Buffer
+		log := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+		incumbent := &RetryEntry{ReactionKind: "", Attempt: 1}
+
+		logRetrySlotDeferral(log, "ci", incumbent)
+
+		output := buf.String()
+		if !strings.Contains(output, "incumbent_kind=continuation") {
+			t.Errorf("log output = %q, want incumbent_kind=continuation", output)
 		}
 	})
 }

--- a/internal/orchestrator/exit.go
+++ b/internal/orchestrator/exit.go
@@ -341,6 +341,19 @@ func HandleWorkerExit(state *State, workerResult WorkerResult, params HandleWork
 	}
 
 	retryScheduled := false
+	// retryDeferred is true whenever this exit found the retry slot
+	// occupied by a foreign incumbent and left it untouched instead of
+	// scheduling its own retry. Distinct from retryScheduled: the two
+	// share the "work remains queued for this issue" outcome the
+	// completion and failure comments report, but only retryScheduled
+	// means this exit itself created or replaced the retry entry.
+	retryDeferred := false
+	// claimRetainedForIncumbent is true on the two arms where the claim
+	// is kept solely to protect a foreign incumbent (the non-active
+	// default branch and the successful-handoff arm). The
+	// reaction-enqueue gate below treats the claim as released on those
+	// two arms specifically, so a deferral changes only the retry slot.
+	claimRetainedForIncumbent := false
 	nextAttempt := 0
 
 	switch workerResult.ExitKind {
@@ -407,6 +420,9 @@ func HandleWorkerExit(state *State, workerResult WorkerResult, params HandleWork
 					)
 					CancelRetry(state, workerResult.IssueID)
 					delete(state.Claimed, workerResult.IssueID)
+				} else if incumbent := retrySlotIncumbent(state, workerResult.IssueID); incumbent != nil {
+					logRetrySlotDeferral(log, triggerContinuation, incumbent)
+					retryDeferred = true
 				} else {
 					log.Warn("handoff configured but tracker adapter is nil, scheduling continuation retry",
 						slog.String("handoff_state", params.HandoffState),
@@ -423,6 +439,7 @@ func HandleWorkerExit(state *State, workerResult WorkerResult, params HandleWork
 						AgentKind:   entry.AgentKind,
 						RuleName:    entry.RuleName,
 						TemplateID:  entry.TemplateID,
+						Logger:      log,
 					}, params.OnRetryFire)
 					metrics.IncRetries(triggerContinuation)
 					retryScheduled = true
@@ -468,6 +485,9 @@ func HandleWorkerExit(state *State, workerResult WorkerResult, params HandleWork
 						)
 						CancelRetry(state, workerResult.IssueID)
 						delete(state.Claimed, workerResult.IssueID)
+					} else if incumbent := retrySlotIncumbent(state, workerResult.IssueID); incumbent != nil {
+						logRetrySlotDeferral(log, triggerContinuation, incumbent)
+						retryDeferred = true
 					} else {
 						log.Warn("handoff transition failed, scheduling continuation retry",
 							slog.String("handoff_state", params.HandoffState),
@@ -485,10 +505,23 @@ func HandleWorkerExit(state *State, workerResult WorkerResult, params HandleWork
 							AgentKind:   entry.AgentKind,
 							RuleName:    entry.RuleName,
 							TemplateID:  entry.TemplateID,
+							Logger:      log,
 						}, params.OnRetryFire)
 						metrics.IncRetries(triggerContinuation)
 						retryScheduled = true
 					}
+				} else if incumbent := retrySlotIncumbent(state, workerResult.IssueID); incumbent != nil {
+					// A successful handoff transition is not a stop signal:
+					// work queued for this issue during the session is
+					// still valid, so the incumbent is kept rather than
+					// cancelled.
+					logRetrySlotDeferral(log, triggerContinuation, incumbent)
+					metrics.IncHandoffTransitions(handoffSuccess)
+					log.Info("handoff transition succeeded, incumbent preserved",
+						slog.String("handoff_state", params.HandoffState),
+					)
+					retryDeferred = true
+					claimRetainedForIncumbent = true
 				} else {
 					log.Info("handoff transition succeeded, releasing claim",
 						slog.String("handoff_state", params.HandoffState),
@@ -516,35 +549,55 @@ func HandleWorkerExit(state *State, workerResult WorkerResult, params HandleWork
 			delete(state.Claimed, workerResult.IssueID)
 
 		case issueIsActive && drivesIssue:
-			// No handoff configured but issue is still active:
-			// schedule continuation retry (existing behavior).
-			ScheduleRetry(state, ScheduleRetryParams{
-				IssueID:     workerResult.IssueID,
-				Identifier:  workerResult.Identifier,
-				DisplayID:   entry.Issue.DisplayID,
-				Attempt:     NextAttempt(entry.RetryAttempt),
-				DelayMS:     continuationDelayMS,
-				Error:       "",
-				LastSSHHost: workerResult.SSHHost,
-				SessionID:   sessionID,
-				AgentKind:   entry.AgentKind,
-				RuleName:    entry.RuleName,
-				TemplateID:  entry.TemplateID,
-			}, params.OnRetryFire)
-			metrics.IncRetries(triggerContinuation)
-			retryScheduled = true
+			// No handoff configured but issue is still active: schedule
+			// continuation retry, unless the slot is already occupied.
+			if incumbent := retrySlotIncumbent(state, workerResult.IssueID); incumbent != nil {
+				logRetrySlotDeferral(log, triggerContinuation, incumbent)
+				retryDeferred = true
+			} else {
+				ScheduleRetry(state, ScheduleRetryParams{
+					IssueID:     workerResult.IssueID,
+					Identifier:  workerResult.Identifier,
+					DisplayID:   entry.Issue.DisplayID,
+					Attempt:     NextAttempt(entry.RetryAttempt),
+					DelayMS:     continuationDelayMS,
+					Error:       "",
+					LastSSHHost: workerResult.SSHHost,
+					SessionID:   sessionID,
+					AgentKind:   entry.AgentKind,
+					RuleName:    entry.RuleName,
+					TemplateID:  entry.TemplateID,
+					Logger:      log,
+				}, params.OnRetryFire)
+				metrics.IncRetries(triggerContinuation)
+				retryScheduled = true
+			}
 
 		default:
 			// Issue is not in an active state: cancel any pending retry
-			// and release claim.
+			// and release claim, unless the slot is occupied by a
+			// foreign incumbent, which is exactly the population this
+			// disposition would otherwise strand.
 			if params.HandoffState != "" {
 				metrics.IncHandoffTransitions(handoffSkipped)
 			}
-			CancelRetry(state, workerResult.IssueID)
-			delete(state.Claimed, workerResult.IssueID)
+			if incumbent := retrySlotIncumbent(state, workerResult.IssueID); incumbent != nil {
+				logRetrySlotDeferral(log, triggerContinuation, incumbent)
+				retryDeferred = true
+				claimRetainedForIncumbent = true
+			} else {
+				CancelRetry(state, workerResult.IssueID)
+				delete(state.Claimed, workerResult.IssueID)
+			}
 		}
 
 		_, stillClaimed := state.Claimed[workerResult.IssueID]
+		// A claim retained solely to protect an incumbent must not widen
+		// reaction seeding, so the predicate is evaluated as if that
+		// claim had been released.
+		if claimRetainedForIncumbent {
+			stillClaimed = false
+		}
 		reactionEnqueueAllowed := claimedAtExit && (handoffPath || stillClaimed) && !terminalSuppressed
 
 		// Record a pending CI check when the CI provider is configured and
@@ -864,36 +917,43 @@ func HandleWorkerExit(state *State, workerResult WorkerResult, params HandleWork
 	default: // WorkerExitError and any unknown kind
 		classification := classifyWorkerError(workerResult.Error)
 		if classification.Retryable {
-			nextAttempt = NextAttempt(entry.RetryAttempt)
-			delayMS := computeBackoffDelay(nextAttempt, params.MaxRetryBackoffMS)
+			if incumbent := retrySlotIncumbent(state, workerResult.IssueID); incumbent != nil {
+				logRetrySlotDeferral(log, "error-backoff", incumbent)
+				nextAttempt = incumbent.Attempt
+				retryDeferred = true
+			} else {
+				nextAttempt = NextAttempt(entry.RetryAttempt)
+				delayMS := computeBackoffDelay(nextAttempt, params.MaxRetryBackoffMS)
 
-			log.Warn("worker run failed, scheduling retry",
-				slog.Any("error", workerResult.Error),
-				slog.Int("next_attempt", nextAttempt),
-				slog.Int64("delay_ms", delayMS),
-			)
+				log.Warn("worker run failed, scheduling retry",
+					slog.Any("error", workerResult.Error),
+					slog.Int("next_attempt", nextAttempt),
+					slog.Int64("delay_ms", delayMS),
+				)
 
-			var errMsg string
-			if workerResult.Error != nil {
-				errMsg = "worker exited: " + workerResult.Error.Error()
+				var errMsg string
+				if workerResult.Error != nil {
+					errMsg = "worker exited: " + workerResult.Error.Error()
+				}
+
+				ScheduleRetry(state, ScheduleRetryParams{
+					IssueID:             workerResult.IssueID,
+					Identifier:          workerResult.Identifier,
+					DisplayID:           entry.Issue.DisplayID,
+					Attempt:             nextAttempt,
+					DelayMS:             delayMS,
+					Error:               errMsg,
+					LastSSHHost:         workerResult.SSHHost,
+					ContinuationContext: entry.ContinuationContext,
+					ReactionKind:        entry.ReactionKind,
+					AgentKind:           entry.AgentKind,
+					RuleName:            entry.RuleName,
+					TemplateID:          entry.TemplateID,
+					Logger:              log,
+				}, params.OnRetryFire)
+				metrics.IncRetries(triggerError)
+				retryScheduled = true
 			}
-
-			ScheduleRetry(state, ScheduleRetryParams{
-				IssueID:             workerResult.IssueID,
-				Identifier:          workerResult.Identifier,
-				DisplayID:           entry.Issue.DisplayID,
-				Attempt:             nextAttempt,
-				DelayMS:             delayMS,
-				Error:               errMsg,
-				LastSSHHost:         workerResult.SSHHost,
-				ContinuationContext: entry.ContinuationContext,
-				ReactionKind:        entry.ReactionKind,
-				AgentKind:           entry.AgentKind,
-				RuleName:            entry.RuleName,
-				TemplateID:          entry.TemplateID,
-			}, params.OnRetryFire)
-			metrics.IncRetries(triggerError)
-			retryScheduled = true
 		} else {
 			log.Error("worker run failed, non-retryable, releasing claim",
 				slog.Any("error", workerResult.Error),
@@ -937,13 +997,18 @@ func HandleWorkerExit(state *State, workerResult WorkerResult, params HandleWork
 	}
 	runDuration := max(now.Sub(entry.StartedAt), 0)
 
+	// A deferral leaves work queued for the issue exactly as a scheduled
+	// retry does, so the completion and failure comments report
+	// re-queuing for either outcome.
+	retryPending := retryScheduled || retryDeferred
+
 	switch workerResult.ExitKind {
 	case WorkerExitNormal:
 		if params.CommentsConfig.OnCompletion {
 			if workerResult.SoftStop {
 				commentText = buildSoftStopComment(sessionID, runDuration, workerResult.TurnsCompleted, workerResult.SoftStopReason)
 			} else {
-				commentText = buildCompletionComment(sessionID, runDuration, workerResult.TurnsCompleted, retryScheduled)
+				commentText = buildCompletionComment(sessionID, runDuration, workerResult.TurnsCompleted, retryPending)
 			}
 			lifecycle = "completion"
 		}
@@ -951,7 +1016,7 @@ func HandleWorkerExit(state *State, workerResult WorkerResult, params HandleWork
 		// No comment on cancellation.
 	default:
 		if params.CommentsConfig.OnFailure {
-			commentText = buildFailureComment(sessionID, runDuration, workerResult.Error, retryScheduled, nextAttempt)
+			commentText = buildFailureComment(sessionID, runDuration, workerResult.Error, retryPending, nextAttempt)
 			lifecycle = "failure"
 		}
 	}

--- a/internal/orchestrator/exit_test.go
+++ b/internal/orchestrator/exit_test.go
@@ -5671,3 +5671,658 @@ func TestHandleWorkerExit_MergeCompletionEnqueue(t *testing.T) {
 		}
 	})
 }
+
+// --- Retry-slot arbitration: worker-exit incumbent protection ---
+
+// TestHandleWorkerExit_HandoffFailureDeferral covers the two handoff
+// branches that schedule a continuation on failure: the nil-adapter
+// branch and the transition-failure branch. Both must defer to a
+// foreign incumbent instead of scheduling their own retry.
+func TestHandleWorkerExit_HandoffFailureDeferral(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil adapter branch defers to a foreign incumbent", func(t *testing.T) {
+		t.Parallel()
+
+		const issueID = "HO-NIL-DEFER"
+		store := &mockExitStore{}
+		state := exitStateWithIssue(t, issueID, "In Progress")
+		state.RetryAttempts[issueID] = &RetryEntry{
+			IssueID:      issueID,
+			Attempt:      7,
+			ReactionKind: ReactionKindCI,
+		}
+		spy := &spyMetrics{}
+		params := defaultExitParams(t, store)
+		params.HandoffState = "Human Review"
+		params.ActiveStates = []string{"In Progress"}
+		params.Metrics = spy
+		// TrackerAdapter left nil.
+
+		HandleWorkerExit(state, WorkerResult{
+			IssueID:      issueID,
+			Identifier:   issueID + "-ident",
+			ExitKind:     WorkerExitNormal,
+			AgentAdapter: "mock",
+		}, params)
+
+		incumbent, ok := state.RetryAttempts[issueID]
+		if !ok {
+			t.Fatal("incumbent removed on a deferral, want preserved")
+		}
+		if incumbent.Attempt != 7 {
+			t.Errorf("RetryAttempts.Attempt = %d, want 7 (unchanged)", incumbent.Attempt)
+		}
+		if incumbent.ReactionKind != ReactionKindCI {
+			t.Errorf("RetryAttempts.ReactionKind = %q, want %q (unchanged)", incumbent.ReactionKind, ReactionKindCI)
+		}
+		if _, ok := state.Claimed[issueID]; !ok {
+			t.Error("claim released on a deferral, want held")
+		}
+		if len(spy.retries) != 0 {
+			t.Errorf("retries = %v, want [] (triggerContinuation must not fire on a deferral)", spy.retries)
+		}
+		if len(spy.handoffTransitions) != 1 || spy.handoffTransitions[0] != handoffError {
+			t.Errorf("handoffTransitions = %v, want [%s]", spy.handoffTransitions, handoffError)
+		}
+	})
+
+	t.Run("transition-failure branch defers to a foreign incumbent", func(t *testing.T) {
+		t.Parallel()
+
+		const issueID = "HO-TXNFAIL-DEFER"
+		store := &mockExitStore{}
+		tracker := &mockTrackerAdapter{
+			transitionIssueFn: func(_ context.Context, _, _ string) error {
+				return errors.New("permission denied")
+			},
+		}
+		state := exitStateWithIssue(t, issueID, "In Progress")
+		state.RetryAttempts[issueID] = &RetryEntry{
+			IssueID:      issueID,
+			Attempt:      3,
+			ReactionKind: ReactionKindReview,
+		}
+		spy := &spyMetrics{}
+		params := defaultExitParams(t, store)
+		params.TrackerAdapter = tracker
+		params.HandoffState = "Human Review"
+		params.ActiveStates = []string{"In Progress"}
+		params.Metrics = spy
+
+		HandleWorkerExit(state, WorkerResult{
+			IssueID:      issueID,
+			Identifier:   issueID + "-ident",
+			ExitKind:     WorkerExitNormal,
+			AgentAdapter: "mock",
+		}, params)
+
+		incumbent, ok := state.RetryAttempts[issueID]
+		if !ok {
+			t.Fatal("incumbent removed on a deferral, want preserved")
+		}
+		if incumbent.Attempt != 3 {
+			t.Errorf("RetryAttempts.Attempt = %d, want 3 (unchanged)", incumbent.Attempt)
+		}
+		if _, ok := state.Claimed[issueID]; !ok {
+			t.Error("claim released on a deferral, want held")
+		}
+		if len(spy.retries) != 0 {
+			t.Errorf("retries = %v, want [] (triggerContinuation must not fire on a deferral)", spy.retries)
+		}
+		if len(spy.handoffTransitions) != 1 || spy.handoffTransitions[0] != handoffError {
+			t.Errorf("handoffTransitions = %v, want [%s]", spy.handoffTransitions, handoffError)
+		}
+	})
+}
+
+// TestHandleWorkerExit_ActiveIssueContinuationDeferral covers the
+// active-issue continuation branch: a foreign incumbent survives
+// unchanged, no continuation retry counter fires, the claim stays held,
+// no retry entry is persisted for this exit, and the completion comment
+// still reports re-queuing even though this exit scheduled nothing.
+func TestHandleWorkerExit_ActiveIssueContinuationDeferral(t *testing.T) {
+	t.Parallel()
+
+	const issueID = "R17-DEFER"
+	store := &mockExitStore{}
+	tracker := &mockTrackerAdapter{}
+	spy := newCommentAwareMetrics()
+	state := exitStateWithIssue(t, issueID, "In Progress")
+	state.RetryAttempts[issueID] = &RetryEntry{
+		IssueID:      issueID,
+		Attempt:      6,
+		DueAtMS:      987654,
+		ReactionKind: ReactionKindCI,
+	}
+	params := exitParamsWithComments(t, store, tracker, config.TrackerCommentsConfig{OnCompletion: true})
+	params.Metrics = spy
+
+	HandleWorkerExit(state, WorkerResult{
+		IssueID:      issueID,
+		Identifier:   issueID + "-ident",
+		ExitKind:     WorkerExitNormal,
+		AgentAdapter: "mock",
+	}, params)
+
+	spy.waitComment(t)
+
+	incumbent, ok := state.RetryAttempts[issueID]
+	if !ok {
+		t.Fatal("incumbent removed on a deferral, want preserved")
+	}
+	if incumbent.ReactionKind != ReactionKindCI {
+		t.Errorf("RetryAttempts.ReactionKind = %q, want %q", incumbent.ReactionKind, ReactionKindCI)
+	}
+	if incumbent.DueAtMS != 987654 {
+		t.Errorf("RetryAttempts.DueAtMS = %d, want 987654 (unchanged)", incumbent.DueAtMS)
+	}
+	if len(spy.retries) != 0 {
+		t.Errorf("retries = %v, want [] (triggerContinuation must not fire on a deferral)", spy.retries)
+	}
+	if _, ok := state.Claimed[issueID]; !ok {
+		t.Error("claim released on a deferral, want held")
+	}
+	if len(store.retryEntries) != 0 {
+		t.Errorf("SaveRetryEntry called %d times, want 0 (this exit scheduled nothing)", len(store.retryEntries))
+	}
+	if len(tracker.commentCalls) != 1 {
+		t.Fatalf("CommentIssue call count = %d, want 1", len(tracker.commentCalls))
+	}
+	if !strings.HasPrefix(tracker.commentCalls[0].Text, "Sortie session completed (re-queuing).") {
+		t.Errorf("completion comment = %q, want prefix %q", tracker.commentCalls[0].Text, "Sortie session completed (re-queuing).")
+	}
+}
+
+// TestHandleWorkerExit_NonActiveDefaultDeferral covers the non-active
+// default branch: a foreign incumbent survives and the claim stays
+// held instead of being released.
+func TestHandleWorkerExit_NonActiveDefaultDeferral(t *testing.T) {
+	t.Parallel()
+
+	const issueID = "R18-DEFER"
+	store := &mockExitStore{}
+	state := exitStateWithIssue(t, issueID, "Some Other State")
+	state.RetryAttempts[issueID] = &RetryEntry{
+		IssueID:      issueID,
+		Attempt:      2,
+		ReactionKind: ReactionKindCI,
+	}
+	params := defaultExitParams(t, store)
+	params.ActiveStates = []string{"In Progress"}
+
+	HandleWorkerExit(state, WorkerResult{
+		IssueID:      issueID,
+		Identifier:   issueID + "-ident",
+		ExitKind:     WorkerExitNormal,
+		AgentAdapter: "mock",
+	}, params)
+
+	if _, ok := state.RetryAttempts[issueID]; !ok {
+		t.Error("ci entry removed by the non-active default branch, want preserved")
+	}
+	if _, ok := state.Claimed[issueID]; !ok {
+		t.Error("claim released by the non-active default branch, want held")
+	}
+}
+
+// TestHandleWorkerExit_RetryableErrorDeferral covers the retryable-error
+// branch: a foreign incumbent survives with its own attempt, the error
+// retry counter does not fire, the claim stays held, and the failure
+// comment reports the incumbent's own attempt number.
+func TestHandleWorkerExit_RetryableErrorDeferral(t *testing.T) {
+	t.Parallel()
+
+	const issueID = "R19-DEFER"
+	store := &mockExitStore{}
+	tracker := &mockTrackerAdapter{}
+	spy := newCommentAwareMetrics()
+	state := exitState(t, issueID, nil)
+	state.RetryAttempts[issueID] = &RetryEntry{
+		IssueID:      issueID,
+		Attempt:      5,
+		ReactionKind: ReactionKindReview,
+	}
+	params := exitParamsWithComments(t, store, tracker, config.TrackerCommentsConfig{OnFailure: true})
+	params.Metrics = spy
+
+	turnTimeoutErr := &domain.AgentError{Kind: domain.ErrTurnTimeout, Message: "timed out"}
+
+	HandleWorkerExit(state, WorkerResult{
+		IssueID:      issueID,
+		Identifier:   issueID + "-ident",
+		ExitKind:     WorkerExitError,
+		Error:        turnTimeoutErr,
+		AgentAdapter: "mock",
+	}, params)
+
+	spy.waitComment(t)
+
+	incumbent, ok := state.RetryAttempts[issueID]
+	if !ok {
+		t.Fatal("incumbent removed on a deferral, want preserved")
+	}
+	if incumbent.Attempt != 5 {
+		t.Errorf("RetryAttempts.Attempt = %d, want 5 (unchanged)", incumbent.Attempt)
+	}
+	if incumbent.ReactionKind != ReactionKindReview {
+		t.Errorf("RetryAttempts.ReactionKind = %q, want %q", incumbent.ReactionKind, ReactionKindReview)
+	}
+	if len(spy.retries) != 0 {
+		t.Errorf("retries = %v, want [] (the error retry counter must not fire on a deferral)", spy.retries)
+	}
+	if _, ok := state.Claimed[issueID]; !ok {
+		t.Error("claim released on a deferral, want held")
+	}
+	if len(tracker.commentCalls) != 1 {
+		t.Fatalf("CommentIssue call count = %d, want 1", len(tracker.commentCalls))
+	}
+	if !strings.Contains(tracker.commentCalls[0].Text, "Retry: yes (attempt 5)") {
+		t.Errorf("failure comment = %q, want to contain %q", tracker.commentCalls[0].Text, "Retry: yes (attempt 5)")
+	}
+}
+
+// TestHandleWorkerExit_StopSignalDispositionsDestroyForeignIncumbent
+// covers the six stop-signal dispositions that keep their destructive
+// behavior even against a foreign incumbent: blocked soft stop,
+// terminal observation, any other soft stop, the nil-adapter handoff
+// soft stop, a verified-terminal handoff observation, and a
+// transition-failure handoff soft stop.
+func TestHandleWorkerExit_StopSignalDispositionsDestroyForeignIncumbent(t *testing.T) {
+	t.Parallel()
+
+	type stopCase struct {
+		name       string
+		issueID    string
+		issueState string
+		build      func(t *testing.T, store *mockExitStore) (HandleWorkerExitParams, WorkerResult)
+	}
+
+	cases := []stopCase{
+		{
+			name:       "blocked soft stop",
+			issueID:    "STOP-BLOCKED",
+			issueState: "In Progress",
+			build: func(t *testing.T, store *mockExitStore) (HandleWorkerExitParams, WorkerResult) {
+				t.Helper()
+				params := defaultExitParams(t, store)
+				params.ActiveStates = []string{"In Progress"}
+				return params, WorkerResult{
+					IssueID:        "STOP-BLOCKED",
+					Identifier:     "STOP-BLOCKED-ident",
+					ExitKind:       WorkerExitNormal,
+					AgentAdapter:   "mock",
+					SoftStop:       true,
+					SoftStopReason: "blocked",
+				}
+			},
+		},
+		{
+			name:       "terminal observation",
+			issueID:    "STOP-TERMINAL",
+			issueState: "ai:in-progress",
+			build: func(t *testing.T, store *mockExitStore) (HandleWorkerExitParams, WorkerResult) {
+				t.Helper()
+				params := defaultExitParams(t, store)
+				params.ActiveStates = []string{"ai:ready", "ai:in-progress"}
+				params.TerminalStates = []string{"ai:done", "ai:cancelled"}
+				return params, WorkerResult{
+					IssueID:            "STOP-TERMINAL",
+					Identifier:         "STOP-TERMINAL-ident",
+					ExitKind:           WorkerExitNormal,
+					AgentAdapter:       "mock",
+					ObservedIssueState: "ai:cancelled",
+				}
+			},
+		},
+		{
+			name:       "other soft stop",
+			issueID:    "STOP-OTHER",
+			issueState: "In Progress",
+			build: func(t *testing.T, store *mockExitStore) (HandleWorkerExitParams, WorkerResult) {
+				t.Helper()
+				params := defaultExitParams(t, store)
+				params.ActiveStates = []string{"In Progress"}
+				return params, WorkerResult{
+					IssueID:        "STOP-OTHER",
+					Identifier:     "STOP-OTHER-ident",
+					ExitKind:       WorkerExitNormal,
+					AgentAdapter:   "mock",
+					SoftStop:       true,
+					SoftStopReason: "needs-human-review",
+				}
+			},
+		},
+		{
+			name:       "nil-adapter handoff soft stop",
+			issueID:    "STOP-NILADAPTER",
+			issueState: "In Progress",
+			build: func(t *testing.T, store *mockExitStore) (HandleWorkerExitParams, WorkerResult) {
+				t.Helper()
+				params := defaultExitParams(t, store)
+				params.ActiveStates = []string{"In Progress"}
+				params.HandoffState = "Human Review"
+				return params, WorkerResult{
+					IssueID:        "STOP-NILADAPTER",
+					Identifier:     "STOP-NILADAPTER-ident",
+					ExitKind:       WorkerExitNormal,
+					AgentAdapter:   "mock",
+					SoftStop:       true,
+					SoftStopReason: "needs-human-review",
+				}
+			},
+		},
+		{
+			name:       "verified-terminal handoff observation",
+			issueID:    "STOP-VERIFIED",
+			issueState: "ai:in-progress",
+			build: func(t *testing.T, store *mockExitStore) (HandleWorkerExitParams, WorkerResult) {
+				t.Helper()
+				tracker := &mockTrackerAdapter{
+					fetchStatesFn: func(_ context.Context, ids []string) (map[string]string, error) {
+						result := make(map[string]string, len(ids))
+						for _, id := range ids {
+							result[id] = "ai:cancelled"
+						}
+						return result, nil
+					},
+				}
+				params := defaultExitParams(t, store)
+				params.TrackerAdapter = tracker
+				params.ActiveStates = []string{"ai:ready", "ai:in-progress"}
+				params.TerminalStates = []string{"ai:done", "ai:cancelled"}
+				params.HandoffState = "ai:in-review"
+				return params, WorkerResult{
+					IssueID:            "STOP-VERIFIED",
+					Identifier:         "STOP-VERIFIED-ident",
+					ExitKind:           WorkerExitNormal,
+					AgentAdapter:       "mock",
+					ObservedIssueState: "ai:in-progress",
+				}
+			},
+		},
+		{
+			name:       "transition-failure handoff soft stop",
+			issueID:    "STOP-TXNFAIL",
+			issueState: "In Progress",
+			build: func(t *testing.T, store *mockExitStore) (HandleWorkerExitParams, WorkerResult) {
+				t.Helper()
+				tracker := &mockTrackerAdapter{
+					transitionIssueFn: func(_ context.Context, _, _ string) error {
+						return errors.New("permission denied")
+					},
+				}
+				params := defaultExitParams(t, store)
+				params.TrackerAdapter = tracker
+				params.ActiveStates = []string{"In Progress"}
+				params.HandoffState = "Human Review"
+				return params, WorkerResult{
+					IssueID:        "STOP-TXNFAIL",
+					Identifier:     "STOP-TXNFAIL-ident",
+					ExitKind:       WorkerExitNormal,
+					AgentAdapter:   "mock",
+					SoftStop:       true,
+					SoftStopReason: "needs-human-review",
+				}
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			store := &mockExitStore{}
+			state := exitStateWithIssue(t, tc.issueID, tc.issueState)
+			state.RetryAttempts[tc.issueID] = &RetryEntry{
+				IssueID:      tc.issueID,
+				Attempt:      9,
+				ReactionKind: ReactionKindCI,
+			}
+			params, result := tc.build(t, store)
+
+			HandleWorkerExit(state, result, params)
+
+			if _, ok := state.RetryAttempts[tc.issueID]; ok {
+				t.Error("RetryAttempts entry survived a stop-signal disposition, want destroyed even against a foreign incumbent")
+			}
+			if _, ok := state.Claimed[tc.issueID]; ok {
+				t.Error("Claimed entry survived a stop-signal disposition, want released even against a foreign incumbent")
+			}
+		})
+	}
+
+	t.Run("blocked soft stop destroys a label-review incumbent too", func(t *testing.T) {
+		t.Parallel()
+
+		const issueID = "STOP-LABELREVIEW"
+		store := &mockExitStore{}
+		state := exitStateWithIssue(t, issueID, "In Progress")
+		state.RetryAttempts[issueID] = &RetryEntry{
+			IssueID:      issueID,
+			Attempt:      1,
+			ReactionKind: ReactionKindLabelReview,
+		}
+		params := defaultExitParams(t, store)
+		params.ActiveStates = []string{"In Progress"}
+
+		HandleWorkerExit(state, WorkerResult{
+			IssueID:        issueID,
+			Identifier:     issueID + "-ident",
+			ExitKind:       WorkerExitNormal,
+			AgentAdapter:   "mock",
+			SoftStop:       true,
+			SoftStopReason: "blocked",
+		}, params)
+
+		if _, ok := state.RetryAttempts[issueID]; ok {
+			t.Error("label-review RetryAttempts entry survived a blocked soft stop, want destroyed")
+		}
+		if _, ok := state.Claimed[issueID]; ok {
+			t.Error("Claimed entry survived a blocked soft stop, want released")
+		}
+	})
+}
+
+// TestHandleWorkerExit_SuccessfulHandoffPreservesIncumbent covers the
+// successful-transition arm of the handoff disposition: a foreign
+// incumbent is preserved rather than cancelled, the claim stays held,
+// and the incumbent's own timer later dispatches from the handoff
+// state. The free-slot case is the unaffected control.
+func TestHandleWorkerExit_SuccessfulHandoffPreservesIncumbent(t *testing.T) {
+	t.Parallel()
+
+	t.Run("slot occupied: incumbent preserved, claim held, then dispatches from the handoff state", func(t *testing.T) {
+		t.Parallel()
+
+		const issueID = "HO-PRESERVE"
+		store := &mockExitStore{}
+		tracker := &mockTrackerAdapter{}
+		state := exitStateWithIssue(t, issueID, "In Progress")
+		state.RetryAttempts[issueID] = &RetryEntry{
+			IssueID:      issueID,
+			Attempt:      4,
+			DueAtMS:      123456,
+			ReactionKind: ReactionKindCI,
+		}
+		spy := &spyMetrics{}
+		params := defaultExitParams(t, store)
+		params.TrackerAdapter = tracker
+		params.HandoffState = "Human Review"
+		params.ActiveStates = []string{"In Progress"}
+		params.Metrics = spy
+
+		HandleWorkerExit(state, WorkerResult{
+			IssueID:      issueID,
+			Identifier:   issueID + "-ident",
+			ExitKind:     WorkerExitNormal,
+			AgentAdapter: "mock",
+		}, params)
+
+		if len(tracker.transitionCalls) != 1 {
+			t.Fatalf("TransitionIssue called %d times, want 1", len(tracker.transitionCalls))
+		}
+		if tracker.transitionCalls[0].TargetState != "Human Review" {
+			t.Errorf("TransitionIssue TargetState = %q, want %q", tracker.transitionCalls[0].TargetState, "Human Review")
+		}
+		if len(spy.handoffTransitions) != 1 || spy.handoffTransitions[0] != handoffSuccess {
+			t.Errorf("handoffTransitions = %v, want [%s]", spy.handoffTransitions, handoffSuccess)
+		}
+		incumbent, ok := state.RetryAttempts[issueID]
+		if !ok {
+			t.Fatal("incumbent removed after a successful handoff transition, want preserved")
+		}
+		if incumbent.ReactionKind != ReactionKindCI {
+			t.Errorf("RetryAttempts.ReactionKind = %q, want %q", incumbent.ReactionKind, ReactionKindCI)
+		}
+		if incumbent.Attempt != 4 {
+			t.Errorf("RetryAttempts.Attempt = %d, want 4 (unchanged)", incumbent.Attempt)
+		}
+		if incumbent.DueAtMS != 123456 {
+			t.Errorf("RetryAttempts.DueAtMS = %d, want 123456 (unchanged)", incumbent.DueAtMS)
+		}
+		if _, ok := state.Claimed[issueID]; !ok {
+			t.Error("claim released after a successful handoff transition with an incumbent, want held")
+		}
+
+		// Firing the incumbent's own timer against a tracker reporting the
+		// handoff state must dispatch: isActive is false, isKnownReaction
+		// is true, isHandoff is true, so HandleRetryTimer falls through to
+		// dispatch instead of taking a paused-reschedule arm.
+		retryStore := &mockRetryStore{}
+		retryTracker := &mockRetryTracker{
+			fetchedIssue: candidateIssue(issueID, issueID+"-ident", "Human Review"),
+		}
+		retryParams := defaultRetryParams(t, retryStore, retryTracker)
+		retryParams.HandoffState = "Human Review"
+
+		HandleRetryTimer(state, issueID, retryParams)
+
+		if _, running := state.Running[issueID]; !running {
+			t.Error("the CI-fix incumbent did not dispatch from the handoff state, want running")
+		}
+	})
+
+	t.Run("slot free: claim released, matching current behavior", func(t *testing.T) {
+		t.Parallel()
+
+		const issueID = "HO-FREE-CONTROL"
+		store := &mockExitStore{}
+		tracker := &mockTrackerAdapter{}
+		state := exitStateWithIssue(t, issueID, "In Progress")
+		params := defaultExitParams(t, store)
+		params.TrackerAdapter = tracker
+		params.HandoffState = "Human Review"
+		params.ActiveStates = []string{"In Progress"}
+
+		HandleWorkerExit(state, WorkerResult{
+			IssueID:      issueID,
+			Identifier:   issueID + "-ident",
+			ExitKind:     WorkerExitNormal,
+			AgentAdapter: "mock",
+		}, params)
+
+		if _, ok := state.Claimed[issueID]; ok {
+			t.Error("claim preserved after a successful handoff transition with a free slot, want released")
+		}
+		if _, ok := state.RetryAttempts[issueID]; ok {
+			t.Error("retry entry present after a free-slot successful handoff, want none")
+		}
+	})
+}
+
+// TestHandleWorkerExit_LabelReviewExitDoesNotWidenReactionSeeding covers
+// R28: retaining the claim to protect an incumbent on the non-active
+// default branch must not widen which reaction kinds a read-only
+// label-review exit seeds. Every reaction kind is configured and the
+// workspace carries full PR metadata, so the only variable between the
+// two subtests is whether the retry slot is occupied.
+func TestHandleWorkerExit_LabelReviewExitDoesNotWidenReactionSeeding(t *testing.T) {
+	t.Parallel()
+
+	buildParams := func(t *testing.T, store *mockExitStore) HandleWorkerExitParams {
+		t.Helper()
+		params := defaultExitParams(t, store)
+		params.ActiveStates = []string{"In Progress"}
+		params.CIProvider = &ciProviderStubExit{}
+		params.SCMAdapter = &scmAdapterStubExit{}
+		params.AutoMergeReactionConfigured = true
+		params.BotReviewReactionConfigured = true
+		params.MergeConflictReactionConfigured = true
+		params.LabelReviewReactionConfigured = true
+		params.LabelFixReactionConfigured = true
+		params.MergeCompletionReactionConfigured = true
+		return params
+	}
+
+	t.Run("slot occupied: incumbent survives, no PendingReactions gained", func(t *testing.T) {
+		t.Parallel()
+
+		const issueID = "LR-WIDEN-OCCUPIED"
+		wsPath := t.TempDir()
+		writePRSCMMetadata(t, wsPath, 55, "acme", "widgets", "feature/lr", "sha-lr")
+
+		store := &mockExitStore{}
+		state := exitStateWithIssue(t, issueID, "In Progress")
+		state.Running[issueID].ReactionKind = ReactionKindLabelReview
+		state.RetryAttempts[issueID] = &RetryEntry{
+			IssueID:      issueID,
+			Attempt:      2,
+			ReactionKind: ReactionKindCI,
+		}
+		params := buildParams(t, store)
+
+		HandleWorkerExit(state, WorkerResult{
+			IssueID:       issueID,
+			Identifier:    issueID + "-ident",
+			ExitKind:      WorkerExitNormal,
+			AgentAdapter:  "mock",
+			WorkspacePath: wsPath,
+		}, params)
+
+		incumbent, ok := state.RetryAttempts[issueID]
+		if !ok {
+			t.Fatal("incumbent removed by a label-review exit, want preserved")
+		}
+		if incumbent.ReactionKind != ReactionKindCI {
+			t.Errorf("RetryAttempts.ReactionKind = %q, want %q", incumbent.ReactionKind, ReactionKindCI)
+		}
+		if _, ok := state.Claimed[issueID]; !ok {
+			t.Error("claim released by a label-review exit with an occupied slot, want held")
+		}
+		if len(state.PendingReactions) != 0 {
+			t.Errorf("PendingReactions count = %d, want 0 (no reaction kind may be seeded by a label-review exit)", len(state.PendingReactions))
+		}
+	})
+
+	t.Run("slot free: entry cancelled, claim released, still no PendingReactions gained", func(t *testing.T) {
+		t.Parallel()
+
+		const issueID = "LR-WIDEN-FREE"
+		wsPath := t.TempDir()
+		writePRSCMMetadata(t, wsPath, 56, "acme", "widgets", "feature/lr2", "sha-lr2")
+
+		store := &mockExitStore{}
+		state := exitStateWithIssue(t, issueID, "In Progress")
+		state.Running[issueID].ReactionKind = ReactionKindLabelReview
+		params := buildParams(t, store)
+
+		HandleWorkerExit(state, WorkerResult{
+			IssueID:       issueID,
+			Identifier:    issueID + "-ident",
+			ExitKind:      WorkerExitNormal,
+			AgentAdapter:  "mock",
+			WorkspacePath: wsPath,
+		}, params)
+
+		if _, ok := state.RetryAttempts[issueID]; ok {
+			t.Error("retry entry present after a free-slot label-review exit, want none")
+		}
+		if _, ok := state.Claimed[issueID]; ok {
+			t.Error("claim preserved after a free-slot label-review exit, want released")
+		}
+		if len(state.PendingReactions) != 0 {
+			t.Errorf("PendingReactions count = %d, want 0 (no reaction kind may be seeded by a label-review exit)", len(state.PendingReactions))
+		}
+	})
+}

--- a/internal/orchestrator/label_fix_reconcile.go
+++ b/internal/orchestrator/label_fix_reconcile.go
@@ -124,10 +124,21 @@ func reconcileLabelFixCommands(state *State, params ReconcileParams, log *slog.L
 		commandConfirmed := len(matches) > 0 && labelPresentNow
 
 		running := state.Running[pending.IssueID] != nil
-		existingRetry, retryQueued := state.RetryAttempts[pending.IssueID]
-		alreadyQueuedOrRunning := running || (retryQueued && existingRetry.ReactionKind == ReactionKindLabelFix)
+		incumbent := retrySlotIncumbent(state, pending.IssueID)
 
-		if commandConfirmed && !alreadyQueuedOrRunning {
+		// A foreign incumbent defers before the same-kind collapse check
+		// runs: evaluating the collapse arm first would advance the mark
+		// past the labeling event and swallow the gesture.
+		if commandConfirmed && incumbent != nil && incumbent.ReactionKind != ReactionKindLabelFix {
+			logRetrySlotDeferral(entryLog, ReactionKindLabelFix, incumbent)
+			pending.CreatedAt = now
+			state.PendingReactions[key] = pending
+			continue
+		}
+
+		sameKindQueuedOrRunning := running || (incumbent != nil && incumbent.ReactionKind == ReactionKindLabelFix)
+
+		if commandConfirmed && !sameKindQueuedOrRunning {
 			// Advance the mark BEFORE scheduling: at-most-once rests on the
 			// persisted mark, so a crash in the window between the two loses
 			// the command rather than duplicating it. The upsert is
@@ -144,7 +155,6 @@ func reconcileLabelFixCommands(state *State, params ReconcileParams, log *slog.L
 			data.HighWaterMark = newestMark
 			data.LastActor = newestMatch.Actor
 
-			CancelRetry(state, pending.IssueID)
 			ScheduleRetry(state, ScheduleRetryParams{
 				IssueID:    pending.IssueID,
 				Identifier: pending.Identifier,
@@ -158,6 +168,7 @@ func reconcileLabelFixCommands(state *State, params ReconcileParams, log *slog.L
 				AgentKind:    pending.AgentKind,
 				RuleName:     pending.RuleName,
 				TemplateID:   pending.TemplateID,
+				Logger:       entryLog,
 			}, params.OnRetryFire)
 
 			// Best-effort acknowledgment: the label's disappearance tells the

--- a/internal/orchestrator/label_fix_reconcile_test.go
+++ b/internal/orchestrator/label_fix_reconcile_test.go
@@ -870,3 +870,100 @@ func TestBuildLabelFixMap_FieldMapping(t *testing.T) {
 		t.Errorf("buildLabelFixMap has %d keys, want %d", len(got), len(want))
 	}
 }
+
+// TestReconcileLabelFixCommands_ForeignIncumbentDefers mirrors
+// TestReconcileLabelReviewCommands_ForeignIncumbentDefers for the
+// label-fix kind: a confirmed command with a foreign incumbent occupying
+// the retry slot defers instead of dispatching, leaving the fingerprint
+// mark, the high-water mark, and the label untouched.
+func TestReconcileLabelFixCommands_ForeignIncumbentDefers(t *testing.T) {
+	t.Parallel()
+
+	const issueID = "LF-FOREIGN"
+	state := stateWithLabelFixPending(t, issueID, 10, "feature/lf-foreign")
+	rkey := ReactionKey(issueID, ReactionKindLabelFix)
+	state.RetryAttempts[issueID] = &RetryEntry{
+		IssueID:      issueID,
+		Attempt:      1,
+		ReactionKind: ReactionKindCI,
+	}
+
+	scm := &labelReviewSCMFake{
+		events: []domain.LabelEvent{
+			labelEvent("1", "sortie:fix", "alice", true, labelReviewBaseTime.Add(-1*time.Minute)),
+		},
+	}
+	store := newLabelReviewFingerprintStore()
+	params := labelFixParams(store, scm)
+
+	reconcileLabelFixCommands(state, params, discardLogger(), context.Background(), &domain.NoopMetrics{})
+
+	entry, ok := state.PendingReactions[rkey]
+	if !ok {
+		t.Fatal("PendingReactions entry dropped on a defer; want re-enqueued")
+	}
+	if !entry.CreatedAt.Equal(labelReviewBaseTime) {
+		t.Errorf("CreatedAt = %v, want refreshed to %v", entry.CreatedAt, labelReviewBaseTime)
+	}
+	incumbent := state.RetryAttempts[issueID]
+	if incumbent.ReactionKind != ReactionKindCI {
+		t.Errorf("RetryAttempts.ReactionKind = %q, want %q (incumbent unchanged)", incumbent.ReactionKind, ReactionKindCI)
+	}
+	mark, _, _ := store.GetReactionFingerprint(context.Background(), issueID, ReactionKindLabelFix)
+	if mark != "" {
+		t.Errorf("stored mark = %q, want empty (a defer must not upsert the fingerprint)", mark)
+	}
+	data, ok := entry.KindData.(*LabelFixReactionData)
+	if !ok {
+		t.Fatalf("KindData type = %T, want *LabelFixReactionData", entry.KindData)
+	}
+	if data.HighWaterMark != "" {
+		t.Errorf("HighWaterMark = %q, want empty (a defer must not advance it)", data.HighWaterMark)
+	}
+	if scm.removeCalls != 0 {
+		t.Errorf("RemoveLabel calls = %d, want 0 (a defer must not acknowledge the command)", scm.removeCalls)
+	}
+}
+
+// TestReconcileLabelFixCommands_SameKindCollapseAdvancesMarkAndReenqueues
+// mirrors the label-review same-kind collapse test: a same-kind
+// incumbent collapses the dispatch, but the mark still advances and the
+// pending entry still re-enqueues.
+func TestReconcileLabelFixCommands_SameKindCollapseAdvancesMarkAndReenqueues(t *testing.T) {
+	t.Parallel()
+
+	const issueID = "LF-COLLAPSE"
+	state := stateWithLabelFixPending(t, issueID, 10, "feature/lf-collapse")
+	rkey := ReactionKey(issueID, ReactionKindLabelFix)
+	state.RetryAttempts[issueID] = &RetryEntry{
+		IssueID:      issueID,
+		Attempt:      1,
+		ReactionKind: ReactionKindLabelFix,
+	}
+
+	event := labelEvent("1", "sortie:fix", "alice", true, labelReviewBaseTime.Add(-1*time.Minute))
+	scm := &labelReviewSCMFake{events: []domain.LabelEvent{event}}
+	store := newLabelReviewFingerprintStore()
+	params := labelFixParams(store, scm)
+
+	reconcileLabelFixCommands(state, params, discardLogger(), context.Background(), &domain.NoopMetrics{})
+
+	if len(state.RetryAttempts) != 1 {
+		t.Fatalf("RetryAttempts count = %d, want 1 (no second dispatch)", len(state.RetryAttempts))
+	}
+	pending, ok := state.PendingReactions[rkey]
+	if !ok {
+		t.Fatal("PendingReactions entry dropped after collapse; want re-enqueued")
+	}
+	mark, _, _ := store.GetReactionFingerprint(context.Background(), issueID, ReactionKindLabelFix)
+	if mark != labelReviewMark(event) {
+		t.Errorf("stored mark = %q, want %q (advanced to the newest examined event)", mark, labelReviewMark(event))
+	}
+	data, ok := pending.KindData.(*LabelFixReactionData)
+	if !ok {
+		t.Fatalf("KindData type = %T, want *LabelFixReactionData", pending.KindData)
+	}
+	if data.HighWaterMark != labelReviewMark(event) {
+		t.Errorf("HighWaterMark = %q, want %q", data.HighWaterMark, labelReviewMark(event))
+	}
+}

--- a/internal/orchestrator/label_review_reconcile.go
+++ b/internal/orchestrator/label_review_reconcile.go
@@ -144,10 +144,21 @@ func reconcileLabelReviewCommands(state *State, params ReconcileParams, log *slo
 		commandConfirmed := len(matches) > 0 && labelPresentNow
 
 		running := state.Running[pending.IssueID] != nil
-		existingRetry, retryQueued := state.RetryAttempts[pending.IssueID]
-		alreadyQueuedOrRunning := running || (retryQueued && existingRetry.ReactionKind == ReactionKindLabelReview)
+		incumbent := retrySlotIncumbent(state, pending.IssueID)
 
-		if commandConfirmed && !alreadyQueuedOrRunning {
+		// A foreign incumbent defers before the same-kind collapse check
+		// runs: evaluating the collapse arm first would advance the mark
+		// past the labeling event and swallow the gesture.
+		if commandConfirmed && incumbent != nil && incumbent.ReactionKind != ReactionKindLabelReview {
+			logRetrySlotDeferral(entryLog, ReactionKindLabelReview, incumbent)
+			pending.CreatedAt = now
+			state.PendingReactions[key] = pending
+			continue
+		}
+
+		sameKindQueuedOrRunning := running || (incumbent != nil && incumbent.ReactionKind == ReactionKindLabelReview)
+
+		if commandConfirmed && !sameKindQueuedOrRunning {
 			// Advance the mark BEFORE scheduling: at-most-once rests on the
 			// persisted mark, so a crash in the window between the two loses
 			// the command rather than duplicating it. The upsert is
@@ -164,7 +175,6 @@ func reconcileLabelReviewCommands(state *State, params ReconcileParams, log *slo
 			data.HighWaterMark = newestMark
 			data.LastActor = newestMatch.Actor
 
-			CancelRetry(state, pending.IssueID)
 			ScheduleRetry(state, ScheduleRetryParams{
 				IssueID:    pending.IssueID,
 				Identifier: pending.Identifier,
@@ -178,6 +188,7 @@ func reconcileLabelReviewCommands(state *State, params ReconcileParams, log *slo
 				AgentKind:    pending.AgentKind,
 				RuleName:     pending.RuleName,
 				TemplateID:   pending.TemplateID,
+				Logger:       entryLog,
 			}, params.OnRetryFire)
 
 			// Best-effort acknowledgment: the label's disappearance tells the

--- a/internal/orchestrator/label_review_reconcile_test.go
+++ b/internal/orchestrator/label_review_reconcile_test.go
@@ -1060,3 +1060,100 @@ func TestBuildLabelReviewMap_FieldMapping(t *testing.T) {
 		t.Errorf("buildLabelReviewMap has %d keys, want %d", len(got), len(want))
 	}
 }
+
+// TestReconcileLabelReviewCommands_ForeignIncumbentDefers covers the first
+// arm of the three-way decision: a confirmed command with a foreign
+// incumbent occupying the retry slot defers instead of dispatching. The
+// fingerprint mark, the high-water mark, and the label must all stay
+// untouched, and the pending entry re-enqueues with a refreshed CreatedAt.
+func TestReconcileLabelReviewCommands_ForeignIncumbentDefers(t *testing.T) {
+	t.Parallel()
+
+	const issueID = "LR-FOREIGN"
+	state := stateWithLabelReviewPending(t, issueID, 10)
+	rkey := ReactionKey(issueID, ReactionKindLabelReview)
+	state.RetryAttempts[issueID] = &RetryEntry{
+		IssueID:      issueID,
+		Attempt:      1,
+		ReactionKind: ReactionKindCI,
+	}
+
+	scm := &labelReviewSCMFake{
+		events: []domain.LabelEvent{
+			labelEvent("1", "sortie:review", "alice", true, labelReviewBaseTime.Add(-1*time.Minute)),
+		},
+	}
+	store := newLabelReviewFingerprintStore()
+	params := labelReviewParams(store, scm)
+
+	reconcileLabelReviewCommands(state, params, discardLogger(), context.Background(), &domain.NoopMetrics{})
+
+	entry, ok := state.PendingReactions[rkey]
+	if !ok {
+		t.Fatal("PendingReactions entry dropped on a defer; want re-enqueued")
+	}
+	if !entry.CreatedAt.Equal(labelReviewBaseTime) {
+		t.Errorf("CreatedAt = %v, want refreshed to %v", entry.CreatedAt, labelReviewBaseTime)
+	}
+	incumbent := state.RetryAttempts[issueID]
+	if incumbent.ReactionKind != ReactionKindCI {
+		t.Errorf("RetryAttempts.ReactionKind = %q, want %q (incumbent unchanged)", incumbent.ReactionKind, ReactionKindCI)
+	}
+	mark, _, _ := store.GetReactionFingerprint(context.Background(), issueID, ReactionKindLabelReview)
+	if mark != "" {
+		t.Errorf("stored mark = %q, want empty (a defer must not upsert the fingerprint)", mark)
+	}
+	data, ok := entry.KindData.(*LabelReviewReactionData)
+	if !ok {
+		t.Fatalf("KindData type = %T, want *LabelReviewReactionData", entry.KindData)
+	}
+	if data.HighWaterMark != "" {
+		t.Errorf("HighWaterMark = %q, want empty (a defer must not advance it)", data.HighWaterMark)
+	}
+	if scm.removeCalls != 0 {
+		t.Errorf("RemoveLabel calls = %d, want 0 (a defer must not acknowledge the command)", scm.removeCalls)
+	}
+}
+
+// TestReconcileLabelReviewCommands_SameKindCollapseAdvancesMarkAndReenqueues
+// covers the second arm of the three-way decision: a same-kind incumbent
+// collapses the dispatch, but the mark still advances to the newest
+// examined event and the pending entry still re-enqueues.
+func TestReconcileLabelReviewCommands_SameKindCollapseAdvancesMarkAndReenqueues(t *testing.T) {
+	t.Parallel()
+
+	const issueID = "LR-COLLAPSE"
+	state := stateWithLabelReviewPending(t, issueID, 10)
+	rkey := ReactionKey(issueID, ReactionKindLabelReview)
+	state.RetryAttempts[issueID] = &RetryEntry{
+		IssueID:      issueID,
+		Attempt:      1,
+		ReactionKind: ReactionKindLabelReview,
+	}
+
+	event := labelEvent("1", "sortie:review", "alice", true, labelReviewBaseTime.Add(-1*time.Minute))
+	scm := &labelReviewSCMFake{events: []domain.LabelEvent{event}}
+	store := newLabelReviewFingerprintStore()
+	params := labelReviewParams(store, scm)
+
+	reconcileLabelReviewCommands(state, params, discardLogger(), context.Background(), &domain.NoopMetrics{})
+
+	if len(state.RetryAttempts) != 1 {
+		t.Fatalf("RetryAttempts count = %d, want 1 (no second dispatch)", len(state.RetryAttempts))
+	}
+	pending, ok := state.PendingReactions[rkey]
+	if !ok {
+		t.Fatal("PendingReactions entry dropped after collapse; want re-enqueued")
+	}
+	mark, _, _ := store.GetReactionFingerprint(context.Background(), issueID, ReactionKindLabelReview)
+	if mark != labelReviewMark(event) {
+		t.Errorf("stored mark = %q, want %q (advanced to the newest examined event)", mark, labelReviewMark(event))
+	}
+	data, ok := pending.KindData.(*LabelReviewReactionData)
+	if !ok {
+		t.Fatalf("KindData type = %T, want *LabelReviewReactionData", pending.KindData)
+	}
+	if data.HighWaterMark != labelReviewMark(event) {
+		t.Errorf("HighWaterMark = %q, want %q", data.HighWaterMark, labelReviewMark(event))
+	}
+}

--- a/internal/orchestrator/merge_conflict_reconcile.go
+++ b/internal/orchestrator/merge_conflict_reconcile.go
@@ -156,6 +156,13 @@ func handleMergeConflictDirty(
 	ctx context.Context,
 	metrics domain.Metrics,
 ) {
+	if incumbent := retrySlotIncumbent(state, pending.IssueID); incumbent != nil {
+		logRetrySlotDeferral(log, ReactionKindMergeConflict, incumbent)
+		pending.CreatedAt = now
+		state.PendingReactions[key] = pending
+		return
+	}
+
 	// An empty head provides no rebase anchor. Defer without burning an
 	// attempt: a deferral is not a resolution attempt.
 	if status.HeadSHA == "" {
@@ -247,8 +254,6 @@ func dispatchMergeConflictContinuation(
 ) {
 	mergeContext := buildMergeConflictTemplateMap(data, status)
 
-	CancelRetry(state, pending.IssueID)
-
 	ScheduleRetry(state, ScheduleRetryParams{
 		IssueID:     pending.IssueID,
 		Identifier:  pending.Identifier,
@@ -263,6 +268,7 @@ func dispatchMergeConflictContinuation(
 		AgentKind:    pending.AgentKind,
 		RuleName:     pending.RuleName,
 		TemplateID:   pending.TemplateID,
+		Logger:       log,
 	}, params.OnRetryFire)
 
 	if markErr := params.Store.MarkReactionDispatched(ctx, pending.IssueID, ReactionKindMergeConflict); markErr != nil {

--- a/internal/orchestrator/merge_conflict_reconcile_test.go
+++ b/internal/orchestrator/merge_conflict_reconcile_test.go
@@ -517,10 +517,11 @@ func TestReconcileMergeConflicts_EpisodicReArm(t *testing.T) {
 	}
 
 	// Tick 2: head H2 clean → branch N1 resets the episode. A worker exit
-	// re-seeds the slot; advance the clock past the poll interval so the
-	// re-enqueued entry is due.
+	// re-seeds the slot and frees the tick-1 retry entry; advance the
+	// clock past the poll interval so the re-enqueued entry is due.
 	head = "H2-clean"
 	now = now.Add(2 * time.Minute)
+	CancelRetry(state, "MC-REARM")
 	state.PendingReactions[rkey] = newMergeConflictPending("MC-REARM", 10)
 	reconcileMergeConflicts(state, params, discardLogger(), context.Background(), metrics)
 	if metrics.checks["clear"] != 1 {
@@ -578,9 +579,10 @@ func TestReconcileMergeConflicts_Escalate(t *testing.T) {
 		t.Fatalf("after tick 1: dispatched = %d, want 1", metrics.checks["dispatched"])
 	}
 
-	// The agent rebased to a NEW head H2 that is still dirty. Re-seed the slot
-	// (a worker exit would do this) and run tick 2.
+	// The agent rebased to a NEW head H2 that is still dirty. A worker exit
+	// frees the tick-1 retry entry and re-seeds the slot; run tick 2.
 	head = "H2"
+	CancelRetry(state, issueID)
 	state.PendingReactions[rkey] = newMergeConflictPending(issueID, 77)
 
 	reconcileMergeConflicts(state, params, discardLogger(), context.Background(), metrics)
@@ -642,8 +644,9 @@ func TestReconcileMergeConflicts_EscalationResetsCounterReArm(t *testing.T) {
 	}
 
 	// Tick 2: still-dirty new head H2 → attempts 2, 2 > 1 → escalate, counter
-	// deleted.
+	// deleted. A worker exit frees the tick-1 retry entry before this tick.
 	head = "H2"
+	CancelRetry(state, issueID)
 	state.PendingReactions[rkey] = newMergeConflictPending(issueID, 88)
 	reconcileMergeConflicts(state, params, discardLogger(), context.Background(), metrics)
 	state.TrackerOpsWg.Wait()
@@ -1176,4 +1179,87 @@ func TestReconcileRunningIssues_MergeConflictOrdering(t *testing.T) {
 			t.Error("PendingReactions entry dropped while not due; want re-enqueued")
 		}
 	})
+}
+
+// TestReconcileMergeConflicts_ForeignIncumbentDefers covers the deferral
+// half of the retry-slot arbitration check at the top of the dirty
+// branch: a foreign incumbent survives, MarkReactionDispatched is not
+// called for the merge-conflict kind, and the merge-conflict
+// ReactionAttempts counter does not move.
+func TestReconcileMergeConflicts_ForeignIncumbentDefers(t *testing.T) {
+	t.Parallel()
+
+	const issueID = "MC-DEFER"
+	state := stateWithMergeConflict(t, issueID, 10)
+	rkey := ReactionKey(issueID, ReactionKindMergeConflict)
+	state.RetryAttempts[issueID] = &RetryEntry{
+		IssueID:      issueID,
+		Attempt:      1,
+		ReactionKind: ReactionKindCI,
+	}
+
+	store := newStatefulFingerprintStore()
+	metrics := newMergeConflictMetricsSpy()
+	scm := &mergeabilitySCM{fn: func() (domain.PRMergeStatus, error) {
+		return dirtyStatus("head-defer", "main"), nil
+	}}
+	params := mergeConflictParams(store, scm, nil)
+
+	reconcileMergeConflicts(state, params, discardLogger(), context.Background(), metrics)
+
+	entry, ok := state.PendingReactions[rkey]
+	if !ok {
+		t.Fatal("PendingReactions entry dropped on a defer; want re-enqueued")
+	}
+	if !entry.CreatedAt.Equal(mcBaseTime) {
+		t.Errorf("CreatedAt = %v, want refreshed to %v", entry.CreatedAt, mcBaseTime)
+	}
+	incumbent := state.RetryAttempts[issueID]
+	if incumbent.ReactionKind != ReactionKindCI {
+		t.Errorf("RetryAttempts.ReactionKind = %q, want %q (incumbent unchanged)", incumbent.ReactionKind, ReactionKindCI)
+	}
+	if _, ok := state.ReactionAttempts[rkey]; ok {
+		t.Errorf("ReactionAttempts[%s] = %d, want absent (a defer must not increment it)", rkey, state.ReactionAttempts[rkey])
+	}
+	if store.markDispatchedCalls != 0 {
+		t.Errorf("MarkReactionDispatched calls = %d, want 0 (no dispatch on a defer)", store.markDispatchedCalls)
+	}
+	if metrics.checks["dispatched"] != 0 {
+		t.Errorf(`IncMergeConflictChecks("dispatched") = %d, want 0`, metrics.checks["dispatched"])
+	}
+}
+
+// TestReconcileMergeConflicts_FreeSlotControlDispatches is the free-slot
+// control paired with TestReconcileMergeConflicts_ForeignIncumbentDefers:
+// the same dirty setup, but with no incumbent occupying the slot, results
+// in a merge-conflict retry and exactly one MarkReactionDispatched call.
+func TestReconcileMergeConflicts_FreeSlotControlDispatches(t *testing.T) {
+	t.Parallel()
+
+	const issueID = "MC-FREE"
+	state := stateWithMergeConflict(t, issueID, 10)
+	rkey := ReactionKey(issueID, ReactionKindMergeConflict)
+
+	store := newStatefulFingerprintStore()
+	metrics := newMergeConflictMetricsSpy()
+	scm := &mergeabilitySCM{fn: func() (domain.PRMergeStatus, error) {
+		return dirtyStatus("head-free", "main"), nil
+	}}
+	params := mergeConflictParams(store, scm, nil)
+
+	reconcileMergeConflicts(state, params, discardLogger(), context.Background(), metrics)
+
+	if _, ok := state.PendingReactions[rkey]; ok {
+		t.Error("PendingReactions entry still present after dispatch; want consumed")
+	}
+	retry, ok := state.RetryAttempts[issueID]
+	if !ok {
+		t.Fatal("retry not scheduled on a free slot; want scheduled")
+	}
+	if retry.ReactionKind != ReactionKindMergeConflict {
+		t.Errorf("RetryEntry.ReactionKind = %q, want %q", retry.ReactionKind, ReactionKindMergeConflict)
+	}
+	if store.markDispatchedCalls != 1 {
+		t.Errorf("MarkReactionDispatched calls = %d, want 1", store.markDispatchedCalls)
+	}
 }

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -3295,11 +3295,14 @@ func TestGracefulShutdown(t *testing.T) {
 		// cancelRetryTimers fails to Stop() it, the timer will fire
 		// within the 200ms wait below, proving the test is effective.
 		// Since TimerHandle is non-nil, activateReconstructedRetries
-		// skips it.
+		// skips it. DueAtMS reflects the timer's real due time so the
+		// reconcile loop's overdue-retry re-arm pass does not treat this
+		// freshly-scheduled entry as one whose timer event was dropped.
 		state.RetryAttempts["retry-1"] = &RetryEntry{
 			IssueID:    "retry-1",
 			Identifier: "RETRY-1",
 			Attempt:    1,
+			DueAtMS:    time.Now().Add(50 * time.Millisecond).UnixMilli(),
 			TimerHandle: time.AfterFunc(50*time.Millisecond, func() {
 				o.onRetryFire("retry-1")
 			}),

--- a/internal/orchestrator/reconcile.go
+++ b/internal/orchestrator/reconcile.go
@@ -215,6 +215,11 @@ func ReconcileRunningIssues(state *State, params ReconcileParams) {
 		now = params.NowFunc().UTC()
 	}
 
+	// Re-arm retry entries whose timer event was dropped by the retry
+	// timer channel's non-blocking send, so an undeliverable incumbent
+	// cannot hold the retry slot for the process lifetime.
+	reconcileOverdueRetries(state, params, log, now)
+
 	// Cancel stalled workers and schedule exponential-backoff retries.
 	reconcileStalled(state, params, log, ctx, now, metrics)
 
@@ -261,6 +266,68 @@ func ReconcileRunningIssues(state *State, params ReconcileParams) {
 	reconcileMergeCompletion(state, params, log, ctx, metrics)
 }
 
+// overdueRetryGrace bounds how long a retry entry's DueAtMS may lag the
+// current tick before [reconcileOverdueRetries] treats its timer event
+// as dropped and re-arms the entry with a zero delay.
+const overdueRetryGrace = 60 * time.Second
+
+// reconcileOverdueRetries re-arms retry entries whose timer event was
+// never delivered, so an undeliverable incumbent cannot hold the retry
+// slot for the process lifetime. Entries whose timer was never armed,
+// which are the startup reconstructions still awaiting activation, are
+// skipped.
+func reconcileOverdueRetries(state *State, params ReconcileParams, log *slog.Logger, now time.Time) {
+	graceMS := overdueRetryGrace.Milliseconds()
+
+	var overdueIDs []string
+	for issueID, entry := range state.RetryAttempts {
+		if entry.TimerHandle == nil {
+			continue
+		}
+		if now.UnixMilli()-entry.DueAtMS > graceMS {
+			overdueIDs = append(overdueIDs, issueID)
+		}
+	}
+
+	for _, issueID := range overdueIDs {
+		entry, ok := state.RetryAttempts[issueID]
+		if !ok {
+			continue
+		}
+
+		overdueMS := now.UnixMilli() - entry.DueAtMS
+		pausedSinceMS := entry.pausedSinceMS
+		entryLog := logging.WithIssue(log, issueID, entry.Identifier)
+
+		CancelRetry(state, issueID)
+		ScheduleRetry(state, ScheduleRetryParams{
+			IssueID:             issueID,
+			Identifier:          entry.Identifier,
+			DisplayID:           entry.DisplayID,
+			Attempt:             entry.Attempt,
+			Error:               entry.Error,
+			LastSSHHost:         entry.LastSSHHost,
+			SessionID:           entry.SessionID,
+			ContinuationContext: entry.ContinuationContext,
+			ReactionKind:        entry.ReactionKind,
+			AgentKind:           entry.AgentKind,
+			RuleName:            entry.RuleName,
+			TemplateID:          entry.TemplateID,
+			Logger:              entryLog,
+		}, params.OnRetryFire)
+
+		if rearmed, ok := state.RetryAttempts[issueID]; ok {
+			rearmed.pausedSinceMS = pausedSinceMS
+		}
+
+		entryLog.Warn("overdue retry re-armed",
+			slog.String("kind", entry.ReactionKind),
+			slog.Int("attempt", entry.Attempt),
+			slog.Int64("overdue_ms", overdueMS),
+		)
+	}
+}
+
 // reconcileStalled cancels running entries whose last activity exceeds the
 // stall timeout and schedules an exponential-backoff retry for each.
 func reconcileStalled(state *State, params ReconcileParams, log *slog.Logger, ctx context.Context, now time.Time, metrics domain.Metrics) {
@@ -287,20 +354,17 @@ func reconcileStalled(state *State, params ReconcileParams, log *slog.Logger, ct
 			entry.CancelFunc()
 		}
 
-		nextAttempt := NextAttempt(entry.RetryAttempt)
+		entryLog.Warn("stall detected, cancelling worker",
+			slog.Int64("elapsed_ms", elapsedMS),
+			slog.Int("stall_timeout_ms", params.StallTimeoutMS),
+		)
 
-		// Skip scheduling when a retry is already present at the same or
-		// higher attempt. Without this guard, every reconciliation tick
-		// would replace the existing timer, pushing DueAtMS forward and
-		// preventing the retry from ever firing.
-		if existing, ok := state.RetryAttempts[issueID]; ok && existing.Attempt >= nextAttempt {
-			entryLog.Debug("stall retry already scheduled, skipping reschedule",
-				slog.Int("current_attempt", existing.Attempt),
-				slog.Int("next_attempt", nextAttempt),
-			)
+		if incumbent := retrySlotIncumbent(state, issueID); incumbent != nil {
+			logRetrySlotDeferral(entryLog, "stall", incumbent)
 			continue
 		}
 
+		nextAttempt := NextAttempt(entry.RetryAttempt)
 		delayMS := computeBackoffDelay(nextAttempt, params.MaxRetryBackoffMS)
 
 		ScheduleRetry(state, ScheduleRetryParams{
@@ -317,6 +381,7 @@ func reconcileStalled(state *State, params ReconcileParams, log *slog.Logger, ct
 			AgentKind:           entry.AgentKind,
 			RuleName:            entry.RuleName,
 			TemplateID:          entry.TemplateID,
+			Logger:              entryLog,
 		}, params.OnRetryFire)
 		metrics.IncRetries(triggerStall)
 
@@ -327,10 +392,6 @@ func reconcileStalled(state *State, params ReconcileParams, log *slog.Logger, ct
 						slog.Any("error", err),
 					)
 				}
-				entryLog.Warn("stall detected, cancelling worker",
-					slog.Int64("elapsed_ms", elapsedMS),
-					slog.Int("stall_timeout_ms", params.StallTimeoutMS),
-				)
 				continue
 			}
 
@@ -350,11 +411,6 @@ func reconcileStalled(state *State, params ReconcileParams, log *slog.Logger, ct
 				)
 			}
 		}
-
-		entryLog.Warn("stall detected, cancelling worker",
-			slog.Int64("elapsed_ms", elapsedMS),
-			slog.Int("stall_timeout_ms", params.StallTimeoutMS),
-		)
 	}
 }
 
@@ -550,11 +606,18 @@ func reconcileTrackerState(state *State, params ReconcileParams, log *slog.Logge
 		if entry.CancelFunc != nil {
 			entry.CancelFunc()
 		}
-		CancelRetry(state, issueID)
-		if err := params.Store.DeleteRetryEntry(ctx, issueID); err != nil {
-			entryLog.Error("failed to delete retry entry for non-active issue",
-				slog.Any("error", err),
-			)
+		if incumbent := retrySlotIncumbent(state, issueID); incumbent != nil {
+			// Skipping only one of CancelRetry or DeleteRetryEntry would
+			// leave the in-memory entry and the persisted row disagreeing,
+			// so both are skipped together to protect the incumbent.
+			logRetrySlotDeferral(entryLog, "tracker-state", incumbent)
+		} else {
+			CancelRetry(state, issueID)
+			if err := params.Store.DeleteRetryEntry(ctx, issueID); err != nil {
+				entryLog.Error("failed to delete retry entry for non-active issue",
+					slog.Any("error", err),
+				)
+			}
 		}
 		metrics.IncReconciliationActions(actionStop)
 		entryLog.Info("stopping worker for non-active issue",

--- a/internal/orchestrator/reconcile_test.go
+++ b/internal/orchestrator/reconcile_test.go
@@ -734,6 +734,65 @@ func TestReconcileTrackerState_NonActiveNonTerminalCancelsWithoutCleanup(t *test
 	}
 }
 
+// TestReconcileTrackerState_NonActiveNonTerminalPreservesIncumbent verifies
+// that when the retry slot is occupied, the non-active stop still cancels
+// the worker and still counts the reconciliation action, but leaves the
+// incumbent retry entry alone — neither CancelRetry nor
+// Store.DeleteRetryEntry runs.
+func TestReconcileTrackerState_NonActiveNonTerminalPreservesIncumbent(t *testing.T) {
+	t.Parallel()
+
+	store := &mockReconcileStore{}
+	// "Backlog" is neither in ActiveStates nor TerminalStates.
+	tracker := &mockReconcileTracker{
+		states: map[string]string{"ISSUE-1": "Backlog"},
+	}
+	metrics := &spyMetrics{}
+	params := defaultReconcileParams(t, store, tracker)
+	params.StallTimeoutMS = 0
+	params.Metrics = metrics
+
+	state := NewState(5000, 4, nil, AgentTotals{})
+	cc := &cancelCounter{}
+	state.Running["ISSUE-1"] = &RunningEntry{
+		Identifier:   "ISSUE-1-ident",
+		StartedAt:    reconcileBaseTime,
+		CancelFunc:   cc.cancel,
+		Issue:        domain.Issue{State: "In Progress"},
+		ReactionKind: "", // continuation entry
+	}
+	state.Claimed["ISSUE-1"] = struct{}{}
+	state.RetryAttempts["ISSUE-1"] = &RetryEntry{
+		IssueID:      "ISSUE-1",
+		Identifier:   "ISSUE-1-ident",
+		Attempt:      1,
+		DueAtMS:      reconcileBaseTime.UnixMilli() + 60_000,
+		ReactionKind: ReactionKindCI,
+	}
+
+	ReconcileRunningIssues(state, params)
+
+	if cc.count != 1 {
+		t.Errorf("CancelFunc called %d times, want 1", cc.count)
+	}
+	entry, ok := state.RetryAttempts["ISSUE-1"]
+	if !ok {
+		t.Fatal("RetryAttempts entry removed while the slot was occupied; want preserved")
+	}
+	if entry.Attempt != 1 {
+		t.Errorf("RetryAttempts.Attempt = %d, want 1 (unchanged)", entry.Attempt)
+	}
+	if entry.DueAtMS != reconcileBaseTime.UnixMilli()+60_000 {
+		t.Errorf("RetryAttempts.DueAtMS = %d, want unchanged", entry.DueAtMS)
+	}
+	if len(store.deletedIssueID) != 0 {
+		t.Errorf("DeleteRetryEntry called %d times, want 0 (incumbent protected)", len(store.deletedIssueID))
+	}
+	if len(metrics.reconciliationActs) != 1 || metrics.reconciliationActs[0] != actionStop {
+		t.Errorf("IncReconciliationActions calls = %v, want [%q]", metrics.reconciliationActs, actionStop)
+	}
+}
+
 func TestReconcileTrackerState_OmittedIssueKeptRunning(t *testing.T) {
 	t.Parallel()
 
@@ -1396,9 +1455,17 @@ func TestReconcileTerminal_PendingCleanupSkipsLogAndRetryDeletion(t *testing.T) 
 	}
 
 	handler := &recordHandler{}
-	params := defaultReconcileParams(t, store, tracker)
-	params.StallTimeoutMS = 0
-	params.Logger = slog.New(handler)
+	params := ReconcileParams{
+		TrackerAdapter:    tracker,
+		ActiveStates:      []string{"In Progress", "In Review"},
+		TerminalStates:    []string{"Done", "Closed"},
+		MaxRetryBackoffMS: 300_000,
+		Store:             store,
+		OnRetryFire:       noopRetryFire,
+		NowFunc:           func() time.Time { return reconcileBaseTime },
+		Ctx:               context.Background(),
+		Logger:            slog.New(handler),
+	}
 
 	state := NewState(5000, 4, nil, AgentTotals{})
 	cc := &cancelCounter{}
@@ -1425,9 +1492,9 @@ func TestReconcileTerminal_PendingCleanupSkipsLogAndRetryDeletion(t *testing.T) 
 	}
 }
 
-// --- Stall Warn log first-tick-only test ---
+// --- Stall Warn log emitted every stalled tick test ---
 
-func TestReconcileStalled_WarnLogOnlyOnFirstTick(t *testing.T) {
+func TestReconcileStalled_WarnLogEveryStalledTick(t *testing.T) {
 	t.Parallel()
 
 	store := &mockReconcileStore{}
@@ -1450,7 +1517,7 @@ func TestReconcileStalled_WarnLogOnlyOnFirstTick(t *testing.T) {
 	}
 	state.Claimed["ISSUE-1"] = struct{}{}
 
-	// First tick: should emit Warn.
+	// First tick: schedules the stall retry and emits the Warn.
 	ReconcileRunningIssues(state, params)
 
 	warnCount := handler.countByMessage("stall detected, cancelling worker")
@@ -1458,18 +1525,88 @@ func TestReconcileStalled_WarnLogOnlyOnFirstTick(t *testing.T) {
 		t.Fatalf("Warn('stall detected, cancelling worker') emitted %d times after first tick, want 1", warnCount)
 	}
 
-	// Second tick: retry already scheduled → no Warn re-emitted.
+	// Second tick: the stall retry now occupies the slot, so the pass
+	// defers instead of rescheduling, but the cancellation Warn still
+	// fires because the worker cancellation is unconditional.
 	ReconcileRunningIssues(state, params)
 
 	warnCount = handler.countByMessage("stall detected, cancelling worker")
-	if warnCount != 1 {
-		t.Errorf("Warn('stall detected, cancelling worker') emitted %d times after second tick, want 1 (no additional Warn)", warnCount)
+	if warnCount != 2 {
+		t.Errorf("Warn('stall detected, cancelling worker') emitted %d times after second tick, want 2 (fires on every stalled tick)", warnCount)
 	}
 
-	// Verify Debug was emitted on second tick instead.
-	debugCount := handler.countByMessage("stall retry already scheduled, skipping reschedule")
-	if debugCount != 1 {
-		t.Errorf("Debug('stall retry already scheduled, skipping reschedule') emitted %d times, want 1", debugCount)
+	// The second tick's deferral is reported through the shared
+	// retry-slot Debug record instead of a stall-specific message.
+	deferCount := handler.countByMessage("retry slot occupied, deferring")
+	if deferCount != 1 {
+		t.Errorf("Debug('retry slot occupied, deferring') emitted %d times, want 1", deferCount)
+	}
+}
+
+// TestReconcileStalled_DeferralSkipsMutations verifies that a stall
+// deferral (the slot already occupied by the first tick's own stall
+// retry) still cancels the worker unconditionally but performs none of
+// the mutations the dispatch arm would: no additional ScheduleRetry (via
+// an unchanged DueAtMS and Attempt), no Store.SaveRetryEntry, no
+// Store.DeleteRetryEntry, and no IncRetries(triggerStall).
+func TestReconcileStalled_DeferralSkipsMutations(t *testing.T) {
+	t.Parallel()
+
+	store := &mockReconcileStore{}
+	tracker := &mockReconcileTracker{
+		states: map[string]string{"ISSUE-1": "In Progress"},
+	}
+	metrics := &spyMetrics{}
+	params := defaultReconcileParams(t, store, tracker)
+	params.StallTimeoutMS = 60_000
+	params.Metrics = metrics
+
+	state := NewState(5000, 4, nil, AgentTotals{})
+	cc := &cancelCounter{}
+	state.Running["ISSUE-1"] = &RunningEntry{
+		Identifier: "ISSUE-1-ident",
+		StartedAt:  reconcileBaseTime.Add(-120 * time.Second), // stalled
+		CancelFunc: cc.cancel,
+		Issue:      domain.Issue{State: "In Progress"},
+	}
+	state.Claimed["ISSUE-1"] = struct{}{}
+
+	// First tick: schedules the stall retry, occupying the slot.
+	ReconcileRunningIssues(state, params)
+
+	firstEntry, ok := state.RetryAttempts["ISSUE-1"]
+	if !ok {
+		t.Fatal("retry not scheduled after first tick")
+	}
+	firstDueAt := firstEntry.DueAtMS
+	firstAttempt := firstEntry.Attempt
+	firstStallTriggers := len(metrics.retries)
+
+	// Second tick: still stalled, but the slot is occupied by the
+	// first tick's own retry. The pass must defer, not reschedule.
+	ReconcileRunningIssues(state, params)
+
+	if cc.count != 2 {
+		t.Errorf("CancelFunc called %d times, want 2 (unconditional on every stalled tick)", cc.count)
+	}
+	secondEntry, ok := state.RetryAttempts["ISSUE-1"]
+	if !ok {
+		t.Fatal("retry entry removed after deferring tick")
+	}
+	if secondEntry.DueAtMS != firstDueAt {
+		t.Errorf("DueAtMS changed from %d to %d on a defer, want unchanged", firstDueAt, secondEntry.DueAtMS)
+	}
+	if secondEntry.Attempt != firstAttempt {
+		t.Errorf("Attempt changed from %d to %d on a defer, want unchanged", firstAttempt, secondEntry.Attempt)
+	}
+	if len(store.savedEntries) != 1 {
+		t.Errorf("SaveRetryEntry called %d times total, want 1 (none on the deferring tick)", len(store.savedEntries))
+	}
+	if len(store.deletedIssueID) != 0 {
+		t.Errorf("DeleteRetryEntry called %d times, want 0", len(store.deletedIssueID))
+	}
+	if len(metrics.retries) != firstStallTriggers {
+		t.Errorf("IncRetries called %d additional time(s) on the deferring tick, want 0", len(metrics.retries)-firstStallTriggers)
 	}
 }
 
@@ -2722,5 +2859,298 @@ func TestSweepWorkspaces_AgeRemovalLogCarriesRequiredAttributes(t *testing.T) {
 	}
 	if got := stringAttr(t, rec, "workspace_key"); got != key {
 		t.Errorf("workspace_key = %q, want %q", got, key)
+	}
+}
+
+// --- reconcileOverdueRetries tests ---
+
+// overdueRetryStore is a store double that records every method call so a
+// re-arm can be proven to perform none of them.
+type overdueRetryStore struct {
+	mockReconcileStore
+}
+
+// callCount returns the total number of ReconcileStore method calls
+// recorded across every method this double tracks.
+func (s *overdueRetryStore) callCount() int {
+	return len(s.savedEntries) + len(s.deletedIssueID) +
+		s.upsertFingerprintCalls + s.getFingerprintCalls +
+		s.markDispatchedCalls + s.deleteFingerprintCalls
+}
+
+func TestReconcileOverdueRetries_ReArmsOverdueEntry(t *testing.T) {
+	t.Parallel()
+
+	store := &overdueRetryStore{}
+	tracker := &mockReconcileTracker{}
+	fired := make(chan string, 4)
+	handler := &sweepLogHandler{}
+	params := ReconcileParams{
+		TrackerAdapter:    tracker,
+		ActiveStates:      []string{"In Progress", "In Review"},
+		TerminalStates:    []string{"Done", "Closed"},
+		MaxRetryBackoffMS: 300_000,
+		Store:             store,
+		OnRetryFire:       func(issueID string) { fired <- issueID },
+		NowFunc:           func() time.Time { return reconcileBaseTime },
+		Ctx:               context.Background(),
+		Logger:            slog.New(handler),
+	}
+
+	state := NewState(5000, 4, nil, AgentTotals{})
+	oldTimer := time.AfterFunc(time.Hour, func() {})
+	overdueDue := reconcileBaseTime.Add(-2 * time.Minute).UnixMilli()
+	state.RetryAttempts["OVERDUE-1"] = &RetryEntry{
+		IssueID:             "OVERDUE-1",
+		Identifier:          "OVERDUE-1-ident",
+		DisplayID:           "OVERDUE-1-display",
+		SessionID:           "sess-1",
+		Attempt:             3,
+		DueAtMS:             overdueDue,
+		Error:               "some error",
+		TimerHandle:         oldTimer,
+		LastSSHHost:         "host-a",
+		ContinuationContext: map[string]any{"ci_failure": map[string]any{"x": 1}},
+		ReactionKind:        ReactionKindCI,
+		RuleName:            "rule-1",
+		TemplateID:          "tmpl-1",
+		AgentKind:           "claude",
+	}
+	state.Claimed["OVERDUE-1"] = struct{}{}
+
+	before := time.Now().UnixMilli()
+	ReconcileRunningIssues(state, params)
+	after := time.Now().UnixMilli()
+
+	entry, ok := state.RetryAttempts["OVERDUE-1"]
+	if !ok {
+		t.Fatal("RetryAttempts entry missing after re-arm")
+	}
+	if entry.DueAtMS < before || entry.DueAtMS > after {
+		t.Errorf("DueAtMS = %d, want between %d and %d (re-armed at the tick's now)", entry.DueAtMS, before, after)
+	}
+	if entry.ReactionKind != ReactionKindCI {
+		t.Errorf("ReactionKind = %q, want %q", entry.ReactionKind, ReactionKindCI)
+	}
+	if entry.Attempt != 3 {
+		t.Errorf("Attempt = %d, want 3", entry.Attempt)
+	}
+	if entry.Identifier != "OVERDUE-1-ident" {
+		t.Errorf("Identifier = %q, want %q", entry.Identifier, "OVERDUE-1-ident")
+	}
+	if entry.DisplayID != "OVERDUE-1-display" {
+		t.Errorf("DisplayID = %q, want %q", entry.DisplayID, "OVERDUE-1-display")
+	}
+	if entry.SessionID != "sess-1" {
+		t.Errorf("SessionID = %q, want %q", entry.SessionID, "sess-1")
+	}
+	if entry.LastSSHHost != "host-a" {
+		t.Errorf("LastSSHHost = %q, want %q", entry.LastSSHHost, "host-a")
+	}
+	if entry.RuleName != "rule-1" {
+		t.Errorf("RuleName = %q, want %q", entry.RuleName, "rule-1")
+	}
+	if entry.TemplateID != "tmpl-1" {
+		t.Errorf("TemplateID = %q, want %q", entry.TemplateID, "tmpl-1")
+	}
+	if entry.AgentKind != "claude" {
+		t.Errorf("AgentKind = %q, want %q", entry.AgentKind, "claude")
+	}
+	if entry.ContinuationContext == nil {
+		t.Fatal("ContinuationContext is nil, want preserved")
+	}
+	if _, ok := state.Claimed["OVERDUE-1"]; !ok {
+		t.Error("Claimed entry removed by re-arm, want unchanged")
+	}
+	if handler.countByMessage("overdue retry re-armed") != 1 {
+		t.Errorf(`Warn("overdue retry re-armed") emitted %d times, want 1`, handler.countByMessage("overdue retry re-armed"))
+	}
+	if handler.countByMessage("retry slot displaced") != 0 {
+		t.Errorf(`Warn("retry slot displaced") emitted %d times, want 0`, handler.countByMessage("retry slot displaced"))
+	}
+	if rec, ok := handler.findByMessage("overdue retry re-armed"); ok {
+		if got := stringAttr(t, rec, "kind"); got != ReactionKindCI {
+			t.Errorf("kind attribute = %q, want %q", got, ReactionKindCI)
+		}
+		if got := intAttr(t, rec, "attempt"); got != 3 {
+			t.Errorf("attempt attribute = %d, want 3", got)
+		}
+		if _, hasOverdueMS := rec.attrs["overdue_ms"]; !hasOverdueMS {
+			t.Error("overdue_ms attribute missing")
+		}
+	}
+	if got := store.callCount(); got != 0 {
+		t.Errorf("Store method calls = %d, want 0", got)
+	}
+
+	select {
+	case id := <-fired:
+		if id != "OVERDUE-1" {
+			t.Errorf("OnRetryFire received %q, want %q", id, "OVERDUE-1")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("OnRetryFire not invoked within 1 second")
+	}
+
+	if entry.TimerHandle != nil {
+		entry.TimerHandle.Stop()
+	}
+}
+
+func TestReconcileOverdueRetries_FutureDueAtMSUntouched(t *testing.T) {
+	t.Parallel()
+
+	store := &overdueRetryStore{}
+	tracker := &mockReconcileTracker{}
+	handler := &sweepLogHandler{}
+	params := ReconcileParams{
+		TrackerAdapter:    tracker,
+		ActiveStates:      []string{"In Progress", "In Review"},
+		TerminalStates:    []string{"Done", "Closed"},
+		MaxRetryBackoffMS: 300_000,
+		Store:             store,
+		OnRetryFire:       noopRetryFire,
+		NowFunc:           func() time.Time { return reconcileBaseTime },
+		Ctx:               context.Background(),
+		Logger:            slog.New(handler),
+	}
+
+	state := NewState(5000, 4, nil, AgentTotals{})
+	timer := time.AfterFunc(time.Hour, func() {})
+	t.Cleanup(func() { timer.Stop() })
+	futureDue := reconcileBaseTime.Add(5 * time.Minute).UnixMilli()
+	original := &RetryEntry{
+		IssueID:      "FUTURE-1",
+		Identifier:   "FUTURE-1-ident",
+		Attempt:      1,
+		DueAtMS:      futureDue,
+		TimerHandle:  timer,
+		ReactionKind: ReactionKindCI,
+	}
+	state.RetryAttempts["FUTURE-1"] = original
+
+	ReconcileRunningIssues(state, params)
+
+	entry, ok := state.RetryAttempts["FUTURE-1"]
+	if !ok {
+		t.Fatal("RetryAttempts entry removed for a future-DueAtMS entry, want untouched")
+	}
+	if entry != original {
+		t.Error("RetryAttempts entry replaced for a future-DueAtMS entry, want the same pointer")
+	}
+	if entry.DueAtMS != futureDue {
+		t.Errorf("DueAtMS = %d, want unchanged %d", entry.DueAtMS, futureDue)
+	}
+	if handler.countByMessage("overdue retry re-armed") != 0 {
+		t.Errorf(`Warn("overdue retry re-armed") emitted %d times, want 0`, handler.countByMessage("overdue retry re-armed"))
+	}
+	if got := store.callCount(); got != 0 {
+		t.Errorf("Store method calls = %d, want 0", got)
+	}
+}
+
+func TestReconcileOverdueRetries_StartupReconstructedEntrySkipped(t *testing.T) {
+	t.Parallel()
+
+	store := &overdueRetryStore{}
+	tracker := &mockReconcileTracker{}
+	fired := make(chan string, 1)
+	handler := &sweepLogHandler{}
+	params := ReconcileParams{
+		TrackerAdapter:    tracker,
+		ActiveStates:      []string{"In Progress", "In Review"},
+		TerminalStates:    []string{"Done", "Closed"},
+		MaxRetryBackoffMS: 300_000,
+		Store:             store,
+		OnRetryFire:       func(issueID string) { fired <- issueID },
+		NowFunc:           func() time.Time { return reconcileBaseTime },
+		Ctx:               context.Background(),
+		Logger:            slog.New(handler),
+	}
+
+	state := NewState(5000, 4, nil, AgentTotals{})
+	overdueDueMs := reconcileBaseTime.Add(-5 * time.Minute).UnixMilli()
+	errStr := "prior error"
+	PopulateRetries(state, []persistence.PendingRetry{
+		{
+			Entry: persistence.RetryEntry{
+				IssueID:    "STARTUP-1",
+				Identifier: "STARTUP-1-ident",
+				Attempt:    2,
+				DueAtMs:    overdueDueMs,
+				Error:      &errStr,
+			},
+			RemainingMs: 0,
+		},
+	}, discardLogger())
+
+	ReconcileRunningIssues(state, params)
+
+	entry, ok := state.RetryAttempts["STARTUP-1"]
+	if !ok {
+		t.Fatal("RetryAttempts entry removed for a startup-reconstructed entry, want untouched")
+	}
+	if entry.TimerHandle != nil {
+		t.Error("TimerHandle became non-nil, want still nil (never activated)")
+	}
+	if entry.DueAtMS != overdueDueMs {
+		t.Errorf("DueAtMS = %d, want unchanged %d", entry.DueAtMS, overdueDueMs)
+	}
+	if handler.countByMessage("overdue retry re-armed") != 0 {
+		t.Errorf(`Warn("overdue retry re-armed") emitted %d times, want 0`, handler.countByMessage("overdue retry re-armed"))
+	}
+
+	select {
+	case id := <-fired:
+		t.Errorf("OnRetryFire invoked with %q, want no invocation for a startup-reconstructed entry", id)
+	case <-time.After(200 * time.Millisecond):
+	}
+}
+
+func TestReconcileOverdueRetries_LargeStartupBatchFiresNothing(t *testing.T) {
+	t.Parallel()
+
+	store := &overdueRetryStore{}
+	tracker := &mockReconcileTracker{}
+	fired := make(chan string, 200)
+	handler := &sweepLogHandler{}
+	params := ReconcileParams{
+		TrackerAdapter:    tracker,
+		ActiveStates:      []string{"In Progress", "In Review"},
+		TerminalStates:    []string{"Done", "Closed"},
+		MaxRetryBackoffMS: 300_000,
+		Store:             store,
+		OnRetryFire:       func(issueID string) { fired <- issueID },
+		NowFunc:           func() time.Time { return reconcileBaseTime },
+		Ctx:               context.Background(),
+		Logger:            slog.New(handler),
+	}
+
+	state := NewState(5000, 4, nil, AgentTotals{})
+	overdueDueMs := reconcileBaseTime.Add(-5 * time.Minute).UnixMilli()
+	entries := make([]persistence.PendingRetry, 0, 200)
+	for i := range 200 {
+		entries = append(entries, persistence.PendingRetry{
+			Entry: persistence.RetryEntry{
+				IssueID:    fmt.Sprintf("STARTUP-BATCH-%d", i),
+				Identifier: fmt.Sprintf("STARTUP-BATCH-%d-ident", i),
+				Attempt:    1,
+				DueAtMs:    overdueDueMs,
+			},
+			RemainingMs: 0,
+		})
+	}
+	PopulateRetries(state, entries, discardLogger())
+
+	ReconcileRunningIssues(state, params)
+
+	if handler.countByMessage("overdue retry re-armed") != 0 {
+		t.Errorf(`Warn("overdue retry re-armed") emitted %d times, want 0`, handler.countByMessage("overdue retry re-armed"))
+	}
+
+	select {
+	case id := <-fired:
+		t.Errorf("OnRetryFire invoked with %q, want no invocation for a 200-entry startup batch", id)
+	case <-time.After(200 * time.Millisecond):
 	}
 }

--- a/internal/orchestrator/retry.go
+++ b/internal/orchestrator/retry.go
@@ -12,6 +12,15 @@ import (
 	"github.com/sortie-ai/sortie/internal/persistence"
 )
 
+// pausedRetryMaxDwell bounds how long a known-reaction retry may be
+// rescheduled consecutively because the issue's own state does not permit
+// a dispatch, before [HandleRetryTimer] drops it instead of holding the
+// retry slot for the process lifetime. Matches the 30-minute pending-entry
+// TTLs the reaction reconcile passes already use, because a paused retry
+// is the retry-slot analogue of a pending reaction that never becomes
+// actionable.
+const pausedRetryMaxDwell = 30 * time.Minute
+
 // RetryTimerStore is the persistence interface required by
 // [HandleRetryTimer]. It is satisfied by [persistence.Store] in production
 // and by test doubles in unit tests.
@@ -179,6 +188,7 @@ func HandleRetryTimer(state *State, issueID string, params HandleRetryTimerParam
 			AgentKind:           popped.AgentKind,
 			RuleName:            popped.RuleName,
 			TemplateID:          popped.TemplateID,
+			Logger:              log,
 		}, params.OnRetryFire)
 		if isKnownReactionKind(popped.ReactionKind) {
 			if err := params.Store.DeleteRetryEntry(ctx, issueID); err != nil {
@@ -320,6 +330,43 @@ func HandleRetryTimer(state *State, issueID string, params HandleRetryTimerParam
 		)
 	}
 
+	// pausedReschedule bounds the two arms below that reschedule a known
+	// reaction retry because the issue's current state does not permit a
+	// dispatch. Left unbounded, either arm re-occupies the slot on every
+	// fire and holds it for the process lifetime; pausedSince tracks how
+	// long the entry has taken one of these arms consecutively, and the
+	// entry is dropped rather than rescheduled once that dwell reaches
+	// pausedRetryMaxDwell.
+	pausedReschedule := func(nextAttempt int, delayMS int64, logReschedule func()) {
+		now := time.Now()
+		pausedSince := now
+		if popped.pausedSinceMS != 0 {
+			pausedSince = time.UnixMilli(popped.pausedSinceMS)
+		}
+		dwell := now.Sub(pausedSince)
+		if dwell >= pausedRetryMaxDwell {
+			delete(state.Claimed, issueID)
+			if err := params.Store.DeleteRetryEntry(ctx, issueID); err != nil {
+				log.Error("failed to delete retry entry after paused-dwell drop",
+					slog.Any("error", err),
+				)
+			}
+			log.Warn("paused reaction retry exceeded max dwell, dropping",
+				slog.String("kind", popped.ReactionKind),
+				slog.String("issue_state", issue.State),
+				slog.Int("attempt", popped.Attempt),
+				slog.Int64("dwell_ms", dwell.Milliseconds()),
+				slog.Int64("max_dwell_ms", pausedRetryMaxDwell.Milliseconds()),
+			)
+			return
+		}
+		logReschedule()
+		reschedule(nextAttempt, delayMS, popped.Error)
+		if entry, ok := state.RetryAttempts[issueID]; ok {
+			entry.pausedSinceMS = pausedSince.UnixMilli()
+		}
+	}
+
 	if issue.ID == "" || issue.Identifier == "" || issue.Title == "" || issue.State == "" {
 		log.Info("issue missing required fields, releasing claim")
 		delete(state.Claimed, issueID)
@@ -352,13 +399,14 @@ func HandleRetryTimer(state *State, issueID string, params HandleRetryTimerParam
 				nextAttempt := popped.Attempt + 1
 				delayMS := computeBackoffDelay(nextAttempt, params.MaxRetryBackoffMS)
 
-				log.Info("issue blocked, rescheduling reaction retry",
-					slog.String("issue_state", issue.State),
-					slog.String("kind", popped.ReactionKind),
-					slog.Int("attempt", nextAttempt),
-					slog.Int64("delay_ms", delayMS),
-				)
-				reschedule(nextAttempt, delayMS, popped.Error)
+				pausedReschedule(nextAttempt, delayMS, func() {
+					log.Info("issue blocked, rescheduling reaction retry",
+						slog.String("issue_state", issue.State),
+						slog.String("kind", popped.ReactionKind),
+						slog.Int("attempt", nextAttempt),
+						slog.Int64("delay_ms", delayMS),
+					)
+				})
 				return
 			}
 
@@ -390,13 +438,14 @@ func HandleRetryTimer(state *State, issueID string, params HandleRetryTimerParam
 		nextAttempt := popped.Attempt + 1
 		delayMS := computeBackoffDelay(nextAttempt, params.MaxRetryBackoffMS)
 
-		log.Info("reaction retry paused by issue state, rescheduling",
-			slog.String("issue_state", issue.State),
-			slog.String("kind", popped.ReactionKind),
-			slog.Int("attempt", nextAttempt),
-			slog.Int64("delay_ms", delayMS),
-		)
-		reschedule(nextAttempt, delayMS, popped.Error)
+		pausedReschedule(nextAttempt, delayMS, func() {
+			log.Info("reaction retry paused by issue state, rescheduling",
+				slog.String("issue_state", issue.State),
+				slog.String("kind", popped.ReactionKind),
+				slog.Int("attempt", nextAttempt),
+				slog.Int64("delay_ms", delayMS),
+			)
+		})
 		return
 	}
 

--- a/internal/orchestrator/retry_slot_test.go
+++ b/internal/orchestrator/retry_slot_test.go
@@ -1,0 +1,742 @@
+package orchestrator
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/sortie-ai/sortie/internal/config"
+	"github.com/sortie-ai/sortie/internal/domain"
+	"github.com/sortie-ai/sortie/internal/persistence"
+)
+
+// --- Test doubles shared by the cross-pass contention tests ---
+
+// retrySlotCI is a controllable CIStatusProvider for the cross-pass
+// contention tests in this file.
+type retrySlotCI struct {
+	result domain.CIResult
+	err    error
+}
+
+var _ domain.CIStatusProvider = (*retrySlotCI)(nil)
+
+func (c *retrySlotCI) FetchCIStatus(_ context.Context, _ string) (domain.CIResult, error) {
+	return c.result, c.err
+}
+
+// retrySlotSCM is a single controllable SCMAdapter covering every method
+// the review, bot-review, merge-conflict, and label-command passes read,
+// so one double can drive a scenario spanning several of those passes.
+type retrySlotSCM struct {
+	reviewComments []domain.ReviewComment
+	reviewErr      error
+	botComments    []domain.ReviewComment
+	mergeStatus    domain.PRMergeStatus
+	mergeErr       error
+	labelEvents    []domain.LabelEvent
+	labelErr       error
+
+	removeLabelCalls int
+	removedLabels    []string
+}
+
+var _ domain.SCMAdapter = (*retrySlotSCM)(nil)
+
+func (s *retrySlotSCM) FetchPendingReviews(_ context.Context, _ int, _, _ string) ([]domain.ReviewComment, error) {
+	return s.reviewComments, s.reviewErr
+}
+
+func (s *retrySlotSCM) FetchBotReviewComments(_ context.Context, _ int, _, _ string, _ []string) ([]domain.ReviewComment, error) {
+	return s.botComments, nil
+}
+
+func (s *retrySlotSCM) GetReviewDecision(_ context.Context, _ int, _, _ string) (domain.ReviewDecision, error) {
+	return "", nil
+}
+
+func (s *retrySlotSCM) GetCIStatus(_ context.Context, _ int, _, _ string) (string, error) {
+	return "", nil
+}
+
+func (s *retrySlotSCM) GetMergeability(_ context.Context, _ int, _, _ string) (domain.PRMergeStatus, error) {
+	return s.mergeStatus, s.mergeErr
+}
+
+func (s *retrySlotSCM) MergePR(_ context.Context, _ int, _, _ string, _ domain.MergeStrategy, _, _, _ string) (domain.MergeResult, error) {
+	return domain.MergeResult{}, nil
+}
+
+func (s *retrySlotSCM) DeleteBranch(_ context.Context, _, _, _ string) error {
+	return nil
+}
+
+func (s *retrySlotSCM) ListLabelEvents(_ context.Context, _ int, _, _ string) ([]domain.LabelEvent, error) {
+	return s.labelEvents, s.labelErr
+}
+
+func (s *retrySlotSCM) RemoveLabel(_ context.Context, _ int, _, _, label string) error {
+	s.removeLabelCalls++
+	s.removedLabels = append(s.removedLabels, label)
+	return nil
+}
+
+// retrySlotStore is a stateful ReconcileStore fake shared by every test in
+// this file. Fingerprint reads reflect prior upserts within the same test,
+// so "unchanged" and "advanced" assertions exercise real state rather than
+// a canned return value.
+type retrySlotStore struct {
+	marks      map[string]string
+	dispatched map[string]bool
+
+	runHistories []persistence.RunHistory
+	savedEntries []persistence.RetryEntry
+	deletedIDs   []string
+
+	upsertCalls   int
+	getCalls      int
+	markCalls     int
+	deleteFPCalls int
+}
+
+var _ ReconcileStore = (*retrySlotStore)(nil)
+
+func newRetrySlotStore() *retrySlotStore {
+	return &retrySlotStore{
+		marks:      make(map[string]string),
+		dispatched: make(map[string]bool),
+	}
+}
+
+func (s *retrySlotStore) SaveRetryEntry(_ context.Context, entry persistence.RetryEntry) error {
+	s.savedEntries = append(s.savedEntries, entry)
+	return nil
+}
+
+func (s *retrySlotStore) DeleteRetryEntry(_ context.Context, issueID string) error {
+	s.deletedIDs = append(s.deletedIDs, issueID)
+	return nil
+}
+
+func (s *retrySlotStore) AppendRunHistory(_ context.Context, run persistence.RunHistory) (persistence.RunHistory, error) {
+	s.runHistories = append(s.runHistories, run)
+	return run, nil
+}
+
+func (s *retrySlotStore) UpsertReactionFingerprint(_ context.Context, issueID, kind, fingerprint string) error {
+	s.upsertCalls++
+	key := issueID + ":" + kind
+	if s.marks[key] != fingerprint {
+		s.dispatched[key] = false
+	}
+	s.marks[key] = fingerprint
+	return nil
+}
+
+func (s *retrySlotStore) GetReactionFingerprint(_ context.Context, issueID, kind string) (string, bool, error) {
+	s.getCalls++
+	key := issueID + ":" + kind
+	return s.marks[key], s.dispatched[key], nil
+}
+
+func (s *retrySlotStore) MarkReactionDispatched(_ context.Context, issueID, kind string) error {
+	s.markCalls++
+	s.dispatched[issueID+":"+kind] = true
+	return nil
+}
+
+func (s *retrySlotStore) DeleteReactionFingerprint(_ context.Context, issueID, kind string) error {
+	s.deleteFPCalls++
+	key := issueID + ":" + kind
+	delete(s.marks, key)
+	delete(s.dispatched, key)
+	return nil
+}
+
+// hasRunHistoryStatus reports whether any recorded run_history row carries
+// the given status.
+func (s *retrySlotStore) hasRunHistoryStatus(status string) bool {
+	for _, run := range s.runHistories {
+		if run.Status == status {
+			return true
+		}
+	}
+	return false
+}
+
+// --- Test helpers ---
+
+// retrySlotBaseTime is a fixed reference time for the cross-pass
+// contention tests in this file.
+func retrySlotBaseTime() time.Time {
+	return time.Date(2026, 8, 1, 9, 0, 0, 0, time.UTC)
+}
+
+// retrySlotParams returns a ReconcileParams wired for every pass that can
+// contend for the retry slot: CI, review, merge-conflict, label-review,
+// and label-fix. Bot-review, auto-merge, and merge-completion stay
+// disabled because no scenario in this file needs them, and enabling an
+// unused pass would only add a source of accidental interference.
+func retrySlotParams(store ReconcileStore, ci domain.CIStatusProvider, scm domain.SCMAdapter, tracker domain.TrackerAdapter, now func() time.Time) ReconcileParams {
+	return ReconcileParams{
+		TrackerAdapter:    tracker,
+		ActiveStates:      []string{"In Progress"},
+		TerminalStates:    []string{"Done"},
+		MaxRetryBackoffMS: 300_000,
+		Store:             store,
+		OnRetryFire:       noopRetryFire,
+		NowFunc:           now,
+		Ctx:               context.Background(),
+		Logger:            discardLogger(),
+
+		CIProvider:   ci,
+		CIFeedback:   config.CIFeedbackConfig{MaxRetries: 2, Escalation: "label", EscalationLabel: "needs-human"},
+		CIPendingTTL: ciPendingDefaultTTL,
+
+		SCMAdapter:       scm,
+		ReviewConfig:     ReviewReactionConfig{Escalation: "label", EscalationLabel: "needs-human", PollIntervalMS: 60_000, DebounceMS: 30_000, MaxContinuationTurns: 3},
+		ReviewPendingTTL: reviewPendingDefaultTTL,
+
+		MergeConflictConfig:             MergeConflictReactionConfig{Escalation: "label", EscalationLabel: "needs-human", PollIntervalMS: 60_000, MaxRetries: 1},
+		MergeConflictReactionConfigured: true,
+		MergeConflictPendingTTL:         mergeConflictPendingDefaultTTL,
+
+		LabelReviewConfig:             LabelReviewReactionConfig{Provider: "github", ReviewLabel: "sortie:review", PollIntervalMS: 60_000},
+		LabelReviewReactionConfigured: true,
+
+		LabelFixConfig:             LabelFixReactionConfig{Provider: "github", FixLabel: "sortie:fix", PollIntervalMS: 60_000},
+		LabelFixReactionConfigured: true,
+	}
+}
+
+func retrySlotCIPending(issueID string, createdAt time.Time) *PendingReaction {
+	return &PendingReaction{
+		IssueID:    issueID,
+		Identifier: issueID + "-ident",
+		DisplayID:  issueID + "-ident",
+		Attempt:    1,
+		Kind:       ReactionKindCI,
+		CreatedAt:  createdAt,
+		KindData:   &CIReactionData{Branch: "feature/x"},
+	}
+}
+
+func retrySlotReviewPending(issueID string, createdAt time.Time) *PendingReaction {
+	return &PendingReaction{
+		IssueID:    issueID,
+		Identifier: issueID + "-ident",
+		DisplayID:  issueID + "-ident",
+		Attempt:    1,
+		Kind:       ReactionKindReview,
+		CreatedAt:  createdAt,
+		KindData:   &ReviewReactionData{PRNumber: 20, Owner: "acme", Repo: "widgets", Branch: "feature/y"},
+	}
+}
+
+func retrySlotMergeConflictPending(issueID string, createdAt time.Time) *PendingReaction {
+	return &PendingReaction{
+		IssueID:    issueID,
+		Identifier: issueID + "-ident",
+		DisplayID:  issueID + "-ident",
+		Attempt:    1,
+		Kind:       ReactionKindMergeConflict,
+		CreatedAt:  createdAt,
+		KindData:   &MergeConflictReactionData{PRNumber: 30, Owner: "acme", Repo: "widgets", Branch: "feature/z"},
+	}
+}
+
+func retrySlotLabelReviewPending(issueID string, createdAt time.Time) *PendingReaction {
+	return &PendingReaction{
+		IssueID:    issueID,
+		Identifier: issueID + "-ident",
+		DisplayID:  issueID + "-ident",
+		Attempt:    1,
+		Kind:       ReactionKindLabelReview,
+		CreatedAt:  createdAt,
+		KindData:   &LabelReviewReactionData{PRNumber: 10, Owner: "acme", Repo: "widgets"},
+	}
+}
+
+func retrySlotLabelFixPending(issueID string, createdAt time.Time) *PendingReaction {
+	return &PendingReaction{
+		IssueID:    issueID,
+		Identifier: issueID + "-ident",
+		DisplayID:  issueID + "-ident",
+		Attempt:    1,
+		Kind:       ReactionKindLabelFix,
+		CreatedAt:  createdAt,
+		KindData:   &LabelFixReactionData{PRNumber: 40, Owner: "acme", Repo: "widgets", Branch: "feature/w"},
+	}
+}
+
+// --- Label-review defers to a ci incumbent it did not create ---
+
+func TestRetrySlot_LabelReviewDefersToCI(t *testing.T) {
+	t.Parallel()
+
+	const issueID = "RS-AC1"
+	now := retrySlotBaseTime()
+	state := NewState(5000, 4, nil, AgentTotals{})
+	state.Claimed[issueID] = struct{}{}
+	state.PendingReactions[ReactionKey(issueID, ReactionKindCI)] = retrySlotCIPending(issueID, now)
+	lrKey := ReactionKey(issueID, ReactionKindLabelReview)
+	state.PendingReactions[lrKey] = retrySlotLabelReviewPending(issueID, now)
+
+	store := newRetrySlotStore()
+	ci := &retrySlotCI{result: domain.CIResult{Status: domain.CIStatusFailing, FailingCount: 1}}
+	scm := &retrySlotSCM{
+		labelEvents: []domain.LabelEvent{labelEvent("1", "sortie:review", "alice", true, now.Add(-1*time.Minute))},
+	}
+	params := retrySlotParams(store, ci, scm, nil, func() time.Time { return now })
+
+	preTickMark, _, _ := store.GetReactionFingerprint(context.Background(), issueID, ReactionKindLabelReview)
+
+	ReconcileRunningIssues(state, params)
+
+	incumbent, ok := state.RetryAttempts[issueID]
+	if !ok {
+		t.Fatal("no incumbent occupies the slot after the tick")
+	}
+	if incumbent.ReactionKind != ReactionKindCI {
+		t.Errorf("RetryAttempts.ReactionKind = %q, want %q", incumbent.ReactionKind, ReactionKindCI)
+	}
+	if _, ok := incumbent.ContinuationContext["ci_failure"]; !ok {
+		t.Error("incumbent ContinuationContext missing ci_failure key")
+	}
+	if _, ok := state.PendingReactions[lrKey]; !ok {
+		t.Error("label-review pending entry consumed; want re-enqueued")
+	}
+	postTickMark, _, _ := store.GetReactionFingerprint(context.Background(), issueID, ReactionKindLabelReview)
+	if postTickMark != preTickMark {
+		t.Errorf("label-review fingerprint = %q, want unchanged %q", postTickMark, preTickMark)
+	}
+	if scm.removeLabelCalls != 0 {
+		t.Errorf("RemoveLabel calls = %d, want 0", scm.removeLabelCalls)
+	}
+}
+
+// --- Review defers to a queued label-review retry ---
+
+func TestRetrySlot_ReviewDefersToLabelReview(t *testing.T) {
+	t.Parallel()
+
+	const issueID = "RS-AC2"
+	now := retrySlotBaseTime()
+	state := NewState(5000, 4, nil, AgentTotals{})
+	state.Claimed[issueID] = struct{}{}
+	state.RetryAttempts[issueID] = &RetryEntry{IssueID: issueID, Attempt: 1, ReactionKind: ReactionKindLabelReview}
+	rKey := ReactionKey(issueID, ReactionKindReview)
+	state.PendingReactions[rKey] = retrySlotReviewPending(issueID, now)
+
+	store := newRetrySlotStore()
+	scm := &retrySlotSCM{
+		reviewComments: []domain.ReviewComment{{ID: "900", Body: "needs fix", SubmittedAt: now.Add(-5 * time.Minute)}},
+	}
+	params := retrySlotParams(store, &retrySlotCI{}, scm, nil, func() time.Time { return now })
+
+	ReconcileRunningIssues(state, params)
+
+	incumbent, ok := state.RetryAttempts[issueID]
+	if !ok {
+		t.Fatal("no incumbent occupies the slot after the tick")
+	}
+	if incumbent.ReactionKind != ReactionKindLabelReview {
+		t.Errorf("RetryAttempts.ReactionKind = %q, want %q (unchanged)", incumbent.ReactionKind, ReactionKindLabelReview)
+	}
+	if _, ok := state.PendingReactions[rKey]; !ok {
+		t.Error("review pending entry consumed; want re-enqueued")
+	}
+	if _, ok := state.ReactionAttempts[rKey]; ok {
+		t.Errorf("ReactionAttempts[%s] present, want absent (a defer must not increment it)", rKey)
+	}
+}
+
+// --- CI and label-fix deferrals in both directions ---
+
+func TestRetrySlot_CIAndLabelFixDeferrals(t *testing.T) {
+	t.Parallel()
+
+	t.Run("label-fix incumbent defers ci", func(t *testing.T) {
+		t.Parallel()
+
+		const issueID = "RS-AC3-A"
+		now := retrySlotBaseTime()
+		state := NewState(5000, 4, nil, AgentTotals{})
+		state.Claimed[issueID] = struct{}{}
+		state.RetryAttempts[issueID] = &RetryEntry{IssueID: issueID, Attempt: 1, ReactionKind: ReactionKindLabelFix}
+		ciKey := ReactionKey(issueID, ReactionKindCI)
+		state.PendingReactions[ciKey] = retrySlotCIPending(issueID, now)
+
+		store := newRetrySlotStore()
+		ci := &retrySlotCI{result: domain.CIResult{Status: domain.CIStatusFailing, FailingCount: 1}}
+		params := retrySlotParams(store, ci, &retrySlotSCM{}, nil, func() time.Time { return now })
+
+		ReconcileRunningIssues(state, params)
+
+		incumbent, ok := state.RetryAttempts[issueID]
+		if !ok || incumbent.ReactionKind != ReactionKindLabelFix {
+			t.Fatalf("incumbent = %+v, want label-fix unchanged", incumbent)
+		}
+		if _, ok := state.PendingReactions[ciKey]; !ok {
+			t.Error("ci pending entry consumed; want re-enqueued")
+		}
+		if _, ok := state.ReactionAttempts[ciKey]; ok {
+			t.Errorf("ReactionAttempts[%s] present, want absent", ciKey)
+		}
+		if store.hasRunHistoryStatus("ci_failed") {
+			t.Error("a ci_failed run_history row was appended on a defer; want none")
+		}
+	})
+
+	t.Run("ci incumbent defers label-fix", func(t *testing.T) {
+		t.Parallel()
+
+		const issueID = "RS-AC3-B"
+		now := retrySlotBaseTime()
+		state := NewState(5000, 4, nil, AgentTotals{})
+		state.Claimed[issueID] = struct{}{}
+		state.RetryAttempts[issueID] = &RetryEntry{IssueID: issueID, Attempt: 1, ReactionKind: ReactionKindCI}
+		lfKey := ReactionKey(issueID, ReactionKindLabelFix)
+		state.PendingReactions[lfKey] = retrySlotLabelFixPending(issueID, now)
+
+		store := newRetrySlotStore()
+		scm := &retrySlotSCM{
+			labelEvents: []domain.LabelEvent{labelEvent("1", "sortie:fix", "alice", true, now.Add(-1*time.Minute))},
+		}
+		params := retrySlotParams(store, &retrySlotCI{}, scm, nil, func() time.Time { return now })
+
+		preTickMark, _, _ := store.GetReactionFingerprint(context.Background(), issueID, ReactionKindLabelFix)
+
+		ReconcileRunningIssues(state, params)
+
+		incumbent, ok := state.RetryAttempts[issueID]
+		if !ok || incumbent.ReactionKind != ReactionKindCI {
+			t.Fatalf("incumbent = %+v, want ci unchanged", incumbent)
+		}
+		entry, ok := state.PendingReactions[lfKey]
+		if !ok {
+			t.Fatal("label-fix pending entry consumed; want re-enqueued")
+		}
+		postTickMark, _, _ := store.GetReactionFingerprint(context.Background(), issueID, ReactionKindLabelFix)
+		if postTickMark != preTickMark {
+			t.Errorf("label-fix fingerprint = %q, want unchanged %q", postTickMark, preTickMark)
+		}
+		data, ok := entry.KindData.(*LabelFixReactionData)
+		if !ok {
+			t.Fatalf("KindData type = %T, want *LabelFixReactionData", entry.KindData)
+		}
+		if data.HighWaterMark != "" {
+			t.Errorf("HighWaterMark = %q, want empty (a defer must not advance it)", data.HighWaterMark)
+		}
+		if scm.removeLabelCalls != 0 {
+			t.Errorf("RemoveLabel calls = %d, want 0", scm.removeLabelCalls)
+		}
+	})
+}
+
+// --- Merge-conflict defers to a ci incumbent (cross-pass half) ---
+
+func TestRetrySlot_MergeConflictDefersToCI(t *testing.T) {
+	t.Parallel()
+
+	const issueID = "RS-AC4"
+	now := retrySlotBaseTime()
+	state := NewState(5000, 4, nil, AgentTotals{})
+	state.Claimed[issueID] = struct{}{}
+	state.RetryAttempts[issueID] = &RetryEntry{IssueID: issueID, Attempt: 1, ReactionKind: ReactionKindCI}
+	mcKey := ReactionKey(issueID, ReactionKindMergeConflict)
+	state.PendingReactions[mcKey] = retrySlotMergeConflictPending(issueID, now)
+
+	store := newRetrySlotStore()
+	scm := &retrySlotSCM{
+		mergeStatus: domain.PRMergeStatus{Mergeability: domain.MergeabilityDirty, HeadSHA: "head-sha", BaseBranch: "main"},
+	}
+	params := retrySlotParams(store, &retrySlotCI{}, scm, nil, func() time.Time { return now })
+
+	ReconcileRunningIssues(state, params)
+
+	incumbent, ok := state.RetryAttempts[issueID]
+	if !ok || incumbent.ReactionKind != ReactionKindCI {
+		t.Fatalf("incumbent = %+v, want ci unchanged", incumbent)
+	}
+	if _, ok := state.PendingReactions[mcKey]; !ok {
+		t.Error("merge-conflict pending entry consumed; want re-enqueued")
+	}
+	if _, ok := state.ReactionAttempts[mcKey]; ok {
+		t.Errorf("ReactionAttempts[%s] present, want absent", mcKey)
+	}
+}
+
+// --- Liveness with a handoff state configured ---
+
+func TestRetrySlot_LivenessWithHandoffConfigured(t *testing.T) {
+	t.Parallel()
+
+	const issueID = "RS-AC6"
+	now := retrySlotBaseTime()
+	state := NewState(5000, 4, nil, AgentTotals{})
+	state.Claimed[issueID] = struct{}{}
+	state.PendingReactions[ReactionKey(issueID, ReactionKindCI)] = retrySlotCIPending(issueID, now)
+	state.PendingReactions[ReactionKey(issueID, ReactionKindLabelReview)] = retrySlotLabelReviewPending(issueID, now)
+
+	store := newRetrySlotStore()
+	ci := &retrySlotCI{result: domain.CIResult{Status: domain.CIStatusFailing, FailingCount: 1}}
+	scm := &retrySlotSCM{
+		labelEvents: []domain.LabelEvent{labelEvent("1", "sortie:review", "alice", true, now.Add(-1*time.Minute))},
+	}
+	tracker := &mockReconcileTracker{states: map[string]string{}}
+	params := retrySlotParams(store, ci, scm, tracker, func() time.Time { return now })
+	params.HandoffState = "Human Review"
+
+	ReconcileRunningIssues(state, params)
+
+	incumbent, ok := state.RetryAttempts[issueID]
+	if !ok || incumbent.ReactionKind != ReactionKindCI {
+		t.Fatalf("incumbent after tick 1 = %+v, want ci", incumbent)
+	}
+
+	// Fire the incumbent's own timer: the CI-fix worker dispatches. A real
+	// timer fire only reaches HandleRetryTimer after its full delay
+	// elapses; clearing the monotonic staleness fields models that
+	// without the test sleeping out the continuation delay.
+	incumbent.scheduledAt = time.Time{}
+	incumbent.scheduledDelayMS = 0
+
+	retryStore := &mockRetryStore{}
+	retryTracker := &mockRetryTracker{fetchedIssue: candidateIssue(issueID, issueID+"-ident", "In Progress")}
+	retryParams := defaultRetryParams(t, retryStore, retryTracker)
+	retryParams.HandoffState = "Human Review"
+
+	HandleRetryTimer(state, issueID, retryParams)
+
+	if _, running := state.Running[issueID]; !running {
+		t.Fatal("CI-fix worker did not dispatch")
+	}
+
+	// That worker exits normally on the handoff path with a free slot,
+	// releasing the claim.
+	exitStore := &mockExitStore{}
+	exitTracker := &mockTrackerAdapter{}
+	exitParams := defaultExitParams(t, exitStore)
+	exitParams.TrackerAdapter = exitTracker
+	exitParams.HandoffState = "Human Review"
+	exitParams.ActiveStates = []string{"In Progress"}
+
+	HandleWorkerExit(state, WorkerResult{
+		IssueID:      issueID,
+		Identifier:   issueID + "-ident",
+		ExitKind:     WorkerExitNormal,
+		AgentAdapter: "mock",
+	}, exitParams)
+
+	if _, ok := state.Claimed[issueID]; ok {
+		t.Fatal("claim held after the CI-fix worker's handoff exit, want released")
+	}
+	if _, ok := state.RetryAttempts[issueID]; ok {
+		t.Fatal("retry entry present after the CI-fix worker's handoff exit, want free")
+	}
+
+	// Second tick: the label is still present and the slot is free.
+	ReconcileRunningIssues(state, params)
+
+	lrIncumbent, ok := state.RetryAttempts[issueID]
+	if !ok || lrIncumbent.ReactionKind != ReactionKindLabelReview {
+		t.Fatalf("incumbent after tick 2 = %+v, want label-review", lrIncumbent)
+	}
+	if _, ok := lrIncumbent.ContinuationContext["label_review"]; !ok {
+		t.Error("incumbent ContinuationContext missing label_review key")
+	}
+	if scm.removeLabelCalls != 1 {
+		t.Errorf("RemoveLabel calls = %d, want 1 across both ticks", scm.removeLabelCalls)
+	}
+}
+
+// --- Liveness with no handoff state configured ---
+
+func TestRetrySlot_LivenessNoHandoffConfigured(t *testing.T) {
+	t.Parallel()
+
+	const issueID = "RS-AC6B"
+	now := retrySlotBaseTime()
+	state := NewState(5000, 4, nil, AgentTotals{})
+	state.Claimed[issueID] = struct{}{}
+	state.Running[issueID] = &RunningEntry{
+		Identifier: issueID + "-ident",
+		StartedAt:  now,
+		Issue:      candidateIssue(issueID, issueID+"-ident", "In Progress"),
+	}
+	state.PendingReactions[ReactionKey(issueID, ReactionKindCI)] = retrySlotCIPending(issueID, now)
+
+	store := newRetrySlotStore()
+	ci := &retrySlotCI{result: domain.CIResult{Status: domain.CIStatusFailing, FailingCount: 1}}
+	params := retrySlotParams(store, ci, &retrySlotSCM{}, nil, func() time.Time { return now })
+
+	// Tick while the continuation worker runs: ci takes the free slot.
+	ReconcileRunningIssues(state, params)
+
+	incumbent, ok := state.RetryAttempts[issueID]
+	if !ok || incumbent.ReactionKind != ReactionKindCI {
+		t.Fatalf("incumbent while the worker runs = %+v, want ci", incumbent)
+	}
+
+	// The continuation worker's own normal exit defers to the ci incumbent.
+	exitStore := &mockExitStore{}
+	exitParams := defaultExitParams(t, exitStore)
+	exitParams.ActiveStates = []string{"In Progress"}
+
+	HandleWorkerExit(state, WorkerResult{
+		IssueID:      issueID,
+		Identifier:   issueID + "-ident",
+		ExitKind:     WorkerExitNormal,
+		AgentAdapter: "mock",
+	}, exitParams)
+
+	ciEntry, ok := state.RetryAttempts[issueID]
+	if !ok || ciEntry.ReactionKind != ReactionKindCI {
+		t.Fatalf("ci incumbent after the continuation worker's exit = %+v, want survived", ciEntry)
+	}
+
+	// Fire the ci incumbent's own timer: it dispatches. A real timer fire
+	// only reaches HandleRetryTimer after its full delay elapses; clearing
+	// the monotonic staleness fields models that without the test
+	// sleeping out the continuation delay.
+	ciEntry.scheduledAt = time.Time{}
+	ciEntry.scheduledDelayMS = 0
+
+	retryStore := &mockRetryStore{}
+	retryTracker := &mockRetryTracker{fetchedIssue: candidateIssue(issueID, issueID+"-ident", "In Progress")}
+	retryParams := defaultRetryParams(t, retryStore, retryTracker)
+
+	HandleRetryTimer(state, issueID, retryParams)
+
+	if _, running := state.Running[issueID]; !running {
+		t.Fatal("ci-fix worker did not dispatch")
+	}
+
+	// That worker's own exit schedules the continuation into the freed slot.
+	exitStore2 := &mockExitStore{}
+	exitParams2 := defaultExitParams(t, exitStore2)
+	exitParams2.ActiveStates = []string{"In Progress"}
+
+	HandleWorkerExit(state, WorkerResult{
+		IssueID:      issueID,
+		Identifier:   issueID + "-ident",
+		ExitKind:     WorkerExitNormal,
+		AgentAdapter: "mock",
+	}, exitParams2)
+
+	continuation, ok := state.RetryAttempts[issueID]
+	if !ok {
+		t.Fatal("continuation not scheduled into the freed slot")
+	}
+	if continuation.ReactionKind != "" {
+		t.Errorf("RetryAttempts.ReactionKind = %q, want empty (continuation)", continuation.ReactionKind)
+	}
+}
+
+// --- The deferral record names an empty-kind continuation incumbent
+// with the literal "continuation" ---
+
+func TestRetrySlot_DeferralRecordReportsContinuationForEmptyKindIncumbent(t *testing.T) {
+	t.Parallel()
+
+	const issueID = "RS-AC13"
+	now := retrySlotBaseTime()
+	state := NewState(5000, 4, nil, AgentTotals{})
+	state.Claimed[issueID] = struct{}{}
+	state.RetryAttempts[issueID] = &RetryEntry{IssueID: issueID, Attempt: 5} // continuation: empty ReactionKind
+	state.PendingReactions[ReactionKey(issueID, ReactionKindCI)] = retrySlotCIPending(issueID, now)
+
+	store := newRetrySlotStore()
+	ci := &retrySlotCI{result: domain.CIResult{Status: domain.CIStatusFailing, FailingCount: 1}}
+	handler := &sweepLogHandler{}
+	params := retrySlotParams(store, ci, &retrySlotSCM{}, nil, func() time.Time { return now })
+	params.Logger = slog.New(handler)
+
+	ReconcileRunningIssues(state, params)
+
+	rec, ok := handler.findByMessage("retry slot occupied, deferring")
+	if !ok {
+		t.Fatal(`"retry slot occupied, deferring" not logged`)
+	}
+	if got := stringAttr(t, rec, "incumbent_kind"); got != "continuation" {
+		t.Errorf("incumbent_kind = %q, want %q", got, "continuation")
+	}
+}
+
+// --- CreatedAt advances on every arbitration deferral, for both a
+// TTL-bearing kind and a kind with no TTL ---
+
+func TestRetrySlot_TTLRefreshOnArbitrationDeferral(t *testing.T) {
+	t.Parallel()
+
+	t.Run("ci pending deferring behind a label-fix incumbent", func(t *testing.T) {
+		t.Parallel()
+
+		const issueID = "RS-AC24-CI"
+		tick1 := retrySlotBaseTime()
+		state := NewState(5000, 4, nil, AgentTotals{})
+		state.Claimed[issueID] = struct{}{}
+		state.RetryAttempts[issueID] = &RetryEntry{IssueID: issueID, Attempt: 1, ReactionKind: ReactionKindLabelFix}
+		ciKey := ReactionKey(issueID, ReactionKindCI)
+		state.PendingReactions[ciKey] = retrySlotCIPending(issueID, tick1.Add(-29*time.Minute))
+
+		store := newRetrySlotStore()
+		ci := &retrySlotCI{result: domain.CIResult{Status: domain.CIStatusFailing, FailingCount: 1}}
+		now := tick1
+		handler := &sweepLogHandler{}
+		params := retrySlotParams(store, ci, &retrySlotSCM{}, nil, func() time.Time { return now })
+		params.Logger = slog.New(handler)
+
+		ticks := []time.Time{tick1, tick1.Add(15 * time.Minute), tick1.Add(32 * time.Minute)}
+		for _, tickNow := range ticks {
+			now = tickNow
+			ReconcileRunningIssues(state, params)
+
+			entry, ok := state.PendingReactions[ciKey]
+			if !ok {
+				t.Fatalf("ci pending entry dropped at tick %v; want re-enqueued", tickNow)
+			}
+			if !entry.CreatedAt.Equal(tickNow) {
+				t.Errorf("CreatedAt at tick %v = %v, want %v", tickNow, entry.CreatedAt, tickNow)
+			}
+		}
+		if handler.countByMessage("ci pending entry exceeded ttl, dropping") != 0 {
+			t.Error("TTL-drop Warn emitted despite the CreatedAt refresh; want none")
+		}
+	})
+
+	t.Run("label-review pending deferring behind a ci incumbent", func(t *testing.T) {
+		t.Parallel()
+
+		const issueID = "RS-AC24-LR"
+		tick1 := retrySlotBaseTime()
+		state := NewState(5000, 4, nil, AgentTotals{})
+		state.Claimed[issueID] = struct{}{}
+		state.RetryAttempts[issueID] = &RetryEntry{IssueID: issueID, Attempt: 1, ReactionKind: ReactionKindCI}
+		lrKey := ReactionKey(issueID, ReactionKindLabelReview)
+		state.PendingReactions[lrKey] = retrySlotLabelReviewPending(issueID, tick1.Add(-29*time.Minute))
+
+		store := newRetrySlotStore()
+		scm := &retrySlotSCM{
+			labelEvents: []domain.LabelEvent{labelEvent("1", "sortie:review", "alice", true, tick1.Add(-40*time.Minute))},
+		}
+		now := tick1
+		params := retrySlotParams(store, &retrySlotCI{}, scm, nil, func() time.Time { return now })
+
+		ticks := []time.Time{tick1, tick1.Add(15 * time.Minute), tick1.Add(32 * time.Minute)}
+		for _, tickNow := range ticks {
+			now = tickNow
+			ReconcileRunningIssues(state, params)
+
+			entry, ok := state.PendingReactions[lrKey]
+			if !ok {
+				t.Fatalf("label-review pending entry dropped at tick %v; want re-enqueued", tickNow)
+			}
+			if !entry.CreatedAt.Equal(tickNow) {
+				t.Errorf("CreatedAt at tick %v = %v, want %v", tickNow, entry.CreatedAt, tickNow)
+			}
+		}
+	})
+}

--- a/internal/orchestrator/retry_test.go
+++ b/internal/orchestrator/retry_test.go
@@ -2947,3 +2947,260 @@ func TestHandleRetryTimer_AgentAdapterLookupUsesAgentKind(t *testing.T) {
 		t.Error("DeleteRetryEntry not called after adapter lookup failure")
 	}
 }
+
+// --- Paused-retry dwell bound tests (R29) ---
+
+func TestHandleRetryTimer_PausedDwellBound(t *testing.T) {
+	t.Parallel()
+
+	t.Run("non-handoff arm: first fire re-occupies slot with incremented attempt and non-zero pausedSinceMS", func(t *testing.T) {
+		t.Parallel()
+
+		const id = "DWELL-UNRELATED-1"
+		state := NewState(5000, 4, nil, AgentTotals{})
+		state.Claimed[id] = struct{}{}
+		state.RetryAttempts[id] = &RetryEntry{
+			IssueID:      id,
+			Identifier:   id,
+			Attempt:      1,
+			ReactionKind: ReactionKindCI,
+		}
+
+		store := &mockRetryStore{}
+		tracker := &mockRetryTracker{
+			// Not active, not terminal, not handoff.
+			fetchedIssue: candidateIssue(id, id, "QA Review"),
+		}
+		params := defaultRetryParams(t, store, tracker)
+		params.HandoffState = "Ready For Review"
+
+		before := time.Now().UnixMilli()
+		HandleRetryTimer(state, id, params)
+		after := time.Now().UnixMilli()
+
+		entry, ok := state.RetryAttempts[id]
+		if !ok {
+			t.Fatal("RetryAttempts missing after non-handoff paused reschedule")
+		}
+		if entry.Attempt != 2 {
+			t.Errorf("RetryAttempts[%s].Attempt = %d, want 2", id, entry.Attempt)
+		}
+		if entry.pausedSinceMS < before || entry.pausedSinceMS > after {
+			t.Errorf("pausedSinceMS = %d, want between %d and %d", entry.pausedSinceMS, before, after)
+		}
+		if entry.TimerHandle != nil {
+			entry.TimerHandle.Stop()
+		}
+	})
+
+	t.Run("non-handoff arm: second fire past max dwell drops the entry", func(t *testing.T) {
+		t.Parallel()
+
+		const id = "DWELL-UNRELATED-2"
+		state := NewState(5000, 4, nil, AgentTotals{})
+		state.Claimed[id] = struct{}{}
+		staleSince := time.Now().Add(-(pausedRetryMaxDwell + time.Minute)).UnixMilli()
+		state.RetryAttempts[id] = &RetryEntry{
+			IssueID:       id,
+			Identifier:    id,
+			Attempt:       2,
+			ReactionKind:  ReactionKindCI,
+			pausedSinceMS: staleSince,
+		}
+
+		store := &mockRetryStore{}
+		tracker := &mockRetryTracker{
+			fetchedIssue: candidateIssue(id, id, "QA Review"),
+		}
+		var buf bytes.Buffer
+		log := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+		params := defaultRetryParams(t, store, tracker)
+		params.HandoffState = "Ready For Review"
+		params.Logger = log
+
+		HandleRetryTimer(state, id, params)
+
+		if _, ok := state.RetryAttempts[id]; ok {
+			t.Error("RetryAttempts entry present after dwell exceeded, want dropped")
+		}
+		if len(store.deletedIssueID) != 1 || store.deletedIssueID[0] != id {
+			t.Errorf("DeleteRetryEntry calls = %v, want [%s]", store.deletedIssueID, id)
+		}
+		if _, claimed := state.Claimed[id]; claimed {
+			t.Error("Claimed still present after dwell exceeded, want released")
+		}
+
+		output := buf.String()
+		if !strings.Contains(output, "paused reaction retry exceeded max dwell, dropping") {
+			t.Errorf("log output = %q, want message %q", output, "paused reaction retry exceeded max dwell, dropping")
+		}
+		if !strings.Contains(output, "kind=ci") {
+			t.Errorf("log output = %q, want kind=ci", output)
+		}
+		if !strings.Contains(output, `issue_state="QA Review"`) {
+			t.Errorf("log output = %q, want issue_state=\"QA Review\"", output)
+		}
+		if !strings.Contains(output, "attempt=2") {
+			t.Errorf("log output = %q, want attempt=2", output)
+		}
+		if !strings.Contains(output, "dwell_ms=") {
+			t.Errorf("log output = %q, want a dwell_ms attribute", output)
+		}
+		if !strings.Contains(output, "max_dwell_ms=") {
+			t.Errorf("log output = %q, want a max_dwell_ms attribute", output)
+		}
+	})
+
+	t.Run("blocked-issue arm: first fire re-occupies slot with incremented attempt and non-zero pausedSinceMS", func(t *testing.T) {
+		t.Parallel()
+
+		const id = "DWELL-BLOCKED-1"
+		state := NewState(5000, 4, nil, AgentTotals{})
+		state.Claimed[id] = struct{}{}
+		state.RetryAttempts[id] = &RetryEntry{
+			IssueID:      id,
+			Identifier:   id,
+			Attempt:      1,
+			ReactionKind: ReactionKindCI,
+		}
+
+		issue := candidateIssue(id, id, "To Do") // active
+		issue.BlockedBy = []domain.BlockerRef{
+			{ID: "BLOCK-1", Identifier: "BLOCK-1", State: "In Progress"}, // non-terminal blocker
+		}
+		store := &mockRetryStore{}
+		tracker := &mockRetryTracker{fetchedIssue: issue}
+		params := defaultRetryParams(t, store, tracker)
+
+		before := time.Now().UnixMilli()
+		HandleRetryTimer(state, id, params)
+		after := time.Now().UnixMilli()
+
+		entry, ok := state.RetryAttempts[id]
+		if !ok {
+			t.Fatal("RetryAttempts missing after blocked-issue paused reschedule")
+		}
+		if entry.Attempt != 2 {
+			t.Errorf("RetryAttempts[%s].Attempt = %d, want 2", id, entry.Attempt)
+		}
+		if entry.pausedSinceMS < before || entry.pausedSinceMS > after {
+			t.Errorf("pausedSinceMS = %d, want between %d and %d", entry.pausedSinceMS, before, after)
+		}
+		if entry.TimerHandle != nil {
+			entry.TimerHandle.Stop()
+		}
+	})
+
+	t.Run("blocked-issue arm: second fire past max dwell drops the entry", func(t *testing.T) {
+		t.Parallel()
+
+		const id = "DWELL-BLOCKED-2"
+		state := NewState(5000, 4, nil, AgentTotals{})
+		state.Claimed[id] = struct{}{}
+		staleSince := time.Now().Add(-(pausedRetryMaxDwell + time.Minute)).UnixMilli()
+		state.RetryAttempts[id] = &RetryEntry{
+			IssueID:       id,
+			Identifier:    id,
+			Attempt:       3,
+			ReactionKind:  ReactionKindReview,
+			pausedSinceMS: staleSince,
+		}
+
+		issue := candidateIssue(id, id, "To Do")
+		issue.BlockedBy = []domain.BlockerRef{
+			{ID: "BLOCK-1", Identifier: "BLOCK-1", State: "In Progress"},
+		}
+		store := &mockRetryStore{}
+		tracker := &mockRetryTracker{fetchedIssue: issue}
+		var buf bytes.Buffer
+		log := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+		params := defaultRetryParams(t, store, tracker)
+		params.Logger = log
+
+		HandleRetryTimer(state, id, params)
+
+		if _, ok := state.RetryAttempts[id]; ok {
+			t.Error("RetryAttempts entry present after dwell exceeded, want dropped")
+		}
+		if len(store.deletedIssueID) != 1 || store.deletedIssueID[0] != id {
+			t.Errorf("DeleteRetryEntry calls = %v, want [%s]", store.deletedIssueID, id)
+		}
+		if _, claimed := state.Claimed[id]; claimed {
+			t.Error("Claimed still present after dwell exceeded, want released")
+		}
+
+		output := buf.String()
+		if !strings.Contains(output, "paused reaction retry exceeded max dwell, dropping") {
+			t.Errorf("log output = %q, want message %q", output, "paused reaction retry exceeded max dwell, dropping")
+		}
+		if !strings.Contains(output, "kind=review") {
+			t.Errorf("log output = %q, want kind=review", output)
+		}
+		if !strings.Contains(output, "attempt=3") {
+			t.Errorf("log output = %q, want attempt=3", output)
+		}
+	})
+
+	t.Run("pausedSinceMS resets to zero after a paused fire followed by a no-orchestrator-slots fire", func(t *testing.T) {
+		t.Parallel()
+
+		const id = "DWELL-RESET"
+		state := NewState(5000, 1, nil, AgentTotals{})
+		state.Claimed[id] = struct{}{}
+		state.RetryAttempts[id] = &RetryEntry{
+			IssueID:      id,
+			Identifier:   id,
+			Attempt:      1,
+			ReactionKind: ReactionKindCI,
+		}
+
+		store := &mockRetryStore{}
+		tracker := &mockRetryTracker{
+			// Not active, not terminal, not handoff: paused arm.
+			fetchedIssue: candidateIssue(id, id, "QA Review"),
+		}
+		params := defaultRetryParams(t, store, tracker)
+		params.HandoffState = "Ready For Review"
+
+		HandleRetryTimer(state, id, params)
+
+		firstEntry, ok := state.RetryAttempts[id]
+		if !ok {
+			t.Fatal("RetryAttempts missing after first paused fire")
+		}
+		if firstEntry.pausedSinceMS == 0 {
+			t.Fatal("pausedSinceMS not set after first paused fire")
+		}
+		if firstEntry.TimerHandle != nil {
+			firstEntry.TimerHandle.Stop()
+		}
+		// A real timer fire only reaches HandleRetryTimer after its full
+		// delay elapses; clearing the monotonic staleness fields models
+		// that without the test sleeping out the backoff delay.
+		firstEntry.scheduledAt = time.Time{}
+		firstEntry.scheduledDelayMS = 0
+
+		// Second fire: the issue is now active with no blocker, and the
+		// sole concurrency slot is occupied by another running issue, so
+		// this fire takes the no-orchestrator-slots arm instead of a
+		// paused arm.
+		tracker.fetchedIssue = candidateIssue(id, id, "To Do")
+		state.Running["OTHER-1"] = &RunningEntry{
+			Identifier: "OTHER-1",
+			Issue:      candidateIssue("OTHER-1", "OTHER-1", "To Do"),
+		}
+
+		HandleRetryTimer(state, id, params)
+
+		secondEntry, ok := state.RetryAttempts[id]
+		if !ok {
+			t.Fatal("RetryAttempts missing after no-orchestrator-slots fire")
+		}
+		if secondEntry.pausedSinceMS != 0 {
+			t.Errorf("pausedSinceMS = %d, want 0 after a non-paused reschedule arm", secondEntry.pausedSinceMS)
+		}
+		if secondEntry.TimerHandle != nil {
+			secondEntry.TimerHandle.Stop()
+		}
+	})
+}

--- a/internal/orchestrator/review_reconcile.go
+++ b/internal/orchestrator/review_reconcile.go
@@ -159,12 +159,18 @@ func reconcileReviewComments(state *State, params ReconcileParams, log *slog.Log
 			continue
 		}
 
+		// Arbitrate the retry slot before dispatching.
+		if incumbent := retrySlotIncumbent(state, pending.IssueID); incumbent != nil {
+			logRetrySlotDeferral(entryLog, ReactionKindReview, incumbent)
+			pending.CreatedAt = now
+			state.PendingReactions[key] = pending
+			continue
+		}
+
 		// Dispatch.
 		metrics.IncReviewChecks("dispatched")
 
 		reviewContext := buildReviewTemplateMap(actionable)
-
-		CancelRetry(state, pending.IssueID)
 
 		ScheduleRetry(state, ScheduleRetryParams{
 			IssueID:     pending.IssueID,
@@ -180,6 +186,7 @@ func reconcileReviewComments(state *State, params ReconcileParams, log *slog.Log
 			AgentKind:    pending.AgentKind,
 			RuleName:     pending.RuleName,
 			TemplateID:   pending.TemplateID,
+			Logger:       entryLog,
 		}, params.OnRetryFire)
 
 		state.ReactionAttempts[rkey]++

--- a/internal/orchestrator/review_reconcile_test.go
+++ b/internal/orchestrator/review_reconcile_test.go
@@ -1087,3 +1087,52 @@ func TestComputeReviewPendingDelay(t *testing.T) {
 		})
 	}
 }
+
+// TestReconcileReviewComments_ForeignIncumbentDefers verifies that a
+// foreign incumbent occupying the retry slot leaves the review pending
+// entry re-enqueued rather than dispatched, and that
+// state.ReactionAttempts for the review kind is left unchanged.
+func TestReconcileReviewComments_ForeignIncumbentDefers(t *testing.T) {
+	t.Parallel()
+
+	const issueID = "ISS-R-DEFER"
+	state := stateWithReviewReaction(t, issueID, 10)
+	rkey := ReactionKey(issueID, ReactionKindReview)
+	state.RetryAttempts[issueID] = &RetryEntry{
+		IssueID:      issueID,
+		Attempt:      1,
+		ReactionKind: ReactionKindLabelReview,
+	}
+
+	// Comment submitted 5 minutes ago — outside the debounce window.
+	comments := []domain.ReviewComment{
+		{ID: "900", Body: "needs fix", SubmittedAt: reviewBaseTime.Add(-5 * time.Minute)},
+	}
+	store := &reviewReconcileStore{}
+	metrics := newReviewMetricsSpy()
+	scm := &mockSCMAdapter{comments: comments}
+	params := reviewParams(store, scm, nil)
+
+	reconcileReviewComments(state, params, discardLogger(), context.Background(), metrics)
+
+	entry, ok := state.PendingReactions[rkey]
+	if !ok {
+		t.Fatal("PendingReactions entry dropped on a defer; want re-enqueued")
+	}
+	if !entry.CreatedAt.Equal(reviewBaseTime) {
+		t.Errorf("CreatedAt = %v, want refreshed to %v", entry.CreatedAt, reviewBaseTime)
+	}
+	incumbent := state.RetryAttempts[issueID]
+	if incumbent.ReactionKind != ReactionKindLabelReview {
+		t.Errorf("RetryAttempts.ReactionKind = %q, want %q (incumbent unchanged)", incumbent.ReactionKind, ReactionKindLabelReview)
+	}
+	if incumbent.Attempt != 1 {
+		t.Errorf("RetryAttempts.Attempt = %d, want 1 (unchanged)", incumbent.Attempt)
+	}
+	if _, ok := state.ReactionAttempts[rkey]; ok {
+		t.Errorf("ReactionAttempts[%s] = %d, want absent (a defer must not increment it)", rkey, state.ReactionAttempts[rkey])
+	}
+	if metrics.reviewChecks["dispatched"] != 0 {
+		t.Errorf(`IncReviewChecks("dispatched") = %d, want 0 (no dispatch on a defer)`, metrics.reviewChecks["dispatched"])
+	}
+}

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -318,6 +318,14 @@ type RetryEntry struct {
 	// Propagated through every retry so [HandleRetryTimer] can look up
 	// the adapter without re-running rule resolution.
 	AgentKind string
+
+	// pausedSinceMS is the wall-clock millisecond at which this entry
+	// first took one of HandleRetryTimer's two paused-by-issue-state
+	// arms, because the issue's current state does not permit a
+	// dispatch. Zero means the entry is not paused. Runtime-only,
+	// alongside scheduledAt and scheduledDelayMS above: never persisted
+	// and never carried on ScheduleRetryParams.
+	pausedSinceMS int64
 }
 
 // ReactionKindCI is the reaction kind constant for CI failure reactions.


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Fix

**Intent:** The orchestrator keeps at most one queued retry per issue, and every reconcile pass that dispatched a continuation cancelled and overwrote that slot without checking who owned it. When two reactions became actionable for the same issue in the same poll window, the later pass silently discarded the work the earlier pass had queued, and that work was unrecoverable - the losing pass had already consumed its own pending-reaction entry and nothing re-detected the condition afterward. This PR gives the retry slot a notion of ownership: dispatching passes now check the slot's incumbent first and defer to a later poll instead of displacing it.

**Related Issues:** #743

### 🧭 Reviewer Guide

**Complexity:** High

#### Entry Point

Start with `internal/orchestrator/dispatch.go`. It introduces `retrySlotIncumbent` (read the slot without side effects), `logRetrySlotDeferral` for observability when a challenger defers, and changes `ScheduleRetry`'s contract: callers must now check the slot is free before calling it, since `ScheduleRetry` itself only stays as a backstop that logs a warning if it is ever called against an occupied slot. Every reconcile pass in the family (`ci_reconcile.go`, `review_reconcile.go`, `bot_review_reconcile.go`, `label_review_reconcile.go`, `label_fix_reconcile.go`, `merge_conflict_reconcile.go`) and the worker-exit continuation path (`exit.go`) were updated to honor this new check-before-write contract instead of cancelling and rescheduling unconditionally.

`internal/orchestrator/retry.go` and `internal/orchestrator/state.go` bound two related stall modes uncovered while fixing the primary bug: a reaction for an issue parked outside every configured state is now dropped after 30 minutes with a warning naming the reaction kind and issue state (previously it retried at the backoff ceiling indefinitely, blocking that issue's other reactions), and a retry whose timer event was lost under load is re-armed on a later poll instead of stalling forever. `state.go` adds the runtime-only `pausedSinceMS` field on `RetryEntry` that tracks this.

`internal/orchestrator/retry_slot_test.go` is a new file with dedicated coverage for slot ownership: a retry already queued by one pass is not lost when a second pass (in either direction, including label commands) tries to dispatch for the same issue, and no orphaned row is left in the persisted retry table.

#### Sensitive Areas

- `internal/orchestrator/dispatch.go`: changes the contract of `ScheduleRetry`, the shared primitive every reaction pass calls to queue a continuation.
- `internal/orchestrator/retry.go`: introduces the 30-minute parked-issue drop bound and the lost-timer-event re-arm, both of which change existing retry/backoff timing behavior.
- `internal/orchestrator/exit.go`: worker-exit continuation scheduling no longer cancels work queued while the worker was running.
- `internal/orchestrator/ci_reconcile.go`, `review_reconcile.go`, `bot_review_reconcile.go`, `label_review_reconcile.go`, `label_fix_reconcile.go`, `merge_conflict_reconcile.go`: each reconcile pass changes from cancel-then-schedule to check-then-defer; a regression here reintroduces the original bug for that specific reaction kind.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes. `ScheduleRetry`'s documented contract changed (callers must check the slot first), but all in-tree callers were updated; this is an internal orchestrator package, not a public API.
- **Migrations/State:** No database migrations. Runtime behavior changes: a reaction for an issue parked outside every configured state is now dropped after 30 minutes instead of retrying indefinitely, and a label command keeps its label on the pull request until it actually starts running (an unremoved label now means "accepted but not yet running" rather than an error state).
