### PR TITLE
docs(workflow-reference): document Claude Code pass-through keys

### DIFF
--- a/docs/claude-code-adapter-notes.md
+++ b/docs/claude-code-adapter-notes.md
@@ -77,13 +77,13 @@ marked "Not passed" are part of the CLI surface but never appear in a Sortie inv
 | `-p <prompt>`                        | Non-interactive (headless) mode. Passes the prompt and exits when done.                      | **(always)** Carries the rendered turn prompt.                                      |
 | `--output-format stream-json`        | Newline-delimited JSON on stdout. Each line is a JSON object.                                | **(always)** The adapter's only event source.                                       |
 | `--verbose`                          | Include internal events (tool calls, system messages) in stream output.                      | **(always)** Needed for full event visibility.                                      |
-| `--max-turns <N>`                    | Maximum number of agentic turns within a single CLI invocation.                               | Passed when `claude-code.max_turns` is set. Availability is an open question below. |
+| `--max-turns <N>`                    | Maximum number of agentic turns within a single CLI invocation (print mode only). Absent from `claude --help`, but accepted and honored. | Passed when `claude-code.max_turns` is set.                                          |
 | `--max-budget-usd <amount>`          | Maximum dollar spend for this invocation (print mode only). Exits with error when exceeded.  | Passed when `claude-code.max_budget_usd` is set.                                     |
 | `--model <model>`                    | Override the model (e.g., `claude-sonnet-4-6`, `claude-opus-4-6`).                           | Passed when `claude-code.model` is set.                                              |
-| `--fallback-model <model>`           | Automatic fallback model when primary is overloaded (print mode only).                       | Passed when `claude-code.fallback_model` is set.                                     |
-| `--effort <level>`                   | Reasoning effort: `low`, `medium`, `high`, `max`.                                             | Passed when `claude-code.effort` is set.                                             |
-| `--allowedTools <tools>`             | Space-separated list of pre-approved tools. Supports prefix matching: `"Bash(git diff *)"`.  | Passed when `claude-code.allowed_tools` is set.                                       |
-| `--disallowedTools <tools>`          | Tools to remove from model context entirely.                                                  | Passed when `claude-code.disallowed_tools` is set.                                    |
+| `--fallback-model <model>`           | Fallback used when the primary model is overloaded, unavailable, or returns another non-retryable server error (print mode only). Accepts a comma-separated chain, capped at three models after duplicate removal. | Passed when `claude-code.fallback_model` is set.                                     |
+| `--effort <level>`                   | Reasoning effort: `low`, `medium`, `high`, `xhigh`, `max`, `ultracode`. An unrecognized value is not rejected: the CLI warns and uses the default effort. | Passed when `claude-code.effort` is set.                                             |
+| `--allowedTools <tools>`             | Comma- or space-separated list of pre-approved tools. Supports prefix matching: `"Bash(git diff *)"`. | Passed when `claude-code.allowed_tools` is set.                                       |
+| `--disallowedTools <tools>`          | Deny rules, in the same format. A bare tool name removes that tool from the model's context; a scoped rule such as `Bash(rm *)` leaves the tool available and denies only matching calls. | Passed when `claude-code.disallowed_tools` is set.                                    |
 | `--append-system-prompt <text>`      | Append text to the system prompt. Preserves built-in capabilities.                            | Passed when `claude-code.system_prompt` is set.                                       |
 | `--mcp-config <path>`                | Path to MCP server configuration JSON.                                                        | Passed with the worker-generated config path; see MCP server configuration.          |
 | `--tools <tools>`                    | Restrict available built-in tools. `""` = none, `"default"` = all.                            | Not passed.                                                                          |
@@ -114,7 +114,7 @@ marked "Not passed" are part of the CLI surface but never appear in a Sortie inv
 | Flag                                   | Description                                                                                    | Adapter usage                                                        |
 | -------------------------------------- | ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
 | `--dangerously-skip-permissions`       | Bypass all permission prompts. No user confirmation required.                                  | Passed when `claude-code.permission_mode` is unset.                  |
