### PR TITLE
fix(scm/gitlab): resolve manual pipeline status from its job set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,6 +129,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   moving them instead.
   ([#811](https://github.com/sortie-ai/sortie/issues/811))
 
+- GitLab: a merge request whose pipeline is waiting on a manual job is
+  no longer held out of auto-merge indefinitely. Such a pipeline was
+  reported as still running on every poll, so the auto-merge entry
+  expired on its timeout and the merge fell to a person. The verdict
+  now follows the pipeline's own jobs: one waiting only on manual jobs
+  counts as passing, one that also holds a failed job reports failing
+  instead of looking identical to a healthy one, and one with work
+  still queued stays pending. Reading a pipeline in this state costs
+  one extra API call per poll; every other pipeline state is unchanged.
+  ([#827](https://github.com/sortie-ai/sortie/issues/827))
+
 ### Migrations
 
 - Add the `handoff_absence_resets` table, recording per issue where its

--- a/internal/scm/gitlab/ci.go
+++ b/internal/scm/gitlab/ci.go
@@ -58,20 +58,6 @@ type gitlabCommitPipeline struct {
 	ID int64 `json:"id"`
 }
 
-// gitlabCommitStatus is one entry of the commit-status list. The list
-// mixes runner jobs and externally reported statuses, and no field
-// separates them, so ID is what the log-excerpt read tests against the
-// pipeline's job set. PipelineID is what the scope filter tests against
-// the pipeline the read asked for.
-type gitlabCommitStatus struct {
-	ID           int64  `json:"id"`
-	Name         string `json:"name"`
-	Status       string `json:"status"`
-	AllowFailure bool   `json:"allow_failure"`
-	TargetURL    string `json:"target_url"`
-	PipelineID   int64  `json:"pipeline_id"`
-}
-
 // gitlabPipelineJob is one entry of the pipeline-jobs list, read only to
 // decide whether a failing commit-status entry is a job whose trace can
 // be fetched.
@@ -206,7 +192,7 @@ func (p *GitLabCIProvider) resolveCommit(ctx context.Context, ref string) (strin
 // walk returns is passed through unconverted for the caller to apply
 // [scmcore.ToCIError].
 func (p *GitLabCIProvider) fetchCommitStatuses(ctx context.Context, sha string, pipelineID int64) ([]gitlabCommitStatus, error) {
-	path := "/projects/" + p.project + "/repository/commits/" + url.PathEscape(sha) + "/statuses"
+	path := commitStatusesPath(p.project, sha)
 	params := url.Values{
 		"per_page":    {"100"},
 		"pipeline_id": {strconv.FormatInt(pipelineID, 10)},
@@ -236,43 +222,7 @@ func (p *GitLabCIProvider) fetchCommitStatuses(ctx context.Context, sha string, 
 		return nil, err
 	}
 
-	kept := make([]gitlabCommitStatus, 0, len(all))
-	for _, entry := range all {
-		if entry.PipelineID == pipelineID {
-			kept = append(kept, entry)
-		}
-	}
-	return kept, nil
-}
-
-// mapJobOutcome maps a commit-status entry's status and allow_failure to
-// its normalized conclusion and run status. recognized is false when
-// status matches no known value, in which case the pair is the same
-// [domain.CheckConclusionPending] / [domain.CheckRunStatusInProgress]
-// deferral the "running" arm produces, so an unrecognized status never
-// settles the aggregate.
-func mapJobOutcome(status string, allowFailure bool) (domain.CheckConclusion, domain.CheckRunStatus, bool) {
-	switch status {
-	case "success":
-		return domain.CheckConclusionSuccess, domain.CheckRunStatusCompleted, true
-	case "failed":
-		if allowFailure {
-			return domain.CheckConclusionNeutral, domain.CheckRunStatusCompleted, true
-		}
-		return domain.CheckConclusionFailure, domain.CheckRunStatusCompleted, true
-	case "canceled":
-		return domain.CheckConclusionCancelled, domain.CheckRunStatusCompleted, true
-	case "skipped":
-		return domain.CheckConclusionSkipped, domain.CheckRunStatusCompleted, true
-	case "manual":
-		return domain.CheckConclusionNeutral, domain.CheckRunStatusCompleted, true
-	case "created", "pending", "waiting_for_resource", "waiting_for_callback", "preparing", "scheduled":
-		return domain.CheckConclusionPending, domain.CheckRunStatusQueued, true
-	case "running", "canceling":
-		return domain.CheckConclusionPending, domain.CheckRunStatusInProgress, true
-	default:
-		return domain.CheckConclusionPending, domain.CheckRunStatusInProgress, false
-	}
+	return scopeToPipeline(all, pipelineID), nil
 }
 
 // fetchPipelineJobIDs walks every page of the pipeline-jobs route for
@@ -413,24 +363,7 @@ func (p *GitLabCIProvider) FetchCIStatus(ctx context.Context, ref string) (domai
 		}
 	}
 
-	runs := make([]domain.CheckRun, len(statuses))
-	var unknownCount int
-	var unknownExample string
-	for i, entry := range statuses {
-		conclusion, runStatus, recognized := mapJobOutcome(entry.Status, entry.AllowFailure)
-		if !recognized {
-			unknownCount++
-			if unknownExample == "" {
-				unknownExample = entry.Status
-			}
-		}
-		runs[i] = domain.CheckRun{
-			Name:       entry.Name,
-			Status:     runStatus,
-			Conclusion: conclusion,
-			DetailsURL: entry.TargetURL,
-		}
-	}
+	runs, unknownExample, unknownCount := normalizeCommitStatuses(statuses)
 	if unknownCount > 0 {
 		p.log.Warn("unrecognized gitlab job status",
 			slog.String("status", unknownExample),

--- a/internal/scm/gitlab/commitstatus.go
+++ b/internal/scm/gitlab/commitstatus.go
@@ -1,0 +1,121 @@
+package gitlab
+
+import (
+	"encoding/json"
+	"net/url"
+
+	"github.com/sortie-ai/sortie/internal/domain"
+)
+
+// gitlabCommitStatus is one entry of the commit-status list. The list
+// mixes runner jobs and externally reported statuses, and no field
+// separates them, so ID is what the log-excerpt read tests against the
+// pipeline's job set. PipelineID is what the scope filter tests against
+// the pipeline the read asked for, and both the log-excerpt read and the
+// merge gate apply that filter.
+type gitlabCommitStatus struct {
+	ID           int64  `json:"id"`
+	Name         string `json:"name"`
+	Status       string `json:"status"`
+	AllowFailure bool   `json:"allow_failure"`
+	TargetURL    string `json:"target_url"`
+	PipelineID   int64  `json:"pipeline_id"`
+}
+
+// mapJobOutcome maps a commit-status entry's status and allow_failure to
+// its normalized conclusion and run status. recognized is false when
+// status matches no known value, in which case the pair is the same
+// [domain.CheckConclusionPending] / [domain.CheckRunStatusInProgress]
+// deferral the "running" arm produces, so an unrecognized status never
+// settles the aggregate.
+func mapJobOutcome(status string, allowFailure bool) (domain.CheckConclusion, domain.CheckRunStatus, bool) {
+	switch status {
+	case "success":
+		return domain.CheckConclusionSuccess, domain.CheckRunStatusCompleted, true
+	case "failed":
+		if allowFailure {
+			return domain.CheckConclusionNeutral, domain.CheckRunStatusCompleted, true
+		}
+		return domain.CheckConclusionFailure, domain.CheckRunStatusCompleted, true
+	case "canceled":
+		return domain.CheckConclusionCancelled, domain.CheckRunStatusCompleted, true
+	case "skipped":
+		return domain.CheckConclusionSkipped, domain.CheckRunStatusCompleted, true
+	case "manual":
+		return domain.CheckConclusionNeutral, domain.CheckRunStatusCompleted, true
+	case "created", "pending", "waiting_for_resource", "waiting_for_callback", "preparing", "scheduled":
+		return domain.CheckConclusionPending, domain.CheckRunStatusQueued, true
+	case "running", "canceling":
+		return domain.CheckConclusionPending, domain.CheckRunStatusInProgress, true
+	default:
+		return domain.CheckConclusionPending, domain.CheckRunStatusInProgress, false
+	}
+}
+
+// commitStatusesPath builds the commit-status route for an
+// already-percent-encoded project segment and a commit SHA. sha is
+// percent-encoded inside this function.
+func commitStatusesPath(project, sha string) string {
+	return "/projects/" + project + "/repository/commits/" + url.PathEscape(sha) + "/statuses"
+}
+
+// scopeToPipeline returns, in input order, every entry of entries whose
+// PipelineID equals pipelineID. It accepts any input including nil and
+// always returns a non-nil slice. docs/gitlab-adapter-notes.md records
+// this filter as load-bearing rather than defensive: a commit carrying
+// two pipelines returns both pipelines' entries unfiltered on the wire.
+func scopeToPipeline(entries []gitlabCommitStatus, pipelineID int64) []gitlabCommitStatus {
+	scoped := make([]gitlabCommitStatus, 0, len(entries))
+	for _, entry := range entries {
+		if entry.PipelineID == pipelineID {
+			scoped = append(scoped, entry)
+		}
+	}
+	return scoped
+}
+
+// normalizeCommitStatuses maps each entry of entries to a
+// [domain.CheckRun] through [mapJobOutcome], preserving input order and
+// length. runs is a non-nil slice, empty rather than nil for a nil or
+// empty input. unrecognizedExample is the status of the first entry
+// mapJobOutcome did not recognize, or the empty string when every entry
+// was recognized; unrecognizedCount is how many entries it did not
+// recognize. normalizeCommitStatuses takes no logger; the caller emits
+// the WARN for an unrecognized status.
+func normalizeCommitStatuses(entries []gitlabCommitStatus) (runs []domain.CheckRun, unrecognizedExample string, unrecognizedCount int) {
+	runs = make([]domain.CheckRun, len(entries))
+	for i, entry := range entries {
+		conclusion, runStatus, recognized := mapJobOutcome(entry.Status, entry.AllowFailure)
+		if !recognized {
+			unrecognizedCount++
+			if unrecognizedExample == "" {
+				unrecognizedExample = entry.Status
+			}
+		}
+		runs[i] = domain.CheckRun{
+			Name:       entry.Name,
+			Status:     runStatus,
+			Conclusion: conclusion,
+			DetailsURL: entry.TargetURL,
+		}
+	}
+	return runs, unrecognizedExample, unrecognizedCount
+}
+
+// decodeCommitStatusPage JSON-decodes one page body of the commit-status
+// route into its entries. A decode failure returns a *[domain.SCMError]
+// of kind [domain.ErrSCMPayload]. This is the SCM-side counterpart to the
+// CI provider's own inline [*domain.CIError] decoder for the same route:
+// the two stay separate because the two readers return different error
+// types.
+func decodeCommitStatusPage(body []byte) ([]gitlabCommitStatus, error) {
+	var page []gitlabCommitStatus
+	if err := json.Unmarshal(body, &page); err != nil {
+		return nil, &domain.SCMError{
+			Kind:    domain.ErrSCMPayload,
+			Message: "failed to parse commit statuses response",
+			Err:     err,
+		}
+	}
+	return page, nil
+}

--- a/internal/scm/gitlab/integration_merge_test.go
+++ b/internal/scm/gitlab/integration_merge_test.go
@@ -221,11 +221,19 @@ func (f *gitlabMergeFixture) deleteBranch(t *testing.T, project, branch string) 
 }
 
 // awaitMergeability polls the merge request's detailed_merge_status with
-// a bounded number of tries until it leaves the computing set
-// (unchecked, checking, preparing, approvals_syncing), and returns
-// whatever status is observed last, settled or not; the caller decides
-// what a settled value other than the one it expects means.
-func (f *gitlabMergeFixture) awaitMergeability(t *testing.T, project string, iid int) string {
+// a bounded number of tries until it settles, and returns whatever status
+// is observed last, settled or not; the caller decides what a settled
+// value other than the one it expects means.
+//
+// A status counts as settled only when it lies outside the computing set
+// (unchecked, checking, preparing, approvals_syncing) and the merge
+// request's own head sha has caught up with wantSHA. GitLab reports the
+// identifier of the conflict check while that check is still running, so
+// a read taken before the merge-request diff is regenerated carries
+// "conflict" for a merge request that has none; such a read is
+// recognizable because its sha still lags the branch. An empty wantSHA
+// disables the sha gate. See gitlab-org/gitlab#608247.
+func (f *gitlabMergeFixture) awaitMergeability(t *testing.T, project string, iid int, wantSHA string) string {
 	t.Helper()
 
 	const maxAttempts = 10
@@ -246,7 +254,7 @@ func (f *gitlabMergeFixture) awaitMergeability(t *testing.T, project string, iid
 			t.Fatalf("unmarshal merge request response: %v", err)
 		}
 		status = mr.DetailedMergeStatus
-		if !computing[status] {
+		if !computing[status] && (wantSHA == "" || mr.SHA == wantSHA) {
 			return status
 		}
 		if attempt < maxAttempts-1 {
@@ -302,7 +310,7 @@ func TestIntegration_MergePR_ProtectedTarget(t *testing.T) {
 	head := "sortie-protected-head-" + suffix
 
 	fixture.createBranch(t, project, head, fixtureDefaultBranch(t, fixture, project))
-	fixture.commitFile(t, project, head, "sortie-protected-sentinel.txt", "protected target probe\n")
+	sentinelSHA := fixture.commitFile(t, project, head, "sortie-protected-sentinel.txt", "protected target probe\n")
 	iid := fixture.openMR(t, project, head, protectedBranch, "sortie protected target "+suffix)
 
 	t.Cleanup(func() {
@@ -310,7 +318,7 @@ func TestIntegration_MergePR_ProtectedTarget(t *testing.T) {
 		fixture.deleteBranch(t, project, head)
 	})
 
-	status := fixture.awaitMergeability(t, project, iid)
+	status := fixture.awaitMergeability(t, project, iid, sentinelSHA)
 	if status != "mergeable" {
 		t.Fatalf("merge request !%d detailed_merge_status = %q after polling, want %q", iid, status, "mergeable")
 	}
@@ -366,7 +374,7 @@ func TestIntegration_SCMMergeFlow(t *testing.T) {
 		fixture.deleteBranch(t, project, base)
 	})
 
-	var staleSHA, currentSHA string
+	var staleSHA, advancedSHA, currentSHA string
 
 	t.Run("GetMergeability", func(t *testing.T) {
 		status, err := adapter.GetMergeability(ctx, iid, owner, repo)
@@ -386,13 +394,36 @@ func TestIntegration_SCMMergeFlow(t *testing.T) {
 		// Advances the head, so staleSHA becomes valid but out of
 		// date, driving GitLab's stale-precondition rejection
 		// deterministically.
-		advancedSHA := fixture.commitFile(t, project, head, "sortie-merge-flow-advance.txt", "advance\n")
+		advancedSHA = fixture.commitFile(t, project, head, "sortie-merge-flow-advance.txt", "advance\n")
 		if advancedSHA == staleSHA {
 			t.Fatalf("commitFile did not advance the head past staleSHA %q", staleSHA)
 		}
 
+		// GitLab evaluates mergeability before the sha precondition, so a
+		// merge attempted while the push is still being processed is
+		// refused as unmergeable and never reaches the sha check at all.
+		// Letting the verdict settle against the pushed head is what makes
+		// the stale sha the reason this merge is rejected.
+		if status := fixture.awaitMergeability(t, project, iid, advancedSHA); status != "mergeable" {
+			t.Fatalf("merge request !%d detailed_merge_status = %q after polling, want %q",
+				iid, status, "mergeable")
+		}
+
 		_, err := adapter.MergePR(ctx, iid, owner, repo, domain.StrategySquash, "", "", staleSHA)
 		adaptertest.AssertSCMErrorKind(t, err, domain.ErrSCMConflict)
+
+		// ErrSCMConflict is promoted from both 405 and 409, so the kind
+		// alone cannot distinguish the stale-sha rejection this subtest
+		// exercises from a merge request GitLab refuses to merge for an
+		// unrelated reason. Only the 409 proves the precondition fired.
+		var te *domain.TrackerError
+		if !errors.As(err, &te) {
+			t.Fatalf("MergePR stale precondition error = %v, want a wrapped *domain.TrackerError", err)
+		}
+		if te.Status != http.StatusConflict {
+			t.Errorf("MergePR stale precondition HTTP status = %d, want %d for a stale-sha rejection",
+				te.Status, http.StatusConflict)
+		}
 
 		var se *domain.SCMError
 		if errors.As(err, &se) && strings.Contains(strings.ToLower(se.Message), "already merged") {
@@ -405,9 +436,10 @@ func TestIntegration_SCMMergeFlow(t *testing.T) {
 
 	t.Run("MergePR_HappyPath", func(t *testing.T) {
 		// The stale-precondition push makes GitLab recompute
-		// detailed_merge_status asynchronously; poll it out of the
-		// computing set before capturing the head SHA to merge with.
-		status := fixture.awaitMergeability(t, project, iid)
+		// detailed_merge_status asynchronously; poll until the verdict
+		// settles against that pushed head before capturing the head SHA
+		// to merge with.
+		status := fixture.awaitMergeability(t, project, iid, advancedSHA)
 		if status != "mergeable" {
 			t.Fatalf("merge request !%d detailed_merge_status = %q after polling, want %q", iid, status, "mergeable")
 		}

--- a/internal/scm/gitlab/scm_merge.go
+++ b/internal/scm/gitlab/scm_merge.go
@@ -36,8 +36,14 @@ type gitlabMergeRequest struct {
 // gitlabPipeline is the head_pipeline object embedded in a merge
 // request. The sibling top-level pipeline field is never decoded: it can
 // report null while head_pipeline is populated.
+//
+// ID and SHA address the pipeline's own job set. The merge request's own
+// sha is not interchangeable with SHA: nothing re-validates head_pipeline
+// against the current head, so the two can disagree.
 type gitlabPipeline struct {
 	Status string `json:"status"`
+	ID     int64  `json:"id"`
+	SHA    string `json:"sha"`
 }
 
 // fetchMergeRequest issues GET /projects/{projectPath}/merge_requests/{prNumber}
@@ -119,6 +125,25 @@ func (a *GitLabSCMAdapter) GetMergeability(ctx context.Context, prNumber int, ow
 	}, nil
 }
 
+// fetchPipelineStatuses walks every page of the commit-status route for
+// sha, scoped to pipelineID both on the wire, via the pipeline_id query
+// parameter, and again after decoding, through [scopeToPipeline].
+//
+// sha is percent-encoded inside [commitStatusesPath]. A decode failure
+// returns a [*domain.SCMError] of kind [domain.ErrSCMPayload]; any other
+// error is whatever [scmcore.AsSCMError] yields for the underlying
+// transport or HTTP failure, propagated unchanged from [paginateSCM].
+func (a *GitLabSCMAdapter) fetchPipelineStatuses(ctx context.Context, owner, repo, sha string, pipelineID int64) ([]gitlabCommitStatus, error) {
+	path := commitStatusesPath(projectPath(owner, repo), sha)
+	params := url.Values{"pipeline_id": {strconv.FormatInt(pipelineID, 10)}}
+
+	entries, err := paginateSCM(ctx, a.client, a.log, path, params, decodeCommitStatusPage)
+	if err != nil {
+		return nil, err
+	}
+	return scopeToPipeline(entries, pipelineID), nil
+}
+
 // mapPipelineStatus classifies a GitLab head_pipeline.status value into
 // the merge-gate vocabulary. recognized is false for any value outside
 // the platform's pipeline-status enum, including the empty string, in
@@ -126,10 +151,10 @@ func (a *GitLabSCMAdapter) GetMergeability(ctx context.Context, prNumber int, ow
 // rather than guessing a more permissive verdict.
 //
 // manual sits in the CIGatePending arm by name rather than by falling
-// through the default: the platform reports manual for a pipeline that
-// has settled, not one still running, but its job set can still carry a
-// failed job alongside the untriggered manual one, so the gate holds
-// until that shape is resolved on its own.
+// through the default: it is the conservative answer this classifier
+// gives when asked about a status its merge-gate caller, [GitLabSCMAdapter.GetCIStatus],
+// resolves for itself from that pipeline's own job set, rather than a
+// value the gate holds until the shape settles on its own.
 func mapPipelineStatus(status string) (gate scmcore.CIGate, recognized bool) {
 	switch status {
 	case "success", "skipped":
@@ -150,13 +175,15 @@ func mapPipelineStatus(status string) (gate scmcore.CIGate, recognized bool) {
 // [scmcore.CIGatePending], or [scmcore.CIGateFailing], or the empty
 // [scmcore.CIGateAbsent] when the head carries no pipeline. A skipped
 // pipeline resolves to CIGateSuccess, since the platform reports it only
-// for a job set with no failing conclusion. A manual pipeline resolves
-// to CIGatePending regardless of settlement, because the platform can
-// report it for a job set that still carries a failed job. A status
-// outside the recognized set logs one WARN naming the observed value so
-// a stalled gate is diagnosable at the tick it stalls. The platform
-// already folds externally reported commit statuses into head_pipeline,
-// so no second request is issued.
+// for a job set with no failing conclusion. A manual pipeline resolves to
+// the verdict computed over that pipeline's own job set, through
+// [GitLabSCMAdapter.manualGate]; an empty job set holds at CIGatePending
+// rather than reporting the absent value. A status outside the recognized
+// set logs one WARN naming the observed value so a stalled gate is
+// diagnosable at the tick it stalls. The platform already folds
+// externally reported commit statuses into head_pipeline for the twelve
+// other statuses, so no second request is issued for them; manual is the
+// exception that pays for one job-set read.
 func (a *GitLabSCMAdapter) GetCIStatus(ctx context.Context, prNumber int, owner, repo string) (string, error) {
 	mr, err := a.fetchMergeRequest(ctx, prNumber, owner, repo)
 	if err != nil {
@@ -165,11 +192,56 @@ func (a *GitLabSCMAdapter) GetCIStatus(ctx context.Context, prNumber int, owner,
 	if mr.HeadPipeline == nil {
 		return string(scmcore.CIGateAbsent), nil
 	}
+	if mr.HeadPipeline.Status == "manual" {
+		return a.manualGate(ctx, owner, repo, mr.HeadPipeline)
+	}
 
 	gate, recognized := mapPipelineStatus(mr.HeadPipeline.Status)
 	if !recognized {
 		a.log.Warn("unrecognized gitlab pipeline status",
 			slog.String("pipeline_status", mr.HeadPipeline.Status))
+	}
+	return string(gate), nil
+}
+
+// manualGate resolves the merge-gate verdict for a manual head pipeline
+// from that pipeline's own job set, folded through [scmcore.MergeGate].
+//
+// A missing sha or a zero id returns a [*domain.SCMError] of kind
+// [domain.ErrSCMPayload] and issues no request: the platform answers a
+// zero pipeline scope with an empty set rather than an error, which would
+// otherwise make the anomaly invisible. A job-set read failure is
+// returned unchanged, never degraded to a verdict. An unrecognized job
+// status logs one WARN naming it. A scoped job set that folds to
+// [scmcore.CIGateAbsent] logs one WARN naming the pipeline id and holds
+// at [scmcore.CIGatePending] rather than reporting the absent value,
+// because the platform never reports manual for a job set with no
+// entries, so an empty scoped set here means the read was mis-addressed.
+func (a *GitLabSCMAdapter) manualGate(ctx context.Context, owner, repo string, pipeline *gitlabPipeline) (string, error) {
+	if pipeline.SHA == "" || pipeline.ID == 0 {
+		return "", &domain.SCMError{
+			Kind:    domain.ErrSCMPayload,
+			Message: "head pipeline missing sha or id",
+		}
+	}
+
+	entries, err := a.fetchPipelineStatuses(ctx, owner, repo, pipeline.SHA, pipeline.ID)
+	if err != nil {
+		return "", err
+	}
+
+	runs, unrecognizedExample, unrecognizedCount := normalizeCommitStatuses(entries)
+	if unrecognizedCount > 0 {
+		a.log.Warn("unrecognized gitlab job status",
+			slog.String("status", unrecognizedExample),
+			slog.Int("count", unrecognizedCount))
+	}
+
+	gate := scmcore.MergeGate(runs)
+	if gate == scmcore.CIGateAbsent {
+		a.log.Warn("manual head pipeline carried no job status",
+			slog.Int64("pipeline_id", pipeline.ID))
+		return string(scmcore.CIGatePending), nil
 	}
 	return string(gate), nil
 }

--- a/internal/scm/gitlab/scm_merge_test.go
+++ b/internal/scm/gitlab/scm_merge_test.go
@@ -308,8 +308,17 @@ func TestGetCIStatus_PipelineStatusEnumAgreement(t *testing.T) {
 			}
 			want := string(scmcore.MergeGate(runs))
 
-			fixture := mergeRequestFixture(t, map[string]any{"head_pipeline": map[string]any{"status": status}})
-			srv := serveJSON(t, fixture)
+			var srv *httptest.Server
+			if status == "manual" {
+				mrFixture := manualHeadPipelineFixture(t, manualPipelineSHA, manualPipelineID, nil)
+				srv = mergeRequestAndStatusesServer(t, mrFixture, func(w http.ResponseWriter, r *http.Request) {
+					w.Header().Set("Content-Type", "application/json")
+					_, _ = w.Write(manualJobSetBody(t))
+				})
+			} else {
+				fixture := mergeRequestFixture(t, map[string]any{"head_pipeline": map[string]any{"status": status}})
+				srv = serveJSON(t, fixture)
+			}
 			defer srv.Close()
 
 			adapter := mustSCMAdapter(t, srv.URL)
@@ -321,14 +330,7 @@ func TestGetCIStatus_PipelineStatusEnumAgreement(t *testing.T) {
 				t.Fatalf("GetCIStatus: unexpected error: %v", err)
 			}
 
-			if status == "manual" {
-				if got != string(scmcore.CIGatePending) {
-					t.Errorf("GetCIStatus() for pipeline status %q = %q, want %q", status, got, string(scmcore.CIGatePending))
-				}
-				if got == want {
-					t.Errorf("GetCIStatus() for pipeline status %q = %q, want it to differ from the computed fold %q (manual is a deliberate divergence)", status, got, want)
-				}
-			} else if got != want {
+			if got != want {
 				t.Errorf("GetCIStatus() for pipeline status %q = %q, want %q (the fold of mapJobOutcome(%q, false) through scmcore.MergeGate)", status, got, want, status)
 			}
 
@@ -345,21 +347,171 @@ func TestGetCIStatus_PipelineStatusEnumAgreement(t *testing.T) {
 func TestGetCIStatus_SingleRequestRouteScope(t *testing.T) {
 	t.Parallel()
 
-	fixture := mergeRequestFixture(t, map[string]any{"head_pipeline": map[string]any{"status": "success"}})
-
 	wantSuffix := "/merge_requests/" + strconv.Itoa(testPRNumber)
 
-	var requests atomic.Int32
+	run := func(t *testing.T, overrides map[string]any) {
+		t.Helper()
+
+		fixture := mergeRequestFixture(t, overrides)
+
+		var requests atomic.Int32
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			requests.Add(1)
+			if strings.Contains(r.URL.Path, "/statuses") || strings.Contains(r.URL.Path, "/pipelines") || strings.Contains(r.URL.Path, "/jobs") {
+				t.Errorf("unexpected request to %s, want only the merge-request read", r.URL.Path)
+			}
+			if !strings.HasSuffix(r.URL.Path, wantSuffix) {
+				t.Errorf("request path = %q, want it to end with %q", r.URL.Path, wantSuffix)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write(fixture)
+		}))
+		defer srv.Close()
+
+		adapter := mustSCMAdapter(t, srv.URL)
+		if _, err := adapter.GetCIStatus(context.Background(), testPRNumber, scmOwner, scmRepo); err != nil {
+			t.Fatalf("GetCIStatus: unexpected error: %v", err)
+		}
+
+		if n := requests.Load(); n != 1 {
+			t.Errorf("requests = %d, want 1 (GetCIStatus must issue exactly one request)", n)
+		}
+	}
+
+	statuses := []string{
+		"created", "waiting_for_resource", "preparing", "waiting_for_callback",
+		"pending", "running", "success", "failed", "canceling", "canceled",
+		"skipped", "scheduled",
+	}
+	for _, status := range statuses {
+		t.Run(status, func(t *testing.T) {
+			t.Parallel()
+			run(t, map[string]any{"head_pipeline": map[string]any{"status": status}})
+		})
+	}
+
+	t.Run("absent head_pipeline", func(t *testing.T) {
+		t.Parallel()
+		run(t, map[string]any{"head_pipeline": nil})
+	})
+}
+
+// --- GetCIStatus: manual head pipeline job-set fold ---
+
+// manualPipelineSHA and manualPipelineID are the full 40-character sha
+// and pipeline id every manual-path test below addresses the statuses
+// route with, so the addressing guard never rejects a fixture as
+// abbreviated or scopeless.
+const (
+	manualPipelineSHA = "aaaa1111bbbb2222cccc3333dddd4444eeee5555"
+	manualPipelineID  = int64(9001)
+)
+
+// manualHeadPipelineFixture returns a merge-request fixture whose
+// head_pipeline reports "manual" at sha and pipelineID, with any
+// additional top-level merge-request field overrides applied on top.
+func manualHeadPipelineFixture(t *testing.T, sha string, pipelineID int64, overrides map[string]any) []byte {
+	t.Helper()
+
+	fields := map[string]any{
+		"head_pipeline": map[string]any{
+			"status": "manual",
+			"id":     pipelineID,
+			"sha":    sha,
+		},
+	}
+	maps.Copy(fields, overrides)
+	return mergeRequestFixture(t, fields)
+}
+
+// commitStatusEntry returns one commit-status wire entry with
+// allow_failure false, which every manual-path job-set shape below
+// carries.
+func commitStatusEntry(id int64, name, status string, pipelineID int64) map[string]any {
+	return map[string]any{
+		"id":            id,
+		"name":          name,
+		"status":        status,
+		"allow_failure": false,
+		"target_url":    nil,
+		"pipeline_id":   pipelineID,
+	}
+}
+
+// commitStatusesJSON marshals entries into a commit-status page body, or
+// fails the test.
+func commitStatusesJSON(t *testing.T, entries []map[string]any) []byte {
+	t.Helper()
+
+	body, err := json.Marshal(entries)
+	if err != nil {
+		t.Fatalf("marshal commit statuses: %v", err)
+	}
+	return body
+}
+
+// manualJobSetBody returns the "manual plus manual, nothing else" job
+// set the documentation's shape table folds to success, scoped to
+// manualPipelineID.
+func manualJobSetBody(t *testing.T) []byte {
+	t.Helper()
+
+	return commitStatusesJSON(t, []map[string]any{
+		commitStatusEntry(1, "gate-a", "manual", manualPipelineID),
+		commitStatusEntry(2, "gate-b", "manual", manualPipelineID),
+	})
+}
+
+// mergeRequestAndStatusesServer serves mrFixture from the merge-request
+// detail route and delegates any request whose path contains "/statuses"
+// to statusesHandler. Any other path fails the test, so a read
+// mis-addressed at a route other than the two the manual path is allowed
+// to use cannot pass silently.
+func mergeRequestAndStatusesServer(t *testing.T, mrFixture []byte, statusesHandler http.HandlerFunc) *httptest.Server {
+	t.Helper()
+
+	wantMRSuffix := "/merge_requests/" + strconv.Itoa(testPRNumber)
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.Contains(r.URL.Path, "/statuses"):
+			statusesHandler(w, r)
+		case strings.HasSuffix(r.URL.Path, wantMRSuffix):
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write(mrFixture)
+		default:
+			t.Errorf("unexpected request to %s, want the merge-request detail route or the statuses route", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+}
+
+func TestGetCIStatus_ManualRequestShape(t *testing.T) {
+	t.Parallel()
+
+	const mrSHA = "0000111122223333444455556666777788889999"
+
+	mrFixture := manualHeadPipelineFixture(t, manualPipelineSHA, manualPipelineID, map[string]any{"sha": mrSHA})
+	statusesBody := manualJobSetBody(t)
+
+	wantMRSuffix := "/merge_requests/" + strconv.Itoa(testPRNumber)
+	wantStatusesSuffix := "/repository/commits/" + manualPipelineSHA + "/statuses"
+
+	var requestPaths []string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		requests.Add(1)
-		if strings.Contains(r.URL.Path, "/statuses") || strings.Contains(r.URL.Path, "/pipelines") || strings.Contains(r.URL.Path, "/jobs") {
-			t.Errorf("unexpected request to %s, want only the merge-request read", r.URL.Path)
-		}
-		if !strings.HasSuffix(r.URL.Path, wantSuffix) {
-			t.Errorf("request path = %q, want it to end with %q", r.URL.Path, wantSuffix)
-		}
+		requestPaths = append(requestPaths, r.URL.Path)
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write(fixture)
+		switch {
+		case strings.HasSuffix(r.URL.Path, wantStatusesSuffix):
+			if got := r.URL.Query().Get("pipeline_id"); got != strconv.FormatInt(manualPipelineID, 10) {
+				t.Errorf("statuses request pipeline_id query param = %q, want %q", got, strconv.FormatInt(manualPipelineID, 10))
+			}
+			_, _ = w.Write(statusesBody)
+		case strings.HasSuffix(r.URL.Path, wantMRSuffix):
+			_, _ = w.Write(mrFixture)
+		default:
+			t.Errorf("unexpected request to %s", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
 	}))
 	defer srv.Close()
 
@@ -368,9 +520,362 @@ func TestGetCIStatus_SingleRequestRouteScope(t *testing.T) {
 		t.Fatalf("GetCIStatus: unexpected error: %v", err)
 	}
 
-	if n := requests.Load(); n != 1 {
-		t.Errorf("requests = %d, want 1 (GetCIStatus must issue exactly one request)", n)
+	if len(requestPaths) != 2 {
+		t.Fatalf("requests = %d, want 2 (the merge-request read then one statuses request); paths: %v", len(requestPaths), requestPaths)
 	}
+	if !strings.HasSuffix(requestPaths[0], wantMRSuffix) {
+		t.Errorf("first request path = %q, want it to end with %q", requestPaths[0], wantMRSuffix)
+	}
+	if !strings.HasSuffix(requestPaths[1], wantStatusesSuffix) {
+		t.Errorf("second request path = %q, want it to end with %q (the merge request's own sha %q must not be addressed)", requestPaths[1], wantStatusesSuffix, mrSHA)
+	}
+}
+
+func TestGetCIStatus_ManualJobSetShapes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		entries []map[string]any
+		want    string
+	}{
+		{
+			"manual plus failed, same stage, folds to failing",
+			[]map[string]any{
+				commitStatusEntry(1, "manual-gate", "manual", manualPipelineID),
+				commitStatusEntry(2, "failing-job", "failed", manualPipelineID),
+			},
+			"failing",
+		},
+		{
+			"success plus manual plus failed, needs DAG, folds to failing",
+			[]map[string]any{
+				commitStatusEntry(1, "build-job", "success", manualPipelineID),
+				commitStatusEntry(2, "manual-gate", "manual", manualPipelineID),
+				commitStatusEntry(3, "failing-job", "failed", manualPipelineID),
+			},
+			"failing",
+		},
+		{
+			"manual plus manual, nothing else, folds to success",
+			[]map[string]any{
+				commitStatusEntry(1, "manual-one", "manual", manualPipelineID),
+				commitStatusEntry(2, "manual-two", "manual", manualPipelineID),
+			},
+			"success",
+		},
+		{
+			"manual gate blocking a later-stage created job folds to pending, not a merge-eligible verdict",
+			[]map[string]any{
+				commitStatusEntry(1, "manual-gate", "manual", manualPipelineID),
+				commitStatusEntry(2, "deploy-job", "created", manualPipelineID),
+			},
+			"pending",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			mrFixture := manualHeadPipelineFixture(t, manualPipelineSHA, manualPipelineID, nil)
+			statusesBody := commitStatusesJSON(t, tt.entries)
+			srv := mergeRequestAndStatusesServer(t, mrFixture, func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write(statusesBody)
+			})
+			defer srv.Close()
+
+			adapter := mustSCMAdapter(t, srv.URL)
+			got, err := adapter.GetCIStatus(context.Background(), testPRNumber, scmOwner, scmRepo)
+			if err != nil {
+				t.Fatalf("GetCIStatus: unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("GetCIStatus() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetCIStatus_ManualReadFailure(t *testing.T) {
+	t.Parallel()
+
+	t.Run("a non-2xx statuses read yields an error and the empty string", func(t *testing.T) {
+		t.Parallel()
+
+		mrFixture := manualHeadPipelineFixture(t, manualPipelineSHA, manualPipelineID, nil)
+		srv := mergeRequestAndStatusesServer(t, mrFixture, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write(loadFixture(t, "error_500.json"))
+		})
+		defer srv.Close()
+
+		adapter := mustSCMAdapter(t, srv.URL)
+		got, err := adapter.GetCIStatus(context.Background(), testPRNumber, scmOwner, scmRepo)
+		if got != "" {
+			t.Errorf("GetCIStatus() = %q, want empty string on a failed job-set read", got)
+		}
+		adaptertest.AssertSCMErrorKind(t, err, domain.ErrSCMTransport)
+	})
+
+	t.Run("an undecodable statuses body yields ErrSCMPayload", func(t *testing.T) {
+		t.Parallel()
+
+		mrFixture := manualHeadPipelineFixture(t, manualPipelineSHA, manualPipelineID, nil)
+		srv := mergeRequestAndStatusesServer(t, mrFixture, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`not valid json {{{`))
+		})
+		defer srv.Close()
+
+		adapter := mustSCMAdapter(t, srv.URL)
+		got, err := adapter.GetCIStatus(context.Background(), testPRNumber, scmOwner, scmRepo)
+		if got != "" {
+			t.Errorf("GetCIStatus() = %q, want empty string on a decode failure", got)
+		}
+		adaptertest.AssertSCMErrorKind(t, err, domain.ErrSCMPayload)
+	})
+}
+
+func TestGetCIStatus_ManualPagination(t *testing.T) {
+	t.Parallel()
+
+	mrFixture := manualHeadPipelineFixture(t, manualPipelineSHA, manualPipelineID, nil)
+	page1 := commitStatusesJSON(t, []map[string]any{
+		commitStatusEntry(1, "manual-gate", "manual", manualPipelineID),
+	})
+	page2 := commitStatusesJSON(t, []map[string]any{
+		commitStatusEntry(2, "failing-job", "failed", manualPipelineID),
+	})
+	statusesSuffix := "/repository/commits/" + manualPipelineSHA + "/statuses"
+
+	var srv *httptest.Server
+	srv = mergeRequestAndStatusesServer(t, mrFixture, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Query().Get("page") == "2" {
+			_, _ = w.Write(page2)
+			return
+		}
+		w.Header().Set("Link", `<`+srv.URL+statusesSuffix+`?page=2>; rel="next"`)
+		_, _ = w.Write(page1)
+	})
+	defer srv.Close()
+
+	adapter := mustSCMAdapter(t, srv.URL)
+	got, err := adapter.GetCIStatus(context.Background(), testPRNumber, scmOwner, scmRepo)
+	if err != nil {
+		t.Fatalf("GetCIStatus: unexpected error: %v", err)
+	}
+	if got != "failing" {
+		t.Errorf("GetCIStatus() = %q, want %q (the failing entry on the second page must be folded in)", got, "failing")
+	}
+}
+
+func TestGetCIStatus_ManualScoping(t *testing.T) {
+	t.Parallel()
+
+	t.Run("an empty scoped job set yields pending, not the empty string", func(t *testing.T) {
+		t.Parallel()
+
+		mrFixture := manualHeadPipelineFixture(t, manualPipelineSHA, manualPipelineID, nil)
+		srv := mergeRequestAndStatusesServer(t, mrFixture, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`[]`))
+		})
+		defer srv.Close()
+
+		adapter := mustSCMAdapter(t, srv.URL)
+		got, err := adapter.GetCIStatus(context.Background(), testPRNumber, scmOwner, scmRepo)
+		if err != nil {
+			t.Fatalf("GetCIStatus: unexpected error: %v", err)
+		}
+		if got == "" {
+			t.Errorf("GetCIStatus() = %q, want a non-empty verdict (an empty job set must not report CIGateAbsent)", got)
+		}
+		if got != "pending" {
+			t.Errorf("GetCIStatus() = %q, want %q", got, "pending")
+		}
+	})
+
+	t.Run("entries carrying a foreign pipeline_id are discarded after decoding", func(t *testing.T) {
+		t.Parallel()
+
+		const foreignPipelineID = int64(4242)
+
+		mrFixture := manualHeadPipelineFixture(t, manualPipelineSHA, manualPipelineID, nil)
+		statusesBody := commitStatusesJSON(t, []map[string]any{
+			commitStatusEntry(1, "manual-one", "manual", manualPipelineID),
+			commitStatusEntry(2, "manual-two", "manual", manualPipelineID),
+			commitStatusEntry(3, "foreign-failing-job", "failed", foreignPipelineID),
+		})
+		srv := mergeRequestAndStatusesServer(t, mrFixture, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write(statusesBody)
+		})
+		defer srv.Close()
+
+		adapter := mustSCMAdapter(t, srv.URL)
+		got, err := adapter.GetCIStatus(context.Background(), testPRNumber, scmOwner, scmRepo)
+		if err != nil {
+			t.Fatalf("GetCIStatus: unexpected error: %v", err)
+		}
+		if got != "success" {
+			t.Errorf("GetCIStatus() = %q, want %q (the foreign pipeline's failing entry must be discarded)", got, "success")
+		}
+	})
+}
+
+func TestGetCIStatus_ManualPayloadGuard(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		sha  string
+		id   int64
+	}{
+		{"empty sha issues no statuses request", "", manualPipelineID},
+		{"zero id issues no statuses request", manualPipelineSHA, 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			mrFixture := manualHeadPipelineFixture(t, tt.sha, tt.id, nil)
+
+			var requests atomic.Int32
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				requests.Add(1)
+				if strings.Contains(r.URL.Path, "/statuses") {
+					t.Errorf("unexpected request to %s, want no statuses request", r.URL.Path)
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write(mrFixture)
+			}))
+			defer srv.Close()
+
+			adapter := mustSCMAdapter(t, srv.URL)
+			got, err := adapter.GetCIStatus(context.Background(), testPRNumber, scmOwner, scmRepo)
+			if got != "" {
+				t.Errorf("GetCIStatus() = %q, want empty string", got)
+			}
+			adaptertest.AssertSCMErrorKind(t, err, domain.ErrSCMPayload)
+
+			if n := requests.Load(); n != 1 {
+				t.Errorf("requests = %d, want 1 (the merge-request read alone; no statuses request)", n)
+			}
+		})
+	}
+}
+
+func TestMapPipelineStatus_RecognizesAllStatuses(t *testing.T) {
+	t.Parallel()
+
+	statuses := []string{
+		"created", "waiting_for_resource", "preparing", "waiting_for_callback",
+		"pending", "running", "success", "failed", "canceling", "canceled",
+		"skipped", "scheduled", "manual",
+	}
+
+	for _, status := range statuses {
+		t.Run(status, func(t *testing.T) {
+			t.Parallel()
+
+			_, recognized := mapPipelineStatus(status)
+			if !recognized {
+				t.Errorf("mapPipelineStatus(%q) recognized = false, want true", status)
+			}
+		})
+	}
+}
+
+func TestGetCIStatus_ManualWarnings(t *testing.T) {
+	t.Parallel()
+
+	t.Run("an unrecognized job status logs one WARN", func(t *testing.T) {
+		t.Parallel()
+
+		mrFixture := manualHeadPipelineFixture(t, manualPipelineSHA, manualPipelineID, nil)
+		statusesBody := commitStatusesJSON(t, []map[string]any{
+			commitStatusEntry(1, "manual-gate", "manual", manualPipelineID),
+			commitStatusEntry(2, "odd-job", "expired", manualPipelineID),
+		})
+		srv := mergeRequestAndStatusesServer(t, mrFixture, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write(statusesBody)
+		})
+		defer srv.Close()
+
+		adapter := mustSCMAdapter(t, srv.URL)
+		log, buf := newCapturingLogger()
+		adapter.log = log
+
+		if _, err := adapter.GetCIStatus(context.Background(), testPRNumber, scmOwner, scmRepo); err != nil {
+			t.Fatalf("GetCIStatus: unexpected error: %v", err)
+		}
+
+		logOutput := buf.String()
+		if n := strings.Count(logOutput, "unrecognized gitlab job status"); n != 1 {
+			t.Errorf("occurrences of %q in log output = %d, want 1 (log output: %q)", "unrecognized gitlab job status", n, logOutput)
+		}
+		if !strings.Contains(logOutput, "status=expired") {
+			t.Errorf("log output = %q, want it to carry the observed status as an attribute", logOutput)
+		}
+	})
+
+	t.Run("every entry recognized logs no WARN", func(t *testing.T) {
+		t.Parallel()
+
+		mrFixture := manualHeadPipelineFixture(t, manualPipelineSHA, manualPipelineID, nil)
+		statusesBody := manualJobSetBody(t)
+		srv := mergeRequestAndStatusesServer(t, mrFixture, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write(statusesBody)
+		})
+		defer srv.Close()
+
+		adapter := mustSCMAdapter(t, srv.URL)
+		log, buf := newCapturingLogger()
+		adapter.log = log
+
+		if _, err := adapter.GetCIStatus(context.Background(), testPRNumber, scmOwner, scmRepo); err != nil {
+			t.Fatalf("GetCIStatus: unexpected error: %v", err)
+		}
+
+		if logOutput := buf.String(); strings.Contains(logOutput, "unrecognized gitlab job status") {
+			t.Errorf("log output = %q, want no unrecognized-status WARN", logOutput)
+		}
+	})
+
+	t.Run("an empty scoped job set logs one WARN carrying the pipeline id", func(t *testing.T) {
+		t.Parallel()
+
+		mrFixture := manualHeadPipelineFixture(t, manualPipelineSHA, manualPipelineID, nil)
+		srv := mergeRequestAndStatusesServer(t, mrFixture, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`[]`))
+		})
+		defer srv.Close()
+
+		adapter := mustSCMAdapter(t, srv.URL)
+		log, buf := newCapturingLogger()
+		adapter.log = log
+
+		if _, err := adapter.GetCIStatus(context.Background(), testPRNumber, scmOwner, scmRepo); err != nil {
+			t.Fatalf("GetCIStatus: unexpected error: %v", err)
+		}
+
+		logOutput := buf.String()
+		if n := strings.Count(logOutput, "manual head pipeline carried no job status"); n != 1 {
+			t.Errorf("occurrences of %q in log output = %d, want 1 (log output: %q)", "manual head pipeline carried no job status", n, logOutput)
+		}
+		wantAttr := "pipeline_id=" + strconv.FormatInt(manualPipelineID, 10)
+		if !strings.Contains(logOutput, wantAttr) {
+			t.Errorf("log output = %q, want it to carry %q", logOutput, wantAttr)
+		}
+	})
 }
 
 // --- Error status coverage ---


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Fix

**Intent:** `GitLabSCMAdapter.GetCIStatus` mapped a `manual` head pipeline status to `CIGatePending` unconditionally, because the platform reports `manual` even for a pipeline whose job set carries a failed job alongside the untriggered manual one. That verdict never changed on a later poll for the same commit, so a merge request blocked only on a manual action never satisfied an auto-merge gate that requires CI, and the reaction stalled until its pending entry expired and a human merged it. `GetCIStatus` now reads the head pipeline's own job set on `manual` and folds it through `scmcore.MergeGate`, the same rule every other pipeline status already resolves through.

This branch also carries a second, unrelated fix to the GitLab merge-flow integration test, which had been failing nightly. It is included here by explicit decision rather than split into its own branch. GitLab reports `detailed_merge_status: "conflict"` while the conflict check is merely still running, because the enum has no value for a check in progress, so the test read a transient `conflict` for a merge request that had none and failed. The poll now treats a status as settled only once the merge request's own head SHA has caught up with the pushed commit, which is what makes the transient value recognizable. The same root cause turned out to affect `MergePR_StalePrecondition`, which merged immediately after pushing and so was refused as not-yet-mergeable before the SHA precondition was ever evaluated; it asserted only that some conflict was reported, so it passed without ever exercising the stale-SHA path it exists to prove. It now settles against the pushed head first and asserts the specific `409` rejection.

**Related Issues:** Fixes #827. Related to #815, which it makes rare rather than impossible: a residual failure remains in the merge call itself, an upstream race in which GitLab refuses a merge as unmergeable while a push is still being processed, and no client-side poll can close it.

### 🧭 Reviewer Guide

**Complexity:** Medium

#### Entry Point

`internal/scm/gitlab/scm_merge.go` - `GetCIStatus` now branches on `manual` into the new `manualGate` method, which addresses the head pipeline's own `sha`/`id` (never the merge request's own `sha`, which can disagree with the pipeline it reports), reads the pipeline's job set, and folds it through `scmcore.MergeGate`. `mapPipelineStatus` stays a pure classifier over the status string, unchanged in behavior for every other status.

#### Sensitive Areas

- `internal/scm/gitlab/scm_merge.go`: `manualGate` is the new code path that issues an extra request only for `manual`; an empty job set or a read failure must not degrade to a merge-eligible verdict.
- `internal/scm/gitlab/commitstatus.go`: new file holding the commit-status wire type and normalization (`mapJobOutcome`, `commitStatusesPath`, `scopeToPipeline`, `normalizeCommitStatuses`, `decodeCommitStatusPage`) moved out of `ci.go` so both the CI provider and the SCM adapter share it instead of duplicating it.
- `internal/scm/gitlab/ci.go`: normalization logic removed in favor of the shared helpers in `commitstatus.go`; the CI provider's read path itself is unchanged.
- `internal/scm/gitlab/integration_merge_test.go`: the separate nightly-failure fix described above. `awaitMergeability` takes a `wantSHA` and gates settlement on it; passing an empty string disables the gate. This is the file that carries the second issue, so a reviewer expecting a single-issue diff should start here.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes
- **Migrations/State:** No migrations or state changes
- **Integration fixture check:** the merge request behind the GitLab integration suite's CI-status fixture was re-read against the self-hosted Community Edition instance and still carries a `failed` head pipeline rather than a `manual` one, so that suite's existing `failing` expectation continues to assert what it was written to assert and needs no change.
