### PR TITLE
fix(orchestrator): re-evaluate CI verdict on current head

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   comment.
   ([#777](https://github.com/sortie-ai/sortie/issues/777))
 
+- The `ci_failure` reaction now evaluates the pull request's current
+  head on every pass and keeps watching after a passing result, so a
+  commit pushed later that fails CI is observed and receives a fix
+  continuation. Previously the watch retired on the first passing
+  result and the commit it polled never advanced past the one the agent
+  handed off, so a branch could sit on a failing commit with its linked
+  issue stuck in the review state and no escalation raised. A new head
+  restores the attempt budget only when Sortie can establish that the
+  commit is not its own work, so an agent cannot extend its own budget
+  by pushing. The watch ends when the pull request merges or closes,
+  and otherwise after `reactions.ci_failure.watch_window_ms`
+  (default `86400000`, twenty-four hours) with no new commit; `0`
+  removes that bound, and applying the configured fix label re-arms a
+  pull request by hand.
+  ([#871](https://github.com/sortie-ai/sortie/issues/871))
+
+### Changed
+
+- `reactions.ci_failure` now resolves the pull request's current head
+  through the same SCM provider every other active SCM-backed reaction
+  uses, so a deployment naming `reactions.ci_failure` with one provider
+  and another active SCM-backed reaction with a different provider now
+  fails at startup instead of running with a currency-blind CI watch.
+  The previously accepted shape, two providers across the active
+  SCM-backed reactions including `ci_failure`, is no longer valid; name
+  one forge across every active SCM-backed reaction, including
+  `ci_failure`, to start again.
+  ([#871](https://github.com/sortie-ai/sortie/issues/871))
+
 ## [1.20.0] - 2026-08-18
 
 ### Added

--- a/cmd/sortie/main.go
+++ b/cmd/sortie/main.go
@@ -406,6 +406,8 @@ func run(ctx context.Context, args []string, stdout io.Writer, stderr io.Writer)
 	// constructs the SCM adapter and joins the provider-conflict check.
 	labelFixActive := br.cfg.LabelCommands.Provider != "" && br.cfg.LabelCommands.FixLabel != ""
 
+	ciFeedbackActive := br.cfg.CIFeedback.Kind != ""
+
 	activeSCMKinds := []scmReactionKind{
 		{name: "review_comments", active: reviewActive, provider: reviewRC.Provider},
 		{name: "auto_merge", active: autoMergeActive, provider: autoMergeRC.Provider},
@@ -413,17 +415,23 @@ func run(ctx context.Context, args []string, stdout io.Writer, stderr io.Writer)
 		{name: "merge_conflicts", active: mergeConflictActive, provider: mergeConflictRC.Provider},
 		{name: "label_commands", active: labelReviewActive || labelFixActive, provider: br.cfg.LabelCommands.Provider},
 		{name: "merge_completion", active: mergeCompletionActive, provider: mergeCompletionRC.Provider},
+		{name: "ci_failure", active: ciFeedbackActive, provider: br.cfg.CIFeedback.Kind},
 	}
 	if conflictKinds, conflictProviders := scmProviderConflict(activeSCMKinds); len(conflictProviders) > 1 {
-		br.logger.Error("unsupported: active SCM reaction kinds must use the same provider",
+		conflictAttrs := []any{
 			slog.String("kinds", strings.Join(conflictKinds, ", ")),
 			slog.String("providers", strings.Join(conflictProviders, ", ")),
-		)
+		}
+		if slices.Contains(conflictKinds, "ci_failure") {
+			conflictAttrs = append(conflictAttrs, slog.String("reason",
+				"reactions.ci_failure now resolves the pull request's head through the SCM provider, so its provider must be the same forge as every other active SCM-backed reaction"))
+		}
+		br.logger.Error("unsupported: active SCM reaction kinds must use the same provider", conflictAttrs...)
 		return 1
 	}
 
-	if reviewActive || autoMergeActive || botReviewActive || mergeConflictActive || labelReviewActive || labelFixActive || mergeCompletionActive {
-		provider := cmp.Or(reviewRC.Provider, autoMergeRC.Provider, botReviewRC.Provider, mergeConflictRC.Provider, br.cfg.LabelCommands.Provider, mergeCompletionRC.Provider)
+	if reviewActive || autoMergeActive || botReviewActive || mergeConflictActive || labelReviewActive || labelFixActive || mergeCompletionActive || ciFeedbackActive {
+		provider := cmp.Or(reviewRC.Provider, autoMergeRC.Provider, botReviewRC.Provider, mergeConflictRC.Provider, br.cfg.LabelCommands.Provider, mergeCompletionRC.Provider, br.cfg.CIFeedback.Kind)
 		scmCtor, scmErr := registry.SCMAdapters.Get(provider)
 		if scmErr != nil {
 			br.logger.Error("unknown SCM adapter kind",

--- a/cmd/sortie/main_test.go
+++ b/cmd/sortie/main_test.go
@@ -1426,6 +1426,160 @@ Fix issue {{ .issue.identifier }}.
 `, issuesPath, workspaceRoot)
 }
 
+// ciFailureOnlyWorkflow returns a WORKFLOW.md configuring only
+// reactions.ci_failure with a valid provider and no other SCM-backed
+// reaction, so a successful startup demonstrates that a CI-only
+// deployment constructs an SCM adapter on its own.
+func ciFailureOnlyWorkflow(issuesPath, workspaceRoot string) []byte {
+	return fmt.Appendf(nil, `---
+tracker:
+  kind: file
+  project: DEMO
+  active_states:
+    - "To Do"
+  handoff_state: Done
+
+file:
+  path: %s
+
+agent:
+  kind: mock
+  max_turns: 1
+
+polling:
+  interval_ms: 500
+
+workspace:
+  root: %s
+
+github:
+  api_key: "unused"
+  project: "acme/widgets"
+
+reactions:
+  ci_failure:
+    provider: github
+    max_retries: 2
+    escalation: label
+---
+
+Fix issue {{ .issue.identifier }}.
+`, issuesPath, workspaceRoot)
+}
+
+// ciFailureWorkflowMismatchedProviders returns a WORKFLOW.md where
+// reactions.ci_failure and reactions.review_comments name different SCM
+// providers, which should cause startup to fail with exit code 1 and
+// name reactions.ci_failure among the conflicting kinds.
+func ciFailureWorkflowMismatchedProviders(issuesPath, workspaceRoot string) []byte {
+	return fmt.Appendf(nil, `---
+tracker:
+  kind: file
+  project: DEMO
+  active_states:
+    - "To Do"
+  handoff_state: Done
+
+file:
+  path: %s
+
+agent:
+  kind: mock
+  max_turns: 1
+
+polling:
+  interval_ms: 500
+
+workspace:
+  root: %s
+
+github:
+  api_key: "unused"
+  project: "acme/widgets"
+
+reactions:
+  review_comments:
+    provider: gitlab
+  ci_failure:
+    provider: github
+    max_retries: 2
+    escalation: label
+---
+
+Fix issue {{ .issue.identifier }}.
+`, issuesPath, workspaceRoot)
+}
+
+// TestRunCIFailureOnly_ConstructsSCMAdapter verifies that a WORKFLOW.md
+// configuring only reactions.ci_failure with a valid provider constructs
+// an SCM adapter and starts normally, rather than skipping SCM
+// construction because no other SCM-backed reaction is active.
+// No t.Parallel: calls t.Chdir.
+func TestRunCIFailureOnly_ConstructsSCMAdapter(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	wsRoot := filepath.Join(dir, "workspaces")
+
+	issuesPath := filepath.Join(dir, "issues.json")
+	if err := os.WriteFile(issuesPath, quickStartIssues(), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	wfPath := writeCustomWorkflowFile(t, dir, ciFailureOnlyWorkflow(issuesPath, wsRoot))
+
+	var stdout bytes.Buffer
+	var stderr lockedBuf
+	ctx, cancel := context.WithTimeout(context.Background(), runTestTimeout)
+	defer cancel()
+
+	code := run(ctx, []string{wfPath}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit code = %d, want 0; stderr:\n%s", code, stderr.String())
+	}
+
+	logs := stderr.String()
+	if !strings.Contains(logs, "CI feedback enabled") {
+		t.Errorf(`expected "CI feedback enabled" in log, got:\n%s`, logs)
+	}
+	if strings.Contains(logs, "unknown SCM adapter kind") || strings.Contains(logs, "failed to construct SCM adapter") {
+		t.Errorf("SCM adapter construction failed for a CI-only deployment; stderr:\n%s", logs)
+	}
+}
+
+// TestRunCIFailure_MismatchedProviders verifies that reactions.ci_failure
+// active alongside another active SCM-backed reaction naming a different
+// provider fails startup with exit code 1, and the emitted error names
+// reactions.ci_failure among the conflicting kinds.
+// No t.Parallel: calls t.Chdir.
+func TestRunCIFailure_MismatchedProviders(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	wsRoot := filepath.Join(dir, "workspaces")
+
+	issuesPath := filepath.Join(dir, "issues.json")
+	if err := os.WriteFile(issuesPath, quickStartIssues(), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	wfPath := writeCustomWorkflowFile(t, dir, ciFailureWorkflowMismatchedProviders(issuesPath, wsRoot))
+
+	var stdout bytes.Buffer
+	var stderr lockedBuf
+	ctx, cancel := context.WithTimeout(context.Background(), runTestTimeout)
+	defer cancel()
+
+	code := run(ctx, []string{wfPath}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("exit code = %d, want 1 (mismatched providers); stderr:\n%s", code, stderr.String())
+	}
+
+	logs := stderr.String()
+	if !strings.Contains(logs, "must use the same provider") {
+		t.Errorf("expected 'must use the same provider' in error log, got:\n%s", logs)
+	}
+	if !strings.Contains(logs, "ci_failure") {
+		t.Errorf("expected the conflicting kinds to name ci_failure, got:\n%s", logs)
+	}
+}
+
 // TestRunAutoMerge_EmptyProvider verifies that when reactions.auto_merge.provider
 // is empty, the server starts normally and does NOT log "auto_merge reaction
 // enabled" (spec Test 6 at the wiring layer).

--- a/cmd/sortie/scmprovider_test.go
+++ b/cmd/sortie/scmprovider_test.go
@@ -94,6 +94,25 @@ func TestScmProviderConflict(t *testing.T) {
 			wantConflict:          true,
 		},
 		{
+			name: "ci_failure active alongside a different provider",
+			kinds: []scmReactionKind{
+				{name: "review_comments", active: true, provider: "github"},
+				{name: "ci_failure", active: true, provider: "gitlab"},
+			},
+			wantActiveKinds:       []string{"review_comments", "ci_failure"},
+			wantDistinctProviders: []string{"github", "gitlab"},
+			wantConflict:          true,
+		},
+		{
+			name: "ci_failure active alone",
+			kinds: []scmReactionKind{
+				{name: "ci_failure", active: true, provider: "github"},
+			},
+			wantActiveKinds:       []string{"ci_failure"},
+			wantDistinctProviders: []string{"github"},
+			wantConflict:          false,
+		},
+		{
 			name: "all inactive kinds",
 			kinds: []scmReactionKind{
 				{name: "review_comments", active: false, provider: "github"},

--- a/docs/architecture/05-workflow-specification.md
+++ b/docs/architecture/05-workflow-specification.md
@@ -365,6 +365,9 @@ Equivalent to the deprecated `ci_feedback` section. See Section 11A for the CI f
 Extra fields:
 
 - `max_log_lines` (integer, via Extra): maximum CI log tail lines. Default: `50`.
+- `watch_window_ms` (integer, via Extra): bounds a pending CI entry's age, measured from the last
+  recorded head. Default: `86400000` (twenty-four hours). Must be non-negative. `0` removes the
+  clock bound.
 
 **Reaction kind: `review_comments`**
 

--- a/docs/architecture/08-polling-scheduling-and-reconciliation.md
+++ b/docs/architecture/08-polling-scheduling-and-reconciliation.md
@@ -196,16 +196,30 @@ Part B: Tracker state refresh
 Part C: CI status reconciliation (when `ci_feedback.kind` or `reactions.ci_failure` is configured)
 
 - For each entry in `pending_reactions` with kind `ci`:
-  - Deduplicate before fetching: a stored fingerprint equal to the current ref and already
-    marked dispatched drops the entry for this pass (§11A.5).
-  - Call `CIStatusProvider.FetchCIStatus` with the SCM ref (SHA preferred, branch as fallback).
+  - Resolve the pull request's current head via `SCMAdapter.GetMergeability` before deduplicating:
+    the fingerprint compares against this pass's live head, not a ref captured at worker exit
+    (§11A.4, §11A.5).
+  - If the call fails with `ErrSCMNotFound`: drop the entry and its attempt counter and log a
+    warning; the watch ends.
+  - If the call fails for any other reason: log a warning and re-enqueue with an exponential
+    backoff delay derived from the poll interval and the pending attempt count.
+  - If the pull request is merged, or closed without merging: drop the entry and its attempt
+    counter and log; the watch ends. The merged check runs first, so a provider whose closed state
+    subsumes merging still ends the watch through the merged branch.
+  - If the resolved head is empty: re-enqueue with backoff, recording no head and spending no
+    attempt.
+  - Deduplicate against the resolved head: a stored fingerprint equal to the current head and
+    already marked dispatched drops the entry for this pass; a stored fingerprint that differs
+    opens a new epoch (§11A.5).
+  - Call `CIStatusProvider.FetchCIStatus` with the resolved head.
   - If the call fails: log a warning, re-enqueue with an exponential backoff delay derived from
     the poll interval and the pending attempt count, and continue to the next entry.
-  - If status is `passing`: clear reaction attempts for the issue and kind, and delete the
-    fingerprint row.
+  - If status is `passing`: clear reaction attempts for the issue and kind and keep watching; the
+    entry re-enqueues rather than retiring, so a later commit's failure is still observed.
   - If status is `pending`: re-enqueue with the same exponential backoff as the fetch-error path.
   - If status is `failing`: consult the retry slot before handling as a CI failure; a non-nil
     incumbent defers instead of dispatching (Section 7.5, Section 7.3 "CI Status Failing").
+  - Every branch that does not end the watch re-enqueues the entry.
 
 Part D: Review comment reconciliation (when `reactions.review_comments` is configured)
 

--- a/docs/architecture/12-ci-feedback-contract.md
+++ b/docs/architecture/12-ci-feedback-contract.md
@@ -179,11 +179,13 @@ entry is dropped for this tick with backoff rather than proceeding to a status r
 not polled again for that head until a later worker exit, startup recovery, or a further head change
 creates or re-arms a pending entry.
 
-Fingerprint errors are logged and treated as non-fatal, but the two directions differ. A failed
-upsert is best-effort: the pass proceeds, and the next pass re-detects the same head change and
-re-applies the transition, which is idempotent for one head. A failed read suppresses epoch
-detection for that pass rather than fabricate a change: treating a read failure as a head change
-would reset the retry budget on a database error.
+Fingerprint errors are logged, and the two directions differ. A failed upsert defers the epoch
+transition: the entry is re-enqueued with backoff and the pass ends without applying it, because the
+durable head must advance before the runtime boundary does. The transition restarts the watch clock
+and re-arms the once-per-epoch escalation, so applying it against a record that did not advance
+repeats both on every later pass, and the age basis never grows old enough for the watch window to
+elapse. A failed read suppresses epoch detection for that pass rather than fabricate a change:
+treating a read failure as a head change would reset the retry budget on a database error.
 
 The `dispatched` flag is not set anywhere in this reconcile pass. `handleCIFailure` (Section 11A.6)
 schedules the CI-fix continuation through the shared retry machinery with `ReactionKind` set to

--- a/docs/architecture/12-ci-feedback-contract.md
+++ b/docs/architecture/12-ci-feedback-contract.md
@@ -129,54 +129,81 @@ Orchestrator behavior on CI errors:
 CI status reconciliation runs as Part C of active run reconciliation (Section 8.5), after tracker
 state refresh. The flow is:
 
-1. Skip entirely when neither `ci_feedback.kind` nor `reactions.ci_failure.provider` is configured
-   (no `CIStatusProvider` constructed).
+1. Skip entirely when `ci_feedback.kind`/`reactions.ci_failure.provider` is not configured (no
+   `CIStatusProvider` constructed), or when no SCM adapter is configured (no `SCMAdapter`
+   constructed).
 2. For each entry in `pending_reactions` with kind `ci`:
    a. Remove the entry from the map (prevents reprocessing within the same tick).
-   b. Determine the ref (SHA preferred, branch as fallback) and apply fingerprint deduplication
-      (Section 11A.5). Entries already dispatched for this exact ref are dropped for this tick.
-   c. Call `CIStatusProvider.FetchCIStatus` with the ref.
-   d. On fetch error: re-enqueue the entry with an exponential backoff delay derived from the
+   b. Check the watch window (Section 11A.9): past `watch_window_ms` from the last recorded head,
+      drop the entry and its attempt counter.
+   c. Resolve the pull request's current head via `SCMAdapter.GetMergeability`, passing the pull
+      request number, owner, and repo carried in the entry's data. This runs on every due pass; the
+      ref is never a value captured once at worker exit.
+   d. On an `ErrSCMNotFound` failure: drop the entry and its attempt counter; the watch ends.
+   e. On any other failure: re-enqueue the entry with an exponential backoff delay derived from the
       poll interval and the pending attempt count; continue.
-   e. On `passing`: clear `reaction_attempts` for the issue and kind, and delete the fingerprint
-      row.
-   f. On `pending`: re-enqueue the entry with the same exponential backoff as the fetch-error
-      path.
-   g. On `failing`: handle CI failure (see Section 11A.6).
+   f. If the pull request is merged: drop the entry and its attempt counter; the watch ends. If the
+      pull request is closed without merging: same outcome. The merged check runs before the closed
+      check, so a provider whose closed state subsumes merging still ends the watch through the
+      merged branch.
+   g. If the resolved head is empty: re-enqueue with backoff, recording no head and spending no
+      attempt.
+   h. Apply fingerprint deduplication against the resolved head (Section 11A.5). A differing stored
+      head opens a new epoch (Section 11A.9) before the status read. Entries already dispatched for
+      the resolved head are dropped for this tick with backoff, skipping the status read.
+   i. Call `CIStatusProvider.FetchCIStatus` with the resolved head.
+   j. On fetch error: re-enqueue the entry with an exponential backoff delay derived from the poll
+      interval and the pending attempt count; continue.
+   k. On `passing`: clear `reaction_attempts` for the issue and kind and keep watching, re-enqueuing
+      the entry rather than retiring it, so a later commit on the same pull request is still
+      observed.
+   l. On `pending`: re-enqueue the entry with the same exponential backoff as the fetch-error path.
+   m. On `failing`: handle CI failure (see Section 11A.6).
+
+Every branch that does not end the watch re-enqueues the entry.
 
 ### 11A.5 Fingerprint and deduplication
 
-Before calling `FetchCIStatus`, the reconcile pass deduplicates against the same ref. The
-fingerprint value is the ref itself (`CIReactionData.SHA`, falling back to `CIReactionData.Branch`),
-the identical string passed to the status fetch. Unlike the merge-conflict (Section 11E.4) and
-review (Section 11B.7) fingerprints, which each hash their input with SHA-256, the CI fingerprint
-is stored as the raw ref string with no hashing.
+The stored fingerprint value is the pull request head this process last evaluated, read live from
+`PRMergeStatus.HeadSHA` on the same pass, not a ref captured once at worker exit. Unlike the
+merge-conflict (Section 11E.4) and review (Section 11B.7) fingerprints, which each hash their input
+with SHA-256, the CI fingerprint is stored as the raw head string with no hashing.
 
-The pass upserts the ref into `reaction_fingerprints` (kind `ci`) and reads the row back. The
-upsert resets `dispatched` to false whenever the stored fingerprint differs from the ref being
-upserted, so a new SHA (or a branch ref that has moved to a new SHA) always re-arms the entry for a
-fresh CI-fix dispatch. When the read-back fingerprint matches the current ref and `dispatched` is
-already true, the entry is dropped for this tick rather than re-enqueued: CI status is not polled
-again for that ref until a later worker exit or startup recovery creates a new pending entry.
+The pass reads the `reaction_fingerprints` row (kind `ci`) before writing it, because the pass
+needs the previous head to detect a change: an upsert-then-read ordering would always read back the
+value just written, and no head change would ever be detected. A stored value that differs from the
+resolved head opens a new epoch (Section 11A.9): the pass applies the epoch transition, then
+upserts the resolved head, which resets `dispatched` to false and re-arms the entry for a fresh
+CI-fix dispatch. When the stored head equals the resolved head and `dispatched` is already true, the
+entry is dropped for this tick with backoff rather than proceeding to a status read: CI status is
+not polled again for that head until a later worker exit, startup recovery, or a further head change
+creates or re-arms a pending entry.
+
 Fingerprint errors are logged and treated as non-fatal, but the two directions differ. A failed
-upsert does not disable dedup: the read-back still runs, so a stored row matching the current ref
-and already marked dispatched still drops the entry. Only a failed read-back skips dedup entirely,
-and the pass then proceeds to `FetchCIStatus` rather than dropping the entry.
+upsert is best-effort: the pass proceeds, and the next pass re-detects the same head change and
+re-applies the transition, which is idempotent for one head. A failed read suppresses epoch
+detection for that pass rather than fabricate a change: treating a read failure as a head change
+would reset the retry budget on a database error.
 
 The `dispatched` flag is not set anywhere in this reconcile pass. `handleCIFailure` (Section 11A.6)
 schedules the CI-fix continuation through the shared retry machinery with `ReactionKind` set to
 `ci`; the flag is marked only once that continuation retry actually fires and dispatches, in the
 shared retry-dispatch path, not in the CI reconcile pass itself.
 
-The fingerprint row is deleted, not merely left stale, when the episode closes: on a `passing`
-result (Section 11A.4) and during escalation (Section 11A.7).
+The fingerprint row is never deleted for kind `ci`. It is the epoch record: neither a `passing`
+result (Section 11A.4) nor escalation (Section 11A.7) removes it, because doing so would erase the
+head this process last evaluated and make the next pass read a head change that did not happen.
 
 ### 11A.6 CI failure handling
 
-When CI status is `failing`, the pass first consults the retry slot (Section 7.5). A non-nil
-incumbent means the pass defers: it re-enqueues the pending entry unchanged except for a
-refreshed `CreatedAt`, and none of the steps below run for this tick — no run-history row is
-appended, no counter increments, and escalation is not evaluated.
+The failing verdict describes the head resolved on this same pass (Section 11A.4), never a value
+captured at worker exit. When CI status is `failing`, the pass first consults the retry slot
+(Section 7.5). A non-nil incumbent means the pass defers: it re-enqueues the pending entry with
+backoff, and none of the steps below run for this tick: no run-history row is appended, no counter
+increments, and escalation is not evaluated. The retry-slot deferral and the fingerprint dedup
+(Section 11A.5) both run before any attempt-counter increment: the fingerprint dedup on the current
+head's prior pass, and the retry-slot deferral on this pass, so a continuation already queued for
+the issue cannot spend a second attempt.
 
 On a free slot:
 
@@ -205,13 +232,17 @@ When `reaction_attempts[issue_id:ci]` exceeds `ci_feedback.max_retries`:
   NOT import an adapter package. The comment call runs in a detached goroutine with a 30-second
   timeout.
 
-After escalation:
+Escalation is a per-epoch soft stop, not a terminal action. The configured action applies at most
+once per recorded head: a further pass over an already-escalated head neither re-applies the action
+nor dispatches. After escalation:
 
 - Cancel any pending retry for the issue.
 - Delete the persisted retry entry from SQLite.
 - Release the claim (`delete claimed[issue_id]`).
-- Clear all `reaction_attempts` and `pending_reactions` entries for the issue.
-- Delete the reaction fingerprint row for kind `ci`.
+- The pending entry, its `reaction_attempts` counter, and its reaction fingerprint row for kind `ci`
+  all survive. The counter stays over budget so no further continuation dispatches until a new
+  epoch resets it (Section 11A.9), and the fingerprint row is the epoch record. The entry
+  re-enqueues with backoff rather than being dropped, so the watch continues past exhaustion.
 
 Escalation failures are logged and counted (`sortie_ci_escalations_total{action="error"}`) but do
 not block claim release.
@@ -259,4 +290,45 @@ excerpt is a real job trace, fetched under a byte cap and sanitized, which is th
 has no equivalent for. The trace route ignores a range request, so a trace exceeding the cap yields
 the tail of the fetched prefix rather than the true tail, and an entry that is an externally
 reported status rather than a pipeline job has no trace at all, leaving the excerpt empty.
+
+### 11A.9 The head watch and the feedback epoch
+
+The pull request's current head is the reaction's subject. Every due pass resolves the head live
+through `SCMAdapter.GetMergeability` (Section 11A.4); there is no ref captured once and frozen for
+the entry's lifetime.
+
+**Age and the watch window.** The entry's age is measured from `HeadRecordedAt`, the UTC time this
+process last recorded a head, falling back to the entry's creation time before any head has been
+recorded. `reactions.ci_failure.watch_window_ms` bounds that age (default `86400000`, twenty-four
+hours; `0` removes the clock bound). Past the window, the entry and its attempt counter are dropped
+and a warning is logged; the fingerprint row is left intact. The watch also ends, whatever the clock
+says, on merge, on close, on a missing pull request (`ErrSCMNotFound`), and when the tracker issue
+reaches a `tracker.terminal_states` state.
+
+**The epoch.** An epoch is the span over which the pull request's head is one commit. The
+`reaction_fingerprints` row for kind `ci` is the durable epoch record: it holds the head this
+process last evaluated, read before it is written on every pass (Section 11A.5). A stored value that
+differs from the freshly resolved head closes the current epoch and opens a new one. The reaction
+re-arms on the transition: the fingerprint upsert clears `dispatched`, so a failing verdict on the
+new head is not deduplicated against the old one.
+
+**Attribution.** On an epoch transition the orchestrator classifies the change as positively not its
+own work, or as unknown; there is no third answer, and in particular no answer that names a person.
+The change is `not_orchestrator` only when no worker session for the issue ran between the recorded
+head and the read: no live entry in the in-memory running, retry, or claimed state, and no
+`run_history` row completed inside the interval (excluding `ci_failed` rows, which record a verdict
+this reaction observed rather than a worker session). Every failure path, including the first
+observation and any observation immediately after a restart, answers unknown. The backoff counter
+(`PendingAttempts`) and the per-head escalation flag (`EscalatedForCurrentHead`) reset
+unconditionally on every transition; the `reaction_attempts` retry budget resets only when the
+answer is `not_orchestrator`. A transition never dispatches by itself: a continuation follows only
+if the pass's subsequent status read then finds a failing verdict.
+
+**Identity in seeding and recovery.** The reaction's data (`CIReactionData`) carries the pull request
+number, owner, and repository alongside the branch and the head at worker exit, because resolving a
+head requires knowing which pull request to ask about. Worker-exit seeding and startup recovery both
+require this identity in full; a workspace whose SCM metadata names a branch but no pull request
+gets no CI watch. A recovered entry leaves `HeadRecordedAt` zero, so the first pass after a restart
+records a baseline and classifies it unknown rather than resetting a counter against a boundary this
+process never observed.
 

--- a/docs/architecture/14-auto-merge-reaction-contract.md
+++ b/docs/architecture/14-auto-merge-reaction-contract.md
@@ -49,8 +49,10 @@ The auto-merge reaction introduces the following domain types:
   `CIConclusion`, `Draft` (bool, separate from `Mergeability`), `Mergeability`
   (`MergeabilityState`), `HeadSHA`, `BranchName`, `BaseBranch` (the PR's target branch, added for
   merge-conflict detection, §11E.1), `Merged` (bool reporting whether the pull request has
-  merged, added for the post-merge closure reaction, ADR-0017), and `MergeCommitSHA` (the merge
-  commit identifier, set only when `Merged` is true, added by the same reaction). `ReviewDecision`
+  merged, added for the post-merge closure reaction, ADR-0017), `MergeCommitSHA` (the merge
+  commit identifier, set only when `Merged` is true, added by the same reaction), and `Closed`
+  (bool reporting whether the provider considers the pull request no longer open, primarily read
+  by the CI reaction, §11A.9). `ReviewDecision`
   and `CIConclusion` are unset by `GetMergeability`; callers obtain those from dedicated reads.
 - `MergeResult`: struct carrying `SHA` (merge commit SHA), `Merged` (bool reporting whether the
   merge completed), and `Message` (provider-supplied status text). The already-merged case is

--- a/docs/architecture/16-merge-conflict-reaction-contract.md
+++ b/docs/architecture/16-merge-conflict-reaction-contract.md
@@ -17,11 +17,12 @@ There is the same YAML-versus-runtime asymmetry §11C.4 documents for auto-merge
 ### 11E.1 SCMAdapter interface
 
 Conflict detection reuses the existing `GetMergeability` read. No new method is added to the
-`SCMAdapter` interface. The interface's `PRMergeStatus` return type gains one additive field:
+`SCMAdapter` interface. The interface's `PRMergeStatus` return type carries these additive fields:
 
 ```go
-// PRMergeStatus addition:
+// PRMergeStatus additions:
 BaseBranch string
+Closed     bool
 ```
 
 `BaseBranch` carries the PR target (base) branch name, for example `"main"` or `"develop"`. Every
@@ -30,6 +31,11 @@ no additional request cost: the GitHub and Gitea adapters from that object's bas
 adapter from the merge request's target branch. Other callers of `GetMergeability` (the auto-merge
 reconcile pass) ignore the new field. Platform-specific field names do not leave the adapter
 package; the orchestrator reads only the domain field.
+
+`Closed` reports whether the provider considers the pull request no longer open, populated from the
+same pull-request object at no additional request cost. A provider whose closed state subsumes
+merging reports both, so a caller that wants the closed-without-merge condition tests
+`Closed && !Merged` rather than `Closed` alone. The CI reaction (§11A.9) is the primary reader.
 
 ### 11E.2 Detection rule
 
@@ -219,6 +225,8 @@ Per-issue `merge-conflict` reaction lifecycle (the `issue_id:merge-conflict` slo
 | pending | Reconcile tick, `Mergeability != dirty` | pending | Delete fingerprint; delete per-episode counter; re-enqueue. Episode closes. |
 | pending | Reconcile tick, `Mergeability == dirty`, precondition guard fails (empty HeadSHA or BaseBranch) | pending | Re-enqueue at `now + poll_interval`; do not increment counter. |
 | pending | Reconcile tick, `Mergeability == dirty`, fingerprint dispatched for this head | pending | Re-enqueue at `now + poll_interval`; do not increment counter. |
+| pending | Reconcile tick, `Mergeability == dirty`, new head this reaction has not dispatched for, attribution `not_orchestrator` | pending | Delete the per-episode counter before incrementing, so the reported attempt count is `1` rather than continuing to climb across successive conflicting heads; record `HeadRecordedAt`. |
+| pending | Reconcile tick, `Mergeability == dirty`, new head this reaction has not dispatched for, attribution `unknown` | pending | Leave the per-episode counter at its prior value; record `HeadRecordedAt`. |
 | pending | Reconcile tick, `Mergeability == dirty`, new head, `attempts <= MaxRetries` | dispatched | Increment per-episode counter; schedule continuation; mark dispatched; count dispatched. |
 | pending | Reconcile tick, `Mergeability == dirty`, new head, `attempts > MaxRetries` | escalated | Increment per-episode counter; apply escalation; delete slot, fingerprint, and per-episode counter. MUST NOT release the claim or clear sibling slots (§11E.5). |
 | pending | Issue reaches terminal state (tracker reconcile) | (none) | Drop the `merge-conflict` pending entry and its per-episode counter, cancel and delete the issue's retry, and release the claim; `reaction_fingerprints` is left intact. |

--- a/docs/architecture/24-persistence-schema.md
+++ b/docs/architecture/24-persistence-schema.md
@@ -140,6 +140,13 @@ comment set last acted on, the git ref last checked, a journal high-water mark, 
 identifier, whichever value identifies "the same observation" for that kind. The column is opaque
 text and this schema attaches no meaning to it beyond equality.
 
+The `ci` row holds the pull request head this process last evaluated, not a ref captured once at
+worker exit; `updated_at` is refreshed on every evaluation, including one that finds the head
+unchanged, so it names the last evaluation rather than a first-seen timestamp for this kind. A
+differing stored head is this kind's head-change detection, and the row is never deleted: neither a
+passing result nor an escalation removes it, because it is the durable half of the feedback epoch
+record (§11A.9).
+
 `dispatched` likewise means "the action this kind performs has been performed for this
 fingerprint", and the row's lifecycle after that point is the owning kind's to define. Most kinds
 treat the row as spent. The merge-completion kind (§11G.4) instead retains a dispatched row rather

--- a/docs/decisions/0024-start-a-new-feedback-epoch-when-the-head-moves.md
+++ b/docs/decisions/0024-start-a-new-feedback-epoch-when-the-head-moves.md
@@ -100,10 +100,16 @@ The orchestrator classifies a head change as its own work or as unknown. There i
 and in particular there is no answer that names a person.
 
 The recorded head is a validity token. When the current head matches it, nothing changed. When it
-does not, the record is spent and yields no attribution on its own. A head change is positively
-**not** the orchestrator's own work when no worker session for that issue ran between the recording
-and the read, which run history answers without depending on the record staying synchronized. Every
-other head change is unknown.
+does not, the record is spent and yields no attribution on its own.
+
+A head change is positively **not** the orchestrator's own work when no worker session for that
+issue ran between the recording and the read. Two sources answer that together, and neither answers
+it alone. The orchestrator holds its live sessions in memory, so it knows what is running now.
+History records an attempt once that attempt completes, so it knows what ran and finished, and the
+rows the CI reaction writes for its own observations describe a verdict rather than a session and
+are excluded from that count. A live session has no completed row yet, so the answer while a session
+is running is unknown, and the first answer after a restart is unknown for the same reason: the
+process has no boundary of its own to measure from. Every other head change is unknown.
 
 Unknown takes the conservative branch on each axis, and the two axes differ. It re-arms, because a
 changed head genuinely voids prior conclusions and a needless re-arm costs one poll. It does not
@@ -179,9 +185,9 @@ completion watch asks a question whose answer a new commit cannot change.
 **Attribute each head change to a person.** It is the obvious reading of "someone else pushed this",
 and it fails in a way that is worse than being unavailable, because the failure is a confident false
 statement to an operator. The stored head desynchronizes whenever two updates run concurrently, and
-the divergence is then indistinguishable from a person's edit. Deriving the answer from the commits
-and from run history on every pass, and answering unknown rather than guessing, costs one comparison
-and cannot produce that failure.
+the divergence is then indistinguishable from a person's edit. Deriving the answer on every pass from
+what the orchestrator knows about its own sessions, and answering unknown rather than guessing,
+costs one comparison and cannot produce that failure.
 
 **Move the tracker issue back to its pre-handoff state.** It re-derives everything with no new
 mechanism, since the ordinary dispatch path would then run. It is rejected because it is the most

--- a/docs/workflow-reference.md
+++ b/docs/workflow-reference.md
@@ -818,6 +818,9 @@ ci_feedback:
 | `escalation`       | string  | No                    | `label`        | Future dispatches | Action when `max_retries` is exceeded. Valid values: `"label"` (add a label to the issue), `"comment"` (post a comment on the issue). |
 | `escalation_label` | string  | No                    | `needs-human`  | Future dispatches | Label applied to the issue when `escalation` is `"label"`.                                                            |
 
+The deprecated `ci_feedback` section exposes no `watch_window_ms` key. A deployment that still uses
+this section receives the default value described in Section 2.10.
+
 **Activation pattern:** CI feedback has no `enabled` flag. The feature is active when
 `ci_feedback.kind` is present and non-empty. Omit the entire `ci_feedback` section to
 disable the feature:
@@ -921,9 +924,10 @@ under `reactions` identifies a reaction kind.
 **Reload behavior:** every field of every reaction kind is read once when the orchestrator
 is constructed and is not rebuilt on a `WORKFLOW.md` reload, so a change takes effect only
 on the next restart. `reactions.ci_failure` is the single exception: the orchestrator folds
-it into the `ci_feedback` shape and re-reads `max_retries`, `escalation`, and
-`escalation_label` from the reloaded config on each tick. Its `max_log_lines` still requires
-a restart, because the CI provider is constructed once at process start.
+it into the `ci_feedback` shape and re-reads `max_retries`, `escalation`,
+`escalation_label`, and `watch_window_ms` from the reloaded config on each tick. Its
+`max_log_lines` still requires a restart, because the CI provider is constructed once at
+process start.
 
 **Escalation recurrence:** `escalation: label` is idempotent (re-applying a
 present label is a no-op); `escalation: comment` posts a new comment each time
@@ -964,14 +968,15 @@ SCM reaction in one workflow MUST name the same provider.
 #### Reaction kind: `ci_failure`
 
 Equivalent to the deprecated `ci_feedback` section. Configures the CI failure feedback
-loop. The orchestrator polls CI status for Sortie-created branches and dispatches
-continuation turns when CI fails.
+loop. The orchestrator resolves the pull request's current head on each pass and polls CI
+status for that head, dispatching continuation turns when CI fails on it.
 
 Additional fields (via Extra):
 
-| Field           | Type    | Default | Dynamic Reload   | Description                                                           |
-| --------------- | ------- | ------- | ---------------- | --------------------------------------------------------------------- |
-| `max_log_lines` | integer | `50`    | Requires restart | Maximum CI log tail lines for prompt injection. `0` disables. Must be non-negative. |
+| Field             | Type    | Default      | Dynamic Reload | Description                                                                                                             |
+| ----------------- | ------- | ------------ | -------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `max_log_lines`   | integer | `50`         | Requires restart | Maximum CI log tail lines for prompt injection. `0` disables. Must be non-negative.                                   |
+| `watch_window_ms` | integer | `86400000`   | Every tick        | Bounds a pending entry's age, measured from the last recorded head. `0` removes the clock bound. Must be non-negative. |
 
 Example:
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -669,6 +669,12 @@ func buildAgentConfig(m map[string]any) (AgentConfig, error) {
 	}, nil
 }
 
+// ciWatchWindowDefaultMS is the default value of
+// CIFeedbackConfig.WatchWindowMS: twenty-four hours, the smallest window
+// covering a reviewer who returns the next working day and pushes a
+// fixup.
+const ciWatchWindowDefaultMS = 86400000
+
 func buildCIFeedbackConfig(m map[string]any) (CIFeedbackConfig, error) {
 	kind := extractString(m, "kind")
 	if kind == "" {
@@ -719,12 +725,15 @@ func buildCIFeedbackConfig(m map[string]any) (CIFeedbackConfig, error) {
 		escalationLabel = "needs-human"
 	}
 
+	// The deprecated ci_feedback section exposes no watch_window_ms key,
+	// so it always resolves to the default.
 	return CIFeedbackConfig{
 		Kind:            kind,
 		MaxRetries:      maxRetries,
 		MaxLogLines:     maxLogLines,
 		Escalation:      escalation,
 		EscalationLabel: escalationLabel,
+		WatchWindowMS:   ciWatchWindowDefaultMS,
 	}, nil
 }
 
@@ -756,12 +765,31 @@ func populateCIFeedbackFromReactions(rc ReactionConfig) (CIFeedbackConfig, error
 		}
 	}
 
+	watchWindowMS := ciWatchWindowDefaultMS
+	if raw, ok := rc.Extra["watch_window_ms"]; ok && raw != nil {
+		parsed, err := coerceInt(raw)
+		if err != nil {
+			return CIFeedbackConfig{}, &ConfigError{
+				Field:   "reactions.ci_failure.watch_window_ms",
+				Message: fmt.Sprintf("invalid integer value: %v", raw),
+			}
+		}
+		watchWindowMS = parsed
+	}
+	if watchWindowMS < 0 {
+		return CIFeedbackConfig{}, &ConfigError{
+			Field:   "reactions.ci_failure.watch_window_ms",
+			Message: "must be non-negative",
+		}
+	}
+
 	return CIFeedbackConfig{
 		Kind:            rc.Provider,
 		MaxRetries:      rc.MaxRetries,
 		MaxLogLines:     maxLogLines,
 		Escalation:      rc.Escalation,
 		EscalationLabel: rc.EscalationLabel,
+		WatchWindowMS:   watchWindowMS,
 	}, nil
 }
 
@@ -1226,6 +1254,14 @@ type CIFeedbackConfig struct {
 	// EscalationLabel is the label applied when escalation is "label".
 	// Default "needs-human".
 	EscalationLabel string
+
+	// WatchWindowMS bounds how long a pending CI reaction entry is kept
+	// once its subject has settled. The age is measured from the last
+	// recorded head rather than from the entry's creation, so an
+	// actively worked pull request stays watched and only silence ages
+	// it out. Default 86400000 (twenty-four hours). Zero removes the
+	// clock bound. Must be non-negative.
+	WatchWindowMS int
 }
 
 // ReactionConfig holds per-kind configuration for a single reaction type.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1778,6 +1778,7 @@ func TestNewServiceConfig_CIFeedback(t *testing.T) {
 		assertIntEqual(t, "CIFeedback.MaxRetries", 2, cfg.CIFeedback.MaxRetries)
 		assertStringEqual(t, "CIFeedback.Escalation", "label", cfg.CIFeedback.Escalation)
 		assertStringEqual(t, "CIFeedback.EscalationLabel", "needs-human", cfg.CIFeedback.EscalationLabel)
+		assertIntEqual(t, "CIFeedback.WatchWindowMS", ciWatchWindowDefaultMS, cfg.CIFeedback.WatchWindowMS)
 	})
 
 	t.Run("ExplicitMaxRetries", func(t *testing.T) {
@@ -2042,6 +2043,7 @@ func TestPopulateCIFeedbackFromReactions(t *testing.T) {
 				MaxLogLines:     50,
 				Escalation:      "label",
 				EscalationLabel: "needs-human",
+				WatchWindowMS:   ciWatchWindowDefaultMS,
 			},
 		},
 		{
@@ -2051,8 +2053,9 @@ func TestPopulateCIFeedbackFromReactions(t *testing.T) {
 				Extra:    nil,
 			},
 			want: CIFeedbackConfig{
-				Kind:        "github-actions",
-				MaxLogLines: 50,
+				Kind:          "github-actions",
+				MaxLogLines:   50,
+				WatchWindowMS: ciWatchWindowDefaultMS,
 			},
 		},
 		{
@@ -2062,8 +2065,9 @@ func TestPopulateCIFeedbackFromReactions(t *testing.T) {
 				Extra:    map[string]any{"max_log_lines": 100},
 			},
 			want: CIFeedbackConfig{
-				Kind:        "github-actions",
-				MaxLogLines: 100,
+				Kind:          "github-actions",
+				MaxLogLines:   100,
+				WatchWindowMS: ciWatchWindowDefaultMS,
 			},
 		},
 		{
@@ -2073,8 +2077,9 @@ func TestPopulateCIFeedbackFromReactions(t *testing.T) {
 				Extra:    map[string]any{"max_log_lines": float64(200)},
 			},
 			want: CIFeedbackConfig{
-				Kind:        "github",
-				MaxLogLines: 200,
+				Kind:          "github",
+				MaxLogLines:   200,
+				WatchWindowMS: ciWatchWindowDefaultMS,
 			},
 		},
 		{
@@ -2101,6 +2106,48 @@ func TestPopulateCIFeedbackFromReactions(t *testing.T) {
 			want: CIFeedbackConfig{},
 		},
 		{
+			name: "WatchWindowMSFromExtra",
+			rc: ReactionConfig{
+				Provider: "github-actions",
+				Extra:    map[string]any{"watch_window_ms": 3600000},
+			},
+			want: CIFeedbackConfig{
+				Kind:          "github-actions",
+				MaxLogLines:   50,
+				WatchWindowMS: 3600000,
+			},
+		},
+		{
+			name: "WatchWindowMSExplicitZeroDisablesBound",
+			rc: ReactionConfig{
+				Provider: "github-actions",
+				Extra:    map[string]any{"watch_window_ms": 0},
+			},
+			want: CIFeedbackConfig{
+				Kind:          "github-actions",
+				MaxLogLines:   50,
+				WatchWindowMS: 0,
+			},
+		},
+		{
+			name: "WatchWindowMSNegative",
+			rc: ReactionConfig{
+				Provider: "github-actions",
+				Extra:    map[string]any{"watch_window_ms": -1},
+			},
+			wantErr:   true,
+			wantField: "reactions.ci_failure.watch_window_ms",
+		},
+		{
+			name: "WatchWindowMSNonInteger",
+			rc: ReactionConfig{
+				Provider: "github-actions",
+				Extra:    map[string]any{"watch_window_ms": "abc"},
+			},
+			wantErr:   true,
+			wantField: "reactions.ci_failure.watch_window_ms",
+		},
+		{
 			name: "EscalationAndLabelPassThrough",
 			rc: ReactionConfig{
 				Provider:        "circle-ci",
@@ -2114,6 +2161,7 @@ func TestPopulateCIFeedbackFromReactions(t *testing.T) {
 				MaxLogLines:     50,
 				Escalation:      "comment",
 				EscalationLabel: "blocked",
+				WatchWindowMS:   ciWatchWindowDefaultMS,
 			},
 		},
 	}

--- a/internal/domain/scm.go
+++ b/internal/domain/scm.go
@@ -103,6 +103,14 @@ type PRMergeStatus struct {
 	// MergeCommitSHA is the merge commit identifier reported by the
 	// provider. Set only when Merged is true.
 	MergeCommitSHA string
+
+	// Closed reports whether the provider considers the pull request
+	// no longer open. It is true for a pull request closed without
+	// merging and, on providers whose closed state subsumes merging,
+	// for a merged one as well, so a caller that wants the
+	// closed-without-merge condition tests Closed && !Merged rather
+	// than Closed alone.
+	Closed bool
 }
 
 // MergeResult carries the outcome of a successful merge call.

--- a/internal/domain/workspace.go
+++ b/internal/domain/workspace.go
@@ -10,13 +10,12 @@ type SCMMetadata struct {
 	// Branch is the branch name (e.g. "feature/PROJ-42").
 	Branch string `json:"branch"`
 
-	// SHA is the commit SHA at push time. When present, the
-	// orchestrator passes this to [CIStatusProvider.FetchCIStatus]
-	// instead of the branch name for deterministic results.
+	// SHA is the commit SHA at push time, carried for reaction seeding
+	// and observability rather than as a polled ref.
 	SHA string `json:"sha,omitempty"`
 
-	// PushedAt is an ISO-8601 timestamp of the push. Used by the
-	// orchestrator to skip CI checks for stale pushes.
+	// PushedAt is an ISO-8601 timestamp of the push. Startup recovery
+	// uses it as the activity timestamp for the freshness cutoff.
 	PushedAt string `json:"pushed_at,omitempty"`
 
 	// PRNumber is the pull request number associated with this branch.

--- a/internal/orchestrator/ci_reconcile.go
+++ b/internal/orchestrator/ci_reconcile.go
@@ -177,16 +177,30 @@ func reconcileCIStatus(state *State, params ReconcileParams, log *slog.Logger, c
 		}
 
 		if storedHead != status.HeadSHA {
+			// The durable head advances before the runtime boundary does.
+			// The transition restarts the watch clock and re-arms the
+			// once-per-epoch escalation, so applying it against a record
+			// that did not advance would repeat both on every later pass:
+			// the age basis would never grow old enough to elapse, and the
+			// escalation would fire once per pass instead of once per
+			// epoch. Deferring costs one poll and keeps the entry bounded.
+			if upsertErr := params.Store.UpsertReactionFingerprint(ctx, pending.IssueID, ReactionKindCI, status.HeadSHA); upsertErr != nil {
+				pending.PendingAttempts++
+				delay := computeCIPendingDelay(base, pending.PendingAttempts)
+				pending.PendingRetryAt = now.Add(delay)
+				entryLog.Warn("failed to upsert reaction fingerprint, deferring the epoch transition",
+					slog.Any("error", upsertErr),
+					slog.Int("pending_attempts", pending.PendingAttempts),
+					slog.Int64("retry_after_ms", int64(delay/time.Millisecond)),
+				)
+				state.PendingReactions[key] = pending
+				continue
+			}
 			// The epoch transition already clears dispatched through the
 			// fingerprint upsert; the status read below proceeds
 			// unconditionally on this branch, so the local dispatched
 			// value needs no update here.
 			applyCIEpochTransition(state, params, pending, rkey, storedHead, status.HeadSHA, now, ctx, entryLog)
-			if upsertErr := params.Store.UpsertReactionFingerprint(ctx, pending.IssueID, ReactionKindCI, status.HeadSHA); upsertErr != nil {
-				entryLog.Warn("failed to upsert reaction fingerprint",
-					slog.Any("error", upsertErr),
-				)
-			}
 		} else if dispatched {
 			pending.PendingAttempts++
 			delay := computeCIPendingDelay(base, pending.PendingAttempts)

--- a/internal/orchestrator/ci_reconcile.go
+++ b/internal/orchestrator/ci_reconcile.go
@@ -2,6 +2,7 @@ package orchestrator
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -19,10 +20,6 @@ const ciPendingBackoffBaseDefault = 10 * time.Second
 
 // ciPendingBackoffCap is the maximum interval between CI status checks.
 const ciPendingBackoffCap = 5 * time.Minute
-
-// ciPendingDefaultTTL is the default lifetime of a PendingReaction entry.
-// Entries older than this are dropped on the next reconcile tick.
-const ciPendingDefaultTTL = 30 * time.Minute
 
 // computeCIPendingDelay returns the backoff delay for a CI pending re-check
 // at the given attempt count. Attempt 0 returns zero (immediate). Each
@@ -46,15 +43,20 @@ func computeCIPendingDelay(base time.Duration, attempts int) time.Duration {
 	return delay
 }
 
-// reconcileCIStatus polls CI status for each CI-kind entry in
-// state.PendingReactions. Called from ReconcileRunningIssues after
-// reconcileTrackerState. Skipped entirely when params.CIProvider is nil.
+// reconcileCIStatus resolves the pull request's current head for each
+// CI-kind entry in state.PendingReactions and polls CI status for that
+// head. Called from ReconcileRunningIssues after reconcileTrackerState.
+// Skipped entirely when params.CIProvider or params.SCMAdapter is nil.
 //
 // Entries that are not yet due (PendingRetryAt in the future) are
 // re-enqueued without making an API call, applying exponential backoff.
-// Entries older than the configured TTL are dropped and a warning is logged.
+// An entry's age is measured from the last head this process recorded,
+// falling back to the entry's creation time before any head is recorded;
+// past params.CIWatchWindow the entry and its attempt counter are dropped
+// and a warning is logged. A zero or negative CIWatchWindow disables the
+// bound.
 func reconcileCIStatus(state *State, params ReconcileParams, log *slog.Logger, ctx context.Context, metrics domain.Metrics) {
-	if params.CIProvider == nil {
+	if params.CIProvider == nil || params.SCMAdapter == nil {
 		return
 	}
 
@@ -63,7 +65,6 @@ func reconcileCIStatus(state *State, params ReconcileParams, log *slog.Logger, c
 		now = params.NowFunc().UTC()
 	}
 
-	ttl := params.CIPendingTTL
 	base := time.Duration(state.PollIntervalMS) * time.Millisecond
 
 	for key, pending := range state.PendingReactions {
@@ -82,12 +83,17 @@ func reconcileCIStatus(state *State, params ReconcileParams, log *slog.Logger, c
 		}
 
 		entryLog := logging.WithIssue(log, pending.IssueID, pending.Identifier)
+		rkey := ReactionKey(pending.IssueID, ReactionKindCI)
 
-		if ttl > 0 && now.Sub(pending.CreatedAt) > ttl {
-			delete(state.ReactionAttempts, ReactionKey(pending.IssueID, ReactionKindCI))
-			entryLog.Warn("ci pending entry exceeded ttl, dropping",
-				slog.Int64("ttl_ms", int64(ttl/time.Millisecond)),
-				slog.Int64("age_ms", int64(now.Sub(pending.CreatedAt)/time.Millisecond)),
+		ageBasis := pending.CreatedAt
+		if !pending.HeadRecordedAt.IsZero() {
+			ageBasis = pending.HeadRecordedAt
+		}
+		if params.CIWatchWindow > 0 && now.Sub(ageBasis) > params.CIWatchWindow {
+			delete(state.ReactionAttempts, rkey)
+			entryLog.Warn("ci watch window elapsed, dropping",
+				slog.Int64("window_ms", int64(params.CIWatchWindow/time.Millisecond)),
+				slog.Int64("age_ms", int64(now.Sub(ageBasis)/time.Millisecond)),
 			)
 			continue
 		}
@@ -97,38 +103,108 @@ func reconcileCIStatus(state *State, params ReconcileParams, log *slog.Logger, c
 			continue
 		}
 
-		ref := ciData.SHA
-		if ref == "" {
-			ref = ciData.Branch
+		status, mergeErr := params.SCMAdapter.GetMergeability(ctx, ciData.PRNumber, ciData.Owner, ciData.Repo)
+		if mergeErr != nil {
+			var scmErr *domain.SCMError
+			if errors.As(mergeErr, &scmErr) && scmErr.Kind == domain.ErrSCMNotFound {
+				delete(state.ReactionAttempts, rkey)
+				entryLog.Warn("ci watch pull request not found, dropping",
+					slog.Int("pr_number", ciData.PRNumber),
+				)
+				continue
+			}
+			pending.PendingAttempts++
+			delay := computeCIPendingDelay(base, pending.PendingAttempts)
+			pending.PendingRetryAt = now.Add(delay)
+			entryLog.Warn("ci mergeability fetch failed, retrying with backoff",
+				slog.Any("error", mergeErr),
+				slog.Int("pending_attempts", pending.PendingAttempts),
+				slog.Int64("retry_after_ms", int64(delay/time.Millisecond)),
+			)
+			state.PendingReactions[key] = pending
+			continue
 		}
 
-		// Fingerprint dedup: upsert the fingerprint row (resets dispatched
-		// when the ref changes) and skip entries already dispatched for this
-		// exact ref. Errors are non-fatal — best-effort dedup.
-		if err := params.Store.UpsertReactionFingerprint(ctx, pending.IssueID, ReactionKindCI, ref); err != nil {
-			entryLog.Warn("failed to upsert reaction fingerprint",
-				slog.Any("error", err),
+		// The merged check runs before the closed check so a provider
+		// whose closed state subsumes merging still ends the watch
+		// through the merged branch and logs the merge rather than a
+		// close.
+		if status.Merged {
+			delete(state.ReactionAttempts, rkey)
+			entryLog.Info("ci watch ended: pull request merged",
+				slog.String("head_sha", status.HeadSHA),
 			)
+			continue
 		}
-		storedFP, dispatched, fpErr := params.Store.GetReactionFingerprint(ctx, pending.IssueID, ReactionKindCI)
-		if fpErr != nil {
-			entryLog.Warn("failed to get reaction fingerprint, proceeding without dedup",
-				slog.Any("error", fpErr),
-			)
-		} else if storedFP == ref && dispatched {
-			entryLog.Debug("CI reaction already dispatched for this ref, skipping",
-				slog.String("ref", ref),
+		if status.Closed {
+			delete(state.ReactionAttempts, rkey)
+			entryLog.Info("ci watch ended: pull request closed without merging",
+				slog.Int("pr_number", ciData.PRNumber),
 			)
 			continue
 		}
 
-		result, err := params.CIProvider.FetchCIStatus(ctx, ref)
+		if status.HeadSHA == "" {
+			pending.PendingAttempts++
+			delay := computeCIPendingDelay(base, pending.PendingAttempts)
+			pending.PendingRetryAt = now.Add(delay)
+			entryLog.Debug("ci deferred: empty head sha",
+				slog.Int("pr_number", ciData.PRNumber),
+			)
+			state.PendingReactions[key] = pending
+			continue
+		}
+
+		// The epoch record is read before it is written, because this
+		// pass needs the previous head to detect a change; an
+		// upsert-then-read ordering would always read back the value
+		// just written and no head change would ever be detected. The
+		// durable observation helper is not used here: its timestamp
+		// survives a restart, and the attribution boundary this pass
+		// maintains (PendingReaction.HeadRecordedAt) deliberately must
+		// not.
+		storedHead, dispatched, fpErr := params.Store.GetReactionFingerprint(ctx, pending.IssueID, ReactionKindCI)
+		if fpErr != nil {
+			entryLog.Warn("failed to get ci reaction fingerprint, proceeding without epoch detection",
+				slog.Any("error", fpErr),
+			)
+			// A read failure suppresses epoch detection for this pass
+			// rather than fabricate one: treating it as a head change
+			// would reset the retry budget on a database error, which
+			// is the unsafe direction.
+			storedHead = status.HeadSHA
+			dispatched = false
+		}
+
+		if storedHead != status.HeadSHA {
+			// The epoch transition already clears dispatched through the
+			// fingerprint upsert; the status read below proceeds
+			// unconditionally on this branch, so the local dispatched
+			// value needs no update here.
+			applyCIEpochTransition(state, params, pending, rkey, storedHead, status.HeadSHA, now, ctx, entryLog)
+			if upsertErr := params.Store.UpsertReactionFingerprint(ctx, pending.IssueID, ReactionKindCI, status.HeadSHA); upsertErr != nil {
+				entryLog.Warn("failed to upsert reaction fingerprint",
+					slog.Any("error", upsertErr),
+				)
+			}
+		} else if dispatched {
+			pending.PendingAttempts++
+			delay := computeCIPendingDelay(base, pending.PendingAttempts)
+			pending.PendingRetryAt = now.Add(delay)
+			entryLog.Debug("CI reaction already dispatched for this head, skipping",
+				slog.String("head_sha", status.HeadSHA),
+			)
+			state.PendingReactions[key] = pending
+			continue
+		}
+
+		result, err := params.CIProvider.FetchCIStatus(ctx, status.HeadSHA)
 		if err != nil {
 			pending.PendingAttempts++
 			delay := computeCIPendingDelay(base, pending.PendingAttempts)
 			pending.PendingRetryAt = now.Add(delay)
 			entryLog.Warn("ci status fetch failed, retrying with backoff",
-				slog.String("ref", ref),
+				slog.String("head_sha", status.HeadSHA),
 				slog.Any("error", err),
 				slog.Int("pending_attempts", pending.PendingAttempts),
 				slog.Int64("retry_after_ms", int64(delay/time.Millisecond)),
@@ -140,19 +216,16 @@ func reconcileCIStatus(state *State, params ReconcileParams, log *slog.Logger, c
 
 		metrics.IncCIStatusChecks(string(result.Status))
 
-		rkey := ReactionKey(pending.IssueID, ReactionKindCI)
-
 		switch result.Status {
 		case domain.CIStatusPassing:
 			delete(state.ReactionAttempts, rkey)
-			if err := params.Store.DeleteReactionFingerprint(ctx, pending.IssueID, ReactionKindCI); err != nil {
-				entryLog.Warn("failed to delete reaction fingerprint on CI pass",
-					slog.Any("error", err),
-				)
-			}
-			entryLog.Info("CI passing, no action needed",
-				slog.String("ref", ref),
+			pending.PendingAttempts++
+			delay := computeCIPendingDelay(base, pending.PendingAttempts)
+			pending.PendingRetryAt = now.Add(delay)
+			entryLog.Info("CI passing on current head, continuing to watch",
+				slog.String("head_sha", status.HeadSHA),
 			)
+			state.PendingReactions[key] = pending
 
 		case domain.CIStatusPending:
 			pending.PendingAttempts++
@@ -160,7 +233,7 @@ func reconcileCIStatus(state *State, params ReconcileParams, log *slog.Logger, c
 			pending.PendingRetryAt = now.Add(delay)
 			state.PendingReactions[key] = pending
 			entryLog.Debug("CI pending, will re-check after backoff",
-				slog.String("ref", ref),
+				slog.String("head_sha", status.HeadSHA),
 				slog.Int("pending_attempts", pending.PendingAttempts),
 				slog.Int64("retry_after_ms", int64(delay/time.Millisecond)),
 			)
@@ -168,16 +241,18 @@ func reconcileCIStatus(state *State, params ReconcileParams, log *slog.Logger, c
 		case domain.CIStatusFailing:
 			if incumbent := retrySlotIncumbent(state, pending.IssueID); incumbent != nil {
 				logRetrySlotDeferral(entryLog, ReactionKindCI, incumbent)
-				pending.CreatedAt = now
+				pending.PendingAttempts++
+				delay := computeCIPendingDelay(base, pending.PendingAttempts)
+				pending.PendingRetryAt = now.Add(delay)
 				state.PendingReactions[key] = pending
 			} else {
-				handleCIFailure(state, params, pending, result, ref, entryLog, ctx, metrics)
+				handleCIFailure(state, params, pending, result, status.HeadSHA, now, base, entryLog, ctx, metrics)
 			}
 
 		default:
 			entryLog.Warn("CI status provider returned unrecognized status, re-enqueueing",
 				slog.String("status", string(result.Status)),
-				slog.String("ref", ref),
+				slog.String("head_sha", status.HeadSHA),
 			)
 			metrics.IncCIStatusChecks("error")
 			pending.PendingAttempts++
@@ -185,6 +260,48 @@ func reconcileCIStatus(state *State, params ReconcileParams, log *slog.Logger, c
 			state.PendingReactions[key] = pending
 		}
 	}
+}
+
+// applyCIEpochTransition applies the runtime consequences of a detected
+// pull request head change: it resets the backoff counter and the
+// per-head escalation flag unconditionally, resets the CI retry budget
+// only when [classifyHeadChange] positively establishes that the change
+// is not the orchestrator's own work, and records the new head as the
+// boundary for the next attribution query.
+//
+// applyCIEpochTransition never dispatches a continuation and never
+// writes to the tracker; a continuation follows only if the caller's
+// subsequent status read then finds a failing verdict.
+func applyCIEpochTransition(
+	state *State,
+	params ReconcileParams,
+	pending *PendingReaction,
+	rkey string,
+	previousHead, newHead string,
+	now time.Time,
+	ctx context.Context,
+	log *slog.Logger,
+) {
+	attribution := classifyHeadChange(state, params, pending, now, ctx)
+
+	// Unconditional: a changed head voids every prior conclusion.
+	pending.PendingAttempts = 0
+	pending.EscalatedForCurrentHead = false
+
+	// Conditional: a needless reset costs an unbounded loop.
+	resetAttempts := attribution == headChangeNotOurs
+	if resetAttempts {
+		delete(state.ReactionAttempts, rkey)
+	}
+
+	pending.HeadRecordedAt = now
+
+	log.Info("CI reaction head changed",
+		slog.String("previous_head", previousHead),
+		slog.String("head", newHead),
+		slog.String("attribution", string(attribution)),
+		slog.Bool("attempts_reset", resetAttempts),
+	)
 }
 
 // handleCIFailure records a CI failure in run_history, increments the
@@ -196,19 +313,21 @@ func handleCIFailure(
 	pending *PendingReaction,
 	result domain.CIResult,
 	ref string,
+	now time.Time,
+	base time.Duration,
 	log *slog.Logger,
 	ctx context.Context,
 	metrics domain.Metrics,
 ) {
-	now := time.Now().UTC()
+	completedAt := time.Now().UTC()
 
 	ciRunHistory := persistence.RunHistory{
 		IssueID:        pending.IssueID,
 		Identifier:     pending.Identifier,
 		DisplayID:      pending.DisplayID,
 		Attempt:        pending.Attempt,
-		StartedAt:      now.Format(time.RFC3339),
-		CompletedAt:    now.Format(time.RFC3339),
+		StartedAt:      completedAt.Format(time.RFC3339),
+		CompletedAt:    completedAt.Format(time.RFC3339),
 		Status:         "ci_failed",
 		Error:          stringPtr("CI checks failed on ref " + ref),
 		TokensMeasured: true,
@@ -226,7 +345,7 @@ func handleCIFailure(
 	maxRetries := params.CIFeedback.MaxRetries
 
 	if attempts > maxRetries {
-		escalateCIFailure(state, params, pending, result, ref, attempts, log, ctx, metrics)
+		escalateCIFailure(state, params, pending, result, ref, attempts, now, base, log, ctx, metrics)
 		return
 	}
 
@@ -261,11 +380,17 @@ func handleCIFailure(
 	)
 }
 
-// escalateCIFailure handles the case where CI fix retries are exhausted.
-// It applies the configured escalation action (label or comment), cancels
-// the retry, releases the claim, and clears the CI reaction's own pending
-// entry, counter, and fingerprint. Sibling reaction kinds for the same
-// issue are left untouched.
+// escalateCIFailure handles the case where the CI retry budget has been
+// spent for the commit currently recorded. It applies the configured
+// escalation action (label or comment) at most once per recorded head,
+// cancels the retry, and releases the claim so the issue does not stay
+// reserved by a reaction that has stopped dispatching. The pending
+// entry, its attempt counter, and its fingerprint row all survive: the
+// counter must stay over budget so no further continuation dispatches
+// until a new epoch resets it, and the row is the epoch record. The
+// entry is re-enqueued with backoff so the watch continues past
+// exhaustion. Sibling reaction kinds for the same issue are left
+// untouched.
 func escalateCIFailure(
 	state *State,
 	params ReconcileParams,
@@ -273,74 +398,82 @@ func escalateCIFailure(
 	result domain.CIResult,
 	ref string,
 	attempts int,
+	now time.Time,
+	base time.Duration,
 	log *slog.Logger,
 	ctx context.Context,
 	metrics domain.Metrics,
 ) {
-	log.Warn("CI fix retries exhausted, escalating",
-		slog.String("ref", ref),
-		slog.Int("attempts", attempts),
-		slog.Int("max_retries", params.CIFeedback.MaxRetries),
-	)
+	if !pending.EscalatedForCurrentHead {
+		log.Warn("CI fix retries exhausted, escalating",
+			slog.String("ref", ref),
+			slog.Int("attempts", attempts),
+			slog.Int("max_retries", params.CIFeedback.MaxRetries),
+		)
 
-	switch params.CIFeedback.Escalation {
-	case "label":
-		label := params.CIFeedback.EscalationLabel
-		if label == "" {
-			label = "needs-human"
-		}
-		if params.TrackerAdapter != nil {
-			issueID := pending.IssueID
-			tracker := params.TrackerAdapter
-			m := metrics
-			escalLog := log
-			escalAction := params.CIFeedback.Escalation
+		switch params.CIFeedback.Escalation {
+		case "label":
+			label := params.CIFeedback.EscalationLabel
+			if label == "" {
+				label = "needs-human"
+			}
+			if params.TrackerAdapter != nil {
+				issueID := pending.IssueID
+				tracker := params.TrackerAdapter
+				m := metrics
+				escalLog := log
+				escalAction := params.CIFeedback.Escalation
 
-			state.TrackerOpsWg.Go(func() {
-				dctx, cancel := context.WithTimeout(
-					context.WithoutCancel(ctx), 30*time.Second)
-				defer cancel()
+				state.TrackerOpsWg.Go(func() {
+					dctx, cancel := context.WithTimeout(
+						context.WithoutCancel(ctx), 30*time.Second)
+					defer cancel()
 
-				if err := tracker.AddLabel(dctx, issueID, label); err != nil {
-					escalLog.Warn("CI escalation label failed",
-						slog.Any("error", err),
-					)
-					m.IncCIEscalations("error")
-				} else {
-					m.IncCIEscalations(escalAction)
-				}
-			})
-		}
-
-	case "comment", "":
-		commentText := buildCIEscalationComment(result, ref, attempts)
-		if params.TrackerAdapter != nil {
-			issueID := pending.IssueID
-			tracker := params.TrackerAdapter
-			m := metrics
-			escalLog := log
-			ct := commentText
-			escalAction := params.CIFeedback.Escalation
-			if escalAction == "" {
-				escalAction = "comment"
+					if err := tracker.AddLabel(dctx, issueID, label); err != nil {
+						escalLog.Warn("CI escalation label failed",
+							slog.Any("error", err),
+						)
+						m.IncCIEscalations("error")
+					} else {
+						m.IncCIEscalations(escalAction)
+					}
+				})
 			}
 
-			state.TrackerOpsWg.Go(func() {
-				dctx, cancel := context.WithTimeout(
-					context.WithoutCancel(ctx), 30*time.Second)
-				defer cancel()
-
-				if err := tracker.CommentIssue(dctx, issueID, ct); err != nil {
-					escalLog.Warn("CI escalation comment failed",
-						slog.Any("error", err),
-					)
-					m.IncCIEscalations("error")
-				} else {
-					m.IncCIEscalations(escalAction)
+		case "comment", "":
+			commentText := buildCIEscalationComment(result, ref, attempts)
+			if params.TrackerAdapter != nil {
+				issueID := pending.IssueID
+				tracker := params.TrackerAdapter
+				m := metrics
+				escalLog := log
+				ct := commentText
+				escalAction := params.CIFeedback.Escalation
+				if escalAction == "" {
+					escalAction = "comment"
 				}
-			})
+
+				state.TrackerOpsWg.Go(func() {
+					dctx, cancel := context.WithTimeout(
+						context.WithoutCancel(ctx), 30*time.Second)
+					defer cancel()
+
+					if err := tracker.CommentIssue(dctx, issueID, ct); err != nil {
+						escalLog.Warn("CI escalation comment failed",
+							slog.Any("error", err),
+						)
+						m.IncCIEscalations("error")
+					} else {
+						m.IncCIEscalations(escalAction)
+					}
+				})
+			}
 		}
 	}
+
+	// Set regardless of the tracker write's outcome: the write runs in
+	// a detached goroutine whose result this pass cannot observe.
+	pending.EscalatedForCurrentHead = true
 
 	CancelRetry(state, pending.IssueID)
 
@@ -352,16 +485,15 @@ func escalateCIFailure(
 
 	delete(state.Claimed, pending.IssueID)
 
-	// Scoped to this kind's own slot: a sibling reaction's pending
-	// entry, counter, and fingerprint for the same issue survive a
-	// CI-only escalation.
-	delete(state.PendingReactions, ReactionKey(pending.IssueID, ReactionKindCI))
-	delete(state.ReactionAttempts, ReactionKey(pending.IssueID, ReactionKindCI))
-	if err := params.Store.DeleteReactionFingerprint(ctx, pending.IssueID, ReactionKindCI); err != nil {
-		log.Warn("failed to delete reaction fingerprint during CI escalation",
-			slog.Any("error", err),
-		)
-	}
+	// The entry, its attempt counter, and its fingerprint row are left
+	// untouched: this scope is limited to this kind's own slot, so a
+	// sibling reaction's pending entry, counter, and fingerprint for the
+	// same issue survive a CI-only escalation. The entry re-enqueues
+	// with backoff so the watch continues past exhaustion.
+	pending.PendingAttempts++
+	delay := computeCIPendingDelay(base, pending.PendingAttempts)
+	pending.PendingRetryAt = now.Add(delay)
+	state.PendingReactions[ReactionKey(pending.IssueID, ReactionKindCI)] = pending
 }
 
 // buildCIEscalationComment builds a plain-text escalation comment for

--- a/internal/orchestrator/ci_reconcile.go
+++ b/internal/orchestrator/ci_reconcile.go
@@ -319,15 +319,13 @@ func handleCIFailure(
 	ctx context.Context,
 	metrics domain.Metrics,
 ) {
-	completedAt := time.Now().UTC()
-
 	ciRunHistory := persistence.RunHistory{
 		IssueID:        pending.IssueID,
 		Identifier:     pending.Identifier,
 		DisplayID:      pending.DisplayID,
 		Attempt:        pending.Attempt,
-		StartedAt:      completedAt.Format(time.RFC3339),
-		CompletedAt:    completedAt.Format(time.RFC3339),
+		StartedAt:      now.Format(time.RFC3339),
+		CompletedAt:    now.Format(time.RFC3339),
 		Status:         "ci_failed",
 		Error:          stringPtr("CI checks failed on ref " + ref),
 		TokensMeasured: true,

--- a/internal/orchestrator/ci_reconcile_test.go
+++ b/internal/orchestrator/ci_reconcile_test.go
@@ -3,6 +3,7 @@ package orchestrator
 import (
 	"context"
 	"errors"
+	"log/slog"
 	"strings"
 	"testing"
 	"time"
@@ -20,14 +21,92 @@ type mockCIProvider struct {
 	result domain.CIResult
 	err    error
 	calls  int
+
+	lastRef []string
 }
 
 var _ domain.CIStatusProvider = (*mockCIProvider)(nil)
 
-func (m *mockCIProvider) FetchCIStatus(_ context.Context, _ string) (domain.CIResult, error) {
+func (m *mockCIProvider) FetchCIStatus(_ context.Context, ref string) (domain.CIResult, error) {
 	m.calls++
+	m.lastRef = append(m.lastRef, ref)
 	return m.result, m.err
 }
+
+// ciReconcileSCM is a controllable SCMAdapter whose GetMergeability
+// results are supplied per call by a function field, so a scenario can
+// advance the head SHA between reconcile passes. The call count and the
+// most recently observed argument triple let tests assert that the pass
+// reads mergeability exactly once per due tick with the pending entry's
+// own PR identity, never a value baked into the fake.
+type ciReconcileSCM struct {
+	fn     func() (domain.PRMergeStatus, error)
+	result domain.PRMergeStatus
+	err    error
+
+	calls        int
+	lastPRNumber int
+	lastOwner    string
+	lastRepo     string
+}
+
+var _ domain.SCMAdapter = (*ciReconcileSCM)(nil)
+
+func (s *ciReconcileSCM) GetMergeability(_ context.Context, prNumber int, owner, repo string) (domain.PRMergeStatus, error) {
+	s.calls++
+	s.lastPRNumber = prNumber
+	s.lastOwner = owner
+	s.lastRepo = repo
+	if s.fn != nil {
+		return s.fn()
+	}
+	return s.result, s.err
+}
+
+func (s *ciReconcileSCM) FetchPendingReviews(_ context.Context, _ int, _, _ string) ([]domain.ReviewComment, error) {
+	return nil, nil
+}
+func (s *ciReconcileSCM) FetchBotReviewComments(_ context.Context, _ int, _, _ string, _ []string) ([]domain.ReviewComment, error) {
+	return nil, nil
+}
+func (s *ciReconcileSCM) GetReviewDecision(_ context.Context, _ int, _, _ string) (domain.ReviewDecision, error) {
+	return "", nil
+}
+func (s *ciReconcileSCM) GetCIStatus(_ context.Context, _ int, _, _ string) (string, error) {
+	return "", nil
+}
+func (s *ciReconcileSCM) MergePR(_ context.Context, _ int, _, _ string, _ domain.MergeStrategy, _, _, _ string) (domain.MergeResult, error) {
+	return domain.MergeResult{}, nil
+}
+func (s *ciReconcileSCM) DeleteBranch(_ context.Context, _, _, _ string) error { return nil }
+func (s *ciReconcileSCM) ListLabelEvents(_ context.Context, _ int, _, _ string) ([]domain.LabelEvent, error) {
+	return nil, nil
+}
+func (s *ciReconcileSCM) RemoveLabel(_ context.Context, _ int, _, _, _ string) error { return nil }
+
+// ciDefaultHead is the head SHA a default ciReconcileSCM reports. Most
+// tests that are not specifically about head-change detection seed the
+// fingerprint store with this same value, so the pass treats the head as
+// already observed rather than incidentally exercising an epoch
+// transition on every single-pass test.
+const ciDefaultHead = "sha-current"
+
+// defaultCISCM returns a ciReconcileSCM reporting an open pull request at
+// ciDefaultHead.
+func defaultCISCM() *ciReconcileSCM {
+	return &ciReconcileSCM{result: domain.PRMergeStatus{HeadSHA: ciDefaultHead}}
+}
+
+// ciReconcileStoreCall records one method invocation for the fingerprint
+// call-order assertion: a store that upserts before it reads
+// passes every other assertion in this file, so the order must be
+// checked explicitly.
+type ciReconcileStoreCall string
+
+const (
+	ciCallGetFingerprint    ciReconcileStoreCall = "get_fingerprint"
+	ciCallUpsertFingerprint ciReconcileStoreCall = "upsert_fingerprint"
+)
 
 // ciReconcileStore records calls to ReconcileStore methods and returns
 // configurable errors. Parallel to mockReconcileStore but distinct so
@@ -55,6 +134,17 @@ type ciReconcileStore struct {
 	getFingerprintErr        error
 	markDispatchedErr        error
 	deleteFingerprintErr     error
+
+	upsertedFingerprints []string
+	callOrder            []ciReconcileStoreCall
+
+	// count and countErr override the embedded
+	// unsupportedReactionObservationStore default for
+	// CountWorkerRunsCompletedSince when countConfigured is true, so a
+	// test can force a specific classifyHeadChange attribution.
+	countConfigured bool
+	count           int
+	countErr        error
 }
 
 var _ ReconcileStore = (*ciReconcileStore)(nil)
@@ -74,13 +164,24 @@ func (s *ciReconcileStore) AppendRunHistory(_ context.Context, run persistence.R
 	return run, s.appendRunHistoryErr
 }
 
-func (s *ciReconcileStore) UpsertReactionFingerprint(_ context.Context, _, _, _ string) error {
+func (s *ciReconcileStore) UpsertReactionFingerprint(_ context.Context, _, _, fingerprint string) error {
 	s.upsertFingerprintCalls++
+	s.upsertedFingerprints = append(s.upsertedFingerprints, fingerprint)
+	s.callOrder = append(s.callOrder, ciCallUpsertFingerprint)
+	if s.upsertFingerprintErr == nil {
+		// Mirrors the persistence-layer upsert contract, so a
+		// multi-pass test observes the same head on its next
+		// GetReactionFingerprint call rather than a value frozen at
+		// construction time.
+		s.getFingerprintResult = fingerprint
+		s.getFingerprintDispatched = false
+	}
 	return s.upsertFingerprintErr
 }
 
 func (s *ciReconcileStore) GetReactionFingerprint(_ context.Context, _, _ string) (string, bool, error) {
 	s.getFingerprintCalls++
+	s.callOrder = append(s.callOrder, ciCallGetFingerprint)
 	return s.getFingerprintResult, s.getFingerprintDispatched, s.getFingerprintErr
 }
 
@@ -94,6 +195,13 @@ func (s *ciReconcileStore) DeleteReactionFingerprint(_ context.Context, _, _ str
 	return s.deleteFingerprintErr
 }
 
+func (s *ciReconcileStore) CountWorkerRunsCompletedSince(ctx context.Context, issueID string, since time.Time) (int, error) {
+	if !s.countConfigured {
+		return s.unsupportedReactionObservationStore.CountWorkerRunsCompletedSince(ctx, issueID, since)
+	}
+	return s.count, s.countErr
+}
+
 // ciTrackerStub is a no-panic TrackerAdapter for CI reconcile tests.
 // Escalation goroutines may call AddLabel or CommentIssue; all other
 // methods return zero values.
@@ -102,6 +210,7 @@ type ciTrackerStub struct {
 	commentIssueCalls int
 	addLabelErr       error
 	commentIssueErr   error
+	lastComment       string
 }
 
 var _ domain.TrackerAdapter = (*ciTrackerStub)(nil)
@@ -125,8 +234,9 @@ func (s *ciTrackerStub) FetchIssueComments(_ context.Context, _ string) ([]domai
 	return nil, nil
 }
 func (s *ciTrackerStub) TransitionIssue(_ context.Context, _ string, _ string) error { return nil }
-func (s *ciTrackerStub) CommentIssue(_ context.Context, _ string, _ string) error {
+func (s *ciTrackerStub) CommentIssue(_ context.Context, _ string, text string) error {
 	s.commentIssueCalls++
+	s.lastComment = text
 	return s.commentIssueErr
 }
 func (s *ciTrackerStub) AddLabel(_ context.Context, _ string, _ string) error {
@@ -160,7 +270,9 @@ func (s *ciMetricsSpy) IncRetries(trigger string)       { s.retriesByTrigger[tri
 // ciBaseTime is a fixed reference for CI reconcile tests.
 var ciBaseTime = time.Date(2026, 4, 1, 9, 0, 0, 0, time.UTC)
 
-// newPendingEntry builds a PendingReaction for a test CI issue.
+// newPendingEntry builds a PendingReaction for a test CI issue, with pull
+// request identity populated so a live GetMergeability call has a real
+// argument triple to receive.
 func newPendingEntry(issueID, identifier, branch string, attempt int) *PendingReaction {
 	return &PendingReaction{
 		IssueID:    issueID,
@@ -170,7 +282,11 @@ func newPendingEntry(issueID, identifier, branch string, attempt int) *PendingRe
 		Kind:       ReactionKindCI,
 		CreatedAt:  ciBaseTime,
 		KindData: &CIReactionData{
-			Branch: branch,
+			PRNumber: 99,
+			Owner:    "acme",
+			Repo:     "widgets",
+			Branch:   branch,
+			SHA:      "seed-sha",
 		},
 	}
 }
@@ -195,35 +311,53 @@ func stateWithPendingReaction(t *testing.T, issueID, branch string, attempt int)
 	return s
 }
 
-// ciParams returns ReconcileParams wired for CI reconcile unit tests.
-func ciParams(t *testing.T, store *ciReconcileStore, ci domain.CIStatusProvider, tracker domain.TrackerAdapter) ReconcileParams {
+// reseedCIPendingEntry installs a fresh CI PendingReaction for issueID,
+// mirroring what HandleWorkerExit does when a dispatched continuation's
+// worker exits: a brand-new entry with HeadRecordedAt zero, because a
+// head recorded before the continuation ran cannot bound the query for
+// the process observing the new one. Used to drive a multi-commit
+// scenario across several reconcile passes without dispatching a real
+// worker.
+func reseedCIPendingEntry(state *State, issueID, branch string, attempt int, now time.Time) {
+	entry := newPendingEntry(issueID, issueID+"-ident", branch, attempt)
+	entry.CreatedAt = now
+	state.PendingReactions[ReactionKey(issueID, ReactionKindCI)] = entry
+	state.Claimed[issueID] = struct{}{}
+}
+
+// ciParams returns ReconcileParams wired for CI reconcile unit tests. scm
+// may be nil to exercise the SCMAdapter-nil guard; every other test
+// supplies a *ciReconcileSCM (commonly [defaultCISCM]).
+func ciParams(t *testing.T, store *ciReconcileStore, ci domain.CIStatusProvider, tracker domain.TrackerAdapter, scm domain.SCMAdapter) ReconcileParams {
 	t.Helper()
 	return ReconcileParams{
 		TrackerAdapter: tracker,
 		CIProvider:     ci,
 		CIFeedback:     defaultCIFeedback(),
+		CIWatchWindow:  24 * time.Hour,
+		SCMAdapter:     scm,
 		Store:          store,
 		OnRetryFire:    noopRetryFire,
 		Ctx:            context.Background(),
 		Logger:         discardLogger(),
 		ActiveStates:   []string{"In Progress"},
 		TerminalStates: []string{"Done"},
+		NowFunc:        func() time.Time { return ciBaseTime },
 	}
 }
 
-// --- Tests ---
+// --- Guard tests ---
 
-func TestReconcileCIStatus_NilProvider(t *testing.T) {
+func TestReconcileCIStatus_NilCIProvider(t *testing.T) {
 	t.Parallel()
 
 	state := stateWithPendingReaction(t, "ISS-CI-1", "feature/fix", 1)
 	store := &ciReconcileStore{}
 	metrics := newCIMetricsSpy()
-	params := ciParams(t, store, nil, nil)
+	params := ciParams(t, store, nil, nil, defaultCISCM())
 
 	reconcileCIStatus(state, params, discardLogger(), context.Background(), metrics)
 
-	// nil CIProvider: entire phase is a no-op.
 	if _, ok := state.PendingReactions[ReactionKey("ISS-CI-1", ReactionKindCI)]; !ok {
 		t.Error("PendingReactions entry consumed when CIProvider is nil; want no-op")
 	}
@@ -235,14 +369,222 @@ func TestReconcileCIStatus_NilProvider(t *testing.T) {
 	}
 }
 
+// TestReconcileCIStatus_NilSCMAdapter verifies that a nil SCMAdapter is a
+// no-op for the whole phase, the same as a nil CIProvider, rather than a
+// panic on the head read.
+func TestReconcileCIStatus_NilSCMAdapter(t *testing.T) {
+	t.Parallel()
+
+	state := stateWithPendingReaction(t, "ISS-CI-NOSCM", "feature/fix", 1)
+	store := &ciReconcileStore{}
+	metrics := newCIMetricsSpy()
+	ci := &mockCIProvider{result: domain.CIResult{Status: domain.CIStatusFailing}}
+	params := ciParams(t, store, ci, nil, nil)
+
+	reconcileCIStatus(state, params, discardLogger(), context.Background(), metrics)
+
+	if _, ok := state.PendingReactions[ReactionKey("ISS-CI-NOSCM", ReactionKindCI)]; !ok {
+		t.Error("PendingReactions entry consumed when SCMAdapter is nil; want no-op")
+	}
+	if ci.calls != 0 {
+		t.Errorf("FetchCIStatus called %d times with nil SCMAdapter; want 0", ci.calls)
+	}
+}
+
+// --- The live head, never the frozen ref ---
+
+// TestReconcileCIStatus_RefIsLiveHead_NeverFrozenBranchOrSHA verifies that
+// the ref passed to FetchCIStatus always equals the freshly-read
+// PRMergeStatus.HeadSHA, never CIReactionData.SHA or CIReactionData.Branch,
+// including when all three differ.
+func TestReconcileCIStatus_RefIsLiveHead_NeverFrozenBranchOrSHA(t *testing.T) {
+	t.Parallel()
+
+	state := stateWithPendingReaction(t, "ISS-CI-REF", "frozen-branch", 1)
+	// CIReactionData.SHA is "seed-sha" (set by newPendingEntry); the live
+	// head reported by GetMergeability is deliberately a third value.
+	store := &ciReconcileStore{}
+	metrics := newCIMetricsSpy()
+	ci := &mockCIProvider{result: domain.CIResult{Status: domain.CIStatusPassing}}
+	scm := &ciReconcileSCM{result: domain.PRMergeStatus{HeadSHA: "live-head-sha"}}
+	params := ciParams(t, store, ci, nil, scm)
+
+	reconcileCIStatus(state, params, discardLogger(), context.Background(), metrics)
+
+	if len(ci.lastRef) != 1 {
+		t.Fatalf("FetchCIStatus calls = %d, want 1", len(ci.lastRef))
+	}
+	if got := ci.lastRef[0]; got != "live-head-sha" {
+		t.Errorf("FetchCIStatus ref = %q, want %q (the live head)", got, "live-head-sha")
+	}
+	if got := ci.lastRef[0]; got == "frozen-branch" || got == "seed-sha" {
+		t.Errorf("FetchCIStatus ref = %q, want neither CIReactionData.Branch nor CIReactionData.SHA", got)
+	}
+	if scm.lastPRNumber != 99 || scm.lastOwner != "acme" || scm.lastRepo != "widgets" {
+		t.Errorf("GetMergeability(prNumber=%d, owner=%q, repo=%q), want (99, acme, widgets)",
+			scm.lastPRNumber, scm.lastOwner, scm.lastRepo)
+	}
+}
+
+// --- Fingerprint read-before-write ordering ---
+
+// TestReconcileCIStatus_FingerprintReadPrecedesWrite_CallOrder verifies
+// that GetReactionFingerprint is called before UpsertReactionFingerprint
+// on a head-changed pass. An implementation that upserts first and then
+// reads would read back the value it just wrote and never detect a head
+// change, so this assertion is on call order rather than end state.
+func TestReconcileCIStatus_FingerprintReadPrecedesWrite_CallOrder(t *testing.T) {
+	t.Parallel()
+
+	state := stateWithPendingReaction(t, "ISS-CI-ORDER", "main", 1)
+	store := &ciReconcileStore{getFingerprintResult: "sha-A"}
+	metrics := newCIMetricsSpy()
+	ci := &mockCIProvider{result: domain.CIResult{Status: domain.CIStatusPassing}}
+	scm := &ciReconcileSCM{result: domain.PRMergeStatus{HeadSHA: "sha-B"}}
+	params := ciParams(t, store, ci, nil, scm)
+
+	reconcileCIStatus(state, params, discardLogger(), context.Background(), metrics)
+
+	if len(store.callOrder) < 2 {
+		t.Fatalf("store call order = %v, want at least [get, upsert]", store.callOrder)
+	}
+	if store.callOrder[0] != ciCallGetFingerprint {
+		t.Errorf("first fingerprint call = %q, want %q", store.callOrder[0], ciCallGetFingerprint)
+	}
+	getIdx, upsertIdx := -1, -1
+	for i, c := range store.callOrder {
+		if c == ciCallGetFingerprint && getIdx == -1 {
+			getIdx = i
+		}
+		if c == ciCallUpsertFingerprint && upsertIdx == -1 {
+			upsertIdx = i
+		}
+	}
+	if getIdx == -1 || upsertIdx == -1 || getIdx > upsertIdx {
+		t.Errorf("GetReactionFingerprint index=%d, UpsertReactionFingerprint index=%d; want get before upsert", getIdx, upsertIdx)
+	}
+	if len(store.upsertedFingerprints) != 1 || store.upsertedFingerprints[0] != "sha-B" {
+		t.Errorf("upserted fingerprints = %v, want [sha-B]", store.upsertedFingerprints)
+	}
+
+	// A same-head pass performs no upsert: with the row already holding
+	// the live head, storedHead == status.HeadSHA and the epoch branch
+	// never runs.
+	store2 := &ciReconcileStore{getFingerprintResult: "sha-B"}
+	state2 := stateWithPendingReaction(t, "ISS-CI-ORDER-2", "main", 1)
+	ci2 := &mockCIProvider{result: domain.CIResult{Status: domain.CIStatusPassing}}
+	scm2 := &ciReconcileSCM{result: domain.PRMergeStatus{HeadSHA: "sha-B"}}
+	params2 := ciParams(t, store2, ci2, nil, scm2)
+
+	reconcileCIStatus(state2, params2, discardLogger(), context.Background(), metrics)
+
+	if store2.upsertFingerprintCalls != 0 {
+		t.Errorf("UpsertReactionFingerprint calls = %d, want 0 when the stored head already matches the live head", store2.upsertFingerprintCalls)
+	}
+}
+
+// --- The core defect and the keeps-passing watch ---
+
+// TestReconcileCIStatus_EarlierPassingLaterFailing_DispatchesOneContinuation
+// covers the core defect this change fixes: a pull request whose earlier
+// head passed and whose later head fails dispatches one CI-fix
+// continuation within budget. Under the frozen-ref behavior this change
+// replaces, the passing pass would have retired the watch and the second
+// pass would never run.
+func TestReconcileCIStatus_EarlierPassingLaterFailing_DispatchesOneContinuation(t *testing.T) {
+	t.Parallel()
+
+	const issueID = "ISS-CI-CORE"
+	state := stateWithPendingReaction(t, issueID, "main", 1)
+	store := &ciReconcileStore{}
+	metrics := newCIMetricsSpy()
+	scm := &ciReconcileSCM{result: domain.PRMergeStatus{HeadSHA: "head-A"}}
+	ci := &mockCIProvider{result: domain.CIResult{Status: domain.CIStatusPassing}}
+	params := ciParams(t, store, ci, nil, scm)
+
+	reconcileCIStatus(state, params, discardLogger(), context.Background(), metrics)
+
+	if _, ok := state.PendingReactions[ReactionKey(issueID, ReactionKindCI)]; !ok {
+		t.Fatal("PendingReactions entry retired after a passing head; want the watch to continue")
+	}
+	if len(store.runHistories) != 0 {
+		t.Fatalf("AppendRunHistory called %d times after a passing head; want 0", len(store.runHistories))
+	}
+
+	// The head advances and now fails.
+	entry := state.PendingReactions[ReactionKey(issueID, ReactionKindCI)]
+	entry.PendingRetryAt = time.Time{}
+	scm.result = domain.PRMergeStatus{HeadSHA: "head-B"}
+	ci.result = domain.CIResult{Status: domain.CIStatusFailing, FailingCount: 1}
+
+	reconcileCIStatus(state, params, discardLogger(), context.Background(), metrics)
+
+	if len(store.runHistories) != 1 {
+		t.Fatalf("AppendRunHistory call count = %d, want 1 (one continuation dispatched)", len(store.runHistories))
+	}
+	if store.runHistories[0].Status != "ci_failed" {
+		t.Errorf("RunHistory.Status = %q, want %q", store.runHistories[0].Status, "ci_failed")
+	}
+	retryEntry, ok := state.RetryAttempts[issueID]
+	if !ok {
+		t.Fatal("continuation not scheduled after the later head failed; want scheduled")
+	}
+	if retryEntry.ReactionKind != ReactionKindCI {
+		t.Errorf("RetryAttempts.ReactionKind = %q, want %q", retryEntry.ReactionKind, ReactionKindCI)
+	}
+	if len(ci.lastRef) != 2 || ci.lastRef[1] != "head-B" {
+		t.Errorf("FetchCIStatus refs = %v, want the second call against head-B", ci.lastRef)
+	}
+}
+
+// TestReconcileCIStatus_KeepsPassing_NoDispatchNoAttemptNoRunHistory
+// covers the case where a pull request whose head keeps passing across several
+// passes dispatches nothing, spends no attempt, writes no run_history
+// row, and makes no tracker call.
+func TestReconcileCIStatus_KeepsPassing_NoDispatchNoAttemptNoRunHistory(t *testing.T) {
+	t.Parallel()
+
+	const issueID = "ISS-CI-KEEPPASS"
+	state := stateWithPendingReaction(t, issueID, "main", 1)
+	store := &ciReconcileStore{}
+	metrics := newCIMetricsSpy()
+	tracker := &ciTrackerStub{}
+	scm := &ciReconcileSCM{result: domain.PRMergeStatus{HeadSHA: "head-steady"}}
+	ci := &mockCIProvider{result: domain.CIResult{Status: domain.CIStatusPassing}}
+	params := ciParams(t, store, ci, tracker, scm)
+
+	for range 3 {
+		entry, ok := state.PendingReactions[ReactionKey(issueID, ReactionKindCI)]
+		if ok {
+			entry.PendingRetryAt = time.Time{}
+		}
+		reconcileCIStatus(state, params, discardLogger(), context.Background(), metrics)
+	}
+
+	if _, ok := state.PendingReactions[ReactionKey(issueID, ReactionKindCI)]; !ok {
+		t.Error("PendingReactions entry retired across repeated passing passes; want the watch to continue")
+	}
+	if _, ok := state.ReactionAttempts[ReactionKey(issueID, ReactionKindCI)]; ok {
+		t.Error("ReactionAttempts set after repeated passing; want unset")
+	}
+	if len(store.runHistories) != 0 {
+		t.Errorf("AppendRunHistory called %d times across a keeps-passing watch; want 0", len(store.runHistories))
+	}
+	if tracker.commentIssueCalls != 0 || tracker.addLabelCalled != 0 {
+		t.Errorf("tracker called (comment=%d, label=%d) across a keeps-passing watch; want 0/0", tracker.commentIssueCalls, tracker.addLabelCalled)
+	}
+}
+
+// --- Steady-state status handling ---
+
 func TestReconcileCIStatus_FetchError_ReEnqueues(t *testing.T) {
 	t.Parallel()
 
 	state := stateWithPendingReaction(t, "ISS-CI-2", "main", 1)
-	store := &ciReconcileStore{}
+	store := &ciReconcileStore{getFingerprintResult: ciDefaultHead}
 	metrics := newCIMetricsSpy()
 	ci := &mockCIProvider{err: errors.New("network timeout")}
-	params := ciParams(t, store, ci, nil)
+	params := ciParams(t, store, ci, nil, defaultCISCM())
 
 	reconcileCIStatus(state, params, discardLogger(), context.Background(), metrics)
 
@@ -257,40 +599,14 @@ func TestReconcileCIStatus_FetchError_ReEnqueues(t *testing.T) {
 	}
 }
 
-func TestReconcileCIStatus_Passing_ClearsReactionAttempts(t *testing.T) {
-	t.Parallel()
-
-	state := stateWithPendingReaction(t, "ISS-CI-3", "feature/done", 1)
-	state.ReactionAttempts[ReactionKey("ISS-CI-3", ReactionKindCI)] = 1 // pre-seeded
-	store := &ciReconcileStore{}
-	metrics := newCIMetricsSpy()
-	ci := &mockCIProvider{result: domain.CIResult{Status: domain.CIStatusPassing}}
-	params := ciParams(t, store, ci, nil)
-
-	reconcileCIStatus(state, params, discardLogger(), context.Background(), metrics)
-
-	if _, ok := state.PendingReactions[ReactionKey("ISS-CI-3", ReactionKindCI)]; ok {
-		t.Error("PendingReactions entry still present after passing; want consumed")
-	}
-	if _, ok := state.ReactionAttempts[ReactionKey("ISS-CI-3", ReactionKindCI)]; ok {
-		t.Error("ReactionAttempts not cleared after CI passing; want cleared")
-	}
-	if _, ok := state.RetryAttempts["ISS-CI-3"]; ok {
-		t.Error("retry scheduled after CI passing; want none")
-	}
-	if metrics.ciStatusChecks["passing"] != 1 {
-		t.Errorf(`IncCIStatusChecks("passing") = %d, want 1`, metrics.ciStatusChecks["passing"])
-	}
-}
-
 func TestReconcileCIStatus_Pending_ReEnqueues(t *testing.T) {
 	t.Parallel()
 
 	state := stateWithPendingReaction(t, "ISS-CI-4", "feature/wip", 1)
-	store := &ciReconcileStore{}
+	store := &ciReconcileStore{getFingerprintResult: ciDefaultHead}
 	metrics := newCIMetricsSpy()
 	ci := &mockCIProvider{result: domain.CIResult{Status: domain.CIStatusPending}}
-	params := ciParams(t, store, ci, nil)
+	params := ciParams(t, store, ci, nil, defaultCISCM())
 
 	reconcileCIStatus(state, params, discardLogger(), context.Background(), metrics)
 
@@ -310,7 +626,8 @@ func TestReconcileCIStatus_Pending_ReEnqueues(t *testing.T) {
 // one. The fixture's Status and FailingCount are derived from the declared
 // check-run set via scmcore.AggregateCIStatus and scmcore.FailingCount,
 // rather than written as literals, so a classifier regression reddens this
-// test rather than passing it vacuously.
+// test rather than passing it vacuously. Guards the shipped cancelled-check
+// behavior against this change.
 func TestReconcileCIStatus_CancelledOnly_NoRetrySpent(t *testing.T) {
 	t.Parallel()
 
@@ -320,14 +637,14 @@ func TestReconcileCIStatus_CancelledOnly_NoRetrySpent(t *testing.T) {
 	}
 
 	state := stateWithPendingReaction(t, "ISS-CI-CANCELLED", "feature/cancelled-only", 1)
-	store := &ciReconcileStore{}
+	store := &ciReconcileStore{getFingerprintResult: ciDefaultHead}
 	metrics := newCIMetricsSpy()
 	ci := &mockCIProvider{result: domain.CIResult{
 		Status:       scmcore.AggregateCIStatus(runs),
 		FailingCount: scmcore.FailingCount(runs),
 		CheckRuns:    runs,
 	}}
-	params := ciParams(t, store, ci, nil)
+	params := ciParams(t, store, ci, nil, defaultCISCM())
 
 	reconcileCIStatus(state, params, discardLogger(), context.Background(), metrics)
 
@@ -354,10 +671,8 @@ func TestReconcileCIStatus_CancelledOnly_NoRetrySpent(t *testing.T) {
 
 // TestReconcileCIStatus_CancelledWithFailure_StillSpendsRetry covers the
 // shape in which a cancellation coexists with a genuine failure on the same
-// ref: the pass still takes the failing arm. The fixture is derived the
-// same way as TestReconcileCIStatus_CancelledOnly_NoRetrySpent, so this
-// test fails against any classifier in which a cancelled run masks a
-// failing sibling.
+// ref: the pass still takes the failing arm. Guards the shipped cancelled-check
+// behavior against this change.
 func TestReconcileCIStatus_CancelledWithFailure_StillSpendsRetry(t *testing.T) {
 	t.Parallel()
 
@@ -367,14 +682,14 @@ func TestReconcileCIStatus_CancelledWithFailure_StillSpendsRetry(t *testing.T) {
 	}
 
 	state := stateWithPendingReaction(t, "ISS-CI-CANCELLED-FAIL", "feature/cancelled-with-failure", 1)
-	store := &ciReconcileStore{}
+	store := &ciReconcileStore{getFingerprintResult: ciDefaultHead}
 	metrics := newCIMetricsSpy()
 	ci := &mockCIProvider{result: domain.CIResult{
 		Status:       scmcore.AggregateCIStatus(runs),
 		FailingCount: scmcore.FailingCount(runs),
 		CheckRuns:    runs,
 	}}
-	params := ciParams(t, store, ci, nil)
+	params := ciParams(t, store, ci, nil, defaultCISCM())
 
 	reconcileCIStatus(state, params, discardLogger(), context.Background(), metrics)
 
@@ -397,7 +712,7 @@ func TestReconcileCIStatus_Failing_UnderMaxRetries(t *testing.T) {
 
 	// ReactionAttempts starts at 0; maxRetries=2 → no escalation after increment to 1.
 	state := stateWithPendingReaction(t, "ISS-CI-5", "feature/break", 1)
-	store := &ciReconcileStore{}
+	store := &ciReconcileStore{getFingerprintResult: ciDefaultHead}
 	metrics := newCIMetricsSpy()
 	ci := &mockCIProvider{result: domain.CIResult{
 		Status:       domain.CIStatusFailing,
@@ -406,7 +721,7 @@ func TestReconcileCIStatus_Failing_UnderMaxRetries(t *testing.T) {
 			{Name: "lint", Status: domain.CheckRunStatusCompleted, Conclusion: domain.CheckConclusionFailure},
 		},
 	}}
-	params := ciParams(t, store, ci, nil)
+	params := ciParams(t, store, ci, nil, defaultCISCM())
 
 	reconcileCIStatus(state, params, discardLogger(), context.Background(), metrics)
 
@@ -469,7 +784,7 @@ func TestReconcileCIStatus_Failing_RunHistoryCompletedAtIsUTC(t *testing.T) {
 	t.Parallel()
 
 	state := stateWithPendingReaction(t, "ISS-CI-UTC", "feature/break", 1)
-	store := &ciReconcileStore{}
+	store := &ciReconcileStore{getFingerprintResult: ciDefaultHead}
 	metrics := newCIMetricsSpy()
 	ci := &mockCIProvider{result: domain.CIResult{
 		Status:       domain.CIStatusFailing,
@@ -478,7 +793,7 @@ func TestReconcileCIStatus_Failing_RunHistoryCompletedAtIsUTC(t *testing.T) {
 			{Name: "lint", Status: domain.CheckRunStatusCompleted, Conclusion: domain.CheckConclusionFailure},
 		},
 	}}
-	params := ciParams(t, store, ci, nil)
+	params := ciParams(t, store, ci, nil, defaultCISCM())
 
 	reconcileCIStatus(state, params, discardLogger(), context.Background(), metrics)
 
@@ -494,20 +809,22 @@ func TestReconcileCIStatus_Failing_RunHistoryCompletedAtIsUTC(t *testing.T) {
 	}
 }
 
+// --- Escalation as a per-epoch soft stop ---
+
 func TestReconcileCIStatus_Failing_ExceedsMaxRetries_Escalates(t *testing.T) {
 	t.Parallel()
 
 	// ReactionAttempts at 2; after increment → 3 > maxRetries(2) → escalate.
 	state := stateWithPendingReaction(t, "ISS-CI-6", "feature/broken", 3)
 	state.ReactionAttempts[ReactionKey("ISS-CI-6", ReactionKindCI)] = 2
-	store := &ciReconcileStore{}
+	store := &ciReconcileStore{getFingerprintResult: ciDefaultHead}
 	metrics := newCIMetricsSpy()
 	tracker := &ciTrackerStub{}
 	ci := &mockCIProvider{result: domain.CIResult{
 		Status:       domain.CIStatusFailing,
 		FailingCount: 1,
 	}}
-	params := ciParams(t, store, ci, tracker)
+	params := ciParams(t, store, ci, tracker, defaultCISCM())
 
 	reconcileCIStatus(state, params, discardLogger(), context.Background(), metrics)
 
@@ -521,9 +838,18 @@ func TestReconcileCIStatus_Failing_ExceedsMaxRetries_Escalates(t *testing.T) {
 		t.Error("claim not released after CI escalation; want released")
 	}
 
-	// ReactionAttempts cleared.
-	if _, ok := state.ReactionAttempts[ReactionKey("ISS-CI-6", ReactionKindCI)]; ok {
-		t.Error("ReactionAttempts not cleared after escalation; want cleared")
+	// The pending entry, its counter, and its fingerprint all survive
+	// the soft stop: the counter must stay over budget so no further
+	// continuation dispatches until a new epoch resets it, and the
+	// fingerprint row is the epoch record.
+	if _, ok := state.PendingReactions[ReactionKey("ISS-CI-6", ReactionKindCI)]; !ok {
+		t.Error("PendingReactions entry removed after escalation; want re-enqueued (soft stop)")
+	}
+	if state.ReactionAttempts[ReactionKey("ISS-CI-6", ReactionKindCI)] != 3 {
+		t.Errorf("ReactionAttempts[ISS-CI-6] = %d after escalation, want 3 (kept over budget)", state.ReactionAttempts[ReactionKey("ISS-CI-6", ReactionKindCI)])
+	}
+	if store.deleteFingerprintCalls != 0 {
+		t.Errorf("DeleteReactionFingerprint calls = %d, want 0 (fingerprint is the epoch record)", store.deleteFingerprintCalls)
 	}
 
 	// Wait for the async escalation goroutine before reading metrics.
@@ -539,7 +865,7 @@ func TestReconcileCIStatus_Failing_ExceedsMaxRetries_Escalates(t *testing.T) {
 		t.Fatalf("AppendRunHistory call count = %d, want 1", len(store.runHistories))
 	}
 
-	// No retry scheduled.
+	// No continuation scheduled.
 	if _, ok := state.RetryAttempts["ISS-CI-6"]; ok {
 		t.Error("retry scheduled after escalation; want none")
 	}
@@ -550,11 +876,11 @@ func TestReconcileCIStatus_Failing_CommentEscalation(t *testing.T) {
 
 	state := stateWithPendingReaction(t, "ISS-CI-7", "main", 1)
 	state.ReactionAttempts[ReactionKey("ISS-CI-7", ReactionKindCI)] = 2
-	store := &ciReconcileStore{}
+	store := &ciReconcileStore{getFingerprintResult: ciDefaultHead}
 	metrics := newCIMetricsSpy()
 	tracker := &ciTrackerStub{}
 	ci := &mockCIProvider{result: domain.CIResult{Status: domain.CIStatusFailing}}
-	params := ciParams(t, store, ci, tracker)
+	params := ciParams(t, store, ci, tracker, defaultCISCM())
 	params.CIFeedback.Escalation = "comment"
 
 	reconcileCIStatus(state, params, discardLogger(), context.Background(), metrics)
@@ -565,12 +891,130 @@ func TestReconcileCIStatus_Failing_CommentEscalation(t *testing.T) {
 	if metrics.ciEscalations["comment"] != 1 {
 		t.Errorf(`IncCIEscalations("comment") = %d, want 1`, metrics.ciEscalations["comment"])
 	}
-	// Claim released and retry cleared in both escalation modes.
+	// Claim released in both escalation modes.
 	if _, ok := state.Claimed["ISS-CI-7"]; ok {
 		t.Error("claim not released after comment escalation")
 	}
+	// The entry survives the soft stop.
+	if _, ok := state.PendingReactions[ReactionKey("ISS-CI-7", ReactionKindCI)]; !ok {
+		t.Error("PendingReactions entry removed after comment escalation; want re-enqueued (soft stop)")
+	}
 }
 
+// TestReconcileCIStatus_EscalationSoftStop_SameHeadDoesNotReescalate
+// covers the case where, after escalation, a later pass on the same head neither
+// escalates again nor dispatches a continuation.
+func TestReconcileCIStatus_EscalationSoftStop_SameHeadDoesNotReescalate(t *testing.T) {
+	t.Parallel()
+
+	const issueID = "ISS-CI-SOFTSTOP"
+	state := stateWithPendingReaction(t, issueID, "main", 3)
+	state.ReactionAttempts[ReactionKey(issueID, ReactionKindCI)] = 2
+	store := &ciReconcileStore{getFingerprintResult: ciDefaultHead}
+	metrics := newCIMetricsSpy()
+	tracker := &ciTrackerStub{}
+	ci := &mockCIProvider{result: domain.CIResult{Status: domain.CIStatusFailing, FailingCount: 1}}
+	params := ciParams(t, store, ci, tracker, defaultCISCM())
+
+	reconcileCIStatus(state, params, discardLogger(), context.Background(), metrics)
+	state.TrackerOpsWg.Wait()
+
+	if metrics.ciEscalations["label"] != 1 {
+		t.Fatalf(`IncCIEscalations("label") after first pass = %d, want 1`, metrics.ciEscalations["label"])
+	}
+
+	// A later pass on the very same head.
+	entry, ok := state.PendingReactions[ReactionKey(issueID, ReactionKindCI)]
+	if !ok {
+		t.Fatal("PendingReactions entry missing before the second pass; want present (soft stop)")
+	}
+	entry.PendingRetryAt = time.Time{}
+
+	reconcileCIStatus(state, params, discardLogger(), context.Background(), metrics)
+	state.TrackerOpsWg.Wait()
+
+	if metrics.ciEscalations["label"] != 1 {
+		t.Errorf(`IncCIEscalations("label") after second pass on the same head = %d, want 1 (no re-escalation)`, metrics.ciEscalations["label"])
+	}
+	if _, ok := state.RetryAttempts[issueID]; ok {
+		t.Error("a continuation was scheduled on the same head after escalation; want none")
+	}
+}
+
+// TestReconcileCIStatus_CommentEscalation_RecursOncePerHead_ThenAgainAfterNotOursHeadChange
+// covers the case where, under escalation: comment, an exhausted budget posts one
+// comment across several passes on one head, and one further comment
+// after a head change positively not attributed to the orchestrator's
+// own work.
+func TestReconcileCIStatus_CommentEscalation_RecursOncePerHead_ThenAgainAfterNotOursHeadChange(t *testing.T) {
+	t.Parallel()
+
+	const issueID = "ISS-CI-COMMENT-RECUR"
+	state := stateWithPendingReaction(t, issueID, "main", 3)
+	state.ReactionAttempts[ReactionKey(issueID, ReactionKindCI)] = 2
+	// The fingerprint starts empty so the first pass triggers a genuine
+	// epoch transition and records HeadRecordedAt, which the later
+	// notOurs transition needs as its non-zero boundary.
+	store := &ciReconcileStore{}
+	metrics := newCIMetricsSpy()
+	tracker := &ciTrackerStub{}
+	scm := defaultCISCM()
+	ci := &mockCIProvider{result: domain.CIResult{Status: domain.CIStatusFailing, FailingCount: 1}}
+	params := ciParams(t, store, ci, tracker, scm)
+	params.CIFeedback.Escalation = "comment"
+
+	for i := range 3 {
+		entry, ok := state.PendingReactions[ReactionKey(issueID, ReactionKindCI)]
+		if i > 0 && !ok {
+			t.Fatalf("pass %d: PendingReactions entry missing; want present (soft stop)", i)
+		}
+		if ok {
+			entry.PendingRetryAt = time.Time{}
+		}
+		reconcileCIStatus(state, params, discardLogger(), context.Background(), metrics)
+		state.TrackerOpsWg.Wait()
+	}
+	if metrics.ciEscalations["comment"] != 1 {
+		t.Fatalf(`IncCIEscalations("comment") across 3 passes on one head = %d, want 1`, metrics.ciEscalations["comment"])
+	}
+
+	// The head changes and the store reports zero worker sessions
+	// completed since the boundary: classifyHeadChange answers
+	// positively not the orchestrator's own work, resetting the counter
+	// and the escalation flag, so the budget re-exhausts across the
+	// next several passes and escalates again.
+	scm.result = domain.PRMergeStatus{HeadSHA: "head-after-push"}
+	store.countConfigured = true
+	store.count = 0
+
+	entry, ok := state.PendingReactions[ReactionKey(issueID, ReactionKindCI)]
+	if !ok {
+		t.Fatal("PendingReactions entry missing before the head-change pass; want present (soft stop)")
+	}
+	entry.PendingRetryAt = time.Time{}
+	now := ciBaseTime
+	for i := range 3 {
+		now = now.Add(time.Duration(i) * time.Minute)
+		if _, ok := state.PendingReactions[ReactionKey(issueID, ReactionKindCI)]; !ok {
+			// A non-escalating failure consumes the entry, converting
+			// it into a continuation dispatch; the next worker exit
+			// would normally reseed the watch, modeled here directly.
+			reseedCIPendingEntry(state, issueID, "main", 3, now)
+			delete(state.RetryAttempts, issueID)
+		}
+		e := state.PendingReactions[ReactionKey(issueID, ReactionKindCI)]
+		e.PendingRetryAt = time.Time{}
+		reconcileCIStatus(state, params, discardLogger(), context.Background(), metrics)
+		state.TrackerOpsWg.Wait()
+	}
+
+	if metrics.ciEscalations["comment"] != 2 {
+		t.Errorf(`IncCIEscalations("comment") after a head change not attributed to the orchestrator = %d, want 2`, metrics.ciEscalations["comment"])
+	}
+}
+
+// TestBuildCIEscalationComment: the escalation comment
+// names exactly the checks the verdict counted as failing.
 func TestBuildCIEscalationComment(t *testing.T) {
 	t.Parallel()
 
@@ -674,6 +1118,57 @@ func TestBuildCIEscalationComment(t *testing.T) {
 	}
 }
 
+// TestReconcileCIStatus_NoPersonAttributingLanguage verifies that no log
+// line, comment, or label emitted on a head-change path contains a
+// person-attributing phrase. The assertion enumerates the emitted
+// strings rather than searching for a denylist.
+func TestReconcileCIStatus_NoPersonAttributingLanguage(t *testing.T) {
+	t.Parallel()
+
+	forbidden := []string{
+		"a person pushed", "person pushed", "human push", "manual commit", "someone pushed",
+	}
+
+	const issueID = "ISS-CI-NOATTR"
+	state := stateWithPendingReaction(t, issueID, "main", 3)
+	state.ReactionAttempts[ReactionKey(issueID, ReactionKindCI)] = 2
+	store := &ciReconcileStore{getFingerprintResult: "head-old"}
+	metrics := newCIMetricsSpy()
+	tracker := &ciTrackerStub{}
+	scm := &ciReconcileSCM{result: domain.PRMergeStatus{HeadSHA: "head-new"}}
+	ci := &mockCIProvider{result: domain.CIResult{Status: domain.CIStatusFailing, FailingCount: 1}}
+	params := ciParams(t, store, ci, tracker, scm)
+	params.CIFeedback.Escalation = "comment"
+
+	handler := &sweepLogHandler{}
+	params.Logger = slog.New(handler)
+
+	reconcileCIStatus(state, params, slog.New(handler), context.Background(), metrics)
+	state.TrackerOpsWg.Wait()
+
+	emitted := make([]string, 0, len(handler.records)+1)
+	for _, rec := range handler.records {
+		emitted = append(emitted, rec.message)
+		for _, v := range rec.attrs {
+			if s, ok := v.(string); ok {
+				emitted = append(emitted, s)
+			}
+		}
+	}
+	if tracker.commentIssueCalls > 0 {
+		emitted = append(emitted, tracker.lastComment)
+	}
+
+	for _, text := range emitted {
+		lower := strings.ToLower(text)
+		for _, phrase := range forbidden {
+			if strings.Contains(lower, phrase) {
+				t.Errorf("emitted text %q contains forbidden person-attributing phrase %q", text, phrase)
+			}
+		}
+	}
+}
+
 // --- TrackerOpsWg lifecycle tests ---
 
 // blockingCITracker is a TrackerAdapter whose AddLabel and CommentIssue
@@ -740,10 +1235,10 @@ func TestEscalateCIFailure_LabelTracksTrackerOps(t *testing.T) {
 	// the limit and triggers escalation.
 	state := stateWithPendingReaction(t, "ESC-WG-1", "main/broken", 3)
 	state.ReactionAttempts[ReactionKey("ESC-WG-1", ReactionKindCI)] = 2
-	store := &ciReconcileStore{}
+	store := &ciReconcileStore{getFingerprintResult: ciDefaultHead}
 	metrics := newCIMetricsSpy()
 	ci := &mockCIProvider{result: domain.CIResult{Status: domain.CIStatusFailing}}
-	params := ciParams(t, store, ci, tracker)
+	params := ciParams(t, store, ci, tracker, defaultCISCM())
 	// defaultCIFeedback sets escalation: "label".
 
 	reconcileCIStatus(state, params, discardLogger(), context.Background(), metrics)
@@ -782,10 +1277,10 @@ func TestEscalateCIFailure_CommentTracksTrackerOps(t *testing.T) {
 
 	state := stateWithPendingReaction(t, "ESC-WG-2", "feature/broken", 2)
 	state.ReactionAttempts[ReactionKey("ESC-WG-2", ReactionKindCI)] = 2
-	store := &ciReconcileStore{}
+	store := &ciReconcileStore{getFingerprintResult: ciDefaultHead}
 	metrics := newCIMetricsSpy()
 	ci := &mockCIProvider{result: domain.CIResult{Status: domain.CIStatusFailing}}
-	params := ciParams(t, store, ci, tracker)
+	params := ciParams(t, store, ci, tracker, defaultCISCM())
 	params.CIFeedback.Escalation = "comment"
 
 	reconcileCIStatus(state, params, discardLogger(), context.Background(), metrics)
@@ -813,7 +1308,7 @@ func TestEscalateCIFailure_CommentTracksTrackerOps(t *testing.T) {
 	}
 }
 
-// --- Backoff and TTL tests ---
+// --- Backoff tests ---
 
 func TestComputeCIPendingDelay(t *testing.T) {
 	t.Parallel()
@@ -922,10 +1417,10 @@ func TestReconcileCIStatus_BackoffUsesStatePollInterval(t *testing.T) {
 	state.PendingReactions[ReactionKey("ISS-PPI-1", ReactionKindCI)] = entry
 	state.Claimed["ISS-PPI-1"] = struct{}{}
 
-	store := &ciReconcileStore{}
+	store := &ciReconcileStore{getFingerprintResult: ciDefaultHead}
 	metrics := newCIMetricsSpy()
 	ci := &mockCIProvider{result: domain.CIResult{Status: domain.CIStatusPending}}
-	params := ciParams(t, store, ci, nil)
+	params := ciParams(t, store, ci, nil, defaultCISCM())
 	params.NowFunc = func() time.Time { return now }
 
 	reconcileCIStatus(state, params, discardLogger(), context.Background(), metrics)
@@ -968,10 +1463,11 @@ func TestReconcileCIStatus_BackoffSkip(t *testing.T) {
 	state.PendingReactions[ReactionKey("ISS-SKIP-1", ReactionKindCI)] = entry
 	state.Claimed["ISS-SKIP-1"] = struct{}{}
 
-	store := &ciReconcileStore{}
+	store := &ciReconcileStore{getFingerprintResult: ciDefaultHead}
 	metrics := newCIMetricsSpy()
 	ci := &mockCIProvider{}
-	params := ciParams(t, store, ci, nil)
+	scm := defaultCISCM()
+	params := ciParams(t, store, ci, nil, scm)
 	params.NowFunc = func() time.Time { return now }
 
 	reconcileCIStatus(state, params, discardLogger(), context.Background(), metrics)
@@ -979,6 +1475,11 @@ func TestReconcileCIStatus_BackoffSkip(t *testing.T) {
 	// FetchCIStatus must not be called when PendingRetryAt is in the future.
 	if ci.calls != 0 {
 		t.Errorf("FetchCIStatus called %d times during backoff window; want 0", ci.calls)
+	}
+	// GetMergeability must not be called either: the backoff gate runs
+	// before the head read.
+	if scm.calls != 0 {
+		t.Errorf("GetMergeability called %d times during backoff window; want 0", scm.calls)
 	}
 
 	// Entry must be re-enqueued with identical PendingAttempts and PendingRetryAt.
@@ -1006,10 +1507,10 @@ func TestReconcileCIStatus_BackoffIncrements_OnPending(t *testing.T) {
 	state.PendingReactions[ReactionKey("ISS-BIP-1", ReactionKindCI)] = entry
 	state.Claimed["ISS-BIP-1"] = struct{}{}
 
-	store := &ciReconcileStore{}
+	store := &ciReconcileStore{getFingerprintResult: ciDefaultHead}
 	metrics := newCIMetricsSpy()
 	ci := &mockCIProvider{result: domain.CIResult{Status: domain.CIStatusPending}}
-	params := ciParams(t, store, ci, nil)
+	params := ciParams(t, store, ci, nil, defaultCISCM())
 	params.NowFunc = func() time.Time { return now }
 
 	reconcileCIStatus(state, params, discardLogger(), context.Background(), metrics)
@@ -1046,10 +1547,10 @@ func TestReconcileCIStatus_BackoffIncrements_OnError(t *testing.T) {
 	state.PendingReactions[ReactionKey("ISS-BIE-1", ReactionKindCI)] = entry
 	state.Claimed["ISS-BIE-1"] = struct{}{}
 
-	store := &ciReconcileStore{}
+	store := &ciReconcileStore{getFingerprintResult: ciDefaultHead}
 	metrics := newCIMetricsSpy()
 	ci := &mockCIProvider{err: errors.New("transient network error")}
-	params := ciParams(t, store, ci, nil)
+	params := ciParams(t, store, ci, nil, defaultCISCM())
 	params.NowFunc = func() time.Time { return now }
 
 	reconcileCIStatus(state, params, discardLogger(), context.Background(), metrics)
@@ -1074,57 +1575,104 @@ func TestReconcileCIStatus_BackoffIncrements_OnError(t *testing.T) {
 	}
 }
 
-func TestReconcileCIStatus_TTLExpiry(t *testing.T) {
+// --- Watch window ---
+
+// TestReconcileCIStatus_WatchWindow_MeasuredFromHeadRecordedAt covers
+// an entry whose age past the last recorded head exceeds
+// watch_window_ms is dropped with its counter, and one whose head moved
+// inside the window is not.
+func TestReconcileCIStatus_WatchWindow_MeasuredFromHeadRecordedAt(t *testing.T) {
 	t.Parallel()
 
-	const ttl = 30 * time.Minute
+	t.Run("age past HeadRecordedAt beyond the window drops the entry and its counter", func(t *testing.T) {
+		t.Parallel()
 
-	tests := []struct {
-		name        string
-		age         time.Duration
-		wantDropped bool
-	}{
-		{"entry within TTL is kept", ttl - time.Second, false},
-		{"entry exactly at TTL boundary is kept", ttl, false},
-		{"entry just past TTL is dropped", ttl + time.Millisecond, true},
-		{"entry well past TTL is dropped", 2 * ttl, true},
-	}
+		const issueID = "ISS-CI-WW-DROP"
+		entry := newPendingEntry(issueID, issueID+"-ident", "main", 1)
+		entry.HeadRecordedAt = ciBaseTime
+		entry.CreatedAt = ciBaseTime.Add(-10 * 24 * time.Hour) // far older than HeadRecordedAt
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
+		state := NewState(5000, 4, nil, AgentTotals{})
+		state.PendingReactions[ReactionKey(issueID, ReactionKindCI)] = entry
+		state.ReactionAttempts[ReactionKey(issueID, ReactionKindCI)] = 1
+		state.Claimed[issueID] = struct{}{}
 
-			createdAt := ciBaseTime
-			now := createdAt.Add(tt.age)
+		store := &ciReconcileStore{}
+		metrics := newCIMetricsSpy()
+		scm := defaultCISCM()
+		ci := &mockCIProvider{}
+		params := ciParams(t, store, ci, nil, scm)
+		params.CIWatchWindow = 30 * time.Minute
+		params.NowFunc = func() time.Time { return ciBaseTime.Add(31 * time.Minute) }
 
-			entry := newPendingEntry("ISS-TTL-1", "ISS-TTL-1-ident", "main", 1)
-			entry.CreatedAt = createdAt
+		reconcileCIStatus(state, params, discardLogger(), context.Background(), metrics)
 
-			state := NewState(5000, 4, nil, AgentTotals{})
-			state.PendingReactions[ReactionKey("ISS-TTL-1", ReactionKindCI)] = entry
-			state.Claimed["ISS-TTL-1"] = struct{}{}
+		if _, ok := state.PendingReactions[ReactionKey(issueID, ReactionKindCI)]; ok {
+			t.Error("PendingReactions entry present after watch window elapsed since HeadRecordedAt; want dropped")
+		}
+		if _, ok := state.ReactionAttempts[ReactionKey(issueID, ReactionKindCI)]; ok {
+			t.Error("ReactionAttempts present after watch window elapsed; want dropped")
+		}
+		if scm.calls != 0 {
+			t.Errorf("GetMergeability called %d times after watch window elapsed; want 0", scm.calls)
+		}
+	})
 
-			store := &ciReconcileStore{}
-			metrics := newCIMetricsSpy()
-			ci := &mockCIProvider{result: domain.CIResult{Status: domain.CIStatusPending}}
-			params := ciParams(t, store, ci, nil)
-			params.NowFunc = func() time.Time { return now }
-			params.CIPendingTTL = ttl
+	t.Run("head moved inside the window is not dropped", func(t *testing.T) {
+		t.Parallel()
 
-			reconcileCIStatus(state, params, discardLogger(), context.Background(), metrics)
+		const issueID = "ISS-CI-WW-KEEP"
+		entry := newPendingEntry(issueID, issueID+"-ident", "main", 1)
+		entry.HeadRecordedAt = ciBaseTime
+		entry.CreatedAt = ciBaseTime.Add(-10 * 24 * time.Hour)
 
-			_, stillPresent := state.PendingReactions[ReactionKey("ISS-TTL-1", ReactionKindCI)]
+		state := NewState(5000, 4, nil, AgentTotals{})
+		state.PendingReactions[ReactionKey(issueID, ReactionKindCI)] = entry
+		state.Claimed[issueID] = struct{}{}
 
-			if tt.wantDropped && stillPresent {
-				t.Error("PendingReactions entry not dropped after TTL expiry; want dropped")
-			}
-			if !tt.wantDropped && !stillPresent {
-				t.Error("PendingReactions entry dropped before TTL expiry; want kept")
-			}
-			if tt.wantDropped && ci.calls != 0 {
-				t.Errorf("FetchCIStatus called %d times after TTL expiry; want 0", ci.calls)
-			}
-		})
+		store := &ciReconcileStore{getFingerprintResult: ciDefaultHead}
+		metrics := newCIMetricsSpy()
+		scm := defaultCISCM()
+		ci := &mockCIProvider{result: domain.CIResult{Status: domain.CIStatusPending}}
+		params := ciParams(t, store, ci, nil, scm)
+		params.CIWatchWindow = 30 * time.Minute
+		params.NowFunc = func() time.Time { return ciBaseTime.Add(29 * time.Minute) }
+
+		reconcileCIStatus(state, params, discardLogger(), context.Background(), metrics)
+
+		if _, ok := state.PendingReactions[ReactionKey(issueID, ReactionKindCI)]; !ok {
+			t.Error("PendingReactions entry dropped inside the watch window; want kept")
+		}
+		if scm.calls != 1 {
+			t.Errorf("GetMergeability called %d times; want 1 (entry survived to the head read)", scm.calls)
+		}
+	})
+}
+
+// TestReconcileCIStatus_WatchWindow_ZeroNeverDrops verifies that
+// watch_window_ms: 0 never drops the entry on age.
+func TestReconcileCIStatus_WatchWindow_ZeroNeverDrops(t *testing.T) {
+	t.Parallel()
+
+	const issueID = "ISS-CI-WW-ZERO"
+	entry := newPendingEntry(issueID, issueID+"-ident", "main", 1)
+	entry.CreatedAt = ciBaseTime.Add(-365 * 24 * time.Hour)
+
+	state := NewState(5000, 4, nil, AgentTotals{})
+	state.PendingReactions[ReactionKey(issueID, ReactionKindCI)] = entry
+	state.Claimed[issueID] = struct{}{}
+
+	store := &ciReconcileStore{getFingerprintResult: ciDefaultHead}
+	metrics := newCIMetricsSpy()
+	ci := &mockCIProvider{result: domain.CIResult{Status: domain.CIStatusPending}}
+	params := ciParams(t, store, ci, nil, defaultCISCM())
+	params.CIWatchWindow = 0
+	params.NowFunc = func() time.Time { return ciBaseTime }
+
+	reconcileCIStatus(state, params, discardLogger(), context.Background(), metrics)
+
+	if _, ok := state.PendingReactions[ReactionKey(issueID, ReactionKindCI)]; !ok {
+		t.Error("PendingReactions entry dropped with CIWatchWindow=0; want never dropped on age")
 	}
 }
 
@@ -1145,9 +1693,9 @@ func TestReconcileCIStatus_DropOnAgeReleasesCounter(t *testing.T) {
 
 	store := &ciReconcileStore{}
 	metrics := newCIMetricsSpy()
-	ci := &mockCIProvider{result: domain.CIResult{Status: domain.CIStatusPending}}
-	params := ciParams(t, store, ci, nil)
-	params.CIPendingTTL = 30 * time.Minute
+	scm := defaultCISCM()
+	params := ciParams(t, store, &mockCIProvider{result: domain.CIResult{Status: domain.CIStatusPending}}, nil, scm)
+	params.CIWatchWindow = 30 * time.Minute
 	params.NowFunc = func() time.Time { return ciBaseTime.Add(31 * time.Minute) }
 
 	reconcileCIStatus(state, params, discardLogger(), context.Background(), metrics)
@@ -1171,39 +1719,211 @@ func TestReconcileCIStatus_DropOnAgeReleasesCounter(t *testing.T) {
 		t.Errorf("fingerprint calls = upsert:%d get:%d delete:%d, want all 0",
 			store.upsertFingerprintCalls, store.getFingerprintCalls, store.deleteFingerprintCalls)
 	}
+	if scm.calls != 0 {
+		t.Errorf("GetMergeability calls = %d, want 0 (watch window exceeded before read)", scm.calls)
+	}
+}
+
+// --- Watch-end conditions ---
+
+func TestReconcileCIStatus_Merged_EndsWatch(t *testing.T) {
+	t.Parallel()
+
+	const issueID = "ISS-CI-MERGED"
+	state := stateWithPendingReaction(t, issueID, "main", 1)
+	state.ReactionAttempts[ReactionKey(issueID, ReactionKindCI)] = 1
+	store := &ciReconcileStore{}
+	metrics := newCIMetricsSpy()
+	scm := &ciReconcileSCM{result: domain.PRMergeStatus{HeadSHA: "merged-sha", Merged: true, MergeCommitSHA: "mc-sha"}}
+	ci := &mockCIProvider{}
+	params := ciParams(t, store, ci, nil, scm)
+
+	reconcileCIStatus(state, params, discardLogger(), context.Background(), metrics)
+
+	if _, ok := state.PendingReactions[ReactionKey(issueID, ReactionKindCI)]; ok {
+		t.Error("PendingReactions entry present after merged pull request; want dropped")
+	}
+	if _, ok := state.ReactionAttempts[ReactionKey(issueID, ReactionKindCI)]; ok {
+		t.Error("ReactionAttempts present after merged pull request; want dropped")
+	}
 	if ci.calls != 0 {
-		t.Errorf("FetchCIStatus calls = %d, want 0 (TTL exceeded before fetch)", ci.calls)
+		t.Errorf("FetchCIStatus called %d times for a merged pull request; want 0", ci.calls)
+	}
+}
+
+func TestReconcileCIStatus_NotFound_EndsWatch(t *testing.T) {
+	t.Parallel()
+
+	const issueID = "ISS-CI-NOTFOUND"
+	state := stateWithPendingReaction(t, issueID, "main", 1)
+	state.ReactionAttempts[ReactionKey(issueID, ReactionKindCI)] = 1
+	store := &ciReconcileStore{}
+	metrics := newCIMetricsSpy()
+	scm := &ciReconcileSCM{err: &domain.SCMError{Kind: domain.ErrSCMNotFound, Message: "pull request not found"}}
+	ci := &mockCIProvider{}
+	params := ciParams(t, store, ci, nil, scm)
+
+	reconcileCIStatus(state, params, discardLogger(), context.Background(), metrics)
+
+	if _, ok := state.PendingReactions[ReactionKey(issueID, ReactionKindCI)]; ok {
+		t.Error("PendingReactions entry present after ErrSCMNotFound; want dropped")
+	}
+	if _, ok := state.ReactionAttempts[ReactionKey(issueID, ReactionKindCI)]; ok {
+		t.Error("ReactionAttempts present after ErrSCMNotFound; want dropped")
+	}
+}
+
+func TestReconcileCIStatus_OtherSCMError_BacksOff(t *testing.T) {
+	t.Parallel()
+
+	const issueID = "ISS-CI-SCMERR"
+	state := stateWithPendingReaction(t, issueID, "main", 1)
+	store := &ciReconcileStore{}
+	metrics := newCIMetricsSpy()
+	scm := &ciReconcileSCM{err: &domain.SCMError{Kind: domain.ErrSCMTransport, Message: "connection reset"}}
+	ci := &mockCIProvider{}
+	params := ciParams(t, store, ci, nil, scm)
+
+	reconcileCIStatus(state, params, discardLogger(), context.Background(), metrics)
+
+	entry, ok := state.PendingReactions[ReactionKey(issueID, ReactionKindCI)]
+	if !ok {
+		t.Fatal("PendingReactions entry dropped after a transient SCM error; want re-enqueued")
+	}
+	if entry.PendingAttempts != 1 {
+		t.Errorf("PendingAttempts = %d, want 1 (backoff, not a watch-end condition)", entry.PendingAttempts)
+	}
+	if ci.calls != 0 {
+		t.Errorf("FetchCIStatus called %d times after a mergeability fetch error; want 0", ci.calls)
+	}
+}
+
+// TestReconcileCIStatus_EmptyHeadSHA_ReEnqueuesNoEpoch verifies that an
+// empty status.HeadSHA re-enqueues, records no head, opens no epoch, and
+// leaves both counters untouched.
+func TestReconcileCIStatus_EmptyHeadSHA_ReEnqueuesNoEpoch(t *testing.T) {
+	t.Parallel()
+
+	const issueID = "ISS-CI-EMPTYHEAD"
+	state := stateWithPendingReaction(t, issueID, "main", 1)
+	state.ReactionAttempts[ReactionKey(issueID, ReactionKindCI)] = 1
+	store := &ciReconcileStore{}
+	metrics := newCIMetricsSpy()
+	scm := &ciReconcileSCM{result: domain.PRMergeStatus{HeadSHA: ""}}
+	ci := &mockCIProvider{}
+	params := ciParams(t, store, ci, nil, scm)
+
+	reconcileCIStatus(state, params, discardLogger(), context.Background(), metrics)
+
+	entry, ok := state.PendingReactions[ReactionKey(issueID, ReactionKindCI)]
+	if !ok {
+		t.Fatal("PendingReactions entry dropped on empty HeadSHA; want re-enqueued")
+	}
+	if !entry.HeadRecordedAt.IsZero() {
+		t.Errorf("HeadRecordedAt = %v, want zero (no epoch opened on empty head)", entry.HeadRecordedAt)
+	}
+	if state.ReactionAttempts[ReactionKey(issueID, ReactionKindCI)] != 1 {
+		t.Errorf("ReactionAttempts[%s] = %d, want 1 (untouched)", issueID, state.ReactionAttempts[ReactionKey(issueID, ReactionKindCI)])
+	}
+	if entry.PendingAttempts != 1 {
+		t.Errorf("PendingAttempts = %d, want 1", entry.PendingAttempts)
+	}
+	if store.upsertFingerprintCalls != 0 || store.getFingerprintCalls != 0 {
+		t.Errorf("fingerprint calls = get:%d upsert:%d, want both 0", store.getFingerprintCalls, store.upsertFingerprintCalls)
+	}
+	if ci.calls != 0 {
+		t.Errorf("FetchCIStatus called %d times on empty head; want 0", ci.calls)
+	}
+}
+
+// TestReconcileCIStatus_Closed_EndsWatch verifies that a pull request
+// reported closed and not merged drops the entry and its counter on the
+// next pass, not at window expiry.
+func TestReconcileCIStatus_Closed_EndsWatch(t *testing.T) {
+	t.Parallel()
+
+	const issueID = "ISS-CI-CLOSED"
+	state := stateWithPendingReaction(t, issueID, "main", 1)
+	state.ReactionAttempts[ReactionKey(issueID, ReactionKindCI)] = 1
+	store := &ciReconcileStore{}
+	metrics := newCIMetricsSpy()
+	scm := &ciReconcileSCM{result: domain.PRMergeStatus{HeadSHA: "closed-sha", Closed: true, Merged: false}}
+	ci := &mockCIProvider{}
+	params := ciParams(t, store, ci, nil, scm)
+
+	reconcileCIStatus(state, params, discardLogger(), context.Background(), metrics)
+
+	if _, ok := state.PendingReactions[ReactionKey(issueID, ReactionKindCI)]; ok {
+		t.Error("PendingReactions entry present after a closed, unmerged pull request; want dropped")
+	}
+	if _, ok := state.ReactionAttempts[ReactionKey(issueID, ReactionKindCI)]; ok {
+		t.Error("ReactionAttempts present after a closed, unmerged pull request; want dropped")
+	}
+	if ci.calls != 0 {
+		t.Errorf("FetchCIStatus called %d times for a closed pull request; want 0", ci.calls)
+	}
+}
+
+// TestReconcileCIStatus_ClosedAndMerged_EndsWatchThroughMergedBranch
+// verifies that a pull request reported both closed and
+// merged ends the watch through the merged branch, logging the merge
+// rather than a close.
+func TestReconcileCIStatus_ClosedAndMerged_EndsWatchThroughMergedBranch(t *testing.T) {
+	t.Parallel()
+
+	const issueID = "ISS-CI-CLOSEDMERGED"
+	state := stateWithPendingReaction(t, issueID, "main", 1)
+	state.ReactionAttempts[ReactionKey(issueID, ReactionKindCI)] = 1
+	store := &ciReconcileStore{}
+	metrics := newCIMetricsSpy()
+	scm := &ciReconcileSCM{result: domain.PRMergeStatus{HeadSHA: "merged-sha", Closed: true, Merged: true}}
+	ci := &mockCIProvider{}
+	handler := &sweepLogHandler{}
+	params := ciParams(t, store, ci, nil, scm)
+	params.Logger = slog.New(handler)
+
+	reconcileCIStatus(state, params, slog.New(handler), context.Background(), metrics)
+
+	if _, ok := state.PendingReactions[ReactionKey(issueID, ReactionKindCI)]; ok {
+		t.Error("PendingReactions entry present after a merged pull request; want dropped")
+	}
+	if _, ok := handler.findByMessage("ci watch ended: pull request merged"); !ok {
+		t.Error(`log missing "ci watch ended: pull request merged" message; want the merged branch, not the closed branch`)
+	}
+	if handler.countByMessage("ci watch ended: pull request closed without merging") != 0 {
+		t.Error(`log unexpectedly contains the closed-without-merging message for a merged pull request`)
 	}
 }
 
 // --- Fingerprint dedup tests ---
 
 // TestReconcileCIStatus_DedupSkip verifies that when GetReactionFingerprint
-// returns the current ref with dispatched=true, the entry is consumed without
-// calling FetchCIStatus.
+// returns the current head with dispatched=true, no FetchCIStatus call is
+// made and the entry is re-enqueued.
 func TestReconcileCIStatus_DedupSkip(t *testing.T) {
 	t.Parallel()
 
-	const ref = "sha-already-done"
-	state := stateWithPendingReaction(t, "ISS-FP-1", ref, 1)
+	const head = "sha-already-done"
+	state := stateWithPendingReaction(t, "ISS-FP-1", "main", 1)
 	store := &ciReconcileStore{
-		getFingerprintResult:     ref,
+		getFingerprintResult:     head,
 		getFingerprintDispatched: true,
 	}
 	metrics := newCIMetricsSpy()
 	ci := &mockCIProvider{}
-	params := ciParams(t, store, ci, nil)
+	scm := &ciReconcileSCM{result: domain.PRMergeStatus{HeadSHA: head}}
+	params := ciParams(t, store, ci, nil, scm)
 
 	reconcileCIStatus(state, params, discardLogger(), context.Background(), metrics)
 
 	if ci.calls != 0 {
 		t.Errorf("FetchCIStatus called %d times when entry already dispatched; want 0", ci.calls)
 	}
-	if _, ok := state.PendingReactions[ReactionKey("ISS-FP-1", ReactionKindCI)]; ok {
-		t.Error("PendingReactions entry still present after dedup skip; want consumed")
+	if _, ok := state.PendingReactions[ReactionKey("ISS-FP-1", ReactionKindCI)]; !ok {
+		t.Error("PendingReactions entry consumed after dedup skip; want re-enqueued")
 	}
-	if store.upsertFingerprintCalls != 1 {
-		t.Errorf("UpsertReactionFingerprint calls = %d, want 1", store.upsertFingerprintCalls)
+	if store.upsertFingerprintCalls != 0 {
+		t.Errorf("UpsertReactionFingerprint calls = %d, want 0 (head unchanged)", store.upsertFingerprintCalls)
 	}
 	if store.getFingerprintCalls != 1 {
 		t.Errorf("GetReactionFingerprint calls = %d, want 1", store.getFingerprintCalls)
@@ -1211,47 +1931,29 @@ func TestReconcileCIStatus_DedupSkip(t *testing.T) {
 }
 
 // TestReconcileCIStatus_FingerprintReset verifies that when the stored
-// fingerprint differs from the current ref (ref changed), UpsertReactionFingerprint
-// is called and reconciliation proceeds (FetchCIStatus is called).
+// fingerprint differs from the live head (head changed), the pass upserts
+// the new head and proceeds to FetchCIStatus.
 func TestReconcileCIStatus_FingerprintReset(t *testing.T) {
 	t.Parallel()
 
-	// Store returns old ref as dispatched; entry's branch is the new ref.
-	const newRef = "sha-new"
-	state := stateWithPendingReaction(t, "ISS-FP-2", newRef, 1)
+	const newHead = "sha-new"
+	state := stateWithPendingReaction(t, "ISS-FP-2", "main", 1)
 	store := &ciReconcileStore{
 		getFingerprintResult:     "sha-old",
 		getFingerprintDispatched: true,
 	}
 	metrics := newCIMetricsSpy()
 	ci := &mockCIProvider{result: domain.CIResult{Status: domain.CIStatusPassing}}
-	params := ciParams(t, store, ci, nil)
+	scm := &ciReconcileSCM{result: domain.PRMergeStatus{HeadSHA: newHead}}
+	params := ciParams(t, store, ci, nil, scm)
 
 	reconcileCIStatus(state, params, discardLogger(), context.Background(), metrics)
 
 	if ci.calls != 1 {
-		t.Errorf("FetchCIStatus calls = %d, want 1 (ref changed, dedup must not skip)", ci.calls)
+		t.Errorf("FetchCIStatus calls = %d, want 1 (head changed, dedup must not skip)", ci.calls)
 	}
-	if store.upsertFingerprintCalls != 1 {
-		t.Errorf("UpsertReactionFingerprint calls = %d, want 1", store.upsertFingerprintCalls)
-	}
-}
-
-// TestReconcileCIStatus_Passing_DeletesFingerprint verifies that on a
-// CI-passing result DeleteReactionFingerprint is called.
-func TestReconcileCIStatus_Passing_DeletesFingerprint(t *testing.T) {
-	t.Parallel()
-
-	state := stateWithPendingReaction(t, "ISS-FP-3", "sha-pass", 1)
-	store := &ciReconcileStore{}
-	metrics := newCIMetricsSpy()
-	ci := &mockCIProvider{result: domain.CIResult{Status: domain.CIStatusPassing}}
-	params := ciParams(t, store, ci, nil)
-
-	reconcileCIStatus(state, params, discardLogger(), context.Background(), metrics)
-
-	if store.deleteFingerprintCalls != 1 {
-		t.Errorf("DeleteReactionFingerprint calls = %d, want 1 on CI pass", store.deleteFingerprintCalls)
+	if len(store.upsertedFingerprints) != 1 || store.upsertedFingerprints[0] != newHead {
+		t.Errorf("upserted fingerprints = %v, want [%s]", store.upsertedFingerprints, newHead)
 	}
 }
 
@@ -1261,13 +1963,13 @@ func TestReconcileCIStatus_Passing_DeletesFingerprint(t *testing.T) {
 func TestReconcileCIStatus_FingerprintGetError_Continues(t *testing.T) {
 	t.Parallel()
 
-	state := stateWithPendingReaction(t, "ISS-FP-4", "sha-fperr", 1)
+	state := stateWithPendingReaction(t, "ISS-FP-4", "main", 1)
 	store := &ciReconcileStore{
 		getFingerprintErr: errors.New("db unavailable"),
 	}
 	metrics := newCIMetricsSpy()
 	ci := &mockCIProvider{result: domain.CIResult{Status: domain.CIStatusPassing}}
-	params := ciParams(t, store, ci, nil)
+	params := ciParams(t, store, ci, nil, defaultCISCM())
 
 	reconcileCIStatus(state, params, discardLogger(), context.Background(), metrics)
 
@@ -1276,34 +1978,104 @@ func TestReconcileCIStatus_FingerprintGetError_Continues(t *testing.T) {
 	}
 }
 
+// TestReconcileCIStatus_UpgradePath_PreExistingFingerprintNotLiveHead
+// verifies that a pre-existing fingerprint row holding a value that is not
+// the live head (the pre-change frozen-ref semantics) produces exactly
+// one unknown transition: the entry re-arms and no counter resets.
+func TestReconcileCIStatus_UpgradePath_PreExistingFingerprintNotLiveHead(t *testing.T) {
+	t.Parallel()
+
+	const issueID = "ISS-CI-UPGRADE"
+	state := stateWithPendingReaction(t, issueID, "main", 1)
+	state.ReactionAttempts[ReactionKey(issueID, ReactionKindCI)] = 1
+	store := &ciReconcileStore{getFingerprintResult: "frozen-ref-from-prior-version"}
+	metrics := newCIMetricsSpy()
+	ci := &mockCIProvider{result: domain.CIResult{Status: domain.CIStatusPending}}
+	scm := &ciReconcileSCM{result: domain.PRMergeStatus{HeadSHA: "current-live-head"}}
+	params := ciParams(t, store, ci, nil, scm)
+
+	reconcileCIStatus(state, params, discardLogger(), context.Background(), metrics)
+
+	if store.upsertFingerprintCalls != 1 {
+		t.Errorf("UpsertReactionFingerprint calls = %d, want 1 (one upgrade transition)", store.upsertFingerprintCalls)
+	}
+	if state.ReactionAttempts[ReactionKey(issueID, ReactionKindCI)] != 1 {
+		t.Errorf("ReactionAttempts[%s] = %d, want 1 (unknown attribution must not reset)", issueID, state.ReactionAttempts[ReactionKey(issueID, ReactionKindCI)])
+	}
+	entry, ok := state.PendingReactions[ReactionKey(issueID, ReactionKindCI)]
+	if !ok {
+		t.Fatal("PendingReactions entry missing after upgrade transition; want re-enqueued")
+	}
+	if entry.HeadRecordedAt.IsZero() {
+		t.Error("HeadRecordedAt still zero after the upgrade transition; want set")
+	}
+}
+
+// --- One head read, one epoch transition, one status fetch per tick ---
+
+// TestReconcileCIStatus_OneHeadReadOneEpochTransitionOneStatusFetchPerTick
+// verifies that across one poll interval (one call to reconcileCIStatus),
+// exactly one head read, one epoch transition, and one FetchCIStatus call
+// occur for the pending entry, even though the underlying adapter is
+// primed to answer three different heads across successive calls.
+func TestReconcileCIStatus_OneHeadReadOneEpochTransitionOneStatusFetchPerTick(t *testing.T) {
+	t.Parallel()
+
+	const issueID = "ISS-CI-ONETICK"
+	state := stateWithPendingReaction(t, issueID, "main", 1)
+	store := &ciReconcileStore{}
+	metrics := newCIMetricsSpy()
+	heads := []string{"head-1", "head-2", "head-3"}
+	call := 0
+	scm := &ciReconcileSCM{fn: func() (domain.PRMergeStatus, error) {
+		head := heads[min(call, len(heads)-1)]
+		call++
+		return domain.PRMergeStatus{HeadSHA: head}, nil
+	}}
+	ci := &mockCIProvider{result: domain.CIResult{Status: domain.CIStatusPending}}
+	params := ciParams(t, store, ci, nil, scm)
+
+	reconcileCIStatus(state, params, discardLogger(), context.Background(), metrics)
+
+	if scm.calls != 1 {
+		t.Errorf("GetMergeability calls = %d, want 1 (one head read per due tick)", scm.calls)
+	}
+	if store.upsertFingerprintCalls != 1 {
+		t.Errorf("UpsertReactionFingerprint calls = %d, want 1 (one epoch transition)", store.upsertFingerprintCalls)
+	}
+	if ci.calls != 1 {
+		t.Errorf("FetchCIStatus calls = %d, want 1", ci.calls)
+	}
+}
+
+// --- Dispatch marking ---
+
 // TestReconcileCIStatus_Failing_DoesNotMarkDispatched verifies that
-// handleCIFailure no longer calls MarkReactionDispatched at schedule time.
-// The mark is deferred to HandleRetryTimer after actual dispatch.
+// handleCIFailure never calls MarkReactionDispatched: CI dispatch tracking
+// is entirely fingerprint-based on the live head, with no separate
+// dispatched marker.
 func TestReconcileCIStatus_Failing_DoesNotMarkDispatched(t *testing.T) {
 	t.Parallel()
 
 	// ReactionAttempts=0 → under maxRetries=2, so handleCIFailure schedules retry.
-	state := stateWithPendingReaction(t, "ISS-FP-5", "sha-fail", 1)
-	store := &ciReconcileStore{}
+	state := stateWithPendingReaction(t, "ISS-FP-5", "main", 1)
+	store := &ciReconcileStore{getFingerprintResult: ciDefaultHead}
 	metrics := newCIMetricsSpy()
 	ci := &mockCIProvider{result: domain.CIResult{Status: domain.CIStatusFailing, FailingCount: 1}}
-	params := ciParams(t, store, ci, nil)
+	params := ciParams(t, store, ci, nil, defaultCISCM())
 
 	reconcileCIStatus(state, params, discardLogger(), context.Background(), metrics)
 
-	// MarkReactionDispatched must NOT be called at schedule time.
 	if store.markDispatchedCalls != 0 {
-		t.Errorf("MarkReactionDispatched calls = %d, want 0 (mark deferred to dispatch site)", store.markDispatchedCalls)
+		t.Errorf("MarkReactionDispatched calls = %d, want 0", store.markDispatchedCalls)
 	}
-	// Retry must still be scheduled.
 	if _, ok := state.RetryAttempts["ISS-FP-5"]; !ok {
 		t.Error("retry not scheduled after CI failure; want scheduled")
 	}
 }
 
-// TestEscalateCIFailure_LabelFailure_IncrementsErrorMetric verifies that when
-// AddLabel returns an error the escalation goroutine increments
-// IncCIEscalations("error") and does not increment IncCIEscalations("label").
+// --- Escalation error metrics ---
+
 func TestEscalateCIFailure_LabelFailure_IncrementsErrorMetric(t *testing.T) {
 	t.Parallel()
 
@@ -1311,10 +2083,10 @@ func TestEscalateCIFailure_LabelFailure_IncrementsErrorMetric(t *testing.T) {
 
 	state := stateWithPendingReaction(t, "ESC-ERR-1", "main/broken", 3)
 	state.ReactionAttempts[ReactionKey("ESC-ERR-1", ReactionKindCI)] = 2
-	store := &ciReconcileStore{}
+	store := &ciReconcileStore{getFingerprintResult: ciDefaultHead}
 	metrics := newCIMetricsSpy()
 	ci := &mockCIProvider{result: domain.CIResult{Status: domain.CIStatusFailing}}
-	params := ciParams(t, store, ci, tracker)
+	params := ciParams(t, store, ci, tracker, defaultCISCM())
 	// defaultCIFeedback sets escalation: "label".
 
 	reconcileCIStatus(state, params, discardLogger(), context.Background(), metrics)
@@ -1328,9 +2100,6 @@ func TestEscalateCIFailure_LabelFailure_IncrementsErrorMetric(t *testing.T) {
 	}
 }
 
-// TestEscalateCIFailure_CommentFailure_IncrementsErrorMetric verifies that
-// when CommentIssue returns an error the escalation goroutine increments
-// IncCIEscalations("error") and does not increment IncCIEscalations("comment").
 func TestEscalateCIFailure_CommentFailure_IncrementsErrorMetric(t *testing.T) {
 	t.Parallel()
 
@@ -1338,10 +2107,10 @@ func TestEscalateCIFailure_CommentFailure_IncrementsErrorMetric(t *testing.T) {
 
 	state := stateWithPendingReaction(t, "ESC-ERR-2", "feature/broken", 2)
 	state.ReactionAttempts[ReactionKey("ESC-ERR-2", ReactionKindCI)] = 2
-	store := &ciReconcileStore{}
+	store := &ciReconcileStore{getFingerprintResult: ciDefaultHead}
 	metrics := newCIMetricsSpy()
 	ci := &mockCIProvider{result: domain.CIResult{Status: domain.CIStatusFailing}}
-	params := ciParams(t, store, ci, tracker)
+	params := ciParams(t, store, ci, tracker, defaultCISCM())
 	params.CIFeedback.Escalation = "comment"
 
 	reconcileCIStatus(state, params, discardLogger(), context.Background(), metrics)
@@ -1363,10 +2132,10 @@ func TestEscalateCIFailure_NilTracker_ZeroIncrements(t *testing.T) {
 
 	state := stateWithPendingReaction(t, "ESC-NIL-1", "main/broken", 3)
 	state.ReactionAttempts[ReactionKey("ESC-NIL-1", ReactionKindCI)] = 2
-	store := &ciReconcileStore{}
+	store := &ciReconcileStore{getFingerprintResult: ciDefaultHead}
 	metrics := newCIMetricsSpy()
 	ci := &mockCIProvider{result: domain.CIResult{Status: domain.CIStatusFailing}}
-	params := ciParams(t, store, ci, nil) // nil TrackerAdapter
+	params := ciParams(t, store, ci, nil, defaultCISCM()) // nil TrackerAdapter
 	// defaultCIFeedback sets escalation: "label".
 
 	reconcileCIStatus(state, params, discardLogger(), context.Background(), metrics)
@@ -1384,10 +2153,10 @@ func TestEscalateCIFailure_NilTracker_ZeroIncrements_Comment(t *testing.T) {
 
 	state := stateWithPendingReaction(t, "ESC-NIL-2", "feature/broken", 2)
 	state.ReactionAttempts[ReactionKey("ESC-NIL-2", ReactionKindCI)] = 2
-	store := &ciReconcileStore{}
+	store := &ciReconcileStore{getFingerprintResult: ciDefaultHead}
 	metrics := newCIMetricsSpy()
 	ci := &mockCIProvider{result: domain.CIResult{Status: domain.CIStatusFailing}}
-	params := ciParams(t, store, ci, nil) // nil TrackerAdapter
+	params := ciParams(t, store, ci, nil, defaultCISCM()) // nil TrackerAdapter
 	params.CIFeedback.Escalation = "comment"
 
 	reconcileCIStatus(state, params, discardLogger(), context.Background(), metrics)
@@ -1398,27 +2167,28 @@ func TestEscalateCIFailure_NilTracker_ZeroIncrements_Comment(t *testing.T) {
 	}
 }
 
-// TestEscalateCIFailure_DeletesFingerprint verifies that escalateCIFailure
-// calls DeleteReactionFingerprint after clearing reactions.
-func TestEscalateCIFailure_DeletesFingerprint(t *testing.T) {
+// TestEscalateCIFailure_FingerprintSurvivesEscalation verifies that
+// escalateCIFailure no longer calls DeleteReactionFingerprint: the row is
+// the epoch record and must survive.
+func TestEscalateCIFailure_FingerprintSurvivesEscalation(t *testing.T) {
 	t.Parallel()
 
 	// ReactionAttempts=2, maxRetries=2 → next increment (→3) triggers escalation.
-	state := stateWithPendingReaction(t, "ISS-FP-6", "sha-escal", 3)
+	state := stateWithPendingReaction(t, "ISS-FP-6", "main", 3)
 	state.ReactionAttempts[ReactionKey("ISS-FP-6", ReactionKindCI)] = 2
-	store := &ciReconcileStore{}
+	store := &ciReconcileStore{getFingerprintResult: ciDefaultHead}
 	metrics := newCIMetricsSpy()
 	tracker := &ciTrackerStub{}
 	ci := &mockCIProvider{result: domain.CIResult{Status: domain.CIStatusFailing, FailingCount: 1}}
-	params := ciParams(t, store, ci, tracker)
+	params := ciParams(t, store, ci, tracker, defaultCISCM())
 
 	reconcileCIStatus(state, params, discardLogger(), context.Background(), metrics)
 
 	// Wait for any escalation goroutine to finish.
 	state.TrackerOpsWg.Wait()
 
-	if store.deleteFingerprintCalls != 1 {
-		t.Errorf("DeleteReactionFingerprint calls = %d, want 1 during CI escalation", store.deleteFingerprintCalls)
+	if store.deleteFingerprintCalls != 0 {
+		t.Errorf("DeleteReactionFingerprint calls = %d, want 0 during CI escalation (fingerprint is the epoch record)", store.deleteFingerprintCalls)
 	}
 	// Claim must be released.
 	if _, ok := state.Claimed["ISS-FP-6"]; ok {
@@ -1427,15 +2197,15 @@ func TestEscalateCIFailure_DeletesFingerprint(t *testing.T) {
 }
 
 // TestReconcileCIStatus_Failing_ExceedsMaxRetries_CrossKindIsolation verifies
-// that CI escalation clears only the CI reaction's own pending entry,
-// counter, and fingerprint. A sibling merge-completion entry parked on the
-// same issue (seeded from the same worker exit as the CI reaction) must
-// survive: the escalation must not clear it.
+// that CI escalation touches only the CI reaction's own pending entry and
+// counter. A sibling merge-completion entry parked on the same issue
+// (seeded from the same worker exit as the CI reaction) must survive
+// untouched.
 func TestReconcileCIStatus_Failing_ExceedsMaxRetries_CrossKindIsolation(t *testing.T) {
 	t.Parallel()
 
 	issueID := "ISS-CI-ISO"
-	state := stateWithPendingReaction(t, issueID, "feature/broken", 3)
+	state := stateWithPendingReaction(t, issueID, "main", 3)
 	state.ReactionAttempts[ReactionKey(issueID, ReactionKindCI)] = 2
 
 	mcKey := ReactionKey(issueID, ReactionKindMergeCompletion)
@@ -1448,11 +2218,11 @@ func TestReconcileCIStatus_Failing_ExceedsMaxRetries_CrossKindIsolation(t *testi
 	}
 	state.ReactionAttempts[ReactionKey(issueID, ReactionKindMergeCompletion)] = 1
 
-	store := &ciReconcileStore{}
+	store := &ciReconcileStore{getFingerprintResult: ciDefaultHead}
 	metrics := newCIMetricsSpy()
 	tracker := &ciTrackerStub{}
 	ci := &mockCIProvider{result: domain.CIResult{Status: domain.CIStatusFailing, FailingCount: 1}}
-	params := ciParams(t, store, ci, tracker)
+	params := ciParams(t, store, ci, tracker, defaultCISCM())
 
 	reconcileCIStatus(state, params, discardLogger(), context.Background(), metrics)
 	state.TrackerOpsWg.Wait()
@@ -1463,8 +2233,8 @@ func TestReconcileCIStatus_Failing_ExceedsMaxRetries_CrossKindIsolation(t *testi
 	if state.ReactionAttempts[ReactionKey(issueID, ReactionKindMergeCompletion)] != 1 {
 		t.Error("sibling merge-completion ReactionAttempts counter altered by CI escalation; want untouched")
 	}
-	if store.deleteFingerprintCalls != 1 {
-		t.Errorf("DeleteReactionFingerprint calls = %d, want 1 (the CI kind's own fingerprint)", store.deleteFingerprintCalls)
+	if store.deleteFingerprintCalls != 0 {
+		t.Errorf("DeleteReactionFingerprint calls = %d, want 0 (escalation no longer deletes the epoch record)", store.deleteFingerprintCalls)
 	}
 }
 
@@ -1495,7 +2265,7 @@ func TestReconcileCIStatus_Failing_DeferralLeavesNoOrphanedRow(t *testing.T) {
 		t.Fatalf("SaveRetryEntry: %v", err)
 	}
 
-	state := stateWithPendingReaction(t, issueID, "feature/orphan", 1)
+	state := stateWithPendingReaction(t, issueID, "main", 1)
 	state.RetryAttempts[issueID] = &RetryEntry{
 		IssueID:    issueID,
 		Identifier: issueID + "-ident",
@@ -1509,6 +2279,8 @@ func TestReconcileCIStatus_Failing_DeferralLeavesNoOrphanedRow(t *testing.T) {
 	params := ReconcileParams{
 		CIProvider:     ci,
 		CIFeedback:     defaultCIFeedback(),
+		CIWatchWindow:  24 * time.Hour,
+		SCMAdapter:     defaultCISCM(),
 		Store:          store,
 		OnRetryFire:    noopRetryFire,
 		Ctx:            ctx,
@@ -1561,10 +2333,10 @@ func TestReconcileCIStatus_Pending_LeavesCreatedAtUnchanged(t *testing.T) {
 	seededCreatedAt := ciBaseTime.Add(-5 * time.Minute)
 	state.PendingReactions[rkey].CreatedAt = seededCreatedAt
 
-	store := &ciReconcileStore{}
+	store := &ciReconcileStore{getFingerprintResult: ciDefaultHead}
 	metrics := newCIMetricsSpy()
 	ci := &mockCIProvider{result: domain.CIResult{Status: domain.CIStatusPending}}
-	params := ciParams(t, store, ci, nil)
+	params := ciParams(t, store, ci, nil, defaultCISCM())
 	params.NowFunc = func() time.Time { return ciBaseTime }
 
 	reconcileCIStatus(state, params, discardLogger(), context.Background(), metrics)
@@ -1578,5 +2350,119 @@ func TestReconcileCIStatus_Pending_LeavesCreatedAtUnchanged(t *testing.T) {
 	}
 	if entry.PendingAttempts != 1 {
 		t.Errorf("PendingAttempts = %d, want 1 (the tick ran)", entry.PendingAttempts)
+	}
+}
+
+// --- End-to-end attribution tests against a real persistence store ---
+
+// TestReconcileCIStatus_CIFailedRunHistoryExcludedFromAttribution verifies
+// that a run_history row with status ci_failed and completed_at inside
+// the attribution interval does not make the next head change unknown.
+// The ci_failed row is dispatched through handleCIFailure itself, as
+// part of a real escalation soft stop (a real CI failure, not a
+// synthesized fixture), so this test fails against an implementation
+// that counts that row as a worker session.
+func TestReconcileCIStatus_CIFailedRunHistoryExcludedFromAttribution(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store := openInMemoryStore(t)
+
+	const issueID = "ISS-CI-EXCLUDE"
+	state := stateWithPendingReaction(t, issueID, "main", 3)
+	// Pre-seeded at the budget: the pass below escalates immediately,
+	// writing exactly one ci_failed row through handleCIFailure and
+	// soft-stopping (the entry survives with its HeadRecordedAt set).
+	state.ReactionAttempts[ReactionKey(issueID, ReactionKindCI)] = 2
+	scm := &ciReconcileSCM{result: domain.PRMergeStatus{HeadSHA: "head-1"}}
+	ci := &mockCIProvider{result: domain.CIResult{Status: domain.CIStatusFailing, FailingCount: 1}}
+	tracker := &ciTrackerStub{}
+	metrics := newCIMetricsSpy()
+
+	now := ciBaseTime
+	params := ReconcileParams{
+		CIProvider:     ci,
+		CIFeedback:     defaultCIFeedback(),
+		CIWatchWindow:  24 * time.Hour,
+		SCMAdapter:     scm,
+		TrackerAdapter: tracker,
+		Store:          store,
+		OnRetryFire:    noopRetryFire,
+		Ctx:            ctx,
+		Logger:         discardLogger(),
+		ActiveStates:   []string{"In Progress"},
+		TerminalStates: []string{"Done"},
+		NowFunc:        func() time.Time { return now },
+	}
+
+	reconcileCIStatus(state, params, discardLogger(), ctx, metrics)
+	state.TrackerOpsWg.Wait()
+
+	if metrics.ciEscalations["label"] != 1 {
+		t.Fatalf(`IncCIEscalations("label") = %d, want 1 (escalation soft stop wrote the ci_failed row)`, metrics.ciEscalations["label"])
+	}
+	entry, ok := state.PendingReactions[ReactionKey(issueID, ReactionKindCI)]
+	if !ok {
+		t.Fatal("PendingReactions entry missing after the soft stop; want present")
+	}
+	if entry.HeadRecordedAt.IsZero() {
+		t.Fatal("HeadRecordedAt still zero after the soft stop; want set")
+	}
+
+	// The head changes; no worker session other than the ci_failed
+	// write occurred inside the interval.
+	now = ciBaseTime.Add(10 * time.Minute)
+	entry.PendingRetryAt = time.Time{}
+	scm.result = domain.PRMergeStatus{HeadSHA: "head-2"}
+
+	reconcileCIStatus(state, params, discardLogger(), ctx, metrics)
+
+	if got := state.ReactionAttempts[ReactionKey(issueID, ReactionKindCI)]; got != 1 {
+		t.Errorf("ReactionAttempts after a head change with only a ci_failed row in the interval = %d, want 1 (the counter reset to 0 and then incremented once; the ci_failed row must not count as a worker session)", got)
+	}
+}
+
+// TestReconcileCIStatus_ThreeSelfPushedFixCommits_EscalateAfterTotalBudget
+// verifies that three successive self-pushed fix commits, each failing,
+// escalate after max_retries continuations in total rather than
+// max_retries per commit. Each fix commit's own worker exit reseeds the
+// watch with HeadRecordedAt zero, so every post-reseed head observation
+// answers unknown on the zero-boundary path and the counter never
+// resets, exhausting the budget across, not within, a single commit.
+func TestReconcileCIStatus_ThreeSelfPushedFixCommits_EscalateAfterTotalBudget(t *testing.T) {
+	t.Parallel()
+
+	const issueID = "ISS-CI-TOTALBUDGET"
+	state := stateWithPendingReaction(t, issueID, "main", 1)
+	store := &ciReconcileStore{}
+	scm := &ciReconcileSCM{result: domain.PRMergeStatus{HeadSHA: "head-0"}}
+	ci := &mockCIProvider{result: domain.CIResult{Status: domain.CIStatusFailing, FailingCount: 1}}
+	tracker := &ciTrackerStub{}
+	metrics := newCIMetricsSpy()
+	params := ciParams(t, store, ci, tracker, scm)
+
+	heads := []string{"head-0", "head-1", "head-2"}
+	var now time.Time
+	for i, head := range heads {
+		now = ciBaseTime.Add(time.Duration(i) * 10 * time.Minute)
+		if _, ok := state.PendingReactions[ReactionKey(issueID, ReactionKindCI)]; !ok {
+			reseedCIPendingEntry(state, issueID, "main", 1, now)
+			delete(state.RetryAttempts, issueID)
+		}
+		scm.result = domain.PRMergeStatus{HeadSHA: head}
+		entry := state.PendingReactions[ReactionKey(issueID, ReactionKindCI)]
+		entry.PendingRetryAt = time.Time{}
+
+		reconcileCIStatus(state, params, discardLogger(), context.Background(), metrics)
+	}
+
+	state.TrackerOpsWg.Wait()
+
+	if state.ReactionAttempts[ReactionKey(issueID, ReactionKindCI)] != 3 {
+		t.Errorf("ReactionAttempts after three self-pushed fix commits = %d, want 3 (accumulated, not reset per commit)",
+			state.ReactionAttempts[ReactionKey(issueID, ReactionKindCI)])
+	}
+	if metrics.ciEscalations["label"] != 1 {
+		t.Errorf(`IncCIEscalations("label") = %d, want 1 (escalated once the total budget was exceeded)`, metrics.ciEscalations["label"])
 	}
 }

--- a/internal/orchestrator/ci_reconcile_test.go
+++ b/internal/orchestrator/ci_reconcile_test.go
@@ -2466,3 +2466,63 @@ func TestReconcileCIStatus_ThreeSelfPushedFixCommits_EscalateAfterTotalBudget(t 
 		t.Errorf(`IncCIEscalations("label") = %d, want 1 (escalated once the total budget was exceeded)`, metrics.ciEscalations["label"])
 	}
 }
+
+// TestReconcileCIStatus_UpsertFailure_DefersEpochTransition verifies that a
+// failed fingerprint upsert defers the epoch transition instead of applying
+// it against a durable record that did not advance. The transition restarts
+// the watch clock and re-arms the once-per-epoch escalation, so applying it
+// on every pass while the write keeps failing would leave the entry unable
+// to age out and would let the escalation fire once per pass.
+func TestReconcileCIStatus_UpsertFailure_DefersEpochTransition(t *testing.T) {
+	t.Parallel()
+
+	const issueID = "ISS-CI-UPSERTFAIL"
+	recordedAt := time.Now().UTC().Add(-time.Hour)
+
+	state := stateWithPendingReaction(t, issueID, "main", 1)
+	rkey := ReactionKey(issueID, ReactionKindCI)
+	state.PendingReactions[rkey].HeadRecordedAt = recordedAt
+	state.PendingReactions[rkey].EscalatedForCurrentHead = true
+	state.ReactionAttempts[rkey] = 1
+
+	store := &ciReconcileStore{
+		getFingerprintResult: "old-head",
+		upsertFingerprintErr: errors.New("database is locked"),
+	}
+	metrics := newCIMetricsSpy()
+	scm := &ciReconcileSCM{result: domain.PRMergeStatus{HeadSHA: "new-head"}}
+	ci := &mockCIProvider{}
+	params := ciParams(t, store, ci, nil, scm)
+
+	// Two passes: one failed write is a deferral, and a second proves the
+	// age basis does not creep forward while the write keeps failing.
+	for range 2 {
+		if entry, ok := state.PendingReactions[rkey]; ok {
+			entry.PendingRetryAt = time.Time{}
+		}
+		reconcileCIStatus(state, params, discardLogger(), context.Background(), metrics)
+	}
+
+	entry, ok := state.PendingReactions[rkey]
+	if !ok {
+		t.Fatal("PendingReactions entry dropped after a failed fingerprint upsert; want re-enqueued")
+	}
+	if !entry.HeadRecordedAt.Equal(recordedAt) {
+		t.Errorf("HeadRecordedAt = %v, want %v (unchanged: the durable head never advanced)", entry.HeadRecordedAt, recordedAt)
+	}
+	if !entry.EscalatedForCurrentHead {
+		t.Error("EscalatedForCurrentHead cleared while the durable head never advanced; the soft stop would re-escalate every pass")
+	}
+	if state.ReactionAttempts[rkey] != 1 {
+		t.Errorf("ReactionAttempts[%s] = %d, want 1 (untouched by a deferred transition)", issueID, state.ReactionAttempts[rkey])
+	}
+	if entry.PendingAttempts != 2 {
+		t.Errorf("PendingAttempts = %d, want 2 (backoff advanced once per failed pass)", entry.PendingAttempts)
+	}
+	if store.upsertFingerprintCalls != 2 {
+		t.Errorf("upsert attempts = %d, want 2 (retried on the next pass)", store.upsertFingerprintCalls)
+	}
+	if ci.calls != 0 {
+		t.Errorf("FetchCIStatus called %d times after a failed upsert; want 0 (the pass ends before the status read)", ci.calls)
+	}
+}

--- a/internal/orchestrator/exit.go
+++ b/internal/orchestrator/exit.go
@@ -40,6 +40,7 @@ type WorkerExitStore interface {
 	ResetHandoffAbsenceSequence(ctx context.Context, issueID string) error
 	UpsertParkedIssue(ctx context.Context, entry persistence.ParkedIssue) error
 	DeleteParkedIssue(ctx context.Context, issueID string) error
+	CountWorkerRunsCompletedSince(ctx context.Context, issueID string, since time.Time) (int, error)
 }
 
 // HandleWorkerExitParams holds the dependencies for [HandleWorkerExit] that
@@ -796,13 +797,16 @@ func HandleWorkerExit(state *State, workerResult WorkerResult, params HandleWork
 		}
 		reactionEnqueueAllowed := claimedAtExit && (handoffPath || stillClaimed) && !terminalSuppressed
 
-		// Record a pending CI check when the CI provider is configured and
-		// the worker produced workspace SCM metadata. Handoff paths remain
-		// eligible even after the claim is released.
-		if params.CIProvider != nil && workerResult.WorkspacePath != "" {
+		// Record a pending CI check when the CI provider and the SCM
+		// adapter are both configured and the worker produced workspace
+		// SCM metadata carrying pull request identity: the reaction
+		// cannot resolve a head, and therefore cannot answer whether it
+		// is current, for a branch with no pull request. Handoff paths
+		// remain eligible even after the claim is released.
+		if params.CIProvider != nil && params.SCMAdapter != nil && workerResult.WorkspacePath != "" {
 			if reactionEnqueueAllowed {
 				scm := workspace.ReadSCMMetadata(workerResult.WorkspacePath, log)
-				if scm.Branch != "" {
+				if scm.PRNumber > 0 && scm.Owner != "" && scm.Repo != "" && scm.Branch != "" {
 					nowCI := time.Now().UTC()
 					if params.NowFunc != nil {
 						nowCI = params.NowFunc().UTC()
@@ -817,13 +821,22 @@ func HandleWorkerExit(state *State, workerResult WorkerResult, params HandleWork
 						LastSSHHost: workerResult.SSHHost,
 						CreatedAt:   nowCI,
 						KindData: &CIReactionData{
-							Branch: scm.Branch,
-							SHA:    scm.SHA,
+							PRNumber: scm.PRNumber,
+							Owner:    scm.Owner,
+							Repo:     scm.Repo,
+							Branch:   scm.Branch,
+							SHA:      scm.SHA,
 						},
 						AgentKind:  entry.AgentKind,
 						RuleName:   entry.RuleName,
 						TemplateID: entry.TemplateID,
 					}
+				} else if scm.Branch != "" {
+					log.Debug("ci watch not seeded: workspace metadata missing pull request identity",
+						slog.Int("pr_number", scm.PRNumber),
+						slog.String("owner", scm.Owner),
+						slog.String("repo", scm.Repo),
+					)
 				}
 			}
 		}

--- a/internal/orchestrator/exit_test.go
+++ b/internal/orchestrator/exit_test.go
@@ -124,6 +124,14 @@ func (m *mockExitStore) DeleteParkedIssue(_ context.Context, issueID string) err
 	return m.deleteParkedErr
 }
 
+// CountWorkerRunsCompletedSince returns a non-nil error, matching the
+// conservative default [unsupportedReactionObservationStore] supplies
+// elsewhere in this package: this reaction-exit test double is not
+// expected to answer an attribution query.
+func (m *mockExitStore) CountWorkerRunsCompletedSince(_ context.Context, _ string, _ time.Time) (int, error) {
+	return 0, errors.New("worker run count is unsupported by this test double")
+}
+
 // --- Test helpers ---
 
 // baseTime is a fixed reference time for deterministic tests.
@@ -2592,7 +2600,7 @@ func TestHandleWorkerExit_ObservationEqualsHandoffStatePerformsHandoffAndEnqueue
 	t.Parallel()
 
 	wsPath := t.TempDir()
-	writeSCMMetadata(t, wsPath, "feature/T-9", "sha9")
+	writePRSCMMetadata(t, wsPath, 77, "acme", "widgets", "feature/T-9", "sha9")
 
 	store := &mockExitStore{}
 	tracker := &mockTrackerAdapter{
@@ -2611,6 +2619,7 @@ func TestHandleWorkerExit_ObservationEqualsHandoffStatePerformsHandoffAndEnqueue
 	params.TerminalStates = []string{"ai:done", "ai:cancelled"}
 	params.HandoffState = "ai:in-review"
 	params.CIProvider = &ciProviderStubExit{}
+	params.SCMAdapter = &scmAdapterStubExit{}
 
 	HandleWorkerExit(state, WorkerResult{
 		IssueID:            "T-9",
@@ -2683,7 +2692,7 @@ func TestHandleWorkerExit_HappyPathUnchangedWithVerificationRead(t *testing.T) {
 	t.Parallel()
 
 	wsPath := t.TempDir()
-	writeSCMMetadata(t, wsPath, "feature/T-11", "sha11")
+	writePRSCMMetadata(t, wsPath, 77, "acme", "widgets", "feature/T-11", "sha11")
 
 	store := &mockExitStore{}
 	tracker := &mockTrackerAdapter{
@@ -2702,6 +2711,7 @@ func TestHandleWorkerExit_HappyPathUnchangedWithVerificationRead(t *testing.T) {
 	params.TerminalStates = []string{"ai:done", "ai:cancelled"}
 	params.HandoffState = "ai:in-review"
 	params.CIProvider = &ciProviderStubExit{}
+	params.SCMAdapter = &scmAdapterStubExit{}
 
 	HandleWorkerExit(state, WorkerResult{
 		IssueID:            "T-11",
@@ -2903,7 +2913,7 @@ func TestHandleWorkerExit_HandoffTransitionSucceeds_PopulatesCIPendingReaction(t
 	t.Parallel()
 
 	wsPath := t.TempDir()
-	writeSCMMetadata(t, wsPath, "feature/HO-C1", "cafebabe")
+	writePRSCMMetadata(t, wsPath, 77, "acme", "widgets", "feature/HO-C1", "cafebabe")
 
 	store := &mockExitStore{}
 	tracker := &mockTrackerAdapter{}
@@ -2913,6 +2923,7 @@ func TestHandleWorkerExit_HandoffTransitionSucceeds_PopulatesCIPendingReaction(t
 	params.HandoffState = "In Review"
 	params.ActiveStates = []string{"In Progress"}
 	params.CIProvider = &ciProviderStubExit{}
+	params.SCMAdapter = &scmAdapterStubExit{}
 
 	HandleWorkerExit(state, WorkerResult{
 		IssueID:       "HO-C1",
@@ -2942,6 +2953,15 @@ func TestHandleWorkerExit_HandoffTransitionSucceeds_PopulatesCIPendingReaction(t
 	if !ok {
 		t.Fatalf("KindData type = %T, want *CIReactionData", ci.KindData)
 	}
+	if ciData.PRNumber != 77 {
+		t.Errorf("CIReactionData.PRNumber = %d, want 77", ciData.PRNumber)
+	}
+	if ciData.Owner != "acme" {
+		t.Errorf("CIReactionData.Owner = %q, want %q", ciData.Owner, "acme")
+	}
+	if ciData.Repo != "widgets" {
+		t.Errorf("CIReactionData.Repo = %q, want %q", ciData.Repo, "widgets")
+	}
 	if ciData.Branch != "feature/HO-C1" {
 		t.Errorf("CIReactionData.Branch = %q, want %q", ciData.Branch, "feature/HO-C1")
 	}
@@ -2954,7 +2974,7 @@ func TestHandleWorkerExit_HandoffTransitionFails_PopulatesCIPendingReaction(t *t
 	t.Parallel()
 
 	wsPath := t.TempDir()
-	writeSCMMetadata(t, wsPath, "feature/HO-C2", "cafebabe")
+	writePRSCMMetadata(t, wsPath, 77, "acme", "widgets", "feature/HO-C2", "cafebabe")
 
 	store := &mockExitStore{}
 	tracker := &mockTrackerAdapter{
@@ -2968,6 +2988,7 @@ func TestHandleWorkerExit_HandoffTransitionFails_PopulatesCIPendingReaction(t *t
 	params.HandoffState = "In Review"
 	params.ActiveStates = []string{"In Progress"}
 	params.CIProvider = &ciProviderStubExit{}
+	params.SCMAdapter = &scmAdapterStubExit{}
 
 	HandleWorkerExit(state, WorkerResult{
 		IssueID:       "HO-C2",
@@ -2991,6 +3012,15 @@ func TestHandleWorkerExit_HandoffTransitionFails_PopulatesCIPendingReaction(t *t
 	ciData, ok := ci.KindData.(*CIReactionData)
 	if !ok {
 		t.Fatalf("KindData type = %T, want *CIReactionData", ci.KindData)
+	}
+	if ciData.PRNumber != 77 {
+		t.Errorf("CIReactionData.PRNumber = %d, want 77", ciData.PRNumber)
+	}
+	if ciData.Owner != "acme" {
+		t.Errorf("CIReactionData.Owner = %q, want %q", ciData.Owner, "acme")
+	}
+	if ciData.Repo != "widgets" {
+		t.Errorf("CIReactionData.Repo = %q, want %q", ciData.Repo, "widgets")
 	}
 	if ciData.Branch != "feature/HO-C2" {
 		t.Errorf("CIReactionData.Branch = %q, want %q", ciData.Branch, "feature/HO-C2")
@@ -4696,12 +4726,13 @@ func TestHandleWorkerExit_CIProvider_PopulatesPendingReaction(t *testing.T) {
 	t.Parallel()
 
 	wsPath := t.TempDir()
-	writeSCMMetadata(t, wsPath, "feature/ci-test", "abc123")
+	writePRSCMMetadata(t, wsPath, 77, "acme", "widgets", "feature/ci-test", "abc123")
 
 	store := &mockExitStore{}
 	state := exitState(t, "CI-ISS-1", nil)
 	params := defaultExitParams(t, store)
 	params.CIProvider = &ciProviderStubExit{}
+	params.SCMAdapter = &scmAdapterStubExit{}
 
 	HandleWorkerExit(state, WorkerResult{
 		IssueID:       "CI-ISS-1",
@@ -4714,11 +4745,20 @@ func TestHandleWorkerExit_CIProvider_PopulatesPendingReaction(t *testing.T) {
 	rkey := ReactionKey("CI-ISS-1", ReactionKindCI)
 	entry, ok := state.PendingReactions[rkey]
 	if !ok {
-		t.Fatal("PendingReactions[CI-ISS-1:ci] missing; want entry after normal exit with branch")
+		t.Fatal("PendingReactions[CI-ISS-1:ci] missing; want entry after normal exit with pull request identity")
 	}
 	ciData, ok := entry.KindData.(*CIReactionData)
 	if !ok {
 		t.Fatal("KindData is not *CIReactionData")
+	}
+	if ciData.PRNumber != 77 {
+		t.Errorf("CIReactionData.PRNumber = %d, want 77", ciData.PRNumber)
+	}
+	if ciData.Owner != "acme" {
+		t.Errorf("CIReactionData.Owner = %q, want %q", ciData.Owner, "acme")
+	}
+	if ciData.Repo != "widgets" {
+		t.Errorf("CIReactionData.Repo = %q, want %q", ciData.Repo, "widgets")
 	}
 	if ciData.Branch != "feature/ci-test" {
 		t.Errorf("CIReactionData.Branch = %q, want %q", ciData.Branch, "feature/ci-test")
@@ -4728,6 +4768,54 @@ func TestHandleWorkerExit_CIProvider_PopulatesPendingReaction(t *testing.T) {
 	}
 	if entry.IssueID != "CI-ISS-1" {
 		t.Errorf("PendingReaction.IssueID = %q, want %q", entry.IssueID, "CI-ISS-1")
+	}
+}
+
+// TestHandleWorkerExit_CIProvider_MissingPRIdentity_NoPendingReaction
+// verifies that worker-exit CI seeding requires the full pull request
+// identity quadruple, one subtest per missing field, mirroring the
+// predicate every sibling PR-backed reaction kind already enforces.
+func TestHandleWorkerExit_CIProvider_MissingPRIdentity_NoPendingReaction(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		prNumber int
+		owner    string
+		repo     string
+		branch   string
+	}{
+		{"zero PRNumber", 0, "acme", "widgets", "feature/x"},
+		{"empty Owner", 77, "", "widgets", "feature/x"},
+		{"empty Repo", 77, "acme", "", "feature/x"},
+		{"empty Branch", 77, "acme", "widgets", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			wsPath := t.TempDir()
+			writePRSCMMetadata(t, wsPath, tt.prNumber, tt.owner, tt.repo, tt.branch, "abc123")
+
+			store := &mockExitStore{}
+			state := exitState(t, "CI-ISS-MISSING", nil)
+			params := defaultExitParams(t, store)
+			params.CIProvider = &ciProviderStubExit{}
+			params.SCMAdapter = &scmAdapterStubExit{}
+
+			HandleWorkerExit(state, WorkerResult{
+				IssueID:       "CI-ISS-MISSING",
+				Identifier:    "CI-ISS-MISSING-ident",
+				ExitKind:      WorkerExitNormal,
+				AgentAdapter:  "mock",
+				WorkspacePath: wsPath,
+			}, params)
+
+			if _, ok := state.PendingReactions[ReactionKey("CI-ISS-MISSING", ReactionKindCI)]; ok {
+				t.Errorf("PendingReactions populated with %s; want absent (full PR identity required)", tt.name)
+			}
+		})
 	}
 }
 
@@ -4762,6 +4850,7 @@ func TestHandleWorkerExit_CIProvider_EmptyWorkspace_NoPendingReaction(t *testing
 	state := exitState(t, "CI-ISS-3", nil)
 	params := defaultExitParams(t, store)
 	params.CIProvider = &ciProviderStubExit{}
+	params.SCMAdapter = &scmAdapterStubExit{}
 
 	// WorkspacePath is empty — worker exited before workspace preparation.
 	HandleWorkerExit(state, WorkerResult{
@@ -4794,6 +4883,7 @@ func TestHandleWorkerExit_CIProvider_NoBranchInSCM_NoPendingReaction(t *testing.
 	state := exitState(t, "CI-ISS-4", nil)
 	params := defaultExitParams(t, store)
 	params.CIProvider = &ciProviderStubExit{}
+	params.SCMAdapter = &scmAdapterStubExit{}
 
 	HandleWorkerExit(state, WorkerResult{
 		IssueID:       "CI-ISS-4",
@@ -4812,12 +4902,13 @@ func TestHandleWorkerExit_CIProvider_SoftStop_NoPendingReaction(t *testing.T) {
 	t.Parallel()
 
 	wsPath := t.TempDir()
-	writeSCMMetadata(t, wsPath, "feature/ci-test", "sha999")
+	writePRSCMMetadata(t, wsPath, 77, "acme", "widgets", "feature/ci-test", "sha999")
 
 	store := &mockExitStore{}
 	state := exitState(t, "CI-ISS-5", nil)
 	params := defaultExitParams(t, store)
 	params.CIProvider = &ciProviderStubExit{}
+	params.SCMAdapter = &scmAdapterStubExit{}
 
 	// SoftStop: claim is released before the CI check; PendingReactions must not be populated.
 	HandleWorkerExit(state, WorkerResult{

--- a/internal/orchestrator/head_change.go
+++ b/internal/orchestrator/head_change.go
@@ -1,0 +1,65 @@
+package orchestrator
+
+import (
+	"context"
+	"time"
+)
+
+// headChangeAttribution is the verdict [classifyHeadChange] returns for an
+// observed pull request head change. There is no third value: the
+// predicate never names a person.
+type headChangeAttribution string
+
+const (
+	// headChangeNotOurs reports that no worker session for the issue ran
+	// between the recorded head and the read, so the change is
+	// positively not the orchestrator's own work.
+	headChangeNotOurs headChangeAttribution = "not_orchestrator"
+
+	// headChangeUnknown reports that the change cannot be positively
+	// attributed away from the orchestrator's own work. This is the
+	// conservative answer on every failure path.
+	headChangeUnknown headChangeAttribution = "unknown"
+)
+
+// classifyHeadChange reports whether an observed pull request head change
+// is positively not the orchestrator's own work, or unknown.
+//
+// Three sources are consulted in order: whether pending.HeadRecordedAt
+// carries a boundary this process recorded, whether the issue holds a
+// live session in state.Running, state.RetryAttempts, or state.Claimed,
+// and whether params.Store.CountWorkerRunsCompletedSince reports a
+// worker session completed inside the interval. Every failure path,
+// including a zero boundary, a live or queued session, and a store
+// error, answers unknown; only the absence of all three answers
+// notOurs. A positive run-history count proves only that a session
+// could have produced the head, never that it did, which is why it
+// answers unknown rather than a stronger claim.
+//
+//nolint:unparam // now completes the predicate's public signature, matching every call site (applyCIEpochTransition, handleMergeConflictDirty) and the interval the caller is reasoning about; the predicate itself bounds its query by pending.HeadRecordedAt rather than by the current instant.
+func classifyHeadChange(state *State, params ReconcileParams, pending *PendingReaction, now time.Time, ctx context.Context) headChangeAttribution {
+	if pending.HeadRecordedAt.IsZero() {
+		return headChangeUnknown
+	}
+
+	issueID := pending.IssueID
+	if state.Running[issueID] != nil {
+		return headChangeUnknown
+	}
+	if state.RetryAttempts[issueID] != nil {
+		return headChangeUnknown
+	}
+	if _, claimed := state.Claimed[issueID]; claimed {
+		return headChangeUnknown
+	}
+
+	count, err := params.Store.CountWorkerRunsCompletedSince(ctx, issueID, pending.HeadRecordedAt)
+	if err != nil {
+		return headChangeUnknown
+	}
+	if count > 0 {
+		return headChangeUnknown
+	}
+
+	return headChangeNotOurs
+}

--- a/internal/orchestrator/head_change_test.go
+++ b/internal/orchestrator/head_change_test.go
@@ -1,0 +1,192 @@
+package orchestrator
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/sortie-ai/sortie/internal/persistence"
+)
+
+// headChangeStore is a minimal ReconcileStore double for classifyHeadChange
+// tests. Only CountWorkerRunsCompletedSince carries configurable behavior;
+// every other method is a no-op, since classifyHeadChange consults no
+// other store method.
+type headChangeStore struct {
+	unsupportedReactionObservationStore
+
+	count int
+	err   error
+
+	calls int
+}
+
+var _ ReconcileStore = (*headChangeStore)(nil)
+
+func (s *headChangeStore) SaveRetryEntry(context.Context, persistence.RetryEntry) error { return nil }
+func (s *headChangeStore) DeleteRetryEntry(context.Context, string) error               { return nil }
+func (s *headChangeStore) AppendRunHistory(_ context.Context, run persistence.RunHistory) (persistence.RunHistory, error) {
+	return run, nil
+}
+func (s *headChangeStore) UpsertReactionFingerprint(context.Context, string, string, string) error {
+	return nil
+}
+func (s *headChangeStore) GetReactionFingerprint(context.Context, string, string) (string, bool, error) {
+	return "", false, nil
+}
+func (s *headChangeStore) MarkReactionDispatched(context.Context, string, string) error { return nil }
+func (s *headChangeStore) DeleteReactionFingerprint(context.Context, string, string) error {
+	return nil
+}
+
+func (s *headChangeStore) CountWorkerRunsCompletedSince(context.Context, string, time.Time) (int, error) {
+	s.calls++
+	return s.count, s.err
+}
+
+// headChangeParams returns a ReconcileParams wired with store for
+// classifyHeadChange tests.
+func headChangeParams(store ReconcileStore) ReconcileParams {
+	return ReconcileParams{
+		Store: store,
+		Ctx:   context.Background(),
+	}
+}
+
+// headChangeBaseTime is a fixed reference time for classifyHeadChange
+// tests.
+var headChangeBaseTime = time.Date(2026, 5, 1, 9, 0, 0, 0, time.UTC)
+
+func TestClassifyHeadChange(t *testing.T) {
+	t.Parallel()
+
+	t.Run("HeadRecordedAt zero answers unknown without querying the store", func(t *testing.T) {
+		t.Parallel()
+
+		state := NewState(5000, 4, nil, AgentTotals{})
+		store := &headChangeStore{count: 0, err: nil}
+		pending := &PendingReaction{IssueID: "ISS-HC-1"}
+
+		got := classifyHeadChange(state, headChangeParams(store), pending, headChangeBaseTime, context.Background())
+
+		if got != headChangeUnknown {
+			t.Errorf("classifyHeadChange() = %q, want %q (zero HeadRecordedAt)", got, headChangeUnknown)
+		}
+		if store.calls != 0 {
+			t.Errorf("CountWorkerRunsCompletedSince calls = %d, want 0 (zero boundary short-circuits)", store.calls)
+		}
+	})
+
+	t.Run("no live session and no qualifying run_history row answers notOurs", func(t *testing.T) {
+		t.Parallel()
+
+		state := NewState(5000, 4, nil, AgentTotals{})
+		store := &headChangeStore{count: 0, err: nil}
+		pending := &PendingReaction{IssueID: "ISS-HC-2", HeadRecordedAt: headChangeBaseTime}
+
+		got := classifyHeadChange(state, headChangeParams(store), pending, headChangeBaseTime.Add(time.Hour), context.Background())
+
+		if got != headChangeNotOurs {
+			t.Errorf("classifyHeadChange() = %q, want %q", got, headChangeNotOurs)
+		}
+		if store.calls != 1 {
+			t.Errorf("CountWorkerRunsCompletedSince calls = %d, want 1", store.calls)
+		}
+	})
+
+	t.Run("a qualifying succeeded run_history row answers unknown", func(t *testing.T) {
+		t.Parallel()
+
+		state := NewState(5000, 4, nil, AgentTotals{})
+		store := &headChangeStore{count: 1, err: nil}
+		pending := &PendingReaction{IssueID: "ISS-HC-3", HeadRecordedAt: headChangeBaseTime}
+
+		got := classifyHeadChange(state, headChangeParams(store), pending, headChangeBaseTime.Add(time.Hour), context.Background())
+
+		if got != headChangeUnknown {
+			t.Errorf("classifyHeadChange() = %q, want %q (positive worker-run count)", got, headChangeUnknown)
+		}
+	})
+
+	t.Run("a live state.Running entry answers unknown without querying the store", func(t *testing.T) {
+		t.Parallel()
+
+		state := NewState(5000, 4, nil, AgentTotals{})
+		state.Running["ISS-HC-4"] = &RunningEntry{Identifier: "ISS-HC-4-ident"}
+		store := &headChangeStore{count: 0, err: nil}
+		pending := &PendingReaction{IssueID: "ISS-HC-4", HeadRecordedAt: headChangeBaseTime}
+
+		got := classifyHeadChange(state, headChangeParams(store), pending, headChangeBaseTime.Add(time.Hour), context.Background())
+
+		if got != headChangeUnknown {
+			t.Errorf("classifyHeadChange() = %q, want %q (live Running entry)", got, headChangeUnknown)
+		}
+		if store.calls != 0 {
+			t.Errorf("CountWorkerRunsCompletedSince calls = %d, want 0 (Running entry short-circuits)", store.calls)
+		}
+	})
+
+	t.Run("a live state.RetryAttempts entry answers unknown without querying the store", func(t *testing.T) {
+		t.Parallel()
+
+		state := NewState(5000, 4, nil, AgentTotals{})
+		state.RetryAttempts["ISS-HC-5"] = &RetryEntry{IssueID: "ISS-HC-5"}
+		store := &headChangeStore{count: 0, err: nil}
+		pending := &PendingReaction{IssueID: "ISS-HC-5", HeadRecordedAt: headChangeBaseTime}
+
+		got := classifyHeadChange(state, headChangeParams(store), pending, headChangeBaseTime.Add(time.Hour), context.Background())
+
+		if got != headChangeUnknown {
+			t.Errorf("classifyHeadChange() = %q, want %q (live RetryAttempts entry)", got, headChangeUnknown)
+		}
+		if store.calls != 0 {
+			t.Errorf("CountWorkerRunsCompletedSince calls = %d, want 0 (RetryAttempts entry short-circuits)", store.calls)
+		}
+	})
+
+	t.Run("a state.Claimed entry answers unknown without querying the store", func(t *testing.T) {
+		t.Parallel()
+
+		state := NewState(5000, 4, nil, AgentTotals{})
+		state.Claimed["ISS-HC-6"] = struct{}{}
+		store := &headChangeStore{count: 0, err: nil}
+		pending := &PendingReaction{IssueID: "ISS-HC-6", HeadRecordedAt: headChangeBaseTime}
+
+		got := classifyHeadChange(state, headChangeParams(store), pending, headChangeBaseTime.Add(time.Hour), context.Background())
+
+		if got != headChangeUnknown {
+			t.Errorf("classifyHeadChange() = %q, want %q (Claimed entry)", got, headChangeUnknown)
+		}
+		if store.calls != 0 {
+			t.Errorf("CountWorkerRunsCompletedSince calls = %d, want 0 (Claimed entry short-circuits)", store.calls)
+		}
+	})
+
+	t.Run("a store error answers unknown", func(t *testing.T) {
+		t.Parallel()
+
+		state := NewState(5000, 4, nil, AgentTotals{})
+		store := &headChangeStore{err: errors.New("db unavailable")}
+		pending := &PendingReaction{IssueID: "ISS-HC-7", HeadRecordedAt: headChangeBaseTime}
+
+		got := classifyHeadChange(state, headChangeParams(store), pending, headChangeBaseTime.Add(time.Hour), context.Background())
+
+		if got != headChangeUnknown {
+			t.Errorf("classifyHeadChange() = %q, want %q (store error)", got, headChangeUnknown)
+		}
+	})
+
+	t.Run("the shared unsupportedReactionObservationStore default answers unknown, never notOurs", func(t *testing.T) {
+		t.Parallel()
+
+		var defaultStore unsupportedReactionObservationStore
+		count, err := defaultStore.CountWorkerRunsCompletedSince(context.Background(), "any", headChangeBaseTime)
+		if err == nil {
+			t.Error("unsupportedReactionObservationStore.CountWorkerRunsCompletedSince returned nil error, want non-nil (must not default to notOurs in every unrelated test)")
+		}
+		if count != 0 {
+			t.Errorf("unsupportedReactionObservationStore.CountWorkerRunsCompletedSince count = %d, want 0", count)
+		}
+	})
+}

--- a/internal/orchestrator/merge_completion_reconcile_test.go
+++ b/internal/orchestrator/merge_completion_reconcile_test.go
@@ -2,6 +2,7 @@ package orchestrator
 
 import (
 	"context"
+	"errors"
 	"path/filepath"
 	"strings"
 	"sync/atomic"
@@ -277,6 +278,14 @@ func (s *mgcStoreFake) MarkReactionObservationDispatched(ctx context.Context, is
 	rec.dispatched = true
 	s.fingerprints[key] = rec
 	return nil
+}
+
+// CountWorkerRunsCompletedSince returns a non-nil error, matching the
+// conservative default [unsupportedReactionObservationStore] supplies
+// elsewhere in this package: this merge-completion test double is not
+// expected to answer an attribution query.
+func (s *mgcStoreFake) CountWorkerRunsCompletedSince(context.Context, string, time.Time) (int, error) {
+	return 0, errors.New("worker run count is unsupported by this test double")
 }
 
 // has reports the fingerprint record for the issue's merge-completion

--- a/internal/orchestrator/merge_conflict_reconcile.go
+++ b/internal/orchestrator/merge_conflict_reconcile.go
@@ -137,10 +137,14 @@ func reconcileMergeConflicts(state *State, params ReconcileParams, log *slog.Log
 
 // handleMergeConflictDirty processes a PR that the provider reports as
 // conflicted. It applies the precondition guards (empty head SHA, empty
-// base branch), deduplicates on the head SHA, increments the per-episode
-// attempt counter, and either dispatches a rebase continuation or
-// escalates when the new conflicting head pushes the episode strictly over
-// the retry budget. The increment-then-strict-over-limit ordering mirrors
+// base branch), deduplicates on the head SHA, resets the per-episode
+// attempt counter when the new conflicting head is positively not the
+// orchestrator's own work, increments the counter, and either dispatches
+// a rebase continuation or escalates when the new conflicting head
+// pushes the episode strictly over the retry budget. The
+// dedup-before-attribution-before-increment ordering means a same-head
+// re-observation returns before either the attribution query or the
+// increment runs. The increment-then-strict-over-limit ordering mirrors
 // [handleCIFailure].
 func handleMergeConflictDirty(
 	state *State,
@@ -197,7 +201,9 @@ func handleMergeConflictDirty(
 	}
 
 	// Head-SHA dedup before the increment so a same-head re-observation
-	// never re-increments the per-episode counter.
+	// never re-increments the per-episode counter, and before the
+	// attribution query below so a same-head re-observation never
+	// reaches run_history either.
 	storedFP, dispatched, fpErr := params.Store.GetReactionFingerprint(ctx, pending.IssueID, ReactionKindMergeConflict)
 	if fpErr != nil {
 		log.Warn("failed to get merge conflict reaction fingerprint, proceeding without dedup",
@@ -211,6 +217,16 @@ func handleMergeConflictDirty(
 		)
 		return
 	}
+
+	// A new conflicting head this reaction has not dispatched for.
+	// Reset the per-episode counter first when the change is positively
+	// not the orchestrator's own work, so a person's push yields
+	// attempts == 1 rather than continuing to climb across successive
+	// conflicting heads regardless of who produced them.
+	if classifyHeadChange(state, params, pending, now, ctx) == headChangeNotOurs {
+		delete(state.ReactionAttempts, rkey)
+	}
+	pending.HeadRecordedAt = now
 
 	// Per-episode increment for this new conflicting head, then the strict
 	// over-limit cap. The increment happens before the cap so the new

--- a/internal/orchestrator/merge_conflict_reconcile_test.go
+++ b/internal/orchestrator/merge_conflict_reconcile_test.go
@@ -1265,3 +1265,141 @@ func TestReconcileMergeConflicts_FreeSlotControlDispatches(t *testing.T) {
 		t.Errorf("MarkReactionDispatched calls = %d, want 1", store.markDispatchedCalls)
 	}
 }
+
+// --- Attribution-gated per-episode reset ---
+
+// mcAttributionStore wraps a *statefulFingerprintStore and overrides
+// CountWorkerRunsCompletedSince with a configurable result, so a test can
+// force a specific classifyHeadChange verdict while still exercising the
+// real fingerprint upsert/get/dispatch semantics for the dedup path.
+type mcAttributionStore struct {
+	*statefulFingerprintStore
+
+	countConfigured bool
+	count           int
+	countErr        error
+	countCalls      int
+}
+
+var _ ReconcileStore = (*mcAttributionStore)(nil)
+
+func (s *mcAttributionStore) CountWorkerRunsCompletedSince(ctx context.Context, issueID string, since time.Time) (int, error) {
+	s.countCalls++
+	if !s.countConfigured {
+		return s.statefulFingerprintStore.CountWorkerRunsCompletedSince(ctx, issueID, since)
+	}
+	return s.count, s.countErr
+}
+
+// TestHandleMergeConflictDirty_AttributionGatedReset covers a new
+// conflicting head classified positively not the orchestrator's own work
+// resetting the per-episode counter before incrementing, so the reported
+// attempt count is 1, and a head classified unknown leaving the counter
+// to continue from its prior value. HeadRecordedAt is pre-seeded to
+// simulate a boundary this process already recorded, since a live
+// pending entry's own dirty-branch outcome always dispatches or
+// escalates and is never itself re-enqueued.
+func TestHandleMergeConflictDirty_AttributionGatedReset(t *testing.T) {
+	t.Parallel()
+
+	t.Run("a head change positively not the orchestrator's own work resets before incrementing", func(t *testing.T) {
+		t.Parallel()
+
+		const issueID = "MC-ATTR-NOTOURS"
+		state := stateWithMergeConflict(t, issueID, 10)
+		rkey := ReactionKey(issueID, ReactionKindMergeConflict)
+		state.ReactionAttempts[rkey] = 5 // a prior-episode counter value
+		entry := state.PendingReactions[rkey]
+		entry.HeadRecordedAt = mcBaseTime.Add(-time.Hour)
+		// No live session may be running for the predicate to reach the
+		// store query at all.
+		delete(state.Claimed, issueID)
+
+		inner := newStatefulFingerprintStore()
+		inner.fingerprints[issueID+":"+ReactionKindMergeConflict] = fingerprintRecord{
+			fingerprint: buildMergeConflictFingerprint("head-old"), dispatched: true,
+		}
+		store := &mcAttributionStore{statefulFingerprintStore: inner, countConfigured: true, count: 0}
+		metrics := newMergeConflictMetricsSpy()
+		scm := &mergeabilitySCM{fn: func() (domain.PRMergeStatus, error) {
+			return dirtyStatus("head-new", "main"), nil
+		}}
+		params := mergeConflictParams(store, scm, nil)
+		params.MergeConflictConfig.MaxRetries = 10 // isolates the reset from an incidental budget exhaustion
+
+		reconcileMergeConflicts(state, params, discardLogger(), context.Background(), metrics)
+
+		if got := state.ReactionAttempts[rkey]; got != 1 {
+			t.Errorf("ReactionAttempts[%s] = %d, want 1 (reset from 5 then incremented once)", rkey, got)
+		}
+	})
+
+	t.Run("a head change classified unknown continues from the prior value", func(t *testing.T) {
+		t.Parallel()
+
+		const issueID = "MC-ATTR-UNKNOWN"
+		state := stateWithMergeConflict(t, issueID, 10)
+		rkey := ReactionKey(issueID, ReactionKindMergeConflict)
+		state.ReactionAttempts[rkey] = 5
+		entry := state.PendingReactions[rkey]
+		entry.HeadRecordedAt = mcBaseTime.Add(-time.Hour)
+		delete(state.Claimed, issueID)
+
+		inner := newStatefulFingerprintStore()
+		inner.fingerprints[issueID+":"+ReactionKindMergeConflict] = fingerprintRecord{
+			fingerprint: buildMergeConflictFingerprint("head-old"), dispatched: true,
+		}
+		// countConfigured left false: the embedded default answers
+		// unknown via a non-nil error, matching every failure path.
+		store := &mcAttributionStore{statefulFingerprintStore: inner}
+		metrics := newMergeConflictMetricsSpy()
+		scm := &mergeabilitySCM{fn: func() (domain.PRMergeStatus, error) {
+			return dirtyStatus("head-new", "main"), nil
+		}}
+		params := mergeConflictParams(store, scm, nil)
+		params.MergeConflictConfig.MaxRetries = 10 // isolates the non-reset from an incidental budget exhaustion
+
+		reconcileMergeConflicts(state, params, discardLogger(), context.Background(), metrics)
+
+		if got := state.ReactionAttempts[rkey]; got != 6 {
+			t.Errorf("ReactionAttempts[%s] = %d, want 6 (continues from 5, incremented once)", rkey, got)
+		}
+	})
+}
+
+// TestHandleMergeConflictDirty_SameHeadDedupPrecedesAttributionQuery
+// covers a same-head re-observation still returning before the counter
+// increment, and now also before the attribution query, so no
+// head-unchanged pass reaches the worker-run-count store method.
+func TestHandleMergeConflictDirty_SameHeadDedupPrecedesAttributionQuery(t *testing.T) {
+	t.Parallel()
+
+	const issueID = "MC-ATTR-DEDUP"
+	state := stateWithMergeConflict(t, issueID, 10)
+	rkey := ReactionKey(issueID, ReactionKindMergeConflict)
+	state.ReactionAttempts[rkey] = 5
+	entry := state.PendingReactions[rkey]
+	entry.HeadRecordedAt = mcBaseTime.Add(-time.Hour)
+
+	inner := newStatefulFingerprintStore()
+	// The stored fingerprint already matches the head this tick
+	// observes, and it was already dispatched for.
+	inner.fingerprints[issueID+":"+ReactionKindMergeConflict] = fingerprintRecord{
+		fingerprint: buildMergeConflictFingerprint("head-same"), dispatched: true,
+	}
+	store := &mcAttributionStore{statefulFingerprintStore: inner}
+	metrics := newMergeConflictMetricsSpy()
+	scm := &mergeabilitySCM{fn: func() (domain.PRMergeStatus, error) {
+		return dirtyStatus("head-same", "main"), nil
+	}}
+	params := mergeConflictParams(store, scm, nil)
+
+	reconcileMergeConflicts(state, params, discardLogger(), context.Background(), metrics)
+
+	if got := state.ReactionAttempts[rkey]; got != 5 {
+		t.Errorf("ReactionAttempts[%s] = %d, want unchanged 5 (dedup must not increment)", rkey, got)
+	}
+	if store.countCalls != 0 {
+		t.Errorf("CountWorkerRunsCompletedSince calls = %d, want 0 (dedup precedes the attribution query)", store.countCalls)
+	}
+}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -51,6 +51,7 @@ type OrchestratorStore interface {
 		observedAt time.Time,
 	) (persistence.ReactionObservation, error)
 	MarkReactionObservationDispatched(ctx context.Context, issueID, kind, fingerprint string) error
+	CountWorkerRunsCompletedSince(ctx context.Context, issueID string, since time.Time) (int, error)
 	LatestRunCompletionByIdentifier(ctx context.Context, identifiers []string) (map[string]string, error)
 	UpsertParkedIssue(ctx context.Context, entry persistence.ParkedIssue) error
 	DeleteParkedIssue(ctx context.Context, issueID string) error
@@ -561,7 +562,7 @@ func (o *Orchestrator) handleTick(ctx context.Context) {
 		Metrics:                           o.metrics,
 		CIProvider:                        o.ciProvider,
 		CIFeedback:                        cfg.CIFeedback,
-		CIPendingTTL:                      ciPendingDefaultTTL,
+		CIWatchWindow:                     time.Duration(cfg.CIFeedback.WatchWindowMS) * time.Millisecond,
 		SCMAdapter:                        o.scmAdapter,
 		ReviewConfig:                      o.reviewConfig,
 		ReviewPendingTTL:                  reviewPendingDefaultTTL,

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -2807,10 +2807,11 @@ func TestOrchestratorDynamicConfigReload(t *testing.T) {
 			t.Fatal("PendingReactions entry dropped on the first tick; want kept (well inside the 24h window)")
 		}
 
-		// Reload with a watch window smaller than the wall-clock gap to
-		// the next tick, and let that gap actually elapse; the reconcile
-		// pass must pick up the new bound on the very next tick.
-		time.Sleep(20 * time.Millisecond)
+		// Age the entry deterministically rather than sleeping for a
+		// wall-clock gap: push the recorded head an hour into the past,
+		// then reload a window far smaller than that. The assertion then
+		// tests the reload path itself instead of racing a loaded runner.
+		state.PendingReactions[rkey].HeadRecordedAt = time.Now().UTC().Add(-time.Hour)
 		cfg.CIFeedback.WatchWindowMS = 5
 		wm.setConfig(cfg)
 

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -2738,6 +2738,88 @@ func TestOrchestratorDynamicConfigReload(t *testing.T) {
 			t.Errorf("observer calls = %d, want 1", got)
 		}
 	})
+
+	// Test Case C: reactions.ci_failure.watch_window_ms takes effect on
+	// the next reconcile tick without a process restart, since
+	// cfg.CIFeedback is rebuilt from o.workflowManager.Config() every
+	// tick.
+	t.Run("ci_watch_window_change", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := lifecycleConfig(t.TempDir())
+		cfg.CIFeedback = config.CIFeedbackConfig{
+			Kind:          "mock",
+			MaxRetries:    2,
+			Escalation:    "label",
+			WatchWindowMS: 24 * 3600 * 1000, // 24h: comfortably survives the first tick
+		}
+
+		wm := &stubWorkflowManager{config: cfg}
+		regs := passingPreflightRegistries()
+		obs := &stubObserver{}
+		state := NewState(cfg.Polling.IntervalMS, cfg.Agent.MaxConcurrentAgents, nil, AgentTotals{})
+
+		const issueID = "CI-RELOAD-1"
+		rkey := ReactionKey(issueID, ReactionKindCI)
+		state.PendingReactions[rkey] = &PendingReaction{
+			IssueID:    issueID,
+			Identifier: issueID + "-ident",
+			DisplayID:  issueID + "-ident",
+			Kind:       ReactionKindCI,
+			CreatedAt:  time.Now().UTC(),
+			KindData:   &CIReactionData{PRNumber: 1, Owner: "acme", Repo: "widgets", Branch: "main"},
+		}
+
+		tracker := &candidateTrackerAdapter{
+			mockTrackerAdapter: &mockTrackerAdapter{},
+			fetchCandidatesFn: func(_ context.Context) ([]domain.Issue, error) {
+				return nil, nil
+			},
+		}
+		ci := &mockCIProvider{result: domain.CIResult{Status: domain.CIStatusPassing}}
+		scm := defaultCISCM()
+
+		o := NewOrchestrator(OrchestratorParams{
+			State:           state,
+			Logger:          discardLogger(),
+			TrackerAdapter:  tracker,
+			AgentAdapter:    &mockAgentAdapter{},
+			WorkflowManager: wm,
+			Store:           &stubStore{},
+			CIProvider:      ci,
+			SCMAdapter:      scm,
+			PreflightParams: PreflightParams{
+				ReloadWorkflow:  func() error { return nil },
+				ConfigFunc:      wm.Config,
+				TrackerRegistry: regs.TrackerRegistry,
+				AgentRegistry:   regs.AgentRegistry,
+			},
+			Observers: []Observer{obs},
+		})
+
+		// The first tick observes the head for the first time (the
+		// fingerprint store has no prior row), which records
+		// HeadRecordedAt as the entry's age basis; a passing status
+		// keeps the watch open per the current-head contract.
+		o.handleTick(context.Background())
+
+		if _, ok := state.PendingReactions[rkey]; !ok {
+			t.Fatal("PendingReactions entry dropped on the first tick; want kept (well inside the 24h window)")
+		}
+
+		// Reload with a watch window smaller than the wall-clock gap to
+		// the next tick, and let that gap actually elapse; the reconcile
+		// pass must pick up the new bound on the very next tick.
+		time.Sleep(20 * time.Millisecond)
+		cfg.CIFeedback.WatchWindowMS = 5
+		wm.setConfig(cfg)
+
+		o.handleTick(context.Background())
+
+		if _, ok := state.PendingReactions[rkey]; ok {
+			t.Error("PendingReactions entry kept after the watch window was reloaded to 5ms; want dropped without a restart")
+		}
+	})
 }
 
 // --- TestOrchestratorDynamicConfigReloadWithFileWatcher ---

--- a/internal/orchestrator/reconcile.go
+++ b/internal/orchestrator/reconcile.go
@@ -30,6 +30,7 @@ type ReconcileStore interface {
 		observedAt time.Time,
 	) (persistence.ReactionObservation, error)
 	MarkReactionObservationDispatched(ctx context.Context, issueID, kind, fingerprint string) error
+	CountWorkerRunsCompletedSince(ctx context.Context, issueID string, since time.Time) (int, error)
 }
 
 var _ ReconcileStore = (*persistence.Store)(nil)
@@ -90,14 +91,11 @@ type ReconcileParams struct {
 	// Only read when CIProvider is non-nil.
 	CIFeedback config.CIFeedbackConfig
 
-	// CIPendingTTL is the maximum age of a PendingReaction entry before
-	// it is dropped and a warning is logged. Protects against indefinite
-	// spinning when the CI provider is unreachable and no new worker exit
-	// refreshes the entry. Zero or negative disables TTL enforcement
-	// entirely. Production callers should set this to a positive value
-	// (e.g. [ciPendingDefaultTTL]); test helpers that do not set NowFunc
-	// may leave it zero to preserve legacy behavior.
-	CIPendingTTL time.Duration
+	// CIWatchWindow bounds the age of a CI PendingReaction entry, measured
+	// from the last recorded head and falling back to the entry's
+	// creation time before any head is recorded. Zero or negative
+	// disables the bound. Supplied from reactions.ci_failure.watch_window_ms.
+	CIWatchWindow time.Duration
 
 	// SCMAdapter provides review comment fetching. When non-nil, the
 	// reconcile loop polls review comments for issues with PR metadata.

--- a/internal/orchestrator/reconcile_test.go
+++ b/internal/orchestrator/reconcile_test.go
@@ -23,7 +23,9 @@ import (
 
 // unsupportedReactionObservationStore lets unrelated store doubles satisfy
 // the compile-time interface while failing loudly if a merge-completion test
-// accidentally uses a double without real observation semantics.
+// accidentally uses a double without real observation semantics. It also
+// supplies a safe, conservative default for CountWorkerRunsCompletedSince
+// for any store double that does not implement its own.
 type unsupportedReactionObservationStore struct{}
 
 func (unsupportedReactionObservationStore) UpsertReactionObservation(
@@ -36,6 +38,15 @@ func (unsupportedReactionObservationStore) UpsertReactionObservation(
 
 func (unsupportedReactionObservationStore) MarkReactionObservationDispatched(context.Context, string, string, string) error {
 	panic("reaction observation persistence is unsupported by this test double")
+}
+
+// CountWorkerRunsCompletedSince returns a non-nil error rather than
+// (0, nil), so a store double that does not override this method drives
+// classifyHeadChange to the conservative "unknown" verdict instead of
+// silently resolving "notOurs" for every test that never considered
+// attribution.
+func (unsupportedReactionObservationStore) CountWorkerRunsCompletedSince(context.Context, string, time.Time) (int, error) {
+	return 0, errors.New("worker run count is unsupported by this test double")
 }
 
 // mockReconcileStore records calls to ReconcileStore methods and returns

--- a/internal/orchestrator/recovery.go
+++ b/internal/orchestrator/recovery.go
@@ -346,7 +346,7 @@ func recoverPendingReactionKinds(
 		}
 	}
 
-	if params.CIProvider != nil && meta.Branch != "" {
+	if params.CIProvider != nil && params.SCMAdapter != nil && meta.PRNumber > 0 && meta.Owner != "" && meta.Repo != "" && meta.Branch != "" {
 		key := ReactionKey(run.IssueID, ReactionKindCI)
 		if _, exists := state.PendingReactions[key]; !exists {
 			state.PendingReactions[key] = &PendingReaction{
@@ -356,9 +356,18 @@ func recoverPendingReactionKinds(
 				Attempt:    run.Attempt,
 				Kind:       ReactionKindCI,
 				CreatedAt:  now,
+				// HeadRecordedAt is left zero: a head recorded by a
+				// previous process cannot bound this process's
+				// attribution query, so the first pass after a restart
+				// records a baseline and classifies it unknown rather
+				// than resetting a counter against a boundary this
+				// process never observed.
 				KindData: &CIReactionData{
-					Branch: meta.Branch,
-					SHA:    meta.SHA,
+					PRNumber: meta.PRNumber,
+					Owner:    meta.Owner,
+					Repo:     meta.Repo,
+					Branch:   meta.Branch,
+					SHA:      meta.SHA,
 				},
 				AgentKind:  run.AgentAdapter,
 				RuleName:   run.RuleName,

--- a/internal/orchestrator/recovery_test.go
+++ b/internal/orchestrator/recovery_test.go
@@ -689,6 +689,9 @@ func TestRecoverPendingReactions_RecreatesCIAfterRestart(t *testing.T) {
 		Branch:   "feature/ci-fix",
 		SHA:      "deadbeef",
 		PushedAt: freshSCMTime(1),
+		PRNumber: 55,
+		Owner:    "acme",
+		Repo:     "widgets",
 	})
 
 	tracker := &recoveryTrackerStub{states: map[string]string{"ISS-2": "In Review"}}
@@ -713,15 +716,84 @@ func TestRecoverPendingReactions_RecreatesCIAfterRestart(t *testing.T) {
 	if !ok {
 		t.Fatalf("KindData type = %T, want *CIReactionData", pr.KindData)
 	}
+	if ci.PRNumber != 55 {
+		t.Errorf("CIReactionData.PRNumber = %d, want 55", ci.PRNumber)
+	}
+	if ci.Owner != "acme" {
+		t.Errorf("CIReactionData.Owner = %q, want %q", ci.Owner, "acme")
+	}
+	if ci.Repo != "widgets" {
+		t.Errorf("CIReactionData.Repo = %q, want %q", ci.Repo, "widgets")
+	}
 	if ci.Branch != "feature/ci-fix" {
 		t.Errorf("CIReactionData.Branch = %q, want %q", ci.Branch, "feature/ci-fix")
 	}
 	if ci.SHA != "deadbeef" {
 		t.Errorf("CIReactionData.SHA = %q, want %q", ci.SHA, "deadbeef")
 	}
+	// A head recorded by a previous process cannot bound this
+	// process's attribution query, so a recovered entry always starts
+	// with a zero boundary.
+	if !pr.HeadRecordedAt.IsZero() {
+		t.Errorf("PendingReaction.HeadRecordedAt = %v, want zero on a recovered entry", pr.HeadRecordedAt)
+	}
 	// Issue must not be claimed.
 	if _, claimed := state.Claimed["ISS-2"]; claimed {
 		t.Error("ISS-2 found in state.Claimed after CI recovery, want not claimed")
+	}
+}
+
+// TestRecoverPendingReactions_CIMissingPRIdentity_NoPendingReaction
+// verifies that startup recovery of the CI kind requires the full pull
+// request identity quadruple, mirroring the predicate every sibling
+// PR-backed reaction kind already enforces, one subtest per missing
+// field.
+func TestRecoverPendingReactions_CIMissingPRIdentity_NoPendingReaction(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		prNumber int
+		owner    string
+		repo     string
+		branch   string
+	}{
+		{"zero PRNumber", 0, "acme", "widgets", "feature/ci-fix"},
+		{"empty Owner", 55, "", "widgets", "feature/ci-fix"},
+		{"empty Repo", 55, "acme", "", "feature/ci-fix"},
+		{"empty Branch", 55, "acme", "widgets", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			wsRoot := t.TempDir()
+			writeRecoverySCM(t, wsRoot, "PROJ-CINOPR", domain.SCMMetadata{
+				Branch:   tt.branch,
+				SHA:      "deadbeef",
+				PushedAt: freshSCMTime(1),
+				PRNumber: tt.prNumber,
+				Owner:    tt.owner,
+				Repo:     tt.repo,
+			})
+
+			tracker := &recoveryTrackerStub{states: map[string]string{"ISS-CINOPR": "In Review"}}
+			state := NewState(5000, 4, nil, AgentTotals{})
+			run := freshRun("ISS-CINOPR", "PROJ-CINOPR", "", 1)
+			params := defaultRecoveryParams(wsRoot, tracker)
+
+			result, err := RecoverPendingReactions(context.Background(), state, []persistence.RunHistory{run}, params)
+			if err != nil {
+				t.Fatalf("RecoverPendingReactions: %v", err)
+			}
+			if result.CIRecovered != 0 {
+				t.Errorf("CIRecovered = %d, want 0 for %s", result.CIRecovered, tt.name)
+			}
+			if _, ok := state.PendingReactions[ReactionKey("ISS-CINOPR", ReactionKindCI)]; ok {
+				t.Errorf("PendingReactions populated with %s; want absent (full PR identity required)", tt.name)
+			}
+		})
 	}
 }
 

--- a/internal/orchestrator/retry_slot_test.go
+++ b/internal/orchestrator/retry_slot_test.go
@@ -192,9 +192,9 @@ func retrySlotParams(store ReconcileStore, ci domain.CIStatusProvider, scm domai
 		Ctx:               context.Background(),
 		Logger:            discardLogger(),
 
-		CIProvider:   ci,
-		CIFeedback:   config.CIFeedbackConfig{MaxRetries: 2, Escalation: "label", EscalationLabel: "needs-human"},
-		CIPendingTTL: ciPendingDefaultTTL,
+		CIProvider:    ci,
+		CIFeedback:    config.CIFeedbackConfig{MaxRetries: 2, Escalation: "label", EscalationLabel: "needs-human"},
+		CIWatchWindow: 30 * time.Minute,
 
 		SCMAdapter:       scm,
 		ReviewConfig:     ReviewReactionConfig{Escalation: "label", EscalationLabel: "needs-human", PollIntervalMS: 60_000, DebounceMS: 30_000, MaxContinuationTurns: 3},
@@ -220,7 +220,7 @@ func retrySlotCIPending(issueID string, createdAt time.Time) *PendingReaction {
 		Attempt:    1,
 		Kind:       ReactionKindCI,
 		CreatedAt:  createdAt,
-		KindData:   &CIReactionData{Branch: "feature/x"},
+		KindData:   &CIReactionData{PRNumber: 50, Owner: "acme", Repo: "widgets", Branch: "feature/x"},
 	}
 }
 
@@ -288,6 +288,7 @@ func TestRetrySlot_LabelReviewDefersToCI(t *testing.T) {
 	store := newRetrySlotStore()
 	ci := &retrySlotCI{result: domain.CIResult{Status: domain.CIStatusFailing, FailingCount: 1}}
 	scm := &retrySlotSCM{
+		mergeStatus: domain.PRMergeStatus{HeadSHA: "ci-sha-1"},
 		labelEvents: []domain.LabelEvent{labelEvent("1", "sortie:review", "alice", true, now.Add(-1*time.Minute))},
 	}
 	params := retrySlotParams(store, ci, scm, nil, func() time.Time { return now })
@@ -485,6 +486,7 @@ func TestRetrySlot_LivenessWithHandoffConfigured(t *testing.T) {
 	store := newRetrySlotStore()
 	ci := &retrySlotCI{result: domain.CIResult{Status: domain.CIStatusFailing, FailingCount: 1}}
 	scm := &retrySlotSCM{
+		mergeStatus: domain.PRMergeStatus{HeadSHA: "ci-sha-liveness"},
 		labelEvents: []domain.LabelEvent{labelEvent("1", "sortie:review", "alice", true, now.Add(-1*time.Minute))},
 	}
 	tracker := &mockReconcileTracker{states: map[string]string{}}
@@ -572,7 +574,8 @@ func TestRetrySlot_LivenessNoHandoffConfigured(t *testing.T) {
 
 	store := newRetrySlotStore()
 	ci := &retrySlotCI{result: domain.CIResult{Status: domain.CIStatusFailing, FailingCount: 1}}
-	params := retrySlotParams(store, ci, &retrySlotSCM{}, nil, func() time.Time { return now })
+	scm := &retrySlotSCM{mergeStatus: domain.PRMergeStatus{HeadSHA: "ci-sha-2"}}
+	params := retrySlotParams(store, ci, scm, nil, func() time.Time { return now })
 
 	// Tick while the continuation worker runs: ci takes the free slot.
 	ReconcileRunningIssues(state, params)
@@ -652,8 +655,9 @@ func TestRetrySlot_DeferralRecordReportsContinuationForEmptyKindIncumbent(t *tes
 
 	store := newRetrySlotStore()
 	ci := &retrySlotCI{result: domain.CIResult{Status: domain.CIStatusFailing, FailingCount: 1}}
+	scm := &retrySlotSCM{mergeStatus: domain.PRMergeStatus{HeadSHA: "ci-sha-3"}}
 	handler := &sweepLogHandler{}
-	params := retrySlotParams(store, ci, &retrySlotSCM{}, nil, func() time.Time { return now })
+	params := retrySlotParams(store, ci, scm, nil, func() time.Time { return now })
 	params.Logger = slog.New(handler)
 
 	ReconcileRunningIssues(state, params)
@@ -682,30 +686,60 @@ func TestRetrySlot_TTLRefreshOnArbitrationDeferral(t *testing.T) {
 		state.Claimed[issueID] = struct{}{}
 		state.RetryAttempts[issueID] = &RetryEntry{IssueID: issueID, Attempt: 1, ReactionKind: ReactionKindLabelFix}
 		ciKey := ReactionKey(issueID, ReactionKindCI)
+		// CreatedAt is deliberately far in the past: an arbitration
+		// deferral no longer refreshes it, so only the head-recorded
+		// boundary set on the first pass keeps the entry alive past
+		// this starting point.
 		state.PendingReactions[ciKey] = retrySlotCIPending(issueID, tick1.Add(-29*time.Minute))
 
 		store := newRetrySlotStore()
 		ci := &retrySlotCI{result: domain.CIResult{Status: domain.CIStatusFailing, FailingCount: 1}}
+		scm := &retrySlotSCM{mergeStatus: domain.PRMergeStatus{HeadSHA: "ci-sha-ttl"}}
 		now := tick1
 		handler := &sweepLogHandler{}
-		params := retrySlotParams(store, ci, &retrySlotSCM{}, nil, func() time.Time { return now })
+		params := retrySlotParams(store, ci, scm, nil, func() time.Time { return now })
 		params.Logger = slog.New(handler)
 
-		ticks := []time.Time{tick1, tick1.Add(15 * time.Minute), tick1.Add(32 * time.Minute)}
-		for _, tickNow := range ticks {
+		var recordedCreatedAt time.Time
+		var recordedHeadAt time.Time
+		ticks := []time.Time{tick1, tick1.Add(15 * time.Minute)}
+		for i, tickNow := range ticks {
 			now = tickNow
 			ReconcileRunningIssues(state, params)
 
 			entry, ok := state.PendingReactions[ciKey]
 			if !ok {
-				t.Fatalf("ci pending entry dropped at tick %v; want re-enqueued", tickNow)
+				t.Fatalf("ci pending entry dropped at tick %v; want re-enqueued (still inside the watch window)", tickNow)
 			}
-			if !entry.CreatedAt.Equal(tickNow) {
-				t.Errorf("CreatedAt at tick %v = %v, want %v", tickNow, entry.CreatedAt, tickNow)
+			if i == 0 {
+				recordedCreatedAt = entry.CreatedAt
+				recordedHeadAt = entry.HeadRecordedAt
+				if recordedHeadAt.IsZero() {
+					t.Fatal("HeadRecordedAt still zero after the first pass; want set by the first epoch transition")
+				}
+			} else {
+				if !entry.CreatedAt.Equal(recordedCreatedAt) {
+					t.Errorf("CreatedAt at tick %v = %v, want unchanged %v (an arbitration deferral must not refresh it)", tickNow, entry.CreatedAt, recordedCreatedAt)
+				}
+				if !entry.HeadRecordedAt.Equal(recordedHeadAt) {
+					t.Errorf("HeadRecordedAt at tick %v = %v, want unchanged %v (the head never changed)", tickNow, entry.HeadRecordedAt, recordedHeadAt)
+				}
 			}
 		}
-		if handler.countByMessage("ci pending entry exceeded ttl, dropping") != 0 {
-			t.Error("TTL-drop Warn emitted despite the CreatedAt refresh; want none")
+		if handler.countByMessage("ci watch window elapsed, dropping") != 0 {
+			t.Error("watch-window drop logged while still inside the window; want none")
+		}
+
+		// Past the watch window measured from the recorded head, the
+		// entry drops even though it has been deferring the whole time.
+		now = tick1.Add(32 * time.Minute)
+		ReconcileRunningIssues(state, params)
+
+		if _, ok := state.PendingReactions[ciKey]; ok {
+			t.Error("ci pending entry present past the watch window measured from HeadRecordedAt; want dropped")
+		}
+		if handler.countByMessage("ci watch window elapsed, dropping") != 1 {
+			t.Errorf(`"ci watch window elapsed, dropping" logged %d times, want 1`, handler.countByMessage("ci watch window elapsed, dropping"))
 		}
 	})
 

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -456,14 +456,28 @@ type PendingReaction struct {
 	// CreatedAt is the UTC time the entry was created.
 	CreatedAt time.Time
 
-	// PendingAttempts is the number of times the entry has been
-	// re-enqueued without a definitive result (pending status or
-	// transient fetch error). Used to compute exponential backoff.
+	// PendingAttempts is the count of consecutive passes that reached no
+	// dispatch. Used to compute exponential backoff.
 	PendingAttempts int
 
 	// PendingRetryAt is the earliest UTC time at which the reconcile
 	// function should poll again. Zero means ready immediately.
 	PendingRetryAt time.Time
+
+	// HeadRecordedAt is the UTC time at which this process recorded the
+	// commit the entry is currently evaluated against. Zero until the
+	// first head is recorded, and zero again for an entry restored on
+	// startup, because a head recorded by a previous process cannot
+	// bound a query over this process's activity. Read only by kinds
+	// whose subject is the pull request head.
+	HeadRecordedAt time.Time
+
+	// EscalatedForCurrentHead reports whether the configured escalation
+	// has already been applied for the commit currently recorded.
+	// Cleared whenever a different head is recorded, so an exhausted
+	// budget escalates at most once per commit rather than once per
+	// pass. Read only by kinds whose subject is the pull request head.
+	EscalatedForCurrentHead bool
 
 	// KindData holds kind-specific typed data. CI reactions use
 	// [*CIReactionData]; future reaction types define their own structs.
@@ -491,13 +505,29 @@ type PendingReaction struct {
 
 // CIReactionData holds CI-specific fields for a pending CI reaction.
 // Stored in [PendingReaction.KindData] for reactions with Kind ==
-// [ReactionKindCI].
+// [ReactionKindCI]. PRNumber, Owner, and Repo are sourced from
+// [domain.SCMMetadata] (written by the agent to scm.json), never from
+// the tracker project configuration.
+//
+// SHA is the head recorded at worker exit. It is not the ref the
+// reaction polls: the polled ref is the head read live from
+// [domain.PRMergeStatus.HeadSHA] on each due tick, so a commit pushed
+// after the agent handed off is the commit the verdict describes.
 type CIReactionData struct {
+	// PRNumber is the pull request number.
+	PRNumber int
+
+	// Owner is the repository owner.
+	Owner string
+
+	// Repo is the repository name.
+	Repo string
+
 	// Branch is the git branch name from SCM metadata.
 	Branch string
 
-	// SHA is the git commit SHA from SCM metadata. When non-empty, used
-	// as the ref for CIStatusProvider.FetchCIStatus.
+	// SHA is the git commit SHA from SCM metadata, carried for logging
+	// and parity with the sibling reaction data.
 	SHA string
 }
 

--- a/internal/persistence/run_history.go
+++ b/internal/persistence/run_history.go
@@ -303,6 +303,28 @@ func (s *Store) CountRunHistoryByIssue(ctx context.Context, issueID string) (int
 	return count, nil
 }
 
+// CountWorkerRunsCompletedSince returns the number of worker-session
+// run_history rows for the given issue whose completed_at is at or
+// after since. Rows whose status is "ci_failed" are excluded by name
+// rather than by an inclusion list of qualifying statuses, because that
+// status records a CI verdict the reconcile pass observed rather than a
+// worker session, and a status added later must count as a worker
+// session by default. Returns (0, nil) when no row qualifies.
+func (s *Store) CountWorkerRunsCompletedSince(ctx context.Context, issueID string, since time.Time) (int, error) {
+	var count int
+	err := s.db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM run_history
+		WHERE issue_id = ?
+		  AND status <> 'ci_failed'
+		  AND completed_at >= ?`,
+		issueID, since.UTC().Format(time.RFC3339),
+	).Scan(&count)
+	if err != nil {
+		return 0, fmt.Errorf("count worker runs completed since for issue %q: %w", issueID, err)
+	}
+	return count, nil
+}
+
 // QueryConsecutiveHandoffAbsenceCounts returns the number of handoff-absence
 // failures for each requested issue since the run at which
 // [Store.ResetHandoffAbsenceSequence] last ended that issue's sequence. Issues

--- a/internal/persistence/run_history_test.go
+++ b/internal/persistence/run_history_test.go
@@ -471,3 +471,68 @@ func TestLatestRunCompletionByIdentifier(t *testing.T) {
 		}
 	})
 }
+
+// countRun returns a run_history row for issueID carrying status and
+// completedAt, with the remaining fields from newTestRun.
+func countRun(i int, issueID, status, completedAt string) RunHistory {
+	run := newTestRun(i)
+	run.IssueID = issueID
+	run.Status = status
+	run.CompletedAt = completedAt
+	return run
+}
+
+// mustParseRFC3339 parses s as RFC3339 or fails the test.
+func mustParseRFC3339(t *testing.T, s string) time.Time {
+	t.Helper()
+	parsed, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		t.Fatalf("time.Parse(RFC3339, %q): %v", s, err)
+	}
+	return parsed
+}
+
+// TestCountWorkerRunsCompletedSince covers the exclusion filter and the
+// inclusive lower bound: succeeded, failed, and cancelled rows count as
+// worker sessions, a ci_failed row does not even when its completed_at
+// falls inside the interval, a row before the bound does not count, and
+// an issue with no rows returns (0, nil).
+func TestCountWorkerRunsCompletedSince(t *testing.T) {
+	t.Parallel()
+
+	const issueID = "ISS-CWR-1"
+	since := mustParseRFC3339(t, "2026-04-01T09:00:00Z")
+
+	s := openTestStore(t)
+	migrateOrFatal(t, s)
+
+	appendOrFatal(t, s, countRun(1, issueID, "succeeded", "2026-04-01T09:00:00Z")) // at bound, counts
+	appendOrFatal(t, s, countRun(2, issueID, "failed", "2026-04-01T10:00:00Z"))
+	appendOrFatal(t, s, countRun(3, issueID, "cancelled", "2026-04-01T11:00:00Z"))
+	appendOrFatal(t, s, countRun(4, issueID, "ci_failed", "2026-04-01T10:30:00Z")) // excluded by status
+	appendOrFatal(t, s, countRun(5, issueID, "succeeded", "2026-03-31T23:59:59Z")) // before bound, excluded
+	appendOrFatal(t, s, countRun(6, "ISS-CWR-OTHER", "succeeded", "2026-04-01T12:00:00Z"))
+
+	got, err := s.CountWorkerRunsCompletedSince(context.Background(), issueID, since)
+	if err != nil {
+		t.Fatalf("CountWorkerRunsCompletedSince: %v", err)
+	}
+	if got != 3 {
+		t.Errorf("CountWorkerRunsCompletedSince(%q, %v) = %d, want 3", issueID, since, got)
+	}
+
+	t.Run("issue with no rows returns zero", func(t *testing.T) {
+		t.Parallel()
+
+		s := openTestStore(t)
+		migrateOrFatal(t, s)
+
+		got, err := s.CountWorkerRunsCompletedSince(context.Background(), "ISS-CWR-NONE", since)
+		if err != nil {
+			t.Fatalf("CountWorkerRunsCompletedSince: %v", err)
+		}
+		if got != 0 {
+			t.Errorf("CountWorkerRunsCompletedSince(%q, %v) = %d, want 0", "ISS-CWR-NONE", since, got)
+		}
+	})
+}

--- a/internal/scm/gitea/scm_merge.go
+++ b/internal/scm/gitea/scm_merge.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/url"
+	"strings"
 
 	"github.com/sortie-ai/sortie/internal/domain"
 	"github.com/sortie-ai/sortie/internal/httpkit"
@@ -22,6 +23,7 @@ type giteaPullRequest struct {
 	Merged             bool        `json:"merged"`
 	MergeCommitSHA     *string     `json:"merge_commit_sha"`
 	Draft              bool        `json:"draft"`
+	State              string      `json:"state"`
 	RequestedReviewers []giteaUser `json:"requested_reviewers"`
 	Head               struct {
 		SHA string `json:"sha"`
@@ -103,6 +105,7 @@ func (a *GiteaSCMAdapter) GetMergeability(ctx context.Context, prNumber int, own
 		BaseBranch:     pr.Base.Ref,
 		Merged:         pr.Merged,
 		MergeCommitSHA: mergeCommitSHA,
+		Closed:         strings.EqualFold(pr.State, "closed"),
 	}, nil
 }
 

--- a/internal/scm/gitea/scm_merge_test.go
+++ b/internal/scm/gitea/scm_merge_test.go
@@ -33,6 +33,7 @@ func TestGiteaSCMGetMergeability(t *testing.T) {
 		wantBaseBranch     string
 		wantMerged         bool
 		wantMergeCommitSHA string
+		wantClosed         bool
 	}{
 		{
 			name:           "mergeable true maps to clean",
@@ -42,6 +43,7 @@ func TestGiteaSCMGetMergeability(t *testing.T) {
 			wantHeadSHA:    "sha-clean-001",
 			wantBranchName: "feature/gitea-scm-reads",
 			wantBaseBranch: "main",
+			wantClosed:     false,
 		},
 		{
 			name:           "draft true maps to blocked even when mergeable is true",
@@ -71,6 +73,18 @@ func TestGiteaSCMGetMergeability(t *testing.T) {
 			wantBaseBranch:     "main",
 			wantMerged:         true,
 			wantMergeCommitSHA: "9f3c1a2e4b5d6c7a8e9f0b1c2d3e4f5a6b7c8d9e",
+			wantClosed:         true,
+		},
+		{
+			name:           "closed without merge populates Closed but not Merged",
+			fixture:        "pr_closed_unmerged.json",
+			wantMergeable:  domain.MergeabilityUnknown,
+			wantDraft:      false,
+			wantHeadSHA:    "sha-clean-001",
+			wantBranchName: "feature/gitea-scm-reads",
+			wantBaseBranch: "main",
+			wantMerged:     false,
+			wantClosed:     true,
 		},
 	}
 
@@ -117,6 +131,9 @@ func TestGiteaSCMGetMergeability(t *testing.T) {
 			}
 			if got.MergeCommitSHA != tt.wantMergeCommitSHA {
 				t.Errorf("GetMergeability().MergeCommitSHA = %q, want %q", got.MergeCommitSHA, tt.wantMergeCommitSHA)
+			}
+			if got.Closed != tt.wantClosed {
+				t.Errorf("GetMergeability().Closed = %v, want %v", got.Closed, tt.wantClosed)
 			}
 		})
 	}

--- a/internal/scm/gitea/testdata/pr_closed_unmerged.json
+++ b/internal/scm/gitea/testdata/pr_closed_unmerged.json
@@ -1,0 +1,17 @@
+{
+  "id": 500009,
+  "number": 6,
+  "title": "Add Gitea SCM read operations",
+  "state": "closed",
+  "mergeable": false,
+  "merged": false,
+  "merged_at": null,
+  "draft": false,
+  "user": { "login": "alice" },
+  "requested_reviewers": [],
+  "head": { "sha": "sha-clean-001", "ref": "feature/gitea-scm-reads" },
+  "base": { "ref": "main" },
+  "html_url": "https://git.example.com/acme/widgets/pulls/6",
+  "created_at": "2026-07-10T08:00:00Z",
+  "updated_at": "2026-07-19T09:30:00Z"
+}

--- a/internal/scm/github/merge.go
+++ b/internal/scm/github/merge.go
@@ -59,6 +59,7 @@ type pullRequestResponse struct {
 	Draft          bool   `json:"draft"`
 	MergeableState string `json:"mergeable_state"`
 	Merged         bool   `json:"merged"`
+	State          string `json:"state"`
 	Head           struct {
 		SHA string `json:"sha"`
 		Ref string `json:"ref"`
@@ -248,6 +249,7 @@ func (a *GitHubSCMAdapter) GetMergeability(ctx context.Context, prNumber int, ow
 		BaseBranch:     pr.Base.Ref,
 		Merged:         pr.Merged,
 		MergeCommitSHA: mergeCommitSHA,
+		Closed:         strings.EqualFold(pr.State, "closed"),
 	}, nil
 }
 

--- a/internal/scm/github/merge_test.go
+++ b/internal/scm/github/merge_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
@@ -717,6 +718,51 @@ func TestGetMergeability_Clean(t *testing.T) {
 	}
 	if status.HeadSHA != "sha1" {
 		t.Errorf("GetMergeability().HeadSHA = %q, want %q", status.HeadSHA, "sha1")
+	}
+}
+
+// TestGetMergeability_Closed verifies that the pull request's state field,
+// already decoded from the same object GetMergeability fetches, populates
+// Closed with no additional request. GitHub reports a merged pull request
+// as state "closed" too, so a merged PR's Closed is also true and Merged
+// remains the discriminator for the closed-without-merge condition.
+func TestGetMergeability_Closed(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		state string
+		want  bool
+	}{
+		{"closed state maps to Closed true", "closed", true},
+		{"open state maps to Closed false", "open", false},
+		{"case-insensitive match", "CLOSED", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var requests atomic.Int64
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				requests.Add(1)
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = fmt.Fprintf(w, `{"head":{"sha":"sha-closed"},"draft":false,"mergeable_state":"clean","state":%q}`, tt.state)
+			}))
+			defer srv.Close()
+
+			a := newTestSCMAdapter(t, srv.URL)
+			status, err := a.GetMergeability(t.Context(), 1, "owner", "repo")
+			if err != nil {
+				t.Fatalf("GetMergeability: %v", err)
+			}
+			if status.Closed != tt.want {
+				t.Errorf("GetMergeability().Closed = %v, want %v for state %q", status.Closed, tt.want, tt.state)
+			}
+			if got := requests.Load(); got != 1 {
+				t.Errorf("HTTP request count = %d, want 1 (Closed rides the existing PR fetch)", got)
+			}
+		})
 	}
 }
 

