### PR TITLE
refactor(agent): remove the unreachable codex.skip_git_repo_check key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   cannot be disabled.
   ([#834](https://github.com/sortie-ai/sortie/issues/834))
 
+- The `codex.skip_git_repo_check` pass-through key is removed. It never
+  had an effect: the value was parsed and read by no launch path, and
+  the `codex app-server` transport the adapter drives exposes no
+  equivalent protocol field and rejects the equivalent flag, which
+  exists only on `codex exec`. The key also promised something the
+  adapter never needed. A workspace that is not a Git repository is the
+  default and already works, because the refusal the key named lives in
+  the `codex exec` wrapper, above the layer the adapter talks to.
+  Nothing validates unknown keys inside the `codex` block, so a
+  WORKFLOW.md that still sets the key is ignored rather than rejected.
+  ([#840](https://github.com/sortie-ai/sortie/issues/840))
+
 ## [1.20.0] - 2026-08-18
 
 ### Added

--- a/docs/codex-adapter-notes.md
+++ b/docs/codex-adapter-notes.md
@@ -772,7 +772,6 @@ codex:
 | `codex.model`               | string  | Model override (e.g., `gpt-5.4`). Maps to `model` on `thread/start` and `turn/start`. |
 | `codex.effort`              | string  | Reasoning effort: `low`, `medium`, `high`. Maps to `effort` on `turn/start`.|
 | `codex.personality`         | string  | Personality preset. Maps to `personality` on `thread/start`.              |
-| `codex.skip_git_repo_check` | boolean | Parsed into `passthroughConfig.SkipGitRepoCheck` and read by no launch path, so the value never reaches the subprocess. |
 
 The turn timeouts are not part of this block. `agent.turn_timeout_ms`, `agent.read_timeout_ms`,
 and `agent.stall_timeout_ms` are core config fields, described under "Timeout enforcement".

--- a/internal/agent/codex/command.go
+++ b/internal/agent/codex/command.go
@@ -15,7 +15,6 @@ type passthroughConfig struct {
 	ThreadSandbox     string
 	TurnSandboxPolicy map[string]any
 	Personality       string
-	SkipGitRepoCheck  bool
 }
 
 // parsePassthroughConfig extracts Codex-specific settings from the
@@ -28,7 +27,6 @@ func parsePassthroughConfig(config map[string]any) passthroughConfig {
 		ThreadSandbox:     typeutil.StringFrom(config, "thread_sandbox"),
 		TurnSandboxPolicy: typeutil.MapFrom(config, "turn_sandbox_policy"),
 		Personality:       typeutil.StringFrom(config, "personality"),
-		SkipGitRepoCheck:  typeutil.BoolFrom(config, "skip_git_repo_check", false),
 	}
 }
 

--- a/internal/agent/codex/parse_test.go
+++ b/internal/agent/codex/parse_test.go
@@ -52,7 +52,6 @@ func TestParsePassthroughConfig(t *testing.T) {
 				"approval_policy":     "never",
 				"thread_sandbox":      "workspaceWrite",
 				"personality":         "helpful",
-				"skip_git_repo_check": true,
 				"turn_sandbox_policy": map[string]any{"networkAccess": true},
 			},
 			want: passthroughConfig{
@@ -61,7 +60,6 @@ func TestParsePassthroughConfig(t *testing.T) {
 				ApprovalPolicy:    "never",
 				ThreadSandbox:     "workspaceWrite",
 				Personality:       "helpful",
-				SkipGitRepoCheck:  true,
 				TurnSandboxPolicy: map[string]any{"networkAccess": true},
 			},
 		},
@@ -72,17 +70,9 @@ func TestParsePassthroughConfig(t *testing.T) {
 				"effort":              false,
 				"approval_policy":     123,
 				"thread_sandbox":      []string{"not-a-string"},
-				"skip_git_repo_check": "yes",
 				"turn_sandbox_policy": "not-a-map",
 			},
 			want: passthroughConfig{},
-		},
-		{
-			name: "explicit false skip_git_repo_check",
-			config: map[string]any{
-				"skip_git_repo_check": false,
-			},
-			want: passthroughConfig{SkipGitRepoCheck: false},
 		},
 	}
 
@@ -104,9 +94,6 @@ func TestParsePassthroughConfig(t *testing.T) {
 			}
 			if got.Personality != tt.want.Personality {
 				t.Errorf("Personality = %q, want %q", got.Personality, tt.want.Personality)
-			}
-			if got.SkipGitRepoCheck != tt.want.SkipGitRepoCheck {
-				t.Errorf("SkipGitRepoCheck = %v, want %v", got.SkipGitRepoCheck, tt.want.SkipGitRepoCheck)
 			}
 			if len(got.TurnSandboxPolicy) != len(tt.want.TurnSandboxPolicy) {
 				t.Errorf("TurnSandboxPolicy len = %d, want %d", len(got.TurnSandboxPolicy), len(tt.want.TurnSandboxPolicy))


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Refactor

**Intent:** The `codex.skip_git_repo_check` pass-through key was parsed into a struct field that no launch path ever read, so an operator who set it got neither an effect nor a warning. There is nothing to connect it to either - the adapter drives `codex app-server`, whose protocol exposes no equivalent field and whose argument parser rejects the equivalent flag, which exists only on `codex exec` and is launched by no adapter code path - so the key is removed rather than wired up. The operator-facing documentation and the shipped example (`docs/workflow-reference.md`, `examples/WORKFLOW.codex.md`, and the published site pages) are deliberately out of scope here and tracked in #844, which is blocked on #840 by design because the wording there depends on how this resolves.

**Related Issues:** #840, #844

### 🧭 Reviewer Guide

**Complexity:** Low

#### Entry Point

`internal/agent/codex/command.go` - the whole change starts here: `passthroughConfig` loses its `SkipGitRepoCheck` field and `parsePassthroughConfig` loses the matching `typeutil.BoolFrom` assignment. The positive control for the field being dead is that every other member of the struct has a production reader (`Model`, `Effort`, `Personality`, `ApprovalPolicy`, `ThreadSandbox`, `TurnSandboxPolicy` are all consumed in `codex.go` or `protocol.go`) while this one has none, and `startThread` builds its `thread/start` params map field by field instead of marshaling the struct, so the value could not have reached the wire by accident.

#### Sensitive Areas

- `internal/agent/codex/parse_test.go`: the removed subtest existed solely to pin the dead field's explicit-`false` behaviour, and the removed fixtures were its inputs. What remains still covers the valid-value and wrong-type arms for every surviving key, so the deletions narrow the surface rather than the assertions.
- `docs/codex-adapter-notes.md`: only the table row for the removed key is dropped. The two remaining mentions in that file describe the upstream `codex exec --skip-git-repo-check` flag and are still accurate, so they stay.

### ⚠️ Risk Assessment

- **Breaking Changes:** No observable behaviour changes - the key never did anything, and nothing validates unknown keys inside the `codex` block, so an existing WORKFLOW.md that still sets it is ignored rather than rejected. That said, a documented configuration key is being withdrawn, which is a surface reduction operators should know about; the CHANGELOG entry records it under `Changed`. Removing the field also orphans nothing, since `typeutil.BoolFrom` keeps nine call sites across the OpenCode, Kiro, Copilot, and Claude Code adapters.
- **Migrations/State:** No migrations or state changes.
