### PR TITLE
refactor: adopt new(expr) and retire the pointer helpers

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -29,8 +29,6 @@ linters:
       disable:
         # omitempty -> omitzero changes JSON marshaling on struct-typed fields.
         - omitzero
-        # new(expr) rewrites leave //go:fix inline wrappers and mixed call sites.
-        - newexpr
   exclusions:
     rules:
       - path: _test\.go

--- a/cmd/sortie/stats.go
+++ b/cmd/sortie/stats.go
@@ -217,16 +217,13 @@ func parseRangeBound(raw string) (*time.Time, error) {
 		return nil, nil
 	}
 	if t, err := time.Parse(time.RFC3339, raw); err == nil {
-		bound := t.UTC()
-		return &bound, nil
+		return new(t.UTC()), nil
 	}
 	if t, err := time.Parse("2006-01-02", raw); err == nil {
-		bound := t.UTC()
-		return &bound, nil
+		return new(t.UTC()), nil
 	}
 	if d, err := time.ParseDuration(raw); err == nil && d > 0 {
-		bound := statsNow().UTC().Add(-d)
-		return &bound, nil
+		return new(statsNow().UTC().Add(-d)), nil
 	}
 	return nil, fmt.Errorf(
 		"invalid range bound %q: accepts an RFC3339 timestamp (2026-07-01T00:00:00Z), "+
@@ -435,12 +432,9 @@ func durationStats(samples []float64) statsDuration {
 		sum += s
 	}
 
-	p50 := percentile(sorted, 50)
-	p95 := percentile(sorted, 95)
-	mean := round1(sum / float64(len(sorted)))
-	d.P50 = &p50
-	d.P95 = &p95
-	d.Mean = &mean
+	d.P50 = new(percentile(sorted, 50))
+	d.P95 = new(percentile(sorted, 95))
+	d.Mean = new(round1(sum / float64(len(sorted))))
 	return d
 }
 
