### PR TITLE
fix(codex): remove mapTurnStatus, superseded by turn disposition

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,16 +82,12 @@ jobs:
 
       # The main Lint job counts a reference from a test as a use, so
       # production code reachable only from its own test never turns up
-      # there. This rerun drops test files from scope, which is what
-      # exposes that class. The linter set is the configured one: --default
-      # only changes the default set and does not clear the enable list in
-      # .golangci.yml. Advisory only: issues-exit-code=0 keeps it from
-      # failing the build.
+      # there. Same configuration, test files out of scope, advisory only.
       - uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
           version-file: .tool-versions
           verify: false
-          args: --default=none --enable=unused --tests=false --issues-exit-code=0 ./...
+          args: --tests=false --issues-exit-code=0 ./...
           # Skip the action's analysis cache: this job runs a different
           # analyzer scope than the main Lint job, and a cache shared
           # between the two could carry a result over from the wrong scope.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,8 +62,8 @@ jobs:
           printf '%s\n' "$changed"
           printf '%s\n' "$changed" | xargs -d '\n' -r shellcheck -x --
 
-  lint-unused:
-    name: Lint (unused, advisory)
+  lint-no-tests:
+    name: Lint (no test files, advisory)
     runs-on: ubuntu-latest
 
     steps:
@@ -80,11 +80,13 @@ jobs:
         with:
           go-version-file: go.mod
 
-      # The main Lint job leaves test files out of scope for the 'unused'
-      # analyzer, so a helper reachable only from a test never turns up
-      # there. This scoped, module-wide rerun is advisory: issues-exit-code=0
-      # keeps it from failing the build, so it only surfaces findings for a
-      # human to act on.
+      # The main Lint job counts a reference from a test as a use, so
+      # production code reachable only from its own test never turns up
+      # there. This rerun drops test files from scope, which is what
+      # exposes that class. The linter set is the configured one: --default
+      # only changes the default set and does not clear the enable list in
+      # .golangci.yml. Advisory only: issues-exit-code=0 keeps it from
+      # failing the build.
       - uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
           version-file: .tool-versions

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,9 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          # No step in this job runs an authenticated git command, so the
+          # token does not need to stay in the local git config.
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
           printf '%s\n' "$changed" | xargs -d '\n' -r shellcheck -x --
 
   lint-no-tests:
-    name: Lint (no test files, advisory)
+    name: Lint (shipped code only)
     runs-on: ubuntu-latest
 
     steps:
@@ -82,12 +82,12 @@ jobs:
 
       # The main Lint job counts a reference from a test as a use, so
       # production code reachable only from its own test never turns up
-      # there. Same configuration, test files out of scope, advisory only.
+      # there. This job is the only one that can fail on that class.
       - uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
           version-file: .tool-versions
           verify: false
-          args: --tests=false --issues-exit-code=0 ./...
+          args: --config .golangci-no-tests.yml --tests=false ./...
           # Skip the action's analysis cache: this job runs a different
           # analyzer scope than the main Lint job, and a cache shared
           # between the two could carry a result over from the wrong scope.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,8 +45,8 @@ jobs:
           version-file: .tool-versions
           verify: false
           # Skip the action's analysis cache: stale entries cause flaky
-          # staticcheck false positives (golangci-lint#5979) that would otherwise
-          # masquerade as new 'latest' findings. setup-go's caches are unaffected.
+          # false positives (golangci-lint#5979) that reproduce on no rerun.
+          # setup-go's caches are unaffected.
           skip-cache: true
 
       - name: Lint shell scripts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
 
       - uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
-          version: latest
+          version-file: .tool-versions
           verify: false
           # Skip the action's analysis cache: stale entries cause flaky
           # staticcheck false positives (golangci-lint#5979) that would otherwise
@@ -61,6 +61,36 @@ jobs:
           [ -n "$changed" ] || exit 0
           printf '%s\n' "$changed"
           printf '%s\n' "$changed" | xargs -d '\n' -r shellcheck -x --
+
+  lint-unused:
+    name: Lint (unused, advisory)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+
+      # The main Lint job leaves test files out of scope for the 'unused'
+      # analyzer, so a helper reachable only from a test never turns up
+      # there. This scoped, module-wide rerun is advisory: issues-exit-code=0
+      # keeps it from failing the build, so it only surfaces findings for a
+      # human to act on.
+      - uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
+        with:
+          version-file: .tool-versions
+          verify: false
+          args: --default=none --enable=unused --tests=false --issues-exit-code=0 ./...
+          # Skip the action's analysis cache: this job runs a different
+          # analyzer scope than the main Lint job, and a cache shared
+          # between the two could carry a result over from the wrong scope.
+          skip-cache: true
 
   test:
     name: Test

