### PR TITLE
fix(agent): unify turn disposition across agent adapters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the dispatch proceeds either way.
   ([#757](https://github.com/sortie-ai/sortie/issues/757))
 
+- An `opencode` turn that exits cleanly having produced no model output
+  at all - no text, no reasoning, no tool call - is no longer reported
+  as completed. The turn now fails and is retried, instead of counting
+  as work done and letting the run advance the issue on nothing.
+
+- A failed or cancelled turn on `opencode` and `codex` now records why
+  it ended. Both agents reported the outcome with no accompanying
+  error, so the run's `error` column and the dashboard showed a failure
+  with no reason attached; the runtime's own diagnostic now reaches
+  both. On `codex`, a turn that fails before it starts and one whose
+  subprocess output ends early also reach the event stream, so the
+  dashboard's last event no longer stops at the last step that worked.
+
+### Changed
+
+- `opencode` transport failures - a stdout read error, a session id
+  mismatch, or a timeout waiting for the first response - now report
+  `exit_reason=turn_failed` instead of `turn_ended_with_error`, which
+  no built-in coding agent reports any more. An alert or dashboard
+  filter on the old value must match on the error kind instead, which
+  already drew the same distinction.
+
+- Turn failure text is now the same across every coding agent: a turn
+  that exits successfully having produced nothing reports `agent exited
+  without producing output`, and a non-zero exit reports `exit code N`.
+  An alert matching the previous `kiro` or `opencode` wording needs
+  updating.
+
+- `run_history.turns_completed` no longer counts a turn that ended in
+  failure or cancellation on `opencode` and `codex`, so the column
+  means the same thing on every coding agent. Turn counts and mean
+  turns per run in `sortie stats` and on the dashboard drop for those
+  two agents at this release, with no change in behavior behind the
+  numbers.
+
 ### Migrations
 
 - Add `tokens_measured INTEGER NOT NULL DEFAULT 1` to `run_history`;

--- a/docs/architecture/10-agent-adapter-contract.md
+++ b/docs/architecture/10-agent-adapter-contract.md
@@ -589,3 +589,47 @@ Recommended additional process settings:
 
 - Max line size: 10 MB (for safe buffering)
 
+### 10.8 Turn Disposition
+
+Every adapter must decide, at the end of each turn, whether the turn completed, failed, or was
+cancelled, and pair that decision with the returned error. This decision follows one shared rule
+so that a new adapter inherits it rather than re-deriving it.
+
+The rule is evaluated as an ordered table. The first matching row decides the turn:
+
+1. The runtime reported the turn cancelled (an orchestrator-initiated cancellation): `turn_cancelled`.
+2. The runtime reported the turn failed, or the adapter itself ended the turn on its own
+   determination (a protocol violation, a timeout waiting for the first response, or a transport
+   failure): `turn_failed`, with the error kind the runtime or the adapter supplied.
+3. The runtime reported the turn succeeded: `turn_completed`. A positive report from the runtime is
+   authoritative and is never second-guessed by counting output.
+4. The runtime reported no outcome at all, and the adapter observed no process exit for the turn (a
+   persistent session with no per-turn exit): `turn_failed`.
+5. The runtime reported no outcome, a process exit was observed, and the exit code is non-zero:
+   `turn_failed`.
+6. The runtime reported no outcome, the process exited zero, and the adapter found no evidence the
+   model produced anything this turn: `turn_failed`. Exit code zero is never by itself a success
+   signal; an adapter with nothing positive to offer reports a failed turn.
+7. The runtime reported no outcome, the process exited zero, and the adapter found evidence the
+   model produced something this turn: `turn_completed`.
+
+Extracting the runtime's own report and the per-turn work evidence from a vendor's wire format is
+adapter-local, and each adapter's protocol document states how it does so. Turning that evidence
+into a disposition is not adapter-local: every adapter obtains its turn disposition from the one
+shared rule above, and an adapter whose runtime reports something the rule cannot express extends
+the rule itself, under review, rather than deciding the case in a private branch.
+
+Two adapters cannot supply the rule's per-turn work evidence in the same currency as the others,
+and diverge from the rule's letter while obeying its intent:
+
+- Headless Kiro reports no token counts at all, so its zero-work guard is expressed in a different
+  currency: the credits trailer on stderr is the positive success signal, and its absence with a
+  zero exit code is the adapter's only evidence of nothing produced.
+- Codex's persistent per-session subprocess has no per-turn process exit to observe, so the rule's
+  zero-work row (row 6 above) is structurally unreachable for it: an absent turn-completion report
+  is already a failure on its own terms.
+
+`turn_ended_with_error` remains a documented normalized event type (Section 10.3), reserved for a
+future adapter whose runtime genuinely distinguishes a transport-class failure from every other
+failure, even though no built-in adapter emits it today.
+

--- a/docs/codex-adapter-notes.md
+++ b/docs/codex-adapter-notes.md
@@ -370,13 +370,21 @@ The `turn/completed` notification contains the final turn state:
 
 `turn.status` values:
 
-| Status          | Adapter mapping    | Description                          |
-| --------------- | ------------------ | ------------------------------------ |
-| `completed`     | `turn_completed`   | Agent finished normally.             |
-| `interrupted`   | `turn_cancelled`   | Cancelled via `turn/interrupt`.      |
-| `failed`        | `turn_failed`      | Error during turn execution.         |
+| Status           | Adapter mapping                                                                                                            | Description                                       |
+| ---------------- | ---------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
+| `completed`      | `turn_completed`                                                                                                            | Agent finished normally.                          |
+| `interrupted`    | `turn_cancelled` when the turn's context was already cancelled; `turn_failed` when the context was still live               | Cancelled via `turn/interrupt`, or an interruption sortie did not request. |
+| `failed`         | `turn_failed`                                                                                                                | Error during turn execution.                      |
+| any other status | `turn_failed`                                                                                                                | An unrecognized status is treated as a failure.   |
 
 On failure, `turn.error` contains `{message, codexErrorInfo?, additionalDetails?}`.
+
+Codex's persistent per-session subprocess exits once at session end, not once per turn, so the
+turn-disposition rule the adapter family shares has no per-turn process exit to consult for this
+adapter. The rule's zero-work row, which the other four adapters reach when their runtime reports
+no outcome and the process exits `0`, is structurally unreachable here: an absent `turn/completed`
+notification is already a failure on its own terms (the stdout channel closed before it arrived),
+so the adapter never needs a separate zero-work guard.
 
 ---
 

--- a/docs/kiro-adapter-notes.md
+++ b/docs/kiro-adapter-notes.md
@@ -541,6 +541,14 @@ Suggested mapping to `domain.TurnResult.ExitReason`:
 | Binary not found on `PATH` (exit 127) | `startup_failed` |
 | No-credential launch that hangs | Prevent by preflight; if it occurs, the orchestrator timeout yields `turn_cancelled` |
 
+The turn-disposition rule the adapter family shares treats a zero exit code with no positive
+signal as a failed turn, and the positive signal is ordinarily a per-turn token count. Headless
+Kiro reports no token counts at all, so it expresses the same guard in a different currency: the
+`▸ Credits:` trailer is the adapter's sole positive success signal, and its absence with exit 0 is
+the adapter's only evidence that nothing was produced. Non-empty answer stdout is deliberately not
+read as a second, looser signal, because Kiro's stdout is an unstructured transcript with no field
+distinguishing an answer from an error message.
+
 ## Token usage and cost reporting
 
 This section answers the core question in the research issue: whether token usage or cost is

--- a/docs/opencode-adapter-notes.md
+++ b/docs/opencode-adapter-notes.md
@@ -470,10 +470,22 @@ For a Sortie adapter built on `opencode run`, a sensible normalization rule is:
 | `session_started` | First successfully parsed JSON envelope carrying `sessionID`, or session ID known from a server/API response |
 | `tool_result` | Each `tool_use` event, using `part.tool`, `part.state.status`, and `part.state.time` |
 | `notification` / `other_message` | Default-mode-only prose is not available in JSON mode; optional if adapter also captures stderr |
-| `turn_completed` | Process exits after a normal run and no terminal `error` was observed |
-| `turn_failed` | Any terminal `error` event, or a process-level CLI/setup failure |
+| `turn_completed` | Process exits after a normal run, no terminal `error` was observed, and at least one `text`, `reasoning`, or `tool_use` part was parsed during the turn |
+| `turn_failed` | Any terminal `error` event; a process-level CLI/setup failure; or the process exits after a normal run with no `text`, `reasoning`, or `tool_use` part parsed, even when the exit code is `0` |
 | `turn_cancelled` | Prefer the server API surface, which exposes `session.abort` and `session.status`; `run --format json` does not emit a dedicated cancel envelope |
 | `token_usage` | Do not treat `step_finish.part.tokens` as authoritative turn totals without extra logic |
+
+A `text`, `reasoning`, or `tool_use` part observed during the turn is the positive work signal
+that decides `turn_completed` when the process exits `0` with no terminal `error`. Without it, an
+exit-`0` run that parsed a JSON envelope but produced no assistant output (an empty step, or a
+stream of `step_start`/`step_finish` bracketing nothing) is `turn_failed`, not `turn_completed`.
+Process exit code stays informative rather than load-bearing, per the row above, but that framing
+no longer extends to meaning an exit-`0` run with no terminal `error` is automatically complete.
+
+A transport-class failure (a stdout read error, a session id mismatch, or a timeout waiting for
+the first JSON event) reports `turn_failed` with the failure's specific error kind, the same
+normalized event the other four adapters in the family use for the same class, rather than
+`turn_ended_with_error`.
 
 ### Token usage caveat
 

--- a/internal/agent/agentcore/disposition.go
+++ b/internal/agent/agentcore/disposition.go
@@ -1,0 +1,319 @@
+package agentcore
+
+import (
+	"fmt"
+	"log/slog"
+
+	"github.com/sortie-ai/sortie/internal/domain"
+)
+
+// zeroWorkMessageStem is the shared diagnostic stem every adapter's
+// zero-work row uses, so an operator can grep one string across the whole
+// agent family.
+const zeroWorkMessageStem = "agent exited without producing output"
+
+// TerminalReport is the adapter-normalized end-of-turn report for one turn:
+// what the runtime said about the outcome, or what the adapter determined
+// when it aborted the turn itself.
+type TerminalReport uint8
+
+const (
+	// TerminalAbsent means neither the runtime nor the adapter has an
+	// outcome to report, so the disposition rests on the process exit and
+	// the work evidence.
+	TerminalAbsent TerminalReport = iota
+
+	// TerminalSuccess means the runtime, or the adapter on its behalf,
+	// reported that the turn completed successfully.
+	TerminalSuccess
+
+	// TerminalFailure means the runtime, or the adapter on its behalf,
+	// reported that the turn ended in failure.
+	TerminalFailure
+
+	// TerminalCancelled means the orchestrator initiated the turn's
+	// cancellation, through context cancellation or StopSession.
+	TerminalCancelled
+)
+
+// WorkReport is the adapter-normalized evidence that the model produced
+// something during this turn.
+type WorkReport uint8
+
+const (
+	// WorkUnobservable means the runtime exposes no per-turn work signal
+	// the adapter can read.
+	WorkUnobservable WorkReport = iota
+
+	// WorkAbsent means the adapter observed a per-turn work signal and it
+	// reported nothing produced.
+	WorkAbsent
+
+	// WorkPresent means the adapter observed a per-turn work signal and it
+	// reported something produced.
+	WorkPresent
+)
+
+// TurnEvidence is everything the shared decision needs to know about how
+// one turn ended. Adapters populate it from their own wire format; it has
+// no adapter-shaped field, so an adapter that cannot express its situation
+// in these fields has found a gap in the shared contract rather than a
+// reason to decide the disposition itself.
+type TurnEvidence struct {
+	// Terminal is the runtime's end-of-turn report, or the adapter's own
+	// determination when it aborted the turn. An adapter MUST NOT report
+	// TerminalSuccess or TerminalFailure for a turn whose runtime produced
+	// no end-of-turn report and whose process exited 0; that combination
+	// belongs to the rows keyed on ExitObserved, ExitCode, and Work.
+	Terminal TerminalReport
+
+	// TerminalErrorKind classifies a TerminalFailure. Ignored for every
+	// other Terminal value. The zero value selects domain.ErrTurnFailed.
+	TerminalErrorKind domain.AgentErrorKind
+
+	// TerminalMessage describes the outcome in the runtime's own words, or
+	// in the adapter's when the adapter ended the turn. Carried onto both
+	// the emitted event and the returned error for a cancelled, failed, or
+	// successful terminal report. May be empty.
+	TerminalMessage string
+
+	// Cause is the underlying Go error the adapter recovered, copied onto
+	// domain.AgentError.Err so the unwrap chain survives. Nil when the
+	// adapter has no underlying error.
+	Cause error
+
+	// ExitObserved reports whether this turn had its own process exit to
+	// observe. False for adapters whose subprocess outlives the turn.
+	ExitObserved bool
+
+	// ExitCode is the turn's process exit code. Meaningful only when
+	// ExitObserved is true.
+	ExitCode int
+
+	// Work is the per-turn work evidence. Consulted only when the runtime
+	// reported no terminal outcome.
+	Work WorkReport
+
+	// WorkDetail names the signal the adapter looked for and did not find,
+	// for the operator's benefit. Appended to both messages of the
+	// zero-work row. May be empty. MUST be a compile-time constant string;
+	// it MUST NOT interpolate stderr, stdout, a file path, or any other
+	// runtime value.
+	WorkDetail string
+}
+
+// DispositionRow identifies the decision-table row that produced a
+// TurnDisposition. It exists so a caller can attach a per-row side effect,
+// and so a test can assert which rule fired, without re-deriving the
+// decision.
+type DispositionRow uint8
+
+const (
+	// RowTerminalCancelled is the row selected when Terminal is
+	// TerminalCancelled.
+	RowTerminalCancelled DispositionRow = iota + 1
+
+	// RowTerminalFailure is the row selected when Terminal is
+	// TerminalFailure.
+	RowTerminalFailure
+
+	// RowTerminalSuccess is the row selected when Terminal is
+	// TerminalSuccess.
+	RowTerminalSuccess
+
+	// RowNoExitObserved is the row selected when Terminal is
+	// TerminalAbsent and no process exit was observed.
+	RowNoExitObserved
+
+	// RowNonZeroExit is the row selected when Terminal is TerminalAbsent,
+	// a process exit was observed, and the exit code is non-zero.
+	RowNonZeroExit
+
+	// RowZeroWork is the row selected when Terminal is TerminalAbsent, the
+	// process exited 0, and Work is not WorkPresent.
+	RowZeroWork
+
+	// RowWorkPresent is the row selected when Terminal is TerminalAbsent,
+	// the process exited 0, and Work is WorkPresent.
+	RowWorkPresent
+)
+
+// TurnDisposition is the normalized outcome of one turn.
+type TurnDisposition struct {
+	// Row is the decision-table row that matched.
+	Row DispositionRow
+
+	// ExitReason is the normalized event type for the turn.
+	ExitReason domain.AgentEventType
+
+	// ErrorKind is empty when and only when ExitReason is
+	// domain.EventTurnCompleted.
+	ErrorKind domain.AgentErrorKind
+
+	// EventMessage is the description carried on the emitted terminal
+	// event. May be empty.
+	EventMessage string
+
+	// ErrorMessage is the description carried on the returned
+	// domain.AgentError. Empty when and only when ErrorKind is empty.
+	ErrorMessage string
+}
+
+// TurnMeta carries the per-turn values the finalizer copies onto the
+// terminal event and the TurnResult without interpreting them.
+type TurnMeta struct {
+	// SessionID is the adapter's current session identifier.
+	SessionID string
+
+	// Usage is the session's run-cumulative token usage snapshot.
+	Usage domain.TokenUsage
+
+	// UsageMeasured reports whether the adapter has observed at least one
+	// usage measurement for the session by the end of this turn.
+	UsageMeasured bool
+
+	// APIDurationMS is the LLM API response wait time in milliseconds for
+	// this turn, or 0 when unavailable.
+	APIDurationMS int64
+}
+
+// DecideTurn returns the normalized disposition for one agent turn. It is
+// pure: no I/O, no logging, no emission, no state. Every TurnEvidence value
+// maps to exactly one of seven rows, evaluated in order and returned on the
+// first match.
+//
+// A positive terminal report is authoritative: when Terminal is
+// TerminalCancelled, TerminalFailure, or TerminalSuccess, DecideTurn does
+// not consult Work. Work is consulted only to fill the gap left by a
+// runtime that reported no terminal outcome and whose process exited 0.
+func DecideTurn(ev TurnEvidence) TurnDisposition {
+	switch ev.Terminal {
+	case TerminalCancelled:
+		message := ev.TerminalMessage
+		if message == "" {
+			message = "turn cancelled"
+		}
+		return TurnDisposition{
+			Row:          RowTerminalCancelled,
+			ExitReason:   domain.EventTurnCancelled,
+			ErrorKind:    domain.ErrTurnCancelled,
+			EventMessage: message,
+			ErrorMessage: message,
+		}
+	case TerminalFailure:
+		kind := ev.TerminalErrorKind
+		if kind == "" {
+			kind = domain.ErrTurnFailed
+		}
+		message := ev.TerminalMessage
+		if message == "" {
+			message = "turn failed"
+		}
+		return TurnDisposition{
+			Row:          RowTerminalFailure,
+			ExitReason:   domain.EventTurnFailed,
+			ErrorKind:    kind,
+			EventMessage: message,
+			ErrorMessage: message,
+		}
+	case TerminalSuccess:
+		return TurnDisposition{
+			Row:          RowTerminalSuccess,
+			ExitReason:   domain.EventTurnCompleted,
+			EventMessage: ev.TerminalMessage,
+		}
+	}
+
+	if !ev.ExitObserved {
+		return TurnDisposition{
+			Row:          RowNoExitObserved,
+			ExitReason:   domain.EventTurnFailed,
+			ErrorKind:    domain.ErrPortExit,
+			EventMessage: "runtime ended without reporting a turn outcome",
+			ErrorMessage: "runtime ended without reporting a turn outcome",
+		}
+	}
+
+	if ev.ExitCode != 0 {
+		return TurnDisposition{
+			Row:          RowNonZeroExit,
+			ExitReason:   domain.EventTurnFailed,
+			ErrorKind:    domain.ErrPortExit,
+			EventMessage: "non-zero exit",
+			ErrorMessage: fmt.Sprintf("exit code %d", ev.ExitCode),
+		}
+	}
+
+	if ev.Work != WorkPresent {
+		message := zeroWorkMessageStem
+		if ev.WorkDetail != "" {
+			message += ": " + ev.WorkDetail
+		}
+		return TurnDisposition{
+			Row:          RowZeroWork,
+			ExitReason:   domain.EventTurnFailed,
+			ErrorKind:    domain.ErrTurnFailed,
+			EventMessage: message,
+			ErrorMessage: message,
+		}
+	}
+
+	return TurnDisposition{
+		Row:        RowWorkPresent,
+		ExitReason: domain.EventTurnCompleted,
+	}
+}
+
+// FinalizeTurn applies DecideTurn to ev, emits the matching terminal event
+// through emit, logs the zero-work warning when the decision selects
+// RowZeroWork, and returns the paired TurnResult and error. The returned
+// *domain.AgentError is nil if and only if the disposition is
+// domain.EventTurnCompleted.
+//
+// FinalizeTurn panics when emit is nil. It substitutes slog.Default() when
+// logger is nil. It is not idempotent, because it emits; callers MUST call
+// it at most once per turn.
+func FinalizeTurn(
+	emit func(domain.AgentEvent),
+	logger *slog.Logger,
+	ev TurnEvidence,
+	meta TurnMeta,
+) (domain.TurnResult, *domain.AgentError) {
+	if emit == nil {
+		panic("agentcore: FinalizeTurn: emit must be non-nil")
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+
+	disposition := DecideTurn(ev)
+
+	switch disposition.ExitReason {
+	case domain.EventTurnCompleted:
+		EmitTurnCompleted(emit, disposition.EventMessage, meta.APIDurationMS, meta.Usage)
+	case domain.EventTurnFailed:
+		EmitTurnFailed(emit, disposition.EventMessage, meta.APIDurationMS, meta.Usage)
+	case domain.EventTurnCancelled:
+		EmitTurnCancelled(emit, disposition.EventMessage, meta.Usage)
+	}
+
+	if disposition.Row == RowZeroWork {
+		logger.Warn("agent exited without producing output, treating as failure")
+	}
+
+	result := domain.TurnResult{
+		SessionID:     meta.SessionID,
+		Usage:         meta.Usage,
+		UsageMeasured: meta.UsageMeasured,
+		ExitReason:    disposition.ExitReason,
+	}
+
+	if disposition.ErrorKind == "" {
+		return result, nil
+	}
+	return result, &domain.AgentError{
+		Kind:    disposition.ErrorKind,
+		Message: disposition.ErrorMessage,
+		Err:     ev.Cause,
+	}
+}

--- a/internal/agent/agentcore/disposition.go
+++ b/internal/agent/agentcore/disposition.go
@@ -229,8 +229,8 @@ func DecideTurn(ev TurnEvidence) TurnDisposition {
 			Row:          RowNoExitObserved,
 			ExitReason:   domain.EventTurnFailed,
 			ErrorKind:    domain.ErrPortExit,
-			EventMessage: "runtime ended without reporting a turn outcome",
-			ErrorMessage: "runtime ended without reporting a turn outcome",
+			EventMessage: "runtime reported no turn outcome",
+			ErrorMessage: "runtime reported no turn outcome",
 		}
 	}
 

--- a/internal/agent/agentcore/disposition_contract_test.go
+++ b/internal/agent/agentcore/disposition_contract_test.go
@@ -1,0 +1,362 @@
+package agentcore
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// dispositionDomainImportPath is the import path the check resolves the
+// "domain" package qualifier from, per file, rather than assuming the
+// literal identifier "domain".
+const dispositionDomainImportPath = "github.com/sortie-ai/sortie/internal/domain"
+
+// dispositionAgentcoreImportPath is the import path the check resolves
+// the "agentcore" package qualifier from, so a call to one of the three
+// Emit* helpers is caught regardless of the local import alias.
+const dispositionAgentcoreImportPath = "github.com/sortie-ai/sortie/internal/agent/agentcore"
+
+// dispositionForbiddenEventConstants are the four terminal-event
+// constants a package other than agentcore or mock must not assign to
+// domain.TurnResult.ExitReason or domain.AgentEvent.Type directly; a
+// package that assigns any other domain.AgentEventType constant (a
+// non-terminal event) is unaffected by the invariant.
+var dispositionForbiddenEventConstants = map[string]bool{
+	"EventTurnCompleted":      true,
+	"EventTurnFailed":         true,
+	"EventTurnCancelled":      true,
+	"EventTurnEndedWithError": true,
+}
+
+// dispositionForbiddenEmitFuncs are the three agentcore helpers reserved
+// for [FinalizeTurn] alone; no other package may call them directly.
+var dispositionForbiddenEmitFuncs = map[string]bool{
+	"EmitTurnCompleted": true,
+	"EmitTurnFailed":    true,
+	"EmitTurnCancelled": true,
+}
+
+// dispositionContractAllowlist names the packages under internal/agent/
+// this check exempts, and why. agentcore is exempt because it is the
+// shared decision itself: FinalizeTurn is the one legal constructor of
+// these values. mock is exempt because it maps an operator-chosen
+// outcome string to a disposition, not parsed runtime evidence, so it
+// has nothing to decide.
+var dispositionContractAllowlist = map[string]string{
+	"agentcore": "the shared decision package itself; FinalizeTurn is the sole permitted constructor and emitter",
+	"mock":      "maps an operator-chosen outcome string, not parsed evidence, so it has nothing to decide",
+}
+
+// dispositionViolation describes one place a file breaks the
+// shared-decision invariant.
+type dispositionViolation struct {
+	pos  token.Position
+	text string
+}
+
+// resolveImportName returns the local identifier a file binds to
+// importPath, or "" when the file does not import it. It reads only the
+// file's own import declarations, never assumes a literal package name,
+// so an aliased import cannot evade the check.
+func resolveImportName(file *ast.File, importPath string) string {
+	for _, imp := range file.Imports {
+		path, err := strconv.Unquote(imp.Path.Value)
+		if err != nil || path != importPath {
+			continue
+		}
+		if imp.Name != nil {
+			return imp.Name.Name
+		}
+		segments := strings.Split(path, "/")
+		return segments[len(segments)-1]
+	}
+	return ""
+}
+
+// isDomainSelector reports whether expr is a selector expression naming
+// domainIdent.selName, e.g. domain.TurnResult when domainIdent is
+// "domain".
+func isDomainSelector(expr ast.Expr, domainIdent, selName string) bool {
+	sel, ok := expr.(*ast.SelectorExpr)
+	if !ok {
+		return false
+	}
+	ident, ok := sel.X.(*ast.Ident)
+	if !ok {
+		return false
+	}
+	return ident.Name == domainIdent && sel.Sel.Name == selName
+}
+
+// isAcceptedEventConstant reports whether expr is the accepted form for
+// an ExitReason or Type field assignment: a selector expression on
+// domainIdent naming an AgentEventType constant other than the four
+// terminal-event constants FinalizeTurn alone may produce.
+func isAcceptedEventConstant(expr ast.Expr, domainIdent string) bool {
+	sel, ok := expr.(*ast.SelectorExpr)
+	if !ok {
+		return false
+	}
+	ident, ok := sel.X.(*ast.Ident)
+	if !ok || ident.Name != domainIdent {
+		return false
+	}
+	if !strings.HasPrefix(sel.Sel.Name, "Event") {
+		return false
+	}
+	return !dispositionForbiddenEventConstants[sel.Sel.Name]
+}
+
+// checkDispositionContractFile walks one parsed file's AST and appends a
+// violation for every composite-literal field assignment or Emit* call
+// that breaks the shared-decision invariant. The rule is decided from
+// syntax alone: no ast.Ident.Obj, ast.Object, or go/types resolution is
+// used, so the check cannot trip the project's own staticcheck SA1019
+// rule and does not become a type-checking pass.
+func checkDispositionContractFile(fset *token.FileSet, file *ast.File) []dispositionViolation {
+	domainIdent := resolveImportName(file, dispositionDomainImportPath)
+	agentcoreIdent := resolveImportName(file, dispositionAgentcoreImportPath)
+
+	var violations []dispositionViolation
+
+	ast.Inspect(file, func(n ast.Node) bool {
+		switch node := n.(type) {
+		case *ast.CompositeLit:
+			if domainIdent == "" {
+				return true
+			}
+			var fieldName, litName string
+			switch {
+			case isDomainSelector(node.Type, domainIdent, "TurnResult"):
+				fieldName, litName = "ExitReason", "domain.TurnResult"
+			case isDomainSelector(node.Type, domainIdent, "AgentEvent"):
+				fieldName, litName = "Type", "domain.AgentEvent"
+			default:
+				return true
+			}
+			for _, elt := range node.Elts {
+				kv, ok := elt.(*ast.KeyValueExpr)
+				if !ok {
+					continue
+				}
+				key, ok := kv.Key.(*ast.Ident)
+				if !ok || key.Name != fieldName {
+					continue
+				}
+				if !isAcceptedEventConstant(kv.Value, domainIdent) {
+					violations = append(violations, dispositionViolation{
+						pos:  fset.Position(kv.Pos()),
+						text: litName + "{" + fieldName + ": ...} assigns a form other than a domain.Event* selector naming a non-terminal constant",
+					})
+				}
+			}
+
+		case *ast.CallExpr:
+			if agentcoreIdent == "" {
+				return true
+			}
+			sel, ok := node.Fun.(*ast.SelectorExpr)
+			if !ok {
+				return true
+			}
+			ident, ok := sel.X.(*ast.Ident)
+			if !ok || ident.Name != agentcoreIdent {
+				return true
+			}
+			if dispositionForbiddenEmitFuncs[sel.Sel.Name] {
+				violations = append(violations, dispositionViolation{
+					pos:  fset.Position(node.Pos()),
+					text: "call to " + agentcoreIdent + "." + sel.Sel.Name + " outside FinalizeTurn",
+				})
+			}
+		}
+		return true
+	})
+
+	return violations
+}
+
+// TestDispositionContractInvariant walks the non-test Go files of every
+// package under internal/agent/ other than the allowlisted ones and
+// fails when any breaks the shared-decision invariant: a
+// domain.TurnResult composite literal assigning ExitReason, or a
+// domain.AgentEvent composite literal assigning Type, to anything other
+// than a selector on the file's own domain import naming a non-terminal
+// event constant; or a direct call to agentcore.EmitTurnCompleted,
+// agentcore.EmitTurnFailed, or agentcore.EmitTurnCancelled.
+func TestDispositionContractInvariant(t *testing.T) {
+	root := ".."
+
+	fset := token.NewFileSet()
+
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			if d.Name() == "testdata" {
+				return filepath.SkipDir
+			}
+			if _, exempt := dispositionContractAllowlist[d.Name()]; exempt {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+
+		file, parseErr := parser.ParseFile(fset, path, nil, parser.SkipObjectResolution)
+		if parseErr != nil {
+			t.Errorf("parse %s: %v", path, parseErr)
+			return nil
+		}
+
+		for _, v := range checkDispositionContractFile(fset, file) {
+			t.Errorf("%s: %s", v.pos, v.text)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk %s: %v", root, err)
+	}
+}
+
+// TestCheckDispositionContractFile_DetectsViolations pins the checker's
+// own logic against inline source fixtures, independent of the current
+// state of any production package, so a regression in the syntactic
+// rule itself is caught even if every adapter happens to comply today.
+func TestCheckDispositionContractFile_DetectsViolations(t *testing.T) {
+	t.Parallel()
+
+	const preamble = `package fixture
+
+import (
+	"github.com/sortie-ai/sortie/internal/agent/agentcore"
+	"github.com/sortie-ai/sortie/internal/domain"
+)
+
+var _ = agentcore.FinalizeTurn
+`
+
+	tests := []struct {
+		name      string
+		src       string
+		wantCount int
+	}{
+		{
+			name: "variable indirection into ExitReason is rejected",
+			src: preamble + `
+func f(reason domain.AgentEventType) domain.TurnResult {
+	return domain.TurnResult{ExitReason: reason}
+}
+`,
+			wantCount: 1,
+		},
+		{
+			name: "forbidden terminal constant on ExitReason is rejected",
+			src: preamble + `
+func f() domain.TurnResult {
+	return domain.TurnResult{ExitReason: domain.EventTurnCompleted}
+}
+`,
+			wantCount: 1,
+		},
+		{
+			name: "forbidden terminal constant on AgentEvent Type is rejected",
+			src: preamble + `
+func f() domain.AgentEvent {
+	return domain.AgentEvent{Type: domain.EventTurnFailed}
+}
+`,
+			wantCount: 1,
+		},
+		{
+			name: "direct EmitTurnFailed call is rejected",
+			src: preamble + `
+func f(emit func(domain.AgentEvent)) {
+	agentcore.EmitTurnFailed(emit, "boom", 0, domain.TokenUsage{})
+}
+`,
+			wantCount: 1,
+		},
+		{
+			name: "non-terminal event constant on ExitReason is accepted",
+			src: preamble + `
+func f() domain.TurnResult {
+	return domain.TurnResult{ExitReason: domain.EventNotification}
+}
+`,
+			wantCount: 0,
+		},
+		{
+			name: "literal with no ExitReason field is accepted",
+			src: preamble + `
+func f() domain.TurnResult {
+	return domain.TurnResult{SessionID: "s"}
+}
+`,
+			wantCount: 0,
+		},
+		{
+			name: "unrelated call through the agentcore identifier is accepted",
+			src: preamble + `
+func f() {
+	agentcore.EmitNotification(nil, "hi")
+}
+`,
+			wantCount: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			fset := token.NewFileSet()
+			file, err := parser.ParseFile(fset, "fixture.go", tt.src, parser.SkipObjectResolution)
+			if err != nil {
+				t.Fatalf("parser.ParseFile: %v", err)
+			}
+
+			got := checkDispositionContractFile(fset, file)
+			if len(got) != tt.wantCount {
+				t.Errorf("checkDispositionContractFile() returned %d violations, want %d: %+v", len(got), tt.wantCount, got)
+			}
+		})
+	}
+}
+
+// TestResolveImportName pins that the qualifier is read from the file's
+// own import declaration, including an aliased import, rather than
+// assumed to be the literal identifier "domain".
+func TestResolveImportName(t *testing.T) {
+	t.Parallel()
+
+	const src = `package fixture
+
+import d "github.com/sortie-ai/sortie/internal/domain"
+
+var _ = d.EventNotification
+`
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "fixture.go", src, parser.SkipObjectResolution)
+	if err != nil {
+		t.Fatalf("parser.ParseFile: %v", err)
+	}
+
+	got := resolveImportName(file, dispositionDomainImportPath)
+	if got != "d" {
+		t.Errorf("resolveImportName() = %q, want %q (the aliased local name)", got, "d")
+	}
+
+	gotAbsent := resolveImportName(file, dispositionAgentcoreImportPath)
+	if gotAbsent != "" {
+		t.Errorf("resolveImportName() for an unimported path = %q, want empty", gotAbsent)
+	}
+}

--- a/internal/agent/agentcore/disposition_test.go
+++ b/internal/agent/agentcore/disposition_test.go
@@ -1,0 +1,256 @@
+package agentcore
+
+import (
+	"testing"
+
+	"github.com/sortie-ai/sortie/internal/domain"
+)
+
+// TestDecideTurn_Rows pins every row of the seven-row decision table
+// (R1 through R7) against a representative TurnEvidence, asserting the
+// full TurnDisposition the table produces for each.
+func TestDecideTurn_Rows(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name             string
+		ev               TurnEvidence
+		wantRow          DispositionRow
+		wantExitReason   domain.AgentEventType
+		wantErrorKind    domain.AgentErrorKind
+		wantEventMessage string
+		wantErrorMessage string
+	}{
+		{
+			name:             "R1 terminal cancelled with message",
+			ev:               TurnEvidence{Terminal: TerminalCancelled, TerminalMessage: "context cancelled"},
+			wantRow:          RowTerminalCancelled,
+			wantExitReason:   domain.EventTurnCancelled,
+			wantErrorKind:    domain.ErrTurnCancelled,
+			wantEventMessage: "context cancelled",
+			wantErrorMessage: "context cancelled",
+		},
+		{
+			name:             "R2 terminal failure with kind and message",
+			ev:               TurnEvidence{Terminal: TerminalFailure, TerminalErrorKind: domain.ErrResponseError, TerminalMessage: "auth rejected"},
+			wantRow:          RowTerminalFailure,
+			wantExitReason:   domain.EventTurnFailed,
+			wantErrorKind:    domain.ErrResponseError,
+			wantEventMessage: "auth rejected",
+			wantErrorMessage: "auth rejected",
+		},
+		{
+			name:             "R3 terminal success carries message on event only",
+			ev:               TurnEvidence{Terminal: TerminalSuccess, TerminalMessage: "All done."},
+			wantRow:          RowTerminalSuccess,
+			wantExitReason:   domain.EventTurnCompleted,
+			wantErrorKind:    "",
+			wantEventMessage: "All done.",
+			wantErrorMessage: "",
+		},
+		{
+			name:             "R4 no exit observed",
+			ev:               TurnEvidence{Terminal: TerminalAbsent, ExitObserved: false},
+			wantRow:          RowNoExitObserved,
+			wantExitReason:   domain.EventTurnFailed,
+			wantErrorKind:    domain.ErrPortExit,
+			wantEventMessage: "runtime ended without reporting a turn outcome",
+			wantErrorMessage: "runtime ended without reporting a turn outcome",
+		},
+		{
+			name:             "R5 non-zero exit differs between event and error message",
+			ev:               TurnEvidence{Terminal: TerminalAbsent, ExitObserved: true, ExitCode: 7},
+			wantRow:          RowNonZeroExit,
+			wantExitReason:   domain.EventTurnFailed,
+			wantErrorKind:    domain.ErrPortExit,
+			wantEventMessage: "non-zero exit",
+			wantErrorMessage: "exit code 7",
+		},
+		{
+			name:             "R6 zero work with no detail",
+			ev:               TurnEvidence{Terminal: TerminalAbsent, ExitObserved: true, ExitCode: 0, Work: WorkAbsent},
+			wantRow:          RowZeroWork,
+			wantExitReason:   domain.EventTurnFailed,
+			wantErrorKind:    domain.ErrTurnFailed,
+			wantEventMessage: "agent exited without producing output",
+			wantErrorMessage: "agent exited without producing output",
+		},
+		{
+			name:             "R7 work present completes",
+			ev:               TurnEvidence{Terminal: TerminalAbsent, ExitObserved: true, ExitCode: 0, Work: WorkPresent},
+			wantRow:          RowWorkPresent,
+			wantExitReason:   domain.EventTurnCompleted,
+			wantErrorKind:    "",
+			wantEventMessage: "",
+			wantErrorMessage: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := DecideTurn(tt.ev)
+
+			if got.Row != tt.wantRow {
+				t.Errorf("DecideTurn(%+v).Row = %v, want %v", tt.ev, got.Row, tt.wantRow)
+			}
+			if got.ExitReason != tt.wantExitReason {
+				t.Errorf("DecideTurn(%+v).ExitReason = %q, want %q", tt.ev, got.ExitReason, tt.wantExitReason)
+			}
+			if got.ErrorKind != tt.wantErrorKind {
+				t.Errorf("DecideTurn(%+v).ErrorKind = %q, want %q", tt.ev, got.ErrorKind, tt.wantErrorKind)
+			}
+			if got.EventMessage != tt.wantEventMessage {
+				t.Errorf("DecideTurn(%+v).EventMessage = %q, want %q", tt.ev, got.EventMessage, tt.wantEventMessage)
+			}
+			if got.ErrorMessage != tt.wantErrorMessage {
+				t.Errorf("DecideTurn(%+v).ErrorMessage = %q, want %q", tt.ev, got.ErrorMessage, tt.wantErrorMessage)
+			}
+		})
+	}
+}
+
+// TestDecideTurn_R1R2DefaultOnlyOnEmptyMessage pins that the "turn
+// cancelled" and "turn failed" substitute texts are used only when
+// TerminalMessage is empty; a supplied TerminalMessage is never
+// overwritten.
+func TestDecideTurn_R1R2DefaultOnlyOnEmptyMessage(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		ev          TurnEvidence
+		wantMessage string
+	}{
+		{
+			name:        "cancelled empty message defaults",
+			ev:          TurnEvidence{Terminal: TerminalCancelled},
+			wantMessage: "turn cancelled",
+		},
+		{
+			name:        "cancelled supplied message is not overwritten",
+			ev:          TurnEvidence{Terminal: TerminalCancelled, TerminalMessage: "operator stopped the session"},
+			wantMessage: "operator stopped the session",
+		},
+		{
+			name:        "failure empty message defaults",
+			ev:          TurnEvidence{Terminal: TerminalFailure},
+			wantMessage: "turn failed",
+		},
+		{
+			name:        "failure supplied message is not overwritten",
+			ev:          TurnEvidence{Terminal: TerminalFailure, TerminalMessage: "invalid api key"},
+			wantMessage: "invalid api key",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := DecideTurn(tt.ev)
+
+			if got.EventMessage != tt.wantMessage {
+				t.Errorf("DecideTurn(%+v).EventMessage = %q, want %q", tt.ev, got.EventMessage, tt.wantMessage)
+			}
+			if got.ErrorMessage != tt.wantMessage {
+				t.Errorf("DecideTurn(%+v).ErrorMessage = %q, want %q", tt.ev, got.ErrorMessage, tt.wantMessage)
+			}
+		})
+	}
+}
+
+// TestDecideTurn_ZeroWorkRowBothWorkValuesFail pins that WorkAbsent and
+// WorkUnobservable both reach RowZeroWork, so an adapter with no positive
+// signal to offer never completes a turn by omission.
+func TestDecideTurn_ZeroWorkRowBothWorkValuesFail(t *testing.T) {
+	t.Parallel()
+
+	for _, work := range []WorkReport{WorkAbsent, WorkUnobservable} {
+		ev := TurnEvidence{Terminal: TerminalAbsent, ExitObserved: true, ExitCode: 0, Work: work}
+
+		got := DecideTurn(ev)
+
+		if got.Row != RowZeroWork {
+			t.Errorf("DecideTurn(Work=%v).Row = %v, want %v", work, got.Row, RowZeroWork)
+		}
+		if got.ExitReason != domain.EventTurnFailed {
+			t.Errorf("DecideTurn(Work=%v).ExitReason = %q, want %q", work, got.ExitReason, domain.EventTurnFailed)
+		}
+		if got.ErrorKind != domain.ErrTurnFailed {
+			t.Errorf("DecideTurn(Work=%v).ErrorKind = %q, want %q", work, got.ErrorKind, domain.ErrTurnFailed)
+		}
+	}
+}
+
+// TestDecideTurn_ZeroWorkRowWorkDetailSuffix pins that the zero-work
+// stem carries a ": "-prefixed WorkDetail suffix only when WorkDetail is
+// non-empty, and both messages carry the same suffixed text.
+func TestDecideTurn_ZeroWorkRowWorkDetailSuffix(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty detail produces the bare stem", func(t *testing.T) {
+		t.Parallel()
+
+		got := DecideTurn(TurnEvidence{Terminal: TerminalAbsent, ExitObserved: true, ExitCode: 0, Work: WorkAbsent})
+
+		const want = "agent exited without producing output"
+		if got.EventMessage != want {
+			t.Errorf("EventMessage = %q, want %q", got.EventMessage, want)
+		}
+		if got.ErrorMessage != want {
+			t.Errorf("ErrorMessage = %q, want %q", got.ErrorMessage, want)
+		}
+	})
+
+	t.Run("non-empty detail is appended with a colon-space separator", func(t *testing.T) {
+		t.Parallel()
+
+		got := DecideTurn(TurnEvidence{
+			Terminal:     TerminalAbsent,
+			ExitObserved: true,
+			ExitCode:     0,
+			Work:         WorkUnobservable,
+			WorkDetail:   "no credits trailer on stderr",
+		})
+
+		const want = "agent exited without producing output: no credits trailer on stderr"
+		if got.EventMessage != want {
+			t.Errorf("EventMessage = %q, want %q", got.EventMessage, want)
+		}
+		if got.ErrorMessage != want {
+			t.Errorf("ErrorMessage = %q, want %q", got.ErrorMessage, want)
+		}
+	})
+}
+
+// TestDecideTurn_Total pins that DecideTurn is total over TurnEvidence:
+// every distinct combination of the fields the table consults maps to
+// exactly one non-zero Row.
+func TestDecideTurn_Total(t *testing.T) {
+	t.Parallel()
+
+	terminals := []TerminalReport{TerminalAbsent, TerminalSuccess, TerminalFailure, TerminalCancelled}
+	exitCodes := []int{0, 1}
+	works := []WorkReport{WorkUnobservable, WorkAbsent, WorkPresent}
+
+	for _, terminal := range terminals {
+		for _, exitObserved := range []bool{false, true} {
+			for _, exitCode := range exitCodes {
+				for _, work := range works {
+					ev := TurnEvidence{
+						Terminal:     terminal,
+						ExitObserved: exitObserved,
+						ExitCode:     exitCode,
+						Work:         work,
+					}
+					got := DecideTurn(ev)
+					if got.Row == 0 {
+						t.Fatalf("DecideTurn(%+v).Row = 0, want a non-zero row", ev)
+					}
+				}
+			}
+		}
+	}
+}