@@ -468,12 +462,10 @@ func (a *statsAggregator) report(
 		ByTemplate:   []statsGroup{},
 	}
 	if since != nil {
-		s := since.UTC().Format(time.RFC3339)
-		rpt.Since = &s
+		rpt.Since = new(since.UTC().Format(time.RFC3339))
 	}
 	if until != nil {
-		u := until.UTC().Format(time.RFC3339)
-		rpt.Until = &u
+		rpt.Until = new(until.UTC().Format(time.RFC3339))
 	}
 	if full {
 		rpt.ByRule = a.groupSlice(a.byRule, full)
@@ -498,22 +490,19 @@ func (a *statsAggregator) summary(full bool) statsSummary {
 		s.SuccessRate = round4(float64(s.Succeeded) / float64(s.Runs))
 	}
 	if full && s.Succeeded > 0 {
-		mean := round2(float64(a.total.succeededTurns) / float64(s.Succeeded))
-		s.MeanTurnsSucceeded = &mean
+		s.MeanTurnsSucceeded = new(round2(float64(a.total.succeededTurns) / float64(s.Succeeded)))
 	}
 	if full {
 		s.TokensUnmeasuredRuns = a.total.unmeasuredRuns
 	}
 	if full && a.total.measuredRuns > 0 {
-		tokens := a.total.tokens
-		s.Tokens = &tokens
+		s.Tokens = new(a.total.tokens)
 	}
 	if full && a.total.pricedRuns > 0 {
 		cost := round2(a.total.costUSD)
 		s.CostUSD = &cost
 		if a.total.succeededMeasured > 0 {
-			perRun := round2(cost / float64(a.total.succeededMeasured))
-			s.CostPerSucceededRunUSD = &perRun
+			s.CostPerSucceededRunUSD = new(round2(cost / float64(a.total.succeededMeasured)))
 		}
 	}
 	return s
@@ -552,19 +541,16 @@ func (a *statsAggregator) groupStat(g *statsGroupAccum, full bool) statsGroup {
 		stat.Share = round4(float64(g.runs) / float64(a.total.runs))
 	}
 	if full {
-		mean := round2(float64(g.turnSum) / float64(g.runs))
-		stat.MeanTurns = &mean
+		stat.MeanTurns = new(round2(float64(g.turnSum) / float64(g.runs)))
 		stat.TokensUnmeasuredRuns = g.unmeasuredRuns
 		if g.measuredRuns > 0 {
-			tokens := g.tokens
-			stat.Tokens = &tokens
+			stat.Tokens = new(g.tokens)
 		}
 		if g.pricedRuns > 0 {
 			cost := round2(g.costUSD)
 			stat.CostUSD = &cost
 			if g.succeededMeasured > 0 {
-				perRun := round2(cost / float64(g.succeededMeasured))
-				stat.CostPerSucceededRunUSD = &perRun
+				stat.CostPerSucceededRunUSD = new(round2(cost / float64(g.succeededMeasured)))
 			}
 		}
 	}
@@ -581,8 +567,7 @@ func (a *statsAggregator) selfReviewReport() *statsSelfReview {
 		UnparsedRuns:     a.selfReview.unparsedRuns,
 	}
 	if a.selfReview.runsWithMetadata > 0 {
-		mean := round2(float64(a.selfReview.iterationSum) / float64(a.selfReview.runsWithMetadata))
-		sr.MeanIterations = &mean
+		sr.MeanIterations = new(round2(float64(a.selfReview.iterationSum) / float64(a.selfReview.runsWithMetadata)))
 	}
 	for verdict, count := range a.selfReview.byVerdict {
 		sr.ByFinalVerdict = append(sr.ByFinalVerdict, statsVerdictCount{Verdict: verdict, Runs: count})

--- a/cmd/sortie/stats_test.go
+++ b/cmd/sortie/stats_test.go
@@ -749,6 +749,52 @@ func TestStatsStatusOrdering(t *testing.T) {
 	}
 }
 
+// --- range bound reporting ---
+
+// TestStatsAggregatorReport_UntilBound verifies that a non-nil until bound
+// populates statsReport.Until, mirroring the existing Since coverage.
+func TestStatsAggregatorReport_UntilBound(t *testing.T) {
+	t.Parallel()
+
+	agg := newStatsAggregator(fullCaps, nil)
+	until := time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC)
+
+	report := agg.report(fixedNow, "/wf", "/db", nil, &until, nil)
+
+	want := "2026-08-01T00:00:00Z"
+	if report.Until == nil || *report.Until != want {
+		t.Errorf("statsAggregator.report(until=%v).Until = %v, want %q", until, report.Until, want)
+	}
+}
+
+// TestParseRangeBound covers the date-only and duration success branches,
+// which the RFC3339 branch's CLI-level coverage does not reach.
+func TestParseRangeBound(t *testing.T) {
+	// No t.Parallel: the duration case pins the package-level statsNow.
+	pinStatsNow(t, time.Date(2026, 8, 7, 9, 15, 0, 0, time.UTC))
+
+	tests := []struct {
+		name string
+		raw  string
+		want time.Time
+	}{
+		{name: "date-only", raw: "2026-07-01", want: time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)},
+		{name: "positive duration", raw: "24h", want: time.Date(2026, 8, 6, 9, 15, 0, 0, time.UTC)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseRangeBound(tt.raw)
+			if err != nil {
+				t.Fatalf("parseRangeBound(%q) unexpected error: %v", tt.raw, err)
+			}
+			if got == nil || !got.Equal(tt.want) {
+				t.Errorf("parseRangeBound(%q) = %v, want %v", tt.raw, got, tt.want)
+			}
+		})
+	}
+}
+
 // --- JSON report contract and byte-stability ---
 
 func TestRunStatsJSON(t *testing.T) {

--- a/cmd/sortie/stats_test.go
+++ b/cmd/sortie/stats_test.go
@@ -33,9 +33,6 @@ var fullCaps = persistence.RunHistoryCapabilities{
 // tests that call statsAggregator.report directly.
 var fixedNow = time.Date(2026, 8, 7, 9, 15, 0, 0, time.UTC)
 
-func floatPtr(v float64) *float64 { return &v }
-func strPtr(v string) *string     { return &v }
-
 // rangeFloats returns the ascending integers from lo to hi inclusive, as
 // float64, for the worked nearest-rank percentile examples.
 func rangeFloats(lo, hi int) []float64 {
@@ -79,8 +76,7 @@ func reviewMetaPtr(t *testing.T, m domain.ReviewMetadata) *string {
 	if err != nil {
 		t.Fatalf("json.Marshal(%+v): %v", m, err)
 	}
-	s := string(b)
-	return &s
+	return new(string(b))
 }
 
 // statsWorkflow returns a minimal WORKFLOW.md whose front matter is
@@ -235,7 +231,7 @@ func TestStatsSummaryFormulas(t *testing.T) {
 	t.Run("duration and turns normalize on succeeded rows; cost per succeeded run divides all spend", func(t *testing.T) {
 		t.Parallel()
 
-		rates := server.TokenRates{"mock": server.TokenRateConfig{InputPerMtok: floatPtr(10)}}
+		rates := server.TokenRates{"mock": server.TokenRateConfig{InputPerMtok: new(float64(10))}}
 		agg := newStatsAggregator(fullCaps, rates)
 
 		addRows(t, agg,
@@ -277,7 +273,7 @@ func TestStatsSummaryFormulas(t *testing.T) {
 func TestStatsGroupDisclosure(t *testing.T) {
 	t.Parallel()
 
-	rates := server.TokenRates{"mock": server.TokenRateConfig{InputPerMtok: floatPtr(10)}}
+	rates := server.TokenRates{"mock": server.TokenRateConfig{InputPerMtok: new(float64(10))}}
 	agg := newStatsAggregator(fullCaps, rates)
 
 	addRows(t, agg, persistence.RunStatsRow{
@@ -337,8 +333,8 @@ func TestStatsCostDerivation(t *testing.T) {
 		t.Parallel()
 
 		rates := server.TokenRates{
-			"claude-code": server.TokenRateConfig{InputPerMtok: floatPtr(10)},
-			"codex":       server.TokenRateConfig{InputPerMtok: floatPtr(20)},
+			"claude-code": server.TokenRateConfig{InputPerMtok: new(float64(10))},
+			"codex":       server.TokenRateConfig{InputPerMtok: new(float64(20))},
 		}
 		agg := newStatsAggregator(fullCaps, rates)
 		addRows(t, agg, makeRow("claude-code", 1_000_000), makeRow("codex", 1_000_000))
@@ -360,7 +356,7 @@ func TestStatsCostDerivation(t *testing.T) {
 		t.Parallel()
 
 		rates := server.TokenRates{
-			"claude-code": server.TokenRateConfig{InputPerMtok: floatPtr(10)},
+			"claude-code": server.TokenRateConfig{InputPerMtok: new(float64(10))},
 		}
 		agg := newStatsAggregator(fullCaps, rates)
 		addRows(t, agg, makeRow("claude-code", 1_000_000), makeRow("codex", 1_000_000))
@@ -417,7 +413,7 @@ func TestStatsCostDerivation(t *testing.T) {
 	t.Run("all runs unmeasured with token_rates configured renders a dash for both figures", func(t *testing.T) {
 		t.Parallel()
 
-		rates := server.TokenRates{"kiro": server.TokenRateConfig{InputPerMtok: floatPtr(10)}}
+		rates := server.TokenRates{"kiro": server.TokenRateConfig{InputPerMtok: new(float64(10))}}
 		agg := newStatsAggregator(fullCaps, rates)
 		addRows(t, agg, persistence.RunStatsRow{
 			Status: "succeeded", AgentAdapter: "kiro",
@@ -467,7 +463,7 @@ func TestStatsCostDerivation(t *testing.T) {
 	t.Run("a range with a measured priced run renders numbers", func(t *testing.T) {
 		t.Parallel()
 
-		rates := server.TokenRates{"claude-code": server.TokenRateConfig{InputPerMtok: floatPtr(10)}}
+		rates := server.TokenRates{"claude-code": server.TokenRateConfig{InputPerMtok: new(float64(10))}}
 		agg := newStatsAggregator(fullCaps, rates)
 		addRows(t, agg, makeRow("claude-code", 1_000_000))
 
@@ -536,8 +532,8 @@ func TestStatsTokenReporting(t *testing.T) {
 		t.Parallel()
 
 		rates := server.TokenRates{
-			"claude-code": server.TokenRateConfig{InputPerMtok: floatPtr(10)},
-			"kiro":        server.TokenRateConfig{InputPerMtok: floatPtr(10)},
+			"claude-code": server.TokenRateConfig{InputPerMtok: new(float64(10))},
+			"kiro":        server.TokenRateConfig{InputPerMtok: new(float64(10))},
 		}
 		agg := newStatsAggregator(fullCaps, rates)
 		addRows(t, agg, measuredUnmeasuredRows()...)
@@ -573,8 +569,8 @@ func TestStatsTokenReporting(t *testing.T) {
 		t.Parallel()
 
 		rates := server.TokenRates{
-			"claude-code": server.TokenRateConfig{InputPerMtok: floatPtr(10)},
-			"kiro":        server.TokenRateConfig{InputPerMtok: floatPtr(10)},
+			"claude-code": server.TokenRateConfig{InputPerMtok: new(float64(10))},
+			"kiro":        server.TokenRateConfig{InputPerMtok: new(float64(10))},
 		}
 		agg := newStatsAggregator(fullCaps, rates)
 		addRows(t, agg, measuredUnmeasuredRows()...)
@@ -684,7 +680,7 @@ func TestStatsSelfReview(t *testing.T) {
 		},
 		persistence.RunStatsRow{
 			Status: "failed", StartedAt: "2026-01-01T00:00:00Z", CompletedAt: "2026-01-01T00:01:00Z",
-			ReviewMetadata: strPtr("{not-json"),
+			ReviewMetadata: new("{not-json"),
 		},
 	)
 

--- a/cmd/sortie/validate_test.go
+++ b/cmd/sortie/validate_test.go
@@ -2152,8 +2152,7 @@ func TestValidateUnresolvedExtensionVar(t *testing.T) {
 		var found *validateDiag
 		for i := range out.Warnings {
 			if out.Warnings[i].Check == "unresolved_extension_var" {
-				w := out.Warnings[i]
-				found = &w
+				found = new(out.Warnings[i])
 				break
 			}
 		}

--- a/internal/agent/agentcore/forkperturn.go
+++ b/internal/agent/agentcore/forkperturn.go
@@ -274,11 +274,12 @@ func (s *ForkPerTurnSession) RunTurn(
 		if ctx.Err() != nil {
 			usage := s.hooks.GetUsage()
 			EmitTurnCancelled(emit, "context cancelled", usage)
-			return domain.TurnResult{
+			result := domain.TurnResult{
 				SessionID:  s.hooks.GetSessionID(),
 				ExitReason: domain.EventTurnCancelled,
 				Usage:      usage,
-			}, &domain.AgentError{
+			}
+			return result, &domain.AgentError{
 				Kind:    domain.ErrTurnCancelled,
 				Message: "turn cancelled",
 				Err:     ctx.Err(),
@@ -340,11 +341,12 @@ func (s *ForkPerTurnSession) RunTurn(
 		if ctx.Err() != nil {
 			usage := s.hooks.GetUsage()
 			EmitTurnCancelled(emit, "context cancelled", usage)
-			return domain.TurnResult{
+			result := domain.TurnResult{
 				SessionID:  s.hooks.GetSessionID(),
 				ExitReason: domain.EventTurnCancelled,
 				Usage:      usage,
-			}, &domain.AgentError{
+			}
+			return result, &domain.AgentError{
 				Kind:    domain.ErrTurnCancelled,
 				Message: "turn cancelled",
 				Err:     ctx.Err(),
@@ -354,11 +356,12 @@ func (s *ForkPerTurnSession) RunTurn(
 		procutil.EmitWarnLines(stderrLines, s.logger)
 		usage := s.hooks.GetUsage()
 		EmitTurnFailed(emit, "stdout read error: "+scanErr.Error(), 0, usage)
-		return domain.TurnResult{
+		result := domain.TurnResult{
 			SessionID:  s.hooks.GetSessionID(),
 			ExitReason: domain.EventTurnFailed,
 			Usage:      usage,
-		}, &domain.AgentError{
+		}
+		return result, &domain.AgentError{
 			Kind:    domain.ErrPortExit,
 			Message: "stdout scanner error",
 			Err:     scanErr,
@@ -381,11 +384,12 @@ func (s *ForkPerTurnSession) RunTurn(
 	if ctx.Err() != nil {
 		usage := s.hooks.GetUsage()
 		EmitTurnCancelled(emit, "context cancelled", usage)
-		return domain.TurnResult{
+		result := domain.TurnResult{
 			SessionID:  s.hooks.GetSessionID(),
 			ExitReason: domain.EventTurnCancelled,
 			Usage:      usage,
-		}, &domain.AgentError{
+		}
+		return result, &domain.AgentError{
 			Kind:    domain.ErrTurnCancelled,
 			Message: "turn cancelled",
 			Err:     ctx.Err(),
@@ -398,11 +402,12 @@ func (s *ForkPerTurnSession) RunTurn(
 		procutil.EmitWarnLines(stderrLines, s.logger)
 		usage := s.hooks.GetUsage()
 		EmitTurnFailed(emit, "agent binary not found", 0, usage)
-		return domain.TurnResult{
+		result := domain.TurnResult{
 			SessionID:  s.hooks.GetSessionID(),
 			ExitReason: domain.EventTurnFailed,
 			Usage:      usage,
-		}, &domain.AgentError{
+		}
+		return result, &domain.AgentError{
 			Kind:    domain.ErrAgentNotFound,
 			Message: "exit code 127",
 		}
@@ -411,11 +416,12 @@ func (s *ForkPerTurnSession) RunTurn(
 	if procutil.WasSignaled(waitErr) {
 		usage := s.hooks.GetUsage()
 		EmitTurnCancelled(emit, "killed by signal", usage)
-		return domain.TurnResult{
+		result := domain.TurnResult{
 			SessionID:  s.hooks.GetSessionID(),
 			ExitReason: domain.EventTurnCancelled,
 			Usage:      usage,
-		}, &domain.AgentError{
+		}
+		return result, &domain.AgentError{
 			Kind:    domain.ErrTurnCancelled,
 			Message: "killed by signal",
 		}

--- a/internal/agent/agentcore/forkperturn_test.go
+++ b/internal/agent/agentcore/forkperturn_test.go
@@ -150,6 +150,25 @@ func TestForkPerTurnSession(t *testing.T) {
 		}
 	})
 
+	t.Run("Arm1_CtxAlreadyCancelledBeforeStart", func(t *testing.T) {
+		t.Parallel()
+		tmpDir := t.TempDir()
+		script := agenttest.WriteScript(t, tmpDir, "agent", `sleep 60`)
+		target := newTestTarget(tmpDir, script)
+		sess := NewForkPerTurnSession(target, noopHooks(), slog.Default())
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		emit, events := sinkEvents()
+
+		_, err := sess.RunTurn(ctx, "p", emit)
+
+		requireAgentError(t, err, domain.ErrTurnCancelled)
+		if !hasEventType(*events, domain.EventTurnCancelled) {
+			t.Errorf("EventTurnCancelled not emitted; got %v", *events)
+		}
+	})
+
 	t.Run("Arm2_ScannerOverflow", func(t *testing.T) {
 		t.Parallel()
 		tmpDir := t.TempDir()

--- a/internal/agent/copilot/copilot.go
+++ b/internal/agent/copilot/copilot.go
@@ -368,8 +368,7 @@ func (a *CopilotAdapter) StartSession(ctx context.Context, params domain.StartSe
 				state.logger().Debug("copilot event logged only", slog.String("event_type", event.Type))
 
 			case "result":
-				captured := event
-				return &captured, nil
+				return new(event), nil
 
 			default:
 				emit(domain.AgentEvent{

--- a/internal/config/schema_test.go
+++ b/internal/config/schema_test.go
@@ -736,8 +736,7 @@ func TestValidateFrontMatter_UnresolvedExtensionVar(t *testing.T) {
 		var found []*FrontMatterWarning
 		for i := range got {
 			if got[i].Check == "unresolved_extension_var" {
-				w := got[i]
-				found = append(found, &w)
+				found = append(found, new(got[i]))
 			}
 		}
 		if len(found) != 1 {
@@ -833,8 +832,7 @@ func TestValidateFrontMatter_UnresolvedExtensionVar(t *testing.T) {
 func findUnresolvedExtVarWarning(warnings []FrontMatterWarning) *FrontMatterWarning {
 	for i := range warnings {
 		if warnings[i].Check == "unresolved_extension_var" {
-			w := warnings[i]
-			return &w
+			return new(warnings[i])
 		}
 	}
 	return nil

--- a/internal/domain/issue_test.go
+++ b/internal/domain/issue_test.go
@@ -2,8 +2,6 @@ package domain
 
 import "testing"
 
-func intPtr(v int) *int { return &v }
-
 func TestToTemplateMap_FullyPopulated(t *testing.T) {
 	t.Parallel()
 
@@ -12,7 +10,7 @@ func TestToTemplateMap_FullyPopulated(t *testing.T) {
 		Identifier:  "PROJ-42",
 		Title:       "Fix login bug",
 		Description: "Users cannot log in with SSO.",
-		Priority:    intPtr(2),
+		Priority:    new(2),
 		State:       "In Progress",
 		BranchName:  "feature/PROJ-42",
 		URL:         "https://tracker.example.com/PROJ-42",
@@ -208,8 +206,8 @@ func TestToTemplateMap_Priority(t *testing.T) {
 		want     any
 	}{
 		{"nil", nil, nil},
-		{"zero", intPtr(0), 0},
-		{"positive", intPtr(3), 3},
+		{"zero", new(0), 0},
+		{"positive", new(3), 3},
 	}
 
 	for _, tt := range tests {

--- a/internal/domain/notify_test.go
+++ b/internal/domain/notify_test.go
@@ -28,8 +28,6 @@ func TestNotifierInterface(t *testing.T) {
 func TestNotification_FieldRoundTrip(t *testing.T) {
 	t.Parallel()
 
-	attempt := 3
-
 	n := Notification{
 		Envelope: NotificationEnvelope{
 			NotificationID: "uuid-1234",
@@ -38,7 +36,7 @@ func TestNotification_FieldRoundTrip(t *testing.T) {
 			IssueID:        "issue-99",
 			Identifier:     "PROJ-99",
 			SessionID:      "sess-abc",
-			Attempt:        &attempt,
+			Attempt:        new(3),
 			Agent:          "claude-code",
 		},
 		Message: NotificationMessage{

--- a/internal/issuekit/issuekit.go
+++ b/internal/issuekit/issuekit.go
@@ -102,6 +102,5 @@ func parseInt(s string) *int {
 	if err != nil {
 		return nil
 	}
-	parsed := int(value)
-	return &parsed
+	return new(int(value))
 }

--- a/internal/notify/slack/slack_test.go
+++ b/internal/notify/slack/slack_test.go
@@ -43,7 +43,6 @@ func slogCapture() (*slog.Logger, func() string) {
 // makeNotification builds a test Notification with recognizable field
 // values.
 func makeNotification() domain.Notification {
-	attempt := 1
 	return domain.Notification{
 		Envelope: domain.NotificationEnvelope{
 			NotificationID: "notif-slack-001",
@@ -52,7 +51,7 @@ func makeNotification() domain.Notification {
 			IssueID:        "issue-8",
 			Identifier:     "PROJ-8",
 			SessionID:      "sess-slack",
-			Attempt:        &attempt,
+			Attempt:        new(1),
 			Agent:          "claude-code",
 		},
 		Message: domain.NotificationMessage{

--- a/internal/notify/webhook/webhook_test.go
+++ b/internal/notify/webhook/webhook_test.go
@@ -43,7 +43,6 @@ func slogCapture() (*slog.Logger, func() string) {
 // makeNotification builds a test Notification with recognizable field
 // values that can be checked in the posted body.
 func makeNotification() domain.Notification {
-	attempt := 2
 	return domain.Notification{
 		Envelope: domain.NotificationEnvelope{
 			NotificationID: "notif-uuid-001",
@@ -52,7 +51,7 @@ func makeNotification() domain.Notification {
 			IssueID:        "issue-7",
 			Identifier:     "PROJ-7",
 			SessionID:      "sess-xyz",
-			Attempt:        &attempt,
+			Attempt:        new(2),
 			Agent:          "claude-code",
 		},
 		Message: domain.NotificationMessage{

--- a/internal/orchestrator/dispatch.go
+++ b/internal/orchestrator/dispatch.go
@@ -401,8 +401,7 @@ func DispatchIssue(ctx context.Context, state *State, issue domain.Issue, attemp
 
 	var attemptCopy *int
 	if attempt != nil {
-		v := *attempt
-		attemptCopy = &v
+		attemptCopy = new(*attempt)
 	}
 
 	state.Claimed[issue.ID] = struct{}{}

--- a/internal/orchestrator/dispatch_test.go
+++ b/internal/orchestrator/dispatch_test.go
@@ -12,10 +12,6 @@ import (
 	"github.com/sortie-ai/sortie/internal/domain"
 )
 
-func intPtr(v int) *int {
-	return &v
-}
-
 func issueWithPriority(id string, p *int, createdAt string) domain.Issue {
 	return domain.Issue{
 		ID:         id,
@@ -62,24 +58,24 @@ func TestSortForDispatch(t *testing.T) {
 		},
 		{
 			name:   "single issue",
-			input:  []domain.Issue{issueWithPriority("A-1", intPtr(1), "2025-01-01T00:00:00Z")},
+			input:  []domain.Issue{issueWithPriority("A-1", new(1), "2025-01-01T00:00:00Z")},
 			wantID: []string{"A-1"},
 		},
 		{
 			name: "priority ordering ascending",
 			input: []domain.Issue{
-				issueWithPriority("P3", intPtr(3), "2025-01-01T00:00:00Z"),
-				issueWithPriority("P1", intPtr(1), "2025-01-01T00:00:00Z"),
-				issueWithPriority("P2", intPtr(2), "2025-01-01T00:00:00Z"),
+				issueWithPriority("P3", new(3), "2025-01-01T00:00:00Z"),
+				issueWithPriority("P1", new(1), "2025-01-01T00:00:00Z"),
+				issueWithPriority("P2", new(2), "2025-01-01T00:00:00Z"),
 			},
 			wantID: []string{"P1", "P2", "P3"},
 		},
 		{
 			name: "nil priority sorts last",
 			input: []domain.Issue{
-				issueWithPriority("P2", intPtr(2), "2025-01-01T00:00:00Z"),
+				issueWithPriority("P2", new(2), "2025-01-01T00:00:00Z"),
 				issueWithPriority("NIL", nil, "2025-01-01T00:00:00Z"),
-				issueWithPriority("P1", intPtr(1), "2025-01-01T00:00:00Z"),
+				issueWithPriority("P1", new(1), "2025-01-01T00:00:00Z"),
 			},
 			wantID: []string{"P1", "P2", "NIL"},
 		},
@@ -95,44 +91,44 @@ func TestSortForDispatch(t *testing.T) {
 		{
 			name: "same priority created_at tiebreaker oldest first",
 			input: []domain.Issue{
-				issueWithPriority("NEW", intPtr(2), "2025-12-01T00:00:00Z"),
-				issueWithPriority("OLD", intPtr(2), "2025-01-01T00:00:00Z"),
-				issueWithPriority("MID", intPtr(2), "2025-06-01T00:00:00Z"),
+				issueWithPriority("NEW", new(2), "2025-12-01T00:00:00Z"),
+				issueWithPriority("OLD", new(2), "2025-01-01T00:00:00Z"),
+				issueWithPriority("MID", new(2), "2025-06-01T00:00:00Z"),
 			},
 			wantID: []string{"OLD", "MID", "NEW"},
 		},
 		{
 			name: "empty created_at sorts last",
 			input: []domain.Issue{
-				issueWithPriority("EMPTY", intPtr(1), ""),
-				issueWithPriority("HAS", intPtr(1), "2025-01-01T00:00:00Z"),
+				issueWithPriority("EMPTY", new(1), ""),
+				issueWithPriority("HAS", new(1), "2025-01-01T00:00:00Z"),
 			},
 			wantID: []string{"HAS", "EMPTY"},
 		},
 		{
 			name: "both empty created_at falls through to identifier",
 			input: []domain.Issue{
-				issueWithPriority("B-1", intPtr(1), ""),
-				issueWithPriority("A-1", intPtr(1), ""),
+				issueWithPriority("B-1", new(1), ""),
+				issueWithPriority("A-1", new(1), ""),
 			},
 			wantID: []string{"A-1", "B-1"},
 		},
 		{
 			name: "identifier tiebreaker lexicographic",
 			input: []domain.Issue{
-				issueWithPriority("C-1", intPtr(1), "2025-01-01T00:00:00Z"),
-				issueWithPriority("A-1", intPtr(1), "2025-01-01T00:00:00Z"),
-				issueWithPriority("B-1", intPtr(1), "2025-01-01T00:00:00Z"),
+				issueWithPriority("C-1", new(1), "2025-01-01T00:00:00Z"),
+				issueWithPriority("A-1", new(1), "2025-01-01T00:00:00Z"),
+				issueWithPriority("B-1", new(1), "2025-01-01T00:00:00Z"),
 			},
 			wantID: []string{"A-1", "B-1", "C-1"},
 		},
 		{
 			name: "full three-key composite",
 			input: []domain.Issue{
-				issueWithPriority("Z-1", intPtr(2), "2025-01-01T00:00:00Z"),
+				issueWithPriority("Z-1", new(2), "2025-01-01T00:00:00Z"),
 				issueWithPriority("A-1", nil, "2025-01-01T00:00:00Z"),
-				issueWithPriority("B-1", intPtr(1), "2025-06-01T00:00:00Z"),
-				issueWithPriority("C-1", intPtr(1), "2025-01-01T00:00:00Z"),
+				issueWithPriority("B-1", new(1), "2025-06-01T00:00:00Z"),
+				issueWithPriority("C-1", new(1), "2025-01-01T00:00:00Z"),
 				issueWithPriority("D-1", nil, ""),
 			},
 			// P1 created oldest: C-1, then B-1; P2: Z-1; nil+dated: A-1; nil+empty: D-1
@@ -141,8 +137,8 @@ func TestSortForDispatch(t *testing.T) {
 		{
 			name: "input slice not modified",
 			input: []domain.Issue{
-				issueWithPriority("B", intPtr(2), "2025-01-01T00:00:00Z"),
-				issueWithPriority("A", intPtr(1), "2025-01-01T00:00:00Z"),
+				issueWithPriority("B", new(2), "2025-01-01T00:00:00Z"),
+				issueWithPriority("A", new(1), "2025-01-01T00:00:00Z"),
 			},
 			wantID: []string{"A", "B"},
 		},
@@ -600,9 +596,9 @@ func TestNextAttempt(t *testing.T) {
 		want    int
 	}{
 		{name: "nil returns 1", current: nil, want: 1},
-		{name: "pointer to 0 returns 1", current: intPtr(0), want: 1},
-		{name: "pointer to 1 returns 2", current: intPtr(1), want: 2},
-		{name: "pointer to 5 returns 6", current: intPtr(5), want: 6},
+		{name: "pointer to 0 returns 1", current: new(0), want: 1},
+		{name: "pointer to 1 returns 2", current: new(1), want: 2},
+		{name: "pointer to 5 returns 6", current: new(5), want: 6},
 	}
 
 	for _, tt := range tests {
@@ -1066,10 +1062,9 @@ func TestDispatchIssue(t *testing.T) {
 		t.Parallel()
 
 		s := newTestState()
-		attempt := 3
 		workerDone := make(chan struct{})
 
-		DispatchIssue(context.Background(), s, testIssue("ISS-R"), &attempt, "", func(_ context.Context, _ domain.Issue, _ *int) {
+		DispatchIssue(context.Background(), s, testIssue("ISS-R"), new(3), "", func(_ context.Context, _ domain.Issue, _ *int) {
 			close(workerDone)
 		})
 		<-workerDone
@@ -1105,7 +1100,6 @@ func TestDispatchIssue(t *testing.T) {
 
 		s := newTestState()
 		issue := testIssue("ISS-W")
-		attempt := 2
 
 		type workerArgs struct {
 			ctx     context.Context
@@ -1114,7 +1108,7 @@ func TestDispatchIssue(t *testing.T) {
 		}
 		ch := make(chan workerArgs, 1)
 
-		DispatchIssue(context.Background(), s, issue, &attempt, "", func(ctx context.Context, iss domain.Issue, att *int) {
+		DispatchIssue(context.Background(), s, issue, new(2), "", func(ctx context.Context, iss domain.Issue, att *int) {
 			ch <- workerArgs{ctx: ctx, issue: iss, attempt: att}
 		})
 
@@ -1177,7 +1171,7 @@ func TestDispatchIssue(t *testing.T) {
 		s.Claimed["ISS-X"] = struct{}{}
 		workerDone := make(chan struct{})
 
-		DispatchIssue(context.Background(), s, testIssue("ISS-X"), intPtr(2), "", func(_ context.Context, _ domain.Issue, _ *int) {
+		DispatchIssue(context.Background(), s, testIssue("ISS-X"), new(2), "", func(_ context.Context, _ domain.Issue, _ *int) {
 			close(workerDone)
 		})
 		<-workerDone

--- a/internal/orchestrator/exit.go
+++ b/internal/orchestrator/exit.go
@@ -384,8 +384,7 @@ func HandleWorkerExit(state *State, workerResult WorkerResult, params HandleWork
 		if marshalErr != nil {
 			log.Warn("failed to marshal review metadata", slog.Any("error", marshalErr))
 		} else {
-			s := string(data)
-			runHistory.ReviewMetadata = &s
+			runHistory.ReviewMetadata = new(string(data))
 		}
 	}
 	runHistoryPersisted := true
@@ -1335,8 +1334,7 @@ func errorStringPtr(err error) *string {
 	if err == nil {
 		return nil
 	}
-	s := err.Error()
-	return &s
+	return new(err.Error())
 }
 
 func stringPtr(s string) *string {

--- a/internal/orchestrator/exit_test.go
+++ b/internal/orchestrator/exit_test.go
@@ -753,7 +753,7 @@ func TestHandleWorkerExit_RetryableReactionErrorPreservesContext(t *testing.T) {
 	t.Parallel()
 
 	store := &mockExitStore{}
-	state := exitState(t, "ISSUE-R", intPtr(2))
+	state := exitState(t, "ISSUE-R", new(2))
 	contContext := map[string]any{
 		"review_comments": map[string]any{"count": 1},
 	}
@@ -1055,8 +1055,7 @@ func TestHandleWorkerExit_RetryAttemptIncrements(t *testing.T) {
 	t.Parallel()
 
 	store := &mockExitStore{}
-	attempt := 3
-	state := exitState(t, "ISSUE-8", &attempt) // RetryAttempt = 3
+	state := exitState(t, "ISSUE-8", new(3)) // RetryAttempt = 3
 	params := defaultExitParams(t, store)
 
 	HandleWorkerExit(state, WorkerResult{
@@ -1169,8 +1168,7 @@ func TestHandleWorkerExit_RunHistoryFields(t *testing.T) {
 	t.Parallel()
 
 	store := &mockExitStore{}
-	attempt := 2
-	state := exitState(t, "HIST-1", &attempt)
+	state := exitState(t, "HIST-1", new(2))
 	state.Running["HIST-1"].Identifier = "PROJ-42"
 	params := defaultExitParams(t, store)
 

--- a/internal/orchestrator/handoff_absence_test.go
+++ b/internal/orchestrator/handoff_absence_test.go
@@ -47,11 +47,10 @@ func (t *recordingHandoffTracker) labels() []handoffLabelCall {
 
 func seedMockHandoffAbsences(store *mockExitStore, issueID string, count int) {
 	for range count {
-		errText := persistence.HandoffAbsenceErrorPrefix + "absence of work observed under observed policy"
 		store.runHistories = append(store.runHistories, persistence.RunHistory{
 			IssueID: issueID,
 			Status:  "failed",
-			Error:   &errText,
+			Error:   new(persistence.HandoffAbsenceErrorPrefix + "absence of work observed under observed policy"),
 		})
 	}
 }
@@ -687,7 +686,6 @@ func TestHandleTickAbsenceReleaseOrdering(t *testing.T) {
 		t.Fatalf("store.Migrate: %v", err)
 	}
 
-	absenceErr := persistence.HandoffAbsenceErrorPrefix + "absence of work observed under observed policy"
 	for range 3 {
 		if _, err := store.AppendRunHistory(ctx, persistence.RunHistory{
 			IssueID:      issueID,
@@ -698,7 +696,7 @@ func TestHandleTickAbsenceReleaseOrdering(t *testing.T) {
 			StartedAt:    "2026-08-17T00:00:00Z",
 			CompletedAt:  "2026-08-17T00:01:00Z",
 			Status:       "failed",
-			Error:        &absenceErr,
+			Error:        new(persistence.HandoffAbsenceErrorPrefix + "absence of work observed under observed policy"),
 		}); err != nil {
 			t.Fatalf("AppendRunHistory: %v", err)
 		}

--- a/internal/orchestrator/mcpconfig_test.go
+++ b/internal/orchestrator/mcpconfig_test.go
@@ -454,7 +454,7 @@ func TestGenerateMCPConfig_Attempt(t *testing.T) {
 		t.Parallel()
 		dir := t.TempDir()
 		p := mcpParams(dir)
-		p.Attempt = intPtr(2)
+		p.Attempt = new(2)
 
 		_, err := GenerateMCPConfig(p)
 		if err != nil {

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -1939,10 +1939,10 @@ func TestDispatchLoopPerStateExhaustion(t *testing.T) {
 	// After dispatching the 2 "In Progress" issues, the "To Do" issue must
 	// still be dispatched.
 	issues := []domain.Issue{
-		{ID: "ip-1", Identifier: "IP-1", Title: "A", State: "In Progress", Priority: intPtr(1)},
-		{ID: "ip-2", Identifier: "IP-2", Title: "B", State: "In Progress", Priority: intPtr(1)},
-		{ID: "ip-3", Identifier: "IP-3", Title: "C", State: "In Progress", Priority: intPtr(1)},
-		{ID: "td-1", Identifier: "TD-1", Title: "D", State: "To Do", Priority: intPtr(2)},
+		{ID: "ip-1", Identifier: "IP-1", Title: "A", State: "In Progress", Priority: new(1)},
+		{ID: "ip-2", Identifier: "IP-2", Title: "B", State: "In Progress", Priority: new(1)},
+		{ID: "ip-3", Identifier: "IP-3", Title: "C", State: "In Progress", Priority: new(1)},
+		{ID: "td-1", Identifier: "TD-1", Title: "D", State: "To Do", Priority: new(2)},
 	}
 
 	tracker := &candidateTrackerAdapter{

--- a/internal/orchestrator/reconcile_test.go
+++ b/internal/orchestrator/reconcile_test.go
@@ -3100,7 +3100,6 @@ func TestReconcileOverdueRetries_StartupReconstructedEntrySkipped(t *testing.T) 
 
 	state := NewState(5000, 4, nil, AgentTotals{})
 	overdueDueMs := reconcileBaseTime.Add(-5 * time.Minute).UnixMilli()
-	errStr := "prior error"
 	PopulateRetries(state, []persistence.PendingRetry{
 		{
 			Entry: persistence.RetryEntry{
@@ -3108,7 +3107,7 @@ func TestReconcileOverdueRetries_StartupReconstructedEntrySkipped(t *testing.T) 
 				Identifier: "STARTUP-1-ident",
 				Attempt:    2,
 				DueAtMs:    overdueDueMs,
-				Error:      &errStr,
+				Error:      new("prior error"),
 			},
 			RemainingMs: 0,
 		},

--- a/internal/orchestrator/route_test.go
+++ b/internal/orchestrator/route_test.go
@@ -9,8 +9,6 @@ import (
 
 // --- helpers ---
 
-func prio(v int) *int { return &v }
-
 func issueWithLabels(labels ...string) domain.Issue {
 	return domain.Issue{
 		ID:         "ISS-1",
@@ -358,7 +356,7 @@ func TestResolveRule(t *testing.T) {
 			name: "priority eq match",
 			issue: domain.Issue{
 				ID: "1", Identifier: "T-1", Title: "t", State: "To Do",
-				Priority: prio(1),
+				Priority: new(1),
 			},
 			dispatch: config.DispatchConfig{
 				Rules: []config.DispatchRule{
@@ -380,7 +378,7 @@ func TestResolveRule(t *testing.T) {
 			name: "priority in match",
 			issue: domain.Issue{
 				ID: "1", Identifier: "T-1", Title: "t", State: "To Do",
-				Priority: prio(2),
+				Priority: new(2),
 			},
 			dispatch: config.DispatchConfig{
 				Rules: []config.DispatchRule{
@@ -402,7 +400,7 @@ func TestResolveRule(t *testing.T) {
 			name: "priority lt match",
 			issue: domain.Issue{
 				ID: "1", Identifier: "T-1", Title: "t", State: "To Do",
-				Priority: prio(1),
+				Priority: new(1),
 			},
 			dispatch: config.DispatchConfig{
 				Rules: []config.DispatchRule{
@@ -424,7 +422,7 @@ func TestResolveRule(t *testing.T) {
 			name: "priority lte match at boundary",
 			issue: domain.Issue{
 				ID: "1", Identifier: "T-1", Title: "t", State: "To Do",
-				Priority: prio(2),
+				Priority: new(2),
 			},
 			dispatch: config.DispatchConfig{
 				Rules: []config.DispatchRule{
@@ -446,7 +444,7 @@ func TestResolveRule(t *testing.T) {
 			name: "priority gt match",
 			issue: domain.Issue{
 				ID: "1", Identifier: "T-1", Title: "t", State: "To Do",
-				Priority: prio(5),
+				Priority: new(5),
 			},
 			dispatch: config.DispatchConfig{
 				Rules: []config.DispatchRule{
@@ -468,7 +466,7 @@ func TestResolveRule(t *testing.T) {
 			name: "priority gte match at boundary",
 			issue: domain.Issue{
 				ID: "1", Identifier: "T-1", Title: "t", State: "To Do",
-				Priority: prio(3),
+				Priority: new(3),
 			},
 			dispatch: config.DispatchConfig{
 				Rules: []config.DispatchRule{

--- a/internal/orchestrator/worker_test.go
+++ b/internal/orchestrator/worker_test.go
@@ -305,9 +305,9 @@ func TestNormalizeAttempt(t *testing.T) {
 		want    int
 	}{
 		{name: "nil returns 0", attempt: nil, want: 0},
-		{name: "ptr(0) returns 0", attempt: intPtr(0), want: 0},
-		{name: "ptr(1) returns 1", attempt: intPtr(1), want: 1},
-		{name: "ptr(5) returns 5", attempt: intPtr(5), want: 5},
+		{name: "ptr(0) returns 0", attempt: new(0), want: 0},
+		{name: "ptr(1) returns 1", attempt: new(1), want: 1},
+		{name: "ptr(5) returns 5", attempt: new(5), want: 5},
 	}
 
 	for _, tt := range tests {
@@ -1281,7 +1281,7 @@ func TestRunWorkerAttempt(t *testing.T) {
 			Logger:                 discardLogger(),
 		}
 
-		attempt := intPtr(3)
+		attempt := new(3)
 		RunWorkerAttempt(context.Background(), workerTestIssue(), attempt, deps)
 
 		result := ec.waitResult(t)
@@ -2451,7 +2451,6 @@ func TestRunWorkerAttempt_DispatchTransition(t *testing.T) {
 		issue := workerTestIssue()
 		issue.State = "In Progress" // already transitioned on prior attempt
 
-		attempt := 2
 		deps := WorkerDeps{
 			TrackerAdapter:         tracker,
 			AgentAdapter:           &mockAgentAdapter{},
@@ -2463,7 +2462,7 @@ func TestRunWorkerAttempt_DispatchTransition(t *testing.T) {
 			Metrics:                spy,
 		}
 
-		RunWorkerAttempt(context.Background(), issue, &attempt, deps)
+		RunWorkerAttempt(context.Background(), issue, new(2), deps)
 		ec.waitResult(t)
 
 		if len(tracker.transitionCalls) != 0 {
@@ -3332,7 +3331,7 @@ func TestRunWorkerAttempt_DispatchComment(t *testing.T) {
 		tracker := &mockTrackerAdapter{}
 		ec := newExitCapture()
 
-		attempt := intPtr(2)
+		attempt := new(2)
 
 		deps := WorkerDeps{
 			TrackerAdapter:         tracker,

--- a/internal/persistence/retry.go
+++ b/internal/persistence/retry.go
@@ -87,12 +87,10 @@ func (s *Store) LoadRetryEntries(ctx context.Context) ([]RetryEntry, error) {
 			return nil, fmt.Errorf("scan retry entry: %w", err)
 		}
 		if errVal.Valid {
-			s := errVal.String
-			e.Error = &s
+			e.Error = new(errVal.String)
 		}
 		if ssnVal.Valid {
-			s := ssnVal.String
-			e.SessionID = &s
+			e.SessionID = new(ssnVal.String)
 		}
 		entries = append(entries, e)
 	}

--- a/internal/persistence/run_history.go
+++ b/internal/persistence/run_history.go
@@ -127,8 +127,7 @@ func (s *Store) QueryRunHistoryByIssue(ctx context.Context, issueID string) ([]R
 			return nil, fmt.Errorf("scan run history: %w", err)
 		}
 		if errVal.Valid {
-			s := errVal.String
-			r.Error = &s
+			r.Error = new(errVal.String)
 		}
 		if wfVal.Valid {
 			r.WorkflowFile = wfVal.String
@@ -137,8 +136,7 @@ func (s *Store) QueryRunHistoryByIssue(ctx context.Context, issueID string) ([]R
 			r.DisplayID = dispIDVal.String
 		}
 		if reviewMetaVal.Valid {
-			metaJSON := reviewMetaVal.String
-			r.ReviewMetadata = &metaJSON
+			r.ReviewMetadata = new(reviewMetaVal.String)
 		}
 		entries = append(entries, r)
 	}
@@ -200,8 +198,7 @@ func (s *Store) LoadLatestSuccessfulRunsForReactionRecovery(ctx context.Context,
 			return nil, fmt.Errorf("load recovery runs: %w", err)
 		}
 		if errVal.Valid {
-			errorText := errVal.String
-			run.Error = &errorText
+			run.Error = new(errVal.String)
 		}
 		if wfVal.Valid {
 			run.WorkflowFile = wfVal.String
@@ -210,8 +207,7 @@ func (s *Store) LoadLatestSuccessfulRunsForReactionRecovery(ctx context.Context,
 			run.DisplayID = dispIDVal.String
 		}
 		if reviewMetaVal.Valid {
-			metaJSON := reviewMetaVal.String
-			run.ReviewMetadata = &metaJSON
+			run.ReviewMetadata = new(reviewMetaVal.String)
 		}
 		entries = append(entries, run)
 	}
@@ -269,8 +265,7 @@ func (s *Store) QueryRecentRunHistory(ctx context.Context, limit int, afterID in
 			return nil, fmt.Errorf("scan run history: %w", err)
 		}
 		if errVal.Valid {
-			s := errVal.String
-			r.Error = &s
+			r.Error = new(errVal.String)
 		}
 		if wfVal.Valid {
 			r.WorkflowFile = wfVal.String
@@ -279,8 +274,7 @@ func (s *Store) QueryRecentRunHistory(ctx context.Context, limit int, afterID in
 			r.DisplayID = dispIDVal.String
 		}
 		if reviewMetaVal.Valid {
-			metaJSON := reviewMetaVal.String
-			r.ReviewMetadata = &metaJSON
+			r.ReviewMetadata = new(reviewMetaVal.String)
 		}
 		entries = append(entries, r)
 	}

--- a/internal/persistence/run_history_test.go
+++ b/internal/persistence/run_history_test.go
@@ -142,6 +142,52 @@ func TestRunHistoryTokenColumns_UnmeasuredRoundTrip(t *testing.T) {
 	assertTokenFields(t, "LoadLatestSuccessfulRunsForReactionRecovery", recovery[0], 0, 0, 0, 0, false)
 }
 
+// TestRunHistoryErrorAndReviewMetadata_RoundTrip verifies that a non-null
+// error and review_metadata column round-trip through QueryRecentRunHistory
+// and LoadLatestSuccessfulRunsForReactionRecovery, not just through
+// QueryRunHistoryByIssue.
+func TestRunHistoryErrorAndReviewMetadata_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	s := openTestStore(t)
+	migrateOrFatal(t, s)
+	ctx := context.Background()
+
+	meta := `{"enabled":true,"iterations":[],"total_iterations":1,"final_verdict":"pass","cap_reached":false}`
+	run := newTestRun(1)
+	run.Error = new("transient network error")
+	run.ReviewMetadata = &meta
+	appendOrFatal(t, s, run)
+
+	recent, err := s.QueryRecentRunHistory(ctx, 1, 0)
+	if err != nil {
+		t.Fatalf("QueryRecentRunHistory: %v", err)
+	}
+	if len(recent) != 1 {
+		t.Fatalf("QueryRecentRunHistory returned %d entries, want 1", len(recent))
+	}
+	if recent[0].Error == nil || *recent[0].Error != "transient network error" {
+		t.Errorf("QueryRecentRunHistory Error = %v, want %q", recent[0].Error, "transient network error")
+	}
+	if recent[0].ReviewMetadata == nil || *recent[0].ReviewMetadata != meta {
+		t.Errorf("QueryRecentRunHistory ReviewMetadata = %v, want %q", recent[0].ReviewMetadata, meta)
+	}
+
+	recovery, err := s.LoadLatestSuccessfulRunsForReactionRecovery(ctx, time.Time{}, 10)
+	if err != nil {
+		t.Fatalf("LoadLatestSuccessfulRunsForReactionRecovery: %v", err)
+	}
+	if len(recovery) != 1 {
+		t.Fatalf("LoadLatestSuccessfulRunsForReactionRecovery returned %d entries, want 1", len(recovery))
+	}
+	if recovery[0].Error == nil || *recovery[0].Error != "transient network error" {
+		t.Errorf("LoadLatestSuccessfulRunsForReactionRecovery Error = %v, want %q", recovery[0].Error, "transient network error")
+	}
+	if recovery[0].ReviewMetadata == nil || *recovery[0].ReviewMetadata != meta {
+		t.Errorf("LoadLatestSuccessfulRunsForReactionRecovery ReviewMetadata = %v, want %q", recovery[0].ReviewMetadata, meta)
+	}
+}
+
 // TestRunHistoryTokenColumns_LegacyRowsReadZero verifies that rows written
 // without token values (matching pre-migration rows, which rely on the
 // NOT NULL DEFAULT 0 column definition) scan as zero.

--- a/internal/persistence/run_stats.go
+++ b/internal/persistence/run_stats.go
@@ -162,8 +162,7 @@ func (s *Store) ScanRunHistoryRange(
 				return fmt.Errorf("scan run history range: %w", err)
 			}
 			if reviewMeta.Valid {
-				metadata := reviewMeta.String
-				row.ReviewMetadata = &metadata
+				row.ReviewMetadata = new(reviewMeta.String)
 			}
 		} else {
 			if err := rows.Scan(&row.Status, &row.AgentAdapter, &row.StartedAt, &row.CompletedAt); err != nil {

--- a/internal/persistence/run_stats_test.go
+++ b/internal/persistence/run_stats_test.go
@@ -316,6 +316,41 @@ func TestScanRunHistoryRange(t *testing.T) {
 		}
 	})
 
+	t.Run("full projection populates ReviewMetadata", func(t *testing.T) {
+		t.Parallel()
+
+		s := openTestStore(t)
+		migrateOrFatal(t, s)
+		ctx := context.Background()
+
+		meta := `{"enabled":true,"iterations":[],"total_iterations":1,"final_verdict":"pass","cap_reached":false}`
+		row := runAt("with-meta", "2026-01-01T00:00:00Z")
+		row.ReviewMetadata = &meta
+		appendOrFatal(t, s, row)
+
+		caps, err := s.RunHistoryCapabilities(ctx)
+		if err != nil {
+			t.Fatalf("RunHistoryCapabilities: %v", err)
+		}
+		if !caps.Full() {
+			t.Fatalf("caps.Full() = false, want true for a fully migrated store")
+		}
+
+		var rows []RunStatsRow
+		if err := s.ScanRunHistoryRange(ctx, caps, nil, nil, func(row RunStatsRow) error {
+			rows = append(rows, row)
+			return nil
+		}); err != nil {
+			t.Fatalf("ScanRunHistoryRange: %v", err)
+		}
+		if len(rows) != 1 {
+			t.Fatalf("ScanRunHistoryRange visited %d rows, want 1", len(rows))
+		}
+		if rows[0].ReviewMetadata == nil || *rows[0].ReviewMetadata != meta {
+			t.Errorf("RunStatsRow.ReviewMetadata = %v, want %q", rows[0].ReviewMetadata, meta)
+		}
+	})
+
 	t.Run("base projection against the legacy table leaves optional fields zero", func(t *testing.T) {
 		t.Parallel()
 

--- a/internal/persistence/session_metadata.go
+++ b/internal/persistence/session_metadata.go
@@ -81,8 +81,7 @@ func (s *Store) LoadSessionMetadata(ctx context.Context, issueID string) (Sessio
 		return SessionMetadata{}, false, fmt.Errorf("load session metadata %q: %w", issueID, err)
 	}
 	if nullPID.Valid {
-		v := nullPID.String
-		m.AgentPID = &v
+		m.AgentPID = new(nullPID.String)
 	}
 	return m, true, nil
 }
@@ -111,8 +110,7 @@ func (s *Store) LoadAllSessionMetadata(ctx context.Context) ([]SessionMetadata, 
 			return nil, fmt.Errorf("scan session metadata: %w", err)
 		}
 		if nullPID.Valid {
-			v := nullPID.String
-			m.AgentPID = &v
+			m.AgentPID = new(nullPID.String)
 		}
 		entries = append(entries, m)
 	}

--- a/internal/persistence/store_test.go
+++ b/internal/persistence/store_test.go
@@ -1360,6 +1360,41 @@ func TestLoadAllSessionMetadata_Empty(t *testing.T) {
 	}
 }
 
+// TestLoadAllSessionMetadata_NonNilAgentPID verifies that a non-null
+// agent_pid column round-trips through LoadAllSessionMetadata, not just
+// through the single-row LoadSessionMetadata reader.
+func TestLoadAllSessionMetadata_NonNilAgentPID(t *testing.T) {
+	t.Parallel()
+
+	s := openTestStore(t)
+	migrateOrFatal(t, s)
+	ctx := context.Background()
+
+	meta := SessionMetadata{
+		IssueID:   "ISS-1",
+		SessionID: "sess-abc",
+		AgentPID:  new("54321"),
+		UpdatedAt: "2026-03-19T10:00:00Z",
+	}
+	if err := s.UpsertSessionMetadata(ctx, meta); err != nil {
+		t.Fatalf("UpsertSessionMetadata: %v", err)
+	}
+
+	got, err := s.LoadAllSessionMetadata(ctx)
+	if err != nil {
+		t.Fatalf("LoadAllSessionMetadata: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("got %d entries, want 1", len(got))
+	}
+	if got[0].AgentPID == nil {
+		t.Fatal("AgentPID = nil, want non-nil")
+	}
+	if *got[0].AgentPID != "54321" {
+		t.Errorf("AgentPID = %q, want %q", *got[0].AgentPID, "54321")
+	}
+}
+
 func TestDeleteSessionMetadata(t *testing.T) {
 	t.Parallel()
 

--- a/internal/persistence/store_test.go
+++ b/internal/persistence/store_test.go
@@ -165,13 +165,12 @@ func TestSaveRetryEntry_Upsert(t *testing.T) {
 		t.Fatalf("SaveRetryEntry (first): %v", err)
 	}
 
-	errMsg := "retry failed"
 	entry2 := RetryEntry{
 		IssueID:    "ISS-1",
 		Identifier: "PROJ-1",
 		Attempt:    2,
 		DueAtMs:    2000,
-		Error:      &errMsg,
+		Error:      new("retry failed"),
 	}
 	if err := s.SaveRetryEntry(ctx, entry2); err != nil {
 		t.Fatalf("SaveRetryEntry (upsert): %v", err)
@@ -206,13 +205,12 @@ func TestSaveRetryEntry_UpsertClearsError(t *testing.T) {
 	migrateOrFatal(t, s)
 	ctx := context.Background()
 
-	errMsg := "something went wrong"
 	entry1 := RetryEntry{
 		IssueID:    "ISS-1",
 		Identifier: "PROJ-1",
 		Attempt:    1,
 		DueAtMs:    1000,
-		Error:      &errMsg,
+		Error:      new("something went wrong"),
 	}
 	if err := s.SaveRetryEntry(ctx, entry1); err != nil {
 		t.Fatalf("SaveRetryEntry (with error): %v", err)
@@ -641,10 +639,9 @@ func TestAppendRunHistory_WithError(t *testing.T) {
 	migrateOrFatal(t, s)
 	ctx := context.Background()
 
-	errMsg := "agent crashed"
 	run := newTestRun(1)
 	run.Status = "failed"
-	run.Error = &errMsg
+	run.Error = new("agent crashed")
 	appendOrFatal(t, s, run)
 
 	entries, err := s.QueryRunHistoryByIssue(ctx, run.IssueID)
@@ -1152,11 +1149,10 @@ func TestUpsertSessionMetadata(t *testing.T) {
 	migrateOrFatal(t, s)
 	ctx := context.Background()
 
-	pid := "12345"
 	meta := SessionMetadata{
 		IssueID:      "ISS-1",
 		SessionID:    "sess-abc",
-		AgentPID:     &pid,
+		AgentPID:     new("12345"),
 		InputTokens:  100,
 		OutputTokens: 50,
 		TotalTokens:  150,
@@ -1206,11 +1202,10 @@ func TestUpsertSessionMetadata_Update(t *testing.T) {
 	migrateOrFatal(t, s)
 	ctx := context.Background()
 
-	pid1 := "111"
 	meta1 := SessionMetadata{
 		IssueID:      "ISS-1",
 		SessionID:    "sess-1",
-		AgentPID:     &pid1,
+		AgentPID:     new("111"),
 		InputTokens:  10,
 		OutputTokens: 5,
 		TotalTokens:  15,
@@ -1220,11 +1215,10 @@ func TestUpsertSessionMetadata_Update(t *testing.T) {
 		t.Fatalf("UpsertSessionMetadata (first): %v", err)
 	}
 
-	pid2 := "222"
 	meta2 := SessionMetadata{
 		IssueID:      "ISS-1",
 		SessionID:    "sess-2",
-		AgentPID:     &pid2,
+		AgentPID:     new("222"),
 		InputTokens:  200,
 		OutputTokens: 100,
 		TotalTokens:  300,
@@ -1697,13 +1691,12 @@ func TestLoadRetryEntriesForRecovery_PreservesEntryFields(t *testing.T) {
 	migrateOrFatal(t, s)
 	ctx := context.Background()
 
-	errMsg := "agent timeout"
 	entry := RetryEntry{
 		IssueID:    "ISS-42",
 		Identifier: "PROJ-42",
 		Attempt:    3,
 		DueAtMs:    7500,
-		Error:      &errMsg,
+		Error:      new("agent timeout"),
 	}
 	if err := s.SaveRetryEntry(ctx, entry); err != nil {
 		t.Fatalf("SaveRetryEntry: %v", err)
@@ -2052,11 +2045,10 @@ func TestUpsertSessionMetadata_ExtendedFields(t *testing.T) {
 	migrateOrFatal(t, s)
 	ctx := context.Background()
 
-	pid := "9876"
 	meta := SessionMetadata{
 		IssueID:         "EXT-1",
 		SessionID:       "sess-ext",
-		AgentPID:        &pid,
+		AgentPID:        new("9876"),
 		InputTokens:     500,
 		OutputTokens:    200,
 		TotalTokens:     700,
@@ -2579,7 +2571,6 @@ func TestLoadLatestSuccessfulRunsForReactionRecovery_PrefersProducingRunOverLate
 	cutoff := recoveryRefTime.Add(-30 * 24 * time.Hour)
 
 	producing := appendRecoveryRun(t, s, "ISS-EVIDENCE", "PROJ-E", 1, recentCompletedAt(2))
-	errorText := "handoff withheld: absence of work observed under observed policy"
 	appendOrFatal(t, s, RunHistory{
 		IssueID:      "ISS-EVIDENCE",
 		Identifier:   "PROJ-E",
@@ -2589,7 +2580,7 @@ func TestLoadLatestSuccessfulRunsForReactionRecovery_PrefersProducingRunOverLate
 		StartedAt:    recentCompletedAt(1),
 		CompletedAt:  recentCompletedAt(1),
 		Status:       "failed",
-		Error:        &errorText,
+		Error:        new("handoff withheld: absence of work observed under observed policy"),
 	})
 
 	got, err := s.LoadLatestSuccessfulRunsForReactionRecovery(ctx, cutoff, 200)

--- a/internal/scm/github/normalize_test.go
+++ b/internal/scm/github/normalize_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/sortie-ai/sortie/internal/domain"
 )
 
-func strPtr(s string) *string              { return &s }
 func typePtr(name string) *githubIssueType { return &githubIssueType{Name: name} }
 func prMarker() *githubPR                  { return &githubPR{} }
 
@@ -20,7 +19,7 @@ func TestNormalizeIssue_AllFields(t *testing.T) {
 		ID:        987654,
 		Number:    42,
 		Title:     "Add dark mode",
-		Body:      strPtr("Users want dark mode."),
+		Body:      new("Users want dark mode."),
 		State:     "open",
 		HTMLURL:   "https://github.com/owner/repo/issues/42",
 		Labels:    []githubLabel{{Name: "In-Progress"}, {Name: "UI"}},

--- a/internal/scm/gitlab/scm_reviews_test.go
+++ b/internal/scm/gitlab/scm_reviews_test.go
@@ -471,11 +471,10 @@ func TestNormalizeNotes_OutdatedDerivationAndConditionalRead(t *testing.T) {
 		defer srv.Close()
 
 		adapter := mustSCMAdapter(t, srv.URL)
-		newLine := 5
 		notes := []gitlabNote{
 			{
 				ID: 2, Author: gitlabUser{Username: "alice"}, Body: "inline note", CreatedAt: "2026-08-10T08:00:00Z",
-				Position: &gitlabNotePosition{HeadSHA: normalizeNotesHeadSHA, NewPath: "a.go", NewLine: &newLine},
+				Position: &gitlabNotePosition{HeadSHA: normalizeNotesHeadSHA, NewPath: "a.go", NewLine: new(5)},
 			},
 		}
 		got, err := adapter.normalizeNotes(context.Background(), testPRNumber, scmOwner, scmRepo, notes)
@@ -503,11 +502,10 @@ func TestNormalizeNotes_OutdatedDerivationAndConditionalRead(t *testing.T) {
 		defer srv.Close()
 
 		adapter := mustSCMAdapter(t, srv.URL)
-		oldLine := 9
 		notes := []gitlabNote{
 			{
 				ID: 3, Author: gitlabUser{Username: "alice"}, Body: "stale inline note", CreatedAt: "2026-08-10T08:00:00Z",
-				Position: &gitlabNotePosition{HeadSHA: "stale-sha-0000000000000000000000000", OldPath: "b.go", OldLine: &oldLine},
+				Position: &gitlabNotePosition{HeadSHA: "stale-sha-0000000000000000000000000", OldPath: "b.go", OldLine: new(9)},
 			},
 		}
 		got, err := adapter.normalizeNotes(context.Background(), testPRNumber, scmOwner, scmRepo, notes)

--- a/internal/server/dashboard.go
+++ b/internal/server/dashboard.go
@@ -292,8 +292,7 @@ func buildDashboardData(
 		data.EstimatedCostLabel = "Active Est. Cost (USD)"
 	}
 	if aggregateCostSet {
-		s := FormatCost(aggregateCost)
-		data.EstimatedCostUSD = &s
+		data.EstimatedCostUSD = new(FormatCost(aggregateCost))
 	}
 
 	// Copy and sort retry entries by DueAtMS ascending before mapping.

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -132,12 +132,10 @@ func toRunningEntryResponse(e orchestrator.SnapshotRunningEntry, nowArgs ...time
 		now := nowArgs[0]
 		elapsedMs := now.Sub(e.StartedAt).Milliseconds()
 		if elapsedMs > 0 && e.ToolTimeMs > 0 {
-			pct := float64(e.ToolTimeMs) / float64(elapsedMs) * 100.0
-			resp.ToolTimePercent = &pct
+			resp.ToolTimePercent = new(float64(e.ToolTimeMs) / float64(elapsedMs) * 100.0)
 		}
 		if elapsedMs > 0 && e.APITimeMs > 0 {
-			pct := float64(e.APITimeMs) / float64(elapsedMs) * 100.0
-			resp.APITimePercent = &pct
+			resp.APITimePercent = new(float64(e.APITimeMs) / float64(elapsedMs) * 100.0)
 		}
 	}
 
@@ -379,16 +377,14 @@ func buildIssueDetail(identifier string, snap orchestrator.RuntimeSnapshotResult
 
 	for _, e := range snap.Running {
 		if e.Identifier == identifier {
-			re := toRunningEntryResponse(e, snap.GeneratedAt)
-			runEntry = &re
+			runEntry = new(toRunningEntryResponse(e, snap.GeneratedAt))
 			break
 		}
 	}
 
 	for _, e := range snap.Retrying {
 		if e.Identifier == identifier {
-			re := toRetryEntryResponse(e)
-			retryEntry = &re
+			retryEntry = new(toRetryEntryResponse(e))
 			break
 		}
 	}

--- a/internal/tool/budget/budget.go
+++ b/internal/tool/budget/budget.go
@@ -124,8 +124,7 @@ func (t *BudgetTool) Execute(ctx context.Context, _ json.RawMessage) (json.RawMe
 
 	var remaining *int64
 	if t.budgetTokens > 0 {
-		r := max(int64(t.budgetTokens)-usedTokens, 0)
-		remaining = &r
+		remaining = new(max(int64(t.budgetTokens)-usedTokens, 0))
 	}
 
 	usedTokensComplete := usage.UnmeasuredSessions == 0 &&

--- a/internal/tool/budget/budget_test.go
+++ b/internal/tool/budget/budget_test.go
@@ -37,8 +37,6 @@ func executeOK(t *testing.T, tool *BudgetTool) costBudgetResponse {
 	return envelope.Data
 }
 
-func int64Ptr(v int64) *int64 { return &v }
-
 // --- Tests ---
 
 func TestBudgetTool_Name(t *testing.T) {
@@ -127,7 +125,7 @@ func TestBudgetTool_Execute(t *testing.T) {
 			budgetSessions:     5,
 			wantUsedTokens:     750,
 			wantBudgetTokens:   1000,
-			wantRemaining:      int64Ptr(250),
+			wantRemaining:      new(int64(250)),
 			wantUsedSessions:   3,
 			wantBudgetSessions: 5,
 		},
@@ -138,7 +136,7 @@ func TestBudgetTool_Execute(t *testing.T) {
 			budgetSessions:     0,
 			wantUsedTokens:     1100,
 			wantBudgetTokens:   1000,
-			wantRemaining:      int64Ptr(0),
+			wantRemaining:      new(int64(0)),
 			wantUsedSessions:   2,
 			wantBudgetSessions: 0,
 		},
@@ -149,7 +147,7 @@ func TestBudgetTool_Execute(t *testing.T) {
 			budgetSessions:     4,
 			wantUsedTokens:     1000,
 			wantBudgetTokens:   1000,
-			wantRemaining:      int64Ptr(0),
+			wantRemaining:      new(int64(0)),
 			wantUsedSessions:   4,
 			wantBudgetSessions: 4,
 		},

--- a/internal/tool/history/history_test.go
+++ b/internal/tool/history/history_test.go
@@ -157,10 +157,9 @@ func TestHistoryTool_Execute_SuccessEnvelopeShape(t *testing.T) {
 func TestHistoryTool_Execute_EntriesReturned(t *testing.T) {
 	t.Parallel()
 
-	errMsg := "agent crashed"
 	canned := []Entry{
 		{Attempt: 1, AgentAdapter: "claude-code", StartedAt: "2026-03-01T10:00:00Z", CompletedAt: "2026-03-01T10:30:00Z", Status: "succeeded", Error: nil},
-		{Attempt: 2, AgentAdapter: "claude-code", StartedAt: "2026-03-02T10:00:00Z", CompletedAt: "2026-03-02T10:05:00Z", Status: "failed", Error: &errMsg},
+		{Attempt: 2, AgentAdapter: "claude-code", StartedAt: "2026-03-02T10:00:00Z", CompletedAt: "2026-03-02T10:05:00Z", Status: "failed", Error: new("agent crashed")},
 		{Attempt: 3, AgentAdapter: "mock", StartedAt: "2026-03-03T10:00:00Z", CompletedAt: "2026-03-03T10:15:00Z", Status: "succeeded", Error: nil},
 	}
 	query := func(_ context.Context, _ string, _ int) ([]Entry, error) {

--- a/internal/tool/notify/notify_test.go
+++ b/internal/tool/notify/notify_test.go
@@ -28,12 +28,11 @@ func (m *mockNotifier) Send(_ context.Context, n domain.Notification) error {
 // testEnv returns a NotificationEnvelopeContext with recognizable test
 // values.
 func testEnv() NotificationEnvelopeContext {
-	attempt := 2
 	return NotificationEnvelopeContext{
 		IssueID:    "issue-42",
 		Identifier: "PROJ-42",
 		SessionID:  "sess-001",
-		Attempt:    &attempt,
+		Attempt:    new(2),
 		Agent:      "claude-code",
 		Source:     "test-host",
 	}

--- a/internal/tool/status/status_test.go
+++ b/internal/tool/status/status_test.go
@@ -182,11 +182,10 @@ func TestStatusTool_AttemptNullAndInteger(t *testing.T) {
 	t.Run("integer_attempt_is_preserved", func(t *testing.T) {
 		t.Parallel()
 		dir := t.TempDir()
-		n := 2
 		writeStateFile(t, dir, stateFile{
 			TurnNumber: 1,
 			MaxTurns:   10,
-			Attempt:    &n,
+			Attempt:    new(2),
 			StartedAt:  time.Now().UTC().Format(time.RFC3339Nano),
 		})
 		m := executeOK(t, New(dir))

--- a/internal/tracker/linear/normalize_test.go
+++ b/internal/tracker/linear/normalize_test.go
@@ -9,10 +9,6 @@ import (
 	"github.com/sortie-ai/sortie/internal/domain"
 )
 
-func ptrFloat(v float64) *float64 { return &v }
-func ptrStr(v string) *string     { return &v }
-func ptrInt(v int) *int           { return &v }
-
 func TestNormalizeIssue(t *testing.T) {
 	t.Parallel()
 
@@ -20,8 +16,8 @@ func TestNormalizeIssue(t *testing.T) {
 		ID:          "uuid-1",
 		Identifier:  "SOR-5",
 		Title:       "Title",
-		Description: ptrStr("body"),
-		Priority:    ptrFloat(2),
+		Description: new("body"),
+		Priority:    new(float64(2)),
 		BranchName:  "tasks/sor-5-anything/with/slashes",
 		URL:         "https://linear.app/org/issue/SOR-5/title",
 		CreatedAt:   "2026-06-10T09:00:00.000Z",
@@ -46,7 +42,7 @@ func TestNormalizeIssue(t *testing.T) {
 		Identifier:  "SOR-5",
 		Title:       "Title",
 		Description: "body",
-		Priority:    ptrInt(2),
+		Priority:    new(2),
 		State:       "In Progress",
 		BranchName:  "tasks/sor-5-anything/with/slashes",
 		URL:         "https://linear.app/org/issue/SOR-5/title",
@@ -128,11 +124,11 @@ func TestNormalizePriority(t *testing.T) {
 		want *int
 	}{
 		{"nil pointer", nil, nil},
-		{"zero maps to nil", ptrFloat(0), nil},
-		{"one", ptrFloat(1), ptrInt(1)},
-		{"two", ptrFloat(2), ptrInt(2)},
-		{"three", ptrFloat(3), ptrInt(3)},
-		{"four", ptrFloat(4), ptrInt(4)},
+		{"zero maps to nil", new(float64(0)), nil},
+		{"one", new(float64(1)), new(1)},
+		{"two", new(float64(2)), new(2)},
+		{"three", new(float64(3)), new(3)},
+		{"four", new(float64(4)), new(4)},
 	}
 
 	for _, tt := range tests {
@@ -300,9 +296,9 @@ func TestSortByPriorityThenCreated(t *testing.T) {
 
 	issues := []domain.Issue{
 		{Identifier: "no-prio-older", Priority: nil, CreatedAt: "2026-06-01"},
-		{Identifier: "prio2", Priority: ptrInt(2), CreatedAt: "2026-06-05"},
-		{Identifier: "prio1-newer", Priority: ptrInt(1), CreatedAt: "2026-06-10"},
-		{Identifier: "prio1-older", Priority: ptrInt(1), CreatedAt: "2026-06-02"},
+		{Identifier: "prio2", Priority: new(2), CreatedAt: "2026-06-05"},
+		{Identifier: "prio1-newer", Priority: new(1), CreatedAt: "2026-06-10"},
+		{Identifier: "prio1-older", Priority: new(1), CreatedAt: "2026-06-02"},
 		{Identifier: "no-prio-newer", Priority: nil, CreatedAt: "2026-06-09"},
 	}
 


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Refactor

**Intent:** Go 1.26 lets `new` take an expression, which retires two idioms this module used throughout: a local declared only so its address could be taken, and a one-line helper per package that returned the address of its argument. Both are removed here, and the `newexpr` modernizer is switched on so they do not come back. The module now reports zero findings for that analyser, where it reported sixty-six before.

### 🧭 Reviewer Guide

**Complexity:** Medium

#### Entry Point

`internal/persistence/run_history.go`. It carries the largest cluster and shows the shape of every other production change: an `if nullValue.Valid` block that declared a local, took its address, and assigned the pointer now assigns `new(nullValue.String)` directly. The same idiom had been copied eleven times across `internal/persistence` alone, so reading one occurrence explains the rest of that package.

#### Sensitive Areas

- `internal/agent/agentcore/forkperturn.go`: unrelated to `new(expr)`, and the one behaviour-adjacent change in the branch. Four multi-value returns placed a multi-line composite literal in the first position, which gofmt indents differently depending on the Go release it ships with, so the toolchain this module pins and the linter's embedded copy each rejected what the other produced. Binding the result to a local before returning removes the construct they disagree on. Both now report the file unchanged; the values returned are identical.
- `.golangci.yml`: the `newexpr` analyser was disabled for a real reason - an automated rewrite expands a helper's call sites and leaves the helper behind as dead code. That property belongs to the automated path, not to the feature, so this branch removes the helpers by hand first and enables the analyser last. The commits are ordered so the enabling commit is the first point at which the tree could pass with it on.
- `internal/scm/github/normalize_test.go`: two helpers here are deliberately kept. Both wrap a composite literal, so inlining them would lengthen every call site rather than shorten it.

Sites left alone follow two rules worth checking while reviewing. A local that is read again after its address is taken stays, because it carries a value rather than holding a place - `cmd/sortie/stats.go` has two such, where the rounded cost is reused a few lines below. And a site whose rewrite would need an explicit conversion to preserve the type stays as well, since `new(int64(250))` is longer than what it replaces.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes. `new(expr)` allocates, initialises from the expression and returns the pointer, which is what the code it replaces did in three lines.
- **Migrations/State:** No migrations or state changes.
