### PR TITLE
fix(scm): unify malformed-timestamp handling across SCM adapters

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -14,3 +14,9 @@ coverage:
 comment:
   layout: "condensed_header, condensed_files, condensed_footer"
   require_changes: true   # only comment when coverage changes
+
+ignore:
+  # Shared test-support assertions, called only from sibling packages'
+  # tests. `go test ./...` instruments the package under test, so these
+  # lines are always reported as uncovered no matter how often they run.
+  - "internal/adaptertest"

--- a/docs/architecture/13-pr-review-comment-feedback-contract.md
+++ b/docs/architecture/13-pr-review-comment-feedback-contract.md
@@ -64,6 +64,12 @@ ReviewComment:
   outdated:     bool        # true when the commented code was modified by a subsequent push
 ```
 
+`submitted_at` feeds the debounce window and nothing else, and a platform value that is absent or
+is not a valid RFC 3339 value normalizes to the zero time and does not fail the read. A zero value
+cannot raise the debounce window's upper bound, so the affected comment set can dispatch up to one
+debounce interval earlier than it otherwise would, and deduplication is unaffected because the
+fingerprint (§11B.7) is built from comment identifiers.
+
 ### 11B.3 SCMError type
 
 ```text

--- a/docs/architecture/14-auto-merge-reaction-contract.md
+++ b/docs/architecture/14-auto-merge-reaction-contract.md
@@ -126,7 +126,15 @@ the result with the PR's requested-reviewers signal into one decision. `GetMerge
 `mergeable` boolean to `clean` (mergeable and not a draft), `blocked` (draft), or `unknown`
 (anything else), and never yields `dirty` or `unstable`. Gitea cannot distinguish a merge conflict
 from an in-progress recheck, so both present as `unknown`, which this table re-enqueues on the poll
-interval as a transient state.
+interval as a transient state. The fold orders decision-bearing reviews by submission time, so that
+timestamp is load-bearing; a review that can change the verdict and carries a submission timestamp
+that is not a valid RFC 3339 value fails the read with a `scm_payload_error` rather than sorting to
+the epoch, because a substituted timestamp can let a superseded approval outrank the
+changes-requested review that supersedes it. A review that cannot change the verdict, a dismissed
+review or one whose state is not a decision, is not parsed and cannot fail the read. The
+precondition read defers with backoff and never merges on this failure, and the pending entry is
+dropped once its age exceeds the TTL backstop (§11C.4), which escalates nothing and leaves the pull
+request unmerged for the operator to merge manually.
 
 **GitLab auto-merge reads.** The GitLab adapter has no aggregate review-decision field and no
 per-condition mergeability enum, so it composes the first and maps the second from a single string.

--- a/docs/architecture/22-test-and-validation-matrix.md
+++ b/docs/architecture/22-test-and-validation-matrix.md
@@ -347,8 +347,12 @@ network access, or external service permissions are unavailable.
   an empty-but-non-nil result on each list method with no results, source-control error kind
   mapping for the auth, not-found, payload, and API classes, the already-merged marker on a merge
   that raced an external merge, the absent-branch disposition on a delete of a missing branch, the
-  absent-label disposition on a removal of an absent label, and a correctly ordered label-event
-  journal.
+  absent-label disposition on a removal of an absent label, a correctly ordered label-event
+  journal, a label-event entry whose timestamp does not parse failing the read with the payload
+  error kind and yielding no events, and a review comment whose timestamp does not parse not
+  failing the read and carrying the zero timestamp. A forge whose review decision is folded from
+  per-review submission times fails that read on an unparseable timestamp of a review that can
+  change the verdict, an adapter-specific obligation with no shared assertion.
 - Each CI provider's suite exercises the shared CI-aggregate conformance assertion against a result
   containing at least one completed-failing run, one in-progress run, and one completed-success
   run, confirming the provider's aggregate status and failing count agree with the forge decision

--- a/docs/architecture/28-label-command-and-read-only-review-contract.md
+++ b/docs/architecture/28-label-command-and-read-only-review-contract.md
@@ -69,6 +69,13 @@ RemoveLabel(ctx context.Context, prNumber int, owner, repo, label string) error
   this by zero-padding the decimal id to a fixed width (the GitHub adapter pads to 19 digits, the
   int64 maximum). An adapter whose native ids do not sort lexically in journal order MUST derive a
   sortable surrogate at the boundary; raw UUIDs do not qualify.
+- `At` MUST be the entry's own timestamp normalized to UTC; an entry whose timestamp is absent or
+  is not a valid RFC 3339 value MUST fail the read with a `scm_payload_error`, and an implementation
+  MUST NOT substitute the zero time or any other synthesized value. `At` is half of the `(At, id)`
+  high-water-mark position, the zero time sorts before every recorded position, and a substituted
+  timestamp therefore withdraws the entry from detection and drops the command it carries. The
+  timestamp is parsed only for entries the adapter retains, so an entry skipped for its kind or its
+  missing label name cannot fail the read.
 - Implementations MUST be safe for concurrent use.
 
 No diff-fetch method and no review-comment-posting method are added. The reviewing agent fetches the
@@ -100,7 +107,10 @@ from the tail, and sorts the normalized events ascending by `(At, ID)` itself, s
 depend on the server's. An entry whose label was later deleted from the project renders its label
 object null and is skipped, because it carries no name to normalize. The forward walk retains the
 events GitLab serves first when a journal exceeds the page cap, where the GitHub tail walk retains
-the newest, and the adapter warns when the cap is reached.
+the newest, and the adapter warns when the cap is reached. An adapter that walks the journal forward
+retains its earliest entries, so an entry whose timestamp fails to parse stays in the retained window
+and does not age out of it, where a tail walk drops such an entry only once the journal grows past
+the page cap.
 
 ### 11F.3 Command contract and detection invariants
 
@@ -447,6 +457,7 @@ budget machinery.
 | Condition | Visibility | Recovery |
 |-----------|------------|----------|
 | `ListLabelEvents` returns a `*SCMError` | Warn with PR number and error kind | Increment per-entry backoff, set `PendingRetryAt`, re-enqueue; retried on the next due tick. No escalation. |
+| `ListLabelEvents` fails because a retained entry's timestamp does not parse | Same Warn | Same backoff and re-enqueue. No command on that PR dispatches for as long as the forge serves that entry: this kind's pending entry has no TTL and no drop-on-age branch, so the retry ends only when the forge serves a parseable value or the issue reaches a terminal state, dropping the entry (§11F.12). |
 | `RemoveLabel` returns a `*SCMError` (including a scope gap) | Warn with PR number and label | None required; deduplication is already committed. The label lingers until removed manually. |
 | Fingerprint read fails | Warn | The pass backs off and re-enqueues without dispatching: at-most-once rests solely on the mark, so a command must not dispatch when the stored mark cannot be read. |
 | Fingerprint upsert fails | Warn | The pass proceeds; the durable guarantee degrades to best-effort for that tick, matching the siblings. |

--- a/docs/gitea-adapter-notes.md
+++ b/docs/gitea-adapter-notes.md
@@ -451,6 +451,7 @@ GET /repos/{owner}/{repo}/pulls/{index}/reviews/{id}/comments
 Gitea has no aggregate review-decision field; the GitHub adapter reads one from GraphQL, which Gitea does not offer. `GetReviewDecision` folds the review list together with the PR object's `requested_reviewers` signal:
 
 - Reviews are ordered by `submitted_at` then `id`, so the latest `APPROVED` or `REQUEST_CHANGES` per reviewer supersedes that reviewer's earlier reviews. `COMMENT`, `PENDING`, and `REQUEST_REVIEW` are not decisions, and dismissed reviews do not contribute.
