### PR TITLE
docs: specify withheld handoff behavior

### DIFF
--- a/docs/architecture/06-configuration-specification.md
+++ b/docs/architecture/06-configuration-specification.md
@@ -48,6 +48,11 @@ Dynamic reload is required:
   kind is active at all, takes effect only on the next restart (Section 11G.3). The CI-failure kind
   is the one carve-out: its configuration is folded into the CI feedback block, which reconciliation
   re-reads from the current snapshot on every tick, so its fields do reload.
+- Primary-dispatch parking after repeated withheld handoffs takes its label name from the captured
+  `reactions.review_comments.escalation_label` value. This is a name lookup only: it does not require
+  the review-comments reaction to be enabled and does not inherit that reaction's `escalation`
+  action. Because the source value is reaction configuration, changing it takes effect only after a
+  restart as well.
 - Reloaded config applies to future dispatch, retry scheduling, reconciliation decisions, hook
   execution, and agent launches.
 - In-flight agent sessions are not restarted automatically when config changes.
@@ -92,6 +97,9 @@ Validation checks:
   state lists. An empty `tracker.active_states` or `tracker.terminal_states` takes the tracker
   adapter's declared fallback list, so a collision the config layer cannot see (because it rules
   on the lists as written) is reported here.
+- `tracker.handoff_evidence` is validated while configuration is parsed as the closed set
+  `observed`, `strict`, and `off`. This is a shape check and never contacts the tracker, so the same
+  invalid value is rejected by startup, reload, and `sortie validate`.
 - `reactions.merge_completion.target_state`, checked once at construction against
   `tracker.handoff_state`, `tracker.active_states`, and `tracker.terminal_states`: required and
   non-empty when `reactions.merge_completion.provider` is set, must not equal
@@ -180,10 +188,18 @@ This section is intentionally redundant so a coding agent can implement the conf
   default terminal-state list in that case
 - `tracker.query_filter`: string, optional, default empty (adapter-defined filter fragment)
 - `tracker.handoff_state`: string, optional, default absent; target state for
-  orchestrator-initiated handoff after successful worker run; must not collide with
+  orchestrator-initiated handoff after a worker run whose exit disposition and handoff-evidence
+  policy permit the write; must not collide with
   `active_states` or `terminal_states`, evaluated against the effective lists, so the tracker
   adapter's fallback participates whenever the matching field is empty; required, non-empty, when
   `reactions.merge_completion.provider` is set; supports `$VAR`
+- `tracker.handoff_evidence`: string, default `observed`; policy governing the evidence condition
+  on an otherwise-eligible handoff. `observed` withholds only when absence of work is positively
+  observed and allows an undeterminable verdict; `strict` also withholds an undeterminable verdict;
+  `off` restores the prior four-condition decision and performs no baseline capture, exit-time
+  workspace inspection, or evidence logging. Values outside `observed`, `strict`, and `off` are
+  rejected offline. The policy is frozen for each run before its baseline decision, so a reload
+  applies to future run launches and does not change an in-flight run's evidence contract
 - `tracker.in_progress_state`: string, optional, default absent; target state for
   dispatch-time transition at the start of each worker attempt; must be in `active_states`,
   must not collide with `terminal_states` or `handoff_state`, and the `terminal_states` rule is
@@ -224,7 +240,12 @@ This section is intentionally redundant so a coding agent can implement the conf
 - `agent.max_turns`: integer, default `20`
 - `agent.max_retry_backoff_ms`: integer, default `300000` (5m)
 - `agent.max_concurrent_agents_by_state`: map of positive integers, default `{}`
-- `agent.max_sessions`: integer, default `0` (unlimited)
+- `agent.max_sessions`: non-negative integer, default `0` (unlimited for the existing total
+  per-issue session budget). A positive value is also the ceiling on the **total count** of
+  consecutive handoff absences, not a retry count. For that safety ceiling only, `0` derives the
+  finite value `3`: the first observed absence may be followed by two retry dispatches, and the
+  third consecutive absence parks the issue. This does not make the ordinary total-session budget
+  finite. Any run on which work is observed resets the consecutive-absence count to zero
 - `agent.max_tokens`: integer, default `0` (unlimited)
 - `ci_feedback.kind`: string, optional, **deprecated**; identifies the CI status provider adapter;
   presence activates CI feedback; use `reactions.ci_failure` instead
