### PR TITLE
feat(validate): check review and merge-conflict reactions

### DIFF
--- a/cmd/sortie/validate_test.go
+++ b/cmd/sortie/validate_test.go
@@ -2334,11 +2334,13 @@ func diagWithCheck(diags []validateDiag, want string) *validateDiag {
 	return nil
 }
 
-// forgeCheckKeys lists every check key this feature can emit: the two
-// reaction-config diagnostics plus the three activation diagnostics.
+// forgeCheckKeys lists every check key this feature can emit: the reaction-
+// config diagnostics plus the three activation diagnostics.
 var forgeCheckKeys = []string{
+	"reactions.review_comments",
 	"reactions.bot_review",
 	"reactions.auto_merge",
+	"reactions.merge_conflicts",
 	"scm_adapter",
 	"ci_provider",
 	"reactions.scm_provider_conflict",
@@ -2540,6 +2542,123 @@ func TestValidateMergeCompletionNonTerminalTargetState(t *testing.T) {
 		t.Errorf("validateOutput.Errors = %v, want a diagnostic with check %q", out.Errors, "reactions.merge_completion")
 	} else if d.Severity != "error" {
 		t.Errorf("reactions.merge_completion diagnostic severity = %q, want %q", d.Severity, "error")
+	}
+}
+
+// TestValidateReviewAndMergeConflictReactionConfigs verifies that validate
+// runs every kind-specific numeric rule for review_comments and
+// merge_conflicts without constructing an adapter or making a network call.
+func TestValidateReviewAndMergeConflictReactionConfigs(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		extraYAML    string
+		wantCheck    string
+		wantField    string
+		wantExitCode int
+	}{
+		{
+			name: "review_comments poll_interval_ms below minimum",
+			extraYAML: `reactions:
+  review_comments:
+    provider: gitea
+    poll_interval_ms: 1000
+`,
+			wantCheck:    "reactions.review_comments",
+			wantField:    "poll_interval_ms",
+			wantExitCode: 1,
+		},
+		{
+			name: "review_comments debounce_ms negative",
+			extraYAML: `reactions:
+  review_comments:
+    provider: gitea
+    debounce_ms: -1
+`,
+			wantCheck:    "reactions.review_comments",
+			wantField:    "debounce_ms",
+			wantExitCode: 1,
+		},
+		{
+			name: "review_comments max_continuation_turns zero",
+			extraYAML: `reactions:
+  review_comments:
+    provider: gitea
+    max_continuation_turns: 0
+`,
+			wantCheck:    "reactions.review_comments",
+			wantField:    "max_continuation_turns",
+			wantExitCode: 1,
+		},
+		{
+			name: "merge_conflicts poll_interval_ms below minimum",
+			extraYAML: `reactions:
+  merge_conflicts:
+    provider: gitea
+    poll_interval_ms: 1000
+`,
+			wantCheck:    "reactions.merge_conflicts",
+			wantField:    "poll_interval_ms",
+			wantExitCode: 1,
+		},
+		{
+			name: "valid numeric settings",
+			extraYAML: `reactions:
+  review_comments:
+    provider: gitea
+    poll_interval_ms: 30000
+    debounce_ms: 0
+    max_continuation_turns: 1
+  merge_conflicts:
+    provider: gitea
+    poll_interval_ms: 30000
+`,
+			wantExitCode: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			dir := t.TempDir()
+			wfPath := writeCustomWorkflowFile(t, dir, forgeFaultWorkflow(tt.extraYAML))
+
+			var stdout, stderr bytes.Buffer
+			code := run(context.Background(), []string{"validate", "--format", "json", wfPath}, &stdout, &stderr)
+			if code != tt.wantExitCode {
+				t.Fatalf("run(validate --format json) = %d, want %d; stderr: %s", code, tt.wantExitCode, stderr.String())
+			}
+
+			var out validateOutput
+			if err := json.Unmarshal(stdout.Bytes(), &out); err != nil {
+				t.Fatalf("json.Unmarshal(%q) error: %v", stdout.String(), err)
+			}
+
+			if tt.wantCheck == "" {
+				if !out.Valid {
+					t.Errorf("validateOutput.Valid = false, want true; errors: %v", out.Errors)
+				}
+				for _, check := range []string{"reactions.review_comments", "reactions.merge_conflicts"} {
+					if d := diagWithCheck(out.Errors, check); d != nil {
+						t.Errorf("validateOutput.Errors contains %q = %v, want none", check, d)
+					}
+				}
+				return
+			}
+
+			if out.Valid {
+				t.Errorf("validateOutput.Valid = true, want false")
+			}
+			d := diagWithCheck(out.Errors, tt.wantCheck)
+			if d == nil {
+				t.Fatalf("validateOutput.Errors = %v, want a diagnostic with check %q", out.Errors, tt.wantCheck)
+			}
+			if !strings.Contains(d.Message, tt.wantField) {
+				t.Errorf("diagnostic message = %q, want field %q", d.Message, tt.wantField)
+			}
+		})
 	}
 }
 

