### PR TITLE
test(github): cover GetCIStatus paginator errors

### DIFF
--- a/internal/scm/github/merge_test.go
+++ b/internal/scm/github/merge_test.go
@@ -531,6 +531,42 @@ func TestGetCIStatus_NoSignals_ReturnsEmpty(t *testing.T) {
 	}
 }
 
+func TestGetCIStatus_PaginatorErrors(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		failingRoute string
+	}{
+		{name: "combined_status", failingRoute: "/status"},
+		{name: "check_runs", failingRoute: "/check-runs"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				switch {
+				case strings.Contains(r.URL.Path, "/pulls/"):
+					_, _ = w.Write([]byte(`{"head":{"sha":"abc123"}}`))
+				case strings.Contains(r.URL.Path, tt.failingRoute):
+					w.WriteHeader(http.StatusInternalServerError)
+					_, _ = w.Write([]byte(`{"message":"Internal Server Error"}`))
+				case strings.Contains(r.URL.Path, "/status"):
+					_, _ = w.Write([]byte(`{"state":"","statuses":[]}`))
+				}
+			}))
+			defer srv.Close()
+
+			a := newTestSCMAdapter(t, srv.URL)
+			_, err := a.GetCIStatus(t.Context(), 1, "owner", "repo")
+			assertSCMErrorKind(t, err, domain.ErrSCMTransport)
+		})
+	}
+}
+
 // combinedStatusPageJSON builds one combined-status page carrying n
 // same-state entries, matching the wire shape [decodeCombinedStatusPage]
 // unmarshals.


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Chore

**Intent:** Cover both paginator failure branches in GitHub `GetCIStatus` so regressions in normalized SCM error handling are caught by the test suite.

**Related Issues:** Closes #809

### 🧭 Reviewer Guide

**Complexity:** Low

#### Entry Point

Start with `internal/scm/github/merge_test.go`. The new table-driven test makes the combined-status route and the check-runs route fail independently, then verifies that `GetCIStatus` returns an SCM transport error in both cases.

#### Sensitive Areas

- `internal/scm/github/merge_test.go`: The check-runs case first returns a valid empty combined-status page so the test reaches the second paginator rather than failing early.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes; test-only change.
- **Migrations/State:** No migrations or state changes.

### ✅ Validation

- `make fmt`
- `make lint` — 0 issues
- `make test PKG=./internal/scm/github/...`

The full local `make test` run also passed the changed GitHub SCM package. It was not fully green because of unrelated environment-dependent failures in the Copilot/Kiro CLI canaries and existing macOS `/var` versus `/private/var` workspace assertions.