--- a/internal/agent/agentcore/disposition_test.go
+++ b/internal/agent/agentcore/disposition_test.go
@@ -54,8 +54,8 @@ func TestDecideTurn_Rows(t *testing.T) {
 			wantRow:          RowNoExitObserved,
 			wantExitReason:   domain.EventTurnFailed,
 			wantErrorKind:    domain.ErrPortExit,
-			wantEventMessage: "runtime ended without reporting a turn outcome",
-			wantErrorMessage: "runtime ended without reporting a turn outcome",
+			wantEventMessage: "runtime reported no turn outcome",
+			wantErrorMessage: "runtime reported no turn outcome",
 		},
 		{
 			name:             "R5 non-zero exit differs between event and error message",

--- a/internal/agent/agenttest/dispositiontest/disposition.go
+++ b/internal/agent/agenttest/dispositiontest/disposition.go
@@ -1,0 +1,71 @@
+// Package dispositiontest provides the conformance assertion that checks an
+// agent adapter's observed turn disposition against the shared decision in
+// [agentcore.DecideTurn].
+//
+// The helper lives in this child package, rather than in agenttest itself,
+// because it imports agentcore: agentcore's own in-package tests declare
+// package agentcore and import agenttest for WriteScript and LogSpy, so an
+// agenttest import of agentcore would close an import cycle and fail
+// go test ./internal/agent/agentcore with "import cycle not allowed in
+// test". agenttest MUST NOT import agentcore, directly or transitively, for
+// as long as any agentcore test file declares package agentcore and
+// imports agenttest. A future in-package agentcore test that needs
+// [AssertDispositionContract] MUST be written as package agentcore_test
+// instead of adding this package's import to agenttest.
+package dispositiontest
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/sortie-ai/sortie/internal/agent/agentcore"
+	"github.com/sortie-ai/sortie/internal/domain"
+)
+
+// AssertDispositionContract fails t when the disposition an adapter
+// produced for a named evidence case does not match the disposition
+// [agentcore.DecideTurn] assigns to the same case.
+//
+// AssertDispositionContract pins the decision table, not the evidence
+// mapping: it checks that the adapter decided consistently with the ev the
+// caller believes it produced, so it catches an adapter that disagrees with
+// the shared table but cannot catch an adapter that built the wrong
+// evidence from its runtime's wire format. err is typed as the plain error
+// interface, not *domain.AgentError, so a typed-nil *domain.AgentError
+// returned as a non-nil interface fails this assertion rather than passing
+// it.
+func AssertDispositionContract(
+	t *testing.T,
+	ev agentcore.TurnEvidence,
+	result domain.TurnResult,
+	err error,
+) {
+	t.Helper()
+
+	want := agentcore.DecideTurn(ev)
+
+	if result.ExitReason != want.ExitReason {
+		t.Errorf("result.ExitReason = %q, want %q", result.ExitReason, want.ExitReason)
+	}
+
+	wantErr := want.ErrorKind != ""
+	if (err != nil) != wantErr {
+		t.Errorf("err = %v, want non-nil: %v", err, wantErr)
+		return
+	}
+	if err == nil {
+		return
+	}
+
+	var agentErr *domain.AgentError
+	if !errors.As(err, &agentErr) {
+		t.Errorf("err = %v, want *domain.AgentError", err)
+		return
+	}
+	if agentErr.Kind != want.ErrorKind {
+		t.Errorf("err.Kind = %q, want %q", agentErr.Kind, want.ErrorKind)
+	}
+	if agentErr.Message != want.ErrorMessage {
+		t.Errorf("err.Message = %q, want %q", agentErr.Message, want.ErrorMessage)
+	}
+}

