### PR TITLE
fix(orchestrator): resolve agent settings by the session's kind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   blocker list, which was previously always empty.
   ([#920](https://github.com/sortie-ai/sortie/issues/920))
 
+- An issue routed by a dispatch rule to an agent kind other than the
+  workflow default now runs with the MCP servers configured in its own
+  agent settings block. It was given the default kind's `mcp_config`
+  instead: servers and credentials meant for another agent were
+  loaded, its own were silently dropped, and a stale or malformed path
+  in the default block failed the session at startup and sent it into
+  retry backoff, naming a file the operator had never associated with
+  that agent. `claude-code` and `copilot-cli` consume the generated
+  file; a session running on the workflow default was unaffected.
+  ([#924](https://github.com/sortie-ai/sortie/issues/924))
+
 ## [1.21.0] - 2026-08-20
 
 ### Fixed

--- a/cmd/sortie/boot.go
+++ b/cmd/sortie/boot.go
@@ -225,7 +225,7 @@ func boot(ctx context.Context, p bootParams) (bootResult, int) {
 	}
 	trackerCfgMap := trackerConfigMap(cfg.Tracker)
 	trackerCfgMap["user_agent"] = "sortie/" + Version
-	mergeExtensions(trackerCfgMap, cfg.Extensions, cfg.Tracker.Kind)
+	config.MergeAdapterExtensions(trackerCfgMap, cfg, cfg.Tracker.Kind)
 	trackerAdapter, err := trackerCtor(trackerCfgMap)
 	if err != nil {
 		logger.Error("failed to construct tracker adapter", slog.Any("error", err))

--- a/cmd/sortie/main.go
+++ b/cmd/sortie/main.go
@@ -381,7 +381,7 @@ func run(ctx context.Context, args []string, stdout io.Writer, stderr io.Writer)
 			return 1
 		}
 		adapterCfgMap := make(map[string]any)
-		mergeExtensions(adapterCfgMap, br.cfg.Extensions, br.cfg.CIFeedback.Kind)
+		config.MergeAdapterExtensions(adapterCfgMap, br.cfg, br.cfg.CIFeedback.Kind)
 		if br.cfg.CIFeedback.Kind == br.cfg.Tracker.Kind {
 			mergeTrackerCredentials(adapterCfgMap, br.cfg.Tracker)
 		}
@@ -460,7 +460,7 @@ func run(ctx context.Context, args []string, stdout io.Writer, stderr io.Writer)
 			return 1
 		}
 		adapterCfgMap := make(map[string]any)
-		mergeExtensions(adapterCfgMap, br.cfg.Extensions, provider)
+		config.MergeAdapterExtensions(adapterCfgMap, br.cfg, provider)
 		if provider == br.cfg.Tracker.Kind {
 			mergeTrackerCredentials(adapterCfgMap, br.cfg.Tracker)
 		}

--- a/cmd/sortie/mcpserver.go
+++ b/cmd/sortie/mcpserver.go
@@ -85,7 +85,7 @@ func runMCPServer(ctx context.Context, args []string, stdout io.Writer, stderr i
 
 		trackerCfgMap := trackerConfigMap(cfg.Tracker)
 		trackerCfgMap["user_agent"] = "sortie-mcp/" + Version
-		mergeExtensions(trackerCfgMap, cfg.Extensions, cfg.Tracker.Kind)
+		config.MergeAdapterExtensions(trackerCfgMap, cfg, cfg.Tracker.Kind)
 
 		adapter, adapterErr := trackerCtor(trackerCfgMap)
 		if adapterErr != nil {

--- a/cmd/sortie/resolve.go
+++ b/cmd/sortie/resolve.go
@@ -45,22 +45,6 @@ func trackerConfigMap(tc config.TrackerConfig) map[string]any {
 	}
 }
 
-// mergeExtensions copies adapter-specific config from the Extensions
-// map into dst. Adapters may define their own configuration fields
-// in a sub-object named after their kind value. Existing keys in dst
-// are not overwritten.
-func mergeExtensions(dst map[string]any, extensions map[string]any, kind string) {
-	sub, ok := extensions[kind].(map[string]any)
-	if !ok {
-		return
-	}
-	for k, v := range sub {
-		if _, exists := dst[k]; !exists {
-			dst[k] = v
-		}
-	}
-}
-
 // mergeTrackerCredentials copies api_key, project, and endpoint from
 // the tracker config into dst when the corresponding key is absent.
 // Called only when the CI provider kind matches the tracker kind so

--- a/cmd/sortie/resolve_test.go
+++ b/cmd/sortie/resolve_test.go
@@ -357,105 +357,6 @@ func TestTrackerConfigMapCompleteness(t *testing.T) {
 	}
 }
 
-// --- mergeExtensions tests ---
-
-func TestMergeExtensions(t *testing.T) {
-	t.Parallel()
-
-	t.Run("copies extension keys", func(t *testing.T) {
-		t.Parallel()
-
-		dst := map[string]any{"kind": "file"}
-		extensions := map[string]any{
-			"file": map[string]any{"path": "issues.json", "extra": 42},
-		}
-
-		mergeExtensions(dst, extensions, "file")
-
-		if dst["path"] != "issues.json" {
-			t.Errorf("path = %v, want %q", dst["path"], "issues.json")
-		}
-		if dst["extra"] != 42 {
-			t.Errorf("extra = %v, want 42", dst["extra"])
-		}
-	})
-
-	t.Run("does not overwrite existing keys", func(t *testing.T) {
-		t.Parallel()
-
-		dst := map[string]any{"kind": "file", "path": "original.json"}
-		extensions := map[string]any{
-			"file": map[string]any{"path": "overridden.json"},
-		}
-
-		mergeExtensions(dst, extensions, "file")
-
-		if dst["path"] != "original.json" {
-			t.Errorf("path = %v, want %q (should not overwrite)", dst["path"], "original.json")
-		}
-	})
-
-	t.Run("missing kind is no-op", func(t *testing.T) {
-		t.Parallel()
-
-		dst := map[string]any{"kind": "jira"}
-		extensions := map[string]any{
-			"file": map[string]any{"path": "issues.json"},
-		}
-
-		mergeExtensions(dst, extensions, "jira")
-
-		if _, ok := dst["path"]; ok {
-			t.Error("path should not be set when kind has no extensions")
-		}
-	})
-
-	t.Run("nil extensions is no-op", func(t *testing.T) {
-		t.Parallel()
-
-		dst := map[string]any{"kind": "file"}
-		mergeExtensions(dst, nil, "file")
-
-		if len(dst) != 1 {
-			t.Errorf("dst has %d keys, want 1", len(dst))
-		}
-	})
-
-	t.Run("non-map extension value is no-op", func(t *testing.T) {
-		t.Parallel()
-
-		dst := map[string]any{"kind": "file"}
-		extensions := map[string]any{
-			"file": "not a map",
-		}
-
-		mergeExtensions(dst, extensions, "file")
-
-		if len(dst) != 1 {
-			t.Errorf("dst has %d keys, want 1", len(dst))
-		}
-	})
-
-	t.Run("adapter max_turns passthrough", func(t *testing.T) {
-		t.Parallel()
-
-		dst := map[string]any{"kind": "claude-code"}
-		extensions := map[string]any{
-			"claude-code": map[string]any{"max_turns": float64(50)},
-		}
-
-		mergeExtensions(dst, extensions, "claude-code")
-
-		got, ok := dst["max_turns"]
-		if !ok {
-			t.Fatal("max_turns not present after mergeExtensions")
-		}
-		if got != float64(50) {
-			t.Errorf("max_turns = %v, want 50 (adapter value, not orchestrator value)", got)
-		}
-	})
-}
-
 // --- mergeTrackerCredentials tests ---
 
 // --- mergeTrackerCredentials tests ---
@@ -547,7 +448,8 @@ func TestMergeTrackerCredentialsExtensionsWin(t *testing.T) {
 
 	// Extensions key wins over tracker key.
 	dst := map[string]any{}
-	mergeExtensions(dst, map[string]any{"github": map[string]any{"api_key": "ext-tok"}}, "github")
+	cfg := config.ServiceConfig{Extensions: map[string]any{"github": map[string]any{"api_key": "ext-tok"}}}
+	config.MergeAdapterExtensions(dst, cfg, "github")
 	mergeTrackerCredentials(dst, config.TrackerConfig{APIKey: "tracker-tok", Project: "PROJ"})
 
 	if got := dst["api_key"]; got != "ext-tok" {
@@ -610,7 +512,7 @@ func TestKindMatchGuardWiring(t *testing.T) {
 			t.Parallel()
 
 			adapterCfgMap := make(map[string]any)
-			mergeExtensions(adapterCfgMap, tt.extensions, tt.ciKind)
+			config.MergeAdapterExtensions(adapterCfgMap, config.ServiceConfig{Extensions: tt.extensions}, tt.ciKind)
 			if tt.ciKind == tt.trackerKind {
 				mergeTrackerCredentials(adapterCfgMap, tt.tc)
 			}

--- a/docs/claude-code-adapter-notes.md
+++ b/docs/claude-code-adapter-notes.md
@@ -62,7 +62,7 @@ Session transcripts live under the user's home directory, not in the workspace. 
 
 ## Sortie's own tools
 
-The worker generates one MCP configuration file per session, declaring the Sortie tool server and carrying the per-session variables it needs. This CLI accepts exactly one such config path, which is why an operator-supplied config cannot simply be passed alongside ours: the worker merges the two, and a name collision on our reserved server key fails the attempt rather than silently overwriting. Credentials reach the tool server through the inherited environment, never through the file.
+The worker generates one MCP configuration file per session, declaring the Sortie tool server and carrying the per-session variables it needs. This CLI accepts exactly one such config path, which is why an operator-supplied config cannot simply be passed alongside ours: the worker merges the two, and a name collision on our reserved server key fails the attempt rather than silently overwriting. That merged file is also where credentials for the tool server come from: the worker copies every `SORTIE_`-prefixed variable out of its own process environment into the config's env block, which is how a workflow's `$SORTIE_*` credential indirection resolves inside the tool server. Treat that file as carrying secrets, not just plumbing.
 
 Whether Sortie's tools reach an agent at all is a per-adapter property, not a guarantee of the fleet. The mechanism depends on what the CLI accepts, so some adapters wire the generated config through and others cannot. Do not assume, from this adapter, that a tool call is available in another.
 

--- a/docs/opencode-adapter-notes.md
+++ b/docs/opencode-adapter-notes.md
@@ -14,7 +14,7 @@ Nothing here pins a flag list, an event vocabulary, a permission key set, or an 
 
 If a future change needs anything the projection hides, retry and backoff state above all, the answer is the server surface with its documented schemas, not a richer parse of `run` output.
 
-One trap to carry into that work if it ever happens. A port of zero on this CLI is not "pick any free port". It is a sentinel meaning try the conventional default first and fall back to an ephemeral port only if that one is taken. The shared option default is zero, so a caller who reads it as ephemeral can attach to a server it did not start, and one who reads it as the fixed default can miss the server entirely. Set the port explicitly on both sides rather than relying on the default.
+One trap to carry into that work if it ever happens: nothing in this adapter wires a port today, but the underlying server mode treats a port value of zero as a sentinel rather than as "pick any free port", and reading that wrong in either direction either attaches to a server this process did not start or misses the server the CLI actually opened. Confirm the current sentinel semantics against `opencode run --help` and the server-mode docs at `opencode.ai` before trusting a zero default, and set the port explicitly on both sides regardless of what you find there.
 
 ## Why this adapter owns its own loop
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -207,13 +207,70 @@ func AgentAdapterConfig(cfg ServiceConfig, kind string) map[string]any {
 		"read_timeout_ms":  cfg.Agent.ReadTimeoutMS,
 		"stall_timeout_ms": cfg.Agent.StallTimeoutMS,
 	}
-	mergeAgentExtensions(m, cfg.Extensions, kind)
+	mergeExtensionSection(m, cfg.Extensions, kind)
 	return m
 }
 
-// mergeAgentExtensions copies the kind-named sub-object from
+// AgentSettings is the resolved answer to what one agent kind
+// resolves to for one session, returned by [ResolveAgentSettings].
+type AgentSettings struct {
+	Kind string
+
+	// Passthrough is the same map [AgentAdapterConfig] returns for
+	// Kind: freshly allocated on every call, and safe for the caller
+	// to keep.
+	Passthrough map[string]any
+
+	// MCPConfigPath is the operator-declared MCP config path resolved
+	// from Passthrough["mcp_config"]. Empty when the kind has no
+	// block, the block carries no mcp_config, or its value is not a
+	// non-empty string.
+	MCPConfigPath string
+}
+
+// ResolveAgentSettings resolves kind to the settings a session running
+// on that kind uses for one attempt. kind is the session's
+// dispatch-frozen agent kind, never the workflow default: a session
+// routed to a different kind than cfg.Agent.Kind resolves against the
+// routed kind's own block. Callers MUST call ResolveAgentSettings once
+// per attempt, never once per session, so a workflow reloaded between
+// attempts takes effect on the next one.
+//
+// A relative mcp_config value is resolved against workflowDir when
+// workflowDir is non-empty; an absolute value and an empty workflowDir
+// are both returned unchanged. ResolveAgentSettings is pure: it reads
+// no environment variable and touches no file, and is safe for
+// concurrent use.
+func ResolveAgentSettings(cfg ServiceConfig, kind string, workflowDir string) AgentSettings {
+	passthrough := AgentAdapterConfig(cfg, kind)
+
+	var mcpConfigPath string
+	if v, ok := passthrough["mcp_config"].(string); ok {
+		mcpConfigPath = v
+	}
+	if mcpConfigPath != "" && !filepath.IsAbs(mcpConfigPath) && workflowDir != "" {
+		mcpConfigPath = filepath.Join(workflowDir, mcpConfigPath)
+	}
+
+	return AgentSettings{
+		Kind:          kind,
+		Passthrough:   passthrough,
+		MCPConfigPath: mcpConfigPath,
+	}
+}
+
+// MergeAdapterExtensions copies the kind-named sub-object from
+// cfg's extensions into dst without overwriting an existing key. It
+// serves the tracker, CI-provider, and SCM adapter families; the
+// agent family goes through [AgentAdapterConfig] and
+// [ResolveAgentSettings] instead.
+func MergeAdapterExtensions(dst map[string]any, cfg ServiceConfig, kind string) {
+	mergeExtensionSection(dst, cfg.Extensions, kind)
+}
+
+// mergeExtensionSection copies the kind-named sub-object from
 // extensions into dst without overwriting an existing key.
-func mergeAgentExtensions(dst map[string]any, extensions map[string]any, kind string) {
+func mergeExtensionSection(dst map[string]any, extensions map[string]any, kind string) {
 	sub, ok := extensions[kind].(map[string]any)
 	if !ok {
 		return

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2851,6 +2851,260 @@ func TestAgentAdapterConfig_FreshMapPerCall(t *testing.T) {
 	}
 }
 
+// --- ResolveAgentSettings tests ---
+
+// TestResolveAgentSettings_MCPConfigPath covers every row of the
+// mcp_config resolution table: the kind's block may be absent or not
+// an object, the block may carry no mcp_config or a non-string one,
+// the value may be empty, absolute, or relative with the workflow
+// directory present or empty.
+func TestResolveAgentSettings_MCPConfigPath(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		cfg         ServiceConfig
+		kind        string
+		workflowDir string
+		wantPath    string
+	}{
+		{
+			name:        "kind has no block",
+			cfg:         ServiceConfig{Agent: AgentConfig{Kind: "claude-code"}},
+			kind:        "codex",
+			workflowDir: "/wf",
+			wantPath:    "",
+		},
+		{
+			name: "block is not an object",
+			cfg: ServiceConfig{Extensions: map[string]any{
+				"codex": "not-a-map",
+			}},
+			kind:        "codex",
+			workflowDir: "/wf",
+			wantPath:    "",
+		},
+		{
+			name: "block has no mcp_config key",
+			cfg: ServiceConfig{Extensions: map[string]any{
+				"codex": map[string]any{"approval_policy": "never"},
+			}},
+			kind:        "codex",
+			workflowDir: "/wf",
+			wantPath:    "",
+		},
+		{
+			name: "mcp_config is not a string",
+			cfg: ServiceConfig{Extensions: map[string]any{
+				"codex": map[string]any{"mcp_config": 42},
+			}},
+			kind:        "codex",
+			workflowDir: "/wf",
+			wantPath:    "",
+		},
+		{
+			name: "mcp_config is the empty string",
+			cfg: ServiceConfig{Extensions: map[string]any{
+				"codex": map[string]any{"mcp_config": ""},
+			}},
+			kind:        "codex",
+			workflowDir: "/wf",
+			wantPath:    "",
+		},
+		{
+			name: "mcp_config is an absolute path",
+			cfg: ServiceConfig{Extensions: map[string]any{
+				"codex": map[string]any{"mcp_config": filepath.FromSlash("/abs/op.json")},
+			}},
+			kind:        "codex",
+			workflowDir: "/wf",
+			wantPath:    filepath.FromSlash("/abs/op.json"),
+		},
+		{
+			name: "mcp_config is relative and workflowDir is non-empty",
+			cfg: ServiceConfig{Extensions: map[string]any{
+				"codex": map[string]any{"mcp_config": "op.json"},
+			}},
+			kind:        "codex",
+			workflowDir: "/wf",
+			wantPath:    filepath.Join("/wf", "op.json"),
+		},
+		{
+			name: "mcp_config is relative and workflowDir is empty",
+			cfg: ServiceConfig{Extensions: map[string]any{
+				"codex": map[string]any{"mcp_config": "op.json"},
+			}},
+			kind:        "codex",
+			workflowDir: "",
+			wantPath:    "op.json",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := ResolveAgentSettings(tt.cfg, tt.kind, tt.workflowDir)
+
+			if got.MCPConfigPath != tt.wantPath {
+				t.Errorf("ResolveAgentSettings(cfg, %q, %q).MCPConfigPath = %q, want %q", tt.kind, tt.workflowDir, got.MCPConfigPath, tt.wantPath)
+			}
+			if got.Kind != tt.kind {
+				t.Errorf("ResolveAgentSettings(cfg, %q, %q).Kind = %q, want %q", tt.kind, tt.workflowDir, got.Kind, tt.kind)
+			}
+		})
+	}
+}
+
+// TestResolveAgentSettings_PassthroughMatchesAgentAdapterConfig asserts
+// that AgentSettings.Passthrough carries exactly what AgentAdapterConfig
+// returns for the same kind, so the two producers can never disagree.
+func TestResolveAgentSettings_PassthroughMatchesAgentAdapterConfig(t *testing.T) {
+	t.Parallel()
+
+	cfg := ServiceConfig{
+		Agent: AgentConfig{Kind: "claude-code", Command: "claude"},
+		Extensions: map[string]any{
+			"codex": map[string]any{"approval_policy": "never"},
+		},
+	}
+
+	got := ResolveAgentSettings(cfg, "codex", "")
+	want := AgentAdapterConfig(cfg, "codex")
+
+	if len(got.Passthrough) != len(want) {
+		t.Fatalf("ResolveAgentSettings().Passthrough = %v (len %d), want %v (len %d)", got.Passthrough, len(got.Passthrough), want, len(want))
+	}
+	for k, wantVal := range want {
+		if gotVal, ok := got.Passthrough[k]; !ok || gotVal != wantVal {
+			t.Errorf("ResolveAgentSettings().Passthrough[%q] = %v, want %v", k, gotVal, wantVal)
+		}
+	}
+}
+
+// TestResolveAgentSettings_IndependentAllocationAcrossCalls asserts that
+// two calls return independently allocated Passthrough maps: mutating
+// one call's result must not affect another.
+func TestResolveAgentSettings_IndependentAllocationAcrossCalls(t *testing.T) {
+	t.Parallel()
+
+	cfg := ServiceConfig{Agent: AgentConfig{Kind: "codex", Command: "codex"}}
+
+	first := ResolveAgentSettings(cfg, "codex", "")
+	first.Passthrough["command"] = "mutated"
+
+	second := ResolveAgentSettings(cfg, "codex", "")
+	if second.Passthrough["command"] != "codex" {
+		t.Errorf(`ResolveAgentSettings() second call Passthrough["command"] = %v, want "codex" (unaffected by mutating the first call's map)`, second.Passthrough["command"])
+	}
+}
+
+// --- MergeAdapterExtensions tests ---
+//
+// These cases re-home the coverage cmd/sortie's now-deleted
+// TestMergeExtensions gave the duplicate mergeExtensions helper before
+// it was removed in favor of this primitive: nil maps, non-overwrite of
+// an existing key, and the claude-code extension merge.
+
+func TestMergeAdapterExtensions(t *testing.T) {
+	t.Parallel()
+
+	t.Run("copies extension keys", func(t *testing.T) {
+		t.Parallel()
+
+		dst := map[string]any{"kind": "file"}
+		cfg := ServiceConfig{Extensions: map[string]any{
+			"file": map[string]any{"path": "issues.json", "extra": 42},
+		}}
+
+		MergeAdapterExtensions(dst, cfg, "file")
+
+		if dst["path"] != "issues.json" {
+			t.Errorf("dst[%q] = %v, want %q", "path", dst["path"], "issues.json")
+		}
+		if dst["extra"] != 42 {
+			t.Errorf("dst[%q] = %v, want %d", "extra", dst["extra"], 42)
+		}
+	})
+
+	t.Run("does not overwrite existing keys", func(t *testing.T) {
+		t.Parallel()
+
+		dst := map[string]any{"kind": "file", "path": "original.json"}
+		cfg := ServiceConfig{Extensions: map[string]any{
+			"file": map[string]any{"path": "overridden.json"},
+		}}
+
+		MergeAdapterExtensions(dst, cfg, "file")
+
+		if dst["path"] != "original.json" {
+			t.Errorf("dst[%q] = %v, want %q (must not overwrite)", "path", dst["path"], "original.json")
+		}
+	})
+
+	t.Run("missing kind is no-op", func(t *testing.T) {
+		t.Parallel()
+
+		dst := map[string]any{"kind": "jira"}
+		cfg := ServiceConfig{Extensions: map[string]any{
+			"file": map[string]any{"path": "issues.json"},
+		}}
+
+		MergeAdapterExtensions(dst, cfg, "jira")
+
+		if _, ok := dst["path"]; ok {
+			t.Error("dst[\"path\"] present, want absent when kind has no extensions block")
+		}
+	})
+
+	t.Run("nil extensions is no-op", func(t *testing.T) {
+		t.Parallel()
+
+		dst := map[string]any{"kind": "file"}
+		cfg := ServiceConfig{}
+
+		MergeAdapterExtensions(dst, cfg, "file")
+
+		if len(dst) != 1 {
+			t.Errorf("len(dst) = %d, want 1 (nil Extensions must be a no-op)", len(dst))
+		}
+	})
+
+	t.Run("non-map extension value is no-op", func(t *testing.T) {
+		t.Parallel()
+
+		dst := map[string]any{"kind": "file"}
+		cfg := ServiceConfig{Extensions: map[string]any{
+			"file": "not a map",
+		}}
+
+		MergeAdapterExtensions(dst, cfg, "file")
+
+		if len(dst) != 1 {
+			t.Errorf("len(dst) = %d, want 1 (non-map extension value must be a no-op)", len(dst))
+		}
+	})
+
+	t.Run("adapter max_turns passthrough", func(t *testing.T) {
+		t.Parallel()
+
+		dst := map[string]any{"kind": "claude-code"}
+		cfg := ServiceConfig{Extensions: map[string]any{
+			"claude-code": map[string]any{"max_turns": float64(50)},
+		}}
+
+		MergeAdapterExtensions(dst, cfg, "claude-code")
+
+		got, ok := dst["max_turns"]
+		if !ok {
+			t.Fatal("dst[\"max_turns\"] not present after MergeAdapterExtensions")
+		}
+		if got != float64(50) {
+			t.Errorf("dst[%q] = %v, want 50 (adapter value, not orchestrator value)", "max_turns", got)
+		}
+	})
+}
+
 // --- buildWorkspaceConfig / workspace.retention_days tests ---
 
 func TestBuildWorkspaceConfig(t *testing.T) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2861,6 +2861,15 @@ func TestAgentAdapterConfig_FreshMapPerCall(t *testing.T) {
 func TestResolveAgentSettings_MCPConfigPath(t *testing.T) {
 	t.Parallel()
 
+	// filepath.FromSlash("/abs/op.json") yields a drive-relative path
+	// on Windows, which filepath.IsAbs correctly rejects. Resolve it to
+	// a genuinely absolute path so the case tests absoluteness rather
+	// than the host's path syntax.
+	absOperatorPath, err := filepath.Abs(filepath.FromSlash("/abs/op.json"))
+	if err != nil {
+		t.Fatalf("filepath.Abs: %v", err)
+	}
+
 	tests := []struct {
 		name        string
 		cfg         ServiceConfig
@@ -2914,11 +2923,11 @@ func TestResolveAgentSettings_MCPConfigPath(t *testing.T) {
 		{
 			name: "mcp_config is an absolute path",
 			cfg: ServiceConfig{Extensions: map[string]any{
-				"codex": map[string]any{"mcp_config": filepath.FromSlash("/abs/op.json")},
+				"codex": map[string]any{"mcp_config": absOperatorPath},
 			}},
 			kind:        "codex",
 			workflowDir: "/wf",
-			wantPath:    filepath.FromSlash("/abs/op.json"),
+			wantPath:    absOperatorPath,
 		},
 		{
 			name: "mcp_config is relative and workflowDir is non-empty",

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -3,6 +3,7 @@ package orchestrator
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -5615,6 +5616,24 @@ func TestDispatch_RuleResolvedKindPersistsToRunHistory(t *testing.T) {
 		},
 	}
 
+	// A non-empty WorkflowAbsPath is the only thing standing between this
+	// test and MCP config generation; the file it names need not exist.
+	// Both agent blocks name an operator MCP config carrying a marker
+	// server unique to that block, so the routed session's generated
+	// file can be told apart from a session that read the wrong block.
+	absWorkflowPath := filepath.Join(tmpDir, "WORKFLOW.md")
+
+	claudeMCPConfigPath := filepath.Join(tmpDir, "claude-mcp.json")
+	writeMarkerMCPConfig(t, claudeMCPConfigPath, "claude-marker")
+
+	codexMCPConfigPath := filepath.Join(tmpDir, "codex-mcp.json")
+	writeMarkerMCPConfig(t, codexMCPConfigPath, "codex-marker")
+
+	cfg.Extensions = map[string]any{
+		"claude-code": map[string]any{"mcp_config": claudeMCPConfigPath},
+		"codex":       map[string]any{"mcp_config": codexMCPConfigPath},
+	}
+
 	bugIssue := domain.Issue{
 		ID:         "id-bug",
 		Identifier: "DISP-1",
@@ -5632,8 +5651,23 @@ func TestDispatch_RuleResolvedKindPersistsToRunHistory(t *testing.T) {
 
 	tmpl := mustParseTemplate(t, "work on {{ .issue.identifier }}")
 
-	codexAdapter := &mockAgentAdapter{}
-	claudeAdapter := &mockAgentAdapter{}
+	// Captured per adapter: the two issues dispatch concurrently through
+	// one run loop, so a shared capture would race between them.
+	var codexGeneratedMCPConfigPath atomic.Value
+	var claudeGeneratedMCPConfigPath atomic.Value
+
+	codexAdapter := &mockAgentAdapter{
+		startSessionFn: func(_ context.Context, params domain.StartSessionParams) (domain.Session, error) {
+			codexGeneratedMCPConfigPath.Store(params.MCPConfigPath)
+			return domain.Session{ID: "sess-codex"}, nil
+		},
+	}
+	claudeAdapter := &mockAgentAdapter{
+		startSessionFn: func(_ context.Context, params domain.StartSessionParams) (domain.Session, error) {
+			claudeGeneratedMCPConfigPath.Store(params.MCPConfigPath)
+			return domain.Session{ID: "sess-claude"}, nil
+		},
+	}
 
 	tracker := &candidateTrackerAdapter{
 		mockTrackerAdapter: &mockTrackerAdapter{
@@ -5650,7 +5684,7 @@ func TestDispatch_RuleResolvedKindPersistsToRunHistory(t *testing.T) {
 		},
 	}
 
-	wm := &stubWorkflowManager{config: cfg, template: tmpl}
+	wm := &stubWorkflowManager{config: cfg, template: tmpl, absPath: absWorkflowPath}
 	store := &stubStore{}
 	regs := passingPreflightRegistries()
 
@@ -5747,6 +5781,61 @@ func TestDispatch_RuleResolvedKindPersistsToRunHistory(t *testing.T) {
 	if docsRow.RuleName != "" {
 		t.Errorf("RunHistory(%q).RuleName = %q, want %q", docsIssue.Identifier, docsRow.RuleName, "")
 	}
+
+	// The routed session's generated MCP config must carry the codex
+	// block's marker server and must not carry the claude-code block's,
+	// proving the routed kind selected its own operator block rather
+	// than the workflow default's.
+	gotPath, _ := codexGeneratedMCPConfigPath.Load().(string)
+	if gotPath == "" {
+		t.Fatal("codex adapter's StartSessionParams.MCPConfigPath is empty, want a generated file")
+	}
+	servers := readMCPServers(t, gotPath)
+	if _, ok := servers["codex-marker"]; !ok {
+		t.Errorf("mcpServers in %q missing %q, want present (routed kind's own block)", gotPath, "codex-marker")
+	}
+	if _, ok := servers["claude-marker"]; ok {
+		t.Errorf("mcpServers in %q contains %q, want absent (default kind's block must not leak into a routed session)", gotPath, "claude-marker")
+	}
+}
+
+// writeMarkerMCPConfig writes an operator MCP config file at path
+// declaring a single stdio server named marker, so a test can tell
+// apart the generated config produced from that block versus another.
+func writeMarkerMCPConfig(t *testing.T, path, marker string) {
+	t.Helper()
+
+	data, err := json.Marshal(map[string]any{
+		"mcpServers": map[string]any{
+			marker: map[string]any{"type": "stdio", "command": "/bin/" + marker},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Marshal operator MCP config: %v", err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("WriteFile(%q): %v", path, err)
+	}
+}
+
+// readMCPServers reads and parses the mcpServers object out of the
+// generated MCP config file at path.
+func readMCPServers(t *testing.T, path string) map[string]any {
+	t.Helper()
+
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile(%q): %v", path, err)
+	}
+	var parsed map[string]any
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		t.Fatalf("Unmarshal(%q): %v", path, err)
+	}
+	servers, ok := parsed["mcpServers"].(map[string]any)
+	if !ok {
+		t.Fatalf("%q: mcpServers is not an object: %v", path, parsed["mcpServers"])
+	}
+	return servers
 }
 
 // --- Blocker gate observability (handleTick) ---

--- a/internal/orchestrator/worker.go
+++ b/internal/orchestrator/worker.go
@@ -400,10 +400,12 @@ func isTurnSuccess(reason domain.AgentEventType) bool {
 }
 
 // toDomainAgentConfig converts a config-layer AgentConfig to the
-// domain-layer AgentConfig expected by agent adapters.
-func toDomainAgentConfig(c config.AgentConfig) domain.AgentConfig {
+// domain-layer AgentConfig expected by agent adapters. kind comes from
+// the caller rather than c.Kind because the session's dispatch-frozen
+// kind and the configuration's workflow default can differ.
+func toDomainAgentConfig(c config.AgentConfig, kind string) domain.AgentConfig {
 	return domain.AgentConfig{
-		Kind:           c.Kind,
+		Kind:           kind,
 		Command:        c.Command,
 		TurnTimeoutMS:  c.TurnTimeoutMS,
 		ReadTimeoutMS:  c.ReadTimeoutMS,
@@ -828,16 +830,7 @@ func RunWorkerAttempt(ctx context.Context, issue domain.Issue, attempt *int, dep
 			return
 		}
 
-		// Resolve operator MCP config path from extensions.
-		var operatorPath string
-		if extMap, ok := cfg.Extensions[cfg.Agent.Kind].(map[string]any); ok {
-			if v, ok := extMap["mcp_config"].(string); ok {
-				operatorPath = v
-			}
-		}
-		if operatorPath != "" && !filepath.IsAbs(operatorPath) {
-			operatorPath = filepath.Join(filepath.Dir(deps.WorkflowPath), operatorPath)
-		}
+		settings := config.ResolveAgentSettings(cfg, agentKind, filepath.Dir(deps.WorkflowPath))
 
 		generatedPath, genErr := GenerateMCPConfig(MCPConfigParams{
 			BinaryPath:            execPath,
@@ -849,7 +842,7 @@ func RunWorkerAttempt(ctx context.Context, issue domain.Issue, attempt *int, dep
 			SessionID:             "",
 			Attempt:               attempt,
 			AgentKind:             agentKind,
-			OperatorMCPConfigPath: operatorPath,
+			OperatorMCPConfigPath: settings.MCPConfigPath,
 			ProcessEnv:            CollectSortieEnv(),
 		})
 		if genErr != nil {
@@ -870,7 +863,10 @@ func RunWorkerAttempt(ctx context.Context, issue domain.Issue, attempt *int, dep
 		}
 
 		mcpConfigPath = generatedPath
-		logger.Info("mcp config written", slog.String("mcp_config_path", generatedPath))
+		logger.Info("mcp config written",
+			slog.String("mcp_config_path", generatedPath),
+			slog.String("agent_kind", agentKind),
+			slog.String("operator_mcp_config_path", settings.MCPConfigPath))
 	}
 
 	// Check context between workspace preparation and session start.
@@ -901,7 +897,7 @@ func RunWorkerAttempt(ctx context.Context, issue domain.Issue, attempt *int, dep
 
 	session, err = deps.AgentAdapter.StartSession(ctx, domain.StartSessionParams{
 		WorkspacePath:            wsResult.Path,
-		AgentConfig:              toDomainAgentConfig(cfg.Agent),
+		AgentConfig:              toDomainAgentConfig(cfg.Agent, agentKind),
 		ResumeSessionID:          deps.ResumeSessionID,
 		SSHHost:                  deps.SSHHost,
 		SSHStrictHostKeyChecking: deps.SSHStrictHostKeyChecking,

--- a/internal/orchestrator/worker_test.go
+++ b/internal/orchestrator/worker_test.go
@@ -53,6 +53,26 @@ func defaultWorkerConfig(workspaceRoot string) config.ServiceConfig {
 	}
 }
 
+// readWorkerTestMCPServers reads and parses the mcpServers object out of
+// the generated MCP config file at path.
+func readWorkerTestMCPServers(t *testing.T, path string) map[string]any {
+	t.Helper()
+
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile(%q): %v", path, err)
+	}
+	var parsed map[string]any
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		t.Fatalf("Unmarshal(%q): %v", path, err)
+	}
+	servers, ok := parsed["mcpServers"].(map[string]any)
+	if !ok {
+		t.Fatalf("%q: mcpServers is not an object: %v", path, parsed["mcpServers"])
+	}
+	return servers
+}
+
 // workerTestIssue returns a minimal valid issue for worker tests.
 func workerTestIssue() domain.Issue {
 	return domain.Issue{
@@ -392,23 +412,42 @@ func TestToDomainAgentConfig(t *testing.T) {
 		StallTimeoutMS: 60000,
 	}
 
-	got := toDomainAgentConfig(src)
+	t.Run("passed kind matches the configuration's default kind", func(t *testing.T) {
+		t.Parallel()
 
-	if got.Kind != src.Kind {
-		t.Errorf("Kind = %q, want %q", got.Kind, src.Kind)
-	}
-	if got.Command != src.Command {
-		t.Errorf("Command = %q, want %q", got.Command, src.Command)
-	}
-	if got.TurnTimeoutMS != src.TurnTimeoutMS {
-		t.Errorf("TurnTimeoutMS = %d, want %d", got.TurnTimeoutMS, src.TurnTimeoutMS)
-	}
-	if got.ReadTimeoutMS != src.ReadTimeoutMS {
-		t.Errorf("ReadTimeoutMS = %d, want %d", got.ReadTimeoutMS, src.ReadTimeoutMS)
-	}
-	if got.StallTimeoutMS != src.StallTimeoutMS {
-		t.Errorf("StallTimeoutMS = %d, want %d", got.StallTimeoutMS, src.StallTimeoutMS)
-	}
+		got := toDomainAgentConfig(src, src.Kind)
+
+		if got.Kind != src.Kind {
+			t.Errorf("Kind = %q, want %q", got.Kind, src.Kind)
+		}
+		if got.Command != src.Command {
+			t.Errorf("Command = %q, want %q", got.Command, src.Command)
+		}
+		if got.TurnTimeoutMS != src.TurnTimeoutMS {
+			t.Errorf("TurnTimeoutMS = %d, want %d", got.TurnTimeoutMS, src.TurnTimeoutMS)
+		}
+		if got.ReadTimeoutMS != src.ReadTimeoutMS {
+			t.Errorf("ReadTimeoutMS = %d, want %d", got.ReadTimeoutMS, src.ReadTimeoutMS)
+		}
+		if got.StallTimeoutMS != src.StallTimeoutMS {
+			t.Errorf("StallTimeoutMS = %d, want %d", got.StallTimeoutMS, src.StallTimeoutMS)
+		}
+	})
+
+	t.Run("passed kind differs from the configuration's default kind", func(t *testing.T) {
+		t.Parallel()
+
+		const routedKind = "codex"
+
+		got := toDomainAgentConfig(src, routedKind)
+
+		if got.Kind != routedKind {
+			t.Errorf("Kind = %q, want %q (the passed kind, not cfg.Agent.Kind %q)", got.Kind, routedKind, src.Kind)
+		}
+		if got.Command != src.Command {
+			t.Errorf("Command = %q, want %q", got.Command, src.Command)
+		}
+	})
 }
 
 // --- RunWorkerAttempt integration tests ---
@@ -2991,6 +3030,110 @@ func TestRunWorkerAttempt_MCPConfig(t *testing.T) {
 		}
 	})
 
+	// Regression: a session routed by a dispatch rule to a kind other
+	// than the workflow default must read that routed kind's own
+	// extension block, never the default kind's.
+	t.Run("routed_kind_selects_its_own_operator_block", func(t *testing.T) {
+		t.Parallel()
+
+		workflowDir := t.TempDir()
+		workspaceTmpDir := t.TempDir()
+		cfg := defaultWorkerConfig(workspaceTmpDir)
+		cfg.Agent.MaxTurns = 1
+		cfg.Agent.Kind = "claude-code"
+
+		defaultPath := filepath.Join(workflowDir, "default-mcp.json")
+		defaultData, _ := json.Marshal(map[string]any{
+			"mcpServers": map[string]any{
+				"default-marker": map[string]any{"type": "stdio", "command": "/bin/default"},
+			},
+		})
+		if err := os.WriteFile(defaultPath, defaultData, 0o600); err != nil {
+			t.Fatalf("WriteFile default operator config: %v", err)
+		}
+
+		routedPath := filepath.Join(workflowDir, "routed-mcp.json")
+		routedData, _ := json.Marshal(map[string]any{
+			"mcpServers": map[string]any{
+				"routed-marker": map[string]any{"type": "stdio", "command": "/bin/routed"},
+			},
+		})
+		if err := os.WriteFile(routedPath, routedData, 0o600); err != nil {
+			t.Fatalf("WriteFile routed operator config: %v", err)
+		}
+
+		cfg.Extensions = map[string]any{
+			"claude-code": map[string]any{"mcp_config": defaultPath},
+			"codex":       map[string]any{"mcp_config": routedPath},
+		}
+
+		var capturedMCPConfigPath atomic.Value
+		ec := newExitCapture()
+
+		deps := WorkerDeps{
+			TrackerAdapter: &mockTrackerAdapter{},
+			AgentAdapter: &mockAgentAdapter{
+				startSessionFn: func(_ context.Context, params domain.StartSessionParams) (domain.Session, error) {
+					capturedMCPConfigPath.Store(params.MCPConfigPath)
+					return domain.Session{ID: "sess-1"}, nil
+				},
+			},
+			ConfigFunc:             func() config.ServiceConfig { return cfg },
+			PromptTemplateByIDFunc: func(_ string) *prompt.Template { return mustParseTemplate(t, "{{ .issue.title }}") },
+			OnEvent:                func(_ string, _ domain.AgentEvent) {},
+			OnExit:                 ec.onExit,
+			Logger:                 discardLogger(),
+			// WorkflowPath is inside workflowDir; the file itself need not exist.
+			WorkflowPath: filepath.Join(workflowDir, "WORKFLOW.md"),
+			// AgentKind is the dispatch-frozen kind, distinct from the
+			// workflow default set on cfg.Agent.Kind above.
+			AgentKind: "codex",
+		}
+
+		RunWorkerAttempt(context.Background(), workerTestIssue(), nil, deps)
+		result := ec.waitResult(t)
+
+		if result.ExitKind != WorkerExitNormal {
+			t.Fatalf("ExitKind = %q, want %q", result.ExitKind, WorkerExitNormal)
+		}
+
+		mcpPath, _ := capturedMCPConfigPath.Load().(string)
+		if mcpPath == "" {
+			t.Fatal("MCPConfigPath is empty")
+		}
+
+		rawData, err := os.ReadFile(mcpPath)
+		if err != nil {
+			t.Fatalf("ReadFile(%q): %v", mcpPath, err)
+		}
+		var merged map[string]any
+		if err := json.Unmarshal(rawData, &merged); err != nil {
+			t.Fatalf("Unmarshal mcp.json: %v", err)
+		}
+		servers, ok := merged["mcpServers"].(map[string]any)
+		if !ok {
+			t.Fatalf("mcpServers is not an object: %v", merged["mcpServers"])
+		}
+		if _, ok := servers["routed-marker"]; !ok {
+			t.Error("routed-marker missing from mcpServers, want present (routed kind's own block)")
+		}
+		if _, ok := servers["default-marker"]; ok {
+			t.Error("default-marker present in mcpServers, want absent (default kind's block must not leak into a routed session)")
+		}
+
+		sortieTools, ok := servers["sortie-tools"].(map[string]any)
+		if !ok {
+			t.Fatalf("sortie-tools is not an object: %v", servers["sortie-tools"])
+		}
+		env, ok := sortieTools["env"].(map[string]any)
+		if !ok {
+			t.Fatalf("sortie-tools.env is not an object: %v", sortieTools["env"])
+		}
+		if got, want := env["SORTIE_SESSION_AGENT_KIND"], "codex"; got != want {
+			t.Errorf("SORTIE_SESSION_AGENT_KIND = %v, want %q", got, want)
+		}
+	})
+
 	// Path resolution: a relative mcp_config extension value must be
 	// resolved relative to the directory containing deps.WorkflowPath.
 	t.Run("relative_operator_path_resolved_from_workflow_dir", func(t *testing.T) {
@@ -3057,6 +3200,126 @@ func TestRunWorkerAttempt_MCPConfig(t *testing.T) {
 		servers, _ := merged["mcpServers"].(map[string]any)
 		if _, ok := servers["relative-tool"]; !ok {
 			t.Errorf("relative-tool missing from merged config: relative operator path was not resolved from workflow dir")
+		}
+	})
+
+	// Hot-reload seam: the kind freezes at dispatch, but the settings it
+	// selects MUST be re-resolved through deps.ConfigFunc() on every
+	// attempt, never cached across attempts. A ConfigFunc that returns a
+	// different mcp_config on its second call simulates a workflow
+	// reloaded between two attempts of the same claim.
+	t.Run("settings_reresolve_per_attempt_through_config_func", func(t *testing.T) {
+		t.Parallel()
+
+		workflowDir := t.TempDir()
+		workspaceTmpDir := t.TempDir()
+
+		firstOperatorPath := filepath.Join(workflowDir, "first-mcp.json")
+		firstData, _ := json.Marshal(map[string]any{
+			"mcpServers": map[string]any{
+				"first-attempt-marker": map[string]any{"type": "stdio", "command": "/bin/first"},
+			},
+		})
+		if err := os.WriteFile(firstOperatorPath, firstData, 0o600); err != nil {
+			t.Fatalf("WriteFile first operator config: %v", err)
+		}
+
+		secondOperatorPath := filepath.Join(workflowDir, "second-mcp.json")
+		secondData, _ := json.Marshal(map[string]any{
+			"mcpServers": map[string]any{
+				"second-attempt-marker": map[string]any{"type": "stdio", "command": "/bin/second"},
+			},
+		})
+		if err := os.WriteFile(secondOperatorPath, secondData, 0o600); err != nil {
+			t.Fatalf("WriteFile second operator config: %v", err)
+		}
+
+		var configCalls atomic.Int32
+		configFunc := func() config.ServiceConfig {
+			cfg := defaultWorkerConfig(workspaceTmpDir)
+			cfg.Agent.MaxTurns = 1
+			operatorPath := firstOperatorPath
+			if configCalls.Add(1) > 1 {
+				operatorPath = secondOperatorPath
+			}
+			cfg.Extensions = map[string]any{
+				"mock": map[string]any{"mcp_config": operatorPath},
+			}
+			return cfg
+		}
+
+		deps := WorkerDeps{
+			TrackerAdapter:         &mockTrackerAdapter{},
+			ConfigFunc:             configFunc,
+			PromptTemplateByIDFunc: func(_ string) *prompt.Template { return mustParseTemplate(t, "{{ .issue.title }}") },
+			OnEvent:                func(_ string, _ domain.AgentEvent) {},
+			Logger:                 discardLogger(),
+			WorkflowPath:           filepath.Join(workflowDir, "WORKFLOW.md"),
+		}
+
+		// First attempt: ConfigFunc's first call resolves to firstOperatorPath.
+		var firstCapturedPath atomic.Value
+		firstEC := newExitCapture()
+		deps.AgentAdapter = &mockAgentAdapter{
+			startSessionFn: func(_ context.Context, params domain.StartSessionParams) (domain.Session, error) {
+				firstCapturedPath.Store(params.MCPConfigPath)
+				return domain.Session{ID: "sess-1"}, nil
+			},
+		}
+		deps.OnExit = firstEC.onExit
+
+		RunWorkerAttempt(context.Background(), workerTestIssue(), nil, deps)
+		firstResult := firstEC.waitResult(t)
+		if firstResult.ExitKind != WorkerExitNormal {
+			t.Fatalf("first attempt ExitKind = %q, want %q", firstResult.ExitKind, WorkerExitNormal)
+		}
+
+		firstPath, _ := firstCapturedPath.Load().(string)
+		if firstPath == "" {
+			t.Fatal("first attempt: MCPConfigPath is empty")
+		}
+		firstServers := readWorkerTestMCPServers(t, firstPath)
+		if _, ok := firstServers["first-attempt-marker"]; !ok {
+			t.Error("first attempt: first-attempt-marker missing, want present (ConfigFunc's first-call value)")
+		}
+		if _, ok := firstServers["second-attempt-marker"]; ok {
+			t.Error("first attempt: second-attempt-marker present, want absent")
+		}
+
+		// Second attempt: same WorkerDeps, same ConfigFunc closure, one
+		// call further. Simulates a second attempt of the same claim
+		// after the workflow reloaded.
+		attempt := 2
+		var secondCapturedPath atomic.Value
+		secondEC := newExitCapture()
+		deps.AgentAdapter = &mockAgentAdapter{
+			startSessionFn: func(_ context.Context, params domain.StartSessionParams) (domain.Session, error) {
+				secondCapturedPath.Store(params.MCPConfigPath)
+				return domain.Session{ID: "sess-2"}, nil
+			},
+		}
+		deps.OnExit = secondEC.onExit
+
+		RunWorkerAttempt(context.Background(), workerTestIssue(), &attempt, deps)
+		secondResult := secondEC.waitResult(t)
+		if secondResult.ExitKind != WorkerExitNormal {
+			t.Fatalf("second attempt ExitKind = %q, want %q", secondResult.ExitKind, WorkerExitNormal)
+		}
+
+		secondPath, _ := secondCapturedPath.Load().(string)
+		if secondPath == "" {
+			t.Fatal("second attempt: MCPConfigPath is empty")
+		}
+		secondServers := readWorkerTestMCPServers(t, secondPath)
+		if _, ok := secondServers["second-attempt-marker"]; !ok {
+			t.Error("second attempt: second-attempt-marker missing, want present (ConfigFunc's second-call value, proving settings re-resolve per attempt)")
+		}
+		if _, ok := secondServers["first-attempt-marker"]; ok {
+			t.Error("second attempt: first-attempt-marker present, want absent (stale value from the first attempt must not survive)")
+		}
+
+		if got := configCalls.Load(); got < 2 {
+			t.Errorf("ConfigFunc call count = %d, want at least 2", got)
 		}
 	})
 

--- a/internal/orchestrator/worker_test.go
+++ b/internal/orchestrator/worker_test.go
@@ -3049,7 +3049,7 @@ func TestRunWorkerAttempt_MCPConfig(t *testing.T) {
 			},
 		})
 		if err != nil {
-			t.Fatalf("Marshal defaultData: %v", err)
+			t.Fatalf("Marshal default operator config: %v", err)
 		}
 		if err := os.WriteFile(defaultPath, defaultData, 0o600); err != nil {
 			t.Fatalf("WriteFile default operator config: %v", err)
@@ -3062,7 +3062,7 @@ func TestRunWorkerAttempt_MCPConfig(t *testing.T) {
 			},
 		})
 		if err != nil {
-			t.Fatalf("Marshal routedData: %v", err)
+			t.Fatalf("Marshal routed operator config: %v", err)
 		}
 		if err := os.WriteFile(routedPath, routedData, 0o600); err != nil {
 			t.Fatalf("WriteFile routed operator config: %v", err)
@@ -3227,7 +3227,7 @@ func TestRunWorkerAttempt_MCPConfig(t *testing.T) {
 			},
 		})
 		if err != nil {
-			t.Fatalf("Marshal firstData: %v", err)
+			t.Fatalf("Marshal first operator config: %v", err)
 		}
 		if err := os.WriteFile(firstOperatorPath, firstData, 0o600); err != nil {
 			t.Fatalf("WriteFile first operator config: %v", err)
@@ -3240,7 +3240,7 @@ func TestRunWorkerAttempt_MCPConfig(t *testing.T) {
 			},
 		})
 		if err != nil {
-			t.Fatalf("Marshal secondData: %v", err)
+			t.Fatalf("Marshal second operator config: %v", err)
 		}
 		if err := os.WriteFile(secondOperatorPath, secondData, 0o600); err != nil {
 			t.Fatalf("WriteFile second operator config: %v", err)

--- a/internal/orchestrator/worker_test.go
+++ b/internal/orchestrator/worker_test.go
@@ -3043,21 +3043,27 @@ func TestRunWorkerAttempt_MCPConfig(t *testing.T) {
 		cfg.Agent.Kind = "claude-code"
 
 		defaultPath := filepath.Join(workflowDir, "default-mcp.json")
-		defaultData, _ := json.Marshal(map[string]any{
+		defaultData, err := json.Marshal(map[string]any{
 			"mcpServers": map[string]any{
 				"default-marker": map[string]any{"type": "stdio", "command": "/bin/default"},
 			},
 		})
+		if err != nil {
+			t.Fatalf("Marshal defaultData: %v", err)
+		}
 		if err := os.WriteFile(defaultPath, defaultData, 0o600); err != nil {
 			t.Fatalf("WriteFile default operator config: %v", err)
 		}
 
 		routedPath := filepath.Join(workflowDir, "routed-mcp.json")
-		routedData, _ := json.Marshal(map[string]any{
+		routedData, err := json.Marshal(map[string]any{
 			"mcpServers": map[string]any{
 				"routed-marker": map[string]any{"type": "stdio", "command": "/bin/routed"},
 			},
 		})
+		if err != nil {
+			t.Fatalf("Marshal routedData: %v", err)
+		}
 		if err := os.WriteFile(routedPath, routedData, 0o600); err != nil {
 			t.Fatalf("WriteFile routed operator config: %v", err)
 		}
@@ -3215,21 +3221,27 @@ func TestRunWorkerAttempt_MCPConfig(t *testing.T) {
 		workspaceTmpDir := t.TempDir()
 
 		firstOperatorPath := filepath.Join(workflowDir, "first-mcp.json")
-		firstData, _ := json.Marshal(map[string]any{
+		firstData, err := json.Marshal(map[string]any{
 			"mcpServers": map[string]any{
 				"first-attempt-marker": map[string]any{"type": "stdio", "command": "/bin/first"},
 			},
 		})
+		if err != nil {
+			t.Fatalf("Marshal firstData: %v", err)
+		}
 		if err := os.WriteFile(firstOperatorPath, firstData, 0o600); err != nil {
 			t.Fatalf("WriteFile first operator config: %v", err)
 		}
 
 		secondOperatorPath := filepath.Join(workflowDir, "second-mcp.json")
-		secondData, _ := json.Marshal(map[string]any{
+		secondData, err := json.Marshal(map[string]any{
 			"mcpServers": map[string]any{
 				"second-attempt-marker": map[string]any{"type": "stdio", "command": "/bin/second"},
 			},
 		})
+		if err != nil {
+			t.Fatalf("Marshal secondData: %v", err)
+		}
 		if err := os.WriteFile(secondOperatorPath, secondData, 0o600); err != nil {
 			t.Fatalf("WriteFile second operator config: %v", err)
 		}


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Fix

**Intent:** A session routed by a dispatch rule to a non-default agent kind was resolving its MCP config path (and, dormant, its domain-layer agent config) under the workflow's default agent block instead of its own routed kind, so it could run with another agent's MCP servers and credentials or silently lose its own.

**Related Issues:** Closes #924

### 🧭 Reviewer Guide

**Complexity:** Medium

#### Entry Point

`internal/orchestrator/worker.go` - `RunWorkerAttempt`. The operator MCP config path lookup previously indexed `cfg.Extensions` by `cfg.Agent.Kind` (the workflow default) instead of the session's dispatch-frozen `agentKind`, a few lines above a call that already used `agentKind` correctly. It now calls the new `config.ResolveAgentSettings(cfg, agentKind, ...)`, and `toDomainAgentConfig` takes the session's kind as an explicit parameter instead of reading `c.Kind`.

#### Sensitive Areas

- `internal/config/config.go`: adds `AgentSettings` and `ResolveAgentSettings`, and consolidates the two duplicate copies of the extension-merge helper (`mergeExtensions` in `cmd/sortie`, `mergeAgentExtensions` in `internal/config`) into one exported `MergeAdapterExtensions` used by the tracker, CI-provider, and SCM adapter families.
- `internal/orchestrator/worker.go`: resolves the MCP config path and the domain-layer `AgentConfig.Kind` from the session's routed kind rather than the workflow default.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes.
- **Migrations/State:** No migrations or state changes.

