### PR TITLE
fix(adapters): redact userinfo from endpoint errors

### DIFF
--- a/internal/httpkit/url.go
+++ b/internal/httpkit/url.go
@@ -1,0 +1,32 @@
+package httpkit
+
+import "strings"
+
+// RedactURLUserinfo removes the complete userinfo prefix from raw while
+// preserving the rest of the URL for diagnostics. It operates on the raw
+// string instead of parsing it so malformed URLs are redacted too. Values
+// without an authority marker or userinfo delimiter are returned unchanged.
+func RedactURLUserinfo(raw string) string {
+	authorityStart := -1
+	if strings.HasPrefix(raw, "//") {
+		authorityStart = 2
+	} else if marker := strings.Index(raw, "://"); marker >= 0 {
+		authorityStart = marker + len("://")
+	}
+	if authorityStart < 0 {
+		return raw
+	}
+
+	authorityEnd := len(raw)
+	if offset := strings.IndexAny(raw[authorityStart:], "/?#"); offset >= 0 {
+		authorityEnd = authorityStart + offset
+	}
+
+	userinfoEnd := strings.LastIndex(raw[authorityStart:authorityEnd], "@")
+	if userinfoEnd < 0 {
+		return raw
+	}
+	userinfoEnd += authorityStart + len("@")
+
+	return raw[:authorityStart] + raw[userinfoEnd:]
+}

--- a/internal/httpkit/url.go
+++ b/internal/httpkit/url.go
@@ -4,17 +4,17 @@ import "strings"
 
 // RedactURLUserinfo removes the complete userinfo prefix from raw while
 // preserving the rest of the URL for diagnostics. It operates on the raw
