### PR TITLE
feat(scm/gitlab): implement SCM adapter write operations

### DIFF
--- a/docs/architecture/14-auto-merge-reaction-contract.md
+++ b/docs/architecture/14-auto-merge-reaction-contract.md
@@ -58,6 +58,12 @@ The auto-merge reaction introduces the following domain types:
   substring `already merged` (case-insensitive) in the error message. Callers disambiguate that
   subcase as documented in §11C.3.
 
+**GitLab caveat.** On GitLab the effective merge strategy is the project's own `merge_method`
+setting rather than a per-call choice. The adapter always calls the one merge route and never the
+asynchronous standalone rebase route, so a configured `rebase` performs the operator's intent on a
+project set to fast-forward or semi-linear history and produces a merge commit on a project set to
+merge commits. The adapter logs one WARN per merge naming that governance.
+
 ### 11C.3 Error kind
 
 `ErrSCMConflict` is an `SCMErrorKind` value alongside the transport, auth, API, not-found, and
@@ -209,6 +215,16 @@ still passes even when the token itself is scoped read-only. That gap surfaces o
 when a `MergePR` or `DeleteBranch` call returns a 403 that the adapter enriches to name the
 missing `write:repository` scope explicitly. An operator satisfies both checks by granting the
 Gitea token's user repository write access and the token the `write:repository` scope.
+
+**GitLab caveat.** The GitLab adapter verifies the credential's own scope record rather than a
+repository or organization signal: it reads the token-introspection endpoint at startup. GitLab
+has no contents-versus-pull-request scope split, so the single `api` scope is the one requirement
+covering the merge, the branch delete, and the label write. A granular token's scope report is
+opaque and takes the fail-open path, and an instance whose introspection route is unavailable
+takes the same fail-open path rather than disabling auto-merge, because that route can answer 404
+for a hidden or blocked path as readily as for a genuinely missing one. A branch-protection
+refusal on this platform is reported at runtime as an auth-class failure rather than being caught
+at startup.
 
 For the full preflight algorithm, see §6.3.
 

--- a/internal/scm/gitlab/normalize.go
+++ b/internal/scm/gitlab/normalize.go
@@ -76,12 +76,21 @@ type gitlabNoteCreated struct {
 }
 
 // gitlabTokenInfo is the token-introspection record the construction
-// preflight decodes. It never carries the token value itself.
+// preflight and the auto-merge scope preflight decode. It never carries
+// the token value itself.
 type gitlabTokenInfo struct {
 	Scopes    []string `json:"scopes"`
 	Active    bool     `json:"active"`
 	Revoked   bool     `json:"revoked"`
 	ExpiresAt string   `json:"expires_at"`
+
+	// Granular reports that the credential is a granular access token,
+	// whose Scopes array carries no usable permission detail. The
+	// response's granular_scopes array stays undecoded: its entries are
+	// scoped to a project or group this method never receives, and no
+	// published mapping turns a permission name into merge-request write
+	// authorization.
+	Granular bool `json:"granular"`
 }
 
 // gitlabErrorBody covers the four error envelopes GitLab returns on a

--- a/internal/scm/gitlab/scm.go
+++ b/internal/scm/gitlab/scm.go
@@ -12,17 +12,22 @@ import (
 
 	"github.com/sortie-ai/sortie/internal/domain"
 	"github.com/sortie-ai/sortie/internal/httpkit"
+	"github.com/sortie-ai/sortie/internal/registry"
 	"github.com/sortie-ai/sortie/internal/scm/scmcore"
 )
 
-// GitLabSCMAdapter implements the read half of [domain.SCMAdapter] for
-// GitLab merge requests over the REST API v4. The client and logger are
-// set once at construction and never mutated; botCache is the only
-// mutable state, guarded by a mutex held only around map access. The
-// adapter is safe for concurrent use.
-//
-// This type does not yet satisfy the full [domain.SCMAdapter] interface:
-// the write methods and registration are a separate concern.
+func init() {
+	registry.SCMAdapters.Register("gitlab", NewGitLabSCMAdapter)
+}
+
+// Compile-time interface satisfaction check.
+var _ domain.SCMAdapter = (*GitLabSCMAdapter)(nil)
+
+// GitLabSCMAdapter implements [domain.SCMAdapter] for GitLab merge
+// requests over the REST API v4. The client and logger are set once at
+// construction and never mutated; botCache is the only mutable state,
+// guarded by a mutex held only around map access. The adapter is safe
+// for concurrent use.
 type GitLabSCMAdapter struct {
 	client *httpkit.Client
 	log    *slog.Logger
@@ -42,7 +47,7 @@ type GitLabSCMAdapter struct {
 // owner and repo arrive per call.
 //
 // Construction performs no network request.
-func NewGitLabSCMAdapter(adapterConfig map[string]any) (*GitLabSCMAdapter, error) {
+func NewGitLabSCMAdapter(adapterConfig map[string]any) (domain.SCMAdapter, error) {
 	apiKey, _ := adapterConfig["api_key"].(string)
 	if apiKey == "" {
 		return nil, &domain.SCMError{

--- a/internal/scm/gitlab/scm_label_events.go
+++ b/internal/scm/gitlab/scm_label_events.go
@@ -1,9 +1,12 @@
 package gitlab
 
 import (
+	"bytes"
 	"cmp"
 	"context"
 	"encoding/json"
+	"log/slog"
+	"net/http"
 	"slices"
 	"strconv"
 	"strings"
@@ -77,4 +80,68 @@ func (a *GitLabSCMAdapter) ListLabelEvents(ctx context.Context, prNumber int, ow
 	})
 
 	return events, nil
+}
+
+// gitlabMergeRequestUpdate is the JSON body of PUT
+// /projects/{project}/merge_requests/{iid}, carrying only the label
+// removal [GitLabSCMAdapter.RemoveLabel] performs.
+type gitlabMergeRequestUpdate struct {
+	RemoveLabels []string `json:"remove_labels,omitempty"`
+}
+
+// RemoveLabel removes every case variant of label from the given merge
+// request via PUT /projects/{project}/merge_requests/{iid}.
+//
+// label is matched against the merge request's stored labels
+// case-insensitively, and every matching variant is sent in
+// remove_labels, so a stored "Sortie:Review" is removed even when label
+// is configured in lowercase; GitLab matches label names
+// case-sensitively. When no stored label matches, RemoveLabel returns
+// nil and issues no write. A [domain.ErrSCMNotFound] reading or writing
+// the merge request maps to nil, since on GitLab that status can only
+// mean the merge request or the project is gone or invisible, never an
+// absent label.
+func (a *GitLabSCMAdapter) RemoveLabel(ctx context.Context, prNumber int, owner, repo, label string) error {
+	target := strings.ToLower(strings.TrimSpace(label))
+	if target == "" {
+		return nil
+	}
+
+	mr, err := a.fetchMergeRequest(ctx, prNumber, owner, repo)
+	if err != nil {
+		return a.labelNotFoundToNil(err, prNumber)
+	}
+
+	variants := labelVariants(mr.Labels, target)
+	if len(variants) == 0 {
+		return nil
+	}
+
+	payload, marshalErr := json.Marshal(gitlabMergeRequestUpdate{RemoveLabels: variants})
+	if marshalErr != nil {
+		return &domain.SCMError{
+			Kind:    domain.ErrSCMPayload,
+			Message: "failed to encode merge request update body",
+			Err:     marshalErr,
+		}
+	}
+
+	path := "/projects/" + projectPath(owner, repo) + "/merge_requests/" + strconv.Itoa(prNumber)
+	if _, sendErr := a.client.Send(ctx, http.MethodPut, path, bytes.NewReader(payload)); sendErr != nil {
+		return a.labelNotFoundToNil(sendErr, prNumber)
+	}
+	return nil
+}
+
+// labelNotFoundToNil maps a [domain.ErrSCMNotFound] from a label read or
+// write to nil, logging one WARN naming prNumber, and returns every
+// other kind unchanged.
+func (a *GitLabSCMAdapter) labelNotFoundToNil(err error, prNumber int) error {
+	scm := asSCMError(err)
+	if scm.Kind == domain.ErrSCMNotFound {
+		a.log.Warn("gitlab merge request not found during label removal",
+			slog.Int("pr_number", prNumber))
+		return nil
+	}
+	return scm
 }

--- a/internal/scm/gitlab/scm_label_events_test.go
+++ b/internal/scm/gitlab/scm_label_events_test.go
@@ -278,3 +278,37 @@ func TestRemoveLabel_NotFoundMapsToNil(t *testing.T) {
 		}
 	})
 }
+
+func TestRemoveLabel_BlankLabelNoRequest(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		label string
+	}{
+		{"an empty label", ""},
+		{"a whitespace-only label", "   "},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name+" issues no request", func(t *testing.T) {
+			t.Parallel()
+
+			var requests atomic.Int32
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				requests.Add(1)
+				t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+				w.WriteHeader(http.StatusNotFound)
+			}))
+			defer srv.Close()
+
+			adapter := mustSCMAdapter(t, srv.URL)
+			err := adapter.RemoveLabel(context.Background(), testPRNumber, scmOwner, scmRepo, tt.label)
+			adaptertest.AssertLabelAbsentDisposition(t, err)
+
+			if n := requests.Load(); n != 0 {
+				t.Errorf("requests = %d, want 0 (a blank label resolves to no target and must not reach the network)", n)
+			}
+		})
+	}
+}