@@ -238,7 +259,12 @@ This section is intentionally redundant so a coding agent can implement the conf
 - `reactions.<kind>.provider`: string, optional; adapter identifier; absent = disabled
 - `reactions.<kind>.max_retries`: integer, default `2`; fix continuation attempts before escalation
 - `reactions.<kind>.escalation`: string, default `label`; `label` or `comment`
-- `reactions.<kind>.escalation_label`: string, default `needs-human`
+- `reactions.<kind>.escalation_label`: string, default `needs-human`. Primary-dispatch parking uses
+  the resolved non-empty `reactions.review_comments.escalation_label`; when that block or value is
+  absent or empty it uses `needs-human`. The lookup ignores
+  `reactions.review_comments.provider`, ignores whether its `escalation` value is `label` or
+  `comment`, and never falls through to another reaction kind's label. The primary path always
+  parks by label; it borrows only this label name and no other review-reaction behavior
 - `reactions.review_comments.poll_interval_ms`: integer, default `120000` (2 min); minimum `30000`
 - `reactions.review_comments.debounce_ms`: integer, default `60000` (60 sec); non-negative
 - `reactions.review_comments.max_continuation_turns`: integer, default `3`; positive
@@ -283,4 +309,3 @@ This section is intentionally redundant so a coding agent can implement the conf
   required
 - `db_path`: path, default `.sortie.db` next to `WORKFLOW.md`; supports `$VAR` and `~`
   expansion; requires restart to take effect
-

--- a/docs/architecture/06-configuration-specification.md
+++ b/docs/architecture/06-configuration-specification.md
@@ -241,8 +241,8 @@ This section is intentionally redundant so a coding agent can implement the conf
 - `agent.max_retry_backoff_ms`: integer, default `300000` (5m)
 - `agent.max_concurrent_agents_by_state`: map of positive integers, default `{}`
 - `agent.max_sessions`: non-negative integer, default `0` (unlimited for the existing total
-  per-issue session budget). A positive value is also the ceiling on the **total count** of
-  consecutive handoff absences, not a retry count. For that safety ceiling only, `0` derives the
+  per-issue session budget). A positive value is also the ceiling on the **consecutive-absence
+  count**, not a retry count. For that safety ceiling only, `0` derives the
   finite value `3`: the first observed absence may be followed by two retry dispatches, and the
   third consecutive absence parks the issue. This does not make the ordinary total-session budget
   finite. Any run on which work is observed resets the consecutive-absence count to zero

--- a/docs/architecture/07-orchestration-state-machine.md
+++ b/docs/architecture/07-orchestration-state-machine.md
@@ -72,8 +72,11 @@ Distinct terminal reasons are important because retry logic and logs differ.
     (via `tracker.in_progress_state`) as their first step, before workspace preparation.
 
 - `Worker Exit (normal)`
-  - Unconditional steps, taken on every normal exit: remove the running entry, update aggregate
-    runtime totals, and persist the completed run attempt to SQLite.
+  - Unconditional steps, taken on every normal exit: remove the running entry and update aggregate
+    runtime totals. Every exit also persists exactly one completed run attempt to SQLite after any
+    handoff-evidence verdict needed for its status is known and before scheduling a retry. The normal
+    exit-kind mapping supplies the status unless the policy withholds the transition; that outcome
+    records `failed` with the evidence verdict named as the cause (§19.2).
   - The exit then takes exactly one disposition. The conditions are evaluated in the order below
     and the first match wins, so an earlier disposition overrides every later one:
 
@@ -85,12 +88,28 @@ Distinct terminal reasons are important because retry logic and logs differ.
        cancel any pending retry, and release the claim. A terminal state is a decision already
        made about this issue; overwriting it with the handoff state would undo it.
     3. A handoff state is configured, the issue is still in an active state, the exit is not a
