### PR TITLE
docs: document the Copilot CLI pass-through keys

### DIFF
--- a/docs/copilot-adapter-notes.md
+++ b/docs/copilot-adapter-notes.md
@@ -16,7 +16,7 @@ Two flags are load-bearing and unconditional. Without the autonomous-continuatio
 
 ## Session identity, and why turn one is different
 
-Unlike some agent CLIs, this one does not accept a caller-assigned session ID. The ID exists only after the runtime creates it and is learned from the terminal event of the turn that created it. So turn one runs with no session flag at all, the finalize hook captures the ID from the terminal event, and later turns resume it explicitly.
+Unlike some agent CLIs, this one does not accept a caller-assigned session ID. The ID exists only after the runtime creates it and is learned from the terminal event of the turn that created it. So the first turn of a session this run created carries no session flag at all, the finalize hook captures the ID from the terminal event, and later turns resume it explicitly. A session the orchestrator hands back after a restart is different: its ID is known before the first turn, and that turn resumes immediately.
 
 When a turn produces no terminal event carrying an ID and none is known from an earlier turn, the adapter falls back to asking the CLI to resume the most recent conversation in the working directory. That is only safe because Sortie isolates one workspace per issue. Do not extend that idea into session discovery: with more than one agent running concurrently, the most recently written session directory is not necessarily this session's. The adapter opens the runtime's session-state tree only by a known ID, and it validates that ID against a path-segment character set before joining it into a path. Both properties are security boundaries, not stylistic choices.
 

--- a/docs/workflow-reference.md
+++ b/docs/workflow-reference.md
@@ -2485,11 +2485,12 @@ claude-code:
 
 The `claude-code` block is forwarded to the Claude Code adapter, which runs
 `claude -p --output-format stream-json --verbose` once per turn and maps these fields to
-CLI flags. Values are forwarded unchanged, and the adapter validates none of them. What
-the CLI does with an invalid value differs per flag: `--permission-mode` is rejected at
-launch, `--effort` falls back to the default effort with a warning, and an unknown model
-name reaches the API and fails there. A key whose YAML value has the wrong type is
-ignored and the default applies.
+CLI flags. The adapter validates none of these values and forwards each as written, with
+one exception described below: `mcp_config` is superseded by the generated configuration
+the worker writes. What the CLI does with an invalid value differs per flag:
+`--permission-mode` is rejected at launch, `--effort` falls back to the default effort
+with a warning, and an unknown model name reaches the API and fails there. A key whose
+YAML value has the wrong type is ignored and the default applies.
 
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -2503,7 +2504,7 @@ ignored and the default applies.
 | `claude-code.disallowed_tools` | string | _(absent)_ | Forwarded to `--disallowedTools` as a single argument. A comma- or space-separated deny list. A bare tool name removes that tool from the model's context; a scoped rule leaves the tool available and denies only matching calls. |
 | `claude-code.system_prompt` | string | _(absent)_ | Forwarded to `--append-system-prompt`. The text is appended to the default system prompt rather than replacing it. Claude Code's built-in tool instructions stay in effect. |
 | `claude-code.mcp_config` | string | _(absent)_ | Path to an MCP server configuration JSON file, resolved relative to the directory holding WORKFLOW.md when it is not absolute. The worker reads that file, merges its own `sortie-tools` server into a generated copy under the workspace, and passes the copy to `--mcp-config`, which takes a single configuration path. The operator's file is never modified. A file that already declares a `sortie-tools` server fails the attempt. |
-| `claude-code.session_persistence` | boolean | `true` | When `false`, adds `--no-session-persistence` and Claude Code writes no session file to disk. Setting it to `false` is refused before the run starts, because the adapter continues a session by passing `--resume <session_id>` on every turn after the first, and that flag needs the persisted session. |
+| `claude-code.session_persistence` | boolean | `true` | When `false`, adds `--no-session-persistence` and Claude Code writes no session file to disk. Setting it to `false` is refused before the run starts, because the adapter passes `--resume <session_id>` on every turn but the first of a session this run created, which uses `--session-id` instead, and `--resume` needs the persisted session. |
 
 > **Important:** `agent.max_turns` (orchestrator turn-loop limit) and
 > `claude-code.max_turns` (CLI `--max-turns` flag) are distinct values. The orchestrator

