### PR TITLE
docs: add a pkg.go.dev badge to the READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Turn tracker tickets into autonomous agent sessions. Agent-agnostic, tracker-agn
 
 [![CI](https://github.com/sortie-ai/sortie/actions/workflows/ci.yml/badge.svg)](https://github.com/sortie-ai/sortie/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/sortie-ai/sortie/graph/badge.svg?token=K2TPXBCbvb)](https://codecov.io/gh/sortie-ai/sortie)
+[![Go Reference](https://pkg.go.dev/badge/github.com/sortie-ai/sortie.svg)](https://pkg.go.dev/github.com/sortie-ai/sortie)
 
 [Documentation](https://docs.sortie-ai.com) · [Contributing](CONTRIBUTING.md)
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -12,6 +12,7 @@
 
 [![CI](https://github.com/sortie-ai/sortie/actions/workflows/ci.yml/badge.svg)](https://github.com/sortie-ai/sortie/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/sortie-ai/sortie/graph/badge.svg?token=K2TPXBCbvb)](https://codecov.io/gh/sortie-ai/sortie)
+[![Go Reference](https://pkg.go.dev/badge/github.com/sortie-ai/sortie.svg)](https://pkg.go.dev/github.com/sortie-ai/sortie)
 
 [文档](https://docs.sortie-ai.com) · [参与贡献](CONTRIBUTING.md)
 


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Chore

**Intent:** The Go module proxy now publishes a version list for this module, so the pkg.go.dev page resolves to a tagged release instead of a pseudo-version. The badge therefore reports something meaningful for the first time, and it gives readers a direct route to the package reference from the front page.

### 🧭 Reviewer Guide

**Complexity:** Low

#### Entry Point

`README.md` - one line added to the badge block, directly below the existing coverage badge. `README.zh-CN.md` receives the identical line so the English and Chinese front pages do not drift apart; the two badge blocks were byte-identical before this change and remain so after it.

Both the badge image and the page it links to were checked and return HTTP 200.

Go Report Card is deliberately left out. That service is retired - its report page for this repository renders only `go report: retired` - so a badge for it would advertise a dead grade permanently.

#### Sensitive Areas

- None. The change adds no code, alters no build or release behaviour, and touches only the badge block of the two README files.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes
- **Migrations/State:** No migrations or state changes