-| `--permission-mode <mode>`             | Set permission mode: `default`, `acceptEdits`, `dontAsk`, `bypassPermissions`, `plan`, `auto`. | Passed instead when `claude-code.permission_mode` is set.            |
+| `--permission-mode <mode>`             | Set permission mode: `default`, `acceptEdits`, `dontAsk`, `bypassPermissions`, `plan`, `auto`, or `manual` as an alias for `default`. Any other value is rejected before the session starts; the allowed-choices list the parser prints omits `default`, which is nonetheless accepted. | Passed instead when `claude-code.permission_mode` is set.            |
 | `--permission-prompt-tool <tool>`      | MCP tool to handle permission prompts programmatically in non-interactive mode.                | Not passed.                                                          |
 | `--allow-dangerously-skip-permissions` | Enable bypassing as an option without activating it.                                           | Not passed.                                                          |
 
@@ -755,14 +755,14 @@ falls back to the zero value, except `session_persistence`, which defaults to `t
 
 | Config key                        | Type    | Description                                                                                                                                                 |
 | --------------------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `claude-code.permission_mode`     | string  | Permission mode: `default`, `acceptEdits`, `dontAsk`, `bypassPermissions`, `plan`, `auto`. Replaces the default `--dangerously-skip-permissions`.           |
+| `claude-code.permission_mode`     | string  | Permission mode: `default`, `acceptEdits`, `dontAsk`, `bypassPermissions`, `plan`, `auto`, `manual`. Replaces the default `--dangerously-skip-permissions`. |
 | `claude-code.model`               | string  | Model override (e.g., `claude-sonnet-4-6`). Maps to `--model`.                                                                                              |
-| `claude-code.fallback_model`      | string  | Fallback model for rate-limit resilience. Maps to `--fallback-model`.                                                                                       |
+| `claude-code.fallback_model`      | string  | Fallback for model availability failures, not for rate limits. Maps to `--fallback-model`. |
 | `claude-code.max_turns`           | integer | Claude Code internal max turns per invocation. Maps to `--max-turns` when greater than zero.                                                                |
 | `claude-code.max_budget_usd`      | number  | Cost cap per invocation. Maps to `--max-budget-usd` when greater than zero.                                                                                 |
-| `claude-code.effort`              | string  | Reasoning effort: `low`, `medium`, `high`, `max`. Maps to `--effort`.                                                                                       |
-| `claude-code.allowed_tools`       | string  | Space-separated tool list. Maps to `--allowedTools`.                                                                                                        |
-| `claude-code.disallowed_tools`    | string  | Space-separated denied tool list. Maps to `--disallowedTools`.                                                                                              |
+| `claude-code.effort`              | string  | Reasoning effort: `low`, `medium`, `high`, `xhigh`, `max`, `ultracode`. Maps to `--effort`. |
+| `claude-code.allowed_tools`       | string  | Comma- or space-separated tool list. Maps to `--allowedTools`. |
+| `claude-code.disallowed_tools`    | string  | Comma- or space-separated denied tool list. Maps to `--disallowedTools`. |
 | `claude-code.system_prompt`       | string  | Additional system prompt text. Maps to `--append-system-prompt`.                                                                                            |
 | `claude-code.mcp_config`          | string  | Path to an operator MCP config JSON. Merged by the worker; see MCP server configuration.                                                                    |
 | `claude-code.session_persistence` | boolean | If `false`, passes `--no-session-persistence`. Default: `true`.                                                                                              |
@@ -870,13 +870,6 @@ async with ClaudeSDKClient(options=options) as client:
 
 ## Open questions
 
-- **Does the CLI accept `--max-turns`?** The flag is documented in the GitHub Actions
-  `claude_args` reference and does not appear in `claude --help` on v2.1.76, which leaves open
-  whether it is an SDK-and-settings surface rather than a CLI flag. `buildArgs` passes it whenever
-  `claude-code.max_turns` is configured, so an unsupported flag would break every turn of such a
-  workflow. Probe: run `claude -p 'reply with ok' --max-turns 1 --output-format stream-json
-  --verbose` against the pinned binary and read the parser exit code and the first stdout line; a
-  rejected flag fails before any JSON is emitted.
 - **What `type` values do task messages carry on the wire?** The message shapes are documented by
   their SDK type names (`TaskStartedMessage`, `TaskProgressMessage`, `TaskNotificationMessage`),
   not by the `type` string that `ParseLine` switches on, so they land in the default arm as
@@ -887,11 +880,14 @@ async with ClaudeSDKClient(options=options) as client:
 
 ## Sources
 
-Local probe:
+Local probes:
 
 - `claude --help` on CLI v2.1.76 (flag surface and version pin).
+- `claude --help` and headless `-p` runs on CLI 2.1.234: accepted `--permission-mode` values,
+  `--effort` levels and its warn-and-ignore handling, `--allowedTools` separators, `--max-turns`
+  acceptance, and the resume behaviour of `--no-session-persistence`.
 
-Anthropic first-party documentation, read March 2026:
+Anthropic first-party documentation, read March 2026 and the CLI reference re-read August 2026:
 
 - Claude Code CLI reference: flags, headless (`-p`) mode, permission modes, session storage.
 - Claude Code `stream-json` output reference: message union, system subtypes, content blocks,

--- a/docs/workflow-reference.md
+++ b/docs/workflow-reference.md
@@ -2414,18 +2414,51 @@ is intended for local testing and CI workflows where a live tracker is not avail
 claude-code:
   permission_mode: bypassPermissions
   model: claude-sonnet-4-20250514
+  fallback_model: claude-haiku-4-5
   max_turns: 50
   max_budget_usd: 5
+  effort: high
+  allowed_tools: "Read Edit Bash(git diff *)"
+  disallowed_tools: WebFetch
+  system_prompt: Prefer table-driven tests.
+  mcp_config: ./mcp-servers.json
+  session_persistence: true
 ```
 