+- The ordering depends on `submitted_at` parsing as RFC 3339, so a value that does not parse fails the decision read instead of sorting the review to the epoch, and only reviews that can change the verdict are parsed.
 - Any standing `REQUEST_CHANGES` yields changes-requested; otherwise any `APPROVED` yields approved; otherwise a non-empty `requested_reviewers` yields review-required; otherwise not-required.
 
 ### Mergeability

--- a/internal/adaptertest/contract_test.go
+++ b/internal/adaptertest/contract_test.go
@@ -47,6 +47,7 @@ var contractBanTable = map[string]string{
 	"extractState":           "issuekit.DeriveLabelState",
 	"findCurrentStateLabel":  "issuekit.CurrentLabelState",
 	"paginatePages":          "httpkit.NewPagePaginator",
+	"parseUTC":               "scmcore.ParseTimestamp or scmcore.ParseTimestampOrZero",
 }
 
 // contractTrackerAdapterMethods are the domain.TrackerAdapter method

--- a/internal/adaptertest/scm.go
+++ b/internal/adaptertest/scm.go
@@ -104,3 +104,45 @@ func AssertLabelEventsOrdered(t *testing.T, events []domain.LabelEvent) {
 		}
 	}
 }
+
+// AssertLabelEventTimestampRejected pins the disposition of a
+// label-event journal entry whose timestamp does not parse: err unwraps
+// to a [*domain.SCMError] of Kind [domain.ErrSCMPayload], and events is
+// empty. The emptiness clause catches an adapter that returns both an
+// error and a poisoned event, which the error kind alone would not.
+func AssertLabelEventTimestampRejected(t *testing.T, events []domain.LabelEvent, err error) {
+	t.Helper()
+
+	AssertSCMErrorKind(t, err, domain.ErrSCMPayload)
+	if len(events) != 0 {
+		t.Errorf("AssertLabelEventTimestampRejected: events = %v, want empty", events)
+	}
+}
+
+// AssertReviewCommentTimestampTolerated pins the disposition of a
+// review comment whose timestamp does not parse: the read succeeds,
+// exactly one returned comment carries the zero SubmittedAt, and every
+// other comment carries a non-zero SubmittedAt. The fixture driving this
+// assertion MUST carry exactly one malformed timestamp per call.
+func AssertReviewCommentTimestampTolerated(t *testing.T, comments []domain.ReviewComment, err error) {
+	t.Helper()
+
+	if err != nil {
+		t.Errorf("AssertReviewCommentTimestampTolerated: err = %v, want nil", err)
+		return
+	}
+	if len(comments) == 0 {
+		t.Errorf("AssertReviewCommentTimestampTolerated: comments is empty, want at least one")
+		return
+	}
+
+	zeroCount := 0
+	for _, c := range comments {
+		if c.SubmittedAt.IsZero() {
+			zeroCount++
+		}
+	}
+	if zeroCount != 1 {
+		t.Errorf("AssertReviewCommentTimestampTolerated: %d comments carry a zero SubmittedAt, want exactly 1", zeroCount)
+	}
+}

--- a/internal/domain/review.go
+++ b/internal/domain/review.go
@@ -27,7 +27,8 @@ type ReviewComment struct {
 
 	// SubmittedAt is the UTC timestamp when the comment was created
 	// on the SCM platform. Used by the orchestrator to drive debounce
-	// gating.
+	// gating. A platform timestamp that is absent or is not RFC 3339
+	// normalizes to the zero time and does not fail the read.
 	SubmittedAt time.Time
 
 	// Outdated indicates the commented code has been modified by a

--- a/internal/domain/scm.go
+++ b/internal/domain/scm.go
@@ -135,7 +135,10 @@ type LabelEvent struct {
 	// Added is true for a labeled event and false for an unlabeled event.
 	Added bool
 
-	// At is the journal timestamp in UTC.
+	// At is the entry's own timestamp, normalized to UTC. It is never
+	// synthesized: At is half of the (At, ID) high-water-mark position,
+	// and the zero time sorts before every recorded position, so a
+	// substituted value would make the entry unreachable for detection.
 	At time.Time
 }
 
@@ -228,6 +231,13 @@ type SCMAdapter interface {
 	// ListLabelEvents returns the label-event journal for the given PR,
 	// oldest first. Returns an empty non-nil slice when the PR has no
 	// label events. Returns a [*SCMError] on failure.
+	//
+	// An entry whose timestamp is absent or is not RFC 3339 MUST fail the
+	// read with a [*SCMError] of Kind [ErrSCMPayload]; an implementation
+	// MUST NOT substitute the zero time or any other synthesized value.
+	// The timestamp is parsed only for entries the implementation
+	// retains, so an entry skipped for its kind or its missing label
+	// name cannot fail the read.
 	ListLabelEvents(ctx context.Context, prNumber int, owner, repo string) ([]LabelEvent, error)
 
 	// RemoveLabel removes the named label from the given PR. Returns nil

--- a/internal/scm/gitea/scm.go
+++ b/internal/scm/gitea/scm.go
@@ -11,7 +11,6 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/sortie-ai/sortie/internal/domain"
 	"github.com/sortie-ai/sortie/internal/httpkit"
@@ -199,20 +198,6 @@ func (a *GiteaSCMAdapter) RemoveLabel(ctx context.Context, prNumber int, owner, 
 		return scm
 	}
 	return nil
-}
-
-// parseUTC parses an RFC 3339 timestamp and returns it in UTC.
-//
-// A malformed timestamp yields the zero [time.Time] rather than an error, so a
-// single unparseable field never fails an entire read. Gitea timestamps are
-// server-generated and well-formed, so the fallback does not arise for valid
-// responses.
-func parseUTC(s string) time.Time {
-	t, err := time.Parse(time.RFC3339, s)
-	if err != nil {
-		return time.Time{}
-	}
-	return t.UTC()
 }
 
 // paginateSCM walks a page-number-paginated Gitea route through the shared

--- a/internal/scm/gitea/scm_label_events.go
+++ b/internal/scm/gitea/scm_label_events.go
@@ -31,8 +31,10 @@ type giteaTimelineEntry struct {
 // Pull requests share the issue timeline route. Only "label" entries with a
 // named label are retained; the label is lowercased and Added is true only for a
 // body of "1". The timeline arrives oldest-first, so the result needs no re-sort.
-// The returned slice is non-nil even when empty; a failure returns a
-// [*domain.SCMError].
+// The returned slice is non-nil even when empty. A retained entry whose
+// created_at does not parse as RFC 3339 fails the read with a
+// [*domain.SCMError] of Kind [domain.ErrSCMPayload]; an entry skipped for its
+// kind or its missing label name is never parsed and cannot fail the read.
 func (a *GiteaSCMAdapter) ListLabelEvents(ctx context.Context, prNumber int, owner, repo string) ([]domain.LabelEvent, error) {
 	path := fmt.Sprintf("/repos/%s/%s/issues/%d/timeline",
 		url.PathEscape(owner), url.PathEscape(repo), prNumber)
@@ -61,12 +63,17 @@ func (a *GiteaSCMAdapter) ListLabelEvents(ctx context.Context, prNumber int, own
 			continue
 		}
 
+		at, err := scmcore.ParseTimestamp("timeline entry created_at", e.CreatedAt)
+		if err != nil {
+			return nil, err
+		}
+
 		events = append(events, domain.LabelEvent{
 			ID:    scmcore.SortableEventID(e.ID),
 			Label: strings.ToLower(e.Label.Name),
 			Actor: e.User.Login,
 			Added: e.Body == "1",
-			At:    parseUTC(e.CreatedAt),
+			At:    at,
 		})
 	}
 

--- a/internal/scm/gitea/scm_label_events_test.go
+++ b/internal/scm/gitea/scm_label_events_test.go
@@ -148,6 +148,47 @@ func TestGiteaSCMListLabelEvents(t *testing.T) {
 		_, err := adapter.ListLabelEvents(context.Background(), 6, testOwner, testRepo)
 		assertSCMErrorKind(t, err, domain.ErrSCMPayload)
 	})
+
+	t.Run("a retained label entry with a malformed created_at fails the read", func(t *testing.T) {
+		t.Parallel()
+
+		const fixture = `[{"id":1,"type":"label","body":"1","user":{"login":"alice"},"label":{"name":"bug"},"created_at":"not-a-timestamp"}]`
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(fixture))
+		}))
+		defer srv.Close()
+
+		adapter := mustSCMAdapter(t, srv.URL)
+		events, err := adapter.ListLabelEvents(context.Background(), 6, testOwner, testRepo)
+		adaptertest.AssertLabelEventTimestampRejected(t, events, err)
+	})
+
+	t.Run("a malformed created_at on a skipped comment entry does not fail the read", func(t *testing.T) {
+		t.Parallel()
+
+		const fixture = `[
+			{"id":2,"type":"comment","body":"checking in","user":{"login":"bob"},"label":null,"created_at":"not-a-timestamp"},
+			{"id":1,"type":"label","body":"1","user":{"login":"alice"},"label":{"name":"bug"},"created_at":"2026-07-14T10:00:00Z"}
+		]`
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(fixture))
+		}))
+		defer srv.Close()
+
+		adapter := mustSCMAdapter(t, srv.URL)
+		events, err := adapter.ListLabelEvents(context.Background(), 6, testOwner, testRepo)
+		if err != nil {
+			t.Fatalf("ListLabelEvents: unexpected error: %v", err)
+		}
+		if len(events) != 1 {
+			t.Fatalf("ListLabelEvents() len = %d, want 1 (the malformed comment entry is skipped before its timestamp is parsed)", len(events))
+		}
+		if events[0].Label != "bug" {
+			t.Errorf("events[0].Label = %q, want %q", events[0].Label, "bug")
+		}
+	})
 }
 
 // --- RemoveLabel ---

