### PR TITLE
test(scm/gitlab): add env-gated integration tests for the SCM and CI surface

### DIFF
--- a/docs/gitlab-adapter-notes.md
+++ b/docs/gitlab-adapter-notes.md
@@ -1747,6 +1747,14 @@ per external status, each with `name`, `status`, `allow_failure`, `pipeline_id`,
 | `created`, `pending`, `waiting_for_resource`, `preparing`, `scheduled` | `pending` | `queued` |
 | `running` | `pending` | `in_progress` |
 
+**The statuses route paginates.** `GET /projects/:id/repository/commits/:sha/statuses` returns
+`X-Per-Page: 20` by default and honors `per_page` up to 100, advertising `X-Total`,
+`X-Total-Pages`, `X-Next-Page`, and a `Link` header carrying `rel="next"` **[live-CE]**. A commit
+carrying 103 seeded statuses returned 100 entries on page one with `X-Total-Pages: 2` and a
+`rel="next"` link at `per_page=100`, confirming `FetchCIStatus`'s walk through
+`httpkit.NewLinkPaginator` must cross a page boundary to see the full set on a pipeline this
+size.
+
 **`allow_failure` belongs in the conclusion, not in the aggregate.** Neither the aggregate nor
 the failing count is the adapter's to choose: `scmcore.AggregateCIStatus` and
 `scmcore.FailingCount` compute both from the normalized `CheckRun` set, and
@@ -2389,6 +2397,5 @@ Carried forward explicitly rather than resolved by inference:
 | Is the timestamp-and-stream prefix on the job trace a property of the API, the runner version, or a runner feature flag? | Decides whether the trace sanitizer can rely on the prefix being present, or must handle both shapes | Fetch a trace produced by an older runner, and one produced with the runner timestamp feature flag disabled |
 | Does the notes route on a merge request paginate and filter identically to the issue variant? | The comment normalization is assumed shared; a divergence would surface as dropped review comments | Seed a merge request with more than 100 notes and repeat the issue-side pagination and `activity_filter` probes |
 | Does `GET /users/:id` draw on a distinct rate-limit budget from the merge-request reads? | Bot classification adds one request per distinct author; a stricter budget would change the caching strategy | Compare `RateLimit-Name` on a throttled `GET /users/:id` against a throttled merge-request read on GitLab.com |
-| Does `GET /projects/:id/repository/commits/:sha/statuses` paginate, and at what page size? | `FetchCIStatus` builds `CheckRuns` from that route and the shared aggregate is computed over whatever the adapter returns, so a silently truncated first page would report a passing verdict for a pipeline whose failing job sits beyond it. Every other list route on this instance paginates at 20 by default **[live-CE]** | Seed a pipeline with more jobs than the default page size, read the route with and without `per_page`, and compare `X-Total` and the `rel="next"` link against the entry count |
 | Should `GetCIStatus` map `head_pipeline.status` into the merge-gate vocabulary, or fetch the statuses list and call `scmcore.MergeGate` over the normalized runs? | The first preserves the measured one-request saving; the second shares the code path rather than only the rule, and cannot drift from `FetchCIStatus` on a status the two partition differently | Compare the two answers on a pipeline whose top-level status and normalized run set disagree, starting with a wholly `skipped` pipeline and with the `allow_failure` warnings-only case |
 | Does self-managed Enterprise Edition behave as its source implies? | Every Enterprise Edition claim here is source plus documentation, never observed | Run the same probe set against a licensed self-managed Enterprise Edition instance |

