### PR TITLE
chore(release): adopt v-prefixed release tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Release version (semver, e.g. 1.0.0 or 1.0.0-rc.1 - no 'v' prefix)"
+        description: "Release version"
         required: true
         type: string
       dry_run:
@@ -25,15 +25,25 @@ jobs:
   validate:
     name: Validate inputs
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.normalize.outputs.version }}
+      tag: ${{ steps.normalize.outputs.tag }}
     steps:
-      - name: Validate version format
+      # An optional leading "v" is accepted and stripped, so both 1.0.0 and
+      # v1.0.0 are valid input. Downstream jobs consume the normalized pair:
+      # bare version for artifact names, image tags and CHANGELOG lookups, and
+      # the v-prefixed tag for git.
+      - name: Normalize and validate version
+        id: normalize
         run: |
-          VERSION='${{ inputs.version }}'
+          INPUT='${{ inputs.version }}'
+          VERSION="${INPUT#[vV]}"
           if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+(\.[a-zA-Z0-9]+)*)?$ ]]; then
-            echo "::error::Invalid version format: '${VERSION}'. Expected semver (e.g. 1.0.0 or 1.0.0-rc.1)"
+            echo "::error::Invalid version format: '${INPUT}'. Expected semver (e.g. 1.0.0, v1.0.0 or 1.0.0-rc.1)"
             exit 1
           fi
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "tag=v${VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Check tag does not already exist
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -42,7 +52,7 @@ jobs:
 
       - name: Verify tag is new
         run: |
-          TAG='${{ inputs.version }}'
+          TAG='${{ steps.normalize.outputs.tag }}'
           if git rev-parse "$TAG" >/dev/null 2>&1; then
             echo "::error::Tag ${TAG} already exists. Delete it first or choose a different version."
             exit 1
@@ -51,7 +61,7 @@ jobs:
 
       - name: Verify CHANGELOG.md contains release version
         run: |
-          VERSION='${{ inputs.version }}'
+          VERSION='${{ steps.normalize.outputs.version }}'
           if ! grep -qP "^## \[${VERSION}\]" CHANGELOG.md; then
             echo "::error::CHANGELOG.md has no entry for version ${VERSION}. Add a '## [${VERSION}] - YYYY-MM-DD' section before releasing."
             exit 1
@@ -445,6 +455,7 @@ jobs:
   release:
     name: Tag & Release
     needs:
+      - validate
       - lint
       - test-unit
       - test-integration-jira
@@ -504,7 +515,7 @@ jobs:
       - name: Create and push tag
         if: ${{ !inputs.dry_run }}
         run: |
-          TAG='${{ inputs.version }}'
+          TAG='${{ needs.validate.outputs.tag }}'
           git config user.name  "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git tag -a "$TAG" -m "Release ${TAG}"
@@ -514,7 +525,7 @@ jobs:
       - name: Create local tag (dry run)
         if: ${{ inputs.dry_run }}
         run: |
-          TAG='${{ inputs.version }}'
+          TAG='${{ needs.validate.outputs.tag }}'
           git config user.name  "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git tag -a "$TAG" -m "Dry run ${TAG}"
@@ -536,27 +547,27 @@ jobs:
       - name: Release summary
         if: ${{ !inputs.dry_run }}
         run: |