--- a/docs/workflow-reference.md
+++ b/docs/workflow-reference.md
@@ -2537,10 +2537,12 @@ copilot-cli:
 
 The `copilot-cli` block is forwarded to the Copilot CLI adapter, which runs
 `copilot -p --output-format json -s --autopilot --no-ask-user` once per turn and maps
-these fields to CLI flags. The first turn passes neither resume flag. After a turn in
-which the CLI reported a session ID, the adapter adds `--resume <session_id>`; after a
-turn that ended without one, it adds `--continue`, which resumes the most recent
-conversation in the workspace directory. Values are forwarded unchanged, and the
+these fields to CLI flags. The adapter adds `--resume <session_id>` once a session ID is
+known, either because the orchestrator resumed the session or because an earlier turn
+reported one. The first turn of a new session carries neither flag, and a turn that ends
+with no session ID, on a session where none was known already, is followed by
+`--continue`, which resumes the most recent conversation in the workspace directory.
+Values are forwarded unchanged, and the
 adapter validates none of them. A key whose YAML value has the wrong type is ignored
 and the default applies.
 

--- a/docs/workflow-reference.md
+++ b/docs/workflow-reference.md
@@ -2564,8 +2564,8 @@ YAML value has the wrong type is ignored and the default applies.
 > **Important:** the four tool-scoping keys act as one switch, not four independent ones.
 > With all of them unset, the adapter passes `--allow-all` and every tool call is
 > auto-approved. Setting any one of them to a non-empty value drops `--allow-all` from
-> every invocation, so a tool that key says nothing about is no longer blanket-approved
-> either; such a call falls to the CLI's own non-interactive policy instead.
+> every invocation, so a tool that no key mentions is no longer blanket-approved; such a
+> call falls to the CLI's own non-interactive policy instead.
 
 > **Important:** the generated MCP configuration file supersedes `copilot-cli.mcp_config`
 > as the value of `--additional-mcp-config`, which is why the operator's servers reach the

--- a/docs/workflow-reference.md
+++ b/docs/workflow-reference.md
@@ -2485,12 +2485,14 @@ claude-code:
 
 The `claude-code` block is forwarded to the Claude Code adapter, which runs
 `claude -p --output-format stream-json --verbose` once per turn and maps these fields to
-CLI flags. The adapter validates none of these values and forwards each as written, with
-one exception described below: `mcp_config` is superseded by the generated configuration
-the worker writes. What the CLI does with an invalid value differs per flag:
-`--permission-mode` is rejected at launch, `--effort` falls back to the default effort
-with a warning, and an unknown model name reaches the API and fails there. A key whose
-YAML value has the wrong type is ignored and the default applies.
+CLI flags. Two keys are checked before a run starts, `permission_mode` and
+`session_persistence`; the preflight refuses a value it cannot support, while the adapter
+itself refuses nothing and would launch on either. Every other value reaches the CLI as
+written, except `mcp_config`, which the generated configuration the worker writes
+supersedes. What the CLI does with an invalid value differs per flag: `--effort` falls
+back to the default effort with a warning, and an unknown model name reaches the API and
+fails there. A key whose YAML value has the wrong type is ignored and the default
+applies.
 
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |

--- a/docs/workflow-reference.md
+++ b/docs/workflow-reference.md
@@ -2520,6 +2520,58 @@ ignored and the default applies.
 > a chain at three models after removing duplicates and ignores the rest. The adapter
 > forwards the configured string unchanged.
 
