### PR TITLE
docs: describe the handoff evidence verdict in worker exit algorithm

### DIFF
--- a/docs/architecture/19-failure-model-and-recovery-strategy.md
+++ b/docs/architecture/19-failure-model-and-recovery-strategy.md
@@ -103,12 +103,12 @@
     incremented and no *new* park is taken by this ceiling on any path: polling, retry firing, and
     worker exit all skip the trigger, and the policy costs nothing while it is selected. This
     governs only whether a *new* park is taken, not whether an existing one holds: a park already
-    recorded, by either trigger, is unaffected by the policy and is released only by the rule
+    recorded, by either trigger, is not lifted by selecting `off` and is released only by the rules
     below. Raising `agent.max_sessions` above the recorded count has the same narrowed effect: it
     changes the ceiling a future count is compared against, but it does not lift a park already
     taken, because the park is a row rather than a value re-derived from the current ceiling on
     every tick.
-  - A park is released by either of two operator gestures, whichever the orchestrator observes
+  - An operator releases a park with either of two gestures, whichever the orchestrator observes
     first, and both apply to every trigger that parks an issue, not only to this ceiling: moving
     the issue to a tracker state different from the one recorded when it was parked, or removing
     a parking label the orchestrator has confirmed reached the tracker. The label gesture carries
@@ -126,6 +126,11 @@
     resets the counter that produced the park, so a released absence-ceiling park does not
     immediately re-derive the same exhausted count and park itself again; release is evaluated
     ahead of the ceiling trigger on the same tick for exactly this reason.
+  - A third release takes no gesture: a worker exit whose evidence verdict is `work observed` lifts
+    the park of the issue it ran on, on the same verdict that resets the absence count, and it too
+    applies to every trigger that parks an issue. This is the one release the evidence policy
+    governs, since `off` computes no verdict, so a deployment that selects it keeps the two
+    gestures above as the only way out of a park.
   - The parking label is the resolved non-empty
     `reactions.review_comments.escalation_label` captured when the orchestrator starts, or
     `needs-human` when that block or value is absent or empty. This lookup deliberately reuses only

--- a/docs/architecture/21-reference-algorithms.md
+++ b/docs/architecture/21-reference-algorithms.md
@@ -389,7 +389,74 @@ function run_agent_attempt(issue, attempt, orchestrator_channel):
 on_worker_exit(issue_id, reason, state):
   running_entry = state.running.remove(issue_id)
   state = add_runtime_seconds_to_totals(state, running_entry)
-  sqlite.persist_run_attempt(running_entry, reason)  # persist before scheduling retry
+
+  status = status_for_exit(reason)
+  run_error = worker_result.error
+  handoff_path = false
+  evidence_withheld = false
+  evidence_work_observed = false
+  absence_parked = false
+
+  # A normal exit resolves the conditions of its handoff disposition
+  # here, ahead of the persist, because a withheld handoff is what
+  # decides the status this run records. The persist still precedes any
+  # retry the dispositions schedule, and those dispositions are still
+  # taken in order below; this pass only reads what they will test.
+  if reason == normal:
+    # The resolved observation feeds the terminal test and nothing else.
+    # The active test reads the dispatch-time snapshot, because the most
+    # common non-active state at a normal exit is the handoff state
+    # itself, applied by the agent through its own tracker calls.
+    observation = resolve_terminal_observation(running_entry, worker_result)
+    terminal = is_terminal_state(observation, cfg.tracker.terminal_states)
+    is_active = is_active_state(running_entry.issue.state, cfg.tracker.active_states)
+    drives_state = dispatch_drives_issue_state(running_entry)
+    blocked_soft_stop = is_blocked_soft_stop(running_entry, worker_result)
+    handoff_path = cfg.tracker.handoff_state is not empty and is_active
+        and not blocked_soft_stop and drives_state
+
+    # The evidence verdict is a fifth condition on the handoff path, read
+    # only where those four already select it and no terminal observation
+    # suppresses the exit. It can withhold a handoff write and can never
+    # cause one (Section 11.5). Under `off` no verdict is computed at all
+    # and the four-condition decision stands.
+    policy = worker_result.handoff_evidence_policy  # frozen at dispatch
+    if handoff_path and not terminal and policy != "off":
+      evidence = evaluate_handoff_evidence(worker_result)
+      absence = evidence.verdict == "absence of work observed"
+      undeterminable = evidence.verdict == "evidence not determinable"
+      evidence_withheld = absence or (undeterminable and policy == "strict")
+      if evidence_withheld:
+        # A withheld handoff is an unsuccessful run even though the agent
+        # process exited normally, so the persisted status is failed with
+        # the verdict named as its cause (Section 19.2).
+        metrics.inc_handoff_transitions("withheld")
+        status = "failed"
+        run_error = handoff_evidence_failure(policy, evidence.verdict)
+      elif evidence.verdict == "work observed":
+        evidence_work_observed = true
+
+  sqlite.persist_run_attempt(running_entry, status, run_error)
+
+  # The absence sequence is reconstructed from run_history rather than
+  # from a verdict column (Section 19.2), so both steps below follow the
+  # row written above: the reset marks that row as the end of the previous
+  # sequence, and the count reads only what follows the last reset. Work
+  # observed clears the sequence at once, ahead of the tracker write the
+  # handoff disposition may still attempt, so a failed write cannot
+  # restore the old count.
+  if evidence_work_observed:
+    sqlite.reset_handoff_absence_sequence(issue_id)
+  elif evidence_withheld:
+    absences = sqlite.consecutive_handoff_absences(issue_id)
+    ceiling = cfg.agent.max_sessions if cfg.agent.max_sessions > 0 else 3
+    log_warn("handoff withheld by evidence policy", evidence.verdict, absences)
+    if absences >= ceiling:
+      # The sequence stops at the ceiling: parking cancels the retry,
+      # releases the claim, and holds the issue out of dispatch until a
+      # later tick observes a release (Section 14.2).
+      park_issue(state, issue_id, reason="handoff_absence")
+      absence_parked = true
 
   if reason == normal:
     state.completed.add(issue_id)  # bookkeeping only
