### PR TITLE
fix(orchestrator): route review outcomes through the verdict file

### DIFF
--- a/docs/architecture/22-test-and-validation-matrix.md
+++ b/docs/architecture/22-test-and-validation-matrix.md
@@ -273,6 +273,16 @@ Unless otherwise noted, Sections 17.1 through 17.7 are `Core Conformance`. Bulle
 - Missing verdict treated as iterate (non-final) / pass (final)
 - Verification command timeout does not block remaining commands
 - Review progress visible in runtime snapshot via selfReviewCh
+- Self-review is admitted from the agent's completion signal (`needs-human-review`), not only
+  from turn-budget exhaustion
+- A `blocked` signal skips self-review and remains an immediate exit, without entering the phase
+- The status file is removed on admission so self-review does not re-observe the signal that
+  admitted it
+- A `needs-human-review` signal read inside self-review is consumed and does not abort the loop
+- A `blocked` signal read inside self-review aborts the phase, and becomes the run's exit reason
+  on a run the completion signal admitted
+- A deployment with self-review disabled treats the completion signal exactly as before, ending
+  the run without entering the phase
 - On an SCM platform that exposes no bot-account marker, a `CHANGES_REQUESTED` review whose author
   matches the operator-configured `bot_usernames` allowlist does not trigger the human
   `review_comments` reaction

--- a/internal/orchestrator/self_review.go
+++ b/internal/orchestrator/self_review.go
@@ -326,7 +326,12 @@ func assembleReviewPrompt(issue domain.Issue, diff string, truncated bool, vresu
 	sb.WriteString("```\n\n")
 	sb.WriteString("Use \"pass\" when the changes are correct and verification passes. Use \"iterate\" when\n")
 	sb.WriteString("issues need to be fixed. On \"iterate\", the orchestrator will give you another turn to\n")
-	sb.WriteString("fix the identified issues.\n")
+	sb.WriteString("fix the identified issues.\n\n")
+	sb.WriteString("4. During this review phase, report your outcome through `.sortie/review_verdict.json`,\n")
+	sb.WriteString("not through `.sortie/status`. Writing \"needs-human-review\" to `.sortie/status` here\n")
+	sb.WriteString("does not end the phase and does not substitute for a verdict. `blocked` remains\n")
+	sb.WriteString("available and still ends the phase — use it when you genuinely cannot carry this\n")
+	sb.WriteString("work further.\n")
 
 	return sb.String()
 }

--- a/internal/orchestrator/self_review_test.go
+++ b/internal/orchestrator/self_review_test.go
@@ -518,6 +518,28 @@ func TestAssembleReviewPrompt_PreviousFeedback(t *testing.T) {
 	}
 }
 
+func TestAssembleReviewPrompt_StatusFileInstruction(t *testing.T) {
+	t.Parallel()
+
+	issue := domain.Issue{ID: "ISS-1", Title: "Fix"}
+	prompt := assembleReviewPrompt(issue, "", false, nil, 1, 3)
+
+	checks := []struct {
+		label string
+		want  string
+	}{
+		{"verdict file over status file", "report your outcome through `.sortie/review_verdict.json`"},
+		{"status file does not end the phase", "does not end the phase and does not substitute for a verdict"},
+		{"blocked remains available", "`blocked` remains"},
+		{"blocked still ends the phase", "still ends the phase"},
+	}
+	for _, c := range checks {
+		if !strings.Contains(prompt, c.want) {
+			t.Errorf("prompt missing %s (%q); prompt = %q", c.label, c.want, prompt)
+		}
+	}
+}
+
 // --- buildFixPrompt tests ---
 
 func TestBuildFixPrompt_WithIssues(t *testing.T) {


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Fix

**Intent:** The first turn of every run tells the agent to write `needs-human-review` to `.sortie/status` when its work is complete. Inside the self-review phase that value is now consumed and the loop continues, so an agent that goes on signalling completion there writes no verdict and burns iterations up to `max_iterations`. The review prompt already named `.sortie/review_verdict.json` as the place to write the verdict, but said nothing about the status file, so the agent had no way to know the two channels differ during the phase.

Also backfills the test and validation matrix, which never gained entries for the completion-signal admission that shipped in #854.

### 🧭 Reviewer Guide

**Complexity:** Low

#### Entry Point

`internal/orchestrator/self_review.go` - `assembleReviewPrompt` gains a fourth numbered instruction: report through `.sortie/review_verdict.json`, a `.sortie/status` write during this phase neither ends the phase nor substitutes for a verdict, and `blocked` remains available and still ends the phase.

`docs/architecture/22-test-and-validation-matrix.md` - six bullets covering admission from the completion signal, `blocked` skipping the phase, removal of the status file on admission, in-phase consumption of the signal, and the unchanged behavior of a deployment with self-review disabled. Each is backed by a test that already exists on `main`.

#### Sensitive Areas

- `internal/orchestrator/self_review.go`: prompt text sent to the agent mid-run. The instruction must not read as a blanket ban on writing `.sortie/status` during the phase, since `blocked` is the agent's only channel for reporting that further work is pointless.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes. No control flow, status-file handling, or exit disposition is touched.
- **Migrations/State:** No migrations or state changes.