--- a/internal/scm/gitea/scm_reviews.go
+++ b/internal/scm/gitea/scm_reviews.go
@@ -9,6 +9,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/sortie-ai/sortie/internal/domain"
 	"github.com/sortie-ai/sortie/internal/scm/scmcore"
@@ -105,7 +106,11 @@ func (a *GiteaSCMAdapter) GetReviewDecision(ctx context.Context, prNumber int, o
 		return "", err
 	}
 
-	return foldReviewDecision(reviews, len(pr.RequestedReviewers) > 0), nil
+	decision, err := foldReviewDecision(reviews, len(pr.RequestedReviewers) > 0)
+	if err != nil {
+		return "", err
+	}
+	return decision, nil
 }
 
 // collectReviewComments fetches every review, retains those passing keepReview
@@ -145,7 +150,7 @@ func (a *GiteaSCMAdapter) collectReviewComments(ctx context.Context, prNumber in
 					ID:          prCommentID,
 					Reviewer:    r.User.Login,
 					Body:        body,
-					SubmittedAt: parseUTC(r.SubmittedAt),
+					SubmittedAt: scmcore.ParseTimestampOrZero(r.SubmittedAt),
 				})
 			}
 		}
@@ -189,39 +194,59 @@ func normalizeReviewComment(c giteaReviewComment) domain.ReviewComment {
 		StartLine:   startLine,
 		Reviewer:    c.User.Login,
 		Body:        c.Body,
-		SubmittedAt: parseUTC(c.CreatedAt),
+		SubmittedAt: scmcore.ParseTimestampOrZero(c.CreatedAt),
 		Outdated:    outdated,
 	}
+}
+
+// giteaContributingReview pairs a decision-bearing [giteaReview] with its
+// parsed submission time, so the ordering timestamp is parsed once, ahead
+// of the sort that depends on it.
+type giteaContributingReview struct {
+	review giteaReview
+	at     time.Time
 }
 
 // foldReviewDecision aggregates the per-review states with the PR's
 // requested-reviewers signal into one [domain.ReviewDecision].
 //
-// Dismissed reviews are skipped. Reviews are ordered by submission time then id
-// so the latest APPROVED or REQUEST_CHANGES per reviewer supersedes their earlier
-// ones; COMMENT, PENDING, and REQUEST_REVIEW states are not decisions. Any
-// standing REQUEST_CHANGES yields changes-requested; otherwise any APPROVED
-// yields approved; otherwise reviewRequested yields review-required; otherwise
-// not-required.
-func foldReviewDecision(reviews []giteaReview, reviewRequested bool) domain.ReviewDecision {
-	slices.SortFunc(reviews, func(a, b giteaReview) int {
-		if c := parseUTC(a.SubmittedAt).Compare(parseUTC(b.SubmittedAt)); c != 0 {
-			return c
-		}
-		return cmp.Compare(a.ID, b.ID)
-	})
-
-	latestDecision := make(map[string]string)
+// Dismissed reviews, and any review whose state is not APPROVED or
+// REQUEST_CHANGES, are filtered out before the parse; only a review that can
+// change the verdict is parsed, so a malformed timestamp on a review that
+// cannot change the verdict never fails the read. A retained review's
+// submitted_at is ordered then id so the latest per reviewer supersedes
+// their earlier ones. A retained review whose submitted_at does not parse
+// as RFC 3339 fails with a [*domain.SCMError] of Kind
+// [domain.ErrSCMPayload]. Any standing REQUEST_CHANGES yields
+// changes-requested; otherwise any APPROVED yields approved; otherwise
+// reviewRequested yields review-required; otherwise not-required.
+func foldReviewDecision(reviews []giteaReview, reviewRequested bool) (domain.ReviewDecision, error) {
+	contributing := make([]giteaContributingReview, 0, len(reviews))
 	for _, r := range reviews {
 		if r.Dismissed {
 			continue
 		}
-		switch r.State {
-		case "APPROVED":
-			latestDecision[r.User.Login] = "APPROVED"
-		case "REQUEST_CHANGES":
-			latestDecision[r.User.Login] = "REQUEST_CHANGES"
+		if r.State != "APPROVED" && r.State != "REQUEST_CHANGES" {
+			continue
 		}
+
+		at, err := scmcore.ParseTimestamp("review submitted_at", r.SubmittedAt)
+		if err != nil {
+			return "", err
+		}
+		contributing = append(contributing, giteaContributingReview{review: r, at: at})
+	}
+
+	slices.SortFunc(contributing, func(a, b giteaContributingReview) int {
+		if c := a.at.Compare(b.at); c != 0 {
+			return c
+		}
+		return cmp.Compare(a.review.ID, b.review.ID)
+	})
+
+	latestDecision := make(map[string]string)
+	for _, pair := range contributing {
+		latestDecision[pair.review.User.Login] = pair.review.State
 	}
 
 	anyChangesRequested := false
@@ -236,15 +261,15 @@ func foldReviewDecision(reviews []giteaReview, reviewRequested bool) domain.Revi
 	}
 
 	if anyChangesRequested {
-		return domain.ReviewDecisionChangesRequested
+		return domain.ReviewDecisionChangesRequested, nil
 	}
 	if anyApproved {
-		return domain.ReviewDecisionApproved
+		return domain.ReviewDecisionApproved, nil
 	}
 	if reviewRequested {
-		return domain.ReviewDecisionReviewRequired
+		return domain.ReviewDecisionReviewRequired, nil
 	}
-	return domain.ReviewDecisionNotRequired
+	return domain.ReviewDecisionNotRequired, nil
 }
 
 // fetchAllReviews returns every review on the given PR, following page-number

--- a/internal/scm/gitea/scm_reviews_test.go
+++ b/internal/scm/gitea/scm_reviews_test.go
@@ -341,6 +341,34 @@ func TestGiteaSCMGetReviewDecision(t *testing.T) {
 	}
 }
 
