### PR TITLE
fix(orchestrator): bound consecutive handoff absences

### DIFF
--- a/internal/orchestrator/exit.go
+++ b/internal/orchestrator/exit.go
@@ -35,6 +35,8 @@ type WorkerExitStore interface {
 	UpsertAggregateMetrics(ctx context.Context, metrics persistence.AggregateMetrics) error
 	UpsertSessionMetadata(ctx context.Context, meta persistence.SessionMetadata) error
 	SaveRetryEntry(ctx context.Context, entry persistence.RetryEntry) error
+	DeleteRetryEntry(ctx context.Context, issueID string) error
+	QueryConsecutiveHandoffAbsenceCounts(ctx context.Context, issueIDs []string) (map[string]int, error)
 }
 
 // HandleWorkerExitParams holds the dependencies for [HandleWorkerExit] that
@@ -49,6 +51,15 @@ type HandleWorkerExitParams struct {
 	// MaxRetryBackoffMS is the configured cap for exponential backoff
 	// delay (from config.Agent.MaxRetryBackoffMS).
 	MaxRetryBackoffMS int
+
+	// MaxSessions supplies the consecutive handoff-absence ceiling when
+	// positive. Zero derives the safety default of three while remaining
+	// unlimited for the ordinary all-session budget.
+	MaxSessions int
+
+	// HandoffParkingLabel is the review-comments escalation label captured
+	// at orchestrator construction. Empty falls back to "needs-human".
+	HandoffParkingLabel string
 
 	// OnRetryFire is the callback invoked when the scheduled retry
 	// timer expires. The orchestrator provides this; it routes the
@@ -309,13 +320,12 @@ func HandleWorkerExit(state *State, workerResult WorkerResult, params HandleWork
 			evidenceWithheld = handoffEvidenceWithholds(policy, evidenceResult)
 			if evidenceWithheld {
 				evidenceErr = handoffEvidenceFailure(policy, evidenceResult)
-				log.Warn("handoff withheld by evidence policy",
-					slog.String("policy", string(policy)),
-					slog.String("verdict", string(evidenceResult.Verdict)),
-					slog.String("reason", evidenceResult.Reason),
-					slog.Int("turns_completed", workerResult.TurnsCompleted),
-				)
 				metrics.IncHandoffTransitions(handoffWithheld)
+			} else if evidenceResult.Verdict == handoffWorkObserved {
+				// A positive verdict resets the runtime gate immediately. The
+				// successful run_history row below supplies the durable reset even
+				// when the later tracker handoff write fails.
+				clearHandoffAbsenceGate(state, workerResult.IssueID)
 			}
 		}
 	}
@@ -370,10 +380,60 @@ func HandleWorkerExit(state *State, workerResult WorkerResult, params HandleWork
 			runHistory.ReviewMetadata = &s
 		}
 	}