--- a/docs/workflow-reference.md
+++ b/docs/workflow-reference.md
@@ -1438,11 +1438,10 @@ reactions:
 
 **Where each rule is enforced:** the rules that the config layer owns (reaction key shape,
 `max_retries`, `escalation`, `escalation_label`, and every `label_commands` rule) run during
-typed config construction, so `sortie validate` reports them offline. Of the kind-specific
-rules, `sortie validate` additionally runs the `auto_merge`, `bot_review`, and
-`merge_completion` builders, so their rules are also reported offline. The `review_comments`
-and `merge_conflicts` kind-specific rules are checked only when the orchestrator constructs
-the reaction, so an invalid value there passes `sortie validate` and fails at startup.
+typed config construction, so `sortie validate` reports them offline. For the kind-specific
+rules, `sortie validate` runs the `review_comments`, `auto_merge`, `bot_review`,
+`merge_conflicts`, and `merge_completion` builders. These are the same builders used when the
+orchestrator constructs the reactions at startup, so both paths report the same invalid values.
 
 ---
 

--- a/internal/orchestrator/reaction_validate.go
+++ b/internal/orchestrator/reaction_validate.go
@@ -10,14 +10,22 @@ import (
 // each active reaction whose configuration would fail. It constructs no
 // adapter and makes no network call.
 //
-// Only the bot_review, auto_merge, and merge_completion reactions are
-// inspected: the review-bot allowlist, the merge strategy, and the
-// tracker-terminal-state target. Each is validated with the same builder
+// The builder-validated reaction kinds are inspected with the same builders
 // the orchestrator runs at construction, so the offline verdict cannot
 // diverge from the construction verdict. trackerMeta MUST come from the
 // tracker registry's Meta(cfg.Tracker.Kind) lookup.
 func ValidateReactionConfigs(cfg config.ServiceConfig, trackerMeta registry.TrackerMeta) []registry.ValidationDiag {
 	var diags []registry.ValidationDiag
+
+	if rc, ok := cfg.Reactions["review_comments"]; ok && rc.Provider != "" {
+		if _, err := BuildReviewReactionConfig(rc); err != nil {
+			diags = append(diags, registry.ValidationDiag{
+				Severity: "error",
+				Check:    "reactions.review_comments",
+				Message:  err.Error(),
+			})
+		}
+	}
 
 	if rc, ok := cfg.Reactions["bot_review"]; ok && rc.Provider != "" {
 		if _, err := BuildBotReviewReactionConfig(rc); err != nil {
@@ -34,6 +42,16 @@ func ValidateReactionConfigs(cfg config.ServiceConfig, trackerMeta registry.Trac
 			diags = append(diags, registry.ValidationDiag{
 				Severity: "error",
 				Check:    "reactions.auto_merge",
+				Message:  err.Error(),
+			})
+		}
+	}
+
+	if rc, ok := cfg.Reactions["merge_conflicts"]; ok && rc.Provider != "" {
+		if _, err := BuildMergeConflictReactionConfig(rc); err != nil {
+			diags = append(diags, registry.ValidationDiag{
+				Severity: "error",
+				Check:    "reactions.merge_conflicts",
 				Message:  err.Error(),
 			})
 		}

--- a/internal/orchestrator/reaction_validate_test.go
+++ b/internal/orchestrator/reaction_validate_test.go
@@ -31,6 +31,33 @@ func TestValidateReactionConfigs(t *testing.T) {
 		wantChecks []string
 	}{
 		{
+			name: "review_comments poll_interval_ms below minimum",
+			cfg: config.ServiceConfig{
+				Reactions: map[string]config.ReactionConfig{
+					"review_comments": {Provider: "gitea", Extra: map[string]any{"poll_interval_ms": 1000}},
+				},
+			},
+			wantChecks: []string{"reactions.review_comments"},
+		},
+		{
+			name: "review_comments debounce_ms negative",
+			cfg: config.ServiceConfig{
+				Reactions: map[string]config.ReactionConfig{
+					"review_comments": {Provider: "gitea", Extra: map[string]any{"debounce_ms": -1}},
+				},
+			},
+			wantChecks: []string{"reactions.review_comments"},
+		},
+		{
+			name: "review_comments max_continuation_turns zero",
+			cfg: config.ServiceConfig{
+				Reactions: map[string]config.ReactionConfig{
+					"review_comments": {Provider: "gitea", Extra: map[string]any{"max_continuation_turns": 0}},
+				},
+			},
+			wantChecks: []string{"reactions.review_comments"},
+		},
+		{
 			name: "bot_review bare string bot_usernames",
 			cfg: config.ServiceConfig{
 				Reactions: map[string]config.ReactionConfig{
@@ -65,6 +92,15 @@ func TestValidateReactionConfigs(t *testing.T) {
 				},
 			},
 			wantChecks: []string{"reactions.auto_merge"},
+		},
+		{
+			name: "merge_conflicts poll_interval_ms below minimum",
+			cfg: config.ServiceConfig{
+				Reactions: map[string]config.ReactionConfig{
+					"merge_conflicts": {Provider: "gitea", Extra: map[string]any{"poll_interval_ms": 1000}},
+				},
+			},
+			wantChecks: []string{"reactions.merge_conflicts"},
 		},
 		{
 			// buildReactionsConfig hard-errors on a malformed escalation
@@ -110,6 +146,33 @@ func TestValidateReactionConfigs(t *testing.T) {
 			wantChecks: nil,
 		},
 		{
+			name: "clean review_comments and merge_conflicts produce no diags",
+			cfg: config.ServiceConfig{
+				Reactions: map[string]config.ReactionConfig{
+					"review_comments": {
+						Provider: "gitea",
+						Extra: map[string]any{
+							"poll_interval_ms":       30000,
+							"debounce_ms":            0,
+							"max_continuation_turns": 1,
+						},
+					},
+					"merge_conflicts": {Provider: "gitea", Extra: map[string]any{"poll_interval_ms": 30000}},
+				},
+			},
+			wantChecks: nil,
+		},
+		{
+			name: "review_comments and merge_conflicts invalid accumulate in order",
+			cfg: config.ServiceConfig{
+				Reactions: map[string]config.ReactionConfig{
+					"review_comments": {Provider: "gitea", Extra: map[string]any{"debounce_ms": -1}},
+					"merge_conflicts": {Provider: "gitea", Extra: map[string]any{"poll_interval_ms": 1000}},
+				},
+			},
+			wantChecks: []string{"reactions.review_comments", "reactions.merge_conflicts"},
+		},
+		{
 			name:       "absent reactions map",
 			cfg:        config.ServiceConfig{},
 			wantChecks: nil,
@@ -118,8 +181,10 @@ func TestValidateReactionConfigs(t *testing.T) {
 			name: "inactive reactions with empty provider are skipped",
 			cfg: config.ServiceConfig{
 				Reactions: map[string]config.ReactionConfig{
-					"bot_review": {Provider: "", Extra: map[string]any{"bot_usernames": "not-a-list"}},
-					"auto_merge": {Provider: "", Extra: map[string]any{"strategy": "bogus"}},
+					"review_comments": {Provider: "", Extra: map[string]any{"poll_interval_ms": 1000}},
+					"bot_review":      {Provider: "", Extra: map[string]any{"bot_usernames": "not-a-list"}},
+					"auto_merge":      {Provider: "", Extra: map[string]any{"strategy": "bogus"}},
+					"merge_conflicts": {Provider: "", Extra: map[string]any{"poll_interval_ms": 1000}},
 				},
 			},
 			wantChecks: nil,
@@ -128,21 +193,19 @@ func TestValidateReactionConfigs(t *testing.T) {
 			name: "nil Extra tolerated with defaults applied",
 			cfg: config.ServiceConfig{
 				Reactions: map[string]config.ReactionConfig{
-					"bot_review": {Provider: "gitea"},
-					"auto_merge": {Provider: "gitea"},
+					"review_comments": {Provider: "gitea"},
+					"bot_review":      {Provider: "gitea"},
+					"auto_merge":      {Provider: "gitea"},
+					"merge_conflicts": {Provider: "gitea"},
 				},
 			},
 			wantChecks: nil,
 		},
 		{
-			// Only bot_review and auto_merge are dispatched; a malformed
-			// review_comments or merge_conflicts Extra field must never
-			// surface a diagnostic here.
-			name: "review_comments and merge_conflicts are never inspected",
+			name: "unknown reaction fields and kinds are ignored",
 			cfg: config.ServiceConfig{
 				Reactions: map[string]config.ReactionConfig{
-					"review_comments":  {Provider: "gitea", Extra: map[string]any{"poll_interval_ms": "not-an-int"}},
-					"merge_conflicts":  {Provider: "gitea", Extra: map[string]any{"debounce_ms": "bad"}},
+					"merge_conflicts":  {Provider: "gitea", Extra: map[string]any{"debounce_ms": "unused"}},
 					"label_commands":   {Provider: "gitea", Extra: map[string]any{"anything": "goes"}},
 					"unknown_reaction": {Provider: "gitea", Extra: map[string]any{"anything": "goes"}},
 				},


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Feat

**Intent:** Make `sortie validate` reject invalid `review_comments` and `merge_conflicts` numeric settings before startup, using the same builders as runtime construction.

**Related Issues:** Closes #803

### 🧭 Reviewer Guide

**Complexity:** Low

#### Entry Point

Start with `internal/orchestrator/reaction_validate.go`. It now invokes `BuildReviewReactionConfig` and `BuildMergeConflictReactionConfig` for active reaction blocks, preserving the existing provider gate and sharing the runtime validation source of truth.

#### Sensitive Areas

- `internal/orchestrator/reaction_validate_test.go`: Covers all four newly surfaced rules, valid boundary values, inactive blocks, and diagnostic ordering.
- `cmd/sortie/validate_test.go`: Exercises the behavior through the CLI and verifies diagnostics name the offending field without constructing an adapter or making a network call.
- `docs/workflow-reference.md`: Updates the documented enforcement split to match the new offline behavior.

### ⚠️ Risk Assessment

- **Breaking Changes:** Invalid workflow values that previously passed `sortie validate` now correctly exit with status 1; valid workflows are unchanged.
- **Migrations/State:** No migrations or state changes.

### ✅ Validation

- `make fmt`
- `make lint` — 0 issues
- `make test PKG='./internal/orchestrator ./cmd/sortie'`

The full local `make test` run also passed both changed packages. It was not fully green because of unrelated environment-dependent failures in the Copilot/Kiro CLI canaries and existing macOS `/var` versus `/private/var` workspace assertions.