--- a/internal/agent/claude/claude.go
+++ b/internal/agent/claude/claude.go
@@ -244,71 +244,41 @@ func (a *ClaudeCodeAdapter) StartSession(_ context.Context, params domain.StartS
 			lastResult, _ := lastParsed.(*rawEvent)
 			usage := state.acc.Snapshot()
 
+			// Work tests this turn's own output, not the run cumulative,
+			// which is non-zero on any second turn.
+			ev := agentcore.TurnEvidence{
+				ExitObserved: true,
+				ExitCode:     exitCode,
+				Work:         agentcore.WorkAbsent,
+			}
+			if sumTurnMessages(state.turnMessages).OutputTokens > 0 {
+				ev.Work = agentcore.WorkPresent
+			}
+
+			var turnAPIDuration int64
 			if lastResult != nil {
 				// Use turn-level duration_api_ms only when no per-request
 				// API timing was emitted, to avoid double-counting.
-				var turnAPIDuration int64
 				if !state.emittedAPITiming {
 					turnAPIDuration = lastResult.DurationAPI
 				}
 				if lastResult.Subtype == "success" && !lastResult.IsError {
-					agentcore.EmitTurnCompleted(emit, typeutil.TruncateRunes(lastResult.Result, 500), turnAPIDuration, usage)
-					return domain.TurnResult{
-						SessionID:     state.claudeSessionID,
-						ExitReason:    domain.EventTurnCompleted,
-						Usage:         usage,
-						UsageMeasured: state.usageMeasured,
-					}, nil
+					ev.Terminal = agentcore.TerminalSuccess
+					ev.TerminalMessage = typeutil.TruncateRunes(lastResult.Result, 500)
+				} else {
+					ev.Terminal = agentcore.TerminalFailure
+					ev.TerminalMessage = lastResult.Subtype
 				}
-				// EmitWarnLines is called by the skeleton when agentErr is non-nil.
-				agentcore.EmitTurnFailed(emit, lastResult.Subtype, turnAPIDuration, usage)
-				return domain.TurnResult{
-						SessionID:     state.claudeSessionID,
-						ExitReason:    domain.EventTurnFailed,
-						Usage:         usage,
-						UsageMeasured: state.usageMeasured,
-					}, &domain.AgentError{
-						Kind:    domain.ErrTurnFailed,
-						Message: lastResult.Subtype,
-					}
 			}
 
-			if exitCode != 0 {
-				agentcore.EmitTurnFailed(emit, "non-zero exit", 0, usage)
-				return domain.TurnResult{
-						SessionID:     state.claudeSessionID,
-						ExitReason:    domain.EventTurnFailed,
-						Usage:         usage,
-						UsageMeasured: state.usageMeasured,
-					}, &domain.AgentError{
-						Kind:    domain.ErrPortExit,
-						Message: fmt.Sprintf("exit code %d", exitCode),
-					}
-			}
-
-			// No result event and exit code 0. Test the turn's own output,
-			// not the run cumulative, which is non-zero on any second turn.
-			if sumTurnMessages(state.turnMessages).OutputTokens == 0 {
-				state.logger().Warn("agent exited without producing output, treating as failure")
-				agentcore.EmitTurnFailed(emit, "agent exited without producing output", 0, usage)
-				return domain.TurnResult{
-						SessionID:     state.claudeSessionID,
-						ExitReason:    domain.EventTurnFailed,
-						Usage:         usage,
-						UsageMeasured: state.usageMeasured,
-					}, &domain.AgentError{
-						Kind:    domain.ErrTurnFailed,
-						Message: "agent exited without producing output",
-					}
-			}
-
-			agentcore.EmitTurnCompleted(emit, "", 0, usage)
-			return domain.TurnResult{
+			meta := agentcore.TurnMeta{
 				SessionID:     state.claudeSessionID,
-				ExitReason:    domain.EventTurnCompleted,
 				Usage:         usage,
 				UsageMeasured: state.usageMeasured,
-			}, nil
+				APIDurationMS: turnAPIDuration,
+			}
+
+			return agentcore.FinalizeTurn(emit, state.logger(), ev, meta)
 		},
 		EmitSessionStartID: nil, // Claude emits EventSessionStarted from ParseLine on "system/init"
 	}

--- a/internal/agent/claude/claude_test.go
+++ b/internal/agent/claude/claude_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/sortie-ai/sortie/internal/agent/agentcore"
 	"github.com/sortie-ai/sortie/internal/agent/agenttest"
+	"github.com/sortie-ai/sortie/internal/agent/agenttest/dispositiontest"
 	"github.com/sortie-ai/sortie/internal/domain"
 	"github.com/sortie-ai/sortie/internal/registry"
 )
@@ -611,6 +612,21 @@ exit 0
 			t.Errorf("event[%d] = %q, want %q", i, eventTypes[i], wt)
 		}
 	}
+
+	// The successful result event's own text reaches the emitted
+	// turn_completed event's message (regression pin against the
+	// success-message mapping reverting to empty).
+	if events[len(events)-1].Message != "All done." {
+		t.Errorf("turn_completed Message = %q, want %q", events[len(events)-1].Message, "All done.")
+	}
+
+	dispositiontest.AssertDispositionContract(t, agentcore.TurnEvidence{
+		Terminal:        agentcore.TerminalSuccess,
+		TerminalMessage: "All done.",
+		ExitObserved:    true,
+		ExitCode:        0,
+		Work:            agentcore.WorkAbsent,
+	}, result, err)
 }
 
 // TestRunTurn_UsageMeasured_AbsentWhenNoUsageObserved verifies that a turn
@@ -1091,6 +1107,14 @@ exit 0
 	if result.ExitReason != domain.EventTurnFailed {
 		t.Errorf("ExitReason = %q, want %q", result.ExitReason, domain.EventTurnFailed)
 	}
+
+	dispositiontest.AssertDispositionContract(t, agentcore.TurnEvidence{
+		Terminal:        agentcore.TerminalFailure,
+		TerminalMessage: "error_max_turns",
+		ExitObserved:    true,
+		ExitCode:        0,
+		Work:            agentcore.WorkAbsent,
+	}, result, err)
 }
 
 func TestRunTurn_NonZeroExit(t *testing.T) {
@@ -1126,6 +1150,12 @@ func TestRunTurn_NonZeroExit(t *testing.T) {
 	if result.ExitReason != domain.EventTurnFailed {
 		t.Errorf("ExitReason = %q", result.ExitReason)
 	}
+
+	dispositiontest.AssertDispositionContract(t, agentcore.TurnEvidence{
+		ExitObserved: true,
+		ExitCode:     1,
+		Work:         agentcore.WorkAbsent,
+	}, result, err)
 }
 
 func TestRunTurn_Exit127(t *testing.T) {
@@ -1483,6 +1513,12 @@ exit 0
 	if result.ExitReason != domain.EventTurnFailed {
 		t.Errorf("ExitReason = %q, want %q", result.ExitReason, domain.EventTurnFailed)
 	}
+
+	dispositiontest.AssertDispositionContract(t, agentcore.TurnEvidence{
+		ExitObserved: true,
+		ExitCode:     0,
+		Work:         agentcore.WorkAbsent,
+	}, result, err)
 }
 
 func TestRunTurn_PartialOutputNoResultExitZero(t *testing.T) {
@@ -1529,6 +1565,12 @@ exit 0
 	if result.Usage.OutputTokens != wantTokens {
 		t.Errorf("Usage.OutputTokens = %d, want %d", result.Usage.OutputTokens, wantTokens)
 	}
+
+	dispositiontest.AssertDispositionContract(t, agentcore.TurnEvidence{
+		ExitObserved: true,
+		ExitCode:     0,
+		Work:         agentcore.WorkPresent,
+	}, result, err)
 }
 
 func TestRunTurn_StderrWarnOnNoOutputExitZero(t *testing.T) {
@@ -2565,5 +2607,106 @@ JSONL
 
 	if warnLines := spy.WarnLines(); len(warnLines) != 0 {
 		t.Errorf("success path produced %d WARN lines for stderr, want 0; got %v", len(warnLines), warnLines)
+	}
+}
+
+// TestRunTurn_SuccessfulResultZeroOutputTokens pins that a successful
+// result event completes the turn even when this turn's output tokens
+// are zero, because a positive terminal report is authoritative and
+// never consults Work.
+func TestRunTurn_SuccessfulResultZeroOutputTokens(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	script := writeScript(t, tmpDir, `
+cat <<'JSONL'
+{"type":"system","subtype":"init","session_id":"zero-output-success","cwd":"/tmp"}
+{"type":"result","subtype":"success","result":"Nothing to change.","is_error":false,"usage":{"input_tokens":10,"output_tokens":0},"session_id":"zero-output-success"}
+JSONL
+exit 0
+`)
+
+	adapter, _ := NewClaudeCodeAdapter(map[string]any{})
+	session, err := adapter.StartSession(context.Background(), domain.StartSessionParams{
+		WorkspacePath: tmpDir,
+		AgentConfig:   domain.AgentConfig{Command: script},
+	})
+	if err != nil {
+		t.Fatalf("StartSession() error = %v", err)
+	}
+
+	result, err := adapter.RunTurn(context.Background(), session, domain.RunTurnParams{
+		Prompt:  "test",
+		OnEvent: func(domain.AgentEvent) {},
+	})
+	if err != nil {
+		t.Fatalf("RunTurn() error = %v", err)
+	}
+	if result.ExitReason != domain.EventTurnCompleted {
+		t.Errorf("ExitReason = %q, want %q", result.ExitReason, domain.EventTurnCompleted)
+	}
+
+	dispositiontest.AssertDispositionContract(t, agentcore.TurnEvidence{
+		Terminal:        agentcore.TerminalSuccess,
+		TerminalMessage: "Nothing to change.",
+		ExitObserved:    true,
+		ExitCode:        0,
+		Work:            agentcore.WorkAbsent,
+	}, result, err)
+}
+
+// TestRunTurn_WorkPredicateIsPerTurn pins that the work predicate reads
+// this turn's own output tokens, not the run cumulative. The first turn
+// produces output and completes; the second turn, on the same session,
+// produces none and must fail rather than inherit the first turn's
+// evidence.
+func TestRunTurn_WorkPredicateIsPerTurn(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	counterFile := filepath.Join(tmpDir, "turn-count")
+	script := writeScript(t, tmpDir, fmt.Sprintf(`
+if [ -f '%s' ]; then
+  echo '{"type":"system","subtype":"init","session_id":"per-turn-work","cwd":"/tmp"}'
+else
+  touch '%s'
+  cat <<'JSONL'
+{"type":"system","subtype":"init","session_id":"per-turn-work","cwd":"/tmp"}
+{"type":"assistant","message":{"id":"msg_1","content":[{"type":"text","text":"ok"}],"usage":{"input_tokens":10,"output_tokens":5}},"session_id":"per-turn-work"}
+JSONL
+fi
+exit 0
+`, counterFile, counterFile))
+
+	adapter, _ := NewClaudeCodeAdapter(map[string]any{})
+	session, err := adapter.StartSession(context.Background(), domain.StartSessionParams{
+		WorkspacePath: tmpDir,
+		AgentConfig:   domain.AgentConfig{Command: script},
+	})
+	if err != nil {
+		t.Fatalf("StartSession() error = %v", err)
+	}
+
+	result1, err := adapter.RunTurn(context.Background(), session, domain.RunTurnParams{
+		Prompt:  "first",
+		OnEvent: func(domain.AgentEvent) {},
+	})
+	if err != nil {
+		t.Fatalf("RunTurn(first) error = %v", err)
+	}
+	if result1.ExitReason != domain.EventTurnCompleted {
+		t.Fatalf("RunTurn(first).ExitReason = %q, want %q", result1.ExitReason, domain.EventTurnCompleted)
+	}
+
+	result2, err := adapter.RunTurn(context.Background(), session, domain.RunTurnParams{
+		Prompt:  "second",
+		OnEvent: func(domain.AgentEvent) {},
+	})
+	if result2.ExitReason != domain.EventTurnFailed {
+		t.Errorf("RunTurn(second).ExitReason = %q, want %q (per-turn work predicate must not carry the first turn's output forward)", result2.ExitReason, domain.EventTurnFailed)
+	}
+	var agentErr *domain.AgentError
+	if !errors.As(err, &agentErr) || agentErr.Kind != domain.ErrTurnFailed {
+		t.Errorf("RunTurn(second) error = %v, want AgentError{Kind: %q}", err, domain.ErrTurnFailed)
 	}
 }

--- a/internal/agent/claude/integration_test.go
+++ b/internal/agent/claude/integration_test.go
@@ -150,6 +150,11 @@ func TestIntegration_StartSession_InvalidCommand(t *testing.T) {
 	}
 }
 
+// TestIntegration_RunTurn drives one real turn against the live
+// claude-code binary and asserts turn_completed, satisfying the shared
+// disposition decision's live-runtime obligation for this adapter: the
+// only check that can catch an evidence mapping that is internally
+// consistent but wrong against the actual wire format.
 func TestIntegration_RunTurn(t *testing.T) {
 	skipUnlessIntegration(t)
 

--- a/internal/agent/codex/codex.go
+++ b/internal/agent/codex/codex.go
@@ -421,14 +421,17 @@ func (a *CodexAdapter) RunTurn(ctx context.Context, session domain.Session, para
 		}
 	}
 	if turnStartResp.Error != nil {
-		return domain.TurnResult{
-				SessionID:     state.threadID,
-				ExitReason:    domain.EventTurnFailed,
-				UsageMeasured: state.usageMeasured,
-			}, &domain.AgentError{
-				Kind:    domain.ErrTurnFailed,
-				Message: fmt.Sprintf("turn/start error: %s", turnStartResp.Error.Message),
-			}
+		ev := agentcore.TurnEvidence{
+			Terminal:          agentcore.TerminalFailure,
+			TerminalErrorKind: domain.ErrTurnFailed,
+			TerminalMessage:   fmt.Sprintf("turn/start error: %s", turnStartResp.Error.Message),
+		}
+		meta := agentcore.TurnMeta{SessionID: state.threadID, UsageMeasured: state.usageMeasured}
+		result, agentErr := agentcore.FinalizeTurn(params.OnEvent, logger, ev, meta)
+		if agentErr != nil {
+			return result, agentErr
+		}
+		return result, nil
 	}
 
 	var turnResult turnStartResult