-          echo "### Release ${{ inputs.version }} published" >> "$GITHUB_STEP_SUMMARY"
+          echo "### Release ${{ needs.validate.outputs.version }} published" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "**Artifacts:**" >> "$GITHUB_STEP_SUMMARY"
-          echo "- \`sortie_${{ inputs.version }}_linux_amd64.tar.gz\`" >> "$GITHUB_STEP_SUMMARY"
-          echo "- \`sortie_${{ inputs.version }}_linux_arm64.tar.gz\`" >> "$GITHUB_STEP_SUMMARY"
-          echo "- \`sortie_${{ inputs.version }}_darwin_amd64.tar.gz\`" >> "$GITHUB_STEP_SUMMARY"
-          echo "- \`sortie_${{ inputs.version }}_darwin_arm64.tar.gz\`" >> "$GITHUB_STEP_SUMMARY"
-          echo "- \`sortie_${{ inputs.version }}_windows_amd64.zip\`" >> "$GITHUB_STEP_SUMMARY"
-          echo "- \`sortie_${{ inputs.version }}_windows_arm64.zip\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- \`sortie_${{ needs.validate.outputs.version }}_linux_amd64.tar.gz\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- \`sortie_${{ needs.validate.outputs.version }}_linux_arm64.tar.gz\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- \`sortie_${{ needs.validate.outputs.version }}_darwin_amd64.tar.gz\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- \`sortie_${{ needs.validate.outputs.version }}_darwin_arm64.tar.gz\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- \`sortie_${{ needs.validate.outputs.version }}_windows_amd64.zip\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- \`sortie_${{ needs.validate.outputs.version }}_windows_arm64.zip\`" >> "$GITHUB_STEP_SUMMARY"
           echo "- \`checksums.txt\`" >> "$GITHUB_STEP_SUMMARY"
           echo "- SBOM manifests (\`*.sbom.json\`)" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Dry run summary
         if: ${{ inputs.dry_run }}
         run: |
-          echo "### Dry run complete for ${{ inputs.version }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "### Dry run complete for ${{ needs.validate.outputs.version }}" >> "$GITHUB_STEP_SUMMARY"
           echo "No tag was created and no release was published." >> "$GITHUB_STEP_SUMMARY"
 
   docker:
     name: Docker image
-    needs: [release]
+    needs: [validate, release]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -570,7 +581,7 @@ jobs:
       - name: Determine pre-release
         id: prerelease
         run: |
-          VERSION='${{ inputs.version }}'
+          VERSION='${{ needs.validate.outputs.version }}'
           if [[ "$VERSION" == *-* ]]; then
             echo "is_prerelease=true" >> "$GITHUB_OUTPUT"
           else
@@ -599,9 +610,9 @@ jobs:
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |
-            type=semver,pattern={{version}},value=${{ inputs.version }}
-            type=semver,pattern={{major}}.{{minor}},value=${{ inputs.version }}
-            type=semver,pattern={{major}},value=${{ inputs.version }},enable=${{ steps.prerelease.outputs.is_prerelease == 'false' }}
+            type=semver,pattern={{version}},value=${{ needs.validate.outputs.version }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ needs.validate.outputs.version }}
+            type=semver,pattern={{major}},value=${{ needs.validate.outputs.version }},enable=${{ steps.prerelease.outputs.is_prerelease == 'false' }}
 
       - name: Build and push
         id: build
@@ -614,7 +625,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           annotations: ${{ steps.meta.outputs.annotations }}
           build-args: |
-            VERSION=${{ inputs.version }}
+            VERSION=${{ needs.validate.outputs.version }}
             REVISION=${{ github.sha }}
             BUILD_DATE=${{ env.BUILD_DATE }}
           provenance: mode=max

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -547,7 +547,7 @@ jobs:
       - name: Release summary
         if: ${{ !inputs.dry_run }}
         run: |
-          echo "### Release ${{ needs.validate.outputs.version }} published" >> "$GITHUB_STEP_SUMMARY"
+          echo "### Release ${{ needs.validate.outputs.tag }} published" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "**Artifacts:**" >> "$GITHUB_STEP_SUMMARY"
           echo "- \`sortie_${{ needs.validate.outputs.version }}_linux_amd64.tar.gz\`" >> "$GITHUB_STEP_SUMMARY"
@@ -562,7 +562,7 @@ jobs:
       - name: Dry run summary
         if: ${{ inputs.dry_run }}
         run: |