--- a/internal/scm/gitlab/scm_label_events_test.go
+++ b/internal/scm/gitlab/scm_label_events_test.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
+	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/sortie-ai/sortie/internal/adaptertest"
@@ -131,5 +134,147 @@ func TestListLabelEvents_ErrorStatuses(t *testing.T) {
 		adapter := mustSCMAdapter(t, srv.URL)
 		_, err := adapter.ListLabelEvents(context.Background(), testPRNumber, scmOwner, scmRepo)
 		adaptertest.AssertSCMErrorKind(t, err, domain.ErrSCMPayload)
+	})
+}
+
+// --- RemoveLabel (AC7) ---
+
+func TestRemoveLabel_AbsentLabelNoOp(t *testing.T) {
+	t.Parallel()
+
+	mrFixture := mergeRequestFixture(t, map[string]any{"labels": []string{"unrelated-label"}})
+	var putCalls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.Method {
+		case http.MethodGet:
+			_, _ = w.Write(mrFixture)
+		case http.MethodPut:
+			putCalls.Add(1)
+			_, _ = w.Write(mrFixture)
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	adapter := mustSCMAdapter(t, srv.URL)
+	err := adapter.RemoveLabel(context.Background(), testPRNumber, scmOwner, scmRepo, "sortie:review")
+	adaptertest.AssertLabelAbsentDisposition(t, err)
+
+	if n := putCalls.Load(); n != 0 {
+		t.Errorf("PUT calls = %d, want 0 (no stored variant matches, so no write is issued)", n)
+	}
+}
+
+func TestRemoveLabel_CaseVariantResolution(t *testing.T) {
+	t.Parallel()
+
+	const storedLabel = "Sortie:Review"
+	mrFixture := mergeRequestFixture(t, map[string]any{"labels": []string{storedLabel, "unrelated-label"}})
+
+	var gotMethod, gotPath string
+	var gotBody gitlabMergeRequestUpdate
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.Method {
+		case http.MethodGet:
+			_, _ = w.Write(mrFixture)
+		case http.MethodPut:
+			gotMethod = r.Method
+			gotPath = r.URL.EscapedPath()
+			decodeRequestBody(t, r, &gotBody)
+			_, _ = w.Write(mrFixture)
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	adapter := mustSCMAdapter(t, srv.URL)
+	if err := adapter.RemoveLabel(context.Background(), testPRNumber, scmOwner, scmRepo, "sortie:review"); err != nil {
+		t.Fatalf("RemoveLabel: unexpected error: %v", err)
+	}
+
+	if gotMethod != http.MethodPut {
+		t.Errorf("request method = %q, want %q", gotMethod, http.MethodPut)
+	}
+	wantPath := "/api/v4/projects/" + projectPath(scmOwner, scmRepo) + "/merge_requests/" + strconv.Itoa(testPRNumber)
+	if gotPath != wantPath {
+		t.Errorf("request path = %q, want %q", gotPath, wantPath)
+	}
+	if len(gotBody.RemoveLabels) != 1 || gotBody.RemoveLabels[0] != storedLabel {
+		t.Errorf("request body remove_labels = %v, want [%q] (the stored spelling, not the configured lowercase form)", gotBody.RemoveLabels, storedLabel)
+	}
+}
+
+func TestRemoveLabel_NotFoundMapsToNil(t *testing.T) {
+	t.Parallel()
+
+	t.Run("404 on the merge-request read maps to nil with one WARN", func(t *testing.T) {
+		t.Parallel()
+
+		errorBody := loadFixture(t, "error_404_project.json")
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write(errorBody)
+		}))
+		defer srv.Close()
+
+		adapter := mustSCMAdapter(t, srv.URL)
+		log, buf := newCapturingLogger()
+		adapter.log = log
+
+		err := adapter.RemoveLabel(context.Background(), testPRNumber, scmOwner, scmRepo, "sortie:review")
+		if err != nil {
+			t.Errorf("RemoveLabel = %v, want nil", err)
+		}
+
+		logOutput := buf.String()
+		const wantWarn = "gitlab merge request not found during label removal"
+		if got := strings.Count(logOutput, wantWarn); got != 1 {
+			t.Errorf("occurrences of %q in log output = %d, want 1 (log output: %q)", wantWarn, got, logOutput)
+		}
+		if !strings.Contains(logOutput, "pr_number="+strconv.Itoa(testPRNumber)) {
+			t.Errorf("log output = %q, want it to carry pr_number=%d", logOutput, testPRNumber)
+		}
+	})
+
+	t.Run("404 on the merge-request update maps to nil with one WARN", func(t *testing.T) {
+		t.Parallel()
+
+		mrFixture := mergeRequestFixture(t, map[string]any{"labels": []string{"Sortie:Review"}})
+		errorBody := loadFixture(t, "error_404_project.json")
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.Method {
+			case http.MethodGet:
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write(mrFixture)
+			case http.MethodPut:
+				w.WriteHeader(http.StatusNotFound)
+				_, _ = w.Write(errorBody)
+			default:
+				t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+				w.WriteHeader(http.StatusNotFound)
+			}
+		}))
+		defer srv.Close()
+
+		adapter := mustSCMAdapter(t, srv.URL)
+		log, buf := newCapturingLogger()
+		adapter.log = log
+
+		err := adapter.RemoveLabel(context.Background(), testPRNumber, scmOwner, scmRepo, "sortie:review")
+		if err != nil {
+			t.Errorf("RemoveLabel = %v, want nil", err)
+		}
+
+		logOutput := buf.String()
+		const wantWarn = "gitlab merge request not found during label removal"
+		if got := strings.Count(logOutput, wantWarn); got != 1 {
+			t.Errorf("occurrences of %q in log output = %d, want 1 (log output: %q)", wantWarn, got, logOutput)
+		}
 	})
 }

--- a/internal/scm/gitlab/scm_merge.go
+++ b/internal/scm/gitlab/scm_merge.go
@@ -1,9 +1,13 @@
 package gitlab
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"log/slog"
+	"net/http"
+	"net/url"
 	"strconv"
 
 	"github.com/sortie-ai/sortie/internal/domain"
@@ -22,6 +26,11 @@ type gitlabMergeRequest struct {
 	MergeCommitSHA      string          `json:"merge_commit_sha"`
 	DetailedMergeStatus string          `json:"detailed_merge_status"`
 	HeadPipeline        *gitlabPipeline `json:"head_pipeline"`
+
+	// Labels carries the merge request's label names in their stored
+	// casing, which RemoveLabel matches case-insensitively before it
+	// sends the stored spelling back.
+	Labels []string `json:"labels"`
 }
 
 // gitlabPipeline is the head_pipeline object embedded in a merge
@@ -134,4 +143,177 @@ func (a *GitLabSCMAdapter) GetCIStatus(ctx context.Context, prNumber int, owner,
 	default:
 		return string(scmcore.CIGatePending), nil
 	}