--- a/.golangci-no-tests.yml
+++ b/.golangci-no-tests.yml
@@ -1,0 +1,13 @@
+# Answers one question the main configuration cannot: is any shipped code
+# reachable only from its own test? The main run analyses test files too,
+# so a reference from a test counts as a use and hides that class.
+#
+# Only the unused analyser runs here. Formatters are deliberately absent:
+# the main run already reports formatting, and running them twice under
+# different configurations produced findings that did not reproduce.
+version: "2"
+
+linters:
+  default: none
+  enable:
+    - unused

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,5 +1,5 @@
 golang 1.26.1
-golangci-lint 2.13.0
+golangci-lint 2.13.1
 goreleaser 2.14.3
 nodejs 24.13.0
 python 3.13.12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- A malformed end-of-turn notification from the `codex app-server` no
+  longer leaves the turn outcome reported as the bare word `turn`
+  followed by a trailing space. A payload that fails to parse carries
+  no status word, so the turn now reports the shared failure message
+  instead: the status API's `last_message` field and the recorded run
+  history both read `turn failed`.
+  ([#842](https://github.com/sortie-ai/sortie/issues/842))
+
 ## [1.21.0] - 2026-08-20
 
 ### Fixed

--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,24 @@ vet: ## Run go vet on all packages
 lint: ## Run golangci-lint on all packages
 	$(LINTER) run ./...
 
+.PHONY: lint-unused
+lint-unused: ## Report code unreachable outside tests (advisory, never fails)
+	$(LINTER) run --default=none --enable=unused --tests=false --issues-exit-code=0 ./...
+
+.PHONY: lint-shell
+lint-shell: ## Run shellcheck on every tracked shell script
+	@files=$$(git ls-files '*.sh'); \
+	if [ -z "$$files" ]; then exit 0; fi; \
+	printf '%s\n' "$$files"; \
+	$(SHELLCHECK) -x -- $$files
+
+.PHONY: fmt-check
+fmt-check: ## Show formatting drift without rewriting any file
+	$(LINTER) fmt --diff ./...
+
+.PHONY: check
+check: lint lint-unused lint-shell test ## Run every gate CI runs
+
 .PHONY: tidy
 tidy: ## Tidy go.sum and prune stale entries from go.mod
 	$(GO) mod tidy

--- a/Makefile
+++ b/Makefile
@@ -62,14 +62,14 @@ lint-shell: ## Run shellcheck on every tracked shell script
 	@files=$$(git ls-files '*.sh'); \
 	if [ -z "$$files" ]; then exit 0; fi; \
 	printf '%s\n' "$$files"; \
-	$(SHELLCHECK) -x -- $$files
+	git ls-files -z '*.sh' | xargs -0 $(SHELLCHECK) -x --
 
 .PHONY: fmt-check
 fmt-check: ## Show formatting drift without rewriting any file
 	$(LINTER) fmt --diff ./...
 
 .PHONY: check
-check: lint lint-unused lint-shell test ## Run every gate CI runs
+check: lint lint-unused lint-shell test ## Run the CI gates; shell lint covers all tracked scripts
 
 .PHONY: tidy
 tidy: ## Tidy go.sum and prune stale entries from go.mod

--- a/Makefile
+++ b/Makefile
@@ -54,8 +54,8 @@ lint: ## Run golangci-lint on all packages
 	$(LINTER) run ./...
 
 .PHONY: lint-no-tests
-lint-no-tests: ## Lint with test files out of scope (advisory, never fails)
-	$(LINTER) run --tests=false --issues-exit-code=0 ./...
+lint-no-tests: ## Report shipped code reachable only from its own test
+	$(LINTER) run --config .golangci-no-tests.yml --tests=false ./...
 
 .PHONY: lint-shell
 lint-shell: ## Run shellcheck on every tracked shell script

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ lint: ## Run golangci-lint on all packages
 	$(LINTER) run ./...
 
 .PHONY: lint-no-tests
-lint-no-tests: ## Report shipped code reachable only from its own test
+lint-no-tests: ## Fail if shipped code is reachable only from its own test
 	$(LINTER) run --config .golangci-no-tests.yml --tests=false ./...
 
 .PHONY: lint-shell

--- a/Makefile
+++ b/Makefile
@@ -53,8 +53,8 @@ vet: ## Run go vet on all packages
 lint: ## Run golangci-lint on all packages
 	$(LINTER) run ./...
 
-.PHONY: lint-unused
-lint-unused: ## Report code unreachable outside tests (advisory, never fails)
+.PHONY: lint-no-tests
+lint-no-tests: ## Lint with test files out of scope (advisory, never fails)
 	$(LINTER) run --default=none --enable=unused --tests=false --issues-exit-code=0 ./...
 
 .PHONY: lint-shell
@@ -69,7 +69,7 @@ fmt-check: ## Show formatting drift without rewriting any file
 	$(LINTER) fmt --diff ./...
 
 .PHONY: check
-check: lint lint-unused lint-shell test ## Run the CI gates; shell lint covers all tracked scripts
+check: lint lint-no-tests lint-shell test ## Run the CI gates; shell lint covers all tracked scripts
 
 .PHONY: tidy
 tidy: ## Tidy go.sum and prune stale entries from go.mod

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ lint: ## Run golangci-lint on all packages
 
 .PHONY: lint-no-tests
 lint-no-tests: ## Lint with test files out of scope (advisory, never fails)
-	$(LINTER) run --default=none --enable=unused --tests=false --issues-exit-code=0 ./...
+	$(LINTER) run --tests=false --issues-exit-code=0 ./...
 
 .PHONY: lint-shell
 lint-shell: ## Run shellcheck on every tracked shell script

--- a/default.mk
+++ b/default.mk
@@ -32,6 +32,7 @@ DATE    ?= $(shell date -u +%Y-%m-%d)
 
 GO      ?= go
 LINTER  ?= golangci-lint
+SHELLCHECK ?= shellcheck
 
 # ── Build flags ───────────────────────────────────────────────────────────────
 #

--- a/internal/agent/codex/codex.go
+++ b/internal/agent/codex/codex.go
@@ -618,7 +618,11 @@ func (a *CodexAdapter) RunTurn(ctx context.Context, session domain.Session, para
 					ev.Terminal = agentcore.TerminalFailure
 					ev.TerminalErrorKind = domain.ErrTurnFailed
 				}
-				if ev.TerminalMessage == "" {
+				if ev.TerminalMessage == "" && tc.Turn.Status != "" {
+					// An empty status means the payload did not unmarshal
+					// into an object; there is no status word to report,
+					// so agentcore.DecideTurn's own fallback message
+					// applies instead of one built from an empty string.
 					ev.TerminalMessage = "turn " + tc.Turn.Status
 				}
 

--- a/internal/agent/codex/codex.go
+++ b/internal/agent/codex/codex.go
@@ -618,12 +618,12 @@ func (a *CodexAdapter) RunTurn(ctx context.Context, session domain.Session, para
 					ev.Terminal = agentcore.TerminalFailure
 					ev.TerminalErrorKind = domain.ErrTurnFailed
 				}
+				// A status word is only worth reporting when the payload
+				// carried one. A malformed payload, or one that omits the
+				// status member, leaves it empty and keeps this message
+				// unset so agentcore.DecideTurn's own fallback applies
+				// instead of one built from an empty string.
 				if ev.TerminalMessage == "" && tc.Turn.Status != "" {
-					// An empty status means the payload was malformed or
-					// carried no status member. Either way there is no
-					// status word to report, so agentcore.DecideTurn's own
-					// fallback message applies instead of one built from
-					// an empty string.
 					ev.TerminalMessage = "turn " + tc.Turn.Status
 				}
 

--- a/internal/agent/codex/codex.go
+++ b/internal/agent/codex/codex.go
@@ -619,10 +619,11 @@ func (a *CodexAdapter) RunTurn(ctx context.Context, session domain.Session, para
 					ev.TerminalErrorKind = domain.ErrTurnFailed
 				}
 				if ev.TerminalMessage == "" && tc.Turn.Status != "" {
-					// An empty status means the payload did not unmarshal
-					// into an object; there is no status word to report,
-					// so agentcore.DecideTurn's own fallback message
-					// applies instead of one built from an empty string.
+					// An empty status means the payload was malformed or
+					// carried no status member. Either way there is no
+					// status word to report, so agentcore.DecideTurn's own
+					// fallback message applies instead of one built from
+					// an empty string.
 					ev.TerminalMessage = "turn " + tc.Turn.Status
 				}
 

--- a/internal/agent/codex/codex_test.go
+++ b/internal/agent/codex/codex_test.go
@@ -437,42 +437,57 @@ func TestRunTurn_FailedOrUnrecognizedStatus(t *testing.T) {
 	}
 }
 
-// TestRunTurn_MalformedTurnCompletedParams pins that a turn/completed
-// notification whose params fail to unmarshal into an object leaves the
-// turn status empty, so the terminal message is never built from that
-// empty status and agentcore.DecideTurn's own fallback message applies.
-func TestRunTurn_MalformedTurnCompletedParams(t *testing.T) {
+// TestRunTurn_EmptyTurnStatus pins both ways a turn/completed
+// notification can arrive without a status word: params that fail to
+// unmarshal into an object, and a turn object that omits the status
+// member. Neither builds a terminal message from the empty status, so
+// agentcore.DecideTurn's own fallback message applies.
+func TestRunTurn_EmptyTurnStatus(t *testing.T) {
 	t.Parallel()
 
-	fixture := `{"id":1,"result":{"turn":{"id":"turn-001","status":"starting"}}}` + "\n" +
-		`{"method":"turn/completed","params":[1,2,3]}` + "\n"
-	state := makeTestState([]byte(fixture))
-	adapter, _ := NewCodexAdapter(map[string]any{})
-
-	result, err := adapter.RunTurn(context.Background(), fakeSession(state), domain.RunTurnParams{
-		Prompt:  "go",
-		OnEvent: func(domain.AgentEvent) {},
-	})
-
-	if result.ExitReason != domain.EventTurnFailed {
-		t.Errorf("ExitReason = %q, want %q", result.ExitReason, domain.EventTurnFailed)
-	}
-	var agentErr *domain.AgentError
-	if !errors.As(err, &agentErr) {
-		t.Fatalf("error type = %T, want *domain.AgentError", err)
-	}
-	if agentErr.Kind != domain.ErrTurnFailed {
-		t.Errorf("AgentError.Kind = %q, want %q", agentErr.Kind, domain.ErrTurnFailed)
-	}
-	if agentErr.Message != "turn failed" {
-		t.Errorf("AgentError.Message = %q, want %q", agentErr.Message, "turn failed")
+	tests := []struct {
+		name   string
+		params string
+	}{
+		{"params do not unmarshal into an object", `[1,2,3]`},
+		{"turn object omits the status member", `{"turn":{"id":"turn-001"}}`},
 	}
 
-	dispositiontest.AssertDispositionContract(t, agentcore.TurnEvidence{
-		Terminal:          agentcore.TerminalFailure,
-		TerminalErrorKind: domain.ErrTurnFailed,
-		Work:              agentcore.WorkUnobservable,
-	}, result, err)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			fixture := `{"id":1,"result":{"turn":{"id":"turn-001","status":"starting"}}}` + "\n" +
+				`{"method":"turn/completed","params":` + tt.params + `}` + "\n"
+			state := makeTestState([]byte(fixture))
+			adapter, _ := NewCodexAdapter(map[string]any{})
+
+			result, err := adapter.RunTurn(context.Background(), fakeSession(state), domain.RunTurnParams{
+				Prompt:  "go",
+				OnEvent: func(domain.AgentEvent) {},
+			})
+
+			if result.ExitReason != domain.EventTurnFailed {
+				t.Errorf("ExitReason = %q, want %q", result.ExitReason, domain.EventTurnFailed)
+			}
+			var agentErr *domain.AgentError
+			if !errors.As(err, &agentErr) {
+				t.Fatalf("error type = %T, want *domain.AgentError", err)
+			}
+			if agentErr.Kind != domain.ErrTurnFailed {
+				t.Errorf("AgentError.Kind = %q, want %q", agentErr.Kind, domain.ErrTurnFailed)
+			}
+			if agentErr.Message != "turn failed" {
+				t.Errorf("AgentError.Message = %q, want %q", agentErr.Message, "turn failed")
+			}
+
+			dispositiontest.AssertDispositionContract(t, agentcore.TurnEvidence{
+				Terminal:          agentcore.TerminalFailure,
+				TerminalErrorKind: domain.ErrTurnFailed,
+				Work:              agentcore.WorkUnobservable,
+			}, result, err)
+		})
+	}
 }
 
 // TestRunTurn_StdoutParseFailure pins that a stdout line that fails to

--- a/internal/agent/codex/codex_test.go
+++ b/internal/agent/codex/codex_test.go
@@ -303,22 +303,28 @@ func TestRunTurn_InterruptedStatus(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name           string
-		contextIsLive  bool
-		wantExitReason domain.AgentEventType
-		wantErrorKind  domain.AgentErrorKind
+		name          string
+		contextIsLive bool
+		wantEvidence  agentcore.TurnEvidence
 	}{
 		{
-			name:           "live context maps to failure, preserving the retryable classification",
-			contextIsLive:  true,
-			wantExitReason: domain.EventTurnFailed,
-			wantErrorKind:  domain.ErrTurnFailed,
+			name:          "live context maps to failure, preserving the retryable classification",
+			contextIsLive: true,
+			wantEvidence: agentcore.TurnEvidence{
+				Terminal:          agentcore.TerminalFailure,
+				TerminalErrorKind: domain.ErrTurnFailed,
+				TerminalMessage:   "turn interrupted",
+				Work:              agentcore.WorkUnobservable,
+			},
 		},
 		{
-			name:           "already-cancelled context maps to cancellation",
-			contextIsLive:  false,
-			wantExitReason: domain.EventTurnCancelled,
-			wantErrorKind:  domain.ErrTurnCancelled,
+			name:          "already-cancelled context maps to cancellation",
+			contextIsLive: false,
+			wantEvidence: agentcore.TurnEvidence{
+				Terminal:        agentcore.TerminalCancelled,
+				TerminalMessage: "turn interrupted",
+				Work:            agentcore.WorkUnobservable,
+			},
 		},
 	}
 
@@ -364,16 +370,7 @@ func TestRunTurn_InterruptedStatus(t *testing.T) {
 			got := <-outcomeCh
 			result, err := got.result, got.err
 
-			if result.ExitReason != tt.wantExitReason {
-				t.Errorf("ExitReason = %q, want %q", result.ExitReason, tt.wantExitReason)
-			}
-			var agentErr *domain.AgentError
-			if !errors.As(err, &agentErr) {
-				t.Fatalf("error type = %T, want *domain.AgentError", err)
-			}
-			if agentErr.Kind != tt.wantErrorKind {
-				t.Errorf("AgentError.Kind = %q, want %q", agentErr.Kind, tt.wantErrorKind)
-			}
+			dispositiontest.AssertDispositionContract(t, tt.wantEvidence, result, err)
 		})
 	}
 }