+	runHistoryPersisted := true
 	if _, err := params.Store.AppendRunHistory(ctx, runHistory); err != nil {
+		runHistoryPersisted = false
 		log.Error("failed to persist run history",
 			slog.Any("error", err),
 		)
+	}
+
+	consecutiveAbsences := 0
+	absenceCeiling := handoffAbsenceCeiling(params.MaxSessions)
+	absenceParked := false
+	if evidenceWithheld {
+		counts, countErr := params.Store.QueryConsecutiveHandoffAbsenceCounts(ctx, []string{workerResult.IssueID})
+		if countErr != nil {
+			// The retry attempt is a conservative fallback when SQLite cannot
+			// answer. It may include other failure attempts, which can only stop
+			// sooner; it cannot reopen an otherwise exhausted loop.
+			consecutiveAbsences = NextAttempt(entry.RetryAttempt)
+			log.Warn("handoff absence count query failed, using retry attempt fallback",
+				slog.Int("consecutive_absences", consecutiveAbsences),
+				slog.Any("error", countErr),
+			)
+		} else {
+			consecutiveAbsences = counts[workerResult.IssueID]
+			if !runHistoryPersisted {
+				consecutiveAbsences++
+			}
+			if consecutiveAbsences == 0 {
+				consecutiveAbsences = 1
+			}
+		}
+
+		log.Warn("handoff withheld by evidence policy",
+			slog.String("policy", string(workerResult.HandoffEvidencePolicy.Effective())),
+			slog.String("verdict", string(evidenceResult.Verdict)),
+			slog.String("reason", evidenceResult.Reason),
+			slog.Int("turns_completed", workerResult.TurnsCompleted),
+			slog.Int("consecutive_absences", consecutiveAbsences),
+		)
+
+		if consecutiveAbsences >= absenceCeiling {
+			parkHandoffAbsence(
+				state,
+				ctx,
+				params.Store,
+				params.TrackerAdapter,
+				workerResult.IssueID,
+				consecutiveAbsences,
+				absenceCeiling,
+				params.HandoffParkingLabel,
+				log,
+			)
+			absenceParked = true
+		}
 	}
 
 	aggMetrics := persistence.AggregateMetrics{
@@ -468,6 +528,10 @@ func HandleWorkerExit(state *State, workerResult WorkerResult, params HandleWork
 			terminalSuppressed = true
 			CancelRetry(state, workerResult.IssueID)
 			delete(state.Claimed, workerResult.IssueID)
+
+		case handoffPath && evidenceWithheld && absenceParked:
+			// Parking already cancelled the sequence, deleted any persisted
+			// retry, released the claim, and installed the durable runtime gate.
 
 		case handoffPath && evidenceWithheld:
 			// A withheld handoff is an unsuccessful run disposition even though

--- a/internal/orchestrator/exit_test.go
+++ b/internal/orchestrator/exit_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -28,11 +29,14 @@ type mockExitStore struct {
 	metrics         []persistence.AggregateMetrics
 	sessionMetadata []persistence.SessionMetadata
 	retryEntries    []persistence.RetryEntry
+	deletedRetryIDs []string
 
 	appendRunHistoryErr       error
 	upsertAggregateMetricsErr error
 	upsertSessionMetadataErr  error
 	saveRetryEntryErr         error
+	deleteRetryEntryErr       error
+	absenceCountErr           error
 }
 
 var _ WorkerExitStore = (*mockExitStore)(nil)
@@ -54,6 +58,32 @@ func (m *mockExitStore) UpsertAggregateMetrics(_ context.Context, metrics persis
 func (m *mockExitStore) SaveRetryEntry(_ context.Context, entry persistence.RetryEntry) error {
 	m.retryEntries = append(m.retryEntries, entry)
 	return m.saveRetryEntryErr
+}
+
+func (m *mockExitStore) DeleteRetryEntry(_ context.Context, issueID string) error {
+	m.deletedRetryIDs = append(m.deletedRetryIDs, issueID)
+	return m.deleteRetryEntryErr
+}
+
+func (m *mockExitStore) QueryConsecutiveHandoffAbsenceCounts(_ context.Context, issueIDs []string) (map[string]int, error) {
+	if m.absenceCountErr != nil {
+		return nil, m.absenceCountErr
+	}
+	counts := make(map[string]int, len(issueIDs))
+	for _, issueID := range issueIDs {
+		for _, run := range slices.Backward(m.runHistories) {
+			if run.IssueID != issueID {
+				continue
+			}
+			if run.Status == "succeeded" {
+				break
+			}
+			if run.Status == "failed" && run.Error != nil && strings.HasPrefix(*run.Error, persistence.HandoffAbsenceErrorPrefix) {
+				counts[issueID]++
+			}
+		}
+	}
+	return counts, nil
 }
 
 func (m *mockExitStore) UpsertSessionMetadata(_ context.Context, meta persistence.SessionMetadata) error {

--- a/internal/orchestrator/handoff_absence.go
+++ b/internal/orchestrator/handoff_absence.go
@@ -1,0 +1,113 @@
+package orchestrator
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/sortie-ai/sortie/internal/config"
+	"github.com/sortie-ai/sortie/internal/domain"
+)
+
+const (
+	defaultHandoffAbsenceCeiling = 3
+	defaultHandoffParkingLabel   = "needs-human"
+	reviewCommentsConfigKey      = "review_comments"
+)
+
+// handoffAbsenceStore is the persistence surface shared by worker exit,
+// retry firing, and ordinary polling. The run-history query is the durable
+// eligibility gate; deleting the retry row stops a recovered timer from
+// competing with that gate.
+type handoffAbsenceStore interface {
+	DeleteRetryEntry(ctx context.Context, issueID string) error
+	QueryConsecutiveHandoffAbsenceCounts(ctx context.Context, issueIDs []string) (map[string]int, error)
+}
+
+func handoffAbsenceCeiling(maxSessions int) int {
+	if maxSessions > 0 {
+		return maxSessions
+	}
+	return defaultHandoffAbsenceCeiling
+}
+
+// resolveHandoffParkingLabel captures only the review-comments escalation
+// label name. The reaction need not be active and its escalation action does
+// not participate in primary-dispatch parking.
+func resolveHandoffParkingLabel(reactions map[string]config.ReactionConfig) string {
+	if review, ok := reactions[reviewCommentsConfigKey]; ok && review.EscalationLabel != "" {
+		return review.EscalationLabel
+	}
+	return defaultHandoffParkingLabel
+}
+
+func clearHandoffAbsenceGate(state *State, issueID string) {
+	if state.BudgetExhaustedReason[issueID] != budgetReasonHandoffAbsence {
+		return
+	}
+	delete(state.BudgetExhausted, issueID)
+	delete(state.BudgetExhaustedReason, issueID)
+}
+
+// parkHandoffAbsence stops all queued work for the issue, records the durable
+// runtime gate, releases the claim, and applies the operator's captured human
+// parking label. The label write is best-effort: failure is logged but never
+// reopens dispatch eligibility.
+func parkHandoffAbsence(
+	state *State,
+	ctx context.Context,
+	store handoffAbsenceStore,
+	tracker domain.TrackerAdapter,
+	issueID string,
+	count int,
+	ceiling int,
+	label string,
+	log *slog.Logger,
+) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if log == nil {
+		log = slog.Default()
+	}
+	if label == "" {
+		label = defaultHandoffParkingLabel
+	}
+
+	CancelRetry(state, issueID)
+	delete(state.Claimed, issueID)
+	state.BudgetExhausted[issueID] = struct{}{}
+	state.BudgetExhaustedReason[issueID] = budgetReasonHandoffAbsence
+
+	if err := store.DeleteRetryEntry(ctx, issueID); err != nil {
+		log.Error("failed to delete retry entry after handoff absence parking",
+			slog.Any("error", err),
+		)
+	}
+
+	log.Warn("handoff absence ceiling reached, parking issue",
+		slog.Int("consecutive_absences", count),
+		slog.Int("absence_ceiling", ceiling),
+		slog.String("escalation_label", label),
+	)
+
+	if tracker == nil {
+		log.Warn("handoff absence escalation label failed",
+			slog.String("escalation_label", label),
+			slog.String("reason", "tracker adapter is nil"),
+		)
+		return
+	}
+
+	state.TrackerOpsWg.Go(func() {
+		dctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
+		defer cancel()
+
+		if err := tracker.AddLabel(dctx, issueID, label); err != nil {
+			log.Warn("handoff absence escalation label failed",
+				slog.String("escalation_label", label),
+				slog.Any("error", err),
+			)
+		}
+	})
+}

--- a/internal/orchestrator/handoff_absence_test.go
+++ b/internal/orchestrator/handoff_absence_test.go
@@ -1,0 +1,361 @@
+package orchestrator
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/sortie-ai/sortie/internal/config"
+	"github.com/sortie-ai/sortie/internal/domain"
+	"github.com/sortie-ai/sortie/internal/persistence"
+)
+
+type handoffLabelCall struct {
+	issueID string
+	label   string
+}
+
+type recordingHandoffTracker struct {
+	*mockTrackerAdapter
+	mu          sync.Mutex
+	labelCalls  []handoffLabelCall
+	addLabelErr error
+}
+
+func newRecordingHandoffTracker() *recordingHandoffTracker {
+	return &recordingHandoffTracker{mockTrackerAdapter: &mockTrackerAdapter{}}
+}
+
+func (t *recordingHandoffTracker) AddLabel(_ context.Context, issueID, label string) error {
+	t.mu.Lock()
+	t.labelCalls = append(t.labelCalls, handoffLabelCall{issueID: issueID, label: label})
+	t.mu.Unlock()
+	return t.addLabelErr
+}
+
+func (t *recordingHandoffTracker) labels() []handoffLabelCall {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return append([]handoffLabelCall(nil), t.labelCalls...)
+}
+
+func seedMockHandoffAbsences(store *mockExitStore, issueID string, count int) {
+	for range count {
+		errText := persistence.HandoffAbsenceErrorPrefix + "absence of work observed under observed policy"
+		store.runHistories = append(store.runHistories, persistence.RunHistory{
+			IssueID: issueID,
+			Status:  "failed",
+			Error:   &errText,
+		})
+	}
+}
+
+func TestResolveHandoffParkingLabel(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		reactions map[string]config.ReactionConfig
+		want      string
+	}{
+		{name: "missing review reaction", want: "needs-human"},
+		{
+			name: "disabled review reaction still supplies label",
+			reactions: map[string]config.ReactionConfig{
+				reviewCommentsConfigKey: {Provider: "", Escalation: "comment", EscalationLabel: "human-queue"},
+			},
+			want: "human-queue",
+		},
+		{
+			name: "empty review label falls back",
+			reactions: map[string]config.ReactionConfig{
+				reviewCommentsConfigKey: {EscalationLabel: ""},
+			},
+			want: "needs-human",
+		},
+		{
+			name: "other reaction label is ignored",
+			reactions: map[string]config.ReactionConfig{
+				"ci_failure": {EscalationLabel: "ci-human"},
+			},
+			want: "needs-human",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := resolveHandoffParkingLabel(tt.reactions); got != tt.want {
+				t.Errorf("resolveHandoffParkingLabel() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHandleWorkerExitParksAtHandoffAbsenceCeiling(t *testing.T) {
+	tests := []struct {
+		name             string
+		maxSessions      int
+		priorAbsences    int
+		wantCeiling      int
+		configuredLabel  string
+		wantAppliedLabel string
+	}{
+		{
+			name:             "positive max_sessions is the exact ceiling",
+			maxSessions:      2,
+			priorAbsences:    1,
+			wantCeiling:      2,
+			configuredLabel:  "manual-review",
+			wantAppliedLabel: "manual-review",
+		},
+		{
+			name:             "zero max_sessions derives three total absences",
+			maxSessions:      0,
+			priorAbsences:    2,
+			wantCeiling:      3,
+			configuredLabel:  "",
+			wantAppliedLabel: "needs-human",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			const issueID = "ABS-PARK"
+			dir, baseline := handoffEvidenceGitWorkspace(t)
+			store := &mockExitStore{}
+			seedMockHandoffAbsences(store, issueID, tt.priorAbsences)
+			tracker := newRecordingHandoffTracker()
+			state := exitStateWithIssue(t, issueID, "In Progress")
+			params := handoffEvidenceExitParams(t, store, tracker.mockTrackerAdapter, &spyMetrics{})
+			params.TrackerAdapter = tracker
+			params.MaxSessions = tt.maxSessions
+			params.HandoffParkingLabel = tt.configuredLabel
+			var logs bytes.Buffer
+			params.Logger = debugLogger(t, &logs)
+
+			HandleWorkerExit(state, WorkerResult{
+				IssueID:                 issueID,
+				Identifier:              "PROJ-769",
+				ExitKind:                WorkerExitNormal,
+				WorkspacePath:           dir,
+				HandoffEvidencePolicy:   config.HandoffEvidenceObserved,
+				HandoffEvidenceBaseline: baseline,
+				AgentAdapter:            "mock",
+			}, params)
+			state.TrackerOpsWg.Wait()
+
+			if len(tracker.transitionCalls) != 0 {
+				t.Errorf("TransitionIssue calls = %d, want 0", len(tracker.transitionCalls))
+			}
+			if _, ok := state.Claimed[issueID]; ok {
+				t.Error("claim remains after parking")
+			}
+			if _, ok := state.RetryAttempts[issueID]; ok {
+				t.Error("retry remains after parking")
+			}
+			if _, ok := state.BudgetExhausted[issueID]; !ok {
+				t.Error("durable dispatch gate missing after parking")
+			}
+			if got := state.BudgetExhaustedReason[issueID]; got != budgetReasonHandoffAbsence {
+				t.Errorf("BudgetExhaustedReason = %q, want %q", got, budgetReasonHandoffAbsence)
+			}
+			calls := tracker.labels()
+			if len(calls) != 1 || calls[0].issueID != issueID || calls[0].label != tt.wantAppliedLabel {
+				t.Errorf("AddLabel calls = %+v, want one %q call", calls, tt.wantAppliedLabel)
+			}
+			if len(store.deletedRetryIDs) != 1 || store.deletedRetryIDs[0] != issueID {
+				t.Errorf("DeleteRetryEntry calls = %v, want [%s]", store.deletedRetryIDs, issueID)
+			}
+			for _, want := range []string{
+				"issue_id=" + issueID,
+				"consecutive_absences=" + strconv.Itoa(tt.wantCeiling),
+				"absence_ceiling=" + strconv.Itoa(tt.wantCeiling),
+				`escalation_label=` + tt.wantAppliedLabel,
+			} {
+				if !strings.Contains(logs.String(), want) {
+					t.Errorf("parking log missing %q\nlogs: %s", want, logs.String())
+				}
+			}
+		})
+	}
+}
+
+func TestHandleWorkerExitDefaultCeilingAllowsSecondAbsenceRetry(t *testing.T) {
+	const issueID = "ABS-SECOND"
+	dir, baseline := handoffEvidenceGitWorkspace(t)
+	store := &mockExitStore{}
+	seedMockHandoffAbsences(store, issueID, 1)
+	tracker := newRecordingHandoffTracker()
+	state := exitStateWithIssue(t, issueID, "In Progress")
+	params := handoffEvidenceExitParams(t, store, tracker.mockTrackerAdapter, &spyMetrics{})
+	params.TrackerAdapter = tracker
+	params.MaxSessions = 0
+
+	HandleWorkerExit(state, WorkerResult{
+		IssueID:                 issueID,
+		Identifier:              "PROJ-SECOND",
+		ExitKind:                WorkerExitNormal,
+		WorkspacePath:           dir,
+		HandoffEvidencePolicy:   config.HandoffEvidenceObserved,
+		HandoffEvidenceBaseline: baseline,
+		AgentAdapter:            "mock",
+	}, params)
+	t.Cleanup(func() { CancelRetry(state, issueID) })
+
+	if _, ok := state.RetryAttempts[issueID]; !ok {
+		t.Fatal("second consecutive absence did not schedule the second retry")
+	}
+	if _, ok := state.Claimed[issueID]; !ok {
+		t.Error("claim released before the third consecutive absence")
+	}
+	if _, ok := state.BudgetExhausted[issueID]; ok {
+		t.Error("issue parked before the default ceiling of three")
+	}
+	state.TrackerOpsWg.Wait()
+	if calls := tracker.labels(); len(calls) != 0 {
+		t.Errorf("AddLabel calls = %+v, want none before the ceiling", calls)
+	}
+}
+
+func TestHandleWorkerExitWorkObservedResetsAbsenceSequenceBeforeHandoffWrite(t *testing.T) {
+	const issueID = "ABS-RESET"
+	dir, baseline := handoffEvidenceGitWorkspace(t)
+	if err := os.WriteFile(filepath.Join(dir, "work.txt"), []byte("work\n"), 0o600); err != nil {
+		t.Fatalf("write work file: %v", err)
+	}
+
+	store := &mockExitStore{}
+	seedMockHandoffAbsences(store, issueID, 2)
+	tracker := newRecordingHandoffTracker()
+	tracker.transitionIssueFn = func(context.Context, string, string) error {
+		return errors.New("handoff unavailable")
+	}
+	state := exitStateWithIssue(t, issueID, "In Progress")
+	state.BudgetExhausted[issueID] = struct{}{}
+	state.BudgetExhaustedReason[issueID] = budgetReasonHandoffAbsence
+	params := handoffEvidenceExitParams(t, store, tracker.mockTrackerAdapter, &spyMetrics{})
+	params.TrackerAdapter = tracker
+
+	HandleWorkerExit(state, WorkerResult{
+		IssueID:                 issueID,
+		Identifier:              "PROJ-RESET",
+		ExitKind:                WorkerExitNormal,
+		WorkspacePath:           dir,
+		HandoffEvidencePolicy:   config.HandoffEvidenceObserved,
+		HandoffEvidenceBaseline: baseline,
+		AgentAdapter:            "mock",
+	}, params)
+	t.Cleanup(func() { CancelRetry(state, issueID) })
+
+	if _, ok := state.BudgetExhausted[issueID]; ok {
+		t.Error("handoff-absence gate survived a work-observed run")
+	}
+	if _, ok := state.BudgetExhaustedReason[issueID]; ok {
+		t.Error("handoff-absence reason survived a work-observed run")
+	}
+	counts, err := store.QueryConsecutiveHandoffAbsenceCounts(context.Background(), []string{issueID})
+	if err != nil {
+		t.Fatalf("QueryConsecutiveHandoffAbsenceCounts: %v", err)
+	}
+	if got := counts[issueID]; got != 0 {
+		t.Errorf("consecutive absences after work observed = %d, want 0", got)
+	}
+	if len(tracker.transitionCalls) != 1 {
+		t.Errorf("TransitionIssue calls = %d, want 1 failing handoff attempt", len(tracker.transitionCalls))
+	}
+}
+
+func TestHandleRetryTimerKeepsRecoveredExhaustedAbsenceParkedWhenLabelFails(t *testing.T) {
+	const issueID = "ABS-RECOVERED"
+	store := &mockRetryStore{absenceCounts: map[string]int{issueID: 3}}
+	tracker := &mockRetryTracker{addLabelErr: errors.New("label service unavailable")}
+	state := retryState(t, issueID, "PROJ-RECOVERED", 3)
+	params := defaultRetryParams(t, store, tracker)
+	params.MaxSessions = 0
+	params.HandoffParkingLabel = "operator-needed"
+	var logs bytes.Buffer
+	params.Logger = debugLogger(t, &logs)
+
+	HandleRetryTimer(state, issueID, params)
+	state.TrackerOpsWg.Wait()
+
+	if tracker.fetchCount != 0 {
+		t.Errorf("FetchIssueByID calls = %d, want 0 for an exhausted recovered retry", tracker.fetchCount)
+	}
+	if len(tracker.addedLabels) != 1 || tracker.addedLabels[0] != "operator-needed" {
+		t.Errorf("AddLabel calls = %v, want [operator-needed]", tracker.addedLabels)
+	}
+	if _, ok := state.Claimed[issueID]; ok {
+		t.Error("claim remains after recovered absence parking")
+	}
+	if _, ok := state.RetryAttempts[issueID]; ok {
+		t.Error("retry was restored after recovered absence parking")
+	}
+	if got := state.BudgetExhaustedReason[issueID]; got != budgetReasonHandoffAbsence {
+		t.Errorf("BudgetExhaustedReason = %q, want %q", got, budgetReasonHandoffAbsence)
+	}
+	if ShouldDispatch(candidateIssue(issueID, "PROJ-RECOVERED", "In Progress"), state, params.ActiveStates, params.TerminalStates) {
+		t.Error("ordinary polling would dispatch after the parking label failed")
+	}
+	if !strings.Contains(logs.String(), "handoff absence escalation label failed") {
+		t.Errorf("missing label failure log\nlogs: %s", logs.String())
+	}
+}
+
+func TestRebuildBudgetExhaustedRestoresAbsenceParkingAfterRestart(t *testing.T) {
+	const issueID = "ABS-POLL"
+	issue := candidateIssue(issueID, "PROJ-POLL", "To Do")
+	startupCfg := config.ServiceConfig{
+		Agent: config.AgentConfig{MaxSessions: 0},
+		Reactions: map[string]config.ReactionConfig{
+			reviewCommentsConfigKey: {
+				Provider:        "",
+				Escalation:      "comment",
+				EscalationLabel: "captured-human-label",
+			},
+		},
+	}
+	manager := &stubWorkflowManager{config: startupCfg}
+	store := &stubStore{absenceCounts: map[string]int{issueID: 3}}
+	tracker := newRecordingHandoffTracker()
+	state := NewState(1000, 1, nil, AgentTotals{})
+	orchestrator := NewOrchestrator(OrchestratorParams{
+		State:           state,
+		Logger:          discardLogger(),
+		TrackerAdapter:  tracker,
+		AgentAdapter:    &mockAgentAdapter{},
+		WorkflowManager: manager,
+		Store:           store,
+	})
+
+	// Reaction configuration reloads do not change the captured parking
+	// label, and escalation: comment does not change the primary action.
+	reloadedCfg := startupCfg
+	reloadedCfg.Reactions = map[string]config.ReactionConfig{
+		reviewCommentsConfigKey: {
+			Escalation:      "comment",
+			EscalationLabel: "reloaded-label",
+		},
+	}
+	manager.setConfig(reloadedCfg)
+	orchestrator.rebuildBudgetExhausted(context.Background(), reloadedCfg, []domain.Issue{issue})
+	state.TrackerOpsWg.Wait()
+
+	if ShouldDispatch(issue, state, []string{"To Do"}, []string{"Done"}) {
+		t.Error("ordinary polling would dispatch an absence-exhausted issue after restart")
+	}
+	if got := state.BudgetExhaustedReason[issueID]; got != budgetReasonHandoffAbsence {
+		t.Errorf("BudgetExhaustedReason = %q, want %q", got, budgetReasonHandoffAbsence)
+	}
+	calls := tracker.labels()
+	if len(calls) != 1 || calls[0].label != "captured-human-label" {
+		t.Errorf("AddLabel calls = %+v, want captured-human-label despite reload", calls)
+	}
+}

--- a/internal/orchestrator/handoff_evidence.go
+++ b/internal/orchestrator/handoff_evidence.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/sortie-ai/sortie/internal/config"
+	"github.com/sortie-ai/sortie/internal/persistence"
 	"github.com/sortie-ai/sortie/internal/workspace"
 )
 
@@ -92,5 +93,5 @@ func handoffEvidenceWithholds(policy config.HandoffEvidencePolicy, result handof
 }
 
 func handoffEvidenceFailure(policy config.HandoffEvidencePolicy, result handoffEvidenceResult) error {
-	return fmt.Errorf("handoff withheld: %s under %s policy", result.Verdict, policy)
+	return fmt.Errorf("%s%s under %s policy", persistence.HandoffAbsenceErrorPrefix, result.Verdict, policy)
 }

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -35,6 +35,7 @@ type OrchestratorStore interface {
 	SaveRetryEntry(ctx context.Context, entry persistence.RetryEntry) error
 	DeleteRetryEntry(ctx context.Context, issueID string) error
 	CountRunHistoryByIssue(ctx context.Context, issueID string) (int, error)
+	QueryConsecutiveHandoffAbsenceCounts(ctx context.Context, issueIDs []string) (map[string]int, error)
 	TokenUsageByIssue(ctx context.Context, issueID string) (persistence.IssueTokenUsage, error)
 	QueryBudgetExhaustedIssues(ctx context.Context, candidateIDs []string, maxSessions int) ([]string, error)
 	QueryTokenBudgetUsage(ctx context.Context, candidateIDs []string) (map[string]persistence.IssueTokenUsage, error)
@@ -229,6 +230,7 @@ type Orchestrator struct {
 	labelFixReactionConfigured        bool
 	mergeCompletionConfig             MergeCompletionReactionConfig
 	mergeCompletionReactionConfigured bool
+	handoffParkingLabel               string
 
 	// sshStrictHostKeyChecking is the current effective OpenSSH
 	// StrictHostKeyChecking value. Written by handleTick on every
@@ -305,6 +307,11 @@ func NewOrchestrator(params OrchestratorParams) *Orchestrator {
 		logger.Warn("AgentAdapterByKind not provided; falling back to single-adapter mode for the workflow default kind only")
 	}
 
+	handoffParkingLabel := defaultHandoffParkingLabel
+	if params.WorkflowManager != nil {
+		handoffParkingLabel = resolveHandoffParkingLabel(params.WorkflowManager.Config().Reactions)
+	}
+
 	o := &Orchestrator{
 		state:                             params.State,
 		logger:                            logger,
@@ -343,6 +350,7 @@ func NewOrchestrator(params OrchestratorParams) *Orchestrator {
 		labelFixReactionConfigured:        params.LabelFixReactionConfigured,
 		mergeCompletionConfig:             params.MergeCompletionConfig,
 		mergeCompletionReactionConfigured: params.MergeCompletionReactionConfigured,
+		handoffParkingLabel:               handoffParkingLabel,
 	}
 	// Startup preflight must have passed for the orchestrator to be
 	// constructed, so the initial value is true.
@@ -383,6 +391,8 @@ func (o *Orchestrator) Run(ctx context.Context) {
 			HandleWorkerExit(o.state, workerExit, HandleWorkerExitParams{
 				Store:                             o.store,
 				MaxRetryBackoffMS:                 cfg.Agent.MaxRetryBackoffMS,
+				MaxSessions:                       cfg.Agent.MaxSessions,
+				HandoffParkingLabel:               o.handoffParkingLabel,
 				OnRetryFire:                       o.onRetryFire,
 				Ctx:                               ctx,
 				Logger:                            o.logger,
@@ -410,23 +420,24 @@ func (o *Orchestrator) Run(ctx context.Context) {
 		case issueID := <-o.retryTimerCh:
 			cfg := o.workflowManager.Config()
 			HandleRetryTimer(o.state, issueID, HandleRetryTimerParams{
-				Store:              o.store,
-				TrackerAdapter:     o.trackerAdapter,
-				ActiveStates:       cfg.Tracker.ActiveStates,
-				TerminalStates:     cfg.Tracker.TerminalStates,
-				HandoffState:       cfg.Tracker.HandoffState,
-				MaxRetryBackoffMS:  cfg.Agent.MaxRetryBackoffMS,
-				MakeWorkerFn:       o.makeWorkerFn,
-				AgentAdapterByKind: o.agentAdapterByKind,
-				DefaultAgentKind:   cfg.Agent.Kind,
-				OnRetryFire:        o.onRetryFire,
-				Ctx:                ctx,
-				Logger:             o.logger,
-				MaxSessions:        cfg.Agent.MaxSessions,
-				MaxTokens:          cfg.Agent.MaxTokens,
-				Metrics:            o.metrics,
-				HostPool:           o.hostPool,
-				WorkflowFile:       o.workflowFile(),
+				Store:               o.store,
+				TrackerAdapter:      o.trackerAdapter,
+				ActiveStates:        cfg.Tracker.ActiveStates,
+				TerminalStates:      cfg.Tracker.TerminalStates,
+				HandoffState:        cfg.Tracker.HandoffState,
+				MaxRetryBackoffMS:   cfg.Agent.MaxRetryBackoffMS,
+				MakeWorkerFn:        o.makeWorkerFn,
+				AgentAdapterByKind:  o.agentAdapterByKind,
+				DefaultAgentKind:    cfg.Agent.Kind,
+				OnRetryFire:         o.onRetryFire,
+				Ctx:                 ctx,
+				Logger:              o.logger,
+				MaxSessions:         cfg.Agent.MaxSessions,
+				HandoffParkingLabel: o.handoffParkingLabel,
+				MaxTokens:           cfg.Agent.MaxTokens,
+				Metrics:             o.metrics,
+				HostPool:            o.hostPool,
+				WorkflowFile:        o.workflowFile(),
 			})
 			o.updateGauges(time.Now())
 			o.notifyObservers()
@@ -857,21 +868,15 @@ func (o *Orchestrator) maybeWriteIncrementalMetadata(ctx context.Context, issueI
 }
 
 // rebuildBudgetExhausted replaces the BudgetExhausted set and its reason
-// map once per tick from run_history, as the union of the session-count
-// and token-sum budgets scoped to the candidate set. An issue blocked on
-// either budget is in the rebuilt set; an issue blocked on both reports
-// the token budget. On a query error for one axis, the prior entries
-// attributed to that axis are folded back in so a transient error never
-// drops an issue mid-tick, while the other axis keeps its fresh result.
+// map once per tick from run_history, as the union of the session-count,
+// token-sum, and consecutive handoff-absence gates scoped to the candidate
+// set. Handoff absence is the most specific reason and takes precedence;
+// token budget takes precedence over the ordinary session budget. On a
+// query error for one axis, the prior entries attributed to that axis are
+// folded back in so a transient error never drops an issue mid-tick, while
+// the other axes keep their fresh results.
 // Must be called from the event loop goroutine.
 func (o *Orchestrator) rebuildBudgetExhausted(ctx context.Context, cfg config.ServiceConfig, sorted []domain.Issue) {
-	if cfg.Agent.MaxSessions == 0 && cfg.Agent.MaxTokens == 0 {
-		o.state.BudgetExhausted = make(map[string]struct{})
-		o.state.BudgetExhaustedReason = make(map[string]string)
-		o.state.TokenBudgetIncomplete = make(map[string]struct{})
-		return
-	}
-
 	candidateIDs := make([]string, len(sorted))
 	identifierByID := make(map[string]string, len(sorted))
 	for i, issue := range sorted {
@@ -883,6 +888,11 @@ func (o *Orchestrator) rebuildBudgetExhausted(ctx context.Context, cfg config.Se
 	priorReason := o.state.BudgetExhaustedReason
 	fresh := make(map[string]struct{})
 	freshReason := make(map[string]string)
+	type parkedCandidate struct {
+		issueID string
+		count   int
+	}
+	newlyParked := make([]parkedCandidate, 0)
 
 	if cfg.Agent.MaxSessions > 0 {
 		sessionExhausted, qErr := o.store.QueryBudgetExhaustedIssues(ctx, candidateIDs, cfg.Agent.MaxSessions)
@@ -905,6 +915,37 @@ func (o *Orchestrator) rebuildBudgetExhausted(ctx context.Context, cfg config.Se
 		}
 	}
 
+	// The handoff-absence ceiling is always finite, including when the
+	// ordinary max_sessions budget is disabled. Rebuild it from run_history
+	// on every poll so a parked issue remains ineligible across restart and
+	// even when no retry row survived the final worker exit.
+	absenceCeiling := handoffAbsenceCeiling(cfg.Agent.MaxSessions)
+	absenceCounts, absenceErr := o.store.QueryConsecutiveHandoffAbsenceCounts(ctx, candidateIDs)
+	if absenceErr != nil {
+		o.logger.Warn("handoff absence exhaustion query failed, retaining previous set",
+			slog.Any("error", absenceErr),
+		)
+		for id := range prior {
+			if priorReason[id] != budgetReasonHandoffAbsence {
+				continue
+			}
+			fresh[id] = struct{}{}
+			freshReason[id] = budgetReasonHandoffAbsence
+		}
+	} else {
+		for _, id := range candidateIDs {
+			count := absenceCounts[id]
+			if count < absenceCeiling {
+				continue
+			}
+			fresh[id] = struct{}{}
+			freshReason[id] = budgetReasonHandoffAbsence
+			if priorReason[id] != budgetReasonHandoffAbsence {
+				newlyParked = append(newlyParked, parkedCandidate{issueID: id, count: count})
+			}
+		}
+	}
+
 	freshIncomplete := make(map[string]struct{})
 	if cfg.Agent.MaxTokens > 0 {
 		usageByIssue, qErr := o.store.QueryTokenBudgetUsage(ctx, candidateIDs)
@@ -916,15 +957,19 @@ func (o *Orchestrator) rebuildBudgetExhausted(ctx context.Context, cfg config.Se
 				if priorReason[id] != budgetReasonToken {
 					continue
 				}
-				fresh[id] = struct{}{}
-				freshReason[id] = budgetReasonToken
+				if freshReason[id] != budgetReasonHandoffAbsence {
+					fresh[id] = struct{}{}
+					freshReason[id] = budgetReasonToken
+				}
 			}
 		} else {
 			for _, id := range candidateIDs {
 				usage := usageByIssue[id]
 				if usage.TotalTokens >= int64(cfg.Agent.MaxTokens) {
-					fresh[id] = struct{}{}
-					freshReason[id] = budgetReasonToken
+					if freshReason[id] != budgetReasonHandoffAbsence {
+						fresh[id] = struct{}{}
+						freshReason[id] = budgetReasonToken
+					}
 					continue
 				}
 				if usage.UnmeasuredSessions == 0 {
@@ -947,6 +992,21 @@ func (o *Orchestrator) rebuildBudgetExhausted(ctx context.Context, cfg config.Se
 
 	o.state.BudgetExhausted = fresh
 	o.state.BudgetExhaustedReason = freshReason
+
+	for _, parked := range newlyParked {
+		issueLog := logging.WithIssue(o.logger, parked.issueID, identifierByID[parked.issueID])
+		parkHandoffAbsence(
+			o.state,
+			ctx,
+			o.store,
+			o.trackerAdapter,
+			parked.issueID,
+			parked.count,
+			absenceCeiling,
+			o.handoffParkingLabel,
+			issueLog,
+		)
+	}
 }
 
 // drainRunningWorkers cancels all running worker contexts and waits for

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -106,6 +106,8 @@ type stubStore struct {
 	// Budget exhaustion query configuration (per-tick rebuild).
 	budgetExhaustedIDs []string
 	budgetExhaustedErr error
+	absenceCounts      map[string]int
+	absenceCountErr    error
 
 	// Token budget query configuration (per-tick rebuild and single-issue gate).
 	tokenExhaustedIDs []string
@@ -190,6 +192,19 @@ func (s *stubStore) QueryBudgetExhaustedIssues(_ context.Context, _ []string, _ 
 	}
 	result := make([]string, len(s.budgetExhaustedIDs))
 	copy(result, s.budgetExhaustedIDs)
+	return result, nil
+}
+
+func (s *stubStore) QueryConsecutiveHandoffAbsenceCounts(_ context.Context, candidateIDs []string) (map[string]int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.absenceCountErr != nil {
+		return nil, s.absenceCountErr
+	}
+	result := make(map[string]int, len(candidateIDs))
+	for _, id := range candidateIDs {
+		result[id] = s.absenceCounts[id]
+	}
 	return result, nil
 }
 

--- a/internal/orchestrator/retry.go
+++ b/internal/orchestrator/retry.go
@@ -28,6 +28,7 @@ type RetryTimerStore interface {
 	SaveRetryEntry(ctx context.Context, entry persistence.RetryEntry) error
 	DeleteRetryEntry(ctx context.Context, issueID string) error
 	CountRunHistoryByIssue(ctx context.Context, issueID string) (int, error)
+	QueryConsecutiveHandoffAbsenceCounts(ctx context.Context, issueIDs []string) (map[string]int, error)
 	TokenUsageByIssue(ctx context.Context, issueID string) (persistence.IssueTokenUsage, error)
 	MarkReactionDispatched(ctx context.Context, issueID, kind string) error
 }
@@ -106,6 +107,10 @@ type HandleRetryTimerParams struct {
 	// the claim instead of dispatching if the count has reached the
 	// budget. When 0, no budget is enforced.
 	MaxSessions int
+
+	// HandoffParkingLabel is the review-comments escalation label captured
+	// at orchestrator construction. Empty falls back to "needs-human".
+	HandoffParkingLabel string
 
 	// MaxTokens is the configured per-issue token budget (from
 	// config.Agent.MaxTokens). When > 0, HandleRetryTimer sums
@@ -213,6 +218,36 @@ func HandleRetryTimer(state *State, issueID string, params HandleRetryTimerParam
 			slog.Int("attempt", popped.Attempt),
 		)
 		reschedule(popped.Attempt, delayMS, popped.Error)
+		return
+	}
+
+	// Consecutive handoff-absence gate. This check runs for every retry
+	// fire, including entries reconstructed after restart, before any tracker
+	// fetch or worker dispatch. The persisted run-history sequence therefore
+	// remains a dispatch gate even if the process exited between recording the
+	// final absence and deleting its retry row.
+	absenceCeiling := handoffAbsenceCeiling(params.MaxSessions)
+	absenceCounts, absenceErr := params.Store.QueryConsecutiveHandoffAbsenceCounts(ctx, []string{issueID})
+	consecutiveAbsences := absenceCounts[issueID]
+	if absenceErr != nil {
+		consecutiveAbsences = max(popped.Attempt, 1)
+		log.Warn("handoff absence count query failed, using retry attempt fallback",
+			slog.Int("consecutive_absences", consecutiveAbsences),
+			slog.Any("error", absenceErr),
+		)
+	}
+	if consecutiveAbsences >= absenceCeiling {
+		parkHandoffAbsence(
+			state,
+			ctx,
+			params.Store,
+			params.TrackerAdapter,
+			issueID,
+			consecutiveAbsences,
+			absenceCeiling,
+			params.HandoffParkingLabel,
+			log,
+		)
 		return
 	}
 

--- a/internal/orchestrator/retry_test.go
+++ b/internal/orchestrator/retry_test.go
@@ -26,6 +26,9 @@ type mockRetryStore struct {
 	runHistoryCount           int
 	countRunHistoryByIssueErr error
 	countedIssueIDs           []string
+	absenceCounts             map[string]int
+	absenceCountErr           error
+	absenceCountedIssueIDs    []string
 
 	tokenSum                 int64
 	tokenSessionCount        int
@@ -54,6 +57,18 @@ func (m *mockRetryStore) DeleteRetryEntry(_ context.Context, issueID string) err
 func (m *mockRetryStore) CountRunHistoryByIssue(_ context.Context, issueID string) (int, error) {
 	m.countedIssueIDs = append(m.countedIssueIDs, issueID)
 	return m.runHistoryCount, m.countRunHistoryByIssueErr
+}
+
+func (m *mockRetryStore) QueryConsecutiveHandoffAbsenceCounts(_ context.Context, issueIDs []string) (map[string]int, error) {
+	m.absenceCountedIssueIDs = append(m.absenceCountedIssueIDs, issueIDs...)
+	if m.absenceCountErr != nil {
+		return nil, m.absenceCountErr
+	}
+	result := make(map[string]int, len(issueIDs))
+	for _, id := range issueIDs {
+		result[id] = m.absenceCounts[id]
+	}
+	return result, nil
 }
 
 func (m *mockRetryStore) TokenUsageByIssue(_ context.Context, issueID string) (persistence.IssueTokenUsage, error) {
@@ -96,6 +111,8 @@ type mockRetryTracker struct {
 	fetchErr     error
 	fetchCount   int
 	fetchedID    string // records the last issueID arg received by FetchIssueByID
+	addLabelErr  error
+	addedLabels  []string
 }
 
 var _ domain.TrackerAdapter = (*mockRetryTracker)(nil)
@@ -134,8 +151,9 @@ func (m *mockRetryTracker) CommentIssue(context.Context, string, string) error {
 	panic("CommentIssue must not be called by HandleRetryTimer")
 }
 
-func (m *mockRetryTracker) AddLabel(context.Context, string, string) error {
-	panic("AddLabel must not be called by HandleRetryTimer")
+func (m *mockRetryTracker) AddLabel(_ context.Context, _ string, label string) error {
+	m.addedLabels = append(m.addedLabels, label)
+	return m.addLabelErr
 }
 
 // --- Test helpers ---

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -45,12 +45,14 @@ const (
 	handoffWithheld = "withheld"
 )
 
-// Budget reason values recorded in [State.BudgetExhaustedReason] and the
-// runtime snapshot. budgetReasonToken takes precedence when both budgets
-// are exhausted for one issue.
+// Dispatch-gate reason values recorded in [State.BudgetExhaustedReason] and
+// the runtime snapshot. Handoff absence takes precedence so a parked issue
+// remains distinguishable; token budget still takes precedence over the
+// ordinary all-session budget.
 const (
-	budgetReasonToken   = "token_budget"
-	budgetReasonSession = "session_budget"
+	budgetReasonToken          = "token_budget"
+	budgetReasonHandoffAbsence = "handoff_absence"
+	budgetReasonSession        = "session_budget"
 )
 
 // AgentTotals holds cumulative token and runtime counters across all ended
@@ -784,21 +786,18 @@ type State struct {
 	// Bookkeeping only — not used for dispatch gating.
 	Completed map[string]struct{}
 
-	// BudgetExhausted is the set of issue IDs whose run_history count
-	// has reached or exceeded the configured max_sessions budget, or
-	// whose summed run_history total_tokens has reached or exceeded the
-	// configured max_tokens budget. Rebuilt from batch SQLite queries at
-	// the start of each poll tick when either budget is enabled. Updated
-	// inline by [HandleRetryTimer] on budget exhaustion. [ShouldDispatch]
-	// checks this set as a dispatch gate. Cleared when both budgets are 0.
+	// BudgetExhausted is the set of issue IDs blocked by a durable
+	// run_history-derived dispatch gate: the configured max_sessions
+	// budget, the max_tokens budget, or the consecutive handoff-absence
+	// ceiling. Rebuilt from batch SQLite queries at the start of each poll
+	// tick and updated inline by worker-exit and retry-timer handling.
+	// [ShouldDispatch] checks this set before dispatch.
 	BudgetExhausted map[string]struct{}
 
-	// BudgetExhaustedReason maps issue ID to the budget that fired for
-	// that issue, either "token_budget" or "session_budget". It is kept
-	// in lockstep with BudgetExhausted: every issue in BudgetExhausted
-	// has a reason entry, and no entry survives for an issue that leaves
-	// the set. When both budgets are exhausted for one issue the reason
-	// is "token_budget". Owned by the single-writer event loop.
+	// BudgetExhaustedReason maps issue ID to the gate that fired for that
+	// issue: "token_budget", "handoff_absence", or "session_budget". It
+	// is kept in lockstep with BudgetExhausted. Owned by the single-writer
+	// event loop.
 	BudgetExhaustedReason map[string]string
 
 	// AgentTotals holds aggregate token counts and cumulative runtime seconds

--- a/internal/persistence/run_history.go
+++ b/internal/persistence/run_history.go
@@ -10,6 +10,13 @@ import (
 
 const reactionRecoveryMaxCandidates = 200
 
+// HandoffAbsenceErrorPrefix is the reserved prefix used when a handoff is
+// withheld because the orchestrator observed no work (or treats an
+// undeterminable verdict as absence under the strict policy). Keeping the
+// marker stable lets the retry and polling paths reconstruct the consecutive
+// absence sequence from run_history without adding a verdict column.
+const HandoffAbsenceErrorPrefix = "handoff withheld: "
+
 // RunHistory represents a single completed run attempt persisted in the
 // run_history table. The ID field is assigned by the database on insert and
 // should be left zero when calling [Store.AppendRunHistory].
@@ -294,6 +301,69 @@ func (s *Store) CountRunHistoryByIssue(ctx context.Context, issueID string) (int
 		return 0, fmt.Errorf("count run history by issue %q: %w", issueID, err)
 	}
 	return count, nil
+}
+
+// QueryConsecutiveHandoffAbsenceCounts returns the number of handoff-absence
+// failures for each requested issue since its most recent successful run.
+// Other failed or cancelled runs do not reset the sequence because they do not
+// establish that work was observed. Issues with no qualifying rows are omitted
+// from the returned map.
+//
+// A successful run ends the active absence sequence. On the otherwise-eligible
+// handoff path this includes a work-observed result, even when the subsequent
+// tracker handoff write fails; successful outcomes that hand off under the
+// observed or off policies also leave the active queue and therefore end that
+// dispatch sequence.
+func (s *Store) QueryConsecutiveHandoffAbsenceCounts(ctx context.Context, issueIDs []string) (map[string]int, error) {
+	counts := make(map[string]int)
+	if len(issueIDs) == 0 {
+		return counts, nil
+	}
+
+	placeholders := strings.Repeat("?,", len(issueIDs))
+	placeholders = placeholders[:len(placeholders)-1]
+
+	args := make([]any, 0, len(issueIDs)+2)
+	for _, id := range issueIDs {
+		args = append(args, id)
+	}
+	args = append(args, len(HandoffAbsenceErrorPrefix), HandoffAbsenceErrorPrefix)
+
+	query := fmt.Sprintf( //nolint:gosec // placeholders is built only from len(issueIDs); values remain bound parameters
+		`SELECT r.issue_id, COUNT(*)
+		 FROM run_history AS r
+		 WHERE r.issue_id IN (%s)
+		   AND r.status = 'failed'
+		   AND substr(r.error, 1, ?) = ?
+		   AND NOT EXISTS (
+		       SELECT 1
+		       FROM run_history AS succeeded
+		       WHERE succeeded.issue_id = r.issue_id
+		         AND succeeded.status = 'succeeded'
+		         AND succeeded.id > r.id
+		   )
+		 GROUP BY r.issue_id`,
+		placeholders,
+	)
+
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("query consecutive handoff absences: %w", err)
+	}
+	defer rows.Close() //nolint:errcheck // read-only query; close error is non-actionable
+
+	for rows.Next() {
+		var issueID string
+		var count int
+		if err := rows.Scan(&issueID, &count); err != nil {
+			return nil, fmt.Errorf("scan consecutive handoff absences: %w", err)
+		}
+		counts[issueID] = count
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("query consecutive handoff absences: %w", err)
+	}
+	return counts, nil
 }
 
 // QueryBudgetExhaustedIssues returns issue IDs from candidateIDs whose

--- a/internal/persistence/run_history_absence_test.go
+++ b/internal/persistence/run_history_absence_test.go
@@ -1,0 +1,108 @@
+package persistence
+
+import (
+	"context"
+	"testing"
+)
+
+func appendAbsenceSequenceRun(t *testing.T, store *Store, issueID, status, errorText string) {
+	t.Helper()
+	var runErr *string
+	if errorText != "" {
+		runErr = &errorText
+	}
+	appendOrFatal(t, store, RunHistory{
+		IssueID:      issueID,
+		Identifier:   issueID,
+		Attempt:      1,
+		AgentAdapter: "mock",
+		Workspace:    "/tmp/" + issueID,
+		StartedAt:    "2026-08-17T00:00:00Z",
+		CompletedAt:  "2026-08-17T00:01:00Z",
+		Status:       status,
+		Error:        runErr,
+	})
+}
+
+func handoffAbsenceError() string {
+	return HandoffAbsenceErrorPrefix + "absence of work observed under observed policy"
+}
+
+func TestQueryConsecutiveHandoffAbsenceCounts(t *testing.T) {
+	t.Parallel()
+
+	store := openTestStore(t)
+	migrateOrFatal(t, store)
+
+	// Non-absence failures do not pretend to reset a sequence.
+	appendAbsenceSequenceRun(t, store, "ISS-FAILURES", "failed", handoffAbsenceError())
+	appendAbsenceSequenceRun(t, store, "ISS-FAILURES", "failed", "agent transport failed")
+	appendAbsenceSequenceRun(t, store, "ISS-FAILURES", "failed", handoffAbsenceError())
+
+	// A successful run resets the sequence; only the later absence counts.
+	appendAbsenceSequenceRun(t, store, "ISS-RESET", "failed", handoffAbsenceError())
+	appendAbsenceSequenceRun(t, store, "ISS-RESET", "succeeded", "")
+	appendAbsenceSequenceRun(t, store, "ISS-RESET", "failed", handoffAbsenceError())
+
+	// Cancellation is not positive evidence and therefore does not reset.
+	appendAbsenceSequenceRun(t, store, "ISS-CANCEL", "failed", handoffAbsenceError())
+	appendAbsenceSequenceRun(t, store, "ISS-CANCEL", "cancelled", "shutdown")
+	appendAbsenceSequenceRun(t, store, "ISS-CANCEL", "failed", handoffAbsenceError())
+
+	// Repeated productive/empty alternation always leaves only the current
+	// one-absence sequence, so it can never accumulate toward three.
+	appendAbsenceSequenceRun(t, store, "ISS-ALTERNATING", "failed", handoffAbsenceError())
+	appendAbsenceSequenceRun(t, store, "ISS-ALTERNATING", "succeeded", "")
+	appendAbsenceSequenceRun(t, store, "ISS-ALTERNATING", "failed", handoffAbsenceError())
+	appendAbsenceSequenceRun(t, store, "ISS-ALTERNATING", "succeeded", "")
+	appendAbsenceSequenceRun(t, store, "ISS-ALTERNATING", "failed", handoffAbsenceError())
+
+	// Similar text that does not begin with the reserved marker is ordinary
+	// failure data and must not be counted.
+	appendAbsenceSequenceRun(t, store, "ISS-OTHER", "failed", "worker error: handoff withheld: no output")
+
+	ids := []string{"ISS-FAILURES", "ISS-RESET", "ISS-CANCEL", "ISS-ALTERNATING", "ISS-OTHER", "ISS-NONE"}
+	got, err := store.QueryConsecutiveHandoffAbsenceCounts(context.Background(), ids)
+	if err != nil {
+		t.Fatalf("QueryConsecutiveHandoffAbsenceCounts: %v", err)
+	}
+
+	want := map[string]int{
+		"ISS-FAILURES":    2,
+		"ISS-RESET":       1,
+		"ISS-CANCEL":      2,
+		"ISS-ALTERNATING": 1,
+	}
+	for _, id := range ids {
+		if got[id] != want[id] {
+			t.Errorf("count[%s] = %d, want %d", id, got[id], want[id])
+		}
+	}
+}
+
+func TestQueryConsecutiveHandoffAbsenceCountsEmptyInput(t *testing.T) {
+	t.Parallel()
+
+	store := openTestStore(t)
+	migrateOrFatal(t, store)
+	got, err := store.QueryConsecutiveHandoffAbsenceCounts(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("QueryConsecutiveHandoffAbsenceCounts(nil): %v", err)
+	}
+	if got == nil || len(got) != 0 {
+		t.Errorf("result = %#v, want empty non-nil map", got)
+	}
+}
+
+func TestQueryConsecutiveHandoffAbsenceCountsQueryError(t *testing.T) {
+	t.Parallel()
+
+	store := openTestStore(t)
+	migrateOrFatal(t, store)
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if _, err := store.QueryConsecutiveHandoffAbsenceCounts(context.Background(), []string{"ISS-1"}); err == nil {
+		t.Fatal("QueryConsecutiveHandoffAbsenceCounts on closed store returned nil error")
+	}
+}


### PR DESCRIPTION
### Scope & Context

**Type:** Fix

**Intent:** Stop withheld handoffs from creating an unbounded redispatch loop. Sortie now counts consecutive handoff absences, resets the sequence when work is observed, and parks an exhausted issue for human review without allowing polling or restart recovery to dispatch it again.

**Related Issues:** Closes #769

### Reviewer Guide

**Complexity:** High

#### Entry Point

Start with `internal/orchestrator/handoff_absence.go`. It derives the absence ceiling, resolves the startup-captured parking label, and performs the common stop operation: cancel the retry, delete its persisted entry, release the claim, install the dispatch gate, and apply the label without reopening the issue if that tracker write fails.

#### Sensitive Areas

- `internal/persistence/run_history.go`: reconstructs the active absence sequence from failed run-history reasons after the latest successful sequence boundary. This adds no schema migration or persisted evidence-verdict field.
- `internal/orchestrator/exit.go`: records the withheld run, obtains the incremented consecutive count, and either schedules the existing exponential-backoff retry or parks the issue at the ceiling.
- `internal/orchestrator/retry.go`: checks the durable absence gate before fetching the issue or dispatching a recovered retry.
- `internal/orchestrator/orchestrator.go`: rebuilds the gate during ordinary polling so an exhausted sequence stays stopped across orchestrator restarts, even when no retry row remains.
- `internal/orchestrator/handoff_absence_test.go`: covers configured and default ceilings, reset on observed work, label failure, captured label semantics, claim release, and restart behavior.

### Risk Assessment

- **Breaking Changes:** No API or configuration breaking changes. An issue that previously retried indefinitely after repeated withheld handoffs is now labelled and kept out of dispatch after reaching the derived ceiling.
- **Migrations/State:** No database migration and no new verdict field. The gate is reconstructed from existing `run_history` status and error data.

### Validation

- `make fmt`
- `make lint` — 0 issues
- `make build`
- Issue-specific orchestrator and persistence tests
- `go test -count=1 -skip '^TestRunWorkerAttempt_CompletionSignalRecordsReviewMetadata$' ./internal/orchestrator/... ./internal/persistence/... ./internal/config/...`
- `go test -race -count=1 -skip '^TestRunWorkerAttempt_CompletionSignalRecordsReviewMetadata$' ./internal/orchestrator/... ./internal/persistence/... ./internal/config/...`
- `git diff --check`

The unmodified `TestRunWorkerAttempt_CompletionSignalRecordsReviewMetadata` from the latest main branch fails locally on macOS because `/bin/sh` writes `echo -n passed` as `-n passed\n`. All other orchestrator tests pass.