-       blocked soft stop, and the dispatch drives issue state. Perform the handoff transition
-       (Section 11.5). On a successful transition, release the claim, unless the retry slot
-       (Section 7.5) is occupied by an incumbent, in which case the incumbent is kept and the
-       claim stays so the poll loop cannot clear it. On transition failure, a soft-stop exit
-       releases the claim; a non-soft-stop exit schedules the continuation retry instead, unless
-       the retry slot is already occupied, in which case the exit defers to the incumbent.
+       blocked soft stop, and the dispatch drives issue state. Only where all four conditions hold,
+       apply the run's frozen `tracker.handoff_evidence` policy as a fifth condition:
+       - Under `off`, compute no verdict and preserve the previous handoff behavior.
+       - `Work observed` permits the handoff. It also resets the issue's consecutive-absence count
+         to zero immediately, even if the later tracker write fails.
+       - `Absence of work observed` withholds the handoff.
+       - `Evidence not determinable` permits the handoff under `observed` and withholds it under
+         `strict`, where it is treated as an absence for the failure disposition and consecutive
+         count. The verdict is recorded in either policy.
+
+       A verdict that permits the write performs the handoff transition (Section 11.5). On a
+       successful transition, release the claim, unless the retry slot (Section 7.5) is occupied by
+       an incumbent, in which case the incumbent is kept and the claim stays so the poll loop cannot
+       clear it. On transition failure, a soft-stop exit releases the claim; a non-soft-stop exit
+       schedules the continuation retry instead, unless the retry slot is already occupied, in which
+       case the exit defers to the incumbent.
+
+       A verdict that withholds the write makes no tracker transition and leaves the issue in its
+       active state. Record the unsuccessful attempt, increment the consecutive-absence count, and
+       use the ordinary failure path with exponential backoff and retry-slot arbitration—not the
+       short continuation path. When the count reaches its ceiling, park the issue and stop the
+       sequence as specified in §14.2.
     4. Any other soft stop. Suppress the continuation retry, cancel any pending retry, and release
        the claim. An unrecognized soft-stop reason is logged before taking this path.
     5. The issue is still in an active state and the dispatch drives issue state. Schedule the
@@ -229,4 +248,3 @@ Two liveness bounds keep an arbitrated slot from being held for the process life
   carries an active timer handle, and re-arms it with a zero delay, changing nothing about the
   entry but its timer. A retry reconstructed at startup and still awaiting its first activation is
   excluded from this pass, so a restart alone never produces the re-arm warning.
-

--- a/docs/architecture/09-workspace-management-and-safety.md
+++ b/docs/architecture/09-workspace-management-and-safety.md
@@ -119,6 +119,35 @@ Hook environment variables available only to `after_run`:
 - `SORTIE_SELF_REVIEW_SUMMARY_PATH`: absolute path to `.sortie/review_summary.md` in
   the workspace. Absent when self-review did not run or summary was not written.
 
+#### 9.4.1 Handoff Evidence Baseline
+
+For a run whose frozen `tracker.handoff_evidence` policy is `observed` or `strict`, the
+orchestrator captures a workspace baseline at the boundary between preparation and agent launch:
+after directory creation/reuse, population, and the applicable pre-run hooks have finished, and
+before `StartSession` can begin agent work. Both the full preparation path and the ensure-only path
+must reach this boundary. Under `off`, no baseline is captured.
+
+The baseline records the workspace's committed position and enough working-tree state to determine
+later whether that state changed. Evidence is a difference from this baseline, not a property of the
+tree at exit:
+
+- A moved committed position or a working-tree state that differs from the baseline is work
+  observed.
+- Workspace SCM metadata naming a pushed commit or pull request for the issue is also work observed,
+  even when an earlier run wrote that metadata. Per-issue workspaces are reused, so this positive
+  signal prevents a later no-op run from stranding work that was already pushed.
+- When no positive signal holds, a successful inspection against a baseline is absence of work
+  observed. A missing baseline, a non-version-controlled workspace, a failed inspection, or no
+  recorded workspace yields evidence not determinable instead.
+
+No particular source-control command or baseline representation is prescribed. The contract must
+distinguish pre-existing uncommitted state from changes made by this run and must recognize a commit
+created by `after_run` even when that hook leaves the tree clean.
+
+The `after_run` contract itself is unchanged. Its failure remains logged and ignored, and its exit
+status has no vote in the handoff disposition. Any files, commits, pushes, or SCM metadata the hook
+produces are visible only through the same workspace evidence rules as other run output.
+
 ### 9.5 Workspace SCM metadata (`.sortie/scm.json`)
 
 The `.sortie/scm.json` file is a workspace-level file that carries SCM metadata written by the