-          echo "### Dry run complete for ${{ needs.validate.outputs.version }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "### Dry run complete for ${{ needs.validate.outputs.tag }}" >> "$GITHUB_STEP_SUMMARY"
           echo "No tag was created and no release was published." >> "$GITHUB_STEP_SUMMARY"
 
   docker:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -191,6 +191,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   reports `scm_api_error`; only a rejected merge reports a conflict. An
   operator's alert on `scm_conflict_error` now fires on merges only.
 
+- Release tags now carry a `v` prefix (`v1.19.0`). Every earlier version
+  was additionally tagged under its prefixed name against the same
+  commit, so the Go module proxy now publishes the full version list and
+  `go install github.com/sortie-ai/sortie/cmd/sortie@v1.18.0` resolves;
+  it previously published no versions at all, leaving the module
+  installable only at a pseudo-version. The install scripts for macOS,
+  Linux, and Windows take a pinned version with or without the prefix,
+  so an existing `SORTIE_VERSION=1.18.0` or `--version 1.18.0` still
+  selects that release.
+
 ### Migrations
 
 - Add `tokens_measured INTEGER NOT NULL DEFAULT 1` to `run_history`;
@@ -1545,41 +1555,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   execution via GitHub Actions.
 - Architecture Decision Records (ADR-0001 through ADR-0005).
 
