### PR TITLE
docs: rewrite adapter notes as version-pinned snapshots

### DIFF
--- a/docs/claude-code-adapter-notes.md
+++ b/docs/claude-code-adapter-notes.md
@@ -1,7 +1,14 @@
-# Claude Code CLI: Adapter Research Notes
+# Claude Code CLI: adapter research notes
 
 > Claude Code CLI v2.x (npm `@anthropic-ai/claude-code`), researched March 2026.
-> Reference for implementing the Claude Code `AgentAdapter`.
+> Reference for implementing the Claude Code `AgentAdapter`, shipped as `internal/agent/claude`.
+>
+> Coverage: the flag surface is anchored to `claude --help` on CLI v2.1.76. The `stream-json`
+> message shapes, result fields, permission modes, session storage layout, hook behavior,
+> OpenTelemetry names, and SDK surface come from Anthropic's Claude Code documentation read in
+> March 2026 and have not been re-observed against a later binary. Statements about Sortie's own
+> code name the Go symbol that implements them and were verified against the tree. Unsettled
+> items are collected under "Open questions"; sources are listed under "Sources".
 
 ---
 
@@ -10,16 +17,17 @@
 Claude Code is an agentic coding tool that runs as a Node.js process in the terminal. It reads
 a codebase, executes tools (file edits, shell commands, searches), and produces code changes
 autonomously. Sortie treats it as a subprocess: launch it with a prompt, read structured output
-from stdout, and terminate it when done.
+from stdout, and terminate it when done. The adapter registers under the agent kind
+`claude-code` in the `claude` package `init` function, with `RequiresCommand: true`.
 
-The primary integration surface is the **CLI in non-interactive ("headless") mode** using the
-`-p` (print) flag. Anthropic also provides TypeScript and Python SDKs (`@anthropic-ai/claude-agent-sdk`
+The integration surface is the **CLI in non-interactive ("headless") mode** using the `-p`
+(print) flag. Anthropic also provides TypeScript and Python SDKs (`@anthropic-ai/claude-agent-sdk`
 and `claude-agent-sdk` respectively), but Sortie's Go adapter uses the CLI subprocess approach per
 [architecture Section 10.7](architecture/10-agent-adapter-contract.md#107-local-subprocess-launch-contract) (Local Subprocess Launch Contract).
 
 ---
 
-## Installation and Prerequisites
+## Installation and prerequisites
 
 Claude Code is an npm package:
 
@@ -27,8 +35,9 @@ Claude Code is an npm package:
 npm install -g @anthropic-ai/claude-code
 ```
 
-After installation the `claude` binary is available on `$PATH`. The adapter's `agent.command`
-config field defaults to `claude` but can be overridden to point to a specific path or wrapper.
+After installation the `claude` binary is available on `$PATH`. The `agent.command` config field
+defaults to `claude` (`agentcore.ResolveLaunchTarget(params, "claude")`) and can be overridden to
+point to a specific path or wrapper.
 
 **Runtime requirements:**
 
@@ -49,147 +58,128 @@ Claude Code authenticates against the Anthropic API (or a compatible provider).
 | Google Vertex AI       | `CLAUDE_CODE_USE_VERTEX=1`, `ANTHROPIC_VERTEX_PROJECT_ID`, `CLOUD_ML_REGION`            | GCP credentials via ADC or explicit env vars.           |
 | LLM Gateway / Proxy    | `ANTHROPIC_BASE_URL` or provider-specific base URL env vars                             | For LiteLLM, custom proxies, etc.                       |
 
-### Config mapping
-
-| Sortie config field           | Value                                                 |
-| ----------------------------- | ----------------------------------------------------- |
-| `agent.kind`                  | `claude-code`                                         |
-| `agent.command`               | `claude` (or full path to the binary)                 |
-| `claude-code.permission_mode` | Pass-through adapter config (see Permissions section) |
-
-The adapter does **not** manage API keys directly. The Anthropic API key must be present in
-the environment of the Sortie process (or passed through via hook env). The adapter inherits
-the parent process environment when spawning the subprocess.
+The adapter does not manage API keys. The Anthropic API key must be present in the environment of
+the Sortie process (or passed through via hook env): `agentcore.ForkPerTurnSession.RunTurn` sets
+`cmd.Env = os.Environ()`, so the subprocess inherits the parent process environment verbatim.
 
 ---
 
-## CLI Flags Reference
+## CLI flags reference
 
-The adapter constructs a `claude` invocation using these flags. Flags marked **(required)**
-are always set by the adapter; others are conditional.
+The adapter builds its argument list in `buildArgs`. Flags marked **(always)** are set on every
+invocation; the rest are conditional on pass-through config or on the session state, and flags
+marked "Not passed" are part of the CLI surface but never appear in a Sortie invocation.
 
 ### Core flags
 
-| Flag                                 | Description                                                                                                             | Adapter usage                                                                           |
-| ------------------------------------ | ----------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
-| `-p <prompt>`                        | Non-interactive (headless) mode. Passes the prompt and exits when done.                                                 | **(required)** Every turn invocation uses this.                                         |
-| `--output-format stream-json`        | Newline-delimited JSON on stdout. Each line is a JSON object.                                                           | **(required)** For real-time event parsing.                                             |
-| `--verbose`                          | Include internal events (tool calls, system messages) in stream output.                                                 | **(required)** Needed for full event visibility.                                        |
-| `--max-turns <N>`                    | Maximum number of agentic turns within a single CLI invocation. Not in `claude --help` v2.1.76; may be SDK/action only. | Set to `1` for single-turn control, or omit to let Claude decide. See Turn Model below. |
-| `--max-budget-usd <amount>`          | Maximum dollar spend for this invocation (print mode only).                                                             | Optional. Cost safety backstop. Exits with error when exceeded.                         |
-| `--model <model>`                    | Override the model (e.g., `claude-sonnet-4-6`, `claude-opus-4-6`).                                                      | Optional. Adapter passes through if configured.                                         |
-| `--fallback-model <model>`           | Automatic fallback model when primary is overloaded (print mode only).                                                  | Optional. Resilience for rate-limited deployments.                                      |
-| `--effort <level>`                   | Reasoning effort: `low`, `medium`, `high`, `max`.                                                                       | Optional. Controls depth of reasoning.                                                  |
-| `--allowedTools <tools>`             | Space-separated list of pre-approved tools. Supports prefix matching: `"Bash(git diff *)"`.                             | Optional. For tool restriction.                                                         |
-| `--disallowedTools <tools>`          | Tools to remove from model context entirely.                                                                            | Optional.                                                                               |
-| `--tools <tools>`                    | Restrict available built-in tools. `""` = none, `"default"` = all.                                                      | Optional. Limits the tool palette.                                                      |
-| `--append-system-prompt <text>`      | Append text to the system prompt. Preserves built-in capabilities.                                                      | Optional. For adapter-injected instructions.                                            |
-| `--system-prompt <text>`             | Replace entire default system prompt.                                                                                   | Optional. **Caution:** removes built-in tool instructions.                              |
-| `--system-prompt-file <path>`        | Replace system prompt from file.                                                                                        | Optional.                                                                               |
-| `--append-system-prompt-file <path>` | Append to system prompt from file.                                                                                      | Optional.                                                                               |
-| `--json-schema <schema>`             | JSON Schema for structured output validation (print mode only).                                                         | Optional. Forces output to conform to a schema.                                         |
-| `--mcp-config <path>`                | Path to MCP server configuration JSON.                                                                                  | Optional. For tool extensions (e.g., `tracker_api`).                                    |
-| `--strict-mcp-config`                | Only use MCP servers from `--mcp-config` (ignore workspace MCP configs).                                                | Optional. For controlled MCP environments.                                              |
-| `--add-dir <dirs>`                   | Additional directories for tool access beyond the cwd.                                                                  | Optional. Multi-repo workflows.                                                         |
-| `--debug [filter]`                   | Enable debug logging with optional category filter (e.g., `"api,hooks"`).                                               | Optional. For troubleshooting.                                                          |
-| `--include-partial-messages`         | Include partial message deltas in stream-json output.                                                                   | Optional. Provides token-by-token streaming for text deltas.                            |
-| `--agents <json>`                    | Define custom subagents via JSON.                                                                                       | Optional. Advanced multi-agent patterns.                                                |
-| `--agent <name>`                     | Use a specific named agent for the session.                                                                             | Optional. Agent routing.                                                                |
+| Flag                                 | Description                                                                                  | Adapter usage                                                                       |
+| ------------------------------------ | ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| `-p <prompt>`                        | Non-interactive (headless) mode. Passes the prompt and exits when done.                      | **(always)** Carries the rendered turn prompt.                                      |
+| `--output-format stream-json`        | Newline-delimited JSON on stdout. Each line is a JSON object.                                | **(always)** The adapter's only event source.                                       |
+| `--verbose`                          | Include internal events (tool calls, system messages) in stream output.                      | **(always)** Needed for full event visibility.                                      |
+| `--max-turns <N>`                    | Maximum number of agentic turns within a single CLI invocation.                               | Passed when `claude-code.max_turns` is set. Availability is an open question below. |
+| `--max-budget-usd <amount>`          | Maximum dollar spend for this invocation (print mode only). Exits with error when exceeded.  | Passed when `claude-code.max_budget_usd` is set.                                     |
+| `--model <model>`                    | Override the model (e.g., `claude-sonnet-4-6`, `claude-opus-4-6`).                           | Passed when `claude-code.model` is set.                                              |
+| `--fallback-model <model>`           | Automatic fallback model when primary is overloaded (print mode only).                       | Passed when `claude-code.fallback_model` is set.                                     |
+| `--effort <level>`                   | Reasoning effort: `low`, `medium`, `high`, `max`.                                             | Passed when `claude-code.effort` is set.                                             |
+| `--allowedTools <tools>`             | Space-separated list of pre-approved tools. Supports prefix matching: `"Bash(git diff *)"`.  | Passed when `claude-code.allowed_tools` is set.                                       |
+| `--disallowedTools <tools>`          | Tools to remove from model context entirely.                                                  | Passed when `claude-code.disallowed_tools` is set.                                    |
+| `--append-system-prompt <text>`      | Append text to the system prompt. Preserves built-in capabilities.                            | Passed when `claude-code.system_prompt` is set.                                       |
+| `--mcp-config <path>`                | Path to MCP server configuration JSON.                                                        | Passed with the worker-generated config path; see MCP server configuration.          |
+| `--tools <tools>`                    | Restrict available built-in tools. `""` = none, `"default"` = all.                            | Not passed.                                                                          |
+| `--system-prompt <text>`             | Replace entire default system prompt. Removes built-in tool instructions.                    | Not passed.                                                                          |
+| `--system-prompt-file <path>`        | Replace system prompt from file.                                                              | Not passed.                                                                          |
+| `--append-system-prompt-file <path>` | Append to system prompt from file.                                                            | Not passed.                                                                          |
+| `--json-schema <schema>`             | JSON Schema for structured output validation (print mode only).                              | Not passed.                                                                          |
+| `--strict-mcp-config`                | Restrict MCP servers to those in `--mcp-config`; see MCP server configuration.                | Not passed.                                                                          |
+| `--add-dir <dirs>`                   | Additional directories for tool access beyond the cwd.                                        | Not passed.                                                                          |
+| `--debug [filter]`                   | Enable debug logging with optional category filter (e.g., `"api,hooks"`).                    | Not passed.                                                                          |
+| `--include-partial-messages`         | Include partial message deltas in stream-json output.                                         | Not passed.                                                                          |
+| `--agents <json>`                    | Define custom subagents via JSON.                                                             | Not passed.                                                                          |
+| `--agent <name>`                     | Use a specific named agent for the session.                                                   | Not passed.                                                                          |
 
 ### Session management flags
 
-| Flag                           | Description                                                         | Adapter usage                                                          |
-| ------------------------------ | ------------------------------------------------------------------- | ---------------------------------------------------------------------- |
-| `--continue` / `-c`            | Resume the most recent conversation in the working directory.       | Used for continuation turns (turn 2+).                                 |
-| `--resume <session_id>` / `-r` | Resume a specific conversation by session ID.                       | Used for continuation turns when explicit session targeting is needed. |
-| `--session-id <uuid>`          | Use a specific UUID for the session (instead of auto-generated).    | Optional. For deterministic session ID assignment.                     |
-| `--fork-session`               | When resuming, create a new session ID instead of reusing original. | Optional. For branching conversations.                                 |
-| `--no-session-persistence`     | Don't save session to disk (print mode only).                       | Optional. For ephemeral runs that don't need history.                  |
-| `--name <name>` / `-n`         | Display name for the session.                                       | Optional. For human-readable session identification.                   |
+| Flag                           | Description                                                         | Adapter usage                                                                                  |
+| ------------------------------ | ------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| `--session-id <uuid>`          | Use a specific UUID for the session (instead of auto-generated).    | Passed on the first turn of a new session with the UUID minted by `newUUID`.                     |
+| `--resume <session_id>` / `-r` | Resume a specific conversation by session ID.                       | Passed on every other turn.                                                                      |
+| `--no-session-persistence`     | Don't save session to disk (print mode only).                       | Passed when `claude-code.session_persistence` is `false`.                                        |
+| `--continue` / `-c`            | Resume the most recent conversation in the working directory.       | Not passed. `--resume` targets the session explicitly and is unambiguous when several exist. |
+| `--fork-session`               | When resuming, create a new session ID instead of reusing original. | Not passed.                                                                                      |
+| `--name <name>` / `-n`         | Display name for the session.                                       | Not passed.                                                                                      |
 
 ### Permission flags
 
-| Flag                                   | Description                                                                                    | Adapter usage                                                                                                                                 |
-| -------------------------------------- | ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
-| `--dangerously-skip-permissions`       | Bypass all permission prompts. No user confirmation required.                                  | **(required for headless)** Without this, the process may hang waiting for interactive approval. Must only be used in sandboxed environments. |
-| `--permission-mode <mode>`             | Set permission mode: `default`, `acceptEdits`, `dontAsk`, `bypassPermissions`, `plan`, `auto`. | Alternative to `--dangerously-skip-permissions`. `bypassPermissions` is equivalent.                                                           |
-| `--permission-prompt-tool <tool>`      | MCP tool to handle permission prompts programmatically in non-interactive mode.                | Optional. Enables programmatic approval decisions instead of blanket bypass.                                                                  |
-| `--allow-dangerously-skip-permissions` | Enable bypassing as an option without activating it.                                           | Optional. Pre-authorization for sandboxed environments.                                                                                       |
-
-> **Security warning:** `--dangerously-skip-permissions` allows arbitrary command execution.
-> Per Anthropic's guidance, this should only be used in sandboxed environments without internet
-> access, inside an externally enforced sandbox (for example a locked-down container or VM with
-> restricted filesystem and network access). Sortie's workspace isolation and hook system operate
-> inside that sandbox as additional defense-in-depth, but do not replace external isolation.
+| Flag                                   | Description                                                                                    | Adapter usage                                                        |
+| -------------------------------------- | ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| `--dangerously-skip-permissions`       | Bypass all permission prompts. No user confirmation required.                                  | Passed when `claude-code.permission_mode` is unset.                  |
+| `--permission-mode <mode>`             | Set permission mode: `default`, `acceptEdits`, `dontAsk`, `bypassPermissions`, `plan`, `auto`. | Passed instead when `claude-code.permission_mode` is set.            |
+| `--permission-prompt-tool <tool>`      | MCP tool to handle permission prompts programmatically in non-interactive mode.                | Not passed.                                                          |
+| `--allow-dangerously-skip-permissions` | Enable bypassing as an option without activating it.                                           | Not passed.                                                          |
 
 ### Input flags
 
-| Flag                      | Description                                                              | Adapter usage                                                        |
-| ------------------------- | ------------------------------------------------------------------------ | -------------------------------------------------------------------- |
-| `--input-format <format>` | Input format (print mode only): `text` (default), `stream-json`.         | Optional. `stream-json` enables real-time streaming input via stdin. |
-| `--replay-user-messages`  | Re-emit user messages from stdin on stdout (requires `stream-json` I/O). | Optional. For bidirectional streaming protocols.                     |
+| Flag                      | Description                                                              | Adapter usage |
+| ------------------------- | ------------------------------------------------------------------------ | ------------- |
+| `--input-format <format>` | Input format (print mode only): `text` (default), `stream-json`.         | Not passed.   |
+| `--replay-user-messages`  | Re-emit user messages from stdin on stdout (requires `stream-json` I/O). | Not passed.   |
 
-### Config/settings flags
+### Config and settings flags
 
-| Flag                          | Description                                                  | Adapter usage                                      |
-| ----------------------------- | ------------------------------------------------------------ | -------------------------------------------------- |
-| `--setting-sources <sources>` | Comma-separated setting sources: `user`, `project`, `local`. | Optional. Control which settings files are loaded. |
-| `--settings <file-or-json>`   | Additional settings JSON file or inline JSON.                | Optional. Inject adapter-specific settings.        |
+| Flag                          | Description                                                  | Adapter usage |
+| ----------------------------- | ------------------------------------------------------------ | ------------- |
+| `--setting-sources <sources>` | Comma-separated setting sources: `user`, `project`, `local`. | Not passed.   |
+| `--settings <file-or-json>`   | Additional settings JSON file or inline JSON.                | Not passed.   |
 
 ---
 
-## Subprocess Invocation
+## Subprocess invocation
 
-Per [architecture Section 10.7](architecture/10-agent-adapter-contract.md#107-local-subprocess-launch-contract), the adapter launches:
+`buildArgs` returns an argv slice and `agentcore.ForkPerTurnSession.RunTurn` launches the binary
+with `exec.CommandContext`. No shell wraps the invocation, so the prompt reaches the CLI as a
+single argv element and shell metacharacters in user-controlled issue content cannot be
+interpreted. A first turn of a new session produces:
 
 ```
-# POSIX (Linux / macOS)
-sh -c '<agent.command> -p "$1" --output-format stream-json --verbose --dangerously-skip-permissions ${2:+--resume "$2"}' -- "$prompt" "$session_id"
+claude -p <prompt> --output-format stream-json --verbose --dangerously-skip-permissions --session-id <uuid>
 ```
 
-On Windows, the adapter invokes the CLI directly without a shell wrapper. The subprocess receives
-`CREATE_NEW_PROCESS_GROUP` and is assigned to a Job Object for process tree management.
+When `StartSessionParams.SSHHost` is set, `agentcore.ResolveLaunchTarget` resolves the local `ssh`
+binary instead and `sshutil.BuildSSHArgs` wraps the same argv, the workspace path, and the remote
+command for remote execution.
 
-> **Shell safety:** The prompt must not be interpolated directly into the `sh -c` string.
-> Pass it as a positional parameter (`$1`) to avoid injection via shell metacharacters
-> in user-controlled issue content.
+Process-group isolation, the graceful-shutdown sequence, and the 10 MB stdout line ceiling follow
+[architecture Section 10.7](architecture/10-agent-adapter-contract.md#107-local-subprocess-launch-contract).
 
 ### Process settings
 
-| Setting           | Value                                               | Rationale                                                |
-| ----------------- | --------------------------------------------------- | -------------------------------------------------------- |
-| Working directory | Workspace path (`StartSessionParams.WorkspacePath`) | Agent must operate in the issue workspace.               |
-| Stdout            | Pipe (read by adapter)                              | `stream-json` output parsed line by line.                |
-| Stderr            | Pipe (read by adapter, logged)                      | Diagnostic output, not structured.                       |
-| Environment       | Inherited from Sortie process                       | `ANTHROPIC_API_KEY` and other auth vars must be present. |
-| Max line size     | 10 MB                                               | Safe buffering per architecture doc recommendation.      |
+| Setting           | Value                                                            | Rationale                                                                                       |
+| ----------------- | ------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------- |
+| Working directory | Workspace path, resolved by `agentcore.ResolveWorkspace`         | Agent must operate in the issue workspace.                                                      |
+| Stdout            | Pipe scanned line by line by `bufio.Scanner`                     | `stream-json` output is parsed one line per event.                                              |
+| Stderr            | Pipe drained by `procutil.NewStderrCollector`                    | Diagnostic output, not structured. Logged, and re-emitted at warn level on failure paths.       |
+| Environment       | `os.Environ()` of the Sortie process                             | `ANTHROPIC_API_KEY` and other auth vars must be present.                                        |
+| Max line size     | 10 MB (`stdoutScannerMaxTokenSize`)                              | A longer line ends the scan with `bufio.ErrTooLong` and fails the turn with `port_exit`.        |
+| Process group     | `procutil.SetProcessGroup` before start, `procutil.AssignProcess` after | POSIX process group and Windows Job Object, so the whole tree can be signaled and reaped. |
 
-### First turn vs. continuation turns
+### First turn and continuation turns
 
-| Turn                   | Invocation                                                                                                                     |
-| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
-| Turn 1 (new session)   | `claude -p "<full_prompt>" --output-format stream-json --verbose --dangerously-skip-permissions`                               |
-| Turn 2+ (continuation) | `claude -p "<continuation_prompt>" --output-format stream-json --verbose --dangerously-skip-permissions --resume <session_id>` |
+| Turn                                                     | Session flag                          |
+| -------------------------------------------------------- | ------------------------------------- |
+| First turn of a new session                              | `--session-id <uuid>`                 |
+| Every later turn, and every turn of a resumed session    | `--resume <session_id>`               |
 
-The `--resume <session_id>` flag continues the conversation in the same session, preserving
-the full message history from prior turns. The `session_id` is captured from the JSON output
-of the first turn.
-
-**Alternative:** `--continue` resumes the most recent conversation in the cwd. Since Sortie
-controls the workspace directory per issue, `--continue` would also work. However,
-`--resume <session_id>` is more explicit and avoids ambiguity if multiple sessions exist
-in the same workspace.
-
-**Deterministic session IDs:** The `--session-id <uuid>` flag allows the adapter to assign a
-known UUID before the first turn, eliminating the need to parse the session ID from output.
-This simplifies the turn-1 → turn-2 handoff.
-
-**Ephemeral runs:** `--no-session-persistence` avoids writing session history to disk,
-reducing I/O overhead for fire-and-forget runs that don't need continuation.
+`StartSession` mints the session UUID with `newUUID` before the first turn, so the adapter never
+has to parse an identifier out of the stream before it can continue a conversation. It marks the
+session a continuation when `StartSessionParams.ResumeSessionID` is non-empty, in which case even
+turn 1 resumes. `--resume` preserves the full message history from prior turns. When the
+`system/init` event reports a `session_id`, `ParseLine` adopts the reported value for later turns
+and for event correlation.
 
 ---
 
-## Output Format: `stream-json`
+## Output format: `stream-json`
 
 With `--output-format stream-json`, Claude Code writes one JSON object per line to stdout
 (newline-delimited JSON / JSONL). Each line is independently parseable.
@@ -202,27 +192,30 @@ The stream produces messages conforming to a union type:
 
 ### Event categories
 
-| `type` field   | Description                                               | Adapter mapping                        |
-| -------------- | --------------------------------------------------------- | -------------------------------------- |
-| `system`       | System/init messages (session start, retries, compaction) | `session_started` or `notification`    |
-| `assistant`    | Complete assistant message (text, tool calls)             | `notification` / `tool_use` tracking   |
-| `user`         | User-role message carrying tool execution results         | `tool_result` (via content blocks)     |
-| `result`       | Final result message when the turn/session completes      | `turn_completed` or `turn_failed`      |
-| `stream_event` | Streaming delta (with `--include-partial-messages`)       | Ignored or used for stall detection    |
+| `type` field   | Description                                               | Adapter mapping                                                                             |
+| -------------- | --------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| `system`       | System/init messages (session start, retries, compaction) | `session_started` on the `init` subtype, `notification` otherwise                            |
+| `assistant`    | Complete assistant message (text, tool calls)             | `token_usage` on a message id's first sighting, tool tracking, and a `notification` summary  |
+| `user`         | User-role message carrying tool execution results         | `tool_result` (via content blocks)                                                           |
+| `result`       | Final result message when the turn/session completes      | Held as the turn's terminal report and read in `OnFinalize`                                  |
+| `stream_event` | Streaming delta (with `--include-partial-messages`)       | Empty `notification`, which only advances the orchestrator's stall clock                     |
+| Anything else  | Unrecognized line                                          | `other_message` carrying `type/subtype`                                                      |
 
-> **Note (v2.1.x change):** Earlier Claude Code versions emitted `tool_use` and `tool_result`
-> as separate top-level event types *or* as content blocks within `assistant` messages. As of
-> v2.1.x, the canonical flow is: `assistant` message with `ToolUseBlock` content → `user`
-> message with `ToolResultBlock` content. The adapter handles both the legacy (assistant-only)
-> and current (assistant + user) patterns.
+`processToolBlocks` scans the content blocks of both `assistant` and `user` events, so a
+`tool_result` block is correlated in either position; CLI versions before v2.1 emit it inside the
+`assistant` message. Correlation runs through `agentcore.ToolTracker`, which supplies the
+originating tool name and the execution duration; an uncorrelated result is reported as tool name
+`unknown`. Error text from a failed tool is unwrapped from Claude Code's
+`<tool_use_error>` envelope and stripped of ANSI escapes by `stripClaudeMarkup`, then bounded to
+2048 bytes by `truncateToolError`, which keeps the first line and the tail.
 
-### SystemMessage subtypes
+### System message subtypes
 
-| Subtype            | Description                                            | Adapter action                               |
-| ------------------ | ------------------------------------------------------ | -------------------------------------------- |
-| `init`             | First message. Contains `session_id` and `cwd`.        | Extract `session_id`, emit `session_started` |
-| `api_retry`        | API retry in progress.                                 | Log; update stall timer                      |
-| `compact_boundary` | Context was compacted (conversation truncated to fit). | Log as `notification`                        |
+| Subtype            | Description                                            | Adapter action                                                                  |
+| ------------------ | ------------------------------------------------------ | --------------------------------------------------------------------------------- |
+| `init`             | First message. Contains `session_id` and `cwd`.        | Adopt `session_id`, emit `session_started`, start the API-timing clock          |
+| `api_retry`        | API retry in progress.                                 | `notification` formatted by `formatAPIRetry`                                    |
+| `compact_boundary` | Context was compacted (conversation truncated to fit). | `notification` carrying `system/compact_boundary`                               |
 
 **Init/system event:**
 
@@ -254,9 +247,9 @@ The stream produces messages conforming to a union type:
 Retry error categories: `authentication_failed`, `billing_error`, `rate_limit`, `invalid_request`,
 `server_error`, `max_output_tokens`, `unknown`.
 
-### ResultMessage (turn/session completion)
+### Result message
 
-The result message is always the final line in the stream. It contains comprehensive metadata:
+The result message is the final line in the stream. It contains comprehensive metadata:
 
 ```json
 {
@@ -279,15 +272,15 @@ The result message is always the final line in the stream. It contains comprehen
 }
 ```
 
-**Result subtypes:**
+**Result subtypes** (their disposition is in Error detection and mapping):
 
-| `subtype`                             | Meaning                                                              | Adapter mapping  |
-| ------------------------------------- | -------------------------------------------------------------------- | ---------------- |
-| `success`                             | Turn completed normally.                                             | `turn_completed` |
-| `error_max_turns`                     | `--max-turns` limit reached.                                         | `turn_failed`    |
-| `error_max_budget_usd`                | `--max-budget-usd` limit reached.                                    | `turn_failed`    |
-| `error_during_execution`              | Runtime error during agent execution.                                | `turn_failed`    |
-| `error_max_structured_output_retries` | Structured output (`--json-schema`) validation failed after retries. | `turn_failed`    |
+| `subtype`                             | Meaning                                                              |
+| ------------------------------------- | -------------------------------------------------------------------- |
+| `success`                             | Turn completed normally.                                             |
+| `error_max_turns`                     | `--max-turns` limit reached.                                         |
+| `error_max_budget_usd`                | `--max-budget-usd` limit reached.                                    |
+| `error_during_execution`              | Runtime error during agent execution.                                |
+| `error_max_structured_output_retries` | Structured output (`--json-schema`) validation failed after retries. |
 
 **Result event fields:**
 
@@ -305,6 +298,11 @@ The result message is always the final line in the stream. It contains comprehen
 | `num_turns`         | integer | Number of internal agentic turns executed.          |
 | `usage`             | object  | Token usage breakdown (see below).                  |
 | `stop_reason`       | string? | `"end_turn"`, `"max_tokens"`, `"refusal"`, or null. |
+
+`rawEvent` decodes `subtype`, `is_error`, `result`, `duration_api_ms`, `usage`, and `modelUsage`
+and acts on all of them. It also decodes `total_cost_usd`, `duration_ms`, `num_turns`,
+`stop_reason`, and the init event's `cwd`, none of which reach a domain event.
+`structured_output` is not decoded.
 
 **Usage object fields:**
 
@@ -326,13 +324,15 @@ Assistant and user messages contain an array of content blocks:
 | `ToolUseBlock`    | `id`, `name`, `input`                | `assistant`   | Tool call request.                |
 | `ToolResultBlock` | `tool_use_id`, `content`, `is_error` | `user`        | Tool execution result.            |
 
-> **v2.1.x:** `ToolResultBlock` moved from `assistant` messages to `user` messages.
-> Legacy streams may still embed `ToolResultBlock` inside `assistant` messages; the
-> adapter handles both layouts.
+`rawContentBlock` decodes `type`, `text`, `name`, `id`, `tool_use_id`, `is_error`, and `content`.
+A `ToolUseBlock` `input` and a `ThinkingBlock` are not decoded. `toolResultText` reads a
+`tool_result` block's `content` in both shapes Claude Code emits: a plain JSON string, and an
+array of typed content objects from which the first `text` entry is taken.
 
-### StreamEvent (partial messages)
+### Stream events (partial messages)
 
-Only emitted when `--include-partial-messages` is set. Wraps raw Claude API streaming events:
+Only emitted when `--include-partial-messages` is set, which `buildArgs` never passes. Wraps raw
+Claude API streaming events:
 
 ```json
 {
@@ -377,42 +377,55 @@ When Claude Code spawns background tasks (subagents, background bash), these mes
 | `TaskProgressMessage`     | `task_id`, `usage`, `last_tool_name`  | Periodic progress update.                                         |
 | `TaskNotificationMessage` | `task_id`, `status`, `summary`        | Task completed. Status: `completed`, `failed`, `stopped`.         |
 
+`ParseLine` has no arm for these messages; they fall to the default arm and become
+`other_message` events. Their wire-level `type` values are an open question below.
+
 ### Parsing strategy
 
-The adapter reads stdout line by line. For each line:
+`agentcore.ForkPerTurnSession.RunTurn` scans stdout line by line and hands each line to the
+adapter's `ParseLine` hook, which:
 
-1. Parse as JSON. If parsing fails → emit `malformed` event.
-2. Check `type` field:
-   - `"system"` with `"init"` subtype → extract `session_id`, emit `session_started`.
-   - `"system"` with `"api_retry"` subtype → log retry info, update stall timer.
-   - `"system"` with `"compact_boundary"` subtype → log context compaction.
-   - `"result"` → extract all fields. Check `subtype` and `is_error`:
-     - `subtype == "success"` and `is_error == false` → emit `turn_completed`.
-     - Any other subtype or `is_error == true` → emit `turn_failed`.
-     - Extract `usage` for `token_usage` event.
-   - `"assistant"` → emit `notification` or `other_message` with content summary.
-     Inspect content blocks for `ToolUseBlock` entries (populate in-flight map).
-     Legacy streams may also contain `ToolResultBlock` here.
-   - `"user"` → inspect content blocks for `ToolResultBlock` entries. Correlate
-     each `tool_use_id` with the in-flight map to emit `tool_result` events with
-     the originating tool name and execution duration.
-   - `"stream_event"` → update stall detection timer. Optionally emit `notification`
-     for text deltas.
-3. Any event with recognizable token/cost data → emit `token_usage` event.
+1. Unmarshals the line into a `rawEvent` via `parseEvent`. On a JSON error the skeleton emits a
+   `malformed` event carrying the raw line truncated to 500 runes, and continues with the next
+   line.
+2. Switches on `type`:
+   - `"system"` with `"init"`: adopt `session_id`, emit `session_started` with the subprocess PID,
+     and start the API-timing clock.
+   - `"system"` with any other subtype: emit a `notification`.
+   - `"assistant"`: record the model, register per-message-id usage, emit `token_usage` on the
+     id's first sighting, scan content blocks for `tool_use` and `tool_result`, and emit a
+     `notification` summarizing the message (`summarizeAssistant`).
+   - `"user"`: scan content blocks for `tool_result` and restart the API-timing clock, because
+     the next API call follows tool execution.
+   - `"result"`: settle the turn's authoritative usage into the run accumulator and return the
+     event to the skeleton as the turn's terminal report.
+   - `"stream_event"`: emit an empty `notification`.
+   - anything else: emit `other_message` carrying `type/subtype`.
+
+Every line other than `result` returns nil, so the last `result` event seen is what `OnFinalize`
+reads. Emitted events carry a UTC timestamp; `orchestrator.HandleAgentEvent` advances the run
+entry's `LastAgentTimestamp` from it, which is what the stall detector reads. The adapter keeps no
+stall timer of its own.
 
 ### Token usage extraction
 
 Assistant events repeat one message id (`message.id`) for every event of the same model
 request; the adapter deduplicates by that id and emits at most one `token_usage` event per id.
 Streamed usage is a snapshot, not a final count: a later event carrying the same id can report a
-larger usage object than an earlier one as the response continues to generate.
+larger usage object than an earlier one as the response continues to generate, so
+`componentwiseMaxUsage` keeps the componentwise maximum per id.
 
 The terminal `result` event's top-level `usage` field excludes sub-agent activity, while its
-`modelUsage` map and `total_cost_usd` include it. The adapter derives the authoritative per-turn
-usage from `modelUsage` when present, summed across every model entry, and falls back to the
-top-level `usage` object only when `modelUsage` is absent or empty.
+`modelUsage` map and `total_cost_usd` include it. `usageFromResult` derives the authoritative
+per-turn usage from `modelUsage` when present, summed across every model entry, and falls back to
+the top-level `usage` object only when `modelUsage` is absent or empty.
 
-The adapter normalizes a usage object into:
+`agentcore.RunUsage` holds the session total: assistant events set the in-flight turn's
+provisional contribution (`SetTurnProvisional`), the result event settles the turn
+(`AddTurn`), and the snapshot never decreases. The terminal event and the `TurnResult` carry that
+run-cumulative snapshot, not a per-turn figure.
+
+`usageFromAssistant` normalizes a usage object into:
 
 ```
 TokenUsage{
@@ -431,153 +444,121 @@ Additional available data:
 | Result `usage` | `input_tokens`, `output_tokens`, `cache_read_input_tokens`, `cache_creation_input_tokens` |
 | Result `modelUsage` (per model) | `inputTokens`, `outputTokens`, `cacheReadInputTokens`, `cacheCreationInputTokens`, `costUSD` |
 
-`total_cost_usd` and `modelUsage[*].costUSD` are cost figures the adapter parses only where it
-already did; no new cost parsing is added.
+Of the cost figures, `rawEvent` decodes `total_cost_usd` and does not carry it anywhere;
+`rawModelUsage` does not decode `costUSD` at all. The adapter reports no cost.
+
+API timing is reported instead: the clock starts on `system/init` and restarts after each `user`
+event, and the elapsed time is attached to the next `token_usage` event as `APIDurationMS`,
+clamped to a minimum of 1 ms. When no per-request timing was emitted during the turn, `OnFinalize`
+falls back to the result event's `duration_api_ms` so the two are never double-counted.
 
 ---
 
-## Session Lifecycle Mapping
+## Session lifecycle mapping
 
 [Architecture Section 10.2](architecture/10-agent-adapter-contract.md#102-session-lifecycle) defines the session lifecycle. Here is how Claude Code maps to it:
 
 ### `StartSession`
 
-Architecture Sections 10.1 and 10.2 define `StartSession` as the operation that "launches or
-connects" to the agent. For Claude Code, the _session_ is disk-persisted and identified by
-`--session-id`, while the OS subprocess is short-lived and created per turn. This adapter
-treats `StartSession` as establishing and validating the logical Claude Code session, while
-deferring creation of the Node.js subprocess until `RunTurn`.
+For Claude Code, the _session_ is disk-persisted and identified by `--session-id`, while the OS
+subprocess is short-lived and created per turn. `StartSession` establishes the logical Claude Code
+session and defers creation of the Node.js subprocess to `RunTurn`. It:
 
-1. Record the workspace path and configuration.
-2. Perform preflight validation:
-   - Resolve and normalize the workspace path.
-   - Enforce workspace path containment rules.
-   - Validate that the Claude Code CLI command is resolvable on `$PATH`.
-3. Optionally assign a deterministic Claude Code session ID (for example a UUID) that will be
-   passed via `--session-id <uuid>` on the first `RunTurn`. This avoids needing to parse the
-   session ID from output before the second turn and makes retries idempotent.
-4. Initialize and return a `Session`:
-   - `ID`: the chosen session ID if pre-assigned, or empty (to be populated after the first
-     turn if Claude Code allocates it).
-   - `Internal`: adapter-internal state (workspace path, config snapshot, chosen session ID).
-     No OS subprocess is spawned at this point; that happens in `RunTurn` while resuming this
-     logical session.
+1. Calls `agentcore.ResolveLaunchTarget`, which resolves the workspace path to absolute form and
+   checks that it exists and is a directory (`agentcore.ResolveWorkspace`), then resolves the
+   `claude` binary on `$PATH` (`agentcore.ResolveBinary`). Workspace root containment is enforced
+   by the workspace manager before `StartSession` runs, not here.
+2. Assigns the Claude Code session ID: `StartSessionParams.ResumeSessionID` when resuming,
+   otherwise a fresh UUID from `newUUID`.
+3. Builds `sessionState` (launch target, session ID, agent config, MCP config path, run usage
+   accumulator) and constructs the `agentcore.ForkPerTurnSession` that owns the subprocess
+   lifecycle.
+4. Returns a `domain.Session` whose `ID` is the chosen session ID and whose `Internal` is the
+   `sessionState`. No OS subprocess exists at this point.
 
 ### `RunTurn`
 
-1. Build the CLI command:
-   - Turn 1: `claude -p "<prompt>" --output-format stream-json --verbose --dangerously-skip-permissions [--session-id <uuid>]`
-   - Turn 2+: append `--resume <session_id>` to continue the conversation.
-2. Launch subprocess (POSIX: `sh -c <command>`; Windows: direct invocation), cwd = workspace path.
-   The subprocess is placed in its own process group and assigned to platform-specific
-   process tree management (Unix process groups / Windows Job Objects).
-3. Read stdout line by line, parse each JSON event, and deliver to `OnEvent` callback.
-4. On each event, update the stall detection timer.
-5. When the process exits:
-   - **Exit code 0:** Parse the final `result` event. Check `subtype`:
-     - `"success"` → return `TurnResult{ExitReason: turn_completed}`.
-     - `"error_max_turns"` or `"error_max_budget_usd"` → return `TurnResult{ExitReason: turn_failed}`.
-     - `"error_during_execution"` → return `TurnResult{ExitReason: turn_failed}`.
-   - **Exit code 1:** General error → return `TurnResult{ExitReason: turn_failed}` with error details.
-   - **Exit code non-zero (other):** Return `TurnResult{ExitReason: turn_failed}`.
-   - **Killed by signal (timeout/cancellation):** Return `TurnResult{ExitReason: turn_cancelled}`.
-6. Extract `session_id` from the init or result event and store it in the `Session.Internal`
-   state for use in subsequent `--resume` invocations.
+`RunTurn` resets the per-turn scan state (message-id usage map, last model, API-timing clock, tool
+tracker) and delegates to `agentcore.ForkPerTurnSession.RunTurn`, which:
+
+1. Calls `buildArgs` for the argv, then starts the subprocess with cwd set to the workspace path.
+2. Scans stdout line by line, delivering normalized events to the `OnEvent` callback.
+3. Drains stderr, waits for the process, and reaps any surviving process-group members.
+4. Decides the outcome. Cancellation, a stdout scan error, exit code 127, and death by signal are
+   decided by the skeleton; every other exit reaches the adapter's `OnFinalize`, which reports the
+   terminal outcome to `agentcore.FinalizeTurn`.
+
+The run accumulator (`agentcore.RunUsage`) is constructed once in `StartSession` and is not reset
+between turns, so `TurnResult.Usage` is run-cumulative.
 
 ### `StopSession`
 
-1. If a subprocess is running, send a platform-appropriate graceful shutdown signal to the
-   process group (POSIX: `SIGTERM`; Windows: `CTRL_BREAK_EVENT`).
-2. Wait briefly (5 seconds) for clean exit.
-3. If still running, force-terminate the process tree (POSIX: `SIGKILL` to process group;
-   Windows: `TerminateJobObject`).
-4. Clean up file descriptors, goroutines, and platform-specific process group resources.
+`StopSession` delegates to `agentcore.ForkPerTurnSession.Stop`, which sends a platform-appropriate
+graceful shutdown signal to the process group (POSIX: `SIGTERM`; Windows: `CTRL_BREAK_EVENT`),
+waits up to 5 seconds for the turn to finish its own cleanup, and force-terminates the process
+group otherwise (POSIX: `SIGKILL`; Windows: `TerminateJobObject`). With no subprocess running it
+returns nil immediately.
 
 ### `EventStream`
 
-Return `nil`. The Claude Code adapter uses the synchronous `OnEvent` callback model, not
-the async channel model.
+Returns nil. The Claude Code adapter uses the synchronous `OnEvent` callback model, not the async
+channel model.
 
 ---
 
-## Turn Model
+## Turn model
 
 Claude Code has its own internal concept of "turns" (agentic loops within a single CLI
-invocation). The `--max-turns` flag controls how many internal turns Claude Code executes
-before returning.
+invocation). Sortie's turn is one CLI invocation, one `RunTurn` call; within it Claude Code may
+execute many internal agentic loops. The result event's `num_turns` field reports how many it ran.
 
-**Default behavior when `--max-turns` is omitted:** Claude Code runs until the model
-decides it is done (the agent loop completes naturally). There is no hardcoded internal
-turn limit — the agent continues executing tool calls and producing responses until it
-emits `end_turn`. In practice this means the only bounds are the cost budget
-(`--max-budget-usd`) and the adapter's `turn_timeout_ms` deadline in Sortie.
-
-> **Note:** `--max-turns` is documented in the GitHub Actions `claude_args` reference but
-> does not appear in `claude --help` as of CLI v2.1.76. It may be handled via the SDK
-> layer or settings rather than a direct CLI flag. Verify availability before relying on it
-> in the adapter; if unavailable, rely on `--max-budget-usd` and `turn_timeout_ms` as the
-> primary safety bounds.
-
-**Sortie's turn model is distinct from Claude Code's internal turns.** Sortie's "turn" is
-one CLI invocation (one `RunTurn` call). Within that invocation, Claude Code may execute
-multiple internal agentic loops.
-
-Two strategies:
-
-### Strategy A: Single Sortie turn = single Claude Code invocation (recommended)
-
-- Omit `--max-turns` (agent runs until done) or set it explicitly if available.
-- Claude Code runs its full agentic loop within one invocation.
-- Sortie calls `RunTurn` once per Sortie turn. Claude Code decides when it's done.
-- After each Sortie turn, the orchestrator re-checks tracker state and decides whether to
-  continue.
-- The result event's `num_turns` field reveals how many internal turns Claude Code executed.
-- Use `--max-budget-usd` as a cost safety backstop alongside `turn_timeout_ms`.
-
-### Strategy B: One-turn-per-invocation (fine-grained control)
-
-- Set `--max-turns 1` on each invocation.
-- Each `RunTurn` call runs exactly one Claude Code internal turn.
-- Sortie has maximum control over the loop but incurs subprocess launch overhead per turn
-  and may interrupt Claude Code's multi-step plans.
-
-**Recommendation:** Strategy A. Let Claude Code run its agentic loop to completion within
-each Sortie turn. Sortie's `agent.turn_timeout_ms` provides the safety backstop. This
-minimizes subprocess overhead and allows Claude Code's planner to execute multi-step
-operations atomically.
+`buildArgs` omits `--max-turns` unless `claude-code.max_turns` is configured, so by default Claude
+Code runs until the model decides it is done. There is no hardcoded internal turn limit: the agent
+continues executing tool calls and producing responses until it emits `end_turn`. The bounds that
+remain are the cost budget (`claude-code.max_budget_usd`) and orchestrator-side cancellation.
+Letting the agentic loop run to completion inside one Sortie turn minimizes subprocess overhead
+and keeps multi-step operations from being interrupted mid-plan; after each Sortie turn the
+orchestrator re-checks tracker state and decides whether to continue.
 
 ---
 
-## Timeout Enforcement
+## Timeout enforcement
 
-| Timeout                  | Source      | Enforcement                                                                                                                                                                                         |
-| ------------------------ | ----------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `agent.turn_timeout_ms`  | WORKFLOW.md | Adapter sets a deadline on the subprocess. On expiry, send SIGTERM → wait → SIGKILL. Map to `turn_cancelled`.                                                                                       |
-| `agent.read_timeout_ms`  | WORKFLOW.md | Not directly applicable to subprocess model (no request/response cycle during the turn). Could apply to initial subprocess startup: if no output within `read_timeout_ms`, consider startup failed. |
-| `agent.stall_timeout_ms` | WORKFLOW.md | Enforced by the **orchestrator**, not the adapter. The orchestrator monitors `last_agent_timestamp` from events. If the gap exceeds `stall_timeout_ms`, the orchestrator calls `StopSession`.       |
+| Timeout                  | Source      | Enforcement                                                                                                                                                                                |
+| ------------------------ | ----------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `agent.turn_timeout_ms`  | WORKFLOW.md | Reaches the adapter as `domain.AgentConfig.TurnTimeoutMS` and is stored in `sessionState`. Nothing on the Claude path reads it; no per-turn deadline is set on the subprocess.              |
+| `agent.read_timeout_ms`  | WORKFLOW.md | Bounds session teardown: `orchestrator.stopSessionBestEffort` gives `StopSession` this many milliseconds on a detached context, defaulting to 10 000 ms.                                    |
+| `agent.stall_timeout_ms` | WORKFLOW.md | Enforced by the orchestrator. `orchestrator.reconcileStalled` compares `LastAgentTimestamp` against the threshold and cancels the worker's context, which terminates the turn.              |
 
 ### Context cancellation
 
-The adapter must respect `context.Context` cancellation:
-
-- `RunTurn` receives a context. If the context is cancelled (e.g., due to tracker
-  reconciliation finding the issue is terminal), the adapter must kill the subprocess
-  promptly.
-- Use `cmd.Process.Signal(syscall.SIGTERM)` followed by a grace period, then
-  `cmd.Process.Kill()`.
+`RunTurn` receives a context; the skeleton passes it to `exec.CommandContext` and installs a
+`cmd.Cancel` that sends `SIGTERM` to the process group, with `cmd.WaitDelay` set to the same
+5-second grace period before the force kill. When the context is cancelled (for example because
+tracker reconciliation found the issue terminal, or the stall detector fired), the turn returns
+`turn_cancelled` with `domain.ErrTurnCancelled` and whatever usage accumulated before the kill.
 
 ---
 
-## Permission and Approval Policy
+## Permission and approval policy
 
 Per [architecture Section 10.4](architecture/10-agent-adapter-contract.md#104-approval-tools-and-user-input-policy), Sortie adopts a high-trust posture:
 
-| Policy                    | Implementation                                                                                                                                                                                                                                                     |
-| ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Auto-approve commands     | `--dangerously-skip-permissions` bypasses all prompts.                                                                                                                                                                                                             |
-| Auto-approve file changes | Same flag covers file edits.                                                                                                                                                                                                                                       |
-| User input required       | The `-p` flag runs non-interactively. If Claude Code somehow requests user input (which should not happen in headless mode with `--dangerously-skip-permissions`), the process would stall. The adapter's turn timeout catches this. Map to `turn_input_required`. |
-| Unsupported tool calls    | Claude Code handles tool routing internally. Unknown MCP tools return failure and the session continues.                                                                                                                                                           |
+| Policy                    | Implementation                                                                                                                                                     |
+| ------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Auto-approve commands     | `--dangerously-skip-permissions` bypasses all prompts.                                                                                                             |
+| Auto-approve file changes | Same flag covers file edits.                                                                                                                                       |
+| User input required       | The `-p` flag runs non-interactively, so no prompt is expected. A process that blocks anyway produces no output and is cut off by orchestrator-side cancellation.   |
+| Unsupported tool calls    | Claude Code handles tool routing internally. Unknown MCP tools return failure and the session continues.                                                            |
+
+`--dangerously-skip-permissions` allows arbitrary command execution. Per Anthropic's guidance it
+should only be used in sandboxed environments without internet access, inside an externally
+enforced sandbox (for example a locked-down container or VM with restricted filesystem and network
+access). Sortie's workspace isolation and hook system operate inside that sandbox as additional
+defense-in-depth, but do not replace external isolation. An operator who wants selective approval
+instead of blanket bypass sets `claude-code.permission_mode`, which replaces the flag, or
+`claude-code.allowed_tools`, which pre-approves a specific set of tools such as
+`"Edit Read Bash(git *) Bash(make *) Grep Glob"`.
 
 ### Permission modes
 
@@ -590,66 +571,38 @@ Per [architecture Section 10.4](architecture/10-agent-adapter-contract.md#104-ap
 | `bypassPermissions` | All tools run without asking. Cannot run as root on Unix.                    |
 | `auto`              | Automatic permission handling.                                               |
 
-### Programmatic permission handling: `--permission-prompt-tool`
-
-Instead of blanket `--dangerously-skip-permissions`, the adapter could use
-`--permission-prompt-tool <mcp_tool_name>` to delegate permission decisions to an MCP tool.
-This enables fine-grained, programmatic approval without human interaction. The MCP tool
-receives the permission request and returns allow/deny.
-
-This is relevant for deployments that want selective approval rather than blanket bypass.
-
-### Alternative: `--allowedTools` for restricted operation
-
-Instead of `--dangerously-skip-permissions`, the adapter could use `--allowedTools` to
-pre-approve a specific set of tools:
-
-```bash
-claude -p "..." --allowedTools "Edit" "Read" "Bash(git *)" "Bash(make *)" "Grep" "Glob"
-```
-
-This provides finer-grained control but requires curating the tool list per use case.
-The adapter could expose this via the `claude-code.allowed_tools` pass-through config.
-
 ---
 
-## Error Detection and Mapping
+## Error detection and mapping
 
-### Process exit codes
+### Process exit and turn disposition
 
-| Exit Code                | Meaning                                              | Adapter mapping                                   |
-| ------------------------ | ---------------------------------------------------- | ------------------------------------------------- |
-| 0                        | Success (check `subtype`/`is_error` in result event). If no `result` event was received and cumulative output tokens are zero, treated as `turn_failed` (no-output safety heuristic). | `turn_completed` or `turn_failed` based on result / no-output heuristic |
-| 1                        | General error                                        | `turn_failed`                                     |
-| Non-zero (other)         | Unexpected failure                                   | `turn_failed`                                     |
-| 127                      | `claude` binary not found                            | `agent_not_found`                                 |
-| Signal (SIGTERM/SIGKILL) | Killed by adapter or OS                              | `turn_cancelled`                                  |
+`agentcore.DecideTurn` is the shared decision table; the Claude adapter feeds it evidence and does
+not decide the disposition itself. The outcome column gives the emitted event and, where one is
+returned, the `domain.AgentError` kind.
 
-### Result event `subtype` and `is_error` fields
+| Condition                                                          | Decided by                                        | Outcome                                    |
+| ------------------------------------------------------------------ | --------------------------------------------------- | -------------------------------------------- |
+| Context cancelled at any point                                     | `agentcore.ForkPerTurnSession.RunTurn`            | `turn_cancelled` / `turn_cancelled`        |
+| Stdout line exceeds 10 MB, or the pipe read fails                  | `agentcore.ForkPerTurnSession.RunTurn`            | `turn_failed` / `port_exit`                |
+| Exit code 127                                                      | `agentcore.ForkPerTurnSession.RunTurn`            | `turn_failed` / `agent_not_found`          |
+| Killed by signal                                                   | `agentcore.ForkPerTurnSession.RunTurn`            | `turn_cancelled` / `turn_cancelled`        |
+| Result event with `subtype: "success"` and `is_error: false`       | `OnFinalize` reports `TerminalSuccess`            | `turn_completed`                            |
+| Result event with any other subtype, or `is_error: true`           | `OnFinalize` reports `TerminalFailure`            | `turn_failed` / `turn_failed`              |
+| No result event, non-zero exit                                     | `agentcore.DecideTurn` row `RowNonZeroExit`       | `turn_failed` / `port_exit`                |
+| No result event, exit 0, no assistant output tokens this turn      | `agentcore.DecideTurn` row `RowZeroWork`          | `turn_failed` / `turn_failed`              |
+| No result event, exit 0, assistant output tokens present           | `agentcore.DecideTurn` row `RowWorkPresent`       | `turn_completed`                            |
 
-Even with exit code 0, the result event may have `is_error: true` or a non-success `subtype`.
-The adapter must check both the exit code and the result event fields.
+The success message is the result event's `result` text truncated to 500 runes; the failure
+message is the result event's `subtype`. Work evidence is this turn's own summed assistant output
+tokens, not the run-cumulative figure, which is non-zero on any second turn.
 
-| `subtype`                             | `is_error` | Adapter mapping  | Description                                   |
-| ------------------------------------- | ---------- | ---------------- | --------------------------------------------- |
-| `success`                             | `false`    | `turn_completed` | Normal completion.                            |
-| `error_max_turns`                     | `true`     | `turn_failed`    | `--max-turns` limit reached.                  |
-| `error_max_budget_usd`                | `true`     | `turn_failed`    | `--max-budget-usd` limit reached.             |
-| `error_during_execution`              | `true`     | `turn_failed`    | Runtime error (API failure, tool crash, etc). |
-| `error_max_structured_output_retries` | `true`     | `turn_failed`    | `--json-schema` validation exhausted retries. |
+Workspace and binary resolution fail earlier, in `StartSession`: an unusable workspace path yields
+`invalid_workspace_cwd` and an unresolvable command yields `agent_not_found`
+(`agentcore.ResolveWorkspace`, `agentcore.ResolveBinary`).
 
-### Error category mapping (per [architecture Section 10.5](architecture/10-agent-adapter-contract.md#105-timeouts-and-error-mapping))
-
-| Condition                                 | Error category          |
-| ----------------------------------------- | ----------------------- |
-| `claude` binary not found on `$PATH`      | `agent_not_found`       |
-| Workspace path invalid or not a directory | `invalid_workspace_cwd` |
-| No output within `read_timeout_ms`        | `response_timeout`      |
-| Turn exceeds `turn_timeout_ms`            | `turn_timeout`          |
-| Process exits non-zero                    | `port_exit`             |
-| Result event `is_error: true`             | `turn_failed`           |
-| Process killed by signal                  | `turn_cancelled`        |
-| Agent requests user input                 | `turn_input_required`   |
+The Claude path never produces `response_timeout`, `turn_timeout`, or `turn_input_required`: it
+enforces no adapter-side deadline, and `-p` admits no interactive prompt.
 
 ### API retry errors
 
@@ -666,12 +619,12 @@ handles internally:
 | `max_output_tokens`     | Output truncated. May retry with continuation.           |
 | `unknown`               | Unclassified error.                                      |
 
-The adapter should log these for debugging but does not need to act on them — Claude Code
-handles retries internally. If retries are exhausted, the process exits with code 1.
+The adapter emits these as notifications and takes no other action, because Claude Code handles
+the retries. If retries are exhausted, the process exits with code 1.
 
 ---
 
-## Session Storage
+## Session storage
 
 Claude Code persists sessions to disk at:
 
@@ -685,32 +638,28 @@ replaced by `-`.
 This is relevant for:
 
 - **Continuation:** `--resume <session_id>` reads from this path.
-- **Cleanup:** Sortie may want to clean up session files when removing workspaces.
-- **Disk usage:** Long sessions can accumulate significant JSONL files.
+- **Disk usage:** long sessions accumulate large JSONL files, and they live under `~/.claude`,
+  outside the workspace, so removing a workspace does not remove them.
 - **Ephemeral mode:** `--no-session-persistence` skips writing entirely.
 
 ---
 
-## Hooks Integration
+## Hooks integration
 
 Claude Code supports lifecycle hooks (`.claude/hooks.json`) that can intercept tool calls,
-validate actions, and inject context. Sortie does **not** manage Claude Code's hook system
-directly — these are workspace-level configurations that the coding agent or `after_create`
-hook can set up.
+validate actions, and inject context. Sortie does not manage Claude Code's hook system: these are
+workspace-level configurations that the coding agent or the `after_create` hook can set up. The
+adapter neither parses nor manages them, but their behavior shows up in turn timing and outcomes:
 
-However, the adapter should be aware that:
-
-- Hooks can block tool calls (exit code 2 from hook → tool is denied).
-- Hooks can add latency to tool execution (timeout per hook: up to 60s default).
+- Hooks can block tool calls (exit code 2 from hook, tool is denied).
+- Hooks can add latency to tool execution (timeout per hook: up to 60s default), which counts
+  against the stall threshold.
 - The `Stop` hook can prevent session completion if it returns exit code 2 (the session
   continues rather than stopping).
 
-The adapter does not need to parse or manage hooks, but hook-induced delays should be
-accounted for in timeout calculations.
-
 ---
 
-## MCP Server Configuration
+## MCP server configuration
 
 The `--mcp-config <path>` flag points Claude Code to a JSON file that declares MCP servers
 for the session. The file uses the standard MCP configuration format with a top-level
@@ -738,30 +687,39 @@ command, arguments, and optional environment variables.
 | `command` | string   | Yes      | Executable to launch for stdio servers.                            |
 | `args`    | string[] | No       | Arguments passed to the command.                                   |
 | `env`     | object   | No       | Environment variables set for the server process. Keys are         |
-|           |          |          | variable names; values are strings. Used for non-secret config.    |
+|           |          |          | variable names; values are strings.                                |
 
 Claude Code reads the file at agent startup and spawns each declared server as a child
 process with the specified command and args. The server inherits the agent's environment,
 merged with any variables in the `env` field.
 
-### `--strict-mcp-config`
-
-When passed alongside `--mcp-config`, Claude Code ignores MCP server declarations from
-workspace-level `.mcp.json` files and only uses servers from the specified config file.
-This prevents workspace-controlled MCP servers from interfering with Sortie-managed tools.
+When `--strict-mcp-config` is passed alongside `--mcp-config`, Claude Code ignores MCP server
+declarations from workspace-level `.mcp.json` files and only uses servers from the specified
+config file.
 
 ### Sortie adapter usage
 
-The worker writes a temporary `.sortie/mcp.json` to the workspace directory containing the
-`sortie mcp-server` stdio declaration. If the operator also specifies `claude-code.mcp_config`
-in WORKFLOW.md, the worker merges both server sets into a single file — Claude Code accepts
-only one `--mcp-config` path. A name collision on the `sortie-tools` key fails the attempt.
-Credential values are never written to this file — they reach the MCP server through
-inherited environment variables. See ADR-0009 for the full merge algorithm.
+`orchestrator.GenerateMCPConfig` writes `<workspace>/.sortie/mcp.json` before the session starts,
+declaring the `sortie-tools` stdio server that runs the Sortie binary as `mcp-server --workflow
+<path>`. The file is written to a temporary path and renamed into place, and `.sortie/.gitignore`
+containing `*` is rewritten on every call so the directory stays out of git. If the operator also
+specifies `claude-code.mcp_config` in WORKFLOW.md, the worker reads that file and merges the
+`sortie-tools` entry into its `mcpServers` object, because Claude Code accepts only one
+`--mcp-config` path; a name collision on the `sortie-tools` key fails the attempt. See ADR-0009
+for the full merge algorithm.
+
+The `env` block of the generated entry carries the per-session variables (`SORTIE_ISSUE_ID`,
+`SORTIE_ISSUE_IDENTIFIER`, `SORTIE_WORKSPACE`, `SORTIE_DB_PATH`, `SORTIE_SESSION_ID`,
+`SORTIE_SESSION_AGENT_KIND`, and `SORTIE_ATTEMPT` on retries) layered over every `SORTIE_`-prefixed
+variable in the orchestrator's own environment (`orchestrator.CollectSortieEnv`), which includes
+tracker credentials. Per-session values win on collision. The file is written with mode 0600.
+
+`buildArgs` passes `--mcp-config` with the generated path whenever the worker produced one, and
+falls back to the operator's `claude-code.mcp_config` path only when it did not.
 
 ---
 
-## OpenTelemetry Integration
+## OpenTelemetry integration
 
 Claude Code supports OpenTelemetry for monitoring:
 
@@ -783,91 +741,71 @@ Available metrics and events:
 | `claude_code.api_request`   | Event   | Per-request: `input_tokens`, `output_tokens`, `cache_read_tokens`, `cost_usd`, `duration_ms` |
 | `claude_code.tool_result`   | Event   | Per-tool: `tool_name`, `success`, `duration_ms`                                              |
 
-Sortie may optionally enable telemetry in the subprocess environment for external monitoring,
-but the adapter's primary event source is the `stream-json` stdout output, not OTel.
+These variables reach the CLI when they are set in the Sortie process environment, since the
+subprocess inherits it. The adapter sets none of them itself, and its event source is the
+`stream-json` stdout output, not OTel.
 
 ---
 
-## Adapter-Specific Pass-Through Config
+## Adapter pass-through config
 
 Per [architecture Section 5.3.5](architecture/05-workflow-specification.md#535-agent-object), the adapter reads pass-through config from the `claude-code`
-sub-object in WORKFLOW.md:
+sub-object in WORKFLOW.md. `parsePassthroughConfig` reads these keys; a missing or wrong-typed key
+falls back to the zero value, except `session_persistence`, which defaults to `true`.
 
 | Config key                        | Type    | Description                                                                                                                                                 |
 | --------------------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `claude-code.permission_mode`     | string  | Permission mode: `default`, `acceptEdits`, `dontAsk`, `bypassPermissions`, `plan`, `auto`. Overrides the default `--dangerously-skip-permissions` behavior. |
+| `claude-code.permission_mode`     | string  | Permission mode: `default`, `acceptEdits`, `dontAsk`, `bypassPermissions`, `plan`, `auto`. Replaces the default `--dangerously-skip-permissions`.           |
 | `claude-code.model`               | string  | Model override (e.g., `claude-sonnet-4-6`). Maps to `--model`.                                                                                              |
 | `claude-code.fallback_model`      | string  | Fallback model for rate-limit resilience. Maps to `--fallback-model`.                                                                                       |
-| `claude-code.max_turns`           | integer | Claude Code internal max turns per invocation. Maps to `--max-turns`.                                                                                       |
-| `claude-code.max_budget_usd`      | number  | Cost cap per invocation. Maps to `--max-budget-usd`.                                                                                                        |
+| `claude-code.max_turns`           | integer | Claude Code internal max turns per invocation. Maps to `--max-turns` when greater than zero.                                                                |
+| `claude-code.max_budget_usd`      | number  | Cost cap per invocation. Maps to `--max-budget-usd` when greater than zero.                                                                                 |
 | `claude-code.effort`              | string  | Reasoning effort: `low`, `medium`, `high`, `max`. Maps to `--effort`.                                                                                       |
 | `claude-code.allowed_tools`       | string  | Space-separated tool list. Maps to `--allowedTools`.                                                                                                        |
 | `claude-code.disallowed_tools`    | string  | Space-separated denied tool list. Maps to `--disallowedTools`.                                                                                              |
 | `claude-code.system_prompt`       | string  | Additional system prompt text. Maps to `--append-system-prompt`.                                                                                            |
-| `claude-code.mcp_config`          | string  | Path to MCP config JSON. Maps to `--mcp-config`.                                                                                                            |
-| `claude-code.session_persistence` | boolean | If `false`, passes `--no-session-persistence`. Default: `true`.                                                                                             |
+| `claude-code.mcp_config`          | string  | Path to an operator MCP config JSON. Merged by the worker; see MCP server configuration.                                                                    |
+| `claude-code.session_persistence` | boolean | If `false`, passes `--no-session-persistence`. Default: `true`.                                                                                              |
 
 ---
 
-## Example Adapter Invocation
+## Example invocation
 
-### Turn 1 (new session)
+`buildArgs` emits flags in a fixed order: `-p`, output format, verbose, the permission flag, the
+session flag, then model, fallback model, max turns, max budget, effort, allowed tools,
+disallowed tools, system prompt, MCP config, and session persistence. A continuation turn of a
+workflow that sets a model, a fallback model, and a cost cap produces this argv (one entry per
+line, no shell involved):
 
-```bash
-prompt='You are working on issue PROJ-123. Fix the authentication bug described below.
-
-## Issue: Authentication fails on expired tokens
-
-The login endpoint returns 500 when the JWT token is expired instead of 401...
-
-## Instructions
-1. Read the relevant code files
-2. Implement the fix
-3. Run tests to verify'
-
-sh -c 'claude -p "$1" \
-  --output-format stream-json \
-  --verbose \
-  --dangerously-skip-permissions' -- "$prompt"
 ```
-
-Working directory: `/var/sortie/workspaces/PROJ-123`
-
-### Turn 2 (continuation)
-
-```bash
-prompt='Continue working on the issue. The previous turn made progress but tests are still failing. Focus on fixing the remaining test failures.'
-session_id='abc123-session-id'
-
-sh -c 'claude -p "$1" \
-  --output-format stream-json \
-  --verbose \
-  --dangerously-skip-permissions \
-  --resume "$2"' -- "$prompt" "$session_id"
-```
-
-Working directory: `/var/sortie/workspaces/PROJ-123`
-
-### With cost cap and model override
-
-```bash
-sh -c 'claude -p "$1" \
-  --output-format stream-json \
-  --verbose \
-  --dangerously-skip-permissions \
-  --model claude-sonnet-4-6 \
-  --fallback-model claude-haiku-4-5-20251001 \
-  --max-budget-usd 5.00 \
-  --max-turns 50' -- "$prompt"
+claude
+-p
+Continue working on the issue. The previous turn made progress but tests are still failing.
+--output-format
+stream-json
+--verbose
+--dangerously-skip-permissions
+--resume
+3f2a1b8c-5d6e-4f70-9a1b-2c3d4e5f6071
+--model
+claude-sonnet-4-6
+--fallback-model
+claude-haiku-4-5-20251001
+--max-budget-usd
+5
+--mcp-config
+/var/sortie/workspaces/PROJ-123/.sortie/mcp.json
 ```
 
 ---
 
-## SDK Alternative (Reference Only)
+## SDK alternative (reference only)
 
 Anthropic provides TypeScript and Python SDKs for programmatic Claude Code usage. Both
 internally spawn the Claude Code CLI as a subprocess with `--input-format stream-json
---output-format stream-json --include-partial-messages` and communicate over stdin/stdout.
+--output-format stream-json --include-partial-messages` and communicate over stdin/stdout. The SDK
+documentation is useful as a reference for expected message types and session behavior, because
+the SDK and CLI share the same underlying protocol.
 
 ### TypeScript SDK (`@anthropic-ai/claude-agent-sdk`)
 
@@ -928,35 +866,38 @@ async with ClaudeSDKClient(options=options) as client:
     await client.query("Now refactor it")  # same session
 ```
 
-Sortie does **not** use the SDKs because the adapter is implemented in Go and the
-architecture mandates subprocess-based integration ([Section 10.7](architecture/10-agent-adapter-contract.md#107-local-subprocess-launch-contract)). The CLI provides a
-clean, language-agnostic integration surface. The SDK documentation is useful as a
-reference for expected message types and session behavior, as the SDK and CLI share the
-same underlying protocol.
+---
+
+## Open questions
+
+- **Does the CLI accept `--max-turns`?** The flag is documented in the GitHub Actions
+  `claude_args` reference and does not appear in `claude --help` on v2.1.76, which leaves open
+  whether it is an SDK-and-settings surface rather than a CLI flag. `buildArgs` passes it whenever
+  `claude-code.max_turns` is configured, so an unsupported flag would break every turn of such a
+  workflow. Probe: run `claude -p 'reply with ok' --max-turns 1 --output-format stream-json
+  --verbose` against the pinned binary and read the parser exit code and the first stdout line; a
+  rejected flag fails before any JSON is emitted.
+- **What `type` values do task messages carry on the wire?** The message shapes are documented by
+  their SDK type names (`TaskStartedMessage`, `TaskProgressMessage`, `TaskNotificationMessage`),
+  not by the `type` string that `ParseLine` switches on, so they land in the default arm as
+  `other_message`. Probe: run a headless turn whose prompt forces a subagent or a
+  background bash task and record the `type` field of each resulting stdout line.
 
 ---
 
-## Summary: Adapter Implementation Checklist
+## Sources
 
-1. **StartSession:** Store workspace path and config. Optionally pre-assign session ID via
-   `--session-id`. Do not launch subprocess yet.
-2. **RunTurn (turn 1):** Launch `claude -p <prompt> --output-format stream-json --verbose
---dangerously-skip-permissions [--session-id <uuid>]` with cwd = workspace. Parse JSONL
-   stdout. Capture `session_id` from init event.
-3. **RunTurn (turn 2+):** Same as turn 1 but append `--resume <session_id>`.
-4. **Event parsing:** Map `stream-json` event types to normalized `AgentEvent` types. Handle
-   all message types: `system`, `assistant`, `result`, `stream_event`.
-5. **Result handling:** Check both `subtype` and `is_error` in result messages. Map subtypes
-   to appropriate exit reasons.
-6. **Token tracking:** Extract `usage` object from result events. Normalize to
-   `{input_tokens, output_tokens, total_tokens}`.
-7. **Cost tracking:** Extract `total_cost_usd` and `duration_ms` from result events.
-8. **Timeout:** Enforce `turn_timeout_ms` via context deadline + SIGTERM/SIGKILL.
-9. **StopSession:** Kill subprocess if running (SIGTERM → grace → SIGKILL).
-10. **Error mapping:** Check exit code, result `subtype`, and `is_error` field. Map to
-    architecture error categories.
-11. **Session continuity:** Use `--resume <session_id>` for multi-turn conversations.
-12. **Permissions:** Default to `--dangerously-skip-permissions` for headless operation.
-13. **Cost safety:** Optionally set `--max-budget-usd` as a per-invocation cost cap.
-14. **API retries:** Log `api_retry` system events for visibility; Claude Code handles
-    retries internally.
+Local probe:
+
+- `claude --help` on CLI v2.1.76 (flag surface and version pin).
+
+Anthropic first-party documentation, read March 2026:
+
+- Claude Code CLI reference: flags, headless (`-p`) mode, permission modes, session storage.
+- Claude Code `stream-json` output reference: message union, system subtypes, content blocks,
+  result fields and subtypes, task messages.
+- Claude Code monitoring reference: OpenTelemetry environment variables, metrics, and events.
+- Claude Code hooks reference: hook exit codes and per-hook timeout.
+- Claude Code GitHub Actions reference: `claude_args`, source of the `--max-turns` claim.
+- `@anthropic-ai/claude-agent-sdk` (TypeScript) and `claude-agent-sdk` (Python) SDK references.
+- Model Context Protocol configuration format (`mcpServers` object).

--- a/docs/codex-adapter-notes.md
+++ b/docs/codex-adapter-notes.md
@@ -527,8 +527,10 @@ own from `agent.turn_timeout_ms`; the turn's deadline is whatever context the or
 passes to `RunTurn`. The `initialize`, `account/read`, `thread/start`, and `thread/resume`
 responses are bounded by that same context, not by the read timeout.
 
-On context cancellation `RunTurn` sends `turn/interrupt` once, on a detached two-second
-context so the cancelled parent cannot drop it:
+On context cancellation `RunTurn` sends `turn/interrupt` once. `sendRequest` takes no context
+and writes the frame straight to the app-server's stdin, so the cancelled parent cannot drop it
+and no deadline bounds the write. `RunTurn` builds a two-second context at that call site and
+never passes it in:
 
 ```json
 {"method": "turn/interrupt", "id": 99, "params": {"threadId": "thr_abc123", "turnId": "turn_456"}}

--- a/docs/codex-adapter-notes.md
+++ b/docs/codex-adapter-notes.md
@@ -1,49 +1,42 @@
-# OpenAI Codex CLI: Adapter Research Notes
+# OpenAI Codex CLI: adapter research notes
 
-> OpenAI Codex CLI v0.134.x (npm `@openai/codex`, binary `codex`), researched April 2026.
-> and updated research on May 2026. Reference for implementing the Codex `AgentAdapter`.
+> OpenAI Codex CLI v0.134.0 (npm `@openai/codex`, binary `codex`) on Linux x86_64.
+> Reference for the `domain.AgentAdapter` implementation in `internal/agent/codex`,
+> registered under kind `codex`.
 >
+> Coverage: the hosted-tool and model-tier behavior, the feature-flag surface, and the
+> self-generated JSON Schema are anchored to v0.134.0, probed May 2026. The app-server
+> transcripts (initialize, thread, turn, item, and token-usage messages) and the `codex exec`
+> JSONL samples were captured on v0.121.0 in April 2026 and have not been re-observed since;
+> the `userAgent` values quoted in the examples carry that version. The dynamic-tool response
+> payload and the granular approval-policy map rest on OpenAI Symphony's Elixir app-server
+> client, not on a local probe.
+>
+> Claims about Sortie's own code name a Go symbol and were verified against the tree.
 > Primary sources are linked under "Sources" at the end.
->
-> **Prior art:** OpenAI Symphony (Elixir) uses the app-server JSON-RPC
-> protocol exclusively. Sortie's adapter uses the same protocol surface per architecture
-> [Section 10.7](architecture/10-agent-adapter-contract.md#107-local-subprocess-launch-contract) (Local Subprocess Launch Contract).
 
 ---
 
 ## Overview
 
-Codex CLI is an agentic coding tool from OpenAI that runs as a native Rust binary with a
-Node.js-optional architecture. It reads a codebase, executes tools (shell commands, file edits,
-MCP tool calls, web searches), and produces code changes autonomously. Sortie treats it as a
-subprocess: launch its app-server mode, send JSON-RPC commands over stdio, read structured
-event notifications, and terminate when done.
+Codex CLI is an agentic coding tool from OpenAI that runs as a native Rust binary. It reads a
+codebase, executes tools (shell commands, file edits, MCP tool calls, and web searches), and
+produces code changes autonomously.
 
-Two integration surfaces exist, in order of relevance to Sortie:
+Codex exposes two non-interactive surfaces:
 
 1. **App-server mode** (`codex app-server`) communicating over JSON-RPC 2.0 on stdio (JSONL).
-   This is the primary integration surface. The app-server protocol powers the Codex VS Code
-   extension and is the surface used by OpenAI's own Symphony orchestrator. It provides full
-   lifecycle control: thread management, turn execution, approval handling, dynamic tool
-   registration, and session resume.
-2. **Non-interactive CLI** (`codex exec`) with `--json` for JSONL output on stdout. This is
-   simpler but offers less control: no approval routing, no dynamic tool injection, no
-   mid-turn steering. Suitable for one-shot CI tasks but insufficient for Sortie's multi-turn
-   orchestration needs.
+   It provides full lifecycle control: thread management, turn execution, approval handling,
+   dynamic tool registration, and session resume. The same protocol powers the Codex VS Code
+   extension.
+2. **Non-interactive CLI** (`codex exec`) with `--json` for JSONL output on stdout. It carries
+   no approval routing, no dynamic tool injection, and no mid-turn steering.
 
-Sortie's Go adapter uses the app-server approach (surface 1). The `codex exec` surface is
-documented as a fallback reference.
-
-### Architectural difference from Claude Code and Copilot adapters
-
-The Claude Code and Copilot adapters use a "launch-per-turn" model: each `RunTurn` call spawns a
-new subprocess with `-p <prompt>` and reads JSONL until the process exits. Session continuity
-relies on `--resume <session_id>`.
-
-The Codex adapter uses a **persistent subprocess** model: `codex app-server` is launched once in
-`StartSession` and kept alive across turns. Each turn is a `turn/start` JSON-RPC request within
-a persistent thread. This matches Symphony's architecture and provides lower per-turn overhead,
-richer approval control, and reliable session state.
+`CodexAdapter` in `internal/agent/codex` uses the app-server surface. Unlike the Claude Code,
+Copilot, and OpenCode adapters, which fork one subprocess per turn, it launches
+`codex app-server` once in `StartSession` and keeps it alive for the whole session; each turn is
+a `turn/start` request on one persistent thread. The `codex exec` surface is described at the
+end of this document for reference; no adapter code path reaches it.
 
 ---
 
@@ -63,17 +56,17 @@ brew install --cask codex
 # codex-x86_64-unknown-linux-musl.tar.gz
 ```
 
-After installation the `codex` binary is available on `$PATH`. The adapter's `agent.command`
-config field defaults to `codex app-server` but can be overridden to point to a specific path
-or wrapper script.
+After installation the `codex` binary is available on `$PATH`. `agentcore.ResolveLaunchTarget`
+falls back to the command `codex app-server` when `agent.command` is unset, splits the command
+on whitespace, and resolves the first token through `exec.LookPath`; an operator can point
+`agent.command` at a specific path or wrapper script instead.
 
 **Runtime requirements:**
 
-- The `codex` binary (Rust-based, statically linked; no Node.js runtime required for the core
-  binary since the rewrite from TypeScript to Rust)
-- A valid OpenAI API key (`CODEX_API_KEY` or ChatGPT session credentials)
-- A Git repository (Codex requires commands to run inside a Git repo; override with
-  `--skip-git-repo-check` if necessary)
+- The `codex` binary, a statically linked native Rust build that needs no Node.js runtime.
+- A valid OpenAI API key (`CODEX_API_KEY` or ChatGPT session credentials).
+- A Git repository. Codex requires commands to run inside a Git repo, and `--skip-git-repo-check`
+  overrides that check.
 
 **Supported platforms:** Linux (x86_64, arm64), macOS (x86_64, Apple Silicon), Windows (native
 or WSL2).
@@ -97,11 +90,11 @@ Codex CLI supports three authentication modes.
 | `agent.kind`         | `codex`                                            |
 | `agent.command`      | `codex app-server` (or full path to the binary)    |
 
-The adapter does **not** manage API keys directly. `CODEX_API_KEY` must be present in the
-environment of the Sortie process. The adapter inherits the parent process environment when
-spawning the subprocess.
+`CODEX_API_KEY` must be present in the environment of the Sortie process. `StartSession` sets
+`cmd.Env = os.Environ()`, so the subprocess inherits it. In SSH mode `buildSSHRemoteCmd`
+prepends `CODEX_API_KEY=<shell-quoted value>` to the remote command.
 
-For headless/CI environments where browser login is unavailable:
+For headless and CI environments where browser login is unavailable:
 
 1. Set `CODEX_API_KEY` as an environment variable (preferred).
 2. Alternatively, authenticate on a machine with a browser via `codex login`, then copy
@@ -109,20 +102,23 @@ For headless/CI environments where browser login is unavailable:
 
 ### App-server authentication sequence
 
-When using the app-server protocol, the adapter verifies auth state after initialization:
+`authenticateIfNeeded` runs after the initialization handshake and reads the auth state:
 
 ```json
 {"method": "account/read", "id": 1, "params": {"refreshToken": false}}
 ```
 
-If `result.account` is `null` and `CODEX_API_KEY` is set, the adapter logs in:
+A non-null `result.account` means the app-server already holds valid credentials and the
+function returns. When `result.account` is `null` and `CODEX_API_KEY` is set, it logs in:
 
 ```json
 {"method": "account/login/start", "id": 2, "params": {"type": "apiKey", "apiKey": "sk-..."}}
 ```
 
-The adapter waits for `account/login/completed` with `success: true` before proceeding to
-thread creation.
+It then waits up to `readTimeout(state)` for the `account/login/completed` notification and
+fails the session with `domain.ErrResponseError` unless it carries `success: true`. When
+`result.account` is `null` and `CODEX_API_KEY` is empty, the function returns without logging
+in and the session proceeds unauthenticated.
 
 **Credential storage:** Codex caches login details in `~/.codex/auth.json` (plaintext) or the
 OS keychain (configurable via `cli_auth_credentials_store` in `config.toml`). The adapter
@@ -147,25 +143,25 @@ adapter.
 
 ### Launching the app-server
 
-```
-sh -c '$AGENT_COMMAND' -- 
-```
-
-Where `$AGENT_COMMAND` defaults to `codex app-server`. The subprocess receives:
+`StartSession` execs the resolved binary directly through `exec.CommandContext`, with no shell
+in between: `LaunchTarget.Command` is the absolute path to `codex` and `LaunchTarget.Args` holds
+the remaining tokens of `agent.command`, so the default yields `codex app-server`. When
+`StartSessionParams.SSHHost` is set the local command is `ssh` and the codex command runs on the
+remote host. The subprocess receives:
 
 | Setting           | Value                                               | Rationale                                                 |
 | ----------------- | --------------------------------------------------- | --------------------------------------------------------- |
 | Working directory | Workspace path (`StartSessionParams.WorkspacePath`) | Agent must operate in the issue workspace.                |
 | Stdout            | Pipe (read by adapter)                              | JSONL output parsed line by line.                         |
 | Stdin             | Pipe (written by adapter)                           | JSON-RPC requests sent as JSONL.                          |
-| Stderr            | Pipe (read by adapter, logged)                      | Diagnostic output, not structured.                        |
+| Stderr            | Pipe (read by `procutil.StderrCollector`, logged)   | Diagnostic output, not structured.                        |
 | Environment       | Inherited from Sortie process                       | `CODEX_API_KEY` and other auth vars must be present.      |
-| Max line size     | 1 MB                                                | Safe buffering per Symphony's observed message sizes.     |
+| Max line size     | 1 MB                                                | `bufio.Scanner` buffer ceiling; a longer line fails the read. |
 
 ### Initialization handshake
 
-After launching, the adapter sends `initialize` followed by the `initialized` notification.
-Requests sent before initialization are rejected.
+`initializeHandshake` sends `initialize` and then the `initialized` notification. Requests sent
+before initialization are rejected.
 
 ```json
 {"method": "initialize", "id": 1, "params": {
@@ -192,8 +188,8 @@ Then:
 {"method": "initialized", "params": {}}
 ```
 
-`capabilities.experimentalApi` enables dynamic tool registration (`dynamicTools` on
-`thread/start`) which Sortie uses for the `tracker_api` tool.
+`initializeHandshake` always requests `capabilities.experimentalApi: true`, which is what
+unlocks the `dynamicTools` field on `thread/start`.
 
 ---
 
@@ -211,10 +207,10 @@ Then:
 
 | Sortie lifecycle event | App-server action                               |
 | ---------------------- | ----------------------------------------------- |
-| `StartSession`         | Launch `codex app-server`, `initialize`, `thread/start` |
+| `StartSession`         | Launch `codex app-server`, `initialize`, `account/read`, `thread/start` or `thread/resume` |
 | `RunTurn` (turn 1)     | `turn/start` with prompt and configuration      |
 | `RunTurn` (turn 2+)    | `turn/start` on the same thread                 |
-| `StopSession`          | Close stdin, SIGTERM → grace → SIGKILL          |
+| `StopSession`          | Close stdin, SIGTERM, grace period, SIGKILL     |
 
 ### Starting a thread
 
@@ -254,11 +250,17 @@ Followed by a notification:
 {"method": "thread/started", "params": {"thread": {"id": "thr_abc123"}}}
 ```
 
-The adapter records `thread.id` for all subsequent turn operations.
+`startThread` sends `cwd`, `approvalPolicy` (default `never`), and `sandbox` (default
+`workspace-write`) on every call, adds `model` and `personality` when the pass-through config
+sets them, and adds `dynamicTools` when the tool registry is non-empty. It reads `thread.id`
+from the response, fails the session when that field is empty, then waits up to
+`readTimeout(state)` for the `thread/started` notification and returns the thread ID even if
+that notification never arrives. `domain.Session.ID` carries the thread ID.
 
-**`dynamicTools`** is an experimental field that requires `experimentalApi` capability.
-It registers client-side tools that Codex can invoke during turns. The adapter uses this
-to expose `tracker_api` without requiring MCP server configuration.
+`dynamicTools` requires the `experimentalApi` capability. It registers client-side tools that
+Codex invokes through `item/tool/call` during turns, which is how Sortie exposes `tracker_api`
+without running an MCP server. `buildDynamicTools` emits one entry per tool in
+`domain.ToolRegistry`, each carrying the tool's `Name()`, `Description()`, and `InputSchema()`.
 
 ### Starting a turn
 
@@ -267,7 +269,6 @@ to expose `tracker_api` without requiring MCP server configuration.
   "threadId": "thr_abc123",
   "input": [{"type": "text", "text": "<rendered prompt>"}],
   "cwd": "/var/sortie/workspaces/PROJ-123",
-  "approvalPolicy": "never",
   "sandboxPolicy": {
     "type": "workspaceWrite",
     "writableRoots": ["/var/sortie/workspaces/PROJ-123"],
@@ -284,12 +285,16 @@ Response:
 {"id": 30, "result": {"turn": {"id": "turn_456", "status": "inProgress", "items": [], "error": null}}}
 ```
 
-The adapter records `turn.id` for timeout enforcement and interrupt capability.
+`RunTurn` sends `threadId`, `input`, and `cwd` on every call. It adds `sandboxPolicy` on the
+first turn of the session and on any turn when `codex.turn_sandbox_policy` is configured, and
+adds `model` and `effort` when the pass-through config sets them. `turn/start` also accepts an
+`approvalPolicy` override, which the adapter never sends, so the thread-level policy governs the
+whole session. The `turn.id` from the response is the interrupt target.
 
 ### Continuation turns
 
-For turn 2+, the adapter sends another `turn/start` on the same thread. No `--resume` flag
-is needed; the thread maintains full conversation history automatically.
+For turn 2 onward, `RunTurn` sends another `turn/start` on the same thread. No resume argument
+is needed; the thread maintains full conversation history.
 
 ```json
 {"method": "turn/start", "id": 31, "params": {
@@ -299,59 +304,64 @@ is needed; the thread maintains full conversation history automatically.
 }}
 ```
 
-This is simpler than the Claude Code and Copilot adapters, which require launching a new
-subprocess per turn with explicit session ID propagation.
-
 ### Resuming a previous session
 
-If the app-server process was terminated between Sortie runs but the thread log exists on disk:
+When `StartSessionParams.ResumeSessionID` is non-empty, `resumeThread` sends:
 
 ```json
 {"method": "thread/resume", "id": 11, "params": {"threadId": "thr_abc123"}}
 ```
 
 The response matches `thread/start`. History is restored from the thread's JSONL rollout file.
+When the resume request fails, `StartSession` logs a warning and falls back to `startThread`,
+so the session continues on a fresh thread with no history rather than failing.
 
 ---
 
 ## Event stream
 
-After `turn/start`, the adapter reads JSONL notifications from stdout until `turn/completed`
-is received. The `turn/completed` payload carries the final status for both successful and
-failed turns.
+After `turn/start`, `RunTurn` reads JSONL notifications from stdout until `turn/completed`
+arrives. The `turn/completed` payload carries the final status for both successful and failed
+turns. Any notification whose method is not listed below becomes a `domain.EventOtherMessage`
+carrying the method name.
 
 ### Turn events
 
 | Notification          | Description                                       | Adapter mapping                  |
 | --------------------- | ------------------------------------------------- | -------------------------------- |
-| `turn/started`        | Turn begins. Contains turn ID.                    | `session_started` (first turn)   |
-| `turn/completed`      | Turn finished. Contains final status. No usage member. | `turn_completed`            |
+| `turn/started`        | Turn begins. Contains turn ID.                    | `session_started` on the session's first turn, `notification` afterwards |
+| `turn/completed`      | Turn finished. Contains final status.             | Terminal event, see "Turn completion" |
 | `thread/tokenUsage/updated` | Token usage snapshot for the thread.        | `token_usage`                    |
-| `turn/diff/updated`   | Aggregated diff across file changes.              | Log for observability            |
+| `turn/diff/updated`   | Aggregated diff across file changes.              | Debug log only, no event         |
 | `turn/plan/updated`   | Agent's plan update.                              | `notification`                   |
 
 ### Item events
 
 | Notification             | Description                                    | Adapter mapping        |
 | ------------------------ | ---------------------------------------------- | ---------------------- |
-| `item/started`           | New item begins (command, message, tool call). | `tool_use` / `notification` |
-| `item/completed`         | Item finished with final state.                | `tool_result` / `assistant_message` |
-| `item/agentMessage/delta`| Streaming text delta for agent message.        | Stall detection timer reset |
-| `item/commandExecution/outputDelta` | Streaming command output.            | Stall detection timer reset |
+| `item/started`           | New item begins (command, message, tool call). | `notification` summarizing type and item ID; tool-shaped items also open an `agentcore.ToolTracker` entry |
+| `item/completed`         | Item finished with final state.                | `tool_result` when the item ID is tracked; `notification` with the first 200 runes for an `agentMessage` |
+| `item/agentMessage/delta`| Streaming text delta for agent message.        | Empty `notification`   |
+| `item/commandExecution/outputDelta` | Streaming command output.            | Empty `notification`   |
+| `item/tool/call`         | Dynamic tool invocation request.               | Dispatched to `domain.ToolRegistry`, see "Dynamic tool calls" |
+
+Every emitted event advances `RunningEntry.LastAgentTimestamp` in the orchestrator, which is
+what the stall detector reads. The empty-message notifications on the two delta methods exist
+for that reason alone.
 
 ### Item types
 
 | `item.type`            | Description                                      | Notes                                  |
 | ---------------------- | ------------------------------------------------ | -------------------------------------- |
-| `userMessage`          | User prompt (echoed back).                       | Ignored by adapter.                    |
-| `agentMessage`         | Agent's text response.                           | Map to `assistant_message`.            |
-| `reasoning`            | Model reasoning output (when supported).         | Log; not mapped to events.             |
-| `commandExecution`     | Shell command execution.                         | Map to `tool_use` / `tool_result`.     |
-| `fileChange`           | Proposed or applied file edits.                  | Map to `tool_use` / `tool_result`.     |
-| `mcpToolCall`          | MCP tool invocation.                             | Map to `tool_use` / `tool_result`.     |
-| `dynamicToolCall`      | Client-side dynamic tool invocation.             | Handle `tracker_api` calls.            |
-| `webSearch`            | Web search request.                              | Log as `notification`.                 |
-| `contextCompaction`    | History compaction event.                        | Log as `notification`.                 |
+| `userMessage`          | User prompt (echoed back).                       | No special handling; summarized as a notification. |
+| `agentMessage`         | Agent's text response.                           | Text emitted as a notification on `item/completed`. |
+| `reasoning`            | Model reasoning output (when supported).         | No special handling.                   |
+| `commandExecution`     | Shell command execution.                         | Tool-tracked under the `command` field, or under the item type when that field is empty. |
+| `fileChange`           | Proposed or applied file edits.                  | Tool-tracked under the item type name. |
+| `mcpToolCall`          | MCP tool invocation.                             | Tool-tracked under the item type name. |
+| `dynamicToolCall`      | Client-side dynamic tool invocation.             | Tool-tracked under the item type name. |
+| `webSearch`            | Web search request.                              | No special handling.                   |
+| `contextCompaction`    | History compaction event.                        | No special handling.                   |
 
 ### Turn completion
 
@@ -373,18 +383,18 @@ The `turn/completed` notification contains the final turn state:
 | Status           | Adapter mapping                                                                                                            | Description                                       |
 | ---------------- | ---------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
 | `completed`      | `turn_completed`                                                                                                            | Agent finished normally.                          |
-| `interrupted`    | `turn_cancelled` when the turn's context was already cancelled; `turn_failed` when the context was still live               | Cancelled via `turn/interrupt`, or an interruption sortie did not request. |
+| `interrupted`    | `turn_cancelled` when the turn's context was already cancelled; `turn_failed` when the context was still live               | Cancelled via `turn/interrupt`, or an interruption Sortie did not request. |
 | `failed`         | `turn_failed`                                                                                                                | Error during turn execution.                      |
 | any other status | `turn_failed`                                                                                                                | An unrecognized status is treated as a failure.   |
 
-On failure, `turn.error` contains `{message, codexErrorInfo?, additionalDetails?}`.
+On failure, `turn.error` contains `{message, codexErrorInfo?, additionalDetails?}`. The adapter
+parses `message` and `codexErrorInfo`.
 
-Codex's persistent per-session subprocess exits once at session end, not once per turn, so the
-turn-disposition rule the adapter family shares has no per-turn process exit to consult for this
-adapter. The rule's zero-work row, which the other four adapters reach when their runtime reports
-no outcome and the process exits `0`, is structurally unreachable here: an absent `turn/completed`
-notification is already a failure on its own terms (the stdout channel closed before it arrived),
-so the adapter never needs a separate zero-work guard.
+The persistent subprocess exits once at session end, not once per turn, so `RunTurn` has no
+per-turn process exit to report to `agentcore.DecideTurn`. It builds every `TurnEvidence` with
+`Work: agentcore.WorkUnobservable` and leaves `ExitObserved` false, which makes the shared
+decision's zero-work row unreachable for this adapter: a missing `turn/completed` means the
+stdout channel closed first, and that path already finalizes as `domain.ErrPortExit`.
 
 ---
 
@@ -411,12 +421,18 @@ Token usage arrives separately, on `thread/tokenUsage/updated`:
 
 `total` is thread-cumulative: it spans every turn of the thread, including turns from an earlier
 run when the thread is resumed. It accumulates as `total(n) = total(n-1) + last(n)`, so a fresh
-thread's first notification reports `total` equal to `last`. The adapter recovers this run's own
+thread's first notification reports `total` equal to `last`. `RunTurn` recovers this run's own
 contribution by subtracting a baseline captured at the first notification whose `turnId` matches
 the run's current turn: `baseline = total - last` at that first notification, and every
-subsequent matching notification reports `total - baseline`.
+subsequent matching notification reports `total - baseline`. A notification carrying a different
+`turnId` raises the baseline to the componentwise maximum through `maxUsage` and emits nothing.
 
-Normalization to Sortie's `{input_tokens, output_tokens, total_tokens, cache_read_tokens}`:
+A notification whose `tokenUsage` object is absent from the wire payload is distinguishable
+from one reporting all-zero counts, because `tokenUsageUpdatedParams.TokenUsage` is a pointer.
+The absent case emits no event and leaves `sessionState.usageMeasured` untouched, so
+`domain.TurnResult.UsageMeasured` stays false until a real measurement arrives.
+
+Normalization by `normalizeBreakdown` to `domain.TokenUsage`:
 
 | Codex field (`total` or `last` breakdown) | Sortie field      | Notes                                    |
 | ----------------------- | ----------------- | ---------------------------------------- |
@@ -440,16 +456,16 @@ Codex enforces OS-level sandboxing (Seatbelt on macOS, bwrap + seccomp on Linux)
 | Danger full access    | `danger-full-access`   | `dangerFullAccess`   | No sandbox. Full filesystem and network access. |
 | External sandbox      | `external-sandbox`     | `externalSandbox`    | Codex skips its sandbox; external enforcement assumed. |
 
-The app-server uses **kebab-case** for the `sandbox` field on `thread/start` and **camelCase**
-for `sandboxPolicy.type` on `turn/start`. The adapter's WORKFLOW.md config (`thread_sandbox`)
-accepts camelCase values and translates to the correct wire format for each endpoint.
+The app-server uses kebab-case for the `sandbox` field on `thread/start` and camelCase for
+`sandboxPolicy.type` on `turn/start`. `normalizeSandbox` and `denormalizeSandbox` translate
+`codex.thread_sandbox` into whichever form the endpoint expects, and pass through a value
+already in the target form.
 
-For Sortie's headless operation in sandboxed containers, two approaches:
-
-1. **`workspaceWrite`** with `writableRoots` set to the workspace path. This is the default
-   and preferred approach, matching Symphony's configuration.
-2. **`dangerFullAccess`** inside an externally sandboxed container (Docker with restricted
-   filesystem and network). Use only when workspace-write is insufficient.
+`buildSandboxPolicy` defaults the turn policy to `workspaceWrite` with `writableRoots` set to
+the workspace path and `networkAccess: false`, then copies `codex.turn_sandbox_policy` over the
+result, so an operator override can replace any key including those two. Running
+`dangerFullAccess` inside an externally sandboxed container (Docker with a restricted filesystem
+and network) is the alternative when workspace write is too narrow.
 
 ### Approval policies
 
@@ -460,48 +476,35 @@ For Sortie's headless operation in sandboxed containers, two approaches:
 | Unless trusted   | `"unlessTrusted"`   | Ask for untrusted commands.                        |
 | Always ask       | `"always"`          | Ask for every action.                              |
 
-For headless orchestration, the adapter sets `approvalPolicy: "never"` on both `thread/start`
-and `turn/start`. This is equivalent to `--full-auto` or `--ask-for-approval never` in CLI
-mode.
+`startThread` sends `approvalPolicy: "never"` unless `codex.approval_policy` overrides it. That
+is the app-server equivalent of `--full-auto` or `--ask-for-approval never` in CLI mode, and it
+permits arbitrary command execution within the sandbox boundary, so OpenAI's guidance is to use
+it only in a sandboxed environment. Sortie's workspace isolation and hook system operate inside
+that sandbox as defense in depth and do not replace container-level isolation.
 
-> **Security note:** `approvalPolicy: "never"` allows arbitrary command execution within the
-> sandbox boundary. Per OpenAI's guidance, this should only be used in sandboxed environments.
-> Sortie's workspace isolation and hook system operate inside that sandbox as additional
-> defense-in-depth, but do not replace external container-level isolation.
-
-### Handling approval requests
+### Approval requests
 
 When `approvalPolicy` is not `"never"`, the app-server sends approval requests as JSON-RPC
 requests to the client:
 
-- `item/commandExecution/requestApproval`: shell command approval
-- `item/fileChange/requestApproval`: file edit approval
-- `item/tool/requestUserInput`: user input request (can carry approval questions)
-- `item/tool/call`: dynamic tool call (client must execute and return result)
+- `item/commandExecution/requestApproval`: shell command approval.
+- `item/fileChange/requestApproval`: file edit approval.
+- `item/tool/requestUserInput`: user input request, which can carry approval questions.
 
-The adapter responds with approval decisions:
+A client answers with one of `accept`, `acceptForSession`, `decline`, or `cancel`:
 
 ```json
 {"id": 42, "result": {"decision": "acceptForSession"}}
 ```
 
-Available decisions for command and file approvals: `accept`, `acceptForSession`, `decline`,
-`cancel`.
+`RunTurn` has no case for any of these three methods. They fall to the default arm of its
+notification switch, which emits a `domain.EventOtherMessage` carrying the method name and
+sends no response. The default `approvalPolicy: "never"` is what keeps that gap harmless,
+because it stops the app-server from asking. Setting `codex.approval_policy` to any other value
+leaves the app-server waiting for a decision the adapter does not send.
 
-For `item/tool/call` (dynamic tool invocations including `tracker_api`), the adapter executes
-the tool and returns the result:
-
-```json
-{"id": 43, "result": {
-  "success": true,
-  "output": "{\"issues\": [...]}",
-  "contentItems": [{"type": "inputText", "text": "{\"issues\": [...]}"}]
-}}
-```
-
-Symphony's implementation auto-approves all command and file change requests (`decision:
-"acceptForSession"`) and executes dynamic tools via a configurable executor function. The
-Sortie adapter follows the same pattern.
+`item/tool/call` is a separate request that the adapter does answer, described under "Dynamic
+tool calls".
 
 ---
 
@@ -509,18 +512,25 @@ Sortie adapter follows the same pattern.
 
 | Timeout           | Source                          | Enforcement                                        |
 | ----------------- | ------------------------------- | -------------------------------------------------- |
-| Turn timeout      | `agent.turn_timeout_ms`         | Context deadline on the turn read loop.            |
-| Read timeout      | `agent.read_timeout_ms`         | Applied to the `initialize` and `thread/start` responses. |
-| Stall timeout     | `agent.stall_timeout_ms`        | Reset on any `item/*` notification or delta event.  |
+| Read timeout      | `agent.read_timeout_ms`, default 30s | `readTimeout(state)` bounds the waits for the `account/login/completed` and `thread/started` notifications. |
+| Turn deadline     | The context passed to `RunTurn` | Cancellation triggers `turn/interrupt`.            |
+| Stall timeout     | `agent.stall_timeout_ms`        | `reconcileStalled` in `internal/orchestrator` cancels the worker context; each emitted event postpones it. |
 
-When the turn timeout fires:
+The adapter reads only `ReadTimeoutMS` from `domain.AgentConfig`. It derives no deadline of its
+own from `agent.turn_timeout_ms`; the turn's deadline is whatever context the orchestrator
+passes to `RunTurn`. The `initialize`, `account/read`, `thread/start`, and `thread/resume`
+responses are bounded by that same context, not by the read timeout.
 
-1. Send `turn/interrupt`:
-   ```json
-   {"method": "turn/interrupt", "id": 99, "params": {"threadId": "thr_abc123", "turnId": "turn_456"}}
-   ```
-2. Wait for `turn/completed` with `status: "interrupted"`.
-3. If no response within a grace period, SIGTERM → SIGKILL the subprocess.
+On context cancellation `RunTurn` sends `turn/interrupt` once, on a detached two-second
+context so the cancelled parent cannot drop it:
+
+```json
+{"method": "turn/interrupt", "id": 99, "params": {"threadId": "thr_abc123", "turnId": "turn_456"}}
+```
+
+It then keeps reading until `turn/completed` arrives or stdout closes. The escalation to
+SIGTERM, a five-second grace period, and SIGKILL belongs to `StopSession`, not to the interrupt
+path.
 
 ---
 
@@ -547,36 +557,41 @@ an `error` object:
 
 ### Error category mapping
 
-| `codexErrorInfo`                    | Adapter mapping     | Description                              |
-| ----------------------------------- | ------------------- | ---------------------------------------- |
-| `ContextWindowExceeded`             | `turn_failed`       | Token limit exceeded.                    |
-| `UsageLimitExceeded`                | `turn_failed`       | API usage quota exhausted.               |
-| `HttpConnectionFailed`              | `turn_failed`       | Upstream API 4xx/5xx.                    |
-| `ResponseStreamConnectionFailed`    | `turn_failed`       | SSE/WS stream disconnect.               |
-| `ResponseStreamDisconnected`        | `turn_failed`       | Mid-stream disconnect.                   |
-| `ResponseTooManyFailedAttempts`     | `turn_failed`       | Retry budget exhausted.                  |
-| `Unauthorized`                      | `agent_auth_error`  | Invalid or expired API credentials.      |
-| `BadRequest`                        | `turn_failed`       | Malformed request.                       |
-| `SandboxError`                      | `turn_failed`       | Sandbox enforcement failure.             |
-| `InternalServerError`               | `turn_failed`       | Server-side error.                       |
-| `Other`                             | `turn_failed`       | Catch-all.                               |
+`mapCodexErrorInfo` maps the `codexErrorInfo` string to a `domain.AgentErrorKind`. Any value
+outside this table, including an empty one, maps to `turn_failed`.
 
-### Process exit codes
+| `codexErrorInfo`                    | `domain.AgentErrorKind` | Description                          |
+| ----------------------------------- | ----------------------- | ------------------------------------ |
+| `ContextWindowExceeded`             | `turn_failed`           | Token limit exceeded.                |
+| `UsageLimitExceeded`                | `turn_failed`           | API usage quota exhausted.           |
+| `HttpConnectionFailed`              | `turn_failed`           | Upstream API 4xx/5xx.                |
+| `ResponseStreamConnectionFailed`    | `turn_failed`           | SSE or WebSocket stream disconnect.  |
+| `ResponseStreamDisconnected`        | `turn_failed`           | Mid-stream disconnect.               |
+| `ResponseTooManyFailedAttempts`     | `turn_failed`           | Retry budget exhausted.              |
+| `Unauthorized`                      | `response_error`        | Invalid or expired API credentials.  |
+| `BadRequest`                        | `response_error`        | Malformed request.                   |
+| `SandboxError`                      | `turn_failed`           | Sandbox enforcement failure.         |
+| `InternalServerError`               | `turn_failed`           | Server-side error.                   |
+| `Other`                             | `turn_failed`           | Catch-all.                           |
 
-| Exit scenario        | Adapter mapping      | Description                               |
-| -------------------- | -------------------- | ----------------------------------------- |
-| Clean shutdown       | n/a                  | Normal after stdin close or interrupt.     |
-| Non-zero exit        | `turn_failed`        | Unexpected failure.                        |
-| 127                  | `agent_not_found`    | `codex` binary not found on `$PATH`.       |
-| Signal (SIGTERM)     | `turn_cancelled`     | Killed by adapter timeout.                 |
-| Signal (SIGKILL)     | `turn_cancelled`     | Force-killed after grace period.           |
+### Failures outside the turn payload
+
+The subprocess outlives the turn, so `RunTurn` never inspects a process exit code. It reports
+`domain.ErrPortExit` when stdout closes before `turn/completed`, when a stdout read fails, when
+the `turn/start` write fails, and when the context is already done at entry. A `turn/start`
+response carrying a JSON-RPC `error` finalizes the turn as `turn_failed`.
+
+A missing binary is caught before launch: `agentcore.ResolveBinary` returns
+`domain.ErrAgentNotFound` when `exec.LookPath` cannot resolve the first token of
+`agent.command`, and again when that token contains whitespace.
 
 ---
 
-## Dynamic tool calls (`tracker_api`)
+## Dynamic tool calls
 
-The adapter registers `tracker_api` as a dynamic tool on `thread/start`. When the agent
-invokes it, the app-server sends an `item/tool/call` request:
+`StartSession` passes every tool in `domain.ToolRegistry` to `thread/start` as a dynamic tool;
+in a normal Sortie run that registry holds `trackerapi.TrackerAPITool`, whose `Name()` is
+`tracker_api`. When the agent invokes one, the app-server sends an `item/tool/call` request:
 
 ```json
 {"method": "item/tool/call", "id": 50, "params": {
@@ -588,7 +603,8 @@ invokes it, the app-server sends an `item/tool/call` request:
 }}
 ```
 
-The adapter dispatches to the configured `TrackerAdapter`, serializes the result, and responds:
+`handleToolCall` looks the name up in the registry and runs `AgentTool.Execute` in its own
+goroutine so the event read loop keeps draining stdout. `toolResultFor` builds the response:
 
 ```json
 {"id": 50, "result": {
@@ -598,8 +614,15 @@ The adapter dispatches to the configured `TrackerAdapter`, serializes the result
 }}
 ```
 
-The response includes `success` (boolean), `output` (string), and `contentItems` (array).
-This matches the dynamic tool response schema observed in Symphony's implementation.
+The result carries `success` (boolean), `output` (string), and `contentItems` (array). A tool
+that returns an error responds with `success: false` and the error text as `output`, and emits
+a `domain.EventToolResult` with `ToolError` set. When the tool name is not registered, or no
+registry was configured, the response is `success: false` with `unsupported tool: <name>` and
+the adapter emits `domain.EventUnsupportedToolCall`. Unparseable params draw a
+`success: false` response and no event.
+
+`RunTurn` waits for every in-flight tool goroutine before it finalizes the turn, so a tool
+result never arrives after the terminal event.
 
 ---
 
@@ -617,8 +640,9 @@ Archived threads move to:
 ~/.codex/sessions/archived/<thread-id>/rollout.jsonl
 ```
 
-The adapter does not interact with these files directly. Thread resume uses the app-server
-`thread/resume` method, which handles rollout loading internally.
+The adapter does not read or write these files. Thread resume goes through the app-server
+`thread/resume` method, which loads the rollout itself. In a containerized deployment,
+`~/.codex/sessions/` has to be a mounted volume for resume to survive a container restart.
 
 ---
 
@@ -649,32 +673,28 @@ codex_hooks = true
 Hooks run as shell commands with JSON on stdin and JSON/text on stdout. Each hook receives
 `session_id`, `transcript_path`, `cwd`, `hook_event_name`, and `model` as common fields.
 
-The `Stop` hook is notable: returning `{"decision": "block", "reason": "..."}` tells Codex
-to continue the turn with the `reason` as a new user prompt. This enables external
-continuation logic without orchestrator involvement.
+Returning `{"decision": "block", "reason": "..."}` from a `Stop` hook tells Codex to continue
+the turn with the `reason` as a new user prompt, which is continuation logic outside the
+orchestrator's view.
 
-Sortie's orchestrator manages its own continuation logic through `RunTurn` calls. The
-adapter does not rely on Codex hooks for turn continuation but does not interfere with
-hooks that the operator configures at the workspace level.
+Sortie drives continuation through repeated `RunTurn` calls. The adapter writes no hook
+configuration and reads no hook output, so hooks the operator places in the workspace run
+without adapter involvement.
 
 ---
 
 ## MCP server configuration
 
-Codex discovers MCP servers from project-level `.codex/mcp.json` files. The adapter can
-inject additional MCP servers (e.g., `tracker_api` as an MCP sidecar) through Codex's
-configuration system.
-
-However, the preferred approach for `tracker_api` is dynamic tool registration on
-`thread/start` (see Dynamic tool calls above), which avoids the need for a separate MCP
-server process.
-
-If MCP configuration is needed, the adapter writes a temporary `mcp.json` to the workspace's
-`.codex/` directory before launching the app-server.
-
+Codex discovers MCP servers from project-level `.codex/mcp.json` files and from `config.toml`.
 When an enabled MCP server is configured with `required = true` and fails to initialize,
-`thread/start` fails instead of continuing without it. The adapter avoids setting
-`required = true` on MCP servers unless they are essential for the workflow.
+`thread/start` fails instead of continuing without it.
+
+Sortie reaches Codex tools through dynamic tool registration on `thread/start` instead, which
+needs no separate server process. `StartSession` copies
+`StartSessionParams.MCPConfigPath` into `sessionState.mcpConfigPath` and nothing reads it
+again: the adapter writes no MCP config, passes no MCP argument, and leaves whatever the
+operator has placed in the workspace untouched. The Claude Code and Copilot adapters, by
+contrast, forward that path as a CLI argument.
 
 ---
 
@@ -704,7 +724,8 @@ observability pipeline.
 ## Adapter-specific pass-through config
 
 The workflow YAML front matter supports a `codex:` block forwarded to the adapter without
-core validation:
+core validation. `parsePassthroughConfig` reads it into `passthroughConfig`; a missing or
+wrong-typed key falls back to the zero value.
 
 ```yaml
 codex:
@@ -712,42 +733,45 @@ codex:
   thread_sandbox: workspaceWrite
   model: gpt-5.4
   effort: medium
-  turn_timeout_ms: 3600000
-  read_timeout_ms: 5000
-  stall_timeout_ms: 300000
+  personality: concise
+  turn_sandbox_policy:
+    networkAccess: true
 ```
 
 | Config key                  | Type    | Description                                                               |
 | --------------------------- | ------- | ------------------------------------------------------------------------- |
-| `codex.approval_policy`     | string or map | Approval policy for thread and turn. Maps to `approvalPolicy`.      |
-| `codex.thread_sandbox`      | string  | Thread sandbox mode. Maps to `sandbox` on `thread/start`.                 |
-| `codex.turn_sandbox_policy` | map     | Per-turn sandbox policy override. Maps to `sandboxPolicy` on `turn/start`.|
-| `codex.model`               | string  | Model override (e.g., `gpt-5.4`). Maps to `model` on `thread/start`.     |
+| `codex.approval_policy`     | string  | Approval policy for the thread. Maps to `approvalPolicy` on `thread/start`. Default `never`. |
+| `codex.thread_sandbox`      | string  | Thread sandbox mode. Maps to `sandbox` on `thread/start`. Default `workspace-write`. |
+| `codex.turn_sandbox_policy` | map     | Per-turn sandbox policy override. Merged over `sandboxPolicy` on `turn/start`. |
+| `codex.model`               | string  | Model override (e.g., `gpt-5.4`). Maps to `model` on `thread/start` and `turn/start`. |
 | `codex.effort`              | string  | Reasoning effort: `low`, `medium`, `high`. Maps to `effort` on `turn/start`.|
 | `codex.personality`         | string  | Personality preset. Maps to `personality` on `thread/start`.              |
+| `codex.skip_git_repo_check` | boolean | Parsed into `passthroughConfig.SkipGitRepoCheck` and read by no launch path, so the value never reaches the subprocess. |
 
-The `approval_policy` field accepts either a simple string (`"never"`, `"onRequest"`,
-`"unlessTrusted"`, `"always"`) or a granular rejection map matching Symphony's schema:
+The turn timeouts are not part of this block. `agent.turn_timeout_ms`, `agent.read_timeout_ms`,
+and `agent.stall_timeout_ms` are core config fields, described under "Timeout enforcement".
+
+`typeutil.StringFrom` reads `approval_policy`, so only the four string values
+(`"never"`, `"onRequest"`, `"unlessTrusted"`, `"always"`) survive parsing. Symphony's client
+exposes a granular rejection map for the same policy, which silently declines whole approval
+categories rather than auto-approving them:
 
 ```yaml
-codex:
-  approval_policy:
-    reject:
-      sandbox_approval: true
-      rules: true
-      mcp_elicitations: true
+approval_policy:
+  reject:
+    sandbox_approval: true
+    rules: true
+    mcp_elicitations: true
 ```
 
-When `approval_policy` is a map with `reject` keys, the adapter translates it to the
-app-server's granular approval policy format. With `reject.sandbox_approval: true`, the
-adapter auto-declines sandbox-related approval requests rather than forwarding them to an
-operator.
+A map written under `codex.approval_policy` is dropped by `parsePassthroughConfig` and the
+thread falls back to `never`.
 
 ---
 
-## Example adapter invocation
+## Full session lifecycle
 
-### Full session lifecycle
+The message ordering across one session, with the `userAgent` value as captured on v0.121.0:
 
 ```
 # 1. Launch app-server
@@ -787,9 +811,12 @@ $ codex app-server
 
 ---
 
-## `codex exec` alternative (reference only)
+## The `codex exec` surface
 
-For one-shot tasks or fallback scenarios, the adapter can use `codex exec`:
+No adapter code path launches `codex exec`. The surface is recorded here because it is the
+other non-interactive entry point Codex ships, and its wire format shares nothing with the
+app-server's: snake_case item types, a `usage` member on `turn.completed`, and dotted event
+type names.
 
 ```bash
 CODEX_API_KEY=sk-... codex exec \
@@ -817,8 +844,8 @@ codex exec resume --last "Continue working on the remaining test failures"
 codex exec resume <session_id> "Pick up where you left off"
 ```
 
-The `codex exec` surface does not support dynamic tool registration, mid-turn steering, or
-programmatic approval routing. It is not the recommended surface for Sortie.
+The `codex exec` surface carries no dynamic tool registration, no mid-turn steering, and no
+programmatic approval routing.
 
 ---
 
@@ -828,38 +855,27 @@ Multiple `codex app-server` instances can run simultaneously, each in a differen
 directory. Each instance is an independent process with its own thread state. There is no
 shared state between instances beyond the filesystem.
 
-Codex's internal sandbox enforcement is per-process. Two instances writing to the same workspace
-directory would conflict. Sortie's orchestrator ensures one agent session per workspace per
-issue, preventing this scenario.
+Codex's internal sandbox enforcement is per-process, so two instances writing to the same
+workspace directory would conflict. The orchestrator keys `State.Running` by issue ID and
+refuses to dispatch an issue that already has an entry there, which keeps one agent session per
+workspace.
 
 ---
 
-## Known behavioral notes
+## Runtime constraints
 
-- **Git repository required:** Codex requires the working directory to be inside a Git
-  repository. The adapter ensures workspaces are initialized as Git repos (or passes
-  `--skip-git-repo-check` if configured). Symphony's workspace manager handles this via a
-  `before_run` hook that initializes Git if needed.
-- **Context compaction:** Codex handles context window limits internally via background
-  compaction. The adapter receives `contextCompaction` item events when this occurs.
-  No adapter action is required.
-- **Thread persistence:** Thread JSONL files are written to `~/.codex/sessions/`. In
-  containerized deployments, this directory should be mounted as a volume if session resume
-  across container restarts is desired.
-- **Protected paths:** In `workspaceWrite` mode, `.git`, `.agents`, and `.codex` directories
-  within writable roots are read-only. The agent cannot modify these directories directly.
-- **Approval policy granularity:** The `approval_policy = {reject: {...}}` map syntax
-  (observed in Symphony) allows silently declining specific approval categories rather than
-  auto-approving them. With `reject.sandbox_approval: true`, sandbox-related prompts are
-  rejected (agent sees a denial) rather than approved.
-- **Model and hosted-tool compatibility:** Previous Codex releases inject a `tool_search`
-  hosted tool into the app-server's default tool set on every turn. The `gpt-5.4-nano` model
-  rejects it with HTTP 400 (`invalid_request_error` on the `tools` param), which the adapter
-  normalizes to `turn_failed`. Use `gpt-5.4-mini` or higher as the minimum viable tier. The
-  tool is no longer gated by a user feature flag (`codex features list` reports `tool_search`
-  as `removed`), so `--disable tool_search` does not suppress it. Verified on CLI v0.134.0;
-  previous versions (e.g., v0.121.0) did not inject the tool, so `gpt-5.4-nano` completed
-  turns there.
+- **Git repository required.** Codex refuses to run outside a Git repository unless
+  `--skip-git-repo-check` is passed. Nothing in the adapter initializes a repository or passes
+  that flag, so the workspace must already be a Git repository when the app-server launches.
+- **Context compaction.** Codex handles context window limits internally through background
+  compaction, surfaced as `contextCompaction` item events. No adapter action follows.
+- **Protected paths.** In `workspaceWrite` mode, the `.git`, `.agents`, and `.codex`
+  directories inside writable roots are read-only. The agent cannot modify them directly.
+- **Model and hosted-tool compatibility.** The app-server injects a `tool_search` hosted tool
+  into its default tool set on every turn. `gpt-5.4-nano` rejects that tool with HTTP 400
+  (`invalid_request_error` on the `tools` param) and the turn fails, so `gpt-5.4-mini` is the
+  lowest viable tier. `codex features list` reports `tool_search` as `removed`, so it is not a
+  user-togglable feature and `--disable tool_search` does not suppress the injection.
 
 ---
 
@@ -871,14 +887,14 @@ issue, preventing this scenario.
 | Runtime                   | Node.js                                                       | Rust (native binary; no Node.js required)                     |
 | Authentication            | `ANTHROPIC_API_KEY` (Anthropic), Bedrock, Vertex              | `CODEX_API_KEY` (OpenAI), ChatGPT session, external tokens    |
 | Integration protocol      | CLI subprocess per turn (`-p <prompt>`)                      | Persistent app-server subprocess (JSON-RPC over stdio)         |
-| Session continuity        | `--resume <session_id>` (new subprocess per turn)            | Same thread across turns (persistent process)                  |
+| Session continuity        | `--session-id` on the first turn, `--resume <session_id>` after (new subprocess per turn) | Same thread across turns (persistent process) |
 | Output format             | `--output-format stream-json` (JSONL)                        | JSON-RPC 2.0 notifications (JSONL)                             |
-| Permission bypass         | `--dangerously-skip-permissions`                             | `approvalPolicy: "never"` on thread/turn                       |
-| Sandbox enforcement       | None (relies on external container isolation)                | OS-level (Seatbelt/bwrap/seccomp) + configurable policies      |
+| Permission bypass         | `--dangerously-skip-permissions`                             | `approvalPolicy: "never"` on `thread/start`                    |
+| Sandbox enforcement       | None (relies on external container isolation)                | OS-level (Seatbelt/bwrap/seccomp) plus configurable policies   |
 | Dynamic tools             | `--mcp-config` (MCP sidecar required)                        | `dynamicTools` on `thread/start` (no sidecar needed)           |
-| Context management        | `compact_boundary` system event                              | `contextCompaction` item + background auto-compaction           |
+| Context management        | `compact_boundary` system event                              | `contextCompaction` item plus background auto-compaction       |
 | Cost cap                  | `--max-budget-usd <amount>`                                  | Subscription quota or API rate limits                          |
-| Internal turn limit       | `--max-turns <N>` (may be SDK-only)                          | Controlled by orchestrator via separate `turn/start` calls     |
+| Internal turn limit       | `--max-turns <N>` when `claude-code.max_turns` is set        | Controlled by orchestrator through separate `turn/start` calls |
 | Init event                | `system` type with `init` subtype, contains `session_id`     | `thread/started` notification contains `thread.id`             |
 | Result event              | Final `result` message with `subtype`, `is_error`, `usage`   | `turn/completed` notification with `turn.status`; usage arrives separately on `thread/tokenUsage/updated` |
 | Hooks location            | `.claude/hooks.json`                                          | `.codex/hooks.json`                                            |
@@ -893,63 +909,51 @@ issue, preventing this scenario.
 | Binary                    | `copilot` (npm `@github/copilot`)                            | `codex` (npm `@openai/codex`, native Rust binary)             |
 | Integration protocol      | CLI subprocess per turn (`-p <prompt>`)                      | Persistent app-server subprocess (JSON-RPC over stdio)         |
 | Authentication            | GitHub token (`GH_TOKEN`, `GITHUB_TOKEN`)                    | `CODEX_API_KEY` (OpenAI), ChatGPT session                     |
-| Permission bypass         | `--allow-all --no-ask-user`                                  | `approvalPolicy: "never"` on thread/turn                       |
+| Permission bypass         | `--allow-all --no-ask-user`                                  | `approvalPolicy: "never"` on `thread/start`                    |
 | Autonomous continuation   | `--autopilot --max-autopilot-continues <N>`                  | Orchestrator sends separate `turn/start` calls                 |
-| Session continuation      | `--resume <session_id>` (new subprocess per turn)            | Same thread across turns (persistent process)                  |
+| Session continuation      | `--resume <session_id>`, `--continue` when no session ID was captured (new subprocess per turn) | Same thread across turns (persistent process) |
 | Dynamic tools             | Not supported via CLI flags                                  | `dynamicTools` on `thread/start`                               |
 | Sandbox enforcement       | None (relies on external container isolation)                | OS-level (Seatbelt/bwrap/seccomp)                              |
-| Approval handling         | Pre-configured via CLI flags                                 | Programmatic approval routing via JSON-RPC                     |
+| Approval handling         | Pre-configured via CLI flags                                 | Thread-level `approvalPolicy`; over JSON-RPC the adapter answers `item/tool/call` only |
 | Models                    | Multi-provider (Claude, GPT-5, etc.)                         | OpenAI family (GPT-5.4 default), configurable providers        |
 
 ---
 
-## Summary: adapter implementation checklist
+## Open questions
 
-1. **StartSession:** Launch `codex app-server` with cwd = workspace. Send `initialize` +
-   `initialized`. Verify authentication via `account/read`. Start thread via `thread/start`
-   with `approvalPolicy`, `sandbox`, and `dynamicTools` configuration. Record `thread.id`.
-2. **RunTurn (turn 1):** Send `turn/start` with rendered prompt and turn configuration.
-   Record `turn.id`. Enter event read loop.
-3. **RunTurn (turn 2+):** Same as turn 1 on the same `thread.id`. No resume flag needed.
-4. **Event parsing:** Read JSONL notifications. Map `item/started` → `tool_use`,
-   `item/completed` → `tool_result` or `assistant_message`, `turn/completed` →
-   `turn_completed` or `turn_failed`. Handle `item/tool/call` for dynamic tool dispatch.
-   Log unknown notification methods as `other_message`.
-5. **Approval handling:** When `approvalPolicy != "never"`, respond to
-   `item/commandExecution/requestApproval` and `item/fileChange/requestApproval` with
-   `{"decision": "acceptForSession"}`. Execute `item/tool/call` requests via
-   `DynamicTool` / `TrackerAdapter` dispatch.
-6. **Token tracking:** Extract `tokenUsage.total` and `tokenUsage.last` from
-   `thread/tokenUsage/updated`, subtract a per-run baseline from the thread-cumulative `total`,
-   and normalize to `{input_tokens, output_tokens, total_tokens, cache_read_tokens}`.
-7. **Timeout:** Enforce `turn_timeout_ms` via context deadline. On timeout, send
-   `turn/interrupt` then SIGTERM → grace → SIGKILL.
-8. **Stall detection:** Reset stall timer on any `item/*` notification or delta event.
-   On stall timeout, treat as turn timeout.
-9. **StopSession:** Close stdin pipe. Send SIGTERM. Wait for process exit. SIGKILL after
-   grace period.
-10. **Error mapping:** Check `turn.status` and `turn.error.codexErrorInfo`. Map to
-    architecture error categories. Process exit code 127 → `agent_not_found`.
-11. **Session resume:** If app-server was restarted, use `thread/resume` with stored
-    `thread.id` to restore conversation history.
-12. **Git requirement:** Ensure workspace is a Git repository before launching app-server,
-    or configure `--skip-git-repo-check`.
+Each entry names the probe that would settle it.
 
-### Open questions
-
-The following behaviors are not characterized here and need experimental verification:
-
-- `dynamicTools` persistence across `thread/resume` (documented but not verified).
-- Exact `codexErrorInfo` values for authentication failures vs. rate limit exhaustion.
-- Behavior when `thread/start` is called with an already-active thread.
-- Whether `turn/interrupt` reliably produces `status: "interrupted"` under all conditions.
-- Process exit code mapping when app-server encounters a fatal internal error.
-- Interaction between OS sandbox enforcement and containerized deployment (Docker with
-  `--security-opt seccomp=unconfined`).
-- Thread storage location customization (whether `CODEX_HOME` env var is respected).
-- Maximum message size on stdio transport (observed 1 MB in Symphony; may vary).
-- `account/login/start` behavior when `CODEX_API_KEY` is already in the environment
-  (auto-login vs. explicit login required).
+- Whether `dynamicTools` registered on `thread/start` survive `thread/resume`. Probe: resume a
+  thread in a fresh app-server without re-registering, then prompt the agent to call
+  `tracker_api` and watch for an `item/tool/call` request.
+- Which `codexErrorInfo` value an authentication failure produces, and which one a rate-limit
+  exhaustion produces. The mapping table splits them across `response_error` and `turn_failed`
+  on the assumption that they arrive as `Unauthorized` and `UsageLimitExceeded`. Probe: run a
+  turn with a revoked key, and a turn on an exhausted quota, and read `turn.error`.
+- What `thread/start` returns when a thread is already active on the same connection. Probe:
+  send a second `thread/start` mid-turn and record the response.
+- Whether `turn/interrupt` always produces `status: "interrupted"`. Probe: interrupt at several
+  points (before the first item, mid command execution, during a dynamic tool call) and compare
+  the resulting `turn/completed` status.
+- What the app-server does when an approval request goes unanswered, which is what the adapter
+  does whenever `codex.approval_policy` is not `never`. Probe: start a thread with
+  `approvalPolicy: "onRequest"`, provoke a command approval, send nothing, and watch whether
+  the turn blocks indefinitely or times out on its own.
+- How the app-server exits on a fatal internal error, and with which exit code. Probe: kill the
+  upstream connection mid-turn under `strace`, or feed it a malformed request that trips a
+  panic path.
+- How OS sandbox enforcement interacts with a containerized deployment. Probe: run a
+  `workspace-write` turn inside Docker with and without
+  `--security-opt seccomp=unconfined` and compare failures.
+- Whether `CODEX_HOME` relocates the thread store away from `~/.codex/sessions/`. Probe: set it
+  to a temporary directory, run a turn, and look for the rollout file under both paths.
+- The real maximum message size on the stdio transport. The adapter's 1 MB scanner buffer comes
+  from Symphony's observed message sizes, not from a documented app-server limit. Probe: request
+  a turn whose diff or tool output exceeds 1 MB in one notification and see whether the
+  app-server splits it.
+- Whether `account/login/start` is required when `CODEX_API_KEY` is already in the subprocess
+  environment, or whether `account/read` reports a non-null account on its own. Probe: launch
+  the app-server with the variable set and read the `account/read` response before logging in.
 
 ---
 

--- a/docs/codex-adapter-notes.md
+++ b/docs/codex-adapter-notes.md
@@ -469,17 +469,23 @@ and network) is the alternative when workspace write is too narrow.
 
 ### Approval policies
 
-| Policy           | App-server value    | Behavior                                           |
-| ---------------- | ------------------- | -------------------------------------------------- |
-| Never ask        | `"never"`           | Never ask for approval. Auto-approve everything.   |
-| On request       | `"onRequest"`       | Ask only when agent explicitly requests it.        |
-| Unless trusted   | `"unlessTrusted"`   | Ask for untrusted commands.                        |
-| Always ask       | `"always"`          | Ask for every action.                              |
+| Policy         | App-server value | Behavior                                                                                                                   |
+| -------------- | ---------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| Never ask      | `"never"`        | Never ask. Execution failures return to the model immediately.                                                             |
+| Unless trusted | `"untrusted"`    | Run only trusted commands (`ls`, `cat`, `sed`) unasked, and escalate anything outside that set.                            |
+| On failure     | `"on-failure"`   | Run everything unasked, and ask only after a command fails, to escalate to un-sandboxed execution. Deprecated upstream.    |
+| On request     | `"on-request"`   | The model decides when to ask.                                                                                             |
 
-`startThread` sends `approvalPolicy: "never"` unless `codex.approval_policy` overrides it. That
-is the app-server equivalent of `--full-auto` or `--ask-for-approval never` in CLI mode, and it
-permits arbitrary command execution within the sandbox boundary, so OpenAI's guidance is to use
-it only in a sandboxed environment. Sortie's workspace isolation and hook system operate inside
+The value set is kebab-case and closed: `AskForApproval` in the app-server's own JSON Schema
+declares exactly these four strings, and the behaviors are the `--ask-for-approval` descriptions
+the binary prints. Both were read from the locally installed v0.121.0 rather than the pinned
+version, which has not been re-probed for this field. A value outside the set is rejected at
+`thread/start`.
+
+`startThread` sends `approvalPolicy: "never"` unless `codex.approval_policy` overrides it. In CLI
+mode the equivalent is `--ask-for-approval never`, not `--full-auto`, which selects `on-request`
+with a workspace-write sandbox. Sending `"never"` permits arbitrary command execution within the
+sandbox boundary, so OpenAI's guidance is to use it only in a sandboxed environment. Sortie's workspace isolation and hook system operate inside
 that sandbox as defense in depth and do not replace container-level isolation.
 
 ### Approval requests
@@ -752,7 +758,7 @@ The turn timeouts are not part of this block. `agent.turn_timeout_ms`, `agent.re
 and `agent.stall_timeout_ms` are core config fields, described under "Timeout enforcement".
 
 `typeutil.StringFrom` reads `approval_policy`, so only the four string values
-(`"never"`, `"onRequest"`, `"unlessTrusted"`, `"always"`) survive parsing. Symphony's client
+(`"never"`, `"untrusted"`, `"on-failure"`, `"on-request"`) survive parsing. Symphony's client
 exposes a granular rejection map for the same policy, which silently declines whole approval
 categories rather than auto-approving them:
 
@@ -937,7 +943,7 @@ Each entry names the probe that would settle it.
   the resulting `turn/completed` status.
 - What the app-server does when an approval request goes unanswered, which is what the adapter
   does whenever `codex.approval_policy` is not `never`. Probe: start a thread with
-  `approvalPolicy: "onRequest"`, provoke a command approval, send nothing, and watch whether
+  `approvalPolicy: "on-request"`, provoke a command approval, send nothing, and watch whether
   the turn blocks indefinitely or times out on its own.
 - How the app-server exits on a fatal internal error, and with which exit code. Probe: kill the
   upstream connection mid-turn under `strace`, or feed it a malformed request that trips a

--- a/docs/codex-adapter-notes.md
+++ b/docs/codex-adapter-notes.md
@@ -1,16 +1,19 @@
 # OpenAI Codex CLI: adapter research notes
 
-> OpenAI Codex CLI v0.134.0 (npm `@openai/codex`, binary `codex`) on Linux x86_64.
-> Reference for the `domain.AgentAdapter` implementation in `internal/agent/codex`,
-> registered under kind `codex`.
+> OpenAI Codex CLI (npm `@openai/codex`, binary `codex`) on Linux x86_64. Reference for the
+> `domain.AgentAdapter` implementation in `internal/agent/codex`, registered under kind `codex`.
 >
-> Coverage: the hosted-tool and model-tier behavior, the feature-flag surface, and the
-> self-generated JSON Schema are anchored to v0.134.0, probed May 2026. The app-server
-> transcripts (initialize, thread, turn, item, and token-usage messages) and the `codex exec`
-> JSONL samples were captured on v0.121.0 in April 2026 and have not been re-observed since;
-> the `userAgent` values quoted in the examples carry that version. The dynamic-tool response
-> payload and the granular approval-policy map rest on OpenAI Symphony's Elixir app-server
-> client, not on a local probe.
+> Coverage. The configuration surface, including the approval policy and the sandbox modes,
+> follows OpenAI's published [configuration schema](https://developers.openai.com/codex/config-schema.json),
+> which tracks the current release and is the authoritative source for those fields. Everything
+> observed locally, including the app-server transcripts, the protocol schema the binary
+> generates for itself, the flag surface, and the `codex exec` JSONL samples, comes from
+> **v0.121.0**, the only build installed on the research host; the `userAgent` values quoted in
+> the examples carry that version. Hosted-tool and model-tier behavior and the feature-flag
+> surface were recorded against v0.134.0 in May 2026 and cannot be re-observed here, so they are
+> the weakest claims in this document. Where the published schema and the installed binary
+> disagree, the schema wins and the divergence is named at the claim. The dynamic-tool response
+> payload rests on OpenAI Symphony's Elixir app-server client, not on a local probe.
 >
 > Claims about Sortie's own code name a Go symbol and were verified against the tree.
 > Primary sources are linked under "Sources" at the end.
@@ -65,8 +68,11 @@ on whitespace, and resolves the first token through `exec.LookPath`; an operator
 
 - The `codex` binary, a statically linked native Rust build that needs no Node.js runtime.
 - A valid OpenAI API key (`CODEX_API_KEY` or ChatGPT session credentials).
-- A Git repository. Codex requires commands to run inside a Git repo, and `--skip-git-repo-check`
-  overrides that check.
+
+A Git repository is not among them for this adapter. The trusted-directory refusal lives in the
+`codex exec` wrapper, above the app-server layer, which is why `--skip-git-repo-check` is an
+`exec` flag and appears in no configuration surface. `thread/start` against a non-git `cwd`
+succeeds and reports `gitInfo: null`.
 
 **Supported platforms:** Linux (x86_64, arm64), macOS (x86_64, Apple Silicon), Windows (native
 or WSL2).
@@ -469,24 +475,34 @@ and network) is the alternative when workspace write is too narrow.
 
 ### Approval policies
 
-| Policy         | App-server value | Behavior                                                                                                                   |
-| -------------- | ---------------- | -------------------------------------------------------------------------------------------------------------------------- |
-| Never ask      | `"never"`        | Never ask. Execution failures return to the model immediately.                                                             |
-| Unless trusted | `"untrusted"`    | Run only trusted commands (`ls`, `cat`, `sed`) unasked, and escalate anything outside that set.                            |
-| On failure     | `"on-failure"`   | Run everything unasked, and ask only after a command fails, to escalate to un-sandboxed execution. Deprecated upstream.    |
-| On request     | `"on-request"`   | The model decides when to ask.                                                                                             |
+`AskForApproval` accepts three kebab-case strings or one object form. The strings:
 
-The value set is kebab-case and closed: `AskForApproval` in the app-server's own JSON Schema
-declares exactly these four strings, and the behaviors are the `--ask-for-approval` descriptions
-the binary prints. Both were read from the locally installed v0.121.0 rather than the pinned
-version, which has not been re-probed for this field. A value outside the set is rejected at
+| Policy         | Value           | Behavior                                                                                                          |
+| -------------- | --------------- | ------------------------------------------------------------------------------------------------------------------ |
+| Never ask      | `"never"`       | Never ask. Failures return to the model immediately and are never escalated to a user.                            |
+| Unless trusted | `"untrusted"`   | Auto-approve only known-safe commands that read files. Everything else asks.                                      |
+| On request     | `"on-request"`  | The model decides when to ask.                                                                                    |
+
+The object form takes a single `granular` member whose booleans allow or reject each approval
+category rather than surfacing it: `sandbox_approval`, `rules`, and `mcp_elicitations` are
+required, and `request_permissions` and `skill_approval` are optional. A `false` field rejects
+that category automatically instead of showing it.
+
+Values and behaviors above come from OpenAI's published configuration schema
+([config-schema.json](https://developers.openai.com/codex/config-schema.json)), which is the
+authoritative surface for this field. A fourth string, `on-failure`, exists in the locally
+installed v0.121.0 and its help text marks it deprecated; the published schema no longer
+declares it, so treat it as removed. A value outside the accepted set is rejected at
 `thread/start`.
 
-`startThread` sends `approvalPolicy: "never"` unless `codex.approval_policy` overrides it. In CLI
-mode the equivalent is `--ask-for-approval never`, not `--full-auto`, which selects `on-request`
-with a workspace-write sandbox. Sending `"never"` permits arbitrary command execution within the
-sandbox boundary, so OpenAI's guidance is to use it only in a sandboxed environment. Sortie's workspace isolation and hook system operate inside
-that sandbox as defense in depth and do not replace container-level isolation.
+`startThread` sends `approvalPolicy: "never"` unless `codex.approval_policy` overrides it, and
+`typeutil.StringFrom` accepts only the string form, so the `granular` object cannot be expressed
+through `codex.approval_policy` and silently falls back to `never`. In CLI mode the equivalent of
+`"never"` is `--ask-for-approval never`, not `--full-auto`, which selects `on-request` with a
+workspace-write sandbox. Sending `"never"` permits arbitrary command execution within the sandbox
+boundary, so OpenAI's guidance is to use it only in a sandboxed environment. Sortie's workspace
+isolation and hook system operate inside that sandbox as defense in depth and do not replace
+container-level isolation.
 
 ### Approval requests
 
@@ -759,21 +775,23 @@ codex:
 The turn timeouts are not part of this block. `agent.turn_timeout_ms`, `agent.read_timeout_ms`,
 and `agent.stall_timeout_ms` are core config fields, described under "Timeout enforcement".
 
-`typeutil.StringFrom` reads `approval_policy`, so only the four string values
-(`"never"`, `"untrusted"`, `"on-failure"`, `"on-request"`) survive parsing. Symphony's client
-exposes a granular rejection map for the same policy, which silently declines whole approval
-categories rather than auto-approving them:
+`typeutil.StringFrom` reads `approval_policy`, so only the three string values
+(`"never"`, `"untrusted"`, `"on-request"`) survive parsing. The object form the schema also
+accepts, a `granular` member whose booleans decide each approval category, is dropped by
+`parsePassthroughConfig`, and the thread falls back to `never`. Written out, the form that
+cannot be expressed here is:
 
 ```yaml
+# Accepted by Codex, rejected by parsePassthroughConfig.
 approval_policy:
-  reject:
+  granular:
     sandbox_approval: true
     rules: true
     mcp_elicitations: true
 ```
 
-A map written under `codex.approval_policy` is dropped by `parsePassthroughConfig` and the
-thread falls back to `never`.
+Symphony configures the same policy with a differently-named map, keyed `reject`, so a snippet
+copied from that project does not describe this wire format either.
 
 ---
 
@@ -872,9 +890,10 @@ workspace.
 
 ## Runtime constraints
 
-- **Git repository required.** Codex refuses to run outside a Git repository unless
-  `--skip-git-repo-check` is passed. Nothing in the adapter initializes a repository or passes
-  that flag, so the workspace must already be a Git repository when the app-server launches.
+- **No Git repository gate on this surface.** The trusted-directory refusal belongs to the
+  `codex exec` wrapper, so `--skip-git-repo-check` guards a path the adapter never takes.
+  `thread/start` accepts a non-git `cwd` and reports `gitInfo: null`, and a workspace that no
+  hook has cloned into is the ordinary case rather than a failure.
 - **Context compaction.** Codex handles context window limits internally through background
   compaction, surfaced as `contextCompaction` item events. No adapter action follows.
 - **Protected paths.** In `workspaceWrite` mode, the `.git`, `.agents`, and `.codex`

--- a/docs/copilot-adapter-notes.md
+++ b/docs/copilot-adapter-notes.md
@@ -1,10 +1,16 @@
-# GitHub Copilot CLI: Adapter Research Notes
+# GitHub Copilot CLI: adapter research notes
 
-> GitHub Copilot CLI v1.0.x (npm `@github/copilot`, binary `copilot`), researched March 2026.
-> Updated April 2026 for v1.0.21 `--additional-mcp-config` path syntax correction.
-> Reference for implementing the Copilot CLI `AgentAdapter`.
+> GitHub Copilot CLI v1.0.13 (npm `@github/copilot`, binary `copilot`), researched March 2026.
+> Instruments: the official documentation listed below, headless runs of the installed binary
+> with `-p --output-format json` and stdout captured, and reads of the on-disk session-state
+> journal. Reference for the Copilot CLI `AgentAdapter` in `internal/agent/copilot`.
 >
-> **Primary sources:** [CLI command reference][cli-ref], [CLI programmatic reference][cli-prog],
+> Coverage: the flag surface, the JSONL event schema, session-id capture, autopilot behavior,
+> and session-state token accounting are anchored to v1.0.13. The `--additional-mcp-config`
+> file syntax and the exit-0 outcome of a config parse failure are anchored to v1.0.21 (April
+> 2026). No other surface has been re-observed on v1.0.21.
+>
+> Primary sources: [CLI command reference][cli-ref], [CLI programmatic reference][cli-prog],
 > [hooks configuration reference][hooks-ref], [about hooks][hooks-about],
 > [hooks tutorial][hooks-tut].
 
@@ -23,18 +29,17 @@ Three integration surfaces exist, in order of relevance to Sortie:
    `--output-format json` for JSONL output. This is the primary integration surface per
    [architecture Section 10.7](architecture/10-agent-adapter-contract.md#107-local-subprocess-launch-contract) (Local Subprocess Launch Contract).
 2. **Agent Client Protocol (ACP)** via `copilot --acp` ([CLI command reference][cli-ref]),
-   which starts an ACP server. This is a structured alternative but details are sparse in
-   official documentation and the protocol surface is subject to breaking changes.
+   which starts an ACP server. The official documentation carries no protocol details for it.
 3. **TypeScript SDK** (`@github/copilot-sdk`), which internally communicates with the CLI process
    via JSON-RPC. Not usable from a Go adapter directly, but serves as reference for session
    behavior and event types.
 
 Sortie's Go adapter uses the CLI subprocess approach (surface 1). The ACP and SDK surfaces are
-documented as reference for expected behavior and as potential future integration paths.
+documented here only as reference for expected behavior.
 
 ---
 
-## Installation and Prerequisites
+## Installation and prerequisites
 
 Copilot CLI is distributed through multiple channels:
 
@@ -72,15 +77,14 @@ Copilot CLI authenticates against GitHub's Copilot API via a GitHub token.
 
 ### Token resolution order
 
-The CLI resolves authentication tokens in a precedence order with **fallback on failure**. The
+The CLI resolves authentication tokens in a precedence order with fallback on failure. The
 official documentation ([authenticate-copilot-cli][auth-ref]) states the order as
 `COPILOT_GITHUB_TOKEN`, `GH_TOKEN`, `GITHUB_TOKEN` (in order of precedence).
 
-**Experimental observation (v1.0.13):** the CLI implements try-and-fallback, not exclusive
-selection. Setting `COPILOT_GITHUB_TOKEN` to an invalid token while `GH_TOKEN` or
-`GITHUB_TOKEN` hold valid tokens does not cause failure — the CLI falls back to the next
-source. This means the precedence order matters only when **all** sources hold valid but
-different tokens.
+The CLI implements try-and-fallback, not exclusive selection. Setting `COPILOT_GITHUB_TOKEN` to
+an invalid token while `GH_TOKEN` or `GITHUB_TOKEN` hold valid tokens does not cause failure:
+the CLI falls back to the next source. So the precedence order matters only when all sources
+hold valid but different tokens.
 
 | Priority | Method                       | Environment Variable / Mechanism         | Notes                                                              |
 | -------- | ---------------------------- | ---------------------------------------- | ------------------------------------------------------------------ |
@@ -90,8 +94,11 @@ different tokens.
 | 4        | OAuth keychain               | System keychain / credential store       | From interactive `/login` device flow.                              |
 | 5        | `gh` CLI fallback            | `gh auth token`                          | Uses the `gh` CLI's stored credential if available.                |
 
-> **Note:** For Sortie's adapter, the precedence order is immaterial: the adapter checks
-> that **at least one** token source is present, not which specific one the CLI will select.
+The precedence order is immaterial to the adapter: `checkAuth` in
+`internal/agent/copilot/copilot.go` checks that at least one source is present, not which one
+the CLI will select. It accepts a non-empty `COPILOT_GITHUB_TOKEN`, `GH_TOKEN`, or
+`GITHUB_TOKEN`, and otherwise falls back to a successful `gh auth status` (logged at WARN).
+With no source at all it returns `agent_not_found` before any turn runs.
 
 [auth-ref]: https://docs.github.com/en/copilot/how-tos/copilot-cli/set-up-copilot-cli/authenticate-copilot-cli
 
@@ -102,7 +109,7 @@ different tokens.
 | OAuth token (device flow)     | `gho_`          | Created via interactive `/login`.                   |
 | Fine-grained PAT              | `github_pat_`   | Requires the "Copilot Requests" permission scope.   |
 | GitHub App user-to-server     | `ghu_`          | For GitHub App integrations.                         |
-| Classic PAT                   | `ghp_`          | **Observed:** failed Copilot CLI authentication in v1.0.13 testing. No official docs confirm this; do not treat as a permanent constraint. |
+| Classic PAT                   | `ghp_`          | Acceptance is unresolved. See "Open questions".      |
 
 ### Config mapping
 
@@ -111,69 +118,72 @@ different tokens.
 | `agent.kind`               | `copilot-cli`                                |
 | `agent.command`            | `copilot` (or full path to the binary)       |
 
-The adapter does **not** manage GitHub tokens directly. The token must be present in the
-environment of the Sortie process (or passed through via hook env). The adapter inherits the
-parent process environment when spawning the subprocess.
+The adapter does not manage GitHub tokens directly. The token must be present in the
+environment of the Sortie process (or passed through via hook env). The subprocess inherits the
+parent process environment.
 
-**Organization and enterprise restrictions:** If the user's Copilot access is provided via an
+Organization and enterprise restrictions: if the user's Copilot access is provided via an
 organization or enterprise, the administrator must enable the Copilot CLI policy in organization
-settings. The CLI will fail to authenticate if this policy is disabled.
+settings. The CLI fails to authenticate when this policy is disabled.
 
 ---
 
-## CLI Flags Reference
+## CLI flags reference
 
-The adapter constructs a `copilot` invocation using these flags. Flags marked **(required)** are
-always set by the adapter; others are conditional.
+`buildArgs` in `internal/agent/copilot/command.go` constructs the argument vector from these
+flags. Flags marked (always) appear on every invocation; the rest are conditional.
 
 ### Core flags
 
 | Flag                               | Description                                                                                        | Adapter usage                                                    |
 | ---------------------------------- | -------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
-| `-p <prompt>` / `--prompt`         | Non-interactive (headless) mode. Passes the prompt and exits when done.                            | **(required)** Every turn invocation uses this.                  |
-| `-s` / `--silent`                  | Suppress stats and decoration, outputting only the agent's response ([CLI programmatic reference][cli-prog]).  | **(required)** Prevents non-JSON text from polluting stdout.     |
-| `--output-format json`             | JSONL on stdout. Each line is a JSON object.                                                       | **(required)** For structured event parsing.                     |
-| `--model <model>`                  | Override the AI model (e.g., `claude-sonnet-4.5`, `gpt-5`).                                       | Optional. Adapter passes through if configured.                  |
-| `--agent <name>`                   | Use a specific custom agent for the session.                                                       | Optional. Agent routing.                                         |
-| `--no-ask-user`                    | Disable the `ask_user` tool. Agent works autonomously without requesting user input ([`copilot --help`][cli-help-ref]). | **(required)** Prevents stalls waiting for user input.           |
-| `--additional-mcp-config <json>`   | Add MCP server configuration for the session (inline JSON or `@<path>` to JSON file).              | Optional. For tool extensions (e.g., `tracker_api`).             |
-| `--disable-builtin-mcps`           | Disable all built-in MCP servers.                                                                  | Optional. For controlled environments.                           |
-| `--disable-mcp-server <name>`      | Disable a specific built-in MCP server.                                                            | Optional.                                                        |
-| `--no-custom-instructions`         | Disable loading custom instructions from workspace files.                                          | Optional. For deterministic behavior.                            |
-| `--secret-env-vars <vars>`         | Redact the values of specified environment variables in output.                                     | Optional. For security when env contains secrets.                |
-| `--share <path>`                   | Export session transcript to markdown file on completion (prompt mode only).                        | Optional. For audit trail.                                       |
-| `--experimental`                   | Enable experimental features.                                                                      | Optional. See verification items.                                |
+| `-p <prompt>` / `--prompt`         | Non-interactive (headless) mode. Passes the prompt and exits when done.                            | (always) Carries the rendered turn prompt.                       |
+| `-s` / `--silent`                  | Suppress stats and decoration, outputting only the agent's response ([CLI programmatic reference][cli-prog]).  | (always) Prevents non-JSON text from polluting stdout.           |
+| `--output-format json`             | JSONL on stdout. Each line is a JSON object.                                                       | (always) For structured event parsing.                           |
+| `--model <model>`                  | Override the AI model (e.g., `claude-sonnet-4.5`, `gpt-5`).                                       | From `copilot-cli.model`.                                        |
+| `--agent <name>`                   | Use a specific custom agent for the session.                                                       | From `copilot-cli.agent`.                                        |
+| `--no-ask-user`                    | Disable the `ask_user` tool. Agent works autonomously without requesting user input ([`copilot --help`][cli-help-ref]). | (always) Prevents stalls waiting for user input.                 |
+| `--additional-mcp-config <json>`   | Add MCP server configuration for the session (inline JSON or `@<path>` to JSON file).              | Tool extensions. See "MCP server configuration".                 |
+| `--disable-builtin-mcps`           | Disable all built-in MCP servers.                                                                  | From `copilot-cli.disable_builtin_mcps`.                         |
+| `--disable-mcp-server <name>`      | Disable a specific built-in MCP server.                                                            | Not passed by the adapter.                                       |
+| `--no-custom-instructions`         | Disable loading custom instructions from workspace files.                                          | From `copilot-cli.no_custom_instructions`.                       |
+| `--secret-env-vars <vars>`         | Redact the values of specified environment variables in output.                                     | Not passed by the adapter.                                       |
+| `--share <path>`                   | Export session transcript to markdown file on completion (prompt mode only).                        | Not passed by the adapter.                                       |
+| `--experimental`                   | Enable experimental features.                                                                      | From `copilot-cli.experimental`. Feature set unenumerated; see "Open questions". |
 
 ### Session management flags
 
 | Flag                           | Description                                                         | Adapter usage                                                          |
 | ------------------------------ | ------------------------------------------------------------------- | ---------------------------------------------------------------------- |
-| `--resume <session_id>`        | Resume a specific conversation by session ID.                       | Used for continuation turns (turn 2+).                                 |
-| `--continue`                   | Resume the most recent conversation in the working directory.       | Alternative to `--resume` for continuation turns.                      |
+| `--resume <session_id>`        | Resume a specific conversation by session ID.                       | Continuation turns with a known session ID.                            |
+| `--continue`                   | Resume the most recent conversation in the working directory.       | Continuation turns after a turn produced no session ID.                |
+
+Both cases are described in "Session continuation".
 
 ### Permission flags
 
 | Flag                       | Description                                                                                                    | Adapter usage                                                                                                                           |
 | -------------------------- | -------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
-| `--allow-all` / `--yolo`   | Grant all permissions: tools, paths, and URLs. Agent operates without any approval prompts.                    | **(required for headless)** Without this, the process hangs waiting for interactive approval.                                           |
-| `--allow-all-tools`        | Allow all tools without confirmation, but still require path/URL approval.                                      | Alternative to `--allow-all` for partial permission.                                                                                    |
-| `--allow-all-paths`        | Disable path verification for file operations.                                                                  | Optional. For environments where path restrictions are handled externally.                                                              |
-| `--allow-all-urls`         | Disable URL verification for fetch operations.                                                                  | Optional.                                                                                                                               |
-| `--allow-tool <tools>`     | Allow specific tools without confirmation. Supports glob patterns (e.g., `"bash(git *)"`, `"edit_file"`).      | Optional. For selective tool approval.                                                                                                  |
-| `--deny-tool <tools>`      | Deny specific tools. Takes precedence over `--allow-tool`. Supports glob patterns.                              | Optional. For tool restriction.                                                                                                         |
+| `--allow-all` / `--yolo`   | Grant all permissions: tools, paths, and URLs. Agent operates without any approval prompts.                    | Passed when no tool-scoping key is configured. Without it, and without scoped grants, the process hangs waiting for interactive approval. |
+| `--allow-all-tools`        | Allow all tools without confirmation, but still require path/URL approval.                                      | Not passed by the adapter.                                                                                                              |
+| `--allow-all-paths`        | Disable path verification for file operations.                                                                  | Not passed by the adapter.                                                                                                              |
+| `--allow-all-urls`         | Disable URL verification for fetch operations.                                                                  | Not passed by the adapter.                                                                                                              |
+| `--allow-tool <tools>`     | Allow specific tools without confirmation. Supports glob patterns (e.g., `"bash(git *)"`, `"edit_file"`).      | From `copilot-cli.allowed_tools`.                                                                                                       |
+| `--deny-tool <tools>`      | Deny specific tools. Takes precedence over `--allow-tool`. Supports glob patterns.                              | From `copilot-cli.denied_tools`.                                                                                                        |
 
-> **Security note:** `--allow-all` / `--yolo` allows arbitrary command execution and file
-> modification. Per [architecture Section 10.4](architecture/10-agent-adapter-contract.md#104-approval-tools-and-user-input-policy), Sortie adopts a high-trust posture where
-> approval requests must not leave a run stalled. The `--allow-all` flag is appropriate for
-> headless operation in sandboxed environments. Sortie's workspace isolation and hook system
-> operate as additional defense-in-depth.
+`--allow-all` and `--yolo` allow arbitrary command execution and file modification. Per
+[architecture Section 10.4](architecture/10-agent-adapter-contract.md#104-approval-tools-and-user-input-policy), Sortie adopts a high-trust posture where approval requests must not leave a
+run stalled, so `buildArgs` grants `--allow-all` whenever the workflow configures none of
+`allowed_tools`, `denied_tools`, `available_tools`, or `excluded_tools`. Configuring any of
+those switches the invocation to scoped grants instead, because `--allow-all` would override
+them. Workspace isolation and the hook system operate as additional defense in depth.
 
 ### Tool filter flags
 
 | Flag                          | Description                                                                         | Adapter usage                                     |
 | ----------------------------- | ----------------------------------------------------------------------------------- | ------------------------------------------------- |
-| `--available-tools <tools>`   | Restrict the set of tools available to the agent. Only listed tools are accessible. | Optional. For tool palette restriction.            |
-| `--excluded-tools <tools>`    | Remove specific tools from the available set.                                       | Optional. For selectively disabling tools.         |
+| `--available-tools <tools>`   | Restrict the set of tools available to the agent. Only listed tools are accessible. | From `copilot-cli.available_tools`.                |
+| `--excluded-tools <tools>`    | Remove specific tools from the available set.                                       | From `copilot-cli.excluded_tools`.                 |
 
 Tool names follow the CLI's tool vocabulary ([CLI command reference: tool availability][cli-ref]).
 Built-in tools include: `bash`, `view`, `edit_file` (shown as `edit` in some CLI docs,
@@ -184,38 +194,45 @@ backed by `apply_patch`), `create`, `apply_patch`, `glob`, `grep`, `web_fetch`, 
 
 | Flag                                | Description                                                                                               | Adapter usage                                                          |
 | ----------------------------------- | --------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
-| `--autopilot`                       | Enable autopilot mode. Agent continues working through steps autonomously until task completion.           | **(required for headless)** Without this, agent may stop after one step. |
-| `--max-autopilot-continues <count>` | Limit the number of autonomous continuation steps. Prevents runaway loops.                                | **(recommended)** Safety backstop for programmatic use.                |
+| `--autopilot`                       | Enable autopilot mode. Agent continues working through steps autonomously until task completion.           | (always) Without it the agent stops after one response.                |
+| `--max-autopilot-continues <count>` | Limit the number of autonomous continuation steps. Prevents runaway loops.                                | (always) From `copilot-cli.max_autopilot_continues`, default 50.       |
 
-> **Autopilot mode is distinct from `--allow-all`.** `--allow-all` grants permission for
-> tool execution. `--autopilot` controls whether the agent continues working through
-> multi-step tasks without waiting for user input between steps. Both are needed for
-> fully autonomous headless operation.
+Autopilot mode is distinct from `--allow-all`. `--allow-all` grants permission for tool
+execution. `--autopilot` controls whether the agent continues working through multi-step tasks
+without waiting for user input between steps. Both are needed for fully autonomous headless
+operation.
 
-### Config/settings flags
+### Config and settings flags
 
 | Flag                    | Description                                      | Adapter usage                                                  |
 | ----------------------- | ------------------------------------------------ | -------------------------------------------------------------- |
-| `--config-dir <path>`   | Set the configuration directory.                | Optional. For isolated config environments.                    |
-| `--log-dir <path>`      | Set the log output directory.                    | Optional. Log file names contain the session ID.               |
+| `--config-dir <path>`   | Set the configuration directory.                | Not passed by the adapter.                                     |
+| `--log-dir <path>`      | Set the log output directory. Log file names contain the session ID. | Not passed by the adapter.                 |
 
 ---
 
-## Subprocess Invocation
+## Subprocess invocation
 
-Per [architecture Section 10.7](architecture/10-agent-adapter-contract.md#107-local-subprocess-launch-contract), the adapter launches:
+Per [architecture Section 10.7](architecture/10-agent-adapter-contract.md#107-local-subprocess-launch-contract), each turn is one subprocess. `agentcore.ForkPerTurnSession.RunTurn`
+execs the resolved binary directly with the argument vector `buildArgs` returns, on every
+platform. No shell is involved, so a prompt carrying shell metacharacters from user-controlled
+issue content cannot be reinterpreted. In SSH mode (`LaunchTarget.RemoteCommand` non-empty) the
+same vector is quoted into an `ssh` invocation by `sshutil.BuildSSHArgs`.
 
 ```
-# POSIX (Linux / macOS)
-sh -c 'copilot -p "$1" --output-format json -s --allow-all --autopilot --no-ask-user --max-autopilot-continues "$2" ${3:+--resume "$3"}' -- "$prompt" "$max_continues" "$session_id"
+copilot -p <prompt> --output-format json -s --autopilot --no-ask-user \
+  --max-autopilot-continues <N> [--resume <session_id> | --continue] \
+  [--model <model>] [--agent <name>] \
+  [--allow-all | --allow-tool <tools> --deny-tool <tools> --available-tools <tools> --excluded-tools <tools>] \
+  [--additional-mcp-config <value>] [--disable-builtin-mcps] [--no-custom-instructions] [--experimental]
 ```
 
-On Windows, the adapter invokes the CLI directly without a shell wrapper. The subprocess receives
-`CREATE_NEW_PROCESS_GROUP` and is assigned to a Job Object for process tree management.
+The flags after `--max-autopilot-continues` appear in that order, each one conditional on the
+workflow configuration described in "Adapter-specific pass-through config".
 
-> **Shell safety:** The prompt must not be interpolated directly into the `sh -c` string. Pass
-> it as a positional parameter (`$1`) to avoid injection via shell metacharacters in
-> user-controlled issue content.
+`procutil.SetProcessGroup` puts the child in its own process group; on Windows it also sets
+`CREATE_NEW_PROCESS_GROUP` and `procutil.AssignProcess` attaches the child to a Job Object for
+process tree termination.
 
 ### Process settings
 
@@ -223,62 +240,43 @@ On Windows, the adapter invokes the CLI directly without a shell wrapper. The su
 | ----------------- | --------------------------------------------------- | ---------------------------------------------------------- |
 | Working directory | Workspace path (`StartSessionParams.WorkspacePath`) | Agent must operate in the issue workspace.                 |
 | Stdout            | Pipe (read by adapter)                              | JSONL output parsed line by line.                          |
-| Stderr            | Pipe (read by adapter, logged)                      | Diagnostic output, not structured.                         |
+| Stderr            | Pipe (drained by `procutil.NewStderrCollector`)     | Diagnostic output, not structured.                         |
 | Environment       | Inherited from Sortie process                       | GitHub token and other auth vars must be present.          |
-| Max line size     | 10 MB                                               | Safe buffering per architecture doc recommendation.        |
+| Max line size     | 10 MB (`stdoutScannerMaxTokenSize`)                 | A longer line ends the scan and fails the turn.            |
 
-### First turn vs. continuation turns
+### Session continuation
 
-| Turn                   | Invocation                                                                                                                                       |
-| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Turn 1 (new session)   | `copilot -p "<prompt>" --output-format json -s --allow-all --autopilot --no-ask-user --max-autopilot-continues <N>`                              |
-| Turn 2+ (continuation) | `copilot -p "<prompt>" --output-format json -s --allow-all --autopilot --no-ask-user --max-autopilot-continues <N> --resume <session_id>`        |
-
-The `--resume <session_id>` flag continues the conversation in the same session, preserving the
-full message history from prior turns. The session ID is available in the final `result` JSONL
-event as the `sessionId` field (confirmed experimentally in v1.0.13).
-
-**Alternative:** `--continue` resumes the most recent conversation in the cwd. Since Sortie
-controls the workspace directory per issue, `--continue` would work. However, `--resume
-<session_id>` is more explicit and avoids ambiguity if multiple sessions exist in the same
-workspace.
-
-**Session ID is in the `result` event.** The `result` event — the last JSONL line before
-process exit — contains `"sessionId": "<uuid>"`. This was confirmed in v1.0.13:
+The `result` event, the last JSONL line before process exit, carries the session ID at the top
+level:
 
 ```json
 {"type":"result","timestamp":"...","sessionId":"aa778ea0-6eab-4ce9-b87e-11d6d33dab4f","exitCode":0,"usage":{...}}
 ```
 
-The adapter must parse the `result` event and store the `sessionId` for use in subsequent
-`--resume` invocations. Historical context: prior to JSONL support, the session ID was not
-programmatically discoverable ([github/copilot-cli#442](https://github.com/github/copilot-cli/issues/442)).
+The adapter's `OnFinalize` hook stores that `sessionId` in its session state, and `buildArgs`
+passes it as `--resume <session_id>` on the next turn. Resuming preserves the full message
+history from prior turns.
 
-> **Concurrency note for `max_concurrent_agents > 1`:** Since the `result` event contains the
-> session ID, the adapter has a reliable per-session ID source. The fallback strategy of
-> scanning `~/.copilot/session-state/` (mentioned in earlier research) is unreliable with
-> concurrent sessions and should not be used. If the `result` event is somehow missing (e.g.,
-> the process is killed before emitting it), the adapter can fall back to `--continue` which
-> resumes the most recent session in the workspace cwd — this is safe because Sortie uses
-> workspace-per-issue isolation.
+When a turn ends with no `result` event carrying a `sessionId` and no ID is known from an
+earlier turn, the adapter sets `fallbackToContinue` and the next turn passes `--continue`
+instead, which resumes the most recent conversation in the working directory. That is
+unambiguous here because Sortie isolates one workspace per issue. Scanning the session-state
+directory is not a session-discovery path: with `max_concurrent_agents > 1` the most recently
+written directory is not necessarily this session's, so the adapter opens that tree only by
+known session ID (`sessionStateRoot` and `readSessionUsage` in
+`internal/agent/copilot/sessionstate.go`).
 
 ---
 
-## Output Format: `--output-format json`
+## Output format: `--output-format json`
 
-With `--output-format json`, Copilot CLI writes one JSON object per line to stdout (newline-
-delimited JSON / JSONL). Each line is independently parseable.
+The [CLI command reference][cli-ref] documents `--output-format=FORMAT` where FORMAT is `text`
+(the default) or `json`. Under `json` the CLI writes one JSON object per line to stdout
+(newline-delimited JSON, JSONL), and each line is independently parseable.
 
-> **History:** JSONL output support was added in response to
-> [github/copilot-cli#52](https://github.com/github/copilot-cli/issues/52). The
-> [CLI command reference][cli-ref] documents `--output-format=FORMAT` where FORMAT is `text`
-> (default) or `json` (outputs JSONL: one JSON object per line).
+### JSONL event schema
 
-### JSONL event schema (observed v1.0.13)
-
-The following schema was determined experimentally by running Copilot CLI v1.0.13 with
-`--output-format json` and capturing stdout. The official documentation does not publish this
-schema; what follows is empirical observation.
+GitHub does not publish this schema; it comes from captured stdout.
 
 **Common envelope.** Every event is a JSON object with these top-level fields:
 
@@ -294,26 +292,26 @@ schema; what follows is empirical observation.
 The `result` event is an exception: it has no `data` or `id` fields and instead carries
 `sessionId`, `exitCode`, and `usage` at the top level.
 
-**Observed event types:**
+**Event types:**
 
 | Event type                        | Ephemeral | `data` fields                                                                              | Adapter mapping           |
 | --------------------------------- | --------- | ------------------------------------------------------------------------------------------ | ------------------------- |
-| `session.warning`                 | yes       | `warningType`, `message`                                                                   | `notification`            |
-| `session.mcp_server_status_changed` | yes     | `serverName`, `status`                                                                     | log only                  |
-| `session.mcp_servers_loaded`      | yes       | `servers` (array of `{name, status, source, error?}`)                                      | log only                  |
-| `session.tools_updated`           | yes       | `model`                                                                                    | log only                  |
-| `session.info`                    | yes       | `infoType`, `message`                                                                      | `notification`            |
-| `session.task_complete`           | no        | `summary`, `success`                                                                       | `notification`            |
-| `user.message`                    | no        | `content`, `transformedContent`, `attachments`, `agentMode`?, `interactionId`              | log only                  |
-| `assistant.turn_start`            | no        | `turnId`, `interactionId`                                                                  | `notification`            |
-| `assistant.message_delta`         | yes       | `messageId`, `deltaContent`                                                                | stall timer reset         |
-| `assistant.message`              | no        | `messageId`, `content`, `toolRequests` (array), `interactionId`, `outputTokens`            | `assistant_message`       |
-| `assistant.turn_end`             | no        | `turnId`                                                                                   | `notification`            |
-| `tool.execution_start`           | no        | `toolCallId`, `toolName`, `arguments`                                                      | `tool_use`                |
-| `tool.execution_complete`        | no        | `toolCallId`, `model`, `interactionId`, `success`, `result`, `toolTelemetry`               | `tool_result`             |
-| `result`                          | no        | *(top-level)* `sessionId`, `exitCode`, `usage{premiumRequests, totalApiDurationMs, sessionDurationMs, codeChanges{linesAdded, linesRemoved, filesModified}}` | `turn_completed` / `turn_failed` |
+| `session.warning`                 | yes       | `warningType`, `message`                                                                   | WARN log and `notification` carrying `message` |
+| `session.mcp_server_status_changed` | yes     | `serverName`, `status`                                                                     | DEBUG log only            |
+| `session.mcp_servers_loaded`      | yes       | `servers` (array of `{name, status, source, error?}`)                                      | DEBUG log only            |
+| `session.tools_updated`           | yes       | `model`                                                                                    | DEBUG log only            |
+| `session.info`                    | yes       | `infoType`, `message`                                                                      | `notification` carrying `message` |
+| `session.task_complete`           | no        | `summary`, `success`                                                                       | `notification` carrying `summary` |
+| `user.message`                    | no        | `content`, `transformedContent`, `attachments`, `agentMode`?, `interactionId`              | DEBUG log only            |
+| `assistant.turn_start`            | no        | `turnId`, `interactionId`                                                                  | `notification` carrying the event type |
+| `assistant.message_delta`         | yes       | `messageId`, `deltaContent`                                                                | empty `notification`, which resets the orchestrator's stall timer |
+| `assistant.message`              | no        | `messageId`, `content`, `toolRequests` (array), `interactionId`, `outputTokens`            | `token_usage` when `outputTokens` is present, plus a `notification` summarizing content or requested tool names |
+| `assistant.turn_end`             | no        | `turnId`                                                                                   | `notification` carrying the event type |
+| `tool.execution_start`           | no        | `toolCallId`, `toolName`, `arguments`                                                      | `notification` naming the tool; starts the duration timer in `agentcore.ToolTracker` |
+| `tool.execution_complete`        | no        | `toolCallId`, `model`, `interactionId`, `success`, `result`, `toolTelemetry`               | `tool_result` with tool name, duration, and the negated `success` as `ToolError` |
+| `result`                          | no        | *(top-level)* `sessionId`, `exitCode`, `usage{premiumRequests, totalApiDurationMs, sessionDurationMs, codeChanges{linesAdded, linesRemoved, filesModified}}` | Held as the turn's terminal record; see "Determining turn completion" |
 
-**Example output** (simple task, autopilot mode, v1.0.13):
+**Example output** (simple task, autopilot mode):
 
 ```jsonl
 {"type":"session.mcp_servers_loaded","data":{"servers":[{"name":"github-mcp-server","status":"connected","source":"builtin"}]},"id":"...","timestamp":"2026-03-30T22:19:18.132Z","parentId":"...","ephemeral":true}
@@ -326,7 +324,7 @@ The `result` event is an exception: it has no `data` or `id` fields and instead 
 {"type":"result","timestamp":"2026-03-30T22:19:28.097Z","sessionId":"aa778ea0-6eab-4ce9-b87e-11d6d33dab4f","exitCode":0,"usage":{"premiumRequests":6,"totalApiDurationMs":6866,"sessionDurationMs":12927,"codeChanges":{"linesAdded":0,"linesRemoved":0,"filesModified":[]}}}
 ```
 
-**Example with tool use** (read file task, v1.0.13):
+**Example with tool use** (read file task):
 
 ```jsonl
 {"type":"assistant.message","data":{"messageId":"...","content":"","toolRequests":[{"toolCallId":"toolu_vrtx_...","name":"view","arguments":{"path":"/tmp/copilot-test/main.go"},"type":"function","intentionSummary":"view the file..."}],"interactionId":"...","outputTokens":102},"id":"...","timestamp":"...","parentId":"..."}
@@ -334,48 +332,34 @@ The `result` event is an exception: it has no `data` or `id` fields and instead 
 {"type":"tool.execution_complete","data":{"toolCallId":"toolu_vrtx_...","model":"claude-opus-4.6","interactionId":"...","success":true,"result":{"content":"1. package main\n2. ","detailedContent":"..."},"toolTelemetry":{"properties":{"command":"view"},"metrics":{"resultLength":19}}},"id":"...","timestamp":"...","parentId":"..."}
 ```
 
-> **Session storage uses the same vocabulary.** The on-disk `events.jsonl` at
-> `~/.copilot/session-state/<session-id>/` uses the same `"type"` field and event type names
-> as stdout JSONL. The `"event"` field format observed in
-> [github/copilot-cli#2201](https://github.com/github/copilot-cli/issues/2201) appears to be
-> from an older CLI version.
->
-> **SDK event types match.** The SDK types (`user.message`, `assistant.message`,
-> `tool.execution_start`, etc.) turn out to be the *same* vocabulary used by
-> `--output-format json`, not a separate format.
+Three surfaces share one event vocabulary. The on-disk `events.jsonl` under the session-state
+root uses the same `"type"` field and event type names as stdout JSONL, and the SDK's session
+event types (`user.message`, `assistant.message`, `tool.execution_start`, and the rest) are the
+same names again rather than a separate format.
 
-> **Implementation note:** The adapter must still handle unknown event types gracefully by
-> logging them as `other_message` events. Future CLI versions may add new event types.
-
-### Determining session completion
-
-In the subprocess model with `-p`, the process exits when the agent completes its work.
-Completion is signaled by two mechanisms:
-
-1. **`result` JSONL event** — the last line emitted before exit, containing `exitCode`,
-   `sessionId`, and `usage` data.
-2. **Process exit code** — 0 for success, non-zero for failure.
-
-The adapter should use the `result` event as the primary completion signal (it contains richer
-data) and fall back to process exit code if the `result` event is missing (e.g., process was
-killed).
+An event type outside the table above is emitted as an `other_message` event carrying the type
+name, so an unrecognized event neither fails the turn nor is silently dropped.
 
 ### Parsing strategy
 
-The adapter reads stdout line by line. For each line:
+`agentcore.ForkPerTurnSession` reads stdout line by line and hands each line to the adapter's
+`ParseLine` hook. A line that fails to parse as JSON produces a `malformed` event and the scan
+continues. A parsed line is dispatched on its `"type"` field to the mapping in the table above.
+The `result` line is returned to the skeleton as the turn's terminal record instead of being
+emitted, and the skeleton keeps the last such record for finalization.
 
-1. Parse as JSON. If parsing fails, emit a `malformed` event and continue.
-2. Read the `"type"` field as the event discriminator.
-3. Based on the event type:
-   - `tool.execution_start` / `tool.execution_complete` -> log tool activity, emit `tool_use` /
-     `tool_result` with tool name, arguments, and result.
-   - `assistant.message` -> emit `assistant_message` with content and output token count.
-   - `assistant.message_delta` -> reset stall detection timer.
-   - `session.task_complete` -> log task completion summary.
-   - `result` -> extract `sessionId` (for `--resume`), `exitCode`, `usage`.
-   - `session.*` (ephemeral) -> log as `notification`, do not store.
-   - Unknown types -> emit `other_message`.
-4. On process exit, check exit code to determine `turn_completed` or `turn_failed`.
+### Determining turn completion
+
+The process exits when the agent completes its work, so a turn has two outcome signals: the
+`result` event, which carries `exitCode`, `sessionId`, and `usage`, and the process exit code.
+
+`OnFinalize` builds `agentcore.TurnEvidence` from both and delegates the decision to
+`agentcore.FinalizeTurn`. A `result` event is authoritative: an `exitCode` of 0 reports
+`TerminalSuccess`, and any other value, including an absent field, reports `TerminalFailure`
+regardless of the process exit code. With no `result` event the
+decision falls to the process exit and to the work evidence, which for this adapter is whether
+any `assistant.message` reported a positive `outputTokens` for the turn. See "Process exit
+codes" for the resulting dispositions.
 
 ### Token usage extraction
 
@@ -412,9 +396,16 @@ tokenDetails.cache_read.tokenCount + tokenDetails.cache_write.tokenCount` equals
 
 The journal is session-cumulative across every process invocation that resumes the session with
 `--resume`: a second turn's `session.shutdown` record reports totals inclusive of the first
-turn's spend, not just the second turn's own contribution. The adapter recovers a single run's
-contribution by reading the record that predates the run (its own baseline) and subtracting it
-from the current record.
+turn's spend, not just the second turn's own contribution. `sessionState.recoverUsage` recovers
+a single run's contribution by reading the record that predates the run (its own baseline) and
+subtracting it from the current record.
+
+The journal read is skipped, leaving the output-only provisional figure standing, when the
+session ID is unknown or fails the path-segment check `sessionIDPattern`, when the session runs
+in SSH mode, when the file exceeds 64 MB or holds a line over 10 MB (`readSessionUsage` returns
+`errSessionStateCapExceeded`), when the file holds no `session.shutdown` record yet, or when a
+resumed run has already missed its first read attempt and can no longer separate its own spend
+from the prior session's.
 
 The adapter normalizes a `session.shutdown` record into:
 
@@ -427,84 +418,68 @@ TokenUsage{
 }
 ```
 
-**Alternative not used by Sortie:** OTel spans ([CLI command reference: OTel monitoring][cli-ref])
-also expose token counts (`invoke_agent` span's `gen_ai.usage.input_tokens` and
-`gen_ai.usage.output_tokens`), gated on `COPILOT_OTEL_FILE_EXPORTER_PATH`. The adapter does not
-configure or parse OTel output; the session-state journal is the source of truth because it
-requires no additional runtime configuration.
+OTel spans ([CLI command reference: OTel monitoring][cli-ref]) also expose token counts, and the
+adapter does not read them. See "OpenTelemetry integration".
 
 ---
 
-## Session Lifecycle Mapping
+## Session lifecycle mapping
 
-[Architecture Section 10.2](architecture/10-agent-adapter-contract.md#102-session-lifecycle) defines the session lifecycle. Here is how Copilot CLI maps to it:
+[Architecture Section 10.2](architecture/10-agent-adapter-contract.md#102-session-lifecycle) defines the session lifecycle. `CopilotAdapter` in
+`internal/agent/copilot/copilot.go` maps onto it as follows.
 
 ### `StartSession`
 
-Architecture Sections 10.1 and 10.2 define `StartSession` as the operation that "launches or
-connects" to the agent. For Copilot CLI, the session is disk-persisted at
-`~/.copilot/session-state/<session-id>/` and identified by a UUID. The OS subprocess is
-short-lived and created per turn. This adapter treats `StartSession` as establishing the
-logical Copilot CLI session, while deferring creation of the Node.js subprocess until `RunTurn`.
+The Copilot CLI session is disk-persisted under the session-state root and identified by a
+UUID, while the OS subprocess is short-lived and created per turn. `StartSession` therefore
+establishes the logical session and spawns nothing.
 
-1. Record the workspace path and configuration.
-2. Perform preflight validation:
-   - Resolve and normalize the workspace path.
-   - Enforce workspace path containment rules.
-   - Validate that the `copilot` CLI command is resolvable on `$PATH`.
-   - Validate that Node.js 22+ is available (Copilot CLI requires it).
-3. Verify authentication by checking that at least one of `COPILOT_GITHUB_TOKEN`, `GH_TOKEN`,
-   or `GITHUB_TOKEN` is set in the environment, or that `gh auth token` returns a valid token.
-4. Initialize and return a `Session`:
-   - `ID`: empty (populated after the first turn from the `result` JSONL event's `sessionId`).
-   - `Internal`: adapter-internal state (workspace path, config snapshot).
-     No OS subprocess is spawned at this point; that happens in `RunTurn`.
+`agentcore.ResolveLaunchTarget` resolves and normalizes the workspace path under the
+containment rules, and resolves the `copilot` command (from `agent.command`, defaulting to
+`copilot`) to an absolute path. In local mode the adapter then runs `copilot --version` under a
+5-second timeout as a canary; a failure returns `agent_not_found` with a message pointing at
+the Node.js 22+ requirement, which is the only check that requirement gets. `checkAuth` runs
+next, as described in "Token resolution order". SSH mode skips both.
+
+The returned `domain.Session` carries `ID` set to `StartSessionParams.ResumeSessionID`, which
+is empty for a new session and populated when a prior attempt is being resumed, and `Internal`
+set to the adapter's `sessionState` (launch target, session ID, agent config, MCP config path,
+usage accumulator, and per-turn scan state).
 
 ### `RunTurn`
 
-1. Build the CLI command:
-   - Turn 1: `copilot -p "<prompt>" --output-format json -s --allow-all --autopilot
-     --no-ask-user --max-autopilot-continues <N>`
-   - Turn 2+: append `--resume <session_id>` to continue the conversation.
-2. Launch subprocess (POSIX: `sh -c <command>`; Windows: direct invocation), cwd = workspace path.
-   The subprocess is placed in its own process group and assigned to platform-specific
-   process tree management (Unix process groups / Windows Job Objects).
-3. Read stdout line by line, parse each JSON event, and deliver to `OnEvent` callback.
-4. On each event, update the stall detection timer.
-5. When the process exits:
-   - **Exit code 0:** Return `TurnResult{ExitReason: turn_completed}`.
-   - **Exit code non-zero:** Return `TurnResult{ExitReason: turn_failed}` with error details.
-   - **Killed by signal (timeout/cancellation):** Return `TurnResult{ExitReason: turn_cancelled}`.
-6. Extract `session_id` from the `result` JSONL event (`sessionId` field). Store it in
-   `Session.Internal` state for use in subsequent `--resume` invocations.
+`RunTurn` resets the per-turn scan state and delegates to
+`agentcore.ForkPerTurnSession.RunTurn`, which builds the argument vector from `buildArgs`,
+launches the subprocess with cwd set to the workspace path, emits `session_started` with the
+PID and the current session ID, scans stdout, and calls the adapter's `OnFinalize` hook once
+the process exits. Each emitted event updates the orchestrator's stall reference timestamp.
+`OnFinalize` stores the `sessionId` from the `result` event, recovers token usage, and returns
+the `TurnResult`.
 
 ### `StopSession`
 
-1. If a subprocess is running, send a platform-appropriate graceful shutdown signal to the
-   process group (POSIX: `SIGTERM`; Windows: `CTRL_BREAK_EVENT`).
-2. Wait briefly (5 seconds) for clean exit.
-3. If still running, force-terminate the process tree (POSIX: `SIGKILL` to process group;
-   Windows: `TerminateJobObject`).
-4. Clean up file descriptors, goroutines, and platform-specific process group resources.
+`StopSession` delegates to `ForkPerTurnSession.Stop`, which signals the process group
+gracefully (`SIGTERM` on POSIX, `CTRL_BREAK_EVENT` on Windows), waits up to 5 seconds for the
+turn goroutine to finish its cleanup, and then force-terminates the process tree (`SIGKILL` to
+the group on POSIX, `TerminateJobObject` on Windows). With no subprocess running it returns
+`nil` immediately.
 
 ### `EventStream`
 
-Return `nil`. The Copilot CLI adapter uses the synchronous `OnEvent` callback model, not the
-async channel model.
+Returns `nil`. The adapter delivers events synchronously through the `OnEvent` callback, not
+through a channel.
 
 ---
 
-## Turn Model
+## Turn model
 
 Copilot CLI has its own internal concept of autonomous continuations controlled by autopilot mode.
 The `--max-autopilot-continues` flag limits how many autonomous steps the agent takes within a
 single CLI invocation.
 
-**Default behavior in autopilot mode:** The agent continues working through steps until it
-determines the task is complete, encounters a problem, or reaches the continuation limit. Without
-`--autopilot`, the agent completes one interaction cycle and exits.
-
-**Experimentally observed difference (v1.0.13):**
+In autopilot mode the agent continues working through steps until it determines the task is
+complete, encounters a problem, or reaches the continuation limit. Without `--autopilot`, the
+agent completes one interaction cycle and exits.
 
 | Aspect                        | With `--autopilot`                                        | Without `--autopilot`                                |
 | ----------------------------- | --------------------------------------------------------- | ---------------------------------------------------- |
@@ -514,70 +489,48 @@ determines the task is complete, encounters a problem, or reaches the continuati
 | `session.info` events         | `infoType: "autopilot_continuation"` with premium request count | absent                                        |
 | `task_complete` tool          | Agent calls `task_complete` to signal completion          | Not invoked; process exits after first response      |
 
-Without `--autopilot`, the agent produces one response and exits — it does NOT run a multi-step
-agentic loop. The `--autopilot` flag is therefore **required** for any non-trivial task in
-headless mode.
+Without `--autopilot` the agent produces one response and exits rather than running a
+multi-step agentic loop, so the flag is what makes a non-trivial headless task possible. That
+is why `buildArgs` passes it unconditionally.
 
-**Sortie's turn model is distinct from Copilot CLI's internal continuations.** Sortie's "turn" is
-one CLI invocation (one `RunTurn` call). Within that invocation, Copilot CLI may execute multiple
-autonomous continuation steps.
-
-### Strategy A: Single Sortie turn = single Copilot CLI invocation with autopilot (recommended)
-
-- Set `--autopilot --max-autopilot-continues <N>` where N provides a reasonable safety limit.
-- Copilot CLI runs its full agentic loop within one invocation.
-- Sortie calls `RunTurn` once per Sortie turn. Copilot CLI decides when it's done.
-- After each Sortie turn, the orchestrator re-checks tracker state and decides whether to
-  continue.
-- Use `agent.turn_timeout_ms` as the time safety backstop.
-
-### Strategy B: Without autopilot (fine-grained control)
-
-- Omit `--autopilot`.
-- Each `RunTurn` call runs one interaction cycle.
-- Sortie has maximum control over the loop but incurs subprocess launch overhead per turn and
-  may interrupt Copilot CLI's multi-step plans.
-
-**Recommendation:** Strategy A. Let Copilot CLI run its agentic loop to completion within each
-Sortie turn. Sortie's `agent.turn_timeout_ms` provides the safety backstop. Set
-`--max-autopilot-continues` to a reasonable value (e.g., 50) to prevent runaway loops.
+Sortie's turn model is distinct from Copilot CLI's internal continuations. A Sortie turn is one
+CLI invocation (one `RunTurn` call), and within that invocation Copilot CLI runs its own
+agentic loop to completion, bounded by `--max-autopilot-continues`. After each turn the
+orchestrator re-checks tracker state and decides whether to run another.
 
 ---
 
-## Timeout Enforcement
+## Timeout enforcement
 
 | Timeout                  | Source      | Enforcement                                                                                                                                                                                           |
 | ------------------------ | ----------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `agent.turn_timeout_ms`  | WORKFLOW.md | Adapter sets a deadline on the subprocess. On expiry, send SIGTERM → wait → SIGKILL. Map to `turn_cancelled`.                                                                                         |
-| `agent.read_timeout_ms`  | WORKFLOW.md | Not directly applicable to subprocess model. Could apply to initial subprocess startup: if no output within `read_timeout_ms`, consider startup failed.                                               |
-| `agent.stall_timeout_ms` | WORKFLOW.md | Enforced by the **orchestrator**, not the adapter. The orchestrator monitors `last_agent_timestamp` from events. If the gap exceeds `stall_timeout_ms`, the orchestrator calls `StopSession`.         |
+| `agent.turn_timeout_ms`  | WORKFLOW.md | Reaches the adapter on `domain.AgentConfig`, and no code path reads it. See "Open questions".                                                                                                          |
+| `agent.read_timeout_ms`  | WORKFLOW.md | The adapter enforces no read deadline. The worker uses this value only to bound its best-effort `StopSession` call.                                                                                    |
+| `agent.stall_timeout_ms` | WORKFLOW.md | Enforced by the orchestrator, not the adapter. `reconcileStalled` in `internal/orchestrator/reconcile.go` compares `LastAgentTimestamp` against the threshold and cancels the worker's context.        |
 
-### Max autopilot continues as timeout proxy
-
-`--max-autopilot-continues <N>` acts as a step-based safety limit complementing the time-based
-`turn_timeout_ms`. Each continuation consumes one or more premium requests. Setting a reasonable
-limit prevents both runaway execution and excessive API cost.
+`--max-autopilot-continues <N>` is a step-based limit rather than a time-based one. Each
+continuation consumes one or more premium requests, so the limit bounds both runaway execution
+and API cost.
 
 ### Context cancellation
 
-The adapter must respect `context.Context` cancellation:
-
-- `RunTurn` receives a context. If the context is cancelled (e.g., due to tracker reconciliation
-  finding the issue is terminal), the adapter must kill the subprocess promptly.
-- The adapter sends a graceful shutdown signal to the process group, followed by a grace period,
-  then force-terminates the process tree. Platform-specific details are handled by `procutil`.
+`RunTurn` receives the worker's context. On cancellation, whether from stall reconciliation or
+from the tracker reporting the issue terminal, `exec.CommandContext` signals the process group
+gracefully through `procutil.SignalGraceful` and force-terminates the tree after the 5-second
+`WaitDelay`. The skeleton reports the turn as `turn_cancelled` with `ErrTurnCancelled`,
+carrying whatever usage had accumulated.
 
 ---
 
-## Permission and Approval Policy
+## Permission and approval policy
 
 Per [architecture Section 10.4](architecture/10-agent-adapter-contract.md#104-approval-tools-and-user-input-policy), Sortie adopts a high-trust posture:
 
 | Policy                    | Implementation                                                                                                                                                                                           |
 | ------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Auto-approve all actions  | `--allow-all` / `--yolo` bypasses all permission prompts for tools, paths, and URLs.                                                                                                                    |
-| User input suppression    | `--no-ask-user` disables the `ask_user` tool ([`copilot --help`][cli-help-ref]). The agent makes decisions autonomously.                                                                                 |
-| Autopilot permissions     | When entering autopilot mode, if `--allow-all` is not set, the CLI prompts for permissions. In headless mode (`-p`), this prompt would stall. `--allow-all` must be used with `--autopilot`.            |
+| Auto-approve all actions  | `--allow-all` / `--yolo` bypasses all permission prompts for tools, paths, and URLs. Passed under the condition described in "Permission flags".                                                         |
+| User input suppression    | `--no-ask-user` disables the `ask_user` tool ([`copilot --help`][cli-help-ref]). The agent makes decisions autonomously. Passed on every invocation, so a turn never ends in `turn_input_required`.       |
+| Autopilot permissions     | When entering autopilot mode without `--allow-all`, the CLI prompts for permissions. In headless mode (`-p`) that prompt stalls, so an operator who configures tool scoping must scope it wide enough to cover the run. |
 | Unsupported tool calls    | Copilot CLI handles tool routing internally. Unknown tools return failure and the session continues.                                                                                                      |
 
 ### Permission system details
@@ -609,85 +562,83 @@ is set.
 
 ---
 
-## Error Detection and Mapping
+## Error detection and mapping
 
 ### Process exit codes
 
-| Exit Code                | Meaning                                  | Adapter mapping                                   |
-| ------------------------ | ---------------------------------------- | ------------------------------------------------- |
-| 0                        | Success (task completed or autopilot ended normally). If no `result` event was received and cumulative output tokens are zero, treated as `turn_failed` (no-output safety heuristic). | `turn_completed` or `turn_failed` (no-output heuristic) |
-| Non-zero                 | General error                            | `turn_failed`                                     |
-| 127                      | `copilot` binary not found               | `agent_not_found`                                 |
-| Signal (graceful/force)  | Killed by adapter or OS                  | `turn_cancelled`                                  |
+Copilot CLI documents no per-failure-mode exit codes, so any non-zero value means only
+"failure" and stderr carries the diagnosis. `procutil.EmitWarnLines` logs the collected stderr
+lines at WARN whenever a turn ends in an error.
 
-> **Gap:** Copilot CLI does not document specific exit codes for different failure modes (unlike
-> Claude Code which uses exit code 1 for general errors). The adapter should treat any non-zero
-> exit code as `turn_failed` and capture stderr for diagnostics.
+| Outcome                                                | Exit reason      | Error category    |
+| ------------------------------------------------------ | ---------------- | ----------------- |
+| `result` event with `exitCode` 0                       | `turn_completed` | none              |
+| `result` event with non-zero `exitCode`                | `turn_failed`    | `turn_failed`     |
+| No `result` event, process exits 0, output tokens seen  | `turn_completed` | none              |
+| No `result` event, process exits 0, no output tokens    | `turn_failed`    | `turn_failed`     |
+| No `result` event, process exits non-zero               | `turn_failed`    | `port_exit`       |
+| Exit 127 (`copilot` not found)                          | `turn_failed`    | `agent_not_found` |
+| Killed by signal                                        | `turn_cancelled` | `turn_cancelled`  |
+| Stdout line over 10 MB, or another scanner error        | `turn_failed`    | `port_exit`       |
+
+The zero-output row is the safety heuristic: a process that exits 0 having produced nothing is
+reported as a failure rather than a silent success, and `FinalizeTurn` logs "agent exited
+without producing output, treating as failure".
 
 ### Authentication failures
 
 | Condition                                  | Behavior                                                  | Adapter mapping         |
 | ------------------------------------------ | --------------------------------------------------------- | ----------------------- |
-| No valid token in environment              | CLI fails to start, outputs error to stderr               | `agent_not_found` or `response_timeout` |
-| Token lacks Copilot access                 | CLI fails during API call                                 | `turn_failed`           |
-| Organization policy disables Copilot CLI   | CLI fails during authentication                            | `turn_failed`           |
-| Classic PAT (`ghp_*`) used                 | Authentication rejected                                    | `turn_failed`           |
+| No token source present                    | `checkAuth` rejects the session before any launch          | `agent_not_found`       |
+| Token present but rejected by the API      | CLI fails during the API call and exits non-zero            | `port_exit`             |
+| Organization policy disables Copilot CLI   | CLI fails during authentication                            | `port_exit`             |
 
 ### Error category mapping (per [architecture Section 10.5](architecture/10-agent-adapter-contract.md#105-timeouts-and-error-mapping))
 
-| Condition                                 | Error category          |
-| ----------------------------------------- | ----------------------- |
-| `copilot` binary not found on `$PATH`     | `agent_not_found`       |
-| Node.js 22+ not available                 | `agent_not_found`       |
-| Workspace path invalid or not a directory | `invalid_workspace_cwd` |
-| No output within `read_timeout_ms`        | `response_timeout`      |
-| Turn exceeds `turn_timeout_ms`            | `turn_timeout`          |
-| Process exits non-zero                    | `port_exit`             |
-| Turn completed with error                 | `turn_failed`           |
-| Process killed by signal                  | `turn_cancelled`        |
-| Agent requests user input (if `--no-ask-user` is not set) | `turn_input_required` |
+`StartSession` produces these categories before any subprocess runs:
+
+| Condition                                       | Error category          |
+| ----------------------------------------------- | ----------------------- |
+| Workspace path invalid or not a directory       | `invalid_workspace_cwd` |
+| `copilot` not resolvable, or `agent.command` empty | `agent_not_found`    |
+| `copilot --version` canary fails                | `agent_not_found`       |
+| No GitHub authentication source                 | `agent_not_found`       |
+
+Turn outcomes use the categories in the exit-code table above. `response_timeout`,
+`turn_timeout`, and `turn_input_required` are unreachable for this adapter: it enforces no read
+or turn deadline, and `--no-ask-user` is passed on every invocation.
 
 ### Known issues in the wild
 
 From [github/copilot-cli issues](https://github.com/github/copilot-cli/issues):
 
 - **Session file corruption** ([#2012](https://github.com/github/copilot-cli/issues/2012)):
-  Raw U+2028/U+2029 characters in `events.jsonl` break `JSON.parse()` on `--resume`. This may
-  affect session continuation.
+  raw U+2028/U+2029 characters in `events.jsonl` break `JSON.parse()` on `--resume`, which
+  breaks session continuation.
 - **Subprocess I/O deadlock** ([#1838](https://github.com/github/copilot-cli/issues/1838)):
-  In Nix/direnv environments, CLI hangs due to subprocess I/O deadlock. The adapter's turn
-  timeout catches this.
+  in Nix and direnv environments the CLI hangs on a subprocess I/O deadlock. Stall
+  reconciliation is what ends such a turn.
 - **Headless server fd leaks** ([#2389](https://github.com/github/copilot-cli/issues/2389)):
-  When running as a headless server, kqueue file descriptors leak and the bash tool stops
+  when running as a headless server, kqueue file descriptors leak and the bash tool stops
   working after prolonged use.
 - **Authentication failures without output** ([#2184](https://github.com/github/copilot-cli/issues/2184)):
-  CLI fails to start without any output when there is a login issue. The adapter should treat
-  no output within `read_timeout_ms` as `response_timeout`.
+  the CLI fails to start without any output when there is a login issue. The turn ends on the
+  process exit, which the zero-output row maps to `turn_failed`.
 - **sessionStart hook fires after userPromptSubmitted** ([#2201](https://github.com/github/copilot-cli/issues/2201)):
-  The `sessionStart` hook fires after `userPromptSubmitted`, not before. Provides real examples
-  of event format in `events.jsonl`.
-- **`--additional-mcp-config` requires `@` prefix for file paths** (confirmed v1.0.21): Bare
-  file paths are parsed as inline JSON and fail with `Invalid JSON in --additional-mcp-config`.
-  The documented syntax for file input is `@<path>` (`github/copilot-cli#428`). Earlier
-  versions (≤1.0.18) had an undocumented fallback that recognized bare paths; this fallback
-  was removed. The Sortie adapter now uses the `@` prefix consistently.
-- **Config parsing errors exit 0 without output** (observed v1.0.21, fixed by PR #405 for
-  the `@` prefix case): When Copilot CLI fails to parse `--additional-mcp-config`, it exits 0
-  without emitting any JSONL events. The adapter's no-output heuristic detects this as
-  `turn_failed`. Operators should check WARN-level logs for the stderr content explaining the
-  parse failure.
+  the `sessionStart` hook fires after `userPromptSubmitted`, not before.
+- **`--additional-mcp-config` requires the `@` prefix for file paths**: a bare file path is
+  parsed as inline JSON and fails with `Invalid JSON in --additional-mcp-config`. The
+  documented syntax for file input is `@<path>` (`github/copilot-cli#428`).
+- **Config parsing errors exit 0 without output**: when Copilot CLI fails to parse
+  `--additional-mcp-config`, it exits 0 without emitting any JSONL events. The zero-output row
+  maps this to `turn_failed`, and the WARN-level stderr log carries the parse failure.
 
 ---
 
-## Session Storage
+## Session storage
 
-Copilot CLI persists sessions to disk at:
-
-```
-~/.copilot/session-state/<session-id>/
-```
-
-Each session directory contains:
+Copilot CLI persists sessions to disk under `<COPILOT_HOME or ~/.copilot>/session-state/<session
+id>/`. Each session directory contains:
 
 | File/Directory    | Description                                                        |
 | ----------------- | ------------------------------------------------------------------ |
@@ -697,11 +648,9 @@ Each session directory contains:
 | `checkpoints/`    | Checkpoints for infinite session context compaction.               |
 | `files/`          | Files tracked by the session.                                      |
 
-This is relevant for:
-
-- **Continuation:** `--resume <session_id>` reads from this directory.
-- **Cleanup:** Sortie may want to clean up session state when removing workspaces.
-- **Disk usage:** Long sessions with infinite context compaction accumulate checkpoint data.
+`--resume <session_id>` reads the conversation back from this directory, and the adapter reads
+`events.jsonl` for token totals as described in "Token usage extraction". Long sessions
+accumulate checkpoint data here; Sortie removes workspaces but not session-state directories.
 
 ### Infinite sessions and context compaction
 
@@ -711,12 +660,12 @@ Copilot CLI uses "infinite sessions" by default. When the context window approac
 2. Processing blocks at ~95% context usage until compaction completes.
 3. Compaction summarizes older conversation history, preserving recent context.
 
-This means a single Copilot CLI session can run indefinitely without hitting context limits.
-The adapter does not need to manage context window size — Copilot CLI handles this internally.
+So a single Copilot CLI session runs indefinitely without hitting context limits, and the
+adapter manages no context window of its own.
 
 ---
 
-## Hooks Integration
+## Hooks integration
 
 Copilot CLI supports lifecycle hooks via `.github/hooks/*.json` in the workspace
 ([hooks configuration reference][hooks-ref], [about hooks][hooks-about]). Each hook file uses
@@ -817,22 +766,20 @@ control][cli-ref]):
 Where `decision` is `"block"` (force another agent turn using `reason` as the prompt) or
 `"allow"` (let the agent stop).
 
-Sortie does **not** manage Copilot CLI's hook system directly. These are workspace-level
-configurations that the coding agent or `after_create` workspace hook can set up. However,
-the adapter should be aware that:
-
-- Hooks can block tool calls (`preToolUse` returning `"deny"`).
-- Hooks can add latency to tool execution (timeout per hook up to 30s default).
-- The `agentStop` hook can prevent session completion if it returns `"block"`.
-- Hook-induced delays should be accounted for in timeout calculations.
+Sortie does not manage Copilot CLI's hook system. Hook files are workspace-level configuration
+that the coding agent or an `after_create` workspace hook sets up. They still change what a
+turn does: a `preToolUse` hook returning `"deny"` blocks a tool call, an `agentStop` hook
+returning `"block"` prevents the session from completing, and each hook adds latency to tool
+execution (30 seconds per hook by default), which lengthens the wall-clock turn a stall timeout
+has to accommodate.
 
 ---
 
-## MCP Server Configuration
+## MCP server configuration
 
 The `--additional-mcp-config <json>` flag adds MCP server declarations for the session.
 It accepts inline JSON or `@<path>` referencing a JSON file. The `@` prefix is required
-for file paths — bare paths are parsed as inline JSON and fail. The format follows the
+for file paths: a bare path is parsed as inline JSON and fails. The format follows the
 standard MCP configuration schema with a top-level `mcpServers` object.
 
 ### File format
@@ -860,9 +807,9 @@ standard MCP configuration schema with a top-level `mcpServers` object.
 
 Copilot CLI reads the configuration at agent startup and spawns each declared server as a
 child process. The server inherits the agent's environment, merged with any variables in
-the `env` field. Unlike `--mcp-config` in Claude Code, `--additional-mcp-config` is
-additive — it supplements rather than replaces Copilot CLI's built-in MCP servers
-(`github-mcp-server`, `playwright`, `fetch`, `time`).
+the `env` field. Unlike `--mcp-config` in Claude Code, `--additional-mcp-config` is additive:
+it supplements rather than replaces Copilot CLI's built-in MCP servers (`github-mcp-server`,
+`playwright`, `fetch`, `time`).
 
 ### Disabling built-in MCP servers
 
@@ -871,17 +818,21 @@ Use `--disable-builtin-mcps` to disable all built-in MCP servers, or
 
 ### Sortie adapter usage
 
-The worker writes `.sortie/mcp.json` to the workspace directory and passes it via
-`--additional-mcp-config @<path>` (the `@` prefix instructs the CLI to read the file).
-If the operator also specifies
-`copilot-cli.mcp_config` in WORKFLOW.md, the worker merges both server sets into a single
-file. A name collision on the `sortie-tools` key fails the attempt. Credential values are
-never written to this file — they reach the MCP server through inherited environment
-variables. See ADR-0009 for the full merge algorithm.
+`orchestrator.GenerateMCPConfig` writes `.sortie/mcp.json` into the workspace directory, and
+`buildArgs` passes that path as `--additional-mcp-config @<path>`. If the operator also sets
+`copilot-cli.mcp_config` in WORKFLOW.md, the worker merges both server sets into that one file;
+a name collision on the reserved `sortie-tools` key fails the attempt. Credential values are
+never written to the file, and reach the MCP server through inherited environment variables
+instead. See ADR-0009 for the full merge algorithm.
+
+When no generated config exists, `formatMCPConfigValue` passes an operator `mcp_config` value
+through on its own: inline JSON (a value starting with `{`) and a value already prefixed with
+`@` go through unchanged, and any other value is treated as a file path and given the `@`
+prefix.
 
 ---
 
-## OpenTelemetry Integration
+## OpenTelemetry integration
 
 Copilot CLI supports OpenTelemetry for monitoring ([CLI command reference: OTel
 monitoring][cli-ref]). OTel is off by default with zero overhead. It activates when any of the
@@ -925,13 +876,16 @@ Lifecycle events recorded on active spans:
 | `github.copilot.session.compaction_complete`  | History compaction completed          |
 | `github.copilot.session.shutdown`            | Session shutting down                  |
 
-Sortie may enable OTel in the subprocess environment for external monitoring, but the adapter's
-primary event source is the JSONL stdout output. OTel data is supplementary and useful for
-per-tool and per-request token breakdowns that JSONL may not provide.
+The adapter neither sets these variables nor parses OTel output: its event source is the JSONL
+stdout stream and its token source is the session-state journal, both of which need no extra
+runtime configuration. An operator who exports one of the variables into Sortie's environment
+gets OTel in the subprocess as well, since the subprocess inherits that environment, and the
+`invoke_agent` span then carries the per-request `gen_ai.usage.input_tokens` and
+`gen_ai.usage.output_tokens` breakdown that the JSONL stream does not.
 
 ---
 
-## Adapter-Specific Pass-Through Config
+## Adapter-specific pass-through config
 
 Per [architecture Section 5.3.5](architecture/05-workflow-specification.md#535-agent-object), the adapter reads pass-through config from the `copilot-cli`
 sub-object in WORKFLOW.md:
@@ -939,100 +893,28 @@ sub-object in WORKFLOW.md:
 | Config key                                | Type    | Description                                                                      |
 | ----------------------------------------- | ------- | -------------------------------------------------------------------------------- |
 | `copilot-cli.model`                       | string  | Model override (e.g., `claude-sonnet-4.5`, `gpt-5`). Maps to `--model`.         |
-| `copilot-cli.max_autopilot_continues`     | integer | Maximum autonomous continuation steps. Maps to `--max-autopilot-continues`.      |
+| `copilot-cli.max_autopilot_continues`     | integer | Maximum autonomous continuation steps. Maps to `--max-autopilot-continues`. A value of zero or less is replaced by 50. |
 | `copilot-cli.agent`                       | string  | Custom agent name. Maps to `--agent`.                                            |
 | `copilot-cli.allowed_tools`               | string  | Space-separated tool allow list. Maps to `--allow-tool`.                         |
 | `copilot-cli.denied_tools`                | string  | Space-separated tool deny list. Maps to `--deny-tool`.                           |
 | `copilot-cli.available_tools`             | string  | Space-separated available tools restriction. Maps to `--available-tools`.        |
 | `copilot-cli.excluded_tools`              | string  | Space-separated excluded tools. Maps to `--excluded-tools`.                      |
-| `copilot-cli.mcp_config`                  | string  | MCP server configuration (inline JSON or file path). The adapter adds the `@` prefix for file paths automatically. Maps to `--additional-mcp-config`. |
+| `copilot-cli.mcp_config`                  | string  | MCP server configuration (inline JSON or file path). Merged into the generated config, or passed through as described in "MCP server configuration". Maps to `--additional-mcp-config`. |
 | `copilot-cli.disable_builtin_mcps`        | boolean | If `true`, passes `--disable-builtin-mcps`. Default: `false`.                   |
 | `copilot-cli.no_custom_instructions`      | boolean | If `true`, passes `--no-custom-instructions`. Default: `false`.                 |
 | `copilot-cli.experimental`                | boolean | If `true`, passes `--experimental`. Default: `false`.                           |
 
 ---
 
-## Example Adapter Invocation
-
-### Turn 1 (new session)
-
-```bash
-prompt='You are working on issue PROJ-123. Fix the authentication bug described below.
-
-## Issue: Authentication fails on expired tokens
-
-The login endpoint returns 500 when the JWT token is expired instead of 401...
-
-## Instructions
-1. Read the relevant code files
-2. Implement the fix
-3. Run tests to verify'
-
-sh -c 'copilot -p "$1" \
-  --output-format json \
-  -s \
-  --allow-all \
-  --autopilot \
-  --no-ask-user \
-  --max-autopilot-continues 50' -- "$prompt"
-```
-
-Working directory: `/var/sortie/workspaces/PROJ-123`
-
-### Turn 2 (continuation)
-
-```bash
-prompt='Continue working on the issue. The previous turn made progress but tests are still failing. Focus on fixing the remaining test failures.'
-session_id='ec41fbe2-af76-4185-ccb9-a61461234abc'
-
-sh -c 'copilot -p "$1" \
-  --output-format json \
-  -s \
-  --allow-all \
-  --autopilot \
-  --no-ask-user \
-  --max-autopilot-continues 50 \
-  --resume "$2"' -- "$prompt" "$session_id"
-```
-
-Working directory: `/var/sortie/workspaces/PROJ-123`
-
-### With model override and tool restriction
-
-```bash
-sh -c 'copilot -p "$1" \
-  --output-format json \
-  -s \
-  --allow-all \
-  --autopilot \
-  --no-ask-user \
-  --max-autopilot-continues 30 \
-  --model gpt-5 \
-  --deny-tool "bash(rm -rf *)"' -- "$prompt"
-```
-
----
-
-## ACP Alternative (Reference Only)
+## ACP alternative (reference only)
 
 The [CLI command reference][cli-ref] lists `--acp` as "Start the Agent Client Protocol server."
-ACP is an open standard for client-agent communication.
+ACP is an open standard for client-agent communication. `copilot --acp` starts that server
+process. The official documentation carries no ACP protocol format, message types, session
+management API, or transport mechanism for Copilot CLI, so the surface is unusable as an
+integration target on the evidence available. See "Open questions".
 
-> **Status:** The `--acp` flag exists but the official documentation provides no details on the
-> ACP protocol format, message types, or session management API for Copilot CLI. Sortie's
-> initial adapter should use the CLI subprocess model. ACP may be considered for a future
-> iteration once documentation matures.
-
-### Starting an ACP server
-
-```bash
-copilot --acp
-```
-
-This starts a server process. The transport mechanism (stdio, TCP, or other) is not
-specified in the CLI documentation.
-
-### ACP vs. subprocess tradeoffs
+### ACP versus subprocess tradeoffs
 
 | Aspect             | Subprocess (`-p`)                           | ACP (`--acp`)                                |
 | ------------------ | ------------------------------------------- | -------------------------------------------- |
@@ -1045,12 +927,11 @@ specified in the CLI documentation.
 
 ---
 
-## SDK Alternative (Reference Only)
+## SDK alternative (reference only)
 
 GitHub provides a TypeScript SDK (`@github/copilot-sdk`, v0.2.0) for programmatic control of
 Copilot CLI via JSON-RPC. The SDK internally spawns the CLI and communicates over stdio or TCP.
-
-> **Status:** The SDK is in technical preview and may change in breaking ways.
+It is labeled a technical preview.
 
 ### SDK architecture
 
@@ -1082,42 +963,33 @@ await client.stop();
 | ------------------------- | ---------------------------------------------------------- | --------------------------------------------------------------- |
 | Permission handling       | `onPermissionRequest` callback required on every session.   | Confirms that headless mode needs explicit permission handling. |
 | Permission result kinds   | `approved`, `denied-interactively-by-user`, `denied-by-rules`, `denied-by-content-exclusion-policy` | Maps to Sortie's approval policy.     |
-| Session events            | `user.message`, `assistant.message`, `assistant.message_delta`, `tool.execution_start`, `tool.execution_complete`, `session.idle` | **Same vocabulary as `--output-format json`.** Confirmed experimentally in v1.0.13: JSONL stdout, session storage `events.jsonl`, and SDK all use the same event type names. |
+| Session events            | `user.message`, `assistant.message`, `assistant.message_delta`, `tool.execution_start`, `tool.execution_complete`, `session.idle` | The shared vocabulary described in "JSONL event schema".        |
 | Infinite sessions         | Background compaction at configurable thresholds.           | Confirms Copilot CLI handles context limits internally.         |
 | Multiple sessions         | Independent sessions with different models.                 | Confirms per-issue session isolation.                            |
 | Streaming                 | `assistant.message_delta` for incremental text.            | Useful for stall detection.                                      |
 | Custom tools              | `defineTool()` with Zod schemas, handler callbacks.        | Not applicable for subprocess model.                             |
 | System message override   | `customize` (per-section) or `replace` mode.               | Reference for prompt injection behavior.                         |
 
-Sortie does **not** use the SDK because the adapter is implemented in Go and the architecture
-mandates subprocess-based integration ([Section 10.7](architecture/10-agent-adapter-contract.md#107-local-subprocess-launch-contract)). The CLI provides a clean, language-agnostic
-integration surface. The SDK documentation is useful as a reference for expected event types and
-session behavior, as the SDK and CLI share the same underlying agent engine.
+Sortie does not use the SDK: the adapter is written in Go and the architecture mandates
+subprocess-based integration ([Section 10.7](architecture/10-agent-adapter-contract.md#107-local-subprocess-launch-contract)), for which the CLI is the language-agnostic surface.
+The SDK documentation stays useful as a reference for event types and session behavior, because
+the SDK and CLI share the same underlying agent engine.
 
 ---
 
-## Fleet Mode (Informational)
+## Fleet mode
 
 Copilot CLI's `/fleet` command breaks implementation plans into independent subtasks and executes
-them in parallel using subagents. Each subagent has its own independent context window.
-
-This is relevant to Sortie because:
-
-- **Parallel execution occurs inside the CLI,** not managed by Sortie. The adapter treats a
-  `/fleet`-based session as a single turn regardless of internal parallelism.
-- **Subagents use separate model configurations.** By default subagents use a low-cost model,
-  but the prompt can override this per-subtask.
-- **Premium request consumption increases** with subagent parallelism. Each subagent interaction
-  consumes premium requests independently.
-- **The `subagentStop` hook** can intercept and block subagent completion.
-
-Sortie's orchestrator manages its own concurrency model (per-issue sessions with
-`max_concurrent_agents`). The CLI's internal parallelism via `/fleet` is transparent to the
-adapter.
+them in parallel using subagents, each with its own context window. Parallel execution happens
+inside the CLI, so the adapter sees a `/fleet` session as one turn regardless of the internal
+parallelism, and Sortie's own concurrency model (per-issue sessions bounded by
+`max_concurrent_agents`) is unaffected. Subagents default to a low-cost model that the prompt
+can override per subtask, each subagent interaction consumes premium requests independently, and
+the `subagentStop` hook can intercept and block subagent completion.
 
 ---
 
-## Differences from Claude Code Adapter
+## Differences from the Claude Code adapter
 
 | Aspect                    | Claude Code                                                   | Copilot CLI                                                   |
 | ------------------------- | ------------------------------------------------------------- | ------------------------------------------------------------- |
@@ -1144,53 +1016,39 @@ adapter.
 
 ---
 
-## Summary: Adapter Implementation Checklist
+## Open questions
 
-1. **StartSession:** Store workspace path and config. Validate `copilot` binary on `$PATH` and
-   Node.js 22+ availability. Verify authentication environment. Do not launch subprocess yet.
-2. **RunTurn (turn 1):** Launch `copilot -p <prompt> --output-format json -s --allow-all
-   --autopilot --no-ask-user --max-autopilot-continues <N>` with cwd = workspace. Parse JSONL
-   stdout. Capture session ID from output.
-3. **RunTurn (turn 2+):** Same as turn 1 but append `--resume <session_id>` (from `result`
-   event's `sessionId` field).
-4. **Event parsing:** Parse `"type"` field. Map `assistant.message` → `assistant_message`,
-   `tool.execution_start` → `tool_use`, `tool.execution_complete` → `tool_result`,
-   `result` → extract session ID and usage. Log unknown types as `other_message`.
-5. **Result handling:** Treat exit code 0 as `turn_completed`, non-zero as `turn_failed`, signal
-   death as `turn_cancelled`.
-6. **Token tracking:** Extract `outputTokens` from `assistant.message` events and
-   `premiumRequests` from the `result` event. For input token counts, enable OTel.
-7. **Timeout:** Enforce `turn_timeout_ms` via context deadline + graceful signal → force-terminate.
-8. **StopSession:** Kill subprocess if running (graceful signal → grace → force-terminate).
-9. **Error mapping:** Check exit code and stderr output. Map to architecture error categories.
-10. **Session continuity:** Use `--resume <session_id>` for multi-turn conversations.
-11. **Permissions:** Default to `--allow-all --no-ask-user` for headless operation.
-12. **Autopilot:** Default to `--autopilot --max-autopilot-continues <N>` for autonomous task
-    completion.
-13. **MCP extensions:** Optionally pass `--additional-mcp-config` for tool extensions.
-
-### Verification items
-
-Resolved items (verified experimentally on v1.0.13):
-
-- [x] JSONL event schema: `"type"` field discriminator, event types documented above.
-- [x] JSONL events match the SDK vocabulary (`user.message`, `assistant.message`, etc.), not
-  the old hook-style format (`"event"` field) from issue #2201.
-- [x] Session ID is in the `result` event's `sessionId` field.
-- [x] `--no-ask-user` flag exists and works (confirmed in `copilot --help` v1.0.13).
-- [x] Without `--autopilot`, the agent exits after one response in `-p` mode.
-
-Remaining items requiring further verification:
-
-- [ ] Exit code behavior for different failure modes (authentication failure, API error, timeout).
-  Auth failure observed: emits `session.warning` + `session.mcp_server_status_changed` before
-  erroring to stderr (exit code non-zero).
-- [ ] Whether `--resume` works reliably with session IDs from the `result` event.
-- [ ] Interaction between `--max-autopilot-continues` and process exit code.
-- [ ] Session storage cleanup behavior when workspaces are removed.
-- [ ] ACP protocol details (`--acp`): transport mechanism, message format, session management.
-- [ ] Token resolution order when all sources have valid but different tokens (GH_TOKEN vs
-  GITHUB_TOKEN precedence — the CLI falls back on failure so the practical impact is minimal).
+- Whether a classic PAT (`ghp_*`) authenticates the CLI. One observation has a classic PAT
+  failing authentication, and no official documentation states such a restriction. Settle it by
+  running one headless turn per token type with every other source unset, and comparing the
+  stderr messages.
+- Exit codes per failure mode (rejected credential, upstream API error, backend timeout). An
+  authentication failure emits `session.warning` and `session.mcp_server_status_changed`, then
+  errors to stderr and exits non-zero; the other modes have not been induced. Settle it by
+  forcing each failure and recording exit code and stderr.
+- Whether `--resume` accepts a session ID taken from the `result` event on every path,
+  including after a turn that ended in failure. Settle it by running a two-turn session with a
+  forced failure on the first turn and checking that the second turn's `user.message` history
+  includes the first prompt.
+- How `--max-autopilot-continues` interacts with the process exit code when the limit is
+  reached. Settle it by running a task that cannot finish within a limit of 1 and reading the
+  `result` event's `exitCode` and the process exit code.
+- Whether Copilot CLI ever removes session-state directories on its own. Settle it by listing
+  the session-state root before and after a long-running session and a CLI restart.
+- What `--experimental` enables. The flag surfaces no feature list in `copilot --help`. Settle
+  it by diffing `copilot --help` and the JSONL event stream of one identical turn run with and
+  without the flag.
+- ACP protocol details for `--acp`: transport, message format, and session management. Settle
+  it by starting `copilot --acp` under a timeout with stdout captured and inspecting the first
+  frames it emits, or by finding an upstream schema dump.
+- Which token source the CLI selects when all sources hold valid but different tokens. The
+  fallback-on-failure behavior makes this immaterial to the adapter, which only checks that one
+  source exists. Settle it by setting three valid tokens for distinct accounts and reading back
+  the authenticated identity.
+- Whether `agent.turn_timeout_ms` is meant to bind this adapter. The value reaches
+  `domain.AgentConfig.TurnTimeoutMS` and no code reads it, so a turn is bounded only by
+  `stall_timeout_ms` and worker cancellation. Settle it against the agent adapter contract in
+  `docs/architecture/10-agent-adapter-contract.md`, not by probing the CLI.
 
 [cli-help-ref]: https://docs.github.com/en/copilot/reference/copilot-cli-reference/cli-command-reference "GitHub Copilot CLI command reference (includes flags such as --no-ask-user)"
 

--- a/docs/gitea-adapter-notes.md
+++ b/docs/gitea-adapter-notes.md
@@ -1,53 +1,14 @@
 # Gitea REST API: Adapter research notes
 
-> Gitea REST API v1, researched July 2026 and pinned to **Gitea 1.27.0**. Route surface taken from the instance's own OpenAPI description (`GET /swagger.v1.json`), cross-checked against docs.gitea.com, then **verified live** against a local Gitea 1.27.0 instance on 2026-07-14. Forgejo compatibility checked against Codeberg's published swagger and version endpoint on the same date. Reference for implementing the Gitea `TrackerAdapter`, `SCMAdapter`, and `CIStatusProvider`. The [SCM read surface](#scm-read-surface) covers review decisions, mergeability, CI status, review comments, and label events; the [SCM write surface](#scm-write-surface) covers merge, branch delete, label removal, and the auto-merge preflight; the [CI status provider](#ci-status-provider) reads combined-status CI feedback.
+> **Product.** Gitea, self-hosted, REST API v1 under `/api/v1`. Gitea serves no GraphQL API, so the REST surface is the whole contract. There is no default host: the instance base URL is part of every configuration, and instance settings rather than an edition tier gate behavior (for example `MAX_RESPONSE_ITEMS`).
 >
-> Gitea is self-hosted: there is no fixed default host, so the instance base URL is part of every configuration, and instances differ in version and settings. Facts below hold for 1.27.0 defaults unless marked otherwise. Gitea exposes no GraphQL API; the REST surface under `/api/v1` is the whole contract.
+> **Versions pinned.** The tracker surface is anchored to **Gitea 1.27.0**, observed 2026-07-14. The SCM read surface, the SCM write surface, and the CI status provider are anchored to **Gitea 1.26.4**, observed 2026-08-10, 2026-08-11, and 2026-08-16. The lab instance runs 1.26.4 and self-reports that release in its own OpenAPI description. The tracker route surface, pagination and clamps, list parameters, label filter, error statuses, dependency direction, and merge rejection each carry a 1.26.4 re-observation; a 1.27.0 claim without one rests on the 2026-07-14 observation of that release. Where the two releases answer differently, both answers are stated at the claim.
 >
-> **Three verification passes, two releases.** The tracker surface was verified on Gitea 1.27.0 (2026-07-14); the SCM read surface on Gitea 1.26.4 (2026-08-10); and on 2026-08-11 a regression pass re-exercised both surfaces against a Gitea **1.26.4** instance whose own OpenAPI description reports `Gitea API 1.26.4`. The lab available for re-verification no longer runs 1.27.0, so every claim in this document that is marked verified but not re-confirmed below rests on the 1.27.0 pass alone and has not been re-observed since 2026-07-14. Claims added or corrected by the 2026-08-11 pass are dated inline and scoped to 1.26.4.
-
----
-
-## Native adapter versus GitHub adapter reuse
-
-The central question for this integration: Gitea's API is GitHub-inspired, and the GitHub adapter honors a configurable `tracker.endpoint`, so basic issue polling might work by pointing the existing GitHub adapter at a Gitea instance. The community request that motivated this research proposed exactly that (issue #619).
-
-**Verdict: build a standalone native `kind: gitea` adapter.** Reuse fails in ways that are worse than hard errors: two of the failure modes below corrupt state or lose data silently. A native adapter also matches the one-package-per-tracker precedent set by the Jira, GitHub, and Linear adapters (per ADR-0003), so no ADR is required for this outcome.
-
-### Reuse compatibility matrix
-
-Every route and behavior the GitHub tracker adapter (`internal/scm/github`, `tracker.go`) depends on, checked against Gitea 1.27.0. "Verified" means exercised live against the local instance.
-
-| GitHub adapter dependency | Gitea 1.27.0 behavior | Consequence under reuse |
-| --- | --- | --- |
-| `Authorization: Bearer <token>` header | Accepted (verified) | Works |
-| `GET /repos/{owner}/{repo}/issues?state=open` | Route exists (verified) | Works |
-| `sort=created&direction=asc` on the issue list | Parameters silently ignored; order is fixed newest-first (verified) | Candidate ordering diverges silently |
-| `per_page=50` | Parameter silently ignored; Gitea reads `limit`, so the default page size 30 applies (verified) | Correct results, more round trips |
-| `pull_request` key on PR entries in the issue list | Present (verified) | PR skip logic works |
-| `Link` header pagination | Same `rel="next"` / `rel="last"` format (verified) | Works |
-| ETag conditional requests (`If-None-Match`) | No `ETag` header on API responses (verified) | Cache never hits; every poll pays full cost |
-| `GET /search/issues` (used for `query_filter` candidates and for terminal states in `FetchIssuesByStates`) | Route absent; Gitea's search lives at `/repos/issues/search` with different, non-qualifier parameters (verified 404) | `query_filter` breaks; the terminal-state half of `FetchIssuesByStates` also breaks, but that method has no orchestrator caller, so nothing observes the failure |
-| `GET .../issues/{n}/dependencies/blocked_by` | Route absent (verified 404); Gitea serves the same data at `.../issues/{index}/dependencies` | Adapter swallows the 404 and returns no blockers: **silent loss of `blocked_by`**, so blocked issues dispatch anyway |
-| `GET .../issues/{n}/parent` | Route absent; Gitea has no parent concept | 404 tolerated, parent is nil; harmless |
-| `DELETE .../issues/{n}/labels/{name}` in `TransitionIssue` | Route parameter is a numeric label id; a name parses to 0 and returns 404 `label does not exist [label_id: 0, ...]` (422 on Gitea 1.26.x and earlier) | Adapter tolerates the 404, so the old state label is **never removed: state labels accumulate and state reads silently corrupt** |
-| `POST .../issues/{n}/labels {"labels": ["name"]}` | Accepted, additive; but an unknown label name is **silently ignored** with HTTP 200 (verified) | A transition to a not-yet-created state label no-ops without any error |
-| `PATCH .../issues/{n} {"state": ..., "state_reason": ...}` | `state` honored; unknown `state_reason` field tolerated and ignored (verified) | Close and reopen work |
-| `GET .../issues/{n}/comments?per_page=50` | Route exists; ignores paging parameters and returns the full comment list in one response (verified with 60 comments) | Complete results by accident: the paginator sees no `Link` header and stops after one page |
-| `POST .../issues/{n}/comments` | Compatible (verified) | Works |
-| `X-GitHub-Api-Version` header | Ignored | Harmless |
-
-Reuse survives the read-mostly happy path and breaks exactly where issue polling turns into orchestration: the state machine (`TransitionIssue`), `query_filter`, terminal cleanup, and blocker awareness. The two silent failures (label removal no-op, unknown-label no-op) would surface as mysteriously stuck workflows rather than as errors an operator can act on.
-
-### Helper sharing
-
-The native adapter is built on the existing shared utility packages, the same way the Linear adapter is: `internal/httpkit` for the HTTP client and the `Link`-header paginator (`httpkit.NewLinkPaginator`, `httpkit.ParseLinkRel`), `internal/issuekit` for shared normalization helpers, `internal/trackermetrics` for instrumentation, and `internal/typeutil` for config decoding. The SCM and CI surfaces added later lean on `internal/scm/scmcore` for the forge decision logic every SCM adapter shares (error conversion and merge-conflict promotion, bot-author classification, sortable event ids, and the CI aggregate). No third-party Gitea client library, consistent with the zero-runtime-dependency model, and no shared base structs with the GitHub adapter: the overlap is transport-shaped, not domain-shaped, and lives in `httpkit` already.
-
-### Package placement
-
-Recommendation: **`internal/scm/gitea`**, the combined tracker-plus-SCM layout the GitHub adapter uses, not a standalone `internal/tracker/gitea` package.
-
-The GitHub precedent shows a tracker registration can ship from an SCM-family package: `internal/scm/github` registers tracker kind `github` (per [architecture Section 11.6](architecture/11-issue-tracker-integration-contract.md#116-implemented-tracker-adapters)), and later grew the `SCMAdapter` and CI surfaces in place. The long-term plan for Gitea is full GitHub parity (tracker, PR reactions, CI feedback, SCM at all levels), so the PR-automation epic sketched in the gap map below lands in the same package. Starting in `internal/tracker/gitea` would force a package move when that epic starts. The `internal/scm/` boundary rules apply unchanged: no cross-adapter imports, no orchestrator imports, and external responses are normalized to domain types at the boundary. The orchestrator resolves the adapter through `internal/registry` under tracker kind `gitea`.
+> **Instruments.** Live `curl` probes against the lab instance carrying the token the adapter carries; the instance's own OpenAPI description (`GET /swagger.v1.json`); docs.gitea.com through Context7; Gitea source read at the `v1.26.4` and `v1.27.0` tags; Codeberg's published swagger and `GET /api/v1/version`, read 2026-07-14, for the Forgejo comparison.
+>
+> **Evidence markers.** `(verified)` marks a claim observed on the 1.27.0 lab on 2026-07-14. "verified live" marks a claim observed on the 1.26.4 lab on the date its sentence names. "swagger" marks the instance OpenAPI description, and an upstream file is cited at the tag it was read at. [Open questions](#open-questions) collects what no probe has settled and names the probe that would settle each.
+>
+> **Interfaces served.** `domain.TrackerAdapter`, `domain.SCMAdapter`, and `domain.CIStatusProvider`, all implemented by `internal/scm/gitea` and resolved through `internal/registry` under kind `gitea`. The [SCM read surface](#scm-read-surface) covers review decisions, mergeability, CI status, review comments, and label events; the [SCM write surface](#scm-write-surface) covers merge, branch delete, label removal, and the auto-merge preflight; the [CI status provider](#ci-status-provider) reads combined-status CI feedback.
 
 ---
 
@@ -59,7 +20,7 @@ Gitea authenticates API requests with personal access tokens. The canonical head
 Authorization: token <access_token>
 ```
 
-The word `token` (lowercase) before the key is required "for historical reasons" per the official API usage guide. Verified alternatives on 1.27.0, all returning 200 for the same token:
+The word `token` (lowercase) before the key is required "for historical reasons" per the official API usage guide. Alternatives verified on 1.27.0, all returning 200 for the same token and all five re-confirmed live on 1.26.4 (2026-08-11):
 
 | Scheme | Format | Notes |
 | --- | --- | --- |
@@ -67,7 +28,7 @@ The word `token` (lowercase) before the key is required "for historical reasons"
 | Bearer header | `Authorization: Bearer <key>` | Documented for OAuth2 access tokens; also accepts personal tokens (verified) |
 | Basic, token as password | `Authorization: Basic base64(user:<key>)` | Works (verified) |
 | Basic, token as username | `Authorization: Basic base64(<key>:)` | Works (verified) |
-| Query parameter | `?access_token=<key>` | Works on 1.27.0 defaults (verified) but leaks the secret into URLs and server logs; the adapter MUST NOT use it |
+| Query parameter | `?access_token=<key>` | Works on 1.27.0 defaults (verified) but leaks the secret into URLs and server logs; the adapter sends the token only in the `Authorization` header (`newGiteaClient`) |
 
 A `Sudo` header (or `sudo` query parameter) lets a site administrator impersonate another user. The adapter does not need it.
 
@@ -99,17 +60,9 @@ Recommended token: `write:issue, read:user, read:repository`.
 - Invalid or missing token: 401 `{"message": "invalid username, password or token"}` (or `"token is required"`).
 - Valid token, missing scope: 403 `{"message": "token does not have at least one of required scope(s), required=[read:user], token scope=..."}`.
 
-The constructor SHOULD run this check before the first poll, mirroring the Linear adapter's `viewer` credential check, so a bad key fails construction rather than the first fetch. The returned `login` is the identity that `assigned_by` and `mentioned_by` filters reference (see Server-side filtering). A second preflight call, `GET /repos/{owner}/{repo}`, fails fast on a mistyped `tracker.project` and reports the token's effective `permissions` (`admin`, `push`, `pull`); without it a bad project surfaces as `tracker_not_found` on every subsequent call, because Gitea's 404 body does not distinguish a missing repository from a missing issue (verified).
+`runPreflight` runs this check before the first poll, so a bad key fails construction rather than the first fetch. The returned `login` is the identity that `assigned_by` and `mentioned_by` filters reference (see Server-side filtering); the read path does not consume it. A second preflight call in the same function, `GET /repos/{owner}/{repo}`, fails fast on a mistyped `tracker.project` and reports the token's effective `permissions` (`admin`, `push`, `pull`); without it a bad project surfaces as `tracker_not_found` on every subsequent call, because Gitea's 404 body does not distinguish a missing repository from a missing issue (verified). A transient 5xx or transport failure is retried with a bounded backoff before construction fails; a 401, 403, or 404 fails construction immediately.
 
-### Config mapping
-
-| Config field | Value |
-| --- | --- |
-| `tracker.endpoint` | Instance base URL, for example `https://gitea.example.com`. Required: there is no default host. The adapter appends `/api/v1`; it SHOULD tolerate a value that already ends in `/api/v1` without double-appending |
-| `tracker.api_key` | Access token (single string, no `email:token` composition) |
-| `tracker.project` | `owner/repo`, for example `myorg/myrepo`; validated as exactly one `/` at startup, like the GitHub adapter |
-
-Sub-path deployments work because Gitea always serves the API at `{ROOT_URL}/api/v1`, so appending is deterministic. Plain-HTTP endpoints send the token in cleartext; operators SHOULD front self-hosted instances with TLS. There is no API version header; behavior is pinned by the instance version, which `GET /api/v1/version` reports (`{"version": "1.27.0"}`).
+Sub-path deployments work because Gitea always serves the API at `{ROOT_URL}/api/v1`, so appending is deterministic. Plain-HTTP endpoints send the token in cleartext; operators SHOULD front self-hosted instances with TLS. There is no API version header; behavior is pinned by the instance version, which `GET /api/v1/version` reports (`{"version": "1.27.0"}`). Config field values are listed under [Config mapping](#config-mapping).
 
 ---
 
@@ -120,7 +73,7 @@ Gitea issues carry two numbers:
 - `number` (the **index**): repo-scoped, human-visible, and the value every per-issue route consumes (`/repos/{owner}/{repo}/issues/{index}`).
 - `id`: an instance-global int64 that no issue route accepts as input.
 
-Verified on a two-repository instance: the first issue of the second repository has `number: 1` and global `id: 6`. Pull requests share the issue index sequence within a repository, and the identity split runs deeper: a PR created after issues 1 through 5 got `number: 6`, its PR object reports the pull-table `id: 1`, while the same entity fetched through the issues route reports the issue-table `id: 7`. The global `id` is therefore a trap for cross-referencing, and the index is the only identifier worth storing.
+Verified on a two-repository instance: the first issue of the second repository has `number: 1` and global `id: 6`. Pull requests share the issue index sequence within a repository, and the identity split runs deeper: a PR opened after issues 1 through 5 takes `number: 6`, its PR object reports the pull-table `id: 1`, and the same entity fetched through the issues route reports the issue-table `id: 7`. The global `id` is therefore a trap for cross-referencing, and the index is the only identifier worth storing.
 
 The adapter maps `domain.Issue.ID` and `domain.Issue.Identifier` both to the index as a string, exactly as the GitHub adapter does (its `FetchIssueStatesByIdentifiers` documents "ID and Identifier are both the issue number" and delegates to one shared fetch path). `tracker.project` is `owner/repo`; the adapter splits it once at construction and builds all paths from the parts.
 
@@ -130,7 +83,7 @@ The adapter maps `domain.Issue.ID` and `domain.Issue.Identifier` both to the ind
 
 Gitea issues natively carry only `open` and `closed` (query enum adds `all`). There is no workflow engine, no transition graph, and no `state_reason`.
 
-**Decision: label-driven workflow states, identical to the GitHub adapter's convention.** The alternative the research brief named, native state combined with labels, is not a distinct option: the GitHub convention already couples the two by closing the issue on a terminal transition and reopening it on an active one. Adopting the same model keeps operator configuration uniform across the two open/closed trackers.
+The adapter derives workflow state from labels, the same convention the GitHub adapter uses, and couples that state to the native open/closed flag by closing the issue on a terminal transition and reopening it on an active one. One model across the two open/closed trackers keeps operator configuration uniform.
 
 - `tracker.active_states`, `tracker.terminal_states`, and `tracker.handoff_state` name repository labels, normalized to lowercase per [architecture Section 11.3](architecture/11-issue-tracker-integration-contract.md#113-normalization-rules).
 - State derivation scans the issue's labels against the configured lists: first match in `active_states` order, then `terminal_states` order; multiple matches log a warning and keep the first.
@@ -142,20 +95,15 @@ Gitea issues natively carry only `open` and `closed` (query enum adds `all`). Th
 
 Three verified Gitea behaviors force different label plumbing:
 
-1. **Label removal is by numeric id.** `DELETE /repos/{owner}/{repo}/issues/{index}/labels/{id}` accepts only a label id; a name in that position returns 404 with `label does not exist [label_id: 0, ...]` (422 on Gitea 1.26.x and earlier). The adapter resolves names to ids up front, so neither status is reached.
-2. **Unknown label names are silently ignored on attach.** `POST .../issues/{index}/labels {"labels": ["no-such-label"]}` returns HTTP 200 and attaches nothing (verified). Gitea never auto-creates labels from this route and never errors. Any flow that trusts the server to reject a bad label name will no-op invisibly, so the adapter MUST resolve every label name itself before attaching, and MUST attach by id.
+1. **Label removal is by numeric id.** `DELETE /repos/{owner}/{repo}/issues/{index}/labels/{id}` accepts only a label id; a delete by id returns 204 (verified). A name in that position returns 404 with `label does not exist [label_id: 0, ...]` on 1.27.0 and 422 with the same message on 1.26.4 (verified live, 2026-08-11). The adapter resolves names to ids up front, so neither status is reached.
+2. **Unknown label names are silently ignored on attach.** `POST .../issues/{index}/labels {"labels": ["no-such-label"]}` returns HTTP 200 and attaches nothing (verified). Gitea never auto-creates labels from this route and never errors. Any flow that trusts the server to reject a bad label name no-ops invisibly, so the adapter resolves every label name itself before attaching and attaches by id (`ensureLabelID`, `AddLabel`, `TransitionIssue`).
 3. **Server-side label filtering is hostile to configuration typos.** See Server-side filtering: an unresolvable name in the `labels` query parameter silently disables the filter instead of returning an empty result.
 
-The adapter therefore loads the repository label list once per operation that needs it (`GET /repos/{owner}/{repo}/labels`, paginated) and resolves names case-insensitively: Gitea stores label names with their original casing and matches them case-sensitively, while Sortie's configured state names are lowercase.
+The adapter therefore loads the repository label list once per operation that needs it (`resolveLabelIndex` over `GET /repos/{owner}/{repo}/labels`, paginated to exhaustion) and resolves names case-insensitively: Gitea stores label names with their original casing and matches them case-sensitively, while Sortie's configured state names are lowercase. Paging the catalog to exhaustion is required, because a first-page-only resolver would miss a label defined on a later page and then either fail to resolve a real label or create a duplicate.
 
 ### Label hygiene for state labels
 
-The state labels MUST exist in the repository before transitions can work. Two policies were considered:
-
-- **Pre-created labels, fail loudly when missing** (the GitHub adapter's policy). On GitHub a missing label produces a visible 422; on Gitea the attach route cannot fail loudly (behavior 2 above), so the failure the operator would see is nothing at all.
-- **Create-on-missing** (the Linear adapter's policy): resolve the name, and when absent, create it with `POST /repos/{owner}/{repo}/labels`, then attach by id.
-
-Recommendation: **create-on-missing**, because Gitea's silent-ignore removes the fail-loudly option, and a state transition that silently does not happen is the worst outcome of the three. Label creation requires `name` and `color` (422 `[Color]: Required` without it, verified); the adapter supplies a fixed default color (for example `#cccccc`). Creation is covered by the `write:issue` scope (verified), so no extra permissions are needed.
+A state label must exist in the repository before it can be attached, and the adapter creates it when it does not: `ensureLabelID` resolves the name against the label catalog and, when absent, creates it with `POST /repos/{owner}/{repo}/labels` and attaches the new id. The GitHub adapter instead requires pre-created labels and lets a missing one fail loudly with a 422, which Gitea's attach route cannot do (behavior 2 above): there the operator would see nothing at all, and a state transition that silently does not happen is the worst outcome available. Label creation requires `name` and `color` (422 `[Color]: Required` without it, verified); the adapter sends the fixed color `cccccc`. Creation is covered by the `write:issue` scope (verified), so no extra permissions are needed.
 
 ---
 
@@ -181,10 +129,10 @@ Route map for the nine `TrackerAdapter` methods (`internal/domain/tracker.go`):
 GET /repos/{owner}/{repo}/issues?state=open&type=issues&limit=50
 ```
 
-- `type=issues` excludes pull requests server-side (verified). The adapter keeps the `pull_request`-key guard as a second line of defense, matching the GitHub adapter's `isPullRequest` check, because single-issue fetches still need it (see operation 2).
-- State filtering is client-side against the configured `active_states`, exactly like the GitHub adapter's no-filter path. The adapter MUST NOT push the configured state labels into the `labels` query parameter: the filter is AND-semantics across multiple labels (an issue must carry all of them, verified), and an unresolvable name silently drops the whole filter and returns everything (verified). Either property alone disqualifies it for state scoping.
-- Gitea offers no `sort` or `direction` parameters on this route; pages arrive newest-first. The GitHub adapter requests oldest-first server-side, so the Gitea adapter SHOULD re-sort the accumulated result by `created_at` ascending after pagination completes, handing the orchestrator identically ordered candidates.
-- Pagination via the `Link` header with `httpkit.NewLinkPaginator` and the shared max-page guard. Comments are set to nil on all returned issues.
+- `type=issues` excludes pull requests server-side (verified; re-confirmed live on 1.26.4, where it excluded all ten PRs from a 16-entry listing). The adapter keeps the `pull_request`-key guard as a second line of defense, matching the GitHub adapter's `isPullRequest` check, because single-issue fetches still need it (see operation 2).
+- State filtering is client-side against the configured `active_states`, exactly like the GitHub adapter's no-filter path (`listAndFilter`). The adapter never pushes the configured state labels into the `labels` query parameter: the filter is AND-semantics across multiple labels (an issue must carry all of them, verified), and an unresolvable name silently drops the whole filter and returns everything (verified). Either property alone disqualifies it for state scoping.
+- Gitea offers no `sort` or `direction` parameters on this route; pages arrive newest-first by `created_at`, and issues sharing a timestamp arrive in index order (verified live, 2026-08-11). The GitHub adapter requests oldest-first server-side, so `FetchCandidateIssues` re-sorts the accumulated result by `CreatedAt` ascending after pagination completes, handing the orchestrator identically ordered candidates.
+- Pagination via the `Link` header with `httpkit.NewLinkPaginator`, capped at the package's `maxPages` guard of 200 pages. Comments are set to nil on all returned issues, and `DisplayID` is qualified to `owner/repo#N` by `setDisplayID`.
 - `tracker.query_filter`, when configured, merges into this same request (see Server-side filtering); there is no separate search endpoint in the flow.
 
 ### 2. `FetchIssueByID`
@@ -195,17 +143,17 @@ GET /repos/{owner}/{repo}/issues/{index}
 
 - 404 maps to `tracker_not_found`.
 - A PR index resolves on this route and returns the PR in issue shape with `pull_request` set (verified: `GET .../issues/6` returned the PR). The adapter returns `tracker_not_found` for it, like the GitHub adapter.
-- Comments come from operation 6's route; blockers from `GET .../issues/{index}/dependencies`, which returns full issue objects for every issue **blocking** the queried one (verified: after `POST .../issues/2/dependencies {"index": 1, "owner": ..., "repo": ...}` created "1 blocks 2", the dependencies list of #2 contains #1, and `.../issues/1/blocks` contains #2). Each blocker normalizes to `domain.BlockerRef` with `ID` and `Identifier` set to the blocker's index and `State` derived from its labels and native state, satisfying the `blocked_by` rule in [architecture Section 11.3](architecture/11-issue-tracker-integration-contract.md#113-normalization-rules).
-- Parent is always nil: Gitea 1.27 has no parent or sub-issue concept.
+- Comments come from operation 6's route; blockers from `GET .../issues/{index}/dependencies`, which returns full issue objects for every issue **blocking** the queried one (verified: after `POST .../issues/2/dependencies {"index": 1, "owner": ..., "repo": ...}` created "1 blocks 2", the dependencies list of #2 contains #1, and `.../issues/1/blocks` contains #2; re-established live on 2026-08-11 by creating and deleting one dependency). The create route takes the blocker from the body and the blocked issue from the path, and it requires the full issue-meta body: a body carrying only `{"index": 1}` returns 404 `IsErrRepoNotExist` (verified live, 2026-08-11). Only the integration harness writes dependencies; the adapter reads them. Each blocker entry carries `number`, `state`, and `labels`, which is everything `normalizeBlockers` needs to produce a `domain.BlockerRef` with `ID` and `Identifier` set to the blocker's index and `State` derived from its labels and native state, satisfying the `blocked_by` rule in [architecture Section 11.3](architecture/11-issue-tracker-integration-contract.md#113-normalization-rules).
+- Parent is always nil and no parent request is issued: Gitea has no parent or sub-issue concept. GitHub's `.../issues/{index}/dependencies/blocked_by` and `.../issues/{index}/parent` are both absent (404, verified; re-confirmed live on 1.26.4 against a 200 on `.../issues/{index}/dependencies` as the control).
 
 ### 3. `FetchIssuesByStates`
 
-Two paginated list queries at most, both with client-side state filtering:
+Two paginated list queries at most, both with client-side state filtering. The requested set is partitioned by whether each state is terminal, so the two listings are disjoint and need no cross-fetch deduplication:
 
-- Requested states intersecting `active_states`: `GET .../issues?state=open&type=issues&limit=50`.
-- Requested states intersecting `terminal_states`: `GET .../issues?state=closed&type=issues&limit=50`.
+- Any requested state that is not terminal: `GET .../issues?state=open&type=issues&limit=50`, with the operator `query_filter` merged in.
+- Any requested terminal state: `GET .../issues?state=closed&type=issues&limit=50`, without the `query_filter`.
 
-The GitHub adapter serves the terminal half through the search endpoint with a server-side label qualifier. Gitea gets the plain closed listing instead, for three reasons: the search route cannot scope to one repository (see Server-side filtering), a server-side `labels` filter inherits the unresolvable-name foot-gun, and a label filter misses closed issues with no terminal label, which the state model still counts as terminal (first `terminal_states` entry). A full closed-issue scan is more traffic, but this method has no orchestrator caller: nothing invokes `FetchIssuesByStates` today. Startup terminal cleanup is served by `FetchIssueStatesByIdentifiers` instead.
+The GitHub adapter serves the terminal half through the search endpoint with a server-side label qualifier. Gitea gets the plain closed listing instead, for three reasons: the search route cannot scope to one repository (see Server-side filtering), a server-side `labels` filter inherits the unresolvable-name foot-gun, and a label filter misses closed issues with no terminal label, which the state model still counts as terminal (first `terminal_states` entry). A full closed-issue scan is more traffic, but this method has no orchestrator caller. Startup terminal cleanup runs through `FetchIssueStatesByIdentifiers` instead.
 
 ### 4. `FetchIssueStatesByIDs` and 5. `FetchIssueStatesByIdentifiers`
 
@@ -217,24 +165,25 @@ Gitea has no bulk state-by-ids route. The adapter loops `GET .../issues/{index}`
 GET /repos/{owner}/{repo}/issues/{index}/comments
 ```
 
-- This route is **unpaginated**: it accepts no `page` or `limit` parameters (per the swagger description) and returns the complete comment list in one response. Verified with 60 comments: all 60 returned in one body, `X-Total-Count: 60`, no `Link` header, and no truncation at the `MAX_RESPONSE_ITEMS` cap that governs paginated routes.
+- This route is **unpaginated**: it accepts no `page` or `limit` parameters (per the swagger description) and returns the complete comment list in one response. Verified with 60 comments: all 60 returned in one body, `X-Total-Count: 60`, no `Link` header, and no truncation at the `MAX_RESPONSE_ITEMS` cap that governs paginated routes. A 61-comment issue behaves identically on 1.26.4, including under an explicit `limit=5`, which the route ignores (verified live, 2026-08-11).
 - Comments arrive oldest-first (ascending id, verified), so no client-side re-sort is needed, unlike Linear.
 - Bodies are Markdown and pass through unflattened, like GitHub and unlike Jira's ADF.
 - System events (close, reopen, label changes, dependency changes) do not appear on this route (verified: a closed issue with no human comments returns an empty array); they live on the separate timeline route.
-- `since` and `before` (RFC 3339) filter by update time (verified) and MAY serve future incremental fetches; the initial implementation fetches all.
+- `since` and `before` (RFC 3339) filter by update time (verified). The route declares no other parameters (swagger, re-read on 1.26.4), and `fetchComments` sends none: it takes the whole list in one request.
 - 404 maps to `tracker_not_found`. Returns an empty non-nil slice when the issue has no comments.
 
 ### 7. `TransitionIssue`
 
 No workflow transition API exists; the adapter composes the transition:
 
-1. `GET .../issues/{index}`: current labels and native state. A `pull_request` entry fails with `tracker_not_found`.
-2. Resolve the repository's labels (`GET .../labels`, paginated) into a case-insensitive name-to-id map. A target state name that resolves to no label triggers the create-on-missing policy (see State model); a target that is not a configured active, terminal, or handoff state fails with `tracker_payload_error` before any write, mirroring the GitHub adapter's guard.
-3. Remove the current state label by id: `DELETE .../issues/{index}/labels/{label_id}`, tolerating 404 as already-removed.
-4. Attach the target state label by id: `POST .../issues/{index}/labels` with `{"labels": [<label_id>]}`. Attaching by id, never by name, is what makes step 2's resolution failure loud instead of the silent no-op the name path produces.
-5. Reconcile native state: terminal target with native `open` sends `PATCH .../issues/{index}` `{"state": "closed"}`; active target with native `closed` sends `{"state": "open"}`. There is no `state_reason` equivalent; the field does not exist in `EditIssueOption`.
+1. A target that is not a configured active, terminal, or handoff state fails with `tracker_payload_error` before any request, mirroring the GitHub adapter's guard.
+2. `GET .../issues/{index}`: current labels and native state. A `pull_request` entry fails with `tracker_not_found`.
+3. When the current state label already equals the target, no label work happens at all. Otherwise `resolveLabelIndex` reads the repository's labels into a case-insensitive name-to-id map, and a target that resolves to no label is created (see State model).
+4. Remove the current state label by id: `DELETE .../issues/{index}/labels/{label_id}`, tolerating 404 as already-removed. That tolerance is what keeps a label an operator removed by hand from failing the transition; on 1.26.4 the route answers 204 or 422 rather than 404, so the arm does not fire there.
+5. Attach the target state label by id: `POST .../issues/{index}/labels` with `{"labels": [<label_id>]}`. Attaching by id, never by name, is what makes a resolution failure loud instead of the silent no-op the name path produces.
+6. Reconcile native state: terminal target with native `open` sends `PATCH .../issues/{index}` `{"state": "closed"}`; active target with native `closed` sends `{"state": "open"}`. There is no `state_reason` equivalent; the field does not exist in `EditIssueOption`, and a GitHub-shaped request carrying one is tolerated and ignored (verified).
 
-An invalid `state` value in the PATCH body returns HTTP 412 `unknown state: ...` (verified), a status GitHub does not use; see Error model. Partial failures converge on retry because each step is idempotent, the same argument the GitHub adapter makes.
+An invalid `state` value in the PATCH body returns HTTP 412 `unknown state: ...` (verified, re-confirmed live on 1.26.4), a status GitHub does not use; see Error model. Partial failures converge on retry because each step is idempotent, the same argument the GitHub adapter makes.
 
 ### 8. `CommentIssue`
 
@@ -243,17 +192,17 @@ POST /repos/{owner}/{repo}/issues/{index}/comments
 {"body": "<markdown text>"}
 ```
 
-Returns 201 with the created comment (verified). The text posts verbatim as Markdown, no format conversion.
+Returns 201 with the created comment (verified). The text posts verbatim as Markdown with no format conversion, and `CommentIssue` ignores the response body.
 
 ### 9. `AddLabel`
 
 Used for CI failure escalation, so a silent no-op violates the contract: the escalation label must actually appear. The flow:
 
-1. Resolve the label name against the repository labels, case-insensitively.
-2. When absent, create it: `POST /repos/{owner}/{repo}/labels` with `{"name": "<label>", "color": "#cccccc"}` (`color` is required; 422 without it, verified). Covered by `write:issue` (verified).
+1. Resolve the label name, lowercased, against the repository labels case-insensitively (`resolveLabelIndex`).
+2. When absent, create it: `POST /repos/{owner}/{repo}/labels` with `{"name": "<label>", "color": "cccccc"}` (`color` is required; 422 `[Color]: Required` without it, verified). Covered by `write:issue` (verified).
 3. Attach by id: `POST .../issues/{index}/labels` `{"labels": [<id>]}`.
 
-The attach endpoint is **additive**: it appends to the issue's label set and never drops existing labels (verified: attaching a second label preserved the first). The response body is the issue's full label list, so the adapter can confirm the attach landed. Label errors remain non-fatal to the orchestrator.
+The attach endpoint is **additive**: it appends to the issue's label set and never drops existing labels (verified: attaching a second label preserved the first), so no read-modify-write is needed. `PUT .../issues/{index}/labels` replaces the whole set instead (verified); no adapter method uses it. The attach response body is the issue's full label list. Label errors remain non-fatal to the orchestrator.
 
 ---
 
@@ -267,7 +216,7 @@ The attach endpoint is **additive**: it appends to the issue's label set and nev
 | --- | --- | --- |
 | `state` | `open`, `closed`, `all` | Defaults to open-only listing |
 | `type` | `issues`, `pulls` | Server-side PR exclusion works |
-| `labels` | comma-separated names | **AND across labels** (an issue must carry all; verified `labels=backlog,bug` returns nothing when no issue has both), despite the swagger description claiming "any of". Name matching is case-sensitive, and a name that resolves to no label **silently disables the entire filter** (verified: `labels=BACKLOG` returned every open issue). Treat as unusable for correctness-critical filtering |
+| `labels` | comma-separated names | **AND across labels** (an issue must carry all; verified `labels=bug,in-progress` matches only the issue holding both and `labels=backlog,bug` returns nothing when no issue has both), despite the swagger description claiming "any of". Name matching is case-sensitive, and a name that resolves to no label **silently disables the entire filter** (verified: `labels=BACKLOG` returned every open issue). Both behaviors are re-confirmed live on 1.26.4. Treat as unusable for correctness-critical filtering |
 | `q` | string | Free-text match on title and body (verified) |
 | `milestones` | comma-separated names or ids | Names with id fallback (swagger) |
 | `since`, `before` | RFC 3339 | Update-time window |
@@ -276,15 +225,15 @@ The attach endpoint is **additive**: it appends to the issue's label set and nev
 | `mentioned_by` | username | Mention filter (verified). Self-mentions do not register: an author mentioning themselves is not counted, so the automation identity must differ from the issue author |
 | `page`, `limit` | integers | See Pagination |
 
-The `assigned_by`, `mentioned_by`, and `created_by` filters take arbitrary usernames and cover the motivating scenario from issue #619 (scope candidate polling to issues assigned to or mentioning the automation identity) directly on the repo-scoped route.
+The `assigned_by`, `mentioned_by`, and `created_by` filters take arbitrary usernames, so scoping candidate polling to issues assigned to or mentioning the automation identity stays on the repo-scoped route.
 
 ### Cross-repo search route
 
-`GET /repos/issues/search` is Gitea's counterpart to GitHub's `/search/issues`, and it is not a drop-in: the path differs, `q` is plain text with **no qualifier syntax** (`label:x repo:o/r` does not parse), and the identity filters (`assigned`, `created`, `mentioned`, `review_requested`) are booleans relative to the authenticated user. Scoping is by `owner` or `team`, not by repository, so the adapter has no use for it: every candidate query stays on the repo issue list route.
+`GET /repos/issues/search` is Gitea's counterpart to GitHub's `/search/issues`, and it is not a drop-in: GitHub's path is absent (404, verified; re-confirmed live on 1.26.4 with a 200 on `/repos/issues/search` as the control), `q` is plain text with **no qualifier syntax** (`label:x repo:o/r` does not parse), and the identity filters (`assigned`, `created`, `mentioned`, `review_requested`) are booleans relative to the authenticated user. Scoping is by `owner` or `team`, not by repository, so the adapter has no use for it: every candidate query stays on the repo issue list route.
 
 ### `query_filter` mapping
 
-`tracker.query_filter` is adapter-defined (Jira: JQL fragment; Linear: `IssueFilter` JSON object). For Gitea the recommendation is a **URL query fragment** merged into the repo issue list request:
+`tracker.query_filter` is adapter-defined (Jira: JQL fragment; Linear: `IssueFilter` JSON object). For Gitea it is a **URL query fragment** merged into the repo issue list request:
 
 ```yaml
 tracker:
@@ -292,7 +241,7 @@ tracker:
   query_filter: "assigned_by=hermes-bot&labels=agent-ready"
 ```
 
-The adapter parses the fragment with `url.ParseQuery`, rejects keys it owns (`state`, `type`, `page`, `limit`) with a configuration error, and merges the rest into the candidate query and the open half of `FetchIssuesByStates`. Operators who put `labels=` in the fragment inherit the server's AND semantics, case sensitivity, and the dropped-filter behavior for unresolvable names; the adapter SHOULD warn when a `query_filter` label does not resolve against the repository's label list, turning the silent foot-gun into a visible diagnostic.
+`parseGiteaQueryFilter` parses the fragment with `url.ParseQuery` and rejects the keys the adapter owns (`state`, `type`, `page`, `limit`) with a configuration error; `mergeQueryParams` merges the rest into the candidate query and the open half of `FetchIssuesByStates`. The offline `sortie validate` hook runs the same parser (`validateQueryFilter`), so its verdict cannot drift from the construction verdict. Operators who put `labels=` in the fragment inherit the server's AND semantics, case sensitivity, and the dropped-filter behavior for unresolvable names, so construction resolves the fragment's label names against the repository label list and warns about each one that does not resolve (`reportUnresolvedLabels`), turning the silent foot-gun into a visible diagnostic. A key outside the recognized set (`knownGiteaFilterKeys`) is passed through with a warning.
 
 ---
 
@@ -304,9 +253,10 @@ The adapter parses the fragment with `url.ParseQuery`, rejects keys it owns (`st
 | --- | --- | --- |
 | `ID` | `number` | Index as string; the global `id` is never used (see Identifiers) |
 | `Identifier` | `number` | Same value as `ID` |
+| `DisplayID` | derived | `owner/repo#N`, applied by `setDisplayID` after normalization, so a bare index is never ambiguous across repositories |
 | `Title` | `title` | |
 | `Description` | `body` | Markdown, empty string when null |
-| `Priority` | none | Gitea has no priority field (verified absent from the 1.27.0 issue object); always nil. Priority-from-labels stays a future enhancement, as in the GitHub notes |
+| `Priority` | none | Gitea has no priority field (verified absent from the 1.27.0 issue object); always nil |
 | `State` | label-derived | See State model |
 | `BranchName` | `ref` | Gitea issues carry an optional branch reference; empty string maps to null. Stored opaque, never parsed |
 | `URL` | `html_url` | Directly available |
@@ -326,9 +276,9 @@ Comment mapping: `id`, `user.login`, `body` (Markdown), `created_at`, `updated_a
 ## Pagination
 
 - List routes take `page` (1-based) and `limit`. The page-size parameter is `limit`, not `per_page`.
-- Responses carry an RFC 8288 `Link` header (`rel="next"`, `rel="last"`) with absolute URLs, in the same format the GitHub adapter already consumes (verified), plus an `X-Total-Count` header that the `Link`-driven pagination flow does not need. `httpkit.NewLinkPaginator` and `httpkit.ParseLinkRel` handle the `Link` header unchanged; the paginator follows the full `Link` URL, which is correct here because Gitea's next-page URLs preserve the query parameters (verified).
-- The server clamps `limit` to the instance's `MAX_RESPONSE_ITEMS` (default 50): `limit=100` returned 50 items (verified), while the `Link` header keeps the requested value and pagination stays consistent. An omitted `limit` falls back to `DEFAULT_PAGING_NUM` (default 30, verified).
-- The adapter sends `limit=50`, which equals both the architecture's page-size default (per [architecture Section 11.2](architecture/11-issue-tracker-integration-contract.md#112-query-semantics)) and the stock cap. Operators can lower the cap in `app.ini` `[api]`, so the adapter MUST iterate by the `Link` header rather than assume 50 arrived; `GET /api/v1/settings/api` exposes the effective values (`max_response_items`, `default_paging_num`) for diagnostics.
+- Responses carry an RFC 8288 `Link` header (`rel="next"`, `rel="last"`) with absolute URLs, in the same format the GitHub adapter already consumes (verified, re-confirmed live on 1.26.4), plus an `X-Total-Count` header that the `Link`-driven pagination flow does not need. `httpkit.NewLinkPaginator` consumes the header unchanged and follows the full `rel="next"` URL, which is correct here because Gitea's next-page URLs preserve the query parameters (verified).
+- The server clamps `limit` to the instance's `MAX_RESPONSE_ITEMS` (default 50): a 56-issue repository returns 50 items at `limit=100` (verified, re-confirmed live on 1.26.4), while the `Link` header keeps the requested value and pagination stays consistent. An omitted `limit` falls back to `DEFAULT_PAGING_NUM` (default 30, verified, re-confirmed live on 1.26.4).
+- The adapter sends `limit=50`, which equals both the architecture's page-size default (per [architecture Section 11.2](architecture/11-issue-tracker-integration-contract.md#112-query-semantics)) and the stock cap. Operators can lower the cap in `app.ini` `[api]`, so `paginateIssues` iterates by the `Link` header rather than assume 50 arrived; `GET /api/v1/settings/api` exposes the effective values (`max_response_items: 50`, `default_paging_num: 30` on a stock instance, verified, re-confirmed live on 1.26.4) for diagnostics.
 - The per-issue comments route is the exception: unpaginated, complete in one response (see operation 6).
 - Cursor integrity (`tracker_missing_end_cursor`) does not apply: there are no cursors, and an absent `Link` header is the normal end-of-results signal.
 
@@ -336,13 +286,13 @@ Comment mapping: `id`, `user.login`, `body` (Markdown), `created_at`, `updated_a
 
 ## Rate limiting
 
-Gitea ships **no built-in API rate limiting**. There is no `/rate_limit` endpoint (404, verified), no `x-ratelimit-*` response headers (verified absent), and the upstream feature request (go-gitea/gitea#9559) remains open. The cost model is inverted from the SaaS trackers: the budget is the self-hosted instance's capacity, and the operator sizes it.
+Gitea ships **no built-in API rate limiting**. There is no `/rate_limit` endpoint (404, verified; re-confirmed live on 1.26.4 against a `GET /version` 200 control), no `x-ratelimit-*` response headers (verified absent), and the upstream feature request (go-gitea/gitea#9559) remains open. The cost model is inverted from the SaaS trackers: the budget is the self-hosted instance's capacity, and the operator sizes it.
 
 Consequences for the adapter:
 
 - No preemptive throttling and no rate-budget accounting. Poll cadence is the only pressure control, configured by the operator.
-- A reverse proxy in front of the instance MAY inject 429 responses. The adapter maps 429 to `tracker_api_error` and honors a `Retry-After` header when present, mirroring the GitHub adapter's handling, but expects never to see one from Gitea itself.
-- No conditional-request machinery: without `ETag` support there is no 304 path and nothing to cache against. The GitHub adapter's ETag cache is dead weight here and is not ported.
+- A reverse proxy in front of the instance MAY inject 429 responses. `classifyHTTPError` maps 429 to `tracker_api_error` and logs any `Retry-After` value at WARN, leaving retry backoff to the orchestrator; Gitea itself sends no 429.
+- No conditional-request machinery: without `ETag` support there is no 304 path and nothing to cache against, so the GitHub adapter's ETag cache has no counterpart here.
 
 ---
 
@@ -354,7 +304,7 @@ Every API error carries one uniform JSON body (verified):
 {"message": "<diagnostic>", "url": "https://<instance>/api/swagger"}
 ```
 
-Verified message texts worth matching on: `token is required` and `invalid username, password or token` (401), `token does not have at least one of required scope(s), required=[...], token scope=...` (403, names the missing scopes verbatim), `not found` (404, identical for a missing repository and a missing issue), `[Title]: Required` and `[Color]: Required` (422), `unknown state: <value>` (412), and `repo is archived` (423).
+Verified message texts worth matching on: `token is required` and `invalid username, password or token` (401), `token does not have at least one of required scope(s), required=[...], token scope=...` (403, names the missing scopes verbatim), `not found` (404, identical for a missing repository and a missing issue), `[Title]: Required` and `[Color]: Required` (422), `unknown state: <value>` (412), and `repo is archived` (423). The 401, 404, 412, and 422 texts are re-confirmed live on 1.26.4 (2026-08-11). `classifyHTTPError` extracts the envelope's `message` into a bounded snippet on every one of these statuses; the 403 body is what `enrichScopeError` parses for the required scope on the write path.
 
 HTTP status to error category, per [architecture Section 11.4](architecture/11-issue-tracker-integration-contract.md#114-error-handling-contract) and the `domain.TrackerErrorKind` values:
 
@@ -368,7 +318,7 @@ HTTP status to error category, per [architecture Section 11.4](architecture/11-i
 | 412 | Precondition failed (verified: unknown `state` value on issue edit; Gitea also uses 412 for other rejected preconditions) | `tracker_payload_error` |
 | 422 | Validation failed (missing required field) | `tracker_payload_error` |
 | 423 | Repository archived or issue dependencies locked (verified: comment write on an archived repository) | `tracker_api_error`; an operator-configuration condition, not retryable |
-| 429 | Rate limited (reverse proxy only; Gitea itself never sends it) | `tracker_api_error`, honor `Retry-After` |
+| 429 | Rate limited (reverse proxy only; Gitea itself never sends it) | `tracker_api_error`; any `Retry-After` value is logged at WARN |
 | 5xx | Server error | `tracker_transport_error` |
 | network | DNS, TCP, TLS failure | `tracker_transport_error` |
 | decode | JSON decode failure on a 2xx | `tracker_payload_error` |
@@ -382,37 +332,30 @@ Two Gitea-specific traps the classification must respect:
 
 ## Forgejo and Codeberg
 
-Forgejo is the 2024 hard fork of Gitea; Codeberg is the flagship hosted Forgejo instance. Findings from Codeberg's live swagger and version endpoint (2026-07-14):
+Forgejo is a hard fork of Gitea; Codeberg is the flagship hosted Forgejo instance. Facts below come from Codeberg's live swagger and version endpoint, read 2026-07-14:
 
 - Forgejo serves the same `/api/v1` base path and the same `Authorization: token <key>` header (its docs keep Gitea's "for historical reasons" phrasing), the same `page`/`limit` pagination with `Link` and `x-total-count`, and the same `/settings/api` endpoint.
-- `GET /api/v1/version` on Codeberg returns `15.0.0-209-2308e484+gitea-1.22.0`: Forgejo pins its Gitea compatibility marker at **1.22**, the fork point, while this research pins 1.27. The shared surface is drifting apart release by release.
+- `GET /api/v1/version` on Codeberg returns `15.0.0-209-2308e484+gitea-1.22.0`: Forgejo pins its Gitea compatibility marker at **1.22**, the fork point, while this document pins 1.27.0 and 1.26.4. The shared surface narrows with each release on either side.
 - Verified route divergence in the exact surface this adapter uses: the label-remove route is `.../labels/{identifier}` on Forgejo, accepting "name or id of the label" (swagger), versus id-only `.../labels/{id}` on Gitea. Forgejo's `IssueLabelsOption` also adds an `updated_at` field Gitea lacks. The adapter's id-based label flow sits inside the portable subset: numeric ids are valid identifiers on both.
 
-**Verdict: Forgejo compatibility is claimed by design, not tested.** The adapter targets the portable subset (issue and comment routes, id-based label operations, `Link` pagination), so a Forgejo or Codeberg instance is expected to work behind the same `kind: gitea` configuration, and no Forgejo-specific adapter is planned. Testing against a pinned Forgejo image (or Codeberg) is explicitly out of scope for this milestone; when demand materializes, the container harness below accepts a Forgejo image with no structural change. Operators pointing Sortie at codeberg.org must respect Codeberg's terms of service for automation; self-hosted instances are the primary target.
+Forgejo compatibility is claimed by design and not tested. The adapter targets the portable subset (issue and comment routes, id-based label operations, `Link` pagination), so a Forgejo or Codeberg instance works behind the same `kind: gitea` configuration; no probe has confirmed it (see Open questions). Operators pointing Sortie at codeberg.org must respect Codeberg's terms of service for automation; self-hosted instances are the primary target.
 
 ---
 
-## Integration test strategy
+## Integration test harness
 
-Two options were evaluated:
+The env-gated integration suite in `internal/scm/gitea` runs against a throwaway containerized instance the job boots and seeds itself, so no repository secret carries a Gitea credential and no state survives between runs.
 
-1. **Containerized Gitea service in CI.** The job starts a pinned image, provisions an admin user, token, repository, labels, and issues at job start, runs the gated tests, and discards the container.
-2. **Hosted long-lived instance with repository secrets**, the pattern the Jira and Linear nightly jobs use against SaaS APIs.
-
-**Recommendation: containerized Gitea in CI.** Gitea is the first tracker in the project that can run inside the job, which removes every drawback the SaaS pattern tolerates by necessity: no repository secrets (the token is generated inside the job), no shared mutable state between runs, no cross-fork secret exposure, exact version pinning to the researched release, and local reproducibility with one `docker run`. The hosted-instance option exercises real TLS and proxy behavior, but that coverage belongs to operators' environments, not to adapter correctness.
-
-Sketch, verified end-to-end by this research's provisioning sequence:
-
-- Image: `docker.gitea.com/gitea:1.27.0-rootless` (the registry and tag scheme documented in the official Docker installation guide; the tag pins the researched version).
-- Provisioning: `gitea admin user create --must-change-password=false ...` (the flag matters: a fresh user is otherwise forced into a password-change state that blocks token creation with a 401-class error), then `POST /api/v1/users/{user}/tokens` with basic auth for the token, then repository, labels, and issues through the API.
-- Gate: `SORTIE_GITEA_TEST=1`, with `SORTIE_GITEA_ENDPOINT`, `SORTIE_GITEA_TOKEN`, and `SORTIE_GITEA_PROJECT` supplied by the job, following the sibling adapters' single-gate convention and their variable naming: `SORTIE_JIRA_ENDPOINT` sets the endpoint-name precedent, and `SORTIE_GITHUB_TOKEN` plus `SORTIE_GITHUB_PROJECT` set the token and project precedents for a token-authenticated tracker. Without the gate the tests MUST skip cleanly, never fail.
-- The same harness slots into the nightly adapter matrix as a tracker entry whose "install" step is the container boot instead of a CLI install.
+- Image: `docker.gitea.com/gitea:1.27.0-rootless`, pinned in `scripts/gitea-integration-provision.sh` and in the nightly matrix entry. The release workflow's `test-integration-gitea` job and the nightly adapter matrix both run the script and then `go test -run 'Integration' ./internal/scm/gitea/...`.
+- Provisioning, all in `scripts/gitea-integration-provision.sh`: `gitea admin user create --must-change-password=false ...` (the flag matters, since a fresh user is otherwise forced into a password-change state that blocks token creation with a 401-class error), then `POST /api/v1/users/{user}/tokens` with basic auth for a token scoped `write:issue`, `write:repository`, and `read:user`, then the repository, the labels `backlog`, `in-progress`, `review`, `done`, and `bug`, seed issues covering each state plus a comment thread and a blocker link, a reviewer user and an allowlisted bot user (Gitea forbids a `REQUEST_CHANGES` self-review, so both differ from the PR author), a feature-branch pull request carrying human and bot reviews with new-side and old-side inline comments, a label add-and-remove pair on that PR's timeline, and a probe commit carrying more statuses than one page.
+- Gate: `SORTIE_GITEA_TEST=1` (`skipUnlessIntegration`), with `SORTIE_GITEA_ENDPOINT`, `SORTIE_GITEA_TOKEN`, and `SORTIE_GITEA_PROJECT` required by `integrationConfig`. The single gate follows the sibling adapters' convention, and the variable names follow `SORTIE_JIRA_ENDPOINT` for the endpoint and `SORTIE_GITHUB_TOKEN` plus `SORTIE_GITHUB_PROJECT` for the token and project. Without the gate every integration test skips cleanly.
+- The script also publishes `SORTIE_GITEA_PR_NUMBER`, `SORTIE_GITEA_BOT_USERNAME`, and `SORTIE_GITEA_MANY_STATUS_SHA`. Each of the three tests that needs one skips with a message naming the fixture when its variable is absent, so a partially seeded lab reports skips rather than failures.
 
 ---
 
 ## SCM read surface
 
-The tracker adapter package also implements the SCM read methods `GetReviewDecision`, `GetMergeability`, `GetCIStatus`, `FetchPendingReviews`, `FetchBotReviewComments`, and `ListLabelEvents` (`domain.SCMAdapter`, `internal/domain/scm.go`). Gitea exposes no GraphQL API and no aggregate review-decision or check-runs endpoint, so each read is composed from REST routes under `/api/v1`. Every route below was reached live against the localhost Gitea 1.27.0 lab instance and returned HTTP 200; where that lab PR carried no data to populate a response, the object shape was schema-inferred from the instance OpenAPI description pending a captured live fixture. Those fixtures have since been captured. On 2026-08-10 a lab instance running **Gitea 1.26.4** was provisioned with reviews, inline review comments, and a 51-status commit, and the review list, the review comments, and the combined commit status were each observed populated; the shapes recorded below are the observed ones. Claims from that second pass are marked "verified live" and scoped to 1.26.4, because the two lab instances do not run the same release.
+The tracker adapter package also implements the SCM read methods `GetReviewDecision`, `GetMergeability`, `GetCIStatus`, `FetchPendingReviews`, `FetchBotReviewComments`, and `ListLabelEvents` (`domain.SCMAdapter`, `internal/domain/scm.go`). Gitea exposes no GraphQL API and no aggregate review-decision or check-runs endpoint, so each read is composed from REST routes under `/api/v1`. Every route below returns HTTP 200 against the lab instance, and the review, review-comment, and combined-status shapes recorded here are the populated ones observed on 1.26.4 against a pull request carrying two reviews, inline review comments on both diff sides, and a 51-status commit.
 
 | Method | Gitea route(s) |
 | --- | --- |
@@ -432,6 +375,7 @@ GET /repos/{owner}/{repo}/pulls/{index}/reviews
 - Returns a JSON array of review objects. The `state` field is an enum: `APPROVED`, `PENDING`, `COMMENT`, `REQUEST_CHANGES`, `REQUEST_REVIEW`. Gitea spells the changes-requested state `REQUEST_CHANGES`, not GitHub's `CHANGES_REQUESTED`; a state filter copied verbatim from the GitHub adapter matches nothing.
 - Each review carries `dismissed` (an operator nullified the review), `official`, `stale`, `body`, `submitted_at`, `user.login`, and `id`. Dismissed reviews are skipped by every read.
 - `FetchPendingReviews` returns the comments of non-bot `REQUEST_CHANGES` reviews; `FetchBotReviewComments` returns the comments of reviews whose author matches a bot-username allowlist, with no review-state filter. Gitea users carry no `type: Bot` marker, so bot classification is the allowlist alone (see [Bot classification](#bot-classification)).
+- Both reads share `collectReviewComments`, which contributes a retained review's own trimmed `body` as a PR-level `domain.ReviewComment` with id `review-<id>` before its inline comments, admits each inline comment only when that comment's author passes the same predicate, and deduplicates by id across reviews.
 - Paginated by page number, not the `Link` header (see [SCM read pagination](#scm-read-pagination)).
 - Verified live against a provisioned PR carrying a `REQUEST_CHANGES` review and a `COMMENT` review: the populated object returned `id`, `state`, `body`, `user.login`, `dismissed`, `official`, `stale`, and `submitted_at`, which is every field these reads consume, plus `comments_count`, `commit_id`, `team`, `updated_at`, and the two HTML URLs.
 
@@ -442,6 +386,7 @@ GET /repos/{owner}/{repo}/pulls/{index}/reviews/{id}/comments
 ```
 
 - Each comment carries `path`, `body`, `position`, `original_position`, `created_at`, `id`, and `user.login`, alongside `commit_id`, `original_commit_id`, `diff_hunk`, `resolver`, `updated_at`, and the two HTML URLs (verified live). There is no `line`, `start_line`, or `end_line` field (verified live), so review comments are single-line and `EndLine` normalizes to 0.
+- `normalizeReviewComment` maps the anchor to one `StartLine`: `position` when it is positive, else `original_position` when that is positive, else 0. The new side wins when both are positive, which keeps the mapping total over every integer pair the route can return.
 - `position` and `original_position` are **file line numbers, not diff offsets**, and they select the side of the diff rather than the freshness of the anchor. `position` is the new-side line, `original_position` the old-side line; each is 0 when the comment is not anchored to that side. Verified live by anchoring two comments on the same modified line of a PR whose hunk header is `@@ -9,7 +9,7 @@`: the comment created with `new_position: 12` returned `position: 12, original_position: 0`, and the one created with `old_position: 12` returned `position: 0, original_position: 12`. A diff-offset reading would have returned 5 for both. The upstream model names the fields `LineNum` and `OldLineNum` (`modules/structs/pull_review.go`, identical at the `v1.26.4` and `v1.27.0` tags), and the write side documents `new_position` as "if comment to new file line or 0".
 - **A zero `position` therefore does not mean outdated.** It means the comment is anchored to the old side of the diff, which is true the moment the comment is created. Verified live: after pushing a commit that deleted the anchored line outright, both comments came back with their `position` and `original_position` unchanged and their `commit_id` still naming the same value as before the push. The route exposes no invalidation field at all: `PullReviewComment` carries no `invalidated` key in the instance OpenAPI or in the upstream model at either tag.
 - **`commit_id` is not a single staleness signal**, and comparing each comment's `commit_id` against the PR head is not the route's available signal that it looks like: the value means one thing on each side, and neither half moves on a later push. On the new side it is the blame commit of the anchored line, sourced from `lineBlame(ctx, pr.BaseRepo, gitRepo, head, treePath, line)` in `createCodeComment` (`services/pull/review.go`, identical at the `v1.26.4` and `v1.27.0` tags), and it can name a commit that was never the pull request head: a comment anchored to a line the head commit did not itself modify reports whichever earlier commit last touched that line, not the head. On the old side it falls through to `headCommitID`, the head ref commit at creation. Verified live: two new-side comments created at one head, anchored to lines that head commit did not modify, both reported the base-branch commit that created the file rather than that head; an old-side comment created at the same head reported the head itself. A further push that touched none of the three anchors changed none of their `commit_id` values.
@@ -454,10 +399,10 @@ GET /repos/{owner}/{repo}/pulls/{index}/reviews/{id}/comments
 
 ### Review decision
 
-Gitea has no aggregate review-decision field; the GitHub adapter reads one from GraphQL, which Gitea does not offer. `GetReviewDecision` folds the review list together with the PR object's `requested_reviewers` signal:
+Gitea has no aggregate review-decision field; the GitHub adapter reads one from GraphQL, which Gitea does not offer. `GetReviewDecision` folds the review list together with the PR object's `requested_reviewers` signal in `foldReviewDecision`:
 
 - Reviews are ordered by `submitted_at` then `id`, so the latest `APPROVED` or `REQUEST_CHANGES` per reviewer supersedes that reviewer's earlier reviews. `COMMENT`, `PENDING`, and `REQUEST_REVIEW` are not decisions, and dismissed reviews do not contribute.
-- The ordering depends on `submitted_at` parsing as RFC 3339, so a value that does not parse fails the decision read instead of sorting the review to the epoch, and only reviews that can change the verdict are parsed.
+- The ordering depends on `submitted_at` parsing as RFC 3339, so a value that does not parse fails the decision read with `domain.ErrSCMPayload` instead of sorting the review to the epoch, and only reviews that can change the verdict are parsed.
 - Any standing `REQUEST_CHANGES` yields changes-requested; otherwise any `APPROVED` yields approved; otherwise a non-empty `requested_reviewers` yields review-required; otherwise not-required.
 
 ### Mergeability
@@ -466,10 +411,10 @@ Gitea has no aggregate review-decision field; the GitHub adapter reads one from 
 GET /repos/{owner}/{repo}/pulls/{index}
 ```
 
-- The PR object carries `mergeable` (a plain bool, verified `true` on the lab PR), `merged`, `draft`, `head.sha`, `head.ref`, `base.ref`, and a `requested_reviewers` array. There is no `mergeable_state` string and no tri-state "computing" field (verified absent).
-- The boolean is the only mergeability signal, so the mapping to `MergeabilityState` is lossy: a draft maps to `blocked`, a mergeable non-draft to `clean`, and any other state to `unknown`. Gitea never yields `dirty` or `unstable`; a merge conflict and an in-progress recheck both collapse to `unknown`, which the auto-merge state machine re-enqueues rather than treating as a hard conflict.
+- The PR object carries `mergeable` (a plain bool, verified `true` on the lab PR, re-confirmed live on 1.26.4), `merged`, `draft`, `head.sha`, `head.ref`, `base.ref`, and a `requested_reviewers` array. There is no `mergeable_state` string and no tri-state "computing" field (verified absent, re-confirmed live on 1.26.4).
+- The boolean is the only mergeability signal, so `mapMergeability` is lossy: a draft maps to `blocked`, a mergeable non-draft to `clean`, and any other state to `unknown`. Gitea never yields `dirty` or `unstable`; a merge conflict and an in-progress recheck both collapse to `unknown`, which the auto-merge state machine re-enqueues rather than treating as a hard conflict.
 - The same read supplies `head.sha` (the CI ref for `GetCIStatus`), `head.ref` (the branch), and `base.ref` (the base branch the merge-conflict reaction needs).
-- The PR object also carries `merge_commit_sha`, serialized from the `MergedCommitID *string` field in `modules/structs/pull.go` at the Gitea `v1.27.0` tag this project pins. This is upstream-source provenance, not a live-verification claim: the lab PR carried no merged pull request to populate the field, so its presence and JSON key name are read from the upstream model rather than observed on the wire.
+- The PR object also carries `merge_commit_sha`, serialized from the `MergedCommitID *string` field in `modules/structs/pull.go` at the Gitea `v1.27.0` tag. This is upstream-source provenance, not a live-verification claim: no merged pull request was read live, so the field's presence and JSON key name come from the upstream model rather than the wire, and the `pr_merged.json` fixture carries the same marker. `GetMergeability` gates the value on `merged`, so a null or stale commit id on an open pull request is never reported as a merge.
 
 ### Combined commit status
 
@@ -480,9 +425,10 @@ GET /repos/{owner}/{repo}/commits/{sha}/status
 - Returns `{state, sha, statuses, total_count}`. The top-level `state` is the aggregate; each entry in the `statuses` array carries its own `status`. The two field names differ and MUST NOT be conflated.
 - A commit with no CI returns `total_count: 0`, `statuses: null`, and a spurious top-level `state: "pending"` (verified, re-verified live on 1.26.4). Trusting the top-level `state` would report `pending` for a no-CI commit and wrongly hold auto-merge, so the aggregate is read from the per-status entries instead.
 - **`total_count` is the current page's length, not the grand total** (verified live: a 51-status commit returned `total_count: 30` on the default page, `50` at `limit=50`, `1` on page two, and `20` at `limit=20`). It can therefore detect neither emptiness nor truncation, so both readers key the empty case on the accumulated status count across every page. The grand total is available, but only in the `X-Total-Count` header, which reported 51 on every one of those requests.
-- Per-status `status` values are `success`, `failure`, `error`, `warning`, and `pending`. `failure` and `error` are failing; `warning` and `success` are non-failing; `pending` is pending. Each entry also carries `context` (the check name), `target_url`, and `description`.
+- `GetCIStatus` reads the PR for `head.sha`, walks that commit's statuses, and answers through `scmcore.MergeGate` over the same normalized check-run set the CI provider computes, so one forge cannot answer "is CI green" two ways. A PR response without a head SHA fails with `domain.ErrSCMPayload`, and a commit with no statuses yields the empty string, the "no required checks" signal.
+- Per-status `status` values declared by the schema are `success`, `failure`, `error`, `warning`, and `pending`. Only `success` and `failure` are observed live; the other three are declared but unobserved, because the lab runs no CI that produces them. `failure` and `error` are failing; `warning` and `success` are non-failing; `pending` is pending. `mapRunStatus` and `mapConclusion` lowercase the value first and fold anything unrecognized, including the empty string, into pending rather than into a passing verdict. Each entry also carries `context` (the check name), `target_url`, and `description`.
 - The per-status `target_url` field name is verified live: every seeded status returned the URL it was created with under that key, and the env-gated integration suite asserts the round-trip from a seeded failing status into the failing check run's `DetailsURL`.
-- **The route paginates**, contrary to the single-GET read the adapter shipped with. Verified live: the default page size is 30, `limit` is honored, and the response carries an RFC 8288 `Link` header with `rel="next"` and `rel="last"` (unlike the reviews, review-comments, and timeline routes, which emit none). A commit with more statuses than one page silently returned only the first page, so a failing status ordered onto a later page could be read as passing by both the CI-failure reaction and the auto-merge CI gate. Both readers now walk every page to a shared page ceiling.
+- **The route paginates.** Verified live: the default page size is 30, `limit` is honored up to the instance clamp (`limit=100` returns 50), and the response carries an RFC 8288 `Link` header with `rel="next"` and `rel="last"` (unlike the reviews, review-comments, and timeline routes, which emit none). The instance OpenAPI declares `page` and `limit` on the route, corroborating the observation. A single-request read would take only the first page, so a failing status ordered onto a later page would read as passing to both the CI-failure reaction and the auto-merge CI gate; both readers instead walk every page through `httpkit.NewPagePaginator` up to the package's shared `scmMaxPages` ceiling of 50 pages, logging a WARN when they reach it.
 
 ### Label event timeline
 
@@ -492,7 +438,8 @@ GET /repos/{owner}/{repo}/issues/{index}/timeline
 
 - Pull requests share the issue timeline route (a PR at index 6 is served at `/issues/6/timeline`). The route returns a JSON array of typed entries; verified types include `label`, `comment`, `add_dependency`, and `pull_push`.
 - A `label` entry carries `type`, a numeric `id`, `body`, `label.name`, `user.login`, and `created_at`. `body` is `"1"` for a label add and `""` for a label remove (verified live on lab issue #4, which round-trips both). The label name keeps Gitea's original casing (for example `Bug`, `REVIEW`) and is lowercased on normalization.
-- Entries arrive oldest-first (verified), so the accumulated slice needs no re-sort. The numeric timeline id is zero-padded to a fixed width so `(timestamp, id)` string ordering matches journal order for entries sharing a timestamp.
+- Entries arrive oldest-first (verified), so the accumulated slice needs no re-sort. `scmcore.SortableEventID` zero-pads the numeric timeline id to 19 digits so `(timestamp, id)` string ordering matches journal order for entries sharing a timestamp.
+- `ListLabelEvents` keeps only `label` entries carrying a label name; a `created_at` that does not parse as RFC 3339 fails the read with `domain.ErrSCMPayload`, and an entry skipped for its kind is never parsed.
 
 ### Bot classification
 
@@ -500,7 +447,7 @@ Gitea users carry no `type: Bot` marker (verified: the review `user` object has 
 
 ### SCM read pagination
 
-The reviews, review-comments, and timeline routes paginate by page number, not by the `Link` header the tracker issue routes use. The timeline route was verified live to emit no `Link` header and an unreliable `X-Total-Count` (it returns the page size, not the grand total), so `httpkit.NewLinkPaginator` MUST NOT drive these reads: it stops at the first response with no `Link` header, which would truncate a multi-page timeline to page one. The shared page-number paginator (`httpkit.NewPagePaginator`) drives all three reads, reached through the package's own `paginateSCM` wrapper, which pins the `page` and `limit` parameter names and the page ceiling every SCM-boundary reader shares and converts a walk failure to the SCM boundary. The package owns no paginator of its own. Because the timeline is oldest-first and read forward to the cap, an unusually long timeline truncates its newest entries, where a label command lives; the adapter logs a WARN on reaching the cap.
+The reviews, review-comments, and timeline routes paginate by page number, not by the `Link` header the tracker issue routes use. The timeline route emits no `Link` header and an unreliable `X-Total-Count`: it reported 2, 5, and 30 against `limit=2`, `limit=5`, and the default page size on an issue whose timeline exceeds one page, so the header carries the page length rather than the grand total (verified live, 2026-08-11). `httpkit.NewLinkPaginator` therefore cannot drive these reads: it stops at the first response with no `Link` header, which would truncate a multi-page timeline to page one. The shared page-number paginator (`httpkit.NewPagePaginator`) drives all three reads, reached through the package's own `paginateSCM` wrapper, which pins the `page` and `limit` parameter names and the page ceiling every SCM-boundary reader shares and converts a walk failure to the SCM boundary. The package owns no paginator of its own. Because the timeline is oldest-first and read forward to the cap, an unusually long timeline truncates its newest entries, where a label command lives; the adapter logs a WARN on reaching the cap.
 
 ---
 
@@ -522,7 +469,7 @@ GET /repos/{owner}/{repo}/commits/{ref}/status
 
 ## SCM write surface
 
-The tracker adapter package also implements the SCM write methods `MergePR`, `DeleteBranch`, and `RemoveLabel` (`domain.SCMAdapter`, `internal/domain/scm.go`), plus the auto-merge scope preflight `VerifyAutoMergeScopes`. The route facts below were verified live against a local Gitea instance.
+The tracker adapter package also implements the SCM write methods `MergePR`, `DeleteBranch`, and `RemoveLabel` (`domain.SCMAdapter`, `internal/domain/scm.go`), plus the auto-merge scope preflight `VerifyAutoMergeScopes`. The route facts below were verified live against the lab instance, and each claim that differs between the two pinned releases says so.
 
 ### MergePR
 
@@ -531,12 +478,11 @@ POST /repos/{owner}/{repo}/pulls/{index}/merge
 {"Do": "merge", "head_commit_id": "<expected head sha>"}
 ```
 
-- Field binding is case-insensitive: Gitea accepts `"Do"` or `"do"`.
-- A successful merge returns HTTP 200 with an **empty body** (`Content-Length: 0`, verified live): no merge-commit SHA comes back on this route.
-- An already-merged PR returns HTTP 405 `{"message":"The PR is already merged"}`. The adapter does not match this wording: `MergePR` re-reads the pull request after the rejection and, on a confirmed merge, reports `scmcore.AlreadyMergedConflict`, which carries the marker text the caller's success dispatch looks for.
+- `giteaMergeOption` sends the merge style in the `Do` field, the stale-precondition SHA in `head_commit_id`, and the caller's commit title and message in `MergeTitleField` and `MergeMessageField`, omitting the latter two when empty so Gitea applies its strategy-specific defaults. `mapMergeStrategy` maps the domain strategies to `merge`, `squash`, and `rebase`, and rejects anything else with `domain.ErrSCMPayload` before a request goes out. Gitea's own `delete_branch_after_merge` and `merge_when_checks_succeed` options stay unused: Sortie keeps the two-step merge-then-delete flow and gates CI itself before calling this route.
+- A successful merge returns HTTP 200 with an **empty body** (`Content-Length: 0`, verified live): no merge-commit SHA comes back on this route, so a successful `domain.MergeResult` carries `Merged: true` and an empty SHA.
+- An already-merged PR returns HTTP 405 `{"message":"The PR is already merged"}` (verified live, 2026-08-11, with the PR unchanged afterward). The adapter does not match that wording: `resolveMergeConflict` re-reads the pull request after the rejection and, on an observed `merged`, returns `scmcore.AlreadyMergedConflict`, which carries the marker text the caller's success dispatch looks for. Gating on the observed state rather than the phrasing survives a reworded rejection and never fires on a stale-head 409.
 - A stale precondition (a `head_commit_id` behind the branch's current head) returns HTTP 409 `{"message":"head out of date"}`.
-- Both 405 and 409 map to `ErrSCMConflict` on this merge call; only the already-merged case carries the marker text.
-- The commit-title and commit-message fields and Gitea's own `delete_branch_after_merge` and `merge_when_checks_succeed` options are not exercised: Sortie keeps the two-step merge-then-delete flow and gates CI itself before calling this route.
+- `classifyHTTPError` records the HTTP status on `domain.TrackerError.Status`, and `scmcore.AsMergeConflict` promotes exactly status 405 and 409 to `domain.ErrSCMConflict`. That promotion is applied on the merge write path only, so a 405 or 409 on any other route keeps its own class. A 403 naming a required scope goes through `enrichScopeError` instead.
 
 ### DeleteBranch
 
@@ -544,9 +490,9 @@ POST /repos/{owner}/{repo}/pulls/{index}/merge
 DELETE /repos/{owner}/{repo}/branches/{branch}
 ```
 
-- Success is HTTP 204.
-- An already-deleted branch returns HTTP 404 `{"message":"not found","errors":["branch does not exist [...]"]}`.
-- A slash-bearing branch name (for example `feature/x`) percent-encoded as `%2F` returns 204, verified live: the route accepts the encoded slash.
+- Success is HTTP 204, which `DeleteBranch` returns as nil.
+- An already-deleted branch returns HTTP 404 `{"message":"not found","errors":["branch does not exist [...]"]}`. `DeleteBranch` returns that as a `domain.ErrSCMNotFound` rather than mapping it to nil; the caller treats it as a successful no-op.
+- A slash-bearing branch name (for example `feature/x`) percent-encoded as `%2F` returns 204, verified live: the route accepts the encoded slash, and the adapter percent-encodes every branch name.
 
 ### RemoveLabel
 
@@ -557,9 +503,9 @@ GET /repos/{owner}/{repo}/issues/{index}/labels          (resolve name to id)
 DELETE /repos/{owner}/{repo}/issues/{index}/labels/{id}
 ```
 
-- A name placed directly in the id position is rejected: HTTP 404 `{"message":"label does not exist [label_id: 0]"}` on Gitea 1.27.0, or 422 with the same message on Gitea 1.26.x and earlier. The 422 half is verified live on 1.26.4 (2026-08-11), which returned exactly that body for a non-numeric name in the id slot. The adapter resolves the name against the PR's own labels first and never places a name in the id slot, so neither status is reachable in practice.
-- An unresolved label name is a no-op: no `DELETE` is issued and the call returns success.
-- Removing a label the issue does not carry is **not** an error. On 1.26.4 a `DELETE` naming an existing repository label that the issue does not have returns 204, repeatably (verified live, 2026-08-11). A numeric id matching no repository label returns 422 with the same `[label_id: 0]` body as the name case, not 404. On that release the route therefore has no 404 path, and the adapter's tolerance of 404 as already-removed never fires. Whether 1.27.0 answers 404 here, as it does for the name case, was not re-tested.
+- A name placed directly in the id position is rejected: HTTP 404 `{"message":"label does not exist [label_id: 0]"}` on 1.27.0, and 422 with the same message on 1.26.4 (verified live, 2026-08-11). `RemoveLabel` resolves the name against the PR's own labels first (`fetchIssueLabels`, `resolveLabelID`) and never places a name in the id slot, so neither status is reachable in practice.
+- An unresolved label name is a no-op: no `DELETE` is issued and the call returns nil, the already-absent behavior the `domain.SCMAdapter` contract requires.
+- Removing a label the issue does not carry is **not** an error. On 1.26.4 a `DELETE` naming an existing repository label that the issue does not have returns 204, repeatably (verified live, 2026-08-11). A numeric id matching no repository label returns 422 with the same `[label_id: 0]` body as the name case, not 404. On that release the route therefore has no 404 path, and `RemoveLabel`'s mapping of 404 to nil, which covers a delete racing an external removal, does not fire there.
 
 ### Auto-merge scope preflight
 
@@ -567,35 +513,51 @@ Gitea exposes no scope-introspection surface: there is no `/rate_limit` endpoint
 
 `VerifyAutoMergeScopes` substitutes a layered check instead of scope verification:
 
-1. **Fail-open scope sentinel.** With no scope surface to probe, the preflight reports "unable to verify" and auto-merge proceeds, the same path the GitHub adapter takes for a fine-grained PAT.
-2. **User-role push gate.** When the tracker project is configured, the preflight reads `permissions.push` from the repository and fails startup when it is false: the token's user lacks repository write access. This is a role check, not a scope check: it catches a wrong-owner or read-only-collaborator token, but not a read-scoped token whose user otherwise has write access.
-3. **Runtime scope enrichment.** A 403 on `MergePR` or `DeleteBranch` naming a required scope is rewritten to name `write:repository` explicitly, so the operator learns which scope to grant even though the startup check could not confirm it.
+1. **Fail-open scope sentinel.** With no scope surface to probe, the method returns the `(nil, nil, nil)` "unable to verify" sentinel and auto-merge proceeds, the same path the GitHub adapter takes for a fine-grained PAT. An absent or malformed `project` config value leaves the preflight hints empty and takes this arm too. The `requireContents` argument is accepted and inert, because Gitea's one coarse scope covers both writes.
+2. **User-role push gate.** When the tracker project is configured, the method reads `permissions.push` from the repository and, when it is false, returns `write:repository` in `missing`, which `orchestrator.RunAutoMergePreflight` reports as a failed preflight. This is a role check, not a scope check: it catches a wrong-owner or read-only-collaborator token, but not a read-scoped token whose user otherwise has write access.
+3. **Runtime scope enrichment.** A 403 on `MergePR` or `DeleteBranch` naming a required scope is rewritten by `enrichScopeError` to name the scope from the `required=[...]` list, falling back to `write:repository` when a bounded body snippet truncated the list, so the operator learns which scope to grant even though the startup check could not confirm it.
 
 ---
 
-## Out of scope: webhooks
+## Webhooks
 
-Webhooks are the only PR-reaction surface with no adapter implementation. Gitea serves standard webhooks at `POST /repos/{owner}/{repo}/hooks`; wiring them aligns with the webhook-ingress future extension rather than the poll-based reads above. These route facts come from the 1.27.0 swagger and were not exercised.
+Webhooks are the one PR-reaction surface with no adapter implementation: nothing in `internal/scm/gitea` reads or registers them, and every read above is poll-based. Gitea serves standard webhooks at `POST /repos/{owner}/{repo}/hooks` (swagger, not exercised).
 
 ---
 
-## Config notes
+## Config mapping
 
-- **`tracker.endpoint`:** required, no default host. Instance base URL; the adapter appends `/api/v1`. TLS strongly recommended; the token travels in a header.
-- **`tracker.api_key`:** access token string, sent as `Authorization: token <key>`. No prefix to validate; the GitHub adapter's key-shape hints do not transfer.
-- **`tracker.project`:** `owner/repo`; validated at startup (exactly one `/`, non-empty halves).
-- **`tracker.active_states` / `tracker.terminal_states` / `tracker.handoff_state`:** repository label names, lowercase, same contract as the GitHub adapter. Missing labels are created on demand (see State model).
+- **`tracker.endpoint`:** required, no default host. Instance base URL, for example `https://gitea.example.com`; every constructor right-trims trailing slashes and appends `/api/v1` unless the value already ends in it. TLS strongly recommended; the token travels in a header.
+- **`tracker.api_key`:** access token string (single value, no `email:token` composition), sent as `Authorization: token <key>`. No prefix to validate, so the GitHub adapter's key-shape hints do not transfer. `validateAPIKeyHint` points an operator with an empty value at `SORTIE_GITEA_TOKEN`.
+- **`tracker.project`:** `owner/repo`; parsed at construction into owner and repo and rejected unless it holds exactly one `/` with non-empty halves.
+- **`tracker.active_states` / `tracker.terminal_states` / `tracker.handoff_state`:** repository label names, lowercased at construction, same contract as the GitHub adapter. Omitted lists fall back to `issuekit.DefaultActiveLabelStates` and `issuekit.DefaultTerminalLabelStates`. Missing labels are created on demand (see State model).
 - **`tracker.query_filter`:** URL query fragment merged into the repo issue list request; see Server-side filtering.
 - **Page size:** `limit=50` per [architecture Section 11.2](architecture/11-issue-tracker-integration-contract.md#112-query-semantics); the instance cap defaults to the same 50.
-- **Network timeout:** 30,000 ms per the same section.
-- **Headers:** `User-Agent: Sortie/<version>`; `Content-Type: application/json` on writes. No API version header exists.
+- **Network timeout:** 30 s, set on the shared client by `newGiteaClient`, matching the same section.
+- **Headers:** `Authorization`, `Accept: application/json`, and `User-Agent`, which `cmd/sortie` sets to `sortie/<version>` and the constructors default to `sortie/dev`. `Content-Type: application/json` is set on requests carrying a body. No API version header exists.
 - **Construction preflight:** `GET /user` (credential and identity check), `GET /repos/{owner}/{repo}` (project check). Both failures are configuration errors surfaced at startup, not at the first poll.
+
+---
+
+## Package layout and shared helpers
+
+One package, `internal/scm/gitea`, registers all three surfaces under kind `gitea`: the tracker through `registry.Trackers.RegisterWithMeta` (which also carries the required-project and required-api-key flags, the default state lists, and the offline `validateConfig` hook), the SCM adapter through `registry.SCMAdapters`, and the CI provider through `registry.CIProviders`. The orchestrator and `cmd/sortie` reach all three through `internal/registry`, never by importing this package. This is the combined tracker-plus-SCM layout `internal/scm/github` uses; the `internal/scm/` boundary rules apply unchanged, with no cross-adapter imports, no orchestrator imports, and external responses normalized to domain types at the boundary.
+
+The adapter builds on the shared utility packages rather than a Gitea client library, which keeps the zero-runtime-dependency model intact:
+
+- `internal/httpkit` for the HTTP client, the `Link`-header paginator (`NewLinkPaginator`), the page-number paginator (`NewPagePaginator`), and the preflight retry backoff.
+- `internal/issuekit` for label-state derivation, label and comment normalization, and the default active and terminal state lists.
+- `internal/trackermetrics` for per-operation instrumentation, wired through `SetMetrics`.
+- `internal/typeutil` for config decoding.
+- `internal/scm/scmcore` for the forge decisions every SCM adapter shares: tracker-to-SCM error conversion, merge-conflict promotion and the already-merged marker, bot-author classification, sortable event ids, timestamp parsing, and the CI aggregate and merge gate.
+
+It shares no base structs with the GitHub adapter: the overlap between the two is transport-shaped rather than domain-shaped, and it already lives in `httpkit`.
 
 ---
 
 ## Key differences from the GitHub adapter
 
-| Aspect | GitHub | Gitea 1.27 |
+| Aspect | GitHub | Gitea |
 | --- | --- | --- |
 | Default host | `https://api.github.com` | None; endpoint is required configuration |
 | Auth header | `Authorization: Bearer <token>` | `Authorization: token <key>` canonical (Bearer also accepted) |
@@ -621,85 +583,52 @@ Webhooks are the only PR-reaction surface with no adapter implementation. Gitea 
 
 ---
 
-## Live verification results
+## Open questions
 
-The fourteen results below were established against a local Gitea 1.27.0 instance on 2026-07-14. They are the first pass only: the SCM read surface was verified separately on 1.26.4 (see [SCM read surface](#scm-read-surface)), and the 2026-08-11 regression pass is recorded after this list.
+Each entry names the probe that would settle it.
 
-1. **Auth scheme matrix.** `token`, `Bearer`, basic with token as password, basic with token as username, and the `access_token` query parameter all authenticate; missing token yields 401 `token is required`, a bad token 401 `invalid username, password or token`.
-2. **Scope collapse and sufficiency.** Requested `read:issue` + `write:issue` + `read:repository` + `write:repository` collapsed to the write pair; a `write:issue`-only token performed every one of the nine operations, including label creation, but got 403 on `GET /user` and `GET /repos/{owner}/{repo}`.
-3. **Label filter semantics.** `labels=in-progress,bug` matched only the issue carrying both; `labels=backlog,bug` matched nothing; `labels=BACKLOG` (wrong case, unresolvable) returned every open issue, proving the dropped filter.
-4. **Label attach and removal.** Attach by name works and is additive; an unknown name returns 200 and attaches nothing; `DELETE .../labels/review` (a name) returns 404 `label does not exist [label_id: 0, repo_id: 1]`; delete by id returns 204; `PUT .../labels` replaces the whole set; label creation without `color` returns 422 `[Color]: Required`.
-5. **Identity split.** A second repository's first issue: `number` 1, global `id` 6. The PR at index 6 reports pull-table `id` 1 as a PR and issue-table `id` 7 when fetched through the issues route, with `pull_request` set in both list and single-fetch shapes.
-6. **List behavior.** Default listing is open-only, newest-first, PRs mixed in; `type=issues` excludes them; `state=all` includes closed; `sort=created&direction=asc&per_page=3` changed nothing (5 items, descending order).
-7. **Pagination.** `limit=2` produced `Link` with `rel="next"` and `rel="last"` plus `X-Total-Count: 5`; `limit=100` over 56 issues returned 50 (clamp); no `limit` returned 30; `/settings/api` reported `max_response_items: 50`, `default_paging_num: 30`.
-8. **Comments.** Ascending order with `updated_at` present; system events excluded (a PATCH-closed issue shows zero comments); `since` filters correctly; an issue with 60 comments returned all 60 in one unpaginated response with `X-Total-Count: 60` and no `Link`.
-9. **Transitions.** `PATCH {"state": "closed"}` and `{"state": "open"}` work; the GitHub-shaped extra `state_reason` field is tolerated and ignored; `{"state": "bogus"}` returns 412 `unknown state: bogus`.
-10. **Dependencies.** `POST .../issues/2/dependencies` requires the full `IssueMeta` body (`index`, `owner`, `repo`); with only `index` it returns 404. After creating "1 blocks 2", `.../issues/2/dependencies` lists #1 and `.../issues/1/blocks` lists #2 (documented responses include 423 for locked dependencies).
-11. **Identity filters.** `assigned_by=sortie` matched the assigned issue; `mentioned_by=sortie` missed the issue whose author self-mentioned; `mentioned_by=hermes` matched after a second user was mentioned by a different author; `q=handle` matched on body text.
-12. **Errors.** 404 body is `not found` for both a missing issue and a missing repository; 422 `[Title]: Required` on an empty create; 403 scope message names the required and held scopes; comment write on an archived repository returns 423 `repo is archived`.
-13. **No rate limiting.** `/api/v1/rate_limit` returns 404; no `x-ratelimit-*` headers on any response; no `ETag` header on API responses.
-14. **Forgejo probe.** Codeberg's swagger title is "Forgejo API" at `/api/v1`; its version string is `15.0.0-209-2308e484+gitea-1.22.0`; the label-remove route is `.../labels/{identifier}` ("name or id"), and `IssueLabelsOption` gains `updated_at`.
-
-### Regression pass, 2026-08-11 (Gitea 1.26.4)
-
-A read-only re-exercise of the cheap claims above against a 1.26.4 lab, with every absence claim paired with a positive control. Re-confirmed unchanged on 1.26.4:
-
-- **No rate limiting.** `/rate_limit` 404 (control: `/version` 200); no `x-ratelimit-*` and no `ETag` on any response.
-- **Pagination.** `/settings/api` reports `max_response_items: 50`, `default_paging_num: 30`; a 56-issue repository returned 50 at `limit=100` and 30 with no `limit`; `Link` carries `rel="next"` and `rel="last"` alongside `X-Total-Count`.
-- **List parameters.** `sort=created&direction=asc` changed nothing, `per_page` was ignored while `limit` was honored, and `type=issues` excluded all ten PRs from a 16-entry listing. Ordering is `created_at` descending; the five same-second fixture issues tie and arrive in index order.
-- **Label filter.** `labels=bug,in-progress` matched only the issue holding both, `labels=backlog,bug` matched nothing, and `labels=BACKLOG` returned every open issue, reproducing the dropped-filter foot-gun.
-- **Absent routes.** `/search/issues`, `.../issues/{index}/dependencies/blocked_by`, and `.../issues/{index}/parent` all 404, with `.../issues/{index}/dependencies` 200 as the control; `/repos/issues/search` is present.
-- **Dependencies direction.** Re-established by creating and then deleting one dependency: `POST` with only `{"index":1}` returns 404 `IsErrRepoNotExist`, the full `IssueMeta` body returns 201, `.../issues/2/dependencies` then lists #1 and `.../issues/1/blocks` lists #2. The blocker entry carries `number`, `state`, and `labels`, which is everything `domain.BlockerRef` needs.
-- **Auth matrix and error model.** All five auth schemes returned 200; 401 `token is required` with no credential and 401 `invalid username, password or token` with a bad one; 404 `not found` identically for a missing issue and a missing repository; 412 `unknown state: bogus`; 422 `[Color]: Required`.
-- **Comments route unpaginated.** A 61-comment issue returned all 61 in one body with `X-Total-Count: 61`, no `Link`, and no truncation even at `limit=5`, which the route ignores. The instance OpenAPI confirms it: the route declares only `since` and `before`, no `page` or `limit`.
-- **Combined commit status.** A 51-status commit returned `total_count` 30 at the default page, 50 at `limit=50`, 1 on page two, and 20 at `limit=20`, with `X-Total-Count: 51` on every request, so `total_count` is the page length. `limit=100` clamped to 50. A commit with no CI returned `total_count: 0`, `statuses: null`, and the spurious top-level `state: "pending"`. The OpenAPI declares `page` and `limit` on the route, corroborating that it paginates.
-- **Review comment side selectors.** The two-comment fixture still returns `position: 12, original_position: 0` for the new-side anchor and `position: 0, original_position: 12` for the old-side one, with no `line`, `start_line`, `end_line`, `invalidated`, or `outdated` key present, and each `commit_id` still naming the superseded head rather than the current PR head.
-- **Reviews and timeline.** `REQUEST_CHANGES` remains the changes-requested spelling. The timeline emits no `Link` header, and its `X-Total-Count` returned 2, 5, and 30 against `limit=2`, `limit=5`, and the default on an issue whose timeline exceeds a page, confirming it reports page length rather than the grand total.
-- **PR object.** `mergeable` is a plain bool and `mergeable_state` is absent.
-- **MergePR rejection.** `POST .../pulls/{index}/merge` against an already-merged PR returns 405 `{"message":"The PR is already merged"}`, and the PR was unchanged afterward.
-
-Reachable per-status values were `success` and `failure` only; `error`, `warning`, and `pending` are declared by the schema but were not produced by this lab.
-
-Not settled by this pass, and still resting on the dates recorded elsewhere in this document:
-
-- **Scope sufficiency.** Every scope claim (`write:issue` covering the nine tracker operations, the 403s without `read:user` and `read:repository`, and the read-plus-write collapse) requires minting scoped tokens, which this pass did not do. The 403 scope-rejection body that `enrichScopeError` parses was therefore not re-observed.
-- **423 `repo is archived`.** The lab's second repository still holds the 56 bulk issues used for the clamp check but is no longer archived, so the archived-repository status could not be re-provoked.
-- **`assigned_by` and `mentioned_by`.** Both returned zero for every instance user. No issue carries an assignee any more, so `assigned_by` had no positive control. Two issue bodies do mention another user, and `mentioned_by` still matched nothing for either, but the fixture was partly built by import and Gitea indexes mentions at write time, so a stale mention index and a behavior change are indistinguishable here. The claim is left as recorded; settling it needs a freshly created issue.
-- **MergePR success and conflict shapes.** The empty 200 body and the 409 `head out of date` were not re-exercised, because both require merging or racing a live pull request. The case-insensitive `Do` / `do` binding is also unconfirmed: both spellings returned the already-merged 405, which is reached without discriminating the binding.
-
-### Integration test setup
-
-The verification lab doubles as the fixture blueprint: a primary test repository with labels `backlog`, `in-progress`, `review`, `done`, `bug`; issues #1 (backlog, two comments, blocks #2), #2 (in-progress and bug, assigned), #3 (closed), #4 (label round-trip target), #5 (60-comment bulk thread), #7 (mentions a second user); PR #6 from branch `feature-x`; plus a second, archived repository (56 bulk issues) for clamp and 423 checks. The provisioning sequence (admin user with `--must-change-password=false`, token via `POST /users/{user}/tokens`, everything else through the API) is fully scriptable for the CI container job.
+- **Token scopes on 1.26.4.** Every scope claim in [Authentication](#authentication) rests on the 1.27.0 observation: `write:issue` covering the nine tracker operations, the 403s without `read:user` and `read:repository`, and the read-plus-write collapse. Settling them on 1.26.4 means minting scoped tokens on that lab and repeating the operation matrix. The 403 scope-rejection body that `enrichScopeError` parses is part of the same probe.
+- **423 `repo is archived` on 1.26.4.** The lab holds no archived repository, so the status has no reproduction there. Probe: archive a throwaway repository and issue a comment write against it.
+- **`assigned_by` and `mentioned_by` on 1.26.4.** Both returned zero for every instance user on that lab: no issue carries an assignee, so `assigned_by` had no positive control, and the two issue bodies that mention another user matched nothing. Because the fixture was partly built by import and Gitea indexes mentions at write time, a stale mention index and a behavior change are indistinguishable there. Probe: create an issue through the API with an assignee and a mention of a second user, then re-query both filters.
+- **`MergePR` success and stale-head shapes on 1.26.4.** The empty 200 body and the 409 `head out of date` each need a live pull request to merge or to race, which no probe has done on that lab. The same probe would observe `merge_commit_sha` on the wire, which rests on upstream-source provenance alone (see [Mergeability](#mergeability)).
+- **Merge-option field-name casing.** Whether Gitea's binder accepts `"do"` as well as the `"Do"` the adapter sends is undetermined: both spellings reached the already-merged 405, which is returned before the binding discriminates. Probe: send each spelling against a mergeable pull request.
+- **Label-remove status on 1.27.0 for an unmatched numeric id.** 1.26.4 answers 422 where 1.27.0 answers 404 for a name in the id slot; the 1.27.0 answer for a numeric id matching no repository label has no observation. Probe: `DELETE .../issues/{index}/labels/{unused-id}` on a 1.27.0 instance.
+- **Forgejo and Codeberg.** Compatibility is claimed from the portable-subset argument in [Forgejo and Codeberg](#forgejo-and-codeberg), not observed. Probe: run the env-gated suite against a pinned Forgejo image through the existing container harness.
 
 ---
 
 ## Source attribution
 
-| Topic | Primary source | Verification method |
+| Topic | Primary source | Evidence |
 | --- | --- | --- |
-| Route surface, parameters, request and response schemas | Local instance `GET /swagger.v1.json` (authoritative for 1.27.0) | Live `curl` against every tracker-relevant route |
-| Canonical `token` header, OAuth2 Bearer, query-parameter auth, sudo | docs.gitea.com: API usage (via Context7 `/websites/gitea`) | Live matrix of all five schemes |
-| Token creation route and scope taxonomy | docs.gitea.com: API usage | Live token creation, scope collapse, and 403 scope probes |
-| Pagination (`page`/`limit`, `Link`, `x-total-count`) | docs.gitea.com: API usage | Live header inspection; clamp and default measured |
-| `MAX_RESPONSE_ITEMS`, `DEFAULT_PAGING_NUM` | docs.gitea.com: config cheat sheet, `[api]` section | Live `/settings/api` readout |
-| Label filter AND semantics and dropped-filter behavior | **Live API** (swagger description says "any of", which the live instance contradicts) | Two-label and unresolvable-name probes |
-| Label id-only removal, silent unknown-name attach, `color` requirement | **Live API** | Direct probes, statuses and bodies captured |
-| Dependencies semantics (`dependencies` = blockers, `blocks` = dependents) | **Live API** | Created a dependency and read both directions |
-| Comments route unpaginated completeness | **Live API** | 60-comment issue returned in full |
-| 412, 422, 423, 401, 403, 404 shapes | **Live API** | Provoked each status |
-| No built-in rate limiting | go-gitea/gitea#9559 (open feature request); go-gitea/gitea#24102 (`/rate_limit` 404) | Live 404 on `/rate_limit`; absent headers |
+| Route surface, parameters, request and response schemas | Instance `GET /swagger.v1.json`, which self-reports its release | Live `curl` against every tracker-relevant route, 1.27.0 on 2026-07-14; OpenAPI re-read on 1.26.4 on 2026-08-11 |
+| Canonical `token` header, OAuth2 Bearer, query-parameter auth, sudo | docs.gitea.com: API usage (via Context7 `/websites/gitea`) | Live matrix of all five schemes, 1.27.0 on 2026-07-14 and 1.26.4 on 2026-08-11 |
+| Token creation route, scope taxonomy, and scope sufficiency | docs.gitea.com: API usage | Live token creation, scope collapse, and 403 scope probes, 1.27.0 on 2026-07-14 |
+| Pagination (`page`/`limit`, `Link`, `x-total-count`), clamps and defaults | docs.gitea.com: API usage | Live header inspection with clamp and default measured, 1.27.0 on 2026-07-14 and 1.26.4 on 2026-08-11 |
+| `MAX_RESPONSE_ITEMS`, `DEFAULT_PAGING_NUM` | docs.gitea.com: config cheat sheet, `[api]` section | Live `/settings/api` readout on both releases, 2026-07-14 and 2026-08-11 |
+| List parameters and ordering (`sort` and `direction` ignored, `per_page` ignored, `type=issues`) | **Live API** | Direct probes, 1.27.0 on 2026-07-14 and 1.26.4 on 2026-08-11 |
+| Label filter AND semantics and dropped-filter behavior | **Live API** (the swagger description says "any of", which the instance contradicts) | Two-label and unresolvable-name probes, 1.27.0 on 2026-07-14 and 1.26.4 on 2026-08-11 |
+| Label id-only removal, silent unknown-name attach, `color` requirement | **Live API** | Direct probes with statuses and bodies captured, 1.27.0 on 2026-07-14 |
+| Label-remove statuses for a name and for an unmatched numeric id | **Live API** (lab instance, Gitea 1.26.4) | 422 for both, and 204 for an existing label the issue does not carry, 2026-08-11 |
+| Absent routes (`/search/issues`, `.../dependencies/blocked_by`, `.../parent`) | **Live API** | 404 on each, paired with a 200 control on a sibling route, 1.27.0 on 2026-07-14 and 1.26.4 on 2026-08-11 |
+| Dependencies semantics (`dependencies` = blockers, `blocks` = dependents) and create-body shape | **Live API** | Created a dependency and read both directions, 1.27.0 on 2026-07-14; repeated and reverted on 1.26.4 on 2026-08-11 |
+| Comments route unpaginated completeness | **Live API**, corroborated by the instance OpenAPI, which declares only `since` and `before` | 60-comment issue returned in full on 1.27.0 on 2026-07-14; 61-comment issue, including under `limit=5`, on 1.26.4 on 2026-08-11 |
+| 412, 422, 423, 401, 403, 404 shapes | **Live API** | Provoked each status on 1.27.0 on 2026-07-14; 401, 404, 412, and 422 re-provoked on 1.26.4 on 2026-08-11 |
+| No built-in rate limiting | go-gitea/gitea#9559 (open feature request); go-gitea/gitea#24102 (`/rate_limit` 404) | Live 404 on `/rate_limit` against a `/version` 200 control, plus absent `x-ratelimit-*` and `ETag` headers, on both releases |
 | Docker image registry and tags | docs.gitea.com: installation with Docker (via Context7) | Documentation only |
-| Forgejo API base, token header, pagination | forgejo.org/docs: API usage | Codeberg live swagger and version endpoint |
+| Forgejo API base, token header, pagination | forgejo.org/docs: API usage | Codeberg live swagger and version endpoint, 2026-07-14 |
 | Codeberg version marker and label-route divergence | **Live Codeberg** `GET /api/v1/version` and `/swagger.v1.json` | Fetched 2026-07-14 |
-| Populated `PullReview` and `PullReviewComment` shapes | **Live API** (lab instance, Gitea 1.26.4) | Provisioned a PR with two reviews and inline comments, then read both routes; re-read the comments under a non-admin identity with identical results |
-| Review-comment `position` / `original_position` semantics | **Live API** (lab instance, Gitea 1.26.4), corroborated by `modules/structs/pull_review.go` at the `v1.26.4` and `v1.27.0` tags | Anchored one comment new-side and one old-side on the same modified line, then pushed a commit deleting that line and re-read both |
-| Combined-status pagination, `total_count` per-page semantics, and `target_url` | **Live API** (lab instance, Gitea 1.26.4) | Seeded 51 statuses on one commit and read the route at the default page size, `limit=50` pages one and two, and `limit=20`, with response headers captured |
-| 2026-08-11 regression pass: rate limiting, pagination and clamps, list parameters, label filter, absent routes, dependency direction, auth matrix, error statuses, unpaginated comments, combined-status paging, review-comment side selectors, timeline headers, PR object shape, already-merged merge rejection | **Live API** (lab instance, Gitea 1.26.4) corroborated by the instance's own OpenAPI (`GET /swagger.v1.json`, which self-reports `Gitea API 1.26.4`) | Read-only probes with a positive control paired to every absence claim; one dependency created and deleted to restore the instance |
-| Label-remove statuses on 1.26.x | **Live API** (lab instance, Gitea 1.26.4) | 422 for a non-numeric name and for an unmatched numeric id; 204 for an existing label the issue does not carry |
-| 2026-08-16 pass: review-comment side selection with both fields non-zero unreachable, the file-scoped both-zero shape, `commit_id`'s two-halved meaning, review `stale` and comment `updated_at` behavior, out-of-diff anchor acceptance, and the uncopied upstream `Invalidated` field. `review_comments_mixed.json`, `review_comments_bot_mixed.json`, and `review_comments_file_scoped.json` were captured from this pass. | **Live API** (probe lab instance, Gitea 1.26.4, `GET /api/v1/version` and its own `GET /swagger.v1.json`) | Two passes against one pull request: the first anchored comments new-side and old-side on the same modified line and pushed two commits, one deleting the anchored line, without changing either comment; the second added three comments anchored away from the head commit's own change (two new-side, one old-side) and pushed a commit touching none of their anchors |
-| `commit_id`'s blame-versus-head mechanism | `services/pull/review.go` (`createCodeComment`) at the `v1.26.4` and `v1.27.0` tags | Upstream-source provenance, not a live-verification claim: the wire response names only a commit identifier, not the mechanism that produced it |
-| GitHub adapter behavior used in the reuse matrix | `internal/scm/github/tracker.go` (`fetchCandidatesViaIssues`, `fetchCandidatesViaSearch`, `fetchStatesByNumbers`, `fetchBlockers`, `fetchParent`, `TransitionIssue`, `AddLabel`) | Code reading at research time |
+| Populated `PullReview` and `PullReviewComment` shapes | **Live API** (lab instance, Gitea 1.26.4) | Provisioned a PR with two reviews and inline comments, then read both routes, 2026-08-10; the comments re-read under a non-admin identity with identical results |
+| Review-comment `position` / `original_position` semantics | **Live API** (lab instance, Gitea 1.26.4), corroborated by `modules/structs/pull_review.go` at the `v1.26.4` and `v1.27.0` tags | Anchored one comment new-side and one old-side on the same modified line, then pushed a commit deleting that line and re-read both, 2026-08-10; the side selectors re-read on 2026-08-11 |
+| Absence of any invalidation signal: the file-scoped both-zero shape, out-of-diff anchor acceptance, review `stale`, and comment `updated_at` | **Live API** (probe lab instance, Gitea 1.26.4, identified by `GET /api/v1/version` and its own `GET /swagger.v1.json`) | Two runs against one pull request on 2026-08-16: the first anchored comments new-side and old-side on the same modified line and pushed two commits, one deleting the anchored line, without changing either comment; the second added three comments anchored away from the head commit's own change (two new-side, one old-side) and pushed a commit touching none of their anchors. `review_comments_mixed.json`, `review_comments_bot_mixed.json`, and `review_comments_file_scoped.json` were captured from those runs |
+| `commit_id`'s blame-versus-head mechanism | `services/pull/review.go` (`createCodeComment`) at the `v1.26.4` and `v1.27.0` tags | Upstream-source provenance, not a live-verification claim: the wire response names only a commit identifier, not the mechanism that produced it. The resulting values were observed live on 1.26.4 on 2026-08-16 |
+| Upstream `Invalidated` field absent from the wire shape | `models/issues/comment.go` and `services/convert/pull_review.go` (`ToPullReviewComment`) at the `v1.26.4` and `v1.27.0` tags | Upstream source, cross-checked against the instance OpenAPI and the live response, 1.26.4 on 2026-08-16 |
+| Combined-status pagination, `total_count` per-page semantics, and `target_url` | **Live API** (lab instance, Gitea 1.26.4), corroborated by the instance OpenAPI, which declares `page` and `limit` | Seeded 51 statuses on one commit and read the route at the default page size, `limit=50` pages one and two, `limit=20`, and `limit=100`, with response headers captured, 2026-08-10 and 2026-08-11 |
+| PR object shape (`mergeable` a plain bool, `mergeable_state` absent) | **Live API** | Lab PR on 1.27.0 on 2026-07-14; re-confirmed on 1.26.4 on 2026-08-11 |
+| Already-merged merge rejection (405) | **Live API** (lab instance, Gitea 1.26.4) | `POST .../pulls/{index}/merge` against a merged PR, which stayed unchanged afterward, 2026-08-11 |
+| Timeline headers (no `Link`, page-length `X-Total-Count`) | **Live API** (lab instance, Gitea 1.26.4) | `limit=2`, `limit=5`, and the default page size on an issue whose timeline exceeds one page, 2026-08-11 |
+| GitHub adapter behavior in the comparison table | `internal/scm/github/tracker.go` (`fetchCandidatesViaIssues`, `fetchCandidatesViaSearch`, `fetchStatesByNumbers`, `fetchBlockers`, `fetchParent`, `TransitionIssue`, `AddLabel`) | Code reading |
 
 ### Context7 verification report
 
-Library resolved: `/websites/gitea` (1,874 snippets, High reputation). Queries confirmed: the canonical `Authorization: token` header and its "historical reasons" phrasing, OAuth2 Bearer and query-parameter alternatives, the scope taxonomy with the `all` special scope, `page`/`limit` pagination with `Link` and `x-total-count` headers, `MAX_RESPONSE_ITEMS` defaulting to 50, and the `docker.gitea.com/gitea:<version>` image reference with rootless variants. Context7 did not cover the label-filter semantics, the id-only label removal, the unpaginated comments route, the 412/423 statuses, or the absence of rate limiting; those facts are live-verified (and, for rate limiting, sourced from the upstream issue tracker). Where the swagger description and the live instance disagreed (the `labels` filter "any of" claim), the live behavior is recorded and the discrepancy noted.
+Library resolved: `/websites/gitea` (1,874 snippets, High reputation). Queries confirm the canonical `Authorization: token` header and its "historical reasons" phrasing, OAuth2 Bearer and query-parameter alternatives, the scope taxonomy with the `all` special scope, `page`/`limit` pagination with `Link` and `x-total-count` headers, `MAX_RESPONSE_ITEMS` defaulting to 50, and the `docker.gitea.com/gitea:<version>` image reference with rootless variants. Context7 covers none of the label-filter semantics, the id-only label removal, the unpaginated comments route, the 412 and 423 statuses, or the absence of rate limiting; those facts are live-verified, and rate limiting is additionally sourced from the upstream issue tracker. Where the swagger description and the instance disagree (the `labels` filter "any of" claim), this document records the live behavior and names the discrepancy.

--- a/docs/github-adapter-notes.md
+++ b/docs/github-adapter-notes.md
@@ -1,32 +1,80 @@
-# GitHub REST API: Adapter research notes
+# GitHub API: Adapter research notes
 
-> GitHub REST API, API version `2026-03-10`, researched March 2026.
-> Reference for implementing the GitHub `TrackerAdapter` and `SCMAdapter`.
+> GitHub REST API and GraphQL API on `github.com`, pinned to REST API version `2026-03-10`
+> through the `X-GitHub-Api-Version` header that `newGitHubClient`
+> (`internal/scm/github/client.go`) sets on every request. REST facts were observed live with
+> `curl` and a personal access token in March 2026 and cross-checked against GitHub's
+> documentation through the Context7 mirror `/websites/github_en_rest`. The pull request
+> payload was re-observed live on 2026-08-10 against the public pull request
+> `sortie-ai/sortie#772`, using API version `2022-11-28` as the comparison control. GraphQL
+> facts come from GitHub's GraphQL documentation; the query text is pinned by the adapter's
+> request-shape unit tests rather than by a live probe.
+>
+> Coverage: every `TrackerAdapter` operation, and the `SCMAdapter` operations the auto-merge
+> and merge-completion reactions depend on (`GetReviewDecision`, `GetCIStatus`,
+> `GetMergeability`, `MergePR`, `DeleteBranch`). The review-comment and label-event operations
+> are listed with their routes, but their payload shapes are not characterized here. The
+> check-runs route is shared with `GitHubCIProvider`, the package's `domain.CIStatusProvider`
+> implementation.
+>
+> Every claim describes `github.com`. No GitHub Enterprise Server instance was observed: the
+> GHES base-URL handling below is a fact about the adapter, not about a server.
+
+Reference for implementing the GitHub `TrackerAdapter` and `SCMAdapter`, both in
+`internal/scm/github`.
+
+---
+
+## Pinned API version
+
+The adapter sends `X-GitHub-Api-Version: 2026-03-10` on every REST request. Under this version
+the following properties are absent from the payloads the adapter reads:
+
+| Removed property | Payload | Consequence for the adapter |
+| ---------------- | ------- | --------------------------- |
+| `assignee` (singular) | Issue and pull request | `normalizeIssue` reads `assignees[0].login`; the plural array survives this version |
+| `merge_commit_sha` | Pull request, on every endpoint that returns a pull request object | `GetMergeability` sources the merge commit from GraphQL instead (see [GetMergeability](#3-getmergeability-pull-request-preview)) |
+| `head.repo.has_downloads`, `base.repo.has_downloads` | Pull request | Not read |
+| `use_squash_pr_title_as_default` | Repository | Not read |
+
+The `merge_commit_sha` removal is reproducible:
+
+```bash
+for V in 2022-11-28 2026-03-10; do
+  curl -sS -H "Authorization: Bearer $TOKEN" -H "X-GitHub-Api-Version: $V" \
+    https://api.github.com/repos/sortie-ai/sortie/pulls/772 \
+    | jq -c '{merged, has: has("merge_commit_sha")}'
+done
+# 2022-11-28: {"merged":true,"has":true}
+# 2026-03-10: {"merged":true,"has":false}
+```
+
+GitHub supports version `2022-11-28` until March 10, 2028. The adapter pins one version in one
+place, `newGitHubClient`, and no configuration key overrides it.
 
 ---
 
 ## Authentication
 
-GitHub supports several authentication methods. All methods send the token in the
-`Authorization` header and must include the `X-GitHub-Api-Version: 2026-03-10` header for
-stable behavior.
+Every method sends the token in the `Authorization` header. `newGitHubClient` also sets
+`Accept: application/vnd.github+json`, the pinned API-version header, and a `User-Agent`.
 
-### Personal access token, fine-grained (recommended for Sortie)
+### Personal access token, fine-grained
 
-Fine-grained PATs grant per-repository, per-permission access. This is the recommended
-method for Sortie because it follows the principle of least privilege.
+Fine-grained PATs grant per-repository, per-permission access, which is the least-privilege
+option for Sortie.
 
 - Generate at `https://github.com/settings/personal-access-tokens/new`.
 - Header: `Authorization: Bearer <token>`
 - Token prefix: `github_pat_` (machine-identifiable).
-- Required repository permission: **Issues: Read and write** (covers issue read, comment
-  read/write, label read/write, dependencies read).
-- Repository scope: restrict the token to the specific repository Sortie will manage.
-- Expiration: mandatory. GitHub enforces a maximum lifetime. The adapter should detect
-  `401` responses and return `tracker_auth_error` with a message suggesting token renewal.
+- Required repository permission for the tracker surface: **Issues: Read and write**, which
+  covers issue read, comment read and write, label read and write, and dependencies read.
+- Repository scope: restrict the token to the repository Sortie manages.
+- Expiration is mandatory and GitHub enforces a maximum lifetime. `classifyHTTPError` maps
+  `401` to `tracker_auth_error` with the message `bad credentials`.
 
-The `X-Accepted-GitHub-Permissions` response header reports the permissions required by
-each endpoint, useful for diagnosing access errors.
+The `X-Accepted-GitHub-Permissions` response header reports the permissions each endpoint
+requires, which is how an access failure is diagnosed.
 
 ### Personal access token, classic
 
@@ -34,189 +82,213 @@ Classic PATs grant broad scope-based access.
 
 - Header: `Authorization: Bearer <token>`
 - Token prefix: `ghp_`
-- Required scope: `repo` (covers full control of private repositories, including issues
-  and labels).
+- Required scope: `repo`, which covers full control of private repositories, including issues
+  and labels.
 
-Less preferred than fine-grained PATs due to coarse scoping. Acceptable for quick setup
-or when fine-grained PATs are unavailable (e.g., some GitHub Enterprise Server instances).
+Coarser than a fine-grained PAT, and the practical choice when fine-grained PATs are
+unavailable, as on some GitHub Enterprise Server instances. A classic PAT is also the only
+token kind whose scopes the auto-merge preflight can read (see
+[Token scopes](#token-scopes)).
 
 ### GitHub App installation token
 
-GitHub Apps authenticate per-installation using short-lived tokens.
+GitHub Apps authenticate per-installation with short-lived tokens.
 
-- Generate by `POST /app/installations/{installation_id}/access_tokens` with a JWT signed
+- Generate with `POST /app/installations/{installation_id}/access_tokens`, using a JWT signed
   by the App's private key.
 - Header: `Authorization: Bearer <installation_token>`
 - Token prefix: `gho_`
-- Token expiration: 1 hour (non-renewable; must re-create).
-- Required permission: **Issues: Read and write**.
+- Expiration: 1 hour, non-renewable; the caller re-creates it.
+- Required permission for the tracker surface: **Issues: Read and write**.
 
-Not used by Sortie initially. Relevant if Sortie is distributed as a GitHub App in the
-future.
+An installation token carries no `X-OAuth-Scopes` header, so the auto-merge preflight cannot
+verify it.
 
-### `GITHUB_TOKEN` (GitHub Actions)
+### `GITHUB_TOKEN` in GitHub Actions
 
-Automatically available in GitHub Actions workflows.
+Available automatically inside a GitHub Actions workflow.
 
 - Header: `Authorization: Bearer $GITHUB_TOKEN`
-- Rate limit: 1,000 requests/hour (lower than PAT's 5,000/hour).
-- Scope: limited to the repository where the workflow runs.
-- Useful for CI-driven Sortie runs.
+- Rate limit: 1,000 requests/hour, below a PAT's 5,000/hour.
+- Scope: the repository the workflow runs in.
 
-### Config mapping
-
-| Config field       | Value                                             |
-| ------------------ | ------------------------------------------------- |
-| `tracker.endpoint` | `https://api.github.com` (default, omit for GHES) |
-| `tracker.api_key`  | PAT value (fine-grained or classic)               |
-| `tracker.project`  | `owner/repo`, e.g. `sortie-ai/sortie`            |
-
-The adapter splits `tracker.project` on `/` to extract `owner` and `repo` for URL
-construction. If the value does not contain exactly one `/`, the adapter returns a
-configuration validation error at startup.
-
-For GitHub Enterprise Server, `tracker.endpoint` is set to the instance URL
-(e.g., `https://github.example.com/api/v3`).
+`validateConfig` (`internal/scm/github/validate.go`) emits a warning when `tracker.api_key` is
+empty, and names `GITHUB_TOKEN` in that warning when the environment variable is set.
 
 ---
 
-## Endpoints
+## Configuration
 
-Each `TrackerAdapter` operation maps to one or more GitHub REST API endpoints.
+| Config field       | Value                                              |
+| ------------------ | -------------------------------------------------- |
+| `tracker.endpoint` | `https://api.github.com` by default; set to the instance URL for GHES, for example `https://github.example.com/api/v3`. Trailing slashes are trimmed |
+| `tracker.api_key`  | A single PAT string, not `email:token` as Jira uses. Passed straight through as a Bearer token |
+| `tracker.project`  | `owner/repo`, for example `sortie-ai/sortie` |
+| `tracker.active_states` | Label names for active states, for example `["backlog", "in-progress", "review"]`. Lowercased at construction. Defaults to `issuekit.DefaultActiveLabelStates()` |
+| `tracker.terminal_states` | Label names for terminal states, for example `["done", "wontfix"]`. Lowercased at construction. Defaults to `issuekit.DefaultTerminalLabelStates()` |
+| `tracker.handoff_state` | Label name for the post-run handoff state, for example `"review"`. Trimmed and lowercased. Per ADR-0007 |
+| `tracker.query_filter` | Optional GitHub search-qualifier fragment, for example `label:sortie-managed milestone:"Sprint 1"`. When set, candidate fetches route through `GET /search/issues` |
+| `extensions.github.etag_cache_size` | Entry cap for the per-path ETag cache, merged into the adapter config by `mergeExtensions` (`cmd/sortie/resolve.go`). Defaults to 1000; `0` disables conditional requests |
 
-### 1. `FetchCandidateIssues` → `GET /repos/{owner}/{repo}/issues`
+`user_agent` is not an operator key: `cmd/sortie/boot.go` sets it to `sortie/<version>` before
+constructing the adapter, and `sortie/dev` is the constructor's fallback when the key is
+absent.
 
-Lists open issues for the repository. Filters issues to those matching the configured
-active states (via label-based state mapping; see State mapping below).
+`NewGitHubAdapter` splits `tracker.project` with `strings.Cut` on `/` and rejects a value whose
+halves are empty or whose second half contains another slash, returning `tracker_payload_error`
+with the message `project must be in owner/repo format`. The offline `sortie validate` pipeline
+reports the same shape through `registry.DiagOwnerRepoProject`.
+
+The constructor runs no credential or repository preflight. A bad token or an inaccessible
+repository surfaces on the first read, not at startup.
+
+Network timeout is 30,000 ms, per
+[architecture Section 11.2](architecture/11-issue-tracker-integration-contract.md#112-query-semantics).
+
+---
+
+## Tracker operations
+
+Every `TrackerAdapter` method is implemented in `internal/scm/github/tracker.go`.
+
+| Operation | Route | Go symbol |
+| --------- | ----- | --------- |
+| `FetchCandidateIssues` | `GET /repos/{owner}/{repo}/issues`, or `GET /search/issues` when `query_filter` is set | `fetchCandidatesViaIssues`, `fetchCandidatesViaSearch` |
+| `FetchIssueByID` | `GET /repos/{owner}/{repo}/issues/{number}` plus the blockers, parent, and comments routes | `FetchIssueByID` |
+| `FetchIssuesByStates` | `GET /repos/{owner}/{repo}/issues?state=open` and `GET /search/issues` per terminal label | `fetchOpenIssuesByStates`, `fetchClosedIssuesByLabel` |
+| `FetchIssueStatesByIDs` | `GET /repos/{owner}/{repo}/issues/{number}`, one per issue | `fetchStatesByNumbers` |
+| `FetchIssueStatesByIdentifiers` | Same route and same helper | `fetchStatesByNumbers` |
+| `FetchIssueComments` | `GET /repos/{owner}/{repo}/issues/{number}/comments` | `fetchAllComments` |
+| `TransitionIssue` | Label delete, label add, and issue patch | `TransitionIssue` |
+| `CommentIssue` | `POST /repos/{owner}/{repo}/issues/{number}/comments` | `CommentIssue` |
+| `AddLabel` | `POST /repos/{owner}/{repo}/issues/{number}/labels` | `AddLabel` |
+
+### 1. `FetchCandidateIssues`
+
+Query parameters on the issues route:
+
+| Parameter   | Value       | Notes                            |
+| ----------- | ----------- | -------------------------------- |
+| `state`     | `open`      | Only open issues are candidates  |
+| `sort`      | `created`   | Stable ordering                  |
+| `direction` | `asc`       | Oldest first                     |
+| `per_page`  | `50`        | Per [architecture Section 11.2](architecture/11-issue-tracker-integration-contract.md#112-query-semantics) |
+
+The adapter sends no `labels` parameter. It normalizes every entry and then drops the ones
+whose derived state is not in `active_states`, so state filtering is client-side.
+
+**Pull request filtering.** The issues route returns both issues and pull requests. A pull
+request entry carries a non-null `pull_request` key, which `isPullRequest`
+(`internal/scm/github/normalize.go`) uses to drop it before normalization.
+
+**Search variant.** When `tracker.query_filter` is set, the adapter builds the query
+`repo:{owner}/{repo} type:issue state:open {query_filter}` and sends it to
+`GET /search/issues` with `sort=created`, `order=asc`, and `per_page=50`. The search endpoint
+accepts the full GitHub qualifier syntax (label, assignee, milestone, date ranges) and carries
+a separate, much smaller rate-limit budget (see [Rate limiting](#rate-limiting)), which is why
+an unset `query_filter` keeps candidate fetches on the plain issues route.
+
+### 2. `FetchIssueByID`
+
+GitHub addresses issues by `number` within a repository. `FetchIssueByID` takes that number as
+a string, reads the issue, rejects the resource as not found when it is a pull request, and
+then fills `BlockedBy`, `Parent`, and `Comments` from their own routes.
+
+### 3. `FetchIssuesByStates`
+
+GitHub's native state is only `open` or `closed`, while Sortie's states are label-based, so the
+adapter splits the requested set:
+
+1. Every requested state that is not a configured terminal state routes through
+   `GET /repos/{owner}/{repo}/issues?state=open`, with client-side filtering against the
+   requested set.
+2. Every requested terminal state gets its own search call:
+   `GET /search/issues?q=repo:{owner}/{repo} type:issue state:closed label:"{state}"`. The
+   operator's `query_filter` is deliberately not appended here, so an operator filter cannot
+   hide a terminal issue from this lookup.
+3. Results are deduplicated by issue identifier across both halves.
+
+An unknown state label on a closed issue is not found. That is intentional: only configured
+terminal states warrant the closed-issue search path.
+
+### 4. `FetchIssueStatesByIDs` and `FetchIssueStatesByIdentifiers`
+
+GitHub offers no bulk state read, and both methods delegate to `fetchStatesByNumbers`, because
+the domain ID and the domain identifier are both the issue number. The helper issues one
+`GET /repos/{owner}/{repo}/issues/{number}` per number, sequentially, and stops on the first
+error other than a 404 (a 404 skips that issue).
+
+Each request goes through `etagCache` (`internal/scm/github/etag_cache.go`): the cached ETag is
+sent as `If-None-Match`, and a `304` reuses the state derived on the last full read without
+re-deriving it. `304` responses do not count against the primary rate limit, which matters because
+reconciliation polls the same issues repeatedly.
+
+### 5. `FetchIssueComments`
 
 Query parameters:
 
-| Parameter   | Value                      | Notes                               |
-| ----------- | -------------------------- | ----------------------------------- |
-| `state`     | `open`                     | Only open issues are candidates     |
-| `labels`    | comma-separated label list | Filter by active state labels       |
-| `sort`      | `created`                  | Stable ordering                     |
-| `direction` | `asc`                      | Oldest first                        |
-| `per_page`  | `50`                       | Per [architecture Section 11.2](architecture/11-issue-tracker-integration-contract.md#112-query-semantics)       |
+| Parameter  | Value          | Notes                                            |
+| ---------- | -------------- | ------------------------------------------------ |
+| `per_page` | `50`           | The only parameter the adapter sends             |
+| `page`     | 1, 2, 3, ...   | Supplied by the `Link` header, not constructed   |
+| `since`    | ISO-8601 timestamp | Supported by GitHub; the adapter does not send it |
 
-**Pull request filtering:** The issues endpoint returns both issues and pull requests.
-Pull requests have a non-null `pull_request` key. The adapter must skip entries where
-`pull_request` is present.
+The per-issue comments route supports neither `sort` nor `direction`; those exist only on the
+repository-wide comments listing (`GET /repos/{owner}/{repo}/issues/comments`). Comments come
+back in ascending ID order, oldest first, so the adapter re-sorts nothing.
 
-**Alternative: `GET /search/issues`** for `query_filter` support. When `tracker.query_filter`
-is configured, the adapter uses the search endpoint instead:
+Each comment carries `id`, `user.login`, `body`, `created_at`, and `updated_at`. The body is
+Markdown, not Jira's ADF, and `normalizeComments` passes it through unchanged.
 
-```
-GET /search/issues?q=repo:{owner}/{repo}+type:issue+state:open+{query_filter}&sort=created&order=asc&per_page=50
-```
+### 6. `TransitionIssue`
 
-The search endpoint supports the full GitHub search qualifier syntax (label, assignee,
-milestone, date ranges). The search API has a **separate rate limit** of 30 requests/minute
-(see Rate limiting below), so the adapter should prefer the issues endpoint when
-`query_filter` is not set.
+GitHub has no workflow transition concept, so the adapter composes a transition from the label
+and issue-edit routes:
 
-### 2. `FetchIssueByID` → `GET /repos/{owner}/{repo}/issues/{issue_number}`
+1. Reject a `targetState` that is not a configured active state, terminal state, or the
+   handoff state, with `tracker_payload_error`, before any write.
+2. Read the issue to find its current state label and native `open`/`closed` status.
+3. When a different state label is present, remove it:
+   `DELETE /repos/{owner}/{repo}/issues/{number}/labels/{name}`. A 404 here is tolerated.
+4. When the target label is not already present, add it:
+   `POST /repos/{owner}/{repo}/issues/{number}/labels` with body
+   `{ "labels": ["target-state-label"] }`.
+5. When the target is terminal and the issue is open, close it:
+   `PATCH /repos/{owner}/{repo}/issues/{number}` with body
+   `{ "state": "closed", "state_reason": "completed" }`.
+6. When the target is active and the issue is closed, reopen it:
+   `PATCH /repos/{owner}/{repo}/issues/{number}` with body `{ "state": "open" }`.
 
-Returns a single issue by number. GitHub identifies issues by `number` within a repository
-(not a global numeric ID).
+GitHub's `state_reason` accepts `"completed"`, `"not_planned"`, `"duplicate"`, and
+`"reopened"`. The adapter always sends `"completed"`.
 
-The `id` field in the response is a global GitHub-internal integer. The adapter uses
-`number` as the domain `Identifier` (as a string, e.g. `"299"`) and `id` as the domain
-`ID` (as a string, e.g. `"4162016052"`).
+Every step is idempotent, so a partial failure converges on the next retry.
 
-### 3. `FetchIssuesByStates` → `GET /repos/{owner}/{repo}/issues` (repeated)
+Fine-grained PAT permission: **Issues: Read and write**, which covers both the issue update and
+the label manipulation.
 
-Fetches issues matching specific states. Since GitHub's native state is only `open` or
-`closed`, and Sortie's states are label-based, the adapter:
+### 7. `CommentIssue` and `AddLabel`
 
-1. Determines which native GitHub state(s) to query (`open`, `closed`, or both) based
-   on whether the requested states overlap with `active_states` or `terminal_states`.
-2. For each page of results, filters to issues whose labels match the requested states.
-3. Paginates until all results are collected.
+`CommentIssue` posts `{ "body": text }` verbatim to
+`POST /repos/{owner}/{repo}/issues/{number}/comments`. GitHub accepts Markdown natively, so no
+format conversion happens.
 
-For terminal state queries that need closed issues: `GET /repos/{owner}/{repo}/issues?state=closed&labels={terminal_label}&per_page=50`.
-
-### 4. `FetchIssueStatesByIDs` → `GET /repos/{owner}/{repo}/issues/{issue_number}` (batched)
-
-GitHub does not provide a bulk "get issue states by IDs" endpoint. The adapter issues
-individual `GET /repos/{owner}/{repo}/issues/{issue_number}` requests for each issue.
-
-To minimize rate limit consumption:
-
-- Use conditional requests (`If-None-Match` with cached ETags) for issues that were
-  recently fetched. Verified: 304 responses do NOT count against the primary rate limit.
-- Parallelize requests within a bounded concurrency pool (e.g., 10 concurrent requests).
-- Return the label-derived state for each issue by scanning labels against the
-  `active_states` and `terminal_states` configuration.
-
-For small numbers of issues (<20), the overhead is acceptable. For larger sets, consider
-using the search endpoint: `GET /search/issues?q=repo:{owner}/{repo}+type:issue+{numbers}`
-but note the 30 req/min search rate limit.
-
-### 5. `FetchIssueStatesByIdentifiers` → same as `FetchIssueStatesByIDs`
-
-GitHub issue identifiers (numbers as strings) map directly to the issues endpoint.
-The adapter converts identifiers to issue numbers and follows the same batched-fetch
-strategy as `FetchIssueStatesByIDs`.
-
-### 6. `FetchIssueComments` → `GET /repos/{owner}/{repo}/issues/{issue_number}/comments`
-
-Query parameters:
-
-| Parameter  | Value          | Notes                                           |
-| ---------- | -------------- | ----------------------------------------------- |
-| `per_page` | `50`           | Per [architecture Section 11.2](architecture/11-issue-tracker-integration-contract.md#112-query-semantics)                   |
-| `page`     | 1, 2, 3, ...   | Offset pagination                               |
-| `since`    | ISO-8601 timestamp | Optional. Only comments updated after this time |
-
-The per-issue comments endpoint does not support `sort` or `direction` parameters.
-Comments are returned in ascending ID order (oldest first) by default. The `sort` and
-`direction` parameters are only available on the repo-wide comments listing
-(`GET /repos/{owner}/{repo}/issues/comments`).
-
-Response is a JSON array of comment objects. Each comment has `id`, `user.login`, `body`
-(Markdown, **not** ADF like Jira), `created_at`, `updated_at`.
-
-Comment `body` is Markdown and requires no flattening (unlike Jira's ADF). The adapter
-passes it through directly as the domain `Comment.Body`.
-
-### 7. `TransitionIssue` → label add/remove + optional state change
-
-GitHub has no workflow transition concept. The adapter implements "state transitions" by
-manipulating labels. Per the project's design (issue #218), `TransitionIssue`:
-
-1. Identifies the current state label(s) on the issue (labels matching `active_states`
-   or `terminal_states`).
-2. Removes the current state label:
-   `DELETE /repos/{owner}/{repo}/issues/{issue_number}/labels/{name}`
-3. Adds the target state label:
-   `POST /repos/{owner}/{repo}/issues/{issue_number}/labels`
-   Body: `{ "labels": ["target-state-label"] }`
-4. If transitioning to a terminal state, also closes the issue:
-   `PATCH /repos/{owner}/{repo}/issues/{issue_number}`
-   Body: `{ "state": "closed", "state_reason": "completed" }`
-5. If transitioning from a terminal state to an active state, reopens the issue:
-   `PATCH /repos/{owner}/{repo}/issues/{issue_number}`
-   Body: `{ "state": "open" }`
-
-The `state_reason` field accepts `"completed"`, `"not_planned"`, `"duplicate"`, or
-`"reopened"`. Default to `"completed"` for terminal transitions. Use `"not_planned"`
-for wontfix-style closures.
-
-Fine-grained PAT permission required: **Issues: Read and write** (covers both issue
-update and label manipulation).
+`AddLabel` posts `{ "labels": [label] }` to
+`POST /repos/{owner}/{repo}/issues/{number}/labels`. The route is additive, so existing labels
+survive.
 
 ---
 
 ## State mapping
 
-GitHub issues have only two native states: `open` and `closed`. Sortie requires richer
-state semantics (backlog, in-progress, review, done). The adapter bridges this gap using
-**labels as state indicators**.
+GitHub issues have two native states, `open` and `closed`. Sortie needs richer state semantics
+(backlog, in progress, review, done), so the adapter uses labels as state indicators, following
+the shared label-state derivation rule in
+[architecture Section 11.6](architecture/11-issue-tracker-integration-contract.md#116-implemented-tracker-adapters).
 
 ### Convention
 
-Each Sortie-managed state maps to a GitHub label. Example configuration:
+Each Sortie-managed state is a GitHub label name. Example configuration:
 
 ```yaml
 tracker:
@@ -225,75 +297,61 @@ tracker:
   handoff_state: "review"
 ```
 
-These values correspond to GitHub label names (normalized to lowercase per architecture
-[Section 11.3](architecture/11-issue-tracker-integration-contract.md#113-normalization-rules)). The adapter:
+State names are normalized to lowercase per
+[Section 11.3](architecture/11-issue-tracker-integration-contract.md#113-normalization-rules).
+`issuekit.DeriveLabelState`, called from `normalizeIssue`, derives an issue's state:
 
-- Derives an issue's state by scanning its labels against the configured state lists.
-- Returns the **first matching** label as the state. If multiple state labels are present,
-  logs a warning and returns the first match in `active_states` order, then
-  `terminal_states` order.
-- Issues with no matching state label and native state `open` are treated as having the
-  first `active_states` entry (e.g., `"backlog"`).
-- Issues with native state `closed` and no matching terminal label are treated as having
-  the first `terminal_states` entry (e.g., `"done"`).
+- It scans the issue's labels against the configured state lists and returns the first match.
+- An issue whose native state is `open` and which carries no matching label takes the first
+  `active_states` entry, for example `"backlog"`.
+- An issue whose native state is `closed` and which carries no matching terminal label takes
+  the first `terminal_states` entry, for example `"done"`.
 
 ### Label hygiene
 
-The adapter does not create labels automatically. The repository must have the state labels
-pre-created before Sortie starts. If a configured state label does not exist in the
-repository, `TransitionIssue` fails with `tracker_payload_error`.
-
-Rationale: automatic label creation requires administrator permissions and could conflict
-with existing repository conventions.
+The adapter creates no labels. `TransitionIssue` and `AddLabel` only attach names through the
+labels-add route, so the repository is expected to carry the state labels before Sortie starts.
+Automatic creation would need broader permissions and would write into a namespace the
+repository's own conventions own. Whether GitHub rejects a label name that does not exist in
+the repository is an [open question](#open-questions); a rejection arrives as HTTP 422, which
+`classifyHTTPError` maps to `tracker_payload_error`.
 
 ---
 
 ## Field mapping
 
-`domain.Issue` field → GitHub REST response path:
+`domain.Issue` field to GitHub REST response path, as implemented by `normalizeIssue` and
+`qualifyDisplayID`:
 
-| `domain.Issue` field | GitHub field                      | Notes                                               |
-| -------------------- | --------------------------------- | --------------------------------------------------- |
-| `ID`                 | `id` (integer)                    | Global numeric ID, convert to string                 |
-| `Identifier`         | `number` (integer)                | Repo-scoped, convert to string, e.g. `"299"`        |
-| `Title`              | `title`                           |                                                      |
-| `Description`        | `body`                            | Markdown. Empty string when missing or null. No flattening needed |
-| `Priority`           | —                                 | GitHub has no native priority. See note below        |
-| `State`              | Label-derived                     | See State mapping section                            |
-| `BranchName`         | —                                 | Not available in issue response. See note below      |
-| `URL`                | `html_url`                        | Directly available, no construction needed           |
-| `Labels`             | `labels[].name`                   | Lowercase each per [Section 11.3](architecture/11-issue-tracker-integration-contract.md#113-normalization-rules)                      |
-| `Assignee`           | `assignees[0].login`              | Empty array → empty string. Uses `login`, not `displayName`. The singular `assignee` field was removed in API version `2026-03-10`; use the `assignees` array |
-| `IssueType`          | `type.name`                       | GitHub issue types (if configured). See note below   |
-| `Parent`             | `GET .../issues/{n}/parent`       | Separate endpoint. 404 → nil                        |
-| `Comments`           | Separate endpoint                 | Markdown body, no flattening                         |
-| `BlockedBy`          | `GET .../issues/{n}/dependencies/blocked_by` | Separate endpoint. See note below    |
-| `CreatedAt`          | `created_at` (ISO-8601)           |                                                      |
-| `UpdatedAt`          | `updated_at` (ISO-8601)           |                                                      |
+| `domain.Issue` field | GitHub field | Notes |
+| -------------------- | ------------ | ----- |
+| `ID`                 | `number` (integer) | Converted to string. GitHub's global `id` is never read |
+| `Identifier`         | `number` (integer) | The same value as `ID`, for example `"299"` |
+| `DisplayID`          | Constructed        | `owner/repo#N`, set by `qualifyDisplayID`, which does not overwrite a value already present |
+| `Title`              | `title`            | |
+| `Description`        | `body`             | Markdown. Empty string when null or missing. No flattening |
+| `Priority`           | Not populated      | GitHub issues carry no priority field. See [Priority](#priority) |
+| `State`              | Label-derived      | See [State mapping](#state-mapping) |
+| `BranchName`         | Not populated      | The issue payload carries no branch reference |
+| `URL`                | `html_url`         | Used directly, no construction |
+| `Labels`             | `labels[].name`    | Lowercased by `issuekit.NormalizeLabels` per [Section 11.3](architecture/11-issue-tracker-integration-contract.md#113-normalization-rules) |
+| `Assignee`           | `assignees[0].login` | Empty array yields the empty string. Uses `login`, not a display name. The singular `assignee` field is absent under the pinned version (see [Pinned API version](#pinned-api-version)) |
+| `IssueType`          | `type.name`        | See [IssueType](#issuetype-via-the-type-field) |
+| `Parent`             | `GET .../issues/{n}/parent` | See [Parent](#parent-via-the-sub-issues-route) |
+| `Comments`           | `GET .../issues/{n}/comments` | Markdown body, no flattening. Populated only by `FetchIssueByID` and `FetchIssueComments` |
+| `BlockedBy`          | `GET .../issues/{n}/dependencies/blocked_by` | See [BlockedBy](#blockedby-via-the-dependencies-route) |
+| `CreatedAt`          | `created_at` (ISO-8601) | |
+| `UpdatedAt`          | `updated_at` (ISO-8601) | |
 
 ### Priority
 
-GitHub issues have no built-in priority field. Options:
+GitHub issues have no built-in priority field, and `normalizeIssue` leaves
+`domain.Issue.Priority` at nil, which the domain reads as "no numeric priority". Priority
+labels such as `priority:1` reach the domain through `Labels` like any other label.
 
-- **Labels:** Use priority labels (e.g., `priority:1`, `priority:critical`). The adapter
-  could parse a numeric suffix from labels matching a configured prefix. Not in initial
-  implementation.
-- **Return nil.** The simplest approach. `domain.Issue.Priority` is `*int` and nil
-  indicates non-numeric priority.
+### `IssueType` via the `type` field
 
-Initial implementation: return nil. Priority-from-labels is a future enhancement.
-
-### BranchName
-
-Not available in the issues REST API response. A linked branch could be discovered via
-the timeline events endpoint (`GET /repos/{owner}/{repo}/issues/{issue_number}/timeline`)
-by looking for `cross-referenced` events from pull requests, or via the Git references
-API. Not required for initial implementation.
-
-### IssueType via `type` field
-
-GitHub's issue types feature (available in organizations) returns a `type` object on
-issues:
+GitHub's issue types feature, available in organizations, returns a `type` object on an issue:
 
 ```json
 {
@@ -306,54 +364,55 @@ issues:
 }
 ```
 
-The adapter maps `type.name` to `domain.Issue.IssueType`. When `type` is null (individual
-user repos or organizations without issue types configured), the adapter returns an empty
-string.
+The adapter maps `type.name` to `domain.Issue.IssueType`. When `type` is null, which is the
+case for personal repositories and for organizations that have not configured issue types, the
+field is the empty string.
 
-### BlockedBy via dependencies API
-
-GitHub provides a first-class dependencies endpoint:
+### `BlockedBy` via the dependencies route
 
 ```
 GET /repos/{owner}/{repo}/issues/{issue_number}/dependencies/blocked_by
 ```
 
-Returns a JSON array of issue objects that block the queried issue. The adapter extracts
-`number` (as string) from each blocking issue to populate `domain.BlockerRef.Identifier`,
-and `id` (as string) to populate `domain.BlockerRef.ID`.
+The route returns a JSON array of full issue objects that block the queried issue. A live call
+against `sortie-ai/sortie` issue #218 returns issue #299 as a blocker.
 
-Verified: `GET /repos/sortie-ai/sortie/issues/218/dependencies/blocked_by` returns
-issue #299 as a blocker (JSON array of full issue objects).
+`normalizeBlockers` sets both `domain.BlockerRef.ID` and `domain.BlockerRef.Identifier` to the
+blocking issue's `number` as a string, and derives `domain.BlockerRef.State` from the blocker's
+own labels with the same rule the issue read uses. A 404 on this route normalizes to an empty
+blocker list, not an error.
 
-This is significantly simpler than Jira's `issuelinks` parsing. No link-type matching or
-directional filtering required.
+This is simpler than Jira's `issuelinks` parsing: no link-type matching and no directional
+filtering.
 
-### Parent via sub-issues API
-
-GitHub provides a parent endpoint:
+### `Parent` via the sub-issues route
 
 ```
 GET /repos/{owner}/{repo}/issues/{issue_number}/parent
 ```
 
-Returns the parent issue object or `404` if no parent is set. The adapter maps:
-- `parent.id` → `domain.ParentRef.ID` (as string)
-- `parent.number` → `domain.ParentRef.Identifier` (as string)
-
-Verified: returns `404` for issues without a parent assignment.
+The route returns the parent issue object, or `404` when the issue has no parent, verified live
+against an issue with no parent assignment. `fetchParent` maps a 404 to a nil `Parent` and sets
+both `domain.ParentRef.ID` and `domain.ParentRef.Identifier` to the parent's `number` as a
+string.
 
 ---
 
 ## Pagination
 
-### Issues endpoint (`GET /repos/{owner}/{repo}/issues`), Link header
+### `Link` header, list routes
 
-GitHub uses `Link` header-based pagination for list endpoints.
+GitHub paginates list routes with the `Link` response header, and every list read in the
+adapter goes through `httpkit.NewLinkPaginator`.
 
-- Set `per_page=50` ([architecture Section 11.2](architecture/11-issue-tracker-integration-contract.md#112-query-semantics) default, max `100`).
-- Parse the `Link` response header for the URL with `rel="next"`.
-- Stop when no `rel="next"` link is present.
-- The `rel="last"` link indicates total pages but is not needed for iteration.
+- Page size is `50` on the tracker routes
+  ([architecture Section 11.2](architecture/11-issue-tracker-integration-contract.md#112-query-semantics)
+  default, GitHub's maximum is `100`) and `100` on the SCM and CI routes.
+- The paginator parses the `rel="next"` URL and follows it verbatim rather than reconstructing
+  the query, because GitHub may change the URL structure or add parameters.
+- Iteration stops when no `rel="next"` link is present. The `rel="last"` link reports the page
+  count and is only needed by `ListLabelEvents`, which walks the journal backward from the last
+  page through `rel="prev"`.
 
 Example `Link` header:
 
@@ -362,183 +421,167 @@ Example `Link` header:
 <https://api.github.com/repos/owner/repo/issues?page=5&per_page=50>; rel="last"
 ```
 
-The adapter must use the full URL from the `Link` header for subsequent requests, not
-construct URLs manually. GitHub may change URL structure or add query parameters.
+Every walk is bounded, and reaching the bound logs a warning and returns what was collected:
 
-### Search endpoint (`GET /search/issues`), page-based
+| Reader | Page cap | Constant |
+| ------ | -------- | -------- |
+| Tracker list routes | 200 (10,000 issues at 50 per page) | `maxPages` |
+| Reviews and review comments | 20 | `maxReviewPages` |
+| Label events | 20 | `maxLabelEventPages` |
+| Combined status and check runs | 10 | `maxCIPages` |
 
-- Uses `page` and `per_page` query parameters.
-- Maximum 1,000 results total (GitHub hard limit on search results).
-- Response includes `total_count` and `incomplete_results` flag.
-- When `incomplete_results` is `true`, results may be missing. Log a warning.
-- Parse `Link` header the same way as the issues endpoint.
+### Search route
 
-### Comments endpoint, page-based
-
-Same `Link` header pattern. `per_page=50`, follow `rel="next"`.
+- `GET /search/issues` takes `page` and `per_page`, and emits the same `Link` header.
+- GitHub caps search results at 1,000 total.
+- The response carries `total_count` and `incomplete_results`. The adapter logs a warning when
+  `incomplete_results` is true and keeps the partial page.
 
 ---
 
 ## Rate limiting
 
-GitHub enforces multiple independent rate limiting systems.
+GitHub enforces several independent rate-limit systems.
 
-### Primary rate limit (per-hour)
+### Primary limit, per hour
 
-| Authentication method     | Limit            |
-| ------------------------- | ---------------- |
-| Fine-grained PAT          | 5,000 req/hour   |
-| Classic PAT               | 5,000 req/hour   |
-| `GITHUB_TOKEN`            | 1,000 req/hour   |
-| GitHub App installation   | 5,000–12,500 req/hour |
-| Unauthenticated           | 60 req/hour      |
+| Authentication method     | Limit                    |
+| ------------------------- | ------------------------ |
+| Fine-grained PAT          | 5,000 req/hour           |
+| Classic PAT               | 5,000 req/hour           |
+| `GITHUB_TOKEN`            | 1,000 req/hour           |
+| GitHub App installation   | 5,000 to 12,500 req/hour |
+| Unauthenticated           | 60 req/hour              |
 
-Resets on a rolling 1-hour window. Response headers on every request:
+The window rolls over one hour. Every response carries:
 
-| Header                  | Value                                |
-| ----------------------- | ------------------------------------ |
-| `x-ratelimit-limit`    | Maximum requests in the window       |
-| `x-ratelimit-remaining`| Remaining requests                   |
-| `x-ratelimit-used`     | Requests consumed                    |
-| `x-ratelimit-reset`    | Unix epoch timestamp of window reset |
-| `x-ratelimit-resource` | Resource category (e.g., `core`, `search`) |
+| Header                  | Value                                       |
+| ----------------------- | ------------------------------------------- |
+| `x-ratelimit-limit`     | Maximum requests in the window              |
+| `x-ratelimit-remaining` | Remaining requests                          |
+| `x-ratelimit-used`      | Requests consumed                           |
+| `x-ratelimit-reset`     | Unix epoch timestamp of the window reset    |
+| `x-ratelimit-resource`  | Resource category, for example `core` or `search` |
 
-### Search rate limit (per-minute)
+### Search limit, per minute
 
-The search endpoint has a separate, stricter rate limit:
+The search route has its own, stricter budget: 30 requests/minute authenticated, 10
+unauthenticated. Verified live: `GET /search/issues` with PAT authentication returns
+`x-ratelimit-limit: 30` and `x-ratelimit-resource: search`.
 
-- **Authenticated:** 30 requests/minute
-- **Unauthenticated:** 10 requests/minute
+Search and core budgets are separate, which is why `FetchCandidateIssues` stays on the issues
+route whenever `query_filter` is unset.
 
-Verified: `x-ratelimit-limit: 30` and `x-ratelimit-resource: search` on
-`GET /search/issues` with PAT authentication.
+### GraphQL limit
 
-The adapter must track search rate limits separately from core rate limits. When
-`query_filter` is not configured, prefer the issues endpoint to avoid consuming the
-scarce search budget.
+GraphQL calls draw on a budget separate from the REST limit. `GetReviewDecision` costs one
+GraphQL request per call, and `GetMergeability` costs one more per merged pull request.
 
-### Secondary rate limits (concurrency and points)
+### Secondary limits
 
-GitHub enforces secondary limits that are not tied to the per-hour quota:
+Secondary limits are independent of the per-hour quota:
 
-- **Concurrency:** No more than 100 concurrent requests.
-- **Points:** No more than 900 points/minute for REST API calls. GET requests to
-  non-mutating endpoints cost 1 point; mutating requests cost more.
-- **Content creation:** No more than 80 content-generating requests/minute and 500/hour
-  (e.g., creating issues, comments).
+- Concurrency: no more than 100 concurrent requests.
+- Points: no more than 900 points/minute for REST calls. A GET against a non-mutating endpoint
+  costs 1 point; a mutating request costs more.
+- Content creation: no more than 80 content-generating requests/minute and 500/hour, for
+  example creating issues or comments.
 
-Secondary limits return `403 Forbidden` or `429 Too Many Requests` with a `Retry-After`
-header. When the status is `403`, the response body contains
-`"You have exceeded a secondary rate limit"`.
+A secondary limit returns `403` or `429` with a `Retry-After` header. On a `403` the response
+body contains `"You have exceeded a secondary rate limit"`.
 
-### Conditional requests (ETag / Last-Modified)
+### Conditional requests
 
-GitHub returns `ETag` and `Last-Modified` headers on responses. The adapter should cache
-these and send `If-None-Match` (or `If-Modified-Since`) on subsequent requests for the
-same resource.
+GitHub returns `ETag` and `Last-Modified` on responses, and honors `If-None-Match` and
+`If-Modified-Since`. A `304 Not Modified` does not count against the primary rate limit,
+verified live: consecutive requests with `If-None-Match` return `304` and `x-ratelimit-used`
+does not increment. `fetchStatesByNumbers` is the only reader that uses this.
 
-- `304 Not Modified` responses do **not** count against the primary rate limit.
-- Verified: consecutive requests with `If-None-Match` return `304` and
-  `x-ratelimit-used` does not increment.
+### Detection and handling
 
-This is valuable for `FetchIssueStatesByIDs` where the same issues are polled
-repeatedly during reconciliation.
+| Status | Condition           | Detection                                                     |
+| ------ | ------------------- | ------------------------------------------------------------- |
+| `403`  | Primary limit hit   | `x-ratelimit-remaining` is `0`                                |
+| `403`  | Secondary limit hit | Body contains `rate limit`; `Retry-After` present             |
+| `429`  | Either limit hit    | `Retry-After` present                                         |
 
-### 429 and 403 handling
-
-| Status | Condition           | Detection                                                       |
-| ------ | ------------------- | --------------------------------------------------------------- |
-| `403`  | Primary limit hit   | `x-ratelimit-remaining` is `0`                                  |
-| `429`  | Primary limit hit   | `Retry-After` header present                                    |
-| `403`  | Secondary limit hit | Body contains `"secondary rate limit"`; `Retry-After` present   |
-| `429`  | Secondary limit hit | `Retry-After` header present; no `x-ratelimit-remaining: 0`     |
-
-**Adapter guidance:** Respect `Retry-After` as minimum delay. Apply exponential backoff
-with jitter (base 2s, max 60s, jitter ±30%). Map both to `tracker_api_error` with the
-`Retry-After` value preserved for the orchestrator's retry logic.
+`classifyHTTPError` checks the `X-Ratelimit-Remaining` header first, then the lower-cased body
+for `rate limit`, and maps both to `tracker_api_error`. The `Retry-After` value is appended to
+the error message and is not carried in a structured field. The adapter itself does not sleep
+or retry: retry backoff belongs to the orchestrator, per
+[architecture Section 11.4](architecture/11-issue-tracker-integration-contract.md#114-error-categories).
 
 ---
 
-## Error mapping
+## Tracker error mapping
 
-HTTP status → error category:
+`classifyHTTPError` (`internal/scm/github/client.go`) reads at most 512 bytes of the response
+body as a diagnostic snippet, never echoing the token, and maps status to
+`domain.TrackerErrorKind`:
 
-| HTTP Status | Condition                        | Error Category            |
-| ----------- | -------------------------------- | ------------------------- |
-| 200–204     | Success                          | —                         |
-| 304         | Not Modified (conditional)       | — (use cached data)       |
-| 400         | Bad request (malformed query)    | `tracker_payload_error`   |
-| 401         | Bad credentials / expired token  | `tracker_auth_error`      |
-| 403         | Insufficient permissions         | `tracker_auth_error`      |
-| 403         | Secondary rate limit             | `tracker_api_error`       |
-| 404         | Issue/resource not found         | `tracker_api_error`       |
-| 410         | Resource permanently gone        | `tracker_api_error`       |
-| 422         | Validation failed (e.g., bad label) | `tracker_payload_error` |
-| 429         | Primary rate limit exceeded      | `tracker_api_error`       |
-| 5xx         | Server error                     | `tracker_transport_error` |
-| TCP/DNS     | Network failure                  | `tracker_transport_error` |
-| —           | JSON decode failure on 200       | `tracker_payload_error`   |
+| HTTP status | Condition                           | Error kind                |
+| ----------- | ----------------------------------- | ------------------------- |
+| 200 to 204  | Success                             | none                      |
+| 304         | Not modified (conditional request)  | none; cached state is reused |
+| 400         | Bad request, malformed query        | `tracker_payload_error`   |
+| 401         | Bad credentials or expired token    | `tracker_auth_error`      |
+| 403         | Insufficient permissions            | `tracker_auth_error`      |
+| 403         | Primary or secondary rate limit     | `tracker_api_error`       |
+| 404         | Issue or resource not found         | `tracker_not_found`       |
+| 405         | Method not allowed                  | `tracker_api_error`       |
+| 409         | Conflict                            | `tracker_api_error`       |
+| 410         | Resource permanently gone           | `tracker_api_error`       |
+| 422         | Validation failed, for example an unusable label | `tracker_payload_error` |
+| 429         | Rate limit exceeded                 | `tracker_api_error`       |
+| 5xx         | Server error                        | `tracker_transport_error` |
+| network     | DNS, TCP, or TLS failure            | `tracker_transport_error` |
+| payload     | JSON decode failure on a 2xx        | `tracker_payload_error`   |
+| other       | Any unlisted status                 | `tracker_api_error`       |
 
-**403 disambiguation:** The adapter distinguishes secondary rate limits (body contains
-`"rate limit"`) from permission errors (body contains `"Resource not accessible"` or
-other messages) by inspecting the response body. Rate limit 403s map to
-`tracker_api_error`; permission 403s map to `tracker_auth_error`.
-
----
-
-## Config notes
-
-- **`tracker.api_key` format:** Single PAT token string (not `email:token` like Jira).
-  The adapter passes it directly as a Bearer token.
-- **`tracker.endpoint`:** Defaults to `https://api.github.com`. Override for GitHub
-  Enterprise Server (e.g., `https://github.example.com/api/v3`). No trailing slash.
-- **`tracker.project`:** `owner/repo` format. The adapter validates the format (exactly
-  one `/`) at startup and rejects invalid values.
-- **`tracker.active_states`:** Label names representing active states.
-  Example: `["backlog", "in-progress", "review"]`.
-- **`tracker.terminal_states`:** Label names representing terminal states.
-  Example: `["done", "wontfix"]`.
-- **`tracker.handoff_state`:** Label name for the post-run handoff state.
-  Example: `"review"`. Per ADR-0007.
-- **`tracker.query_filter`:** Optional GitHub search qualifier string appended to
-  the search query. Example: `label:sortie-managed milestone:"Sprint 1"`.
-  When set, the adapter uses `GET /search/issues` instead of `GET /repos/.../issues`.
-- **Network timeout:** 30,000 ms per [architecture Section 11.2](architecture/11-issue-tracker-integration-contract.md#112-query-semantics).
-- **API version header:** The adapter must send `X-GitHub-Api-Version: 2026-03-10` on
-  every request. This pins behavior to the latest supported version and prevents
-  breakage from future API evolution. This version also removes `head.repo.has_downloads`
-  and `base.repo.has_downloads` from the pull request read and `use_squash_pr_title_as_default`
-  from the repository read; the adapter does not read any of these three fields. The prior
-  version, `2022-11-28`, remains supported until March 10, 2028.
-- **User-Agent header:** The adapter must send a `User-Agent` header identifying the
-  application, for example `Sortie/<version>`.
+**403 disambiguation.** A 403 is a rate limit when `X-Ratelimit-Remaining` is `0` or the body
+mentions `rate limit`, and a permission failure otherwise. The two map to different kinds, so
+the distinction changes how the orchestrator treats the failure.
 
 ---
 
-## SCM write surface
+## SCM adapter surface
 
-The `SCMAdapter` interface (per `internal/domain/scm.go`) is implemented by
-`internal/scm/github/`. The package exposes the six methods listed in
-[architecture §11C.1](architecture/14-auto-merge-reaction-contract.md#11c1-scmadapter-write-surface): one read-only method documented in [§11B.1](architecture/13-pr-review-comment-feedback-contract.md#11b1-scmadapter-interface)
-(`FetchPendingReviews`) and five additional methods used by the auto-merge
-reconcile loop. The five methods below extend the surface beyond the seven
-tracker operations covered earlier in this document.
+`GitHubSCMAdapter` (`internal/scm/github/review.go`) implements the nine methods of
+`domain.SCMAdapter`. `FetchPendingReviews` is specified in
+[architecture §11B.1](architecture/13-pr-review-comment-feedback-contract.md#11b1-scmadapter-interface),
+the five auto-merge methods in
+[§11C.1](architecture/14-auto-merge-reaction-contract.md#11c1-scmadapter-write-surface), and
+the remaining three by the reaction kinds that use them.
 
-All implementations are safe for concurrent use. SCM errors are normalized to
-`*domain.SCMError` with a `SCMErrorKind` drawn from the six values in
-`internal/domain/scm.go`. Network and HTTP classification is shared with the
-tracker adapter via `internal/httpkit` and the `classifyHTTPError` helper in
-`internal/scm/github/client.go`; `scmcore.ToSCMError` remaps the result into
-the SCM error namespace and performs no conflict promotion of its own. The
-405/409 promotion to `ErrSCMConflict` is a separate step, applied by
-`scmcore.AsMergeConflict` only to the error `MergePR` gets back from the
-merge write call.
+| Method | Route | Go symbol |
+| ------ | ----- | --------- |
+| `FetchPendingReviews` | `GET /repos/{o}/{r}/pulls/{n}/reviews` and `.../pulls/{n}/comments` | `FetchPendingReviews` |
+| `FetchBotReviewComments` | The same two routes | `FetchBotReviewComments` |
+| `GetReviewDecision` | `POST /graphql` | `GetReviewDecision` |
+| `GetCIStatus` | `GET .../pulls/{n}`, `.../commits/{sha}/status`, `.../commits/{sha}/check-runs` | `GetCIStatus` |
+| `GetMergeability` | `GET .../pulls/{n}` plus one gated `POST /graphql` | `GetMergeability` |
+| `MergePR` | `PUT .../pulls/{n}/merge` | `MergePR` |
+| `DeleteBranch` | `DELETE .../git/refs/heads/{branch}` | `DeleteBranch` |
+| `ListLabelEvents` | `GET .../issues/{n}/events` | `ListLabelEvents` |
+| `RemoveLabel` | `DELETE .../issues/{n}/labels/{name}` | `RemoveLabel` |
+
+All implementations are safe for concurrent use. SCM errors are normalized to `*domain.SCMError`
+with a `SCMErrorKind` drawn from the six values in `internal/domain/scm.go`. Network and HTTP
+classification is shared with the tracker adapter through `internal/httpkit` and
+`classifyHTTPError`; `scmcore.ToSCMError` remaps the result into the SCM error namespace and
+performs no conflict promotion of its own. The 405 and 409 promotion to `ErrSCMConflict` is a
+separate step that `scmcore.AsMergeConflict` applies only to the error `MergePR` gets back from
+the merge write call.
+
+GraphQL requests go to a second `httpkit.Client` whose base URL comes from `graphqlBasePath`.
+For `github.com` that resolves to `https://api.github.com/graphql`. For a GHES endpoint ending
+in `/api/v3`, the `/v3` suffix is stripped so the request lands on `/api/graphql`.
 
 ### 1. `GetReviewDecision` (GraphQL `pullRequest.reviewDecision`)
 
-Returns the platform's authoritative review decision for a PR. Issues a
-GraphQL POST rather than a REST call because the four-valued enum is exposed
-only on the GraphQL `PullRequest` type.
+Returns the platform's authoritative review decision for a pull request. This is a GraphQL POST
+rather than a REST call because the four-valued enum is exposed only on the GraphQL
+`PullRequest` type.
 
 ```
 POST /graphql
@@ -556,33 +599,32 @@ Content-Type: application/json
 }
 ```
 
-Response shape (subset):
+Response shape, subset:
 
 ```json
 { "data": { "repository": { "pullRequest": { "reviewDecision": "APPROVED" } } } }
 ```
 
-Mapping from GraphQL value to `domain.ReviewDecision`:
+`mapReviewDecision` (`internal/scm/github/graphql.go`) maps the value:
 
-| GraphQL value       | Domain value                          |
-| ------------------- | ------------------------------------- |
-| `APPROVED`          | `ReviewDecisionApproved`              |
-| `CHANGES_REQUESTED` | `ReviewDecisionChangesRequested`      |
-| `REVIEW_REQUIRED`   | `ReviewDecisionReviewRequired`        |
-| `null` (no policy)  | `ReviewDecisionNotRequired`           |
-| Unknown enum value  | `ReviewDecisionNotRequired` (logs warn) |
+| GraphQL value       | Domain value                            |
+| ------------------- | --------------------------------------- |
+| `APPROVED`          | `ReviewDecisionApproved`                |
+| `CHANGES_REQUESTED` | `ReviewDecisionChangesRequested`        |
+| `REVIEW_REQUIRED`   | `ReviewDecisionReviewRequired`          |
+| `null` (no policy)  | `ReviewDecisionNotRequired`             |
+| Unknown enum value  | `ReviewDecisionNotRequired`, logged at warn |
 
-Idempotent and read-only: repeated calls return the current decision and do
-not mutate platform state. Errors route through `scmcore.ToSCMError` like
-every other read, which never promotes a status to `ErrSCMConflict`; only
-`MergePR` calls `scmcore.AsMergeConflict`, so this read path cannot produce
-that kind and needs no exemption from it.
+A 200 response carrying a non-empty `errors` array becomes `ErrSCMAPI` with the joined error
+messages. A missing `pullRequest` payload becomes `ErrSCMPayload`.
 
-### 2. `GetCIStatus` (combined status + check runs)
+Idempotent and read-only: repeated calls return the current decision and mutate nothing.
+Errors route through `scmcore.ToSCMError`, which never promotes a status to `ErrSCMConflict`.
 
-Returns an aggregate CI conclusion string for the PR head commit. The
-adapter first reads the PR object to obtain the head SHA, then queries two
-additional commit-scoped endpoints in sequence, three calls in total:
+### 2. `GetCIStatus` (combined status plus check runs)
+
+Returns an aggregate CI conclusion string for the pull request head commit. The adapter reads
+the pull request object for the head SHA, then walks two commit-scoped page sequences:
 
 ```
 GET /repos/{owner}/{repo}/pulls/{prNumber}
@@ -590,28 +632,58 @@ GET /repos/{owner}/{repo}/commits/{headSHA}/status
 GET /repos/{owner}/{repo}/commits/{headSHA}/check-runs
 ```
 
-The first call returns the head SHA from `head.sha`. The second returns the
-combined commit-status payload (`{ "state": "...", "statuses": [...] }`).
-The third returns the check-runs payload (`{ "total_count": N, "check_runs":
-[...] }`).
+That is three requests when neither list paginates, and more when either does: both walks use
+`httpkit.NewPagePaginator` with `per_page=100` and a 10-page cap. A pull request payload with
+no `head.sha` fails the read with `ErrSCMPayload`.
 
-The aggregate is computed from both signals:
+The combined-status payload is `{ "state": "...", "statuses": [...] }` and the check-runs
+payload is `{ "total_count": N, "check_runs": [...] }`. The adapter reads only the arrays; it
+does not key on the top-level `state` or on `total_count`.
 
-| Observation                                                 | Returned conclusion |
-| ----------------------------------------------------------- | ------------------- |
-| No statuses and no check runs                               | `""` (no signal)    |
-| Any failing status (`failure`, `error`) or check conclusion (`failure`, `timed_out`, `cancelled`, `action_required`) | `"failing"`         |
-| At least one pending status or check (`pending`, `in_progress`, `queued`) and none failing | `"pending"`         |
-| All passing or non-failing (`success`, `neutral`, `skipped`) | `"success"`         |
+The two routes use different vocabularies for the same underlying gate, so each has its own
+mapping into `domain.CheckRun`:
 
-Idempotent and read-only. The empty-string return signals "no required
-checks exist on the PR" and the auto-merge loop treats it as a satisfied
-CI precondition when `require_ci` is not set.
+| Source | Wire value | Normalized conclusion |
+| ------ | ---------- | --------------------- |
+| Combined status | `success` | success (completed) |
+| Combined status | `failure`, `error` | failure (completed) |
+| Combined status | anything else, including `pending` and the empty string | pending (in progress) |
+| Check run | `success` | success |
+| Check run | `failure`, `action_required` | failure |
+| Check run | `cancelled` | cancelled |
+| Check run | `timed_out` | timed out |
+| Check run | `neutral`, `skipped` | neutral, skipped |
+| Check run | `stale`, null, anything else | pending |
+
+`action_required` is a failure because it asks for a manual UI action the agent cannot
+perform. `stale` is pending because the check run that superseded it carries the authoritative
+conclusion.
+
+`scmcore.MergeGate` then reduces the combined set to one string:
+
+| Observation | Returned conclusion |
+| ----------- | ------------------- |
+| No statuses and no check runs | `""` (no signal) |
+| Any run whose conclusion is failure, timed out, or cancelled | `"failing"` |
+| Every run reports completed status and none failed | `"success"` |
+| Anything else | `"pending"` |
+
+Idempotent and read-only. The empty string means "no required checks exist on this pull
+request", and the auto-merge loop treats it as a satisfied CI precondition when `require_ci` is
+not set.
+
+`GitHubCIProvider.FetchCIStatus` (`internal/scm/github/ci.go`) reads the same check-runs route
+through the same normalization helpers (`mapCheckRunStatus`, `mapCheckConclusion`), reduces it
+with `scmcore.AggregateCIStatus` instead of `scmcore.MergeGate`, and additionally pulls a log
+tail from `GET /repos/{owner}/{repo}/actions/jobs/{check_run_id}/logs` for the first failing
+GitHub Actions check. GitHub Actions creates check runs 1:1 with workflow jobs, so the check
+run id doubles as the job id on that route. Neither reader sends the `filter` parameter, so
+GitHub's default applies; see [Open questions](#open-questions).
 
 ### 3. `GetMergeability` (pull request preview)
 
-Returns the merge precondition state for a PR. Reuses the same pull request
-read used by `GetCIStatus`:
+Returns the merge precondition state. It reuses `fetchPullRequest`, the same read
+`GetCIStatus` performs:
 
 ```
 GET /repos/{owner}/{repo}/pulls/{prNumber}
@@ -625,7 +697,7 @@ Response subset:
   "base": { "ref": "<baseBranch>" } }
 ```
 
-The adapter maps `mergeable_state` to `domain.MergeabilityState`:
+`mapMergeableState` maps the state onto `domain.MergeabilityState`:
 
 | GitHub `mergeable_state` | Domain `MergeabilityState` |
 | ------------------------ | -------------------------- |
@@ -633,21 +705,20 @@ The adapter maps `mergeable_state` to `domain.MergeabilityState`:
 | `unstable`               | `MergeabilityUnstable`     |
 | `blocked`, `behind`, `draft` | `MergeabilityBlocked`  |
 | `dirty`                  | `MergeabilityDirty`        |
-| anything else (including the empty string) | `MergeabilityUnknown` |
+| anything else, including the empty string | `MergeabilityUnknown` |
 
-The returned `PRMergeStatus` populates `Draft`, `Mergeability`, `HeadSHA`, `BranchName`,
-`BaseBranch` (from `base.ref`), and `Merged` (from `merged`) from this REST read, unchanged.
-`ReviewDecision` and `CIConclusion` are left unset: callers obtain those values from the
-dedicated reads (see §1 and §2 above). GitHub computes `mergeable_state` asynchronously after
-a push, so callers treat `MergeabilityUnknown` as a deferral condition per
+The returned `PRMergeStatus` takes `Draft`, `Mergeability`, `HeadSHA`, `BranchName`,
+`BaseBranch` (from `base.ref`), and `Merged` from this REST read unchanged. `ReviewDecision`
+and `CIConclusion` are left unset: callers obtain those from the dedicated reads above. GitHub
+computes `mergeable_state` asynchronously after a push, so callers treat
+`MergeabilityUnknown` as a deferral condition per
 [§11C.5](architecture/14-auto-merge-reaction-contract.md#11c5-merge-precondition-state-machine).
 
-API version `2026-03-10` removes `merge_commit_sha` from pull request payloads across every
-endpoint that returns a pull request object, the same version that removed `Assignee`. Because
-the adapter pins `2026-03-10` on every request, the response never carries `merge_commit_sha`.
-
-`MergeCommitSHA` is instead sourced from a second, gated GraphQL call. When the REST read
-reports `merged: true`, the adapter issues one `POST /graphql` carrying a pinned query:
+**The merge commit identifier comes from GraphQL.** The pinned API version returns no
+`merge_commit_sha` on any pull request payload (see
+[Pinned API version](#pinned-api-version)), so `MergeCommitSHA` is sourced from a second,
+gated call. When the REST read reports `merged: true`, `fetchMergeCommitOID` issues one
+`POST /graphql` carrying a query pinned by a request-shape unit test:
 
 ```graphql
 query($owner: String!, $repo: String!, $number: Int!) {
@@ -662,24 +733,22 @@ query($owner: String!, $repo: String!, $number: Int!) {
 ```
 
 The query requests only `mergeCommit { oid }`, never `potentialMergeCommit`, so GitHub's
-test-merge commit cannot enter `MergeCommitSHA` through this path. The call is gated on
-`merged: true`: an open, draft, or closed-unmerged pull request costs no GraphQL request and
-`MergeCommitSHA` stays the empty string. A merged pull request whose `mergeCommit` field is
-null (no commit reported) also yields `MergeCommitSHA` as the empty string, with no error.
-A GraphQL failure on this call fails the whole `GetMergeability` read.
+test-merge commit is structurally unreachable through this path. The `merged: true` gate bounds
+the extra request: an open, draft, or closed-unmerged pull request costs no GraphQL call and
+leaves `MergeCommitSHA` empty. A merged pull request whose `mergeCommit` field is null also
+yields the empty string, with no error. A GraphQL failure on this call fails the whole
+`GetMergeability` read.
 
-The added cost is one GraphQL POST per merged pull request per `GetMergeability` call, measured
-at 1 point against the GraphQL rate limit, which is a budget separate from the REST rate limit
-consumed by the pull request read above. A deployment that configures `reactions.merge_completion`
-without also configuring `auto_merge` now needs a token that can read the GitHub GraphQL API,
-a requirement `GetReviewDecision` already imposes but that `GetMergeability` did not previously
-share.
+The cost is one GraphQL POST per merged pull request per call, measured at 1 point against the
+GraphQL rate limit. A deployment that configures `reactions.merge_completion` without
+`auto_merge` therefore needs a token that can read the GitHub GraphQL API, the same requirement
+`GetReviewDecision` imposes.
 
 Idempotent and read-only.
 
 ### 4. `MergePR` (PUT merge)
 
-Performs the merge. Sends:
+Performs the merge:
 
 ```
 PUT /repos/{owner}/{repo}/pulls/{prNumber}/merge
@@ -695,51 +764,46 @@ Content-Type: application/json
 
 Field rules:
 
-- `merge_method` is the only required field. Mapped 1:1 from
-  `domain.MergeStrategy` constant values.
-- `sha`, `commit_title`, and `commit_message` are omitted when the caller
-  passes the empty string (`omitempty`). GitHub then uses the
-  strategy-specific defaults for the commit title and message.
-- When `sha` is present GitHub uses it as a precondition: if the PR head
-  has moved since the caller read it, GitHub returns HTTP 409. The
-  `expectedHeadSHA` parameter is sourced from the latest
-  `PRMergeStatus.HeadSHA` value the caller observed.
+- `merge_method` is the only required field, mapped 1:1 from the `domain.MergeStrategy`
+  constant values.
+- `sha`, `commit_title`, and `commit_message` are omitted when the caller passes the empty
+  string (`omitempty`), and GitHub then applies its strategy-specific defaults for the commit
+  title and message.
+- When `sha` is present GitHub treats it as a precondition: a head that moved since the caller
+  read it returns HTTP 409. `expectedHeadSHA` comes from the latest `PRMergeStatus.HeadSHA` the
+  caller observed.
 
 Response on 200:
 
 ```json
-{ "sha": "<merge_commit_sha>", "merged": true, "message": "Pull Request successfully merged" }
+{ "sha": "<merge commit sha>", "merged": true, "message": "Pull Request successfully merged" }
 ```
 
-The adapter returns a `domain.MergeResult` populated from these fields.
+This `sha` is the merge endpoint's own response field and is unaffected by the pull request
+payload's `merge_commit_sha` removal. `MergePR` populates `domain.MergeResult` from it.
 
-Idempotency: a second `PUT` against a PR already merged by the first call
-returns HTTP 200 with `"merged": true` and the existing merge commit SHA,
-not an error. GitHub short-circuits once a PR is merged: the `sha`
-precondition is no longer evaluated, so a stale or even invalid
-`expectedHeadSHA` still yields 200. The adapter therefore returns a
-successful `domain.MergeResult` (carrying the existing merge commit SHA)
-with a nil error, and the orchestrator's reconcile loop
-(`internal/orchestrator/auto_merge_reconcile.go`) records the duplicate
-merge as success through its normal success path.
+A success response with `"merged": false`, the platform's documented but rare refusal path,
+becomes `*SCMError` with kind `ErrSCMConflict` and message
+`merge endpoint returned merged=false`.
 
-The 405/409 promotion to `ErrSCMConflict`, and the orchestrator's
-`already merged` substring check, are exactly the path GitHub exercises
-when a different actor merges the PR first: GitHub's rejection carries no
-wording saying the pull request was already merged, so `MergePR` re-reads
-the pull request after the rejection and, on a confirmed merge, reports
-the already-merged marker itself (see the already-merged subcase in the
-HTTP status mapping below). The `expectedHeadSHA` precondition, in
-contrast, produces HTTP 409 only while the PR is still open and its head
-has moved.
+**Idempotency.** A second `PUT` against a pull request the first call already merged returns
+HTTP 200 with `"merged": true` and the existing merge commit SHA, not an error. GitHub
+short-circuits once a pull request is merged: it stops evaluating the `sha` precondition, so a
+stale or even invalid `expectedHeadSHA` still yields 200. The adapter returns a successful
+`domain.MergeResult` with a nil error, and the reconcile loop
+(`internal/orchestrator/auto_merge_reconcile.go`) records the duplicate merge as success
+through its normal path.
 
-A success response with `"merged": false` (the platform's documented but
-rare refusal path) is mapped to `*SCMError` with kind `ErrSCMConflict` and
-message `merge endpoint returned merged=false`.
+**The already-merged race.** When a different actor merges the pull request first, GitHub
+rejects the call with a status the promotion covers, and the rejection body carries no wording
+saying the pull request was already merged. `resolveMergeConflict` therefore re-reads the pull
+request after the rejection and, when the re-read confirms `merged: true`, returns the marker
+itself through `scmcore.AlreadyMergedConflict`. The `expectedHeadSHA` precondition, in
+contrast, produces HTTP 409 only while the pull request is still open and its head has moved.
 
 ### 5. `DeleteBranch` (DELETE git ref)
 
-Deletes the source branch after a successful merge. Sends:
+Deletes the source branch after a successful merge:
 
 ```
 DELETE /repos/{owner}/{repo}/git/refs/heads/{branch}
@@ -747,186 +811,128 @@ DELETE /repos/{owner}/{repo}/git/refs/heads/{branch}
 
 No request body. GitHub returns HTTP 204 on success.
 
-Idempotency: an HTTP 404 (branch already gone) maps to
-`*SCMError` with kind `ErrSCMNotFound`. The auto-merge reconcile loop
-treats this as a successful no-op so that a retried delete after a
-partial-failure tail does not block the issue's completion path.
+**Idempotency.** HTTP 404, meaning the branch is already gone, maps to `*SCMError` with kind
+`ErrSCMNotFound`. The auto-merge reconcile loop treats that as a successful no-op, so a retried
+delete after a partial-failure tail does not block the issue's completion path.
 
-GitHub refuses a delete that targets a protected or default branch. The
-documented refusal statuses for this endpoint are HTTP 409 (conflict) and
-HTTP 422 (validation failed); GitHub's reference attributes the
-default-branch case to both, so the adapter must handle either. A 409 maps
-to `ErrSCMConflict` and a 422 maps to `ErrSCMPayload` (see the status table
-below). The auto-merge loop does not target default branches, so either
-status is an operator-configuration error rather than a recoverable runtime
-condition.
+GitHub refuses a delete that targets a protected or default branch. The documented refusal
+statuses for this route are HTTP 409 and HTTP 422, and GitHub's reference attributes the
+default-branch case to both, so the adapter handles either: 409 keeps `ErrSCMAPI` and 422 maps
+to `ErrSCMPayload`. The auto-merge loop never targets a default branch, so either status is an
+operator-configuration error rather than a recoverable runtime condition.
 
 ### HTTP status mapping
 
-The mapping below is the SCM view: each row reports the HTTP status the
-adapter receives and the `SCMErrorKind` it returns. The base classification
-happens in `classifyHTTPError` (`internal/scm/github/client.go`), and
-`scmcore.ToSCMError` remaps the result for the SCM error namespace. The 405
-and 409 rows reflect the merge write path only; every other call keeps the
-`ErrSCMAPI` kind `scmcore.ToSCMError` assigns.
+Each row reports the HTTP status the adapter receives and the `SCMErrorKind` it returns. The
+base classification happens in `classifyHTTPError`, and `scmcore.ToSCMError` remaps the result
+into the SCM namespace. The 405 and 409 rows reflect the merge write path only; every other
+call keeps the kind `scmcore.ToSCMError` assigns.
 
-| HTTP Status | Condition                                          | SCM error kind        |
-| ----------- | -------------------------------------------------- | --------------------- |
-| 200, 204    | Success                                            | (no error)            |
-| 400         | Malformed request                                  | `ErrSCMPayload`       |
-| 401         | Bad credentials or expired token                   | `ErrSCMAuth`          |
-| 403         | Insufficient permissions (non-rate-limit body)     | `ErrSCMAuth`          |
-| 403, 429    | Rate limit (primary or secondary, with `Retry-After` or `X-RateLimit-Remaining: 0` or `rate limit` body) | `ErrSCMAPI` |
-| 404         | Resource not found (PR, branch, ref)               | `ErrSCMNotFound`      |
-| 405         | Method not allowed. On `MergePR` this promotes to `ErrSCMConflict`; every other call keeps `ErrSCMAPI` | `ErrSCMConflict` on `MergePR`, `ErrSCMAPI` elsewhere |
-| 409         | Conflict: head-SHA drift or branch-protection refusal on `MergePR`, or a ref conflict on `DeleteBranch`. Only `MergePR` promotes; `DeleteBranch` and every other call keep `ErrSCMAPI` | `ErrSCMConflict` on `MergePR`, `ErrSCMAPI` elsewhere |
-| 410         | Resource permanently gone                          | `ErrSCMAPI`           |
-| 422         | Validation failed (unsupported `merge_method`, default-branch delete, spam check) | `ErrSCMPayload` |
-| 5xx         | Server error                                       | `ErrSCMTransport`     |
-| network     | DNS, TCP, TLS failure                              | `ErrSCMTransport`     |
-| payload     | JSON decode failure on a 2xx response              | `ErrSCMPayload`       |
+| HTTP status | Condition                                       | SCM error kind      |
+| ----------- | ----------------------------------------------- | ------------------- |
+| 200, 204    | Success                                         | none                |
+| 400         | Malformed request                               | `ErrSCMPayload`     |
+| 401         | Bad credentials or expired token                | `ErrSCMAuth`        |
+| 403         | Insufficient permissions, non-rate-limit body   | `ErrSCMAuth`        |
+| 403, 429    | Rate limit, primary or secondary                | `ErrSCMAPI`         |
+| 404         | Resource not found (pull request, branch, ref)  | `ErrSCMNotFound`    |
+| 405         | Method not allowed                              | `ErrSCMConflict` on `MergePR`, `ErrSCMAPI` elsewhere |
+| 409         | Conflict: head-SHA drift or branch-protection refusal on `MergePR`, a ref conflict on `DeleteBranch` | `ErrSCMConflict` on `MergePR`, `ErrSCMAPI` elsewhere |
+| 410         | Resource permanently gone                       | `ErrSCMAPI`         |
+| 422         | Validation failed: unsupported `merge_method`, default-branch delete, spam check | `ErrSCMPayload` |
+| 5xx         | Server error                                    | `ErrSCMTransport`   |
+| network     | DNS, TCP, or TLS failure                        | `ErrSCMTransport`   |
+| payload     | JSON decode failure on a 2xx response           | `ErrSCMPayload`     |
 
-The 405/409-to-`ErrSCMConflict` promotion is keyed on the originating
-`domain.TrackerError.Status` field, not on the error message text.
-`scmcore.AsMergeConflict` checks that field directly against 405 and 409
-and promotes only on a match; any other error, including one whose message
-happens to mention "conflict", passes through unchanged. `MergePR` is the
-only caller: it applies the promotion to the error the merge PUT call
-returns, and no other GitHub SCM method calls it. A 409 from `DeleteBranch`
-(a ref conflict) therefore keeps `ErrSCMAPI` like the rest of the REST
-surface. Because the promotion never inspects the error message, and the
-GraphQL surface never calls it at all, no exemption for the
-`POST /graphql:` prefix is needed.
+`scmcore.AsMergeConflict` keys the promotion on `domain.TrackerError.Status`, not on message
+text: it compares that field against 405 and 409 and promotes only on a match, so an error
+whose message merely mentions "conflict" passes through unchanged. `MergePR` is its only
+caller, which is why a 409 from `DeleteBranch` keeps `ErrSCMAPI` like the rest of the REST
+surface, and why the GraphQL reads need no exemption from it.
 
-The already-merged 409 subcase is not signaled by GitHub's response body:
-`MergePR` re-reads the pull request after a rejected merge and, when the
-re-read confirms the pull request is merged, returns `ErrSCMConflict` with
-the marker phrase `already merged` in `SCMError.Message` itself. The
-orchestrator inspects the message case-insensitively and dispatches the
-subcase to the merge-success branch; every other `ErrSCMConflict` is
-re-enqueued at the poll interval per [§11C.5](architecture/14-auto-merge-reaction-contract.md#11c5-merge-precondition-state-machine).
+`RemoveLabel` is the one method that swallows its `ErrSCMNotFound`: an already-absent label
+returns nil rather than an error.
 
 ### Token scopes
 
-The auto-merge reaction requires write scopes that the read-only tracker
-surface does not. The names below are stable constants in
-`internal/scm/github/merge.go`.
+The auto-merge reaction needs write scopes the read-only tracker surface does not. The names
+below are stable constants in `internal/scm/github/merge.go`.
 
-| Operation       | Fine-grained PAT permission | Classic PAT scope |
-| --------------- | --------------------------- | ----------------- |
-| `MergePR`       | `pull_requests:write`       | `repo`            |
-| `DeleteBranch`  | `contents:write`            | `repo`            |
-| Both            | both of the above           | `repo` covers both |
+| Operation      | Fine-grained PAT permission | Classic PAT scope   |
+| -------------- | --------------------------- | ------------------- |
+| `MergePR`      | `pull_requests:write`       | `repo`              |
+| `DeleteBranch` | `contents:write`            | `repo`              |
+| Both           | both of the above           | `repo` covers both  |
 
-A classic PAT with the `repo` scope is a superset that satisfies the
-fine-grained `pull_requests:write` and `contents:write` permissions for
-this adapter. Fine-grained PAT permission names are accepted by the
-startup token-scope preflight (per [§11C.9](architecture/14-auto-merge-reaction-contract.md#11c9-token-scope-and-preflight)).
+A classic PAT with the `repo` scope is a superset that satisfies both fine-grained permissions
+for this adapter, and `VerifyAutoMergeScopes` short-circuits on it. Fine-grained permission
+names are accepted by the startup token-scope preflight, per
+[§11C.9](architecture/14-auto-merge-reaction-contract.md#11c9-token-scope-and-preflight).
 
-The preflight reads the `X-OAuth-Scopes` header on `GET /rate_limit`.
-Classic PATs populate that header; fine-grained PATs and GitHub App
-installation tokens do not. When the verifier returns no scope information
-the preflight fails open: it logs a warning and proceeds, and any genuine
-scope gap surfaces at runtime as `ErrSCMAuth` on the first `MergePR` call.
+The preflight reads the `X-OAuth-Scopes` header on `GET /rate_limit`. Classic PATs populate
+that header; fine-grained PATs and GitHub App installation tokens do not. When the header is
+absent or empty, `VerifyAutoMergeScopes` returns nil scopes and nil missing scopes, which the
+caller reads as "unable to verify": it logs a warning and proceeds, and any genuine scope gap
+surfaces at runtime as `ErrSCMAuth` on the first `MergePR` call.
 
 ### `expectedHeadSHA` and the TOCTOU window
 
-`GetMergeability` and `MergePR` are two separate HTTP calls. Between them
-the PR head can move: a new push, a force-push, a base-branch update, or a
-rebase performed by another actor. Without a precondition the second call
-would merge whatever the head is at the moment of the merge, not the head
-the precondition check approved.
+`GetMergeability` and `MergePR` are two separate HTTP calls, and between them the pull request
+head can move: a new push, a force-push, a base-branch update, or a rebase by another actor.
+Without a precondition the second call would merge whatever the head is at merge time, not the
+head the precondition check approved.
 
-The `expectedHeadSHA` parameter forecloses that window. The caller passes
-the `PRMergeStatus.HeadSHA` it read from `GetMergeability` (or any later
-read) directly to `MergePR`. The adapter places that value in the merge
-request body's `sha` field. GitHub treats the field as a precondition: if
-the current PR head does not match, the server returns HTTP 409, the
-adapter maps it to `ErrSCMConflict` with the verbatim GitHub body, and the
-reconcile loop re-enqueues the merge for the next tick. The next tick
-re-reads the merge state, computes a fresh fingerprint over the new SHA
-(per [§11C.7](architecture/14-auto-merge-reaction-contract.md#11c7-fingerprint)), and either retries with the new head SHA or defers further
-when other preconditions still fail.
+`expectedHeadSHA` closes that window. The caller passes the `PRMergeStatus.HeadSHA` it read
+from `GetMergeability`, or from any later read, straight to `MergePR`, which places it in the
+merge body's `sha` field. When the current head does not match, GitHub returns HTTP 409, the
+adapter maps it to `ErrSCMConflict` carrying the verbatim GitHub body, and the reconcile loop
+re-enqueues the merge for the next tick. That tick re-reads the merge state, computes a fresh
+fingerprint over the new SHA (per
+[§11C.7](architecture/14-auto-merge-reaction-contract.md#11c7-fingerprint)), and either retries
+with the new head SHA or defers further when other preconditions still fail.
 
-The window the SHA closes is the only race the merge call exposes: review
-decision and CI conclusion are read separately and have no equivalent
-precondition mechanism, so changes there are caught by the next-tick
-re-read rather than by the merge call itself.
+The SHA closes the only race the merge call exposes. Review decision and CI conclusion are read
+separately and have no equivalent precondition mechanism, so a change in either is caught by
+the next tick's re-read rather than by the merge call.
 
 ---
 
-## Key differences from Jira adapter
+## Open questions
 
-| Aspect             | Jira                                  | GitHub                                       |
-| ------------------ | ------------------------------------- | -------------------------------------------- |
-| State model        | Rich workflow states                  | `open`/`closed` only; labels for states      |
-| Issue identifier   | Project key (`PROJ-123`)              | Number within repo (`299`)                   |
-| Description format | ADF (JSON tree, must flatten)         | Markdown (pass through)                      |
-| Priority           | `priority.id` (numeric)              | None natively; labels possible               |
-| Blocker detection  | `issuelinks` parsing                  | `dependencies/blocked_by` endpoint           |
-| Parent reference   | `fields.parent` in issue response     | Separate `parent` endpoint                   |
-| Issue types        | `issuetype.name` (always present)     | `type.name` (org feature, may be null)       |
-| Auth format        | `email:api_token` (Basic)             | Bearer token (single string)                 |
-| Pagination         | Cursor-based (`nextPageToken`)        | `Link` header with `rel="next"`              |
-| Rate limiting      | Points-based (65K/hr)                 | Request-count (5K/hr) + search (30/min)      |
-| Transitions        | Workflow transition API               | Label add/remove + state change              |
-| Comment format     | ADF (must flatten)                    | Markdown (pass through)                      |
-| Search syntax      | JQL                                   | GitHub search qualifiers                     |
+| Question | Probe that would settle it |
+| -------- | -------------------------- |
+| Does `POST /repos/{o}/{r}/issues/{n}/labels` create a label name that does not exist in the repository, or reject it? The label-hygiene rule above assumes a rejection, and `TransitionIssue` reports one as `tracker_payload_error` | Against a scratch repository, POST a name absent from `GET /repos/{o}/{r}/labels`, record the status, then re-read the label list to see whether the name now exists |
+| Does the check-runs route default to `filter=latest`, keeping only the most recent run per check name? Neither `GetCIStatus` nor `GitHubCIProvider.FetchCIStatus` sends `filter`, so the default decides whether a superseded run still contributes to the verdict | On a commit whose checks were re-run, compare `GET .../commits/{sha}/check-runs` with `GET .../commits/{sha}/check-runs?filter=all` and diff the returned run sets |
+| Does version `2026-03-10` remove properties from routes other than `/pulls/{n}`? Only the pull request object was diffed against `2022-11-28` | Fetch `/pulls/{n}/reviews`, `/pulls/{n}/comments`, `/issues/{n}/comments`, `/issues/{n}/events`, `/commits/{sha}/status`, and `/commits/{sha}/check-runs` under both versions and diff the key sets |
+| Does GitHub Enterprise Server serve the same route surface and the same version header behavior? Nothing in this document was observed against a GHES instance | Repeat the tracker and SCM read probes against a GHES deployment with `tracker.endpoint` set to `https://<host>/api/v3` |
 
 ---
 
-## Source attribution
+## Evidence
 
-| Topic                    | Primary source                                                              | Verification method          |
-| ------------------------ | --------------------------------------------------------------------------- | ---------------------------- |
-| Authentication methods   | GitHub Docs: Authenticating to the REST API; Context7 `/websites/github_en_rest` | `curl` with PAT confirmed    |
-| Fine-grained permissions | GitHub Docs: Permissions required for fine-grained PATs                     | Cross-referenced Context7    |
-| Issues endpoints         | GitHub Docs: REST API / Issues                                              | `curl` live API              |
-| Comments endpoints       | GitHub Docs: REST API / Issue Comments                                      | Verified field structure     |
-| Labels endpoints         | GitHub Docs: REST API / Labels                                              | Verified via live API        |
-| Rate limits (primary)    | GitHub Docs: Rate limits for the REST API                                   | `curl` header inspection     |
-| Rate limits (search)     | Live API verification                                                       | `x-ratelimit-limit: 30` confirmed |
-| Rate limits (secondary)  | GitHub Docs: Best practices for using the REST API                          | Documentation only           |
-| Conditional requests     | GitHub Docs: Best practices; live verification                              | `304` + unchanged `x-ratelimit-used` confirmed |
-| Pagination               | GitHub Docs: Using pagination in the REST API                               | `Link` header confirmed live |
-| Search qualifiers        | GitHub Docs: Searching issues and pull requests                             | Live search query confirmed  |
-| Dependencies/blocked_by  | Fine-grained PAT permissions page (endpoint discovered)                     | `curl` live: issue #218 returns #299 as blocker |
-| Sub-issues/parent        | Fine-grained PAT permissions page (endpoint discovered)                     | `curl` live: 404 for issue without parent     |
-| Issue types (`type`)     | Live API response                                                           | `curl`: `type.name` = `"Research"` on #299    |
-| `state_reason` field     | Live API response                                                           | `curl`: `null` on open issue |
-| Merge endpoint           | GitHub Docs: REST API / Pulls / Merge a pull request                        | Context7 `/websites/github_en_rest`: 200, 403, 404, 405, 409, 422 |
-| Branch delete endpoint   | GitHub Docs: REST API / Git / Delete a reference                            | Context7 `/websites/github_en_rest`: 204 on success, 409 or 422 on a refused delete (including a default-branch delete) |
-| Review decision (GraphQL) | GitHub Docs: GraphQL / PullRequest.reviewDecision                          | Adapter unit test pins the query text         |
-| Token scopes (merge)     | GitHub Docs: Permissions required for GitHub Apps and fine-grained PATs     | Constants in `internal/scm/github/merge.go`   |
+| Topic | Source | Verification |
+| ----- | ------ | ------------ |
+| Authentication methods | GitHub Docs: Authenticating to the REST API; Context7 `/websites/github_en_rest` | `curl` with a PAT |
+| Fine-grained permissions | GitHub Docs: Permissions required for fine-grained PATs | Cross-checked against Context7 |
+| Issues routes | GitHub Docs: REST API / Issues | `curl` against the live API |
+| Comments routes | GitHub Docs: REST API / Issue Comments | Field structure verified live |
+| Labels routes | GitHub Docs: REST API / Labels | Verified live |
+| Rate limits, primary | GitHub Docs: Rate limits for the REST API | `curl` header inspection |
+| Rate limits, search | Live observation | `x-ratelimit-limit: 30`, `x-ratelimit-resource: search` |
+| Rate limits, secondary | GitHub Docs: Best practices for using the REST API | Documentation only |
+| Conditional requests | GitHub Docs: Best practices | `304` with unchanged `x-ratelimit-used`, verified live |
+| Pagination | GitHub Docs: Using pagination in the REST API | `Link` header confirmed live |
+| Search qualifiers | GitHub Docs: Searching issues and pull requests | Live search query |
+| `dependencies/blocked_by` | Fine-grained PAT permissions page (route discovered there) | Live: issue #218 returns #299 as a blocker |
+| Sub-issues `parent` | Fine-grained PAT permissions page (route discovered there) | Live: 404 for an issue with no parent |
+| Issue types (`type`) | Live response | `curl`: `type.name` is `"Research"` on issue #299 |
+| `state_reason` | Live response | `curl`: null on an open issue |
+| Version `2026-03-10` removals | GitHub Docs: breaking changes for the REST API | Live diff of `/pulls/772` under `2022-11-28` and `2026-03-10` on 2026-08-10 |
+| Merge route | GitHub Docs: REST API / Pulls / Merge a pull request | Context7 `/websites/github_en_rest`: 200, 403, 404, 405, 409, 422 |
+| Branch delete route | GitHub Docs: REST API / Git / Delete a reference | Context7 `/websites/github_en_rest`: 204 on success, 409 or 422 on a refused delete including a default-branch delete |
+| Review decision (GraphQL) | GitHub Docs: GraphQL / `PullRequest.reviewDecision` | Adapter unit test pins the query text |
+| Merge commit (GraphQL) | GitHub Docs: GraphQL / `PullRequest.mergeCommit` | Adapter unit test pins the query text |
+| Token scopes for merge | GitHub Docs: Permissions required for GitHub Apps and fine-grained PATs | Constants in `internal/scm/github/merge.go` |
 
-## Context7 verification report
-
-Library resolved: `/websites/github_en_rest` (7,164 code snippets, High reputation,
-benchmark score 73.57).
-
-Queries executed:
-
-1. **Authentication** — `topic: authentication`, 5,000 tokens. Confirmed: fine-grained
-   PATs use Bearer auth, GitHub Apps use JWT → installation token flow, classic PATs use
-   `repo` scope. Consistent with official docs.
-
-2. **Search endpoint** — `topic: search`, 5,000 tokens. Confirmed: `GET /search/issues`
-   with `q` parameter, `per_page` max 100, response includes `total_count` and
-   `incomplete_results`. Search rate limit (30/min) confirmed independently via live
-   `curl` (not in Context7 snippets).
-
-Context7 did not cover: dependencies/blocked_by endpoint, sub-issues/parent endpoint,
-issue types (`type` field), or secondary rate limit details. These were verified
-exclusively through live API calls and the official GitHub documentation pages.
-
-3. **Merge endpoint** (added with SCM write surface). Confirmed via Context7:
-   `PUT /repos/{owner}/{repo}/pulls/{pull_number}/merge` returns 200 on success
-   and 403, 404, 405, 409, 422 on various failure modes. Body fields are
-   `commit_title`, `commit_message`, `sha`, and `merge_method`. The `sha` field
-   acts as a precondition; mismatch returns 409.
-
-4. **Branch delete endpoint** (added with SCM write surface). Confirmed via
-   Context7: `DELETE /repos/{owner}/{repo}/git/refs/{ref}` returns 204 on
-   success. A refused delete returns 409 (conflict) or 422 (validation
-   failed); GitHub's reference attributes a default-branch delete to both
-   statuses.
+Claims about Sortie's own code carry a Go symbol or package path instead of an evidence row:
+reading this repository is not an observation of GitHub.

--- a/docs/gitlab-adapter-notes.md
+++ b/docs/gitlab-adapter-notes.md
@@ -1,20 +1,32 @@
 # GitLab REST API: Adapter research notes
 
-> GitLab REST API v4, researched August 2026 and pinned to **self-managed GitLab Community
-> Edition 19.2.1** (revision `f4d029d2da8`, `enterprise: false`), **verified live** on
-> 2026-08-04. Community Edition is the compatibility floor: the adapter depends only on what
-> it provides. A second live instance, **GitLab.com** (version `19.3.0-pre`, revision
-> `7725732be39`, `enterprise: true`, namespace subscription plan `free`), was used solely for
-> the self-managed-versus-SaaS comparison. A second live pass on 2026-08-05 re-verified the
-> pinned container image `gitlab/gitlab-ce:19.2.1-ce.0` (version `19.2.1`, revision
-> `f4d029d2da8`, matching the self-managed lab) and GitLab.com, whose revision had moved to
-> `6f59ad3485c` as a continuously deployed instance does. A third live pass on 2026-08-10
-> characterized the merge-request, approval, review, pipeline, and job surface against the same
-> self-managed Community Edition 19.2.1 instance (revision `f4d029d2da8`), using a project at
-> namespace depth three and a registered runner executing real jobs. A fourth live pass on
-> 2026-08-16 characterized the `manual` pipeline shape against the same instance and revision,
-> using a purpose-built scratch project and its own registered runner. Reference for
-> implementing the GitLab `TrackerAdapter` and `SCMAdapter`.
+> **Product:** GitLab REST API v4.
+>
+> **Pinned deployment:** self-managed GitLab **Community Edition 19.2.1**, revision
+> `f4d029d2da8`, `enterprise: false`, run from the container image
+> `gitlab/gitlab-ce:19.2.1-ce.0`. Community Edition is the compatibility floor: the adapter
+> depends only on what it provides.
+>
+> **Comparison deployment:** **GitLab.com**, version `19.3.0-pre`, `enterprise: true`,
+> namespace subscription plan `free`. It is continuously deployed, so its revision moves;
+> `7725732be39` and `6f59ad3485c` were both current during observation. It serves the
+> self-managed-versus-SaaS comparison only.
+>
+> **Instruments:** live HTTP against both deployments, the pinned instance's own GraphQL
+> introspection, first-party GitLab documentation, and upstream `gitlab-org/gitlab` source at
+> ref `v19.2.1-ee`.
+>
+> **Coverage.** The tracker surface (issues, notes, labels, filters, pagination, rate limits,
+> error envelopes) is anchored to Community Edition 19.2.1 at revision `f4d029d2da8`, observed
+> 2026-08-04 and 2026-08-05, with the GitLab.com comparisons observed on the same dates. The
+> merge-request, approval, review-state, pipeline, and job surface is anchored to the same
+> version and revision, observed 2026-08-10 against a project at namespace depth three with a
+> registered runner executing real jobs. The `manual` pipeline shape and the pipeline-status
+> enumeration are anchored to the same version and revision, observed 2026-08-16. No
+> self-managed Enterprise Edition instance was ever observed, so every Enterprise Edition
+> claim rests on **[source]** plus **[docs]**.
+>
+> **Interfaces served:** the GitLab `TrackerAdapter` and `SCMAdapter`.
 >
 > Self-managed GitLab has no fixed host, so the instance base URL is part of every
 > self-managed configuration, and instances differ in version and settings. Facts hold for
@@ -30,17 +42,19 @@ is not an observation of GitLab.
 
 | Tag | Meaning |
 | --- | --- |
-| **[live-CE]** | Observed directly against the self-managed Community Edition 19.2.1 instance on 2026-08-04, again on 2026-08-05 against the pinned container image `gitlab/gitlab-ce:19.2.1-ce.0` (version `19.2.1`, revision `f4d029d2da8`, matching the lab), again on 2026-08-10 for the merge-request, approval, pipeline, and job surface, and again on 2026-08-16 for the `manual` pipeline shape. The strongest evidence for Community Edition behavior. On 2026-08-10 and 2026-08-16 the tag also covers the instance's **own GraphQL introspection response**, which is version-exact for the deployment under test and is named as such wherever it is the source. |
-| **[live-SaaS]** | Observed directly against GitLab.com (`19.3.0-pre`, `enterprise: true`, plan `free`) on 2026-08-04, and again on 2026-08-05 at revision `6f59ad3485c`, moved from the previously recorded `7725732be39` as a continuously deployed instance does. Evidence about GitLab.com only, never about self-managed. |
+| **[live-CE]** | Observed directly against the pinned self-managed Community Edition 19.2.1 instance (revision `f4d029d2da8`), or against that instance's **own GraphQL introspection response**, which is version-exact for the deployment under test and is named as such wherever it is the source. The strongest evidence for Community Edition behavior. |
+| **[live-SaaS]** | Observed directly against GitLab.com (`19.3.0-pre`, `enterprise: true`, plan `free`). Evidence about GitLab.com only, never about self-managed. |
 | **[docs]** | First-party GitLab documentation, cited by URL. |
-| **[source]** | Upstream source in `gitlab-org/gitlab`, cited by path at ref `v19.2.1-ee` (the tag matching the researched Community Edition version; the `-ee` tag carries both the Community Edition code and the `ee/` tree, which is how a route's edition gating is proved). |
-| **[unknown]** | Not settled by this research. Listed with the evidence that would settle it. |
+| **[source]** | Upstream source in `gitlab-org/gitlab`, cited by path at ref `v19.2.1-ee` (the tag matching the pinned Community Edition version; the `-ee` tag carries both the Community Edition code and the `ee/` tree, which is how a route's edition gating is proved). |
+| **[unknown]** | Not settled by this research. Carried in [Open questions](#open-questions) with the evidence that would settle it. |
+
+A claim carries its own date when the date is load-bearing; otherwise the coverage
+statement in the provenance block supplies it.
 
 Where documentation and observed behavior disagree, both sides are recorded and the
-behavior the adapter must trust is named. No self-managed Enterprise Edition instance was
-available, so **every Enterprise Edition claim is [source] plus [docs] and was never
-observed live**; GitLab.com is an Enterprise Edition codebase but not a self-managed
-Enterprise Edition deployment, and the two are not interchangeable.
+behavior the adapter must trust is named. **Every Enterprise Edition claim is [source] plus
+[docs] and was never observed live**: GitLab.com is an Enterprise Edition codebase but not a
+self-managed Enterprise Edition deployment, and the two are not interchangeable.
 
 ### Why no machine-readable route surface backs these notes
 
@@ -212,9 +226,8 @@ header is shared with OAuth flows.
 ### Token types
 
 Four token types authenticate against the issue surface. All four are sent in the same
-header, and all carry the same fixed GitLab access-token prefix and were 51 characters
-long at the researched version
-**[live-CE]**. The prefix makes a token machine-identifiable, so secret scanners can
+header, and all carry the same fixed GitLab access-token prefix and are 51 characters
+long **[live-CE]**. The prefix makes a token machine-identifiable, so secret scanners can
 recognize a leak by shape.
 
 | Token type | Identity returned by `GET /user` | Access scope | Suitability |
@@ -262,9 +275,8 @@ and carries no usable permission detail. A granular GitLab.com token that reads 
 fails a note create with a bare `403 {"message":"403 Forbidden"}` carrying no
 `insufficient_scope` marker **[live-SaaS]**. Whether self-managed Community Edition 19.2.1
 supports granular tokens, and what its introspection reports, is **[unknown]**: both
-Community Edition tokens observed here reported `"granular": false`. Creating a granular
-token on a self-managed Community Edition instance and reading `/personal_access_tokens/self`
-would settle it.
+Community Edition tokens observed here reported `"granular": false`. See
+[Open questions](#open-questions).
 
 ### Cheap token validation
 
@@ -359,9 +371,10 @@ percent-encode the whole path segment exactly once. A project can be moved or
 renamed, which changes the path but not the ID; a deployment that expects to survive a
 rename SHOULD configure the numeric ID.
 
-Nested subgroups are supported and produce more than one slash
-(`group/subgroup/project` becomes `group%2Fsubgroup%2Fproject`), so unlike the GitHub and
-Gitea adapters the value MUST NOT be validated as "exactly one slash".
+Nested subgroups are supported and produce more than one slash, so unlike the GitHub and
+Gitea adapters the value MUST NOT be validated as "exactly one slash". The forge half shares
+this convention and carries the depth-three evidence and the encoding prohibitions; see
+[project addressing](#8-project-addressing).
 
 ---
 
@@ -495,9 +508,8 @@ merely cross-referenced issues. Because a blocker whose state is unknown is trea
 non-terminal (conservative), inventing blockers is the more harmful error.
 
 On an Enterprise Edition instance licensed at Premium or above, `GET .../links` entries carry
-`link_type: "blocks"` or `"is_blocked_by"` **[source]** and could populate `blocked_by`.
-Whether to read them conditionally is a design question this research does not settle; the
-Community Edition floor requires the empty-slice behavior regardless.
+`link_type: "blocks"` or `"is_blocked_by"` **[source]**. The Community Edition floor requires
+the empty-slice behavior regardless.
 
 ---
 
@@ -536,7 +548,8 @@ Each parameter earns its place:
 - **`issue_type=issue` excludes non-issue work items server-side.** GitLab's issue list
   returns tasks, incidents, and test cases alongside issues. Verified: after creating one
   `task` and one `incident`, the unfiltered `state=opened` listing returned all seven items
-  including both, while `issue_type=issue` returned exactly the five issues **[live-CE]**.
+  including both, `issue_type=issue` returned exactly the five issues, and `issue_type=task`
+  returned only the task **[live-CE]**.
   This is the direct analogue of Gitea's `type=issues` pull-request exclusion, and omitting
   it would dispatch agents against checklist items. Accepted values are `issue`, `incident`,
   `test_case`, `task` [[docs]](https://docs.gitlab.com/api/issues/).
@@ -617,13 +630,12 @@ configuration, not on GitLab; a conservative chunk size well below any plausible
 avoids the question. Both methods share one implementation because ID equals Identifier
 equals `iid`.
 
-Conditional requests are available and worth considering here, unlike on Gitea: GitLab sends
-a weak `ETag` on list and notes responses, and `If-None-Match` returns `304` **[live-CE]**
-(verified on both the issue list and the notes list). Whether a `304` is cheaper than a `200`
-against a rate-limit budget is **[unknown]**; GitLab's rate-limit documentation does not
-address conditional requests, and no `RateLimit-*` headers were observable on the
-Community Edition instance because throttling is off by default there. Measuring
-`RateLimit-Observed` across a `304` on GitLab.com would settle it.
+Conditional requests are available here, unlike on Gitea: GitLab sends a weak `ETag` on list
+and notes responses, and `If-None-Match` returns `304` **[live-CE]** (verified on both the
+issue list and the notes list). Whether a `304` is cheaper than a `200` against a rate-limit
+budget is **[unknown]**; GitLab's rate-limit documentation does not address conditional
+requests, and no `RateLimit-*` headers are observable on the Community Edition instance
+because throttling is off by default there. See [Open questions](#open-questions).
 
 ### 6. `FetchIssueComments`
 
@@ -661,8 +673,8 @@ GET /projects/:id/issues/:iid/notes?activity_filter=only_comments&sort=asc&per_p
   paginate.
 - Bodies are Markdown and pass through unflattened, like GitHub and Gitea and unlike Jira's
   ADF **[live-CE]**.
-- Notes carry an `internal` boolean (renamed from `confidential` in an earlier release)
-  **[live-CE]** **[source]**. Internal notes are visible only to project members at
+- Notes carry an `internal` boolean **[live-CE]** **[source]**. Internal notes are visible
+  only to project members at
   Reporter level and above; they are returned to a token that can see them. The adapter
   passes them through: they are genuine human comments, and an operator who does not want
   them in prompts controls that by not writing them.
@@ -843,8 +855,8 @@ The approximation's limits must be stated, because it looks like a mention filte
   [[docs]](https://docs.gitlab.com/user/gitlab_com/#rate-limits-on-gitlabcom), and
   `search_rate_limit = 30` per minute on the Community Edition instance's own settings
   **[live-CE]**. This applies to the dedicated search API; whether the `search` *parameter*
-  on the issue-list route draws on the same budget is **[unknown]** and would be settled by
-  observing `RateLimit-Name` on a throttled response.
+  on the issue-list route draws on the same budget is **[unknown]**, carried in
+  [Open questions](#open-questions).
 
 Recommendation: treat "assigned to the automation identity" as the supported scoping
 mechanism and "mentions" as a best-effort text filter the operator opts into, with the
@@ -977,12 +989,11 @@ diagnostically. It is recorded as the available remedy if a deployment shows pag
 itself: an absent `rel="next"` is the normal end-of-results signal in both modes, and in
 keyset mode the cursor is embedded in a URL the paginator follows opaquely.
 
-One caveat worth stating because it affects proxied self-managed deployments: the `Link`
-URLs observed were absolute and matched the requested host **[live-CE]**, but whether GitLab
-builds them from the incoming request or from the instance's configured external URL is
-**[unknown]**. On a deployment where the two differ, following an absolute `Link` URL could
-address the wrong host. Issuing one paginated request through a proxy whose forwarded host
-differs from the instance's external URL and inspecting the `Link` header would settle it.
+One caveat affects proxied self-managed deployments: the `Link` URLs are absolute and match
+the requested host **[live-CE]**, but whether GitLab builds them from the incoming request or
+from the instance's configured external URL is **[unknown]**. On a deployment where the two
+differ, following an absolute `Link` URL could address the wrong host. See
+[Open questions](#open-questions).
 
 ---
 
@@ -1380,10 +1391,11 @@ capability records the response shape, the mapping onto the `internal/domain` SC
 decision taken. Nothing here is part of the tracker adapter.
 
 The fixture is a project at namespace depth three (`scmlab/team/squad/mrlab`), five merge
-requests covering the clean, conflicting, draft, and merged cases, a registered runner
-executing real jobs, and a project access token identity for the bot probes. Every probe
-below was run against it. Reads use the project Developer token unless a probe is explicitly
-about the administrator view.
+requests covering the clean, conflicting, draft, and merged cases, a registered
+Docker-executor runner executing real jobs, and a project access token identity for the bot
+probes. It stands on the lab instance as the SCM fixture blueprint. Every probe below was run
+against it or against a scratch project of the same shape with its own runner. Reads use the
+project Developer token unless a probe is explicitly about the administrator view.
 
 Three findings dominate the design and are stated once here because several capabilities
 depend on them:
@@ -1394,16 +1406,14 @@ depend on them:
 - **The merge endpoint's rejection body does not name its reason.** Already-merged, draft, and
   conflicting merge requests all return the byte-identical `405 {"message":"405 Method Not
   Allowed"}` **[live-CE]**. See [the merge call](#6-merge-call) for what that forces.
-- **Embedded user objects carry no bot marker.** The `bot` field exists on `GET /users/:id` but
-  not on the author of a note **[live-CE]** **[source]**, which reopens a claim the earlier
-  gap map got wrong.
+- **Embedded user objects carry no bot marker.** The `bot` field exists on `GET /users/:id`
+  but not on the author of a note **[live-CE]** **[source]**.
 
 ### Decisions the adapter does not make
 
-Several decisions this section once left to the GitLab author arrive from
-`internal/scm/scmcore`, which every forge half depends on and which imports only
-`internal/domain`. The adapter supplies the wire read and the normalization; the verdict is
-computed once, shared:
+Several decisions arrive from `internal/scm/scmcore`, which every forge half depends on and
+which imports only `internal/domain`. The adapter supplies the wire read and the
+normalization; the verdict is computed once, shared:
 
 | Decision | Shared owner | What GitLab supplies |
 | --- | --- | --- |
@@ -1416,7 +1426,7 @@ computed once, shared:
 | Bot-author classification | `scmcore.IsBotAuthor` | The platform bot flag and the configured allowlist |
 | Label-event id ordering | `scmcore.SortableEventID` | The numeric journal id |
 
-Two consequences change behavior this section previously described as the adapter's own:
+Two consequences of that ownership shape the merge path:
 
 - **`ErrSCMConflict` is reachable only from the merge write path.** `scmcore.ToSCMError`
   performs no promotion, and `scmcore.AsMergeConflict` is called only by `MergePR`. A 405 or
@@ -1614,10 +1624,8 @@ with 405 if any still holds, so a stale `clean` read cannot merge a blocked merg
 
 ### 3. Changes-requested reviews
 
-**GitLab does have a per-reviewer review state on the REST surface, and the reference
-documentation does not mention it.** This was the single most contested question in this
-research, because two sources appeared to disagree. Both turned out to be describing different
-objects.
+**GitLab has a per-reviewer review state on the REST surface, and the reference documentation
+does not mention it.** Two objects carry a `state` field and they describe different things.
 
 The **merge-request object's** `reviewers[]` array holds bare user objects whose `state` is the
 user's *account* state **[live-CE]**:
@@ -1643,7 +1651,7 @@ Both `state` fields appear in one response and mean different things. Reading th
 where the review state was intended is the trap, and it is easy to fall into because the outer
 object nests the very field name it shadows.
 
-Three independent confirmations that the review state is Community Edition and real:
+Three independent confirmations that the review state is a Community Edition feature:
 
 - `lib/api/merge_requests.rb` defines the route at CE level, outside the `ee/` tree, and renders
   it with `Entities::MergeRequestReviewer`, which exposes `user`, `state`, and `created_at`
@@ -1689,8 +1697,8 @@ current `sha`.
 
 ### 4. CI status source
 
-The issue frames pipelines and commit statuses as two competing models. They are not: **GitLab
-unifies them, and the unification was verified in both directions.**
+**GitLab unifies pipelines and commit statuses, and the unification holds in both
+directions.** They are not two competing models.
 
 Posting an external commit status to a SHA that **already has a pipeline** attaches it to that
 pipeline and changes the pipeline's own status. A pipeline reporting `success` (its only failing
@@ -1737,7 +1745,11 @@ merge-gate vocabulary so that one forge cannot answer "is CI green" two ways, an
 and Gitea adapters both return its four values (`success`, `pending`, `failing`, and the empty
 string). GitLab maps into the same four through `mapPipelineStatus`
 (`internal/scm/gitlab/scm_merge.go`), which partitions every value of the platform's 13-value
-`head_pipeline.status` enum:
+`head_pipeline.status` enum. The instance's own GraphQL `PipelineStatusEnum` and `CiJobStatus`
+each enumerate exactly those 13 values (`created`, `waiting_for_resource`, `preparing`,
+`waiting_for_callback`, `pending`, `running`, `success`, `failed`, `canceling`, `canceled`,
+`skipped`, `manual`, `scheduled`) **[live-CE]**, matching `AVAILABLE_STATUSES` at
+`v19.2.1-ee` **[source]**:
 
 | `head_pipeline.status` | `GetCIStatus` returns |
 | --- | --- |
@@ -1780,6 +1792,10 @@ reports `manual`. Two arrangements reach that shape, and both were reproduced **
   stage `build`), `manual_gate` (`manual`, stage `gate`), and `failing_job` (`failed`, stage
   `test`, `needs: [build_job]`) likewise produced `head_pipeline.status: "manual"`.
 
+Neither arrangement moves `detailed_merge_status`: both merge requests read `mergeable`
+**[live-CE]**, so on a project that does not require passing pipelines the CI read is reached
+and the merge gate rests entirely on it.
+
 Only the pipeline's own job set separates those shapes from the benign one; no other field of
 the merge-request response distinguishes them. Reading
 `GET /projects/:id/repository/commits/:sha/statuses` for `head_pipeline.sha`, scoped to
@@ -1806,9 +1822,11 @@ load-bearing rather than defensive. A commit carrying two pipelines returned bot
 entries unfiltered (`X-Total: 2`) and exactly one entry under each `pipeline_id` value
 (`X-Total: 1`), and `head_pipeline` moved to the newer pipeline **[live-CE]**.
 
-A project that enables the "Pipelines must succeed" setting never reaches the CI read at all.
+A project that enables the "Pipelines must succeed" setting
+(`only_allow_merge_if_pipeline_succeeds: true`) never reaches the CI read at all.
 There a merge request whose head pipeline is `manual` reports
-`detailed_merge_status: "ci_still_running"` **[live-CE]**, which is outside `mapMergeability`'s
+`detailed_merge_status: "ci_still_running"` while `merge_status` stays `can_be_merged`
+**[live-CE]**, which is outside `mapMergeability`'s
 recognized set and lands in its `blocked` arm, so the auto-merge precondition table stops on
 mergeability before it calls `GetCIStatus`. The value is `ci_still_running` rather than
 `ci_must_pass` because the reason is chosen by `diff_head_pipeline_considered_in_progress?`,
@@ -1865,9 +1883,8 @@ size.
 the failing count is the adapter's to choose: `scmcore.AggregateCIStatus` and
 `scmcore.FailingCount` compute both from the normalized `CheckRun` set, and
 `adaptertest.AssertCIAggregateMatchesCore` recomputes them from the returned `CheckRuns` and
-fails the suite when either disagrees. Sourcing the aggregate from the pipeline's own status,
-as this section previously specified, would fail that assertion on exactly the case that
-motivated it.
+fails the suite when either disagrees. Sourcing the aggregate from the pipeline's own status
+would fail that assertion on exactly the case that motivated it.
 
 Mapping a soft-failing job to `neutral` reconciles the two: the platform's `allow_failure`
 rule is applied once, where the entry is normalized, and the shared fold then agrees with the
@@ -2012,14 +2029,12 @@ conflicting    (iid 2, correct sha) -> 405 {"message":"405 Method Not Allowed"}
 ```
 
 The source explains why: both arms of `execute_merge` call the same bare `not_allowed!` helper,
-which renders a constant **[source]**. When these notes were written the `SCMAdapter` contract
-keyed the already-merged marker on the provider's response body, and GitLab's constant body was
-a problem to be worked around. It is no longer one. The contract requires implementations to
-surface the substring "already merged" in `SCMError.Message` "when they have confirmed, by
-re-reading the pull request, that the pull request is merged, rather than by matching the
-provider's response wording" (`MergePR`, `internal/domain/scm.go`). GitLab's opaque 405 is
-therefore no longer exceptional: GitHub and Gitea re-read for the same reason, and Gitea does
-so even though its own body does say "already merged".
+which renders a constant **[source]**. The opaque body is not exceptional under the contract,
+which requires implementations to surface the substring "already merged" in `SCMError.Message`
+"when they have confirmed, by re-reading the pull request, that the pull request is merged,
+rather than by matching the provider's response wording" (`MergePR`,
+`internal/domain/scm.go`). GitHub and Gitea re-read for the same reason, and Gitea does so
+even though its own body does say "already merged".
 
 **Decision: on 405, re-read the merge request and classify from its state.** This is the
 contract's own procedure rather than a substitute for it.
@@ -2076,8 +2091,8 @@ only the merge write path promotes.
 
 ### 7. Bot classification
 
-**The platform bot marker does not reach note authors, which corrects a claim in the earlier gap
-map.** That claim was true of *token identities* and does not carry to *note authors*.
+**The platform bot marker does not reach note authors.** It is a property of *token
+identities*, readable on one route, and it does not travel with an embedded author object.
 
 Every embedded user object in the API, including a note's `author`, is rendered with
 `API::Entities::UserBasic`, which exposes `id`, `username`, `name`, `state`, `locked`,
@@ -2181,12 +2196,19 @@ Every route below was exercised on the fixture unless the status column says oth
 | `ListLabelEvents` | `GET .../merge_requests/:iid/resource_label_events` | Route verified, `200 []`; shape verified on the issue variant **[live-CE]**. Entry ids normalize through `scmcore.SortableEventID`, so ordering by `(At, ID)` as strings matches journal order |
 | `RemoveLabel` | `PUT .../merge_requests/:iid` with `remove_labels` | Not exercised on merge requests; identical parameter to the issue route. A name that does not exist returns `200` and changes nothing **[live-CE]**, which is already the contract's nil-return no-op |
 
-Two findings from the tracker research that the forge half inherits unchanged:
+Every other forge route the fixture exercised matches: merge-request list, merge-request notes
+and discussions, merge-request `approvals`, pipelines, commits, branches, protected branches,
+`related_merge_requests`, and both resource-event journals **[live-CE]**. Merge-request
+`approval_state` is the one route that does not match; see
+[what Community Edition cannot do](#what-community-edition-cannot-do).
+
+Two properties of the tracker surface the forge half inherits unchanged:
 
 - **State-change and label-change events are not notes.** GitLab keeps them in separate journals,
-  `resource_label_events` and `resource_state_events`, both available on Community Edition and
-  both verified to return typed entries **[live-CE]**. The label-command reaction reads the label
-  journal, not the note stream.
+  `resource_label_events` and `resource_state_events`, both available on Community Edition.
+  The label journal returns typed `add` and `remove` entries naming the label, the actor, and
+  the timestamp, and the state journal returns the close event **[live-CE]**. The
+  label-command reaction reads the label journal, not the note stream.
 - **Notes are the same entity as on issues**, so the comment normalization is shared. System notes
   must be filtered the same way, and the merge-request notes route accepts the same
   `activity_filter` and `sort` parameters.
@@ -2278,236 +2300,6 @@ Stated plainly, with the degradation rather than a workaround:
 
 ---
 
-## Live verification results
-
-Established against self-managed GitLab Community Edition 19.2.1 (revision `f4d029d2da8`,
-`enterprise: false`) on 2026-08-04, using a **project Developer** token for every probe whose
-result is reported, and an administrator token only for provisioning and cleanup. GitLab.com
-(`19.3.0-pre`, revision `7725732be39`, `enterprise: true`, namespace plan `free`) was used
-only for the comparisons marked **[live-SaaS]**.
-
-1. **Edition and tier.** `GET /version` reported `enterprise: false` on the self-managed
-   instance and `enterprise: true` on GitLab.com; `GET /namespaces` reported `plan: free` for
-   the GitLab.com namespace. Both `/version` and `/metadata` returned 401 without a token and
-   200 with a `read_api` token.
-2. **Auth scheme matrix.** `PRIVATE-TOKEN`, `Authorization: Bearer`, and
-   `?private_token=` all returned 200; `JOB-TOKEN` with a personal access token returned 401.
-   A bad token returned `401 {"message":"401 Unauthorized"}`; a revoked token returned
-   `401 {"error":"invalid_token","error_description":"Token was revoked. ..."}`; no token at
-   all against a private project returned `404 {"message":"404 Project Not Found"}`.
-3. **Scope sufficiency.** A `read_api`-only token performed all four probed reads and was
-   refused all three writes with
-   `403 {"error":"insufficient_scope",...}`; an `api` token performed everything.
-4. **Token types.** Personal, project, and group access tokens all authenticated. The project
-   token's identity was `project_<id>_bot_<hex>` with `bot: true` and could not see a sibling
-   project (404); the group token's identity was `group_<id>_bot_<hex>` with `bot: true` and
-   could see both projects in the group and `GET /groups/:id/issues`. A human-owned personal
-   access token reported `bot: false`. `GET /personal_access_tokens/self` returned the token
-   record for all of them.
-5. **Identifier divergence.** Two issues created in the first project had `(iid, id)` of
-   `(7, 9)` and `(8, 10)`; the second project's first two issues were `(1, 7)` and `(2, 8)`.
-   On GitLab.com a new project's first two issues were `(1, 196614283)` and `(2, 196614285)`.
-   `GET /issues/:id` returned 403 for the Developer token and 200 for the administrator.
-6. **Project addressing.** A percent-encoded `group%2Fproject` path resolved; an unencoded
-   slash returned `404 {"error":"404 Not Found"}`.
-7. **Blocking links.** `link_type=blocks` and `is_blocked_by` returned
-   `400 {"error":"link_type does not have a valid value"}`; `relates_to` returned 201; an
-   omitted `link_type` defaulted to `relates_to`; the created link was visible from both
-   endpoints of the relation. On GitLab.com the same two values returned
-   `403 {"message":"Blocked issues not available for current license"}`.
-8. **Tier boundaries.** A `PUT` carrying only `weight=3` returned a 400 enumerating the
-   entire accepted parameter set, which excluded `weight`; the same request on GitLab.com
-   returned a list additionally containing `weight`, `epic_id`, and `epic_iid`, and the write
-   itself returned 200. `weight=3` as a *filter* was silently ignored. Two
-   `assignee_username` values returned `400 {"error":"assignee_username allows one value, but
-   found 2: ...}` on Community Edition and 200 on GitLab.com. The Community Edition and
-   GitLab.com issue objects differed by exactly one key, `blocking_issues_count`.
-9. **Scoped labels.** `workflow::testing` and `workflow::other` were both created as ordinary
-   project labels and coexisted on one issue after a single `add_labels` carrying both.
-10. **Silent parameter ignore.** `labels=backlog` returned 3 of 6 issues, while `labelz=`,
-    `label=`, `assignee=`, `totally_bogus_param=`, `or[label_name][]=` (with an existing label
-    and with a nonexistent one), and `weight=` each returned all 6. On GitLab.com
-    `or[label_name][]=<existing label>` likewise returned every issue. By contrast
-    `state=open`, `state_event=closed`, and `activity_filter=bogus` each returned
-    `400 {"error":"<param> does not have a valid value"}`.
-11. **Filter semantics.** `labels=bug,in-progress` matched only the issue carrying both;
-    `labels=backlog,bug` matched nothing; `labels=BACKLOG` and `labels=no-such-label` returned
-    empty sets; `labels=Any` returned all, `labels=None` none; `not[labels]=backlog` returned
-    the complement; `assignee_username`, `assignee_id`, `assignee_id=None|Any`,
-    `author_username`, `scope=assigned_to_me`, `search`, `search&in=`, `iids[]`, and
-    `updated_after` (future timestamp empty, current day full) all behaved as documented.
-12. **Work item exclusion.** After creating one `task` and one `incident`, the unfiltered
-    `state=opened` list returned seven items including both; `issue_type=issue` returned
-    exactly the five issues; `issue_type=task` returned only the task.
-13. **State and label writes.** `state_event=close` then `reopen` toggled the native state and
-    were idempotent on repetition; `closed` and `open` returned 400. `add_labels` was additive
-    and created a nonexistent label as a project label; `remove_labels` tolerated a
-    nonexistent name; `add_labels=REVIEW` on an issue carrying `review` produced both labels
-    and a second project label; `labels=` replaced the entire set. A single `PUT` carrying
-    `state_event`, `add_labels`, and `remove_labels` applied all three, and `add` plus
-    `remove` of the same name resolved in favor of remove.
-14. **Group labels.** A group-level label (`is_project_label: false`) attached to a project
-    issue and matched a `labels=` filter.
-15. **Notes.** The route returned system notes mixed with user comments;
-    `activity_filter=only_comments` and `only_activity` partitioned them exactly;
-    `sort=asc` reordered them oldest-first against a `desc` default; a 55-note issue paginated
-    at 20 per page with `X-Total: 55` and a `rel="next"` link, and returned all 55 at
-    `per_page=100`; `user_notes_count` counted non-system notes only; creating a note returned
-    201 with the Markdown body and newlines preserved; an omitted body returned
-    `400 {"error":"body is missing"}` and an empty body a 400 embedding a model-validation
-    rendering.
-16. **Resource event journals.** `resource_label_events` returned typed `add` and `remove`
-    entries naming the label, actor, and timestamp; `resource_state_events` returned the close
-    event. Label changes appeared in the label journal and **not** in the note stream.
-17. **Pagination.** `per_page` defaulted to 20 and clamped 200 to 100; offset responses carried
-    `X-Total`, `X-Total-Pages`, `X-Page`, `X-Per-Page`, `X-Next-Page` and a `Link` header;
-    `pagination=keyset` returned a `rel="next"` link embedding an opaque `cursor` and omitted
-    the `X-Total` family; five `order_by` values were accepted in keyset mode; the keyset link
-    echoed the effective query, which is how the `state=all` default was established.
-18. **Conditional requests.** A weak `ETag` was present on the issue-list and notes responses,
-    and `If-None-Match` returned 304 for both.
-19. **Rate limiting.** No `RateLimit-*` headers appeared on any Community Edition response, and
-    the instance reported `throttle_authenticated_api_enabled: false` with a 7,200-per-3,600s
-    default, alongside enabled granular limits including `notes_create_limit: 300` and
-    `search_rate_limit: 30`, and a null `rate_limiting_response_text`. GitLab.com returned
-    `ratelimit-limit: 2000`, `ratelimit-name: throttle_authenticated_api`,
-    `ratelimit-observed`, `ratelimit-remaining`, and `ratelimit-reset`.
-20. **Errors.** Four envelope shapes were observed. A missing issue returned
-    `404 {"message":"404 Not found"}`; a missing project, an unauthorized project, and an
-    unauthenticated request to a private project all returned the byte-identical
-    `404 {"message":"404 Project Not Found"}`; an unmatched route returned
-    `404 {"error":"404 Not Found"}`; a non-numeric `iid` returned
-    `400 {"error":"issue_iid is invalid"}`.
-21. **Forge route existence.** Merge-request list, merge-request notes and discussions,
-    merge-request `approvals`, pipelines, commits, branches, protected branches,
-    `related_merge_requests`, and both resource-event journals all matched their routes;
-    merge-request `approval_state` did not.
-22. **Container cost and boot profile.** The `gitlab/gitlab-ce:19.2.1-ce.0` image is
-    1,382,863,597 bytes compressed and 3,555,125,274 bytes on disk, and pulled in 63 s. Two
-    independent boots of the same image and configuration produced the same three-stage
-    profile: no TCP connection for roughly the first 90 s, `502` from the web front end at
-    100 to 114 s, and a real application response by 120 to 124 s. The Docker healthcheck
-    reported `healthy` at 60 s, before the application answered at all. On a fully booted
-    instance, `/-/readiness` returned `200` from inside the container and
-    `404 {"error":"Not Found","status":404}` from the host through the published port,
-    matching the shipped default `gitlab_rails['monitoring_whitelist'] = ['127.0.0.0/8',
-    '::1/128']` read from the image's own configuration template, while
-    `GET /api/v4/version` returned `401` from both.
-
-The 2026-08-10 pass added the following against a purpose-built project at namespace depth three
-(`scmlab/team/squad/mrlab`), with a registered Docker-executor runner:
-
-23. **Project addressing at depth.** `GET /projects/scmlab%2Fteam%2Fsquad%2Fmrlab` returned 200
-    and echoed `path_with_namespace: "scmlab/team/squad/mrlab"`; the sub-route
-    `.../merge_requests` returned `200 []`. Unencoded slashes returned
-    `404 {"error":"404 Not Found"}` and double-encoded `%252F` returned
-    `404 {"message":"404 Project Not Found"}`, the two envelopes distinguishing an unmatched
-    route from a failed lookup.
-24. **`detailed_merge_status` values.** Six values were observed in REST bodies: `preparing` and
-    `checking` on freshly created or freshly approved merge requests, `mergeable`, `conflict`
-    (with `has_conflicts: true`), `draft_status`, and `not_open` after merge. The instance's own
-    GraphQL schema enumerated 24 values, two more than the upstream default branch carries.
-    Approving a merge request moved the field from `mergeable` back to `checking`, proving it
-    recomputes.
-25. **Approvals payload.** Community Edition returned exactly four keys: `user_has_approved`,
-    `user_can_approve`, `approved`, `approved_by[]`. No `approvals_required` and no
-    `approvals_left`. The first two keys were viewer-relative: the same merge request reported
-    `user_has_approved: true` to the approver and `false` to another token. `approval_state`,
-    `approval_rules`, and the project-level `approvals` route each returned
-    `404 {"error":"404 Not Found"}`. With zero approvals the merge request was still `mergeable`.
-26. **Per-reviewer review state.** `GET .../merge_requests/:iid/reviewers` returned objects
-    nesting the user under `user` and exposing a top-level `state`, which read `unreviewed` on
-    assignment, `approved` after `approve`, and `unapproved` after `unapprove`. The
-    merge-request object's own `reviewers[]` array carried only bare user objects whose `state`
-    was the account state `active`. No REST route and no GraphQL mutation set the review state.
-27. **CI unification.** An external commit status posted to a SHA that already had a pipeline
-    attached to that pipeline (`pipeline_id` echoed the existing id) and flipped the pipeline
-    from `success` to `failed`. An external status posted to a SHA with no pipeline created one
-    with `source: "external"`, which became the merge request's `head_pipeline`. A pipeline whose
-    only failing job carried `allow_failure: true` reported top-level `success` with
-    `detailed_status.group: "success-with-warnings"`, and `detailed_status` was present on the
-    pipeline detail route and on `head_pipeline` but absent from the pipeline list route.
-28. **Job trace.** `GET /projects/:id/jobs/:job_id/trace` returned `text/plain` with
-    `Content-Length: 3926` over 44 lines for a real failing job. Every line carried an RFC 3339
-    nanosecond timestamp, a stream token (`00O`, `01O`, `01E`, `00O+`), and ANSI escape
-    sequences, plus `section_start`/`section_end` markers terminated by carriage returns. A
-    `Range: bytes=0-99` request returned 200 with the full body and no `Accept-Ranges` or
-    `Content-Range` header. A nonexistent job returned `404 {"message":"404 Not found"}`.
-29. **Merge endpoint.** Omitting `sha` returned `400 {"message":"SHA must be provided when
-    merging"}` for both token identities. A Developer token returned
-    `401 {"message":"401 Unauthorized"}` against the default branch, which is protected with
-    `merge_access_levels` of Maintainers. A wrong `sha` returned `409 {"message":"SHA does not
-    match HEAD of source branch: <actual sha>"}`. Already-merged, draft, and conflicting merge
-    requests each returned the byte-identical `405 {"message":"405 Method Not Allowed"}`. A
-    squash merge returned both a `squash_commit_sha` and a `merge_commit_sha`. The standalone
-    rebase route returned `202 {"rebase_in_progress":true}`.
-30. **Bot marker.** A note authored by a project access token identity and a note authored by a
-    human carried identical author key sets, neither containing `bot`. `GET /users/:id` returned
-    `bot: true` for the token identity, and returned it to a non-administrator token.
-    `GET /users?username=` omitted the field.
-31. **Branch deletion.** `DELETE .../repository/branches/:branch` returned 204 with an empty body
-    on success and `404 {"message":"404 Branch Not Found"}` for an absent branch. A branch name
-    containing a slash deleted successfully when percent-encoded. `should_remove_source_branch:
-    true` on the merge call did not delete the branch synchronously: it was still readable
-    immediately after the 200 merge response.
-
-The 2026-08-16 pass added the following against a purpose-built scratch project in the
-administrator's own namespace, with its own registered Docker-executor runner. Every result
-below was read with the project Developer token; the administrator token created the project,
-the runner, and the branches only.
-
-32. **A `manual` head pipeline can carry a failed job, in two arrangements.** A pipeline whose
-    stage `test` held `manual_gate` (`when: manual`, `allow_failure: false`) and `failing_job`
-    (`exit 1`) settled at `head_pipeline.status: "manual"` with jobs `failing_job: failed` and
-    `manual_gate: manual`. A second pipeline with `build_job` in stage `build`, `manual_gate` in
-    stage `gate`, and `failing_job` in stage `test` declaring `needs: [build_job]` likewise
-    settled at `manual`, with `build_job: success`, `manual_gate: manual`, and
-    `failing_job: failed`. Neither merge request's `detailed_merge_status` was affected: both
-    read `mergeable`, so the CI read is reached on a project that does not require passing
-    pipelines.
-33. **The commit-statuses view of those pipelines.** Scoped to `head_pipeline.sha` and
-    `head_pipeline.id`, the same-stage pipeline returned two entries (`manual_gate: manual`,
-    `failing_job: failed`, `allow_failure: false` on both) and the `needs` pipeline returned
-    three. Normalizing each through the job-outcome mapping yields `neutral` plus `failure`, and
-    `success` plus `neutral` plus `failure`, so `scmcore.MergeGate` returns `failing` for both.
-34. **A wholly manual pipeline folds to a merge-eligible verdict.** Two blocking manual jobs and
-    nothing else settled at `head_pipeline.status: "manual"` and returned two `manual` entries,
-    which normalize to two completed `neutral` runs, so `scmcore.MergeGate` returns `success`.
-35. **A manual gate blocking a later stage folds to a deferral.** `manual_gate` in stage `gate`
-    with `deploy_job` in stage `deploy` settled at `head_pipeline.status: "manual"` with
-    `deploy_job: created`, which normalizes to a `queued` run, so `scmcore.MergeGate` returns
-    `pending`. Folding the job set therefore distinguishes this shape from the wholly manual one,
-    which no single pipeline status can.
-36. **`pipeline_id` scoping is load-bearing on the statuses route.** Triggering a second pipeline
-    for an unchanged SHA moved `head_pipeline` to the new pipeline and left the commit carrying
-    two. The unfiltered statuses read returned `X-Total: 2` with one entry per pipeline; each
-    `pipeline_id` value returned `X-Total: 1`. Every fixture in this pass fit one page:
-    `X-Total` of 2, 3, 2, and 2 with `X-Total-Pages: 1`.
-37. **`head_pipeline` can describe a superseded commit.** After a commit that removed
-    `.gitlab-ci.yml`, and therefore created no pipeline, a merge request reported
-    `sha: 86c6dc4b` while `head_pipeline` still reported `id: 18`, `sha: 5487092b`, and
-    `status: "success"`. Its merge-request pipeline list carried that one pipeline only.
-38. **"Pipelines must succeed" reports `ci_still_running` for a `manual` head pipeline.** With
-    `only_allow_merge_if_pipeline_succeeds: true` on the project, all three `manual` merge
-    requests moved from `detailed_merge_status: "mergeable"` to `"ci_still_running"`, while
-    `merge_status` stayed `can_be_merged`. Setting the flag back to false restored `mergeable`.
-39. **The pipeline-status enum still has 13 values.** The instance's own GraphQL
-    `PipelineStatusEnum` and `CiJobStatus` each enumerate `created`, `waiting_for_resource`,
-    `preparing`, `waiting_for_callback`, `pending`, `running`, `success`, `failed`, `canceling`,
-    `canceled`, `skipped`, `manual`, and `scheduled`, matching `AVAILABLE_STATUSES` at
-    `v19.2.1-ee`. `DetailedMergeStatus` still enumerates 24 values, `ci_still_running` among
-    them.
-
-All fixture mutations made during the 2026-08-04 and 2026-08-05 passes were reverted:
-probe-created issues, notes, issue links, and labels were deleted, altered label sets and issue
-states were restored, and every token created for scope probing was revoked. The 2026-08-10
-fixtures were **left in place** as the SCM fixture blueprint: the `scmlab` group tree, the
-`scmlab/team/squad/mrlab` project, its merge requests, and the registered runner. The 2026-08-16
-pass created its own project and runner rather than mutating that blueprint, and deleted both
-afterwards.
-
----
-
 ## Source attribution
 
 | Topic | Primary source | Verification method |
@@ -2539,12 +2331,15 @@ afterwards.
 | Pipeline-status enum completeness | The live instance's own GraphQL introspection, and [`app/models/concerns/ci/has_status.rb`](https://gitlab.com/gitlab-org/gitlab/-/blob/v19.2.1-ee/app/models/concerns/ci/has_status.rb) | 13 values on both, against a control query whose known-good types resolved |
 | Declared authentication mechanisms, and the incompleteness of the machine-readable route surface | [`doc/api/openapi/openapi_v2.yaml`](https://gitlab.com/gitlab-org/gitlab/-/blob/v19.2.1-ee/doc/api/openapi/openapi_v2.yaml) and the [interactive rendering](https://docs.gitlab.com/api/openapi/openapi_interactive/) | Inspected for declared paths and parameters; live 404 on every instance-served description path |
 | Container image size and boot behavior | Docker Hub registry API; local image inspection | Measured pull, boot, healthcheck, and readiness polling |
-| Gitea and GitHub adapter behavior used in the comparison tables | The Gitea and GitHub adapter research notes in this directory, and `internal/domain/tracker.go` | Document and code reading at research time |
-| Decisions attributed to a shared package rather than to this adapter | `internal/scm/scmcore`, `internal/adaptertest`, `internal/httpkit`, `internal/issuekit`, `internal/registry`, and the `domain.SCMAdapter` and `domain.CIResult` godoc in `internal/domain` | Repository code reading after the adapter-family consolidation. No GitLab observation is involved, so these claims carry a symbol rather than an evidence tag |
+| Gitea and GitHub adapter behavior used in the comparison tables | The Gitea and GitHub adapter research notes in this directory, and `internal/domain/tracker.go` | Document and code reading |
+| Decisions attributed to a shared package rather than to this adapter | `internal/scm/scmcore`, `internal/adaptertest`, `internal/httpkit`, `internal/issuekit`, `internal/registry`, and the `domain.SCMAdapter` and `domain.CIResult` godoc in `internal/domain` | Repository code reading. No GitLab observation is involved, so these claims carry a symbol rather than an evidence tag |
 
-### Open questions
+---
 
-Carried forward explicitly rather than resolved by inference:
+## Open questions
+
+Every **[unknown]** tag in this document resolves to one row here. Each names the evidence
+that would settle it.
 
 | Question | Why it matters | Evidence that would settle it |
 | --- | --- | --- |

--- a/docs/jira-adapter-notes.md
+++ b/docs/jira-adapter-notes.md
@@ -1,269 +1,406 @@
-# Jira REST API: Adapter Research Notes
+# Jira REST API: Adapter research notes
 
-> Jira Cloud REST API v3, researched March 2026.
-> Reference for implementing the Jira `TrackerAdapter`.
+> Jira Cloud REST API v3 and Jira Server / Data Center REST API v2. No Jira deployment
+> version, revision, or edition is pinned: Jira Cloud is continuously deployed, the adapter
+> reads no version route, and no Server or Data Center instance has been probed. The Cloud v3
+> surface is documentation-derived from a reading of Atlassian's published REST API
+> documentation in March 2026; the Server / Data Center v2 surface is documentation-derived
+> from a second reading in June 2026, when `tracker.api_version` support shipped. Neither
+> reading recorded a per-claim citation, so this document carries no per-claim evidence tags
+> for its Jira statements and no probe record. Reference for implementing the Jira
+> `TrackerAdapter`. The adapter serves no `SCMAdapter` and no `CIStatusProvider` surface.
+
+## Provenance of every claim
+
+This is the weakest-evidenced document in the `docs/*-adapter-notes.md` family, and stating
+that plainly is more useful than implying a rigor it does not have. One tag marks the Jira
+claims with stronger backing:
+
+| Tag | Meaning |
+| --- | --- |
+| **[live-exercised]** | Exercised against a live Jira Cloud site by the env-gated integration suite `internal/tracker/jira/integration_test.go`, which the release and nightly workflows run with `SORTIE_JIRA_TEST=1` against site credentials held as repository secrets. The suite asserts that a route answers and that the normalized `domain.Issue` fields are populated; it captures no payload and inspects no header, so it is weaker evidence than a recorded probe, and it backs only the claims it is attached to. |
+
+Every other Jira statement in this document is untagged: it comes from the documentation
+readings named in the provenance block, it carries no per-claim citation, and no running
+instance has confirmed it. Treat an untagged Jira sentence as a documentation summary, not as
+observed behavior. Unsettled points are collected in [Open questions](#open-questions) rather
+than hedged inline.
+
+Claims about sortie's own code carry a Go symbol or package path instead of a tag and were
+each checked against `internal/tracker/jira/` and `internal/domain/`. Reading this repository
+is not an observation of Jira.
+
+The unit-test fixtures under `internal/tracker/jira/testdata/` are hand-authored, not captured
+payloads. They pin the adapter's decoding of a shape someone believed Jira returns; they are
+not evidence about Jira and are never cited as such below.
 
 ---
 
 ## Authentication
 
-Jira supports several authentication methods depending on hosting environment and use case.
+Jira accepts several authentication schemes. The adapter uses Basic with an API token on v3,
+and Basic or Bearer on v2.
 
-### Basic auth with API token (Cloud, recommended for Sortie)
+### Basic auth with an API token (Cloud, v3)
 
-The standard method for scripts and service integrations. Uses the user's email and an
-API token generated from their Atlassian account profile.
+The standard scheme for scripts and service integrations. It uses the user's email and an API
+token generated from their Atlassian account profile.
 
 - Generate a token at `https://id.atlassian.com/manage/api-tokens`.
 - Header: `Authorization: Basic <base64(email:api_token)>`
 
-This is the recommended method for Sortie because it runs as a background service, not
-an interactive user-facing application.
+Sortie uses this scheme on v3 because it runs as a background service, not an interactive
+user-facing application. **[live-exercised]** Every Jira integration job authenticates this
+way against a live Cloud site.
 
-### OAuth 2.0 (Cloud)
+### Personal access tokens (Server and Data Center, v2)
 
-The recommended method for external apps accessing Jira on behalf of users. Uses the
-authorization code grant type (3LO, Three-Legged OAuth). More secure as it restricts
-scope and doesn't require sharing user credentials.
-
-Not used by Sortie. Sortie runs as a headless background service and does not implement
-the interactive 3LO authorization flow or user-facing callback required by this pattern.
-
-### Personal Access Tokens (Data Center / Server)
-
-PATs act as a secure alternative to Basic Auth passwords, behaving like bearer tokens.
+Personal access tokens replace Basic Auth passwords on Jira Data Center and Server and behave
+like bearer tokens.
 
 - Header: `Authorization: Bearer <your_pat>`
-- Available in Jira Data Center and Server.
 
-Sortie supports PAT authentication when `tracker.api_version: "2"` is set. The adapter
-selects the auth mode from the `tracker.api_key` value using a presence-of-colon rule:
+`resolveAuth` selects the scheme from `tracker.api_key` on a presence-of-colon rule:
 
 - `api_key` contains a colon (`user:password`): Basic auth, `Authorization: Basic
-  base64(user:password)`. Both sides of the colon must be non-empty; an empty user
-  (`":password"`) or empty secret (`"user:"`) is rejected at construction time with
-  `ErrTrackerAuth`.
-- `api_key` has no colon (a colon-free token string): Bearer auth, `Authorization:
-  Bearer <token>`. This is the PAT path for Server and Data Center.
+  base64(user:password)`. Both sides of the colon must be non-empty; a colon at the first or
+  last character is rejected at construction with `domain.ErrTrackerAuth`.
+- `api_key` has no colon (a colon-free token string): Bearer auth, `Authorization: Bearer
+  <token>`. This is the personal-access-token path for Server and Data Center.
 
-Under an effective `api_version` of `"3"` - the default when the field is unset - a
-colon-free `api_key` is always rejected with `ErrTrackerAuth`, because v3 requires
-`email:token` format. The rule keys on the version, not the host: a self-hosted endpoint
-left at the default version rejects a PAT the same way a Cloud endpoint does, and the
-remedy is either an `email:token` key or `tracker.api_version: "2"`.
+Under an effective `api_version` of `"3"`, the default when the field is unset, a colon-free
+`api_key` is always rejected with `domain.ErrTrackerAuth`, because v3 requires `email:token`
+format. The rule keys on the version, not the host: a self-hosted endpoint left at the default
+version rejects a personal access token the same way a Cloud endpoint does, and the remedy is
+either an `email:token` key or `tracker.api_version: "2"`. `authFormatError` owns both message
+texts.
+
+### OAuth 2.0
+
+The scheme Atlassian recommends for external apps acting on Jira on behalf of users. It uses
+the authorization code grant (3LO, three-legged OAuth), restricts scope, and avoids sharing
+user credentials.
+
+The adapter does not implement it. Sortie runs as a headless background service and has
+neither the interactive 3LO authorization flow nor the user-facing callback the pattern
+requires.
 
 ### Config mapping
 
-| Config field            | Cloud (v3)                                           | Server / DC (v2)                                   |
-| ----------------------- | ---------------------------------------------------- | -------------------------------------------------- |
+| Config field            | Cloud (v3)                                           | Server / DC (v2)                                    |
+| ----------------------- | ---------------------------------------------------- | --------------------------------------------------- |
 | `tracker.endpoint`      | `https://<site>.atlassian.net` (no trailing /)       | `https://jira.internal.example.com` (no trailing /) |
-| `tracker.api_key`       | `email:api_token`; splits on first `:`               | `user:password` (Basic) or PAT token (Bearer)      |
-| `tracker.project`       | Jira project key, e.g. `SORT`                        | Same                                               |
-| `tracker.api_version`   | `"3"` (default, may be omitted)                      | `"2"` (required for Server / DC)                   |
+| `tracker.api_key`       | `email:api_token`; splits on first `:`               | `user:password` (Basic) or a token (Bearer)         |
+| `tracker.project`       | Jira project key, e.g. `SORT`                        | Same                                                |
+| `tracker.api_version`   | `"3"` (default, may be omitted)                      | `"2"` (required for Server / DC)                    |
 
 Encoding `email:token` in a single field follows curl convention (`-u email:token`) and avoids
-adding Jira-specific config keys to the core schema. The value may be provided via environment
-variable indirection (e.g. `$JIRA_API_KEY`) if the config layer supports it.
+adding Jira-specific config keys to the core schema. `internal/config` resolves
+`tracker.api_key` through `os.ExpandEnv`, so a value such as `$JIRA_API_KEY` expands from the
+environment.
 
-**Construction-time host/version guard:** An `endpoint` that is not a URL with a scheme
-and host is rejected at startup (`ErrTrackerPayload`). A `.atlassian.net` endpoint combined
-with `api_version: "2"` is rejected at startup (`ErrTrackerPayload`). A non-`.atlassian.net`
-endpoint combined with `api_version: "3"` emits a warning and proceeds, except for a
-loopback IP or `localhost` endpoint, which is a test or local-dev target and does not
-warn.
+`normalizeAPIVersion` accepts a string, an int, or a whole-number float, trims surrounding
+whitespace, and resolves an absent or empty value to `"3"`. Any other value returns
+`domain.ErrTrackerPayload`.
 
-**Offline parity:** the adapter's `sortie validate` hook re-decides the three
-version-dependent faults above without constructing an adapter or touching the network -
-an `api_version` outside `"2"` and `"3"`, `"2"` against an `.atlassian.net` endpoint, and
-a colon-free `api_key` at an effective version of `"3"` - and reuses the constructor's own
-message text, so the offline verdict cannot drift from the startup verdict. An invalid
-`api_version` suppresses the Cloud-conflict diagnostic, mirroring the constructor, which
-never reaches the host/version guard for a version it rejects.
+### Construction-time guards
 
-**CAPTCHA caveat:** After several failed logins Jira triggers CAPTCHA and returns
-`X-Seraph-LoginReason: AUTHENTICATION_DENIED`. The adapter should detect this header and
-return `tracker_auth_error`.
+`NewJiraAdapter` rejects a bad configuration before any network call, in this order:
+
+1. An empty `endpoint` returns `domain.ErrTrackerPayload`.
+2. An `endpoint` containing `/rest/api/` returns `domain.ErrTrackerPayload`: the field is the
+   base URL, and the adapter appends the REST path itself.
+3. An `api_version` outside `"2"` and `"3"` returns `domain.ErrTrackerPayload`
+   (`normalizeAPIVersion`).
+4. An `endpoint` that is not a URL with both a scheme and a host returns
+   `domain.ErrTrackerPayload` (`checkHostVersion`, which redacts any userinfo in the message
+   through `httpkit.RedactURLUserinfo`).
+5. A `.atlassian.net` endpoint combined with `api_version: "2"` returns
+   `domain.ErrTrackerPayload` (`cloudVersionConflict`).
+6. An empty `api_key` returns `domain.ErrMissingTrackerAPIKey`; a malformed one returns
+   `domain.ErrTrackerAuth` (`resolveAuth`).
+7. An empty `project` returns `domain.ErrMissingTrackerProject`.
+
+A non-`.atlassian.net` endpoint combined with `api_version: "3"` logs a warning and proceeds,
+except for a loopback IP or `localhost` endpoint, which `isLocalEndpoint` treats as a test or
+local-dev target and does not warn about.
+
+### Offline validate parity
+
+`validateConfig` re-decides the same faults for `sortie validate` without constructing an
+adapter or touching the network, and reuses the constructor's own message text where one
+exists, so the offline verdict cannot drift from the startup verdict. It emits eight
+Jira-specific diagnostics, all at severity `error`:
+
+| Check | Condition |
+| --- | --- |
+| `tracker.endpoint.missing` | `tracker.endpoint` is empty |
+| `tracker.endpoint.api_suffix` | the trimmed endpoint contains `/rest/api/` |
+| `tracker.endpoint.invalid` | the trimmed endpoint is not a URL with a scheme and host |
+| `tracker.api_version.invalid` | `tracker.api_version` is outside `"2"` and `"3"` |
+| `tracker.api_version.cloud_conflict` | `"2"` against a `.atlassian.net` endpoint |
+| `tracker.api_key.jira_format` | the colon sits at the first or last character of the key |
+| `tracker.api_key.jira_cloud_format` | a colon-free key against a Cloud endpoint |
+| `tracker.api_key.jira_v3_format` | a colon-free key at an effective version of `"3"` |
+
+It also runs the shared state diagnostics: `registry.DiagStateLabelElements` on
+`tracker.active_states` and `tracker.terminal_states` at severity `warning`, and
+`registry.DiagStateOverlap`. An invalid `api_version` suppresses the Cloud-conflict
+diagnostic, mirroring the constructor, which never reaches the host/version guard for a
+version it rejects. `validateAPIKeyFormat` skips its version arm when the endpoint host cannot
+be classified, since `validateEndpoint` already reports that fault. The `api_key` value never
+appears in a diagnostic message.
+
+### CAPTCHA challenge
+
+After several failed logins Jira triggers CAPTCHA and returns `X-Seraph-LoginReason:
+AUTHENTICATION_DENIED`. `classifyHTTPError` maps 401 and 403 to `domain.ErrTrackerAuth`
+whether or not the header is present; when it carries that value the error message names the
+CAPTCHA challenge and points the operator at a browser login. The header changes the message,
+not the error kind.
 
 ---
 
-## Endpoints
+## Endpoints and operations
 
-Each `TrackerAdapter` operation maps to a Jira REST endpoint. The base path is
-`/rest/api/3` when `api_version` is `"3"` (default) and `/rest/api/2` when
-`api_version` is `"2"`. The table below shows the v3 paths; substitute `/rest/api/2`
-for v2. The one exception is the search resource: v3 uses `/rest/api/3/search/jql`
-whereas v2 uses `/rest/api/2/search` (no `/jql` segment).
+Each `domain.TrackerAdapter` operation maps to a Jira REST endpoint. `basePath` returns
+`/rest/api/3` when `api_version` is `"3"` (the default) and `/rest/api/2` when it is `"2"`.
+The routes below show the v3 paths; substitute `/rest/api/2` for v2. The one exception is the
+search resource: v3 uses `/rest/api/3/search/jql` whereas v2 uses `/rest/api/2/search`, with
+no `/jql` segment.
 
-### v2 body format
+`newJiraClient` builds the shared `httpkit.Client` with a 30 second timeout and sets
+`Authorization`, `Accept: application/json`, and `User-Agent` on every request. The user agent
+is `sortie/<version>`, injected by `cmd/sortie` as the `user_agent` adapter config key, and
+falls back to `sortie/dev` when absent.
 
-On v2, `description` and comment `body` fields are returned as a **raw string in Jira
-wiki markup** (for example `h2. Heading`, `*bold*`, `{code}...{code}`). The adapter
-reads this string verbatim; it does not flatten or translate markup tokens. Downstream
-consumers (prompt templates, agents) therefore see wiki markup rather than clean prose
-when `api_version: "2"` is set. The v3 path returns ADF, which the adapter flattens to
-text before storing in `domain.Issue.Description` and `domain.Comment.Body`.
+### Body format by version
 
-Comment creation on v2 sends a raw-string body:
+On v3, `description` and comment `body` are ADF (Atlassian Document Format) JSON trees, which
+`extractBody` flattens to text through `flattenADF` before storing in
+`domain.Issue.Description` and `domain.Comment.Body`.
+
+On v2, the same fields are JSON strings carrying Jira wiki markup (for example `h2. Heading`,
+`*bold*`, `{code}...{code}`). `extractBody` unquotes the JSON string and returns it verbatim,
+translating no markup token. Downstream consumers (prompt templates, agents) therefore see
+wiki markup rather than clean prose when `api_version: "2"` is set. Rendered HTML
+(`expand=renderedBody`) is not requested and not in scope. Empty or undecodable input yields
+an empty string on both versions.
+
+Comment creation mirrors the split, through `commentPayload`. On v2 the request body is a raw
+string:
 
 ```json
 {"body": "<text>"}
 ```
 
-Comment creation on v3 sends an ADF document (see ADF flattening section below).
+On v3 it is an ADF document (see [ADF flattening](#adf-flattening)).
 
-### v2 search pagination
+### 1. `FetchCandidateIssues`
 
-The v2 search endpoint (`GET /rest/api/2/search`) uses offset-based pagination
-(`startAt` / `total`). The adapter loops until `startAt + page_count >= total` or the
-page is empty. Page size is 50 for both versions.
-
-### 1. `FetchCandidateIssues` → `GET /rest/api/3/search/jql`
-
-JQL:
+`GET /rest/api/3/search/jql`, built by `buildCandidateJQL`:
 
 ```
 project = "<KEY>" AND status IN ("<state1>", "<state2>", ...) ORDER BY priority ASC, created ASC
 ```
 
-Query params: `jql`, `fields`, `maxResults`, `nextPageToken`
+Query params: `jql`, `fields`, `maxResults`, `nextPageToken`.
 
-Request only needed fields:
-`summary`, `status`, `priority`, `labels`, `assignee`, `issuetype`, `parent`,
-`issuelinks`, `created`, `updated`, `description`
+The `fields` value is the `searchFields` constant, which requests only `summary`, `status`,
+`priority`, `labels`, `assignee`, `issuetype`, `parent`, `issuelinks`, `created`, `updated`,
+and `description`. It does not request `comment`; comments have their own endpoint, and
+`FetchCandidateIssues` sets `Comments` to nil on every issue it returns.
 
-Does **not** request `comment` (separate call; comments use a dedicated endpoint).
+When `tracker.query_filter` is set, its raw JQL fragment is appended as ` AND (<fragment>)`
+before the `ORDER BY` clause.
 
-Note: `POST /rest/api/3/search/jql` also accepts JQL in the request body and avoids URI
-length limits for very long queries. However, POST uses offset-based pagination and
-Atlassian recommends the GET endpoint with cursor-based pagination. Sortie's JQL queries
-are short enough for GET.
+**[live-exercised]** The route answers with this JQL and the requested fields populate `ID`,
+`Identifier`, `Title`, `State`, `Labels`, `URL`, `CreatedAt`, and `UpdatedAt` on every issue
+returned.
 
-### 2. `FetchIssueByID` → `GET /rest/api/3/issue/{issueIdOrKey}`
+### 2. `FetchIssueByID`
 
-Query param `fields` to select specific fields. Returns a single issue with full detail.
+`GET /rest/api/3/issue/{issueIdOrKey}` with the `fields` param set to `searchFields`. The
+`issueID` argument is the Jira issue key, for example `PROJ-123`. The operation then calls
+`fetchComments` for the same issue, so a fully populated issue costs two or more requests. A
+404 on either request is re-wrapped as `domain.ErrTrackerNotFound` with the message
+`issue not found: <key>`.
 
-The `description` field uses **ADF** (Atlassian Document Format), a JSON tree, not plain text.
-Must be flattened (see ADF section below).
+**[live-exercised]** The route answers for a key drawn from the candidate set, returns a
+non-nil `Comments` slice, and returns `domain.ErrTrackerNotFound` for a key that does not
+exist.
 
-### 3. `FetchIssuesByStates` → `GET /rest/api/3/search/jql`
+### 3. `FetchIssuesByStates`
 
-JQL:
+`GET /rest/api/3/search/jql`, built by `buildStatesFetchJQL`:
 
 ```
 project = "<KEY>" AND status IN ("<state1>", ...) ORDER BY created ASC
 ```
 
-Same endpoint as candidate fetch, different JQL. No orchestrator caller invokes this
-operation; startup terminal cleanup is served by `FetchIssueStatesByIdentifiers` instead.
-Paginate to fetch all matching issues.
+Same endpoint as the candidate fetch with different JQL, and `tracker.query_filter` merges the
+same way. No orchestrator caller and no agent tool invokes this operation; startup terminal
+cleanup is served by `FetchIssueStatesByIdentifiers` instead. Adapters implement it to satisfy
+`domain.TrackerAdapter`. An empty `states` argument returns an empty slice without a request.
 
-### 4. `FetchIssueStatesByIDs` → `GET /rest/api/3/search/jql`
+**[live-exercised]** The route answers, and every issue returned carries a state from the
+requested set.
 
-JQL:
+### 4. `FetchIssueStatesByIDs`
+
+`GET /rest/api/3/search/jql`, built by `buildIDINJQL`:
+
+```
+id IN (10001, 10002, ...) ORDER BY key ASC
+```
+
+`id IN (...)` takes Jira's numeric internal IDs, which is what this operation receives.
+`buildIDINJQL` drops any non-numeric element, so a caller bug such as passing a key surfaces
+as a missing map entry rather than a query against the wrong issue; a batch with no numeric ID
+left produces no request at all. Only the `status` field is requested, keeping the payload
+small. Used for active-run reconciliation. `tracker.query_filter` is deliberately not applied:
+these issues already passed filtering at dispatch time.
+
+Keys and IDs are batched at `batchSize`, 40 per request, on every call rather than only on
+large sets, because a long `IN` clause in a GET URL exceeds URI length limits. The loop checks
+`ctx.Err()` between batches.
+
+**[live-exercised]** The route answers for a batch of candidate IDs and returns a non-empty
+state for each.
+
+### 5. `FetchIssueStatesByIdentifiers`
+
+`GET /rest/api/3/search/jql`, built by `buildKeyINJQL`:
 
 ```
 key IN ("PROJ-1", "PROJ-2", ...) ORDER BY key ASC
 ```
 
-Request only `status` field to minimize payload. Used for active-run reconciliation.
+`key IN (...)` takes project-prefixed keys. Only the `status` field is requested, the same
+`batchSize` of 40 applies, and `tracker.query_filter` is likewise not applied. Used for
+startup terminal workspace cleanup. Issues not found are omitted from the returned map rather
+than reported as an error.
 
-Note: `id IN (...)` uses numeric internal IDs; `key IN (...)` uses project-prefixed keys.
+### 6. `FetchIssueComments`
 
-With many running issues (50+), the `key IN (...)` JQL in a GET URL may exceed URI length
-limits. When this happens, split the keys into smaller batches and issue multiple
-`GET /rest/api/3/search/jql` requests so each URL stays within safe limits.
+`GET /rest/api/3/issue/{issueIdOrKey}/comment`.
 
-### 5. `FetchIssueComments` → `GET /rest/api/3/issue/{issueIdOrKey}/comment`
+Query params: `startAt`, `maxResults`, `orderBy`. `fetchComments` sends `orderBy=created` and
+a `maxResults` of `maxCommentResults`, 50.
 
-Query params: `startAt`, `maxResults`, `orderBy`
+Response: `{ startAt, maxResults, total, comments: [...] }`. Each comment carries `id`,
+`author.displayName`, `body`, and `created`; `normalizeComments` maps them through
+`issuekit.NormalizeComments`, and a nil author yields an empty author string. A 404 becomes
+`domain.ErrTrackerNotFound`. No comments yields an empty non-nil slice.
 
-Response: `{ startAt, maxResults, total, comments: [...] }`
+**[live-exercised]** The route answers and every comment returned carries a non-empty `ID` and
+`CreatedAt`.
 
-Comment body uses ADF and must be flattened. Each comment has `id`, `author.displayName`,
-`body` (ADF), `created`, `updated`.
+### 7. `TransitionIssue`
 
-### Transitions
+The orchestrator calls this after a successful worker run to move the issue to the configured
+`tracker.handoff_state`, for example "Human Review" (per ADR-0007).
 
-Sortie uses these endpoints for orchestrator-initiated handoff transitions when
-`tracker.handoff_state` is configured (per ADR-0007). After a successful worker run, the
-orchestrator calls `TransitionIssue` to move the issue to the configured handoff state
-(e.g., "Human Review").
+- `GET /rest/api/3/issue/{issueIdOrKey}/transitions` lists the transitions available for the
+  issue given the current user's permissions and the workflow rules. The adapter matches the
+  configured target state against `transition.to.name` case-insensitively and takes the first
+  match, not the transition label (`transition.name`), which avoids workflow-specific naming
+  fragility.
+- `POST /rest/api/3/issue/{issueIdOrKey}/transitions` executes the transition. Request body:
+  `{ "transition": { "id": "<transition_id>" } }`. Success is `204 No Content` with an empty
+  body.
 
-- `GET /rest/api/3/issue/{issueIdOrKey}/transitions`: lists available transitions for an
-  issue based on the current user's permissions and workflow rules. The adapter matches the
-  configured target state against `transition.to.name` (case-insensitive), not the
-  transition label (`transition.name`), to avoid workflow-specific naming fragility.
-- `POST /rest/api/3/issue/{issueIdOrKey}/transitions`: executes a transition, moving the
-  issue to a new status. Request body: `{ "transition": { "id": "<transition_id>" } }`.
-  Returns `204 No Content` on success (empty body).
+When no available transition targets the requested state, the adapter returns
+`domain.ErrTrackerPayload` with the message `no transition to state %q available for issue
+%s`, without issuing the POST.
 
-OAuth scopes required: `write:jira-work` (classic) or `write:issue:jira` (granular). This
-is an escalation from the read-only scopes (`read:jira-work`) used by other adapter
-operations.
+OAuth scopes required: `write:jira-work` (classic) or `write:issue:jira` (granular). This is
+an escalation from the read-only scopes (`read:jira-work`) the fetch operations use.
+
+### 8. `CommentIssue`
+
+`POST /rest/api/3/issue/{issueIdOrKey}/comment` with the body shape described in
+[Body format by version](#body-format-by-version). On v3 `buildADFComment` splits the text on
+newlines and emits one ADF paragraph node per line, so line breaks render correctly in Jira's
+UI; an empty line becomes a paragraph with empty content.
+
+### 9. `AddLabel`
+
+`PUT /rest/api/3/issue/{issueIdOrKey}` with an update-verb body:
+
+```json
+{"update": {"labels": [{"add": "<label>"}]}}
+```
+
+Used for CI failure escalation. The orchestrator treats `AddLabel` errors as non-fatal.
 
 ---
 
-## Field Mapping
+## Field mapping
 
-`domain.Issue` field → Jira REST response path:
+`normalizeSearchIssue` maps a Jira response to `domain.Issue`:
 
-| `domain.Issue` field | Jira field                        | Notes                                   |
+| `domain.Issue` field | Jira response path                | Notes                                   |
 | -------------------- | --------------------------------- | --------------------------------------- |
-| `ID`                 | `id` (string)                     | Numeric ID as string                    |
+| `ID`                 | `id` (string)                     | Numeric ID as a string                  |
 | `Identifier`         | `key` (string)                    | e.g. `"PROJ-123"`                       |
 | `Title`              | `fields.summary`                  |                                         |
-| `Description`        | `fields.description`              | v3: ADF flattened to text. v2: raw string (wiki markup). |
-| `Priority`           | `fields.priority.id` (string)     | e.g. `"3"` → int 3; use `id` not `name` |
-| `State`              | `fields.status.name`              | Preserve original casing                |
-| `BranchName`         | —                                 | See dev-status note below               |
-| `URL`                | `{endpoint}/browse/{key}`         | Constructed                             |
-| `Labels`             | `fields.labels` (string array)    | Lowercase each                          |
-| `Assignee`           | `fields.assignee.displayName`     | Nil → empty string                      |
+| `Description`        | `fields.description`              | v3: ADF flattened to text. v2: raw wiki-markup string. |
+| `Priority`           | `fields.priority.id` (string)     | `issuekit.ParsePriorityIntFromString`; a non-integer yields nil. Read `id`, never `name`. |
+| `State`              | `fields.status.name`              | Original casing preserved              |
+| `BranchName`         | not set                           | See [branch name](#branch-name)         |
+| `URL`                | `{endpoint}/browse/{key}`         | Constructed by the adapter              |
+| `Labels`             | `fields.labels` (string array)    | `issuekit.NormalizeLabels` lowercases each |
+| `Assignee`           | `fields.assignee.displayName`     | Nil yields an empty string              |
 | `IssueType`          | `fields.issuetype.name`           |                                         |
 | `Parent`             | `fields.parent.id`, `.parent.key` | Nil when absent                         |
-| `Comments`           | Separate endpoint                 | v3: ADF flattened to text. v2: raw string (wiki markup). |
-| `BlockedBy`          | `fields.issuelinks[]` (filtered)  | See blocker extraction below            |
-| `CreatedAt`          | `fields.created` (ISO-8601)       |                                         |
-| `UpdatedAt`          | `fields.updated` (ISO-8601)       |                                         |
+| `Comments`           | separate endpoint                 | See operation 6                         |
+| `BlockedBy`          | `fields.issuelinks[]` (filtered)  | See [blocker extraction](#blocker-extraction-from-issuelinks) |
+| `CreatedAt`          | `fields.created`                  | Stored verbatim as a string             |
+| `UpdatedAt`          | `fields.updated`                  | Stored verbatim as a string             |
 
-### BranchName via dev-status API
+**[live-exercised]** `CreatedAt` and `UpdatedAt` parse as either RFC 3339 or the Jira
+millisecond-and-offset form `2006-01-02T15:04:05.000-0700`; the adapter itself performs no
+timestamp parsing.
 
-Not available through the core REST API v3. However, Jira Cloud exposes development
-information via `GET /rest/dev-status/latest/issue/detail?issueId={id}&applicationType=GitHub`
-when a source control tool (GitHub, Bitbucket) is connected. This returns branches, commits,
-and PRs linked to the issue. Not required for initial implementation but noted as a potential
-future source.
+### Branch name
+
+`domain.Issue.BranchName` is left empty. The core REST API does not carry it. Jira Cloud
+exposes development information at
+`GET /rest/dev-status/latest/issue/detail?issueId={id}&applicationType=GitHub`, which returns
+the branches, commits, and pull requests linked to an issue when a source control tool (GitHub,
+Bitbucket) is connected. The adapter does not call that route.
 
 ### Blocker extraction from `issuelinks`
 
-The "Blocks" link type has `type.inward = "is blocked by"` and `type.outward = "blocks"`.
-
-When reading links from the **blocked** issue, the blocking issue appears in `inwardIssue`.
-Filter for links where:
-
-- `type.name == "Blocks"` AND `inwardIssue` is present
-- Extract `inwardIssue.key` as the blocker identifier.
-
-Example: if issue A blocks issue B, then on issue B the link looks like:
+The "Blocks" link type has `type.inward = "is blocked by"` and `type.outward = "blocks"`. Read
+from the blocked issue, the blocking issue appears in `inwardIssue`. If issue A blocks issue
+B, then on issue B the link looks like:
 
 ```json
 {
   "type": { "name": "Blocks", "inward": "is blocked by" },
-  "inwardIssue": { "key": "A-1" }
+  "inwardIssue": {
+    "id": "10020",
+    "key": "PROJ-20",
+    "fields": { "status": { "name": "To Do" } }
+  }
 }
 ```
 
-Caveats:
+`extractBlockers` keeps links whose `type.name` equals the `blockerLinkTypeName` constant,
+`"Blocks"`, and whose `inwardIssue` is present, and builds a `domain.BlockerRef` from
+`inwardIssue.id` and `inwardIssue.key`, adding `inwardIssue.fields.status.name` as the blocker
+state when the response carries it. Links with only an `outwardIssue` are skipped, so a
+dependent issue is never mistaken for a blocker.
 
-- The link type name "Blocks" may be renamed by Jira admins. The adapter should make
-  the expected link type name configurable (or at minimum, a named constant) so it can
-  be adjusted without code changes.
-- Verify link direction against live Jira responses during adapter implementation;
-  the inward/outward semantics depend on which issue the link is read from.
+The comparison is exact and the link type name is a compile-time constant, so a Jira admin who
+renames the "Blocks" link type silently removes every blocker from the adapter's view, and
+blocked issues dispatch anyway.
 
-### ADF (Atlassian Document Format) flattening
+### ADF flattening
 
-Jira v3 returns `description` and comment `body` as ADF JSON:
+An ADF document is a typed node tree:
 
 ```json
 {
@@ -278,69 +415,76 @@ Jira v3 returns `description` and comment `body` as ADF JSON:
 }
 ```
 
-The adapter must recursively walk the tree and extract all `text` node values, joining
-paragraphs with newlines. Without this, `Description` and comment `Body` would be raw JSON.
-
-**v2 bodies are not ADF:** When `api_version: "2"`, `description` and comment `body` are
-JSON strings containing Jira wiki markup, not ADF objects. The adapter reads them verbatim
-with a JSON string unquote, not ADF flattening. Rendered HTML (`expand=renderedBody`) is
-not requested and not in scope.
+`flattenADF` walks the tree recursively, concatenating the `text` value of every `text` node
+and appending a newline after each node whose type is in `blockLevelTypes` (paragraph,
+heading, the list and table families, blockquote, codeBlock, rule, media, panel, decision, and
+task nodes). Trailing newlines and spaces are trimmed from the result. Nil or non-map input
+yields an empty string. Without this step, `Description` and comment `Body` would carry raw
+JSON.
 
 ---
 
 ## Pagination
 
-### v3 search endpoint (`GET /rest/api/3/search/jql`), cursor-based
+### v3 search endpoint, cursor-based
 
-- First request: omit `nextPageToken`, set `maxResults` (recommend `50`).
+`paginatedSearch` drives `httpkit.NewTokenPaginator` against `/rest/api/3/search/jql` with the
+`nextPageToken` parameter and a `maxResults` of `maxSearchResults`, 50.
+
+- First request: omit `nextPageToken`.
 - Subsequent requests: pass the `nextPageToken` from the previous response.
-- Stop when `nextPageToken` is absent from the response.
-- If the response returns fewer results than `maxResults` but `nextPageToken` is missing
-  and there are signals of remaining data, raise `tracker_missing_end_cursor` rather than
-  silently treating pagination as complete.
+- The walk ends when the response carries no `nextPageToken`.
 
-`POST /rest/api/3/search/jql` uses offset-based (`startAt`/`total`) pagination but is
-deprecated for new integrations. Prefer `GET` with cursor-based pagination.
+`httpkit.Paginator.All` treats an absent token as the end of the walk unconditionally. The
+Jira decoder never returns `domain.ErrTrackerMissingCursor`, so a truncated result set caused
+by a dropped cursor is indistinguishable from a complete one.
 
-### v2 search endpoint (`GET /rest/api/2/search`), offset-based
+`POST /rest/api/3/search/jql` also accepts JQL in the request body and so avoids URI length
+limits on very long queries, but it paginates by offset (`startAt`/`total`) and Atlassian
+recommends the cursor-based GET for new integrations. The adapter uses GET only; its JQL is
+short enough, and long `IN` clauses are handled by batching instead.
 
-The v2 endpoint uses offset-based pagination. The adapter maintains a `startAt` counter
-and advances it by the number of results returned per page.
+### v2 search endpoint, offset-based
+
+`paginatedSearchV2` maintains a `startAt` counter against `/rest/api/2/search` with the same
+page size of 50.
 
 - First request: `startAt=0`, `maxResults=50`.
 - Subsequent requests: `startAt += len(page.issues)`.
 - Stop when `len(page.issues) == 0` or `startAt + len(page.issues) >= total`.
 
-This mirrors the comment pagination loop already used by both v2 and v3.
+The loop checks `ctx.Err()` before each request. It mirrors the comment pagination loop, which
+both versions share.
 
 ### Comment endpoint, offset-based
 
-- `startAt` (0-indexed), `maxResults` (default 50)
-- Response includes `total`. Continue while `startAt + len(comments) < total`.
+`fetchComments` sends `startAt` (0-indexed) and `maxResults` of 50, and continues while
+`startAt + len(comments) < total`, on both versions.
 
 ---
 
-## Rate Limiting
+## Rate limiting
 
-Jira Cloud enforces three independent rate limiting systems:
+Jira Cloud enforces three independent rate limiting systems.
 
-### 1. Points-based quota (per-hour)
+### Points-based quota, per hour
 
-- Each call consumes points: base 1 + object costs (e.g., single issue GET = 2 points).
-- Default quota: **65,000 points/hour** (resets at top of UTC hour).
-- API-token traffic may be exempt from points-based limits (as of March 2026).
+- Each call consumes points: base 1 plus object costs, so a single-issue GET costs 2 points.
+- Default quota: 65,000 points per hour, reset at the top of the UTC hour.
 
-### 2. Burst rate limits (per-second, per-endpoint)
+### Burst rate limits, per second and per endpoint
 
-- Token bucket algorithm per endpoint per tenant.
+- A token bucket per endpoint per tenant.
 - Defaults: GET 100 req/s, POST 100 req/s, PUT 50 req/s, DELETE 50 req/s.
-- `GET /rest/api/3/issue/{id}`: 150 req/s burst bucket.
+- `GET /rest/api/3/issue/{id}`: a 150 req/s bucket.
 - `GET /rest/api/3/search/jql`: 100 req/s.
 
-### 3. Per-issue write limits
+### Per-issue write limits
 
-- 20 writes/2s, 100 writes/30s per issue.
-- **Not relevant.** Sortie is read-only from the tracker.
+- 20 writes per 2 seconds and 100 writes per 30 seconds, per issue.
+- The adapter writes on three operations: `TransitionIssue`, `CommentIssue`, and `AddLabel`.
+  All three target a single issue and fire on session lifecycle events, so the write path is
+  in scope for this limit even though the orchestrator's normal cadence stays well under it.
 
 ### 429 handling
 
@@ -353,36 +497,92 @@ All limits return `429 Too Many Requests` with:
 | `X-RateLimit-Reset`     | ISO-8601 reset timestamp                            |
 | `RateLimit-Reason`      | `jira-quota-global-based`, `jira-burst-based`, etc. |
 
-**Adapter guidance:** Respect `Retry-After` as minimum delay. Exponential backoff with jitter
-(base 2s, max 30s, jitter ±30%). Map 429 → `tracker_api_error` with `Retry-After` preserved.
+`classifyHTTPError` maps 429 to `domain.ErrTrackerAPI` and interpolates `Retry-After` into the
+error message when the header is present. `domain.TrackerError` has no field for the value, so
+it survives as message text only, and the status reaches the caller through
+`TrackerError.Status`. The adapter performs no retry and no backoff of its own:
+`domain.TrackerErrorKind.RetryClassification` marks `ErrTrackerAPI` retryable with
+`domain.BackoffExponential`, and the orchestrator owns the delay.
 
 ---
 
-## Error Mapping
+## Error mapping
 
-HTTP status → error category:
+`classifyHTTPError` maps a non-success HTTP response to a `domain.TrackerError`, reading up to
+`maxErrorBody` (512) bytes of the body into the message for diagnostics:
 
-| HTTP Status | Condition                  | Error Category            |
+| HTTP status | Condition                  | Error kind                |
 | ----------- | -------------------------- | ------------------------- |
-| 200         | Success                    | —                         |
 | 400         | Bad JQL, invalid request   | `tracker_payload_error`   |
-| 401         | Invalid/expired token      | `tracker_auth_error`      |
+| 401         | Invalid or expired token   | `tracker_auth_error`      |
 | 403         | Insufficient permissions   | `tracker_auth_error`      |
-| 404         | Issue/resource not found   | `tracker_api_error`       |
+| 404         | Issue or resource not found | `tracker_not_found`      |
 | 429         | Rate limited               | `tracker_api_error`       |
 | 5xx         | Server error               | `tracker_transport_error` |
-| TCP/DNS     | Network failure            | `tracker_transport_error` |
-| —           | JSON decode failure on 200 | `tracker_payload_error`   |
-| —           | CAPTCHA (X-Seraph header)  | `tracker_auth_error`      |
+| other       | Any other non-success status | `tracker_api_error`     |
+
+`httpkit.ClassifyTransport` maps a TCP or DNS failure to `tracker_transport_error`. A JSON
+decode failure on a 200 produces `tracker_payload_error` at each call site, with a message
+naming the response that failed to parse. `FetchIssueByID` and `fetchComments` re-wrap a 404
+as `tracker_not_found` with an `issue not found: <key>` message, replacing the generic route
+message.
 
 ---
 
-## Config Notes
+## Config notes
 
-- **`tracker.api_key` format:** `email:api_token`, split on first `:`.
-- **`tracker.endpoint`:** Site URL without trailing slash or path. Adapter appends `/rest/api/3/...`.
-- **`tracker.project`:** Jira project key used in all JQL queries.
-- **`tracker.active_states`:** Common defaults: `["Backlog", "Selected for Development", "In Progress"]`.
-- **`tracker.terminal_states`:** Common defaults: `["Done", "Cancelled"]`.
-- **JQL quoting:** Always quote string values in JQL to handle special characters in state names.
-- **Network timeout:** 30000 ms.
+- **`tracker.api_key`:** `email:api_token` on v3, split on the first `:`. See
+  [authentication](#authentication) for the v2 forms.
+- **`tracker.endpoint`:** site URL without a trailing slash or path. The adapter appends
+  `/rest/api/<version>/...`.
+- **`tracker.project`:** Jira project key, used in the candidate and states JQL.
+- **`tracker.active_states`:** defaults to `["Backlog", "Selected for Development", "In
+  Progress"]` (`defaultActiveStates`, published to the registry as
+  `registry.TrackerMeta.DefaultActiveStates`).
+- **`tracker.terminal_states`:** common defaults: `["Done", "Cancelled"]`.
+- **`tracker.query_filter`:** a raw JQL fragment appended as ` AND (<fragment>)` to the
+  candidate and states queries. The adapter does not parse or validate it, and it is not
+  applied to the reconciliation queries.
+- **`tracker.api_version`:** `"2"` or `"3"`, defaulting to `"3"`.
+- **JQL quoting:** `escapeJQLString` strips double-quote characters from every interpolated
+  project key, state name, and issue key. JQL delimits string literals with double quotes and
+  offers no backslash escape for them, so removal is the only safe treatment.
+- **Network timeout:** 30 seconds, set on the shared `httpkit.Client`.
+
+---
+
+## Open questions
+
+Carried forward explicitly rather than resolved by inference. Nothing in this section is
+asserted anywhere else in the document.
+
+| Question | Why it matters | Evidence that would settle it |
+| --- | --- | --- |
+| Does a live instance really place the blocking issue in `inwardIssue` when the link is read from the blocked issue? | `extractBlockers` reads `inwardIssue` only; a reversed convention silently drops every blocker and blocked issues dispatch anyway | Create a "Blocks" link between two issues and read `fields.issuelinks` from both sides |
+| Under what `type.name` does a renamed "Blocks" link type appear? | `blockerLinkTypeName` compares exactly, so a rename is a silent blocker loss | Rename the link type in a test project and re-read `fields.issuelinks` |
+| Do `CommentIssue` and `AddLabel` need scopes beyond `write:jira-work` / `write:issue:jira`? | The scope claim was read for transitions only; a missing scope surfaces as a 403 at runtime | Run each write with a token restricted to the classic write scope and record which return 403 |
+| Can the v3 search response omit `nextPageToken` while results remain? | The paginator treats an absent token as the end of the walk, so a dropped cursor is a silent truncation | Page a result set larger than one page and compare the accumulated count against a JQL count of the same query |
+| Is API-token traffic exempt from the points-based quota? | Decides whether the 65,000-point budget constrains the poll interval at all | Exceed 65,000 points in one UTC hour with an API token and record whether a 429 with `RateLimit-Reason: jira-quota-global-based` arrives |
+| What values do the four rate-limit headers actually carry on a 429? | The header table is documentation-derived; the adapter reads only `Retry-After` | Provoke a burst 429 and capture `Retry-After`, `X-RateLimit-Remaining`, `X-RateLimit-Reset`, and `RateLimit-Reason` |
+| Do the Server / Data Center v2 routes behave as documented? | The entire v2 path, auth, search, pagination, and wiki-markup bodies, has never met a running instance | Run the integration suite against a Data Center instance with `api_version: "2"` |
+| What JSON envelope does each rejection class return? | `classifyHTTPError` reads only the status and copies raw body bytes, so a structured envelope is never parsed | Provoke 400 (bad JQL), 401, 403, 404, and 409 and record each response shape |
+| At what key or ID count does the `IN (...)` GET URL exceed the deployment's URI limit? | `batchSize` is 40, chosen without measurement; too low costs round trips and too high returns 414 | Raise the batch size against a representative deployment until a request returns 414 |
+| Does `GET /rest/dev-status/latest/issue/detail` return usable branch names? | It is the only known source for `domain.Issue.BranchName` on Jira | Connect a source control tool to a test site and read the route for an issue with a linked branch |
+| Does ADF carry text in node types `flattenADF` does not handle, such as `inlineCard`, `mention`, or `emoji`? | Unhandled inline nodes drop content from the prompt without any error | Post a description containing each and compare the flattened output against the rendered text |
+| Is `X-Seraph-LoginReason` present on Jira Cloud, or only on Server and Data Center? | The CAPTCHA message may be unreachable on the deployment sortie actually targets | Fail authentication repeatedly against both and capture the response headers |
+| Which comment ordering does `orderBy=created` produce, and does the parameter exist on v2? | The workpad pattern assumes oldest-first comments | Read a multi-comment issue with and without the parameter on both versions |
+
+---
+
+## Source attribution
+
+| Topic | Primary source | Verification method |
+| --- | --- | --- |
+| Authentication schemes, token creation URL, OAuth 3LO, personal access tokens | Atlassian REST API documentation, read March 2026 (Cloud) and June 2026 (Server / Data Center) | None recorded; no URL captured per claim |
+| Route surface, query parameters, request and response shapes | Atlassian REST API documentation, same readings | Read-path routes exercised by `internal/tracker/jira/integration_test.go` against a live Cloud site; no payload captured |
+| ADF document shape and the `search/jql` cursor contract | Atlassian REST API documentation, March 2026 | None recorded |
+| v2 wiki-markup bodies and the offset-paginated `search` route | Atlassian REST API documentation, June 2026 | None recorded |
+| Rate-limit systems, quotas, burst buckets, and 429 headers | Atlassian REST API documentation, March 2026 | None recorded |
+| `X-Seraph-LoginReason` CAPTCHA behavior | Atlassian REST API documentation, March 2026 | None recorded |
+| Every claim about the adapter's own behavior | `internal/tracker/jira` (`jira.go`, `client.go`, `jql.go`, `normalize.go`, `adf.go`, `validate.go`) and `internal/domain` (`tracker.go`, `errors.go`) | Repository code reading. No Jira observation is involved, so these claims carry a symbol rather than an evidence tag |
+| Which operations reach a live instance in CI | `.github/workflows/release.yml` and `.github/workflows/nightly.yml`, the `SORTIE_JIRA_TEST` jobs | Workflow reading |

--- a/docs/kiro-adapter-notes.md
+++ b/docs/kiro-adapter-notes.md
@@ -1,27 +1,20 @@
 # Kiro CLI: adapter research notes
 
-> Kiro CLI 2.4.2 (`kiro-cli`), researched and probed on 2026-05-27 on Linux x86_64.
-> Reference for implementing the Kiro `AgentAdapter`.
+> Kiro CLI 2.4.2 (`kiro-cli`) on Linux x86_64, probed on 2026-05-27. Reference for the Kiro
+> `domain.AgentAdapter`, implemented in `internal/agent/kiro`.
 >
-> Provenance: Kiro CLI is the rebranded Amazon Q Developer CLI. The November 2025
-> Kiro general-availability release renamed the `q` binary to `kiro-cli` and moved
-> configuration from `~/.aws/amazonq` to `~/.kiro`. The installed 2.4.2 binary is built from
-> the open-source [`aws/amazon-q-developer-cli`](https://github.com/aws/amazon-q-developer-cli)
-> codebase: it embeds Rust source paths under `crates/q_cli/` and changelog entries that link
-> to pull requests in that repository (local `strings` probe of the 2.4.2 binary).
+> Instruments: `--help` surfaces and exit-code probes of the installed binary, `strings` and
+> `file` on the resolved binary, the SQLite store at `~/.local/share/kiro-cli/data.sqlite3`,
+> and authenticated headless turns run with a `KIRO_API_KEY` credential on a Kiro Pro account.
+> The rendered docs at `kiro.dev`, the `aws/amazon-q-developer-cli` source repository, and the
+> `kirodotdev/Kiro` tracker corroborate; all are linked under "Sources".
 >
-> Local validation: direct probes of `kiro-cli 2.4.2`, including authenticated headless turns
-> run with a `KIRO_API_KEY` credential on a Kiro Pro account. These cover help surfaces, exit
-> codes, authentication gating, the SQLite store schema, the success-turn stdout shape, the
-> cost-trailer location, conversation persistence and resume, the live model list, and the MCP
-> config-load mechanism. Claims that rest on secondary sources are attributed in the prose;
-> behaviors not exercised here are listed under "Known limitations". All sources are linked
-> under "Sources" at the end.
->
-> Version note: the docs at `kiro.dev` track the current product. The source repository
-> tags its own releases on a separate `1.x` line. Runtime claims here are anchored to the
-> installed 2.4.2 binary and the `kiro.dev` docs; the source repository is corroborating
-> evidence, not the version of record.
+> Coverage: every claim about the CLI is anchored to 2.4.2 on that date and spans help
+> surfaces, exit codes, authentication gating, the store schema, the success-turn stdout
+> shape, the cost-trailer stream, conversation persistence and resume, the model list, and
+> MCP config loading. Turns that invoke tools, quota exhaustion, and MCP under a credential
+> other than `KIRO_API_KEY` are not observed and appear under "Open questions". Claims about
+> Sortie's own code cite Go symbols and are verified against the tree, not against the CLI.
 
 ## Overview
 
@@ -37,10 +30,10 @@ to stdout, and exits.
 | `kiro-cli chat` (interactive) | TUI | Rich terminal UI with panels and slash commands | Not suitable for unattended orchestration |
 | `kiro-cli acp` | stdin/stdout nd-JSON | Agent Client Protocol server | Exists in the command tree (local `--help-all` probe), but the headless `chat` path is the documented automation surface and the focus of this note |
 
-This places the Kiro adapter in Sortie's synchronous, launch-per-turn category. It satisfies
-`domain.AgentAdapter` (defined in `internal/domain/agent.go`) with one subprocess per turn,
-delivers events through the `RunTurn` `OnEvent` callback, and returns `nil` from
-`EventStream()`.
+This places the Kiro adapter in Sortie's synchronous, launch-per-turn category.
+`kiro.KiroAdapter` satisfies `domain.AgentAdapter` (declared in `internal/domain/agent.go`)
+by driving one subprocess per turn through `agentcore.ForkPerTurnSession`, delivers events
+through the `RunTurn` `OnEvent` callback, and returns `nil` from `EventStream`.
 
 The single most important architectural fact for the adapter: **headless Kiro CLI has no
 structured output**. There is no JSON event stream, no machine-readable result envelope, and
@@ -57,28 +50,27 @@ Kiro CLI installs as the `kiro-cli` binary:
 curl -fsSL https://cli.kiro.dev/install | bash
 ```
 
-For backward compatibility the rebrand keeps the legacy `q` and `q chat` entry points
-working, and existing Amazon Q users migrate in place via `q update`.
-
 | Item | Requirement | Evidence |
 | ---- | ----------- | -------- |
 | Kiro CLI binary | `kiro-cli` on `PATH` | Local probe, 2.4.2 |
 | Credentials | A valid Builder ID, IAM Identity Center, social, external IdP, or `KIRO_API_KEY` token | Published docs, local probe |
 | Subscription for headless | `KIRO_API_KEY` requires Kiro Pro, Pro+, or Power | Published docs |
-| Working directory | Any project directory; the adapter must launch with cwd set to the workspace | Local probe |
+| Working directory | Any project directory; the session runs with cwd set to the workspace | Local probe |
 | Headless use | `kiro-cli chat --no-interactive` runs without a TTY once a credential is present | Published docs, hands-on report |
+
+The adapter registers under kind `kiro` with `registry.AgentMeta{RequiresCommand: true}`, so
+`orchestrator` preflight rejects a dispatch whose `agent.command` is empty.
+`agentcore.ResolveLaunchTarget` resolves that command through `exec.LookPath`, falling back to
+`kiro-cli`, and validates the workspace path that becomes the subprocess cwd.
 
 The binary is large (roughly 118 MB for 2.4.2) and dynamically linked against glibc (local
 `file` probe). It bundles shell-integration assets (`inline`, autosuggestions, completions)
 that are irrelevant to headless orchestration.
 
-## Provenance and the Amazon Q lineage
+## Lineage and source of record
 
-The rebrand is not cosmetic-only, and the lineage matters because it lets the adapter reuse
-verified facts from the open-source Amazon Q Developer CLI while staying anchored to the
-Kiro distribution.
-
-Evidence that `kiro-cli` 2.4.2 is the rebranded Amazon Q Developer CLI:
+`kiro-cli` 2.4.2 is the Kiro distribution of the open-source Amazon Q Developer CLI, which
+is why upstream code and issues are cited from `aws/amazon-q-developer-cli`:
 
 - The binary embeds Rust crate paths such as `crates/q_cli/src/cli/mod.rs`,
   `crates/fig_auth/src/session.rs`, and `crates/fig_api_client/src/endpoints.rs`, and the
@@ -86,8 +78,6 @@ Evidence that `kiro-cli` 2.4.2 is the rebranded Amazon Q Developer CLI:
 - The 2.4.2 changelog strings link to pull requests in
   `github.com/aws/amazon-q-developer-cli` (for example `/pull/2561` and `/pull/2516`)
   (local `strings` probe).
-- The official migration guide documents the `q` to `kiro-cli` rename and the configuration
-  move from `~/.aws/amazonq` to `~/.kiro`.
 - The CLI talks to AWS CodeWhisperer endpoints under SSO authentication
   (`codewhisperer.us-east-1.amazonaws.com`, `cps.prod-us-east-1.codewhisperer.ai.aws.dev`)
   and to Kiro runtime endpoints under API-key authentication
@@ -97,6 +87,12 @@ Evidence that `kiro-cli` 2.4.2 is the rebranded Amazon Q Developer CLI:
 The `kirodotdev/Kiro` repository is the Kiro IDE and the public issue tracker (TypeScript,
 not the CLI source). CLI feature requests such as machine-readable headless output are filed
 there. The CLI source of record remains `aws/amazon-q-developer-cli`.
+
+The two projects number releases differently: the source repository tags its own line (for
+example [v1.19.7](https://github.com/aws/amazon-q-developer-cli/releases/tag/v1.19.7)) while
+the installed distribution reports `kiro-cli 2.4.2` (local probe). Runtime claims here are
+anchored to the installed binary and the `kiro.dev` docs; the source repository is
+corroborating evidence, not the version of record.
 
 ## Authentication
 
@@ -111,13 +107,17 @@ flows; `KIRO_API_KEY` is the unattended path.
 | External IdP | Refresh-token flow stored under `kirocli:external-idp:token` | Interactive setup |
 | API key | `KIRO_API_KEY` environment variable | The unattended path. Requires Kiro Pro, Pro+, or Power. |
 
-`KIRO_API_KEY` is the credential the adapter should rely on. Per the first-party blog, "when
+`KIRO_API_KEY` is the credential the adapter relies on. Per the first-party blog, "when
 the `KIRO_API_KEY` environment variable is set, Kiro CLI skips the browser-based login flow
 entirely." The headless docs state plainly that "headless mode requires an API key set as the
 `KIRO_API_KEY` environment variable." The binary confirms an `API_KEY` token type and an
 `https://runtime.<region>.kiro.dev` endpoint for that path, plus a changelog entry "Fix API
-key authentication failing for non us-east-1 users" (local `strings` probe), so the adapter
-MUST treat the active region as a configurable input rather than assuming `us-east-1`.
+key authentication failing for non us-east-1 users" (local `strings` probe), so the active
+region is not fixed at `us-east-1`. The adapter passes no region argument: the subprocess
+inherits the orchestrator environment (`cmd.Env = os.Environ()` in
+`agentcore.ForkPerTurnSession.RunTurn`), so region selection rests on what the operator
+exports. In SSH mode `kiro.buildSSHRemoteCmd` prepends only `KIRO_API_KEY`, shell-quoted,
+because OpenSSH drops the local environment.
 
 ### Token storage
 
@@ -127,10 +127,10 @@ Authentication tokens persist in a SQLite database at
 `kirocli:external-idp:token` (local SQLite probe). The stored OIDC client registration names
 the client `Kiro CLI`, uses the `DeviceCode` OAuth flow, and requests the CodeWhisperer
 scopes `codewhisperer:completions`, `codewhisperer:analysis`, and
-`codewhisperer:conversations` (local SQLite probe). The adapter does not need to read this
-store; it should provide `KIRO_API_KEY` and let the CLI manage tokens.
+`codewhisperer:conversations` (local SQLite probe). The adapter never reads this store: it
+verifies `KIRO_API_KEY` and leaves token management to the CLI.
 
-### The login-hang hazard (critical)
+### The login-hang hazard
 
 When no valid credential is present, the behavior is not uniform across commands, and this
 asymmetry is the single biggest operational hazard for the adapter:
@@ -143,21 +143,24 @@ asymmetry is the single biggest operational hazard for the adapter:
   indefinitely waiting for the operator to complete browser authentication (local probe).
 
 The `--no-interactive` flag does not suppress this login flow. A headless `chat` invocation
-without a valid credential does not error out; it hangs until killed. Confirmed locally:
-`kiro-cli chat --no-interactive --trust-all-tools "..."` with no credential produced only the
-device-login prompt and spinner on stdout, an empty stderr, and never exited on its own.
+without a valid credential does not error out; it hangs until killed:
+`kiro-cli chat --no-interactive --trust-all-tools "..."` with no credential emits only the
+device-login prompt and spinner on stdout, leaves stderr empty, and never exits on its own
+(local probe).
 
-The authenticated probe sharpened this hazard into two distinct cases. An **invalid**
-`KIRO_API_KEY` does not hang: `chat --no-interactive` fails fast with `Authentication failed.`
-on stderr, empty stdout, and exit 0. The indefinite device-login hang is specific to **no
-credential at all** (no `KIRO_API_KEY` and no cached SSO token). The two failure shapes need
-different defenses.
+The hazard has two distinct shapes. An **invalid** `KIRO_API_KEY` does not hang:
+`chat --no-interactive` fails fast with `Authentication failed.` on stderr, empty stdout, and
+exit 0. The indefinite device-login hang is specific to **no credential at all** (no
+`KIRO_API_KEY` and no cached SSO token). The two shapes need different defenses.
 
-Adapter requirement: the adapter MUST verify that `KIRO_API_KEY` (or a pre-completed SSO
-token) is present before launching `chat` (defends against the hang), SHOULD validate the
-credential is usable with a free `kiro-cli whoami` or `kiro-cli chat --list-models` call
-(defends against the silent exit-0 empty turn an invalid key produces), and MUST enforce its
-own turn timeout as a backstop, because the CLI provides no self-timeout on the login wait.
+`kiro.checkCredential` defends against both shapes before any turn runs. It rejects an empty
+`KIRO_API_KEY` with `domain.ErrResponseError`, then runs a `kiro-cli whoami` canary under a
+five-second timeout and rejects the credential unless the output contains
+`Authenticated with API key` and does not contain `Authentication failed.`. A canary that
+times out or exits non-zero is also rejected, classified as a retryable credential problem
+rather than `domain.ErrAgentNotFound`, because `agentcore.ResolveLaunchTarget` has already
+proved the binary exists. `kiro.KiroAdapter.StartSession` skips this preflight in SSH mode,
+where the key is injected into the remote command instead.
 
 ## Relevant CLI commands and flags
 
@@ -169,41 +172,39 @@ is `kiro-cli-chat chat [OPTIONS] [INPUT]`, where `[INPUT]` is "the first questio
 
 | Flag | Short | Meaning | Adapter use |
 | ---- | ----- | ------- | ----------- |
-| `--no-interactive` | | Run without expecting user input; print the response to stdout and exit | Required for headless turns |
-| `--trust-all-tools` | `-a` | Allow any tool without confirmation | One option for unattended runs (see permissions) |
-| `--trust-tools <NAMES>` | | Trust only a comma-separated set, for example `--trust-tools=read,grep`; empty value trusts nothing | Preferred least-privilege option |
-| `--model <MODEL>` | | Model to use for this invocation | Primary per-turn model selector |
-| `--agent <AGENT>` | | Context profile (custom agent) to use | Optional; selects a named agent config |
-| `--resume` | `-r` | Resume the most recent conversation from this directory | Continuation, but see resume caveat |
-| `--resume-id <SESSION_ID>` | | Resume a specific conversation by session ID | Preferred deterministic continuation |
+| `--no-interactive` | | Run without expecting user input; print the response to stdout and exit | Passed on every turn |
+| `--trust-all-tools` | `-a` | Allow any tool without confirmation | Passed when `trust_all_tools` is configured |
+| `--trust-tools <NAMES>` | | Trust only a comma-separated set, for example `--trust-tools=read,grep`; empty value trusts nothing | Passed with the configured allowlist whenever `trust_all_tools` is off |
+| `--model <MODEL>` | | Model to use for this invocation | Passed when `model` is configured |
+| `--agent <AGENT>` | | Context profile (custom agent) to use | Passed when `agent` is configured |
+| `--resume` | `-r` | Resume the most recent conversation from this directory | Passed on every turn after the first successful one |
+| `--resume-id <SESSION_ID>` | | Resume a specific conversation by session ID | Unused; the ID is not enumerable headless (see session continuity) |
 | `--resume-picker` | | Interactively select a conversation to resume | Interactive only; unusable headless |
-| `--list-sessions` | `-l` | List saved chat sessions for the current directory | Enumeration |
-| `--delete-session <SESSION_ID>` | `-d` | Delete a saved chat session by ID | Cleanup |
-| `--session-source <v1\|v2>` | | Target only the v1 or v2 store for `--delete-session` (default: both) | Two conversation stores exist (see session continuity) |
+| `--list-sessions` | `-l` | List saved chat sessions for the current directory | Unused |
+| `--delete-session <SESSION_ID>` | `-d` | Delete a saved chat session by ID | Unused |
+| `--session-source <v1\|v2>` | | Target only the v1 or v2 store for `--delete-session` (default: both) | Unused; two conversation stores exist (see session continuity) |
 | `--list-models` | | List available models and exit | Meta command; honors `--format` |
 | `--format <FORMAT>` | `-f` | Output format for list commands: `plain`, `json`, `json-pretty` (default `plain`) | Applies to `--list-models` only, not to chat turns |
-| `--require-mcp-startup` | | Exit with code 3 if any enabled MCP server fails to start | Fail-fast for MCP-dependent pipelines |
-| `--wrap <WRAP>` | `-w` | Line wrapping: `always`, `never`, `auto` (default auto-detect) | Set `never` for raw output when parsing |
-| `--agent-engine <ENGINE>` | | Agent engine: `v2` (default), `v1`, or `kas` | Leave default unless a reason exists |
+| `--require-mcp-startup` | | Exit with code 3 if any enabled MCP server fails to start | Unused; MCP is disabled under API-key auth (see MCP integration) |
+| `--wrap <WRAP>` | `-w` | Line wrapping: `always`, `never`, `auto` (default auto-detect) | Passed as `--wrap never` on every turn so captured lines are unwrapped |
+| `--agent-engine <ENGINE>` | | Agent engine: `v2` (default), `v1`, or `kas` | Unused; the default engine applies |
 | `--mode <MODE>` | | KAS agent mode: `vibe` (default) or `spec` | Only meaningful with the `kas` engine |
 | `--tui` | | Use the new terminal UI | Interactive only |
 | `--legacy-ui` | | Use the legacy harness (alias `--classic`) | Interactive only |
-| `--verbose` | `-v` | Increase logging verbosity (repeatable) | Diagnostic |
+| `--verbose` | `-v` | Increase logging verbosity (repeatable) | Unused |
 
-Example headless invocation:
+`kiro.buildArgs` assembles exactly this shape, with the optional segments included per the
+table above:
 
 ```bash
-KIRO_API_KEY="$KIRO_API_KEY" \
-kiro-cli chat \
-  --no-interactive \
-  --trust-tools=read,grep \
-  --model "$MODEL" \
-  --wrap never \
-  -- "Implement the requested fix"
+kiro-cli chat --no-interactive --wrap never \
+  [--model <MODEL>] (--trust-all-tools | --trust-tools=<names>) [--agent <AGENT>] [--resume] \
+  -- "<rendered prompt>"
 ```
 
-The `--` separator passes the full prompt as one positional argument so a wrapper does not
-have to escape leading hyphens.
+The `--` separator passes the full prompt as one positional argument, so a prompt with
+leading hyphens needs no escaping. Arguments go to `exec.Command` directly, never through a
+shell.
 
 ### Other commands
 
@@ -213,7 +214,6 @@ have to escape leading hyphens.
 | `kiro-cli agent` | `list`, `create`, `edit`, `validate`, `migrate`, `set-default` | Local `agent --help` |
 | `kiro-cli settings` | Read or write CLI settings, for example `kiro-cli settings chat.defaultModel <model>` | Hands-on report, local probe |
 | `kiro-cli login` / `logout` / `whoami` | Authentication management; `whoami` prints `Not logged in` or the active method | Local probe |
-| `kiro-cli mcp` / `agent` when unauthenticated | Fail fast with exit 1 (`You are not logged in`) | Local probe |
 
 ## Subprocess behavior
 
@@ -229,17 +229,29 @@ Claude Code and Copilot adapters rather than the Codex app-server.
 
 Saved sessions are scoped to the current directory: `--list-sessions` lists "all saved chat
 sessions for the current directory" and `--resume` resumes "the most recent conversation from
-this directory" (local `chat --help`). The adapter MUST launch with cwd set to the per-issue
-workspace so that resume and session listing operate on the correct conversation set.
+this directory" (local `chat --help`). `agentcore.ForkPerTurnSession.RunTurn` sets `cmd.Dir`
+to the workspace path validated by `agentcore.ResolveLaunchTarget`, so resume operates on the
+per-issue conversation set.
 
 ### Process lifetime and cancellation
 
-Kiro CLI exposes no native per-turn timeout flag on `chat` (local `chat --help`). Turn
-duration is therefore the orchestrator's responsibility, enforced by killing the subprocess.
-Combined with the login-hang hazard above, this means the orchestrator's turn timeout is the
-only reliable upper bound on a Kiro turn. On SIGTERM the process terminates and the shell
-reports exit status 143 (128 + 15); on SIGKILL, 137 (128 + 9). The adapter maps signal-caused
-termination to `turn_cancelled`.
+Kiro CLI exposes no native per-turn timeout flag on `chat` (local `chat --help`), so an
+external bound is the only upper limit on a turn, and the login-hang hazard above makes it
+mandatory rather than optional. Cancelling the context passed to `RunTurn` is what stops a
+Kiro subprocess: `agentcore.ForkPerTurnSession` puts the process in its own group, sends
+SIGTERM to that group through `procutil.SignalGraceful`, waits the five-second
+`stopGracePeriod`, and then sends SIGKILL. `KiroAdapter.StopSession` reaches the same path
+through `ForkPerTurnSession.Stop`. On SIGTERM the process terminates and the shell reports
+exit status 143 (128 + 15); on SIGKILL, 137 (128 + 9). The skeleton detects the signal with
+`procutil.WasSignaled` and returns `domain.EventTurnCancelled` with `domain.ErrTurnCancelled`
+before the adapter's own finalizer runs.
+
+Stall detection still reaches Kiro turns despite the absent event stream: every non-empty
+stdout line becomes a `domain.EventNotification` carrying a fresh
+timestamp, and `orchestrator.HandleAgentEvent` advances `LastAgentTimestamp` from it, which
+is the reference time `orchestrator.reconcileStalled` compares against `stall_timeout_ms`
+before cancelling the worker. A turn that prints nothing for longer than that threshold is
+cancelled; a turn that keeps printing transcript lines keeps resetting the timer.
 
 ## Output format
 
@@ -260,40 +272,40 @@ output for a chat turn. Evidence, triangulated:
   request explicitly motivates the need to "parse the final response without stripping ANSI
   codes or text parsing," which confirms that no such clean output exists today.
 
-Caution on secondary sources: some web summaries describe `--output-format json` as if it
-ships in Kiro CLI. It does not in 2.4.2. Those summaries appear to paraphrase the wording of
-feature request #5423. Treat the binary `--help` and `strings` output as authoritative for
-this version.
+Some web summaries describe `--output-format json` as if it ships in Kiro CLI. It does not in
+2.4.2, and those summaries paraphrase the wording of feature request #5423. The binary
+`--help` and `strings` output are authoritative for this version.
 
 ### What stdout actually contains
 
 In `--no-interactive` mode the stdout stream is a human transcript, not a parseable protocol.
-The authenticated probe refined the picture of how the streams divide:
+The streams divide as follows:
 
-- **stdout carries the assistant answer.** For a turn that invokes no tools, stdout held only
-  the answer, prefixed with a colorized `> ` marker and ANSI styling, with no trailing
+- **stdout carries the assistant answer.** For a turn that invokes no tools, stdout holds
+  only the answer, prefixed with a colorized `> ` marker and ANSI styling, with no trailing
   newline (observed: `\x1b[38;5;141m> \x1b[0mPONG`). Per the independent hands-on report, a
   turn that invokes tools also prints tool-progress lines such as
-  `Reading directory: ... (using tool: read ...)` and markdown answers including tables. The
-  tool-progress case was not re-exercised here, so where exactly tool logs land relative to
-  stdout and stderr is still secondary-sourced.
+  `Reading directory: ... (using tool: read ...)` and markdown answers including tables.
 - **stderr carries the cost trailer and warnings.** The closing cost line of the form
-  `▸ Credits: 0.01 • Time: 1s` is emitted on **stderr**, not stdout. The format matches the
-  `▸ Credits: 0.05 • Time: 6s` shape from the hands-on report, so the trailer format is
-  corroborated by two independent observations. A `Failed to retrieve MCP settings` warning
-  and any `--trust-tools` warnings also land on stderr.
+  `▸ Credits: 0.01 • Time: 1s` is emitted on **stderr**, not stdout, even though the hands-on
+  report shows it inside the printed transcript; direct observation places it on stderr. A
+  `Failed to retrieve MCP settings` warning and any `--trust-tools` warnings also land there.
 
-Consequences for parsing:
+How the adapter reads these streams:
 
-- The cost trailer on stderr is the most reliable success signal available on the headless
-  path: a turn that actually ran prints `▸ Credits: …`, whereas an auth failure prints
-  `Authentication failed.` and no trailer (see "Exit codes"). Exit code alone is not
-  sufficient because both success and auth failure exit 0.
-- Output is formatted for a terminal and may carry markdown and ANSI styling. Set
-  `--wrap never` to avoid width-based line wrapping, and strip ANSI when capturing to a log.
-- There is no per-event timestamped stream. Tool calls cannot be reconstructed reliably from
-  stdout text, so the adapter cannot emit precise `EventToolResult` events with
-  `ToolDurationMS` from the headless path.
+- The cost trailer on stderr is the one positive success signal on the headless path: a turn
+  that actually ran prints `▸ Credits: …`, whereas an auth failure prints
+  `Authentication failed.` and no trailer. `kiro.classifyStderr` scans the collected stderr
+  lines for both markers by substring containment, never by the numeric values that follow
+  (see "Exit codes and error detection").
+- Output is formatted for a terminal and carries markdown and ANSI styling. `--wrap never`
+  suppresses width-based wrapping, and `kiro.stripANSI` removes the remaining color and style
+  escapes from each stdout line before it is emitted or accumulated.
+- Each non-empty stripped line becomes a `domain.EventNotification` with the text truncated
+  to 500 runes by `typeutil.TruncateRunes`, and the untruncated text accumulates in
+  `sessionState.turnStdout` for the turn.
+- There is no per-event timestamped stream, so tool calls cannot be reconstructed from stdout
+  text. The adapter emits no `domain.EventToolResult` and no `ToolDurationMS`.
 
 ## Session continuity
 
@@ -302,40 +314,30 @@ Kiro CLI persists conversations per directory and supports several resume modes 
 
 | Mode | Mechanism | Adapter notes |
 | ---- | --------- | ------------- |
-| Fresh | No resume flag | Default; starts a new conversation in the cwd |
-| `--resume` / `-r` | Resume the most recent conversation from this directory | Convenient, but "most recent" is positional, not an explicit identity |
-| `--resume-id <SESSION_ID>` | Resume a specific session by ID | Preferred deterministic continuation; map to `StartSessionParams.ResumeSessionID` |
+| Fresh | No resume flag | The first turn of a session starts a new conversation in the cwd |
+| `--resume` / `-r` | Resume the most recent conversation from this directory | The continuation path the adapter uses; "most recent" is positional, not an explicit identity |
+| `--resume-id <SESSION_ID>` | Resume a specific session by ID | Retains context headless, but the ID is not obtainable at run time |
 | `--resume-picker` | Interactive selection | Unusable headless |
-| `--list-sessions` / `-l` | List saved sessions for the cwd | Enumeration before resume |
+| `--list-sessions` / `-l` | List saved sessions for the cwd | Returns empty for headless conversations |
 | `--delete-session <ID>` | Delete a saved session | Cleanup; `--session-source <v1\|v2>` selects which store |
 
-Two stores exist. The `--session-source` flag accepts `v1` or `v2` and defaults to both for
-deletion (local `chat --help`), indicating a legacy (v1) and current (v2) conversation store.
 The store schema is observable directly. The `~/.local/share/kiro-cli/data.sqlite3` database
 holds tables `migrations`, `history`, `auth_kv`, `state`, `conversations`, and
-`conversations_v2`. Chat persistence does not live in the `state` table, which holds only
-telemetry and migration keys (`telemetryClientId`, `migration.kiro.completed`, and similar);
-conversations persist in the dedicated `conversations` (legacy) and `conversations_v2`
-(current) tables. `conversations_v2` has columns
+`conversations_v2`, and `--session-source` selects between the last two. Chat persistence does
+not live in the `state` table, which holds only telemetry and migration keys
+(`telemetryClientId`, `migration.kiro.completed`, and similar). `conversations_v2` has columns
 `key, conversation_id, value, created_at, updated_at`, keyed by the **workspace directory
 path** with a UUID `conversation_id`. The `history` table is the unrelated shell
 command-history feature. A headless `--no-interactive` turn persists a resumable conversation
-scoped to cwd, even though `--list-sessions` does not surface it (see below).
+scoped to cwd, even though `--list-sessions` returns empty for it, so the conversation ID is
+reachable only by reading `conversations_v2`, never through the CLI or the turn output.
 
-Adapter mapping. Both resume paths work headless and retain conversation context:
-
-- `--resume-id <conversation_id>`: resumes a specific conversation by the UUID recorded in
-  `conversations_v2`.
-- `--resume` (no id): resumes the most recent conversation in the cwd.
-
-`--list-sessions` returns **empty** for a workspace whose only conversation was created
-headless, so the adapter cannot obtain the session ID through the CLI, and the session ID is
-absent from the headless turn output (no structured envelope exists). The two viable
-continuation strategies are therefore: rely on cwd-scoped `--resume`, which needs no ID and
-suits Sortie's one-conversation-per-workspace model, or read `conversation_id` from
-`conversations_v2` keyed by the workspace path (brittle, depends on store internals). The
-cwd-scoped `--resume` path is recommended because it avoids both ID capture and store-internal
-coupling.
+The adapter therefore continues by directory rather than by ID. `kiro.sessionState` sets
+`resumeRequested` in `OnFinalize` once a turn succeeds, and `kiro.buildArgs` appends `--resume`
+on every later turn in the same workspace. The session identity the adapter carries is
+`params.ResumeSessionID`, stored in `sessionState.sessionID` and reported back through
+`domain.TurnResult.SessionID` and the session logger; it is never passed to `kiro-cli`, and
+the adapter reads no SQLite store.
 
 ## Tool permissions
 
@@ -350,8 +352,8 @@ execution. Two flags control approval without a human:
 ### Built-in tool catalog
 
 Tool names and default permissions, from the published reference and cross-checked against
-symbol counts in the 2.4.2 binary (local `strings` probe). The rebrand simplified names and
-kept the old names as aliases, so both work with `--trust-tools`.
+symbol counts in the 2.4.2 binary (local `strings` probe). Each name in the aliases column is
+accepted by `--trust-tools` alongside the primary name.
 
 | Tool | Aliases | Default permission |
 | ---- | ------- | ------------------ |
@@ -367,11 +369,13 @@ kept the old names as aliases, so both work with `--trust-tools`.
 | `introspect`, `delegate`, `subagent`, `tool_search`, `knowledge`, `thinking`, `todo`, `session` | | Auto-activated or configurable |
 | `report` | `report_issue` | Trusted by default |
 
-The migration mapping is `fs_read` to `read`, `fs_write` to `write`, `use_aws` to `aws`,
-`execute_bash` to `shell`, and `report_issue` to `report`. For least-privilege headless runs,
-a read-only profile such as `--trust-tools=read,grep,glob` is the natural starting point; add
-`write` and `shell` only when the workflow requires file edits or command execution, and only
-inside a sandbox.
+`kiro.parsePassthroughConfig` reads `trust_all_tools` and `trust_tools` from the `kiro`
+sub-object in WORKFLOW.md and rejects a config that sets both, because the two trust modes are
+mutually exclusive. When `trust_all_tools` is off, `kiro.buildArgs` always emits
+`--trust-tools=<joined>`, so an unset `trust_tools` list produces `--trust-tools=` and trusts
+nothing. A read-only profile such as `trust_tools: [read, grep, glob]` is the least-privilege
+starting point; `write` and `shell` belong there only when the workflow requires file edits or
+command execution, and only inside a sandbox.
 
 ## Model selection
 
@@ -387,29 +391,30 @@ subscription, so it is not embedded in the binary (a `strings` search for `claud
 returned nothing, local probe). `kiro-cli chat --list-models --format json` returns a JSON
 object `{"models": [...], "default_model": "..."}`, where each model carries `model_name`,
 `model_id`, `description`, `context_window_tokens`, `rate_multiplier`, and `rate_unit`. On the
-probed Kiro Pro account the default model was `auto` (`rate_multiplier` 1.0), and the list
-included `claude-opus-4.7` and `claude-opus-4.6` (2.2), `claude-sonnet-4.6`/`4.5`/`4` (1.3),
+probed Kiro Pro account the default model is `auto` (`rate_multiplier` 1.0), and the list
+holds `claude-opus-4.7` and `claude-opus-4.6` (2.2), `claude-sonnet-4.6`/`4.5`/`4` (1.3),
 `claude-opus-4.5` (2.2), `claude-haiku-4.5` (0.4), `deepseek-3.2` and `minimax-m2.5` (0.25),
 `minimax-m2.1` (0.15), `glm-5` (0.5), and `qwen3-coder-next` (0.05). The `rate_multiplier`
 scales credit cost per turn, so the cheapest model is far cheaper than the Claude options.
-Treat the exact set as account- and date-specific, not a stable contract; the adapter SHOULD
-read `--list-models --format json` at configuration time rather than hardcode IDs. Because
-`/model` is unavailable headless, the adapter MUST pin the model with `--model` per turn, or
-set `chat.defaultModel` before launch.
+That set is account-specific and is not a stable contract: the authoritative list for an
+account comes from `--list-models --format json`. The adapter hardcodes no model IDs and
+validates none; whatever `model` the config carries is passed through.
 
-Sortie's `AgentEvent.Model` field expects a model identifier such as
+Because `/model` is unavailable headless, the model can be pinned only per invocation or as a
+CLI default. `kiro.buildArgs` passes `--model <MODEL>` whenever the `kiro` config sub-object
+sets `model`; with no such value the CLI's own `chat.defaultModel` setting decides.
+
+Sortie's `domain.AgentEvent.Model` field expects a model identifier such as
 `claude-sonnet-4-20250514`. The headless path does not print the resolved model identifier in
-machine-readable form, so the adapter can populate `Model` only from the value it passed via
-`--model`, not from anything Kiro reports back.
+machine-readable form, and the adapter leaves `Model` empty on the events it emits.
 
 ## MCP integration
 
 Kiro CLI is an MCP client. MCP servers are managed with the `mcp` subcommand
 (`add`, `remove`, `list`, `import`, `status`) and configured via JSON files. The global
-configuration lives at `~/.kiro/settings/mcp.json` after the rebrand (previously
-`~/.aws/amazonq/mcp.json`), with a workspace-level `mcp.json` also supported. The config uses
-the standard `mcpServers` object (the binary references the `mcpServers` key and a legacy
-`useLegacyMcpJson` toggle, local `strings` probe).
+configuration lives at `~/.kiro/settings/mcp.json`, with a workspace-level `mcp.json` also
+supported. The config uses the standard `mcpServers` object (the binary references the
+`mcpServers` key, local `strings` probe).
 
 There is no per-launch `--mcp-config <path>` flag on `chat` (the `chat --help` flag table
 above has none). Servers are configured out of band with `kiro-cli mcp import --file <FILE>
@@ -425,19 +430,19 @@ authentication. With an API key the CLI's `GetProfile` call returns HTTP 403
 (`AccessDeniedException`), the CLI logs `Failed to check MCP configuration, defaulting to
 disabled`, and prints `Failed to retrieve MCP settings; MCP functionality disabled` to stderr
 on every invocation (authenticated probe). With MCP disabled the workspace `mcp.json` is not
-loaded: a deliberately broken server placed at `<cwd>/.kiro/settings/mcp.json` did not appear
-in `mcp list`, and `kiro-cli chat --no-interactive --require-mcp-startup` ran the turn to
-completion and exited 0 rather than 3 (authenticated probe). The same symptom is reported in
+loaded: a deliberately broken server placed at `<cwd>/.kiro/settings/mcp.json` does not appear
+in `mcp list`, and `kiro-cli chat --no-interactive --require-mcp-startup` runs the turn to
+completion and exits 0 rather than 3 (authenticated probe). The same symptom is reported in
 [amazon-q-developer-cli#3603](https://github.com/aws/amazon-q-developer-cli/issues/3603) and
 [#3650](https://github.com/aws/amazon-q-developer-cli/issues/3650), where it occurs under IAM
 Identity Center while Builder ID is reported to work, which points to a profile-entitlement
 gate rather than a missing config.
 
-Adapter consequence: under the unattended `KIRO_API_KEY` path, MCP injection does not function
-and `--require-mcp-startup` exit 3 is unreachable, so `StartSessionParams.MCPConfigPath` has no
-effect. The `mcp import` mechanism and the exit-3 behavior apply only when MCP is enabled,
-which on this evidence requires an auth path whose profile the backend authorizes (Builder ID
-reported to work; not verified here).
+The adapter reflects that gate: it passes no MCP flag and ignores
+`domain.StartSessionParams.MCPConfigPath`, since MCP injection does not function on the
+unattended `KIRO_API_KEY` path and exit 3 is therefore unreachable. The `mcp import` mechanism
+and the exit-3 behavior apply only when MCP is enabled, which on this evidence needs an auth
+path whose profile the backend authorizes.
 
 ## Exit codes and error detection
 
@@ -465,8 +470,7 @@ Local probes on 2.4.2:
 | `kiro-cli chat --help` | 0 | |
 | `kiro-cli --no-such-flag` | 2 | Top-level argument-parse error (the Rust `clap` usage-error code) |
 | `kiro-cli no-such-subcommand` | 2 | `error: unrecognized subcommand 'no-such-subcommand'` |
-| `kiro-cli chat --no-such-flag` (pristine auth state) | 1 | Subcommand-level error, observed once before any device registration was cached |
-| `kiro-cli mcp list` (unauthenticated) | 1 | `You are not logged in` |
+| `kiro-cli chat --no-such-flag` (pristine auth state) | 1 | Subcommand-level error; reachable only while no device registration is cached |
 | `kiro-cli chat --no-interactive ...` (no credential at all) | hangs | Enters interactive device login; killed by external timeout |
 | `kiro-cli whoami` (valid `KIRO_API_KEY`) | 0 | Prints `Authenticated with API key` and the account email (authenticated probe) |
 | `kiro-cli chat --list-models --format json` (valid key) | 0 | Prints the model JSON and exits (authenticated probe) |
@@ -477,10 +481,10 @@ Conflict, then reconciliation: the docs fold "invalid arguments" into exit code 
 binary returns the `clap` usage-error code 2 for an unrecognized top-level flag or subcommand
 (local probe). The reconciliation that fits the observations is that the top-level `clap`
 parser uses code 2 for malformed invocations, while a subcommand's own argument and semantic
-errors exit 1 (a pristine `kiro-cli chat --no-such-flag` exited 1, local probe), which is the
-case the docs describe. The docs do not mention code 2 at all. The adapter SHOULD treat any
-non-zero exit as failure and not depend on the specific value to distinguish argument errors
-from runtime errors.
+errors exit 1 (a pristine `kiro-cli chat --no-such-flag` exits 1, local probe), which is the
+case the docs describe. The docs do not mention code 2 at all. The adapter reads no meaning
+into the specific value: any non-zero exit reaches the shared decision's non-zero row and
+fails the turn.
 
 **Exit code 0 does not mean the turn succeeded.** A successful turn and an invalid-credential
 turn both exit 0. With an invalid `KIRO_API_KEY`, `chat --no-interactive` produces empty
@@ -488,81 +492,74 @@ stdout, prints `Authentication failed. Your API key may be invalid or expired.` 
 emits no `▸ Credits:` trailer, and exits 0 (authenticated probe). This conflicts with the
 documented "exit 1 = authentication error". The invalid-credential case is distinct from the
 no-credential case: an invalid key fails fast as just described, whereas no credential at all
-triggers the interactive device-login hang. The adapter consequence is concrete: an exit-0
-turn with empty stdout and no credits trailer is a silent failure, not an empty success. The
-adapter MUST NOT map exit 0 to `turn_completed` unconditionally; it MUST require a positive
-success signal (the `▸ Credits:` trailer on stderr, or non-empty answer stdout) and treat
-`Authentication failed.` on stderr as `turn_failed`. Validating the key in `StartSession` with
-a free `whoami` or `--list-models` call catches an invalid key before any turn runs.
+triggers the interactive device-login hang. So an exit-0 turn with empty stdout and no credits
+trailer is a silent failure, not an empty success. `kiro.KiroAdapter` never maps a bare exit 0
+to `turn_completed`: its `OnFinalize` hook reports `agentcore.TerminalSuccess` only when the
+credits trailer is on stderr, and reports `agentcore.TerminalFailure` with
+`domain.ErrResponseError` and the message `kiro authentication failed` when exit 0 arrives with
+`Authentication failed.` on stderr and empty stdout. The `whoami` canary in
+`kiro.checkCredential` catches an invalid key before any turn runs.
 
-Second observation, and a nondeterminism worth recording: once the CLI has a cached device
-registration (written to the `auth_kv` table after any login attempt), an unauthenticated
-`chat` invocation resumes that pending device authorization and blocks on the login flow
-before surfacing a flag error. In that state, `kiro-cli chat --no-such-flag`,
-`kiro-cli chat --model` (missing value), and `kiro-cli chat --agent-engine bogus` all printed
-the device code and hung rather than returning a parse-error code (repeated local probes). In
-a pristine state the same unknown-flag invocation exited 1. The adapter MUST NOT rely on Kiro
-to validate flags with a clean exit code; it MUST guarantee a credential before launch and
-enforce an external timeout.
+A cached device registration makes flag validation nondeterministic: once the `auth_kv` table
+holds a registration written by an earlier login attempt, an unauthenticated `chat` invocation
+resumes that pending device authorization and blocks on the login flow before surfacing a flag
+error. In that state, `kiro-cli chat --no-such-flag`, `kiro-cli chat --model` (missing value),
+and `kiro-cli chat --agent-engine bogus` all print the device code and hang rather than
+returning a parse-error code (repeated local probes); in a pristine state the same unknown-flag
+invocation exits 1. Kiro is therefore no guard against a malformed invocation, which is why the
+credential preflight and the external cancellation bound carry that weight instead.
 
-### Failure signals available to the adapter
+### How a turn is classified
 
-Because there is no structured output, failure detection on the headless path rests on the
-following signals, in priority order:
+Because there is no structured output, classification rests on three signals:
 
-1. The `▸ Credits: … • Time: …` trailer on stderr. This is the one reliable positive signal
-   that a turn actually executed (authenticated probe). Its presence with exit 0 indicates
-   success; its absence with exit 0 indicates the turn did not run (most commonly an
-   authentication failure).
-2. The `Authentication failed.` line on stderr. Present with exit 0 and empty stdout, it marks
-   an invalid-credential turn that the adapter MUST classify as `turn_failed`, not as an empty
-   success.
-3. Process exit code. Non-zero indicates failure; the specific value is not a reliable
-   category (see conflict above). Exit 0 is not by itself a success signal (see the
-   authenticated finding above). Exit 3 would indicate MCP startup failure under
-   `--require-mcp-startup`, but is unreachable under `KIRO_API_KEY` auth, where MCP is disabled
-   (see MCP integration).
-4. Signal termination. SIGTERM (143) or SIGKILL (137) indicates the orchestrator cancelled the
-   turn; map to `turn_cancelled`.
-5. stdout/stderr text. The transcript may contain error prose, including quota messages. The
-   binary defines quota error types `DailyRequestCount`, `MonthlyRequestCount`, and
-   `InsufficientModelCapacity` (local `strings` probe), which surface as upstream failures.
-   Text classification is brittle and SHOULD be a last resort.
+1. The `▸ Credits: … • Time: …` trailer on stderr, the one positive proof that a turn actually
+   executed (authenticated probe). Its presence with exit 0 means success; its absence with
+   exit 0 means the turn did not run, most commonly an authentication failure.
+2. The `Authentication failed.` line on stderr, which with exit 0 and empty stdout marks an
+   invalid-credential turn rather than an empty success.
+3. The process exit and signal status. A non-zero code means failure and the specific value
+   carries no category (see the conflict above). Exit 3 would mean an MCP startup failure under
+   `--require-mcp-startup`, which the adapter never passes and which is unreachable under
+   `KIRO_API_KEY` auth anyway (see MCP integration).
 
-Suggested mapping to `domain.TurnResult.ExitReason`:
+Error prose in the transcript is not a fourth signal. The binary defines quota error types
+`DailyRequestCount`, `MonthlyRequestCount`, and `InsufficientModelCapacity` (local `strings`
+probe) that surface as upstream failures, but `kiro.classifyStderr` matches only the credits
+and authentication markers and the adapter classifies nothing else from text.
 
-| Kiro evidence | Sortie `ExitReason` |
-| ------------- | ------------------- |
-| Exit 0 with a `▸ Credits:` trailer on stderr | `turn_completed` |
-| Exit 0 with empty stdout, no credits trailer, `Authentication failed.` on stderr | `turn_failed` (auth) |
-| Exit 1 or other non-zero (not a signal) | `turn_failed` |
-| Exit 3 (`--require-mcp-startup`) | `turn_failed` (MCP startup) |
-| SIGTERM or SIGKILL | `turn_cancelled` |
-| Binary not found on `PATH` (exit 127) | `startup_failed` |
-| No-credential launch that hangs | Prevent by preflight; if it occurs, the orchestrator timeout yields `turn_cancelled` |
+Resulting `domain.TurnResult.ExitReason`, as `kiro.KiroAdapter` and the
+`agentcore.ForkPerTurnSession` skeleton produce it:
 
-The turn-disposition rule the adapter family shares treats a zero exit code with no positive
-signal as a failed turn, and the positive signal is ordinarily a per-turn token count. Headless
-Kiro reports no token counts at all, so it expresses the same guard in a different currency: the
-`▸ Credits:` trailer is the adapter's sole positive success signal, and its absence with exit 0 is
-the adapter's only evidence that nothing was produced. Non-empty answer stdout is deliberately not
-read as a second, looser signal, because Kiro's stdout is an unstructured transcript with no field
-distinguishing an answer from an error message.
+| Kiro evidence | `ExitReason` and error kind |
+| ------------- | --------------------------- |
+| Exit 0 with a `▸ Credits:` trailer on stderr | `turn_completed`; the session also arms `--resume` for later turns |
+| Exit 0 with empty stdout, no credits trailer, `Authentication failed.` on stderr | `turn_failed` with `domain.ErrResponseError` and the message `kiro authentication failed` |
+| Exit 0 with no credits trailer and no authentication marker | `turn_failed` with `domain.ErrTurnFailed`, reported as `agent exited without producing output: no credits trailer on stderr` |
+| Any other non-zero exit that is not a signal or 127 | `turn_failed` with `domain.ErrPortExit` and the message `exit code N` |
+| Exit 127 | `turn_failed` with `domain.ErrAgentNotFound`; the skeleton handles this arm before the adapter's finalizer, so it is not `startup_failed` |
+| SIGTERM or SIGKILL, or a cancelled context | `turn_cancelled` with `domain.ErrTurnCancelled` |
+| No-credential launch that hangs | Prevented by the credential preflight; a hang that reaches a cancelled context yields `turn_cancelled` |
+
+The shared disposition rule in `agentcore.DecideTurn` treats a zero exit code with no positive
+work signal as a failed turn, and that signal is ordinarily a per-turn token count. Headless
+Kiro reports no token counts, so the adapter reports `agentcore.WorkUnobservable` with the
+detail `no credits trailer on stderr` and expresses the same guard in the credits currency: the
+trailer is its only success signal, and the trailer's absence with exit 0 is its only evidence
+that nothing was produced. Non-empty answer stdout is deliberately not read as a second, looser
+signal, because Kiro's stdout is an unstructured transcript with no field distinguishing an
+answer from an error message.
 
 ## Token usage and cost reporting
 
-This section answers the core question in the research issue: whether token usage or cost is
-reported anywhere on the headless output path.
-
-Finding: **the headless path does not report token counts.** It reports an abstract "credits"
-cost and elapsed time as human-readable text.
+**The headless path does not report token counts.** It reports an abstract "credits" cost and
+elapsed time as human-readable text.
 
 - The first-party headless announcement does not mention token usage or cost reporting.
-- The cost line of the form `▸ Credits: 0.01 • Time: 1s` was confirmed directly on stderr
-  (authenticated probe), matching the shape the independent hands-on report observed. It
-  carries an abstract credits figure and elapsed time, and no input or output token counts.
-  This is the central finding for token accounting and it is now double-sourced: the headless
-  path surfaces credits, never tokens.
+- The cost line, `▸ Credits: 0.01 • Time: 1s` (see "What stdout actually contains" for the
+  stream it lands on), carries an abstract credits figure and elapsed time, and no input or
+  output token counts. The hands-on report shows the same shape with other values
+  (`▸ Credits: 0.05 • Time: 6s`), so the shape is stable and the numbers are not a contract.
 - Token and context usage are available only through interactive slash commands. The binary
   defines `/usage`, `/context`, `/model`, `/tools`, and `/compact` (local `strings` probe),
   and the chat docs describe `/context show` displaying "per-file token usage". None of these
@@ -574,48 +571,15 @@ cost and elapsed time as human-readable text.
 ### Consequences for `EventTokenUsage` and budget tracking
 
 Sortie's `domain.TokenUsage` carries `InputTokens`, `OutputTokens`, `TotalTokens`, and
-`CacheReadTokens`, and `EventTokenUsage` exists to carry these normalized counters. The
+`CacheReadTokens`, and `domain.EventTokenUsage` exists to carry these normalized counters. The
 orchestrator computes deltas across turns and accumulates session totals.
 
-The Kiro headless adapter cannot populate these fields:
-
-- There are no input or output token counts on the headless path, so `InputTokens`,
-  `OutputTokens`, `TotalTokens`, and `CacheReadTokens` cannot be filled with real values.
-- The only cost signal is the "credits" figure, which is an abstract billing unit. Sortie's
-  `TokenUsage` has no credits or cost field, so credits do not map onto the existing model.
-- Therefore the Kiro adapter SHOULD NOT emit `EventTokenUsage`, and `TurnResult.Usage` will be
-  the zero value. Any budget enforcement based on token counts will be inert for the Kiro
-  adapter.
-
-Options the adapter implementation MAY consider (each a tradeoff, none free):
-
-1. Emit no token usage and document Kiro as a no-token-accounting adapter. Lowest complexity;
-   budget-by-tokens does not apply.
-2. Parse the credits trailer from stderr as a cost proxy for observability only. This requires
-   a new cost field in the domain model and a stable trailer format, which #5423 shows is not
-   yet contracted. Not recommended until the format stabilizes.
-3. Wait for, or upstream, the `--output-format json` feature in #5423, which proposes a
-   structured envelope but no token counts in its current draft. This would solve parsing, not
-   token accounting.
-
-The honest conclusion for M22: the Kiro adapter is a no-token-usage adapter on the headless
-path, and budget tracking by tokens is not feasible for it. This MUST be stated in the adapter
-and in any operator-facing documentation.
-
-## Timeout enforcement
-
-Kiro CLI has no native per-turn timeout flag (local `chat --help`). The orchestrator owns
-turn duration through `AgentConfig.TurnTimeoutMS` and enforces it by killing the subprocess.
-Recommended sequence on timeout:
-
-1. Send SIGTERM to the `kiro-cli` process group.
-2. Wait a short grace period for clean exit.
-3. Send SIGKILL if the process is still alive.
-
-Stall detection via `AgentConfig.StallTimeoutMS` is weaker for Kiro than for protocol-based
-adapters, because the headless transcript has no per-event signal the orchestrator can use to
-reset a stall timer. The turn timeout is the primary control. The login-hang hazard makes this
-timeout mandatory rather than optional.
+None of those fields has a source on the headless path, and the credits figure is an abstract
+billing unit that `domain.TokenUsage` has no field for. Kiro is therefore a
+no-token-accounting adapter: its `GetUsage` hook returns a zero `domain.TokenUsage`, it emits
+no `domain.EventTokenUsage`, and `domain.TurnResult` leaves both `Usage` and `UsageMeasured`
+at their zero values on every turn. Every run is reported unmeasured, and token-based budget
+enforcement is inert for this adapter; only cancellation bounds a turn.
 
 ## Concurrency and session isolation
 
@@ -624,131 +588,77 @@ directory (local `chat --help`), and Sortie runs one agent session per workspace
 two turns for the same issue never share a cwd concurrently. The shared local state across
 processes is the SQLite store at `~/.local/share/kiro-cli/data.sqlite3` and the configuration
 under `~/.kiro`. Two processes in different workspace directories keep separate conversation
-sets because `conversations_v2` is keyed by the workspace path. Concurrent writes within a
-single workspace are not characterized here; Sortie runs one session per workspace, so the
-case does not arise.
+sets because `conversations_v2` is keyed by the workspace path. Sortie runs one session per
+workspace, so concurrent writes to a single workspace's conversation do not arise.
+`kiro.KiroAdapter` is safe for concurrent use across sessions: one adapter instance serves all
+sessions and per-session state lives in `kiro.sessionState` behind `domain.Session.Internal`,
+while turns within one session are serialized by the orchestrator.
 
-## Adapter implications
+## Adapter lifecycle
 
-The evidence supports a clear shape for the Kiro adapter:
+`kiro.KiroAdapter` is a synchronous, launch-per-turn adapter built on
+`agentcore.ForkPerTurnSession`:
 
-- It is a synchronous, launch-per-turn adapter. `EventStream()` returns `nil`; events are
-  delivered through the `RunTurn` `OnEvent` callback.
-- `StartSession` validates the credential (`KIRO_API_KEY` present, or a usable SSO token) and
-  records the workspace path. It does not launch a long-lived process.
-- `RunTurn` launches `kiro-cli chat --no-interactive` with the rendered prompt, the chosen
-  `--model`, a `--trust-tools` allowlist (or `--trust-all-tools` inside a sandbox),
-  `--wrap never`, and `--resume-id` on continuation turns. It reads stdout as an opaque
-  transcript, captures it into `AgentEvent.Message` for observability, and determines
-  `ExitReason` from the process exit and signal status.
-- The adapter emits `EventSessionStarted` (with the session ID once known), optional
-  `EventNotification` or `EventOtherMessage` carrying transcript summaries, and a terminal
-  `turn_completed`, `turn_failed`, or `turn_cancelled`. It does not emit `EventTokenUsage`
-  (no token data) and cannot emit reliable `EventToolResult` events (no per-tool structure on
-  stdout).
-- `StopSession` is a no-op for a clean turn, and on cancellation it ensures the subprocess is
-  terminated.
+- `NewKiroAdapter` parses the `kiro` config sub-object into `kiro.passthroughConfig` and fails
+  when `trust_all_tools` and `trust_tools` are both set.
+- `StartSession` resolves the launch target, runs the credential preflight in local mode,
+  builds `kiro.sessionState`, and constructs the fork-per-turn session. It starts no
+  long-lived process.
+- `RunTurn` resets the per-turn stdout accumulator and delegates to
+  `agentcore.ForkPerTurnSession.RunTurn`, which forks `kiro-cli chat --no-interactive` with the
+  arguments from `kiro.buildArgs` in the workspace directory. It panics when
+  `domain.RunTurnParams.OnEvent` is nil, and returns `domain.ErrResponseError` when the
+  session's `Internal` value is not a `kiro.sessionState`.
+- Events: each non-empty stdout line becomes a `domain.EventNotification`, and the terminal
+  event is `turn_completed`, `turn_failed`, or `turn_cancelled`. The adapter sets no
+  `EmitSessionStartID` hook, so it emits no `domain.EventSessionStarted`; it emits no
+  `domain.EventTokenUsage` and no `domain.EventToolResult`.
+- `StopSession` returns nil when no subprocess is active and otherwise delegates to
+  `agentcore.ForkPerTurnSession.Stop`. `EventStream` returns nil.
 
-If structured headless output ships later (tracking #5423), the adapter can be upgraded to
-parse `--output-format json` and emit richer events, but token accounting still depends on
-the upstream adding token counts, which the current proposal does not.
-
-## Differences from the existing adapters
+## Comparison with Sortie's other agent adapters
 
 | Aspect | Claude Code | Codex CLI | OpenCode `run` | Kiro CLI |
 | ------ | ----------- | --------- | -------------- | -------- |
 | Binary | `claude` | `codex` | `opencode` | `kiro-cli` |
-| Lineage | Anthropic | OpenAI | OpenCode | Rebranded Amazon Q Developer CLI |
+| Lineage | Anthropic | OpenAI | OpenCode | Amazon Q Developer CLI, Kiro distribution |
 | Integration | Subprocess per turn | Persistent JSON-RPC app-server | Subprocess per turn (in-process server) | Subprocess per turn |
 | Headless output | `--output-format stream-json` (JSONL) | JSON-RPC notifications (JSONL) | `--format json` (CLI projection) | Plain text transcript, no structured output |
 | Token usage | `usage` in result event | `usage` in `turn/completed` | `step_finish.tokens` (step-scoped) | None on headless path (credits only) |
 | Auth | `ANTHROPIC_API_KEY`, Bedrock, Vertex | `CODEX_API_KEY`, ChatGPT session | Provider env vars and config | `KIRO_API_KEY` (Pro+), Builder ID, IAM Identity Center |
 | Permission bypass | `--dangerously-skip-permissions` | `approvalPolicy: "never"` | `--dangerously-skip-permissions` | `--trust-all-tools` or `--trust-tools` |
-| Session resume | `--resume <id>` | `thread/resume` | `--session <id>` | `--resume-id <id>` (directory-scoped) |
+| Session resume | `--resume <id>` | `thread/resume` | `--session <id>` | `--resume` (directory-scoped, no ID) |
 | Models | Claude family | OpenAI family | provider/model | Backend-served set (Claude, DeepSeek observed) |
 | MCP config | `--mcp-config <path>` | `.codex/mcp.json`, `config.toml` | `opencode.json` | `~/.kiro/settings/mcp.json`, workspace `mcp.json` |
 | Cancellation | Signal | `turn/interrupt` then signal | Signal | Signal (no native interrupt) |
 
-The Kiro adapter is closest to the OpenCode `run` adapter in shape, but with strictly less
-information available on stdout: OpenCode `run --format json` at least emits a CLI JSON
+The fifth adapter, `internal/agent/copilot`, is also launch-per-turn and parses a structured
+stream (`--output-format json`). Kiro is closest to the OpenCode `run` adapter in shape but has
+strictly less information on stdout: OpenCode `run --format json` at least emits a CLI JSON
 projection, while Kiro emits only a human transcript.
 
-## Known limitations
+## Open questions
 
-- No structured event stream in headless mode. stdout carries the assistant answer (and
-  tool-progress lines when tools run); there is no machine-readable envelope. This is the
-  central limitation for any wrapper.
-- No token-count reporting on the headless path. Only an abstract "credits" cost and elapsed
-  time are surfaced, and only as text. `EventTokenUsage` cannot be populated; token-based
-  budget tracking does not apply.
-- `--no-interactive` does not bypass authentication. With **no** `KIRO_API_KEY` and no cached
-  SSO token, `chat` blocks on an interactive device-login flow with no self-timeout (local
-  probe). An **invalid** `KIRO_API_KEY` instead fails fast (exit 0, `Authentication failed.` on
-  stderr, empty stdout), which is a silent non-success the adapter must detect (authenticated
-  probe).
-- No native per-turn timeout. The orchestrator must enforce timeouts by killing the process
-  (local `chat --help`).
-- Interactive-only token and model controls. `/usage`, `/context`, and `/model` are
-  unavailable headless, so the model MUST be pinned with `--model` or `chat.defaultModel`.
-- Exit-code granularity is coarse. Documented codes are 0, 1, and 3, with `clap` returning 2
-  for argument errors that the docs do not list. Non-zero means failure; the value is not a
-  reliable category.
-- MCP is unavailable under `KIRO_API_KEY` auth. The `GetProfile` gate returns 403, MCP is
-  disabled, a configured `mcp.json` is not loaded, and `--require-mcp-startup` exit 3 is
-  unreachable. MCP reportedly works under Builder ID; not verified here.
-- The shape of a tool-using turn is not characterized here. Only no-tool turns were exercised;
-  where tool-progress lines land relative to stdout and stderr rests on the hands-on report.
-- Exit behavior on quota exhaustion (`DailyRequestCount`, `MonthlyRequestCount`) and on a
-  mid-turn upstream error is not characterized; those conditions were not induced.
-
-## Documented conflicts and drift
-
-| Topic | One source says | Authoritative source says | Impact |
-| ----- | --------------- | ------------------------- | ------ |
-| `--output-format json` for chat | Some web summaries present it as shipped | Binary `chat --help` and `strings` have no such flag in 2.4.2; it is open feature request [#5423](https://github.com/kirodotdev/Kiro/issues/5423) | High; adapters must not depend on structured headless output |
-| Exit code for invalid arguments | Docs fold invalid args into code 1 | Binary returns `clap` code 2 for an unknown top-level flag (local probe) | Medium; treat any non-zero as failure |
-| Version numbering | Source repo tags releases on a `1.x` line (for example [v1.19.7](https://github.com/aws/amazon-q-developer-cli/releases/tag/v1.19.7)) | Installed distribution reports `kiro-cli 2.4.2` (local probe) | Low; anchor runtime claims to 2.4.2 and the docs |
-| Chat-command flag validation | A pristine `chat --no-such-flag` exits 1 (local probe) | Once a device registration is cached, the same invocation hangs on the login flow instead of erroring (repeated local probes) | Medium; preflight the credential, do not depend on flag-error exit codes |
-| Exit code for authentication failure | Docs map authentication error to exit 1 | An invalid `KIRO_API_KEY` exits **0** with `Authentication failed.` on stderr and empty stdout (authenticated probe) | High; exit 0 is not a success signal, require the credits trailer |
-| Credits and time trailer stream | The hands-on report shows the cost line within the printed transcript | The `▸ Credits: … • Time: …` trailer is emitted on **stderr** (authenticated probe) | Medium; read the trailer from stderr, treat stdout as the answer |
-| Credits and time trailer format | Hands-on report shows `▸ Credits: 0.05 • Time: 6s` | A second observation matches the shape, `▸ Credits: 0.01 • Time: 1s` (authenticated probe); format stable, values vary | Low; the shape is stable, the numbers are not a contract |
-| Headless session enumeration | `--list-sessions` lists saved sessions for the directory | It returns empty for a conversation created by a headless `--no-interactive` turn (authenticated probe) | Medium; use cwd-scoped `--resume`, the ID is not enumerable via the CLI |
-
-## Summary: adapter implementation checklist
-
-1. StartSession: verify the credential. Require `KIRO_API_KEY` (or confirm a usable SSO token)
-   before any `chat` launch, and validate it is not merely present but usable with a free
-   `kiro-cli whoami` or `kiro-cli chat --list-models` call, because an invalid key produces a
-   silent exit-0 empty turn rather than an error. Record the workspace path as cwd. Do not
-   start a long-lived process.
-2. RunTurn (turn 1): launch `kiro-cli chat --no-interactive` with the rendered prompt passed
-   after `--`, plus `--model`, a `--trust-tools` allowlist (or `--trust-all-tools` inside a
-   sandbox), and `--wrap never`. Capture stdout and stderr.
-3. RunTurn (turn 2+): launch in the same workspace directory and add `--resume` to continue
-   the cwd-scoped conversation. This needs no session ID and is the recommended path; both
-   `--resume` and `--resume-id <conversation_id>` were confirmed to retain context, but the
-   session ID is not enumerable via `--list-sessions` on the headless path.
-4. Output handling: treat stdout as the assistant answer (plus tool-progress text when tools
-   run) and read the `▸ Credits:` trailer and warnings from stderr. Strip ANSI for logs. Store
-   a summary in `AgentEvent.Message`. Do not attempt to parse a structured result.
-5. Completion and failure: map exit 0 **with a `▸ Credits:` trailer on stderr** to
-   `turn_completed`; exit 0 with empty stdout and `Authentication failed.` on stderr to
-   `turn_failed`; non-zero to `turn_failed`; exit 3 under `--require-mcp-startup` to an MCP
-   startup failure; and SIGTERM or SIGKILL to `turn_cancelled`. Exit 127 maps to
-   `startup_failed` (binary not found). Do not treat a bare exit 0 as success.
-6. Token usage: emit none. Leave `TurnResult.Usage` zero. Document Kiro as a no-token-accounting
-   adapter.
-7. Model: pin with `--model` per turn, or set `chat.defaultModel` before launch. `/model` is
-   unavailable headless.
-8. MCP: unavailable under `KIRO_API_KEY` auth. The `GetProfile` gate returns 403 and MCP is
-   disabled, so `MCPConfigPath` has no effect and `--require-mcp-startup` is inert. If a
-   workflow needs MCP, it requires an auth path the backend authorizes for the profile (Builder
-   ID reported to work). When MCP is enabled, load servers with `kiro-cli mcp import --file
-   "$MCPConfigPath" workspace` (there is no per-launch `--mcp-config` flag).
-9. Permissions: prefer a least-privilege `--trust-tools` allowlist over `--trust-all-tools`.
-10. Timeout: enforce `TurnTimeoutMS` by killing the process group. This is the only backstop
-    against the login hang and the absence of a native timeout.
-11. StopSession: no-op on clean exit; on cancellation, ensure the subprocess is terminated.
+- The shape of a tool-using turn. Coverage extends to no-tool turns only, so where
+  tool-progress lines land relative to stdout and stderr rests on the hands-on report alone.
+  Settled by an
+  authenticated headless turn with `--trust-tools=read,grep` over a small workspace, capturing
+  stdout and stderr to separate files.
+- Behavior on quota exhaustion and on a mid-turn upstream error. The `DailyRequestCount`,
+  `MonthlyRequestCount`, and `InsufficientModelCapacity` error types exist in the binary, but
+  the exit code and stderr shape they produce are unobserved, so the adapter's classification
+  of them is unknown. Settled by driving an account to its request limit, or by inducing an
+  upstream error mid-turn, under a captured-streams probe.
+- Whether MCP loads under an auth path other than `KIRO_API_KEY`. The upstream issues report
+  Builder ID working while IAM Identity Center fails. Settled by repeating the workspace
+  `mcp.json` probe (`mcp list` plus `chat --no-interactive --require-mcp-startup`) under a
+  Builder ID login.
+- What enforces `agent.turn_timeout_ms` for a Kiro turn. The value reaches adapters through
+  `orchestrator.toDomainAgentConfig` as `domain.AgentConfig.TurnTimeoutMS`, and
+  `kiro.sessionState` stores it without reading it, but no deadline derived from it appears on
+  the path that calls `RunTurn`; `orchestrator.reconcileStalled` cancels on
+  `stall_timeout_ms` only. Settled by tracing the worker's turn context in
+  `internal/orchestrator`.
 
 ## Sources
 

--- a/docs/linear-adapter-notes.md
+++ b/docs/linear-adapter-notes.md
@@ -1,20 +1,29 @@
 # Linear GraphQL API: Adapter research notes
 
-> Linear public GraphQL API, researched June 2026 against the official developer
-> documentation, the published SDK schema (`linear/linear@df20561`, 2026-06-11),
-> and the official TypeScript SDK error classifier, then **verified live** against
-> a real workspace (team `SOR`) on 2026-06-13.
-> Reference for implementing the Linear `TrackerAdapter`.
+> Linear public GraphQL API, hosted cloud only, pinned to the published SDK
+> schema `linear/linear@df20561` (2026-06-11). Instruments: live GraphQL calls
+> against the Linear workspace `sortie-ai`, team `SOR`, on 2026-06-13; the
+> official developer and user documentation; and the official TypeScript SDK
+> error classifier (`packages/sdk/src/error.ts`). Reference for the Linear
+> `domain.TrackerAdapter` implementation in `internal/tracker/linear`.
 >
-> Claims tagged **[live-verified]** were confirmed by direct GraphQL calls against
-> the live API, the strongest available evidence. Where the live API contradicted
-> the published documentation, the live behavior wins and the conflict is noted.
+> Claims tagged **[live-verified]** rest on the live pass, and where the live API
+> contradicts the published documentation the live behavior wins and the conflict
+> is recorded. Every other claim is schema- or documentation-sourced and names its
+> source in Source attribution.
+>
+> Coverage: authentication, identifiers, the team state model, all nine
+> `domain.TrackerAdapter` operations, field mapping, pagination, rate limiting,
+> and the error model are anchored to the pinned schema and the 2026-06-13 live
+> pass. The forbidden label-create path and the rate-limit response body are not
+> live-observed; see Open questions.
 
 Linear exposes a single GraphQL endpoint rather than the REST surfaces of the
-existing Jira and GitHub adapters. Client construction, query shapes, pagination,
-and error handling all differ. The adapter is built on `internal/httpkit` with no
-third-party GraphQL library: a GraphQL call is an HTTP POST with a JSON body, and
-the response is a JSON envelope. Nothing more is required.
+Jira and GitHub adapters. Client construction, query shapes, pagination, and
+error handling all differ. `linear.newLinearClient` builds on
+`httpkit.NewClient` with no third-party GraphQL library: a GraphQL call is an
+HTTP POST with a JSON body, and the response is a JSON envelope. Nothing more is
+required.
 
 ---
 
@@ -95,9 +104,9 @@ query Me {
 }
 ```
 
-The adapter should run this at construction time: a failure classifies the key
-before the first poll cycle, and the returned `viewer.id` is useful when an
-assignee filter is configured (see `FetchCandidateIssues`).
+`linear.checkViewer` runs it at construction, inside `linear.runPreflight`, so a
+failure classifies the key before the first poll cycle. The adapter discards the
+returned payload and keeps only the classification.
 
 **[live-verified]** A valid key returns
 `{ "data": { "viewer": { "id": "<uuid>", "name": "...", "email": "..." } } }`
@@ -107,14 +116,6 @@ error: `message: "Authentication required, not authenticated"`,
 `statusCode: 401`, `userPresentableMessage: "You need to authenticate to access
 this operation."` So an invalid key fails at both the HTTP layer (401) and the
 body layer; the adapter's body-first classifier handles it either way.
-
-### Config mapping
-
-| Config field       | Value                                                     |
-| ------------------ | --------------------------------------------------------- |
-| `tracker.endpoint` | `https://api.linear.app/graphql` (default, omit normally) |
-| `tracker.api_key`  | Personal API key (`lin_api_...`), sent verbatim           |
-| `tracker.project`  | Linear **team key**, e.g. `ENG` (see Identifiers below)   |
 
 ---
 
@@ -127,7 +128,8 @@ body layer; the adapter's body-first classifier handles it either way.
   top-level `errors` array, **potentially alongside partial `data`**.
 - The endpoint supports introspection; the full schema is also published at
   `linear/linear` (`packages/sdk/src/schema.graphql`).
-- Network timeout: 30,000 ms ([architecture Section 11.2](architecture/11-issue-tracker-integration-contract.md#112-query-semantics) default).
+- Network timeout: 30,000 ms, the [architecture Section 11.2](architecture/11-issue-tracker-integration-contract.md#112-query-semantics)
+  default, set by `linear.defaultTimeout` and passed to `httpkit.ClientOptions.Timeout`.
 
 HTTP status semantics differ from REST APIs and from each other. The table marks
 what was observed live:
@@ -141,7 +143,7 @@ what was observed live:
 | 429    | Also documented for rate limiting; the official SDK handles both 400 and 429                                                | documented                              |
 | 5xx    | Server-side failure                                                                                                         | documented                              |
 
-The decisive rule, now confirmed by the spread above: **HTTP status alone never
+The decisive rule, which the spread above confirms: **HTTP status alone never
 classifies a Linear response.** An entity-not-found and an argument-validation
 failure both arrive on HTTP 200 with the real error in the body; an invalid key
 arrives on 401 with the same body shape. Error classification inspects the
@@ -150,23 +152,24 @@ no `errors` array (see Error model).
 
 ### httpkit fit
 
-GraphQL inverts two assumptions baked into the current `httpkit` surface:
+GraphQL inverts two assumptions the REST side of `httpkit` is built on, and the
+adapter resolves each one:
 
-- All calls are `POST` to one path. `httpkit.Client.Send` provides POST, but it
-  returns only the body, not the response headers. Reading the rate-limit and
-  `X-Complexity` headers on success requires a Send variant that exposes
-  headers (small additive change).
+- All calls are `POST` to one path, and the rate-limit and `X-Complexity`
+  headers must be readable on success. `linearClient.Execute` posts through
+  `httpkit.Client.SendWithHeaders`, which returns the body together with a clone
+  of the response headers; the endpoint carries the full URL, so the path
+  argument is empty.
 - Cursor state travels in the JSON `variables` object (`after`), not in a URL
-  query parameter, so `httpkit.NewTokenPaginator` does not apply as-is. The
-  adapter implements the same loop shape over POST: issue request, decode
-  `nodes` + `pageInfo`, stop when `hasNextPage` is false, honor a `MaxPages`
-  bound, and report a missing cursor (see Pagination). Either generalize the
-  paginator with a request-builder hook or keep the loop local to the adapter;
-  the loop is ~30 lines either way.
+  query parameter, so `httpkit.NewTokenPaginator` does not apply. The adapter
+  keeps its own loop of the same shape, `linear.paginate`: issue the request,
+  decode `nodes` plus `pageInfo`, stop when `hasNextPage` is false, bound the
+  walk at `linear.maxPages`, and report a missing cursor (see Pagination).
 
-Error classification stays in the `httpkit` mold: the GraphQL transport wraps
-`ClassifyError`/`ClassifyTransport` for HTTP-level failures and adds a
-body-level classification pass that REST adapters do not need.
+Error classification stays in the `httpkit` mold: `linear.classifyResponseBody`
+and `linear.classifyTransport` are wired into `httpkit.ClientOptions` as the
+error and transport classifiers, and `classifyResponseBody` adds the body-level
+pass that REST adapters do not need.
 
 ---
 
@@ -188,8 +191,8 @@ Domain mapping: `issue.id` is the domain `ID`, `issue.identifier` is the domain
 `Identifier`. The lookup queries accept both forms: the official documentation
 queries `issue(id: "BLA-123")` directly, and documents `issueUpdate` as
 accepting "a UUID or a shorthand ID". This is convenient but silent: nothing in
-a response says which form was used, so the adapter should always pass the form
-it means and never construct one from the other.
+a response says which form was used, so the adapter passes the form it means
+verbatim and never constructs one from the other.
 
 **`tracker.project` selects the team key** (`ENG`), not a Linear project. Three
 reasons:
@@ -205,15 +208,15 @@ reasons:
    team for state resolution.
 
 The filter is `team: { key: { eq: "ENG" } }` (`TeamFilter.key` is a
-`StringComparator`); no team UUID resolution is needed for reads.
+`StringComparator`), built by `linear.buildFetchFilter`; no team UUID resolution
+is needed for reads. Only the label-create write path needs the team UUID, and
+it resolves one per call through `LinearAdapter.resolveTeamID` (see operation 9).
 
 ---
 
 ## State model
 
-This is the least mechanical part of the port. Jira has rich named workflow
-states; GitHub has only `open`/`closed` plus labels. Linear sits in between: it
-has real named states, but every state also carries a workspace-immutable
+Linear has real named states, and every state also carries a workspace-immutable
 **category** that tells you what the state means.
 
 ### Workflow state shape
@@ -243,11 +246,13 @@ type WorkflowState {
 **[live-verified]** A freshly created team (`SOR`) shipped with exactly six
 default states and no `triage`: Backlog (`backlog`), Todo (`unstarted`),
 In Progress (`started`), Done (`completed`), Canceled (`canceled`),
-Duplicate (`duplicate`). `triage` is opt-in per team, confirming it must be
-excluded by default. A sensible default mapping for this stock layout is active
-`["Backlog", "Todo", "In Progress"]`, terminal `["Done", "Canceled",
-"Duplicate"]`, and an operator-added `"In Review"` (`started`) for
-`handoff_state`.
+Duplicate (`duplicate`). `triage` is opt-in per team, so it is excluded by
+default. The adapter's defaults for this stock layout are
+`linear.defaultActiveStates` (`["Backlog", "Todo", "In Progress"]`) and
+`linear.defaultTerminalStates` (`["Done", "Canceled", "Duplicate"]`), applied
+when the config omits the list and registered as `DefaultActiveStates` and
+`DefaultTerminalStates` in the adapter's `registry.TrackerMeta`. There is no
+default `handoff_state`; an operator-added `"In Review"` (`started`) fills it.
 
 Two properties make this trickier than it looks:
 
@@ -271,10 +276,11 @@ tracker:
   handoff_state: "In Review"
 ```
 
-The `type` field is not used for candidate selection (names are more precise
-and match the other adapters), but it is the right tool for a **startup
-preflight**: fetch the team's states once and verify every configured name
-exists, with a case-insensitive comparison in Go:
+The `type` field does not drive candidate selection (names are more precise and
+match the other adapters). It serves the **startup preflight** instead:
+`linear.runPreflight` fetches the team's states once through
+`linear.fetchTeamStates` and verifies every configured name exists, comparing
+case-insensitively in Go:
 
 ```graphql
 query TeamStates($teamKey: String!) {
@@ -298,18 +304,21 @@ query TeamStates($teamKey: String!) {
 This preflight serves three purposes:
 
 1. Misconfigured state names fail at startup, not silently as an empty
-   candidate list.
-2. The adapter caches the canonical casing of each configured name. The `in`
-   state filter used by the fetch queries is case-sensitive
+   candidate list. A name absent from the team, and an unknown team key, both
+   return `domain.ErrTrackerPayload` and block construction.
+2. The adapter caches the canonical casing of each configured name in the map
+   `runPreflight` returns, and `linear.canonicalize` applies it to every state
+   list the fetch queries send. The `in` state filter is case-sensitive
    (`StringComparator` distinguishes `eq`/`in` from `eqIgnoreCase`, which has
    no `in` analogue), so queries must send the canonical names.
    **[live-verified]** `state: { name: { in: ["todo"] } }` returned zero issues
    while `["Todo"]` returned all six; case-sensitivity of the `in` filter is
    real, and the preflight casing cache is mandatory, not a nicety.
-3. Warn when a configured `active_states` entry resolves to a state whose
-   `type` is `completed`, `canceled`, or `duplicate` (and vice versa for
-   `terminal_states`). The categories are wrong-config tripwires even though
-   they do not drive selection.
+3. `linear.warnWrongCategory` emits a WARN when a configured `active_states`
+   entry resolves to a state whose `type` is `completed`, `canceled`, or
+   `duplicate`, and the reverse for `terminal_states`. The categories are
+   wrong-config tripwires even though they do not drive selection, so the
+   mismatch never fails construction.
 
 ### Transitions need a UUID
 
@@ -335,9 +344,10 @@ query ResolveStateID($issueId: String!, $stateName: String!) {
 
 `eqIgnoreCase` tolerates casing drift between operator config and Linear.
 An empty `nodes` array means no state with that name exists in the issue's
-team: return `ErrTrackerPayload` (no available transition leads to the target
-state). Unlike Jira there is no transition graph: any state can move to any
-state, so resolve-then-update is the entire flow.
+team, and `LinearAdapter.TransitionIssue` returns `domain.ErrTrackerPayload`
+for it; a null `issue` means the issue itself is missing and returns
+`domain.ErrTrackerNotFound`. Unlike Jira there is no transition graph: any state
+can move to any state, so resolve-then-update is the entire flow.
 
 **[live-verified]** The resolve query with `stateName: "in review"` (lowercase)
 against `issue("SOR-5")` returned the team's `In Review` state and its UUID, then
@@ -349,7 +359,7 @@ case-insensitive resolve plus update, works end to end.
 
 ## Operations
 
-The `TrackerAdapter` Go interface has nine methods. Seven of them are the
+The `domain.TrackerAdapter` Go interface has nine methods. Seven of them are the
 required tracker operations in the architecture spec ([Section 11.1](architecture/11-issue-tracker-integration-contract.md#111-required-operations)),
 `FetchCandidateIssues` through `TransitionIssue`; the interface adds
 `CommentIssue` (lifecycle comments) and `AddLabel` (CI-failure label
@@ -360,19 +370,11 @@ endpoint and are covered below as operations 1 through 9 (`CommentIssue` and
 ### 1. `FetchCandidateIssues`: `issues` query, team + active states
 
 ```graphql
-query CandidateIssues(
-  $teamKey: String!
-  $states: [String!]!
-  $first: Int!
-  $after: String
-) {
+query CandidateIssues($filter: IssueFilter!, $first: Int!, $after: String) {
   issues(
     first: $first
     after: $after
-    filter: {
-      team: { key: { eq: $teamKey } }
-      state: { name: { in: $states } }
-    }
+    filter: $filter
     sort: [
       { priority: { order: Ascending, noPriorityFirst: false } }
       { createdAt: { order: Ascending } }
@@ -404,6 +406,9 @@ query CandidateIssues(
         nodes {
           name
         }
+        pageInfo {
+          hasNextPage
+        }
       }
       inverseRelations(first: 25) {
         nodes {
@@ -416,6 +421,9 @@ query CandidateIssues(
             }
           }
         }
+        pageInfo {
+          hasNextPage
+        }
       }
     }
     pageInfo {
@@ -426,78 +434,53 @@ query CandidateIssues(
 }
 ```
 
-Variables: `{ "teamKey": "ENG", "states": ["Backlog", "Todo"], "first": 50, "after": null }`.
+Variables: `{ "filter": { ... }, "first": 50, "after": null }`. The filter
+travels in the variables object, never in the query text.
+`linear.buildFetchFilter` allocates it per call from the configured team key,
+the state list, and the operator's `tracker.query_filter` fragment (see Config
+notes), so concurrent fetches never share a map.
 
 Notes:
 
 - The `sort` argument exists on `issues` (`IssueSortInput`), but
-  **[live-verified]** its priority ordering is non-obvious and should not be
-  relied on. With issues of priority 0, 2, and 3 present,
+  **[live-verified]** its priority ordering is non-obvious and the adapter does
+  not rely on it. With issues of priority 0, 2, and 3 present,
   `sort: [{ priority: { order: Ascending, noPriorityFirst: false } }, { createdAt: { order: Ascending } }]`
   returned the no-priority (0) group first, then priority 3, then priority 2,
-  which is neither plain ascending nor descending by the numeric value. Rather
-  than depend on server-side priority semantics, the adapter should compute the
-  normalized domain priority (0 to nil, 1..4 to int) and **sort candidates
-  client-side** for deterministic, cross-adapter-consistent dispatch order. The
-  `sort` argument can be dropped or kept as a coarse hint; the createdAt
-  secondary is still a reasonable stable order for the fetch itself.
-- Comments are deliberately not fetched; `Issue.Comments` stays nil per the
-  interface contract, and the pre-dispatch `FetchIssueByID` supplies them.
+  which is neither plain ascending nor descending by the numeric value. Instead
+  of depending on server-side priority semantics,
+  `linear.sortByPriorityThenCreated` sorts candidates client-side by normalized
+  priority (nil last) then `createdAt`, giving deterministic dispatch order
+  consistent with the other adapters. The `sort` argument stays on the candidate
+  query as a coarse hint and is dropped from the by-states query
+  (`linear.queryIssuesByStates`), where dispatch order is irrelevant.
+- Comments are deliberately not fetched; `LinearAdapter.fetchIssues` sets
+  `Issue.Comments` to nil per the interface contract, and the pre-dispatch
+  `FetchIssueByID` supplies them.
 - Nested connections are capped at `first: 25` as cheap insurance against a
-  pathological issue (hundreds of labels/blockers); the candidate query
+  pathological issue (hundreds of labels or blockers); the candidate query
   measured only 95 complexity points, so this is not cap-avoidance (see Rate
-  limiting).
+  limiting). The adapter does not paginate nested connections. It selects their
+  `pageInfo.hasNextPage` and `linear.warnNestedOverflow` emits a WARN naming the
+  issue and the connection when the cap truncates, so a dropped label or blocker
+  stays observable.
 - Archived issues are excluded by default (`includeArchived` defaults to
-  false); do not pass the argument.
-- Optional assignee scoping, if ever configured, is a filter fragment rather
-  than a post-filter: `assignee: { isMe: { eq: true } }` selects issues
+  false); the adapter does not pass the argument.
+- Assignee scoping belongs in the operator's `tracker.query_filter` fragment
+  rather than a post-filter: `assignee: { isMe: { eq: true } }` selects issues
   assigned to the key's user without resolving the viewer id, and
-  `assignee: { id: { eq: $uuid } }` pins a specific user. **[live-verified]**
+  `assignee: { id: { eq: "<uuid>" } }` pins a specific user. **[live-verified]**
   `isMe: { eq: true }` returned only the one issue assigned to the key's user.
 
 ### 2. `FetchIssueByID`: `issue` query, UUID or identifier
 
+The issue selection is the one shown for operation 1, plus an inline first page
+of comments:
+
 ```graphql
 query IssueByID($id: String!) {
   issue(id: $id) {
-    id
-    identifier
-    title
-    description
-    priority
-    branchName
-    url
-    createdAt
-    updatedAt
-    state {
-      name
-    }
-    assignee {
-      displayName
-      name
-      email
-    }
-    parent {
-      id
-      identifier
-    }
-    labels(first: 25) {
-      nodes {
-        name
-      }
-    }
-    inverseRelations(first: 25) {
-      nodes {
-        type
-        issue {
-          id
-          identifier
-          state {
-            name
-          }
-        }
-      }
-    }
+    # ...the operation 1 node selection...
     comments(first: 50, orderBy: createdAt) {
       nodes {
         id
@@ -523,20 +506,24 @@ query IssueByID($id: String!) {
 
 `Query.issue(id: String!)` accepts either the UUID or the human identifier;
 the official docs query `issue(id: "BLA-123")` directly. When
-`comments.pageInfo.hasNextPage` is true, continue with the dedicated comment
-pagination from operation 6 and append.
+`comments.pageInfo.hasNextPage` is true, `LinearAdapter.collectComments`
+resumes the operation 6 connection from the inline `endCursor` and appends the
+continuation pages, so the inline page is never re-fetched; an inline
+`hasNextPage` with an empty `endCursor` returns
+`domain.ErrTrackerMissingCursor`.
 
-Not-found surfaces as a body-level error with `data.issue: null`; map it to
-`ErrTrackerNotFound` (see Error model).
+Not-found surfaces as a body-level error with `data.issue: null`, which
+`FetchIssueByID` maps to `domain.ErrTrackerNotFound` (see Error model).
 
 ### 3. `FetchIssuesByStates`: same query, caller-supplied states
 
-The `FetchCandidateIssues` query verbatim, with the orchestrator-supplied
-state list (terminal cleanup passes terminal states) and without the `sort`
-argument (order is irrelevant to cleanup). State names pass through the same
-canonical-casing cache built by the startup preflight, because `in` matching
-is case-sensitive while the interface contract promises case-insensitive
-comparison.
+`linear.queryIssuesByStates` is the `FetchCandidateIssues` query without the
+`sort` argument (order is irrelevant to cleanup), run with the
+orchestrator-supplied state list; terminal cleanup passes terminal states.
+`FetchIssuesByStates` returns an empty slice with no API call when the state
+list is empty, and otherwise passes the names through the same canonical-casing
+cache the preflight built, because `in` matching is case-sensitive while the
+interface contract promises case-insensitive comparison.
 
 ### 4. `FetchIssueStatesByIDs`: `issues` filtered by id batch
 
@@ -553,18 +540,24 @@ query IssueStatesByIDs($ids: [ID!]!, $first: Int!) {
 }
 ```
 
-`IssueIDComparator.in` takes UUIDs. Chunk at 50 ids per request and set
-`first` to the chunk length. Build the result map from the returned nodes;
-ids absent from the response are simply omitted from the map (the interface
-treats missing as not-an-error). No `pageInfo` is needed because the page size
-equals the requested id count.
+`IssueIDComparator.in` takes UUIDs. `FetchIssueStatesByIDs` chunks at
+`linear.stateBatchChunkSize` (50) ids per request and sets `first` to the chunk
+length, then builds the result map from the returned nodes; ids absent from the
+response are omitted from the map (the interface treats missing as
+not-an-error). No `pageInfo` is needed because the page size equals the
+requested id count. A connection filter is what makes that omission safe: an
+aliased `issue(id:)` batch fails the whole response on one miss (see Error
+model).
 
 ### 5. `FetchIssueStatesByIdentifiers`: team-key + number filter
 
 `IssueFilter` has **no `identifier` field** (schema-verified; it offers `id`,
-`number`, `team`, and others). The adapter splits each identifier into its team
-key and numeric part (`"SOR-7"` to `("SOR", 7)`) and filters by the number set,
-scoped to the configured team:
+`number`, `team`, and others). `linear.extractNumbers` splits each identifier on
+its last hyphen and keeps the trailing integer (`"SOR-7"` to `7`), skipping any
+identifier whose trailing part is not an integer, and the query filters by the
+number set scoped to the configured team key. The team half of the identifier is
+not read: every identifier the orchestrator passes belongs to the configured
+team, and `tracker.project` supplies the team key.
 
 ```graphql
 query IssueStatesByNumbers(
@@ -588,22 +581,17 @@ query IssueStatesByNumbers(
 ```
 
 `Issue.number` is a `Float` in the schema, and `NumberComparator.in` is the
-matching filter. Build the result map keyed by `identifier` from the returned
-nodes; numbers absent from the response are omitted (the interface treats
-missing as not-an-error). All identifiers share the configured `tracker.project`
-team key, so one filter covers the batch; chunk the number list at 50.
+matching filter. `FetchIssueStatesByIdentifiers` builds the result map keyed by
+`identifier` from the returned nodes; numbers absent from the response are
+omitted (the interface treats missing as not-an-error), and the number list is
+chunked at `linear.stateBatchChunkSize` (50).
 
-> **Do not use an aliased `issue(id:)` batch here.** It is the obvious design and
-> it is broken. `Query.issue` returns the non-null type `Issue!`, so when **any**
-> alias resolves to a missing issue, the GraphQL executor nulls the **entire**
-> `data` object and abandons the sibling aliases. **[live-verified]** A batch of
-> `i0: issue("SOR-5")`, `i1: issue("SOR-99999")`, `i2: issue("SOR-7")` returned
-> `data: null` with a single error for `i1`; the two valid lookups returned
-> nothing. A deleted or renamed issue, the exact reconciliation case this method
-> serves, would wipe the states of every other issue in the batch. The
-> connection-filter form above does not have this failure: **[live-verified]**
-> `number: { in: [5, 7, 99999] }` returned SOR-5 and SOR-7 and silently dropped 99999. The same reasoning is why `FetchIssueStatesByIDs` (operation 4) uses
-> `id: { in: [...] }` rather than aliased lookups.
+The connection filter, not an aliased `issue(id:)` batch, is what makes a
+missing issue harmless here. An alias batch nulls the entire `data` object when
+any one alias misses, which is the exact reconciliation case this method serves
+(see Error model). **[live-verified]** The connection-filter form has no such
+failure: `number: { in: [5, 7, 99999] }` returned SOR-5 and SOR-7 and silently
+dropped 99999.
 
 ### 6. `FetchIssueComments`: `issue.comments` connection
 
@@ -635,21 +623,24 @@ query IssueComments($id: String!, $first: Int!, $after: String) {
 
 - `orderBy: createdAt` is the documented default field. **[live-verified]** Its
   direction is **descending, newest first**: two comments created 28 ms apart
-  came back newest-then-oldest. Agents want chronological context, so the
-  adapter MUST sort the accumulated slice by `createdAt` ascending in Go before
-  returning. The client-side sort is mandatory, not defensive.
+  came back newest-then-oldest. Agents want chronological context, so
+  `linear.sortCommentsByCreatedAt` sorts the accumulated slice by `createdAt`
+  ascending before returning. The client-side sort is mandatory, not defensive.
 - `body` is markdown ("derived representation of the canonical bodyData
-  ProseMirror content" per the schema); no flattening, pass through.
+  ProseMirror content" per the schema); the adapter passes it through without
+  flattening.
 - `user` is null for comments created by integrations or bots; `botActor`
-  covers agent/bot comments. Author resolution: `user.displayName`, then
-  `user.name`, then `botActor.name`, else empty string. (`externalUser`
-  exists for Slack/Intercom-originated comments; not selected initially.)
-  **[live-verified]** A human-authored comment returned
-  `user: { displayName, name, email }` with `botActor: null`; the comment
-  `body` round-tripped verbatim, including a raw issue URL (mention rendering
-  happens in the UI, not in the stored markdown).
-- Empty connection returns an empty non-nil slice. Not-found maps to
-  `ErrTrackerNotFound`.
+  covers agent and bot comments. `linear.resolveCommentAuthor` resolves the
+  author as `user.displayName`, then `user.name`, then `botActor.name`, else the
+  empty string. `externalUser` exists for Slack- and Intercom-originated
+  comments and the adapter does not select it, so such comments resolve to
+  `botActor.name` or the empty string. **[live-verified]** A human-authored
+  comment returned `user: { displayName, name, email }` with `botActor: null`;
+  the comment `body` round-tripped verbatim, including a raw issue URL (mention
+  rendering happens in the UI, not in the stored markdown).
+- An empty connection returns an empty non-nil slice. The query re-selects the
+  parent issue on every continuation page, so a not-found mid-pagination
+  surfaces as `domain.ErrTrackerNotFound` from `linear.decodeCommentsPage`.
 
 ### 7. `TransitionIssue`: resolve query + `issueUpdate`
 
@@ -670,10 +661,11 @@ mutation IssueUpdateState($id: String!, $stateId: String!) {
 ```
 
 `issueUpdate` is documented to accept a UUID or shorthand id. The payload is
-`IssuePayload { success: Boolean!, issue: Issue, lastSyncId: Float! }`. Treat
-a non-empty `errors` array as failure regardless of `success`; treat
-`success: false` without errors as `ErrTrackerAPI` (defensive; Linear
-normally signals failure via `errors`).
+`IssuePayload { success: Boolean!, issue: Issue, lastSyncId: Float! }`.
+`linear.runMutation` applies the result policy for every mutation: a non-empty
+`errors` array is a failure regardless of `success`, and `success: false` with
+no errors maps to `domain.ErrTrackerAPI` (defensive; Linear normally signals
+failure through `errors`).
 
 ### 8. `CommentIssue`: `commentCreate`
 
@@ -699,27 +691,20 @@ UUID, so prefer it for clarity, but a shorthand-id call is not an error.
 `organization.urlKey` was `sortie-ai`, so SOR-5 is
 `https://linear.app/sortie-ai/issue/SOR-5/...`; a user profile is
 `https://linear.app/<urlKey>/profiles/<handle>`). An agent may embed such URLs
-in a comment body to reference issues for human readers. Do **not** rely on a
-plain URL rendering as an interactive mention "pill", though: **[live-verified]**
-the comment body round-trips verbatim through the API (the URL is stored as
-plain text), and mention-pill rendering is a paste-time editor behavior that the
-editor itself lets users decline ("Keep as link"). Whether a markdown-body URL
-becomes a mention on display is not documented for the API path and was not
-verified, so the adapter treats URLs as plain text and makes no mention
-guarantee.
+in a comment body to reference issues for human readers. A plain URL does not
+render as an interactive mention "pill": **[live-verified]** the comment body
+round-trips verbatim through the API (the URL is stored as plain text), and
+mention-pill rendering is a paste-time editor behavior that the editor itself
+lets users decline ("Keep as link"). The adapter treats URLs as plain text and
+makes no mention guarantee.
 
 ### 9. `AddLabel`: resolve + optional create + append
 
-Linear attaches labels by UUID, so "add label by name" is a compound
-operation. The schema offers two write shapes on `IssueUpdateInput`, and the
-choice matters (see Collection writes below for the hazard):
-
-- `labelIds: [String!]`: "the identifiers of the issue labels associated with
-  this ticket". **Replaces the full set.**
-- `addedLabelIds: [String!]` / `removedLabelIds: [String!]`: "labels to be
-  added to" / "removed from" the issue. **Append/remove semantics.**
-
-The adapter uses `addedLabelIds`, which reduces `AddLabel` to:
+Linear attaches labels by UUID, so "add label by name" is a compound operation.
+`IssueUpdateInput` offers a replace-style field and an append/remove pair for
+the same collection, and `LinearAdapter.AddLabel` uses the append form
+`addedLabelIds` (see Collection writes for the hazard the replace form carries).
+That reduces `AddLabel` to three steps.
 
 **Step 1.** Resolve the label by name, covering both team-scoped and
 workspace labels (the root query returns both, per its schema doc):
@@ -732,16 +717,25 @@ query ResolveLabel($name: String!) {
       name
       team {
         id
+        key
       }
     }
   }
 }
 ```
 
-Prefer a label whose `team.id` matches the configured team; fall back to a
-workspace label (`team` null).
+The selection carries `team.key`, not `team.id` alone, because
+`tracker.project` is a team **key** and `IssueLabel.team.id` is a UUID: matching
+the configured project against the UUID field never matches and silently
+demotes every team-scoped label. `LinearAdapter.resolveLabelID` compares
+`node.team.key` with the configured project, returns the first team-scoped
+match, and falls back to the first workspace label (`team` null) when no
+team-scoped label matches.
 
-**Step 2.** If no label matched, create it scoped to the team:
+**Step 2.** If no label matched, resolve the owning team's UUID with
+`LinearAdapter.resolveTeamID` (the label create needs a UUID, and the transition
+path that would otherwise resolve one does not run here), then create the label
+scoped to that team:
 
 ```graphql
 mutation LabelCreate($teamId: String!, $name: String!) {
@@ -755,12 +749,14 @@ mutation LabelCreate($teamId: String!, $name: String!) {
 ```
 
 Omitting `teamId` would create a workspace-level label (schema-documented);
-the adapter always passes the team id, because workspace-label management is
-more likely to require elevated permissions. On a name-uniqueness conflict
-from a concurrent create (`invalid input` class error), re-run step 1 once
-and use the now-existing id. If creation is forbidden for the key, return
-`ErrTrackerAuth`; the orchestrator treats label errors as non-fatal, and the
-operator remedy is to pre-create the escalation label in Linear.
+`LinearAdapter.createLabel` always passes the team id, because workspace-label
+management is more likely to require elevated permissions. On any payload-class
+create error, which covers the name-uniqueness conflict a concurrent create
+produces, `AddLabel` re-runs step 1 once and uses the now-existing id; only a
+re-resolve that still finds nothing surfaces the original create error. A
+create forbidden for the key classifies as `domain.ErrTrackerAuth`. The
+orchestrator treats label errors as non-fatal (`internal/orchestrator` logs the
+failure at WARN and counts a CI-escalation error), and the operator remedy is to pre-create the escalation label in Linear.
 
 Label-creation is gated by a specific, named team setting, not just admin
 status: under **Team settings > Access and permissions**, a team owner chooses
@@ -771,7 +767,7 @@ a Read+Write member key gets a `FORBIDDEN`/`feature not accessible` error on
 owners. The operator has two clean remedies: flip that team setting to allow
 members, or pre-create the escalation label (default `needs-human`) once, after
 which the adapter's lookup in step 1 finds it and never calls
-`issueLabelCreate`. Document both in the operator README.
+`issueLabelCreate`.
 
 **Step 3.** Append by id; no read of the existing label set is needed:
 
@@ -783,20 +779,20 @@ mutation IssueAddLabel($id: String!, $labelIds: [String!]!) {
 }
 ```
 
-**[live-verified]** The whole flow was exercised end to end:
-`issueLabelCreate(input: { teamId, name: "needs-human" })` returned
+**[live-verified]** The whole flow works end to end:
+`issueLabelCreate(input: { teamId, name: "needs-human" })` returns
 `success: true` with a team-scoped label id, and
 `issueUpdate(id: "SOR-5", input: { addedLabelIds: [<id>] })` left the issue with
 **both** its pre-existing `Feature` label and the new `needs-human` label. The
 append semantics are real and the read-before-write step is genuinely
-unnecessary. (The test key had full access, so the `FORBIDDEN` degradation path
-was not exercised; that branch remains documentation-sourced.)
+unnecessary.
 
 ---
 
 ## Field mapping
 
-`domain.Issue` field to Linear source (all field names schema-verified):
+`linear.normalizeIssue` maps a Linear issue node to `domain.Issue` as follows
+(all Linear field names schema-verified):
 
 | `domain.Issue` field | Linear source                                         | Notes                                                                                                                                                                                                                                                                  |
 | -------------------- | ----------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -805,16 +801,16 @@ was not exercised; that branch remains documentation-sourced.)
 | `DisplayID`          | empty                                                 | Identifiers are already display-ready                                                                                                                                                                                                                                  |
 | `Title`              | `issue.title`                                         |                                                                                                                                                                                                                                                                        |
 | `Description`        | `issue.description`                                   | Markdown per schema; nullable, null becomes empty string                                                                                                                                                                                                               |
-| `Priority`           | `issue.priority`                                      | Float in schema: 0 = No priority, 1 = Urgent, 2 = High, 3 = Medium, 4 = Low. Map 1..4 to `*int`; map 0 to nil                                                                                                                                                          |
+| `Priority`           | `issue.priority`                                      | Float in schema: 0 = No priority, 1 = Urgent, 2 = High, 3 = Medium, 4 = Low. `linear.normalizePriority` maps 1..4 to `*int` and 0 or null to nil                                                                                                                                                          |
 | `State`              | `issue.state.name`                                    | Original casing preserved                                                                                                                                                                                                                                              |
 | `BranchName`         | `issue.branchName`                                    | Non-null; auto-generated. Format is workspace-configurable (see below); treat the whole string as opaque, never parse the prefix                                                                                                                                       |
 | `URL`                | `issue.url`                                           | Provided directly, no construction                                                                                                                                                                                                                                     |
-| `Labels`             | `issue.labels.nodes[].name`                           | Lowercase each ([Section 11.3](architecture/11-issue-tracker-integration-contract.md#113-normalization-rules)); non-nil empty slice when none                                                                                                                                                                                                           |
-| `Assignee`           | `assignee.displayName`, fallback `name`, then `email` | `assignee` is strictly the `User` type, nullable; null becomes empty string. Agents/apps are not `User`s (they surface under the separate `delegate`/`botActor` fields the adapter does not read), so an agent-driven issue with no human assignee normalizes to empty |
+| `Labels`             | `issue.labels.nodes[].name`                           | Lowercased by `issuekit.NormalizeLabels` ([Section 11.3](architecture/11-issue-tracker-integration-contract.md#113-normalization-rules)); non-nil empty slice when none                                                                                                                                                                                                           |
+| `Assignee`           | `assignee.displayName`, fallback `name`, then `email` | Resolved by `linear.resolveAssignee`; `assignee` is strictly the `User` type, nullable; null becomes empty string. Agents/apps are not `User`s (they surface under the separate `delegate`/`botActor` fields the adapter does not read), so an agent-driven issue with no human assignee normalizes to empty |
 | `IssueType`          | empty                                                 | Linear has no native issue-type field                                                                                                                                                                                                                                  |
 | `Parent`             | `issue.parent` `{id, identifier}`                     | Nil when absent                                                                                                                                                                                                                                                        |
-| `Comments`           | separate connection (op 6)                            | Nil when not fetched; empty non-nil when fetched and empty                                                                                                                                                                                                             |
-| `BlockedBy`          | `inverseRelations.nodes` where `type == "blocks"`     | See below                                                                                                                                                                                                                                                              |
+| `Comments`           | separate connection (operation 6)                     | Nil when not fetched; empty non-nil when fetched and empty                                                                                                                                                                                                             |
+| `BlockedBy`          | `inverseRelations.nodes` where `type == "blocks"`     | Extracted by `linear.extractBlockers`; see below                                                                                                                                                                                                                                                              |
 | `CreatedAt`          | `issue.createdAt`                                     | ISO-8601 `DateTime`, passed through                                                                                                                                                                                                                                    |
 | `UpdatedAt`          | `issue.updatedAt`                                     | ISO-8601 `DateTime`, passed through                                                                                                                                                                                                                                    |
 
@@ -836,8 +832,9 @@ So when issue A blocks issue B, the relation record is
 
 This matches the architecture's normalization rule ("blocked_by derived from
 inverse relations where relation type is `blocks`") almost verbatim; Linear is
-the tracker whose native model the rule was phrased for. Compare `type`
-case-insensitively after trimming, defensively.
+the tracker whose native model the rule was phrased for. `linear.extractBlockers`
+compares `type` case-insensitively after trimming, defensively, and always
+returns a non-nil slice.
 
 **[live-verified]** With SOR-5 set to block SOR-7
 (`issueRelationCreate(issueId: SOR-5, relatedIssueId: SOR-7, type: blocks)`),
@@ -847,27 +844,25 @@ state: { name: "Todo" } } }]`. The blocked issue carries the relation, the
 blocker is `node.issue`, and `type` came back as the lowercase string
 `"blocks"`. The direction in the mapping above is correct.
 
-Other field mappings confirmed against live issues: `priority` 2 and 3 returned
-as expected and onboarding issues returned `priority: 0` (map to nil);
-`branchName` was always present and auto-generated (`tasks/sor-5-implement-...`,
-where the `tasks/` prefix is this workspace user's handle, not a fixed string);
-`description` was markdown and came back `null` for an issue created without one
-(map null to empty string); `assignee` returned
-`{ displayName, name, email }` for an assigned issue and `null` for unassigned;
-`parent` returned `{ id, identifier }` on the sub-issue; `url` was supplied
-directly.
+**[live-verified]** The nullability behavior in the table above holds on live
+issues: `priority` came back 2 and 3 on prioritized issues and 0 on onboarding
+issues; `description` was markdown and `null` on an issue created without one;
+`assignee` was `{ displayName, name, email }` when assigned and `null` when
+unassigned; `parent` was `{ id, identifier }` on a sub-issue; and `url` was
+supplied directly with no construction needed.
 
 ### `branchName` is not a fixed format
 
-The branch-name prefix is **not** stable across workspaces. This run observed
+`branchName` is non-null and auto-generated, but its prefix is **not** stable
+across workspaces. **[live-verified]** SOR-5 returned
 `tasks/sor-5-implement-...`, where `tasks/` is the acting user's handle rather
 than a fixed token. The schema explains why: `Organization.gitBranchFormat` is a
 workspace-level template ("Supports template variables like `{issueIdentifier}`
 and `{issueTitle}`. If null, the default formatting will be used"), so the
-default prefix is derived from the acting user's handle and the whole format is
+default prefix derives from the acting user's handle and the whole format is
 operator-configurable. The adapter MUST treat `branchName` as an opaque string:
-store it, never parse the prefix or assume a `<handle>/<identifier>-<slug>`
-shape.
+`linear.normalizeIssue` copies it into `domain.Issue.BranchName` unparsed, and
+no code may assume a `<handle>/<identifier>-<slug>` shape.
 
 ### Comment mapping
 
@@ -882,26 +877,36 @@ shape.
 
 ## Pagination
 
-Linear uses Relay-style cursor connections everywhere:
+Linear uses Relay-style cursor connections everywhere, and `linear.paginate`
+walks them:
 
 - Arguments: `first` (forward page size) + `after` (cursor); `last`/`before`
-  exist for backward paging and are not used.
-- Every connection exposes `pageInfo { hasNextPage endCursor }`. Loop: request
-  with `after: null`, then `after: endCursor`, until `hasNextPage` is false.
+  exist for backward paging and the adapter does not use them.
+- Every connection exposes `pageInfo { hasNextPage endCursor }`. The loop sends
+  `after: null` on the first request, then `after: endCursor`, until
+  `hasNextPage` is false. The cursor travels in the `variables` object, so a
+  caller may seed `variables["after"]` to resume a connection past a page it
+  already holds; `paginate` preserves that seed instead of restarting at the
+  first page, which is what keeps the inline comment page from being re-fetched
+  and duplicated (see operation 2).
 - Default page size is 50 when `first` is omitted (documented and repeated in
   every connection's schema doc). Sortie always passes `first` explicitly:
-  50 for top-level collections ([Section 11.2](architecture/11-issue-tracker-integration-contract.md#112-query-semantics)), smaller for nested connections
-  (complexity, below).
+  `linear.topLevelPageSize` (50) for top-level collections
+  ([Section 11.2](architecture/11-issue-tracker-integration-contract.md#112-query-semantics)),
+  and a literal 25 for the nested `labels` and `inverseRelations` connections
+  inside issue nodes.
 - `first` must be in the range **1 to 250**, both bounds enforced and
   **[live-verified]**: `first: 251` fails with
   `constraints.max: "first must not be greater than 250"` and `first: 0` fails
   with `constraints.min: "first must not be less than 1"`, both as an
   `Argument Validation Error` on HTTP 200. With Sortie's page size of 50, neither
   bound is reachable; keep `first` between 1 and 250.
-- If `hasNextPage` is true but `endCursor` is empty or null, return
-  `ErrTrackerMissingCursor` (`tracker_missing_end_cursor`, [Section 11.4](architecture/11-issue-tracker-integration-contract.md#114-error-handling-contract))
+- When `hasNextPage` is true but `endCursor` is empty or null, the loop returns
+  `domain.ErrTrackerMissingCursor` (`tracker_missing_end_cursor`, [Section 11.4](architecture/11-issue-tracker-integration-contract.md#114-error-handling-contract))
   instead of treating pagination as complete. Silent truncation here is a
   data-loss bug; this mirrors the Jira adapter's guard.
+  `LinearAdapter.collectComments` applies the same guard to the inline comment
+  page before it hands the cursor to `paginate`.
 - Default ordering is by `createdAt`; `orderBy: updatedAt` is the only
   alternative (`PaginationOrderBy` has exactly those two values).
   **[live-verified]** The direction is **descending (newest first)**, so any
@@ -912,8 +917,11 @@ Linear uses Relay-style cursor connections everywhere:
   (`eyJrZXkiOi..."`), while the `comments` connection returned a bare comment
   UUID. Treat `endCursor` as an opaque token and pass it back verbatim; never
   parse or construct it.
-- Cap the pagination loop with the existing `MaxPages`-style bound and surface
-  the same `OnLimitReached` warning the REST paginator emits today.
+- The loop is bounded by `linear.maxPages` (200, so 10,000 items at the
+  top-level page size). On reaching it with more pages available, `paginate`
+  logs a WARN carrying `max_pages` and returns the items accumulated so far.
+  This is the adapter's own bound; `httpkit.PaginatorOptions.OnLimitReached`
+  belongs to the REST paginator, which the GraphQL path does not use.
 
 ---
 
@@ -925,12 +933,13 @@ The official rate-limiting page documents 5,000 requests/hour for an API key,
 5,000 for an OAuth app, and 600 unauthenticated.
 
 **[live-verified] conflict:** the live test workspace returned
-`x-ratelimit-requests-limit: 2500`, **half** the documented figure. A
-follow-up confirmed the request limit is **dynamic**: Linear scales it by the
-number of paid seats in the workspace, so a free or single-seat workspace gets
-less than the documented headline. **Do not hardcode 5,000.** Read
-`x-ratelimit-requests-limit` and `-remaining` from each response and treat them
-as the source of truth.
+`x-ratelimit-requests-limit: 2500`, **half** the documented figure. The request
+limit is **dynamic**: Linear scales it by the number of paid seats in the
+workspace, so a free or single-seat workspace gets less than the documented
+headline. No quota figure may be hardcoded; the response headers are the source
+of truth. `linear.recordRateLimit` reads
+`x-ratelimit-requests-remaining` after every call and treats exhaustion as an
+observable event rather than tracking the quota itself.
 
 ### Complexity budget
 
@@ -974,9 +983,8 @@ Two lessons for the implementation:
   `inverseRelations` is cheap insurance against a pathological issue with
   hundreds of labels or blockers, not a cap-avoidance necessity.
 
-The authoritative cost is always the `X-Complexity` response header. Log it
-(the adapter can expose `sortie_tracker_complexity` later) rather than
-predicting from the formula.
+The authoritative cost is always the `X-Complexity` response header, never the
+documented formula.
 
 At Sortie's expected scale (poll every 60 s, one or two pages per poll, a
 handful of reconcile lookups) neither the hourly budgets nor the single-query
@@ -999,21 +1007,30 @@ All header names below were observed on live responses.
 | `Retry-After`                        | Seconds to wait (the official SDK reads it on rate-limit errors) |
 
 The `*-reset` values are epoch **milliseconds** (e.g. `1781361577787`), not
-seconds; divide by 1000 before comparing to a Go `time.Unix` value.
+seconds. `linear.parseResetSeconds` divides by `linear.rateLimitResetDivisor`
+(1000) before the value is comparable to a Go `time.Unix` value.
 
 ### Detection and backoff
 
 A rate-limited response is documented to arrive as **HTTP 400 with
 `errors[].extensions.code == "RATELIMITED"`**. The official SDK additionally
 treats HTTP 429 as rate-limited and reads `Retry-After`; the two sources
-disagree on the status code, so the adapter accepts **either** status and keys
-on the body code. (The limit could not be exhausted on the live workspace
-without abusing it, so the rate-limit body was not captured first-hand; the
-classifier keys on the body regardless.) Classification: `ErrTrackerAPI`
-(retryable, exponential backoff per the orchestrator's existing semantics).
-Honor `Retry-After` as a minimum delay when present; otherwise back off with
-the standard base 2 s, max 30 s, jitter plus or minus 30%, and log the relevant
-`*-reset` value at WARN.
+disagree on the status code, so `linear.classifyGraphQLErrors` keys on the body,
+accepting either `extensions.code == "RATELIMITED"` or
+`extensions.type == "ratelimited"` on any status, and `linear.classifyHTTPStatus`
+maps a bare 429 with no errors array to the same kind. Classification is
+`domain.ErrTrackerAPI`, which `domain.TrackerErrorKind.RetryClassification`
+reports as retryable with `domain.BackoffExponential`, so the orchestrator owns
+the delay.
+
+The adapter does not sleep on `Retry-After` and does not track the quota. Its
+only rate-limit behavior is observational: `linear.recordRateLimit` logs one
+WARN, "rate limit exhausted", carrying `requests_remaining`, the reset time in
+epoch seconds, and `Retry-After` when present, and only when
+`x-ratelimit-requests-remaining` reaches zero. The one place a delay is applied
+in the adapter is construction: `linear.runPreflight` retries a transient
+preflight failure through `httpkit.RetryWithBackoff` on the shared
+`httpkit.DefaultPreflightBackoff` schedule (1 s, 2 s, 4 s) before failing.
 
 ---
 
@@ -1079,31 +1096,32 @@ than 250" }`.
 
 ### The not-found special case [live-verified]
 
-This is the most important error finding, and it overturns the pre-key
-assumption. There is **no dedicated not-found code or type**. A nonexistent
-issue returns, on **HTTP 200**:
-
-- `message`: `"Entity not found: Issue"`
-- `extensions.type`: `"invalid input"` (the generic input-error bucket)
-- `extensions.code`: `"INPUT_ERROR"`
-- `extensions.userPresentableMessage`: `"Could not find referenced Issue."`
-- `data`: `null`
-
-Because `type` is the generic `"invalid input"`, the only signal that
-distinguishes not-found from any other input error is the **message**.
-Detection: an error whose `message` begins with `Entity not found`
-(case-insensitive) maps to `ErrTrackerNotFound`. The `userPresentableMessage`
+There is **no dedicated not-found code or type**. The envelope above is the
+whole of it: a nonexistent issue arrives on HTTP 200 under the generic
+`type: "invalid input"`, so the only signal that separates not-found from any
+other input error is the **message**. An error whose `message` begins with
+`Entity not found` (case-insensitive) maps to `domain.ErrTrackerNotFound`;
+`linear.notFoundPrefix` holds that prefix and the check is a lowercase,
+trimmed `strings.HasPrefix`. The `userPresentableMessage`
 "Could not find referenced Issue." is a secondary confirmation.
 
 **The non-null-abort gotcha.** `Query.issue` returns `Issue!`. When the
-resolver fails, the executor propagates null to the root and **nulls the entire
-`data` object**, and it abandons sibling root fields in the same operation
-(verified: a 3-alias batch with one bad id returned `data: null` and only the
-bad alias's error). This is why operation 5 must not use an aliased `issue(id:)`
-batch. For a single `FetchIssueByID`, a not-found simply yields `data: null`
+resolver fails, the executor propagates null to the root, **nulls the entire
+`data` object**, and abandons sibling root fields in the same operation.
+**[live-verified]** A batch of `i0: issue("SOR-5")`, `i1: issue("SOR-99999")`,
+`i2: issue("SOR-7")` returned `data: null` with a single error for `i1`, and the
+two valid lookups returned nothing. An aliased `issue(id:)` batch is therefore
+unusable for the state-batch operations 4 and 5, where a deleted or renamed
+issue is the normal case: one miss would wipe the states of every other issue in
+the batch. For a single `FetchIssueByID`, a not-found simply yields `data: null`
 plus the not-found error, which classifies cleanly.
 
 ### Classification algorithm
+
+`linear.classifyGraphQLErrors` classifies a decoded errors array, and
+`linear.classifyHTTPStatus` is the fallback for a non-2xx response with no
+errors array. `linear.classifyResponseBody`, wired in as the `httpkit` error
+classifier, runs the body test first and falls back to the status:
 
 ```
 classify(httpStatus, body):
@@ -1117,47 +1135,53 @@ classify(httpStatus, body):
     if type == "forbidden"
        or type == "feature not accessible":          ErrTrackerAuth
     if type in {"invalid input", "user error",
-                "graphql error"} or userError:       ErrTrackerPayload
+                "graphql error"}:                    ErrTrackerPayload
     if type in {"internal error", "network error",
                 "lock timeout", "bootstrap error"}:  ErrTrackerTransport
+    if userError:                                    ErrTrackerPayload
     otherwise:                                       ErrTrackerAPI
-  if httpStatus is not 200 (no errors array):
+  if the response is non-2xx with no errors array:
     400:                                             ErrTrackerPayload
-    401:                                             ErrTrackerAuth
-    403:                                             ErrTrackerAuth
+    401, 403:                                        ErrTrackerAuth
     429:                                             ErrTrackerAPI (retryable)
     5xx:                                             ErrTrackerTransport
-  if body does not parse as JSON on 200:             ErrTrackerPayload
+    any other:                                       ErrTrackerAPI
+  if the body does not parse as JSON:                ErrTrackerPayload
 ```
 
 The not-found message check runs **first**, before the `type`-based rules,
 precisely because not-found arrives under the generic `type: "invalid input"`
-that would otherwise classify as `ErrTrackerPayload`. Include the first error's
-`userPresentableMessage` (falling back to `message`) in `TrackerError.Message`
-so operators see Linear's own wording.
+that would otherwise classify as `ErrTrackerPayload`.
+`linear.classifiedMessage` puts the first error's `userPresentableMessage`
+(falling back to its `message`) in `domain.TrackerError.Message`, so operators
+see Linear's own wording.
 
-`feature not accessible` is grouped with `ErrTrackerAuth` deliberately. It means
-the workspace plan does not include a requested capability, which is an
-operator-actionable, **non-retryable** condition. The alternative mapping
-(`ErrTrackerAPI`) is retryable and would make the orchestrator retry a plan
-limitation forever, so the non-retryable bucket is the safer fit even though the
-condition is not strictly an auth failure. The domain error enum has no
-dedicated "configuration" kind; if one is added later, this is the case to move.
+`feature not accessible` is grouped with `domain.ErrTrackerAuth` deliberately.
+It means the workspace plan does not include a requested capability, which is an
+operator-actionable, **non-retryable** condition. The alternative mapping,
+`domain.ErrTrackerAPI`, is retryable and would make the orchestrator retry a
+plan limitation forever, so the non-retryable bucket is the safer fit even
+though the condition is not strictly an auth failure.
 
 ### Partial success
 
 GraphQL permits `data` populated alongside non-empty `errors` (officially
-documented: "queries can partially succeed with a 200"). Policy:
+documented: "queries can partially succeed with a 200"). The adapter does not
+consume partial data: every decode path runs `classifyGraphQLErrors` on the
+errors array before it looks at `data`, so a non-empty array fails the call on
+reads and writes alike.
 
-- **Mutations:** any non-empty `errors` array is a failure, regardless of
-  `data` or `success`.
+- **Mutations:** a non-empty `errors` array is a failure regardless of `data` or
+  `success`, enforced once in `linear.runMutation`.
 - **State batches (operations 4 and 5):** these use connection filters
-  (`id: { in }`, `number: { in }`), so a missing issue is simply an absent node,
-  never an error. Do not rely on per-alias error handling; the non-null-abort
-  behavior above makes aliased batches unusable for this.
-- **Other reads:** if the requested root field is non-null and usable, log the
-  errors at DEBUG and return the data; if the root field is null, classify the
-  first error.
+  (`id: { in }`, `number: { in }`), so a missing issue is an absent node rather
+  than an error, and no per-alias error handling is involved. The non-null-abort
+  behavior above is what makes aliased batches unusable here.
+- **Other reads:** a non-empty `errors` array is classified and returned as the
+  call's error even when the root field is populated. A null root field on a
+  clean errors array is the separate not-found case each read maps explicitly
+  (`FetchIssueByID`, `decodeCommentsPage`, `TransitionIssue`,
+  `resolveTeamID`).
 
 ---
 
@@ -1178,47 +1202,59 @@ implementation that reads one page (default 50) and writes back
 `existing + new` **silently deletes every label beyond the first page**. This
 is the read-before-write pagination hazard this adapter must not have:
 
-- `AddLabel` uses `addedLabelIds` exclusively. No read of the current set, no
-  pagination, no race window between read and write. **[live-verified]** Adding
-  `needs-human` via `addedLabelIds` to an issue that already had `Feature` left
-  the issue with both labels, so the append semantics hold and the read is
-  genuinely unnecessary.
-- If any future write path genuinely needs `labelIds` (full replacement), it
-  MUST paginate `issue.labels` to exhaustion first, and apply the
-  missing-cursor guard, before composing the write.
+- `LinearAdapter.AddLabel` uses `addedLabelIds` exclusively (query
+  `linear.queryIssueAddLabel`). No read of the current set, no pagination, no
+  race window between read and write; operation 9 carries the live evidence that
+  the append preserves existing labels.
+- A write through `labelIds` (full replacement) MUST paginate `issue.labels` to
+  exhaustion first, and apply the missing-cursor guard, before composing the
+  write. No adapter path uses `labelIds`.
 
-The same audit applies to any other collection-valued update field added
-later; check for an `added*`/`removed*` pair in the schema before reaching
-for the replace-style field. (Subscriber lists, for example, follow the same
-pattern in `IssueUpdateInput`.)
+Every collection-valued field in `IssueUpdateInput` needs the same audit: check
+for an `added*`/`removed*` pair in the schema before reaching for the
+replace-style field. Subscriber lists follow the same pattern.
 
 ---
 
 ## Config notes
 
 - **`tracker.api_key`:** single `lin_api_...` string, sent verbatim in
-  `Authorization` (no Bearer, no `email:token` composition).
-- **`tracker.endpoint`:** defaults to `https://api.linear.app/graphql`; there
-  is no self-hosted Linear, so overriding only serves tests and mocks.
-- **`tracker.project`:** the team key (`ENG`). Validated at startup by the
-  team-states preflight; an unknown key is a configuration error
-  (`ErrTrackerPayload` at construction).
+  `Authorization` (no Bearer, no `email:token` composition). Required:
+  `NewLinearAdapter` returns `domain.ErrMissingTrackerAPIKey` when it is empty.
+  The offline `sortie validate` hook `linear.validateAPIKeyHint` warns on a
+  missing key, on surrounding whitespace, and on a key without the `lin_api_`
+  prefix, and never puts the key value in a diagnostic.
+- **`tracker.endpoint`:** defaults to `linear.defaultEndpoint`
+  (`https://api.linear.app/graphql`); there is no self-hosted Linear, so
+  overriding only serves tests and mocks.
+- **`tracker.project`:** the team key (`ENG`). Required:
+  `NewLinearAdapter` returns `domain.ErrMissingTrackerProject` when it is empty.
+  Validated at construction by the team-states preflight; an unknown key returns
+  `domain.ErrTrackerPayload`. The offline hook `linear.validateProject` flags
+  whitespace as an error and a `/` as a warning, and leaves existence and casing
+  to the preflight.
 - **`tracker.active_states` / `tracker.terminal_states` /
-  `tracker.handoff_state`:** team-scoped state **names**, resolved to
-  canonical casing at startup. Example: active `["Backlog", "Todo"]`,
-  terminal `["Done", "Canceled", "Duplicate"]`, handoff `"In Review"`.
-- **Page size:** 50 top-level, 25 for nested connections inside issue nodes;
-  always explicit `first`.
-- **Network timeout:** 30,000 ms.
+  `tracker.handoff_state`:** team-scoped state **names**, resolved to canonical
+  casing at construction. Example: active `["Backlog", "Todo"]`, terminal
+  `["Done", "Canceled", "Duplicate"]`, handoff `"In Review"`. The two lists fall
+  back to the adapter defaults when omitted (see State model); `handoff_state`
+  has no default.
+- **`tracker.query_filter`:** an optional JSON object merged into the fetch
+  filter by `linear.buildFetchFilter` as extra `IssueFilter` fields, which
+  Linear ANDs with the adapter's own constraints. `linear.parseQueryFilter`
+  rejects a value that is not a JSON object, and rejects the top-level reserved
+  keys `team` and `state` so the operator cannot widen the team or state scope.
+  The fragment travels in the GraphQL variables object, never in the query text.
+- **Page size:** see Pagination.
+- **Network timeout:** see Endpoint and transport.
 - **No API-version header exists**; the GraphQL schema evolves in place.
   Breaking-change exposure is limited by requesting only needed fields.
 - **Write side effects:** Linear emits webhooks on data changes, including
   issue, comment, and label events. The adapter's writes (`TransitionIssue`,
   `CommentIssue`, `AddLabel`) are ordinary data changes, so they can trigger any
-  webhook automations the operator has configured in the workspace. Whether a
-  change made through the API also notifies the key's own user is not documented
-  and was not verified. Sortie polls rather than consuming webhooks, so this is
-  an operator-awareness note, not an adapter dependency.
+  webhook automations the operator has configured in the workspace. Sortie polls
+  rather than consuming webhooks, so this is an operator-awareness note, not an
+  adapter dependency.
 
 ---
 
@@ -1244,56 +1280,55 @@ pattern in `IssueUpdateInput`.)
 
 ---
 
-## Live verification results
-
-The six items the pre-key draft flagged as unverified were all resolved against
-the live API on 2026-06-13 (team `SOR`):
-
-1. **Entity-not-found shape.** HTTP 200, `extensions.type: "invalid input"`,
-   `code: "INPUT_ERROR"`, `message: "Entity not found: Issue"`. No dedicated
-   not-found code; classify by message. Also nulls the whole `data` object. See
-   Error model.
-2. **Maximum `first` = 250.** Confirmed: 251 is rejected with "first must not be
-   greater than 250".
-3. **`orderBy: createdAt` direction = descending (newest first).** Confirmed;
-   the adapter must re-sort comments ascending client-side.
-4. **`X-Complexity` measurements.** Candidate query 95 (not the ~5,900 the
-   documented formula predicts); the top-level `first` is not multiplied. See
-   the measured-complexity table.
-5. **`commentCreate.input.issueId` accepts shorthand identifiers.** Confirmed
-   (`"SOR-5"` worked); UUID still preferred for clarity.
-6. **`issueLabelCreate` permission.** Worked with the full-access test key and
-   created a team-scoped label. The `FORBIDDEN` degradation path for a
-   restricted key was not exercised and remains documentation-sourced.
-
-One additional finding the live run surfaced that the draft did not anticipate:
-the aliased-`issue(id:)` batch for `FetchIssueStatesByIdentifiers` is broken by
-the non-null `Issue!` return type (one miss nulls the whole response). Operation
-5 was rewritten to a `number: { in: [...] }` connection filter.
-
-A later verification pass confirmed several secondary facts now folded into the
-sections above: the `branchName` format is workspace-configurable
-(`Organization.gitBranchFormat` template), so the prefix is opaque; label
-creation is gated by the **Team settings > Access and permissions** label
-toggle, sharpening the `FORBIDDEN` guidance; `first` has an enforced minimum of 1
-(`first: 0` rejected); and the issue URL format is
-`https://linear.app/<urlKey>/issue/<IDENTIFIER>/<slug>` (live `urlKey` =
-`sortie-ai`).
-
-### Integration test setup
+## Integration test setup
 
 The live test workspace is configured and reusable: team key `SOR`, with states
-Backlog/Todo/In Progress/In Review/Done/Canceled/Duplicate and labels
-Feature/Bug/Improvement/needs-human. Issues SOR-5 (Todo, assigned, labeled,
-2 comments, blocks SOR-7, parent of SOR-8), SOR-6 (Done), SOR-7 (Backlog,
-blocked by SOR-5), SOR-8 (Todo sub-issue) exercise every read path; SOR-5 was
-moved to In Review by the transition test.
+Backlog, Todo, In Progress, In Review, Done, Canceled, and Duplicate, and labels
+Feature, Bug, Improvement, and needs-human. Issues SOR-5 (assigned, labeled,
+commented, blocks SOR-7, parent of SOR-8), SOR-6, SOR-7 (blocked by SOR-5), and
+SOR-8 (sub-issue) exercise every read path.
 
-Integration tests gate on `SORTIE_LINEAR_TEST=1` (plus `SORTIE_LINEAR_API_KEY`
-and `SORTIE_LINEAR_TEAM_KEY`) and must skip cleanly when unset, per the
-project's existing convention. Keep them read-only by default; gate the
-transition, comment, and label-write paths behind an additional explicit opt-in
-so a default run never mutates the workspace.
+`internal/tracker/linear/integration_test.go` gates every test, read and write
+alike, on the single variable `SORTIE_LINEAR_TEST=1` and skips cleanly when it
+is unset, matching the sibling adapters. `skipUnlessIntegration` enforces the
+gate; `newIntegrationAdapter` requires `SORTIE_LINEAR_API_KEY` and
+`SORTIE_LINEAR_TEAM_KEY`, and reads the optional `SORTIE_LINEAR_ENDPOINT` and
+`SORTIE_LINEAR_ACTIVE_STATES` overrides. The write tests are shaped to leave the
+workspace where they found it: `TestIntegration_TransitionIssue` re-applies the
+issue's current state, and `TestIntegration_AddLabel` adds the idempotent
+`needs-human` label. `TestIntegration_CommentIssue` is the one test that leaves a
+trace, a timestamped comment on the first candidate issue.
+
+---
+
+## Open questions
+
+Each entry names the probe that would settle it.
+
+- **The `FORBIDDEN` label-create path.** `issueLabelCreate` is documented to
+  fail for a member key when the team restricts label management to owners, and
+  the adapter classifies that as `domain.ErrTrackerAuth`, but the branch is
+  documentation-sourced: the live pass covers only a full-access key. Probe: set
+  **Team settings > Access and permissions** to owners-only, call
+  `issueLabelCreate` with a member key restricted to that team, and record the
+  status, `extensions.type`, and `extensions.code`.
+- **The rate-limit error body.** The 400-versus-429 status and the
+  `RATELIMITED` envelope are documentation- and SDK-sourced; the live workspace
+  cannot be exhausted without abusing it. Probe: on a disposable workspace,
+  drive requests past `x-ratelimit-requests-limit` and capture the status,
+  headers, and full errors array of the first rejected call.
+- **Mention rendering of a URL posted through the API.** A comment body
+  round-trips verbatim, but whether the Linear UI renders a bare issue URL in an
+  API-created comment as an interactive mention is not documented. Probe: post a
+  comment whose body is a bare issue URL through `commentCreate`, then read the
+  same comment's `bodyData` and compare it with a comment where the URL was
+  pasted in the editor.
+- **Self-notification on API writes.** Linear emits webhooks for the adapter's
+  writes, but whether a change made with a personal API key also notifies that
+  key's own user is not documented. Probe: with notifications enabled for the
+  key's user, run `issueUpdate` and `commentCreate` on an issue that user
+  subscribes to, then read the `notifications` connection for entries whose
+  actor is that user.
 
 ---
 
@@ -1314,14 +1349,3 @@ so a default run never mutates the workspace.
 | Relation direction semantics                                                    | **Live API** (created SOR-5 blocks SOR-7, read SOR-7 inverseRelations)             | Schema doc strings on `IssueRelation`                                                    |
 | Max `first`, orderBy direction, complexity, identifier acceptance, label append | **Live API**, team `SOR`, 2026-06-13                                               | Schema constraints and SDK where applicable                                              |
 | Dynamic request rate limit (2,500 live vs 5,000 documented)                     | **Live API** response headers                                                      | Web search: Linear scales request limit by paid seats                                    |
-
-### Context7 verification report
-
-Library resolved: `/websites/linear_app_developers` (347 snippets, High
-reputation). Queries confirmed: the auth header formats (API key verbatim vs
-OAuth Bearer), the `issue(id: "BLA-123")` lookup-by-identifier example, the
-`issueUpdate` "UUID or shorthand ID" statement, and the `RATELIMITED` error
-envelope. Context7 did not cover API key scopes (taken from first-party user
-docs). The items Context7 and the docs left open (not-found shape, maximum page
-size, sort direction, real complexity) are now closed by live verification
-rather than left single-sourced.

--- a/docs/opencode-adapter-notes.md
+++ b/docs/opencode-adapter-notes.md
@@ -1,24 +1,16 @@
 # OpenCode CLI: adapter research notes
 
-> OpenCode CLI v1.14.25 (`opencode`, npm `opencode-ai`), researched April 2026.
-> Re-validated against v1.14.50 on 2026-05-14, and against v1.15.12 on 2026-05-29;
-> version-specific drift is called out inline.
-> Reference for implementing the OpenCode `AgentAdapter`.
+> **CLI:** OpenCode, binary `opencode`, npm package `opencode-ai`.
+> **Pinned version:** v1.15.12 on Linux.
+> **Serves:** the OpenCode `AgentAdapter` in `internal/agent/opencode`.
+> **Instruments:** the installed binary; `npx -y opencode-ai@latest` for the v1.14.x anchors
+> below; the upstream repository at the `v1.14.25` tag; the rendered docs at `opencode.ai`.
+> **Coverage:**
 >
-> Local validation: probes of `npx -y opencode-ai@latest` v1.14.25 on Linux on 2026-04-26,
-> v1.14.50 on 2026-05-14, and the locally installed v1.15.12 on 2026-05-29. All sources are
-> linked under "Sources" at the end.
->
-> All source-code and raw-docs links point at the `v1.14.25` tag, the exact version most
-> claims were originally validated against. Tags are immutable, so quoted code and line
-> numbers stay correct. Where later behavior diverges from v1.14.25 (failure exit code,
-> stderr content, duplicated `error` events), the relevant section names the version and the
-> observed difference. Between v1.14.50 and v1.15.12 the upstream changelog records only
-> additive `run` changes (`--replay` and `--replay-limit` for interactive resume in v1.15.5,
-> a project-local `--agent` resolution fix in v1.15.2); no flag the adapter builds was renamed
-> or removed across that window. The rendered public docs at `opencode.ai/docs/...` track the
-> latest published documentation and may move ahead of the tagged source; where rendered docs
-> and observed binary behavior disagree, this note calls the drift out explicitly.
+> - v1.15.12, 2026-05-29: the `run` flag surface, session storage layout, and dir-scoped resume.
+> - v1.14.50, 2026-05-14: the logical-failure exit code, stderr content, and duplicated `error` events. Not re-observed on v1.15.12.
+> - v1.14.25, 2026-04-26: every other locally observed claim, including the credential commands, `serve` port binding, `session list` ordering, `export` payloads, permission warnings on stdout, and parallel-session isolation. Not re-observed since.
+> - Source-code and raw-docs links point at the immutable `v1.14.25` tag, so quoted code and line numbers stay valid. The rendered docs track the latest release and can lead the tagged source; "Documented conflicts and drift" records where the two disagree.
 
 ## Overview
 
@@ -28,12 +20,11 @@ OpenCode exposes three relevant automation surfaces:
 | ------- | --------- | ------------ | ----------------- |
 | `opencode run` | stdout/stderr plus an internal or attached HTTP server | Non-interactive one-shot execution | Closest match to Claude/Copilot launch-per-turn adapters |
 | `opencode serve` | HTTP + SSE | Headless server exposing sessions, messages, permissions, files, tools, and `/doc` OpenAPI | Cleaner programmatic surface than scraping CLI JSON |
-| `opencode acp` | stdin/stdout nd-JSON | ACP server | Exists, but this note does not reverse-engineer the ACP payloads |
+| `opencode acp` | stdin/stdout nd-JSON | ACP server | Unused; the payloads are an open question |
 
-Source inspection shows that `opencode run` is a thin client over the same server APIs exposed
-by `opencode serve`. Without `--attach`, `run` bootstraps an in-process server and points the
-SDK at `Server.Default().app.fetch(...)`. With `--attach`, it points the SDK at an existing
-server URL.
+`opencode run` is a thin client over the same server APIs `opencode serve` exposes. Without
+`--attach`, `run` bootstraps an in-process server and points the SDK at
+`Server.Default().app.fetch(...)`. With `--attach`, it points the SDK at an existing server URL.
 
 That architectural detail matters. `opencode run --format json` is not the canonical OpenCode
 event bus. It is a CLI-specific projection emitted by `run.ts`. The canonical bus is the
@@ -57,7 +48,7 @@ Adapter-relevant prerequisites:
 | OpenCode binary | `opencode` on `PATH` | README, CLI docs |
 | Provider credentials | Auth file, environment variables, `.env`, or provider config | Providers docs, CLI docs, SDK types |
 | Working directory | Any project directory; `run --dir` overrides cwd, `--attach` treats it as remote-server path | CLI docs, `run.ts` source |
-| Headless use | `opencode run` works without a TTY | Observed locally in v1.14.25 |
+| Headless use | `opencode run` works without a TTY | Binary probe |
 
 ## Authentication and provider configuration
 
@@ -68,14 +59,14 @@ configured providers through Models.dev. Credentials can come from several place
 
 | Source | Mechanism | Notes |
 | ------ | --------- | ----- |
-| Interactive credential store | `opencode providers login` or `opencode auth login`, stored in `~/.local/share/opencode/auth.json` | The docs still present `auth`; shipped root help promotes `providers`, while `auth` remains an alias and alias-specific help still prints `auth`-prefixed subcommands. Observed locally in v1.14.25. |
+| Interactive credential store | `opencode providers login` or `opencode auth login`, stored in `~/.local/share/opencode/auth.json` | `auth` is an alias of `providers`; see "Documented conflicts and drift". |
 | Environment variables | Provider-specific env vars such as `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `AWS_*`, `GITLAB_TOKEN`, `CLOUDFLARE_*`, `GOOGLE_CLOUD_PROJECT`, `VERTEX_LOCATION`, and many others | Loaded at startup alongside credentials and project `.env` files (CLI docs, providers docs). |
 | `opencode.json` provider config | `provider.<id>.options.apiKey`, `baseURL`, headers, model overrides, routing options | Useful for proxy gateways, local models, or custom OpenAI-compatible providers (providers docs, SDK types). |
 | Server API | `PUT /auth/{id}` | Programmatic credential injection when integrating through `serve` instead of the CLI wrapper (server and SDK docs). |
 
 ### Adapter-relevant observations
 
-- Browser and device-code flows exist for some providers, including GitHub Copilot, OpenAI, and GitLab Duo. They are not suitable for unattended orchestration. Prefer environment variables, config injection, or pre-populated auth storage (providers docs, CLI docs).
+- Browser and device-code flows exist for some providers, including GitHub Copilot, OpenAI, and GitLab Duo. They block on human interaction, so an unattended run depends on environment variables, config injection, or pre-populated auth storage instead (providers docs, CLI docs). The adapter injects no credential: `buildRunEnv` passes the parent environment through unchanged apart from the five variables it manages.
 - Provider fallback is not a universal CLI flag. It is provider-specific configuration. For example, OpenRouter and Vercel AI Gateway support routing and fallback policies inside `opencode.json` model options (providers docs).
 - The server and SDK surfaces expose providers and default models directly through `/provider`, `/provider/auth`, and `/config/providers`, which is cleaner than parsing CLI text (server and SDK docs).
 
@@ -83,23 +74,30 @@ configured providers through Models.dev. Credentials can come from several place
 
 The full env var surface is documented in the raw `cli.mdx` and exposed via `flag.ts` (both
 linked under Sources). The subset below is the one relevant to a deterministic, unattended
-adapter; bold rows are security- or determinism-critical and should be set explicitly by the
-adapter rather than left to inherited shell state.
+adapter.
 
-| Variable | Type | Purpose | Adapter notes |
-| -------- | ---- | ------- | ------------- |
-| `OPENCODE_CONFIG` / `OPENCODE_CONFIG_DIR` / `OPENCODE_CONFIG_CONTENT` | string | Point OpenCode at a config file, directory, or inline JSON config | Useful when Sortie wants to inject provider or permission config without mutating the repo. |
-| **`OPENCODE_PERMISSION`** | string | Inline JSON permission config; `JSON.parse`d and **deep-merged** into the resolved `opencode.json` `permission` field at startup, not replacing it | See "OPENCODE_PERMISSION env var format" below. The adapter must remove any inherited value before setting its own, otherwise an operator-side `OPENCODE_PERMISSION` contaminates the merged result. |
-| **`OPENCODE_AUTO_SHARE`** | boolean | When truthy, sessions are automatically shared on completion | Adapter should set explicitly to `false` to prevent operator shells leaking session URLs into Sortie runs. |
-| **`OPENCODE_DISABLE_AUTOUPDATE`** | boolean | Disable self-update | Set `true` for CI, container, and pinned-version environments. |
-| **`OPENCODE_DISABLE_AUTOCOMPACT`** | boolean | Disable automatic context compaction between steps | Set `true` when token accounting via `opencode export` must reflect what the adapter actually saw on stdout. Otherwise compaction rewrites prior turns and changes export totals. |
-| **`OPENCODE_DISABLE_LSP_DOWNLOAD`** | boolean | Disable automatic LSP server downloads | Set `true` for air-gapped and CI environments where outbound network access is restricted. |
-| `OPENCODE_DISABLE_MODELS_FETCH` | boolean | Disable fetching the Models.dev catalogue | Useful for fully offline runs. |
-| `OPENCODE_DISABLE_PRUNE` | boolean | Disable storage pruning of old data | Relevant only if the adapter relies on long-term local session history. |
-| `OPENCODE_DISABLE_DEFAULT_PLUGINS` | boolean | Disable default plugins | Reduces implicit behavior in headless runs. |
-| `OPENCODE_DISABLE_CLAUDE_CODE`, `OPENCODE_DISABLE_CLAUDE_CODE_PROMPT`, `OPENCODE_DISABLE_CLAUDE_CODE_SKILLS` | boolean | Disable reading `.claude` prompt and skills content | Setting `OPENCODE_DISABLE_CLAUDE_CODE=true` implies the other two via `flag.ts` derivation; setting `OPENCODE_DISABLE_CLAUDE_CODE_SKILLS=true` also implies `OPENCODE_DISABLE_EXTERNAL_SKILLS=true`. |
-| `OPENCODE_ENABLE_QUESTION_TOOL` | boolean | Enable the `question` tool (which surfaces an interactive question to the user) | Should remain off for unattended use; complements the `question` permission. |
-| `OPENCODE_SERVER_PASSWORD` / `OPENCODE_SERVER_USERNAME` | string | Basic auth for `serve` and `web`; also used by `run --attach` when `--password` is omitted | Server docs, CLI docs, `run.ts` source |
+`buildManagedEnv` (`internal/agent/opencode/command.go`) owns five of these variables. It sets
+`OPENCODE_AUTO_SHARE=false`, `OPENCODE_DISABLE_AUTOUPDATE=true`, `OPENCODE_DISABLE_LSP_DOWNLOAD=true`,
+`OPENCODE_DISABLE_AUTOCOMPACT` from the `disable_autocompact` passthrough key (default `true`), and
+`OPENCODE_PERMISSION` when the workflow configures `allowed_tools` or `denied_tools`.
+`shouldDropManagedEnv` strips all five from the inherited environment before the managed values are
+appended, so an operator-side value never survives into the subprocess. The adapter sets none of the
+other variables in this table.
+
+| Variable | Type | Purpose | Adapter use |
+| -------- | ---- | ------- | ----------- |
+| `OPENCODE_CONFIG` / `OPENCODE_CONFIG_DIR` / `OPENCODE_CONFIG_CONTENT` | string | Point OpenCode at a config file, directory, or inline JSON config | Not set. Injects provider or permission config without mutating the repo. |
+| `OPENCODE_PERMISSION` | string | Inline JSON permission config; `JSON.parse`d and deep-merged into the resolved `opencode.json` `permission` field at startup, not replacing it | Set from the tool policy. See "OPENCODE_PERMISSION env var format" below. |
+| `OPENCODE_AUTO_SHARE` | boolean | When truthy, sessions are automatically shared on completion | Set to `false`, so an operator shell cannot leak session URLs into Sortie runs. |
+| `OPENCODE_DISABLE_AUTOUPDATE` | boolean | Disable self-update | Set to `true`, which pins the version in CI and container environments. |
+| `OPENCODE_DISABLE_AUTOCOMPACT` | boolean | Disable automatic context compaction between steps | Set from `disable_autocompact`, default `true`. Compaction rewrites prior turns and changes the totals `opencode export` reports. |
+| `OPENCODE_DISABLE_LSP_DOWNLOAD` | boolean | Disable automatic LSP server downloads | Set to `true`, which keeps air-gapped and network-restricted runs working. |
+| `OPENCODE_DISABLE_MODELS_FETCH` | boolean | Disable fetching the Models.dev catalogue | Not set. Enables fully offline runs. |
+| `OPENCODE_DISABLE_PRUNE` | boolean | Disable storage pruning of old data | Not set. Relevant only to long-term local session history. |
+| `OPENCODE_DISABLE_DEFAULT_PLUGINS` | boolean | Disable default plugins | Not set. See "Plugin and prompt contamination". |
+| `OPENCODE_DISABLE_CLAUDE_CODE`, `OPENCODE_DISABLE_CLAUDE_CODE_PROMPT`, `OPENCODE_DISABLE_CLAUDE_CODE_SKILLS` | boolean | Disable reading `.claude` prompt and skills content | Not set. `OPENCODE_DISABLE_CLAUDE_CODE=true` implies the other two via `flag.ts` derivation, and `OPENCODE_DISABLE_CLAUDE_CODE_SKILLS=true` also implies `OPENCODE_DISABLE_EXTERNAL_SKILLS=true`. |
+| `OPENCODE_ENABLE_QUESTION_TOOL` | boolean | Enable the `question` tool, which surfaces an interactive question to the user | Not set, so the tool stays off. Complements the `question` permission. |
+| `OPENCODE_SERVER_PASSWORD` / `OPENCODE_SERVER_USERNAME` | string | Basic auth for `serve` and `web`; also used by `run --attach` when `--password` is omitted | Not set. The adapter does not use `--attach`. |
 
 ## Relevant CLI commands and flags
 
@@ -107,42 +105,40 @@ adapter rather than left to inherited shell state.
 
 `opencode run [message..]` is the non-interactive CLI entry point.
 
-The flag set below was confirmed present in `opencode run --help` on v1.15.12. The adapter
-(`internal/agent/opencode/command.go`, `buildRunArgs`) emits a fixed subset:
-`run --format json --dir <ws>`, then conditionally `--session`, `--model`, `--agent`,
-`--variant`, `--thinking`, `--pure`, `--dangerously-skip-permissions`, then `--` and the
-prompt.
+The flag set below is the one `opencode run --help` prints. `buildRunArgs`
+(`internal/agent/opencode/command.go`) emits a fixed subset: `run --format json --dir <ws>`,
+then conditionally `--session`, `--model`, `--agent`, `--variant`, `--thinking`, `--pure`,
+`--dangerously-skip-permissions`, then `--` and the prompt.
 
 | Flag | Short | Meaning | Adapter use |
 | ---- | ----- | ------- | ----------- |
-| `--command` |  | Run a slash command instead of a freeform prompt | Optional. Confirmed present in v1.15.12 `run --help`; the adapter does not use it. |
-| `--continue` | `-c` | Resume the last root session | Useful, but see resume caveat below |
-| `--session` | `-s` | Resume a specific session ID | Preferred for deterministic continuation. The adapter sets this from the persisted `sessionID`. See the dir-scoped resume caveat below. |
-| `--fork` |  | Fork the resumed session first | Optional branch semantics |
-| `--share` |  | Share session on completion | Usually disable for automation. Confirmed present in v1.15.12 `run --help`. The adapter does not pass this flag; it sets `OPENCODE_AUTO_SHARE=false` instead. |
-| `--model` | `-m` | Model in `provider/model` form | Primary model selector |
-| `--agent` |  | Primary agent name | Validated against available agents; subagents fall back to default with a warning (`run.ts` source). v1.15.2 fixed resolution of project-local agents. |
-| `--file` | `-f` | Attach files or directories to the prompt | Optional |
-| `--format` |  | `default` or `json` | `json` is required if scraping stdout |
-| `--title` |  | Explicit session title | Useful when automation wants deterministic session names instead of truncated prompts |
-| `--attach` |  | Target an existing `serve` instance | Avoids server cold start per turn |
-| `--password` | `-p` | Basic-auth password for `--attach` | Falls back to `OPENCODE_SERVER_PASSWORD` (`run.ts` source). |
-| `--username` | `-u` | Basic-auth username for `--attach` | Falls back to `OPENCODE_SERVER_USERNAME`, then `opencode` (CLI docs). |
-| `--dir` |  | Local cwd override, or remote path when attached | Required by the adapter; also scopes session resume (see caveat below). |
-| `--port` |  | Local server port when not attached | Effective port `0` means try `4096` first, then fall back to an ephemeral port if `4096` is busy; shipped `run --help` phrases this as "defaults to random port" |
-| `--variant` |  | Provider-specific reasoning variant such as `high`, `max`, or `minimal` | Secondary model control |
-| `--thinking` |  | Emit reasoning blocks | Only affects CLI output |
-| `--dangerously-skip-permissions` |  | Auto-approve permissions that are not explicitly denied | Required for clean unattended runs in many tooling scenarios |
-| `--pure` |  | Run without external plugins | Present in shipped v1.14.25 and v1.15.12 help output, but omitted from the CLI docs page. |
-| `--print-logs` |  | Print logs to stderr during the run | Diagnostic only; confirmed in v1.15.12 `run --help` ("print logs to stderr"). Not used by the adapter. |
-| `--log-level` |  | Set log verbosity | Diagnostic only; confirmed in v1.15.12 `run --help` (choices DEBUG, INFO, WARN, ERROR). Not used by the adapter. |
-| `--replay` / `--replay-limit` |  | Replay recent history when resuming an interactive run | Added in v1.15.5. Targets interactive resume, not `--format json` automation; not used by the adapter. |
+| `--command` |  | Run a slash command instead of a freeform prompt | Not used. |
+| `--continue` | `-c` | Resume the last root session | Not used. The adapter resumes by explicit session ID. |
+| `--session` | `-s` | Resume a specific session ID | Set from the persisted `sessionID`, which makes continuation deterministic. Resume is dir-scoped; see "Fresh session vs continuation". |
+| `--fork` |  | Fork the resumed session first | Not used. Creates a child session before continuing. |
+| `--share` |  | Share session on completion | Not used. The adapter sets `OPENCODE_AUTO_SHARE=false` instead. |
+| `--model` | `-m` | Model in `provider/model` form | Set from the `model` passthrough key. |
+| `--agent` |  | Primary agent name | Set from the `agent` passthrough key. `run.ts` validates the name against the available agents; a subagent name falls back to the default agent with a warning. |
+| `--file` | `-f` | Attach files or directories to the prompt | Not used. |
+| `--format` |  | `default` or `json` | Always `json`, which is what makes stdout parseable. |
+| `--title` |  | Explicit session title | Not used. Without it the session title is the truncated prompt. |
+| `--attach` |  | Target an existing `serve` instance | Not used. Would avoid a server cold start per turn. |
+| `--password` | `-p` | Basic-auth password for `--attach` | Not used. Falls back to `OPENCODE_SERVER_PASSWORD` (`run.ts` source). |
+| `--username` | `-u` | Basic-auth username for `--attach` | Not used. Falls back to `OPENCODE_SERVER_USERNAME`, then `opencode` (CLI docs). |
+| `--dir` |  | Local cwd override, or remote path when attached | Always set to the issue workspace. Also scopes session resume. |
+| `--port` |  | Local server port when not attached | Not used. For the `0` sentinel semantics see "`opencode serve`". |
+| `--variant` |  | Provider-specific reasoning variant such as `high`, `max`, or `minimal` | Set from the `variant` passthrough key. |
+| `--thinking` |  | Emit reasoning blocks | Set from the `thinking` passthrough key. Affects CLI output only. |
+| `--dangerously-skip-permissions` |  | Auto-approve permissions that are not explicitly denied | Set from `dangerously_skip_permissions`, default `true`, which keeps unattended runs from stalling on tool prompts. |
+| `--pure` |  | Run without external plugins | Set from the `pure` passthrough key, default `false`. Present in shipped help output but omitted from the CLI docs page. |
+| `--print-logs` |  | Print logs to stderr during the run | Not used. Diagnostic only. |
+| `--log-level` |  | Set log verbosity, one of DEBUG, INFO, WARN, ERROR | Not used. Diagnostic only. |
+| `--replay` / `--replay-limit` |  | Replay recent history when resuming an interactive run | Not used. Targets interactive resume, not `--format json` automation. |
 
 Separately, the top-level `opencode [project]` command documents a `--prompt` flag in the CLI
-docs and shipped root help. That is a TUI/root flag rather than the documented `run` surface.
-In local v1.14.25 probing, `opencode run --prompt ...` printed `run` help and exited with code
-`1`, so adapters should treat positional `message..` as the stable non-interactive prompt
-input. Observed locally in v1.14.25.
+docs and in root help. That is a TUI and root flag rather than part of the `run` surface:
+`opencode run --prompt ...` prints `run` help and exits `1`. Positional `message..` is the
+non-interactive prompt input, and `buildRunArgs` passes the prompt that way.
 
 Example invocation for a headless turn:
 
@@ -164,31 +160,31 @@ argument.
 
 | Flag | Meaning | Notes |
 | ---- | ------- | ----- |
-| `--port` | Listen port | Runtime semantics: an effective port of `0` means try `4096` first, then fall back to an ephemeral port if `4096` is busy |
+| `--port` | Listen port | An effective port of `0` means try `4096` first, then fall back to an ephemeral port if `4096` is busy. Both `run --port` and `serve --port` share these semantics. |
 | `--hostname` | Listen address | Docs default to `127.0.0.1`. |
-| `--mdns` / `--mdns-domain` | mDNS discovery | Usually irrelevant for Sortie |
-| `--cors` | Additional CORS origins | Only matters for browser clients |
+| `--mdns` / `--mdns-domain` | mDNS discovery | Not relevant to a launch-per-turn adapter. |
+| `--cors` | Additional CORS origins | Only matters for browser clients. |
 
 Shared network options define `port` with a default of `0`, but both the Node and Bun server
 adapters interpret `0` as a sentinel: they attempt to bind `4096` first, then fall back to an
 ephemeral port only if `4096` is unavailable (server docs, `network.ts`, and the Node and Bun
-server adapter sources). A local v1.14.25 `opencode serve` probe bound to
-`http://127.0.0.1:4096` with no flags. Observed locally in v1.14.25.
+server adapter sources). `opencode serve` with no flags binds `http://127.0.0.1:4096`.
 
 ### Session and provider helper commands
 
 | Command | Use |
 | ------- | --- |
-| `opencode session list --format json -n N` | Enumerate recent sessions. The observed output is newest-first. Observed locally in v1.14.25. |
-| `opencode export [sessionID] [--sanitize]` | Export session data as JSON. Without arguments, exports the most recent session in the current directory; with `sessionID`, exports that exact session. The `--sanitize` flag redacts sensitive transcript and file data, suitable when the adapter uses `export` to recover authoritative token usage without leaking tool-output bodies into logs. Observed locally in v1.14.25. |
-| `opencode providers list` | Enumerate configured provider credentials. This is the primary command name in shipped root help and in `providers --help`. Observed locally in v1.14.25. |
-| `opencode auth list` | Alias for `providers list`. The docs still use `auth`, and `auth --help` keeps `auth`-prefixed subcommands under an `opencode providers` header. Observed locally in v1.14.25. |
+| `opencode session list --format json -n N` | Enumerate recent sessions. Output is newest-first. |
+| `opencode export [sessionID] [--sanitize]` | Export session data as JSON. Without arguments it exports the most recent session in the current directory; with `sessionID` it exports that exact session. `--sanitize` redacts sensitive transcript and file data. `queryExportUsage` (`internal/agent/opencode/parse.go`) runs `export --sanitize <sessionID>` after the turn subprocess exits, so token usage is recovered without leaking tool-output bodies into logs. |
+| `opencode models` | List the model catalog, one `provider/model` slug per entry. `queryModelNotFound` (`internal/agent/opencode/parse.go`) runs it to restore an unknown-model diagnostic; see "Example: logical failure". |
+| `opencode providers list` | Enumerate configured provider credentials. This is the primary command name in root help and in `providers --help`. |
+| `opencode auth list` | Alias for `providers list`. `auth --help` keeps `auth`-prefixed subcommands under an `opencode providers` header. |
 
 ## Subprocess behavior
 
 ### `run` is not a standalone agent protocol
 
-Source inspection of `run.ts` shows this control flow inside `opencode run`:
+`opencode run` follows this control flow (`run.ts` source):
 
 1. Parse CLI flags and optional attached files.
 2. Create or resume a session through the SDK.
@@ -205,43 +201,43 @@ server in-process and routes SDK calls through an internal fetch function backed
 
 | Mode | Mechanism | Notes |
 | ---- | --------- | ----- |
-| Fresh | `sdk.session.create({ title, permission: rules })` | Session ID is server-generated and looks like `ses_...`. Observed locally in v1.14.25. |
-| `--session <id>` | Resume exact session ID | Deterministic resume path, but dir-scoped. See the resume caveat below. |
-| `--continue` | `sdk.session.list()` then first root session | In practice, `session list --format json` returns newest-first, so `--continue` resumes the most recent root session today. That ordering is observed locally, not promised by the docs. |
-| `--fork` with resume | `sdk.session.fork({ sessionID })` | Creates a child session before continuing |
+| Fresh | `sdk.session.create({ title, permission: rules })` | Session ID is server-generated and looks like `ses_...`. |
+| `--session <id>` | Resume exact session ID | Deterministic resume path, but dir-scoped. |
+| `--continue` | `sdk.session.list()` then first root session | `session list --format json` returns newest-first, so `--continue` resumes the most recent root session. The docs do not promise that ordering. |
+| `--fork` with resume | `sdk.session.fork({ sessionID })` | Creates a child session before continuing. |
 
-**Resume is dir-scoped.** `opencode run --session <id>` only replays a session when the run
+Resume is dir-scoped. `opencode run --session <id>` replays a session only when the run
 executes with the same `--dir` (project directory) the session was created in. Resuming the
-same session ID under a different `--dir` exits `0` with no JSON events on stdout. Confirmed by
-experiment on v1.15.12: same-dir resume emits events; different-dir resume emits nothing. This
-is consistent with sessions being stored in a single global database (see "Session storage"
-below) and keyed to their originating project directory. The adapter relies on this: it reuses
-an issue's workspace across turns and passes that path as `--dir` on every turn
-(`internal/agent/opencode/opencode.go`, `command.go`), so resume turns share turn one's
-directory. An adapter that resumed a session under a different workspace would observe a silent
-empty turn, not an error.
+same session ID under a different `--dir` exits `0` with no JSON events on stdout: same-dir
+resume emits events, different-dir resume emits nothing. This is consistent with sessions being
+stored in a single global database (see "Session storage") and keyed to their originating
+project directory. The adapter satisfies the constraint by construction: `buildRunArgs` passes
+`state.target.WorkspacePath` as `--dir` on every turn, and that path is the issue workspace
+resolved once per session by `agentcore.ResolveLaunchTarget`. Resuming a session under a
+different workspace produces a silent empty turn rather than an error, which the adapter would
+report as `turn_failed` through the zero-work row rather than as a resume fault.
 
-Source inspection of `run.ts` also shows that `run` injects three deny rules when it creates a
-new session: `question=*`, `plan_enter=*`, and `plan_exit=*`. That is source-derived behavior.
-Resumed sessions reuse the existing session state instead of re-creating these rules.
+When `run` creates a new session it injects three deny rules: `question=*`, `plan_enter=*`, and
+`plan_exit=*` (`run.ts` source). Resumed sessions reuse the existing session state instead of
+re-creating these rules.
 
 ### Working directory handling
 
 - When not attached, `--dir` calls `process.chdir(args.dir)` before bootstrapping the local server. Invalid paths terminate immediately with exit code `1` (`run.ts` source).
 - When attached, `--dir` is passed to the SDK as the remote directory selector instead of changing the local process cwd (`run.ts` source).
 - The server and SDK surfaces also accept `directory` query parameters on many APIs, which makes `serve` a better fit when a single OpenCode backend serves multiple workspaces (server and SDK docs).
+- The adapter sets both: `RunTurn` assigns `cmd.Dir` to the workspace path and `buildRunArgs` passes the same path as `--dir`, so the subprocess cwd and the session's project directory cannot diverge.
 
 ### Session storage
 
 Sessions are persisted in a single global SQLite database at
 `~/.local/share/opencode/opencode.db`, not in a per-project store under the workspace. The same
-directory holds the credential store (`auth.json`) and other shared state. Confirmed locally on
-v1.15.12.
+directory holds the credential store (`auth.json`) and other shared state.
 
 Two consequences for the adapter:
 
 - Sessions created in any workspace are visible to the same OS user from any other workspace. Isolation between concurrent issues comes from distinct server-generated session IDs, not from separate storage files.
-- Resume is still dir-scoped at replay time even though storage is global (see the resume caveat above): the session row exists regardless of cwd, but `run --session <id>` only emits events when invoked under the originating `--dir`.
+- Resume stays dir-scoped at replay time even though storage is global: the session row exists regardless of cwd, but `run --session <id>` emits events only when invoked under the originating `--dir`.
 
 ## Permissions and tool access control
 
@@ -250,7 +246,7 @@ OpenCode permission control is config-driven. Each rule resolves to `allow`, `as
 
 ### Permission keys
 
-The `permissions.mdx` page (rendered as the public permissions docs) documents 14 tool and
+The `permissions.mdx` page, rendered as the public permissions docs, documents 14 tool and
 safety keys:
 
 - `read`
@@ -268,13 +264,14 @@ safety keys:
 - `external_directory`
 - `doom_loop`
 
-The runtime schema in `config/permission.ts` (v1.14.25) explicitly declares two more keys not
-surfaced by the docs page (`list` and `todowrite`), and accepts any additional string key
-through a `Schema.StructWithRest` catchall. In practice this means OpenCode validates more
-permission keys than the public documentation lists. Adapters that whitelist keys strictly
-against the 14 documented ones will reject configurations that OpenCode itself accepts;
-adapters that pass keys through verbatim stay compatible with both the documented and the
-undocumented surface as the schema evolves.
+The runtime schema in `config/permission.ts` declares two more keys the docs page does not
+surface, `list` and `todowrite`, and accepts any additional string key through a
+`Schema.StructWithRest` catchall, so OpenCode validates more permission keys than the public
+documentation lists. `knownPermissionKeys` (`internal/agent/opencode/command.go`) carries all 16
+and uses them for one purpose only: when the workflow sets `allowed_tools`, every known key
+outside that set is denied explicitly. Keys the workflow names are forwarded verbatim whether or
+not they are known, with `logUnknownPermissionKey` recording the unknown ones at debug level, so
+a configuration OpenCode accepts is never rejected by the adapter.
 
 ### Defaults
 
@@ -301,7 +298,7 @@ if (Flag.OPENCODE_PERMISSION) {
 Two consequences for adapters:
 
 1. The value is parsed as JSON and must conform to the same schema as the `permission` field in `opencode.json`, defined in `config/permission.ts`.
-2. The result is **deep-merged** into the resolved `opencode.json` `permission`, not used as a replacement. An adapter-supplied policy stacks on top of any operator-side `permission` block instead of overriding it.
+2. The result is deep-merged into the resolved `opencode.json` `permission`, not used as a replacement. An adapter-supplied policy stacks on top of any operator-side `permission` block instead of overriding it.
 
 Three accepted forms (all valid for `opencode.json` `permission` and therefore valid for
 `OPENCODE_PERMISSION` as JSON-encoded values):
@@ -321,14 +318,18 @@ Three accepted forms (all valid for `opencode.json` `permission` and therefore v
 
 Action values are `"allow" | "ask" | "deny"` (see `config/permission.ts`). Pattern syntax: `*`
 matches zero or more characters, `?` exactly one, `~` and `$HOME` expand to the user home;
-rules are evaluated by pattern match with the **last matching rule winning** (see
+rules are evaluated by pattern match with the last matching rule winning (see
 `permissions.mdx`).
 
-**Adapter implication for unattended use.** Because the value is merged rather than replaced,
-the adapter must:
-
-- Remove any inherited `OPENCODE_PERMISSION` from the parent environment before launching `opencode run`, otherwise the operator's value pre-pollutes the merge result.
-- Cover every key the adapter cares about explicitly in its own policy. Keys absent from the adapter's JSON fall through to whatever the operator's `~/.config/opencode/opencode.json` declares, or to OpenCode defaults.
+Merge semantics drive two adapter behaviors. `shouldDropManagedEnv` removes any inherited
+`OPENCODE_PERMISSION` before the subprocess launches, so the operator's value cannot
+pre-pollute the merge result. And `buildPermissionPolicy` emits the flat key-to-action form
+covering every key it decides: the keys named in `allowed_tools` map to `allow`, the keys named
+in `denied_tools` map to `deny`, and when `allowed_tools` is non-empty every remaining known key
+maps to `deny`. Keys outside that policy fall through to the operator's
+`~/.config/opencode/opencode.json` or to OpenCode defaults. When the workflow sets neither list,
+the adapter sets no `OPENCODE_PERMISSION` at all and OpenCode's own resolution applies.
+`parsePassthroughConfig` rejects a configuration that names the same key in both lists.
 
 ### Headless behavior of `run`
 
@@ -344,18 +345,20 @@ The full `Reply` schema accepts `once | always | reject`; `run.ts` only emits `o
 the rest of the session) is not reachable through `opencode run` (`permission/index.ts`
 source).
 
-Observed with v1.14.25:
+A rejection prints this pair:
 
 ```text
 ! permission requested: external_directory (/etc/*); auto-rejecting
 {"type":"tool_use", ... "state":{"status":"error","error":"The user rejected permission to use this specific tool call."}}
 ```
 
-That warning is written to stdout before the JSON envelope. This means
-`opencode run --format json` is not actually JSON-clean unless the prompt avoids permission
-prompts or the adapter uses `--dangerously-skip-permissions`. Observed locally in v1.14.25, and
-consistent with the `run.ts` source branch that calls `UI.println(...)` before replying
-`reject`.
+The warning goes to stdout before the JSON envelope, from the `run.ts` branch that calls
+`UI.println(...)` before replying `reject`. So `opencode run --format json` is not JSON-clean
+unless the prompt avoids permission prompts or the run passes
+`--dangerously-skip-permissions`. The adapter parses each stdout line as JSON and, on failure,
+treats the line as plain text: `isPermissionWarning`
+(`internal/agent/opencode/opencode.go`) matches the `! permission requested:` prefix and emits a
+notification, and any other unparseable line becomes a `domain.EventMalformed` event.
 
 ## Output format: `opencode run --format json`
 
@@ -372,18 +375,22 @@ top-level shape:
 }
 ```
 
-### Observed stdout event types
+### Stdout event types
 
 | `type` | Payload | When emitted | Evidence |
 | ------ | ------- | ------------ | -------- |
-| `step_start` | `part: StepStartPart` | Start of a model step | `run.ts` source and observed locally |
-| `tool_use` | `part: ToolPart` | When a tool part reaches `completed` or `error` | `run.ts` source and observed locally |
-| `text` | `part: TextPart` | Completed text part | `run.ts` source and observed locally |
+| `step_start` | `part: StepStartPart` | Start of a model step | `run.ts` source, binary probe |
+| `tool_use` | `part: ToolPart` | When a tool part reaches `completed` or `error` | `run.ts` source, binary probe |
+| `text` | `part: TextPart` | Completed text part | `run.ts` source, binary probe |
 | `reasoning` | `part: ReasoningPart` | Completed reasoning part, only when `--thinking` is set | `run.ts` source |
-| `step_finish` | `part: StepFinishPart` | End of a model step | `run.ts` source and observed locally |
-| `error` | `error: EventSessionError.properties.error` | When the server emits `session.error` for this session | `run.ts` source, SDK types, and observed locally |
+| `step_finish` | `part: StepFinishPart` | End of a model step | `run.ts` source, binary probe |
+| `error` | `error: EventSessionError.properties.error` | When the server emits `session.error` for this session | `run.ts` source, SDK types, binary probe |
 
-What the CLI does **not** emit in JSON mode:
+The parser mirrors this set: `parse.go` declares one `raw*Part` struct per payload, and
+`RunTurn`'s event switch handles exactly these six types, emitting `domain.EventMalformed` for
+any other `type` value.
+
+What the CLI does not emit in JSON mode:
 
 - No `session_started` event
 - No raw `message.updated` or `message.part.updated` server events
@@ -393,8 +400,6 @@ What the CLI does **not** emit in JSON mode:
 
 ### Example: simple one-step turn
 
-Observed locally in v1.14.25:
-
 ```json
 {"type":"step_start","timestamp":1777197446593,"sessionID":"ses_236c713fcffel8QozOz4ca0AYK","part":{"id":"prt_dc938f5be001xlQ2FdVcM0ybM8","messageID":"msg_dc938ecbe001pHUOguAaJY92Pz","sessionID":"ses_236c713fcffel8QozOz4ca0AYK","snapshot":"45865d3017876fc42b80fa16e317d109a7008c30","type":"step-start"}}
 {"type":"text","timestamp":1777197446597,"sessionID":"ses_236c713fcffel8QozOz4ca0AYK","part":{"id":"prt_dc938f5c3001Xf6Jb1dJzX7Po6","messageID":"msg_dc938ecbe001pHUOguAaJY92Pz","sessionID":"ses_236c713fcffel8QozOz4ca0AYK","type":"text","text":"\n\nHello","time":{"start":1777197446595,"end":1777197446596}}}
@@ -403,21 +408,19 @@ Observed locally in v1.14.25:
 
 ### Example: tool call
 
-Observed locally in v1.14.25:
-
 ```json
 {"type":"tool_use","timestamp":1777197461503,"sessionID":"ses_236c6de07ffeMCaCIVqcZsSjBi","part":{"type":"tool","tool":"read","callID":"call_function_1hg9s1exw5vv_1","state":{"status":"completed","input":{"filePath":"/home/ubuntu/work/sortie/README.md"},"output":"<path>/home/ubuntu/work/sortie/README.md</path>\n<type>file</type>\n<content>\n1: <p align=\"center\">\n...","metadata":{"preview":"<p align=\"center\">...","truncated":false,"loaded":[]},"title":"README.md","time":{"start":1777197461489,"end":1777197461502}},"id":"prt_dc9392fd2001HeyUJbUUYfz0Ez","sessionID":"ses_236c6de07ffeMCaCIVqcZsSjBi","messageID":"msg_dc93922a40015YBm8bwcEdTQXV"}}
 ```
 
 Tool payloads can be large. The `read` tool embeds the returned file content directly in
-`state.output`, which means one JSON line can contain the whole file body. Adapters should use
-a generous line buffer when parsing stdout. This is consistent with the CLI's
-`JSON.stringify(...) + EOL` implementation in `run.ts` and observed local output from
-`read README.md`.
+`state.output`, so one JSON line can carry a whole file body: the CLI writes each event as
+`JSON.stringify(...) + EOL` in `run.ts`. The adapter's stdout scanner
+(`startOpenCodeReader`) therefore starts at a 64 KiB buffer and grows to `maxLineBytes`, which
+is 10 MiB.
 
 ### Example: logical failure
 
-Observed locally in v1.14.50 with an invalid model:
+An invalid model produces this (v1.14.50 anchor):
 
 ```text
 {"type":"error","timestamp":1778777973456,"sessionID":"ses_1d8921de2ffeMg3sLcTUjJxwoX","error":{"name":"UnknownError","data":{"message":"Model not found: nonexistent/nonexistent."}}}
@@ -425,23 +428,29 @@ Observed locally in v1.14.50 with an invalid model:
 EXIT:1
 ```
 
-Two `error` events are emitted on stdout for a single failure. The first carries the actionable
+Two `error` events reach stdout for this single failure. The first carries the actionable
 diagnostic from the `session.error` event stream; the second is the generic HTTP 500 envelope
-from the in-process server when the underlying defect was not declared in the API error schema.
-Both arrive wrapped as `{"name":"UnknownError","data":{"message":...}}`. Adapters MUST iterate
-all `error` events rather than relying on a single emission; the first one is the meaningful
-diagnostic.
+the in-process server emits when the underlying defect was not declared in the API error schema.
+Both arrive wrapped as `{"name":"UnknownError","data":{"message":...}}`.
 
-Stderr is empty in v1.14.50, and the process exit code is `1`. In v1.14.25 stderr carried a
-`ProviderModelNotFoundError` stack trace and exit code was `0`; both behaviors changed in the
-v1.14.x series after the server migrated to `effect/unstable/http`. Treat exit code and stderr
-as informative but not load-bearing; the JSON `error` events on stdout remain the authoritative
-failure signal.
+`RunTurn`'s event loop assigns `runtime.terminalError` on every `error` event, so the last one
+wins and the masked message rather than the diagnostic is what would otherwise reach the
+`turn_failed` event. `isMaskedServerError` (`internal/agent/opencode/opencode.go`) recognizes
+that placeholder by exact match on `Unexpected server error. Check server logs for details.`,
+and `finalizeExitedTurn` then calls `queryModelNotFound`, which reports
+`Model not found: <model>` when the configured model is absent from the `opencode models`
+catalog. A masked failure from any other cause keeps the placeholder message.
+
+Stderr is empty for this failure and the process exits `1`. Neither signal is load-bearing:
+`finalizeExitedTurn` derives the terminal failure from the `error` event alone, so a logical
+failure maps to `turn_failed` whatever the exit code, and the adapter collects stderr through
+`procutil.StderrCollector` and logs it at warn level instead of classifying its text.
 
 ## Turn completion, failure detection, and `TurnResult` mapping
 
-Sortie's turn model lives in `internal/domain/agent.go`. `TurnResult` needs `SessionID`, a
-normalized `ExitReason`, and cumulative token usage.
+Sortie's turn model lives in `internal/domain/agent.go`. `domain.TurnResult` carries
+`SessionID`, a normalized `ExitReason`, the session's run-cumulative `Usage`, and
+`UsageMeasured`, which distinguishes an unknown spend from a zero one.
 
 ### Completion detection
 
@@ -458,75 +467,75 @@ Practical implication:
 
 | Signal | Reliability | Notes |
 | ------ | ----------- | ----- |
-| Stdout `{"type":"error", ...}` | Authoritative | Emitted from `session.error`. A single failure can emit multiple `error` events (see logical-failure example) |
+| Stdout `{"type":"error", ...}` | Authoritative | Emitted from `session.error`. A single failure can emit several `error` events; see "Example: logical failure" |
 | `tool_use` with `part.state.status == "error"` | Important, but not always terminal | Permission rejection and tool failures land here |
-| stderr text | Diagnostic only when present | v1.14.50 emits no stderr for `session.error`; older versions wrote stack traces |
-| Process exit code | Informative, not load-bearing | v1.14.50 exits `1` on `session.error`; v1.14.25 exited `0` for the same failure |
+| stderr text | Diagnostic only when present | Empty for a `session.error` failure |
+| Process exit code | Informative, not load-bearing | See "Documented conflicts and drift" |
 
-For a Sortie adapter built on `opencode run`, a sensible normalization rule is:
+The adapter maps that evidence onto domain events as follows. `RunTurn` emits the per-event
+rows; `finalizeExitedTurn` fills an `agentcore.TurnEvidence` and hands the terminal decision to
+`agentcore.DecideTurn`, which is shared by every agent adapter.
 
-| Sortie normalized outcome | OpenCode evidence |
-| ------------------------ | ----------------- |
-| `session_started` | First successfully parsed JSON envelope carrying `sessionID`, or session ID known from a server/API response |
-| `tool_result` | Each `tool_use` event, using `part.tool`, `part.state.status`, and `part.state.time` |
-| `notification` / `other_message` | Default-mode-only prose is not available in JSON mode; optional if adapter also captures stderr |
-| `turn_completed` | Process exits after a normal run, no terminal `error` was observed, and at least one `text`, `reasoning`, or `tool_use` part was parsed during the turn |
-| `turn_failed` | Any terminal `error` event; a process-level CLI/setup failure; or the process exits after a normal run with no `text`, `reasoning`, or `tool_use` part parsed, even when the exit code is `0` |
-| `turn_cancelled` | Prefer the server API surface, which exposes `session.abort` and `session.status`; `run --format json` does not emit a dedicated cancel envelope |
-| `token_usage` | Do not treat `step_finish.part.tokens` as authoritative turn totals without extra logic |
+| Domain event | OpenCode evidence |
+| ------------ | ----------------- |
+| `session_started` | The first envelope carrying a `sessionID`, applied by `applySessionEvent`. A later envelope carrying a different ID is a session id mismatch, which fails the turn |
+| `tool_result` | Each `tool_use` event, using `part.tool` for the name, `part.state.time` for the duration, and `part.state.status == "error"` for the error flag |
+| `notification` | `step_start`, the text of a `text` part truncated to 500 runes, `step_finish` with its reason, and permission-warning lines from stdout |
+| `other_message` | Each `reasoning` part |
+| `malformed` | An unparseable payload for a known `type`, an unrecognized `type`, and any non-JSON stdout line that is not a permission warning |
+| `token_usage` | The `opencode export` figures, never `step_finish.part.tokens`. See "Token usage" |
+| `turn_completed` | The process exits `0`, no `error` event arrived, and at least one `text`, `reasoning`, or `tool_use` part was parsed during the turn |
+| `turn_failed` | Any `error` event (`ErrTurnFailed`); a non-zero exit with no `error` event (`ErrPortExit`); an exit-`0` turn with no assistant part parsed (`ErrTurnFailed`); a stdout read error or session id mismatch (`ErrResponseError`); or a timeout waiting for the first JSON event (`ErrResponseTimeout`) |
+| `turn_cancelled` | Context cancellation or `StopSession`. `run --format json` emits no cancel envelope, so the signal is the adapter's own |
 
-A `text`, `reasoning`, or `tool_use` part observed during the turn is the positive work signal
-that decides `turn_completed` when the process exits `0` with no terminal `error`. Without it, an
-exit-`0` run that parsed a JSON envelope but produced no assistant output (an empty step, or a
-stream of `step_start`/`step_finish` bracketing nothing) is `turn_failed`, not `turn_completed`.
-Process exit code stays informative rather than load-bearing, per the row above, but that framing
-no longer extends to meaning an exit-`0` run with no terminal `error` is automatically complete.
+The `text`, `reasoning`, or `tool_use` part is the per-turn work signal: `RunTurn` sets
+`assistantOutputSeen`, and `finalizeExitedTurn` passes it as `agentcore.WorkPresent` or
+`agentcore.WorkAbsent`. An exit-`0` run that parsed envelopes but produced no assistant output,
+such as a `step_start`/`step_finish` pair bracketing nothing, therefore takes the shared
+zero-work row and reports `turn_failed`.
 
-A transport-class failure (a stdout read error, a session id mismatch, or a timeout waiting for
-the first JSON event) reports `turn_failed` with the failure's specific error kind, the same
-normalized event the other four adapters in the family use for the same class, rather than
-`turn_ended_with_error`.
+### Token usage
 
-### Token usage caveat
-
-`StepFinishPart.tokens` are step-scoped, not a final turn summary. In a two-step run, the
-observed token breakdown changed between the tool-call step and the final text step instead of
-monotonically accumulating:
+`StepFinishPart.tokens` are step-scoped, not a final turn summary. In a two-step run the token
+breakdown changes between the tool-call step and the final text step instead of accumulating
+monotonically:
 
 - Tool step: `{"input":14412,"output":58,"cache":{"read":1840}}`
 - Final step: `{"input":1446,"output":149,"cache":{"read":16240}}`
 
-The adapter recovers authoritative usage with `opencode export --sanitize <sessionID>` after the
-subprocess exits rather than reading `step_finish.part.tokens` from stdout. The export carries
+`queryExportUsage` therefore recovers authoritative usage with
+`opencode export --sanitize <sessionID>` after the subprocess exits rather than reading
+`step_finish.part.tokens` from stdout. The export carries
 per-assistant-message `info.tokens {total, input, output, reasoning, cache{read, write}}`. The
 per-message `cache.write` field reaches no `step_finish` token count on stdout at all: a captured
 three-message session showed `cache.write` values of 16586, 15, and 16618 across the messages the
 stdout stream never surfaces. `tokens.total` includes both cache and reasoning tokens and is not
-`input + output`; the adapter computes its own total as `input + cache.read + cache.write` for
-`input_tokens` plus `output + reasoning` for `output_tokens`, rather than reading `tokens.total`
-directly.
+`input + output`, so `parseExportOutput` computes its own figures instead of reading
+`tokens.total`: `input + cache.read + cache.write` for `input_tokens`, `output + reasoning` for
+`output_tokens`.
 
 The export's session aggregate, at the top-level `info.tokens` of the export payload, equals the
 sum over every assistant message in the session: a captured session with per-message totals
 16593, 16609, and 16626 reported a session aggregate whose components (`input` 9, `output` 14,
 `reasoning` 0, `cache.read` 16586, `cache.write` 33219) sum to 49828, the sum of the three message
-totals. The adapter sums the run's own assistant messages directly rather than reading this
-aggregate field, because the aggregate spans the whole session (including turns from an earlier
-run when the session is resumed) while the adapter needs a run-scoped figure.
+totals. `parseExportOutput` ignores that aggregate and sums the run's own assistant messages,
+because the aggregate spans the whole session including turns from an earlier run, while the
+figure the adapter reports is run-scoped. It selects messages by `info.sessionID` and, on a
+resumed session, by `info.time.created` at or after the run's start. `finalizeExitedTurn` skips
+the update when the export yields nothing, so a failed export cannot lower a figure the run has
+already reported.
 
 ## Concurrency and session isolation
 
-Observed locally in v1.14.25, two `opencode run --format json` commands launched in parallel in
-the same workspace produced distinct session IDs and completed independently:
+Two `opencode run --format json` commands launched in parallel in the same workspace produce
+distinct session IDs and complete independently:
 
 - `ses_236c5a996ffeWzz4OuQinQRiAj`
 - `ses_236c5ba76ffeL6MNEglFHLGLXv`
 
-`opencode session list --format json -n 10` returned sessions in newest-first order for the
-same project directory. That makes `--continue` workable today, because the current
-implementation picks the first root session from `session.list()`. It is still safer for a
-Sortie adapter to persist the exact `sessionID` and use `--session <id>` on continuation turns.
-Observed locally in v1.14.25 and consistent with `run.ts`.
+Session isolation therefore rests on the server-generated ID, which is why the adapter persists
+the exact `sessionID` and passes `--session <id>` on continuation turns instead of relying on
+`--continue` and the `session.list()` ordering.
 
 ## Edge cases and operational notes
 
@@ -536,66 +545,64 @@ The server event model includes `session.status` values of `busy`, `idle`, and
 `retry { attempt, message, next }` (SDK v2 types). The plugin docs also list `session.status`,
 `session.idle`, and `session.error` as first-class events.
 
-`run --format json` does not surface those server status events. That means:
-
-- retry/backoff timing is visible on the server SSE surface, not on CLI JSON stdout
-- if Sortie needs live stall/retry visibility, `serve` is the better integration surface
-
-This point is source-derived from the SDK types and plugin event docs. It was not observed in a
-live rate-limit run during this research session.
+`run --format json` does not surface those server status events, so retry and backoff timing is
+visible on the server SSE surface only. The adapter reads no stall or retry signal; its only
+liveness control is the first-JSON-event read timeout in `RunTurn`, which defaults to 30 seconds
+and is overridden by `AgentConfig.ReadTimeoutMS`. The timer stops once the first JSON envelope
+arrives, so a mid-turn stall does not trip it.
 
 ### Output-length and context-limit failures
 
 The server error union includes `MessageOutputLengthError`, `MessageAbortedError`, `APIError`,
-`ProviderAuthError`, and `UnknownError` (SDK v2 types). Those errors can appear through the CLI
-as `type: "error"` envelopes or stderr diagnostics. An adapter should capture the structured
-error object when present and avoid relying on stderr text classification alone.
+`ProviderAuthError`, and `UnknownError` (SDK v2 types). Those errors reach the CLI as
+`type: "error"` envelopes. `rawRunError` captures the structured object, and
+`rawRunErrorMessage` reads `data.message` first, then `name`, so the adapter never classifies
+stderr text.
 
 ### External-directory access
 
 The documented defaults make `external_directory` an `ask` permission (permissions docs). In
 unattended `run` usage without `--dangerously-skip-permissions`, this produces a non-JSON
-warning line and a `tool_use` error part. Observed locally in v1.14.25.
+warning line and a `tool_use` error part.
 
 ### Plugin and prompt contamination
 
-OpenCode can load default plugins, project plugins, global plugins, and `.claude` prompt/skill
-content unless explicitly disabled (CLI docs, plugin docs). For deterministic orchestration,
-test whether you need one or more of:
+OpenCode loads default plugins, project plugins, global plugins, and `.claude` prompt and skill
+content unless explicitly disabled (CLI docs, plugin docs). The adapter disables none of it: it
+sets no `OPENCODE_DISABLE_DEFAULT_PLUGINS` and no `OPENCODE_DISABLE_CLAUDE_CODE*` variable, and
+`--pure` is opt-in through the `pure` passthrough key.
 
-- `--pure`
-- `OPENCODE_DISABLE_DEFAULT_PLUGINS=1`
-- `OPENCODE_DISABLE_CLAUDE_CODE=1`
-- `OPENCODE_DISABLE_CLAUDE_CODE_PROMPT=1`
-- `OPENCODE_DISABLE_CLAUDE_CODE_SKILLS=1`
+## Fit of `run` as an adapter surface
 
-## Adapter implications
-
-The evidence above supports two practical conclusions:
-
-- `opencode run --format json` is usable for a launch-per-turn adapter.
-- It is not a lossless wire protocol. It hides server status events, omits a final result envelope, and can mix human text into stdout during permission rejection (`run.ts` source). Observed locally in v1.14.25. v1.14.50 added a duplicated `error` event for a single `session.error` (the second is a generic HTTP 500 wrapper from the new `effect/unstable/http` server layer), so adapters MUST iterate all `error` events instead of treating the first one as terminal.
-
-`opencode serve` is the cleaner long-term surface because it exposes explicit session, message,
-permission, and event APIs with documented schemas and an OpenAPI spec (server and SDK docs).
-
-If Sortie wants maximum symmetry with the existing Claude/Copilot launch-per-turn adapters,
-`opencode run` can work, but only with stricter parsing rules and explicit session tracking. If
-Sortie wants the lowest integration risk, a persistent `opencode serve` subprocess plus
-HTTP/SSE integration is a better fit.
+`opencode run --format json` carries what a launch-per-turn adapter needs, but it is not a
+lossless wire protocol. It hides server status events, omits a final result envelope, mixes
+human-readable text into stdout during permission rejection, and can repeat an `error` event for
+one failure. `opencode serve` exposes explicit session, message, permission, and event APIs with
+documented schemas and an OpenAPI spec (server and SDK docs), which is the surface those gaps
+would be closed on.
 
 ## Documented conflicts and drift
 
 | Topic | Docs say | Shipped CLI / source say | Impact |
 | ----- | -------- | ------------------------ | ------ |
-| Auth command name | `opencode auth ...` | Root help promotes `opencode providers ...`; `auth` remains an alias, and alias help still renders `auth` subcommands under an `opencode providers` header | Low; parser should not depend on human help text |
-| Network port default wording | Server docs describe `4096` | Shared CLI options expose `0` in help/config, while the Bun/Node adapters treat `0` as "try `4096` first, then fall back to an ephemeral port" | High for `--attach`; always set `--port` explicitly |
+| Auth command name | `opencode auth ...` | Root help promotes `opencode providers ...`; `auth` is an alias whose own help renders `auth` subcommands under an `opencode providers` header | Low; no parser should depend on human help text |
+| Network port default wording | Server docs describe `4096` | Shared CLI options expose `0` in help and config, while the Bun and Node adapters treat `0` as "try `4096` first, then fall back to an ephemeral port" | High for `--attach`; set `--port` explicitly |
 | `run --format json` | "raw JSON events" | CLI-emitted projection from `run.ts`, not raw SSE | High for adapters |
 | Permissions in JSON mode | Not called out | Permission rejection prints a plain-text warning to stdout before JSON | High for parsers |
-| Exit codes | Not documented | v1.14.25 exited `0` on logical failure; v1.14.50 exits `1`. Treat as informative, not load-bearing | High for failure handling |
-| `--pure` flag | Not on docs page | Present in shipped help output through v1.15.12 | Medium for deterministic runs |
-| Permission keys | `permissions.mdx` lists 14 keys | `config/permission.ts` schema explicitly accepts 16 (adds `list`, `todowrite`) and any other string key via a `StructWithRest` catchall | Medium; adapters that strictly whitelist against the documented set break on configurations OpenCode itself accepts |
-| `OPENCODE_PERMISSION` precedence | Listed in env-var table, no merge semantics specified | [`config/config.ts` lines 656-658](https://github.com/anomalyco/opencode/blob/v1.14.25/packages/opencode/src/config/config.ts#L656-L658) call `mergeDeep(opencode.json.permission, JSON.parse(env))`; env var stacks on top of operator config, never replaces it | High; adapter must scrub inherited value and cover every key it cares about, otherwise operator-side policy bleeds in |
+| Exit codes | Not documented | The code is unstable across releases: `0` on a logical failure in v1.14.25, `1` in v1.14.50 | High for failure handling; the adapter keys failure on the stdout `error` event instead |
+| `--pure` flag | Not on docs page | Present in shipped help output | Medium for deterministic runs |
+| Permission keys | `permissions.mdx` lists 14 keys | `config/permission.ts` accepts 16 explicitly (adding `list` and `todowrite`) and any other string key via a `StructWithRest` catchall | Medium; a strict whitelist against the documented set would break on configurations OpenCode itself accepts |
+| `OPENCODE_PERMISSION` precedence | Listed in the env-var table, no merge semantics specified | [`config/config.ts` lines 656-658](https://github.com/anomalyco/opencode/blob/v1.14.25/packages/opencode/src/config/config.ts#L656-L658) call `mergeDeep(opencode.json.permission, JSON.parse(env))`, so the env var stacks on top of operator config and never replaces it | High; an inherited value bleeds into the merged policy unless the launcher scrubs it |
+
+## Open questions
+
+- Whether the logical-failure shape (exit `1`, empty stderr, two `error` events) still holds on the pinned binary. Repeat the invalid-model run on v1.15.12 and capture stdout, stderr, and the exit code separately.
+- What `run --format json` shows while the server is in `session.status.type == "retry"`. Drive a provider into rate limiting and capture stdout for the duration of the backoff.
+- The output shape of `opencode models`. `queryModelNotFound` treats the catalog as whitespace-separated `provider/model` slugs, and no probe backs that. Run `opencode models` on the pinned binary.
+- Which failures other than an unknown model arrive as the masked generic server error. The adapter package comment attributes the masking to OpenCode 1.16.0 and later, which is above the pinned version, so both the version boundary and the set of masked causes are unverified here. Probe 1.16.x with an invalid model, a revoked credential, and an aborted message.
+- Whether the newest-first ordering of `session.list()` is guaranteed rather than incidental. Read the session list implementation at the pinned tag.
+- Whether default plugins or `.claude` prompt and skill content change a headless run. Run one prompt with and without `--pure` in a repo that carries `.claude` content and diff the event streams.
+- The nd-JSON payloads of `opencode acp`. Capture one ACP session over stdin and stdout.
 
 ## Sources
 


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Chore

**Intent:** The ten `docs/*-adapter-notes.md` files had been appended to rather than updated, so each mixed current behavior with older releases, with the itinerary of past research passes, and with plans that never shipped. A reader could not tell which sentence still applied, and where two eras of one fact coexisted the file contradicted itself. This pass converts all ten to a single genre: a present-tense snapshot of the pinned version.

### 🧭 Reviewer Guide

**Complexity:** Medium

#### Entry Point

`docs/gitlab-adapter-notes.md` - the largest and most journal-shaped of the ten, and the clearest illustration of the new form. Its header no longer narrates four live passes but states coverage per surface; its tag table defines each tag instead of listing every visit that used it; and its 39 numbered live-verification findings are folded into the sections that own their subjects, with the pass-ordered appendix removed. Every evidence tag count held or grew across the rewrite.

#### Sensitive Areas

- `docs/github-adapter-notes.md`: the tracker and SCM halves were written at different times and duplicated statements about authentication, pagination, versioning, and error envelopes. Facts about what API version `2026-03-10` removes now live in one section rather than three.
- `docs/jira-adapter-notes.md`: the only file that grew. It gained an honest provenance statement (documentation-derived, never live-verified), corrections to thirteen claims that disagreed with `internal/tracker/jira`, and an open-questions section. It is also the weakest-evidenced note in the family, and the description now says so.
- `docs/gitea-adapter-notes.md`: the pre-implementation section arguing whether to reuse the GitHub adapter was removed. That decision shipped; the Gitea facts it carried live in their own sections.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes. Documentation only; no code, tests, or configuration touched.
- **Migrations/State:** No migrations or state changes.

### Notes for the reviewer

No external fact was re-researched. Upstream claims about each CLI or API are unchanged apart from losing their era markers, and every one keeps its version anchor. What did change against evidence are the claims each note made about this repository: those were verified against the tree, now cite a Go symbol, and were corrected where they disagreed with it.

Several of those corrections point at the code rather than the prose - a documented turn timeout that no adapter enforces, approval requests the Codex adapter never answers, an MCP config path it never passes, and a launch mechanism the contract describes as a shell invocation while three adapters build an argv. Those are being investigated separately and are not addressed here.