+**Copilot CLI adapter:**
+
+```yaml
+copilot-cli:
+  model: gpt-5-mini
+  max_autopilot_continues: 100
+  agent: coding-agent
+  allowed_tools: shell
+  denied_tools: write
+  mcp_config: ./mcp-servers.json
+  disable_builtin_mcps: true
+  no_custom_instructions: true
+  experimental: true
+```
+
+The `copilot-cli` block is forwarded to the Copilot CLI adapter, which runs
+`copilot -p --output-format json -s --autopilot --no-ask-user` once per turn and maps
+these fields to CLI flags. The first turn passes neither resume flag. After a turn in
+which the CLI reported a session ID, the adapter adds `--resume <session_id>`; after a
+turn that ended without one, it adds `--continue`, which resumes the most recent
+conversation in the workspace directory. Values are forwarded unchanged, and the
+adapter validates none of them. A key whose YAML value has the wrong type is ignored
+and the default applies.
+
+| Field | Type | Default | Description |
+| --- | --- | --- | --- |
+| `copilot-cli.model` | string | _(absent)_ | Forwarded to `--model`. The accepted model identifiers depend on the installed CLI and the account; `copilot --help` lists the set. |
+| `copilot-cli.max_autopilot_continues` | integer | `50` | Forwarded to `--max-autopilot-continues`, the ceiling on autopilot continuation steps inside one turn. The flag is always passed. An absent key, a non-integer value, and any value of zero or less all send `50`. |
+| `copilot-cli.agent` | string | _(absent)_ | Forwarded to `--agent`. Selects a named Copilot agent persona for the turn. |
+| `copilot-cli.allowed_tools` | string | _(absent)_ | Forwarded to `--allow-tool` as a single argument. Names a tool to allow explicitly. See the tool-scoping note below. |
+| `copilot-cli.denied_tools` | string | _(absent)_ | Forwarded to `--deny-tool` as a single argument. Names a tool to deny explicitly. See the tool-scoping note below. |
+| `copilot-cli.available_tools` | string | _(absent)_ | Forwarded to `--available-tools` as a single argument. Names the set of tools the agent may see. See the tool-scoping note below. |
+| `copilot-cli.excluded_tools` | string | _(absent)_ | Forwarded to `--excluded-tools` as a single argument. Names the set of tools withheld from the agent. See the tool-scoping note below. |
+| `copilot-cli.mcp_config` | string | _(absent)_ | Path to an MCP server configuration JSON file, resolved relative to the directory holding WORKFLOW.md when it is not absolute. The worker reads that file, merges its own `sortie-tools` server into a generated copy under the workspace, and passes the copy to `--additional-mcp-config` prefixed with `@`, which is how the Copilot CLI reads a configuration from a file. The operator's file is never modified. A file that already declares a `sortie-tools` server fails the attempt. See the value-handling note below. |
+| `copilot-cli.disable_builtin_mcps` | boolean | `false` | Adds `--disable-builtin-mcps` when `true`, withholding the CLI's built-in MCP servers. |
+| `copilot-cli.no_custom_instructions` | boolean | `false` | Adds `--no-custom-instructions` when `true`, so the CLI skips the custom instruction files it would otherwise read. |
+| `copilot-cli.experimental` | boolean | `false` | Adds `--experimental` when `true`, enabling the CLI's experimental features. |
+
+> **Important:** the four tool-scoping keys act as one switch, not four independent ones.
+> With all of them unset, the adapter passes `--allow-all` and every tool call is
+> auto-approved. Setting any single one of them drops `--allow-all` from every
+> invocation, so a tool that key says nothing about is no longer blanket-approved
+> either; such a call falls to the CLI's own non-interactive policy instead.
+
+> **Important:** the generated MCP configuration file supersedes `copilot-cli.mcp_config`
+> as the value of `--additional-mcp-config`, which is why the operator's servers reach the
+> agent through the merge described above rather than through a second flag. The
+> configured value is forwarded on its own only when no generated file exists. In that
+> case its form decides the argument: a value beginning with `{` is passed as inline JSON,
+> a value already beginning with `@` is passed unchanged, and anything else is read as a
+> file path and prefixed with `@`.
+
 **Codex adapter:**
 
 ```yaml
@@ -2685,12 +2737,8 @@ stating that Sortie's tools will be neither advertised nor callable for it. Both
 warnings and not errors: such a configuration stays valid, the run proceeds, and the
 exit code is unchanged.
 
-`claude-code.mcp_config` is documented in the Claude Code table above. The Copilot CLI
-reads the same key:
-
-| Field | Type | Default | Description |
-| --- | --- | --- | --- |
-| `copilot-cli.mcp_config` | string | _(absent)_ | Path to an MCP server configuration JSON file, resolved relative to the directory holding WORKFLOW.md when it is not absolute. The worker reads that file, merges its own `sortie-tools` server into a generated copy under the workspace, and passes the copy to `--additional-mcp-config` prefixed with `@`, which is how the Copilot CLI reads a configuration from a file. The operator's file is never modified. A file that already declares a `sortie-tools` server fails the attempt. |
+`claude-code.mcp_config` and `copilot-cli.mcp_config` are documented in the Claude Code
+and Copilot CLI tables above.
 
 **Custom or future adapters (illustrative example):**
 

--- a/docs/workflow-reference.md
+++ b/docs/workflow-reference.md
@@ -2542,9 +2542,10 @@ known, either because the orchestrator resumed the session or because an earlier
 reported one. The first turn of a new session carries neither flag, and a turn that ends
 with no session ID, on a session where none was known already, is followed by
 `--continue`, which resumes the most recent conversation in the workspace directory.
-Values are forwarded unchanged, and the
-adapter validates none of them. A key whose YAML value has the wrong type is ignored
-and the default applies.
+The adapter validates none of these values and forwards each as written, except in the
+two cases described below: a non-positive `max_autopilot_continues` is replaced by `50`,
+and `mcp_config` is reformatted before it reaches `--additional-mcp-config`. A key whose
+YAML value has the wrong type is ignored and the default applies.
 
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -2562,8 +2563,8 @@ and the default applies.
 
 > **Important:** the four tool-scoping keys act as one switch, not four independent ones.
 > With all of them unset, the adapter passes `--allow-all` and every tool call is
-> auto-approved. Setting any single one of them drops `--allow-all` from every
-> invocation, so a tool that key says nothing about is no longer blanket-approved
+> auto-approved. Setting any one of them to a non-empty value drops `--allow-all` from
+> every invocation, so a tool that key says nothing about is no longer blanket-approved
 > either; such a call falls to the CLI's own non-interactive policy instead.
 
 > **Important:** the generated MCP configuration file supersedes `copilot-cli.mcp_config`


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Docs

**Intent:** The adapter pass-through section of the config reference lists blocks for `claude-code`, `codex`, `opencode` and `kiro`, but nothing for `copilot-cli`, even though the kind is named elsewhere on the page (the `agent.kind` row, the `token_rates` example, the Codex block's subprocess note). A reader concludes the adapter accepts no configuration. This adds a `copilot-cli` block documenting all eleven keys the adapter parses - `model`, `max_autopilot_continues`, `agent`, `allowed_tools`, `denied_tools`, `available_tools`, `excluded_tools`, `mcp_config`, `disable_builtin_mcps`, `no_custom_instructions` and `experimental` - with each key's type, default and CLI flag, matching the field-table form already used by the `claude-code`, `opencode` and `kiro` blocks. It also documents three behaviors invisible from the key names: the `50` substitution for a non-positive or absent `max_autopilot_continues`, the `--allow-all` interaction across the four tool-scoping keys, and the `mcp_config` resolution rules (inline JSON vs. path, `@` prefix, supersession by the generated workspace MCP config). The prior standalone `copilot-cli.mcp_config` stub near the MCP section is folded into a single cross-reference to the new table.

**Related Issues:** #876

### 🧭 Reviewer Guide

**Complexity:** Low

#### Entry Point

`docs/workflow-reference.md` - the new `copilot-cli` block sits directly after the Claude Code adapter block and before the Codex block, in the adapter pass-through section. The two `> **Important:**` callouts beneath the table carry the non-obvious behaviors called out in the issue.

#### Sensitive Areas

None - this is a documentation-only change with no code, config, or test impact.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes
- **Migrations/State:** No migrations or state changes