@@ -492,32 +495,43 @@ func (a *CodexAdapter) RunTurn(ctx context.Context, session domain.Session, para
 				for evt := range toolEventCh {
 					params.OnEvent(evt)
 				}
-				return domain.TurnResult{
-						SessionID:     state.threadID,
-						ExitReason:    domain.EventTurnFailed,
-						Usage:         state.acc.Snapshot(),
-						UsageMeasured: state.usageMeasured,
-					}, &domain.AgentError{
-						Kind:    domain.ErrPortExit,
-						Message: "subprocess stdout closed unexpectedly",
-					}
+				ev := agentcore.TurnEvidence{
+					Terminal:          agentcore.TerminalFailure,
+					TerminalErrorKind: domain.ErrPortExit,
+					TerminalMessage:   "subprocess stdout closed unexpectedly",
+				}
+				meta := agentcore.TurnMeta{
+					SessionID:     state.threadID,
+					Usage:         state.acc.Snapshot(),
+					UsageMeasured: state.usageMeasured,
+				}
+				result, agentErr := agentcore.FinalizeTurn(params.OnEvent, logger, ev, meta)
+				if agentErr != nil {
+					return result, agentErr
+				}
+				return result, nil
 			}
 			if msg.Err != nil {
-				agentcore.EmitTurnFailed(params.OnEvent, msg.Err.Error(), 0, state.acc.Snapshot())
 				go func() { toolWg.Wait(); close(toolEventCh) }()
 				for evt := range toolEventCh {
 					params.OnEvent(evt)
 				}
-				return domain.TurnResult{
-						SessionID:     state.threadID,
-						ExitReason:    domain.EventTurnFailed,
-						Usage:         state.acc.Snapshot(),
-						UsageMeasured: state.usageMeasured,
-					}, &domain.AgentError{
-						Kind:    domain.ErrPortExit,
-						Message: fmt.Sprintf("stdout read error: %v", msg.Err),
-						Err:     msg.Err,
-					}
+				ev := agentcore.TurnEvidence{
+					Terminal:          agentcore.TerminalFailure,
+					TerminalErrorKind: domain.ErrPortExit,
+					TerminalMessage:   fmt.Sprintf("stdout read error: %v", msg.Err),
+					Cause:             msg.Err,
+				}
+				meta := agentcore.TurnMeta{
+					SessionID:     state.threadID,
+					Usage:         state.acc.Snapshot(),
+					UsageMeasured: state.usageMeasured,
+				}
+				result, agentErr := agentcore.FinalizeTurn(params.OnEvent, logger, ev, meta)
+				if agentErr != nil {
+					return result, agentErr
+				}
+				return result, nil
 			}
 
 			// Response messages (echoed tool-call confirmations).
@@ -582,47 +596,52 @@ func (a *CodexAdapter) RunTurn(ctx context.Context, session domain.Session, para
 					logger.Warn("turn/completed unmarshal failed", slog.Any("error", err))
 				}
 
-				exitReason := mapTurnStatus(tc.Turn.Status)
 				snapshot := state.acc.Snapshot()
 
-				if tc.Turn.Status == "failed" && tc.Turn.Error != nil {
-					kind := mapCodexErrorInfo(tc.Turn.Error.CodexErrorInfo)
-					errMsg := tc.Turn.Error.Message
-					agentcore.EmitTurnFailed(params.OnEvent, errMsg, 0, snapshot)
-					go func() { toolWg.Wait(); close(toolEventCh) }()
-					for evt := range toolEventCh {
-						params.OnEvent(evt)
-					}
-					return domain.TurnResult{
-							SessionID:     state.threadID,
-							ExitReason:    exitReason,
-							Usage:         snapshot,
-							UsageMeasured: state.usageMeasured,
-						}, &domain.AgentError{
-							Kind:    kind,
-							Message: errMsg,
-						}
+				// Work is unreachable here: codex's persistent subprocess
+				// has no per-turn process exit to observe, so the shared
+				// decision's zero-work row never applies to this adapter.
+				ev := agentcore.TurnEvidence{Work: agentcore.WorkUnobservable}
+
+				switch {
+				case tc.Turn.Status == "completed":
+					ev.Terminal = agentcore.TerminalSuccess
+				case tc.Turn.Status == "interrupted" && ctx.Err() != nil:
+					ev.Terminal = agentcore.TerminalCancelled
+				case tc.Turn.Status == "interrupted":
+					// An interrupt sortie did not request is a failure,
+					// not a cancellation, from the orchestrator's side:
+					// it must not release the claim in place of a retry.
+					ev.Terminal = agentcore.TerminalFailure
+					ev.TerminalErrorKind = domain.ErrTurnFailed
+				case tc.Turn.Status == "failed" && tc.Turn.Error != nil:
+					ev.Terminal = agentcore.TerminalFailure
+					ev.TerminalErrorKind = mapCodexErrorInfo(tc.Turn.Error.CodexErrorInfo)
+					ev.TerminalMessage = tc.Turn.Error.Message
+				default:
+					ev.Terminal = agentcore.TerminalFailure
+					ev.TerminalErrorKind = domain.ErrTurnFailed
+				}
+				if ev.TerminalMessage == "" {
+					ev.TerminalMessage = "turn " + tc.Turn.Status
 				}
 
-				switch exitReason {
-				case domain.EventTurnCompleted:
-					agentcore.EmitTurnCompleted(params.OnEvent, "turn "+tc.Turn.Status, 0, snapshot)
-				case domain.EventTurnCancelled:
-					agentcore.EmitTurnCancelled(params.OnEvent, "turn "+tc.Turn.Status, snapshot)
-				default:
-					agentcore.EmitTurnFailed(params.OnEvent, "turn "+tc.Turn.Status, 0, snapshot)
+				meta := agentcore.TurnMeta{
+					SessionID:     state.threadID,
+					Usage:         snapshot,
+					UsageMeasured: state.usageMeasured,
 				}
 
 				go func() { toolWg.Wait(); close(toolEventCh) }()
 				for evt := range toolEventCh {
 					params.OnEvent(evt)
 				}
-				return domain.TurnResult{
-					SessionID:     state.threadID,
-					ExitReason:    exitReason,
-					Usage:         snapshot,
-					UsageMeasured: state.usageMeasured,
-				}, nil
+
+				result, agentErr := agentcore.FinalizeTurn(params.OnEvent, logger, ev, meta)
+				if agentErr != nil {
+					return result, agentErr
+				}
+				return result, nil
 
 			case "item/started":
 				var ip itemParams

--- a/internal/agent/codex/codex_test.go
+++ b/internal/agent/codex/codex_test.go
@@ -3,13 +3,19 @@
 package codex
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"io"
 	"os"
 	"path/filepath"
+	"strings"
+	"sync/atomic"
 	"testing"
 
+	"github.com/sortie-ai/sortie/internal/agent/agentcore"
 	"github.com/sortie-ai/sortie/internal/agent/agenttest"
+	"github.com/sortie-ai/sortie/internal/agent/agenttest/dispositiontest"
 	"github.com/sortie-ai/sortie/internal/domain"
 	"github.com/sortie-ai/sortie/internal/registry"
 )
@@ -230,5 +236,247 @@ func TestRunTurn_UsageMeasured_TrueOnTokenUsageNotification(t *testing.T) {
 
 	if !result.UsageMeasured {
 		t.Error("RunTurn().UsageMeasured = false, want true when a thread/tokenUsage/updated notification carried a token-usage object")
+	}
+}
+
+// TestRunTurn_CompletedTurnReturnsUntypedNilError pins that a completed
+// turn's returned error interface is genuinely nil, not a typed-nil
+// *domain.AgentError promoted to a non-nil error interface.
+func TestRunTurn_CompletedTurnReturnsUntypedNilError(t *testing.T) {
+	t.Parallel()
+
+	state := makeTestState(loadFixture(t, "runturn_success.jsonl"))
+	adapter, _ := NewCodexAdapter(map[string]any{})
+
+	_, err := adapter.RunTurn(context.Background(), fakeSession(state), domain.RunTurnParams{
+		Prompt:  "do something",
+		OnEvent: func(domain.AgentEvent) {},
+	})
+	if err != nil {
+		t.Errorf("RunTurn() error = %v, want nil (not a typed-nil *domain.AgentError)", err)
+	}
+}
+
+// atomicErrContext behaves like context.Background() to every consumer
+// that selects on Done() (the channel is nil and never closes), but its
+// Err() method reports context.Canceled once cancelled is set, so a
+// test can drive a code path that reads ctx.Err() synchronously without
+// racing RunTurn's own <-ctx.Done() select case.
+type atomicErrContext struct {
+	context.Context
+	cancelled *atomic.Bool
+}
+
+func (c atomicErrContext) Err() error {
+	if c.cancelled.Load() {
+		return context.Canceled
+	}
+	return nil
+}
+
+// newInterruptedStatusState builds a sessionState whose msgCh is
+// unbuffered, so the test driving it can set the cancellation flag at
+// the exact point between the turn/start response and the
+// turn/completed notification: an unbuffered send only returns once
+// RunTurn's own goroutine has received it, and the Go memory model
+// guarantees everything RunTurn did before that receive (including its
+// ctx.Err() fast-path check) happened before the send returns.
+func newInterruptedStatusState() *sessionState {
+	return &sessionState{
+		threadID:   "thread-001",
+		target:     agentcore.LaunchTarget{WorkspacePath: "/tmp"},
+		waitCh:     make(chan struct{}),
+		stdin:      nopWriteCloser{},
+		stdout:     io.NopCloser(bytes.NewReader(nil)),
+		msgCh:      make(chan parsedMessage),
+		readerDone: make(chan struct{}),
+		stopCh:     make(chan struct{}),
+		acc:        agentcore.NewRunUsage(),
+	}
+}
+
+// TestRunTurn_InterruptedStatus pins the context-gated mapping for a
+// turn/completed notification reporting status interrupted: cancelled
+// only when the turn context is already done, failed (preserving the
+// retryable classification) when the context is still live.
+func TestRunTurn_InterruptedStatus(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		contextIsLive  bool
+		wantExitReason domain.AgentEventType
+		wantErrorKind  domain.AgentErrorKind
+	}{
+		{
+			name:           "live context maps to failure, preserving the retryable classification",
+			contextIsLive:  true,
+			wantExitReason: domain.EventTurnFailed,
+			wantErrorKind:  domain.ErrTurnFailed,
+		},
+		{
+			name:           "already-cancelled context maps to cancellation",
+			contextIsLive:  false,
+			wantExitReason: domain.EventTurnCancelled,
+			wantErrorKind:  domain.ErrTurnCancelled,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			state := newInterruptedStatusState()
+			close(state.readerDone)
+
+			var cancelled atomic.Bool
+			ctx := atomicErrContext{Context: context.Background(), cancelled: &cancelled}
+
+			type outcome struct {
+				result domain.TurnResult
+				err    error
+			}
+			outcomeCh := make(chan outcome, 1)
+
+			adapter, _ := NewCodexAdapter(map[string]any{})
+			go func() {
+				result, err := adapter.RunTurn(ctx, fakeSession(state), domain.RunTurnParams{
+					Prompt:  "go",
+					OnEvent: func(domain.AgentEvent) {},
+				})
+				outcomeCh <- outcome{result, err}
+			}()
+
+			// This send returns only once RunTurn's response-wait loop has
+			// received it, which happens strictly after the ctx.Err()
+			// fast-path check, so cancelled is still guaranteed false here.
+			state.msgCh <- parseMessage([]byte(`{"id":1,"result":{"turn":{"id":"turn-001","status":"starting"}}}`))
+
+			if !tt.contextIsLive {
+				cancelled.Store(true)
+			}
+
+			// This send returns only once RunTurn's main loop is ready to
+			// receive again, which happens strictly after the turn/start
+			// response above has been fully processed.
+			state.msgCh <- parseMessage([]byte(`{"method":"turn/completed","params":{"turn":{"id":"turn-001","status":"interrupted"}}}`))
+
+			got := <-outcomeCh
+			result, err := got.result, got.err
+
+			if result.ExitReason != tt.wantExitReason {
+				t.Errorf("ExitReason = %q, want %q", result.ExitReason, tt.wantExitReason)
+			}
+			var agentErr *domain.AgentError
+			if !errors.As(err, &agentErr) {
+				t.Fatalf("error type = %T, want *domain.AgentError", err)
+			}
+			if agentErr.Kind != tt.wantErrorKind {
+				t.Errorf("AgentError.Kind = %q, want %q", agentErr.Kind, tt.wantErrorKind)
+			}
+		})
+	}
+}
+
+// TestRunTurn_FailedOrUnrecognizedStatus pins that a failed status with
+// no turn.error object, and any status other than completed,
+// interrupted, and failed, both produce turn_failed with a non-nil
+// error and the message "turn <status>", unchanged from before the
+// shared decision.
+func TestRunTurn_FailedOrUnrecognizedStatus(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		fixture     string
+		wantMessage string
+	}{
+		{
+			name:        "failed status with no turn.error object",
+			fixture:     `{"method":"turn/completed","params":{"turn":{"id":"turn-001","status":"failed"}}}` + "\n",
+			wantMessage: "turn failed",
+		},
+		{
+			name:        "unrecognized status",
+			fixture:     `{"method":"turn/completed","params":{"turn":{"id":"turn-001","status":"queued_for_review"}}}` + "\n",
+			wantMessage: "turn queued_for_review",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			fixture := `{"id":1,"result":{"turn":{"id":"turn-001","status":"starting"}}}` + "\n" + tt.fixture
+			state := makeTestState([]byte(fixture))
+			adapter, _ := NewCodexAdapter(map[string]any{})
+
+			result, err := adapter.RunTurn(context.Background(), fakeSession(state), domain.RunTurnParams{
+				Prompt:  "go",
+				OnEvent: func(domain.AgentEvent) {},
+			})
+
+			if result.ExitReason != domain.EventTurnFailed {
+				t.Errorf("ExitReason = %q, want %q", result.ExitReason, domain.EventTurnFailed)
+			}
+			var agentErr *domain.AgentError
+			if !errors.As(err, &agentErr) {
+				t.Fatalf("error type = %T, want *domain.AgentError", err)
+			}
+			if agentErr.Kind != domain.ErrTurnFailed {
+				t.Errorf("AgentError.Kind = %q, want %q", agentErr.Kind, domain.ErrTurnFailed)
+			}
+			if agentErr.Message != tt.wantMessage {
+				t.Errorf("AgentError.Message = %q, want %q", agentErr.Message, tt.wantMessage)
+			}
+
+			dispositiontest.AssertDispositionContract(t, agentcore.TurnEvidence{
+				Terminal:          agentcore.TerminalFailure,
+				TerminalErrorKind: domain.ErrTurnFailed,
+				TerminalMessage:   tt.wantMessage,
+				Work:              agentcore.WorkUnobservable,
+			}, result, err)
+		})
+	}
+}
+
+// TestRunTurn_StdoutParseFailure pins that a stdout line that fails to
+// parse produces the same text on both the emitted event and the
+// returned error, prefixed "stdout read error: ", and preserves the
+// underlying parse error on the unwrap chain.
+func TestRunTurn_StdoutParseFailure(t *testing.T) {
+	t.Parallel()
+
+	fixture := "{\"id\":1,\"result\":{\"turn\":{\"id\":\"turn-001\",\"status\":\"starting\"}}}\n" +
+		"not valid json\n"
+	state := makeTestState([]byte(fixture))
+	adapter, _ := NewCodexAdapter(map[string]any{})
+
+	var events []domain.AgentEvent
+	result, err := adapter.RunTurn(context.Background(), fakeSession(state), domain.RunTurnParams{
+		Prompt:  "go",
+		OnEvent: collectEvents(&events),
+	})
+
+	if result.ExitReason != domain.EventTurnFailed {
+		t.Errorf("ExitReason = %q, want %q", result.ExitReason, domain.EventTurnFailed)
+	}
+	var agentErr *domain.AgentError
+	if !errors.As(err, &agentErr) {
+		t.Fatalf("error type = %T, want *domain.AgentError", err)
+	}
+	if agentErr.Kind != domain.ErrPortExit {
+		t.Errorf("AgentError.Kind = %q, want %q", agentErr.Kind, domain.ErrPortExit)
+	}
+	if !strings.HasPrefix(agentErr.Message, "stdout read error: ") {
+		t.Errorf("AgentError.Message = %q, want prefix %q", agentErr.Message, "stdout read error: ")
+	}
+
+	turnFailedEvents := filterEventsOfType(events, domain.EventTurnFailed)
+	if len(turnFailedEvents) != 1 {
+		t.Fatalf("turn_failed event count = %d, want 1", len(turnFailedEvents))
+	}
+	if turnFailedEvents[0].Message != agentErr.Message {
+		t.Errorf("turn_failed Message = %q, want the same text as AgentError.Message %q", turnFailedEvents[0].Message, agentErr.Message)
 	}
 }