-The `claude-code` block is forwarded to the Claude Code adapter, which maps these fields
-to CLI flags.
+The `claude-code` block is forwarded to the Claude Code adapter, which runs
+`claude -p --output-format stream-json --verbose` once per turn and maps these fields to
+CLI flags. Values are forwarded unchanged. The adapter validates none of them; the
+Claude Code CLI rejects an unrecognized value at launch. A key whose YAML value has the
+wrong type is ignored and the default applies.
+
+| Field | Type | Default | Description |
+| --- | --- | --- | --- |
+| `claude-code.permission_mode` | string | _(absent)_ | Forwarded to `--permission-mode`. Values: `acceptEdits`, `auto`, `bypassPermissions`, `dontAsk`, `manual` (an alias for `default`), and `plan`. When absent, the adapter passes `--dangerously-skip-permissions` instead. |
+| `claude-code.model` | string | _(absent)_ | Forwarded to `--model`. Accepts a model alias such as `sonnet`, or a full model name. |
+| `claude-code.fallback_model` | string | _(absent)_ | Forwarded to `--fallback-model`. Accepts one model or a comma-separated chain. Covers model availability only; see the fallback note below. |
+| `claude-code.max_turns` | integer | _(absent)_ | Forwarded to `--max-turns` when greater than zero. Claude Code's own agentic turn budget within one invocation. |
+| `claude-code.max_budget_usd` | number | _(absent)_ | Forwarded to `--max-budget-usd` when greater than zero. Spend cap for one invocation. The counter restarts on every turn, including resumed ones, so the ceiling for a whole session is this value times `agent.max_turns`. |
+| `claude-code.effort` | string | _(absent)_ | Forwarded to `--effort`. Values: `low`, `medium`, `high`, `xhigh`, and `max`. The accepted set depends on the model. |
+| `claude-code.allowed_tools` | string | _(absent)_ | Forwarded to `--allowedTools` as a single argument. A comma- or space-separated list of tools that run without a permission prompt, including scoped rules such as `Bash(git diff *)`. |
+| `claude-code.disallowed_tools` | string | _(absent)_ | Forwarded to `--disallowedTools` as a single argument. A comma- or space-separated deny list. A bare tool name removes that tool from the model's context; a scoped rule leaves the tool available and denies only matching calls. |
+| `claude-code.system_prompt` | string | _(absent)_ | Forwarded to `--append-system-prompt`. The text is appended to the default system prompt rather than replacing it. Claude Code's built-in tool instructions stay in effect. |
+| `claude-code.mcp_config` | string | _(absent)_ | Path to an MCP server configuration JSON file, resolved relative to the directory holding WORKFLOW.md when it is not absolute. The worker merges its own `sortie-tools` server into that file and passes the merged copy to `--mcp-config`, which takes a single configuration path. A file that already declares a `sortie-tools` server fails the attempt. |
+| `claude-code.session_persistence` | boolean | `true` | When `false`, adds `--no-session-persistence` and Claude Code writes no session file to disk. The adapter continues a session by passing `--resume <session_id>` on every turn after the first, and that flag reads the persisted session. |
 
 > **Important:** `agent.max_turns` (orchestrator turn-loop limit) and
 > `claude-code.max_turns` (CLI `--max-turns` flag) are distinct values. The orchestrator
 > limit controls how many turns the worker runs before exiting. The adapter limit controls
 > the Claude Code CLI's internal turn budget. They serve different purposes and should
 > typically have different values.
