### PR TITLE
fix: refuse agent requests only a human could answer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   quoting the whole endpoint, credential included.
   ([#908](https://github.com/sortie-ai/sortie/issues/908))
 
+- A run no longer stalls when an agent stops to ask for something only
+  a person could give, such as permission to run a command, to change
+  a file, or an answer to a direct question. Where the runtime can be
+  answered, Sortie declines the request and the agent carries on by
+  another route; where it cannot be answered, or where the agent is
+  putting a question to a person, the attempt ends at once and releases
+  its claim on the issue. Previously the turn stayed open until a
+  timeout expired, the attempt was reported as a timeout rather than as
+  a run that needed a person, and the retry that followed could only
+  re-enter the same wait. A run that ended this way is now recorded
+  under its own `needs_person` status instead of being counted among
+  ordinary failures in run reports.
+  ([#837](https://github.com/sortie-ai/sortie/issues/837))
+
+- A runtime configuration that would let an agent stop and ask for
+  approval mid-turn (`codex.approval_policy`,
+  `claude-code.permission_mode`) is now refused by `sortie validate`,
+  at startup and on reload, instead of being accepted and surfacing
+  later as a stalled run. Not every such request is governed by an
+  approval setting, so this check reduces how often the situation
+  arises rather than removing it.
+  ([#837](https://github.com/sortie-ai/sortie/issues/837))
+
 ## [1.21.0] - 2026-08-20
 
 ### Fixed

--- a/cmd/sortie/main.go
+++ b/cmd/sortie/main.go
@@ -89,9 +89,7 @@ func buildAgentAdapterCache(cfg config.ServiceConfig, defaultAdapter domain.Agen
 			)
 			continue
 		}
-		cfgMap := agentConfigMap(cfg.Agent)
-		cfgMap["kind"] = kind
-		mergeExtensions(cfgMap, cfg.Extensions, kind)
+		cfgMap := config.AgentAdapterConfig(cfg, kind)
 		adapter, err := ctor(cfgMap)
 		if err != nil {
 			log.Warn("skipping agent adapter cache entry, construction failed",
@@ -297,8 +295,7 @@ func run(ctx context.Context, args []string, stdout io.Writer, stderr io.Writer)
 		br.logger.Error("unknown agent kind", slog.String("kind", br.cfg.Agent.Kind), slog.Any("error", err))
 		return 1
 	}
-	agentCfgMap := agentConfigMap(br.cfg.Agent)
-	mergeExtensions(agentCfgMap, br.cfg.Extensions, br.cfg.Agent.Kind)
+	agentCfgMap := config.AgentAdapterConfig(br.cfg, br.cfg.Agent.Kind)
 	agentAdapter, err := agentCtor(agentCfgMap)
 	if err != nil {
 		br.logger.Error("failed to construct agent adapter", slog.Any("error", err))

--- a/cmd/sortie/resolve.go
+++ b/cmd/sortie/resolve.go
@@ -45,26 +45,6 @@ func trackerConfigMap(tc config.TrackerConfig) map[string]any {
 	}
 }
 
-// agentConfigMap converts typed [config.AgentConfig] fields into the
-// raw map expected by [registry.AgentConstructor]. Adapter packages
-// extract their required fields from this map.
-//
-// Orchestrator-only fields (max_turns, max_concurrent_agents,
-// max_retry_backoff_ms, max_concurrent_agents_by_state) are
-// intentionally excluded. They are consumed by the orchestrator via
-// the typed [config.AgentConfig] before this map reaches the adapter
-// constructor, and including them would shadow adapter-specific
-// extension keys of the same name during [mergeExtensions].
-func agentConfigMap(ac config.AgentConfig) map[string]any {
-	return map[string]any{
-		"kind":             ac.Kind,
-		"command":          ac.Command,
-		"turn_timeout_ms":  ac.TurnTimeoutMS,
-		"read_timeout_ms":  ac.ReadTimeoutMS,
-		"stall_timeout_ms": ac.StallTimeoutMS,
-	}
-}
-
 // mergeExtensions copies adapter-specific config from the Extensions
 // map into dst. Adapters may define their own configuration fields
 // in a sub-object named after their kind value. Existing keys in dst

--- a/cmd/sortie/resolve_test.go
+++ b/cmd/sortie/resolve_test.go
@@ -357,83 +357,6 @@ func TestTrackerConfigMapCompleteness(t *testing.T) {
 	}
 }
 
-func TestAgentConfigMapCompleteness(t *testing.T) {
-	t.Parallel()
-
-	m := agentConfigMap(config.AgentConfig{})
-	rt := reflect.TypeFor[config.AgentConfig]()
-
-	// Orchestrator-only fields are intentionally excluded from the
-	// adapter config map. They are consumed by the orchestrator via
-	// typed config.AgentConfig and would shadow adapter extension
-	// keys of the same name during mergeExtensions.
-	excluded := map[string]bool{
-		"MaxTurns":             true,
-		"MaxConcurrentAgents":  true,
-		"MaxRetryBackoffMS":    true,
-		"MaxConcurrentByState": true,
-		"MaxSessions":          true,
-		"MaxTokens":            true,
-	}
-
-	for _, field := range reflect.VisibleFields(rt) {
-		if !field.IsExported() || excluded[field.Name] {
-			continue
-		}
-		key := toSnakeCase(field.Name)
-		if _, ok := m[key]; !ok {
-			t.Errorf("agentConfigMap missing key %q for field %s", key, field.Name)
-		}
-	}
-}
-
-func TestAgentConfigMapExcludesOrchestratorFields(t *testing.T) {
-	t.Parallel()
-
-	cfg := config.AgentConfig{
-		Kind:                 "claude-code",
-		Command:              "claude",
-		TurnTimeoutMS:        3600000,
-		ReadTimeoutMS:        5000,
-		StallTimeoutMS:       300000,
-		MaxConcurrentAgents:  10,
-		MaxTurns:             20,
-		MaxRetryBackoffMS:    300000,
-		MaxConcurrentByState: map[string]int{"open": 5},
-	}
-
-	m := agentConfigMap(cfg)
-
-	excluded := []string{
-		"max_turns",
-		"max_concurrent_agents",
-		"max_retry_backoff_ms",
-		"max_concurrent_agents_by_state",
-		"max_sessions",
-		"max_tokens",
-	}
-	for _, key := range excluded {
-		if _, ok := m[key]; ok {
-			t.Errorf("agentConfigMap contains orchestrator-only key %q", key)
-		}
-	}
-
-	required := []string{
-		"kind",
-		"command",
-		"turn_timeout_ms",
-		"read_timeout_ms",
-		"stall_timeout_ms",
-	}
-	for _, key := range required {
-		if _, ok := m[key]; !ok {
-			t.Errorf("agentConfigMap missing required key %q", key)
-		}
-	}
-}
-
-// --- mergeExtensions tests ---
-
 // --- mergeExtensions tests ---
 
 func TestMergeExtensions(t *testing.T) {
@@ -516,7 +439,7 @@ func TestMergeExtensions(t *testing.T) {
 	t.Run("adapter max_turns passthrough", func(t *testing.T) {
 		t.Parallel()
 
-		dst := agentConfigMap(config.AgentConfig{MaxTurns: 5})
+		dst := map[string]any{"kind": "claude-code"}
 		extensions := map[string]any{
 			"claude-code": map[string]any{"max_turns": float64(50)},
 		}

--- a/cmd/sortie/validate_test.go
+++ b/cmd/sortie/validate_test.go
@@ -1519,6 +1519,354 @@ func TestValidateGitHubTokenHintWarning(t *testing.T) {
 	}
 }
 
+// codexInteractiveApprovalPolicyWorkflow returns a workflow selecting the
+// codex agent with an approval_policy value that lets the agent stop and
+// ask for approval, used to trigger the agent-side offline verdict
+// without constructing any adapter.
+func codexInteractiveApprovalPolicyWorkflow() []byte {
+	return []byte(`---
+polling:
+  interval_ms: 30000
+tracker:
+  kind: file
+  active_states:
+    - To Do
+  terminal_states:
+    - Done
+agent:
+  kind: codex
+  command: /usr/bin/true
+codex:
+  approval_policy: untrusted
+file:
+  path: issues.json
+---
+Do {{ .issue.title }}.
+`)
+}
+
+// TestValidateAgentConfigOfflineVerdict drives the offline sortie validate
+// path against a workflow whose codex.approval_policy is set to an
+// interactive value, asserting valid: false, exit code 1, and the check
+// name codex.approval_policy.interactive, without constructing any
+// adapter (the offline path never calls a constructor). This exercises
+// one leg of the shared verdict channel; the startup and reload legs are
+// exercised elsewhere.
+func TestValidateAgentConfigOfflineVerdict(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	wfPath := writeCustomWorkflowFile(t, dir, codexInteractiveApprovalPolicyWorkflow())
+
+	var stdout, stderr bytes.Buffer
+	ctx := context.Background()
+
+	code := run(ctx, []string{"validate", "--format", "json", wfPath}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("run(validate --format json) = %d, want 1; stderr: %s", code, stderr.String())
+	}
+
+	var out validateOutput
+	if err := json.Unmarshal(stdout.Bytes(), &out); err != nil {
+		t.Fatalf("json.Unmarshal(%q) error: %v", stdout.String(), err)
+	}
+	if out.Valid {
+		t.Errorf("validateOutput.Valid = true, want false")
+	}
+
+	foundErr := false
+	for _, e := range out.Errors {
+		if e.Check == "codex.approval_policy.interactive" {
+			foundErr = true
+			break
+		}
+	}
+	if !foundErr {
+		t.Errorf("validateOutput.Errors = %v, want entry with check %q", out.Errors, "codex.approval_policy.interactive")
+	}
+}
+
+// copilotToolScopingWorkflow returns a workflow selecting the copilot-cli
+// agent with allowed_tools configured, used to trigger the agent-side
+// offline verdict without constructing any adapter.
+func copilotToolScopingWorkflow() []byte {
+	return []byte(`---
+polling:
+  interval_ms: 30000
+tracker:
+  kind: file
+  active_states:
+    - To Do
+  terminal_states:
+    - Done
+agent:
+  kind: copilot-cli
+  command: /usr/bin/true
+copilot-cli:
+  allowed_tools: bash
+file:
+  path: issues.json
+---
+Do {{ .issue.title }}.
+`)
+}
+
+// TestValidateAgentConfigOfflineVerdict_CopilotToolScoping drives the
+// offline sortie validate path against a workflow whose copilot-cli
+// configuration displaces --allow-all, asserting valid: true (a warning
+// does not fail validation), exit code 0, and the check name
+// copilot-cli.tool_scoping.interactive, without constructing any adapter
+// (the offline path never calls a constructor). This exercises the same
+// verdict channel already established for codex, following the pattern
+// this project's validators report through: a warning-severity check
+// reports identically whether observed via sortie validate, at startup, or
+// on reload.
+func TestValidateAgentConfigOfflineVerdict_CopilotToolScoping(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	wfPath := writeCustomWorkflowFile(t, dir, copilotToolScopingWorkflow())
+
+	var stdout, stderr bytes.Buffer
+	ctx := context.Background()
+
+	code := run(ctx, []string{"validate", "--format", "json", wfPath}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("run(validate --format json) = %d, want 0; stderr: %s", code, stderr.String())
+	}
+
+	var out validateOutput
+	if err := json.Unmarshal(stdout.Bytes(), &out); err != nil {
+		t.Fatalf("json.Unmarshal(%q) error: %v", stdout.String(), err)
+	}
+	if !out.Valid {
+		t.Errorf("validateOutput.Valid = false, want true (a warning must not fail validation)")
+	}
+
+	foundWarn := false
+	for _, w := range out.Warnings {
+		if w.Check == "copilot-cli.tool_scoping.interactive" {
+			foundWarn = true
+			break
+		}
+	}
+	if !foundWarn {
+		t.Errorf("validateOutput.Warnings = %v, want entry with check %q", out.Warnings, "copilot-cli.tool_scoping.interactive")
+	}
+}
+
+// kiroUntrustedToolsWorkflow returns a workflow selecting the kiro agent
+// with a trust_tools allowlist and no trust_all_tools, which resolves to a
+// trust posture short of full trust, used to trigger the agent-side
+// offline verdict without constructing any adapter.
+func kiroUntrustedToolsWorkflow() []byte {
+	return []byte(`---
+polling:
+  interval_ms: 30000
+tracker:
+  kind: file
+  active_states:
+    - To Do
+  terminal_states:
+    - Done
+agent:
+  kind: kiro
+  command: /usr/bin/true
+kiro:
+  trust_tools:
+    - read
+file:
+  path: issues.json
+---
+Do {{ .issue.title }}.
+`)
+}
+
+// TestValidateAgentConfigOfflineVerdict_KiroUntrustedTools drives the
+// offline sortie validate path against a workflow whose kiro configuration
+// resolves to a trust posture short of full trust, asserting valid: false,
+// exit code 1, and the check name kiro.trust_tools.untrusted, without
+// constructing any adapter (the offline path never calls a constructor).
+// This exercises the same verdict channel established for codex,
+// confirming kiro's validator is wired into agent registration and its
+// diagnostic actually reaches sortie validate, not only validateConfig
+// called directly.
+func TestValidateAgentConfigOfflineVerdict_KiroUntrustedTools(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	wfPath := writeCustomWorkflowFile(t, dir, kiroUntrustedToolsWorkflow())
+
+	var stdout, stderr bytes.Buffer
+	ctx := context.Background()
+
+	code := run(ctx, []string{"validate", "--format", "json", wfPath}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("run(validate --format json) = %d, want 1; stderr: %s", code, stderr.String())
+	}
+
+	var out validateOutput
+	if err := json.Unmarshal(stdout.Bytes(), &out); err != nil {
+		t.Fatalf("json.Unmarshal(%q) error: %v", stdout.String(), err)
+	}
+	if out.Valid {
+		t.Errorf("validateOutput.Valid = true, want false")
+	}
+
+	foundErr := false
+	for _, e := range out.Errors {
+		if e.Check == "kiro.trust_tools.untrusted" {
+			foundErr = true
+			break
+		}
+	}
+	if !foundErr {
+		t.Errorf("validateOutput.Errors = %v, want entry with check %q", out.Errors, "kiro.trust_tools.untrusted")
+	}
+}
+
+// opencodeToolOverlapWorkflow returns a workflow selecting the opencode
+// agent with allowed_tools and denied_tools naming the same tool, used to
+// trigger the agent-side offline verdict without constructing any
+// adapter.
+func opencodeToolOverlapWorkflow() []byte {
+	return []byte(`---
+polling:
+  interval_ms: 30000
+tracker:
+  kind: file
+  active_states:
+    - To Do
+  terminal_states:
+    - Done
+agent:
+  kind: opencode
+  command: /usr/bin/true
+opencode:
+  allowed_tools:
+    - bash
+  denied_tools:
+    - bash
+file:
+  path: issues.json
+---
+Do {{ .issue.title }}.
+`)
+}
+
+// TestValidateAgentConfigOfflineVerdict_OpenCodeToolOverlap drives the
+// offline sortie validate path against a workflow whose opencode
+// configuration names the same tool in both allowed_tools and
+// denied_tools, asserting valid: false, exit code 1, and the check name
+// opencode.allowed_tools.overlap, without constructing any adapter (the
+// offline path never calls a constructor). This is the regression guard
+// for a defect where opencode's agent registration omitted its
+// ValidateAgentConfig hook entirely: validateConfig was unit-tested and
+// passed because a direct call bypasses registration, but sortie validate
+// reached no diagnostic at all until the hook was wired in.
+func TestValidateAgentConfigOfflineVerdict_OpenCodeToolOverlap(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	wfPath := writeCustomWorkflowFile(t, dir, opencodeToolOverlapWorkflow())
+
+	var stdout, stderr bytes.Buffer
+	ctx := context.Background()
+
+	code := run(ctx, []string{"validate", "--format", "json", wfPath}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("run(validate --format json) = %d, want 1; stderr: %s", code, stderr.String())
+	}
+
+	var out validateOutput
+	if err := json.Unmarshal(stdout.Bytes(), &out); err != nil {
+		t.Fatalf("json.Unmarshal(%q) error: %v", stdout.String(), err)
+	}
+	if out.Valid {
+		t.Errorf("validateOutput.Valid = true, want false")
+	}
+
+	foundErr := false
+	for _, e := range out.Errors {
+		if e.Check == "opencode.allowed_tools.overlap" {
+			foundErr = true
+			break
+		}
+	}
+	if !foundErr {
+		t.Errorf("validateOutput.Errors = %v, want entry with check %q", out.Errors, "opencode.allowed_tools.overlap")
+	}
+}
+
+// claudeCodeInteractivePermissionModeWorkflow returns a workflow selecting
+// the claude-code agent with a permission_mode value outside the
+// non-asking allowlist, used to trigger the agent-side offline verdict
+// without constructing any adapter.
+func claudeCodeInteractivePermissionModeWorkflow() []byte {
+	return []byte(`---
+polling:
+  interval_ms: 30000
+tracker:
+  kind: file
+  active_states:
+    - To Do
+  terminal_states:
+    - Done
+agent:
+  kind: claude-code
+  command: /usr/bin/true
+claude-code:
+  permission_mode: acceptEdits
+file:
+  path: issues.json
+---
+Do {{ .issue.title }}.
+`)
+}
+
+// TestValidateAgentConfigOfflineVerdict_ClaudeCodePermissionMode drives
+// the offline sortie validate path against a workflow whose claude-code
+// permission_mode lets the agent stop and ask for approval, asserting
+// valid: false, exit code 1, and the check name
+// claude-code.permission_mode.interactive, without constructing any
+// adapter (the offline path never calls a constructor). This confirms
+// claude-code's validator is wired into agent registration and its
+// diagnostic actually reaches sortie validate, not only validateConfig
+// called directly.
+func TestValidateAgentConfigOfflineVerdict_ClaudeCodePermissionMode(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	wfPath := writeCustomWorkflowFile(t, dir, claudeCodeInteractivePermissionModeWorkflow())
+
+	var stdout, stderr bytes.Buffer
+	ctx := context.Background()
+
+	code := run(ctx, []string{"validate", "--format", "json", wfPath}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("run(validate --format json) = %d, want 1; stderr: %s", code, stderr.String())
+	}
+
+	var out validateOutput
+	if err := json.Unmarshal(stdout.Bytes(), &out); err != nil {
+		t.Fatalf("json.Unmarshal(%q) error: %v", stdout.String(), err)
+	}
+	if out.Valid {
+		t.Errorf("validateOutput.Valid = true, want false")
+	}
+
+	foundErr := false
+	for _, e := range out.Errors {
+		if e.Check == "claude-code.permission_mode.interactive" {
+			foundErr = true
+			break
+		}
+	}
+	if !foundErr {
+		t.Errorf("validateOutput.Errors = %v, want entry with check %q", out.Errors, "claude-code.permission_mode.interactive")
+	}
+}
+
 // --- HTTP Server Always-On integration tests ---
 
 func TestValidateShortHelp(t *testing.T) {

--- a/docs/architecture/10-agent-adapter-contract.md
+++ b/docs/architecture/10-agent-adapter-contract.md
@@ -77,8 +77,7 @@ native protocol events to this normalized set:
 - `turn_failed`: turn finished with failure
 - `turn_cancelled`: turn was cancelled
 - `turn_ended_with_error`: turn ended due to an error condition
-- `turn_input_required`: agent requested user input (hard failure per policy)
-- `approval_auto_approved`: approval request was auto-resolved
+- `turn_input_required`: agent asked for a decision only a person could give, ending the attempt under the shared refusal posture
 - `unsupported_tool_call`: agent requested an unsupported tool
 - `token_usage`: normalized token usage event: `{input_tokens, output_tokens, total_tokens, cache_read_tokens}`. Optional `model` field (string) identifies the LLM model when available. Optional `api_duration_ms` field (int64, milliseconds) carries per-request or per-turn API response wait time when the adapter can measure it.
 
@@ -143,20 +142,19 @@ sessions.
 
 #### 10.4.1 Approval policy
 
-Approval, sandbox, and user-input behavior is implementation-defined.
+Every agent run is unattended: no person is present to grant a permission or answer a question
+while a run is in progress. A request for consent to act is refused in the continuable form the
+runtime's own protocol offers, where the runtime offers one, so the turn can proceed by another
+route; a request addressed to a person ends the attempt with the `turn_input_required` outcome.
+The posture is uniform across every agent adapter and is not an operator-configurable setting.
 
 Policy requirements:
 
-- Each deployment MUST document its chosen approval, sandbox, and operator-confirmation posture.
-- Approval requests and user-input-required events MUST NOT leave a run stalled indefinitely.
-  Sortie MUST either satisfy them, surface them to an operator, auto-resolve them, or fail the
-  run according to its documented policy.
-
-Example high-trust behavior:
-
-- Auto-approve command execution approvals for the session.
-- Auto-approve file-change approvals for the session.
-- Treat user-input-required turns as hard failure.
+- Each deployment enforces the same refusal posture: a permission request is refused rather than
+  granted, and a request for human input ends the attempt rather than stalling.
+- Approval requests and user-input-required events MUST NOT leave a run stalled indefinitely. A
+  configuration value that would let the agent stop and wait for a person is refused before the
+  run, rather than satisfied when it arrives mid-turn.
 
 Unsupported dynamic tool calls:
 
@@ -164,9 +162,10 @@ Unsupported dynamic tool calls:
   adapter returns a tool failure response and continues the session.
 - This is adapter-level behavior; the orchestrator does not intercept tool call routing.
 
-Hard failure on user input requirement:
+Ending on a request only a person could answer:
 
-- If the agent requests user input, fail the run attempt immediately.
+- If the agent asks for something only a person could give, end the run attempt immediately with
+  the `turn_input_required` outcome, distinct from a generic turn failure.
 
 #### 10.4.2 Tool interface contract
 
@@ -316,7 +315,7 @@ Availability: registered when the database path and issue ID are present in the 
 On success the tool returns, under `data` in the envelope `{"success": true, "data": {...}}` of
 Section 10.4.2, a JSON object `{issue_id, entries}`, where `entries` lists at most the 10 most
 recent runs, newest first. Each entry has `attempt`, `agent_adapter`, `started_at`,
-`completed_at`, `status` (`succeeded`, `failed`, `cancelled`, or `ci_failed`), and
+`completed_at`, `status` (`succeeded`, `failed`, `cancelled`, `ci_failed`, or `needs_person`), and
 `error` (null unless the run failed). The per-entry `error` is the run's own error and is distinct
 from the envelope's `error` object.
 

--- a/docs/architecture/10-agent-adapter-contract.md
+++ b/docs/architecture/10-agent-adapter-contract.md
@@ -622,19 +622,23 @@ so that a new adapter inherits it rather than re-deriving it.
 The rule is evaluated as an ordered table. The first matching row decides the turn:
 
 1. The runtime reported the turn cancelled (an orchestrator-initiated cancellation): `turn_cancelled`.
-2. The runtime reported the turn failed, or the adapter itself ended the turn on its own
+2. The adapter recognized a request only a person could answer that the turn cannot continue
+   past: `turn_input_required`. It outranks every failure row below, so such a request is
+   never reported as a generic turn failure, and it ranks under cancellation, so a shutdown
+   already in progress still reports itself.
+3. The runtime reported the turn failed, or the adapter itself ended the turn on its own
    determination (a protocol violation, a timeout waiting for the first response, or a transport
    failure): `turn_failed`, with the error kind the runtime or the adapter supplied.
-3. The runtime reported the turn succeeded: `turn_completed`. A positive report from the runtime is
+4. The runtime reported the turn succeeded: `turn_completed`. A positive report from the runtime is
    authoritative and is never second-guessed by counting output.
-4. The runtime reported no outcome at all, and the adapter observed no process exit for the turn (a
+5. The runtime reported no outcome at all, and the adapter observed no process exit for the turn (a
    persistent session with no per-turn exit): `turn_failed`.
-5. The runtime reported no outcome, a process exit was observed, and the exit code is non-zero:
+6. The runtime reported no outcome, a process exit was observed, and the exit code is non-zero:
    `turn_failed`.
-6. The runtime reported no outcome, the process exited zero, and the adapter found no evidence the
+7. The runtime reported no outcome, the process exited zero, and the adapter found no evidence the
    model produced anything this turn: `turn_failed`. Exit code zero is never by itself a success
    signal; an adapter with nothing positive to offer reports a failed turn.
-7. The runtime reported no outcome, the process exited zero, and the adapter found evidence the
+8. The runtime reported no outcome, the process exited zero, and the adapter found evidence the
    model produced something this turn: `turn_completed`.
 
 Extracting the runtime's own report and the per-turn work evidence from a vendor's wire format is
@@ -650,7 +654,7 @@ and diverge from the rule's letter while obeying its intent:
   currency: the credits trailer on stderr is the positive success signal, and its absence with a
   zero exit code is the adapter's only evidence of nothing produced.
 - Codex's persistent per-session subprocess has no per-turn process exit to observe, so the rule's
-  zero-work row (row 6 above) is structurally unreachable for it: an absent turn-completion report
+  zero-work row (row 7 above) is structurally unreachable for it: an absent turn-completion report
   is already a failure on its own terms.
 
 `turn_ended_with_error` remains a documented normalized event type (Section 10.3), reserved for a

--- a/docs/architecture/24-persistence-schema.md
+++ b/docs/architecture/24-persistence-schema.md
@@ -37,7 +37,7 @@ Note: `timer_handle` is runtime-only and is not stored.
 | `workspace`     | TEXT    | Workspace path                            |
 | `started_at`    | TEXT    | ISO-8601 timestamp                        |
 | `completed_at`  | TEXT    | ISO-8601 timestamp                        |
-| `status`          | TEXT    | Run disposition (`succeeded`, `failed`, `cancelled`, or `ci_failed`) |
+| `status`          | TEXT    | Run disposition (`succeeded`, `failed`, `cancelled`, `ci_failed`, or `needs_person`) |
 | `error`           | TEXT    | Error message if failed, may be null      |
 | `workflow_file`   | TEXT    | Workflow file name the run was driven by, may be null (migration 003) |
 | `turns_completed`   | INTEGER | Agent turns the attempt completed (migration 005) |

--- a/docs/claude-code-adapter-notes.md
+++ b/docs/claude-code-adapter-notes.md
@@ -6,9 +6,11 @@
 > Coverage: the flag surface is anchored to `claude --help` on CLI v2.1.76. The `stream-json`
 > message shapes, result fields, permission modes, session storage layout, hook behavior,
 > OpenTelemetry names, and SDK surface come from Anthropic's Claude Code documentation read in
-> March 2026 and have not been re-observed against a later binary. Statements about Sortie's own
-> code name the Go symbol that implements them and were verified against the tree. Unsettled
-> items are collected under "Open questions"; sources are listed under "Sources".
+> March 2026 and have not been re-observed against a later binary. The `system/permission_denied`
+> event and its refusal recognition path are anchored to CLI v2.1.239 (August 2026); see
+> "Refusing requests only a person could answer". Statements about Sortie's own code name the Go
+> symbol that implements them and were verified against the tree. Unsettled items are collected
+> under "Open questions"; sources are listed under "Sources".
 
 ---
 
@@ -216,6 +218,7 @@ originating tool name and the execution duration; an uncorrelated result is repo
 | `init`             | First message. Contains `session_id` and `cwd`.        | Adopt `session_id`, emit `session_started`, start the API-timing clock          |
 | `api_retry`        | API retry in progress.                                 | `notification` formatted by `formatAPIRetry`                                    |
 | `compact_boundary` | Context was compacted (conversation truncated to fit). | `notification` carrying `system/compact_boundary`                               |
+| `permission_denied` | Undocumented by Anthropic; observed when the runtime has denied a tool call on its own, before the tool's `tool_result`. Carries `tool_name` and, sometimes, `decision_reason_type`/`decision_reason`. | See "Refusing requests only a person could answer" |
 
 **Init/system event:**
 
@@ -549,7 +552,7 @@ Per [architecture Section 10.4](architecture/10-agent-adapter-contract.md#104-ap
 | ------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Auto-approve commands     | `--dangerously-skip-permissions` bypasses all prompts.                                                                                                             |
 | Auto-approve file changes | Same flag covers file edits.                                                                                                                                       |
-| User input required       | The `-p` flag runs non-interactively, so no prompt is expected. A process that blocks anyway produces no output and is cut off by orchestrator-side cancellation.   |
+| User input required       | The `-p` flag runs non-interactively, so no prompt is expected. A call the runtime would otherwise have to prompt for is denied instead; see "Refusing requests only a person could answer". |
 | Unsupported tool calls    | Claude Code handles tool routing internally. Unknown MCP tools return failure and the session continues.                                                            |
 
 `--dangerously-skip-permissions` allows arbitrary command execution. Per Anthropic's guidance it
@@ -572,6 +575,51 @@ instead of blanket bypass sets `claude-code.permission_mode`, which replaces the
 | `bypassPermissions` | All tools run without asking. Cannot run as root on Unix.                    |
 | `auto`              | Automatic permission handling.                                               |
 
+### Refusing requests only a person could answer
+
+The adapter passes `--dangerously-skip-permissions` by default and exposes no reply channel, so
+every request it recognizes here reads as unanswerable by this run. Two request classes are
+distinguished on the wire.
+
+**A permission request the runtime already resolved on its own.** A tool call the runtime would
+otherwise have to ask about, most commonly a write or read outside the workspace's allowed
+directories, produces an undocumented `system` event with `subtype: "permission_denied"` before the
+tool's own `tool_result`, observed on CLI v2.1.239:
+
+```json
+{"type":"system","subtype":"permission_denied","tool_name":"Read","tool_use_id":"toolu_...","decision_reason_type":"workingDir","decision_reason":"Path is outside allowed working directories","message":"Claude requested permissions to read from ..., but you haven't granted it yet.","session_id":"..."}
+```
+
+The turn continues after this event; a later `assistant` message picks another route. This is
+observed even under `--dangerously-skip-permissions`, because workspace-directory containment is
+enforced independently of the permission mode. `decision_reason_type` and `decision_reason` are
+present on some denials and absent on others; neither is required to recognize the event, and
+neither is documented by Anthropic. The paired `user` event's `tool_result` block carries
+`is_error: true` and, on this denial path only, a `tool_result_meta` entry with
+`"non_execution_kind":"user-rejected"`; the terminal `result` event's `permission_denials` array
+also lists the denial. None of the three appears for an unrelated tool failure such as a missing
+file.
+
+**A request for human input.** The built-in `AskUserQuestion` tool carries a genuine question
+rather than a request for consent to act. Anthropic's own documentation states that this tool "is
+denied even when an allow rule matches" under `dontAsk` mode, and that under `-p
+--dangerously-skip-permissions` specifically, "the few calls that would still prompt are denied
+instead" of stalling; `AskUserQuestion` is named among those calls. The adapter therefore treats a
+`system/permission_denied` event naming `tool_name: "AskUserQuestion"` as a request for human
+input rather than a permission request, ending the attempt with `turn_input_required`. This
+specific combination (`AskUserQuestion` resolving through the same `permission_denied` event
+shape observed above) was not itself driven end to end on the installed CLI: getting the model to
+call that tool under a non-interactive session that excludes it from the discoverable tool set
+proved impractical, so this path is inferred from the uniform shape every other observed denial
+uses plus the documented statement above, not from a captured transcript naming
+`AskUserQuestion`.
+
+Claude Code's headless mode resolves every recognized request synchronously; there is no
+observed wire signal for a permission request the runtime has left open pending a reply, and
+none is expected under any configuration this adapter is permitted to construct, because the
+adapter never passes `--permission-prompt-tool`, the flag that gates the one reply channel the
+CLI documents for this state.
+
 ---
 
 ## Error detection and mapping
@@ -588,6 +636,7 @@ returned, the `domain.AgentError` kind.
 | Stdout line exceeds 10 MB, or the pipe read fails                  | `agentcore.ForkPerTurnSession.RunTurn`            | `turn_failed` / `port_exit`                |
 | Exit code 127                                                      | `agentcore.ForkPerTurnSession.RunTurn`            | `turn_failed` / `agent_not_found`          |
 | Killed by signal                                                   | `agentcore.ForkPerTurnSession.RunTurn`            | `turn_cancelled` / `turn_cancelled`        |
+| A `system/permission_denied` event named `AskUserQuestion`         | `OnFinalize` reports `TerminalHumanInputRequired` ahead of the result-event rows below | `turn_input_required` |
 | Result event with `subtype: "success"` and `is_error: false`       | `OnFinalize` reports `TerminalSuccess`            | `turn_completed`                            |
 | Result event with any other subtype, or `is_error: true`           | `OnFinalize` reports `TerminalFailure`            | `turn_failed` / `turn_failed`              |
 | No result event, non-zero exit                                     | `agentcore.DecideTurn` row `RowNonZeroExit`       | `turn_failed` / `port_exit`                |
@@ -602,10 +651,11 @@ Workspace and binary resolution fail earlier, in `StartSession`: an unusable wor
 `invalid_workspace_cwd` and an unresolvable command yields `agent_not_found`
 (`agentcore.ResolveWorkspace`, `agentcore.ResolveBinary`).
 
-The Claude path never produces `response_timeout` or `turn_input_required`: it enforces no
-adapter-side deadline, and `-p` admits no interactive prompt. It can end with `turn_timeout`: the
-orchestrator produces that kind on the adapter's return once its derived turn deadline expires,
-not the adapter itself.
+The Claude path never produces `response_timeout`: it enforces no adapter-side deadline of its
+own. It can end with `turn_timeout`: the orchestrator produces that kind on the adapter's return
+once its derived turn deadline expires, not the adapter itself. It can also end with
+`turn_input_required`, when a `system/permission_denied` event names the built-in
+`AskUserQuestion` tool; see "Refusing requests only a person could answer".
 
 ### API retry errors
 
@@ -879,6 +929,16 @@ async with ClaudeSDKClient(options=options) as client:
   `other_message`. Probe: run a headless turn whose prompt forces a subagent or a
   background bash task and record the `type` field of each resulting stdout line.
 
+- **Does a denied `AskUserQuestion` call use the same `system/permission_denied` shape as a
+  denied tool call?** "Refusing requests only a person could answer" treats it that way, by
+  inference from the uniform shape every other observed denial uses plus Anthropic's documented
+  statement that the tool is denied rather than left pending under `-p
+  --dangerously-skip-permissions`. No transcript naming `AskUserQuestion` in a
+  `system/permission_denied` event was captured. Probe: find a prompt that reaches
+  `AskUserQuestion` under a plain headless `-p --dangerously-skip-permissions` invocation (it is
+  absent from the discoverable tool set under `manual` mode, which is the mode this note's other
+  permission probes used to observe a denial) and record the exact event.
+
 ---
 
 ## Sources
@@ -889,12 +949,27 @@ Local probes:
 - `claude --help` and headless `-p` runs on CLI 2.1.234: accepted `--permission-mode` values,
   `--effort` levels and its warn-and-ignore handling, `--allowedTools` separators, `--max-turns`
   acceptance, and the resume behaviour of `--no-session-persistence`.
+- Headless `-p --output-format stream-json --verbose` runs on CLI v2.1.239 (August 2026), with
+  `--setting-sources ""` and `--permission-mode manual` to strip an account-level
+  `bypassPermissions` default: the `system/permission_denied` event shape (including the
+  `decision_reason_type`/`decision_reason` pair on a workspace-containment denial), the paired
+  `tool_result_meta`/`non_execution_kind` marker, the `result` event's `permission_denials`
+  array, and the absence of `AskUserQuestion` from the `system/init` tool list under `manual`
+  mode with and without `--brief`.
 
-Anthropic first-party documentation, read March 2026 and the CLI reference re-read August 2026:
+Anthropic first-party documentation, read March 2026 and the CLI reference and the headless and
+permission-modes pages re-read August 2026:
 
 - Claude Code CLI reference: flags, headless (`-p`) mode, permission modes, session storage.
 - Claude Code `stream-json` output reference: message union, system subtypes, content blocks,
   result fields and subtypes, task messages.
+- Claude Code headless-mode reference: the SIGTERM-and-unanswered-prompt behaviour, the
+  `-p --dangerously-skip-permissions` container example stating that "the few calls that would
+  still prompt are denied instead," and the documented `system` subtypes (`init`, `api_retry`,
+  `plugin_install`), which do not include `permission_denied`.
+- Claude Code permission-modes reference: the `AskUserQuestion` tool's exemption from every
+  mode's auto-approval, including `bypassPermissions`, and the `dontAsk` mode's explicit denial
+  of it.
 - Claude Code monitoring reference: OpenTelemetry environment variables, metrics, and events.
 - Claude Code hooks reference: hook exit codes and per-hook timeout.
 - Claude Code GitHub Actions reference: `claude_args`, source of the `--max-turns` claim.

--- a/docs/codex-adapter-notes.md
+++ b/docs/codex-adapter-notes.md
@@ -540,7 +540,10 @@ that both refuses and lets the turn continue.
 
 The default `approvalPolicy: "never"` keeps the app-server from asking most of these questions in
 the first place. Setting `codex.approval_policy` to any other value only changes how often the
-app-server asks; every method above is refused the same way regardless of `approvalPolicy`.
+app-server sends these requests. It does not change how any of them is answered: the seven
+recognized methods keep the replies listed in the table above, which differ from one another,
+and `item/tool/call`, `account/chatgptAuthTokens/refresh` and `attestation/generate` are not
+in this class at all.
 
 ---
 

--- a/docs/codex-adapter-notes.md
+++ b/docs/codex-adapter-notes.md
@@ -508,27 +508,39 @@ container-level isolation.
 
 ### Approval requests
 
-When `approvalPolicy` is not `"never"`, the app-server sends approval requests as JSON-RPC
-requests to the client:
+The protocol schema `codex-cli 0.147.0` generates for itself declares ten server-to-client
+JSON-RPC requests, each with `id`, `method`, and `params` required. `RunTurn` recognizes seven of
+them as a request only a person could answer and refuses every one: an unattended run has no one
+to grant the permission or supply the answer any of the seven asks for.
 
-- `item/commandExecution/requestApproval`: shell command approval.
-- `item/fileChange/requestApproval`: file edit approval.
-- `item/tool/requestUserInput`: user input request, which can carry approval questions.
+| Method | What it asks | `RunTurn`'s reply |
+| --- | --- | --- |
+| `item/commandExecution/requestApproval` | Run a shell command. | Result `{"decision": "decline"}`, documented as "User denied the command. The agent will continue the turn." |
+| `item/fileChange/requestApproval` | Change a file. | Result `{"decision": "decline"}`, documented as "User denied the file changes. The agent will continue the turn." |
+| `applyPatchApproval` | Change a file; the legacy form of `item/fileChange/requestApproval`. | Result `{"decision": {"denied": {"rejection": "sortie refuses requests that only a person could answer"}}}`, the `ReviewDecision` variant documented as "the agent should not execute it, but it should continue the session and try something else." |
+| `execCommandApproval` | Run a shell command; the legacy form of `item/commandExecution/requestApproval`. | Same reply as `applyPatchApproval`. |
+| `mcpServer/elicitation/request` | Answer a question an MCP server addressed to a person. | Result `{"action": "decline"}`, which the response schema declares; the `content` member is left absent, which the schema documents as null on a decline. |
+| `item/permissions/requestApproval` | Widen the agent's filesystem or network access. | The response schema declares no denial value and requires a `permissions` grant object, so no result can express a refusal. `RunTurn` writes the JSON-RPC error `{"code": -32001, "message": "sortie refuses requests that only a person could answer"}` instead. |
+| `item/tool/requestUserInput` | Answer a question. | The response schema requires an `answers` member, so any result would be an answer rather than a refusal. `RunTurn` writes the same JSON-RPC error as `item/permissions/requestApproval`. |
+| `item/tool/call` | Invoke a registered dynamic tool. | Out of this class; answered by `handleToolCall`, described under "Dynamic tool calls". |
+| `account/chatgptAuthTokens/refresh` | Refresh a stored credential. | Out of this class; falls to the default arm of the notification switch, which emits a `domain.EventOtherMessage` carrying the method name and sends no response. |
+| `attestation/generate` | Produce an attestation. | Out of this class; same default-arm handling as `account/chatgptAuthTokens/refresh`. |
 
-A client answers with one of `accept`, `acceptForSession`, `decline`, or `cancel`:
+The `-32001` code and its message are both pinned rather than derived: the schema declares `code`
+as a required `int64` and `message` as a required string on the error object, enumerating no
+values for either, and the app-server acknowledges no client response, so an unaccepted code
+produces silence rather than an error. The bounded cancellation wait described below is the
+backstop for that silence.
 
-```json
-{"id": 42, "result": {"decision": "acceptForSession"}}
-```
+A permission request that `RunTurn` refuses in the continuable form lets the agent proceed by
+another route within the same turn. A refused `mcpServer/elicitation/request`,
+`item/permissions/requestApproval`, or `item/tool/requestUserInput` ends the turn immediately with
+the human-input-required outcome, because none of those three response schemas offers a result
+that both refuses and lets the turn continue.
 
-`RunTurn` has no case for any of these three methods. They fall to the default arm of its
-notification switch, which emits a `domain.EventOtherMessage` carrying the method name and
-sends no response. The default `approvalPolicy: "never"` is what keeps that gap harmless,
-because it stops the app-server from asking. Setting `codex.approval_policy` to any other value
-leaves the app-server waiting for a decision the adapter does not send.
-
-`item/tool/call` is a separate request that the adapter does answer, described under "Dynamic
-tool calls".
+The default `approvalPolicy: "never"` keeps the app-server from asking most of these questions in
+the first place. Setting `codex.approval_policy` to any other value only changes how often the
+app-server asks; every method above is refused the same way regardless of `approvalPolicy`.
 
 ---
 
@@ -536,8 +548,8 @@ tool calls".
 
 | Timeout           | Source                          | Enforcement                                        |
 | ----------------- | ------------------------------- | -------------------------------------------------- |
-| Read timeout      | `agent.read_timeout_ms`, default 30s | `readTimeout(state)` bounds the waits for the `account/login/completed` and `thread/started` notifications. |
-| Turn deadline     | The context passed to `RunTurn` | Cancellation triggers `turn/interrupt`.            |
+| Read timeout      | `agent.read_timeout_ms`, default 30s | `readTimeout(state)` bounds the waits for the `account/login/completed` and `thread/started` notifications, and, once a turn's context is cancelled, how long `RunTurn` waits for `turn/completed` before returning. |
+| Turn deadline     | The context passed to `RunTurn` | Cancellation triggers `turn/interrupt`, then the read timeout above bounds the wait for the runtime's own response to it. |
 | Stall timeout     | `agent.stall_timeout_ms`        | `reconcileStalled` in `internal/orchestrator` cancels the worker context; each emitted event postpones it. |
 
 The adapter reads only `ReadTimeoutMS` from `domain.AgentConfig`. It derives no deadline of its
@@ -554,9 +566,11 @@ never passes it in:
 {"method": "turn/interrupt", "id": 99, "params": {"threadId": "thr_abc123", "turnId": "turn_456"}}
 ```
 
-It then keeps reading until `turn/completed` arrives or stdout closes. The escalation to
-SIGTERM, a five-second grace period, and SIGKILL belongs to `StopSession`, not to the interrupt
-path.
+It then keeps reading until `turn/completed` arrives, stdout closes, or `readTimeout(state)`
+elapses, whichever comes first; past that bound `RunTurn` returns with `TerminalCancelled` rather
+than waiting indefinitely for a `turn/interrupt` the app-server may never acknowledge. The
+escalation to SIGTERM, a five-second grace period, and SIGKILL belongs to `StopSession`, not to
+the interrupt path.
 
 ---
 

--- a/docs/copilot-adapter-notes.md
+++ b/docs/copilot-adapter-notes.md
@@ -8,7 +8,9 @@
 > Coverage: the flag surface, the JSONL event schema, session-id capture, autopilot behavior,
 > and session-state token accounting are anchored to v1.0.13. The `--additional-mcp-config`
 > file syntax and the exit-0 outcome of a config parse failure are anchored to v1.0.21 (April
-> 2026). No other surface has been re-observed on v1.0.21.
+> 2026). No other surface has been re-observed on v1.0.21. The behavior of tool scoping without
+> `--allow-all` (denies and continues, does not stall) is anchored to v1.0.80 (August 2026); see
+> "Permission and approval policy".
 >
 > Primary sources: [CLI command reference][cli-ref], [CLI programmatic reference][cli-prog],
 > [hooks configuration reference][hooks-ref], [about hooks][hooks-about],
@@ -164,7 +166,7 @@ Both cases are described in "Session continuation".
 
 | Flag                       | Description                                                                                                    | Adapter usage                                                                                                                           |
 | -------------------------- | -------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
-| `--allow-all` / `--yolo`   | Grant all permissions: tools, paths, and URLs. Agent operates without any approval prompts.                    | Passed when no tool-scoping key is configured. Without it, and without scoped grants, the process hangs waiting for interactive approval. |
+| `--allow-all` / `--yolo`   | Grant all permissions: tools, paths, and URLs. Agent operates without any approval prompts.                    | Passed when no tool-scoping key is configured. Without it, a tool call the scoped grants do not cover is denied by the CLI's own policy and the run continues; observed on GitHub Copilot CLI 1.0.80, see "Permission and approval policy". |
 | `--allow-all-tools`        | Allow all tools without confirmation, but still require path/URL approval.                                      | Not passed by the adapter.                                                                                                              |
 | `--allow-all-paths`        | Disable path verification for file operations.                                                                  | Not passed by the adapter.                                                                                                              |
 | `--allow-all-urls`         | Disable URL verification for fetch operations.                                                                  | Not passed by the adapter.                                                                                                              |
@@ -530,8 +532,10 @@ Per [architecture Section 10.4](architecture/10-agent-adapter-contract.md#104-ap
 | ------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Auto-approve all actions  | `--allow-all` / `--yolo` bypasses all permission prompts for tools, paths, and URLs. Passed under the condition described in "Permission flags".                                                         |
 | User input suppression    | `--no-ask-user` disables the `ask_user` tool ([`copilot --help`][cli-help-ref]). The agent makes decisions autonomously. Passed on every invocation, so a turn never ends in `turn_input_required`.       |
-| Autopilot permissions     | When entering autopilot mode without `--allow-all`, the CLI prompts for permissions. In headless mode (`-p`) that prompt stalls, so an operator who configures tool scoping must scope it wide enough to cover the run. |
+| Autopilot permissions     | When tool scoping displaces `--allow-all` and a tool call falls outside the scoped grants, the CLI denies it on its own and the session continues; it does not stall waiting for interactive approval. Observed on GitHub Copilot CLI 1.0.80, see below. |
 | Unsupported tool calls    | Copilot CLI handles tool routing internally. Unknown tools return failure and the session continues.                                                                                                      |
+
+Local probe (GitHub Copilot CLI 1.0.80, 2026-08-21): running `copilot -p ... --output-format json -s --autopilot --no-ask-user --deny-tool "shell"` (no `--allow-all`, no `--allow-all-tools`) against a prompt that requires a shell command produces a `tool.execution_complete` event with `success: false` and `error: {"message":"Permission to run this tool was denied due to the following rules: \`shell\`","code":"denied"}`, then the run continues to a normal `session.task_complete` and exits 0. The same result, with message `"Permission denied and could not request permission from user"`, occurs with only `--allow-tool "write"` configured (no `--deny-tool`) against a tool the allowlist excludes. Neither run stalled or timed out. `error.code` is `"denied"` only for this refusal; an unrelated tool failure (a missing file, a non-zero shell exit) reports `success: true` for a non-zero shell exit or a different `error.code` (e.g. `"failure"`), never `"denied"`.
 
 ### Permission system details
 

--- a/docs/kiro-adapter-notes.md
+++ b/docs/kiro-adapter-notes.md
@@ -382,9 +382,11 @@ mutually exclusive. When neither key is set, `trust_all_tools` now resolves to `
 "Untrusted-tool behavior" below); when `trust_all_tools` resolves to `false`, `kiro.buildArgs`
 emits `--trust-tools=<joined>`, so an explicit but empty `trust_tools` list produces
 `--trust-tools=` and trusts nothing. A read-only profile such as
-`trust_tools: [read, grep, glob]` is the least-privilege starting point; `write` and `shell`
-belong there only when the workflow requires file edits or command execution, and only inside
-a sandbox.
+`trust_tools: [read, grep, glob]` is the least-privilege posture the CLI itself supports, but
+Sortie refuses it: `validateConfig` reports `kiro.trust_tools.untrusted` for any configuration
+that does not resolve to full trust, for the reason given under "Untrusted-tool behavior"
+below. Treat that profile as raw CLI behavior rather than a usable Sortie configuration until
+the untrusted-tool path is observed.
 
 ### Untrusted-tool behavior under `--no-interactive`
 

--- a/docs/kiro-adapter-notes.md
+++ b/docs/kiro-adapter-notes.md
@@ -378,11 +378,46 @@ accepted by `--trust-tools` alongside the primary name.
 
 `kiro.parsePassthroughConfig` reads `trust_all_tools` and `trust_tools` from the `kiro`
 sub-object in WORKFLOW.md and rejects a config that sets both, because the two trust modes are
-mutually exclusive. When `trust_all_tools` is off, `kiro.buildArgs` always emits
-`--trust-tools=<joined>`, so an unset `trust_tools` list produces `--trust-tools=` and trusts
-nothing. A read-only profile such as `trust_tools: [read, grep, glob]` is the least-privilege
-starting point; `write` and `shell` belong there only when the workflow requires file edits or
-command execution, and only inside a sandbox.
+mutually exclusive. When neither key is set, `trust_all_tools` now resolves to `true` (see
+"Untrusted-tool behavior" below); when `trust_all_tools` resolves to `false`, `kiro.buildArgs`
+emits `--trust-tools=<joined>`, so an explicit but empty `trust_tools` list produces
+`--trust-tools=` and trusts nothing. A read-only profile such as
+`trust_tools: [read, grep, glob]` is the least-privilege starting point; `write` and `shell`
+belong there only when the workflow requires file edits or command execution, and only inside
+a sandbox.
+
+### Untrusted-tool behavior under `--no-interactive`
+
+What `kiro-cli chat --no-interactive` does when it meets a tool `--trust-tools=` does not
+trust is unestablished. Driving an authenticated turn to observe it requires a Kiro Pro,
+Pro+, or Power credential; this host has none: `kiro-cli whoami` reports "Not logged in", no
+`KIRO_API_KEY` is present in the environment, and `kiro-cli login` offers only interactive
+flows, a browser redirect or an OAuth device-code exchange, both of which need a person to
+complete them. No authenticated headless turn could be run against `kiro-cli 2.4.2` to settle
+the question, so this entry records that the observation was not performed rather than a
+result.
+
+The adapter follows the conservative fail-safe instead: the untrusted case is assumed to wait
+for an approval that never arrives, the same shape already documented above for the
+credential-hang case. Two changes follow from that assumption. `kiro.parsePassthroughConfig`
+defaults `trust_all_tools` to `true` when the `kiro` sub-object sets neither `trust_all_tools`
+nor `trust_tools`, so a default configuration no longer emits `--trust-tools=` and cannot
+reach the untrusted case at all. And `kiro.validateConfig` refuses, at check
+`kiro.trust_tools.untrusted`, any configuration whose resolved trust posture falls short of
+full trust, because such a configuration can still reach an untrusted tool call.
+
+No mid-turn recognition path was added for a request the CLI prints while it waits. There is
+no observed wire text to recognize, and the credential-hang shape documented above prints
+nothing distinguishing on stdout while it waits, which is some evidence that the untrusted-tool
+wait looks the same: a hang with no line for the adapter's per-line `ParseLine` hook to
+classify. `agentcore.ForkPerTurnSession.RunTurn` also returns through its own cancellation
+handling before `OnFinalize` runs whenever the run context is already done once the subprocess
+exits, so a hang that only ends because the orchestrator's turn or stall timeout kills the
+subprocess resolves as a cancelled turn regardless of anything `ParseLine` recorded; a
+recognition path could only ever fire for a request the CLI answers by printing something and
+then exiting on its own, a shape this entry does not establish either. Revisit this section,
+and the recognition path, once an authenticated credential is available to drive a real turn
+against `--trust-tools=` excluding a tool the prompt will attempt.
 
 ## Model selection
 

--- a/docs/opencode-adapter-notes.md
+++ b/docs/opencode-adapter-notes.md
@@ -9,7 +9,7 @@
 >
 > - v1.15.12, 2026-05-29: the `run` flag surface, session storage layout, and dir-scoped resume.
 > - v1.14.50, 2026-05-14: the logical-failure exit code, stderr content, and duplicated `error` events. Not re-observed on v1.15.12.
-> - v1.14.25, 2026-04-26: every other locally observed claim, including the credential commands, `serve` port binding, `session list` ordering, `export` payloads, permission warnings on stdout, and parallel-session isolation. Not re-observed since.
+> - v1.14.25, 2026-04-26: every other locally observed claim, including the credential commands, `serve` port binding, `session list` ordering, `export` payloads, permission warnings on stderr, and parallel-session isolation. Not re-observed since.
 > - Source-code and raw-docs links point at the immutable `v1.14.25` tag, so quoted code and line numbers stay valid. The rendered docs track the latest release and can lead the tagged source; "Documented conflicts and drift" records where the two disagree.
 
 ## Overview
@@ -352,13 +352,16 @@ A rejection prints this pair:
 {"type":"tool_use", ... "state":{"status":"error","error":"The user rejected permission to use this specific tool call."}}
 ```
 
-The warning goes to stdout before the JSON envelope, from the `run.ts` branch that calls
-`UI.println(...)` before replying `reject`. So `opencode run --format json` is not JSON-clean
-unless the prompt avoids permission prompts or the run passes
-`--dangerously-skip-permissions`. The adapter parses each stdout line as JSON and, on failure,
-treats the line as plain text: `isPermissionWarning`
-(`internal/agent/opencode/opencode.go`) matches the `! permission requested:` prefix and emits a
-notification, and any other unparseable line becomes a `domain.EventMalformed` event.
+The warning goes to stderr, and the JSON envelope goes to stdout: `run.ts` calls
+`UI.println(...)` before replying `reject`, and `println` writes through `print`, which calls
+`process.stderr.write` (`cli/ui.ts`, v1.14.25 tag; not re-observed on the pinned v1.15.12
+binary, since reproducing it needs an authenticated run). `opencode run --format json`'s stdout
+stream stays JSON-clean whether or not a permission prompt occurs. The adapter recognizes the
+warning from the turn's collected stderr lines once the subprocess has exited:
+`isPermissionWarning` (`internal/agent/opencode/opencode.go`) matches the
+`! permission requested:` prefix against each stderr line and emits a notification. Any stdout
+line that fails to parse as an event is a `domain.EventMalformed` event; the permission warning
+is not one of those, because it never arrives on stdout.
 
 ## Output format: `opencode run --format json`
 

--- a/docs/opencode-adapter-notes.md
+++ b/docs/opencode-adapter-notes.md
@@ -483,9 +483,9 @@ rows; `finalizeExitedTurn` fills an `agentcore.TurnEvidence` and hands the termi
 | ------------ | ----------------- |
 | `session_started` | The first envelope carrying a `sessionID`, applied by `applySessionEvent`. A later envelope carrying a different ID is a session id mismatch, which fails the turn |
 | `tool_result` | Each `tool_use` event, using `part.tool` for the name, `part.state.time` for the duration, and `part.state.status == "error"` for the error flag |
-| `notification` | `step_start`, the text of a `text` part truncated to 500 runes, `step_finish` with its reason, and permission-warning lines from stdout |
+| `notification` | `step_start`, the text of a `text` part truncated to 500 runes, `step_finish` with its reason, and permission-warning lines from stderr |
 | `other_message` | Each `reasoning` part |
-| `malformed` | An unparseable payload for a known `type`, an unrecognized `type`, and any non-JSON stdout line that is not a permission warning |
+| `malformed` | An unparseable payload for a known `type`, an unrecognized `type`, and any non-JSON stdout line; the permission warning never reaches this stream |
 | `token_usage` | The `opencode export` figures, never `step_finish.part.tokens`. See "Token usage" |
 | `turn_completed` | The process exits `0`, no `error` event arrived, and at least one `text`, `reasoning`, or `tool_use` part was parsed during the turn |
 | `turn_failed` | Any `error` event (`ErrTurnFailed`); a non-zero exit with no `error` event (`ErrPortExit`); an exit-`0` turn with no assistant part parsed (`ErrTurnFailed`); a stdout read error or session id mismatch (`ErrResponseError`); or a timeout waiting for the first JSON event (`ErrResponseTimeout`) |
@@ -579,7 +579,7 @@ sets no `OPENCODE_DISABLE_DEFAULT_PLUGINS` and no `OPENCODE_DISABLE_CLAUDE_CODE*
 
 `opencode run --format json` carries what a launch-per-turn adapter needs, but it is not a
 lossless wire protocol. It hides server status events, omits a final result envelope, mixes
-human-readable text into stdout during permission rejection, and can repeat an `error` event for
+human-readable text into stderr during permission rejection, and can repeat an `error` event for
 one failure. `opencode serve` exposes explicit session, message, permission, and event APIs with
 documented schemas and an OpenAPI spec (server and SDK docs), which is the surface those gaps
 would be closed on.
@@ -591,7 +591,7 @@ would be closed on.
 | Auth command name | `opencode auth ...` | Root help promotes `opencode providers ...`; `auth` is an alias whose own help renders `auth` subcommands under an `opencode providers` header | Low; no parser should depend on human help text |
 | Network port default wording | Server docs describe `4096` | Shared CLI options expose `0` in help and config, while the Bun and Node adapters treat `0` as "try `4096` first, then fall back to an ephemeral port" | High for `--attach`; set `--port` explicitly |
 | `run --format json` | "raw JSON events" | CLI-emitted projection from `run.ts`, not raw SSE | High for adapters |
-| Permissions in JSON mode | Not called out | Permission rejection prints a plain-text warning to stdout before JSON | High for parsers |
+| Permissions in JSON mode | Not called out | Permission rejection prints a plain-text warning to stderr; stdout carries the JSON envelope alone | Low for parsers, the streams are separate |
 | Exit codes | Not documented | The code is unstable across releases: `0` on a logical failure in v1.14.25, `1` in v1.14.50 | High for failure handling; the adapter keys failure on the stdout `error` event instead |
 | `--pure` flag | Not on docs page | Present in shipped help output | Medium for deterministic runs |
 | Permission keys | `permissions.mdx` lists 14 keys | `config/permission.ts` accepts 16 explicitly (adding `list` and `todowrite`) and any other string key via a `StructWithRest` catchall | Medium; a strict whitelist against the documented set would break on configurations OpenCode itself accepts |

--- a/docs/workflow-reference.md
+++ b/docs/workflow-reference.md
@@ -2586,14 +2586,18 @@ is the rebranded Amazon Q Developer CLI; the binary is `kiro-cli`.
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
 | `kiro.model` | string | _(absent)_ | Forwarded to `kiro-cli chat --model`. The `/model` slash command is unavailable headless, so the model MUST be pinned per turn (here or via `kiro-cli settings chat.defaultModel`). Use `kiro-cli chat --list-models --format json` to enumerate the account-specific model set. |
-| `kiro.trust_all_tools` | boolean | `false` | Adds `--trust-all-tools`, auto-approving every tool call. Use only inside a hardened sandbox. Mutually exclusive with `kiro.trust_tools`. |
-| `kiro.trust_tools` | list of strings | `[]` | Adds `--trust-tools=<names>` with the comma-joined list. An empty list trusts nothing (the adapter still passes `--trust-tools=`, which is the explicit no-trust mode). Mutually exclusive with `kiro.trust_all_tools`. Tool names include `read`, `write`, `glob`, `grep`, `shell`, `aws`, `web_search`, `web_fetch`, `code`, and `report`. |
+| `kiro.trust_all_tools` | boolean | `true` when neither trust key is set | Adds `--trust-all-tools`, auto-approving every tool call. Use only inside a hardened sandbox. Mutually exclusive with `kiro.trust_tools`. |
+| `kiro.trust_tools` | list of strings | _(absent)_ | Adds `--trust-tools=<names>` with the comma-joined list. Setting it is currently refused: any configuration that does not resolve to full trust draws an error, because what the CLI does when it meets an untrusted tool without a person present is unestablished. Mutually exclusive with `kiro.trust_all_tools`. Tool names include `read`, `write`, `glob`, `grep`, `shell`, `aws`, `web_search`, `web_fetch`, `code`, and `report`. |
 | `kiro.agent` | string | _(absent)_ | Forwarded to `kiro-cli chat --agent` to select a named Kiro context profile (custom agent). |
 
 **Validation rules:**
 
 - `kiro.trust_all_tools: true` and a non-empty `kiro.trust_tools` list MUST NOT
-  be set together. The adapter rejects this combination at construction time.
+  be set together. The adapter rejects this combination at construction time and
+  reports it identically from offline validation.
+- A configuration that does not resolve to full trust is refused. Leave both keys
+  unset, or set `kiro.trust_all_tools: true`, and run the agent inside a hardened
+  sandbox.
 
 **Environment variables consumed by the adapter:**
 

--- a/examples/WORKFLOW.kiro.md
+++ b/examples/WORKFLOW.kiro.md
@@ -50,13 +50,12 @@ kiro:
   # unavailable in headless mode; the adapter passes --model on every turn.
   # Run "kiro-cli chat --list-models --format json" to see the live list.
   model: claude-sonnet-4.6
-  # Least-privilege tool allowlist. The read-only profile (read, grep, glob)
-  # is the safe starting point; add "write" and "shell" only when the
-  # workflow requires file edits or command execution.
-  trust_tools:
-    - read
-    - grep
-    - glob
+  # Neither trust_all_tools nor trust_tools is set, so the adapter resolves
+  # to full trust and passes --trust-all-tools. A narrower allowlist is
+  # refused today: what kiro-cli does when it meets an untrusted tool under
+  # --no-interactive is unestablished, and the conservative assumption is
+  # that it waits for an approval an unattended run cannot give. Run this
+  # agent inside a hardened sandbox.
 
 server:
   port: 8642

--- a/internal/agent/agentcore/disposition.go
+++ b/internal/agent/agentcore/disposition.go
@@ -12,6 +12,11 @@ import (
 // agent family.
 const zeroWorkMessageStem = "agent exited without producing output"
 
+// turnInputRequiredMessageStem is the shared diagnostic stem every
+// adapter's human-input-required row uses, so an operator can grep one
+// string across the whole agent family.
+const turnInputRequiredMessageStem = "agent asked for a decision only a person can make"
+
 // TerminalReport is the adapter-normalized end-of-turn report for one turn:
 // what the runtime said about the outcome, or what the adapter determined
 // when it aborted the turn itself.
@@ -34,6 +39,12 @@ const (
 	// TerminalCancelled means the orchestrator initiated the turn's
 	// cancellation, through context cancellation or StopSession.
 	TerminalCancelled
+
+	// TerminalHumanInputRequired means the runtime asked for a decision
+	// only a person could give and the shared posture ends the attempt.
+	// An adapter reports it after classifying the request; it never
+	// decides the consequence itself.
+	TerminalHumanInputRequired
 )
 
 // WorkReport is the adapter-normalized evidence that the model produced
@@ -73,8 +84,14 @@ type TurnEvidence struct {
 
 	// TerminalMessage describes the outcome in the runtime's own words, or
 	// in the adapter's when the adapter ended the turn. Carried onto both
-	// the emitted event and the returned error for a cancelled, failed, or
-	// successful terminal report. May be empty.
+	// the emitted event and the returned error for a cancelled, failed,
+	// successful, or human-input-required terminal report. May be empty.
+	//
+	// On the human-input-required report alone, the field is appended
+	// after the shared message stem rather than used as the whole
+	// message, and it MUST be a compile-time constant string that never
+	// interpolates stderr, stdout, a file path, or any other runtime
+	// value, for the same reason WorkDetail must be.
 	TerminalMessage string
 
 	// Cause is the underlying Go error the adapter recovered, copied onto
@@ -136,6 +153,10 @@ const (
 	// RowWorkPresent is the row selected when Terminal is TerminalAbsent,
 	// the process exited 0, and Work is WorkPresent.
 	RowWorkPresent
+
+	// RowHumanInputRequired is the row selected when Terminal is
+	// TerminalHumanInputRequired.
+	RowHumanInputRequired
 )
 
 // TurnDisposition is the normalized outcome of one turn.
@@ -179,7 +200,7 @@ type TurnMeta struct {
 
 // DecideTurn returns the normalized disposition for one agent turn. It is
 // pure: no I/O, no logging, no emission, no state. Every TurnEvidence value
-// maps to exactly one of seven rows, evaluated in order and returned on the
+// maps to exactly one of eight rows, evaluated in order and returned on the
 // first match.
 //
 // A positive terminal report is authoritative: when Terminal is
@@ -197,6 +218,18 @@ func DecideTurn(ev TurnEvidence) TurnDisposition {
 			Row:          RowTerminalCancelled,
 			ExitReason:   domain.EventTurnCancelled,
 			ErrorKind:    domain.ErrTurnCancelled,
+			EventMessage: message,
+			ErrorMessage: message,
+		}
+	case TerminalHumanInputRequired:
+		message := turnInputRequiredMessageStem
+		if ev.TerminalMessage != "" {
+			message += ": " + ev.TerminalMessage
+		}
+		return TurnDisposition{
+			Row:          RowHumanInputRequired,
+			ExitReason:   domain.EventTurnInputRequired,
+			ErrorKind:    domain.ErrTurnInputRequired,
 			EventMessage: message,
 			ErrorMessage: message,
 		}
@@ -265,9 +298,9 @@ func DecideTurn(ev TurnEvidence) TurnDisposition {
 }
 
 // FinalizeTurn applies DecideTurn to ev, emits the matching terminal event
-// through emit, logs the zero-work warning when the decision selects
-// RowZeroWork, and returns the paired TurnResult and error. The returned
-// *domain.AgentError is nil if and only if the disposition is
+// through emit, logs a warn message when the decision selects RowZeroWork
+// or RowHumanInputRequired, and returns the paired TurnResult and error.
+// The returned *domain.AgentError is nil if and only if the disposition is
 // domain.EventTurnCompleted.
 //
 // FinalizeTurn panics when emit is nil. It substitutes slog.Default() when
@@ -295,10 +328,15 @@ func FinalizeTurn(
 		EmitTurnFailed(emit, disposition.EventMessage, meta.APIDurationMS, meta.Usage)
 	case domain.EventTurnCancelled:
 		EmitTurnCancelled(emit, disposition.EventMessage, meta.Usage)
+	case domain.EventTurnInputRequired:
+		EmitTurnInputRequired(emit, disposition.EventMessage, meta.Usage)
 	}
 
 	if disposition.Row == RowZeroWork {
 		logger.Warn("agent exited without producing output, treating as failure")
+	}
+	if disposition.Row == RowHumanInputRequired {
+		logger.Warn("agent asked for a decision only a person can make, ending the attempt")
 	}
 
 	result := domain.TurnResult{

--- a/internal/agent/agentcore/disposition_contract_test.go
+++ b/internal/agent/agentcore/disposition_contract_test.go
@@ -17,11 +17,11 @@ import (
 const dispositionDomainImportPath = "github.com/sortie-ai/sortie/internal/domain"
 
 // dispositionAgentcoreImportPath is the import path the check resolves
-// the "agentcore" package qualifier from, so a call to one of the three
+// the "agentcore" package qualifier from, so a call to one of the four
 // Emit* helpers is caught regardless of the local import alias.
 const dispositionAgentcoreImportPath = "github.com/sortie-ai/sortie/internal/agent/agentcore"
 
-// dispositionForbiddenEventConstants are the four terminal-event
+// dispositionForbiddenEventConstants are the five terminal-event
 // constants a package other than agentcore or mock must not assign to
 // domain.TurnResult.ExitReason or domain.AgentEvent.Type directly; a
 // package that assigns any other domain.AgentEventType constant (a
@@ -31,14 +31,16 @@ var dispositionForbiddenEventConstants = map[string]bool{
 	"EventTurnFailed":         true,
 	"EventTurnCancelled":      true,
 	"EventTurnEndedWithError": true,
+	"EventTurnInputRequired":  true,
 }
 
-// dispositionForbiddenEmitFuncs are the three agentcore helpers reserved
+// dispositionForbiddenEmitFuncs are the four agentcore helpers reserved
 // for [FinalizeTurn] alone; no other package may call them directly.
 var dispositionForbiddenEmitFuncs = map[string]bool{
-	"EmitTurnCompleted": true,
-	"EmitTurnFailed":    true,
-	"EmitTurnCancelled": true,
+	"EmitTurnCompleted":     true,
+	"EmitTurnFailed":        true,
+	"EmitTurnCancelled":     true,
+	"EmitTurnInputRequired": true,
 }
 
 // dispositionContractAllowlist names the packages under internal/agent/
@@ -46,7 +48,11 @@ var dispositionForbiddenEmitFuncs = map[string]bool{
 // shared decision itself: FinalizeTurn is the one legal constructor of
 // these values. mock is exempt because it maps an operator-chosen
 // outcome string to a disposition, not parsed runtime evidence, so it
-// has nothing to decide.
+// has nothing to decide; for the human-input-required outcome
+// specifically, the exemption is unenforced rather than justified, since
+// the walk's filepath.SkipDir on this directory means no per-constant
+// check ever inspects mock's own source, and a private construction of
+// that outcome inside it would pass unnoticed.
 var dispositionContractAllowlist = map[string]string{
 	"agentcore": "the shared decision package itself; FinalizeTurn is the sole permitted constructor and emitter",
 	"mock":      "maps an operator-chosen outcome string, not parsed evidence, so it has nothing to decide",
@@ -277,10 +283,28 @@ func f() domain.AgentEvent {
 			wantCount: 1,
 		},
 		{
+			name: "forbidden human-input-required constant on TurnResult ExitReason is rejected",
+			src: preamble + `
+func f() domain.TurnResult {
+	return domain.TurnResult{ExitReason: domain.EventTurnInputRequired}
+}
+`,
+			wantCount: 1,
+		},
+		{
 			name: "direct EmitTurnFailed call is rejected",
 			src: preamble + `
 func f(emit func(domain.AgentEvent)) {
 	agentcore.EmitTurnFailed(emit, "boom", 0, domain.TokenUsage{})
+}
+`,
+			wantCount: 1,
+		},
+		{
+			name: "direct EmitTurnInputRequired call is rejected",
+			src: preamble + `
+func f(emit func(domain.AgentEvent)) {
+	agentcore.EmitTurnInputRequired(emit, "boom", domain.TokenUsage{})
 }
 `,
 			wantCount: 1,

--- a/internal/agent/agentcore/disposition_test.go
+++ b/internal/agent/agentcore/disposition_test.go
@@ -225,6 +225,83 @@ func TestDecideTurn_ZeroWorkRowWorkDetailSuffix(t *testing.T) {
 	})
 }
 
+// TestDecideTurn_HumanInputRequiredRow pins the human-input-required row:
+// the bare stem when TerminalMessage is empty, the stem joined to a
+// non-empty TerminalMessage with ": ", the row's fixed ExitReason and
+// ErrorKind, and that TerminalCancelled still wins when both Terminal
+// values could apply (case ordering, not an added precedence flag,
+// decides it).
+func TestDecideTurn_HumanInputRequiredRow(t *testing.T) {
+	t.Parallel()
+
+	const stem = "agent asked for a decision only a person can make"
+
+	t.Run("empty detail produces the bare stem", func(t *testing.T) {
+		t.Parallel()
+
+		got := DecideTurn(TurnEvidence{Terminal: TerminalHumanInputRequired})
+
+		if got.Row != RowHumanInputRequired {
+			t.Errorf("DecideTurn().Row = %v, want %v", got.Row, RowHumanInputRequired)
+		}
+		if got.ExitReason != domain.EventTurnInputRequired {
+			t.Errorf("DecideTurn().ExitReason = %q, want %q", got.ExitReason, domain.EventTurnInputRequired)
+		}
+		if got.ErrorKind != domain.ErrTurnInputRequired {
+			t.Errorf("DecideTurn().ErrorKind = %q, want %q", got.ErrorKind, domain.ErrTurnInputRequired)
+		}
+		if got.EventMessage != stem {
+			t.Errorf("DecideTurn().EventMessage = %q, want %q", got.EventMessage, stem)
+		}
+		if got.ErrorMessage != stem {
+			t.Errorf("DecideTurn().ErrorMessage = %q, want %q", got.ErrorMessage, stem)
+		}
+	})
+
+	t.Run("non-empty detail is appended with a colon-space separator", func(t *testing.T) {
+		t.Parallel()
+
+		got := DecideTurn(TurnEvidence{Terminal: TerminalHumanInputRequired, TerminalMessage: "an answer to a question"})
+
+		const want = stem + ": an answer to a question"
+		if got.EventMessage != want {
+			t.Errorf("DecideTurn().EventMessage = %q, want %q", got.EventMessage, want)
+		}
+		if got.ErrorMessage != want {
+			t.Errorf("DecideTurn().ErrorMessage = %q, want %q", got.ErrorMessage, want)
+		}
+	})
+
+	t.Run("ErrorKind is non-empty, preserving the empty-iff-completed invariant", func(t *testing.T) {
+		t.Parallel()
+
+		got := DecideTurn(TurnEvidence{Terminal: TerminalHumanInputRequired})
+
+		if got.ErrorKind == "" {
+			t.Error("DecideTurn().ErrorKind is empty, want non-empty since ExitReason is not EventTurnCompleted")
+		}
+	})
+
+	t.Run("cancelled still wins when both terminal reports could apply", func(t *testing.T) {
+		t.Parallel()
+
+		// TerminalReport is a single field, so no TurnEvidence value can
+		// literally set both at once; this asserts the case ordering
+		// itself, cancelled evaluated before human-input-required, by
+		// confirming cancelled's row is selected whenever Terminal is
+		// TerminalCancelled regardless of TerminalMessage shape used by
+		// the human-input-required row.
+		got := DecideTurn(TurnEvidence{Terminal: TerminalCancelled, TerminalMessage: "an answer to a question"})
+
+		if got.Row != RowTerminalCancelled {
+			t.Errorf("DecideTurn().Row = %v, want %v", got.Row, RowTerminalCancelled)
+		}
+		if got.ExitReason != domain.EventTurnCancelled {
+			t.Errorf("DecideTurn().ExitReason = %q, want %q", got.ExitReason, domain.EventTurnCancelled)
+		}
+	})
+}
+
 // TestDecideTurn_Total pins that DecideTurn is total over TurnEvidence:
 // every distinct combination of the fields the table consults maps to
 // exactly one non-zero Row.

--- a/internal/agent/agentcore/events.go
+++ b/internal/agent/agentcore/events.go
@@ -64,6 +64,19 @@ func EmitTurnCancelled(emit func(domain.AgentEvent), message string, usage domai
 	})
 }
 
+// EmitTurnInputRequired emits an EventTurnInputRequired event with the
+// given human-readable message. usage is the session's run-cumulative
+// token usage snapshot; the zero value means the caller reports no usage
+// for this event.
+func EmitTurnInputRequired(emit func(domain.AgentEvent), message string, usage domain.TokenUsage) {
+	emit(domain.AgentEvent{
+		Type:      domain.EventTurnInputRequired,
+		Timestamp: time.Now().UTC(),
+		Message:   message,
+		Usage:     usage,
+	})
+}
+
 // EmitMalformed emits an EventMalformed event. line is the raw unparseable
 // bytes from the agent output stream; it is truncated to 500 Unicode code
 // points before inclusion in the event message.

--- a/internal/agent/agentcore/events_test.go
+++ b/internal/agent/agentcore/events_test.go
@@ -127,6 +127,26 @@ func TestEmitTurnCancelled(t *testing.T) {
 	}
 }
 
+func TestEmitTurnInputRequired(t *testing.T) {
+	t.Parallel()
+
+	wantUsage := domain.TokenUsage{InputTokens: 12, OutputTokens: 3, TotalTokens: 15}
+	got := captureOne(t, func(emit func(domain.AgentEvent)) {
+		EmitTurnInputRequired(emit, "agent asked for a decision only a person can make", wantUsage)
+	})
+
+	if got.Type != domain.EventTurnInputRequired {
+		t.Errorf("Type = %q, want EventTurnInputRequired", got.Type)
+	}
+	assertTimestamp(t, got.Timestamp)
+	if got.Message != "agent asked for a decision only a person can make" {
+		t.Errorf("Message = %q, want 'agent asked for a decision only a person can make'", got.Message)
+	}
+	if got.Usage != wantUsage {
+		t.Errorf("Usage = %+v, want %+v", got.Usage, wantUsage)
+	}
+}
+
 func TestEmitMalformed_ShortLine(t *testing.T) {
 	t.Parallel()
 

--- a/internal/agent/agentcore/humanrequest.go
+++ b/internal/agent/agentcore/humanrequest.go
@@ -1,0 +1,141 @@
+package agentcore
+
+import "fmt"
+
+// HumanRequestClass names the two classes of runtime request that only a
+// person could answer. The class is determined by what the runtime asked
+// for, never by which runtime asked.
+type HumanRequestClass uint8
+
+const (
+	// ClassPermission is a request for consent to act: to run a command,
+	// to change a file, to use a tool, to widen a sandbox.
+	ClassPermission HumanRequestClass = iota + 1
+
+	// ClassHumanInput is a genuine question addressed to a person.
+	ClassHumanInput
+)
+
+// HumanRequestAnswer reports whether the recognized request is still open
+// when the adapter observes it. Some runtimes answer such a request
+// themselves before Sortie sees it, which is a different situation from a
+// request nobody has answered.
+type HumanRequestAnswer uint8
+
+const (
+	// AnswerPending means nothing has answered the request. Whether a
+	// refusal can be transmitted is then a property of the protocol,
+	// reported separately.
+	AnswerPending HumanRequestAnswer = iota + 1
+
+	// AnswerRuntimeRefused means the runtime refused the request on its
+	// own and reported the refusal to the adapter. Nothing is left to
+	// answer, and no consent was granted.
+	AnswerRuntimeRefused
+)
+
+// noticePermissionContinuable, noticePermissionNoReplyChannel,
+// noticePermissionRuntimeRefused, noticeHumanInputRequired, and
+// noticeHumanInputRuntimeRefused are the operator-facing Notice values
+// [DecideHumanRequest] returns, one per distinct posture. Rows 4 and 5 of
+// the posture table share noticeHumanInputRequired: they differ only in
+// wire mechanics an operator has no use for.
+const (
+	noticePermissionContinuable    = "refused a permission request because this run is unattended and no one can approve it"
+	noticePermissionNoReplyChannel = "the agent needs a permission this unattended run cannot grant"
+	noticePermissionRuntimeRefused = "the agent runtime refused a permission request on its own because this run is unattended"
+	noticeHumanInputRequired       = "the agent asked for something only a person could give, and this unattended run has no one to give it"
+	noticeHumanInputRuntimeRefused = "the agent runtime refused a request only a person could answer, and this unattended run has no one to answer it"
+)
+
+// RefusalPosture is the shared layer's decision for one recognized request.
+// An adapter reads it and acts; it never constructs one.
+type RefusalPosture struct {
+	// Transmit reports whether the adapter writes a refusal on the
+	// runtime's reply channel. False when the runtime offers none and
+	// when the request already carries a refusal.
+	Transmit bool
+
+	// Continuable reports whether the transmitted refusal must take the
+	// form that permits the agent to continue the turn by another route.
+	// Meaningful only when Transmit is true.
+	Continuable bool
+
+	// EndAttempt reports whether the turn ends now with the
+	// human-input-required outcome.
+	EndAttempt bool
+
+	// Notice is the operator-facing stem explaining the refusal, on every
+	// posture row. The caller emits it as a domain.EventNotification,
+	// alone when it has no detail for this request and joined to that
+	// detail by ": " when it has one, using the same detail it passes to
+	// [HumanInputEvidence]. It is a stem rather than a whole sentence
+	// because the specific ask is adapter knowledge that
+	// [DecideHumanRequest]'s three inputs do not carry, and a stem that
+	// named the ask would be false on some request its row admits. No
+	// permission-refusal form in the fleet has a field that could carry
+	// it to the agent, so it is operator-facing text and is named for
+	// that reader. It is a compile-time constant and MUST NOT interpolate
+	// stderr, stdout, a file path, or any other runtime value.
+	Notice string
+}
+
+// NoticeWithDetail joins p.Notice with detail. It returns the bare notice
+// when detail is empty, and the notice followed by ": " and detail
+// otherwise. detail MUST be a compile-time constant string that never
+// interpolates stderr, stdout, a file path, or any other runtime value,
+// the same rule [RefusalPosture.Notice] follows.
+func (p RefusalPosture) NoticeWithDetail(detail string) string {
+	if detail == "" {
+		return p.Notice
+	}
+	return p.Notice + ": " + detail
+}
+
+// DecideHumanRequest returns the shared refusal posture for one recognized
+// runtime request that only a person could answer. It is pure: no I/O, no
+// logging, no adapter-specific vocabulary. Every adapter reads its posture
+// from this function; none constructs one directly.
+//
+// DecideHumanRequest panics when class or answer is not one of its own two
+// declared constants, including the zero value either type takes when a
+// call site is only partially initialized: a posture returned for such a
+// call would hand it an end-the-attempt or continue-the-turn decision it
+// never asked for.
+func DecideHumanRequest(class HumanRequestClass, replyChannel bool, answer HumanRequestAnswer) RefusalPosture {
+	if class != ClassPermission && class != ClassHumanInput {
+		panic(fmt.Sprintf("agentcore: DecideHumanRequest: invalid HumanRequestClass %d", class))
+	}
+	if answer != AnswerPending && answer != AnswerRuntimeRefused {
+		panic(fmt.Sprintf("agentcore: DecideHumanRequest: invalid HumanRequestAnswer %d", answer))
+	}
+
+	switch {
+	case class == ClassPermission && answer == AnswerRuntimeRefused:
+		return RefusalPosture{Notice: noticePermissionRuntimeRefused}
+	case class == ClassPermission && replyChannel:
+		return RefusalPosture{Transmit: true, Continuable: true, Notice: noticePermissionContinuable}
+	case class == ClassPermission:
+		return RefusalPosture{EndAttempt: true, Notice: noticePermissionNoReplyChannel}
+	case class == ClassHumanInput && answer == AnswerRuntimeRefused:
+		return RefusalPosture{EndAttempt: true, Notice: noticeHumanInputRuntimeRefused}
+	case replyChannel:
+		return RefusalPosture{Transmit: true, EndAttempt: true, Notice: noticeHumanInputRequired}
+	default:
+		return RefusalPosture{EndAttempt: true, Notice: noticeHumanInputRequired}
+	}
+}
+
+// HumanInputEvidence returns the [TurnEvidence] an adapter passes to
+// [FinalizeTurn] once a [RefusalPosture] read from [DecideHumanRequest]
+// has EndAttempt true. detail is appended to the shared message stem
+// [FinalizeTurn] and [DecideTurn] build for [TerminalHumanInputRequired];
+// it MUST be a compile-time constant string that never interpolates
+// stderr, stdout, a file path, or any other runtime value, the same rule
+// [RefusalPosture.Notice] follows.
+func HumanInputEvidence(detail string) TurnEvidence {
+	return TurnEvidence{
+		Terminal:        TerminalHumanInputRequired,
+		TerminalMessage: detail,
+	}
+}

--- a/internal/agent/agentcore/humanrequest_test.go
+++ b/internal/agent/agentcore/humanrequest_test.go
@@ -1,0 +1,218 @@
+package agentcore
+
+import (
+	"testing"
+)
+
+// TestDecideHumanRequest_Rows pins all six rows of the posture table
+// against a representative (class, replyChannel, answer) combination.
+func TestDecideHumanRequest_Rows(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		class           HumanRequestClass
+		replyChannel    bool
+		answer          HumanRequestAnswer
+		wantTransmit    bool
+		wantContinuable bool
+		wantEndAttempt  bool
+	}{
+		{
+			name:         "permission, reply channel, pending: continue and transmit",
+			class:        ClassPermission,
+			replyChannel: true,
+			answer:       AnswerPending,
+			wantTransmit: true, wantContinuable: true, wantEndAttempt: false,
+		},
+		{
+			name:         "permission, no reply channel, pending: end the attempt",
+			class:        ClassPermission,
+			replyChannel: false,
+			answer:       AnswerPending,
+			wantTransmit: false, wantContinuable: false, wantEndAttempt: true,
+		},
+		{
+			name:         "permission, reply channel, runtime refused: continue, nothing to transmit",
+			class:        ClassPermission,
+			replyChannel: true,
+			answer:       AnswerRuntimeRefused,
+			wantTransmit: false, wantContinuable: false, wantEndAttempt: false,
+		},
+		{
+			name:         "permission, no reply channel, runtime refused: continue, nothing to transmit",
+			class:        ClassPermission,
+			replyChannel: false,
+			answer:       AnswerRuntimeRefused,
+			wantTransmit: false, wantContinuable: false, wantEndAttempt: false,
+		},
+		{
+			name:         "human input, reply channel, pending: end, not continuable",
+			class:        ClassHumanInput,
+			replyChannel: true,
+			answer:       AnswerPending,
+			wantTransmit: true, wantContinuable: false, wantEndAttempt: true,
+		},
+		{
+			name:         "human input, no reply channel, pending: end, nothing to transmit",
+			class:        ClassHumanInput,
+			replyChannel: false,
+			answer:       AnswerPending,
+			wantTransmit: false, wantContinuable: false, wantEndAttempt: true,
+		},
+		{
+			name:         "human input, reply channel, runtime refused: end",
+			class:        ClassHumanInput,
+			replyChannel: true,
+			answer:       AnswerRuntimeRefused,
+			wantTransmit: false, wantContinuable: false, wantEndAttempt: true,
+		},
+		{
+			name:         "human input, no reply channel, runtime refused: end",
+			class:        ClassHumanInput,
+			replyChannel: false,
+			answer:       AnswerRuntimeRefused,
+			wantTransmit: false, wantContinuable: false, wantEndAttempt: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := DecideHumanRequest(tt.class, tt.replyChannel, tt.answer)
+
+			if got.Transmit != tt.wantTransmit {
+				t.Errorf("DecideHumanRequest(%v, %v, %v).Transmit = %v, want %v",
+					tt.class, tt.replyChannel, tt.answer, got.Transmit, tt.wantTransmit)
+			}
+			if got.Continuable != tt.wantContinuable {
+				t.Errorf("DecideHumanRequest(%v, %v, %v).Continuable = %v, want %v",
+					tt.class, tt.replyChannel, tt.answer, got.Continuable, tt.wantContinuable)
+			}
+			if got.EndAttempt != tt.wantEndAttempt {
+				t.Errorf("DecideHumanRequest(%v, %v, %v).EndAttempt = %v, want %v",
+					tt.class, tt.replyChannel, tt.answer, got.EndAttempt, tt.wantEndAttempt)
+			}
+			if got.Notice == "" {
+				t.Errorf("DecideHumanRequest(%v, %v, %v).Notice = \"\", want non-empty",
+					tt.class, tt.replyChannel, tt.answer)
+			}
+		})
+	}
+}
+
+// TestDecideHumanRequest_PanicsOnInvalidClass pins that an out-of-range
+// class, including its zero value, panics rather than silently returning
+// a decision an uninitialized call site never asked for.
+func TestDecideHumanRequest_PanicsOnInvalidClass(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		class HumanRequestClass
+	}{
+		{name: "zero value", class: HumanRequestClass(0)},
+		{name: "out of range", class: HumanRequestClass(99)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			defer func() {
+				if recover() == nil {
+					t.Errorf("DecideHumanRequest(class=%d, ...) did not panic, want panic", tt.class)
+				}
+			}()
+			DecideHumanRequest(tt.class, true, AnswerPending)
+		})
+	}
+}
+
+// TestDecideHumanRequest_PanicsOnInvalidAnswer pins that an out-of-range
+// answer, including its zero value, panics rather than silently returning
+// a decision an uninitialized call site never asked for.
+func TestDecideHumanRequest_PanicsOnInvalidAnswer(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		answer HumanRequestAnswer
+	}{
+		{name: "zero value", answer: HumanRequestAnswer(0)},
+		{name: "out of range", answer: HumanRequestAnswer(99)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			defer func() {
+				if recover() == nil {
+					t.Errorf("DecideHumanRequest(..., answer=%d) did not panic, want panic", tt.answer)
+				}
+			}()
+			DecideHumanRequest(ClassPermission, true, tt.answer)
+		})
+	}
+}
+
+// TestHumanInputEvidence pins that HumanInputEvidence sets Terminal to
+// TerminalHumanInputRequired and carries detail on TerminalMessage
+// unchanged.
+func TestHumanInputEvidence(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		detail string
+	}{
+		{name: "empty detail", detail: ""},
+		{name: "non-empty detail", detail: "an answer to a question"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := HumanInputEvidence(tt.detail)
+
+			if got.Terminal != TerminalHumanInputRequired {
+				t.Errorf("HumanInputEvidence(%q).Terminal = %v, want %v", tt.detail, got.Terminal, TerminalHumanInputRequired)
+			}
+			if got.TerminalMessage != tt.detail {
+				t.Errorf("HumanInputEvidence(%q).TerminalMessage = %q, want %q", tt.detail, got.TerminalMessage, tt.detail)
+			}
+		})
+	}
+}
+
+// TestRefusalPosture_NoticeWithDetail pins that NoticeWithDetail returns
+// the bare notice when detail is empty, and notice+": "+detail otherwise.
+func TestRefusalPosture_NoticeWithDetail(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		notice string
+		detail string
+		want   string
+	}{
+		{name: "empty detail returns the bare notice", notice: "refused", detail: "", want: "refused"},
+		{name: "non-empty detail is joined with a colon-space separator", notice: "refused", detail: "a tool call", want: "refused: a tool call"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			posture := RefusalPosture{Notice: tt.notice}
+			got := posture.NoticeWithDetail(tt.detail)
+
+			if got != tt.want {
+				t.Errorf("RefusalPosture{Notice: %q}.NoticeWithDetail(%q) = %q, want %q", tt.notice, tt.detail, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/agent/claude/claude.go
+++ b/internal/agent/claude/claude.go
@@ -25,7 +25,8 @@ import (
 
 func init() {
 	registry.Agents.RegisterWithMeta("claude-code", NewClaudeCodeAdapter, registry.AgentMeta{
-		RequiresCommand: true,
+		RequiresCommand:     true,
+		ValidateAgentConfig: validateConfig,
 	})
 }
 
@@ -78,6 +79,16 @@ type sessionState struct {
 	apiCallStart     time.Time
 	emittedAPITiming bool
 	inFlight         *agentcore.ToolTracker
+
+	// humanInputEnds and humanInputDetail record a recognized request that
+	// only a person could answer, observed in ParseLine on a
+	// system/permission_denied event whose [agentcore.RefusalPosture] read
+	// EndAttempt true. OnFinalize applies the consequence, ahead of its
+	// normal disposition logic, because ParseLine runs while the
+	// subprocess is still active and cannot itself call
+	// [agentcore.FinalizeTurn].
+	humanInputEnds   bool
+	humanInputDetail string
 }
 
 func (s *sessionState) logger() *slog.Logger {
@@ -101,6 +112,18 @@ func NewClaudeCodeAdapter(config map[string]any) (domain.AgentAdapter, error) {
 	pt := parsePassthroughConfig(config)
 	return &ClaudeCodeAdapter{passthrough: pt}, nil
 }
+
+// askUserQuestionTool is the built-in Claude Code tool name that carries a
+// genuine question to a person. A system/permission_denied event naming it
+// is a request for human input rather than a request for consent to act,
+// even though the runtime resolves both through the same denial mechanism.
+const askUserQuestionTool = "AskUserQuestion"
+
+// detailAnswerToQuestion names, for the operator, the specific ask behind
+// a recognized request for human input, appended to
+// [agentcore.RefusalPosture]'s notice stem and to the turn's terminal
+// message.
+const detailAnswerToQuestion = "an answer to a question"
 
 // StartSession validates the workspace path, resolves the claude binary, and
 // initializes per-session state. No subprocess is spawned; that happens in
@@ -155,6 +178,26 @@ func (a *ClaudeCodeAdapter) StartSession(_ context.Context, params domain.StartS
 					state.apiCallStart = time.Now()
 				case "api_retry":
 					agentcore.EmitNotification(emit, formatAPIRetry(event))
+				case "permission_denied":
+					// The runtime resolved this request on its own: --dangerously-
+					// skip-permissions (or a validated bypassPermissions mode)
+					// exposes no reply channel, so replyChannel is false on every
+					// row this event reads. AskUserQuestion is the one built-in
+					// tool that carries a genuine question rather than a request
+					// for consent to act; every other tool name is a permission
+					// request.
+					class := agentcore.ClassPermission
+					detail := ""
+					if event.ToolName == askUserQuestionTool {
+						class = agentcore.ClassHumanInput
+						detail = detailAnswerToQuestion
+					}
+					posture := agentcore.DecideHumanRequest(class, false, agentcore.AnswerRuntimeRefused)
+					if posture.EndAttempt {
+						state.humanInputEnds = true
+						state.humanInputDetail = detail
+					}
+					agentcore.EmitNotification(emit, posture.NoticeWithDetail(detail))
 				default:
 					agentcore.EmitNotification(emit, event.summary())
 				}
@@ -241,8 +284,22 @@ func (a *ClaudeCodeAdapter) StartSession(_ context.Context, params domain.StartS
 		GetUsage:     func() domain.TokenUsage { return state.acc.Snapshot() },
 		GetSessionID: func() string { return state.claudeSessionID },
 		OnFinalize: func(emit func(domain.AgentEvent), lastParsed any, exitCode int, stderrLines []string) (domain.TurnResult, *domain.AgentError) {
-			lastResult, _ := lastParsed.(*rawEvent)
 			usage := state.acc.Snapshot()
+
+			// A recognized request that only a person could answer, observed
+			// in ParseLine, overrides the turn's normal success/failure
+			// disposition regardless of how the subprocess exited.
+			if state.humanInputEnds {
+				evidence := agentcore.HumanInputEvidence(state.humanInputDetail)
+				meta := agentcore.TurnMeta{
+					SessionID:     state.claudeSessionID,
+					Usage:         usage,
+					UsageMeasured: state.usageMeasured,
+				}
+				return agentcore.FinalizeTurn(emit, state.logger(), evidence, meta)
+			}
+
+			lastResult, _ := lastParsed.(*rawEvent)
 
 			// Work tests this turn's own output, not the run cumulative,
 			// which is non-zero on any second turn.
@@ -317,6 +374,8 @@ func (a *ClaudeCodeAdapter) RunTurn(ctx context.Context, session domain.Session,
 	state.apiCallStart = time.Time{}
 	state.emittedAPITiming = false
 	state.inFlight = agentcore.NewToolTracker()
+	state.humanInputEnds = false
+	state.humanInputDetail = ""
 
 	return state.forkSession.RunTurn(ctx, params.Prompt, params.OnEvent)
 }

--- a/internal/agent/claude/claude_test.go
+++ b/internal/agent/claude/claude_test.go
@@ -396,6 +396,22 @@ func TestBuildArgs_AlwaysPresent(t *testing.T) {
 	}
 }
 
+// TestBuildArgs_DefaultConfigurationSkipsPermissions asserts that the full
+// configuration path, from an empty WORKFLOW.md claude-code sub-object
+// through buildArgs, passes --dangerously-skip-permissions. This is the
+// launch posture the refusal path in ParseLine assumes: no reply channel,
+// so every recognized request reads replyChannel = false.
+func TestBuildArgs_DefaultConfigurationSkipsPermissions(t *testing.T) {
+	t.Parallel()
+
+	pt := parsePassthroughConfig(map[string]any{})
+	got := buildArgs(&sessionState{claudeSessionID: "sess-default"}, 1, "p", pt)
+
+	if !slices.Contains(got, "--dangerously-skip-permissions") {
+		t.Errorf("buildArgs(default config) = %v, want --dangerously-skip-permissions present", got)
+	}
+}
+
 func TestNewUUID(t *testing.T) {
 	t.Parallel()
 
@@ -1481,6 +1497,99 @@ exit 0
 	if events[0].Type != domain.EventOtherMessage {
 		t.Errorf("unknown type mapped to %q, want %q", events[0].Type, domain.EventOtherMessage)
 	}
+}
+
+// TestRunTurn_PermissionDeniedContinuesTurn drives the wire shape observed
+// against a live claude CLI (v2.1.239): an undocumented system event with
+// subtype permission_denied and a tool_name field, produced when the
+// runtime denies a tool call on its own before the tool's own tool_result.
+// Because the tool named is not AskUserQuestion, this is a permission
+// request the runtime already refused, so the turn must continue rather
+// than end.
+func TestRunTurn_PermissionDeniedContinuesTurn(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	script := writeScript(t, tmpDir, `
+cat <<'JSONL'
+{"type":"system","subtype":"init","session_id":"perm-session","cwd":"/tmp"}
+{"type":"system","subtype":"permission_denied","tool_name":"Read"}
+{"type":"result","subtype":"success","result":"done","is_error":false,"usage":{"input_tokens":5,"output_tokens":5},"session_id":"perm-session"}
+JSONL
+exit 0
+`)
+
+	adapter, _ := NewClaudeCodeAdapter(map[string]any{})
+	session, err := adapter.StartSession(context.Background(), domain.StartSessionParams{
+		WorkspacePath: tmpDir,
+		AgentConfig:   domain.AgentConfig{Command: script},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var events []domain.AgentEvent
+	result, err := adapter.RunTurn(context.Background(), session, domain.RunTurnParams{
+		Prompt: "test",
+		OnEvent: func(e domain.AgentEvent) {
+			events = append(events, e)
+		},
+	})
+	if err != nil {
+		t.Fatalf("RunTurn() error = %v", err)
+	}
+	if result.ExitReason != domain.EventTurnCompleted {
+		t.Errorf("ExitReason = %q, want %q (turn must continue past the runtime's own refusal)", result.ExitReason, domain.EventTurnCompleted)
+	}
+
+	wantNotice := agentcore.DecideHumanRequest(agentcore.ClassPermission, false, agentcore.AnswerRuntimeRefused).NoticeWithDetail("")
+	var found bool
+	for _, e := range events {
+		if e.Type == domain.EventNotification && e.Message == wantNotice {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("no EventNotification with Message = %q found among events %v", wantNotice, events)
+	}
+}
+
+// TestRunTurn_PermissionDeniedAskUserQuestionEndsAttempt drives the
+// adapter's own classification logic, not an observed runtime ending: given
+// a system/permission_denied event naming the built-in AskUserQuestion
+// tool, the adapter infers a genuine question rather than a request for
+// consent to act (AskUserQuestion resolving through this same event shape
+// was never itself captured on a live transcript) and ends the attempt with
+// the human-input-required outcome and the "an answer to a question"
+// detail.
+func TestRunTurn_PermissionDeniedAskUserQuestionEndsAttempt(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	script := writeScript(t, tmpDir, `
+cat <<'JSONL'
+{"type":"system","subtype":"init","session_id":"ask-session","cwd":"/tmp"}
+{"type":"system","subtype":"permission_denied","tool_name":"AskUserQuestion"}
+JSONL
+exit 0
+`)
+
+	adapter, _ := NewClaudeCodeAdapter(map[string]any{})
+	session, err := adapter.StartSession(context.Background(), domain.StartSessionParams{
+		WorkspacePath: tmpDir,
+		AgentConfig:   domain.AgentConfig{Command: script},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := adapter.RunTurn(context.Background(), session, domain.RunTurnParams{
+		Prompt:  "test",
+		OnEvent: func(domain.AgentEvent) {},
+	})
+
+	dispositiontest.AssertDispositionContract(t, agentcore.HumanInputEvidence(detailAnswerToQuestion), result, err)
 }
 
 func TestRunTurn_NoOutputExitZero(t *testing.T) {

--- a/internal/agent/claude/parse.go
+++ b/internal/agent/claude/parse.go
@@ -20,6 +20,9 @@ type rawEvent struct {
 	SessionID string `json:"session_id,omitempty"`
 	Cwd       string `json:"cwd,omitempty"`
 
+	// System/permission_denied fields.
+	ToolName string `json:"tool_name,omitempty"`
+
 	// Result fields.
 	Result      string  `json:"result,omitempty"`
 	IsError     bool    `json:"is_error,omitempty"`

--- a/internal/agent/claude/validate.go
+++ b/internal/agent/claude/validate.go
@@ -1,0 +1,34 @@
+package claude
+
+import (
+	"github.com/sortie-ai/sortie/internal/registry"
+	"github.com/sortie-ai/sortie/internal/typeutil"
+)
+
+// nonAskingPermissionModes is the allowlist of claude-code.permission_mode
+// values that do not leave the agent waiting on a person. The direction is
+// deliberately an allowlist, not a denylist of asking modes, so a mode the
+// runtime adds later is refused until someone establishes what it does
+// rather than passing validation unexamined. Its only member is the
+// semantic equivalent of the --dangerously-skip-permissions flag this
+// adapter passes by default.
+var nonAskingPermissionModes = map[string]bool{
+	"bypassPermissions": true,
+}
+
+// validateConfig checks claude-code-specific configuration constraints
+// and returns diagnostics for the sortie validate pipeline. It does not
+// construct an adapter instance or launch a subprocess.
+func validateConfig(fields registry.AgentConfigFields) []registry.ValidationDiag {
+	mode := typeutil.StringFrom(fields.Passthrough, "permission_mode")
+	if mode == "" || nonAskingPermissionModes[mode] {
+		return nil
+	}
+
+	return []registry.ValidationDiag{{
+		Severity: "error",
+		Check:    "claude-code.permission_mode.interactive",
+		Message: "claude-code.permission_mode is set to a value that lets the agent stop and ask " +
+			"for approval, and an unattended run has no one to answer; only \"bypassPermissions\" is supported",
+	}}
+}

--- a/internal/agent/claude/validate_test.go
+++ b/internal/agent/claude/validate_test.go
@@ -1,0 +1,87 @@
+package claude
+
+import (
+	"testing"
+
+	"github.com/sortie-ai/sortie/internal/registry"
+)
+
+// TestValidateConfig covers claude-code.permission_mode: absent or
+// "bypassPermissions" draws no diagnostic, and every other named mode plus
+// an arbitrary unrecognized string draws an error-severity diagnostic,
+// since the allowlist direction means an unlisted future mode is refused
+// rather than silently passed.
+func TestValidateConfig(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		passthrough   map[string]any
+		wantDiagCount int
+	}{
+		{
+			name:          "absent permission_mode draws no diagnostic",
+			passthrough:   map[string]any{},
+			wantDiagCount: 0,
+		},
+		{
+			name:          `permission_mode "bypassPermissions" draws no diagnostic`,
+			passthrough:   map[string]any{"permission_mode": "bypassPermissions"},
+			wantDiagCount: 0,
+		},
+		{
+			name:          `permission_mode "acceptEdits" draws an error`,
+			passthrough:   map[string]any{"permission_mode": "acceptEdits"},
+			wantDiagCount: 1,
+		},
+		{
+			name:          `permission_mode "auto" draws an error`,
+			passthrough:   map[string]any{"permission_mode": "auto"},
+			wantDiagCount: 1,
+		},
+		{
+			name:          `permission_mode "manual" draws an error`,
+			passthrough:   map[string]any{"permission_mode": "manual"},
+			wantDiagCount: 1,
+		},
+		{
+			name:          `permission_mode "dontAsk" draws an error`,
+			passthrough:   map[string]any{"permission_mode": "dontAsk"},
+			wantDiagCount: 1,
+		},
+		{
+			name:          `permission_mode "plan" draws an error`,
+			passthrough:   map[string]any{"permission_mode": "plan"},
+			wantDiagCount: 1,
+		},
+		{
+			name:          "arbitrary unrecognized mode draws an error",
+			passthrough:   map[string]any{"permission_mode": "somethingFutureRuntimeAdds"},
+			wantDiagCount: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := validateConfig(registry.AgentConfigFields{Kind: "claude-code", Passthrough: tt.passthrough})
+
+			if len(got) != tt.wantDiagCount {
+				t.Fatalf("validateConfig(%v) returned %d diagnostics, want %d: %+v", tt.passthrough, len(got), tt.wantDiagCount, got)
+			}
+			if tt.wantDiagCount == 0 {
+				return
+			}
+			if got[0].Severity != "error" {
+				t.Errorf("validateConfig(%v)[0].Severity = %q, want %q", tt.passthrough, got[0].Severity, "error")
+			}
+			if got[0].Check != "claude-code.permission_mode.interactive" {
+				t.Errorf("validateConfig(%v)[0].Check = %q, want %q", tt.passthrough, got[0].Check, "claude-code.permission_mode.interactive")
+			}
+			if got[0].Message == "" {
+				t.Errorf("validateConfig(%v)[0].Message = \"\", want non-empty", tt.passthrough)
+			}
+		})
+	}
+}

--- a/internal/agent/codex/codex.go
+++ b/internal/agent/codex/codex.go
@@ -31,7 +31,8 @@ import (
 
 func init() {
 	registry.Agents.RegisterWithMeta("codex", NewCodexAdapter, registry.AgentMeta{
-		RequiresCommand: true,
+		RequiresCommand:     true,
+		ValidateAgentConfig: validateConfig,
 	})
 }
 
@@ -330,6 +331,29 @@ func (a *CodexAdapter) StartSession(ctx context.Context, params domain.StartSess
 	}, nil
 }
 
+// codexRefusalErrorCode and codexRefusalMessage are pinned rather than
+// derived: the app-server protocol schema declares no enumerated value
+// for either the error code an implementation-defined JSON-RPC refusal
+// may use or the free-text field the legacy ReviewDecision denial
+// requires, and the app-server acknowledges no client response, so
+// neither can be confirmed accepted at runtime. codexRefusalErrorCode
+// is written as the JSON-RPC error code on a server request whose
+// response schema offers no result shape that could express a
+// decline. codexRefusalMessage is written both as that error's message
+// and as the legacy ReviewDecision denial's rejection text.
+const (
+	codexRefusalErrorCode = -32001
+	codexRefusalMessage   = "sortie refuses requests that only a person could answer"
+)
+
+// detailAnswerToQuestion and detailWiderAccess name, for the operator,
+// the specific ask behind a recognized request for human input,
+// appended to agentcore.RefusalPosture's notice stem.
+const (
+	detailAnswerToQuestion = "an answer to a question"
+	detailWiderAccess      = "wider filesystem or network access"
+)
+
 // RunTurn sends a turn/start request on the existing thread and reads
 // events until turn/completed. Events are delivered synchronously via
 // params.OnEvent.
@@ -444,6 +468,11 @@ func (a *CodexAdapter) RunTurn(ctx context.Context, session domain.Session, para
 	var toolWg sync.WaitGroup
 	toolEventCh := make(chan domain.AgentEvent, 8)
 	ctxDone := ctx.Done()
+	// cancelDeadline stays nil, and so never selectable, until the
+	// ctxDone arm below arms it with a one-shot timer bounding how long
+	// the loop waits for the runtime's own turn/completed after the
+	// best-effort interrupt.
+	var cancelDeadline <-chan time.Time
 
 	// Replay buffered notifications (received during the response-waiting
 	// loop above) before entering the main event loop. These are
@@ -474,15 +503,30 @@ func (a *CodexAdapter) RunTurn(ctx context.Context, session domain.Session, para
 		case <-ctxDone:
 			// A cancelled context's Done channel stays ready forever. Disable
 			// this arm before sending the one-shot interrupt so later selects
-			// wait for a terminal message or stdout to close.
+			// wait for a terminal message, stdout to close, or the deadline
+			// armed below.
 			ctxDone = nil
 			// Best-effort write of turn/interrupt on the already-cancelled turn.
 			sendRequest(state, "turn/interrupt", map[string]any{ //nolint:errcheck,gosec // best-effort interrupt
 				"threadId": state.threadID,
 				"turnId":   turnID,
 			})
-			// Continue reading until turn/completed or channel close.
+			// Bound how long the loop keeps reading for the runtime's own
+			// turn/completed: past this deadline the interrupt is presumed
+			// lost, and the loop returns rather than reading until stdout
+			// closes.
+			cancelDeadline = time.After(readTimeout(state))
 			continue
+
+		case <-cancelDeadline:
+			ev := agentcore.TurnEvidence{Terminal: agentcore.TerminalCancelled, Work: agentcore.WorkUnobservable}
+			meta := agentcore.TurnMeta{
+				SessionID:     state.threadID,
+				Usage:         state.acc.Snapshot(),
+				UsageMeasured: state.usageMeasured,
+			}
+			result, agentErr := drainToolEventsAndFinalize(&toolWg, toolEventCh, params.OnEvent, logger, ev, meta)
+			return result, agentErr
 
 		case msg, ok := <-state.msgCh:
 			if !ok {
@@ -687,6 +731,102 @@ func (a *CodexAdapter) RunTurn(ctx context.Context, session domain.Session, para
 					params.OnEvent(*evt)
 				}
 
+			case "item/commandExecution/requestApproval", "item/fileChange/requestApproval",
+				"applyPatchApproval", "execCommandApproval",
+				"mcpServer/elicitation/request", "item/permissions/requestApproval",
+				"item/tool/requestUserInput":
+				requestID := msg.Response.ID
+				if requestID == 0 {
+					params.OnEvent(domain.AgentEvent{
+						Type:      domain.EventOtherMessage,
+						Timestamp: now,
+						Message:   method,
+					})
+					break
+				}
+
+				// An orchestrator-initiated cancellation outranks any
+				// classification of a request this turn recognizes, matching
+				// the adapter's existing treatment of an interrupted turn.
+				if ctx.Err() != nil {
+					ev := agentcore.TurnEvidence{Terminal: agentcore.TerminalCancelled, Work: agentcore.WorkUnobservable}
+					meta := agentcore.TurnMeta{
+						SessionID:     state.threadID,
+						Usage:         state.acc.Snapshot(),
+						UsageMeasured: state.usageMeasured,
+					}
+					result, agentErr := drainToolEventsAndFinalize(&toolWg, toolEventCh, params.OnEvent, logger, ev, meta)
+					return result, agentErr
+				}
+
+				switch method {
+				case "item/commandExecution/requestApproval", "item/fileChange/requestApproval":
+					posture := agentcore.DecideHumanRequest(agentcore.ClassPermission, true, agentcore.AnswerPending)
+					state.mu.Lock()
+					sendResponse(state, requestID, map[string]any{"decision": "decline"}) //nolint:errcheck,gosec // best-effort refusal
+					state.mu.Unlock()
+					agentcore.EmitNotification(params.OnEvent, posture.NoticeWithDetail(""))
+
+				case "applyPatchApproval", "execCommandApproval":
+					posture := agentcore.DecideHumanRequest(agentcore.ClassPermission, true, agentcore.AnswerPending)
+					state.mu.Lock()
+					sendResponse(state, requestID, map[string]any{ //nolint:errcheck,gosec // best-effort refusal
+						"decision": map[string]any{
+							"denied": map[string]any{"rejection": codexRefusalMessage},
+						},
+					})
+					state.mu.Unlock()
+					agentcore.EmitNotification(params.OnEvent, posture.NoticeWithDetail(""))
+
+				case "mcpServer/elicitation/request":
+					posture := agentcore.DecideHumanRequest(agentcore.ClassHumanInput, true, agentcore.AnswerPending)
+					state.mu.Lock()
+					sendResponse(state, requestID, map[string]any{"action": "decline"}) //nolint:errcheck,gosec // best-effort refusal
+					state.mu.Unlock()
+					agentcore.EmitNotification(params.OnEvent, posture.NoticeWithDetail(detailAnswerToQuestion))
+
+					meta := agentcore.TurnMeta{
+						SessionID:     state.threadID,
+						Usage:         state.acc.Snapshot(),
+						UsageMeasured: state.usageMeasured,
+					}
+					evidence := agentcore.HumanInputEvidence(detailAnswerToQuestion)
+					result, agentErr := drainToolEventsAndFinalize(&toolWg, toolEventCh, params.OnEvent, logger, evidence, meta)
+					return result, agentErr
+
+				case "item/permissions/requestApproval":
+					posture := agentcore.DecideHumanRequest(agentcore.ClassHumanInput, true, agentcore.AnswerPending)
+					state.mu.Lock()
+					sendErrorResponse(state, requestID, codexRefusalErrorCode, codexRefusalMessage) //nolint:errcheck,gosec // best-effort refusal
+					state.mu.Unlock()
+					agentcore.EmitNotification(params.OnEvent, posture.NoticeWithDetail(detailWiderAccess))
+
+					meta := agentcore.TurnMeta{
+						SessionID:     state.threadID,
+						Usage:         state.acc.Snapshot(),
+						UsageMeasured: state.usageMeasured,
+					}
+					evidence := agentcore.HumanInputEvidence(detailWiderAccess)
+					result, agentErr := drainToolEventsAndFinalize(&toolWg, toolEventCh, params.OnEvent, logger, evidence, meta)
+					return result, agentErr
+
+				case "item/tool/requestUserInput":
+					posture := agentcore.DecideHumanRequest(agentcore.ClassHumanInput, true, agentcore.AnswerPending)
+					state.mu.Lock()
+					sendErrorResponse(state, requestID, codexRefusalErrorCode, codexRefusalMessage) //nolint:errcheck,gosec // best-effort refusal
+					state.mu.Unlock()
+					agentcore.EmitNotification(params.OnEvent, posture.NoticeWithDetail(detailAnswerToQuestion))
+
+					meta := agentcore.TurnMeta{
+						SessionID:     state.threadID,
+						Usage:         state.acc.Snapshot(),
+						UsageMeasured: state.usageMeasured,
+					}
+					evidence := agentcore.HumanInputEvidence(detailAnswerToQuestion)
+					result, agentErr := drainToolEventsAndFinalize(&toolWg, toolEventCh, params.OnEvent, logger, evidence, meta)
+					return result, agentErr
+				}
+
 			case "turn/plan/updated":
 				agentcore.EmitNotification(params.OnEvent, "plan updated")
 
@@ -702,6 +842,28 @@ func (a *CodexAdapter) RunTurn(ctx context.Context, session domain.Session, para
 			}
 		}
 	}
+}
+
+// drainToolEventsAndFinalize closes toolEventCh once every tool
+// goroutine toolWg tracks has sent its result, delivers the buffered
+// events through emit, and returns through agentcore.FinalizeTurn.
+// Every terminal return RunTurn takes for a recognized human-only
+// request calls this first: toolEventCh is buffered, and skipping the
+// drain leaves an in-flight tool goroutine blocked on a full channel
+// for the life of the process.
+func drainToolEventsAndFinalize(
+	toolWg *sync.WaitGroup,
+	toolEventCh chan domain.AgentEvent,
+	emit func(domain.AgentEvent),
+	logger *slog.Logger,
+	ev agentcore.TurnEvidence,
+	meta agentcore.TurnMeta,
+) (domain.TurnResult, *domain.AgentError) {
+	go func() { toolWg.Wait(); close(toolEventCh) }()
+	for evt := range toolEventCh {
+		emit(evt)
+	}
+	return agentcore.FinalizeTurn(emit, logger, ev, meta)
 }
 
 // handleToolCall dispatches a dynamic tool call from the app-server to

--- a/internal/agent/codex/handshake_test.go
+++ b/internal/agent/codex/handshake_test.go
@@ -5,6 +5,7 @@ package codex
 import (
 	"bufio"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -208,6 +209,43 @@ func TestStartThread_Success(t *testing.T) {
 	}
 	if threadID != "thread-abc" {
 		t.Errorf("startThread() threadID = %q, want %q", threadID, "thread-abc")
+	}
+}
+
+// TestStartThread_DefaultApprovalPolicyIsNever asserts the non-interactive
+// launch posture: under default configuration, thread/start carries
+// approvalPolicy "never" so the app-server does not ask interactively.
+func TestStartThread_DefaultApprovalPolicyIsNever(t *testing.T) {
+	t.Parallel()
+
+	stdin := &capturingWriteCloser{}
+	state := handshakeState()
+	state.stdin = stdin
+	scanCh := scanChanFromLines(
+		`{"id":1,"result":{"thread":{"id":"thread-abc"}}}`,
+		`{"method":"thread/started","params":{"threadId":"thread-abc"}}`,
+	)
+
+	if _, err := startThread(context.Background(), state, scanCh, passthroughConfig{}, nil); err != nil {
+		t.Fatalf("startThread() error = %v", err)
+	}
+
+	write, ok := stdin.find(`{"method":"thread/start"`)
+	if !ok {
+		t.Fatal("startThread() wrote no thread/start request")
+	}
+
+	var req struct {
+		Method string `json:"method"`
+		Params struct {
+			ApprovalPolicy string `json:"approvalPolicy"`
+		} `json:"params"`
+	}
+	if err := json.Unmarshal([]byte(write), &req); err != nil {
+		t.Fatalf("unmarshal written thread/start request: %v", err)
+	}
+	if req.Params.ApprovalPolicy != "never" {
+		t.Errorf("thread/start approvalPolicy = %q, want %q", req.Params.ApprovalPolicy, "never")
 	}
 }
 

--- a/internal/agent/codex/protocol.go
+++ b/internal/agent/codex/protocol.go
@@ -87,6 +87,27 @@ func sendResponse(state *sessionState, id int64, result any) error {
 	return nil
 }
 
+// sendErrorResponse writes a JSON-RPC error response to the app-server
+// stdin. The caller must hold state.mu.
+func sendErrorResponse(state *sessionState, id int64, code int, message string) error {
+	type errorResponse struct {
+		ID    int64    `json:"id"`
+		Error rpcError `json:"error"`
+	}
+	resp := errorResponse{ID: id, Error: rpcError{Code: code, Message: message}}
+	data, err := json.Marshal(resp)
+	if err != nil {
+		return fmt.Errorf("marshal error response id=%d: %w", id, err)
+	}
+	data = append(data, '\n')
+
+	_, writeErr := state.stdin.Write(data)
+	if writeErr != nil {
+		return fmt.Errorf("write error response id=%d: %w", id, writeErr)
+	}
+	return nil
+}
+
 // scanResult carries one line from the background scanner goroutine,
 // or a terminal condition (EOF / error).
 type scanResult struct {

--- a/internal/agent/codex/protocol_test.go
+++ b/internal/agent/codex/protocol_test.go
@@ -8,11 +8,64 @@ import (
 	"errors"
 	"io"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/sortie-ai/sortie/internal/domain"
 )
+
+// capturingWriteCloser records each Write call as one entry, in the order
+// received, so a test can assert on the exact bytes a handshake function
+// or the RunTurn event loop wrote back to the app-server. Safe for
+// concurrent use, matching every production caller of sendResponse and
+// sendErrorResponse, which write under state.mu.
+type capturingWriteCloser struct {
+	mu     sync.Mutex
+	writes []string
+}
+
+func (w *capturingWriteCloser) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.writes = append(w.writes, string(p))
+	return len(p), nil
+}
+
+func (w *capturingWriteCloser) Close() error { return nil }
+
+// find returns the first captured write with the given prefix.
+func (w *capturingWriteCloser) find(prefix string) (string, bool) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	for _, write := range w.writes {
+		if strings.HasPrefix(write, prefix) {
+			return write, true
+		}
+	}
+	return "", false
+}
+
+func TestSendErrorResponse_WritesExactBytes(t *testing.T) {
+	t.Parallel()
+
+	stdin := &capturingWriteCloser{}
+	state := &sessionState{stdin: stdin}
+
+	err := sendErrorResponse(state, 7, -32001, "sortie refuses requests that only a person could answer")
+	if err != nil {
+		t.Fatalf("sendErrorResponse() error = %v", err)
+	}
+
+	write, ok := stdin.find(`{"id":7,`)
+	if !ok {
+		t.Fatal("sendErrorResponse() wrote nothing to stdin")
+	}
+	const want = `{"id":7,"error":{"code":-32001,"message":"sortie refuses requests that only a person could answer"}}` + "\n"
+	if write != want {
+		t.Errorf("sendErrorResponse(id=7, code=-32001) wrote %q, want %q", write, want)
+	}
+}
 
 func TestSendNotification_WritesToStdin(t *testing.T) {
 	t.Parallel()

--- a/internal/agent/codex/runturn_test.go
+++ b/internal/agent/codex/runturn_test.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"log/slog"
 	"os"
@@ -106,6 +107,14 @@ func makeTestState(fixtureData []byte) *sessionState {
 		}
 	}()
 
+	return state
+}
+
+// makeTestStateWithStdin behaves like makeTestState but installs stdin so a
+// test can capture the exact bytes RunTurn writes back to the app-server.
+func makeTestStateWithStdin(fixtureData []byte, stdin io.WriteCloser) *sessionState {
+	state := makeTestState(fixtureData)
+	state.stdin = stdin
 	return state
 }
 
@@ -798,6 +807,397 @@ func TestRunTurn_ToolCallToolNotInRegistry(t *testing.T) {
 
 	if _, ok := firstEventOfType(events, domain.EventUnsupportedToolCall); !ok {
 		t.Fatal("expected EventUnsupportedToolCall for unregistered tool, not found")
+	}
+}
+
+// --- Human-only-request recognition and refusal ---
+
+// runTurnFixtureWithServerRequest builds a turn/start response, a
+// turn/started notification, and one server request (a method carrying
+// both "id" and "method") for the given method and request id, followed
+// by the given trailing lines (e.g. a turn/completed notification, or
+// none when the request is expected to end the attempt before any more
+// input is read).
+func runTurnFixtureWithServerRequest(requestID int64, method string, trailing ...string) []byte {
+	fixture := fmt.Sprintf(
+		"{\"id\":1,\"result\":{\"turn\":{\"id\":\"turn-001\",\"status\":\"starting\"}}}\n"+
+			"{\"method\":\"turn/started\",\"params\":{}}\n"+
+			"{\"id\":%d,\"method\":%q,\"params\":{}}\n",
+		requestID, method,
+	)
+	for _, line := range trailing {
+		fixture += line + "\n"
+	}
+	return []byte(fixture)
+}
+
+const turnCompletedLine = `{"method":"turn/completed","params":{"turn":{"id":"turn-001","status":"completed"}}}`
+
+// TestRunTurn_PermissionRequestDeniedContinues drives the two current-form
+// permission requests through the turn loop and asserts the exact bytes
+// written back to the app-server for that request id, and that the turn
+// continues to turn/completed rather than ending.
+func TestRunTurn_PermissionRequestDeniedContinues(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		method    string
+		requestID int64
+	}{
+		{name: "item/commandExecution/requestApproval", method: "item/commandExecution/requestApproval", requestID: 20},
+		{name: "item/fileChange/requestApproval", method: "item/fileChange/requestApproval", requestID: 21},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			stdin := &capturingWriteCloser{}
+			state := makeTestStateWithStdin(runTurnFixtureWithServerRequest(tt.requestID, tt.method, turnCompletedLine), stdin)
+			adapter, _ := NewCodexAdapter(map[string]any{})
+
+			result, err := adapter.RunTurn(context.Background(), fakeSession(state), domain.RunTurnParams{
+				Prompt:  "go",
+				OnEvent: func(domain.AgentEvent) {},
+			})
+			if err != nil {
+				t.Fatalf("RunTurn() error = %v", err)
+			}
+			if result.ExitReason != domain.EventTurnCompleted {
+				t.Errorf("ExitReason = %q, want %q (turn must continue past the refusal)", result.ExitReason, domain.EventTurnCompleted)
+			}
+
+			write, ok := stdin.find(fmt.Sprintf(`{"id":%d,`, tt.requestID))
+			if !ok {
+				t.Fatalf("no response written for request id %d", tt.requestID)
+			}
+			want := fmt.Sprintf(`{"id":%d,"result":{"decision":"decline"}}`, tt.requestID) + "\n"
+			if write != want {
+				t.Errorf("response for %s = %q, want %q", tt.method, write, want)
+			}
+		})
+	}
+}
+
+// TestRunTurn_LegacyPermissionRequestDeniedContinues drives the two legacy
+// ReviewDecision-form permission requests through the turn loop and asserts
+// the exact denial payload the schema declares, and that the turn
+// continues rather than ending.
+func TestRunTurn_LegacyPermissionRequestDeniedContinues(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		method    string
+		requestID int64
+	}{
+		{name: "applyPatchApproval", method: "applyPatchApproval", requestID: 22},
+		{name: "execCommandApproval", method: "execCommandApproval", requestID: 23},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			stdin := &capturingWriteCloser{}
+			state := makeTestStateWithStdin(runTurnFixtureWithServerRequest(tt.requestID, tt.method, turnCompletedLine), stdin)
+			adapter, _ := NewCodexAdapter(map[string]any{})
+
+			result, err := adapter.RunTurn(context.Background(), fakeSession(state), domain.RunTurnParams{
+				Prompt:  "go",
+				OnEvent: func(domain.AgentEvent) {},
+			})
+			if err != nil {
+				t.Fatalf("RunTurn() error = %v", err)
+			}
+			if result.ExitReason != domain.EventTurnCompleted {
+				t.Errorf("ExitReason = %q, want %q (turn must continue past the refusal)", result.ExitReason, domain.EventTurnCompleted)
+			}
+
+			write, ok := stdin.find(fmt.Sprintf(`{"id":%d,`, tt.requestID))
+			if !ok {
+				t.Fatalf("no response written for request id %d", tt.requestID)
+			}
+			want := fmt.Sprintf(`{"id":%d,"result":{"decision":{"denied":{"rejection":%q}}}}`, tt.requestID, codexRefusalMessage) + "\n"
+			if write != want {
+				t.Errorf("response for %s = %q, want %q", tt.method, write, want)
+			}
+		})
+	}
+}
+
+// TestRunTurn_PermissionRequestEmitsNotification asserts that a continued
+// permission refusal emits RefusalPosture.Notice as an EventNotification,
+// so the operator learns why the turn kept going even though nothing was
+// granted.
+func TestRunTurn_PermissionRequestEmitsNotification(t *testing.T) {
+	t.Parallel()
+
+	state := makeTestState(runTurnFixtureWithServerRequest(24, "item/commandExecution/requestApproval", turnCompletedLine))
+	adapter, _ := NewCodexAdapter(map[string]any{})
+
+	var events []domain.AgentEvent
+	if _, err := adapter.RunTurn(context.Background(), fakeSession(state), domain.RunTurnParams{
+		Prompt:  "go",
+		OnEvent: collectEvents(&events),
+	}); err != nil {
+		t.Fatalf("RunTurn() error = %v", err)
+	}
+
+	wantNotice := agentcore.DecideHumanRequest(agentcore.ClassPermission, true, agentcore.AnswerPending).NoticeWithDetail("")
+
+	var found bool
+	for _, e := range filterEventsOfType(events, domain.EventNotification) {
+		if e.Message == wantNotice {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("no EventNotification with Message = %q found", wantNotice)
+	}
+}
+
+// TestRunTurn_HumanInputRequestEndsAttempt drives each ClassHumanInput
+// method through the turn loop and asserts the exact bytes written back
+// for that request id, and that the attempt ends with the
+// human-input-required outcome rather than continuing or reading further
+// input.
+func TestRunTurn_HumanInputRequestEndsAttempt(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		method    string
+		requestID int64
+		detail    string
+		wantWrite string
+	}{
+		{
+			name:      "mcpServer/elicitation/request",
+			method:    "mcpServer/elicitation/request",
+			requestID: 30,
+			detail:    detailAnswerToQuestion,
+			wantWrite: `{"id":30,"result":{"action":"decline"}}` + "\n",
+		},
+		{
+			name:      "item/permissions/requestApproval",
+			method:    "item/permissions/requestApproval",
+			requestID: 31,
+			detail:    detailWiderAccess,
+			wantWrite: `{"id":31,"error":{"code":-32001,"message":"sortie refuses requests that only a person could answer"}}` + "\n",
+		},
+		{
+			name:      "item/tool/requestUserInput",
+			method:    "item/tool/requestUserInput",
+			requestID: 32,
+			detail:    detailAnswerToQuestion,
+			wantWrite: `{"id":32,"error":{"code":-32001,"message":"sortie refuses requests that only a person could answer"}}` + "\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			stdin := &capturingWriteCloser{}
+			state := makeTestStateWithStdin(runTurnFixtureWithServerRequest(tt.requestID, tt.method), stdin)
+			adapter, _ := NewCodexAdapter(map[string]any{})
+
+			result, err := adapter.RunTurn(context.Background(), fakeSession(state), domain.RunTurnParams{
+				Prompt:  "go",
+				OnEvent: func(domain.AgentEvent) {},
+			})
+
+			dispositiontest.AssertDispositionContract(t, agentcore.HumanInputEvidence(tt.detail), result, err)
+
+			write, ok := stdin.find(fmt.Sprintf(`{"id":%d,`, tt.requestID))
+			if !ok {
+				t.Fatalf("no response written for request id %d", tt.requestID)
+			}
+			if write != tt.wantWrite {
+				t.Errorf("response for %s = %q, want %q", tt.method, write, tt.wantWrite)
+			}
+		})
+	}
+}
+
+// TestRunTurn_HumanInputRequestDrainsInFlightToolCall pins the
+// refusal path: with a tool call in flight when a ClassHumanInput
+// request arrives, the terminal return must close and drain toolEventCh
+// so the tool goroutine's send completes rather than leaking. If the
+// drain were skipped, RunTurn would return before the delayed tool
+// finishes and its EventToolResult would never be observed by this test,
+// because OnEvent is only ever called while RunTurn itself is still
+// running.
+func TestRunTurn_HumanInputRequestDrainsInFlightToolCall(t *testing.T) {
+	t.Parallel()
+
+	reg := domain.NewToolRegistry()
+	reg.Register(&fakeTool{name: "slow_tool", result: json.RawMessage(`"ok"`), delay: 50 * time.Millisecond})
+
+	fixture := "{\"id\":1,\"result\":{\"turn\":{\"id\":\"turn-001\",\"status\":\"starting\"}}}\n" +
+		"{\"method\":\"turn/started\",\"params\":{}}\n" +
+		"{\"id\":41,\"method\":\"item/tool/call\",\"params\":{\"tool\":\"slow_tool\",\"arguments\":{}}}\n" +
+		"{\"id\":42,\"method\":\"mcpServer/elicitation/request\",\"params\":{}}\n"
+
+	state := makeTestState([]byte(fixture))
+	adapter, _ := NewCodexAdapter(map[string]any{"tool_registry": reg})
+
+	var events []domain.AgentEvent
+	result, err := adapter.RunTurn(context.Background(), fakeSession(state), domain.RunTurnParams{
+		Prompt:  "use tool",
+		OnEvent: collectEvents(&events),
+	})
+
+	dispositiontest.AssertDispositionContract(t, agentcore.HumanInputEvidence(detailAnswerToQuestion), result, err)
+
+	if _, ok := firstEventOfType(events, domain.EventToolResult); !ok {
+		t.Fatal("in-flight tool call's EventToolResult was not drained before the terminal return")
+	}
+}
+
+// TestRunTurn_CancelledReturnsWithinBoundWhenTurnCompletedNeverArrives
+// pins the post-cancellation bound: after the best-effort turn/interrupt,
+// the loop must return once read_timeout_ms elapses rather than reading
+// until stdout closes. The runtime's own turn/completed never arrives in
+// this test.
+func TestRunTurn_CancelledReturnsWithinBoundWhenTurnCompletedNeverArrives(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	state := newInterruptedStatusState()
+	state.agentConfig = domain.AgentConfig{ReadTimeoutMS: 50}
+	close(state.readerDone)
+	stdin := &interruptTrackingWriteCloser{interrupts: make(chan struct{}, 1)}
+	state.stdin = stdin
+
+	type outcome struct {
+		result domain.TurnResult
+		err    error
+	}
+	outcomeCh := make(chan outcome, 1)
+	finished := make(chan struct{})
+
+	adapter, _ := NewCodexAdapter(map[string]any{})
+	go func() {
+		defer close(finished)
+		result, err := adapter.RunTurn(ctx, fakeSession(state), domain.RunTurnParams{
+			Prompt:  "go",
+			OnEvent: func(domain.AgentEvent) {},
+		})
+		outcomeCh <- outcome{result: result, err: err}
+	}()
+
+	t.Cleanup(func() {
+		select {
+		case <-finished:
+			return
+		default:
+		}
+		close(state.msgCh)
+		select {
+		case <-finished:
+		case <-time.After(time.Second):
+		}
+	})
+
+	state.msgCh <- parseMessage([]byte(`{"id":1,"result":{"turn":{"id":"turn-001","status":"starting"}}}`))
+	state.msgCh <- parseMessage([]byte(`{"method":"turn/started","params":{"turnId":"turn-001"}}`))
+
+	start := time.Now()
+	cancel()
+
+	select {
+	case <-stdin.interrupts:
+	case <-time.After(time.Second):
+		t.Fatal("RunTurn did not send turn/interrupt after cancellation")
+	}
+
+	// turn/completed is never sent. RunTurn must return once the
+	// configured read_timeout_ms bound elapses, not merely eventually.
+	select {
+	case got := <-outcomeCh:
+		if elapsed := time.Since(start); elapsed > time.Second {
+			t.Errorf("RunTurn returned after %v, want well within the 50ms read_timeout_ms bound", elapsed)
+		}
+		if got.result.ExitReason != domain.EventTurnCancelled {
+			t.Errorf("ExitReason = %q, want %q", got.result.ExitReason, domain.EventTurnCancelled)
+		}
+		requireAgentError(t, got.err, domain.ErrTurnCancelled)
+	case <-time.After(2 * time.Second):
+		t.Fatal("RunTurn did not return within the bound; it kept reading after cancellation with no turn/completed")
+	}
+}
+
+// TestRunTurn_CancelledDrainsInFlightToolCall asserts that when the
+// post-cancellation bound elapses with a tool call in flight, the timeout
+// return still closes and drains toolEventCh before calling FinalizeTurn.
+func TestRunTurn_CancelledDrainsInFlightToolCall(t *testing.T) {
+	t.Parallel()
+
+	reg := domain.NewToolRegistry()
+	reg.Register(&fakeTool{name: "slow_tool", result: json.RawMessage(`"ok"`), delay: 20 * time.Millisecond})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	state := newInterruptedStatusState()
+	state.agentConfig = domain.AgentConfig{ReadTimeoutMS: 200}
+	close(state.readerDone)
+
+	type outcome struct {
+		result domain.TurnResult
+		err    error
+	}
+	outcomeCh := make(chan outcome, 1)
+	finished := make(chan struct{})
+	var events []domain.AgentEvent
+
+	adapter, _ := NewCodexAdapter(map[string]any{"tool_registry": reg})
+	go func() {
+		defer close(finished)
+		result, err := adapter.RunTurn(ctx, fakeSession(state), domain.RunTurnParams{
+			Prompt:  "use tool",
+			OnEvent: collectEvents(&events),
+		})
+		outcomeCh <- outcome{result: result, err: err}
+	}()
+
+	t.Cleanup(func() {
+		select {
+		case <-finished:
+			return
+		default:
+		}
+		close(state.msgCh)
+		select {
+		case <-finished:
+		case <-time.After(time.Second):
+		}
+	})
+
+	state.msgCh <- parseMessage([]byte(`{"id":1,"result":{"turn":{"id":"turn-001","status":"starting"}}}`))
+	state.msgCh <- parseMessage([]byte(`{"method":"turn/started","params":{"turnId":"turn-001"}}`))
+	state.msgCh <- parseMessage([]byte(`{"id":60,"method":"item/tool/call","params":{"tool":"slow_tool","arguments":{}}}`))
+
+	cancel()
+
+	select {
+	case got := <-outcomeCh:
+		if got.result.ExitReason != domain.EventTurnCancelled {
+			t.Errorf("ExitReason = %q, want %q", got.result.ExitReason, domain.EventTurnCancelled)
+		}
+		requireAgentError(t, got.err, domain.ErrTurnCancelled)
+	case <-time.After(2 * time.Second):
+		t.Fatal("RunTurn did not return within the bound with a tool call in flight")
+	}
+
+	if _, ok := firstEventOfType(events, domain.EventToolResult); !ok {
+		t.Fatal("in-flight tool call's EventToolResult was not drained before the cancellation-timeout return")
 	}
 }
 

--- a/internal/agent/codex/validate.go
+++ b/internal/agent/codex/validate.go
@@ -1,0 +1,23 @@
+package codex
+
+import (
+	"github.com/sortie-ai/sortie/internal/registry"
+	"github.com/sortie-ai/sortie/internal/typeutil"
+)
+
+// validateConfig checks codex-specific configuration constraints and
+// returns diagnostics for the sortie validate pipeline. It does not
+// construct an adapter instance or launch a subprocess.
+func validateConfig(fields registry.AgentConfigFields) []registry.ValidationDiag {
+	policy := typeutil.StringFrom(fields.Passthrough, "approval_policy")
+	if policy == "" || policy == "never" {
+		return nil
+	}
+
+	return []registry.ValidationDiag{{
+		Severity: "error",
+		Check:    "codex.approval_policy.interactive",
+		Message: "codex.approval_policy is set to a value that lets the agent stop and ask for " +
+			"approval, and an unattended run has no one to answer; only \"never\" is supported",
+	}}
+}

--- a/internal/agent/codex/validate_test.go
+++ b/internal/agent/codex/validate_test.go
@@ -1,0 +1,68 @@
+package codex
+
+import (
+	"testing"
+
+	"github.com/sortie-ai/sortie/internal/registry"
+)
+
+// TestValidateConfig covers codex.approval_policy: absent or "never"
+// draws no diagnostic, and any other value draws an error-severity
+// diagnostic checked "codex.approval_policy.interactive".
+func TestValidateConfig(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		passthrough   map[string]any
+		wantDiagCount int
+		wantCheck     string
+	}{
+		{
+			name:          "absent approval_policy draws no diagnostic",
+			passthrough:   map[string]any{},
+			wantDiagCount: 0,
+		},
+		{
+			name:          `approval_policy "never" draws no diagnostic`,
+			passthrough:   map[string]any{"approval_policy": "never"},
+			wantDiagCount: 0,
+		},
+		{
+			name:          `approval_policy "untrusted" draws an error`,
+			passthrough:   map[string]any{"approval_policy": "untrusted"},
+			wantDiagCount: 1,
+			wantCheck:     "codex.approval_policy.interactive",
+		},
+		{
+			name:          `approval_policy "on-request" draws an error`,
+			passthrough:   map[string]any{"approval_policy": "on-request"},
+			wantDiagCount: 1,
+			wantCheck:     "codex.approval_policy.interactive",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := validateConfig(registry.AgentConfigFields{Kind: "codex", Passthrough: tt.passthrough})
+
+			if len(got) != tt.wantDiagCount {
+				t.Fatalf("validateConfig(%v) returned %d diagnostics, want %d: %+v", tt.passthrough, len(got), tt.wantDiagCount, got)
+			}
+			if tt.wantDiagCount == 0 {
+				return
+			}
+			if got[0].Severity != "error" {
+				t.Errorf("validateConfig(%v)[0].Severity = %q, want %q", tt.passthrough, got[0].Severity, "error")
+			}
+			if got[0].Check != tt.wantCheck {
+				t.Errorf("validateConfig(%v)[0].Check = %q, want %q", tt.passthrough, got[0].Check, tt.wantCheck)
+			}
+			if got[0].Message == "" {
+				t.Errorf("validateConfig(%v)[0].Message = \"\", want non-empty", tt.passthrough)
+			}
+		})
+	}
+}

--- a/internal/agent/copilot/command_test.go
+++ b/internal/agent/copilot/command_test.go
@@ -393,3 +393,38 @@ func TestBuildArgs_AlwaysPresent(t *testing.T) {
 	assertHasArgPair(t, got, "-p", "test prompt")
 	assertHasArgPair(t, got, "--output-format", "json")
 }
+
+// TestBuildArgs_LaunchPosture asserts the launch posture the refusal path
+// assumes: --no-ask-user closes the human-question path on every
+// invocation, and --allow-all is present only when no tool-scoping key is
+// configured, since any of the four tool-scoping keys displaces it.
+func TestBuildArgs_LaunchPosture(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		pt           passthroughConfig
+		wantAllowAll bool
+	}{
+		{name: "no tool scoping configured", pt: passthroughConfig{}, wantAllowAll: true},
+		{name: "allowed_tools configured", pt: passthroughConfig{AllowedTools: "bash"}, wantAllowAll: false},
+		{name: "denied_tools configured", pt: passthroughConfig{DeniedTools: "bash"}, wantAllowAll: false},
+		{name: "available_tools configured", pt: passthroughConfig{AvailableTools: "bash"}, wantAllowAll: false},
+		{name: "excluded_tools configured", pt: passthroughConfig{ExcludedTools: "bash"}, wantAllowAll: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := buildArgs(&sessionState{}, 1, "p", tt.pt)
+
+			assertHasFlag(t, got, "--no-ask-user")
+			if tt.wantAllowAll {
+				assertHasFlag(t, got, "--allow-all")
+			} else {
+				assertNoFlag(t, got, "--allow-all")
+			}
+		})
+	}
+}

--- a/internal/agent/copilot/copilot.go
+++ b/internal/agent/copilot/copilot.go
@@ -32,9 +32,15 @@ import (
 // session-state path.
 var sessionIDPattern = regexp.MustCompile(`^[A-Za-z0-9._-]+$`)
 
+// copilotToolDeniedCode is the tool.execution_complete error code the CLI
+// reports when its own non-interactive permission policy refuses a tool
+// call and the session continues.
+const copilotToolDeniedCode = "denied"
+
 func init() {
 	registry.Agents.RegisterWithMeta("copilot-cli", NewCopilotAdapter, registry.AgentMeta{
-		RequiresCommand: true,
+		RequiresCommand:     true,
+		ValidateAgentConfig: validateConfig,
 	})
 }
 
@@ -329,6 +335,16 @@ func (a *CopilotAdapter) StartSession(ctx context.Context, params domain.StartSe
 							ToolDurationMS: durationMS,
 							ToolError:      !toolData.Success,
 						})
+
+						// The CLI's own non-interactive permission policy
+						// denied this tool call and the session continues;
+						// --no-ask-user closes the human-question path, so
+						// every recognized request here is a permission
+						// request with no reply channel.
+						if !toolData.Success && toolData.Error != nil && toolData.Error.Code == copilotToolDeniedCode {
+							posture := agentcore.DecideHumanRequest(agentcore.ClassPermission, false, agentcore.AnswerRuntimeRefused)
+							agentcore.EmitNotification(emit, posture.Notice)
+						}
 					}
 				}
 

--- a/internal/agent/copilot/copilot_test.go
+++ b/internal/agent/copilot/copilot_test.go
@@ -776,6 +776,47 @@ func TestRunTurn_ToolUseEvents(t *testing.T) {
 	}
 }
 
+// TestRunTurn_ToolDeniedContinuesTurn drives a tool.execution_complete
+// event whose error.code is "denied", the CLI's own non-interactive
+// permission policy refusing a tool call and continuing the session. With
+// --no-ask-user closing the human-question path unconditionally, every
+// recognized request here is a permission request with no reply channel,
+// so the turn must continue rather than end.
+func TestRunTurn_ToolDeniedContinuesTurn(t *testing.T) {
+	// t.Setenv is incompatible with t.Parallel.
+	t.Setenv("GH_TOKEN", "test-token-for-unit-test")
+
+	const deniedJSONL = `{"type":"tool.execution_complete","data":{"toolCallId":"tc-1","toolName":"bash","success":false,"error":{"code":"denied","message":"denied by policy"}}}
+{"type":"result","timestamp":"2026-03-30T22:19:28.097Z","sessionId":"dd112233-4455-6677-8899-aabbccddeeff","exitCode":0,"usage":{"premiumRequests":0,"totalApiDurationMs":0,"sessionDurationMs":0}}`
+
+	adapter, session := newTestSession(t, t.TempDir())
+	state := session.Internal.(*sessionState)
+	state.target.Command = fakeCopilotBinaryWithOutput(t, deniedJSONL, 0)
+
+	var events []domain.AgentEvent
+	result, err := adapter.RunTurn(context.Background(), session, domain.RunTurnParams{
+		OnEvent: func(e domain.AgentEvent) { events = append(events, e) },
+	})
+	if err != nil {
+		t.Fatalf("RunTurn() error = %v", err)
+	}
+	if result.ExitReason != domain.EventTurnCompleted {
+		t.Errorf("ExitReason = %q, want %q (turn must continue past the runtime's own refusal)", result.ExitReason, domain.EventTurnCompleted)
+	}
+
+	wantNotice := agentcore.DecideHumanRequest(agentcore.ClassPermission, false, agentcore.AnswerRuntimeRefused).Notice
+	var found bool
+	for _, ev := range events {
+		if ev.Type == domain.EventNotification && ev.Message == wantNotice {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("no EventNotification with Message = %q found among events %v", wantNotice, events)
+	}
+}
+
 func TestRunTurn_NonZeroResultExitCode(t *testing.T) {
 	// t.Setenv is incompatible with t.Parallel.
 	t.Setenv("GH_TOKEN", "test-token-for-unit-test")

--- a/internal/agent/copilot/parse.go
+++ b/internal/agent/copilot/parse.go
@@ -57,14 +57,24 @@ type rawToolRequest struct {
 }
 
 type toolExecutionData struct {
-	ToolCallID    string          `json:"toolCallId"`
-	ToolName      string          `json:"toolName"`
-	Arguments     json.RawMessage `json:"arguments,omitempty"`
-	Model         string          `json:"model,omitempty"`
-	InteractionID string          `json:"interactionId,omitempty"`
-	Success       bool            `json:"success"`
-	Result        json.RawMessage `json:"result,omitempty"`
-	ToolTelemetry json.RawMessage `json:"toolTelemetry,omitempty"`
+	ToolCallID    string              `json:"toolCallId"`
+	ToolName      string              `json:"toolName"`
+	Arguments     json.RawMessage     `json:"arguments,omitempty"`
+	Model         string              `json:"model,omitempty"`
+	InteractionID string              `json:"interactionId,omitempty"`
+	Success       bool                `json:"success"`
+	Result        json.RawMessage     `json:"result,omitempty"`
+	Error         *toolExecutionError `json:"error,omitempty"`
+	ToolTelemetry json.RawMessage     `json:"toolTelemetry,omitempty"`
+}
+
+// toolExecutionError is the error payload a tool.execution_complete event
+// carries when Success is false. Code "denied" is the CLI's own
+// non-interactive permission policy refusing the tool call and continuing
+// the session; every other value is an unrelated execution failure.
+type toolExecutionError struct {
+	Message string `json:"message,omitempty"`
+	Code    string `json:"code,omitempty"`
 }
 
 type sessionInfoData struct {

--- a/internal/agent/copilot/validate.go
+++ b/internal/agent/copilot/validate.go
@@ -1,0 +1,34 @@
+package copilot
+
+import (
+	"github.com/sortie-ai/sortie/internal/registry"
+	"github.com/sortie-ai/sortie/internal/typeutil"
+)
+
+// validateConfig checks copilot-cli-specific configuration constraints and
+// returns diagnostics for the sortie validate pipeline. It does not
+// construct an adapter instance or launch a subprocess.
+//
+// A configured allowed_tools, denied_tools, available_tools, or
+// excluded_tools displaces the unconditional --allow-all buildArgs passes
+// otherwise. The CLI's own non-interactive permission policy denies and
+// continues past a tool call that scoping excludes, so the diagnostic is a
+// warning rather than an error: the configuration narrows what the agent
+// may do, but does not defeat the non-interactive launch posture.
+func validateConfig(fields registry.AgentConfigFields) []registry.ValidationDiag {
+	hasToolScoping := typeutil.StringFrom(fields.Passthrough, "allowed_tools") != "" ||
+		typeutil.StringFrom(fields.Passthrough, "denied_tools") != "" ||
+		typeutil.StringFrom(fields.Passthrough, "available_tools") != "" ||
+		typeutil.StringFrom(fields.Passthrough, "excluded_tools") != ""
+	if !hasToolScoping {
+		return nil
+	}
+
+	return []registry.ValidationDiag{{
+		Severity: "warning",
+		Check:    "copilot-cli.tool_scoping.interactive",
+		Message: "copilot-cli tool scoping (allowed_tools, denied_tools, available_tools, or excluded_tools) " +
+			"displaces --allow-all; a tool call the scoping excludes is denied and the run continues, " +
+			"rather than being auto-approved",
+	}}
+}

--- a/internal/agent/copilot/validate_test.go
+++ b/internal/agent/copilot/validate_test.go
@@ -1,0 +1,73 @@
+package copilot
+
+import (
+	"testing"
+
+	"github.com/sortie-ai/sortie/internal/registry"
+)
+
+// TestValidateConfig covers copilot-cli's tool-scoping diagnostic: absent
+// tool scoping draws no diagnostic, and each of the four keys that
+// displace --allow-all (allowed_tools, denied_tools, available_tools,
+// excluded_tools) draws a warning-severity diagnostic on its own, since
+// the CLI's own non-interactive permission policy denies and continues
+// past a scoped-out tool call rather than stalling.
+func TestValidateConfig(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		passthrough   map[string]any
+		wantDiagCount int
+	}{
+		{
+			name:          "no tool scoping draws no diagnostic",
+			passthrough:   map[string]any{},
+			wantDiagCount: 0,
+		},
+		{
+			name:          "allowed_tools draws a warning",
+			passthrough:   map[string]any{"allowed_tools": "bash"},
+			wantDiagCount: 1,
+		},
+		{
+			name:          "denied_tools draws a warning",
+			passthrough:   map[string]any{"denied_tools": "bash"},
+			wantDiagCount: 1,
+		},
+		{
+			name:          "available_tools draws a warning",
+			passthrough:   map[string]any{"available_tools": "bash"},
+			wantDiagCount: 1,
+		},
+		{
+			name:          "excluded_tools draws a warning",
+			passthrough:   map[string]any{"excluded_tools": "bash"},
+			wantDiagCount: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := validateConfig(registry.AgentConfigFields{Kind: "copilot-cli", Passthrough: tt.passthrough})
+
+			if len(got) != tt.wantDiagCount {
+				t.Fatalf("validateConfig(%v) returned %d diagnostics, want %d: %+v", tt.passthrough, len(got), tt.wantDiagCount, got)
+			}
+			if tt.wantDiagCount == 0 {
+				return
+			}
+			if got[0].Severity != "warning" {
+				t.Errorf("validateConfig(%v)[0].Severity = %q, want %q", tt.passthrough, got[0].Severity, "warning")
+			}
+			if got[0].Check != "copilot-cli.tool_scoping.interactive" {
+				t.Errorf("validateConfig(%v)[0].Check = %q, want %q", tt.passthrough, got[0].Check, "copilot-cli.tool_scoping.interactive")
+			}
+			if got[0].Message == "" {
+				t.Errorf("validateConfig(%v)[0].Message = \"\", want non-empty", tt.passthrough)
+			}
+		})
+	}
+}

--- a/internal/agent/kiro/command.go
+++ b/internal/agent/kiro/command.go
@@ -30,24 +30,54 @@ type passthroughConfig struct {
 }
 
 // parsePassthroughConfig extracts Kiro-specific settings from the raw
-// config map. Missing or wrong-typed keys use zero-value defaults.
+// config map. Missing or wrong-typed keys use zero-value defaults, except
+// TrustAllTools, which [resolveTrustPosture] defaults to true rather than
+// false when the config sets neither trust key.
 //
 // It returns a non-nil error when both trust_all_tools is true and
 // trust_tools is non-empty, because the two trust modes are mutually
 // exclusive.
 func parsePassthroughConfig(config map[string]any) (passthroughConfig, error) {
+	trustAllTools, trustTools := resolveTrustPosture(config)
+
 	pt := passthroughConfig{
 		Model:         typeutil.StringFrom(config, "model"),
-		TrustAllTools: typeutil.BoolFrom(config, "trust_all_tools", false),
-		TrustTools:    slices.Clone(typeutil.ExtractStringSlice(config["trust_tools"])),
+		TrustAllTools: trustAllTools,
+		TrustTools:    trustTools,
 		Agent:         typeutil.StringFrom(config, "agent"),
 	}
 
 	if pt.TrustAllTools && len(pt.TrustTools) > 0 {
-		return passthroughConfig{}, fmt.Errorf("trust_all_tools and trust_tools are mutually exclusive")
+		return passthroughConfig{}, fmt.Errorf("%s", trustToolsConflictMessage)
 	}
 
 	return pt, nil
+}
+
+// resolveTrustPosture computes the effective trust_all_tools value and the
+// trust_tools allowlist from the raw config map. [validateConfig] calls it
+// too, so the offline verdict and the constructor read the same effective
+// posture.
+//
+// trust_all_tools resolves to true when the config sets neither
+// trust_all_tools nor trust_tools: kiro-cli's behavior on an untrusted tool
+// under --no-interactive is unestablished (see "Untrusted-tool behavior"
+// in docs/kiro-adapter-notes.md), and the conservative default trusts
+// every tool rather than risk a wait for an approval that never arrives.
+// Once either key is set explicitly, including an explicit false or an
+// empty trust_tools list, the configured value is used unmodified.
+func resolveTrustPosture(config map[string]any) (trustAllTools bool, trustTools []string) {
+	_, trustAllToolsSet := config["trust_all_tools"]
+	_, trustToolsSet := config["trust_tools"]
+
+	trustAllTools = typeutil.BoolFrom(config, "trust_all_tools", false)
+	trustTools = slices.Clone(typeutil.ExtractStringSlice(config["trust_tools"]))
+
+	if !trustAllToolsSet && !trustToolsSet {
+		trustAllTools = true
+	}
+
+	return trustAllTools, trustTools
 }
 
 // buildArgs constructs the CLI argument slice for one headless Kiro turn.

--- a/internal/agent/kiro/command_test.go
+++ b/internal/agent/kiro/command_test.go
@@ -126,14 +126,14 @@ func TestParsePassthroughConfig_Fields(t *testing.T) {
 		want   passthroughConfig
 	}{
 		{
-			name:   "empty config yields zero-value defaults",
+			name:   "empty config defaults trust_all_tools to true",
 			config: map[string]any{},
-			want:   passthroughConfig{},
+			want:   passthroughConfig{TrustAllTools: true},
 		},
 		{
-			name:   "nil config yields zero-value defaults",
+			name:   "nil config defaults trust_all_tools to true",
 			config: nil,
-			want:   passthroughConfig{},
+			want:   passthroughConfig{TrustAllTools: true},
 		},
 		{
 			name: "allowlist fields extracted",
@@ -156,12 +156,12 @@ func TestParsePassthroughConfig_Fields(t *testing.T) {
 		{
 			name:   "only model set",
 			config: map[string]any{"model": "claude-opus-4.7"},
-			want:   passthroughConfig{Model: "claude-opus-4.7"},
+			want:   passthroughConfig{Model: "claude-opus-4.7", TrustAllTools: true},
 		},
 		{
 			name:   "wrong-typed model takes zero-value default",
 			config: map[string]any{"model": 42},
-			want:   passthroughConfig{},
+			want:   passthroughConfig{TrustAllTools: true},
 		},
 		{
 			name:   "wrong-typed trust_all_tools takes false default",
@@ -181,7 +181,7 @@ func TestParsePassthroughConfig_Fields(t *testing.T) {
 		{
 			name:   "wrong-typed agent takes zero-value default",
 			config: map[string]any{"agent": true},
-			want:   passthroughConfig{},
+			want:   passthroughConfig{TrustAllTools: true},
 		},
 	}
 
@@ -345,6 +345,39 @@ func TestBuildArgs_ResumeFollowsState(t *testing.T) {
 		args := buildArgs(&sessionState{resumeRequested: false}, 5, "p", passthroughConfig{})
 		assertNoToken(t, args, "--resume")
 	})
+}
+
+// TestBuildArgs_EmptyConfigDefaultsToTrustAllTools pins the trust posture
+// default: an empty or nil passthrough config, carried through
+// parsePassthroughConfig into buildArgs, must emit --trust-all-tools
+// rather than the empty-allowlist --trust-tools= a prior default would
+// have produced.
+func TestBuildArgs_EmptyConfigDefaultsToTrustAllTools(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		config map[string]any
+	}{
+		{name: "empty config", config: map[string]any{}},
+		{name: "nil config", config: nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			pt, err := parsePassthroughConfig(tt.config)
+			if err != nil {
+				t.Fatalf("parsePassthroughConfig(%v) error = %v, want nil", tt.config, err)
+			}
+
+			args := buildArgs(&sessionState{}, 1, "p", pt)
+
+			assertHasToken(t, args, "--trust-all-tools")
+			assertNoToken(t, args, "--trust-tools=")
+		})
+	}
 }
 
 func TestKiroRegistered(t *testing.T) {

--- a/internal/agent/kiro/kiro.go
+++ b/internal/agent/kiro/kiro.go
@@ -40,7 +40,8 @@ import (
 
 func init() {
 	registry.Agents.RegisterWithMeta("kiro", NewKiroAdapter, registry.AgentMeta{
-		RequiresCommand: true,
+		RequiresCommand:     true,
+		ValidateAgentConfig: validateConfig,
 	})
 }
 

--- a/internal/agent/kiro/kiro_test.go
+++ b/internal/agent/kiro/kiro_test.go
@@ -16,7 +16,36 @@ import (
 	"github.com/sortie-ai/sortie/internal/agent/agenttest"
 	"github.com/sortie-ai/sortie/internal/agent/agenttest/dispositiontest"
 	"github.com/sortie-ai/sortie/internal/domain"
+	"github.com/sortie-ai/sortie/internal/registry"
 )
+
+// TestNewKiroAdapter_TrustToolsConflictMatchesValidateConfig asserts that
+// NewKiroAdapter's constructor refusal and validateConfig's offline
+// diagnostic report byte-identical text for the same conflicting
+// configuration, so the two surfaces can never disagree.
+func TestNewKiroAdapter_TrustToolsConflictMatchesValidateConfig(t *testing.T) {
+	t.Parallel()
+
+	config := map[string]any{
+		"trust_all_tools": true,
+		"trust_tools":     []any{"read", "grep"},
+	}
+
+	_, err := NewKiroAdapter(config)
+	if err == nil {
+		t.Fatal("NewKiroAdapter() error = nil, want trust_tools conflict error")
+	}
+
+	diags := validateConfig(registry.AgentConfigFields{Kind: "kiro", Passthrough: config})
+	diag := hasCheck(diags, "kiro.trust_tools.conflict")
+	if diag == nil {
+		t.Fatalf("validateConfig() missing check %q; got %+v", "kiro.trust_tools.conflict", diags)
+	}
+
+	if err.Error() != diag.Message {
+		t.Errorf("NewKiroAdapter() error = %q, validateConfig() diagnostic message = %q, want identical", err.Error(), diag.Message)
+	}
+}
 
 // fakeChatScript is the body of a fake kiro-cli that answers the StartSession
 // "whoami" canary and, for any other invocation (the "chat" turn), replays a

--- a/internal/agent/kiro/validate.go
+++ b/internal/agent/kiro/validate.go
@@ -1,0 +1,68 @@
+package kiro
+
+import (
+	"github.com/sortie-ai/sortie/internal/registry"
+	"github.com/sortie-ai/sortie/internal/typeutil"
+)
+
+// trustToolsConflictMessage is the byte-identical message both
+// [validateConfig] and [NewKiroAdapter] report when trust_all_tools and a
+// non-empty trust_tools are both configured.
+const trustToolsConflictMessage = "trust_all_tools and trust_tools are mutually exclusive"
+
+// trustToolsUntrustedMessage is the diagnostic [validateTrustToolsUntrusted]
+// reports for a configuration whose resolved trust posture falls short of
+// full trust. kiro-cli's behavior on an untrusted tool under
+// --no-interactive is unestablished, and the conservative reading assumes
+// it waits for an approval this unattended run cannot give.
+const trustToolsUntrustedMessage = "trust_all_tools does not resolve to true, and kiro-cli's behavior on an untrusted tool under --no-interactive is unestablished; the conservative assumption is that it waits for an approval this unattended run cannot give, so trust_all_tools: true (or leaving trust_all_tools and trust_tools both unset) is required"
+
+// validateConfig checks kiro-specific configuration constraints and
+// returns diagnostics for the sortie validate pipeline. It does not
+// construct an adapter instance or launch a subprocess. [NewKiroAdapter]
+// calls this same function so the constructor's refusal and the offline
+// verdict can never disagree.
+func validateConfig(fields registry.AgentConfigFields) []registry.ValidationDiag {
+	var diags []registry.ValidationDiag
+
+	diags = append(diags, validateTrustToolsConflict(fields.Passthrough)...)
+	diags = append(diags, validateTrustToolsUntrusted(fields.Passthrough)...)
+
+	return diags
+}
+
+// validateTrustToolsConflict reports an error when trust_all_tools is
+// true and trust_tools is also non-empty, mirroring the check
+// [parsePassthroughConfig] used to enforce inline at construction.
+func validateTrustToolsConflict(passthrough map[string]any) []registry.ValidationDiag {
+	trustAllTools, _ := passthrough["trust_all_tools"].(bool)
+	trustTools := typeutil.ExtractStringSlice(passthrough["trust_tools"])
+	if !trustAllTools || len(trustTools) == 0 {
+		return nil
+	}
+
+	return []registry.ValidationDiag{{
+		Severity: "error",
+		Check:    "kiro.trust_tools.conflict",
+		Message:  trustToolsConflictMessage,
+	}}
+}
+
+// validateTrustToolsUntrusted reports an error when the effective trust
+// posture, resolved the same way [resolveTrustPosture] resolves it for
+// [NewKiroAdapter], leaves any tool untrusted. The wait branch recorded in
+// docs/kiro-adapter-notes.md is assumed for kiro-cli's untrusted-tool
+// behavior, so any configuration that can still reach an untrusted tool
+// call is refused rather than accepted unexamined.
+func validateTrustToolsUntrusted(passthrough map[string]any) []registry.ValidationDiag {
+	trustAllTools, _ := resolveTrustPosture(passthrough)
+	if trustAllTools {
+		return nil
+	}
+
+	return []registry.ValidationDiag{{
+		Severity: "error",
+		Check:    "kiro.trust_tools.untrusted",
+		Message:  trustToolsUntrustedMessage,
+	}}
+}

--- a/internal/agent/kiro/validate_test.go
+++ b/internal/agent/kiro/validate_test.go
@@ -1,0 +1,178 @@
+package kiro
+
+import (
+	"testing"
+
+	"github.com/sortie-ai/sortie/internal/registry"
+)
+
+// hasCheck reports whether diags carries a diagnostic with the given
+// check name.
+func hasCheck(diags []registry.ValidationDiag, check string) *registry.ValidationDiag {
+	for i := range diags {
+		if diags[i].Check == check {
+			return &diags[i]
+		}
+	}
+	return nil
+}
+
+// TestValidateConfig covers the trust_tools conflict: an error-severity
+// diagnostic checked "kiro.trust_tools.conflict" when trust_all_tools is
+// true and trust_tools is also non-empty, none in every other case.
+func TestValidateConfig(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		passthrough map[string]any
+		wantErr     bool
+	}{
+		{
+			name:        "trust_all_tools with non-empty trust_tools conflicts",
+			passthrough: map[string]any{"trust_all_tools": true, "trust_tools": []any{"read", "grep"}},
+			wantErr:     true,
+		},
+		{
+			name:        "trust_all_tools alone is valid",
+			passthrough: map[string]any{"trust_all_tools": true},
+			wantErr:     false,
+		},
+		{
+			name:        "trust_tools alone is valid",
+			passthrough: map[string]any{"trust_tools": []any{"read", "grep"}},
+			wantErr:     false,
+		},
+		{
+			name:        "trust_all_tools with empty trust_tools is valid",
+			passthrough: map[string]any{"trust_all_tools": true, "trust_tools": []any{}},
+			wantErr:     false,
+		},
+		{
+			name:        "neither key set is valid",
+			passthrough: map[string]any{},
+			wantErr:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := validateConfig(registry.AgentConfigFields{Kind: "kiro", Passthrough: tt.passthrough})
+
+			diag := hasCheck(got, "kiro.trust_tools.conflict")
+			if tt.wantErr && diag == nil {
+				t.Fatalf("validateConfig(%v) missing check %q; got %+v", tt.passthrough, "kiro.trust_tools.conflict", got)
+			}
+			if !tt.wantErr && diag != nil {
+				t.Fatalf("validateConfig(%v) has unexpected check %q; got %+v", tt.passthrough, "kiro.trust_tools.conflict", got)
+			}
+			if diag != nil && diag.Severity != "error" {
+				t.Errorf("validateConfig(%v) check %q Severity = %q, want %q", tt.passthrough, diag.Check, diag.Severity, "error")
+			}
+		})
+	}
+}
+
+// TestValidateConfig_TrustToolsUntrusted covers the kiro.trust_tools.untrusted
+// check: an error-severity diagnostic fires whenever the resolved trust
+// posture ([resolveTrustPosture]) falls short of full trust, and none fires
+// once it resolves to full trust, including the empty-config and nil-config
+// default. kiro-cli's actual behavior on an untrusted tool could not be
+// observed in this environment, so the check assumes the conservative
+// wait-for-approval reading documented in docs/kiro-adapter-notes.md's
+// "Untrusted-tool behavior under --no-interactive" section.
+func TestValidateConfig_TrustToolsUntrusted(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		passthrough map[string]any
+		wantErr     bool
+	}{
+		{
+			name:        "non-empty trust_tools without trust_all_tools is untrusted",
+			passthrough: map[string]any{"trust_tools": []any{"read", "grep"}},
+			wantErr:     true,
+		},
+		{
+			name:        "trust_all_tools explicitly false is untrusted",
+			passthrough: map[string]any{"trust_all_tools": false},
+			wantErr:     true,
+		},
+		{
+			name:        "trust_all_tools true is fully trusted",
+			passthrough: map[string]any{"trust_all_tools": true},
+			wantErr:     false,
+		},
+		{
+			name:        "empty config defaults to full trust",
+			passthrough: map[string]any{},
+			wantErr:     false,
+		},
+		{
+			name:        "nil config defaults to full trust",
+			passthrough: nil,
+			wantErr:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := validateConfig(registry.AgentConfigFields{Kind: "kiro", Passthrough: tt.passthrough})
+
+			diag := hasCheck(got, "kiro.trust_tools.untrusted")
+			if tt.wantErr && diag == nil {
+				t.Fatalf("validateConfig(%v) missing check %q; got %+v", tt.passthrough, "kiro.trust_tools.untrusted", got)
+			}
+			if !tt.wantErr && diag != nil {
+				t.Fatalf("validateConfig(%v) has unexpected check %q; got %+v", tt.passthrough, "kiro.trust_tools.untrusted", got)
+			}
+			if diag != nil && diag.Severity != "error" {
+				t.Errorf("validateConfig(%v) check %q Severity = %q, want %q", tt.passthrough, diag.Check, diag.Severity, "error")
+			}
+		})
+	}
+}
+
+// TestValidateConfig_ConflictAndUntrustedCoexist asserts that
+// validateTrustToolsConflict and validateTrustToolsUntrusted are
+// independent checks, each still producible after the other was added: a
+// conflicting configuration reports kiro.trust_tools.conflict without
+// kiro.trust_tools.untrusted (the conflicting posture resolves to full
+// trust), and an untrusted configuration reports
+// kiro.trust_tools.untrusted without kiro.trust_tools.conflict.
+func TestValidateConfig_ConflictAndUntrustedCoexist(t *testing.T) {
+	t.Parallel()
+
+	t.Run("conflict fires without untrusted", func(t *testing.T) {
+		t.Parallel()
+
+		passthrough := map[string]any{"trust_all_tools": true, "trust_tools": []any{"read"}}
+		got := validateConfig(registry.AgentConfigFields{Kind: "kiro", Passthrough: passthrough})
+
+		if hasCheck(got, "kiro.trust_tools.conflict") == nil {
+			t.Errorf("validateConfig(%v) missing check %q; got %+v", passthrough, "kiro.trust_tools.conflict", got)
+		}
+		if hasCheck(got, "kiro.trust_tools.untrusted") != nil {
+			t.Errorf("validateConfig(%v) has unexpected check %q; got %+v", passthrough, "kiro.trust_tools.untrusted", got)
+		}
+	})
+
+	t.Run("untrusted fires without conflict", func(t *testing.T) {
+		t.Parallel()
+
+		passthrough := map[string]any{"trust_tools": []any{"read"}}
+		got := validateConfig(registry.AgentConfigFields{Kind: "kiro", Passthrough: passthrough})
+
+		if hasCheck(got, "kiro.trust_tools.untrusted") == nil {
+			t.Errorf("validateConfig(%v) missing check %q; got %+v", passthrough, "kiro.trust_tools.untrusted", got)
+		}
+		if hasCheck(got, "kiro.trust_tools.conflict") != nil {
+			t.Errorf("validateConfig(%v) has unexpected check %q; got %+v", passthrough, "kiro.trust_tools.conflict", got)
+		}
+	})
+}

--- a/internal/agent/mock/mock.go
+++ b/internal/agent/mock/mock.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/sortie-ai/sortie/internal/agent/agentcore"
 	"github.com/sortie-ai/sortie/internal/domain"
 	"github.com/sortie-ai/sortie/internal/registry"
 )
@@ -255,6 +256,19 @@ func (m *MockAdapter) RunTurn(ctx context.Context, session domain.Session, param
 		})
 	}
 
+	if outcome == "input_required" {
+		ev := agentcore.TurnEvidence{
+			Terminal:        agentcore.TerminalHumanInputRequired,
+			TerminalMessage: fmt.Sprintf("mock turn %s", outcome),
+		}
+		meta := agentcore.TurnMeta{
+			SessionID:     session.ID,
+			Usage:         usage,
+			UsageMeasured: m.reportTokenUsage,
+		}
+		return agentcore.FinalizeTurn(params.OnEvent, nil, ev, meta)
+	}
+
 	exitReason, errKind, isError := outcomeToEvent(outcome)
 	params.OnEvent(domain.AgentEvent{
 		Type:      exitReason,
@@ -314,8 +328,6 @@ func outcomeToEvent(outcome string) (domain.AgentEventType, domain.AgentErrorKin
 		return domain.EventTurnCancelled, domain.ErrTurnCancelled, true
 	case "error":
 		return domain.EventTurnEndedWithError, domain.ErrPortExit, true
-	case "input_required":
-		return domain.EventTurnInputRequired, domain.ErrTurnInputRequired, true
 	default:
 		return domain.EventTurnCompleted, "", false
 	}

--- a/internal/agent/mock/mock_test.go
+++ b/internal/agent/mock/mock_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/sortie-ai/sortie/internal/agent/agentcore"
 	"github.com/sortie-ai/sortie/internal/agent/agenttest"
 	"github.com/sortie-ai/sortie/internal/domain"
 	"github.com/sortie-ai/sortie/internal/registry"
@@ -532,6 +533,52 @@ func TestRunTurn_InputRequired(t *testing.T) {
 	last := (*events)[len(*events)-1]
 	if last.Type != domain.EventTurnInputRequired {
 		t.Errorf("last event = %q, want %q", last.Type, domain.EventTurnInputRequired)
+	}
+}
+
+// TestRunTurn_InputRequired_MatchesSharedLayer asserts that the
+// "input_required" outcome's emitted event and returned *domain.AgentError
+// are exactly the values agentcore.FinalizeTurn would produce for any
+// other adapter reporting agentcore.TerminalHumanInputRequired with the
+// same message: same ExitReason, same ErrorKind, and a message built from
+// the shared stem, not a value the mock constructs on its own.
+func TestRunTurn_InputRequired_MatchesSharedLayer(t *testing.T) {
+	t.Parallel()
+
+	adapter, _ := NewMockAdapter(map[string]any{
+		"turn_outcomes": []any{"input_required"},
+	})
+	sess := domain.Session{ID: "s"}
+	params := defaultParams()
+	events := collectEvents(&params)
+
+	result, err := adapter.RunTurn(context.Background(), sess, params)
+
+	wantDisposition := agentcore.DecideTurn(agentcore.TurnEvidence{
+		Terminal:        agentcore.TerminalHumanInputRequired,
+		TerminalMessage: "mock turn input_required",
+	})
+
+	var ae *domain.AgentError
+	if !errors.As(err, &ae) {
+		t.Fatalf("expected *AgentError, got %T: %v", err, err)
+	}
+	if ae.Kind != wantDisposition.ErrorKind {
+		t.Errorf("AgentError.Kind = %q, want %q (agentcore.DecideTurn's ErrorKind)", ae.Kind, wantDisposition.ErrorKind)
+	}
+	if ae.Message != wantDisposition.ErrorMessage {
+		t.Errorf("AgentError.Message = %q, want %q (agentcore.DecideTurn's ErrorMessage)", ae.Message, wantDisposition.ErrorMessage)
+	}
+	if result.ExitReason != wantDisposition.ExitReason {
+		t.Errorf("TurnResult.ExitReason = %q, want %q (agentcore.DecideTurn's ExitReason)", result.ExitReason, wantDisposition.ExitReason)
+	}
+
+	last := (*events)[len(*events)-1]
+	if last.Type != wantDisposition.ExitReason {
+		t.Errorf("last event Type = %q, want %q", last.Type, wantDisposition.ExitReason)
+	}
+	if last.Message != wantDisposition.EventMessage {
+		t.Errorf("last event Message = %q, want %q (agentcore.DecideTurn's EventMessage)", last.Message, wantDisposition.EventMessage)
 	}
 }
 

--- a/internal/agent/opencode/command.go
+++ b/internal/agent/opencode/command.go
@@ -65,20 +65,8 @@ func parsePassthroughConfig(config map[string]any) (passthroughConfig, error) {
 		DeniedTools:              slices.Clone(typeutil.ExtractStringSlice(config["denied_tools"])),
 	}
 
-	allowed := make(map[string]struct{}, len(pt.AllowedTools))
-	for _, key := range pt.AllowedTools {
-		allowed[key] = struct{}{}
-	}
-
-	var conflicts []string
-	for _, key := range pt.DeniedTools {
-		if _, ok := allowed[key]; ok {
-			conflicts = append(conflicts, key)
-		}
-	}
-	if len(conflicts) > 0 {
-		slices.Sort(conflicts)
-		return passthroughConfig{}, fmt.Errorf("allowed_tools and denied_tools overlap: %s", strings.Join(conflicts, ", "))
+	if message := overlapMessage(pt.AllowedTools, pt.DeniedTools); message != "" {
+		return passthroughConfig{}, fmt.Errorf("%s", message)
 	}
 
 	return pt, nil

--- a/internal/agent/opencode/command_test.go
+++ b/internal/agent/opencode/command_test.go
@@ -296,6 +296,26 @@ func TestBuildRunArgs(t *testing.T) {
 	}
 }
 
+// TestBuildRunArgs_DefaultConfigurationSkipsPermissions asserts that the
+// full configuration path, from an empty WORKFLOW.md opencode sub-object
+// through buildRunArgs, passes --dangerously-skip-permissions. This is the
+// launch posture the finalizeExitedTurn refusal path assumes: no reply
+// channel, so a recognized permission warning always reads
+// AnswerRuntimeRefused.
+func TestBuildRunArgs_DefaultConfigurationSkipsPermissions(t *testing.T) {
+	t.Parallel()
+
+	pt, err := parsePassthroughConfig(map[string]any{})
+	if err != nil {
+		t.Fatalf("parsePassthroughConfig(map[string]any{}) error = %v", err)
+	}
+
+	state := newTestSessionState("/tmp/workspace", "")
+	args := buildRunArgs(state, "work", pt)
+
+	assertHasFlag(t, args, "--dangerously-skip-permissions")
+}
+
 func TestBuildRunEnv(t *testing.T) {
 	t.Parallel()
 

--- a/internal/agent/opencode/opencode.go
+++ b/internal/agent/opencode/opencode.go
@@ -32,7 +32,8 @@ import (
 
 func init() {
 	registry.Agents.RegisterWithMeta("opencode", NewOpenCodeAdapter, registry.AgentMeta{
-		RequiresCommand: true,
+		RequiresCommand:     true,
+		ValidateAgentConfig: validateConfig,
 	})
 }
 
@@ -308,15 +309,11 @@ func (a *OpenCodeAdapter) RunTurn(ctx context.Context, session domain.Session, p
 				}
 
 				plainText := typeutil.TruncateRunes(parsed.PlainText, 500)
-				if isPermissionWarning(parsed.PlainText) {
-					agentcore.EmitNotification(emit, plainText)
-				} else {
-					emit(domain.AgentEvent{
-						Type:      domain.EventMalformed,
-						Timestamp: time.Now().UTC(),
-						Message:   plainText,
-					})
-				}
+				emit(domain.AgentEvent{
+					Type:      domain.EventMalformed,
+					Timestamp: time.Now().UTC(),
+					Message:   plainText,
+				})
 				continue
 			}
 
@@ -496,6 +493,13 @@ func (a *OpenCodeAdapter) EventStream() <-chan domain.AgentEvent {
 	return nil
 }
 
+// finalizeExitedTurn builds and emits the turn's terminal disposition once
+// the subprocess has exited. It also scans the turn's stderr lines for a
+// denied-permission warning, which the runtime writes to stderr rather than
+// stdout; recognizing it here rather than mid-turn means the corresponding
+// notification arrives at turn end rather than as it happens, and it does
+// not reset the read timer the way a stdout line does, neither of which is
+// a regression because the warning has never actually reached stdout.
 func (a *OpenCodeAdapter) finalizeExitedTurn(ctx context.Context, state *sessionState, runtime *turnRuntime, emit func(domain.AgentEvent), exit waitResult) (domain.TurnResult, error) {
 	window := int64(0)
 	if !state.createdSession {
@@ -524,6 +528,13 @@ func (a *OpenCodeAdapter) finalizeExitedTurn(ctx context.Context, state *session
 
 	clearActive(state, runtime)
 	stderrLines := runtime.stderrCollector.Lines()
+	for _, line := range stderrLines {
+		if !isPermissionWarning(line) {
+			continue
+		}
+		posture := agentcore.DecideHumanRequest(agentcore.ClassPermission, false, agentcore.AnswerRuntimeRefused)
+		agentcore.EmitNotification(emit, posture.Notice)
+	}
 	sessionID := state.currentSessionID()
 
 	// Work reflects this turn's own parsed parts, not the run-cumulative
@@ -664,11 +675,14 @@ func startOpenCodeReader(stdout io.Reader, runtime *turnRuntime) {
 
 func startWait(runtime *turnRuntime, cmd *exec.Cmd) {
 	go func() {
-		// Wait for the reader goroutine to finish before calling
-		// cmd.Wait(). cmd.Wait() closes the stdout pipe read end, which
-		// races with the scanner in startOpenCodeReader if called before
-		// the reader has drained all buffered output.
+		// Wait for both reader goroutines to finish before calling
+		// cmd.Wait(). cmd.Wait() closes the stdout and stderr pipe read
+		// ends after reaping the process, which races with a scanner
+		// still reading buffered output on either stream if called
+		// first; for stderr this can silently drop a permission-refusal
+		// warning that finalizeExitedTurn depends on.
 		<-runtime.readerDone
+		<-runtime.stderrCollector.Done()
 
 		waitErr := cmd.Wait()
 		procutil.KillProcessGroup(cmd.Process.Pid) //nolint:errcheck,gosec // best-effort cleanup of surviving group members

--- a/internal/agent/opencode/opencode_test.go
+++ b/internal/agent/opencode/opencode_test.go
@@ -3,10 +3,14 @@
 package opencode
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
+	"io"
+	"log/slog"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -15,7 +19,9 @@ import (
 	"github.com/sortie-ai/sortie/internal/agent/agentcore"
 	"github.com/sortie-ai/sortie/internal/agent/agenttest"
 	"github.com/sortie-ai/sortie/internal/agent/agenttest/dispositiontest"
+	"github.com/sortie-ai/sortie/internal/agent/procutil"
 	"github.com/sortie-ai/sortie/internal/domain"
+	"github.com/sortie-ai/sortie/internal/registry"
 )
 
 // writeOpenCodeScript writes an executable shell script named fake-opencode
@@ -59,6 +65,40 @@ cat '` + runPath + `'`
 	return writeOpenCodeScript(t, dir, body)
 }
 
+// splitPermissionWarningFixture returns the two lines of
+// testdata/permission_warning_then_error.txt: the plain-text permission
+// warning the opencode runtime writes to stderr, and the tool_use JSON
+// envelope it writes to stdout.
+func splitPermissionWarningFixture(t *testing.T) (warningLine, stdoutLine string) {
+	t.Helper()
+	lines := bytes.Split(bytes.TrimRight(loadFixture(t, "permission_warning_then_error.txt"), "\n"), []byte("\n"))
+	if len(lines) != 2 {
+		t.Fatalf("permission_warning_then_error.txt has %d lines, want 2", len(lines))
+	}
+	return string(lines[0]), string(lines[1])
+}
+
+// writeFixtureFile writes content to name inside dir, fataling on error.
+func writeFixtureFile(t *testing.T, dir, name, content string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("WriteFile(%q): %v", path, err)
+	}
+	return path
+}
+
+// hasNotification reports whether events contains an EventNotification
+// with exactly message.
+func hasNotification(events []domain.AgentEvent, message string) bool {
+	for _, e := range events {
+		if e.Type == domain.EventNotification && e.Message == message {
+			return true
+		}
+	}
+	return false
+}
+
 // collectEvents runs a turn and collects all emitted events.
 func collectEvents(t *testing.T, a domain.AgentAdapter, session domain.Session, prompt string) ([]domain.AgentEvent, domain.TurnResult, error) {
 	t.Helper()
@@ -84,6 +124,34 @@ func TestNewOpenCodeAdapter(t *testing.T) {
 	}
 	if _, ok := a.(*OpenCodeAdapter); !ok {
 		t.Errorf("adapter type = %T, want *OpenCodeAdapter", a)
+	}
+}
+
+// TestNewOpenCodeAdapter_OverlapErrorMatchesValidateConfig asserts that
+// NewOpenCodeAdapter's constructor refusal and validateConfig's offline
+// diagnostic report byte-identical text for the same overlapping
+// configuration, so the two surfaces can never disagree.
+func TestNewOpenCodeAdapter_OverlapErrorMatchesValidateConfig(t *testing.T) {
+	t.Parallel()
+
+	config := map[string]any{
+		"allowed_tools": []any{"bash"},
+		"denied_tools":  []any{"bash"},
+	}
+
+	_, err := NewOpenCodeAdapter(config)
+	if err == nil {
+		t.Fatal("NewOpenCodeAdapter() error = nil, want overlap error")
+	}
+
+	diags := validateConfig(registry.AgentConfigFields{Kind: "opencode", Passthrough: config})
+	diag := hasCheck(diags, "opencode.allowed_tools.overlap")
+	if diag == nil {
+		t.Fatalf("validateConfig() missing check %q; got %+v", "opencode.allowed_tools.overlap", diags)
+	}
+
+	if err.Error() != diag.Message {
+		t.Errorf("NewOpenCodeAdapter() error = %q, validateConfig() diagnostic message = %q, want identical", err.Error(), diag.Message)
 	}
 }
 
@@ -1017,7 +1085,7 @@ func TestRunTurn_ActivityVisibilityForStallWatchdog(t *testing.T) {
 	script := writeOpenCodeScript(t, tmpDir, `case "$1" in
   export) echo '{"messages":[]}'; exit 0;;
 esac
-printf '! permission requested: external_directory (/etc/*); auto-rejecting\n'
+printf '! permission requested: external_directory (/etc/*); auto-rejecting\n' >&2
 printf '{"type":"step_start","timestamp":1000,"sessionID":"ses_visibility123","part":{"id":"p1","messageID":"m1","sessionID":"ses_visibility123","snapshot":"","type":"step-start"}}\n'
 printf '{"type":"text","timestamp":1001,"sessionID":"ses_visibility123","part":{"id":"p3","messageID":"m1","sessionID":"ses_visibility123","type":"text","text":"working on it","time":{"start":1001,"end":1001}}}\n'
 printf '{"type":"unknown_future_type","timestamp":1001,"sessionID":"ses_visibility123","data":"something"}\n'
@@ -1045,7 +1113,7 @@ printf '{"type":"step_finish","timestamp":1002,"sessionID":"ses_visibility123","
 		switch event.Type {
 		case domain.EventNotification:
 			switch {
-			case strings.HasPrefix(event.Message, "! permission requested:"):
+			case strings.HasPrefix(event.Message, "the agent runtime refused a permission request"):
 				sawPermissionWarning = true
 			case event.Message == "step started":
 				sawStepStarted = true
@@ -1087,6 +1155,98 @@ printf '{"type":"step_finish","timestamp":1002,"sessionID":"ses_visibility123","
 		ExitCode:     0,
 		Work:         agentcore.WorkPresent,
 	}, result, err)
+}
+
+// TestRunTurn_PermissionWarningRecognizedOnStderr drives the
+// permission_warning_then_error.txt fixture split across the two real
+// streams the opencode runtime uses: the denial warning on stderr, the
+// tool_use envelope alone on stdout. Previously both lines
+// arrived on stdout and the recognition branch that would have read the
+// warning there was dead code, so a fixture that did not distinguish the
+// streams let a test pass without exercising the refusal path at all. See
+// TestRunTurn_PermissionWarningOnStdoutIsNotRecognized for the negative
+// control this test alone cannot provide.
+func TestRunTurn_PermissionWarningRecognizedOnStderr(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	warningLine, stdoutLine := splitPermissionWarningFixture(t)
+
+	stdoutPath := writeFixtureFile(t, tmpDir, "stdout.jsonl", stdoutLine+"\n")
+	stderrPath := writeFixtureFile(t, tmpDir, "stderr.txt", warningLine+"\n")
+	exportPath := writeFixtureFile(t, tmpDir, "export.json", `{"messages":[]}`)
+
+	script := writeOpenCodeScript(t, tmpDir, `case "$1" in
+  export) cat '`+exportPath+`'; exit 0;;
+esac
+cat '`+stderrPath+`' >&2
+cat '`+stdoutPath+`'`)
+
+	a, _ := NewOpenCodeAdapter(map[string]any{})
+	session := mustStartSession(t, a, tmpDir, script)
+
+	events, result, err := collectEvents(t, a, session, "work")
+	if err != nil {
+		t.Fatalf("RunTurn() error = %v", err)
+	}
+	if result.ExitReason != domain.EventTurnCompleted {
+		t.Fatalf("ExitReason = %q, want %q", result.ExitReason, domain.EventTurnCompleted)
+	}
+
+	wantNotice := agentcore.DecideHumanRequest(agentcore.ClassPermission, false, agentcore.AnswerRuntimeRefused).Notice
+	if !hasNotification(events, wantNotice) {
+		t.Errorf("events = %v, want an EventNotification with Message %q for the stderr-delivered permission warning", events, wantNotice)
+	}
+}
+
+// TestRunTurn_PermissionWarningOnStdoutIsNotRecognized is the negative
+// control for TestRunTurn_PermissionWarningRecognizedOnStderr: it delivers
+// the same fixture's warning line on stdout instead of stderr, the shape
+// the fixture previously modeled, and asserts the permission
+// refusal notification is absent; the line is malformed input on stdout
+// instead, since the dead stdout-side filter was removed. Together
+// the two tests carry the guarantee that recognition fires on the stream
+// the runtime actually uses and nowhere else: this one fails if
+// recognition leaked back onto stdout or the fixture regressed to its old
+// single-stream shape, and its counterpart fails if isPermissionWarning
+// stopped firing on stderr at all.
+func TestRunTurn_PermissionWarningOnStdoutIsNotRecognized(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	warningLine, stdoutLine := splitPermissionWarningFixture(t)
+
+	stdoutPath := writeFixtureFile(t, tmpDir, "stdout.jsonl", warningLine+"\n"+stdoutLine+"\n")
+	exportPath := writeFixtureFile(t, tmpDir, "export.json", `{"messages":[]}`)
+
+	script := writeOpenCodeScript(t, tmpDir, `case "$1" in
+  export) cat '`+exportPath+`'; exit 0;;
+esac
+cat '`+stdoutPath+`'`)
+
+	a, _ := NewOpenCodeAdapter(map[string]any{})
+	session := mustStartSession(t, a, tmpDir, script)
+
+	events, _, err := collectEvents(t, a, session, "work")
+	if err != nil {
+		t.Fatalf("RunTurn() error = %v", err)
+	}
+
+	wantNotice := agentcore.DecideHumanRequest(agentcore.ClassPermission, false, agentcore.AnswerRuntimeRefused).Notice
+	if hasNotification(events, wantNotice) {
+		t.Errorf("events = %v, unexpectedly contains the permission-refusal notification %q for a warning delivered on stdout", events, wantNotice)
+	}
+
+	var sawMalformed bool
+	for _, e := range events {
+		if e.Type == domain.EventMalformed && strings.Contains(e.Message, "permission requested") {
+			sawMalformed = true
+			break
+		}
+	}
+	if !sawMalformed {
+		t.Error("no EventMalformed for the stdout-delivered permission warning line")
+	}
 }
 
 func TestRunTurn_TurnCancelledOnContextCancel(t *testing.T) {
@@ -1463,5 +1623,62 @@ fi`, counterFile, counterFile))
 	var agentErr *domain.AgentError
 	if !errors.As(err, &agentErr) || agentErr.Kind != domain.ErrTurnFailed {
 		t.Errorf("RunTurn(second) error = %v, want AgentError{Kind: %q}", err, domain.ErrTurnFailed)
+	}
+}
+
+// TestStartWait_BlocksOnStderrDrainBeforeCmdWait drives startWait directly
+// with a stderrCollector built over an [io.Pipe] whose write end the test
+// holds open, decoupling the collector's drain from the race-prone real
+// stderr pipe entirely: instead of racing cmd.Wait's pipe close against a
+// concurrent read (the shape of the original bug, and why the fix's own
+// regression test flaked roughly one run in three), the drain is blocked
+// on a synchronization primitive the test controls outright, so the guard
+// under test either blocks forever or doesn't - no timing luck involved.
+//
+// With the guard in place, startWait's goroutine cannot reach cmd.Wait
+// while the pipe is held open, so runtime.waitCh must still be open after
+// a generous bounded wait. Removing the
+// "<-runtime.stderrCollector.Done()" line in startWait lets the goroutine
+// call cmd.Wait immediately after readerDone closes; since the underlying
+// process ("true") has already exited, waitCh closes within a few
+// milliseconds, deterministically failing the first select below.
+func TestStartWait_BlocksOnStderrDrainBeforeCmdWait(t *testing.T) {
+	t.Parallel()
+
+	pr, pw := io.Pipe()
+	collector := procutil.NewStderrCollector(pr, slog.Default())
+
+	cmd := exec.Command("true")
+	procutil.SetProcessGroup(cmd)
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("cmd.Start() = %v", err)
+	}
+
+	readerDone := make(chan struct{})
+	close(readerDone)
+
+	runtime := &turnRuntime{
+		readerDone:      readerDone,
+		stderrCollector: collector,
+		waitCh:          make(chan waitResult, 1),
+	}
+
+	startWait(runtime, cmd)
+
+	select {
+	case <-runtime.waitCh:
+		t.Fatal("startWait closed waitCh before the stderr drain finished; " +
+			"the <-runtime.stderrCollector.Done() guard is missing or bypassed")
+	case <-time.After(300 * time.Millisecond):
+	}
+
+	if err := pw.Close(); err != nil {
+		t.Fatalf("pw.Close() = %v", err)
+	}
+
+	select {
+	case <-runtime.waitCh:
+	case <-time.After(5 * time.Second):
+		t.Fatal("startWait did not close waitCh after the stderr drain finished")
 	}
 }

--- a/internal/agent/opencode/validate.go
+++ b/internal/agent/opencode/validate.go
@@ -1,0 +1,84 @@
+package opencode
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/sortie-ai/sortie/internal/registry"
+	"github.com/sortie-ai/sortie/internal/typeutil"
+)
+
+// validateConfig checks opencode-specific configuration constraints and
+// returns diagnostics for the sortie validate pipeline. It does not
+// construct an adapter instance or launch a subprocess. [NewOpenCodeAdapter]
+// calls this same function so the constructor's refusal and the offline
+// verdict can never disagree.
+func validateConfig(fields registry.AgentConfigFields) []registry.ValidationDiag {
+	var diags []registry.ValidationDiag
+
+	diags = append(diags, validateSkipPermissions(fields.Passthrough)...)
+	diags = append(diags, validateToolOverlap(fields.Passthrough)...)
+
+	return diags
+}
+
+// validateSkipPermissions warns when opencode.dangerously_skip_permissions
+// is explicitly false, which silently auto-rejects every permissioned tool
+// call. Absent or true draws no diagnostic: the value does not defeat the
+// non-interactive launch posture, so no verdict is required.
+func validateSkipPermissions(passthrough map[string]any) []registry.ValidationDiag {
+	v, ok := passthrough["dangerously_skip_permissions"].(bool)
+	if !ok || v {
+		return nil
+	}
+
+	return []registry.ValidationDiag{{
+		Severity: "warning",
+		Check:    "opencode.dangerously_skip_permissions.auto_reject",
+		Message: "opencode.dangerously_skip_permissions is set to false, which silently " +
+			"auto-rejects every permissioned tool call",
+	}}
+}
+
+// validateToolOverlap reports an error when allowed_tools and
+// denied_tools name at least one of the same tools, mirroring the check
+// [parsePassthroughConfig] used to enforce inline at construction.
+func validateToolOverlap(passthrough map[string]any) []registry.ValidationDiag {
+	message := overlapMessage(
+		typeutil.ExtractStringSlice(passthrough["allowed_tools"]),
+		typeutil.ExtractStringSlice(passthrough["denied_tools"]),
+	)
+	if message == "" {
+		return nil
+	}
+
+	return []registry.ValidationDiag{{
+		Severity: "error",
+		Check:    "opencode.allowed_tools.overlap",
+		Message:  message,
+	}}
+}
+
+// overlapMessage returns the byte-identical message both [validateConfig]
+// and [NewOpenCodeAdapter] report when allowed and denied name at least
+// one common tool, or "" when they do not overlap.
+func overlapMessage(allowed, denied []string) string {
+	allowedSet := make(map[string]struct{}, len(allowed))
+	for _, key := range allowed {
+		allowedSet[key] = struct{}{}
+	}
+
+	var conflicts []string
+	for _, key := range denied {
+		if _, ok := allowedSet[key]; ok {
+			conflicts = append(conflicts, key)
+		}
+	}
+	if len(conflicts) == 0 {
+		return ""
+	}
+
+	slices.Sort(conflicts)
+	return fmt.Sprintf("allowed_tools and denied_tools overlap: %s", strings.Join(conflicts, ", "))
+}

--- a/internal/agent/opencode/validate.go
+++ b/internal/agent/opencode/validate.go
@@ -11,9 +11,11 @@ import (
 
 // validateConfig checks opencode-specific configuration constraints and
 // returns diagnostics for the sortie validate pipeline. It does not
-// construct an adapter instance or launch a subprocess. [NewOpenCodeAdapter]
-// calls this same function so the constructor's refusal and the offline
-// verdict can never disagree.
+// construct an adapter instance or launch a subprocess. It shares the
+// overlap check with [NewOpenCodeAdapter], which reaches it through
+// parsePassthroughConfig, so the constructor's refusal and the offline
+// verdict report that fault identically. The warning below has no
+// constructor counterpart.
 func validateConfig(fields registry.AgentConfigFields) []registry.ValidationDiag {
 	var diags []registry.ValidationDiag
 
@@ -24,8 +26,8 @@ func validateConfig(fields registry.AgentConfigFields) []registry.ValidationDiag
 }
 
 // validateSkipPermissions warns when opencode.dangerously_skip_permissions
-// is explicitly false, which silently auto-rejects every permissioned tool
-// call. Absent or true draws no diagnostic: the value does not defeat the
+// is explicitly false, which makes the runtime auto-reject every
+// permissioned tool call. Absent or true draws no diagnostic: the value does not defeat the
 // non-interactive launch posture, so no verdict is required.
 func validateSkipPermissions(passthrough map[string]any) []registry.ValidationDiag {
 	v, ok := passthrough["dangerously_skip_permissions"].(bool)
@@ -36,8 +38,9 @@ func validateSkipPermissions(passthrough map[string]any) []registry.ValidationDi
 	return []registry.ValidationDiag{{
 		Severity: "warning",
 		Check:    "opencode.dangerously_skip_permissions.auto_reject",
-		Message: "opencode.dangerously_skip_permissions is set to false, which silently " +
-			"auto-rejects every permissioned tool call",
+		Message: "opencode.dangerously_skip_permissions is set to false, so the " +
+			"runtime auto-rejects every permissioned tool call and reports each " +
+			"rejection as a warning rather than performing the call",
 	}}
 }
 

--- a/internal/agent/opencode/validate_test.go
+++ b/internal/agent/opencode/validate_test.go
@@ -1,0 +1,97 @@
+package opencode
+
+import (
+	"testing"
+
+	"github.com/sortie-ai/sortie/internal/registry"
+)
+
+// hasCheck reports whether diags carries a diagnostic with the given
+// check name.
+func hasCheck(diags []registry.ValidationDiag, check string) *registry.ValidationDiag {
+	for i := range diags {
+		if diags[i].Check == check {
+			return &diags[i]
+		}
+	}
+	return nil
+}
+
+// TestValidateConfig_SkipPermissions covers
+// opencode.dangerously_skip_permissions: absent or true draws no
+// diagnostic, and an explicit false draws a warning-severity diagnostic.
+func TestValidateConfig_SkipPermissions(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		passthrough map[string]any
+		wantWarn    bool
+	}{
+		{name: "absent draws no diagnostic", passthrough: map[string]any{}, wantWarn: false},
+		{name: "explicit true draws no diagnostic", passthrough: map[string]any{"dangerously_skip_permissions": true}, wantWarn: false},
+		{name: "explicit false draws a warning", passthrough: map[string]any{"dangerously_skip_permissions": false}, wantWarn: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := validateConfig(registry.AgentConfigFields{Kind: "opencode", Passthrough: tt.passthrough})
+
+			diag := hasCheck(got, "opencode.dangerously_skip_permissions.auto_reject")
+			if tt.wantWarn && diag == nil {
+				t.Fatalf("validateConfig(%v) missing check %q; got %+v", tt.passthrough, "opencode.dangerously_skip_permissions.auto_reject", got)
+			}
+			if !tt.wantWarn && diag != nil {
+				t.Fatalf("validateConfig(%v) has unexpected check %q; got %+v", tt.passthrough, "opencode.dangerously_skip_permissions.auto_reject", got)
+			}
+			if diag != nil && diag.Severity != "warning" {
+				t.Errorf("validateConfig(%v) check %q Severity = %q, want %q", tt.passthrough, diag.Check, diag.Severity, "warning")
+			}
+		})
+	}
+}
+
+// TestValidateConfig_ToolOverlap covers allowed_tools/denied_tools
+// overlap: an error-severity diagnostic when the two lists name at least
+// one common tool, none when they do not.
+func TestValidateConfig_ToolOverlap(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		passthrough map[string]any
+		wantErr     bool
+	}{
+		{
+			name:        "no overlap draws no diagnostic",
+			passthrough: map[string]any{"allowed_tools": []any{"edit"}, "denied_tools": []any{"bash"}},
+			wantErr:     false,
+		},
+		{
+			name:        "overlapping tool draws an error",
+			passthrough: map[string]any{"allowed_tools": []any{"bash"}, "denied_tools": []any{"bash"}},
+			wantErr:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := validateConfig(registry.AgentConfigFields{Kind: "opencode", Passthrough: tt.passthrough})
+
+			diag := hasCheck(got, "opencode.allowed_tools.overlap")
+			if tt.wantErr && diag == nil {
+				t.Fatalf("validateConfig(%v) missing check %q; got %+v", tt.passthrough, "opencode.allowed_tools.overlap", got)
+			}
+			if !tt.wantErr && diag != nil {
+				t.Fatalf("validateConfig(%v) has unexpected check %q; got %+v", tt.passthrough, "opencode.allowed_tools.overlap", got)
+			}
+			if diag != nil && diag.Severity != "error" {
+				t.Errorf("validateConfig(%v) check %q Severity = %q, want %q", tt.passthrough, diag.Check, diag.Severity, "error")
+			}
+		})
+	}
+}

--- a/internal/agent/procutil/procutil.go
+++ b/internal/agent/procutil/procutil.go
@@ -199,6 +199,20 @@ func (c *StderrCollector) drain(r io.Reader) {
 	}
 }
 
+// Done returns a channel that closes once the drain goroutine has
+// finished reading its source to EOF (or a read error), after which all
+// collected lines are available.
+//
+// A caller that owns the underlying [*exec.Cmd] and created the reader
+// via [exec.Cmd.StderrPipe] must wait on Done before calling
+// [exec.Cmd.Wait]: Wait reaps the process and then closes the pipe's
+// read end, which races with a concurrent read in the drain goroutine
+// and can make it return early, silently discarding stderr lines that
+// were still buffered in the pipe.
+func (c *StderrCollector) Done() <-chan struct{} {
+	return c.done
+}
+
 // Lines blocks until the drain goroutine finishes and returns all
 // collected stderr lines in chronological order. When lines were
 // discarded, a synthetic marker line is inserted between the head and

--- a/internal/agent/procutil/procutil_test.go
+++ b/internal/agent/procutil/procutil_test.go
@@ -4,12 +4,14 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"os/exec"
 	"runtime"
 	"slices"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestExtractExitCode(t *testing.T) {
@@ -500,4 +502,52 @@ func TestEmitWarnLines_NilLogger(t *testing.T) {
 
 	// Must not panic when logger is nil — falls back to slog.Default().
 	EmitWarnLines([]string{"test line"}, nil)
+}
+
+// TestStderrCollector_DoneClosesOnlyAfterDrainComplete pins the contract
+// documented on [StderrCollector.Done]: the channel it returns closes only
+// once the drain goroutine has fully consumed the reader, so a caller that
+// waits on Done before reading the underlying pipe further (as
+// [exec.Cmd.Wait] does when it closes the pipe after reaping the child) is
+// guaranteed every line the reader ever produced is already in Lines().
+//
+// The reader is an [io.Pipe] whose writer withholds its final line and the
+// EOF-producing Close until the test releases them, so the assertion that
+// Done has not yet fired is a genuine channel block rather than a timing
+// guess.
+func TestStderrCollector_DoneClosesOnlyAfterDrainComplete(t *testing.T) {
+	t.Parallel()
+
+	pr, pw := io.Pipe()
+	c := NewStderrCollector(pr, slog.Default())
+
+	if _, err := io.WriteString(pw, "first line\n"); err != nil {
+		t.Fatalf("pw.Write(first line) = %v", err)
+	}
+
+	select {
+	case <-c.Done():
+		t.Fatal("Done() closed before the writer sent the final line and closed the pipe")
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	const finalLine = "final line released after the block"
+	if _, err := io.WriteString(pw, finalLine+"\n"); err != nil {
+		t.Fatalf("pw.Write(final line) = %v", err)
+	}
+	if err := pw.Close(); err != nil {
+		t.Fatalf("pw.Close() = %v", err)
+	}
+
+	select {
+	case <-c.Done():
+	case <-time.After(5 * time.Second):
+		t.Fatal("Done() did not close after the reader reached EOF")
+	}
+
+	got := c.Lines()
+	want := []string{"first line", finalLine}
+	if !slices.Equal(got, want) {
+		t.Fatalf("Lines() after Done() closed = %v, want %v", got, want)
+	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -182,6 +182,49 @@ type AgentConfig struct {
 	MaxTokens int
 }
 
+// AgentAdapterConfig returns the effective pass-through config map for
+// the agent adapter kind, the single producer both the offline
+// preflight validator and the adapter constructor read, so the two can
+// never disagree about what an adapter of that kind would see.
+//
+// The map carries exactly five keys derived from cfg.Agent's typed
+// fields: kind (set to the kind parameter rather than cfg.Agent.Kind,
+// so a dispatch-rule-routed kind resolves correctly), command,
+// turn_timeout_ms, read_timeout_ms, and stall_timeout_ms. Every other
+// [AgentConfig] field is intentionally excluded: those fields are
+// orchestrator-only, consumed through the typed [AgentConfig] before
+// this map reaches a constructor, and including them would shadow an
+// adapter extension key of the same name during the merge below.
+//
+// The kind-named sub-object under cfg.Extensions, if present, is
+// merged in without overwriting any of the five keys above. The
+// returned map is freshly allocated on every call.
+func AgentAdapterConfig(cfg ServiceConfig, kind string) map[string]any {
+	m := map[string]any{
+		"kind":             kind,
+		"command":          cfg.Agent.Command,
+		"turn_timeout_ms":  cfg.Agent.TurnTimeoutMS,
+		"read_timeout_ms":  cfg.Agent.ReadTimeoutMS,
+		"stall_timeout_ms": cfg.Agent.StallTimeoutMS,
+	}
+	mergeAgentExtensions(m, cfg.Extensions, kind)
+	return m
+}
+
+// mergeAgentExtensions copies the kind-named sub-object from
+// extensions into dst without overwriting an existing key.
+func mergeAgentExtensions(dst map[string]any, extensions map[string]any, kind string) {
+	sub, ok := extensions[kind].(map[string]any)
+	if !ok {
+		return
+	}
+	for k, v := range sub {
+		if _, exists := dst[k]; !exists {
+			dst[k] = v
+		}
+	}
+}
+
 // knownTopLevelKeys enumerates the front matter keys consumed by the
 // core schema. Anything else is collected into Extensions.
 var knownTopLevelKeys = map[string]bool{

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2714,6 +2714,143 @@ func TestNewServiceConfigExtensions(t *testing.T) {
 	})
 }
 
+// --- AgentAdapterConfig tests ---
+
+// TestAgentAdapterConfig_ExactlyFiveKeysWithNoExtensions asserts that
+// AgentAdapterConfig returns exactly the five documented keys when
+// cfg.Extensions carries no sub-object for kind.
+func TestAgentAdapterConfig_ExactlyFiveKeysWithNoExtensions(t *testing.T) {
+	t.Parallel()
+
+	cfg := ServiceConfig{
+		Agent: AgentConfig{
+			Kind:           "claude-code",
+			Command:        "claude",
+			TurnTimeoutMS:  3600000,
+			ReadTimeoutMS:  5000,
+			StallTimeoutMS: 300000,
+		},
+	}
+
+	got := AgentAdapterConfig(cfg, "claude-code")
+
+	want := map[string]any{
+		"kind":             "claude-code",
+		"command":          "claude",
+		"turn_timeout_ms":  3600000,
+		"read_timeout_ms":  5000,
+		"stall_timeout_ms": 300000,
+	}
+	if len(got) != len(want) {
+		t.Fatalf("AgentAdapterConfig() = %v (len %d), want exactly %d keys: %v", got, len(got), len(want), want)
+	}
+	for key, wantVal := range want {
+		if gotVal, ok := got[key]; !ok || gotVal != wantVal {
+			t.Errorf("AgentAdapterConfig()[%q] = %v, want %v", key, gotVal, wantVal)
+		}
+	}
+}
+
+// TestAgentAdapterConfig_KindParameterOverridesAgentKind asserts that the
+// "kind" key carries the kind parameter rather than cfg.Agent.Kind, so a
+// dispatch-rule-routed kind resolves correctly.
+func TestAgentAdapterConfig_KindParameterOverridesAgentKind(t *testing.T) {
+	t.Parallel()
+
+	cfg := ServiceConfig{Agent: AgentConfig{Kind: "claude-code"}}
+
+	got := AgentAdapterConfig(cfg, "codex")
+
+	if got["kind"] != "codex" {
+		t.Errorf(`AgentAdapterConfig(cfg, "codex")["kind"] = %v, want "codex"`, got["kind"])
+	}
+}
+
+// TestAgentAdapterConfig_ExtensionCollisionWithOrchestratorOnlyFieldSurvives
+// asserts that an extension key whose name collides with an
+// orchestrator-only field (max_turns is consumed through the typed
+// AgentConfig, never placed in this map) survives the merge untouched,
+// proving the exclusion the godoc documents actually holds rather than
+// being shadowed by a pre-set key of the same name.
+func TestAgentAdapterConfig_ExtensionCollisionWithOrchestratorOnlyFieldSurvives(t *testing.T) {
+	t.Parallel()
+
+	cfg := ServiceConfig{
+		Agent: AgentConfig{
+			Kind:     "codex",
+			Command:  "codex",
+			MaxTurns: 20,
+		},
+		Extensions: map[string]any{
+			"codex": map[string]any{
+				"max_turns":       float64(5),
+				"approval_policy": "never",
+			},
+		},
+	}
+
+	got := AgentAdapterConfig(cfg, "codex")
+
+	if got["max_turns"] != float64(5) {
+		t.Errorf(`AgentAdapterConfig()["max_turns"] = %v, want the extension value 5 (not shadowed by cfg.Agent.MaxTurns)`, got["max_turns"])
+	}
+	if got["approval_policy"] != "never" {
+		t.Errorf(`AgentAdapterConfig()["approval_policy"] = %v, want "never"`, got["approval_policy"])
+	}
+
+	// The exact key set: the five documented keys plus the two merged
+	// extension keys, nothing else.
+	wantKeys := []string{"kind", "command", "turn_timeout_ms", "read_timeout_ms", "stall_timeout_ms", "max_turns", "approval_policy"}
+	if len(got) != len(wantKeys) {
+		t.Fatalf("AgentAdapterConfig() = %v (len %d), want exactly the keys %v", got, len(got), wantKeys)
+	}
+	for _, key := range wantKeys {
+		if _, ok := got[key]; !ok {
+			t.Errorf("AgentAdapterConfig() missing key %q; got %v", key, got)
+		}
+	}
+}
+
+// TestAgentAdapterConfig_DoesNotOverwriteDocumentedKeys asserts that an
+// extension sub-object cannot shadow any of the five documented keys:
+// the merge only fills keys absent from the map built from cfg.Agent's
+// typed fields.
+func TestAgentAdapterConfig_DoesNotOverwriteDocumentedKeys(t *testing.T) {
+	t.Parallel()
+
+	cfg := ServiceConfig{
+		Agent: AgentConfig{Kind: "codex", Command: "codex"},
+		Extensions: map[string]any{
+			"codex": map[string]any{
+				"command": "should-not-win",
+			},
+		},
+	}
+
+	got := AgentAdapterConfig(cfg, "codex")
+
+	if got["command"] != "codex" {
+		t.Errorf(`AgentAdapterConfig()["command"] = %v, want "codex" (the typed field, not the extension override)`, got["command"])
+	}
+}
+
+// TestAgentAdapterConfig_FreshMapPerCall asserts the returned map is
+// freshly allocated on every call: mutating one call's result must not
+// affect another.
+func TestAgentAdapterConfig_FreshMapPerCall(t *testing.T) {
+	t.Parallel()
+
+	cfg := ServiceConfig{Agent: AgentConfig{Kind: "codex", Command: "codex"}}
+
+	first := AgentAdapterConfig(cfg, "codex")
+	first["command"] = "mutated"
+
+	second := AgentAdapterConfig(cfg, "codex")
+	if second["command"] != "codex" {
+		t.Errorf(`AgentAdapterConfig() second call ["command"] = %v, want "codex" (unaffected by mutating the first call's map)`, second["command"])
+	}
+}
+
 // --- buildWorkspaceConfig / workspace.retention_days tests ---
 
 func TestBuildWorkspaceConfig(t *testing.T) {

--- a/internal/domain/agent.go
+++ b/internal/domain/agent.go
@@ -32,13 +32,10 @@ const (
 	// error condition.
 	EventTurnEndedWithError AgentEventType = "turn_ended_with_error"
 
-	// EventTurnInputRequired indicates the agent requested user
-	// input. This is a hard failure per policy.
+	// EventTurnInputRequired indicates the agent asked for a decision
+	// only a person could give. It is a declared, non-retryable ending
+	// the shared agentcore layer produces, not a policy footnote.
 	EventTurnInputRequired AgentEventType = "turn_input_required"
-
-	// EventApprovalAutoApproved indicates an approval request was
-	// auto-resolved by the adapter.
-	EventApprovalAutoApproved AgentEventType = "approval_auto_approved"
 
 	// EventUnsupportedToolCall indicates the agent requested an
 	// unsupported tool.

--- a/internal/domain/agent_test.go
+++ b/internal/domain/agent_test.go
@@ -43,7 +43,6 @@ func TestAgentEventType_Values(t *testing.T) {
 		{EventTurnCancelled, "turn_cancelled"},
 		{EventTurnEndedWithError, "turn_ended_with_error"},
 		{EventTurnInputRequired, "turn_input_required"},
-		{EventApprovalAutoApproved, "approval_auto_approved"},
 		{EventUnsupportedToolCall, "unsupported_tool_call"},
 		{EventTokenUsage, "token_usage"},
 		{EventNotification, "notification"},
@@ -58,8 +57,8 @@ func TestAgentEventType_Values(t *testing.T) {
 			}
 		})
 	}
-	if len(tests) != 13 {
-		t.Errorf("expected 13 event types, got %d", len(tests))
+	if len(tests) != 12 {
+		t.Errorf("expected 12 event types, got %d", len(tests))
 	}
 }
 

--- a/internal/orchestrator/exit.go
+++ b/internal/orchestrator/exit.go
@@ -340,6 +340,20 @@ func HandleWorkerExit(state *State, workerResult WorkerResult, params HandleWork
 
 	status := mapExitKindToStatus(workerResult.ExitKind)
 	runError := workerResult.Error
+
+	// A needs-a-person ending is reported as its own status only when the
+	// worker's own error, not a shutdown racing it, is what stopped the
+	// run. mapExitKindToStatus already reports a live-context cancel as
+	// "cancelled" rather than "failed", so this guard alone keeps a
+	// shutdown from being relabelled. The error is always wrapped by the
+	// worker, never held directly, so it MUST be unwrapped rather than
+	// asserted or switched on.
+	if status == "failed" {
+		if agentErr, ok := errors.AsType[*domain.AgentError](runError); ok && agentErr.Kind == domain.ErrTurnInputRequired {
+			status = "needs_person"
+		}
+	}
+
 	if evidenceWithheld {
 		status = "failed"
 		runError = evidenceErr

--- a/internal/orchestrator/exit_test.go
+++ b/internal/orchestrator/exit_test.go
@@ -856,6 +856,167 @@ func TestHandleWorkerExit_NonRetryableError(t *testing.T) {
 	}
 }
 
+// TestHandleWorkerExit_InputRequiredStatus asserts that a worker error
+// exit whose Error carries a wrapped *domain.AgentError of kind
+// ErrTurnInputRequired records run_history.status as "needs_person". The
+// error is seeded wrapped, exactly as the worker delivers it
+// (fmt.Errorf("agent turn %d: %w", n, err)): a direct type assertion on
+// WorkerResult.Error compiles but never matches this shape, so this
+// fixture is the one that would catch a regression from
+// errors.AsType to a raw assertion.
+func TestHandleWorkerExit_InputRequiredStatus(t *testing.T) {
+	t.Parallel()
+
+	store := &mockExitStore{}
+	state := exitState(t, "ISSUE-IR-1", nil)
+	params := defaultExitParams(t, store)
+
+	wrappedErr := fmt.Errorf("agent turn 1: %w", &domain.AgentError{
+		Kind:    domain.ErrTurnInputRequired,
+		Message: "agent asked for a decision only a person can make",
+	})
+
+	HandleWorkerExit(state, WorkerResult{
+		IssueID:       "ISSUE-IR-1",
+		Identifier:    "ISSUE-IR-1-ident",
+		ExitKind:      WorkerExitError,
+		Error:         wrappedErr,
+		AgentAdapter:  "mock",
+		WorkspacePath: "/tmp/ws",
+	}, params)
+
+	if len(store.runHistories) != 1 {
+		t.Fatalf("AppendRunHistory called %d times, want 1", len(store.runHistories))
+	}
+	if got := store.runHistories[0].Status; got != "needs_person" {
+		t.Errorf("RunHistory.Status = %q, want %q", got, "needs_person")
+	}
+}
+
+// TestHandleWorkerExit_CancelledWithInputRequiredErrorStaysCancelled
+// asserts that a WorkerExitCancelled result whose wrapped error also
+// carries ErrTurnInputRequired still records status "cancelled": a
+// shutdown racing the adapter's own recognition of the same situation
+// must not be relabelled as needing a person.
+func TestHandleWorkerExit_CancelledWithInputRequiredErrorStaysCancelled(t *testing.T) {
+	t.Parallel()
+
+	store := &mockExitStore{}
+	state := exitState(t, "ISSUE-IR-2", nil)
+	params := defaultExitParams(t, store)
+
+	wrappedErr := fmt.Errorf("agent turn 1: %w", &domain.AgentError{
+		Kind:    domain.ErrTurnInputRequired,
+		Message: "agent asked for a decision only a person can make",
+	})
+
+	HandleWorkerExit(state, WorkerResult{
+		IssueID:       "ISSUE-IR-2",
+		Identifier:    "ISSUE-IR-2-ident",
+		ExitKind:      WorkerExitCancelled,
+		Error:         wrappedErr,
+		AgentAdapter:  "mock",
+		WorkspacePath: "/tmp/ws",
+	}, params)
+
+	if len(store.runHistories) != 1 {
+		t.Fatalf("AppendRunHistory called %d times, want 1", len(store.runHistories))
+	}
+	if got := store.runHistories[0].Status; got != "cancelled" {
+		t.Errorf("RunHistory.Status = %q, want %q", got, "cancelled")
+	}
+}
+
+// TestHandleWorkerExit_InputRequiredMessageDistinctFromFailedAndZeroWork
+// asserts that the recorded run_history.error for a human-input-required
+// exit carries the pinned message stem, carries no timeout vocabulary,
+// and differs from the text a generic turn_failed exit and a zero-work
+// exit produce.
+func TestHandleWorkerExit_InputRequiredMessageDistinctFromFailedAndZeroWork(t *testing.T) {
+	t.Parallel()
+
+	const stem = "agent asked for a decision only a person can make"
+
+	runExit := func(t *testing.T, issueID string, agentErr *domain.AgentError) string {
+		t.Helper()
+
+		store := &mockExitStore{}
+		state := exitState(t, issueID, nil)
+		params := defaultExitParams(t, store)
+
+		HandleWorkerExit(state, WorkerResult{
+			IssueID:       issueID,
+			Identifier:    issueID + "-ident",
+			ExitKind:      WorkerExitError,
+			Error:         fmt.Errorf("agent turn 1: %w", agentErr),
+			AgentAdapter:  "mock",
+			WorkspacePath: "/tmp/ws",
+		}, params)
+
+		if len(store.runHistories) != 1 {
+			t.Fatalf("AppendRunHistory called %d times, want 1", len(store.runHistories))
+		}
+		if store.runHistories[0].Error == nil {
+			t.Fatalf("RunHistory.Error = nil, want non-nil")
+		}
+		return *store.runHistories[0].Error
+	}
+
+	needsPersonMessage := runExit(t, "ISSUE-IR-3", &domain.AgentError{Kind: domain.ErrTurnInputRequired, Message: stem})
+	turnFailedMessage := runExit(t, "ISSUE-IR-4", &domain.AgentError{Kind: domain.ErrTurnFailed, Message: "turn failed"})
+	zeroWorkMessage := runExit(t, "ISSUE-IR-5", &domain.AgentError{Kind: domain.ErrTurnFailed, Message: "agent exited without producing output"})
+
+	if !strings.Contains(needsPersonMessage, stem) {
+		t.Errorf("needs_person RunHistory.Error = %q, want to contain %q", needsPersonMessage, stem)
+	}
+	if strings.Contains(strings.ToLower(needsPersonMessage), "timeout") {
+		t.Errorf("needs_person RunHistory.Error = %q, want no timeout vocabulary", needsPersonMessage)
+	}
+	if needsPersonMessage == turnFailedMessage {
+		t.Errorf("needs_person and turn_failed RunHistory.Error are identical: %q", needsPersonMessage)
+	}
+	if needsPersonMessage == zeroWorkMessage {
+		t.Errorf("needs_person and zero-work RunHistory.Error are identical: %q", needsPersonMessage)
+	}
+}
+
+// TestHandleWorkerExit_InputRequiredReleasesClaimNoRetry asserts the
+// end-to-end claim-release path: a worker error exit whose wrapped error
+// carries ErrTurnInputRequired deletes the issue from state.Claimed and
+// schedules no retry entry, exercising HandleWorkerExit rather than the
+// retry-classification unit alone.
+func TestHandleWorkerExit_InputRequiredReleasesClaimNoRetry(t *testing.T) {
+	t.Parallel()
+
+	store := &mockExitStore{}
+	state := exitState(t, "ISSUE-IR-6", nil)
+	params := defaultExitParams(t, store)
+
+	wrappedErr := fmt.Errorf("agent turn 1: %w", &domain.AgentError{
+		Kind:    domain.ErrTurnInputRequired,
+		Message: "agent asked for a decision only a person can make",
+	})
+
+	HandleWorkerExit(state, WorkerResult{
+		IssueID:       "ISSUE-IR-6",
+		Identifier:    "ISSUE-IR-6-ident",
+		ExitKind:      WorkerExitError,
+		Error:         wrappedErr,
+		AgentAdapter:  "mock",
+		WorkspacePath: "/tmp/ws",
+	}, params)
+
+	if _, ok := state.Claimed["ISSUE-IR-6"]; ok {
+		t.Error("claim preserved after human-input-required exit, should be released")
+	}
+	if _, ok := state.RetryAttempts["ISSUE-IR-6"]; ok {
+		t.Error("retry scheduled after human-input-required exit, should not be")
+	}
+	if len(store.retryEntries) != 0 {
+		t.Errorf("SaveRetryEntry called %d times, want 0", len(store.retryEntries))
+	}
+}
+
 func TestHandleWorkerExit_CancelledExit(t *testing.T) {
 	t.Parallel()
 

--- a/internal/orchestrator/preflight.go
+++ b/internal/orchestrator/preflight.go
@@ -210,6 +210,29 @@ func ValidateDispatchConfig(params PreflightParams) PreflightResult {
 		}
 	}
 
+	// Adapter-specific agent config validation, for every distinct kind
+	// this configuration can reach. A registered kind the configuration
+	// never references is skipped, because that would report a fault in
+	// a block no run reads.
+	for _, kind := range orderedUniqueAgentKinds(cfg) {
+		agentMeta, registered := params.AgentRegistry.Meta(kind)
+		if !registered || agentMeta.ValidateAgentConfig == nil {
+			continue
+		}
+		fields := registry.AgentConfigFields{
+			Kind:        kind,
+			Passthrough: config.AgentAdapterConfig(cfg, kind),
+		}
+		for _, d := range agentMeta.ValidateAgentConfig(fields) {
+			switch d.Severity {
+			case "warning":
+				warns = append(warns, PreflightWarning{Check: d.Check, Message: d.Message})
+			default:
+				errs = append(errs, PreflightError{Check: d.Check, Message: d.Message})
+			}
+		}
+	}
+
 	// Workspace root must exist and be writable.
 	if cfg.Workspace.Root != "" {
 		if err := checkWorkspaceRootWritable(cfg.Workspace.Root); err != nil {
@@ -221,6 +244,33 @@ func ValidateDispatchConfig(params PreflightParams) PreflightResult {
 	}
 
 	return PreflightResult{Errors: errs, Warnings: warns}
+}
+
+// orderedUniqueAgentKinds returns the agent kinds cfg can reach, in
+// deterministic order: the default cfg.Agent.Kind first, then
+// cfg.Dispatch.Default.AgentKind, then each
+// cfg.Dispatch.Rules[i].Selection.AgentKind in rule order. Empty
+// strings are skipped and duplicates are removed, keeping each kind's
+// first occurrence.
+func orderedUniqueAgentKinds(cfg config.ServiceConfig) []string {
+	seen := make(map[string]bool)
+	var kinds []string
+
+	add := func(kind string) {
+		if kind == "" || seen[kind] {
+			return
+		}
+		seen[kind] = true
+		kinds = append(kinds, kind)
+	}
+
+	add(cfg.Agent.Kind)
+	add(cfg.Dispatch.Default.AgentKind)
+	for _, rule := range cfg.Dispatch.Rules {
+		add(rule.Selection.AgentKind)
+	}
+
+	return kinds
 }
 
 // validateDefaultedTrackerStates reports the state collisions that

--- a/internal/orchestrator/preflight_test.go
+++ b/internal/orchestrator/preflight_test.go
@@ -724,6 +724,139 @@ func TestValidateDispatchConfig_APIVersionPropagation(t *testing.T) {
 	})
 }
 
+// TestValidateDispatchConfig_AgentConfigValidation covers the agent-side
+// validation channel: a kind reached only through a dispatch rule, the
+// documented deterministic emission order across the default and
+// rule-referenced kinds, a registered-but-unreferenced kind drawing no
+// diagnostic, and the severity-to-diagnostic-kind mapping.
+func TestValidateDispatchConfig_AgentConfigValidation(t *testing.T) {
+	t.Parallel()
+
+	t.Run("a kind reached only through a dispatch rule draws the same verdict the default kind would", func(t *testing.T) {
+		t.Parallel()
+
+		params := validPreflightParams()
+		params.ConfigFunc = func() config.ServiceConfig {
+			return config.ServiceConfig{
+				Tracker: config.TrackerConfig{Kind: "test-tracker", APIKey: "secret"},
+				Agent:   config.AgentConfig{Kind: "test-agent", Command: "/usr/bin/agent"},
+				Dispatch: config.DispatchConfig{
+					Rules: []config.DispatchRule{
+						{Selection: config.DispatchSelection{AgentKind: "rule-agent"}},
+					},
+				},
+			}
+		}
+		params.AgentRegistry = &stubAgentRegistry{
+			getFunc: func(string) (registry.AgentConstructor, error) { return nil, nil },
+			metaFunc: func(kind string) (registry.AgentMeta, bool) {
+				if kind == "rule-agent" {
+					return registry.AgentMeta{ValidateAgentConfig: func(fields registry.AgentConfigFields) []registry.ValidationDiag {
+						return []registry.ValidationDiag{{Severity: "error", Check: "rule.check", Message: "bad rule kind " + fields.Kind}}
+					}}, true
+				}
+				return registry.AgentMeta{}, true
+			},
+		}
+
+		result := ValidateDispatchConfig(params)
+
+		requireCheck(t, result, "rule.check")
+	})
+
+	t.Run("diagnostics are emitted in the documented deterministic order", func(t *testing.T) {
+		t.Parallel()
+
+		params := validPreflightParams()
+		params.ConfigFunc = func() config.ServiceConfig {
+			return config.ServiceConfig{
+				Tracker: config.TrackerConfig{Kind: "test-tracker", APIKey: "secret"},
+				Agent:   config.AgentConfig{Kind: "kind-a", Command: "/usr/bin/agent"},
+				Dispatch: config.DispatchConfig{
+					Default: config.DispatchSelection{AgentKind: "kind-b"},
+					Rules: []config.DispatchRule{
+						{Selection: config.DispatchSelection{AgentKind: "kind-c"}},
+						{Selection: config.DispatchSelection{AgentKind: "kind-a"}},
+					},
+				},
+			}
+		}
+		params.AgentRegistry = &stubAgentRegistry{
+			getFunc: func(string) (registry.AgentConstructor, error) { return nil, nil },
+			metaFunc: func(string) (registry.AgentMeta, bool) {
+				return registry.AgentMeta{ValidateAgentConfig: func(fields registry.AgentConfigFields) []registry.ValidationDiag {
+					return []registry.ValidationDiag{{Severity: "error", Check: fields.Kind + ".check", Message: fields.Kind}}
+				}}, true
+			},
+		}
+
+		result := ValidateDispatchConfig(params)
+
+		var gotChecks []string
+		for _, e := range result.Errors {
+			if strings.HasSuffix(e.Check, ".check") {
+				gotChecks = append(gotChecks, e.Check)
+			}
+		}
+		want := []string{"kind-a.check", "kind-b.check", "kind-c.check"}
+		if len(gotChecks) != len(want) {
+			t.Fatalf("ValidateDispatchConfig() agent checks = %v, want exactly %v (default kind first, then rule kinds in rule order, deduplicated)", gotChecks, want)
+		}
+		for i, wantCheck := range want {
+			if gotChecks[i] != wantCheck {
+				t.Errorf("ValidateDispatchConfig() checks[%d] = %q, want %q", i, gotChecks[i], wantCheck)
+			}
+		}
+	})
+
+	t.Run("a registered kind the configuration never references draws no diagnostic", func(t *testing.T) {
+		t.Parallel()
+
+		params := validPreflightParams()
+		params.AgentRegistry = &stubAgentRegistry{
+			getFunc: func(string) (registry.AgentConstructor, error) { return nil, nil },
+			metaFunc: func(kind string) (registry.AgentMeta, bool) {
+				if kind == "unused-kind" {
+					return registry.AgentMeta{ValidateAgentConfig: func(_ registry.AgentConfigFields) []registry.ValidationDiag {
+						return []registry.ValidationDiag{{Severity: "error", Check: "unused.check", Message: "should never fire"}}
+					}}, true
+				}
+				return registry.AgentMeta{}, true
+			},
+		}
+
+		result := ValidateDispatchConfig(params)
+
+		requireNoCheck(t, result, "unused.check")
+	})
+
+	t.Run("warning severity maps to PreflightWarning, anything else maps to PreflightError", func(t *testing.T) {
+		t.Parallel()
+
+		params := validPreflightParams()
+		params.AgentRegistry = &stubAgentRegistry{
+			getFunc: func(string) (registry.AgentConstructor, error) { return nil, nil },
+			metaFunc: func(string) (registry.AgentMeta, bool) {
+				return registry.AgentMeta{ValidateAgentConfig: func(_ registry.AgentConfigFields) []registry.ValidationDiag {
+					return []registry.ValidationDiag{
+						{Severity: "warning", Check: "agent.warn", Message: "advisory"},
+						{Severity: "error", Check: "agent.err", Message: "fatal"},
+						{Severity: "", Check: "agent.other", Message: "anything else maps to an error"},
+					}
+				}}, true
+			},
+		}
+
+		result := ValidateDispatchConfig(params)
+
+		requireWarnCheck(t, result, "agent.warn")
+		requireCheck(t, result, "agent.err")
+		requireCheck(t, result, "agent.other")
+		requireNoWarnCheck(t, result, "agent.err")
+		requireNoWarnCheck(t, result, "agent.other")
+	})
+}
+
 // TestValidateDispatchConfig_DefaultedTrackerStates covers the collision
 // rules re-run against the effective state lists, the ones a tracker
 // adapter fills from its own fallback when the workflow list is empty.

--- a/internal/persistence/run_history.go
+++ b/internal/persistence/run_history.go
@@ -30,7 +30,7 @@ type RunHistory struct {
 	Workspace      string  // Workspace path used for this run.
 	StartedAt      string  // ISO-8601 timestamp of run start.
 	CompletedAt    string  // ISO-8601 timestamp of run completion.
-	Status         string  // Terminal status: "succeeded", "failed", "cancelled", or "ci_failed".
+	Status         string  // Terminal status: "succeeded", "failed", "cancelled", "ci_failed", or "needs_person".
 	Error          *string // Error message if failed; nil on success.
 	WorkflowFile   string  // Base filename of the WORKFLOW.md file; empty for pre-migration rows.
 	TurnsCompleted int     // Number of coding turns completed in this run.

--- a/internal/persistence/run_history_test.go
+++ b/internal/persistence/run_history_test.go
@@ -581,4 +581,53 @@ func TestCountWorkerRunsCompletedSince(t *testing.T) {
 			t.Errorf("CountWorkerRunsCompletedSince(%q, %v) = %d, want 0", "ISS-CWR-NONE", since, got)
 		}
 	})
+
+	t.Run("needs_person row counts as a worker session", func(t *testing.T) {
+		t.Parallel()
+
+		const npIssueID = "ISS-CWR-NP"
+		s := openTestStore(t)
+		migrateOrFatal(t, s)
+
+		appendOrFatal(t, s, countRun(1, npIssueID, "needs_person", "2026-04-01T09:30:00Z"))
+
+		got, err := s.CountWorkerRunsCompletedSince(context.Background(), npIssueID, since)
+		if err != nil {
+			t.Fatalf("CountWorkerRunsCompletedSince: %v", err)
+		}
+		if got != 1 {
+			t.Errorf("CountWorkerRunsCompletedSince(%q, %v) = %d, want 1 (a needs_person row is a worker session, not a CI verdict)", npIssueID, since, got)
+		}
+	})
+}
+
+// TestLoadLatestSuccessfulRunsForReactionRecovery_ExcludesNeedsPerson pins
+// that a needs_person row, like a failed or cancelled row, is not a
+// success and is therefore excluded from reaction recovery.
+func TestLoadLatestSuccessfulRunsForReactionRecovery_ExcludesNeedsPerson(t *testing.T) {
+	t.Parallel()
+
+	s := openTestStore(t)
+	migrateOrFatal(t, s)
+	ctx := context.Background()
+	cutoff := recoveryRefTime.Add(-30 * 24 * time.Hour)
+
+	appendOrFatal(t, s, RunHistory{
+		IssueID: "ISS-NEEDS-PERSON", Identifier: "PROJ-NP", Attempt: 1,
+		AgentAdapter: "mock", Workspace: "/ws/PROJ-NP",
+		StartedAt: recentCompletedAt(2), CompletedAt: recentCompletedAt(2),
+		Status: "needs_person",
+	})
+	eligible := appendRecoveryRun(t, s, "ISS-OK-NP", "PROJ-OK-NP", 1, recentCompletedAt(2))
+
+	got, err := s.LoadLatestSuccessfulRunsForReactionRecovery(ctx, cutoff, 200)
+	if err != nil {
+		t.Fatalf("LoadLatestSuccessfulRunsForReactionRecovery: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("LoadLatestSuccessfulRunsForReactionRecovery() len = %d, want 1", len(got))
+	}
+	if got[0].IssueID != eligible.IssueID {
+		t.Errorf("LoadLatestSuccessfulRunsForReactionRecovery().IssueID = %q, want %q", got[0].IssueID, eligible.IssueID)
+	}
 }

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -150,6 +150,26 @@ type AgentMeta struct {
 	// RequiresCommand indicates the agent adapter requires a
 	// non-empty agent.command config value.
 	RequiresCommand bool
+
+	// ValidateAgentConfig is an optional function the preflight
+	// pipeline calls to run agent-specific config validation. Nil
+	// means no adapter-specific validation.
+	ValidateAgentConfig func(fields AgentConfigFields) []ValidationDiag
+}
+
+// AgentConfigFields holds the config values passed to agent adapter
+// validation functions. This is a plain data struct that avoids
+// coupling the registry package to the config package.
+type AgentConfigFields struct {
+	// Kind is the agent adapter kind whose configuration is under
+	// validation. It is the default agent.kind or a kind a dispatch
+	// rule routes to.
+	Kind string
+
+	// Passthrough is the effective config map an adapter of this kind
+	// receives at construction. Read-only: a validator MUST NOT
+	// mutate it.
+	Passthrough map[string]any
 }
 
 // Registry is a typed adapter registry mapping kind strings to

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -282,6 +282,59 @@ func TestRegisterWithMeta_AndMeta(t *testing.T) {
 	})
 }
 
+// dummyAgentConstructor returns an AgentConstructor whose construction
+// result is never inspected by these tests; only its registration and
+// retrieval matter.
+func dummyAgentConstructor() AgentConstructor {
+	return func(map[string]any) (domain.AgentAdapter, error) { return nil, nil }
+}
+
+// TestRegisterWithMeta_AndMeta_AgentValidateAgentConfig pins that
+// AgentMeta.ValidateAgentConfig round-trips through RegisterWithMeta and
+// Meta, mirroring TestRegisterWithMeta_AndMeta for the real AgentMeta
+// type rather than the generic testMeta fixture.
+func TestRegisterWithMeta_AndMeta_AgentValidateAgentConfig(t *testing.T) {
+	t.Parallel()
+
+	t.Run("RegisterWithMeta with a non-nil ValidateAgentConfig round-trips through Meta", func(t *testing.T) {
+		t.Parallel()
+
+		r := NewRegistry[AgentConstructor, AgentMeta]("agent")
+		validate := func(fields AgentConfigFields) []ValidationDiag {
+			return []ValidationDiag{{Severity: "error", Check: "marker.check", Message: "marker " + fields.Kind}}
+		}
+		r.RegisterWithMeta("alpha", dummyAgentConstructor(), AgentMeta{ValidateAgentConfig: validate})
+
+		got, ok := r.Meta("alpha")
+		if !ok {
+			t.Fatalf("Meta(%q) ok = false, want true", "alpha")
+		}
+		if got.ValidateAgentConfig == nil {
+			t.Fatalf("Meta(%q).ValidateAgentConfig = nil, want non-nil", "alpha")
+		}
+
+		diags := got.ValidateAgentConfig(AgentConfigFields{Kind: "alpha"})
+		if len(diags) != 1 || diags[0].Check != "marker.check" || diags[0].Message != "marker alpha" {
+			t.Errorf("Meta(%q).ValidateAgentConfig(...) = %+v, want the registered function's own output", "alpha", diags)
+		}
+	})
+
+	t.Run("plain Register reports nil ValidateAgentConfig", func(t *testing.T) {
+		t.Parallel()
+
+		r := NewRegistry[AgentConstructor, AgentMeta]("agent")
+		r.Register("mock", dummyAgentConstructor())
+
+		got, ok := r.Meta("mock")
+		if !ok {
+			t.Fatalf("Meta(%q) ok = false, want true for plain Register", "mock")
+		}
+		if got.ValidateAgentConfig != nil {
+			t.Errorf("Meta(%q).ValidateAgentConfig = non-nil, want nil for plain Register", "mock")
+		}
+	})
+}
+
 func TestRegisterWithMeta_Panics(t *testing.T) {
 	t.Parallel()
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -48,7 +48,7 @@ type RunHistoryEntry struct {
 	// Attempt is the one-based retry attempt number.
 	Attempt int
 	// Status is the terminal run outcome: "succeeded", "failed",
-	// "cancelled", or "ci_failed".
+	// "cancelled", "ci_failed", or "needs_person".
 	Status string
 	// WorkflowFile is the path to the workflow definition used.
 	WorkflowFile string

--- a/internal/tool/history/history.go
+++ b/internal/tool/history/history.go
@@ -32,7 +32,7 @@ type Entry struct {
 	AgentAdapter string  // Agent adapter kind used (e.g. "claude-code").
 	StartedAt    string  // ISO-8601 timestamp of run start.
 	CompletedAt  string  // ISO-8601 timestamp of run completion.
-	Status       string  // Terminal status: succeeded, failed, cancelled, or ci_failed.
+	Status       string  // Terminal status: succeeded, failed, cancelled, ci_failed, or needs_person.
 	Error        *string // Error message if failed; nil on success.
 }
 


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Fix

**Intent:** Sortie drives agent runtimes unattended, and several of them stop their own work to ask for a decision only a person could give: permission to run a command or change a file, or a genuine question addressed to a human. None of those requests were being refused; they burned a run's turn or stall budget waiting for an answer that never comes, and the eventual timeout was reported as a generic failure rather than as a run that needed a person. This closes that gap: a shared refusal posture in `agentcore` classifies and refuses the request (or ends the attempt with a dedicated, non-retryable outcome), each of the five real adapters gains the recognition and wire-level refusal its own protocol needs, and a pass-through config value that would reopen the interactive path now draws the same verdict at startup, on reload, and from offline validation.

**Related Issues:** Closes #837

### 🧭 Reviewer Guide

**Complexity:** High

#### Entry Point

Start at `internal/agent/agentcore/humanrequest.go`. `DecideHumanRequest` is the pure function that turns a recognized request (its class - permission or human input - and whether the protocol offers a reply channel) into a `RefusalPosture`: whether to transmit a refusal, whether that refusal must let the agent continue by another route, and whether the attempt ends now. Every adapter reads this posture and acts on it; none of them decide the consequence themselves. `internal/agent/agentcore/disposition.go` is the second file to read - it adds `TerminalHumanInputRequired` as a fourth terminal report alongside completion, failure, and cancellation, so the ending flows through the same `DecideTurn`/`FinalizeTurn` path every other outcome already uses.

Once the shared layer is clear, each adapter's change is a self-contained, smaller diff: `internal/agent/codex/codex.go` (recognizes six app-server request methods and fixes a turn-loop cancellation defect), `internal/agent/claude/claude.go` (recognizes a runtime-refused `permission_denied` event), `internal/agent/copilot/copilot.go` (recognizes a `tool.execution_complete` denial), `internal/agent/opencode/opencode.go` (moves permission-warning recognition from a dead stdout filter to the stderr stream the runtime actually writes to), and `internal/agent/kiro/command.go` (changes the trust-tools default because the CLI's behaviour on an untrusted tool could not be observed).

#### Sensitive Areas

- `internal/agent/codex/codex.go`: the turn loop's cancellation handling changes - a best-effort `turn/interrupt` now arms a one-shot deadline instead of reading indefinitely, and six new JSON-RPC request methods are recognized and answered in their own reply shapes (a decline decision, a denied review decision, or a JSON-RPC error).
- `internal/orchestrator/exit.go`: a new `needs_person` run status is derived from an unwrapped `*domain.AgentError`, guarded so a shutdown racing the worker is still reported as `cancelled` rather than relabelled.
- `internal/agent/opencode/opencode.go` and `internal/agent/procutil/procutil.go`: `startWait` now waits on both the stdout reader and a new `StderrCollector.Done()` channel before calling `cmd.Wait()`, closing a race that could silently drop the last stderr line.
- `internal/agent/kiro/command.go`: `trust_all_tools` now defaults to `true` (trust every tool) rather than `false` when a `kiro` config sets neither trust key, a deliberate behaviour change explained in `docs/kiro-adapter-notes.md`.
- Every adapter's `init()` and new `validate.go`: wires `registry.AgentMeta.ValidateAgentConfig`, called from `internal/orchestrator/preflight.go` for every agent kind a configuration can reach.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes for any consumer outside this module. `domain.EventApprovalAutoApproved` is removed from the normalized event vocabulary - it had no producer anywhere in the tree, and `internal/` is not importable outside this module.
- **Migrations/State:** No database migrations. `internal/persistence` and `internal/server` run-history readers gain a new terminal status string, `needs_person`, alongside the existing `succeeded`/`failed`/`cancelled`/`ci_failed` values; no schema change.

