### PR TITLE
fix(orchestrator): consume an in-phase blocked status signal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - An issue that reached a terminal state during a run no longer receives a session-failure comment, a failed run record, or a retry that is then discarded. Sortie now re-checks the issue's tracker state immediately before recording that kind of failure, and stays silent when the issue is already finished.
   ([#887](https://github.com/sortie-ai/sortie/issues/887))
 
+- An `after_run` hook that inspects `.sortie/status` after a run whose self-review phase ended on `blocked` now finds the file absent, the same as it already found for a phase-ending `needs-human-review`. A run that never enters the self-review phase is unchanged.
+  ([#894](https://github.com/sortie-ai/sortie/issues/894))
+
 ### Changed
 
 - The consecutive-absence ceiling no longer follows `agent.max_sessions`. It now reads a new field, `agent.max_consecutive_absences`, which defaults to three and rejects `0` as a configuration error; a deployment that wants no absence checking at all sets `tracker.handoff_evidence: off` instead. `agent.max_sessions` itself is unchanged: it remains the total per-issue session budget. A deployment that set `agent.max_sessions` well above three, paired with a workflow whose runs legitimately leave the workspace untouched, now parks such an issue considerably sooner than before; the park is announced and reversible. An operator who chose a low `agent.max_sessions` to bound a loop should revisit that value, because a workflow advancing one issue through several phases needs a session budget sized to those phases rather than to the runaway guard it was previously also serving.

--- a/docs/agent-to-orchestrator-protocol.md
+++ b/docs/agent-to-orchestrator-protocol.md
@@ -288,6 +288,9 @@ The self-review phase reads `.sortie/status` again after each review turn and ea
 `blocked` aborts the phase. The iteration in progress is recorded as aborted, naming the signal,
 and the run proceeds to its exit as if the phase had produced this outcome directly: the run ends
 as a blocked soft stop whichever of the two admissions (Section 2.3.2) brought it into the phase.
+It is consumed at the same point and on the same terms as `needs-human-review`: the file is
+removed before the phase acts on the value, so the abort is not visible to a later reader of the
+file.
 
 `needs-human-review` does not end the phase. It is consumed on the same terms as the value that
 admitted the run: the file is removed, and the iteration continues exactly as if the file had
@@ -400,11 +403,13 @@ exit_normal(pending_reason)    // exit handler differentiates (Section 3.6)
 The **agent** is the sole writer of the `.sortie/status` file.
 
 The **orchestrator** MUST NOT write to or modify the `.sortie/status` file during a worker run.
-The orchestrator's file-system operations on this path are the pre-dispatch cleanup
-(Section 3.4), the post-turn read (Section 3.1), and a removal at the moment the orchestrator
-acts on a recognized value read during a run (Section 3.4). The file therefore states what the
-agent has said since the orchestrator last responded to it, rather than carrying forward a value
-the orchestrator has already acted on.
+The orchestrator's file-system operations on this path are: the pre-dispatch cleanup
+(Section 3.4); the post-turn read after a coding turn (Section 3.1), which removes nothing; the
+admission removal, when a pending reason admits the run to the self-review phase (Section 3.4);
+and the two in-phase removals, after a review turn and after a fix turn (Section 3.4). Inside the
+self-review phase the file therefore states what the agent has said since the phase last acted on
+it. On a run that never enters the phase, the file states the value the run ended on, since
+nothing removes it between the coding-turn read and teardown.
 
 The agent creates the `.sortie/` directory and status file as needed. The write is a simple
 file creation or overwrite:
@@ -474,12 +479,48 @@ function pre_dispatch_cleanup(workspace_path):
         log_warn("status file cleanup failed", workspace_path, err)
 ```
 
-The orchestrator applies this same removal a second time during a run, at the moment it acts on
-a recognized status value that admits the run to the self-review phase (Section 2.3.2): the file
-is removed immediately before the phase's first review turn, so the phase's own first read does
-not observe the value that admitted it. This second removal applies the same `Lstat` symlink
-rejection and the same tolerance of failure as the pre-dispatch removal; a failed removal does
-not prevent the phase from running.
+The orchestrator applies this same removal at three further points during a run. On admission to
+the self-review phase (Section 2.3.2), the file is removed for the recognized status value that
+admitted the run, immediately before the phase's first review turn, so the phase's own first read
+does not observe the value that admitted it. Inside the phase, the file is removed again after
+each review turn and after each fix turn, whenever the value read there is recognized (Section
+2.3.5). Every one of these removals applies the same `Lstat` symlink rejection and the same
+tolerance of failure as the pre-dispatch removal; a failed removal does not prevent the phase from
+running and does not change the run's exit.
+
+The table below states, for each point at which the orchestrator reads or removes the file,
+whether it removes the file for each of the two recognized values and for the unrecognized-or-
+absent case:
+
+| Point | `blocked` | `needs-human-review` | Unrecognized or absent |
+|---|---|---|---|
+| Pre-dispatch cleanup | Removed | Removed | Removed |
+| Read after a coding turn | Not removed | Not removed | Not removed |
+| Admission to the self-review phase | Does not occur: a pending `blocked` reason does not admit | Removed | Does not occur: the turn-budget admission carries no acted-on value |
+| Read after a review turn | Removed | Removed | Not removed |
+| Read after a fix turn | Removed | Removed | Not removed |
+
+The rule behind this table is a property of the point, not of the value read: whether a point
+removes the file MUST NOT depend on which recognized value was read there, only on whether the
+value is recognized at all. The self-review phase's two reads consume because the point reads
+again: a recognized value read after a review turn or a fix turn is, in the general case, followed
+by a further read inside the same phase, and that later read must not re-observe a value the phase
+has already acted on. This reasoning holds for the in-phase `blocked` case too, even though the
+branch that handles `blocked` ends the phase and reads nothing further; the point still consumes,
+because the answer belongs to the point and not to the value the branch happened to receive. The
+read after a coding turn has no later read behind it, except through the admission to the
+self-review phase, and that case is already covered by the admission removal. The pre-dispatch
+cleanup stands outside this reasoning: it precedes every read of the run and exists to stop one
+run's value from reaching the next, rather than to protect a later read within the same run. The
+difference between the phase's reads and the coding-turn read is therefore a deliberate boundary
+stated here, not an artifact of where a removal call happens to appear in the code.
+
+Because the rule is stated over the five points above and over whether a value is recognized,
+rather than over the two values `blocked` and `needs-human-review` themselves, a status value a
+later protocol version adds inherits each point's answer with no further edit to this section:
+consumed at the two in-phase reads, and left in place at the read after a coding turn. What the
+self-review phase does with such a value once it has consumed it is a separate question, settled
+by whichever section defines the value.
 
 ### 3.5 Idempotency
 
@@ -839,8 +880,10 @@ Operators can inspect the current status signal for any workspace:
 cat /path/to/workspace/.sortie/status
 ```
 
-A missing file or empty output indicates no advisory signal (normal operation). The presence
-of `blocked` or `needs-human-review` indicates the agent's last assessment.
+A missing file or empty output means one of two things: the agent has written nothing since the
+file was last removed, or the orchestrator has already consumed a recognized value the agent
+wrote (Section 3.4). The presence of `blocked` or `needs-human-review` indicates the agent's last
+assessment, not yet acted on by the orchestrator.
 
 ## 9. Conformance
 
@@ -852,15 +895,20 @@ An implementation conforms to this specification if it satisfies all of the foll
 2. The orchestrator recognizes `blocked` and `needs-human-review` per Section 2.3.
 3. The orchestrator ignores unrecognized values per Section 2.5.
 4. The orchestrator handles read errors per Section 2.6.
-5. The orchestrator deletes `.sortie/status` before each new dispatch per Section 3.4, and again
-   at the moment it acts on a recognized value that admits the run to the self-review phase per
-   Section 2.3.2 and Section 3.4.
+5. The orchestrator deletes `.sortie/status` at four points: before each new dispatch; at the
+   moment it acts on a recognized value that admits the run to the self-review phase; after each
+   review turn inside the phase, when the value read is recognized; and after each fix turn
+   inside the phase, when the value read is recognized. All four are per Section 3.4.
 6. The orchestrator never writes to `.sortie/status`, and its only removals of the file are the
-   pre-dispatch cleanup and the removal it makes each time it acts on a recognized value read
-   during a run, both per Section 3.2 and Section 3.4.
+   four named in item 5. In particular: the read after a coding turn removes nothing, for either
+   recognized value, on any deployment (Section 3.2, Section 3.4); and a recognized value read at
+   that point, when the run is not admitted to the self-review phase, remains in the file at
+   teardown (Section 8.3).
 7. The status file does not trigger tracker state transitions per Section 3.6.
 8. Symbolic links at any path component are treated as read errors per Section 7.2.
-9. Pre-dispatch cleanup applies the same symlink rejection as reads per Section 3.4.
+9. Every removal named in item 5, not the pre-dispatch cleanup alone, applies the same `Lstat`
+   symlink rejection, and every one tolerates a failed removal without changing the run's control
+   flow, per Section 3.4.
 10. The orchestrator parks the issue on `blocked` where the dispatch drives issue state, and
     holds it out of dispatch until it observes a release per Section 2.3.1 and Section 3.5.
 

--- a/docs/architecture/09-workspace-management-and-safety.md
+++ b/docs/architecture/09-workspace-management-and-safety.md
@@ -192,16 +192,23 @@ Safety and parsing rules:
 
 #### 9.5.1 `.sortie/status` lifecycle
 
-The orchestrator removes `.sortie/status` at two points in a run's lifetime, both best-effort and
-both subject to the same `Lstat` symlink rejection described for `.sortie/scm.json` above: neither
-removal follows a symbolic link at `.sortie/` or at the file itself, and a rejected or failed
-removal is logged and does not affect the run.
+A run that enters the self-review phase has the file removed at four points in its lifetime, all
+best-effort and all subject to the same `Lstat` symlink rejection described for `.sortie/scm.json`
+above: no removal follows a symbolic link at `.sortie/` or at the file itself, and a rejected or
+failed removal is logged and does not affect the run.
 
 The first removal happens before each new dispatch to a workspace, so a stale value from a
 previous run cannot affect the new one. The second happens during a run, at the moment the
-orchestrator acts on a recognized value read from the file: the removal runs immediately before
-the self-review phase's first review turn, so the file states what the agent has said since the
-orchestrator last responded to it rather than carrying forward a value already acted on.
+orchestrator acts on a recognized value that admits the run to the self-review phase: the removal
+runs immediately before the phase's first review turn, so the phase's own first read does not
+observe the value that admitted it. The third and fourth happen inside the phase itself, after
+each review turn and after each fix turn, whenever the value read there is recognized. Together
+these four removals keep the file stating what the agent has said since the phase last acted on
+it, rather than carrying forward a value already acted on.
+
+The read after each completed coding turn, outside the self-review phase, removes nothing: a
+recognized value read there is left in the file, and a run that never enters the phase carries
+that value through to teardown.
 
 ### 9.6 Safety Invariants
 

--- a/docs/architecture/22-test-and-validation-matrix.md
+++ b/docs/architecture/22-test-and-validation-matrix.md
@@ -386,8 +386,12 @@ Unless otherwise noted, Sections 17.1 through 17.7 are `Core Conformance`. Bulle
 - A `needs-human-review` signal read inside self-review is consumed and does not abort the loop
 - A `blocked` signal read inside self-review aborts the phase, and becomes the run's exit reason
   on either admission path into the phase
+- The status file is removed at both in-phase read sites, after a review turn and after a fix
+  turn, when the phase reads `blocked`, on either admission path into the phase
 - A deployment with self-review disabled treats the completion signal exactly as before, ending
   the run without entering the phase
+- A recognized signal read outside the self-review phase, at the read after a coding turn, leaves
+  the status file in place at teardown, for both `blocked` and `needs-human-review`
 - On an SCM platform that exposes no bot-account marker, a `CHANGES_REQUESTED` review whose author
   matches the operator-configured `bot_usernames` allowlist does not trigger the human
   `review_comments` reaction

--- a/docs/architecture/26-agent-authored-workspace-files.md
+++ b/docs/architecture/26-agent-authored-workspace-files.md
@@ -27,8 +27,9 @@ Recognized values:
   the self-review phase (Section 7); it remains an immediate exit whether or not self-review is
   configured. Written during a phase turn instead, `blocked` ends the phase and gives the run this
   same disposition, distinguished from the coding-turn read by the phase's own tail work: the
-  review-summary write and the non-`disabled` `SORTIE_SELF_REVIEW_STATUS` value the `after_run`
-  hook then receives (Section 13.8).
+  removal of the status file at the point the phase acts on it, the review-summary write, and the
+  non-`disabled` `SORTIE_SELF_REVIEW_STATUS` value the `after_run` hook then receives
+  (Section 13.8).
 - `needs-human-review`: agent signals that work is complete and requires review. Like `blocked`,
   this value suppresses continuation retries and releases the issue claim. Unlike `blocked`, when
   `tracker.handoff_state` is configured, the issue is in an active tracker state, and the dispatch

--- a/internal/orchestrator/self_review.go
+++ b/internal/orchestrator/self_review.go
@@ -445,6 +445,21 @@ func writeReviewSummary(workspacePath string, meta domain.ReviewMetadata, logger
 	}
 }
 
+// readAndConsumeStatusSignal reads the A2O status file and removes it when
+// the returned signal is recognized, so a recognized value is never
+// observed by a later read at the same site.
+//
+// The removal is best-effort and never changes the returned signal: the
+// caller sees the value that was read, whether or not the file was
+// actually removed.
+func readAndConsumeStatusSignal(workspacePath string, logger *slog.Logger) workspace.StatusSignal {
+	signal := workspace.ReadStatusFile(workspacePath, logger)
+	if signal.IsRecognized() {
+		workspace.CleanupStatusFile(workspacePath, logger)
+	}
+	return signal
+}
+
 func runSelfReviewLoop(ctx context.Context, params RunSelfReviewParams) (*domain.ReviewMetadata, workspace.StatusSignal, error) {
 	maxIter := params.Config.MaxIterations
 	iterations := make([]domain.ReviewIterationRecord, 0, maxIter)
@@ -531,7 +546,7 @@ func runSelfReviewLoop(ctx context.Context, params RunSelfReviewParams) (*domain
 		*params.TurnsCompleted++
 
 		// Check A2O status for early abort signals.
-		statusSignal := workspace.ReadStatusFile(params.WorkspacePath, logger)
+		statusSignal := readAndConsumeStatusSignal(params.WorkspacePath, logger)
 		if statusSignal == workspace.StatusBlocked {
 			logger.Info("self-review aborted by agent status",
 				slog.Int("iteration", i),
@@ -546,9 +561,6 @@ func runSelfReviewLoop(ctx context.Context, params RunSelfReviewParams) (*domain
 			})
 			terminalSignal = workspace.StatusBlocked
 			break
-		}
-		if statusSignal == workspace.StatusNeedsHumanReview {
-			workspace.CleanupStatusFile(params.WorkspacePath, logger)
 		}
 
 		verdict, rawJSON, parseErr := readReviewVerdict(params.WorkspacePath)
@@ -641,7 +653,7 @@ func runSelfReviewLoop(ctx context.Context, params RunSelfReviewParams) (*domain
 		*params.TurnsCompleted++
 
 		// Check A2O status after fix turn.
-		statusSignal = workspace.ReadStatusFile(params.WorkspacePath, logger)
+		statusSignal = readAndConsumeStatusSignal(params.WorkspacePath, logger)
 		if statusSignal == workspace.StatusBlocked {
 			logger.Info("self-review aborted by agent status after fix",
 				slog.Int("iteration", i),
@@ -650,9 +662,6 @@ func runSelfReviewLoop(ctx context.Context, params RunSelfReviewParams) (*domain
 			iterations[len(iterations)-1].VerdictParseError = fmt.Sprintf("aborted: agent status %q", statusSignal)
 			terminalSignal = workspace.StatusBlocked
 			break
-		}
-		if statusSignal == workspace.StatusNeedsHumanReview {
-			workspace.CleanupStatusFile(params.WorkspacePath, logger)
 		}
 	}
 

--- a/internal/orchestrator/self_review_test.go
+++ b/internal/orchestrator/self_review_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -1262,11 +1263,12 @@ func TestSelfReviewLoop_TerminalStatusSignal(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name       string
-		maxIter    int
-		cancelled  bool
-		newAdapter func(t *testing.T, wsPath string) domain.AgentAdapter
-		wantSignal workspace.StatusSignal
+		name                  string
+		maxIter               int
+		cancelled             bool
+		newAdapter            func(t *testing.T, wsPath string) domain.AgentAdapter
+		wantSignal            workspace.StatusSignal
+		wantStatusFilePresent bool
 	}{
 		{
 			name:    "blocked_after_review_turn",
@@ -1274,7 +1276,8 @@ func TestSelfReviewLoop_TerminalStatusSignal(t *testing.T) {
 			newAdapter: func(_ *testing.T, wsPath string) domain.AgentAdapter {
 				return &statusWriterAdapter{wsPath: wsPath, status: "blocked"}
 			},
-			wantSignal: workspace.StatusBlocked,
+			wantSignal:            workspace.StatusBlocked,
+			wantStatusFilePresent: false,
 		},
 		{
 			name:    "blocked_after_fix_turn",
@@ -1285,7 +1288,8 @@ func TestSelfReviewLoop_TerminalStatusSignal(t *testing.T) {
 					{status: "blocked"},
 				}}
 			},
-			wantSignal: workspace.StatusBlocked,
+			wantSignal:            workspace.StatusBlocked,
+			wantStatusFilePresent: false,
 		},
 		{
 			name:    "cancelled_context_at_iteration_start",
@@ -1293,8 +1297,9 @@ func TestSelfReviewLoop_TerminalStatusSignal(t *testing.T) {
 			newAdapter: func(_ *testing.T, wsPath string) domain.AgentAdapter {
 				return &verdictWriter{wsPath: wsPath, verdicts: []domain.ReviewVerdict{{Verdict: "pass"}}}
 			},
-			cancelled:  true,
-			wantSignal: workspace.StatusNone,
+			cancelled:             true,
+			wantSignal:            workspace.StatusNone,
+			wantStatusFilePresent: false,
 		},
 		{
 			name:    "review_turn_error",
@@ -1302,7 +1307,8 @@ func TestSelfReviewLoop_TerminalStatusSignal(t *testing.T) {
 			newAdapter: func(_ *testing.T, wsPath string) domain.AgentAdapter {
 				return &failOnFirstAdapter{wsPath: wsPath}
 			},
-			wantSignal: workspace.StatusNone,
+			wantSignal:            workspace.StatusNone,
+			wantStatusFilePresent: false,
 		},
 		{
 			name:    "fix_turn_error",
@@ -1313,7 +1319,8 @@ func TestSelfReviewLoop_TerminalStatusSignal(t *testing.T) {
 					{err: errors.New("simulated fix turn error")},
 				}}
 			},
-			wantSignal: workspace.StatusNone,
+			wantSignal:            workspace.StatusNone,
+			wantStatusFilePresent: false,
 		},
 		{
 			name:    "passing_verdict",
@@ -1321,7 +1328,8 @@ func TestSelfReviewLoop_TerminalStatusSignal(t *testing.T) {
 			newAdapter: func(_ *testing.T, wsPath string) domain.AgentAdapter {
 				return &verdictWriter{wsPath: wsPath, verdicts: []domain.ReviewVerdict{{Verdict: "pass"}}}
 			},
-			wantSignal: workspace.StatusNone,
+			wantSignal:            workspace.StatusNone,
+			wantStatusFilePresent: false,
 		},
 		{
 			name:    "reached_cap",
@@ -1329,7 +1337,29 @@ func TestSelfReviewLoop_TerminalStatusSignal(t *testing.T) {
 			newAdapter: func(_ *testing.T, wsPath string) domain.AgentAdapter {
 				return &verdictWriter{wsPath: wsPath, verdicts: []domain.ReviewVerdict{{Verdict: "iterate"}}}
 			},
-			wantSignal: workspace.StatusNone,
+			wantSignal:            workspace.StatusNone,
+			wantStatusFilePresent: false,
+		},
+		{
+			name:    "unrecognized_after_review_turn",
+			maxIter: 1,
+			newAdapter: func(_ *testing.T, wsPath string) domain.AgentAdapter {
+				return &statusWriterAdapter{wsPath: wsPath, status: "some-unrecognized-token"}
+			},
+			wantSignal:            workspace.StatusNone,
+			wantStatusFilePresent: true,
+		},
+		{
+			name:    "unrecognized_after_fix_turn",
+			maxIter: 3,
+			newAdapter: func(t *testing.T, wsPath string) domain.AgentAdapter {
+				return &scriptedReviewAdapter{t: t, wsPath: wsPath, steps: []reviewStep{
+					{verdict: &domain.ReviewVerdict{Verdict: "iterate", Summary: "needs fix"}},
+					{status: "some-unrecognized-token"},
+				}}
+			},
+			wantSignal:            workspace.StatusNone,
+			wantStatusFilePresent: true,
 		},
 	}
 
@@ -1363,6 +1393,16 @@ func TestSelfReviewLoop_TerminalStatusSignal(t *testing.T) {
 
 			if signal != tt.wantSignal {
 				t.Errorf("runSelfReviewLoop(...) terminal signal = %q, want %q", signal, tt.wantSignal)
+			}
+
+			statusPath := filepath.Join(wsPath, ".sortie", "status")
+			_, statErr := os.Stat(statusPath)
+			if tt.wantStatusFilePresent {
+				if statErr != nil {
+					t.Errorf("os.Stat(%q) = %v, want file present", statusPath, statErr)
+				}
+			} else if statErr == nil || !errors.Is(statErr, fs.ErrNotExist) {
+				t.Errorf("os.Stat(%q) error = %v, want fs.ErrNotExist", statusPath, statErr)
 			}
 		})
 	}

--- a/internal/orchestrator/worker_test.go
+++ b/internal/orchestrator/worker_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io/fs"
 	"log/slog"
 	"os"
 	"os/exec"
@@ -5592,6 +5593,15 @@ func TestRunWorkerAttempt_BlockedSignalSkipsSelfReview(t *testing.T) {
 	if got := tracker.fetchStatesCalls.Load(); got != 0 {
 		t.Errorf("FetchIssueStatesByIDs called %d times, want 0 (no per-turn refresh on a blocked signal)", got)
 	}
+
+	statusPath := filepath.Join(result.WorkspacePath, ".sortie", "status")
+	data, err := os.ReadFile(statusPath) //nolint:gosec // test-controlled path
+	if err != nil {
+		t.Fatalf("reading %q: %v", statusPath, err)
+	}
+	if strings.TrimSpace(string(data)) != "blocked" {
+		t.Errorf("status file content = %q, want %q", strings.TrimSpace(string(data)), "blocked")
+	}
 }
 
 // TestRunWorkerAttempt_SelfReviewDisabledSignalUnchanged is a regression
@@ -5781,6 +5791,11 @@ func TestRunWorkerAttempt_InPhaseBlockedOnReviewTurn(t *testing.T) {
 	if result.ExitKind != WorkerExitNormal {
 		t.Errorf("ExitKind = %q, want %q", result.ExitKind, WorkerExitNormal)
 	}
+
+	statusPath := filepath.Join(result.WorkspacePath, ".sortie", "status")
+	if _, err := os.Stat(statusPath); !errors.Is(err, fs.ErrNotExist) {
+		t.Errorf("os.Stat(%q) error = %v, want fs.ErrNotExist", statusPath, err)
+	}
 }
 
 // TestRunWorkerAttempt_InPhaseBlockedOnFixTurn verifies that a blocked
@@ -5850,6 +5865,11 @@ func TestRunWorkerAttempt_InPhaseBlockedOnFixTurn(t *testing.T) {
 	if result.ExitKind != WorkerExitNormal {
 		t.Errorf("ExitKind = %q, want %q", result.ExitKind, WorkerExitNormal)
 	}
+
+	statusPath := filepath.Join(result.WorkspacePath, ".sortie", "status")
+	if _, err := os.Stat(statusPath); !errors.Is(err, fs.ErrNotExist) {
+		t.Errorf("os.Stat(%q) error = %v, want fs.ErrNotExist", statusPath, err)
+	}
 }
 
 // TestRunWorkerAttempt_TurnBudgetInPhaseBlockedOnFixTurn_BecomesSoftStop
@@ -5915,6 +5935,11 @@ func TestRunWorkerAttempt_TurnBudgetInPhaseBlockedOnFixTurn_BecomesSoftStop(t *t
 	}
 	if result.ExitKind != WorkerExitNormal {
 		t.Errorf("ExitKind = %q, want %q", result.ExitKind, WorkerExitNormal)
+	}
+
+	statusPath := filepath.Join(result.WorkspacePath, ".sortie", "status")
+	if _, err := os.Stat(statusPath); !errors.Is(err, fs.ErrNotExist) {
+		t.Errorf("os.Stat(%q) error = %v, want fs.ErrNotExist", statusPath, err)
 	}
 }
 
@@ -6175,6 +6200,75 @@ func TestRunWorkerAttempt_TurnBudgetInPhaseBlocked_BecomesSoftStop(t *testing.T)
 	last := result.ReviewMetadata.Iterations[len(result.ReviewMetadata.Iterations)-1]
 	if !strings.Contains(last.VerdictParseError, "blocked") {
 		t.Errorf("last iteration VerdictParseError = %q, want to name %q", last.VerdictParseError, "blocked")
+	}
+
+	statusPath := filepath.Join(result.WorkspacePath, ".sortie", "status")
+	if _, err := os.Stat(statusPath); !errors.Is(err, fs.ErrNotExist) {
+		t.Errorf("os.Stat(%q) error = %v, want fs.ErrNotExist", statusPath, err)
+	}
+}
+
+// TestRunWorkerAttempt_AfterRunHookObservesConsumedBlockedStatus reproduces
+// the issue's Steps to Reproduce end to end: self-review enabled, the
+// coding turn writes needs-human-review, the review turn writes blocked,
+// and the after_run hook that inspects .sortie/status finds it absent
+// because the in-phase blocked read consumed it.
+func TestRunWorkerAttempt_AfterRunHookObservesConsumedBlockedStatus(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("after_run hook uses a shell test")
+	}
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	issue := workerTestIssue()
+	wsRoot := filepath.Join(tmpDir, issue.Identifier)
+	statusPath := filepath.Join(wsRoot, ".sortie", "status")
+	hookObservedAbsent := filepath.Join(tmpDir, "hook_observed_absent")
+
+	cfg := defaultWorkerConfig(tmpDir)
+	cfg.Agent.MaxTurns = 10
+	cfg.Hooks.AfterRun = fmt.Sprintf("test ! -f %q && touch %q", statusPath, hookObservedAbsent)
+	cfg.SelfReview = config.SelfReviewConfig{
+		Enabled:               true,
+		MaxIterations:         1,
+		VerificationCommands:  []string{"echo ok"},
+		VerificationTimeoutMS: 5000,
+	}
+
+	startFn, wsPath := captureWorkspacePath()
+	var codingTurnDone bool
+	ec := newExitCapture()
+
+	deps := WorkerDeps{
+		TrackerAdapter: &mockTrackerAdapter{},
+		AgentAdapter: &mockAgentAdapter{
+			startSessionFn: startFn,
+			runTurnFn: func(_ context.Context, session domain.Session, params domain.RunTurnParams) (domain.TurnResult, error) {
+				switch {
+				case isSelfReviewTurnPrompt(params.Prompt):
+					writeStatusFile(t, wsPath(), "blocked")
+				case !codingTurnDone:
+					codingTurnDone = true
+					writeStatusFile(t, wsPath(), "needs-human-review")
+				}
+				return domain.TurnResult{SessionID: session.ID, ExitReason: domain.EventTurnCompleted}, nil
+			},
+		},
+		ConfigFunc:             func() config.ServiceConfig { return cfg },
+		PromptTemplateByIDFunc: func(_ string) *prompt.Template { return mustParseTemplate(t, "{{ .issue.title }}") },
+		OnEvent:                func(_ string, _ domain.AgentEvent) {},
+		OnExit:                 ec.onExit,
+		Logger:                 discardLogger(),
+	}
+
+	RunWorkerAttempt(context.Background(), issue, nil, deps)
+	result := ec.waitResult(t)
+
+	if result.SoftStopReason != "blocked" {
+		t.Errorf("SoftStopReason = %q, want %q", result.SoftStopReason, "blocked")
+	}
+	if _, err := os.Stat(hookObservedAbsent); err != nil {
+		t.Errorf("after_run hook did not observe the status file as absent: %v", err)
 	}
 }
 


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Fix

**Intent:** The self-review phase read `.sortie/status` after each review turn and each fix turn, but only removed the file when the value was `needs-human-review`. A `blocked` value ended the phase and became the run's soft-stop reason without the file being removed, so an `after_run` hook that inspects the file observed a value the orchestrator had already acted on. This makes the in-phase `blocked` branch consume the file on the same terms as its sibling `needs-human-review`.

**Related Issues:** #894

### 🧭 Reviewer Guide

**Complexity:** Low

#### Entry Point

`internal/orchestrator/self_review.go` - the new `readAndConsumeStatusSignal` helper wraps the existing read with a removal that runs whenever the returned signal is recognized, and replaces the two in-phase `workspace.ReadStatusFile` call sites (after a review turn and after a fix turn). Each site's separate `needs-human-review`-only cleanup call is gone because the helper now does that unconditionally for any recognized value.

#### Sensitive Areas

- `internal/orchestrator/self_review.go`: both in-phase read sites now share one removal path; a regression here would silently reintroduce the asymmetry between `blocked` and `needs-human-review`.
- `docs/agent-to-orchestrator-protocol.md`: the conformance list and the removal-points table were rewritten to state the rule as a property of the read point rather than of the value read there, so a future recognized value inherits the same behavior without a doc edit.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes
- **Migrations/State:** No migrations or state changes