+}
+
+// gitlabMergeAccept is the JSON body of PUT
+// /projects/{project}/merge_requests/{iid}/merge. SHA is always sent so
+// the platform rejects a moved head. Squash is set only for the squash
+// strategy, and exactly one message field is set, so an unset field
+// defers to the platform's own strategy default.
+type gitlabMergeAccept struct {
+	SHA                 string `json:"sha"`
+	Squash              bool   `json:"squash,omitempty"`
+	MergeCommitMessage  string `json:"merge_commit_message,omitempty"`
+	SquashCommitMessage string `json:"squash_commit_message,omitempty"`
+}
+
+// composeMessage joins title and body into the one message field GitLab
+// takes per merge strategy. Either side being empty yields the other
+// side unchanged, so both empty leaves the composed value empty and the
+// platform applies its own default.
+func composeMessage(title, body string) string {
+	if title == "" {
+		return body
+	}
+	if body == "" {
+		return title
+	}
+	return title + "\n\n" + body
+}
+
+// buildMergeAccept encodes strategy, the composed commit message, and
+// expectedHeadSHA into the merge-accept body. ok is false for a strategy
+// outside the three domain constants, in which case the returned body is
+// the zero value and the caller must reject the call before issuing any
+// request.
+//
+// Squash is true only in the squash arm; the merge and rebase arms leave
+// it at its zero value so the project's own squash setting governs.
+// buildMergeAccept issues no request and logs nothing: the caller logs
+// the rebase governance warning, since only the caller owns a logger.
+func buildMergeAccept(strategy domain.MergeStrategy, commitTitle, commitMessage, expectedHeadSHA string) (gitlabMergeAccept, bool) {
+	message := composeMessage(commitTitle, commitMessage)
+
+	switch strategy {
+	case domain.StrategyMerge:
+		return gitlabMergeAccept{SHA: expectedHeadSHA, MergeCommitMessage: message}, true
+	case domain.StrategySquash:
+		return gitlabMergeAccept{SHA: expectedHeadSHA, Squash: true, SquashCommitMessage: message}, true
+	case domain.StrategyRebase:
+		return gitlabMergeAccept{SHA: expectedHeadSHA, MergeCommitMessage: message}, true
+	default:
+		return gitlabMergeAccept{}, false
+	}
+}
+
+// MergePR merges the given merge request with the requested strategy via
+// PUT /projects/{project}/merge_requests/{prNumber}/merge.
+//
+// An empty expectedHeadSHA or an unsupported strategy returns a
+// [*domain.SCMError] of kind [domain.ErrSCMPayload] before any request is
+// issued. GitLab expresses rebase-on-merge as the target project's own
+// merge_method setting rather than a per-call parameter, so
+// [domain.StrategyRebase] issues the same merge call as
+// [domain.StrategyMerge] and logs one WARN naming that governance.
+//
+// A 405 or 409 rejection promotes to [domain.ErrSCMConflict] through
+// [scmcore.AsMergeConflict]; the already-merged marker is present only
+// after a merge-request re-read confirms the merge landed. A 401 or 403
+// keeps kind [domain.ErrSCMAuth] with a message naming both the
+// invalid-credential and branch-protection-refusal causes, since GitLab
+// answers a branch-protection refusal on this route with 401. A 200
+// whose decoded state is not "merged" returns [domain.ErrSCMConflict]
+// directly, with no already-merged marker.
+func (a *GitLabSCMAdapter) MergePR(ctx context.Context, prNumber int, owner, repo string, strategy domain.MergeStrategy, commitTitle, commitMessage, expectedHeadSHA string) (domain.MergeResult, error) {
+	if expectedHeadSHA == "" {
+		return domain.MergeResult{}, &domain.SCMError{
+			Kind:    domain.ErrSCMPayload,
+			Message: "merge precondition sha is required",
+		}
+	}
+
+	body, ok := buildMergeAccept(strategy, commitTitle, commitMessage, expectedHeadSHA)
+	if !ok {
+		return domain.MergeResult{}, &domain.SCMError{
+			Kind:    domain.ErrSCMPayload,
+			Message: fmt.Sprintf("unsupported merge strategy: %q", strategy),
+		}
+	}
+	if strategy == domain.StrategyRebase {
+		a.log.Warn("gitlab rebase strategy is governed by the project merge method")
+	}
+
+	payload, marshalErr := json.Marshal(body)
+	if marshalErr != nil {
+		return domain.MergeResult{}, &domain.SCMError{
+			Kind:    domain.ErrSCMPayload,
+			Message: "failed to encode merge request body",
+			Err:     marshalErr,
+		}
+	}
+
+	path := "/projects/" + projectPath(owner, repo) + "/merge_requests/" + strconv.Itoa(prNumber) + "/merge"
+	respBody, sendErr := a.client.Send(ctx, http.MethodPut, path, bytes.NewReader(payload))
+	if sendErr != nil {
+		scm := scmcore.AsMergeConflict(asSCMError(sendErr))
+		switch scm.Kind {
+		case domain.ErrSCMConflict:
+			return domain.MergeResult{}, a.resolveMergeConflict(ctx, prNumber, owner, repo, scm)
+		case domain.ErrSCMAuth:
+			return domain.MergeResult{}, enrichMergeAuthError(scm)
+		default:
+			return domain.MergeResult{}, scm
+		}
+	}
+
+	var mr gitlabMergeRequest
+	if jsonErr := json.Unmarshal(respBody, &mr); jsonErr != nil {
+		return domain.MergeResult{}, &domain.SCMError{
+			Kind:    domain.ErrSCMPayload,
+			Message: "failed to parse merge response",
+			Err:     jsonErr,
+		}
+	}
+	if mr.State != "merged" {
+		return domain.MergeResult{}, &domain.SCMError{
+			Kind:    domain.ErrSCMConflict,
+			Message: fmt.Sprintf("merge endpoint returned state %q", mr.State),
+		}
+	}
+
+	return domain.MergeResult{SHA: mr.MergeCommitSHA, Merged: true}, nil
+}
+
+// resolveMergeConflict re-reads the merge request after a promoted
+// conflict and returns a conflict carrying the canonical "already
+// merged" marker when the re-read observes state "merged".
+//
+// The marker is gated on the observed state rather than on GitLab's
+// rejection wording, which is a constant carrying no reason, so it
+// survives a reworded rejection and never fires on a stale-head 409. A
+// failed re-read returns scm unchanged, at most delaying the outcome by
+// one retry cycle.
+func (a *GitLabSCMAdapter) resolveMergeConflict(ctx context.Context, prNumber int, owner, repo string, scm *domain.SCMError) *domain.SCMError {
+	mr, readErr := a.fetchMergeRequest(ctx, prNumber, owner, repo)
+	if readErr == nil && mr.State == "merged" {
+		return scmcore.AlreadyMergedConflict(scm.Message, scm.Err)
+	}
+	return scm
+}
+
+// enrichMergeAuthError rewrites the message of a 401 or 403 from the
+// merge route to name both possible causes. GitLab returns 401 on this
+// route when branch protection forbids the caller from merging into the
+// target branch, which deviates from the rest of the API, where 401
+// otherwise means an invalid credential. The kind stays
+// [domain.ErrSCMAuth], preserving the caller's immediate escalation.
+func enrichMergeAuthError(scm *domain.SCMError) *domain.SCMError {
+	scm.Message = "gitlab refused the merge: the credential is invalid, or it may not merge into the target branch: " + scm.Message
+	return scm
+}
+
+// DeleteBranch deletes the branch reference via DELETE
+// /projects/{project}/repository/branches/{branch}.
+//
+// branch is percent-encoded into the path, so a slash-bearing name
+// reaches GitLab as %2F. An already-gone branch (HTTP 404) returns a
+// [*domain.SCMError] of kind [domain.ErrSCMNotFound]; DeleteBranch
+// returns that error rather than mapping it to nil, and the caller
+// treats it as a successful no-op. Returns nil on a 200 or 204.
+func (a *GitLabSCMAdapter) DeleteBranch(ctx context.Context, owner, repo, branch string) error {
+	path := "/projects/" + projectPath(owner, repo) + "/repository/branches/" + url.PathEscape(branch)
+	if err := a.client.SendNoBody(ctx, http.MethodDelete, path); err != nil {
+		return asSCMError(err)
+	}
+	return nil
 }