+// TestGiteaSCMGetReviewDecision_EqualTimestampTiebreak pins the review id
+// as the tiebreaker when two decision-bearing reviews by one reviewer share
+// a submitted_at. The sort is not stable, so without the tiebreaker the
+// winning review is unspecified. The fixture serves the reviews in
+// descending id order so a fold that preserved wire order would yield the
+// opposite verdict.
+func TestGiteaSCMGetReviewDecision_EqualTimestampTiebreak(t *testing.T) {
+	t.Parallel()
+
+	const reviewsFixture = `[
+		{"id":607,"state":"REQUEST_CHANGES","body":"","user":{"login":"alice"},"dismissed":false,"submitted_at":"2026-07-14T09:00:00Z"},
+		{"id":606,"state":"APPROVED","body":"","user":{"login":"alice"},"dismissed":false,"submitted_at":"2026-07-14T09:00:00Z"}
+	]`
+	prFixture := loadFixture(t, "pr_clean.json")
+	srv := httptest.NewServer(giteaReviewDecisionHandler(t, []byte(reviewsFixture), prFixture))
+	defer srv.Close()
+
+	adapter := mustSCMAdapter(t, srv.URL)
+	got, err := adapter.GetReviewDecision(context.Background(), 6, testOwner, testRepo)
+	if err != nil {
+		t.Fatalf("GetReviewDecision: unexpected error: %v", err)
+	}
+	if got != domain.ReviewDecisionChangesRequested {
+		t.Errorf("GetReviewDecision() = %q, want %q (review 607 outranks 606 on the id tiebreak)",
+			got, domain.ReviewDecisionChangesRequested)
+	}
+}
+
 // TestGiteaSCMGetReviewDecision_MalformedTimestamp pins the fold's strict
 // disposition: a decision-bearing review's malformed submitted_at fails
 // the read, while the same malformed value on a review the fold never

--- a/internal/scm/gitea/scm_reviews_test.go
+++ b/internal/scm/gitea/scm_reviews_test.go
@@ -143,6 +143,19 @@ func TestGiteaSCMFetchPendingReviews(t *testing.T) {
 		_, err := adapter.FetchPendingReviews(context.Background(), 6, testOwner, testRepo)
 		assertSCMErrorKind(t, err, domain.ErrSCMPayload)
 	})
+
+	t.Run("a malformed review submitted_at does not fail the read and normalizes to the zero time", func(t *testing.T) {
+		t.Parallel()
+
+		const reviewsFixture = `[{"id":201,"state":"REQUEST_CHANGES","body":"Fix this","user":{"login":"alice"},"dismissed":false,"submitted_at":"not-a-timestamp"}]`
+		const commentsFixture = `[{"id":3001,"path":"a.go","body":"nit","position":5,"original_position":5,"user":{"login":"alice"},"created_at":"2026-07-14T09:00:00Z"}]`
+		srv := httptest.NewServer(giteaReviewsAndCommentsHandler(t, []byte(reviewsFixture), []byte(commentsFixture)))
+		defer srv.Close()
+
+		adapter := mustSCMAdapter(t, srv.URL)
+		got, err := adapter.FetchPendingReviews(context.Background(), 6, testOwner, testRepo)
+		adaptertest.AssertReviewCommentTimestampTolerated(t, got, err)
+	})
 }
 
 // --- FetchBotReviewComments ---
