### PR TITLE
fix(orchestrator): hold blocked issues out of dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `after_run` hook in place of `disabled`.
   ([#813](https://github.com/sortie-ai/sortie/issues/813))
 
+- An agent that writes `blocked` to `.sortie/status` now holds its
+  issue until a person acts, instead of having it dispatched again on
+  the next poll and on every poll after that. Sortie parks the issue:
+  it attaches the escalation label configured under
+  `reactions.review_comments.escalation_label` (`needs-human` when that
+  block or value is absent), holds the issue out of dispatch and out of
+  the retry lane, keeps it parked across a restart, and counts it on
+  `sortie_issue_parks_total{reason}`. The issue keeps the tracker state
+  it was dispatched in, so the label is what marks it as waiting on a
+  person. Nothing previously outlasted the run, leaving
+  `agent.max_sessions` as the only bound on the repeat and no bound at
+  all where it is unset. A park is released when Sortie observes
+  someone act on the issue: moving it to another tracker state, or
+  removing the parking label. The same release now applies to an issue
+  parked for producing no observable work. Where `tracker.query_filter`
+  excludes the parking label, Sortie never confirms the label is
+  present and removing it releases nothing, so release those issues by
+  moving them instead.
+  ([#811](https://github.com/sortie-ai/sortie/issues/811))
+
 ### Migrations
 
 - Add the `handoff_absence_resets` table, recording per issue where its
@@ -116,6 +136,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   work. An issue with no row there has its recorded empty runs counted
   in full, so an upgrade carries any absences already in the database
   into the new ceiling.
+
+- Add the `parked_issues` table, holding one row per issue currently
+  held out of dispatch. It records current state rather than history:
+  the row is deleted when the park is released. An upgrade starts with
+  no parked issues, so an issue whose agent reported itself blocked
+  before the upgrade is parked the next time it reports it.
 
 ## [1.19.0] - 2026-08-12
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,7 @@ Read the Makefile to discover available targets before running any Go toolchain 
 Consult these for the area you are working on, not as a blanket prerequisite:
 
 - `docs/architecture.md` - the index. A system-at-a-glance plus a routing table mapping each task to the one section it needs. It is a map, not a second source of truth.
-- `docs/architecture/NN-<slug>.md` - the specification, one file per section. Open only the section the index routes you to; on conflict the section file wins.
+- `docs/architecture/NN-<slug>.md` - the specification, one file per section; `NN` is a file ordinal, not the section number (file 14 holds section 11C). Open only the section the index routes you to; on conflict the section file wins.
 - `docs/decisions/*.md` - accepted ADRs. Read when discussing or revising a prior design choice.
 - `docs/workflow-reference.md` - WORKFLOW.md syntax.
 - `docs/*-adapter-notes.md` - API details, response examples and implementation tips per integration.

--- a/cmd/sortie/main.go
+++ b/cmd/sortie/main.go
@@ -253,6 +253,13 @@ func run(ctx context.Context, args []string, stdout io.Writer, stderr io.Writer)
 	)
 	orchestrator.PopulateRetries(state, pendingRetries, br.logger)
 
+	parkedRows, err := store.ListParkedIssues(ctx)
+	if err != nil {
+		br.logger.Warn("failed to load park records, starting with none", slog.Any("error", err))
+	} else {
+		orchestrator.PopulateParked(state, parkedRows, br.logger)
+	}
+
 	// --- Agent adapter construction ---
 
 	agentCtor, err := registry.Agents.Get(br.cfg.Agent.Kind)

--- a/docs/agent-to-orchestrator-protocol.md
+++ b/docs/agent-to-orchestrator-protocol.md
@@ -182,8 +182,11 @@ current turn normally, then breaks the turn loop — no further continuation tur
 the current worker run. This value never admits the run to the self-review phase (Section 2.3.2);
 it remains an immediate exit whether or not self-review is configured. On worker exit, the
 orchestrator MUST NOT schedule a continuation retry
-([architecture Section 8.4](architecture/08-polling-scheduling-and-reconciliation.md#84-retry-and-backoff)). The claim on the issue is released. If the issue subsequently returns
-to an active state (e.g., after a human updates it), normal dispatch eligibility resumes.
+([architecture Section 8.4](architecture/08-polling-scheduling-and-reconciliation.md#84-retry-and-backoff)). When the dispatch that produced this run drives issue state, the orchestrator
+releases the claim and parks the issue: it records a durable park, applies the configured parking
+label to the issue, and holds it out of dispatch. The park is lifted, and normal dispatch
+eligibility resumes, when the orchestrator observes either a change in the issue's tracker state
+or the removal of a parking label it has confirmed reached the tracker.
 
 To clarify the two distinct suppression effects:
 
@@ -247,9 +250,12 @@ Additionally, for `needs-human-review` only: when `tracker.handoff_state` is con
 issue is in an active tracker state, the orchestrator attempts the handoff transition between
 steps 6 and 8. See Section 2.3.2 for failure handling.
 
-After the orchestrator releases the claim, the issue becomes eligible for re-dispatch on a
-subsequent tracker poll if it still satisfies normal dispatch rules (active state, not
-claimed, not budget-exhausted).
+For `needs-human-review`, after the orchestrator releases the claim, the issue becomes eligible
+for re-dispatch on a subsequent tracker poll if it still satisfies normal dispatch rules (active
+state, not claimed, not budget-exhausted, not parked). For `blocked`, where the dispatch drove
+issue state, the orchestrator parks the issue instead (Section 2.3.1): the issue is held out of
+dispatch until the orchestrator observes a tracker state change or the removal of a confirmed
+parking label, not merely until it satisfies the ordinary rules again.
 
 #### 2.3.4 Last-state-wins semantics
 
@@ -464,12 +470,19 @@ not prevent the phase from running.
 The re-dispatch and re-block cycle is an expected operational pattern:
 
 1. Agent writes `blocked` to `.sortie/status`.
-2. Orchestrator reads the signal, exits normally, releases claim.
-3. A human updates the issue in the tracker (adds information, changes state).
-4. Next tracker poll detects the issue is active and eligible.
-5. Orchestrator dispatches a new worker run for the issue.
+2. Orchestrator reads the signal, exits normally, releases claim, records a park, and applies
+   the parking label.
+3. A human acts on the issue: either moves it to a different tracker state, or removes the
+   parking label the orchestrator has confirmed reached the tracker.
+4. The next poll tick observes the state change or the confirmed label's removal and lifts the
+   park.
+5. If the issue is now active and eligible, the orchestrator dispatches a new worker run for it.
 6. Pre-dispatch cleanup (Section 3.4) removes the stale `.sortie/status` file.
 7. Agent begins fresh work. If still blocked, it writes `blocked` again.
+
+An update to the issue that is neither a state change nor a removal of the confirmed parking
+label, for example adding a comment while leaving both the state and the label untouched, does
+not lift the park.
 
 The polling interval provides natural rate limiting for this cycle. No additional idempotency
 mechanism is required.
@@ -483,9 +496,13 @@ exit phase. The status file value determines whether the handoff transition fire
 | `.sortie/status` value | Worker exit | Handoff transition | Continuation retry |
 |---|---|---|---|
 | `needs-human-review` | Normal | Performed (if configured and issue is active) | Suppressed |
-| `blocked` | Normal | Skipped | Suppressed |
+| `blocked` | Normal | Skipped; issue parked instead where the dispatch drives issue state | Suppressed |
 | absent or unrecognized | Normal | Performed (if configured and issue is active) | Depends on handoff result |
 | (any) | Error | Skipped | Standard error retry |
+
+The parking label the orchestrator applies on a `blocked` park is a non-state write: it marks the
+issue without transitioning it, the same way the handoff transition moves the issue's state
+without touching any label.
 
 Every row that performs the handoff is additionally subject to the run's
 `tracker.handoff_evidence` verdict
@@ -818,6 +835,8 @@ An implementation conforms to this specification if it satisfies all of the foll
 7. The status file does not trigger tracker state transitions per Section 3.6.
 8. Symbolic links at any path component are treated as read errors per Section 7.2.
 9. Pre-dispatch cleanup applies the same symlink rejection as reads per Section 3.4.
+10. The orchestrator parks the issue on `blocked` where the dispatch drives issue state, and
+    holds it out of dispatch until it observes a release per Section 2.3.1 and Section 3.5.
 
 ## References
 

--- a/docs/architecture/07-orchestration-state-machine.md
+++ b/docs/architecture/07-orchestration-state-machine.md
@@ -88,8 +88,15 @@ Distinct terminal reasons are important because retry logic and logs differ.
   - The exit then takes exactly one disposition. The conditions are evaluated in the order below
     and the first match wins, so an earlier disposition overrides every later one:
 
-    1. The agent reported itself blocked through a soft stop. Suppress the continuation retry,
-       cancel any pending retry, and release the claim. Blocked work has nowhere to continue to.
+    1. The agent reported itself blocked through a soft stop. Suppress the continuation retry.
+       Where the dispatch drives issue state, park the issue instead of merely releasing the
+       claim: cancel any pending retry, release the claim, record a durable park keyed by issue
+       ID, and apply the configured parking label to the issue through the tracker adapter. The
+       park holds the issue out of dispatch until a later poll tick observes either a change in
+       the issue's tracker state or the removal of a parking label the orchestrator has confirmed
+       reached the tracker (§14.2). Where the dispatch does not drive issue state, cancel any
+       pending retry and release the claim without recording a park. Blocked work has nowhere to
+       continue to either way.
     2. The freshest tracker observation for the issue reports a terminal state, resolved with
        precedence reconciliation's observation, then the worker's own per-turn observation, then
        the dispatch-time snapshot. Suppress the handoff transition and the continuation retry,
@@ -204,9 +211,9 @@ Distinct terminal reasons are important because retry logic and logs differ.
 - The orchestrator serializes state mutations through one authority to avoid duplicate dispatch.
 - `claimed` and `running` checks are required before launching any worker.
 - Reconciliation runs before dispatch on every tick.
-- Restart recovery uses persisted state from SQLite for retry queues and session metadata,
-  supplemented by tracker polling for current issue states and filesystem inspection for workspace
-  existence.
+- Restart recovery uses persisted state from SQLite for retry queues, session metadata, and
+  parked issues, supplemented by tracker polling for current issue states and filesystem
+  inspection for workspace existence.
 - Startup pending reaction recovery uses `run_history`, tracker state, and `.sortie/scm.json` to
   reconstruct runtime `pending_reactions` for recent handoff-stage runs before the first poll tick.
   The scan is bounded by `PendingReactionRecoveryLookback` and a fixed candidate cap.
@@ -220,12 +227,14 @@ Distinct terminal reasons are important because retry logic and logs differ.
 1. Open or create the SQLite database and run schema migrations.
 2. Load persisted retry entries from SQLite.
 3. Reconstruct retry timers from persisted `due_at` timestamps.
-4. Map existing workspace directories to issue identifiers, query the tracker for the states of
+4. Load persisted park records from SQLite and reconstruct the runtime park set before the
+   event loop starts, so a parked issue stays out of dispatch across the restart.
+5. Map existing workspace directories to issue identifiers, query the tracker for the states of
    those specific issues, and clean the ones in terminal states.
-5. Construct reaction providers and call `RecoverPendingReactions` to restore eligible CI and
+6. Construct reaction providers and call `RecoverPendingReactions` to restore eligible CI and
   review pending entries for handoff-stage issues.
-6. Query tracker for active issues and reconcile with persisted state.
-7. Begin normal polling loop.
+7. Query tracker for active issues and reconcile with persisted state.
+8. Begin normal polling loop.
 
 ### 7.5 Retry-Slot Arbitration
 

--- a/docs/architecture/08-polling-scheduling-and-reconciliation.md
+++ b/docs/architecture/08-polling-scheduling-and-reconciliation.md
@@ -16,8 +16,16 @@ Tick sequence:
 4. Run the periodic workspace sweep when its tick counter is due (Section 8.7).
 5. Fetch candidate issues from tracker using active states.
 6. Sort issues by dispatch priority.
-7. Dispatch eligible issues while slots remain.
-8. Notify observability/status consumers of state changes.
+7. Rebuild the exhausted-issue set from the session and token ceilings (§14.2).
+8. Evaluate the release rule for every parked issue (§14.2): observe the tick's candidates
+   directly for a state change or a confirmed parking label's removal, then read the tracker
+   state of the parked issues the candidate fetch did not return, through one batched,
+   comment-free call. This is the only tracker call this step makes beyond the candidate fetch
+   in step 5; it is skipped when every parked issue is already a candidate.
+9. Park each candidate whose consecutive handoff-absence count has just reached the ceiling
+   (§14.2), skipped entirely under `tracker.handoff_evidence: off`.
+10. Dispatch eligible issues while slots remain.
+11. Notify observability/status consumers of state changes.
 
 Preflight runs first so the reload it forces is visible to reconciliation and to the sweep, not
 only to dispatch. If validation fails, dispatch is skipped for that tick, but configuration is
@@ -33,6 +41,7 @@ An issue is dispatch-eligible only if all are true:
 - Its state is in `active_states` and not in `terminal_states`.
 - It is not already in `running`.
 - It is not already in `claimed`.
+- It is not parked (§14.2).
 - Global concurrency slots are available.
 - Per-state concurrency slots are available.
 - Blocker rule passes: for issues in any non-running active state, do not dispatch when any blocker
@@ -116,15 +125,17 @@ Per-issue token budget (cost ceiling):
   either is reached, so whichever fills first across polling cycles is the one that fires. When
   a single evaluation finds both exhausted, the reported and logged reason names the token
   budget; the block itself is identical regardless of which ceiling triggered it.
-- The per-tick rebuild of the exhausted-issue set accounts for these ceilings and for the
-  consecutive handoff-absence ceiling (§14.2): it runs the session-count batch query when
-  `max_sessions > 0`, the token-sum batch query when `max_tokens > 0`, and the absence-count
-  batch query when `tracker.handoff_evidence` is not `off`, and unions the results. Each
-  blocked issue carries a machine-readable reason (`handoff_absence`, `token_budget` or
-  `session_budget`, absence taking precedence over both budgets and token over session)
-  surfaced in the runtime snapshot beside the exhausted set. Under `handoff_evidence: off` no
-  absence is recorded and none is queried, so the rebuild is skipped entirely when both budgets
-  are also disabled.
+- The per-tick rebuild of the exhausted-issue set accounts for these two ceilings only: it runs
+  the session-count batch query when `max_sessions > 0` and the token-sum batch query when
+  `max_tokens > 0`, and unions the results. Each blocked issue carries a machine-readable reason
+  (`token_budget` or `session_budget`, token taking precedence over session) surfaced in the
+  runtime snapshot beside the exhausted set. The rebuild is skipped entirely when both budgets
+  are disabled.
+- The consecutive handoff-absence ceiling (§14.2) is evaluated separately, by the same
+  mechanism that parks a `blocked` soft stop, after the release-evaluation step below so a
+  park released this tick is not immediately re-parked. It shares the `parked` reason
+  vocabulary with the `blocked` park rather than the exhausted-issue set's own reasons, and is
+  skipped entirely under `tracker.handoff_evidence: off`, which records no absence.
 - If the token query fails, the check fails open and dispatch proceeds, matching the session
   check. A token sum recorded before the token columns were added reads as zero.
 - A sum below the ceiling that includes at least one unmeasured run allows the dispatch and

--- a/docs/architecture/10-agent-adapter-contract.md
+++ b/docs/architecture/10-agent-adapter-contract.md
@@ -464,7 +464,8 @@ simultaneously; no tool-call-based mechanism achieves this.
 1. Agent calls a tool (e.g., `tracker_api.fetch_issue`) to gather context.
 2. Agent determines the task requires a human architectural decision.
 3. Agent writes `mkdir -p .sortie && echo "blocked" > .sortie/status`.
-4. Turn completes; orchestrator reads the status file and suppresses retries.
+4. Turn completes; orchestrator reads the status file, suppresses retries, and, where the
+   dispatch drives issue state, parks the issue and applies the parking label.
 
 The two channels do not interact. A tool call cannot write to `.sortie/status` on behalf of
 the agent, and the `.sortie/status` file cannot trigger tool execution. The orchestrator

--- a/docs/architecture/11-issue-tracker-integration-contract.md
+++ b/docs/architecture/11-issue-tracker-integration-contract.md
@@ -118,8 +118,17 @@ comments and applies escalation labels, none of which carries state semantics: t
 comment (`tracker.comments.on_dispatch`), the worker-exit completion and failure comments
 (`tracker.comments.on_completion`, `tracker.comments.on_failure`), the auto-merge success comment
 (§11C), a reaction escalation label or comment when a reaction's retry budget is exhausted or a
-non-retryable error occurs, and the primary-dispatch parking label applied when the consecutive
-handoff-absence ceiling is reached (§14.2). None of these is a state transition.
+non-retryable error occurs, and the primary-dispatch parking label applied both when a `blocked`
+soft stop parks an issue and when the consecutive handoff-absence ceiling is reached (§14.2).
+None of these is a state transition.
+
+The parking label is a non-state write whose later presence or absence on the issue is read back:
+the orchestrator's own release rule observes the label on a subsequent fetch of the issue to
+confirm the write took effect, and observes its absence to decide the park is released. An adapter
+that accepts a parking-label write MUST make that label visible to subsequent reads of the issue,
+in particular to the candidate fetch, so the release rule can observe it. An adapter that accepts
+the write and records nothing produces a park the label gesture can never confirm and, by design,
+therefore never release on that gesture (§14.2); the state gesture remains available regardless.
 
 Free-form ticket mutation falls outside these three writes and stays with the coding agent, which
 mutates tickets through the `tracker_api` tool subsystem (Section 10.4), part of the agent

--- a/docs/architecture/18-logging-status-and-observability.md
+++ b/docs/architecture/18-logging-status-and-observability.md
@@ -26,10 +26,16 @@ Handoff-evidence records are part of the required operator surface:
 - An `evidence not determinable` verdict emits an `Info` record under both `observed` and `strict`,
   carrying the policy and `turns_completed`. Under `strict`, the separate withheld warning is also
   emitted because that policy converts the verdict into the absence disposition.
-- Parking at the consecutive-absence ceiling emits a `Warn` record carrying
-  `consecutive_absences`, `absence_ceiling`, and `escalation_label`. A failed label write is recorded
-  separately as an escalation error and does not suppress the parking record.
 - A run frozen to `tracker.handoff_evidence: off` emits none of these evidence records.
+
+Parking an issue, whichever trigger produced it, emits exactly one `Warn` record, message
+`"issue parked"`, carrying `reason` (`agent_blocked` or `handoff_absence`), `parked_state`
+(the tracker state recorded, empty when unobserved), and `label` (the parking label applied).
+The consecutive-absence ceiling's park additionally carries `consecutive_absences` and
+`absence_ceiling`; a `blocked` park carries neither. A failed label write is recorded separately,
+message `"park label write failed"`, at `Warn`, and does not suppress the parking record. Lifting
+a park emits one `Info` record, message `"issue unparked"`, carrying `trigger`
+(`state_changed`, `label_removed`, or `evidence_observed`) and `reason`.
 
 The periodic workspace sweep emits exactly one summary record per pass, at `Info` level, message
 `"sweep: pass complete"`, on every pass that produced a candidate set, including a pass over zero
@@ -83,7 +89,15 @@ should return:
 - `rate_limits` (latest coding-agent rate limit payload, if available)
 - `budget_exhausted_count` (number of issues currently blocked by a re-dispatch budget; always present)
 - `budget_exhausted` (sorted list of blocked issue IDs; omitted when the set is empty)
-- `budget_exhausted_reason` (map from blocked issue ID to the gate that fired, `handoff_absence`, `token_budget` or `session_budget`; `handoff_absence` takes precedence over both budgets and `token_budget` takes precedence over `session_budget` when one issue reaches more than one gate; omitted when the set is empty). The exhausted set and its reasons are rebuilt per tick from those gates (Section 8.4); an issue's reason entry exists exactly when that issue is in `budget_exhausted`.
+- `budget_exhausted_reason` (map from blocked issue ID to the gate that fired, `token_budget` or
+  `session_budget`; `token_budget` takes precedence over `session_budget` when one issue reaches
+  both gates; omitted when the set is empty). The exhausted set and its reasons are rebuilt per
+  tick from those two gates (Section 8.4); an issue's reason entry exists exactly when that issue
+  is in `budget_exhausted`.
+- `parked_count` (number of issues currently held out of primary dispatch; always present)
+- `parked` (sorted list of parked issue IDs; omitted when the set is empty)
+- `parked_reason` (map from parked issue ID to the park's reason, `agent_blocked` or
+  `handoff_absence`; omitted when the set is empty)
 
 Recommended snapshot error modes:
 
@@ -400,6 +414,7 @@ Defined metrics (label sets and buckets are specified here; see ADR-0008 for his
 | `sortie_tracker_comments_total{lifecycle,result}` | Counter | Tracker comment attempts, partitioned by lifecycle point (`dispatch`, `completion`, `failure`) and result (`success`, `error`). |
 | `sortie_handoff_transitions_total{result}` | Counter | Handoff-state dispositions, partitioned by result (`success`, `error`, `skipped`, `withheld`). `withheld` means the handoff-evidence policy selected the absence failure path before any transition attempt, distinguishing it from an ordinary worker failure. `skipped` retains its two earlier causes and does not distinguish them: the issue was no longer in an active state at worker exit, or the issue was already reported terminal and the write was suppressed (Section 11.5). All four values are counted only when `tracker.handoff_state` is configured. |
 | `sortie_dispatch_transitions_total{result}` | Counter | Dispatch-time in-progress transition attempts, partitioned by result (`success`, `error`, `skipped`). `skipped` indicates the issue was already in the target state. |
+| `sortie_issue_parks_total{reason}` | Counter | Issue park events, partitioned by reason (`agent_blocked`, `handoff_absence`). Incremented once per park, whichever trigger produced it. |
 | `sortie_dispatch_rule_match_total{layer,rule}` | Counter | Dispatch rule match outcomes, partitioned by resolution layer (`rule`, `default`, `fallback`) and matched rule name. Empty rule names report as `<none>` to bound label cardinality. |
 | `sortie_tool_calls_total{tool,result}` | Counter | Agent tool call completions, partitioned by tool name and result (`success`, `error`). |
 | `sortie_ci_status_checks_total{result}` | Counter | CI status check outcomes, partitioned by result (`passing`, `pending`, `failing`, `error`). |

--- a/docs/architecture/19-failure-model-and-recovery-strategy.md
+++ b/docs/architecture/19-failure-model-and-recovery-strategy.md
@@ -56,7 +56,10 @@
 
 - Recognized `.sortie/status` signal:
   - Both values keep their existing dispositions. A `blocked` soft stop suppresses the handoff
-    transition and the continuation retry. A completion signal (`needs-human-review`) suppresses
+    transition and the continuation retry, and, where the dispatch drives issue state, parks the
+    issue instead of merely releasing the claim: it records a durable park and applies the
+    parking label, sharing both the mechanism and the release rule the consecutive-absence
+    ceiling uses below. A completion signal (`needs-human-review`) suppresses
     the continuation retry and takes the ordered handoff disposition (§7.3) unchanged: the
     transition fires only where a handoff state is configured, the issue is still active, the
     dispatch drives issue state, no terminal observation suppresses it, and the evidence verdict
@@ -92,11 +95,37 @@
     a reaction continuation retry on the same issue carries its own sequence, cannot record an
     absence, and is not cancelled here. Ceiling exhaustion is an eligibility gate rather than only a
     cancelled timer: ordinary polling and restart recovery must not silently begin another run in
-    the same exhausted absence sequence. Its representation is an implementation detail; the rule
+    the same exhausted absence sequence. The representation is fixed and shared with the `blocked`
+    park: the same durable park record, the same runtime gate, and the same release rule, tagged
+    with the reason this ceiling produced it rather than the reason a `blocked` signal did. The rule
     requires neither a second numeric setting nor a durable verdict column on `run_history`.
-  - Under `tracker.handoff_evidence: off` no absence is ever recorded, so neither the count nor the
-    gate is evaluated on any path: polling, retry firing, and worker exit all skip it. The policy
-    costs nothing and no issue is parked by this mechanism while it is selected.
+  - Under `tracker.handoff_evidence: off`, no absence is ever recorded, so the count is never
+    incremented and no *new* park is taken by this ceiling on any path: polling, retry firing, and
+    worker exit all skip the trigger, and the policy costs nothing while it is selected. This
+    governs only whether a *new* park is taken, not whether an existing one holds: a park already
+    recorded, by either trigger, is unaffected by the policy and is released only by the rule
+    below. Raising `agent.max_sessions` above the recorded count has the same narrowed effect: it
+    changes the ceiling a future count is compared against, but it does not lift a park already
+    taken, because the park is a row rather than a value re-derived from the current ceiling on
+    every tick.
+  - A park is released by either of two operator gestures, whichever the orchestrator observes
+    first, and both apply to every trigger that parks an issue, not only to this ceiling: moving
+    the issue to a tracker state different from the one recorded when it was parked, or removing
+    a parking label the orchestrator has confirmed reached the tracker. The label gesture carries
+    a confirmation guard: confirmation comes only from observing the label present on a later
+    fetch of the issue, never from the label write itself returning without error, because a
+    tracker adapter is permitted to accept a label write and record nothing. Releasing on an
+    unconfirmed label's absence would let such an adapter undo the park silently. A park taken
+    from the retry lane records no observed state at the moment it is taken, since the retry lane
+    parks ahead of its own tracker fetch by design; the first later observation backfills the
+    state without releasing the park on that same tick, so the operator's own action is never
+    mistaken for the very read that first captured the baseline. A parked issue absent from the
+    poll tick's candidate set, because it now sits in a state the deployment does not call
+    active, is still read for its state through a separate, filter-free tracker call, so the
+    state gesture reaches it exactly as it would if the issue were still a candidate. Release
+    resets the counter that produced the park, so a released absence-ceiling park does not
+    immediately re-derive the same exhausted count and park itself again; release is evaluated
+    ahead of the ceiling trigger on the same tick for exactly this reason.
   - The parking label is the resolved non-empty
     `reactions.review_comments.escalation_label` captured when the orchestrator starts, or
     `needs-human` when that block or value is absent or empty. This lookup deliberately reuses only
@@ -154,6 +183,9 @@ Sortie uses SQLite persistence to improve restart recovery semantics:
 
 - Retry entries with future `due_at` timestamps are restored from SQLite and rescheduled on
   startup.
+- Parked issues are reloaded from SQLite before the event loop starts, so an issue parked before
+  a restart stays out of dispatch across it without depending on any tracker read to rediscover
+  the park.
 - Session metadata from the previous run is available for observability and debugging.
 - Run history is preserved in SQLite for operational review.
 - Running sessions are not recoverable (agent subprocesses do not survive restart), but the

--- a/docs/architecture/21-reference-algorithms.md
+++ b/docs/architecture/21-reference-algorithms.md
@@ -67,7 +67,13 @@ on_tick(state):
     schedule_tick(state.poll_interval_ms)
     return state
 
-  for issue in sort_for_dispatch(issues):
+  sorted = sort_for_dispatch(issues)
+
+  state = rebuild_budget_exhausted(state, sorted)
+  state = refresh_parked_issues(state, sorted)
+  state = park_exhausted_absences(state, sorted)
+
+  for issue in sorted:
     if no_available_slots(state):
       break
 
@@ -394,10 +400,16 @@ on_worker_exit(issue_id, reason, state):
     # the first match wins and overrides every later one.
 
     # Disposition 1: the agent reported itself blocked through a soft
-    # stop. Blocked work has nowhere to continue to.
+    # stop. Blocked work has nowhere to continue to. Where the dispatch
+    # drives issue state, park the issue instead of merely releasing the
+    # claim, so it stays out of dispatch until a later tick observes a
+    # release (Section 14.2).
     if is_blocked_soft_stop(running_entry, worker_result):
-      cancel_retry(state, issue_id)
-      state.claimed.remove(issue_id)
+      if dispatch_drives_issue_state(running_entry):
+        park_issue(state, issue_id, reason="agent_blocked")
+      else:
+        cancel_retry(state, issue_id)
+        state.claimed.remove(issue_id)
       notify_observers()
       return state
 

--- a/docs/architecture/22-test-and-validation-matrix.md
+++ b/docs/architecture/22-test-and-validation-matrix.md
@@ -112,7 +112,46 @@ Unless otherwise noted, Sections 17.1 through 17.7 are `Core Conformance`. Bulle
   immediately before the handoff write; a terminal result suppresses the write and a failed read
   lets it proceed
 - With no terminal states configured, no verification read is issued
-- A blocked soft stop releases the claim with no handoff and no continuation retry
+- A blocked soft stop releases the claim with no handoff and no continuation retry, and, where
+  the dispatch drives issue state, records a durable park, applies the parking label, and holds
+  the issue out of dispatch (§14.2)
+- A blocked soft stop from a dispatch that does not drive issue state records no park
+- `ShouldDispatch` and the dispatch loop's pre-built-set variant return false for a parked issue
+  regardless of the configured effort budgets
+- A retry timer firing for an already-parked issue releases the claim and deletes the retry row
+  without dispatching, under every evidence policy, and this refusal does not disturb the
+  retry lane's own ability to park a newly ceiling-exhausted issue
+- The release rule: a tracker state change unparks the issue; a confirmed parking label observed
+  absent unparks the issue; an unconfirmed label observed absent leaves the park in place; a
+  parking label observed while unconfirmed is recorded as confirmed
+- A failed parking-label write leaves the park in place with the label unconfirmed, and a later
+  release pass that still observes the label absent does not unpark the issue on that evidence
+  alone
+- A successful parking-label write does not by itself confirm the label; only a later observation
+  of the label on the issue does
+- Loading persisted park records at startup restores the runtime park set, skipping a malformed
+  record and loading a record with no recorded tracker state
+- The runtime snapshot reports the parked-issue count always, and the parked issue list and
+  reason map only when the parked set is non-empty
+- A parked issue absent from the poll tick's candidate set is read for its state through a
+  separate, filter-free tracker call, and that call carries only the parked issues the candidate
+  fetch did not return
+- Parking on the consecutive handoff-absence ceiling and parking on a blocked soft stop produce
+  the same durable record shape, differing only in the reason attributed to the park
+- Releasing an absence-ceiling park resets its consecutive-absence count, and the same poll tick
+  does not immediately re-derive the exhausted count and park the issue again
+- Releasing a `blocked` park does not touch the consecutive-absence count
+- A park held under `tracker.handoff_evidence: off` is not released by the policy, and no new
+  absence park is taken while the policy is set
+- A retry-lane absence park records no observed tracker state; the next poll tick backfills it
+  without releasing the park, and a state change observed after the backfill releases it
+- A worker exit whose own run is parked for absence and later reports a work-observed verdict
+  releases the park
+- One park produces exactly one park log record and one park counter increment, whichever
+  trigger produced it
+- The worker-exit absence park records the same tracker state the run's own terminal observation
+  resolved, not an unrecorded state, and is releasable by a later state change without an
+  intervening backfill tick
 - A dispatch that does not drive issue state performs neither the dispatch-time transition nor the
   handoff transition, and enqueues no reaction on its own exit
 - Abnormal worker exit increments retries with 10s-based exponential backoff

--- a/docs/architecture/24-persistence-schema.md
+++ b/docs/architecture/24-persistence-schema.md
@@ -163,7 +163,31 @@ or a run under `handoff_evidence: off` from resetting a sequence they say nothin
 The reset point is read from `run_history` inside the write, so a work-observed run whose own
 history row could not be persisted still clears the absences recorded before it. This table holds no
 verdict history: it is a per-issue position that is overwritten, and deleting a row only restores
-the issue's full recorded absence sequence.
+the issue's full recorded absence sequence. A work-observed run is no longer the table's only
+writer: releasing a parked issue whose park reason is the consecutive-absence ceiling (below) also
+writes a reset here, so the loop does not immediately re-derive the exhausted count and park the
+issue again on the tick that released it.
+
+**`parked_issues`**: issues held out of primary dispatch until a human acts (migration 014)
+
+| Column          | Type    | Notes                                                              |
+| --------------- | ------- | ------------------------------------------------------------------ |
+| `issue_id`      | TEXT PK | Tracker-internal issue ID                                          |
+| `identifier`    | TEXT    | Human-readable ticket key                                          |
+| `display_id`    | TEXT    | Qualified display form; empty when the tracker needs none          |
+| `reason`        | TEXT    | `agent_blocked` or `handoff_absence`                                |
+| `parked_state`  | TEXT    | Tracker state observed when the park was recorded; empty when unobserved |
+| `label`         | TEXT    | Parking label the orchestrator applied                             |
+| `label_applied` | INTEGER | `1` once the orchestrator has confirmed the label reached the tracker |
+| `parked_at`     | TEXT    | ISO-8601 timestamp                                                  |
+
+One row per parked issue, holding current state rather than history: the row is deleted the
+moment the park is lifted, not retained as a record of a past park. `parked_state` is nullable in
+meaning though not in type: an empty string means no tracker state was observed at park time,
+which only a park taken from the retry lane produces, since that lane parks ahead of its own
+tracker fetch by design (§14.2). `label_applied` has exactly one writer: the orchestrator's
+release-rule observation of the label on a later fetch of the issue, never the outcome of the
+label write itself.
 
 ### 19.3 Migration Strategy
 

--- a/docs/architecture/26-agent-authored-workspace-files.md
+++ b/docs/architecture/26-agent-authored-workspace-files.md
@@ -20,16 +20,20 @@ Recognized values:
 
 - `blocked`: agent signals it cannot proceed without human intervention. The orchestrator treats
   this as a soft stop: it completes the current turn normally, suppresses continuation retries,
-  and releases the issue claim. The issue becomes eligible for re-dispatch on future tracker
-  polls under normal dispatch rules. This value never enters the self-review phase (Section 7);
-  it remains an immediate exit whether or not self-review is configured.
+  and releases the issue claim. Where the dispatch drives issue state, it also parks the issue: it
+  records a durable park and applies the parking label, and holds the issue out of dispatch until
+  it observes a change in the issue's tracker state or the removal of a parking label it has
+  confirmed reached the tracker (Section 14.2). This value never enters the self-review phase
+  (Section 7); it remains an immediate exit whether or not self-review is configured.
 - `needs-human-review`: agent signals that work is complete and requires review. Like `blocked`,
   this value suppresses continuation retries and releases the issue claim. Unlike `blocked`, when
   `tracker.handoff_state` is configured and the issue is in an active tracker state, the
   orchestrator performs the handoff transition (Section 5.3.1). This ensures completed work moves
   to a review state in the tracker, maintaining tracker-as-source-of-truth semantics. If
-  `tracker.handoff_state` is not configured, the behavior is identical to `blocked`. The
-  transition is also subject to the run's `tracker.handoff_evidence` verdict (Section 7.3): a
+  `tracker.handoff_state` is not configured, the issue becomes eligible for re-dispatch on future
+  tracker polls under normal dispatch rules; unlike `blocked` in that deployment, no park is
+  recorded, so the two values are still distinguishable. The transition is also subject to the
+  run's `tracker.handoff_evidence` verdict (Section 7.3): a
   verdict that withholds it leaves the issue in its active state, keeps the claim, and takes the
   backoff failure path instead of releasing the claim. Where
   self-review is enabled and the phase's other gate conditions hold, this value first admits the

--- a/docs/decisions/0022-release-a-parked-issue-on-a-human-gesture.md
+++ b/docs/decisions/0022-release-a-parked-issue-on-a-human-gesture.md
@@ -1,0 +1,357 @@
+---
+status: accepted
+date: 2026-08-17
+decision-makers: Serghei Iakovlev
+---
+
+# Release a Parked Issue on a Human Gesture in the Tracker
+
+## Context and Problem Statement
+
+The orchestrator selects issues for dispatch from the tracker states the operator declared active.
+Two paths declare that the selection should stop because a person is needed. On the first, the agent
+itself reports that it cannot proceed, through the status file whose vocabulary Sortie appends to
+every run's first prompt. On the second, the orchestrator observes that consecutive runs produced no
+work; [ADR-0020](0020-withhold-handoff-on-observed-absence-of-work.md) bounded that sequence with a
+ceiling and, on reaching it, withheld further dispatch and applied the operator's escalation label
+to the issue. Both paths mean the same thing to the person who reads the tracker: this issue is not
+moving and a human must look at it.
+
+Nothing released such an issue. The eligibility gate that held it was derived from durable state
+that only a successful run could clear, and a held issue cannot run, so it could not produce the
+clearing evidence. The circularity was complete rather than approximate: the count was re-derived on
+every poll tick from run history, run history had no delete, prune, or retention path, and the one
+routine that ended the sequence ran on the exit of a run that produced work. An issue that reached
+the ceiling stayed there for the lifetime of the deployment's database.
+
+The escalation label was write-only. The orchestrator applied it on the recovery paths and on the
+absence ceiling, and read it nowhere that bore on whether an issue was dispatched. Dispatch
+eligibility was decided by required fields, active-state membership, non-terminal state, whether a
+run was already in flight, whether the issue was claimed, whether an effort budget was exhausted,
+and whether a non-terminal blocker existed. Labels were not consulted on any of those. They were
+consulted elsewhere in the same layer, to select which dispatch rule matched an issue, which is what
+makes their absence from the eligibility decision a real absence rather than an oversight in the
+reading. So the system announced that a human was needed and offered the human no gesture that had
+any effect.
+
+The label-shaped exclusion that did work belonged to the operator, not to the orchestrator.
+`tracker.query_filter` is label-capable on every shipped adapter, but it is a query string the
+adapter interpolates into the forge's own query language and sends to the forge. The orchestrator
+receives only the issues that survived, and never learns that any were withheld or why. That
+distinction is load-bearing, because it is why "labels already affect what is dispatched" was never
+a counter-argument: the filter changes what the orchestrator is shown, not what the orchestrator
+decides. It also sets the bar that had to be cleared. An operator who excluded labelled issues
+through the filter could undo the exclusion by editing the filter. An operator whose issue was
+parked by the orchestrator could not undo that by any means aimed at that issue.
+
+The only releases were deployment-wide. Raising the per-issue effort ceiling above the recorded
+count lifted the gate, because the absence ceiling derives from that same setting. Disabling the
+evidence policy lifted it too, for every issue at once. Neither is a gesture an operator can make
+about one issue, and both ask a deployment to change its global posture to unstick a single ticket.
+
+That is the asymmetry worth recording: a state an operator can be placed into, can observe in the
+tracker, and cannot leave. It was strictly worse than the operator-side workaround it stood beside,
+and worse in the one respect that matters, which is reversibility.
+
+The precedent cuts both ways and is stated honestly rather than hidden. The sibling gate that
+suppresses dispatch on an exhausted effort budget is releasable only by a configuration change, for
+exactly the same reason: its count comes from run history, and run history is monotone because
+nothing removes rows from it. A design that gives one derived gate a per-issue release and leaves
+the other without one is asserting that the two gates mean different things. That assertion has to
+be made, not assumed.
+
+## Decision Drivers
+
+1. **A state the system can enter and the operator cannot leave is worse than a state the system
+   never enters.** Every other durable disposition in the system is reversible by someone: a claim
+   is released, a retry is cancelled, a workspace is reclaimed, an issue in a terminal state can be
+   moved back. A park was the only disposition with no exit. Its cost is not that it fires wrongly;
+   it is that firing correctly is also permanent, so the remedy for a correctly parked issue and the
+   remedy for a wrongly parked one are the same remedy, and there was none.
+2. **The announcement and the release must live on the same surface.** The park announces itself in
+   the tracker, to a person who is reading the tracker. A release that required orchestrator access
+   would summon a person to one system and answer them in another, and would exclude every operator
+   who can triage a ticket but cannot reach the host. The gesture must be available to whoever the
+   label was addressed to.
+3. **Parking must mean one thing across every trigger.** Two triggers already park, a third class of
+   trigger is conceivable, and each one arrives at the same tracker-visible outcome. If the release
+   rule were attached to the trigger rather than to the park, an operator would have to know why an
+   issue was parked before knowing how to release it, and would learn that from a log they may not
+   have. One meaning system-wide is what makes the label legible without the record behind it.
+4. **A release the system cannot distinguish from a write that never happened is not a release.**
+   The label reaches the tracker through a network call that can fail, and one shipped adapter
+   accepted the write while recording nothing. If absence of the label released the park, then a
+   park whose label never landed would release itself on the next tick, silently, and the issue
+   would resume dispatch having never been seen by anyone. The release rule and the write it depends
+   on cannot be evaluated independently.
+5. **A release must actually release.** The gate is not a stored flag; it is re-derived on each poll
+   tick from durable history. Removing the runtime record without ending the sequence that produced
+   it leaves the derivation intact, so the same tick that honors the operator's gesture re-computes
+   the exhausted count and parks the issue again. The operator would observe their action being
+   undone within one poll interval, which is worse than no release at all because it looks like the
+   system rejecting them.
+6. **Making labels an input to dispatch is a real cost, and it should be paid once.** Until this
+   decision the dispatch path could be read without reference to labels at all. Afterwards it
+   cannot. That is a permanent widening of what a reader of that path must hold in mind, and it
+   argues for one label-reading rule with one meaning rather than a family of them.
+7. **The effort budget and the park express different things, so their releases need not match.** An
+   exhausted effort budget says the deployment has spent what it allotted; the allotment is a
+   configuration value, so changing the configuration is the coherent release and the gate is
+   correctly monotone. A park says a person is needed; the coherent release is that person acting.
+   Deriving both from run history is an implementation resemblance, not a shared meaning.
+
+## Considered Options
+
+- Release the park only when the parking label is removed from the issue
+- Release the park only when the issue is moved to a different tracker state
+- Release on either gesture, guarded by confirmation that the parking label reached the tracker, and
+  resetting the counter that produced the park
+- Release through an explicit operator command issued to the orchestrator
+- Provide no per-issue release, leaving only the deployment-wide levers
+
+## Decision Outcome
+
+Chosen option: **release on either gesture, guarded by confirmation that the parking label reached
+the tracker, and resetting the counter that produced the park**, because it puts the release on the
+surface the park addressed, accepts both of the natural things an operator does to a ticket they
+have just triaged, and closes the two ways a release can be hollow.
+
+### Two gestures, one meaning
+
+A parked issue is released when the orchestrator observes, on a poll tick, either that the parking
+label is no longer on the issue or that the issue's tracker state differs from the state it held
+when it was parked. Both are gestures a person makes in the tracker with no knowledge of the
+orchestrator, and both are things an operator does anyway on finishing a triage: they clear the
+marker, or they move the ticket.
+
+Accepting both is not indecision. They are the two ends of one triage and an operator may perform
+either, in either order, and frequently performs only one. An operator who decides the issue is not
+ready moves it out of the active queue; an operator who fixes whatever blocked the agent clears the
+label and leaves the state alone. A rule that recognized one and not the other would leave half of
+all correct operator behavior with no effect, which is the fault this decision exists to remove,
+reproduced in a smaller form.
+
+Where the gesture is a state change, the effect on dispatch still runs through the pre-existing
+active-state gate. Moving a parked issue to a state the deployment does not call active releases the
+park and leaves the issue undispatchable for the ordinary reason. That is the correct outcome and it
+is worth stating: the release lifts the park, it does not assert that the issue should now run.
+
+Both releases apply to every trigger that parks an issue. The rule is a property of the park, not of
+the reason recorded on it. A park taken because the agent reported itself unable to proceed and a
+park taken because the absence ceiling was reached are released by the same two gestures, on the
+same terms. This is the substance of the decision rather than a tidiness preference: the label on
+the issue is the whole of what most operators will ever see, and it has to carry one instruction.
+
+### The release is guarded by confirmation that the label reached the tracker
+
+The orchestrator records, alongside the park, whether it has confirmed that the parking label is on
+the issue. Confirmation comes from observing the label on a later fetch of that issue, not from the
+write returning without error. Until the label has been confirmed, the absence of the label does not
+release the park.
+
+Without the guard the release rule would be evaluated against a fact the orchestrator does not have.
+A label write that failed, or that was accepted by an adapter which stores nothing, leaves the issue
+looking exactly like an issue whose label a human just removed. Release-on-absent-label would then
+un-park the issue on the very next tick, silently, and the loop the park existed to stop would
+resume with no human having seen anything. The guard is what makes the two cases distinguishable: an
+issue with no confirmed label stays parked, because the system has no evidence its request for
+attention was ever delivered.
+
+The state-change gesture carries the same shape of problem and the same shape of answer. A park
+recorded without an observed tracker state, which happens where the park is taken on a path that
+deliberately runs before any tracker fetch, cannot be compared against a later observation. Such a
+park is not released by the state gesture until an observation supplies the missing baseline, and
+the first observation supplies it rather than releasing on it. The alternative, treating a missing
+baseline as "release on any observation", would release every such park on the next tick and defeat
+the gate entirely.
+
+### A release resets the counter that produced the park
+
+Releasing a park whose trigger maintains a counter also ends that counter's sequence, whatever the
+release gesture was.
+
+Without this the release is inert. The runtime record is removed, the same poll tick re-derives the
+exhausted count from run history, finds it still at or above the ceiling, and parks the issue again
+before the dispatch loop runs. The operator's gesture would be honored and reversed inside one tick,
+and the log would show a release followed immediately by a park, which reads as the system arguing
+with the person it summoned.
+
+The reset is also the correct meaning independently of that mechanical necessity. The counter exists
+to bound how many times the system will retry something that is not working before asking for help.
+A person acting on the issue is precisely the event that licenses the bound to start over, on
+exactly the terms a run that produced work already does. Treating the human gesture as weaker
+evidence than a successful run would say that the system trusts its own observations more than the
+judgement of the person it asked for.
+
+Ordering follows from this. The release rule is evaluated before the trigger that would re-park, on
+the same tick and over the same candidates, so an issue released this tick is not re-parked by a
+derivation that has not yet been reset.
+
+### Why the release is defined on the park and not on the trigger
+
+The park is one record with one gate and one tracker-visible marker. Defining the release on the
+park means a new parking trigger inherits a release rather than choosing one, and cannot ship a park
+with no way out. That is the property this decision most wants to be durable: the fault being closed
+here was not that one trigger forgot to define a release, it was that a park could exist without
+anyone having had to answer the question.
+
+### Considered Options in Detail
+
+**Release only when the parking label is removed.** This is the most direct reading of the label:
+the marker says a human is needed, so removing it says a human came. It needs no baseline, no
+comparison against an earlier observation, and no per-trigger knowledge. It is rejected as the sole
+rule because it makes the release conditional on a gesture many operators will not make. An operator
+who triages the ticket and moves it, leaving the label, has acted decisively and would see no
+effect; worse, the label they left behind would keep the issue parked in a state they consider
+resolved. It would also make the release rule wholly dependent on a tracker write having previously
+succeeded, with no second path when it did not.
+
+**Release only when the issue is moved to a different tracker state.** A state change is the
+strongest available evidence that a person made a decision, and it is the gesture the system already
+treats as authoritative elsewhere: the handoff transition is a state change, and a terminal state
+already suppresses dispatch. Basing the release on it alone would need no label read at all, which
+would preserve the property that the orchestrator does not consult labels for eligibility. It is
+rejected because it forces the operator to move a ticket in order to say something about a ticket.
+An operator who has fixed the blocking condition and wants the agent to try again wants the issue to
+stay exactly where it is; the only way to release it would be to move it out of the active state and
+back, which is an awkward gesture that pollutes the issue's history and, in a tracker with a
+constrained workflow, may not be permitted at all. It also cannot be recognized where no baseline
+state was recorded.
+
+**Release through an explicit operator command issued to the orchestrator.** A command is
+unambiguous, needs no inference from tracker observations, requires no label read, and could report
+its own outcome directly to the person who issued it. Nothing about the design would be guessed. It
+is rejected because it answers the wrong audience. The park announces itself in the tracker, to
+whoever triages tickets, and that person may have no access to the orchestrator's host, its
+configuration, or any command surface it exposes. A release that only a deployment operator can
+perform turns every parked issue into an escalation to a second person, and the number of people who
+can unstick an issue becomes smaller than the number who can diagnose it. It also introduces a
+control surface with its own authentication and audit questions, to duplicate a signal the tracker
+already carries. The option is not foreclosed by this decision: a command could later be added as a
+further release trigger without disturbing the two defined here, since the release is defined on the
+park.
+
+**Provide no per-issue release.** This is the status quo and it is the serious alternative. It
+matches the sibling effort-budget gate exactly, which is monotone for the same reason and releasable
+only by configuration; consistency between two gates of identical construction is a genuine
+architectural good. It adds no capability, so it cannot add a defect. It keeps the orchestrator
+ignorant of labels, preserving a property of the dispatch path that a reader can currently rely on
+absolutely. And it has a coherent story for the operator: a park means the deployment's tolerance
+for this issue is spent, and spending more means saying so in configuration.
+
+It is rejected on the seventh driver. The consistency is a resemblance between implementations
+rather than between meanings. An effort budget is a resource allotment, and the party who set the
+allotment is the party who changes it, so a configuration release is the right shape. A park is a
+request addressed to a person, and a request whose only answer is a global configuration change is
+not a request. The asymmetry with the budget gate is also not symmetric in cost: an over-budget
+issue has consumed something measurable and the operator can decide whether to spend more, whereas a
+parked issue may have consumed almost nothing and be parked on a verdict about residue. Leaving it
+unreleasable makes a bounded retry policy into a permanent verdict on a ticket. The option's best
+argument, that it keeps labels out of the dispatch path, is real and is recorded below as the price
+of the decision rather than being disputed.
+
+## Consequences
+
+### Positive
+
+- A park becomes a reversible disposition, so the remedy for a correctly parked issue and for a
+  wrongly parked one is the same gesture, performed by the same person, in the system where the park
+  announced itself.
+- The gesture requires no orchestrator access. Whoever the label was addressed to can answer it.
+- Parking has one meaning system-wide. A new parking trigger inherits the release rule rather than
+  choosing one, and cannot ship a hold with no exit.
+- The escalation label stops being write-only on this path. What the system writes to the tracker to
+  request attention is now also what it reads to learn that attention was given, so the marker is a
+  channel rather than an annotation.
+- The release cannot be hollow in either of the two ways available to it. It is not undone by a poll
+  tick re-deriving the count, and it is not granted by a label that never arrived.
+- The deployment-wide levers remain, and remain correct for what they express. Raising the effort
+  ceiling or disabling the evidence policy still changes the deployment's posture; neither is now
+  the only way to unstick one ticket.
+
+### Negative
+
+- **Issue labels become an input to dispatch eligibility for the first time.** Until this decision
+  the orchestrator wrote labels and never read them to decide whether an issue was dispatched; the
+  eligibility rules could be read and reasoned about without labels entering the account at all.
+  Afterwards they cannot. Anyone reading the dispatch path must know that a label can change whether
+  an issue is eligible, and that the label in question is not named in the dispatch rules but
+  derived from a reaction's escalation setting. This is a permanent widening of that path's surface
+  and it is the price of the decision, not an incidental detail of it.
+- **A label a human removes for an unrelated reason releases a park.** The gesture is not
+  distinguishable from a deliberate release, because nothing about a label removal records intent.
+  An operator tidying labels, a bulk edit, an automation that normalizes label sets, or a person who
+  simply disagrees with the label's wording all release every park they touch. The issue then
+  resumes dispatch with its counter reset, and the only trace is the release record.
+- **The system's willingness to be released depends on the tracker having been reachable earlier.**
+  The confirmation guard is what makes the release safe, and it means a release now rests on a prior
+  write having succeeded. Where the label write failed, the label-removal gesture has nothing to act
+  on, and the issue stays parked until the operator makes the state-change gesture instead. The park
+  is still escapable, but by only one of the two routes, and the operator has no indication from the
+  tracker which route is available to them, because the missing label is exactly what they would
+  have looked at.
+- **A park recorded with no observed state is releasable by only one gesture until the next
+  observation.** Where the park is taken on a path that runs before any tracker fetch, no baseline
+  state exists to compare against, and the first observation records the baseline rather than
+  releasing on it. An operator who moved the issue between the park and that first observation has
+  their move recorded as the parked state instead of honoring it, and must act a second time.
+- **The label the release rule compares against is fixed when the orchestrator starts.** It is taken
+  from the review reaction's escalation setting, falling back to `needs-human`, and is captured once
+  at construction rather than re-read when configuration reloads. An operator who changes that
+  setting while the orchestrator is running finds that parks continue to be written and compared
+  against the previous value until a restart, so the label on the issue and the label the rule
+  watches can disagree.
+- **The two derived gates now differ in kind, and the difference must be learned.** The effort
+  budget remains monotone and releasable only by configuration; the park is releasable per issue.
+  Both are computed from the same durable history and both suppress dispatch, so an operator seeing
+  an issue that will not dispatch has to establish which of the two is holding it before knowing
+  whether a tracker gesture will help.
+- **A release resets a bound that was reached for a reason.** An operator who removes the label
+  without addressing the underlying condition grants the system a full fresh sequence of attempts.
+  The park will be re-reached, so the loop is still bounded, but each unconsidered release buys
+  another full run of it, and the effort those runs consume is real.
+
+## Specification Material Requiring Update
+
+Named by document and topic rather than by section or filename, since neither is stable.
+
+1. The failure model and recovery strategy material: the park as one record with one gate shared by
+   every trigger, the two release gestures, the confirmation guard on the label gesture and the
+   baseline requirement on the state gesture, the reset of a trigger's counter on release, and the
+   ordering of the release evaluation ahead of any trigger that would re-park on the same tick.
+2. The orchestration state machine material: dispatch eligibility restated to include the park, and
+   the statement that a label is now read on that path.
+3. The issue tracker integration contract material: the parking label as a non-state write whose
+   later presence or absence on the issue is read back, and the requirement that an adapter
+   accepting a label write must make that label visible to subsequent reads of the issue.
+4. The agent-to-orchestrator protocol material: the consequence of the agent's inability-to-proceed
+   report now parking its issue, and what releases that park.
+5. The logging, status and observability material: the records emitted on park and on release, the
+   release trigger named on the release record, and the parked set surfaced in the runtime snapshot.
+6. The persistence material: the durability of the park across restart, and the statement that the
+   park is current state rather than run history.
+
+## Confirmation
+
+The decision is validated when all of the following hold:
+
+1. A parked issue whose parking label a person removes is released on the next poll tick and becomes
+   an ordinary dispatch candidate on that same tick.
+2. A parked issue that a person moves to a different tracker state is released on the next poll
+   tick, and where the new state is not active the issue remains undispatchable by the pre-existing
+   active-state gate rather than by the park.
+3. Both releases behave identically for a park taken because the agent reported it could not proceed
+   and for a park taken because the absence ceiling was reached.
+4. A park whose label write failed, or whose adapter recorded nothing, is not released by the
+   absence of that label. The issue stays parked.
+5. A park whose label is later observed on the issue becomes releasable by removal of that label,
+   and the confirmation survives a restart.
+6. Releasing a park whose trigger maintains a counter ends that counter's sequence, so the same
+   tick's trigger does not re-park the issue, and a subsequent run begins a fresh sequence.
+7. Releasing a park whose trigger maintains no counter touches no counter.
+8. An issue released on a tick is not re-parked on that tick by a derivation computed before the
+   reset.
+9. A release is recorded, naming which of the two gestures triggered it, so an operator can tell a
+   released issue from one that was never parked.
+10. An operator with no access to the orchestrator host, its configuration, or its command surface
+    can release a parked issue using only the tracker.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -28,3 +28,4 @@ This directory contains architecturally significant decisions for Sortie, docume
 | [0019](0019-keep-usage-data-on-the-host.md)             | Keep Usage Data on the Host and Aggregate Across Instances by Pull | Accepted |
 | [0020](0020-withhold-handoff-on-observed-absence-of-work.md) | Withhold the Handoff Transition Only When Absence of Work Is Observed | Accepted |
 | [0021](0021-run-self-review-before-ending-on-the-completion-signal.md) | Run Self-Review Before Ending the Run on the Completion Signal | Accepted |
+| [0022](0022-release-a-parked-issue-on-a-human-gesture.md) | Release a Parked Issue on a Human Gesture in the Tracker | Accepted |

--- a/internal/domain/metrics.go
+++ b/internal/domain/metrics.go
@@ -75,6 +75,11 @@ type Metrics interface {
 	// (sortie_handoff_transitions_total{result} counter).
 	IncHandoffTransitions(result string)
 
+	// IncIssueParks increments the issue park counter. reason is
+	// "agent_blocked" or "handoff_absence"
+	// (sortie_issue_parks_total{reason} counter).
+	IncIssueParks(reason string)
+
 	// IncDispatchTransitions increments the dispatch-time in-progress
 	// transition counter. result is "success", "error", or "skipped"
 	// (sortie_dispatch_transitions_total{result} counter).
@@ -201,6 +206,7 @@ func (*NoopMetrics) IncReconciliationActions(string)                       {}
 func (*NoopMetrics) IncPollCycles(string)                                  {}
 func (*NoopMetrics) IncTrackerRequests(string, string)                     {}
 func (*NoopMetrics) IncHandoffTransitions(string)                          {}
+func (*NoopMetrics) IncIssueParks(string)                                  {}
 func (*NoopMetrics) IncDispatchTransitions(string)                         {}
 func (*NoopMetrics) IncTrackerComments(string, string)                     {}
 func (*NoopMetrics) IncToolCalls(string, string)                           {}

--- a/internal/orchestrator/dispatch.go
+++ b/internal/orchestrator/dispatch.go
@@ -110,6 +110,12 @@ func ShouldDispatch(issue domain.Issue, state *State, activeStates, terminalStat
 		return false
 	}
 
+	// Parked issues are held out of dispatch until the release rule lifts
+	// the park, whatever the parking reason.
+	if _, parked := state.Parked[issue.ID]; parked {
+		return false
+	}
+
 	// Any non-terminal blocker blocks dispatch.
 	if isBlockedByNonTerminalSet(issue, terminalSet) {
 		return false
@@ -150,6 +156,12 @@ func ShouldDispatchWithSets(issue domain.Issue, state *State, activeSet, termina
 
 	// Issues that exhausted their effort budget are blocked from dispatch.
 	if _, exhausted := state.BudgetExhausted[issue.ID]; exhausted {
+		return false
+	}
+
+	// Parked issues are held out of dispatch until the release rule lifts
+	// the park, whatever the parking reason.
+	if _, parked := state.Parked[issue.ID]; parked {
 		return false
 	}
 

--- a/internal/orchestrator/dispatch_test.go
+++ b/internal/orchestrator/dispatch_test.go
@@ -356,6 +356,51 @@ func TestShouldDispatch(t *testing.T) {
 	}
 }
 
+// TestShouldDispatchParkedIssue verifies that both ShouldDispatch and
+// ShouldDispatchWithSets return false for a parked issue that satisfies
+// every other gate, with state.BudgetExhausted empty — matching a
+// deployment where both agent.max_sessions and agent.max_tokens are zero,
+// so the park gate alone, not a budget gate, accounts for the refusal.
+func TestShouldDispatchParkedIssue(t *testing.T) {
+	t.Parallel()
+
+	issue := domain.Issue{ID: "PARK-GATE", Identifier: "PARK-GATE", Title: "T", State: "To Do"}
+	active := []string{"To Do"}
+	terminal := []string{"Done"}
+
+	newParkedState := func() *State {
+		s := NewState(1000, 10, nil, AgentTotals{})
+		s.Parked[issue.ID] = &ParkedEntry{Identifier: issue.Identifier, Reason: parkReasonAgentBlocked}
+		return s
+	}
+
+	t.Run("ShouldDispatch", func(t *testing.T) {
+		t.Parallel()
+
+		s := newParkedState()
+		if len(s.BudgetExhausted) != 0 {
+			t.Fatalf("BudgetExhausted = %v, want empty", s.BudgetExhausted)
+		}
+		if got := ShouldDispatch(issue, s, active, terminal); got {
+			t.Errorf("ShouldDispatch(%q) = %t, want false for a parked issue", issue.Identifier, got)
+		}
+	})
+
+	t.Run("ShouldDispatchWithSets", func(t *testing.T) {
+		t.Parallel()
+
+		s := newParkedState()
+		activeSet := stateSet(active)
+		terminalSet := stateSet(terminal)
+		if len(s.BudgetExhausted) != 0 {
+			t.Fatalf("BudgetExhausted = %v, want empty", s.BudgetExhausted)
+		}
+		if got := ShouldDispatchWithSets(issue, s, activeSet, terminalSet); got {
+			t.Errorf("ShouldDispatchWithSets(%q) = %t, want false for a parked issue", issue.Identifier, got)
+		}
+	})
+}
+
 // TestShouldDispatch_ReopenAfterTerminalRelease verifies that releasing an
 // issue's claim through [releaseTerminalIssueState] makes it dispatchable
 // again once the tracker reports it back in an active state, and that the

--- a/internal/orchestrator/exit.go
+++ b/internal/orchestrator/exit.go
@@ -38,6 +38,8 @@ type WorkerExitStore interface {
 	DeleteRetryEntry(ctx context.Context, issueID string) error
 	QueryConsecutiveHandoffAbsenceCounts(ctx context.Context, issueIDs []string) (map[string]int, error)
 	ResetHandoffAbsenceSequence(ctx context.Context, issueID string) error
+	UpsertParkedIssue(ctx context.Context, entry persistence.ParkedIssue) error
+	DeleteParkedIssue(ctx context.Context, issueID string) error
 }
 
 // HandleWorkerExitParams holds the dependencies for [HandleWorkerExit] that
@@ -324,11 +326,13 @@ func HandleWorkerExit(state *State, workerResult WorkerResult, params HandleWork
 				evidenceErr = handoffEvidenceFailure(policy, evidenceResult)
 				metrics.IncHandoffTransitions(handoffWithheld)
 			} else if evidenceResult.Verdict == handoffWorkObserved {
-				// A positive verdict resets the runtime gate immediately. The
-				// durable reset recorded after the run_history write below holds
-				// even when the later tracker handoff write fails.
+				// A positive verdict releases a park immediately. The durable
+				// reset recorded after the run_history write below holds even
+				// when the later tracker handoff write fails.
 				evidenceWorkObserved = true
-				clearHandoffAbsenceGate(state, workerResult.IssueID)
+				if _, parked := state.Parked[workerResult.IssueID]; parked {
+					unparkIssue(ctx, state, workerResult.IssueID, unparkTriggerEvidenceObserved, params.Store, log)
+				}
 			}
 		}
 	}
@@ -437,7 +441,11 @@ func HandleWorkerExit(state *State, workerResult WorkerResult, params HandleWork
 				ctx,
 				params.Store,
 				params.TrackerAdapter,
+				metrics,
 				workerResult.IssueID,
+				workerResult.Identifier,
+				entry.Issue.DisplayID,
+				observation,
 				consecutiveAbsences,
 				absenceCeiling,
 				params.HandoffParkingLabel,
@@ -520,8 +528,24 @@ func HandleWorkerExit(state *State, workerResult WorkerResult, params HandleWork
 			log.Info("continuation retry suppressed",
 				slog.String("reason", workerResult.SoftStopReason),
 			)
-			CancelRetry(state, workerResult.IssueID)
-			delete(state.Claimed, workerResult.IssueID)
+			if drivesIssue {
+				parkIssue(state, parkIssueParams{
+					IssueID:        workerResult.IssueID,
+					Identifier:     workerResult.Identifier,
+					DisplayID:      entry.Issue.DisplayID,
+					ObservedState:  observation,
+					Reason:         parkReasonAgentBlocked,
+					Label:          params.HandoffParkingLabel,
+					Store:          params.Store,
+					TrackerAdapter: params.TrackerAdapter,
+					Metrics:        metrics,
+					Logger:         log,
+					Ctx:            ctx,
+				})
+			} else {
+				CancelRetry(state, workerResult.IssueID)
+				delete(state.Claimed, workerResult.IssueID)
+			}
 
 		case terminal:
 			// The tracker already reports a terminal state for this issue,

--- a/internal/orchestrator/exit_test.go
+++ b/internal/orchestrator/exit_test.go
@@ -36,6 +36,11 @@ type mockExitStore struct {
 	absenceResetAt map[string]int
 	absenceResetOf []string
 
+	parkedIssues     []persistence.ParkedIssue
+	deletedParkedIDs []string
+	upsertParkedErr  error
+	deleteParkedErr  error
+
 	appendRunHistoryErr       error
 	upsertAggregateMetricsErr error
 	upsertSessionMetadataErr  error
@@ -107,6 +112,16 @@ func (m *mockExitStore) ResetHandoffAbsenceSequence(_ context.Context, issueID s
 func (m *mockExitStore) UpsertSessionMetadata(_ context.Context, meta persistence.SessionMetadata) error {
 	m.sessionMetadata = append(m.sessionMetadata, meta)
 	return m.upsertSessionMetadataErr
+}
+
+func (m *mockExitStore) UpsertParkedIssue(_ context.Context, entry persistence.ParkedIssue) error {
+	m.parkedIssues = append(m.parkedIssues, entry)
+	return m.upsertParkedErr
+}
+
+func (m *mockExitStore) DeleteParkedIssue(_ context.Context, issueID string) error {
+	m.deletedParkedIDs = append(m.deletedParkedIDs, issueID)
+	return m.deleteParkedErr
 }
 
 // --- Test helpers ---
@@ -4356,6 +4371,161 @@ func TestHandleWorkerExit_SoftStop(t *testing.T) {
 			t.Errorf("retries = %v, want [] (no retry on nil adapter soft-stop)", spy.retries)
 		}
 	})
+}
+
+// TestHandleWorkerExitBlockedDrivingDispatchParksIssue verifies that a
+// blocked soft stop from a dispatch that drives issue state records the
+// durable park, releases the claim, cancels and deletes the retry, counts
+// the park, and starts the parking-label write.
+func TestHandleWorkerExitBlockedDrivingDispatchParksIssue(t *testing.T) {
+	t.Parallel()
+
+	store := &mockExitStore{}
+	tracker := newRecordingHandoffTracker()
+	spy := &spyMetrics{}
+	state := exitStateWithIssue(t, "BLK-1", "In Progress")
+	params := defaultExitParams(t, store)
+	params.TrackerAdapter = tracker
+	params.HandoffParkingLabel = "needs-human"
+	params.Metrics = spy
+
+	HandleWorkerExit(state, WorkerResult{
+		IssueID:        "BLK-1",
+		Identifier:     "BLK-1-ident",
+		ExitKind:       WorkerExitNormal,
+		AgentAdapter:   "mock",
+		SoftStop:       true,
+		SoftStopReason: "blocked",
+	}, params)
+	state.TrackerOpsWg.Wait()
+
+	entry, ok := state.Parked["BLK-1"]
+	if !ok {
+		t.Fatal("issue not parked after a blocked soft stop that drives issue state")
+	}
+	if entry.Reason != parkReasonAgentBlocked {
+		t.Errorf("Parked[BLK-1].Reason = %q, want %q", entry.Reason, parkReasonAgentBlocked)
+	}
+	if len(store.parkedIssues) != 1 || store.parkedIssues[0].IssueID != "BLK-1" {
+		t.Errorf("UpsertParkedIssue calls = %+v, want one call for BLK-1", store.parkedIssues)
+	}
+	if _, ok := state.Claimed["BLK-1"]; ok {
+		t.Error("claim remains after parking")
+	}
+	if _, ok := state.RetryAttempts["BLK-1"]; ok {
+		t.Error("retry remains after parking")
+	}
+	if len(store.deletedRetryIDs) != 1 || store.deletedRetryIDs[0] != "BLK-1" {
+		t.Errorf("DeleteRetryEntry calls = %v, want [BLK-1]", store.deletedRetryIDs)
+	}
+	spy.mu.Lock()
+	parks := append([]string(nil), spy.issueParks...)
+	spy.mu.Unlock()
+	if len(parks) != 1 || parks[0] != parkReasonAgentBlocked {
+		t.Errorf("IncIssueParks calls = %v, want one %q call", parks, parkReasonAgentBlocked)
+	}
+	calls := tracker.labels()
+	if len(calls) != 1 || calls[0].issueID != "BLK-1" || calls[0].label != "needs-human" {
+		t.Errorf("AddLabel calls = %+v, want one needs-human call for BLK-1", calls)
+	}
+}
+
+// TestHandleWorkerExitBlockedLabelCommandPostureTakesUnchangedDisposition
+// verifies that a blocked soft stop from a dispatch whose posture does not
+// drive issue state keeps today's disposition: log, cancel the retry,
+// release the claim, no park recorded, no label write started.
+func TestHandleWorkerExitBlockedLabelCommandPostureTakesUnchangedDisposition(t *testing.T) {
+	t.Parallel()
+
+	store := &mockExitStore{}
+	tracker := newRecordingHandoffTracker()
+	spy := &spyMetrics{}
+	state := exitStateWithIssue(t, "BLK-2", "In Progress")
+	state.Running["BLK-2"].ReactionKind = ReactionKindLabelReview
+	params := defaultExitParams(t, store)
+	params.TrackerAdapter = tracker
+	params.HandoffParkingLabel = "needs-human"
+	params.Metrics = spy
+
+	HandleWorkerExit(state, WorkerResult{
+		IssueID:        "BLK-2",
+		Identifier:     "BLK-2-ident",
+		ExitKind:       WorkerExitNormal,
+		AgentAdapter:   "mock",
+		SoftStop:       true,
+		SoftStopReason: "blocked",
+	}, params)
+	state.TrackerOpsWg.Wait()
+
+	if _, ok := state.Parked["BLK-2"]; ok {
+		t.Error("issue parked despite a posture that does not drive issue state")
+	}
+	if len(store.parkedIssues) != 0 {
+		t.Errorf("UpsertParkedIssue calls = %+v, want none", store.parkedIssues)
+	}
+	if _, ok := state.Claimed["BLK-2"]; ok {
+		t.Error("claim remains after soft stop")
+	}
+	if _, ok := state.RetryAttempts["BLK-2"]; ok {
+		t.Error("retry remains after soft stop")
+	}
+	if calls := tracker.labels(); len(calls) != 0 {
+		t.Errorf("AddLabel calls = %+v, want none", calls)
+	}
+	spy.mu.Lock()
+	parks := append([]string(nil), spy.issueParks...)
+	spy.mu.Unlock()
+	if len(parks) != 0 {
+		t.Errorf("IncIssueParks calls = %v, want none", parks)
+	}
+}
+
+// TestHandleWorkerExitNeedsHumanReviewPerformsHandoffWithoutParking is
+// issue #811's own regression requirement: a needs-human-review exit still
+// performs the handoff transition where configured, records no park, and
+// applies no parking label.
+func TestHandleWorkerExitNeedsHumanReviewPerformsHandoffWithoutParking(t *testing.T) {
+	t.Parallel()
+
+	store := &mockExitStore{}
+	tracker := newRecordingHandoffTracker()
+	spy := &spyMetrics{}
+	state := exitStateWithIssue(t, "NHR-1", "In Progress")
+	params := defaultExitParams(t, store)
+	params.TrackerAdapter = tracker
+	params.HandoffState = "Human Review"
+	params.ActiveStates = []string{"In Progress"}
+	params.HandoffParkingLabel = "needs-human"
+	params.Metrics = spy
+
+	HandleWorkerExit(state, WorkerResult{
+		IssueID:        "NHR-1",
+		Identifier:     "NHR-1-ident",
+		ExitKind:       WorkerExitNormal,
+		AgentAdapter:   "mock",
+		SoftStop:       true,
+		SoftStopReason: "needs-human-review",
+	}, params)
+	state.TrackerOpsWg.Wait()
+
+	if len(tracker.transitionCalls) != 1 || tracker.transitionCalls[0].TargetState != "Human Review" {
+		t.Errorf("TransitionIssue calls = %+v, want one transition to %q", tracker.transitionCalls, "Human Review")
+	}
+	if _, ok := state.Parked["NHR-1"]; ok {
+		t.Error("needs-human-review recorded a park, want none")
+	}
+	if len(store.parkedIssues) != 0 {
+		t.Errorf("UpsertParkedIssue calls = %+v, want none", store.parkedIssues)
+	}
+	if calls := tracker.labels(); len(calls) != 0 {
+		t.Errorf("AddLabel calls = %+v, want none: needs-human-review applies no parking label", calls)
+	}
+	spy.mu.Lock()
+	parks := append([]string(nil), spy.issueParks...)
+	spy.mu.Unlock()
+	if len(parks) != 0 {
+		t.Errorf("IncIssueParks calls = %v, want none", parks)
+	}
 }
 
 // TestBuildSoftStopComment verifies the format of the soft-stop comment string.

--- a/internal/orchestrator/handoff_absence.go
+++ b/internal/orchestrator/handoff_absence.go
@@ -3,7 +3,6 @@ package orchestrator
 import (
 	"context"
 	"log/slog"
-	"time"
 
 	"github.com/sortie-ai/sortie/internal/config"
 	"github.com/sortie-ai/sortie/internal/domain"
@@ -14,15 +13,6 @@ const (
 	defaultHandoffParkingLabel   = "needs-human"
 	reviewCommentsConfigKey      = "review_comments"
 )
-
-// handoffAbsenceStore is the persistence surface shared by worker exit,
-// retry firing, and ordinary polling. The run-history query is the durable
-// eligibility gate; deleting the retry row stops a recovered timer from
-// competing with that gate.
-type handoffAbsenceStore interface {
-	DeleteRetryEntry(ctx context.Context, issueID string) error
-	QueryConsecutiveHandoffAbsenceCounts(ctx context.Context, issueIDs []string) (map[string]int, error)
-}
 
 func handoffAbsenceCeiling(maxSessions int) int {
 	if maxSessions > 0 {
@@ -41,26 +31,17 @@ func resolveHandoffParkingLabel(reactions map[string]config.ReactionConfig) stri
 	return defaultHandoffParkingLabel
 }
 
-func clearHandoffAbsenceGate(state *State, issueID string) {
-	if state.BudgetExhaustedReason[issueID] != budgetReasonHandoffAbsence {
-		return
-	}
-	delete(state.BudgetExhausted, issueID)
-	delete(state.BudgetExhaustedReason, issueID)
-}
-
-// parkHandoffAbsence stops all queued work for the issue, records the durable
-// runtime gate, releases the claim, and applies the operator's captured human
-// parking label. The label write is best-effort: failure is logged but never
-// reopens dispatch eligibility.
+// parkHandoffAbsence records an absence park through [parkIssue].
+// observedState is empty only on the retry lane, which parks before its
+// tracker fetch.
 func parkHandoffAbsence(
 	state *State,
 	ctx context.Context,
-	store handoffAbsenceStore,
+	store ParkStore,
 	tracker domain.TrackerAdapter,
-	issueID string,
-	count int,
-	ceiling int,
+	metrics domain.Metrics,
+	issueID, identifier, displayID, observedState string,
+	count, ceiling int,
 	label string,
 	log *slog.Logger,
 ) {
@@ -74,40 +55,19 @@ func parkHandoffAbsence(
 		label = defaultHandoffParkingLabel
 	}
 
-	CancelRetry(state, issueID)
-	delete(state.Claimed, issueID)
-	state.BudgetExhausted[issueID] = struct{}{}
-	state.BudgetExhaustedReason[issueID] = budgetReasonHandoffAbsence
-
-	if err := store.DeleteRetryEntry(ctx, issueID); err != nil {
-		log.Error("failed to delete retry entry after handoff absence parking",
-			slog.Any("error", err),
-		)
-	}
-
-	log.Warn("handoff absence ceiling reached, parking issue",
-		slog.Int("consecutive_absences", count),
-		slog.Int("absence_ceiling", ceiling),
-		slog.String("escalation_label", label),
-	)
-
-	if tracker == nil {
-		log.Warn("handoff absence escalation label failed",
-			slog.String("escalation_label", label),
-			slog.String("reason", "tracker adapter is nil"),
-		)
-		return
-	}
-
-	state.TrackerOpsWg.Go(func() {
-		dctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
-		defer cancel()
-
-		if err := tracker.AddLabel(dctx, issueID, label); err != nil {
-			log.Warn("handoff absence escalation label failed",
-				slog.String("escalation_label", label),
-				slog.Any("error", err),
-			)
-		}
+	parkIssue(state, parkIssueParams{
+		IssueID:        issueID,
+		Identifier:     identifier,
+		DisplayID:      displayID,
+		ObservedState:  observedState,
+		Reason:         parkReasonHandoffAbsence,
+		Label:          label,
+		Absences:       count,
+		Ceiling:        ceiling,
+		Store:          store,
+		TrackerAdapter: tracker,
+		Metrics:        metrics,
+		Logger:         log,
+		Ctx:            ctx,
 	})
 }

--- a/internal/orchestrator/handoff_absence_test.go
+++ b/internal/orchestrator/handoff_absence_test.go
@@ -160,11 +160,12 @@ func TestHandleWorkerExitParksAtHandoffAbsenceCeiling(t *testing.T) {
 			if _, ok := state.RetryAttempts[issueID]; ok {
 				t.Error("retry remains after parking")
 			}
-			if _, ok := state.BudgetExhausted[issueID]; !ok {
+			entry, ok := state.Parked[issueID]
+			if !ok {
 				t.Error("durable dispatch gate missing after parking")
 			}
-			if got := state.BudgetExhaustedReason[issueID]; got != budgetReasonHandoffAbsence {
-				t.Errorf("BudgetExhaustedReason = %q, want %q", got, budgetReasonHandoffAbsence)
+			if entry != nil && entry.Reason != parkReasonHandoffAbsence {
+				t.Errorf("Parked[%s].Reason = %q, want %q", issueID, entry.Reason, parkReasonHandoffAbsence)
 			}
 			calls := tracker.labels()
 			if len(calls) != 1 || calls[0].issueID != issueID || calls[0].label != tt.wantAppliedLabel {
@@ -177,7 +178,7 @@ func TestHandleWorkerExitParksAtHandoffAbsenceCeiling(t *testing.T) {
 				"issue_id=" + issueID,
 				"consecutive_absences=" + strconv.Itoa(tt.wantCeiling),
 				"absence_ceiling=" + strconv.Itoa(tt.wantCeiling),
-				`escalation_label=` + tt.wantAppliedLabel,
+				`label=` + tt.wantAppliedLabel,
 			} {
 				if !strings.Contains(logs.String(), want) {
 					t.Errorf("parking log missing %q\nlogs: %s", want, logs.String())
@@ -215,7 +216,7 @@ func TestHandleWorkerExitDefaultCeilingAllowsSecondAbsenceRetry(t *testing.T) {
 	if _, ok := state.Claimed[issueID]; !ok {
 		t.Error("claim released before the third consecutive absence")
 	}
-	if _, ok := state.BudgetExhausted[issueID]; ok {
+	if _, ok := state.Parked[issueID]; ok {
 		t.Error("issue parked before the default ceiling of three")
 	}
 	state.TrackerOpsWg.Wait()
@@ -238,8 +239,10 @@ func TestHandleWorkerExitWorkObservedResetsAbsenceSequenceBeforeHandoffWrite(t *
 		return errors.New("handoff unavailable")
 	}
 	state := exitStateWithIssue(t, issueID, "In Progress")
-	state.BudgetExhausted[issueID] = struct{}{}
-	state.BudgetExhaustedReason[issueID] = budgetReasonHandoffAbsence
+	state.Parked[issueID] = &ParkedEntry{
+		Identifier: "PROJ-RESET",
+		Reason:     parkReasonHandoffAbsence,
+	}
 	params := handoffEvidenceExitParams(t, store, tracker.mockTrackerAdapter, &spyMetrics{})
 	params.TrackerAdapter = tracker
 
@@ -254,11 +257,8 @@ func TestHandleWorkerExitWorkObservedResetsAbsenceSequenceBeforeHandoffWrite(t *
 	}, params)
 	t.Cleanup(func() { CancelRetry(state, issueID) })
 
-	if _, ok := state.BudgetExhausted[issueID]; ok {
-		t.Error("handoff-absence gate survived a work-observed run")
-	}
-	if _, ok := state.BudgetExhaustedReason[issueID]; ok {
-		t.Error("handoff-absence reason survived a work-observed run")
+	if _, ok := state.Parked[issueID]; ok {
+		t.Error("handoff-absence park survived a work-observed run")
 	}
 	counts, err := store.QueryConsecutiveHandoffAbsenceCounts(context.Background(), []string{issueID})
 	if err != nil {
@@ -270,8 +270,17 @@ func TestHandleWorkerExitWorkObservedResetsAbsenceSequenceBeforeHandoffWrite(t *
 	if len(tracker.transitionCalls) != 1 {
 		t.Errorf("TransitionIssue calls = %d, want 1 failing handoff attempt", len(tracker.transitionCalls))
 	}
-	if len(store.absenceResetOf) != 1 || store.absenceResetOf[0] != issueID {
-		t.Errorf("ResetHandoffAbsenceSequence calls = %v, want [%s]", store.absenceResetOf, issueID)
+	// Two calls are expected here, not one: unparking the handoff-absence
+	// park resets the sequence, and the standalone reset that already runs
+	// on every work-observed verdict (independent of whether a park
+	// existed) also fires. Both target the same issue and are idempotent.
+	for _, id := range store.absenceResetOf {
+		if id != issueID {
+			t.Errorf("ResetHandoffAbsenceSequence calls = %v, want every call for %s", store.absenceResetOf, issueID)
+		}
+	}
+	if len(store.absenceResetOf) != 2 {
+		t.Errorf("ResetHandoffAbsenceSequence call count = %d, want 2", len(store.absenceResetOf))
 	}
 }
 
@@ -329,7 +338,7 @@ func TestHandleWorkerExitSucceededWithoutVerdictKeepsAbsenceSequence(t *testing.
 	absentState.TrackerOpsWg.Wait()
 	t.Cleanup(func() { CancelRetry(absentState, issueID) })
 
-	if _, ok := absentState.BudgetExhausted[issueID]; !ok {
+	if _, ok := absentState.Parked[issueID]; !ok {
 		t.Error("third consecutive absence did not park the issue")
 	}
 	if calls := tracker.labels(); len(calls) != 1 {
@@ -363,13 +372,13 @@ func TestHandleRetryTimerKeepsRecoveredExhaustedAbsenceParkedWhenLabelFails(t *t
 	if _, ok := state.RetryAttempts[issueID]; ok {
 		t.Error("retry was restored after recovered absence parking")
 	}
-	if got := state.BudgetExhaustedReason[issueID]; got != budgetReasonHandoffAbsence {
-		t.Errorf("BudgetExhaustedReason = %q, want %q", got, budgetReasonHandoffAbsence)
+	if entry := state.Parked[issueID]; entry == nil || entry.Reason != parkReasonHandoffAbsence {
+		t.Errorf("Parked[%s] = %+v, want reason %q", issueID, entry, parkReasonHandoffAbsence)
 	}
 	if ShouldDispatch(candidateIssue(issueID, "PROJ-RECOVERED", "In Progress"), state, params.ActiveStates, params.TerminalStates) {
 		t.Error("ordinary polling would dispatch after the parking label failed")
 	}
-	if !strings.Contains(logs.String(), "handoff absence escalation label failed") {
+	if !strings.Contains(logs.String(), "park label write failed") {
 		t.Errorf("missing label failure log\nlogs: %s", logs.String())
 	}
 }
@@ -425,7 +434,7 @@ func TestHandleRetryTimerFallsBackWhenAbsenceQueryFails(t *testing.T) {
 	if !strings.Contains(logs.String(), "handoff absence count query failed") {
 		t.Errorf("missing query failure log\nlogs: %s", logs.String())
 	}
-	if _, ok := state.BudgetExhausted[issueID]; !ok {
+	if _, ok := state.Parked[issueID]; !ok {
 		t.Error("an unanswerable absence query resumed an exhausted sequence")
 	}
 	if tracker.fetchCount != 0 {
@@ -439,8 +448,7 @@ func TestRebuildBudgetExhaustedRetainsAbsenceParkingOnQueryError(t *testing.T) {
 	cfg := config.ServiceConfig{}
 	store := &stubStore{absenceCountErr: errors.New("database is locked")}
 	state := NewState(1000, 1, nil, AgentTotals{})
-	state.BudgetExhausted[issueID] = struct{}{}
-	state.BudgetExhaustedReason[issueID] = budgetReasonHandoffAbsence
+	state.Parked[issueID] = &ParkedEntry{Identifier: "PROJ-REBUILD", Reason: parkReasonHandoffAbsence}
 	orchestrator := NewOrchestrator(OrchestratorParams{
 		State:           state,
 		Logger:          discardLogger(),
@@ -450,10 +458,11 @@ func TestRebuildBudgetExhaustedRetainsAbsenceParkingOnQueryError(t *testing.T) {
 		Store:           store,
 	})
 
-	orchestrator.rebuildBudgetExhausted(context.Background(), cfg, []domain.Issue{issue})
+	orchestrator.parkExhaustedAbsences(context.Background(), cfg, []domain.Issue{issue})
 
-	if got := state.BudgetExhaustedReason[issueID]; got != budgetReasonHandoffAbsence {
-		t.Errorf("BudgetExhaustedReason = %q, want the parking retained across a query error", got)
+	entry := state.Parked[issueID]
+	if entry == nil || entry.Reason != parkReasonHandoffAbsence {
+		t.Errorf("Parked[%s] = %+v, want the parking retained across a query error", issueID, entry)
 	}
 	if ShouldDispatch(issue, state, []string{"To Do"}, []string{"Done"}) {
 		t.Error("a query error released a parked issue")
@@ -478,7 +487,7 @@ func TestHandleRetryTimerExemptsReactionContinuationFromAbsenceGate(t *testing.T
 	if len(tracker.addedLabels) != 0 {
 		t.Errorf("AddLabel calls = %v, want none for a reaction continuation", tracker.addedLabels)
 	}
-	if _, ok := state.BudgetExhausted[issueID]; ok {
+	if _, ok := state.Parked[issueID]; ok {
 		t.Error("reaction continuation parked by the handoff-absence ceiling")
 	}
 }
@@ -498,7 +507,7 @@ func TestHandleRetryTimerSkipsAbsenceGateUnderOffPolicy(t *testing.T) {
 	if len(store.absenceCountedIssueIDs) != 0 {
 		t.Errorf("absence query ran for %v under the off policy, want no query", store.absenceCountedIssueIDs)
 	}
-	if _, ok := state.BudgetExhausted[issueID]; ok {
+	if _, ok := state.Parked[issueID]; ok {
 		t.Error("issue parked under the off policy")
 	}
 }
@@ -512,8 +521,6 @@ func TestRebuildBudgetExhaustedSkipsAbsenceGateUnderOffPolicy(t *testing.T) {
 	store := &stubStore{absenceCounts: map[string]int{issueID: 5}}
 	tracker := newRecordingHandoffTracker()
 	state := NewState(1000, 1, nil, AgentTotals{})
-	state.BudgetExhausted[issueID] = struct{}{}
-	state.BudgetExhaustedReason[issueID] = budgetReasonHandoffAbsence
 	orchestrator := NewOrchestrator(OrchestratorParams{
 		State:           state,
 		Logger:          discardLogger(),
@@ -523,11 +530,14 @@ func TestRebuildBudgetExhaustedSkipsAbsenceGateUnderOffPolicy(t *testing.T) {
 		Store:           store,
 	})
 
-	orchestrator.rebuildBudgetExhausted(context.Background(), cfg, []domain.Issue{issue})
+	orchestrator.parkExhaustedAbsences(context.Background(), cfg, []domain.Issue{issue})
 	state.TrackerOpsWg.Wait()
 
 	if store.absenceQueryCalls != 0 {
 		t.Errorf("absence query ran %d times under the off policy, want 0", store.absenceQueryCalls)
+	}
+	if _, ok := state.Parked[issueID]; ok {
+		t.Error("the off policy parked an issue by the absence ceiling")
 	}
 	if !ShouldDispatch(issue, state, []string{"To Do"}, []string{"Done"}) {
 		t.Error("the off policy left an issue gated by the absence ceiling")
@@ -573,17 +583,450 @@ func TestRebuildBudgetExhaustedRestoresAbsenceParkingAfterRestart(t *testing.T) 
 		},
 	}
 	manager.setConfig(reloadedCfg)
-	orchestrator.rebuildBudgetExhausted(context.Background(), reloadedCfg, []domain.Issue{issue})
+	orchestrator.parkExhaustedAbsences(context.Background(), reloadedCfg, []domain.Issue{issue})
 	state.TrackerOpsWg.Wait()
 
 	if ShouldDispatch(issue, state, []string{"To Do"}, []string{"Done"}) {
 		t.Error("ordinary polling would dispatch an absence-exhausted issue after restart")
 	}
-	if got := state.BudgetExhaustedReason[issueID]; got != budgetReasonHandoffAbsence {
-		t.Errorf("BudgetExhaustedReason = %q, want %q", got, budgetReasonHandoffAbsence)
+	entry := state.Parked[issueID]
+	if entry == nil || entry.Reason != parkReasonHandoffAbsence {
+		t.Errorf("Parked[%s] = %+v, want reason %q", issueID, entry, parkReasonHandoffAbsence)
 	}
 	calls := tracker.labels()
 	if len(calls) != 1 || calls[0].label != "captured-human-label" {
 		t.Errorf("AddLabel calls = %+v, want captured-human-label despite reload", calls)
+	}
+}
+
+// TestParkExhaustedAbsencesLeavesBudgetExhaustedEmpty verifies that an
+// absence park taken by the tick pass produces a parked_issues row with
+// reason handoff_absence and leaves BudgetExhausted and
+// BudgetExhaustedReason empty: the absence park is the sole gate, not a
+// second budget-exhaustion mechanism.
+func TestParkExhaustedAbsencesLeavesBudgetExhaustedEmpty(t *testing.T) {
+	t.Parallel()
+
+	const issueID = "ABS-BUDGET"
+	issue := candidateIssue(issueID, "PROJ-BUDGET", "To Do")
+	cfg := config.ServiceConfig{}
+	store := &stubStore{absenceCounts: map[string]int{issueID: 3}}
+	tracker := newRecordingHandoffTracker()
+	state := NewState(1000, 1, nil, AgentTotals{})
+	orchestrator := NewOrchestrator(OrchestratorParams{
+		State:           state,
+		Logger:          discardLogger(),
+		TrackerAdapter:  tracker,
+		AgentAdapter:    &mockAgentAdapter{},
+		WorkflowManager: &stubWorkflowManager{config: cfg},
+		Store:           store,
+	})
+
+	orchestrator.parkExhaustedAbsences(context.Background(), cfg, []domain.Issue{issue})
+	state.TrackerOpsWg.Wait()
+
+	entry := state.Parked[issueID]
+	if entry == nil || entry.Reason != parkReasonHandoffAbsence {
+		t.Fatalf("Parked[%s] = %+v, want reason %q", issueID, entry, parkReasonHandoffAbsence)
+	}
+	if len(state.BudgetExhausted) != 0 {
+		t.Errorf("BudgetExhausted = %v, want empty", state.BudgetExhausted)
+	}
+	if len(state.BudgetExhaustedReason) != 0 {
+		t.Errorf("BudgetExhaustedReason = %v, want empty", state.BudgetExhaustedReason)
+	}
+}
+
+// TestUnparkIssueAgentBlockedDoesNotResetAbsenceSequence verifies that
+// releasing a park whose reason is agent_blocked does not call
+// ResetHandoffAbsenceSequence: that reset belongs only to the
+// handoff_absence reason, which owns a sequence to reset.
+func TestUnparkIssueAgentBlockedDoesNotResetAbsenceSequence(t *testing.T) {
+	t.Parallel()
+
+	const issueID = "BLK-UNPARK"
+	store := &mockExitStore{}
+	state := NewState(1000, 1, nil, AgentTotals{})
+	state.Parked[issueID] = &ParkedEntry{Identifier: "PROJ-BLK", Reason: parkReasonAgentBlocked}
+
+	unparkIssue(context.Background(), state, issueID, unparkTriggerStateChanged, store, discardLogger())
+
+	if _, ok := state.Parked[issueID]; ok {
+		t.Error("issue remains parked after unparkIssue")
+	}
+	if len(store.absenceResetOf) != 0 {
+		t.Errorf("ResetHandoffAbsenceSequence calls = %v, want none for an agent_blocked park", store.absenceResetOf)
+	}
+	if len(store.deletedParkedIDs) != 1 || store.deletedParkedIDs[0] != issueID {
+		t.Errorf("DeleteParkedIssue calls = %v, want [%s]", store.deletedParkedIDs, issueID)
+	}
+}
+
+// TestHandleTickAbsenceReleaseOrdering drives the real release pass and
+// the real absence trigger, in tick order, against a real store. A
+// pre-existing handoff-absence park is released by a candidate state
+// change; the release must reset the absence sequence before the trigger
+// re-evaluates the same candidate, so the issue is not re-parked on the
+// same tick. A fake store cannot substitute here: the defect this guards
+// is the two passes disagreeing about a real, persisted sequence.
+func TestHandleTickAbsenceReleaseOrdering(t *testing.T) {
+	t.Parallel()
+
+	const issueID = "ORD-1"
+	ctx := context.Background()
+	store, err := persistence.Open(ctx, ":memory:")
+	if err != nil {
+		t.Fatalf("persistence.Open: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := store.Close(); err != nil {
+			t.Errorf("store.Close: %v", err)
+		}
+	})
+	if err := store.Migrate(ctx); err != nil {
+		t.Fatalf("store.Migrate: %v", err)
+	}
+
+	absenceErr := persistence.HandoffAbsenceErrorPrefix + "absence of work observed under observed policy"
+	for range 3 {
+		if _, err := store.AppendRunHistory(ctx, persistence.RunHistory{
+			IssueID:      issueID,
+			Identifier:   "PROJ-ORD",
+			Attempt:      1,
+			AgentAdapter: "mock",
+			Workspace:    "/tmp/" + issueID,
+			StartedAt:    "2026-08-17T00:00:00Z",
+			CompletedAt:  "2026-08-17T00:01:00Z",
+			Status:       "failed",
+			Error:        &absenceErr,
+		}); err != nil {
+			t.Fatalf("AppendRunHistory: %v", err)
+		}
+	}
+
+	if err := store.UpsertParkedIssue(ctx, persistence.ParkedIssue{
+		IssueID:     issueID,
+		Identifier:  "PROJ-ORD",
+		Reason:      parkReasonHandoffAbsence,
+		ParkedState: "In Progress",
+		Label:       "needs-human",
+		ParkedAt:    "2026-08-17T00:01:00Z",
+	}); err != nil {
+		t.Fatalf("UpsertParkedIssue: %v", err)
+	}
+
+	state := NewState(1000, 4, nil, AgentTotals{})
+	state.Parked[issueID] = &ParkedEntry{
+		Identifier:  "PROJ-ORD",
+		Reason:      parkReasonHandoffAbsence,
+		ParkedState: "In Progress",
+		Label:       "needs-human",
+	}
+
+	tracker := newRecordingHandoffTracker()
+	orchestrator := NewOrchestrator(OrchestratorParams{
+		State:           state,
+		Logger:          discardLogger(),
+		TrackerAdapter:  tracker,
+		AgentAdapter:    &mockAgentAdapter{},
+		WorkflowManager: &stubWorkflowManager{config: config.ServiceConfig{}},
+		Store:           store,
+	})
+
+	candidates := []domain.Issue{
+		{ID: issueID, Identifier: "PROJ-ORD", Title: "T", State: "Done"},
+	}
+
+	orchestrator.refreshParkedIssues(ctx, candidates)
+	orchestrator.parkExhaustedAbsences(ctx, config.ServiceConfig{}, candidates)
+	state.TrackerOpsWg.Wait()
+
+	if _, ok := state.Parked[issueID]; ok {
+		t.Error("the issue was re-parked on the same tick it was released")
+	}
+	counts, err := store.QueryConsecutiveHandoffAbsenceCounts(ctx, []string{issueID})
+	if err != nil {
+		t.Fatalf("QueryConsecutiveHandoffAbsenceCounts: %v", err)
+	}
+	if got := counts[issueID]; got != 0 {
+		t.Errorf("consecutive absences after release = %d, want 0", got)
+	}
+	if calls := tracker.labels(); len(calls) != 0 {
+		t.Errorf("AddLabel calls = %+v, want none: the issue must not be re-parked", calls)
+	}
+}
+
+// TestParkExhaustedAbsencesOffPolicyHoldsExistingParkAndSkipsNewPark
+// verifies both halves of the off-policy behavior in one pass: a park
+// already held stands, because the policy governs the trigger and not the
+// gate, and a candidate whose absence count has just reached the ceiling
+// is not newly parked, because the trigger is skipped entirely under the
+// off policy.
+func TestParkExhaustedAbsencesOffPolicyHoldsExistingParkAndSkipsNewPark(t *testing.T) {
+	t.Parallel()
+
+	const heldIssueID = "OFF-HELD"
+	const freshIssueID = "OFF-FRESH"
+	cfg := config.ServiceConfig{Tracker: config.TrackerConfig{HandoffEvidence: config.HandoffEvidenceOff}}
+	store := &stubStore{absenceCounts: map[string]int{freshIssueID: 5}}
+	tracker := newRecordingHandoffTracker()
+	state := NewState(1000, 1, nil, AgentTotals{})
+	state.Parked[heldIssueID] = &ParkedEntry{
+		Identifier:  "PROJ-HELD",
+		Reason:      parkReasonHandoffAbsence,
+		ParkedState: "In Progress",
+		Label:       "needs-human",
+	}
+
+	orchestrator := NewOrchestrator(OrchestratorParams{
+		State:           state,
+		Logger:          discardLogger(),
+		TrackerAdapter:  tracker,
+		AgentAdapter:    &mockAgentAdapter{},
+		WorkflowManager: &stubWorkflowManager{config: cfg},
+		Store:           store,
+	})
+
+	candidates := []domain.Issue{
+		{ID: heldIssueID, Identifier: "PROJ-HELD", Title: "T", State: "In Progress"},
+		{ID: freshIssueID, Identifier: "PROJ-FRESH", Title: "T", State: "To Do"},
+	}
+
+	orchestrator.refreshParkedIssues(context.Background(), candidates)
+	orchestrator.parkExhaustedAbsences(context.Background(), cfg, candidates)
+	state.TrackerOpsWg.Wait()
+
+	if _, ok := state.Parked[heldIssueID]; !ok {
+		t.Error("the off policy released a park it does not govern")
+	}
+	if _, ok := state.Parked[freshIssueID]; ok {
+		t.Error("the off policy took a new absence park")
+	}
+	if store.absenceQueryCalls != 0 {
+		t.Errorf("absence query ran %d times under the off policy, want 0", store.absenceQueryCalls)
+	}
+}
+
+// TestParkRetryLaneBackfillAndRelease verifies that a retry-lane absence
+// park records an empty parked_state, the next release pass backfills it
+// without releasing, and a state change observed after the backfill
+// releases the park.
+func TestParkRetryLaneBackfillAndRelease(t *testing.T) {
+	t.Parallel()
+
+	const issueID = "BACKFILL-1"
+	store := &stubStore{absenceCounts: map[string]int{issueID: 3}}
+	retryTracker := &mockRetryTracker{}
+	state := retryState(t, issueID, "PROJ-BACKFILL", 1)
+	retryParams := HandleRetryTimerParams{
+		Store:             store,
+		TrackerAdapter:    retryTracker,
+		ActiveStates:      []string{"To Do", "In Progress"},
+		TerminalStates:    []string{"Done"},
+		MaxRetryBackoffMS: 300_000,
+		MakeWorkerFn: func(_, _, _, _, _ string, _ domain.AgentAdapter) WorkerFunc {
+			return func(context.Context, domain.Issue, *int) {}
+		},
+		AgentAdapterByKind: func(string) (domain.AgentAdapter, error) { return &mockAgentAdapter{}, nil },
+		OnRetryFire:        noopRetryFire,
+		Ctx:                context.Background(),
+		Logger:             discardLogger(),
+	}
+	retryParams.MaxSessions = 0
+
+	HandleRetryTimer(state, issueID, retryParams)
+	state.TrackerOpsWg.Wait()
+
+	entry := state.Parked[issueID]
+	if entry == nil {
+		t.Fatal("issue not parked after the retry-lane absence ceiling was reached")
+	}
+	if entry.ParkedState != "" {
+		t.Fatalf("Parked[%s].ParkedState = %q, want empty for a retry-lane park", issueID, entry.ParkedState)
+	}
+
+	tickTracker := &mockTrackerAdapter{
+		fetchStatesFn: func(_ context.Context, _ []string) (map[string]string, error) {
+			return map[string]string{issueID: "In Progress"}, nil
+		},
+	}
+	orchestrator := NewOrchestrator(OrchestratorParams{
+		State:           state,
+		Logger:          discardLogger(),
+		TrackerAdapter:  tickTracker,
+		AgentAdapter:    &mockAgentAdapter{},
+		WorkflowManager: &stubWorkflowManager{config: config.ServiceConfig{}},
+		Store:           store,
+	})
+
+	orchestrator.refreshParkedIssues(context.Background(), nil)
+
+	if entry.ParkedState != "In Progress" {
+		t.Errorf("Parked[%s].ParkedState after backfill = %q, want %q", issueID, entry.ParkedState, "In Progress")
+	}
+	if _, ok := state.Parked[issueID]; !ok {
+		t.Error("the backfill tick released the park, want it to stand")
+	}
+
+	tickTracker.fetchStatesFn = func(_ context.Context, _ []string) (map[string]string, error) {
+		return map[string]string{issueID: "Done"}, nil
+	}
+	orchestrator.refreshParkedIssues(context.Background(), nil)
+
+	if _, ok := state.Parked[issueID]; ok {
+		t.Error("a state change observed after the backfill did not release the park")
+	}
+	if len(store.deletedParkedIDs) != 1 || store.deletedParkedIDs[0] != issueID {
+		t.Errorf("DeleteParkedIssue calls = %v, want [%s]", store.deletedParkedIDs, issueID)
+	}
+}
+
+// TestParkSingleLogRecordPerTrigger verifies that one park emits exactly
+// one issue-parked log record and one counter increment, whatever the
+// trigger, that the absence path's record carries the absence attributes
+// and the blocked path's does not, and that the retired
+// ceiling-reached log message never appears.
+func TestParkSingleLogRecordPerTrigger(t *testing.T) {
+	t.Parallel()
+
+	t.Run("blocked path", func(t *testing.T) {
+		t.Parallel()
+
+		store := &mockExitStore{}
+		spy := &spyMetrics{}
+		state := exitStateWithIssue(t, "LOG-BLOCKED", "In Progress")
+		params := defaultExitParams(t, store)
+		params.Metrics = spy
+		var logs bytes.Buffer
+		params.Logger = debugLogger(t, &logs)
+
+		HandleWorkerExit(state, WorkerResult{
+			IssueID:        "LOG-BLOCKED",
+			Identifier:     "LOG-BLOCKED-ident",
+			ExitKind:       WorkerExitNormal,
+			AgentAdapter:   "mock",
+			SoftStop:       true,
+			SoftStopReason: "blocked",
+		}, params)
+		state.TrackerOpsWg.Wait()
+
+		output := logs.String()
+		if got := strings.Count(output, `msg="issue parked"`); got != 1 {
+			t.Errorf("issue-parked log record count = %d, want 1\nlogs: %s", got, output)
+		}
+		if strings.Contains(output, "handoff absence ceiling reached, parking issue") {
+			t.Errorf("retired log message present\nlogs: %s", output)
+		}
+		if strings.Contains(output, "consecutive_absences") || strings.Contains(output, "absence_ceiling") {
+			t.Errorf("blocked-path log carries absence attributes, want neither\nlogs: %s", output)
+		}
+		spy.mu.Lock()
+		parks := len(spy.issueParks)
+		spy.mu.Unlock()
+		if parks != 1 {
+			t.Errorf("IncIssueParks call count = %d, want 1", parks)
+		}
+	})
+
+	t.Run("absence path", func(t *testing.T) {
+		t.Parallel()
+
+		const issueID = "LOG-ABSENCE"
+		issue := candidateIssue(issueID, "PROJ-LOG", "To Do")
+		cfg := config.ServiceConfig{}
+		store := &stubStore{absenceCounts: map[string]int{issueID: 3}}
+		tracker := newRecordingHandoffTracker()
+		spy := &spyMetrics{}
+		state := NewState(1000, 1, nil, AgentTotals{})
+		var logs bytes.Buffer
+		orchestrator := NewOrchestrator(OrchestratorParams{
+			State:           state,
+			Logger:          debugLogger(t, &logs),
+			TrackerAdapter:  tracker,
+			AgentAdapter:    &mockAgentAdapter{},
+			WorkflowManager: &stubWorkflowManager{config: cfg},
+			Store:           store,
+			Metrics:         spy,
+		})
+
+		orchestrator.parkExhaustedAbsences(context.Background(), cfg, []domain.Issue{issue})
+		state.TrackerOpsWg.Wait()
+
+		output := logs.String()
+		if got := strings.Count(output, `msg="issue parked"`); got != 1 {
+			t.Errorf("issue-parked log record count = %d, want 1\nlogs: %s", got, output)
+		}
+		if strings.Contains(output, "handoff absence ceiling reached, parking issue") {
+			t.Errorf("retired log message present\nlogs: %s", output)
+		}
+		if !strings.Contains(output, "consecutive_absences=3") || !strings.Contains(output, "absence_ceiling=3") {
+			t.Errorf("absence-path log missing absence attributes\nlogs: %s", output)
+		}
+		spy.mu.Lock()
+		parks := len(spy.issueParks)
+		spy.mu.Unlock()
+		if parks != 1 {
+			t.Errorf("IncIssueParks call count = %d, want 1", parks)
+		}
+	})
+}
+
+// TestHandleWorkerExitAbsenceParkRecordsObservedStateAndReleasesWithoutBackfill
+// verifies that the worker-exit absence park records the resolved
+// terminal observation as parked_state rather than an empty string, and
+// that the resulting park is released by a later state change with no
+// intervening backfill tick.
+func TestHandleWorkerExitAbsenceParkRecordsObservedStateAndReleasesWithoutBackfill(t *testing.T) {
+	t.Parallel()
+
+	const issueID = "ABS-OBSERVED"
+	dir, baseline := handoffEvidenceGitWorkspace(t)
+	store := &mockExitStore{}
+	seedMockHandoffAbsences(store, issueID, 2)
+	tracker := newRecordingHandoffTracker()
+	state := exitStateWithIssue(t, issueID, "In Progress")
+	params := handoffEvidenceExitParams(t, store, tracker.mockTrackerAdapter, &spyMetrics{})
+	params.TrackerAdapter = tracker
+
+	HandleWorkerExit(state, WorkerResult{
+		IssueID:                 issueID,
+		Identifier:              "PROJ-OBS",
+		ExitKind:                WorkerExitNormal,
+		WorkspacePath:           dir,
+		HandoffEvidencePolicy:   config.HandoffEvidenceObserved,
+		HandoffEvidenceBaseline: baseline,
+		AgentAdapter:            "mock",
+	}, params)
+	state.TrackerOpsWg.Wait()
+
+	entry := state.Parked[issueID]
+	if entry == nil {
+		t.Fatal("the third consecutive absence did not park the issue")
+	}
+	if entry.ParkedState == "" {
+		t.Error("the worker-exit absence park recorded an empty parked_state, want the resolved observation")
+	}
+	if entry.ParkedState != "In Progress" {
+		t.Errorf("Parked[%s].ParkedState = %q, want %q", issueID, entry.ParkedState, "In Progress")
+	}
+
+	tickStore := &stubStore{}
+	orchestrator := NewOrchestrator(OrchestratorParams{
+		State:           state,
+		Logger:          discardLogger(),
+		TrackerAdapter:  tracker,
+		AgentAdapter:    &mockAgentAdapter{},
+		WorkflowManager: &stubWorkflowManager{config: config.ServiceConfig{}},
+		Store:           tickStore,
+	})
+	candidates := []domain.Issue{{ID: issueID, Identifier: "PROJ-OBS", Title: "T", State: "Done"}}
+
+	orchestrator.refreshParkedIssues(context.Background(), candidates)
+
+	if _, ok := state.Parked[issueID]; ok {
+		t.Error("a state change did not release the worker-exit absence park")
+	}
+	if len(tickStore.deletedParkedIDs) != 1 || tickStore.deletedParkedIDs[0] != issueID {
+		t.Errorf("DeleteParkedIssue calls = %v, want [%s]", tickStore.deletedParkedIDs, issueID)
 	}
 }

--- a/internal/orchestrator/metrics_test.go
+++ b/internal/orchestrator/metrics_test.go
@@ -29,6 +29,7 @@ type spyMetrics struct {
 	pollCycles           []string
 	trackerRequests      []trackerReqCall
 	handoffTransitions   []string
+	issueParks           []string
 	dispatchTransitions  []string
 	toolCalls            []toolCallCall
 	pollDurations        []float64
@@ -140,6 +141,12 @@ func (s *spyMetrics) IncHandoffTransitions(result string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.handoffTransitions = append(s.handoffTransitions, result)
+}
+
+func (s *spyMetrics) IncIssueParks(reason string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.issueParks = append(s.issueParks, reason)
 }
 
 func (s *spyMetrics) IncDispatchTransitions(result string) {

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"slices"
 	"sync/atomic"
 	"time"
 
@@ -45,6 +46,10 @@ type OrchestratorStore interface {
 	MarkReactionDispatched(ctx context.Context, issueID, kind string) error
 	DeleteReactionFingerprint(ctx context.Context, issueID, kind string) error
 	LatestRunCompletionByIdentifier(ctx context.Context, identifiers []string) (map[string]string, error)
+	UpsertParkedIssue(ctx context.Context, entry persistence.ParkedIssue) error
+	DeleteParkedIssue(ctx context.Context, issueID string) error
+	MarkParkedIssueLabelApplied(ctx context.Context, issueID string) error
+	ListParkedIssues(ctx context.Context) ([]persistence.ParkedIssue, error)
 }
 
 // Observer receives notifications when orchestrator state changes.
@@ -614,6 +619,8 @@ func (o *Orchestrator) handleTick(ctx context.Context) {
 	sorted := SortForDispatch(issues)
 
 	o.rebuildBudgetExhausted(ctx, cfg, sorted)
+	o.refreshParkedIssues(ctx, sorted)
+	o.parkExhaustedAbsences(ctx, cfg, sorted)
 
 	// Pre-build state sets once for the dispatch loop.
 	activeSet := stateSet(cfg.Tracker.ActiveStates)
@@ -869,19 +876,121 @@ func (o *Orchestrator) maybeWriteIncrementalMetadata(ctx context.Context, issueI
 	entry.LastMetadataWrite = now
 }
 
+// refreshParkedIssues evaluates the release rule against this tick's
+// candidates, then against the state of every parked issue the candidate
+// slice does not carry, read through one batched, comment-free tracker
+// call. Must be called from the event loop goroutine, after the budget
+// rebuild and before the dispatch loop.
+func (o *Orchestrator) refreshParkedIssues(ctx context.Context, candidates []domain.Issue) {
+	if len(o.state.Parked) == 0 {
+		return
+	}
+
+	seen := make(map[string]struct{}, len(candidates))
+	for _, issue := range candidates {
+		entry, ok := o.state.Parked[issue.ID]
+		if !ok {
+			continue
+		}
+		seen[issue.ID] = struct{}{}
+		if !observeParkedState(ctx, o.state, o.store, o.logger, entry, issue.ID, issue.State) {
+			continue
+		}
+		observeParkedLabels(ctx, o.state, o.store, o.logger, entry, issue.ID, issue.Labels)
+	}
+
+	missing := make([]string, 0, len(o.state.Parked))
+	for id := range o.state.Parked {
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		missing = append(missing, id)
+	}
+	if len(missing) == 0 || o.trackerAdapter == nil {
+		return
+	}
+	slices.Sort(missing)
+
+	states, err := o.trackerAdapter.FetchIssueStatesByIDs(ctx, missing)
+	if err != nil {
+		o.logger.Warn("parked issue state read failed, retaining parks",
+			slog.Any("error", err),
+		)
+		return
+	}
+	for _, id := range missing {
+		entry, ok := o.state.Parked[id]
+		if !ok {
+			continue
+		}
+		observed, found := states[id]
+		if !found {
+			continue
+		}
+		observeParkedState(ctx, o.state, o.store, o.logger, entry, id, observed)
+	}
+}
+
+// parkExhaustedAbsences parks each candidate whose consecutive
+// handoff-absence count has just reached the ceiling. Skipped entirely
+// under the off evidence policy, which records no absence. Must be called
+// from the event loop goroutine, after [Orchestrator.refreshParkedIssues]
+// so a release on this tick is not immediately re-parked.
+func (o *Orchestrator) parkExhaustedAbsences(ctx context.Context, cfg config.ServiceConfig, candidates []domain.Issue) {
+	if cfg.Tracker.HandoffEvidence.Effective() == config.HandoffEvidenceOff {
+		return
+	}
+
+	candidateIDs := make([]string, len(candidates))
+	for i, issue := range candidates {
+		candidateIDs[i] = issue.ID
+	}
+
+	ceiling := handoffAbsenceCeiling(cfg.Agent.MaxSessions)
+	counts, err := o.store.QueryConsecutiveHandoffAbsenceCounts(ctx, candidateIDs)
+	if err != nil {
+		o.logger.Warn("handoff absence exhaustion query failed, retaining previous set",
+			slog.Any("error", err),
+		)
+		return
+	}
+
+	for _, issue := range candidates {
+		count := counts[issue.ID]
+		if count < ceiling {
+			continue
+		}
+		if _, parked := o.state.Parked[issue.ID]; parked {
+			continue
+		}
+		issueLog := logging.WithIssue(o.logger, issue.ID, issue.Identifier)
+		parkHandoffAbsence(
+			o.state,
+			ctx,
+			o.store,
+			o.trackerAdapter,
+			o.metrics,
+			issue.ID,
+			issue.Identifier,
+			issue.DisplayID,
+			issue.State,
+			count,
+			ceiling,
+			o.handoffParkingLabel,
+			issueLog,
+		)
+	}
+}
+
 // rebuildBudgetExhausted replaces the BudgetExhausted set and its reason
-// map once per tick from run_history, as the union of the session-count,
-// token-sum, and consecutive handoff-absence gates scoped to the candidate
-// set. Handoff absence is the most specific reason and takes precedence;
-// token budget takes precedence over the ordinary session budget. On a
-// query error for one axis, the prior entries attributed to that axis are
-// folded back in so a transient error never drops an issue mid-tick, while
-// the other axes keep their fresh results. The absence gate is skipped under
-// the off evidence policy, which records no absence and must cost nothing.
-// Must be called from the event loop goroutine.
+// map once per tick from run_history, as the union of the session-count
+// and token-sum gates scoped to the candidate set. Token budget takes
+// precedence over the ordinary session budget. On a query error for one
+// axis, the prior entries attributed to that axis are folded back in so a
+// transient error never drops an issue mid-tick, while the other axis
+// keeps its fresh results. Must be called from the event loop goroutine.
 func (o *Orchestrator) rebuildBudgetExhausted(ctx context.Context, cfg config.ServiceConfig, sorted []domain.Issue) {
-	absenceGateEnabled := cfg.Tracker.HandoffEvidence.Effective() != config.HandoffEvidenceOff
-	if cfg.Agent.MaxSessions == 0 && cfg.Agent.MaxTokens == 0 && !absenceGateEnabled {
+	if cfg.Agent.MaxSessions == 0 && cfg.Agent.MaxTokens == 0 {
 		o.state.BudgetExhausted = make(map[string]struct{})
 		o.state.BudgetExhaustedReason = make(map[string]string)
 		o.state.TokenBudgetIncomplete = make(map[string]struct{})
@@ -899,11 +1008,6 @@ func (o *Orchestrator) rebuildBudgetExhausted(ctx context.Context, cfg config.Se
 	priorReason := o.state.BudgetExhaustedReason
 	fresh := make(map[string]struct{})
 	freshReason := make(map[string]string)
-	type parkedCandidate struct {
-		issueID string
-		count   int
-	}
-	newlyParked := make([]parkedCandidate, 0)
 
 	if cfg.Agent.MaxSessions > 0 {
 		sessionExhausted, qErr := o.store.QueryBudgetExhaustedIssues(ctx, candidateIDs, cfg.Agent.MaxSessions)
@@ -926,39 +1030,6 @@ func (o *Orchestrator) rebuildBudgetExhausted(ctx context.Context, cfg config.Se
 		}
 	}
 
-	// The handoff-absence ceiling is always finite, including when the
-	// ordinary max_sessions budget is disabled. Rebuild it from run_history
-	// on every poll so a parked issue remains ineligible across restart and
-	// even when no retry row survived the final worker exit.
-	absenceCeiling := handoffAbsenceCeiling(cfg.Agent.MaxSessions)
-	if absenceGateEnabled {
-		absenceCounts, absenceErr := o.store.QueryConsecutiveHandoffAbsenceCounts(ctx, candidateIDs)
-		if absenceErr != nil {
-			o.logger.Warn("handoff absence exhaustion query failed, retaining previous set",
-				slog.Any("error", absenceErr),
-			)
-			for id := range prior {
-				if priorReason[id] != budgetReasonHandoffAbsence {
-					continue
-				}
-				fresh[id] = struct{}{}
-				freshReason[id] = budgetReasonHandoffAbsence
-			}
-		} else {
-			for _, id := range candidateIDs {
-				count := absenceCounts[id]
-				if count < absenceCeiling {
-					continue
-				}
-				fresh[id] = struct{}{}
-				freshReason[id] = budgetReasonHandoffAbsence
-				if priorReason[id] != budgetReasonHandoffAbsence {
-					newlyParked = append(newlyParked, parkedCandidate{issueID: id, count: count})
-				}
-			}
-		}
-	}
-
 	freshIncomplete := make(map[string]struct{})
 	if cfg.Agent.MaxTokens > 0 {
 		usageByIssue, qErr := o.store.QueryTokenBudgetUsage(ctx, candidateIDs)
@@ -970,19 +1041,15 @@ func (o *Orchestrator) rebuildBudgetExhausted(ctx context.Context, cfg config.Se
 				if priorReason[id] != budgetReasonToken {
 					continue
 				}
-				if freshReason[id] != budgetReasonHandoffAbsence {
-					fresh[id] = struct{}{}
-					freshReason[id] = budgetReasonToken
-				}
+				fresh[id] = struct{}{}
+				freshReason[id] = budgetReasonToken
 			}
 		} else {
 			for _, id := range candidateIDs {
 				usage := usageByIssue[id]
 				if usage.TotalTokens >= int64(cfg.Agent.MaxTokens) {
-					if freshReason[id] != budgetReasonHandoffAbsence {
-						fresh[id] = struct{}{}
-						freshReason[id] = budgetReasonToken
-					}
+					fresh[id] = struct{}{}
+					freshReason[id] = budgetReasonToken
 					continue
 				}
 				if usage.UnmeasuredSessions == 0 {
@@ -1005,21 +1072,6 @@ func (o *Orchestrator) rebuildBudgetExhausted(ctx context.Context, cfg config.Se
 
 	o.state.BudgetExhausted = fresh
 	o.state.BudgetExhaustedReason = freshReason
-
-	for _, parked := range newlyParked {
-		issueLog := logging.WithIssue(o.logger, parked.issueID, identifierByID[parked.issueID])
-		parkHandoffAbsence(
-			o.state,
-			ctx,
-			o.store,
-			o.trackerAdapter,
-			parked.issueID,
-			parked.count,
-			absenceCeiling,
-			o.handoffParkingLabel,
-			issueLog,
-		)
-	}
 }
 
 // drainRunningWorkers cancels all running worker contexts and waits for

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -125,6 +125,12 @@ type stubStore struct {
 	tokenIncompleteIDs []string
 
 	upsertSessionMetadataErr error
+
+	parkedIssues       []persistence.ParkedIssue
+	deletedParkedIDs   []string
+	labelAppliedIDs    []string
+	listParkedIssues   []persistence.ParkedIssue
+	listParkedIssueErr error
 }
 
 func (s *stubStore) AppendRunHistory(_ context.Context, run persistence.RunHistory) (persistence.RunHistory, error) {
@@ -260,6 +266,38 @@ func (s *stubStore) DeleteReactionFingerprint(_ context.Context, _, _ string) er
 
 func (s *stubStore) LatestRunCompletionByIdentifier(_ context.Context, _ []string) (map[string]string, error) {
 	return map[string]string{}, nil
+}
+
+func (s *stubStore) UpsertParkedIssue(_ context.Context, entry persistence.ParkedIssue) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.parkedIssues = append(s.parkedIssues, entry)
+	return nil
+}
+
+func (s *stubStore) DeleteParkedIssue(_ context.Context, issueID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.deletedParkedIDs = append(s.deletedParkedIDs, issueID)
+	return nil
+}
+
+func (s *stubStore) MarkParkedIssueLabelApplied(_ context.Context, issueID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.labelAppliedIDs = append(s.labelAppliedIDs, issueID)
+	return nil
+}
+
+func (s *stubStore) ListParkedIssues(_ context.Context) ([]persistence.ParkedIssue, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.listParkedIssueErr != nil {
+		return nil, s.listParkedIssueErr
+	}
+	out := make([]persistence.ParkedIssue, len(s.listParkedIssues))
+	copy(out, s.listParkedIssues)
+	return out, nil
 }
 
 // stubObserver implements [Observer] with an atomic call counter.

--- a/internal/orchestrator/park.go
+++ b/internal/orchestrator/park.go
@@ -1,0 +1,247 @@
+package orchestrator
+
+import (
+	"context"
+	"log/slog"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/sortie-ai/sortie/internal/domain"
+	"github.com/sortie-ai/sortie/internal/persistence"
+)
+
+// Park reason and unpark trigger values, shared by both parking triggers
+// and by every release path.
+const (
+	parkReasonAgentBlocked   = "agent_blocked"
+	parkReasonHandoffAbsence = "handoff_absence"
+
+	unparkTriggerStateChanged     = "state_changed"
+	unparkTriggerLabelRemoved     = "label_removed"
+	unparkTriggerEvidenceObserved = "evidence_observed"
+)
+
+// ParkStore is the persistence contract [parkIssue] and [unparkIssue] need.
+type ParkStore interface {
+	UpsertParkedIssue(ctx context.Context, entry persistence.ParkedIssue) error
+	DeleteParkedIssue(ctx context.Context, issueID string) error
+	DeleteRetryEntry(ctx context.Context, issueID string) error
+	ResetHandoffAbsenceSequence(ctx context.Context, issueID string) error
+}
+
+// parkObserverStore widens [ParkStore] with the one method the release pass
+// needs to confirm a parking label. It stays off ParkStore itself, because
+// only the release pass, running on the orchestrator's own store, ever
+// reaches it.
+type parkObserverStore interface {
+	ParkStore
+	MarkParkedIssueLabelApplied(ctx context.Context, issueID string) error
+}
+
+// parkIssueParams carries the inputs of one park.
+type parkIssueParams struct {
+	IssueID       string
+	Identifier    string
+	DisplayID     string
+	ObservedState string // tracker state to record as parked_state
+	Reason        string
+	Label         string // resolved parking label; empty disables the label write
+	Absences      int    // log attribute only; omitted from the record when zero
+	Ceiling       int    // log attribute only; omitted from the record when zero
+
+	Store          ParkStore
+	TrackerAdapter domain.TrackerAdapter // nil skips the label write
+	Metrics        domain.Metrics
+	Logger         *slog.Logger
+	Ctx            context.Context
+}
+
+// parkIssue records the park, releases the claim, cancels and deletes any
+// pending retry, and starts the detached parking-label write.
+func parkIssue(state *State, params parkIssueParams) {
+	ctx := params.Ctx
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	log := params.Logger
+	if log == nil {
+		log = slog.Default()
+	}
+
+	CancelRetry(state, params.IssueID)
+	delete(state.Claimed, params.IssueID)
+
+	parkedAt := time.Now().UTC()
+	entry := &ParkedEntry{
+		Identifier:   params.Identifier,
+		DisplayID:    params.DisplayID,
+		Reason:       params.Reason,
+		ParkedState:  params.ObservedState,
+		Label:        params.Label,
+		LabelApplied: false,
+		ParkedAt:     parkedAt,
+	}
+	state.Parked[params.IssueID] = entry
+
+	if err := params.Store.UpsertParkedIssue(ctx, parkedIssueRow(params.IssueID, entry)); err != nil {
+		log.Error("failed to persist park record", slog.Any("error", err))
+	}
+	if err := params.Store.DeleteRetryEntry(ctx, params.IssueID); err != nil {
+		log.Error("failed to delete retry entry after park", slog.Any("error", err))
+	}
+
+	params.Metrics.IncIssueParks(params.Reason)
+
+	attrs := []slog.Attr{
+		slog.String("reason", params.Reason),
+		slog.String("parked_state", params.ObservedState),
+		slog.String("label", params.Label),
+	}
+	if params.Absences != 0 {
+		attrs = append(attrs, slog.Int("consecutive_absences", params.Absences))
+	}
+	if params.Ceiling != 0 {
+		attrs = append(attrs, slog.Int("absence_ceiling", params.Ceiling))
+	}
+	log.LogAttrs(ctx, slog.LevelWarn, "issue parked", attrs...)
+
+	if params.TrackerAdapter == nil || params.Label == "" {
+		return
+	}
+
+	issueID := params.IssueID
+	label := params.Label
+	tracker := params.TrackerAdapter
+	state.TrackerOpsWg.Go(func() {
+		dctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
+		defer cancel()
+
+		if err := tracker.AddLabel(dctx, issueID, label); err != nil {
+			log.Warn("park label write failed", slog.Any("error", err))
+		}
+	})
+}
+
+// unparkIssue lifts the park and deletes the persisted row. It is a no-op
+// when issueID is absent from state.Parked.
+func unparkIssue(ctx context.Context, state *State, issueID, trigger string, store ParkStore, log *slog.Logger) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if log == nil {
+		log = slog.Default()
+	}
+
+	entry, ok := state.Parked[issueID]
+	if !ok {
+		return
+	}
+	delete(state.Parked, issueID)
+
+	if err := store.DeleteParkedIssue(ctx, issueID); err != nil {
+		log.Error("failed to delete park record", slog.Any("error", err))
+	}
+	if entry.Reason == parkReasonHandoffAbsence {
+		if err := store.ResetHandoffAbsenceSequence(ctx, issueID); err != nil {
+			log.Error("failed to reset handoff absence sequence after unpark", slog.Any("error", err))
+		}
+	}
+
+	log.Info("issue unparked",
+		slog.String("trigger", trigger),
+		slog.String("reason", entry.Reason),
+	)
+}
+
+// PopulateParked loads persisted park records into state.Parked. Called
+// during startup recovery, before the event loop starts, beside
+// [PopulateRetries].
+func PopulateParked(state *State, rows []persistence.ParkedIssue, log *slog.Logger) {
+	if log == nil {
+		log = slog.Default()
+	}
+
+	for _, row := range rows {
+		if row.IssueID == "" {
+			log.Warn("skipping malformed park record")
+			continue
+		}
+
+		parkedAt, err := time.Parse(time.RFC3339, row.ParkedAt)
+		if err != nil {
+			parkedAt = time.Time{}
+		}
+
+		state.Parked[row.IssueID] = &ParkedEntry{
+			Identifier:   row.Identifier,
+			DisplayID:    row.DisplayID,
+			Reason:       row.Reason,
+			ParkedState:  row.ParkedState,
+			Label:        row.Label,
+			LabelApplied: row.LabelApplied,
+			ParkedAt:     parkedAt,
+		}
+	}
+}
+
+// observeParkedState evaluates the state-change release rule for one
+// parked issue against an observed tracker state and reports whether the
+// issue is still parked afterward. An empty observed state is ignored. An
+// empty entry.ParkedState is backfilled from observed without releasing.
+// A non-empty entry.ParkedState that differs from observed, compared
+// case-insensitively, unparks the issue with trigger "state_changed".
+func observeParkedState(ctx context.Context, state *State, store parkObserverStore, log *slog.Logger, entry *ParkedEntry, issueID, observed string) (stillParked bool) {
+	if observed == "" {
+		return true
+	}
+	if entry.ParkedState == "" {
+		entry.ParkedState = observed
+		if err := store.UpsertParkedIssue(ctx, parkedIssueRow(issueID, entry)); err != nil {
+			log.Error("failed to persist park state backfill", slog.Any("error", err))
+		}
+		return true
+	}
+	if !strings.EqualFold(observed, entry.ParkedState) {
+		unparkIssue(ctx, state, issueID, unparkTriggerStateChanged, store, log)
+		return false
+	}
+	return true
+}
+
+// observeParkedLabels evaluates the label-confirmation and label-removal
+// release rules for one parked issue against an observed label set. A
+// parking label observed while unconfirmed sets and persists
+// LabelApplied. A parking label observed absent while confirmed unparks
+// the issue with trigger "label_removed". A parking label observed absent
+// while unconfirmed leaves the park unchanged.
+func observeParkedLabels(ctx context.Context, state *State, store parkObserverStore, log *slog.Logger, entry *ParkedEntry, issueID string, labels []string) {
+	hasLabel := slices.ContainsFunc(labels, func(label string) bool {
+		return strings.EqualFold(label, entry.Label)
+	})
+
+	if hasLabel && !entry.LabelApplied {
+		entry.LabelApplied = true
+		if err := store.MarkParkedIssueLabelApplied(ctx, issueID); err != nil {
+			log.Error("failed to persist park label confirmation", slog.Any("error", err))
+		}
+		return
+	}
+	if !hasLabel && entry.LabelApplied {
+		unparkIssue(ctx, state, issueID, unparkTriggerLabelRemoved, store, log)
+	}
+}
+
+// parkedIssueRow builds the persisted row for the given runtime park entry.
+func parkedIssueRow(issueID string, entry *ParkedEntry) persistence.ParkedIssue {
+	return persistence.ParkedIssue{
+		IssueID:      issueID,
+		Identifier:   entry.Identifier,
+		DisplayID:    entry.DisplayID,
+		Reason:       entry.Reason,
+		ParkedState:  entry.ParkedState,
+		Label:        entry.Label,
+		LabelApplied: entry.LabelApplied,
+		ParkedAt:     entry.ParkedAt.Format(time.RFC3339),
+	}
+}

--- a/internal/orchestrator/park_test.go
+++ b/internal/orchestrator/park_test.go
@@ -1,0 +1,443 @@
+package orchestrator
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sortie-ai/sortie/internal/config"
+	"github.com/sortie-ai/sortie/internal/domain"
+	"github.com/sortie-ai/sortie/internal/persistence"
+)
+
+// The release rule: a state change unparks, a confirmed label removed
+// unparks, an unconfirmed label absent stays parked, and a label observed
+// while unconfirmed sets and persists the confirmation flag.
+
+func TestObserveParkedStateReleaseRule(t *testing.T) {
+	t.Parallel()
+
+	t.Run("state change unparks with trigger state_changed", func(t *testing.T) {
+		t.Parallel()
+
+		store := &stubStore{}
+		state := NewState(1000, 1, nil, AgentTotals{})
+		entry := &ParkedEntry{Identifier: "PROJ-1", Reason: parkReasonAgentBlocked, ParkedState: "In Progress"}
+		state.Parked["ISS-1"] = entry
+
+		stillParked := observeParkedState(context.Background(), state, store, discardLogger(), entry, "ISS-1", "Done")
+
+		if stillParked {
+			t.Error("observeParkedState(...) = true, want false after a state change")
+		}
+		if _, ok := state.Parked["ISS-1"]; ok {
+			t.Error("issue remains in state.Parked after an observed state change")
+		}
+		if len(store.deletedParkedIDs) != 1 || store.deletedParkedIDs[0] != "ISS-1" {
+			t.Errorf("DeleteParkedIssue calls = %v, want [ISS-1]", store.deletedParkedIDs)
+		}
+	})
+
+	t.Run("empty parked_state is backfilled, not released", func(t *testing.T) {
+		t.Parallel()
+
+		store := &stubStore{}
+		state := NewState(1000, 1, nil, AgentTotals{})
+		entry := &ParkedEntry{Identifier: "PROJ-2", Reason: parkReasonAgentBlocked}
+		state.Parked["ISS-2"] = entry
+
+		stillParked := observeParkedState(context.Background(), state, store, discardLogger(), entry, "ISS-2", "In Progress")
+
+		if !stillParked {
+			t.Error("observeParkedState(...) = false, want true: an empty parked_state backfills rather than releases")
+		}
+		if entry.ParkedState != "In Progress" {
+			t.Errorf("ParkedState after backfill = %q, want %q", entry.ParkedState, "In Progress")
+		}
+		if _, ok := state.Parked["ISS-2"]; !ok {
+			t.Error("issue was released by the backfill observation")
+		}
+		if len(store.deletedParkedIDs) != 0 {
+			t.Errorf("DeleteParkedIssue calls = %v, want none", store.deletedParkedIDs)
+		}
+	})
+}
+
+func TestObserveParkedLabelsReleaseRule(t *testing.T) {
+	t.Parallel()
+
+	t.Run("label observed while unconfirmed sets and persists LabelApplied", func(t *testing.T) {
+		t.Parallel()
+
+		store := &stubStore{}
+		state := NewState(1000, 1, nil, AgentTotals{})
+		entry := &ParkedEntry{Identifier: "PROJ-3", Reason: parkReasonAgentBlocked, Label: "needs-human"}
+		state.Parked["ISS-3"] = entry
+
+		observeParkedLabels(context.Background(), state, store, discardLogger(), entry, "ISS-3", []string{"Needs-Human"})
+
+		if !entry.LabelApplied {
+			t.Error("LabelApplied = false, want true after observing the parking label")
+		}
+		if len(store.labelAppliedIDs) != 1 || store.labelAppliedIDs[0] != "ISS-3" {
+			t.Errorf("MarkParkedIssueLabelApplied calls = %v, want [ISS-3]", store.labelAppliedIDs)
+		}
+		if _, ok := state.Parked["ISS-3"]; !ok {
+			t.Error("label confirmation released the park, want it to stay")
+		}
+	})
+
+	t.Run("confirmed label observed absent unparks with trigger label_removed", func(t *testing.T) {
+		t.Parallel()
+
+		store := &stubStore{}
+		state := NewState(1000, 1, nil, AgentTotals{})
+		entry := &ParkedEntry{Identifier: "PROJ-4", Reason: parkReasonAgentBlocked, Label: "needs-human", LabelApplied: true}
+		state.Parked["ISS-4"] = entry
+
+		observeParkedLabels(context.Background(), state, store, discardLogger(), entry, "ISS-4", nil)
+
+		if _, ok := state.Parked["ISS-4"]; ok {
+			t.Error("issue remains in state.Parked after a confirmed label was observed removed")
+		}
+		if len(store.deletedParkedIDs) != 1 || store.deletedParkedIDs[0] != "ISS-4" {
+			t.Errorf("DeleteParkedIssue calls = %v, want [ISS-4]", store.deletedParkedIDs)
+		}
+	})
+
+	t.Run("unconfirmed label observed absent does not unpark", func(t *testing.T) {
+		t.Parallel()
+
+		store := &stubStore{}
+		state := NewState(1000, 1, nil, AgentTotals{})
+		entry := &ParkedEntry{Identifier: "PROJ-5", Reason: parkReasonAgentBlocked, Label: "needs-human"}
+		state.Parked["ISS-5"] = entry
+
+		observeParkedLabels(context.Background(), state, store, discardLogger(), entry, "ISS-5", nil)
+
+		if _, ok := state.Parked["ISS-5"]; !ok {
+			t.Error("unconfirmed label absence released the park, want it held")
+		}
+		if len(store.deletedParkedIDs) != 0 {
+			t.Errorf("DeleteParkedIssue calls = %v, want none", store.deletedParkedIDs)
+		}
+	})
+}
+
+// A failed label write must not cost the park: it stays in place with the
+// label unconfirmed, and a later release pass that still observes the
+// label absent leaves it exactly where a failed write left it.
+
+func TestParkIssueFailedLabelWriteLeavesLabelUnconfirmed(t *testing.T) {
+	t.Parallel()
+
+	const issueID = "PARK-LABEL-FAIL"
+	store := &stubStore{}
+	tracker := newRecordingHandoffTracker()
+	tracker.addLabelErr = errors.New("label service unavailable")
+	state := NewState(1000, 1, nil, AgentTotals{})
+	var logs bytes.Buffer
+
+	parkIssue(state, parkIssueParams{
+		IssueID:        issueID,
+		Identifier:     "PROJ-LABEL-FAIL",
+		ObservedState:  "In Progress",
+		Reason:         parkReasonAgentBlocked,
+		Label:          "needs-human",
+		Store:          store,
+		TrackerAdapter: tracker,
+		Metrics:        &domain.NoopMetrics{},
+		Logger:         debugLogger(t, &logs),
+		Ctx:            context.Background(),
+	})
+	state.TrackerOpsWg.Wait()
+
+	entry := state.Parked[issueID]
+	if entry == nil {
+		t.Fatal("issue not parked")
+	}
+	if entry.LabelApplied {
+		t.Error("LabelApplied = true after a failed label write, want false")
+	}
+	if !strings.Contains(logs.String(), "park label write failed") {
+		t.Errorf("missing label failure log\nlogs: %s", logs.String())
+	}
+
+	observeParkedLabels(context.Background(), state, store, discardLogger(), entry, issueID, nil)
+
+	if _, ok := state.Parked[issueID]; !ok {
+		t.Error("release pass unparked an issue whose label write failed, want it held")
+	}
+	if entry.LabelApplied {
+		t.Error("LabelApplied became true after the release pass, want it to stay false")
+	}
+}
+
+// A successful AddLabel write is not, by itself, confirmation: only a
+// later observation of the label on a tracker read sets LabelApplied. A
+// tracker whose AddLabel reports success without the label ever becoming
+// visible on a read must not release the park it never confirmed.
+
+func TestParkIssueSuccessfulLabelWriteDoesNotConfirmWithoutObservation(t *testing.T) {
+	t.Parallel()
+
+	const issueID = "PARK-LABEL-UNCONFIRMED"
+	store := &stubStore{}
+	tracker := newRecordingHandoffTracker() // AddLabel returns nil by default.
+
+	state := NewState(1000, 1, nil, AgentTotals{})
+
+	parkIssue(state, parkIssueParams{
+		IssueID:        issueID,
+		Identifier:     "PROJ-UNCONFIRMED",
+		ObservedState:  "In Progress",
+		Reason:         parkReasonAgentBlocked,
+		Label:          "needs-human",
+		Store:          store,
+		TrackerAdapter: tracker,
+		Metrics:        &domain.NoopMetrics{},
+		Logger:         discardLogger(),
+		Ctx:            context.Background(),
+	})
+	state.TrackerOpsWg.Wait()
+
+	if calls := tracker.labels(); len(calls) != 1 {
+		t.Fatalf("AddLabel calls = %+v, want exactly one successful write", calls)
+	}
+
+	entry := state.Parked[issueID]
+	if entry == nil {
+		t.Fatal("issue not parked")
+	}
+	if entry.LabelApplied {
+		t.Error("LabelApplied = true immediately after a successful write, want false: confirmation comes from observation, not the write result")
+	}
+	if len(store.labelAppliedIDs) != 0 {
+		t.Errorf("MarkParkedIssueLabelApplied calls = %v, want none before any observation", store.labelAppliedIDs)
+	}
+
+	observeParkedLabels(context.Background(), state, store, discardLogger(), entry, issueID, nil)
+
+	if entry.LabelApplied {
+		t.Error("LabelApplied became true after a read carrying no label")
+	}
+	if _, ok := state.Parked[issueID]; !ok {
+		t.Error("issue was unparked despite label_applied never having been confirmed")
+	}
+	if len(store.labelAppliedIDs) != 0 {
+		t.Errorf("MarkParkedIssueLabelApplied calls = %v, want none", store.labelAppliedIDs)
+	}
+}
+
+// A park recorded through a store opened on a temporary file survives a
+// simulated restart: the in-memory State is discarded and rebuilt purely
+// from the durable rows, and the rebuilt state still refuses dispatch.
+
+func TestParkSurvivesRestart(t *testing.T) {
+	t.Parallel()
+
+	const issueID = "PARK-RESTART"
+	ctx := context.Background()
+	dbPath := t.TempDir() + "/test.db"
+	store, err := persistence.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("persistence.Open: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := store.Close(); err != nil {
+			t.Errorf("store.Close: %v", err)
+		}
+	})
+	if err := store.Migrate(ctx); err != nil {
+		t.Fatalf("store.Migrate: %v", err)
+	}
+
+	state := exitStateWithIssue(t, issueID, "In Progress")
+	params := HandleWorkerExitParams{
+		Store:               store,
+		MaxRetryBackoffMS:   300_000,
+		OnRetryFire:         noopRetryFire,
+		NowFunc:             func() time.Time { return baseTime.Add(60 * time.Second) },
+		Logger:              discardLogger(),
+		HandoffParkingLabel: "needs-human",
+	}
+
+	HandleWorkerExit(state, WorkerResult{
+		IssueID:        issueID,
+		Identifier:     "PROJ-RESTART",
+		ExitKind:       WorkerExitNormal,
+		AgentAdapter:   "mock",
+		SoftStop:       true,
+		SoftStopReason: "blocked",
+	}, params)
+	state.TrackerOpsWg.Wait()
+
+	if _, ok := state.Parked[issueID]; !ok {
+		t.Fatal("issue not parked before the simulated restart")
+	}
+
+	rows, err := store.ListParkedIssues(ctx)
+	if err != nil {
+		t.Fatalf("ListParkedIssues: %v", err)
+	}
+
+	fresh := NewState(1000, 4, nil, AgentTotals{})
+	PopulateParked(fresh, rows, discardLogger())
+
+	if _, ok := fresh.Parked[issueID]; !ok {
+		t.Fatal("PopulateParked did not restore the park after the restart")
+	}
+
+	candidate := domain.Issue{ID: issueID, Identifier: "PROJ-RESTART", Title: "T", State: "In Progress"}
+	activeSet := stateSet([]string{"In Progress"})
+	terminalSet := stateSet([]string{"Done"})
+
+	if ShouldDispatchWithSets(candidate, fresh, activeSet, terminalSet) {
+		t.Error("ShouldDispatchWithSets dispatched an issue whose park was restored across a restart")
+	}
+}
+
+// The release pass reads the state of every parked issue the tick's
+// candidate slice does not carry, through one batched tracker call, and
+// applies the state rule to whatever it returns.
+
+func TestRefreshParkedIssuesNonCandidateStateRead(t *testing.T) {
+	t.Parallel()
+
+	t.Run("state differs from parked_state unparks with trigger state_changed", func(t *testing.T) {
+		t.Parallel()
+
+		const parkedID, candidateID = "MISS-1", "CAND-1"
+		state := NewState(1000, 1, nil, AgentTotals{})
+		state.Parked[parkedID] = &ParkedEntry{Identifier: "PROJ-MISS-1", Reason: parkReasonAgentBlocked, ParkedState: "In Progress"}
+
+		var fetchedIDs []string
+		tracker := &mockTrackerAdapter{
+			fetchStatesFn: func(_ context.Context, ids []string) (map[string]string, error) {
+				fetchedIDs = append([]string(nil), ids...)
+				return map[string]string{parkedID: "Done"}, nil
+			},
+		}
+		store := &stubStore{}
+		orchestrator := NewOrchestrator(OrchestratorParams{
+			State:           state,
+			Logger:          discardLogger(),
+			TrackerAdapter:  tracker,
+			AgentAdapter:    &mockAgentAdapter{},
+			WorkflowManager: &stubWorkflowManager{config: config.ServiceConfig{}},
+			Store:           store,
+		})
+		candidates := []domain.Issue{{ID: candidateID, Identifier: "PROJ-CAND-1", Title: "T", State: "To Do"}}
+
+		orchestrator.refreshParkedIssues(context.Background(), candidates)
+
+		// The regression this guards against: a read that fetches every
+		// parked issue on every tick instead of only the ones the
+		// candidate slice did not carry.
+		if !slices.Equal(fetchedIDs, []string{parkedID}) {
+			t.Errorf("FetchIssueStatesByIDs called with %v, want [%s] only", fetchedIDs, parkedID)
+		}
+		if _, ok := state.Parked[parkedID]; ok {
+			t.Error("issue remains parked after the non-candidate read reported a different state")
+		}
+	})
+
+	t.Run("same state leaves the park", func(t *testing.T) {
+		t.Parallel()
+
+		const parkedID = "MISS-2"
+		state := NewState(1000, 1, nil, AgentTotals{})
+		state.Parked[parkedID] = &ParkedEntry{Identifier: "PROJ-MISS-2", Reason: parkReasonAgentBlocked, ParkedState: "In Progress"}
+		tracker := &mockTrackerAdapter{
+			fetchStatesFn: func(_ context.Context, _ []string) (map[string]string, error) {
+				return map[string]string{parkedID: "In Progress"}, nil
+			},
+		}
+		store := &stubStore{}
+		orchestrator := NewOrchestrator(OrchestratorParams{
+			State:           state,
+			Logger:          discardLogger(),
+			TrackerAdapter:  tracker,
+			AgentAdapter:    &mockAgentAdapter{},
+			WorkflowManager: &stubWorkflowManager{config: config.ServiceConfig{}},
+			Store:           store,
+		})
+
+		orchestrator.refreshParkedIssues(context.Background(), nil)
+
+		if _, ok := state.Parked[parkedID]; !ok {
+			t.Error("issue was unparked despite an unchanged observed state")
+		}
+		if len(store.deletedParkedIDs) != 0 {
+			t.Errorf("DeleteParkedIssue calls = %v, want none", store.deletedParkedIDs)
+		}
+	})
+
+	t.Run("issue omitted from the returned map leaves the park", func(t *testing.T) {
+		t.Parallel()
+
+		const parkedID = "MISS-3"
+		state := NewState(1000, 1, nil, AgentTotals{})
+		state.Parked[parkedID] = &ParkedEntry{Identifier: "PROJ-MISS-3", Reason: parkReasonAgentBlocked, ParkedState: "In Progress"}
+		tracker := &mockTrackerAdapter{
+			fetchStatesFn: func(_ context.Context, _ []string) (map[string]string, error) {
+				return map[string]string{}, nil
+			},
+		}
+		store := &stubStore{}
+		orchestrator := NewOrchestrator(OrchestratorParams{
+			State:           state,
+			Logger:          discardLogger(),
+			TrackerAdapter:  tracker,
+			AgentAdapter:    &mockAgentAdapter{},
+			WorkflowManager: &stubWorkflowManager{config: config.ServiceConfig{}},
+			Store:           store,
+		})
+
+		orchestrator.refreshParkedIssues(context.Background(), nil)
+
+		if _, ok := state.Parked[parkedID]; !ok {
+			t.Error("issue was unparked despite being omitted from the state-read response")
+		}
+	})
+
+	t.Run("read error leaves every park in place and logs at warn", func(t *testing.T) {
+		t.Parallel()
+
+		const parkedID1, parkedID2 = "ERR-1", "ERR-2"
+		state := NewState(1000, 1, nil, AgentTotals{})
+		state.Parked[parkedID1] = &ParkedEntry{Identifier: "PROJ-ERR-1", Reason: parkReasonAgentBlocked, ParkedState: "In Progress"}
+		state.Parked[parkedID2] = &ParkedEntry{Identifier: "PROJ-ERR-2", Reason: parkReasonHandoffAbsence, ParkedState: "In Progress"}
+		tracker := &mockTrackerAdapter{
+			fetchStatesFn: func(context.Context, []string) (map[string]string, error) {
+				return nil, errors.New("tracker unavailable")
+			},
+		}
+		store := &stubStore{}
+		var logs bytes.Buffer
+		orchestrator := NewOrchestrator(OrchestratorParams{
+			State:           state,
+			Logger:          debugLogger(t, &logs),
+			TrackerAdapter:  tracker,
+			AgentAdapter:    &mockAgentAdapter{},
+			WorkflowManager: &stubWorkflowManager{config: config.ServiceConfig{}},
+			Store:           store,
+		})
+
+		orchestrator.refreshParkedIssues(context.Background(), nil)
+
+		if _, ok := state.Parked[parkedID1]; !ok {
+			t.Error("park released after a failed non-candidate state read")
+		}
+		if _, ok := state.Parked[parkedID2]; !ok {
+			t.Error("park released after a failed non-candidate state read")
+		}
+		if !strings.Contains(logs.String(), "parked issue state read failed, retaining parks") {
+			t.Errorf("missing read-failure warning\nlogs: %s", logs.String())
+		}
+	})
+}

--- a/internal/orchestrator/retry.go
+++ b/internal/orchestrator/retry.go
@@ -32,6 +32,9 @@ type RetryTimerStore interface {
 	QueryConsecutiveHandoffAbsenceCounts(ctx context.Context, issueIDs []string) (map[string]int, error)
 	TokenUsageByIssue(ctx context.Context, issueID string) (persistence.IssueTokenUsage, error)
 	MarkReactionDispatched(ctx context.Context, issueID, kind string) error
+	UpsertParkedIssue(ctx context.Context, entry persistence.ParkedIssue) error
+	DeleteParkedIssue(ctx context.Context, issueID string) error
+	ResetHandoffAbsenceSequence(ctx context.Context, issueID string) error
 }
 
 // HandleRetryTimerParams holds the dependencies for [HandleRetryTimer]
@@ -227,42 +230,55 @@ func HandleRetryTimer(state *State, issueID string, params HandleRetryTimerParam
 		return
 	}
 
-	// Consecutive handoff-absence gate. This check runs for every primary
-	// retry fire, including entries reconstructed after restart, before any
-	// tracker fetch or worker dispatch. The persisted run-history sequence
-	// therefore remains a dispatch gate even if the process exited between
-	// recording the final absence and deleting its retry row.
-	//
-	// A reaction continuation is exempt. Only a primary dispatch can record an
-	// absence, so parking one here would cancel a retry sequence the ceiling
-	// does not govern, on the strength of absences from unrelated runs. The off
-	// policy records no absence at all and is not inspected here either.
-	absenceGateApplies := params.HandoffEvidencePolicy.Effective() != config.HandoffEvidenceOff &&
-		!isKnownReactionKind(popped.ReactionKind)
-	if absenceGateApplies {
-		absenceCeiling := handoffAbsenceCeiling(params.MaxSessions)
-		absenceCounts, absenceErr := params.Store.QueryConsecutiveHandoffAbsenceCounts(ctx, []string{issueID})
-		consecutiveAbsences := absenceCounts[issueID]
-		if absenceErr != nil {
-			consecutiveAbsences = max(popped.Attempt, 1)
-			log.Warn("handoff absence count query failed, using retry attempt fallback",
-				slog.Int("consecutive_absences", consecutiveAbsences),
-				slog.Any("error", absenceErr),
+	// The retry lane carries two decisions ahead of any tracker fetch or
+	// worker dispatch, both exempt for a known reaction continuation: an
+	// already-parked issue is refused regardless of evidence policy (the
+	// park gate is policy-independent), and an issue whose absence count
+	// has just reached the ceiling is parked, skipped under the off policy
+	// because that policy records no absence at all.
+	if !isKnownReactionKind(popped.ReactionKind) {
+		if parked := state.Parked[issueID]; parked != nil {
+			log.Info("issue parked, releasing claim",
+				slog.String("reason", parked.Reason),
 			)
-		}
-		if consecutiveAbsences >= absenceCeiling {
-			parkHandoffAbsence(
-				state,
-				ctx,
-				params.Store,
-				params.TrackerAdapter,
-				issueID,
-				consecutiveAbsences,
-				absenceCeiling,
-				params.HandoffParkingLabel,
-				log,
-			)
+			delete(state.Claimed, issueID)
+			if err := params.Store.DeleteRetryEntry(ctx, issueID); err != nil {
+				log.Error("failed to delete retry entry for parked issue",
+					slog.Any("error", err),
+				)
+			}
 			return
+		}
+
+		if params.HandoffEvidencePolicy.Effective() != config.HandoffEvidenceOff {
+			absenceCeiling := handoffAbsenceCeiling(params.MaxSessions)
+			absenceCounts, absenceErr := params.Store.QueryConsecutiveHandoffAbsenceCounts(ctx, []string{issueID})
+			consecutiveAbsences := absenceCounts[issueID]
+			if absenceErr != nil {
+				consecutiveAbsences = max(popped.Attempt, 1)
+				log.Warn("handoff absence count query failed, using retry attempt fallback",
+					slog.Int("consecutive_absences", consecutiveAbsences),
+					slog.Any("error", absenceErr),
+				)
+			}
+			if consecutiveAbsences >= absenceCeiling {
+				parkHandoffAbsence(
+					state,
+					ctx,
+					params.Store,
+					params.TrackerAdapter,
+					metrics,
+					issueID,
+					popped.Identifier,
+					popped.DisplayID,
+					"",
+					consecutiveAbsences,
+					absenceCeiling,
+					params.HandoffParkingLabel,
+					log,
+				)
+				return
+			}
 		}
 	}
 

--- a/internal/orchestrator/retry_test.go
+++ b/internal/orchestrator/retry_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/sortie-ai/sortie/internal/config"
 	"github.com/sortie-ai/sortie/internal/domain"
 	"github.com/sortie-ai/sortie/internal/persistence"
 )
@@ -40,6 +41,13 @@ type mockRetryStore struct {
 	markDispatchedIssueID string
 	markDispatchedKind    string
 	markDispatchedErr     error
+
+	parkedIssues     []persistence.ParkedIssue
+	deletedParkedIDs []string
+	absenceResetOf   []string
+	upsertParkedErr  error
+	deleteParkedErr  error
+	absenceResetErr  error
 }
 
 var _ RetryTimerStore = (*mockRetryStore)(nil)
@@ -101,6 +109,21 @@ func (m *mockRetryStore) MarkReactionDispatched(_ context.Context, issueID, kind
 
 func (m *mockRetryStore) DeleteReactionFingerprint(_ context.Context, _, _ string) error {
 	return nil
+}
+
+func (m *mockRetryStore) UpsertParkedIssue(_ context.Context, entry persistence.ParkedIssue) error {
+	m.parkedIssues = append(m.parkedIssues, entry)
+	return m.upsertParkedErr
+}
+
+func (m *mockRetryStore) DeleteParkedIssue(_ context.Context, issueID string) error {
+	m.deletedParkedIDs = append(m.deletedParkedIDs, issueID)
+	return m.deleteParkedErr
+}
+
+func (m *mockRetryStore) ResetHandoffAbsenceSequence(_ context.Context, issueID string) error {
+	m.absenceResetOf = append(m.absenceResetOf, issueID)
+	return m.absenceResetErr
 }
 
 // mockRetryTracker implements domain.TrackerAdapter for retry timer tests.
@@ -3293,6 +3316,102 @@ func TestHandleRetryTimer_PausedDwellBound(t *testing.T) {
 		}
 		if secondEntry.TimerHandle != nil {
 			secondEntry.TimerHandle.Stop()
+		}
+	})
+}
+
+// TestHandleRetryTimerParkGate exercises the retry lane's two independent
+// decisions ahead of any tracker fetch: an already-parked issue is refused
+// regardless of the evidence policy, and an issue whose absence count has
+// just reached the ceiling is parked under any policy other than off.
+// Neither decision replaces the other, and a known reaction kind is exempt
+// from both.
+func TestHandleRetryTimerParkGate(t *testing.T) {
+	t.Parallel()
+
+	t.Run("already parked issue is refused under every evidence policy", func(t *testing.T) {
+		t.Parallel()
+
+		policies := []config.HandoffEvidencePolicy{"", config.HandoffEvidenceOff}
+		for _, policy := range policies {
+			t.Run(string(policy)+"_policy", func(t *testing.T) {
+				t.Parallel()
+
+				const issueID = "PARK-REFUSE"
+				store := &mockRetryStore{}
+				tracker := &mockRetryTracker{}
+				state := retryState(t, issueID, "PROJ-PARK", 1)
+				state.Parked[issueID] = &ParkedEntry{Identifier: "PROJ-PARK", Reason: parkReasonAgentBlocked}
+				params := defaultRetryParams(t, store, tracker)
+				params.HandoffEvidencePolicy = policy
+
+				HandleRetryTimer(state, issueID, params)
+
+				if _, ok := state.Claimed[issueID]; ok {
+					t.Error("claim remains after the retry timer fired for a parked issue")
+				}
+				if len(store.deletedIssueID) != 1 || store.deletedIssueID[0] != issueID {
+					t.Errorf("DeleteRetryEntry calls = %v, want [%s]", store.deletedIssueID, issueID)
+				}
+				// The discriminating assertion: a conjoined reaction-and-policy
+				// test would skip the park refusal entirely under the off
+				// policy and fall through to a tracker fetch instead.
+				if tracker.fetchCount != 0 {
+					t.Errorf("FetchIssueByID calls = %d, want 0 for an already-parked issue", tracker.fetchCount)
+				}
+				if len(store.absenceCountedIssueIDs) != 0 {
+					t.Errorf("absence query ran for %v, want none for an already-parked issue", store.absenceCountedIssueIDs)
+				}
+			})
+		}
+	})
+
+	t.Run("newly exhausted issue parks under a policy other than off", func(t *testing.T) {
+		t.Parallel()
+
+		const issueID = "PARK-NEWLY"
+		store := &mockRetryStore{absenceCounts: map[string]int{issueID: 3}}
+		tracker := &mockRetryTracker{}
+		state := retryState(t, issueID, "PROJ-NEWLY", 1)
+		params := defaultRetryParams(t, store, tracker)
+		params.MaxSessions = 0
+
+		HandleRetryTimer(state, issueID, params)
+		state.TrackerOpsWg.Wait()
+
+		if tracker.fetchCount != 0 {
+			t.Errorf("FetchIssueByID calls = %d, want 0: parking short-circuits before the fetch", tracker.fetchCount)
+		}
+		entry := state.Parked[issueID]
+		if entry == nil || entry.Reason != parkReasonHandoffAbsence {
+			t.Errorf("Parked[%s] = %+v, want reason %q", issueID, entry, parkReasonHandoffAbsence)
+		}
+	})
+
+	t.Run("known reaction kind dispatches regardless of park state or policy", func(t *testing.T) {
+		t.Parallel()
+
+		policies := []config.HandoffEvidencePolicy{"", config.HandoffEvidenceOff}
+		for _, policy := range policies {
+			t.Run(string(policy)+"_policy", func(t *testing.T) {
+				t.Parallel()
+
+				const issueID = "PARK-REACTION"
+				store := &mockRetryStore{absenceCounts: map[string]int{issueID: 99}}
+				tracker := &mockRetryTracker{fetchedIssue: candidateIssue(issueID, "PROJ-REACTION", "In Progress")}
+				state := retryState(t, issueID, "PROJ-REACTION", 1)
+				state.RetryAttempts[issueID].ReactionKind = ReactionKindReview
+				state.Parked[issueID] = &ParkedEntry{Identifier: "PROJ-REACTION", Reason: parkReasonAgentBlocked}
+				params := defaultRetryParams(t, store, tracker)
+				params.HandoffEvidencePolicy = policy
+
+				HandleRetryTimer(state, issueID, params)
+				state.TrackerOpsWg.Wait()
+
+				if tracker.fetchCount != 1 {
+					t.Errorf("FetchIssueByID calls = %d, want 1: a known reaction kind is exempt from the park gate", tracker.fetchCount)
+				}
+			})
 		}
 	})
 }

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -46,13 +46,11 @@ const (
 )
 
 // Dispatch-gate reason values recorded in [State.BudgetExhaustedReason] and
-// the runtime snapshot. Handoff absence takes precedence so a parked issue
-// remains distinguishable; token budget still takes precedence over the
-// ordinary all-session budget.
+// the runtime snapshot. Token budget takes precedence over the ordinary
+// all-session budget.
 const (
-	budgetReasonToken          = "token_budget"
-	budgetReasonHandoffAbsence = "handoff_absence"
-	budgetReasonSession        = "session_budget"
+	budgetReasonToken   = "token_budget"
+	budgetReasonSession = "session_budget"
 )
 
 // AgentTotals holds cumulative token and runtime counters across all ended
@@ -738,6 +736,18 @@ type MergeCompletionReactionConfig struct {
 	MaxRetries      int
 }
 
+// ParkedEntry is the runtime view of one issue held out of primary dispatch
+// until the orchestrator observes that a person acted on it.
+type ParkedEntry struct {
+	Identifier   string
+	DisplayID    string
+	Reason       string // "agent_blocked" or "handoff_absence"
+	ParkedState  string // tracker state observed at park time; empty when unobserved
+	Label        string // parking label the orchestrator applied
+	LabelApplied bool
+	ParkedAt     time.Time
+}
+
 // State is the single authoritative runtime state owned by the orchestrator.
 // The running map and claimed set are in-memory for performance. The
 // agent_totals and completed set are backed by SQLite and survive restarts.
@@ -787,18 +797,24 @@ type State struct {
 	Completed map[string]struct{}
 
 	// BudgetExhausted is the set of issue IDs blocked by a durable
-	// run_history-derived dispatch gate: the configured max_sessions
-	// budget, the max_tokens budget, or the consecutive handoff-absence
-	// ceiling. Rebuilt from batch SQLite queries at the start of each poll
-	// tick and updated inline by worker-exit and retry-timer handling.
-	// [ShouldDispatch] checks this set before dispatch.
+	// run_history-derived effort budget: the configured max_sessions
+	// budget or the max_tokens budget. Rebuilt from batch SQLite queries
+	// at the start of each poll tick and updated inline by worker-exit
+	// and retry-timer handling. [ShouldDispatch] checks this set before
+	// dispatch.
 	BudgetExhausted map[string]struct{}
 
-	// BudgetExhaustedReason maps issue ID to the gate that fired for that
-	// issue: "token_budget", "handoff_absence", or "session_budget". It
-	// is kept in lockstep with BudgetExhausted. Owned by the single-writer
-	// event loop.
+	// BudgetExhaustedReason maps issue ID to the budget that fired for
+	// that issue: "token_budget" or "session_budget". It is kept in
+	// lockstep with BudgetExhausted. Owned by the single-writer event
+	// loop.
 	BudgetExhaustedReason map[string]string
+
+	// Parked maps issue ID to the runtime view of an issue held out of
+	// primary dispatch until the orchestrator observes that a person acted
+	// on it. The durable mirror is the parked_issues table. Owned by the
+	// single-writer event loop.
+	Parked map[string]*ParkedEntry
 
 	// AgentTotals holds aggregate token counts and cumulative runtime seconds
 	// across all ended sessions. Active session elapsed time is computed at
@@ -903,6 +919,7 @@ func NewState(pollIntervalMS, maxConcurrentAgents int, maxConcurrentByState map[
 		Completed:             make(map[string]struct{}),
 		BudgetExhausted:       make(map[string]struct{}),
 		BudgetExhaustedReason: make(map[string]string),
+		Parked:                make(map[string]*ParkedEntry),
 		AgentTotals:           totals,
 		ReactionAttempts:      make(map[string]int),
 		PendingReactions:      make(map[string]*PendingReaction),
@@ -993,6 +1010,9 @@ type RuntimeSnapshotResult struct {
 	BudgetExhaustedCount  int                    `json:"budget_exhausted_count"`
 	BudgetExhausted       []string               `json:"budget_exhausted,omitempty"`
 	BudgetExhaustedReason map[string]string      `json:"budget_exhausted_reason,omitempty"`
+	ParkedCount           int                    `json:"parked_count"`
+	Parked                []string               `json:"parked,omitempty"`
+	ParkedReason          map[string]string      `json:"parked_reason,omitempty"`
 }
 
 // ActiveElapsedSeconds returns the sum of wall-clock elapsed seconds
@@ -1117,6 +1137,22 @@ func RuntimeSnapshot(state *State, now time.Time) RuntimeSnapshotResult {
 			reasons[id] = state.BudgetExhaustedReason[id]
 		}
 		snap.BudgetExhaustedReason = reasons
+	}
+
+	snap.ParkedCount = len(state.Parked)
+	if len(state.Parked) > 0 {
+		ids := make([]string, 0, len(state.Parked))
+		for id := range state.Parked {
+			ids = append(ids, id)
+		}
+		slices.Sort(ids)
+		snap.Parked = ids
+
+		reasons := make(map[string]string, len(state.Parked))
+		for _, id := range ids {
+			reasons[id] = state.Parked[id].Reason
+		}
+		snap.ParkedReason = reasons
 	}
 
 	if state.AgentRateLimits != nil {

--- a/internal/orchestrator/state_test.go
+++ b/internal/orchestrator/state_test.go
@@ -1,6 +1,7 @@
 package orchestrator
 
 import (
+	"bytes"
 	"math"
 	"strings"
 	"testing"
@@ -8,6 +9,7 @@ import (
 
 	"github.com/sortie-ai/sortie/internal/config"
 	"github.com/sortie-ai/sortie/internal/domain"
+	"github.com/sortie-ai/sortie/internal/persistence"
 	"github.com/sortie-ai/sortie/internal/registry"
 )
 
@@ -1737,4 +1739,161 @@ func TestBuildLabelFixReactionConfig(t *testing.T) {
 	if got != want {
 		t.Errorf("BuildLabelFixReactionConfig(%+v) = %+v, want %+v", cfg, got, want)
 	}
+}
+
+// TestPopulateParked verifies that PopulateParked loads persisted rows into
+// state.Parked, skips a row with an empty issue_id while logging a
+// warning, loads a row with an empty parked_state rather than skipping it,
+// and that the resulting state.Parked is honored by ShouldDispatch's gate.
+func TestPopulateParked(t *testing.T) {
+	t.Parallel()
+
+	t.Run("loads rows into state.Parked", func(t *testing.T) {
+		t.Parallel()
+
+		state := NewState(5000, 4, nil, AgentTotals{})
+		rows := []persistence.ParkedIssue{
+			{
+				IssueID:      "id-1",
+				Identifier:   "PROJ-1",
+				DisplayID:    "PROJ-1-display",
+				Reason:       parkReasonAgentBlocked,
+				ParkedState:  "In Progress",
+				Label:        "needs-human",
+				LabelApplied: true,
+				ParkedAt:     "2026-08-17T00:00:00Z",
+			},
+			{
+				IssueID:     "id-2",
+				Identifier:  "PROJ-2",
+				Reason:      parkReasonHandoffAbsence,
+				ParkedState: "",
+				Label:       "needs-human",
+				ParkedAt:    "2026-08-17T01:00:00Z",
+			},
+		}
+
+		PopulateParked(state, rows, nil)
+
+		if len(state.Parked) != 2 {
+			t.Fatalf("len(state.Parked) = %d, want 2", len(state.Parked))
+		}
+
+		entry1, ok := state.Parked["id-1"]
+		if !ok {
+			t.Fatal("state.Parked missing id-1")
+		}
+		if entry1.Identifier != "PROJ-1" || entry1.DisplayID != "PROJ-1-display" ||
+			entry1.Reason != parkReasonAgentBlocked || entry1.ParkedState != "In Progress" ||
+			entry1.Label != "needs-human" || !entry1.LabelApplied {
+			t.Errorf("state.Parked[id-1] = %+v, want fields to match the persisted row", entry1)
+		}
+		if !entry1.ParkedAt.Equal(time.Date(2026, 8, 17, 0, 0, 0, 0, time.UTC)) {
+			t.Errorf("state.Parked[id-1].ParkedAt = %v, want 2026-08-17T00:00:00Z", entry1.ParkedAt)
+		}
+
+		// A row loaded with an empty parked_state is loaded, not skipped:
+		// only an empty issue_id is a malformed row.
+		entry2, ok := state.Parked["id-2"]
+		if !ok {
+			t.Fatal("state.Parked missing id-2")
+		}
+		if entry2.ParkedState != "" {
+			t.Errorf("state.Parked[id-2].ParkedState = %q, want empty", entry2.ParkedState)
+		}
+	})
+
+	t.Run("skips a row with an empty issue_id and logs a warning", func(t *testing.T) {
+		t.Parallel()
+
+		state := NewState(5000, 4, nil, AgentTotals{})
+		rows := []persistence.ParkedIssue{
+			{IssueID: "", Identifier: "PROJ-MALFORMED", Reason: parkReasonAgentBlocked, ParkedAt: "2026-08-17T00:00:00Z"},
+			{IssueID: "id-3", Identifier: "PROJ-3", Reason: parkReasonAgentBlocked, ParkedAt: "2026-08-17T00:00:00Z"},
+		}
+		var logs bytes.Buffer
+
+		PopulateParked(state, rows, debugLogger(t, &logs))
+
+		if len(state.Parked) != 1 {
+			t.Fatalf("len(state.Parked) = %d, want 1 (the malformed row skipped)", len(state.Parked))
+		}
+		if _, ok := state.Parked["id-3"]; !ok {
+			t.Error("state.Parked missing id-3")
+		}
+		if !strings.Contains(logs.String(), "skipping malformed park record") {
+			t.Errorf("missing malformed-row warning\nlogs: %s", logs.String())
+		}
+	})
+
+	t.Run("resulting state.Parked is honored by ShouldDispatch", func(t *testing.T) {
+		t.Parallel()
+
+		state := NewState(5000, 4, nil, AgentTotals{})
+		PopulateParked(state, []persistence.ParkedIssue{
+			{IssueID: "id-4", Identifier: "PROJ-4", Reason: parkReasonAgentBlocked, ParkedAt: "2026-08-17T00:00:00Z"},
+		}, nil)
+
+		issue := domain.Issue{ID: "id-4", Identifier: "PROJ-4", Title: "T", State: "To Do"}
+		if ShouldDispatch(issue, state, []string{"To Do"}, []string{"Done"}) {
+			t.Error("ShouldDispatch dispatched an issue PopulateParked loaded into state.Parked")
+		}
+	})
+}
+
+// TestRuntimeSnapshot_ParkedFields verifies that RuntimeSnapshot reports
+// ParkedCount always, including zero, and Parked/ParkedReason only when
+// state.Parked is non-empty, mirroring the BudgetExhausted* projection.
+func TestRuntimeSnapshot_ParkedFields(t *testing.T) {
+	t.Parallel()
+
+	fixedNow := time.Date(2026, 3, 24, 12, 0, 0, 0, time.UTC)
+
+	t.Run("empty Parked produces zero count and nil slices", func(t *testing.T) {
+		t.Parallel()
+
+		state := NewState(5000, 10, nil, AgentTotals{})
+
+		result := RuntimeSnapshot(state, fixedNow)
+
+		if result.ParkedCount != 0 {
+			t.Errorf("ParkedCount = %d, want 0", result.ParkedCount)
+		}
+		if result.Parked != nil {
+			t.Errorf("Parked = %v, want nil", result.Parked)
+		}
+		if result.ParkedReason != nil {
+			t.Errorf("ParkedReason = %v, want nil", result.ParkedReason)
+		}
+	})
+
+	t.Run("non-empty Parked sorted, counted, and reasoned", func(t *testing.T) {
+		t.Parallel()
+
+		state := NewState(5000, 10, nil, AgentTotals{})
+		state.Parked["ISS-C"] = &ParkedEntry{Identifier: "PROJ-C", Reason: parkReasonAgentBlocked}
+		state.Parked["ISS-A"] = &ParkedEntry{Identifier: "PROJ-A", Reason: parkReasonHandoffAbsence}
+		state.Parked["ISS-B"] = &ParkedEntry{Identifier: "PROJ-B", Reason: parkReasonAgentBlocked}
+
+		result := RuntimeSnapshot(state, fixedNow)
+
+		if result.ParkedCount != 3 {
+			t.Errorf("ParkedCount = %d, want 3", result.ParkedCount)
+		}
+		want := []string{"ISS-A", "ISS-B", "ISS-C"}
+		if len(result.Parked) != len(want) {
+			t.Fatalf("len(Parked) = %d, want %d", len(result.Parked), len(want))
+		}
+		for i, id := range want {
+			if result.Parked[i] != id {
+				t.Errorf("Parked[%d] = %q, want %q", i, result.Parked[i], id)
+			}
+		}
+		if got := result.ParkedReason["ISS-A"]; got != parkReasonHandoffAbsence {
+			t.Errorf("ParkedReason[ISS-A] = %q, want %q", got, parkReasonHandoffAbsence)
+		}
+		if got := result.ParkedReason["ISS-C"]; got != parkReasonAgentBlocked {
+			t.Errorf("ParkedReason[ISS-C] = %q, want %q", got, parkReasonAgentBlocked)
+		}
+	})
 }

--- a/internal/persistence/migrations.go
+++ b/internal/persistence/migrations.go
@@ -50,6 +50,9 @@ var migration012SQL string
 //go:embed sql/013_handoff_absence_resets.sql
 var migration013SQL string
 
+//go:embed sql/014_parked_issues.sql
+var migration014SQL string
+
 var migrations = []Migration{
 	{Version: 1, Description: "core persistence tables", SQL: migration001SQL},
 	{Version: 2, Description: "extended token metrics", SQL: migration002SQL},
@@ -64,4 +67,5 @@ var migrations = []Migration{
 	{Version: 11, Description: "run_history token columns", SQL: migration011SQL},
 	{Version: 12, Description: "tokens_measured column on run_history", SQL: migration012SQL},
 	{Version: 13, Description: "handoff absence sequence reset points", SQL: migration013SQL},
+	{Version: 14, Description: "parked issues held out of primary dispatch", SQL: migration014SQL},
 }

--- a/internal/persistence/parked_issues.go
+++ b/internal/persistence/parked_issues.go
@@ -1,0 +1,93 @@
+package persistence
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+)
+
+// ParkedIssue is one row of the parked_issues table: an issue held out of
+// primary dispatch until the orchestrator observes that a person acted.
+type ParkedIssue struct {
+	IssueID      string
+	Identifier   string
+	DisplayID    string // empty when the tracker needs no qualified form
+	Reason       string // "agent_blocked" or "handoff_absence"
+	ParkedState  string // tracker state observed at park time; empty when unobserved
+	Label        string // parking label the orchestrator applied
+	LabelApplied bool
+	ParkedAt     string // RFC 3339
+}
+
+// UpsertParkedIssue persists a park record using upsert semantics. If a
+// record for entry.IssueID already exists, it is replaced entirely.
+func (s *Store) UpsertParkedIssue(ctx context.Context, entry ParkedIssue) error {
+	_, err := s.db.ExecContext(ctx,
+		`INSERT INTO parked_issues (issue_id, identifier, display_id, reason, parked_state, label, label_applied, parked_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT (issue_id) DO UPDATE SET
+			identifier    = excluded.identifier,
+			display_id    = excluded.display_id,
+			reason        = excluded.reason,
+			parked_state  = excluded.parked_state,
+			label         = excluded.label,
+			label_applied = excluded.label_applied,
+			parked_at     = excluded.parked_at`,
+		entry.IssueID, entry.Identifier, entry.DisplayID, entry.Reason, entry.ParkedState,
+		entry.Label, entry.LabelApplied, entry.ParkedAt,
+	)
+	if err != nil {
+		return fmt.Errorf("upsert parked issue %q: %w", entry.IssueID, err)
+	}
+	return nil
+}
+
+// MarkParkedIssueLabelApplied sets label_applied for the given issue ID. It
+// is a no-op, not an error, when no row exists for that issue ID.
+func (s *Store) MarkParkedIssueLabelApplied(ctx context.Context, issueID string) error {
+	_, err := s.db.ExecContext(ctx,
+		`UPDATE parked_issues SET label_applied = 1 WHERE issue_id = ?`, issueID)
+	if err != nil {
+		return fmt.Errorf("mark parked issue label applied %q: %w", issueID, err)
+	}
+	return nil
+}
+
+// DeleteParkedIssue removes the park record for the given issue ID. It is a
+// no-op, not an error, when no row exists for that issue ID.
+func (s *Store) DeleteParkedIssue(ctx context.Context, issueID string) error {
+	_, err := s.db.ExecContext(ctx,
+		`DELETE FROM parked_issues WHERE issue_id = ?`, issueID)
+	if err != nil {
+		return fmt.Errorf("delete parked issue %q: %w", issueID, err)
+	}
+	return nil
+}
+
+// ListParkedIssues returns every persisted park record. Ordering is
+// unspecified. Returns an empty slice (not nil) when no records exist.
+func (s *Store) ListParkedIssues(ctx context.Context) ([]ParkedIssue, error) {
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT issue_id, identifier, display_id, reason, parked_state, label, label_applied, parked_at
+		FROM parked_issues`)
+	if err != nil {
+		return nil, fmt.Errorf("list parked issues: %w", err)
+	}
+	defer rows.Close() //nolint:errcheck // read-only query; close error is non-actionable
+
+	entries := []ParkedIssue{}
+	for rows.Next() {
+		var e ParkedIssue
+		var displayID sql.NullString
+		if err := rows.Scan(&e.IssueID, &e.Identifier, &displayID, &e.Reason, &e.ParkedState,
+			&e.Label, &e.LabelApplied, &e.ParkedAt); err != nil {
+			return nil, fmt.Errorf("scan parked issue: %w", err)
+		}
+		e.DisplayID = displayID.String
+		entries = append(entries, e)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("list parked issues: %w", err)
+	}
+	return entries, nil
+}

--- a/internal/persistence/parked_issues_test.go
+++ b/internal/persistence/parked_issues_test.go
@@ -1,0 +1,248 @@
+package persistence
+
+import (
+	"context"
+	"testing"
+)
+
+func TestMigrate_Migration014AppliesFromVersion13(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	s := openTestStore(t)
+
+	if _, err := s.db.ExecContext(ctx,
+		`CREATE TABLE IF NOT EXISTS schema_migrations (
+			version    INTEGER PRIMARY KEY,
+			applied_at TEXT    NOT NULL
+		)`); err != nil {
+		t.Fatalf("create schema_migrations table: %v", err)
+	}
+	for _, m := range migrations {
+		if m.Version > 13 {
+			continue
+		}
+		if err := s.applyMigration(ctx, m); err != nil {
+			t.Fatalf("apply migration %d: %v", m.Version, err)
+		}
+	}
+
+	var versionBefore int
+	if err := s.db.QueryRowContext(ctx, "SELECT MAX(version) FROM schema_migrations").Scan(&versionBefore); err != nil {
+		t.Fatalf("query schema version before Migrate: %v", err)
+	}
+	if versionBefore != 13 {
+		t.Fatalf("schema version before Migrate = %d, want 13", versionBefore)
+	}
+
+	if err := s.Migrate(ctx); err != nil {
+		t.Fatalf("Migrate from version 13: %v", err)
+	}
+
+	var versionAfter int
+	if err := s.db.QueryRowContext(ctx, "SELECT MAX(version) FROM schema_migrations").Scan(&versionAfter); err != nil {
+		t.Fatalf("query schema version after Migrate: %v", err)
+	}
+	if versionAfter != 14 {
+		t.Errorf("schema version after Migrate = %d, want 14", versionAfter)
+	}
+
+	var tableName string
+	if err := s.db.QueryRowContext(ctx,
+		`SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'parked_issues'`,
+	).Scan(&tableName); err != nil {
+		t.Fatalf("parked_issues table not found after migration 014: %v", err)
+	}
+}
+
+func TestUpsertParkedIssue_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	s := mustOpenStore(t)
+
+	entry := ParkedIssue{
+		IssueID:      "ISS-1",
+		Identifier:   "PROJ-1",
+		DisplayID:    "PROJ-1-display",
+		Reason:       "agent_blocked",
+		ParkedState:  "In Progress",
+		Label:        "needs-human",
+		LabelApplied: false,
+		ParkedAt:     "2026-08-17T00:00:00Z",
+	}
+	if err := s.UpsertParkedIssue(ctx, entry); err != nil {
+		t.Fatalf("UpsertParkedIssue: %v", err)
+	}
+
+	rows, err := s.ListParkedIssues(ctx)
+	if err != nil {
+		t.Fatalf("ListParkedIssues: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("ListParkedIssues() length = %d, want 1", len(rows))
+	}
+	if rows[0] != entry {
+		t.Errorf("ListParkedIssues()[0] = %+v, want %+v", rows[0], entry)
+	}
+}
+
+func TestUpsertParkedIssue_RewritesExistingRow(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	s := mustOpenStore(t)
+	const issueID = "ISS-2"
+
+	if err := s.UpsertParkedIssue(ctx, ParkedIssue{
+		IssueID: issueID, Identifier: "PROJ-2", Reason: "agent_blocked",
+		ParkedState: "In Progress", Label: "needs-human", ParkedAt: "2026-08-17T00:00:00Z",
+	}); err != nil {
+		t.Fatalf("UpsertParkedIssue (initial): %v", err)
+	}
+
+	if err := s.UpsertParkedIssue(ctx, ParkedIssue{
+		IssueID: issueID, Identifier: "PROJ-2", Reason: "handoff_absence",
+		ParkedState: "Blocked", Label: "operator-needed", LabelApplied: true,
+		ParkedAt: "2026-08-17T01:00:00Z",
+	}); err != nil {
+		t.Fatalf("UpsertParkedIssue (rewrite): %v", err)
+	}
+
+	rows, err := s.ListParkedIssues(ctx)
+	if err != nil {
+		t.Fatalf("ListParkedIssues: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("ListParkedIssues() length = %d, want 1 (rewrite, not a duplicate row)", len(rows))
+	}
+	if rows[0].Reason != "handoff_absence" || !rows[0].LabelApplied {
+		t.Errorf("ListParkedIssues()[0] = %+v, want the rewritten row", rows[0])
+	}
+}
+
+func TestMarkParkedIssueLabelApplied_SetsFlag(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	s := mustOpenStore(t)
+	const issueID = "ISS-3"
+
+	if err := s.UpsertParkedIssue(ctx, ParkedIssue{
+		IssueID: issueID, Identifier: "PROJ-3", Reason: "agent_blocked",
+		ParkedState: "In Progress", Label: "needs-human", ParkedAt: "2026-08-17T00:00:00Z",
+	}); err != nil {
+		t.Fatalf("UpsertParkedIssue: %v", err)
+	}
+
+	if err := s.MarkParkedIssueLabelApplied(ctx, issueID); err != nil {
+		t.Fatalf("MarkParkedIssueLabelApplied: %v", err)
+	}
+
+	rows, err := s.ListParkedIssues(ctx)
+	if err != nil {
+		t.Fatalf("ListParkedIssues: %v", err)
+	}
+	if len(rows) != 1 || !rows[0].LabelApplied {
+		t.Errorf("ListParkedIssues() = %+v, want LabelApplied = true", rows)
+	}
+}
+
+func TestMarkParkedIssueLabelApplied_AbsentRowIsNotAnError(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	s := mustOpenStore(t)
+
+	if err := s.MarkParkedIssueLabelApplied(ctx, "MISSING"); err != nil {
+		t.Fatalf("MarkParkedIssueLabelApplied on absent row returned error: %v", err)
+	}
+}
+
+func TestDeleteParkedIssue_RemovesRow(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	s := mustOpenStore(t)
+	const issueID = "ISS-4"
+
+	if err := s.UpsertParkedIssue(ctx, ParkedIssue{
+		IssueID: issueID, Identifier: "PROJ-4", Reason: "agent_blocked",
+		ParkedState: "In Progress", Label: "needs-human", ParkedAt: "2026-08-17T00:00:00Z",
+	}); err != nil {
+		t.Fatalf("UpsertParkedIssue: %v", err)
+	}
+
+	if err := s.DeleteParkedIssue(ctx, issueID); err != nil {
+		t.Fatalf("DeleteParkedIssue: %v", err)
+	}
+
+	rows, err := s.ListParkedIssues(ctx)
+	if err != nil {
+		t.Fatalf("ListParkedIssues: %v", err)
+	}
+	if len(rows) != 0 {
+		t.Errorf("ListParkedIssues() length = %d, want 0 after delete", len(rows))
+	}
+}
+
+func TestDeleteParkedIssue_AbsentRowIsNotAnError(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	s := mustOpenStore(t)
+
+	if err := s.DeleteParkedIssue(ctx, "MISSING"); err != nil {
+		t.Fatalf("DeleteParkedIssue on absent row returned error: %v", err)
+	}
+}
+
+func TestListParkedIssues_EmptyReturnsEmptySliceNotNil(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	s := mustOpenStore(t)
+
+	rows, err := s.ListParkedIssues(ctx)
+	if err != nil {
+		t.Fatalf("ListParkedIssues: %v", err)
+	}
+	if rows == nil {
+		t.Error("ListParkedIssues() = nil, want an empty non-nil slice")
+	}
+	if len(rows) != 0 {
+		t.Errorf("ListParkedIssues() length = %d, want 0", len(rows))
+	}
+}
+
+func TestListParkedIssues_MultipleRowsIndependent(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	s := mustOpenStore(t)
+
+	if err := s.UpsertParkedIssue(ctx, ParkedIssue{
+		IssueID: "ISS-5", Identifier: "PROJ-5", Reason: "agent_blocked",
+		ParkedState: "In Progress", Label: "needs-human", ParkedAt: "2026-08-17T00:00:00Z",
+	}); err != nil {
+		t.Fatalf("UpsertParkedIssue(ISS-5): %v", err)
+	}
+	if err := s.UpsertParkedIssue(ctx, ParkedIssue{
+		IssueID: "ISS-6", Identifier: "PROJ-6", Reason: "handoff_absence",
+		ParkedState: "Blocked", Label: "needs-human", ParkedAt: "2026-08-17T00:00:00Z",
+	}); err != nil {
+		t.Fatalf("UpsertParkedIssue(ISS-6): %v", err)
+	}
+
+	if err := s.DeleteParkedIssue(ctx, "ISS-5"); err != nil {
+		t.Fatalf("DeleteParkedIssue(ISS-5): %v", err)
+	}
+
+	rows, err := s.ListParkedIssues(ctx)
+	if err != nil {
+		t.Fatalf("ListParkedIssues: %v", err)
+	}
+	if len(rows) != 1 || rows[0].IssueID != "ISS-6" {
+		t.Errorf("ListParkedIssues() = %+v, want only ISS-6 to remain", rows)
+	}
+}

--- a/internal/persistence/sql/014_parked_issues.sql
+++ b/internal/persistence/sql/014_parked_issues.sql
@@ -1,0 +1,18 @@
+-- Migration 14: issues held out of primary dispatch until a human acts
+--
+-- One row per parked issue. The row is deleted when the park is lifted,
+-- so the table holds current state rather than history. parked_state is
+-- the tracker state observed when the park was recorded. label is the
+-- parking label the orchestrator applied. label_applied is 1 once the
+-- orchestrator has confirmed the label is on the issue.
+
+CREATE TABLE parked_issues (
+    issue_id      TEXT    PRIMARY KEY,
+    identifier    TEXT    NOT NULL,
+    display_id    TEXT,
+    reason        TEXT    NOT NULL,
+    parked_state  TEXT    NOT NULL DEFAULT '',
+    label         TEXT    NOT NULL,
+    label_applied INTEGER NOT NULL DEFAULT 0,
+    parked_at     TEXT    NOT NULL
+);

--- a/internal/server/metrics.go
+++ b/internal/server/metrics.go
@@ -29,6 +29,7 @@ type PromMetrics struct {
 	pollCyclesTotal               *prometheus.CounterVec
 	trackerRequestsTotal          *prometheus.CounterVec
 	handoffTransitions            *prometheus.CounterVec
+	issueParksTotal               *prometheus.CounterVec
 	dispatchTransitions           *prometheus.CounterVec
 	trackerCommentsTotal          *prometheus.CounterVec
 	toolCallsTotal                *prometheus.CounterVec
@@ -145,6 +146,12 @@ func NewPromMetrics(version, goVersion string) *PromMetrics {
 		Name:      "handoff_transitions_total",
 		Help:      "Handoff state transition outcomes.",
 	}, []string{"result"})
+
+	issueParksTotal := prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "sortie",
+		Name:      "issue_parks_total",
+		Help:      "Issue park events by reason.",
+	}, []string{"reason"})
 
 	dispatchTransitions := prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "sortie",
@@ -290,6 +297,7 @@ func NewPromMetrics(version, goVersion string) *PromMetrics {
 		pollCyclesTotal,
 		trackerRequestsTotal,
 		handoffTransitions,
+		issueParksTotal,
 		dispatchTransitions,
 		trackerCommentsTotal,
 		toolCallsTotal,
@@ -328,6 +336,7 @@ func NewPromMetrics(version, goVersion string) *PromMetrics {
 		pollCyclesTotal:                pollCyclesTotal,
 		trackerRequestsTotal:           trackerRequestsTotal,
 		handoffTransitions:             handoffTransitions,
+		issueParksTotal:                issueParksTotal,
 		dispatchTransitions:            dispatchTransitions,
 		trackerCommentsTotal:           trackerCommentsTotal,
 		toolCallsTotal:                 toolCallsTotal,
@@ -430,6 +439,11 @@ func (p *PromMetrics) IncTrackerRequests(operation, outcome string) {
 // IncHandoffTransitions increments the handoff state transition outcome counter.
 func (p *PromMetrics) IncHandoffTransitions(outcome string) {
 	p.handoffTransitions.WithLabelValues(outcome).Inc()
+}
+
+// IncIssueParks increments the issue park counter.
+func (p *PromMetrics) IncIssueParks(reason string) {
+	p.issueParksTotal.WithLabelValues(reason).Inc()
 }
 
 // IncDispatchTransitions increments the dispatch-time in-progress transition counter.

--- a/internal/tracker/file/file.go
+++ b/internal/tracker/file/file.go
@@ -12,6 +12,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -44,6 +45,7 @@ type FileAdapter struct {
 	mu               sync.RWMutex
 	overrides        map[string]string           // issue ID → overridden state
 	commentOverrides map[string][]domain.Comment // issue ID → appended comments
+	labelOverrides   map[string]string           // issue ID → label to merge into raw.Labels
 	metrics          domain.Metrics              // nil-safe: check before calling
 }
 
@@ -72,6 +74,7 @@ func NewFileAdapter(config map[string]any) (domain.TrackerAdapter, error) {
 		activeStates:     toStringSet(typeutil.ExtractStringSlice(config["active_states"])),
 		overrides:        make(map[string]string),
 		commentOverrides: make(map[string][]domain.Comment),
+		labelOverrides:   make(map[string]string),
 	}, nil
 }
 
@@ -361,18 +364,30 @@ func (a *FileAdapter) SetMetrics(m domain.Metrics) {
 	a.metrics = m
 }
 
-// AddLabel is a no-op for the file adapter. File-based issues do not
-// support labels.
-func (a *FileAdapter) AddLabel(_ context.Context, _ string, _ string) error {
-	return trackermetrics.Track(a.metrics, "add_label", func() error { return nil })
+// AddLabel records the label in the adapter's in-memory label overlay, so
+// it is visible on subsequent reads of the issue. Only one label per issue
+// is retained; a second call for the same issue ID overwrites the first.
+func (a *FileAdapter) AddLabel(_ context.Context, issueID string, label string) error {
+	return trackermetrics.Track(a.metrics, "add_label", func() error {
+		a.mu.Lock()
+		a.labelOverrides[issueID] = label
+		a.mu.Unlock()
+		return nil
+	})
 }
 
 // applyOverride returns a copy of raw with its State replaced by the
-// in-memory override value when one exists. Caller must hold at least
-// a read lock on a.mu.
+// in-memory state override when one exists, and with the in-memory label
+// override merged into Labels (case-insensitive against the existing
+// entries) when one exists. Caller must hold at least a read lock on a.mu.
 func (a *FileAdapter) applyOverride(raw rawIssue) rawIssue {
 	if st, ok := a.overrides[raw.ID]; ok {
 		raw.State = st
+	}
+	if label, ok := a.labelOverrides[raw.ID]; ok && !slices.ContainsFunc(raw.Labels, func(l string) bool {
+		return strings.EqualFold(l, label)
+	}) {
+		raw.Labels = append(raw.Labels, label)
 	}
 	return raw
 }

--- a/internal/tracker/file/file_test.go
+++ b/internal/tracker/file/file_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -1120,6 +1121,54 @@ func TestAddLabel_IsANoOp(t *testing.T) {
 	if err := a.AddLabel(context.Background(), "10001", "urgent"); err != nil {
 		t.Fatalf("AddLabel: %v", err)
 	}
+}
+
+// TestAddLabel_VisibleOnSubsequentReads verifies that a label recorded
+// through AddLabel is visible on a later FetchCandidateIssues call — the
+// load-bearing read, since it is the one the orchestrator's park release
+// rule evaluates — and on a later FetchIssueByID call.
+func TestAddLabel_VisibleOnSubsequentReads(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	t.Run("visible via FetchCandidateIssues", func(t *testing.T) {
+		t.Parallel()
+
+		a := newAdapter(t, fixture("basic.json"), nil)
+		if err := a.AddLabel(ctx, "10001", "needs-human"); err != nil {
+			t.Fatalf("AddLabel: %v", err)
+		}
+
+		issues, err := a.FetchCandidateIssues(ctx)
+		if err != nil {
+			t.Fatalf("FetchCandidateIssues: %v", err)
+		}
+		idx := slices.IndexFunc(issues, func(issue domain.Issue) bool { return issue.ID == "10001" })
+		if idx == -1 {
+			t.Fatal("issue 10001 not found in FetchCandidateIssues result")
+		}
+		if !slices.ContainsFunc(issues[idx].Labels, func(l string) bool { return strings.EqualFold(l, "needs-human") }) {
+			t.Errorf("FetchCandidateIssues labels = %v, want to include %q", issues[idx].Labels, "needs-human")
+		}
+	})
+
+	t.Run("visible via FetchIssueByID", func(t *testing.T) {
+		t.Parallel()
+
+		a := newAdapter(t, fixture("basic.json"), nil)
+		if err := a.AddLabel(ctx, "10001", "needs-human"); err != nil {
+			t.Fatalf("AddLabel: %v", err)
+		}
+
+		issue, err := a.FetchIssueByID(ctx, "10001")
+		if err != nil {
+			t.Fatalf("FetchIssueByID: %v", err)
+		}
+		if !slices.ContainsFunc(issue.Labels, func(l string) bool { return strings.EqualFold(l, "needs-human") }) {
+			t.Errorf("FetchIssueByID labels = %v, want to include %q", issue.Labels, "needs-human")
+		}
+	})
 }
 
 func TestCommentIssue(t *testing.T) {


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Fix

**Intent:** An agent that writes `blocked` to `.sortie/status` stopped its run with no durable record, so the issue kept the active tracker state it was dispatched from and was re-dispatched on every subsequent poll cycle - unbounded when no effort budget was configured. This introduces a durable park mechanism that holds such an issue out of dispatch until a human acts, distinct from the existing `needs-human-review` handoff-state transition.

**Related Issues:** #811

### 🧭 Reviewer Guide

**Complexity:** High

#### Entry Point

`internal/orchestrator/park.go` - implements park and unpark. The exit handler in `internal/orchestrator/exit.go` parks an issue on the blocked soft-stop reason, applying the operator's configured escalation label in the tracker; a park is released once a later poll observes the label removed or the issue moved to a non-active tracker state. The existing consecutive-handoff-absence gate (`internal/orchestrator/handoff_absence.go`) now shares this same park/release mechanism instead of its own bespoke one.

#### Sensitive Areas

- `internal/orchestrator/exit.go`: worker-exit dispatch logic; the blocked soft-stop arm now diverges into either a park or the prior retry-cancel path depending on whether the issue drives dispatch.
- `internal/orchestrator/park.go`: durable park/unpark, including the label write and the release-on-poll checks.
- `internal/persistence/parked_issues.go`: new store backing the park state across restarts.
- `internal/tracker/file/file.go`: `AddLabel` changed from a no-op to an in-memory overlay so tests can assert on applied labels.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes.
- **Migrations/State:** Adds migration 014, creating the `parked_issues` table. An upgrade starts with no parked issues; an issue whose agent already reported itself blocked before the upgrade is parked the next time it reports it.