### PR TITLE
feat(agent): declare each adapter's MCP config disposition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   held by a full slot.
   ([#920](https://github.com/sortie-ai/sortie/issues/920))
 
+- `sortie validate` now reports a warning when an agent block sets
+  `mcp_config` for an agent kind that never receives the generated MCP
+  configuration file. `claude-code` and `copilot-cli` pass that file to
+  the agent process; `codex`, `kiro` and `opencode` do not, so an
+  `mcp_config` value in one of their blocks had no effect and nothing
+  said so. The reference documentation now states which kinds consume
+  the file. It is a warning and not an error: such a configuration
+  stays valid, the run proceeds, and the exit code is unchanged.
+  ([#928](https://github.com/sortie-ai/sortie/issues/928))
+
 ### Fixed
 
 - A malformed end-of-turn notification from the `codex app-server` no

--- a/docs/codex-adapter-notes.md
+++ b/docs/codex-adapter-notes.md
@@ -60,7 +60,7 @@ The prompt half. The worker appends the tool advertisement on the first turn of 
 
 The dispatch path itself is complete and covered by tests, so what is missing is the wiring, not the mechanism.
 
-The generated MCP configuration path is copied into session state and never read again. This adapter writes no MCP configuration and passes no MCP argument.
+The generated MCP configuration path is discarded: the adapter neither stores it nor reads it. This adapter writes no MCP configuration and passes no MCP argument.
 
 Whether Sortie's tools reach an agent at all is a per-adapter property, and this is the adapter where the answer is currently no.
 

--- a/docs/workflow-reference.md
+++ b/docs/workflow-reference.md
@@ -2410,6 +2410,10 @@ Each adapter (tracker or agent) may define configuration in a top-level object n
 after its `kind` value. These values are passed through to the adapter without validation
 by the orchestrator core.
 
+A session dispatched by a `dispatch.rules` entry to an agent kind other than the workflow
+default reads that kind's own block, on every attempt of that session. The block named by
+`agent.kind` applies only to sessions no rule routed elsewhere.
+
 **File tracker adapter:**
 
 ```yaml
@@ -2615,6 +2619,38 @@ bound. A turn that goes silent is caught first by `agent.stall_timeout_ms`.
 **MCP:** Under `KIRO_API_KEY` authentication the backend `GetProfile` gate
 disables MCP. A workspace `mcp.json` is not loaded and `--require-mcp-startup`
 is unreachable, so MCP-dependent workflows cannot run on the API-key path.
+
+**MCP configuration and the generated file:**
+
+For every agent kind, the worker writes a generated MCP configuration file into the
+session workspace at `.sortie/mcp.json`. It always carries Sortie's own `sortie-tools`
+server. When the session's own agent block sets `mcp_config`, the servers declared in
+the file that key names are merged into the generated copy; the operator's file itself
+is never modified, and a file that already declares a server named `sortie-tools` fails
+the attempt.
+
+Which adapters hand that generated file to the agent process differs by kind:
+
+| Agent kind | Generated file reaches the agent | How |
+| --- | --- | --- |
+| `claude-code` | Yes | passed to `--mcp-config` |
+| `copilot-cli` | Yes | passed to `--additional-mcp-config` as `@<path>` |
+| `codex` | No | the adapter passes no MCP argument |
+| `kiro` | No | the backend profile gate disables MCP under API-key authentication |
+| `opencode` | No | the adapter passes no MCP configuration to the agent process |
+| `mock` | No | the adapter launches no process |
+
+Setting `mcp_config` in a block belonging to a kind in a `No` row therefore has no
+effect on the agent. `sortie validate` reports that combination as a warning naming the
+kind. It is a warning and not an error: such a configuration stays valid, the run
+proceeds, and the exit code is unchanged.
+
+`claude-code.mcp_config` is documented in the Claude Code table above. The Copilot CLI
+reads the same key:
+
+| Field | Type | Default | Description |
+| --- | --- | --- | --- |
+| `copilot-cli.mcp_config` | string | _(absent)_ | Path to an MCP server configuration JSON file, resolved relative to the directory holding WORKFLOW.md when it is not absolute. The worker reads that file, merges its own `sortie-tools` server into a generated copy under the workspace, and passes the copy to `--additional-mcp-config` prefixed with `@`, which is how the Copilot CLI reads a configuration from a file. The operator's file is never modified. A file that already declares a `sortie-tools` server fails the attempt. |
 
 **Custom or future adapters (illustrative example):**
 

--- a/docs/workflow-reference.md
+++ b/docs/workflow-reference.md
@@ -2410,9 +2410,12 @@ Each adapter (tracker or agent) may define configuration in a top-level object n
 after its `kind` value. These values are passed through to the adapter without validation
 by the orchestrator core.
 
-A session dispatched by a `dispatch.rules` entry to an agent kind other than the workflow
-default reads that kind's own block, on every attempt of that session. The block named by
-`agent.kind` applies only to sessions no rule routed elsewhere.
+A session reads the block belonging to the agent kind it was dispatched on, and reads it
+again on every attempt of that session. That kind is the one a matching `dispatch.rules`
+entry selected, otherwise `dispatch.default.agent`, otherwise `agent.kind`, following the
+fallback chain in [Section 2.11](#211-dispatch--rule-based-routing). The block named by
+`agent.kind` therefore applies only when neither a matching rule nor the dispatch default
+chose another kind.
 
 **File tracker adapter:**
 

--- a/internal/agent/agentcore/mcp_contract_test.go
+++ b/internal/agent/agentcore/mcp_contract_test.go
@@ -75,9 +75,14 @@ func mcpCompositeLitKeyValue(expr ast.Expr, key string) ast.Expr {
 }
 
 // mcpPackageReferencesIdentifier reports whether any file in files
-// contains the bare identifier name anywhere in its syntax tree,
-// which catches both a plain reference and a selector's trailing
-// field name (e.g. params.MCPConfigPath).
+// reads name as the trailing field of a selector expression, which is
+// the form an adapter takes when it reads the worker-generated path
+// off its start-session parameters. A declaration of the same name,
+// and a bare identifier, are deliberately not reads: a package that
+// only declares a field called MCPConfigPath hands nothing to the
+// agent process, so it must neither satisfy the supported rule nor
+// breach the unsupported one. The match stays syntactic, resolving no
+// symbol, so this check does not become a type-checking pass.
 func mcpPackageReferencesIdentifier(files []*ast.File, name string) bool {
 	for _, file := range files {
 		found := false
@@ -85,7 +90,7 @@ func mcpPackageReferencesIdentifier(files []*ast.File, name string) bool {
 			if found {
 				return false
 			}
-			if ident, ok := n.(*ast.Ident); ok && ident.Name == name {
+			if sel, ok := n.(*ast.SelectorExpr); ok && sel.Sel.Name == name {
 				found = true
 				return false
 			}
@@ -336,7 +341,9 @@ func init() {
 	})
 }
 
-var _ = MCPConfigPath
+func start(params domain.StartSessionParams) string {
+	return params.MCPConfigPath
+}
 `,
 			wantCount: 1,
 		},
@@ -389,13 +396,54 @@ func init() {
 	})
 }
 
-func useParams(mcpConfigPath string) []string {
-	return []string{"--mcp-config", mcpConfigPath}
+func useParams(params domain.StartSessionParams) []string {
+	return []string{"--mcp-config", params.MCPConfigPath}
 }
-
-var _ = MCPConfigPath
 `,
 			wantCount: 0,
+		},
+		{
+			// A field named MCPConfigPath is a declaration, not a read.
+			// The package hands nothing to the agent process, so an
+			// unsupported declaration is not in breach.
+			name:    "Y2 negative: declaring a field of the same name is not a read",
+			dirName: "fixture",
+			src: `package fixture
+
+import "github.com/sortie-ai/sortie/internal/registry"
+
+func init() {
+	registry.Agents.RegisterWithMeta("fixture", newFixtureAdapter, registry.AgentMeta{
+		MCPInjection: registry.MCPInjectionUnsupported,
+	})
+}
+
+type sessionParams struct {
+	MCPConfigPath string
+}
+`,
+			wantCount: 0,
+		},
+		{
+			// The mirror of the case above: a declaration must not let a
+			// package claim supported without ever reading the path.
+			name:    "Y3: declaring a field of the same name does not satisfy supported",
+			dirName: "fixture",
+			src: `package fixture
+
+import "github.com/sortie-ai/sortie/internal/registry"
+
+func init() {
+	registry.Agents.RegisterWithMeta("fixture", newFixtureAdapter, registry.AgentMeta{
+		MCPInjection: registry.MCPInjectionSupported,
+	})
+}
+
+type sessionParams struct {
+	MCPConfigPath string
+}
+`,
+			wantCount: 1,
 		},
 		{
 			name:    "a package this walk never observed registering draws no violation",

--- a/internal/agent/agentcore/mcp_contract_test.go
+++ b/internal/agent/agentcore/mcp_contract_test.go
@@ -77,30 +77,53 @@ func mcpCompositeLitKeyValue(expr ast.Expr, key string) ast.Expr {
 // mcpPackageReferencesIdentifier reports whether any file in files
 // reads name as the trailing field of a selector expression, which is
 // the form an adapter takes when it reads the worker-generated path
-// off its start-session parameters. A declaration of the same name,
-// and a bare identifier, are deliberately not reads: a package that
-// only declares a field called MCPConfigPath hands nothing to the
-// agent process, so it must neither satisfy the supported rule nor
-// breach the unsupported one. The match stays syntactic, resolving no
-// symbol, so this check does not become a type-checking pass.
+// off its start-session parameters. Three shapes are deliberately not
+// reads, because none of them hands anything to the agent process: a
+// declaration of a field with the same name, a bare identifier, and
+// the target of a plain assignment. A package matching only one of
+// them must neither satisfy the supported rule nor breach the
+// unsupported one. The match stays syntactic, resolving no symbol, so
+// this check does not become a type-checking pass.
 func mcpPackageReferencesIdentifier(files []*ast.File, name string) bool {
 	for _, file := range files {
-		found := false
-		ast.Inspect(file, func(n ast.Node) bool {
-			if found {
-				return false
-			}
-			if sel, ok := n.(*ast.SelectorExpr); ok && sel.Sel.Name == name {
-				found = true
-				return false
-			}
-			return true
-		})
-		if found {
+		if fileReadsSelector(file, name) {
 			return true
 		}
 	}
 	return false
+}
+
+// fileReadsSelector reports whether file contains a selector
+// expression naming name in a position that reads it. Assignment
+// targets are collected first and excluded from the second pass;
+// compound assignments are left in, since an operator such as += reads
+// the field before it writes it.
+func fileReadsSelector(file *ast.File, name string) bool {
+	assigned := make(map[ast.Node]bool)
+	ast.Inspect(file, func(n ast.Node) bool {
+		assign, ok := n.(*ast.AssignStmt)
+		if !ok || assign.Tok != token.ASSIGN {
+			return true
+		}
+		for _, lhs := range assign.Lhs {
+			assigned[lhs] = true
+		}
+		return true
+	})
+
+	found := false
+	ast.Inspect(file, func(n ast.Node) bool {
+		if found {
+			return false
+		}
+		sel, ok := n.(*ast.SelectorExpr)
+		if !ok || sel.Sel.Name != name || assigned[sel] {
+			return true
+		}
+		found = true
+		return false
+	})
+	return found
 }
 
 // mcpRegistrationFacts scans every file of one package for a call to
@@ -444,6 +467,79 @@ type sessionParams struct {
 }
 `,
 			wantCount: 1,
+		},
+		{
+			// Assigning to the field on a by-value parameter writes to a
+			// local copy and hands nothing over, so it is not a read.
+			name:    "Y2 negative: writing the field is not a read",
+			dirName: "fixture",
+			src: `package fixture
+
+import (
+	"github.com/sortie-ai/sortie/internal/domain"
+	"github.com/sortie-ai/sortie/internal/registry"
+)
+
+func init() {
+	registry.Agents.RegisterWithMeta("fixture", newFixtureAdapter, registry.AgentMeta{
+		MCPInjection: registry.MCPInjectionUnsupported,
+	})
+}
+
+func start(params domain.StartSessionParams) {
+	params.MCPConfigPath = ""
+}
+`,
+			wantCount: 0,
+		},
+		{
+			// The mirror: a write must not let a package claim supported.
+			name:    "Y3: writing the field does not satisfy supported",
+			dirName: "fixture",
+			src: `package fixture
+
+import (
+	"github.com/sortie-ai/sortie/internal/domain"
+	"github.com/sortie-ai/sortie/internal/registry"
+)
+
+func init() {
+	registry.Agents.RegisterWithMeta("fixture", newFixtureAdapter, registry.AgentMeta{
+		MCPInjection: registry.MCPInjectionSupported,
+	})
+}
+
+func start(params domain.StartSessionParams) {
+	params.MCPConfigPath = ""
+}
+`,
+			wantCount: 1,
+		},
+		{
+			// A read on the right-hand side of an assignment is still a
+			// read; only the target of one is excluded.
+			name:    "Y3: reading the field on an assignment right-hand side satisfies supported",
+			dirName: "fixture",
+			src: `package fixture
+
+import (
+	"github.com/sortie-ai/sortie/internal/domain"
+	"github.com/sortie-ai/sortie/internal/registry"
+)
+
+func init() {
+	registry.Agents.RegisterWithMeta("fixture", newFixtureAdapter, registry.AgentMeta{
+		MCPInjection: registry.MCPInjectionSupported,
+	})
+}
+
+func start(params domain.StartSessionParams) string {
+	var path string
+	path = params.MCPConfigPath
+	return path
+}
+`,
+			wantCount: 0,
 		},
 		{
 			name:    "a package this walk never observed registering draws no violation",

--- a/internal/agent/agentcore/mcp_contract_test.go
+++ b/internal/agent/agentcore/mcp_contract_test.go
@@ -1,0 +1,456 @@
+package agentcore
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// mcpContractRegistryImportPath is the import path the checker
+// resolves the "registry" package qualifier from, per file, rather
+// than assuming the literal identifier "registry".
+const mcpContractRegistryImportPath = "github.com/sortie-ai/sortie/internal/registry"
+
+// mcpConfigPathIdentifier is the bare identifier rules Y2 and Y3 look
+// for across a package's non-test files. Files feeding the check are
+// parsed without comments, so a doc comment naming the field, as
+// kiro's and opencode's package godoc both do, is never a reference.
+const mcpConfigPathIdentifier = "MCPConfigPath"
+
+// mcpContractUndeclaredSelector is the selector name a meta literal
+// carries when a package spells the zero value out explicitly rather
+// than omitting the key; it is treated identically to an omitted key.
+const mcpContractUndeclaredSelector = "MCPInjectionUndeclared"
+
+// mcpContractAllowlist names the packages under internal/agent/ this
+// check exempts because they register no agent kind, and why. A
+// package absent from this map that this walk reaches is expected to
+// register an agent kind and declare a disposition.
+var mcpContractAllowlist = map[string]string{
+	"agentcore":       "the shared decision package itself; registers no agent kind",
+	"agenttest":       "the conformance-assertion package itself; registers no agent kind",
+	"dispositiontest": "test-only fixture support package; registers no agent kind",
+	"procutil":        "process-launch helper package; registers no agent kind",
+	"sshutil":         "SSH helper package; registers no agent kind",
+}
+
+// mcpContractViolation describes one place a package breaks the MCP
+// injection declaration invariant.
+type mcpContractViolation struct {
+	pos  token.Position
+	text string
+}
+
+// mcpContractPackage carries one package's identity and its parsed
+// non-test files.
+type mcpContractPackage struct {
+	dirName string
+	files   []*ast.File
+}
+
+// mcpCompositeLitKeyValue returns the value expression of the field
+// keyed by the given identifier name in the composite literal expr
+// denotes, or nil when expr is not such a literal or carries no such
+// key.
+func mcpCompositeLitKeyValue(expr ast.Expr, key string) ast.Expr {
+	lit, ok := expr.(*ast.CompositeLit)
+	if !ok {
+		return nil
+	}
+	for _, elt := range lit.Elts {
+		kv, ok := elt.(*ast.KeyValueExpr)
+		if !ok {
+			continue
+		}
+		if ident, ok := kv.Key.(*ast.Ident); ok && ident.Name == key {
+			return kv.Value
+		}
+	}
+	return nil
+}
+
+// mcpPackageReferencesIdentifier reports whether any file in files
+// contains the bare identifier name anywhere in its syntax tree,
+// which catches both a plain reference and a selector's trailing
+// field name (e.g. params.MCPConfigPath).
+func mcpPackageReferencesIdentifier(files []*ast.File, name string) bool {
+	for _, file := range files {
+		found := false
+		ast.Inspect(file, func(n ast.Node) bool {
+			if found {
+				return false
+			}
+			if ident, ok := n.(*ast.Ident); ok && ident.Name == name {
+				found = true
+				return false
+			}
+			return true
+		})
+		if found {
+			return true
+		}
+	}
+	return false
+}
+
+// mcpRegistrationFacts scans every file of one package for a call to
+// registry.Agents.Register or registry.Agents.RegisterWithMeta,
+// resolving the "registry" qualifier from each file's own imports. It
+// reports whether the package registers an agent kind at all, and,
+// for RegisterWithMeta, the selector name of the MCPInjection value
+// carried in the meta literal ("" when Register was used, or when the
+// literal carries no MCPInjection key).
+func mcpRegistrationFacts(fset *token.FileSet, files []*ast.File) (registers bool, declared string, pos token.Position) {
+	for _, file := range files {
+		registryIdent := resolveImportName(file, mcpContractRegistryImportPath)
+		if registryIdent == "" {
+			continue
+		}
+
+		ast.Inspect(file, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			outer, ok := call.Fun.(*ast.SelectorExpr)
+			if !ok {
+				return true
+			}
+			inner, ok := outer.X.(*ast.SelectorExpr)
+			if !ok {
+				return true
+			}
+			ident, ok := inner.X.(*ast.Ident)
+			if !ok || ident.Name != registryIdent || inner.Sel.Name != "Agents" {
+				return true
+			}
+
+			switch outer.Sel.Name {
+			case "Register":
+				registers = true
+				pos = fset.Position(call.Pos())
+			case "RegisterWithMeta":
+				registers = true
+				pos = fset.Position(call.Pos())
+				if len(call.Args) < 3 {
+					return true
+				}
+				val := mcpCompositeLitKeyValue(call.Args[2], "MCPInjection")
+				sel, ok := val.(*ast.SelectorExpr)
+				if !ok {
+					return true
+				}
+				if selIdent, ok := sel.X.(*ast.Ident); ok && selIdent.Name == registryIdent {
+					declared = sel.Sel.Name
+				}
+			}
+			return true
+		})
+	}
+	return registers, declared, pos
+}
+
+// checkMCPContractPackage evaluates rules Y1, Y2, and Y3 against pkg,
+// honoring the allowlist entries in mcpContractAllowlist. A package
+// this walk never observes registering an agent kind draws no
+// violation, since only a registering package can declare a
+// disposition at all.
+func checkMCPContractPackage(fset *token.FileSet, pkg mcpContractPackage) []mcpContractViolation {
+	if _, exempt := mcpContractAllowlist[pkg.dirName]; exempt {
+		return nil
+	}
+
+	registers, declared, pos := mcpRegistrationFacts(fset, pkg.files)
+	if !registers {
+		return nil
+	}
+
+	if declared == "" || declared == mcpContractUndeclaredSelector {
+		return []mcpContractViolation{{
+			pos:  pos,
+			text: "registers an agent kind but declares no non-empty MCPInjection",
+		}}
+	}
+
+	referencesPath := mcpPackageReferencesIdentifier(pkg.files, mcpConfigPathIdentifier)
+
+	var violations []mcpContractViolation
+	switch declared {
+	case "MCPInjectionUnsupported":
+		if referencesPath {
+			violations = append(violations, mcpContractViolation{
+				pos:  pos,
+				text: "declares MCPInjectionUnsupported but non-test files reference " + mcpConfigPathIdentifier,
+			})
+		}
+	case "MCPInjectionSupported":
+		if !referencesPath {
+			violations = append(violations, mcpContractViolation{
+				pos:  pos,
+				text: "declares MCPInjectionSupported but non-test files never reference " + mcpConfigPathIdentifier,
+			})
+		}
+	}
+	return violations
+}
+
+// TestMCPInjectionContractInvariant walks the non-test Go files under
+// internal/agent/, grouped by package directory, and fails when a
+// package outside mcpContractAllowlist registers an agent kind and
+// either declares no non-empty MCPInjection, declares
+// MCPInjectionUnsupported while its non-test files reference
+// MCPConfigPath, or declares MCPInjectionSupported while its non-test
+// files never reference it.
+func TestMCPInjectionContractInvariant(t *testing.T) {
+	root := ".."
+
+	fset := token.NewFileSet()
+	packages := map[string]*mcpContractPackage{}
+	var dirOrder []string
+	parsed := 0
+
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() {
+			if d.Name() == "testdata" {
+				return filepath.SkipDir
+			}
+			if _, exempt := mcpContractAllowlist[d.Name()]; exempt {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+
+		dir := filepath.Dir(path)
+		pkg, seen := packages[dir]
+		if !seen {
+			pkg = &mcpContractPackage{dirName: filepath.Base(dir)}
+			packages[dir] = pkg
+			dirOrder = append(dirOrder, dir)
+		}
+
+		file, parseErr := parser.ParseFile(fset, path, nil, parser.SkipObjectResolution)
+		if parseErr != nil {
+			t.Errorf("parse %s: %v", path, parseErr)
+			return nil
+		}
+		pkg.files = append(pkg.files, file)
+		parsed++
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk %s: %v", root, err)
+	}
+	if parsed == 0 {
+		t.Fatalf("root %s yielded no parsed Go files, want at least one", root)
+	}
+
+	sort.Strings(dirOrder)
+	for _, dir := range dirOrder {
+		for _, v := range checkMCPContractPackage(fset, *packages[dir]) {
+			t.Errorf("%s: %s", v.pos, v.text)
+		}
+	}
+}
+
+// TestCheckMCPContractPackage_DetectsViolations pins the checker's own
+// logic against inline source fixtures, independent of the current
+// state of any adapter package, so a regression in a rule is caught
+// even when every real adapter happens to comply. Each fixture is
+// parsed the same way the walking test parses production files:
+// without comments, so the negative fixture proves comment immunity
+// rather than merely asserting it.
+func TestCheckMCPContractPackage_DetectsViolations(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		dirName   string
+		src       string
+		wantCount int
+	}{
+		{
+			name:    "Y1: a kind registered through plain Register declares nothing",
+			dirName: "fixture",
+			src: `package fixture
+
+import "github.com/sortie-ai/sortie/internal/registry"
+
+func init() {
+	registry.Agents.Register("fixture", newFixtureAdapter)
+}
+`,
+			wantCount: 1,
+		},
+		{
+			name:    "Y1: a RegisterWithMeta literal omitting MCPInjection declares nothing",
+			dirName: "fixture",
+			src: `package fixture
+
+import "github.com/sortie-ai/sortie/internal/registry"
+
+func init() {
+	registry.Agents.RegisterWithMeta("fixture", newFixtureAdapter, registry.AgentMeta{
+		RequiresCommand: true,
+	})
+}
+`,
+			wantCount: 1,
+		},
+		{
+			name:    "Y1: a literal spelling out the zero value is still undeclared",
+			dirName: "fixture",
+			src: `package fixture
+
+import "github.com/sortie-ai/sortie/internal/registry"
+
+func init() {
+	registry.Agents.RegisterWithMeta("fixture", newFixtureAdapter, registry.AgentMeta{
+		MCPInjection: registry.MCPInjectionUndeclared,
+	})
+}
+`,
+			wantCount: 1,
+		},
+		{
+			name:    "Y2: declares unsupported but a non-test file references MCPConfigPath",
+			dirName: "fixture",
+			src: `package fixture
+
+import "github.com/sortie-ai/sortie/internal/registry"
+
+func init() {
+	registry.Agents.RegisterWithMeta("fixture", newFixtureAdapter, registry.AgentMeta{
+		MCPInjection: registry.MCPInjectionUnsupported,
+	})
+}
+
+var _ = MCPConfigPath
+`,
+			wantCount: 1,
+		},
+		{
+			name:    "Y3: declares supported but no non-test file ever references MCPConfigPath",
+			dirName: "fixture",
+			src: `package fixture
+
+import "github.com/sortie-ai/sortie/internal/registry"
+
+func init() {
+	registry.Agents.RegisterWithMeta("fixture", newFixtureAdapter, registry.AgentMeta{
+		MCPInjection: registry.MCPInjectionSupported,
+	})
+}
+`,
+			wantCount: 1,
+		},
+		{
+			// The doc comment names MCPConfigPath, but the check parses
+			// without comments, so this fixture must draw zero violations.
+			// Without this fixture, nothing stops a later rewrite from
+			// parsing comments and taking kiro's and opencode's package
+			// godoc with it.
+			name:    "Y2 negative: a comment-only mention of MCPConfigPath is not a reference",
+			dirName: "fixture",
+			src: `package fixture
+
+import "github.com/sortie-ai/sortie/internal/registry"
+
+// MCPConfigPath is ignored; this adapter passes no MCP argument.
+func init() {
+	registry.Agents.RegisterWithMeta("fixture", newFixtureAdapter, registry.AgentMeta{
+		MCPInjection: registry.MCPInjectionUnsupported,
+	})
+}
+`,
+			wantCount: 0,
+		},
+		{
+			name:    "a compliant Supported package referencing MCPConfigPath in real code is accepted",
+			dirName: "fixture",
+			src: `package fixture
+
+import "github.com/sortie-ai/sortie/internal/registry"
+
+func init() {
+	registry.Agents.RegisterWithMeta("fixture", newFixtureAdapter, registry.AgentMeta{
+		MCPInjection: registry.MCPInjectionSupported,
+	})
+}
+
+func useParams(mcpConfigPath string) []string {
+	return []string{"--mcp-config", mcpConfigPath}
+}
+
+var _ = MCPConfigPath
+`,
+			wantCount: 0,
+		},
+		{
+			name:    "a package this walk never observed registering draws no violation",
+			dirName: "fixture",
+			src: `package fixture
+
+func helper() string {
+	return "no registration here"
+}
+`,
+			wantCount: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			fset := token.NewFileSet()
+			file, err := parser.ParseFile(fset, "fixture.go", tt.src, parser.SkipObjectResolution)
+			if err != nil {
+				t.Fatalf("parser.ParseFile: %v", err)
+			}
+
+			pkg := mcpContractPackage{dirName: tt.dirName, files: []*ast.File{file}}
+			got := checkMCPContractPackage(fset, pkg)
+			if len(got) != tt.wantCount {
+				t.Errorf("checkMCPContractPackage() returned %d violations, want %d: %+v", len(got), tt.wantCount, got)
+			}
+		})
+	}
+}
+
+// TestCheckMCPContractPackage_AllowlistedPackageDrawsNoViolation pins
+// that a package named in mcpContractAllowlist is exempt from every
+// rule, even one whose fixture would otherwise trip Y1.
+func TestCheckMCPContractPackage_AllowlistedPackageDrawsNoViolation(t *testing.T) {
+	t.Parallel()
+
+	const src = `package fixture
+
+import "github.com/sortie-ai/sortie/internal/registry"
+
+func init() {
+	registry.Agents.Register("fixture", newFixtureAdapter)
+}
+`
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "fixture.go", src, parser.SkipObjectResolution)
+	if err != nil {
+		t.Fatalf("parser.ParseFile: %v", err)
+	}
+
+	pkg := mcpContractPackage{dirName: "procutil", files: []*ast.File{file}}
+	got := checkMCPContractPackage(fset, pkg)
+	if len(got) != 0 {
+		t.Errorf("checkMCPContractPackage() for an allowlisted dirName returned %d violations, want 0: %+v", len(got), got)
+	}
+}

