### PR TITLE
fix(codex): remove unreachable git repo check config

### DIFF
--- a/internal/agent/codex/command.go
+++ b/internal/agent/codex/command.go
@@ -15,7 +15,6 @@ type passthroughConfig struct {
 	ThreadSandbox     string
 	TurnSandboxPolicy map[string]any
 	Personality       string
-	SkipGitRepoCheck  bool
 }
 
 // parsePassthroughConfig extracts Codex-specific settings from the
@@ -28,7 +27,6 @@ func parsePassthroughConfig(config map[string]any) passthroughConfig {
 		ThreadSandbox:     typeutil.StringFrom(config, "thread_sandbox"),
 		TurnSandboxPolicy: typeutil.MapFrom(config, "turn_sandbox_policy"),
 		Personality:       typeutil.StringFrom(config, "personality"),
-		SkipGitRepoCheck:  typeutil.BoolFrom(config, "skip_git_repo_check", false),
 	}
 }
 

--- a/internal/agent/codex/parse_test.go
+++ b/internal/agent/codex/parse_test.go
@@ -52,7 +52,6 @@ func TestParsePassthroughConfig(t *testing.T) {
 				"approval_policy":     "never",
 				"thread_sandbox":      "workspaceWrite",
 				"personality":         "helpful",
-				"skip_git_repo_check": true,
 				"turn_sandbox_policy": map[string]any{"networkAccess": true},
 			},
 			want: passthroughConfig{
@@ -61,7 +60,6 @@ func TestParsePassthroughConfig(t *testing.T) {
 				ApprovalPolicy:    "never",
 				ThreadSandbox:     "workspaceWrite",
 				Personality:       "helpful",
-				SkipGitRepoCheck:  true,
 				TurnSandboxPolicy: map[string]any{"networkAccess": true},
 			},
 		},
@@ -72,17 +70,9 @@ func TestParsePassthroughConfig(t *testing.T) {
 				"effort":              false,
 				"approval_policy":     123,
 				"thread_sandbox":      []string{"not-a-string"},
-				"skip_git_repo_check": "yes",
 				"turn_sandbox_policy": "not-a-map",
 			},
 			want: passthroughConfig{},
-		},
-		{
-			name: "explicit false skip_git_repo_check",
-			config: map[string]any{
-				"skip_git_repo_check": false,
-			},
-			want: passthroughConfig{SkipGitRepoCheck: false},
 		},
 	}
 
@@ -104,9 +94,6 @@ func TestParsePassthroughConfig(t *testing.T) {
 			}
 			if got.Personality != tt.want.Personality {
 				t.Errorf("Personality = %q, want %q", got.Personality, tt.want.Personality)
-			}
-			if got.SkipGitRepoCheck != tt.want.SkipGitRepoCheck {
-				t.Errorf("SkipGitRepoCheck = %v, want %v", got.SkipGitRepoCheck, tt.want.SkipGitRepoCheck)
 			}
 			if len(got.TurnSandboxPolicy) != len(tt.want.TurnSandboxPolicy) {
 				t.Errorf("TurnSandboxPolicy len = %d, want %d", len(got.TurnSandboxPolicy), len(tt.want.TurnSandboxPolicy))


### PR DESCRIPTION
### Scope & Context

**Type:** Fix

**Intent:** Removes `codex.skip_git_repo_check`, which the adapter parsed but never read or sent to `codex app-server`. The corresponding CLI flag is unavailable on the app-server transport, so the key has always been a no-op.

**Related Issues:** Closes #840

### Reviewer Guide

**Complexity:** Low

#### Entry Point

`internal/agent/codex/command.go` removes the dead field and parsing path. `internal/agent/codex/parse_test.go` drops the matching parser cases.

### Risk Assessment

- **Breaking Changes:** Existing workflows that still contain the key remain accepted as unknown configuration and behave as before; it had no effect.
- **Migrations/State:** No migrations or state changes.

### Testing

- `make test PKG=./internal/agent/codex/...`
- `make lint`
- `make test` was attempted but failed only in untouched Kiro, orchestrator, and workspace packages on this macOS environment.