--- a/internal/scm/gitlab/scm_merge.go
+++ b/internal/scm/gitlab/scm_merge.go
@@ -173,6 +173,7 @@ func (a *GitLabSCMAdapter) GetMergeability(ctx context.Context, prNumber int, ow
 		BaseBranch:     mr.TargetBranch,
 		Merged:         merged,
 		MergeCommitSHA: mergeCommitSHA,
+		Closed:         mr.State == "closed",
 	}, nil
 }
 

--- a/internal/scm/gitlab/scm_merge_test.go
+++ b/internal/scm/gitlab/scm_merge_test.go
@@ -384,6 +384,44 @@ func TestGetMergeability_OpenDispositionIgnoresMergeCommitSHA(t *testing.T) {
 	}
 }
 
+// TestGetMergeability_Closed verifies that Closed is sourced from the
+// already-decoded state field with no additional request, and that
+// "merged" and "closed" are disjoint on GitLab: a merged merge request
+// reports state "merged" rather than "closed", so Closed is false there
+// and true only for a genuine closed-without-merge state.
+func TestGetMergeability_Closed(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		state      string
+		wantClosed bool
+	}{
+		{"opened state maps to Closed false", "opened", false},
+		{"closed state maps to Closed true", "closed", true},
+		{"merged state maps to Closed false (disjoint from closed)", "merged", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			fixture := mergeRequestFixture(t, map[string]any{"state": tt.state})
+			srv := serveJSON(t, fixture)
+			defer srv.Close()
+
+			adapter := mustSCMAdapter(t, srv.URL)
+			got, err := adapter.GetMergeability(context.Background(), testPRNumber, scmOwner, scmRepo)
+			if err != nil {
+				t.Fatalf("GetMergeability: unexpected error: %v", err)
+			}
+			if got.Closed != tt.wantClosed {
+				t.Errorf("GetMergeability().Closed = %v, want %v for state %q", got.Closed, tt.wantClosed, tt.state)
+			}
+		})
+	}
+}
+
 // --- GetMergeability: field population ---
 
 func TestGetMergeability_FieldPopulation(t *testing.T) {


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Fix

**Intent:** The `ci_failure` reaction stopped watching a pull request after its first passing CI result, and the ref it polled was captured once from workspace SCM metadata at worker exit and never refreshed. A later commit that failed CI was therefore never observed - no continuation dispatched, no retry budget spent, no escalation fired - and the linked issue stayed in its review state while the branch sat on a failing commit. `reconcileCIStatus` now resolves the pull request's current head on every pass and keeps watching past a passing result, so a later failing commit is observed and a fix continuation is dispatched within the configured retry budget.

**Related Issues:** Closes #871, #824

### 🧭 Reviewer Guide

**Complexity:** High

#### Entry Point

`internal/orchestrator/ci_reconcile.go`: `reconcileCIStatus` now calls `SCMAdapter.GetMergeability` on every pass to resolve the pull request's current head instead of polling the SHA recorded at worker exit, and no longer clears its own watch entry on a passing result - it re-enqueues with backoff instead, so a later commit on the same pull request is still observed. `PRMergeStatus` gains `Closed`, so a closed or merged pull request ends the watch outright (checked before the merge-branch check, since a provider's closed state can subsume merging). A detected head change now runs through the fingerprint read-before-write ordering (read the previous head, then upsert the new one) rather than upsert-then-read, because the pass needs the previous head to detect a change.