+
+> **Important:** `claude-code.fallback_model` covers model availability, not provider
+> exhaustion. Claude Code switches to the fallback when the primary model is overloaded,
+> unavailable (a retired model, for example), or returns another non-retryable server
+> error. Authentication, billing, rate-limit, request-size, and transport errors never
+> trigger a switch; they follow their normal retry and error handling. The switch lasts
+> for the current turn only; the next turn starts on the primary model. Claude Code caps
+> a chain at three models after removing duplicates and ignores the rest. The adapter
+> forwards the configured string unchanged.
 
 **Codex adapter:**
 

--- a/docs/workflow-reference.md
+++ b/docs/workflow-reference.md
@@ -2435,7 +2435,7 @@ ignored and the default applies.
 
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
-| `claude-code.permission_mode` | string | _(absent)_ | Forwarded to `--permission-mode`. Values: `acceptEdits`, `auto`, `bypassPermissions`, `dontAsk`, `manual` (an alias for `default`), and `plan`. When absent, the adapter passes `--dangerously-skip-permissions` instead. |
+| `claude-code.permission_mode` | string | _(absent)_ | Forwarded to `--permission-mode`. Values: `acceptEdits`, `auto`, `bypassPermissions`, `default`, `dontAsk`, `manual` (an alias for `default`), and `plan`. When absent, the adapter passes `--dangerously-skip-permissions` instead. |
 | `claude-code.model` | string | _(absent)_ | Forwarded to `--model`. Accepts a model alias such as `sonnet`, or a full model name. |
 | `claude-code.fallback_model` | string | _(absent)_ | Forwarded to `--fallback-model`. Accepts one model or a comma-separated chain. Covers model availability only; see the fallback note below. |
 | `claude-code.max_turns` | integer | _(absent)_ | Forwarded to `--max-turns` when greater than zero. Claude Code's own agentic turn budget within one invocation. |

--- a/docs/workflow-reference.md
+++ b/docs/workflow-reference.md
@@ -2427,9 +2427,11 @@ claude-code:
 
 The `claude-code` block is forwarded to the Claude Code adapter, which runs
 `claude -p --output-format stream-json --verbose` once per turn and maps these fields to
-CLI flags. Values are forwarded unchanged. The adapter validates none of them; the
-Claude Code CLI rejects an unrecognized value at launch. A key whose YAML value has the
-wrong type is ignored and the default applies.
+CLI flags. Values are forwarded unchanged, and the adapter validates none of them. What
+the CLI does with an invalid value differs per flag: `--permission-mode` is rejected at
+launch, `--effort` falls back to the default effort with a warning, and an unknown model
+name reaches the API and fails there. A key whose YAML value has the wrong type is
+ignored and the default applies.
 
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -2438,12 +2440,12 @@ wrong type is ignored and the default applies.
 | `claude-code.fallback_model` | string | _(absent)_ | Forwarded to `--fallback-model`. Accepts one model or a comma-separated chain. Covers model availability only; see the fallback note below. |
 | `claude-code.max_turns` | integer | _(absent)_ | Forwarded to `--max-turns` when greater than zero. Claude Code's own agentic turn budget within one invocation. |
 | `claude-code.max_budget_usd` | number | _(absent)_ | Forwarded to `--max-budget-usd` when greater than zero. Spend cap for one invocation. The counter restarts on every turn, including resumed ones, so the ceiling for a whole session is this value times `agent.max_turns`. |