@@ -438,6 +435,44 @@ func TestRunTurn_FailedOrUnrecognizedStatus(t *testing.T) {
 			}, result, err)
 		})
 	}
+}
+
+// TestRunTurn_MalformedTurnCompletedParams pins that a turn/completed
+// notification whose params fail to unmarshal into an object leaves the
+// turn status empty, so the terminal message is never built from that
+// empty status and agentcore.DecideTurn's own fallback message applies.
+func TestRunTurn_MalformedTurnCompletedParams(t *testing.T) {
+	t.Parallel()
+
+	fixture := `{"id":1,"result":{"turn":{"id":"turn-001","status":"starting"}}}` + "\n" +
+		`{"method":"turn/completed","params":[1,2,3]}` + "\n"
+	state := makeTestState([]byte(fixture))
+	adapter, _ := NewCodexAdapter(map[string]any{})
+
+	result, err := adapter.RunTurn(context.Background(), fakeSession(state), domain.RunTurnParams{
+		Prompt:  "go",
+		OnEvent: func(domain.AgentEvent) {},
+	})
+
+	if result.ExitReason != domain.EventTurnFailed {
+		t.Errorf("ExitReason = %q, want %q", result.ExitReason, domain.EventTurnFailed)
+	}
+	var agentErr *domain.AgentError
+	if !errors.As(err, &agentErr) {
+		t.Fatalf("error type = %T, want *domain.AgentError", err)
+	}
+	if agentErr.Kind != domain.ErrTurnFailed {
+		t.Errorf("AgentError.Kind = %q, want %q", agentErr.Kind, domain.ErrTurnFailed)
+	}
+	if agentErr.Message != "turn failed" {
+		t.Errorf("AgentError.Message = %q, want %q", agentErr.Message, "turn failed")
+	}
+
+	dispositiontest.AssertDispositionContract(t, agentcore.TurnEvidence{
+		Terminal:          agentcore.TerminalFailure,
+		TerminalErrorKind: domain.ErrTurnFailed,
+		Work:              agentcore.WorkUnobservable,
+	}, result, err)
 }
 
 // TestRunTurn_StdoutParseFailure pins that a stdout line that fails to

