### PR TITLE
fix(orchestrator): suppress withheld-handoff failure on a terminal issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A workflow that sets `claude-code.session_persistence: false` is now rejected before the run starts, by `sortie validate` and at startup. The setting prevents Claude Code from resuming a session, so such a run previously failed partway through.
   ([#879](https://github.com/sortie-ai/sortie/issues/879))
 
+- An issue that reached a terminal state during a run no longer receives a session-failure comment, a failed run record, or a retry that is then discarded. Sortie now re-checks the issue's tracker state immediately before recording that kind of failure, and stays silent when the issue is already finished.
+  ([#887](https://github.com/sortie-ai/sortie/issues/887))
+
 ## [1.21.0] - 2026-08-20
 
 ### Fixed

--- a/docs/agent-to-orchestrator-protocol.md
+++ b/docs/agent-to-orchestrator-protocol.md
@@ -217,9 +217,12 @@ retry.
 
 The transition is additionally subject to the run's `tracker.handoff_evidence` verdict
 ([architecture Section 7.3](architecture/07-orchestration-state-machine.md#73-transition-triggers)).
-Where that verdict withholds the transition, no tracker write is attempted: the issue keeps its
-active state and its claim, and the exit takes the exponential-backoff failure path instead of
-releasing the claim.
+Where that verdict withholds the transition, the orchestrator re-reads the issue's tracker state
+once before recording the outcome. When that read does not find the issue terminal, no tracker
+write is attempted: the issue keeps its active state and its claim, and the exit takes the
+exponential-backoff failure path instead of releasing the claim. When that read does find the issue
+terminal, the exit releases the claim and records `succeeded` instead, exactly as it would have had
+the issue already been observed terminal.
 
 This distinction reflects the semantic difference between the two values: `blocked` means "I
 cannot proceed" (no completed work to hand off), while `needs-human-review` means "work is
@@ -520,9 +523,12 @@ without touching any label.
 Every row that performs the handoff is additionally subject to the run's
 `tracker.handoff_evidence` verdict
 ([architecture Section 7.3](architecture/07-orchestration-state-machine.md#73-transition-triggers)).
-Where the verdict withholds the transition, the issue keeps its active state and its claim, the
-run is recorded as failed with the verdict as its reason, and the exit takes the
-exponential-backoff failure path rather than the row's stated retry outcome.
+Where the verdict withholds the transition, the orchestrator re-reads the issue's tracker state
+once before recording the outcome. When that read does not find the issue terminal, the issue
+keeps its active state and its claim, the run is recorded as failed with the verdict as its
+reason, and the exit takes the exponential-backoff failure path rather than the row's stated
+retry outcome. When that read does find the issue terminal, the exit releases the claim and
+records `succeeded` instead.
 
 The semantic distinction drives the difference: `blocked` means the agent cannot proceed, so
 there is no completed work to hand off. `needs-human-review` means the agent completed its work

--- a/docs/agent-to-orchestrator-protocol.md
+++ b/docs/agent-to-orchestrator-protocol.md
@@ -257,6 +257,13 @@ Additionally, for `needs-human-review` only: when `tracker.handoff_state` is con
 issue is in an active tracker state, the orchestrator attempts the handoff transition between
 steps 6 and 8. See Section 2.3.2 for failure handling.
 
+Steps 7 and 8 carry one exception, also for `needs-human-review` only. Where the run's
+`tracker.handoff_evidence` verdict withholds that transition and the verification read described in
+Section 2.3.2 does not find the issue in a terminal state, the orchestrator keeps the issue claim
+and schedules a retry on the exponential-backoff failure path. That retry is a failure-path retry
+rather than a continuation retry, so step 2 still holds and the run takes no further turns. Where
+that read does find the issue terminal, steps 7 and 8 apply as written.
+
 For `needs-human-review`, after the orchestrator releases the claim, the issue becomes eligible
 for re-dispatch on a subsequent tracker poll if it still satisfies normal dispatch rules (active
 state, not claimed, not budget-exhausted, not parked). For `blocked`, where the dispatch drove

--- a/docs/architecture/07-orchestration-state-machine.md
+++ b/docs/architecture/07-orchestration-state-machine.md
@@ -85,8 +85,11 @@ Distinct terminal reasons are important because retry logic and logs differ.
   - Unconditional steps, taken on every normal exit: remove the running entry and update aggregate
     runtime totals. Every exit also persists exactly one completed run attempt to SQLite after any
     handoff-evidence verdict needed for its status is known and before scheduling a retry. The normal
-    exit-kind mapping supplies the status unless the policy withholds the transition; that outcome
-    records `failed` with the evidence verdict named as the cause (§19.2).
+    exit-kind mapping supplies the status, unless the policy withholds the transition and the
+    withheld verdict's own verification read (disposition 3 below) does not find the issue
+    terminal: in that case the run instead records `failed`, with the evidence verdict named as the
+    cause (§19.2). A withheld verdict whose verification read does find the issue terminal keeps
+    the exit-kind mapping's status.
   - The exit then takes exactly one disposition. The conditions are evaluated in the order below
     and the first match wins, so an earlier disposition overrides every later one:
 
@@ -101,9 +104,10 @@ Distinct terminal reasons are important because retry logic and logs differ.
        continue to either way.
     2. The freshest tracker observation for the issue reports a terminal state, resolved with
        precedence reconciliation's observation, then the worker's own per-turn observation, then
-       the dispatch-time snapshot. Suppress the handoff transition and the continuation retry,
-       cancel any pending retry, and release the claim. A terminal state is a decision already
-       made about this issue; overwriting it with the handoff state would undo it.
+       the dispatch-time snapshot, or the withheld path's own verification read below reports one
+       instead. Suppress the handoff transition and the continuation retry, cancel any pending
+       retry, and release the claim. A terminal state is a decision already made about this issue;
+       overwriting it with the handoff state would undo it.
     3. A handoff state is configured, the issue is still in an active state, the exit is not a
        blocked soft stop, and the dispatch drives issue state. Only where all four conditions hold,
        apply the run's frozen `tracker.handoff_evidence` policy as a fifth condition:
@@ -122,9 +126,14 @@ Distinct terminal reasons are important because retry logic and logs differ.
        schedules the continuation retry instead, unless the retry slot is already occupied, in which
        case the exit defers to the incumbent.
 
-       A verdict that withholds the write makes no tracker transition and leaves the issue in its
-       active state. Record the unsuccessful attempt, increment the consecutive-absence count, and
-       use the ordinary failure path with exponential backoff and retry-slot arbitration—not the
+       A verdict that withholds the write is, immediately before any of its effects, checked once
+       more against the tracker: a `fetch_issue_states_by_ids` read for the issue, gated the same
+       way the permit path's own pre-write read is gated. When that read reports a terminal state,
+       the exit takes disposition 2 above instead. Only when it does not—because no terminal states
+       are configured, the read reports an active state, the issue is absent from the response, or
+       the read fails—does the withheld verdict make no tracker transition and leave the issue in
+       its active state. Record the unsuccessful attempt, increment the consecutive-absence count,
+       and use the ordinary failure path with exponential backoff and retry-slot arbitration—not the
        short continuation path. When the count reaches its ceiling, park the issue and stop the
        sequence as specified in §14.2.
     4. Any other soft stop. Suppress the continuation retry, cancel any pending retry, and release

--- a/docs/architecture/11-issue-tracker-integration-contract.md
+++ b/docs/architecture/11-issue-tracker-integration-contract.md
@@ -115,8 +115,11 @@ itself observed:
   permits the write; `absence of work observed` withholds it; `evidence not determinable` permits it
   under `observed` and withholds it under `strict`; and `off` computes no verdict and preserves the
   four-condition decision. This condition can suppress a write and can never cause one. A withheld
-  outcome makes no handoff transition or pre-write verification call, leaves the issue in its active
-  state, and follows the failure and retry disposition in §14.2.
+  outcome is itself preceded by one verification read, gated the same way the permit path's own
+  pre-write read described below is gated. A terminal result from that read routes the exit to the
+  terminal disposition instead of the failure and retry disposition in §14.2. Otherwise the withheld
+  outcome makes no handoff transition, leaves the issue in its active state, and follows that
+  failure and retry disposition.
 
   A write that the evidence policy permits is still preceded by a terminal test against the freshest
   available observation of the issue's state and, when `tracker.terminal_states` is non-empty and

--- a/docs/architecture/18-logging-status-and-observability.md
+++ b/docs/architecture/18-logging-status-and-observability.md
@@ -20,12 +20,17 @@ Message formatting requirements:
 
 Handoff-evidence records are part of the required operator surface:
 
-- A withheld handoff emits a `Warn` record naming the verdict and carrying
-  `turns_completed` plus the resulting `consecutive_absences` count. The standard issue context
-  fields identify the affected issue.
+- A withheld verdict whose verification read (§11.5, §14.2) does not find the issue terminal emits
+  a `Warn` record naming the verdict and carrying `turns_completed` plus the resulting
+  `consecutive_absences` count. The standard issue context fields identify the affected issue.
+- A withheld verdict whose verification read does find the issue terminal emits an `Info` record at
+  the read site naming the discarded verdict, its reason, `state_source="verified"`, and
+  `turns_completed`, instead of the `Warn` record above. The terminal disposition's own `Info`
+  record then follows, carrying the verified state and the same `state_source="verified"` value.
 - An `evidence not determinable` verdict emits an `Info` record under both `observed` and `strict`,
   carrying the policy and `turns_completed`. Under `strict`, the separate withheld warning is also
-  emitted because that policy converts the verdict into the absence disposition.
+  emitted because that policy converts the verdict into the absence disposition, unless the
+  verification read above finds the issue terminal.
 - A run frozen to `tracker.handoff_evidence: off` emits none of these evidence records.
 
 Parking an issue, whichever trigger produced it, emits exactly one `Warn` record, message
@@ -441,7 +446,7 @@ Defined metrics (label sets and buckets are specified here; see ADR-0008 for his
 | `sortie_poll_cycles_total{result}` | Counter | Poll tick completions, partitioned by result (`success`, `error`, `skipped`). |
 | `sortie_tracker_requests_total{operation,result}` | Counter | Tracker adapter API calls, partitioned by operation (`fetch_candidates`, `fetch_issue`, `fetch_by_states`, `fetch_states_by_ids`, `fetch_states_by_identifiers`, `fetch_comments`, `fetch_blockers`, `transition`, `comment`, `add_label`) and result (`success`, `error`). |
 | `sortie_tracker_comments_total{lifecycle,result}` | Counter | Tracker comment attempts, partitioned by lifecycle point (`dispatch`, `completion`, `failure`) and result (`success`, `error`). |
-| `sortie_handoff_transitions_total{result}` | Counter | Handoff-state dispositions, partitioned by result (`success`, `error`, `skipped`, `withheld`). `withheld` means the handoff-evidence policy selected the absence failure path before any transition attempt, distinguishing it from an ordinary worker failure. `skipped` retains its two earlier causes and does not distinguish them: the issue was no longer in an active state at worker exit, or the issue was already reported terminal and the write was suppressed (Section 11.5). All four values are counted only when `tracker.handoff_state` is configured. |
+| `sortie_handoff_transitions_total{result}` | Counter | Handoff-state dispositions, partitioned by result (`success`, `error`, `skipped`, `withheld`). `withheld` means the handoff-evidence policy selected the absence failure path before any transition attempt, distinguishing it from an ordinary worker failure; a withholding verdict whose own verification read then finds the issue terminal does not increment this label, it increments `skipped` instead. `skipped` names three causes and does not distinguish them: the issue was no longer in an active state at worker exit, the issue was already reported terminal and the handoff write was suppressed (Section 11.5), or a withheld verdict's own verification read reported the issue terminal and suppressed the absence-failure recording (Section 14.2). All four values are counted only when `tracker.handoff_state` is configured. |
 | `sortie_dispatch_transitions_total{result}` | Counter | Dispatch-time in-progress transition attempts, partitioned by result (`success`, `error`, `skipped`). `skipped` indicates the issue was already in the target state. |
 | `sortie_issue_parks_total{reason}` | Counter | Issue park events, partitioned by reason (`agent_blocked`, `handoff_absence`). Incremented once per park, whichever trigger produced it. |
 | `sortie_dispatch_rule_match_total{layer,rule}` | Counter | Dispatch rule match outcomes, partitioned by resolution layer (`rule`, `default`, `fallback`) and matched rule name. Empty rule names report as `<none>` to bound label cardinality. |

--- a/docs/architecture/19-failure-model-and-recovery-strategy.md
+++ b/docs/architecture/19-failure-model-and-recovery-strategy.md
@@ -72,9 +72,13 @@
     above, on either admission path into the phase.
 
 - Withheld handoff evidence:
-  - Leave the issue in its active tracker state, record the run as `failed` with the evidence verdict
-    in its error reason, and schedule the ordinary exponential-backoff failure path. Do not use the
-    fixed-delay continuation path.
+  - Immediately before recording an absence failure, re-read the issue's tracker state once, gated
+    the same way the permit path's own pre-write read is gated (§11.5). A terminal result routes
+    the exit to the terminal disposition (§7.3) instead: no failure record, no failure comment, no
+    retry, no absence count. Only when that read finds no terminal state does the withheld
+    disposition below apply: leave the issue in its active tracker state, record the run as `failed`
+    with the evidence verdict in its error reason, and schedule the ordinary exponential-backoff
+    failure path. Do not use the fixed-delay continuation path.
   - Maintain a count of consecutive outcomes treated as handoff absences for each issue. `Absence of
     work observed` increments it, as does `evidence not determinable` under `strict`. A
     `work observed` verdict resets it to zero immediately; a later handoff-write error cannot restore
@@ -204,8 +208,13 @@ Sortie uses SQLite persistence to improve restart recovery semantics:
   rather than waiting for the next polling cycle to discover them.
 - Pending reaction recovery reconstructs runtime reaction entries after a restart from the most
   recent `run_history` row recorded as `succeeded` for each issue and by reading that candidate's
-  workspace SCM metadata. A later handoff withheld for absence is recorded as `failed`, so it no
-  longer displaces an earlier producing run in this selection; no query-shape change is required.
+  workspace SCM metadata. A handoff withheld for absence still records `failed` and is not
+  selectable by this query. A handoff withheld by evidence but suppressed by a verified terminal
+  state (§11.5, §14.2) records `succeeded` and is selectable, so it becomes its issue's candidate
+  for as long as it is that issue's newest such row; no query-shape change is required either way.
+  `docs/decisions/0026-re-read-issue-state-before-recording-absence-failure.md`, "Re-Read the
+  Issue State Before Recording an Absence Failure", ratifies this reach into restart reaction
+  recovery and bounds what a suppressed row's candidacy can actually change.
   Recovery considers only a candidate whose selected successful activity falls inside its lookback
   window. The pass narrows in a fixed order: it first drops any candidate
   the orchestrator already holds as running, retry-queued, or claimed, then truncates what is left

--- a/docs/architecture/21-reference-algorithms.md
+++ b/docs/architecture/21-reference-algorithms.md
@@ -454,6 +454,26 @@ on_worker_exit(issue_id, reason, worker_result, state):
       absence = evidence.verdict == "absence of work observed"
       undeterminable = evidence.verdict == "evidence not determinable"
       evidence_withheld = absence or (undeterminable and policy == "strict")
+
+      # Before recording an absence failure, re-read the issue's state
+      # once, gated the same way the permit path's own pre-write read is
+      # gated below. A terminal result routes this exit to disposition 2
+      # instead of the withheld path: no failure record, no failure
+      # comment, no retry, no absence count.
+      if evidence_withheld and cfg.tracker.terminal_states and tracker_adapter:
+        verified, verify_err = tracker_adapter.fetch_issue_states_by_ids([issue_id])
+        if verify_err:
+          log_warn("withheld handoff verification read failed, recording withheld handoff",
+                    verify_err, observation_source)
+        elif issue_id in verified and is_terminal_state(verified[issue_id], cfg.tracker.terminal_states):
+          log_info("withheld handoff suppressed for terminal issue",
+                    verified[issue_id], "verified", cfg.tracker.handoff_state,
+                    policy, evidence.verdict, evidence.reason, worker_result.turns_completed)
+          observation = verified[issue_id]
+          observation_source = "verified"
+          terminal = true
+          evidence_withheld = false
+
       if evidence_withheld:
         # A withheld handoff is an unsuccessful run even though the agent
         # process exited normally, so the persisted status is failed with

--- a/docs/architecture/22-test-and-validation-matrix.md
+++ b/docs/architecture/22-test-and-validation-matrix.md
@@ -117,6 +117,10 @@ Unless otherwise noted, Sections 17.1 through 17.7 are `Core Conformance`. Bulle
 - With terminal states configured and a non-terminal observation, one verification read runs
   immediately before the handoff write; a terminal result suppresses the write and a failed read
   lets it proceed
+- With a withheld handoff-evidence verdict, terminal states configured, and a tracker adapter
+  present, one verification read runs before any withheld-handoff effect; a terminal result
+  routes the exit to the terminal disposition, and a non-terminal result, a response omitting the
+  issue, or a failed read keeps the withheld disposition
 - With no terminal states configured, no verification read is issued
 - A blocked soft stop releases the claim with no handoff and no continuation retry, and, where
   the dispatch drives issue state, records a durable park, applies the parking label, and holds

--- a/docs/architecture/24-persistence-schema.md
+++ b/docs/architecture/24-persistence-schema.md
@@ -52,16 +52,21 @@ Note: `timer_handle` is runtime-only and is not stored.
 | `tokens_measured`   | INTEGER | `1` when the four token columns above carry a figure the coding agent's runtime reported; `0` when the run's spend is unknown and all four are zero (migration 012) |
 
 `status` is no longer a pure mapping from the worker's exit kind. A normal exit that reaches an
-otherwise-eligible handoff and is withheld by the handoff-evidence policy records `failed`; its
-`error` value names the evidence verdict as the cause. For an otherwise-normal exit on that handoff
-path, `succeeded` means the policy did not withhold it. It does not assert that work was positively
-observed: an undeterminable verdict under `observed`, and every normal exit under `off`, may still
-record `succeeded`.
+otherwise-eligible handoff and is withheld by the handoff-evidence policy records `failed`, with its
+`error` value naming the evidence verdict as the cause, only when a verification read taken
+immediately before that recording does not find the issue in a terminal tracker state (§11.5,
+§14.2). When that read does find the issue terminal, the exit takes the terminal disposition
+instead and records `succeeded` with no error, exactly as an exit whose observation was terminal
+earlier already does. For an otherwise-normal exit on that handoff path, `succeeded` means the
+policy did not withhold it, or withheld it but the verification read then found the issue terminal.
+It does not assert that work was positively observed: an undeterminable verdict under `observed`,
+every normal exit under `off`, and a withheld verdict suppressed by that verification read may all
+still record `succeeded`.
 
 Rows written before this rule and rows written under `tracker.handoff_evidence: off` retain the
-earlier exit-kind-only meaning and are not rewritten. Reports spanning the change therefore span two
-definitions of `succeeded` and must not present a changed success rate as proof that agent behavior
-changed.
+earlier exit-kind-only meaning and are not rewritten. Reports spanning the change therefore span
+three definitions of `succeeded`, not two, and must not present a changed success rate as proof that
+agent behavior changed.
 
 No column stores the handoff-evidence verdict. The verdict is logged and counted, and a withheld
 run carries it in the existing `error` field. In particular, this change adds no evidence field to

--- a/docs/architecture/26-agent-authored-workspace-files.md
+++ b/docs/architecture/26-agent-authored-workspace-files.md
@@ -38,9 +38,11 @@ Recognized values:
   `tracker.handoff_state` is not configured, the issue becomes eligible for re-dispatch on future
   tracker polls under normal dispatch rules; unlike `blocked` in that deployment, no park is
   recorded, so the two values are still distinguishable. The transition is also subject to the
-  run's `tracker.handoff_evidence` verdict (Section 7.3): a
-  verdict that withholds it leaves the issue in its active state, keeps the claim, and takes the
-  backoff failure path instead of releasing the claim. Where
+  run's `tracker.handoff_evidence` verdict (Section 7.3): a verdict that withholds it is checked
+  once more against the tracker before the exit records it. Only when that check does not find the
+  issue terminal does the withheld verdict leave the issue in its active state, keep the claim, and
+  take the backoff failure path instead of releasing the claim; when it does find the issue
+  terminal, the exit releases the claim instead. Where
   self-review is enabled and the phase's other gate conditions hold, this value first admits the
   run to the self-review phase (Section 7); the handoff transition and claim release described
   above happen once that phase ends, rather than at the read.

--- a/docs/decisions/0026-re-read-issue-state-before-recording-absence-failure.md
+++ b/docs/decisions/0026-re-read-issue-state-before-recording-absence-failure.md
@@ -1,0 +1,196 @@
+---
+status: accepted
+date: 2026-08-24
+decision-makers: Serghei Iakovlev
+---
+
+# Re-Read the Issue State Before Recording an Absence Failure
+
+## Context and Problem Statement
+
+When a worker exits, the orchestrator computes a disposition for the run. If the issue is observed
+to be in a terminal state, the run takes the terminal disposition: the handoff write is suppressed,
+the claim is released, and nothing is scheduled. If instead the handoff-evidence policy withholds
+the handoff because no work was observed in the workspace, the run takes the absence-failure
+disposition: a failed run record, a session-failure comment written back to the issue, and a
+scheduled retry.
+
+Both branches are chosen from an observation of the issue's tracker state, and that observation was
+the freshest one captured before the worker exited, which could be a full turn old. Only one branch
+guarded against that. The path that writes the handoff state re-read the tracker immediately before
+the write, because overwriting a terminal state with a handoff state would undo a person's own
+action. The path that withheld the handoff had no such guard, because withholding writes nothing and
+so looked harmless.
+
+It was not harmless. An issue that reached a terminal state late in the run, written by the agent's
+own tracker tool, by an `after_run` hook, or by a person, still took the absence-failure path. The
+system reported a failure and promised a retry on an issue that was already finished, and the retry
+was later discarded unread when reconciliation observed the terminal state and released the claim.
+Nothing was corrupted. What was wrong is that a disposition decided on a stale observation
+contradicted a decision the tracker already held, and the orchestrator had the means to know it.
+
+## Decision Drivers
+
+1. **A guard present on one branch and absent on its sibling is an accident of construction.** Both
+   branches answer the same question from the same observation. The re-read was added to the write
+   path because writing over a terminal state destroys information. That reasoning explains why the
+   guard appeared there first; it does not explain why the other branch may act on a stale reading.
+2. **A report is a claim about the world, and a wrong one is not free.** A session-failure comment
+   on a finished issue is read by whoever is watching that issue. An operator who learns that these
+   reports are sometimes about issues that are done stops reading them, which costs the reports that
+   were right.
+3. **A retry that cannot change anything still consumes.** It holds a retry slot, keeps the issue
+   claimed until reconciliation catches up, and is then thrown away. The work it displaces is real
+   even though the work it does is not.
+4. **A finished issue must not accumulate toward being parked.** Consecutive observed absences on
+   one issue reach a ceiling, at which point the issue is parked and an escalation is applied. An
+   issue that finished its work by a route other than the evidence policy's own signal should not
+   move toward that ceiling at all.
+5. **The status column of a run record has more than one consumer.** The restart recovery pass
+   filters on it, the operator's aggregate surfaces group by it, and the absence-parking count
+   filters on it together with the text of the error. Changing what that column says for one
+   population of runs is a change that has to be checked against all three.
+6. **Freshness at exit is cheap.** Exit is not a hot path. One tracker read per withheld run, on a
+   run that has already spent an entire agent turn, is affordable in a way that a read per dispatch
+   candidate would not be.
+
+## Considered Options
+
+- Re-read the issue state before recording an absence failure, route a terminal state into the
+  ordinary terminal disposition, and let that disposition record `succeeded` as it already does
+- Re-read and route as above, but record `failed` with an error that omits the absence marker
+- Re-read, record `succeeded`, and exclude suppressed records from the restart recovery query
+
+## Decision Outcome
+
+Chosen option: **re-read and record `succeeded`**, because the property the change rests on is that
+a late-observed terminal state produces the same exit as an early-observed one, and the
+early-observed terminal exit already records `succeeded`, including on a run that produced nothing.
+
+### The re-read
+
+Before recording an absence failure, the orchestrator reads the issue's state from the tracker. A
+terminal state routes the run into the ordinary terminal disposition: the handoff write is
+suppressed, the claim is released, no retry is scheduled, and no failure is reported. Any other
+state, and a read that fails, leaves the absence-failure disposition exactly as it was.
+
+This is the guard the handoff write path already applies, placed on the arm that had none, and it
+inherits that guard's conditions. It is attempted only where terminal states are configured, since
+with none configured no value can classify as terminal and the read would spend a tracker call and
+up to one request timeout on the event loop for an outcome it cannot reach. A read that errors is
+not evidence of anything and does not redirect the run.
+
+The status the terminal disposition writes is unchanged and is not conditional on how that
+disposition was reached. On the handoff path `succeeded` has always meant that the run exited
+normally and the policy did not withhold the transition, not that work was positively observed; a
+run suppressed on an early-observed terminal state has always recorded it. A run suppressed on a
+late-observed one records the same thing for the same reason.
+
+### What of the earlier decision remains in force
+
+The decision to withhold the handoff transition only when absence of work is observed remains in
+force. What counts as evidence is unchanged. Where the baseline is taken is unchanged. The three
+policy values and their meanings are unchanged. The failure and backoff lane an absence is scheduled
+on is unchanged, as is the ceiling on consecutive absences, the escalation applied at it, and the
+reset a producing run performs. No stored run record gains a field for the verdict. Nothing about
+the evidence rule itself is revised here; this decision changes only which runs reach it.
+
+One of that decision's acceptance criteria is superseded, and only for the population this decision
+creates. It asserted that after a restart the pass rebuilding pending reaction entries selects the
+most recent run that produced something in preference to a later run observed to have produced
+nothing. That preference was never a rule the recovery pass expressed. It fell out of the status
+column: the query selects the most recent `succeeded` record per issue, and a run observed to have
+produced nothing recorded `failed`, so it was passed over. A suppressed run is a run observed to
+have produced nothing, and it now records `succeeded`, so the query can select it. For that
+population the criterion no longer holds, and it is not reinstated by other means.
+
+The new model is that the preference was incidental rather than load-bearing, and four facts bound
+what its loss can change.
+
+A suppressed run's workspace held no source-control metadata naming a pushed commit or a pull
+request. Such metadata is itself positive evidence and never withholds, so it cannot be present on a
+suppressed record.
+
+The recovery pass reads workspace metadata live, from a path it computes from the candidate's
+identifier, rather than from the stored run record, and every reaction kind it can rebuild requires
+a pull request number from that metadata. Which record wins therefore cannot change which pull
+request is recovered, nor whether one is recovered at all. It can change only the attempt number,
+agent, rule and template attributed to the rebuilt entry.
+
+A candidate is used only where the tracker reports its issue in the configured handoff state. A
+terminal issue is skipped, and terminal is the state a suppressed run's issue is in at the moment of
+suppression.
+
+A producing record and a suppressed record can therefore appear in that order on one issue only
+where the workspace carried no such metadata at the later run's exit.
+
+### What this decision does not settle
+
+Whether an agent may declare that the requested result was already true and that nothing needed
+changing, so that a run producing nothing can be a positive outcome rather than an absence, is a
+separate question and is not settled here. This decision adds no agent signal, no run outcome, no
+status-file value and no run-history status value. It routes a run into one of the two dispositions
+the orchestrator already had.
+
+### Considered Options in Detail
+
+**Record `failed` with an error that omits the absence marker.** This would preserve the superseded
+criterion, and the parking count would still not advance, since that count requires both a failed
+status and the marker. Rejected on three grounds. The operator's aggregate surfaces group run
+history by that column and would report a failure for a run that ended correctly. The persisted
+status would become conditional on how the terminal disposition was reached, so two runs with
+identical endings would record different statuses for a reason no consumer can see. And the failed
+status would gain a third sense, neither a run that errored nor a run withheld for absence, that
+nothing reading the column can distinguish.
+
+**Keep `succeeded` and exclude suppressed records from the recovery query.** Rejected because the
+record carries no discriminator to exclude on, and no schema change is wanted for a case this
+narrow. Steering the query by writing recognizable text into the error column of a succeeded record
+would be a covert schema in a column reserved for naming the cause of a failure.
+
+## Consequences
+
+### Positive
+
+- A finished issue is no longer reported as a failure and no longer draws a retry, so the
+  operator-facing claim and the scheduling both follow what the tracker holds.
+- The consecutive-absence count that parks an issue no longer advances for a finished issue. That
+  count requires both a failed status and the absence marker in the error, and a suppressed run
+  carries neither, so an issue finished by an `after_run` hook or by a person cannot be parked for
+  producing nothing.
+- The terminal guard is now the same on both branches, so a reader does not have to know which arm a
+  run is on to know whether the state was verified.
+
+### Negative
+
+- **One tracker read per withheld run.** It runs on the event loop and is bounded by the adapter's
+  request timeout. It is spent only where the policy already withheld, which is the rarer path.
+- **A read that fails leaves the old behaviour intact.** The fallback is conservative, but a tracker
+  unreachable at exit still yields a failure report and a retry on a finished issue. This decision
+  does not close that case.
+- **An attribution substitution is possible.** Where an issue leaves its terminal state for the
+  handoff state before the next restart, and its suppressed record is more recent than a producing
+  one, the rebuilt reaction entry carries the suppressed run's attempt number, agent, rule and
+  template rather than the producing run's. The pull request recovered is the same either way.
+- **A suppressed record can occupy a slot at the recovery pass's candidate bound.** That bound is
+  applied before the tracker read, so a record the read would have skipped can still displace
+  another issue's candidate on a restart carrying more candidates than the bound allows.
+
+## Confirmation
+
+The decision is validated when all of the following hold:
+
+1. A run whose issue reached a terminal state after the last observation, and whose workspace shows
+   no work, suppresses the handoff, releases the claim, schedules no retry, and writes no
+   session-failure comment.
+2. That run records `succeeded`, and its run record is indistinguishable from that of a run
+   suppressed on an early-observed terminal state.
+3. A run whose issue is not terminal at the re-read, and whose workspace shows no work, takes the
+   absence-failure disposition unchanged: a failed record carrying the absence marker, a
+   session-failure comment, and a retry on the backoff lane.
+4. A re-read that fails leaves the absence-failure disposition in place.
+5. No re-read is attempted where no terminal states are configured.
+6. Consecutive absences on an issue that reaches a terminal state stop accumulating, and the issue
+   is not parked by that mechanism.
+7. The restart recovery pass rebuilds the same pull request from a suppressed record as it would
+   from a producing record for the same issue.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -32,3 +32,4 @@ This directory contains architecturally significant decisions for Sortie, docume
 | [0023](0023-scope-the-ci-verdict-to-the-current-head.md) | Scope the CI Verdict to the Pull Request's Current Head | Accepted |
 | [0024](0024-start-a-new-feedback-epoch-when-the-head-moves.md) | Start a New Feedback Epoch When the Pull Request Head Moves | Accepted |
 | [0025](0025-refuse-agent-requests-only-a-human-could-answer.md) | Refuse Agent Requests That Only a Human Could Answer | Accepted |
+| [0026](0026-re-read-issue-state-before-recording-absence-failure.md) | Re-Read the Issue State Before Recording an Absence Failure | Accepted |

--- a/docs/workflow-reference.md
+++ b/docs/workflow-reference.md
@@ -241,8 +241,10 @@ tracker:
   no value can classify as terminal there. A failed verification read is logged and the
   handoff proceeds.
 - A transition suppressed by a terminal state, or by the issue not being in an active state at
-  worker exit, increments `sortie_handoff_transitions_total` with `result="skipped"`. One withheld
-  by the evidence verdict increments the same counter with `result="withheld"` instead
+  worker exit, increments `sortie_handoff_transitions_total` with `result="skipped"`. A run withheld
+  by the evidence verdict increments the same counter with `result="withheld"` instead, but only
+  when its own verification read below does not find the issue terminal; when that read does find
+  the issue terminal, the run increments `result="skipped"` instead
   (see [Section 4.1](#41-http-server-serverport-serverhost)).
 
 **`handoff_evidence` runtime behavior:**
@@ -255,10 +257,15 @@ tracker:
   determinable. It is computed at worker exit over the run's workspace against a baseline captured
   immediately before the agent starts. Under `off` no baseline is captured and no verdict is
   computed, so the four-condition decision stands unchanged.
-- A withheld run makes no handoff transition and no pre-write verification read, leaves the issue
-  in its active tracker state, is recorded in run history as `failed` with an error reason composed
-  of a reserved marker prefix, the verdict, and the policy that withheld it, and schedules the
-  ordinary exponential-backoff failure path rather than the fixed-delay continuation path.
+- A withheld verdict is, immediately before any of its effects, checked once more against the
+  tracker: a verification read for the issue, gated the same way the permit path's own pre-write
+  read above is gated. When that read reports the issue terminal, the run takes the terminal
+  disposition instead: no handoff transition, no failure record, no retry, and the completion
+  comment where `tracker.comments.on_completion` is enabled. Only when that read does not find the
+  issue terminal does the withheld run make no handoff transition, leave the issue in its active
+  tracker state, get recorded in run history as `failed` with an error reason composed of a
+  reserved marker prefix, the verdict, and the policy that withheld it, and schedule the ordinary
+  exponential-backoff failure path rather than the fixed-delay continuation path.
 - Consecutive withheld outcomes are counted per issue, and reaching the ceiling parks the issue
   under a label whose name is taken from `reactions.review_comments.escalation_label`. That
   ceiling's derivation from `agent.max_sessions`, the reset rule for the count, and the two
@@ -2217,7 +2224,7 @@ are included alongside Sortie-specific metrics.
 | `sortie_reconciliation_actions_total`           | Counter   | `action`                    | Reconciliation outcomes (`stop`, `cleanup`, `keep`, `sweep_cleanup`, `sweep_expired`). |
 | `sortie_poll_cycles_total`                      | Counter   | `result`                    | Poll tick completions (`success`, `error`, `skipped`).         |
 | `sortie_tracker_requests_total`                 | Counter   | `operation`, `result`       | Tracker adapter API calls by operation and result.             |
-| `sortie_handoff_transitions_total`              | Counter   | `result`                    | Handoff-state transition attempts (`success`, `error`, `skipped`, `withheld`). `skipped` covers two suppression causes: the issue had already reached a terminal state, or the issue was not in an active state at worker exit. `withheld` is the third: the run's handoff-evidence verdict did not permit the write, and the run is recorded as failed. Recorded only when `tracker.handoff_state` is set. |
+| `sortie_handoff_transitions_total`              | Counter   | `result`                    | Handoff-state transition attempts (`success`, `error`, `skipped`, `withheld`). `skipped` covers three suppression causes: the issue had already reached a terminal state, the issue was not in an active state at worker exit, or a withheld verdict's own verification read reported the issue terminal, suppressing the absence-failure recording. `withheld` covers the remaining case: the run's handoff-evidence verdict did not permit the write and its own verification read did not find the issue terminal, so the run is recorded as failed. Recorded only when `tracker.handoff_state` is set. |
 | `sortie_issue_parks_total`                      | Counter   | `reason`                    | Issue park events (`agent_blocked`, `handoff_absence`).        |
 | `sortie_tool_calls_total`                       | Counter   | `tool`, `result`            | Agent tool call completions by tool name and result.           |
 | `sortie_poll_duration_seconds`                  | Histogram | —                           | Wall-clock time per poll cycle.                                |

--- a/internal/orchestrator/exit.go
+++ b/internal/orchestrator/exit.go
@@ -323,6 +323,37 @@ func HandleWorkerExit(state *State, workerResult WorkerResult, params HandleWork
 				)
 			}
 			evidenceWithheld = handoffEvidenceWithholds(policy, evidenceResult)
+
+			// Before recording an absence failure, re-read the issue's
+			// tracker state once: the resolved observation above may
+			// already be stale by the time the worker's teardown has
+			// completed. With no terminal states configured no value
+			// can classify as terminal, so the read would spend a
+			// tracker call and up to one request timeout on the event
+			// loop without ever changing the disposition.
+			if evidenceWithheld && len(params.TerminalStates) > 0 && params.TrackerAdapter != nil {
+				if verified, verifyErr := params.TrackerAdapter.FetchIssueStatesByIDs(ctx, []string{workerResult.IssueID}); verifyErr != nil {
+					log.Warn("withheld handoff verification read failed, recording withheld handoff",
+						slog.Any("error", verifyErr),
+						slog.String("state_source", observationSource),
+					)
+				} else if verifiedState, ok := verified[workerResult.IssueID]; ok && isTerminalState(verifiedState, params.TerminalStates) {
+					log.Info("withheld handoff suppressed for terminal issue",
+						slog.String("state", verifiedState),
+						slog.String("state_source", "verified"),
+						slog.String("handoff_state", params.HandoffState),
+						slog.String("policy", string(policy)),
+						slog.String("verdict", string(evidenceResult.Verdict)),
+						slog.String("reason", evidenceResult.Reason),
+						slog.Int("turns_completed", workerResult.TurnsCompleted),
+					)
+					observation = verifiedState
+					observationSource = "verified"
+					terminal = true
+					evidenceWithheld = false
+				}
+			}
+
 			if evidenceWithheld {
 				evidenceErr = handoffEvidenceFailure(policy, evidenceResult)
 				metrics.IncHandoffTransitions(handoffWithheld)

--- a/internal/orchestrator/exit_test.go
+++ b/internal/orchestrator/exit_test.go
@@ -1816,8 +1816,8 @@ func TestHandleWorkerExit_HandoffEvidenceObservedAbsenceWithholds(t *testing.T) 
 	if len(tracker.commentCalls) != 0 {
 		t.Errorf("completion comment posted for withheld run: %+v", tracker.commentCalls)
 	}
-	if got := tracker.fetchStatesCalls.Load(); got != 0 {
-		t.Errorf("FetchIssueStatesByIDs called %d times, want 0 before a withheld handoff", got)
+	if got := tracker.fetchStatesCalls.Load(); got != 1 {
+		t.Errorf("FetchIssueStatesByIDs called %d times, want 1 (the verification read that precedes a withheld handoff)", got)
 	}
 	if _, ok := state.Claimed[issueID]; !ok {
 		t.Error("claim released after withheld handoff, want issue to remain active and claimed")
@@ -1862,6 +1862,948 @@ func TestHandleWorkerExit_HandoffEvidenceObservedAbsenceWithholds(t *testing.T) 
 		if !strings.Contains(logs.String(), want) {
 			t.Errorf("log output missing %q\ngot: %s", want, logs.String())
 		}
+	}
+}
+
+// --- Withheld-handoff verification-read suppression tests ---
+
+// suppressedExitWant carries the read-site log values a suppressed
+// exit's records are asserted against.
+type suppressedExitWant struct {
+	VerifiedState string
+	Policy        config.HandoffEvidencePolicy
+	Verdict       handoffEvidenceVerdict
+}
+
+// suppressedShapeFixture holds the collaborators a suppressed-exit test
+// shares: a tracker whose verification read reports a terminal state,
+// a failure comment configured so only its absence proves the
+// disposition changed, and a Git workspace built unchanged (absence of
+// work observed under the Observed policy) for tests that consume it.
+type suppressedShapeFixture struct {
+	Store         *mockExitStore
+	Tracker       *mockTrackerAdapter
+	Metrics       *spyMetrics
+	State         *State
+	Params        HandleWorkerExitParams
+	Logs          *bytes.Buffer
+	WorkspacePath string
+	Baseline      *workspace.HandoffEvidenceBaseline
+}
+
+func newSuppressedShapeFixture(t *testing.T, issueID string) suppressedShapeFixture {
+	t.Helper()
+	dir, baseline := handoffEvidenceGitWorkspace(t)
+	store := &mockExitStore{}
+	tracker := &mockTrackerAdapter{
+		fetchStatesFn: func(_ context.Context, ids []string) (map[string]string, error) {
+			result := make(map[string]string, len(ids))
+			for _, id := range ids {
+				result[id] = "Done"
+			}
+			return result, nil
+		},
+	}
+	spy := &spyMetrics{}
+	state := exitStateWithIssue(t, issueID, "In Progress")
+	params := handoffEvidenceExitParams(t, store, tracker, spy)
+	params.CommentsConfig.OnFailure = true
+	var logs bytes.Buffer
+	params.Logger = debugLogger(t, &logs)
+	return suppressedShapeFixture{
+		Store: store, Tracker: tracker, Metrics: spy, State: state, Params: params, Logs: &logs,
+		WorkspacePath: dir, Baseline: baseline,
+	}
+}
+
+// assertSuppressedExitEffects asserts the full effect set a suppressed
+// exit produces: exactly one verification read, no transition, no
+// comment call, one succeeded run-history row with no error, no
+// absence-count query or park, no retry of any kind, the claim
+// released, no pending reaction, one skipped handoff-transition
+// increment, and the read-site log record naming the discarded
+// verdict.
+func assertSuppressedExitEffects(t *testing.T, f suppressedShapeFixture, issueID string, want suppressedExitWant) {
+	t.Helper()
+
+	if got := f.Tracker.fetchStatesCalls.Load(); got != 1 {
+		t.Errorf("FetchIssueStatesByIDs called %d times, want 1", got)
+	}
+	if len(f.Tracker.transitionCalls) != 0 {
+		t.Errorf("TransitionIssue called %d times, want 0", len(f.Tracker.transitionCalls))
+	}
+	if len(f.Tracker.commentCalls) != 0 {
+		t.Errorf("CommentIssue called %d times, want 0: %+v", len(f.Tracker.commentCalls), f.Tracker.commentCalls)
+	}
+	if len(f.Store.runHistories) != 1 {
+		t.Fatalf("AppendRunHistory calls = %d, want 1", len(f.Store.runHistories))
+	}
+	if got := f.Store.runHistories[0].Status; got != "succeeded" {
+		t.Errorf("RunHistory.Status = %q, want %q", got, "succeeded")
+	}
+	if f.Store.runHistories[0].Error != nil {
+		t.Errorf("RunHistory.Error = %q, want nil", *f.Store.runHistories[0].Error)
+	}
+	if len(f.Store.absenceCountedIssueIDs) != 0 {
+		t.Errorf("QueryConsecutiveHandoffAbsenceCounts issue IDs = %v, want none", f.Store.absenceCountedIssueIDs)
+	}
+	if len(f.Store.parkedIssues) != 0 {
+		t.Errorf("UpsertParkedIssue calls = %d, want 0", len(f.Store.parkedIssues))
+	}
+	if _, ok := f.State.Parked[issueID]; ok {
+		t.Error("issue parked after a suppressed exit, want not parked")
+	}
+	if _, ok := f.State.RetryAttempts[issueID]; ok {
+		t.Error("RetryAttempts entry present after a suppressed exit, want none")
+	}
+	if len(f.Store.retryEntries) != 0 {
+		t.Errorf("SaveRetryEntry calls = %d, want 0", len(f.Store.retryEntries))
+	}
+	if _, ok := f.State.Claimed[issueID]; ok {
+		t.Error("claim retained after a suppressed exit, want released")
+	}
+	if len(f.State.PendingReactions) != 0 {
+		t.Errorf("PendingReactions = %v, want none", f.State.PendingReactions)
+	}
+	if len(f.Metrics.handoffTransitions) != 1 || f.Metrics.handoffTransitions[0] != handoffSkipped {
+		t.Errorf("handoffTransitions = %v, want [%s]", f.Metrics.handoffTransitions, handoffSkipped)
+	}
+
+	output := f.Logs.String()
+	if !strings.Contains(output, "withheld handoff suppressed for terminal issue") {
+		t.Errorf("log output missing %q\ngot: %s", "withheld handoff suppressed for terminal issue", output)
+	}
+	if !strings.Contains(output, "state="+want.VerifiedState) {
+		t.Errorf("log output missing verified state %q\ngot: %s", want.VerifiedState, output)
+	}
+	if !strings.Contains(output, "state_source=verified") {
+		t.Errorf("log output missing state_source=verified\ngot: %s", output)
+	}
+	if !strings.Contains(output, "policy="+string(want.Policy)) {
+		t.Errorf("log output missing policy=%q\ngot: %s", want.Policy, output)
+	}
+	if !strings.Contains(output, `verdict="`+string(want.Verdict)+`"`) {
+		t.Errorf("log output missing verdict=%q\ngot: %s", want.Verdict, output)
+	}
+	if strings.Contains(output, "handoff withheld by evidence policy") {
+		t.Errorf("log output contains the withheld-disposition warning, want suppressed:\n%s", output)
+	}
+}
+
+// TestHandleWorkerExit_SuppressedTerminalShape1SoftStopWorkerSource is
+// exit shape one: a soft-stop exit whose resolved observation source is
+// the worker's own per-turn refresh.
+func TestHandleWorkerExit_SuppressedTerminalShape1SoftStopWorkerSource(t *testing.T) {
+	t.Parallel()
+
+	const issueID = "SUP-SHAPE1"
+	f := newSuppressedShapeFixture(t, issueID)
+
+	HandleWorkerExit(f.State, WorkerResult{
+		IssueID:                 issueID,
+		Identifier:              issueID + "-ident",
+		ExitKind:                WorkerExitNormal,
+		TurnsCompleted:          2,
+		WorkspacePath:           f.WorkspacePath,
+		HandoffEvidencePolicy:   config.HandoffEvidenceObserved,
+		HandoffEvidenceBaseline: f.Baseline,
+		AgentAdapter:            "mock",
+		SoftStop:                true,
+		SoftStopReason:          "needs-human-review",
+		ObservedIssueState:      "In Progress",
+	}, f.Params)
+
+	assertSuppressedExitEffects(t, f, issueID, suppressedExitWant{
+		VerifiedState: "Done",
+		Policy:        config.HandoffEvidenceObserved,
+		Verdict:       handoffAbsenceObserved,
+	})
+}
+
+// TestHandleWorkerExit_SuppressedTerminalShape2NonSoftStopWorkerSource is
+// exit shape two: a non-soft-stop exit whose resolved observation source
+// is the worker's own per-turn refresh.
+func TestHandleWorkerExit_SuppressedTerminalShape2NonSoftStopWorkerSource(t *testing.T) {
+	t.Parallel()
+
+	const issueID = "SUP-SHAPE2"
+	f := newSuppressedShapeFixture(t, issueID)
+
+	HandleWorkerExit(f.State, WorkerResult{
+		IssueID:                 issueID,
+		Identifier:              issueID + "-ident",
+		ExitKind:                WorkerExitNormal,
+		TurnsCompleted:          2,
+		WorkspacePath:           f.WorkspacePath,
+		HandoffEvidencePolicy:   config.HandoffEvidenceObserved,
+		HandoffEvidenceBaseline: f.Baseline,
+		AgentAdapter:            "mock",
+		ObservedIssueState:      "In Progress",
+	}, f.Params)
+
+	assertSuppressedExitEffects(t, f, issueID, suppressedExitWant{
+		VerifiedState: "Done",
+		Policy:        config.HandoffEvidenceObserved,
+		Verdict:       handoffAbsenceObserved,
+	})
+}
+
+// TestHandleWorkerExit_SuppressedTerminalShape3NonSoftStopSnapshotSource
+// is exit shape three: a non-soft-stop exit whose resolved observation
+// falls through to the dispatch-time snapshot because no per-turn
+// refresh ran.
+func TestHandleWorkerExit_SuppressedTerminalShape3NonSoftStopSnapshotSource(t *testing.T) {
+	t.Parallel()
+
+	const issueID = "SUP-SHAPE3"
+	f := newSuppressedShapeFixture(t, issueID)
+
+	HandleWorkerExit(f.State, WorkerResult{
+		IssueID:                 issueID,
+		Identifier:              issueID + "-ident",
+		ExitKind:                WorkerExitNormal,
+		TurnsCompleted:          2,
+		WorkspacePath:           f.WorkspacePath,
+		HandoffEvidencePolicy:   config.HandoffEvidenceObserved,
+		HandoffEvidenceBaseline: f.Baseline,
+		AgentAdapter:            "mock",
+	}, f.Params)
+
+	assertSuppressedExitEffects(t, f, issueID, suppressedExitWant{
+		VerifiedState: "Done",
+		Policy:        config.HandoffEvidenceObserved,
+		Verdict:       handoffAbsenceObserved,
+	})
+}
+
+// TestHandleWorkerExit_SuppressedTerminalShape4SoftStopSnapshotSource is
+// exit shape four: a soft-stop exit whose resolved observation falls
+// through to the dispatch-time snapshot, the combination a field report
+// of this behavior would most likely produce.
+func TestHandleWorkerExit_SuppressedTerminalShape4SoftStopSnapshotSource(t *testing.T) {
+	t.Parallel()
+
+	const issueID = "SUP-SHAPE4"
+	f := newSuppressedShapeFixture(t, issueID)
+
+	HandleWorkerExit(f.State, WorkerResult{
+		IssueID:                 issueID,
+		Identifier:              issueID + "-ident",
+		ExitKind:                WorkerExitNormal,
+		TurnsCompleted:          2,
+		WorkspacePath:           f.WorkspacePath,
+		HandoffEvidencePolicy:   config.HandoffEvidenceObserved,
+		HandoffEvidenceBaseline: f.Baseline,
+		AgentAdapter:            "mock",
+		SoftStop:                true,
+		SoftStopReason:          "needs-human-review",
+	}, f.Params)
+
+	assertSuppressedExitEffects(t, f, issueID, suppressedExitWant{
+		VerifiedState: "Done",
+		Policy:        config.HandoffEvidenceObserved,
+		Verdict:       handoffAbsenceObserved,
+	})
+}
+
+// TestHandleWorkerExit_WithheldReadGating covers the read-gating decision
+// table: the five conditions under which the withheld-path verification
+// read fires or does not.
+func TestHandleWorkerExit_WithheldReadGating(t *testing.T) {
+	t.Parallel()
+
+	t.Run("active-state control: withheld disposition holds in full", func(t *testing.T) {
+		t.Parallel()
+
+		const issueID = "GATE-ACTIVE"
+		dir, baseline := handoffEvidenceGitWorkspace(t)
+		store := &mockExitStore{}
+		tracker := &mockTrackerAdapter{
+			fetchStatesFn: func(_ context.Context, ids []string) (map[string]string, error) {
+				result := make(map[string]string, len(ids))
+				for _, id := range ids {
+					result[id] = "In Progress"
+				}
+				return result, nil
+			},
+		}
+		spy := &spyMetrics{}
+		state := exitStateWithIssue(t, issueID, "In Progress")
+		params := handoffEvidenceExitParams(t, store, tracker, spy)
+		params.CommentsConfig.OnFailure = true
+
+		HandleWorkerExit(state, WorkerResult{
+			IssueID:                 issueID,
+			Identifier:              issueID + "-ident",
+			ExitKind:                WorkerExitNormal,
+			WorkspacePath:           dir,
+			HandoffEvidencePolicy:   config.HandoffEvidenceObserved,
+			HandoffEvidenceBaseline: baseline,
+			AgentAdapter:            "mock",
+		}, params)
+		t.Cleanup(func() { CancelRetry(state, issueID) })
+		state.TrackerOpsWg.Wait()
+
+		if got := tracker.fetchStatesCalls.Load(); got != 1 {
+			t.Errorf("FetchIssueStatesByIDs called %d times, want 1", got)
+		}
+		if len(store.runHistories) != 1 || store.runHistories[0].Status != "failed" {
+			t.Fatalf("run histories = %+v, want one failed row", store.runHistories)
+		}
+		if store.runHistories[0].Error == nil || !strings.HasPrefix(*store.runHistories[0].Error, persistence.HandoffAbsenceErrorPrefix) {
+			t.Errorf("RunHistory.Error = %v, want the %q prefix", store.runHistories[0].Error, persistence.HandoffAbsenceErrorPrefix)
+		}
+		if len(spy.handoffTransitions) != 1 || spy.handoffTransitions[0] != handoffWithheld {
+			t.Errorf("handoffTransitions = %v, want [%s]", spy.handoffTransitions, handoffWithheld)
+		}
+		if len(store.absenceCountedIssueIDs) != 1 {
+			t.Errorf("QueryConsecutiveHandoffAbsenceCounts issue IDs = %v, want one call", store.absenceCountedIssueIDs)
+		}
+		retry, ok := state.RetryAttempts[issueID]
+		if !ok {
+			t.Fatal("retry not scheduled, want the withheld disposition to schedule one")
+		}
+		if retry.scheduledDelayMS != backoffBaseMS {
+			t.Errorf("retry delay = %d, want exponential-backoff base %d", retry.scheduledDelayMS, backoffBaseMS)
+		}
+		if _, ok := state.Claimed[issueID]; !ok {
+			t.Error("claim released, want retained on the withheld disposition")
+		}
+		if len(tracker.commentCalls) != 1 {
+			t.Errorf("CommentIssue called %d times, want 1 (on_failure enabled)", len(tracker.commentCalls))
+		}
+	})
+
+	t.Run("TerminalStates empty: no read, unchanged from pinned revision", func(t *testing.T) {
+		t.Parallel()
+
+		const issueID = "GATE-NOTERMINAL"
+		dir, baseline := handoffEvidenceGitWorkspace(t)
+		store := &mockExitStore{}
+		tracker := &mockTrackerAdapter{}
+		spy := &spyMetrics{}
+		state := exitStateWithIssue(t, issueID, "In Progress")
+		params := handoffEvidenceExitParams(t, store, tracker, spy)
+		params.TerminalStates = nil
+
+		HandleWorkerExit(state, WorkerResult{
+			IssueID:                 issueID,
+			Identifier:              issueID + "-ident",
+			ExitKind:                WorkerExitNormal,
+			WorkspacePath:           dir,
+			HandoffEvidencePolicy:   config.HandoffEvidenceObserved,
+			HandoffEvidenceBaseline: baseline,
+			AgentAdapter:            "mock",
+		}, params)
+		t.Cleanup(func() { CancelRetry(state, issueID) })
+
+		if got := tracker.fetchStatesCalls.Load(); got != 0 {
+			t.Errorf("FetchIssueStatesByIDs called %d times, want 0 (no terminal states configured)", got)
+		}
+		if len(store.runHistories) != 1 || store.runHistories[0].Status != "failed" {
+			t.Fatalf("run histories = %+v, want one failed row", store.runHistories)
+		}
+		if len(spy.handoffTransitions) != 1 || spy.handoffTransitions[0] != handoffWithheld {
+			t.Errorf("handoffTransitions = %v, want [%s]", spy.handoffTransitions, handoffWithheld)
+		}
+		if _, ok := state.RetryAttempts[issueID]; !ok {
+			t.Error("retry not scheduled, want the withheld disposition unchanged")
+		}
+	})
+
+	t.Run("TrackerAdapter nil: no read, no panic, withheld disposition preserved", func(t *testing.T) {
+		t.Parallel()
+
+		const issueID = "GATE-NILADAPTER"
+		dir, baseline := handoffEvidenceGitWorkspace(t)
+		store := &mockExitStore{}
+		state := exitStateWithIssue(t, issueID, "In Progress")
+		params := defaultExitParams(t, store)
+		params.HandoffState = "Human Review"
+		params.ActiveStates = []string{"In Progress"}
+		params.TerminalStates = []string{"Done"}
+		// TrackerAdapter is left nil: the gate must exclude the read
+		// without panicking on a nil-interface call.
+
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("HandleWorkerExit panicked: %v", r)
+				}
+			}()
+			HandleWorkerExit(state, WorkerResult{
+				IssueID:                 issueID,
+				Identifier:              issueID + "-ident",
+				ExitKind:                WorkerExitNormal,
+				WorkspacePath:           dir,
+				HandoffEvidencePolicy:   config.HandoffEvidenceObserved,
+				HandoffEvidenceBaseline: baseline,
+				AgentAdapter:            "mock",
+			}, params)
+		}()
+		t.Cleanup(func() { CancelRetry(state, issueID) })
+
+		if len(store.runHistories) != 1 || store.runHistories[0].Status != "failed" {
+			t.Fatalf("run histories = %+v, want one failed row", store.runHistories)
+		}
+		if _, ok := state.RetryAttempts[issueID]; !ok {
+			t.Error("retry not scheduled, want the withheld disposition preserved")
+		}
+	})
+
+	t.Run("off policy: no verdict computed, zero reads", func(t *testing.T) {
+		t.Parallel()
+
+		const issueID = "GATE-OFF"
+		dir, baseline := handoffEvidenceGitWorkspace(t)
+		store := &mockExitStore{}
+		tracker := &mockTrackerAdapter{}
+		state := exitStateWithIssue(t, issueID, "In Progress")
+		params := defaultExitParams(t, store)
+		params.TrackerAdapter = tracker
+		params.HandoffState = "Human Review"
+		params.ActiveStates = []string{"In Progress"}
+		// TerminalStates is intentionally left unset: the handoff-write
+		// path's own pre-existing verification read (unrelated to this
+		// change) also gates only on len(TerminalStates) > 0, and
+		// configuring it here would let that read fire too and confound
+		// the zero-call assertion below. The property under test is that
+		// the off policy skips evidence evaluation entirely, before
+		// either read's gate is reached.
+
+		HandleWorkerExit(state, WorkerResult{
+			IssueID:                 issueID,
+			Identifier:              issueID + "-ident",
+			ExitKind:                WorkerExitNormal,
+			WorkspacePath:           dir,
+			HandoffEvidencePolicy:   config.HandoffEvidenceOff,
+			HandoffEvidenceBaseline: baseline,
+			AgentAdapter:            "mock",
+		}, params)
+
+		if got := tracker.fetchStatesCalls.Load(); got != 0 {
+			t.Errorf("FetchIssueStatesByIDs called %d times, want 0 under the off policy", got)
+		}
+		if len(tracker.transitionCalls) != 1 {
+			t.Fatalf("TransitionIssue called %d times, want 1 (the off policy never withholds)", len(tracker.transitionCalls))
+		}
+		if len(store.runHistories) != 1 || store.runHistories[0].Status != "succeeded" {
+			t.Errorf("run histories = %+v, want one succeeded row", store.runHistories)
+		}
+	})
+
+	t.Run("work observed: only the write path's own read fires", func(t *testing.T) {
+		t.Parallel()
+
+		const issueID = "GATE-WORKOBSERVED"
+		dir, baseline := handoffEvidenceGitWorkspace(t)
+		if err := os.WriteFile(filepath.Join(dir, "work.txt"), []byte("work\n"), 0o600); err != nil {
+			t.Fatalf("write work file: %v", err)
+		}
+		store := &mockExitStore{}
+		tracker := &mockTrackerAdapter{
+			fetchStatesFn: func(_ context.Context, ids []string) (map[string]string, error) {
+				result := make(map[string]string, len(ids))
+				for _, id := range ids {
+					result[id] = "In Progress"
+				}
+				return result, nil
+			},
+		}
+		spy := &spyMetrics{}
+		state := exitStateWithIssue(t, issueID, "In Progress")
+		params := handoffEvidenceExitParams(t, store, tracker, spy)
+
+		HandleWorkerExit(state, WorkerResult{
+			IssueID:                 issueID,
+			Identifier:              issueID + "-ident",
+			ExitKind:                WorkerExitNormal,
+			WorkspacePath:           dir,
+			HandoffEvidencePolicy:   config.HandoffEvidenceObserved,
+			HandoffEvidenceBaseline: baseline,
+			AgentAdapter:            "mock",
+		}, params)
+
+		if got := tracker.fetchStatesCalls.Load(); got != 1 {
+			t.Errorf("FetchIssueStatesByIDs called %d times, want 1 (the write path's own read, not this change's)", got)
+		}
+		if len(tracker.transitionCalls) != 1 {
+			t.Errorf("TransitionIssue called %d times, want 1", len(tracker.transitionCalls))
+		}
+	})
+}
+
+// TestHandleWorkerExit_WithheldReadFailOpen covers the read's two
+// fail-open causes: a transport error and a response that omits the
+// exiting issue.
+func TestHandleWorkerExit_WithheldReadFailOpen(t *testing.T) {
+	t.Parallel()
+
+	t.Run("read error: fail open, one Warn, positive retry line", func(t *testing.T) {
+		t.Parallel()
+
+		const issueID = "FAILOPEN-ERROR"
+		dir, baseline := handoffEvidenceGitWorkspace(t)
+		store := &mockExitStore{}
+		readErr := errors.New("tracker unavailable")
+		tracker := &mockTrackerAdapter{
+			fetchStatesFn: func(_ context.Context, _ []string) (map[string]string, error) {
+				return nil, readErr
+			},
+		}
+		spy := newCommentAwareMetrics()
+		state := exitStateWithIssue(t, issueID, "In Progress")
+		params := handoffEvidenceExitParams(t, store, tracker, spy)
+		params.CommentsConfig.OnFailure = true
+		var logs bytes.Buffer
+		params.Logger = debugLogger(t, &logs)
+
+		HandleWorkerExit(state, WorkerResult{
+			IssueID:                 issueID,
+			Identifier:              issueID + "-ident",
+			ExitKind:                WorkerExitNormal,
+			WorkspacePath:           dir,
+			HandoffEvidencePolicy:   config.HandoffEvidenceObserved,
+			HandoffEvidenceBaseline: baseline,
+			AgentAdapter:            "mock",
+		}, params)
+		t.Cleanup(func() { CancelRetry(state, issueID) })
+		spy.waitComment(t)
+
+		if len(store.runHistories) != 1 || store.runHistories[0].Status != "failed" {
+			t.Fatalf("run histories = %+v, want one failed row", store.runHistories)
+		}
+		if len(spy.handoffTransitions) != 1 || spy.handoffTransitions[0] != handoffWithheld {
+			t.Errorf("handoffTransitions = %v, want [%s]", spy.handoffTransitions, handoffWithheld)
+		}
+		retry, ok := state.RetryAttempts[issueID]
+		if !ok {
+			t.Fatal("retry not scheduled, want the withheld disposition preserved on a fail-open read")
+		}
+		if _, ok := state.Claimed[issueID]; !ok {
+			t.Error("claim released, want retained on the withheld disposition")
+		}
+
+		output := logs.String()
+		if !strings.Contains(output, "withheld handoff verification read failed, recording withheld handoff") {
+			t.Errorf("log output missing the fail-open Warn\ngot: %s", output)
+		}
+		if !strings.Contains(output, readErr.Error()) {
+			t.Errorf("log output missing the read error %q\ngot: %s", readErr.Error(), output)
+		}
+
+		if len(tracker.commentCalls) != 1 {
+			t.Fatalf("CommentIssue called %d times, want 1", len(tracker.commentCalls))
+		}
+		wantRetryLine := fmt.Sprintf("Retry: yes (attempt %d)", retry.Attempt)
+		if !strings.Contains(tracker.commentCalls[0].Text, wantRetryLine) {
+			t.Errorf("failure comment = %q, want it to contain %q", tracker.commentCalls[0].Text, wantRetryLine)
+		}
+	})
+
+	t.Run("read omits the issue: fail open, no new log record", func(t *testing.T) {
+		t.Parallel()
+
+		const issueID = "FAILOPEN-OMIT"
+		dir, baseline := handoffEvidenceGitWorkspace(t)
+		store := &mockExitStore{}
+		tracker := &mockTrackerAdapter{
+			fetchStatesFn: func(_ context.Context, _ []string) (map[string]string, error) {
+				return map[string]string{}, nil
+			},
+		}
+		spy := &spyMetrics{}
+		state := exitStateWithIssue(t, issueID, "In Progress")
+		params := handoffEvidenceExitParams(t, store, tracker, spy)
+		var logs bytes.Buffer
+		params.Logger = debugLogger(t, &logs)
+
+		HandleWorkerExit(state, WorkerResult{
+			IssueID:                 issueID,
+			Identifier:              issueID + "-ident",
+			ExitKind:                WorkerExitNormal,
+			WorkspacePath:           dir,
+			HandoffEvidencePolicy:   config.HandoffEvidenceObserved,
+			HandoffEvidenceBaseline: baseline,
+			AgentAdapter:            "mock",
+		}, params)
+		t.Cleanup(func() { CancelRetry(state, issueID) })
+
+		if len(store.runHistories) != 1 || store.runHistories[0].Status != "failed" {
+			t.Fatalf("run histories = %+v, want one failed row", store.runHistories)
+		}
+		if _, ok := state.RetryAttempts[issueID]; !ok {
+			t.Error("retry not scheduled, want the withheld disposition preserved")
+		}
+		if _, ok := state.Claimed[issueID]; !ok {
+			t.Error("claim released, want retained on the withheld disposition")
+		}
+
+		output := logs.String()
+		if strings.Contains(output, "withheld handoff verification read failed") {
+			t.Errorf("log output contains the fail-open Warn, want none for an omitted issue:\n%s", output)
+		}
+		if strings.Contains(output, "withheld handoff suppressed for terminal issue") {
+			t.Errorf("log output contains the suppression Info, want none for an omitted issue:\n%s", output)
+		}
+	})
+}
+
+// TestHandleWorkerExit_StrictUndeterminableTerminalSuppresses covers the
+// strict-policy row of the read-gating table: an undeterminable verdict
+// withholds under strict, and a terminal verification read still
+// suppresses it.
+func TestHandleWorkerExit_StrictUndeterminableTerminalSuppresses(t *testing.T) {
+	t.Parallel()
+
+	const issueID = "STRICT-UNDETERMINED"
+	f := newSuppressedShapeFixture(t, issueID)
+
+	HandleWorkerExit(f.State, WorkerResult{
+		IssueID:               issueID,
+		Identifier:            issueID + "-ident",
+		ExitKind:              WorkerExitNormal,
+		TurnsCompleted:        1,
+		HandoffEvidencePolicy: config.HandoffEvidenceStrict,
+		AgentAdapter:          "mock",
+		// WorkspacePath and HandoffEvidenceBaseline are deliberately not
+		// taken from the fixture: an absent baseline makes the verdict
+		// undeterminable regardless of workspace state, and this test's
+		// whole point is that path, not the unchanged-workspace path the
+		// fixture's Git repository exists to support for its other callers.
+	}, f.Params)
+
+	assertSuppressedExitEffects(t, f, issueID, suppressedExitWant{
+		VerifiedState: "Done",
+		Policy:        config.HandoffEvidenceStrict,
+		Verdict:       handoffEvidenceUndetermined,
+	})
+}
+
+// TestHandleWorkerExit_SuppressedExitDropsForeignIncumbent pins the
+// terminal disposition's unconditional cancellation of a queued
+// retry-slot incumbent: a suppressed exit drops it exactly as the
+// early-observed terminal disposition already does.
+func TestHandleWorkerExit_SuppressedExitDropsForeignIncumbent(t *testing.T) {
+	t.Parallel()
+
+	const issueID = "SUPPRESSED-INCUMBENT"
+	dir, baseline := handoffEvidenceGitWorkspace(t)
+	store := &mockExitStore{}
+	tracker := &mockTrackerAdapter{
+		fetchStatesFn: func(_ context.Context, ids []string) (map[string]string, error) {
+			result := make(map[string]string, len(ids))
+			for _, id := range ids {
+				result[id] = "Done"
+			}
+			return result, nil
+		},
+	}
+	state := exitStateWithIssue(t, issueID, "In Progress")
+	state.RetryAttempts[issueID] = &RetryEntry{
+		IssueID:      issueID,
+		Attempt:      9,
+		ReactionKind: ReactionKindCI,
+	}
+	params := handoffEvidenceExitParams(t, store, tracker, &spyMetrics{})
+	var logs bytes.Buffer
+	params.Logger = debugLogger(t, &logs)
+
+	HandleWorkerExit(state, WorkerResult{
+		IssueID:                 issueID,
+		Identifier:              issueID + "-ident",
+		ExitKind:                WorkerExitNormal,
+		WorkspacePath:           dir,
+		HandoffEvidencePolicy:   config.HandoffEvidenceObserved,
+		HandoffEvidenceBaseline: baseline,
+		AgentAdapter:            "mock",
+	}, params)
+
+	if _, ok := state.RetryAttempts[issueID]; ok {
+		t.Error("RetryAttempts entry survived a suppressed exit, want destroyed even against a foreign incumbent")
+	}
+	if _, ok := state.Claimed[issueID]; ok {
+		t.Error("claim survived a suppressed exit, want released")
+	}
+	if len(store.deletedRetryIDs) != 0 {
+		t.Errorf("DeleteRetryEntry called for %v, want none: a suppressed exit never persists a deletion for a foreign incumbent's row", store.deletedRetryIDs)
+	}
+	if strings.Contains(logs.String(), "retry slot occupied, deferring") {
+		t.Errorf("log output contains a retry-slot deferral, want none for a suppressed exit:\n%s", logs.String())
+	}
+}
+
+// TestHandleWorkerExit_RetryPromiseInvariantAcrossWithheldFamily pins the
+// retry-promise invariant across the withheld family: an operator-facing
+// message never asserts a retry the exit did not actually leave pending.
+func TestHandleWorkerExit_RetryPromiseInvariantAcrossWithheldFamily(t *testing.T) {
+	t.Parallel()
+
+	t.Run("suppressed: no comment mentions a retry", func(t *testing.T) {
+		t.Parallel()
+
+		const issueID = "PROMISE-SUPPRESSED"
+		dir, baseline := handoffEvidenceGitWorkspace(t)
+		store := &mockExitStore{}
+		tracker := &mockTrackerAdapter{
+			fetchStatesFn: func(_ context.Context, ids []string) (map[string]string, error) {
+				result := make(map[string]string, len(ids))
+				for _, id := range ids {
+					result[id] = "Done"
+				}
+				return result, nil
+			},
+		}
+		spy := newCommentAwareMetrics()
+		state := exitStateWithIssue(t, issueID, "In Progress")
+		params := handoffEvidenceExitParams(t, store, tracker, spy)
+		params.CommentsConfig.OnFailure = true
+		params.CommentsConfig.OnCompletion = true
+
+		HandleWorkerExit(state, WorkerResult{
+			IssueID:                 issueID,
+			Identifier:              issueID + "-ident",
+			ExitKind:                WorkerExitNormal,
+			WorkspacePath:           dir,
+			HandoffEvidencePolicy:   config.HandoffEvidenceObserved,
+			HandoffEvidenceBaseline: baseline,
+			AgentAdapter:            "mock",
+		}, params)
+		spy.waitComment(t)
+
+		if len(tracker.commentCalls) != 1 {
+			t.Fatalf("CommentIssue called %d times, want 1", len(tracker.commentCalls))
+		}
+		if strings.Contains(strings.ToLower(tracker.commentCalls[0].Text), "retry") {
+			t.Errorf("comment mentions a retry, want none for a suppressed exit\ngot: %q", tracker.commentCalls[0].Text)
+		}
+	})
+
+	t.Run("parked at ceiling: negative form, no retry entry", func(t *testing.T) {
+		t.Parallel()
+
+		const issueID = "PROMISE-PARKED"
+		dir, baseline := handoffEvidenceGitWorkspace(t)
+		store := &mockExitStore{}
+		seedMockHandoffAbsences(store, issueID, 2) // default ceiling is 3
+		tracker := &mockTrackerAdapter{
+			fetchStatesFn: func(_ context.Context, ids []string) (map[string]string, error) {
+				result := make(map[string]string, len(ids))
+				for _, id := range ids {
+					result[id] = "In Progress"
+				}
+				return result, nil
+			},
+		}
+		spy := newCommentAwareMetrics()
+		state := exitStateWithIssue(t, issueID, "In Progress")
+		params := handoffEvidenceExitParams(t, store, tracker, spy)
+		params.CommentsConfig.OnFailure = true
+
+		HandleWorkerExit(state, WorkerResult{
+			IssueID:                 issueID,
+			Identifier:              issueID + "-ident",
+			ExitKind:                WorkerExitNormal,
+			WorkspacePath:           dir,
+			HandoffEvidencePolicy:   config.HandoffEvidenceObserved,
+			HandoffEvidenceBaseline: baseline,
+			AgentAdapter:            "mock",
+		}, params)
+		spy.waitComment(t)
+
+		if _, ok := state.RetryAttempts[issueID]; ok {
+			t.Error("RetryAttempts entry present after parking, want none")
+		}
+		if len(tracker.commentCalls) != 1 {
+			t.Fatalf("CommentIssue called %d times, want 1", len(tracker.commentCalls))
+		}
+		if !strings.Contains(tracker.commentCalls[0].Text, "Retry: no") {
+			t.Errorf("comment = %q, want the negative retry form", tracker.commentCalls[0].Text)
+		}
+	})
+
+	t.Run("scheduled retry: positive form with the scheduled attempt", func(t *testing.T) {
+		t.Parallel()
+
+		const issueID = "PROMISE-SCHEDULED"
+		dir, baseline := handoffEvidenceGitWorkspace(t)
+		store := &mockExitStore{}
+		tracker := &mockTrackerAdapter{
+			fetchStatesFn: func(_ context.Context, ids []string) (map[string]string, error) {
+				result := make(map[string]string, len(ids))
+				for _, id := range ids {
+					result[id] = "In Progress"
+				}
+				return result, nil
+			},
+		}
+		spy := newCommentAwareMetrics()
+		state := exitStateWithIssue(t, issueID, "In Progress")
+		params := handoffEvidenceExitParams(t, store, tracker, spy)
+		params.CommentsConfig.OnFailure = true
+
+		HandleWorkerExit(state, WorkerResult{
+			IssueID:                 issueID,
+			Identifier:              issueID + "-ident",
+			ExitKind:                WorkerExitNormal,
+			WorkspacePath:           dir,
+			HandoffEvidencePolicy:   config.HandoffEvidenceObserved,
+			HandoffEvidenceBaseline: baseline,
+			AgentAdapter:            "mock",
+		}, params)
+		t.Cleanup(func() { CancelRetry(state, issueID) })
+		spy.waitComment(t)
+
+		retry, ok := state.RetryAttempts[issueID]
+		if !ok {
+			t.Fatal("retry not scheduled")
+		}
+		if len(tracker.commentCalls) != 1 {
+			t.Fatalf("CommentIssue called %d times, want 1", len(tracker.commentCalls))
+		}
+		wantLine := fmt.Sprintf("Retry: yes (attempt %d)", retry.Attempt)
+		if !strings.Contains(tracker.commentCalls[0].Text, wantLine) {
+			t.Errorf("comment = %q, want it to contain %q", tracker.commentCalls[0].Text, wantLine)
+		}
+	})
+
+	t.Run("deferred to a foreign incumbent: positive form with the incumbent's attempt", func(t *testing.T) {
+		t.Parallel()
+
+		const issueID = "PROMISE-DEFERRED"
+		dir, baseline := handoffEvidenceGitWorkspace(t)
+		store := &mockExitStore{}
+		tracker := &mockTrackerAdapter{
+			fetchStatesFn: func(_ context.Context, ids []string) (map[string]string, error) {
+				result := make(map[string]string, len(ids))
+				for _, id := range ids {
+					result[id] = "In Progress"
+				}
+				return result, nil
+			},
+		}
+		spy := newCommentAwareMetrics()
+		state := exitStateWithIssue(t, issueID, "In Progress")
+		state.RetryAttempts[issueID] = &RetryEntry{
+			IssueID:      issueID,
+			Attempt:      5,
+			ReactionKind: ReactionKindCI,
+		}
+		params := handoffEvidenceExitParams(t, store, tracker, spy)
+		params.CommentsConfig.OnFailure = true
+
+		HandleWorkerExit(state, WorkerResult{
+			IssueID:                 issueID,
+			Identifier:              issueID + "-ident",
+			ExitKind:                WorkerExitNormal,
+			WorkspacePath:           dir,
+			HandoffEvidencePolicy:   config.HandoffEvidenceObserved,
+			HandoffEvidenceBaseline: baseline,
+			AgentAdapter:            "mock",
+		}, params)
+		t.Cleanup(func() { CancelRetry(state, issueID) })
+		spy.waitComment(t)
+
+		incumbent, ok := state.RetryAttempts[issueID]
+		if !ok || incumbent.Attempt != 5 {
+			t.Fatalf("RetryAttempts[%s] = %+v, want the incumbent preserved at attempt 5", issueID, incumbent)
+		}
+		if len(tracker.commentCalls) != 1 {
+			t.Fatalf("CommentIssue called %d times, want 1", len(tracker.commentCalls))
+		}
+		wantLine := "Retry: yes (attempt 5)"
+		if !strings.Contains(tracker.commentCalls[0].Text, wantLine) {
+			t.Errorf("comment = %q, want it to contain %q", tracker.commentCalls[0].Text, wantLine)
+		}
+	})
+}
+
+// TestHandleWorkerExit_SuppressedExitPostsCompletionCommentNotFailure
+// pins the completion-not-failure rule: a suppressed exit never posts a
+// failure comment, and posts the soft-stop or ordinary completion
+// variant when on_completion is enabled.
+func TestHandleWorkerExit_SuppressedExitPostsCompletionCommentNotFailure(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		issueID        string
+		softStop       bool
+		softStopReason string
+		wantHeadline   string
+	}{
+		{
+			name:           "soft-stop variant",
+			issueID:        "SUP-COMMENT-SOFT",
+			softStop:       true,
+			softStopReason: "needs-human-review",
+			wantHeadline:   "Sortie session completed (agent signaled: needs-human-review).",
+		},
+		{
+			name:         "ordinary completion",
+			issueID:      "SUP-COMMENT-COMPLETE",
+			wantHeadline: "Sortie session completed.",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			dir, baseline := handoffEvidenceGitWorkspace(t)
+			store := &mockExitStore{}
+			tracker := &mockTrackerAdapter{
+				fetchStatesFn: func(_ context.Context, ids []string) (map[string]string, error) {
+					result := make(map[string]string, len(ids))
+					for _, id := range ids {
+						result[id] = "Done"
+					}
+					return result, nil
+				},
+			}
+			spy := newCommentAwareMetrics()
+			state := exitStateWithIssue(t, tt.issueID, "In Progress")
+			params := handoffEvidenceExitParams(t, store, tracker, spy)
+			params.CommentsConfig.OnFailure = true
+			params.CommentsConfig.OnCompletion = true
+
+			HandleWorkerExit(state, WorkerResult{
+				IssueID:                 tt.issueID,
+				Identifier:              tt.issueID + "-ident",
+				ExitKind:                WorkerExitNormal,
+				WorkspacePath:           dir,
+				HandoffEvidencePolicy:   config.HandoffEvidenceObserved,
+				HandoffEvidenceBaseline: baseline,
+				AgentAdapter:            "mock",
+				SoftStop:                tt.softStop,
+				SoftStopReason:          tt.softStopReason,
+			}, params)
+			spy.waitComment(t)
+
+			if len(tracker.commentCalls) != 1 {
+				t.Fatalf("CommentIssue called %d times, want 1", len(tracker.commentCalls))
+			}
+			text := tracker.commentCalls[0].Text
+			if !strings.Contains(text, tt.wantHeadline) {
+				t.Errorf("comment = %q, want headline %q", text, tt.wantHeadline)
+			}
+			if strings.Contains(text, "Sortie session failed.") {
+				t.Errorf("comment contains the failure headline, want none:\n%s", text)
+			}
+			if strings.Contains(text, "Retry:") {
+				t.Errorf("comment contains a retry line, want none:\n%s", text)
+			}
+			if strings.Contains(text, "re-queuing") {
+				t.Errorf("comment contains the re-queuing headline, want none:\n%s", text)
+			}
+
+			spy.mu.Lock()
+			comments := append([]trackerCommentCall(nil), spy.trackerComments...)
+			spy.mu.Unlock()
+			if len(comments) != 1 || comments[0].lifecycle != "completion" {
+				t.Errorf("IncTrackerComments calls = %+v, want one completion call", comments)
+			}
+		})
 	}
 }
 

--- a/internal/orchestrator/handoff_absence_test.go
+++ b/internal/orchestrator/handoff_absence_test.go
@@ -345,6 +345,55 @@ func TestHandleWorkerExitSucceededWithoutVerdictKeepsAbsenceSequence(t *testing.
 	}
 }
 
+// TestHandleWorkerExitSuppressedTerminalKeepsAbsenceSequence verifies that
+// a suppressed exit neither advances nor resets the consecutive-absence
+// count: it must not even query it, since a verified terminal issue was
+// never withheld for absence in the first place.
+func TestHandleWorkerExitSuppressedTerminalKeepsAbsenceSequence(t *testing.T) {
+	const issueID = "ABS-SUPPRESSED"
+	store := &mockExitStore{}
+	seedMockHandoffAbsences(store, issueID, 2)
+	tracker := newRecordingHandoffTracker()
+	tracker.fetchStatesFn = func(_ context.Context, ids []string) (map[string]string, error) {
+		result := make(map[string]string, len(ids))
+		for _, id := range ids {
+			result[id] = "Done"
+		}
+		return result, nil
+	}
+	state := exitStateWithIssue(t, issueID, "In Progress")
+	params := handoffEvidenceExitParams(t, store, tracker.mockTrackerAdapter, &spyMetrics{})
+	params.TrackerAdapter = tracker
+
+	dir, baseline := handoffEvidenceGitWorkspace(t)
+	HandleWorkerExit(state, WorkerResult{
+		IssueID:                 issueID,
+		Identifier:              "PROJ-SUPPRESSED",
+		ExitKind:                WorkerExitNormal,
+		WorkspacePath:           dir,
+		HandoffEvidencePolicy:   config.HandoffEvidenceObserved,
+		HandoffEvidenceBaseline: baseline,
+		AgentAdapter:            "mock",
+	}, params)
+
+	if len(store.absenceResetOf) != 0 {
+		t.Errorf("ResetHandoffAbsenceSequence calls = %v, want none", store.absenceResetOf)
+	}
+	if len(store.absenceCountedIssueIDs) != 0 {
+		t.Errorf("QueryConsecutiveHandoffAbsenceCounts issue IDs = %v, want none: a suppressed exit must not query", store.absenceCountedIssueIDs)
+	}
+	counts, err := store.QueryConsecutiveHandoffAbsenceCounts(context.Background(), []string{issueID})
+	if err != nil {
+		t.Fatalf("QueryConsecutiveHandoffAbsenceCounts: %v", err)
+	}
+	if got := counts[issueID]; got != 2 {
+		t.Fatalf("consecutive absences after a suppressed exit = %d, want 2 (unchanged)", got)
+	}
+	if calls := tracker.labels(); len(calls) != 0 {
+		t.Errorf("AddLabel calls = %+v, want none", calls)
+	}
+}
+
 func TestHandleRetryTimerKeepsRecoveredExhaustedAbsenceParkedWhenLabelFails(t *testing.T) {
 	const issueID = "ABS-RECOVERED"
 	store := &mockRetryStore{absenceCounts: map[string]int{issueID: 3}}

--- a/internal/orchestrator/worker_test.go
+++ b/internal/orchestrator/worker_test.go
@@ -2203,6 +2203,55 @@ func TestRunWorkerAttempt_ObservedIssueStateEmptyWhenNoRefresh(t *testing.T) {
 	}
 }
 
+// TestRunWorkerAttempt_AfterRunHookCannotReachWorkerResult pins the
+// ordering that makes a hook's terminal tracker write invisible to the
+// exit disposition: the after_run hook runs after the turn loop's last
+// per-turn refresh and after workspace teardown, immediately before
+// OnExit, so nothing it does can feed back into ObservedIssueState.
+func TestRunWorkerAttempt_AfterRunHookCannotReachWorkerResult(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("after_run hook uses touch command")
+	}
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	markerPath := filepath.Join(tmpDir, "after_run_marker")
+
+	cfg := defaultWorkerConfig(tmpDir)
+	cfg.Agent.MaxTurns = 2
+	cfg.Hooks.AfterRun = fmt.Sprintf("touch %s", markerPath)
+
+	ec := newExitCapture()
+	deps := WorkerDeps{
+		// The default mockTrackerAdapter reports "To Do" for every per-turn
+		// refresh, an active state under defaultWorkerConfig's ActiveStates,
+		// so ObservedIssueState is non-empty by the time the loop ends on
+		// max_turns.
+		TrackerAdapter:         &mockTrackerAdapter{},
+		AgentAdapter:           &mockAgentAdapter{},
+		ConfigFunc:             func() config.ServiceConfig { return cfg },
+		PromptTemplateByIDFunc: func(_ string) *prompt.Template { return mustParseTemplate(t, "{{ .issue.title }}") },
+		OnEvent:                func(_ string, _ domain.AgentEvent) {},
+		OnExit:                 ec.onExit,
+		Logger:                 discardLogger(),
+		// Posture left at its zero value, PostureNormal, so the after_run
+		// hook runs.
+	}
+
+	RunWorkerAttempt(context.Background(), workerTestIssue(), nil, deps)
+	result := ec.waitResult(t)
+
+	if result.ExitKind != WorkerExitNormal {
+		t.Fatalf("ExitKind = %q, want %q", result.ExitKind, WorkerExitNormal)
+	}
+	if _, err := os.Stat(markerPath); err != nil {
+		t.Errorf("after_run marker file not found: %v (workspace.Finish not called)", err)
+	}
+	if result.ObservedIssueState != "To Do" {
+		t.Errorf("ObservedIssueState = %q, want %q (the last per-turn refresh, not a hook write)", result.ObservedIssueState, "To Do")
+	}
+}
+
 // --- stopSessionBestEffort unit tests ---
 
 func TestStopSessionBestEffort(t *testing.T) {

--- a/internal/persistence/store_test.go
+++ b/internal/persistence/store_test.go
@@ -2631,6 +2631,39 @@ func TestLoadLatestSuccessfulRunsForReactionRecovery_PrefersProducingRunOverLate
 	}
 }
 
+// TestLoadLatestSuccessfulRunsForReactionRecovery_SuppressedRunBecomesCandidate
+// guards the MAX(id) selection this query already performs against a
+// later change that adds a discriminator excluding a suppressed row (one
+// whose handoff was withheld by evidence but suppressed by a verified
+// terminal state, and which records "succeeded" with a nil error like
+// any other run taking the terminal disposition). The selection itself
+// is unchanged by that population's existence: this test exists to fail
+// loudly if a later change carves it out of the query, not to endorse
+// which run's attribution a rebuilt reaction entry inherits.
+func TestLoadLatestSuccessfulRunsForReactionRecovery_SuppressedRunBecomesCandidate(t *testing.T) {
+	t.Parallel()
+
+	s := openTestStore(t)
+	migrateOrFatal(t, s)
+	ctx := context.Background()
+	cutoff := recoveryRefTime.Add(-30 * 24 * time.Hour)
+
+	appendRecoveryRun(t, s, "ISS-SUPPRESSED", "PROJ-S", 1, recentCompletedAt(2))
+	suppressed := appendRecoveryRun(t, s, "ISS-SUPPRESSED", "PROJ-S", 2, recentCompletedAt(1))
+
+	got, err := s.LoadLatestSuccessfulRunsForReactionRecovery(ctx, cutoff, 200)
+	if err != nil {
+		t.Fatalf("LoadLatestSuccessfulRunsForReactionRecovery: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("LoadLatestSuccessfulRunsForReactionRecovery() len = %d, want 1", len(got))
+	}
+	if got[0].ID != suppressed.ID || got[0].Attempt != suppressed.Attempt {
+		t.Errorf("recovery run = (id=%d, attempt=%d), want the later succeeded run (id=%d, attempt=%d)",
+			got[0].ID, got[0].Attempt, suppressed.ID, suppressed.Attempt)
+	}
+}
+
 func TestLoadLatestSuccessfulRunsForReactionRecovery_DisplayIDRoundTrip(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Fix

**Intent:** Stop the orchestrator from reporting a session failure and scheduling a retry for an issue that has already reached a terminal state by the time the withheld-handoff disposition is computed, since that report is wrong and the retry is discarded unread.

**Related Issues:** #887

### 🧭 Reviewer Guide

**Complexity:** Medium

#### Entry Point

`internal/orchestrator/exit.go` - `HandleWorkerExit` now re-reads the issue's tracker state, once, immediately before recording an absence failure. The read only happens where `params.TerminalStates` is non-empty and a tracker adapter is available; a verified terminal state reroutes the run into the same suppression path the early-observed terminal case already takes (handoff write suppressed, claim released, no retry, no failure comment), while a read failure or a non-terminal state leaves the absence-failure disposition unchanged.

#### Sensitive Areas

- `internal/orchestrator/exit.go`: the new branch changes which disposition (and therefore which persisted run status) a withheld-handoff run ends up with; a mistake here would misclassify runs on the failure/retry path.
- `internal/persistence/store_test.go`: added a regression test pinning that the restart recovery query's run selection is unaffected by a suppressed run now recording `succeeded` rather than `failed`.
- `docs/decisions/0026-re-read-issue-state-before-recording-absence-failure.md`: records the tradeoffs considered (why `succeeded` was chosen over a distinguishable `failed`, and the known edge cases the fix does not close, such as a tracker read that fails at exit).

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes.
- **Migrations/State:** No migrations or state changes. A suppressed run now persists a `succeeded` run-history record instead of a `failed` one with the absence marker, which changes what the restart recovery query and the consecutive-absence count observe for that population, but requires no schema change (see the ADR's Consequences section for the two known edge cases this leaves open).
