### PR TITLE
fix: gate dispatch on candidate blockers for every tracker adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- A `sortie_candidate_holds_total` counter reports how many issues
+  the scheduler held back and why, separating an unfinished blocker
+  from a blocker list that could not be read, one the tracker
+  reported as incomplete, and one left unread because the poll had
+  already spent its budget of dependency lookups. `sortie --dry-run`
+  names the same reason for each issue it would not start, so an
+  issue held by a dependency is no longer indistinguishable from one
+  held by a full slot.
+  ([#920](https://github.com/sortie-ai/sortie/issues/920))
+
 ### Fixed
 
 - A malformed end-of-turn notification from the `codex app-server` no
@@ -62,6 +74,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   second `opencode` call; every other cause reached the operator as the
   placeholder.
   ([#839](https://github.com/sortie-ai/sortie/issues/839))
+
+- On GitHub and Gitea, an issue whose blockers are still open is no
+  longer started. Both trackers reported every candidate issue as
+  having no blockers at all, so a dependency recorded in the tracker
+  had no effect on what ran: work began on issues whose prerequisites
+  were unfinished, holding a slot until the agent discovered for
+  itself that it could not proceed. Jira and Linear were unaffected.
+  An issue is now held until every blocker reaches a terminal state,
+  and where its blocker list cannot be read the issue is held and
+  retried on the next poll rather than started on an unread list. A
+  forge that does not serve issue dependencies at all is now reported
+  as an error instead of read as an empty list, and no issue on it is
+  started while that lasts. Reading dependencies costs GitHub and
+  Gitea up to four extra tracker requests per poll; an issue whose
+  own tracker data already proves it has no dependencies costs none.
+  Workflow templates on those two trackers now receive the real
+  blocker list, which was previously always empty.
+  ([#920](https://github.com/sortie-ai/sortie/issues/920))
 
 ## [1.21.0] - 2026-08-20
 

--- a/cmd/sortie/boot.go
+++ b/cmd/sortie/boot.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/sortie-ai/sortie/internal/blockers"
 	"github.com/sortie-ai/sortie/internal/config"
 	"github.com/sortie-ai/sortie/internal/domain"
 	"github.com/sortie-ai/sortie/internal/logging"
@@ -36,6 +37,7 @@ type bootResult struct {
 	path            string
 	preflightParams orchestrator.PreflightParams
 	trackerAdapter  domain.TrackerAdapter
+	blockerResolver orchestrator.BlockerResolver
 	serverPort      int
 	serverHost      string
 	serverEnabled   bool
@@ -230,6 +232,18 @@ func boot(ctx context.Context, p bootParams) (bootResult, int) {
 		return bootResult{}, 1
 	}
 
+	trackerMeta, _ := registry.Trackers.Meta(cfg.Tracker.Kind)
+	resolver := blockers.NewResolver(trackerAdapter, trackerMeta.BlockerSource, logger)
+
+	// resolver is a *blockers.Resolver; assign it into the interface
+	// field only through this typed variable so a nil resolver stays a
+	// nil BlockerResolver interface value rather than a non-nil
+	// interface wrapping a nil pointer.
+	var blockerResolver orchestrator.BlockerResolver
+	if resolver != nil {
+		blockerResolver = resolver
+	}
+
 	// Transfer ownership of mgr to the caller — suppress the deferred Stop.
 	mgrStarted = false
 
@@ -240,6 +254,7 @@ func boot(ctx context.Context, p bootParams) (bootResult, int) {
 		path:            path,
 		preflightParams: preflightParams,
 		trackerAdapter:  trackerAdapter,
+		blockerResolver: blockerResolver,
 		serverPort:      serverPort,
 		serverHost:      serverHost,
 		serverEnabled:   serverEnabled,

--- a/cmd/sortie/dryrun.go
+++ b/cmd/sortie/dryrun.go
@@ -15,7 +15,13 @@ import (
 // returns an exit code. No database is opened, no agents are spawned,
 // and no state is written. The caller constructs and defers closing
 // the tracker adapter.
-func runDryRun(ctx context.Context, cfg config.ServiceConfig, logger *slog.Logger, trackerAdapter domain.TrackerAdapter) int {
+//
+// resolver may be nil, in which case no candidate's blockers are
+// resolved. A single dry-run cycle spends at most
+// orchestrator's per-pass blocker-read budget, evaluated against one
+// [orchestrator.TickResolution] constructed at offset zero for the
+// whole cycle.
+func runDryRun(ctx context.Context, cfg config.ServiceConfig, logger *slog.Logger, trackerAdapter domain.TrackerAdapter, resolver orchestrator.BlockerResolver) int {
 	issues, err := trackerAdapter.FetchCandidateIssues(ctx)
 	if err != nil {
 		logger.Error("dry-run: failed to fetch candidate issues", slog.Any("error", err))
@@ -40,6 +46,8 @@ func runDryRun(ctx context.Context, cfg config.ServiceConfig, logger *slog.Logge
 	activeSet := dryRunStateSet(cfg.Tracker.ActiveStates)
 	terminalSet := dryRunStateSet(cfg.Tracker.TerminalStates)
 
+	pass := &orchestrator.TickResolution{}
+
 	var eligible, ineligible int
 	for i, issue := range sorted {
 		globalAvail := orchestrator.GlobalAvailableSlots(
@@ -63,13 +71,24 @@ func runDryRun(ctx context.Context, cfg config.ServiceConfig, logger *slog.Logge
 		stateAvail := orchestrator.StateAvailableSlots(
 			issue.State, state.MaxConcurrentByState, stateRunning, globalAvail)
 
-		wouldDispatch := orchestrator.ShouldDispatchWithSets(
-			issue, state, activeSet, terminalSet) && globalAvail > 0 && stateAvail > 0
+		// Capacity is evaluated before EvaluateCandidate so a
+		// candidate with no free slot spends no blocker read.
+		wouldDispatch := false
+		skipReason := ""
+		if globalAvail > 0 && stateAvail > 0 {
+			decision := orchestrator.EvaluateCandidate(ctx, issue, state, activeSet, terminalSet, resolver, pass)
+			issue = decision.Issue
+			wouldDispatch = decision.Dispatch
+			if isBlockerSkipReason(decision.Reason) {
+				skipReason = string(decision.Reason)
+			}
+		}
 
 		if wouldDispatch && hostPool.IsSSHEnabled() {
 			_, ok := hostPool.AcquireHost(issue.ID, "")
 			if !ok {
 				wouldDispatch = false
+				skipReason = "ssh_hosts_at_capacity"
 			}
 		}
 
@@ -87,6 +106,9 @@ func runDryRun(ctx context.Context, cfg config.ServiceConfig, logger *slog.Logge
 		}
 		if hostPool.IsSSHEnabled() {
 			logFields = append(logFields, slog.String("ssh_host", hostPool.HostFor(issue.ID)))
+		}
+		if skipReason != "" {
+			logFields = append(logFields, slog.String("skip_reason", skipReason))
 		}
 
 		logger.Info("dry-run: candidate", logFields...)
@@ -111,6 +133,19 @@ func runDryRun(ctx context.Context, cfg config.ServiceConfig, logger *slog.Logge
 	)
 
 	return 0
+}
+
+// isBlockerSkipReason reports whether reason is one of the four
+// blocker-hold reasons [orchestrator.EvaluateCandidate] can name, as
+// opposed to [orchestrator.SkipIneligible] or [orchestrator.SkipNone].
+func isBlockerSkipReason(reason orchestrator.SkipReason) bool {
+	switch reason {
+	case orchestrator.SkipBlockedBy, orchestrator.SkipBlockersUnresolved,
+		orchestrator.SkipBlockersNotRead, orchestrator.SkipBlockersIncomplete:
+		return true
+	default:
+		return false
+	}
 }
 
 // dryRunStateSet builds a set of lowercase state names for O(1) membership

--- a/cmd/sortie/dryrun_test.go
+++ b/cmd/sortie/dryrun_test.go
@@ -5,10 +5,15 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/sortie-ai/sortie/internal/config"
+	"github.com/sortie-ai/sortie/internal/domain"
 )
 
 // --- --dry-run flag tests ---
@@ -316,3 +321,234 @@ func TestRunDryRunNoServer(t *testing.T) {
 }
 
 // --- resolveLogFormat tests ---
+
+// --- runDryRun blocker-gate tests ---
+
+// dryRunFakeTracker is a configurable domain.TrackerAdapter double that
+// returns a fixed candidate list, so runDryRun tests can drive specific
+// blocker scenarios without a real tracker adapter.
+type dryRunFakeTracker struct {
+	issues []domain.Issue
+}
+
+var _ domain.TrackerAdapter = (*dryRunFakeTracker)(nil)
+
+func (f *dryRunFakeTracker) FetchCandidateIssues(context.Context) ([]domain.Issue, error) {
+	return f.issues, nil
+}
+func (f *dryRunFakeTracker) FetchIssueByID(context.Context, string) (domain.Issue, error) {
+	return domain.Issue{}, nil
+}
+func (f *dryRunFakeTracker) FetchIssuesByStates(context.Context, []string) ([]domain.Issue, error) {
+	return nil, nil
+}
+func (f *dryRunFakeTracker) FetchIssueStatesByIDs(context.Context, []string) (map[string]string, error) {
+	return nil, nil
+}
+func (f *dryRunFakeTracker) FetchIssueStatesByIdentifiers(context.Context, []string) (map[string]string, error) {
+	return nil, nil
+}
+func (f *dryRunFakeTracker) FetchIssueComments(context.Context, string) ([]domain.Comment, error) {
+	return nil, nil
+}
+func (f *dryRunFakeTracker) TransitionIssue(context.Context, string, string) error { return nil }
+func (f *dryRunFakeTracker) CommentIssue(context.Context, string, string) error    { return nil }
+func (f *dryRunFakeTracker) AddLabel(context.Context, string, string) error        { return nil }
+
+// dryRunFakeResolver is a configurable orchestrator.BlockerResolver
+// double, recording every Resolve call in the order runDryRun makes
+// them.
+type dryRunFakeResolver struct {
+	needsReadFn func(domain.Issue) bool
+	resolveFn   func(context.Context, domain.Issue) (domain.Issue, error)
+	calls       []string
+}
+
+func (f *dryRunFakeResolver) NeedsRead(issue domain.Issue) bool {
+	if f.needsReadFn == nil {
+		return false
+	}
+	return f.needsReadFn(issue)
+}
+
+func (f *dryRunFakeResolver) Resolve(ctx context.Context, issue domain.Issue) (domain.Issue, error) {
+	f.calls = append(f.calls, issue.ID)
+	if f.resolveFn == nil {
+		return issue, nil
+	}
+	return f.resolveFn(ctx, issue)
+}
+
+// discardStdoutLogger returns a text logger writing to w at Info
+// level, matching the level runDryRun's own records need to be
+// captured at.
+func discardStdoutLogger(w io.Writer) *slog.Logger {
+	return slog.New(slog.NewTextHandler(w, nil))
+}
+
+// dryRunTestConfig returns a minimal config.ServiceConfig suitable for
+// direct runDryRun calls, with active/terminal states and a
+// caller-supplied concurrency cap.
+func dryRunTestConfig(maxConcurrentAgents int) config.ServiceConfig {
+	return config.ServiceConfig{
+		Tracker: config.TrackerConfig{
+			ActiveStates:   []string{"To Do"},
+			TerminalStates: []string{"Done"},
+		},
+		Polling: config.PollingConfig{IntervalMS: 30000},
+		Agent:   config.AgentConfig{MaxConcurrentAgents: maxConcurrentAgents},
+	}
+}
+
+func TestRunDryRun_SkipReasonBlockedBy(t *testing.T) {
+	t.Parallel()
+
+	tracker := &dryRunFakeTracker{issues: []domain.Issue{
+		{
+			ID: "1", Identifier: "X-1", Title: "T", State: "To Do",
+			BlockedBy: []domain.BlockerRef{{ID: "b", State: "To Do"}},
+		},
+	}}
+
+	var stderr bytes.Buffer
+	logger := discardStdoutLogger(&stderr)
+
+	code := runDryRun(context.Background(), dryRunTestConfig(10), logger, tracker, nil)
+	if code != 0 {
+		t.Fatalf("runDryRun = %d, want 0", code)
+	}
+
+	got := stderr.String()
+	if !strings.Contains(got, "skip_reason=blocked_by") {
+		t.Errorf("stderr missing skip_reason=blocked_by: %s", got)
+	}
+	if !strings.Contains(got, "would_dispatch=false") {
+		t.Errorf("stderr missing would_dispatch=false: %s", got)
+	}
+}
+
+func TestRunDryRun_SkipReasonBlockersUnresolved(t *testing.T) {
+	t.Parallel()
+
+	transientErr := &domain.TrackerError{Kind: domain.ErrTrackerTransport}
+	tracker := &dryRunFakeTracker{issues: []domain.Issue{
+		{ID: "1", Identifier: "X-1", Title: "T", State: "To Do", BlockersUnresolved: true},
+	}}
+	resolver := &dryRunFakeResolver{
+		needsReadFn: func(domain.Issue) bool { return true },
+		resolveFn: func(_ context.Context, issue domain.Issue) (domain.Issue, error) {
+			issue.BlockersUnresolved = true
+			return issue, transientErr
+		},
+	}
+
+	var stderr bytes.Buffer
+	logger := discardStdoutLogger(&stderr)
+
+	code := runDryRun(context.Background(), dryRunTestConfig(10), logger, tracker, resolver)
+	if code != 0 {
+		t.Fatalf("runDryRun = %d, want 0", code)
+	}
+
+	got := stderr.String()
+	if !strings.Contains(got, "skip_reason=blockers_unresolved") {
+		t.Errorf("stderr missing skip_reason=blockers_unresolved: %s", got)
+	}
+	if len(resolver.calls) != 1 {
+		t.Errorf("resolver calls = %d, want 1", len(resolver.calls))
+	}
+}
+
+func TestRunDryRun_SkipReasonBlockersIncomplete(t *testing.T) {
+	t.Parallel()
+
+	tracker := &dryRunFakeTracker{issues: []domain.Issue{
+		{ID: "1", Identifier: "X-1", Title: "T", State: "To Do", BlockersUnresolved: true},
+	}}
+	resolver := &dryRunFakeResolver{
+		needsReadFn: func(domain.Issue) bool { return false },
+	}
+
+	var stderr bytes.Buffer
+	logger := discardStdoutLogger(&stderr)
+
+	code := runDryRun(context.Background(), dryRunTestConfig(10), logger, tracker, resolver)
+	if code != 0 {
+		t.Fatalf("runDryRun = %d, want 0", code)
+	}
+
+	got := stderr.String()
+	if !strings.Contains(got, "skip_reason=blockers_incomplete") {
+		t.Errorf("stderr missing skip_reason=blockers_incomplete: %s", got)
+	}
+	if len(resolver.calls) != 0 {
+		t.Errorf("resolver calls = %d, want 0 (NeedsRead reported false)", len(resolver.calls))
+	}
+}
+
+// TestRunDryRun_CapacityFullMakesNoBlockerRead pins that capacity is
+// evaluated before EvaluateCandidate, so a candidate with no free slot
+// spends no blocker read.
+func TestRunDryRun_CapacityFullMakesNoBlockerRead(t *testing.T) {
+	t.Parallel()
+
+	tracker := &dryRunFakeTracker{issues: []domain.Issue{
+		{ID: "1", Identifier: "X-1", Title: "T", State: "To Do", BlockersUnresolved: true},
+	}}
+	resolver := &dryRunFakeResolver{
+		needsReadFn: func(domain.Issue) bool { return true },
+	}
+
+	var stderr bytes.Buffer
+	logger := discardStdoutLogger(&stderr)
+
+	// Zero concurrency budget: no candidate ever has a free slot.
+	code := runDryRun(context.Background(), dryRunTestConfig(0), logger, tracker, resolver)
+	if code != 0 {
+		t.Fatalf("runDryRun = %d, want 0", code)
+	}
+
+	if len(resolver.calls) != 0 {
+		t.Errorf("resolver calls = %d, want 0: a capacity-full candidate must not spend a blocker read", len(resolver.calls))
+	}
+	if !strings.Contains(stderr.String(), "would_dispatch=false") {
+		t.Errorf("stderr missing would_dispatch=false: %s", stderr.String())
+	}
+}
+
+// TestRunDryRun_ReadBudgetPerCycle pins that a single dry-run cycle
+// issues at most the per-pass blocker-read budget, holding the
+// remainder as blockers_not_read.
+func TestRunDryRun_ReadBudgetPerCycle(t *testing.T) {
+	t.Parallel()
+
+	const needyCount = 6
+	issues := make([]domain.Issue, needyCount)
+	for i := range issues {
+		id := fmt.Sprintf("N-%d", i+1)
+		issues[i] = domain.Issue{ID: id, Identifier: id, Title: "T", State: "To Do", BlockersUnresolved: true}
+	}
+	tracker := &dryRunFakeTracker{issues: issues}
+	resolver := &dryRunFakeResolver{
+		needsReadFn: func(issue domain.Issue) bool { return issue.BlockersUnresolved },
+		resolveFn: func(_ context.Context, issue domain.Issue) (domain.Issue, error) {
+			issue.BlockersUnresolved = false
+			return issue, nil
+		},
+	}
+
+	var stderr bytes.Buffer
+	logger := discardStdoutLogger(&stderr)
+
+	code := runDryRun(context.Background(), dryRunTestConfig(10), logger, tracker, resolver)
+	if code != 0 {
+		t.Fatalf("runDryRun = %d, want 0", code)
+	}
+
+	if len(resolver.calls) == 0 || len(resolver.calls) >= needyCount {
+		t.Fatalf("resolver calls = %d, want a positive count below %d (the budget must bind for this fixture)", len(resolver.calls), needyCount)
+	}
+	if got := strings.Count(stderr.String(), "skip_reason=blockers_not_read"); got != needyCount-len(resolver.calls) {
+		t.Errorf("blockers_not_read count = %d, want %d", got, needyCount-len(resolver.calls))
+	}
+}

--- a/cmd/sortie/main.go
+++ b/cmd/sortie/main.go
@@ -232,7 +232,7 @@ func run(ctx context.Context, args []string, stdout io.Writer, stderr io.Writer)
 	}
 	if br.dryRun {
 		br.logger.Info("sortie dry-run starting", logAttrs...)
-		return runDryRun(ctx, br.cfg, br.logger, br.trackerAdapter)
+		return runDryRun(ctx, br.cfg, br.logger, br.trackerAdapter, br.blockerResolver)
 	}
 	br.logger.Info("sortie starting", logAttrs...)
 
@@ -766,6 +766,7 @@ func run(ctx context.Context, args []string, stdout io.Writer, stderr io.Writer)
 		LabelFixReactionConfigured:        labelFixConfigured,
 		MergeCompletionConfig:             mergeCompletionConfig,
 		MergeCompletionReactionConfigured: mergeCompletionConfigured,
+		BlockerResolver:                   br.blockerResolver,
 	})
 
 	var srv *server.Server

--- a/docs/architecture/04-core-domain-model.md
+++ b/docs/architecture/04-core-domain-model.md
@@ -39,13 +39,15 @@ Fields:
     whatever its producer last held and is not to be trusted; the dispatch gate treats an
     unresolved list as blocking, the same conservative rule an unknown blocker state already
     carries one level down.
-  - Each blocker ref contains:
-    - `id` (string or null)
-    - `identifier` (string or null)
-    - `state` (string or null)
-    - `display_id` (string or null)
+  - Each blocker ref contains four string fields, and an unavailable value is the empty
+    string rather than null. Null is reserved for the `blocked_by` list itself, which is how
+    an unresolved list is distinguished from one that is known to be empty:
+    - `id` (string)
+    - `identifier` (string)
+    - `state` (string)
+    - `display_id` (string)
       - Qualified form of `identifier`, by the same rule the issue's own `display_id` follows.
-        Empty or null means `identifier` is already display-ready. A blocker ref's identifier
+        Empty means `identifier` is already display-ready. A blocker ref's identifier
         fields follow the same rule the issue's own do on every adapter: an adapter that qualifies
         its issues qualifies its blockers the same way.
   - If `blocker.state` is null or unknown, treat it as non-terminal (conservative).

--- a/docs/architecture/04-core-domain-model.md
+++ b/docs/architecture/04-core-domain-model.md
@@ -34,11 +34,20 @@ Fields:
 - `comments` (list or null)
   - Comment records containing human feedback, review notes, and prior agent workpad entries.
     Needed for continuation runs where the agent must understand prior communication.
-- `blocked_by` (list of blocker refs)
+- `blocked_by` (list of blocker refs, or null)
+  - Authoritative unless the issue is marked `blockers_unresolved`, in which case the list is
+    whatever its producer last held and is not to be trusted; the dispatch gate treats an
+    unresolved list as blocking, the same conservative rule an unknown blocker state already
+    carries one level down.
   - Each blocker ref contains:
     - `id` (string or null)
     - `identifier` (string or null)
     - `state` (string or null)
+    - `display_id` (string or null)
+      - Qualified form of `identifier`, by the same rule the issue's own `display_id` follows.
+        Empty or null means `identifier` is already display-ready. A blocker ref's identifier
+        fields follow the same rule the issue's own do on every adapter: an adapter that qualifies
+        its issues qualifies its blockers the same way.
   - If `blocker.state` is null or unknown, treat it as non-terminal (conservative).
 - `created_at` (timestamp or null)
 - `updated_at` (timestamp or null)

--- a/docs/architecture/08-polling-scheduling-and-reconciliation.md
+++ b/docs/architecture/08-polling-scheduling-and-reconciliation.md
@@ -24,7 +24,10 @@ Tick sequence:
    in step 5; it is skipped when every parked issue is already a candidate.
 9. Park each candidate whose consecutive handoff-absence count has just reached the ceiling
    (§14.2), skipped entirely under `tracker.handoff_evidence: off`.
-10. Dispatch eligible issues while slots remain.
+10. Dispatch eligible issues while slots remain. For a candidate whose tracker adapter declares the
+    per-issue blocker source, this step may read that one candidate's blocker list, bounded by the
+    per-pass read budget and its rotating window (§8.2); a candidate the budget or window excludes
+    this tick is held rather than dispatched.
 11. Notify observability/status consumers of state changes.
 
 Preflight runs first so the reload it forces is visible to reconciliation and to the sweep, not
@@ -47,6 +50,23 @@ An issue is dispatch-eligible only if all are true:
 - Blocker rule passes: for issues in any non-running active state, do not dispatch when any blocker
   is non-terminal. The blocker-gating states are the configured active states, not a hardcoded
   state name.
+- Its blockers could be resolved this tick: an issue whose blocker list could not be resolved,
+  whether because its own read failed, the read budget or rotating window excluded it, or its
+  producer declared the list incomplete, is not dispatched. The next tick retries.
+
+An adapter derives a blocker's state from the active and terminal state lists it captured at
+construction, while the orchestrator rebuilds its own terminal set from the tick's reloaded
+configuration (step 2 above), so the two vocabularies can disagree until the adapter restarts after
+a `WORKFLOW.md` edit that changes those lists. This divergence already exists on the retry lane
+(§8.4) and extends here to the poll lane's blocker resolution.
+
+For a tracker adapter whose candidate fetch cannot carry blockers, one read per needy candidate is
+bounded at a fixed per-pass budget, so a fleet with more needy candidates than the budget spends no
+more than that many blocker reads per tick. The excluded candidates are held this tick rather than
+evaluated, and a rotating window walks the needy candidates across ticks so every one is read within
+a bounded number of ticks rather than being starved behind a permanently-held head of the list. The
+window's position resets whenever a tick's budget goes unspent, so it never drifts ahead of a
+shrinking backlog.
 
 Sorting order (stable intent):
 

--- a/docs/architecture/08-polling-scheduling-and-reconciliation.md
+++ b/docs/architecture/08-polling-scheduling-and-reconciliation.md
@@ -65,7 +65,10 @@ bounded at a fixed per-pass budget, so a fleet with more needy candidates than t
 more than that many blocker reads per tick. The excluded candidates are held this tick rather than
 evaluated, and a rotating window walks the needy candidates across ticks so every one is read within
 a bounded number of ticks rather than being starved behind a permanently-held head of the list. The
-window's position resets whenever a tick's budget goes unspent, so it never drifts ahead of a
+window advances only when the budget actually denied a needy candidate its read, which is what
+leaves a backlog for the next tick to step to, and resets otherwise. A tick that spends its whole
+budget on the last needy candidates denies nobody, so it resets too: advancing there would make the
+next tick skip exactly the candidates it just served. That keeps the window from drifting ahead of a
 shrinking backlog.
 
 Sorting order (stable intent):

--- a/docs/architecture/11-issue-tracker-integration-contract.md
+++ b/docs/architecture/11-issue-tracker-integration-contract.md
@@ -64,7 +64,7 @@ Additional normalization details:
 - `priority` -> integer only (non-integers become null)
 - `created_at` and `updated_at` -> parse ISO-8601 timestamps
 
-Every candidate `fetch_candidate_issues` returns either carries an authoritative `blocked_by` or is
+Every issue returned by `fetch_candidate_issues` either carries an authoritative `blocked_by` or is
 marked `blockers_unresolved`, so the dispatch gate never treats an unread blocker list as an empty
 one. Each adapter declares which of three blocker sources it implements at registration: candidates
 carry every blocker already, the tracker has no blocking relation to carry, or a shared layer

--- a/docs/architecture/11-issue-tracker-integration-contract.md
+++ b/docs/architecture/11-issue-tracker-integration-contract.md
@@ -6,6 +6,8 @@ A tracker adapter must support these operations:
 
 1. `fetch_candidate_issues()`
    - Return issues in configured active states for the configured project.
+   - Each returned issue either carries an authoritative `blocked_by` or is marked
+     `blockers_unresolved`, per the adapter's declared blocker source (Section 11.3).
 
 2. `fetch_issue_by_id(issue_id)`
    - Return a single fully-populated issue including comments and attachments. Used for
@@ -61,6 +63,20 @@ Additional normalization details:
 - `blocked_by` -> derived from inverse relations where relation type is `blocks`
 - `priority` -> integer only (non-integers become null)
 - `created_at` and `updated_at` -> parse ISO-8601 timestamps
+
+Every candidate `fetch_candidate_issues` returns either carries an authoritative `blocked_by` or is
+marked `blockers_unresolved`, so the dispatch gate never treats an unread blocker list as an empty
+one. Each adapter declares which of three blocker sources it implements at registration: candidates
+carry every blocker already, the tracker has no blocking relation to carry, or a shared layer
+between the registry and the orchestrator completes the list per candidate, after the cheaper
+dispatch gates pass, for a candidate that reaches that gate. The declaration decides whether a
+per-issue read happens; nothing about it is inferred from a normalized field.
+
+For GitHub and Gitea, whose candidate routes cannot carry blockers, the candidate path itself does
+not read the dependencies route: it marks the candidate's blocker list unresolved and lets the
+shared resolution layer read it per candidate, after the cheaper eligibility gates pass. For GitLab,
+the always-empty `blocked_by` list is a declared capability of that adapter's registration rather
+than an inferred property of its normalization code.
 
 ### 11.4 Error Handling Contract
 
@@ -296,8 +312,11 @@ above. Its native open and closed status values are `open` and `closed`.
 - `priority` is always null, because Gitea issues carry no priority field.
 - `parent` is always null, because Gitea has no sub-issue relationship, and no parent request is
   issued.
-- `blocked_by` is read from the issue dependencies route (`/issues/{index}/dependencies`), the Gitea
-  form of the inverse `blocks` relation described in Section 11.3.
+- `blocked_by` is not read on the candidate path: `giteaIssue` carries no dependency field, so every
+  candidate is marked `blockers_unresolved` and the shared resolution layer reads the issue
+  dependencies route (`/issues/{index}/dependencies`), the Gitea form of the inverse `blocks`
+  relation described in Section 11.3, per candidate after the cheaper eligibility gates pass. The
+  by-ID read (`fetch_issue_by_id`) still reads the same route directly and clears the flag.
 - `branch_name` comes from the issue `ref` field and is stored as an opaque string.
 - `assignee` is the first entry of the issue's assignee list. Pull requests are skipped on every
   list route, so they never enter the candidate set.
@@ -398,7 +417,8 @@ intended new label rather than an error.
   request is issued.
 - `blocked_by` is always a non-nil empty slice. The issue-links route exists on Community Edition
   but accepts only the `relates_to` link type, so no `blocks` relation exists to invert as
-  Section 11.3 describes, and no links request is issued.
+  Section 11.3 describes, and no links request is issued. The adapter declares this capability
+  limit at registration rather than leaving it to be inferred from the normalization code.
 - `branch_name` is always empty, because GitLab derives branch names in the UI rather than storing
   one on the issue.
 - `assignee` is the username of the first entry of the issue's assignee list.
@@ -498,9 +518,13 @@ closed status values are `open` and `closed`, the same spelling Gitea uses.
 - `id` and `identifier` are both the repository-scoped issue number as a string; GitHub's global
   issue id is never read.
 - `priority` is always null, because GitHub issues carry no priority field.
-- `blocked_by` is read from the issue dependencies route
+- `blocked_by` is not read on the candidate path: every candidate is marked `blockers_unresolved`
+  by default, and the shared resolution layer reads the issue dependencies route
   (`/issues/{number}/dependencies/blocked_by`), the GitHub form of the inverse `blocks` relation
-  described in Section 11.3.
+  described in Section 11.3, per candidate after the cheaper eligibility gates pass. A candidate
+  whose payload carries a dependency summary proving it has no dependencies at all clears the flag
+  without a read. The by-ID read (`fetch_issue_by_id`) still reads the same route directly and
+  clears the flag.
 - `parent` comes from the issue's parent route; a missing parent (HTTP 404) normalizes to nil
   rather than an error.
 - `assignee` is the first entry of the issue's assignee list.

--- a/docs/architecture/18-logging-status-and-observability.md
+++ b/docs/architecture/18-logging-status-and-observability.md
@@ -59,6 +59,35 @@ attributes:
 Each workspace removed by the age bound also emits its own `Info` record, message `"sweep:
 removed expired workspace"`, carrying `workspace_key`, `last_activity` (RFC3339), and `age_days`.
 
+The `"tick completed"` `Info` record carries four integer attributes for the blocker gate in
+addition to its existing ones: `held_by_blockers`, `blockers_unresolved`, `blockers_not_read`, and
+`blockers_incomplete`, each counting the candidates the tick held for that reason.
+
+A candidate the dispatch gate holds for a blocker reason produces exactly one of five per-issue
+records, and a pass whose reads were refused by the forge produces exactly one pass-level record in
+addition:
+
+- Held by a non-terminal blocker: one `Debug` record, message `"candidate held by blocker"`,
+  carrying the issue context fields plus `blocker_identifier` and `blocker_state` for the first
+  non-terminal blocker.
+- Held because its own blocker read was attempted and failed: one `Warn` record, message
+  `"candidate blockers unresolved, holding issue"`, carrying the issue context fields and `error`.
+- Held because the pass had already halted on another candidate's failure: one `Debug` record,
+  message `"candidate blockers not read this tick, pass halted"`, carrying `error_kind` and no
+  `error`, because nothing failed on this candidate.
+- Held because its producer declared the list incomplete, with no read attempted: one `Debug`
+  record, message `"candidate blocker list incomplete, holding issue"`, carrying the issue context
+  fields and no `error`.
+- Held because the pass had already spent its read budget: one `Debug` record, message `"candidate
+  blockers not read this tick, holding issue"`, carrying `reads_spent` and no `error`.
+
+A pass whose reads halted emits exactly one `Error` record, message `"blocker reads halted for this
+tick"`, carrying `error_kind`, `http_status` (`0` when the failure carried none), `operation`
+(`"fetch_blockers"`), and `held_unread`. A tick that dispatches nothing because every blocker read
+it attempted failed transiently, and that did not already emit the pass-level `Error` above, emits
+one additional `Warn` record, message `"tick dispatched nothing: every attempted candidate blocker
+read failed"`, carrying `reads_failed`, the count of reads the pass attempted and lost.
+
 ### 13.2 Logging Outputs and Sinks
 
 Sortie does not prescribe where logs must go (stderr, file, remote sink, etc.).
@@ -410,12 +439,13 @@ Defined metrics (label sets and buckets are specified here; see ADR-0008 for his
 | `sortie_retries_total{trigger}` | Counter | Retry schedule events, partitioned by trigger (`error`, `continuation`, `timer`, `stall`, `ci_fix`). |
 | `sortie_reconciliation_actions_total{action}` | Counter | Reconciliation outcomes per issue, partitioned by action (`stop`, `cleanup`, `keep`, `sweep_cleanup`, `sweep_expired`). |
 | `sortie_poll_cycles_total{result}` | Counter | Poll tick completions, partitioned by result (`success`, `error`, `skipped`). |
-| `sortie_tracker_requests_total{operation,result}` | Counter | Tracker adapter API calls, partitioned by operation (`fetch_candidates`, `fetch_issue`, `fetch_by_states`, `fetch_states_by_ids`, `fetch_states_by_identifiers`, `fetch_comments`, `transition`, `comment`, `add_label`) and result (`success`, `error`). |
+| `sortie_tracker_requests_total{operation,result}` | Counter | Tracker adapter API calls, partitioned by operation (`fetch_candidates`, `fetch_issue`, `fetch_by_states`, `fetch_states_by_ids`, `fetch_states_by_identifiers`, `fetch_comments`, `fetch_blockers`, `transition`, `comment`, `add_label`) and result (`success`, `error`). |
 | `sortie_tracker_comments_total{lifecycle,result}` | Counter | Tracker comment attempts, partitioned by lifecycle point (`dispatch`, `completion`, `failure`) and result (`success`, `error`). |
 | `sortie_handoff_transitions_total{result}` | Counter | Handoff-state dispositions, partitioned by result (`success`, `error`, `skipped`, `withheld`). `withheld` means the handoff-evidence policy selected the absence failure path before any transition attempt, distinguishing it from an ordinary worker failure. `skipped` retains its two earlier causes and does not distinguish them: the issue was no longer in an active state at worker exit, or the issue was already reported terminal and the write was suppressed (Section 11.5). All four values are counted only when `tracker.handoff_state` is configured. |
 | `sortie_dispatch_transitions_total{result}` | Counter | Dispatch-time in-progress transition attempts, partitioned by result (`success`, `error`, `skipped`). `skipped` indicates the issue was already in the target state. |
 | `sortie_issue_parks_total{reason}` | Counter | Issue park events, partitioned by reason (`agent_blocked`, `handoff_absence`). Incremented once per park, whichever trigger produced it. |
 | `sortie_dispatch_rule_match_total{layer,rule}` | Counter | Dispatch rule match outcomes, partitioned by resolution layer (`rule`, `default`, `fallback`) and matched rule name. Empty rule names report as `<none>` to bound label cardinality. |
+| `sortie_candidate_holds_total{reason}` | Counter | `IncCandidateHolds`. Candidates the dispatch loop held, partitioned by reason (`blocked_by`, `blockers_unresolved`, `blockers_not_read`, `blockers_incomplete`). Incremented once per held candidate; never incremented for a candidate rejected by an eligibility or capacity gate, and never incremented a second time for the pass-level `blocker reads halted for this tick` ERROR that accompanies a run of `blockers_unresolved` holds. |
 | `sortie_tool_calls_total{tool,result}` | Counter | Agent tool call completions, partitioned by tool name and result (`success`, `error`). |
 | `sortie_ci_status_checks_total{result}` | Counter | CI status check outcomes, partitioned by result (`passing`, `pending`, `failing`, `error`). |
 | `sortie_ci_escalations_total{action}` | Counter | CI escalation actions when fix retries are exhausted, partitioned by action (`label`, `comment`, `error`). |

--- a/docs/architecture/22-test-and-validation-matrix.md
+++ b/docs/architecture/22-test-and-validation-matrix.md
@@ -87,12 +87,16 @@ Unless otherwise noted, Sections 17.1 through 17.7 are `Core Conformance`. Bulle
 - Each tracker adapter's suite exercises the shared tracker conformance assertions: normalized
   issue shape, ascending comment order, an empty-but-non-nil result on an empty list operation, a
   state map that omits an unknown id, no request issued on empty input, tracker error kind mapping
-  for every class the adapter can produce, and an additive label write
+  for every class the adapter can produce, an additive label write, a candidate's blocker fields
+  agreeing with the adapter's declared blocker source (`AssertCandidateBlockerSource`), a resolved
+  blocker list's normalization (`AssertBlockerRefsNormalized`), and a blocker ref's identifier shape
+  matching the issue's own (`AssertBlockerIdentifiersMatchIssue`)
 
 ### 17.4 Orchestrator Dispatch, Reconciliation, and Retry
 
 - Dispatch sort order is priority then oldest creation time
 - Issue with non-terminal blockers in a non-running active state is not eligible
+- An issue whose blockers could not be resolved is not eligible either
 - Issue with terminal blockers is eligible
 - Active-state issue refresh updates running entry state
 - Non-active state stops running agent without workspace cleanup

--- a/docs/gitea-adapter-notes.md
+++ b/docs/gitea-adapter-notes.md
@@ -109,7 +109,8 @@ A state label must exist in the repository before it can be attached, and the ad
 
 ## Operations
 
-Route map for the nine `TrackerAdapter` methods (`internal/domain/tracker.go`):
+Route map for the nine `TrackerAdapter` methods (`internal/domain/tracker.go`) plus the optional
+`FetchIssueBlockers` (`domain.BlockerReader`) this adapter also implements:
 
 | # | Method | Gitea route(s) |
 | --- | --- | --- |
@@ -122,6 +123,7 @@ Route map for the nine `TrackerAdapter` methods (`internal/domain/tracker.go`):
 | 7 | `TransitionIssue` | `GET .../issues/{index}` + `GET .../labels` + `DELETE .../issues/{index}/labels/{id}` + `POST .../issues/{index}/labels` + `PATCH .../issues/{index}` |
 | 8 | `CommentIssue` | `POST .../issues/{index}/comments` |
 | 9 | `AddLabel` | `GET .../labels` + optional `POST .../labels` + `POST .../issues/{index}/labels` |
+| 10 | `FetchIssueBlockers` | `GET .../issues/{index}/dependencies` |
 
 ### 1. `FetchCandidateIssues`
 
@@ -145,6 +147,31 @@ GET /repos/{owner}/{repo}/issues/{index}
 - A PR index resolves on this route and returns the PR in issue shape with `pull_request` set (verified: `GET .../issues/6` returned the PR). The adapter returns `tracker_not_found` for it, like the GitHub adapter.
 - Comments come from operation 6's route; blockers from `GET .../issues/{index}/dependencies`, which returns full issue objects for every issue **blocking** the queried one (verified: after `POST .../issues/2/dependencies {"index": 1, "owner": ..., "repo": ...}` created "1 blocks 2", the dependencies list of #2 contains #1, and `.../issues/1/blocks` contains #2; re-established live on 2026-08-11 by creating and deleting one dependency). The create route takes the blocker from the body and the blocked issue from the path, and it requires the full issue-meta body: a body carrying only `{"index": 1}` returns 404 `IsErrRepoNotExist` (verified live, 2026-08-11). Only the integration harness writes dependencies; the adapter reads them. Each blocker entry carries `number`, `state`, and `labels`, which is everything `normalizeBlockers` needs to produce a `domain.BlockerRef` with `ID` and `Identifier` set to the blocker's index and `State` derived from its labels and native state, satisfying the `blocked_by` rule in [architecture Section 11.3](architecture/11-issue-tracker-integration-contract.md#113-normalization-rules).
 - Parent is always nil and no parent request is issued: Gitea has no parent or sub-issue concept. GitHub's `.../issues/{index}/dependencies/blocked_by` and `.../issues/{index}/parent` are both absent (404, verified; re-confirmed live on 1.26.4 against a 200 on `.../issues/{index}/dependencies` as the control).
+
+### `FetchIssueBlockers` and the candidate path's blocker cost
+
+`giteaIssue` carries no dependency field, so `FetchCandidateIssues` cannot answer the blocker
+question from the candidate payload the way the GitHub adapter's `issue_dependencies_summary`
+pre-filter does: every Gitea candidate is marked `BlockersUnresolved` unconditionally, with no
+cheap zero-dependency exception. `FetchIssueBlockers`, exported on `GiteaAdapter` for the shared
+resolver between the registry and the orchestrator, wraps the same `fetchBlockers` helper
+operation 2 already calls and issues `GET .../issues/{index}/dependencies` directly, counted as
+its own `fetch_blockers` operation through `trackermetrics.Track`. A 404, or any
+other non-2xx response, is a failure on both the by-ID path and this exported path: the tolerance
+that once mapped a 404 to an empty blocker list is gone, because this route addresses a list
+resource and the forge is expected to answer a genuinely empty list with `200 []`, not `404`.
+
+Additional requests per tick are `min(N, K)`, where `N` is the candidates that reach blocker
+resolution past the cheaper eligibility and capacity gates and `K` is the per-pass read budget (4);
+there is no pre-filter to shrink `N` further here, which is the asymmetry against the GitHub
+adapter's wire format rather than a difference in mechanism.
+
+**Pending live observation.** What `GET .../issues/{index}/dependencies` returns for an existing
+issue with zero dependencies, specifically the `200 []` shape this reading assumes rather than the
+already-verified 404-on-the-wrong-path evidence above, has not been confirmed against a live Gitea
+instance as of this note. The reasoning that a list route answers an empty list with `200` rather
+than `404` is stated above as the general rule this adapter family follows; it has not yet been
+checked against this specific route on this specific forge.
 
 ### 3. `FetchIssuesByStates`
 
@@ -265,7 +292,7 @@ tracker:
 | `IssueType` | none | No native issue-type concept; always empty, like Linear |
 | `Parent` | none | No parent concept; always nil |
 | `Comments` | separate route | Markdown, no flattening |
-| `BlockedBy` | `GET .../issues/{index}/dependencies` | Full issue objects; see operation 2 |
+| `BlockedBy` | `GET .../issues/{index}/dependencies` | Full issue objects; read by `FetchIssueByID` directly and by `FetchIssueBlockers` for the shared resolver; see operation 2 |
 | `CreatedAt` | `created_at` | RFC 3339 with zone offset, parses as ISO-8601 |
 | `UpdatedAt` | `updated_at` | Same |
 

--- a/docs/github-adapter-notes.md
+++ b/docs/github-adapter-notes.md
@@ -185,6 +185,7 @@ Every `TrackerAdapter` method is implemented in `internal/scm/github/tracker.go`
 | `FetchIssueStatesByIDs` | `GET /repos/{owner}/{repo}/issues/{number}`, one per issue | `fetchStatesByNumbers` |
 | `FetchIssueStatesByIdentifiers` | Same route and same helper | `fetchStatesByNumbers` |
 | `FetchIssueComments` | `GET /repos/{owner}/{repo}/issues/{number}/comments` | `fetchAllComments` |
+| `FetchIssueBlockers` | `GET /repos/{owner}/{repo}/issues/{number}/dependencies/blocked_by` | `FetchIssueBlockers` |
 | `TransitionIssue` | Label delete, label add, and issue patch | `TransitionIssue` |
 | `CommentIssue` | `POST /repos/{owner}/{repo}/issues/{number}/comments` | `CommentIssue` |
 | `AddLabel` | `POST /repos/{owner}/{repo}/issues/{number}/labels` | `AddLabel` |
@@ -404,12 +405,76 @@ The route returns a JSON array of full issue objects that block the queried issu
 against `sortie-ai/sortie` issue #218 returns issue #299 as a blocker.
 
 `normalizeBlockers` sets both `domain.BlockerRef.ID` and `domain.BlockerRef.Identifier` to the
-blocking issue's `number` as a string, and derives `domain.BlockerRef.State` from the blocker's
-own labels with the same rule the issue read uses. A 404 on this route normalizes to an empty
-blocker list, not an error.
+blocking issue's `number` as a string, sets `domain.BlockerRef.DisplayID` to the same
+`owner/repo#N` qualified form `qualifyDisplayID` gives the issue itself, and derives
+`domain.BlockerRef.State` from the blocker's own labels with the same rule the issue read uses.
+
+The candidate routes (`FetchCandidateIssues`) do not call this route at all: a candidate is marked
+`BlockersUnresolved` and a shared resolution layer between the registry and the orchestrator calls
+`FetchIssueBlockers` per candidate, after the cheaper dispatch gates pass, bounded by a per-pass
+read budget. `FetchIssueByID` still calls this route directly and clears the flag on success. A
+404, or any other non-2xx response, is a failure rather than an empty list on both paths: this
+route addresses a list resource, so a 200 with an empty array is how the forge spells "no
+blockers," and a 404 means either the issue is gone or the route is absent, neither of which
+this adapter is entitled to read as "no blockers."
 
 This is simpler than Jira's `issuelinks` parsing: no link-type matching and no directional
 filtering.
+
+### `issue_dependencies_summary` pre-filter
+
+Both candidate routes, `GET /repos/{owner}/{repo}/issues` and `GET /search/issues`, carry a
+per-issue summary object:
+
+```json
+{
+  "issue_dependencies_summary": {
+    "blocked_by": 0,
+    "blocking": 0,
+    "total_blocked_by": 2,
+    "total_blocking": 0
+  }
+}
+```
+
+It is `null` on a pull request, which the issues route co-mingles with issues; `isPullRequest`
+already filters those before normalization reaches this field, and a null summary is read the
+same as an absent one regardless. `normalizeIssue` clears `BlockersUnresolved` on a candidate,
+leaving `BlockedBy` the non-nil empty slice, only when the summary is non-nil and
+`total_blocked_by` is exactly `0`; every other shape, including a null or absent summary, leaves
+the flag set so the resolver reads the dependencies route for that issue.
+
+`total_blocked_by` counts every dependency the issue has; `blocked_by` counts only the ones
+GitHub itself still considers open. The two diverge: `sortie-ai/sortie#877` returned
+`{"blocked_by": 0, "total_blocked_by": 2}` while both of its dependencies were closed. The
+pre-filter reads `total_blocked_by` alone, because the dispatch gate's question is "does this
+issue have any dependency at all", not "does it have an open one"; a closed dependency still
+needs a read to confirm its state maps to a configured terminal label rather than being assumed
+terminal from its native `closed` status.
+
+**Cost.** Let `D` be the candidates, past the cheaper eligibility and capacity gates, whose summary
+does not prove zero dependencies. Additional requests per tick are `min(D, K)`, where `K` is the
+per-pass read budget (4). At the default 30-second polling interval that ceiling is 480
+requests/hour, 9.6 percent of a fine-grained or classic PAT's 5,000/hour primary budget and 48
+percent of a `GITHUB_TOKEN`'s 1,000/hour budget, whatever the candidate volume. An operator who has
+created no dependencies at all pays zero additional requests: the pre-filter answers every
+candidate from the summary already on the candidate payload.
+
+### The zero-dependency response
+
+`GET .../issues/{issue_number}/dependencies/blocked_by` answers `200` with an empty JSON array for
+an existing issue that has no dependencies. It does not spell "no dependencies" as `404`. Verified
+live against `github.com` on 2026-08-22: three issues whose `issue_dependencies_summary.total_blocked_by`
+reported `0` each returned `HTTP/2 200` with `[]`, taken against a `200` control on an issue whose
+summary reported two dependencies and whose response carried both.
+
+This is what makes a `404` from this route mean the route, or a segment of its path, is absent
+rather than the list being empty, which is why `fetchBlockers` treats a not-found response as a
+failure instead of converting it to an empty list. Note the contrast with the sub-issues parent
+route below, a single-resource route where `404` legitimately means there is no parent.
+
+The same observation has not been taken against a GitHub Enterprise Server instance, whose route
+surface is not confirmed to match; it stays in [Open questions](#open-questions) below.
 
 ### `Parent` via the sub-issues route
 
@@ -932,6 +997,7 @@ the next tick's re-read rather than by the merge call.
 | Does the check-runs route default to `filter=latest`, keeping only the most recent run per check name? Neither `GetCIStatus` nor `GitHubCIProvider.FetchCIStatus` sends `filter`, so the default decides whether a superseded run still contributes to the verdict | On a commit whose checks were re-run, compare `GET .../commits/{sha}/check-runs` with `GET .../commits/{sha}/check-runs?filter=all` and diff the returned run sets |
 | Does version `2026-03-10` remove properties from routes other than `/pulls/{n}`? Only the pull request object was diffed against `2022-11-28` | Fetch `/pulls/{n}/reviews`, `/pulls/{n}/comments`, `/issues/{n}/comments`, `/issues/{n}/events`, `/commits/{sha}/status`, and `/commits/{sha}/check-runs` under both versions and diff the key sets |
 | Does GitHub Enterprise Server serve the same route surface and the same version header behavior? Nothing in this document was observed against a GHES instance | Repeat the tracker and SCM read probes against a GHES deployment with `tracker.endpoint` set to `https://<host>/api/v3` |
+| What does `GET .../issues/{n}/dependencies/blocked_by` return for an existing issue with zero dependencies against a **GHES** instance? Answered for `github.com`: `200` with an empty array, verified 2026-08-22 with a positive control, recorded above. A 404 on GHES would mean that deployment spells "none" as not-found on a list route, which has to be escalated rather than absorbed, because the adapter fixes its blocker source at registration and could not vary it per endpoint | Create an issue with zero dependencies on a scratch repository on a GHES instance and call the route directly |
 
 ---
 

--- a/docs/gitlab-adapter-notes.md
+++ b/docs/gitlab-adapter-notes.md
@@ -513,6 +513,8 @@ On an Enterprise Edition instance licensed at Premium or above, `GET .../links` 
 `link_type: "blocks"` or `"is_blocked_by"` **[source]**. The Community Edition floor requires
 the empty-slice behavior regardless.
 
+**Declared, not inferred.** The adapter's registration declares `BlockerSource: registry.BlockersUnsupported`, so the dispatch gate's shared resolution layer reads this as a positive statement that the tracker has no blocking relation to carry, rather than as a property a reader has to infer from the always-empty list `normalizeIssue` produces. `domain.Issue.BlockersUnresolved` stays false on every candidate this adapter normalizes: the empty list is complete, not unread.
+
 ---
 
 ## Operations

--- a/docs/workflow-reference.md
+++ b/docs/workflow-reference.md
@@ -2678,7 +2678,7 @@ underlying tracker system.
 | `.issue.issue_type`  | string          | Tracker-defined type (Bug, Story, Task, Epic). Empty string when absent.                                                                         |
 | `.issue.parent`      | object or nil   | Parent issue reference (sub-task relationship). `nil` when no parent.                                                                            |
 | `.issue.comments`    | list or nil     | Comment records (feedback, review notes, workpad entries). `nil` means comments were not fetched; an empty non-nil list means no comments exist. |
-| `.issue.blocked_by`  | list of objects | Blocker references, each with `.id`, `.identifier`, `.state`. Non-nil empty list when no blockers.                                               |
+| `.issue.blocked_by`  | list or nil     | Blocker references, each with `.id`, `.identifier`, `.state`, `.display_id`. `nil` means the blockers were not resolved; an empty non-nil list means no blockers exist. `.display_id` is the qualified form when the tracker's identifier alone is ambiguous (for example GitHub's `owner/repo#5` against an `identifier` of `5`) and empty otherwise. |
 | `.issue.created_at`  | string          | ISO-8601 creation timestamp. Empty string when absent.                                                                                           |
 | `.issue.updated_at`  | string          | ISO-8601 last-update timestamp. Empty string when absent.                                                                                        |
 

--- a/examples/grafana-dashboard.json
+++ b/examples/grafana-dashboard.json
@@ -2501,6 +2501,121 @@
             "title": "Dispatch Rule Matches",
             "description": "Dispatch routing resolutions per second by layer (rule, default, fallback). A high fallback share means few issues match your configured rules.",
             "type": "timeseries"
+        },
+        {
+            "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+            "fieldConfig": {
+                "defaults": {
+                    "color": { "mode": "palette-classic" },
+                    "custom": {
+                        "axisBorderShow": false,
+                        "axisCenteredZero": false,
+                        "axisColorMode": "text",
+                        "axisLabel": "",
+                        "axisPlacement": "auto",
+                        "barAlignment": 0,
+                        "drawStyle": "bars",
+                        "fillOpacity": 100,
+                        "gradientMode": "none",
+                        "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                        },
+                        "insertNulls": false,
+                        "lineInterpolation": "linear",
+                        "lineWidth": 1,
+                        "pointSize": 5,
+                        "scaleDistribution": { "type": "linear" },
+                        "showPoints": "never",
+                        "spanNulls": false,
+                        "stacking": { "group": "A", "mode": "normal" },
+                        "thresholdsStyle": { "mode": "off" }
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [{ "color": "green", "value": null }]
+                    }
+                },
+                "overrides": [
+                    {
+                        "matcher": { "id": "byName", "options": "blocked_by" },
+                        "properties": [
+                            {
+                                "id": "color",
+                                "value": {
+                                    "fixedColor": "blue",
+                                    "mode": "fixed"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "matcher": { "id": "byName", "options": "blockers_unresolved" },
+                        "properties": [
+                            {
+                                "id": "color",
+                                "value": {
+                                    "fixedColor": "red",
+                                    "mode": "fixed"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "matcher": { "id": "byName", "options": "blockers_not_read" },
+                        "properties": [
+                            {
+                                "id": "color",
+                                "value": {
+                                    "fixedColor": "yellow",
+                                    "mode": "fixed"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "matcher": { "id": "byName", "options": "blockers_incomplete" },
+                        "properties": [
+                            {
+                                "id": "color",
+                                "value": {
+                                    "fixedColor": "orange",
+                                    "mode": "fixed"
+                                }
+                            }
+                        ]
+                    }
+                ]
+            },
+            "gridPos": { "h": 8, "w": 12, "x": 0, "y": 117 },
+            "id": 40,
+            "options": {
+                "legend": {
+                    "calcs": ["sum"],
+                    "displayMode": "table",
+                    "placement": "bottom",
+                    "showLegend": true
+                },
+                "tooltip": { "mode": "multi", "sort": "desc" }
+            },
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${DS_PROMETHEUS}"
+                    },
+                    "editorMode": "code",
+                    "expr": "sum(rate(sortie_candidate_holds_total[5m])) by (reason)",
+                    "legendFormat": "{{reason}}",
+                    "range": true,
+                    "refId": "A"
+                }
+            ],
+            "title": "Candidate Holds",
+            "description": "Candidates the dispatch loop held per second by reason (blocked_by, blockers_unresolved, blockers_not_read, blockers_incomplete).",
+            "type": "timeseries"
         }
     ],
     "refresh": "30s",

--- a/internal/adaptertest/contract_test.go
+++ b/internal/adaptertest/contract_test.go
@@ -53,9 +53,11 @@ var contractBanTable = map[string]string{
 	"parseUTC":               "scmcore.ParseTimestamp or scmcore.ParseTimestampOrZero",
 }
 
-// contractTrackerAdapterMethods are the domain.TrackerAdapter method
-// names rule METRICS requires a trackermetrics.Track call inside, when
-// the enclosing package registers a tracker kind.
+// contractTrackerAdapterMethods are the tracker operation method names
+// rule METRICS requires a trackermetrics.Track call inside, when the
+// enclosing package registers a tracker kind. Most are
+// domain.TrackerAdapter methods; FetchIssueBlockers is a
+// domain.BlockerReader method instead.
 var contractTrackerAdapterMethods = map[string]bool{
 	"FetchCandidateIssues":          true,
 	"FetchIssueByID":                true,
@@ -63,13 +65,13 @@ var contractTrackerAdapterMethods = map[string]bool{
 	"FetchIssueStatesByIDs":         true,
 	"FetchIssueStatesByIdentifiers": true,
 	"FetchIssueComments":            true,
+	"FetchIssueBlockers":            true,
 	"TransitionIssue":               true,
 	"CommentIssue":                  true,
 	"AddLabel":                      true,
 }
 
-// contractRule names one of the three syntactic rules the checker
-// enforces.
+// contractRule names one of the syntactic rules the checker enforces.
 type contractRule string
 
 const (
@@ -77,6 +79,7 @@ const (
 	ruleMETRICS contractRule = "METRICS"
 	ruleHOOK    contractRule = "HOOK"
 	ruleIMPORT  contractRule = "IMPORT"
+	ruleBLOCKER contractRule = "BLOCKER"
 )
 
 // Family roots and the orchestrator path rule IMPORT matches an import
@@ -168,12 +171,13 @@ func unwrapCompositeLit(expr ast.Expr) (*ast.CompositeLit, bool) {
 	return nil, false
 }
 
-// compositeLitHasKey reports whether expr is a composite literal
-// carrying a field keyed by the given identifier name.
-func compositeLitHasKey(expr ast.Expr, key string) bool {
+// compositeLitKeyValue returns the value expression of the field keyed
+// by the given identifier name in the composite literal expr denotes,
+// or nil when expr is not such a literal or carries no such key.
+func compositeLitKeyValue(expr ast.Expr, key string) ast.Expr {
 	lit, ok := unwrapCompositeLit(expr)
 	if !ok {
-		return false
+		return nil
 	}
 	for _, elt := range lit.Elts {
 		kv, ok := elt.(*ast.KeyValueExpr)
@@ -181,6 +185,36 @@ func compositeLitHasKey(expr ast.Expr, key string) bool {
 			continue
 		}
 		if ident, ok := kv.Key.(*ast.Ident); ok && ident.Name == key {
+			return kv.Value
+		}
+	}
+	return nil
+}
+
+// compositeLitHasKey reports whether expr is a composite literal
+// carrying a field keyed by the given identifier name.
+func compositeLitHasKey(expr ast.Expr, key string) bool {
+	return compositeLitKeyValue(expr, key) != nil
+}
+
+// packageReferencesIdentifier reports whether any file in files
+// contains the bare identifier name anywhere in its syntax tree,
+// which catches both a plain reference and a selector's trailing
+// field name (e.g. issue.BlockersUnresolved).
+func packageReferencesIdentifier(files []*ast.File, name string) bool {
+	for _, file := range files {
+		found := false
+		ast.Inspect(file, func(n ast.Node) bool {
+			if found {
+				return false
+			}
+			if ident, ok := n.(*ast.Ident); ok && ident.Name == name {
+				found = true
+				return false
+			}
+			return true
+		})
+		if found {
 			return true
 		}
 	}
@@ -192,8 +226,9 @@ func compositeLitHasKey(expr ast.Expr, key string) bool {
 // resolving the "registry" qualifier from each file's own imports. It
 // reports whether the package registers a tracker kind at all, which
 // constructor form it used, and, for RegisterWithMeta, whether the meta
-// literal supplies ValidateTrackerConfig.
-func contractRegistrationFacts(fset *token.FileSet, files []*ast.File) (registers bool, usedMeta bool, hasHook bool, pos token.Position) {
+// literal supplies ValidateTrackerConfig and BlockerSource, and whether
+// BlockerSource is set to registry.BlockersPerIssue.
+func contractRegistrationFacts(fset *token.FileSet, files []*ast.File) (registers bool, usedMeta bool, hasHook bool, hasBlockerSource bool, blockerSourceIsPerIssue bool, pos token.Position) {
 	for _, file := range files {
 		registryIdent := resolveContractImportName(file, contractRegistryImportPath)
 		if registryIdent == "" {
@@ -229,12 +264,20 @@ func contractRegistrationFacts(fset *token.FileSet, files []*ast.File) (register
 				pos = fset.Position(call.Pos())
 				if len(call.Args) >= 3 {
 					hasHook = compositeLitHasKey(call.Args[2], "ValidateTrackerConfig")
+					if val := compositeLitKeyValue(call.Args[2], "BlockerSource"); val != nil {
+						hasBlockerSource = true
+						if sel, ok := val.(*ast.SelectorExpr); ok {
+							if valIdent, ok := sel.X.(*ast.Ident); ok && valIdent.Name == registryIdent && sel.Sel.Name == "BlockersPerIssue" {
+								blockerSourceIsPerIssue = true
+							}
+						}
+					}
 				}
 			}
 			return true
 		})
 	}
-	return registers, usedMeta, hasHook, pos
+	return registers, usedMeta, hasHook, hasBlockerSource, blockerSourceIsPerIssue, pos
 }
 
 // checkContractBan reports a violation for every top-level function
@@ -433,7 +476,7 @@ func checkAdapterContractPackage(fset *token.FileSet, pkg contractPackage) []con
 		}
 	}
 
-	registers, usedMeta, hasHook, hookPos := contractRegistrationFacts(fset, pkg.files)
+	registers, usedMeta, hasHook, hasBlockerSource, blockerSourceIsPerIssue, factsPos := contractRegistrationFacts(fset, pkg.files)
 
 	if !contractExempt(pkg.dirName, ruleMETRICS) {
 		for _, file := range pkg.files {
@@ -444,8 +487,23 @@ func checkAdapterContractPackage(fset *token.FileSet, pkg contractPackage) []con
 	if registers && !contractExempt(pkg.dirName, ruleHOOK) {
 		if !usedMeta || !hasHook {
 			violations = append(violations, contractViolation{
-				pos:  hookPos,
+				pos:  factsPos,
 				text: "tracker kind registers no config validation hook",
+			})
+		}
+	}
+
+	if registers && !contractExempt(pkg.dirName, ruleBLOCKER) {
+		if !usedMeta || !hasBlockerSource {
+			violations = append(violations, contractViolation{
+				pos:  factsPos,
+				text: "tracker kind registers no declared blocker source",
+			})
+		}
+		if blockerSourceIsPerIssue && !packageReferencesIdentifier(pkg.files, "BlockersUnresolved") {
+			violations = append(violations, contractViolation{
+				pos:  factsPos,
+				text: "tracker kind declares BlockersPerIssue but never references BlockersUnresolved",
 			})
 		}
 	}
@@ -590,6 +648,7 @@ import "github.com/sortie-ai/sortie/internal/registry"
 func init() {
 	registry.Trackers.RegisterWithMeta("fixture", newFixtureAdapter, registry.TrackerMeta{
 		ValidateTrackerConfig: validateConfig,
+		BlockerSource:         registry.BlockersFromCandidates,
 	})
 }
 
@@ -614,6 +673,8 @@ func record(metrics Metrics) {
 			wantCount: 1,
 		},
 		{
+			// No meta literal at all means no declared blocker source
+			// either, so this fixture is caught by both HOOK and BLOCKER.
 			name:       "a tracker kind registered through plain Register is rejected",
 			dirName:    "fixture",
 			importPath: "github.com/sortie-ai/sortie/internal/tracker/fixture",
@@ -625,7 +686,7 @@ func init() {
 	registry.Trackers.Register("fixture", newFixtureAdapter)
 }
 `,
-			wantCount: 1,
+			wantCount: 2,
 		},
 		{
 			name:       "a RegisterWithMeta literal omitting ValidateTrackerConfig is rejected",
@@ -638,6 +699,7 @@ import "github.com/sortie-ai/sortie/internal/registry"
 func init() {
 	registry.Trackers.RegisterWithMeta("fixture", newFixtureAdapter, registry.TrackerMeta{
 		RequiresProject: true,
+		BlockerSource:   registry.BlockersFromCandidates,
 	})
 }
 `,
@@ -657,6 +719,7 @@ import (
 func init() {
 	registry.Trackers.RegisterWithMeta("fixture", newFixtureAdapter, registry.TrackerMeta{
 		ValidateTrackerConfig: validateConfig,
+		BlockerSource:         registry.BlockersFromCandidates,
 	})
 }
 
@@ -669,6 +732,11 @@ func (a *fixtureAdapter) FetchIssueByID(ctx int, id string) (int, error) {
 			wantCount: 0,
 		},
 		{
+			// The fixture registers through the plain Register form, which
+			// carries no meta literal at all, so it is also caught by rule
+			// BLOCKER (no package can declare a blocker source without a
+			// meta literal to carry it); dirName "file" is allowlisted for
+			// HOOK only, so both BAN and BLOCKER fire here.
 			name:       "a package allowlisted for HOOK stays subject to BAN",
 			dirName:    "file",
 			importPath: "github.com/sortie-ai/sortie/internal/tracker/file",
@@ -682,7 +750,7 @@ func init() {
 
 func withRetry() error { return nil }
 `,
-			wantCount: 1,
+			wantCount: 2,
 		},
 		{
 			name:       "the github SCM package importing a sibling SCM adapter package is rejected",
@@ -806,6 +874,44 @@ import "github.com/sortie-ai/sortie/internal/tracker/jira"
 `,
 			wantCount: 1,
 		},
+		{
+			name:       "a per_issue package that never references BlockersUnresolved is rejected",
+			dirName:    "fixture",
+			importPath: "github.com/sortie-ai/sortie/internal/tracker/fixture",
+			src: `package fixture
+
+import "github.com/sortie-ai/sortie/internal/registry"
+
+func init() {
+	registry.Trackers.RegisterWithMeta("fixture", newFixtureAdapter, registry.TrackerMeta{
+		ValidateTrackerConfig: validateConfig,
+		BlockerSource:         registry.BlockersPerIssue,
+	})
+}
+`,
+			wantCount: 1,
+		},
+		{
+			name:       "a per_issue package that references BlockersUnresolved is accepted",
+			dirName:    "fixture",
+			importPath: "github.com/sortie-ai/sortie/internal/tracker/fixture",
+			src: `package fixture
+
+import "github.com/sortie-ai/sortie/internal/registry"
+
+func init() {
+	registry.Trackers.RegisterWithMeta("fixture", newFixtureAdapter, registry.TrackerMeta{
+		ValidateTrackerConfig: validateConfig,
+		BlockerSource:         registry.BlockersPerIssue,
+	})
+}
+
+func markUnresolved(issue *domain.Issue) {
+	issue.BlockersUnresolved = true
+}
+`,
+			wantCount: 0,
+		},
 	}
 
 	for _, tt := range tests {
@@ -829,6 +935,19 @@ import "github.com/sortie-ai/sortie/internal/tracker/jira"
 				t.Errorf("checkAdapterContractPackage() returned %d violations, want %d: %+v", len(got), tt.wantCount, got)
 			}
 		})
+	}
+}
+
+// TestContractAllowlist_BlockerRuleHasNoExemptions pins that no package
+// carries a contractAllowlist entry for ruleBLOCKER, so every
+// tracker-registering package, including file, is subject to it.
+func TestContractAllowlist_BlockerRuleHasNoExemptions(t *testing.T) {
+	t.Parallel()
+
+	for dirName, reasons := range contractAllowlist {
+		if _, exempt := reasons[ruleBLOCKER]; exempt {
+			t.Errorf("contractAllowlist[%q] exempts %q, want no exemption from that rule", dirName, ruleBLOCKER)
+		}
 	}
 }
 

--- a/internal/adaptertest/tracker.go
+++ b/internal/adaptertest/tracker.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 
 	"github.com/sortie-ai/sortie/internal/domain"
+	"github.com/sortie-ai/sortie/internal/registry"
 )
 
 // AssertIssueNormalized pins the normalization clause every tracker
@@ -124,5 +125,82 @@ func AssertLabelAddIsAdditive(t *testing.T, before, after []string, added string
 	}
 	if !slices.ContainsFunc(after, func(label string) bool { return strings.EqualFold(label, added) }) {
 		t.Errorf("AssertLabelAddIsAdditive: added label %q is missing after AddLabel", added)
+	}
+}
+
+// AssertCandidateBlockerSource pins the clause that a candidate issue's
+// blocker fields agree with the blocker source its adapter declared.
+// wantBlockers is the number of blockers the caller's fixture defines
+// for that issue.
+//
+// For a per-issue source the caller must pass a candidate whose own
+// payload does not prove the issue has no dependencies, because that is
+// the only candidate whose unresolved marking the assertion can check;
+// the assertion fails when such a candidate is not marked. A caller
+// whose fixture carries no such candidate is asserting nothing, so the
+// assertion says that in its failure message rather than passing.
+func AssertCandidateBlockerSource(t *testing.T, source registry.BlockerSource, issue domain.Issue, wantBlockers int) {
+	t.Helper()
+
+	switch source {
+	case registry.BlockersFromCandidates, registry.BlockersUnsupported:
+		if issue.BlockersUnresolved {
+			t.Errorf("AssertCandidateBlockerSource: issue.BlockersUnresolved is true for blocker source %q, want false", source)
+		}
+		if len(issue.BlockedBy) != wantBlockers {
+			t.Errorf("AssertCandidateBlockerSource: len(issue.BlockedBy) = %d, want %d", len(issue.BlockedBy), wantBlockers)
+		}
+	case registry.BlockersPerIssue:
+		if wantBlockers == 0 && !issue.BlockersUnresolved {
+			if len(issue.BlockedBy) != 0 {
+				t.Errorf("AssertCandidateBlockerSource: len(issue.BlockedBy) = %d, want 0 for a cheaply-answered no-dependency candidate", len(issue.BlockedBy))
+			}
+			return
+		}
+		if !issue.BlockersUnresolved {
+			t.Error("AssertCandidateBlockerSource: issue.BlockersUnresolved is false for a per_issue candidate the caller's fixture did not prove dependency-free; the fixture asserts nothing about the unresolved-marking clause")
+		}
+	default:
+		t.Errorf("AssertCandidateBlockerSource: unrecognized blocker source %q", source)
+	}
+}
+
+// AssertBlockerRefsNormalized pins the clause that a resolved blocker
+// list is a non-nil slice whose entries carry a stable ID and a
+// human-readable Identifier. A blocker State may be empty, which the
+// dispatch gate reads as non-terminal.
+func AssertBlockerRefsNormalized(t *testing.T, blockers []domain.BlockerRef) {
+	t.Helper()
+
+	if blockers == nil {
+		t.Error("AssertBlockerRefsNormalized: blockers is nil, want a non-nil slice even when the issue carries no blockers")
+	}
+	for i, b := range blockers {
+		if b.ID == "" {
+			t.Errorf("AssertBlockerRefsNormalized: blockers[%d].ID is empty, want a stable tracker-internal identifier", i)
+		}
+		if b.Identifier == "" {
+			t.Errorf("AssertBlockerRefsNormalized: blockers[%d].Identifier is empty, want a human-readable key", i)
+		}
+	}
+}
+
+// AssertBlockerIdentifiersMatchIssue pins the clause that a blocker ref
+// carries the same identifier shape the adapter gives an issue: an
+// unqualified Identifier, and a DisplayID that is either empty on every
+// ref or qualified on every ref, matching whether issue.DisplayID is
+// itself non-empty. issue is any issue the same adapter normalized.
+func AssertBlockerIdentifiersMatchIssue(t *testing.T, issue domain.Issue, blockers []domain.BlockerRef) {
+	t.Helper()
+
+	issueQualifies := issue.DisplayID != ""
+	for i, b := range blockers {
+		if b.Identifier != "" && strings.ContainsAny(b.Identifier, "/#") {
+			t.Errorf("AssertBlockerIdentifiersMatchIssue: blockers[%d].Identifier %q looks qualified, want the bare tracker key", i, b.Identifier)
+		}
+		refQualifies := b.DisplayID != ""
+		if refQualifies != issueQualifies {
+			t.Errorf("AssertBlockerIdentifiersMatchIssue: blockers[%d].DisplayID qualified = %v, want %v to match issue.DisplayID", i, refQualifies, issueQualifies)
+		}
 	}
 }

--- a/internal/blockers/blockers.go
+++ b/internal/blockers/blockers.go
@@ -1,0 +1,87 @@
+// Package blockers resolves the blocker list of a candidate issue
+// whose tracker adapter cannot carry one on the candidate path. Start
+// with [Resolver] and [NewResolver].
+package blockers
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/sortie-ai/sortie/internal/domain"
+	"github.com/sortie-ai/sortie/internal/registry"
+)
+
+// Resolver completes the blocker list of one issue according to the
+// blocker source its tracker adapter declared. It is safe for
+// concurrent use and holds no per-tick state.
+type Resolver struct {
+	adapter domain.TrackerAdapter
+	source  registry.BlockerSource
+	reader  domain.BlockerReader
+	logger  *slog.Logger
+}
+
+// NewResolver returns a Resolver for one tracker adapter and the
+// blocker source that adapter declared. A nil adapter yields a nil
+// Resolver, which resolves nothing.
+func NewResolver(adapter domain.TrackerAdapter, source registry.BlockerSource, logger *slog.Logger) *Resolver {
+	if adapter == nil {
+		return nil
+	}
+
+	reader, _ := adapter.(domain.BlockerReader)
+
+	return &Resolver{
+		adapter: adapter,
+		source:  source,
+		reader:  reader,
+		logger:  logger,
+	}
+}
+
+// NeedsRead reports whether Resolve would issue a tracker request for
+// issue. It answers from the declared source and the issue's own
+// flag, makes no call, and is the same two inputs Resolve decides on,
+// so a caller can price a candidate without learning the source.
+func (r *Resolver) NeedsRead(issue domain.Issue) bool {
+	if r == nil {
+		return false
+	}
+	if r.source != registry.BlockersPerIssue {
+		return false
+	}
+	return issue.BlockersUnresolved
+}
+
+// Resolve returns issue with an authoritative BlockedBy, or with
+// BlockersUnresolved set when it could not produce one. It reads only
+// when the issue still needs reading: an issue whose producer already
+// resolved the list, cheaply or otherwise, costs no request. The
+// returned issue is always safe to gate on: a caller that ignores the
+// error still holds the issue, because the flag rather than the error
+// is what the gate reads.
+func (r *Resolver) Resolve(ctx context.Context, issue domain.Issue) (domain.Issue, error) {
+	if r == nil {
+		return issue, nil
+	}
+	if r.source != registry.BlockersPerIssue {
+		return issue, nil
+	}
+	if !issue.BlockersUnresolved {
+		return issue, nil
+	}
+	if r.reader == nil {
+		issue.BlockersUnresolved = true
+		return issue, domain.ErrNoBlockerReader
+	}
+
+	blockers, err := r.reader.FetchIssueBlockers(ctx, issue.ID)
+	if err != nil {
+		issue.BlockersUnresolved = true
+		return issue, err
+	}
+
+	issue.BlockedBy = blockers
+	issue.BlockersUnresolved = false
+	return issue, nil
+}

--- a/internal/blockers/blockers_test.go
+++ b/internal/blockers/blockers_test.go
@@ -1,0 +1,331 @@
+package blockers
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/sortie-ai/sortie/internal/domain"
+	"github.com/sortie-ai/sortie/internal/registry"
+)
+
+// fakeTrackerAdapter is a minimal domain.TrackerAdapter stub. Only the
+// methods this package's tests need behave; the rest satisfy the
+// interface with zero values.
+type fakeTrackerAdapter struct{}
+
+var _ domain.TrackerAdapter = (*fakeTrackerAdapter)(nil)
+
+func (fakeTrackerAdapter) FetchCandidateIssues(context.Context) ([]domain.Issue, error) {
+	return nil, nil
+}
+func (fakeTrackerAdapter) FetchIssueByID(context.Context, string) (domain.Issue, error) {
+	return domain.Issue{}, nil
+}
+func (fakeTrackerAdapter) FetchIssuesByStates(context.Context, []string) ([]domain.Issue, error) {
+	return nil, nil
+}
+func (fakeTrackerAdapter) FetchIssueStatesByIDs(context.Context, []string) (map[string]string, error) {
+	return nil, nil
+}
+func (fakeTrackerAdapter) FetchIssueStatesByIdentifiers(context.Context, []string) (map[string]string, error) {
+	return nil, nil
+}
+func (fakeTrackerAdapter) FetchIssueComments(context.Context, string) ([]domain.Comment, error) {
+	return nil, nil
+}
+func (fakeTrackerAdapter) TransitionIssue(context.Context, string, string) error { return nil }
+func (fakeTrackerAdapter) CommentIssue(context.Context, string, string) error    { return nil }
+func (fakeTrackerAdapter) AddLabel(context.Context, string, string) error        { return nil }
+
+// fakeBlockerReaderAdapter embeds fakeTrackerAdapter and additionally
+// implements domain.BlockerReader, recording every call and returning
+// a scripted result.
+type fakeBlockerReaderAdapter struct {
+	fakeTrackerAdapter
+	calls   []string
+	blocked []domain.BlockerRef
+	err     error
+}
+
+var _ domain.BlockerReader = (*fakeBlockerReaderAdapter)(nil)
+
+func (f *fakeBlockerReaderAdapter) FetchIssueBlockers(_ context.Context, issueID string) ([]domain.BlockerRef, error) {
+	f.calls = append(f.calls, issueID)
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.blocked, nil
+}
+
+func unresolvedIssue() domain.Issue {
+	return domain.Issue{ID: "1", Identifier: "1", BlockersUnresolved: true}
+}
+
+func resolvedIssue(id string) domain.Issue {
+	return domain.Issue{ID: id, Identifier: id, BlockedBy: []domain.BlockerRef{}}
+}
+
+func TestNewResolver_NilAdapterYieldsNilResolver(t *testing.T) {
+	t.Parallel()
+
+	r := NewResolver(nil, registry.BlockersPerIssue, nil)
+	if r != nil {
+		t.Errorf("NewResolver(nil, ...) = %v, want nil", r)
+	}
+}
+
+func TestResolver_NilReceiver(t *testing.T) {
+	t.Parallel()
+
+	var r *Resolver
+
+	if got := r.NeedsRead(unresolvedIssue()); got {
+		t.Errorf("(*Resolver)(nil).NeedsRead() = %t, want false", got)
+	}
+
+	issue := unresolvedIssue()
+	got, err := r.Resolve(context.Background(), issue)
+	if err != nil {
+		t.Errorf("(*Resolver)(nil).Resolve() error = %v, want nil", err)
+	}
+	if !reflect.DeepEqual(got, issue) {
+		t.Errorf("(*Resolver)(nil).Resolve() = %+v, want the issue unchanged %+v", got, issue)
+	}
+}
+
+func TestResolver_NeedsRead(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		source registry.BlockerSource
+		issue  domain.Issue
+		want   bool
+	}{
+		{
+			name:   "candidates source never needs a read",
+			source: registry.BlockersFromCandidates,
+			issue:  unresolvedIssue(),
+			want:   false,
+		},
+		{
+			name:   "unsupported source never needs a read",
+			source: registry.BlockersUnsupported,
+			issue:  unresolvedIssue(),
+			want:   false,
+		},
+		{
+			name:   "empty source never needs a read",
+			source: "",
+			issue:  unresolvedIssue(),
+			want:   false,
+		},
+		{
+			name:   "per_issue source with resolved issue needs no read",
+			source: registry.BlockersPerIssue,
+			issue:  resolvedIssue("1"),
+			want:   false,
+		},
+		{
+			name:   "per_issue source with unresolved issue needs a read",
+			source: registry.BlockersPerIssue,
+			issue:  unresolvedIssue(),
+			want:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			r := NewResolver(&fakeBlockerReaderAdapter{}, tt.source, nil)
+			if got := r.NeedsRead(tt.issue); got != tt.want {
+				t.Errorf("NeedsRead(source=%q, issue) = %t, want %t", tt.source, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolver_Resolve(t *testing.T) {
+	t.Parallel()
+
+	sentinelErr := &domain.TrackerError{Kind: domain.ErrTrackerTransport, Message: "boom"}
+
+	tests := []struct {
+		name           string
+		source         registry.BlockerSource
+		reader         *fakeBlockerReaderAdapter // nil means the adapter carries no reader
+		issue          domain.Issue
+		wantCalls      int
+		wantErr        error
+		wantUnresolved bool
+		wantBlockedLen int
+	}{
+		{
+			name:           "candidates source returns the issue unchanged, no call",
+			source:         registry.BlockersFromCandidates,
+			reader:         &fakeBlockerReaderAdapter{},
+			issue:          unresolvedIssue(),
+			wantCalls:      0,
+			wantUnresolved: true,
+		},
+		{
+			name:           "already-resolved per_issue issue costs no call",
+			source:         registry.BlockersPerIssue,
+			reader:         &fakeBlockerReaderAdapter{},
+			issue:          resolvedIssue("1"),
+			wantCalls:      0,
+			wantUnresolved: false,
+		},
+		{
+			name:           "per_issue read succeeds and clears the flag",
+			source:         registry.BlockersPerIssue,
+			reader:         &fakeBlockerReaderAdapter{blocked: []domain.BlockerRef{{ID: "b1", Identifier: "b1"}}},
+			issue:          unresolvedIssue(),
+			wantCalls:      1,
+			wantUnresolved: false,
+			wantBlockedLen: 1,
+		},
+		{
+			name:           "per_issue read fails and sets the flag",
+			source:         registry.BlockersPerIssue,
+			reader:         &fakeBlockerReaderAdapter{err: sentinelErr},
+			issue:          unresolvedIssue(),
+			wantCalls:      1,
+			wantErr:        sentinelErr,
+			wantUnresolved: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			r := NewResolver(tt.reader, tt.source, nil)
+			got, err := r.Resolve(context.Background(), tt.issue)
+
+			if len(tt.reader.calls) != tt.wantCalls {
+				t.Errorf("reader calls = %d, want %d", len(tt.reader.calls), tt.wantCalls)
+			}
+			if tt.wantErr != nil {
+				if !errors.Is(err, tt.wantErr) {
+					t.Errorf("Resolve() error = %v, want %v", err, tt.wantErr)
+				}
+			} else if err != nil {
+				t.Errorf("Resolve() unexpected error: %v", err)
+			}
+			if got.BlockersUnresolved != tt.wantUnresolved {
+				t.Errorf("Resolve().BlockersUnresolved = %t, want %t", got.BlockersUnresolved, tt.wantUnresolved)
+			}
+			if len(got.BlockedBy) != tt.wantBlockedLen {
+				t.Errorf("Resolve().BlockedBy len = %d, want %d", len(got.BlockedBy), tt.wantBlockedLen)
+			}
+		})
+	}
+}
+
+// TestResolver_MissingReader pins that a per_issue adapter that does
+// not implement domain.BlockerReader degrades to
+// domain.ErrNoBlockerReader rather than panicking or silently
+// resolving to no blockers.
+func TestResolver_MissingReader(t *testing.T) {
+	t.Parallel()
+
+	r := NewResolver(fakeTrackerAdapter{}, registry.BlockersPerIssue, nil)
+
+	got, err := r.Resolve(context.Background(), unresolvedIssue())
+	if !errors.Is(err, domain.ErrNoBlockerReader) {
+		t.Errorf("Resolve() error = %v, want %v", err, domain.ErrNoBlockerReader)
+	}
+	if !got.BlockersUnresolved {
+		t.Error("Resolve().BlockersUnresolved = false, want true when no reader is available")
+	}
+}
+
+// TestResolver_CancelledContext pins that a cancelled context reaches
+// the reader as an ordinary read failure: the resolver does not
+// special-case it, and the issue is left unresolved.
+func TestResolver_CancelledContext(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	reader := &fakeBlockerReaderAdapter{err: context.Canceled}
+	r := NewResolver(reader, registry.BlockersPerIssue, nil)
+
+	got, err := r.Resolve(ctx, unresolvedIssue())
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("Resolve() error = %v, want context.Canceled", err)
+	}
+	if !got.BlockersUnresolved {
+		t.Error("Resolve().BlockersUnresolved = false, want true after a cancelled-context failure")
+	}
+	if len(reader.calls) != 1 {
+		t.Errorf("reader calls = %d, want 1", len(reader.calls))
+	}
+}
+
+// TestResolver_NeedsReadResolveAgreement pins that NeedsRead and
+// Resolve decide from the same two inputs (declared source, issue
+// flag): whenever NeedsRead reports false, Resolve must make no call
+// and must return the issue unchanged.
+func TestResolver_NeedsReadResolveAgreement(t *testing.T) {
+	t.Parallel()
+
+	issues := []domain.Issue{
+		unresolvedIssue(),
+		resolvedIssue("2"),
+	}
+	sources := []registry.BlockerSource{
+		registry.BlockersFromCandidates,
+		registry.BlockersUnsupported,
+		registry.BlockersPerIssue,
+		"",
+	}
+
+	for _, source := range sources {
+		for _, issue := range issues {
+			reader := &fakeBlockerReaderAdapter{blocked: []domain.BlockerRef{{ID: "x", Identifier: "x"}}}
+			r := NewResolver(reader, source, nil)
+
+			needsRead := r.NeedsRead(issue)
+			got, err := r.Resolve(context.Background(), issue)
+
+			if !needsRead {
+				if len(reader.calls) != 0 {
+					t.Errorf("source=%q issue=%q: NeedsRead=false but Resolve made %d calls, want 0", source, issue.ID, len(reader.calls))
+				}
+				if !reflect.DeepEqual(got, issue) {
+					t.Errorf("source=%q issue=%q: Resolve() = %+v, want the issue unchanged %+v", source, issue.ID, got, issue)
+				}
+				if err != nil {
+					t.Errorf("source=%q issue=%q: Resolve() error = %v, want nil", source, issue.ID, err)
+				}
+			}
+		}
+	}
+}
+
+// TestResolver_ResolveDoesNotMutateArgument pins that Resolve returns a
+// copy: the caller's original issue value is untouched even when the
+// read succeeds and changes BlockedBy and BlockersUnresolved.
+func TestResolver_ResolveDoesNotMutateArgument(t *testing.T) {
+	t.Parallel()
+
+	original := unresolvedIssue()
+	argument := original
+
+	reader := &fakeBlockerReaderAdapter{blocked: []domain.BlockerRef{{ID: "b1", Identifier: "b1"}}}
+	r := NewResolver(reader, registry.BlockersPerIssue, nil)
+
+	if _, err := r.Resolve(context.Background(), argument); err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+
+	if argument.BlockersUnresolved != original.BlockersUnresolved {
+		t.Error("Resolve mutated the caller's issue value in place")
+	}
+}

--- a/internal/domain/issue.go
+++ b/internal/domain/issue.go
@@ -73,6 +73,12 @@ type Issue struct {
 	// Non-nil empty slice when no blockers exist.
 	BlockedBy []BlockerRef
 
+	// BlockersUnresolved reports that the producer of this Issue did
+	// not resolve BlockedBy, so the list is not authoritative and the
+	// dispatch gate holds the issue. False, the zero value, means
+	// BlockedBy is authoritative.
+	BlockersUnresolved bool
+
 	// CreatedAt is an ISO-8601 timestamp. Empty string when absent.
 	CreatedAt string
 
@@ -93,6 +99,11 @@ type BlockerRef struct {
 	// State is the current state of the blocking issue. Empty string
 	// when unknown, which is treated as non-terminal (conservative).
 	State string
+
+	// DisplayID is the qualified form of Identifier, set by the same
+	// rule the adapter applies to an issue's own DisplayID. Empty
+	// means Identifier is already display-ready.
+	DisplayID string
 }
 
 // ParentRef identifies the parent issue for a sub-task.
@@ -150,13 +161,18 @@ func (iss *Issue) ToTemplateMap() map[string]any {
 		comments = cm
 	}
 
-	blockedBy := make([]map[string]any, len(iss.BlockedBy))
-	for i, b := range iss.BlockedBy {
-		blockedBy[i] = map[string]any{
-			"id":         b.ID,
-			"identifier": b.Identifier,
-			"state":      b.State,
+	var blockedBy any
+	if !iss.BlockersUnresolved {
+		bb := make([]map[string]any, len(iss.BlockedBy))
+		for i, b := range iss.BlockedBy {
+			bb[i] = map[string]any{
+				"id":         b.ID,
+				"identifier": b.Identifier,
+				"state":      b.State,
+				"display_id": b.DisplayID,
+			}
 		}
+		blockedBy = bb
 	}
 
 	labels := iss.Labels

--- a/internal/domain/issue_test.go
+++ b/internal/domain/issue_test.go
@@ -282,3 +282,75 @@ func TestToTemplateMap_NilLabelsNormalized(t *testing.T) {
 		t.Errorf("len(labels) = %d, want 0", len(labels))
 	}
 }
+
+// TestToTemplateMap_BlockedByNilWhenUnresolved pins that blocked_by
+// renders as nil when BlockersUnresolved is true, the same nil-means-
+// not-fetched rule comments already uses, rather than as an empty
+// list that would read as "no blockers" to a template.
+func TestToTemplateMap_BlockedByNilWhenUnresolved(t *testing.T) {
+	t.Parallel()
+
+	// Unresolved: renders nil even though the producer left a stale
+	// BlockedBy value in place.
+	issUnresolved := &Issue{
+		ID:                 "1",
+		Identifier:         "X-1",
+		Title:              "Unresolved",
+		State:              "Open",
+		Labels:             []string{},
+		BlockedBy:          []BlockerRef{{ID: "2", Identifier: "X-2", State: "Open"}},
+		BlockersUnresolved: true,
+	}
+	mUnresolved := issUnresolved.ToTemplateMap()
+	if mUnresolved["blocked_by"] != nil {
+		t.Errorf("blocked_by = %v, want nil when BlockersUnresolved is true", mUnresolved["blocked_by"])
+	}
+
+	// Resolved with no blockers: renders a non-nil empty list, not nil.
+	issResolved := &Issue{
+		ID:                 "2",
+		Identifier:         "X-3",
+		Title:              "Resolved",
+		State:              "Open",
+		Labels:             []string{},
+		BlockedBy:          []BlockerRef{},
+		BlockersUnresolved: false,
+	}
+	mResolved := issResolved.ToTemplateMap()
+	blockers, ok := mResolved["blocked_by"].([]map[string]any)
+	if !ok {
+		t.Fatalf("blocked_by type = %T, want []map[string]any when resolved", mResolved["blocked_by"])
+	}
+	if len(blockers) != 0 {
+		t.Errorf("len(blocked_by) = %d, want 0", len(blockers))
+	}
+}
+
+// TestToTemplateMap_BlockerDisplayID pins that each blocker entry
+// publishes display_id alongside id, identifier, and state.
+func TestToTemplateMap_BlockerDisplayID(t *testing.T) {
+	t.Parallel()
+
+	iss := &Issue{
+		ID:         "1",
+		Identifier: "X-1",
+		Title:      "Qualified blocker",
+		State:      "Open",
+		Labels:     []string{},
+		BlockedBy: []BlockerRef{
+			{ID: "5", Identifier: "5", State: "Open", DisplayID: "owner/repo#5"},
+		},
+	}
+	m := iss.ToTemplateMap()
+
+	blockers, ok := m["blocked_by"].([]map[string]any)
+	if !ok {
+		t.Fatalf("blocked_by type = %T, want []map[string]any", m["blocked_by"])
+	}
+	if len(blockers) != 1 {
+		t.Fatalf("len(blocked_by) = %d, want 1", len(blockers))
+	}
+	if blockers[0]["display_id"] != "owner/repo#5" {
+		t.Errorf("blocked_by[0].display_id = %v, want %q", blockers[0]["display_id"], "owner/repo#5")
+	}
+}

--- a/internal/domain/metrics.go
+++ b/internal/domain/metrics.go
@@ -64,8 +64,8 @@ type Metrics interface {
 	// IncTrackerRequests increments the tracker adapter API call
 	// counter. operation is one of "fetch_candidates", "fetch_issue",
 	// "fetch_comments", "fetch_by_states", "fetch_states_by_ids",
-	// "fetch_states_by_identifiers", "transition", "comment",
-	// or "add_label".
+	// "fetch_states_by_identifiers", "fetch_blockers", "transition",
+	// "comment", or "add_label".
 	// result is "success" or "error"
 	// (sortie_tracker_requests_total{operation,result} counter).
 	IncTrackerRequests(operation string, result string)
@@ -183,6 +183,13 @@ type Metrics interface {
 	// the label cardinality bounded.
 	// (sortie_dispatch_rule_match_total{layer,rule} counter).
 	IncDispatchRuleMatch(layer string, rule string)
+
+	// IncCandidateHolds increments the counter of candidates the
+	// dispatch loop held. reason is "blocked_by",
+	// "blockers_unresolved", "blockers_not_read", or
+	// "blockers_incomplete"
+	// (sortie_candidate_holds_total{reason} counter).
+	IncCandidateHolds(reason string)
 }
 
 // NoopMetrics is a [Metrics] implementation where every method is a no-op.
@@ -227,6 +234,7 @@ func (*NoopMetrics) IncAutoMergeReactions(string)                          {}
 func (*NoopMetrics) IncMergeConflictChecks(string)                         {}
 func (*NoopMetrics) IncMergeConflictEscalations(string)                    {}
 func (*NoopMetrics) IncDispatchRuleMatch(string, string)                   {}
+func (*NoopMetrics) IncCandidateHolds(string)                              {}
 
 // MetricsSetter is implemented by adapters that accept a [Metrics]
 // recorder for self-instrumentation.

--- a/internal/domain/tracker.go
+++ b/internal/domain/tracker.go
@@ -1,6 +1,9 @@
 package domain
 
-import "context"
+import (
+	"context"
+	"errors"
+)
 
 // TrackerAdapter defines the contract that all issue tracker
 // integrations must satisfy.
@@ -17,6 +20,10 @@ type TrackerAdapter interface {
 	// use [TrackerAdapter.FetchIssueByID] or
 	// [TrackerAdapter.FetchIssueComments]. Pagination is handled
 	// internally by the adapter.
+	//
+	// A returned issue either carries an authoritative BlockedBy or
+	// has BlockersUnresolved set, according to the adapter's declared
+	// blocker source.
 	FetchCandidateIssues(ctx context.Context) ([]Issue, error)
 
 	// FetchIssueByID returns a single fully-populated issue including
@@ -106,3 +113,17 @@ type TrackerAdapter interface {
 	// than an error. The orchestrator treats all errors as non-fatal.
 	AddLabel(ctx context.Context, issueID string, label string) error
 }
+
+// BlockerReader is the optional capability a tracker adapter
+// implements when its candidate fetch cannot carry blockers.
+type BlockerReader interface {
+	// FetchIssueBlockers returns the blockers of one issue. It returns
+	// a non-nil empty slice when the issue has none, and a
+	// [*TrackerError] on failure.
+	FetchIssueBlockers(ctx context.Context, issueID string) ([]BlockerRef, error)
+}
+
+// ErrNoBlockerReader reports that an adapter declared the per-issue
+// blocker source and does not implement [BlockerReader]. Callers
+// treat it as a condition the next attempt will not fix.
+var ErrNoBlockerReader = errors.New("tracker adapter declares per-issue blockers and implements no reader")

--- a/internal/orchestrator/dispatch.go
+++ b/internal/orchestrator/dispatch.go
@@ -208,19 +208,6 @@ func IsBlockedByNonTerminal(issue domain.Issue, terminalStates []string) bool {
 // because BlockedBy is not authoritative for it. This is the one
 // authority for the blocker-hold decision; every caller, including
 // [EvaluateCandidate] and the retry lane, inherits it.
-// nextBlockerReadOffset returns the offset the next pass starts from:
-// advanced by the reads this pass spent when it exhausted its budget,
-// reset to zero on every other ending, which covers a pass that walked
-// the whole candidate list, one that broke on capacity, and one that
-// halted. Resetting is what keeps the window from creeping against a
-// needy sequence that shifts as the fleet fills and drains.
-func nextBlockerReadOffset(pass *TickResolution) int {
-	if pass.budgetExhausted {
-		return pass.offset + pass.reads
-	}
-	return 0
-}
-
 func isBlockedByNonTerminalSet(issue domain.Issue, terminalSet map[string]struct{}) bool {
 	if issue.BlockersUnresolved {
 		return true
@@ -234,6 +221,21 @@ func isBlockedByNonTerminalSet(issue domain.Issue, terminalSet map[string]struct
 		}
 	}
 	return false
+}
+
+// nextBlockerReadOffset returns the offset the next pass starts from:
+// advanced by the reads this pass spent when the budget denied a needy
+// candidate its read, and reset to zero otherwise. Only a denial leaves
+// a backlog for the window to step to, so a pass that spends its whole
+// budget with nobody left to deny resets, as does one that walked the
+// whole candidate list, broke on capacity, or halted. Resetting is what
+// keeps the window from creeping against a needy sequence that shifts
+// as the fleet fills and drains.
+func nextBlockerReadOffset(pass *TickResolution) int {
+	if pass.budgetExhausted {
+		return pass.offset + pass.reads
+	}
+	return 0
 }
 
 // stateSet builds a set of lowercase state names for O(1) membership testing.

--- a/internal/orchestrator/dispatch.go
+++ b/internal/orchestrator/dispatch.go
@@ -215,7 +215,7 @@ func IsBlockedByNonTerminal(issue domain.Issue, terminalStates []string) bool {
 // halted. Resetting is what keeps the window from creeping against a
 // needy sequence that shifts as the fleet fills and drains.
 func nextBlockerReadOffset(pass *TickResolution) int {
-	if pass.reads == maxBlockerReadsPerPass {
+	if pass.budgetExhausted {
 		return pass.offset + pass.reads
 	}
 	return 0
@@ -290,6 +290,13 @@ type TickResolution struct {
 	reads      int
 	offset     int
 	heldUnread int
+
+	// budgetExhausted records that a needy candidate went unread
+	// because the budget was already spent, which is what makes a
+	// backlog exist for the next pass to step to. Spending the whole
+	// budget on the last needy candidates denies nobody, so it does
+	// not set this.
+	budgetExhausted bool
 }
 
 // passesEligibilityGates applies the seven non-blocker checks
@@ -423,6 +430,9 @@ func EvaluateCandidate(ctx context.Context, issue domain.Issue, state *State,
 			haltSkipped = true
 			pass.heldUnread++
 		case pass.reads >= maxBlockerReadsPerPass || pass.needy <= pass.offset:
+			if pass.reads >= maxBlockerReadsPerPass {
+				pass.budgetExhausted = true
+			}
 			budgetSkipped = true
 			pass.heldUnread++
 		default:

--- a/internal/orchestrator/dispatch.go
+++ b/internal/orchestrator/dispatch.go
@@ -208,6 +208,19 @@ func IsBlockedByNonTerminal(issue domain.Issue, terminalStates []string) bool {
 // because BlockedBy is not authoritative for it. This is the one
 // authority for the blocker-hold decision; every caller, including
 // [EvaluateCandidate] and the retry lane, inherits it.
+// nextBlockerReadOffset returns the offset the next pass starts from:
+// advanced by the reads this pass spent when it exhausted its budget,
+// reset to zero on every other ending, which covers a pass that walked
+// the whole candidate list, one that broke on capacity, and one that
+// halted. Resetting is what keeps the window from creeping against a
+// needy sequence that shifts as the fleet fills and drains.
+func nextBlockerReadOffset(pass *TickResolution) int {
+	if pass.reads == maxBlockerReadsPerPass {
+		return pass.offset + pass.reads
+	}
+	return 0
+}
+
 func isBlockedByNonTerminalSet(issue domain.Issue, terminalSet map[string]struct{}) bool {
 	if issue.BlockersUnresolved {
 		return true

--- a/internal/orchestrator/dispatch.go
+++ b/internal/orchestrator/dispatch.go
@@ -3,6 +3,7 @@ package orchestrator
 import (
 	"cmp"
 	"context"
+	"errors"
 	"log/slog"
 	"slices"
 	"strings"
@@ -10,6 +11,10 @@ import (
 
 	"github.com/sortie-ai/sortie/internal/domain"
 )
+
+// maxBlockerReadsPerPass bounds how many per-issue blocker reads one
+// dispatch pass may issue.
+const maxBlockerReadsPerPass = 4
 
 // SortForDispatch returns a new slice of issues sorted in dispatch priority
 // order: priority ascending (nil sorts last), created_at oldest first (empty
@@ -77,6 +82,15 @@ func compareCreatedAt(a, b string) int {
 // not running, not claimed, and blocker rule. Capacity checks (global and
 // per-state slot limits) are not included; the dispatch loop checks slot
 // availability incrementally between dispatches via [HasAvailableSlots].
+//
+// ShouldDispatch does not resolve blockers: it reads BlockedBy and
+// BlockersUnresolved as the caller's issue value already carries them
+// and issues no tracker request of its own. It MUST NOT be used to
+// make a dispatch decision on an adapter whose candidates do not
+// already carry a resolved blocker list; [EvaluateCandidate] is the
+// dispatch decision. ShouldDispatch has no production caller and
+// survives as an independent oracle other tests compare
+// [EvaluateCandidate] against.
 func ShouldDispatch(issue domain.Issue, state *State, activeStates, terminalStates []string) bool {
 	// Issues missing required fields are not eligible for dispatch.
 	if issue.ID == "" || issue.Identifier == "" || issue.Title == "" || issue.State == "" {
@@ -128,6 +142,10 @@ func ShouldDispatch(issue domain.Issue, state *State, activeStates, terminalStat
 // The dispatch loop calls this to avoid rebuilding state sets on each
 // candidate. activeSet and terminalSet must contain lowercase state names
 // built via [stateSet].
+//
+// ShouldDispatchWithSets does not resolve blockers, for the same
+// reason and with the same restriction as [ShouldDispatch].
+// [EvaluateCandidate] is the dispatch decision.
 func ShouldDispatchWithSets(issue domain.Issue, state *State, activeSet, terminalSet map[string]struct{}) bool {
 	// Issues missing required fields are not eligible for dispatch.
 	if issue.ID == "" || issue.Identifier == "" || issue.Title == "" || issue.State == "" {
@@ -185,7 +203,15 @@ func IsBlockedByNonTerminal(issue domain.Issue, terminalStates []string) bool {
 // isBlockedByNonTerminalSet is the pre-built-set variant of
 // [IsBlockedByNonTerminal]. [ShouldDispatch] calls this directly to
 // avoid rebuilding the terminal set that it already constructed.
+//
+// An issue whose BlockersUnresolved is true is treated as blocked,
+// because BlockedBy is not authoritative for it. This is the one
+// authority for the blocker-hold decision; every caller, including
+// [EvaluateCandidate] and the retry lane, inherits it.
 func isBlockedByNonTerminalSet(issue domain.Issue, terminalSet map[string]struct{}) bool {
+	if issue.BlockersUnresolved {
+		return true
+	}
 	for _, blocker := range issue.BlockedBy {
 		if blocker.State == "" {
 			return true
@@ -204,6 +230,215 @@ func stateSet(states []string) map[string]struct{} {
 		set[strings.ToLower(s)] = struct{}{}
 	}
 	return set
+}
+
+// BlockerResolver is the orchestrator's view of the blocker resolver.
+// NeedsRead lets the caller price a candidate before spending its
+// read budget on one, without the caller learning which blocker
+// source the adapter declared.
+type BlockerResolver interface {
+	NeedsRead(issue domain.Issue) bool
+	Resolve(ctx context.Context, issue domain.Issue) (domain.Issue, error)
+}
+
+// SkipReason names why a candidate was not dispatched.
+type SkipReason string
+
+const (
+	SkipNone               SkipReason = ""
+	SkipIneligible         SkipReason = "ineligible"
+	SkipBlockedBy          SkipReason = "blocked_by"
+	SkipBlockersUnresolved SkipReason = "blockers_unresolved"
+	SkipBlockersNotRead    SkipReason = "blockers_not_read"
+	SkipBlockersIncomplete SkipReason = "blockers_incomplete"
+)
+
+// CandidateDecision is the outcome of evaluating one candidate.
+type CandidateDecision struct {
+	Dispatch bool
+	Reason   SkipReason
+	Issue    domain.Issue // the issue as resolved; dispatch uses this value
+	Err      error        // resolution failure, for the caller's log record only
+}
+
+// TickResolution carries the blocker-resolution state one dispatch
+// pass owns: whether a failure has already halted reads for this
+// pass, the failure that halted them, how many candidates needing a
+// read this pass has visited so far, how many reads it has spent,
+// where in that needy order it began reading, and how many
+// candidates it held without one. Its zero value is ready to use. It
+// is not safe for concurrent use and MUST NOT be shared between
+// passes; one dispatch loop constructs one and discards it when the
+// loop ends.
+type TickResolution struct {
+	halted     bool
+	haltErr    error
+	needy      int
+	reads      int
+	offset     int
+	heldUnread int
+}
+
+// passesEligibilityGates applies the seven non-blocker checks
+// [ShouldDispatchWithSets] applies before its blocker arm, in the
+// same order: required fields, active state, not terminal, not
+// running, not claimed, not budget-exhausted, not parked. This is a
+// fresh, independent re-implementation rather than a call into
+// [ShouldDispatchWithSets], so the latter survives as an independent
+// oracle a parity test compares [EvaluateCandidate] against.
+func passesEligibilityGates(issue domain.Issue, state *State, activeSet, terminalSet map[string]struct{}) bool {
+	if issue.ID == "" || issue.Identifier == "" || issue.Title == "" || issue.State == "" {
+		return false
+	}
+
+	normalizedState := strings.ToLower(issue.State)
+
+	if _, active := activeSet[normalizedState]; !active {
+		return false
+	}
+	if _, terminal := terminalSet[normalizedState]; terminal {
+		return false
+	}
+	if _, running := state.Running[issue.ID]; running {
+		return false
+	}
+	if _, claimed := state.Claimed[issue.ID]; claimed {
+		return false
+	}
+	if _, exhausted := state.BudgetExhausted[issue.ID]; exhausted {
+		return false
+	}
+	if _, parked := state.Parked[issue.ID]; parked {
+		return false
+	}
+
+	return true
+}
+
+// classifyBlockerFailureClass reports whether a blocker-read failure
+// is deployment class, meaning the next tick's read of the same
+// candidate will not fix it, or transient class otherwise. The
+// classification reads the error alone: an adapter kind or a
+// forge-specific value is never inspected.
+func classifyBlockerFailureClass(err error) bool {
+	if errors.Is(err, domain.ErrNoBlockerReader) {
+		return true
+	}
+
+	trackerErr, ok := errors.AsType[*domain.TrackerError](err)
+	if !ok {
+		return false
+	}
+
+	if !trackerErr.Kind.RetryClassification().Retryable {
+		return true
+	}
+
+	switch trackerErr.Status {
+	case 403, 405, 410, 423, 429:
+		return true
+	default:
+		return false
+	}
+}
+
+// blockerErrorKind reports the domain error kind of a blocker-read
+// failure for observability records: the [domain.TrackerErrorKind]
+// when err wraps a [*domain.TrackerError], a fixed string for
+// [domain.ErrNoBlockerReader], and "unknown" otherwise.
+func blockerErrorKind(err error) string {
+	if err == nil {
+		return ""
+	}
+	if errors.Is(err, domain.ErrNoBlockerReader) {
+		return "no_blocker_reader"
+	}
+
+	if trackerErr, ok := errors.AsType[*domain.TrackerError](err); ok {
+		return string(trackerErr.Kind)
+	}
+
+	return "unknown"
+}
+
+// blockerErrorStatus reports the HTTP status a blocker-read failure
+// carried, or 0 when it carried none.
+func blockerErrorStatus(err error) int {
+	if trackerErr, ok := errors.AsType[*domain.TrackerError](err); ok {
+		return trackerErr.Status
+	}
+	return 0
+}
+
+// firstNonTerminalBlocker returns the first blocker whose state is
+// empty or not in terminalSet, matching the criterion
+// [isBlockedByNonTerminalSet] uses to decide the hold. Returns the
+// zero [domain.BlockerRef] when blockers has no such entry.
+func firstNonTerminalBlocker(blockers []domain.BlockerRef, terminalSet map[string]struct{}) domain.BlockerRef {
+	for _, b := range blockers {
+		if b.State == "" {
+			return b
+		}
+		if _, terminal := terminalSet[strings.ToLower(b.State)]; !terminal {
+			return b
+		}
+	}
+	return domain.BlockerRef{}
+}
+
+// EvaluateCandidate applies the issue-level dispatch gates to one
+// candidate, resolving its blockers first when, and only when, every
+// cheaper gate has already passed and this pass still has both a
+// read budget and no halting failure. Capacity is the caller's
+// business, as it is today.
+func EvaluateCandidate(ctx context.Context, issue domain.Issue, state *State,
+	activeSet, terminalSet map[string]struct{}, resolver BlockerResolver,
+	pass *TickResolution,
+) CandidateDecision {
+	if !passesEligibilityGates(issue, state, activeSet, terminalSet) {
+		return CandidateDecision{Reason: SkipIneligible, Issue: issue}
+	}
+
+	var readErr error
+	haltSkipped := false
+	budgetSkipped := false
+
+	if resolver != nil && resolver.NeedsRead(issue) {
+		pass.needy++
+		switch {
+		case pass.halted:
+			haltSkipped = true
+			pass.heldUnread++
+		case pass.reads >= maxBlockerReadsPerPass || pass.needy <= pass.offset:
+			budgetSkipped = true
+			pass.heldUnread++
+		default:
+			issue, readErr = resolver.Resolve(ctx, issue)
+			pass.reads++
+			if readErr != nil && classifyBlockerFailureClass(readErr) {
+				pass.halted = true
+				pass.haltErr = readErr
+			}
+		}
+	}
+
+	if readErr == nil && !isBlockedByNonTerminalSet(issue, terminalSet) {
+		return CandidateDecision{Dispatch: true, Issue: issue}
+	}
+
+	var reason SkipReason
+	switch {
+	case budgetSkipped:
+		reason = SkipBlockersNotRead
+	case readErr != nil || haltSkipped:
+		reason = SkipBlockersUnresolved
+	case issue.BlockersUnresolved:
+		reason = SkipBlockersIncomplete
+	default:
+		reason = SkipBlockedBy
+	}
+
+	return CandidateDecision{Reason: reason, Issue: issue, Err: readErr}
 }
 
 // NextAttempt returns the next retry attempt number. A nil input (first

--- a/internal/orchestrator/dispatch_test.go
+++ b/internal/orchestrator/dispatch_test.go
@@ -3,6 +3,8 @@ package orchestrator
 import (
 	"bytes"
 	"context"
+	"errors"
+	"fmt"
 	"log/slog"
 	"strings"
 	"sync"
@@ -507,6 +509,26 @@ func TestIsBlockedByNonTerminal(t *testing.T) {
 			},
 			terminalStates: nil,
 			want:           true,
+		},
+		{
+			name: "unresolved blockers block dispatch even with no listed blockers",
+			issue: domain.Issue{
+				ID:                 "1",
+				BlockedBy:          []domain.BlockerRef{},
+				BlockersUnresolved: true,
+			},
+			terminalStates: terminal,
+			want:           true,
+		},
+		{
+			name: "resolved empty blocker list does not block dispatch",
+			issue: domain.Issue{
+				ID:                 "1",
+				BlockedBy:          []domain.BlockerRef{},
+				BlockersUnresolved: false,
+			},
+			terminalStates: terminal,
+			want:           false,
 		},
 	}
 
@@ -1205,4 +1227,630 @@ func TestDispatchIssue(t *testing.T) {
 
 		DispatchIssue(context.Background(), s, testIssue("ISS-P"), nil, "", nil)
 	})
+}
+
+// --- EvaluateCandidate ---
+
+// fakeBlockerResolver is a test double for BlockerResolver. Both
+// functions default to a no-op when nil: NeedsRead reports false and
+// Resolve returns the issue unchanged. Every Resolve call is recorded
+// in callOrder, in the order EvaluateCandidate makes them.
+type fakeBlockerResolver struct {
+	needsReadFn func(domain.Issue) bool
+	resolveFn   func(context.Context, domain.Issue) (domain.Issue, error)
+	callOrder   []string
+}
+
+func (f *fakeBlockerResolver) NeedsRead(issue domain.Issue) bool {
+	if f.needsReadFn == nil {
+		return false
+	}
+	return f.needsReadFn(issue)
+}
+
+func (f *fakeBlockerResolver) Resolve(ctx context.Context, issue domain.Issue) (domain.Issue, error) {
+	f.callOrder = append(f.callOrder, issue.ID)
+	if f.resolveFn == nil {
+		return issue, nil
+	}
+	return f.resolveFn(ctx, issue)
+}
+
+func TestEvaluateCandidate(t *testing.T) {
+	t.Parallel()
+
+	active := []string{"To Do"}
+	terminal := []string{"Done"}
+	activeSet := stateSet(active)
+	terminalSet := stateSet(terminal)
+
+	readErr := &domain.TrackerError{Kind: domain.ErrTrackerTransport, Message: "boom"}
+
+	tests := []struct {
+		name            string
+		issue           domain.Issue
+		resolver        *fakeBlockerResolver
+		wantDispatch    bool
+		wantReason      SkipReason
+		wantErr         error
+		wantResolverLen int
+	}{
+		{
+			name:            "ineligible candidate makes zero resolver calls",
+			issue:           domain.Issue{ID: "", Identifier: "X-1", Title: "T", State: "To Do"},
+			resolver:        &fakeBlockerResolver{needsReadFn: func(domain.Issue) bool { return true }},
+			wantDispatch:    false,
+			wantReason:      SkipIneligible,
+			wantResolverLen: 0,
+		},
+		{
+			name:         "eligible with no blockers dispatches",
+			issue:        domain.Issue{ID: "1", Identifier: "X-1", Title: "T", State: "To Do"},
+			wantDispatch: true,
+			wantReason:   SkipNone,
+		},
+		{
+			name: "eligible with only a terminal blocker dispatches",
+			issue: domain.Issue{
+				ID: "1", Identifier: "X-1", Title: "T", State: "To Do",
+				BlockedBy: []domain.BlockerRef{{ID: "b", State: "Done"}},
+			},
+			wantDispatch: true,
+			wantReason:   SkipNone,
+		},
+		{
+			name: "eligible with a non-terminal blocker holds as blocked_by",
+			issue: domain.Issue{
+				ID: "1", Identifier: "X-1", Title: "T", State: "To Do",
+				BlockedBy: []domain.BlockerRef{{ID: "b", State: "To Do"}},
+			},
+			wantDispatch: false,
+			wantReason:   SkipBlockedBy,
+		},
+		{
+			name: "resolver read failure holds as blockers_unresolved and carries the error",
+			issue: domain.Issue{
+				ID: "1", Identifier: "X-1", Title: "T", State: "To Do", BlockersUnresolved: true,
+			},
+			resolver: &fakeBlockerResolver{
+				needsReadFn: func(domain.Issue) bool { return true },
+				resolveFn: func(_ context.Context, issue domain.Issue) (domain.Issue, error) {
+					issue.BlockersUnresolved = true
+					return issue, readErr
+				},
+			},
+			wantDispatch:    false,
+			wantReason:      SkipBlockersUnresolved,
+			wantErr:         readErr,
+			wantResolverLen: 1,
+		},
+		{
+			name: "producer-declared incomplete list with no read attempted",
+			issue: domain.Issue{
+				ID: "1", Identifier: "X-1", Title: "T", State: "To Do", BlockersUnresolved: true,
+			},
+			resolver:        &fakeBlockerResolver{needsReadFn: func(domain.Issue) bool { return false }},
+			wantDispatch:    false,
+			wantReason:      SkipBlockersIncomplete,
+			wantResolverLen: 0,
+		},
+		{
+			name: "a resolver error holds the candidate even when it leaves the flag false",
+			issue: domain.Issue{
+				ID: "1", Identifier: "X-1", Title: "T", State: "To Do", BlockersUnresolved: true,
+			},
+			resolver: &fakeBlockerResolver{
+				needsReadFn: func(domain.Issue) bool { return true },
+				resolveFn: func(_ context.Context, issue domain.Issue) (domain.Issue, error) {
+					issue.BlockersUnresolved = false
+					return issue, readErr
+				},
+			},
+			wantDispatch:    false,
+			wantReason:      SkipBlockersUnresolved,
+			wantErr:         readErr,
+			wantResolverLen: 1,
+		},
+		{
+			name: "nil resolver reproduces today's ShouldDispatchWithSets behavior when blocked",
+			issue: domain.Issue{
+				ID: "1", Identifier: "X-1", Title: "T", State: "To Do",
+				BlockedBy: []domain.BlockerRef{{ID: "b", State: "To Do"}},
+			},
+			resolver:     nil,
+			wantDispatch: false,
+			wantReason:   SkipBlockedBy,
+		},
+		{
+			name:         "nil resolver reproduces today's ShouldDispatchWithSets behavior when eligible",
+			issue:        domain.Issue{ID: "1", Identifier: "X-1", Title: "T", State: "To Do"},
+			resolver:     nil,
+			wantDispatch: true,
+			wantReason:   SkipNone,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			s := NewState(1000, 10, nil, AgentTotals{})
+			pass := &TickResolution{}
+
+			var resolver BlockerResolver
+			if tt.resolver != nil {
+				resolver = tt.resolver
+			}
+
+			got := EvaluateCandidate(context.Background(), tt.issue, s, activeSet, terminalSet, resolver, pass)
+
+			if got.Dispatch != tt.wantDispatch {
+				t.Errorf("EvaluateCandidate(%q).Dispatch = %t, want %t", tt.issue.Identifier, got.Dispatch, tt.wantDispatch)
+			}
+			if got.Reason != tt.wantReason {
+				t.Errorf("EvaluateCandidate(%q).Reason = %q, want %q", tt.issue.Identifier, got.Reason, tt.wantReason)
+			}
+			if tt.wantErr != nil {
+				if !errors.Is(got.Err, tt.wantErr) {
+					t.Errorf("EvaluateCandidate(%q).Err = %v, want %v", tt.issue.Identifier, got.Err, tt.wantErr)
+				}
+			} else if got.Err != nil {
+				t.Errorf("EvaluateCandidate(%q).Err = %v, want nil", tt.issue.Identifier, got.Err)
+			}
+			if tt.resolver != nil && len(tt.resolver.callOrder) != tt.wantResolverLen {
+				t.Errorf("resolver calls = %d, want %d", len(tt.resolver.callOrder), tt.wantResolverLen)
+			}
+		})
+	}
+}
+
+// TestEvaluateCandidate_ParityWithShouldDispatchWithSets pins that for
+// an issue whose blockers are already resolved, EvaluateCandidate's
+// dispatch decision agrees with the independent ShouldDispatchWithSets
+// oracle. Both predicates are exercised over the same table so a
+// divergence in either fails the test.
+func TestEvaluateCandidate_ParityWithShouldDispatchWithSets(t *testing.T) {
+	t.Parallel()
+
+	active := []string{"To Do"}
+	terminal := []string{"Done"}
+	activeSet := stateSet(active)
+	terminalSet := stateSet(terminal)
+
+	issues := []domain.Issue{
+		{ID: "1", Identifier: "X-1", Title: "T", State: "To Do"},
+		{ID: "2", Identifier: "X-2", Title: "T", State: "Backlog"},
+		{
+			ID: "3", Identifier: "X-3", Title: "T", State: "To Do",
+			BlockedBy: []domain.BlockerRef{{ID: "b", State: "To Do"}},
+		},
+		{
+			ID: "4", Identifier: "X-4", Title: "T", State: "To Do",
+			BlockedBy: []domain.BlockerRef{{ID: "b", State: "Done"}},
+		},
+		{ID: "", Identifier: "X-5", Title: "T", State: "To Do"},
+	}
+
+	for _, issue := range issues {
+		t.Run(issue.Identifier, func(t *testing.T) {
+			t.Parallel()
+
+			s := NewState(1000, 10, nil, AgentTotals{})
+			pass := &TickResolution{}
+
+			decision := EvaluateCandidate(context.Background(), issue, s, activeSet, terminalSet, nil, pass)
+			want := ShouldDispatchWithSets(issue, s, activeSet, terminalSet)
+
+			if decision.Dispatch != want {
+				t.Errorf("EvaluateCandidate(%q).Dispatch = %t, ShouldDispatchWithSets(%q) = %t, want equal",
+					issue.Identifier, decision.Dispatch, issue.Identifier, want)
+			}
+		})
+	}
+}
+
+func TestClassifyBlockerFailureClass(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		err            error
+		wantDeployment bool
+	}{
+		{
+			name:           "ErrNoBlockerReader is deployment class",
+			err:            domain.ErrNoBlockerReader,
+			wantDeployment: true,
+		},
+		{
+			name:           "auth error is deployment class",
+			err:            &domain.TrackerError{Kind: domain.ErrTrackerAuth},
+			wantDeployment: true,
+		},
+		{
+			name:           "not found error is deployment class",
+			err:            &domain.TrackerError{Kind: domain.ErrTrackerNotFound, Status: 404},
+			wantDeployment: true,
+		},
+		{
+			name:           "payload error is deployment class",
+			err:            &domain.TrackerError{Kind: domain.ErrTrackerPayload},
+			wantDeployment: true,
+		},
+		{
+			name:           "api error with status 403 is deployment class",
+			err:            &domain.TrackerError{Kind: domain.ErrTrackerAPI, Status: 403},
+			wantDeployment: true,
+		},
+		{
+			name:           "api error with status 429 is deployment class",
+			err:            &domain.TrackerError{Kind: domain.ErrTrackerAPI, Status: 429},
+			wantDeployment: true,
+		},
+		{
+			name:           "api error with status 423 is deployment class",
+			err:            &domain.TrackerError{Kind: domain.ErrTrackerAPI, Status: 423},
+			wantDeployment: true,
+		},
+		{
+			name:           "api error with status 405 is deployment class",
+			err:            &domain.TrackerError{Kind: domain.ErrTrackerAPI, Status: 405},
+			wantDeployment: true,
+		},
+		{
+			name:           "api error with status 410 is deployment class",
+			err:            &domain.TrackerError{Kind: domain.ErrTrackerAPI, Status: 410},
+			wantDeployment: true,
+		},
+		{
+			name:           "api error with status 500 stays transient",
+			err:            &domain.TrackerError{Kind: domain.ErrTrackerAPI, Status: 500},
+			wantDeployment: false,
+		},
+		{
+			name:           "transport error stays transient",
+			err:            &domain.TrackerError{Kind: domain.ErrTrackerTransport},
+			wantDeployment: false,
+		},
+		{
+			name:           "cancelled context stays transient",
+			err:            context.Canceled,
+			wantDeployment: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := classifyBlockerFailureClass(tt.err)
+			if got != tt.wantDeployment {
+				t.Errorf("classifyBlockerFailureClass(%v) = %t, want %t", tt.err, got, tt.wantDeployment)
+			}
+		})
+	}
+}
+
+// TestEvaluateCandidate_HaltLatch pins that once a deployment-class
+// failure halts a pass, every later candidate needing a read is held
+// with zero further resolver calls, and the halting error is recorded
+// only against the candidate whose own read produced it.
+func TestEvaluateCandidate_HaltLatch(t *testing.T) {
+	t.Parallel()
+
+	active := []string{"To Do"}
+	terminal := []string{"Done"}
+	activeSet := stateSet(active)
+	terminalSet := stateSet(terminal)
+
+	deploymentErr := &domain.TrackerError{Kind: domain.ErrTrackerAuth}
+
+	s := NewState(1000, 10, nil, AgentTotals{})
+	pass := &TickResolution{}
+
+	resolver := &fakeBlockerResolver{
+		needsReadFn: func(domain.Issue) bool { return true },
+		resolveFn: func(_ context.Context, issue domain.Issue) (domain.Issue, error) {
+			issue.BlockersUnresolved = true
+			return issue, deploymentErr
+		},
+	}
+
+	first := domain.Issue{ID: "1", Identifier: "X-1", Title: "T", State: "To Do", BlockersUnresolved: true}
+	second := domain.Issue{ID: "2", Identifier: "X-2", Title: "T", State: "To Do", BlockersUnresolved: true}
+	third := domain.Issue{ID: "3", Identifier: "X-3", Title: "T", State: "To Do", BlockersUnresolved: true}
+
+	got1 := EvaluateCandidate(context.Background(), first, s, activeSet, terminalSet, resolver, pass)
+	if got1.Reason != SkipBlockersUnresolved || !errors.Is(got1.Err, deploymentErr) {
+		t.Fatalf("first candidate decision = %+v, want reason %q carrying the halting error", got1, SkipBlockersUnresolved)
+	}
+	if !pass.halted {
+		t.Fatal("pass.halted = false after a deployment-class failure, want true")
+	}
+
+	got2 := EvaluateCandidate(context.Background(), second, s, activeSet, terminalSet, resolver, pass)
+	got3 := EvaluateCandidate(context.Background(), third, s, activeSet, terminalSet, resolver, pass)
+
+	if len(resolver.callOrder) != 1 {
+		t.Errorf("resolver calls after halt = %d, want 1 (only the candidate that halted the pass)", len(resolver.callOrder))
+	}
+	if got2.Reason != SkipBlockersUnresolved || got2.Err != nil {
+		t.Errorf("halt-skipped candidate decision = %+v, want reason %q with no per-issue error", got2, SkipBlockersUnresolved)
+	}
+	if got3.Reason != SkipBlockersUnresolved || got3.Err != nil {
+		t.Errorf("halt-skipped candidate decision = %+v, want reason %q with no per-issue error", got3, SkipBlockersUnresolved)
+	}
+	if pass.heldUnread != 2 {
+		t.Errorf("pass.heldUnread = %d, want 2", pass.heldUnread)
+	}
+}
+
+// TestEvaluateCandidate_TransientFailureDoesNotHalt pins that a
+// transient-class failure holds only the candidate it happened to,
+// and the pass keeps reading later candidates.
+func TestEvaluateCandidate_TransientFailureDoesNotHalt(t *testing.T) {
+	t.Parallel()
+
+	active := []string{"To Do"}
+	terminal := []string{"Done"}
+	activeSet := stateSet(active)
+	terminalSet := stateSet(terminal)
+
+	transientErr := &domain.TrackerError{Kind: domain.ErrTrackerTransport}
+
+	s := NewState(1000, 10, nil, AgentTotals{})
+	pass := &TickResolution{}
+
+	resolver := &fakeBlockerResolver{
+		needsReadFn: func(domain.Issue) bool { return true },
+		resolveFn: func(_ context.Context, issue domain.Issue) (domain.Issue, error) {
+			issue.BlockersUnresolved = true
+			return issue, transientErr
+		},
+	}
+
+	first := domain.Issue{ID: "1", Identifier: "X-1", Title: "T", State: "To Do", BlockersUnresolved: true}
+	second := domain.Issue{ID: "2", Identifier: "X-2", Title: "T", State: "To Do", BlockersUnresolved: true}
+
+	EvaluateCandidate(context.Background(), first, s, activeSet, terminalSet, resolver, pass)
+	if pass.halted {
+		t.Fatal("pass.halted = true after a transient-class failure, want false")
+	}
+
+	EvaluateCandidate(context.Background(), second, s, activeSet, terminalSet, resolver, pass)
+	if len(resolver.callOrder) != 2 {
+		t.Errorf("resolver calls = %d, want 2 (transient failure does not halt the pass)", len(resolver.callOrder))
+	}
+}
+
+// --- Read budget window ---
+
+// budgetWindowIssueCount is the fixed number of needy candidates
+// budgetWindowIssues returns: more than maxBlockerReadsPerPass, so the
+// read budget binds in every test that uses this fixture.
+const budgetWindowIssueCount = 6
+
+// budgetWindowIssues returns budgetWindowIssueCount needy candidates
+// that stay eligible and needy across as many passes as the caller
+// drives: nothing in the table claims, runs, or exhausts them, so only
+// a read outcome changes their state.
+func budgetWindowIssues() []domain.Issue {
+	issues := make([]domain.Issue, budgetWindowIssueCount)
+	for i := range issues {
+		id := fmt.Sprintf("N-%d", i+1)
+		issues[i] = domain.Issue{ID: id, Identifier: id, Title: "T", State: "To Do", BlockersUnresolved: true}
+	}
+	return issues
+}
+
+// advanceBlockerReadOffset applies the same rule the orchestrator's
+// tick loop applies after a pass ends: advance by the reads spent when
+// the budget was exhausted, reset to zero on every other ending
+// (walked the whole list, broke on capacity, or halted).
+func advanceBlockerReadOffset(pass *TickResolution) int {
+	if pass.reads == maxBlockerReadsPerPass {
+		return pass.offset + pass.reads
+	}
+	return 0
+}
+
+// TestEvaluateCandidate_ReadBudgetWindow pins the read-budget window
+// over a fixture with more needy candidates than maxBlockerReadsPerPass:
+// each pass reads exactly the budget, holds the remainder as
+// blockers_not_read, and the offset rotation reaches every needy
+// candidate within the starvation bound.
+func TestEvaluateCandidate_ReadBudgetWindow(t *testing.T) {
+	t.Parallel()
+
+	active := []string{"To Do"}
+	terminal := []string{"Done"}
+	activeSet := stateSet(active)
+	terminalSet := stateSet(terminal)
+	transientErr := &domain.TrackerError{Kind: domain.ErrTrackerTransport}
+
+	const needyCount = 6
+	issues := budgetWindowIssues()
+
+	resolver := &fakeBlockerResolver{
+		needsReadFn: func(issue domain.Issue) bool { return issue.BlockersUnresolved },
+		resolveFn: func(_ context.Context, issue domain.Issue) (domain.Issue, error) {
+			issue.BlockersUnresolved = true
+			return issue, transientErr
+		},
+	}
+
+	s := NewState(1000, 10, nil, AgentTotals{})
+	offset := 0
+
+	wantPasses := (needyCount + maxBlockerReadsPerPass - 1) / maxBlockerReadsPerPass
+	var perPassReads [][]string
+	var perPassNotRead []int
+
+	for passNum := range wantPasses {
+		pass := &TickResolution{offset: offset}
+		before := len(resolver.callOrder)
+		notRead := 0
+
+		for _, issue := range issues {
+			decision := EvaluateCandidate(context.Background(), issue, s, activeSet, terminalSet, resolver, pass)
+			if decision.Reason == SkipBlockersNotRead {
+				notRead++
+			}
+		}
+
+		perPassReads = append(perPassReads, resolver.callOrder[before:])
+		perPassNotRead = append(perPassNotRead, notRead)
+		offset = advanceBlockerReadOffset(pass)
+
+		if passNum < wantPasses-1 {
+			if pass.reads != maxBlockerReadsPerPass {
+				t.Fatalf("pass %d: reads = %d, want the full budget %d (not yet the last pass)", passNum, pass.reads, maxBlockerReadsPerPass)
+			}
+		}
+	}
+
+	if len(perPassReads[0]) != maxBlockerReadsPerPass {
+		t.Errorf("pass 0 reads = %d, want %d", len(perPassReads[0]), maxBlockerReadsPerPass)
+	}
+	if perPassNotRead[0] != needyCount-maxBlockerReadsPerPass {
+		t.Errorf("pass 0 blockers_not_read count = %d, want %d", perPassNotRead[0], needyCount-maxBlockerReadsPerPass)
+	}
+
+	totalReads := 0
+	for _, reads := range perPassReads {
+		totalReads += len(reads)
+	}
+	if totalReads != needyCount {
+		t.Errorf("total reads across %d passes = %d, want %d (every needy candidate read within the starvation bound)", wantPasses, totalReads, needyCount)
+	}
+
+	// The candidates a read was attempted on, across every pass in
+	// order, are pass 1's four followed by pass 2's two: the rotation
+	// covers the whole population without repeating anyone early.
+	var gotOrder []string
+	for _, reads := range perPassReads {
+		gotOrder = append(gotOrder, reads...)
+	}
+	wantOrder := []string{"N-1", "N-2", "N-3", "N-4", "N-5", "N-6"}
+	if !equalStringSlice(gotOrder, wantOrder) {
+		t.Errorf("read order across passes = %v, want %v", gotOrder, wantOrder)
+	}
+}
+
+// TestEvaluateCandidate_OffsetResetsOnCapacityBreak pins that the
+// offset-advance rule resets to zero on a pass that ends by walking
+// only part of the list (a capacity break), not only on a pass that
+// completes its walk without exhausting the budget.
+func TestEvaluateCandidate_OffsetResetsOnCapacityBreak(t *testing.T) {
+	t.Parallel()
+
+	active := []string{"To Do"}
+	terminal := []string{"Done"}
+	activeSet := stateSet(active)
+	terminalSet := stateSet(terminal)
+
+	issues := budgetWindowIssues()
+	resolver := &fakeBlockerResolver{
+		needsReadFn: func(issue domain.Issue) bool { return issue.BlockersUnresolved },
+		resolveFn: func(_ context.Context, issue domain.Issue) (domain.Issue, error) {
+			issue.BlockersUnresolved = false
+			return issue, nil
+		},
+	}
+
+	s := NewState(1000, 10, nil, AgentTotals{})
+	pass := &TickResolution{offset: 0}
+
+	// A capacity break stops the walk after two candidates, well under
+	// the read budget.
+	for _, issue := range issues[:2] {
+		EvaluateCandidate(context.Background(), issue, s, activeSet, terminalSet, resolver, pass)
+	}
+
+	if pass.reads != 2 {
+		t.Fatalf("pass.reads = %d, want 2 before checking the reset rule", pass.reads)
+	}
+	if got := advanceBlockerReadOffset(pass); got != 0 {
+		t.Errorf("offset after a capacity break with %d reads (below budget) = %d, want 0", pass.reads, got)
+	}
+}
+
+// TestEvaluateCandidate_DispatchedOrderPreservingSubsequence pins that
+// a budget-bounded pass's dispatched issues form an order-preserving
+// subsequence of what an equivalent budget-lifted resolution (the same
+// candidates fully read across enough passes) would have dispatched.
+// Whole-sequence equality is not asserted: it is not satisfiable once
+// the budget binds.
+func TestEvaluateCandidate_DispatchedOrderPreservingSubsequence(t *testing.T) {
+	t.Parallel()
+
+	active := []string{"To Do"}
+	terminal := []string{"Done"}
+	activeSet := stateSet(active)
+	terminalSet := stateSet(terminal)
+
+	issues := budgetWindowIssues()
+	resolveOK := func(_ context.Context, issue domain.Issue) (domain.Issue, error) {
+		issue.BlockersUnresolved = false
+		return issue, nil
+	}
+
+	// Budget-bounded run: one pass, offset 0.
+	boundedResolver := &fakeBlockerResolver{
+		needsReadFn: func(issue domain.Issue) bool { return issue.BlockersUnresolved },
+		resolveFn:   resolveOK,
+	}
+	boundedState := NewState(1000, 10, nil, AgentTotals{})
+	boundedPass := &TickResolution{offset: 0}
+	var boundedDispatched []string
+	for _, issue := range issues {
+		decision := EvaluateCandidate(context.Background(), issue, boundedState, activeSet, terminalSet, boundedResolver, boundedPass)
+		if decision.Dispatch {
+			boundedDispatched = append(boundedDispatched, issue.ID)
+		}
+	}
+
+	// Budget-lifted run: enough passes over an independent state to
+	// read every needy candidate at least once.
+	liftedResolver := &fakeBlockerResolver{
+		needsReadFn: func(issue domain.Issue) bool { return issue.BlockersUnresolved },
+		resolveFn:   resolveOK,
+	}
+	liftedState := NewState(1000, 10, nil, AgentTotals{})
+	var liftedDispatched []string
+	offset := 0
+	wantPasses := (len(issues) + maxBlockerReadsPerPass - 1) / maxBlockerReadsPerPass
+	for range wantPasses {
+		pass := &TickResolution{offset: offset}
+		for _, issue := range issues {
+			decision := EvaluateCandidate(context.Background(), issue, liftedState, activeSet, terminalSet, liftedResolver, pass)
+			if decision.Dispatch {
+				liftedDispatched = append(liftedDispatched, issue.ID)
+			}
+		}
+		offset = advanceBlockerReadOffset(pass)
+	}
+
+	if len(boundedDispatched) == 0 {
+		t.Fatal("bounded run dispatched nothing; the test fixture does not exercise the budget")
+	}
+	if len(boundedDispatched) >= len(liftedDispatched) {
+		t.Fatalf("bounded dispatched %v, lifted dispatched %v: the budget must strictly reduce what one pass dispatches for this assertion to have teeth",
+			boundedDispatched, liftedDispatched)
+	}
+	if !isOrderPreservingSubsequence(boundedDispatched, liftedDispatched) {
+		t.Errorf("bounded dispatched %v is not an order-preserving subsequence of lifted dispatched %v", boundedDispatched, liftedDispatched)
+	}
+}
+
+// isOrderPreservingSubsequence reports whether sub appears in full,
+// in order, within full (not necessarily contiguous).
+func isOrderPreservingSubsequence(sub, full []string) bool {
+	i := 0
+	for _, v := range full {
+		if i < len(sub) && sub[i] == v {
+			i++
+		}
+	}
+	return i == len(sub)
 }

--- a/internal/orchestrator/dispatch_test.go
+++ b/internal/orchestrator/dispatch_test.go
@@ -1849,3 +1849,59 @@ func isOrderPreservingSubsequence(sub, full []string) bool {
 	}
 	return i == len(sub)
 }
+
+// TestEvaluateCandidate_BudgetSpentWithoutBinding pins the case where a
+// pass spends its whole read budget on the last needy candidates and
+// denies none: the budget did not bind, so no candidate is waiting for
+// a later pass and the window must not step over anything. Advancing
+// here would make the next pass skip exactly those candidates, so the
+// two passes would alternate between reading everything and reading
+// nothing.
+func TestEvaluateCandidate_BudgetSpentWithoutBinding(t *testing.T) {
+	t.Parallel()
+
+	activeSet := stateSet([]string{"To Do"})
+	terminalSet := stateSet([]string{"Done"})
+
+	issues := make([]domain.Issue, maxBlockerReadsPerPass)
+	for i := range issues {
+		id := fmt.Sprintf("E-%d", i+1)
+		issues[i] = domain.Issue{ID: id, Identifier: id, Title: "T", State: "To Do", BlockersUnresolved: true}
+	}
+
+	resolver := &fakeBlockerResolver{
+		needsReadFn: func(issue domain.Issue) bool { return issue.BlockersUnresolved },
+		resolveFn: func(_ context.Context, issue domain.Issue) (domain.Issue, error) {
+			issue.BlockersUnresolved = false
+			issue.BlockedBy = nil
+			return issue, nil
+		},
+	}
+
+	s := NewState(1000, 10, nil, AgentTotals{})
+	offset := 0
+
+	for passNum := range 2 {
+		pass := &TickResolution{offset: offset}
+		before := len(resolver.callOrder)
+		dispatched := 0
+
+		for _, issue := range issues {
+			if EvaluateCandidate(context.Background(), issue, s, activeSet, terminalSet, resolver, pass).Dispatch {
+				dispatched++
+			}
+		}
+
+		if got := len(resolver.callOrder) - before; got != maxBlockerReadsPerPass {
+			t.Errorf("pass %d: read %d candidates, want %d", passNum+1, got, maxBlockerReadsPerPass)
+		}
+		if dispatched != len(issues) {
+			t.Errorf("pass %d: dispatched %d, want %d", passNum+1, dispatched, len(issues))
+		}
+
+		offset = advanceBlockerReadOffset(pass)
+		if offset != 0 {
+			t.Errorf("pass %d: next offset = %d, want 0 because no candidate was denied a read", passNum+1, offset)
+		}
+	}
+}

--- a/internal/orchestrator/dispatch_test.go
+++ b/internal/orchestrator/dispatch_test.go
@@ -1643,15 +1643,10 @@ func budgetWindowIssues() []domain.Issue {
 	return issues
 }
 
-// advanceBlockerReadOffset applies the same rule the orchestrator's
-// tick loop applies after a pass ends: advance by the reads spent when
-// the budget was exhausted, reset to zero on every other ending
-// (walked the whole list, broke on capacity, or halted).
+// advanceBlockerReadOffset delegates to the production rule so these
+// tests cannot pass against a stale copy of it.
 func advanceBlockerReadOffset(pass *TickResolution) int {
-	if pass.reads == maxBlockerReadsPerPass {
-		return pass.offset + pass.reads
-	}
-	return 0
+	return nextBlockerReadOffset(pass)
 }
 
 // TestEvaluateCandidate_ReadBudgetWindow pins the read-budget window

--- a/internal/orchestrator/metrics_test.go
+++ b/internal/orchestrator/metrics_test.go
@@ -36,6 +36,7 @@ type spyMetrics struct {
 	workerDurations      []workerDurCall
 	sshHostUsage         []sshHostUsageCall
 	trackerComments      []trackerCommentCall
+	candidateHolds       []string
 }
 
 type tokenCall struct {
@@ -217,6 +218,12 @@ func (s *spyMetrics) IncMergeConflictChecks(_ string) {}
 func (s *spyMetrics) IncMergeConflictEscalations(_ string) {}
 
 func (s *spyMetrics) IncDispatchRuleMatch(_ string, _ string) {}
+
+func (s *spyMetrics) IncCandidateHolds(reason string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.candidateHolds = append(s.candidateHolds, reason)
+}
 
 // --- Tests ---
 

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -198,9 +198,14 @@ type OrchestratorParams struct {
 	AgentAdapterByKind func(kind string) (domain.AgentAdapter, error)
 
 	// BlockerResolver completes a candidate's blocker list according
-	// to its tracker adapter's declared blocker source. Optional: a
-	// nil value means "resolve nothing", which reproduces the
-	// orchestrator's behavior before this collaborator existed.
+	// to its tracker adapter's declared blocker source. Optional, and
+	// nil means no blocker read happens. That is equivalent to the
+	// behavior before this collaborator existed only for an adapter
+	// whose candidates already carry every blocker; for an adapter
+	// that resolves blockers per issue, candidates stay marked
+	// unresolved and the gate holds every one of them, because an
+	// unread list is never read as an empty one. The production
+	// binary always populates this field.
 	BlockerResolver BlockerResolver
 }
 
@@ -729,11 +734,7 @@ func (o *Orchestrator) handleTick(ctx context.Context) {
 		dispatched++
 	}
 
-	if pass.reads == maxBlockerReadsPerPass {
-		o.state.BlockerReadOffset = pass.offset + pass.reads
-	} else {
-		o.state.BlockerReadOffset = 0
-	}
+	o.state.BlockerReadOffset = nextBlockerReadOffset(pass)
 
 	switch {
 	case pass.halted:

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -196,6 +196,12 @@ type OrchestratorParams struct {
 	// during the migration window; the production binary always
 	// populates this field.
 	AgentAdapterByKind func(kind string) (domain.AgentAdapter, error)
+
+	// BlockerResolver completes a candidate's blocker list according
+	// to its tracker adapter's declared blocker source. Optional: a
+	// nil value means "resolve nothing", which reproduces the
+	// orchestrator's behavior before this collaborator existed.
+	BlockerResolver BlockerResolver
 }
 
 // Orchestrator owns the poll-and-dispatch event loop and all runtime
@@ -212,6 +218,7 @@ type Orchestrator struct {
 	workflowManager    WorkflowManager
 	store              OrchestratorStore
 	metrics            domain.Metrics
+	blockerResolver    BlockerResolver
 
 	workerExitCh chan WorkerResult
 	retryTimerCh chan string
@@ -366,6 +373,7 @@ func NewOrchestrator(params OrchestratorParams) *Orchestrator {
 		mergeCompletionConfig:             params.MergeCompletionConfig,
 		mergeCompletionReactionConfigured: params.MergeCompletionReactionConfigured,
 		handoffParkingLabel:               handoffParkingLabel,
+		blockerResolver:                   params.BlockerResolver,
 	}
 	// Startup preflight must have passed for the orchestrator to be
 	// constructed, so the initial value is true.
@@ -638,7 +646,11 @@ func (o *Orchestrator) handleTick(ctx context.Context) {
 	// Break only when global capacity is exhausted; skip individual
 	// issues whose per-state limit is full so issues in other states
 	// can still be dispatched.
+	pass := &TickResolution{offset: o.state.BlockerReadOffset}
+
 	var dispatched, dispatchedByRule, dispatchedByDefault, dispatchedByFallback int
+	var heldByBlockers, blockersUnresolvedHeld, blockersNotReadHeld, blockersIncompleteHeld int
+	var readFailures int
 	for _, issue := range sorted {
 		if GlobalAvailableSlots(o.state.MaxConcurrentAgents, len(o.state.Running)) == 0 {
 			break
@@ -649,9 +661,26 @@ func (o *Orchestrator) handleTick(ctx context.Context) {
 		if !HasAvailableSlots(o.state, issue.State) {
 			continue
 		}
-		if !ShouldDispatchWithSets(issue, o.state, activeSet, terminalSet) {
+
+		decision := EvaluateCandidate(ctx, issue, o.state, activeSet, terminalSet, o.blockerResolver, pass)
+		if !decision.Dispatch {
+			if decision.Err != nil {
+				readFailures++
+			}
+			o.recordCandidateHold(decision, pass, terminalSet)
+			switch decision.Reason {
+			case SkipBlockedBy:
+				heldByBlockers++
+			case SkipBlockersUnresolved:
+				blockersUnresolvedHeld++
+			case SkipBlockersNotRead:
+				blockersNotReadHeld++
+			case SkipBlockersIncomplete:
+				blockersIncompleteHeld++
+			}
 			continue
 		}
+		issue = decision.Issue
 
 		resolution := ResolveRule(issue, cfg.Dispatch, cfg.Agent.Kind, "")
 		adapter, adapterErr := o.agentAdapterByKind(resolution.AgentKind)
@@ -700,6 +729,26 @@ func (o *Orchestrator) handleTick(ctx context.Context) {
 		dispatched++
 	}
 
+	if pass.reads == maxBlockerReadsPerPass {
+		o.state.BlockerReadOffset = pass.offset + pass.reads
+	} else {
+		o.state.BlockerReadOffset = 0
+	}
+
+	switch {
+	case pass.halted:
+		o.logger.Error("blocker reads halted for this tick",
+			slog.String("error_kind", blockerErrorKind(pass.haltErr)),
+			slog.Int("http_status", blockerErrorStatus(pass.haltErr)),
+			slog.String("operation", "fetch_blockers"),
+			slog.Int("held_unread", pass.heldUnread),
+		)
+	case dispatched == 0 && pass.reads > 0 && readFailures == pass.reads:
+		o.logger.Warn("tick dispatched nothing: every attempted candidate blocker read failed",
+			slog.Int("reads_failed", readFailures),
+		)
+	}
+
 	o.logger.Info("tick completed",
 		slog.Int("candidates", len(sorted)),
 		slog.Int("dispatched", dispatched),
@@ -708,9 +757,54 @@ func (o *Orchestrator) handleTick(ctx context.Context) {
 		slog.Int("dispatched_by_fallback", dispatchedByFallback),
 		slog.Int("running", len(o.state.Running)),
 		slog.Int("retrying", len(o.state.RetryAttempts)),
+		slog.Int("held_by_blockers", heldByBlockers),
+		slog.Int("blockers_unresolved", blockersUnresolvedHeld),
+		slog.Int("blockers_not_read", blockersNotReadHeld),
+		slog.Int("blockers_incomplete", blockersIncompleteHeld),
 	)
 
 	o.notifyObservers()
+}
+
+// recordCandidateHold logs the per-issue observability record for one
+// candidate the dispatch gate held, and increments [IncCandidateHolds]
+// for every reason except [SkipIneligible], which produces no record
+// and no counter increment (it predates the blocker gate and carries
+// its own silence forward).
+func (o *Orchestrator) recordCandidateHold(decision CandidateDecision, pass *TickResolution, terminalSet map[string]struct{}) {
+	if decision.Reason == SkipIneligible {
+		return
+	}
+
+	issue := decision.Issue
+	log := logging.WithIssue(o.logger, issue.ID, issue.Identifier)
+
+	switch decision.Reason {
+	case SkipBlockedBy:
+		blocker := firstNonTerminalBlocker(issue.BlockedBy, terminalSet)
+		log.Debug("candidate held by blocker",
+			slog.String("blocker_identifier", blocker.Identifier),
+			slog.String("blocker_state", blocker.State),
+		)
+	case SkipBlockersUnresolved:
+		if decision.Err != nil {
+			log.Warn("candidate blockers unresolved, holding issue",
+				slog.Any("error", decision.Err),
+			)
+		} else {
+			log.Debug("candidate blockers not read this tick, pass halted",
+				slog.String("error_kind", blockerErrorKind(pass.haltErr)),
+			)
+		}
+	case SkipBlockersNotRead:
+		log.Debug("candidate blockers not read this tick, holding issue",
+			slog.Int("reads_spent", pass.reads),
+		)
+	case SkipBlockersIncomplete:
+		log.Debug("candidate blocker list incomplete, holding issue")
+	}
+
+	o.metrics.IncCandidateHolds(string(decision.Reason))
 }
 
 // makeWorkerFn returns a [WorkerFunc] closure that runs

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -5748,3 +5748,368 @@ func TestDispatch_RuleResolvedKindPersistsToRunHistory(t *testing.T) {
 		t.Errorf("RunHistory(%q).RuleName = %q, want %q", docsIssue.Identifier, docsRow.RuleName, "")
 	}
 }
+
+// --- Blocker gate observability (handleTick) ---
+
+// newBlockerGateOrchestrator builds an Orchestrator wired with a "mock"
+// tracker returning issues as its candidates and resolver as the
+// blocker resolver, logging at Debug so per-issue records are
+// captured. metrics may be nil, in which case NewOrchestrator's own
+// default applies.
+func newBlockerGateOrchestrator(t *testing.T, issues []domain.Issue, resolver BlockerResolver, metrics domain.Metrics) (*Orchestrator, *lockedBuf) {
+	t.Helper()
+
+	tmpDir := t.TempDir()
+	cfg := config.ServiceConfig{
+		Tracker: config.TrackerConfig{
+			Kind:           "mock",
+			ActiveStates:   []string{"To Do"},
+			TerminalStates: []string{"Done"},
+		},
+		Polling:   config.PollingConfig{IntervalMS: 1000},
+		Workspace: config.WorkspaceConfig{Root: tmpDir},
+		Hooks:     config.HooksConfig{TimeoutMS: 5000},
+		Agent: config.AgentConfig{
+			Kind:                "mock",
+			Command:             "/usr/bin/agent",
+			MaxConcurrentAgents: 10,
+			MaxTurns:            1,
+			ReadTimeoutMS:       1000,
+		},
+	}
+
+	lb := &lockedBuf{}
+	logger := slog.New(slog.NewTextHandler(lb, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	pf := passingPreflightRegistries()
+	pf.ReloadWorkflow = func() error { return nil }
+	pf.ConfigFunc = func() config.ServiceConfig { return cfg }
+
+	tmpl := mustParseTemplate(t, "do {{.issue.identifier}}")
+
+	o := NewOrchestrator(OrchestratorParams{
+		State:  NewState(1000, 10, nil, AgentTotals{}),
+		Logger: logger,
+		TrackerAdapter: &candidateTrackerAdapter{
+			mockTrackerAdapter: &mockTrackerAdapter{},
+			fetchCandidatesFn: func(_ context.Context) ([]domain.Issue, error) {
+				return issues, nil
+			},
+		},
+		AgentAdapter:    &mockAgentAdapter{},
+		WorkflowManager: &stubWorkflowManager{config: cfg, template: tmpl},
+		Store:           &stubStore{},
+		PreflightParams: pf,
+		BlockerResolver: resolver,
+		Metrics:         metrics,
+	})
+
+	return o, lb
+}
+
+// TestHandleTick_DispatchUsesResolvedIssue pins that a dispatched
+// candidate's running entry carries the resolver's returned issue, not
+// the raw candidate the tracker produced.
+func TestHandleTick_DispatchUsesResolvedIssue(t *testing.T) {
+	t.Parallel()
+
+	issue := domain.Issue{ID: "R-1", Identifier: "R-1", Title: "T", State: "To Do", BlockersUnresolved: true}
+
+	resolver := &fakeBlockerResolver{
+		needsReadFn: func(i domain.Issue) bool { return i.BlockersUnresolved },
+		resolveFn: func(_ context.Context, i domain.Issue) (domain.Issue, error) {
+			i.BlockersUnresolved = false
+			i.Description = "resolved-by-test"
+			return i, nil
+		},
+	}
+
+	o, _ := newBlockerGateOrchestrator(t, []domain.Issue{issue}, resolver, nil)
+
+	o.handleTick(context.Background())
+	o.state.WorkerWg.Wait()
+
+	entry, ok := o.state.Running[issue.ID]
+	if !ok {
+		t.Fatal("issue was not dispatched")
+	}
+	if entry.Issue.BlockersUnresolved {
+		t.Error("dispatched entry carries BlockersUnresolved = true, want the resolved issue")
+	}
+	if entry.Issue.Description != "resolved-by-test" {
+		t.Errorf("dispatched entry.Issue.Description = %q, want %q (the resolver's return value, not the raw candidate)",
+			entry.Issue.Description, "resolved-by-test")
+	}
+}
+
+// TestHandleTick_CandidateHoldReasons pins that IncCandidateHolds
+// increments once per hold with the matching reason, across all four
+// blocker-related reasons, never for an ineligible candidate, and
+// never for the pass-level halt record.
+func TestHandleTick_CandidateHoldReasons(t *testing.T) {
+	t.Parallel()
+
+	blockedByIssue := domain.Issue{
+		ID: "H-1", Identifier: "H-1", Title: "T", State: "To Do",
+		BlockedBy: []domain.BlockerRef{{ID: "b", State: "To Do"}},
+	}
+	incompleteIssue := domain.Issue{
+		ID: "H-2", Identifier: "H-2", Title: "T", State: "To Do", BlockersUnresolved: true,
+	}
+	unresolvedFailIssue := domain.Issue{
+		ID: "H-3", Identifier: "H-3", Title: "T", State: "To Do", BlockersUnresolved: true,
+	}
+	ineligibleIssue := domain.Issue{ID: "", Identifier: "H-4", Title: "T", State: "To Do"}
+
+	transientErr := &domain.TrackerError{Kind: domain.ErrTrackerTransport}
+
+	resolver := &fakeBlockerResolver{
+		needsReadFn: func(i domain.Issue) bool { return i.ID == unresolvedFailIssue.ID },
+		resolveFn: func(_ context.Context, i domain.Issue) (domain.Issue, error) {
+			i.BlockersUnresolved = true
+			return i, transientErr
+		},
+	}
+
+	spy := &spyMetrics{}
+	o, _ := newBlockerGateOrchestrator(t, []domain.Issue{
+		blockedByIssue, incompleteIssue, unresolvedFailIssue, ineligibleIssue,
+	}, resolver, spy)
+
+	o.handleTick(context.Background())
+	o.state.WorkerWg.Wait()
+
+	spy.mu.Lock()
+	holds := append([]string(nil), spy.candidateHolds...)
+	spy.mu.Unlock()
+
+	wantCounts := map[string]int{
+		string(SkipBlockedBy):          1,
+		string(SkipBlockersIncomplete): 1,
+		string(SkipBlockersUnresolved): 1,
+	}
+	gotCounts := map[string]int{}
+	for _, reason := range holds {
+		gotCounts[reason]++
+	}
+	for reason, want := range wantCounts {
+		if gotCounts[reason] != want {
+			t.Errorf("IncCandidateHolds(%q) called %d times, want %d (holds=%v)", reason, gotCounts[reason], want, holds)
+		}
+	}
+	if gotCounts[string(SkipIneligible)] != 0 {
+		t.Errorf("IncCandidateHolds(%q) called %d times, want 0: an ineligible candidate must never be counted", SkipIneligible, gotCounts[string(SkipIneligible)])
+	}
+	if len(holds) != 3 {
+		t.Errorf("total IncCandidateHolds calls = %d, want 3 (holds=%v)", len(holds), holds)
+	}
+}
+
+// TestHandleTick_EveryAttemptedReadFailedWarning pins the four
+// distinguishing cases the "every attempted read failed" WARN
+// depends on: it fires only when every read the pass attempted
+// failed transiently and the tick dispatched nothing, and it carries
+// reads_failed as the count of reads attempted, not the count of
+// candidates held.
+func TestHandleTick_EveryAttemptedReadFailedWarning(t *testing.T) {
+	t.Parallel()
+
+	const warnMsg = "tick dispatched nothing: every attempted candidate blocker read failed"
+	transientErr := &domain.TrackerError{Kind: domain.ErrTrackerTransport}
+
+	t.Run("fires when every attempted read fails and nothing dispatches", func(t *testing.T) {
+		t.Parallel()
+
+		issues := []domain.Issue{
+			{ID: "W-1", Identifier: "W-1", Title: "T", State: "To Do", BlockersUnresolved: true},
+			{ID: "W-2", Identifier: "W-2", Title: "T", State: "To Do", BlockersUnresolved: true},
+		}
+		resolver := &fakeBlockerResolver{
+			needsReadFn: func(i domain.Issue) bool { return i.BlockersUnresolved },
+			resolveFn: func(_ context.Context, i domain.Issue) (domain.Issue, error) {
+				i.BlockersUnresolved = true
+				return i, transientErr
+			},
+		}
+
+		o, lb := newBlockerGateOrchestrator(t, issues, resolver, nil)
+		o.handleTick(context.Background())
+		o.state.WorkerWg.Wait()
+
+		got := lb.String()
+		if strings.Count(got, warnMsg) != 1 {
+			t.Fatalf("WARN count = %d, want 1: %s", strings.Count(got, warnMsg), got)
+		}
+		if !strings.Contains(got, "reads_failed=2") {
+			t.Errorf("log missing reads_failed=2: %s", got)
+		}
+	})
+
+	t.Run("does not fire when only one of several attempted reads failed", func(t *testing.T) {
+		t.Parallel()
+
+		issues := []domain.Issue{
+			{ID: "W-3", Identifier: "W-3", Title: "T", State: "To Do", BlockersUnresolved: true},
+			{ID: "W-4", Identifier: "W-4", Title: "T", State: "To Do", BlockersUnresolved: true},
+		}
+		resolver := &fakeBlockerResolver{
+			needsReadFn: func(i domain.Issue) bool { return i.BlockersUnresolved },
+			resolveFn: func(_ context.Context, i domain.Issue) (domain.Issue, error) {
+				if i.ID == "W-3" {
+					i.BlockersUnresolved = true
+					return i, transientErr
+				}
+				// W-4 resolves successfully but stays held by a live
+				// non-terminal blocker, so the tick still dispatches
+				// nothing even though this read did not fail.
+				i.BlockersUnresolved = false
+				i.BlockedBy = []domain.BlockerRef{{ID: "b", State: "To Do"}}
+				return i, nil
+			},
+		}
+
+		o, lb := newBlockerGateOrchestrator(t, issues, resolver, nil)
+		o.handleTick(context.Background())
+		o.state.WorkerWg.Wait()
+
+		got := lb.String()
+		if strings.Contains(got, warnMsg) {
+			t.Errorf("WARN fired with only one of two attempted reads failing: %s", got)
+		}
+	})
+
+	t.Run("does not fire on a pass that attempted no read", func(t *testing.T) {
+		t.Parallel()
+
+		issues := []domain.Issue{
+			{ID: "W-5", Identifier: "W-5", Title: "T", State: "To Do", BlockersUnresolved: true},
+		}
+		resolver := &fakeBlockerResolver{
+			needsReadFn: func(domain.Issue) bool { return false },
+		}
+
+		o, lb := newBlockerGateOrchestrator(t, issues, resolver, nil)
+		o.handleTick(context.Background())
+		o.state.WorkerWg.Wait()
+
+		got := lb.String()
+		if strings.Contains(got, warnMsg) {
+			t.Errorf("WARN fired on a pass with zero attempted reads: %s", got)
+		}
+	})
+
+	t.Run("carries the attempted-and-failed count, not the held count, when the budget binds", func(t *testing.T) {
+		t.Parallel()
+
+		issues := budgetWindowIssues()
+		resolver := &fakeBlockerResolver{
+			needsReadFn: func(i domain.Issue) bool { return i.BlockersUnresolved },
+			resolveFn: func(_ context.Context, i domain.Issue) (domain.Issue, error) {
+				i.BlockersUnresolved = true
+				return i, transientErr
+			},
+		}
+
+		o, lb := newBlockerGateOrchestrator(t, issues, resolver, nil)
+		o.handleTick(context.Background())
+		o.state.WorkerWg.Wait()
+
+		got := lb.String()
+		if strings.Count(got, warnMsg) != 1 {
+			t.Fatalf("WARN count = %d, want 1: %s", strings.Count(got, warnMsg), got)
+		}
+		if !strings.Contains(got, fmt.Sprintf("reads_failed=%d", maxBlockerReadsPerPass)) {
+			t.Errorf("log missing reads_failed=%d (the budget, not the 6 candidates held): %s", maxBlockerReadsPerPass, got)
+		}
+	})
+
+	t.Run("suppressed when the pass already halted", func(t *testing.T) {
+		t.Parallel()
+
+		deploymentErr := &domain.TrackerError{Kind: domain.ErrTrackerAuth}
+		issues := []domain.Issue{
+			{ID: "W-6", Identifier: "W-6", Title: "T", State: "To Do", BlockersUnresolved: true},
+		}
+		resolver := &fakeBlockerResolver{
+			needsReadFn: func(i domain.Issue) bool { return i.BlockersUnresolved },
+			resolveFn: func(_ context.Context, i domain.Issue) (domain.Issue, error) {
+				i.BlockersUnresolved = true
+				return i, deploymentErr
+			},
+		}
+
+		o, lb := newBlockerGateOrchestrator(t, issues, resolver, nil)
+		o.handleTick(context.Background())
+		o.state.WorkerWg.Wait()
+
+		got := lb.String()
+		if strings.Contains(got, warnMsg) {
+			t.Errorf("WARN fired on a halted pass, want it suppressed in favor of the pass-level ERROR: %s", got)
+		}
+		if !strings.Contains(got, "blocker reads halted for this tick") {
+			t.Errorf("log missing the pass-level halt ERROR: %s", got)
+		}
+	})
+}
+
+// TestHandleTick_BudgetSkipAndHaltSkipLogRecordsDiffer pins that a
+// budget-skipped candidate and a halt-skipped candidate emit distinct
+// DEBUG messages, even though both share the blockers_unresolved and
+// blockers_not_read reason vocabulary respectively.
+func TestHandleTick_BudgetSkipAndHaltSkipLogRecordsDiffer(t *testing.T) {
+	t.Parallel()
+
+	t.Run("budget-skipped candidate logs the not-read-this-tick record", func(t *testing.T) {
+		t.Parallel()
+
+		issues := budgetWindowIssues()
+		resolver := &fakeBlockerResolver{
+			needsReadFn: func(i domain.Issue) bool { return i.BlockersUnresolved },
+			resolveFn: func(_ context.Context, i domain.Issue) (domain.Issue, error) {
+				i.BlockersUnresolved = false
+				return i, nil
+			},
+		}
+
+		o, lb := newBlockerGateOrchestrator(t, issues, resolver, nil)
+		o.handleTick(context.Background())
+		o.state.WorkerWg.Wait()
+
+		got := lb.String()
+		if !strings.Contains(got, "candidate blockers not read this tick, holding issue") {
+			t.Errorf("log missing the budget-skip DEBUG record: %s", got)
+		}
+		if strings.Contains(got, "candidate blockers not read this tick, pass halted") {
+			t.Errorf("log carries the halt-skip DEBUG record on a pass that never halted: %s", got)
+		}
+	})
+
+	t.Run("halt-skipped candidate logs the pass-halted record", func(t *testing.T) {
+		t.Parallel()
+
+		deploymentErr := &domain.TrackerError{Kind: domain.ErrTrackerAuth}
+		issues := []domain.Issue{
+			{ID: "HS-1", Identifier: "HS-1", Title: "T", State: "To Do", BlockersUnresolved: true},
+			{ID: "HS-2", Identifier: "HS-2", Title: "T", State: "To Do", BlockersUnresolved: true},
+		}
+		resolver := &fakeBlockerResolver{
+			needsReadFn: func(i domain.Issue) bool { return i.BlockersUnresolved },
+			resolveFn: func(_ context.Context, i domain.Issue) (domain.Issue, error) {
+				i.BlockersUnresolved = true
+				return i, deploymentErr
+			},
+		}
+
+		o, lb := newBlockerGateOrchestrator(t, issues, resolver, nil)
+		o.handleTick(context.Background())
+		o.state.WorkerWg.Wait()
+
+		got := lb.String()
+		if !strings.Contains(got, "candidate blockers not read this tick, pass halted") {
+			t.Errorf("log missing the halt-skip DEBUG record: %s", got)
+		}
+		if strings.Contains(got, "candidate blockers not read this tick, holding issue") {
+			t.Errorf("log carries the budget-skip DEBUG record on a pass that halted before the budget bound: %s", got)
+		}
+	})
+}

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -900,6 +900,14 @@ type State struct {
 	// Runtime-only (not persisted).
 	SweepTickCounter int
 
+	// BlockerReadOffset is the position, among a tick's needy
+	// candidates, at which the per-pass blocker-read budget resumes.
+	// Mutated once per tick by the event loop that owns this struct:
+	// advanced by the reads spent when a pass exhausts its budget, and
+	// reset to zero on every other pass ending. Runtime-only (not
+	// persisted).
+	BlockerReadOffset int
+
 	// TokenBudgetIncomplete is the set of issue IDs whose per-issue token
 	// spend, as evaluated on the most recent poll tick, is below the
 	// configured max_tokens budget but includes at least one unmeasured

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -141,7 +141,31 @@ type TrackerMeta struct {
 	// callers must treat it as read-only and copy before sorting or
 	// filtering.
 	DefaultTerminalStates []string
+
+	// BlockerSource declares where this adapter's blocker data comes
+	// from. The empty value is read as BlockersFromCandidates.
+	BlockerSource BlockerSource
 }
+
+// BlockerSource declares where a tracker adapter's blocker data comes
+// from, so the layer between the registry and the orchestrator knows
+// whether a candidate issue is gate-ready as fetched.
+type BlockerSource string
+
+const (
+	// BlockersFromCandidates declares that the adapter's candidate
+	// fetch already carries every blocker the tracker reports.
+	BlockersFromCandidates BlockerSource = "candidates"
+
+	// BlockersPerIssue declares that the adapter's candidate fetch
+	// carries no blockers, and that one issue's blockers are read
+	// through domain.BlockerReader.
+	BlockersPerIssue BlockerSource = "per_issue"
+
+	// BlockersUnsupported declares that the tracker has no blocking
+	// relation, so an empty blocker list on a candidate is complete.
+	BlockersUnsupported BlockerSource = "unsupported"
+)
 
 // AgentMeta holds optional agent-adapter-declared properties queried
 // by the orchestrator at preflight time. Zero value means no special

--- a/internal/scm/gitea/gitea.go
+++ b/internal/scm/gitea/gitea.go
@@ -39,6 +39,7 @@ func init() {
 		ValidateTrackerConfig: validateConfig,
 		DefaultActiveStates:   defaultActiveStates,
 		DefaultTerminalStates: defaultTerminalStates,
+		BlockerSource:         registry.BlockersPerIssue,
 	})
 }
 
@@ -572,6 +573,7 @@ func (a *GiteaAdapter) FetchIssueByID(ctx context.Context, issueID string) (doma
 			return err
 		}
 		fetched.BlockedBy = blockers
+		fetched.BlockersUnresolved = false
 
 		comments, err := a.fetchComments(ctx, issueID)
 		if err != nil {
@@ -585,22 +587,30 @@ func (a *GiteaAdapter) FetchIssueByID(ctx context.Context, issueID string) (doma
 	return issue, err
 }
 
+// FetchIssueBlockers returns the blockers of one issue, read from the
+// forge's dependencies route.
+func (a *GiteaAdapter) FetchIssueBlockers(ctx context.Context, index string) ([]domain.BlockerRef, error) {
+	blockers := make([]domain.BlockerRef, 0)
+	err := trackermetrics.Track(a.metrics, "fetch_blockers", func() error {
+		var fetchErr error
+		blockers, fetchErr = a.fetchBlockers(ctx, index)
+		return fetchErr
+	})
+	return blockers, err
+}
+
 // fetchBlockers returns the issues blocking the given issue, read from the
-// dependencies route through the Link paginator. A 404 is tolerated and yields
-// a non-nil empty slice.
+// dependencies route through the Link paginator.
 func (a *GiteaAdapter) fetchBlockers(ctx context.Context, index string) ([]domain.BlockerRef, error) {
 	path := "/repos/" + a.owner + "/" + a.repo + "/issues/" + url.PathEscape(index) + "/dependencies"
 	params := url.Values{"limit": {"50"}}
 
 	raw, err := a.paginateIssues(ctx, path, params)
 	if err != nil {
-		if domain.IsNotFound(err) {
-			return []domain.BlockerRef{}, nil
-		}
 		return nil, err
 	}
 
-	return normalizeBlockers(raw, a.activeStates, a.terminalStates, a.handoffState, a.log), nil
+	return normalizeBlockers(raw, a.activeStates, a.terminalStates, a.handoffState, a.owner, a.repo, a.log), nil
 }
 
 // FetchIssueComments returns all comments for the issue. It returns a non-nil

--- a/internal/scm/gitea/gitea_test.go
+++ b/internal/scm/gitea/gitea_test.go
@@ -738,6 +738,10 @@ func TestFetchCandidateIssues(t *testing.T) {
 			if iss.DisplayID != want {
 				t.Errorf("issue %s: DisplayID = %q, want %q", iss.Identifier, iss.DisplayID, want)
 			}
+			// giteaIssue carries no dependency field, so every candidate
+			// this adapter produces must be marked unresolved rather
+			// than read as having no blockers.
+			adaptertest.AssertCandidateBlockerSource(t, registry.BlockersPerIssue, iss, 0)
 		}
 	})
 
@@ -1371,6 +1375,9 @@ func TestFetchIssueByID(t *testing.T) {
 		if len(issue.BlockedBy) != 1 || issue.BlockedBy[0].Identifier != "1" {
 			t.Errorf("BlockedBy = %v, want one blocker with Identifier 1", issue.BlockedBy)
 		}
+		if issue.BlockersUnresolved {
+			t.Error("BlockersUnresolved = true, want false: the blocker read succeeded")
+		}
 		if len(issue.Comments) != 2 {
 			t.Fatalf("Comments len = %d, want 2", len(issue.Comments))
 		}
@@ -1651,11 +1658,22 @@ func TestFetchBlockers(t *testing.T) {
 		if blockers[0].State != "in-progress" {
 			t.Errorf("blockers[0].State = %q, want %q", blockers[0].State, "in-progress")
 		}
+		if want := testOwner + "/" + testRepo + "#1"; blockers[0].DisplayID != want {
+			t.Errorf("blockers[0].DisplayID = %q, want %q", blockers[0].DisplayID, want)
+		}
+
+		adaptertest.AssertBlockerRefsNormalized(t, blockers)
+		qualifiedIssue := domain.Issue{Identifier: "42", DisplayID: testOwner + "/" + testRepo + "#42"}
+		adaptertest.AssertBlockerIdentifiersMatchIssue(t, qualifiedIssue, blockers)
 	})
 
-	t.Run("404 is tolerated and returns a non-nil empty slice", func(t *testing.T) {
+	t.Run("404 propagates as a not-found error rather than degrading to no blockers", func(t *testing.T) {
 		t.Parallel()
 
+		// A 404 on the dependencies route is not a signal that the issue
+		// has no blockers: it is a condition the resolver must surface,
+		// so the candidate stays held rather than dispatched on an
+		// unknown blocker list.
 		mux := newPreflightMux(t)
 		mux.HandleFunc("GET /api/v1/repos/"+testOwner+"/"+testRepo+"/issues/42/dependencies", func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusNotFound)
@@ -1663,16 +1681,8 @@ func TestFetchBlockers(t *testing.T) {
 		})
 		a := mustAdapter(t, mux)
 
-		blockers, err := a.fetchBlockers(context.Background(), "42")
-		if err != nil {
-			t.Fatalf("fetchBlockers should tolerate 404: %v", err)
-		}
-		if blockers == nil {
-			t.Fatal("blockers is nil, want non-nil empty slice")
-		}
-		if len(blockers) != 0 {
-			t.Errorf("len = %d, want 0", len(blockers))
-		}
+		_, err := a.fetchBlockers(context.Background(), "42")
+		assertTrackerErrorKind(t, err, domain.ErrTrackerNotFound)
 	})
 }
 

--- a/internal/scm/gitea/integration_test.go
+++ b/internal/scm/gitea/integration_test.go
@@ -169,9 +169,62 @@ func TestIntegration_FetchCandidateIssues(t *testing.T) {
 		if iss.BlockedBy == nil {
 			t.Errorf("issue %s: BlockedBy is nil, want non-nil slice", iss.Identifier)
 		}
+		if !iss.BlockersUnresolved {
+			t.Errorf("issue %s: BlockersUnresolved is false, want true: giteaIssue carries no dependency field to prove any candidate dependency-free", iss.Identifier)
+		}
 		if iss.Comments != nil {
 			t.Errorf("issue %s: Comments should be nil for candidate fetch", iss.Identifier)
 		}
+	}
+}
+
+// TestIntegration_SeededBlockerLinkResolves pins that the per-issue
+// blocker read resolves a real, live dependency: the provisioning
+// script seeds one blocker link, so among every issue in an active or
+// terminal state, at least one FetchIssueBlockers call must return a
+// non-empty list.
+func TestIntegration_SeededBlockerLinkResolves(t *testing.T) {
+	skipUnlessIntegration(t)
+
+	adapter := newIntegrationAdapter(t)
+	reader, ok := adapter.(domain.BlockerReader)
+	if !ok {
+		t.Fatal("GiteaAdapter does not implement domain.BlockerReader")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	candidates, err := adapter.FetchCandidateIssues(ctx)
+	if err != nil {
+		t.Fatalf("FetchCandidateIssues: %v", err)
+	}
+	terminal, err := adapter.FetchIssuesByStates(ctx, []string{"done"})
+	if err != nil {
+		t.Fatalf("FetchIssuesByStates(done): %v", err)
+	}
+
+	seen := map[string]bool{}
+	foundBlocker := false
+	for _, iss := range append(candidates, terminal...) {
+		if seen[iss.ID] {
+			continue
+		}
+		seen[iss.ID] = true
+
+		blockers, err := reader.FetchIssueBlockers(ctx, iss.ID)
+		if err != nil {
+			t.Fatalf("FetchIssueBlockers(%s): %v", iss.ID, err)
+		}
+		if len(blockers) > 0 {
+			foundBlocker = true
+			t.Logf("issue %s carries %d blocker(s), first identifier %q", iss.ID, len(blockers), blockers[0].Identifier)
+			break
+		}
+	}
+
+	if !foundBlocker {
+		t.Error("no issue among the fetched candidates and terminal issues carries a blocker; want the seeded blocker link to resolve")
 	}
 }
 
@@ -197,6 +250,9 @@ func TestIntegration_FetchIssueByID(t *testing.T) {
 	}
 	if fetched.BlockedBy == nil {
 		t.Error("BlockedBy is nil, want non-nil slice for fully populated issue")
+	}
+	if fetched.BlockersUnresolved {
+		t.Error("BlockersUnresolved = true after a successful FetchIssueByID, want false: the by-ID read always resolves blockers")
 	}
 }
 

--- a/internal/scm/gitea/normalize.go
+++ b/internal/scm/gitea/normalize.go
@@ -68,6 +68,10 @@ func giteaLabelNames(labels []giteaLabel) []string {
 // Identifier are both set to the repo-scoped index; the global id is never used.
 // Parent and Comments remain nil; BlockedBy is a non-nil empty slice.
 //
+// BlockersUnresolved is always set true: the candidate route carries no
+// dependency field, so every candidate this function produces needs a
+// blocker read through the shared resolver or [GiteaAdapter.FetchIssueByID].
+//
 // DisplayID is left empty; callers apply [setDisplayID] after normalization.
 // The state lists and log are threaded to [issuekit.DeriveLabelState].
 func normalizeIssue(gi giteaIssue, activeStates, terminalStates []string, handoffState string, log *slog.Logger) domain.Issue {
@@ -82,18 +86,19 @@ func normalizeIssue(gi giteaIssue, activeStates, terminalStates []string, handof
 	states := issuekit.LabelStates{Active: activeStates, Terminal: terminalStates, Handoff: handoffState}
 
 	return domain.Issue{
-		ID:          num,
-		Identifier:  num,
-		Title:       gi.Title,
-		Description: gi.Body,
-		State:       issuekit.DeriveLabelState(labelNames, gi.State, "open", "closed", states, num, log),
-		BranchName:  gi.Ref,
-		URL:         gi.HTMLURL,
-		Labels:      issuekit.NormalizeLabels(labelNames),
-		Assignee:    assignee,
-		BlockedBy:   []domain.BlockerRef{},
-		CreatedAt:   gi.CreatedAt,
-		UpdatedAt:   gi.UpdatedAt,
+		ID:                 num,
+		Identifier:         num,
+		Title:              gi.Title,
+		Description:        gi.Body,
+		State:              issuekit.DeriveLabelState(labelNames, gi.State, "open", "closed", states, num, log),
+		BranchName:         gi.Ref,
+		URL:                gi.HTMLURL,
+		Labels:             issuekit.NormalizeLabels(labelNames),
+		Assignee:           assignee,
+		BlockedBy:          []domain.BlockerRef{},
+		BlockersUnresolved: true,
+		CreatedAt:          gi.CreatedAt,
+		UpdatedAt:          gi.UpdatedAt,
 	}
 }
 
@@ -124,18 +129,23 @@ func normalizeComments(raw []giteaComment) []domain.Comment {
 
 // normalizeBlockers converts blocker issue responses to [domain.BlockerRef]
 // values. Returns a non-nil empty slice when input is empty. Each blocker's
-// state is derived from its labels and native state.
-func normalizeBlockers(blockers []giteaIssue, activeStates, terminalStates []string, handoffState string, log *slog.Logger) []domain.BlockerRef {
+// state is derived from its labels and native state, and its DisplayID is
+// qualified the same way [setDisplayID] qualifies an issue's own DisplayID.
+func normalizeBlockers(blockers []giteaIssue, activeStates, terminalStates []string, handoffState, owner, repo string, log *slog.Logger) []domain.BlockerRef {
 	states := issuekit.LabelStates{Active: activeStates, Terminal: terminalStates, Handoff: handoffState}
 
 	refs := make([]domain.BlockerRef, 0, len(blockers))
 	for _, b := range blockers {
 		num := strconv.Itoa(b.Number)
-		refs = append(refs, domain.BlockerRef{
+		ref := domain.BlockerRef{
 			ID:         num,
 			Identifier: num,
 			State:      issuekit.DeriveLabelState(giteaLabelNames(b.Labels), b.State, "open", "closed", states, num, log),
-		})
+		}
+		if ref.DisplayID == "" {
+			ref.DisplayID = owner + "/" + repo + "#" + num
+		}
+		refs = append(refs, ref)
 	}
 	return refs
 }

--- a/internal/scm/gitea/normalize_test.go
+++ b/internal/scm/gitea/normalize_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/sortie-ai/sortie/internal/adaptertest"
 	"github.com/sortie-ai/sortie/internal/domain"
 )
 
@@ -67,6 +68,9 @@ func TestNormalizeIssue_AllFields(t *testing.T) {
 	}
 	if len(got.BlockedBy) != 0 {
 		t.Errorf("BlockedBy len = %d, want 0", len(got.BlockedBy))
+	}
+	if !got.BlockersUnresolved {
+		t.Error("BlockersUnresolved = false, want true: giteaIssue carries no dependency field to prove the issue has none")
 	}
 	if got.CreatedAt != "2026-01-01T00:00:00Z" {
 		t.Errorf("CreatedAt = %q, want %q", got.CreatedAt, "2026-01-01T00:00:00Z")
@@ -255,7 +259,7 @@ func TestNormalizeBlockers_NonEmpty(t *testing.T) {
 	active := []string{"backlog", "in-progress", "review"}
 	terminal := []string{"done", "wontfix"}
 
-	got := normalizeBlockers(blockers, active, terminal, "", nil)
+	got := normalizeBlockers(blockers, active, terminal, "", "acme", "widgets", nil)
 
 	if len(got) != 2 {
 		t.Fatalf("normalizeBlockers len = %d, want 2", len(got))
@@ -272,12 +276,19 @@ func TestNormalizeBlockers_NonEmpty(t *testing.T) {
 	if got[1].State != "done" {
 		t.Errorf("got[1].State = %q, want %q", got[1].State, "done")
 	}
+	if got[0].DisplayID != "acme/widgets#5" {
+		t.Errorf("got[0].DisplayID = %q, want %q", got[0].DisplayID, "acme/widgets#5")
+	}
+
+	adaptertest.AssertBlockerRefsNormalized(t, got)
+	qualifiedIssue := domain.Issue{Identifier: "1", DisplayID: "acme/widgets#1"}
+	adaptertest.AssertBlockerIdentifiersMatchIssue(t, qualifiedIssue, got)
 }
 
 func TestNormalizeBlockers_EmptyReturnsNonNilSlice(t *testing.T) {
 	t.Parallel()
 
-	got := normalizeBlockers(nil, nil, nil, "", nil)
+	got := normalizeBlockers(nil, nil, nil, "", "acme", "widgets", nil)
 
 	if got == nil {
 		t.Error("normalizeBlockers(nil) returned nil, want non-nil empty slice")

--- a/internal/scm/github/integration_test.go
+++ b/internal/scm/github/integration_test.go
@@ -69,6 +69,13 @@ func TestIntegration_FetchCandidateIssues(t *testing.T) {
 		if iss.BlockedBy == nil {
 			t.Errorf("issue %s: BlockedBy should be non-nil", iss.ID)
 		}
+		if !iss.BlockersUnresolved && len(iss.BlockedBy) != 0 {
+			t.Errorf("issue %s: BlockersUnresolved is false with a non-empty BlockedBy, want the dependency summary to have proved this specific issue dependency-free", iss.ID)
+		}
+		// This integration environment seeds no blocker relation on any
+		// candidate, so a resolved candidate here always means the
+		// dependency summary proved it has none, not that a real
+		// blocker was read and found terminal.
 		if iss.Priority != nil {
 			t.Errorf("issue %s: Priority should always be nil (GitHub has no native priority)", iss.ID)
 		}
@@ -108,6 +115,9 @@ func TestIntegration_FetchIssueByID(t *testing.T) {
 	}
 	if issue.BlockedBy == nil {
 		t.Error("BlockedBy is nil, want non-nil (may be empty)")
+	}
+	if issue.BlockersUnresolved {
+		t.Error("BlockersUnresolved = true after a successful FetchIssueByID, want false: the by-ID read always resolves blockers")
 	}
 	if issue.Priority != nil {
 		t.Error("Priority should always be nil for GitHub issues")

--- a/internal/scm/github/normalize.go
+++ b/internal/scm/github/normalize.go
@@ -10,19 +10,31 @@ import (
 
 // githubIssue represents a single issue from the GitHub REST API.
 type githubIssue struct {
-	ID          int64            `json:"id"`
-	Number      int              `json:"number"`
-	Title       string           `json:"title"`
-	Body        *string          `json:"body"`
-	State       string           `json:"state"`
-	StateReason *string          `json:"state_reason"`
-	HTMLURL     string           `json:"html_url"`
-	Labels      []githubLabel    `json:"labels"`
-	Assignees   []githubUser     `json:"assignees"`
-	Type        *githubIssueType `json:"type"`
-	PullRequest *githubPR        `json:"pull_request"`
-	CreatedAt   string           `json:"created_at"`
-	UpdatedAt   string           `json:"updated_at"`
+	ID                  int64                      `json:"id"`
+	Number              int                        `json:"number"`
+	Title               string                     `json:"title"`
+	Body                *string                    `json:"body"`
+	State               string                     `json:"state"`
+	StateReason         *string                    `json:"state_reason"`
+	HTMLURL             string                     `json:"html_url"`
+	Labels              []githubLabel              `json:"labels"`
+	Assignees           []githubUser               `json:"assignees"`
+	Type                *githubIssueType           `json:"type"`
+	PullRequest         *githubPR                  `json:"pull_request"`
+	DependenciesSummary *githubDependenciesSummary `json:"issue_dependencies_summary"`
+	CreatedAt           string                     `json:"created_at"`
+	UpdatedAt           string                     `json:"updated_at"`
+}
+
+// githubDependenciesSummary is GitHub's per-issue dependency count.
+// TotalBlockedBy counts every dependency; BlockedBy counts only those
+// GitHub considers open, which is not the question the dispatch gate
+// asks. A nil pointer means the field is absent or null, both of
+// which mean "unknown" (a pull request co-mingled into the issues
+// route, or a payload that omits the field).
+type githubDependenciesSummary struct {
+	BlockedBy      int `json:"blocked_by"`
+	TotalBlockedBy int `json:"total_blocked_by"`
 }
 
 type githubLabel struct {
@@ -69,8 +81,13 @@ func githubLabelNames(labels []githubLabel) []string {
 // The ID and Identifier are both set to the issue number since the
 // GitHub REST API indexes issues by number, not by global integer ID.
 // Parent and Comments remain at their zero values; BlockedBy is
-// initialized to a non-nil empty slice. Callers requiring full
-// population must use [GitHubAdapter.FetchIssueByID].
+// initialized to a non-nil empty slice.
+//
+// BlockersUnresolved is set true by default, because the candidate
+// routes do not carry blockers; it is cleared, leaving BlockedBy
+// empty, only when DependenciesSummary proves the issue has no
+// dependencies at all. Otherwise a caller resolves blockers through
+// the shared resolver or [GitHubAdapter.FetchIssueByID].
 //
 // DisplayID is left empty; callers that know the repository
 // owner and name should set it to "owner/repo#N" after normalization.
@@ -95,20 +112,34 @@ func normalizeIssue(gi githubIssue, activeStates, terminalStates []string, hando
 
 	states := issuekit.LabelStates{Active: activeStates, Terminal: terminalStates, Handoff: handoffState}
 
+	// Only a summary proving the issue has no dependencies at all lets a
+	// candidate claim an authoritative blocker list. TotalBlockedBy counts
+	// every dependency; BlockedBy counts only the ones the forge considers
+	// open, which is a different question from whether a blocker sits
+	// outside the configured terminal states, so it cannot stand in here.
+	blockersUnresolved := gi.DependenciesSummary == nil || gi.DependenciesSummary.TotalBlockedBy != 0
+
 	return domain.Issue{
-		ID:          num,
-		Identifier:  num,
-		Title:       gi.Title,
-		Description: desc,
-		State:       issuekit.DeriveLabelState(labelNames, gi.State, "open", "closed", states, num, log),
-		URL:         gi.HTMLURL,
-		Labels:      issuekit.NormalizeLabels(labelNames),
-		Assignee:    assignee,
-		IssueType:   issueType,
-		BlockedBy:   []domain.BlockerRef{},
-		CreatedAt:   gi.CreatedAt,
-		UpdatedAt:   gi.UpdatedAt,
+		ID:                 num,
+		Identifier:         num,
+		Title:              gi.Title,
+		Description:        desc,
+		State:              issuekit.DeriveLabelState(labelNames, gi.State, "open", "closed", states, num, log),
+		URL:                gi.HTMLURL,
+		Labels:             issuekit.NormalizeLabels(labelNames),
+		Assignee:           assignee,
+		IssueType:          issueType,
+		BlockedBy:          []domain.BlockerRef{},
+		BlockersUnresolved: blockersUnresolved,
+		CreatedAt:          gi.CreatedAt,
+		UpdatedAt:          gi.UpdatedAt,
 	}
+}
+
+// qualifyIdentifier renders owner/repo#identifier, the qualified form
+// GitHub issue and blocker references share.
+func qualifyIdentifier(owner, repo, identifier string) string {
+	return owner + "/" + repo + "#" + identifier
 }
 
 // qualifyDisplayID sets DisplayID to "owner/repo#N" so
@@ -118,23 +149,28 @@ func (a *GitHubAdapter) qualifyDisplayID(issue *domain.Issue) {
 	if issue.DisplayID != "" {
 		return
 	}
-	issue.DisplayID = a.owner + "/" + a.repo + "#" + issue.Identifier
+	issue.DisplayID = qualifyIdentifier(a.owner, a.repo, issue.Identifier)
 }
 
 // normalizeBlockers converts blocker issue responses to
 // [domain.BlockerRef] values. Returns a non-nil empty slice when
-// input is empty.
-func normalizeBlockers(blockers []githubIssue, activeStates, terminalStates []string, handoffState string, log *slog.Logger) []domain.BlockerRef {
+// input is empty. owner and repo qualify each ref's DisplayID the
+// same way an issue's own DisplayID is qualified.
+func normalizeBlockers(blockers []githubIssue, activeStates, terminalStates []string, handoffState, owner, repo string, log *slog.Logger) []domain.BlockerRef {
 	states := issuekit.LabelStates{Active: activeStates, Terminal: terminalStates, Handoff: handoffState}
 
 	refs := make([]domain.BlockerRef, 0, len(blockers))
 	for _, b := range blockers {
 		num := strconv.Itoa(b.Number)
-		refs = append(refs, domain.BlockerRef{
+		ref := domain.BlockerRef{
 			ID:         num,
 			Identifier: num,
 			State:      issuekit.DeriveLabelState(githubLabelNames(b.Labels), b.State, "open", "closed", states, num, log),
-		})
+		}
+		if ref.DisplayID == "" {
+			ref.DisplayID = qualifyIdentifier(owner, repo, num)
+		}
+		refs = append(refs, ref)
 	}
 	return refs
 }

--- a/internal/scm/github/normalize_test.go
+++ b/internal/scm/github/normalize_test.go
@@ -1,9 +1,11 @@
 package github
 
 import (
+	"encoding/json"
 	"strconv"
 	"testing"
 
+	"github.com/sortie-ai/sortie/internal/adaptertest"
 	"github.com/sortie-ai/sortie/internal/domain"
 )
 
@@ -165,6 +167,12 @@ func TestNormalizeIssue_MultipleAssignees(t *testing.T) {
 	}
 }
 
+// TestNormalizeIssue_NonNilEmptyBlockedBy pins that a candidate with no
+// dependency summary carries a non-nil empty BlockedBy AND is marked
+// unresolved: the empty slice alone is not authoritative here, because
+// nothing on the candidate route read the dependencies route. A green
+// assertion on the shape alone, without the flag, is the defect this
+// design replaces.
 func TestNormalizeIssue_NonNilEmptyBlockedBy(t *testing.T) {
 	t.Parallel()
 
@@ -176,6 +184,9 @@ func TestNormalizeIssue_NonNilEmptyBlockedBy(t *testing.T) {
 	}
 	if len(got.BlockedBy) != 0 {
 		t.Errorf("BlockedBy len = %d, want 0", len(got.BlockedBy))
+	}
+	if !got.BlockersUnresolved {
+		t.Error("BlockersUnresolved = false, want true: no DependenciesSummary was present to prove the issue has no dependencies")
 	}
 }
 
@@ -278,7 +289,7 @@ func TestNormalizeBlockers_NonEmpty(t *testing.T) {
 	active := []string{"backlog", "in-progress", "review"}
 	terminal := []string{"done", "wontfix"}
 
-	got := normalizeBlockers(blockers, active, terminal, "", nil)
+	got := normalizeBlockers(blockers, active, terminal, "", "owner", "repo", nil)
 
 	if len(got) != 2 {
 		t.Fatalf("normalizeBlockers len = %d, want 2", len(got))
@@ -295,12 +306,19 @@ func TestNormalizeBlockers_NonEmpty(t *testing.T) {
 	if got[1].State != "done" {
 		t.Errorf("got[1].State = %q, want %q", got[1].State, "done")
 	}
+	if got[0].DisplayID != "owner/repo#5" {
+		t.Errorf("got[0].DisplayID = %q, want %q", got[0].DisplayID, "owner/repo#5")
+	}
+
+	adaptertest.AssertBlockerRefsNormalized(t, got)
+	qualifiedIssue := domain.Issue{Identifier: "1", DisplayID: "owner/repo#1"}
+	adaptertest.AssertBlockerIdentifiersMatchIssue(t, qualifiedIssue, got)
 }
 
 func TestNormalizeBlockers_EmptyReturnsNonNilSlice(t *testing.T) {
 	t.Parallel()
 
-	got := normalizeBlockers(nil, nil, nil, "", nil)
+	got := normalizeBlockers(nil, nil, nil, "", "owner", "repo", nil)
 
 	if got == nil {
 		t.Error("normalizeBlockers(nil) returned nil, want non-nil empty slice")
@@ -387,6 +405,118 @@ func TestIsPullRequest(t *testing.T) {
 				t.Errorf("isPullRequest() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+// --- dependency-summary cheap-answer pre-filter ---
+
+func TestNormalizeIssue_DependenciesSummaryPreFilter(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name               string
+		summary            *githubDependenciesSummary
+		wantBlockersUnres  bool
+		wantBlockedByEmpty bool
+	}{
+		{
+			name:               "absent summary leaves the flag set",
+			summary:            nil,
+			wantBlockersUnres:  true,
+			wantBlockedByEmpty: true,
+		},
+		{
+			name:               "zero total_blocked_by clears the flag",
+			summary:            &githubDependenciesSummary{BlockedBy: 0, TotalBlockedBy: 0},
+			wantBlockersUnres:  false,
+			wantBlockedByEmpty: true,
+		},
+		{
+			name:               "positive total_blocked_by leaves the flag set",
+			summary:            &githubDependenciesSummary{BlockedBy: 1, TotalBlockedBy: 1},
+			wantBlockersUnres:  true,
+			wantBlockedByEmpty: true,
+		},
+		{
+			name: "the reporter's exact divergence: blocked_by 0, total_blocked_by 2, both closed but configured non-terminal",
+			// GitHub's own blocked_by count answers "how many of my
+			// dependencies does GitHub itself consider still open",
+			// which is not the question the dispatch gate asks: a
+			// blocker GitHub calls closed can still be a configured
+			// non-terminal state. Reading BlockedBy here would wrongly
+			// clear the flag on an issue that in fact has two blockers.
+			summary:            &githubDependenciesSummary{BlockedBy: 0, TotalBlockedBy: 2},
+			wantBlockersUnres:  true,
+			wantBlockedByEmpty: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			gi := githubIssue{Number: 1, State: "open", DependenciesSummary: tt.summary}
+			got := normalizeIssue(gi, nil, nil, "", nil)
+
+			if got.BlockersUnresolved != tt.wantBlockersUnres {
+				t.Errorf("BlockersUnresolved = %t, want %t", got.BlockersUnresolved, tt.wantBlockersUnres)
+			}
+			if tt.wantBlockedByEmpty && len(got.BlockedBy) != 0 {
+				t.Errorf("len(BlockedBy) = %d, want 0", len(got.BlockedBy))
+			}
+			if got.BlockedBy == nil {
+				t.Error("BlockedBy is nil, want non-nil empty slice on every candidate path")
+			}
+		})
+	}
+}
+
+// TestNormalizeIssue_DependenciesSummaryNullDecodesToNil pins that a
+// JSON null for issue_dependencies_summary decodes to a nil pointer,
+// read the same nil-safe way an absent field is.
+func TestNormalizeIssue_DependenciesSummaryNullDecodesToNil(t *testing.T) {
+	t.Parallel()
+
+	var gi githubIssue
+	raw := []byte(`{"number":1,"state":"open","issue_dependencies_summary":null}`)
+	if err := json.Unmarshal(raw, &gi); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+	if gi.DependenciesSummary != nil {
+		t.Fatalf("DependenciesSummary = %v, want nil after decoding a JSON null", gi.DependenciesSummary)
+	}
+
+	got := normalizeIssue(gi, nil, nil, "", nil)
+	if !got.BlockersUnresolved {
+		t.Error("BlockersUnresolved = false, want true: a JSON null summary proves nothing about dependencies")
+	}
+}
+
+// TestNormalizeIssue_PreFilterDecisionEquality pins that for an
+// issue whose summary proves zero dependencies, the pre-filter's
+// cheap answer and an actual per-issue blocker read of the same
+// zero-dependency issue produce the identical dispatch-relevant
+// fields, so turning the pre-filter off would not change the
+// decision, only its cost.
+func TestNormalizeIssue_PreFilterDecisionEquality(t *testing.T) {
+	t.Parallel()
+
+	gi := githubIssue{
+		Number:              1,
+		State:               "open",
+		DependenciesSummary: &githubDependenciesSummary{BlockedBy: 0, TotalBlockedBy: 0},
+	}
+	preFiltered := normalizeIssue(gi, nil, nil, "", nil)
+
+	// The per-issue read path: a dependencies route responding with no
+	// entries, normalized the same way fetchBlockers would.
+	readBlockedBy := normalizeBlockers(nil, nil, nil, "", "owner", "repo", nil)
+
+	if preFiltered.BlockersUnresolved {
+		t.Fatal("pre-filtered issue has BlockersUnresolved = true, want false")
+	}
+	if len(preFiltered.BlockedBy) != len(readBlockedBy) {
+		t.Errorf("pre-filtered BlockedBy len = %d, per-issue-read BlockedBy len = %d, want equal", len(preFiltered.BlockedBy), len(readBlockedBy))
 	}
 }
 

--- a/internal/scm/github/tracker.go
+++ b/internal/scm/github/tracker.go
@@ -41,6 +41,7 @@ func init() {
 		ValidateTrackerConfig: validateConfig,
 		DefaultActiveStates:   defaultActiveStates,
 		DefaultTerminalStates: defaultTerminalStates,
+		BlockerSource:         registry.BlockersPerIssue,
 	})
 }
 
@@ -336,6 +337,7 @@ func (a *GitHubAdapter) FetchIssueByID(ctx context.Context, issueID string) (dom
 		if err != nil {
 			return err
 		}
+		fetchedIssue.BlockersUnresolved = false
 
 		fetchedIssue.Parent, err = a.fetchParent(ctx, issueID)
 		if err != nil {
@@ -351,6 +353,18 @@ func (a *GitHubAdapter) FetchIssueByID(ctx context.Context, issueID string) (dom
 		return nil
 	})
 	return issue, err
+}
+
+// FetchIssueBlockers returns the blockers of one issue, read from the
+// forge's dependencies route.
+func (a *GitHubAdapter) FetchIssueBlockers(ctx context.Context, issueID string) ([]domain.BlockerRef, error) {
+	blockers := make([]domain.BlockerRef, 0)
+	err := trackermetrics.Track(a.metrics, "fetch_blockers", func() error {
+		var fetchErr error
+		blockers, fetchErr = a.fetchBlockers(ctx, issueID)
+		return fetchErr
+	})
+	return blockers, err
 }
 
 func (a *GitHubAdapter) fetchBlockers(ctx context.Context, issueID string) ([]domain.BlockerRef, error) {
@@ -378,13 +392,10 @@ func (a *GitHubAdapter) fetchBlockers(ctx context.Context, issueID string) ([]do
 
 	blockers, err := paginator.All(ctx)
 	if err != nil {
-		if domain.IsNotFound(err) {
-			return []domain.BlockerRef{}, nil
-		}
 		return nil, err
 	}
 
-	return normalizeBlockers(blockers, a.activeStates, a.terminalStates, a.handoffState, a.log), nil
+	return normalizeBlockers(blockers, a.activeStates, a.terminalStates, a.handoffState, a.owner, a.repo, a.log), nil
 }
 
 func (a *GitHubAdapter) fetchParent(ctx context.Context, issueID string) (*domain.ParentRef, error) {

--- a/internal/scm/github/tracker_test.go
+++ b/internal/scm/github/tracker_test.go
@@ -453,6 +453,10 @@ func TestFetchCandidateIssues_CommentsNil(t *testing.T) {
 		if iss.Labels == nil {
 			t.Errorf("issue %s: Labels should be non-nil", iss.Identifier)
 		}
+		// issues.json carries no issue_dependencies_summary field, so
+		// every candidate must be marked unresolved rather than read as
+		// having no blockers.
+		adaptertest.AssertCandidateBlockerSource(t, registry.BlockersPerIssue, iss, 0)
 	}
 }
 
@@ -775,16 +779,48 @@ func TestFetchIssueByID_PRReturnsNotFound(t *testing.T) {
 	assertTrackerErrorKind(t, err, domain.ErrTrackerNotFound)
 }
 
-func TestFetchIssueByID_BlockerNotFound_Degrades(t *testing.T) {
+// TestFetchIssueByID_BlockerNotFound_Propagates pins that a 404 on
+// the dependencies route is not a signal that the issue has no
+// blockers. It
+// must surface as a *domain.TrackerError of kind ErrTrackerNotFound
+// rather than degrade to a non-nil empty BlockedBy, because a caller
+// that cannot tell "no blockers" from "could not read blockers" would
+// dispatch an issue whose blocker state is actually unknown.
+func TestFetchIssueByID_BlockerNotFound_Propagates(t *testing.T) {
 	t.Parallel()
 
-	// blockers endpoint returns 404 → BlockedBy should be empty non-nil slice.
+	issueFix := loadFixture(t, "issue.json")
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/owner/repo/issues/42/dependencies/blocked_by", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	})
+	mux.HandleFunc("/repos/owner/repo/issues/42", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write(issueFix) //nolint:errcheck // test helper
+	})
+
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	a := mustAdapter(t, validConfig(srv.URL))
+	_, err := a.FetchIssueByID(context.Background(), "42")
+	assertTrackerErrorKind(t, err, domain.ErrTrackerNotFound)
+}
+
+// TestFetchIssueByID_ParentNotFound_Degrades pins that a 404 on the
+// parent route is unaffected by the blocker-completeness change: it
+// still degrades to a nil Parent rather than an error.
+func TestFetchIssueByID_ParentNotFound_Degrades(t *testing.T) {
+	t.Parallel()
+
 	issueFix := loadFixture(t, "issue.json")
 	commentsFix := loadFixture(t, "comments.json")
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/repos/owner/repo/issues/42/dependencies/blocked_by", func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusNotFound)
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("[]")) //nolint:errcheck // test helper
 	})
 	mux.HandleFunc("/repos/owner/repo/issues/42/parent", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNotFound)
@@ -807,9 +843,11 @@ func TestFetchIssueByID_BlockerNotFound_Degrades(t *testing.T) {
 		t.Fatalf("FetchIssueByID: %v", err)
 	}
 
-	// 404 on blockers → empty non-nil slice.
+	if issue.BlockersUnresolved {
+		t.Error("BlockersUnresolved = true, want false: the blocker read succeeded")
+	}
 	if issue.BlockedBy == nil {
-		t.Error("BlockedBy is nil, want non-nil empty slice on 404")
+		t.Error("BlockedBy is nil, want non-nil empty slice")
 	}
 	if len(issue.BlockedBy) != 0 {
 		t.Errorf("BlockedBy len = %d, want 0", len(issue.BlockedBy))
@@ -2476,7 +2514,8 @@ func TestFetchCandidateIssueByIDEquivalence(t *testing.T) {
 
 	// Issue 1: active, exists.
 	mux.HandleFunc("/repos/owner/repo/issues/1/dependencies/blocked_by", func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusNotFound)
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(emptyList)) //nolint:errcheck // test helper
 	})
 	mux.HandleFunc("/repos/owner/repo/issues/1/parent", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNotFound)
@@ -2498,7 +2537,8 @@ func TestFetchCandidateIssueByIDEquivalence(t *testing.T) {
 
 	// Issue 3: non-active, exists.
 	mux.HandleFunc("/repos/owner/repo/issues/3/dependencies/blocked_by", func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusNotFound)
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(emptyList)) //nolint:errcheck // test helper
 	})
 	mux.HandleFunc("/repos/owner/repo/issues/3/parent", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNotFound)
@@ -2575,6 +2615,4 @@ func TestFetchCandidateIssueByIDEquivalence(t *testing.T) {
 			t.Errorf("issue 3 appeared in candidates, want excluded (non-active state)")
 		}
 	}
-
-	_ = emptyList // suppress unused warning
 }

--- a/internal/scm/gitlab/gitlab.go
+++ b/internal/scm/gitlab/gitlab.go
@@ -68,6 +68,7 @@ func init() {
 		DefaultActiveStates:   defaultActiveStates,
 		DefaultTerminalStates: defaultTerminalStates,
 		ValidateTrackerConfig: validateConfig,
+		BlockerSource:         registry.BlockersUnsupported,
 	})
 }
 

--- a/internal/scm/gitlab/gitlab_test.go
+++ b/internal/scm/gitlab/gitlab_test.go
@@ -1042,6 +1042,11 @@ func TestFetchCandidateIssues(t *testing.T) {
 			if iss.Comments != nil {
 				t.Errorf("issue %s: Comments = %v, want nil", iss.Identifier, iss.Comments)
 			}
+			// GitLab Community Edition's issue-links route carries no
+			// "blocks" relation, so every candidate's empty list is
+			// declared complete rather than something a resolver owes
+			// a read for.
+			adaptertest.AssertCandidateBlockerSource(t, registry.BlockersUnsupported, iss, 0)
 		}
 		if got := calls.Load(); got != 2 {
 			t.Errorf("call count = %d, want 2 (two pages)", got)

--- a/internal/scm/gitlab/normalize_test.go
+++ b/internal/scm/gitlab/normalize_test.go
@@ -3,6 +3,9 @@ package gitlab
 import (
 	"encoding/json"
 	"testing"
+
+	"github.com/sortie-ai/sortie/internal/adaptertest"
+	"github.com/sortie-ai/sortie/internal/registry"
 )
 
 func TestNormalizeIssue_AllFields(t *testing.T) {
@@ -128,6 +131,12 @@ func TestNormalizeIssue_MultipleAssignees(t *testing.T) {
 	}
 }
 
+// TestNormalizeIssue_BlockedByAlwaysNonNilEmpty pins that the always-
+// empty blocker list is a declared capability limit, not an unread
+// value: GitLab Community Edition's issue-links route carries no
+// "blocks" relation to invert, so [registry.BlockersUnsupported] reads
+// the empty list as complete rather than as something a resolver
+// still owes a read.
 func TestNormalizeIssue_BlockedByAlwaysNonNilEmpty(t *testing.T) {
 	t.Parallel()
 
@@ -140,6 +149,9 @@ func TestNormalizeIssue_BlockedByAlwaysNonNilEmpty(t *testing.T) {
 	if len(got.BlockedBy) != 0 {
 		t.Errorf("BlockedBy len = %d, want 0 (gitlab community edition has no blocks relation type)", len(got.BlockedBy))
 	}
+
+	adaptertest.AssertCandidateBlockerSource(t, registry.BlockersUnsupported, got, 0)
+	adaptertest.AssertBlockerIdentifiersMatchIssue(t, got, got.BlockedBy)
 }
 
 func TestNormalizeIssue_NullDescriptionDecodesToEmptyString(t *testing.T) {

--- a/internal/server/grafana_coverage_test.go
+++ b/internal/server/grafana_coverage_test.go
@@ -41,6 +41,7 @@ var knownSortieMetrics = []string{
 	"sortie_review_escalations_total",
 	"sortie_reactions_auto_merge_total",
 	"sortie_dispatch_rule_match_total",
+	"sortie_candidate_holds_total",
 	"sortie_self_review_iterations_total",
 	"sortie_self_review_sessions_total",
 	"sortie_self_review_verification_duration_seconds",

--- a/internal/server/metrics.go
+++ b/internal/server/metrics.go
@@ -43,6 +43,7 @@ type PromMetrics struct {
 	mergeConflictChecksTotal      *prometheus.CounterVec
 	mergeConflictEscalationsTotal *prometheus.CounterVec
 	dispatchRuleMatchTotal        *prometheus.CounterVec
+	candidateHoldsTotal           *prometheus.CounterVec
 
 	selfReviewIterationsTotal      *prometheus.CounterVec
 	selfReviewSessionsTotal        *prometheus.CounterVec
@@ -258,6 +259,12 @@ func NewPromMetrics(version, goVersion string) *PromMetrics {
 		Help:      "Dispatch rule match outcomes by resolution layer and rule name.",
 	}, []string{"layer", "rule"})
 
+	candidateHoldsTotal := prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "sortie",
+		Name:      "candidate_holds_total",
+		Help:      "Candidates the dispatch loop held, by reason.",
+	}, []string{"reason"})
+
 	selfReviewIterationsTotal := prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "sortie",
 		Name:      "self_review_iterations_total",
@@ -315,6 +322,7 @@ func NewPromMetrics(version, goVersion string) *PromMetrics {
 		mergeConflictChecksTotal,
 		mergeConflictEscalationsTotal,
 		dispatchRuleMatchTotal,
+		candidateHoldsTotal,
 		selfReviewIterationsTotal,
 		selfReviewSessionsTotal,
 		selfReviewVerificationDuration,
@@ -353,6 +361,7 @@ func NewPromMetrics(version, goVersion string) *PromMetrics {
 		mergeConflictChecksTotal:       mergeConflictChecksTotal,
 		mergeConflictEscalationsTotal:  mergeConflictEscalationsTotal,
 		dispatchRuleMatchTotal:         dispatchRuleMatchTotal,
+		candidateHoldsTotal:            candidateHoldsTotal,
 		selfReviewIterationsTotal:      selfReviewIterationsTotal,
 		selfReviewSessionsTotal:        selfReviewSessionsTotal,
 		selfReviewVerificationDuration: selfReviewVerificationDuration,
@@ -534,6 +543,13 @@ func (p *PromMetrics) IncDispatchRuleMatch(layer, rule string) {
 		rule = "<none>"
 	}
 	p.dispatchRuleMatchTotal.WithLabelValues(layer, rule).Inc()
+}
+
+// IncCandidateHolds increments the counter of candidates the dispatch
+// loop held. reason is "blocked_by", "blockers_unresolved",
+// "blockers_not_read", or "blockers_incomplete".
+func (p *PromMetrics) IncCandidateHolds(reason string) {
+	p.candidateHoldsTotal.WithLabelValues(reason).Inc()
 }
 
 // IncSelfReviewIterations increments the review iteration counter.

--- a/internal/server/metrics_test.go
+++ b/internal/server/metrics_test.go
@@ -137,6 +137,7 @@ func TestNewPromMetrics(t *testing.T) {
 	m.IncBotReviewEscalations("label")
 	m.IncAutoMergeReactions("merged")
 	m.IncDispatchRuleMatch("rule", "bug-rule")
+	m.IncCandidateHolds("blocked_by")
 	m.IncSelfReviewIterations("pass")
 	m.IncSelfReviewSessions("pass")
 	m.ObserveSelfReviewVerificationDuration("go test ./...", 1.5)

--- a/internal/tracker/file/file.go
+++ b/internal/tracker/file/file.go
@@ -25,7 +25,9 @@ import (
 )
 
 func init() {
-	registry.Trackers.Register("file", NewFileAdapter)
+	registry.Trackers.RegisterWithMeta("file", NewFileAdapter, registry.TrackerMeta{
+		BlockerSource: registry.BlockersFromCandidates,
+	})
 }
 
 // Compile-time interface satisfaction check.

--- a/internal/tracker/file/file_test.go
+++ b/internal/tracker/file/file_test.go
@@ -139,12 +139,23 @@ func TestFetchCandidateIssues(t *testing.T) {
 			t.Fatalf("got %d issues, want 2", len(issues))
 		}
 		ids := map[string]bool{}
+		byIdentifier := map[string]domain.Issue{}
 		for _, iss := range issues {
 			ids[iss.Identifier] = true
+			byIdentifier[iss.Identifier] = iss
 		}
 		if !ids["PROJ-1"] || !ids["PROJ-2"] {
 			t.Errorf("unexpected issues: %v", ids)
 		}
+
+		// The file adapter declares BlockersFromCandidates: a fixture
+		// entry carrying a real blocker must produce it on the
+		// candidate path too, not only through FetchIssueByID.
+		proj1 := byIdentifier["PROJ-1"]
+		if len(proj1.BlockedBy) != 1 || proj1.BlockedBy[0].ID != "10002" {
+			t.Errorf("PROJ-1.BlockedBy = %v, want one blocker with ID 10002", proj1.BlockedBy)
+		}
+		adaptertest.AssertCandidateBlockerSource(t, registry.BlockersFromCandidates, proj1, 1)
 	})
 
 	t.Run("no active states returns all", func(t *testing.T) {
@@ -304,6 +315,8 @@ func TestFetchIssueByID(t *testing.T) {
 		}
 
 		adaptertest.AssertIssueNormalized(t, iss)
+		adaptertest.AssertBlockerRefsNormalized(t, iss.BlockedBy)
+		adaptertest.AssertBlockerIdentifiersMatchIssue(t, iss, iss.BlockedBy)
 	})
 
 	t.Run("not found", func(t *testing.T) {
@@ -671,9 +684,15 @@ func TestNormalization(t *testing.T) {
 		}
 	})
 
-	t.Run("absent blocked_by is non-nil empty", func(t *testing.T) {
+	t.Run("absent blocked_by is authoritatively empty, not unread", func(t *testing.T) {
 		t.Parallel()
 
+		// n7's own fixture entry carries no blocked_by key, so the
+		// empty list here means the input has none; it is not the
+		// unresolved-by-default shape GitHub and Gitea produce when
+		// their candidate route cannot answer the question at all.
+		// The file adapter declares BlockersFromCandidates, so
+		// AssertCandidateBlockerSource requires the flag stay clear.
 		iss := issueByID["n7"]
 		if iss.BlockedBy == nil {
 			t.Fatal("BlockedBy is nil, want non-nil empty slice")
@@ -681,6 +700,7 @@ func TestNormalization(t *testing.T) {
 		if len(iss.BlockedBy) != 0 {
 			t.Errorf("len(BlockedBy) = %d, want 0", len(iss.BlockedBy))
 		}
+		adaptertest.AssertCandidateBlockerSource(t, registry.BlockersFromCandidates, iss, 0)
 	})
 
 	t.Run("absent parent is nil", func(t *testing.T) {

--- a/internal/tracker/jira/jira.go
+++ b/internal/tracker/jira/jira.go
@@ -33,6 +33,7 @@ func init() {
 		RequiresAPIKey:        true,
 		DefaultActiveStates:   defaultActiveStates,
 		ValidateTrackerConfig: validateConfig,
+		BlockerSource:         registry.BlockersFromCandidates,
 	})
 }
 

--- a/internal/tracker/jira/jira_test.go
+++ b/internal/tracker/jira/jira_test.go
@@ -239,7 +239,9 @@ func TestFetchCandidateIssues_SinglePage(t *testing.T) {
 
 	fixture := loadFixture(t, "search_single_page.json")
 	var receivedJQL string
+	var requestCount atomic.Int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount.Add(1)
 		receivedJQL = r.URL.Query().Get("jql")
 		w.WriteHeader(http.StatusOK)
 		w.Write(fixture) //nolint:errcheck // test helper
@@ -253,6 +255,13 @@ func TestFetchCandidateIssues_SinglePage(t *testing.T) {
 	}
 	if len(issues) != 2 {
 		t.Fatalf("len = %d, want 2", len(issues))
+	}
+
+	// searchFields already names issuelinks, so a single-page candidate
+	// fetch costs exactly one HTTP request with no per-issue blocker
+	// fan-out.
+	if got := requestCount.Load(); got != 1 {
+		t.Errorf("HTTP request count = %d, want 1 (no per-issue blocker fan-out)", got)
 	}
 
 	// Verify normalization on first issue

--- a/internal/tracker/jira/normalize_test.go
+++ b/internal/tracker/jira/normalize_test.go
@@ -3,6 +3,9 @@ package jira
 import (
 	"encoding/json"
 	"testing"
+
+	"github.com/sortie-ai/sortie/internal/adaptertest"
+	"github.com/sortie-ai/sortie/internal/registry"
 )
 
 func TestNormalizeSearchIssue_AllFields(t *testing.T) {
@@ -86,6 +89,13 @@ func TestNormalizeSearchIssue_AllFields(t *testing.T) {
 	if issue.BlockedBy[0].State != "In Progress" {
 		t.Errorf("BlockedBy[0].State = %q, want In Progress", issue.BlockedBy[0].State)
 	}
+
+	// searchFields carries issuelinks into every candidate search, so
+	// Jira declares BlockersFromCandidates and this candidate already
+	// carries its one real blocker with no further read owed.
+	adaptertest.AssertCandidateBlockerSource(t, registry.BlockersFromCandidates, issue, 1)
+	adaptertest.AssertBlockerRefsNormalized(t, issue.BlockedBy)
+	adaptertest.AssertBlockerIdentifiersMatchIssue(t, issue, issue.BlockedBy)
 }
 
 func TestNormalizeSearchIssue_NilFields(t *testing.T) {

--- a/internal/tracker/linear/linear.go
+++ b/internal/tracker/linear/linear.go
@@ -34,6 +34,7 @@ func init() {
 		ValidateTrackerConfig: validateConfig,
 		DefaultActiveStates:   defaultActiveStates,
 		DefaultTerminalStates: defaultTerminalStates,
+		BlockerSource:         registry.BlockersFromCandidates,
 	})
 }
 

--- a/internal/tracker/linear/linear_test.go
+++ b/internal/tracker/linear/linear_test.go
@@ -317,6 +317,7 @@ func TestFetchCandidateIssues(t *testing.T) {
 		f.queueBody("query CandidateIssues", loadFixture(t, "candidates_page2.json"))
 
 		adapter := newTestAdapter(t, f)
+		callsBeforeFetch := len(f.calls)
 
 		issues, err := adapter.FetchCandidateIssues(context.Background())
 		if err != nil {
@@ -339,6 +340,13 @@ func TestFetchCandidateIssues(t *testing.T) {
 		calls := f.callsFor("query CandidateIssues")
 		if len(calls) != 2 {
 			t.Fatalf("CandidateIssues call count = %d, want 2 (one per page)", len(calls))
+		}
+
+		// Every GraphQL call this fetch made, of any query name, is
+		// exactly the two candidate pages: no per-issue blocker
+		// fan-out, excluding the construction-time preflight call.
+		if got := len(f.calls) - callsBeforeFetch; got != 2 {
+			t.Errorf("total GraphQL requests during FetchCandidateIssues = %d, want 2 (zero per-issue fan-out)", got)
 		}
 		if calls[0].variables["after"] != nil {
 			t.Errorf("first page after = %v, want nil", calls[0].variables["after"])

--- a/internal/tracker/linear/normalize.go
+++ b/internal/tracker/linear/normalize.go
@@ -300,20 +300,21 @@ func normalizeIssue(li linearIssue, log *slog.Logger) domain.Issue {
 	}
 
 	return domain.Issue{
-		ID:          li.ID,
-		Identifier:  li.Identifier,
-		Title:       li.Title,
-		Description: description,
-		Priority:    normalizePriority(li.Priority),
-		State:       li.State.Name,
-		BranchName:  li.BranchName,
-		URL:         li.URL,
-		Labels:      issuekit.NormalizeLabels(labelNames),
-		Assignee:    resolveAssignee(li.Assignee),
-		Parent:      parent,
-		BlockedBy:   extractBlockers(li.InverseRelations),
-		CreatedAt:   li.CreatedAt,
-		UpdatedAt:   li.UpdatedAt,
+		ID:                 li.ID,
+		Identifier:         li.Identifier,
+		Title:              li.Title,
+		Description:        description,
+		Priority:           normalizePriority(li.Priority),
+		State:              li.State.Name,
+		BranchName:         li.BranchName,
+		URL:                li.URL,
+		Labels:             issuekit.NormalizeLabels(labelNames),
+		Assignee:           resolveAssignee(li.Assignee),
+		Parent:             parent,
+		BlockedBy:          extractBlockers(li.InverseRelations),
+		BlockersUnresolved: li.InverseRelations.PageInfo.HasNextPage,
+		CreatedAt:          li.CreatedAt,
+		UpdatedAt:          li.UpdatedAt,
 	}
 }
 

--- a/internal/tracker/linear/normalize_test.go
+++ b/internal/tracker/linear/normalize_test.go
@@ -6,7 +6,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/sortie-ai/sortie/internal/adaptertest"
 	"github.com/sortie-ai/sortie/internal/domain"
+	"github.com/sortie-ai/sortie/internal/registry"
 )
 
 func TestNormalizeIssue(t *testing.T) {
@@ -57,6 +59,13 @@ func TestNormalizeIssue(t *testing.T) {
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("normalizeIssue() = %+v, want %+v", got, want)
 	}
+
+	// inverseRelations(first: 25) carries the real blocker inline, so
+	// Linear declares BlockersFromCandidates and this candidate already
+	// has its one blocker with no further read owed.
+	adaptertest.AssertCandidateBlockerSource(t, registry.BlockersFromCandidates, got, 1)
+	adaptertest.AssertBlockerRefsNormalized(t, got.BlockedBy)
+	adaptertest.AssertBlockerIdentifiersMatchIssue(t, got, got.BlockedBy)
 }
 
 func TestNormalizeIssueDisplayIDAndTypeEmpty(t *testing.T) {
@@ -345,6 +354,14 @@ func TestNormalizeNestedOverflowWarn(t *testing.T) {
 			}
 			if len(got.BlockedBy) != 1 {
 				t.Errorf("BlockedBy len = %d, want 1 (truncated set returned)", len(got.BlockedBy))
+			}
+			// A truncated inverseRelations connection marks the issue
+			// unresolved, so the dispatch gate holds it rather than
+			// trusting a blocker list that might be missing an entry
+			// past the first page; every other overflow combination
+			// leaves the flag clear.
+			if got.BlockersUnresolved != tt.relationsNext {
+				t.Errorf("BlockersUnresolved = %t, want %t", got.BlockersUnresolved, tt.relationsNext)
 			}
 
 			output := buf.String()


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Fix

**Intent:** On GitHub, the dispatch gate always saw an empty `BlockedBy` on candidate issues, so it never held an issue back for an open blocker. This makes the gate see the real blocker list for GitHub (and brings every other adapter's declared blocker behavior into the same conformance suite so the same gap cannot reappear on another tracker unnoticed).

**Related Issues:** #920

### 🧭 Reviewer Guide

**Complexity:** High

#### Entry Point

Start at `internal/scm/github/normalize.go`. `normalizeIssue` now reads GitHub's `issue_dependencies_summary` field and sets a new `BlockersUnresolved` flag instead of always returning an empty `BlockedBy`; the adapter declares `registry.BlockersPerIssue` and implements `FetchIssueBlockers` (`internal/scm/github/tracker.go`) so a shared resolver can complete the list. From there, `internal/blockers/blockers.go` (new package) is the resolver itself, and `internal/orchestrator/dispatch.go` (`EvaluateCandidate`) is where the tick loop spends a bounded per-tick read budget and holds any candidate it cannot resolve rather than dispatching it. `internal/orchestrator/orchestrator.go`'s `handleTick` wires the resolver into that loop and records the new `sortie_candidate_holds_total` metric and hold-reason log fields.

#### Sensitive Areas

- `internal/orchestrator/dispatch.go`: the dispatch gate itself - a regression here either starts blocked work or wrongly stalls unblocked work.
- `internal/scm/github/normalize.go` / `internal/scm/gitea/normalize.go`: the two adapters whose candidate routes needed a real fix rather than a declaration; a wrong `BlockersUnresolved` default reintroduces the bug or over-holds every candidate.
- `internal/domain/tracker.go`: the new `BlockerReader` capability and `registry.BlockerSource` enum other trackers now declare against.
- `cmd/sortie/boot.go`: constructs the resolver and threads it into both the live orchestrator and dry-run; a nil-interface mistake here would silently disable the gate.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes. `BlockerSource` defaults to the pre-existing "candidates" behavior when unset, and the production binary always supplies a resolver. The field is optional in the type: with a nil resolver a candidates-source adapter behaves exactly as before, while a per-issue adapter's candidates are held rather than dispatched, because an unread blocker list is never read as an empty one.
- **Migrations/State:** No database migrations. The orchestrator gains one new in-memory field (`BlockerReadOffset`) that resumes a partially-read tick on the next poll; no persisted schema changes.
