### PR TITLE
fix(config): unexport the extensions map behind a closed accessor set

### DIFF
--- a/cmd/sortie/boot.go
+++ b/cmd/sortie/boot.go
@@ -181,7 +181,7 @@ func boot(ctx context.Context, p bootParams) (bootResult, int) {
 
 	var needResetup bool
 	if !logLevelSet {
-		lvl, err := resolveLogLevel("", false, cfg.Extensions)
+		lvl, err := resolveLogLevel("", false, cfg.ExtensionSection("logging"))
 		if err != nil {
 			fmt.Fprintf(p.stderr, "sortie: %s\n", err) //nolint:errcheck // stderr write failure is unrecoverable
 			return bootResult{}, 1
@@ -192,7 +192,7 @@ func boot(ctx context.Context, p bootParams) (bootResult, int) {
 		}
 	}
 	if !logFormatSet {
-		resolvedFmt, err := resolveLogFormat("", false, cfg.Extensions)
+		resolvedFmt, err := resolveLogFormat("", false, cfg.ExtensionSection("logging"))
 		if err != nil {
 			fmt.Fprintf(p.stderr, "sortie: %s\n", err) //nolint:errcheck // stderr write failure is unrecoverable
 			return bootResult{}, 1
@@ -207,12 +207,12 @@ func boot(ctx context.Context, p bootParams) (bootResult, int) {
 		mgr.SetLogger(logger)
 	}
 
-	serverPort, serverEnabled, portErr := resolveServerPort(*port, portFlagSet, cfg.Extensions)
+	serverPort, serverEnabled, portErr := resolveServerPort(*port, portFlagSet, cfg.ExtensionSection("server"))
 	if portErr != nil {
 		logger.Error("server port configuration error", slog.Any("error", portErr))
 		return bootResult{}, 1
 	}
-	serverHost, hostErr := resolveServerHost(*host, hostFlagSet, cfg.Extensions)
+	serverHost, hostErr := resolveServerHost(*host, hostFlagSet, cfg.ExtensionSection("server"))
 	if hostErr != nil {
 		logger.Error("server host configuration error", slog.Any("error", hostErr))
 		return bootResult{}, 1
@@ -258,7 +258,7 @@ func boot(ctx context.Context, p bootParams) (bootResult, int) {
 		serverPort:      serverPort,
 		serverHost:      serverHost,
 		serverEnabled:   serverEnabled,
-		portIsImplicit:  !portFlagSet && !hasServerPortExtension(cfg.Extensions),
+		portIsImplicit:  !portFlagSet && !hasServerPortExtension(cfg.ExtensionSection("server")),
 		dryRun:          *dryRun,
 		effectiveLevel:  effectiveLevel,
 		effectiveFormat: effectiveFormat,

--- a/cmd/sortie/dryrun.go
+++ b/cmd/sortie/dryrun.go
@@ -37,7 +37,7 @@ func runDryRun(ctx context.Context, cfg config.ServiceConfig, logger *slog.Logge
 		orchestrator.AgentTotals{},
 	)
 
-	wc := orchestrator.ParseWorkerConfig(cfg.Extensions)
+	wc := orchestrator.ParseWorkerConfig(cfg.ExtensionSection("worker"))
 	for _, w := range wc.Warnings {
 		logger.LogAttrs(ctx, slog.LevelWarn, w.Message, w.Attrs...) //nolint:sloglint // WorkerWarning.Message is one of two fixed string constants from parseSSHStrictHostKeyChecking
 	}

--- a/cmd/sortie/main.go
+++ b/cmd/sortie/main.go
@@ -771,7 +771,8 @@ func run(ctx context.Context, args []string, stdout io.Writer, stderr io.Writer)
 
 	var srv *server.Server
 	if serverEnabled {
-		tokenRates, trWarnings := server.ParseTokenRates(br.cfg.Extensions)
+		rawTokenRates, tokenRatesPresent := br.cfg.ExtensionValue("token_rates")
+		tokenRates, trWarnings := server.ParseTokenRates(rawTokenRates, tokenRatesPresent)
 		for _, w := range trWarnings {
 			br.logger.Warn("skipped invalid token rate entry", slog.String("detail", w))
 		}

--- a/cmd/sortie/resolve.go
+++ b/cmd/sortie/resolve.go
@@ -77,11 +77,12 @@ func resolveDBPath(cfgPath, workflowDir string) string {
 }
 
 // resolveServerPort determines the effective HTTP server port from the
-// CLI flag and workflow extensions. Returns the port, whether the
-// server should be started, and an error if an explicitly configured
-// port is invalid. When no port is configured, the default port is
-// returned with the server enabled. Port 0 disables the server.
-func resolveServerPort(portFlag int, portFlagSet bool, extensions map[string]any) (int, bool, error) {
+// CLI flag and the server extension section. Returns the port,
+// whether the server should be started, and an error if an explicitly
+// configured port is invalid. When no port is configured, the default
+// port is returned with the server enabled. Port 0 disables the
+// server.
+func resolveServerPort(portFlag int, portFlagSet bool, serverSection map[string]any) (int, bool, error) {
 	if portFlagSet {
 		if portFlag < 0 || portFlag > 65535 {
 			return 0, false, fmt.Errorf("invalid --port value %d: must be between 0 and 65535", portFlag)
@@ -89,12 +90,11 @@ func resolveServerPort(portFlag int, portFlagSet bool, extensions map[string]any
 		return portFlag, portFlag != 0, nil
 	}
 
-	serverExt, ok := extensions["server"].(map[string]any)
-	if !ok {
+	if serverSection == nil {
 		return defaultServerPort, true, nil
 	}
 
-	portVal, exists := serverExt["port"]
+	portVal, exists := serverSection["port"]
 	if !exists {
 		return defaultServerPort, true, nil
 	}
@@ -119,10 +119,10 @@ func resolveServerPort(portFlag int, portFlagSet bool, extensions map[string]any
 }
 
 // resolveServerHost determines the effective HTTP server bind address
-// from the CLI flag and workflow extensions. Returns an error if the
-// resolved value is not a parseable IP address. When no host is
-// configured, the loopback address is returned.
-func resolveServerHost(hostFlag string, hostFlagSet bool, extensions map[string]any) (string, error) {
+// from the CLI flag and the server extension section. Returns an
+// error if the resolved value is not a parseable IP address. When no
+// host is configured, the loopback address is returned.
+func resolveServerHost(hostFlag string, hostFlagSet bool, serverSection map[string]any) (string, error) {
 	if hostFlagSet {
 		if net.ParseIP(hostFlag) == nil {
 			return "", fmt.Errorf("invalid --host value %q: not a valid IP address", hostFlag)
@@ -130,12 +130,11 @@ func resolveServerHost(hostFlag string, hostFlagSet bool, extensions map[string]
 		return hostFlag, nil
 	}
 
-	serverExt, ok := extensions["server"].(map[string]any)
-	if !ok {
+	if serverSection == nil {
 		return defaultServerHost, nil
 	}
 
-	hostVal, exists := serverExt["host"]
+	hostVal, exists := serverSection["host"]
 	if !exists {
 		return defaultServerHost, nil
 	}
@@ -151,32 +150,30 @@ func resolveServerHost(hostFlag string, hostFlagSet bool, extensions map[string]
 	return hostStr, nil
 }
 
-// hasServerPortExtension reports whether the extensions map contains a
-// server object with a port key. The check is presence-based: even
-// server.port matching the default counts as explicit configuration.
-func hasServerPortExtension(extensions map[string]any) bool {
-	serverExt, ok := extensions["server"].(map[string]any)
-	if !ok {
+// hasServerPortExtension reports whether the server extension section
+// contains a port key. The check is presence-based: even server.port
+// matching the default counts as explicit configuration.
+func hasServerPortExtension(serverSection map[string]any) bool {
+	if serverSection == nil {
 		return false
 	}
-	_, exists := serverExt["port"]
+	_, exists := serverSection["port"]
 	return exists
 }
 
 // resolveLogLevel determines the effective log level from the CLI flag
-// and workflow extensions. Precedence: CLI flag > logging.level
-// extension > default (info).
-func resolveLogLevel(flagValue string, flagSet bool, extensions map[string]any) (slog.Level, error) {
+// and the logging extension section. Precedence: CLI flag >
+// logging.level extension > default (info).
+func resolveLogLevel(flagValue string, flagSet bool, loggingSection map[string]any) (slog.Level, error) {
 	if flagSet {
 		return logging.ParseLevel(flagValue)
 	}
 
-	loggingExt, ok := extensions["logging"].(map[string]any)
-	if !ok {
+	if loggingSection == nil {
 		return slog.LevelInfo, nil
 	}
 
-	rawLevel, ok := loggingExt["level"]
+	rawLevel, ok := loggingSection["level"]
 	if !ok || rawLevel == nil {
 		return slog.LevelInfo, nil
 	}
@@ -189,25 +186,21 @@ func resolveLogLevel(flagValue string, flagSet bool, extensions map[string]any) 
 	return logging.ParseLevel(levelStr)
 }
 
-// resolveLogFormat determines the effective log output format from the CLI
-// flag and workflow extensions. Precedence: CLI flag > logging.format
-// extension > default (text). All map and type accesses use the comma-ok
-// idiom to avoid panics on unexpected extension shapes.
-func resolveLogFormat(flagValue string, flagSet bool, extensions map[string]any) (logging.Format, error) {
+// resolveLogFormat determines the effective log output format from the
+// CLI flag and the logging extension section. Precedence: CLI flag >
+// logging.format extension > default (text). All map and type
+// accesses use the comma-ok idiom to avoid panics on unexpected
+// extension shapes.
+func resolveLogFormat(flagValue string, flagSet bool, loggingSection map[string]any) (logging.Format, error) {
 	if flagSet {
 		return logging.ParseFormat(flagValue)
 	}
 
-	loggingRaw, ok := extensions["logging"]
-	if !ok {
-		return logging.FormatText, nil
-	}
-	loggingExt, ok := loggingRaw.(map[string]any)
-	if !ok {
+	if loggingSection == nil {
 		return logging.FormatText, nil
 	}
 
-	formatRaw, ok := loggingExt["format"]
+	formatRaw, ok := loggingSection["format"]
 	if !ok {
 		return logging.FormatText, nil
 	}

--- a/cmd/sortie/resolve_test.go
+++ b/cmd/sortie/resolve_test.go
@@ -448,7 +448,8 @@ func TestMergeTrackerCredentialsExtensionsWin(t *testing.T) {
 
 	// Extensions key wins over tracker key.
 	dst := map[string]any{}
-	cfg := config.ServiceConfig{Extensions: map[string]any{"github": map[string]any{"api_key": "ext-tok"}}}
+	var cfg config.ServiceConfig
+	cfg.SetExtensionSection("github", map[string]any{"api_key": "ext-tok"})
 	config.MergeAdapterExtensions(dst, cfg, "github")
 	mergeTrackerCredentials(dst, config.TrackerConfig{APIKey: "tracker-tok", Project: "PROJ"})
 
@@ -511,8 +512,14 @@ func TestKindMatchGuardWiring(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
+			var cfg config.ServiceConfig
+			for name, section := range tt.extensions {
+				sectionMap, _ := section.(map[string]any)
+				cfg.SetExtensionSection(name, sectionMap)
+			}
+
 			adapterCfgMap := make(map[string]any)
-			config.MergeAdapterExtensions(adapterCfgMap, config.ServiceConfig{Extensions: tt.extensions}, tt.ciKind)
+			config.MergeAdapterExtensions(adapterCfgMap, cfg, tt.ciKind)
 			if tt.ciKind == tt.trackerKind {
 				mergeTrackerCredentials(adapterCfgMap, tt.tc)
 			}
@@ -773,7 +780,8 @@ func TestResolveServerPort(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			gotPort, gotEnabled, gotErr := resolveServerPort(tt.portFlag, tt.portFlagSet, tt.extensions)
+			serverSection, _ := tt.extensions["server"].(map[string]any)
+			gotPort, gotEnabled, gotErr := resolveServerPort(tt.portFlag, tt.portFlagSet, serverSection)
 			if gotPort != tt.wantPort {
 				t.Errorf("resolveServerPort() port = %d, want %d", gotPort, tt.wantPort)
 			}
@@ -782,6 +790,60 @@ func TestResolveServerPort(t *testing.T) {
 			}
 			if (gotErr != nil) != tt.wantErr {
 				t.Errorf("resolveServerPort() err = %v, wantErr %v", gotErr, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestHasServerPortExtension(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		extensions map[string]any
+		want       bool
+	}{
+		{
+			name:       "nil extensions",
+			extensions: nil,
+			want:       false,
+		},
+		{
+			name:       "no server key",
+			extensions: map[string]any{"other": "value"},
+			want:       false,
+		},
+		{
+			name:       "server extension is not a map",
+			extensions: map[string]any{"server": "not-a-map"},
+			want:       false,
+		},
+		{
+			name:       "server map without port key",
+			extensions: map[string]any{"server": map[string]any{"host": "0.0.0.0"}},
+			want:       false,
+		},
+		{
+			name:       "server map with port key matching the default value still counts as explicit",
+			extensions: map[string]any{"server": map[string]any{"port": defaultServerPort}},
+			want:       true,
+		},
+		{
+			name:       "server map with port key present",
+			extensions: map[string]any{"server": map[string]any{"port": 9090}},
+			want:       true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			serverSection, _ := tt.extensions["server"].(map[string]any)
+			got := hasServerPortExtension(serverSection)
+
+			if got != tt.want {
+				t.Errorf("hasServerPortExtension(%v) = %v, want %v", serverSection, got, tt.want)
 			}
 		})
 	}
@@ -885,7 +947,8 @@ func TestResolveServerHost(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			gotHost, gotErr := resolveServerHost(tt.hostFlag, tt.hostFlagSet, tt.extensions)
+			serverSection, _ := tt.extensions["server"].(map[string]any)
+			gotHost, gotErr := resolveServerHost(tt.hostFlag, tt.hostFlagSet, serverSection)
 			if gotHost != tt.wantHost {
 				t.Errorf("resolveServerHost() host = %q, want %q", gotHost, tt.wantHost)
 			}
@@ -995,7 +1058,8 @@ func TestResolveLogLevel(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			got, err := resolveLogLevel(tt.flagValue, tt.flagSet, tt.extensions)
+			loggingSection, _ := tt.extensions["logging"].(map[string]any)
+			got, err := resolveLogLevel(tt.flagValue, tt.flagSet, loggingSection)
 			if tt.wantErr {
 				if err == nil {
 					t.Fatalf("resolveLogLevel(%q, %v, ...) = %v, want error", tt.flagValue, tt.flagSet, got)
@@ -1109,7 +1173,8 @@ func TestResolveLogFormat(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			got, err := resolveLogFormat(tt.flagValue, tt.flagSet, tt.extensions)
+			loggingSection, _ := tt.extensions["logging"].(map[string]any)
+			got, err := resolveLogFormat(tt.flagValue, tt.flagSet, loggingSection)
 			if tt.wantErr {
 				if err == nil {
 					t.Fatalf("resolveLogFormat(%q, %v, ...) = %v, want error", tt.flagValue, tt.flagSet, got)

--- a/cmd/sortie/stats.go
+++ b/cmd/sortie/stats.go
@@ -969,7 +969,8 @@ func runStats(ctx context.Context, args []string, stdout io.Writer, stderr io.Wr
 		return 1
 	}
 
-	rates, rateWarnings := server.ParseTokenRates(cfg.Extensions)
+	rawTokenRates, tokenRatesPresent := cfg.ExtensionValue("token_rates")
+	rates, rateWarnings := server.ParseTokenRates(rawTokenRates, tokenRatesPresent)
 
 	agg := newStatsAggregator(caps, rates)
 	if err := store.ScanRunHistoryRange(ctx, caps, since, until, agg.add); err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -57,10 +57,14 @@ type ServiceConfig struct {
 	// already-open database connection.
 	DBPath string
 
-	// Extensions holds top-level front matter keys not covered by the
-	// core schema (e.g. "server", "worker"). Consumers access these
-	// via map lookup. Never nil after construction.
-	Extensions map[string]any
+	// extensions holds top-level front matter keys not covered by the
+	// core schema (e.g. "server", "worker"). Never nil after
+	// construction. Unexported: every access goes through
+	// [ServiceConfig.ExtensionSection], [ServiceConfig.ExtensionValue],
+	// or [ServiceConfig.SetExtensionSection], and a kind-scoped read
+	// goes through [AgentAdapterConfig], [ResolveAgentSettings], or
+	// [MergeAdapterExtensions] instead.
+	extensions map[string]any
 
 	// extensionsPreResolution maps a dotted-and-indexed extension field
 	// path (for example "github.api_key" or "worker.ssh_hosts[0]") to
@@ -88,6 +92,40 @@ type ServiceConfig struct {
 // runs.
 func (c *ServiceConfig) SetDispatch(d DispatchConfig) {
 	c.Dispatch = d
+}
+
+// ExtensionSection returns the top-level extension section named
+// name, or nil when the section is absent or is not a
+// map[string]any. name is a section name known at compile time, never
+// a kind; a kind-scoped read goes through [AgentAdapterConfig],
+// [ResolveAgentSettings], or [MergeAdapterExtensions] instead. The
+// returned map is the one stored inside c, not a copy; callers MUST
+// treat it as read-only.
+func (c ServiceConfig) ExtensionSection(name string) map[string]any {
+	section, _ := c.extensions[name].(map[string]any)
+	return section
+}
+
+// ExtensionValue returns the raw value stored under the top-level
+// extension key name and whether that key is present, with no type
+// assertion applied. name is a section name known at compile time,
+// never a kind. Use ExtensionValue instead of ExtensionSection when a
+// caller's behavior depends on telling an absent key apart from a key
+// present with an unexpected type.
+func (c ServiceConfig) ExtensionValue(name string) (any, bool) {
+	v, ok := c.extensions[name]
+	return v, ok
+}
+
+// SetExtensionSection replaces the top-level extension section named
+// name with section. It exists for callers that build a ServiceConfig
+// directly instead of through [NewServiceConfig], matching the
+// [ServiceConfig.SetDispatch] precedent above.
+func (c *ServiceConfig) SetExtensionSection(name string, section map[string]any) {
+	if c.extensions == nil {
+		c.extensions = make(map[string]any)
+	}
+	c.extensions[name] = section
 }
 
 // TrackerConfig holds issue tracker connection and query settings.
@@ -196,7 +234,7 @@ type AgentConfig struct {
 // this map reaches a constructor, and including them would shadow an
 // adapter extension key of the same name during the merge below.
 //
-// The kind-named sub-object under cfg.Extensions, if present, is
+// The kind-named sub-object under cfg.extensions, if present, is
 // merged in without overwriting any of the five keys above. The
 // returned map is freshly allocated on every call.
 func AgentAdapterConfig(cfg ServiceConfig, kind string) map[string]any {
@@ -207,7 +245,7 @@ func AgentAdapterConfig(cfg ServiceConfig, kind string) map[string]any {
 		"read_timeout_ms":  cfg.Agent.ReadTimeoutMS,
 		"stall_timeout_ms": cfg.Agent.StallTimeoutMS,
 	}
-	mergeExtensionSection(m, cfg.Extensions, kind)
+	mergeExtensionSection(m, cfg.extensions, kind)
 	return m
 }
 
@@ -265,7 +303,7 @@ func ResolveAgentSettings(cfg ServiceConfig, kind string, workflowDir string) Ag
 // agent family goes through [AgentAdapterConfig] and
 // [ResolveAgentSettings] instead.
 func MergeAdapterExtensions(dst map[string]any, cfg ServiceConfig, kind string) {
-	mergeExtensionSection(dst, cfg.Extensions, kind)
+	mergeExtensionSection(dst, cfg.extensions, kind)
 }
 
 // mergeExtensionSection copies the kind-named sub-object from
@@ -283,7 +321,7 @@ func mergeExtensionSection(dst map[string]any, extensions map[string]any, kind s
 }
 
 // knownTopLevelKeys enumerates the front matter keys consumed by the
-// core schema. Anything else is collected into Extensions.
+// core schema. Anything else is collected into extensions.
 var knownTopLevelKeys = map[string]bool{
 	"tracker":       true,
 	"polling":       true,
@@ -479,7 +517,7 @@ func NewServiceConfig(raw map[string]any) (ServiceConfig, error) {
 		Reactions:               reactions,
 		LabelCommands:           labelCommands,
 		DBPath:                  dbPath,
-		Extensions:              extensions,
+		extensions:              extensions,
 		extensionsPreResolution: preResolution,
 		Notifications:           notifications,
 	}, nil
@@ -1085,7 +1123,7 @@ func ValidateInProgressState(inProgressState string, activeStates, terminalState
 	return nil
 }
 
-// resolveExtensionEnvRefs walks the Extensions subtree and resolves
+// resolveExtensionEnvRefs walks the extensions subtree and resolves
 // $VAR references on every string leaf using [os.ExpandEnv]. Nested
 // map[string]any and []any values are traversed; non-string leaves are
 // returned unchanged. The function mutates the input map in place.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -36,7 +36,7 @@ func TestNewServiceConfig(t *testing.T) {
 			t.Errorf("Agent.MaxConcurrentByState has %d entries, want 0", len(cfg.Agent.MaxConcurrentByState))
 		}
 		if cfg.extensions == nil {
-			t.Error("Extensions is nil, want empty map")
+			t.Error("extensions is nil, want empty map")
 		}
 	})
 
@@ -348,7 +348,7 @@ func TestNewServiceConfig(t *testing.T) {
 		assertIntEqual(t, "Hooks.TimeoutMS", 60000, cfg.Hooks.TimeoutMS)
 	})
 
-	t.Run("Extensions/Collected", func(t *testing.T) {
+	t.Run("extensions/Collected", func(t *testing.T) {
 		t.Parallel()
 		raw := map[string]any{
 			"server": map[string]any{"port": 8080},
@@ -360,17 +360,17 @@ func TestNewServiceConfig(t *testing.T) {
 		}
 		serverExt, ok := cfg.extensions["server"]
 		if !ok {
-			t.Fatal("Extensions missing 'server'")
+			t.Fatal("extensions missing 'server'")
 		}
 		serverMap, ok := serverExt.(map[string]any)
 		if !ok {
-			t.Fatalf("Extensions['server'] is %T, want map[string]any", serverExt)
+			t.Fatalf("extensions['server'] is %T, want map[string]any", serverExt)
 		}
 		if serverMap["port"] != 8080 {
 			t.Errorf("server.port = %v, want 8080", serverMap["port"])
 		}
 		if _, ok := cfg.extensions["worker"]; !ok {
-			t.Error("Extensions missing 'worker'")
+			t.Error("extensions missing 'worker'")
 		}
 	})
 
@@ -3168,4 +3168,141 @@ func TestBuildWorkspaceConfig(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestExtensionSection(t *testing.T) {
+	t.Parallel()
+
+	server := map[string]any{"port": 8080}
+	cfg := ServiceConfig{extensions: map[string]any{
+		"server":  server,
+		"logging": "not-a-section",
+		"nothing": nil,
+		"empty":   map[string]any{},
+	}}
+
+	tests := []struct {
+		name    string
+		section string
+		wantNil bool
+		wantLen int
+	}{
+		{name: "present section", section: "server", wantLen: 1},
+		{name: "absent section", section: "worker", wantNil: true},
+		{name: "section holding a non-object", section: "logging", wantNil: true},
+		{name: "section holding nil", section: "nothing", wantNil: true},
+		{name: "present but empty section", section: "empty"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := cfg.ExtensionSection(tt.section)
+			if (got == nil) != tt.wantNil {
+				t.Fatalf("ExtensionSection(%q) nil = %t, want %t", tt.section, got == nil, tt.wantNil)
+			}
+			if len(got) != tt.wantLen {
+				t.Errorf("ExtensionSection(%q) len = %d, want %d", tt.section, len(got), tt.wantLen)
+			}
+		})
+	}
+}
+
+// TestExtensionSectionCollapsesAbsentAndNonObject pins the equivalence
+// every section-scoped caller depends on: a caller that reached for a
+// section and got nil cannot tell an absent key from a key holding
+// something that is not an object, and does not need to, because both
+// mean the same thing to it. A caller whose behavior does differ
+// between the two uses [ServiceConfig.ExtensionValue] instead.
+func TestExtensionSectionCollapsesAbsentAndNonObject(t *testing.T) {
+	t.Parallel()
+
+	cfg := ServiceConfig{extensions: map[string]any{"worker": "not-a-section"}}
+
+	absent := cfg.ExtensionSection("nothing-here")
+	nonObject := cfg.ExtensionSection("worker")
+
+	if absent != nil || nonObject != nil {
+		t.Fatalf("ExtensionSection absent = %v and non-object = %v, want both nil", absent, nonObject)
+	}
+}
+
+// TestExtensionSectionReturnsTheStoredMap pins the documented contract
+// that the returned map is the stored one rather than a copy, which is
+// why callers must treat it as read-only.
+func TestExtensionSectionReturnsTheStoredMap(t *testing.T) {
+	t.Parallel()
+
+	cfg := ServiceConfig{extensions: map[string]any{"server": map[string]any{"port": 8080}}}
+
+	cfg.ExtensionSection("server")["port"] = 9090
+
+	if got := cfg.ExtensionSection("server")["port"]; got != 9090 {
+		t.Errorf("port after mutating the returned map = %v, want 9090", got)
+	}
+}
+
+func TestExtensionValue(t *testing.T) {
+	t.Parallel()
+
+	cfg := ServiceConfig{extensions: map[string]any{
+		"token_rates": "not-a-map",
+		"nothing":     nil,
+	}}
+
+	tests := []struct {
+		name        string
+		key         string
+		wantPresent bool
+		wantValue   any
+	}{
+		{name: "present non-object value", key: "token_rates", wantPresent: true, wantValue: "not-a-map"},
+		{name: "present nil value", key: "nothing", wantPresent: true},
+		{name: "absent key", key: "worker"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, present := cfg.ExtensionValue(tt.key)
+			if present != tt.wantPresent {
+				t.Fatalf("ExtensionValue(%q) present = %t, want %t", tt.key, present, tt.wantPresent)
+			}
+			if got != tt.wantValue {
+				t.Errorf("ExtensionValue(%q) = %v, want %v", tt.key, got, tt.wantValue)
+			}
+		})
+	}
+}
+
+func TestSetExtensionSection(t *testing.T) {
+	t.Parallel()
+
+	t.Run("allocates on a zero-value config", func(t *testing.T) {
+		t.Parallel()
+
+		var cfg ServiceConfig
+		cfg.SetExtensionSection("worker", map[string]any{"ssh_hosts": []any{"host-a"}})
+
+		if got := len(cfg.ExtensionSection("worker")); got != 1 {
+			t.Errorf("worker section len = %d, want 1", got)
+		}
+	})
+
+	t.Run("replaces an existing section", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := ServiceConfig{extensions: map[string]any{"server": map[string]any{"port": 8080, "host": "127.0.0.1"}}}
+		cfg.SetExtensionSection("server", map[string]any{"port": 9090})
+
+		section := cfg.ExtensionSection("server")
+		if got := section["port"]; got != 9090 {
+			t.Errorf("port = %v, want 9090", got)
+		}
+		if _, ok := section["host"]; ok {
+			t.Error("host survived the replacement, want the section replaced wholesale")
+		}
+	})
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -35,7 +35,7 @@ func TestNewServiceConfig(t *testing.T) {
 		if len(cfg.Agent.MaxConcurrentByState) != 0 {
 			t.Errorf("Agent.MaxConcurrentByState has %d entries, want 0", len(cfg.Agent.MaxConcurrentByState))
 		}
-		if cfg.Extensions == nil {
+		if cfg.extensions == nil {
 			t.Error("Extensions is nil, want empty map")
 		}
 	})
@@ -358,7 +358,7 @@ func TestNewServiceConfig(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		serverExt, ok := cfg.Extensions["server"]
+		serverExt, ok := cfg.extensions["server"]
 		if !ok {
 			t.Fatal("Extensions missing 'server'")
 		}
@@ -369,7 +369,7 @@ func TestNewServiceConfig(t *testing.T) {
 		if serverMap["port"] != 8080 {
 			t.Errorf("server.port = %v, want 8080", serverMap["port"])
 		}
-		if _, ok := cfg.Extensions["worker"]; !ok {
+		if _, ok := cfg.extensions["worker"]; !ok {
 			t.Error("Extensions missing 'worker'")
 		}
 	})
@@ -518,7 +518,7 @@ func TestNewServiceConfig(t *testing.T) {
 		if err != nil {
 			t.Fatalf("NewServiceConfig(db_path=/data/sortie.db) unexpected error: %v", err)
 		}
-		if _, ok := cfg.Extensions["db_path"]; ok {
+		if _, ok := cfg.extensions["db_path"]; ok {
 			t.Error("db_path should not appear in Extensions")
 		}
 	})
@@ -1845,8 +1845,8 @@ func TestNewServiceConfig_CIFeedback(t *testing.T) {
 		if err != nil {
 			t.Fatalf("NewServiceConfig: %v", err)
 		}
-		if _, ok := cfg.Extensions["ci_feedback"]; ok {
-			t.Error("ci_feedback leaked into cfg.Extensions; want absent")
+		if _, ok := cfg.extensions["ci_feedback"]; ok {
+			t.Error("ci_feedback leaked into cfg.extensions; want absent")
 		}
 	})
 }
@@ -2011,8 +2011,8 @@ func TestNewServiceConfig_SelfReview(t *testing.T) {
 		if err != nil {
 			t.Fatalf("NewServiceConfig: %v", err)
 		}
-		if _, ok := cfg.Extensions["self_review"]; ok {
-			t.Error("self_review leaked into cfg.Extensions; want absent")
+		if _, ok := cfg.extensions["self_review"]; ok {
+			t.Error("self_review leaked into cfg.extensions; want absent")
 		}
 	})
 }
@@ -2634,9 +2634,9 @@ func TestNewServiceConfigExtensions(t *testing.T) {
 		// Core field: the SORTIE_* override wins.
 		assertStringEqual(t, "Tracker.APIKey", "from-env-override", cfg.Tracker.APIKey)
 		// Extension field: $VAR resolved against process environment.
-		extMap, ok := cfg.Extensions["myext"].(map[string]any)
+		extMap, ok := cfg.extensions["myext"].(map[string]any)
 		if !ok {
-			t.Fatal("cfg.Extensions[myext] not a map")
+			t.Fatal("cfg.extensions[myext] not a map")
 		}
 		assertStringEqual(t, "myext.api_key resolved", "ext-resolved-value", extMap["api_key"].(string))
 	})
@@ -2652,9 +2652,9 @@ func TestNewServiceConfigExtensions(t *testing.T) {
 		if err != nil {
 			t.Fatalf("NewServiceConfig: %v", err)
 		}
-		workerExt, ok := cfg.Extensions["worker"].(map[string]any)
+		workerExt, ok := cfg.extensions["worker"].(map[string]any)
 		if !ok {
-			t.Fatal("cfg.Extensions[worker] not a map")
+			t.Fatal("cfg.extensions[worker] not a map")
 		}
 		hosts, ok := workerExt["ssh_hosts"].([]any)
 		if !ok {
@@ -2679,9 +2679,9 @@ func TestNewServiceConfigExtensions(t *testing.T) {
 		if err != nil {
 			t.Fatalf("NewServiceConfig with int32 leaf: %v", err)
 		}
-		extMap, ok := cfg.Extensions["myext"].(map[string]any)
+		extMap, ok := cfg.extensions["myext"].(map[string]any)
 		if !ok {
-			t.Fatal("cfg.Extensions[myext] not a map")
+			t.Fatal("cfg.extensions[myext] not a map")
 		}
 		if extMap["count"] != int32(42) {
 			t.Errorf("myext.count = %v (%T), want int32(42)", extMap["count"], extMap["count"])
@@ -2718,7 +2718,7 @@ func TestNewServiceConfigExtensions(t *testing.T) {
 
 // TestAgentAdapterConfig_ExactlyFiveKeysWithNoExtensions asserts that
 // AgentAdapterConfig returns exactly the five documented keys when
-// cfg.Extensions carries no sub-object for kind.
+// cfg.extensions carries no sub-object for kind.
 func TestAgentAdapterConfig_ExactlyFiveKeysWithNoExtensions(t *testing.T) {
 	t.Parallel()
 
@@ -2781,7 +2781,7 @@ func TestAgentAdapterConfig_ExtensionCollisionWithOrchestratorOnlyFieldSurvives(
 			Command:  "codex",
 			MaxTurns: 20,
 		},
-		Extensions: map[string]any{
+		extensions: map[string]any{
 			"codex": map[string]any{
 				"max_turns":       float64(5),
 				"approval_policy": "never",
@@ -2820,7 +2820,7 @@ func TestAgentAdapterConfig_DoesNotOverwriteDocumentedKeys(t *testing.T) {
 
 	cfg := ServiceConfig{
 		Agent: AgentConfig{Kind: "codex", Command: "codex"},
-		Extensions: map[string]any{
+		extensions: map[string]any{
 			"codex": map[string]any{
 				"command": "should-not-win",
 			},
@@ -2886,7 +2886,7 @@ func TestResolveAgentSettings_MCPConfigPath(t *testing.T) {
 		},
 		{
 			name: "block is not an object",
-			cfg: ServiceConfig{Extensions: map[string]any{
+			cfg: ServiceConfig{extensions: map[string]any{
 				"codex": "not-a-map",
 			}},
 			kind:        "codex",
@@ -2895,7 +2895,7 @@ func TestResolveAgentSettings_MCPConfigPath(t *testing.T) {
 		},
 		{
 			name: "block has no mcp_config key",
-			cfg: ServiceConfig{Extensions: map[string]any{
+			cfg: ServiceConfig{extensions: map[string]any{
 				"codex": map[string]any{"approval_policy": "never"},
 			}},
 			kind:        "codex",
@@ -2904,7 +2904,7 @@ func TestResolveAgentSettings_MCPConfigPath(t *testing.T) {
 		},
 		{
 			name: "mcp_config is not a string",
-			cfg: ServiceConfig{Extensions: map[string]any{
+			cfg: ServiceConfig{extensions: map[string]any{
 				"codex": map[string]any{"mcp_config": 42},
 			}},
 			kind:        "codex",
@@ -2913,7 +2913,7 @@ func TestResolveAgentSettings_MCPConfigPath(t *testing.T) {
 		},
 		{
 			name: "mcp_config is the empty string",
-			cfg: ServiceConfig{Extensions: map[string]any{
+			cfg: ServiceConfig{extensions: map[string]any{
 				"codex": map[string]any{"mcp_config": ""},
 			}},
 			kind:        "codex",
@@ -2922,7 +2922,7 @@ func TestResolveAgentSettings_MCPConfigPath(t *testing.T) {
 		},
 		{
 			name: "mcp_config is an absolute path",
-			cfg: ServiceConfig{Extensions: map[string]any{
+			cfg: ServiceConfig{extensions: map[string]any{
 				"codex": map[string]any{"mcp_config": absOperatorPath},
 			}},
 			kind:        "codex",
@@ -2931,7 +2931,7 @@ func TestResolveAgentSettings_MCPConfigPath(t *testing.T) {
 		},
 		{
 			name: "mcp_config is relative and workflowDir is non-empty",
-			cfg: ServiceConfig{Extensions: map[string]any{
+			cfg: ServiceConfig{extensions: map[string]any{
 				"codex": map[string]any{"mcp_config": "op.json"},
 			}},
 			kind:        "codex",
@@ -2940,7 +2940,7 @@ func TestResolveAgentSettings_MCPConfigPath(t *testing.T) {
 		},
 		{
 			name: "mcp_config is relative and workflowDir is empty",
-			cfg: ServiceConfig{Extensions: map[string]any{
+			cfg: ServiceConfig{extensions: map[string]any{
 				"codex": map[string]any{"mcp_config": "op.json"},
 			}},
 			kind:        "codex",
@@ -2973,7 +2973,7 @@ func TestResolveAgentSettings_PassthroughMatchesAgentAdapterConfig(t *testing.T)
 
 	cfg := ServiceConfig{
 		Agent: AgentConfig{Kind: "claude-code", Command: "claude"},
-		Extensions: map[string]any{
+		extensions: map[string]any{
 			"codex": map[string]any{"approval_policy": "never"},
 		},
 	}
@@ -3022,7 +3022,7 @@ func TestMergeAdapterExtensions(t *testing.T) {
 		t.Parallel()
 
 		dst := map[string]any{"kind": "file"}
-		cfg := ServiceConfig{Extensions: map[string]any{
+		cfg := ServiceConfig{extensions: map[string]any{
 			"file": map[string]any{"path": "issues.json", "extra": 42},
 		}}
 
@@ -3040,7 +3040,7 @@ func TestMergeAdapterExtensions(t *testing.T) {
 		t.Parallel()
 
 		dst := map[string]any{"kind": "file", "path": "original.json"}
-		cfg := ServiceConfig{Extensions: map[string]any{
+		cfg := ServiceConfig{extensions: map[string]any{
 			"file": map[string]any{"path": "overridden.json"},
 		}}
 
@@ -3055,7 +3055,7 @@ func TestMergeAdapterExtensions(t *testing.T) {
 		t.Parallel()
 
 		dst := map[string]any{"kind": "jira"}
-		cfg := ServiceConfig{Extensions: map[string]any{
+		cfg := ServiceConfig{extensions: map[string]any{
 			"file": map[string]any{"path": "issues.json"},
 		}}
 
@@ -3083,7 +3083,7 @@ func TestMergeAdapterExtensions(t *testing.T) {
 		t.Parallel()
 
 		dst := map[string]any{"kind": "file"}
-		cfg := ServiceConfig{Extensions: map[string]any{
+		cfg := ServiceConfig{extensions: map[string]any{
 			"file": "not a map",
 		}}
 
@@ -3098,7 +3098,7 @@ func TestMergeAdapterExtensions(t *testing.T) {
 		t.Parallel()
 
 		dst := map[string]any{"kind": "claude-code"}
-		cfg := ServiceConfig{Extensions: map[string]any{
+		cfg := ServiceConfig{extensions: map[string]any{
 			"claude-code": map[string]any{"max_turns": float64(50)},
 		}}
 

--- a/internal/config/extensions_contract_test.go
+++ b/internal/config/extensions_contract_test.go
@@ -66,9 +66,12 @@ func resolveExtensionsImportName(file *ast.File, importPath string) string {
 
 // isExtensionsIndexBase reports whether expr is the base of an index
 // expression that X1 forbids outside the allow-list: the extensions
-// field selector, or a bare identifier named extensions.
+// field selector, or a bare identifier named extensions. Enclosing
+// parentheses are stripped first, since the parser wraps a
+// parenthesized expression in a node of its own and the shape the rule
+// forbids is the same with or without them.
 func isExtensionsIndexBase(expr ast.Expr) bool {
-	switch e := expr.(type) {
+	switch e := ast.Unparen(expr).(type) {
 	case *ast.Ident:
 		return e.Name == "extensions"
 	case *ast.SelectorExpr:
@@ -79,13 +82,14 @@ func isExtensionsIndexBase(expr ast.Expr) bool {
 
 // isAgentKindSelector reports whether expr is a selector expression
 // ending in Agent.Kind, the shape of the original defect spelled in
-// the new API.
+// the new API. Parentheses are stripped at both selector levels for
+// the reason [isExtensionsIndexBase] gives.
 func isAgentKindSelector(expr ast.Expr) bool {
-	sel, ok := expr.(*ast.SelectorExpr)
+	sel, ok := ast.Unparen(expr).(*ast.SelectorExpr)
 	if !ok || sel.Sel.Name != "Kind" {
 		return false
 	}
-	inner, ok := sel.X.(*ast.SelectorExpr)
+	inner, ok := ast.Unparen(sel.X).(*ast.SelectorExpr)
 	return ok && inner.Sel.Name == "Agent"
 }
 
@@ -131,14 +135,14 @@ func checkExtensionsX2X3(fset *token.FileSet, file *ast.File) []extensionsViolat
 			return true
 		}
 
-		switch fun := call.Fun.(type) {
+		switch fun := ast.Unparen(call.Fun).(type) {
 		case *ast.SelectorExpr:
 			switch fun.Sel.Name {
 			case "ExtensionSection", "ExtensionValue":
 				if len(call.Args) != 1 {
 					return true
 				}
-				if lit, ok := call.Args[0].(*ast.BasicLit); ok && lit.Kind == token.STRING {
+				if lit, ok := ast.Unparen(call.Args[0]).(*ast.BasicLit); ok && lit.Kind == token.STRING {
 					return true
 				}
 				violations = append(violations, extensionsViolation{
@@ -146,7 +150,7 @@ func checkExtensionsX2X3(fset *token.FileSet, file *ast.File) []extensionsViolat
 					text: fun.Sel.Name + " called with a non-literal name argument",
 				})
 			case "ResolveAgentSettings":
-				ident, ok := fun.X.(*ast.Ident)
+				ident, ok := ast.Unparen(fun.X).(*ast.Ident)
 				if !ok || configIdent == "" || ident.Name != configIdent {
 					return true
 				}
@@ -286,6 +290,36 @@ func resolve(cfg ServiceConfig, dir string) config.AgentSettings {
 }
 `,
 			wantCount: 1,
+		},
+		{
+			name: "parentheses do not hide any of the three shapes",
+			src: `package fixture
+
+import "github.com/sortie-ai/sortie/internal/config"
+
+func leakExtensions(cfg ServiceConfig) any {
+	return (cfg.extensions)["worker"]
+}
+
+func readSection(cfg ServiceConfig, name string) map[string]any {
+	return (cfg.ExtensionSection)(name)
+}
+
+func resolve(cfg ServiceConfig, dir string) config.AgentSettings {
+	return config.ResolveAgentSettings(cfg, (cfg.Agent).Kind, dir)
+}
+`,
+			wantCount: 3,
+		},
+		{
+			name: "a parenthesized string literal is still a literal section name",
+			src: `package fixture
+
+func readSection(cfg ServiceConfig) map[string]any {
+	return cfg.ExtensionSection(("worker"))
+}
+`,
+			wantCount: 0,
 		},
 	}
 

--- a/internal/config/extensions_contract_test.go
+++ b/internal/config/extensions_contract_test.go
@@ -1,0 +1,309 @@
+package config
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// extensionsConfigImportPath is the import path the checker resolves
+// the "config" package qualifier from, per file, so a call to
+// ResolveAgentSettings is caught regardless of the local import alias.
+const extensionsConfigImportPath = "github.com/sortie-ai/sortie/internal/config"
+
+// extensionsX1Allowlist names the internal/config functions permitted
+// to index the extensions field or an identifier named extensions.
+// Membership is verified against the tree, not copied from the source
+// spec: ExtensionSection, ExtensionValue, and SetExtensionSection own
+// the field selector form (c.extensions[...]); mergeExtensionSection
+// and resolveExtensionEnvRefs own the identifier form on a parameter
+// named extensions; NewServiceConfig owns the identifier form on the
+// local map it assembles before storing it in the field.
+// lookupExtensionValue indexes only a local variable named current,
+// never extensions itself, so it can never trip the rule below, but it
+// stays listed because it is the function the field's own godoc names
+// as an owner of kind-scoped reads.
+var extensionsX1Allowlist = map[string]bool{
+	"ExtensionSection":        true,
+	"ExtensionValue":          true,
+	"SetExtensionSection":     true,
+	"mergeExtensionSection":   true,
+	"lookupExtensionValue":    true,
+	"resolveExtensionEnvRefs": true,
+	"NewServiceConfig":        true,
+}
+
+// extensionsViolation describes one place a file breaks the closed
+// access-path invariant this checker enforces.
+type extensionsViolation struct {
+	pos  token.Position
+	text string
+}
+
+// resolveExtensionsImportName returns the local identifier a file binds
+// to importPath, or "" when the file does not import it. It reads only
+// the file's own import declarations, never assumes a literal package
+// name, so an aliased import cannot evade the check.
+func resolveExtensionsImportName(file *ast.File, importPath string) string {
+	for _, imp := range file.Imports {
+		path, err := strconv.Unquote(imp.Path.Value)
+		if err != nil || path != importPath {
+			continue
+		}
+		if imp.Name != nil {
+			return imp.Name.Name
+		}
+		segments := strings.Split(path, "/")
+		return segments[len(segments)-1]
+	}
+	return ""
+}
+
+// isExtensionsIndexBase reports whether expr is the base of an index
+// expression that X1 forbids outside the allow-list: the extensions
+// field selector, or a bare identifier named extensions.
+func isExtensionsIndexBase(expr ast.Expr) bool {
+	switch e := expr.(type) {
+	case *ast.Ident:
+		return e.Name == "extensions"
+	case *ast.SelectorExpr:
+		return e.Sel.Name == "extensions"
+	}
+	return false
+}
+
+// isAgentKindSelector reports whether expr is a selector expression
+// ending in Agent.Kind, the shape of the original defect spelled in
+// the new API.
+func isAgentKindSelector(expr ast.Expr) bool {
+	sel, ok := expr.(*ast.SelectorExpr)
+	if !ok || sel.Sel.Name != "Kind" {
+		return false
+	}
+	inner, ok := sel.X.(*ast.SelectorExpr)
+	return ok && inner.Sel.Name == "Agent"
+}
+
+// checkExtensionsX1 appends a violation for every index expression
+// inside file whose base is the extensions field selector or an
+// identifier named extensions, in a function outside
+// extensionsX1Allowlist. The caller restricts this check to
+// internal/config's own non-test files, per X1's scope.
+func checkExtensionsX1(fset *token.FileSet, file *ast.File) []extensionsViolation {
+	var violations []extensionsViolation
+	for _, decl := range file.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Body == nil || extensionsX1Allowlist[fn.Name.Name] {
+			continue
+		}
+		ast.Inspect(fn.Body, func(n ast.Node) bool {
+			idx, ok := n.(*ast.IndexExpr)
+			if !ok || !isExtensionsIndexBase(idx.X) {
+				return true
+			}
+			violations = append(violations, extensionsViolation{
+				pos:  fset.Position(idx.Pos()),
+				text: "func " + fn.Name.Name + " indexes extensions directly outside the allow-list",
+			})
+			return true
+		})
+	}
+	return violations
+}
+
+// checkExtensionsX2X3 appends a violation for every call inside file
+// that breaks X2 (a non-literal argument to ExtensionSection or
+// ExtensionValue) or X3 (a ResolveAgentSettings call whose kind
+// argument is a selector ending in Agent.Kind). Both rules apply
+// anywhere in the two walked roots, not only inside internal/config.
+func checkExtensionsX2X3(fset *token.FileSet, file *ast.File) []extensionsViolation {
+	configIdent := resolveExtensionsImportName(file, extensionsConfigImportPath)
+
+	var violations []extensionsViolation
+	ast.Inspect(file, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+
+		switch fun := call.Fun.(type) {
+		case *ast.SelectorExpr:
+			switch fun.Sel.Name {
+			case "ExtensionSection", "ExtensionValue":
+				if len(call.Args) != 1 {
+					return true
+				}
+				if lit, ok := call.Args[0].(*ast.BasicLit); ok && lit.Kind == token.STRING {
+					return true
+				}
+				violations = append(violations, extensionsViolation{
+					pos:  fset.Position(call.Pos()),
+					text: fun.Sel.Name + " called with a non-literal name argument",
+				})
+			case "ResolveAgentSettings":
+				ident, ok := fun.X.(*ast.Ident)
+				if !ok || configIdent == "" || ident.Name != configIdent {
+					return true
+				}
+				violations = append(violations, checkResolveAgentSettingsKind(fset, call)...)
+			}
+		case *ast.Ident:
+			if fun.Name == "ResolveAgentSettings" {
+				violations = append(violations, checkResolveAgentSettingsKind(fset, call)...)
+			}
+		}
+		return true
+	})
+	return violations
+}
+
+// checkResolveAgentSettingsKind reports X3 for a single
+// ResolveAgentSettings call whose kind argument (the second parameter)
+// is a selector expression ending in Agent.Kind.
+func checkResolveAgentSettingsKind(fset *token.FileSet, call *ast.CallExpr) []extensionsViolation {
+	if len(call.Args) < 2 || !isAgentKindSelector(call.Args[1]) {
+		return nil
+	}
+	return []extensionsViolation{{
+		pos:  fset.Position(call.Pos()),
+		text: "ResolveAgentSettings called with a selector ending in Agent.Kind instead of the session's frozen kind",
+	}}
+}
+
+// TestExtensionsContract walks the non-test Go files under internal/
+// and cmd/, skipping testdata directories, and fails when any file
+// breaks the closed access-path invariant this work establishes: a
+// direct index of the extensions map outside internal/config's own
+// allow-listed owner functions (X1), a call to ExtensionSection or
+// ExtensionValue whose section name is not a string literal (X2), or a
+// call to ResolveAgentSettings whose kind argument reaches for the
+// configuration's default kind instead of the session's frozen one
+// (X3).
+func TestExtensionsContract(t *testing.T) {
+	fset := token.NewFileSet()
+	internalConfigDir := filepath.Join("..", "config")
+
+	roots := []string{
+		filepath.Join(".."),
+		filepath.Join("..", "..", "cmd"),
+	}
+
+	for _, root := range roots {
+		parsed := 0
+		err := filepath.WalkDir(root, func(path string, d fs.DirEntry, walkErr error) error {
+			if walkErr != nil {
+				return walkErr
+			}
+			if d.IsDir() {
+				if d.Name() == "testdata" {
+					return filepath.SkipDir
+				}
+				return nil
+			}
+			if !strings.HasSuffix(path, ".go") {
+				return nil
+			}
+
+			isTestFile := strings.HasSuffix(path, "_test.go")
+			mode := parser.SkipObjectResolution
+			if isTestFile {
+				mode |= parser.ImportsOnly
+			}
+			file, parseErr := parser.ParseFile(fset, path, nil, mode)
+			if parseErr != nil {
+				t.Errorf("parse %s: %v", path, parseErr)
+				return nil
+			}
+			parsed++
+			if isTestFile {
+				return nil
+			}
+
+			var violations []extensionsViolation
+			if filepath.Dir(path) == internalConfigDir {
+				violations = append(violations, checkExtensionsX1(fset, file)...)
+			}
+			violations = append(violations, checkExtensionsX2X3(fset, file)...)
+			for _, v := range violations {
+				t.Errorf("%s: %s", v.pos, v.text)
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("walk %s: %v", root, err)
+		}
+		if parsed == 0 {
+			t.Fatalf("root %s yielded no parsed Go files, want at least one", root)
+		}
+	}
+}
+
+// TestExtensionsContract_DetectsViolations pins the checker's own logic
+// against inline source fixtures, independent of the current state of
+// any production file, so a regression in a rule is caught even when
+// every real caller happens to comply.
+func TestExtensionsContract_DetectsViolations(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		src       string
+		wantCount int
+	}{
+		{
+			name: "X1: a function outside the allow-list indexes extensions directly",
+			src: `package fixture
+
+func leakExtensions(extensions map[string]any) any {
+	return extensions["worker"]
+}
+`,
+			wantCount: 1,
+		},
+		{
+			name: "X2: ExtensionSection called with a variable argument instead of a string literal",
+			src: `package fixture
+
+func readSection(cfg ServiceConfig, name string) map[string]any {
+	return cfg.ExtensionSection(name)
+}
+`,
+			wantCount: 1,
+		},
+		{
+			name: "X3: ResolveAgentSettings called with a selector ending in Agent.Kind",
+			src: `package fixture
+
+import "github.com/sortie-ai/sortie/internal/config"
+
+func resolve(cfg ServiceConfig, dir string) config.AgentSettings {
+	return config.ResolveAgentSettings(cfg, cfg.Agent.Kind, dir)
+}
+`,
+			wantCount: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			fset := token.NewFileSet()
+			file, err := parser.ParseFile(fset, "fixture.go", tt.src, parser.SkipObjectResolution)
+			if err != nil {
+				t.Fatalf("parser.ParseFile: %v", err)
+			}
+
+			got := checkExtensionsX1(fset, file)
+			got = append(got, checkExtensionsX2X3(fset, file)...)
+			if len(got) != tt.wantCount {
+				t.Errorf("got %d violations, want %d: %+v", len(got), tt.wantCount, got)
+			}
+		})
+	}
+}

--- a/internal/config/notifications.go
+++ b/internal/config/notifications.go
@@ -111,8 +111,8 @@ func parseNotificationBackend(index int, elem any) (NotificationBackend, error) 
 		passthrough[key] = val
 	}
 
-	// A typed knownTopLevelKeys section is excluded from Extensions, and
-	// the only existing $VAR walker runs over Extensions, so resolve the
+	// A typed knownTopLevelKeys section is excluded from extensions, and
+	// the only existing $VAR walker runs over extensions, so resolve the
 	// entry leaves here. An unset reference resolves to the empty string,
 	// which the backend constructor then rejects as a missing secret.
 	var snapshot map[string]string

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -359,7 +359,7 @@ func ValidateFrontMatter(raw map[string]any, cfg ServiceConfig) []FrontMatterWar
 	warnings = checkHooksTimeoutSemantic(warnings, raw)
 	warnings = checkByStateSemantic(warnings, raw)
 
-	// Surface unresolved $VAR references in Extensions by replaying the
+	// Surface unresolved $VAR references in extensions by replaying the
 	// snapshot captured during NewServiceConfig. A non-empty resolved
 	// leaf indicates the variable was set; a resolved empty leaf is the
 	// warning trigger.
@@ -383,7 +383,7 @@ func checkUnresolvedExtensionVars(warnings []FrontMatterWarning, cfg ServiceConf
 	paths := maputil.SortedKeys(cfg.extensionsPreResolution)
 	for _, path := range paths {
 		before := cfg.extensionsPreResolution[path]
-		_, ok := lookupExtensionValue(cfg.Extensions, path)
+		_, ok := lookupExtensionValue(cfg.extensions, path)
 		if !ok {
 			continue
 		}

--- a/internal/orchestrator/hostpool.go
+++ b/internal/orchestrator/hostpool.go
@@ -222,26 +222,17 @@ type WorkerConfig struct {
 	Warnings []WorkerWarning
 }
 
-// ParseWorkerConfig parses worker extension configuration from the
-// Extensions map. Returns a [WorkerConfig] with SSH host list,
-// per-host concurrency cap, and SSH StrictHostKeyChecking behavior.
-// When the worker key is absent or malformed, returns zero-value
-// defaults (local mode).
-func ParseWorkerConfig(extensions map[string]any) WorkerConfig {
-	if extensions == nil {
-		return WorkerConfig{}
-	}
-	workerRaw, ok := extensions["worker"]
-	if !ok {
-		return WorkerConfig{}
-	}
-	workerMap, ok := workerRaw.(map[string]any)
-	if !ok {
+// ParseWorkerConfig parses the worker extension section. Returns a
+// [WorkerConfig] with SSH host list, per-host concurrency cap, and SSH
+// StrictHostKeyChecking behavior. When workerSection is nil, returns
+// zero-value defaults (local mode).
+func ParseWorkerConfig(workerSection map[string]any) WorkerConfig {
+	if workerSection == nil {
 		return WorkerConfig{}
 	}
 
 	var hosts []string
-	if rawHosts, ok := workerMap["ssh_hosts"]; ok {
+	if rawHosts, ok := workerSection["ssh_hosts"]; ok {
 		if hostList, ok := rawHosts.([]any); ok {
 			for _, h := range hostList {
 				if s, ok := h.(string); ok && s != "" {
@@ -252,7 +243,7 @@ func ParseWorkerConfig(extensions map[string]any) WorkerConfig {
 	}
 
 	var maxPerHost int
-	if rawMax, ok := workerMap["max_concurrent_agents_per_host"]; ok {
+	if rawMax, ok := workerSection["max_concurrent_agents_per_host"]; ok {
 		switch v := rawMax.(type) {
 		case int:
 			if v > 0 {
@@ -265,7 +256,7 @@ func ParseWorkerConfig(extensions map[string]any) WorkerConfig {
 		}
 	}
 
-	strictHostKeyChecking, warn := parseSSHStrictHostKeyChecking(workerMap)
+	strictHostKeyChecking, warn := parseSSHStrictHostKeyChecking(workerSection)
 
 	var warnings []WorkerWarning
 	if warn != nil {

--- a/internal/orchestrator/hostpool_test.go
+++ b/internal/orchestrator/hostpool_test.go
@@ -257,123 +257,93 @@ func TestParseWorkerConfig(t *testing.T) {
 
 	tests := []struct {
 		name                      string
-		extensions                map[string]any
+		workerSection             map[string]any
 		wantHosts                 []string
 		wantMaxPerHost            int
 		wantSSHStrictHostKeyCheck string
 		wantWarnings              []WorkerWarning
 	}{
 		{
-			name:       "nil extensions",
-			extensions: nil,
-		},
-		{
-			name:       "missing worker key",
-			extensions: map[string]any{"other": "value"},
-		},
-		{
-			name:       "worker not a map",
-			extensions: map[string]any{"worker": "invalid"},
+			name:          "nil worker section",
+			workerSection: nil,
 		},
 		{
 			name: "empty ssh_hosts",
-			extensions: map[string]any{
-				"worker": map[string]any{
-					"ssh_hosts": []any{},
-				},
+			workerSection: map[string]any{
+				"ssh_hosts": []any{},
 			},
 		},
 		{
 			name: "valid config",
-			extensions: map[string]any{
-				"worker": map[string]any{
-					"ssh_hosts":                      []any{"host-a", "host-b"},
-					"max_concurrent_agents_per_host": 3,
-				},
+			workerSection: map[string]any{
+				"ssh_hosts":                      []any{"host-a", "host-b"},
+				"max_concurrent_agents_per_host": 3,
 			},
 			wantHosts:      []string{"host-a", "host-b"},
 			wantMaxPerHost: 3,
 		},
 		{
 			name: "float64 max_concurrent_agents_per_host",
-			extensions: map[string]any{
-				"worker": map[string]any{
-					"ssh_hosts":                      []any{"host-a"},
-					"max_concurrent_agents_per_host": float64(2),
-				},
+			workerSection: map[string]any{
+				"ssh_hosts":                      []any{"host-a"},
+				"max_concurrent_agents_per_host": float64(2),
 			},
 			wantHosts:      []string{"host-a"},
 			wantMaxPerHost: 2,
 		},
 		{
 			name: "deduplicates hosts",
-			extensions: map[string]any{
-				"worker": map[string]any{
-					"ssh_hosts": []any{"host-a", "host-a", "host-b"},
-				},
+			workerSection: map[string]any{
+				"ssh_hosts": []any{"host-a", "host-a", "host-b"},
 			},
 			wantHosts: []string{"host-a", "host-b"},
 		},
 		{
 			name: "skips empty and non-string hosts",
-			extensions: map[string]any{
-				"worker": map[string]any{
-					"ssh_hosts": []any{"", 42, "host-a"},
-				},
+			workerSection: map[string]any{
+				"ssh_hosts": []any{"", 42, "host-a"},
 			},
 			wantHosts: []string{"host-a"},
 		},
 		// ssh_strict_host_key_checking cases
 		{
-			name: "absent ssh_strict_host_key_checking",
-			extensions: map[string]any{
-				"worker": map[string]any{"ssh_hosts": []any{"host-a"}},
-			},
+			name:                      "absent ssh_strict_host_key_checking",
+			workerSection:             map[string]any{"ssh_hosts": []any{"host-a"}},
 			wantHosts:                 []string{"host-a"},
 			wantSSHStrictHostKeyCheck: "",
 		},
 		{
 			name: "valid accept-new",
-			extensions: map[string]any{
-				"worker": map[string]any{
-					"ssh_strict_host_key_checking": "accept-new",
-				},
+			workerSection: map[string]any{
+				"ssh_strict_host_key_checking": "accept-new",
 			},
 			wantSSHStrictHostKeyCheck: "accept-new",
 		},
 		{
 			name: "valid yes",
-			extensions: map[string]any{
-				"worker": map[string]any{
-					"ssh_strict_host_key_checking": "yes",
-				},
+			workerSection: map[string]any{
+				"ssh_strict_host_key_checking": "yes",
 			},
 			wantSSHStrictHostKeyCheck: "yes",
 		},
 		{
 			name: "valid no",
-			extensions: map[string]any{
-				"worker": map[string]any{
-					"ssh_strict_host_key_checking": "no",
-				},
+			workerSection: map[string]any{
+				"ssh_strict_host_key_checking": "no",
 			},
 			wantSSHStrictHostKeyCheck: "no",
 		},
 		{
 			name: "uppercase YES normalized to yes",
-			extensions: map[string]any{
-				"worker": map[string]any{
-					"ssh_strict_host_key_checking": "YES",
-				},
+			workerSection: map[string]any{
+				"ssh_strict_host_key_checking": "YES",
 			},
 			wantSSHStrictHostKeyCheck: "yes",
 		},
 		{
 			name: "invalid string falls back to empty",
-			extensions: map[string]any{
-				"worker": map[string]any{
-					"ssh_strict_host_key_checking": "ask",
-				},
+			workerSection: map[string]any{
+				"ssh_strict_host_key_checking": "ask",
 			},
 			wantSSHStrictHostKeyCheck: "",
 			wantWarnings: []WorkerWarning{
@@ -385,10 +355,8 @@ func TestParseWorkerConfig(t *testing.T) {
 		},
 		{
 			name: "wrong type integer falls back to empty",
-			extensions: map[string]any{
-				"worker": map[string]any{
-					"ssh_strict_host_key_checking": 42,
-				},
+			workerSection: map[string]any{
+				"ssh_strict_host_key_checking": 42,
 			},
 			wantSSHStrictHostKeyCheck: "",
 			wantWarnings: []WorkerWarning{
@@ -404,8 +372,7 @@ func TestParseWorkerConfig(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			workerSection, _ := tt.extensions["worker"].(map[string]any)
-			wc := ParseWorkerConfig(workerSection)
+			wc := ParseWorkerConfig(tt.workerSection)
 
 			if len(wc.SSHHosts) != len(tt.wantHosts) {
 				t.Fatalf("ParseWorkerConfig() SSHHosts = %v, want %v", wc.SSHHosts, tt.wantHosts)

--- a/internal/orchestrator/hostpool_test.go
+++ b/internal/orchestrator/hostpool_test.go
@@ -404,7 +404,8 @@ func TestParseWorkerConfig(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			wc := ParseWorkerConfig(tt.extensions)
+			workerSection, _ := tt.extensions["worker"].(map[string]any)
+			wc := ParseWorkerConfig(workerSection)
 
 			if len(wc.SSHHosts) != len(tt.wantHosts) {
 				t.Fatalf("ParseWorkerConfig() SSHHosts = %v, want %v", wc.SSHHosts, tt.wantHosts)

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -304,7 +304,7 @@ func NewOrchestrator(params OrchestratorParams) *Orchestrator {
 	} else {
 		// Warn if max_concurrent_agents_per_host is set without ssh_hosts.
 		cfg := params.WorkflowManager.Config()
-		if worker, ok := cfg.Extensions["worker"].(map[string]any); ok {
+		if worker := cfg.ExtensionSection("worker"); worker != nil {
 			if _, hasMax := worker["max_concurrent_agents_per_host"]; hasMax {
 				logger.Warn("max_concurrent_agents_per_host has no effect without worker.ssh_hosts")
 			}
@@ -548,7 +548,7 @@ func (o *Orchestrator) handleTick(ctx context.Context) {
 	o.state.MaxConcurrentByState = cfg.Agent.MaxConcurrentByState
 
 	// Update host pool from config extensions.
-	wc := ParseWorkerConfig(cfg.Extensions)
+	wc := ParseWorkerConfig(cfg.ExtensionSection("worker"))
 	o.hostPool.Update(wc.SSHHosts, wc.MaxPerHost)
 	o.sshStrictHostKeyChecking = wc.SSHStrictHostKeyChecking
 

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -5449,12 +5449,10 @@ func TestHandleTick_WorkerWarningChangeDetection(t *testing.T) {
 			Kind:                "mock",
 			MaxConcurrentAgents: 1,
 		},
-		Extensions: map[string]any{
-			"worker": map[string]any{
-				"ssh_strict_host_key_checking": "ask",
-			},
-		},
 	}
+	cfg.SetExtensionSection("worker", map[string]any{
+		"ssh_strict_host_key_checking": "ask",
+	})
 
 	wm := &stubWorkflowManager{config: cfg}
 	state := NewState(60000, 1, nil, AgentTotals{})
@@ -5484,11 +5482,9 @@ func TestHandleTick_WorkerWarningChangeDetection(t *testing.T) {
 	}
 
 	// Change to a different invalid value — a new warning must appear.
-	cfg.Extensions = map[string]any{
-		"worker": map[string]any{
-			"ssh_strict_host_key_checking": "strict",
-		},
-	}
+	cfg.SetExtensionSection("worker", map[string]any{
+		"ssh_strict_host_key_checking": "strict",
+	})
 	wm.setConfig(cfg)
 	o.handleTick(ctx)
 	if got := strings.Count(buf.String(), warnMsg); got != 2 {
@@ -5496,12 +5492,10 @@ func TestHandleTick_WorkerWarningChangeDetection(t *testing.T) {
 	}
 
 	// Change SSHHosts while keeping the same invalid value — warning must be suppressed.
-	cfg.Extensions = map[string]any{
-		"worker": map[string]any{
-			"ssh_strict_host_key_checking": "strict",
-			"ssh_hosts":                    []any{"host-a"},
-		},
-	}
+	cfg.SetExtensionSection("worker", map[string]any{
+		"ssh_strict_host_key_checking": "strict",
+		"ssh_hosts":                    []any{"host-a"},
+	})
 	wm.setConfig(cfg)
 	o.handleTick(ctx)
 	if got := strings.Count(buf.String(), warnMsg); got != 2 {
@@ -5629,10 +5623,8 @@ func TestDispatch_RuleResolvedKindPersistsToRunHistory(t *testing.T) {
 	codexMCPConfigPath := filepath.Join(tmpDir, "codex-mcp.json")
 	writeMarkerMCPConfig(t, codexMCPConfigPath, "codex-marker")
 
-	cfg.Extensions = map[string]any{
-		"claude-code": map[string]any{"mcp_config": claudeMCPConfigPath},
-		"codex":       map[string]any{"mcp_config": codexMCPConfigPath},
-	}
+	cfg.SetExtensionSection("claude-code", map[string]any{"mcp_config": claudeMCPConfigPath})
+	cfg.SetExtensionSection("codex", map[string]any{"mcp_config": codexMCPConfigPath})
 
 	bugIssue := domain.Issue{
 		ID:         "id-bug",

--- a/internal/orchestrator/worker_test.go
+++ b/internal/orchestrator/worker_test.go
@@ -2911,9 +2911,7 @@ func TestRunWorkerAttempt_MCPConfig(t *testing.T) {
 			t.Fatalf("WriteFile operator config: %v", err)
 		}
 
-		cfg.Extensions = map[string]any{
-			"mock": map[string]any{"mcp_config": operatorPath},
-		}
+		cfg.SetExtensionSection("mock", map[string]any{"mcp_config": operatorPath})
 
 		var startCalled atomic.Bool
 		ec := newExitCapture()
@@ -2954,8 +2952,8 @@ func TestRunWorkerAttempt_MCPConfig(t *testing.T) {
 		}
 	})
 
-	// Extension lookup: operator mcp_config from cfg.Extensions[agentKind]
-	// must be merged into the generated .sortie/mcp.json.
+	// Extension lookup: operator mcp_config from the agent kind's own
+	// extension section must be merged into the generated .sortie/mcp.json.
 	t.Run("operator_config_merged_from_extensions", func(t *testing.T) {
 		t.Parallel()
 
@@ -2975,9 +2973,7 @@ func TestRunWorkerAttempt_MCPConfig(t *testing.T) {
 			t.Fatalf("WriteFile operator config: %v", err)
 		}
 
-		cfg.Extensions = map[string]any{
-			"mock": map[string]any{"mcp_config": operatorPath},
-		}
+		cfg.SetExtensionSection("mock", map[string]any{"mcp_config": operatorPath})
 
 		var capturedMCPConfigPath atomic.Value
 		ec := newExitCapture()
@@ -3068,10 +3064,8 @@ func TestRunWorkerAttempt_MCPConfig(t *testing.T) {
 			t.Fatalf("WriteFile routed operator config: %v", err)
 		}
 
-		cfg.Extensions = map[string]any{
-			"claude-code": map[string]any{"mcp_config": defaultPath},
-			"codex":       map[string]any{"mcp_config": routedPath},
-		}
+		cfg.SetExtensionSection("claude-code", map[string]any{"mcp_config": defaultPath})
+		cfg.SetExtensionSection("codex", map[string]any{"mcp_config": routedPath})
 
 		var capturedMCPConfigPath atomic.Value
 		ec := newExitCapture()
@@ -3162,10 +3156,8 @@ func TestRunWorkerAttempt_MCPConfig(t *testing.T) {
 			t.Fatalf("WriteFile: %v", err)
 		}
 
-		cfg.Extensions = map[string]any{
-			// Relative path — worker must resolve it via filepath.Dir(WorkflowPath).
-			"mock": map[string]any{"mcp_config": relName},
-		}
+		// Relative path — worker must resolve it via filepath.Dir(WorkflowPath).
+		cfg.SetExtensionSection("mock", map[string]any{"mcp_config": relName})
 
 		var capturedMCPConfigPath atomic.Value
 		ec := newExitCapture()
@@ -3254,9 +3246,7 @@ func TestRunWorkerAttempt_MCPConfig(t *testing.T) {
 			if configCalls.Add(1) > 1 {
 				operatorPath = secondOperatorPath
 			}
-			cfg.Extensions = map[string]any{
-				"mock": map[string]any{"mcp_config": operatorPath},
-			}
+			cfg.SetExtensionSection("mock", map[string]any{"mcp_config": operatorPath})
 			return cfg
 		}
 

--- a/internal/server/token_rates.go
+++ b/internal/server/token_rates.go
@@ -20,19 +20,19 @@ type TokenRateConfig struct {
 // on the dashboard.
 type TokenRates map[string]TokenRateConfig
 
-// ParseTokenRates extracts and validates token rates from the
-// Extensions map produced by config parsing. Returns nil rates when
-// the "token_rates" key is absent or empty. Warnings are advisory
-// and do not prevent boot.
-func ParseTokenRates(extensions map[string]any) (TokenRates, []string) {
-	raw, ok := extensions["token_rates"]
-	if !ok || raw == nil {
+// ParseTokenRates extracts and validates token rates from the raw
+// "token_rates" extension value. present tells whether the key
+// existed in the extensions map at all, distinguishing an absent key
+// from one holding a nil value. Returns nil rates when the key is
+// absent or empty. Warnings are advisory and do not prevent boot.
+func ParseTokenRates(rawSection any, present bool) (TokenRates, []string) {
+	if !present || rawSection == nil {
 		return nil, nil
 	}
 
-	topMap, ok := raw.(map[string]any)
+	topMap, ok := rawSection.(map[string]any)
 	if !ok {
-		return nil, []string{fmt.Sprintf("token_rates: expected map, got %T", raw)}
+		return nil, []string{fmt.Sprintf("token_rates: expected map, got %T", rawSection)}
 	}
 	if len(topMap) == 0 {
 		return nil, nil

--- a/internal/server/token_rates_test.go
+++ b/internal/server/token_rates_test.go
@@ -205,7 +205,8 @@ func TestParseTokenRates(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			got, warnings := ParseTokenRates(tt.extensions)
+			rawSection, present := tt.extensions["token_rates"]
+			got, warnings := ParseTokenRates(rawSection, present)
 
 			if len(warnings) != tt.wantWarnings {
 				t.Errorf("ParseTokenRates warnings = %d, want %d: %v", len(warnings), tt.wantWarnings, warnings)


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Fix

**Intent:** `ServiceConfig.Extensions` was indexable by any package with an agent kind of its own choosing, the same writable shape that produced the kind-confusion defect fixed by #924 at its one live call site. Unexport the field and give `internal/config` a closed accessor set that every outside caller goes through, closing that shape for good and guarding it with a new AST contract check.

**Related Issues:** #927

### 🧭 Reviewer Guide

**Complexity:** Medium

#### Entry Point

`internal/config/config.go` - `ServiceConfig.Extensions` is renamed to the unexported `extensions`, with `ExtensionSection`, `ExtensionValue`, and `SetExtensionSection` added as the closed accessor set. Every other file in this change narrows a caller that used to receive the whole map down to the section or value it actually indexes.

#### Sensitive Areas

- `internal/server/token_rates.go`: `ParseTokenRates` is the one migrated function whose absent-versus-present-but-not-an-object distinction is load-bearing; it now takes the raw section and a presence flag instead of the whole map so both arms (silent on absence, warning on a present non-object value) stay intact.
- `internal/config/extensions_contract_test.go`: new AST contract checker that forbids indexing the extensions map outside its accessor allow-list, calling an accessor with a non-literal section name, or passing the workflow default agent kind to the typed producer added by #924; paired with a `_DetectsViolations` companion asserting each rule fires.
- `cmd/sortie/resolve.go`: the five server and logging resolvers (`resolveServerPort`, `resolveServerHost`, `hasServerPortExtension`, `resolveLogLevel`, `resolveLogFormat`) are narrowed to take the section directly, each preserving its existing default for an absent or non-object section.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes - `ServiceConfig.Extensions` was only reachable from within this repository, and every caller is migrated in this same change.
- **Migrations/State:** No migrations or state changes.
