### PR TITLE
fix(scm): spend no CI-failure retry on a cancelled check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- A check run cancelled by a newer commit no longer spends a retry from
+  the `reactions.ci_failure` budget. The CI verdict counts only
+  `failure` and `timed_out` as failing; a cancelled check now withholds
+  green instead of asserting failure, holding the verdict at pending, so
+  it dispatches no fix continuation and appends no failure to run
+  history. A required workflow configured to cancel its own in-flight
+  runs when a newer commit lands was spending the whole bounded budget
+  on ordinary pushes, so a commit that genuinely failed later went
+  unremediated. The merge gate answers by the same rule and reports such
+  a head as pending rather than failing, which on GitLab also covers a
+  `canceled` pipeline status. The escalation raised on budget exhaustion
+  now names exactly the checks the verdict counted as failing.
+  ([#831](https://github.com/sortie-ai/sortie/issues/831))
+
 ## [1.20.0] - 2026-08-18
 
 ### Added

--- a/docs/architecture/12-ci-feedback-contract.md
+++ b/docs/architecture/12-ci-feedback-contract.md
@@ -42,25 +42,31 @@ CIResult:
 
 | Value | Meaning |
 |-------|---------|
-| `pending` | CI checks are still running or no checks have been reported. |
+| `pending` | CI checks are still running, no checks have been reported, or a completed check concluded `cancelled` while no check is failing. |
 | `passing` | All checks completed successfully. |
-| `failing` | At least one check completed with a failure, timed-out, or cancelled conclusion. |
+| `failing` | At least one check completed with a failure or timed-out conclusion. |
 
-The aggregate treats exactly three completed conclusions as failing: `failure`, `timed_out`, and
-`cancelled`. A `neutral` or `skipped` conclusion is non-failing, and an unmappable platform
-conclusion maps to `pending`, which is also non-failing. Whether the aggregate defers is decided by
-the run's `status`, not its conclusion: a run that has not completed holds the aggregate at
-`pending`, while a completed run carrying a `pending` conclusion counts toward `passing`.
+Two completed conclusions are failing: `failure` and `timed_out`. A completed check whose
+conclusion is `cancelled` reached no result, so it is neither a passing nor a failing statement
+about the commit: it withholds a passing verdict without asserting a failing one. A `neutral` or
+`skipped` conclusion is non-failing, and an unmappable platform conclusion maps to `pending`, which
+is also non-failing. The aggregate answers in that order: failing when any run's conclusion is
+`failure` or `timed_out`; otherwise pending when a run has not completed or a completed run
+concluded `cancelled`; otherwise passing. A completed run carrying a `pending` conclusion still
+counts toward `passing`.
 
 Every forge that exposes both a CI provider and a source-control merge-gate read applies this one
-aggregation rule, so neither reader can invent its own definition of failing. The two can still
-reach different verdicts when they read different signals: on GitHub the CI provider reads check
-runs only, while the merge gate reads the combined commit status as well, so a commit whose sole
-failing signal is a legacy commit status is passing to one and failing to the other. On GitLab the
-CI provider derives its verdict from the normalized run set. The merge gate reads the platform's
-own pipeline aggregate for every pipeline status whose aggregate is a function of the failing set,
-and falls back to that same normalized run set for the one status where it is not: a pipeline
-blocked on a manual action. What remains is the shape where the platform reports a
+aggregation rule, so neither reader can invent its own definition of failing. Only the GitHub and
+GitLab adapters can produce a `cancelled` conclusion; Gitea's commit-status vocabulary has no
+equivalent, so the shared rule governs a case two of the three adapters can reach. The two readers
+can still reach different verdicts when they read different signals: on GitHub the CI provider
+reads check runs only, while the merge gate reads the combined commit status as well, so a commit
+whose sole failing signal is a legacy commit status is passing to one and failing to the other. On
+GitLab the CI provider derives its verdict from the normalized run set. The merge gate answers from
+the platform's own pipeline aggregate for every status except a pipeline blocked on a manual
+action, which is the one status resolved from that pipeline's own job set; a `canceled` pipeline
+answers pending, withholding green without asserting failure, in step with what a cancelled
+conclusion does to the aggregate. What remains is the shape where the platform reports a
 settled, non-failing pipeline that carries no run at all: the merge gate answers from the
 aggregate, and the CI provider answers `pending` from an empty run set.
 
@@ -193,9 +199,11 @@ When `reaction_attempts[issue_id:ci]` exceeds `ci_feedback.max_retries`:
 - `escalation: label` (default): add `escalation_label` (default `needs-human`) to the tracker
   issue via `TrackerAdapter.AddLabel`. The label call runs in a detached goroutine with a 30-second
   timeout.
-- `escalation: comment`: post a plain-text comment listing the ref, attempt count, failing check
-  names, conclusions, and details URLs. The comment call runs in a detached goroutine with a
-  30-second timeout.
+- `escalation: comment`: post a plain-text comment listing the ref, attempt count, and the names,
+  conclusions, and details URLs of exactly the checks the verdict counted as failing. The reaction
+  layer applies the same shared classification rather than restating the conclusion set; it MUST
+  NOT import an adapter package. The comment call runs in a detached goroutine with a 30-second
+  timeout.
 
 After escalation:
 

--- a/docs/github-adapter-notes.md
+++ b/docs/github-adapter-notes.md
@@ -664,8 +664,9 @@ conclusion.
 | Observation | Returned conclusion |
 | ----------- | ------------------- |
 | No statuses and no check runs | `""` (no signal) |
-| Any run whose conclusion is failure, timed out, or cancelled | `"failing"` |
-| Every run reports completed status and none failed | `"success"` |
+| Any run whose conclusion is failure or timed out | `"failing"` |
+| A completed run's conclusion is cancelled, and no run is failing | `"pending"` |
+| Every run reports completed status and none failed or is cancelled | `"success"` |
 | Anything else | `"pending"` |
 
 Idempotent and read-only. The empty string means "no required checks exist on this pull

--- a/docs/gitlab-adapter-notes.md
+++ b/docs/gitlab-adapter-notes.md
@@ -1808,10 +1808,16 @@ each enumerate exactly those 13 values (`created`, `waiting_for_resource`, `prep
 | --- | --- |
 | `null` (no pipeline for the head SHA) | `""` |
 | `success`, `skipped` | `"success"` |
-| `failed`, `canceled` | `"failing"` |
+| `failed` | `"failing"` |
+| `canceled` | `"pending"`: the pipeline reached no conclusion, so the gate withholds green without asserting failure |
 | `created`, `waiting_for_resource`, `preparing`, `waiting_for_callback`, `pending`, `running`, `canceling`, `scheduled` | `"pending"` (still settling) |
 | `manual` | the verdict `scmcore.MergeGate` computes over the pipeline's own job set, at the cost of one extra request (see below) |
 | any other value, including the empty string | `"pending"`, and logs one WARN naming the observed value |
+
+For a `canceled` head pipeline the gate answers `"pending"` from `head_pipeline.status` alone and
+issues no job-set read (`mapPipelineStatus`, `internal/scm/gitlab/scm_merge.go`), unlike `manual`.
+The answer is the withhold-green verdict this table states, not a fold of that pipeline's own
+jobs; what a `canceled` pipeline's job set actually contains is not established here.
 
 **The table above applies only when `head_pipeline.sha` matches the merge request's own `sha`,
 compared case-insensitively.** A difference means the platform has not caught up with a new
@@ -1824,9 +1830,10 @@ pipeline's id, rather than reporting the status the superseded pipeline carries.
 dispositions actually change: a superseded pipeline reporting `success` or `skipped` no longer
 answers `"success"`, and a superseded `manual` pipeline whose job set would fold to `success` no
 longer pays for the job-set read below at all. A superseded `failed`, `canceled`, or one of the
-eight settling statuses already answered a non-merge-eligible value and still does. A `null`
-`head_pipeline` is unaffected by the comparison and keeps its `""`: the platform reports a
-genuinely uncovered head with `head_pipeline: null` and `detailed_merge_status: "mergeable"`
+eight settling statuses already answered a non-merge-eligible value (`"failing"` or `"pending"`)
+and still does. A `null` `head_pipeline` is unaffected by the comparison and keeps its `""`: the
+platform reports a genuinely uncovered head with `head_pipeline: null` and
+`detailed_merge_status: "mergeable"`
 **[live-CE]**, a shape the wire distinguishes from a superseded pipeline, so the two are never
 conflated.
 

--- a/internal/domain/ci.go
+++ b/internal/domain/ci.go
@@ -9,16 +9,17 @@ import (
 type CIStatus string
 
 const (
-	// CIStatusPending indicates CI checks are still running or no
-	// checks have been reported yet.
+	// CIStatusPending indicates CI checks are still running, no
+	// checks have been reported yet, or a completed check concluded
+	// cancelled while no check is failing.
 	CIStatusPending CIStatus = "pending"
 
 	// CIStatusPassing indicates all checks have completed
 	// successfully.
 	CIStatusPassing CIStatus = "passing"
 
-	// CIStatusFailing indicates at least one check has completed
-	// with a failure conclusion.
+	// CIStatusFailing indicates at least one check completed with a
+	// failure or timed-out conclusion.
 	CIStatusFailing CIStatus = "failing"
 )
 

--- a/internal/orchestrator/ci_reconcile.go
+++ b/internal/orchestrator/ci_reconcile.go
@@ -10,6 +10,7 @@ import (
 	"github.com/sortie-ai/sortie/internal/domain"
 	"github.com/sortie-ai/sortie/internal/logging"
 	"github.com/sortie-ai/sortie/internal/persistence"
+	"github.com/sortie-ai/sortie/internal/scm/scmcore"
 )
 
 // ciPendingBackoffBaseDefault is the fallback base interval for CI-pending
@@ -366,6 +367,11 @@ func escalateCIFailure(
 // buildCIEscalationComment builds a plain-text escalation comment for
 // CI failures that exceeded the retry budget. Plain text is used so the
 // comment renders consistently across all tracker adapters.
+//
+// The comment names exactly the checks the verdict counted as failing,
+// obtaining that classification from [scmcore.IsFailingConclusion]
+// rather than restating it, so the named checks never disagree with the
+// verdict that triggered the escalation.
 func buildCIEscalationComment(result domain.CIResult, ref string, attempts int) string {
 	var b strings.Builder
 	fmt.Fprintf(&b, "CI fix retries exhausted\n\n")
@@ -376,14 +382,14 @@ func buildCIEscalationComment(result domain.CIResult, ref string, attempts int) 
 	}
 
 	for _, cr := range result.CheckRuns {
-		switch cr.Conclusion {
-		case domain.CheckConclusionFailure, domain.CheckConclusionTimedOut, domain.CheckConclusionCancelled:
-			fmt.Fprintf(&b, "- %s: %s", cr.Name, cr.Conclusion)
-			if cr.DetailsURL != "" {
-				fmt.Fprintf(&b, " (details: %s)", cr.DetailsURL)
-			}
-			b.WriteString("\n")
+		if !scmcore.IsFailingConclusion(cr.Conclusion) {
+			continue
 		}
+		fmt.Fprintf(&b, "- %s: %s", cr.Name, cr.Conclusion)
+		if cr.DetailsURL != "" {
+			fmt.Fprintf(&b, " (details: %s)", cr.DetailsURL)
+		}
+		b.WriteString("\n")
 	}
 
 	b.WriteString("\nManual intervention required.")

--- a/internal/orchestrator/ci_reconcile_test.go
+++ b/internal/orchestrator/ci_reconcile_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/sortie-ai/sortie/internal/config"
 	"github.com/sortie-ai/sortie/internal/domain"
 	"github.com/sortie-ai/sortie/internal/persistence"
+	"github.com/sortie-ai/sortie/internal/scm/scmcore"
 )
 
 // --- Test doubles ---
@@ -302,6 +303,93 @@ func TestReconcileCIStatus_Pending_ReEnqueues(t *testing.T) {
 	}
 }
 
+// TestReconcileCIStatus_CancelledOnly_NoRetrySpent covers the case where a
+// ref's only completed checks are a cancelled run alongside a successful
+// one. The fixture's Status and FailingCount are derived from the declared
+// check-run set via scmcore.AggregateCIStatus and scmcore.FailingCount,
+// rather than written as literals, so a classifier regression reddens this
+// test rather than passing it vacuously.
+func TestReconcileCIStatus_CancelledOnly_NoRetrySpent(t *testing.T) {
+	t.Parallel()
+
+	runs := []domain.CheckRun{
+		{Name: "build", Status: domain.CheckRunStatusCompleted, Conclusion: domain.CheckConclusionCancelled},
+		{Name: "lint", Status: domain.CheckRunStatusCompleted, Conclusion: domain.CheckConclusionSuccess},
+	}
+
+	state := stateWithPendingReaction(t, "ISS-CI-CANCELLED", "feature/cancelled-only", 1)
+	store := &ciReconcileStore{}
+	metrics := newCIMetricsSpy()
+	ci := &mockCIProvider{result: domain.CIResult{
+		Status:       scmcore.AggregateCIStatus(runs),
+		FailingCount: scmcore.FailingCount(runs),
+		CheckRuns:    runs,
+	}}
+	params := ciParams(t, store, ci, nil)
+
+	reconcileCIStatus(state, params, discardLogger(), context.Background(), metrics)
+
+	if _, ok := state.ReactionAttempts[ReactionKey("ISS-CI-CANCELLED", ReactionKindCI)]; ok {
+		t.Error("ReactionAttempts set after cancelled-only result; want unchanged (unset)")
+	}
+	if len(store.runHistories) != 0 {
+		t.Errorf("AppendRunHistory call count = %d, want 0", len(store.runHistories))
+	}
+	if _, ok := state.RetryAttempts["ISS-CI-CANCELLED"]; ok {
+		t.Error("retry scheduled after cancelled-only result; want none")
+	}
+	entry, ok := state.PendingReactions[ReactionKey("ISS-CI-CANCELLED", ReactionKindCI)]
+	if !ok {
+		t.Fatal("PendingReactions entry not re-enqueued after cancelled-only result; want re-enqueued")
+	}
+	if entry.PendingAttempts != 1 {
+		t.Errorf("PendingReactions entry PendingAttempts = %d, want 1", entry.PendingAttempts)
+	}
+	if metrics.ciStatusChecks["pending"] != 1 {
+		t.Errorf(`IncCIStatusChecks("pending") = %d, want 1`, metrics.ciStatusChecks["pending"])
+	}
+}
+
+// TestReconcileCIStatus_CancelledWithFailure_StillSpendsRetry covers the
+// shape in which a cancellation coexists with a genuine failure on the same
+// ref: the pass still takes the failing arm. The fixture is derived the
+// same way as TestReconcileCIStatus_CancelledOnly_NoRetrySpent, so this
+// test fails against any classifier in which a cancelled run masks a
+// failing sibling.
+func TestReconcileCIStatus_CancelledWithFailure_StillSpendsRetry(t *testing.T) {
+	t.Parallel()
+
+	runs := []domain.CheckRun{
+		{Name: "build", Status: domain.CheckRunStatusCompleted, Conclusion: domain.CheckConclusionCancelled},
+		{Name: "test", Status: domain.CheckRunStatusCompleted, Conclusion: domain.CheckConclusionFailure},
+	}
+
+	state := stateWithPendingReaction(t, "ISS-CI-CANCELLED-FAIL", "feature/cancelled-with-failure", 1)
+	store := &ciReconcileStore{}
+	metrics := newCIMetricsSpy()
+	ci := &mockCIProvider{result: domain.CIResult{
+		Status:       scmcore.AggregateCIStatus(runs),
+		FailingCount: scmcore.FailingCount(runs),
+		CheckRuns:    runs,
+	}}
+	params := ciParams(t, store, ci, nil)
+
+	reconcileCIStatus(state, params, discardLogger(), context.Background(), metrics)
+
+	if state.ReactionAttempts[ReactionKey("ISS-CI-CANCELLED-FAIL", ReactionKindCI)] != 1 {
+		t.Errorf("ReactionAttempts[ISS-CI-CANCELLED-FAIL] = %d, want 1", state.ReactionAttempts[ReactionKey("ISS-CI-CANCELLED-FAIL", ReactionKindCI)])
+	}
+	if len(store.runHistories) != 1 {
+		t.Fatalf("AppendRunHistory call count = %d, want 1", len(store.runHistories))
+	}
+	if store.runHistories[0].Status != "ci_failed" {
+		t.Errorf("RunHistory.Status = %q, want %q", store.runHistories[0].Status, "ci_failed")
+	}
+	if _, ok := state.RetryAttempts["ISS-CI-CANCELLED-FAIL"]; !ok {
+		t.Error("retry not scheduled after cancelled-with-failure result; want scheduled")
+	}
+}
+
 func TestReconcileCIStatus_Failing_UnderMaxRetries(t *testing.T) {
 	t.Parallel()
 
@@ -536,7 +624,7 @@ func TestBuildCIEscalationComment(t *testing.T) {
 		{
 			name: "only failure check runs included",
 			result: domain.CIResult{
-				FailingCount: 3,
+				FailingCount: 2,
 				CheckRuns: []domain.CheckRun{
 					{Name: "lint", Status: domain.CheckRunStatusCompleted, Conclusion: domain.CheckConclusionSuccess},
 					{Name: "test", Status: domain.CheckRunStatusCompleted, Conclusion: domain.CheckConclusionFailure},
@@ -546,8 +634,8 @@ func TestBuildCIEscalationComment(t *testing.T) {
 			},
 			ref:            "feature/x",
 			attempts:       2,
-			wantContains:   []string{"test", "deploy", "e2e"},
-			wantNotContain: []string{"lint"},
+			wantContains:   []string{"test", "deploy"},
+			wantNotContain: []string{"lint", "e2e"},
 		},
 		{
 			name: "check run without details URL omits link",

--- a/internal/scm/gitlab/scm_merge.go
+++ b/internal/scm/gitlab/scm_merge.go
@@ -206,14 +206,19 @@ func (a *GitLabSCMAdapter) fetchPipelineStatuses(ctx context.Context, owner, rep
 // gives when asked about a status its merge-gate caller, [GitLabSCMAdapter.GetCIStatus],
 // resolves for itself from that pipeline's own job set, rather than a
 // value the gate holds until the shape settles on its own.
+//
+// canceled reports no conclusion about the code: the pipeline reached no
+// result, so the gate answers what folding that pipeline's own jobs
+// would answer, which is [scmcore.CIGatePending] unless a sibling job
+// failed.
 func mapPipelineStatus(status string) (gate scmcore.CIGate, recognized bool) {
 	switch status {
 	case "success", "skipped":
 		return scmcore.CIGateSuccess, true
-	case "failed", "canceled":
+	case "failed":
 		return scmcore.CIGateFailing, true
 	case "created", "waiting_for_resource", "preparing", "waiting_for_callback",
-		"pending", "running", "canceling", "scheduled", "manual":
+		"pending", "running", "canceling", "canceled", "scheduled", "manual":
 		return scmcore.CIGatePending, true
 	default:
 		return scmcore.CIGatePending, false

--- a/internal/scm/gitlab/scm_merge_test.go
+++ b/internal/scm/gitlab/scm_merge_test.go
@@ -450,7 +450,7 @@ func TestGetCIStatus_HeadPipelineMapping(t *testing.T) {
 	}{
 		{"success maps to CIGateSuccess", map[string]any{"head_pipeline": headPipeline(map[string]any{"status": "success"})}, "success", false, ""},
 		{"failed maps to CIGateFailing", map[string]any{"head_pipeline": headPipeline(map[string]any{"status": "failed"})}, "failing", false, ""},
-		{"canceled maps to CIGateFailing", map[string]any{"head_pipeline": headPipeline(map[string]any{"status": "canceled"})}, "failing", false, ""},
+		{"canceled maps to CIGatePending", map[string]any{"head_pipeline": headPipeline(map[string]any{"status": "canceled"})}, "pending", false, ""},
 		{"an unrecognized status defers to CIGatePending and logs a warning", map[string]any{"head_pipeline": headPipeline(map[string]any{"status": "expired"})}, "pending", true, "expired"},
 		{"an empty head_pipeline status defers to CIGatePending and logs a warning", map[string]any{"head_pipeline": headPipeline(map[string]any{"status": ""})}, "pending", true, ""},
 		{"a nil head_pipeline maps to CIGateAbsent (empty string)", map[string]any{"head_pipeline": nil}, "", false, ""},

--- a/internal/scm/scmcore/cistatus.go
+++ b/internal/scm/scmcore/cistatus.go
@@ -33,7 +33,7 @@ const (
 	CIGateAbsent CIGate = ""
 )
 
-// IsFailingConclusion reports whether conclusion is one of the three
+// IsFailingConclusion reports whether conclusion is one of the two
 // conclusions the aggregate and the merge gate both treat as failing.
 //
 // Callers that need the rule for something other than a verdict, such as
@@ -41,40 +41,57 @@ const (
 // conclusion set.
 func IsFailingConclusion(conclusion domain.CheckConclusion) bool {
 	switch conclusion {
-	case domain.CheckConclusionFailure, domain.CheckConclusionTimedOut, domain.CheckConclusionCancelled:
+	case domain.CheckConclusionFailure, domain.CheckConclusionTimedOut:
 		return true
 	default:
 		return false
 	}
 }
 
+// isInconclusiveConclusion reports whether conclusion means the run
+// reached no result, so it is neither a passing nor a failing statement
+// about the commit and therefore withholds a passing verdict without
+// producing a failing one.
+//
+// Adding a conclusion to this predicate withholds green from every
+// forge and both readers, the CI verdict and the merge gate, since both
+// derive from [AggregateCIStatus].
+func isInconclusiveConclusion(conclusion domain.CheckConclusion) bool {
+	return conclusion == domain.CheckConclusionCancelled
+}
+
 // AggregateCIStatus reports the pipeline verdict a normalized check-run
-// set implies: pending for an empty set, failing when any run's
-// conclusion is failure, timed_out, or cancelled, passing when every run
-// has completed with none of those conclusions, and pending otherwise.
+// set implies, answering in this order: failing when any run's
+// conclusion satisfies [IsFailingConclusion]; otherwise pending when any
+// run has not completed or any completed run's conclusion satisfies
+// isInconclusiveConclusion; otherwise passing. The empty or nil set
+// answers pending. A completed run whose conclusion is cancelled holds
+// the aggregate at pending unless another run forces failing.
 func AggregateCIStatus(runs []domain.CheckRun) domain.CIStatus {
 	if len(runs) == 0 {
 		return domain.CIStatusPending
 	}
 
-	allCompleted := true
-	anyFailed := false
+	anyFailing := false
+	anyWithholds := false
 	for _, run := range runs {
 		if run.Status != domain.CheckRunStatusCompleted {
-			allCompleted = false
+			anyWithholds = true
+		} else if isInconclusiveConclusion(run.Conclusion) {
+			anyWithholds = true
 		}
 		if IsFailingConclusion(run.Conclusion) {
-			anyFailed = true
+			anyFailing = true
 		}
 	}
 
-	if anyFailed {
+	if anyFailing {
 		return domain.CIStatusFailing
 	}
-	if allCompleted {
-		return domain.CIStatusPassing
+	if anyWithholds {
+		return domain.CIStatusPending
 	}
-	return domain.CIStatusPending
+	return domain.CIStatusPassing
 }
 
 // FailingCount counts the runs AggregateCIStatus treats as failing.

--- a/internal/scm/scmcore/cistatus.go
+++ b/internal/scm/scmcore/cistatus.go
@@ -54,8 +54,11 @@ func IsFailingConclusion(conclusion domain.CheckConclusion) bool {
 // producing a failing one.
 //
 // Adding a conclusion to this predicate withholds green from every
-// forge and both readers, the CI verdict and the merge gate, since both
-// derive from [AggregateCIStatus].
+// reader that folds the normalized run set: the CI verdict on every
+// forge, and the merge gate wherever it derives from
+// [AggregateCIStatus]. A forge whose merge gate maps a platform-level
+// pipeline aggregate directly does not pass through this predicate, and
+// has to be kept in step at that mapping instead.
 func isInconclusiveConclusion(conclusion domain.CheckConclusion) bool {
 	return conclusion == domain.CheckConclusionCancelled
 }

--- a/internal/scm/scmcore/cistatus_test.go
+++ b/internal/scm/scmcore/cistatus_test.go
@@ -54,12 +54,12 @@ func TestAggregateCIStatus(t *testing.T) {
 			want: domain.CIStatusPending,
 		},
 		{
-			name: "cancelled returns Failing",
+			name: "cancelled with success returns Pending",
 			runs: []domain.CheckRun{
 				run(domain.CheckRunStatusCompleted, domain.CheckConclusionCancelled),
 				run(domain.CheckRunStatusCompleted, domain.CheckConclusionSuccess),
 			},
-			want: domain.CIStatusFailing,
+			want: domain.CIStatusPending,
 		},
 		{
 			name: "timed_out returns Failing",
@@ -67,6 +67,38 @@ func TestAggregateCIStatus(t *testing.T) {
 				run(domain.CheckRunStatusCompleted, domain.CheckConclusionTimedOut),
 			},
 			want: domain.CIStatusFailing,
+		},
+		{
+			name: "all cancelled returns Pending",
+			runs: []domain.CheckRun{
+				run(domain.CheckRunStatusCompleted, domain.CheckConclusionCancelled),
+				run(domain.CheckRunStatusCompleted, domain.CheckConclusionCancelled),
+			},
+			want: domain.CIStatusPending,
+		},
+		{
+			name: "cancelled with failure returns Failing",
+			runs: []domain.CheckRun{
+				run(domain.CheckRunStatusCompleted, domain.CheckConclusionCancelled),
+				run(domain.CheckRunStatusCompleted, domain.CheckConclusionFailure),
+			},
+			want: domain.CIStatusFailing,
+		},
+		{
+			name: "cancelled with timed_out returns Failing",
+			runs: []domain.CheckRun{
+				run(domain.CheckRunStatusCompleted, domain.CheckConclusionCancelled),
+				run(domain.CheckRunStatusCompleted, domain.CheckConclusionTimedOut),
+			},
+			want: domain.CIStatusFailing,
+		},
+		{
+			name: "cancelled with in_progress returns Pending",
+			runs: []domain.CheckRun{
+				run(domain.CheckRunStatusCompleted, domain.CheckConclusionCancelled),
+				run(domain.CheckRunStatusInProgress, domain.CheckConclusionPending),
+			},
+			want: domain.CIStatusPending,
 		},
 		{
 			name: "all neutral and skipped completed returns Passing",
@@ -136,14 +168,14 @@ func TestFailingCount(t *testing.T) {
 			want: 1,
 		},
 		{
-			name: "counts failure timed_out and cancelled",
+			name: "counts failure and timed_out but not cancelled",
 			runs: []domain.CheckRun{
 				run(domain.CheckConclusionFailure),
 				run(domain.CheckConclusionTimedOut),
 				run(domain.CheckConclusionCancelled),
 				run(domain.CheckConclusionSuccess),
 			},
-			want: 3,
+			want: 2,
 		},
 		{
 			name: "empty slice returns 0",
@@ -166,6 +198,52 @@ func TestFailingCount(t *testing.T) {
 			got := scmcore.FailingCount(tt.runs)
 			if got != tt.want {
 				t.Errorf("FailingCount: got %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMergeGate(t *testing.T) {
+	t.Parallel()
+
+	run := func(conclusion domain.CheckConclusion) domain.CheckRun {
+		return domain.CheckRun{Status: domain.CheckRunStatusCompleted, Conclusion: conclusion}
+	}
+
+	tests := []struct {
+		name string
+		runs []domain.CheckRun
+		want scmcore.CIGate
+	}{
+		{
+			name: "empty slice returns CIGateAbsent",
+			runs: []domain.CheckRun{},
+			want: scmcore.CIGateAbsent,
+		},
+		{
+			name: "cancelled with no failing conclusion returns CIGatePending",
+			runs: []domain.CheckRun{
+				run(domain.CheckConclusionCancelled),
+				run(domain.CheckConclusionSuccess),
+			},
+			want: scmcore.CIGatePending,
+		},
+		{
+			name: "cancelled with a failing conclusion returns CIGateFailing",
+			runs: []domain.CheckRun{
+				run(domain.CheckConclusionCancelled),
+				run(domain.CheckConclusionFailure),
+			},
+			want: scmcore.CIGateFailing,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := scmcore.MergeGate(tt.runs)
+			if got != tt.want {
+				t.Errorf("MergeGate: got %q, want %q", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Fix

**Intent:** The shared CI verdict counted three completed conclusions as failing: `failure`, `timed_out` and `cancelled`. A required workflow configured to cancel its own in-flight runs when a newer commit lands therefore produced a failing verdict on every push, which dispatched a fix continuation and spent one of the retries bounded by `reactions.ci_failure.max_retries`. Nothing had failed. In the deployment that reported this, both configured retries went exactly that way, so a commit that genuinely failed CI later found the budget already gone and went unremediated while the issue sat in its review state.

Cancelled now withholds green rather than asserting failure. Only `failure` and `timed_out` remain failing, on every forge. A cancelled check holds the aggregate at pending, so it neither dispatches a continuation nor appends a failure to run history, and it cannot grant a green merge gate to checks that never ran. A head carrying three cancelled checks and one successful one is pending: not green, because checks that never ran cannot grant green, and not failing, because nothing failed.

**Related Issues:** #831, #820

### 🧭 Reviewer Guide

**Complexity:** Medium

#### Entry Point

`internal/scm/scmcore/cistatus.go` - the one place the rule lives, shared by every forge and by both readers. `IsFailingConclusion` narrows to two conclusions, and `AggregateCIStatus` gains a second predicate so that dropping `cancelled` from the failing set does not silently promote it to passing. That distinction is the whole change: deferral is decided by a run `status` rather than its conclusion, and a cancelled check run completes, so removing it from the failing set alone would make a cancelled-only head read `passing`, retire the CI episode and let the merge gate green a pull request whose required checks never ran. The aggregate now answers in order: any failure or timeout is failing; otherwise any queued, running or cancelled check is pending; otherwise passing. `FailingCount` and `MergeGate` derive from the same predicate and needed no edit.

#### Sensitive Areas

- `internal/scm/gitlab/scm_merge.go`: GitLab is the one forge whose merge gate does not read the shared job aggregate. `mapPipelineStatus` reads the platform pipeline status directly and mapped `canceled` to a failing gate, so a core-only change would have left GitLab answering differently from every other forge while the suite looked green. `canceled` now maps to a pending gate. Worth knowing that the adapter conformance helper covers each adapter CI verdict but not this second GitLab reader, so what forces the change here is `TestGetCIStatus_PipelineStatusEnumAgreement`, which computes its expectation through the shared merge gate.
- `internal/orchestrator/ci_reconcile.go`: `buildCIEscalationComment` held a second, hand-copied copy of the failing set and now derives it from the shared classifier, so the escalation names exactly the checks the verdict counted rather than citing cancelled checks as the reason manual intervention is required. The new `scmcore` import is the second production use of that package from this layer, alongside the existing `IsBotAuthor` call in `review_reconcile.go`.
- `docs/architecture/12-ci-feedback-contract.md`: the three-conclusion rule was stated normatively here, so the specification changes together with the behaviour. The amendment also covers two sentences the change falsifies downstream of the rule itself: the one asserting deferral is decided by run status alone, and the one naming a manual-action pipeline as the only GitLab status not answered from the platform aggregate.
- Adapter conclusion mappings are deliberately untouched on all three forges. GitHub still maps `stale` to pending, which is a different mechanism: there the platform states that a replacement run is coming. Gitea cannot produce a cancelled conclusion at all, so it inherits the new rule through the shared layer with no adapter edit.

Both new orchestrator tests build their fixtures by computing `Status` and `FailingCount` from the shared classifier over the declared check-run set rather than writing either as a literal. That matters because `reconcileCIStatus` routes on `result.Status` alone and the CI provider mock returns its stored result verbatim, so a fixture with a hand-set status never reaches the classifier and would pass identically before and after this change. The cancelled-only test was confirmed red against the previous classifier and green against the new one.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes. No exported symbol was added, removed or renamed, and no configuration field changed.
- **Migrations/State:** No migrations or state changes. The observable behaviour change is that a cancelled check now yields a pending verdict instead of a failing one, so a pull request whose checks were all cancelled holds rather than reporting a failure, and resolves when the checks are re-run or a newer commit lands.