### PR TITLE
fix(cmd/sortie): report the ci_failure provider conflict offline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,11 +64,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   uses, so a deployment naming `reactions.ci_failure` with one provider
   and another active SCM-backed reaction with a different provider now
   fails at startup instead of running with a currency-blind CI watch.
-  The previously accepted shape, two providers across the active
-  SCM-backed reactions including `ci_failure`, is no longer valid; name
-  one forge across every active SCM-backed reaction, including
-  `ci_failure`, to start again.
-  ([#871](https://github.com/sortie-ai/sortie/issues/871))
+  `sortie validate` now reports the same conflict offline, under the
+  `reactions.scm_provider_conflict` check. The previously accepted
+  shape, two providers across the active SCM-backed reactions including
+  `ci_failure`, is no longer valid; name one forge across every active
+  SCM-backed reaction, including `ci_failure`, to start again.
+  ([#871](https://github.com/sortie-ai/sortie/issues/871),
+  [#890](https://github.com/sortie-ai/sortie/issues/890))
 
 ## [1.20.0] - 2026-08-18
 

--- a/cmd/sortie/main.go
+++ b/cmd/sortie/main.go
@@ -155,6 +155,36 @@ func scmProviderConflict(kinds []scmReactionKind) (activeKinds, distinctProvider
 	return activeKinds, distinctProviders
 }
 
+// activeSCMReactionKinds builds the roster of every SCM-backed reaction
+// kind, including the ci_failure reaction's resolved CI feedback kind, for
+// the shared-provider check both the startup path and sortie validate
+// consume. A single SCMAdapter is shared by all active SCM reaction
+// reconcile passes, so every active kind in the roster must name the same
+// provider.
+//
+// The returned slice always has seven entries, active or not; the caller
+// filters by the active field. activeSCMReactionKinds performs no registry
+// lookup, no adapter construction, and no I/O.
+func activeSCMReactionKinds(cfg config.ServiceConfig) []scmReactionKind {
+	reviewRC := cfg.Reactions["review_comments"]
+	autoMergeRC := cfg.Reactions["auto_merge"]
+	botReviewRC := cfg.Reactions["bot_review"]
+	mergeConflictRC := cfg.Reactions["merge_conflicts"]
+	mergeCompletionRC := cfg.Reactions["merge_completion"]
+	labelReviewActive := cfg.LabelCommands.Provider != "" && cfg.LabelCommands.ReviewLabel != ""
+	labelFixActive := cfg.LabelCommands.Provider != "" && cfg.LabelCommands.FixLabel != ""
+
+	return []scmReactionKind{
+		{name: "review_comments", active: reviewRC.Provider != "", provider: reviewRC.Provider},
+		{name: "auto_merge", active: autoMergeRC.Provider != "", provider: autoMergeRC.Provider},
+		{name: "bot_review", active: botReviewRC.Provider != "", provider: botReviewRC.Provider},
+		{name: "merge_conflicts", active: mergeConflictRC.Provider != "", provider: mergeConflictRC.Provider},
+		{name: "label_commands", active: labelReviewActive || labelFixActive, provider: cfg.LabelCommands.Provider},
+		{name: "merge_completion", active: mergeCompletionRC.Provider != "", provider: mergeCompletionRC.Provider},
+		{name: "ci_failure", active: cfg.CIFeedback.Kind != "", provider: cfg.CIFeedback.Kind},
+	}
+}
+
 func main() {
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 
@@ -408,15 +438,7 @@ func run(ctx context.Context, args []string, stdout io.Writer, stderr io.Writer)
 
 	ciFeedbackActive := br.cfg.CIFeedback.Kind != ""
 
-	activeSCMKinds := []scmReactionKind{
-		{name: "review_comments", active: reviewActive, provider: reviewRC.Provider},
-		{name: "auto_merge", active: autoMergeActive, provider: autoMergeRC.Provider},
-		{name: "bot_review", active: botReviewActive, provider: botReviewRC.Provider},
-		{name: "merge_conflicts", active: mergeConflictActive, provider: mergeConflictRC.Provider},
-		{name: "label_commands", active: labelReviewActive || labelFixActive, provider: br.cfg.LabelCommands.Provider},
-		{name: "merge_completion", active: mergeCompletionActive, provider: mergeCompletionRC.Provider},
-		{name: "ci_failure", active: ciFeedbackActive, provider: br.cfg.CIFeedback.Kind},
-	}
+	activeSCMKinds := activeSCMReactionKinds(br.cfg)
 	if conflictKinds, conflictProviders := scmProviderConflict(activeSCMKinds); len(conflictProviders) > 1 {
 		conflictAttrs := []any{
 			slog.String("kinds", strings.Join(conflictKinds, ", ")),

--- a/cmd/sortie/main_test.go
+++ b/cmd/sortie/main_test.go
@@ -1526,6 +1526,20 @@ func TestRunCIFailureOnly_ConstructsSCMAdapter(t *testing.T) {
 	}
 	wfPath := writeCustomWorkflowFile(t, dir, ciFailureOnlyWorkflow(issuesPath, wsRoot))
 
+	var offlineStdout, offlineStderr bytes.Buffer
+	if code := run(context.Background(), []string{"validate", "--format", "json", wfPath}, &offlineStdout, &offlineStderr); code != 0 {
+		t.Fatalf("run(validate) = %d, want 0; stderr:\n%s", code, offlineStderr.String())
+	}
+	var out validateOutput
+	if err := json.Unmarshal(offlineStdout.Bytes(), &out); err != nil {
+		t.Fatalf("json.Unmarshal(%q) error: %v", offlineStdout.String(), err)
+	}
+	for _, key := range forgeCheckKeys {
+		if d := diagWithCheck(out.Errors, key); d != nil {
+			t.Errorf("validateOutput.Errors contains forge diagnostic %q = %v, want none", key, d)
+		}
+	}
+
 	var stdout bytes.Buffer
 	var stderr lockedBuf
 	ctx, cancel := context.WithTimeout(context.Background(), runTestTimeout)
@@ -1560,6 +1574,18 @@ func TestRunCIFailure_MismatchedProviders(t *testing.T) {
 		t.Fatal(err)
 	}
 	wfPath := writeCustomWorkflowFile(t, dir, ciFailureWorkflowMismatchedProviders(issuesPath, wsRoot))
+
+	var offlineStdout, offlineStderr bytes.Buffer
+	if code := run(context.Background(), []string{"validate", "--format", "json", wfPath}, &offlineStdout, &offlineStderr); code != 1 {
+		t.Fatalf("run(validate) = %d, want 1; stderr:\n%s", code, offlineStderr.String())
+	}
+	var out validateOutput
+	if err := json.Unmarshal(offlineStdout.Bytes(), &out); err != nil {
+		t.Fatalf("json.Unmarshal(%q) error: %v", offlineStdout.String(), err)
+	}
+	if d := diagWithCheck(out.Errors, "reactions.scm_provider_conflict"); d == nil {
+		t.Fatalf("validateOutput.Errors = %v, want a diagnostic with check %q", out.Errors, "reactions.scm_provider_conflict")
+	}
 
 	var stdout bytes.Buffer
 	var stderr lockedBuf

--- a/cmd/sortie/scmprovider_test.go
+++ b/cmd/sortie/scmprovider_test.go
@@ -2,7 +2,92 @@ package main
 
 import (
 	"testing"
+
+	"github.com/sortie-ai/sortie/internal/config"
 )
+
+// TestActiveSCMReactionKinds pins activeSCMReactionKinds's roster: its
+// seven entries, their fixed order, and each entry's provider source.
+func TestActiveSCMReactionKinds(t *testing.T) {
+	t.Parallel()
+
+	wantNames := []string{
+		"review_comments", "auto_merge", "bot_review", "merge_conflicts",
+		"label_commands", "merge_completion", "ci_failure",
+	}
+
+	t.Run("all seven kinds active on one provider", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := config.ServiceConfig{
+			Reactions: map[string]config.ReactionConfig{
+				"review_comments":  {Provider: "gitea"},
+				"auto_merge":       {Provider: "gitea"},
+				"bot_review":       {Provider: "gitea"},
+				"merge_conflicts":  {Provider: "gitea"},
+				"merge_completion": {Provider: "gitea"},
+			},
+			LabelCommands: config.LabelCommandsConfig{Provider: "gitea", ReviewLabel: "sortie:review"},
+			CIFeedback:    config.CIFeedbackConfig{Kind: "gitea"},
+		}
+
+		got := activeSCMReactionKinds(cfg)
+		if len(got) != len(wantNames) {
+			t.Fatalf("activeSCMReactionKinds(cfg) = %v, want %d entries", got, len(wantNames))
+		}
+		for i, name := range wantNames {
+			if got[i].name != name {
+				t.Errorf("activeSCMReactionKinds(cfg)[%d].name = %q, want %q", i, got[i].name, name)
+			}
+			if !got[i].active {
+				t.Errorf("activeSCMReactionKinds(cfg)[%d].active = false, want true (name %q)", i, name)
+			}
+			if got[i].provider != "gitea" {
+				t.Errorf("activeSCMReactionKinds(cfg)[%d].provider = %q, want %q", i, got[i].provider, "gitea")
+			}
+		}
+	})
+
+	t.Run("zero config", func(t *testing.T) {
+		t.Parallel()
+
+		got := activeSCMReactionKinds(config.ServiceConfig{})
+		if len(got) != len(wantNames) {
+			t.Fatalf("activeSCMReactionKinds(cfg) = %v, want %d entries", got, len(wantNames))
+		}
+		for i, name := range wantNames {
+			if got[i].name != name {
+				t.Errorf("activeSCMReactionKinds(cfg)[%d].name = %q, want %q", i, got[i].name, name)
+			}
+			if got[i].active {
+				t.Errorf("activeSCMReactionKinds(cfg)[%d].active = true, want false (name %q)", i, name)
+			}
+			if got[i].provider != "" {
+				t.Errorf("activeSCMReactionKinds(cfg)[%d].provider = %q, want empty", i, got[i].provider)
+			}
+		}
+	})
+
+	t.Run("ci_failure follows CIFeedback.Kind, not the reactions map", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := config.ServiceConfig{
+			Reactions: map[string]config.ReactionConfig{
+				"ci_failure": {Provider: "gitlab"},
+			},
+			CIFeedback: config.CIFeedbackConfig{Kind: "github"},
+		}
+
+		got := activeSCMReactionKinds(cfg)
+		last := got[len(got)-1]
+		if last.name != "ci_failure" {
+			t.Fatalf("activeSCMReactionKinds(cfg) last entry name = %q, want %q", last.name, "ci_failure")
+		}
+		if last.provider != "github" {
+			t.Errorf("activeSCMReactionKinds(cfg) ci_failure.provider = %q, want %q (CIFeedback.Kind, not the reactions map entry)", last.provider, "github")
+		}
+	})
+}
 
 func TestScmProviderConflict(t *testing.T) {
 	t.Parallel()

--- a/cmd/sortie/validate.go
+++ b/cmd/sortie/validate.go
@@ -233,31 +233,18 @@ func mapPreflightErrors(errs []orchestrator.PreflightError) []validateDiag {
 
 // activationChecks reports the offline-decidable SCM and CI activation
 // faults in the resolved config: an active SCM reaction naming an
-// unregistered provider, active SCM reactions disagreeing on the provider,
-// and a ci_feedback.kind naming no registered CI provider. It reuses
+// unregistered provider, active SCM reactions disagreeing on the
+// provider, and a reactions.ci_failure.provider (or its deprecated
+// ci_feedback.kind equivalent) naming no registered CI provider. The
+// resolved CI feedback kind joins the same active-SCM-reaction provider
+// set the runtime uses, so a disagreement between reactions.ci_failure
+// and another active SCM reaction is caught here too. It reuses
 // scmProviderConflict and the adapter registries the runtime consults at
 // construction, so it constructs no adapter and opens no socket.
 func activationChecks(cfg config.ServiceConfig) []validateDiag {
 	var diags []validateDiag
 
-	reviewRC := cfg.Reactions["review_comments"]
-	autoMergeRC := cfg.Reactions["auto_merge"]
-	botReviewRC := cfg.Reactions["bot_review"]
-	mergeConflictRC := cfg.Reactions["merge_conflicts"]
-	mergeCompletionRC := cfg.Reactions["merge_completion"]
-	labelReviewActive := cfg.LabelCommands.Provider != "" && cfg.LabelCommands.ReviewLabel != ""
-	labelFixActive := cfg.LabelCommands.Provider != "" && cfg.LabelCommands.FixLabel != ""
-
-	activeSCMKinds := []scmReactionKind{
-		{name: "review_comments", active: reviewRC.Provider != "", provider: reviewRC.Provider},
-		{name: "auto_merge", active: autoMergeRC.Provider != "", provider: autoMergeRC.Provider},
-		{name: "bot_review", active: botReviewRC.Provider != "", provider: botReviewRC.Provider},
-		{name: "merge_conflicts", active: mergeConflictRC.Provider != "", provider: mergeConflictRC.Provider},
-		{name: "label_commands", active: labelReviewActive || labelFixActive, provider: cfg.LabelCommands.Provider},
-		{name: "merge_completion", active: mergeCompletionRC.Provider != "", provider: mergeCompletionRC.Provider},
-	}
-
-	activeKinds, providers := scmProviderConflict(activeSCMKinds)
+	activeKinds, providers := scmProviderConflict(activeSCMReactionKinds(cfg))
 	if len(providers) > 1 {
 		diags = append(diags, validateDiag{
 			Severity: "error",
@@ -268,7 +255,7 @@ func activationChecks(cfg config.ServiceConfig) []validateDiag {
 		diags = append(diags, validateDiag{
 			Severity: "error",
 			Check:    "scm_adapter",
-			Message:  fmt.Sprintf("no registered SCM adapter for kind %q named by active reactions", providers[0]),
+			Message:  fmt.Sprintf("no registered SCM adapter for kind %q named by active SCM reactions %v", providers[0], activeKinds),
 		})
 	}
 

--- a/cmd/sortie/validate_test.go
+++ b/cmd/sortie/validate_test.go
@@ -2392,9 +2392,10 @@ func TestActivationChecks(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name       string
-		cfg        config.ServiceConfig
-		wantChecks []string
+		name                string
+		cfg                 config.ServiceConfig
+		wantChecks          []string
+		wantMessageContains map[string]string
 	}{
 		{
 			name: "unregistered SCM provider",
@@ -2410,7 +2411,23 @@ func TestActivationChecks(t *testing.T) {
 			cfg: config.ServiceConfig{
 				CIFeedback: config.CIFeedbackConfig{Kind: "gitea-ci"},
 			},
-			wantChecks: []string{"ci_provider"},
+			wantChecks: []string{"scm_adapter", "ci_provider"},
+			wantMessageContains: map[string]string{
+				"scm_adapter": `"gitea-ci" named by active SCM reactions [ci_failure]`,
+			},
+		},
+		{
+			name: "ci_failure disagrees with an active review_comments provider",
+			cfg: config.ServiceConfig{
+				Reactions: map[string]config.ReactionConfig{
+					"review_comments": {Provider: "gitea"},
+				},
+				CIFeedback: config.CIFeedbackConfig{Kind: "github"},
+			},
+			wantChecks: []string{"reactions.scm_provider_conflict"},
+			wantMessageContains: map[string]string{
+				"reactions.scm_provider_conflict": "ci_failure",
+			},
 		},
 		{
 			name: "two active reactions naming different providers",
@@ -2484,6 +2501,15 @@ func TestActivationChecks(t *testing.T) {
 				}
 				if got[i].Severity != "error" {
 					t.Errorf("activationChecks(cfg) diag[%d].Severity = %q, want %q", i, got[i].Severity, "error")
+				}
+			}
+			for check, substr := range tt.wantMessageContains {
+				d := diagWithCheck(got, check)
+				if d == nil {
+					t.Fatalf("activationChecks(cfg) = %v, want a diagnostic with check %q", got, check)
+				}
+				if !strings.Contains(d.Message, substr) {
+					t.Errorf("activationChecks(cfg) diag[%q].Message = %q, want substring %q", check, d.Message, substr)
 				}
 			}
 		})
@@ -2669,10 +2695,11 @@ func TestValidateGiteaForge(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name      string
-		extraYAML string
-		wantCheck string
-		wantCode  int
+		name                string
+		extraYAML           string
+		wantChecks          []string
+		wantMessageContains map[string]string
+		wantCode            int
 	}{
 		{
 			name: "bot_review bare string bot_usernames",
@@ -2681,8 +2708,8 @@ func TestValidateGiteaForge(t *testing.T) {
     provider: gitea
     bot_usernames: alice
 `,
-			wantCheck: "reactions.bot_review",
-			wantCode:  1,
+			wantChecks: []string{"reactions.bot_review"},
+			wantCode:   1,
 		},
 		{
 			name: "auto_merge strategy rebase-merge",
@@ -2691,8 +2718,8 @@ func TestValidateGiteaForge(t *testing.T) {
     provider: gitea
     strategy: rebase-merge
 `,
-			wantCheck: "reactions.auto_merge",
-			wantCode:  1,
+			wantChecks: []string{"reactions.auto_merge"},
+			wantCode:   1,
 		},
 		{
 			name: "unregistered SCM provider",
@@ -2700,16 +2727,19 @@ func TestValidateGiteaForge(t *testing.T) {
   bot_review:
     provider: gitea-scm
 `,
-			wantCheck: "scm_adapter",
-			wantCode:  1,
+			wantChecks: []string{"scm_adapter"},
+			wantCode:   1,
 		},
 		{
 			name: "unregistered CI provider",
 			extraYAML: `ci_feedback:
   kind: gitea-ci
 `,
-			wantCheck: "ci_provider",
-			wantCode:  1,
+			wantChecks: []string{"scm_adapter", "ci_provider"},
+			wantMessageContains: map[string]string{
+				"scm_adapter": "ci_failure",
+			},
+			wantCode: 1,
 		},
 		{
 			name: "active reactions naming different providers",
@@ -2719,8 +2749,36 @@ func TestValidateGiteaForge(t *testing.T) {
   auto_merge:
     provider: github
 `,
-			wantCheck: "reactions.scm_provider_conflict",
-			wantCode:  1,
+			wantChecks: []string{"reactions.scm_provider_conflict"},
+			wantCode:   1,
+		},
+		{
+			name: "ci_failure provider conflict with review_comments",
+			extraYAML: `reactions:
+  review_comments:
+    provider: gitlab
+  ci_failure:
+    provider: github
+`,
+			wantChecks: []string{"reactions.scm_provider_conflict"},
+			wantMessageContains: map[string]string{
+				"reactions.scm_provider_conflict": "ci_failure",
+			},
+			wantCode: 1,
+		},
+		{
+			name: "modern ci_failure key joins the clean provider set",
+			extraYAML: `reactions:
+  bot_review:
+    provider: gitea
+  auto_merge:
+    provider: gitea
+    strategy: squash
+  ci_failure:
+    provider: gitea
+`,
+			wantChecks: nil,
+			wantCode:   0,
 		},
 		{
 			name: "fully valid gitea forge configuration",
@@ -2735,8 +2793,8 @@ func TestValidateGiteaForge(t *testing.T) {
 ci_feedback:
   kind: gitea
 `,
-			wantCheck: "",
-			wantCode:  0,
+			wantChecks: nil,
+			wantCode:   0,
 		},
 	}
 
@@ -2758,7 +2816,7 @@ ci_feedback:
 				t.Fatalf("json.Unmarshal(%q) error: %v", stdout.String(), err)
 			}
 
-			if tt.wantCheck == "" {
+			if len(tt.wantChecks) == 0 {
 				if !out.Valid {
 					t.Errorf("validateOutput.Valid = false, want true; errors: %v", out.Errors)
 				}
@@ -2776,12 +2834,23 @@ ci_feedback:
 			if out.Valid {
 				t.Errorf("validateOutput.Valid = true, want false")
 			}
-			d := diagWithCheck(out.Errors, tt.wantCheck)
-			if d == nil {
-				t.Fatalf("validateOutput.Errors = %v, want a diagnostic with check %q", out.Errors, tt.wantCheck)
+			for _, wantCheck := range tt.wantChecks {
+				d := diagWithCheck(out.Errors, wantCheck)
+				if d == nil {
+					t.Fatalf("validateOutput.Errors = %v, want a diagnostic with check %q", out.Errors, wantCheck)
+				}
+				if d.Severity != "error" {
+					t.Errorf("validateOutput.Errors[%q].Severity = %q, want %q", wantCheck, d.Severity, "error")
+				}
 			}
-			if d.Severity != "error" {
-				t.Errorf("validateOutput.Errors[%q].Severity = %q, want %q", tt.wantCheck, d.Severity, "error")
+			for check, substr := range tt.wantMessageContains {
+				d := diagWithCheck(out.Errors, check)
+				if d == nil {
+					t.Fatalf("validateOutput.Errors = %v, want a diagnostic with check %q", out.Errors, check)
+				}
+				if !strings.Contains(d.Message, substr) {
+					t.Errorf("validateOutput.Errors[%q].Message = %q, want substring %q", check, d.Message, substr)
+				}
 			}
 		})
 	}

--- a/docs/workflow-reference.md
+++ b/docs/workflow-reference.md
@@ -971,6 +971,8 @@ Equivalent to the deprecated `ci_feedback` section. Configures the CI failure fe
 loop. The orchestrator resolves the pull request's current head on each pass and polls CI
 status for that head, dispatching continuation turns when CI fails on it.
 
+Its `provider` must match the provider of every other active SCM reaction.
+
 Additional fields (via Extra):
 
 | Field             | Type    | Default      | Dynamic Reload | Description                                                                                                             |


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Fix

**Intent:** Make `sortie validate` agree with the orchestrator's startup verdict for the `ci_failure` SCM provider check, so a misconfigured `reactions.ci_failure.provider` is caught offline instead of only surfacing as a startup exit `1`. A separate `docs:` commit states the shared-provider requirement in the `ci_failure` reaction reference, where an operator meeting the new diagnostic looks first, and records the offline check in the existing unreleased changelog entry.

**Related Issues:** #890

### 🧭 Reviewer Guide

**Complexity:** Medium

#### Entry Point

`cmd/sortie/main.go`'s new `activeSCMReactionKinds(cfg)` function is the change to understand first. It builds the canonical seven-entry roster of SCM-backed reaction kinds (`review_comments`, `auto_merge`, `bot_review`, `merge_conflicts`, `label_commands`, `merge_completion`, `ci_failure`), replacing the inline slice literal that used to live only in `run()`. `cmd/sortie/validate.go`'s `activationChecks()` now calls the same helper instead of building its own six-entry slice, which is the actual bug fix: it previously omitted `ci_failure`, so the offline check couldn't see a conflict that the startup path would later reject.

#### Sensitive Areas

- `cmd/sortie/main.go`: shared helper now feeds both the runtime startup gate and the offline validator - a bug here affects both surfaces at once.
- `cmd/sortie/validate.go`: the `scm_adapter` diagnostic message changed shape (it now lists the active SCM reaction kinds), which is a visible output change for anyone scripting against `sortie validate --format json`.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes. The `scm_adapter` diagnostic's `Message` text gained additional detail (the active reaction kinds), but its `Check` key and `Severity` are unchanged.
- **Migrations/State:** No migrations or state changes.

