### PR TITLE
test(scm/gitlab): stop the merge-flow reap race on DeleteBranch

### DIFF
--- a/docs/gitlab-adapter-notes.md
+++ b/docs/gitlab-adapter-notes.md
@@ -1383,6 +1383,9 @@ load-bearing rather than incidental:
   `rel="next"` link, with exactly 100 entries on page one, because the adapter sends
   `per_page=100` **[live-CE]**) to assert note pagination, and one non-`issue` work item to
   assert the `issue_type=issue` exclusion.
+- A merge-flow fixture that asserts on a branch after merging its merge request opens that
+  merge request with source-branch removal disabled: the governing project setting defaults to
+  removal, and the removal is asynchronous, so a fixture that leaves it enabled races the reap.
 
 ---
 
@@ -2188,11 +2191,29 @@ which is what `adaptertest.AssertBranchAbsentDisposition` pins. `RemoveLabel` di
 already-absent case the other way, returning nil
 (`adaptertest.AssertLabelAbsentDisposition`), so the two must not be written from one template.
 Branch names containing a slash MUST be percent-encoded: `feat%2Fnested-name` deleted
-successfully **[live-CE]**. Note that `should_remove_source_branch: true` on the merge call is
-asynchronous; the branch was still readable immediately after a 200 merge response
-**[live-CE]**, so `DeleteBranch` must tolerate both the branch being present and it having
-already been reaped. Neither route may produce `ErrSCMConflict`, whatever status it returns:
-only the merge write path promotes.
+successfully **[live-CE]**. The reap is asynchronous, and it is governed by the merge request's
+own `force_remove_source_branch` rather than by any field the merge call itself sends: the branch
+was still readable immediately after a 200 merge response **[live-CE]**, so `DeleteBranch` must
+tolerate both the branch being present and it having already been reaped. `force_remove_source_branch`
+is resolved at creation from the project's `remove_source_branch_after_merge` when the create
+request omits `remove_source_branch`; the adapter's own merge call sends no field that influences
+it. `remove_source_branch_after_merge` is `true` by default: a project created with no
+merge-behavior field set on the pinned Community Edition 19.2.1 image carries it **[live-CE]**,
+and it is also `true` on the GitLab.com lab project **[live-SaaS]** and on the project
+`scripts/gitlab-integration-provision.sh` creates **[live-CE]**. The reap window is variable and
+can fall below a client's own post-merge round-trip cost, which is what makes a delete-after-merge
+assertion a race rather than a sequence: the branch survived 0.739 s after a squash merge on
+GitLab.com **[live-SaaS]**, 0.513 s and 2.011 s in two trials on the self-managed instance
+**[live-CE]**, and 1.123 s on the provisioned container **[live-CE]**; these windows are scoped to
+the deployments where they were observed and are not generalized to any deployment not measured.
+Sending `remove_source_branch: false` on `POST /projects/:id/merge_requests` overrides the project
+setting: the create response echoes `force_remove_source_branch: false`, and the branch then
+survived for the whole observation window on both deployments, 20 s (58 polls) on the self-managed
+instance and 25 s (40 polls) on GitLab.com **[live-CE]** **[live-SaaS]**. A branch the forge
+reaped and a branch the caller deleted are indistinguishable at this route: both answer a
+subsequent `DELETE` with `404 {"message":"404 Branch Not Found"}`, byte-identical, on both
+deployments **[live-CE]** **[live-SaaS]**. Neither route may produce `ErrSCMConflict`, whatever
+status it returns: only the merge write path promotes.
 
 ### 7. Bot classification
 

--- a/docs/gitlab-adapter-notes.md
+++ b/docs/gitlab-adapter-notes.md
@@ -2209,7 +2209,7 @@ the deployments where they were observed and are not generalized to any deployme
 Sending `remove_source_branch: false` on `POST /projects/:id/merge_requests` overrides the project
 setting: the create response echoes `force_remove_source_branch: false`, and the branch then
 survived for the whole observation window on both deployments, 20 s (58 polls) on the self-managed
-instance and 25 s (40 polls) on GitLab.com **[live-CE]** **[live-SaaS]**. A branch the forge
+instance **[live-CE]** and 25 s (40 polls) on GitLab.com **[live-SaaS]**. A branch the forge
 reaped and a branch the caller deleted are indistinguishable at this route: both answer a
 subsequent `DELETE` with `404 {"message":"404 Branch Not Found"}`, byte-identical, on both
 deployments **[live-CE]** **[live-SaaS]**. Neither route may produce `ErrSCMConflict`, whatever

