### PR TITLE
docs: drop codex skip_git_repo_check from reference and sample

### DIFF
--- a/docs/workflow-reference.md
+++ b/docs/workflow-reference.md
@@ -2492,7 +2492,6 @@ codex:
   approval_policy: never          # "never" (default), "onRequest", "unlessTrusted", "always"
   thread_sandbox: workspaceWrite  # "workspaceWrite" (default), "readOnly", "dangerFullAccess", "externalSandbox"
   personality: concise            # Personality preset
-  skip_git_repo_check: false      # Skip git repo validation for non-git workspaces
   turn_sandbox_policy:            # Per-turn sandbox policy override (optional)
     networkAccess: true
 ```

--- a/examples/WORKFLOW.codex.md
+++ b/examples/WORKFLOW.codex.md
@@ -50,7 +50,6 @@ codex:
   effort: medium
   approval_policy: never
   thread_sandbox: workspaceWrite
-  skip_git_repo_check: false
 
 server:
   port: 8642


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Docs

**Intent:** Stop offering operators `codex.skip_git_repo_check` as a working setting. The Codex adapter no longer parses the key, and the `codex app-server` transport it drives exposes no equivalent protocol field and rejects the equivalent flag, which exists only on `codex exec` - a subcommand no adapter code path launches. These two files were the operator-facing remainder after the code stopped reading the key: a reference page presenting it as a working boolean and a shipped sample setting it. This finishes the correction in this repository; the published documentation site lives in a separate repository, where the matching change is staged but pending its own docs release, so the tracking issue stays open.

**Related Issues:** Related to #844

### 🧭 Reviewer Guide

**Complexity:** Low

#### Entry Point

`docs/workflow-reference.md` - the Codex pass-through block in the agent configuration reference. This is the page an operator consults when writing the `codex:` block, and it was the strongest of the two claims: the key was listed with a comment describing it as skipping git repository validation for non-git workspaces. That description was misleading in exactly the case it named, since the workspace the orchestrator creates is an empty directory unless an operator hook clones into it, and the transport does not check for a repository anyway. Confirming the removed line is the only change here is enough to review the page.

#### Sensitive Areas

- `examples/WORKFLOW.codex.md`: a shipped sample, so operators copy it verbatim into their own `WORKFLOW.md`. Worth confirming the surrounding `codex:` block still parses as valid YAML after the removal and that no other sample or reference still presents the key.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes. Nothing validates unknown keys inside the `codex` block, so a `WORKFLOW.md` that still sets `skip_git_repo_check` continues to load and start; the value is silently ignored rather than rejected. No operator action is required.
- **Migrations/State:** No migrations or state changes.