#### Sensitive Areas

- `internal/orchestrator/head_change.go`: new `classifyHeadChange` predicate that positively attributes an observed head change away from the orchestrator's own work (no live session in `state.Running`/`state.RetryAttempts`/`state.Claimed`, and no worker run completed since the recorded head per `Store.CountWorkerRunsCompletedSince`) before the CI retry budget is reset. Every failure path answers "unknown" rather than a positive attribution, since a needless reset costs an unbounded retry loop. The same predicate now also backs the merge-conflict reaction's epoch transition in `internal/orchestrator/merge_conflict_reconcile.go`.
- `internal/config/config.go`: replaces the creation-time pending TTL with `CIFeedbackConfig.WatchWindowMS` (`reactions.ci_failure.watch_window_ms`, default 24h), measured from the last recorded head rather than entry creation, so an actively worked pull request stays watched and only silence ages it out.
- `internal/persistence/run_history.go`: adds `CountWorkerRunsCompletedSince`, which excludes `ci_failed` rows by name (rather than an inclusion list) so a status added later counts as a worker session by default.
- `internal/scm/{github,gitea,gitlab}`: `GetMergeability` now reports `Closed` on the normalized `PRMergeStatus`.
- `cmd/sortie/main.go`: `ci_failure` now joins the active-SCM-reaction provider-conflict check at startup, since resolving the current head requires calling the SCM provider.
- Architecture, ADR, workflow-reference, and changelog documentation now describe the same lifecycle.

### ⚠️ Risk Assessment

- **Breaking Changes:** Yes. A deployment with `reactions.ci_failure` on one SCM provider and another active SCM-backed reaction on a different provider previously started; it now fails at startup with `unsupported: active SCM reaction kinds must use the same provider`, because the current-head resolution requires the same forge. Naming one provider across every active SCM-backed reaction, including `ci_failure`, resolves it.
- **Migrations/State:** No schema migration. `CountWorkerRunsCompletedSince` is a new read-only query against the existing `run_history` table.