--- a/internal/agent/codex/parse.go
+++ b/internal/agent/codex/parse.go
@@ -237,21 +237,6 @@ func maxUsage(a, b domain.TokenUsage) domain.TokenUsage {
 	return result
 }
 
-// mapTurnStatus maps a turn/completed status string to a domain event
-// type.
-func mapTurnStatus(status string) domain.AgentEventType {
-	switch status {
-	case "completed":
-		return domain.EventTurnCompleted
-	case "interrupted":
-		return domain.EventTurnCancelled
-	case "failed":
-		return domain.EventTurnFailed
-	default:
-		return domain.EventTurnFailed
-	}
-}
-
 // mapCodexErrorInfo maps a codexErrorInfo string to a domain error
 // kind. Retryable vs non-retryable classification is encoded in the
 // AgentErrorKind value.

--- a/internal/agent/codex/parse_test.go
+++ b/internal/agent/codex/parse_test.go
@@ -326,32 +326,6 @@ func TestMaxUsage(t *testing.T) {
 	}
 }
 
-func TestMapTurnStatus(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		status string
-		want   domain.AgentEventType
-	}{
-		{"completed", domain.EventTurnCompleted},
-		{"interrupted", domain.EventTurnCancelled},
-		{"failed", domain.EventTurnFailed},
-		{"unknown", domain.EventTurnFailed},
-		{"", domain.EventTurnFailed},
-		{"COMPLETED", domain.EventTurnFailed},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.status, func(t *testing.T) {
-			t.Parallel()
-			got := mapTurnStatus(tt.status)
-			if got != tt.want {
-				t.Errorf("mapTurnStatus(%q) = %q, want %q", tt.status, got, tt.want)
-			}
-		})
-	}
-}
-
 func TestMapCodexErrorInfo(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Fix

**Intent:** Remove `mapTurnStatus`, a Codex adapter helper reachable only from its own unit test and no longer consulted by the live turn/completed path, which decides outcomes through the shared `agentcore.DecideTurn` disposition table instead. Removing it exposed a related bug: a `turn/completed` notification whose payload fails to unmarshal leaves the turn status empty, which used to produce the bare word `turn` with a trailing space as the terminal message; it now falls through to `DecideTurn`'s own `turn failed` message.

**Related Issues:** #842

### 🧭 Reviewer Guide

**Complexity:** Medium

#### Entry Point

`internal/agent/codex/codex.go` - the `turn/completed` arm in `RunTurn`'s event loop. The guard building `ev.TerminalMessage` now only builds the `"turn " + status` message when `Turn.Status` is non-empty, letting `agentcore.DecideTurn`'s fallback apply to the malformed-payload case instead.

#### Sensitive Areas

- `internal/agent/codex/parse.go`: `mapTurnStatus` removed along with its now-orphaned test, `TestMapTurnStatus`, in `internal/agent/codex/parse_test.go`.
- `internal/agent/codex/codex_test.go`: `TestRunTurn_InterruptedStatus` rewritten to assert against `agentcore.TurnEvidence` via `dispositiontest.AssertDispositionContract` rather than the removed helper's output shape; new `TestRunTurn_MalformedTurnCompletedParams` pins the empty-status fallback.
- `.github/workflows/ci.yml`: new `lint-no-tests` job runs the `unused` analyser module-wide over shipped code only, through the five-line `.golangci-no-tests.yml`. It gates rather than advises: the main Lint job counts a reference from a test as a use, so it reports `mapTurnStatus` and its kind clean, and this job is the only one that can fail on them. Also pins the action's golangci-lint version to `.tool-versions` instead of `latest`, and drops the persisted checkout credential in that job.
- `Makefile`: mirrors the new CI job as a `lint-no-tests` target, which fails on the same findings, adds `lint-shell` and `fmt-check` targets, and a `check` target that runs the CI gates locally.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes.
- **Migrations/State:** No migrations or state changes.