-// string instead of parsing it so malformed URLs are redacted too. Values
-// without an authority marker or userinfo delimiter are returned unchanged.
+// string instead of parsing it so malformed URLs are redacted too. When the
+// authority marker is missing or malformed, the leading segment is treated as
+// the authority so credentials in invalid endpoint values are still removed.
 func RedactURLUserinfo(raw string) string {
-	authorityStart := -1
-	if strings.HasPrefix(raw, "//") {
-		authorityStart = 2
-	} else if marker := strings.Index(raw, "://"); marker >= 0 {
+	authorityStart := 0
+	if marker := strings.Index(raw, "://"); marker >= 0 {
 		authorityStart = marker + len("://")
-	}
-	if authorityStart < 0 {
-		return raw
+	} else if marker := strings.Index(raw, "//"); marker >= 0 {
+		authorityStart = marker + len("//")
+	} else if marker := strings.Index(raw, ":/"); marker >= 0 {
+		authorityStart = marker + len(":/")
 	}
 
 	authorityEnd := len(raw)

--- a/internal/httpkit/url_test.go
+++ b/internal/httpkit/url_test.go
@@ -51,9 +51,19 @@ func TestRedactURLUserinfo(t *testing.T) {
 			want: "https://example.com/users/operator@example.com?owner=user@example.com",
 		},
 		{
-			name: "value without authority marker unchanged",
+			name: "userinfo without authority marker",
 			raw:  "operator:secret@example.com",
-			want: "operator:secret@example.com",
+			want: "example.com",
+		},
+		{
+			name: "userinfo after single slash scheme typo",
+			raw:  "https:/operator:secret@example.com/path",
+			want: "https:/example.com/path",
+		},
+		{
+			name: "at sign after path without authority marker unchanged",
+			raw:  "example.com/users/operator@example.com",
+			want: "example.com/users/operator@example.com",
 		},
 	}
 

--- a/internal/httpkit/url_test.go
+++ b/internal/httpkit/url_test.go
@@ -1,0 +1,69 @@
+package httpkit
+
+import "testing"
+
+func TestRedactURLUserinfo(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{
+			name: "username and password",
+			raw:  "https://operator:secret@example.com/path?key=value#fragment",
+			want: "https://example.com/path?key=value#fragment",
+		},
+		{
+			name: "token in username position",
+			raw:  "ftp://token-only@example.com/path",
+			want: "ftp://example.com/path",
+		},
+		{
+			name: "malformed URL still redacted",
+			raw:  "https://operator:secret@example.com/%zz",
+			want: "https://example.com/%zz",
+		},
+		{
+			name: "scheme-relative URL",
+			raw:  "//operator:secret@example.com/path",
+			want: "//example.com/path",
+		},
+		{
+			name: "last at sign delimits malformed userinfo",
+			raw:  "https://operator:p@ss@example.com/path",
+			want: "https://example.com/path",
+		},
+		{
+			name: "userinfo with missing host",
+			raw:  "https://operator:secret@",
+			want: "https://",
+		},
+		{
+			name: "URL without userinfo unchanged",
+			raw:  "https://example.com/path",
+			want: "https://example.com/path",
+		},
+		{
+			name: "at sign outside authority unchanged",
+			raw:  "https://example.com/users/operator@example.com?owner=user@example.com",
+			want: "https://example.com/users/operator@example.com?owner=user@example.com",
+		},
+		{
+			name: "value without authority marker unchanged",
+			raw:  "operator:secret@example.com",
+			want: "operator:secret@example.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := RedactURLUserinfo(tt.raw); got != tt.want {
+				t.Errorf("RedactURLUserinfo(%q) = %q, want %q", tt.raw, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/scm/gitlab/ci.go
+++ b/internal/scm/gitlab/ci.go
@@ -131,7 +131,7 @@ func NewGitLabCIProvider(maxLogLines int, adapterConfig map[string]any) (domain.
 	if err != nil || (parsedEndpoint.Scheme != "http" && parsedEndpoint.Scheme != "https") || parsedEndpoint.Host == "" {
 		return nil, &domain.CIError{
 			Kind:    domain.ErrCIPayload,
-			Message: fmt.Sprintf("gitlab: endpoint %q is not a valid absolute http(s) url", endpoint),
+			Message: fmt.Sprintf("gitlab: endpoint %q is not a valid absolute http(s) url", httpkit.RedactURLUserinfo(endpoint)),
 		}
 	}
 	baseURL := strings.TrimRight(endpoint, "/")

--- a/internal/scm/gitlab/ci_test.go
+++ b/internal/scm/gitlab/ci_test.go
@@ -284,7 +284,7 @@ func TestNewGitLabCIProvider_Validation(t *testing.T) {
 	t.Run("invalid endpoint redacts userinfo", func(t *testing.T) {
 		t.Parallel()
 
-		const endpoint = "ftp://operator:secret@gitlab.example.com/group"
+		const endpoint = "operator:secret@gitlab.example.com/group"
 		provider, err := NewGitLabCIProvider(0, map[string]any{
 			"api_key":  "test-token",
 			"project":  testProject,
@@ -299,7 +299,7 @@ func TestNewGitLabCIProvider_Validation(t *testing.T) {
 		if !errors.As(err, &ciErr) {
 			t.Fatalf("error type = %T, want *domain.CIError", err)
 		}
-		assertMessageRedacted(t, ciErr.Message, "ftp://gitlab.example.com/group", "operator", "secret")
+		assertMessageRedacted(t, ciErr.Message, "gitlab.example.com/group", "operator", "secret")
 	})
 
 	t.Run("an absent endpoint defaults to https://gitlab.com", func(t *testing.T) {

--- a/internal/scm/gitlab/ci_test.go
+++ b/internal/scm/gitlab/ci_test.go
@@ -281,6 +281,27 @@ func TestNewGitLabCIProvider_Validation(t *testing.T) {
 		})
 	}
 
+	t.Run("invalid endpoint redacts userinfo", func(t *testing.T) {
+		t.Parallel()
+
+		const endpoint = "ftp://operator:secret@gitlab.example.com/group"
+		provider, err := NewGitLabCIProvider(0, map[string]any{
+			"api_key":  "test-token",
+			"project":  testProject,
+			"endpoint": endpoint,
+		})
+
+		assertCIErrorKind(t, err, domain.ErrCIPayload)
+		if provider != nil {
+			t.Error("provider should be nil on error")
+		}
+		var ciErr *domain.CIError
+		if !errors.As(err, &ciErr) {
+			t.Fatalf("error type = %T, want *domain.CIError", err)
+		}
+		assertMessageRedacted(t, ciErr.Message, "ftp://gitlab.example.com/group", "operator", "secret")
+	})
+
 	t.Run("an absent endpoint defaults to https://gitlab.com", func(t *testing.T) {
 		t.Parallel()
 

--- a/internal/scm/gitlab/gitlab.go
+++ b/internal/scm/gitlab/gitlab.go
@@ -348,7 +348,7 @@ func NewGitLabAdapter(config map[string]any) (domain.TrackerAdapter, error) {
 	if err != nil || (parsedEndpoint.Scheme != "http" && parsedEndpoint.Scheme != "https") || parsedEndpoint.Host == "" {
 		return nil, &domain.TrackerError{
 			Kind:    domain.ErrTrackerPayload,
-			Message: fmt.Sprintf("gitlab: tracker.endpoint %q is not a valid absolute http(s) url", endpoint),
+			Message: fmt.Sprintf("gitlab: tracker.endpoint %q is not a valid absolute http(s) url", httpkit.RedactURLUserinfo(endpoint)),
 		}
 	}
 	baseURL := strings.TrimRight(endpoint, "/")

--- a/internal/scm/gitlab/gitlab_test.go
+++ b/internal/scm/gitlab/gitlab_test.go
@@ -403,7 +403,7 @@ func TestNewGitLabAdapter(t *testing.T) {
 	t.Run("invalid endpoint redacts userinfo", func(t *testing.T) {
 		t.Parallel()
 
-		const endpoint = "ftp://operator:secret@gitlab.example.com/group"
+		const endpoint = "operator:secret@gitlab.example.com/group"
 		a, err := NewGitLabAdapter(map[string]any{
 			"api_key":  "tok",
 			"project":  testProject,
@@ -418,7 +418,7 @@ func TestNewGitLabAdapter(t *testing.T) {
 		if !errors.As(err, &trackerErr) {
 			t.Fatalf("error type = %T, want *domain.TrackerError", err)
 		}
-		assertMessageRedacted(t, trackerErr.Message, "ftp://gitlab.example.com/group", "operator", "secret")
+		assertMessageRedacted(t, trackerErr.Message, "gitlab.example.com/group", "operator", "secret")
 	})
 
 	t.Run("query_filter colliding spellings name both keys and are order-independent", func(t *testing.T) {

--- a/internal/scm/gitlab/gitlab_test.go
+++ b/internal/scm/gitlab/gitlab_test.go
@@ -28,6 +28,18 @@ const testProject = "acme/widgets"
 
 var testEscapedProject = url.PathEscape(testProject)
 
+func assertMessageRedacted(t *testing.T, message, want string, forbidden ...string) {
+	t.Helper()
+	if !strings.Contains(message, want) {
+		t.Errorf("message = %q, want to contain %q", message, want)
+	}
+	for _, value := range forbidden {
+		if strings.Contains(message, value) {
+			t.Errorf("message = %q, must not contain %q", message, value)
+		}
+	}
+}
+
 func loadFixture(t *testing.T, name string) []byte {
 	t.Helper()
 	data, err := os.ReadFile("testdata/" + name)
@@ -386,6 +398,27 @@ func TestNewGitLabAdapter(t *testing.T) {
 				}
 			})
 		}
+	})
+
+	t.Run("invalid endpoint redacts userinfo", func(t *testing.T) {
+		t.Parallel()
+
+		const endpoint = "ftp://operator:secret@gitlab.example.com/group"
+		a, err := NewGitLabAdapter(map[string]any{
+			"api_key":  "tok",
+			"project":  testProject,
+			"endpoint": endpoint,
+		})
+
+		assertTrackerErrorKind(t, err, domain.ErrTrackerPayload)
+		if a != nil {
+			t.Error("adapter should be nil on error")
+		}
+		var trackerErr *domain.TrackerError
+		if !errors.As(err, &trackerErr) {
+			t.Fatalf("error type = %T, want *domain.TrackerError", err)
+		}
+		assertMessageRedacted(t, trackerErr.Message, "ftp://gitlab.example.com/group", "operator", "secret")
 	})
 
 	t.Run("query_filter colliding spellings name both keys and are order-independent", func(t *testing.T) {

--- a/internal/scm/gitlab/scm.go
+++ b/internal/scm/gitlab/scm.go
@@ -63,7 +63,7 @@ func NewGitLabSCMAdapter(adapterConfig map[string]any) (domain.SCMAdapter, error
 	if err != nil || (parsedEndpoint.Scheme != "http" && parsedEndpoint.Scheme != "https") || parsedEndpoint.Host == "" {
 		return nil, &domain.SCMError{
 			Kind:    domain.ErrSCMPayload,
-			Message: fmt.Sprintf("gitlab: endpoint %q is not a valid absolute http(s) url", endpoint),
+			Message: fmt.Sprintf("gitlab: endpoint %q is not a valid absolute http(s) url", httpkit.RedactURLUserinfo(endpoint)),
 		}
 	}
 	baseURL := strings.TrimRight(endpoint, "/")

--- a/internal/scm/gitlab/scm_test.go
+++ b/internal/scm/gitlab/scm_test.go
@@ -135,10 +135,10 @@ func TestNewGitLabSCMAdapter_Validation(t *testing.T) {
 		}
 	})
 
-	t.Run("malformed endpoint redacts userinfo", func(t *testing.T) {
+	t.Run("invalid endpoint redacts userinfo", func(t *testing.T) {
 		t.Parallel()
 
-		const endpoint = "ftp://operator:secret@gitlab.example.com/group"
+		const endpoint = "https:/operator:secret@gitlab.example.com/group"
 		a, err := NewGitLabSCMAdapter(map[string]any{
 			"api_key":  "test-token",
 			"endpoint": endpoint,
@@ -152,7 +152,7 @@ func TestNewGitLabSCMAdapter_Validation(t *testing.T) {
 		if !errors.As(err, &scmErr) {
 			t.Fatalf("error type = %T, want *domain.SCMError", err)
 		}
-		assertMessageRedacted(t, scmErr.Message, "ftp://gitlab.example.com/group", "operator", "secret")
+		assertMessageRedacted(t, scmErr.Message, "https:/gitlab.example.com/group", "operator", "secret")
 	})
 }
 

--- a/internal/scm/gitlab/scm_test.go
+++ b/internal/scm/gitlab/scm_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -132,6 +133,26 @@ func TestNewGitLabSCMAdapter_Validation(t *testing.T) {
 				adaptertest.AssertSCMErrorKind(t, err, domain.ErrSCMPayload)
 			})
 		}
+	})
+
+	t.Run("malformed endpoint redacts userinfo", func(t *testing.T) {
+		t.Parallel()
+
+		const endpoint = "ftp://operator:secret@gitlab.example.com/group"
+		a, err := NewGitLabSCMAdapter(map[string]any{
+			"api_key":  "test-token",
+			"endpoint": endpoint,
+		})
+
+		adaptertest.AssertSCMErrorKind(t, err, domain.ErrSCMPayload)
+		if a != nil {
+			t.Error("adapter should be nil on error")
+		}
+		var scmErr *domain.SCMError
+		if !errors.As(err, &scmErr) {
+			t.Fatalf("error type = %T, want *domain.SCMError", err)
+		}
+		assertMessageRedacted(t, scmErr.Message, "ftp://gitlab.example.com/group", "operator", "secret")
 	})
 }
 

--- a/internal/tracker/jira/jira.go
+++ b/internal/tracker/jira/jira.go
@@ -284,7 +284,7 @@ func checkHostVersion(endpoint, apiVersion string) error {
 	if !ok {
 		return &domain.TrackerError{
 			Kind:    domain.ErrTrackerPayload,
-			Message: fmt.Sprintf("endpoint %q must be a URL with a scheme and host", endpoint),
+			Message: fmt.Sprintf("endpoint %q must be a URL with a scheme and host", httpkit.RedactURLUserinfo(endpoint)),
 		}
 	}
 	isCloud := isCloudHost(host)

--- a/internal/tracker/jira/jira_v2_test.go
+++ b/internal/tracker/jira/jira_v2_test.go
@@ -282,7 +282,7 @@ func TestNewJiraAdapter_HostVersionGuard_RejectUnparseableEndpoint(t *testing.T)
 func TestNewJiraAdapter_HostVersionGuard_RedactsEndpointUserinfo(t *testing.T) {
 	t.Parallel()
 
-	const endpoint = "https://operator:secret@jira.example.com/%zz"
+	const endpoint = "operator:secret@jira.example.com"
 	a, err := NewJiraAdapter(map[string]any{
 		"endpoint":    endpoint,
 		"api_key":     "user@test.com:tok",
@@ -296,7 +296,7 @@ func TestNewJiraAdapter_HostVersionGuard_RedactsEndpointUserinfo(t *testing.T) {
 	}
 	var trackerErr *domain.TrackerError
 	asTrackerError(t, err, &trackerErr)
-	if !strings.Contains(trackerErr.Message, "https://jira.example.com/%zz") {
+	if !strings.Contains(trackerErr.Message, "jira.example.com") {
 		t.Errorf("TrackerError.Message = %q, want the endpoint without userinfo", trackerErr.Message)
 	}
 	for _, secret := range []string{"operator", "secret"} {

--- a/internal/tracker/jira/jira_v2_test.go
+++ b/internal/tracker/jira/jira_v2_test.go
@@ -279,6 +279,33 @@ func TestNewJiraAdapter_HostVersionGuard_RejectUnparseableEndpoint(t *testing.T)
 	}
 }
 
+func TestNewJiraAdapter_HostVersionGuard_RedactsEndpointUserinfo(t *testing.T) {
+	t.Parallel()
+
+	const endpoint = "https://operator:secret@jira.example.com/%zz"
+	a, err := NewJiraAdapter(map[string]any{
+		"endpoint":    endpoint,
+		"api_key":     "user@test.com:tok",
+		"project":     "P",
+		"api_version": "3",
+	})
+
+	assertTrackerErrorKind(t, err, domain.ErrTrackerPayload)
+	if a != nil {
+		t.Error("adapter should be nil when the endpoint is malformed")
+	}
+	var trackerErr *domain.TrackerError
+	asTrackerError(t, err, &trackerErr)
+	if !strings.Contains(trackerErr.Message, "https://jira.example.com/%zz") {
+		t.Errorf("TrackerError.Message = %q, want the endpoint without userinfo", trackerErr.Message)
+	}
+	for _, secret := range []string{"operator", "secret"} {
+		if strings.Contains(trackerErr.Message, secret) {
+			t.Errorf("TrackerError.Message = %q, must not contain %q", trackerErr.Message, secret)
+		}
+	}
+}
+
 // TestNewJiraAdapter_HostVersionGuard_ConsistentCombos verifies the two
 // consistent (host, version) pairs construct successfully.
 func TestNewJiraAdapter_HostVersionGuard_ConsistentCombos(t *testing.T) {


### PR DESCRIPTION
Closes #791.

Jira and GitLab endpoint validation errors were printing the configured URL directly, which could leak credentials into logs.

This removes the whole userinfo part before adding the endpoint to the error. It also works for malformed URLs. I included the GitLab CI provider since it has the same error path.

Added tests for the helper and the affected constructors.

Tested with `make fmt`, `make lint`, the related package tests, and `make build`. Full `make test` still hits the existing macOS-only failures in `internal/workspace`.
