### PR TITLE
fix(scm/gitlab): reject a head pipeline for a superseded commit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,6 +140,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   one extra API call per poll; every other pipeline state is unchanged.
   ([#827](https://github.com/sortie-ai/sortie/issues/827))
 
+- GitLab: auto-merge no longer acts on a CI verdict belonging to an
+  earlier commit. GitLab reports a merge request's pipeline as stored,
+  not as re-checked against the current commit, so a push that produced
+  no pipeline of its own - removing the CI configuration, or a change
+  the pipeline rules exclude - left the previous commit's result in
+  place. A merge request could merge on a passing result that never
+  covered the commit being merged, and the same staleness held the gate
+  shut the other way. The verdict is now withheld as pending whenever
+  the pipeline on offer describes a commit other than the merge request
+  head. A merge request whose branch never produced a pipeline still
+  reports no verdict and merges where the deployment allows it.
+  Projects using merged results pipelines or merge trains keep the
+  previous behavior, because those pipelines run on a commit that
+  exists in neither branch and never match the head by design.
+  ([#828](https://github.com/sortie-ai/sortie/issues/828))
+
 ### Migrations
 
 - Add the `handoff_absence_resets` table, recording per issue where its

--- a/docs/architecture/12-ci-feedback-contract.md
+++ b/docs/architecture/12-ci-feedback-contract.md
@@ -65,10 +65,10 @@ settled, non-failing pipeline that carries no run at all: the merge gate answers
 aggregate, and the CI provider answers `pending` from an empty run set.
 
 The two readers are also addressed differently, which is a second reason their answers can differ.
-`SCMAdapter.GetCIStatus` takes a pull-request identity (`prNumber`, `owner`, `repo`) and answers
-about that pull request as the forge currently reports it, while `CIStatusProvider.FetchCIStatus`
-takes a caller-supplied ref string and answers about that ref, which may no longer be the pull
-request's head.
+`SCMAdapter.GetCIStatus` takes a pull-request identity (`prNumber`, `owner`, `repo`). On GitLab the
+merge gate answers from the head pipeline only when that pipeline describes the pull request's
+current head, and defers otherwise; `CIStatusProvider.FetchCIStatus` takes a caller-supplied ref
+string and answers about that ref, which may no longer be the pull request's head.
 
 Each `CheckRun` contains:
 

--- a/docs/gitlab-adapter-notes.md
+++ b/docs/gitlab-adapter-notes.md
@@ -1747,6 +1747,21 @@ head
 `head_pipeline.sha` and `head_pipeline.id`, never the merge request's own `sha`, so the
 pipeline and the commit it describes cannot disagree.
 
+The consequence for `GetCIStatus`: it compares the two SHAs before classifying anything, and
+defers at `"pending"` rather than classify a status computed for a superseded commit. The
+divergence also reproduces on the external-status path: a merge request reported `sha` at
+`635f42a9` while `head_pipeline` reported `{id: 22, sha: 24f87df6, status: "success",
+ref: "feature-828b", source: "external"}`, stable across several minutes of re-reads and with
+`detailed_merge_status: "mergeable"`, so the CI read is genuinely reached rather than shadowed
+by a mergeability block **[live-CE]**. The same shape reproduces on GitLab.com: a merge request
+reported `sha: d959449b` against an unchanged `head_pipeline` at `d85c06f5`, settling at
+`detailed_merge_status: "mergeable"` and `merge_status: "can_be_merged"` **[live-SaaS]**, so the
+defect and its fix are not specific to the compatibility floor. The divergence also opens
+transiently on the ordinary path: sampling a merge request every 0.4 seconds across a push that
+does create a pipeline, one sample at t+0.75 s reported the new `sha` with `head_pipeline` still
+on the previous commit, and by t+1.32 s both had advanced **[live-CE]**, so `GetCIStatus` must
+treat the deferral as recoverable on the next poll rather than terminal.
+
 **`GetCIStatus` mapping.** The orchestrator compares the returned string against the literal
 `"success"` and treats the empty string as "no checks exist"
 (`internal/orchestrator/auto_merge_reconcile.go`). Returning GitLab's pipeline status verbatim
@@ -1769,6 +1784,53 @@ each enumerate exactly those 13 values (`created`, `waiting_for_resource`, `prep
 | `created`, `waiting_for_resource`, `preparing`, `waiting_for_callback`, `pending`, `running`, `canceling`, `scheduled` | `"pending"` (still settling) |
 | `manual` | the verdict `scmcore.MergeGate` computes over the pipeline's own job set, at the cost of one extra request (see below) |
 | any other value, including the empty string | `"pending"`, and logs one WARN naming the observed value |
+
+**The table above applies only when `head_pipeline.sha` matches the merge request's own `sha`,
+compared case-insensitively.** A difference means the platform has not caught up with a new
+head commit, most often because a push created no new pipeline of its own for it:
+`GET /projects/:id/repository/commits/:sha` for the new head reports `last_pipeline: null` and
+the statuses route for it returns `200 []`, so no read available to the adapter reports a
+verdict for that head **[live-CE]**. `GetCIStatus` answers `"pending"` for that shape, together
+with one WARN naming the merge request's own `sha`, the head pipeline's `sha`, and the head
+pipeline's id, rather than reporting the status the superseded pipeline carries. Three
+dispositions actually change: a superseded pipeline reporting `success` or `skipped` no longer
+answers `"success"`, and a superseded `manual` pipeline whose job set would fold to `success` no
+longer pays for the job-set read below at all. A superseded `failed`, `canceled`, or one of the
+eight settling statuses already answered a non-merge-eligible value and still does. A `null`
+`head_pipeline` is unaffected by the comparison and keeps its `""`: the platform reports a
+genuinely uncovered head with `head_pipeline: null` and `detailed_merge_status: "mergeable"`
+**[live-CE]**, a shape the wire distinguishes from a superseded pipeline, so the two are never
+conflated.
+
+**Two shapes are exempt from the comparison: a merged-results pipeline and a merge-train
+pipeline generated for the merge request being read.** Both run on a temporary ref whose commit
+exists in neither branch, so their `sha` can never equal the merge request's own, and neither
+the embedded `head_pipeline` object nor the pipeline detail route exposes a `source_sha` or a
+`target_sha` relating that commit to the head: an authenticated read of a GitLab.com merge
+request using merged results returned 22 keys on the embedded object and 23 on the pipeline
+detail route, and neither field appeared on either **[live-SaaS]**. Both shapes are Premium and
+Ultimate only; a Community Edition project carries neither the `merge_pipelines_enabled` nor
+the `merge_trains_enabled` setting, and a `PUT` request setting the former returns `200` with
+the key still absent **[live-CE]**, so every shape Community Edition can produce stays inside
+the comparison. The exemption is not a test of `ref` alone: a branch literally named
+`refs/merge-requests/999/merge` is accepted by the platform, and a pipeline created on it
+reports `source: "external"` or `source: "push"` depending on how the pipeline was created,
+neither of which is `merge_request_event` **[live-CE]**. `GetCIStatus` therefore tests the
+platform-set `source` together with the exact ref anchored to the merge request being read,
+which a branch name cannot forge. A detached merge-request pipeline
+(`ref: "refs/merge-requests/{iid}/head"`) is not exempt: its `sha` equals the merge request's
+own whenever it describes the head **[live-CE]**, so it stays inside the comparison like a
+branch pipeline. GitLab's own narrower association, `MergeRequest.headPipeline` on GraphQL,
+resolves this correctly for every shape: it returned `null` for a stale Community Edition
+fixture whose REST response reported the superseded pipeline, and the pipeline for a healthy
+fixture on the same instance, matching `diffHeadSha` **[live-CE]**; on GitLab.com it returned
+the merged-results pipeline for a merge request whose `sha` differs from that pipeline's own
+**[live-SaaS]**. The adapter stays on REST v4 for this read regardless; see
+[GraphQL](#graphql). The merge-train ref name rests on the
+merge-trains API reference's own example (`"ref": "refs/merge-requests/59/train"`) rather than
+on an observation, because merge trains are unreachable below Premium; if the name is wrong a
+train pipeline falls outside the exemption and defers at `"pending"` rather than merging
+**[docs]**.
 
 `skipped` is a terminal, non-failing status, and it folds to a merge-eligible verdict rather
 than to a deferral. The platform's composite-status computation reports `skipped` for a pipeline
@@ -2205,7 +2267,7 @@ Every route below was exercised on the fixture unless the status column says oth
 | --- | --- | --- |
 | `GetMergeability` | `GET /projects/:id/merge_requests/:iid` | Verified **[live-CE]** |
 | `GetReviewDecision` | `GET .../merge_requests/:iid/approvals` plus `.../reviewers` | Verified, two requests **[live-CE]** |
-| `GetCIStatus` | `head_pipeline` on the merge-request object, plus `GET /projects/:id/repository/commits/:sha/statuses` on a `manual` head pipeline | Verified, no extra request for twelve of the thirteen pipeline statuses and one extra request for `manual` **[live-CE]** |
+| `GetCIStatus` | `head_pipeline` on the merge-request object, plus `GET /projects/:id/repository/commits/:sha/statuses` on a `manual` head pipeline that describes the merge request head | Verified, no extra request for twelve of the thirteen pipeline statuses and one extra request for `manual`, spent only when the head pipeline describes the merge request head; a superseded head pipeline of any status costs nothing beyond the merge-request read **[live-CE]** |
 | `FetchCIStatus` | `GET /projects/:id/repository/commits/:sha/statuses` | Verified **[live-CE]** |
 | Job log for `max_log_lines` | `GET /projects/:id/jobs/:job_id/trace` | Verified, `text/plain`, no range support **[live-CE]** |
 | `FetchPendingReviews` | `.../merge_requests/:iid/reviewers` plus `.../notes` | Verified **[live-CE]** |

--- a/internal/scm/gitlab/scm_merge.go
+++ b/internal/scm/gitlab/scm_merge.go
@@ -182,9 +182,9 @@ func mapPipelineStatus(status string) (gate scmcore.CIGate, recognized bool) {
 // isGeneratedMergeRefPipeline reports whether pipeline is one the
 // platform generated for merge request prNumber and ran on a ref whose
 // commit exists in neither branch: a merged-results pipeline or a
-// merge-train pipeline. It returns false for every other input,
-// including a pipeline with an empty ref or an empty source, and for a
-// pipeline generated for a different merge request.
+// merge-train pipeline. It returns false for every other non-nil
+// pipeline, including one with an empty ref or an empty source, and one
+// generated for a different merge request. pipeline must not be nil.
 //
 // The comparison is an exact whole-string match on both source and ref,
 // never a prefix or suffix test over ref alone: a branch can be named

--- a/internal/scm/gitlab/scm_merge.go
+++ b/internal/scm/gitlab/scm_merge.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"strings"
 
 	"github.com/sortie-ai/sortie/internal/domain"
 	"github.com/sortie-ai/sortie/internal/scm/scmcore"
@@ -40,10 +41,19 @@ type gitlabMergeRequest struct {
 // ID and SHA address the pipeline's own job set. The merge request's own
 // sha is not interchangeable with SHA: nothing re-validates head_pipeline
 // against the current head, so the two can disagree.
+//
+// Ref and Source together recognize a pipeline the platform generated for
+// this merge request and ran on a ref whose commit exists in neither
+// branch. Neither field carries that meaning alone: a branch name can
+// imitate a generated ref and the platform reports Ref verbatim, and a
+// detached merge-request pipeline also reports Source as a
+// platform-generated value while its SHA equals the merge request's own.
 type gitlabPipeline struct {
 	Status string `json:"status"`
 	ID     int64  `json:"id"`
 	SHA    string `json:"sha"`
+	Ref    string `json:"ref"`
+	Source string `json:"source"`
 }
 
 // fetchMergeRequest issues GET /projects/{projectPath}/merge_requests/{prNumber}
@@ -169,21 +179,52 @@ func mapPipelineStatus(status string) (gate scmcore.CIGate, recognized bool) {
 	}
 }
 
+// isGeneratedMergeRefPipeline reports whether pipeline is one the
+// platform generated for merge request prNumber and ran on a ref whose
+// commit exists in neither branch: a merged-results pipeline or a
+// merge-train pipeline. It returns false for every other input,
+// including a pipeline with an empty ref or an empty source, and for a
+// pipeline generated for a different merge request.
+//
+// The comparison is an exact whole-string match on both source and ref,
+// never a prefix or suffix test over ref alone: a branch can be named
+// after a generated ref, and only source is a value a repository writer
+// cannot forge.
+func isGeneratedMergeRefPipeline(pipeline *gitlabPipeline, prNumber int) bool {
+	if pipeline.Source != "merge_request_event" {
+		return false
+	}
+	prefix := "refs/merge-requests/" + strconv.Itoa(prNumber) + "/"
+	return pipeline.Ref == prefix+"merge" || pipeline.Ref == prefix+"train"
+}
+
 // GetCIStatus returns the merge-gate CI conclusion for the PR head,
 // mapped from the merge request's head_pipeline status through
 // [mapPipelineStatus]: one of [scmcore.CIGateSuccess],
 // [scmcore.CIGatePending], or [scmcore.CIGateFailing], or the empty
-// [scmcore.CIGateAbsent] when the head carries no pipeline. A skipped
-// pipeline resolves to CIGateSuccess, since the platform reports it only
-// for a job set with no failing conclusion. A manual pipeline resolves to
-// the verdict computed over that pipeline's own job set, through
-// [GitLabSCMAdapter.manualGate]; an empty job set holds at CIGatePending
-// rather than reporting the absent value. A status outside the recognized
-// set logs one WARN naming the observed value so a stalled gate is
-// diagnosable at the tick it stalls. The platform already folds
-// externally reported commit statuses into head_pipeline for the twelve
-// other statuses, so no second request is issued for them; manual is the
-// exception that pays for one job-set read.
+// [scmcore.CIGateAbsent] when the head carries no pipeline. The mapping
+// applies only to a head pipeline that describes the merge request's
+// current head, established by comparing head_pipeline.sha against the
+// merge request's own sha; a merged-results or merge-train pipeline
+// generated for this merge request is exempt from that comparison,
+// through [isGeneratedMergeRefPipeline], because no REST field relates
+// its SHA to the merge request head. A head pipeline describing a
+// superseded commit resolves to CIGatePending with one WARN naming both
+// SHAs and the pipeline id, before either the exemption or the manual
+// arm are considered. A merge request whose response carries a head
+// pipeline but no head SHA of its own fails as a [*domain.SCMError] of
+// kind [domain.ErrSCMPayload], since head identity cannot be established
+// against an absent head. A skipped pipeline resolves to CIGateSuccess,
+// since the platform reports it only for a job set with no failing
+// conclusion. A manual pipeline resolves to the verdict computed over
+// that pipeline's own job set, through [GitLabSCMAdapter.manualGate]; an
+// empty job set holds at CIGatePending rather than reporting the absent
+// value. A status outside the recognized set logs one WARN naming the
+// observed value so a stalled gate is diagnosable at the tick it stalls.
+// The platform already folds externally reported commit statuses into
+// head_pipeline for the twelve other statuses, so no second request is
+// issued for them; manual is the exception that pays for one job-set
+// read.
 func (a *GitLabSCMAdapter) GetCIStatus(ctx context.Context, prNumber int, owner, repo string) (string, error) {
 	mr, err := a.fetchMergeRequest(ctx, prNumber, owner, repo)
 	if err != nil {
@@ -192,6 +233,26 @@ func (a *GitLabSCMAdapter) GetCIStatus(ctx context.Context, prNumber int, owner,
 	if mr.HeadPipeline == nil {
 		return string(scmcore.CIGateAbsent), nil
 	}
+	if mr.SHA == "" {
+		return "", &domain.SCMError{
+			Kind:    domain.ErrSCMPayload,
+			Message: "merge request response missing head sha",
+		}
+	}
+
+	if isGeneratedMergeRefPipeline(mr.HeadPipeline, prNumber) {
+		a.log.Debug("head pipeline runs on a generated merge-request ref",
+			slog.String("pipeline_ref", mr.HeadPipeline.Ref),
+			slog.Int64("pipeline_id", mr.HeadPipeline.ID),
+			slog.String("pipeline_source", mr.HeadPipeline.Source))
+	} else if !strings.EqualFold(mr.HeadPipeline.SHA, mr.SHA) {
+		a.log.Warn("head pipeline does not describe the merge request head",
+			slog.String("merge_request_sha", mr.SHA),
+			slog.String("head_pipeline_sha", mr.HeadPipeline.SHA),
+			slog.Int64("pipeline_id", mr.HeadPipeline.ID))
+		return string(scmcore.CIGatePending), nil
+	}
+
 	if mr.HeadPipeline.Status == "manual" {
 		return a.manualGate(ctx, owner, repo, mr.HeadPipeline)
 	}
@@ -206,6 +267,14 @@ func (a *GitLabSCMAdapter) GetCIStatus(ctx context.Context, prNumber int, owner,
 
 // manualGate resolves the merge-gate verdict for a manual head pipeline
 // from that pipeline's own job set, folded through [scmcore.MergeGate].
+//
+// Its caller, [GitLabSCMAdapter.GetCIStatus], establishes head identity,
+// the head-sha comparison and the generated-merge-ref exemption, before
+// calling manualGate, so on the ordinary matching path the empty-sha half
+// of the guard below is defense in depth rather than the route by which
+// this function is ordinarily reached. The exempt path skips that
+// comparison entirely and is the ordinary way to reach manualGate with an
+// empty pipeline sha.
 //
 // A missing sha or a zero id returns a [*domain.SCMError] of kind
 // [domain.ErrSCMPayload] and issues no request: the platform answers a

--- a/internal/scm/gitlab/scm_merge.go
+++ b/internal/scm/gitlab/scm_merge.go
@@ -208,10 +208,10 @@ func isGeneratedMergeRefPipeline(pipeline *gitlabPipeline, prNumber int) bool {
 // merge request's own sha; a merged-results or merge-train pipeline
 // generated for this merge request is exempt from that comparison,
 // through [isGeneratedMergeRefPipeline], because no REST field relates
-// its SHA to the merge request head. A head pipeline describing a
-// superseded commit resolves to CIGatePending with one WARN naming both
-// SHAs and the pipeline id, before either the exemption or the manual
-// arm are considered. A merge request whose response carries a head
+// its SHA to the merge request head. A head pipeline that is not exempt
+// and describes a superseded commit resolves to CIGatePending with one
+// WARN naming both SHAs and the pipeline id, before the manual arm is
+// considered. A merge request whose response carries a head
 // pipeline but no head SHA of its own fails as a [*domain.SCMError] of
 // kind [domain.ErrSCMPayload], since head identity cannot be established
 // against an absent head. A skipped pipeline resolves to CIGateSuccess,

--- a/internal/scm/gitlab/scm_merge_test.go
+++ b/internal/scm/gitlab/scm_merge_test.go
@@ -26,6 +26,12 @@ func decodeRequestBody(t *testing.T, r *http.Request, v any) {
 	}
 }
 
+// mrBaselineSHA is mergeRequestFixture's own default "sha" value. A
+// head_pipeline override that wants the status mapping exercised, rather
+// than the head-comparison deferral, sets its own "sha" to this value;
+// headPipeline does that by default.
+const mrBaselineSHA = "d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0"
+
 // mergeRequestFixture returns a JSON-encoded merge request object built
 // from a documented baseline shape, with overrides applied on top. This
 // lets the detailed_merge_status and head_pipeline enumeration tables
@@ -38,7 +44,7 @@ func mergeRequestFixture(t *testing.T, overrides map[string]any) []byte {
 		"iid":                   testPRNumber,
 		"state":                 "opened",
 		"draft":                 false,
-		"sha":                   "d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0",
+		"sha":                   mrBaselineSHA,
 		"source_branch":         "feature/scm-reads",
 		"target_branch":         "main",
 		"merge_commit_sha":      "",
@@ -52,6 +58,16 @@ func mergeRequestFixture(t *testing.T, overrides map[string]any) []byte {
 		t.Fatalf("marshal merge request fixture: %v", err)
 	}
 	return data
+}
+
+// headPipeline returns a head_pipeline override map whose "sha" defaults
+// to mrBaselineSHA, the merge request fixture's own sha, so the fixture
+// exercises the status mapping rather than the head-comparison deferral,
+// unless fields already sets "sha" itself.
+func headPipeline(fields map[string]any) map[string]any {
+	out := map[string]any{"sha": mrBaselineSHA}
+	maps.Copy(out, fields)
+	return out
 }
 
 func serveJSON(t *testing.T, body []byte) *httptest.Server {
@@ -236,11 +252,11 @@ func TestGetCIStatus_HeadPipelineMapping(t *testing.T) {
 		wantWarn  bool
 		wantAttr  string // pipeline_status attribute value; checked only when wantWarn is true
 	}{
-		{"success maps to CIGateSuccess", map[string]any{"head_pipeline": map[string]any{"status": "success"}}, "success", false, ""},
-		{"failed maps to CIGateFailing", map[string]any{"head_pipeline": map[string]any{"status": "failed"}}, "failing", false, ""},
-		{"canceled maps to CIGateFailing", map[string]any{"head_pipeline": map[string]any{"status": "canceled"}}, "failing", false, ""},
-		{"an unrecognized status defers to CIGatePending and logs a warning", map[string]any{"head_pipeline": map[string]any{"status": "expired"}}, "pending", true, "expired"},
-		{"an empty head_pipeline status defers to CIGatePending and logs a warning", map[string]any{"head_pipeline": map[string]any{"status": ""}}, "pending", true, ""},
+		{"success maps to CIGateSuccess", map[string]any{"head_pipeline": headPipeline(map[string]any{"status": "success"})}, "success", false, ""},
+		{"failed maps to CIGateFailing", map[string]any{"head_pipeline": headPipeline(map[string]any{"status": "failed"})}, "failing", false, ""},
+		{"canceled maps to CIGateFailing", map[string]any{"head_pipeline": headPipeline(map[string]any{"status": "canceled"})}, "failing", false, ""},
+		{"an unrecognized status defers to CIGatePending and logs a warning", map[string]any{"head_pipeline": headPipeline(map[string]any{"status": "expired"})}, "pending", true, "expired"},
+		{"an empty head_pipeline status defers to CIGatePending and logs a warning", map[string]any{"head_pipeline": headPipeline(map[string]any{"status": ""})}, "pending", true, ""},
 		{"a nil head_pipeline maps to CIGateAbsent (empty string)", map[string]any{"head_pipeline": nil}, "", false, ""},
 		{"a populated top-level pipeline is never substituted for a nil head_pipeline", map[string]any{"head_pipeline": nil, "pipeline": map[string]any{"status": "success"}}, "", false, ""},
 	}
@@ -316,7 +332,7 @@ func TestGetCIStatus_PipelineStatusEnumAgreement(t *testing.T) {
 					_, _ = w.Write(manualJobSetBody(t))
 				})
 			} else {
-				fixture := mergeRequestFixture(t, map[string]any{"head_pipeline": map[string]any{"status": status}})
+				fixture := mergeRequestFixture(t, map[string]any{"head_pipeline": headPipeline(map[string]any{"status": status})})
 				srv = serveJSON(t, fixture)
 			}
 			defer srv.Close()
@@ -386,7 +402,7 @@ func TestGetCIStatus_SingleRequestRouteScope(t *testing.T) {
 	for _, status := range statuses {
 		t.Run(status, func(t *testing.T) {
 			t.Parallel()
-			run(t, map[string]any{"head_pipeline": map[string]any{"status": status}})
+			run(t, map[string]any{"head_pipeline": headPipeline(map[string]any{"status": status})})
 		})
 	}
 
@@ -394,6 +410,445 @@ func TestGetCIStatus_SingleRequestRouteScope(t *testing.T) {
 		t.Parallel()
 		run(t, map[string]any{"head_pipeline": nil})
 	})
+}
+
+// --- GetCIStatus: head-comparison deferral ---
+
+// divergentPipelineSHA names a commit that is never the merge request's
+// own sha in any fixture in this file, so a head_pipeline carrying it
+// always describes a superseded commit.
+const divergentPipelineSHA = "1111222233334444555566667777888899990000"
+
+// assertHeadComparisonWarn asserts that logOutput carries exactly one
+// deferral WARN naming mrSHA, pipelineSHA, and pipelineID as its
+// merge_request_sha, head_pipeline_sha, and pipeline_id attributes.
+func assertHeadComparisonWarn(t *testing.T, logOutput, mrSHA, pipelineSHA string, pipelineID int64) {
+	t.Helper()
+
+	const msg = "head pipeline does not describe the merge request head"
+	if n := strings.Count(logOutput, msg); n != 1 {
+		t.Errorf("occurrences of %q in log output = %d, want 1 (log output: %q)", msg, n, logOutput)
+	}
+	if want := "merge_request_sha=" + mrSHA; !strings.Contains(logOutput, want) {
+		t.Errorf("log output = %q, want it to carry %q", logOutput, want)
+	}
+	if want := "head_pipeline_sha=" + quoteIfEmpty(pipelineSHA); !strings.Contains(logOutput, want) {
+		t.Errorf("log output = %q, want it to carry %q", logOutput, want)
+	}
+	if want := "pipeline_id=" + strconv.FormatInt(pipelineID, 10); !strings.Contains(logOutput, want) {
+		t.Errorf("log output = %q, want it to carry %q", logOutput, want)
+	}
+}
+
+func TestGetCIStatus_HeadComparisonDeferral(t *testing.T) {
+	t.Parallel()
+
+	run := func(t *testing.T, overrides map[string]any, wantPipelineSHA string) {
+		t.Helper()
+
+		fixture := mergeRequestFixture(t, overrides)
+
+		var requests atomic.Int32
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			requests.Add(1)
+			if strings.Contains(r.URL.Path, "/statuses") {
+				t.Errorf("unexpected request to %s, want no statuses request", r.URL.Path)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write(fixture)
+		}))
+		defer srv.Close()
+
+		adapter := mustSCMAdapter(t, srv.URL)
+		log, buf := newCapturingLogger()
+		adapter.log = log
+
+		got, err := adapter.GetCIStatus(context.Background(), testPRNumber, scmOwner, scmRepo)
+		if err != nil {
+			t.Fatalf("GetCIStatus: unexpected error: %v", err)
+		}
+		if got != "pending" {
+			t.Errorf("GetCIStatus() = %q, want %q", got, "pending")
+		}
+		if got == "" || got == "success" {
+			t.Errorf("GetCIStatus() = %q, want neither the empty string nor %q", got, "success")
+		}
+		if n := requests.Load(); n != 1 {
+			t.Errorf("requests = %d, want 1", n)
+		}
+		assertHeadComparisonWarn(t, buf.String(), mrBaselineSHA, wantPipelineSHA, manualPipelineID)
+	}
+
+	statuses := []string{"success", "skipped", "failed", "canceled", "manual"}
+	for _, status := range statuses {
+		t.Run(status, func(t *testing.T) {
+			t.Parallel()
+			run(t, map[string]any{"head_pipeline": map[string]any{
+				"status": status,
+				"id":     manualPipelineID,
+				"sha":    divergentPipelineSHA,
+			}}, divergentPipelineSHA)
+		})
+	}
+
+	t.Run("an empty pipeline sha against a non-empty merge-request sha also defers, not a defensive pass-through", func(t *testing.T) {
+		t.Parallel()
+		run(t, map[string]any{"head_pipeline": map[string]any{
+			"status": "success",
+			"id":     manualPipelineID,
+			"sha":    "",
+		}}, "")
+	})
+}
+
+// --- GetCIStatus: absent head_pipeline ---
+
+func TestGetCIStatus_NilHeadPipelineIssuesNoWarning(t *testing.T) {
+	t.Parallel()
+
+	fixture := mergeRequestFixture(t, map[string]any{"head_pipeline": nil})
+
+	var requests atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(fixture)
+	}))
+	defer srv.Close()
+
+	adapter := mustSCMAdapter(t, srv.URL)
+	log, buf := newCapturingLogger()
+	adapter.log = log
+
+	got, err := adapter.GetCIStatus(context.Background(), testPRNumber, scmOwner, scmRepo)
+	if err != nil {
+		t.Fatalf("GetCIStatus: unexpected error: %v", err)
+	}
+	if got != "" {
+		t.Errorf("GetCIStatus() = %q, want empty string", got)
+	}
+	if n := requests.Load(); n != 1 {
+		t.Errorf("requests = %d, want 1", n)
+	}
+	if logOutput := buf.String(); strings.Contains(logOutput, "level=WARN") {
+		t.Errorf("log output = %q, want no WARN of any kind", logOutput)
+	}
+}
+
+// --- GetCIStatus: missing merge-request sha ---
+
+func TestGetCIStatus_MissingMergeRequestSHA(t *testing.T) {
+	t.Parallel()
+
+	fixture := mergeRequestFixture(t, map[string]any{
+		"sha": "",
+		"head_pipeline": map[string]any{
+			"status": "success",
+			"id":     manualPipelineID,
+			"sha":    manualPipelineSHA,
+		},
+	})
+
+	var requests atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(fixture)
+	}))
+	defer srv.Close()
+
+	adapter := mustSCMAdapter(t, srv.URL)
+	got, err := adapter.GetCIStatus(context.Background(), testPRNumber, scmOwner, scmRepo)
+	if got != "" {
+		t.Errorf("GetCIStatus() = %q, want empty string", got)
+	}
+	adaptertest.AssertSCMErrorKind(t, err, domain.ErrSCMPayload)
+
+	if n := requests.Load(); n != 1 {
+		t.Errorf("requests = %d, want 1", n)
+	}
+}
+
+// --- GetCIStatus: case-insensitive head comparison ---
+
+func TestGetCIStatus_HeadComparisonCaseInsensitive(t *testing.T) {
+	t.Parallel()
+
+	t.Run("a non-manual status maps normally despite a case difference", func(t *testing.T) {
+		t.Parallel()
+
+		fixture := mergeRequestFixture(t, map[string]any{
+			"head_pipeline": map[string]any{
+				"status": "success",
+				"sha":    strings.ToUpper(mrBaselineSHA),
+			},
+		})
+		srv := serveJSON(t, fixture)
+		defer srv.Close()
+
+		adapter := mustSCMAdapter(t, srv.URL)
+		log, buf := newCapturingLogger()
+		adapter.log = log
+
+		got, err := adapter.GetCIStatus(context.Background(), testPRNumber, scmOwner, scmRepo)
+		if err != nil {
+			t.Fatalf("GetCIStatus: unexpected error: %v", err)
+		}
+		if got != "success" {
+			t.Errorf("GetCIStatus() = %q, want %q", got, "success")
+		}
+		if logOutput := buf.String(); strings.Contains(logOutput, "head pipeline does not describe the merge request head") {
+			t.Errorf("log output = %q, want no deferral WARN", logOutput)
+		}
+	})
+
+	t.Run("a manual status still runs the job-set read", func(t *testing.T) {
+		t.Parallel()
+
+		mrFixture := manualHeadPipelineFixture(t, strings.ToUpper(manualPipelineSHA), manualPipelineID, map[string]any{"sha": manualPipelineSHA})
+		statusesBody := manualJobSetBody(t)
+
+		var statusesRequested atomic.Bool
+		srv := mergeRequestAndStatusesServer(t, mrFixture, func(w http.ResponseWriter, r *http.Request) {
+			statusesRequested.Store(true)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write(statusesBody)
+		})
+		defer srv.Close()
+
+		adapter := mustSCMAdapter(t, srv.URL)
+		got, err := adapter.GetCIStatus(context.Background(), testPRNumber, scmOwner, scmRepo)
+		if err != nil {
+			t.Fatalf("GetCIStatus: unexpected error: %v", err)
+		}
+		if got != "success" {
+			t.Errorf("GetCIStatus() = %q, want %q", got, "success")
+		}
+		if !statusesRequested.Load() {
+			t.Error("no /statuses request issued, want the job-set read to run despite the case difference")
+		}
+	})
+}
+
+// --- GetCIStatus: generated merge-ref exemption ---
+
+// exemptPipelineSHA names a commit that is never the merge request's own
+// sha in any fixture in this file, matching the shape of a merged
+// results or merge-train pipeline: a sha that exists in neither branch.
+const exemptPipelineSHA = "2222333344445555666677778888999900001111"
+
+// assertGeneratedMergeRefDebug asserts that logOutput carries exactly
+// one exemption Debug line naming ref, id, and source as its
+// pipeline_ref, pipeline_id, and pipeline_source attributes.
+func assertGeneratedMergeRefDebug(t *testing.T, logOutput, ref string, id int64, source string) {
+	t.Helper()
+
+	const msg = "head pipeline runs on a generated merge-request ref"
+	if n := strings.Count(logOutput, msg); n != 1 {
+		t.Errorf("occurrences of %q in log output = %d, want 1 (log output: %q)", msg, n, logOutput)
+	}
+	if want := "pipeline_ref=" + ref; !strings.Contains(logOutput, want) {
+		t.Errorf("log output = %q, want it to carry %q", logOutput, want)
+	}
+	if want := "pipeline_id=" + strconv.FormatInt(id, 10); !strings.Contains(logOutput, want) {
+		t.Errorf("log output = %q, want it to carry %q", logOutput, want)
+	}
+	if want := "pipeline_source=" + source; !strings.Contains(logOutput, want) {
+		t.Errorf("log output = %q, want it to carry %q", logOutput, want)
+	}
+}
+
+func TestGetCIStatus_GeneratedMergeRefExemption(t *testing.T) {
+	t.Parallel()
+
+	mergeRef := "refs/merge-requests/" + strconv.Itoa(testPRNumber) + "/merge"
+	trainRef := "refs/merge-requests/" + strconv.Itoa(testPRNumber) + "/train"
+
+	t.Run("a merged-results pipeline is exempt and maps normally", func(t *testing.T) {
+		t.Parallel()
+
+		const exemptPipelineID = int64(4001)
+		fixture := mergeRequestFixture(t, map[string]any{
+			"head_pipeline": map[string]any{
+				"status": "success",
+				"id":     exemptPipelineID,
+				"sha":    exemptPipelineSHA,
+				"ref":    mergeRef,
+				"source": "merge_request_event",
+			},
+		})
+		srv := serveJSON(t, fixture)
+		defer srv.Close()
+
+		adapter := mustSCMAdapter(t, srv.URL)
+		log, buf := newCapturingLogger()
+		adapter.log = log
+
+		got, err := adapter.GetCIStatus(context.Background(), testPRNumber, scmOwner, scmRepo)
+		if err != nil {
+			t.Fatalf("GetCIStatus: unexpected error: %v", err)
+		}
+		if got != "success" {
+			t.Errorf("GetCIStatus() = %q, want %q", got, "success")
+		}
+
+		logOutput := buf.String()
+		if strings.Contains(logOutput, "head pipeline does not describe the merge request head") {
+			t.Errorf("log output = %q, want no deferral WARN", logOutput)
+		}
+		assertGeneratedMergeRefDebug(t, logOutput, mergeRef, exemptPipelineID, "merge_request_event")
+	})
+
+	t.Run("a merge-train pipeline is exempt and its manual status is addressed at the pipeline's own sha and id", func(t *testing.T) {
+		t.Parallel()
+
+		const exemptPipelineID = int64(4002)
+		mrFixture := mergeRequestFixture(t, map[string]any{
+			"head_pipeline": map[string]any{
+				"status": "manual",
+				"id":     exemptPipelineID,
+				"sha":    exemptPipelineSHA,
+				"ref":    trainRef,
+				"source": "merge_request_event",
+			},
+		})
+		statusesBody := commitStatusesJSON(t, []map[string]any{
+			commitStatusEntry(1, "manual-one", "manual", exemptPipelineID),
+			commitStatusEntry(2, "manual-two", "manual", exemptPipelineID),
+		})
+		wantStatusesSuffix := "/repository/commits/" + exemptPipelineSHA + "/statuses"
+
+		var statusesPath, statusesPipelineID string
+		srv := mergeRequestAndStatusesServer(t, mrFixture, func(w http.ResponseWriter, r *http.Request) {
+			statusesPath = r.URL.Path
+			statusesPipelineID = r.URL.Query().Get("pipeline_id")
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write(statusesBody)
+		})
+		defer srv.Close()
+
+		adapter := mustSCMAdapter(t, srv.URL)
+		log, buf := newCapturingLogger()
+		adapter.log = log
+
+		got, err := adapter.GetCIStatus(context.Background(), testPRNumber, scmOwner, scmRepo)
+		if err != nil {
+			t.Fatalf("GetCIStatus: unexpected error: %v", err)
+		}
+		if got != "success" {
+			t.Errorf("GetCIStatus() = %q, want %q", got, "success")
+		}
+		if !strings.HasSuffix(statusesPath, wantStatusesSuffix) {
+			t.Errorf("statuses request path = %q, want it to end with %q", statusesPath, wantStatusesSuffix)
+		}
+		if want := strconv.FormatInt(exemptPipelineID, 10); statusesPipelineID != want {
+			t.Errorf("statuses request pipeline_id query param = %q, want %q", statusesPipelineID, want)
+		}
+
+		assertGeneratedMergeRefDebug(t, buf.String(), trainRef, exemptPipelineID, "merge_request_event")
+	})
+}
+
+// --- GetCIStatus: detached merge-request pipeline ---
+
+func TestGetCIStatus_DetachedMergeRequestPipelineInsideComparison(t *testing.T) {
+	t.Parallel()
+
+	headRef := "refs/merge-requests/" + strconv.Itoa(testPRNumber) + "/head"
+
+	t.Run("equal shas map normally", func(t *testing.T) {
+		t.Parallel()
+
+		fixture := mergeRequestFixture(t, map[string]any{
+			"head_pipeline": map[string]any{
+				"status": "success",
+				"sha":    mrBaselineSHA,
+				"ref":    headRef,
+				"source": "merge_request_event",
+			},
+		})
+		srv := serveJSON(t, fixture)
+		defer srv.Close()
+
+		adapter := mustSCMAdapter(t, srv.URL)
+		got, err := adapter.GetCIStatus(context.Background(), testPRNumber, scmOwner, scmRepo)
+		if err != nil {
+			t.Fatalf("GetCIStatus: unexpected error: %v", err)
+		}
+		if got != "success" {
+			t.Errorf("GetCIStatus() = %q, want %q", got, "success")
+		}
+	})
+
+	t.Run("differing shas defer to pending", func(t *testing.T) {
+		t.Parallel()
+
+		fixture := mergeRequestFixture(t, map[string]any{
+			"head_pipeline": map[string]any{
+				"status": "success",
+				"sha":    divergentPipelineSHA,
+				"ref":    headRef,
+				"source": "merge_request_event",
+			},
+		})
+		srv := serveJSON(t, fixture)
+		defer srv.Close()
+
+		adapter := mustSCMAdapter(t, srv.URL)
+		got, err := adapter.GetCIStatus(context.Background(), testPRNumber, scmOwner, scmRepo)
+		if err != nil {
+			t.Fatalf("GetCIStatus: unexpected error: %v", err)
+		}
+		if got != "pending" {
+			t.Errorf("GetCIStatus() = %q, want %q", got, "pending")
+		}
+	})
+}
+
+// --- GetCIStatus: shapes that imitate the exemption ---
+
+func TestGetCIStatus_ExemptionRejectsImitatingShapes(t *testing.T) {
+	t.Parallel()
+
+	mergeRef := "refs/merge-requests/" + strconv.Itoa(testPRNumber) + "/merge"
+	otherMergeRef := "refs/merge-requests/" + strconv.Itoa(testPRNumber+1) + "/merge"
+
+	tests := []struct {
+		name   string
+		ref    string
+		source string
+	}{
+		{"an ordinary branch name", "feature/scm-reads", "push"},
+		{"a branch literally named after the generated merge ref, created by a push", mergeRef, "push"},
+		{"a branch literally named after the generated merge ref, reported externally", mergeRef, "external"},
+		{"a generated ref anchored to a different merge request", otherMergeRef, "merge_request_event"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			fixture := mergeRequestFixture(t, map[string]any{
+				"head_pipeline": map[string]any{
+					"status": "success",
+					"sha":    divergentPipelineSHA,
+					"ref":    tt.ref,
+					"source": tt.source,
+				},
+			})
+			srv := serveJSON(t, fixture)
+			defer srv.Close()
+
+			adapter := mustSCMAdapter(t, srv.URL)
+			got, err := adapter.GetCIStatus(context.Background(), testPRNumber, scmOwner, scmRepo)
+			if err != nil {
+				t.Fatalf("GetCIStatus: unexpected error: %v", err)
+			}
+			if got != "pending" {
+				t.Errorf("GetCIStatus() = %q, want %q (the exemption must not admit this shape)", got, "pending")
+			}
+		})
+	}
 }
 
 // --- GetCIStatus: manual head pipeline job-set fold ---
@@ -408,12 +863,16 @@ const (
 )
 
 // manualHeadPipelineFixture returns a merge-request fixture whose
-// head_pipeline reports "manual" at sha and pipelineID, with any
-// additional top-level merge-request field overrides applied on top.
+// head_pipeline reports "manual" at sha and pipelineID. The merge
+// request's own "sha" defaults to sha, the pipeline's own value, so the
+// job-set fold is reached rather than the head-comparison deferral,
+// unless overrides sets "sha" itself. Any additional top-level
+// merge-request field overrides are applied on top.
 func manualHeadPipelineFixture(t *testing.T, sha string, pipelineID int64, overrides map[string]any) []byte {
 	t.Helper()
 
 	fields := map[string]any{
+		"sha": sha,
 		"head_pipeline": map[string]any{
 			"status": "manual",
 			"id":     pipelineID,
@@ -485,49 +944,40 @@ func mergeRequestAndStatusesServer(t *testing.T, mrFixture []byte, statusesHandl
 	}))
 }
 
+// TestGetCIStatus_ManualRequestShape calls manualGate directly, rather
+// than through GetCIStatus, because a pipeline whose sha differs from
+// every merge-request fixture in this file no longer reaches manualGate
+// through GetCIStatus: it defers before the manual arm is considered.
+// The direct call preserves the addressing assertion this test has
+// always made, independent of that routing.
 func TestGetCIStatus_ManualRequestShape(t *testing.T) {
 	t.Parallel()
 
-	const mrSHA = "0000111122223333444455556666777788889999"
-
-	mrFixture := manualHeadPipelineFixture(t, manualPipelineSHA, manualPipelineID, map[string]any{"sha": mrSHA})
+	pipeline := &gitlabPipeline{Status: "manual", ID: manualPipelineID, SHA: manualPipelineSHA}
 	statusesBody := manualJobSetBody(t)
-
-	wantMRSuffix := "/merge_requests/" + strconv.Itoa(testPRNumber)
 	wantStatusesSuffix := "/repository/commits/" + manualPipelineSHA + "/statuses"
 
 	var requestPaths []string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestPaths = append(requestPaths, r.URL.Path)
-		w.Header().Set("Content-Type", "application/json")
-		switch {
-		case strings.HasSuffix(r.URL.Path, wantStatusesSuffix):
-			if got := r.URL.Query().Get("pipeline_id"); got != strconv.FormatInt(manualPipelineID, 10) {
-				t.Errorf("statuses request pipeline_id query param = %q, want %q", got, strconv.FormatInt(manualPipelineID, 10))
-			}
-			_, _ = w.Write(statusesBody)
-		case strings.HasSuffix(r.URL.Path, wantMRSuffix):
-			_, _ = w.Write(mrFixture)
-		default:
-			t.Errorf("unexpected request to %s", r.URL.Path)
-			w.WriteHeader(http.StatusNotFound)
+		if got := r.URL.Query().Get("pipeline_id"); got != strconv.FormatInt(manualPipelineID, 10) {
+			t.Errorf("statuses request pipeline_id query param = %q, want %q", got, strconv.FormatInt(manualPipelineID, 10))
 		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(statusesBody)
 	}))
 	defer srv.Close()
 
 	adapter := mustSCMAdapter(t, srv.URL)
-	if _, err := adapter.GetCIStatus(context.Background(), testPRNumber, scmOwner, scmRepo); err != nil {
-		t.Fatalf("GetCIStatus: unexpected error: %v", err)
+	if _, err := adapter.manualGate(context.Background(), scmOwner, scmRepo, pipeline); err != nil {
+		t.Fatalf("manualGate: unexpected error: %v", err)
 	}
 
-	if len(requestPaths) != 2 {
-		t.Fatalf("requests = %d, want 2 (the merge-request read then one statuses request); paths: %v", len(requestPaths), requestPaths)
+	if len(requestPaths) != 1 {
+		t.Fatalf("requests = %d, want 1 (manualGate must issue exactly one request); paths: %v", len(requestPaths), requestPaths)
 	}
-	if !strings.HasSuffix(requestPaths[0], wantMRSuffix) {
-		t.Errorf("first request path = %q, want it to end with %q", requestPaths[0], wantMRSuffix)
-	}
-	if !strings.HasSuffix(requestPaths[1], wantStatusesSuffix) {
-		t.Errorf("second request path = %q, want it to end with %q (the merge request's own sha %q must not be addressed)", requestPaths[1], wantStatusesSuffix, mrSHA)
+	if !strings.HasSuffix(requestPaths[0], wantStatusesSuffix) {
+		t.Errorf("request path = %q, want it to end with %q (the pipeline's own sha %q must be addressed)", requestPaths[0], wantStatusesSuffix, manualPipelineSHA)
 	}
 }
 
@@ -730,44 +1180,62 @@ func TestGetCIStatus_ManualScoping(t *testing.T) {
 func TestGetCIStatus_ManualPayloadGuard(t *testing.T) {
 	t.Parallel()
 
-	tests := []struct {
-		name string
-		sha  string
-		id   int64
-	}{
-		{"empty sha issues no statuses request", "", manualPipelineID},
-		{"zero id issues no statuses request", manualPipelineSHA, 0},
-	}
+	t.Run("zero id issues no statuses request", func(t *testing.T) {
+		t.Parallel()
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
+		mrFixture := manualHeadPipelineFixture(t, manualPipelineSHA, 0, nil)
 
-			mrFixture := manualHeadPipelineFixture(t, tt.sha, tt.id, nil)
-
-			var requests atomic.Int32
-			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				requests.Add(1)
-				if strings.Contains(r.URL.Path, "/statuses") {
-					t.Errorf("unexpected request to %s, want no statuses request", r.URL.Path)
-				}
-				w.Header().Set("Content-Type", "application/json")
-				_, _ = w.Write(mrFixture)
-			}))
-			defer srv.Close()
-
-			adapter := mustSCMAdapter(t, srv.URL)
-			got, err := adapter.GetCIStatus(context.Background(), testPRNumber, scmOwner, scmRepo)
-			if got != "" {
-				t.Errorf("GetCIStatus() = %q, want empty string", got)
+		var requests atomic.Int32
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			requests.Add(1)
+			if strings.Contains(r.URL.Path, "/statuses") {
+				t.Errorf("unexpected request to %s, want no statuses request", r.URL.Path)
 			}
-			adaptertest.AssertSCMErrorKind(t, err, domain.ErrSCMPayload)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write(mrFixture)
+		}))
+		defer srv.Close()
 
-			if n := requests.Load(); n != 1 {
-				t.Errorf("requests = %d, want 1 (the merge-request read alone; no statuses request)", n)
-			}
-		})
-	}
+		adapter := mustSCMAdapter(t, srv.URL)
+		got, err := adapter.GetCIStatus(context.Background(), testPRNumber, scmOwner, scmRepo)
+		if got != "" {
+			t.Errorf("GetCIStatus() = %q, want empty string", got)
+		}
+		adaptertest.AssertSCMErrorKind(t, err, domain.ErrSCMPayload)
+
+		if n := requests.Load(); n != 1 {
+			t.Errorf("requests = %d, want 1 (the merge-request read alone; no statuses request)", n)
+		}
+	})
+
+	// An empty pipeline sha reaches manualGate only through the
+	// generated-merge-ref exempt path once a non-empty merge-request sha
+	// is present, since a non-exempt divergence answers the
+	// head-comparison deferral first. The direct call keeps manualGate's
+	// own guard covered independent of that routing.
+	t.Run("empty sha issues no statuses request", func(t *testing.T) {
+		t.Parallel()
+
+		pipeline := &gitlabPipeline{Status: "manual", ID: manualPipelineID, SHA: ""}
+
+		var requests atomic.Int32
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			requests.Add(1)
+			t.Errorf("unexpected request to %s, want no request issued", r.URL.Path)
+		}))
+		defer srv.Close()
+
+		adapter := mustSCMAdapter(t, srv.URL)
+		got, err := adapter.manualGate(context.Background(), scmOwner, scmRepo, pipeline)
+		if got != "" {
+			t.Errorf("manualGate() = %q, want empty string", got)
+		}
+		adaptertest.AssertSCMErrorKind(t, err, domain.ErrSCMPayload)
+
+		if n := requests.Load(); n != 0 {
+			t.Errorf("requests = %d, want 0 (an empty pipeline sha must not reach the network)", n)
+		}
+	})
 }
 
 func TestMapPipelineStatus_RecognizesAllStatuses(t *testing.T) {


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Fix

**Intent:** `GitLabSCMAdapter.GetCIStatus` classified `head_pipeline.status` without checking whether that pipeline described the merge request's current head. GitLab exposes `head_pipeline` as stored, not re-validated against the commit the merge request currently points at, so a push that produced no pipeline of its own left a superseded pipeline's status in place - letting auto-merge act on a CI verdict that never covered the commit being merged, or holding the gate shut on stale data the other way.

**Related Issues:** #828

### 🧭 Reviewer Guide

**Complexity:** Medium

#### Entry Point

`internal/scm/gitlab/scm_merge.go` - `GetCIStatus` now compares `head_pipeline.sha` against the merge request's own `sha` before trusting the pipeline's status, and withholds the verdict as `CIGatePending` (with a WARN naming both SHAs and the pipeline id) when they disagree. A merge request with no head `sha` of its own now fails as a `domain.SCMError` of kind `ErrSCMPayload`, since head identity can't be established. `isGeneratedMergeRefPipeline` exempts merged-results and merge-train pipelines from the SHA comparison, since those run on a generated ref whose commit exists in neither branch by design.

#### Sensitive Areas

- `internal/scm/gitlab/scm_merge.go`: feeds the auto-merge reaction's CI gate; a wrong verdict here can let a merge proceed on stale CI or block one that should proceed.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes.
- **Migrations/State:** No migrations or state changes.
