### PR TITLE
refactor: apply Go modernize idioms for golangci-lint 2.13.0

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,5 +1,5 @@
 golang 1.26.1
-golangci-lint 2.12.2
+golangci-lint 2.13.0
 goreleaser 2.14.3
 nodejs 24.13.0
 python 3.13.12

--- a/cmd/sortie/main_test.go
+++ b/cmd/sortie/main_test.go
@@ -521,8 +521,7 @@ func TestRunSIGINTCleanShutdown(t *testing.T) {
 	select {
 	case waitErr := <-done:
 		if waitErr != nil {
-			var exitErr *exec.ExitError
-			if errors.As(waitErr, &exitErr) {
+			if exitErr, ok := errors.AsType[*exec.ExitError](waitErr); ok {
 				t.Errorf("subprocess exited with code %d after SIGINT, want 0; stderr:\n%s",
 					exitErr.ExitCode(), subStderr.String())
 			} else {

--- a/cmd/sortie/validate.go
+++ b/cmd/sortie/validate.go
@@ -201,8 +201,7 @@ func writeJSON(w io.Writer, v any) error {
 // arrive as *prompt.TemplateError and route through "template_parse"
 // with the offending absolute path included verbatim.
 func mapManagerError(err error) []validateDiag {
-	var we *workflow.WorkflowError
-	if errors.As(err, &we) {
+	if we, ok := errors.AsType[*workflow.WorkflowError](err); ok {
 		check := "workflow_load"
 		if we.Kind == workflow.ErrFrontMatterNotMap {
 			check = "workflow_front_matter"
@@ -210,13 +209,11 @@ func mapManagerError(err error) []validateDiag {
 		return []validateDiag{{Severity: "error", Check: check, Message: err.Error()}}
 	}
 
-	var ce *config.ConfigError
-	if errors.As(err, &ce) {
+	if ce, ok := errors.AsType[*config.ConfigError](err); ok {
 		return []validateDiag{{Severity: "error", Check: "config." + ce.Field, Message: ce.Message}}
 	}
 
-	var te *prompt.TemplateError
-	if errors.As(err, &te) {
+	if _, ok := errors.AsType[*prompt.TemplateError](err); ok {
 		return []validateDiag{{Severity: "error", Check: "template_parse", Message: err.Error()}}
 	}
 

--- a/internal/agent/agentcore/forkperturn.go
+++ b/internal/agent/agentcore/forkperturn.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"os"
 	"os/exec"
+	"slices"
 	"strconv"
 	"sync"
 	"time"
@@ -237,8 +238,8 @@ func (s *ForkPerTurnSession) RunTurn(
 		)
 		cmd = exec.CommandContext(cmdCtx, s.target.Command, sshArgs...) //nolint:gosec // args are constructed programmatically with shell quoting
 	} else {
-		allArgs := append(s.target.Args[:len(s.target.Args):len(s.target.Args)], cmdArgs...) //nolint:gocritic // intentional: target.Args has cap==len so append always allocates
-		cmd = exec.CommandContext(cmdCtx, s.target.Command, allArgs...)                      //nolint:gosec // args are constructed programmatically
+		allArgs := append(slices.Clip(s.target.Args), cmdArgs...)       //nolint:gocritic // intentional: target.Args has cap==len so append always allocates
+		cmd = exec.CommandContext(cmdCtx, s.target.Command, allArgs...) //nolint:gosec // args are constructed programmatically
 	}
 	procutil.SetProcessGroup(cmd)
 	cmd.Cancel = func() error {
@@ -274,14 +275,14 @@ func (s *ForkPerTurnSession) RunTurn(
 			usage := s.hooks.GetUsage()
 			EmitTurnCancelled(emit, "context cancelled", usage)
 			return domain.TurnResult{
-					SessionID:  s.hooks.GetSessionID(),
-					ExitReason: domain.EventTurnCancelled,
-					Usage:      usage,
-				}, &domain.AgentError{
-					Kind:    domain.ErrTurnCancelled,
-					Message: "turn cancelled",
-					Err:     ctx.Err(),
-				}
+				SessionID:  s.hooks.GetSessionID(),
+				ExitReason: domain.EventTurnCancelled,
+				Usage:      usage,
+			}, &domain.AgentError{
+				Kind:    domain.ErrTurnCancelled,
+				Message: "turn cancelled",
+				Err:     ctx.Err(),
+			}
 		}
 		return domain.TurnResult{}, &domain.AgentError{
 			Kind:    domain.ErrPortExit,
@@ -340,28 +341,28 @@ func (s *ForkPerTurnSession) RunTurn(
 			usage := s.hooks.GetUsage()
 			EmitTurnCancelled(emit, "context cancelled", usage)
 			return domain.TurnResult{
-					SessionID:  s.hooks.GetSessionID(),
-					ExitReason: domain.EventTurnCancelled,
-					Usage:      usage,
-				}, &domain.AgentError{
-					Kind:    domain.ErrTurnCancelled,
-					Message: "turn cancelled",
-					Err:     ctx.Err(),
-				}
+				SessionID:  s.hooks.GetSessionID(),
+				ExitReason: domain.EventTurnCancelled,
+				Usage:      usage,
+			}, &domain.AgentError{
+				Kind:    domain.ErrTurnCancelled,
+				Message: "turn cancelled",
+				Err:     ctx.Err(),
+			}
 		}
 
 		procutil.EmitWarnLines(stderrLines, s.logger)
 		usage := s.hooks.GetUsage()
 		EmitTurnFailed(emit, "stdout read error: "+scanErr.Error(), 0, usage)
 		return domain.TurnResult{
-				SessionID:  s.hooks.GetSessionID(),
-				ExitReason: domain.EventTurnFailed,
-				Usage:      usage,
-			}, &domain.AgentError{
-				Kind:    domain.ErrPortExit,
-				Message: "stdout scanner error",
-				Err:     scanErr,
-			}
+			SessionID:  s.hooks.GetSessionID(),
+			ExitReason: domain.EventTurnFailed,
+			Usage:      usage,
+		}, &domain.AgentError{
+			Kind:    domain.ErrPortExit,
+			Message: "stdout scanner error",
+			Err:     scanErr,
+		}
 	}
 
 	// Drain stderr before cmd.Wait() to avoid losing buffered data:
@@ -381,14 +382,14 @@ func (s *ForkPerTurnSession) RunTurn(
 		usage := s.hooks.GetUsage()
 		EmitTurnCancelled(emit, "context cancelled", usage)
 		return domain.TurnResult{
-				SessionID:  s.hooks.GetSessionID(),
-				ExitReason: domain.EventTurnCancelled,
-				Usage:      usage,
-			}, &domain.AgentError{
-				Kind:    domain.ErrTurnCancelled,
-				Message: "turn cancelled",
-				Err:     ctx.Err(),
-			}
+			SessionID:  s.hooks.GetSessionID(),
+			ExitReason: domain.EventTurnCancelled,
+			Usage:      usage,
+		}, &domain.AgentError{
+			Kind:    domain.ErrTurnCancelled,
+			Message: "turn cancelled",
+			Err:     ctx.Err(),
+		}
 	}
 
 	exitCode := procutil.ExtractExitCode(waitErr)
@@ -398,26 +399,26 @@ func (s *ForkPerTurnSession) RunTurn(
 		usage := s.hooks.GetUsage()
 		EmitTurnFailed(emit, "agent binary not found", 0, usage)
 		return domain.TurnResult{
-				SessionID:  s.hooks.GetSessionID(),
-				ExitReason: domain.EventTurnFailed,
-				Usage:      usage,
-			}, &domain.AgentError{
-				Kind:    domain.ErrAgentNotFound,
-				Message: "exit code 127",
-			}
+			SessionID:  s.hooks.GetSessionID(),
+			ExitReason: domain.EventTurnFailed,
+			Usage:      usage,
+		}, &domain.AgentError{
+			Kind:    domain.ErrAgentNotFound,
+			Message: "exit code 127",
+		}
 	}
 
 	if procutil.WasSignaled(waitErr) {
 		usage := s.hooks.GetUsage()
 		EmitTurnCancelled(emit, "killed by signal", usage)
 		return domain.TurnResult{
-				SessionID:  s.hooks.GetSessionID(),
-				ExitReason: domain.EventTurnCancelled,
-				Usage:      usage,
-			}, &domain.AgentError{
-				Kind:    domain.ErrTurnCancelled,
-				Message: "killed by signal",
-			}
+			SessionID:  s.hooks.GetSessionID(),
+			ExitReason: domain.EventTurnCancelled,
+			Usage:      usage,
+		}, &domain.AgentError{
+			Kind:    domain.ErrTurnCancelled,
+			Message: "killed by signal",
+		}
 	}
 
 	// Arms 6–10: delegated to OnFinalize.

--- a/internal/agent/codex/runturn_test.go
+++ b/internal/agent/codex/runturn_test.go
@@ -364,8 +364,7 @@ func TestRunTurn_FailedTurnContextWindowExceeded(t *testing.T) {
 	if err == nil {
 		t.Fatal("RunTurn() expected error, got nil")
 	}
-	var ae *domain.AgentError
-	if !errors.As(err, &ae) {
+	if _, ok := errors.AsType[*domain.AgentError](err); !ok {
 		t.Fatalf("error type = %T, want *domain.AgentError", err)
 	}
 	if result.ExitReason != domain.EventTurnFailed {

--- a/internal/agent/opencode/opencode_test.go
+++ b/internal/agent/opencode/opencode_test.go
@@ -410,8 +410,7 @@ func TestStopSession_WrongInternalType(t *testing.T) {
 	if err == nil {
 		t.Fatal("StopSession() error = nil, want error for wrong internal type")
 	}
-	var agentErr *domain.AgentError
-	if !errors.As(err, &agentErr) {
+	if _, ok := errors.AsType[*domain.AgentError](err); !ok {
 		t.Fatalf("error type = %T, want *domain.AgentError", err)
 	}
 }

--- a/internal/agent/procutil/procutil.go
+++ b/internal/agent/procutil/procutil.go
@@ -79,8 +79,7 @@ func ExtractExitCode(err error) int {
 	if err == nil {
 		return 0
 	}
-	var exitErr *exec.ExitError
-	if errors.As(err, &exitErr) {
+	if exitErr, ok := errors.AsType[*exec.ExitError](err); ok {
 		return exitErr.ExitCode()
 	}
 	return -1

--- a/internal/config/notifications_test.go
+++ b/internal/config/notifications_test.go
@@ -312,8 +312,7 @@ func TestNotificationsConfig_ErrorIsPtrConfigError(t *testing.T) {
 		t.Fatal("expected error, got nil")
 	}
 
-	var ce *ConfigError
-	if !errors.As(err, &ce) {
+	if _, ok := errors.AsType[*ConfigError](err); !ok {
 		t.Fatalf("error type = %T, want *ConfigError", err)
 	}
 }

--- a/internal/orchestrator/exit.go
+++ b/internal/orchestrator/exit.go
@@ -1320,13 +1320,11 @@ func classifyWorkerError(err error) domain.RetryClassification {
 		return domain.RetryClassification{Retryable: true, Backoff: domain.BackoffExponential}
 	}
 
-	var agentErr *domain.AgentError
-	if errors.As(err, &agentErr) {
+	if agentErr, ok := errors.AsType[*domain.AgentError](err); ok {
 		return agentErr.Kind.RetryClassification()
 	}
 
-	var trackerErr *domain.TrackerError
-	if errors.As(err, &trackerErr) {
+	if trackerErr, ok := errors.AsType[*domain.TrackerError](err); ok {
 		return trackerErr.Kind.RetryClassification()
 	}
 

--- a/internal/orchestrator/merge_completion_reconcile.go
+++ b/internal/orchestrator/merge_completion_reconcile.go
@@ -417,9 +417,8 @@ func routeTransitionFailure(
 ) {
 	rkey := ReactionKey(pending.IssueID, ReactionKindMergeCompletion)
 
-	var trackerErr *domain.TrackerError
 	kind := domain.ErrTrackerTransport
-	if errors.As(err, &trackerErr) {
+	if trackerErr, ok := errors.AsType[*domain.TrackerError](err); ok {
 		kind = trackerErr.Kind
 	}
 

--- a/internal/orchestrator/preflight.go
+++ b/internal/orchestrator/preflight.go
@@ -292,8 +292,7 @@ func validateDefaultedTrackerStates(tc config.TrackerConfig, meta registry.Track
 // a preflight message.
 func defaultedStateError(check string, err error, emptyKey, kind string) PreflightError {
 	message := err.Error()
-	var cfgErr *config.ConfigError
-	if errors.As(err, &cfgErr) {
+	if cfgErr, ok := errors.AsType[*config.ConfigError](err); ok {
 		message = cfgErr.Message
 	}
 

--- a/internal/prompt/turn_test.go
+++ b/internal/prompt/turn_test.go
@@ -178,8 +178,7 @@ func TestBuildTurnPrompt(t *testing.T) {
 		if err == nil {
 			t.Fatal("expected render error on continuation turn, got nil")
 		}
-		var te *TemplateError
-		if !errors.As(err, &te) {
+		if _, ok := errors.AsType[*TemplateError](err); !ok {
 			t.Fatalf("expected *TemplateError, got %T: %v", err, err)
 		}
 	})
@@ -197,8 +196,7 @@ func TestBuildTurnPrompt(t *testing.T) {
 			t.Fatal("expected error for turnNumber=0, got nil")
 		}
 		// Must NOT be a *TemplateError — this is a caller bug, not a template issue.
-		var te *TemplateError
-		if errors.As(err, &te) {
+		if _, ok := errors.AsType[*TemplateError](err); ok {
 			t.Errorf("BuildTurnPrompt(turnNumber=0) error type = %T, want plain error", err)
 		}
 	})

--- a/internal/scm/gitea/ci.go
+++ b/internal/scm/gitea/ci.go
@@ -135,8 +135,7 @@ func (p *GiteaCIProvider) FetchCIStatus(ctx context.Context, ref string) (domain
 
 	statuses, err := paginator.All(ctx)
 	if err != nil {
-		var ciErr *domain.CIError
-		if errors.As(err, &ciErr) {
+		if ciErr, ok := errors.AsType[*domain.CIError](err); ok {
 			return domain.CIResult{}, ciErr
 		}
 		return domain.CIResult{}, scmcore.ToCIError(fmt.Errorf("fetching ci status for ref %q: %w", ref, err))

--- a/internal/scm/gitea/ci_test.go
+++ b/internal/scm/gitea/ci_test.go
@@ -667,8 +667,7 @@ func TestGiteaToCIError(t *testing.T) {
 		if !errors.Is(err, context.Canceled) {
 			t.Errorf("FetchCIStatus(cancelled context) = %v, want context.Canceled in the chain", err)
 		}
-		var ciErr *domain.CIError
-		if errors.As(err, &ciErr) {
+		if ciErr, ok := errors.AsType[*domain.CIError](err); ok {
 			t.Errorf("FetchCIStatus(cancelled context) = %v, want the context error without CIError conversion", ciErr)
 		}
 	})

--- a/internal/scm/gitea/validate.go
+++ b/internal/scm/gitea/validate.go
@@ -42,8 +42,7 @@ func validateQueryFilter(raw string) []registry.ValidationDiag {
 	}
 
 	message := err.Error()
-	var trackerErr *domain.TrackerError
-	if errors.As(err, &trackerErr) {
+	if trackerErr, ok := errors.AsType[*domain.TrackerError](err); ok {
 		message = trackerErr.Message
 	}
 

--- a/internal/scm/github/integration_test.go
+++ b/internal/scm/github/integration_test.go
@@ -229,8 +229,7 @@ func TestIntegration_VerifyAutoMergeScopes(t *testing.T) {
 
 	scopes, missing, verifyErr := scmAdapter.VerifyAutoMergeScopes(context.Background(), true)
 	if verifyErr != nil {
-		var se *domain.SCMError
-		if errors.As(verifyErr, &se) {
+		if se, ok := errors.AsType[*domain.SCMError](verifyErr); ok {
 			t.Logf("VerifyAutoMergeScopes transport error (kind=%s): %v", se.Kind, verifyErr)
 		}
 		t.Skipf("VerifyAutoMergeScopes returned transport error; skipping scope assertion: %v", verifyErr)

--- a/internal/scm/github/tracker_test.go
+++ b/internal/scm/github/tracker_test.go
@@ -753,8 +753,7 @@ func TestFetchIssueByID_NotFound(t *testing.T) {
 	_, err := a.FetchIssueByID(context.Background(), "99")
 	assertTrackerErrorKind(t, err, domain.ErrTrackerNotFound)
 
-	var te *domain.TrackerError
-	if errors.As(err, &te) {
+	if te, ok := errors.AsType[*domain.TrackerError](err); ok {
 		if !strings.Contains(te.Message, "99") {
 			t.Errorf("TrackerError.Message = %q, should contain issue ID 99", te.Message)
 		}

--- a/internal/scm/gitlab/ci_test.go
+++ b/internal/scm/gitlab/ci_test.go
@@ -1071,8 +1071,7 @@ func TestFetchCIStatus_ContextCancelled(t *testing.T) {
 	if !errors.Is(err, context.Canceled) {
 		t.Errorf("FetchCIStatus(cancelled context) = %v, want context.Canceled in the chain", err)
 	}
-	var ciErr *domain.CIError
-	if errors.As(err, &ciErr) {
+	if ciErr, ok := errors.AsType[*domain.CIError](err); ok {
 		t.Errorf("FetchCIStatus(cancelled context) = %v, want the context error without CIError conversion", ciErr)
 	}
 }

--- a/internal/scm/gitlab/validate.go
+++ b/internal/scm/gitlab/validate.go
@@ -206,8 +206,7 @@ func validateQueryFilter(raw string) []registry.ValidationDiag {
 	}
 
 	message := err.Error()
-	var trackerErr *domain.TrackerError
-	if errors.As(err, &trackerErr) {
+	if trackerErr, ok := errors.AsType[*domain.TrackerError](err); ok {
 		message = trackerErr.Message
 	}
 

--- a/internal/scm/scmcore/cierror.go
+++ b/internal/scm/scmcore/cierror.go
@@ -40,13 +40,11 @@ func ToCIError(err error) error {
 		return err
 	}
 
-	var ciErr *domain.CIError
-	if errors.As(err, &ciErr) {
+	if _, ok := errors.AsType[*domain.CIError](err); ok {
 		return err
 	}
 
-	var te *domain.TrackerError
-	if errors.As(err, &te) {
+	if te, ok := errors.AsType[*domain.TrackerError](err); ok {
 		kind, ok := trackerToCIKind[te.Kind]
 		if !ok {
 			kind = domain.ErrCIAPI

--- a/internal/scm/scmcore/cierror_test.go
+++ b/internal/scm/scmcore/cierror_test.go
@@ -72,8 +72,7 @@ func TestToCIError_ContextCanceled(t *testing.T) {
 		if !errors.Is(got, context.Canceled) {
 			t.Errorf("ToCIError(context.Canceled) = %v, want context.Canceled passthrough", got)
 		}
-		var ce *domain.CIError
-		if errors.As(got, &ce) {
+		if ce, ok := errors.AsType[*domain.CIError](got); ok {
 			t.Errorf("ToCIError(context.Canceled) = %v, want no CIError conversion", ce)
 		}
 	})
@@ -86,8 +85,7 @@ func TestToCIError_ContextCanceled(t *testing.T) {
 		if got != context.Canceled {
 			t.Errorf("ToCIError(context.Canceled) = %v, want context.Canceled returned unchanged", got)
 		}
-		var ce *domain.CIError
-		if errors.As(got, &ce) {
+		if ce, ok := errors.AsType[*domain.CIError](got); ok {
 			t.Errorf("ToCIError(context.Canceled) = %v, want no CIError conversion", ce)
 		}
 	})
@@ -104,8 +102,7 @@ func TestToCIError_DeadlineExceeded(t *testing.T) {
 		if !errors.Is(got, context.DeadlineExceeded) {
 			t.Errorf("ToCIError(context.DeadlineExceeded) = %v, want context.DeadlineExceeded passthrough", got)
 		}
-		var ce *domain.CIError
-		if errors.As(got, &ce) {
+		if ce, ok := errors.AsType[*domain.CIError](got); ok {
 			t.Errorf("ToCIError(context.DeadlineExceeded) = %v, want no CIError conversion", ce)
 		}
 	})
@@ -118,8 +115,7 @@ func TestToCIError_DeadlineExceeded(t *testing.T) {
 		if got != context.DeadlineExceeded {
 			t.Errorf("ToCIError(context.DeadlineExceeded) = %v, want context.DeadlineExceeded returned unchanged", got)
 		}
-		var ce *domain.CIError
-		if errors.As(got, &ce) {
+		if ce, ok := errors.AsType[*domain.CIError](got); ok {
 			t.Errorf("ToCIError(context.DeadlineExceeded) = %v, want no CIError conversion", ce)
 		}
 	})

--- a/internal/scm/scmcore/scmerror.go
+++ b/internal/scm/scmcore/scmerror.go
@@ -67,8 +67,7 @@ func ToSCMError(err error) *domain.SCMError {
 // it, so it is the safe choice whenever an error may already carry one; an
 // error that cannot may use [ToSCMError] directly.
 func AsSCMError(err error) *domain.SCMError {
-	var scmErr *domain.SCMError
-	if errors.As(err, &scmErr) {
+	if scmErr, ok := errors.AsType[*domain.SCMError](err); ok {
 		return scmErr
 	}
 	return ToSCMError(err)

--- a/internal/tool/trackerapi/trackerapi.go
+++ b/internal/tool/trackerapi/trackerapi.go
@@ -253,8 +253,7 @@ func mapTrackerError(err error) (json.RawMessage, error) {
 		return toolresult.Failure("tracker_transport_error", "deadline exceeded")
 	}
 
-	var te *domain.TrackerError
-	if errors.As(err, &te) {
+	if te, ok := errors.AsType[*domain.TrackerError](err); ok {
 		return toolresult.Failure(string(te.Kind), te.Message)
 	}
 

--- a/internal/tracker/jira/client_test.go
+++ b/internal/tracker/jira/client_test.go
@@ -186,8 +186,7 @@ func TestClientGet_ContextCancellation(t *testing.T) {
 		t.Errorf("error = %v, want context.Canceled", err)
 	}
 	// Must NOT be wrapped in TrackerError
-	var te *domain.TrackerError
-	if errors.As(err, &te) {
+	if te, ok := errors.AsType[*domain.TrackerError](err); ok {
 		t.Errorf("context cancellation should not be wrapped in TrackerError, got Kind=%q", te.Kind)
 	}
 }
@@ -302,8 +301,7 @@ func TestClientSend_ContextCancellation(t *testing.T) {
 	if !errors.Is(err, context.Canceled) {
 		t.Errorf("Send() error = %v, want context.Canceled", err)
 	}
-	var te *domain.TrackerError
-	if errors.As(err, &te) {
+	if te, ok := errors.AsType[*domain.TrackerError](err); ok {
 		t.Errorf("context cancellation should not be wrapped in TrackerError, got Kind=%q", te.Kind)
 	}
 }

--- a/internal/tracker/jira/validate.go
+++ b/internal/tracker/jira/validate.go
@@ -38,8 +38,7 @@ func validateConfig(fields registry.TrackerConfigFields) []registry.ValidationDi
 // [checkHostVersion] for a version it rejects.
 func validateAPIVersion(versionErr error, version, host string) []registry.ValidationDiag {
 	if versionErr != nil {
-		var trackerErr *domain.TrackerError
-		if errors.As(versionErr, &trackerErr) {
+		if trackerErr, ok := errors.AsType[*domain.TrackerError](versionErr); ok {
 			return []registry.ValidationDiag{{
 				Severity: "error",
 				Check:    "tracker.api_version.invalid",

--- a/internal/workspace/hook_test.go
+++ b/internal/workspace/hook_test.go
@@ -201,8 +201,7 @@ func TestRunHook(t *testing.T) {
 		// or non-zero (SIGPIPE). Either way, check the captured output.
 		output := result.Output
 		if err != nil {
-			var he *HookError
-			if errors.As(err, &he) {
+			if he, ok := errors.AsType[*HookError](err); ok {
 				output = he.Output
 			}
 		}

--- a/internal/workspace/hook_unix.go
+++ b/internal/workspace/hook_unix.go
@@ -95,8 +95,7 @@ func RunHook(ctx context.Context, params HookParams) (HookResult, error) {
 		}
 	}
 
-	var exitErr *exec.ExitError
-	if errors.As(err, &exitErr) {
+	if exitErr, ok := errors.AsType[*exec.ExitError](err); ok {
 		return HookResult{}, &HookError{
 			Op:       "run",
 			Script:   truncateScript(params.Script),

--- a/internal/workspace/lifecycle_test.go
+++ b/internal/workspace/lifecycle_test.go
@@ -724,8 +724,7 @@ func TestCleanup(t *testing.T) {
 		if err == nil {
 			t.Fatal("Cleanup() with empty identifier should return error")
 		}
-		var pe *PathError
-		if !errors.As(err, &pe) {
+		if _, ok := errors.AsType[*PathError](err); !ok {
 			t.Fatalf("error type = %T, want *PathError", err)
 		}
 	})
@@ -1217,8 +1216,7 @@ func TestCleanupTerminal(t *testing.T) {
 		if _, ok := result.Errors[""]; !ok {
 			t.Error("CleanupTerminal() expected error for empty identifier")
 		}
-		var pe *PathError
-		if !errors.As(result.Errors[""], &pe) {
+		if _, ok := errors.AsType[*PathError](result.Errors[""]); !ok {
 			t.Errorf("error type = %T, want *PathError", result.Errors[""])
 		}
 	})


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Refactor

**Intent:** `.github/workflows/ci.yml` pins `golangci-lint-action` with `version: latest` and no `only-new-issues`, so CI lints the whole module against whatever release `latest` resolves to at run time. golangci-lint v2.13.0 published 2026-08-19T23:29:17Z. CI run `32315013985` (main, started 2026-08-19T23:51:55Z) resolved to v2.12.2 and passed. CI run `32317249821` (PR #896, started 2026-08-20T00:25:45Z) resolved to v2.13.0 and failed with 38 findings (37 `modernize`, 1 `gofmt`) across 27 files, none touched by that PR. `main` is green only because its last CI run predates the resolver catching up to v2.13.0 - a fresh run against unmodified `main` fails identically (reproduced locally before making any change). This PR bumps the local `golangci-lint` pin to 2.13.0 and applies the mechanical rewrites the new analyzers require, so `make lint` and CI agree again.

**Related Issues:** None

### 🧭 Reviewer Guide

**Complexity:** Medium

#### Entry Point

`internal/agent/agentcore/forkperturn.go` - carries both new-analyzer categories in one file: the `slicesclip` rewrite (`x[:len(x):len(x)]` → `slices.Clip(x)`) and the one `gofmt` realignment CI flagged (golangci-lint 2.13.0 is built with go1.27, whose `gofmt` reformats vertical alignment inside multi-value `return` statements that wrap a multi-line composite literal differently than the project's pinned go1.26.1 `gofmt` would). Reviewing this file first shows both mechanical patterns before the `errors.AsType` rewrites repeated across the other 26 files.

#### Sensitive Areas

- `internal/scm/scmcore/cierror.go`, `internal/scm/scmcore/scmerror.go`: shared SCM error-normalization helpers used by every SCM adapter; a scoping mistake here would be the widest-blast-radius version of the risk below.
- `internal/orchestrator/exit.go`, `internal/orchestrator/merge_completion_reconcile.go`, `internal/orchestrator/preflight.go`: orchestrator-core error classification, where `errors.As` results drive retry/backoff and preflight diagnostics.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes. Every hunk is a like-for-like idiom swap applied by `golangci-lint run --fix` (`errors.As(err, &target)` → `errors.AsType[*T](err)`, and the slice-clip idiom → `slices.Clip`), plus one `gofmt` realignment. No logic, error kind, or return value changed. Since this is a mechanical rewrite spanning 27 files, the one thing to specifically check per hunk is whether the rewritten `errors.As` site changed variable scope or nil-handling - e.g. a `target` variable that used to be declared before the `if` and referenced after it or in an `else` branch cannot be safely inlined into the `if _, ok := errors.AsType[*T](err); ok` form. Each site in this diff was checked by hand and the target variable is used only inside its own `if`/`else` branch, so no such case occurs here, but it's the correctness question a second reader should re-verify.
- **Migrations/State:** No migrations or state changes. `.tool-versions` also bumps the local `golangci-lint` pin from 2.12.2 to 2.13.0 so `make lint` matches what CI already enforces.
