### PR TITLE
test(codex): assert TurnSandboxPolicy contents, not length

### DIFF
--- a/internal/agent/codex/parse_test.go
+++ b/internal/agent/codex/parse_test.go
@@ -2,6 +2,7 @@ package codex
 
 import (
 	"encoding/json"
+	"reflect"
 	"strings"
 	"testing"
 	"unicode/utf8"
@@ -31,20 +32,43 @@ func TestParsePassthroughConfig(t *testing.T) {
 		{
 			name: "all fields present",
 			config: map[string]any{
-				"model":               "o4-mini",
-				"effort":              "high",
-				"approval_policy":     "never",
-				"thread_sandbox":      "workspaceWrite",
-				"personality":         "helpful",
-				"turn_sandbox_policy": map[string]any{"networkAccess": true},
+				"model":           "o4-mini",
+				"effort":          "high",
+				"approval_policy": "never",
+				"thread_sandbox":  "workspaceWrite",
+				"personality":     "helpful",
+				"turn_sandbox_policy": map[string]any{
+					"networkAccess": true,
+					"writableRoots": []any{"/workspace/abc", "/tmp"},
+				},
 			},
 			want: passthroughConfig{
-				Model:             "o4-mini",
-				Effort:            "high",
-				ApprovalPolicy:    "never",
-				ThreadSandbox:     "workspaceWrite",
-				Personality:       "helpful",
-				TurnSandboxPolicy: map[string]any{"networkAccess": true},
+				Model:          "o4-mini",
+				Effort:         "high",
+				ApprovalPolicy: "never",
+				ThreadSandbox:  "workspaceWrite",
+				Personality:    "helpful",
+				TurnSandboxPolicy: map[string]any{
+					"networkAccess": true,
+					"writableRoots": []any{"/workspace/abc", "/tmp"},
+				},
+			},
+		},
+		{
+			// turn_sandbox_policy is forwarded verbatim, so a nested
+			// value survives parsing uninterpreted.
+			name: "nested turn_sandbox_policy value passes through",
+			config: map[string]any{
+				"turn_sandbox_policy": map[string]any{
+					"networkAccess": false,
+					"nested":        map[string]any{"inner": "value"},
+				},
+			},
+			want: passthroughConfig{
+				TurnSandboxPolicy: map[string]any{
+					"networkAccess": false,
+					"nested":        map[string]any{"inner": "value"},
+				},
 			},
 		},
 		{
@@ -79,8 +103,11 @@ func TestParsePassthroughConfig(t *testing.T) {
 			if got.Personality != tt.want.Personality {
 				t.Errorf("Personality = %q, want %q", got.Personality, tt.want.Personality)
 			}
-			if len(got.TurnSandboxPolicy) != len(tt.want.TurnSandboxPolicy) {
-				t.Errorf("TurnSandboxPolicy len = %d, want %d", len(got.TurnSandboxPolicy), len(tt.want.TurnSandboxPolicy))
+			// Compared with reflect.DeepEqual rather than maps.Equal:
+			// the values are any, and nested maps and the []any that
+			// YAML sequences decode into are not comparable with ==.
+			if !reflect.DeepEqual(got.TurnSandboxPolicy, tt.want.TurnSandboxPolicy) {
+				t.Errorf("TurnSandboxPolicy = %#v, want %#v", got.TurnSandboxPolicy, tt.want.TurnSandboxPolicy)
 			}
 		})
 	}


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Fix

**Intent:** `TestParsePassthroughConfig` compared the parsed `TurnSandboxPolicy` map by entry count only, so a renamed key, a coerced or dropped value, or a swapped sub-object could pass unnoticed as long as the count matched. Replace the length check with a full content comparison so the test actually catches map-content regressions.

**Related Issues:** #897

### 🧭 Reviewer Guide

**Complexity:** Low

#### Entry Point

`internal/agent/codex/parse_test.go` - the `TestParsePassthroughConfig` assertion now compares `got.TurnSandboxPolicy` against `tt.want.TurnSandboxPolicy` with `reflect.DeepEqual` instead of `len(...) != len(...)`. `reflect.DeepEqual` is needed because the map values are `any` and can hold nested maps or `[]any` slices that are not comparable with `==`. A new "nested turn_sandbox_policy value passes through" subtest confirms a nested value survives parsing uninterpreted.

#### Sensitive Areas

None - test-only change with no production code touched.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes
- **Migrations/State:** No migrations or state changes