--- a/internal/scm/gitlab/integration_merge_test.go
+++ b/internal/scm/gitlab/integration_merge_test.go
@@ -1,0 +1,468 @@
+package gitlab
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sortie-ai/sortie/internal/adaptertest"
+	"github.com/sortie-ai/sortie/internal/domain"
+)
+
+// gitlabMergeFixture is a minimal GitLab REST client used only to build
+// and clean up the throwaway merge requests the write tests drive. It
+// never calls a method under test (domain.SCMAdapter or
+// domain.CIStatusProvider).
+type gitlabMergeFixture struct {
+	token      string
+	baseURL    string
+	httpClient *http.Client
+}
+
+// newGitLabMergeFixture builds the fixture client from the integration
+// env vars, authenticating with SORTIE_GITLAB_TOKEN in the PRIVATE-TOKEN
+// header against SORTIE_GITLAB_ENDPOINT suffixed with /api/v4.
+func newGitLabMergeFixture(t *testing.T) *gitlabMergeFixture {
+	t.Helper()
+	endpoint := strings.TrimRight(requireEnv(t, "SORTIE_GITLAB_ENDPOINT"), "/")
+	if !strings.HasSuffix(endpoint, "/api/v4") {
+		endpoint += "/api/v4"
+	}
+	return &gitlabMergeFixture{
+		token:      requireEnv(t, "SORTIE_GITLAB_TOKEN"),
+		baseURL:    endpoint,
+		httpClient: &http.Client{Timeout: 30 * time.Second},
+	}
+}
+
+// do executes a request and fails the test on a transport error or a
+// non-2xx status, returning the raw response body.
+func (f *gitlabMergeFixture) do(t *testing.T, method, path string, body any) []byte {
+	t.Helper()
+
+	var reader io.Reader
+	if body != nil {
+		data, err := json.Marshal(body)
+		if err != nil {
+			t.Fatalf("marshal body for %s %s: %v", method, path, err)
+		}
+		reader = bytes.NewReader(data)
+	}
+
+	req, err := http.NewRequestWithContext(context.Background(), method, f.baseURL+path, reader)
+	if err != nil {
+		t.Fatalf("build request %s %s: %v", method, path, err)
+	}
+	req.Header.Set("PRIVATE-TOKEN", f.token)
+	req.Header.Set("Accept", "application/json")
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	resp, err := f.httpClient.Do(req)
+	if err != nil {
+		t.Fatalf("%s %s: %v", method, path, err)
+	}
+	defer resp.Body.Close() //nolint:errcheck // test helper; best-effort cleanup
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read response for %s %s: %v", method, path, err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		t.Fatalf("%s %s returned %d: %s", method, path, resp.StatusCode, string(respBody))
+	}
+	return respBody
+}
+
+// doStatus executes a request and returns the status code, tolerating a
+// non-2xx response so cleanup helpers can ignore an already-gone
+// resource.
+func (f *gitlabMergeFixture) doStatus(method, path string, body any) (int, error) {
+	var reader io.Reader
+	if body != nil {
+		data, err := json.Marshal(body)
+		if err != nil {
+			return 0, fmt.Errorf("marshal body: %w", err)
+		}
+		reader = bytes.NewReader(data)
+	}
+
+	req, err := http.NewRequestWithContext(context.Background(), method, f.baseURL+path, reader)
+	if err != nil {
+		return 0, fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("PRIVATE-TOKEN", f.token)
+	req.Header.Set("Accept", "application/json")
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	resp, err := f.httpClient.Do(req)
+	if err != nil {
+		return 0, err
+	}
+	defer resp.Body.Close()        //nolint:errcheck // cleanup helper
+	io.Copy(io.Discard, resp.Body) //nolint:errcheck // drain body to reuse connection
+	return resp.StatusCode, nil
+}
+
+// gitlabFixtureMergeRequest decodes the fields the fixture client reads
+// off a merge-request response: the current head SHA and the settled
+// mergeability status.
+type gitlabFixtureMergeRequest struct {
+	SHA                 string `json:"sha"`
+	DetailedMergeStatus string `json:"detailed_merge_status"`
+}
+
+// createBranch creates branch from ref in project, failing the test on
+// a transport or HTTP error. project is the percent-encoded path the
+// adapter itself addresses.
+func (f *gitlabMergeFixture) createBranch(t *testing.T, project, branch, ref string) {
+	t.Helper()
+	f.do(t, http.MethodPost, "/projects/"+project+"/repository/branches", map[string]any{
+		"branch": branch,
+		"ref":    ref,
+	})
+}
+
+// commitFile commits a single file to branch and returns the resulting
+// commit SHA, read from the commits response's id field; the files route
+// returns no commit identifier.
+func (f *gitlabMergeFixture) commitFile(t *testing.T, project, branch, path, content string) string {
+	t.Helper()
+	resp := f.do(t, http.MethodPost, "/projects/"+project+"/repository/commits", map[string]any{
+		"branch":         branch,
+		"commit_message": "test: " + path,
+		"actions": []map[string]any{
+			{"action": "create", "file_path": path, "content": content},
+		},
+	})
+	var commit struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal(resp, &commit); err != nil {
+		t.Fatalf("unmarshal commit response: %v", err)
+	}
+	if commit.ID == "" {
+		t.Fatal("commit response carried no id")
+	}
+	return commit.ID
+}
+
+// openMR opens a merge request from source to target and returns its
+// iid.
+func (f *gitlabMergeFixture) openMR(t *testing.T, project, source, target, title string) int {
+	t.Helper()
+	resp := f.do(t, http.MethodPost, "/projects/"+project+"/merge_requests", map[string]any{
+		"source_branch": source,
+		"target_branch": target,
+		"title":         title,
+	})
+	var mr struct {
+		IID int `json:"iid"`
+	}
+	if err := json.Unmarshal(resp, &mr); err != nil {
+		t.Fatalf("unmarshal create merge request response: %v", err)
+	}
+	return mr.IID
+}
+
+// headSHA re-reads the merge request and returns its current head SHA.
+func (f *gitlabMergeFixture) headSHA(t *testing.T, project string, iid int) string {
+	t.Helper()
+	resp := f.do(t, http.MethodGet, "/projects/"+project+"/merge_requests/"+strconv.Itoa(iid), nil)
+	var mr gitlabFixtureMergeRequest
+	if err := json.Unmarshal(resp, &mr); err != nil {
+		t.Fatalf("unmarshal merge request response: %v", err)
+	}
+	return mr.SHA
+}
+
+// addLabel attaches label to the merge request via add_labels, letting
+// GitLab store whatever casing label carries.
+func (f *gitlabMergeFixture) addLabel(t *testing.T, project string, iid int, label string) {
+	t.Helper()
+	f.do(t, http.MethodPut, "/projects/"+project+"/merge_requests/"+strconv.Itoa(iid), map[string]any{
+		"add_labels": label,
+	})
+}
+
+// closeMR closes the merge request if still open, tolerating an
+// already-closed or already-merged state.
+func (f *gitlabMergeFixture) closeMR(t *testing.T, project string, iid int) {
+	t.Helper()
+	status, err := f.doStatus(http.MethodPut, "/projects/"+project+"/merge_requests/"+strconv.Itoa(iid), map[string]any{
+		"state_event": "close",
+	})
+	if err != nil || status >= 300 {
+		t.Logf("cleanup: close merge request !%d returned status=%d err=%v (tolerated)", iid, status, err)
+	}
+}
+
+// deleteBranch deletes branch, tolerating a 404 when it is already gone.
+func (f *gitlabMergeFixture) deleteBranch(t *testing.T, project, branch string) {
+	t.Helper()
+	status, err := f.doStatus(http.MethodDelete,
+		"/projects/"+project+"/repository/branches/"+branch, nil)
+	if err != nil || (status >= 300 && status != http.StatusNotFound) {
+		t.Logf("cleanup: delete branch %q returned status=%d err=%v (tolerated)", branch, status, err)
+	}
+}
+
+// awaitMergeability polls the merge request's detailed_merge_status with
+// a bounded number of tries until it leaves the computing set
+// (unchecked, checking, preparing, approvals_syncing), and returns
+// whatever status is observed last, settled or not; the caller decides
+// what a settled value other than the one it expects means.
+func (f *gitlabMergeFixture) awaitMergeability(t *testing.T, project string, iid int) string {
+	t.Helper()
+
+	const maxAttempts = 10
+	const pollInterval = 2 * time.Second
+
+	computing := map[string]bool{
+		"unchecked":         true,
+		"checking":          true,
+		"preparing":         true,
+		"approvals_syncing": true,
+	}
+
+	var status string
+	for attempt := range maxAttempts {
+		resp := f.do(t, http.MethodGet, "/projects/"+project+"/merge_requests/"+strconv.Itoa(iid), nil)
+		var mr gitlabFixtureMergeRequest
+		if err := json.Unmarshal(resp, &mr); err != nil {
+			t.Fatalf("unmarshal merge request response: %v", err)
+		}
+		status = mr.DetailedMergeStatus
+		if !computing[status] {
+			return status
+		}
+		if attempt < maxAttempts-1 {
+			time.Sleep(pollInterval)
+		}
+	}
+	return status
+}
+
+// mergeSuffix returns a per-run random suffix so branch and merge-request
+// names never collide across repeated runs against one provisioned
+// instance.
+func mergeSuffix(t *testing.T) string {
+	t.Helper()
+	b := make([]byte, 4)
+	if _, err := rand.Read(b); err != nil {
+		t.Fatalf("read random bytes for merge fixture suffix: %v", err)
+	}
+	return fmt.Sprintf("%d-%s", time.Now().UnixNano(), hex.EncodeToString(b))
+}
+
+// fixtureDefaultBranch reads project's default branch, so the write tests
+// cut their own throwaway branches from the real default rather than
+// assuming a name.
+func fixtureDefaultBranch(t *testing.T, f *gitlabMergeFixture, project string) string {
+	t.Helper()
+	resp := f.do(t, http.MethodGet, "/projects/"+project, nil)
+	var proj struct {
+		DefaultBranch string `json:"default_branch"`
+	}
+	if err := json.Unmarshal(resp, &proj); err != nil {
+		t.Fatalf("unmarshal project response: %v", err)
+	}
+	if proj.DefaultBranch == "" {
+		t.Fatal("project response carried no default_branch")
+	}
+	return proj.DefaultBranch
+}
+
+func TestIntegration_MergePR_ProtectedTarget(t *testing.T) {
+	skipUnlessIntegration(t)
+
+	protectedBranch := optionalEnv(t, "SORTIE_GITLAB_PROTECTED_BRANCH")
+	owner, repo := integrationOwnerRepo(t)
+	adapter := newIntegrationSCMAdapter(t)
+	fixture := newGitLabMergeFixture(t)
+	project := projectPath(owner, repo)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	suffix := mergeSuffix(t)
+	head := "sortie-protected-head-" + suffix
+
+	fixture.createBranch(t, project, head, fixtureDefaultBranch(t, fixture, project))
+	fixture.commitFile(t, project, head, "sortie-protected-sentinel.txt", "protected target probe\n")
+	iid := fixture.openMR(t, project, head, protectedBranch, "sortie protected target "+suffix)
+
+	t.Cleanup(func() {
+		fixture.closeMR(t, project, iid)
+		fixture.deleteBranch(t, project, head)
+	})
+
+	status := fixture.awaitMergeability(t, project, iid)
+	if status != "mergeable" {
+		t.Fatalf("merge request !%d detailed_merge_status = %q after polling, want %q", iid, status, "mergeable")
+	}
+	headSHA := fixture.headSHA(t, project, iid)
+
+	_, err := adapter.MergePR(ctx, iid, owner, repo, domain.StrategySquash, "", "", headSHA)
+
+	var se *domain.SCMError
+	if !errors.As(err, &se) {
+		t.Fatalf("MergePR(!%d, protected target) error type = %T, want *domain.SCMError", iid, err)
+	}
+	adaptertest.AssertSCMErrorKind(t, err, domain.ErrSCMAuth)
+	if se.Kind == domain.ErrSCMConflict {
+		t.Errorf("MergePR(!%d, protected target) Kind = %q, want NOT %q", iid, se.Kind, domain.ErrSCMConflict)
+	}
+	lower := strings.ToLower(se.Message)
+	if !strings.Contains(lower, "credential") {
+		t.Errorf("MergePR(!%d, protected target) Message = %q, want it to name the invalid-credential cause", iid, se.Message)
+	}
+	if !strings.Contains(lower, "may not merge") {
+		t.Errorf("MergePR(!%d, protected target) Message = %q, want it to name the may-not-merge cause", iid, se.Message)
+	}
+}
+
+func TestIntegration_SCMMergeFlow(t *testing.T) {
+	skipUnlessIntegration(t)
+
+	owner, repo := integrationOwnerRepo(t)
+	adapter := newIntegrationSCMAdapter(t)
+	fixture := newGitLabMergeFixture(t)
+	project := projectPath(owner, repo)
+
+	// The flow runs several network calls plus a bounded mergeability
+	// readiness poll, so it uses a wider budget than the single-call
+	// read tests; each underlying request stays bounded by the
+	// adapter's own client timeout.
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	suffix := mergeSuffix(t)
+	base := "sortie-merge-base-" + suffix
+	head := "sortie-merge-head-" + suffix
+
+	defaultBranch := fixtureDefaultBranch(t, fixture, project)
+	fixture.createBranch(t, project, base, defaultBranch)
+	fixture.createBranch(t, project, head, base)
+	fixture.commitFile(t, project, head, "sortie-merge-flow.txt", "first commit\n")
+	iid := fixture.openMR(t, project, head, base, "sortie merge-flow "+suffix)
+
+	t.Cleanup(func() {
+		fixture.closeMR(t, project, iid)
+		fixture.deleteBranch(t, project, head)
+		fixture.deleteBranch(t, project, base)
+	})
+
+	var staleSHA, currentSHA string
+
+	t.Run("GetMergeability", func(t *testing.T) {
+		status, err := adapter.GetMergeability(ctx, iid, owner, repo)
+		if err != nil {
+			t.Fatalf("GetMergeability(!%d): %v", iid, err)
+		}
+		if status.HeadSHA == "" {
+			t.Fatalf("GetMergeability(!%d).HeadSHA is empty", iid)
+		}
+		staleSHA = status.HeadSHA
+	})
+	if t.Failed() {
+		t.Skip("GetMergeability subtest failed; skipping dependent subtests")
+	}
+
+	t.Run("MergePR_StalePrecondition", func(t *testing.T) {
+		// Advances the head, so staleSHA becomes valid but out of
+		// date, driving GitLab's stale-precondition rejection
+		// deterministically.
+		advancedSHA := fixture.commitFile(t, project, head, "sortie-merge-flow-advance.txt", "advance\n")
+		if advancedSHA == staleSHA {
+			t.Fatalf("commitFile did not advance the head past staleSHA %q", staleSHA)
+		}
+
+		_, err := adapter.MergePR(ctx, iid, owner, repo, domain.StrategySquash, "", "", staleSHA)
+		adaptertest.AssertSCMErrorKind(t, err, domain.ErrSCMConflict)
+
+		var se *domain.SCMError
+		if errors.As(err, &se) && strings.Contains(strings.ToLower(se.Message), "already merged") {
+			t.Errorf("MergePR stale precondition Message = %q, want no already-merged marker", se.Message)
+		}
+	})
+	if t.Failed() {
+		t.Skip("MergePR_StalePrecondition subtest failed; skipping dependent subtests")
+	}
+
+	t.Run("MergePR_HappyPath", func(t *testing.T) {
+		// The stale-precondition push makes GitLab recompute
+		// detailed_merge_status asynchronously; poll it out of the
+		// computing set before capturing the head SHA to merge with.
+		status := fixture.awaitMergeability(t, project, iid)
+		if status != "mergeable" {
+			t.Fatalf("merge request !%d detailed_merge_status = %q after polling, want %q", iid, status, "mergeable")
+		}
+		currentSHA = fixture.headSHA(t, project, iid)
+
+		result, err := adapter.MergePR(ctx, iid, owner, repo, domain.StrategySquash, "", "", currentSHA)
+		if err != nil {
+			t.Fatalf("MergePR(!%d, squash, sha=%q): %v", iid, currentSHA, err)
+		}
+		if !result.Merged {
+			t.Errorf("MergePR(!%d).Merged = false, want true", iid)
+		}
+		if result.SHA == "" {
+			t.Errorf("MergePR(!%d).SHA is empty, want non-empty merge commit sha", iid)
+		}
+	})
+	if t.Failed() {
+		t.Skip("MergePR_HappyPath subtest failed; skipping dependent subtests")
+	}
+
+	t.Run("GetMergeability_AfterMerge", func(t *testing.T) {
+		status, err := adapter.GetMergeability(ctx, iid, owner, repo)
+		if err != nil {
+			t.Fatalf("GetMergeability(!%d) after merge: %v", iid, err)
+		}
+		if !status.Merged {
+			t.Errorf("GetMergeability(!%d).Merged = false, want true after the happy-path merge", iid)
+		}
+		if status.MergeCommitSHA == "" {
+			t.Errorf("GetMergeability(!%d).MergeCommitSHA is empty, want non-empty after the happy-path merge", iid)
+		}
+	})
+	if t.Failed() {
+		t.Skip("GetMergeability_AfterMerge subtest failed; skipping dependent subtests")
+	}
+
+	t.Run("MergePR_AlreadyMerged", func(t *testing.T) {
+		_, err := adapter.MergePR(ctx, iid, owner, repo, domain.StrategySquash, "", "", currentSHA)
+		adaptertest.AssertAlreadyMergedMarker(t, err)
+	})
+	if t.Failed() {
+		t.Skip("MergePR_AlreadyMerged subtest failed; skipping DeleteBranch subtests")
+	}
+
+	t.Run("DeleteBranch", func(t *testing.T) {
+		if err := adapter.DeleteBranch(ctx, owner, repo, head); err != nil {
+			t.Fatalf("DeleteBranch(%q): %v", head, err)
+		}
+	})
+	if t.Failed() {
+		t.Skip("DeleteBranch subtest failed; skipping DeleteBranch_Again")
+	}
+
+	t.Run("DeleteBranch_Again", func(t *testing.T) {
+		err := adapter.DeleteBranch(ctx, owner, repo, head)
+		adaptertest.AssertBranchAbsentDisposition(t, err)
+	})
+}

--- a/internal/scm/gitlab/integration_scm_test.go
+++ b/internal/scm/gitlab/integration_scm_test.go
@@ -1,0 +1,563 @@
+package gitlab
+
+import (
+	"context"
+	"slices"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sortie-ai/sortie/internal/adaptertest"
+	"github.com/sortie-ai/sortie/internal/domain"
+)
+
+// manyStatusCount is the total number of commit statuses the
+// provisioning script seeds on the pagination-probe commit: 101
+// succeeding, one failing, and one running. The count sits above 100,
+// the page size the CI provider requests per page, so a multi-status
+// read that reports exactly this many entries proves the walk crossed a
+// page boundary rather than stopping at the provider's own page size.
+// The committed provisioning script seeds the same count.
+const manyStatusCount = 103
+
+// seededFailingTargetURL is the target_url the provisioning script
+// attaches to the failing status on the forge merge request head. The
+// integration suite asserts it round-trips to the failing check run's
+// DetailsURL, proving the per-status field name. The committed
+// provisioning script hard-codes the same value.
+const seededFailingTargetURL = "https://ci.example.com/build/12345"
+
+// seededJournalLabel is the label the provisioning script adds and then
+// removes on the forge merge request, producing the two-entry
+// label-event journal the suite reads.
+const seededJournalLabel = "forge-journal"
+
+// probeMixedCaseLabel is the mixed-case label the RemoveLabel test
+// attaches through the merge-flow fixture client and then removes with
+// its lowercased spelling, pinning the case-insensitive match plus
+// stored-casing write RemoveLabel performs.
+const probeMixedCaseLabel = "Forge:Probe"
+
+// newIntegrationSCMAdapter constructs a live GitLab SCM adapter from the
+// integration env vars.
+func newIntegrationSCMAdapter(t *testing.T) domain.SCMAdapter {
+	t.Helper()
+	adapter, err := NewGitLabSCMAdapter(integrationConfig(t))
+	if err != nil {
+		t.Fatalf("NewGitLabSCMAdapter: %v", err)
+	}
+	return adapter
+}
+
+// newIntegrationCIProvider constructs a live GitLab CI status provider
+// from the integration env vars with the given log-line budget.
+func newIntegrationCIProvider(t *testing.T, maxLogLines int) domain.CIStatusProvider {
+	t.Helper()
+	provider, err := NewGitLabCIProvider(maxLogLines, integrationConfig(t))
+	if err != nil {
+		t.Fatalf("NewGitLabCIProvider: %v", err)
+	}
+	return provider
+}
+
+// integrationSCMAdapterConcrete returns the live adapter as
+// *GitLabSCMAdapter, reaching VerifyAutoMergeScopes, which is declared on
+// the concrete type rather than on domain.SCMAdapter, without importing
+// the orchestrator package that declares the wider interface.
+func integrationSCMAdapterConcrete(t *testing.T) *GitLabSCMAdapter {
+	t.Helper()
+	adapter := newIntegrationSCMAdapter(t)
+	concrete, ok := adapter.(*GitLabSCMAdapter)
+	if !ok {
+		t.Fatalf("adapter type = %T, want *GitLabSCMAdapter", adapter)
+	}
+	return concrete
+}
+
+// integrationOwnerRepo splits SORTIE_GITLAB_PROJECT at its last "/" into
+// the namespace path and the project path. The forge fixture project
+// lives at namespace depth three, so a first-"/" split would cut the
+// namespace segment short.
+func integrationOwnerRepo(t *testing.T) (owner, repo string) {
+	t.Helper()
+	project := requireEnv(t, "SORTIE_GITLAB_PROJECT")
+	idx := strings.LastIndex(project, "/")
+	if idx < 0 {
+		t.Fatalf("SORTIE_GITLAB_PROJECT=%q must be owner/repo", project)
+	}
+	owner, repo = project[:idx], project[idx+1:]
+	if owner == "" || repo == "" {
+		t.Fatalf("SORTIE_GITLAB_PROJECT=%q must be owner/repo", project)
+	}
+	return owner, repo
+}
+
+// integrationMRIID reads the named merge-request iid coordinate,
+// skipping the test cleanly when it is unset.
+func integrationMRIID(t *testing.T, key string) int {
+	t.Helper()
+	raw := optionalEnv(t, key)
+	iid, err := strconv.Atoi(raw)
+	if err != nil {
+		t.Fatalf("%s=%q is not a valid integer: %v", key, raw, err)
+	}
+	return iid
+}
+
+func TestIntegration_FetchPendingReviews(t *testing.T) {
+	skipUnlessIntegration(t)
+
+	forgeIID := integrationMRIID(t, "SORTIE_GITLAB_MR_IID")
+	draftIID := integrationMRIID(t, "SORTIE_GITLAB_DRAFT_MR_IID")
+	owner, repo := integrationOwnerRepo(t)
+	adapter := newIntegrationSCMAdapter(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	t.Run("forge_approved", func(t *testing.T) {
+		got, err := adapter.FetchPendingReviews(ctx, forgeIID, owner, repo)
+		if err != nil {
+			t.Fatalf("FetchPendingReviews(!%d): %v", forgeIID, err)
+		}
+		adaptertest.AssertEmptyNonNil(t, got, "FetchPendingReviews")
+	})
+
+	t.Run("draft_unreviewed", func(t *testing.T) {
+		got, err := adapter.FetchPendingReviews(ctx, draftIID, owner, repo)
+		if err != nil {
+			t.Fatalf("FetchPendingReviews(!%d): %v", draftIID, err)
+		}
+		adaptertest.AssertEmptyNonNil(t, got, "FetchPendingReviews")
+	})
+}
+
+// forgeSentinelPath is the file the provisioning script commits on the
+// forge merge request head and attaches the bot's inline discussion to.
+const forgeSentinelPath = "forge-sentinel.txt"
+
+func TestIntegration_FetchBotReviewComments(t *testing.T) {
+	skipUnlessIntegration(t)
+
+	forgeIID := integrationMRIID(t, "SORTIE_GITLAB_MR_IID")
+	botUsername := optionalEnv(t, "SORTIE_GITLAB_BOT_USERNAME")
+	humanUsername := optionalEnv(t, "SORTIE_GITLAB_HUMAN_USERNAME")
+	owner, repo := integrationOwnerRepo(t)
+	adapter := newIntegrationSCMAdapter(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	assertBotComments := func(t *testing.T, comments []domain.ReviewComment) {
+		t.Helper()
+		var hasPlain, hasInline bool
+		for _, c := range comments {
+			if strings.EqualFold(c.Reviewer, humanUsername) {
+				t.Errorf("comment %s Reviewer = %q, want no human-authored comment", c.ID, c.Reviewer)
+			}
+			switch c.FilePath {
+			case "":
+				hasPlain = true
+			case forgeSentinelPath:
+				if c.StartLine != 1 {
+					t.Errorf("inline comment %s StartLine = %d, want 1", c.ID, c.StartLine)
+				}
+				if c.Outdated {
+					t.Errorf("inline comment %s Outdated = true, want false", c.ID)
+				}
+				hasInline = true
+			}
+		}
+		if !hasPlain {
+			t.Error("no plain (non-inline) bot comment found")
+		}
+		if !hasInline {
+			t.Errorf("no inline bot comment on %q found", forgeSentinelPath)
+		}
+	}
+
+	t.Run("allowlisted", func(t *testing.T) {
+		comments, err := adapter.FetchBotReviewComments(ctx, forgeIID, owner, repo, []string{botUsername})
+		if err != nil {
+			t.Fatalf("FetchBotReviewComments(!%d, [%s]): %v", forgeIID, botUsername, err)
+		}
+		if comments == nil {
+			t.Fatal("FetchBotReviewComments returned nil, want non-nil slice")
+		}
+		assertBotComments(t, comments)
+	})
+
+	t.Run("empty_allowlist", func(t *testing.T) {
+		comments, err := adapter.FetchBotReviewComments(ctx, forgeIID, owner, repo, nil)
+		if err != nil {
+			t.Fatalf("FetchBotReviewComments(!%d, nil allowlist): %v", forgeIID, err)
+		}
+		if comments == nil {
+			t.Fatal("FetchBotReviewComments returned nil, want non-nil slice")
+		}
+		// GitLab qualifies an author by the platform bot flag alone, so
+		// an empty allowlist still selects the bot's comments, unlike
+		// the Gitea sibling suite.
+		assertBotComments(t, comments)
+	})
+}
+
+func TestIntegration_GetReviewDecision(t *testing.T) {
+	skipUnlessIntegration(t)
+
+	forgeIID := integrationMRIID(t, "SORTIE_GITLAB_MR_IID")
+	draftIID := integrationMRIID(t, "SORTIE_GITLAB_DRAFT_MR_IID")
+	conflictIID := integrationMRIID(t, "SORTIE_GITLAB_CONFLICT_MR_IID")
+	owner, repo := integrationOwnerRepo(t)
+	adapter := newIntegrationSCMAdapter(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	tests := []struct {
+		name string
+		iid  int
+		want domain.ReviewDecision
+	}{
+		{"forge_approved", forgeIID, domain.ReviewDecisionApproved},
+		{"draft_review_required", draftIID, domain.ReviewDecisionReviewRequired},
+		{"conflict_not_required", conflictIID, domain.ReviewDecisionNotRequired},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := adapter.GetReviewDecision(ctx, tt.iid, owner, repo)
+			if err != nil {
+				t.Fatalf("GetReviewDecision(!%d): %v", tt.iid, err)
+			}
+			if got != tt.want {
+				t.Errorf("GetReviewDecision(!%d) = %q, want %q", tt.iid, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIntegration_GetMergeability(t *testing.T) {
+	skipUnlessIntegration(t)
+
+	forgeIID := integrationMRIID(t, "SORTIE_GITLAB_MR_IID")
+	draftIID := integrationMRIID(t, "SORTIE_GITLAB_DRAFT_MR_IID")
+	conflictIID := integrationMRIID(t, "SORTIE_GITLAB_CONFLICT_MR_IID")
+	owner, repo := integrationOwnerRepo(t)
+	adapter := newIntegrationSCMAdapter(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	t.Run("forge_clean", func(t *testing.T) {
+		status, err := adapter.GetMergeability(ctx, forgeIID, owner, repo)
+		if err != nil {
+			t.Fatalf("GetMergeability(!%d): %v", forgeIID, err)
+		}
+		if status.Mergeability != domain.MergeabilityClean {
+			t.Errorf("GetMergeability(!%d).Mergeability = %q, want %q", forgeIID, status.Mergeability, domain.MergeabilityClean)
+		}
+		if status.HeadSHA == "" {
+			t.Errorf("GetMergeability(!%d).HeadSHA is empty, want non-empty", forgeIID)
+		}
+		if status.BranchName != "forge-fixture" {
+			t.Errorf("GetMergeability(!%d).BranchName = %q, want %q", forgeIID, status.BranchName, "forge-fixture")
+		}
+		if status.BaseBranch == "" {
+			t.Errorf("GetMergeability(!%d).BaseBranch is empty, want non-empty", forgeIID)
+		}
+		if status.Draft {
+			t.Errorf("GetMergeability(!%d).Draft = true, want false", forgeIID)
+		}
+		if status.Merged {
+			t.Errorf("GetMergeability(!%d).Merged = true, want false", forgeIID)
+		}
+		if status.MergeCommitSHA != "" {
+			t.Errorf("GetMergeability(!%d).MergeCommitSHA = %q, want empty", forgeIID, status.MergeCommitSHA)
+		}
+	})
+
+	t.Run("draft_blocked", func(t *testing.T) {
+		status, err := adapter.GetMergeability(ctx, draftIID, owner, repo)
+		if err != nil {
+			t.Fatalf("GetMergeability(!%d): %v", draftIID, err)
+		}
+		if status.Mergeability != domain.MergeabilityBlocked {
+			t.Errorf("GetMergeability(!%d).Mergeability = %q, want %q", draftIID, status.Mergeability, domain.MergeabilityBlocked)
+		}
+		if !status.Draft {
+			t.Errorf("GetMergeability(!%d).Draft = false, want true", draftIID)
+		}
+	})
+
+	t.Run("conflict_dirty", func(t *testing.T) {
+		status, err := adapter.GetMergeability(ctx, conflictIID, owner, repo)
+		if err != nil {
+			t.Fatalf("GetMergeability(!%d): %v", conflictIID, err)
+		}
+		if status.Mergeability != domain.MergeabilityDirty {
+			t.Errorf("GetMergeability(!%d).Mergeability = %q, want %q", conflictIID, status.Mergeability, domain.MergeabilityDirty)
+		}
+	})
+}
+
+func TestIntegration_GetCIStatus(t *testing.T) {
+	skipUnlessIntegration(t)
+
+	forgeIID := integrationMRIID(t, "SORTIE_GITLAB_MR_IID")
+	draftIID := integrationMRIID(t, "SORTIE_GITLAB_DRAFT_MR_IID")
+	owner, repo := integrationOwnerRepo(t)
+	adapter := newIntegrationSCMAdapter(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	tests := []struct {
+		name string
+		iid  int
+		want string
+	}{
+		{"forge_failing", forgeIID, "failing"},
+		{"draft_no_checks", draftIID, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := adapter.GetCIStatus(ctx, tt.iid, owner, repo)
+			if err != nil {
+				t.Fatalf("GetCIStatus(!%d): %v", tt.iid, err)
+			}
+			if got != tt.want {
+				t.Errorf("GetCIStatus(!%d) = %q, want %q", tt.iid, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIntegration_FetchCIStatus(t *testing.T) {
+	skipUnlessIntegration(t)
+
+	forgeIID := integrationMRIID(t, "SORTIE_GITLAB_MR_IID")
+	owner, repo := integrationOwnerRepo(t)
+	adapter := newIntegrationSCMAdapter(t)
+	provider := newIntegrationCIProvider(t, 0)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	merge, err := adapter.GetMergeability(ctx, forgeIID, owner, repo)
+	if err != nil {
+		t.Fatalf("GetMergeability(!%d): %v", forgeIID, err)
+	}
+	if merge.HeadSHA == "" {
+		t.Fatalf("GetMergeability(!%d).HeadSHA is empty; cannot resolve commit A", forgeIID)
+	}
+
+	result, err := provider.FetchCIStatus(ctx, merge.HeadSHA)
+	if err != nil {
+		t.Fatalf("FetchCIStatus(%q): %v", merge.HeadSHA, err)
+	}
+	if result.Status != domain.CIStatusFailing {
+		t.Errorf("FetchCIStatus(%q).Status = %q, want %q", merge.HeadSHA, result.Status, domain.CIStatusFailing)
+	}
+	if result.FailingCount != 1 {
+		t.Errorf("FetchCIStatus(%q).FailingCount = %d, want 1", merge.HeadSHA, result.FailingCount)
+	}
+	if result.CheckRuns == nil {
+		t.Fatal("FetchCIStatus CheckRuns is nil, want non-nil slice")
+	}
+	if len(result.CheckRuns) != 2 {
+		t.Errorf("len(FetchCIStatus(%q).CheckRuns) = %d, want 2", merge.HeadSHA, len(result.CheckRuns))
+	}
+
+	var failingURL string
+	for _, run := range result.CheckRuns {
+		if run.Conclusion == domain.CheckConclusionFailure {
+			failingURL = run.DetailsURL
+		}
+	}
+	if failingURL != seededFailingTargetURL {
+		t.Errorf("failing CheckRun.DetailsURL = %q, want %q", failingURL, seededFailingTargetURL)
+	}
+	if result.Ref != merge.HeadSHA {
+		t.Errorf("FetchCIStatus(%q).Ref = %q, want %q", merge.HeadSHA, result.Ref, merge.HeadSHA)
+	}
+
+	adaptertest.AssertCIAggregateMatchesCore(t, result)
+}
+
+func TestIntegration_FetchCIStatus_ManyStatuses(t *testing.T) {
+	skipUnlessIntegration(t)
+
+	sha := optionalEnv(t, "SORTIE_GITLAB_MANY_STATUS_SHA")
+	provider := newIntegrationCIProvider(t, 50)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	result, err := provider.FetchCIStatus(ctx, sha)
+	if err != nil {
+		t.Fatalf("FetchCIStatus(%q): %v", sha, err)
+	}
+	if len(result.CheckRuns) != manyStatusCount {
+		t.Errorf("len(FetchCIStatus(%q).CheckRuns) = %d, want %d", sha, len(result.CheckRuns), manyStatusCount)
+	}
+
+	var hasSuccess, hasFailure, hasInProgress bool
+	for _, run := range result.CheckRuns {
+		switch {
+		case run.Status == domain.CheckRunStatusCompleted && run.Conclusion == domain.CheckConclusionSuccess:
+			hasSuccess = true
+		case run.Status == domain.CheckRunStatusCompleted && run.Conclusion == domain.CheckConclusionFailure:
+			hasFailure = true
+		case run.Status == domain.CheckRunStatusInProgress:
+			hasInProgress = true
+		}
+	}
+	if !hasSuccess {
+		t.Error("FetchCIStatus many-statuses result has no completed-success run")
+	}
+	if !hasFailure {
+		t.Error("FetchCIStatus many-statuses result has no completed-failure run")
+	}
+	if !hasInProgress {
+		t.Error("FetchCIStatus many-statuses result has no in-progress run")
+	}
+
+	adaptertest.AssertCIAggregateMatchesCore(t, result)
+
+	if result.LogExcerpt != "" {
+		t.Errorf("FetchCIStatus(%q).LogExcerpt = %q, want empty; no failing entry is a pipeline job", sha, result.LogExcerpt)
+	}
+}
+
+func TestIntegration_ListLabelEvents(t *testing.T) {
+	skipUnlessIntegration(t)
+
+	forgeIID := integrationMRIID(t, "SORTIE_GITLAB_MR_IID")
+	owner, repo := integrationOwnerRepo(t)
+	adapter := newIntegrationSCMAdapter(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	events, err := adapter.ListLabelEvents(ctx, forgeIID, owner, repo)
+	if err != nil {
+		t.Fatalf("ListLabelEvents(!%d): %v", forgeIID, err)
+	}
+	if events == nil {
+		t.Fatal("ListLabelEvents returned nil, want non-nil slice")
+	}
+	if len(events) != 2 {
+		t.Fatalf("ListLabelEvents(!%d) returned %d events, want 2", forgeIID, len(events))
+	}
+	if !events[0].Added {
+		t.Errorf("ListLabelEvents(!%d)[0].Added = false, want true", forgeIID)
+	}
+	if events[1].Added {
+		t.Errorf("ListLabelEvents(!%d)[1].Added = true, want false", forgeIID)
+	}
+	for i, e := range events {
+		if e.Label != seededJournalLabel {
+			t.Errorf("event[%d].Label = %q, want %q", i, e.Label, seededJournalLabel)
+		}
+		if e.Label != strings.ToLower(e.Label) {
+			t.Errorf("event[%d].Label = %q, want lowercased", i, e.Label)
+		}
+		if e.ID == "" {
+			t.Errorf("event[%d].ID is empty, want non-empty", i)
+		}
+		if e.Actor == "" {
+			t.Errorf("event[%d].Actor is empty, want non-empty", i)
+		}
+	}
+
+	adaptertest.AssertLabelEventsOrdered(t, events)
+}
+
+func TestIntegration_RemoveLabel(t *testing.T) {
+	skipUnlessIntegration(t)
+
+	labelIID := integrationMRIID(t, "SORTIE_GITLAB_LABEL_MR_IID")
+	owner, repo := integrationOwnerRepo(t)
+	adapter := integrationSCMAdapterConcrete(t)
+	fixture := newGitLabMergeFixture(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	fixture.addLabel(t, projectPath(owner, repo), labelIID, probeMixedCaseLabel)
+
+	lowered := strings.ToLower(probeMixedCaseLabel)
+	if err := adapter.RemoveLabel(ctx, labelIID, owner, repo, lowered); err != nil {
+		t.Fatalf("RemoveLabel(!%d, %q): %v", labelIID, lowered, err)
+	}
+
+	mr, err := adapter.fetchMergeRequest(ctx, labelIID, owner, repo)
+	if err != nil {
+		t.Fatalf("fetchMergeRequest(!%d): %v", labelIID, err)
+	}
+	if slices.ContainsFunc(mr.Labels, func(l string) bool { return strings.EqualFold(l, probeMixedCaseLabel) }) {
+		t.Errorf("merge request !%d labels = %v, want %q removed", labelIID, mr.Labels, probeMixedCaseLabel)
+	}
+
+	err = adapter.RemoveLabel(ctx, labelIID, owner, repo, lowered)
+	adaptertest.AssertLabelAbsentDisposition(t, err)
+}
+
+func TestIntegration_VerifyAutoMergeScopes(t *testing.T) {
+	skipUnlessIntegration(t)
+	// SORTIE_GITLAB_MR_IID is read only as the provisioned-instance
+	// marker: this test consumes no seeded object of its own.
+	_ = integrationMRIID(t, "SORTIE_GITLAB_MR_IID")
+
+	adapter := integrationSCMAdapterConcrete(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	scopes, missing, err := adapter.VerifyAutoMergeScopes(ctx, true)
+	if err != nil {
+		t.Fatalf("VerifyAutoMergeScopes: %v", err)
+	}
+	if !slices.Contains(scopes, "api") {
+		t.Errorf("VerifyAutoMergeScopes scopes = %v, want to contain %q", scopes, "api")
+	}
+	if len(missing) != 0 {
+		t.Errorf("VerifyAutoMergeScopes missing = %v, want empty", missing)
+	}
+}
+
+func TestIntegration_SCMErrorKinds(t *testing.T) {
+	skipUnlessIntegration(t)
+	// SORTIE_GITLAB_MR_IID is read only as the provisioned-instance
+	// marker: this test consumes no seeded object of its own.
+	_ = integrationMRIID(t, "SORTIE_GITLAB_MR_IID")
+
+	owner, repo := integrationOwnerRepo(t)
+	adapter := newIntegrationSCMAdapter(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	t.Run("not_found", func(t *testing.T) {
+		const nonexistentIID = 999999
+		_, err := adapter.GetMergeability(ctx, nonexistentIID, owner, repo)
+		adaptertest.AssertSCMErrorKind(t, err, domain.ErrSCMNotFound)
+	})
+
+	t.Run("auth", func(t *testing.T) {
+		cfg := integrationConfig(t)
+		cfg["api_key"] = "glpat-integration-suite-unknown-token"
+		badAdapter, err := NewGitLabSCMAdapter(cfg)
+		if err != nil {
+			t.Fatalf("NewGitLabSCMAdapter with unknown token: %v", err)
+		}
+		_, err = badAdapter.GetMergeability(ctx, 1, owner, repo)
+		adaptertest.AssertSCMErrorKind(t, err, domain.ErrSCMAuth)
+	})
+
+	t.Run("payload_empty_expected_head_sha", func(t *testing.T) {
+		_, err := adapter.MergePR(ctx, 1, owner, repo, domain.StrategySquash, "", "", "")
+		adaptertest.AssertSCMErrorKind(t, err, domain.ErrSCMPayload)
+	})
+}

--- a/scripts/gitlab-integration-provision.sh
+++ b/scripts/gitlab-integration-provision.sh
@@ -49,6 +49,30 @@ gitlab_call() {
 	api_call "$_gl_method" "${ENDPOINT}/api/v4${_gl_path}" -H "PRIVATE-TOKEN: ${_gl_token}"
 }
 
+# wait_for_json FIELD_EXPR EXPECTED URL TIMEOUT INTERVAL
+#
+# Polls URL under the published token until `jq -r FIELD_EXPR` equals
+# EXPECTED or TIMEOUT elapses, the same shape as the shared HTTP-status
+# poll uses for a JSON field instead of a status code. GitLab is the only
+# forge whose fixture fields settle asynchronously, so this stays local
+# to this script rather than joining scripts/lib/provision.sh for a
+# second caller that does not exist.
+wait_for_json() {
+	_wj_field=$1 _wj_expected=$2 _wj_url=$3 _wj_timeout=$4 _wj_interval=$5
+	_wj_start=$(date +%s)
+	while :; do
+		_wj_value=$(curl -sS --max-time 30 -H "PRIVATE-TOKEN: ${PUBLISHED_TOKEN}" "$_wj_url" | jq -r "$_wj_field" 2>/dev/null || true)
+		if [ "$_wj_value" = "$_wj_expected" ]; then
+			return 0
+		fi
+		_wj_elapsed=$(($(date +%s) - _wj_start))
+		[ "$_wj_elapsed" -lt "$_wj_timeout" ] || break
+		sleep "$_wj_interval"
+	done
+	log "fixture ${_wj_url} field ${_wj_field} was ${_wj_value} after ${_wj_timeout}s, want ${_wj_expected}"
+	return 1
+}
+
 reclaim_container
 
 # Released Community Edition images live only on Docker Hub, pulled anonymously.
@@ -117,12 +141,26 @@ sibling_response=$(jq -nc --arg name "$SIBLING_PROJECT_NAME" --argjson namespace
 SIBLING_ID=$(printf '%s' "$sibling_response" | jq -er '.id')
 SIBLING_PATH=$(printf '%s' "$sibling_response" | jq -er '.path_with_namespace')
 
+# The primary project moves one namespace level deeper than the sibling so
+# the forge suite exercises a project addressed through a nested namespace
+# path, the rule the adapter is forbidden to split or validate as one
+# segment.
+log "creating subgroup team"
+team_response=$(jq -nc --arg name "team" --arg path "team" --argjson parent_id "$GROUP_ID" \
+	'{name: $name, path: $path, parent_id: $parent_id, visibility: "private"}' |
+	gitlab_call POST "/groups" "$BOOTSTRAP_TOKEN")
+TEAM_GROUP_ID=$(printf '%s' "$team_response" | jq -er '.id')
+
+# initialize_with_readme seeds the one commit every branch-based forge
+# fixture below is cut from; a project with no default branch has no ref
+# to branch off of.
 log "creating primary project ${PRIMARY_PROJECT_NAME}"
-primary_response=$(jq -nc --arg name "$PRIMARY_PROJECT_NAME" --argjson namespace_id "$GROUP_ID" \
-	'{name: $name, namespace_id: $namespace_id, visibility: "private"}' |
+primary_response=$(jq -nc --arg name "$PRIMARY_PROJECT_NAME" --argjson namespace_id "$TEAM_GROUP_ID" \
+	'{name: $name, namespace_id: $namespace_id, visibility: "private", initialize_with_readme: true}' |
 	gitlab_call POST "/projects" "$BOOTSTRAP_TOKEN")
 PRIMARY_ID=$(printf '%s' "$primary_response" | jq -er '.id')
 PRIMARY_PATH=$(printf '%s' "$primary_response" | jq -er '.path_with_namespace')
+DEFAULT_BRANCH=$(printf '%s' "$primary_response" | jq -er '.default_branch')
 
 # Seeding the sibling first is what makes the primary project's iids diverge
 # from their instance-global ids.
@@ -222,6 +260,227 @@ log "closing issue ${issue_done} into its terminal state"
 jq -nc '{state_event: "close"}' |
 	gitlab_call PUT "/projects/${PRIMARY_ID}/issues/${issue_done}" "$PUBLISHED_TOKEN" >/dev/null
 
+# Fixed values the integration suite hard-codes on its own side; a mismatch
+# between the two is a test failure by design.
+SEEDED_FAILING_TARGET_URL="https://ci.example.com/build/12345"
+SEEDED_JOURNAL_LABEL="forge-journal"
+
+# create_branch BRANCH REF
+create_branch() {
+	_cb_branch=$1 _cb_ref=$2
+	jq -nc --arg branch "$_cb_branch" --arg ref "$_cb_ref" \
+		'{branch: $branch, ref: $ref}' |
+		gitlab_call POST "/projects/${PRIMARY_ID}/repository/branches" "$PUBLISHED_TOKEN" >/dev/null
+}
+
+# commit_file BRANCH PATH CONTENT MESSAGE
+#
+# Echoes the new commit's id, read from the commits route rather than the
+# files route, which returns no commit identifier.
+commit_file() {
+	_cf_branch=$1 _cf_path=$2 _cf_content=$3 _cf_message=$4
+	_cf_out=$(jq -nc --arg branch "$_cf_branch" --arg message "$_cf_message" \
+		--arg path "$_cf_path" --arg content "$_cf_content" \
+		'{branch: $branch, commit_message: $message,
+		  actions: [{action: "create", file_path: $path, content: $content}]}' |
+		gitlab_call POST "/projects/${PRIMARY_ID}/repository/commits" "$PUBLISHED_TOKEN")
+	printf '%s' "$_cf_out" | jq -er '.id'
+}
+
+# post_status SHA STATE NAME [TARGET_URL] [DESCRIPTION]
+post_status() {
+	_ps_sha=$1 _ps_state=$2 _ps_name=$3 _ps_url=${4:-} _ps_desc=${5:-}
+	jq -nc --arg state "$_ps_state" --arg name "$_ps_name" --arg url "$_ps_url" --arg desc "$_ps_desc" \
+		'{state: $state, name: $name}
+		 + (if $url != "" then {target_url: $url} else {} end)
+		 + (if $desc != "" then {description: $desc} else {} end)' |
+		gitlab_call POST "/projects/${PRIMARY_ID}/statuses/${_ps_sha}" "$PUBLISHED_TOKEN" >/dev/null
+}
+
+# open_mr SOURCE TARGET TITLE TOKEN
+#
+# Echoes the new merge request's iid.
+open_mr() {
+	_om_source=$1 _om_target=$2 _om_title=$3 _om_token=$4
+	_om_out=$(jq -nc --arg source "$_om_source" --arg target "$_om_target" --arg title "$_om_title" \
+		'{source_branch: $source, target_branch: $target, title: $title}' |
+		gitlab_call POST "/projects/${PRIMARY_ID}/merge_requests" "$_om_token")
+	printf '%s' "$_om_out" | jq -er '.iid'
+}
+
+# Two more identities, both used only inside this script and never
+# emitted: the published token already covers the fixture the tracker
+# suite reads, but every project access token is bot:true, so the forge
+# suite needs a platform bot distinct from its own identity and a
+# non-bot human to review, approve, and author a comment the bot
+# predicate must reject.
+log "creating bot project access token"
+bot_response=$(jq -nc --arg name "sortie-integration-bot" --arg expires_at "$EXPIRY" \
+	'{name: $name, scopes: ["api"], access_level: 30, expires_at: $expires_at}' |
+	gitlab_call POST "/projects/${PRIMARY_ID}/access_tokens" "$BOOTSTRAP_TOKEN")
+BOT_TOKEN=$(printf '%s' "$bot_response" | jq -er '.token')
+BOT_LOGIN=$(curl -sS --max-time 30 -H "PRIVATE-TOKEN: ${BOT_TOKEN}" "${ENDPOINT}/api/v4/user" | jq -er '.username')
+
+log "waiting up to ${AUTHORIZATION_TIMEOUT_SECONDS}s for the bot token's project authorization"
+if ! wait_for_http "${ENDPOINT}/api/v4/projects/${PRIMARY_ID}" "200" \
+	"$AUTHORIZATION_TIMEOUT_SECONDS" "$AUTHORIZATION_POLL_INTERVAL_SECONDS" \
+	-H "PRIVATE-TOKEN: ${BOT_TOKEN}"; then
+	log "bot token never saw project ${PRIMARY_ID} within ${AUTHORIZATION_TIMEOUT_SECONDS}s; last status ${WAIT_STATUS}"
+	exit 1
+fi
+log "bot token authorized after ${WAITED_SECONDS}s"
+
+# force_random_password plus skip_confirmation means no password literal
+# ever enters this script.
+log "creating human user"
+HUMAN_USERNAME="sortie-human-$(date +%s)"
+human_response=$(jq -nc --arg email "${HUMAN_USERNAME}@example.com" --arg username "$HUMAN_USERNAME" --arg name "Sortie Human" \
+	'{email: $email, username: $username, name: $name, force_random_password: true, skip_confirmation: true}' |
+	gitlab_call POST "/users" "$BOOTSTRAP_TOKEN")
+HUMAN_ID=$(printf '%s' "$human_response" | jq -er '.id')
+
+jq -nc --argjson user_id "$HUMAN_ID" '{user_id: $user_id, access_level: 30}' |
+	gitlab_call POST "/projects/${PRIMARY_ID}/members" "$BOOTSTRAP_TOKEN" >/dev/null
+
+human_token_response=$(jq -nc --arg name "sortie-integration-human" --arg expires_at "$EXPIRY" \
+	'{name: $name, scopes: ["api"], expires_at: $expires_at}' |
+	gitlab_call POST "/users/${HUMAN_ID}/personal_access_tokens" "$BOOTSTRAP_TOKEN")
+HUMAN_TOKEN=$(printf '%s' "$human_token_response" | jq -er '.token')
+
+log "waiting up to ${AUTHORIZATION_TIMEOUT_SECONDS}s for the human token's project authorization"
+if ! wait_for_http "${ENDPOINT}/api/v4/projects/${PRIMARY_ID}" "200" \
+	"$AUTHORIZATION_TIMEOUT_SECONDS" "$AUTHORIZATION_POLL_INTERVAL_SECONDS" \
+	-H "PRIVATE-TOKEN: ${HUMAN_TOKEN}"; then
+	log "human token never saw project ${PRIMARY_ID} within ${AUTHORIZATION_TIMEOUT_SECONDS}s; last status ${WAIT_STATUS}"
+	exit 1
+fi
+log "human token authorized after ${WAITED_SECONDS}s"
+
+# The protected-target merge refusal needs a branch protected at
+# Maintainer level; the published Developer-level token cannot merge into
+# it, and cannot delete it either, so no test ever removes it.
+log "creating and protecting branch protected-base"
+create_branch "protected-base" "$DEFAULT_BRANCH"
+jq -nc '{name: "protected-base", push_access_level: 40, merge_access_level: 40}' |
+	gitlab_call POST "/projects/${PRIMARY_ID}/protected_branches" "$BOOTSTRAP_TOKEN" >/dev/null
+
+# The forge merge request: mergeable, reviewed, approved, CI on its head,
+# a plain note from each identity, one inline discussion note, and a
+# two-entry label-event journal.
+log "seeding the forge merge request fixture"
+create_branch "forge-fixture" "$DEFAULT_BRANCH"
+FORGE_SHA=$(commit_file "forge-fixture" "forge-sentinel.txt" \
+	"$(printf 'sentinel line 1\nsentinel line 2\nsentinel line 3\nsentinel line 4\nsentinel line 5\n')" \
+	"Add forge sentinel file")
+post_status "$FORGE_SHA" "success" "ci/build"
+post_status "$FORGE_SHA" "failed" "ci/test" "$SEEDED_FAILING_TARGET_URL" "The test job failed."
+
+MR_IID=$(open_mr "forge-fixture" "$DEFAULT_BRANCH" "Forge fixture merge request" "$PUBLISHED_TOKEN")
+
+log "waiting up to 60s for the forge merge request diff version to prepare"
+if ! wait_for_json '.[0].head_commit_sha' "$FORGE_SHA" \
+	"${ENDPOINT}/api/v4/projects/${PRIMARY_ID}/merge_requests/${MR_IID}/versions" 60 2; then
+	exit 1
+fi
+
+jq -nc '{body: "Human note on the forge merge request."}' |
+	gitlab_call POST "/projects/${PRIMARY_ID}/merge_requests/${MR_IID}/notes" "$HUMAN_TOKEN" >/dev/null
+jq -nc '{body: "Bot note on the forge merge request."}' |
+	gitlab_call POST "/projects/${PRIMARY_ID}/merge_requests/${MR_IID}/notes" "$BOT_TOKEN" >/dev/null
+
+version_response=$(curl -sS --max-time 30 -H "PRIVATE-TOKEN: ${PUBLISHED_TOKEN}" \
+	"${ENDPOINT}/api/v4/projects/${PRIMARY_ID}/merge_requests/${MR_IID}/versions")
+version_base_sha=$(printf '%s' "$version_response" | jq -er '.[0].base_commit_sha')
+version_head_sha=$(printf '%s' "$version_response" | jq -er '.[0].head_commit_sha')
+version_start_sha=$(printf '%s' "$version_response" | jq -er '.[0].start_commit_sha')
+
+jq -nc --arg base "$version_base_sha" --arg head "$version_head_sha" --arg start "$version_start_sha" \
+	'{body: "Bot inline note on the sentinel file.",
+	  position: {base_sha: $base, head_sha: $head, start_sha: $start,
+	             new_path: "forge-sentinel.txt", position_type: "text", new_line: 1}}' |
+	gitlab_call POST "/projects/${PRIMARY_ID}/merge_requests/${MR_IID}/discussions" "$BOT_TOKEN" >/dev/null
+
+jq -nc --argjson id "$HUMAN_ID" '{reviewer_ids: [$id]}' |
+	gitlab_call PUT "/projects/${PRIMARY_ID}/merge_requests/${MR_IID}" "$PUBLISHED_TOKEN" >/dev/null
+# The approval MUST precede the mergeability gate in await_fixture_settled
+# below: approving moves detailed_merge_status back to "checking", so
+# gating first would make "mergeable" the pre-approval value rather than
+# the settled one.
+gitlab_call POST "/projects/${PRIMARY_ID}/merge_requests/${MR_IID}/approve" "$HUMAN_TOKEN" </dev/null >/dev/null
+
+jq -nc --arg label "$SEEDED_JOURNAL_LABEL" '{add_labels: $label}' |
+	gitlab_call PUT "/projects/${PRIMARY_ID}/merge_requests/${MR_IID}" "$PUBLISHED_TOKEN" >/dev/null
+jq -nc --arg label "$SEEDED_JOURNAL_LABEL" '{remove_labels: $label}' |
+	gitlab_call PUT "/projects/${PRIMARY_ID}/merge_requests/${MR_IID}" "$PUBLISHED_TOKEN" >/dev/null
+
+# The draft merge request: blocked mergeability, review required, no
+# pipeline on its head.
+log "seeding the draft merge request fixture"
+create_branch "forge-draft" "$DEFAULT_BRANCH"
+commit_file "forge-draft" "forge-draft.txt" "draft fixture content" "Add forge draft file" >/dev/null
+DRAFT_IID=$(open_mr "forge-draft" "$DEFAULT_BRANCH" "Draft: forge draft merge request" "$PUBLISHED_TOKEN")
+jq -nc --argjson id "$HUMAN_ID" '{reviewer_ids: [$id]}' |
+	gitlab_call PUT "/projects/${PRIMARY_ID}/merge_requests/${DRAFT_IID}" "$PUBLISHED_TOKEN" >/dev/null
+
+# The conflicting merge request: the same file diverges on each side, no
+# reviewer, no approval.
+log "seeding the conflicting merge request fixture"
+create_branch "conflict-base" "$DEFAULT_BRANCH"
+create_branch "forge-conflict" "conflict-base"
+commit_file "forge-conflict" "conflict-sentinel.txt" "conflict side A content" "Add conflict side A" >/dev/null
+commit_file "conflict-base" "conflict-sentinel.txt" "conflict side B content" "Add conflict side B" >/dev/null
+CONFLICT_IID=$(open_mr "forge-conflict" "conflict-base" "Forge conflict merge request" "$PUBLISHED_TOKEN")
+
+# The label-probe merge request: the only merge request any test writes
+# labels to, so no other fixture's mergeability or review state can be
+# perturbed by a label-driven recompute.
+log "seeding the label-probe merge request fixture"
+create_branch "label-probe" "$DEFAULT_BRANCH"
+commit_file "label-probe" "label-probe.txt" "label probe fixture content" "Add label probe file" >/dev/null
+LABEL_IID=$(open_mr "label-probe" "$DEFAULT_BRANCH" "Forge label-probe merge request" "$PUBLISHED_TOKEN")
+
+# The pagination-probe commit: 103 statuses on a commit no merge request
+# heads, crossing the CI provider's per_page=100 boundary.
+log "seeding the pagination-probe commit and its 103 statuses"
+create_branch "status-probe" "$DEFAULT_BRANCH"
+PROBE_SHA=$(commit_file "status-probe" "status-probe.txt" "status pagination probe commit" "Add status probe file")
+i=1
+while [ "$i" -le 101 ]; do
+	post_status "$PROBE_SHA" "success" "ci/probe-${i}"
+	i=$((i + 1))
+done
+post_status "$PROBE_SHA" "failed" "ci/probe-fail"
+post_status "$PROBE_SHA" "running" "ci/probe-running"
+
+# await_fixture_settled gates every asynchronously computed merge-request
+# field this script publishes a coordinate for, so no test ever reads an
+# unsettled platform value. Each gate fails the script rather than
+# warning: publishing an unsettled fixture would turn a provisioning
+# fault into a test failure attributed to the adapter.
+await_fixture_settled() {
+	log "waiting up to 60s for the forge merge request to settle mergeable"
+	if ! wait_for_json '.detailed_merge_status' "mergeable" \
+		"${ENDPOINT}/api/v4/projects/${PRIMARY_ID}/merge_requests/${MR_IID}" 60 2; then
+		exit 1
+	fi
+	log "waiting up to 60s for the forge merge request head pipeline to settle failed"
+	if ! wait_for_json '.head_pipeline.status' "failed" \
+		"${ENDPOINT}/api/v4/projects/${PRIMARY_ID}/merge_requests/${MR_IID}" 60 2; then
+		exit 1
+	fi
+	log "waiting up to 60s for the draft merge request to settle draft_status"
+	if ! wait_for_json '.detailed_merge_status' "draft_status" \
+		"${ENDPOINT}/api/v4/projects/${PRIMARY_ID}/merge_requests/${DRAFT_IID}" 60 2; then
+		exit 1
+	fi
+	log "waiting up to 60s for the conflicting merge request to settle conflict"
+	if ! wait_for_json '.detailed_merge_status' "conflict" \
+		"${ENDPOINT}/api/v4/projects/${PRIMARY_ID}/merge_requests/${CONFLICT_IID}" 60 2; then
+		exit 1
+	fi
+}
+await_fixture_settled
+
 # The bootstrap token is never emitted, so only this one needs masking.
 mask_secret "$PUBLISHED_TOKEN"
 
@@ -233,4 +492,12 @@ emit SORTIE_GITLAB_MANY_NOTES_IID "$issue_bulk"
 emit SORTIE_GITLAB_SYSTEM_NOTES_IID "$issue_linktarget"
 emit SORTIE_GITLAB_TASK_IID "$issue_task"
 emit SORTIE_GITLAB_FOREIGN_PROJECT "$SIBLING_PATH"
+emit SORTIE_GITLAB_MR_IID "$MR_IID"
+emit SORTIE_GITLAB_LABEL_MR_IID "$LABEL_IID"
+emit SORTIE_GITLAB_DRAFT_MR_IID "$DRAFT_IID"
+emit SORTIE_GITLAB_CONFLICT_MR_IID "$CONFLICT_IID"
+emit SORTIE_GITLAB_BOT_USERNAME "$BOT_LOGIN"
+emit SORTIE_GITLAB_HUMAN_USERNAME "$HUMAN_USERNAME"
+emit SORTIE_GITLAB_MANY_STATUS_SHA "$PROBE_SHA"
+emit SORTIE_GITLAB_PROTECTED_BRANCH "protected-base"
 emit GITLAB_IMAGE "$IMAGE"


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Test

**Intent:** The GitLab integration harness previously seeded issues and comments only, so the SCM and CI surface (merge requests, reviews, statuses, CI checks) had no live coverage and its response-shape assumptions were never exercised against a real GitLab instance. Extend the provisioning script with the forge fixtures that surface needs, and add env-gated integration tests that exercise the read, write, and CI paths against them.

**Related Issues:** #723

### 🧭 Reviewer Guide

**Complexity:** Medium

#### Entry Point

`scripts/gitlab-integration-provision.sh` - seeds a bot project-access-token identity and a second human identity (needed because every project access token reports `bot: true`, and the fixtures require a non-bot note author and reviewer), a protected branch, and four merge request fixtures: a "forge" MR that is mergeable, reviewed, approved, carries CI success and failed statuses, human and bot notes, one inline discussion note, and a two-entry label journal; a draft MR; a conflicting MR; and a label-probe MR isolated so no other fixture's mergeability or review state is perturbed by a label-driven recompute. It also seeds a pagination-probe commit with 103 statuses to cross the CI provider's `per_page=100` boundary, and adds an `await_fixture_settled` gate so the script fails outright rather than publishing an unsettled async field (`detailed_merge_status`, `head_pipeline.status`) as a coordinate.

#### Sensitive Areas

- `scripts/gitlab-integration-provision.sh`: the `await_fixture_settled` gate and the approve-before-mergeability-check ordering are load-bearing - approving a merge request resets `detailed_merge_status` to `checking`, so reading it before approval would publish the wrong pre-approval value.
- `internal/scm/gitlab/integration_scm_test.go` and `internal/scm/gitlab/integration_merge_test.go`: every test is gated on `SORTIE_GITLAB_TEST` and must skip cleanly when it is unset - verified via `go test ./internal/scm/gitlab/...` with the gate unset.
- The suite has not been executed end to end against a live instance - the lab's host port was occupied by an unrelated running container. Individual API sequences were probed live and the assertions derive from those probes plus the adapter source, but the `test-integration-gitlab` job and the nightly `gitlab` matrix row are the first genuine execution.
- `docs/gitlab-adapter-notes.md`: records the live-verified pagination behavior of the commit-statuses route and resolves the corresponding open question.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes
- **Migrations/State:** No migrations or state changes