-[Unreleased]: https://github.com/sortie-ai/sortie/compare/1.18.0...HEAD
-[1.18.0]: https://github.com/sortie-ai/sortie/compare/1.17.0...1.18.0
-[1.17.0]: https://github.com/sortie-ai/sortie/compare/1.16.1...1.17.0
-[1.16.1]: https://github.com/sortie-ai/sortie/compare/1.16.0...1.16.1
-[1.16.0]: https://github.com/sortie-ai/sortie/compare/1.15.0...1.16.0
-[1.15.0]: https://github.com/sortie-ai/sortie/compare/1.14.1...1.15.0
-[1.14.1]: https://github.com/sortie-ai/sortie/compare/1.14.0...1.14.1
-[1.14.0]: https://github.com/sortie-ai/sortie/compare/1.13.0...1.14.0
-[1.13.0]: https://github.com/sortie-ai/sortie/compare/1.12.0...1.13.0
-[1.12.0]: https://github.com/sortie-ai/sortie/compare/1.11.0...1.12.0
-[1.11.0]: https://github.com/sortie-ai/sortie/compare/1.10.0...1.11.0
-[1.10.0]: https://github.com/sortie-ai/sortie/compare/1.9.1...1.10.0
-[1.9.1]: https://github.com/sortie-ai/sortie/compare/1.9.0...1.9.1
-[1.9.0]: https://github.com/sortie-ai/sortie/compare/1.8.0...1.9.0
-[1.8.0]: https://github.com/sortie-ai/sortie/compare/1.7.1...1.8.0
-[1.7.1]: https://github.com/sortie-ai/sortie/compare/1.7.0...1.7.1
-[1.7.0]: https://github.com/sortie-ai/sortie/compare/1.6.1...1.7.0
-[1.6.1]: https://github.com/sortie-ai/sortie/compare/1.6.0...1.6.1
-[1.6.0]: https://github.com/sortie-ai/sortie/compare/1.5.1...1.6.0
-[1.5.1]: https://github.com/sortie-ai/sortie/compare/1.5.0...1.5.1
-[1.5.0]: https://github.com/sortie-ai/sortie/compare/1.4.0...1.5.0
-[1.4.0]: https://github.com/sortie-ai/sortie/compare/1.3.0...1.4.0
-[1.3.0]: https://github.com/sortie-ai/sortie/compare/1.2.1...1.3.0
-[1.2.1]: https://github.com/sortie-ai/sortie/compare/1.2.0...1.2.1
-[1.2.0]: https://github.com/sortie-ai/sortie/compare/1.1.0...1.2.0
-[1.1.0]: https://github.com/sortie-ai/sortie/compare/1.0.0...1.1.0
-[1.0.0]: https://github.com/sortie-ai/sortie/compare/0.0.10...1.0.0
-[0.0.10]: https://github.com/sortie-ai/sortie/compare/0.0.9...0.0.10
-[0.0.9]: https://github.com/sortie-ai/sortie/compare/0.0.8...0.0.9
-[0.0.8]: https://github.com/sortie-ai/sortie/compare/0.0.7...0.0.8
-[0.0.7]: https://github.com/sortie-ai/sortie/compare/0.0.6...0.0.7
-[0.0.6]: https://github.com/sortie-ai/sortie/compare/0.0.5...0.0.6
-[0.0.5]: https://github.com/sortie-ai/sortie/compare/0.0.4...0.0.5
-[0.0.4]: https://github.com/sortie-ai/sortie/compare/0.0.3...0.0.4
-[0.0.3]: https://github.com/sortie-ai/sortie/compare/0.0.2...0.0.3
-[0.0.2]: https://github.com/sortie-ai/sortie/compare/0.0.1...0.0.2
-[0.0.1]: https://github.com/sortie-ai/sortie/compare/0.0.0...0.0.1
+[Unreleased]: https://github.com/sortie-ai/sortie/compare/v1.18.0...HEAD
+[1.18.0]: https://github.com/sortie-ai/sortie/compare/v1.17.0...v1.18.0
+[1.17.0]: https://github.com/sortie-ai/sortie/compare/v1.16.1...v1.17.0
+[1.16.1]: https://github.com/sortie-ai/sortie/compare/v1.16.0...v1.16.1
+[1.16.0]: https://github.com/sortie-ai/sortie/compare/v1.15.0...v1.16.0
+[1.15.0]: https://github.com/sortie-ai/sortie/compare/v1.14.1...v1.15.0
+[1.14.1]: https://github.com/sortie-ai/sortie/compare/v1.14.0...v1.14.1
+[1.14.0]: https://github.com/sortie-ai/sortie/compare/v1.13.0...v1.14.0
+[1.13.0]: https://github.com/sortie-ai/sortie/compare/v1.12.0...v1.13.0
+[1.12.0]: https://github.com/sortie-ai/sortie/compare/v1.11.0...v1.12.0
+[1.11.0]: https://github.com/sortie-ai/sortie/compare/v1.10.0...v1.11.0
+[1.10.0]: https://github.com/sortie-ai/sortie/compare/v1.9.1...v1.10.0
+[1.9.1]: https://github.com/sortie-ai/sortie/compare/v1.9.0...v1.9.1
+[1.9.0]: https://github.com/sortie-ai/sortie/compare/v1.8.0...v1.9.0
+[1.8.0]: https://github.com/sortie-ai/sortie/compare/v1.7.1...v1.8.0
+[1.7.1]: https://github.com/sortie-ai/sortie/compare/v1.7.0...v1.7.1
+[1.7.0]: https://github.com/sortie-ai/sortie/compare/v1.6.1...v1.7.0
+[1.6.1]: https://github.com/sortie-ai/sortie/compare/v1.6.0...v1.6.1
+[1.6.0]: https://github.com/sortie-ai/sortie/compare/v1.5.1...v1.6.0
+[1.5.1]: https://github.com/sortie-ai/sortie/compare/v1.5.0...v1.5.1
+[1.5.0]: https://github.com/sortie-ai/sortie/compare/v1.4.0...v1.5.0
+[1.4.0]: https://github.com/sortie-ai/sortie/compare/v1.3.0...v1.4.0
+[1.3.0]: https://github.com/sortie-ai/sortie/compare/v1.2.1...v1.3.0
+[1.2.1]: https://github.com/sortie-ai/sortie/compare/v1.2.0...v1.2.1
+[1.2.0]: https://github.com/sortie-ai/sortie/compare/v1.1.0...v1.2.0
+[1.1.0]: https://github.com/sortie-ai/sortie/compare/v1.0.0...v1.1.0
+[1.0.0]: https://github.com/sortie-ai/sortie/compare/v0.0.10...v1.0.0
+[0.0.10]: https://github.com/sortie-ai/sortie/compare/v0.0.9...v0.0.10
+[0.0.9]: https://github.com/sortie-ai/sortie/compare/v0.0.8...v0.0.9
+[0.0.8]: https://github.com/sortie-ai/sortie/compare/v0.0.7...v0.0.8
+[0.0.7]: https://github.com/sortie-ai/sortie/compare/v0.0.6...v0.0.7
+[0.0.6]: https://github.com/sortie-ai/sortie/compare/v0.0.5...v0.0.6
+[0.0.5]: https://github.com/sortie-ai/sortie/compare/v0.0.4...v0.0.5
+[0.0.4]: https://github.com/sortie-ai/sortie/compare/v0.0.3...v0.0.4
+[0.0.3]: https://github.com/sortie-ai/sortie/compare/v0.0.2...v0.0.3
+[0.0.2]: https://github.com/sortie-ai/sortie/compare/v0.0.1...v0.0.2
+[0.0.1]: https://github.com/sortie-ai/sortie/compare/v0.0.0...v0.0.1
 [0.0.0]: https://github.com/sortie-ai/sortie/releases/tag/0.0.0

