### PR TITLE
fix(orchestrator): correct the consecutive handoff-absence bound

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   run, and sets the field to `off`.
   ([#768](https://github.com/sortie-ai/sortie/issues/768))
 
+- An issue whose runs keep producing nothing is now parked instead of
+  being dispatched again indefinitely. Sortie counts the consecutive
+  withheld handoffs on each issue and, on reaching the ceiling, attaches
+  the escalation label configured under
+  `reactions.review_comments.escalation_label` (`needs-human` when that
+  block or value is absent), stops the retry sequence, and dispatches
+  the issue no further. The ceiling is `agent.max_sessions` where the
+  deployment sets one and `3` otherwise, which is the first attempt plus
+  two more. Parking is announced with the issue, how many consecutive
+  empty runs were seen, the ceiling, and the label applied, so a parked
+  issue can be told apart from an abandoned one. A run that produces
+  work clears the count at once; a run that ends without an evidence
+  verdict, such as an agent reporting itself blocked, leaves the count
+  where it stood. The count is neither kept nor consulted under
+  `tracker.handoff_evidence: off`, and a review-comment or CI
+  continuation retry is never stopped by this ceiling.
+  ([#769](https://github.com/sortie-ai/sortie/issues/769))
+
 ### Fixed
 
 - Adapter endpoint validation errors no longer print credentials
@@ -90,6 +108,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   it previously recorded none, and passes that outcome to the
   `after_run` hook in place of `disabled`.
   ([#813](https://github.com/sortie-ai/sortie/issues/813))
+
+### Migrations
+
+- Add the `handoff_absence_resets` table, recording per issue where its
+  consecutive-absence count was last cleared by an observed piece of
+  work. An issue with no row there has its recorded empty runs counted
+  in full, so an upgrade carries any absences already in the database
+  into the new ceiling.
 
 ## [1.19.0] - 2026-08-12
 

--- a/docs/architecture/08-polling-scheduling-and-reconciliation.md
+++ b/docs/architecture/08-polling-scheduling-and-reconciliation.md
@@ -116,11 +116,15 @@ Per-issue token budget (cost ceiling):
   either is reached, so whichever fills first across polling cycles is the one that fires. When
   a single evaluation finds both exhausted, the reported and logged reason names the token
   budget; the block itself is identical regardless of which ceiling triggered it.
-- The per-tick rebuild of the exhausted-issue set accounts for both ceilings: it runs the
-  session-count batch query when `max_sessions > 0` and the token-sum batch query when
-  `max_tokens > 0`, and unions the results. Each blocked issue carries a machine-readable
-  reason (`token_budget` or `session_budget`, token taking precedence) surfaced in the runtime
-  snapshot beside the exhausted set.
+- The per-tick rebuild of the exhausted-issue set accounts for these ceilings and for the
+  consecutive handoff-absence ceiling (§14.2): it runs the session-count batch query when
+  `max_sessions > 0`, the token-sum batch query when `max_tokens > 0`, and the absence-count
+  batch query when `tracker.handoff_evidence` is not `off`, and unions the results. Each
+  blocked issue carries a machine-readable reason (`handoff_absence`, `token_budget` or
+  `session_budget`, absence taking precedence over both budgets and token over session)
+  surfaced in the runtime snapshot beside the exhausted set. Under `handoff_evidence: off` no
+  absence is recorded and none is queried, so the rebuild is skipped entirely when both budgets
+  are also disabled.
 - If the token query fails, the check fails open and dispatch proceeds, matching the session
   check. A token sum recorded before the token columns were added reads as zero.
 - A sum below the ceiling that includes at least one unmeasured run allows the dispatch and

--- a/docs/architecture/18-logging-status-and-observability.md
+++ b/docs/architecture/18-logging-status-and-observability.md
@@ -83,7 +83,7 @@ should return:
 - `rate_limits` (latest coding-agent rate limit payload, if available)
 - `budget_exhausted_count` (number of issues currently blocked by a re-dispatch budget; always present)
 - `budget_exhausted` (sorted list of blocked issue IDs; omitted when the set is empty)
-- `budget_exhausted_reason` (map from blocked issue ID to the budget that fired, `token_budget` or `session_budget`, token taking precedence when both are exhausted for one issue; omitted when the set is empty). The exhausted set and its reasons are rebuilt per tick from the budget ceilings (Section 8.4); an issue's reason entry exists exactly when that issue is in `budget_exhausted`.
+- `budget_exhausted_reason` (map from blocked issue ID to the gate that fired, `handoff_absence`, `token_budget` or `session_budget`; `handoff_absence` takes precedence over both budgets and `token_budget` takes precedence over `session_budget` when one issue reaches more than one gate; omitted when the set is empty). The exhausted set and its reasons are rebuilt per tick from those gates (Section 8.4); an issue's reason entry exists exactly when that issue is in `budget_exhausted`.
 
 Recommended snapshot error modes:
 

--- a/docs/architecture/19-failure-model-and-recovery-strategy.md
+++ b/docs/architecture/19-failure-model-and-recovery-strategy.md
@@ -88,10 +88,15 @@
     of full agent sessions. Turn, tool, or model-iteration limits inside one session do not set this
     ceiling and are not comparable to it.
   - On reaching the ceiling, cancel this retry sequence, apply the primary-dispatch parking label,
-    and release the claim. Ceiling exhaustion is an eligibility gate rather than only a cancelled
-    timer: ordinary polling and restart recovery must not silently begin another run in the same
-    exhausted absence sequence. Its representation is an implementation detail; the rule requires
-    neither a second numeric setting nor a durable verdict column on `run_history`.
+    and release the claim. The sequence cancelled is the primary-dispatch one the count is kept for:
+    a reaction continuation retry on the same issue carries its own sequence, cannot record an
+    absence, and is not cancelled here. Ceiling exhaustion is an eligibility gate rather than only a
+    cancelled timer: ordinary polling and restart recovery must not silently begin another run in
+    the same exhausted absence sequence. Its representation is an implementation detail; the rule
+    requires neither a second numeric setting nor a durable verdict column on `run_history`.
+  - Under `tracker.handoff_evidence: off` no absence is ever recorded, so neither the count nor the
+    gate is evaluated on any path: polling, retry firing, and worker exit all skip it. The policy
+    costs nothing and no issue is parked by this mechanism while it is selected.
   - The parking label is the resolved non-empty
     `reactions.review_comments.escalation_label` captured when the orchestrator starts, or
     `needs-human` when that block or value is absent or empty. This lookup deliberately reuses only

--- a/docs/architecture/24-persistence-schema.md
+++ b/docs/architecture/24-persistence-schema.md
@@ -65,7 +65,9 @@ changed.
 
 No column stores the handoff-evidence verdict. The verdict is logged and counted, and a withheld
 run carries it in the existing `error` field. In particular, this change adds no evidence field to
-`run_history` and requires no rewrite of historical rows.
+`run_history` and requires no rewrite of historical rows. Because `succeeded` does not assert that
+work was observed, it cannot serve as the reset for a consecutive-absence sequence; that reset is
+recorded per issue in `handoff_absence_resets` below.
 
 A row with `tokens_measured = 0` always carries zero in all four token columns; the invariant
 runs in one direction only, because a measured run can legitimately report a zero spend. Every
@@ -142,6 +144,26 @@ text and this schema attaches no meaning to it beyond equality.
 fingerprint", and the row's lifecycle after that point is the owning kind's to define. Most kinds
 treat the row as spent. The merge-completion kind (§11G.4) instead retains a dispatched row rather
 than deleting it, because deleting it would let the next poll observe the same merge as new.
+
+**`handoff_absence_resets`**: end of a consecutive handoff-absence sequence (migration 013)
+
+| Column         | Type    | Notes                                                              |
+| -------------- | ------- | ------------------------------------------------------------------ |
+| `issue_id`     | TEXT PK | Tracker-internal issue ID                                          |
+| `reset_run_id` | INTEGER | Highest `run_history.id` for the issue at the reset; `0` when none |
+| `updated_at`   | TEXT    | ISO-8601 timestamp                                                 |
+
+One row per issue, written only when a run's evidence verdict is `work observed`. The
+consecutive-absence count (§14.2) is the number of the issue's absence-marked `run_history` rows
+with an `id` above `reset_run_id`, so the count returns to zero the moment a work-observed run is
+recorded and cannot be restored by a later handoff-write failure. Outcomes that carry no verdict
+never write here, which is what keeps a blocked soft stop, a reaction run, an undeterminable verdict
+or a run under `handoff_evidence: off` from resetting a sequence they say nothing about.
+
+The reset point is read from `run_history` inside the write, so a work-observed run whose own
+history row could not be persisted still clears the absences recorded before it. This table holds no
+verdict history: it is a per-issue position that is overwritten, and deleting a row only restores
+the issue's full recorded absence sequence.
 
 ### 19.3 Migration Strategy
 

--- a/internal/orchestrator/exit.go
+++ b/internal/orchestrator/exit.go
@@ -37,6 +37,7 @@ type WorkerExitStore interface {
 	SaveRetryEntry(ctx context.Context, entry persistence.RetryEntry) error
 	DeleteRetryEntry(ctx context.Context, issueID string) error
 	QueryConsecutiveHandoffAbsenceCounts(ctx context.Context, issueIDs []string) (map[string]int, error)
+	ResetHandoffAbsenceSequence(ctx context.Context, issueID string) error
 }
 
 // HandleWorkerExitParams holds the dependencies for [HandleWorkerExit] that
@@ -297,6 +298,7 @@ func HandleWorkerExit(state *State, workerResult WorkerResult, params HandleWork
 	var terminal bool
 	var evidenceResult handoffEvidenceResult
 	var evidenceWithheld bool
+	var evidenceWorkObserved bool
 	var evidenceErr error
 	if workerResult.ExitKind == WorkerExitNormal {
 		issueIsActive = len(params.ActiveStates) == 0 || isActiveState(entry.Issue.State, params.ActiveStates)
@@ -323,8 +325,9 @@ func HandleWorkerExit(state *State, workerResult WorkerResult, params HandleWork
 				metrics.IncHandoffTransitions(handoffWithheld)
 			} else if evidenceResult.Verdict == handoffWorkObserved {
 				// A positive verdict resets the runtime gate immediately. The
-				// successful run_history row below supplies the durable reset even
-				// when the later tracker handoff write fails.
+				// durable reset recorded after the run_history write below holds
+				// even when the later tracker handoff write fails.
+				evidenceWorkObserved = true
 				clearHandoffAbsenceGate(state, workerResult.IssueID)
 			}
 		}
@@ -386,6 +389,14 @@ func HandleWorkerExit(state *State, workerResult WorkerResult, params HandleWork
 		log.Error("failed to persist run history",
 			slog.Any("error", err),
 		)
+	}
+
+	if evidenceWorkObserved {
+		if err := params.Store.ResetHandoffAbsenceSequence(ctx, workerResult.IssueID); err != nil {
+			log.Error("failed to reset handoff absence sequence",
+				slog.Any("error", err),
+			)
+		}
 	}
 
 	consecutiveAbsences := 0

--- a/internal/orchestrator/exit_test.go
+++ b/internal/orchestrator/exit_test.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -31,12 +30,19 @@ type mockExitStore struct {
 	retryEntries    []persistence.RetryEntry
 	deletedRetryIDs []string
 
+	// absenceResetAt maps an issue ID to the number of recorded runs at
+	// which its absence sequence was last reset, mirroring the run-history
+	// watermark the real store keeps.
+	absenceResetAt map[string]int
+	absenceResetOf []string
+
 	appendRunHistoryErr       error
 	upsertAggregateMetricsErr error
 	upsertSessionMetadataErr  error
 	saveRetryEntryErr         error
 	deleteRetryEntryErr       error
 	absenceCountErr           error
+	absenceResetErr           error
 }
 
 var _ WorkerExitStore = (*mockExitStore)(nil)
@@ -71,12 +77,12 @@ func (m *mockExitStore) QueryConsecutiveHandoffAbsenceCounts(_ context.Context, 
 	}
 	counts := make(map[string]int, len(issueIDs))
 	for _, issueID := range issueIDs {
-		for _, run := range slices.Backward(m.runHistories) {
+		// Only a recorded reset ends the sequence. A terminal status of
+		// "succeeded" does not, because it is also recorded for outcomes that
+		// carry no work-observed verdict.
+		for _, run := range m.runHistories[m.absenceResetAt[issueID]:] {
 			if run.IssueID != issueID {
 				continue
-			}
-			if run.Status == "succeeded" {
-				break
 			}
 			if run.Status == "failed" && run.Error != nil && strings.HasPrefix(*run.Error, persistence.HandoffAbsenceErrorPrefix) {
 				counts[issueID]++
@@ -84,6 +90,18 @@ func (m *mockExitStore) QueryConsecutiveHandoffAbsenceCounts(_ context.Context, 
 		}
 	}
 	return counts, nil
+}
+
+func (m *mockExitStore) ResetHandoffAbsenceSequence(_ context.Context, issueID string) error {
+	m.absenceResetOf = append(m.absenceResetOf, issueID)
+	if m.absenceResetErr != nil {
+		return m.absenceResetErr
+	}
+	if m.absenceResetAt == nil {
+		m.absenceResetAt = make(map[string]int)
+	}
+	m.absenceResetAt[issueID] = len(m.runHistories)
+	return nil
 }
 
 func (m *mockExitStore) UpsertSessionMetadata(_ context.Context, meta persistence.SessionMetadata) error {

--- a/internal/orchestrator/handoff_absence_test.go
+++ b/internal/orchestrator/handoff_absence_test.go
@@ -374,6 +374,92 @@ func TestHandleRetryTimerKeepsRecoveredExhaustedAbsenceParkedWhenLabelFails(t *t
 	}
 }
 
+func TestHandleWorkerExitReportsAbsenceResetFailure(t *testing.T) {
+	const issueID = "ABS-RESET-ERR"
+	dir, baseline := handoffEvidenceGitWorkspace(t)
+	if err := os.WriteFile(filepath.Join(dir, "work.txt"), []byte("work\n"), 0o600); err != nil {
+		t.Fatalf("write work file: %v", err)
+	}
+
+	store := &mockExitStore{absenceResetErr: errors.New("database is locked")}
+	seedMockHandoffAbsences(store, issueID, 1)
+	tracker := newRecordingHandoffTracker()
+	state := exitStateWithIssue(t, issueID, "In Progress")
+	params := handoffEvidenceExitParams(t, store, tracker.mockTrackerAdapter, &spyMetrics{})
+	params.TrackerAdapter = tracker
+	var logs bytes.Buffer
+	params.Logger = debugLogger(t, &logs)
+
+	HandleWorkerExit(state, WorkerResult{
+		IssueID:                 issueID,
+		Identifier:              "PROJ-RESET-ERR",
+		ExitKind:                WorkerExitNormal,
+		WorkspacePath:           dir,
+		HandoffEvidencePolicy:   config.HandoffEvidenceObserved,
+		HandoffEvidenceBaseline: baseline,
+		AgentAdapter:            "mock",
+	}, params)
+	t.Cleanup(func() { CancelRetry(state, issueID) })
+
+	if !strings.Contains(logs.String(), "failed to reset handoff absence sequence") {
+		t.Errorf("missing reset failure log\nlogs: %s", logs.String())
+	}
+	if len(tracker.transitionCalls) != 1 {
+		t.Errorf("TransitionIssue calls = %d, want 1: the handoff was withheld by a bookkeeping failure", len(tracker.transitionCalls))
+	}
+}
+
+func TestHandleRetryTimerFallsBackWhenAbsenceQueryFails(t *testing.T) {
+	const issueID = "ABS-QUERY-ERR"
+	store := &mockRetryStore{absenceCountErr: errors.New("database is locked")}
+	tracker := &mockRetryTracker{fetchedIssue: candidateIssue(issueID, "PROJ-QUERY", "In Progress")}
+	state := retryState(t, issueID, "PROJ-QUERY", 3)
+	params := defaultRetryParams(t, store, tracker)
+	params.MaxSessions = 0
+	var logs bytes.Buffer
+	params.Logger = debugLogger(t, &logs)
+
+	HandleRetryTimer(state, issueID, params)
+	state.TrackerOpsWg.Wait()
+
+	if !strings.Contains(logs.String(), "handoff absence count query failed") {
+		t.Errorf("missing query failure log\nlogs: %s", logs.String())
+	}
+	if _, ok := state.BudgetExhausted[issueID]; !ok {
+		t.Error("an unanswerable absence query resumed an exhausted sequence")
+	}
+	if tracker.fetchCount != 0 {
+		t.Errorf("FetchIssueByID calls = %d, want 0 after parking", tracker.fetchCount)
+	}
+}
+
+func TestRebuildBudgetExhaustedRetainsAbsenceParkingOnQueryError(t *testing.T) {
+	const issueID = "ABS-REBUILD-ERR"
+	issue := candidateIssue(issueID, "PROJ-REBUILD", "To Do")
+	cfg := config.ServiceConfig{}
+	store := &stubStore{absenceCountErr: errors.New("database is locked")}
+	state := NewState(1000, 1, nil, AgentTotals{})
+	state.BudgetExhausted[issueID] = struct{}{}
+	state.BudgetExhaustedReason[issueID] = budgetReasonHandoffAbsence
+	orchestrator := NewOrchestrator(OrchestratorParams{
+		State:           state,
+		Logger:          discardLogger(),
+		TrackerAdapter:  newRecordingHandoffTracker(),
+		AgentAdapter:    &mockAgentAdapter{},
+		WorkflowManager: &stubWorkflowManager{config: cfg},
+		Store:           store,
+	})
+
+	orchestrator.rebuildBudgetExhausted(context.Background(), cfg, []domain.Issue{issue})
+
+	if got := state.BudgetExhaustedReason[issueID]; got != budgetReasonHandoffAbsence {
+		t.Errorf("BudgetExhaustedReason = %q, want the parking retained across a query error", got)
+	}
+	if ShouldDispatch(issue, state, []string{"To Do"}, []string{"Done"}) {
+		t.Error("a query error released a parked issue")
+	}
+}
+
 func TestHandleRetryTimerExemptsReactionContinuationFromAbsenceGate(t *testing.T) {
 	const issueID = "ABS-REACTION"
 	store := &mockRetryStore{absenceCounts: map[string]int{issueID: 3}}

--- a/internal/orchestrator/handoff_absence_test.go
+++ b/internal/orchestrator/handoff_absence_test.go
@@ -374,6 +374,83 @@ func TestHandleRetryTimerKeepsRecoveredExhaustedAbsenceParkedWhenLabelFails(t *t
 	}
 }
 
+func TestHandleRetryTimerExemptsReactionContinuationFromAbsenceGate(t *testing.T) {
+	const issueID = "ABS-REACTION"
+	store := &mockRetryStore{absenceCounts: map[string]int{issueID: 3}}
+	tracker := &mockRetryTracker{fetchedIssue: candidateIssue(issueID, "PROJ-REACTION", "In Progress")}
+	state := retryState(t, issueID, "PROJ-REACTION", 1)
+	state.RetryAttempts[issueID].ReactionKind = ReactionKindReview
+	params := defaultRetryParams(t, store, tracker)
+	params.MaxSessions = 0
+
+	HandleRetryTimer(state, issueID, params)
+	state.TrackerOpsWg.Wait()
+
+	if tracker.fetchCount != 1 {
+		t.Errorf("FetchIssueByID calls = %d, want 1: the reaction retry was cancelled by unrelated absences", tracker.fetchCount)
+	}
+	if len(tracker.addedLabels) != 0 {
+		t.Errorf("AddLabel calls = %v, want none for a reaction continuation", tracker.addedLabels)
+	}
+	if _, ok := state.BudgetExhausted[issueID]; ok {
+		t.Error("reaction continuation parked by the handoff-absence ceiling")
+	}
+}
+
+func TestHandleRetryTimerSkipsAbsenceGateUnderOffPolicy(t *testing.T) {
+	const issueID = "ABS-OFF-RETRY"
+	store := &mockRetryStore{absenceCounts: map[string]int{issueID: 3}}
+	tracker := &mockRetryTracker{fetchedIssue: candidateIssue(issueID, "PROJ-OFF", "In Progress")}
+	state := retryState(t, issueID, "PROJ-OFF", 1)
+	params := defaultRetryParams(t, store, tracker)
+	params.MaxSessions = 0
+	params.HandoffEvidencePolicy = config.HandoffEvidenceOff
+
+	HandleRetryTimer(state, issueID, params)
+	state.TrackerOpsWg.Wait()
+
+	if len(store.absenceCountedIssueIDs) != 0 {
+		t.Errorf("absence query ran for %v under the off policy, want no query", store.absenceCountedIssueIDs)
+	}
+	if _, ok := state.BudgetExhausted[issueID]; ok {
+		t.Error("issue parked under the off policy")
+	}
+}
+
+func TestRebuildBudgetExhaustedSkipsAbsenceGateUnderOffPolicy(t *testing.T) {
+	const issueID = "ABS-OFF"
+	issue := candidateIssue(issueID, "PROJ-OFF", "To Do")
+	cfg := config.ServiceConfig{
+		Tracker: config.TrackerConfig{HandoffEvidence: config.HandoffEvidenceOff},
+	}
+	store := &stubStore{absenceCounts: map[string]int{issueID: 5}}
+	tracker := newRecordingHandoffTracker()
+	state := NewState(1000, 1, nil, AgentTotals{})
+	state.BudgetExhausted[issueID] = struct{}{}
+	state.BudgetExhaustedReason[issueID] = budgetReasonHandoffAbsence
+	orchestrator := NewOrchestrator(OrchestratorParams{
+		State:           state,
+		Logger:          discardLogger(),
+		TrackerAdapter:  tracker,
+		AgentAdapter:    &mockAgentAdapter{},
+		WorkflowManager: &stubWorkflowManager{config: cfg},
+		Store:           store,
+	})
+
+	orchestrator.rebuildBudgetExhausted(context.Background(), cfg, []domain.Issue{issue})
+	state.TrackerOpsWg.Wait()
+
+	if store.absenceQueryCalls != 0 {
+		t.Errorf("absence query ran %d times under the off policy, want 0", store.absenceQueryCalls)
+	}
+	if !ShouldDispatch(issue, state, []string{"To Do"}, []string{"Done"}) {
+		t.Error("the off policy left an issue gated by the absence ceiling")
+	}
+	if calls := tracker.labels(); len(calls) != 0 {
+		t.Errorf("AddLabel calls = %+v, want none under the off policy", calls)
+	}
+}
+
 func TestRebuildBudgetExhaustedRestoresAbsenceParkingAfterRestart(t *testing.T) {
 	const issueID = "ABS-POLL"
 	issue := candidateIssue(issueID, "PROJ-POLL", "To Do")

--- a/internal/orchestrator/handoff_absence_test.go
+++ b/internal/orchestrator/handoff_absence_test.go
@@ -270,6 +270,71 @@ func TestHandleWorkerExitWorkObservedResetsAbsenceSequenceBeforeHandoffWrite(t *
 	if len(tracker.transitionCalls) != 1 {
 		t.Errorf("TransitionIssue calls = %d, want 1 failing handoff attempt", len(tracker.transitionCalls))
 	}
+	if len(store.absenceResetOf) != 1 || store.absenceResetOf[0] != issueID {
+		t.Errorf("ResetHandoffAbsenceSequence calls = %v, want [%s]", store.absenceResetOf, issueID)
+	}
+}
+
+func TestHandleWorkerExitSucceededWithoutVerdictKeepsAbsenceSequence(t *testing.T) {
+	const issueID = "ABS-BLOCKED"
+	store := &mockExitStore{}
+	seedMockHandoffAbsences(store, issueID, 2)
+	tracker := newRecordingHandoffTracker()
+	blockedState := exitStateWithIssue(t, issueID, "In Progress")
+	params := handoffEvidenceExitParams(t, store, tracker.mockTrackerAdapter, &spyMetrics{})
+	params.TrackerAdapter = tracker
+
+	// A blocked soft stop records "succeeded" and carries no evidence verdict,
+	// so it must neither reset the sequence nor advance it.
+	blockedDir, blockedBaseline := handoffEvidenceGitWorkspace(t)
+	HandleWorkerExit(blockedState, WorkerResult{
+		IssueID:                 issueID,
+		Identifier:              "PROJ-BLOCKED",
+		ExitKind:                WorkerExitNormal,
+		WorkspacePath:           blockedDir,
+		SoftStop:                true,
+		SoftStopReason:          "blocked",
+		HandoffEvidencePolicy:   config.HandoffEvidenceObserved,
+		HandoffEvidenceBaseline: blockedBaseline,
+		AgentAdapter:            "mock",
+	}, params)
+
+	if len(store.runHistories) == 0 || store.runHistories[len(store.runHistories)-1].Status != "succeeded" {
+		t.Fatalf("blocked soft stop recorded %+v, want a succeeded row", store.runHistories)
+	}
+	if len(store.absenceResetOf) != 0 {
+		t.Errorf("ResetHandoffAbsenceSequence calls = %v, want none without a work-observed verdict", store.absenceResetOf)
+	}
+	counts, err := store.QueryConsecutiveHandoffAbsenceCounts(context.Background(), []string{issueID})
+	if err != nil {
+		t.Fatalf("QueryConsecutiveHandoffAbsenceCounts: %v", err)
+	}
+	if got := counts[issueID]; got != 2 {
+		t.Fatalf("consecutive absences after a blocked soft stop = %d, want 2", got)
+	}
+
+	// The next absence is therefore the third, and reaches the ceiling instead
+	// of restarting a sequence the soft stop appeared to have cleared.
+	absentDir, absentBaseline := handoffEvidenceGitWorkspace(t)
+	absentState := exitStateWithIssue(t, issueID, "In Progress")
+	HandleWorkerExit(absentState, WorkerResult{
+		IssueID:                 issueID,
+		Identifier:              "PROJ-BLOCKED",
+		ExitKind:                WorkerExitNormal,
+		WorkspacePath:           absentDir,
+		HandoffEvidencePolicy:   config.HandoffEvidenceObserved,
+		HandoffEvidenceBaseline: absentBaseline,
+		AgentAdapter:            "mock",
+	}, params)
+	absentState.TrackerOpsWg.Wait()
+	t.Cleanup(func() { CancelRetry(absentState, issueID) })
+
+	if _, ok := absentState.BudgetExhausted[issueID]; !ok {
+		t.Error("third consecutive absence did not park the issue")
+	}
+	if calls := tracker.labels(); len(calls) != 1 {
+		t.Errorf("AddLabel calls = %+v, want one parking call", calls)
+	}
 }
 
 func TestHandleRetryTimerKeepsRecoveredExhaustedAbsenceParkedWhenLabelFails(t *testing.T) {

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -36,6 +36,7 @@ type OrchestratorStore interface {
 	DeleteRetryEntry(ctx context.Context, issueID string) error
 	CountRunHistoryByIssue(ctx context.Context, issueID string) (int, error)
 	QueryConsecutiveHandoffAbsenceCounts(ctx context.Context, issueIDs []string) (map[string]int, error)
+	ResetHandoffAbsenceSequence(ctx context.Context, issueID string) error
 	TokenUsageByIssue(ctx context.Context, issueID string) (persistence.IssueTokenUsage, error)
 	QueryBudgetExhaustedIssues(ctx context.Context, candidateIDs []string, maxSessions int) ([]string, error)
 	QueryTokenBudgetUsage(ctx context.Context, candidateIDs []string) (map[string]persistence.IssueTokenUsage, error)

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -421,24 +421,25 @@ func (o *Orchestrator) Run(ctx context.Context) {
 		case issueID := <-o.retryTimerCh:
 			cfg := o.workflowManager.Config()
 			HandleRetryTimer(o.state, issueID, HandleRetryTimerParams{
-				Store:               o.store,
-				TrackerAdapter:      o.trackerAdapter,
-				ActiveStates:        cfg.Tracker.ActiveStates,
-				TerminalStates:      cfg.Tracker.TerminalStates,
-				HandoffState:        cfg.Tracker.HandoffState,
-				MaxRetryBackoffMS:   cfg.Agent.MaxRetryBackoffMS,
-				MakeWorkerFn:        o.makeWorkerFn,
-				AgentAdapterByKind:  o.agentAdapterByKind,
-				DefaultAgentKind:    cfg.Agent.Kind,
-				OnRetryFire:         o.onRetryFire,
-				Ctx:                 ctx,
-				Logger:              o.logger,
-				MaxSessions:         cfg.Agent.MaxSessions,
-				HandoffParkingLabel: o.handoffParkingLabel,
-				MaxTokens:           cfg.Agent.MaxTokens,
-				Metrics:             o.metrics,
-				HostPool:            o.hostPool,
-				WorkflowFile:        o.workflowFile(),
+				Store:                 o.store,
+				TrackerAdapter:        o.trackerAdapter,
+				ActiveStates:          cfg.Tracker.ActiveStates,
+				TerminalStates:        cfg.Tracker.TerminalStates,
+				HandoffState:          cfg.Tracker.HandoffState,
+				MaxRetryBackoffMS:     cfg.Agent.MaxRetryBackoffMS,
+				MakeWorkerFn:          o.makeWorkerFn,
+				AgentAdapterByKind:    o.agentAdapterByKind,
+				DefaultAgentKind:      cfg.Agent.Kind,
+				OnRetryFire:           o.onRetryFire,
+				Ctx:                   ctx,
+				Logger:                o.logger,
+				MaxSessions:           cfg.Agent.MaxSessions,
+				HandoffParkingLabel:   o.handoffParkingLabel,
+				HandoffEvidencePolicy: cfg.Tracker.HandoffEvidence,
+				MaxTokens:             cfg.Agent.MaxTokens,
+				Metrics:               o.metrics,
+				HostPool:              o.hostPool,
+				WorkflowFile:          o.workflowFile(),
 			})
 			o.updateGauges(time.Now())
 			o.notifyObservers()
@@ -875,9 +876,18 @@ func (o *Orchestrator) maybeWriteIncrementalMetadata(ctx context.Context, issueI
 // token budget takes precedence over the ordinary session budget. On a
 // query error for one axis, the prior entries attributed to that axis are
 // folded back in so a transient error never drops an issue mid-tick, while
-// the other axes keep their fresh results.
+// the other axes keep their fresh results. The absence gate is skipped under
+// the off evidence policy, which records no absence and must cost nothing.
 // Must be called from the event loop goroutine.
 func (o *Orchestrator) rebuildBudgetExhausted(ctx context.Context, cfg config.ServiceConfig, sorted []domain.Issue) {
+	absenceGateEnabled := cfg.Tracker.HandoffEvidence.Effective() != config.HandoffEvidenceOff
+	if cfg.Agent.MaxSessions == 0 && cfg.Agent.MaxTokens == 0 && !absenceGateEnabled {
+		o.state.BudgetExhausted = make(map[string]struct{})
+		o.state.BudgetExhaustedReason = make(map[string]string)
+		o.state.TokenBudgetIncomplete = make(map[string]struct{})
+		return
+	}
+
 	candidateIDs := make([]string, len(sorted))
 	identifierByID := make(map[string]string, len(sorted))
 	for i, issue := range sorted {
@@ -921,28 +931,30 @@ func (o *Orchestrator) rebuildBudgetExhausted(ctx context.Context, cfg config.Se
 	// on every poll so a parked issue remains ineligible across restart and
 	// even when no retry row survived the final worker exit.
 	absenceCeiling := handoffAbsenceCeiling(cfg.Agent.MaxSessions)
-	absenceCounts, absenceErr := o.store.QueryConsecutiveHandoffAbsenceCounts(ctx, candidateIDs)
-	if absenceErr != nil {
-		o.logger.Warn("handoff absence exhaustion query failed, retaining previous set",
-			slog.Any("error", absenceErr),
-		)
-		for id := range prior {
-			if priorReason[id] != budgetReasonHandoffAbsence {
-				continue
+	if absenceGateEnabled {
+		absenceCounts, absenceErr := o.store.QueryConsecutiveHandoffAbsenceCounts(ctx, candidateIDs)
+		if absenceErr != nil {
+			o.logger.Warn("handoff absence exhaustion query failed, retaining previous set",
+				slog.Any("error", absenceErr),
+			)
+			for id := range prior {
+				if priorReason[id] != budgetReasonHandoffAbsence {
+					continue
+				}
+				fresh[id] = struct{}{}
+				freshReason[id] = budgetReasonHandoffAbsence
 			}
-			fresh[id] = struct{}{}
-			freshReason[id] = budgetReasonHandoffAbsence
-		}
-	} else {
-		for _, id := range candidateIDs {
-			count := absenceCounts[id]
-			if count < absenceCeiling {
-				continue
-			}
-			fresh[id] = struct{}{}
-			freshReason[id] = budgetReasonHandoffAbsence
-			if priorReason[id] != budgetReasonHandoffAbsence {
-				newlyParked = append(newlyParked, parkedCandidate{issueID: id, count: count})
+		} else {
+			for _, id := range candidateIDs {
+				count := absenceCounts[id]
+				if count < absenceCeiling {
+					continue
+				}
+				fresh[id] = struct{}{}
+				freshReason[id] = budgetReasonHandoffAbsence
+				if priorReason[id] != budgetReasonHandoffAbsence {
+					newlyParked = append(newlyParked, parkedCandidate{issueID: id, count: count})
+				}
 			}
 		}
 	}

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -108,6 +108,8 @@ type stubStore struct {
 	budgetExhaustedErr error
 	absenceCounts      map[string]int
 	absenceCountErr    error
+	absenceQueryCalls  int
+	absenceResetOf     []string
 
 	// Token budget query configuration (per-tick rebuild and single-issue gate).
 	tokenExhaustedIDs []string
@@ -198,6 +200,7 @@ func (s *stubStore) QueryBudgetExhaustedIssues(_ context.Context, _ []string, _ 
 func (s *stubStore) QueryConsecutiveHandoffAbsenceCounts(_ context.Context, candidateIDs []string) (map[string]int, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	s.absenceQueryCalls++
 	if s.absenceCountErr != nil {
 		return nil, s.absenceCountErr
 	}
@@ -206,6 +209,14 @@ func (s *stubStore) QueryConsecutiveHandoffAbsenceCounts(_ context.Context, cand
 		result[id] = s.absenceCounts[id]
 	}
 	return result, nil
+}
+
+func (s *stubStore) ResetHandoffAbsenceSequence(_ context.Context, issueID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.absenceResetOf = append(s.absenceResetOf, issueID)
+	delete(s.absenceCounts, issueID)
+	return nil
 }
 
 // QueryTokenBudgetUsage reports a candidate named in tokenExhaustedIDs as

--- a/internal/orchestrator/retry.go
+++ b/internal/orchestrator/retry.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/sortie-ai/sortie/internal/config"
 	"github.com/sortie-ai/sortie/internal/domain"
 	"github.com/sortie-ai/sortie/internal/logging"
 	"github.com/sortie-ai/sortie/internal/persistence"
@@ -111,6 +112,11 @@ type HandleRetryTimerParams struct {
 	// HandoffParkingLabel is the review-comments escalation label captured
 	// at orchestrator construction. Empty falls back to "needs-human".
 	HandoffParkingLabel string
+
+	// HandoffEvidencePolicy is the configured evidence policy. Under the
+	// off policy no absence is ever recorded, so the absence gate is not
+	// consulted. The zero value applies the default policy.
+	HandoffEvidencePolicy config.HandoffEvidencePolicy
 
 	// MaxTokens is the configured per-issue token budget (from
 	// config.Agent.MaxTokens). When > 0, HandleRetryTimer sums
@@ -221,34 +227,43 @@ func HandleRetryTimer(state *State, issueID string, params HandleRetryTimerParam
 		return
 	}
 
-	// Consecutive handoff-absence gate. This check runs for every retry
-	// fire, including entries reconstructed after restart, before any tracker
-	// fetch or worker dispatch. The persisted run-history sequence therefore
-	// remains a dispatch gate even if the process exited between recording the
-	// final absence and deleting its retry row.
-	absenceCeiling := handoffAbsenceCeiling(params.MaxSessions)
-	absenceCounts, absenceErr := params.Store.QueryConsecutiveHandoffAbsenceCounts(ctx, []string{issueID})
-	consecutiveAbsences := absenceCounts[issueID]
-	if absenceErr != nil {
-		consecutiveAbsences = max(popped.Attempt, 1)
-		log.Warn("handoff absence count query failed, using retry attempt fallback",
-			slog.Int("consecutive_absences", consecutiveAbsences),
-			slog.Any("error", absenceErr),
-		)
-	}
-	if consecutiveAbsences >= absenceCeiling {
-		parkHandoffAbsence(
-			state,
-			ctx,
-			params.Store,
-			params.TrackerAdapter,
-			issueID,
-			consecutiveAbsences,
-			absenceCeiling,
-			params.HandoffParkingLabel,
-			log,
-		)
-		return
+	// Consecutive handoff-absence gate. This check runs for every primary
+	// retry fire, including entries reconstructed after restart, before any
+	// tracker fetch or worker dispatch. The persisted run-history sequence
+	// therefore remains a dispatch gate even if the process exited between
+	// recording the final absence and deleting its retry row.
+	//
+	// A reaction continuation is exempt. Only a primary dispatch can record an
+	// absence, so parking one here would cancel a retry sequence the ceiling
+	// does not govern, on the strength of absences from unrelated runs. The off
+	// policy records no absence at all and is not inspected here either.
+	absenceGateApplies := params.HandoffEvidencePolicy.Effective() != config.HandoffEvidenceOff &&
+		!isKnownReactionKind(popped.ReactionKind)
+	if absenceGateApplies {
+		absenceCeiling := handoffAbsenceCeiling(params.MaxSessions)
+		absenceCounts, absenceErr := params.Store.QueryConsecutiveHandoffAbsenceCounts(ctx, []string{issueID})
+		consecutiveAbsences := absenceCounts[issueID]
+		if absenceErr != nil {
+			consecutiveAbsences = max(popped.Attempt, 1)
+			log.Warn("handoff absence count query failed, using retry attempt fallback",
+				slog.Int("consecutive_absences", consecutiveAbsences),
+				slog.Any("error", absenceErr),
+			)
+		}
+		if consecutiveAbsences >= absenceCeiling {
+			parkHandoffAbsence(
+				state,
+				ctx,
+				params.Store,
+				params.TrackerAdapter,
+				issueID,
+				consecutiveAbsences,
+				absenceCeiling,
+				params.HandoffParkingLabel,
+				log,
+			)
+			return
+		}
 	}
 
 	// blockBudget releases the claim and drops the retry entry for an issue

--- a/internal/persistence/migrations.go
+++ b/internal/persistence/migrations.go
@@ -47,6 +47,9 @@ var migration011SQL string
 //go:embed sql/012_run_history_tokens_measured.sql
 var migration012SQL string
 
+//go:embed sql/013_handoff_absence_resets.sql
+var migration013SQL string
+
 var migrations = []Migration{
 	{Version: 1, Description: "core persistence tables", SQL: migration001SQL},
 	{Version: 2, Description: "extended token metrics", SQL: migration002SQL},
@@ -60,4 +63,5 @@ var migrations = []Migration{
 	{Version: 10, Description: "dispatch rule routing columns on retry_entries and run_history", SQL: migration010SQL},
 	{Version: 11, Description: "run_history token columns", SQL: migration011SQL},
 	{Version: 12, Description: "tokens_measured column on run_history", SQL: migration012SQL},
+	{Version: 13, Description: "handoff absence sequence reset points", SQL: migration013SQL},
 }

--- a/internal/persistence/run_history.go
+++ b/internal/persistence/run_history.go
@@ -304,16 +304,16 @@ func (s *Store) CountRunHistoryByIssue(ctx context.Context, issueID string) (int
 }
 
 // QueryConsecutiveHandoffAbsenceCounts returns the number of handoff-absence
-// failures for each requested issue since its most recent successful run.
-// Other failed or cancelled runs do not reset the sequence because they do not
-// establish that work was observed. Issues with no qualifying rows are omitted
-// from the returned map.
+// failures for each requested issue since the run at which
+// [Store.ResetHandoffAbsenceSequence] last ended that issue's sequence. Issues
+// with no qualifying rows are omitted from the returned map.
 //
-// A successful run ends the active absence sequence. On the otherwise-eligible
-// handoff path this includes a work-observed result, even when the subsequent
-// tracker handoff write fails; successful outcomes that hand off under the
-// observed or off policies also leave the active queue and therefore end that
-// dispatch sequence.
+// Only a work-observed verdict resets the sequence. A terminal status of
+// "succeeded" does not, because it is also recorded for outcomes that carry no
+// verdict at all: a blocked soft stop, a run that does not drive issue state, a
+// run whose evidence was not determinable, and every run under the off policy.
+// Counting those as a reset would let an absence sequence alternate below the
+// ceiling indefinitely.
 func (s *Store) QueryConsecutiveHandoffAbsenceCounts(ctx context.Context, issueIDs []string) (map[string]int, error) {
 	counts := make(map[string]int)
 	if len(issueIDs) == 0 {
@@ -335,13 +335,11 @@ func (s *Store) QueryConsecutiveHandoffAbsenceCounts(ctx context.Context, issueI
 		 WHERE r.issue_id IN (%s)
 		   AND r.status = 'failed'
 		   AND substr(r.error, 1, ?) = ?
-		   AND NOT EXISTS (
-		       SELECT 1
-		       FROM run_history AS succeeded
-		       WHERE succeeded.issue_id = r.issue_id
-		         AND succeeded.status = 'succeeded'
-		         AND succeeded.id > r.id
-		   )
+		   AND r.id > COALESCE((
+		       SELECT reset.reset_run_id
+		       FROM handoff_absence_resets AS reset
+		       WHERE reset.issue_id = r.issue_id
+		   ), 0)
 		 GROUP BY r.issue_id`,
 		placeholders,
 	)
@@ -364,6 +362,30 @@ func (s *Store) QueryConsecutiveHandoffAbsenceCounts(ctx context.Context, issueI
 		return nil, fmt.Errorf("query consecutive handoff absences: %w", err)
 	}
 	return counts, nil
+}
+
+// ResetHandoffAbsenceSequence ends the issue's consecutive handoff-absence
+// sequence at its most recently recorded run, so
+// [Store.QueryConsecutiveHandoffAbsenceCounts] reports zero until a further
+// absence is recorded.
+//
+// The reset point is read from run_history inside the statement rather than
+// supplied by the caller, so a work-observed run whose own history row could
+// not be persisted still clears the absences recorded before it.
+func (s *Store) ResetHandoffAbsenceSequence(ctx context.Context, issueID string) error {
+	now := time.Now().UTC().Format(time.RFC3339)
+	_, err := s.db.ExecContext(ctx, `
+		INSERT INTO handoff_absence_resets (issue_id, reset_run_id, updated_at)
+		VALUES (?, COALESCE((SELECT MAX(id) FROM run_history WHERE issue_id = ?), 0), ?)
+		ON CONFLICT (issue_id) DO UPDATE SET
+			reset_run_id = excluded.reset_run_id,
+			updated_at = excluded.updated_at`,
+		issueID, issueID, now,
+	)
+	if err != nil {
+		return fmt.Errorf("reset handoff absence sequence for %q: %w", issueID, err)
+	}
+	return nil
 }
 
 // QueryBudgetExhaustedIssues returns issue IDs from candidateIDs whose

--- a/internal/persistence/run_history_absence_test.go
+++ b/internal/persistence/run_history_absence_test.go
@@ -24,6 +24,22 @@ func appendAbsenceSequenceRun(t *testing.T, store *Store, issueID, status, error
 	})
 }
 
+func resetOrFatal(t *testing.T, store *Store, issueID string) {
+	t.Helper()
+	if err := store.ResetHandoffAbsenceSequence(context.Background(), issueID); err != nil {
+		t.Fatalf("ResetHandoffAbsenceSequence(%q): %v", issueID, err)
+	}
+}
+
+func absenceCountOrFatal(t *testing.T, store *Store, issueID string) int {
+	t.Helper()
+	counts, err := store.QueryConsecutiveHandoffAbsenceCounts(context.Background(), []string{issueID})
+	if err != nil {
+		t.Fatalf("QueryConsecutiveHandoffAbsenceCounts(%q): %v", issueID, err)
+	}
+	return counts[issueID]
+}
+
 func handoffAbsenceError() string {
 	return HandoffAbsenceErrorPrefix + "absence of work observed under observed policy"
 }
@@ -39,10 +55,19 @@ func TestQueryConsecutiveHandoffAbsenceCounts(t *testing.T) {
 	appendAbsenceSequenceRun(t, store, "ISS-FAILURES", "failed", "agent transport failed")
 	appendAbsenceSequenceRun(t, store, "ISS-FAILURES", "failed", handoffAbsenceError())
 
-	// A successful run resets the sequence; only the later absence counts.
+	// A work-observed run resets the sequence; only the later absence counts.
 	appendAbsenceSequenceRun(t, store, "ISS-RESET", "failed", handoffAbsenceError())
 	appendAbsenceSequenceRun(t, store, "ISS-RESET", "succeeded", "")
+	resetOrFatal(t, store, "ISS-RESET")
 	appendAbsenceSequenceRun(t, store, "ISS-RESET", "failed", handoffAbsenceError())
+
+	// A successful run that carries no work-observed verdict - a blocked soft
+	// stop, a reaction run, a run under the off policy - does not reset the
+	// sequence, so absences either side of it accumulate toward the ceiling.
+	appendAbsenceSequenceRun(t, store, "ISS-SUCCEEDED", "failed", handoffAbsenceError())
+	appendAbsenceSequenceRun(t, store, "ISS-SUCCEEDED", "failed", handoffAbsenceError())
+	appendAbsenceSequenceRun(t, store, "ISS-SUCCEEDED", "succeeded", "")
+	appendAbsenceSequenceRun(t, store, "ISS-SUCCEEDED", "failed", handoffAbsenceError())
 
 	// Cancellation is not positive evidence and therefore does not reset.
 	appendAbsenceSequenceRun(t, store, "ISS-CANCEL", "failed", handoffAbsenceError())
@@ -53,15 +78,17 @@ func TestQueryConsecutiveHandoffAbsenceCounts(t *testing.T) {
 	// one-absence sequence, so it can never accumulate toward three.
 	appendAbsenceSequenceRun(t, store, "ISS-ALTERNATING", "failed", handoffAbsenceError())
 	appendAbsenceSequenceRun(t, store, "ISS-ALTERNATING", "succeeded", "")
+	resetOrFatal(t, store, "ISS-ALTERNATING")
 	appendAbsenceSequenceRun(t, store, "ISS-ALTERNATING", "failed", handoffAbsenceError())
 	appendAbsenceSequenceRun(t, store, "ISS-ALTERNATING", "succeeded", "")
+	resetOrFatal(t, store, "ISS-ALTERNATING")
 	appendAbsenceSequenceRun(t, store, "ISS-ALTERNATING", "failed", handoffAbsenceError())
 
 	// Similar text that does not begin with the reserved marker is ordinary
 	// failure data and must not be counted.
 	appendAbsenceSequenceRun(t, store, "ISS-OTHER", "failed", "worker error: handoff withheld: no output")
 
-	ids := []string{"ISS-FAILURES", "ISS-RESET", "ISS-CANCEL", "ISS-ALTERNATING", "ISS-OTHER", "ISS-NONE"}
+	ids := []string{"ISS-FAILURES", "ISS-RESET", "ISS-SUCCEEDED", "ISS-CANCEL", "ISS-ALTERNATING", "ISS-OTHER", "ISS-NONE"}
 	got, err := store.QueryConsecutiveHandoffAbsenceCounts(context.Background(), ids)
 	if err != nil {
 		t.Fatalf("QueryConsecutiveHandoffAbsenceCounts: %v", err)
@@ -70,6 +97,7 @@ func TestQueryConsecutiveHandoffAbsenceCounts(t *testing.T) {
 	want := map[string]int{
 		"ISS-FAILURES":    2,
 		"ISS-RESET":       1,
+		"ISS-SUCCEEDED":   3,
 		"ISS-CANCEL":      2,
 		"ISS-ALTERNATING": 1,
 	}
@@ -77,6 +105,68 @@ func TestQueryConsecutiveHandoffAbsenceCounts(t *testing.T) {
 		if got[id] != want[id] {
 			t.Errorf("count[%s] = %d, want %d", id, got[id], want[id])
 		}
+	}
+}
+
+func TestResetHandoffAbsenceSequence(t *testing.T) {
+	t.Parallel()
+
+	store := openTestStore(t)
+	migrateOrFatal(t, store)
+
+	appendAbsenceSequenceRun(t, store, "ISS-1", "failed", handoffAbsenceError())
+	appendAbsenceSequenceRun(t, store, "ISS-1", "failed", handoffAbsenceError())
+	if got := absenceCountOrFatal(t, store, "ISS-1"); got != 2 {
+		t.Fatalf("count before reset = %d, want 2", got)
+	}
+
+	resetOrFatal(t, store, "ISS-1")
+	if got := absenceCountOrFatal(t, store, "ISS-1"); got != 0 {
+		t.Errorf("count after reset = %d, want 0", got)
+	}
+
+	// A later absence starts a fresh sequence, and a second reset ends that
+	// one too rather than being ignored as already recorded.
+	appendAbsenceSequenceRun(t, store, "ISS-1", "failed", handoffAbsenceError())
+	if got := absenceCountOrFatal(t, store, "ISS-1"); got != 1 {
+		t.Errorf("count after later absence = %d, want 1", got)
+	}
+	resetOrFatal(t, store, "ISS-1")
+	if got := absenceCountOrFatal(t, store, "ISS-1"); got != 0 {
+		t.Errorf("count after second reset = %d, want 0", got)
+	}
+}
+
+func TestResetHandoffAbsenceSequenceWithoutRunHistoryRow(t *testing.T) {
+	t.Parallel()
+
+	store := openTestStore(t)
+	migrateOrFatal(t, store)
+
+	// A work-observed run whose own history row could not be persisted still
+	// clears the absences recorded before it, and does not swallow later ones.
+	appendAbsenceSequenceRun(t, store, "ISS-NOROW", "failed", handoffAbsenceError())
+	resetOrFatal(t, store, "ISS-NOROW")
+	if got := absenceCountOrFatal(t, store, "ISS-NOROW"); got != 0 {
+		t.Errorf("count after reset = %d, want 0", got)
+	}
+
+	appendAbsenceSequenceRun(t, store, "ISS-NOROW", "failed", handoffAbsenceError())
+	if got := absenceCountOrFatal(t, store, "ISS-NOROW"); got != 1 {
+		t.Errorf("count after later absence = %d, want 1", got)
+	}
+}
+
+func TestResetHandoffAbsenceSequenceError(t *testing.T) {
+	t.Parallel()
+
+	store := openTestStore(t)
+	migrateOrFatal(t, store)
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if err := store.ResetHandoffAbsenceSequence(context.Background(), "ISS-1"); err == nil {
+		t.Fatal("ResetHandoffAbsenceSequence on closed store returned nil error")
 	}
 }
 

--- a/internal/persistence/sql/013_handoff_absence_resets.sql
+++ b/internal/persistence/sql/013_handoff_absence_resets.sql
@@ -1,0 +1,13 @@
+-- Migration 13: reset points for the consecutive handoff-absence sequence
+--
+-- Records, per issue, the run_history id at which a work-observed verdict
+-- ended that issue's absence sequence. Absence rows at or below that id are
+-- excluded from the consecutive count, so only a work-observed verdict resets
+-- the sequence. No verdict is stored on run_history: a terminal status of
+-- 'succeeded' does not by itself assert that work was observed.
+
+CREATE TABLE handoff_absence_resets (
+    issue_id     TEXT    PRIMARY KEY,
+    reset_run_id INTEGER NOT NULL,
+    updated_at   TEXT    NOT NULL
+);


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Fix

**Intent:** The consecutive handoff-absence bound landed with a reset predicate wider than the rule it enforces and a gate that fired on paths that can never record an absence. As merged, an issue could alternate absence, absence, blocked, absence, absence, blocked forever without reaching the ceiling, so the unbounded loop the bound exists to close survived in a narrower form; separately, a review-comment or CI continuation retry could be cancelled and its issue parked because of absences from unrelated primary runs.

**Related Issues:** Follow-up to [#769](https://github.com/sortie-ai/sortie/issues/769)

### 🧭 Reviewer Guide

**Complexity:** High

#### Entry Point

`internal/persistence/run_history.go` - `QueryConsecutiveHandoffAbsenceCounts` previously ended an absence sequence at any `run_history` row recorded as `succeeded`. That status is a function of the worker exit kind, so it is also written for outcomes carrying no evidence verdict at all: a blocked soft stop, a run that does not drive issue state, a handoff permitted under `observed` whose tracker write then failed, and every run under `off`. The rule resets the count on a work-observed verdict only.

Nothing already stored distinguishes a work-observed run from any other successful one, and both the accepted decision and the schema material rule out a verdict column on `run_history`. The reset is therefore recorded as its own per-issue fact: migration 013 adds `handoff_absence_resets`, holding the run at which a work-observed verdict last ended the sequence, and the count is the absence rows recorded after it. The reset point is read from `run_history` inside the write, so a work-observed run whose own history row failed to persist still clears the absences before it. The table stores a position that is overwritten, not verdict history.

The other three fixes are smaller: `HandleWorkerExit` now records that reset, `rebuildBudgetExhausted` regained its early return so `handoff_evidence: off` issues no query and gates no issue, and the retry-timer gate consults the popped entry.

#### Sensitive Areas

- `internal/persistence/sql/013_handoff_absence_resets.sql`: new table, applied at startup. An existing database has no rows in it, so absences already recorded count in full against the ceiling on first run after the upgrade.
- `internal/orchestrator/exit.go`: the reset is written after the run history row and before the handoff transition is attempted, so a failing tracker write cannot restore the old count.
- `internal/orchestrator/retry.go`: the absence gate is now skipped for a known reaction kind and under the `off` policy. The count-query failure fallback, which substitutes the retry attempt number, could otherwise park an issue that never recorded an absence at all.
- `internal/orchestrator/exit_test.go`: the worker-exit test double reproduced the same too-broad predicate, so the suite could not fail on it. It now mirrors the store.

#### Not addressed

A parked issue still has no release path per issue. The gate is derived from recorded absences and only a work-observed run clears it, but a parked issue cannot be dispatched, so it cannot produce one. Raising `agent.max_sessions` above the recorded count releases it, and so does `handoff_evidence: off`, which after this change disables the gate outright - both follow from what is already specified, and both are deployment-wide rather than per issue. A human gesture such as removing the escalation label or moving the issue back to an active state would require reading labels or issue state as a dispatch input, which nothing in the system does today and neither the decision nor the specification establishes. That is a decision to take, not a patch to write, so it is left alone here.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes. The corrected reset makes the ceiling reachable in sequences where it previously was not, which is the intended behavior; an issue whose empty runs were interleaved with blocked stops or reaction runs will now park.
- **Migrations/State:** Migration 013 adds the `handoff_absence_resets` table. It is additive and applied automatically at startup.