-| `claude-code.effort` | string | _(absent)_ | Forwarded to `--effort`. Values: `low`, `medium`, `high`, `xhigh`, and `max`. The accepted set depends on the model. |
+| `claude-code.effort` | string | _(absent)_ | Forwarded to `--effort`. Values: `low`, `medium`, `high`, `xhigh`, `max`, and `ultracode`, which starts the session at `xhigh` with ultracode enabled. The accepted set depends on the model. |
 | `claude-code.allowed_tools` | string | _(absent)_ | Forwarded to `--allowedTools` as a single argument. A comma- or space-separated list of tools that run without a permission prompt, including scoped rules such as `Bash(git diff *)`. |
 | `claude-code.disallowed_tools` | string | _(absent)_ | Forwarded to `--disallowedTools` as a single argument. A comma- or space-separated deny list. A bare tool name removes that tool from the model's context; a scoped rule leaves the tool available and denies only matching calls. |
 | `claude-code.system_prompt` | string | _(absent)_ | Forwarded to `--append-system-prompt`. The text is appended to the default system prompt rather than replacing it. Claude Code's built-in tool instructions stay in effect. |
-| `claude-code.mcp_config` | string | _(absent)_ | Path to an MCP server configuration JSON file, resolved relative to the directory holding WORKFLOW.md when it is not absolute. The worker merges its own `sortie-tools` server into that file and passes the merged copy to `--mcp-config`, which takes a single configuration path. A file that already declares a `sortie-tools` server fails the attempt. |
-| `claude-code.session_persistence` | boolean | `true` | When `false`, adds `--no-session-persistence` and Claude Code writes no session file to disk. The adapter continues a session by passing `--resume <session_id>` on every turn after the first, and that flag reads the persisted session. |
+| `claude-code.mcp_config` | string | _(absent)_ | Path to an MCP server configuration JSON file, resolved relative to the directory holding WORKFLOW.md when it is not absolute. The worker reads that file, merges its own `sortie-tools` server into a generated copy under the workspace, and passes the copy to `--mcp-config`, which takes a single configuration path. The operator's file is never modified. A file that already declares a `sortie-tools` server fails the attempt. |
+| `claude-code.session_persistence` | boolean | `true` | When `false`, adds `--no-session-persistence` and Claude Code writes no session file to disk. The adapter continues a session by passing `--resume <session_id>` on every turn after the first, and that flag reads the persisted session, so with persistence off every turn after the first exits non-zero with `No conversation found with session ID`. |
 
 > **Important:** `agent.max_turns` (orchestrator turn-loop limit) and
 > `claude-code.max_turns` (CLI `--max-turns` flag) are distinct values. The orchestrator


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Docs

**Intent:** The Claude Code adapter parses eleven pass-through keys, but `docs/workflow-reference.md` documented only four of them (`permission_mode`, `model`, `max_turns`, `max_budget_usd`) as a bare YAML example with no field table, unlike the `opencode` and `kiro` blocks on the same page. Add the missing seven keys (`fallback_model`, `effort`, `allowed_tools`, `disallowed_tools`, `system_prompt`, `mcp_config`, `session_persistence`) as a full field table with type, default, and CLI flag mapping, and give `fallback_model` a dedicated callout stating which failure classes do not trigger a switch.

**Related Issues:** #875

### 🧭 Reviewer Guide

**Complexity:** Low

#### Entry Point

`docs/workflow-reference.md` - the `claude-code` config block section now carries a field table for all eleven pass-through keys plus a callout on `fallback_model`'s scope (model availability only, not provider exhaustion; switch lasts one turn; the CLI caps a chain at three models).

#### Sensitive Areas

- `docs/workflow-reference.md`: the `fallback_model` callout states which error classes do not trigger a fallback switch - verify this stays consistent with `docs/claude-code-adapter-notes.md`, which already documents all eleven keys accurately.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes
- **Migrations/State:** No migrations or state changes