@@ -203,4 +232,3 @@ fingerprint write, and no creation or deletion of a pending reaction entry. Reac
 read-only to the age bound. Every removal it performs routes through the same workspace removal
 path as the terminal gate, so key sanitization, containment under the workspace root, and the
 `before_remove` hook apply unchanged. The age bound introduces no new way to reach the filesystem.
-

--- a/docs/architecture/10-agent-adapter-contract.md
+++ b/docs/architecture/10-agent-adapter-contract.md
@@ -48,6 +48,24 @@ The orchestrator interacts with an agent session as follows:
 The session handle and any session identifiers are adapter-specific. The orchestrator treats
 `session_id` as an opaque string.
 
+#### 10.2.1 Handoff-Evidence Ownership
+
+The handoff-evidence verdict belongs to the orchestrator. It is computed from the workspace baseline
+and the positive SCM signals the orchestrator already reads, after an otherwise-eligible normal
+worker exit. This decision adds no operation, event, result field, or work-classification obligation
+to the agent adapter interface.
+
+An adapter's turn disposition (§10.8) and the handoff-evidence verdict answer different questions.
+The former normalizes what one runtime reported about a turn; the latter decides whether the
+orchestrator observed durable output behind a tracker handoff. A successful adapter result, a
+non-zero completed-turn count, token usage, or a tool call is diagnostic context only and cannot by
+itself establish either work observed or absence of work.
+
+A future adapter may contribute a positive work signal. Such a signal can only change an absence or
+undeterminable case to work observed; it cannot declare absence and does not transfer ownership of
+the verdict from the orchestrator. This preserves one monotone verdict across present and future
+runtimes.
+
 ### 10.3 Normalized Event Types
 
 The orchestrator expects the following event types from any agent adapter. Adapters map their
@@ -631,4 +649,3 @@ and diverge from the rule's letter while obeying its intent:
 `turn_ended_with_error` remains a documented normalized event type (Section 10.3), reserved for a
 future adapter whose runtime genuinely distinguishes a transport-class failure from every other
 failure, even though no built-in adapter emits it today.
-

--- a/docs/architecture/11-issue-tracker-integration-contract.md
+++ b/docs/architecture/11-issue-tracker-integration-contract.md
@@ -92,14 +92,22 @@ itself observed:
 - The in-progress state (`tracker.in_progress_state`), at dispatch, when that field is
   configured and the dispatch drives issue state (§11F excludes the read-only and read-write
   label-command postures).
-- The handoff state (`tracker.handoff_state`), on a normal worker exit with the issue still in an
-  active tracker state and not a blocked soft stop, when that field is configured and the
-  dispatch drives issue state. The write is preceded by a terminal test against the freshest
-  available observation of the issue's state, and, when `tracker.terminal_states` is non-empty
-  and that observation is not already terminal, by one `fetch_issue_states_by_ids` verification
-  read immediately before the write. A terminal result from either the observation or the
-  verification read suppresses the write. With no terminal states configured no value can
-  classify as terminal, so the verification read is skipped.
+- The handoff state (`tracker.handoff_state`), on a normal worker exit when that field is configured,
+  the issue is still in an active tracker state, the exit is not a blocked soft stop, and the
+  dispatch drives issue state. Only where those four conditions already select the handoff path is
+  the run's frozen `tracker.handoff_evidence` policy consulted as a fifth condition. `Work observed`
+  permits the write; `absence of work observed` withholds it; `evidence not determinable` permits it
+  under `observed` and withholds it under `strict`; and `off` computes no verdict and preserves the
+  four-condition decision. This condition can suppress a write and can never cause one. A withheld
+  outcome makes no handoff transition or pre-write verification call, leaves the issue in its active
+  state, and follows the failure and retry disposition in §14.2.
+
+  A write that the evidence policy permits is still preceded by a terminal test against the freshest
+  available observation of the issue's state and, when `tracker.terminal_states` is non-empty and
+  that observation is not already terminal, by one `fetch_issue_states_by_ids` verification read
+  immediately before the write. A terminal result from either the observation or the verification
+  read suppresses the write. With no terminal states configured no value can classify as terminal,
+  so the verification read is skipped.
 - The merge-completion target state (`reactions.merge_completion.target_state`), when a
   Sortie-managed pull request merges while the linked issue is still parked in
   `tracker.handoff_state`, independently of who or what performed the merge. Active only when