--- a/default.mk
+++ b/default.mk
@@ -3,7 +3,7 @@
 # Included by the root Makefile.  Every variable is defined with ?= so any of
 # them can be overridden on the command line or in the environment:
 #
-#   make build VERSION=v1.2.3
+#   make build VERSION=1.2.3
 #   make lint  LINT=/usr/local/bin/golangci-lint
 #
 # Requires GNU make >= 3.81 (the version shipped with macOS Xcode CLT).
@@ -20,10 +20,11 @@ BIN    := sortie
 
 # ── Versioning ────────────────────────────────────────────────────────────────
 #
-# Derived from the nearest reachable git tag.  Falls back to "dev" in shallow
-# clones, detached HEADs without tags, or non-git directories.
+# Derived from the nearest reachable git tag, with any leading "v" stripped so
+# a local build reports the same string as a released binary.  Falls back to
+# "dev" in shallow clones, detached HEADs without tags, or non-git directories.
 
-VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
+VERSION ?= $(patsubst v%,%,$(shell git describe --tags --always --dirty 2>/dev/null || echo dev))
 COMMIT  ?= $(shell git rev-parse HEAD 2>/dev/null || echo unknown)
 DATE    ?= $(shell date -u +%Y-%m-%d)
 

--- a/install.ps1
+++ b/install.ps1
@@ -10,7 +10,8 @@
         irm 'https://get.sortie-ai.com/install.ps1' | iex
 
     Environment:
-        SORTIE_VERSION      Pin a specific release tag (e.g. 1.14.0 or 0.0.7).
+        SORTIE_VERSION      Pin a specific release, with or without the
+                            leading "v" (e.g. 1.18.0 or v1.18.0).
         SORTIE_INSTALL_DIR  Override install directory
                             (default: %LOCALAPPDATA%\Programs\sortie).
         SORTIE_NO_VERIFY    Set to 1 to skip checksum verification.