--- a/internal/scm/gitlab/scm_merge_test.go
+++ b/internal/scm/gitlab/scm_merge_test.go
@@ -3,15 +3,27 @@ package gitlab
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"maps"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/sortie-ai/sortie/internal/adaptertest"
 	"github.com/sortie-ai/sortie/internal/domain"
 )
+
+// decodeRequestBody decodes r's JSON body into v, failing the test if the
+// decode itself fails.
+func decodeRequestBody(t *testing.T, r *http.Request, v any) {
+	t.Helper()
+	if err := json.NewDecoder(r.Body).Decode(v); err != nil {
+		t.Fatalf("decode request body: %v", err)
+	}
+}
 
 // mergeRequestFixture returns a JSON-encoded merge request object built
 // from a documented baseline shape, with overrides applied on top. This
@@ -317,4 +329,459 @@ func TestGetCIStatus_ErrorStatuses(t *testing.T) {
 		_, err := adapter.GetCIStatus(context.Background(), testPRNumber, scmOwner, scmRepo)
 		adaptertest.AssertSCMErrorKind(t, err, domain.ErrSCMPayload)
 	})
+}
+
+// --- MergePR: success, strategy encoding, and request shape (AC3, AC13, R35) ---
+
+func TestMergePR_StrategyEncodingAndRequestShape(t *testing.T) {
+	t.Parallel()
+
+	const (
+		wantSHA            = "sha-expected-head-001"
+		wantMergeCommitSHA = "9f8e7d6c5b4a392817061524334251627384950a"
+		commitTitle        = "Merge feature branch"
+		commitMessage      = "Closes the review cycle."
+	)
+	wantMessage := commitTitle + "\n\n" + commitMessage
+
+	tests := []struct {
+		name       string
+		strategy   domain.MergeStrategy
+		wantSquash bool
+	}{
+		{"merge strategy sends merge_commit_message", domain.StrategyMerge, false},
+		{"squash strategy sends squash true and squash_commit_message", domain.StrategySquash, true},
+		{"rebase strategy sends merge_commit_message, governed by project merge_method", domain.StrategyRebase, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			fixture := mergeRequestFixture(t, map[string]any{
+				"state":            "merged",
+				"merge_commit_sha": wantMergeCommitSHA,
+			})
+
+			var gotMethod, gotPath string
+			var gotBody gitlabMergeAccept
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotMethod = r.Method
+				gotPath = r.URL.EscapedPath()
+				decodeRequestBody(t, r, &gotBody)
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write(fixture)
+			}))
+			defer srv.Close()
+
+			adapter := mustSCMAdapter(t, srv.URL)
+			got, err := adapter.MergePR(context.Background(), testPRNumber, scmOwner, scmRepo, tt.strategy, commitTitle, commitMessage, wantSHA)
+			if err != nil {
+				t.Fatalf("MergePR: unexpected error: %v", err)
+			}
+
+			if gotMethod != http.MethodPut {
+				t.Errorf("request method = %q, want %q", gotMethod, http.MethodPut)
+			}
+			wantPath := "/api/v4/projects/" + projectPath(scmOwner, scmRepo) + "/merge_requests/" + strconv.Itoa(testPRNumber) + "/merge"
+			if gotPath != wantPath {
+				t.Errorf("request path = %q, want %q", gotPath, wantPath)
+			}
+			if gotBody.SHA != wantSHA {
+				t.Errorf("request body sha = %q, want %q", gotBody.SHA, wantSHA)
+			}
+			if gotBody.Squash != tt.wantSquash {
+				t.Errorf("request body squash = %v, want %v", gotBody.Squash, tt.wantSquash)
+			}
+			if tt.wantSquash {
+				if gotBody.SquashCommitMessage != wantMessage {
+					t.Errorf("request body squash_commit_message = %q, want %q", gotBody.SquashCommitMessage, wantMessage)
+				}
+				if gotBody.MergeCommitMessage != "" {
+					t.Errorf("request body merge_commit_message = %q, want empty for the squash strategy", gotBody.MergeCommitMessage)
+				}
+			} else {
+				if gotBody.MergeCommitMessage != wantMessage {
+					t.Errorf("request body merge_commit_message = %q, want %q", gotBody.MergeCommitMessage, wantMessage)
+				}
+				if gotBody.SquashCommitMessage != "" {
+					t.Errorf("request body squash_commit_message = %q, want empty for the %s strategy", gotBody.SquashCommitMessage, tt.strategy)
+				}
+			}
+
+			want := domain.MergeResult{SHA: wantMergeCommitSHA, Merged: true}
+			if got != want {
+				t.Errorf("MergePR(...) = %+v, want %+v", got, want)
+			}
+		})
+	}
+}
+
+func TestMergePR_RebaseStrategyLogsGovernanceWarning(t *testing.T) {
+	t.Parallel()
+
+	fixture := mergeRequestFixture(t, map[string]any{
+		"state":            "merged",
+		"merge_commit_sha": "9f8e7d6c5b4a392817061524334251627384950a",
+	})
+	srv := serveJSON(t, fixture)
+	defer srv.Close()
+
+	adapter := mustSCMAdapter(t, srv.URL)
+	log, buf := newCapturingLogger()
+	adapter.log = log
+
+	if _, err := adapter.MergePR(context.Background(), testPRNumber, scmOwner, scmRepo, domain.StrategyRebase, "", "", "sha-expected-head-001"); err != nil {
+		t.Fatalf("MergePR: unexpected error: %v", err)
+	}
+
+	logOutput := buf.String()
+	const wantWarn = "gitlab rebase strategy is governed by the project merge method"
+	if got := strings.Count(logOutput, wantWarn); got != 1 {
+		t.Errorf("occurrences of %q in log output = %d, want 1 (log output: %q)", wantWarn, got, logOutput)
+	}
+}
+
+func TestMergePR_ResponseStateNotMerged(t *testing.T) {
+	t.Parallel()
+
+	fixture := mergeRequestFixture(t, map[string]any{"state": "opened"})
+	srv := serveJSON(t, fixture)
+	defer srv.Close()
+
+	adapter := mustSCMAdapter(t, srv.URL)
+	got, err := adapter.MergePR(context.Background(), testPRNumber, scmOwner, scmRepo, domain.StrategyMerge, "", "", "sha-expected-head-001")
+
+	se := assertMergeConflict(t, err)
+	if strings.Contains(strings.ToLower(se.Message), "already merged") {
+		t.Errorf("SCMError.Message = %q, want it NOT to contain %q (a 200 whose state is not merged carries no marker)", se.Message, "already merged")
+	}
+	if got != (domain.MergeResult{}) {
+		t.Errorf("MergePR(...) result = %+v, want the zero value", got)
+	}
+}
+
+func TestMergePR_PayloadValidation(t *testing.T) {
+	t.Parallel()
+
+	t.Run("an empty expectedHeadSHA returns ErrSCMPayload with no request issued", func(t *testing.T) {
+		t.Parallel()
+
+		var requests atomic.Int32
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			requests.Add(1)
+			w.WriteHeader(http.StatusInternalServerError)
+		}))
+		defer srv.Close()
+
+		adapter := mustSCMAdapter(t, srv.URL)
+		got, err := adapter.MergePR(context.Background(), testPRNumber, scmOwner, scmRepo, domain.StrategyMerge, "", "", "")
+		adaptertest.AssertSCMErrorKind(t, err, domain.ErrSCMPayload)
+		if got != (domain.MergeResult{}) {
+			t.Errorf("MergePR(...) result = %+v, want the zero value", got)
+		}
+		if n := requests.Load(); n != 0 {
+			t.Errorf("requests = %d, want 0 (an empty expectedHeadSHA must not reach the network)", n)
+		}
+	})
+
+	t.Run("an unsupported strategy returns ErrSCMPayload with no request issued", func(t *testing.T) {
+		t.Parallel()
+
+		var requests atomic.Int32
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			requests.Add(1)
+			w.WriteHeader(http.StatusInternalServerError)
+		}))
+		defer srv.Close()
+
+		adapter := mustSCMAdapter(t, srv.URL)
+		got, err := adapter.MergePR(context.Background(), testPRNumber, scmOwner, scmRepo, domain.MergeStrategy("bogus"), "", "", "sha-expected-head-001")
+		adaptertest.AssertSCMErrorKind(t, err, domain.ErrSCMPayload)
+		if got != (domain.MergeResult{}) {
+			t.Errorf("MergePR(...) result = %+v, want the zero value", got)
+		}
+		if n := requests.Load(); n != 0 {
+			t.Errorf("requests = %d, want 0 (an unsupported strategy must not reach the network)", n)
+		}
+	})
+}
+
+// --- MergePR: conflict promotion, already-merged marker, and auth enrichment (AC4, AC5, AC10, R10-R14) ---
+
+func TestMergePR_ConflictPromotion(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		status        int
+		rejectionBody []byte
+	}{
+		{"405 rejection", http.StatusMethodNotAllowed, loadFixture(t, "error_405.json")},
+		{"409 rejection", http.StatusConflict, loadFixture(t, "error_409.json")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			rereadFixture := mergeRequestFixture(t, map[string]any{"state": "opened"})
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				switch {
+				case r.Method == http.MethodPut && strings.HasSuffix(r.URL.Path, "/merge"):
+					w.WriteHeader(tt.status)
+					_, _ = w.Write(tt.rejectionBody)
+				case r.Method == http.MethodGet:
+					_, _ = w.Write(rereadFixture)
+				default:
+					t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+					w.WriteHeader(http.StatusNotFound)
+				}
+			}))
+			defer srv.Close()
+
+			adapter := mustSCMAdapter(t, srv.URL)
+			_, err := adapter.MergePR(context.Background(), testPRNumber, scmOwner, scmRepo, domain.StrategyMerge, "", "", "sha-expected-head-001")
+
+			se := assertMergeConflict(t, err)
+			if strings.Contains(strings.ToLower(se.Message), "already merged") {
+				t.Errorf("SCMError.Message = %q, want it NOT to contain %q (the re-read shows the merge request still open)", se.Message, "already merged")
+			}
+		})
+	}
+}
+
+func TestMergePR_AlreadyMergedMarker(t *testing.T) {
+	t.Parallel()
+
+	statuses := []struct {
+		name          string
+		status        int
+		rejectionBody []byte
+	}{
+		{"405 rejection", http.StatusMethodNotAllowed, loadFixture(t, "error_405.json")},
+		{"409 rejection", http.StatusConflict, loadFixture(t, "error_409.json")},
+	}
+
+	for _, tt := range statuses {
+		t.Run(tt.name+" plus a merged re-read carries the already-merged marker", func(t *testing.T) {
+			t.Parallel()
+
+			rereadFixture := loadFixture(t, "mr_merged.json")
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				switch {
+				case r.Method == http.MethodPut && strings.HasSuffix(r.URL.Path, "/merge"):
+					w.WriteHeader(tt.status)
+					_, _ = w.Write(tt.rejectionBody)
+				case r.Method == http.MethodGet:
+					_, _ = w.Write(rereadFixture)
+				default:
+					t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+					w.WriteHeader(http.StatusNotFound)
+				}
+			}))
+			defer srv.Close()
+
+			adapter := mustSCMAdapter(t, srv.URL)
+			_, err := adapter.MergePR(context.Background(), testPRNumber, scmOwner, scmRepo, domain.StrategyMerge, "", "", "sha-expected-head-001")
+
+			adaptertest.AssertAlreadyMergedMarker(t, err)
+		})
+	}
+
+	t.Run("a failed re-read leaves the conflict without the already-merged marker", func(t *testing.T) {
+		t.Parallel()
+
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			switch {
+			case r.Method == http.MethodPut && strings.HasSuffix(r.URL.Path, "/merge"):
+				w.WriteHeader(http.StatusConflict)
+				_, _ = w.Write(loadFixture(t, "error_409.json"))
+			case r.Method == http.MethodGet:
+				w.WriteHeader(http.StatusInternalServerError)
+				_, _ = w.Write(loadFixture(t, "error_500.json"))
+			default:
+				t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+				w.WriteHeader(http.StatusNotFound)
+			}
+		}))
+		defer srv.Close()
+
+		adapter := mustSCMAdapter(t, srv.URL)
+		_, err := adapter.MergePR(context.Background(), testPRNumber, scmOwner, scmRepo, domain.StrategyMerge, "", "", "sha-expected-head-001")
+
+		se := assertMergeConflict(t, err)
+		if strings.Contains(strings.ToLower(se.Message), "already merged") {
+			t.Errorf("SCMError.Message = %q, want it NOT to contain %q (a failed re-read must not synthesize the marker)", se.Message, "already merged")
+		}
+	})
+}
+
+func TestMergePR_AuthEnrichment(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		status int
+		body   []byte
+	}{
+		{"401 from the merge route", http.StatusUnauthorized, loadFixture(t, "error_401.json")},
+		{"403 from the merge route", http.StatusForbidden, loadFixture(t, "error_403.json")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tt.status)
+				_, _ = w.Write(tt.body)
+			}))
+			defer srv.Close()
+
+			adapter := mustSCMAdapter(t, srv.URL)
+			_, err := adapter.MergePR(context.Background(), testPRNumber, scmOwner, scmRepo, domain.StrategyMerge, "", "", "sha-expected-head-001")
+			adaptertest.AssertSCMErrorKind(t, err, domain.ErrSCMAuth)
+
+			var se *domain.SCMError
+			if !errors.As(err, &se) {
+				t.Fatalf("error type = %T, want *domain.SCMError", err)
+			}
+			if !strings.Contains(se.Message, "credential is invalid") {
+				t.Errorf("SCMError.Message = %q, want it to name the invalid-credential cause", se.Message)
+			}
+			if !strings.Contains(se.Message, "may not merge into the target branch") {
+				t.Errorf("SCMError.Message = %q, want it to name the branch-protection-refusal cause", se.Message)
+			}
+		})
+	}
+}
+
+// assertMergeConflict fails the test if err is not a *domain.SCMError of
+// kind ErrSCMConflict, returning the typed error for further message
+// inspection.
+func assertMergeConflict(t *testing.T, err error) *domain.SCMError {
+	t.Helper()
+	adaptertest.AssertSCMErrorKind(t, err, domain.ErrSCMConflict)
+	var se *domain.SCMError
+	if !errors.As(err, &se) {
+		t.Fatalf("error type = %T, want *domain.SCMError", err)
+	}
+	return se
+}
+
+// --- DeleteBranch (AC6) ---
+
+func TestDeleteBranch_AbsentBranchDisposition(t *testing.T) {
+	t.Parallel()
+
+	errorBody := loadFixture(t, "error_404_project.json")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write(errorBody)
+	}))
+	defer srv.Close()
+
+	adapter := mustSCMAdapter(t, srv.URL)
+	err := adapter.DeleteBranch(context.Background(), scmOwner, scmRepo, "feature/gone")
+	adaptertest.AssertBranchAbsentDisposition(t, err)
+}
+
+func TestDeleteBranch_Success(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	adapter := mustSCMAdapter(t, srv.URL)
+	if err := adapter.DeleteBranch(context.Background(), scmOwner, scmRepo, "feature/done"); err != nil {
+		t.Fatalf("DeleteBranch: unexpected error: %v", err)
+	}
+}
+
+func TestDeleteBranch_SlashBearingNameEncoded(t *testing.T) {
+	t.Parallel()
+
+	var gotPath, gotEscapedPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotEscapedPath = r.URL.EscapedPath()
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	adapter := mustSCMAdapter(t, srv.URL)
+	if err := adapter.DeleteBranch(context.Background(), scmOwner, scmRepo, "feature/needs-slash"); err != nil {
+		t.Fatalf("DeleteBranch: unexpected error: %v", err)
+	}
+
+	wantPath := "/api/v4/projects/" + scmOwner + "/" + scmRepo + "/repository/branches/feature/needs-slash"
+	if gotPath != wantPath {
+		t.Errorf("decoded request path = %q, want %q", gotPath, wantPath)
+	}
+	const wantEscapedSuffix = "/repository/branches/feature%2Fneeds-slash"
+	if !strings.HasSuffix(gotEscapedPath, wantEscapedSuffix) {
+		t.Errorf("escaped request path = %q, want it to end with %q (the branch slash percent-encoded)", gotEscapedPath, wantEscapedSuffix)
+	}
+}
+
+// --- Cross-kind conflict isolation (AC9, R17, R36) ---
+
+func TestGitLabSCM_ConflictKindBelongsToMergeOnly(t *testing.T) {
+	t.Parallel()
+
+	statuses := []struct {
+		name          string
+		status        int
+		rejectionBody []byte
+	}{
+		{"405", http.StatusMethodNotAllowed, loadFixture(t, "error_405.json")},
+		{"409", http.StatusConflict, loadFixture(t, "error_409.json")},
+	}
+
+	for _, st := range statuses {
+		t.Run(st.name+" on DeleteBranch", func(t *testing.T) {
+			t.Parallel()
+
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(st.status)
+				_, _ = w.Write(st.rejectionBody)
+			}))
+			defer srv.Close()
+
+			adapter := mustSCMAdapter(t, srv.URL)
+			err := adapter.DeleteBranch(context.Background(), scmOwner, scmRepo, "feature/blocked-by-race")
+			adaptertest.AssertSCMErrorKind(t, err, domain.ErrSCMAPI)
+		})
+
+		t.Run(st.name+" on RemoveLabel", func(t *testing.T) {
+			t.Parallel()
+
+			mrFixture := mergeRequestFixture(t, map[string]any{"labels": []string{"Sortie:Review"}})
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				switch r.Method {
+				case http.MethodGet:
+					_, _ = w.Write(mrFixture)
+				case http.MethodPut:
+					w.WriteHeader(st.status)
+					_, _ = w.Write(st.rejectionBody)
+				default:
+					t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+					w.WriteHeader(http.StatusNotFound)
+				}
+			}))
+			defer srv.Close()
+
+			adapter := mustSCMAdapter(t, srv.URL)
+			err := adapter.RemoveLabel(context.Background(), testPRNumber, scmOwner, scmRepo, "sortie:review")
+			adaptertest.AssertSCMErrorKind(t, err, domain.ErrSCMAPI)
+		})
+	}
 }