@@ -326,4 +339,71 @@ func TestGiteaSCMGetReviewDecision(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestGiteaSCMGetReviewDecision_MalformedTimestamp pins the fold's strict
+// disposition: a decision-bearing review's malformed submitted_at fails
+// the read, while the same malformed value on a review the fold never
+// parses (dismissed, or a non-decision state) leaves the verdict
+// unaffected.
+func TestGiteaSCMGetReviewDecision_MalformedTimestamp(t *testing.T) {
+	t.Parallel()
+
+	t.Run("a decision-bearing review with a malformed submitted_at fails the read", func(t *testing.T) {
+		t.Parallel()
+
+		const reviewsFixture = `[{"id":601,"state":"APPROVED","body":"","user":{"login":"alice"},"dismissed":false,"submitted_at":"not-a-timestamp"}]`
+		prFixture := loadFixture(t, "pr_clean.json")
+		srv := httptest.NewServer(giteaReviewDecisionHandler(t, []byte(reviewsFixture), prFixture))
+		defer srv.Close()
+
+		adapter := mustSCMAdapter(t, srv.URL)
+		got, err := adapter.GetReviewDecision(context.Background(), 6, testOwner, testRepo)
+		adaptertest.AssertSCMErrorKind(t, err, domain.ErrSCMPayload)
+		if got != "" {
+			t.Errorf("GetReviewDecision() = %q, want empty on failure", got)
+		}
+	})
+
+	t.Run("a dismissed review with a malformed submitted_at does not block a live changes-requested verdict", func(t *testing.T) {
+		t.Parallel()
+
+		const reviewsFixture = `[
+			{"id":602,"state":"REQUEST_CHANGES","body":"","user":{"login":"alice"},"dismissed":false,"submitted_at":"2026-07-14T09:00:00Z"},
+			{"id":603,"state":"REQUEST_CHANGES","body":"","user":{"login":"bob"},"dismissed":true,"submitted_at":"not-a-timestamp"}
+		]`
+		prFixture := loadFixture(t, "pr_clean.json")
+		srv := httptest.NewServer(giteaReviewDecisionHandler(t, []byte(reviewsFixture), prFixture))
+		defer srv.Close()
+
+		adapter := mustSCMAdapter(t, srv.URL)
+		got, err := adapter.GetReviewDecision(context.Background(), 6, testOwner, testRepo)
+		if err != nil {
+			t.Fatalf("GetReviewDecision: unexpected error: %v", err)
+		}
+		if got != domain.ReviewDecisionChangesRequested {
+			t.Errorf("GetReviewDecision() = %q, want %q", got, domain.ReviewDecisionChangesRequested)
+		}
+	})
+
+	t.Run("a COMMENT review with a malformed submitted_at does not block a live approved verdict", func(t *testing.T) {
+		t.Parallel()
+
+		const reviewsFixture = `[
+			{"id":604,"state":"APPROVED","body":"","user":{"login":"alice"},"dismissed":false,"submitted_at":"2026-07-14T09:00:00Z"},
+			{"id":605,"state":"COMMENT","body":"","user":{"login":"bob"},"dismissed":false,"submitted_at":"not-a-timestamp"}
+		]`
+		prFixture := loadFixture(t, "pr_clean.json")
+		srv := httptest.NewServer(giteaReviewDecisionHandler(t, []byte(reviewsFixture), prFixture))
+		defer srv.Close()
+
+		adapter := mustSCMAdapter(t, srv.URL)
+		got, err := adapter.GetReviewDecision(context.Background(), 6, testOwner, testRepo)
+		if err != nil {
+			t.Fatalf("GetReviewDecision: unexpected error: %v", err)
+		}
+		if got != domain.ReviewDecisionApproved {
+			t.Errorf("GetReviewDecision() = %q, want %q", got, domain.ReviewDecisionApproved)
+		}
+	})
 }

--- a/internal/scm/github/label_events.go
+++ b/internal/scm/github/label_events.go
@@ -9,7 +9,6 @@ import (
 	"net/url"
 	"slices"
 	"strings"
-	"time"
 
 	"github.com/sortie-ai/sortie/internal/domain"
 	"github.com/sortie-ai/sortie/internal/httpkit"
@@ -110,10 +109,12 @@ func (a *GitHubSCMAdapter) ListLabelEvents(ctx context.Context, prNumber int, ow
 
 // decodeLabelEvents parses one page of issue events, retaining only
 // labeled and unlabeled entries and normalizing each to a
-// [domain.LabelEvent] with a lowercased label name and a UTC timestamp.
-// Returns a non-nil empty slice when the page carries no label events and
-// a [*domain.SCMError] with Kind [domain.ErrSCMPayload] on a malformed
-// payload.
+// [domain.LabelEvent] with a lowercased label name and a UTC timestamp via
+// [scmcore.ParseTimestamp]. Returns a non-nil empty slice when the page
+// carries no label events. A retained entry whose created_at does not
+// parse as RFC 3339 fails the read with a [*domain.SCMError] of Kind
+// [domain.ErrSCMPayload]; a skipped entry is never parsed and cannot fail
+// the read. Returns the same kind on a malformed payload.
 func decodeLabelEvents(body []byte) ([]domain.LabelEvent, error) {
 	var raw []githubIssueEvent
 	if err := json.Unmarshal(body, &raw); err != nil {
@@ -140,13 +141,9 @@ func decodeLabelEvents(body []byte) ([]domain.LabelEvent, error) {
 			actor = e.Actor.Login
 		}
 
-		at, parseErr := time.Parse(time.RFC3339, e.CreatedAt)
-		if parseErr != nil {
-			return nil, &domain.SCMError{
-				Kind:    domain.ErrSCMPayload,
-				Message: "failed to parse issue event created_at",
-				Err:     parseErr,
-			}
+		at, err := scmcore.ParseTimestamp("issue event created_at", e.CreatedAt)
+		if err != nil {
+			return nil, err
 		}
 
 		events = append(events, domain.LabelEvent{
@@ -157,7 +154,7 @@ func decodeLabelEvents(body []byte) ([]domain.LabelEvent, error) {
 			Label: strings.ToLower(e.Label.Name),
 			Actor: actor,
 			Added: e.Event == "labeled",
-			At:    at.UTC(),
+			At:    at,
 		})
 	}
 	return events, nil

--- a/internal/scm/github/label_events_test.go
+++ b/internal/scm/github/label_events_test.go
@@ -2,6 +2,7 @@ package github
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -281,6 +282,40 @@ func TestListLabelEvents_MalformedTimestampIsPayloadError(t *testing.T) {
 	defer srv.Close()
 
 	adapter := newTestSCMAdapter(t, srv.URL)
-	_, err := adapter.ListLabelEvents(context.Background(), 1, "o", "r")
-	assertSCMErrorKind(t, err, domain.ErrSCMPayload)
+	events, err := adapter.ListLabelEvents(context.Background(), 1, "o", "r")
+	adaptertest.AssertLabelEventTimestampRejected(t, events, err)
+
+	var scmErr *domain.SCMError
+	if !errors.As(err, &scmErr) {
+		t.Fatalf("ListLabelEvents() error = %v, want *domain.SCMError", err)
+	}
+	const wantMessage = "failed to parse issue event created_at"
+	if scmErr.Message != wantMessage {
+		t.Errorf("ListLabelEvents() error Message = %q, want %q", scmErr.Message, wantMessage)
+	}
+}
+
+func TestListLabelEvents_MalformedTimestampOnSkippedEventDoesNotFail(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[
+			{"id":2,"event":"commented","actor":{"login":"bob"},"label":null,"created_at":"not-a-timestamp"},
+			{"id":1,"event":"labeled","actor":{"login":"alice"},"label":{"name":"sortie:review"},"created_at":"2026-01-01T00:00:00Z"}
+		]`))
+	}))
+	defer srv.Close()
+
+	adapter := newTestSCMAdapter(t, srv.URL)
+	events, err := adapter.ListLabelEvents(context.Background(), 1, "o", "r")
+	if err != nil {
+		t.Fatalf("ListLabelEvents: unexpected error: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("ListLabelEvents() len = %d, want 1 (the malformed commented event is skipped before its timestamp is parsed)", len(events))
+	}
+	if events[0].Label != "sortie:review" {
+		t.Errorf("events[0].Label = %q, want %q", events[0].Label, "sortie:review")
+	}
 }

--- a/internal/scm/github/review.go
+++ b/internal/scm/github/review.go
@@ -9,7 +9,6 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/sortie-ai/sortie/internal/domain"
 	"github.com/sortie-ai/sortie/internal/httpkit"
@@ -95,6 +94,10 @@ func NewGitHubSCMAdapter(adapterConfig map[string]any) (domain.SCMAdapter, error
 // CHANGES_REQUESTED reviews on the given PR. Outdated comments (where
 // GitHub reports position as null) have Outdated=true. Returns an empty
 // non-nil slice when no matching reviews exist.
+//
+// SubmittedAt is parsed via [scmcore.ParseTimestampOrZero]: a review or
+// comment timestamp that is not RFC 3339 normalizes to the zero time
+// rather than failing the read, since SubmittedAt drives debounce only.
 func (a *GitHubSCMAdapter) FetchPendingReviews(ctx context.Context, prNumber int, owner, repo string) ([]domain.ReviewComment, error) {
 	reviews, err := a.fetchAllReviews(ctx, prNumber, owner, repo)
 	if err != nil {
@@ -118,7 +121,7 @@ func (a *GitHubSCMAdapter) FetchPendingReviews(ctx context.Context, prNumber int
 			prCommentID := fmt.Sprintf("review-%d", review.ID)
 			if _, dup := seen[prCommentID]; !dup {
 				seen[prCommentID] = struct{}{}
-				submittedAt, _ := time.Parse(time.RFC3339, review.SubmittedAt)
+				submittedAt := scmcore.ParseTimestampOrZero(review.SubmittedAt)
 				result = append(result, domain.ReviewComment{
 					ID:          prCommentID,
 					Reviewer:    review.User.Login,
@@ -157,7 +160,7 @@ func (a *GitHubSCMAdapter) FetchPendingReviews(ctx context.Context, prNumber int
 				endLine = *c.Line
 			}
 
-			createdAt, _ := time.Parse(time.RFC3339, c.CreatedAt)
+			createdAt := scmcore.ParseTimestampOrZero(c.CreatedAt)
 
 			result = append(result, domain.ReviewComment{
 				ID:          commentID,
@@ -188,6 +191,10 @@ func (a *GitHubSCMAdapter) FetchPendingReviews(ctx context.Context, prNumber int
 // Unlike [GitHubSCMAdapter.FetchPendingReviews], no review-state filter is
 // applied: review bots commonly post COMMENTED reviews, so requiring
 // CHANGES_REQUESTED would drop most bot findings.
+//
+// SubmittedAt is parsed via [scmcore.ParseTimestampOrZero]: a review or
+// comment timestamp that is not RFC 3339 normalizes to the zero time
+// rather than failing the read, since SubmittedAt drives debounce only.
 func (a *GitHubSCMAdapter) FetchBotReviewComments(ctx context.Context, prNumber int, owner, repo string, botUsernames []string) ([]domain.ReviewComment, error) {
 	reviews, err := a.fetchAllReviews(ctx, prNumber, owner, repo)
 	if err != nil {
@@ -208,7 +215,7 @@ func (a *GitHubSCMAdapter) FetchBotReviewComments(ctx context.Context, prNumber 
 			prCommentID := fmt.Sprintf("review-%d", review.ID)
 			if _, dup := seen[prCommentID]; !dup {
 				seen[prCommentID] = struct{}{}
-				submittedAt, _ := time.Parse(time.RFC3339, review.SubmittedAt)
+				submittedAt := scmcore.ParseTimestampOrZero(review.SubmittedAt)
 				result = append(result, domain.ReviewComment{
 					ID:          prCommentID,
 					Reviewer:    review.User.Login,
@@ -247,7 +254,7 @@ func (a *GitHubSCMAdapter) FetchBotReviewComments(ctx context.Context, prNumber 
 				endLine = *c.Line
 			}
 
-			createdAt, _ := time.Parse(time.RFC3339, c.CreatedAt)
+			createdAt := scmcore.ParseTimestampOrZero(c.CreatedAt)
 
 			result = append(result, domain.ReviewComment{
 				ID:          commentID,

--- a/internal/scm/github/review_test.go
+++ b/internal/scm/github/review_test.go
@@ -771,6 +771,84 @@ func TestFetchBotReviewComments_CommentsFetchError(t *testing.T) {
 	assertSCMErrorKind(t, err, domain.ErrSCMPayload)
 }
 
+// TestFetchPendingReviews_MalformedReviewBodyTimestampTolerated verifies
+// that a CHANGES_REQUESTED review body whose submitted_at is not RFC 3339
+// does not fail the read: the comment is returned with a zero SubmittedAt
+// while a sibling review's well-formed timestamp survives.
+func TestFetchPendingReviews_MalformedReviewBodyTimestampTolerated(t *testing.T) {
+	t.Parallel()
+
+	const reviewsFixture = `[
+		{"id":10,"state":"CHANGES_REQUESTED","body":"Fix A","user":{"login":"alice","type":"User"},"submitted_at":"not-a-timestamp"},
+		{"id":11,"state":"CHANGES_REQUESTED","body":"Fix B","user":{"login":"bob","type":"User"},"submitted_at":"2026-04-01T10:00:00Z"}
+	]`
+	srv := httptest.NewServer(reviewsAndCommentsHandler(t, []byte(reviewsFixture), loadFixture(t, "comments_empty.json")))
+	defer srv.Close()
+
+	adapter := newTestSCMAdapter(t, srv.URL)
+	got, err := adapter.FetchPendingReviews(context.Background(), 1, "owner", "repo")
+	adaptertest.AssertReviewCommentTimestampTolerated(t, got, err)
+}
+
+// TestFetchPendingReviews_MalformedInlineCommentTimestampTolerated verifies
+// that an inline comment's created_at that is not RFC 3339 does not fail
+// the read: the comment is returned with a zero SubmittedAt while a
+// sibling comment's well-formed timestamp survives.
+func TestFetchPendingReviews_MalformedInlineCommentTimestampTolerated(t *testing.T) {
+	t.Parallel()
+
+	reviewsFixture := loadFixture(t, "reviews_changes_requested_no_body.json")
+	const commentsFixture = `[
+		{"id":100,"path":"internal/handler.go","start_line":10,"line":12,"position":5,"body":"A","user":{"login":"alice","type":"User"},"created_at":"not-a-timestamp"},
+		{"id":101,"path":"internal/handler.go","start_line":20,"line":22,"position":6,"body":"B","user":{"login":"alice","type":"User"},"created_at":"2026-04-01T10:05:00Z"}
+	]`
+	srv := httptest.NewServer(reviewsAndCommentsHandler(t, reviewsFixture, []byte(commentsFixture)))
+	defer srv.Close()
+
+	adapter := newTestSCMAdapter(t, srv.URL)
+	got, err := adapter.FetchPendingReviews(context.Background(), 1, "owner", "repo")
+	adaptertest.AssertReviewCommentTimestampTolerated(t, got, err)
+}
+
+// TestFetchBotReviewComments_MalformedReviewBodyTimestampTolerated verifies
+// that a bot review body whose submitted_at is not RFC 3339 does not fail
+// the read: the comment is returned with a zero SubmittedAt while a
+// sibling bot review's well-formed timestamp survives.
+func TestFetchBotReviewComments_MalformedReviewBodyTimestampTolerated(t *testing.T) {
+	t.Parallel()
+
+	const reviewsFixture = `[
+		{"id":30,"state":"CHANGES_REQUESTED","body":"Feedback A","user":{"login":"github-actions[bot]","type":"Bot"},"submitted_at":"not-a-timestamp"},
+		{"id":31,"state":"COMMENTED","body":"Feedback B","user":{"login":"github-actions[bot]","type":"Bot"},"submitted_at":"2026-04-01T10:00:00Z"}
+	]`
+	srv := httptest.NewServer(reviewsAndCommentsHandler(t, []byte(reviewsFixture), loadFixture(t, "comments_empty.json")))
+	defer srv.Close()
+
+	adapter := newTestSCMAdapter(t, srv.URL)
+	got, err := adapter.FetchBotReviewComments(context.Background(), 1, "owner", "repo", nil)
+	adaptertest.AssertReviewCommentTimestampTolerated(t, got, err)
+}
+
+// TestFetchBotReviewComments_MalformedInlineCommentTimestampTolerated
+// verifies that a bot inline comment's created_at that is not RFC 3339
+// does not fail the read: the comment is returned with a zero SubmittedAt
+// while a sibling bot inline comment's well-formed timestamp survives.
+func TestFetchBotReviewComments_MalformedInlineCommentTimestampTolerated(t *testing.T) {
+	t.Parallel()
+
+	reviewsFixture := loadFixture(t, "reviews_bot_commented.json")
+	const commentsFixture = `[
+		{"id":501,"path":"internal/handler.go","start_line":20,"line":22,"position":3,"body":"A","user":{"login":"golangci-lint[bot]","type":"Bot"},"created_at":"not-a-timestamp"},
+		{"id":502,"path":"internal/handler.go","start_line":30,"line":32,"position":4,"body":"B","user":{"login":"golangci-lint[bot]","type":"Bot"},"created_at":"2026-04-01T10:10:00Z"}
+	]`
+	srv := httptest.NewServer(reviewsAndCommentsHandler(t, reviewsFixture, []byte(commentsFixture)))
+	defer srv.Close()
+
+	adapter := newTestSCMAdapter(t, srv.URL)
+	got, err := adapter.FetchBotReviewComments(context.Background(), 1, "owner", "repo", nil)
+	adaptertest.AssertReviewCommentTimestampTolerated(t, got, err)
+}
+
 // TestFetchBotReviewComments_SkipsNonBotInlineComment verifies that an inline
 // comment authored by a non-bot, non-allowlisted user is excluded from the
 // results while bot-authored inline comments are kept.

--- a/internal/scm/gitlab/scm.go
+++ b/internal/scm/gitlab/scm.go
@@ -8,7 +8,6 @@ import (
 	"net/url"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/sortie-ai/sortie/internal/domain"
 	"github.com/sortie-ai/sortie/internal/httpkit"
@@ -91,18 +90,6 @@ func NewGitLabSCMAdapter(adapterConfig map[string]any) (domain.SCMAdapter, error
 // or encoded separately.
 func projectPath(owner, repo string) string {
 	return url.PathEscape(owner + "/" + repo)
-}
-
-// parseUTC parses an RFC 3339 timestamp and returns it in UTC.
-//
-// A malformed timestamp yields the zero [time.Time] rather than an
-// error, so a single unparseable field never fails an entire read.
-func parseUTC(s string) time.Time {
-	t, err := time.Parse(time.RFC3339, s)
-	if err != nil {
-		return time.Time{}
-	}
-	return t.UTC()
 }
 
 // asSCMError normalizes err to a [*domain.SCMError]. An error that

--- a/internal/scm/gitlab/scm_label_events.go
+++ b/internal/scm/gitlab/scm_label_events.go
@@ -38,8 +38,11 @@ type gitlabResourceLabelEvent struct {
 //
 // An entry whose label is null or unnamed describes a label later
 // deleted from the project and is skipped, since it carries no name to
-// normalize. Added is true only for action "add". The returned slice is
-// non-nil even when empty; a failure returns a [*domain.SCMError].
+// normalize; a skipped entry is never parsed and cannot fail the read.
+// Added is true only for action "add". The returned slice is non-nil
+// even when empty. A retained entry whose created_at does not parse as
+// RFC 3339 fails the read with a [*domain.SCMError] of Kind
+// [domain.ErrSCMPayload].
 func (a *GitLabSCMAdapter) ListLabelEvents(ctx context.Context, prNumber int, owner, repo string) ([]domain.LabelEvent, error) {
 	path := "/projects/" + projectPath(owner, repo) + "/merge_requests/" + strconv.Itoa(prNumber) + "/resource_label_events"
 
@@ -63,12 +66,18 @@ func (a *GitLabSCMAdapter) ListLabelEvents(ctx context.Context, prNumber int, ow
 		if e.Label == nil || e.Label.Name == "" {
 			continue
 		}
+
+		at, err := scmcore.ParseTimestamp("label event created_at", e.CreatedAt)
+		if err != nil {
+			return nil, err
+		}
+
 		events = append(events, domain.LabelEvent{
 			ID:    scmcore.SortableEventID(e.ID),
 			Label: strings.ToLower(e.Label.Name),
 			Actor: e.User.Username,
 			Added: e.Action == "add",
-			At:    parseUTC(e.CreatedAt),
+			At:    at,
 		})
 	}
 

--- a/internal/scm/gitlab/scm_label_events_test.go
+++ b/internal/scm/gitlab/scm_label_events_test.go
@@ -135,6 +135,41 @@ func TestListLabelEvents_ErrorStatuses(t *testing.T) {
 		_, err := adapter.ListLabelEvents(context.Background(), testPRNumber, scmOwner, scmRepo)
 		adaptertest.AssertSCMErrorKind(t, err, domain.ErrSCMPayload)
 	})
+
+	t.Run("a retained label event with a malformed created_at fails the read", func(t *testing.T) {
+		t.Parallel()
+
+		const fixture = `[{"id":701,"user":{"id":501,"username":"alice"},"created_at":"not-a-timestamp","action":"add","label":{"name":"bug"}}]`
+		srv := serveJSON(t, []byte(fixture))
+		defer srv.Close()
+
+		adapter := mustSCMAdapter(t, srv.URL)
+		got, err := adapter.ListLabelEvents(context.Background(), testPRNumber, scmOwner, scmRepo)
+		adaptertest.AssertLabelEventTimestampRejected(t, got, err)
+	})
+
+	t.Run("a malformed created_at on a null-label entry does not fail the read", func(t *testing.T) {
+		t.Parallel()
+
+		const fixture = `[
+			{"id":702,"user":{"id":501,"username":"alice"},"created_at":"not-a-timestamp","action":"add","label":null},
+			{"id":703,"user":{"id":501,"username":"alice"},"created_at":"2026-08-10T08:00:00Z","action":"add","label":{"name":"bug"}}
+		]`
+		srv := serveJSON(t, []byte(fixture))
+		defer srv.Close()
+
+		adapter := mustSCMAdapter(t, srv.URL)
+		got, err := adapter.ListLabelEvents(context.Background(), testPRNumber, scmOwner, scmRepo)
+		if err != nil {
+			t.Fatalf("ListLabelEvents: unexpected error: %v", err)
+		}
+		if len(got) != 1 {
+			t.Fatalf("ListLabelEvents() len = %d, want 1 (the null-label entry is skipped before its timestamp is parsed)", len(got))
+		}
+		if got[0].Label != "bug" {
+			t.Errorf("events[0].Label = %q, want %q", got[0].Label, "bug")
+		}
+	})
 }
 
 // --- RemoveLabel (AC7) ---

--- a/internal/scm/gitlab/scm_reviews.go
+++ b/internal/scm/gitlab/scm_reviews.go
@@ -155,7 +155,7 @@ func (a *GitLabSCMAdapter) normalizeNotes(ctx context.Context, prNumber int, own
 			ID:          strconv.FormatInt(n.ID, 10),
 			Reviewer:    n.Author.Username,
 			Body:        n.Body,
-			SubmittedAt: parseUTC(n.CreatedAt),
+			SubmittedAt: scmcore.ParseTimestampOrZero(n.CreatedAt),
 		}
 
 		if n.Position != nil {

--- a/internal/scm/gitlab/scm_reviews_test.go
+++ b/internal/scm/gitlab/scm_reviews_test.go
@@ -558,6 +558,28 @@ func TestNormalizeNotes_OutdatedDerivationAndConditionalRead(t *testing.T) {
 	})
 }
 
+// TestNormalizeNotes_MalformedTimestampTolerated verifies that a note's
+// created_at that is not RFC 3339 does not fail the read: the comment is
+// returned with a zero SubmittedAt while a sibling note's well-formed
+// timestamp survives.
+func TestNormalizeNotes_MalformedTimestampTolerated(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(loadFixture(t, "mr_basic.json"))
+	}))
+	defer srv.Close()
+
+	adapter := mustSCMAdapter(t, srv.URL)
+	notes := []gitlabNote{
+		{ID: 7, Author: gitlabUser{Username: "alice"}, Body: "malformed", CreatedAt: "not-a-timestamp"},
+		{ID: 8, Author: gitlabUser{Username: "alice"}, Body: "well formed", CreatedAt: "2026-08-10T08:00:00Z"},
+	}
+	got, err := adapter.normalizeNotes(context.Background(), testPRNumber, scmOwner, scmRepo, notes)
+	adaptertest.AssertReviewCommentTimestampTolerated(t, got, err)
+}
+
 // --- GetReviewDecision ---
 
 func TestGetReviewDecision_ArmOrder(t *testing.T) {

--- a/internal/scm/gitlab/scm_test.go
+++ b/internal/scm/gitlab/scm_test.go
@@ -14,7 +14,6 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
-	"time"
 
 	"github.com/sortie-ai/sortie/internal/adaptertest"
 	"github.com/sortie-ai/sortie/internal/domain"
@@ -356,66 +355,6 @@ func TestProjectPath(t *testing.T) {
 			t.Errorf("projectPath(%q, %q) = %q, want %q", "acme/team/squad", "widgets", got, want)
 		}
 	})
-}
-
-// TestParseUTC pins the timestamp shapes GitLab actually emits. Self-hosted
-// instances render a fractional second and a numeric zone offset, and the
-// fractional part must survive the conversion to UTC rather than truncate or
-// fail the parse: a dropped timestamp would collapse to the zero time, which
-// orders every event identically instead of erroring.
-func TestParseUTC(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name  string
-		input string
-		want  time.Time
-	}{
-		{
-			name:  "fractional second with positive zone offset",
-			input: "2026-08-11T01:53:22.509+02:00",
-			want:  time.Date(2026, time.August, 10, 23, 53, 22, 509000000, time.UTC),
-		},
-		{
-			name:  "fractional second on a note timestamp",
-			input: "2026-08-10T15:45:19.454+02:00",
-			want:  time.Date(2026, time.August, 10, 13, 45, 19, 454000000, time.UTC),
-		},
-		{
-			name:  "fractional second in zulu form",
-			input: "2026-01-10T09:00:00.000Z",
-			want:  time.Date(2026, time.January, 10, 9, 0, 0, 0, time.UTC),
-		},
-		{
-			name:  "whole second in zulu form",
-			input: "2026-08-10T08:00:00Z",
-			want:  time.Date(2026, time.August, 10, 8, 0, 0, 0, time.UTC),
-		},
-		{
-			name:  "malformed timestamp yields the zero time",
-			input: "not-a-timestamp",
-			want:  time.Time{},
-		},
-		{
-			name:  "empty timestamp yields the zero time",
-			input: "",
-			want:  time.Time{},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			got := parseUTC(tt.input)
-			if !got.Equal(tt.want) {
-				t.Errorf("parseUTC(%q) = %v, want %v", tt.input, got, tt.want)
-			}
-			if got.Location() != time.UTC {
-				t.Errorf("parseUTC(%q): location = %v, want UTC", tt.input, got.Location())
-			}
-		})
-	}
 }
 
 // --- paginateSCM ---

--- a/internal/scm/scmcore/timestamp.go
+++ b/internal/scm/scmcore/timestamp.go
@@ -1,0 +1,43 @@
+package scmcore
+
+import (
+	"time"
+
+	"github.com/sortie-ai/sortie/internal/domain"
+)
+
+// ParseTimestamp parses value as an RFC 3339 timestamp and returns it in
+// UTC. field names the wire field for the error message, for example
+// "issue event created_at"; it is the only forge-specific vocabulary
+// that crosses into this package.
+//
+// On success ParseTimestamp returns a nil error interface, never a typed
+// nil [*domain.SCMError], so a caller comparing the result against nil
+// never takes the failure branch on a well-formed timestamp. On failure,
+// including an empty value, it returns the zero [time.Time] and a
+// [*domain.SCMError] of Kind [domain.ErrSCMPayload] whose Err wraps the
+// underlying parse error. ParseTimestamp accepts no layout other than
+// [time.RFC3339], has no side effects, and is safe for concurrent use.
+func ParseTimestamp(field, value string) (time.Time, error) {
+	t, err := time.Parse(time.RFC3339, value)
+	if err != nil {
+		return time.Time{}, &domain.SCMError{
+			Kind:    domain.ErrSCMPayload,
+			Message: "failed to parse " + field,
+			Err:     err,
+		}
+	}
+	return t.UTC(), nil
+}
+
+// ParseTimestampOrZero parses value as an RFC 3339 timestamp and returns
+// it in UTC, returning the zero [time.Time] when value is empty or is
+// not RFC 3339 rather than failing. ParseTimestampOrZero has no side
+// effects and is safe for concurrent use.
+func ParseTimestampOrZero(value string) time.Time {
+	t, err := time.Parse(time.RFC3339, value)
+	if err != nil {
+		return time.Time{}
+	}
+	return t.UTC()
+}

--- a/internal/scm/scmcore/timestamp_test.go
+++ b/internal/scm/scmcore/timestamp_test.go
@@ -1,0 +1,118 @@
+package scmcore
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/sortie-ai/sortie/internal/domain"
+)
+
+func TestParseTimestampOrZero(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input string
+		want  time.Time
+	}{
+		{
+			name:  "fractional second with positive zone offset",
+			input: "2026-08-11T01:53:22.509+02:00",
+			want:  time.Date(2026, time.August, 10, 23, 53, 22, 509000000, time.UTC),
+		},
+		{
+			name:  "fractional second in zulu form",
+			input: "2026-01-10T09:00:00.000Z",
+			want:  time.Date(2026, time.January, 10, 9, 0, 0, 0, time.UTC),
+		},
+		{
+			name:  "whole second in zulu form",
+			input: "2026-08-10T08:00:00Z",
+			want:  time.Date(2026, time.August, 10, 8, 0, 0, 0, time.UTC),
+		},
+		{
+			name:  "malformed timestamp yields the zero time",
+			input: "not-a-timestamp",
+			want:  time.Time{},
+		},
+		{
+			name:  "empty timestamp yields the zero time",
+			input: "",
+			want:  time.Time{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := ParseTimestampOrZero(tt.input)
+			if !got.Equal(tt.want) {
+				t.Errorf("ParseTimestampOrZero(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+			if got.Location() != time.UTC {
+				t.Errorf("ParseTimestampOrZero(%q): location = %v, want UTC", tt.input, got.Location())
+			}
+		})
+	}
+}
+
+func TestParseTimestamp(t *testing.T) {
+	t.Parallel()
+
+	t.Run("a valid value returns the UTC instant with a nil error interface", func(t *testing.T) {
+		t.Parallel()
+
+		got, err := ParseTimestamp("test field", "2026-08-10T08:00:00Z")
+		if err != nil {
+			t.Fatalf("ParseTimestamp() err = %v, want nil (a typed-nil return would fail this comparison)", err)
+		}
+
+		want := time.Date(2026, time.August, 10, 8, 0, 0, 0, time.UTC)
+		if !got.Equal(want) {
+			t.Errorf("ParseTimestamp() = %v, want %v", got, want)
+		}
+		if got.Location() != time.UTC {
+			t.Errorf("ParseTimestamp(): location = %v, want UTC", got.Location())
+		}
+	})
+
+	t.Run("a malformed value returns a payload error naming the field", func(t *testing.T) {
+		t.Parallel()
+
+		got, err := ParseTimestamp("review submitted_at", "not-a-timestamp")
+		if !got.IsZero() {
+			t.Errorf("ParseTimestamp() = %v, want the zero time on failure", got)
+		}
+
+		var scmErr *domain.SCMError
+		if !errors.As(err, &scmErr) {
+			t.Fatalf("ParseTimestamp() error = %v, want *domain.SCMError", err)
+		}
+		if scmErr.Kind != domain.ErrSCMPayload {
+			t.Errorf("ParseTimestamp() error Kind = %q, want %q", scmErr.Kind, domain.ErrSCMPayload)
+		}
+		wantMessage := "failed to parse review submitted_at"
+		if scmErr.Message != wantMessage {
+			t.Errorf("ParseTimestamp() error Message = %q, want %q", scmErr.Message, wantMessage)
+		}
+		if scmErr.Err == nil {
+			t.Error("ParseTimestamp() error Err = nil, want the wrapped *time.ParseError")
+		}
+	})
+
+	t.Run("an empty value returns a payload error", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := ParseTimestamp("issue event created_at", "")
+
+		var scmErr *domain.SCMError
+		if !errors.As(err, &scmErr) {
+			t.Fatalf("ParseTimestamp() error = %v, want *domain.SCMError", err)
+		}
+		if scmErr.Kind != domain.ErrSCMPayload {
+			t.Errorf("ParseTimestamp() error Kind = %q, want %q", scmErr.Kind, domain.ErrSCMPayload)
+		}
+	})
+}


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Fix

**Intent:** The three SCM adapters disagreed on what a malformed `created_at`/`submitted_at` timestamp means. Gitea and GitLab each declared a byte-identical `parseUTC` that silently discarded the parse error and returned the zero time; GitHub had no shared helper and applied two different ad hoc policies of its own. Because `domain.LabelEvent.At` is half of the `(At, ID)` high-water mark that drives the label-command journal's at-most-once guarantee, a zero `At` sorts before every recorded mark - so a malformed label-event timestamp silently skipped the label command on Gitea and GitLab, while the identical input failed the read loudly on GitHub. This replaces every local parse with two shared `scmcore` helpers and applies one documented policy per call site across all three adapters: fail the read on a malformed label-event timestamp (ordering-critical), tolerate it on a review-comment timestamp (feeds debounce only).

**Related Issues:** #798

### 🧭 Reviewer Guide

**Complexity:** Medium

#### Entry Point

Start with `internal/scm/scmcore/timestamp.go`, the new shared helper package. `ParseTimestamp` fails with a `domain.ErrSCMPayload` `SCMError` on a malformed or empty RFC 3339 value; `ParseTimestampOrZero` tolerates it and returns the zero time. Every other change in this PR is a call site switching to one of these two functions in place of a local, duplicated, or ad hoc parse.

#### Sensitive Areas

- `internal/scm/gitea/scm_reviews.go`: `foldReviewDecision` now parses each contributing review's `submitted_at` before the sort that depends on it and returns an error instead of a bare `domain.ReviewDecision`, since a malformed timestamp on a review that can change the verdict must fail the read rather than sort unpredictably. Only reviews that could change the decision (not dismissed, state `APPROVED` or `REQUEST_CHANGES`) are parsed, so a malformed timestamp on a review that cannot affect the outcome never fails the read.
- `internal/scm/*/scm_label_events.go` (gitea, github, gitlab): the label-event read now fails the whole page on the first retained entry with an unparseable timestamp, since `At` drives journal ordering and ergo the at-most-once dispatch guarantee.
- `internal/adaptertest/scm.go` and `contract_test.go`: shared conformance assertions extended so all three adapters are held to the identical policy rather than three separately trusted ones.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes. `foldReviewDecision` is unexported and internal to the Gitea adapter package; the public `SCMAdapter` interface is unchanged aside from doc comments codifying the existing `ListLabelEvents` contract.
- **Migrations/State:** No migrations or state changes.