@@ -239,12 +240,25 @@ function Invoke-Install {
     $arch = Get-Architecture
     Write-Info "Platform: windows/$arch"
 
-    $tag = Resolve-Tag
-    $version = $tag -replace '^v', ''
-    Write-Info "Release:  $tag"
+    $resolved = Resolve-Tag
+    $version = $resolved -replace '^v', ''
+    # $tag is the label reported to the user; the tag form itself matters only
+    # when building the download URL.
+    $tag = $version
+    Write-Info "Release:  $version"
 
     $archive = "${Bin}_${version}_windows_${arch}.zip"
-    $base    = "https://github.com/$Repo/releases/download/$tag"
+
+    # Releases from 1.19.0 on are tagged "v1.19.0"; earlier ones are tagged
+    # "1.18.0". A pinned version comes from the user and may use either form,
+    # so try the current convention first and fall back to the legacy one. A
+    # tag read from the latest release is already exact - use it as is.
+    if (-not [string]::IsNullOrEmpty($env:SORTIE_VERSION)) {
+        $candidates = @("v$version", $version)
+    }
+    else {
+        $candidates = @($resolved)
+    }
 
     $tmpDir = Join-Path ([System.IO.Path]::GetTempPath()) ("sortie-install-" + (New-Guid).Guid)
     New-Item -ItemType Directory -Path $tmpDir -Force | Out-Null
@@ -253,11 +267,20 @@ function Invoke-Install {
         $archivePath = Join-Path $tmpDir $archive
 
         Write-Info "Downloading $archive"
-        try {
-            Invoke-Download -Url "$base/$archive" -OutFile $archivePath
+        $base = $null
+        foreach ($candidate in $candidates) {
+            $candidateBase = "https://github.com/$Repo/releases/download/$candidate"
+            try {
+                Invoke-Download -Url "$candidateBase/$archive" -OutFile $archivePath
+                $base = $candidateBase
+                break
+            }
+            catch {
+                # Try the next tag form before giving up.
+            }
         }
-        catch {
-            throw "download failed - verify release $tag has asset for windows/$arch"
+        if ($null -eq $base) {
+            throw "download failed - verify release $version has asset for windows/$arch"
         }
 
         if ($env:SORTIE_NO_VERIFY -ne '1') {

--- a/install.ps1
+++ b/install.ps1
@@ -267,7 +267,12 @@ function Invoke-Install {
         $archivePath = Join-Path $tmpDir $archive
 
         Write-Info "Downloading $archive"
+        # Errors are held back while candidates are tried: a 404 on the first
+        # form only means the release uses the other one, and reporting it would
+        # alarm a user whose install then succeeds. If every form fails, the last
+        # error is released so a genuine network fault stays diagnosable.
         $base = $null
+        $lastError = $null
         foreach ($candidate in $candidates) {
             $candidateBase = "https://github.com/$Repo/releases/download/$candidate"
             try {
@@ -276,10 +281,13 @@ function Invoke-Install {
                 break
             }
             catch {
-                # Try the next tag form before giving up.
+                $lastError = $_
             }
         }
         if ($null -eq $base) {
+            if ($null -ne $lastError) {
+                Write-Err $lastError.Exception.Message
+            }
             throw "download failed - verify release $version has asset for windows/$arch"
         }
 

--- a/install.sh
+++ b/install.sh
@@ -6,7 +6,8 @@
 #   curl -sSL https://get.sortie-ai.com/install.sh | sh -s -- --help
 #
 # Environment (each has an equivalent flag, see --help):
-#   SORTIE_VERSION      Pin a specific release tag (e.g. 1.17.0 or 0.0.7).
+#   SORTIE_VERSION      Pin a specific release, with or without the leading
+#                       "v" (e.g. 1.18.0 or v1.18.0).
 #   SORTIE_INSTALL_DIR  Override install directory
 #                       (default: /usr/local/bin as root, ~/.local/bin otherwise).
 #   SORTIE_NO_VERIFY    Set to 1 to skip checksum verification.
@@ -231,10 +232,13 @@ install_release() {
     detect_platform
     info "Platform: ${OS}/${ARCH}"
 
-    _tag=$(resolve_tag)
-    [ -n "$_tag" ] || die "could not determine latest release"
-    _version=$(printf '%s' "$_tag" | sed 's/^v//')
-    info "Release:  ${_tag}"
+    _resolved=$(resolve_tag)
+    [ -n "$_resolved" ] || die "could not determine latest release"
+    _version=${_resolved#[vV]}
+    # _tag is the label both install paths report; the tag form itself matters
+    # only when building the download URL.
+    _tag=$_version
+    info "Release:  ${_version}"
 
     if [ "$(installed_version "${_dir}/${BIN}")" = "$_version" ]; then
         _already_installed=1
@@ -242,15 +246,41 @@ install_release() {
     fi
 
     _archive="${BIN}_${_version}_${OS}_${ARCH}.tar.gz"
-    _base="https://github.com/${REPO}/releases/download/${_tag}"
+
+    # Releases from 1.19.0 on are tagged "v1.19.0"; earlier ones are tagged
+    # "1.18.0". A pinned version comes from the user and may use either form,
+    # so try the current convention first and fall back to the legacy one. A
+    # tag discovered from the latest release is already exact - use it as is.
+    if [ -n "${SORTIE_VERSION-}" ]; then
+        _candidates="v${_version} ${_version}"
+    else
+        _candidates=$_resolved
+    fi
 
     TMPDIR_INSTALL=$(mktemp -d)
     trap cleanup EXIT
     trap 'exit 1' INT TERM
 
     info "Downloading ${_archive}"
-    fetch "${_base}/${_archive}" "${TMPDIR_INSTALL}/${_archive}" \
-        || die "download failed - verify release ${_tag} has asset for ${OS}/${ARCH}"
+    # Errors are held back while candidates are tried: a 404 on the first form
+    # only means the release uses the other one, and printing it would alarm a
+    # user whose install then succeeds. If every form fails, the last error is
+    # released so a genuine network fault stays diagnosable.
+    _found=0
+    for _candidate in $_candidates; do
+        _base="https://github.com/${REPO}/releases/download/${_candidate}"
+        if fetch "${_base}/${_archive}" "${TMPDIR_INSTALL}/${_archive}" \
+            2>"${TMPDIR_INSTALL}/fetch.err"; then
+            _found=1
+            break
+        fi
+    done
+    if [ "$_found" != 1 ]; then
+        if [ -s "${TMPDIR_INSTALL}/fetch.err" ]; then
+            cat "${TMPDIR_INSTALL}/fetch.err" >&2
+        fi
+        die "download failed - verify release ${_version} has asset for ${OS}/${ARCH}"
+    fi
 
     if [ "${SORTIE_NO_VERIFY-}" != "1" ]; then
         fetch "${_base}/checksums.txt" "${TMPDIR_INSTALL}/checksums.txt" \


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Chore

**Intent:** Release tags now carry a `v` prefix (`v1.19.0`) because the Go module proxy requires it to publish a module's version list - without it, `go install github.com/sortie-ai/sortie/cmd/sortie@v1.18.0` could not resolve a tagged version and the module was only reachable via a pseudo-version.

### 🧭 Reviewer Guide

**Complexity:** Medium

#### Entry Point

`.github/workflows/release.yml` is where the migration originates: the workflow now normalizes an optional leading `v` on the `workflow_dispatch` version input and derives two outputs - a bare `version` (used for artifact names, image tags, and CHANGELOG lookups) and a `v`-prefixed `tag` (used for git tag creation, dry-run tagging, and the release summary). Downstream jobs consume these outputs instead of the raw input.

#### Sensitive Areas

- `.github/workflows/release.yml`: drives the actual release process - the `validate` job's new outputs are consumed by the `release` and `docker` jobs, so a wiring mistake here would surface only during a real release run.
- `install.sh` / `install.ps1`: user-facing installers. Both now try the `v`-prefixed tag first and fall back to the legacy unprefixed tag when downloading a pinned `SORTIE_VERSION`, since releases before 1.19.0 remain tagged without the prefix. Fetch errors are held back until every candidate tag is exhausted so a successful fallback does not print a spurious error.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes. `SORTIE_VERSION` and `--version` still accept a pinned version with or without the `v` prefix, and `default.mk` strips a leading `v` from `git describe` so local builds keep reporting the same version string as a released binary.
- **Migrations/State:** No database or schema changes. As a one-time manual step, every existing release tag needs to be additionally tagged under its `v`-prefixed name against the same commit so the Go module proxy backfills the full version list; the CHANGELOG entry documents this.