### PR TITLE
fix(github): preserve inline review comment locations

### DIFF
--- a/internal/scm/github/review.go
+++ b/internal/scm/github/review.go
@@ -37,13 +37,16 @@ type githubReview struct {
 }
 
 type githubReviewComment struct {
-	ID        int64  `json:"id"`
-	Path      string `json:"path"`
-	StartLine *int   `json:"start_line"`
-	Line      *int   `json:"line"`
-	Position  *int   `json:"position"`
-	Body      string `json:"body"`
-	User      struct {
+	ID                  int64  `json:"id"`
+	PullRequestReviewID *int64 `json:"pull_request_review_id"`
+	Path                string `json:"path"`
+	StartLine           *int   `json:"start_line"`
+	OriginalStartLine   *int   `json:"original_start_line"`
+	Line                *int   `json:"line"`
+	OriginalLine        *int   `json:"original_line"`
+	SubjectType         string `json:"subject_type"`
+	Body                string `json:"body"`
+	User                struct {
 		Login string `json:"login"`
 		Type  string `json:"type"`
 	} `json:"user"`
@@ -90,9 +93,9 @@ func NewGitHubSCMAdapter(adapterConfig map[string]any) (domain.SCMAdapter, error
 }
 
 // FetchPendingReviews returns review comments from non-bot
-// CHANGES_REQUESTED reviews on the given PR. Outdated comments (where
-// GitHub reports position as null) have Outdated=true. Returns an empty
-// non-nil slice when no matching reviews exist.
+// CHANGES_REQUESTED reviews on the given PR. Outdated line comments
+// (where GitHub no longer reports a current line) have Outdated=true.
+// Returns an empty non-nil slice when no matching reviews exist.
 //
 // SubmittedAt is parsed via [scmcore.ParseTimestampOrZero]: a review or
 // comment timestamp that is not RFC 3339 normalizes to the zero time
@@ -103,9 +106,7 @@ func (a *GitHubSCMAdapter) FetchPendingReviews(ctx context.Context, prNumber int
 		return nil, err
 	}
 
-	seen := make(map[string]struct{})
-	var result []domain.ReviewComment
-
+	selected := make([]githubReview, 0, len(reviews))
 	for _, review := range reviews {
 		if !strings.EqualFold(review.State, "CHANGES_REQUESTED") {
 			continue
@@ -113,79 +114,20 @@ func (a *GitHubSCMAdapter) FetchPendingReviews(ctx context.Context, prNumber int
 		if strings.EqualFold(review.User.Type, "Bot") {
 			continue
 		}
-
-		// Include non-empty review body as a PR-level comment.
-		body := strings.TrimSpace(review.Body)
-		if body != "" {
-			prCommentID := fmt.Sprintf("review-%d", review.ID)
-			if _, dup := seen[prCommentID]; !dup {
-				seen[prCommentID] = struct{}{}
-				submittedAt := scmcore.ParseTimestampOrZero(review.SubmittedAt)
-				result = append(result, domain.ReviewComment{
-					ID:          prCommentID,
-					Reviewer:    review.User.Login,
-					Body:        body,
-					SubmittedAt: submittedAt,
-				})
-			}
-		}
-
-		// Fetch inline comments for this review.
-		comments, fetchErr := a.fetchReviewComments(ctx, prNumber, owner, repo, review.ID)
-		if fetchErr != nil {
-			return nil, fetchErr
-		}
-
-		for _, c := range comments {
-			if strings.EqualFold(c.User.Type, "Bot") {
-				continue
-			}
-
-			commentID := strconv.FormatInt(c.ID, 10)
-			if _, dup := seen[commentID]; dup {
-				continue
-			}
-			seen[commentID] = struct{}{}
-
-			startLine := 0
-			if c.StartLine != nil {
-				startLine = *c.StartLine
-			} else if c.Line != nil {
-				startLine = *c.Line
-			}
-
-			endLine := 0
-			if c.Line != nil && *c.Line != startLine {
-				endLine = *c.Line
-			}
-
-			createdAt := scmcore.ParseTimestampOrZero(c.CreatedAt)
-
-			result = append(result, domain.ReviewComment{
-				ID:          commentID,
-				FilePath:    c.Path,
-				StartLine:   startLine,
-				EndLine:     endLine,
-				Reviewer:    c.User.Login,
-				Body:        c.Body,
-				SubmittedAt: createdAt,
-				Outdated:    c.Position == nil,
-			})
-		}
+		selected = append(selected, review)
 	}
 
-	if result == nil {
-		result = []domain.ReviewComment{}
-	}
-	return result, nil
+	return a.collectReviewComments(ctx, prNumber, owner, repo, selected, func(comment githubReviewComment) bool {
+		return !strings.EqualFold(comment.User.Type, "Bot")
+	})
 }
 
 // FetchBotReviewComments returns review comments authored by automated
 // review bots on the given PR. A review or comment is bot-authored when
 // its user.type is "Bot" or its author login matches a botUsernames entry
-// case-insensitively. Outdated comments (where GitHub reports position as
-// null) have Outdated=true. Returns an empty non-nil slice when no bot
-// comments exist.
+// case-insensitively. Outdated line comments (where GitHub no longer
+// reports a current line) have Outdated=true. Returns an empty non-nil
+// slice when no bot comments exist.
 //
 // Unlike [GitHubSCMAdapter.FetchPendingReviews], no review-state filter is
 // applied: review bots commonly post COMMENTED reviews, so requiring
@@ -200,78 +142,123 @@ func (a *GitHubSCMAdapter) FetchBotReviewComments(ctx context.Context, prNumber 
 		return nil, err
 	}
 
-	seen := make(map[string]struct{})
-	var result []domain.ReviewComment
-
+	selected := make([]githubReview, 0, len(reviews))
 	for _, review := range reviews {
 		if !scmcore.IsBotAuthor(review.User.Login, strings.EqualFold(review.User.Type, "Bot"), botUsernames) {
 			continue
 		}
+		selected = append(selected, review)
+	}
 
-		// Include non-empty review body as a PR-level comment.
+	return a.collectReviewComments(ctx, prNumber, owner, repo, selected, func(comment githubReviewComment) bool {
+		return scmcore.IsBotAuthor(comment.User.Login, strings.EqualFold(comment.User.Type, "Bot"), botUsernames)
+	})
+}
+
+func (a *GitHubSCMAdapter) collectReviewComments(
+	ctx context.Context,
+	prNumber int,
+	owner, repo string,
+	reviews []githubReview,
+	includeComment func(githubReviewComment) bool,
+) ([]domain.ReviewComment, error) {
+	result := make([]domain.ReviewComment, 0)
+	if len(reviews) == 0 {
+		return result, nil
+	}
+
+	comments, err := a.fetchAllReviewComments(ctx, prNumber, owner, repo)
+	if err != nil {
+		return nil, err
+	}
+
+	commentsByReview := make(map[int64][]githubReviewComment)
+	for _, comment := range comments {
+		if comment.PullRequestReviewID == nil {
+			continue
+		}
+		reviewID := *comment.PullRequestReviewID
+		commentsByReview[reviewID] = append(commentsByReview[reviewID], comment)
+	}
+
+	seen := make(map[string]struct{})
+	for _, review := range reviews {
 		body := strings.TrimSpace(review.Body)
 		if body != "" {
 			prCommentID := fmt.Sprintf("review-%d", review.ID)
 			if _, dup := seen[prCommentID]; !dup {
 				seen[prCommentID] = struct{}{}
-				submittedAt := scmcore.ParseTimestampOrZero(review.SubmittedAt)
 				result = append(result, domain.ReviewComment{
 					ID:          prCommentID,
 					Reviewer:    review.User.Login,
 					Body:        body,
-					SubmittedAt: submittedAt,
+					SubmittedAt: scmcore.ParseTimestampOrZero(review.SubmittedAt),
 				})
 			}
 		}
 
-		// Fetch inline comments for this review.
-		comments, fetchErr := a.fetchReviewComments(ctx, prNumber, owner, repo, review.ID)
-		if fetchErr != nil {
-			return nil, fetchErr
-		}
-
-		for _, c := range comments {
-			if !scmcore.IsBotAuthor(c.User.Login, strings.EqualFold(c.User.Type, "Bot"), botUsernames) {
+		for _, comment := range commentsByReview[review.ID] {
+			if !includeComment(comment) {
 				continue
 			}
 
-			commentID := strconv.FormatInt(c.ID, 10)
+			commentID := strconv.FormatInt(comment.ID, 10)
 			if _, dup := seen[commentID]; dup {
 				continue
 			}
 			seen[commentID] = struct{}{}
-
-			startLine := 0
-			if c.StartLine != nil {
-				startLine = *c.StartLine
-			} else if c.Line != nil {
-				startLine = *c.Line
-			}
-
-			endLine := 0
-			if c.Line != nil && *c.Line != startLine {
-				endLine = *c.Line
-			}
-
-			createdAt := scmcore.ParseTimestampOrZero(c.CreatedAt)
-
-			result = append(result, domain.ReviewComment{
-				ID:          commentID,
-				FilePath:    c.Path,
-				StartLine:   startLine,
-				EndLine:     endLine,
-				Reviewer:    c.User.Login,
-				Body:        c.Body,
-				SubmittedAt: createdAt,
-				Outdated:    c.Position == nil,
-			})
+			result = append(result, normalizeReviewComment(comment))
 		}
 	}
 
-	if result == nil {
-		result = []domain.ReviewComment{}
-	}
 	return result, nil
+}
+
+func normalizeReviewComment(comment githubReviewComment) domain.ReviewComment {
+	startLine, endLine := reviewCommentLines(comment)
+	return domain.ReviewComment{
+		ID:          strconv.FormatInt(comment.ID, 10),
+		FilePath:    comment.Path,
+		StartLine:   startLine,
+		EndLine:     endLine,
+		Reviewer:    comment.User.Login,
+		Body:        comment.Body,
+		SubmittedAt: scmcore.ParseTimestampOrZero(comment.CreatedAt),
+		Outdated:    isOutdatedReviewComment(comment),
+	}
+}
+
+func reviewCommentLines(comment githubReviewComment) (int, int) {
+	if strings.EqualFold(comment.SubjectType, "file") {
+		return 0, 0
+	}
+
+	var startLine, endLine int
+	if comment.Line != nil {
+		endLine = *comment.Line
+		startLine = endLine
+		if comment.StartLine != nil {
+			startLine = *comment.StartLine
+		}
+	} else if comment.OriginalLine != nil {
+		endLine = *comment.OriginalLine
+		startLine = endLine
+		if comment.OriginalStartLine != nil {
+			startLine = *comment.OriginalStartLine
+		}
+	}
+
+	if startLine == endLine {
+		endLine = 0
+	}
+	return startLine, endLine
+}
+
+func isOutdatedReviewComment(comment githubReviewComment) bool {
+	if strings.EqualFold(comment.SubjectType, "file") {
+		return false
+	}
+	return comment.Line == nil && (comment.OriginalLine != nil || strings.EqualFold(comment.SubjectType, "line"))
 }
 
 func (a *GitHubSCMAdapter) fetchAllReviews(ctx context.Context, prNumber int, owner, repo string) ([]githubReview, error) {
@@ -306,9 +293,9 @@ func (a *GitHubSCMAdapter) fetchAllReviews(ctx context.Context, prNumber int, ow
 	return all, nil
 }
 
-func (a *GitHubSCMAdapter) fetchReviewComments(ctx context.Context, prNumber int, owner, repo string, reviewID int64) ([]githubReviewComment, error) {
-	path := fmt.Sprintf("/repos/%s/%s/pulls/%d/reviews/%d/comments",
-		url.PathEscape(owner), url.PathEscape(repo), prNumber, reviewID)
+func (a *GitHubSCMAdapter) fetchAllReviewComments(ctx context.Context, prNumber int, owner, repo string) ([]githubReviewComment, error) {
+	path := fmt.Sprintf("/repos/%s/%s/pulls/%d/comments",
+		url.PathEscape(owner), url.PathEscape(repo), prNumber)
 	params := url.Values{"per_page": {"100"}}
 
 	paginator := httpkit.NewLinkPaginator(a.client, path, params, func(body []byte) ([]githubReviewComment, error) {
@@ -328,7 +315,6 @@ func (a *GitHubSCMAdapter) fetchReviewComments(ctx context.Context, prNumber int
 				slog.String("owner", owner),
 				slog.String("repo", repo),
 				slog.Int("pr_number", prNumber),
-				slog.Int64("review_id", reviewID),
 				slog.Int("max_pages", limit))
 		},
 	})

--- a/internal/scm/github/review_test.go
+++ b/internal/scm/github/review_test.go
@@ -38,14 +38,17 @@ func assertSCMErrorKind(t *testing.T, err error, want domain.SCMErrorKind) {
 // reviewsAndCommentsHandler builds an httptest handler that serves review
 // and comment fixtures from the testdata directory. It handles:
 //   - GET .../reviews → reviewsFixture (no Link header)
-//   - GET .../reviews/{id}/comments → commentsFixture (no Link header)
+//   - GET .../pulls/{number}/comments → commentsFixture (no Link header)
+//
+// The legacy review-scoped comments route is intentionally not served: it
+// omits line fields in GitHub's live response.
 func reviewsAndCommentsHandler(t *testing.T, reviewsFixture, commentsFixture []byte) http.HandlerFunc {
 	t.Helper()
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		path := r.URL.Path
 		switch {
-		case strings.Contains(path, "/comments"):
+		case strings.HasSuffix(path, "/comments") && !strings.Contains(path, "/reviews/"):
 			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write(commentsFixture)
 		case strings.HasSuffix(path, "/reviews"):
@@ -196,7 +199,7 @@ func TestFetchPendingReviews_ChangesRequestedWithInlineComment(t *testing.T) {
 		t.Error("Body is empty, want non-empty")
 	}
 	if c.Outdated {
-		t.Error("Outdated = true, want false (position is non-nil)")
+		t.Error("Outdated = true, want false (current line is present)")
 	}
 	if c.SubmittedAt.IsZero() {
 		t.Error("SubmittedAt is zero, want parsed timestamp")
@@ -238,8 +241,8 @@ func TestFetchPendingReviews_PRLevelBodyAppended(t *testing.T) {
 	}
 
 	c := got[0]
-	if c.ID != "review-10" {
-		t.Errorf("PR-level comment ID = %q, want %q", c.ID, "review-10")
+	if c.ID != "review-20" {
+		t.Errorf("PR-level comment ID = %q, want %q", c.ID, "review-20")
 	}
 	if c.FilePath != "" {
 		t.Errorf("PR-level comment FilePath = %q, want empty", c.FilePath)
@@ -272,14 +275,14 @@ func TestFetchPendingReviews_OutdatedComment(t *testing.T) {
 		t.Fatalf("FetchPendingReviews len = %d, want 1", len(got))
 	}
 	if !got[0].Outdated {
-		t.Error("Outdated = false, want true (position is nil)")
+		t.Error("Outdated = false, want true (current line is nil)")
 	}
 }
 
 func TestFetchPendingReviews_Deduplication(t *testing.T) {
 	t.Parallel()
 
-	// Review has both a body (becomes review-10) and one inline comment (100).
+	// Review has both a body (becomes review-20) and one inline comment (100).
 	// The same comment ID should not appear twice even if somehow duplicated.
 	reviewsFixture := loadFixture(t, "reviews_changes_requested_with_body.json")
 	commentsFixture := loadFixture(t, "comments_inline.json")
@@ -309,21 +312,17 @@ func TestFetchPendingReviews_Pagination_Reviews(t *testing.T) {
 
 	page1 := loadFixture(t, "reviews_page1.json")
 	page2 := loadFixture(t, "reviews_page2.json")
-	commentsPage1 := loadFixture(t, "comments_page1.json")
-	commentsPage2 := loadFixture(t, "comments_page2.json")
+	commentsFixture := loadFixture(t, "comments_reviews_paginated.json")
 
 	var reviewCallCount atomic.Int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		path := r.URL.Path
 		switch {
-		case strings.Contains(path, "/reviews/11/comments"):
+		case strings.HasSuffix(path, "/comments") && !strings.Contains(path, "/reviews/"):
 			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write(commentsPage1)
-		case strings.Contains(path, "/reviews/12/comments"):
-			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write(commentsPage2)
-		case strings.Contains(path, "/reviews"):
+			_, _ = w.Write(commentsFixture)
+		case strings.HasSuffix(path, "/reviews"):
 			n := reviewCallCount.Add(1)
 			if n == 1 {
 				// Return page 1 with Link next header.
@@ -370,10 +369,10 @@ func TestFetchPendingReviews_Pagination_Comments(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		path := r.URL.Path
 		switch {
-		case strings.Contains(path, "/comments"):
+		case strings.HasSuffix(path, "/comments") && !strings.Contains(path, "/reviews/"):
 			n := commentCallCount.Add(1)
 			if n == 1 {
-				nextURL := fmt.Sprintf("http://%s/repos/owner/repo/pulls/1/reviews/20/comments?page=2", r.Host)
+				nextURL := fmt.Sprintf("http://%s/repos/owner/repo/pulls/1/comments?page=2", r.Host)
 				w.Header().Set("Link", fmt.Sprintf(`<%s>; rel="next"`, nextURL))
 				w.WriteHeader(http.StatusOK)
 				_, _ = w.Write(commentsPage1)
@@ -381,7 +380,7 @@ func TestFetchPendingReviews_Pagination_Comments(t *testing.T) {
 				w.WriteHeader(http.StatusOK)
 				_, _ = w.Write(commentsPage2)
 			}
-		case strings.Contains(path, "/reviews"):
+		case strings.HasSuffix(path, "/reviews"):
 			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write(reviewsFixture)
 		default:
@@ -674,12 +673,12 @@ func TestFetchBotReviewComments_EmptyResultNonNil(t *testing.T) {
 }
 
 // TestFetchBotReviewComments_OutdatedCommentFlag verifies that a bot inline
-// comment with null position carries Outdated == true.
+// comment with no current line carries Outdated == true.
 func TestFetchBotReviewComments_OutdatedCommentFlag(t *testing.T) {
 	t.Parallel()
 
 	// Use the COMMENTED bot review (user.type == "Bot") with an outdated inline
-	// comment (position == null).
+	// comment (line == null, original_line populated).
 	reviewsFixture := loadFixture(t, "reviews_bot_commented.json")
 	commentsFixture := loadFixture(t, "comments_bot_outdated.json")
 	srv := httptest.NewServer(reviewsAndCommentsHandler(t, reviewsFixture, commentsFixture))
@@ -696,12 +695,89 @@ func TestFetchBotReviewComments_OutdatedCommentFlag(t *testing.T) {
 		if c.ID == "500" {
 			foundOutdated = true
 			if !c.Outdated {
-				t.Errorf("FetchBotReviewComments: comment id %q Outdated = false, want true (position is null)", c.ID)
+				t.Errorf("FetchBotReviewComments: comment id %q Outdated = false, want true (current line is null)", c.ID)
 			}
 		}
 	}
 	if !foundOutdated {
 		t.Errorf("FetchBotReviewComments: outdated bot comment id %q not found in results", "500")
+	}
+}
+
+// TestFetchBotReviewComments_LiveResponseLocations uses responses captured
+// from sortie-ai/sortie PR #649. GitHub's review-scoped endpoint omitted all
+// line fields for the same comments, while the PR-scoped endpoint returned
+// the current and original ranges used below.
+func TestFetchBotReviewComments_LiveResponseLocations(t *testing.T) {
+	t.Parallel()
+
+	reviewsFixture := loadFixture(t, "reviews_live_pr649.json")
+	commentsFixture := loadFixture(t, "review_comments_live_pr649.json")
+	legacyFixture := loadFixture(t, "review_comments_legacy_live_pr649.json")
+
+	var legacyCalls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/repos/sortie-ai/sortie/pulls/649/reviews":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(reviewsFixture)
+		case "/repos/sortie-ai/sortie/pulls/649/comments":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(commentsFixture)
+		case "/repos/sortie-ai/sortie/pulls/649/reviews/4702010051/comments":
+			legacyCalls.Add(1)
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(legacyFixture)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"message":"not found"}`))
+		}
+	}))
+	defer srv.Close()
+
+	adapter := newTestSCMAdapter(t, srv.URL)
+	got, err := adapter.FetchBotReviewComments(context.Background(), 649, "sortie-ai", "sortie", nil)
+	if err != nil {
+		t.Fatalf("FetchBotReviewComments: %v", err)
+	}
+	if legacyCalls.Load() != 0 {
+		t.Fatalf("legacy review-scoped comment calls = %d, want 0", legacyCalls.Load())
+	}
+	if len(got) != 3 {
+		t.Fatalf("FetchBotReviewComments len = %d, want 3", len(got))
+	}
+
+	byID := make(map[string]domain.ReviewComment, len(got))
+	for _, comment := range got {
+		byID[comment.ID] = comment
+	}
+
+	prLevel, ok := byID["review-4702010051"]
+	if !ok {
+		t.Fatal("PR-level review body not returned")
+	}
+	if prLevel.FilePath != "" || prLevel.StartLine != 0 || prLevel.EndLine != 0 || prLevel.Outdated {
+		t.Errorf("PR-level comment location = (%q, %d, %d, outdated=%t), want empty and zero",
+			prLevel.FilePath, prLevel.StartLine, prLevel.EndLine, prLevel.Outdated)
+	}
+
+	current, ok := byID["3585411603"]
+	if !ok {
+		t.Fatal("current multi-line review comment not returned")
+	}
+	if current.StartLine != 147 || current.EndLine != 151 || current.Outdated {
+		t.Errorf("current comment location = (%d, %d, outdated=%t), want (147, 151, false)",
+			current.StartLine, current.EndLine, current.Outdated)
+	}
+
+	outdated, ok := byID["3585411671"]
+	if !ok {
+		t.Fatal("outdated multi-line review comment not returned")
+	}
+	if outdated.StartLine != 681 || outdated.EndLine != 703 || !outdated.Outdated {
+		t.Errorf("outdated comment location = (%d, %d, outdated=%t), want (681, 703, true)",
+			outdated.StartLine, outdated.EndLine, outdated.Outdated)
 	}
 }
 
@@ -799,8 +875,8 @@ func TestFetchPendingReviews_MalformedInlineCommentTimestampTolerated(t *testing
 
 	reviewsFixture := loadFixture(t, "reviews_changes_requested_no_body.json")
 	const commentsFixture = `[
-		{"id":100,"path":"internal/handler.go","start_line":10,"line":12,"position":5,"body":"A","user":{"login":"alice","type":"User"},"created_at":"not-a-timestamp"},
-		{"id":101,"path":"internal/handler.go","start_line":20,"line":22,"position":6,"body":"B","user":{"login":"alice","type":"User"},"created_at":"2026-04-01T10:05:00Z"}
+		{"id":100,"pull_request_review_id":20,"path":"internal/handler.go","start_line":10,"original_start_line":10,"line":12,"original_line":12,"subject_type":"line","body":"A","user":{"login":"alice","type":"User"},"created_at":"not-a-timestamp"},
+		{"id":101,"pull_request_review_id":20,"path":"internal/handler.go","start_line":20,"original_start_line":20,"line":22,"original_line":22,"subject_type":"line","body":"B","user":{"login":"alice","type":"User"},"created_at":"2026-04-01T10:05:00Z"}
 	]`
 	srv := httptest.NewServer(reviewsAndCommentsHandler(t, reviewsFixture, []byte(commentsFixture)))
 	defer srv.Close()
@@ -838,8 +914,8 @@ func TestFetchBotReviewComments_MalformedInlineCommentTimestampTolerated(t *test
 
 	reviewsFixture := loadFixture(t, "reviews_bot_commented.json")
 	const commentsFixture = `[
-		{"id":501,"path":"internal/handler.go","start_line":20,"line":22,"position":3,"body":"A","user":{"login":"golangci-lint[bot]","type":"Bot"},"created_at":"not-a-timestamp"},
-		{"id":502,"path":"internal/handler.go","start_line":30,"line":32,"position":4,"body":"B","user":{"login":"golangci-lint[bot]","type":"Bot"},"created_at":"2026-04-01T10:10:00Z"}
+		{"id":501,"pull_request_review_id":50,"path":"internal/handler.go","start_line":20,"original_start_line":20,"line":22,"original_line":22,"subject_type":"line","body":"A","user":{"login":"golangci-lint[bot]","type":"Bot"},"created_at":"not-a-timestamp"},
+		{"id":502,"pull_request_review_id":50,"path":"internal/handler.go","start_line":30,"original_start_line":30,"line":32,"original_line":32,"subject_type":"line","body":"B","user":{"login":"golangci-lint[bot]","type":"Bot"},"created_at":"2026-04-01T10:10:00Z"}
 	]`
 	srv := httptest.NewServer(reviewsAndCommentsHandler(t, reviewsFixture, []byte(commentsFixture)))
 	defer srv.Close()

--- a/internal/scm/github/testdata/comments_bot_inline.json
+++ b/internal/scm/github/testdata/comments_bot_inline.json
@@ -1,9 +1,13 @@
 [
   {
     "id": 501,
+    "pull_request_review_id": 30,
     "path": "internal/handler.go",
     "start_line": 20,
+    "original_start_line": 20,
     "line": 22,
+    "original_line": 22,
+    "subject_type": "line",
     "position": 3,
     "body": "Error return value of `doWork` is not checked.",
     "user": {

--- a/internal/scm/github/testdata/comments_bot_mixed.json
+++ b/internal/scm/github/testdata/comments_bot_mixed.json
@@ -1,9 +1,13 @@
 [
   {
     "id": 700,
+    "pull_request_review_id": 30,
     "path": "internal/handler.go",
     "start_line": 10,
+    "original_start_line": 10,
     "line": 12,
+    "original_line": 12,
+    "subject_type": "line",
     "position": 4,
     "body": "Bot finding: unchecked error.",
     "user": {
@@ -14,9 +18,13 @@
   },
   {
     "id": 701,
+    "pull_request_review_id": 30,
     "path": "internal/handler.go",
     "start_line": 15,
+    "original_start_line": null,
     "line": 15,
+    "original_line": 15,
+    "subject_type": "line",
     "position": 5,
     "body": "Human reviewer note, not a bot.",
     "user": {
@@ -27,9 +35,13 @@
   },
   {
     "id": 700,
+    "pull_request_review_id": 30,
     "path": "internal/handler.go",
     "start_line": 10,
+    "original_start_line": 10,
     "line": 12,
+    "original_line": 12,
+    "subject_type": "line",
     "position": 4,
     "body": "Bot finding: unchecked error.",
     "user": {

--- a/internal/scm/github/testdata/comments_bot_outdated.json
+++ b/internal/scm/github/testdata/comments_bot_outdated.json
@@ -1,10 +1,14 @@
 [
   {
     "id": 500,
+    "pull_request_review_id": 50,
     "path": "internal/auth.go",
     "start_line": null,
-    "line": 42,
-    "position": null,
+    "original_start_line": null,
+    "line": null,
+    "original_line": 42,
+    "position": 1,
+    "subject_type": "line",
     "body": "Unused variable detected by linter.",
     "user": {
       "login": "golangci-lint[bot]",

--- a/internal/scm/github/testdata/comments_inline.json
+++ b/internal/scm/github/testdata/comments_inline.json
@@ -1,9 +1,13 @@
 [
   {
     "id": 100,
+    "pull_request_review_id": 20,
     "path": "internal/handler.go",
     "start_line": 10,
+    "original_start_line": 10,
     "line": 12,
+    "original_line": 12,
+    "subject_type": "line",
     "position": 5,
     "body": "This function is too long. Please extract a helper.",
     "user": {

--- a/internal/scm/github/testdata/comments_outdated.json
+++ b/internal/scm/github/testdata/comments_outdated.json
@@ -1,10 +1,14 @@
 [
   {
     "id": 200,
+    "pull_request_review_id": 20,
     "path": "internal/old.go",
     "start_line": null,
-    "line": 5,
-    "position": null,
+    "original_start_line": null,
+    "line": null,
+    "original_line": 5,
+    "position": 1,
+    "subject_type": "line",
     "body": "This comment refers to outdated code.",
     "user": {
       "login": "alice",

--- a/internal/scm/github/testdata/comments_page1.json
+++ b/internal/scm/github/testdata/comments_page1.json
@@ -1,9 +1,13 @@
 [
   {
     "id": 300,
+    "pull_request_review_id": 20,
     "path": "cmd/main.go",
     "start_line": null,
+    "original_start_line": null,
     "line": 20,
+    "original_line": 20,
+    "subject_type": "line",
     "position": 3,
     "body": "First page comment.",
     "user": {

--- a/internal/scm/github/testdata/comments_page2.json
+++ b/internal/scm/github/testdata/comments_page2.json
@@ -1,9 +1,13 @@
 [
   {
     "id": 301,
+    "pull_request_review_id": 20,
     "path": "cmd/main.go",
     "start_line": null,
+    "original_start_line": null,
     "line": 35,
+    "original_line": 35,
+    "subject_type": "line",
     "position": 7,
     "body": "Second page comment.",
     "user": {

--- a/internal/scm/github/testdata/comments_reviews_paginated.json
+++ b/internal/scm/github/testdata/comments_reviews_paginated.json
@@ -1,0 +1,36 @@
+[
+  {
+    "id": 300,
+    "pull_request_review_id": 11,
+    "path": "cmd/main.go",
+    "start_line": null,
+    "original_start_line": null,
+    "line": 20,
+    "original_line": 20,
+    "position": 3,
+    "subject_type": "line",
+    "body": "First review comment.",
+    "user": {
+      "login": "alice",
+      "type": "User"
+    },
+    "created_at": "2026-04-01T10:10:00Z"
+  },
+  {
+    "id": 301,
+    "pull_request_review_id": 12,
+    "path": "cmd/main.go",
+    "start_line": null,
+    "original_start_line": null,
+    "line": 35,
+    "original_line": 35,
+    "position": 7,
+    "subject_type": "line",
+    "body": "Second review comment.",
+    "user": {
+      "login": "bob",
+      "type": "User"
+    },
+    "created_at": "2026-04-01T11:10:00Z"
+  }
+]

--- a/internal/scm/github/testdata/comments_user_allowlisted.json
+++ b/internal/scm/github/testdata/comments_user_allowlisted.json
@@ -1,9 +1,13 @@
 [
   {
     "id": 600,
+    "pull_request_review_id": 60,
     "path": "internal/handler.go",
     "start_line": 5,
+    "original_start_line": 5,
     "line": 7,
+    "original_line": 7,
+    "subject_type": "line",
     "position": 2,
     "body": "Trailing whitespace detected.",
     "user": {

--- a/internal/scm/github/testdata/review_comments_legacy_live_pr649.json
+++ b/internal/scm/github/testdata/review_comments_legacy_live_pr649.json
@@ -1,0 +1,126 @@
+[
+  {
+    "id": 3585411603,
+    "node_id": "PRRC_kwDORpXKYc7VtQoT",
+    "url": "https://api.github.com/repos/sortie-ai/sortie/pulls/comments/3585411603",
+    "pull_request_review_id": 4702010051,
+    "diff_hunk": "@@ -143,15 +144,183 @@ func NewGiteaAdapter(config map[string]any) (domain.TrackerAdapter, error) {\n \t\treturn nil, err\n \t}\n \n-\treturn &GiteaAdapter{\n+\traw, _ := config[\"query_filter\"].(string)\n+\tfilter, err := parseGiteaQueryFilter(raw)\n+\tif err != nil {\n+\t\treturn nil, err\n+\t}",
+    "path": "internal/scm/gitea/gitea.go",
+    "position": 17,
+    "original_position": 17,
+    "commit_id": "8fff6e3a0535ea0dcefb5938b37a5643566f723b",
+    "user": {
+      "login": "Copilot",
+      "id": 175728472,
+      "node_id": "BOT_kgDOCnlnWA",
+      "avatar_url": "https://avatars.githubusercontent.com/in/946600?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/Copilot",
+      "html_url": "https://github.com/apps/copilot-pull-request-reviewer",
+      "followers_url": "https://api.github.com/users/Copilot/followers",
+      "following_url": "https://api.github.com/users/Copilot/following{/other_user}",
+      "gists_url": "https://api.github.com/users/Copilot/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/Copilot/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/Copilot/subscriptions",
+      "organizations_url": "https://api.github.com/users/Copilot/orgs",
+      "repos_url": "https://api.github.com/users/Copilot/repos",
+      "events_url": "https://api.github.com/users/Copilot/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/Copilot/received_events",
+      "type": "Bot",
+      "user_view_type": "public",
+      "site_admin": false
+    },
+    "body": "`query_filter` is read with a bare type assertion (`raw, _ := ....(string)`), so a mis-typed config value (e.g. YAML map/number via templating or env indirection mistakes) is silently treated as \"unset\" instead of failing fast like other config keys. This can widen candidate polling unexpectedly.",
+    "created_at": "2026-07-15T07:47:51Z",
+    "updated_at": "2026-07-15T07:47:53Z",
+    "html_url": "https://github.com/sortie-ai/sortie/pull/649#discussion_r3585411603",
+    "pull_request_url": "https://api.github.com/repos/sortie-ai/sortie/pulls/649",
+    "author_association": "NONE",
+    "_links": {
+      "self": {
+        "href": "https://api.github.com/repos/sortie-ai/sortie/pulls/comments/3585411603"
+      },
+      "html": {
+        "href": "https://github.com/sortie-ai/sortie/pull/649#discussion_r3585411603"
+      },
+      "pull_request": {
+        "href": "https://api.github.com/repos/sortie-ai/sortie/pulls/649"
+      }
+    },
+    "original_commit_id": "772b6ff7812d03b02dae5ded0fc2d456342d201f",
+    "reactions": {
+      "url": "https://api.github.com/repos/sortie-ai/sortie/pulls/comments/3585411603/reactions",
+      "total_count": 0,
+      "+1": 0,
+      "-1": 0,
+      "laugh": 0,
+      "hooray": 0,
+      "confused": 0,
+      "heart": 0,
+      "rocket": 0,
+      "eyes": 0
+    }
+  },
+  {
+    "id": 3585411671,
+    "node_id": "PRRC_kwDORpXKYc7VtQpX",
+    "url": "https://api.github.com/repos/sortie-ai/sortie/pulls/comments/3585411671",
+    "pull_request_review_id": 4702010051,
+    "diff_hunk": "@@ -539,6 +674,149 @@ func TestFetchCandidateIssues(t *testing.T) {\n \t\t_, err := a.FetchCandidateIssues(context.Background())\n \t\tassertTrackerErrorKind(t, err, domain.ErrTrackerAuth)\n \t})\n+\n+\tt.Run(\"operator query_filter merges into the request params\", func(t *testing.T) {\n+\t\tt.Parallel()\n+\n+\t\tmux := newPreflightMux(t)\n+\t\tvar gotQuery url.Values\n+\t\tmux.HandleFunc(\"GET /api/v1/repos/\"+testOwner+\"/\"+testRepo+\"/issues\", func(w http.ResponseWriter, r *http.Request) {\n+\t\t\tgotQuery = r.URL.Query()\n+\t\t\tw.WriteHeader(http.StatusOK)\n+\t\t\tw.Write(loadFixture(t, \"issues_candidates_page2.json\")) //nolint:errcheck // test helper\n+\t\t})\n+\t\tsrv := httptest.NewServer(mux)\n+\t\tdefer srv.Close()\n+\n+\t\tcfg := validConfig(srv.URL)\n+\t\tcfg[\"query_filter\"] = \"assigned_by=hermes-bot\"\n+\t\tadapter, err := NewGiteaAdapter(cfg)\n+\t\tif err != nil {\n+\t\t\tt.Fatalf(\"NewGiteaAdapter: %v\", err)\n+\t\t}\n+\n+\t\tissues, err := adapter.(*GiteaAdapter).FetchCandidateIssues(context.Background())\n+\t\tif err != nil {\n+\t\t\tt.Fatalf(\"FetchCandidateIssues: %v\", err)\n+\t\t}\n+\n+\t\tassertQueryParams(t, \"candidate\", gotQuery, map[string]string{",
+    "path": "internal/scm/gitea/gitea_test.go",
+    "position": 1,
+    "original_position": 192,
+    "commit_id": "772b6ff7812d03b02dae5ded0fc2d456342d201f",
+    "user": {
+      "login": "Copilot",
+      "id": 175728472,
+      "node_id": "BOT_kgDOCnlnWA",
+      "avatar_url": "https://avatars.githubusercontent.com/in/946600?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/Copilot",
+      "html_url": "https://github.com/apps/copilot-pull-request-reviewer",
+      "followers_url": "https://api.github.com/users/Copilot/followers",
+      "following_url": "https://api.github.com/users/Copilot/following{/other_user}",
+      "gists_url": "https://api.github.com/users/Copilot/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/Copilot/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/Copilot/subscriptions",
+      "organizations_url": "https://api.github.com/users/Copilot/orgs",
+      "repos_url": "https://api.github.com/users/Copilot/repos",
+      "events_url": "https://api.github.com/users/Copilot/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/Copilot/received_events",
+      "type": "Bot",
+      "user_view_type": "public",
+      "site_admin": false
+    },
+    "body": "`gotQuery` is written by the httptest server goroutine and read later by the test goroutine without synchronization, which can trip `-race`. Use a channel (or mutex) to synchronize passing the captured query back to the test goroutine.",
+    "created_at": "2026-07-15T07:47:52Z",
+    "updated_at": "2026-07-15T07:47:53Z",
+    "html_url": "https://github.com/sortie-ai/sortie/pull/649#discussion_r3585411671",
+    "pull_request_url": "https://api.github.com/repos/sortie-ai/sortie/pulls/649",
+    "author_association": "NONE",
+    "_links": {
+      "self": {
+        "href": "https://api.github.com/repos/sortie-ai/sortie/pulls/comments/3585411671"
+      },
+      "html": {
+        "href": "https://github.com/sortie-ai/sortie/pull/649#discussion_r3585411671"
+      },
+      "pull_request": {
+        "href": "https://api.github.com/repos/sortie-ai/sortie/pulls/649"
+      }
+    },
+    "original_commit_id": "772b6ff7812d03b02dae5ded0fc2d456342d201f",
+    "reactions": {
+      "url": "https://api.github.com/repos/sortie-ai/sortie/pulls/comments/3585411671/reactions",
+      "total_count": 0,
+      "+1": 0,
+      "-1": 0,
+      "laugh": 0,
+      "hooray": 0,
+      "confused": 0,
+      "heart": 0,
+      "rocket": 0,
+      "eyes": 0
+    }
+  }
+]

--- a/internal/scm/github/testdata/review_comments_live_pr649.json
+++ b/internal/scm/github/testdata/review_comments_live_pr649.json
@@ -1,0 +1,140 @@
+[
+  {
+    "url": "https://api.github.com/repos/sortie-ai/sortie/pulls/comments/3585411603",
+    "pull_request_review_id": 4702010051,
+    "id": 3585411603,
+    "node_id": "PRRC_kwDORpXKYc7VtQoT",
+    "diff_hunk": "@@ -143,15 +144,183 @@ func NewGiteaAdapter(config map[string]any) (domain.TrackerAdapter, error) {\n \t\treturn nil, err\n \t}\n \n-\treturn &GiteaAdapter{\n+\traw, _ := config[\"query_filter\"].(string)\n+\tfilter, err := parseGiteaQueryFilter(raw)\n+\tif err != nil {\n+\t\treturn nil, err\n+\t}",
+    "path": "internal/scm/gitea/gitea.go",
+    "commit_id": "8fff6e3a0535ea0dcefb5938b37a5643566f723b",
+    "original_commit_id": "772b6ff7812d03b02dae5ded0fc2d456342d201f",
+    "user": {
+      "login": "Copilot",
+      "id": 175728472,
+      "node_id": "BOT_kgDOCnlnWA",
+      "avatar_url": "https://avatars.githubusercontent.com/in/946600?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/Copilot",
+      "html_url": "https://github.com/apps/copilot-pull-request-reviewer",
+      "followers_url": "https://api.github.com/users/Copilot/followers",
+      "following_url": "https://api.github.com/users/Copilot/following{/other_user}",
+      "gists_url": "https://api.github.com/users/Copilot/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/Copilot/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/Copilot/subscriptions",
+      "organizations_url": "https://api.github.com/users/Copilot/orgs",
+      "repos_url": "https://api.github.com/users/Copilot/repos",
+      "events_url": "https://api.github.com/users/Copilot/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/Copilot/received_events",
+      "type": "Bot",
+      "user_view_type": "public",
+      "site_admin": false
+    },
+    "body": "`query_filter` is read with a bare type assertion (`raw, _ := ....(string)`), so a mis-typed config value (e.g. YAML map/number via templating or env indirection mistakes) is silently treated as \"unset\" instead of failing fast like other config keys. This can widen candidate polling unexpectedly.",
+    "created_at": "2026-07-15T07:47:51Z",
+    "updated_at": "2026-07-15T07:47:53Z",
+    "html_url": "https://github.com/sortie-ai/sortie/pull/649#discussion_r3585411603",
+    "pull_request_url": "https://api.github.com/repos/sortie-ai/sortie/pulls/649",
+    "_links": {
+      "self": {
+        "href": "https://api.github.com/repos/sortie-ai/sortie/pulls/comments/3585411603"
+      },
+      "html": {
+        "href": "https://github.com/sortie-ai/sortie/pull/649#discussion_r3585411603"
+      },
+      "pull_request": {
+        "href": "https://api.github.com/repos/sortie-ai/sortie/pulls/649"
+      }
+    },
+    "reactions": {
+      "url": "https://api.github.com/repos/sortie-ai/sortie/pulls/comments/3585411603/reactions",
+      "total_count": 0,
+      "+1": 0,
+      "-1": 0,
+      "laugh": 0,
+      "hooray": 0,
+      "confused": 0,
+      "heart": 0,
+      "rocket": 0,
+      "eyes": 0
+    },
+    "start_line": 147,
+    "original_start_line": 147,
+    "start_side": "RIGHT",
+    "line": 151,
+    "original_line": 151,
+    "side": "RIGHT",
+    "author_association": "NONE",
+    "original_position": 17,
+    "position": 17,
+    "subject_type": "line"
+  },
+  {
+    "url": "https://api.github.com/repos/sortie-ai/sortie/pulls/comments/3585411671",
+    "pull_request_review_id": 4702010051,
+    "id": 3585411671,
+    "node_id": "PRRC_kwDORpXKYc7VtQpX",
+    "diff_hunk": "@@ -539,6 +674,149 @@ func TestFetchCandidateIssues(t *testing.T) {\n \t\t_, err := a.FetchCandidateIssues(context.Background())\n \t\tassertTrackerErrorKind(t, err, domain.ErrTrackerAuth)\n \t})\n+\n+\tt.Run(\"operator query_filter merges into the request params\", func(t *testing.T) {\n+\t\tt.Parallel()\n+\n+\t\tmux := newPreflightMux(t)\n+\t\tvar gotQuery url.Values\n+\t\tmux.HandleFunc(\"GET /api/v1/repos/\"+testOwner+\"/\"+testRepo+\"/issues\", func(w http.ResponseWriter, r *http.Request) {\n+\t\t\tgotQuery = r.URL.Query()\n+\t\t\tw.WriteHeader(http.StatusOK)\n+\t\t\tw.Write(loadFixture(t, \"issues_candidates_page2.json\")) //nolint:errcheck // test helper\n+\t\t})\n+\t\tsrv := httptest.NewServer(mux)\n+\t\tdefer srv.Close()\n+\n+\t\tcfg := validConfig(srv.URL)\n+\t\tcfg[\"query_filter\"] = \"assigned_by=hermes-bot\"\n+\t\tadapter, err := NewGiteaAdapter(cfg)\n+\t\tif err != nil {\n+\t\t\tt.Fatalf(\"NewGiteaAdapter: %v\", err)\n+\t\t}\n+\n+\t\tissues, err := adapter.(*GiteaAdapter).FetchCandidateIssues(context.Background())\n+\t\tif err != nil {\n+\t\t\tt.Fatalf(\"FetchCandidateIssues: %v\", err)\n+\t\t}\n+\n+\t\tassertQueryParams(t, \"candidate\", gotQuery, map[string]string{",
+    "path": "internal/scm/gitea/gitea_test.go",
+    "commit_id": "772b6ff7812d03b02dae5ded0fc2d456342d201f",
+    "original_commit_id": "772b6ff7812d03b02dae5ded0fc2d456342d201f",
+    "user": {
+      "login": "Copilot",
+      "id": 175728472,
+      "node_id": "BOT_kgDOCnlnWA",
+      "avatar_url": "https://avatars.githubusercontent.com/in/946600?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/Copilot",
+      "html_url": "https://github.com/apps/copilot-pull-request-reviewer",
+      "followers_url": "https://api.github.com/users/Copilot/followers",
+      "following_url": "https://api.github.com/users/Copilot/following{/other_user}",
+      "gists_url": "https://api.github.com/users/Copilot/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/Copilot/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/Copilot/subscriptions",
+      "organizations_url": "https://api.github.com/users/Copilot/orgs",
+      "repos_url": "https://api.github.com/users/Copilot/repos",
+      "events_url": "https://api.github.com/users/Copilot/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/Copilot/received_events",
+      "type": "Bot",
+      "user_view_type": "public",
+      "site_admin": false
+    },
+    "body": "`gotQuery` is written by the httptest server goroutine and read later by the test goroutine without synchronization, which can trip `-race`. Use a channel (or mutex) to synchronize passing the captured query back to the test goroutine.",
+    "created_at": "2026-07-15T07:47:52Z",
+    "updated_at": "2026-07-15T07:47:53Z",
+    "html_url": "https://github.com/sortie-ai/sortie/pull/649#discussion_r3585411671",
+    "pull_request_url": "https://api.github.com/repos/sortie-ai/sortie/pulls/649",
+    "_links": {
+      "self": {
+        "href": "https://api.github.com/repos/sortie-ai/sortie/pulls/comments/3585411671"
+      },
+      "html": {
+        "href": "https://github.com/sortie-ai/sortie/pull/649#discussion_r3585411671"
+      },
+      "pull_request": {
+        "href": "https://api.github.com/repos/sortie-ai/sortie/pulls/649"
+      }
+    },
+    "reactions": {
+      "url": "https://api.github.com/repos/sortie-ai/sortie/pulls/comments/3585411671/reactions",
+      "total_count": 0,
+      "+1": 0,
+      "-1": 0,
+      "laugh": 0,
+      "hooray": 0,
+      "confused": 0,
+      "heart": 0,
+      "rocket": 0,
+      "eyes": 0
+    },
+    "start_line": null,
+    "original_start_line": 681,
+    "start_side": "RIGHT",
+    "line": null,
+    "original_line": 703,
+    "side": "RIGHT",
+    "author_association": "NONE",
+    "original_position": 192,
+    "position": 1,
+    "subject_type": "line"
+  }
+]

--- a/internal/scm/github/testdata/reviews_changes_requested_with_body.json
+++ b/internal/scm/github/testdata/reviews_changes_requested_with_body.json
@@ -1,6 +1,6 @@
 [
   {
-    "id": 10,
+    "id": 20,
     "state": "CHANGES_REQUESTED",
     "body": "Please fix these issues before merging.",
     "user": {

--- a/internal/scm/github/testdata/reviews_live_pr649.json
+++ b/internal/scm/github/testdata/reviews_live_pr649.json
@@ -1,0 +1,42 @@
+[
+  {
+    "id": 4702010051,
+    "node_id": "PRR_kwDORpXKYc8AAAABGEL6ww",
+    "user": {
+      "login": "copilot-pull-request-reviewer[bot]",
+      "id": 175728472,
+      "node_id": "BOT_kgDOCnlnWA",
+      "avatar_url": "https://avatars.githubusercontent.com/in/946600?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/copilot-pull-request-reviewer%5Bbot%5D",
+      "html_url": "https://github.com/apps/copilot-pull-request-reviewer",
+      "followers_url": "https://api.github.com/users/copilot-pull-request-reviewer%5Bbot%5D/followers",
+      "following_url": "https://api.github.com/users/copilot-pull-request-reviewer%5Bbot%5D/following{/other_user}",
+      "gists_url": "https://api.github.com/users/copilot-pull-request-reviewer%5Bbot%5D/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/copilot-pull-request-reviewer%5Bbot%5D/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/copilot-pull-request-reviewer%5Bbot%5D/subscriptions",
+      "organizations_url": "https://api.github.com/users/copilot-pull-request-reviewer%5Bbot%5D/orgs",
+      "repos_url": "https://api.github.com/users/copilot-pull-request-reviewer%5Bbot%5D/repos",
+      "events_url": "https://api.github.com/users/copilot-pull-request-reviewer%5Bbot%5D/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/copilot-pull-request-reviewer%5Bbot%5D/received_events",
+      "type": "Bot",
+      "user_view_type": "public",
+      "site_admin": false
+    },
+    "body": "## Pull request overview\n\nCopilot reviewed 6 out of 6 changed files in this pull request and generated 8 comments.\n\n\n\n\n",
+    "state": "COMMENTED",
+    "html_url": "https://github.com/sortie-ai/sortie/pull/649#pullrequestreview-4702010051",
+    "pull_request_url": "https://api.github.com/repos/sortie-ai/sortie/pulls/649",
+    "author_association": "NONE",
+    "_links": {
+      "html": {
+        "href": "https://github.com/sortie-ai/sortie/pull/649#pullrequestreview-4702010051"
+      },
+      "pull_request": {
+        "href": "https://api.github.com/repos/sortie-ai/sortie/pulls/649"
+      }
+    },
+    "submitted_at": "2026-07-15T07:47:53Z",
+    "commit_id": "772b6ff7812d03b02dae5ded0fc2d456342d201f"
+  }
+]


### PR DESCRIPTION
Closes #776.

GitHub's review-scoped comments endpoint returns legacy objects without current or original line fields, so both human and bot inline feedback reached the agent with zero locations.

This changes both paths to read the PR-scoped comments feed once and group comments by review. Location normalization is shared: current comments use `start_line` and `line`, outdated comments fall back to `original_start_line` and `original_line`, and outdated detection no longer relies on the retiring `position` field. PR-level review bodies keep zero locations.

Added fixtures captured from live sortie-ai/sortie PR #649 responses for both endpoint shapes. They cover a current multi-line comment, an outdated multi-line comment with a non-null `position`, and the PR-level review body.

Tested with `make fmt`, `make lint`, `make test PKG='./internal/scm/github/... ./internal/orchestrator/...'`, and `make build`.