--- a/internal/scm/gitlab/scm_merge_test.go
+++ b/internal/scm/gitlab/scm_merge_test.go
@@ -785,3 +785,73 @@ func TestGitLabSCM_ConflictKindBelongsToMergeOnly(t *testing.T) {
 		})
 	}
 }
+
+// --- MergePR: message composition and non-conflict failure classes ---
+
+func TestComposeMessage(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		title string
+		body  string
+		want  string
+	}{
+		{"both sides join with a blank line", "Merge feature", "Closes the cycle.", "Merge feature\n\nCloses the cycle."},
+		{"an empty body yields the title alone", "Merge feature", "", "Merge feature"},
+		{"an empty title yields the body alone", "", "Closes the cycle.", "Closes the cycle."},
+		{"both empty leaves the platform default", "", "", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := composeMessage(tt.title, tt.body); got != tt.want {
+				t.Errorf("composeMessage(%q, %q) = %q, want %q", tt.title, tt.body, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMergePR_NonConflictErrorPassthrough(t *testing.T) {
+	t.Parallel()
+
+	var requests atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write(loadFixture(t, "error_500.json"))
+	}))
+	defer srv.Close()
+
+	adapter := mustSCMAdapter(t, srv.URL)
+	got, err := adapter.MergePR(context.Background(), testPRNumber, scmOwner, scmRepo, domain.StrategyMerge, "", "", "sha-expected-head-001")
+
+	adaptertest.AssertSCMErrorKind(t, err, domain.ErrSCMTransport)
+	if got != (domain.MergeResult{}) {
+		t.Errorf("MergePR(...) result = %+v, want the zero value", got)
+	}
+	if n := requests.Load(); n != 1 {
+		t.Errorf("requests = %d, want 1 (a non-conflict rejection must not trigger a merge request re-read)", n)
+	}
+}
+
+func TestMergePR_MalformedSuccessBody(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"state": "merged"`))
+	}))
+	defer srv.Close()
+
+	adapter := mustSCMAdapter(t, srv.URL)
+	got, err := adapter.MergePR(context.Background(), testPRNumber, scmOwner, scmRepo, domain.StrategyMerge, "", "", "sha-expected-head-001")
+
+	adaptertest.AssertSCMErrorKind(t, err, domain.ErrSCMPayload)
+	if got != (domain.MergeResult{}) {
+		t.Errorf("MergePR(...) result = %+v, want the zero value", got)
+	}
+}

--- a/internal/scm/gitlab/scm_scope.go
+++ b/internal/scm/gitlab/scm_scope.go
@@ -1,0 +1,54 @@
+package gitlab
+
+import (
+	"context"
+	"encoding/json"
+	"slices"
+
+	"github.com/sortie-ai/sortie/internal/domain"
+)
+
+// VerifyAutoMergeScopes reports whether the configured credential can
+// perform GitLab's merge, branch-delete, and label-write routes, reading
+// GET /personal_access_tokens/self once.
+//
+// requireContents is accepted and ignored: GitLab has no contents and
+// pull-request scope split, so the single coarse api scope covers every
+// write this adapter performs. A non-empty scopes with an empty missing
+// means the credential can perform the writes; a non-empty missing
+// (always ["api"]) is a verified gap. (nil, nil, nil) means no usable
+// scope report is available and the caller fails open: this covers a
+// granular token, whose Scopes carry no usable permission detail, an
+// empty Scopes array, an unreadable response body, and an instance whose
+// introspection route answers 404, which never distinguishes an absent
+// route from a credential that cannot see it. Any other failure is
+// returned as err.
+func (a *GitLabSCMAdapter) VerifyAutoMergeScopes(ctx context.Context, requireContents bool) (scopes []string, missing []string, err error) {
+	body, _, getErr := a.client.Get(ctx, "/personal_access_tokens/self", nil)
+	if getErr != nil {
+		scm := asSCMError(getErr)
+		if scm.Kind == domain.ErrSCMNotFound {
+			a.log.Warn("gitlab token introspection route unavailable")
+			return nil, nil, nil
+		}
+		return nil, nil, scm
+	}
+
+	var info gitlabTokenInfo
+	if jsonErr := json.Unmarshal(body, &info); jsonErr != nil {
+		a.log.Warn("gitlab token introspection unreadable")
+		return nil, nil, nil
+	}
+
+	if info.Revoked || !info.Active {
+		a.log.Warn("gitlab token reports revoked or inactive")
+	}
+
+	if info.Granular || slices.Contains(info.Scopes, "granular") || len(info.Scopes) == 0 {
+		return nil, nil, nil
+	}
+	if slices.Contains(info.Scopes, "api") {
+		return info.Scopes, nil, nil
+	}
+	return nil, []string{"api"}, nil
+}

--- a/internal/scm/gitlab/scm_scope.go
+++ b/internal/scm/gitlab/scm_scope.go
@@ -12,17 +12,17 @@ import (
 // perform GitLab's merge, branch-delete, and label-write routes, reading
 // GET /personal_access_tokens/self once.
 //
-// requireContents is accepted and ignored: GitLab has no contents and
-// pull-request scope split, so the single coarse api scope covers every
-// write this adapter performs. A non-empty scopes with an empty missing
-// means the credential can perform the writes; a non-empty missing
-// (always ["api"]) is a verified gap. (nil, nil, nil) means no usable
-// scope report is available and the caller fails open: this covers a
-// granular token, whose Scopes carry no usable permission detail, an
-// empty Scopes array, an unreadable response body, and an instance whose
-// introspection route answers 404, which never distinguishes an absent
-// route from a credential that cannot see it. Any other failure is
-// returned as err.
+// requireContents is accepted and ignored, because GitLab has one coarse
+// api scope covering every write this adapter performs rather than a
+// contents and pull-request split. A non-empty scopes slice with an empty
+// missing list means the credential can perform those writes; a non-empty
+// missing list (always ["api"]) is a verified gap. The (nil, nil, nil)
+// sentinel means no usable scope report exists and the caller fails open,
+// which covers a granular token whose scopes carry no permission detail,
+// an empty scopes array, an unreadable response body, and an instance
+// answering 404 on the introspection route, a status that never separates
+// an absent route from a credential that cannot see it. Any other failure
+// is returned as err.
 func (a *GitLabSCMAdapter) VerifyAutoMergeScopes(ctx context.Context, requireContents bool) (scopes []string, missing []string, err error) {
 	body, _, getErr := a.client.Get(ctx, "/personal_access_tokens/self", nil)
 	if getErr != nil {

--- a/internal/scm/gitlab/scm_scope_test.go
+++ b/internal/scm/gitlab/scm_scope_test.go
@@ -1,0 +1,187 @@
+package gitlab
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/sortie-ai/sortie/internal/adaptertest"
+	"github.com/sortie-ai/sortie/internal/domain"
+)
+
+// --- VerifyAutoMergeScopes: scope report (R25, R27, AC8) ---
+
+func TestVerifyAutoMergeScopes_ScopeReport(t *testing.T) {
+	t.Parallel()
+
+	t.Run("scopes carrying api yields the scope list with an empty missing", func(t *testing.T) {
+		t.Parallel()
+
+		fixture := loadFixture(t, "token_self.json")
+		srv := serveJSON(t, fixture)
+		defer srv.Close()
+
+		adapter := mustSCMAdapter(t, srv.URL)
+		scopes, missing, err := adapter.VerifyAutoMergeScopes(context.Background(), false)
+		if err != nil {
+			t.Fatalf("VerifyAutoMergeScopes: unexpected error: %v", err)
+		}
+		if len(scopes) == 0 {
+			t.Errorf("VerifyAutoMergeScopes() scopes = %v, want non-empty", scopes)
+		}
+		if len(missing) != 0 {
+			t.Errorf("VerifyAutoMergeScopes() missing = %v, want empty", missing)
+		}
+	})
+
+	t.Run("read_api-only scopes yields missing=[api] with a nil error", func(t *testing.T) {
+		t.Parallel()
+
+		fixture := loadFixture(t, "token_self_read_api_only.json")
+		srv := serveJSON(t, fixture)
+		defer srv.Close()
+
+		adapter := mustSCMAdapter(t, srv.URL)
+		scopes, missing, err := adapter.VerifyAutoMergeScopes(context.Background(), false)
+		if err != nil {
+			t.Fatalf("VerifyAutoMergeScopes: unexpected error: %v", err)
+		}
+		if scopes != nil {
+			t.Errorf("VerifyAutoMergeScopes() scopes = %v, want nil", scopes)
+		}
+		if len(missing) != 1 || missing[0] != "api" {
+			t.Errorf("VerifyAutoMergeScopes() missing = %v, want [api]", missing)
+		}
+	})
+}
+
+// --- VerifyAutoMergeScopes: fail-open sentinel (R26, R26a) ---
+
+func TestVerifyAutoMergeScopes_FailOpen(t *testing.T) {
+	t.Parallel()
+
+	t.Run("a granular token yields the fail-open sentinel", func(t *testing.T) {
+		t.Parallel()
+
+		fixture := loadFixture(t, "token_self_granular.json")
+		srv := serveJSON(t, fixture)
+		defer srv.Close()
+
+		adapter := mustSCMAdapter(t, srv.URL)
+		scopes, missing, err := adapter.VerifyAutoMergeScopes(context.Background(), false)
+		if err != nil {
+			t.Fatalf("VerifyAutoMergeScopes: unexpected error: %v", err)
+		}
+		if scopes != nil || missing != nil {
+			t.Errorf("VerifyAutoMergeScopes() = (%v, %v, nil), want (nil, nil, nil)", scopes, missing)
+		}
+	})
+
+	t.Run("an empty scopes array yields the fail-open sentinel", func(t *testing.T) {
+		t.Parallel()
+
+		fixture := loadFixture(t, "token_self_empty_scopes.json")
+		srv := serveJSON(t, fixture)
+		defer srv.Close()
+
+		adapter := mustSCMAdapter(t, srv.URL)
+		scopes, missing, err := adapter.VerifyAutoMergeScopes(context.Background(), false)
+		if err != nil {
+			t.Fatalf("VerifyAutoMergeScopes: unexpected error: %v", err)
+		}
+		if scopes != nil || missing != nil {
+			t.Errorf("VerifyAutoMergeScopes() = (%v, %v, nil), want (nil, nil, nil)", scopes, missing)
+		}
+	})
+
+	t.Run("an undecodable body yields the fail-open sentinel", func(t *testing.T) {
+		t.Parallel()
+
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`not valid json {{{`))
+		}))
+		defer srv.Close()
+
+		adapter := mustSCMAdapter(t, srv.URL)
+		scopes, missing, err := adapter.VerifyAutoMergeScopes(context.Background(), false)
+		if err != nil {
+			t.Fatalf("VerifyAutoMergeScopes: unexpected error: %v", err)
+		}
+		if scopes != nil || missing != nil {
+			t.Errorf("VerifyAutoMergeScopes() = (%v, %v, nil), want (nil, nil, nil)", scopes, missing)
+		}
+	})
+
+	t.Run("a 404 on the introspection route yields the fail-open sentinel and logs one WARN naming the route", func(t *testing.T) {
+		t.Parallel()
+
+		errorBody := loadFixture(t, "error_404_project.json")
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write(errorBody)
+		}))
+		defer srv.Close()
+
+		adapter := mustSCMAdapter(t, srv.URL)
+		log, buf := newCapturingLogger()
+		adapter.log = log
+
+		scopes, missing, err := adapter.VerifyAutoMergeScopes(context.Background(), false)
+		if err != nil {
+			t.Fatalf("VerifyAutoMergeScopes: unexpected error: %v", err)
+		}
+		if scopes != nil || missing != nil {
+			t.Errorf("VerifyAutoMergeScopes() = (%v, %v, nil), want (nil, nil, nil)", scopes, missing)
+		}
+
+		logOutput := buf.String()
+		if !strings.Contains(logOutput, "gitlab token introspection route unavailable") {
+			t.Errorf("log output = %q, want it to contain %q", logOutput, "gitlab token introspection route unavailable")
+		}
+	})
+}
+
+// --- VerifyAutoMergeScopes: error classes (R29, AC8) ---
+
+func TestVerifyAutoMergeScopes_ErrorClasses(t *testing.T) {
+	t.Parallel()
+
+	t.Run("a 401 yields ErrSCMAuth", func(t *testing.T) {
+		t.Parallel()
+
+		errorBody := loadFixture(t, "error_401.json")
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write(errorBody)
+		}))
+		defer srv.Close()
+
+		adapter := mustSCMAdapter(t, srv.URL)
+		scopes, missing, err := adapter.VerifyAutoMergeScopes(context.Background(), false)
+		adaptertest.AssertSCMErrorKind(t, err, domain.ErrSCMAuth)
+		if scopes != nil || missing != nil {
+			t.Errorf("VerifyAutoMergeScopes() = (%v, %v, err), want (nil, nil, err)", scopes, missing)
+		}
+	})
+
+	t.Run("a 500 yields ErrSCMTransport", func(t *testing.T) {
+		t.Parallel()
+
+		errorBody := loadFixture(t, "error_500.json")
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write(errorBody)
+		}))
+		defer srv.Close()
+
+		adapter := mustSCMAdapter(t, srv.URL)
+		scopes, missing, err := adapter.VerifyAutoMergeScopes(context.Background(), false)
+		adaptertest.AssertSCMErrorKind(t, err, domain.ErrSCMTransport)
+		if scopes != nil || missing != nil {
+			t.Errorf("VerifyAutoMergeScopes() = (%v, %v, err), want (nil, nil, err)", scopes, missing)
+		}
+	})
+}

--- a/internal/scm/gitlab/scm_scope_test.go
+++ b/internal/scm/gitlab/scm_scope_test.go
@@ -185,3 +185,29 @@ func TestVerifyAutoMergeScopes_ErrorClasses(t *testing.T) {
 		}
 	})
 }
+
+func TestVerifyAutoMergeScopes_RevokedTokenWarns(t *testing.T) {
+	t.Parallel()
+
+	srv := serveJSON(t, loadFixture(t, "token_self_revoked.json"))
+	defer srv.Close()
+
+	adapter := mustSCMAdapter(t, srv.URL)
+	log, buf := newCapturingLogger()
+	adapter.log = log
+
+	scopes, missing, err := adapter.VerifyAutoMergeScopes(context.Background(), false)
+	if err != nil {
+		t.Fatalf("VerifyAutoMergeScopes: unexpected error: %v", err)
+	}
+	if len(scopes) == 0 {
+		t.Errorf("VerifyAutoMergeScopes() scopes = %v, want non-empty (a revoked token still reports its granted scopes)", scopes)
+	}
+	if len(missing) != 0 {
+		t.Errorf("VerifyAutoMergeScopes() missing = %v, want empty", missing)
+	}
+
+	if logOutput := buf.String(); !strings.Contains(logOutput, "gitlab token reports revoked or inactive") {
+		t.Errorf("log output = %q, want it to contain %q", logOutput, "gitlab token reports revoked or inactive")
+	}
+}

--- a/internal/scm/gitlab/scm_test.go
+++ b/internal/scm/gitlab/scm_test.go
@@ -4,11 +4,14 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"go/parser"
+	"go/token"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
-	"reflect"
+	"os"
 	"strconv"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -37,7 +40,7 @@ func mustSCMAdapter(t *testing.T, endpoint string) *GitLabSCMAdapter {
 	if err != nil {
 		t.Fatalf("NewGitLabSCMAdapter: %v", err)
 	}
-	return a
+	return a.(*GitLabSCMAdapter)
 }
 
 // newCapturingLogger returns a logger backed by a buffer so a test can
@@ -578,19 +581,78 @@ func TestErrorStatusMapping(t *testing.T) {
 	}
 }
 
-// --- No write methods, no registration (R4) ---
+// --- Registration (R34, AC1) ---
 
-func TestGitLabSCM_NoWriteMethodsNoRegistration(t *testing.T) {
+func TestGitLabSCMRegistration(t *testing.T) {
 	t.Parallel()
 
-	adapterType := reflect.TypeFor[*GitLabSCMAdapter]()
-	for _, banned := range []string{"MergePR", "DeleteBranch", "RemoveLabel"} {
-		if _, ok := adapterType.MethodByName(banned); ok {
-			t.Errorf("*GitLabSCMAdapter declares %s, which belongs to the write half", banned)
+	if !registry.SCMAdapters.Has("gitlab") {
+		t.Fatal(`SCMAdapters.Has("gitlab") = false, want true`)
+	}
+
+	constructor, err := registry.SCMAdapters.Get("gitlab")
+	if err != nil {
+		t.Fatalf(`SCMAdapters.Get("gitlab") = %v, want registered constructor`, err)
+	}
+
+	adapter, err := constructor(map[string]any{
+		"api_key":  "test-token",
+		"endpoint": "http://gitlab.invalid",
+	})
+	if err != nil {
+		t.Fatalf("registered gitlab SCM constructor(...) = %v, want nil error", err)
+	}
+	if _, ok := adapter.(*GitLabSCMAdapter); !ok {
+		t.Errorf("registered gitlab SCM constructor(...) = %T, want *GitLabSCMAdapter", adapter)
+	}
+
+	if !registry.Trackers.Has("gitlab") {
+		t.Error(`Trackers.Has("gitlab") = false, want true (SCM registration must not disturb the tracker registration)`)
+	}
+}
+
+// --- Write-path import boundary (R38) ---
+
+func TestGitLabSCMWriteBoundary(t *testing.T) {
+	t.Parallel()
+
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("ReadDir(.): %v", err)
+	}
+
+	banned := []string{
+		"github.com/sortie-ai/sortie/internal/scm/github",
+		"github.com/sortie-ai/sortie/internal/scm/gitea",
+		"github.com/sortie-ai/sortie/internal/tracker/",
+		"github.com/sortie-ai/sortie/internal/orchestrator",
+	}
+
+	fset := token.NewFileSet()
+	checked := 0
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".go") {
+			continue
+		}
+		checked++
+
+		f, parseErr := parser.ParseFile(fset, name, nil, parser.ImportsOnly)
+		if parseErr != nil {
+			t.Fatalf("ParseFile(%s): %v", name, parseErr)
+		}
+
+		for _, imp := range f.Imports {
+			importPath := strings.Trim(imp.Path.Value, `"`)
+			for _, forbidden := range banned {
+				if strings.Contains(importPath, forbidden) {
+					t.Errorf("%s imports %q, want no import matching %q", name, importPath, forbidden)
+				}
+			}
 		}
 	}
 
-	if registry.SCMAdapters.Has("gitlab") {
-		t.Error(`registry.SCMAdapters.Has("gitlab") = true, want false (registration is out of scope for this task)`)
+	if checked == 0 {
+		t.Fatal("no .go files were checked, want at least one")
 	}
 }

--- a/internal/scm/gitlab/testdata/token_self_empty_scopes.json
+++ b/internal/scm/gitlab/testdata/token_self_empty_scopes.json
@@ -1,0 +1,10 @@
+{
+  "id": 10,
+  "name": "sortie-ci-no-scopes",
+  "revoked": false,
+  "created_at": "2026-01-01T00:00:00.000Z",
+  "scopes": [],
+  "user_id": 3,
+  "active": true,
+  "expires_at": "2027-01-01"
+}

--- a/internal/scm/gitlab/testdata/token_self_granular.json
+++ b/internal/scm/gitlab/testdata/token_self_granular.json
@@ -1,0 +1,11 @@
+{
+  "id": 9,
+  "name": "sortie-ci-granular",
+  "revoked": false,
+  "created_at": "2026-01-01T00:00:00.000Z",
+  "scopes": ["granular"],
+  "granular": true,
+  "user_id": 3,
+  "active": true,
+  "expires_at": "2027-01-01"
+}

--- a/internal/scm/gitlab/testdata/token_self_read_api_only.json
+++ b/internal/scm/gitlab/testdata/token_self_read_api_only.json
@@ -1,0 +1,10 @@
+{
+  "id": 8,
+  "name": "sortie-ci-read-only",
+  "revoked": false,
+  "created_at": "2026-01-01T00:00:00.000Z",
+  "scopes": ["read_api"],
+  "user_id": 3,
+  "active": true,
+  "expires_at": "2027-01-01"
+}

--- a/internal/scm/gitlab/testdata/token_self_revoked.json
+++ b/internal/scm/gitlab/testdata/token_self_revoked.json
@@ -1,0 +1,10 @@
+{
+  "id": 9,
+  "name": "sortie-ci-revoked",
+  "revoked": true,
+  "created_at": "2026-01-01T00:00:00.000Z",
+  "scopes": ["api", "read_api"],
+  "user_id": 3,
+  "active": false,
+  "expires_at": "2027-01-01"
+}


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Feat

**Intent:** Complete the write half of `domain.SCMAdapter` for GitLab so auto-merge and post-merge branch cleanup become available on GitLab deployments, and register the `gitlab` kind so `provider: gitlab` becomes a resolvable reaction setting.

**Related Issues:** #721

### 🧭 Reviewer Guide

**Complexity:** Medium

#### Entry Point

Start with `internal/scm/gitlab/scm_merge.go`. It implements `MergePR`, sending the precondition SHA so GitLab rejects the call when the head has moved, and re-reads the merge request afterward to mark the already-merged subcase distinctly from a head-drift refusal - the disambiguation is driven by the post-merge state, never by pattern-matching the rejection body. `internal/scm/gitlab/scm_label_events.go` adds `DeleteBranch` and `RemoveLabel`, each with its own absent-resource disposition rather than sharing the merge path's conflict kind. `internal/scm/gitlab/scm_scope.go` adds the construction-time token-scope preflight, and `internal/scm/gitlab/scm.go` registers the `gitlab` kind with `registry.SCMAdapters` now that the adapter satisfies the full interface.

#### Sensitive Areas

- `internal/scm/gitlab/scm_merge.go`: precondition-SHA handling and the already-merged disambiguation are the parts of the contract most likely to regress silently if reworded upstream.
- `internal/scm/gitlab/scm_scope.go`: the preflight fails open when the token's scope report is opaque (granular tokens) or when the introspection route is unreachable, rather than blocking construction - worth confirming this matches the intended safety posture.
- `internal/scm/gitlab/scm.go`: registry registration changes adapter construction behavior for any workflow already configuring `provider: gitlab`.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes.
- **Migrations/State:** No migrations or state changes.