--- a/internal/agent/agentcore/mcp_contract_test.go
+++ b/internal/agent/agentcore/mcp_contract_test.go
@@ -609,6 +609,54 @@ func start(params domain.StartSessionParams, xs []string) {
 			wantCount: 1,
 		},
 		{
+			// A single-target range clause assigns to the key, which is
+			// the other of the two branches a range target can take.
+			name:    "Y2 negative: a range key target is not a read",
+			dirName: "fixture",
+			src: `package fixture
+
+import (
+	"github.com/sortie-ai/sortie/internal/domain"
+	"github.com/sortie-ai/sortie/internal/registry"
+)
+
+func init() {
+	registry.Agents.RegisterWithMeta("fixture", newFixtureAdapter, registry.AgentMeta{
+		MCPInjection: registry.MCPInjectionUnsupported,
+	})
+}
+
+func start(params domain.StartSessionParams, xs map[string]int) {
+	for params.MCPConfigPath = range xs {
+	}
+}
+`,
+			wantCount: 0,
+		},
+		{
+			name:    "Y3: a range key target does not satisfy supported",
+			dirName: "fixture",
+			src: `package fixture
+
+import (
+	"github.com/sortie-ai/sortie/internal/domain"
+	"github.com/sortie-ai/sortie/internal/registry"
+)
+
+func init() {
+	registry.Agents.RegisterWithMeta("fixture", newFixtureAdapter, registry.AgentMeta{
+		MCPInjection: registry.MCPInjectionSupported,
+	})
+}
+
+func start(params domain.StartSessionParams, xs map[string]int) {
+	for params.MCPConfigPath, _ = range xs {
+	}
+}
+`,
+			wantCount: 1,
+		},
+		{
 			// Ranging over the field reads it; only a target is excluded.
 			name:    "Y3: ranging over the field is a read",
 			dirName: "fixture",

--- a/internal/agent/agentcore/mcp_contract_test.go
+++ b/internal/agent/agentcore/mcp_contract_test.go
@@ -28,9 +28,13 @@ const mcpConfigPathIdentifier = "MCPConfigPath"
 const mcpContractUndeclaredSelector = "MCPInjectionUndeclared"
 
 // mcpContractAllowlist names the packages under internal/agent/ this
-// check exempts because they register no agent kind, and why. A
-// package absent from this map that this walk reaches is expected to
-// register an agent kind and declare a disposition.
+// check exempts, and why: each is a support package that registers no
+// agent kind. The exemption is belt alongside braces, because
+// checkMCPContractPackage already draws no violation from a package
+// that registers nothing; naming them keeps a later change to
+// registration detection from starting to judge them. What puts a
+// package under the rules is registering a kind, never its absence
+// from this map.
 var mcpContractAllowlist = map[string]string{
 	"agentcore":       "the shared decision package itself; registers no agent kind",
 	"agenttest":       "the conformance-assertion package itself; registers no agent kind",
@@ -95,18 +99,33 @@ func mcpPackageReferencesIdentifier(files []*ast.File, name string) bool {
 
 // fileReadsSelector reports whether file contains a selector
 // expression naming name in a position that reads it. Assignment
-// targets are collected first and excluded from the second pass;
-// compound assignments are left in, since an operator such as += reads
-// the field before it writes it.
+// targets are collected first and excluded from the second pass.
+// Compound assignments are left in, since an operator such as += reads
+// the field before it writes it, as is an increment for the same
+// reason. A plain assignment and a range clause are the only two
+// statement forms whose target can be a selector, so collecting both
+// closes the set.
 func fileReadsSelector(file *ast.File, name string) bool {
 	assigned := make(map[ast.Node]bool)
 	ast.Inspect(file, func(n ast.Node) bool {
-		assign, ok := n.(*ast.AssignStmt)
-		if !ok || assign.Tok != token.ASSIGN {
-			return true
-		}
-		for _, lhs := range assign.Lhs {
-			assigned[lhs] = true
+		switch stmt := n.(type) {
+		case *ast.AssignStmt:
+			if stmt.Tok != token.ASSIGN {
+				return true
+			}
+			for _, lhs := range stmt.Lhs {
+				assigned[lhs] = true
+			}
+		case *ast.RangeStmt:
+			if stmt.Tok != token.ASSIGN {
+				return true
+			}
+			if stmt.Key != nil {
+				assigned[stmt.Key] = true
+			}
+			if stmt.Value != nil {
+				assigned[stmt.Value] = true
+			}
 		}
 		return true
 	})
@@ -537,6 +556,81 @@ func start(params domain.StartSessionParams) string {
 	var path string
 	path = params.MCPConfigPath
 	return path
+}
+`,
+			wantCount: 0,
+		},
+		{
+			// A range clause with "=" assigns to existing lvalues, so a
+			// selector used as its target is written, not read.
+			name:    "Y2 negative: a range-assignment target is not a read",
+			dirName: "fixture",
+			src: `package fixture
+
+import (
+	"github.com/sortie-ai/sortie/internal/domain"
+	"github.com/sortie-ai/sortie/internal/registry"
+)
+
+func init() {
+	registry.Agents.RegisterWithMeta("fixture", newFixtureAdapter, registry.AgentMeta{
+		MCPInjection: registry.MCPInjectionUnsupported,
+	})
+}
+
+func start(params domain.StartSessionParams, xs []string) {
+	for _, params.MCPConfigPath = range xs {
+	}
+}
+`,
+			wantCount: 0,
+		},
+		{
+			name:    "Y3: a range-assignment target does not satisfy supported",
+			dirName: "fixture",
+			src: `package fixture
+
+import (
+	"github.com/sortie-ai/sortie/internal/domain"
+	"github.com/sortie-ai/sortie/internal/registry"
+)
+
+func init() {
+	registry.Agents.RegisterWithMeta("fixture", newFixtureAdapter, registry.AgentMeta{
+		MCPInjection: registry.MCPInjectionSupported,
+	})
+}
+
+func start(params domain.StartSessionParams, xs []string) {
+	for _, params.MCPConfigPath = range xs {
+	}
+}
+`,
+			wantCount: 1,
+		},
+		{
+			// Ranging over the field reads it; only a target is excluded.
+			name:    "Y3: ranging over the field is a read",
+			dirName: "fixture",
+			src: `package fixture
+
+import (
+	"github.com/sortie-ai/sortie/internal/domain"
+	"github.com/sortie-ai/sortie/internal/registry"
+)
+
+func init() {
+	registry.Agents.RegisterWithMeta("fixture", newFixtureAdapter, registry.AgentMeta{
+		MCPInjection: registry.MCPInjectionSupported,
+	})
+}
+
+func start(params domain.StartSessionParams) int {
+	n := 0
+	for range params.MCPConfigPath {
+		n++
+	}
+	return n
 }
 `,
 			wantCount: 0,

--- a/internal/agent/agentcore/mcp_contract_test.go
+++ b/internal/agent/agentcore/mcp_contract_test.go
@@ -222,9 +222,10 @@ func TestMCPInjectionContractInvariant(t *testing.T) {
 			if d.Name() == "testdata" {
 				return filepath.SkipDir
 			}
-			if _, exempt := mcpContractAllowlist[d.Name()]; exempt {
-				return filepath.SkipDir
-			}
+			// An allowlisted directory is not pruned here, only exempted
+			// by checkMCPContractPackage when its own package is judged.
+			// Pruning would also hide any package nested below it, which
+			// would let a registering package escape the walk entirely.
 			return nil
 		}
 		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {

--- a/internal/agent/agenttest/mcp.go
+++ b/internal/agent/agenttest/mcp.go
@@ -1,6 +1,7 @@
 package agenttest
 
 import (
+	"slices"
 	"strings"
 	"testing"
 
@@ -19,10 +20,15 @@ type MCPLaunchSurface struct {
 // launch surface an adapter actually produced for a session carrying
 // mcpConfigPath. The caller captures surface from its own command
 // construction (argument slice, environment slice, or both) for a
-// session whose MCPConfigPath is mcpConfigPath; the check is substring
-// containment against every element of surface.Args and surface.Env,
-// so an adapter that passes the path inside a composed argument (for
-// example, prefixed with an '@') is still detected.
+// session whose MCPConfigPath is mcpConfigPath.
+//
+// An element carries the path when it is the path exactly, or when the
+// path is its tail behind a single composition marker: an adapter may
+// pass the path prefixed with an '@', and an environment entry carries
+// it as KEY=<path>. An element that continues past the path names a
+// different file, so it is not a match; the workspace holds a
+// <path>.tmp beside the generated file during generation, and an
+// adapter handed that one has delivered nothing.
 func AssertMCPInjection(t *testing.T, declared registry.MCPInjection, mcpConfigPath string, surface MCPLaunchSurface) {
 	t.Helper()
 	assertMCPInjection(t, declared, mcpConfigPath, surface)
@@ -47,21 +53,11 @@ func assertMCPInjection(t mcpInjectionReporter, declared registry.MCPInjection, 
 		return
 	}
 
-	hit := false
-	for _, arg := range surface.Args {
-		if strings.Contains(arg, mcpConfigPath) {
-			hit = true
-			break
-		}
-	}
-	if !hit {
-		for _, env := range surface.Env {
-			if strings.Contains(env, mcpConfigPath) {
-				hit = true
-				break
-			}
-		}
-	}
+	hit := slices.ContainsFunc(surface.Args, func(arg string) bool {
+		return carriesMCPConfigPath(arg, mcpConfigPath)
+	}) || slices.ContainsFunc(surface.Env, func(env string) bool {
+		return carriesMCPConfigPath(env, mcpConfigPath)
+	})
 
 	switch declared {
 	case registry.MCPInjectionSupported:
@@ -76,5 +72,25 @@ func assertMCPInjection(t mcpInjectionReporter, declared registry.MCPInjection, 
 		t.Errorf("declared = %q, want a kind that declares an MCP injection disposition", declared)
 	default:
 		t.Errorf("declared = %q, want a supported or unsupported MCP injection disposition", declared)
+	}
+}
+
+// carriesMCPConfigPath reports whether one launch-surface element hands
+// path to the agent process. The path must be the whole element, or its
+// tail behind one composition marker, so an element naming a neighbouring
+// file such as <path>.tmp is not read as a delivery.
+func carriesMCPConfigPath(elem, path string) bool {
+	if elem == path {
+		return true
+	}
+	prefix, ok := strings.CutSuffix(elem, path)
+	if !ok || prefix == "" {
+		return false
+	}
+	switch prefix[len(prefix)-1] {
+	case '@', '=':
+		return true
+	default:
+		return false
 	}
 }

--- a/internal/agent/agenttest/mcp.go
+++ b/internal/agent/agenttest/mcp.go
@@ -74,5 +74,7 @@ func assertMCPInjection(t mcpInjectionReporter, declared registry.MCPInjection, 
 		}
 	case registry.MCPInjectionUndeclared:
 		t.Errorf("declared = %q, want a kind that declares an MCP injection disposition", declared)
+	default:
+		t.Errorf("declared = %q, want a supported or unsupported MCP injection disposition", declared)
 	}
 }

--- a/internal/agent/agenttest/mcp.go
+++ b/internal/agent/agenttest/mcp.go
@@ -1,0 +1,78 @@
+package agenttest
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/sortie-ai/sortie/internal/registry"
+)
+
+// MCPLaunchSurface is every channel by which an adapter can hand the
+// generated MCP config path to the agent process for one session.
+type MCPLaunchSurface struct {
+	Args []string
+	Env  []string
+}
+
+// AssertMCPInjection fails t unless declared, the kind's registered
+// [registry.MCPInjection] disposition, agrees with surface, the
+// launch surface an adapter actually produced for a session carrying
+// mcpConfigPath. The caller captures surface from its own command
+// construction (argument slice, environment slice, or both) for a
+// session whose MCPConfigPath is mcpConfigPath; the check is substring
+// containment against every element of surface.Args and surface.Env,
+// so an adapter that passes the path inside a composed argument (for
+// example, prefixed with an '@') is still detected.
+func AssertMCPInjection(t *testing.T, declared registry.MCPInjection, mcpConfigPath string, surface MCPLaunchSurface) {
+	t.Helper()
+	assertMCPInjection(t, declared, mcpConfigPath, surface)
+}
+
+// mcpInjectionReporter is the minimal reporting surface
+// assertMCPInjection needs; [*testing.T] satisfies it. Splitting the
+// check out from [AssertMCPInjection] lets a package-internal test
+// drive the same failure-detection logic against a lightweight
+// double, since a *testing.T's own failure state cannot itself be
+// inspected without failing the enclosing test.
+type mcpInjectionReporter interface {
+	Helper()
+	Errorf(format string, args ...any)
+}
+
+func assertMCPInjection(t mcpInjectionReporter, declared registry.MCPInjection, mcpConfigPath string, surface MCPLaunchSurface) {
+	t.Helper()
+
+	if mcpConfigPath == "" {
+		t.Errorf("mcpConfigPath is empty, want a non-empty path to look for")
+		return
+	}
+
+	hit := false
+	for _, arg := range surface.Args {
+		if strings.Contains(arg, mcpConfigPath) {
+			hit = true
+			break
+		}
+	}
+	if !hit {
+		for _, env := range surface.Env {
+			if strings.Contains(env, mcpConfigPath) {
+				hit = true
+				break
+			}
+		}
+	}
+
+	switch declared {
+	case registry.MCPInjectionSupported:
+		if !hit {
+			t.Errorf("declared = %q, hit = %t, want the surface to carry mcpConfigPath", declared, hit)
+		}
+	case registry.MCPInjectionUnsupported:
+		if hit {
+			t.Errorf("declared = %q, hit = %t, want the surface not to carry mcpConfigPath", declared, hit)
+		}
+	case registry.MCPInjectionUndeclared:
+		t.Errorf("declared = %q, want a kind that declares an MCP injection disposition", declared)
+	}
+}

--- a/internal/agent/agenttest/mcp_test.go
+++ b/internal/agent/agenttest/mcp_test.go
@@ -1,0 +1,124 @@
+package agenttest
+
+import (
+	"testing"
+
+	"github.com/sortie-ai/sortie/internal/registry"
+)
+
+// mcpFakeReporter is a minimal [mcpInjectionReporter] double that
+// records Errorf calls instead of failing the enclosing test, so a
+// deliberately-violating input can be driven through
+// assertMCPInjection without reddening the smoke test itself.
+type mcpFakeReporter struct {
+	errors []string
+}
+
+func (f *mcpFakeReporter) Helper() {}
+
+func (f *mcpFakeReporter) Errorf(format string, args ...any) {
+	f.errors = append(f.errors, format)
+}
+
+// TestAssertMCPInjection_Passing exercises the exported
+// AssertMCPInjection entry point against a real *testing.T for both
+// declared dispositions: Supported with a surface that carries the
+// path, and Unsupported with a surface that does not. Neither case
+// must report a failure.
+func TestAssertMCPInjection_Passing(t *testing.T) {
+	t.Parallel()
+
+	t.Run("supported with the path in Args", func(t *testing.T) {
+		t.Parallel()
+
+		AssertMCPInjection(t, registry.MCPInjectionSupported, "/ws/.sortie/mcp.json",
+			MCPLaunchSurface{Args: []string{"--mcp-config", "/ws/.sortie/mcp.json"}})
+	})
+
+	t.Run("supported with the path composed inside an argument", func(t *testing.T) {
+		t.Parallel()
+
+		AssertMCPInjection(t, registry.MCPInjectionSupported, "/ws/.sortie/mcp.json",
+			MCPLaunchSurface{Args: []string{"--additional-mcp-config", "@/ws/.sortie/mcp.json"}})
+	})
+
+	t.Run("supported with the path in Env", func(t *testing.T) {
+		t.Parallel()
+
+		AssertMCPInjection(t, registry.MCPInjectionSupported, "/ws/.sortie/mcp.json",
+			MCPLaunchSurface{Env: []string{"MCP_CONFIG=/ws/.sortie/mcp.json"}})
+	})
+
+	t.Run("unsupported with an empty surface", func(t *testing.T) {
+		t.Parallel()
+
+		AssertMCPInjection(t, registry.MCPInjectionUnsupported, "/ws/.sortie/mcp.json", MCPLaunchSurface{})
+	})
+
+	t.Run("unsupported with an unrelated surface", func(t *testing.T) {
+		t.Parallel()
+
+		AssertMCPInjection(t, registry.MCPInjectionUnsupported, "/ws/.sortie/mcp.json",
+			MCPLaunchSurface{Args: []string{"--model", "gpt-5"}})
+	})
+}
+
+// TestAssertMCPInjection_Violating drives assertMCPInjection through a
+// fakeReporter for every failure arm the check defines: an empty path,
+// Supported declared but not hit, Unsupported declared but hit, and
+// Undeclared regardless of the surface. Each case must record at least
+// one failure.
+func TestAssertMCPInjection_Violating(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		declared      registry.MCPInjection
+		mcpConfigPath string
+		surface       MCPLaunchSurface
+	}{
+		{
+			name:          "empty mcpConfigPath",
+			declared:      registry.MCPInjectionSupported,
+			mcpConfigPath: "",
+			surface:       MCPLaunchSurface{Args: []string{"--mcp-config", "/ws/.sortie/mcp.json"}},
+		},
+		{
+			name:          "supported declared but the surface carries nothing",
+			declared:      registry.MCPInjectionSupported,
+			mcpConfigPath: "/ws/.sortie/mcp.json",
+			surface:       MCPLaunchSurface{},
+		},
+		{
+			name:          "unsupported declared but the surface carries the path in Args",
+			declared:      registry.MCPInjectionUnsupported,
+			mcpConfigPath: "/ws/.sortie/mcp.json",
+			surface:       MCPLaunchSurface{Args: []string{"--mcp-config", "/ws/.sortie/mcp.json"}},
+		},
+		{
+			name:          "unsupported declared but the surface carries the path in Env",
+			declared:      registry.MCPInjectionUnsupported,
+			mcpConfigPath: "/ws/.sortie/mcp.json",
+			surface:       MCPLaunchSurface{Env: []string{"MCP_CONFIG=/ws/.sortie/mcp.json"}},
+		},
+		{
+			name:          "undeclared regardless of the surface",
+			declared:      registry.MCPInjectionUndeclared,
+			mcpConfigPath: "/ws/.sortie/mcp.json",
+			surface:       MCPLaunchSurface{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			reporter := &mcpFakeReporter{}
+			assertMCPInjection(reporter, tt.declared, tt.mcpConfigPath, tt.surface)
+
+			if len(reporter.errors) == 0 {
+				t.Errorf("assertMCPInjection(%s) recorded no failures, want at least one", tt.name)
+			}
+		})
+	}
+}

--- a/internal/agent/agenttest/mcp_test.go
+++ b/internal/agent/agenttest/mcp_test.go
@@ -61,6 +61,19 @@ func TestAssertMCPInjection_Passing(t *testing.T) {
 		AssertMCPInjection(t, registry.MCPInjectionUnsupported, "/ws/.sortie/mcp.json",
 			MCPLaunchSurface{Args: []string{"--model", "gpt-5"}})
 	})
+
+	t.Run("unsupported with a neighbouring file that extends the path", func(t *testing.T) {
+		t.Parallel()
+
+		// The workspace holds mcp.json.tmp beside the generated file
+		// during generation. An element naming it delivers nothing, so
+		// an unsupported adapter must not be failed for carrying it.
+		AssertMCPInjection(t, registry.MCPInjectionUnsupported, "/ws/.sortie/mcp.json",
+			MCPLaunchSurface{
+				Args: []string{"--mcp-config", "/ws/.sortie/mcp.json.tmp"},
+				Env:  []string{"BACKUP=/ws/.sortie/mcp.json-disabled"},
+			})
+	})
 }
 
 // TestAssertMCPInjection_Violating drives assertMCPInjection through a
@@ -106,6 +119,21 @@ func TestAssertMCPInjection_Violating(t *testing.T) {
 			declared:      registry.MCPInjectionUndeclared,
 			mcpConfigPath: "/ws/.sortie/mcp.json",
 			surface:       MCPLaunchSurface{},
+		},
+		{
+			// Delivering a neighbouring file is not delivering the
+			// generated one: a supported adapter handed <path>.tmp has
+			// injected nothing, and the assertion must say so.
+			name:          "supported declared but the surface carries only a file extending the path",
+			declared:      registry.MCPInjectionSupported,
+			mcpConfigPath: "/ws/.sortie/mcp.json",
+			surface:       MCPLaunchSurface{Args: []string{"--mcp-config", "/ws/.sortie/mcp.json.tmp"}},
+		},
+		{
+			name:          "supported declared but an env value only extends the path",
+			declared:      registry.MCPInjectionSupported,
+			mcpConfigPath: "/ws/.sortie/mcp.json",
+			surface:       MCPLaunchSurface{Env: []string{"BACKUP=/ws/.sortie/mcp.json-disabled"}},
 		},
 		{
 			// MCPInjection is a string type, so a value outside the

--- a/internal/agent/agenttest/mcp_test.go
+++ b/internal/agent/agenttest/mcp_test.go
@@ -107,6 +107,17 @@ func TestAssertMCPInjection_Violating(t *testing.T) {
 			mcpConfigPath: "/ws/.sortie/mcp.json",
 			surface:       MCPLaunchSurface{},
 		},
+		{
+			// MCPInjection is a string type, so a value outside the
+			// declared set is representable. Without the switch's
+			// default arm such a value matches no case and the
+			// assertion returns having checked nothing, which is the
+			// one way this helper can pass while measuring nothing.
+			name:          "a disposition outside the declared set",
+			declared:      registry.MCPInjection("conditional"),
+			mcpConfigPath: "/ws/.sortie/mcp.json",
+			surface:       MCPLaunchSurface{},
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/agent/claude/claude.go
+++ b/internal/agent/claude/claude.go
@@ -27,6 +27,7 @@ func init() {
 	registry.Agents.RegisterWithMeta("claude-code", NewClaudeCodeAdapter, registry.AgentMeta{
 		RequiresCommand:     true,
 		ValidateAgentConfig: validateConfig,
+		MCPInjection:        registry.MCPInjectionSupported,
 	})
 }
 

--- a/internal/agent/claude/command_test.go
+++ b/internal/agent/claude/command_test.go
@@ -4,6 +4,9 @@ import (
 	"slices"
 	"strings"
 	"testing"
+
+	"github.com/sortie-ai/sortie/internal/agent/agenttest"
+	"github.com/sortie-ai/sortie/internal/registry"
 )
 
 // assertHasArgPair fails if flag and value do not appear as consecutive
@@ -34,6 +37,24 @@ func newFirstTurnState(mcpConfigPath string) *sessionState {
 		isContinuation:  false,
 		mcpConfigPath:   mcpConfigPath,
 	}
+}
+
+// TestMCPInjectionConformance proves claude-code's real buildArgs
+// output carries the generated MCP config path, matching its declared
+// disposition.
+func TestMCPInjectionConformance(t *testing.T) {
+	t.Parallel()
+
+	declared, ok := registry.Agents.Meta("claude-code")
+	if !ok {
+		t.Fatal(`registry.Agents.Meta("claude-code") reported not registered`)
+	}
+
+	const mcpConfigPath = "/ws/.sortie/mcp.json"
+	state := newFirstTurnState(mcpConfigPath)
+	args := buildArgs(state, 1, "do work", passthroughConfig{SessionPersistence: true})
+
+	agenttest.AssertMCPInjection(t, declared.MCPInjection, mcpConfigPath, agenttest.MCPLaunchSurface{Args: args})
 }
 
 func TestBuildArgs_MCPConfig(t *testing.T) {

--- a/internal/agent/codex/codex.go
+++ b/internal/agent/codex/codex.go
@@ -33,6 +33,7 @@ func init() {
 	registry.Agents.RegisterWithMeta("codex", NewCodexAdapter, registry.AgentMeta{
 		RequiresCommand:     true,
 		ValidateAgentConfig: validateConfig,
+		MCPInjection:        registry.MCPInjectionUnsupported,
 	})
 }
 
@@ -76,8 +77,6 @@ type sessionState struct {
 	// object has been processed for this run. Monotone: set true once
 	// and never cleared.
 	usageMeasured bool
-
-	mcpConfigPath string
 
 	// mu guards proc, waitCh, stdin, stdout, and stderrCollector for
 	// concurrent access from StopSession and the event read loop.
@@ -127,10 +126,9 @@ func (a *CodexAdapter) StartSession(ctx context.Context, params domain.StartSess
 	}
 
 	state := &sessionState{
-		target:        target,
-		agentConfig:   params.AgentConfig,
-		mcpConfigPath: params.MCPConfigPath,
-		acc:           agentcore.NewRunUsage(),
+		target:      target,
+		agentConfig: params.AgentConfig,
+		acc:         agentcore.NewRunUsage(),
 	}
 
 	var cmd *exec.Cmd

--- a/internal/agent/codex/command_test.go
+++ b/internal/agent/codex/command_test.go
@@ -14,9 +14,10 @@ import (
 // TestMCPInjectionConformance proves codex's real launch surface never
 // carries the generated MCP config path, matching its declared
 // disposition. codex builds no CLI-flag argument slice for MCP; its
-// only launch surface is [agentcore.ResolveLaunchTarget]'s Args, so the
-// override command below stands in for "codex app-server" to keep the
-// check independent of whether a codex binary is installed on the host
+// only launch surface is [agentcore.ResolveLaunchTarget]'s Args. A
+// non-empty AgentConfig.Command supersedes the default, so the
+// "codex app-server" argument below is never resolved and the check
+// does not depend on a codex binary being installed on the host
 // running the test.
 func TestMCPInjectionConformance(t *testing.T) {
 	t.Parallel()

--- a/internal/agent/codex/command_test.go
+++ b/internal/agent/codex/command_test.go
@@ -4,8 +4,42 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/sortie-ai/sortie/internal/agent/agentcore"
+	"github.com/sortie-ai/sortie/internal/agent/agenttest"
 	"github.com/sortie-ai/sortie/internal/agent/sshutil"
+	"github.com/sortie-ai/sortie/internal/domain"
+	"github.com/sortie-ai/sortie/internal/registry"
 )
+
+// TestMCPInjectionConformance proves codex's real launch surface never
+// carries the generated MCP config path, matching its declared
+// disposition. codex builds no CLI-flag argument slice for MCP; its
+// only launch surface is [agentcore.ResolveLaunchTarget]'s Args, so the
+// override command below stands in for "codex app-server" to keep the
+// check independent of whether a codex binary is installed on the host
+// running the test.
+func TestMCPInjectionConformance(t *testing.T) {
+	t.Parallel()
+
+	declared, ok := registry.Agents.Meta("codex")
+	if !ok {
+		t.Fatal(`registry.Agents.Meta("codex") reported not registered`)
+	}
+
+	const mcpConfigPath = "/ws/.sortie/mcp.json"
+	params := domain.StartSessionParams{
+		WorkspacePath: t.TempDir(),
+		AgentConfig:   domain.AgentConfig{Command: "sh -c"},
+		MCPConfigPath: mcpConfigPath,
+	}
+
+	target, agentErr := agentcore.ResolveLaunchTarget(params, "codex app-server")
+	if agentErr != nil {
+		t.Fatalf("agentcore.ResolveLaunchTarget() error = %v", agentErr)
+	}
+
+	agenttest.AssertMCPInjection(t, declared.MCPInjection, mcpConfigPath, agenttest.MCPLaunchSurface{Args: target.Args})
+}
 
 func TestBuildSSHRemoteCmd(t *testing.T) {
 	t.Parallel()

--- a/internal/agent/copilot/command_test.go
+++ b/internal/agent/copilot/command_test.go
@@ -4,6 +4,9 @@ import (
 	"slices"
 	"strings"
 	"testing"
+
+	"github.com/sortie-ai/sortie/internal/agent/agenttest"
+	"github.com/sortie-ai/sortie/internal/registry"
 )
 
 // assertHasArgPair fails if flag and value do not appear as consecutive
@@ -124,6 +127,25 @@ func TestParsePassthroughConfig(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestMCPInjectionConformance proves copilot-cli's real buildArgs
+// output carries the generated MCP config path, matching its declared
+// disposition. The path is checked by substring containment because
+// buildArgs composes it as "@<path>".
+func TestMCPInjectionConformance(t *testing.T) {
+	t.Parallel()
+
+	declared, ok := registry.Agents.Meta("copilot-cli")
+	if !ok {
+		t.Fatal(`registry.Agents.Meta("copilot-cli") reported not registered`)
+	}
+
+	const mcpConfigPath = "/ws/.sortie/mcp.json"
+	state := &sessionState{mcpConfigPath: mcpConfigPath}
+	args := buildArgs(state, 1, "do work", passthroughConfig{})
+
+	agenttest.AssertMCPInjection(t, declared.MCPInjection, mcpConfigPath, agenttest.MCPLaunchSurface{Args: args})
 }
 
 func TestBuildArgs(t *testing.T) {

--- a/internal/agent/copilot/copilot.go
+++ b/internal/agent/copilot/copilot.go
@@ -41,6 +41,7 @@ func init() {
 	registry.Agents.RegisterWithMeta("copilot-cli", NewCopilotAdapter, registry.AgentMeta{
 		RequiresCommand:     true,
 		ValidateAgentConfig: validateConfig,
+		MCPInjection:        registry.MCPInjectionSupported,
 	})
 }
 

--- a/internal/agent/kiro/command_test.go
+++ b/internal/agent/kiro/command_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/sortie-ai/sortie/internal/agent/agenttest"
 	"github.com/sortie-ai/sortie/internal/registry"
 )
 
@@ -378,6 +379,24 @@ func TestBuildArgs_EmptyConfigDefaultsToTrustAllTools(t *testing.T) {
 			assertNoToken(t, args, "--trust-tools=")
 		})
 	}
+}
+
+// TestMCPInjectionConformance proves kiro's real buildArgs output
+// never carries the generated MCP config path, matching its declared
+// disposition. buildArgs takes no MCP config parameter at all, so the
+// path passed here reaches nothing by construction.
+func TestMCPInjectionConformance(t *testing.T) {
+	t.Parallel()
+
+	declared, ok := registry.Agents.Meta("kiro")
+	if !ok {
+		t.Fatal(`registry.Agents.Meta("kiro") reported not registered`)
+	}
+
+	const mcpConfigPath = "/ws/.sortie/mcp.json"
+	args := buildArgs(&sessionState{}, 1, "do work", passthroughConfig{})
+
+	agenttest.AssertMCPInjection(t, declared.MCPInjection, mcpConfigPath, agenttest.MCPLaunchSurface{Args: args})
 }
 
 func TestKiroRegistered(t *testing.T) {

--- a/internal/agent/kiro/kiro.go
+++ b/internal/agent/kiro/kiro.go
@@ -42,6 +42,7 @@ func init() {
 	registry.Agents.RegisterWithMeta("kiro", NewKiroAdapter, registry.AgentMeta{
 		RequiresCommand:     true,
 		ValidateAgentConfig: validateConfig,
+		MCPInjection:        registry.MCPInjectionUnsupported,
 	})
 }
 

--- a/internal/agent/mock/mock.go
+++ b/internal/agent/mock/mock.go
@@ -18,7 +18,9 @@ import (
 )
 
 func init() {
-	registry.Agents.Register("mock", NewMockAdapter)
+	registry.Agents.RegisterWithMeta("mock", NewMockAdapter, registry.AgentMeta{
+		MCPInjection: registry.MCPInjectionUnsupported,
+	})
 }
 
 // Compile-time interface satisfaction check.

--- a/internal/agent/mock/mock_test.go
+++ b/internal/agent/mock/mock_test.go
@@ -159,6 +159,22 @@ func TestRegistration(t *testing.T) {
 	}
 }
 
+// TestMCPInjectionConformance proves mock's declared disposition pins
+// its true behavior: it launches no process, so its launch surface is
+// empty. The call stays in place even though mock builds no launch
+// surface, because a kind with no call is a kind whose declaration
+// nothing checks.
+func TestMCPInjectionConformance(t *testing.T) {
+	t.Parallel()
+
+	declared, ok := registry.Agents.Meta("mock")
+	if !ok {
+		t.Fatal(`registry.Agents.Meta("mock") reported not registered`)
+	}
+
+	agenttest.AssertMCPInjection(t, declared.MCPInjection, "/ws/.sortie/mcp.json", agenttest.MCPLaunchSurface{})
+}
+
 func TestStartSession(t *testing.T) {
 	t.Parallel()
 

--- a/internal/agent/opencode/command_test.go
+++ b/internal/agent/opencode/command_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 
 	"github.com/sortie-ai/sortie/internal/agent/agentcore"
+	"github.com/sortie-ai/sortie/internal/agent/agenttest"
+	"github.com/sortie-ai/sortie/internal/registry"
 )
 
 // envLookup returns the value for key in an env []string slice.
@@ -207,6 +209,31 @@ func TestNewOpenCodeAdapter_ParsePassthroughConfig(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestMCPInjectionConformance proves opencode's real launch surface
+// never carries the generated MCP config path, matching its declared
+// disposition. Both channels the adapter builds are captured, not the
+// argument slice alone: opencode is the adapter that carries most of
+// its configuration through the environment, so an environment-only
+// leak would otherwise go unseen.
+func TestMCPInjectionConformance(t *testing.T) {
+	t.Parallel()
+
+	declared, ok := registry.Agents.Meta("opencode")
+	if !ok {
+		t.Fatal(`registry.Agents.Meta("opencode") reported not registered`)
+	}
+
+	const mcpConfigPath = "/ws/.sortie/mcp.json"
+	state := newTestSessionState("/workspace", "")
+	args := buildRunArgs(state, "do work", passthroughConfig{})
+	env, err := buildRunEnv([]string{"PATH=/usr/bin"}, passthroughConfig{})
+	if err != nil {
+		t.Fatalf("buildRunEnv() error = %v", err)
+	}
+
+	agenttest.AssertMCPInjection(t, declared.MCPInjection, mcpConfigPath, agenttest.MCPLaunchSurface{Args: args, Env: env})
 }
 
 func TestBuildRunArgs(t *testing.T) {

--- a/internal/agent/opencode/opencode.go
+++ b/internal/agent/opencode/opencode.go
@@ -5,6 +5,10 @@
 // stream carried nothing but opencode's masked generic server error, the
 // adapter consults `opencode models` to reconstruct the unknown-model
 // diagnostic.
+//
+// The adapter passes no MCP configuration to the agent process:
+// [domain.StartSessionParams] MCPConfigPath is ignored and no MCP startup
+// flag is passed.
 package opencode
 
 import (
@@ -34,6 +38,7 @@ func init() {
 	registry.Agents.RegisterWithMeta("opencode", NewOpenCodeAdapter, registry.AgentMeta{
 		RequiresCommand:     true,
 		ValidateAgentConfig: validateConfig,
+		MCPInjection:        registry.MCPInjectionUnsupported,
 	})
 }
 

--- a/internal/orchestrator/preflight.go
+++ b/internal/orchestrator/preflight.go
@@ -216,12 +216,27 @@ func ValidateDispatchConfig(params PreflightParams) PreflightResult {
 	// a block no run reads.
 	for _, kind := range orderedUniqueAgentKinds(cfg) {
 		agentMeta, registered := params.AgentRegistry.Meta(kind)
+		settings := config.ResolveAgentSettings(cfg, kind, "")
+
+		// A kind whose adapter never hands the generated MCP config
+		// path to the agent process cannot make use of an mcp_config
+		// value in its own block. This is evaluated for every kind,
+		// including one with no config validator (for example
+		// "mock"), so it is not folded behind the early continue
+		// below.
+		if registered && agentMeta.MCPInjection == registry.MCPInjectionUnsupported && settings.MCPConfigPath != "" {
+			warns = append(warns, PreflightWarning{
+				Check:   "agent.mcp_config",
+				Message: "mcp_config in the " + strconv.Quote(kind) + " block cannot reach the agent: this agent kind receives no MCP configuration",
+			})
+		}
+
 		if !registered || agentMeta.ValidateAgentConfig == nil {
 			continue
 		}
 		fields := registry.AgentConfigFields{
 			Kind:        kind,
-			Passthrough: config.AgentAdapterConfig(cfg, kind),
+			Passthrough: settings.Passthrough,
 		}
 		for _, d := range agentMeta.ValidateAgentConfig(fields) {
 			switch d.Severity {

--- a/internal/orchestrator/preflight_test.go
+++ b/internal/orchestrator/preflight_test.go
@@ -857,6 +857,168 @@ func TestValidateDispatchConfig_AgentConfigValidation(t *testing.T) {
 	})
 }
 
+// TestValidateDispatchConfig_MCPConfigWarning covers the five states an
+// mcp_config value in an agent kind's block can draw the "agent.mcp_config"
+// warning from: a non-injecting kind with the value set, a non-injecting
+// kind without it, an injecting kind with it, a kind the registry reports
+// unregistered, and a registered non-injecting kind whose adapter supplies
+// no config validator. The last state is mock's own shape and is the one
+// that reddens if the check is folded behind ValidateDispatchConfig's
+// existing "no validator" early continue, since that continue would skip
+// the warning for exactly the kind most likely to carry mcp_config in
+// practice.
+func TestValidateDispatchConfig_MCPConfigWarning(t *testing.T) {
+	t.Parallel()
+
+	t.Run("a non-injecting kind with mcp_config set draws one warning and no error", func(t *testing.T) {
+		t.Parallel()
+
+		params := validPreflightParams()
+		params.ConfigFunc = func() config.ServiceConfig {
+			cfg := config.ServiceConfig{
+				Tracker: config.TrackerConfig{Kind: "test-tracker", APIKey: "secret"},
+				Agent:   config.AgentConfig{Kind: "test-agent", Command: "/usr/bin/agent"},
+			}
+			cfg.SetExtensionSection("test-agent", map[string]any{"mcp_config": "/ws/.sortie/mcp.json"})
+			return cfg
+		}
+		params.AgentRegistry = &stubAgentRegistry{
+			getFunc: func(string) (registry.AgentConstructor, error) { return nil, nil },
+			metaFunc: func(string) (registry.AgentMeta, bool) {
+				return registry.AgentMeta{MCPInjection: registry.MCPInjectionUnsupported}, true
+			},
+		}
+
+		result := ValidateDispatchConfig(params)
+
+		requireWarnCheck(t, result, "agent.mcp_config")
+		requireNoCheck(t, result, "agent.mcp_config")
+		if !result.OK() {
+			t.Errorf("ValidateDispatchConfig().OK() = false, want true: a warning must not block dispatch")
+		}
+
+		// Exactly one warning per affected kind, and it names the kind,
+		// so an operator reading it knows which block to edit.
+		var got []PreflightWarning
+		for _, w := range result.Warnings {
+			if w.Check == "agent.mcp_config" {
+				got = append(got, w)
+			}
+		}
+		if len(got) != 1 {
+			t.Fatalf("ValidateDispatchConfig() produced %d agent.mcp_config warnings, want 1: %v", len(got), got)
+		}
+		if !strings.Contains(got[0].Message, "test-agent") {
+			t.Errorf("warning message = %q, want it to name the agent kind %q", got[0].Message, "test-agent")
+		}
+	})
+
+	t.Run("a non-injecting kind without mcp_config draws no warning", func(t *testing.T) {
+		t.Parallel()
+
+		params := validPreflightParams()
+		params.AgentRegistry = &stubAgentRegistry{
+			getFunc: func(string) (registry.AgentConstructor, error) { return nil, nil },
+			metaFunc: func(string) (registry.AgentMeta, bool) {
+				return registry.AgentMeta{MCPInjection: registry.MCPInjectionUnsupported}, true
+			},
+		}
+
+		result := ValidateDispatchConfig(params)
+
+		requireNoWarnCheck(t, result, "agent.mcp_config")
+	})
+
+	t.Run("an injecting kind with mcp_config draws no warning", func(t *testing.T) {
+		t.Parallel()
+
+		params := validPreflightParams()
+		params.ConfigFunc = func() config.ServiceConfig {
+			cfg := config.ServiceConfig{
+				Tracker: config.TrackerConfig{Kind: "test-tracker", APIKey: "secret"},
+				Agent:   config.AgentConfig{Kind: "test-agent", Command: "/usr/bin/agent"},
+			}
+			cfg.SetExtensionSection("test-agent", map[string]any{"mcp_config": "/ws/.sortie/mcp.json"})
+			return cfg
+		}
+		params.AgentRegistry = &stubAgentRegistry{
+			getFunc: func(string) (registry.AgentConstructor, error) { return nil, nil },
+			metaFunc: func(string) (registry.AgentMeta, bool) {
+				return registry.AgentMeta{MCPInjection: registry.MCPInjectionSupported}, true
+			},
+		}
+
+		result := ValidateDispatchConfig(params)
+
+		requireNoWarnCheck(t, result, "agent.mcp_config")
+	})
+
+	t.Run("a kind reached only through a dispatch rule that the registry reports unregistered draws no warning", func(t *testing.T) {
+		t.Parallel()
+
+		params := validPreflightParams()
+		params.ConfigFunc = func() config.ServiceConfig {
+			cfg := config.ServiceConfig{
+				Tracker: config.TrackerConfig{Kind: "test-tracker", APIKey: "secret"},
+				Agent:   config.AgentConfig{Kind: "test-agent", Command: "/usr/bin/agent"},
+				Dispatch: config.DispatchConfig{
+					Rules: []config.DispatchRule{
+						{Selection: config.DispatchSelection{AgentKind: "rule-agent"}},
+					},
+				},
+			}
+			cfg.SetExtensionSection("rule-agent", map[string]any{"mcp_config": "/ws/.sortie/mcp.json"})
+			return cfg
+		}
+		params.AgentRegistry = &stubAgentRegistry{
+			getFunc: func(string) (registry.AgentConstructor, error) { return nil, nil },
+			metaFunc: func(kind string) (registry.AgentMeta, bool) {
+				if kind == "rule-agent" {
+					return registry.AgentMeta{}, false
+				}
+				return registry.AgentMeta{MCPInjection: registry.MCPInjectionUnsupported}, true
+			},
+		}
+
+		result := ValidateDispatchConfig(params)
+
+		requireNoWarnCheck(t, result, "agent.mcp_config")
+	})
+
+	t.Run("mock's shape: registered, no config validator, block sets mcp_config draws one warning", func(t *testing.T) {
+		t.Parallel()
+
+		params := validPreflightParams()
+		params.ConfigFunc = func() config.ServiceConfig {
+			cfg := config.ServiceConfig{
+				Tracker: config.TrackerConfig{Kind: "test-tracker", APIKey: "secret"},
+				Agent:   config.AgentConfig{Kind: "test-agent", Command: "/usr/bin/agent"},
+				Dispatch: config.DispatchConfig{
+					Rules: []config.DispatchRule{
+						{Selection: config.DispatchSelection{AgentKind: "mock"}},
+					},
+				},
+			}
+			cfg.SetExtensionSection("mock", map[string]any{"mcp_config": "/ws/.sortie/mcp.json"})
+			return cfg
+		}
+		params.AgentRegistry = &stubAgentRegistry{
+			getFunc: func(string) (registry.AgentConstructor, error) { return nil, nil },
+			metaFunc: func(kind string) (registry.AgentMeta, bool) {
+				if kind == "mock" {
+					return registry.AgentMeta{MCPInjection: registry.MCPInjectionUnsupported}, true
+				}
+				return registry.AgentMeta{}, true
+			},
+		}
+
+		result := ValidateDispatchConfig(params)
+
+		requireWarnCheck(t, result, "agent.mcp_config")
+		requireNoCheck(t, result, "agent.mcp_config")
+	})
+}
+
 // TestValidateDispatchConfig_DefaultedTrackerStates covers the collision
 // rules re-run against the effective state lists, the ones a tracker
 // adapter fills from its own fallback when the workflow list is empty.

--- a/internal/registry/adapter_meta_test.go
+++ b/internal/registry/adapter_meta_test.go
@@ -8,6 +8,9 @@ import (
 
 	// Trigger adapter init() registrations.
 	_ "github.com/sortie-ai/sortie/internal/agent/claude"
+	_ "github.com/sortie-ai/sortie/internal/agent/codex"
+	_ "github.com/sortie-ai/sortie/internal/agent/copilot"
+	_ "github.com/sortie-ai/sortie/internal/agent/kiro"
 	_ "github.com/sortie-ai/sortie/internal/agent/mock"
 	_ "github.com/sortie-ai/sortie/internal/agent/opencode"
 	_ "github.com/sortie-ai/sortie/internal/scm/gitea"
@@ -106,23 +109,45 @@ func TestAdapterMeta_RealRegistrations(t *testing.T) {
 		t.Parallel()
 
 		tests := []struct {
-			name        string
-			kind        string
-			wantCommand bool
+			name             string
+			kind             string
+			wantCommand      bool
+			wantMCPInjection registry.MCPInjection
 		}{
 			{
-				name:        "claude-code requires command",
-				kind:        "claude-code",
-				wantCommand: true,
+				name:             "claude-code requires command and declares MCP injection supported",
+				kind:             "claude-code",
+				wantCommand:      true,
+				wantMCPInjection: registry.MCPInjectionSupported,
 			},
 			{
-				name:        "opencode requires command",
-				kind:        "opencode",
-				wantCommand: true,
+				name:             "copilot-cli requires command and declares MCP injection supported",
+				kind:             "copilot-cli",
+				wantCommand:      true,
+				wantMCPInjection: registry.MCPInjectionSupported,
 			},
 			{
-				name: "mock requires nothing",
-				kind: "mock",
+				name:             "codex requires command and declares MCP injection unsupported",
+				kind:             "codex",
+				wantCommand:      true,
+				wantMCPInjection: registry.MCPInjectionUnsupported,
+			},
+			{
+				name:             "kiro requires command and declares MCP injection unsupported",
+				kind:             "kiro",
+				wantCommand:      true,
+				wantMCPInjection: registry.MCPInjectionUnsupported,
+			},
+			{
+				name:             "opencode requires command and declares MCP injection unsupported",
+				kind:             "opencode",
+				wantCommand:      true,
+				wantMCPInjection: registry.MCPInjectionUnsupported,
+			},
+			{
+				name:             "mock requires nothing and declares MCP injection unsupported",
+				kind:             "mock",
+				wantMCPInjection: registry.MCPInjectionUnsupported,
 			},
 		}
 
@@ -137,6 +162,9 @@ func TestAdapterMeta_RealRegistrations(t *testing.T) {
 
 				if meta.RequiresCommand != tt.wantCommand {
 					t.Errorf("Agents.Meta(%q).RequiresCommand = %v, want %v", tt.kind, meta.RequiresCommand, tt.wantCommand)
+				}
+				if meta.MCPInjection != tt.wantMCPInjection {
+					t.Errorf("Agents.Meta(%q).MCPInjection = %q, want %q", tt.kind, meta.MCPInjection, tt.wantMCPInjection)
 				}
 			})
 		}

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -179,7 +179,32 @@ type AgentMeta struct {
 	// pipeline calls to run agent-specific config validation. Nil
 	// means no adapter-specific validation.
 	ValidateAgentConfig func(fields AgentConfigFields) []ValidationDiag
+
+	// MCPInjection declares what this adapter does with the
+	// worker-generated MCP config path today, not what the underlying
+	// CLI is capable of. The empty value means undeclared.
+	MCPInjection MCPInjection
 }
+
+// MCPInjection declares what an agent adapter does with the
+// worker-generated MCP config path. The value describes what the
+// adapter does with the path today, not what the underlying CLI is
+// capable of, and the empty value means undeclared.
+type MCPInjection string
+
+const (
+	// MCPInjectionUndeclared is the zero value: the adapter has not
+	// declared a disposition toward the generated MCP config path.
+	MCPInjectionUndeclared MCPInjection = ""
+
+	// MCPInjectionSupported declares that the adapter hands the
+	// generated MCP config path to the agent process.
+	MCPInjectionSupported MCPInjection = "supported"
+
+	// MCPInjectionUnsupported declares that the adapter never hands
+	// the generated MCP config path to the agent process.
+	MCPInjectionUnsupported MCPInjection = "unsupported"
+)
 
 // AgentConfigFields holds the config values passed to agent adapter
 // validation functions. This is a plain data struct that avoids


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Feat

**Intent:** The six agent adapters diverged in what they did with the worker-generated MCP config path, and nothing in CI signaled the divergence - `codex` copied it into a session field nothing read, `opencode` dropped it silently, and `mock` used the plain registration form. This makes MCP-config consumption a declared, structurally-enforced capability on each adapter registration, so an adapter can no longer change its mind about it without a test noticing.

**Related Issues:** #928

### 🧭 Reviewer Guide

**Complexity:** Medium

#### Entry Point

Start with `internal/registry/registry.go`, which adds the `MCPInjection` type (`undeclared` / `supported` / `unsupported`) and the `AgentMeta.MCPInjection` field. From there, `internal/agent/agentcore/mcp_contract_test.go` is the structural enforcement: an AST-based checker that walks every package under `internal/agent/` and fails if a package registering an agent kind omits a disposition, or if its non-test files reference the MCP config path identifier in contradiction to its declared disposition. `internal/agent/agenttest/mcp.go` is the runtime counterpart - `AssertMCPInjection` compares a declared disposition against the actual launch surface (args/env) an adapter's command construction produces, and every adapter package now calls it in its own tests (see `internal/agent/claude/command_test.go` for the pattern).

#### Sensitive Areas

- `internal/orchestrator/preflight.go`: adds the `sortie validate` warning for a kind whose block sets `mcp_config` but whose adapter declares `MCPInjectionUnsupported`. The check reads `config.ResolveAgentSettings` for every kind, including one with no config validator, so it had to be placed before the existing early `continue` in the per-kind loop rather than folded behind it.
- `internal/agent/codex/codex.go`: deletes the dead `sessionState.mcpConfigPath` field and its assignment now that the disposition is declared instead of silently carried.
- `internal/agent/mock/mock.go`: migrates from `registry.Agents.Register` to `RegisterWithMeta` so `mock` can declare a disposition too.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes. The new preflight check is a warning, not an error, and `sortie validate`'s exit code is unchanged.
- **Migrations/State:** No migrations or state changes.