@@ -109,8 +117,9 @@ The orchestrator writes no other tracker state. Beyond these three writes, it po
 comments and applies escalation labels, none of which carries state semantics: the dispatch
 comment (`tracker.comments.on_dispatch`), the worker-exit completion and failure comments
 (`tracker.comments.on_completion`, `tracker.comments.on_failure`), the auto-merge success comment
-(§11C), and a reaction escalation label or comment when a reaction's retry budget is exhausted or
-a non-retryable error occurs. None of these is a state transition.
+(§11C), a reaction escalation label or comment when a reaction's retry budget is exhausted or a
+non-retryable error occurs, and the primary-dispatch parking label applied when the consecutive
+handoff-absence ceiling is reached (§14.2). None of these is a state transition.
 
 Free-form ticket mutation falls outside these three writes and stays with the coding agent, which
 mutates tickets through the `tracker_api` tool subsystem (Section 10.4), part of the agent

--- a/docs/architecture/18-logging-status-and-observability.md
+++ b/docs/architecture/18-logging-status-and-observability.md
@@ -18,6 +18,19 @@ Message formatting requirements:
 - Include concise failure reason when present.
 - Avoid logging large raw payloads unless necessary.
 
+Handoff-evidence records are part of the required operator surface:
+
+- A withheld handoff emits a `Warn` record naming the verdict and carrying
+  `turns_completed` plus the resulting `consecutive_absences` count. The standard issue context
+  fields identify the affected issue.
+- An `evidence not determinable` verdict emits an `Info` record under both `observed` and `strict`,
+  carrying the policy and `turns_completed`. Under `strict`, the separate withheld warning is also
+  emitted because that policy converts the verdict into the absence disposition.
+- Parking at the consecutive-absence ceiling emits a `Warn` record carrying
+  `consecutive_absences`, `absence_ceiling`, and `escalation_label`. A failed label write is recorded
+  separately as an escalation error and does not suppress the parking record.
+- A run frozen to `tracker.handoff_evidence: off` emits none of these evidence records.
+
 The periodic workspace sweep emits exactly one summary record per pass, at `Info` level, message
 `"sweep: pass complete"`, on every pass that produced a candidate set, including a pass over zero
 keys, a pass whose tracker read failed, and a pass that removed nothing. This is deliberate: a
