### PR TITLE
docs: document the GitLab forge surface and correct spec drift

### DIFF
--- a/docs/architecture/10-agent-adapter-contract.md
+++ b/docs/architecture/10-agent-adapter-contract.md
@@ -152,8 +152,7 @@ Hard failure on user input requirement:
 
 #### 10.4.2 Tool interface contract
 
-All tools that Sortie exposes to agents implement the `AgentTool` interface
-(`internal/domain/tool.go`):
+All tools that Sortie exposes to agents implement the `AgentTool` interface:
 
 - `Name() string`: stable tool identifier used for matching tool call requests to
   implementations. MUST be unique within a `ToolRegistry`.
@@ -176,7 +175,7 @@ the two shapes are byte-identical at the top level across tools.
 
 #### 10.4.3 Tool registry
 
-`ToolRegistry` (`internal/domain/tool.go`) is the central registration point for all agent tools.
+`ToolRegistry` is the central registration point for all agent tools.
 
 Invariants:
 
@@ -482,7 +481,7 @@ The family has the following parts:
 - **The `registry.Notifiers` registry** maps a `kind` string to a constructor. Backend
   packages register in `init()`; the sidecar resolves backends by `kind` at runtime. This
   mirrors `registry.SCMAdapters` exactly.
-- **The backend packages** live under `internal/notify/<kind>/`. v1 ships `webhook` (posts
+- **The backend packages** are one per `kind`. v1 ships `webhook` (posts
   the notification as a JSON object using generic field names) and `slack` (posts a
   Slack-shaped body with a `text` field). Each builds on the shared HTTP client with its
   configured endpoint as the base URL, applies a mandatory per-call timeout, and classifies

--- a/docs/architecture/11-issue-tracker-integration-contract.md
+++ b/docs/architecture/11-issue-tracker-integration-contract.md
@@ -168,7 +168,7 @@ diverges from this shared rule.
 The Linear adapter targets Linear's single GraphQL endpoint
 (`https://api.linear.app/graphql`). Unlike the Jira and GitHub adapters, which call multiple REST
 endpoints, every Linear operation is an HTTP POST of a `{ "query", "variables" }` body to that one
-endpoint, built on `internal/httpkit` with no third-party GraphQL library.
+endpoint, built on the shared HTTP client with no third-party GraphQL library.
 
 **Authentication.** The resolved `tracker.api_key` is sent verbatim in the `Authorization` header
 with no `Bearer` prefix and no `email:token` composition. Linear personal API keys carry the
@@ -246,7 +246,7 @@ and GitHub adapters do. See the workflow reference for the operator-facing shape
 #### 11.6.2 Gitea adapter
 
 The Gitea adapter targets the REST API v1 of a self-hosted Gitea instance, built on
-`internal/httpkit` with no third-party Gitea client library. Gitea has no hosted tier, so
+the shared HTTP client with no third-party Gitea client library. Gitea has no hosted tier, so
 `tracker.endpoint` is required and carries the instance base URL; the adapter trims a trailing
 slash, appends `/api/v1`, and tolerates an endpoint that already ends in `/api/v1`. Its wire model
 is close to the GitHub adapter's, issues plus labels plus an open/closed status, and it diverges
@@ -328,7 +328,7 @@ filter keys.
 #### 11.6.3 GitLab adapter
 
 The GitLab adapter targets the REST API v4 of GitLab.com or a self-managed instance, built on
-`internal/httpkit` with no third-party GitLab client library. `tracker.endpoint` carries the
+the shared HTTP client with no third-party GitLab client library. `tracker.endpoint` carries the
 instance base URL and is optional: it defaults to the GitLab.com host, which a self-managed
 deployment overrides. The adapter trims a trailing slash, appends `/api/v4`, and tolerates an
 endpoint that already ends in `/api/v4`. Its wire model is closest to the GitHub and Gitea adapters,
@@ -456,9 +456,9 @@ emits for filter labels absent from the project catalog.
 #### 11.6.4 GitHub adapter
 
 The GitHub adapter targets the REST API (plus the search endpoint) at `tracker.endpoint`, which
-defaults to `https://api.github.com`, built on `internal/httpkit` with no third-party GitHub client
-library. Its wire model is the closest of the three forges to Gitea's, issues plus labels plus an
-open/closed status, and the two diverge mainly in how each locates issues by state.
+defaults to `https://api.github.com`, built on the shared HTTP client with no third-party GitHub
+client library. Its wire model is the closest of the three forges to Gitea's, issues plus labels
+plus an open/closed status, and the two diverge mainly in how each locates issues by state.
 
 **Authentication.** The resolved `tracker.api_key` is sent as a `Bearer` token in the
 `Authorization` header alongside a pinned API-version header. Unlike the Gitea and GitLab adapters,

--- a/docs/architecture/12-ci-feedback-contract.md
+++ b/docs/architecture/12-ci-feedback-contract.md
@@ -56,7 +56,10 @@ Every forge that exposes both a CI provider and a source-control merge-gate read
 aggregation rule, so neither reader can invent its own definition of failing. The two can still
 reach different verdicts when they read different signals: on GitHub the CI provider reads check
 runs only, while the merge gate reads the combined commit status as well, so a commit whose sole
-failing signal is a legacy commit status is passing to one and failing to the other.
+failing signal is a legacy commit status is passing to one and failing to the other. On GitLab the
+CI provider derives its verdict from the normalized run set while the merge gate reads the
+platform's own pipeline aggregate, so the two can differ whenever that aggregate is not a function
+of the failing set.
 
 Each `CheckRun` contains:
 
@@ -229,10 +232,14 @@ status description and target URL already present in the authenticated response;
 fetches the target URL, so the trust boundary stays at the Gitea API.
 
 **GitLab provider.** A GitLab CI status provider registers under kind `gitlab`. Every ref is
-resolved to a full commit SHA first, because the commit-status route matches its path segment
-literally and answers a branch name or an abbreviated SHA with an empty list. The same commit
+resolved to a full commit SHA first, through the commit-retrieval route, which accepts a branch or
+tag name where the commit-status route documents its path segment as a commit hash. The same commit
 response names the pipeline the read is scoped to, so a superseded pipeline's entries cannot hold a
-green commit at failing. Each entry of that pipeline maps to one check run, with `allow_failure`
-folded into the conclusion. The failing-check log excerpt is a real job trace, fetched under a byte
-cap and sanitized, which is the capability Gitea has no equivalent for.
+green commit at failing; the scope is applied twice, once as a query parameter and again after
+decoding, so a deployment that ignores the parameter cannot widen it. Each entry of that pipeline
+maps to one check run, with `allow_failure` folded into the conclusion. The failing-check log
+excerpt is a real job trace, fetched under a byte cap and sanitized, which is the capability Gitea
+has no equivalent for. The trace route ignores a range request, so a trace exceeding the cap yields
+the tail of the fetched prefix rather than the true tail, and an entry that is an externally
+reported status rather than a pipeline job has no trace at all, leaving the excerpt empty.
 

--- a/docs/architecture/13-pr-review-comment-feedback-contract.md
+++ b/docs/architecture/13-pr-review-comment-feedback-contract.md
@@ -36,6 +36,20 @@ bot-authored changes-requested review the way the GitHub adapter's platform-mark
 automated-reviewer feedback is separated instead through the bot-review reaction's username
 allowlist (§11D).
 
+**GitLab adapter.** A GitLab SCM adapter registers under kind `gitlab`. GitLab has no review
+object bundling a verdict with a comment set, so `FetchPendingReviews` composes the selection from
+two reads: the merge request's dedicated reviewers route supplies each reviewer's review state, and
+the notes route supplies the comments, joined on the author login. Only a reviewer whose review
+state is `requested_changes` is kept, and because the platform attaches no comment to a verdict,
+the returned set is every comment that reviewer wrote on the merge request rather than the comments
+of one review round. No embedded user object in the API carries a platform bot marker, so a
+reviewer is classified through a separate per-user lookup cached for the adapter's lifetime; a
+lookup that fails for any reason other than a deleted account treats the reviewer as not a bot and
+the read continues. `end_line` is always zero, because a GitLab comment position describes one
+line, and `outdated` has no platform field: the adapter derives it by comparing the recorded head
+SHA against the merge request's current head, so a comment carrying no diff position is never
+outdated.
+
 ### 11B.2 ReviewComment structure
 
 ```text

--- a/docs/architecture/14-auto-merge-reaction-contract.md
+++ b/docs/architecture/14-auto-merge-reaction-contract.md
@@ -123,6 +123,28 @@ the result with the PR's requested-reviewers signal into one decision. `GetMerge
 from an in-progress recheck, so both present as `unknown`, which this table re-enqueues on the poll
 interval as a transient state.
 
+**GitLab auto-merge reads.** The GitLab adapter has no aggregate review-decision field and no
+per-condition mergeability enum, so it composes the first and maps the second from a single string.
+`GetReviewDecision` folds two reads: a reviewer whose review state is `requested_changes` returns
+`CHANGES_REQUESTED` before the approvals payload is read at all, then an approved payload returns
+`APPROVED`, a non-empty reviewer list returns `REVIEW_REQUIRED`, and neither returns
+`NOT_REQUIRED`. The changes-requested arm returns unconditionally, so a later approval by a second
+reviewer never clears an outstanding block. Community Edition carries no `approvals_required` and
+no `approvals_left` on the merge request, exposes no approval-state route, and has no approval
+rules at all, so it can never require an approval: a merge request with no reviewer assigned folds
+to `NOT_REQUIRED`, and this table proceeds to the merge. Enforcing review on Community Edition
+means assigning a reviewer, because the platform offers no server-side alternative.
+`GetMergeability` maps GitLab's single `detailed_merge_status` value: `mergeable` to `clean`,
+`conflict` to `dirty`, `unchecked`, `checking`, `preparing`, and `approvals_syncing` to `unknown`,
+and every other value, recognized or not, to `blocked`, logging an unrecognized one at WARN. It
+never yields `unstable`, because a pipeline whose only failing job is allowed to fail reports
+success and leaves the merge request `mergeable`, and this table treats `clean` and `unstable`
+identically. The value names one blocking condition at a time and recomputes: approving a merge
+request has been observed to move it from `mergeable` to `checking` and back, so a read landing
+mid-recompute reports `unknown` and re-enqueues as a transient state. A `dirty` read is a
+mergeability observation rather than an error, re-enqueued on the poll interval, so the conflict
+error kind stays confined to the merge write path.
+
 ### 11C.6 Escalation behavior
 
 The count-based escalation check guards the comparison with `MaxRetries > 0`: the orchestrator
@@ -220,11 +242,13 @@ Gitea token's user repository write access and the token the `write:repository` 
 repository or organization signal: it reads the token-introspection endpoint at startup. GitLab
 has no contents-versus-pull-request scope split, so the single `api` scope is the one requirement
 covering the merge, the branch delete, and the label write. A granular token's scope report is
-opaque and takes the fail-open path, and an instance whose introspection route is unavailable
-takes the same fail-open path rather than disabling auto-merge, because that route can answer 404
-for a hidden or blocked path as readily as for a genuinely missing one. A branch-protection
-refusal on this platform is reported at runtime as an auth-class failure rather than being caught
-at startup.
+opaque and takes the fail-open path, as do an empty scope list and an introspection response the
+adapter cannot read, and an instance whose introspection route is unavailable takes the same
+fail-open path rather than disabling auto-merge, because that route can answer 404
+for a hidden or blocked path as readily as for a genuinely missing one. A classic token whose
+scope list omits `api` is a verified gap instead, and takes the auth-class sticky posture. A
+branch-protection refusal on this platform is reported at runtime as an auth-class failure rather
+than being caught at startup.
 
 For the full preflight algorithm, see §6.3.
 

--- a/docs/architecture/16-merge-conflict-reaction-contract.md
+++ b/docs/architecture/16-merge-conflict-reaction-contract.md
@@ -20,7 +20,7 @@ Conflict detection reuses the existing `GetMergeability` read. No new method is 
 `SCMAdapter` interface. The interface's `PRMergeStatus` return type gains one additive field:
 
 ```go
-// PRMergeStatus addition (internal/domain/scm.go):
+// PRMergeStatus addition:
 BaseBranch string
 ```
 

--- a/docs/architecture/22-test-and-validation-matrix.md
+++ b/docs/architecture/22-test-and-validation-matrix.md
@@ -152,6 +152,105 @@ Unless otherwise noted, Sections 17.1 through 17.7 are `Core Conformance`. Bulle
 - Worker exit with `scm.json` containing `pr_number > 0`, `owner`, and `repo` creates review
   pending reaction; missing fields degrade to no-review behavior
 - Worker exit does not overwrite existing pending review entry (preserves debounce state)
+- Bot-review reconciliation is skipped when no SCM adapter is constructed or when bot-review is not
+  configured
+- Bot classification is the union of the platform bot marker and the `bot_usernames` allowlist, so
+  on a provider that reports no bot marker an empty allowlist selects nothing and the kind never
+  dispatches
+- Bot-review selection requires no `CHANGES_REQUESTED` review state, and outdated comments are
+  filtered before the fingerprint is computed
+- New actionable bot comments dispatch on the tick they are detected, with no debounce window and no
+  `debounce_ms` field
+- The bot-review budget is `max_continuation_turns` with a per-kind default of `5` and a poll
+  interval defaulting to `60000`, both independent of the `review` kind's values
+- The bot-review fingerprint is the sorted non-outdated comment-ID hash under its own kind row; a
+  changed comment set resets the dispatched flag and re-arms a dispatch, leaving the `review`
+  fingerprint untouched
+- A non-nil retry-slot incumbent defers the bot-review pass without dispatching
+- Bot-review escalation at the cap clears only the `bot-review` pending entry and fingerprint row,
+  leaving the residual attempt counter, the pending retry, and the claim for the terminal-state path
+- Bot-review escalation tracker-call failures are logged and counted but do not block the
+  slot-scoped cleanup
+- Worker-exit seeding and startup recovery create a bot-review entry only when SCM metadata reports
+  `pr_number > 0` and non-empty `owner`, `repo`, and `branch`, and recovery is gated on the
+  configured flag so a configured-but-providerless setup recovers none
+- Merge-conflict reconciliation is skipped when no SCM adapter is constructed or when merge-conflict
+  is not configured, and the pass runs after bot-review and before auto-merge
+- Only the normalized `dirty` state arms the reaction; `unknown` defers at the poll interval without
+  touching the fingerprint or the attempt counter
+- A provider whose mergeability mapping never yields `dirty` leaves the kind inert: every due tick
+  defers and the pending TTL drops the entry without escalating
+- The mergeability read runs on every due tick with no retry-budget check ahead of it, so the
+  not-dirty branch that closes the episode stays reachable
+- The retry-slot guard, the empty head-SHA guard, and the empty base-branch guard all run before the
+  attempt increment, so a deferral never burns an attempt
+- The merge-conflict fingerprint is the SHA-256 of the head SHA under its own kind row; a same-head
+  dispatched observation re-enqueues without incrementing or dispatching, a new head re-arms a fresh
+  attempt, and the not-dirty branch deletes the row so the next dirty observation dispatches
+- The merge-conflict cap is a strict over-limit comparison against `max_retries`, whose per-kind
+  default is `1`, so a configured `0` escalates on the first conflict detection
+- Both merge-conflict episode exits, the not-dirty branch and escalation, delete the per-episode
+  attempt counter, so a later independent conflict opens a fresh episode at attempt 1
+- Merge-conflict escalation scopes every deletion to the `merge-conflict` kind, cancels and deletes
+  no retry, releases no claim, and leaves parallel `ci`, `review`, `bot-review`, and `merge`
+  reactions intact
+- The rebase continuation carries the PR's base branch read live on the dispatching tick rather than
+  an assumed default branch
+- Auto-merge reconciliation is skipped when `reactions.auto_merge.provider` is empty or no SCM
+  adapter is present
+- The auto-merge pass runs after the CI, review-comment, bot-review, and merge-conflict passes and
+  before the two label-command passes
+- A sticky auth-class preflight failure drops every `merge`-kind pending entry on each later tick, a
+  transport-class preflight failure schedules exactly one retry before the flag sticks, and absent
+  scope information fails open with auto-merge enabled
+- A draft PR, a mergeability outside `clean` and `unstable`, a review decision other than `APPROVED`
+  or `NOT_REQUIRED`, and a CI conclusion other than success while `require_ci` holds each re-enqueue
+  at the poll interval instead of merging
+- Count-based auto-merge escalation applies only when `max_retries > 0`, whose default is `2`, so a
+  configured `0` disables it rather than escalating on the first attempt
+- An auth-class or payload-class `MergePR` failure escalates immediately, bypassing the
+  `max_retries` check, including when it is `0`; any other conflict re-enqueues at the poll interval
+- A merge rejection carrying the already-merged marker is treated as idempotent success and takes
+  the same post-merge actions as a completed merge
+- The merge fingerprint is the SHA-256 of the head SHA, a newline byte, and the review-decision
+  string under kind `merge`; a changed head SHA or review decision refreshes it, and a successful
+  merge clears it
+- A branch-delete or tracker-comment failure after a completed merge is not rolled back
+- Neither the post-merge success path nor the auto-merge escalation path cancels or deletes a retry,
+  clears every entry an issue holds, or deletes the issue's claim, so parallel `ci` and `review`
+  continuations survive
+- The already-merged disposition clears only the `merge`-kind pending entry and fingerprint and
+  never transitions the tracker issue
+- Each label-command pass is skipped when no SCM adapter is constructed or its own command is not
+  configured, and an absent or empty `provider` means no journal read happens for either command
+- A fix-only configuration, with `review_label` empty and `fix_label` non-empty, activates the block
+  and constructs the SCM adapter exactly as a review-only configuration does
+- A `provider` set while both command labels are empty is rejected offline
+- The high-water mark advances to the newest examined event on every tick that reads new events,
+  including `unlabeled` entries, foreign labels, and retracted gestures
+- All matching `labeled` events in one batch collapse to at most one command
+- A command is confirmed only when its label is still present on the PR at detection time; otherwise
+  the mark advances and nothing dispatches
+- The mark is persisted before the dispatch is scheduled, so a crash between the two loses the
+  command rather than duplicating it
+- The `dispatched` flag is not a deduplication input for either label kind, and the review pass's
+  "stored fingerprint matches and dispatched" skip is not adopted
+- A failed mark read backs off without dispatching, while a failed mark upsert proceeds
+- Neither label kind carries a TTL, a drop-on-age branch, an attempt counter, or an escalation
+  posture
+- A foreign-kind retry-slot incumbent defers with the mark unchanged and no label removal, a
+  same-kind incumbent or a running command of the same kind advances the mark and collapses the
+  gesture, and only a free slot dispatches
+- Each label-command pass re-enqueues its own detection entry on dispatch, because neither command's
+  exit satisfies the reaction-enqueue gate and so re-seeds nothing
+- A `label-review` entry seeds and recovers on PR metadata without a branch, while a `label-fix`
+  entry additionally requires a non-empty head branch and seeds none without one
+- A `label-review` dispatch runs the read-only, no-clone posture with the operator hooks skipped and
+  a `label-fix` dispatch takes the normal workspace preparation path with the hooks run; both
+  suppress the dispatch-time transition, the dispatch comment, the per-turn tracker-state refresh,
+  the self-review loop, the handoff transition, and the active-issue continuation retry
+- Each label-command pass scopes every `pending_reactions` and `reaction_fingerprints` mutation to
+  its own kind, so the relative ordering of the two passes does not affect correctness
 - Merge-completion reconciliation is skipped when `reactions.merge_completion` is not configured,
   or when no SCM adapter or no tracker adapter is present
 - Merge-completion drops an entry whose issue is missing from the state response, already terminal,

--- a/docs/architecture/28-label-command-and-read-only-review-contract.md
+++ b/docs/architecture/28-label-command-and-read-only-review-contract.md
@@ -99,8 +99,8 @@ zero-padding the GitHub adapter applies. The GitLab adapter walks that journal f
 from the tail, and sorts the normalized events ascending by `(At, ID)` itself, so ordering does not
 depend on the server's. An entry whose label was later deleted from the project renders its label
 object null and is skipped, because it carries no name to normalize. The forward walk retains the
-oldest events when a journal exceeds the page cap, the opposite of the GitHub tail walk, and the
-adapter warns when the cap is reached.
+events GitLab serves first when a journal exceeds the page cap, where the GitHub tail walk retains
+the newest, and the adapter warns when the cap is reached.
 
 ### 11F.3 Command contract and detection invariants
 

--- a/docs/architecture/28-label-command-and-read-only-review-contract.md
+++ b/docs/architecture/28-label-command-and-read-only-review-contract.md
@@ -92,9 +92,15 @@ When the journal exceeds the cap the adapter emits a warning naming the PR, so a
 never silently dropped on an event-heavy PR. Managed PRs are short-lived and low-traffic, so
 journals stay small; a page cache is an available optimization if profiling ever demands one.
 
-The abstraction is portable. The normalized `LabelEvent` shape is satisfiable by GitLab resource
-label events on merge requests, which carry the same id, user, action, and timestamp; a future
-adapter fits without a contract change.
+The abstraction is portable, and the GitLab adapter fits it without a contract change. On GitLab
+the journal is the merge request's resource label-event route, whose entries carry the same id,
+user, action, and timestamp, and whose numeric ids satisfy the `ID` ordering rule through the same
+zero-padding the GitHub adapter applies. The GitLab adapter walks that journal forward rather than
+from the tail, and sorts the normalized events ascending by `(At, ID)` itself, so ordering does not
+depend on the server's. An entry whose label was later deleted from the project renders its label
+object null and is skipped, because it carries no name to normalize. The forward walk retains the
+oldest events when a journal exceeds the page cap, the opposite of the GitHub tail walk, and the
+adapter warns when the cap is reached.
 
 ### 11F.3 Command contract and detection invariants
 

--- a/docs/workflow-reference.md
+++ b/docs/workflow-reference.md
@@ -923,13 +923,19 @@ issue stops on the same pass. The release is scoped to in-memory state and leave
 Remaining keys within a kind sub-object are kind-specific and collected into an `Extra` map.
 
 **SCM and CI provider selection.** The reaction `provider` field (and the deprecated
-`ci_feedback.kind`) names a registered SCM adapter or CI provider kind: `github` or `gitea`. The
-reaction kinds are provider-agnostic. Setting `provider: gitea` activates the Gitea adapter for
-that reaction. Its `endpoint`, `api_key`, and `project` come from the top-level `gitea:`
+`ci_feedback.kind`) names a registered SCM adapter or CI provider kind: `github`, `gitea`, or
+`gitlab`. The reaction kinds are provider-agnostic. Setting `provider: gitea` activates the Gitea
+adapter for that reaction. Its `endpoint`, `api_key`, and `project` come from the top-level `gitea:`
 pass-through block ([Section 4.5](#45-adapter-specific-pass-through-config)); when `tracker.kind`
 is also `gitea`, any of the three left unset in that block falls back to the matching `tracker:`
 value. A Gitea reaction can therefore pair with a non-Gitea tracker, as long as the `gitea:` block
-supplies the credentials, including the instance `endpoint` Gitea always requires. Every active
+supplies the credentials, including the instance `endpoint` Gitea always requires. Setting
+`provider: gitlab` activates the GitLab adapter for that reaction and resolves the same three
+fields from the top-level `gitlab:` block by the same rule. `endpoint` is optional there, because
+the GitLab adapter defaults it to `https://gitlab.com`; only a self-managed instance sets one. The
+GitLab SCM adapter ignores `project` and takes the owner and repository from the pull request
+metadata on every call, while the GitLab CI provider requires `project`, so a GitLab `ci_failure`
+reaction paired with a non-GitLab tracker MUST set it in the `gitlab:` block. Every active
 SCM reaction in one workflow MUST name the same provider.
 
 #### Reaction kind: `ci_failure`


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Chore

**Intent:** The GitLab SCM adapter and CI status provider registered, and the repository references still described the SCM and CI contracts adapter by adapter with no GitLab counterpart, which turned several statements from incomplete into wrong. Two unrelated pieces of specification hygiene ride along: package paths that the specification forbids, and four reaction contracts the conformance matrix never grew to cover.

**Related Issues:** #724, #753, #752

### 🧭 Reviewer Guide

**Complexity:** Low

#### Entry Point

`docs/architecture/14-auto-merge-reaction-contract.md`. Its new GitLab paragraph carries the claims most worth checking: the review-decision fold and its order, the Community Edition limits that make an approval impossible to require, and the four inputs the scope preflight fails open on, where the section previously named two. Every claim there was traced to the adapter source and to the live-verified research notes.

#### Sensitive Areas

- `docs/architecture/12-ci-feedback-contract.md`: one claim was removed rather than restated. The section asserted that the commit-status route answers a branch name with an empty list, which no observation supported. It now rests on the documented difference between the two routes instead.
- `docs/architecture/14-auto-merge-reaction-contract.md`: the Community Edition statements are load-bearing for an operator deciding whether review can be enforced. They rest on live probes against a pinned Community Edition instance, not on vendor documentation.
- `docs/architecture/22-test-and-validation-matrix.md`: each added expectation is meant to be traceable to a rule stated in the corresponding contract section. Where a contract states no such rule, none was invented.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes. Documentation only; no code, tests, or configuration are touched.
- **Migrations/State:** No migrations or state changes.