### PR TITLE
feat(orchestrator): enforce handoff evidence policy

### DIFF
--- a/cmd/sortie/resolve.go
+++ b/cmd/sortie/resolve.go
@@ -34,6 +34,7 @@ func trackerConfigMap(tc config.TrackerConfig) map[string]any {
 		"terminal_states":   tc.TerminalStates,
 		"query_filter":      tc.QueryFilter,
 		"handoff_state":     tc.HandoffState,
+		"handoff_evidence":  string(tc.HandoffEvidence.Effective()),
 		"in_progress_state": tc.InProgressState,
 		"api_version":       tc.APIVersion,
 		"comments": map[string]any{

--- a/cmd/sortie/validate_test.go
+++ b/cmd/sortie/validate_test.go
@@ -2974,6 +2974,48 @@ Do {{ .issue.title }}.
 `, kind, handoff)
 }
 
+func TestValidateRejectsInvalidHandoffEvidenceOffline(t *testing.T) {
+	t.Parallel()
+
+	workflow := []byte(`---
+tracker:
+  kind: file
+  active_states:
+    - To Do
+  terminal_states:
+    - Done
+  handoff_state: Human Review
+  handoff_evidence: required
+agent:
+  kind: mock
+---
+Do {{ .issue.title }}.
+`)
+	wfPath := writeCustomWorkflowFile(t, t.TempDir(), workflow)
+
+	var stdout, stderr bytes.Buffer
+	code := run(context.Background(), []string{"validate", "--format", "json", wfPath}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("run(validate --format json) = %d, want 1; stderr: %s", code, stderr.String())
+	}
+
+	var out validateOutput
+	if err := json.Unmarshal(stdout.Bytes(), &out); err != nil {
+		t.Fatalf("json.Unmarshal(%q): %v", stdout.String(), err)
+	}
+	if out.Valid {
+		t.Error("validateOutput.Valid = true, want false")
+	}
+	const wantCheck = "config.tracker.handoff_evidence"
+	diagnostic := diagWithCheck(out.Errors, wantCheck)
+	if diagnostic == nil {
+		t.Fatalf("validateOutput.Errors = %v, want diagnostic %q", out.Errors, wantCheck)
+	}
+	if !strings.Contains(diagnostic.Message, "observed, strict, or off") {
+		t.Errorf("diagnostic.Message = %q, want allowed policy names", diagnostic.Message)
+	}
+}
+
 // TestValidateHandoffStateCollisionEveryTrackerKind verifies that a
 // handoff_state colliding with active_states or terminal_states is a hard
 // error for every registered tracker kind. The rule is enforced by the

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -100,9 +100,30 @@ type TrackerConfig struct {
 	TerminalStates  []string
 	QueryFilter     string
 	HandoffState    string
+	HandoffEvidence HandoffEvidencePolicy
 	InProgressState string
 	APIVersion      string
 	Comments        TrackerCommentsConfig
+}
+
+// HandoffEvidencePolicy controls whether the orchestrator requires
+// workspace evidence before moving an otherwise-eligible issue to its
+// configured handoff state.
+type HandoffEvidencePolicy string
+
+const (
+	HandoffEvidenceObserved HandoffEvidencePolicy = "observed"
+	HandoffEvidenceStrict   HandoffEvidencePolicy = "strict"
+	HandoffEvidenceOff      HandoffEvidencePolicy = "off"
+)
+
+// Effective returns the configured policy, applying the default for
+// zero-value TrackerConfig instances assembled by internal callers or tests.
+func (p HandoffEvidencePolicy) Effective() HandoffEvidencePolicy {
+	if p == "" {
+		return HandoffEvidenceObserved
+	}
+	return p
 }
 
 // TrackerCommentsConfig holds the boolean flags controlling whether
@@ -195,6 +216,12 @@ func NewServiceConfig(raw map[string]any) (ServiceConfig, error) {
 
 	rawTracker := extractSubMap(raw, "tracker")
 	tracker := buildTrackerConfig(rawTracker, envKeys)
+
+	handoffEvidence, err := parseHandoffEvidencePolicy(rawTracker)
+	if err != nil {
+		return ServiceConfig{}, err
+	}
+	tracker.HandoffEvidence = handoffEvidence
 
 	// Validate handoff_state: enforce string type, reject explicit empty
 	// values, and detect env var indirection that resolved to empty.
@@ -421,6 +448,32 @@ func buildTrackerConfig(m map[string]any, envKeys map[string]bool) TrackerConfig
 			OnCompletion: coerceBool(commentsMap, "on_completion"),
 			OnFailure:    coerceBool(commentsMap, "on_failure"),
 		},
+	}
+}
+
+func parseHandoffEvidencePolicy(m map[string]any) (HandoffEvidencePolicy, error) {
+	raw, exists := m["handoff_evidence"]
+	if !exists || raw == nil {
+		return HandoffEvidenceObserved, nil
+	}
+
+	value, ok := raw.(string)
+	if !ok {
+		return "", &ConfigError{
+			Field:   "tracker.handoff_evidence",
+			Message: fmt.Sprintf("expected string, got %T", raw),
+		}
+	}
+
+	policy := HandoffEvidencePolicy(value)
+	switch policy {
+	case HandoffEvidenceObserved, HandoffEvidenceStrict, HandoffEvidenceOff:
+		return policy, nil
+	default:
+		return "", &ConfigError{
+			Field:   "tracker.handoff_evidence",
+			Message: "must be one of observed, strict, or off",
+		}
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -656,6 +656,56 @@ func TestNewServiceConfig(t *testing.T) {
 		assertConfigErrorField(t, err, "tracker.handoff_state")
 	})
 
+	// --- HandoffEvidence subtests ---
+
+	t.Run("HandoffEvidence/DefaultsToObserved", func(t *testing.T) {
+		t.Parallel()
+		cfg, err := NewServiceConfig(map[string]any{})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got := cfg.Tracker.HandoffEvidence; got != HandoffEvidenceObserved {
+			t.Errorf("Tracker.HandoffEvidence = %q, want %q", got, HandoffEvidenceObserved)
+		}
+	})
+
+	for _, policy := range []HandoffEvidencePolicy{
+		HandoffEvidenceObserved,
+		HandoffEvidenceStrict,
+		HandoffEvidenceOff,
+	} {
+		t.Run("HandoffEvidence/Valid/"+string(policy), func(t *testing.T) {
+			t.Parallel()
+			cfg, err := NewServiceConfig(map[string]any{
+				"tracker": map[string]any{"handoff_evidence": string(policy)},
+			})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got := cfg.Tracker.HandoffEvidence; got != policy {
+				t.Errorf("Tracker.HandoffEvidence = %q, want %q", got, policy)
+			}
+		})
+	}
+
+	for _, tt := range []struct {
+		name  string
+		value any
+	}{
+		{name: "empty", value: ""},
+		{name: "unknown", value: "required"},
+		{name: "wrong_case", value: "Observed"},
+		{name: "non_string", value: true},
+	} {
+		t.Run("HandoffEvidence/Invalid/"+tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := NewServiceConfig(map[string]any{
+				"tracker": map[string]any{"handoff_evidence": tt.value},
+			})
+			assertConfigErrorField(t, err, "tracker.handoff_evidence")
+		})
+	}
+
 	t.Run("MaxSessions/DefaultIsZero", func(t *testing.T) {
 		t.Parallel()
 		cfg, err := NewServiceConfig(map[string]any{})

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -50,6 +50,7 @@ var knownFieldsRegistry = map[string]SectionSchema{
 			{Name: "terminal_states", Type: FieldStringList},
 			{Name: "query_filter", Type: FieldString},
 			{Name: "handoff_state", Type: FieldString},
+			{Name: "handoff_evidence", Type: FieldString},
 			{Name: "in_progress_state", Type: FieldString},
 			{Name: "api_version", Type: FieldString},
 			{Name: "comments", Type: FieldMap, Nested: []FieldDef{

--- a/internal/orchestrator/exit.go
+++ b/internal/orchestrator/exit.go
@@ -272,7 +272,60 @@ func HandleWorkerExit(state *State, workerResult WorkerResult, params HandleWork
 	metrics.ObserveWorkerDuration(exitType, elapsed)
 	metrics.AddAgentRuntime(elapsed)
 
+	// Resolve the normal-exit disposition far enough to know whether the
+	// handoff-evidence policy changes this run's persisted status. Evidence is
+	// only consulted where the pre-existing handoff conditions already hold,
+	// and only after the higher-priority blocked and terminal dispositions have
+	// been ruled out.
+	var issueIsActive bool
+	var blockedSoftStop bool
+	var drivesIssue bool
+	var handoffPath bool
+	var observation string
+	var observationSource string
+	var terminal bool
+	var evidenceResult handoffEvidenceResult
+	var evidenceWithheld bool
+	var evidenceErr error
+	if workerResult.ExitKind == WorkerExitNormal {
+		issueIsActive = len(params.ActiveStates) == 0 || isActiveState(entry.Issue.State, params.ActiveStates)
+		blockedSoftStop = workerResult.SoftStop && workerResult.SoftStopReason == string(workspace.StatusBlocked)
+		drivesIssue = dispatchPostureForReactionKind(entry.ReactionKind).DrivesIssueState()
+		handoffPath = params.HandoffState != "" && issueIsActive && !blockedSoftStop && drivesIssue
+		observation, observationSource = resolveTerminalObservation(entry, workerResult)
+		terminal = isTerminalState(observation, params.TerminalStates)
+
+		policy := workerResult.HandoffEvidencePolicy.Effective()
+		if handoffPath && !terminal && policy != config.HandoffEvidenceOff {
+			evidenceResult = evaluateHandoffEvidence(ctx, workerResult, log)
+			if evidenceResult.Verdict == handoffEvidenceUndetermined {
+				log.Info("handoff evidence not determinable",
+					slog.String("policy", string(policy)),
+					slog.String("verdict", string(evidenceResult.Verdict)),
+					slog.String("reason", evidenceResult.Reason),
+					slog.Int("turns_completed", workerResult.TurnsCompleted),
+				)
+			}
+			evidenceWithheld = handoffEvidenceWithholds(policy, evidenceResult)
+			if evidenceWithheld {
+				evidenceErr = handoffEvidenceFailure(policy, evidenceResult)
+				log.Warn("handoff withheld by evidence policy",
+					slog.String("policy", string(policy)),
+					slog.String("verdict", string(evidenceResult.Verdict)),
+					slog.String("reason", evidenceResult.Reason),
+					slog.Int("turns_completed", workerResult.TurnsCompleted),
+				)
+				metrics.IncHandoffTransitions(handoffWithheld)
+			}
+		}
+	}
+
 	status := mapExitKindToStatus(workerResult.ExitKind)
+	runError := workerResult.Error
+	if evidenceWithheld {
+		status = "failed"
+		runError = evidenceErr
+	}
 
 	// RunHistory.Attempt is 1-based for display: first dispatch = 1,
 	// first retry = 2, etc. normalizeAttempt returns the 0-based retry
@@ -287,7 +340,7 @@ func HandleWorkerExit(state *State, workerResult WorkerResult, params HandleWork
 		StartedAt:       entry.StartedAt.Format(time.RFC3339),
 		CompletedAt:     now.Format(time.RFC3339),
 		Status:          status,
-		Error:           errorStringPtr(workerResult.Error),
+		Error:           errorStringPtr(runError),
 		WorkflowFile:    entry.WorkflowFile,
 		TurnsCompleted:  workerResult.TurnsCompleted,
 		RuleName:        entry.RuleName,
@@ -386,25 +439,7 @@ func HandleWorkerExit(state *State, workerResult WorkerResult, params HandleWork
 	case WorkerExitNormal:
 		state.Completed[workerResult.IssueID] = struct{}{}
 
-		// Determine whether the issue is still in an active tracker state.
-		// When ActiveStates is nil or empty, default to true (pessimistic —
-		// backward compatibility guard: continuation retry fires).
-		issueIsActive := len(params.ActiveStates) == 0 || isActiveState(entry.Issue.State, params.ActiveStates)
 		_, claimedAtExit := state.Claimed[workerResult.IssueID]
-		blockedSoftStop := workerResult.SoftStop && workerResult.SoftStopReason == string(workspace.StatusBlocked)
-		// A dispatch that does not drive issue state (a label-command
-		// posture) performs no work handoff and schedules no continuation
-		// on a clean exit, so it never takes the handoff path or the
-		// active-issue continuation-retry branch.
-		drivesIssue := dispatchPostureForReactionKind(entry.ReactionKind).DrivesIssueState()
-		handoffPath := params.HandoffState != "" && issueIsActive && !blockedSoftStop && drivesIssue
-
-		// The resolved observation feeds the terminal test only; it MUST
-		// NOT be substituted for entry.Issue.State above, because the most
-		// common non-active state at a normal exit is the handoff state
-		// itself, applied by the agent through its own tracker_api calls.
-		observation, observationSource := resolveTerminalObservation(entry, workerResult)
-		terminal := isTerminalState(observation, params.TerminalStates)
 		terminalSuppressed := false
 
 		switch {
@@ -433,6 +468,42 @@ func HandleWorkerExit(state *State, workerResult WorkerResult, params HandleWork
 			terminalSuppressed = true
 			CancelRetry(state, workerResult.IssueID)
 			delete(state.Claimed, workerResult.IssueID)
+
+		case handoffPath && evidenceWithheld:
+			// A withheld handoff is an unsuccessful run disposition even though
+			// the agent process exited normally. Keep the issue claimed and use
+			// the ordinary exponential-backoff failure lane, not the short
+			// continuation lane.
+			if incumbent := retrySlotIncumbent(state, workerResult.IssueID); incumbent != nil {
+				logRetrySlotDeferral(log, "evidence-backoff", incumbent)
+				nextAttempt = incumbent.Attempt
+				retryDeferred = true
+			} else {
+				nextAttempt = NextAttempt(entry.RetryAttempt)
+				delayMS := computeBackoffDelay(nextAttempt, params.MaxRetryBackoffMS)
+				log.Warn("handoff evidence failure, scheduling retry",
+					slog.Any("error", evidenceErr),
+					slog.Int("next_attempt", nextAttempt),
+					slog.Int64("delay_ms", delayMS),
+				)
+				ScheduleRetry(state, ScheduleRetryParams{
+					IssueID:             workerResult.IssueID,
+					Identifier:          workerResult.Identifier,
+					DisplayID:           entry.Issue.DisplayID,
+					Attempt:             nextAttempt,
+					DelayMS:             delayMS,
+					Error:               "worker exited: " + evidenceErr.Error(),
+					LastSSHHost:         workerResult.SSHHost,
+					ContinuationContext: entry.ContinuationContext,
+					ReactionKind:        entry.ReactionKind,
+					AgentKind:           entry.AgentKind,
+					RuleName:            entry.RuleName,
+					TemplateID:          entry.TemplateID,
+					Logger:              log,
+				}, params.OnRetryFire)
+				metrics.IncRetries(triggerError)
+				retryScheduled = true
+			}
 
 		case handoffPath:
 			// Handoff: issue is active and handoff_state is configured.
@@ -1030,7 +1101,12 @@ func HandleWorkerExit(state *State, workerResult WorkerResult, params HandleWork
 
 	switch workerResult.ExitKind {
 	case WorkerExitNormal:
-		if params.CommentsConfig.OnCompletion {
+		if evidenceWithheld {
+			if params.CommentsConfig.OnFailure {
+				commentText = buildFailureComment(sessionID, runDuration, evidenceErr, retryPending, nextAttempt)
+				lifecycle = "failure"
+			}
+		} else if params.CommentsConfig.OnCompletion {
 			if workerResult.SoftStop {
 				commentText = buildSoftStopComment(sessionID, runDuration, workerResult.TurnsCompleted, workerResult.SoftStopReason)
 			} else {

--- a/internal/orchestrator/exit_test.go
+++ b/internal/orchestrator/exit_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/sortie-ai/sortie/internal/config"
 	"github.com/sortie-ai/sortie/internal/domain"
 	"github.com/sortie-ai/sortie/internal/persistence"
+	"github.com/sortie-ai/sortie/internal/workspace"
 )
 
 // --- Test doubles ---
@@ -1523,6 +1524,403 @@ func exitStateWithIssue(t *testing.T, issueID, issueState string) *State {
 	state := exitState(t, issueID, nil)
 	state.Running[issueID].Issue.State = issueState
 	return state
+}
+
+func handoffEvidenceGitWorkspace(t *testing.T) (string, *workspace.HandoffEvidenceBaseline) {
+	t.Helper()
+	dir := t.TempDir()
+	initGitRepo(t, dir)
+	baseline, err := workspace.CaptureHandoffEvidenceBaseline(context.Background(), dir)
+	if err != nil {
+		t.Fatalf("CaptureHandoffEvidenceBaseline: %v", err)
+	}
+	return dir, &baseline
+}
+
+func handoffEvidenceExitParams(t *testing.T, store *mockExitStore, tracker *mockTrackerAdapter, metrics domain.Metrics) HandleWorkerExitParams {
+	t.Helper()
+	params := defaultExitParams(t, store)
+	params.TrackerAdapter = tracker
+	params.HandoffState = "Human Review"
+	params.ActiveStates = []string{"In Progress"}
+	params.TerminalStates = []string{"Done"}
+	params.Metrics = metrics
+	return params
+}
+
+func TestHandleWorkerExit_HandoffEvidenceObservedAbsenceWithholds(t *testing.T) {
+	const issueID = "HE-ABSENT"
+	dir, baseline := handoffEvidenceGitWorkspace(t)
+	store := &mockExitStore{}
+	tracker := &mockTrackerAdapter{}
+	spy := &spyMetrics{}
+	state := exitStateWithIssue(t, issueID, "In Progress")
+	state.Running[issueID].ContinuationContext = map[string]any{"review_comments": "preserved"}
+	params := handoffEvidenceExitParams(t, store, tracker, spy)
+	params.CommentsConfig.OnCompletion = true
+	var logs bytes.Buffer
+	params.Logger = debugLogger(t, &logs)
+
+	HandleWorkerExit(state, WorkerResult{
+		IssueID:                 issueID,
+		Identifier:              issueID + "-ident",
+		ExitKind:                WorkerExitNormal,
+		TurnsCompleted:          2,
+		WorkspacePath:           dir,
+		HandoffEvidencePolicy:   config.HandoffEvidenceObserved,
+		HandoffEvidenceBaseline: baseline,
+		AgentAdapter:            "mock",
+	}, params)
+	t.Cleanup(func() { CancelRetry(state, issueID) })
+
+	if len(tracker.transitionCalls) != 0 {
+		t.Errorf("TransitionIssue called %d times, want 0", len(tracker.transitionCalls))
+	}
+	if len(tracker.commentCalls) != 0 {
+		t.Errorf("completion comment posted for withheld run: %+v", tracker.commentCalls)
+	}
+	if got := tracker.fetchStatesCalls.Load(); got != 0 {
+		t.Errorf("FetchIssueStatesByIDs called %d times, want 0 before a withheld handoff", got)
+	}
+	if _, ok := state.Claimed[issueID]; !ok {
+		t.Error("claim released after withheld handoff, want issue to remain active and claimed")
+	}
+	retry, ok := state.RetryAttempts[issueID]
+	if !ok {
+		t.Fatal("retry not scheduled after withheld handoff")
+	}
+	if retry.scheduledDelayMS != backoffBaseMS {
+		t.Errorf("retry delay = %d, want exponential-backoff base %d", retry.scheduledDelayMS, backoffBaseMS)
+	}
+	if retry.scheduledDelayMS == continuationDelayMS {
+		t.Errorf("retry used continuation delay %d", continuationDelayMS)
+	}
+	if retry.ContinuationContext == nil || retry.ContinuationContext["review_comments"] != "preserved" {
+		t.Errorf("retry ContinuationContext = %#v, want preserved", retry.ContinuationContext)
+	}
+	if !strings.Contains(retry.Error, string(handoffAbsenceObserved)) {
+		t.Errorf("retry Error = %q, want verdict %q", retry.Error, handoffAbsenceObserved)
+	}
+	if len(store.runHistories) != 1 {
+		t.Fatalf("AppendRunHistory calls = %d, want 1", len(store.runHistories))
+	}
+	if got := store.runHistories[0].Status; got != "failed" {
+		t.Errorf("RunHistory.Status = %q, want failed", got)
+	}
+	if store.runHistories[0].Error == nil || !strings.Contains(*store.runHistories[0].Error, string(handoffAbsenceObserved)) {
+		t.Errorf("RunHistory.Error = %v, want absence verdict", store.runHistories[0].Error)
+	}
+	if len(spy.handoffTransitions) != 1 || spy.handoffTransitions[0] != handoffWithheld {
+		t.Errorf("handoffTransitions = %v, want [%s]", spy.handoffTransitions, handoffWithheld)
+	}
+	if len(spy.retries) != 1 || spy.retries[0] != triggerError {
+		t.Errorf("retries = %v, want [%s]", spy.retries, triggerError)
+	}
+	for _, want := range []string{
+		`msg="handoff withheld by evidence policy"`,
+		`verdict="absence of work observed"`,
+		"turns_completed=2",
+		"issue_id=" + issueID,
+	} {
+		if !strings.Contains(logs.String(), want) {
+			t.Errorf("log output missing %q\ngot: %s", want, logs.String())
+		}
+	}
+}
+
+func TestHandleWorkerExit_HandoffEvidenceWorkspaceChangesPermitHandoff(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(t *testing.T, dir string)
+	}{
+		{
+			name: "commit moved",
+			mutate: func(t *testing.T, dir string) {
+				t.Helper()
+				if err := os.WriteFile(filepath.Join(dir, "work.txt"), []byte("work\n"), 0o600); err != nil {
+					t.Fatalf("write work file: %v", err)
+				}
+				runGit(t, dir, "add", "work.txt")
+				runGit(t, dir, "commit", "-m", "work")
+			},
+		},
+		{
+			name: "working tree changed",
+			mutate: func(t *testing.T, dir string) {
+				t.Helper()
+				if err := os.WriteFile(filepath.Join(dir, "work.txt"), []byte("work\n"), 0o600); err != nil {
+					t.Fatalf("write work file: %v", err)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir, baseline := handoffEvidenceGitWorkspace(t)
+			tt.mutate(t, dir)
+			const issueID = "HE-WORK"
+			store := &mockExitStore{}
+			tracker := &mockTrackerAdapter{}
+			spy := &spyMetrics{}
+			state := exitStateWithIssue(t, issueID, "In Progress")
+			params := handoffEvidenceExitParams(t, store, tracker, spy)
+
+			HandleWorkerExit(state, WorkerResult{
+				IssueID:                 issueID,
+				Identifier:              issueID + "-ident",
+				ExitKind:                WorkerExitNormal,
+				WorkspacePath:           dir,
+				HandoffEvidencePolicy:   config.HandoffEvidenceObserved,
+				HandoffEvidenceBaseline: baseline,
+				AgentAdapter:            "mock",
+			}, params)
+
+			if len(tracker.transitionCalls) != 1 {
+				t.Fatalf("TransitionIssue called %d times, want 1", len(tracker.transitionCalls))
+			}
+			if len(store.runHistories) != 1 || store.runHistories[0].Status != "succeeded" {
+				t.Errorf("run histories = %+v, want one succeeded row", store.runHistories)
+			}
+			if len(spy.handoffTransitions) != 1 || spy.handoffTransitions[0] != handoffSuccess {
+				t.Errorf("handoffTransitions = %v, want [%s]", spy.handoffTransitions, handoffSuccess)
+			}
+		})
+	}
+}
+
+func TestHandleWorkerExit_HandoffEvidencePriorSCMMetadataPermitsHandoff(t *testing.T) {
+	tests := []struct {
+		name  string
+		write func(t *testing.T, dir string)
+	}{
+		{
+			name: "pushed commit",
+			write: func(t *testing.T, dir string) {
+				writeSCMMetadata(t, dir, "feature/issue", "pushed-sha")
+			},
+		},
+		{
+			name: "pull request",
+			write: func(t *testing.T, dir string) {
+				writePRSCMMetadata(t, dir, 42, "acme", "repo", "feature/issue", "")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			const issueID = "HE-SCM"
+			dir := t.TempDir()
+			tt.write(t, dir)
+			store := &mockExitStore{}
+			tracker := &mockTrackerAdapter{}
+			state := exitStateWithIssue(t, issueID, "In Progress")
+			params := handoffEvidenceExitParams(t, store, tracker, &spyMetrics{})
+
+			HandleWorkerExit(state, WorkerResult{
+				IssueID:               issueID,
+				Identifier:            issueID + "-ident",
+				ExitKind:              WorkerExitNormal,
+				WorkspacePath:         dir,
+				HandoffEvidencePolicy: config.HandoffEvidenceObserved,
+				AgentAdapter:          "mock",
+			}, params)
+
+			if len(tracker.transitionCalls) != 1 {
+				t.Fatalf("TransitionIssue called %d times, want 1", len(tracker.transitionCalls))
+			}
+			if store.runHistories[0].Status != "succeeded" {
+				t.Errorf("RunHistory.Status = %q, want succeeded", store.runHistories[0].Status)
+			}
+		})
+	}
+}
+
+func TestHandleWorkerExit_HandoffEvidenceNonGitPolicies(t *testing.T) {
+	dir := t.TempDir()
+	_, baselineErr := workspace.CaptureHandoffEvidenceBaseline(context.Background(), dir)
+	if !errors.Is(baselineErr, workspace.ErrNotGitWorkspace) {
+		t.Fatalf("baseline error = %v, want ErrNotGitWorkspace", baselineErr)
+	}
+
+	t.Run("observed permits undeterminable evidence", func(t *testing.T) {
+		const issueID = "HE-NONGIT-OBS"
+		store := &mockExitStore{}
+		tracker := &mockTrackerAdapter{}
+		spy := &spyMetrics{}
+		state := exitStateWithIssue(t, issueID, "In Progress")
+		params := handoffEvidenceExitParams(t, store, tracker, spy)
+		var logs bytes.Buffer
+		params.Logger = debugLogger(t, &logs)
+
+		HandleWorkerExit(state, WorkerResult{
+			IssueID:                      issueID,
+			Identifier:                   issueID + "-ident",
+			ExitKind:                     WorkerExitNormal,
+			TurnsCompleted:               1,
+			WorkspacePath:                dir,
+			HandoffEvidencePolicy:        config.HandoffEvidenceObserved,
+			HandoffEvidenceBaselineError: baselineErr,
+			AgentAdapter:                 "mock",
+		}, params)
+
+		if len(tracker.transitionCalls) != 1 {
+			t.Fatalf("TransitionIssue called %d times, want 1", len(tracker.transitionCalls))
+		}
+		if store.runHistories[0].Status != "succeeded" {
+			t.Errorf("RunHistory.Status = %q, want succeeded", store.runHistories[0].Status)
+		}
+		if strings.Contains(logs.String(), "handoff withheld by evidence policy") {
+			t.Errorf("observed policy withheld undeterminable evidence\nlogs: %s", logs.String())
+		}
+		if !strings.Contains(logs.String(), "handoff evidence not determinable") {
+			t.Errorf("missing undeterminable info record\nlogs: %s", logs.String())
+		}
+	})
+
+	t.Run("strict withholds undeterminable evidence", func(t *testing.T) {
+		const issueID = "HE-NONGIT-STRICT"
+		store := &mockExitStore{}
+		tracker := &mockTrackerAdapter{}
+		spy := &spyMetrics{}
+		state := exitStateWithIssue(t, issueID, "In Progress")
+		params := handoffEvidenceExitParams(t, store, tracker, spy)
+		var logs bytes.Buffer
+		params.Logger = debugLogger(t, &logs)
+
+		HandleWorkerExit(state, WorkerResult{
+			IssueID:                      issueID,
+			Identifier:                   issueID + "-ident",
+			ExitKind:                     WorkerExitNormal,
+			TurnsCompleted:               1,
+			WorkspacePath:                dir,
+			HandoffEvidencePolicy:        config.HandoffEvidenceStrict,
+			HandoffEvidenceBaselineError: baselineErr,
+			AgentAdapter:                 "mock",
+		}, params)
+		t.Cleanup(func() { CancelRetry(state, issueID) })
+
+		if len(tracker.transitionCalls) != 0 {
+			t.Errorf("TransitionIssue called %d times, want 0", len(tracker.transitionCalls))
+		}
+		if store.runHistories[0].Status != "failed" || store.runHistories[0].Error == nil ||
+			!strings.Contains(*store.runHistories[0].Error, string(handoffEvidenceUndetermined)) {
+			t.Errorf("RunHistory = %+v, want failed with undeterminable verdict", store.runHistories[0])
+		}
+		if !strings.Contains(logs.String(), "handoff evidence not determinable") ||
+			!strings.Contains(logs.String(), "handoff withheld by evidence policy") {
+			t.Errorf("strict policy logs missing info or warning\nlogs: %s", logs.String())
+		}
+		if len(spy.handoffTransitions) != 1 || spy.handoffTransitions[0] != handoffWithheld {
+			t.Errorf("handoffTransitions = %v, want [%s]", spy.handoffTransitions, handoffWithheld)
+		}
+	})
+}
+
+func TestHandleWorkerExit_HandoffEvidenceOffPreservesOldBehavior(t *testing.T) {
+	const issueID = "HE-OFF"
+	store := &mockExitStore{}
+	tracker := &mockTrackerAdapter{}
+	spy := &spyMetrics{}
+	state := exitStateWithIssue(t, issueID, "In Progress")
+	params := handoffEvidenceExitParams(t, store, tracker, spy)
+	var logs bytes.Buffer
+	params.Logger = debugLogger(t, &logs)
+
+	HandleWorkerExit(state, WorkerResult{
+		IssueID:                      issueID,
+		Identifier:                   issueID + "-ident",
+		ExitKind:                     WorkerExitNormal,
+		WorkspacePath:                filepath.Join(t.TempDir(), "does-not-exist"),
+		HandoffEvidencePolicy:        config.HandoffEvidenceOff,
+		HandoffEvidenceBaselineError: errors.New("must not be consulted"),
+		AgentAdapter:                 "mock",
+	}, params)
+
+	if len(tracker.transitionCalls) != 1 {
+		t.Fatalf("TransitionIssue called %d times, want 1", len(tracker.transitionCalls))
+	}
+	if store.runHistories[0].Status != "succeeded" || store.runHistories[0].Error != nil {
+		t.Errorf("RunHistory = %+v, want old succeeded disposition", store.runHistories[0])
+	}
+	if strings.Contains(logs.String(), "handoff evidence") || strings.Contains(logs.String(), "handoff withheld") {
+		t.Errorf("off policy emitted evidence record\nlogs: %s", logs.String())
+	}
+	if len(spy.handoffTransitions) != 1 || spy.handoffTransitions[0] != handoffSuccess {
+		t.Errorf("handoffTransitions = %v, want only [%s]", spy.handoffTransitions, handoffSuccess)
+	}
+}
+
+func TestHandleWorkerExit_HandoffEvidenceOnlyAppliesToEligibleHandoff(t *testing.T) {
+	t.Run("no handoff state keeps the continuation disposition", func(t *testing.T) {
+		const issueID = "HE-NO-HANDOFF"
+		store := &mockExitStore{}
+		tracker := &mockTrackerAdapter{}
+		spy := &spyMetrics{}
+		state := exitStateWithIssue(t, issueID, "In Progress")
+		params := defaultExitParams(t, store)
+		params.TrackerAdapter = tracker
+		params.ActiveStates = []string{"In Progress"}
+		params.Metrics = spy
+		var logs bytes.Buffer
+		params.Logger = debugLogger(t, &logs)
+
+		HandleWorkerExit(state, WorkerResult{
+			IssueID:                      issueID,
+			Identifier:                   issueID + "-ident",
+			ExitKind:                     WorkerExitNormal,
+			HandoffEvidencePolicy:        config.HandoffEvidenceStrict,
+			HandoffEvidenceBaselineError: errors.New("must not be consulted"),
+			AgentAdapter:                 "mock",
+		}, params)
+		t.Cleanup(func() { CancelRetry(state, issueID) })
+
+		retry := state.RetryAttempts[issueID]
+		if retry == nil || retry.scheduledDelayMS != continuationDelayMS {
+			t.Errorf("retry = %+v, want existing continuation disposition", retry)
+		}
+		if store.runHistories[0].Status != "succeeded" {
+			t.Errorf("RunHistory.Status = %q, want succeeded", store.runHistories[0].Status)
+		}
+		if strings.Contains(logs.String(), "handoff evidence") || len(spy.handoffTransitions) != 0 {
+			t.Errorf("ineligible path consulted evidence; metrics=%v logs=%s", spy.handoffTransitions, logs.String())
+		}
+	})
+
+	t.Run("terminal disposition wins before evidence", func(t *testing.T) {
+		const issueID = "HE-TERMINAL"
+		store := &mockExitStore{}
+		tracker := &mockTrackerAdapter{}
+		spy := &spyMetrics{}
+		state := exitStateWithIssue(t, issueID, "In Progress")
+		params := handoffEvidenceExitParams(t, store, tracker, spy)
+		var logs bytes.Buffer
+		params.Logger = debugLogger(t, &logs)
+
+		HandleWorkerExit(state, WorkerResult{
+			IssueID:                      issueID,
+			Identifier:                   issueID + "-ident",
+			ExitKind:                     WorkerExitNormal,
+			ObservedIssueState:           "Done",
+			HandoffEvidencePolicy:        config.HandoffEvidenceStrict,
+			HandoffEvidenceBaselineError: errors.New("must not be consulted"),
+			AgentAdapter:                 "mock",
+		}, params)
+
+		if len(tracker.transitionCalls) != 0 {
+			t.Errorf("TransitionIssue called %d times, want 0", len(tracker.transitionCalls))
+		}
+		if store.runHistories[0].Status != "succeeded" {
+			t.Errorf("RunHistory.Status = %q, want succeeded terminal suppression", store.runHistories[0].Status)
+		}
+		if strings.Contains(logs.String(), "handoff evidence") {
+			t.Errorf("terminal path consulted evidence\nlogs: %s", logs.String())
+		}
+		if len(spy.handoffTransitions) != 1 || spy.handoffTransitions[0] != handoffSkipped {
+			t.Errorf("handoffTransitions = %v, want [%s]", spy.handoffTransitions, handoffSkipped)
+		}
+	})
 }
 
 func TestHandleWorkerExit_HandoffTransitionSucceeds(t *testing.T) {

--- a/internal/orchestrator/handoff_evidence.go
+++ b/internal/orchestrator/handoff_evidence.go
@@ -1,0 +1,78 @@
+package orchestrator
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/sortie-ai/sortie/internal/config"
+	"github.com/sortie-ai/sortie/internal/workspace"
+)
+
+type handoffEvidenceVerdict string
+
+const (
+	handoffWorkObserved         handoffEvidenceVerdict = "work observed"
+	handoffAbsenceObserved      handoffEvidenceVerdict = "absence of work observed"
+	handoffEvidenceUndetermined handoffEvidenceVerdict = "evidence not determinable"
+)
+
+type handoffEvidenceResult struct {
+	Verdict handoffEvidenceVerdict
+	Reason  string
+}
+
+func evaluateHandoffEvidence(ctx context.Context, result WorkerResult, log *slog.Logger) handoffEvidenceResult {
+	if result.WorkspacePath != "" {
+		scm := workspace.ReadSCMMetadata(result.WorkspacePath, log)
+		if scm.SHA != "" || scm.PRNumber > 0 {
+			return handoffEvidenceResult{
+				Verdict: handoffWorkObserved,
+				Reason:  "workspace SCM metadata names a pushed commit or pull request",
+			}
+		}
+	}
+
+	if result.HandoffEvidenceBaseline == nil {
+		reason := "run has no workspace baseline"
+		if result.HandoffEvidenceBaselineError != nil {
+			reason = result.HandoffEvidenceBaselineError.Error()
+		} else if result.WorkspacePath == "" {
+			reason = "run has no recorded workspace"
+		}
+		return handoffEvidenceResult{Verdict: handoffEvidenceUndetermined, Reason: reason}
+	}
+
+	change, err := workspace.CompareHandoffEvidenceBaseline(ctx, result.WorkspacePath, *result.HandoffEvidenceBaseline)
+	if err != nil {
+		return handoffEvidenceResult{
+			Verdict: handoffEvidenceUndetermined,
+			Reason:  fmt.Sprintf("workspace comparison failed: %v", err),
+		}
+	}
+	if change.CommitMoved {
+		return handoffEvidenceResult{Verdict: handoffWorkObserved, Reason: "workspace commit moved from the run baseline"}
+	}
+	if change.WorktreeChanged {
+		return handoffEvidenceResult{Verdict: handoffWorkObserved, Reason: "working tree changed from the run baseline"}
+	}
+	return handoffEvidenceResult{
+		Verdict: handoffAbsenceObserved,
+		Reason:  "workspace commit and working tree match the run baseline",
+	}
+}
+
+func handoffEvidenceWithholds(policy config.HandoffEvidencePolicy, result handoffEvidenceResult) bool {
+	switch result.Verdict {
+	case handoffAbsenceObserved:
+		return true
+	case handoffEvidenceUndetermined:
+		return policy == config.HandoffEvidenceStrict
+	default:
+		return false
+	}
+}
+
+func handoffEvidenceFailure(policy config.HandoffEvidencePolicy, result handoffEvidenceResult) error {
+	return fmt.Errorf("handoff withheld: %s under %s policy", result.Verdict, policy)
+}

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -39,9 +39,10 @@ const (
 	actionSweepCleanup = "sweep_cleanup"
 	actionSweepExpired = "sweep_expired"
 
-	handoffSuccess = "success"
-	handoffError   = "error"
-	handoffSkipped = "skipped"
+	handoffSuccess  = "success"
+	handoffError    = "error"
+	handoffSkipped  = "skipped"
+	handoffWithheld = "withheld"
 )
 
 // Budget reason values recorded in [State.BudgetExhaustedReason] and the

--- a/internal/orchestrator/worker.go
+++ b/internal/orchestrator/worker.go
@@ -115,6 +115,19 @@ type WorkerResult struct {
 	// Empty if workspace preparation failed.
 	WorkspacePath string
 
+	// HandoffEvidencePolicy is frozen from the run's initial config snapshot
+	// before the baseline decision. Reloads during the run cannot change it.
+	HandoffEvidencePolicy config.HandoffEvidencePolicy
+
+	// HandoffEvidenceBaseline is the Git state captured after workspace
+	// preparation and pre-run hooks, immediately before StartSession. It is nil
+	// when capture failed or the frozen policy is off.
+	HandoffEvidenceBaseline *workspace.HandoffEvidenceBaseline
+
+	// HandoffEvidenceBaselineError records why baseline capture failed. It is
+	// nil when capture succeeded or the frozen policy is off.
+	HandoffEvidenceBaselineError error
+
 	// AgentAdapter is the agent adapter kind string used to dispatch
 	// this attempt. Equals the rule-resolved kind when dispatch routing
 	// selected a non-default agent; otherwise equals the workflow-wide
@@ -468,6 +481,7 @@ func foldLocalUsage(usage, cumulative, lastUsage domain.TokenUsage) (newCumulati
 // closure over deps.
 func RunWorkerAttempt(ctx context.Context, issue domain.Issue, attempt *int, deps WorkerDeps) {
 	cfg := deps.ConfigFunc()
+	handoffEvidencePolicy := cfg.Tracker.HandoffEvidence.Effective()
 	tmpl := deps.PromptTemplateByIDFunc(deps.TemplateID)
 	attemptInt := normalizeAttempt(attempt)
 	logger := deps.Logger
@@ -570,6 +584,8 @@ func RunWorkerAttempt(ctx context.Context, issue domain.Issue, attempt *int, dep
 	var sessionStarted bool
 	var mcpConfigPath string
 	var sessionStartedAt time.Time
+	var handoffEvidenceBaseline *workspace.HandoffEvidenceBaseline
+	var handoffEvidenceBaselineErr error
 	// localUsage is the worker's own mirror of the run-cumulative token
 	// counters, folded from any usage-bearing event on the worker
 	// goroutine; localLastUsage holds the matching last-reported
@@ -811,6 +827,15 @@ func RunWorkerAttempt(ctx context.Context, issue domain.Issue, attempt *int, dep
 		return
 	}
 
+	if handoffEvidencePolicy != config.HandoffEvidenceOff {
+		baseline, baselineErr := workspace.CaptureHandoffEvidenceBaseline(ctx, wsResult.Path)
+		if baselineErr != nil {
+			handoffEvidenceBaselineErr = baselineErr
+		} else {
+			handoffEvidenceBaseline = &baseline
+		}
+	}
+
 	session, err = deps.AgentAdapter.StartSession(ctx, domain.StartSessionParams{
 		WorkspacePath:            wsResult.Path,
 		AgentConfig:              toDomainAgentConfig(cfg.Agent),
@@ -1048,20 +1073,23 @@ func RunWorkerAttempt(ctx context.Context, issue domain.Issue, attempt *int, dep
 			finishWorkspace()
 			reported = true
 			deps.OnExit(issue.ID, WorkerResult{
-				IssueID:            issue.ID,
-				Identifier:         issue.Identifier,
-				ExitKind:           WorkerExitNormal,
-				TurnsCompleted:     turnsCompleted,
-				SessionID:          session.ID,
-				WorkspacePath:      wsResult.Path,
-				AgentAdapter:       agentKind,
-				Attempt:            attempt,
-				SSHHost:            deps.SSHHost,
-				SoftStop:           true,
-				SoftStopReason:     string(statusSignal),
-				ObservedIssueState: observedIssueState,
-				Usage:              localUsage,
-				UsageMeasured:      localMeasured,
+				IssueID:                      issue.ID,
+				Identifier:                   issue.Identifier,
+				ExitKind:                     WorkerExitNormal,
+				TurnsCompleted:               turnsCompleted,
+				SessionID:                    session.ID,
+				WorkspacePath:                wsResult.Path,
+				HandoffEvidencePolicy:        handoffEvidencePolicy,
+				HandoffEvidenceBaseline:      handoffEvidenceBaseline,
+				HandoffEvidenceBaselineError: handoffEvidenceBaselineErr,
+				AgentAdapter:                 agentKind,
+				Attempt:                      attempt,
+				SSHHost:                      deps.SSHHost,
+				SoftStop:                     true,
+				SoftStopReason:               string(statusSignal),
+				ObservedIssueState:           observedIssueState,
+				Usage:                        localUsage,
+				UsageMeasured:                localMeasured,
 			})
 			return
 		}
@@ -1178,19 +1206,22 @@ func RunWorkerAttempt(ctx context.Context, issue domain.Issue, attempt *int, dep
 
 	reported = true
 	deps.OnExit(issue.ID, WorkerResult{
-		IssueID:            issue.ID,
-		Identifier:         issue.Identifier,
-		ExitKind:           WorkerExitNormal,
-		TurnsCompleted:     turnsCompleted,
-		SessionID:          session.ID,
-		WorkspacePath:      wsResult.Path,
-		AgentAdapter:       agentKind,
-		Attempt:            attempt,
-		SSHHost:            deps.SSHHost,
-		ReviewMetadata:     reviewMeta,
-		ObservedIssueState: observedIssueState,
-		Usage:              localUsage,
-		UsageMeasured:      localMeasured,
+		IssueID:                      issue.ID,
+		Identifier:                   issue.Identifier,
+		ExitKind:                     WorkerExitNormal,
+		TurnsCompleted:               turnsCompleted,
+		SessionID:                    session.ID,
+		WorkspacePath:                wsResult.Path,
+		HandoffEvidencePolicy:        handoffEvidencePolicy,
+		HandoffEvidenceBaseline:      handoffEvidenceBaseline,
+		HandoffEvidenceBaselineError: handoffEvidenceBaselineErr,
+		AgentAdapter:                 agentKind,
+		Attempt:                      attempt,
+		SSHHost:                      deps.SSHHost,
+		ReviewMetadata:               reviewMeta,
+		ObservedIssueState:           observedIssueState,
+		Usage:                        localUsage,
+		UsageMeasured:                localMeasured,
 	})
 }
 

--- a/internal/orchestrator/worker_test.go
+++ b/internal/orchestrator/worker_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -19,6 +20,7 @@ import (
 	"github.com/sortie-ai/sortie/internal/config"
 	"github.com/sortie-ai/sortie/internal/domain"
 	"github.com/sortie-ai/sortie/internal/prompt"
+	"github.com/sortie-ai/sortie/internal/workspace"
 )
 
 // --- Test helpers ---
@@ -2434,6 +2436,288 @@ func TestRunWorkerAttempt_DispatchTransition(t *testing.T) {
 			t.Errorf("dispatchTransitions = %v, want [%q]", transitions, outcomeSkipped)
 		}
 	})
+}
+
+func TestRunWorkerAttempt_HandoffEvidenceBaselineBoundary(t *testing.T) {
+	t.Run("full preparation captures after pre-run hook", func(t *testing.T) {
+		root := t.TempDir()
+		cfg := defaultWorkerConfig(root)
+		cfg.Agent.MaxTurns = 1
+		cfg.Tracker.HandoffEvidence = config.HandoffEvidenceObserved
+		cfg.Hooks.AfterCreate = `
+git init
+git config user.email test@example.com
+git config user.name Test
+git commit --allow-empty -m initial
+`
+		cfg.Hooks.BeforeRun = `printf 'prepared\n' > hook-output.txt`
+		ec := newExitCapture()
+
+		RunWorkerAttempt(context.Background(), workerTestIssue(), nil, WorkerDeps{
+			TrackerAdapter:         &mockTrackerAdapter{},
+			AgentAdapter:           &mockAgentAdapter{},
+			ConfigFunc:             func() config.ServiceConfig { return cfg },
+			PromptTemplateByIDFunc: func(_ string) *prompt.Template { return mustParseTemplate(t, "{{ .issue.title }}") },
+			OnEvent:                func(_ string, _ domain.AgentEvent) {},
+			OnExit:                 ec.onExit,
+			Logger:                 discardLogger(),
+		})
+		result := ec.waitResult(t)
+
+		if result.HandoffEvidenceBaseline == nil {
+			t.Fatalf("HandoffEvidenceBaseline is nil; capture error: %v", result.HandoffEvidenceBaselineError)
+		}
+		change, err := workspace.CompareHandoffEvidenceBaseline(context.Background(), result.WorkspacePath, *result.HandoffEvidenceBaseline)
+		if err != nil {
+			t.Fatalf("CompareHandoffEvidenceBaseline: %v", err)
+		}
+		if change.CommitMoved || change.WorktreeChanged {
+			t.Errorf("pre-run hook output counted as agent work: %+v", change)
+		}
+	})
+
+	t.Run("agent start runs after baseline capture", func(t *testing.T) {
+		root := t.TempDir()
+		cfg := defaultWorkerConfig(root)
+		cfg.Agent.MaxTurns = 1
+		cfg.Tracker.HandoffEvidence = config.HandoffEvidenceObserved
+		cfg.Hooks.AfterCreate = `
+git init
+git config user.email test@example.com
+git config user.name Test
+git commit --allow-empty -m initial
+`
+		cfg.Hooks.BeforeRun = `printf 'prepared\n' > hook-output.txt`
+		ec := newExitCapture()
+
+		RunWorkerAttempt(context.Background(), workerTestIssue(), nil, WorkerDeps{
+			TrackerAdapter: &mockTrackerAdapter{},
+			AgentAdapter: &mockAgentAdapter{
+				startSessionFn: func(_ context.Context, params domain.StartSessionParams) (domain.Session, error) {
+					if err := os.WriteFile(filepath.Join(params.WorkspacePath, "hook-output.txt"), []byte("changed by agent start\n"), 0o600); err != nil {
+						t.Fatalf("update hook output: %v", err)
+					}
+					return domain.Session{ID: "sess-1"}, nil
+				},
+			},
+			ConfigFunc:             func() config.ServiceConfig { return cfg },
+			PromptTemplateByIDFunc: func(_ string) *prompt.Template { return mustParseTemplate(t, "{{ .issue.title }}") },
+			OnEvent:                func(_ string, _ domain.AgentEvent) {},
+			OnExit:                 ec.onExit,
+			Logger:                 discardLogger(),
+		})
+		result := ec.waitResult(t)
+
+		if result.HandoffEvidenceBaseline == nil {
+			t.Fatalf("HandoffEvidenceBaseline is nil; capture error: %v", result.HandoffEvidenceBaselineError)
+		}
+		change, err := workspace.CompareHandoffEvidenceBaseline(context.Background(), result.WorkspacePath, *result.HandoffEvidenceBaseline)
+		if err != nil {
+			t.Fatalf("CompareHandoffEvidenceBaseline: %v", err)
+		}
+		if !change.WorktreeChanged {
+			t.Errorf("change = %+v, want StartSession mutation after baseline", change)
+		}
+	})
+
+	t.Run("ensure-only path reaches the same boundary", func(t *testing.T) {
+		root := t.TempDir()
+		issue := workerTestIssue()
+		ensured, err := workspace.Ensure(root, issue.Identifier)
+		if err != nil {
+			t.Fatalf("workspace.Ensure: %v", err)
+		}
+		initGitRepo(t, ensured.Path)
+		cfg := defaultWorkerConfig(root)
+		cfg.Agent.MaxTurns = 1
+		cfg.Tracker.HandoffEvidence = config.HandoffEvidenceObserved
+		ec := newExitCapture()
+
+		RunWorkerAttempt(context.Background(), issue, nil, WorkerDeps{
+			TrackerAdapter: &mockTrackerAdapter{},
+			AgentAdapter: &mockAgentAdapter{
+				startSessionFn: func(_ context.Context, params domain.StartSessionParams) (domain.Session, error) {
+					if err := os.WriteFile(filepath.Join(params.WorkspacePath, "review-output.txt"), []byte("work\n"), 0o600); err != nil {
+						t.Fatalf("write review output: %v", err)
+					}
+					return domain.Session{ID: "sess-1"}, nil
+				},
+			},
+			ConfigFunc:             func() config.ServiceConfig { return cfg },
+			PromptTemplateByIDFunc: func(_ string) *prompt.Template { return mustParseTemplate(t, "{{ .issue.title }}") },
+			OnEvent:                func(_ string, _ domain.AgentEvent) {},
+			OnExit:                 ec.onExit,
+			Logger:                 discardLogger(),
+			Posture:                PostureReview,
+		})
+		result := ec.waitResult(t)
+
+		if result.HandoffEvidenceBaseline == nil {
+			t.Fatalf("HandoffEvidenceBaseline is nil; capture error: %v", result.HandoffEvidenceBaselineError)
+		}
+		change, err := workspace.CompareHandoffEvidenceBaseline(context.Background(), result.WorkspacePath, *result.HandoffEvidenceBaseline)
+		if err != nil {
+			t.Fatalf("CompareHandoffEvidenceBaseline: %v", err)
+		}
+		if !change.WorktreeChanged {
+			t.Errorf("change = %+v, want Ensure-path StartSession mutation", change)
+		}
+	})
+}
+
+func TestRunWorkerAttempt_HandoffEvidencePolicyIsFrozen(t *testing.T) {
+	root := t.TempDir()
+	cfg := defaultWorkerConfig(root)
+	cfg.Agent.MaxTurns = 1
+	cfg.Tracker.HandoffEvidence = config.HandoffEvidenceObserved
+	cfg.Hooks.AfterCreate = `
+git init
+git config user.email test@example.com
+git config user.name Test
+git commit --allow-empty -m initial
+`
+	ec := newExitCapture()
+
+	RunWorkerAttempt(context.Background(), workerTestIssue(), nil, WorkerDeps{
+		TrackerAdapter: &mockTrackerAdapter{},
+		AgentAdapter: &mockAgentAdapter{
+			startSessionFn: func(_ context.Context, _ domain.StartSessionParams) (domain.Session, error) {
+				cfg.Tracker.HandoffEvidence = config.HandoffEvidenceOff
+				return domain.Session{ID: "sess-1"}, nil
+			},
+		},
+		ConfigFunc:             func() config.ServiceConfig { return cfg },
+		PromptTemplateByIDFunc: func(_ string) *prompt.Template { return mustParseTemplate(t, "{{ .issue.title }}") },
+		OnEvent:                func(_ string, _ domain.AgentEvent) {},
+		OnExit:                 ec.onExit,
+		Logger:                 discardLogger(),
+	})
+	result := ec.waitResult(t)
+
+	if got := result.HandoffEvidencePolicy; got != config.HandoffEvidenceObserved {
+		t.Errorf("HandoffEvidencePolicy = %q, want frozen %q", got, config.HandoffEvidenceObserved)
+	}
+	if result.HandoffEvidenceBaseline == nil {
+		t.Fatalf("HandoffEvidenceBaseline is nil; capture error: %v", result.HandoffEvidenceBaselineError)
+	}
+}
+
+func TestRunWorkerAttempt_HandoffEvidenceOffSkipsCapture(t *testing.T) {
+	for _, tt := range []struct {
+		name           string
+		policy         config.HandoffEvidencePolicy
+		wantCaptureErr bool
+	}{
+		{name: "observed attempts capture", policy: config.HandoffEvidenceObserved, wantCaptureErr: true},
+		{name: "off skips capture", policy: config.HandoffEvidenceOff, wantCaptureErr: false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := defaultWorkerConfig(t.TempDir())
+			cfg.Agent.MaxTurns = 1
+			cfg.Tracker.HandoffEvidence = tt.policy
+			ec := newExitCapture()
+
+			RunWorkerAttempt(context.Background(), workerTestIssue(), nil, WorkerDeps{
+				TrackerAdapter:         &mockTrackerAdapter{},
+				AgentAdapter:           &mockAgentAdapter{},
+				ConfigFunc:             func() config.ServiceConfig { return cfg },
+				PromptTemplateByIDFunc: func(_ string) *prompt.Template { return mustParseTemplate(t, "{{ .issue.title }}") },
+				OnEvent:                func(_ string, _ domain.AgentEvent) {},
+				OnExit:                 ec.onExit,
+				Logger:                 discardLogger(),
+			})
+			result := ec.waitResult(t)
+
+			if result.HandoffEvidenceBaseline != nil {
+				t.Errorf("HandoffEvidenceBaseline = %+v, want nil for non-Git workspace", result.HandoffEvidenceBaseline)
+			}
+			if got := result.HandoffEvidenceBaselineError != nil; got != tt.wantCaptureErr {
+				t.Errorf("capture error present = %v, want %v (error: %v)", got, tt.wantCaptureErr, result.HandoffEvidenceBaselineError)
+			}
+		})
+	}
+}
+
+func TestRunWorkerAttempt_AfterRunCommitPushCountsAsHandoffWork(t *testing.T) {
+	root := t.TempDir()
+	remote := filepath.Join(t.TempDir(), "remote.git")
+	runGit(t, filepath.Dir(remote), "init", "--bare", remote)
+	cfg := defaultWorkerConfig(root)
+	cfg.Agent.MaxTurns = 1
+	cfg.Tracker.HandoffEvidence = config.HandoffEvidenceObserved
+	cfg.Hooks.AfterCreate = fmt.Sprintf(`
+git init
+git config user.email test@example.com
+git config user.name Test
+git commit --allow-empty -m initial
+git branch -M main
+git remote add origin %q
+git push -u origin main
+`, remote)
+	cfg.Hooks.AfterRun = `
+git add agent-output.txt
+git commit -m after-run
+git push origin HEAD
+`
+	ec := newExitCapture()
+	var agentWorkspace string
+
+	RunWorkerAttempt(context.Background(), workerTestIssue(), nil, WorkerDeps{
+		TrackerAdapter: &mockTrackerAdapter{},
+		AgentAdapter: &mockAgentAdapter{
+			startSessionFn: func(_ context.Context, params domain.StartSessionParams) (domain.Session, error) {
+				agentWorkspace = params.WorkspacePath
+				return domain.Session{ID: "sess-1"}, nil
+			},
+			runTurnFn: func(_ context.Context, session domain.Session, params domain.RunTurnParams) (domain.TurnResult, error) {
+				if err := os.WriteFile(filepath.Join(agentWorkspace, "agent-output.txt"), []byte("work\n"), 0o600); err != nil {
+					t.Fatalf("write agent output: %v", err)
+				}
+				return domain.TurnResult{SessionID: session.ID, ExitReason: domain.EventTurnCompleted}, nil
+			},
+		},
+		ConfigFunc:             func() config.ServiceConfig { return cfg },
+		PromptTemplateByIDFunc: func(_ string) *prompt.Template { return mustParseTemplate(t, "{{ .issue.title }}") },
+		OnEvent:                func(_ string, _ domain.AgentEvent) {},
+		OnExit:                 ec.onExit,
+		Logger:                 discardLogger(),
+	})
+	result := ec.waitResult(t)
+
+	if result.HandoffEvidenceBaseline == nil {
+		t.Fatalf("HandoffEvidenceBaseline is nil; capture error: %v", result.HandoffEvidenceBaselineError)
+	}
+	if got := strings.TrimSpace(handoffEvidenceGitOutput(t, result.WorkspacePath, "status", "--porcelain")); got != "" {
+		t.Fatalf("workspace is dirty after after_run commit/push: %q", got)
+	}
+	change, err := workspace.CompareHandoffEvidenceBaseline(context.Background(), result.WorkspacePath, *result.HandoffEvidenceBaseline)
+	if err != nil {
+		t.Fatalf("CompareHandoffEvidenceBaseline: %v", err)
+	}
+	if !change.CommitMoved {
+		t.Fatalf("change = %+v, want commit movement from after_run", change)
+	}
+
+	store := &mockExitStore{}
+	tracker := &mockTrackerAdapter{}
+	state := exitStateWithIssue(t, result.IssueID, "To Do")
+	params := handoffEvidenceExitParams(t, store, tracker, &spyMetrics{})
+	params.ActiveStates = []string{"To Do"}
+	HandleWorkerExit(state, result, params)
+	if len(tracker.transitionCalls) != 1 {
+		t.Fatalf("TransitionIssue called %d times, want 1 for clean after_run commit", len(tracker.transitionCalls))
+	}
+}
+
+func handoffEvidenceGitOutput(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, output)
+	}
+	return string(output)
 }
 
 // TestRunWorkerAttempt_MCPConfig covers MCP config generation, which

--- a/internal/orchestrator/worker_test.go
+++ b/internal/orchestrator/worker_test.go
@@ -2444,13 +2444,8 @@ func TestRunWorkerAttempt_HandoffEvidenceBaselineBoundary(t *testing.T) {
 		cfg := defaultWorkerConfig(root)
 		cfg.Agent.MaxTurns = 1
 		cfg.Tracker.HandoffEvidence = config.HandoffEvidenceObserved
-		cfg.Hooks.AfterCreate = `
-git init
-git config user.email test@example.com
-git config user.name Test
-git commit --allow-empty -m initial
-`
-		cfg.Hooks.BeforeRun = `printf 'prepared\n' > hook-output.txt`
+		cfg.Hooks.AfterCreate = "git init && git config user.email test@example.com && git config user.name Test && git commit --allow-empty -m initial"
+		cfg.Hooks.BeforeRun = "echo prepared > hook-output.txt"
 		ec := newExitCapture()
 
 		RunWorkerAttempt(context.Background(), workerTestIssue(), nil, WorkerDeps{
@@ -2481,13 +2476,8 @@ git commit --allow-empty -m initial
 		cfg := defaultWorkerConfig(root)
 		cfg.Agent.MaxTurns = 1
 		cfg.Tracker.HandoffEvidence = config.HandoffEvidenceObserved
-		cfg.Hooks.AfterCreate = `
-git init
-git config user.email test@example.com
-git config user.name Test
-git commit --allow-empty -m initial
-`
-		cfg.Hooks.BeforeRun = `printf 'prepared\n' > hook-output.txt`
+		cfg.Hooks.AfterCreate = "git init && git config user.email test@example.com && git config user.name Test && git commit --allow-empty -m initial"
+		cfg.Hooks.BeforeRun = "echo prepared > hook-output.txt"
 		ec := newExitCapture()
 
 		RunWorkerAttempt(context.Background(), workerTestIssue(), nil, WorkerDeps{
@@ -2570,12 +2560,7 @@ func TestRunWorkerAttempt_HandoffEvidencePolicyIsFrozen(t *testing.T) {
 	cfg := defaultWorkerConfig(root)
 	cfg.Agent.MaxTurns = 1
 	cfg.Tracker.HandoffEvidence = config.HandoffEvidenceObserved
-	cfg.Hooks.AfterCreate = `
-git init
-git config user.email test@example.com
-git config user.name Test
-git commit --allow-empty -m initial
-`
+	cfg.Hooks.AfterCreate = "git init && git config user.email test@example.com && git config user.name Test && git commit --allow-empty -m initial"
 	ec := newExitCapture()
 
 	RunWorkerAttempt(context.Background(), workerTestIssue(), nil, WorkerDeps{
@@ -2645,20 +2630,11 @@ func TestRunWorkerAttempt_AfterRunCommitPushCountsAsHandoffWork(t *testing.T) {
 	cfg := defaultWorkerConfig(root)
 	cfg.Agent.MaxTurns = 1
 	cfg.Tracker.HandoffEvidence = config.HandoffEvidenceObserved
-	cfg.Hooks.AfterCreate = fmt.Sprintf(`
-git init
-git config user.email test@example.com
-git config user.name Test
-git commit --allow-empty -m initial
-git branch -M main
-git remote add origin %q
-git push -u origin main
-`, remote)
-	cfg.Hooks.AfterRun = `
-git add agent-output.txt
-git commit -m after-run
-git push origin HEAD
-`
+	cfg.Hooks.AfterCreate = fmt.Sprintf(
+		"git init && git config user.email test@example.com && git config user.name Test && git commit --allow-empty -m initial && git branch -M main && git remote add origin %q && git push -u origin main",
+		filepath.ToSlash(remote),
+	)
+	cfg.Hooks.AfterRun = "git add agent-output.txt && git commit -m after-run && git push origin HEAD"
 	ec := newExitCapture()
 	var agentWorkspace string
 

--- a/internal/orchestrator/worker_test.go
+++ b/internal/orchestrator/worker_test.go
@@ -2627,18 +2627,24 @@ func TestRunWorkerAttempt_AfterRunCommitPushCountsAsHandoffWork(t *testing.T) {
 	root := t.TempDir()
 	remote := filepath.Join(t.TempDir(), "remote.git")
 	runGit(t, filepath.Dir(remote), "init", "--bare", remote)
+	issue := workerTestIssue()
+	ensured, err := workspace.Ensure(root, issue.Identifier)
+	if err != nil {
+		t.Fatalf("workspace.Ensure: %v", err)
+	}
+	initGitRepo(t, ensured.Path)
+	runGit(t, ensured.Path, "branch", "-M", "main")
+	runGit(t, ensured.Path, "remote", "add", "origin", remote)
+	runGit(t, ensured.Path, "push", "-u", "origin", "main")
+
 	cfg := defaultWorkerConfig(root)
 	cfg.Agent.MaxTurns = 1
 	cfg.Tracker.HandoffEvidence = config.HandoffEvidenceObserved
-	cfg.Hooks.AfterCreate = fmt.Sprintf(
-		"git init && git config user.email test@example.com && git config user.name Test && git commit --allow-empty -m initial && git branch -M main && git remote add origin %q && git push -u origin main",
-		filepath.ToSlash(remote),
-	)
 	cfg.Hooks.AfterRun = "git add agent-output.txt && git commit -m after-run && git push origin HEAD"
 	ec := newExitCapture()
 	var agentWorkspace string
 
-	RunWorkerAttempt(context.Background(), workerTestIssue(), nil, WorkerDeps{
+	RunWorkerAttempt(context.Background(), issue, nil, WorkerDeps{
 		TrackerAdapter: &mockTrackerAdapter{},
 		AgentAdapter: &mockAgentAdapter{
 			startSessionFn: func(_ context.Context, params domain.StartSessionParams) (domain.Session, error) {

--- a/internal/persistence/store_test.go
+++ b/internal/persistence/store_test.go
@@ -2570,6 +2570,41 @@ func TestLoadLatestSuccessfulRunsForReactionRecovery_IgnoresFailedAndEmptyWorksp
 	}
 }
 
+func TestLoadLatestSuccessfulRunsForReactionRecovery_PrefersProducingRunOverLaterFailedRun(t *testing.T) {
+	t.Parallel()
+
+	s := openTestStore(t)
+	migrateOrFatal(t, s)
+	ctx := context.Background()
+	cutoff := recoveryRefTime.Add(-30 * 24 * time.Hour)
+
+	producing := appendRecoveryRun(t, s, "ISS-EVIDENCE", "PROJ-E", 1, recentCompletedAt(2))
+	errorText := "handoff withheld: absence of work observed under observed policy"
+	appendOrFatal(t, s, RunHistory{
+		IssueID:      "ISS-EVIDENCE",
+		Identifier:   "PROJ-E",
+		Attempt:      2,
+		AgentAdapter: "mock",
+		Workspace:    "/ws/PROJ-E",
+		StartedAt:    recentCompletedAt(1),
+		CompletedAt:  recentCompletedAt(1),
+		Status:       "failed",
+		Error:        &errorText,
+	})
+
+	got, err := s.LoadLatestSuccessfulRunsForReactionRecovery(ctx, cutoff, 200)
+	if err != nil {
+		t.Fatalf("LoadLatestSuccessfulRunsForReactionRecovery: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("LoadLatestSuccessfulRunsForReactionRecovery() len = %d, want 1", len(got))
+	}
+	if got[0].ID != producing.ID || got[0].Attempt != producing.Attempt {
+		t.Errorf("recovery run = (id=%d, attempt=%d), want earlier successful run (id=%d, attempt=%d)",
+			got[0].ID, got[0].Attempt, producing.ID, producing.Attempt)
+	}
+}
+
 func TestLoadLatestSuccessfulRunsForReactionRecovery_DisplayIDRoundTrip(t *testing.T) {
 	t.Parallel()
 

--- a/internal/server/metrics_test.go
+++ b/internal/server/metrics_test.go
@@ -357,6 +357,7 @@ func TestPromMetricsCounters(t *testing.T) {
 		m.IncHandoffTransitions("success")
 		m.IncHandoffTransitions("success")
 		m.IncHandoffTransitions("skipped")
+		m.IncHandoffTransitions("withheld")
 
 		families := gatherFamilies(t, m)
 		if got := counterValue(t, families, "sortie_handoff_transitions_total", map[string]string{"result": "success"}); got != 2 {
@@ -364,6 +365,9 @@ func TestPromMetricsCounters(t *testing.T) {
 		}
 		if got := counterValue(t, families, "sortie_handoff_transitions_total", map[string]string{"result": "skipped"}); got != 1 {
 			t.Errorf("sortie_handoff_transitions_total{result=skipped} = %v, want 1", got)
+		}
+		if got := counterValue(t, families, "sortie_handoff_transitions_total", map[string]string{"result": "withheld"}); got != 1 {
+			t.Errorf("sortie_handoff_transitions_total{result=withheld} = %v, want 1", got)
 		}
 	})
 

--- a/internal/workspace/handoff_evidence.go
+++ b/internal/workspace/handoff_evidence.go
@@ -1,0 +1,203 @@
+package workspace
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// ErrNotGitWorkspace identifies a workspace that cannot provide a Git
+// baseline. Callers treat this as an undeterminable evidence verdict rather
+// than as a worker failure.
+var ErrNotGitWorkspace = errors.New("workspace is not a Git work tree")
+
+// HandoffEvidenceBaseline captures the durable Git state immediately before
+// the agent session starts. The working-tree fingerprint excludes Sortie's
+// .sortie control directory; pushed commit and pull-request metadata from that
+// directory is evaluated separately as a positive signal.
+type HandoffEvidenceBaseline struct {
+	Commit              string
+	WorktreeFingerprint [sha256.Size]byte
+}
+
+// HandoffEvidenceChange describes the workspace differences that can
+// independently establish work observed for a run.
+type HandoffEvidenceChange struct {
+	CommitMoved     bool
+	WorktreeChanged bool
+}
+
+// CaptureHandoffEvidenceBaseline inspects a Git workspace without modifying
+// its index or working tree.
+func CaptureHandoffEvidenceBaseline(ctx context.Context, workspacePath string) (HandoffEvidenceBaseline, error) {
+	commit, fingerprint, err := inspectHandoffEvidenceState(ctx, workspacePath)
+	if err != nil {
+		return HandoffEvidenceBaseline{}, err
+	}
+	return HandoffEvidenceBaseline{
+		Commit:              commit,
+		WorktreeFingerprint: fingerprint,
+	}, nil
+}
+
+// CompareHandoffEvidenceBaseline compares the current Git state with the
+// run's frozen baseline.
+func CompareHandoffEvidenceBaseline(ctx context.Context, workspacePath string, baseline HandoffEvidenceBaseline) (HandoffEvidenceChange, error) {
+	commit, fingerprint, err := inspectHandoffEvidenceState(ctx, workspacePath)
+	if err != nil {
+		return HandoffEvidenceChange{}, err
+	}
+	return HandoffEvidenceChange{
+		CommitMoved:     commit != baseline.Commit,
+		WorktreeChanged: fingerprint != baseline.WorktreeFingerprint,
+	}, nil
+}
+
+func inspectHandoffEvidenceState(ctx context.Context, workspacePath string) (string, [sha256.Size]byte, error) {
+	var zero [sha256.Size]byte
+	if workspacePath == "" {
+		return "", zero, fmt.Errorf("workspace path is empty")
+	}
+
+	absPath, err := filepath.Abs(workspacePath)
+	if err != nil {
+		return "", zero, fmt.Errorf("resolve workspace path: %w", err)
+	}
+	absPath, err = filepath.EvalSymlinks(absPath)
+	if err != nil {
+		return "", zero, fmt.Errorf("resolve workspace symlinks: %w", err)
+	}
+
+	inside, err := runGit(ctx, absPath, "rev-parse", "--is-inside-work-tree")
+	if err != nil || strings.TrimSpace(string(inside)) != "true" {
+		return "", zero, ErrNotGitWorkspace
+	}
+
+	topRaw, err := runGit(ctx, absPath, "rev-parse", "--show-toplevel")
+	if err != nil {
+		return "", zero, fmt.Errorf("resolve Git work-tree root: %w", err)
+	}
+	top := filepath.Clean(strings.TrimSpace(string(topRaw)))
+	relWorkspace, err := filepath.Rel(top, absPath)
+	if err != nil || relWorkspace == ".." || strings.HasPrefix(relWorkspace, ".."+string(filepath.Separator)) {
+		return "", zero, fmt.Errorf("workspace %q is outside Git work-tree root %q", absPath, top)
+	}
+
+	commitRaw, commitErr := runGit(ctx, absPath, "rev-parse", "--verify", "--quiet", "HEAD")
+	commit := strings.TrimSpace(string(commitRaw))
+	if commitErr != nil {
+		var exitErr *exec.ExitError
+		if !errors.As(commitErr, &exitErr) || exitErr.ExitCode() != 1 {
+			return "", zero, fmt.Errorf("inspect Git HEAD: %w", commitErr)
+		}
+		commit = ""
+	}
+
+	pathspecs := handoffEvidencePathspecs(relWorkspace)
+	hasher := sha256.New()
+	for _, command := range [][]string{
+		{"status", "--porcelain=v2", "-z", "--untracked-files=all", "--ignored=no", "--"},
+		{"diff", "--binary", "--no-ext-diff", "--no-textconv", "--submodule=diff", "--"},
+		{"diff", "--cached", "--binary", "--no-ext-diff", "--no-textconv", "--submodule=diff", "--"},
+	} {
+		args := append(command, pathspecs...)
+		output, cmdErr := runGit(ctx, absPath, args...)
+		if cmdErr != nil {
+			return "", zero, fmt.Errorf("inspect Git working tree: %w", cmdErr)
+		}
+		writeFingerprintPart(hasher, output)
+	}
+
+	untrackedArgs := append([]string{"ls-files", "--others", "--exclude-standard", "-z", "--full-name", "--"}, pathspecs...)
+	untrackedRaw, err := runGit(ctx, absPath, untrackedArgs...)
+	if err != nil {
+		return "", zero, fmt.Errorf("list untracked files: %w", err)
+	}
+	for pathBytes := range bytes.SplitSeq(untrackedRaw, []byte{0}) {
+		if len(pathBytes) == 0 {
+			continue
+		}
+		relPath := string(pathBytes)
+		writeFingerprintPart(hasher, pathBytes)
+		if err := hashUntrackedFile(hasher, filepath.Join(top, filepath.FromSlash(relPath))); err != nil {
+			return "", zero, fmt.Errorf("inspect untracked file %q: %w", relPath, err)
+		}
+	}
+
+	var fingerprint [sha256.Size]byte
+	copy(fingerprint[:], hasher.Sum(nil))
+	return commit, fingerprint, nil
+}
+
+func handoffEvidencePathspecs(relWorkspace string) []string {
+	relWorkspace = filepath.ToSlash(filepath.Clean(relWorkspace))
+	dotSortie := ".sortie"
+	if relWorkspace != "." {
+		dotSortie = relWorkspace + "/.sortie"
+	}
+	return []string{
+		".",
+		":(top,exclude)" + dotSortie,
+		":(top,exclude)" + dotSortie + "/**",
+	}
+}
+
+func writeFingerprintPart(dst io.Writer, value []byte) {
+	_, _ = fmt.Fprintf(dst, "%d:", len(value))
+	_, _ = dst.Write(value)
+}
+
+func hashUntrackedFile(dst io.Writer, path string) error {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return err
+	}
+	writeFingerprintPart(dst, []byte(info.Mode().String()))
+
+	switch {
+	case info.Mode().IsRegular():
+		file, err := os.Open(path) //nolint:gosec // path comes from git ls-files under the inspected work tree
+		if err != nil {
+			return err
+		}
+		defer func() { _ = file.Close() }()
+		_, _ = fmt.Fprintf(dst, "%d:", info.Size())
+		if _, err := io.Copy(dst, file); err != nil {
+			return err
+		}
+		return nil
+	case info.Mode()&os.ModeSymlink != 0:
+		target, err := os.Readlink(path)
+		if err != nil {
+			return err
+		}
+		writeFingerprintPart(dst, []byte(target))
+		return nil
+	default:
+		return fmt.Errorf("unsupported file mode %s", info.Mode())
+	}
+}
+
+func runGit(ctx context.Context, dir string, args ...string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, "git", args...) //nolint:gosec // executable is the fixed git binary; only its argument vector varies
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(), "GIT_OPTIONAL_LOCKS=0")
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	output, err := cmd.Output()
+	if err != nil {
+		message := strings.TrimSpace(stderr.String())
+		if message != "" {
+			return output, fmt.Errorf("git %s: %s: %w", args[0], message, err)
+		}
+		return output, fmt.Errorf("git %s: %w", args[0], err)
+	}
+	return output, nil
+}

--- a/internal/workspace/handoff_evidence_test.go
+++ b/internal/workspace/handoff_evidence_test.go
@@ -1,0 +1,178 @@
+package workspace
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+func handoffEvidenceGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, output)
+	}
+}
+
+func newHandoffEvidenceGitWorkspace(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	handoffEvidenceGit(t, dir, "init")
+	handoffEvidenceGit(t, dir, "config", "user.name", "Sortie Test")
+	handoffEvidenceGit(t, dir, "config", "user.email", "sortie@example.test")
+	if err := os.WriteFile(filepath.Join(dir, "tracked.txt"), []byte("initial\n"), 0o600); err != nil {
+		t.Fatalf("write tracked file: %v", err)
+	}
+	handoffEvidenceGit(t, dir, "add", "tracked.txt")
+	handoffEvidenceGit(t, dir, "commit", "-m", "initial")
+	return dir
+}
+
+func TestHandoffEvidenceBaselineNoChange(t *testing.T) {
+	dir := newHandoffEvidenceGitWorkspace(t)
+	baseline, err := CaptureHandoffEvidenceBaseline(context.Background(), dir)
+	if err != nil {
+		t.Fatalf("CaptureHandoffEvidenceBaseline: %v", err)
+	}
+
+	change, err := CompareHandoffEvidenceBaseline(context.Background(), dir, baseline)
+	if err != nil {
+		t.Fatalf("CompareHandoffEvidenceBaseline: %v", err)
+	}
+	if change.CommitMoved || change.WorktreeChanged {
+		t.Errorf("change = %+v, want no change", change)
+	}
+}
+
+func TestHandoffEvidenceDetectsCommitMovement(t *testing.T) {
+	dir := newHandoffEvidenceGitWorkspace(t)
+	baseline, err := CaptureHandoffEvidenceBaseline(context.Background(), dir)
+	if err != nil {
+		t.Fatalf("CaptureHandoffEvidenceBaseline: %v", err)
+	}
+
+	if err := os.WriteFile(filepath.Join(dir, "tracked.txt"), []byte("committed\n"), 0o600); err != nil {
+		t.Fatalf("write tracked file: %v", err)
+	}
+	handoffEvidenceGit(t, dir, "add", "tracked.txt")
+	handoffEvidenceGit(t, dir, "commit", "-m", "work")
+
+	change, err := CompareHandoffEvidenceBaseline(context.Background(), dir, baseline)
+	if err != nil {
+		t.Fatalf("CompareHandoffEvidenceBaseline: %v", err)
+	}
+	if !change.CommitMoved {
+		t.Errorf("change = %+v, want CommitMoved", change)
+	}
+	if change.WorktreeChanged {
+		t.Errorf("change = %+v, clean tree should retain its clean-tree fingerprint", change)
+	}
+}
+
+func TestHandoffEvidenceDetectsWorkingTreeChange(t *testing.T) {
+	dir := newHandoffEvidenceGitWorkspace(t)
+	baseline, err := CaptureHandoffEvidenceBaseline(context.Background(), dir)
+	if err != nil {
+		t.Fatalf("CaptureHandoffEvidenceBaseline: %v", err)
+	}
+
+	if err := os.WriteFile(filepath.Join(dir, "tracked.txt"), []byte("modified\n"), 0o600); err != nil {
+		t.Fatalf("write tracked file: %v", err)
+	}
+	change, err := CompareHandoffEvidenceBaseline(context.Background(), dir, baseline)
+	if err != nil {
+		t.Fatalf("CompareHandoffEvidenceBaseline: %v", err)
+	}
+	if !change.WorktreeChanged {
+		t.Errorf("change = %+v, want WorktreeChanged", change)
+	}
+}
+
+func TestHandoffEvidencePreexistingDirtyTreeNeedsFurtherChange(t *testing.T) {
+	dir := newHandoffEvidenceGitWorkspace(t)
+	path := filepath.Join(dir, "tracked.txt")
+	if err := os.WriteFile(path, []byte("dirty before run\n"), 0o600); err != nil {
+		t.Fatalf("write preexisting dirty file: %v", err)
+	}
+	baseline, err := CaptureHandoffEvidenceBaseline(context.Background(), dir)
+	if err != nil {
+		t.Fatalf("CaptureHandoffEvidenceBaseline: %v", err)
+	}
+
+	unchanged, err := CompareHandoffEvidenceBaseline(context.Background(), dir, baseline)
+	if err != nil {
+		t.Fatalf("CompareHandoffEvidenceBaseline unchanged: %v", err)
+	}
+	if unchanged.CommitMoved || unchanged.WorktreeChanged {
+		t.Errorf("unchanged dirty tree = %+v, want no run-local change", unchanged)
+	}
+
+	if err := os.WriteFile(path, []byte("dirty and changed during run\n"), 0o600); err != nil {
+		t.Fatalf("update dirty file: %v", err)
+	}
+	changed, err := CompareHandoffEvidenceBaseline(context.Background(), dir, baseline)
+	if err != nil {
+		t.Fatalf("CompareHandoffEvidenceBaseline changed: %v", err)
+	}
+	if !changed.WorktreeChanged {
+		t.Errorf("changed dirty tree = %+v, want WorktreeChanged", changed)
+	}
+}
+
+func TestHandoffEvidenceDetectsUntrackedContentChange(t *testing.T) {
+	dir := newHandoffEvidenceGitWorkspace(t)
+	path := filepath.Join(dir, "untracked.txt")
+	if err := os.WriteFile(path, []byte("before\n"), 0o600); err != nil {
+		t.Fatalf("write untracked file: %v", err)
+	}
+	baseline, err := CaptureHandoffEvidenceBaseline(context.Background(), dir)
+	if err != nil {
+		t.Fatalf("CaptureHandoffEvidenceBaseline: %v", err)
+	}
+	if err := os.WriteFile(path, []byte("after\n"), 0o600); err != nil {
+		t.Fatalf("update untracked file: %v", err)
+	}
+
+	change, err := CompareHandoffEvidenceBaseline(context.Background(), dir, baseline)
+	if err != nil {
+		t.Fatalf("CompareHandoffEvidenceBaseline: %v", err)
+	}
+	if !change.WorktreeChanged {
+		t.Errorf("change = %+v, want WorktreeChanged", change)
+	}
+}
+
+func TestHandoffEvidenceExcludesSortieControlFiles(t *testing.T) {
+	dir := newHandoffEvidenceGitWorkspace(t)
+	baseline, err := CaptureHandoffEvidenceBaseline(context.Background(), dir)
+	if err != nil {
+		t.Fatalf("CaptureHandoffEvidenceBaseline: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, ".sortie"), 0o700); err != nil {
+		t.Fatalf("create .sortie: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".sortie", "state.json"), []byte(`{"turn":1}`), 0o600); err != nil {
+		t.Fatalf("write control file: %v", err)
+	}
+
+	change, err := CompareHandoffEvidenceBaseline(context.Background(), dir, baseline)
+	if err != nil {
+		t.Fatalf("CompareHandoffEvidenceBaseline: %v", err)
+	}
+	if change.CommitMoved || change.WorktreeChanged {
+		t.Errorf("change = %+v, want .sortie control files excluded", change)
+	}
+}
+
+func TestHandoffEvidenceNonGitWorkspace(t *testing.T) {
+	dir := t.TempDir()
+	_, err := CaptureHandoffEvidenceBaseline(context.Background(), dir)
+	if !errors.Is(err, ErrNotGitWorkspace) {
+		t.Fatalf("CaptureHandoffEvidenceBaseline error = %v, want ErrNotGitWorkspace", err)
+	}
+}


### PR DESCRIPTION
### Scope & Context

**Type:** Feat

**Intent:** Prevent an otherwise successful run from handing an active issue off when the orchestrator can positively observe that the run produced no work. The default remains permissive when evidence cannot be determined, while `strict` and `off` provide explicit fail-closed and legacy behavior.

**Related Issues:** Closes https://github.com/sortie-ai/sortie/issues/768

This intentionally does not implement the consecutive-absence counter and parking behavior from https://github.com/sortie-ai/sortie/issues/769 or the public documentation from https://github.com/sortie-ai/sortie/issues/770.

### Reviewer Guide

**Complexity:** High

#### Entry Point

Start with `internal/orchestrator/exit.go`. It applies the frozen evidence policy only after the four existing handoff conditions hold, changes a withheld run to the failed disposition before run-history persistence, and routes it through ordinary exponential backoff rather than the continuation path.

#### Sensitive Areas

- `internal/workspace/handoff_evidence.go`: captures and compares the Git commit and a content-sensitive working-tree fingerprint while excluding Sortie's `.sortie` control directory.
- `internal/orchestrator/worker.go`: freezes the policy and captures the baseline after workspace preparation and pre-run hooks, immediately before `StartSession`.
- `internal/orchestrator/handoff_evidence.go`: combines workspace differences with existing pushed-commit or pull-request metadata into the three evidence verdicts.
- `internal/persistence/store_test.go`: confirms that a later withheld run recorded as failed does not displace the latest successful run used for reaction recovery.

### Risk Assessment

- **Breaking Changes:** The default `observed` policy intentionally changes otherwise-eligible no-output Git runs: they remain active and retry instead of transitioning to the handoff state. `off` preserves the previous behavior.
- **Migrations/State:** No migrations or new persisted verdict field. Withheld runs use the existing `failed` status and `error` field.

### Validation

- Targeted race tests for configuration, offline validation, workspace evidence, worker boundaries, exit disposition, reaction recovery, and metrics
- `make fmt`
- `make lint` — 0 issues
- `make build`
- `git diff --check`

The full `make test` run was not completely green locally. The new handoff-evidence tests passed; unchanged macOS workspace cases still fail on `/var` versus `/private/var` resolution and `/bin/sh` handling of `echo -n`, which also reproduce on the untouched main checkout. Copilot and Kiro canary processes were killed during the full parallel race run but pass when run separately.
