### PR TITLE
fix(scm/gitlab): narrow the unrecognized mergeability warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -156,6 +156,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   exists in neither branch and never match the head by design.
   ([#828](https://github.com/sortie-ai/sortie/issues/828))
 
+- GitLab: mergeability reads no longer warn about values GitLab
+  documents and the adapter already handles. A draft merge request, one
+  that is no longer open, and one whose pipeline is still running each
+  logged `unrecognized gitlab detailed_merge_status value` at WARN on
+  every poll for as long as the condition held, burying the diagnostic
+  that exists to surface a value a newer GitLab release introduced. The
+  warning is now raised only for a value outside the set GitLab's API
+  documents, and every mergeability verdict is unchanged. Licensed
+  instances stop warning on five further blocking values, among them
+  failing status checks and security policy violations, which the
+  adapter had been matching against the wrong spelling. A merge request
+  held back by a merge check is now reported at DEBUG, naming the value
+  and the merge request it came from.
+  ([#829](https://github.com/sortie-ai/sortie/issues/829))
+
 ### Migrations
 
 - Add the `handoff_absence_resets` table, recording per issue where its

--- a/docs/architecture/14-auto-merge-reaction-contract.md
+++ b/docs/architecture/14-auto-merge-reaction-contract.md
@@ -149,7 +149,8 @@ to `NOT_REQUIRED`, and this table proceeds to the merge. Enforcing review on Com
 means assigning a reviewer, because the platform offers no server-side alternative.
 `GetMergeability` maps GitLab's single `detailed_merge_status` value: `mergeable` to `clean`,
 `conflict` to `dirty`, `unchecked`, `checking`, `preparing`, and `approvals_syncing` to `unknown`,
-and every other value, recognized or not, to `blocked`, logging an unrecognized one at WARN. It
+and every other value to `blocked`, logging at WARN only a value outside the set the platform
+documents. It
 never yields `unstable`, because a pipeline whose only failing job is allowed to fail reports
 success and leaves the merge request `mergeable`, and this table treats `clean` and `unstable`
 identically. The value names one blocking condition at a time and recomputes: approving a merge

--- a/docs/gitlab-adapter-notes.md
+++ b/docs/gitlab-adapter-notes.md
@@ -1568,7 +1568,10 @@ values come from `MergeRequests::Mergeability::DetailedMergeStatusService#execut
 first-party [Merge requests API reference](https://docs.gitlab.com/api/merge_requests/), which
 documents the same 24 wire strings **[docs]**. Seven values were observed directly in REST
 bodies: `preparing`, `checking`, `mergeable`, `conflict`, `draft_status`, `not_open`, and
-`ci_still_running` **[live-CE]**. The rest are **[live-CE]** at schema level only.
+`ci_still_running` **[live-CE]**. The remaining seventeen were not observed in a REST body
+during this characterization and rest on **[source]** and **[docs]**. Their GraphQL counterparts
+are **[live-CE]** through schema introspection, which is a property of the GraphQL enum; the REST
+surface publishes no enum to introspect.
 
 **The Community Edition source file and the running instance disagree, and the gap is
 resolved.** `app/graphql/types/merge_requests/detailed_merge_status_enum.rb` declares **22**
@@ -1619,8 +1622,9 @@ adapter simply never emits `unstable`, matching the Gitea adapter, which never e
 affirmative and computing arms is a blocking reason, so an unfamiliar value from a newer
 instance is far more likely to be a new blocker than a new computing state. Both arms
 re-enqueue, so this choice is about not misreporting a permanent blocker as transient. The
-adapter logs at WARN only a value outside the documented set, the union of the two vocabularies
-above; a documented blocking value stays available to the operator at Debug rather than WARN.
+adapter logs at WARN only a value outside the documented wire set, the 24 REST strings above.
+A GraphQL-only spelling is not a wire value, so it is unexpected and does trip the WARN. A
+documented blocking value stays available to the operator at Debug rather than WARN.
 The set has only grown across the releases sampled (`v16.11.0-ee` declares 16 values,
 `v17.11.0-ee` declares 21, `v18.5.0-ee` declares 22, each a subset of the pinned 24), so a
 deployment older than the pinned version reports a subset of it and never trips the WARN for a

--- a/docs/gitlab-adapter-notes.md
+++ b/docs/gitlab-adapter-notes.md
@@ -1538,43 +1538,59 @@ blocker at a time with undocumented precedence (see [mergeability](#2-mergeabili
 
 ### 2. Mergeability
 
-`detailed_merge_status` is a single string naming **one** blocking condition. The version-exact
-enumeration was read from the live instance's own GraphQL schema, which is the authority for
-this deployment rather than the upstream default branch:
+`detailed_merge_status` is a single string naming **one** blocking condition. The adapter
+classifies against the wire vocabulary the REST surface actually reports, which is 24 values
+across two groups:
 
 ```
-approvals_syncing  blocked_status  checking  ci_must_pass  ci_still_running
-commits_status  conflict  discussions_not_resolved  draft_status
-external_status_checks  jira_association  locked_lfs_files  locked_paths
-mergeable  merge_time  need_rebase  not_approved  not_open  preparing
-requested_changes  security_policies_violations  security_policy_pipeline_check
-title_not_matching  unchecked
+mergeable  conflict  unchecked  checking  preparing  approvals_syncing
 ```
 
-24 values **[live-CE]**. REST renders them lowercase snake_case; the GraphQL enum renders the
-same symbols upper-case. Six were observed directly in REST bodies: `preparing`, `checking`,
-`mergeable`, `conflict`, `draft_status`, and `not_open` **[live-CE]**. The rest are
-**[live-CE]** at schema level only.
+```
+ci_must_pass  ci_still_running  commits_status  discussions_not_resolved
+draft_status  locked_lfs_files  merge_time  need_rebase  not_open
+jira_association_missing  locked_paths  merge_request_blocked  not_approved
+requested_changes  security_policy_pipeline_check  security_policy_violations
+status_checks_must_pass  title_regex
+```
 
-**The source file and the running instance disagree, and the gap was not fully explained.**
-`app/graphql/types/merge_requests/detailed_merge_status_enum.rb` declares **22** values, and the
-file is byte-identical at the `v19.2.1-ee` tag and on the upstream default branch (its last
-change was 2025-04-15, confirmed through the repository commit history) **[source]**. The
-running Community Edition 19.2.1 instance serves **24**, adding `requested_changes` and
-`security_policy_pipeline_check` **[live-CE]**. The file ends with
-`DetailedMergeStatusEnum.prepend_mod_with(...)`, the hook an Enterprise module uses to extend it,
-but the expected `ee/app/graphql/types/merge_requests/detailed_merge_status_enum.rb` path returns
-404 **[source]**, so **the file that contributes the two extra values was not located**. This is
-carried into the [open questions](#open-questions) rather than resolved by inference.
+The GraphQL enum and the REST surface spell five of those values differently: `blocked_status`
+is `merge_request_blocked`, `external_status_checks` is `status_checks_must_pass`,
+`jira_association` is `jira_association_missing`, `security_policies_violations` is
+`security_policy_violations`, and `title_not_matching` is `title_regex`. REST does not render
+the GraphQL enum's own spelling in lowercase snake_case; the two vocabularies are independently
+named identifiers that agree on nineteen strings and diverge on five.
 
-Two consequences hold regardless of where the extra values come from:
+The two vocabularies were established independently and cross-checked against each other. The
+24 GraphQL names come from the live instance's own introspection **[live-CE]**. The 24 wire
+values come from `MergeRequests::Mergeability::DetailedMergeStatusService#execute` and the
+`set_identifier` declaration on each of its check services **[source]**, and agree with the
+first-party [Merge requests API reference](https://docs.gitlab.com/api/merge_requests/), which
+documents the same 24 wire strings **[docs]**. Seven values were observed directly in REST
+bodies: `preparing`, `checking`, `mergeable`, `conflict`, `draft_status`, `not_open`, and
+`ci_still_running` **[live-CE]**. The rest are **[live-CE]** at schema level only.
+
+**The Community Edition source file and the running instance disagree, and the gap is
+resolved.** `app/graphql/types/merge_requests/detailed_merge_status_enum.rb` declares **22**
+values, and the file is byte-identical at the `v19.2.1-ee` tag and on the upstream default
+branch (its last change was 2025-04-15, confirmed through the repository commit history)
+**[source]**. The running Community Edition 19.2.1 instance serves **24**, adding
+`requested_changes` and `security_policy_pipeline_check`. Both come from
+`ee/app/graphql/ee/types/merge_requests/detailed_merge_status_enum.rb`, which prepends them onto
+the Community Edition enum through `DetailedMergeStatusEnum.prepend_mod_with(...)` **[source]**.
+The pinned instance also serves Enterprise-only GraphQL types (`Epic`, `ApprovalRule`,
+`MergeRequestApprovalState`) while reporting `enterprise: false` **[live-CE]**, which is what
+makes the two Enterprise-sourced values reachable in its schema despite the instance identifying
+as Community Edition.
+
+Two consequences hold regardless of edition:
 
 - **A declared value is not a reachable value.** Enum membership describes the schema surface,
   not what a licensed check can actually emit. `not_approved` is declared and, as shown above,
   cannot occur on Community Edition because no approval rule exists to produce it.
-- **The mapping MUST have a default arm.** The list is demonstrably not closed against the source
-  file, so an adapter that switches exhaustively over 22 or even 24 values will meet a string it
-  does not know.
+- **The mapping MUST have a default arm.** The list is demonstrably not closed against the
+  Community Edition source file, so an adapter that switches exhaustively over 22 or even 24
+  values will meet a string it does not know.
 
 **Mapping to `domain.MergeabilityState`:**
 
@@ -1599,11 +1615,16 @@ request in that state reports `mergeable` and maps to `clean`. The warning is vi
 The merge state machine treats `clean` and `unstable` identically, so nothing is lost; the
 adapter simply never emits `unstable`, matching the Gitea adapter, which never emits it either.
 
-**Unrecognized values map to `blocked`, not `unknown`.** Every value in the live enum other than
-`mergeable` and the four computing states is a blocking reason, so an unfamiliar value from a
-newer instance is far more likely to be a new blocker than a new computing state. Both arms
+**A value outside the documented set maps to `blocked`, not `unknown`.** Every value outside the
+affirmative and computing arms is a blocking reason, so an unfamiliar value from a newer
+instance is far more likely to be a new blocker than a new computing state. Both arms
 re-enqueue, so this choice is about not misreporting a permanent blocker as transient. The
-adapter SHOULD log the unrecognized value at WARN.
+adapter logs at WARN only a value outside the documented set, the union of the two vocabularies
+above; a documented blocking value stays available to the operator at Debug rather than WARN.
+The set has only grown across the releases sampled (`v16.11.0-ee` declares 16 values,
+`v17.11.0-ee` declares 21, `v18.5.0-ee` declares 22, each a subset of the pinned 24), so a
+deployment older than the pinned version reports a subset of it and never trips the WARN for a
+value this adapter already expects.
 
 **Robustness to masking, which the mapping MUST assume.** GitLab returns one value even when
 several conditions block at once, and the precedence between them is neither documented nor
@@ -1907,9 +1928,9 @@ A project that enables the "Pipelines must succeed" setting
 (`only_allow_merge_if_pipeline_succeeds: true`) never reaches the CI read at all.
 There a merge request whose head pipeline is `manual` reports
 `detailed_merge_status: "ci_still_running"` while `merge_status` stays `can_be_merged`
-**[live-CE]**, which is outside `mapMergeability`'s
-recognized set and lands in its `blocked` arm, so the auto-merge precondition table stops on
-mergeability before it calls `GetCIStatus`. The value is `ci_still_running` rather than
+**[live-CE]**, which `mapMergeability` classifies as an expected blocking value and maps to
+`blocked`, so the auto-merge precondition table stops on mergeability before it calls
+`GetCIStatus`, and the read produces no WARN. The value is `ci_still_running` rather than
 `ci_must_pass` because the reason is chosen by `diff_head_pipeline_considered_in_progress?`,
 which under that setting reduces to `!pipeline.complete?`, and `manual` is not one of the four
 completed statuses
@@ -1917,8 +1938,7 @@ completed statuses
 [`app/models/merge_request.rb`](https://gitlab.com/gitlab-org/gitlab/-/blob/v19.2.1-ee/app/models/merge_request.rb),
 [`app/models/concerns/ci/has_status.rb`](https://gitlab.com/gitlab-org/gitlab/-/blob/v19.2.1-ee/app/models/concerns/ci/has_status.rb))
 **[source]**. `ci_still_running` is one of the 24 values the instance's own `DetailedMergeStatus`
-enum declares **[live-CE]**, and it reaches `mapMergeability`'s unrecognized arm, so the adapter
-logs one WARN naming it on each such read.
+enum declares **[live-CE]**.
 
 A `skipped` pipeline created by a `[ci skip]` commit carries no commit-status entry at all,
 rather than one entry per skipped job: the pipeline-creation chain halts before it seeds any
@@ -2402,7 +2422,7 @@ Stated plainly, with the degradation rather than a workaround:
 | Merge-request approval Community/Enterprise split | [`lib/api/merge_request_approvals.rb`](https://gitlab.com/gitlab-org/gitlab/-/blob/v19.2.1-ee/lib/api/merge_request_approvals.rb) and [`ee/lib/ee/api/merge_request_approvals.rb`](https://gitlab.com/gitlab-org/gitlab/-/blob/v19.2.1-ee/ee/lib/ee/api/merge_request_approvals.rb) | Live: `approvals` route matched, `approval_state` did not |
 | Per-reviewer review state route and entity | [`lib/api/merge_requests.rb`](https://gitlab.com/gitlab-org/gitlab/-/blob/v19.2.1-ee/lib/api/merge_requests.rb) and [`lib/api/entities/merge_request_reviewer.rb`](https://gitlab.com/gitlab-org/gitlab/-/blob/v19.2.1-ee/lib/api/entities/merge_request_reviewer.rb) | Live: state read as `unreviewed`, `approved`, and `unapproved` in turn. Route is defined outside `ee/` and is undocumented in the reference docs |
 | Review-state enum | [`app/models/concerns/merge_request_reviewer_state.rb`](https://gitlab.com/gitlab-org/gitlab/-/blob/v19.2.1-ee/app/models/concerns/merge_request_reviewer_state.rb) | Six values; the `ee/` override path returns 404. Corroborated by the live instance's `MergeRequestReviewState` GraphQL enum |
-| `detailed_merge_status` enumeration | The live instance's own GraphQL introspection, and [`app/graphql/types/merge_requests/detailed_merge_status_enum.rb`](https://gitlab.com/gitlab-org/gitlab/-/blob/v19.2.1-ee/app/graphql/types/merge_requests/detailed_merge_status_enum.rb) | 24 values on 19.2.1 against 22 on the upstream default branch; six confirmed in REST bodies |
+| `detailed_merge_status` enumeration | Live introspection for the 24 GraphQL names; [`app/services/merge_requests/mergeability/detailed_merge_status_service.rb`](https://gitlab.com/gitlab-org/gitlab/-/blob/v19.2.1-ee/app/services/merge_requests/mergeability/detailed_merge_status_service.rb) and each check service's `set_identifier` declaration for the 24 wire values; the [Merge requests API reference](https://docs.gitlab.com/api/merge_requests/) as the independent cross-check | Seven values confirmed in REST bodies; all three sources agree on the 24-value set and its five divergent spellings |
 | Merge-endpoint check ordering, the 405 constant, and the conditional `sha` requirement | [`lib/api/merge_requests.rb`](https://gitlab.com/gitlab-org/gitlab/-/blob/v19.2.1-ee/lib/api/merge_requests.rb) (`build_merge_params`, `check_sha_param!`, `execute_merge`, `not_allowed!`) | Live: all five response classes provoked in order |
 | Absence of a bot marker on embedded users | [`lib/api/entities/note.rb`](https://gitlab.com/gitlab-org/gitlab/-/blob/v19.2.1-ee/lib/api/entities/note.rb) and [`lib/api/entities/user_basic.rb`](https://gitlab.com/gitlab-org/gitlab/-/blob/v19.2.1-ee/lib/api/entities/user_basic.rb) | Live: identical author key sets for a token-bot note and a human note; `bot` present only on `GET /users/:id` |
 | Single-value `detailed_merge_status` masking | [gitlab-org/gitlab#570458](https://gitlab.com/gitlab-org/gitlab/-/issues/570458) | Upstream issue report; the precedence itself was not reproduced here |
@@ -2430,7 +2450,7 @@ that would settle it.
 | Does self-managed Community Edition 19.2.1 support granular access tokens, and what does introspection report? | Decides whether scope preflight can be trusted on self-managed | Create a granular token on a self-managed Community Edition instance and read `/personal_access_tokens/self` |
 | At what `iids[]` count does a deployment return `414`? | Sets the batch chunk size for reconciliation | Increase `iids[]` count against a representative front-end web server configuration |
 | Do 409 or 422 statuses occur anywhere on the nine operations' routes? | Two rows of the error mapping are unexercised | Provoke a conflict or unprocessable-entity condition on the issue routes |
-| Which file contributes `requested_changes` and `security_policy_pipeline_check` to a Community Edition instance's `DetailedMergeStatus` enum? | The Community Edition source file declares 22 values and the running instance serves 24, so the enum cannot be enumerated from the source path alone, and it is unclear whether either value is reachable without a license | Locate the module reached by `DetailedMergeStatusEnum.prepend_mod_with`, and check whether its mergeability checks are license-gated at runtime |
+| Can `requested_changes` or `security_policy_pipeline_check` actually occur on a deployment reporting `enterprise: false`? | Both values are declared by `ee/app/graphql/ee/types/merge_requests/detailed_merge_status_enum.rb` and reach the schema regardless, but whether their producing checks run without a license was not established | Construct a merge request that trips either check on a Community Edition instance and confirm the value is reported rather than a license refusal |
 | What is the precedence order among simultaneously blocking `detailed_merge_status` values? | Decides how many poll ticks a merge request needs to clear several blockers, and whether any blocker can be starved indefinitely | Construct a merge request that is simultaneously conflicted, draft, and unapproved, and record which value is reported as each condition is cleared in turn |
 | Does `require_sha_for_merge?` vary by namespace or instance, and what governs it? | The adapter always sends `sha`, so behavior is safe either way, but a wrong error message would mislead an operator whose instance does not require it | Read `require_sha_for_merge?` on a second namespace, and on an instance where the merge call succeeds without `sha` |
 | Can a reviewer reach `requested_changes` on Community Edition through the web UI, and does the REST `reviewers` route then report it? | The `FetchPendingReviews` selection rests on that state being reachable; only `approved` and `unapproved` were produced through the API | Drive the "request changes" action in the Community Edition web UI, then re-read `GET .../merge_requests/:iid/reviewers` |

--- a/internal/scm/gitlab/integration_scm_test.go
+++ b/internal/scm/gitlab/integration_scm_test.go
@@ -278,6 +278,15 @@ func TestIntegration_GetMergeability(t *testing.T) {
 	})
 
 	t.Run("draft_blocked", func(t *testing.T) {
+		concrete, ok := adapter.(*GitLabSCMAdapter)
+		if !ok {
+			t.Fatalf("adapter type = %T, want *GitLabSCMAdapter", adapter)
+		}
+		prevLog := concrete.log
+		log, buf := newCapturingLogger()
+		concrete.log = log
+		defer func() { concrete.log = prevLog }()
+
 		status, err := adapter.GetMergeability(ctx, draftIID, owner, repo)
 		if err != nil {
 			t.Fatalf("GetMergeability(!%d): %v", draftIID, err)
@@ -287,6 +296,23 @@ func TestIntegration_GetMergeability(t *testing.T) {
 		}
 		if !status.Draft {
 			t.Errorf("GetMergeability(!%d).Draft = false, want true", draftIID)
+		}
+
+		// A settled draft on this deployment reports draft_status on
+		// every read, so the Debug record's attribute pins the observed
+		// wire value positively rather than resting on the WARN's
+		// absence alone, which would pass identically for an unsettled
+		// computing value.
+		logOutput := buf.String()
+		if want := "detailed_merge_status=draft_status"; !strings.Contains(logOutput, want) {
+			t.Errorf("GetMergeability(!%d) log output = %q, want it to carry %q", draftIID, logOutput, want)
+		}
+		const debugMsg = "gitlab reported a non-mergeable detailed_merge_status"
+		if n := strings.Count(logOutput, debugMsg); n != 1 {
+			t.Errorf("GetMergeability(!%d): occurrences of %q in log output = %d, want 1 (log output: %q)", draftIID, debugMsg, n, logOutput)
+		}
+		if strings.Contains(logOutput, "unrecognized gitlab detailed_merge_status value") {
+			t.Errorf("GetMergeability(!%d) log output = %q, want no unrecognized-value WARN", draftIID, logOutput)
 		}
 	})
 

--- a/internal/scm/gitlab/scm_merge.go
+++ b/internal/scm/gitlab/scm_merge.go
@@ -79,13 +79,40 @@ func (a *GitLabSCMAdapter) fetchMergeRequest(ctx context.Context, prNumber int, 
 	return mr, nil
 }
 
+// gitlabExpectedBlockingStatuses holds the wire values GitLab's REST
+// surface reports for its mergeability checks. These are the check
+// services' own identifiers, not the names their GraphQL enum counterparts
+// carry, so a future edit correcting a spelling toward the GraphQL
+// vocabulary would reintroduce the drift this set closes.
+var gitlabExpectedBlockingStatuses = map[string]struct{}{
+	"ci_must_pass":                   {},
+	"ci_still_running":               {},
+	"commits_status":                 {},
+	"discussions_not_resolved":       {},
+	"draft_status":                   {},
+	"locked_lfs_files":               {},
+	"merge_time":                     {},
+	"need_rebase":                    {},
+	"not_open":                       {},
+	"jira_association_missing":       {},
+	"locked_paths":                   {},
+	"merge_request_blocked":          {},
+	"not_approved":                   {},
+	"requested_changes":              {},
+	"security_policy_pipeline_check": {},
+	"security_policy_violations":     {},
+	"status_checks_must_pass":        {},
+	"title_regex":                    {},
+}
+
 // mapMergeability classifies a GitLab detailed_merge_status value into a
-// [domain.MergeabilityState]. recognized is false for any value outside
-// the four documented arms, including an empty or absent field, which
-// still maps to [domain.MergeabilityBlocked] because every remaining
-// value in the live enum is a blocking reason.
+// [domain.MergeabilityState]. The classification covers every value the
+// platform documents for this field: expected reports whether status is
+// one of them. A value outside that set still maps to
+// [domain.MergeabilityBlocked], because every documented value other
+// than the affirmative and computing ones is a blocking reason.
 // [domain.MergeabilityUnstable] is never returned.
-func mapMergeability(status string) (state domain.MergeabilityState, recognized bool) {
+func mapMergeability(status string) (state domain.MergeabilityState, expected bool) {
 	switch status {
 	case "mergeable":
 		return domain.MergeabilityClean, true
@@ -93,9 +120,11 @@ func mapMergeability(status string) (state domain.MergeabilityState, recognized 
 		return domain.MergeabilityDirty, true
 	case "unchecked", "checking", "preparing", "approvals_syncing":
 		return domain.MergeabilityUnknown, true
-	default:
-		return domain.MergeabilityBlocked, false
 	}
+	if _, ok := gitlabExpectedBlockingStatuses[status]; ok {
+		return domain.MergeabilityBlocked, true
+	}
+	return domain.MergeabilityBlocked, false
 }
 
 // GetMergeability returns the merge precondition state for the given PR,
@@ -106,6 +135,14 @@ func mapMergeability(status string) (state domain.MergeabilityState, recognized 
 // MergeCommitSHA is populated only when the merge request's state is
 // "merged", so an identifier reported on an open merge request is never
 // asserted as a merge.
+//
+// A detailed_merge_status value outside the platform's documented set,
+// including an absent or empty field, produces one WARN naming the
+// observed value. A documented value that resolves to
+// [domain.MergeabilityBlocked] produces one Debug record naming the
+// observed value and the merge request; the record reports what GitLab
+// returned, not that a block exists, since the same value can be the one
+// a later read observes on a merge request that has since merged.
 func (a *GitLabSCMAdapter) GetMergeability(ctx context.Context, prNumber int, owner, repo string) (domain.PRMergeStatus, error) {
 	mr, err := a.fetchMergeRequest(ctx, prNumber, owner, repo)
 	if err != nil {
@@ -118,10 +155,14 @@ func (a *GitLabSCMAdapter) GetMergeability(ctx context.Context, prNumber int, ow
 		mergeCommitSHA = mr.MergeCommitSHA
 	}
 
-	state, recognized := mapMergeability(mr.DetailedMergeStatus)
-	if !recognized {
+	state, expected := mapMergeability(mr.DetailedMergeStatus)
+	if !expected {
 		a.log.Warn("unrecognized gitlab detailed_merge_status value",
 			slog.String("detailed_merge_status", mr.DetailedMergeStatus))
+	} else if state == domain.MergeabilityBlocked {
+		a.log.Debug("gitlab reported a non-mergeable detailed_merge_status",
+			slog.String("detailed_merge_status", mr.DetailedMergeStatus),
+			slog.Int("pr_number", prNumber))
 	}
 
 	return domain.PRMergeStatus{

--- a/internal/scm/gitlab/scm_merge_test.go
+++ b/internal/scm/gitlab/scm_merge_test.go
@@ -95,7 +95,7 @@ func TestGetMergeability_StatusTable(t *testing.T) {
 		{"checking maps to unknown", "checking", domain.MergeabilityUnknown, false},
 		{"preparing maps to unknown", "preparing", domain.MergeabilityUnknown, false},
 		{"approvals_syncing maps to unknown", "approvals_syncing", domain.MergeabilityUnknown, false},
-		{"an unrecognized value maps to blocked and logs a warning", "need_rebase", domain.MergeabilityBlocked, true},
+		{"a documented blocking value maps to blocked and logs no warning", "need_rebase", domain.MergeabilityBlocked, false},
 		{"an empty value maps to blocked and logs a warning", "", domain.MergeabilityBlocked, true},
 	}
 
@@ -141,6 +141,202 @@ func quoteIfEmpty(s string) string {
 		return `""`
 	}
 	return s
+}
+
+// --- GetMergeability: expected blocking values ---
+
+func TestGetMergeability_ExpectedBlockingValues(t *testing.T) {
+	t.Parallel()
+
+	// Every blocking wire value the platform documents, listed literally
+	// rather than derived from mapMergeability's own set, so the test and
+	// the implementation cannot drift together. The five values whose REST
+	// spelling diverges from their GraphQL enum name are included here
+	// spelled as the wire reports them.
+	statuses := []string{
+		"ci_must_pass",
+		"ci_still_running",
+		"commits_status",
+		"discussions_not_resolved",
+		"draft_status",
+		"locked_lfs_files",
+		"merge_time",
+		"need_rebase",
+		"not_open",
+		"jira_association_missing",
+		"locked_paths",
+		"merge_request_blocked",
+		"not_approved",
+		"requested_changes",
+		"security_policy_pipeline_check",
+		"security_policy_violations",
+		"status_checks_must_pass",
+		"title_regex",
+	}
+
+	for _, status := range statuses {
+		t.Run(status, func(t *testing.T) {
+			t.Parallel()
+
+			fixture := mergeRequestFixture(t, map[string]any{"detailed_merge_status": status})
+			srv := serveJSON(t, fixture)
+			defer srv.Close()
+
+			adapter := mustSCMAdapter(t, srv.URL)
+			log, buf := newCapturingLogger()
+			adapter.log = log
+
+			got, err := adapter.GetMergeability(context.Background(), testPRNumber, scmOwner, scmRepo)
+			if err != nil {
+				t.Fatalf("GetMergeability(%q): unexpected error: %v", status, err)
+			}
+			if got.Mergeability != domain.MergeabilityBlocked {
+				t.Errorf("GetMergeability(%q).Mergeability = %q, want %q", status, got.Mergeability, domain.MergeabilityBlocked)
+			}
+
+			logOutput := buf.String()
+			if strings.Contains(logOutput, "unrecognized gitlab detailed_merge_status value") {
+				t.Errorf("GetMergeability(%q) logged the unrecognized-value WARN, want none (log output: %q)", status, logOutput)
+			}
+		})
+	}
+}
+
+// --- GetMergeability: unexpected values ---
+
+func TestGetMergeability_UnexpectedValues(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		status string
+	}{
+		{"a GraphQL-only spelling for merge_request_blocked is unexpected", "blocked_status"},
+		{"a GraphQL-only spelling for title_regex is unexpected", "title_not_matching"},
+		{"a value no sampled GitLab release has declared is unexpected", "future_release_check"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			fixture := mergeRequestFixture(t, map[string]any{"detailed_merge_status": tt.status})
+			srv := serveJSON(t, fixture)
+			defer srv.Close()
+
+			adapter := mustSCMAdapter(t, srv.URL)
+			log, buf := newCapturingLogger()
+			adapter.log = log
+
+			got, err := adapter.GetMergeability(context.Background(), testPRNumber, scmOwner, scmRepo)
+			if err != nil {
+				t.Fatalf("GetMergeability(%q): unexpected error: %v", tt.status, err)
+			}
+			if got.Mergeability != domain.MergeabilityBlocked {
+				t.Errorf("GetMergeability(%q).Mergeability = %q, want %q", tt.status, got.Mergeability, domain.MergeabilityBlocked)
+			}
+
+			logOutput := buf.String()
+			const msg = "unrecognized gitlab detailed_merge_status value"
+			if n := strings.Count(logOutput, msg); n != 1 {
+				t.Errorf("occurrences of %q in log output = %d, want 1 (log output: %q)", msg, n, logOutput)
+			}
+			if want := "detailed_merge_status=" + quoteIfEmpty(tt.status); !strings.Contains(logOutput, want) {
+				t.Errorf("log output = %q, want it to carry %q", logOutput, want)
+			}
+		})
+	}
+}
+
+// --- GetMergeability: the non-mergeable Debug record ---
+
+func TestGetMergeability_NonMergeableDebugRecord(t *testing.T) {
+	t.Parallel()
+
+	const debugMsg = "gitlab reported a non-mergeable detailed_merge_status"
+	const warnMsg = "unrecognized gitlab detailed_merge_status value"
+
+	t.Run("not_open logs the debug record naming the value and the merge request", func(t *testing.T) {
+		t.Parallel()
+
+		fixture := mergeRequestFixture(t, map[string]any{"detailed_merge_status": "not_open"})
+		srv := serveJSON(t, fixture)
+		defer srv.Close()
+
+		adapter := mustSCMAdapter(t, srv.URL)
+		log, buf := newCapturingLogger()
+		adapter.log = log
+
+		got, err := adapter.GetMergeability(context.Background(), testPRNumber, scmOwner, scmRepo)
+		if err != nil {
+			t.Fatalf("GetMergeability: unexpected error: %v", err)
+		}
+		if got.Mergeability != domain.MergeabilityBlocked {
+			t.Errorf("GetMergeability().Mergeability = %q, want %q", got.Mergeability, domain.MergeabilityBlocked)
+		}
+
+		logOutput := buf.String()
+		if n := strings.Count(logOutput, debugMsg); n != 1 {
+			t.Errorf("occurrences of %q in log output = %d, want 1 (log output: %q)", debugMsg, n, logOutput)
+		}
+		if want := "detailed_merge_status=not_open"; !strings.Contains(logOutput, want) {
+			t.Errorf("log output = %q, want it to carry %q", logOutput, want)
+		}
+		if want := "pr_number=" + strconv.Itoa(testPRNumber); !strings.Contains(logOutput, want) {
+			t.Errorf("log output = %q, want it to carry %q", logOutput, want)
+		}
+		if strings.Contains(logOutput, warnMsg) {
+			t.Errorf("log output = %q, want no unrecognized-value WARN", logOutput)
+		}
+	})
+
+	t.Run("a second blocking value also logs the debug record", func(t *testing.T) {
+		t.Parallel()
+
+		fixture := mergeRequestFixture(t, map[string]any{"detailed_merge_status": "draft_status"})
+		srv := serveJSON(t, fixture)
+		defer srv.Close()
+
+		adapter := mustSCMAdapter(t, srv.URL)
+		log, buf := newCapturingLogger()
+		adapter.log = log
+
+		if _, err := adapter.GetMergeability(context.Background(), testPRNumber, scmOwner, scmRepo); err != nil {
+			t.Fatalf("GetMergeability: unexpected error: %v", err)
+		}
+
+		logOutput := buf.String()
+		if n := strings.Count(logOutput, debugMsg); n != 1 {
+			t.Errorf("occurrences of %q in log output = %d, want 1 (log output: %q)", debugMsg, n, logOutput)
+		}
+		if want := "detailed_merge_status=draft_status"; !strings.Contains(logOutput, want) {
+			t.Errorf("log output = %q, want it to carry %q", logOutput, want)
+		}
+	})
+
+	t.Run("a mergeable value logs no debug record", func(t *testing.T) {
+		t.Parallel()
+
+		fixture := mergeRequestFixture(t, map[string]any{"detailed_merge_status": "mergeable"})
+		srv := serveJSON(t, fixture)
+		defer srv.Close()
+
+		adapter := mustSCMAdapter(t, srv.URL)
+		log, buf := newCapturingLogger()
+		adapter.log = log
+
+		if _, err := adapter.GetMergeability(context.Background(), testPRNumber, scmOwner, scmRepo); err != nil {
+			t.Fatalf("GetMergeability: unexpected error: %v", err)
+		}
+
+		logOutput := buf.String()
+		if strings.Contains(logOutput, debugMsg) {
+			t.Errorf("log output = %q, want no non-mergeable debug record for a mergeable value", logOutput)
+		}
+		if strings.Contains(logOutput, warnMsg) {
+			t.Errorf("log output = %q, want no unrecognized-value WARN for a mergeable value", logOutput)
+		}
+	})
 }
 
 // --- GetMergeability: merged and open dispositions ---


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Fix

**Intent:** Narrow `GitLabSCMAdapter.GetMergeability`'s unrecognized-value WARN so it fires only for a `detailed_merge_status` value GitLab's API does not document, instead of firing on every read for a draft merge request, a merged merge request, or one waiting on its pipeline - values the adapter already classifies correctly.

**Related Issues:** #829

### 🧭 Reviewer Guide

**Complexity:** Medium

#### Entry Point

`internal/scm/gitlab/scm_merge.go` - `mapMergeability` gains `gitlabExpectedBlockingStatuses`, the full set of blocking wire values GitLab's REST surface documents (including five whose REST spelling diverges from their GraphQL enum name). A value in that set still resolves to `MergeabilityBlocked` but no longer trips the WARN; `GetMergeability` instead logs one Debug record naming the value and the merge request. Only a value outside the documented set still logs the WARN.

#### Sensitive Areas

- `internal/scm/gitlab/scm_merge.go`: the mergeability verdict for every status value must stay unchanged - only the logging behavior changes.
- `docs/gitlab-adapter-notes.md`: records which wire values were observed live and which come from GitLab's documentation only, so a future characterization pass can tell the two apart.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes.
- **Migrations/State:** No migrations or state changes.