@@ -404,8 +471,8 @@ on_worker_exit(issue_id, reason, state):
     # drives issue state, park the issue instead of merely releasing the
     # claim, so it stays out of dispatch until a later tick observes a
     # release (Section 14.2).
-    if is_blocked_soft_stop(running_entry, worker_result):
-      if dispatch_drives_issue_state(running_entry):
+    if blocked_soft_stop:
+      if drives_state:
         park_issue(state, issue_id, reason="agent_blocked")
       else:
         cancel_retry(state, issue_id)
@@ -418,27 +485,33 @@ on_worker_exit(issue_id, reason, state):
     # dispatch-time snapshot) reports a terminal state. Overwriting a
     # terminal decision with the handoff state would undo it, so no
     # handoff, retry, or reaction follows.
-    observation = resolve_terminal_observation(running_entry, worker_result)
-    if is_terminal_state(observation, cfg.tracker.terminal_states):
+    if terminal:
       cancel_retry(state, issue_id)
       state.claimed.remove(issue_id)
       log_info("handoff suppressed for terminal issue", observation)
       notify_observers()
       return state
 
-    # The resolved observation feeds the terminal test above and nothing
-    # else. The active test reads the dispatch-time snapshot, because the
-    # most common non-active state at a normal exit is the handoff state
-    # itself, applied by the agent through its own tracker calls.
-    is_active = is_active_state(running_entry.issue.state, cfg.tracker.active_states)
-    drives_state = dispatch_drives_issue_state(running_entry)
-    handoff_taken = false
-
     # Disposition 3: a handoff state is configured, the issue is still
-    # active, and the dispatch drives issue state. Perform the handoff
-    # transition (Section 11.5).
-    if cfg.tracker.handoff_state is not empty and is_active and drives_state:
-      handoff_taken = true
+    # active, and the dispatch drives issue state. The evidence verdict
+    # resolved above decides which arm runs: a verdict that permits the
+    # write performs the handoff transition (Section 11.5), and one that
+    # withholds it makes no tracker write at all.
+    if handoff_path and evidence_withheld:
+      # A withheld verdict makes no tracker transition and leaves the
+      # issue in its active state. The exit is a failure even though the
+      # agent process exited normally, so it takes the ordinary
+      # exponential-backoff failure lane under the same retry-slot
+      # arbitration, not the short continuation lane. Parking at the
+      # ceiling above already cancelled the sequence and released the
+      # claim, so nothing further is scheduled for it here.
+      if not absence_parked and retry_slot_incumbent(state, issue_id) is nil:
+        state = schedule_retry(state, issue_id, next_attempt_from(running_entry), {
+          identifier: running_entry.identifier,
+          error: format("worker exited: %run_error")
+        })
+
+    elif handoff_path:
       result = perform_handoff_transition(issue_id, cfg.tracker.handoff_state)
       if result.ok:
         if retry_slot_incumbent(state, issue_id) is nil:
@@ -502,7 +575,7 @@ on_worker_exit(issue_id, reason, state):
     # disposition 6, and its retained claim counts as released here
     # exactly as an ordinary released claim would.
     still_claimed = (issue_id in state.claimed) and not claim_protected_for_incumbent
-    if was_claimed and (handoff_taken or still_claimed):
+    if was_claimed and (handoff_path or still_claimed):
       scm = read_scm_metadata(workspace_path) if workspace_path is not empty else nil
 
       # CI is rewritten on every exit so it always carries the ref the

--- a/docs/architecture/21-reference-algorithms.md
+++ b/docs/architecture/21-reference-algorithms.md
@@ -386,7 +386,7 @@ function run_agent_attempt(issue, attempt, orchestrator_channel):
 ### 16.6 Worker Exit and Retry Handling
 
 ```text
-on_worker_exit(issue_id, reason, state):
+on_worker_exit(issue_id, reason, worker_result, state):
   running_entry = state.running.remove(issue_id)
   state = add_runtime_seconds_to_totals(state, running_entry)
 


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Chore

**Intent:** Section 16.6's `on_worker_exit` pseudo-code enumerated six ordered dispositions with no arm for the handoff evidence verdict, so a reader implementing from it alone would always advance the issue when a handoff transition is configured, contradicting the shipped behaviour and the rest of the specification. This brings the reference algorithm into agreement with the authoritative disposition list in `docs/architecture/07-orchestration-state-machine.md`.

**Related Issues:** #855

### 🧭 Reviewer Guide

**Complexity:** Low

#### Entry Point

`docs/architecture/21-reference-algorithms.md`, section 16.6 (`on_worker_exit`). The evidence verdict is now resolved as a fifth condition on the handoff disposition: a withheld verdict persists a failed status naming the verdict as its cause, counts on `sortie_handoff_transitions_total{result="withheld"}`, and takes the ordinary backoff retry lane instead of a tracker write. The consecutive-absence park and its release on observed work are folded in as well, since the pseudo-code previously omitted both.

#### Sensitive Areas

- `docs/architecture/19-failure-model-and-recovery-strategy.md`: corrects the park-release wording to include the worker-exit release (a verdict of `work observed`) alongside the two operator gestures, so the release rule stays consistent with section 21's pseudo-code.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes
- **Migrations/State:** No migrations or state changes