--- a/internal/agent/codex/integration_test.go
+++ b/internal/agent/codex/integration_test.go
@@ -266,7 +266,10 @@ func TestIntegration_StartSession_InvalidCommand(t *testing.T) {
 // TestIntegration_RunTurn executes a single turn and verifies the mandatory
 // event sequence, token usage, and tool result correlation. A file-read
 // prompt is used so the adapter emits at least one EventToolResult with a
-// populated ToolName.
+// populated ToolName. Its turn_completed assertion is this adapter's
+// live-runtime obligation for the shared disposition decision: the only
+// check that can catch an evidence mapping that is internally consistent
+// but wrong against the actual wire format.
 func TestIntegration_RunTurn(t *testing.T) {
 	skipUnlessCodexIntegration(t)
 

--- a/internal/agent/codex/runturn_test.go
+++ b/internal/agent/codex/runturn_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/sortie-ai/sortie/internal/agent/agentcore"
 	"github.com/sortie-ai/sortie/internal/agent/agenttest"
+	"github.com/sortie-ai/sortie/internal/agent/agenttest/dispositiontest"
 	"github.com/sortie-ai/sortie/internal/domain"
 )
 
@@ -147,6 +148,11 @@ func TestRunTurn_SuccessfulTurn(t *testing.T) {
 	if _, ok := firstEventOfType(events, domain.EventTokenUsage); !ok {
 		t.Error("expected EventTokenUsage event, none found")
 	}
+
+	dispositiontest.AssertDispositionContract(t, agentcore.TurnEvidence{
+		Terminal: agentcore.TerminalSuccess,
+		Work:     agentcore.WorkUnobservable,
+	}, result, err)
 }
 
 // filterEventsOfType returns every event of the given type, in order.
@@ -371,8 +377,19 @@ func TestRunTurn_FailedTurnContextWindowExceeded(t *testing.T) {
 	if _, ok := firstEventOfType(events, domain.EventTokenUsage); !ok {
 		t.Error("expected EventTokenUsage event on failed turn, none found")
 	}
+
+	dispositiontest.AssertDispositionContract(t, agentcore.TurnEvidence{
+		Terminal:          agentcore.TerminalFailure,
+		TerminalErrorKind: domain.ErrTurnFailed,
+		TerminalMessage:   "Context window exceeded",
+		Work:              agentcore.WorkUnobservable,
+	}, result, err)
 }
 
+// TestRunTurn_StdoutClosedBeforeTurnCompleted pins the channel-closed
+// abort arm: the disposition and kind are unchanged from before the
+// shared decision, and the arm now emits exactly one turn_failed event
+// where it emitted none before.
 func TestRunTurn_StdoutClosedBeforeTurnCompleted(t *testing.T) {
 	t.Parallel()
 
@@ -383,11 +400,27 @@ func TestRunTurn_StdoutClosedBeforeTurnCompleted(t *testing.T) {
 	state := makeTestState([]byte(fixture))
 	adapter, _ := NewCodexAdapter(map[string]any{})
 
-	_, err := adapter.RunTurn(context.Background(), fakeSession(state), domain.RunTurnParams{
+	var events []domain.AgentEvent
+	result, err := adapter.RunTurn(context.Background(), fakeSession(state), domain.RunTurnParams{
 		Prompt:  "go",
-		OnEvent: func(domain.AgentEvent) {},
+		OnEvent: collectEvents(&events),
 	})
 	requireAgentError(t, err, domain.ErrPortExit)
+
+	turnFailedEvents := filterEventsOfType(events, domain.EventTurnFailed)
+	if len(turnFailedEvents) != 1 {
+		t.Fatalf("turn_failed event count = %d, want 1", len(turnFailedEvents))
+	}
+	if turnFailedEvents[0].Message != "subprocess stdout closed unexpectedly" {
+		t.Errorf("turn_failed Message = %q, want %q", turnFailedEvents[0].Message, "subprocess stdout closed unexpectedly")
+	}
+
+	dispositiontest.AssertDispositionContract(t, agentcore.TurnEvidence{
+		Terminal:          agentcore.TerminalFailure,
+		TerminalErrorKind: domain.ErrPortExit,
+		TerminalMessage:   "subprocess stdout closed unexpectedly",
+		Work:              agentcore.WorkUnobservable,
+	}, result, err)
 }
 
 func TestRunTurn_StdoutEOFBeforeTurnStartResponse(t *testing.T) {
@@ -405,6 +438,10 @@ func TestRunTurn_StdoutEOFBeforeTurnStartResponse(t *testing.T) {
 	requireAgentError(t, err, domain.ErrPortExit)
 }
 
+// TestRunTurn_TurnStartErrorResponse pins the turn/start error abort
+// arm: the disposition and kind are unchanged from before the shared
+// decision, and the arm now emits exactly one turn_failed event where
+// it emitted none before.
 func TestRunTurn_TurnStartErrorResponse(t *testing.T) {
 	t.Parallel()
 
@@ -413,11 +450,28 @@ func TestRunTurn_TurnStartErrorResponse(t *testing.T) {
 	state := makeTestState([]byte(fixture))
 	adapter, _ := NewCodexAdapter(map[string]any{})
 
-	_, err := adapter.RunTurn(context.Background(), fakeSession(state), domain.RunTurnParams{
+	var events []domain.AgentEvent
+	result, err := adapter.RunTurn(context.Background(), fakeSession(state), domain.RunTurnParams{
 		Prompt:  "go",
-		OnEvent: func(domain.AgentEvent) {},
+		OnEvent: collectEvents(&events),
 	})
 	requireAgentError(t, err, domain.ErrTurnFailed)
+
+	const wantMessage = "turn/start error: thread not found"
+	turnFailedEvents := filterEventsOfType(events, domain.EventTurnFailed)
+	if len(turnFailedEvents) != 1 {
+		t.Fatalf("turn_failed event count = %d, want 1", len(turnFailedEvents))
+	}
+	if turnFailedEvents[0].Message != wantMessage {
+		t.Errorf("turn_failed Message = %q, want %q", turnFailedEvents[0].Message, wantMessage)
+	}
+
+	dispositiontest.AssertDispositionContract(t, agentcore.TurnEvidence{
+		Terminal:          agentcore.TerminalFailure,
+		TerminalErrorKind: domain.ErrTurnFailed,
+		TerminalMessage:   wantMessage,
+		Work:              agentcore.WorkUnobservable,
+	}, result, err)
 }
 
 func TestRunTurn_CancelledContextReturnsError(t *testing.T) {

--- a/internal/agent/copilot/copilot.go
+++ b/internal/agent/copilot/copilot.go
@@ -401,9 +401,19 @@ func (a *CopilotAdapter) StartSession(ctx context.Context, params domain.StartSe
 			usage, journalMeasured := state.recoverUsage(state.logger())
 			measured := journalMeasured || state.assistantFieldSeen
 
+			// Work tests this turn's own output, not the run cumulative,
+			// which is non-zero on any second turn.
+			ev := agentcore.TurnEvidence{
+				ExitObserved: true,
+				ExitCode:     exitCode,
+				Work:         agentcore.WorkAbsent,
+			}
+			if state.turnOutputTokens > 0 {
+				ev.Work = agentcore.WorkPresent
+			}
+
+			var apiDurationMS int64
 			if lastResult != nil {
-				// Extract API duration from the result event.
-				var apiDurationMS int64
 				if lastResult.Usage != nil {
 					apiDurationMS = lastResult.Usage.TotalAPIDurMS
 					state.logger().Info("copilot turn completed",
@@ -411,64 +421,21 @@ func (a *CopilotAdapter) StartSession(ctx context.Context, params domain.StartSe
 				}
 
 				if lastResult.ExitCode != nil && *lastResult.ExitCode == 0 {
-					agentcore.EmitTurnCompleted(emit, "", apiDurationMS, usage)
-					return domain.TurnResult{
-						SessionID:     state.copilotSessionID,
-						ExitReason:    domain.EventTurnCompleted,
-						Usage:         usage,
-						UsageMeasured: measured,
-					}, nil
+					ev.Terminal = agentcore.TerminalSuccess
+				} else {
+					ev.Terminal = agentcore.TerminalFailure
+					ev.TerminalMessage = "non-zero exit in result event"
 				}
-				// EmitWarnLines is called by the skeleton when agentErr is non-nil.
-				agentcore.EmitTurnFailed(emit, "non-zero exit in result event", apiDurationMS, usage)
-				return domain.TurnResult{
-						SessionID:     state.copilotSessionID,
-						ExitReason:    domain.EventTurnFailed,
-						Usage:         usage,
-						UsageMeasured: measured,
-					}, &domain.AgentError{
-						Kind:    domain.ErrTurnFailed,
-						Message: "non-zero exit in result event",
-					}
 			}
 
-			// No result event.
-			if exitCode != 0 {
-				agentcore.EmitTurnFailed(emit, "non-zero exit", 0, usage)
-				return domain.TurnResult{
-						SessionID:     state.copilotSessionID,
-						ExitReason:    domain.EventTurnFailed,
-						Usage:         usage,
-						UsageMeasured: measured,
-					}, &domain.AgentError{
-						Kind:    domain.ErrPortExit,
-						Message: fmt.Sprintf("exit code %d", exitCode),
-					}
-			}
-
-			// No result event and exit code 0. Test the turn's own output,
-			// not the run cumulative, which is non-zero on any second turn.
-			if state.turnOutputTokens == 0 {
-				state.logger().Warn("agent exited without producing output, treating as failure")
-				agentcore.EmitTurnFailed(emit, "agent exited without producing output", 0, usage)
-				return domain.TurnResult{
-						SessionID:     state.copilotSessionID,
-						ExitReason:    domain.EventTurnFailed,
-						Usage:         usage,
-						UsageMeasured: measured,
-					}, &domain.AgentError{
-						Kind:    domain.ErrTurnFailed,
-						Message: "agent exited without producing output",
-					}
-			}
-
-			agentcore.EmitTurnCompleted(emit, "", 0, usage)
-			return domain.TurnResult{
+			meta := agentcore.TurnMeta{
 				SessionID:     state.copilotSessionID,
-				ExitReason:    domain.EventTurnCompleted,
 				Usage:         usage,
 				UsageMeasured: measured,
-			}, nil
+				APIDurationMS: apiDurationMS,
+			}
+
+			return agentcore.FinalizeTurn(emit, state.logger(), ev, meta)
 		},
 		// Copilot emits EventSessionStarted before the scan loop using the
 		// current session ID (empty on turn 1; populated on turns 2+ from

--- a/internal/agent/copilot/copilot_test.go
+++ b/internal/agent/copilot/copilot_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/sortie-ai/sortie/internal/agent/agentcore"
 	"github.com/sortie-ai/sortie/internal/agent/agenttest"
+	"github.com/sortie-ai/sortie/internal/agent/agenttest/dispositiontest"
 	"github.com/sortie-ai/sortie/internal/domain"
 	"github.com/sortie-ai/sortie/internal/registry"
 )
@@ -551,6 +552,13 @@ func TestRunTurn_HappyPath(t *testing.T) {
 			break
 		}
 	}
+
+	dispositiontest.AssertDispositionContract(t, agentcore.TurnEvidence{
+		Terminal:     agentcore.TerminalSuccess,
+		ExitObserved: true,
+		ExitCode:     0,
+		Work:         agentcore.WorkPresent,
+	}, result, err)
 }
 
 func TestRunTurn_ExitCode127(t *testing.T) {
@@ -581,7 +589,7 @@ func TestRunTurn_NonZeroExitNoResult(t *testing.T) {
 	state.target.Command = fakeCopilotBinaryWithOutput(t, "", 1)
 
 	var events []domain.AgentEvent
-	_, err := adapter.RunTurn(context.Background(), session, domain.RunTurnParams{
+	result, err := adapter.RunTurn(context.Background(), session, domain.RunTurnParams{
 		OnEvent: func(e domain.AgentEvent) { events = append(events, e) },
 	})
 
@@ -589,6 +597,12 @@ func TestRunTurn_NonZeroExitNoResult(t *testing.T) {
 	if !hasEventType(events, domain.EventTurnFailed) {
 		t.Error("EventTurnFailed not delivered for non-zero exit")
 	}
+
+	dispositiontest.AssertDispositionContract(t, agentcore.TurnEvidence{
+		ExitObserved: true,
+		ExitCode:     1,
+		Work:         agentcore.WorkAbsent,
+	}, result, err)
 }
 
 func TestRunTurn_NoOutputExitZero(t *testing.T) {
@@ -610,6 +624,12 @@ func TestRunTurn_NoOutputExitZero(t *testing.T) {
 	if !hasEventType(events, domain.EventTurnFailed) {
 		t.Error("EventTurnFailed not delivered for no-output exit 0")
 	}
+
+	dispositiontest.AssertDispositionContract(t, agentcore.TurnEvidence{
+		ExitObserved: true,
+		ExitCode:     0,
+		Work:         agentcore.WorkAbsent,
+	}, result, err)
 }
 
 func TestRunTurn_PartialOutputNoResultExitZero(t *testing.T) {
@@ -639,6 +659,12 @@ func TestRunTurn_PartialOutputNoResultExitZero(t *testing.T) {
 	if result.Usage.OutputTokens != wantTokens {
 		t.Errorf("Usage.OutputTokens = %d, want %d", result.Usage.OutputTokens, wantTokens)
 	}
+
+	dispositiontest.AssertDispositionContract(t, agentcore.TurnEvidence{
+		ExitObserved: true,
+		ExitCode:     0,
+		Work:         agentcore.WorkPresent,
+	}, result, err)
 }
 
 func TestRunTurn_StderrWarnOnNoOutputExitZero(t *testing.T) {
@@ -762,7 +788,7 @@ func TestRunTurn_NonZeroResultExitCode(t *testing.T) {
 	state.target.Command = fakeCopilotBinaryWithOutput(t, failResultJSONL, 0)
 
 	var events []domain.AgentEvent
-	_, err := adapter.RunTurn(context.Background(), session, domain.RunTurnParams{
+	result, err := adapter.RunTurn(context.Background(), session, domain.RunTurnParams{
 		OnEvent: func(e domain.AgentEvent) { events = append(events, e) },
 	})
 
@@ -770,6 +796,14 @@ func TestRunTurn_NonZeroResultExitCode(t *testing.T) {
 	if !hasEventType(events, domain.EventTurnFailed) {
 		t.Error("EventTurnFailed not delivered for non-zero result exit code")
 	}
+
+	dispositiontest.AssertDispositionContract(t, agentcore.TurnEvidence{
+		Terminal:        agentcore.TerminalFailure,
+		TerminalMessage: "non-zero exit in result event",
+		ExitObserved:    true,
+		ExitCode:        0,
+		Work:            agentcore.WorkAbsent,
+	}, result, err)
 }
 
 // TestRunTurn_TurnFailed_APIDurationMS verifies that EventTurnFailed carries
@@ -1436,4 +1470,148 @@ func TestRunTurn_SessionStateRecovery_FirstReadAttempt(t *testing.T) {
 			t.Errorf("WARN log count after third call = %d, want 1 (no further read attempted)", warnCount)
 		}
 	})
+}
+
+// TestRunTurn_SuccessfulResultZeroOutputTokens pins that a successful
+// result event completes the turn even when this turn's own output
+// tokens are zero, because a positive terminal report is authoritative
+// and never consults Work.
+func TestRunTurn_SuccessfulResultZeroOutputTokens(t *testing.T) {
+	// t.Setenv is incompatible with t.Parallel.
+	t.Setenv("GH_TOKEN", "test-token-for-unit-test")
+
+	const successJSONL = `{"type":"result","timestamp":"2026-04-08T00:00:01Z","sessionId":"zero-output-success-session","exitCode":0,"usage":{"premiumRequests":1,"totalApiDurationMs":10}}`
+
+	adapter, session := newTestSession(t, t.TempDir())
+	state := session.Internal.(*sessionState)
+	state.target.Command = fakeCopilotBinaryWithOutput(t, successJSONL, 0)
+
+	result, err := adapter.RunTurn(context.Background(), session, domain.RunTurnParams{
+		OnEvent: func(domain.AgentEvent) {},
+	})
+	if err != nil {
+		t.Fatalf("RunTurn() error = %v", err)
+	}
+	if result.ExitReason != domain.EventTurnCompleted {
+		t.Errorf("ExitReason = %q, want %q", result.ExitReason, domain.EventTurnCompleted)
+	}
+
+	dispositiontest.AssertDispositionContract(t, agentcore.TurnEvidence{
+		Terminal:     agentcore.TerminalSuccess,
+		ExitObserved: true,
+		ExitCode:     0,
+		Work:         agentcore.WorkAbsent,
+	}, result, err)
+}
+
+// TestRunTurn_SuccessMessageStaysEmpty is the regression pin for the
+// success-message mapping: copilot's result event carries no completion
+// text, so the emitted turn_completed event's message stays empty
+// unchanged, even on a turn that produced real assistant output.
+func TestRunTurn_SuccessMessageStaysEmpty(t *testing.T) {
+	// t.Setenv is incompatible with t.Parallel.
+	t.Setenv("GH_TOKEN", "test-token-for-unit-test")
+
+	adapter, session := newTestSession(t, t.TempDir())
+	state := session.Internal.(*sessionState)
+	state.target.Command = fakeCopilotBinaryWithOutput(t, loadTestFixture(t, "simple_session.jsonl"), 0)
+
+	var events []domain.AgentEvent
+	result, err := adapter.RunTurn(context.Background(), session, domain.RunTurnParams{
+		OnEvent: func(e domain.AgentEvent) { events = append(events, e) },
+	})
+	if err != nil {
+		t.Fatalf("RunTurn() error = %v", err)
+	}
+	if result.ExitReason != domain.EventTurnCompleted {
+		t.Fatalf("ExitReason = %q, want %q", result.ExitReason, domain.EventTurnCompleted)
+	}
+
+	e, ok := findEventByType(events, domain.EventTurnCompleted)
+	if !ok {
+		t.Fatal("turn_completed event not delivered")
+	}
+	if e.Message != "" {
+		t.Errorf("turn_completed Message = %q, want empty (copilot's result event carries no completion text)", e.Message)
+	}
+}
+
+// TestRunTurn_WorkPredicateIsPerTurn pins that the work predicate reads
+// this turn's own output tokens, not the run cumulative. The first turn
+// produces output and completes; the second turn, on the same session,
+// produces none and must fail rather than inherit the first turn's
+// evidence.
+func TestRunTurn_WorkPredicateIsPerTurn(t *testing.T) {
+	// t.Setenv is incompatible with t.Parallel.
+	t.Setenv("GH_TOKEN", "test-token-for-unit-test")
+
+	adapter, session := newTestSession(t, t.TempDir())
+	state := session.Internal.(*sessionState)
+
+	tmpDir := t.TempDir()
+	counterFile := filepath.Join(tmpDir, "turn-count")
+	outFile := filepath.Join(tmpDir, "out.jsonl")
+	const outputJSONL = `{"type":"assistant.message","timestamp":"2026-04-08T00:00:00Z","data":{"role":"assistant","content":"hello","outputTokens":10}}` + "\n"
+	if err := os.WriteFile(outFile, []byte(outputJSONL), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	state.target.Command = agenttest.WriteScript(t, tmpDir, "copilot", fmt.Sprintf(`
+if [ -f '%s' ]; then
+  exit 0
+fi
+touch '%s'
+cat '%s'
+exit 0
+`, counterFile, counterFile, outFile))
+
+	result1, err := adapter.RunTurn(context.Background(), session, domain.RunTurnParams{
+		OnEvent: func(domain.AgentEvent) {},
+	})
+	if err != nil {
+		t.Fatalf("RunTurn(first) error = %v", err)
+	}
+	if result1.ExitReason != domain.EventTurnCompleted {
+		t.Fatalf("RunTurn(first).ExitReason = %q, want %q", result1.ExitReason, domain.EventTurnCompleted)
+	}
+
+	result2, err := adapter.RunTurn(context.Background(), session, domain.RunTurnParams{
+		OnEvent: func(domain.AgentEvent) {},
+	})
+	if result2.ExitReason != domain.EventTurnFailed {
+		t.Errorf("RunTurn(second).ExitReason = %q, want %q (per-turn work predicate must not carry the first turn's output forward)", result2.ExitReason, domain.EventTurnFailed)
+	}
+	requireAgentError(t, err, domain.ErrTurnFailed)
+}
+
+// TestRunTurn_PremiumRequestsLoggedOnce pins the premium_requests side
+// effect: the Info log keeps firing on exactly today's condition, a
+// result event carrying a non-nil usage object, exactly once per turn.
+func TestRunTurn_PremiumRequestsLoggedOnce(t *testing.T) {
+	// No t.Parallel(): installs a global slog default; t.Setenv is also
+	// incompatible with t.Parallel.
+	spy := agenttest.InstallLogSpy(t)
+	t.Setenv("GH_TOKEN", "test-token-for-unit-test")
+
+	const successJSONL = `{"type":"result","timestamp":"2026-04-08T00:00:01Z","sessionId":"premium-session","exitCode":0,"usage":{"premiumRequests":3,"totalApiDurationMs":10}}`
+
+	adapter, session := newTestSession(t, t.TempDir())
+	state := session.Internal.(*sessionState)
+	state.target.Command = fakeCopilotBinaryWithOutput(t, successJSONL, 0)
+
+	_, err := adapter.RunTurn(context.Background(), session, domain.RunTurnParams{
+		OnEvent: func(domain.AgentEvent) {},
+	})
+	if err != nil {
+		t.Fatalf("RunTurn() error = %v", err)
+	}
+
+	var premiumCount int
+	for _, e := range spy.Entries() {
+		if e.Msg == "copilot turn completed" {
+			premiumCount++
+		}
+	}
+	if premiumCount != 1 {
+		t.Errorf("premium_requests Info line count = %d, want 1", premiumCount)
+	}
 }

--- a/internal/agent/copilot/integration_test.go
+++ b/internal/agent/copilot/integration_test.go
@@ -182,7 +182,10 @@ func TestIntegration_StartSession_InvalidCommand(t *testing.T) {
 
 // TestIntegration_RunTurn executes a single-turn session, verifying that the
 // adapter delivers the mandatory event sequence and populates TurnResult
-// correctly.
+// correctly. Its turn_completed assertion is this adapter's live-runtime
+// obligation for the shared disposition decision: the only check that can
+// catch an evidence mapping that is internally consistent but wrong against
+// the actual wire format.
 func TestIntegration_RunTurn(t *testing.T) {
 	skipUnlessCopilotIntegration(t)
 
@@ -235,14 +238,18 @@ func TestIntegration_RunTurn(t *testing.T) {
 	assertNoEventType(t, events, domain.EventTurnFailed)
 	assertNoEventType(t, events, domain.EventStartupFailed)
 
-	// Copilot CLI does not expose per-message input tokens; verify
-	// cumulative output tokens are positive.
+	// Cumulative output tokens must be positive regardless of which usage
+	// path recovered them. TotalTokens must equal InputTokens plus
+	// OutputTokens on both paths: the output-only fallback (SSH mode, or a
+	// failed journal read) reports InputTokens 0, so the two forms agree
+	// there, and a successful session-state journal read reports the full
+	// breakdown, where TotalTokens must not silently drop the input half.
 	if result.Usage.OutputTokens <= 0 {
 		t.Errorf("TurnResult.Usage.OutputTokens = %d, want > 0", result.Usage.OutputTokens)
 	}
-	if result.Usage.TotalTokens != result.Usage.OutputTokens {
-		t.Errorf("TurnResult.Usage.TotalTokens = %d, want == OutputTokens (%d)",
-			result.Usage.TotalTokens, result.Usage.OutputTokens)
+	if result.Usage.TotalTokens != result.Usage.InputTokens+result.Usage.OutputTokens {
+		t.Errorf("TurnResult.Usage.TotalTokens = %d, want InputTokens+OutputTokens (%d)",
+			result.Usage.TotalTokens, result.Usage.InputTokens+result.Usage.OutputTokens)
 	}
 
 	// At least one EventTokenUsage must have been delivered.

--- a/internal/agent/kiro/integration_test.go
+++ b/internal/agent/kiro/integration_test.go
@@ -50,6 +50,11 @@ func mustNewAdapter(t *testing.T) domain.AgentAdapter {
 	return a
 }
 
+// TestKiroAdapter_Integration drives one real turn against the live
+// kiro-cli binary and asserts turn_completed, satisfying the shared
+// disposition decision's live-runtime obligation for this adapter: the
+// only check that can catch an evidence mapping that is internally
+// consistent but wrong against the actual wire format.
 func TestKiroAdapter_Integration(t *testing.T) {
 	skipIfNotEnabled(t)
 

--- a/internal/agent/kiro/kiro.go
+++ b/internal/agent/kiro/kiro.go
@@ -160,51 +160,31 @@ func (a *KiroAdapter) StartSession(ctx context.Context, params domain.StartSessi
 		GetSessionID: func() string { return state.sessionID },
 		OnFinalize: func(emit func(domain.AgentEvent), _ any, exitCode int, stderrLines []string) (domain.TurnResult, *domain.AgentError) {
 			creditsSeen, authFailed := classifyStderr(stderrLines)
-			zero := domain.TokenUsage{}
 
-			if exitCode == 0 && creditsSeen {
+			// Headless Kiro reports no per-turn token count, so the work
+			// signal this adapter can offer is the currency the runtime
+			// actually exposes: the credits trailer, consumed below as the
+			// success signal rather than as Work.
+			ev := agentcore.TurnEvidence{
+				ExitObserved: true,
+				ExitCode:     exitCode,
+				Work:         agentcore.WorkUnobservable,
+				WorkDetail:   "no credits trailer on stderr",
+			}
+
+			switch {
+			case exitCode == 0 && creditsSeen:
+				ev.Terminal = agentcore.TerminalSuccess
 				state.resumeRequested = true
-				agentcore.EmitTurnCompleted(emit, "", 0, zero)
-				return domain.TurnResult{
-					SessionID:  state.sessionID,
-					ExitReason: domain.EventTurnCompleted,
-					Usage:      zero,
-				}, nil
+			case exitCode == 0 && authFailed && state.turnStdout.Len() == 0:
+				ev.Terminal = agentcore.TerminalFailure
+				ev.TerminalErrorKind = domain.ErrResponseError
+				ev.TerminalMessage = "kiro authentication failed"
 			}
 
-			if exitCode == 0 && authFailed && state.turnStdout.Len() == 0 {
-				agentcore.EmitTurnFailed(emit, "kiro authentication failed", 0, zero)
-				return domain.TurnResult{
-						SessionID:  state.sessionID,
-						ExitReason: domain.EventTurnFailed,
-						Usage:      zero,
-					}, &domain.AgentError{
-						Kind:    domain.ErrResponseError,
-						Message: "kiro authentication failed",
-					}
-			}
+			meta := agentcore.TurnMeta{SessionID: state.sessionID}
 
-			if exitCode == 0 {
-				agentcore.EmitTurnFailed(emit, "kiro exited without a credits trailer", 0, zero)
-				return domain.TurnResult{
-						SessionID:  state.sessionID,
-						ExitReason: domain.EventTurnFailed,
-						Usage:      zero,
-					}, &domain.AgentError{
-						Kind:    domain.ErrTurnFailed,
-						Message: "kiro exited without a credits trailer",
-					}
-			}
-
-			agentcore.EmitTurnFailed(emit, "kiro exited with a non-zero status", 0, zero)
-			return domain.TurnResult{
-					SessionID:  state.sessionID,
-					ExitReason: domain.EventTurnFailed,
-					Usage:      zero,
-				}, &domain.AgentError{
-					Kind:    domain.ErrPortExit,
-					Message: "kiro exited with a non-zero status",
-				}
+			return agentcore.FinalizeTurn(emit, state.logger(), ev, meta)
 		},
 	}
 

--- a/internal/agent/kiro/kiro_test.go
+++ b/internal/agent/kiro/kiro_test.go
@@ -12,7 +12,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/sortie-ai/sortie/internal/agent/agentcore"
 	"github.com/sortie-ai/sortie/internal/agent/agenttest"
+	"github.com/sortie-ai/sortie/internal/agent/agenttest/dispositiontest"
 	"github.com/sortie-ai/sortie/internal/domain"
 )
 
@@ -43,6 +45,34 @@ cat '%s'
 cat '%s' >&2
 exit %d
 `, outFile, errFile, chatExit)
+
+	return agenttest.WriteScript(t, dir, "kiro-cli", body)
+}
+
+// fakeChatScriptWithArgsLog behaves exactly like fakeChatScript, except
+// every non-whoami invocation appends its argument list to argsLog
+// before replaying stdoutBody and stderrBody, so a test can inspect
+// what buildArgs produced for each turn.
+func fakeChatScriptWithArgsLog(t *testing.T, dir, stdoutBody, stderrBody string, chatExit int, argsLog string) string {
+	t.Helper()
+	outFile := filepath.Join(dir, "chat_stdout")
+	errFile := filepath.Join(dir, "chat_stderr")
+	if err := os.WriteFile(outFile, []byte(stdoutBody), 0o644); err != nil {
+		t.Fatalf("writing chat stdout fixture: %v", err)
+	}
+	if err := os.WriteFile(errFile, []byte(stderrBody), 0o644); err != nil {
+		t.Fatalf("writing chat stderr fixture: %v", err)
+	}
+
+	body := fmt.Sprintf(`if [ "$1" = "whoami" ]; then
+  printf '%%s\n' 'Authenticated with API key'
+  exit 0
+fi
+printf '%%s\n' "$*" >> '%s'
+cat '%s'
+cat '%s' >&2
+exit %d
+`, argsLog, outFile, errFile, chatExit)
 
 	return agenttest.WriteScript(t, dir, "kiro-cli", body)
 }
@@ -115,6 +145,17 @@ func hasEventType(events []domain.AgentEvent, typ domain.AgentEventType) bool {
 	return false
 }
 
+// findEventByType returns the first event matching typ and true, or a
+// zero value and false when no matching event exists.
+func findEventByType(events []domain.AgentEvent, typ domain.AgentEventType) (domain.AgentEvent, bool) {
+	for _, e := range events {
+		if e.Type == typ {
+			return e, true
+		}
+	}
+	return domain.AgentEvent{}, false
+}
+
 // The observed success trailer and auth-failure line use the exact literals
 // from the adapter research notes: stderr carries "▸ Credits: … • Time: …" on
 // a turn that ran, and "Authentication failed." on an invalid-credential turn.
@@ -146,6 +187,14 @@ func TestOnFinalize_SuccessWithCredits(t *testing.T) {
 	if !state.resumeRequested {
 		t.Error("state.resumeRequested = false, want true after a turn with the credits trailer")
 	}
+
+	dispositiontest.AssertDispositionContract(t, agentcore.TurnEvidence{
+		Terminal:     agentcore.TerminalSuccess,
+		ExitObserved: true,
+		ExitCode:     0,
+		Work:         agentcore.WorkUnobservable,
+		WorkDetail:   "no credits trailer on stderr",
+	}, result, err)
 }
 
 func TestOnFinalize_AuthFailed(t *testing.T) {
@@ -170,6 +219,16 @@ func TestOnFinalize_AuthFailed(t *testing.T) {
 	if state.resumeRequested {
 		t.Error("state.resumeRequested = true, want false after an auth-failed turn")
 	}
+
+	dispositiontest.AssertDispositionContract(t, agentcore.TurnEvidence{
+		Terminal:          agentcore.TerminalFailure,
+		TerminalErrorKind: domain.ErrResponseError,
+		TerminalMessage:   "kiro authentication failed",
+		ExitObserved:      true,
+		ExitCode:          0,
+		Work:              agentcore.WorkUnobservable,
+		WorkDetail:        "no credits trailer on stderr",
+	}, result, err)
 }
 
 func TestOnFinalize_ExitZeroNoSignal(t *testing.T) {
@@ -193,6 +252,29 @@ func TestOnFinalize_ExitZeroNoSignal(t *testing.T) {
 	if state.resumeRequested {
 		t.Error("state.resumeRequested = true, want false after a no-credits turn")
 	}
+
+	// The zero-work message carries the family-wide stem plus the
+	// credits-trailer detail, so an operator can grep one string across
+	// every adapter and still see kiro's own signal.
+	const wantMessage = "agent exited without producing output: no credits trailer on stderr"
+	turnFailed, ok := findEventByType(events, domain.EventTurnFailed)
+	if !ok {
+		t.Fatal("turn_failed event not found")
+	}
+	if turnFailed.Message != wantMessage {
+		t.Errorf("turn_failed Message = %q, want %q", turnFailed.Message, wantMessage)
+	}
+	var agentErr *domain.AgentError
+	if errors.As(err, &agentErr) && agentErr.Message != wantMessage {
+		t.Errorf("AgentError.Message = %q, want %q", agentErr.Message, wantMessage)
+	}
+
+	dispositiontest.AssertDispositionContract(t, agentcore.TurnEvidence{
+		ExitObserved: true,
+		ExitCode:     0,
+		Work:         agentcore.WorkUnobservable,
+		WorkDetail:   "no credits trailer on stderr",
+	}, result, err)
 }
 
 func TestOnFinalize_NonZeroExit(t *testing.T) {
@@ -211,6 +293,27 @@ func TestOnFinalize_NonZeroExit(t *testing.T) {
 	if !hasEventType(events, domain.EventTurnFailed) {
 		t.Error("EventTurnFailed not delivered for non-zero exit")
 	}
+
+	// The non-zero-exit row deliberately uses two different texts: the
+	// event message names the class, the error message names the code.
+	turnFailed, ok := findEventByType(events, domain.EventTurnFailed)
+	if !ok {
+		t.Fatal("turn_failed event not found")
+	}
+	if turnFailed.Message != "non-zero exit" {
+		t.Errorf("turn_failed Message = %q, want %q", turnFailed.Message, "non-zero exit")
+	}
+	var agentErr *domain.AgentError
+	if errors.As(err, &agentErr) && agentErr.Message != "exit code 1" {
+		t.Errorf("AgentError.Message = %q, want %q", agentErr.Message, "exit code 1")
+	}
+
+	dispositiontest.AssertDispositionContract(t, agentcore.TurnEvidence{
+		ExitObserved: true,
+		ExitCode:     1,
+		Work:         agentcore.WorkUnobservable,
+		WorkDetail:   "no credits trailer on stderr",
+	}, result, err)
 }
 
 // TestOnFinalize_AuthLineWithStdoutIsNotAuthError verifies the auth-failure arm
@@ -229,6 +332,13 @@ func TestOnFinalize_AuthLineWithStdoutIsNotAuthError(t *testing.T) {
 		t.Errorf("result.ExitReason = %q, want %q", result.ExitReason, domain.EventTurnFailed)
 	}
 	requireAgentError(t, err, domain.ErrTurnFailed)
+
+	dispositiontest.AssertDispositionContract(t, agentcore.TurnEvidence{
+		ExitObserved: true,
+		ExitCode:     0,
+		Work:         agentcore.WorkUnobservable,
+		WorkDetail:   "no credits trailer on stderr",
+	}, result, err)
 }
 
 // TestOnFinalize_NoTokenEvent verifies that across every owned OnFinalize row,
@@ -262,6 +372,50 @@ func TestOnFinalize_NoTokenEvent(t *testing.T) {
 
 			agenttest.AssertMeasurementAbsent(t, events, result)
 		})
+	}
+}
+
+// TestOnFinalize_ResumeRequestedOnSecondTurn pins the resumeRequested
+// side effect against being dropped in the move to the shared decision:
+// a successful turn sets it, and the next turn's argument list carries
+// the resume flag as a result.
+func TestOnFinalize_ResumeRequestedOnSecondTurn(t *testing.T) {
+	// t.Setenv is incompatible with t.Parallel.
+	setValidAPIKey(t)
+
+	dir := t.TempDir()
+	argsLog := filepath.Join(dir, "args.log")
+	bin := fakeChatScriptWithArgsLog(t, dir, "PONG", creditsLine, 0, argsLog)
+	adapter, session, state := mustStartSession(t, bin)
+
+	_, result1, err := runChatTurn(t, adapter, session, "first")
+	if err != nil {
+		t.Fatalf("RunTurn(first) error = %v", err)
+	}
+	if result1.ExitReason != domain.EventTurnCompleted {
+		t.Fatalf("RunTurn(first).ExitReason = %q, want %q", result1.ExitReason, domain.EventTurnCompleted)
+	}
+	if !state.resumeRequested {
+		t.Fatal("state.resumeRequested = false after a successful turn, want true")
+	}
+
+	if _, _, err := runChatTurn(t, adapter, session, "second"); err != nil {
+		t.Fatalf("RunTurn(second) error = %v", err)
+	}
+
+	logged, err := os.ReadFile(argsLog)
+	if err != nil {
+		t.Fatalf("reading captured args: %v", err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(logged)), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("captured chat invocations = %d, want 2; log = %q", len(lines), string(logged))
+	}
+	if strings.Contains(lines[0], "--resume") {
+		t.Errorf("first turn args = %q, want no --resume flag", lines[0])
+	}
+	if !strings.Contains(lines[1], "--resume") {
+		t.Errorf("second turn args = %q, want the --resume flag", lines[1])
 	}
 }
 

--- a/internal/agent/opencode/integration_test.go
+++ b/internal/agent/opencode/integration_test.go
@@ -109,6 +109,14 @@ func collectAllEvents(t *testing.T, a domain.AgentAdapter, session domain.Sessio
 	return events, result
 }
 
+// TestIntegration_HappyPathFreshTurn drives one real turn against the
+// live opencode binary and asserts turn_completed, satisfying the
+// shared disposition decision's live-runtime obligation for this
+// adapter. A live opencode turn reports no terminal outcome of its own,
+// so turn_completed is reachable only when the work predicate resolves
+// to present; this test therefore also exercises that predicate against
+// the real wire format, which is the only check that can catch it being
+// internally consistent but wrong.
 func TestIntegration_HappyPathFreshTurn(t *testing.T) {
 	skipIfNotEnabled(t)
 

--- a/internal/agent/opencode/opencode.go
+++ b/internal/agent/opencode/opencode.go
@@ -77,6 +77,11 @@ type turnRuntime struct {
 	terminalOutcome domain.AgentEventType
 	waitMu          sync.Mutex
 	waitRes         waitResult
+
+	// assistantOutputSeen is true once at least one text, reasoning, or
+	// tool_use part has been parsed during this turn. It is the per-turn
+	// work signal for the shared turn-disposition decision.
+	assistantOutputSeen bool
 }
 
 type waitResult struct {
@@ -273,40 +278,28 @@ func (a *OpenCodeAdapter) RunTurn(ctx context.Context, session domain.Session, p
 			}
 
 			if parsed.Err != nil {
-				if ctx.Err() != nil || state.isClosed() {
-					closeStop(runtime)
-					killTurnProcess(runtime)
-					<-runtime.readerDone
-					_ = waitForProcess(runtime)
-					clearActive(state, runtime)
-					usage := state.acc.Snapshot()
-					agentcore.EmitTurnCancelled(emit, "turn cancelled", usage)
-					return domain.TurnResult{
-						SessionID:     state.currentSessionID(),
-						ExitReason:    domain.EventTurnCancelled,
-						Usage:         usage,
-						UsageMeasured: state.usageMeasured,
-					}, nil
-				}
-
-				emitTurnEndedWithError(emit, "stdout read error")
 				closeStop(runtime)
 				killTurnProcess(runtime)
 				<-runtime.readerDone
 				_ = waitForProcess(runtime)
-				procutil.EmitWarnLines(runtime.stderrCollector.Lines(), state.logger())
 				clearActive(state, runtime)
-				usage := state.acc.Snapshot()
-				return domain.TurnResult{
-						SessionID:     state.currentSessionID(),
-						ExitReason:    domain.EventTurnEndedWithError,
-						Usage:         usage,
-						UsageMeasured: state.usageMeasured,
-					}, &domain.AgentError{
-						Kind:    domain.ErrResponseError,
-						Message: "stdout read error",
-						Err:     parsed.Err,
+
+				ev := agentcore.TurnEvidence{Terminal: agentcore.TerminalCancelled, TerminalMessage: "turn cancelled"}
+				if ctx.Err() == nil && !state.isClosed() {
+					procutil.EmitWarnLines(runtime.stderrCollector.Lines(), state.logger())
+					ev = agentcore.TurnEvidence{
+						Terminal:          agentcore.TerminalFailure,
+						TerminalErrorKind: domain.ErrResponseError,
+						TerminalMessage:   "stdout read error",
+						Cause:             parsed.Err,
 					}
+				}
+				meta := agentcore.TurnMeta{SessionID: state.currentSessionID(), Usage: state.acc.Snapshot(), UsageMeasured: state.usageMeasured}
+				result, agentErr := agentcore.FinalizeTurn(emit, state.logger(), ev, meta)
+				if agentErr != nil {
+					return result, agentErr
+				}
+				return result, nil
 			}
 
 			if parsed.PlainText != "" {
@@ -341,22 +334,23 @@ func (a *OpenCodeAdapter) RunTurn(ctx context.Context, session domain.Session, p
 			started, mismatch := state.applySessionEvent(event.SessionID)
 			if mismatch {
 				message := fmt.Sprintf("session id mismatch: expected %q, got %q", state.currentSessionID(), event.SessionID)
-				emitTurnEndedWithError(emit, message)
 				closeStop(runtime)
 				killTurnProcess(runtime)
 				<-runtime.readerDone
 				_ = waitForProcess(runtime)
 				procutil.EmitWarnLines(runtime.stderrCollector.Lines(), state.logger())
 				clearActive(state, runtime)
-				return domain.TurnResult{
-						SessionID:     state.currentSessionID(),
-						ExitReason:    domain.EventTurnEndedWithError,
-						Usage:         state.acc.Snapshot(),
-						UsageMeasured: state.usageMeasured,
-					}, &domain.AgentError{
-						Kind:    domain.ErrResponseError,
-						Message: message,
-					}
+				ev := agentcore.TurnEvidence{
+					Terminal:          agentcore.TerminalFailure,
+					TerminalErrorKind: domain.ErrResponseError,
+					TerminalMessage:   message,
+				}
+				meta := agentcore.TurnMeta{SessionID: state.currentSessionID(), Usage: state.acc.Snapshot(), UsageMeasured: state.usageMeasured}
+				result, agentErr := agentcore.FinalizeTurn(emit, state.logger(), ev, meta)
+				if agentErr != nil {
+					return result, agentErr
+				}
+				return result, nil
 			}
 			if started {
 				emit(domain.AgentEvent{
@@ -382,6 +376,7 @@ func (a *OpenCodeAdapter) RunTurn(ctx context.Context, session domain.Session, p
 					emit(domain.AgentEvent{Type: domain.EventMalformed, Timestamp: now, Message: "invalid text payload"})
 					continue
 				}
+				runtime.assistantOutputSeen = true
 				agentcore.EmitNotification(emit, typeutil.TruncateRunes(part.Text, 500))
 
 			case "reasoning":
@@ -389,6 +384,7 @@ func (a *OpenCodeAdapter) RunTurn(ctx context.Context, session domain.Session, p
 					emit(domain.AgentEvent{Type: domain.EventMalformed, Timestamp: now, Message: "invalid reasoning payload"})
 					continue
 				}
+				runtime.assistantOutputSeen = true
 				emit(domain.AgentEvent{
 					Type:      domain.EventOtherMessage,
 					Timestamp: now,
@@ -401,6 +397,7 @@ func (a *OpenCodeAdapter) RunTurn(ctx context.Context, session domain.Session, p
 					emit(domain.AgentEvent{Type: domain.EventMalformed, Timestamp: now, Message: "invalid tool_use payload"})
 					continue
 				}
+				runtime.assistantOutputSeen = true
 				emit(domain.AgentEvent{
 					Type:           domain.EventToolResult,
 					Timestamp:      now,
@@ -421,7 +418,6 @@ func (a *OpenCodeAdapter) RunTurn(ctx context.Context, session domain.Session, p
 			case "error":
 				runtime.terminalOutcome = domain.EventTurnFailed
 				runtime.terminalError = event.Error
-				agentcore.EmitTurnFailed(emit, rawRunErrorMessage(event.Error), 0, state.acc.Snapshot())
 
 			default:
 				emit(domain.AgentEvent{
@@ -445,32 +441,32 @@ func (a *OpenCodeAdapter) RunTurn(ctx context.Context, session domain.Session, p
 			<-runtime.readerDone
 			_ = waitForProcess(runtime)
 			clearActive(state, runtime)
-			usage := state.acc.Snapshot()
-			agentcore.EmitTurnCancelled(emit, "turn cancelled", usage)
-			return domain.TurnResult{
-				SessionID:     state.currentSessionID(),
-				ExitReason:    domain.EventTurnCancelled,
-				Usage:         usage,
-				UsageMeasured: state.usageMeasured,
-			}, nil
+			ev := agentcore.TurnEvidence{Terminal: agentcore.TerminalCancelled, TerminalMessage: "turn cancelled"}
+			meta := agentcore.TurnMeta{SessionID: state.currentSessionID(), Usage: state.acc.Snapshot(), UsageMeasured: state.usageMeasured}
+			result, agentErr := agentcore.FinalizeTurn(emit, state.logger(), ev, meta)
+			if agentErr != nil {
+				return result, agentErr
+			}
+			return result, nil
 
 		case <-readTimeoutC:
-			emitTurnEndedWithError(emit, "timed out waiting for first opencode json event")
 			closeStop(runtime)
 			killTurnProcess(runtime)
 			<-runtime.readerDone
 			_ = waitForProcess(runtime)
 			procutil.EmitWarnLines(runtime.stderrCollector.Lines(), state.logger())
 			clearActive(state, runtime)
-			return domain.TurnResult{
-					SessionID:     state.currentSessionID(),
-					ExitReason:    domain.EventTurnEndedWithError,
-					Usage:         state.acc.Snapshot(),
-					UsageMeasured: state.usageMeasured,
-				}, &domain.AgentError{
-					Kind:    domain.ErrResponseTimeout,
-					Message: "timed out waiting for first opencode json event",
-				}
+			ev := agentcore.TurnEvidence{
+				Terminal:          agentcore.TerminalFailure,
+				TerminalErrorKind: domain.ErrResponseTimeout,
+				TerminalMessage:   "timed out waiting for first opencode json event",
+			}
+			meta := agentcore.TurnMeta{SessionID: state.currentSessionID(), Usage: state.acc.Snapshot(), UsageMeasured: state.usageMeasured}
+			result, agentErr := agentcore.FinalizeTurn(emit, state.logger(), ev, meta)
+			if agentErr != nil {
+				return result, agentErr
+			}
+			return result, nil
 		}
 	}
 }
@@ -530,80 +526,56 @@ func (a *OpenCodeAdapter) finalizeExitedTurn(ctx context.Context, state *session
 	stderrLines := runtime.stderrCollector.Lines()
 	sessionID := state.currentSessionID()
 
-	if runtime.terminalError != nil {
-		if isMaskedServerError(rawRunErrorMessage(runtime.terminalError)) {
+	// Work reflects this turn's own parsed parts, not the run-cumulative
+	// export figure, which is non-zero on any turn after the first.
+	ev := agentcore.TurnEvidence{
+		ExitObserved: true,
+		ExitCode:     exit.exitCode,
+		Cause:        exit.err,
+		Work:         agentcore.WorkAbsent,
+		WorkDetail:   "no assistant output on the run stream",
+	}
+	if runtime.assistantOutputSeen {
+		ev.Work = agentcore.WorkPresent
+	}
+
+	switch {
+	case runtime.terminalOutcome == domain.EventTurnFailed:
+		ev.Terminal = agentcore.TerminalFailure
+		ev.TerminalErrorKind = domain.ErrTurnFailed
+		ev.Cause = nil
+		ev.TerminalMessage = rawRunErrorMessage(runtime.terminalError)
+		if isMaskedServerError(ev.TerminalMessage) {
 			if detail, ok := queryModelNotFound(ctx, state); ok {
 				state.logger().Debug("recovered masked opencode failure detail", slog.String("detail", detail))
-				agentcore.EmitTurnFailed(emit, detail, 0, snapshot)
+				ev.TerminalMessage = detail
 			}
 		}
 		procutil.EmitWarnLines(stderrLines, state.logger())
-		return domain.TurnResult{
-			SessionID:     sessionID,
-			ExitReason:    domain.EventTurnFailed,
-			Usage:         snapshot,
-			UsageMeasured: state.usageMeasured,
-		}, nil
-	}
 
-	if ctx.Err() != nil {
-		agentcore.EmitTurnCancelled(emit, "turn cancelled", snapshot)
-		return domain.TurnResult{
-			SessionID:     sessionID,
-			ExitReason:    domain.EventTurnCancelled,
-			Usage:         snapshot,
-			UsageMeasured: state.usageMeasured,
-		}, nil
-	}
+	case ctx.Err() != nil || state.isClosed():
+		ev.Terminal = agentcore.TerminalCancelled
+		ev.TerminalMessage = "turn cancelled"
+		ev.Cause = nil
 
-	if state.isClosed() {
-		agentcore.EmitTurnCancelled(emit, "turn cancelled", snapshot)
-		return domain.TurnResult{
-			SessionID:     sessionID,
-			ExitReason:    domain.EventTurnCancelled,
-			Usage:         snapshot,
-			UsageMeasured: state.usageMeasured,
-		}, nil
-	}
-
-	if !runtime.firstJSONSeen {
+	case !runtime.firstJSONSeen:
 		procutil.EmitWarnLines(stderrLines, state.logger())
-		emitTurnEndedWithError(emit, "process exited before first opencode json event")
-		return domain.TurnResult{
-				SessionID:     sessionID,
-				ExitReason:    domain.EventTurnEndedWithError,
-				Usage:         snapshot,
-				UsageMeasured: state.usageMeasured,
-			}, &domain.AgentError{
-				Kind:    domain.ErrPortExit,
-				Message: "process exited before first opencode json event",
-				Err:     exit.err,
-			}
-	}
 
-	if exit.err != nil || exit.exitCode != 0 {
+	case exit.err != nil || exit.exitCode != 0:
 		procutil.EmitWarnLines(stderrLines, state.logger())
-		message := portExitMessage(exit)
-		emitTurnEndedWithError(emit, message)
-		return domain.TurnResult{
-				SessionID:     sessionID,
-				ExitReason:    domain.EventTurnEndedWithError,
-				Usage:         snapshot,
-				UsageMeasured: state.usageMeasured,
-			}, &domain.AgentError{
-				Kind:    domain.ErrPortExit,
-				Message: message,
-				Err:     exit.err,
-			}
 	}
 
-	agentcore.EmitTurnCompleted(emit, "", 0, snapshot)
-	return domain.TurnResult{
+	meta := agentcore.TurnMeta{
 		SessionID:     sessionID,
-		ExitReason:    domain.EventTurnCompleted,
 		Usage:         snapshot,
 		UsageMeasured: state.usageMeasured,
-	}, nil
+	}
+
+	result, agentErr := agentcore.FinalizeTurn(emit, state.logger(), ev, meta)
+	if agentErr != nil {
+		return result, agentErr
+	}
+	return result, nil
 }
 
 func (s *sessionState) logger() *slog.Logger {
@@ -800,14 +772,6 @@ func exportTimeout(state *sessionState) time.Duration {
 	return timeout
 }
 
-func emitTurnEndedWithError(emit func(domain.AgentEvent), message string) {
-	emit(domain.AgentEvent{
-		Type:      domain.EventTurnEndedWithError,
-		Timestamp: time.Now().UTC(),
-		Message:   message,
-	})
-}
-
 func isPermissionWarning(line string) bool {
 	return strings.HasPrefix(strings.TrimSpace(line), "! permission requested:")
 }
@@ -843,16 +807,6 @@ const maskedServerErrorMessage = "Unexpected server error. Check server logs for
 // beyond opencode's generic server-error placeholder.
 func isMaskedServerError(message string) bool {
 	return strings.TrimSpace(message) == maskedServerErrorMessage
-}
-
-func portExitMessage(exit waitResult) string {
-	if exit.exitCode > 0 {
-		return fmt.Sprintf("opencode exited with code %d", exit.exitCode)
-	}
-	if exit.err != nil {
-		return fmt.Sprintf("opencode exited unexpectedly: %v", exit.err)
-	}
-	return "opencode exited unexpectedly"
 }
 
 func hasUsage(usage exportUsage) bool {

--- a/internal/agent/opencode/opencode_test.go
+++ b/internal/agent/opencode/opencode_test.go
@@ -5,13 +5,16 @@ package opencode
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/sortie-ai/sortie/internal/agent/agentcore"
 	"github.com/sortie-ai/sortie/internal/agent/agenttest"
+	"github.com/sortie-ai/sortie/internal/agent/agenttest/dispositiontest"
 	"github.com/sortie-ai/sortie/internal/domain"
 )
 
@@ -280,25 +283,33 @@ func TestRunTurn_SessionIDMismatch(t *testing.T) {
 	if agentErr.Kind != domain.ErrResponseError {
 		t.Errorf("Kind = %q, want %q", agentErr.Kind, domain.ErrResponseError)
 	}
-	if result.ExitReason != domain.EventTurnEndedWithError {
-		t.Errorf("ExitReason = %q, want %q", result.ExitReason, domain.EventTurnEndedWithError)
+	if result.ExitReason != domain.EventTurnFailed {
+		t.Errorf("ExitReason = %q, want %q", result.ExitReason, domain.EventTurnFailed)
 	}
 
 	var mismatchCount int
+	var mismatchMessage string
 	for _, event := range events {
 		if event.Type == domain.EventSessionStarted {
 			t.Fatalf("unexpected session_started event for mismatched session: %+v", event)
 		}
-		if event.Type == domain.EventTurnEndedWithError {
+		if event.Type == domain.EventTurnFailed {
 			mismatchCount++
+			mismatchMessage = event.Message
 			if !strings.Contains(event.Message, `expected "ses_expected"`) || !strings.Contains(event.Message, `got "ses_abc123"`) {
-				t.Errorf("turn_ended_with_error message = %q, want mismatch details", event.Message)
+				t.Errorf("turn_failed message = %q, want mismatch details", event.Message)
 			}
 		}
 	}
 	if mismatchCount != 1 {
-		t.Errorf("turn_ended_with_error count = %d, want 1", mismatchCount)
+		t.Errorf("turn_failed count = %d, want 1", mismatchCount)
 	}
+
+	dispositiontest.AssertDispositionContract(t, agentcore.TurnEvidence{
+		Terminal:          agentcore.TerminalFailure,
+		TerminalErrorKind: domain.ErrResponseError,
+		TerminalMessage:   mismatchMessage,
+	}, result, runErr)
 }
 
 func TestStopSession_NoActiveTurn(t *testing.T) {
@@ -376,8 +387,10 @@ while :; do sleep 1; done`)
 		if result.ExitReason != domain.EventTurnCancelled {
 			t.Errorf("ExitReason = %q, want %q", result.ExitReason, domain.EventTurnCancelled)
 		}
-		if runErr := <-errCh; runErr != nil {
-			t.Errorf("RunTurn() error = %v, want nil", runErr)
+		runErr := <-errCh
+		var agentErr *domain.AgentError
+		if !errors.As(runErr, &agentErr) || agentErr.Kind != domain.ErrTurnCancelled {
+			t.Errorf("RunTurn() error = %v, want AgentError{Kind: %q}", runErr, domain.ErrTurnCancelled)
 		}
 	case <-testCtx.Done():
 		t.Fatal("RunTurn did not return after StopSession timeout")
@@ -537,25 +550,38 @@ func TestRunTurn_LogicalFailureExitZero(t *testing.T) {
 	session := mustStartSession(t, a, tmpDir, script)
 
 	events, result, err := collectEvents(t, a, session, "work")
-	if err != nil {
-		t.Fatalf("RunTurn() error = %v, want nil", err)
-	}
 	if result.ExitReason != domain.EventTurnFailed {
 		t.Errorf("ExitReason = %q, want %q", result.ExitReason, domain.EventTurnFailed)
 	}
+	var agentErr *domain.AgentError
+	if !errors.As(err, &agentErr) || agentErr.Kind != domain.ErrTurnFailed {
+		t.Fatalf("RunTurn() error = %v, want AgentError{Kind: %q}", err, domain.ErrTurnFailed)
+	}
 
 	var turnFailedCount int
+	var turnFailedMessage string
 	for _, event := range events {
 		if event.Type == domain.EventTurnEndedWithError {
 			t.Fatalf("unexpected turn_ended_with_error event: %+v", event)
 		}
 		if event.Type == domain.EventTurnFailed {
 			turnFailedCount++
+			turnFailedMessage = event.Message
 		}
 	}
 	if turnFailedCount != 1 {
 		t.Errorf("turn_failed count = %d, want 1", turnFailedCount)
 	}
+
+	dispositiontest.AssertDispositionContract(t, agentcore.TurnEvidence{
+		Terminal:          agentcore.TerminalFailure,
+		TerminalErrorKind: domain.ErrTurnFailed,
+		TerminalMessage:   turnFailedMessage,
+		ExitObserved:      true,
+		ExitCode:          0,
+		Work:              agentcore.WorkAbsent,
+		WorkDetail:        "no assistant output on the run stream",
+	}, result, err)
 }
 
 func TestRunTurn_LogicalFailureDualError(t *testing.T) {
@@ -568,13 +594,18 @@ func TestRunTurn_LogicalFailureDualError(t *testing.T) {
 	session := mustStartSession(t, a, tmpDir, script)
 
 	events, result, err := collectEvents(t, a, session, "work")
-	if err != nil {
-		t.Fatalf("RunTurn() error = %v, want nil", err)
-	}
 	if result.ExitReason != domain.EventTurnFailed {
 		t.Errorf("ExitReason = %q, want %q", result.ExitReason, domain.EventTurnFailed)
 	}
+	var agentErr *domain.AgentError
+	if !errors.As(err, &agentErr) || agentErr.Kind != domain.ErrTurnFailed {
+		t.Fatalf("RunTurn() error = %v, want AgentError{Kind: %q}", err, domain.ErrTurnFailed)
+	}
 
+	// Exactly one terminal event fires per turn: the second "error"
+	// event on the run stream overwrites the first in per-turn state, so
+	// only the last error's detail survives to the single emitted
+	// turn_failed event.
 	var turnFailedMessages []string
 	for _, event := range events {
 		if event.Type == domain.EventTurnEndedWithError {
@@ -584,15 +615,22 @@ func TestRunTurn_LogicalFailureDualError(t *testing.T) {
 			turnFailedMessages = append(turnFailedMessages, event.Message)
 		}
 	}
-	if len(turnFailedMessages) != 2 {
-		t.Fatalf("turn_failed count = %d, want 2 (one per upstream error event)", len(turnFailedMessages))
+	if len(turnFailedMessages) != 1 {
+		t.Fatalf("turn_failed count = %d, want 1; messages = %q", len(turnFailedMessages), turnFailedMessages)
 	}
-	if !strings.Contains(turnFailedMessages[0], "Model not found") {
-		t.Errorf("first turn_failed message = %q, want substring %q", turnFailedMessages[0], "Model not found")
+	if !strings.Contains(turnFailedMessages[0], "Unexpected server error") {
+		t.Errorf("turn_failed message = %q, want substring %q (the last error event on the stream)", turnFailedMessages[0], "Unexpected server error")
 	}
-	if !strings.Contains(turnFailedMessages[1], "Unexpected server error") {
-		t.Errorf("second turn_failed message = %q, want substring %q", turnFailedMessages[1], "Unexpected server error")
-	}
+
+	dispositiontest.AssertDispositionContract(t, agentcore.TurnEvidence{
+		Terminal:          agentcore.TerminalFailure,
+		TerminalErrorKind: domain.ErrTurnFailed,
+		TerminalMessage:   turnFailedMessages[0],
+		ExitObserved:      true,
+		ExitCode:          0,
+		Work:              agentcore.WorkAbsent,
+		WorkDetail:        "no assistant output on the run stream",
+	}, result, err)
 }
 
 // writeMaskedRunScript writes a fake opencode whose run stream emits only the
@@ -629,6 +667,17 @@ func collectTurnFailedMessages(events []domain.AgentEvent) []string {
 	return messages
 }
 
+// turnFailedEvents returns every turn_failed event in events, in order.
+func turnFailedEvents(events []domain.AgentEvent) []domain.AgentEvent {
+	var out []domain.AgentEvent
+	for _, e := range events {
+		if e.Type == domain.EventTurnFailed {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
 func TestRunTurn_MaskedErrorRecoversModelNotFound(t *testing.T) {
 	t.Parallel()
 
@@ -639,23 +688,36 @@ func TestRunTurn_MaskedErrorRecoversModelNotFound(t *testing.T) {
 	session := mustStartSession(t, a, tmpDir, script)
 
 	events, result, err := collectEvents(t, a, session, "work")
-	if err != nil {
-		t.Fatalf("RunTurn() error = %v, want nil", err)
-	}
 	if result.ExitReason != domain.EventTurnFailed {
 		t.Errorf("ExitReason = %q, want %q", result.ExitReason, domain.EventTurnFailed)
 	}
+	var agentErr *domain.AgentError
+	if !errors.As(err, &agentErr) || agentErr.Kind != domain.ErrTurnFailed {
+		t.Fatalf("RunTurn() error = %v, want AgentError{Kind: %q}", err, domain.ErrTurnFailed)
+	}
 
+	// Exactly one terminal event fires per turn even when the
+	// masked-model recovery succeeds: the recovered detail replaces the
+	// masked relay message in place, rather than the two-event trail
+	// this arm produced before the shared decision.
 	messages := collectTurnFailedMessages(events)
-	if len(messages) != 2 {
-		t.Fatalf("turn_failed count = %d, want 2 (masked relay plus recovered detail), messages=%q", len(messages), messages)
+	if len(messages) != 1 {
+		t.Fatalf("turn_failed count = %d, want 1 (the recovered detail replaces the masked relay), messages=%q", len(messages), messages)
 	}
-	if !strings.Contains(messages[0], "Unexpected server error") {
-		t.Errorf("first turn_failed message = %q, want substring %q", messages[0], "Unexpected server error")
+	const wantMessage = "Model not found: nonexistent/nonexistent"
+	if messages[0] != wantMessage {
+		t.Errorf("turn_failed message = %q, want %q", messages[0], wantMessage)
 	}
-	if messages[1] != "Model not found: nonexistent/nonexistent" {
-		t.Errorf("second turn_failed message = %q, want %q", messages[1], "Model not found: nonexistent/nonexistent")
-	}
+
+	dispositiontest.AssertDispositionContract(t, agentcore.TurnEvidence{
+		Terminal:          agentcore.TerminalFailure,
+		TerminalErrorKind: domain.ErrTurnFailed,
+		TerminalMessage:   wantMessage,
+		ExitObserved:      true,
+		ExitCode:          0,
+		Work:              agentcore.WorkAbsent,
+		WorkDetail:        "no assistant output on the run stream",
+	}, result, err)
 }
 
 func TestRunTurn_MaskedErrorModelListed(t *testing.T) {
@@ -668,11 +730,12 @@ func TestRunTurn_MaskedErrorModelListed(t *testing.T) {
 	session := mustStartSession(t, a, tmpDir, script)
 
 	events, result, err := collectEvents(t, a, session, "work")
-	if err != nil {
-		t.Fatalf("RunTurn() error = %v, want nil", err)
-	}
 	if result.ExitReason != domain.EventTurnFailed {
 		t.Errorf("ExitReason = %q, want %q", result.ExitReason, domain.EventTurnFailed)
+	}
+	var agentErr *domain.AgentError
+	if !errors.As(err, &agentErr) || agentErr.Kind != domain.ErrTurnFailed {
+		t.Fatalf("RunTurn() error = %v, want AgentError{Kind: %q}", err, domain.ErrTurnFailed)
 	}
 
 	messages := collectTurnFailedMessages(events)
@@ -682,6 +745,16 @@ func TestRunTurn_MaskedErrorModelListed(t *testing.T) {
 	if !strings.Contains(messages[0], "Unexpected server error") {
 		t.Errorf("turn_failed message = %q, want substring %q", messages[0], "Unexpected server error")
 	}
+
+	dispositiontest.AssertDispositionContract(t, agentcore.TurnEvidence{
+		Terminal:          agentcore.TerminalFailure,
+		TerminalErrorKind: domain.ErrTurnFailed,
+		TerminalMessage:   messages[0],
+		ExitObserved:      true,
+		ExitCode:          0,
+		Work:              agentcore.WorkAbsent,
+		WorkDetail:        "no assistant output on the run stream",
+	}, result, err)
 }
 
 func TestRunTurn_MaskedErrorModelsCommandFails(t *testing.T) {
@@ -694,11 +767,12 @@ func TestRunTurn_MaskedErrorModelsCommandFails(t *testing.T) {
 	session := mustStartSession(t, a, tmpDir, script)
 
 	events, result, err := collectEvents(t, a, session, "work")
-	if err != nil {
-		t.Fatalf("RunTurn() error = %v, want nil", err)
-	}
 	if result.ExitReason != domain.EventTurnFailed {
 		t.Errorf("ExitReason = %q, want %q", result.ExitReason, domain.EventTurnFailed)
+	}
+	var agentErr *domain.AgentError
+	if !errors.As(err, &agentErr) || agentErr.Kind != domain.ErrTurnFailed {
+		t.Fatalf("RunTurn() error = %v, want AgentError{Kind: %q}", err, domain.ErrTurnFailed)
 	}
 
 	messages := collectTurnFailedMessages(events)
@@ -708,6 +782,16 @@ func TestRunTurn_MaskedErrorModelsCommandFails(t *testing.T) {
 	if !strings.Contains(messages[0], "Unexpected server error") {
 		t.Errorf("turn_failed message = %q, want substring %q", messages[0], "Unexpected server error")
 	}
+
+	dispositiontest.AssertDispositionContract(t, agentcore.TurnEvidence{
+		Terminal:          agentcore.TerminalFailure,
+		TerminalErrorKind: domain.ErrTurnFailed,
+		TerminalMessage:   messages[0],
+		ExitObserved:      true,
+		ExitCode:          0,
+		Work:              agentcore.WorkAbsent,
+		WorkDetail:        "no assistant output on the run stream",
+	}, result, err)
 }
 
 func TestRunTurn_MaskedErrorNoModelConfigured(t *testing.T) {
@@ -721,20 +805,31 @@ func TestRunTurn_MaskedErrorNoModelConfigured(t *testing.T) {
 	session := mustStartSession(t, a, tmpDir, script)
 
 	events, result, err := collectEvents(t, a, session, "work")
-	if err != nil {
-		t.Fatalf("RunTurn() error = %v, want nil", err)
-	}
 	if result.ExitReason != domain.EventTurnFailed {
 		t.Errorf("ExitReason = %q, want %q", result.ExitReason, domain.EventTurnFailed)
+	}
+	var agentErr *domain.AgentError
+	if !errors.As(err, &agentErr) || agentErr.Kind != domain.ErrTurnFailed {
+		t.Fatalf("RunTurn() error = %v, want AgentError{Kind: %q}", err, domain.ErrTurnFailed)
 	}
 
 	messages := collectTurnFailedMessages(events)
 	if len(messages) != 1 {
 		t.Fatalf("turn_failed count = %d, want 1, messages=%q", len(messages), messages)
 	}
-	if _, err := os.Stat(sentinel); !errors.Is(err, os.ErrNotExist) {
-		t.Errorf("models subcommand was invoked without a configured model (sentinel stat err = %v)", err)
+	if _, statErr := os.Stat(sentinel); !errors.Is(statErr, os.ErrNotExist) {
+		t.Errorf("models subcommand was invoked without a configured model (sentinel stat err = %v)", statErr)
 	}
+
+	dispositiontest.AssertDispositionContract(t, agentcore.TurnEvidence{
+		Terminal:          agentcore.TerminalFailure,
+		TerminalErrorKind: domain.ErrTurnFailed,
+		TerminalMessage:   messages[0],
+		ExitObserved:      true,
+		ExitCode:          0,
+		Work:              agentcore.WorkAbsent,
+		WorkDetail:        "no assistant output on the run stream",
+	}, result, err)
 }
 
 func TestRunTurn_OversizedStdoutLine(t *testing.T) {
@@ -747,7 +842,7 @@ printf '\n'`)
 	a, _ := NewOpenCodeAdapter(map[string]any{})
 	session := mustStartSession(t, a, tmpDir, script)
 
-	_, result, err := collectEvents(t, a, session, "work")
+	events, result, err := collectEvents(t, a, session, "work")
 	if err == nil {
 		t.Fatal("RunTurn() error = nil, want oversized-line failure")
 	}
@@ -758,9 +853,23 @@ printf '\n'`)
 	if agentErr.Kind != domain.ErrResponseError {
 		t.Errorf("Kind = %q, want %q", agentErr.Kind, domain.ErrResponseError)
 	}
-	if result.ExitReason != domain.EventTurnEndedWithError {
-		t.Errorf("ExitReason = %q, want %q", result.ExitReason, domain.EventTurnEndedWithError)
+	if result.ExitReason != domain.EventTurnFailed {
+		t.Errorf("ExitReason = %q, want %q", result.ExitReason, domain.EventTurnFailed)
 	}
+
+	failedEvents := turnFailedEvents(events)
+	if len(failedEvents) != 1 {
+		t.Fatalf("turn_failed event count = %d, want 1", len(failedEvents))
+	}
+	if failedEvents[0].Message != "stdout read error" {
+		t.Errorf("turn_failed Message = %q, want %q", failedEvents[0].Message, "stdout read error")
+	}
+
+	dispositiontest.AssertDispositionContract(t, agentcore.TurnEvidence{
+		Terminal:          agentcore.TerminalFailure,
+		TerminalErrorKind: domain.ErrResponseError,
+		TerminalMessage:   "stdout read error",
+	}, result, err)
 }
 
 func TestRunTurn_EventAgentPID(t *testing.T) {
@@ -851,6 +960,12 @@ func TestRunTurn_UsageMeasured_AbsentWhenExportYieldsNoUsage(t *testing.T) {
 	}
 
 	agenttest.AssertMeasurementAbsent(t, events, result)
+
+	dispositiontest.AssertDispositionContract(t, agentcore.TurnEvidence{
+		ExitObserved: true,
+		ExitCode:     0,
+		Work:         agentcore.WorkPresent,
+	}, result, err)
 }
 
 // TestRunTurn_UsageMeasured_TrueWhenExportYieldsUsage verifies that a
@@ -895,11 +1010,17 @@ func TestRunTurn_ActivityVisibilityForStallWatchdog(t *testing.T) {
 	t.Parallel()
 
 	tmpDir := t.TempDir()
+	// A "text" part carries the turn's own work evidence, keeping this
+	// turn on row R7 (turn_completed) so the test still exercises
+	// notification, malformed-event, and session-lifecycle visibility
+	// during an otherwise-successful turn, rather than becoming a
+	// duplicate of the dedicated zero-work-row pin.
 	script := writeOpenCodeScript(t, tmpDir, `case "$1" in
   export) echo '{"messages":[]}'; exit 0;;
 esac
 printf '! permission requested: external_directory (/etc/*); auto-rejecting\n'
 printf '{"type":"step_start","timestamp":1000,"sessionID":"ses_visibility123","part":{"id":"p1","messageID":"m1","sessionID":"ses_visibility123","snapshot":"","type":"step-start"}}\n'
+printf '{"type":"text","timestamp":1001,"sessionID":"ses_visibility123","part":{"id":"p3","messageID":"m1","sessionID":"ses_visibility123","type":"text","text":"working on it","time":{"start":1001,"end":1001}}}\n'
 printf '{"type":"unknown_future_type","timestamp":1001,"sessionID":"ses_visibility123","data":"something"}\n'
 printf '{"type":"step_finish","timestamp":1002,"sessionID":"ses_visibility123","part":{"id":"p2","messageID":"m1","sessionID":"ses_visibility123","type":"step-finish","reason":"stop"}}\n'`)
 
@@ -961,6 +1082,12 @@ printf '{"type":"step_finish","timestamp":1002,"sessionID":"ses_visibility123","
 	if !sawTurnCompleted {
 		t.Error("turn_completed event was not emitted")
 	}
+
+	dispositiontest.AssertDispositionContract(t, agentcore.TurnEvidence{
+		ExitObserved: true,
+		ExitCode:     0,
+		Work:         agentcore.WorkPresent,
+	}, result, err)
 }
 
 func TestRunTurn_TurnCancelledOnContextCancel(t *testing.T) {
@@ -1021,8 +1148,10 @@ sleep 1000`)
 		if result.ExitReason != domain.EventTurnCancelled {
 			t.Errorf("ExitReason = %q, want %q", result.ExitReason, domain.EventTurnCancelled)
 		}
-		if err := <-errCh; err != nil {
-			t.Errorf("RunTurn() error = %v, want nil on cancel", err)
+		err := <-errCh
+		var agentErr *domain.AgentError
+		if !errors.As(err, &agentErr) || agentErr.Kind != domain.ErrTurnCancelled {
+			t.Errorf("RunTurn() error = %v, want AgentError{Kind: %q}", err, domain.ErrTurnCancelled)
 		}
 	case <-outerCtx.Done():
 		t.Fatal("RunTurn did not return after context cancel")
@@ -1100,4 +1229,240 @@ sleep 1000`)
 func mustMakeTempDir(t *testing.T) string {
 	t.Helper()
 	return t.TempDir()
+}
+
+// TestRunTurn_ExitZeroNoAssistantOutputPart pins that a process which
+// exits 0 having parsed JSON events but never a text, reasoning, or
+// tool_use part reports turn_failed, not the silent success this class
+// of bug produced before the shared decision.
+func TestRunTurn_ExitZeroNoAssistantOutputPart(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	script := writeOpenCodeScript(t, tmpDir, `case "$1" in
+  export) echo '{"messages":[]}'; exit 0;;
+esac
+printf '{"type":"step_start","timestamp":1000,"sessionID":"ses_c1","part":{"id":"p1","messageID":"m1","sessionID":"ses_c1","snapshot":"","type":"step-start"}}\n'
+printf '{"type":"step_finish","timestamp":1001,"sessionID":"ses_c1","part":{"id":"p2","messageID":"m1","sessionID":"ses_c1","type":"step-finish","reason":"stop"}}\n'`)
+
+	a, _ := NewOpenCodeAdapter(map[string]any{})
+	session := mustStartSession(t, a, tmpDir, script)
+
+	events, result, err := collectEvents(t, a, session, "work")
+	if result.ExitReason != domain.EventTurnFailed {
+		t.Errorf("ExitReason = %q, want %q", result.ExitReason, domain.EventTurnFailed)
+	}
+	var agentErr *domain.AgentError
+	if !errors.As(err, &agentErr) || agentErr.Kind != domain.ErrTurnFailed {
+		t.Fatalf("RunTurn() error = %v, want AgentError{Kind: %q}", err, domain.ErrTurnFailed)
+	}
+	const wantMessage = "agent exited without producing output: no assistant output on the run stream"
+	if agentErr.Message != wantMessage {
+		t.Errorf("AgentError.Message = %q, want %q", agentErr.Message, wantMessage)
+	}
+
+	failedEvents := turnFailedEvents(events)
+	if len(failedEvents) != 1 {
+		t.Fatalf("turn_failed event count = %d, want 1", len(failedEvents))
+	}
+
+	dispositiontest.AssertDispositionContract(t, agentcore.TurnEvidence{
+		ExitObserved: true,
+		ExitCode:     0,
+		Work:         agentcore.WorkAbsent,
+		WorkDetail:   "no assistant output on the run stream",
+	}, result, err)
+}
+
+// TestRunTurn_ExitZeroNoJSONEventAtAll pins an emptier variant of the
+// no-output case: the process exits 0 having emitted nothing parseable
+// at all. It routes to the same zero-work row rather than letting the
+// adapter pre-classify a bare exit 0 as a success.
+func TestRunTurn_ExitZeroNoJSONEventAtAll(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	script := writeOpenCodeScript(t, tmpDir, `case "$1" in
+  export) echo '{"messages":[]}'; exit 0;;
+esac
+exit 0`)
+
+	a, _ := NewOpenCodeAdapter(map[string]any{})
+	session := mustStartSession(t, a, tmpDir, script)
+
+	events, result, err := collectEvents(t, a, session, "work")
+	if result.ExitReason != domain.EventTurnFailed {
+		t.Errorf("ExitReason = %q, want %q", result.ExitReason, domain.EventTurnFailed)
+	}
+	var agentErr *domain.AgentError
+	if !errors.As(err, &agentErr) || agentErr.Kind != domain.ErrTurnFailed {
+		t.Fatalf("RunTurn() error = %v, want AgentError{Kind: %q}", err, domain.ErrTurnFailed)
+	}
+	const wantMessage = "agent exited without producing output: no assistant output on the run stream"
+	if agentErr.Message != wantMessage {
+		t.Errorf("AgentError.Message = %q, want %q", agentErr.Message, wantMessage)
+	}
+
+	failedEvents := turnFailedEvents(events)
+	if len(failedEvents) != 1 {
+		t.Fatalf("turn_failed event count = %d, want 1", len(failedEvents))
+	}
+
+	dispositiontest.AssertDispositionContract(t, agentcore.TurnEvidence{
+		ExitObserved: true,
+		ExitCode:     0,
+		Work:         agentcore.WorkAbsent,
+		WorkDetail:   "no assistant output on the run stream",
+	}, result, err)
+}
+
+// TestRunTurn_NonZeroExitNoTerminalReport pins the non-zero-exit
+// transport-class abort: the disposition, kind, and message pair are the
+// same ones every adapter produces for this row.
+func TestRunTurn_NonZeroExitNoTerminalReport(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	script := writeOpenCodeScript(t, tmpDir, `case "$1" in
+  export) echo '{"messages":[]}'; exit 0;;
+esac
+printf '{"type":"step_start","timestamp":1000,"sessionID":"ses_nonzero","part":{"id":"p1","messageID":"m1","sessionID":"ses_nonzero","snapshot":"","type":"step-start"}}\n'
+exit 7`)
+
+	a, _ := NewOpenCodeAdapter(map[string]any{})
+	session := mustStartSession(t, a, tmpDir, script)
+
+	events, result, err := collectEvents(t, a, session, "work")
+	if result.ExitReason != domain.EventTurnFailed {
+		t.Errorf("ExitReason = %q, want %q", result.ExitReason, domain.EventTurnFailed)
+	}
+	var agentErr *domain.AgentError
+	if !errors.As(err, &agentErr) || agentErr.Kind != domain.ErrPortExit {
+		t.Fatalf("RunTurn() error = %v, want AgentError{Kind: %q}", err, domain.ErrPortExit)
+	}
+	if agentErr.Message != "exit code 7" {
+		t.Errorf("AgentError.Message = %q, want %q", agentErr.Message, "exit code 7")
+	}
+
+	failedEvents := turnFailedEvents(events)
+	if len(failedEvents) != 1 {
+		t.Fatalf("turn_failed event count = %d, want 1", len(failedEvents))
+	}
+	if failedEvents[0].Message != "non-zero exit" {
+		t.Errorf("turn_failed Message = %q, want %q", failedEvents[0].Message, "non-zero exit")
+	}
+
+	dispositiontest.AssertDispositionContract(t, agentcore.TurnEvidence{
+		ExitObserved: true,
+		ExitCode:     7,
+		Work:         agentcore.WorkAbsent,
+	}, result, err)
+}
+
+// TestRunTurn_ReadTimeoutBeforeFirstJSONEvent pins the read-timeout
+// transport-class abort: the disposition, kind, and message pair are the
+// same ones today's arm already produces.
+func TestRunTurn_ReadTimeoutBeforeFirstJSONEvent(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	script := writeOpenCodeScript(t, tmpDir, `case "$1" in
+  export) echo '{"messages":[]}'; exit 0;;
+esac
+sleep 5`)
+
+	a, _ := NewOpenCodeAdapter(map[string]any{})
+	session, err := a.StartSession(context.Background(), domain.StartSessionParams{
+		WorkspacePath: tmpDir,
+		AgentConfig:   domain.AgentConfig{Command: script, ReadTimeoutMS: 100},
+	})
+	if err != nil {
+		t.Fatalf("StartSession() error = %v", err)
+	}
+
+	events, result, err := collectEvents(t, a, session, "work")
+	if result.ExitReason != domain.EventTurnFailed {
+		t.Errorf("ExitReason = %q, want %q", result.ExitReason, domain.EventTurnFailed)
+	}
+	var agentErr *domain.AgentError
+	if !errors.As(err, &agentErr) || agentErr.Kind != domain.ErrResponseTimeout {
+		t.Fatalf("RunTurn() error = %v, want AgentError{Kind: %q}", err, domain.ErrResponseTimeout)
+	}
+	const wantMessage = "timed out waiting for first opencode json event"
+	if agentErr.Message != wantMessage {
+		t.Errorf("AgentError.Message = %q, want %q", agentErr.Message, wantMessage)
+	}
+
+	failedEvents := turnFailedEvents(events)
+	if len(failedEvents) != 1 {
+		t.Fatalf("turn_failed event count = %d, want 1", len(failedEvents))
+	}
+
+	dispositiontest.AssertDispositionContract(t, agentcore.TurnEvidence{
+		Terminal:          agentcore.TerminalFailure,
+		TerminalErrorKind: domain.ErrResponseTimeout,
+		TerminalMessage:   wantMessage,
+	}, result, err)
+}
+
+// TestRunTurn_CompletedTurnReturnsUntypedNilError pins that a completed
+// turn's returned error interface is genuinely nil, not a typed-nil
+// *domain.AgentError promoted to a non-nil error interface.
+func TestRunTurn_CompletedTurnReturnsUntypedNilError(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	script := writeRunFixtureScript(t, tmpDir, "simple_turn.jsonl")
+
+	a, _ := NewOpenCodeAdapter(map[string]any{})
+	session := mustStartSession(t, a, tmpDir, script)
+
+	_, result, err := collectEvents(t, a, session, "work")
+	if result.ExitReason != domain.EventTurnCompleted {
+		t.Fatalf("ExitReason = %q, want %q", result.ExitReason, domain.EventTurnCompleted)
+	}
+	if err != nil {
+		t.Errorf("RunTurn() error = %v, want nil (not a typed-nil *domain.AgentError)", err)
+	}
+}
+
+// TestRunTurn_WorkPredicateIsPerTurn pins that the work predicate reads
+// this turn's own parsed parts, not the run cumulative. The first turn
+// produces a text part and completes; the second turn, on the same
+// session, produces none and must fail rather than inherit the first
+// turn's evidence.
+func TestRunTurn_WorkPredicateIsPerTurn(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	counterFile := filepath.Join(tmpDir, "turn-count")
+	script := writeOpenCodeScript(t, tmpDir, fmt.Sprintf(`case "$1" in
+  export) echo '{"messages":[]}'; exit 0;;
+esac
+if [ -f '%s' ]; then
+  printf '{"type":"step_start","timestamp":1000,"sessionID":"ses_work_pin","part":{"id":"p1","messageID":"m1","sessionID":"ses_work_pin","snapshot":"","type":"step-start"}}\n'
+else
+  touch '%s'
+  printf '{"type":"text","timestamp":1000,"sessionID":"ses_work_pin","part":{"id":"p1","messageID":"m1","sessionID":"ses_work_pin","type":"text","text":"ok","time":{"start":1000,"end":1000}}}\n'
+fi`, counterFile, counterFile))
+
+	a, _ := NewOpenCodeAdapter(map[string]any{})
+	session := mustStartSession(t, a, tmpDir, script)
+
+	_, result1, err := collectEvents(t, a, session, "first")
+	if err != nil {
+		t.Fatalf("RunTurn(first) error = %v", err)
+	}
+	if result1.ExitReason != domain.EventTurnCompleted {
+		t.Fatalf("RunTurn(first).ExitReason = %q, want %q", result1.ExitReason, domain.EventTurnCompleted)
+	}
+
+	_, result2, err := collectEvents(t, a, session, "second")
+	if result2.ExitReason != domain.EventTurnFailed {
+		t.Errorf("RunTurn(second).ExitReason = %q, want %q (per-turn work predicate must not carry the first turn's output forward)", result2.ExitReason, domain.EventTurnFailed)
+	}
+	var agentErr *domain.AgentError
+	if !errors.As(err, &agentErr) || agentErr.Kind != domain.ErrTurnFailed {
+		t.Errorf("RunTurn(second) error = %v, want AgentError{Kind: %q}", err, domain.ErrTurnFailed)
+	}
 }


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Fix

**Intent:** Move turn-disposition logic - deciding whether a turn completed, failed, or was cancelled - out of each of the five agent adapters into one shared decision in `internal/agent/agentcore`, so the rule is stated once and a new adapter inherits it instead of re-deriving it. Converting `kiro`, `codex`, and `opencode` to the shared decision closes real divergences: an `opencode` turn that produced no model output at all was reported as completed, and failed or cancelled turns on `opencode` and `codex` reported no error text.

### 🧭 Reviewer Guide

**Complexity:** High

#### Entry Point

`internal/agent/agentcore/disposition.go` - the shared `DecideTurn`/`FinalizeTurn` decision every adapter now routes through. `DecideTurn` resolves a turn's outcome from its terminal report, its process exit, and its per-turn work evidence; `FinalizeTurn` emits the matching event and builds the returned error, so adapters no longer construct a `domain.AgentEvent` or `domain.AgentError` for their own outcome. Read this file first, then the two adapter commits that follow it.

#### Sensitive Areas

- `internal/agent/opencode/opencode.go`: the zero-output-turn fix and the `exit_reason` rename change what the orchestrator sees for a real running fleet - a turn that used to advance an issue on nothing now fails and retries instead.
- `internal/agent/codex/codex.go`: failed and cancelled turns now carry error text they previously reported as `nil`, and `turns_completed` counting changes for this adapter.
- `internal/agent/agentcore/disposition_contract_test.go`: a syntactic `go/ast` check that fails if any adapter outside `agentcore`/`mock` constructs a turn-outcome event or error directly, enforcing the shared decision as an invariant rather than a convention.

### ⚠️ Risk Assessment

- **Breaking Changes:** Yes - operator-facing, not API-breaking. `opencode` transport failures now report `exit_reason=turn_failed` instead of `turn_ended_with_error` (an alert or dashboard filter on the old value must match the error kind instead); turn failure text is now identical across every coding agent; and `run_history.turns_completed` no longer counts a turn that ended in failure or cancellation on `opencode` and `codex`, so turn counts and mean turns per run drop for those two agents at this release with no behavior change behind the numbers.
- **Migrations/State:** No migrations or state changes. No `run_history` column is added; existing rows keep their previous meaning.