@@ -385,7 +398,7 @@ Defined metrics (label sets and buckets are specified here; see ADR-0008 for his
 | `sortie_poll_cycles_total{result}` | Counter | Poll tick completions, partitioned by result (`success`, `error`, `skipped`). |
 | `sortie_tracker_requests_total{operation,result}` | Counter | Tracker adapter API calls, partitioned by operation (`fetch_candidates`, `fetch_issue`, `fetch_by_states`, `fetch_states_by_ids`, `fetch_states_by_identifiers`, `fetch_comments`, `transition`, `comment`, `add_label`) and result (`success`, `error`). |
 | `sortie_tracker_comments_total{lifecycle,result}` | Counter | Tracker comment attempts, partitioned by lifecycle point (`dispatch`, `completion`, `failure`) and result (`success`, `error`). |
-| `sortie_handoff_transitions_total{result}` | Counter | Handoff-state transition attempts, partitioned by result (`success`, `error`, `skipped`). `skipped` has two causes and does not distinguish them: the issue was no longer in an active state at worker exit, or the issue was already reported terminal and the write was suppressed (Section 11.5). Both are counted only when `tracker.handoff_state` is configured. |
+| `sortie_handoff_transitions_total{result}` | Counter | Handoff-state dispositions, partitioned by result (`success`, `error`, `skipped`, `withheld`). `withheld` means the handoff-evidence policy selected the absence failure path before any transition attempt, distinguishing it from an ordinary worker failure. `skipped` retains its two earlier causes and does not distinguish them: the issue was no longer in an active state at worker exit, or the issue was already reported terminal and the write was suppressed (Section 11.5). All four values are counted only when `tracker.handoff_state` is configured. |
 | `sortie_dispatch_transitions_total{result}` | Counter | Dispatch-time in-progress transition attempts, partitioned by result (`success`, `error`, `skipped`). `skipped` indicates the issue was already in the target state. |
 | `sortie_dispatch_rule_match_total{layer,rule}` | Counter | Dispatch rule match outcomes, partitioned by resolution layer (`rule`, `default`, `fallback`) and matched rule name. Empty rule names report as `<none>` to bound label cardinality. |
 | `sortie_tool_calls_total{tool,result}` | Counter | Agent tool call completions, partitioned by tool name and result (`success`, `error`). |
@@ -401,4 +414,3 @@ Defined metrics (label sets and buckets are specified here; see ADR-0008 for his
 | `sortie_worker_duration_seconds{exit_type}` | Histogram | Worker session wall-clock time; buckets via `ExponentialBuckets(10, 2, 12)` (10 s–5.7 h). `exit_type` carries the same values as `sortie_worker_exits_total`. |
 | `sortie_self_review_verification_duration_seconds{command}` | Histogram | Per-command verification duration during self-review; buckets via `ExponentialBuckets(10, 2, 12)` (10 s–5.7 h). The `command` label is truncated to the first 64 characters. |
 | `sortie_build_info{version,go_version}` | Gauge | Always `1`; carries build metadata as labels. |
-

--- a/docs/architecture/19-failure-model-and-recovery-strategy.md
+++ b/docs/architecture/19-failure-model-and-recovery-strategy.md
@@ -38,6 +38,12 @@
    - Escalation failures (label or comment write to tracker)
    - Missing or malformed `.sortie/scm.json`
 
+7. `Handoff Evidence Failures`
+   - Absence of work observed where the four pre-existing handoff conditions otherwise permit the
+     transition
+   - Evidence not determinable under the `strict` policy, which deliberately treats that verdict as
+     an absence
+
 ### 14.2 Recovery Behavior
 
 - Dispatch validation failures:
@@ -47,6 +53,45 @@
 
 - Worker failures:
   - Convert to retries with exponential backoff.
+
+- Withheld handoff evidence:
+  - Leave the issue in its active tracker state, record the run as `failed` with the evidence verdict
+    in its error reason, and schedule the ordinary exponential-backoff failure path. Do not use the
+    fixed-delay continuation path.
+  - Maintain a count of consecutive outcomes treated as handoff absences for each issue. `Absence of
+    work observed` increments it, as does `evidence not determinable` under `strict`. A
+    `work observed` verdict resets it to zero immediately; a later handoff-write error cannot restore
+    the old count. Outcomes that provide no work-observed verdict do not pretend to reset it.
+  - Derive the consecutive-absence ceiling from `agent.max_sessions`, without adding a setting:
+    when `agent.max_sessions > 0`, use that value verbatim; when it is `0`, use `3` for this ceiling
+    only while retaining `0` as unlimited for the ordinary total-session budget. The comparison is
+    against the incremented **total absence count**, and parking occurs when `count >= ceiling`.
+    Thus the default sequence is absence `1`, retry; absence `2`, retry; absence `3`, park. It is the
+    initial run plus two retries, not three retries. A positive `agent.max_sessions` continues to
+    enforce its existing all-run effort budget independently, so whichever applicable gate is
+    reached first stops re-dispatch.
+  - The derived default of `3` follows the `max_retries: 2` default used by most reaction kinds: one
+    initial attempt plus two retries. This avoids treating one legitimate no-change conclusion as
+    immediately terminal, gives two further sessions a chance to surface work, and bounds the cost
+    of full agent sessions. Turn, tool, or model-iteration limits inside one session do not set this
+    ceiling and are not comparable to it.
+  - On reaching the ceiling, cancel this retry sequence, apply the primary-dispatch parking label,
+    and release the claim. Ceiling exhaustion is an eligibility gate rather than only a cancelled
+    timer: ordinary polling and restart recovery must not silently begin another run in the same
+    exhausted absence sequence. Its representation is an implementation detail; the rule requires
+    neither a second numeric setting nor a durable verdict column on `run_history`.
+  - The parking label is the resolved non-empty
+    `reactions.review_comments.escalation_label` captured when the orchestrator starts, or
+    `needs-human` when that block or value is absent or empty. This lookup deliberately reuses only
+    the label name: review-comments need not be enabled, `escalation: comment` does not turn primary
+    parking into a comment, and labels configured under `ci_failure`, `merge_conflicts`,
+    `auto_merge`, or any other reaction do not participate. This explicit one-way dependency keeps
+    the existing operator-visible escalation channel without creating a second configuration field.
+    `review_comments` is the source because this parking happens immediately before human review;
+    CI, merge-conflict, and auto-merge labels describe different recovery domains.
+  - Announce parking with the issue, the consecutive count, the ceiling, and the label. A label-write
+    failure follows the existing escalation-failure rule: log and count the error and keep the
+    absence sequence stopped rather than resuming an unbounded loop.
 
 - Tracker candidate-fetch failures:
   - Skip this tick.
@@ -97,9 +142,12 @@ Sortie uses SQLite persistence to improve restart recovery semantics:
 - Running sessions are not recoverable (agent subprocesses do not survive restart), but the
   orchestrator knows which issues were in-flight at shutdown and re-dispatches them immediately
   rather than waiting for the next polling cycle to discover them.
-- Pending reaction recovery reconstructs runtime reaction entries after a restart by reading each
-  candidate's workspace SCM metadata, and it considers only a candidate whose latest activity
-  falls inside its lookback window. The pass narrows in a fixed order: it first drops any candidate
+- Pending reaction recovery reconstructs runtime reaction entries after a restart from the most
+  recent `run_history` row recorded as `succeeded` for each issue and by reading that candidate's
+  workspace SCM metadata. A later handoff withheld for absence is recorded as `failed`, so it no
+  longer displaces an earlier producing run in this selection; no query-shape change is required.
+  Recovery considers only a candidate whose selected successful activity falls inside its lookback
+  window. The pass narrows in a fixed order: it first drops any candidate
   the orchestrator already holds as running, retry-queued, or claimed, then truncates what is left
   to a fixed cap on candidate issues per startup pass, and only then reads tracker state and keeps
   the candidates still sitting in the configured handoff state. Because the cap is applied before
@@ -129,4 +177,3 @@ Operators can control behavior by:
   - non-active state -> running session is stopped without cleanup
 - Restarting the service for process recovery or deployment (not as the normal path for applying
   workflow config changes).
-

--- a/docs/architecture/19-failure-model-and-recovery-strategy.md
+++ b/docs/architecture/19-failure-model-and-recovery-strategy.md
@@ -65,7 +65,7 @@
   - Derive the consecutive-absence ceiling from `agent.max_sessions`, without adding a setting:
     when `agent.max_sessions > 0`, use that value verbatim; when it is `0`, use `3` for this ceiling
     only while retaining `0` as unlimited for the ordinary total-session budget. The comparison is
-    against the incremented **total absence count**, and parking occurs when `count >= ceiling`.
+    against the incremented **consecutive-absence count**, and parking occurs when `count >= ceiling`.
     Thus the default sequence is absence `1`, retry; absence `2`, retry; absence `3`, park. It is the
     initial run plus two retries, not three retries. A positive `agent.max_sessions` continues to
     enforce its existing all-run effort budget independently, so whichever applicable gate is

--- a/docs/architecture/24-persistence-schema.md
+++ b/docs/architecture/24-persistence-schema.md
@@ -37,7 +37,7 @@ Note: `timer_handle` is runtime-only and is not stored.
 | `workspace`     | TEXT    | Workspace path                            |
 | `started_at`    | TEXT    | ISO-8601 timestamp                        |
 | `completed_at`  | TEXT    | ISO-8601 timestamp                        |
-| `status`          | TEXT    | Terminal status (succeeded, failed, etc.) |
+| `status`          | TEXT    | Run disposition (`succeeded`, `failed`, `cancelled`, or `ci_failed`) |
 | `error`           | TEXT    | Error message if failed, may be null      |
 | `workflow_file`   | TEXT    | Workflow file name the run was driven by, may be null (migration 003) |
 | `turns_completed`   | INTEGER | Agent turns the attempt completed (migration 005) |
@@ -50,6 +50,22 @@ Note: `timer_handle` is runtime-only and is not stored.
 | `total_tokens`      | INTEGER | Accumulated total tokens, 0 for pre-migration rows (migration 011) |
 | `cache_read_tokens` | INTEGER | Accumulated cache-read tokens, 0 for pre-migration rows (migration 011) |
 | `tokens_measured`   | INTEGER | `1` when the four token columns above carry a figure the coding agent's runtime reported; `0` when the run's spend is unknown and all four are zero (migration 012) |
+
+`status` is no longer a pure mapping from the worker's exit kind. A normal exit that reaches an
+otherwise-eligible handoff and is withheld by the handoff-evidence policy records `failed`; its
+`error` value names the evidence verdict as the cause. For an otherwise-normal exit on that handoff
+path, `succeeded` means the policy did not withhold it. It does not assert that work was positively
+observed: an undeterminable verdict under `observed`, and every normal exit under `off`, may still
+record `succeeded`.
+
+Rows written before this rule and rows written under `tracker.handoff_evidence: off` retain the
+earlier exit-kind-only meaning and are not rewritten. Reports spanning the change therefore span two
+definitions of `succeeded` and must not present a changed success rate as proof that agent behavior
+changed.
+
+No column stores the handoff-evidence verdict. The verdict is logged and counted, and a withheld
+run carries it in the existing `error` field. In particular, this change adds no evidence field to
+`run_history` and requires no rewrite of historical rows.
 
 A row with `tokens_measured = 0` always carries zero in all four token columns; the invariant
 runs in one direction only, because a measured run can legitimately report a zero spend. Every
@@ -133,4 +149,3 @@ than deleting it, because deleting it would let the next poll observe the same m
 - Applied migrations are tracked in a `schema_migrations` table.
 - Migrations are additive (new columns/tables) where possible; destructive migrations require
   explicit versioning.
-


### PR DESCRIPTION
### Scope & Context

**Type:** Docs

**Intent:** Bring the architecture specification into line with ADR 0020 before implementation begins. The update makes handoff evidence a fifth, suppressing condition and defines the baseline, failure disposition, bounded absence sequence, parking label, persistence meaning, and observability contract.

**Related Issues:** Closes #767; unblocks #768 and #769

### Reviewer Guide

**Complexity:** Medium

#### Entry Point

`docs/architecture/07-orchestration-state-machine.md` is the best starting point. It restates normal worker exit as the four existing handoff conditions plus the evidence policy and routes a withheld handoff to the ordinary failure path rather than the short continuation path.

#### Specification Choices

ADR 0020 leaves two details for the specification to settle.

- When `agent.max_sessions` is `0`, the consecutive-absence ceiling is three total absences: the initial run plus two retries. A single empty run can be a legitimate no-change conclusion, while most reaction kinds already use `max_retries: 2`. At the same time, each retry here is a complete agent session, so reusing an internal turn or model-iteration limit would make the default unnecessarily expensive.
- Primary-dispatch parking reuses only the name from `reactions.review_comments.escalation_label`, with `needs-human` as the fallback. This is the recovery path closest to the human-review handoff, while CI, merge-conflict, and auto-merge labels describe different failure domains. The review reaction does not need to be enabled, and its `escalation` action is not inherited.

If either interpretation conflicts with maintainer expectations or the planned implementation of #768 and #769, I’m happy to discuss it and revise the specification before those changes proceed.

#### Sensitive Areas

- `docs/architecture/19-failure-model-and-recovery-strategy.md`: `agent.max_sessions: 0` remains unlimited for the existing all-run budget but derives a total consecutive-absence ceiling of three. Positive values are reused verbatim, work observed resets the count, and exhaustion parks the issue after the initial absence plus two retries.
- `docs/architecture/06-configuration-specification.md`: primary parking borrows only `reactions.review_comments.escalation_label`, falls back to `needs-human`, and does not inherit provider enablement or `escalation: comment`.
- `docs/architecture/09-workspace-management-and-safety.md` and `docs/architecture/24-persistence-schema.md`: the baseline is captured after workspace preparation and before agent launch; withheld runs use the existing failed status and error field without adding a durable verdict column.

### Validation

- `git diff --check`
- `make lint`
- `go test -race -count=1 ./internal/orchestrator/... ./internal/config/... ./internal/persistence/...`

The full `make test` run also completed all unchanged packages except the macOS workspace cases affected by `/var` resolving to `/private/var` and `/bin/sh` printing `echo -n` literally. Copilot and Kiro canaries that timed out during the parallel run pass when rerun separately.

### Risk Assessment

- **Breaking Changes:** No runtime behavior changes in this pull request. It updates the architecture contract that #768 and #769 will implement.
- **Migrations/State:** No migrations or state changes; no durable evidence-verdict field is introduced.
