### PR TITLE
docs: close handoff-evidence and dispatch-posture doc gaps

### DIFF
--- a/docs/agent-to-orchestrator-protocol.md
+++ b/docs/agent-to-orchestrator-protocol.md
@@ -184,7 +184,7 @@ it remains an immediate exit whether or not self-review is configured. On worker
 orchestrator MUST NOT schedule a continuation retry
 ([architecture Section 8.4](architecture/08-polling-scheduling-and-reconciliation.md#84-retry-and-backoff)). When the dispatch that produced this run drives issue state, the orchestrator
 releases the claim and parks the issue: it records a durable park, applies the configured parking
-label to the issue, and holds it out of dispatch. The park is lifted, and normal dispatch
+label ([architecture Section 14.2](architecture/19-failure-model-and-recovery-strategy.md#142-recovery-behavior)) to the issue, and holds it out of dispatch. The park is lifted, and normal dispatch
 eligibility resumes, when the orchestrator observes either a change in the issue's tracker state
 or the removal of a parking label it has confirmed reached the tracker.
 
@@ -194,8 +194,8 @@ To clarify the two distinct suppression effects:
   immediately after reading the recognized status token. The worker does not proceed to the next
   turn.
 - **Continuation retries** (new worker runs scheduled after a normal worker exit): the
-  post-exit retry handler skips scheduling. The issue is not re-dispatched until its tracker
-  state changes.
+  post-exit retry handler skips scheduling. Where the dispatch drives issue state, the park
+  determines when the issue is re-dispatched; where it does not, nothing is parked.
 
 #### 2.3.2 `needs-human-review`
 
@@ -206,10 +206,12 @@ has low confidence in its solution.
 
 **Orchestrator behavior:** Like `blocked`, this value triggers a soft stop: the turn loop breaks,
 continuation retries are suppressed, and the issue claim is released. Unlike `blocked`, when
-`tracker.handoff_state` is configured ([architecture Section 5.3.1](architecture/05-workflow-specification.md#531-tracker-object)) and the issue is in an active
-tracker state, the orchestrator performs the handoff transition before releasing the claim. If the
-handoff transition fails (network error, permission denied, nil adapter), the orchestrator logs a
-warning and releases the claim without scheduling a retry.
+`tracker.handoff_state` is configured ([architecture Section 5.3.1](architecture/05-workflow-specification.md#531-tracker-object)), the issue is in an active
+tracker state, and the dispatch drives issue state, the orchestrator performs the handoff
+transition before releasing the claim. Where the dispatch does not drive issue state, no transition
+is attempted and the claim is released. If the handoff transition fails (network error, permission
+denied, nil adapter), the orchestrator logs a warning and releases the claim without scheduling a
+retry.
 
 The transition is additionally subject to the run's `tracker.handoff_evidence` verdict
 ([architecture Section 7.3](architecture/07-orchestration-state-machine.md#73-transition-triggers)).
@@ -444,8 +446,9 @@ The cleanup operation MUST apply the same symlink rejection as the read path (Se
 before deleting, verify via `Lstat` that neither `.sortie/` nor `status` is a symbolic link. If
 a symlink is detected, log a warning and skip the deletion — do not follow the link.
 
-If the deletion fails (e.g., the file was already removed, or the `.sortie/` directory does not
-exist), the error is logged at debug level and ignored.
+A deletion that fails because the file is already absent, or because the `.sortie/` directory
+does not exist, is ignored without a log entry. Any other removal error is logged at warn level
+and ignored.
 
 ```
 function pre_dispatch_cleanup(workspace_path):
@@ -455,7 +458,7 @@ function pre_dispatch_cleanup(workspace_path):
         return
     err = remove(status_path)
     if err and err is not "file not found":
-        log_debug("status file cleanup failed", workspace_path, err)
+        log_warn("status file cleanup failed", workspace_path, err)
 ```
 
 The orchestrator applies this same removal a second time during a run, at the moment it acts on
@@ -484,6 +487,13 @@ An update to the issue that is neither a state change nor a removal of the confi
 label, for example adding a comment while leaving both the state and the label untouched, does
 not lift the park.
 
+Where `tracker.query_filter` excludes the parking label, the label removal in step 3 releases
+nothing. The orchestrator observes labels only on the issues the candidate query returns, so it
+never confirms the label reached the tracker, and an unconfirmed label's absence does not lift
+the park. Such an issue is released by moving it to a different tracker state: the orchestrator
+reads the state of every parked issue the candidate query omits through a separate, filter-free
+tracker call.
+
 The polling interval provides natural rate limiting for this cycle. No additional idempotency
 mechanism is required.
 
@@ -495,9 +505,9 @@ exit phase. The status file value determines whether the handoff transition fire
 
 | `.sortie/status` value | Worker exit | Handoff transition | Continuation retry |
 |---|---|---|---|
-| `needs-human-review` | Normal | Performed (if configured and issue is active) | Suppressed |
+| `needs-human-review` | Normal | Performed (if configured, issue is active, and the dispatch drives issue state) | Suppressed |
 | `blocked` | Normal | Skipped; issue parked instead where the dispatch drives issue state | Suppressed |
-| absent or unrecognized | Normal | Performed (if configured and issue is active) | Depends on handoff result |
+| absent or unrecognized | Normal | Performed (if configured, issue is active, and the dispatch drives issue state) | Depends on handoff result |
 | (any) | Error | Skipped | Standard error retry |
 
 The parking label the orchestrator applies on a `blocked` park is a non-state write: it marks the
@@ -515,8 +525,7 @@ The semantic distinction drives the difference: `blocked` means the agent cannot
 there is no completed work to hand off. `needs-human-review` means the agent completed its work
 and the issue should move to a review state in the tracker.
 
-Both values suppress continuation retries and release the issue claim. The handoff transition is
-the only behavioral divergence between them.
+Both values suppress continuation retries and release the issue claim.
 
 When a `handoff_state` is configured and the agent writes `blocked`, the orchestrator skips the
 handoff transition entirely. The issue remains in its current tracker state. This is correct:
@@ -830,8 +839,8 @@ An implementation conforms to this specification if it satisfies all of the foll
    at the moment it acts on a recognized value that admits the run to the self-review phase per
    Section 2.3.2 and Section 3.4.
 6. The orchestrator never writes to `.sortie/status`, and its only removals of the file are the
-   pre-dispatch cleanup and the removal on admission to the self-review phase, both per
-   Section 3.2 and Section 3.4.
+   pre-dispatch cleanup and the removal it makes each time it acts on a recognized value read
+   during a run, both per Section 3.2 and Section 3.4.
 7. The status file does not trigger tracker state transitions per Section 3.6.
 8. Symbolic links at any path component are treated as read errors per Section 7.2.
 9. Pre-dispatch cleanup applies the same symlink rejection as reads per Section 3.4.

--- a/docs/architecture/26-agent-authored-workspace-files.md
+++ b/docs/architecture/26-agent-authored-workspace-files.md
@@ -27,8 +27,9 @@ Recognized values:
   (Section 7); it remains an immediate exit whether or not self-review is configured.
 - `needs-human-review`: agent signals that work is complete and requires review. Like `blocked`,
   this value suppresses continuation retries and releases the issue claim. Unlike `blocked`, when
-  `tracker.handoff_state` is configured and the issue is in an active tracker state, the
-  orchestrator performs the handoff transition (Section 5.3.1). This ensures completed work moves
+  `tracker.handoff_state` is configured, the issue is in an active tracker state, and the dispatch
+  drives issue state, the orchestrator performs the handoff transition (Section 5.3.1). This
+  ensures completed work moves
   to a review state in the tracker, maintaining tracker-as-source-of-truth semantics. If
   `tracker.handoff_state` is not configured, the issue becomes eligible for re-dispatch on future
   tracker polls under normal dispatch rules; unlike `blocked` in that deployment, no park is

--- a/docs/workflow-reference.md
+++ b/docs/workflow-reference.md
@@ -199,7 +199,8 @@ tracker:
 | `active_states`   | list of strings | **Yes** (see rules below) | `[]` (empty)    | Future dispatch and reconciliation | Issue states eligible for agent dispatch. An issue is eligible for dispatch only if its state appears in this list. An empty list means no issues will be dispatched.                           |
 | `terminal_states` | list of strings | **Yes** (see rules below) | `[]` (empty)    | Future dispatch and reconciliation | Issue states that release claims and trigger cleanup.                                                                                                                                           |
 | `query_filter`    | string          | No                        | `""` (empty)    | Future dispatches                  | Adapter-defined query fragment that narrows the candidate issue query and, for adapters that apply it there, the terminal-state query. Each adapter interprets it in its own query language. For Jira: JQL fragment (e.g., `"labels = 'agent-ready'"`). For Linear: an `IssueFilter` JSON object, merged rather than appended (see the Linear note below). For Gitea: a URL query fragment for the repo issue-list route, merged into candidate polling only (see the Gitea note below). For GitLab: a URL query fragment for the project issue-list route, key-checked against an allowlist and merged into candidate polling only (see the GitLab note below). |
-| `handoff_state`   | string          | No                        | _(absent)_      | Future worker exits                | Target tracker state for orchestrator-initiated handoff after successful worker run. When absent, no handoff transition is performed. The transition is suppressed when the issue has already reached a terminal state.                                     |
+| `handoff_state`   | string          | No                        | _(absent)_      | Future worker exits                | Target tracker state for orchestrator-initiated handoff after successful worker run. When absent, no handoff transition is performed. The transition is suppressed when the issue has already reached a terminal state, and withheld when the run's frozen `handoff_evidence` policy does not permit the write ([architecture §11.5](architecture/11-issue-tracker-integration-contract.md#115-tracker-writes-important-boundary)). |
+| `handoff_evidence` | string         | No                        | `observed`      | Future worker attempts             | Policy governing the evidence condition on an otherwise-eligible handoff. `observed` withholds only when absence of work is positively observed and allows an undeterminable verdict; `strict` also withholds an undeterminable verdict; `off` restores the prior four-condition decision and performs no baseline capture, exit-time workspace inspection, or evidence logging. Values outside `observed`, `strict`, and `off` are rejected as a closed set while configuration is parsed, without contacting the tracker, so startup, reload, and `sortie validate` all reject the same value. See [architecture §6.4](architecture/06-configuration-specification.md#64-config-fields-summary-cheat-sheet) for the verdict's derivation. |
 | `in_progress_state` | string        | No                        | _(absent)_      | Future dispatches                  | Target tracker state for dispatch-time transition at the start of each worker attempt. When absent, no dispatch-time transition is performed. Must be in `active_states`. Must not collide with `terminal_states` or `handoff_state`. |
 | `comments`        | map of booleans | No                        | all `false`     | Future dispatches (`on_dispatch`); future worker exits (`on_completion`, `on_failure`) | Toggles for orchestrator-posted tracker comments at session lifecycle points. Keys: `on_dispatch`, `on_completion`, `on_failure`. Each is a boolean defaulting to `false`. Non-boolean values are rejected with a configuration error. See [Section 3.2](#32-curated-variable-list) for the matching `SORTIE_TRACKER_COMMENTS_*` env overrides. |
 
@@ -239,8 +240,30 @@ tracker:
   still caught. The verification read is skipped when `terminal_states` is empty, because
   no value can classify as terminal there. A failed verification read is logged and the
   handoff proceeds.
-- Each suppressed transition increments `sortie_handoff_transitions_total` with
-  `result="skipped"` (see [Section 4.1](#41-http-server-serverport-serverhost)).
+- A transition suppressed by a terminal state, or by the issue not being in an active state at
+  worker exit, increments `sortie_handoff_transitions_total` with `result="skipped"`. One withheld
+  by the evidence verdict increments the same counter with `result="withheld"` instead
+  (see [Section 4.1](#41-http-server-serverport-serverhost)).
+
+**`handoff_evidence` runtime behavior:**
+
+- The evidence condition is a fifth condition on the handoff path, consulted only where four
+  conditions already select that path: a handoff state is configured, the issue is still in an
+  active state, the exit is not a blocked soft stop, and the dispatch drives issue state. It can
+  suppress a handoff write and can never cause one.
+- The verdict has three values, not two: work observed, absence of work observed, and evidence not
+  determinable. It is computed at worker exit over the run's workspace against a baseline captured
+  immediately before the agent starts. Under `off` no baseline is captured and no verdict is
+  computed, so the four-condition decision stands unchanged.
+- A withheld run makes no handoff transition and no pre-write verification read, leaves the issue
+  in its active tracker state, is recorded in run history as `failed` with the verdict as its error
+  reason, and schedules the ordinary exponential-backoff failure path rather than the fixed-delay
+  continuation path.
+- Consecutive withheld outcomes are counted per issue, and reaching the ceiling parks the issue
+  under a label whose name is taken from `reactions.review_comments.escalation_label`. That
+  ceiling's derivation from `agent.max_sessions`, the reset rule for the count, and the two
+  operator gestures that release a park are specified in
+  [architecture §14.2](architecture/19-failure-model-and-recovery-strategy.md#142-recovery-behavior).
 
 **`in_progress_state` validation rules:**
 
@@ -1840,6 +1863,7 @@ as an environment variable reference.
 | `hooks.timeout_ms`                     | Low-risk tuning; hooks are rarely changed per-environment       |
 | `agent.max_concurrent_agents_by_state` | Complex map type; no clean single-value representation          |
 | `tracker.api_version`                  | No override variable exists; set it in the front matter or through `$VAR` indirection |
+| `tracker.handoff_evidence`             | No override variable exists; set it in the front matter. The value is matched against the closed set as written, so `$VAR` indirection does not apply. |
 | `notifications`                        | List of pass-through backend maps; no single-value representation. Backend secrets are referenced via `$SORTIE_*` indirection from inside the entry (see Section 2.12), not as field-level overrides. |
 | `ci_feedback.*`                        | No override variables exist; the section is deprecated and rarely differs per environment |
 | `reactions.*` (including `reactions.label_commands`) | No override variables exist; reaction configuration comes from WORKFLOW.md |
@@ -2167,12 +2191,13 @@ are included alongside Sortie-specific metrics.
 | `sortie_tokens_total`                           | Counter   | `type`                      | Tokens consumed, by type (`input`, `output`, `cache_read`).    |
 | `sortie_agent_runtime_seconds_total`            | Counter   | —                           | Cumulative agent-session wall-clock time for completed sessions. |
 | `sortie_dispatches_total`                       | Counter   | `outcome`                   | Dispatch attempts (`success`, `error`).                        |
-| `sortie_worker_exits_total`                     | Counter   | `exit_type`                 | Worker exits (`normal`, `error`, `cancelled`).                 |
+| `sortie_worker_exits_total`                     | Counter   | `exit_type`                 | Worker exits (`normal`, `error`, `cancelled`, `soft_stop`).    |
 | `sortie_retries_total`                          | Counter   | `trigger`                   | Retry schedule events (`error`, `continuation`, `timer`, `stall`). |
 | `sortie_reconciliation_actions_total`           | Counter   | `action`                    | Reconciliation outcomes (`stop`, `cleanup`, `keep`, `sweep_cleanup`, `sweep_expired`). |
 | `sortie_poll_cycles_total`                      | Counter   | `result`                    | Poll tick completions (`success`, `error`, `skipped`).         |
 | `sortie_tracker_requests_total`                 | Counter   | `operation`, `result`       | Tracker adapter API calls by operation and result.             |
-| `sortie_handoff_transitions_total`              | Counter   | `result`                    | Handoff-state transition attempts (`success`, `error`, `skipped`). `skipped` covers both suppression causes: the issue had already reached a terminal state, or the issue was not in an active state at worker exit. Recorded only when `tracker.handoff_state` is set. |
+| `sortie_handoff_transitions_total`              | Counter   | `result`                    | Handoff-state transition attempts (`success`, `error`, `skipped`, `withheld`). `skipped` covers two suppression causes: the issue had already reached a terminal state, or the issue was not in an active state at worker exit. `withheld` is the third: the run's handoff-evidence verdict did not permit the write, and the run is recorded as failed. Recorded only when `tracker.handoff_state` is set. |
+| `sortie_issue_parks_total`                      | Counter   | `reason`                    | Issue park events (`agent_blocked`, `handoff_absence`).        |
 | `sortie_tool_calls_total`                       | Counter   | `tool`, `result`            | Agent tool call completions by tool name and result.           |
 | `sortie_poll_duration_seconds`                  | Histogram | —                           | Wall-clock time per poll cycle.                                |
 | `sortie_worker_duration_seconds`                | Histogram | `exit_type`                 | Worker session wall-clock time.                                |
@@ -3115,6 +3140,7 @@ re-applies configuration and prompt template without restart.
 | `tracker.query_filter`                 | Future dispatches.                                                                             |
 | `tracker.handoff_state`                | Future worker exits, not in-flight sessions.                                                   |
 | `tracker.in_progress_state`            | Future dispatches, not in-flight sessions.                                                     |
+| `tracker.handoff_evidence`             | Future worker attempts, not in-flight sessions.                                                |
 | `polling.interval_ms`                  | **Immediate** — affects future tick scheduling.                                                |
 | `workspace.root`                       | Future workspace operations.                                                                   |
 | `workspace.retention_days`             | Dynamic reload. Applies on the next sweep pass.                                                |
@@ -3265,6 +3291,8 @@ Each error identifies the offending field path.
 | `config: tracker.handoff_state: resolved to empty (check environment variable)` | `$VAR` reference resolved to an empty string (variable unset or empty).  | Set the referenced environment variable to a valid state name.                                                                       |
 | `config: tracker.handoff_state: "<val>" collides with active state "<state>"`   | `handoff_state` matches one of the `active_states` (case-insensitive).   | Use a state that is not in `active_states`. The handoff state must be distinct from active and terminal states.                      |
 | `config: tracker.handoff_state: "<val>" collides with terminal state "<state>"` | `handoff_state` matches one of the `terminal_states` (case-insensitive). | Use a state that is not in `terminal_states`.                                                                                        |
+| `config: tracker.handoff_evidence: expected string, got <type>`                 | `handoff_evidence` is not a string (e.g., integer, boolean, list).       | Ensure the value is a string, quoted if necessary.                                                                                   |
+| `config: tracker.handoff_evidence: must be one of observed, strict, or off`     | `handoff_evidence` is set to a value outside the closed set.             | Use `observed`, `strict`, or `off`. Omit the field to keep the default `observed`.                                                   |
 | `config: tracker.in_progress_state: expected string, got <type>`                    | `in_progress_state` is not a string (e.g., integer, boolean, list).          | Ensure the value is a string, quoted if necessary.                                                                                   |
 | `config: tracker.in_progress_state: must not be empty`                              | `in_progress_state` is set to an explicit empty string.                      | Provide a valid state name, or omit the field entirely to disable dispatch-time transitions.                                         |
 | `config: tracker.in_progress_state: resolved to empty (check environment variable)` | `$VAR` reference resolved to an empty string (variable unset or empty).      | Set the referenced environment variable to a valid state name.                                                                       |
@@ -3329,6 +3357,7 @@ lists the `SORTIE_*` variable that overrides the field, or "—" if not overrida
 | `tracker.terminal_states`               | `[string]`       | `[]` (empty)                 | `SORTIE_TRACKER_TERMINAL_STATES`         | CSV; at least one of active/terminal required                                          |
 | `tracker.query_filter`                  | string           | `""`                         | `SORTIE_TRACKER_QUERY_FILTER`            | Adapter-interpreted                                                                    |
 | `tracker.handoff_state`                 | string           | _(absent)_                   | `SORTIE_TRACKER_HANDOFF_STATE`           | Must not collide with active/terminal                                                  |
+| `tracker.handoff_evidence`              | string           | `observed`                   | —                                        | `observed`, `strict`, or `off`; closed set                                             |
 | `tracker.in_progress_state`             | string           | _(absent)_                   | `SORTIE_TRACKER_IN_PROGRESS_STATE`       | Must be in active; must not collide with terminal/handoff                              |
 | `tracker.api_version`                   | string           | `"3"`                        | —                                        | Jira only; `"3"` (Cloud) or `"2"` (Server/DC); `$VAR` supported; quote the value       |
 | `tracker.comments.on_dispatch`          | bool             | `false`                      | `SORTIE_TRACKER_COMMENTS_ON_DISPATCH`    |                                                                                        |

--- a/docs/workflow-reference.md
+++ b/docs/workflow-reference.md
@@ -256,9 +256,9 @@ tracker:
   immediately before the agent starts. Under `off` no baseline is captured and no verdict is
   computed, so the four-condition decision stands unchanged.
 - A withheld run makes no handoff transition and no pre-write verification read, leaves the issue
-  in its active tracker state, is recorded in run history as `failed` with the verdict as its error
-  reason, and schedules the ordinary exponential-backoff failure path rather than the fixed-delay
-  continuation path.
+  in its active tracker state, is recorded in run history as `failed` with an error reason composed
+  of a reserved marker prefix, the verdict, and the policy that withheld it, and schedules the
+  ordinary exponential-backoff failure path rather than the fixed-delay continuation path.
 - Consecutive withheld outcomes are counted per issue, and reaching the ceiling parks the issue
   under a label whose name is taken from `reactions.review_comments.escalation_label`. That
   ceiling's derivation from `agent.max_sessions`, the reset rule for the count, and the two

--- a/internal/domain/metrics.go
+++ b/internal/domain/metrics.go
@@ -71,8 +71,8 @@ type Metrics interface {
 	IncTrackerRequests(operation string, result string)
 
 	// IncHandoffTransitions increments the handoff state transition
-	// outcome counter. result is "success", "error", or "skipped"
-	// (sortie_handoff_transitions_total{result} counter).
+	// outcome counter. result is "success", "error", "skipped", or
+	// "withheld" (sortie_handoff_transitions_total{result} counter).
 	IncHandoffTransitions(result string)
 
 	// IncIssueParks increments the issue park counter. reason is


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Docs

**Intent:** Bring the agent-to-orchestrator protocol, architecture, and workflow-reference docs in line with behavior that already shipped - the `withheld` handoff-transition outcome, the `soft_stop` worker exit type, the `sortie_issue_parks_total` metric, and the `query_filter` interaction with parking-label release were implemented in code but not yet documented.

### 🧭 Reviewer Guide

**Complexity:** Low

#### Entry Point

`docs/workflow-reference.md` - carries the bulk of the change: the new `tracker.handoff_evidence` field runtime-behavior section, the `withheld` metric result value, the `sortie_issue_parks_total` metric row, and validation/reload/env-override table entries for `handoff_evidence`.

#### Sensitive Areas

- `docs/agent-to-orchestrator-protocol.md`: describes the `blocked`/`needs-human-review` handoff and park semantics that the orchestrator implements; verify the described conditions (dispatch drives issue state, query_filter excluding the parking label) still match `internal/orchestrator/exit.go` and `internal/orchestrator/park.go`.
- `internal/domain/metrics.go`: godoc-only change to the `IncHandoffTransitions` comment, listing the `withheld` result value already emitted by `internal/orchestrator/exit.go`.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes
- **Migrations/State:** No migrations or state changes