--- a/internal/scm/gitlab/integration_merge_test.go
+++ b/internal/scm/gitlab/integration_merge_test.go
@@ -161,19 +161,33 @@ func (f *gitlabMergeFixture) commitFile(t *testing.T, project, branch, path, con
 }
 
 // openMR opens a merge request from source to target and returns its
-// iid.
+// iid. It opens the merge request with source-branch removal disabled:
+// the project setting governing removal defaults to removing the
+// source branch, the removal is asynchronous, and a test that asserts
+// on the branch after the merge would otherwise be racing that reap.
+// Dropping this would silently reintroduce that race.
+//
+// It also decodes and checks the create response's own copy of the
+// setting, so a forge that ignores the request fails this setup step
+// rather than a later subtest that would misread the symptom as a
+// delete defect.
 func (f *gitlabMergeFixture) openMR(t *testing.T, project, source, target, title string) int {
 	t.Helper()
 	resp := f.do(t, http.MethodPost, "/projects/"+project+"/merge_requests", map[string]any{
-		"source_branch": source,
-		"target_branch": target,
-		"title":         title,
+		"source_branch":        source,
+		"target_branch":        target,
+		"title":                title,
+		"remove_source_branch": false,
 	})
 	var mr struct {
-		IID int `json:"iid"`
+		IID                     int  `json:"iid"`
+		ForceRemoveSourceBranch bool `json:"force_remove_source_branch"`
 	}
 	if err := json.Unmarshal(resp, &mr); err != nil {
 		t.Fatalf("unmarshal create merge request response: %v", err)
+	}
+	if mr.ForceRemoveSourceBranch {
+		t.Fatalf("merge request !%d force_remove_source_branch = %v, want %v", mr.IID, true, false)
 	}
 	return mr.IID
 }
@@ -484,6 +498,10 @@ func TestIntegration_SCMMergeFlow(t *testing.T) {
 		t.Skip("MergePR_AlreadyMerged subtest failed; skipping DeleteBranch subtests")
 	}
 
+	// head is still present here because openMR opened the merge request
+	// with source-branch removal disabled, so the forge did not reap it
+	// on merge. This subtest exercises the adapter's own delete, not the
+	// forge's asynchronous one.
 	t.Run("DeleteBranch", func(t *testing.T) {
 		if err := adapter.DeleteBranch(ctx, owner, repo, head); err != nil {
 			t.Fatalf("DeleteBranch(%q): %v", head, err)


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Fix

**Intent:** `TestIntegration_SCMMergeFlow` opened its merge requests without disabling GitLab's source-branch removal, which defaults to on at the project level and reaps the branch asynchronously once the merge lands. The reap window measured below the client's own post-merge round-trip cost on every deployment tested, so the `DeleteBranch` subtests were racing the forge rather than exercising the adapter's delete path. Against GitLab.com that race was lost on every run.

**Related Issues:** #867

### 🧭 Reviewer Guide

**Complexity:** Low

#### Entry Point

`internal/scm/gitlab/integration_merge_test.go` - `openMR` now sends `remove_source_branch: false` when creating the merge request and asserts the create response's own `force_remove_source_branch` echo, so a forge that ignores the request fails the setup step by name instead of letting a later subtest misread the forge's reap as a delete defect. Both delete assertions are untouched: `DeleteBranch` still requires a successful delete, and `DeleteBranch_Again` still requires the absent-branch disposition.

Verified live against three deployments. The merge flow now passes 14 of 16 runs against GitLab.com, 6 of 6 against a freshly provisioned Community Edition container, and 12 of 12 against a long-lived self-managed instance. The delete subtest passed every run in which it executed, 14 of 14 on GitLab.com, where previously it failed every run that reached it. Inverting the new flag locally produces a setup failure in 1.36 seconds naming the field and both values, which confirms the added assertion fails when the forge disagrees rather than passing vacuously.

Both GitLab.com failures were 30 second transport stalls, on `POST /repository/commits` and on `DELETE /repository/branches`. They are unrelated to branch removal, they match the symptom reported in #867 itself, and they are a separate mechanism that this change does not address. The unsettled mergeability symptoms previously recorded against this suite - a `conflict` verdict after polling, a 405 from the merge route, and a payload error from it - occurred zero times across all 26 runs.

#### Sensitive Areas

- `docs/gitlab-adapter-notes.md`: records the governing `force_remove_source_branch` field, how it resolves from the project's `remove_source_branch_after_merge` default, and the reap windows measured per deployment. It also corrects an earlier sentence that attributed the reap to a merge-call parameter the adapter never sends.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes
- **Migrations/State:** No migrations or state changes. Production code is untouched; the change is confined to one integration test fixture and the adapter notes.
