### PR TITLE
fix(orchestrator): enforce agent.turn_timeout_ms on every turn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   pull request by hand.
   ([#871](https://github.com/sortie-ai/sortie/issues/871))
 
+- `agent.turn_timeout_ms` is now enforced. A turn that exceeds the
+  configured bound ends, the attempt is recorded as failed with the
+  `turn_timeout` reason, and a retry is scheduled with the usual
+  exponential backoff. The bound covers self-review turns too: a
+  self-review turn that exceeds it fails the attempt rather than
+  completing it, so such a run is retried instead of handed off.
+  Previously the value was parsed and reported by `sortie resolve` but
+  applied nowhere, so nothing bounded a turn whose agent kept producing
+  output; stall detection could not cover the gap, because it measures
+  silence rather than duration.
+  ([#834](https://github.com/sortie-ai/sortie/issues/834))
+
 ### Changed
 
 - `reactions.ci_failure` now resolves the pull request's current head
@@ -71,6 +83,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   SCM-backed reaction, including `ci_failure`, to start again.
   ([#871](https://github.com/sortie-ai/sortie/issues/871),
   [#890](https://github.com/sortie-ai/sortie/issues/890))
+
+- A non-positive `agent.turn_timeout_ms` is now rejected at startup, by
+  `sortie validate`, and on reload. `0` or a negative number is no
+  longer accepted; `0` did not disable the bound before either, it
+  silently meant one hour. Unlike `agent.stall_timeout_ms`, this bound
+  cannot be disabled.
+  ([#834](https://github.com/sortie-ai/sortie/issues/834))
 
 ## [1.20.0] - 2026-08-18
 

--- a/cmd/sortie/validate_test.go
+++ b/cmd/sortie/validate_test.go
@@ -1879,6 +1879,70 @@ func TestValidateWorkspaceRetentionDaysOutOfRange(t *testing.T) {
 	}
 }
 
+// nonPositiveTurnTimeoutWorkflow returns workflow content with a
+// non-positive agent.turn_timeout_ms and otherwise valid tracker/agent
+// fields, offline (the file tracker makes no network call).
+func nonPositiveTurnTimeoutWorkflow() []byte {
+	return []byte(`---
+polling:
+  interval_ms: 30000
+tracker:
+  kind: file
+  active_states:
+    - To Do
+  terminal_states:
+    - Done
+agent:
+  kind: mock
+  turn_timeout_ms: 0
+file:
+  path: issues.json
+---
+Do {{ .issue.title }}.
+`)
+}
+
+// TestValidateNonPositiveTurnTimeoutMSJSON verifies that a non-positive
+// agent.turn_timeout_ms is reported as an error diagnostic with check
+// name config.agent.turn_timeout_ms, offline (the file tracker makes no
+// network call).
+func TestValidateNonPositiveTurnTimeoutMSJSON(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	wfPath := writeCustomWorkflowFile(t, dir, nonPositiveTurnTimeoutWorkflow())
+
+	var stdout, stderr bytes.Buffer
+	ctx := context.Background()
+
+	code := run(ctx, []string{"validate", "--format", "json", wfPath}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("run(validate) = %d, want 1; stderr: %s", code, stderr.String())
+	}
+
+	var out validateOutput
+	if err := json.Unmarshal(stdout.Bytes(), &out); err != nil {
+		t.Fatalf("json.Unmarshal(%q) error: %v", stdout.String(), err)
+	}
+	if out.Valid {
+		t.Errorf("validateOutput.Valid = true, want false")
+	}
+
+	found := false
+	for _, d := range out.Errors {
+		if d.Check == "config.agent.turn_timeout_ms" {
+			found = true
+			if d.Message != "must be greater than 0" {
+				t.Errorf("diagnostic.Message = %q, want %q", d.Message, "must be greater than 0")
+			}
+			break
+		}
+	}
+	if !found {
+		t.Errorf("validateOutput.Errors = %v, want a diagnostic with check %q", out.Errors, "config.agent.turn_timeout_ms")
+	}
+}
+
 // TestValidateWorkspaceRetentionDaysValid covers R1 and R5: an in-range
 // workspace.retention_days value in the front matter is recognized by
 // the schema and produces no warnings, offline (the file tracker makes

--- a/docs/architecture/05-workflow-specification.md
+++ b/docs/architecture/05-workflow-specification.md
@@ -197,6 +197,9 @@ Fields:
   - HTTP-based agent adapters do not require a local command.
 - `turn_timeout_ms` (integer)
   - Default: `3600000` (1 hour)
+  - Must be positive. A non-positive value is rejected when the configuration is parsed.
+  - Unlike `stall_timeout_ms` below, this bound cannot be disabled: it is the last wall-clock
+    stop on an unattended turn, so no non-positive value switches it off.
 - `read_timeout_ms` (integer)
   - Default: `5000`
 - `stall_timeout_ms` (integer)

--- a/docs/architecture/06-configuration-specification.md
+++ b/docs/architecture/06-configuration-specification.md
@@ -233,7 +233,13 @@ This section is intentionally redundant so a coding agent can implement the conf
 - `hooks.timeout_ms`: integer, default `60000`
 - `agent.kind`: string, default `claude-code`
 - `agent.command`: shell command string, adapter-defined default
-- `agent.turn_timeout_ms`: integer, default `3600000`
+- `agent.turn_timeout_ms`: positive integer, default `3600000`; the deadline the orchestrator
+  places on the context of every agent turn it runs, self-review turns included; the expiry of
+  that deadline cancels the turn's context, and the attempt then fails with the `turn_timeout`
+  failure class, retryable per the retry path, once the adapter returns from the cancelled turn,
+  which for an adapter that does not observe a done context promptly is later than the deadline;
+  a non-positive value is rejected when the config is parsed, so startup, `sortie validate`, and
+  the live-reload fail-safe path all reject it
 - `agent.read_timeout_ms`: integer, default `5000`
 - `agent.stall_timeout_ms`: integer, default `300000`
 - `agent.max_concurrent_agents`: integer, default `10`

--- a/docs/architecture/21-reference-algorithms.md
+++ b/docs/architecture/21-reference-algorithms.md
@@ -274,6 +274,7 @@ selection without re-evaluating rules.
 ```text
 function run_agent_attempt(issue, attempt, orchestrator_channel):
   cfg = current_config()
+  turn_timeout_ms = cfg.agent.turn_timeout_ms  // snapshot at attempt start; bounds every turn below, including the self-review phase's turns (not re-read per turn)
 
   // Dispatch-time in-progress transition (non-fatal).
   if cfg.tracker.in_progress_state is configured:
@@ -312,17 +313,25 @@ function run_agent_attempt(issue, attempt, orchestrator_channel):
       run_hook_best_effort("after_run", workspace.path)
       fail_worker("prompt error")
 
-    turn_result = agent_adapter.run_turn(
+    // The derived turn context bounds only this call; worker_ctx itself is
+    // never replaced and keeps flowing to every consumer below.
+    turn_result, turn_err = agent_adapter.run_turn(
+      ctx=with_timeout(worker_ctx, turn_timeout_ms),
       session=session,
       prompt=prompt,
       issue=issue,
       on_message=(msg) -> send(orchestrator_channel, {agent_update, issue.id, msg})
     )
+    // An expiry of the derived context, observed once run_turn returns and
+    // with worker_ctx still live, is reclassified as a turn_timeout error.
+    // A worker_ctx that is already done (stall detection, terminal-state
+    // reconciliation, shutdown) keeps its own cancellation disposition
+    // instead, whatever the derived context is doing.
 
     if turn_result failed:
-      agent_adapter.stop_session(session)
+      agent_adapter.stop_session(session)  // on worker_ctx, never the derived turn context
       run_hook_best_effort("after_run", workspace.path)
-      fail_worker("agent turn error")
+      fail_worker(exit_kind_for_err(worker_ctx), turn_err)
 
     status = read_sortie_status(workspace.path)
     if status in ["blocked", "needs-human-review"]:
@@ -351,14 +360,16 @@ function run_agent_attempt(issue, attempt, orchestrator_channel):
   // when it is empty or names the completion signal; a pending "blocked"
   // reason skips the phase.
   review_metadata = null
-  cfg = current_config()  // re-read for dynamic reload
+  phase_err = null
+  cfg = current_config()  // re-read for dynamic reload; NOT the source of turn_timeout_ms (R-9)
   signal_admits = pending_reason == "" OR pending_reason == "needs-human-review"
   if cfg.self_review.enabled AND issue.state is active AND context not cancelled AND signal_admits:
     if pending_reason != "":
       log_info("agent signaled completion, entering self-review", issue.id, pending_reason)
       remove_sortie_status(workspace.path)  // consume on entry, before the phase's first read
-    review_metadata, phase_signal = run_self_review_loop(
-      session, workspace, issue, cfg.self_review, agent_adapter, orchestrator_channel
+    review_metadata, phase_signal, phase_err = run_self_review_loop(
+      session, workspace, issue, cfg.self_review, agent_adapter, orchestrator_channel,
+      turn_timeout_ms=turn_timeout_ms  // the attempt-start snapshot, bounding both phase turns
     )
     if pending_reason != "" AND phase_signal == "blocked":
       pending_reason = "blocked"
@@ -373,6 +384,22 @@ function run_agent_attempt(issue, attempt, orchestrator_channel):
       self_review_status = "cap_reached"
     else:
       self_review_status = "error"
+
+  // A phase turn's deadline expiry is the only self-review failure that
+  // ends the attempt: a diff-generation failure, a verification-command
+  // failure, a verdict parse failure, and a "blocked" status all keep the
+  // degrade-not-fail disposition above and fall through to the normal exit
+  // below. The derivation of self_review_status above runs unconditionally,
+  // on both the failure exit and the normal exit, so either teardown call
+  // carries the phase's real status rather than the "disabled" value a
+  // phase that never ran would leave behind.
+  if phase_err != null:
+    agent_adapter.stop_session(session)  // on worker_ctx, never the derived turn context
+    run_hook_best_effort("after_run", workspace.path, {
+      SORTIE_SELF_REVIEW_STATUS: self_review_status,
+      SORTIE_SELF_REVIEW_SUMMARY_PATH: workspace.path + "/.sortie/review_summary.md"
+    })
+    fail_worker(exit_kind_for_err(worker_ctx), phase_err, review_metadata=review_metadata)
 
   agent_adapter.stop_session(session)
   run_hook_best_effort("after_run", workspace.path, {

--- a/docs/architecture/22-test-and-validation-matrix.md
+++ b/docs/architecture/22-test-and-validation-matrix.md
@@ -29,6 +29,8 @@ Unless otherwise noted, Sections 17.1 through 17.7 are `Core Conformance`. Bulle
 - `$VAR` resolution works for tracker API key and path values
 - `~` path expansion works
 - `agent.command` is preserved as a shell command string
+- A non-positive `agent.turn_timeout_ms` is rejected at config parse time; an absent key takes
+  the default
 - Per-state concurrency override map normalizes state names and ignores invalid values
 - Prompt template renders `issue`, `attempt`, and `run`
 - Prompt rendering fails on unknown variables (strict mode)
@@ -158,6 +160,13 @@ Unless otherwise noted, Sections 17.1 through 17.7 are `Core Conformance`. Bulle
 - Retry backoff cap uses configured `agent.max_retry_backoff_ms`
 - Retry queue entries include attempt, due time, identifier, and error
 - Stall detection kills stalled sessions and schedules retry
+- A turn exceeding the configured turn timeout ends the attempt with the `turn_timeout` failure
+  and schedules a retry, while a worker whose context was already cancelled keeps its
+  cancellation disposition; this is the enforcing side of the property Section 17.5 lists as
+  "Turn timeout is enforced"
+- A self-review turn expiry ends the attempt the same way, while every other self-review failure
+  (diff generation, a verification command, a verdict parse, a `blocked` status) still exits
+  normally
 - Slot exhaustion requeues retries with explicit error reason
 - Dispatch-time in-progress transition calls `TransitionIssue` when `tracker.in_progress_state`
   is configured

--- a/docs/claude-code-adapter-notes.md
+++ b/docs/claude-code-adapter-notes.md
@@ -526,7 +526,7 @@ orchestrator re-checks tracker state and decides whether to continue.
 
 | Timeout                  | Source      | Enforcement                                                                                                                                                                                |
 | ------------------------ | ----------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `agent.turn_timeout_ms`  | WORKFLOW.md | Reaches the adapter as `domain.AgentConfig.TurnTimeoutMS` and is stored in `sessionState`. Nothing on the Claude path reads it; no per-turn deadline is set on the subprocess.              |
+| `agent.turn_timeout_ms`  | WORKFLOW.md | Reaches the adapter as `domain.AgentConfig.TurnTimeoutMS` and is stored in `sessionState`. Nothing on the Claude path reads it; the orchestrator derives the per-turn deadline and the subprocess inherits it through the context the skeleton passes to `exec.CommandContext`.              |
 | `agent.read_timeout_ms`  | WORKFLOW.md | Bounds session teardown: `orchestrator.stopSessionBestEffort` gives `StopSession` this many milliseconds on a detached context, defaulting to 10 000 ms.                                    |
 | `agent.stall_timeout_ms` | WORKFLOW.md | Enforced by the orchestrator. `orchestrator.reconcileStalled` compares `LastAgentTimestamp` against the threshold and cancels the worker's context, which terminates the turn.              |
 
@@ -535,8 +535,9 @@ orchestrator re-checks tracker state and decides whether to continue.
 `RunTurn` receives a context; the skeleton passes it to `exec.CommandContext` and installs a
 `cmd.Cancel` that sends `SIGTERM` to the process group, with `cmd.WaitDelay` set to the same
 5-second grace period before the force kill. When the context is cancelled (for example because
-tracker reconciliation found the issue terminal, or the stall detector fired), the turn returns
-`turn_cancelled` with `domain.ErrTurnCancelled` and whatever usage accumulated before the kill.
+tracker reconciliation found the issue terminal, the stall detector fired, or the orchestrator's
+per-turn deadline expired), the turn returns `turn_cancelled` with `domain.ErrTurnCancelled` and
+whatever usage accumulated before the kill.
 
 ---
 
@@ -601,8 +602,10 @@ Workspace and binary resolution fail earlier, in `StartSession`: an unusable wor
 `invalid_workspace_cwd` and an unresolvable command yields `agent_not_found`
 (`agentcore.ResolveWorkspace`, `agentcore.ResolveBinary`).
 
-The Claude path never produces `response_timeout`, `turn_timeout`, or `turn_input_required`: it
-enforces no adapter-side deadline, and `-p` admits no interactive prompt.
+The Claude path never produces `response_timeout` or `turn_input_required`: it enforces no
+adapter-side deadline, and `-p` admits no interactive prompt. It can end with `turn_timeout`: the
+orchestrator produces that kind on the adapter's return once its derived turn deadline expires,
+not the adapter itself.
 
 ### API retry errors
 

--- a/docs/copilot-adapter-notes.md
+++ b/docs/copilot-adapter-notes.md
@@ -504,7 +504,7 @@ orchestrator re-checks tracker state and decides whether to run another.
 
 | Timeout                  | Source      | Enforcement                                                                                                                                                                                           |
 | ------------------------ | ----------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `agent.turn_timeout_ms`  | WORKFLOW.md | Reaches the adapter on `domain.AgentConfig`, and no code path reads it. See "Open questions".                                                                                                          |
+| `agent.turn_timeout_ms`  | WORKFLOW.md | Reaches the adapter on `domain.AgentConfig`, and no code path on the Copilot side reads it; the orchestrator applies the bound per turn on the context it passes to `RunTurn`.                                                                                                          |
 | `agent.read_timeout_ms`  | WORKFLOW.md | The adapter enforces no read deadline. The worker uses this value only to bound its best-effort `StopSession` call.                                                                                    |
 | `agent.stall_timeout_ms` | WORKFLOW.md | Enforced by the orchestrator, not the adapter. `reconcileStalled` in `internal/orchestrator/reconcile.go` compares `LastAgentTimestamp` against the threshold and cancels the worker's context.        |
 
@@ -514,11 +514,11 @@ and API cost.
 
 ### Context cancellation
 
-`RunTurn` receives the worker's context. On cancellation, whether from stall reconciliation or
-from the tracker reporting the issue terminal, `exec.CommandContext` signals the process group
-gracefully through `procutil.SignalGraceful` and force-terminates the tree after the 5-second
-`WaitDelay`. The skeleton reports the turn as `turn_cancelled` with `ErrTurnCancelled`,
-carrying whatever usage had accumulated.
+`RunTurn` receives the worker's context. On cancellation, whether from stall reconciliation, from
+the tracker reporting the issue terminal, or from the orchestrator's per-turn deadline expiring,
+`exec.CommandContext` signals the process group gracefully through `procutil.SignalGraceful` and
+force-terminates the tree after the 5-second `WaitDelay`. The skeleton reports the turn as
+`turn_cancelled` with `ErrTurnCancelled`, carrying whatever usage had accumulated.
 
 ---
 
@@ -604,9 +604,10 @@ without producing output, treating as failure".
 | `copilot --version` canary fails                | `agent_not_found`       |
 | No GitHub authentication source                 | `agent_not_found`       |
 
-Turn outcomes use the categories in the exit-code table above. `response_timeout`,
-`turn_timeout`, and `turn_input_required` are unreachable for this adapter: it enforces no read
-or turn deadline, and `--no-ask-user` is passed on every invocation.
+Turn outcomes use the categories in the exit-code table above. `response_timeout` and
+`turn_input_required` are unreachable for this adapter: it enforces no read or turn deadline of
+its own, and `--no-ask-user` is passed on every invocation. `turn_timeout` is reachable: the
+orchestrator produces it on the adapter's return once its derived turn deadline expires.
 
 ### Known issues in the wild
 
@@ -1045,10 +1046,6 @@ the `subagentStop` hook can intercept and block subagent completion.
   fallback-on-failure behavior makes this immaterial to the adapter, which only checks that one
   source exists. Settle it by setting three valid tokens for distinct accounts and reading back
   the authenticated identity.
-- Whether `agent.turn_timeout_ms` is meant to bind this adapter. The value reaches
-  `domain.AgentConfig.TurnTimeoutMS` and no code reads it, so a turn is bounded only by
-  `stall_timeout_ms` and worker cancellation. Settle it against the agent adapter contract in
-  `docs/architecture/10-agent-adapter-contract.md`, not by probing the CLI.
 
 [cli-help-ref]: https://docs.github.com/en/copilot/reference/copilot-cli-reference/cli-command-reference "GitHub Copilot CLI command reference (includes flags such as --no-ask-user)"
 

--- a/docs/kiro-adapter-notes.md
+++ b/docs/kiro-adapter-notes.md
@@ -246,6 +246,12 @@ exit status 143 (128 + 15); on SIGKILL, 137 (128 + 9). The skeleton detects the 
 `procutil.WasSignaled` and returns `domain.EventTurnCancelled` with `domain.ErrTurnCancelled`
 before the adapter's own finalizer runs.
 
+The orchestrator now derives a per-turn deadline from `agent.turn_timeout_ms` and passes it on
+the context given to `RunTurn`, the same inheritance mechanism every other adapter relies on: a
+Go context deadline propagates to `agentcore.ForkPerTurnSession`'s own `context.WithCancel`
+re-derivation, so an expiry cancels the Kiro subprocess through the same signal-then-force-kill
+path described above.
+
 Stall detection still reaches Kiro turns despite the absent event stream: every non-empty
 stdout line becomes a `domain.EventNotification` carrying a fresh
 timestamp, and `orchestrator.HandleAgentEvent` advances `LastAgentTimestamp` from it, which
@@ -653,12 +659,6 @@ projection, while Kiro emits only a human transcript.
   Builder ID working while IAM Identity Center fails. Settled by repeating the workspace
   `mcp.json` probe (`mcp list` plus `chat --no-interactive --require-mcp-startup`) under a
   Builder ID login.
-- What enforces `agent.turn_timeout_ms` for a Kiro turn. The value reaches adapters through
-  `orchestrator.toDomainAgentConfig` as `domain.AgentConfig.TurnTimeoutMS`, and
-  `kiro.sessionState` stores it without reading it, but no deadline derived from it appears on
-  the path that calls `RunTurn`; `orchestrator.reconcileStalled` cancels on
-  `stall_timeout_ms` only. Settled by tracing the worker's turn context in
-  `internal/orchestrator`.
 
 ## Sources
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -576,12 +576,22 @@ func buildAgentConfig(m map[string]any) (AgentConfig, error) {
 
 	command := extractString(m, "command")
 
-	turnTimeoutMS, err := coerceIntField(m, "turn_timeout_ms", "agent.turn_timeout_ms")
-	if err != nil {
-		return AgentConfig{}, err
+	turnTimeoutMS := 3600000
+	if v, exists := m["turn_timeout_ms"]; exists && v != nil {
+		parsed, err := coerceInt(v)
+		if err != nil {
+			return AgentConfig{}, &ConfigError{
+				Field:   "agent.turn_timeout_ms",
+				Message: fmt.Sprintf("invalid integer value: %v", v),
+			}
+		}
+		turnTimeoutMS = parsed
 	}
-	if turnTimeoutMS == 0 {
-		turnTimeoutMS = 3600000
+	if turnTimeoutMS <= 0 {
+		return AgentConfig{}, &ConfigError{
+			Field:   "agent.turn_timeout_ms",
+			Message: "must be greater than 0",
+		}
 	}
 
 	readTimeoutMS, err := coerceIntField(m, "read_timeout_ms", "agent.read_timeout_ms")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2017,6 +2017,46 @@ func TestNewServiceConfig_SelfReview(t *testing.T) {
 	})
 }
 
+func TestNewServiceConfig_AgentTurnTimeoutMS(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Zero", func(t *testing.T) {
+		t.Parallel()
+		_, err := NewServiceConfig(map[string]any{"agent": map[string]any{"turn_timeout_ms": 0}})
+		assertConfigErrorField(t, err, "agent.turn_timeout_ms")
+		var ce *ConfigError
+		errors.As(err, &ce)
+		assertStringEqual(t, "ConfigError.Message", "must be greater than 0", ce.Message)
+	})
+
+	t.Run("Negative", func(t *testing.T) {
+		t.Parallel()
+		_, err := NewServiceConfig(map[string]any{"agent": map[string]any{"turn_timeout_ms": -1}})
+		assertConfigErrorField(t, err, "agent.turn_timeout_ms")
+		var ce *ConfigError
+		errors.As(err, &ce)
+		assertStringEqual(t, "ConfigError.Message", "must be greater than 0", ce.Message)
+	})
+
+	t.Run("AbsentKeyDefaults", func(t *testing.T) {
+		t.Parallel()
+		cfg, err := NewServiceConfig(map[string]any{})
+		if err != nil {
+			t.Fatalf("NewServiceConfig: %v", err)
+		}
+		assertIntEqual(t, "Agent.TurnTimeoutMS", 3600000, cfg.Agent.TurnTimeoutMS)
+	})
+
+	t.Run("NullValueDefaults", func(t *testing.T) {
+		t.Parallel()
+		cfg, err := NewServiceConfig(map[string]any{"agent": map[string]any{"turn_timeout_ms": nil}})
+		if err != nil {
+			t.Fatalf("NewServiceConfig: %v", err)
+		}
+		assertIntEqual(t, "Agent.TurnTimeoutMS", 3600000, cfg.Agent.TurnTimeoutMS)
+	})
+}
+
 // TestPopulateCIFeedbackFromReactions exercises the bridge function that
 // maps a ReactionConfig for the "ci_failure" kind into a CIFeedbackConfig.
 func TestPopulateCIFeedbackFromReactions(t *testing.T) {

--- a/internal/config/envoverride_test.go
+++ b/internal/config/envoverride_test.go
@@ -482,6 +482,13 @@ func TestApplyEnvOverrides(t *testing.T) {
 		assertEnvOverrideError(t, err, "workspace.retention_days", "SORTIE_WORKSPACE_RETENTION_DAYS")
 	})
 
+	t.Run("agent turn timeout override zero fails config construction", func(t *testing.T) {
+		t.Setenv("SORTIE_AGENT_TURN_TIMEOUT_MS", "0")
+
+		_, err := NewServiceConfig(map[string]any{})
+		assertEnvOverrideError(t, err, "agent.turn_timeout_ms", "must be greater than 0")
+	})
+
 	t.Run("top-level SORTIE_DB_PATH", func(t *testing.T) {
 		t.Setenv("SORTIE_DB_PATH", "/data/sortie.db")
 

--- a/internal/domain/agent.go
+++ b/internal/domain/agent.go
@@ -172,7 +172,9 @@ type AgentConfig struct {
 	Command string
 
 	// TurnTimeoutMS is the maximum duration in milliseconds for a
-	// single agent turn.
+	// single agent turn. The value is always positive: the
+	// configuration layer rejects a non-positive one rather than
+	// treating it as a sentinel that disables the bound.
 	TurnTimeoutMS int
 
 	// ReadTimeoutMS is the request/response timeout in milliseconds

--- a/internal/orchestrator/self_review.go
+++ b/internal/orchestrator/self_review.go
@@ -3,6 +3,7 @@ package orchestrator
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -39,6 +40,10 @@ type RunSelfReviewParams struct {
 	Logger         *slog.Logger
 	Metrics        domain.Metrics
 	TurnsCompleted *int
+
+	// TurnTimeoutMS bounds each agent turn the phase runs. Sourced
+	// from the attempt-start config snapshot, not re-read per turn.
+	TurnTimeoutMS int
 }
 
 // maxVerdictFileBytes is the cap on .sortie/review_verdict.json reads.
@@ -440,11 +445,12 @@ func writeReviewSummary(workspacePath string, meta domain.ReviewMetadata, logger
 	}
 }
 
-func runSelfReviewLoop(ctx context.Context, params RunSelfReviewParams) (*domain.ReviewMetadata, workspace.StatusSignal) {
+func runSelfReviewLoop(ctx context.Context, params RunSelfReviewParams) (*domain.ReviewMetadata, workspace.StatusSignal, error) {
 	maxIter := params.Config.MaxIterations
 	iterations := make([]domain.ReviewIterationRecord, 0, maxIter)
 	logger := params.Logger
 	terminalSignal := workspace.StatusNone
+	var expiryErr error
 
 	if params.OnProgress != nil {
 		params.OnProgress(selfReviewProgressMsg{
@@ -496,13 +502,13 @@ func runSelfReviewLoop(ctx context.Context, params RunSelfReviewParams) (*domain
 			)
 		}
 
-		_, turnErr := params.AgentAdapter.RunTurn(ctx, params.Session, domain.RunTurnParams{
+		_, turnErr := runBoundedTurn(ctx, params.AgentAdapter, params.Session, domain.RunTurnParams{
 			Prompt: reviewPrompt,
 			Issue:  params.Issue,
 			OnEvent: func(event domain.AgentEvent) {
 				params.OnEvent(params.Issue.ID, event)
 			},
-		})
+		}, params.TurnTimeoutMS, logger, slog.Int("iteration", i), slog.String("review_turn", "review"))
 		if turnErr != nil {
 			logger.Warn("self-review turn failed",
 				slog.Int("iteration", i),
@@ -515,6 +521,10 @@ func runSelfReviewLoop(ctx context.Context, params RunSelfReviewParams) (*domain
 				VerificationResults: verificationResults,
 				VerdictParseError:   fmt.Sprintf("turn error: %v", turnErr),
 			})
+			var agentErr *domain.AgentError
+			if errors.As(turnErr, &agentErr) && agentErr.Kind == domain.ErrTurnTimeout {
+				expiryErr = fmt.Errorf("self-review review turn (iteration %d): %w", i, turnErr)
+			}
 			break
 		}
 
@@ -602,18 +612,29 @@ func runSelfReviewLoop(ctx context.Context, params RunSelfReviewParams) (*domain
 
 		fixPrompt := buildFixPrompt(verdict, parseErr, i, maxIter)
 
-		_, fixErr := params.AgentAdapter.RunTurn(ctx, params.Session, domain.RunTurnParams{
+		_, fixErr := runBoundedTurn(ctx, params.AgentAdapter, params.Session, domain.RunTurnParams{
 			Prompt: fixPrompt,
 			Issue:  params.Issue,
 			OnEvent: func(event domain.AgentEvent) {
 				params.OnEvent(params.Issue.ID, event)
 			},
-		})
+		}, params.TurnTimeoutMS, logger, slog.Int("iteration", i), slog.String("review_turn", "fix"))
 		if fixErr != nil {
 			logger.Warn("self-review fix turn failed",
 				slog.Int("iteration", i),
 				slog.Any("error", fixErr),
 			)
+			var agentErr *domain.AgentError
+			if errors.As(fixErr, &agentErr) && agentErr.Kind == domain.ErrTurnTimeout {
+				expiryErr = fmt.Errorf("self-review fix turn (iteration %d): %w", i, fixErr)
+				note := fmt.Sprintf("turn timeout: %v", fixErr)
+				last := &iterations[len(iterations)-1]
+				if last.VerdictParseError == "" {
+					last.VerdictParseError = note
+				} else {
+					last.VerdictParseError += "; " + note
+				}
+			}
 			break
 		}
 
@@ -666,5 +687,5 @@ func runSelfReviewLoop(ctx context.Context, params RunSelfReviewParams) (*domain
 
 	params.Metrics.IncSelfReviewSessions(finalVerdict)
 
-	return meta, terminalSignal
+	return meta, terminalSignal, expiryErr
 }

--- a/internal/orchestrator/self_review_test.go
+++ b/internal/orchestrator/self_review_test.go
@@ -908,7 +908,7 @@ func TestSelfReviewLoop_PassOnFirst(t *testing.T) {
 		verdicts: []domain.ReviewVerdict{{Verdict: "pass", Summary: "looks good"}},
 	}
 
-	meta, _ := runSelfReviewLoop(context.Background(), RunSelfReviewParams{
+	meta, _, _ := runSelfReviewLoop(context.Background(), RunSelfReviewParams{
 		Session:        domain.Session{ID: "sess"},
 		Issue:          selfReviewIssue(),
 		WorkspacePath:  wsPath,
@@ -970,7 +970,7 @@ func TestSelfReviewLoop_IterateThenPass(t *testing.T) {
 		},
 	}
 
-	meta, _ := runSelfReviewLoop(context.Background(), RunSelfReviewParams{
+	meta, _, _ := runSelfReviewLoop(context.Background(), RunSelfReviewParams{
 		Session:        domain.Session{ID: "sess"},
 		Issue:          selfReviewIssue(),
 		WorkspacePath:  wsPath,
@@ -1021,7 +1021,7 @@ func TestSelfReviewLoop_CapReached(t *testing.T) {
 		},
 	}
 
-	meta, _ := runSelfReviewLoop(context.Background(), RunSelfReviewParams{
+	meta, _, _ := runSelfReviewLoop(context.Background(), RunSelfReviewParams{
 		Session:        domain.Session{ID: "sess"},
 		Issue:          selfReviewIssue(),
 		WorkspacePath:  wsPath,
@@ -1062,7 +1062,7 @@ func TestSelfReviewLoop_MissingVerdict(t *testing.T) {
 	// Adapter writes no verdict file.
 	adapter := &verdictWriter{wsPath: wsPath, verdicts: nil}
 
-	meta, _ := runSelfReviewLoop(context.Background(), RunSelfReviewParams{
+	meta, _, _ := runSelfReviewLoop(context.Background(), RunSelfReviewParams{
 		Session:        domain.Session{ID: "sess"},
 		Issue:          selfReviewIssue(),
 		WorkspacePath:  wsPath,
@@ -1090,7 +1090,7 @@ func TestSelfReviewLoop_TurnError(t *testing.T) {
 
 	adapter := &failOnFirstAdapter{wsPath: wsPath}
 
-	meta, _ := runSelfReviewLoop(context.Background(), RunSelfReviewParams{
+	meta, _, _ := runSelfReviewLoop(context.Background(), RunSelfReviewParams{
 		Session:        domain.Session{ID: "sess"},
 		Issue:          selfReviewIssue(),
 		WorkspacePath:  wsPath,
@@ -1120,7 +1120,7 @@ func TestSelfReviewLoop_StatusBlocked(t *testing.T) {
 	// Adapter writes "blocked" status signal during the first review turn.
 	adapter := &statusWriterAdapter{wsPath: wsPath, status: "blocked"}
 
-	meta, _ := runSelfReviewLoop(context.Background(), RunSelfReviewParams{
+	meta, _, _ := runSelfReviewLoop(context.Background(), RunSelfReviewParams{
 		Session:        domain.Session{ID: "sess"},
 		Issue:          selfReviewIssue(),
 		WorkspacePath:  wsPath,
@@ -1159,7 +1159,7 @@ func TestSelfReviewLoop_ContextCancelled(t *testing.T) {
 		verdicts: []domain.ReviewVerdict{{Verdict: "pass", Summary: "done"}},
 	}
 
-	meta, _ := runSelfReviewLoop(ctx, RunSelfReviewParams{
+	meta, _, _ := runSelfReviewLoop(ctx, RunSelfReviewParams{
 		Session:        domain.Session{ID: "sess"},
 		Issue:          selfReviewIssue(),
 		WorkspacePath:  wsPath,
@@ -1192,7 +1192,7 @@ func TestSelfReviewLoop_ProgressEvents(t *testing.T) {
 		verdicts: []domain.ReviewVerdict{{Verdict: "pass", Summary: "good"}},
 	}
 
-	runSelfReviewLoop(context.Background(), RunSelfReviewParams{
+	_, _, _ = runSelfReviewLoop(context.Background(), RunSelfReviewParams{
 		Session:        domain.Session{ID: "sess"},
 		Issue:          selfReviewIssue(),
 		WorkspacePath:  wsPath,
@@ -1235,7 +1235,7 @@ func TestSelfReviewLoop_ReviewSummaryWritten(t *testing.T) {
 		verdicts: []domain.ReviewVerdict{{Verdict: "pass", Summary: "ok"}},
 	}
 
-	runSelfReviewLoop(context.Background(), RunSelfReviewParams{
+	_, _, _ = runSelfReviewLoop(context.Background(), RunSelfReviewParams{
 		Session:        domain.Session{ID: "sess"},
 		Issue:          selfReviewIssue(),
 		WorkspacePath:  wsPath,
@@ -1349,7 +1349,7 @@ func TestSelfReviewLoop_TerminalStatusSignal(t *testing.T) {
 				cancel()
 			}
 
-			_, signal := runSelfReviewLoop(ctx, RunSelfReviewParams{
+			_, signal, _ := runSelfReviewLoop(ctx, RunSelfReviewParams{
 				Session:        domain.Session{ID: "sess"},
 				Issue:          selfReviewIssue(),
 				WorkspacePath:  wsPath,
@@ -1390,7 +1390,7 @@ func TestSelfReviewLoop_NeedsHumanReviewOnFixTurnContinues(t *testing.T) {
 		},
 	}
 
-	meta, signal := runSelfReviewLoop(context.Background(), RunSelfReviewParams{
+	meta, signal, _ := runSelfReviewLoop(context.Background(), RunSelfReviewParams{
 		Session:        domain.Session{ID: "sess"},
 		Issue:          selfReviewIssue(),
 		WorkspacePath:  wsPath,
@@ -1433,7 +1433,7 @@ func TestSelfReviewLoop_NeedsHumanReviewEveryTurnHitsCap(t *testing.T) {
 
 	adapter := &repeatingNeedsReviewAdapter{t: t, wsPath: wsPath}
 
-	meta, signal := runSelfReviewLoop(context.Background(), RunSelfReviewParams{
+	meta, signal, _ := runSelfReviewLoop(context.Background(), RunSelfReviewParams{
 		Session:        domain.Session{ID: "sess"},
 		Issue:          selfReviewIssue(),
 		WorkspacePath:  wsPath,

--- a/internal/orchestrator/self_review_test.go
+++ b/internal/orchestrator/self_review_test.go
@@ -1455,3 +1455,135 @@ func TestSelfReviewLoop_NeedsHumanReviewEveryTurnHitsCap(t *testing.T) {
 		t.Error("CapReached = false, want true")
 	}
 }
+
+// --- Fix-turn deadline expiry ---
+
+// expiringFixTurnAdapter writes an optional verdict on its first RunTurn
+// call and then blocks until the context is done on every later call,
+// modeling an agent whose fix turn keeps running until the turn deadline
+// cancels it. Returning ctx.Err() mirrors what the subprocess-backed
+// adapters report once their context is cancelled.
+type expiringFixTurnAdapter struct {
+	t          *testing.T
+	wsPath     string
+	verdict    *domain.ReviewVerdict
+	rawVerdict string
+	callIdx    int
+}
+
+var _ domain.AgentAdapter = (*expiringFixTurnAdapter)(nil)
+
+func (e *expiringFixTurnAdapter) StartSession(_ context.Context, _ domain.StartSessionParams) (domain.Session, error) {
+	return domain.Session{ID: "expiring-sess"}, nil
+}
+func (e *expiringFixTurnAdapter) StopSession(_ context.Context, _ domain.Session) error { return nil }
+func (e *expiringFixTurnAdapter) EventStream() <-chan domain.AgentEvent                 { return nil }
+func (e *expiringFixTurnAdapter) RunTurn(ctx context.Context, sess domain.Session, params domain.RunTurnParams) (domain.TurnResult, error) {
+	idx := e.callIdx
+	e.callIdx++
+
+	if idx > 0 {
+		<-ctx.Done()
+		return domain.TurnResult{}, ctx.Err()
+	}
+
+	if e.verdict != nil {
+		writeVerdictFile(e.t, e.wsPath, *e.verdict)
+	}
+	if e.rawVerdict != "" {
+		dir := filepath.Join(e.wsPath, ".sortie")
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			e.t.Fatalf("MkdirAll(.sortie): %v", err)
+		}
+		path := filepath.Join(dir, "review_verdict.json")
+		if err := os.WriteFile(path, []byte(e.rawVerdict), 0o600); err != nil {
+			e.t.Fatalf("WriteFile(review_verdict.json): %v", err)
+		}
+	}
+	if params.OnEvent != nil {
+		params.OnEvent(domain.AgentEvent{Type: domain.EventNotification})
+	}
+	return domain.TurnResult{SessionID: sess.ID, ExitReason: domain.EventTurnCompleted}, nil
+}
+
+// TestSelfReviewLoop_FixTurnTimeoutAnnotatesIteration verifies that a fix
+// turn exceeding the turn bound fails the phase and records the expiry on
+// the iteration already appended for that round, adding to any verdict
+// diagnostic already there instead of replacing it.
+func TestSelfReviewLoop_FixTurnTimeoutAnnotatesIteration(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		// verdict is written by the review turn when set.
+		verdict *domain.ReviewVerdict
+		// rawVerdict, when set, is written as the verdict file before the
+		// phase starts so the iteration carries a parse diagnostic.
+		rawVerdict string
+		// wantPrior is the diagnostic the expiry note must be appended to,
+		// empty when the iteration carries none.
+		wantPrior string
+	}{
+		{
+			name:    "sets the note on an iteration with no prior diagnostic",
+			verdict: &domain.ReviewVerdict{Verdict: "iterate", Summary: "needs fix"},
+		},
+		{
+			name:       "appends to a prior diagnostic instead of replacing it",
+			rawVerdict: "{not json",
+			wantPrior:  "verdict parse error",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			wsPath := t.TempDir()
+			turns := 0
+			cfg := selfReviewCfg()
+			cfg.MaxIterations = 2
+
+			meta, _, phaseErr := runSelfReviewLoop(context.Background(), RunSelfReviewParams{
+				Session:        domain.Session{ID: "sess"},
+				Issue:          selfReviewIssue(),
+				WorkspacePath:  wsPath,
+				Config:         cfg,
+				AgentAdapter:   &expiringFixTurnAdapter{t: t, wsPath: wsPath, verdict: tt.verdict, rawVerdict: tt.rawVerdict},
+				OnEvent:        func(_ string, _ domain.AgentEvent) {},
+				Logger:         discardLogger(),
+				Metrics:        &domain.NoopMetrics{},
+				TurnsCompleted: &turns,
+				TurnTimeoutMS:  100,
+			})
+
+			var agentErr *domain.AgentError
+			if !errors.As(phaseErr, &agentErr) {
+				t.Fatalf("phase error = %v (%T), want *domain.AgentError", phaseErr, phaseErr)
+			}
+			if agentErr.Kind != domain.ErrTurnTimeout {
+				t.Errorf("AgentError.Kind = %q, want %q", agentErr.Kind, domain.ErrTurnTimeout)
+			}
+			if meta == nil {
+				t.Fatal("ReviewMetadata = nil, want the iteration record to survive the failure exit")
+			}
+			if len(meta.Iterations) != 1 {
+				t.Fatalf("len(Iterations) = %d, want 1", len(meta.Iterations))
+			}
+
+			got := meta.Iterations[0].VerdictParseError
+			if tt.wantPrior == "" {
+				if !strings.HasPrefix(got, "turn timeout: ") {
+					t.Errorf("VerdictParseError = %q, want prefix %q", got, "turn timeout: ")
+				}
+				return
+			}
+			if !strings.HasPrefix(got, tt.wantPrior) {
+				t.Errorf("VerdictParseError = %q, want the prior diagnostic %q preserved at the start", got, tt.wantPrior)
+			}
+			if !strings.Contains(got, "; turn timeout: ") {
+				t.Errorf("VerdictParseError = %q, want the expiry note appended after the prior diagnostic", got)
+			}
+		})
+	}
+}

--- a/internal/orchestrator/worker.go
+++ b/internal/orchestrator/worker.go
@@ -3,6 +3,7 @@ package orchestrator
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"maps"
@@ -443,6 +444,65 @@ func exitKindForErr(ctx context.Context) WorkerExitKind {
 		return WorkerExitCancelled
 	}
 	return WorkerExitError
+}
+
+// defaultTurnTimeoutMS is the fallback bound runBoundedTurn applies
+// when it receives a non-positive turnTimeoutMS, matching the config
+// layer's own default for agent.turn_timeout_ms.
+const defaultTurnTimeoutMS = 3_600_000
+
+// runBoundedTurn calls adapter.RunTurn under a deadline derived from
+// turnTimeoutMS and classifies the outcome once the call returns. A
+// parent ctx that is already done takes priority over the deadline, so
+// stall detection, tracker-state reconciliation, and shutdown keep
+// reporting their own cancellation rather than a turn timeout; only a
+// turn context that expired while ctx stayed live is reported as
+// [domain.ErrTurnTimeout]. Every other outcome, including a
+// non-timeout adapter error, is returned unchanged.
+//
+// ctx is never replaced or shadowed for the caller: runBoundedTurn
+// derives its own child context for the call and releases it before
+// returning. identity carries the caller's typed attributes naming
+// the turn in the log record an expiry or a non-positive substitution
+// produces; the caller's logger is used unmodified.
+func runBoundedTurn(
+	ctx context.Context,
+	adapter domain.AgentAdapter,
+	session domain.Session,
+	params domain.RunTurnParams,
+	turnTimeoutMS int,
+	logger *slog.Logger,
+	identity ...slog.Attr,
+) (domain.TurnResult, error) {
+	effectiveMS := turnTimeoutMS
+	if effectiveMS <= 0 {
+		attrs := append([]slog.Attr{slog.Int("configured_turn_timeout_ms", turnTimeoutMS)}, identity...)
+		logger.LogAttrs(ctx, slog.LevelWarn, "non-positive turn timeout, applying default", attrs...)
+		effectiveMS = defaultTurnTimeoutMS
+	}
+
+	turnCtx, cancel := context.WithTimeout(ctx, time.Duration(effectiveMS)*time.Millisecond)
+	defer cancel()
+
+	result, err := adapter.RunTurn(turnCtx, session, params)
+
+	if ctx.Err() != nil {
+		return result, err
+	}
+	if errors.Is(turnCtx.Err(), context.DeadlineExceeded) {
+		attrs := append([]slog.Attr{slog.Int("turn_timeout_ms", effectiveMS)}, identity...)
+		logger.LogAttrs(ctx, slog.LevelWarn, "turn timeout exceeded", attrs...)
+		cause := err
+		if cause == nil {
+			cause = context.DeadlineExceeded
+		}
+		return result, &domain.AgentError{
+			Kind:    domain.ErrTurnTimeout,
+			Message: fmt.Sprintf("turn exceeded the configured %d ms bound; the adapter then reported", effectiveMS),
+			Err:     cause,
+		}
+	}
+	return result, err
 }
 
 // foldLocalUsage applies the clamped-delta accounting rule to the
@@ -967,7 +1027,7 @@ func RunWorkerAttempt(ctx context.Context, issue domain.Issue, attempt *int, dep
 			localMeasured = false
 		}
 
-		turnResult, err := deps.AgentAdapter.RunTurn(ctx, session, domain.RunTurnParams{
+		turnResult, err := runBoundedTurn(ctx, deps.AgentAdapter, session, domain.RunTurnParams{
 			Prompt: rendered,
 			Issue:  issue,
 			OnEvent: func(event domain.AgentEvent) {
@@ -1001,7 +1061,7 @@ func RunWorkerAttempt(ctx context.Context, issue domain.Issue, attempt *int, dep
 				}
 				deps.OnEvent(issue.ID, event)
 			},
-		})
+		}, cfg.Agent.TurnTimeoutMS, logger, slog.Int("turn_number", turnNumber))
 
 		// Fold TurnResult.Usage into the local mirror on both the success
 		// and the error path, so a run-cumulative figure the adapter
@@ -1131,6 +1191,7 @@ func RunWorkerAttempt(ctx context.Context, issue domain.Issue, attempt *int, dep
 	// the completion signal; a pending blocked reason skips the phase.
 	reviewCfg := deps.ConfigFunc()
 	var reviewMeta *domain.ReviewMetadata
+	var phaseErr error
 
 	signalAdmits := pendingSoftStopReason == "" || pendingSoftStopReason == string(workspace.StatusNeedsHumanReview)
 	selfReviewGate := reviewCfg.SelfReview.Enabled && isActiveState(issue.State, activeStates) && ctx.Err() == nil && deps.Posture.DrivesIssueState() && signalAdmits
@@ -1144,7 +1205,7 @@ func RunWorkerAttempt(ctx context.Context, issue domain.Issue, attempt *int, dep
 			workspace.CleanupStatusFile(wsResult.Path, logger)
 		}
 		var phaseSignal workspace.StatusSignal
-		reviewMeta, phaseSignal = runSelfReviewLoop(ctx, RunSelfReviewParams{
+		reviewMeta, phaseSignal, phaseErr = runSelfReviewLoop(ctx, RunSelfReviewParams{
 			Session:        session,
 			Issue:          issue,
 			WorkspacePath:  wsResult.Path,
@@ -1155,6 +1216,7 @@ func RunWorkerAttempt(ctx context.Context, issue domain.Issue, attempt *int, dep
 			Logger:         logger,
 			Metrics:        deps.Metrics,
 			TurnsCompleted: &turnsCompleted,
+			TurnTimeoutMS:  cfg.Agent.TurnTimeoutMS,
 		})
 		// A blocked signal read inside the phase only replaces the
 		// pending reason when one is already pending: a run admitted
@@ -1189,6 +1251,47 @@ func RunWorkerAttempt(ctx context.Context, issue domain.Issue, attempt *int, dep
 				selfReviewSummaryPath = reviewSummaryPath
 			}
 		}
+	}
+
+	// A self-review turn's deadline expiry fails the attempt: the phase
+	// already ran its tail work above, so teardown here mirrors the
+	// normal exit's teardown, carrying the phase's own status and
+	// summary path rather than the empty values finishWorkspace() would
+	// pass to a hook that reads them.
+	if phaseErr != nil {
+		stopSessionBestEffort(ctx, deps.AgentAdapter, session, cfg, logger)
+		if deps.Posture.RunsSetupHooks() {
+			workspace.Finish(ctx, workspace.FinishParams{
+				Path:                  wsResult.Path,
+				Identifier:            issue.Identifier,
+				IssueID:               issue.ID,
+				Attempt:               attemptInt,
+				AfterRun:              cfg.Hooks.AfterRun,
+				HookTimeoutMS:         cfg.Hooks.TimeoutMS,
+				Logger:                logger,
+				SSHHost:               deps.SSHHost,
+				SelfReviewStatus:      selfReviewStatus,
+				SelfReviewSummaryPath: selfReviewSummaryPath,
+			})
+		}
+		reported = true
+		deps.OnExit(issue.ID, WorkerResult{
+			IssueID:            issue.ID,
+			Identifier:         issue.Identifier,
+			ExitKind:           exitKindForErr(ctx),
+			Error:              phaseErr,
+			ReviewMetadata:     reviewMeta,
+			TurnsCompleted:     turnsCompleted,
+			SessionID:          session.ID,
+			WorkspacePath:      wsResult.Path,
+			AgentAdapter:       agentKind,
+			Attempt:            attempt,
+			SSHHost:            deps.SSHHost,
+			ObservedIssueState: observedIssueState,
+			Usage:              localUsage,
+			UsageMeasured:      localMeasured,
+		})
+		return
 	}
 
 	stopSessionBestEffort(ctx, deps.AgentAdapter, session, cfg, logger)

--- a/internal/orchestrator/worker.go
+++ b/internal/orchestrator/worker.go
@@ -447,8 +447,11 @@ func exitKindForErr(ctx context.Context) WorkerExitKind {
 }
 
 // defaultTurnTimeoutMS is the fallback bound runBoundedTurn applies
-// when it receives a non-positive turnTimeoutMS, matching the config
-// layer's own default for agent.turn_timeout_ms.
+// when it receives a non-positive turnTimeoutMS. It repeats the config
+// layer's default for agent.turn_timeout_ms. Because that layer rejects
+// a non-positive value outright, the fallback is unreachable from a
+// parsed configuration; it exists so an AgentConfig assembled in code
+// cannot leave a turn unbounded.
 const defaultTurnTimeoutMS = 3_600_000
 
 // runBoundedTurn calls adapter.RunTurn under a deadline derived from
@@ -498,7 +501,7 @@ func runBoundedTurn(
 		}
 		return result, &domain.AgentError{
 			Kind:    domain.ErrTurnTimeout,
-			Message: fmt.Sprintf("turn exceeded the configured %d ms bound; the adapter then reported", effectiveMS),
+			Message: fmt.Sprintf("turn exceeded the configured %d ms bound; the adapter's own report follows", effectiveMS),
 			Err:     cause,
 		}
 	}

--- a/internal/orchestrator/worker_test.go
+++ b/internal/orchestrator/worker_test.go
@@ -5661,3 +5661,538 @@ func TestRunWorkerAttempt_StatusSignalLogLines(t *testing.T) {
 		}
 	})
 }
+
+// --- Turn-timeout enforcement (issue #834) ---
+
+// boundedTurnStub is a domain.AgentAdapter.RunTurn stub that emits an
+// event on every tick of interval until ctx is done or natural elapses,
+// whichever comes first. natural must exceed whatever turn-timeout bound
+// the calling test configures, by a margin the test can measure: with no
+// deadline applied anywhere, the stub returns successfully at natural and
+// assertions expecting a timeout fail on a completed turn instead of the
+// test blocking on it.
+type boundedTurnStub struct {
+	natural time.Duration
+}
+
+// boundedTurnStubEventInterval is the fixed tick at which boundedTurnStub
+// emits an event while its RunTurn call is still running.
+const boundedTurnStubEventInterval = 10 * time.Millisecond
+
+func (s *boundedTurnStub) runTurn(ctx context.Context, session domain.Session, params domain.RunTurnParams) (domain.TurnResult, error) {
+	ticker := time.NewTicker(boundedTurnStubEventInterval)
+	defer ticker.Stop()
+	timer := time.NewTimer(s.natural)
+	defer timer.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return domain.TurnResult{}, ctx.Err()
+		case <-timer.C:
+			return domain.TurnResult{SessionID: session.ID, ExitReason: domain.EventTurnCompleted}, nil
+		case <-ticker.C:
+			if params.OnEvent != nil {
+				params.OnEvent(domain.AgentEvent{Type: domain.EventNotification, Timestamp: time.Now().UTC()})
+			}
+		}
+	}
+}
+
+// newBoundedTurnFn returns a mockAgentAdapter.runTurnFn-shaped stub (see
+// boundedTurnStub).
+func newBoundedTurnFn(natural time.Duration) func(ctx context.Context, session domain.Session, params domain.RunTurnParams) (domain.TurnResult, error) {
+	stub := &boundedTurnStub{natural: natural}
+	return stub.runTurn
+}
+
+// linesWithAttr returns every line of a slog TextHandler's output carrying
+// the given attribute key, isolating one structured log record from
+// others the same code path may also emit.
+func linesWithAttr(logOutput, key string) []string {
+	var lines []string
+	for line := range strings.SplitSeq(logOutput, "\n") {
+		if strings.Contains(line, key+"=") {
+			lines = append(lines, line)
+		}
+	}
+	return lines
+}
+
+func TestRunWorkerAttempt_TurnTimeoutExpires(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	cfg := defaultWorkerConfig(tmpDir)
+	cfg.Agent.TurnTimeoutMS = 150
+	cfg.Agent.StallTimeoutMS = 0
+	cfg.Agent.MaxTurns = 1
+
+	var logBuf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&logBuf, nil))
+
+	runTurnFn := newBoundedTurnFn(2 * time.Second)
+	ec := newExitCapture()
+
+	deps := WorkerDeps{
+		TrackerAdapter:         &mockTrackerAdapter{},
+		AgentAdapter:           &mockAgentAdapter{runTurnFn: runTurnFn},
+		ConfigFunc:             func() config.ServiceConfig { return cfg },
+		PromptTemplateByIDFunc: func(_ string) *prompt.Template { return mustParseTemplate(t, "{{ .issue.title }}") },
+		OnEvent:                func(_ string, _ domain.AgentEvent) {},
+		OnExit:                 ec.onExit,
+		Logger:                 logger,
+	}
+
+	start := time.Now()
+	RunWorkerAttempt(context.Background(), workerTestIssue(), nil, deps)
+	elapsed := time.Since(start)
+	result := ec.waitResult(t)
+
+	var agentErr *domain.AgentError
+	if !errors.As(result.Error, &agentErr) {
+		t.Fatalf("result.Error = %v (%T), want *domain.AgentError", result.Error, result.Error)
+	}
+	if agentErr.Kind != domain.ErrTurnTimeout {
+		t.Errorf("AgentError.Kind = %q, want %q", agentErr.Kind, domain.ErrTurnTimeout)
+	}
+	if elapsed >= 1*time.Second {
+		t.Errorf("RunWorkerAttempt took %v, want well under the stub's 2s natural duration", elapsed)
+	}
+
+	lines := linesWithAttr(logBuf.String(), "turn_timeout_ms")
+	if len(lines) != 1 {
+		t.Fatalf("WARN records carrying turn_timeout_ms = %d, want 1; log:\n%s", len(lines), logBuf.String())
+	}
+	if !strings.Contains(lines[0], "level=WARN") {
+		t.Errorf("record = %q, want level=WARN", lines[0])
+	}
+	if !strings.Contains(lines[0], "turn_timeout_ms=150") {
+		t.Errorf("record = %q, want turn_timeout_ms=150", lines[0])
+	}
+	if !strings.Contains(lines[0], "turn_number=1") {
+		t.Errorf("record = %q, want turn_number=1", lines[0])
+	}
+}
+
+func TestRunWorkerAttempt_TurnTimeoutSchedulesRetry(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	cfg := defaultWorkerConfig(tmpDir)
+	cfg.Agent.TurnTimeoutMS = 150
+	cfg.Agent.StallTimeoutMS = 0
+	cfg.Agent.MaxTurns = 1
+
+	runTurnFn := newBoundedTurnFn(2 * time.Second)
+	ec := newExitCapture()
+
+	deps := WorkerDeps{
+		TrackerAdapter:         &mockTrackerAdapter{},
+		AgentAdapter:           &mockAgentAdapter{runTurnFn: runTurnFn},
+		ConfigFunc:             func() config.ServiceConfig { return cfg },
+		PromptTemplateByIDFunc: func(_ string) *prompt.Template { return mustParseTemplate(t, "{{ .issue.title }}") },
+		OnEvent:                func(_ string, _ domain.AgentEvent) {},
+		OnExit:                 ec.onExit,
+		Logger:                 discardLogger(),
+	}
+
+	RunWorkerAttempt(context.Background(), workerTestIssue(), nil, deps)
+	result := ec.waitResult(t)
+
+	if result.ExitKind != WorkerExitError {
+		t.Fatalf("ExitKind = %q, want %q (a deadline placed on the worker context instead of the turn would yield %q and no retry entry)",
+			result.ExitKind, WorkerExitError, WorkerExitCancelled)
+	}
+
+	store := &mockExitStore{}
+	state := exitStateWithIssue(t, result.IssueID, "To Do")
+	params := defaultExitParams(t, store)
+
+	HandleWorkerExit(state, result, params)
+
+	retryEntry, ok := state.RetryAttempts[result.IssueID]
+	if !ok {
+		t.Fatal("retry not scheduled after turn-timeout error exit")
+	}
+	if want := NextAttempt(nil); retryEntry.Attempt != want {
+		t.Errorf("retry Attempt = %d, want %d", retryEntry.Attempt, want)
+	}
+}
+
+func TestRunWorkerAttempt_CancellationNotReportedAsTimeout(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	cfg := defaultWorkerConfig(tmpDir)
+	cfg.Agent.TurnTimeoutMS = 60_000 // far above the stub's natural duration
+	cfg.Agent.MaxTurns = 1
+
+	var logBuf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&logBuf, nil))
+
+	runTurnFn := newBoundedTurnFn(5 * time.Second)
+	ec := newExitCapture()
+	ctx, cancel := context.WithCancel(context.Background())
+
+	deps := WorkerDeps{
+		TrackerAdapter:         &mockTrackerAdapter{},
+		AgentAdapter:           &mockAgentAdapter{runTurnFn: runTurnFn},
+		ConfigFunc:             func() config.ServiceConfig { return cfg },
+		PromptTemplateByIDFunc: func(_ string) *prompt.Template { return mustParseTemplate(t, "{{ .issue.title }}") },
+		OnEvent:                func(_ string, _ domain.AgentEvent) {},
+		OnExit:                 ec.onExit,
+		Logger:                 logger,
+	}
+
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+
+	RunWorkerAttempt(ctx, workerTestIssue(), nil, deps)
+	result := ec.waitResult(t)
+
+	if result.ExitKind != WorkerExitCancelled {
+		t.Fatalf("ExitKind = %q, want %q", result.ExitKind, WorkerExitCancelled)
+	}
+	var agentErr *domain.AgentError
+	if errors.As(result.Error, &agentErr) && agentErr.Kind == domain.ErrTurnTimeout {
+		t.Errorf("result.Error classified as turn_timeout on a plain cancellation: %v", result.Error)
+	}
+	if lines := linesWithAttr(logBuf.String(), "turn_timeout_ms"); len(lines) != 0 {
+		t.Errorf("WARN records carrying turn_timeout_ms = %v, want none on a cancellation", lines)
+	}
+}
+
+func TestRunWorkerAttempt_TurnTimeoutTeardownUsesReadTimeout(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("after_run hook uses touch command")
+	}
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	markerPath := filepath.Join(tmpDir, "after_run_marker")
+
+	cfg := defaultWorkerConfig(tmpDir)
+	cfg.Agent.TurnTimeoutMS = 150
+	cfg.Agent.ReadTimeoutMS = 5000
+	cfg.Agent.StallTimeoutMS = 0
+	cfg.Agent.MaxTurns = 1
+	cfg.Hooks.AfterRun = fmt.Sprintf("touch %s", markerPath)
+
+	runTurnFn := newBoundedTurnFn(2 * time.Second)
+	ec := newExitCapture()
+
+	// The context itself must be inspected inside the StopSession call:
+	// stopSessionBestEffort's own deferred cancel fires as soon as the
+	// call returns, so a context object captured here and inspected only
+	// after RunWorkerAttempt returns would always read back canceled.
+	var (
+		stopCalledMu    sync.Mutex
+		stopCalled      bool
+		stopErrAtCall   error
+		stopDeadline    time.Time
+		stopHadDeadline bool
+	)
+
+	deps := WorkerDeps{
+		TrackerAdapter: &mockTrackerAdapter{},
+		AgentAdapter: &mockAgentAdapter{
+			runTurnFn: runTurnFn,
+			stopSessionFn: func(ctx context.Context, _ domain.Session) error {
+				stopCalledMu.Lock()
+				stopCalled = true
+				stopErrAtCall = ctx.Err()
+				stopDeadline, stopHadDeadline = ctx.Deadline()
+				stopCalledMu.Unlock()
+				return nil
+			},
+		},
+		ConfigFunc:             func() config.ServiceConfig { return cfg },
+		PromptTemplateByIDFunc: func(_ string) *prompt.Template { return mustParseTemplate(t, "{{ .issue.title }}") },
+		OnEvent:                func(_ string, _ domain.AgentEvent) {},
+		OnExit:                 ec.onExit,
+		Logger:                 discardLogger(),
+	}
+
+	RunWorkerAttempt(context.Background(), workerTestIssue(), nil, deps)
+	ec.waitResult(t)
+
+	stopCalledMu.Lock()
+	called, errAtCall, deadline, hadDeadline := stopCalled, stopErrAtCall, stopDeadline, stopHadDeadline
+	stopCalledMu.Unlock()
+
+	if !called {
+		t.Fatal("StopSession was never called")
+	}
+	if errAtCall != nil {
+		t.Errorf("StopSession context already done at call time: %v, want live", errAtCall)
+	}
+	if !hadDeadline {
+		t.Fatal("StopSession context has no deadline")
+	}
+	if remaining := time.Until(deadline); remaining <= 3*time.Second || remaining > 5*time.Second {
+		t.Errorf("StopSession context deadline = %v from now, want in (3s, 5s], reflecting read_timeout_ms=5000 rather than the 150ms turn bound", remaining)
+	}
+
+	if _, err := os.Stat(markerPath); err != nil {
+		t.Errorf("after_run marker file not found: %v (teardown must still run after a turn timeout)", err)
+	}
+}
+
+func TestRunWorkerAttempt_NonPositiveTurnTimeoutSubstitutesDefault(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		value int
+	}{
+		{name: "zero", value: 0},
+		{name: "negative", value: -1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			tmpDir := t.TempDir()
+			cfg := defaultWorkerConfig(tmpDir)
+			cfg.Agent.TurnTimeoutMS = tt.value
+			cfg.Agent.MaxTurns = 1
+
+			var logBuf bytes.Buffer
+			logger := slog.New(slog.NewTextHandler(&logBuf, nil))
+			ec := newExitCapture()
+
+			deps := WorkerDeps{
+				TrackerAdapter:         &mockTrackerAdapter{},
+				AgentAdapter:           &mockAgentAdapter{}, // default RunTurn completes immediately
+				ConfigFunc:             func() config.ServiceConfig { return cfg },
+				PromptTemplateByIDFunc: func(_ string) *prompt.Template { return mustParseTemplate(t, "{{ .issue.title }}") },
+				OnEvent:                func(_ string, _ domain.AgentEvent) {},
+				OnExit:                 ec.onExit,
+				Logger:                 logger,
+			}
+
+			RunWorkerAttempt(context.Background(), workerTestIssue(), nil, deps)
+			result := ec.waitResult(t)
+
+			if result.ExitKind != WorkerExitNormal {
+				t.Fatalf("ExitKind = %q, want %q (a non-positive bound must still bound the turn at the package default, not skip it)",
+					result.ExitKind, WorkerExitNormal)
+			}
+
+			lines := linesWithAttr(logBuf.String(), "configured_turn_timeout_ms")
+			if len(lines) != 1 {
+				t.Fatalf("WARN records carrying configured_turn_timeout_ms = %d, want 1; log:\n%s", len(lines), logBuf.String())
+			}
+			if want := fmt.Sprintf("configured_turn_timeout_ms=%d", tt.value); !strings.Contains(lines[0], want) {
+				t.Errorf("record = %q, want it to contain %q", lines[0], want)
+			}
+		})
+	}
+}
+
+func TestRunWorkerAttempt_SelfReviewTurnTimeoutFailsAttempt(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	cfg := defaultWorkerConfig(tmpDir)
+	cfg.Agent.TurnTimeoutMS = 150
+	cfg.Agent.StallTimeoutMS = 0
+	cfg.Agent.MaxTurns = 1
+	cfg.Tracker.HandoffState = "Human Review"
+	cfg.SelfReview = config.SelfReviewConfig{
+		Enabled:               true,
+		MaxIterations:         2,
+		VerificationCommands:  []string{"echo ok"},
+		VerificationTimeoutMS: 5000,
+	}
+
+	var logBuf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&logBuf, nil))
+
+	reviewTurnFn := newBoundedTurnFn(2 * time.Second)
+	ec := newExitCapture()
+
+	deps := WorkerDeps{
+		TrackerAdapter: &mockTrackerAdapter{},
+		AgentAdapter: &mockAgentAdapter{
+			runTurnFn: func(ctx context.Context, session domain.Session, params domain.RunTurnParams) (domain.TurnResult, error) {
+				if isSelfReviewTurnPrompt(params.Prompt) {
+					return reviewTurnFn(ctx, session, params)
+				}
+				return domain.TurnResult{SessionID: session.ID, ExitReason: domain.EventTurnCompleted}, nil
+			},
+		},
+		ConfigFunc:             func() config.ServiceConfig { return cfg },
+		PromptTemplateByIDFunc: func(_ string) *prompt.Template { return mustParseTemplate(t, "{{ .issue.title }}") },
+		OnEvent:                func(_ string, _ domain.AgentEvent) {},
+		OnExit:                 ec.onExit,
+		Logger:                 logger,
+	}
+
+	RunWorkerAttempt(context.Background(), workerTestIssue(), nil, deps)
+	result := ec.waitResult(t)
+
+	var agentErr *domain.AgentError
+	if !errors.As(result.Error, &agentErr) {
+		t.Fatalf("result.Error = %v (%T), want *domain.AgentError", result.Error, result.Error)
+	}
+	if agentErr.Kind != domain.ErrTurnTimeout {
+		t.Errorf("AgentError.Kind = %q, want %q", agentErr.Kind, domain.ErrTurnTimeout)
+	}
+	if result.ExitKind != WorkerExitError {
+		t.Errorf("ExitKind = %q, want %q (a self-review turn expiry must fail the attempt, not degrade it)", result.ExitKind, WorkerExitError)
+	}
+	if !strings.Contains(result.Error.Error(), "iteration 1") {
+		t.Errorf("error text = %q, want it to name iteration 1", result.Error.Error())
+	}
+	if !strings.Contains(result.Error.Error(), "review turn") {
+		t.Errorf("error text = %q, want it to name the review turn", result.Error.Error())
+	}
+	if result.ReviewMetadata == nil {
+		t.Fatal("ReviewMetadata is nil, want non-nil")
+	}
+
+	store := &mockExitStore{}
+	tracker := &mockTrackerAdapter{}
+	state := exitStateWithIssue(t, result.IssueID, "To Do")
+	params := handoffEvidenceExitParams(t, store, tracker, &domain.NoopMetrics{})
+	params.CommentsConfig.OnFailure = true
+
+	HandleWorkerExit(state, result, params)
+	state.TrackerOpsWg.Wait()
+
+	if len(tracker.commentCalls) != 1 {
+		t.Errorf("commentCalls = %v, want exactly 1 failure comment", tracker.commentCalls)
+	}
+	if len(tracker.transitionCalls) != 0 {
+		t.Errorf("transitionCalls = %v, want 0 (no handoff attempted on a phase failure exit, even with handoff_state configured)", tracker.transitionCalls)
+	}
+
+	lines := linesWithAttr(logBuf.String(), "turn_timeout_ms")
+	if len(lines) != 1 {
+		t.Fatalf("WARN records carrying turn_timeout_ms = %d, want 1; log:\n%s", len(lines), logBuf.String())
+	}
+	if !strings.Contains(lines[0], "level=WARN") {
+		t.Errorf("record = %q, want level=WARN", lines[0])
+	}
+	if !strings.Contains(lines[0], "iteration=1") {
+		t.Errorf("record = %q, want iteration=1", lines[0])
+	}
+	if !strings.Contains(lines[0], "review_turn=review") {
+		t.Errorf("record = %q, want review_turn=review", lines[0])
+	}
+	if strings.Contains(lines[0], "turn_number=") {
+		t.Errorf("record = %q, want no turn_number attribute for a phase-turn expiry", lines[0])
+	}
+}
+
+func TestRunWorkerAttempt_SelfReviewNonTimeoutTurnErrorStillExitsNormal(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	cfg := defaultWorkerConfig(tmpDir)
+	cfg.Agent.MaxTurns = 1
+	cfg.SelfReview = config.SelfReviewConfig{
+		Enabled:               true,
+		MaxIterations:         2,
+		VerificationCommands:  []string{"echo ok"},
+		VerificationTimeoutMS: 5000,
+	}
+
+	ec := newExitCapture()
+
+	deps := WorkerDeps{
+		TrackerAdapter: &mockTrackerAdapter{},
+		AgentAdapter: &mockAgentAdapter{
+			runTurnFn: func(_ context.Context, session domain.Session, params domain.RunTurnParams) (domain.TurnResult, error) {
+				if isSelfReviewTurnPrompt(params.Prompt) {
+					return domain.TurnResult{}, fmt.Errorf("simulated turn error")
+				}
+				return domain.TurnResult{SessionID: session.ID, ExitReason: domain.EventTurnCompleted}, nil
+			},
+		},
+		ConfigFunc:             func() config.ServiceConfig { return cfg },
+		PromptTemplateByIDFunc: func(_ string) *prompt.Template { return mustParseTemplate(t, "{{ .issue.title }}") },
+		OnEvent:                func(_ string, _ domain.AgentEvent) {},
+		OnExit:                 ec.onExit,
+		Logger:                 discardLogger(),
+	}
+
+	RunWorkerAttempt(context.Background(), workerTestIssue(), nil, deps)
+	result := ec.waitResult(t)
+
+	if result.ExitKind != WorkerExitNormal {
+		t.Errorf("ExitKind = %q, want %q (a non-timeout phase turn error must not fail the attempt)", result.ExitKind, WorkerExitNormal)
+	}
+	if result.Error != nil {
+		t.Errorf("result.Error = %v, want nil on a normal exit", result.Error)
+	}
+}
+
+func TestRunWorkerAttempt_TurnTimeoutBoundIsAttemptStartSnapshot(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	baseCfg := defaultWorkerConfig(tmpDir)
+	baseCfg.Agent.MaxTurns = 1
+	baseCfg.SelfReview = config.SelfReviewConfig{
+		Enabled:               true,
+		MaxIterations:         1,
+		VerificationCommands:  []string{"echo ok"},
+		VerificationTimeoutMS: 5000,
+	}
+
+	const attemptStartBoundMS = 10_000 // T
+	const postSwitchBoundMS = 100      // U
+
+	var useSecondConfig atomic.Bool
+	configFunc := func() config.ServiceConfig {
+		cfg := baseCfg
+		if useSecondConfig.Load() {
+			cfg.Agent.TurnTimeoutMS = postSwitchBoundMS
+		} else {
+			cfg.Agent.TurnTimeoutMS = attemptStartBoundMS
+		}
+		return cfg
+	}
+
+	ec := newExitCapture()
+
+	deps := WorkerDeps{
+		TrackerAdapter: &mockTrackerAdapter{},
+		AgentAdapter: &mockAgentAdapter{
+			runTurnFn: func(_ context.Context, session domain.Session, params domain.RunTurnParams) (domain.TurnResult, error) {
+				if isSelfReviewTurnPrompt(params.Prompt) {
+					// Between U (100ms) and T (10s): correct under T, expires under U.
+					time.Sleep(300 * time.Millisecond)
+					return domain.TurnResult{SessionID: session.ID, ExitReason: domain.EventTurnCompleted}, nil
+				}
+				// The primary-loop coding turn: flip the switch after this
+				// turn's own work is done but before returning, so the
+				// phase's later reviewCfg := deps.ConfigFunc() read has
+				// already observed the flip by the time it runs.
+				useSecondConfig.Store(true)
+				return domain.TurnResult{SessionID: session.ID, ExitReason: domain.EventTurnCompleted}, nil
+			},
+		},
+		ConfigFunc:             configFunc,
+		PromptTemplateByIDFunc: func(_ string) *prompt.Template { return mustParseTemplate(t, "{{ .issue.title }}") },
+		OnEvent:                func(_ string, _ domain.AgentEvent) {},
+		OnExit:                 ec.onExit,
+		Logger:                 discardLogger(),
+	}
+
+	RunWorkerAttempt(context.Background(), workerTestIssue(), nil, deps)
+	result := ec.waitResult(t)
+
+	if result.ExitKind != WorkerExitNormal {
+		t.Fatalf("ExitKind = %q, want %q", result.ExitKind, WorkerExitNormal)
+	}
+	if result.Error != nil {
+		t.Errorf("result.Error = %v, want nil (the self-review turn must be bounded by the attempt-start T, not a later re-read of U)", result.Error)
+	}
+}

--- a/internal/orchestrator/worker_test.go
+++ b/internal/orchestrator/worker_test.go
@@ -6196,3 +6196,38 @@ func TestRunWorkerAttempt_TurnTimeoutBoundIsAttemptStartSnapshot(t *testing.T) {
 		t.Errorf("result.Error = %v, want nil (the self-review turn must be bounded by the attempt-start T, not a later re-read of U)", result.Error)
 	}
 }
+
+// TestRunBoundedTurn_ExpiryWithNilAdapterError verifies that an adapter
+// reporting success after its context expired is still classified as a
+// turn timeout, with the deadline substituted as the wrapped cause so the
+// rendered error names something rather than trailing off.
+func TestRunBoundedTurn_ExpiryWithNilAdapterError(t *testing.T) {
+	t.Parallel()
+
+	adapter := &mockAgentAdapter{
+		runTurnFn: func(ctx context.Context, _ domain.Session, _ domain.RunTurnParams) (domain.TurnResult, error) {
+			<-ctx.Done()
+			return domain.TurnResult{}, nil
+		},
+	}
+
+	_, err := runBoundedTurn(
+		context.Background(),
+		adapter,
+		domain.Session{ID: "sess"},
+		domain.RunTurnParams{},
+		50,
+		discardLogger(),
+	)
+
+	var agentErr *domain.AgentError
+	if !errors.As(err, &agentErr) {
+		t.Fatalf("err = %v (%T), want *domain.AgentError", err, err)
+	}
+	if agentErr.Kind != domain.ErrTurnTimeout {
+		t.Errorf("AgentError.Kind = %q, want %q", agentErr.Kind, domain.ErrTurnTimeout)
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("err = %v, want the deadline substituted as the wrapped cause", err)
+	}
+}

--- a/internal/workflow/manager_test.go
+++ b/internal/workflow/manager_test.go
@@ -29,6 +29,12 @@ func retentionWorkflow(days int) []byte {
 	return fmt.Appendf(nil, "---\npolling:\n  interval_ms: 5000\nworkspace:\n  retention_days: %d\n---\nDo the task for {{ .issue.title }}.\n", days)
 }
 
+// turnTimeoutWorkflow returns a minimal WORKFLOW.md content with the given
+// agent.turn_timeout_ms value.
+func turnTimeoutWorkflow(ms int) []byte {
+	return fmt.Appendf(nil, "---\npolling:\n  interval_ms: 5000\nagent:\n  turn_timeout_ms: %d\n---\nDo the task for {{ .issue.title }}.\n", ms)
+}
+
 func testLogger() *slog.Logger {
 	return slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 }
@@ -259,6 +265,39 @@ func TestManager_ReloadRetainsOnInvalidRetentionDays(t *testing.T) {
 	}
 	if got := mgr.Config().Workspace.RetentionDays; got != 30 {
 		t.Errorf("after failed Reload: Config().Workspace.RetentionDays = %d, want 30 (retained)", got)
+	}
+	if mgr.LastLoadError() == nil {
+		t.Error("after failed Reload: LastLoadError() is nil, want non-nil")
+	}
+}
+
+// TestManager_ReloadRetainsOnInvalidTurnTimeoutMS verifies that a reload
+// whose agent.turn_timeout_ms fails validation leaves the previously
+// loaded configuration in force rather than disabling the bound or
+// terminating the process.
+func TestManager_ReloadRetainsOnInvalidTurnTimeoutMS(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "WORKFLOW.md")
+	mustWriteFile(t, path, turnTimeoutWorkflow(1800000))
+
+	mgr, err := NewManager(path, testLogger())
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	if got := mgr.Config().Agent.TurnTimeoutMS; got != 1800000 {
+		t.Fatalf("initial Config().Agent.TurnTimeoutMS = %d, want 1800000", got)
+	}
+
+	mustWriteFile(t, path, turnTimeoutWorkflow(0))
+
+	err = mgr.Reload()
+	if err == nil {
+		t.Fatal("Reload() error = nil, want error")
+	}
+	if got := mgr.Config().Agent.TurnTimeoutMS; got != 1800000 {
+		t.Errorf("after failed Reload: Config().Agent.TurnTimeoutMS = %d, want 1800000 (retained)", got)
 	}
 	if mgr.LastLoadError() == nil {
 		t.Error("after failed Reload: LastLoadError() is nil, want non-nil")


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Fix

**Intent:** `agent.turn_timeout_ms` was parsed, schema-declared, and reported by `sortie resolve`, but no code path ever applied it, so a single agent turn could run indefinitely while `stall_timeout_ms` only bounds silence, not duration. This wires a per-turn deadline into the orchestrator so a turn that overruns the configured bound now ends and retries instead of running forever.

**Related Issues:** #834

### 🧭 Reviewer Guide

**Complexity:** Medium

#### Entry Point

`internal/orchestrator/worker.go`'s new `runBoundedTurn` helper. It derives a `context.WithTimeout` from `cfg.Agent.TurnTimeoutMS` around each `RunTurn` call and classifies the outcome once the call returns: if the parent context is already done, that cancellation disposition wins (so stall detection, tracker reconciliation, and shutdown still report their own reason); otherwise, an expired derived context is reported as `domain.ErrTurnTimeout` (the existing, already-retryable `turn_timeout` failure kind). The helper is used both in the main turn loop and in `runSelfReviewLoop` (`internal/orchestrator/self_review.go`), so a self-review turn's expiry now fails the attempt rather than degrading to a normal exit the way other self-review failures (verdict parse errors, failed verification commands, a `blocked` status) do.

#### Sensitive Areas

- `internal/orchestrator/worker.go`: the new failure branch after the self-review phase mirrors the normal-exit teardown (stop session, run the `after_run` hook with the phase's real status, report the exit) so a turn-timeout during self-review doesn't skip teardown or report stale status.
- `internal/config/config.go`: `agent.turn_timeout_ms` now rejects zero and negative values at parse time (startup, `sortie validate`, and reload) instead of silently substituting the one-hour default for `0`. This is a breaking change to a previously-tolerated input.

### ⚠️ Risk Assessment

- **Breaking Changes:** Yes. A `0` or negative `agent.turn_timeout_ms` in an existing WORKFLOW.md now fails config validation instead of being silently treated as the one-hour default. `agent.stall_timeout_ms` is unaffected and can still be disabled with a non-positive value.
- **Migrations/State:** No migrations or state changes.
