### PR TITLE
fix(workspace): resume the windows hook process after job assignment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,6 +177,9 @@ jobs:
       - name: Run tests
         run: go test -count=1 ./...
 
+      - name: Run workspace tests verbosely
+        run: go test -v -count=1 ./internal/workspace/...
+
   build:
     name: Build
     runs-on: ubuntu-latest

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -377,3 +377,22 @@ jobs:
         run: |
           echo "::error::Integration check failed for ${ADAPTER}"
           exit 1
+
+  hook-stress:
+    name: Windows hook stress
+    runs-on: windows-latest
+    timeout-minutes: 25
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+
+      - name: Run the hook stress harness
+        env:
+          SORTIE_HOOKSTRESS_TEST: "1"
+        run: go test -v -count=1 -timeout 15m ./internal/workspace/...

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `reactions.ci_failure.watch_window_ms` now rejects a value above `9223372036854` (about 292 years) instead of converting it to a window of a fraction of a millisecond or to no bound at all. `0` still means no time limit. A deployment currently carrying a larger value is refused at startup and by `sortie validate` until the value is lowered.
   ([#956](https://github.com/sortie-ai/sortie/issues/956))
 
-- On Windows, a hook's background child can no longer outlive the timeout's process-tree kill and hold the workspace directory open. The hook subprocess is now created suspended and only allowed to run after it has been placed in the Job Object that the timeout kills, closing a window in which a child started before that assignment survived termination and kept the directory locked.
+- On Windows, a hook's background child no longer escapes the timeout's process-tree kill by starting before the hook process joined the Job Object that the kill targets. The hook subprocess is now created suspended and only allowed to run once it is a member, closing the window in which such a child survived termination and kept the workspace directory locked. A hook whose Job Object cannot be created still runs, as it did before, and the failure is logged.
   ([#883](https://github.com/sortie-ai/sortie/issues/883))
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `reactions.ci_failure.watch_window_ms` now rejects a value above `9223372036854` (about 292 years) instead of converting it to a window of a fraction of a millisecond or to no bound at all. `0` still means no time limit. A deployment currently carrying a larger value is refused at startup and by `sortie validate` until the value is lowered.
   ([#956](https://github.com/sortie-ai/sortie/issues/956))
 
+- On Windows, a hook's background child can no longer outlive the timeout's process-tree kill and hold the workspace directory open. The hook subprocess is now created suspended and only allowed to run after it has been placed in the Job Object that the timeout kills, closing a window in which a child started before that assignment survived termination and kept the directory locked.
+  ([#883](https://github.com/sortie-ai/sortie/issues/883))
+
 ### Changed
 
 - `reactions.review_comments`, `reactions.bot_review`, `reactions.merge_conflicts`, and `reactions.auto_merge` now bound a pending entry's age with a per-reaction `watch_window_ms` key instead of a hardcoded thirty-minute constant. The default stays `1800000` (thirty minutes), so a deployment that sets nothing behaves exactly as before; setting `0` removes the bound entirely. A workflow with no `auto_merge`, where a person reviews and merges, will normally want a larger value than the default. The four expiry log records changed their message text and renamed their `ttl_ms` attribute to `window_ms`.

--- a/docs/architecture/09-workspace-management-and-safety.md
+++ b/docs/architecture/09-workspace-management-and-safety.md
@@ -87,9 +87,11 @@ Execution contract:
   `cwd`.
 - On POSIX systems, `sh -c <script>` is the conforming default; `bash -lc <script>` may be used
   when a login shell environment is required.
-- On Windows, `cmd.exe /C <script>` is the conforming default. The hook subprocess is assigned to
-  a Job Object with `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` so that timeout-triggered termination
-  kills the entire process tree, not just the direct child.
+- On Windows, `cmd.exe /C <script>` is the conforming default. The hook subprocess is created
+  suspended and assigned to a Job Object with `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` before it is
+  resumed, so no unsupervised execution window exists in which a spawned descendant could start
+  before the job assignment takes effect. Timeout-triggered termination therefore kills the
+  entire process tree, not just the direct child.
 - Hook timeout uses `hooks.timeout_ms`; default: `60000 ms`.
 - Log hook start, failures, and timeouts. A failure or timeout record carries the hook's captured
   combined stdout and stderr under `hook_output`; a hook that succeeds with output emits it in a

--- a/docs/architecture/09-workspace-management-and-safety.md
+++ b/docs/architecture/09-workspace-management-and-safety.md
@@ -91,7 +91,9 @@ Execution contract:
   suspended and assigned to a Job Object with `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` before it is
   resumed, so no unsupervised execution window exists in which a spawned descendant could start
   before the job assignment takes effect. Timeout-triggered termination therefore kills the
-  entire process tree, not just the direct child.
+  entire process tree, not just the direct child. Job Object creation is not a precondition for
+  running the hook: when it fails, the failure is logged, the hook still runs, and that run has
+  no process-tree termination guarantee.
 - Hook timeout uses `hooks.timeout_ms`; default: `60000 ms`.
 - Log hook start, failures, and timeouts. A failure or timeout record carries the hook's captured
   combined stdout and stderr under `hook_output`; a hook that succeeds with output emits it in a

--- a/docs/architecture/22-test-and-validation-matrix.md
+++ b/docs/architecture/22-test-and-validation-matrix.md
@@ -71,7 +71,8 @@ Unless otherwise noted, Sections 17.1 through 17.7 are `Core Conformance`. Bulle
   that pass
 - One sweep summary record is emitted per pass that produced a candidate set, including a pass
   that removed nothing, and its outcome counters sum to the candidate count
-- On Windows, the hook subprocess is a Job Object member before it executes
+- On Windows, the hook subprocess is a Job Object member before it executes whenever the Job
+  Object was created; a creation failure is reported and the hook runs without one
 - On Windows, a hook process that cannot be resumed after job assignment is reported as a start
   failure rather than a timeout, unless a context error was already pending when resume was
   attempted

--- a/docs/architecture/22-test-and-validation-matrix.md
+++ b/docs/architecture/22-test-and-validation-matrix.md
@@ -71,6 +71,10 @@ Unless otherwise noted, Sections 17.1 through 17.7 are `Core Conformance`. Bulle
   that pass
 - One sweep summary record is emitted per pass that produced a candidate set, including a pass
   that removed nothing, and its outcome counters sum to the candidate count
+- On Windows, the hook subprocess is a Job Object member before it executes
+- On Windows, a hook process that cannot be resumed after job assignment is reported as a start
+  failure rather than a timeout, unless a context error was already pending when resume was
+  attempted
 
 ### 17.3 Issue Tracker Client
 

--- a/internal/workspace/hook_windows.go
+++ b/internal/workspace/hook_windows.go
@@ -56,6 +56,8 @@ type hookTeardown struct {
 	RootProbeErr     error // non-nil when the root probe itself failed
 	Survivors        []hookSurvivor
 	SurvivorScanErr  error // non-nil when the scan itself failed
+	JobListErr       error // non-nil when reading the job's PID list failed
+	DrainQueryErr    error // non-nil when a drain accounting query failed
 }
 
 // hookSurvivor names one process descended from the hook root that was
@@ -199,7 +201,7 @@ func RunHook(ctx context.Context, params HookParams) (HookResult, error) {
 
 	var jobPIDs []uint32
 	if job != 0 {
-		jobPIDs, _ = jobMemberPIDs(job)
+		jobPIDs, teardown.JobListErr = jobMemberPIDs(job)
 	}
 	teardown.JobMemberPIDs = jobPIDs
 
@@ -321,8 +323,21 @@ func logHookTeardown(params HookParams, teardown hookTeardown) {
 	if teardown.SurvivorScanErr != nil {
 		args = append(args, slog.Any("survivor_scan_err", teardown.SurvivorScanErr))
 	}
+	if teardown.JobListErr != nil {
+		args = append(args, slog.Any("job_list_err", teardown.JobListErr))
+	}
+	if teardown.DrainQueryErr != nil {
+		args = append(args, slog.Any("drain_query_err", teardown.DrainQueryErr))
+	}
 
-	unsettled := len(teardown.Survivors) > 0 || teardown.ActiveLast > 0 || teardown.SurvivorScanErr != nil
+	// An observation that failed is not an observation of a clean
+	// teardown: it says nothing either way, so it raises the record
+	// rather than letting a default zero value read as settled.
+	unsettled := len(teardown.Survivors) > 0 ||
+		teardown.ActiveLast > 0 ||
+		teardown.SurvivorScanErr != nil ||
+		teardown.JobListErr != nil ||
+		teardown.DrainQueryErr != nil
 	if unsettled {
 		slog.Warn("hook process tree did not settle", args...)
 		return
@@ -470,6 +485,14 @@ func resumeHookProcess(pid uint32) (resumedThreads int, err error) {
 		}
 	}
 
+	if unresolvedErr == nil && resumedThreads == 0 {
+		// The snapshot held no thread owned by the hook process, so
+		// nothing was resumed and the process is still suspended.
+		// Reporting success here would leave it to block until the
+		// context expires and be misreported as a script timeout.
+		unresolvedErr = fmt.Errorf("no thread owned by process %d appeared in the thread snapshot", pid)
+	}
+
 	return resumedThreads, unresolvedErr
 }
 
@@ -528,6 +551,9 @@ func scanSurvivors(rootPID uint32, jobPIDs []uint32) ([]hookSurvivor, error) {
 	var entry windows.ProcessEntry32
 	entry.Size = uint32(unsafe.Sizeof(entry))
 	walkErr := windows.Process32First(snapshot, &entry)
+	if walkErr != nil {
+		return nil, fmt.Errorf("Process32First: %w", walkErr)
+	}
 	for walkErr == nil {
 		entries = append(entries, procInfo{
 			pid:    entry.ProcessID,
@@ -652,6 +678,7 @@ func waitJobDrained(job windows.Handle, teardown *hookTeardown) {
 		)
 		teardown.DrainPolls++
 		if err != nil {
+			teardown.DrainQueryErr = err
 			slog.Warn("hook job accounting query failed; drain skipped",
 				slog.Any("error", err))
 			return

--- a/internal/workspace/hook_windows.go
+++ b/internal/workspace/hook_windows.go
@@ -9,6 +9,8 @@ import (
 	"log/slog"
 	"math"
 	"os/exec"
+	"slices"
+	"sync/atomic"
 	"syscall"
 	"time"
 	"unsafe"
@@ -22,19 +24,75 @@ import (
 // from normal non-zero exits.
 const statusControlCExit uint32 = 0xC000013A
 
+// hookAssignDelay is a fault-injection seam that delays job assignment
+// relative to process start, for reproducing a start-to-assign race on
+// demand. Its zero value is production behavior: RunHook reads it once
+// per invocation and skips the sleep entirely when it is zero. It is
+// unreachable from configuration, from an environment variable, or
+// from any exported identifier, and is only ever written by a
+// non-parallel top-level test, which restores it to zero through
+// t.Cleanup. It is an atomic.Int64 rather than a plain variable
+// because the Windows test job runs without the race detector and so
+// cannot enforce single-writer discipline by convention.
+var hookAssignDelay atomic.Int64 // nanoseconds
+
+// hookTeardown carries what RunHook observed while tearing the hook
+// process tree down, for one invocation. Every field is populated on
+// every path that reaches the point where the record is emitted,
+// including the resume-failure path.
+type hookTeardown struct {
+	WaitMS           int64  // cmd.Wait duration
+	WaitDelayExpired bool   // errors.Is(waitErr, exec.ErrWaitDelay)
+	DrainMS          int64  // waitJobDrained duration
+	DrainPolls       int    // QueryInformationJobObject calls made
+	ActiveFirst      uint32 // ActiveProcesses at the first poll
+	ActiveLast       uint32 // ActiveProcesses at the last poll
+	TotalProcesses   uint32 // processes ever associated with the job
+	TotalTerminated  uint32 // TotalTerminatedProcesses
+	ResumedThreads   int    // threads resumed while starting the hook process
+	JobMemberPIDs    []uint32
+	RootOpenable     bool  // hook root still openable after the drain
+	RootInJobList    bool  // hook root PID still in JobMemberPIDs
+	RootProbeErr     error // non-nil when the root probe itself failed
+	Survivors        []hookSurvivor
+	SurvivorScanErr  error // non-nil when the scan itself failed
+}
+
+// hookSurvivor names one process descended from the hook root that was
+// still alive after the drain returned.
+type hookSurvivor struct {
+	PID       uint32
+	ParentPID uint32
+	Image     string // ProcessEntry32.ExeFile, base name only
+	InJob     bool   // PID present in hookTeardown.JobMemberPIDs
+}
+
+// jobObjectBasicProcessIDList mirrors the Win32
+// JOBOBJECT_BASIC_PROCESS_ID_LIST layout consumed by
+// QueryInformationJobObject with JobObjectBasicProcessIdList;
+// x/sys/windows defines the information class constant but not the
+// struct. ProcessIDList is a variable-length trailing array: callers
+// must over-allocate the buffer passed to QueryInformationJobObject
+// and read past the fixed one-element bound to reach every entry.
+type jobObjectBasicProcessIDList struct {
+	NumberOfAssignedProcesses uint32
+	NumberOfProcessIdsInList  uint32
+	ProcessIDList             [1]uintptr
+}
+
 // RunHook executes a hook script via cmd.exe on Windows, enforcing a
-// timeout and capturing output. The subprocess is placed in a Job
-// Object with KILL_ON_JOB_CLOSE so that the entire process tree is
-// terminated on timeout or context cancellation. Before returning,
-// RunHook terminates any process remaining in the job and waits for
-// the job to drain, so no descendant still holds a handle into the
-// hook directory when the caller proceeds to clean it up.
+// timeout and capturing output. The subprocess is created suspended
+// and assigned to a Job Object with KILL_ON_JOB_CLOSE before it is
+// resumed, so nothing it spawns can start before the job assignment
+// takes effect. Before returning, RunHook terminates any process
+// remaining in the job and waits for the job to report zero active
+// processes, or for the drain deadline to elapse.
 //
 // On success (exit code 0), returns a [HookResult] with truncated
 // output. On failure, returns a [*HookError] with Op indicating the
 // failure mode:
 //   - "validate": invalid params
-//   - "start": subprocess could not be started
+//   - "start": subprocess could not be started, or could not be resumed
 //   - "run": subprocess exited with non-zero exit code
 //   - "timeout": subprocess exceeded TimeoutMS or parent ctx cancelled
 func RunHook(ctx context.Context, params HookParams) (HookResult, error) {
@@ -48,7 +106,7 @@ func RunHook(ctx context.Context, params HookParams) (HookResult, error) {
 	cmd := exec.CommandContext(hookCtx, "cmd.exe", "/C", params.Script) //nolint:gosec // G204: hook scripts are from trusted workflow configuration
 	cmd.Dir = params.Dir
 	cmd.SysProcAttr = &syscall.SysProcAttr{
-		CreationFlags: windows.CREATE_NEW_PROCESS_GROUP,
+		CreationFlags: windows.CREATE_NEW_PROCESS_GROUP | windows.CREATE_SUSPENDED,
 	}
 	cmd.Env = hookEnv(params.Env)
 
@@ -63,6 +121,12 @@ func RunHook(ctx context.Context, params HookParams) (HookResult, error) {
 			ExitCode: -1,
 			Err:      err,
 		}
+	}
+	startedAt := time.Now()
+
+	// The fault-injection seam: zero in production, a no-op sleep.
+	if delay := hookAssignDelay.Load(); delay != 0 {
+		time.Sleep(time.Duration(delay))
 	}
 
 	// Create a Job Object and assign the hook process so that all
@@ -89,7 +153,32 @@ func RunHook(ctx context.Context, params HookParams) (HookResult, error) {
 
 	cmd.WaitDelay = 3 * time.Second
 
+	// The process was created suspended, so it cannot run at all until
+	// its threads are resumed. Resume verifies its own success through
+	// the returned previous suspend count rather than trusting a nil
+	// error, and a failure here terminates the process rather than
+	// letting it run unsupervised: a suspended process cannot be made
+	// to run without a thread handle, so there is no unsupervised
+	// fallback to degrade to.
+	var teardown hookTeardown
+	resumedThreads, resumeErr := resumeHookProcess(uint32(cmd.Process.Pid)) //nolint:gosec // G115: a Windows PID never exceeds uint32 range
+	teardown.ResumedThreads = resumedThreads
+	if resumeErr != nil {
+		if job != 0 {
+			_ = windows.TerminateJobObject(job, statusControlCExit)
+		} else {
+			_ = cmd.Process.Kill()
+		}
+		slog.Warn("hook process resume failed",
+			slog.String("dir", params.Dir),
+			slog.Int("timeout_ms", params.TimeoutMS),
+			slog.Any("error", resumeErr))
+	}
+
+	waitStart := time.Now()
 	err := cmd.Wait()
+	teardown.WaitMS = time.Since(waitStart).Milliseconds()
+	teardown.WaitDelayExpired = errors.Is(err, exec.ErrWaitDelay)
 	output := buf.String()
 
 	// Job process termination is asynchronous: TerminateJobObject and
@@ -103,7 +192,54 @@ func RunHook(ctx context.Context, params HookParams) (HookResult, error) {
 			slog.Warn("hook job termination after wait failed; drain may not settle",
 				slog.Any("error", termErr))
 		}
-		waitJobDrained(job)
+		drainStart := time.Now()
+		waitJobDrained(job, &teardown)
+		teardown.DrainMS = time.Since(drainStart).Milliseconds()
+	}
+
+	var jobPIDs []uint32
+	if job != 0 {
+		jobPIDs, _ = jobMemberPIDs(job)
+	}
+	teardown.JobMemberPIDs = jobPIDs
+
+	pid := uint32(cmd.Process.Pid) //nolint:gosec // G115: a Windows PID never exceeds uint32 range
+	teardown.Survivors, teardown.SurvivorScanErr = scanSurvivors(pid, jobPIDs)
+	teardown.RootInJobList, teardown.RootOpenable, teardown.RootProbeErr = probeHookRoot(pid, jobPIDs, startedAt)
+
+	logHookTeardown(params, teardown)
+
+	if resumeErr != nil {
+		// Consult the context error first, exactly like the ordinary
+		// classification below: a deadline or cancellation landing in
+		// the resume window killed the suspended process and left no
+		// thread to resume, which is a timeout rather than a start
+		// failure.
+		if hookCtx.Err() == context.DeadlineExceeded {
+			return HookResult{}, &HookError{
+				Op:       "timeout",
+				Script:   truncateScript(params.Script),
+				ExitCode: -1,
+				Output:   output,
+				Err:      fmt.Errorf("hook timed out after %dms: %w", params.TimeoutMS, context.DeadlineExceeded),
+			}
+		}
+		if hookCtx.Err() == context.Canceled {
+			return HookResult{}, &HookError{
+				Op:       "timeout",
+				Script:   truncateScript(params.Script),
+				ExitCode: -1,
+				Output:   output,
+				Err:      fmt.Errorf("hook cancelled: %w", context.Canceled),
+			}
+		}
+		return HookResult{}, &HookError{
+			Op:       "start",
+			Script:   truncateScript(params.Script),
+			ExitCode: -1,
+			Output:   output,
+			Err:      fmt.Errorf("resume hook process: %w", resumeErr),
+		}
 	}
 
 	if err == nil {
@@ -150,6 +286,48 @@ func RunHook(ctx context.Context, params HookParams) (HookResult, error) {
 		Output:   output,
 		Err:      err,
 	}
+}
+
+// logHookTeardown emits exactly one record per RunHook invocation
+// describing what teardown observed. The level is Warn only on
+// conclusive evidence of a leak (a surviving descendant, a non-zero
+// active-process count at the last drain poll, or a failed survivor
+// scan); otherwise it is Debug, which the default logger suppresses.
+// Every populated field of teardown is carried as an attribute on
+// both arms so an operator reading either record can tell whether a
+// process escaped the job, whether the hook root outlived its removal
+// from the job's active count, and how long each phase took.
+func logHookTeardown(params HookParams, teardown hookTeardown) {
+	args := []any{
+		slog.String("dir", params.Dir),
+		slog.Int("timeout_ms", params.TimeoutMS),
+		slog.Int64("wait_ms", teardown.WaitMS),
+		slog.Bool("wait_delay_expired", teardown.WaitDelayExpired),
+		slog.Int64("drain_ms", teardown.DrainMS),
+		slog.Int("drain_polls", teardown.DrainPolls),
+		slog.Int64("active_first", int64(teardown.ActiveFirst)),
+		slog.Int64("active_last", int64(teardown.ActiveLast)),
+		slog.Int64("total_processes", int64(teardown.TotalProcesses)),
+		slog.Int64("total_terminated", int64(teardown.TotalTerminated)),
+		slog.Int("resumed_threads", teardown.ResumedThreads),
+		slog.Any("job_member_pids", teardown.JobMemberPIDs),
+		slog.Bool("root_openable", teardown.RootOpenable),
+		slog.Bool("root_in_job_list", teardown.RootInJobList),
+		slog.Any("survivors", teardown.Survivors),
+	}
+	if teardown.RootProbeErr != nil {
+		args = append(args, slog.Any("root_probe_err", teardown.RootProbeErr))
+	}
+	if teardown.SurvivorScanErr != nil {
+		args = append(args, slog.Any("survivor_scan_err", teardown.SurvivorScanErr))
+	}
+
+	unsettled := len(teardown.Survivors) > 0 || teardown.ActiveLast > 0 || teardown.SurvivorScanErr != nil
+	if unsettled {
+		slog.Warn("hook process tree did not settle", args...)
+		return
+	}
+	slog.Debug("hook process tree settled", args...)
 }
 
 // createHookJobObject creates an anonymous Job Object with
@@ -204,6 +382,238 @@ func createHookJobObject(pid int) (windows.Handle, error) {
 	return job, nil
 }
 
+// createToolhelp32SnapshotRetry calls CreateToolhelp32Snapshot, retrying
+// up to 3 attempts total with a 10 ms pause between attempts.
+// CreateToolhelp32Snapshot can fail transiently, so a single failure is
+// not conclusive. Callers decide their own policy for exhaustion; this
+// helper only retries and reports the last error.
+func createToolhelp32SnapshotRetry(flags uint32, processID uint32) (windows.Handle, error) {
+	const (
+		maxAttempts = 3
+		retryDelay  = 10 * time.Millisecond
+	)
+
+	var lastErr error
+	for attempt := range maxAttempts {
+		if attempt > 0 {
+			time.Sleep(retryDelay)
+		}
+		snapshot, err := windows.CreateToolhelp32Snapshot(flags, processID)
+		if err == nil {
+			return snapshot, nil
+		}
+		lastErr = err
+	}
+	return 0, fmt.Errorf("CreateToolhelp32Snapshot: %w", lastErr)
+}
+
+// resumeHookProcess resumes every thread owned by the process
+// identified by pid, verifying each resume through the returned
+// previous suspend count rather than assuming success from a nil
+// error. A returned count greater than 1 means another agent also
+// suspended the thread, so resume is retried on that thread until the
+// previous count reaches 1, bounded at 8 iterations. PID reuse is not
+// a hazard here: os/exec holds an open handle to the child process
+// from Start until Wait, so the identifier cannot be recycled while
+// this function runs. Any unresolved per-thread failure is reported
+// as this function's error; it does not stop enumeration of the
+// remaining threads.
+func resumeHookProcess(pid uint32) (resumedThreads int, err error) {
+	const maxResumeAttempts = 8
+
+	snapshot, snapErr := createToolhelp32SnapshotRetry(windows.TH32CS_SNAPTHREAD, 0)
+	if snapErr != nil {
+		return 0, fmt.Errorf("thread snapshot: %w", snapErr)
+	}
+	defer func() { _ = windows.CloseHandle(snapshot) }()
+
+	var entry windows.ThreadEntry32
+	entry.Size = uint32(unsafe.Sizeof(entry))
+	walkErr := windows.Thread32First(snapshot, &entry)
+	if walkErr != nil {
+		return 0, fmt.Errorf("Thread32First: %w", walkErr)
+	}
+
+	var unresolvedErr error
+	for {
+		if entry.OwnerProcessID == pid {
+			tid := entry.ThreadID
+			handle, openErr := windows.OpenThread(windows.THREAD_SUSPEND_RESUME, false, tid)
+			if openErr != nil {
+				unresolvedErr = fmt.Errorf("OpenThread(%d): %w", tid, openErr)
+			} else {
+				resolved := false
+				for range maxResumeAttempts {
+					prev, resumeErr := windows.ResumeThread(handle)
+					if resumeErr != nil {
+						unresolvedErr = fmt.Errorf("ResumeThread(%d): %w", tid, resumeErr)
+						break
+					}
+					if prev == 1 {
+						resolved = true
+						break
+					}
+				}
+				_ = windows.CloseHandle(handle)
+				switch {
+				case resolved:
+					resumedThreads++
+				case unresolvedErr == nil:
+					unresolvedErr = fmt.Errorf("thread %d did not reach a previous suspend count of 1 within %d attempts", tid, maxResumeAttempts)
+				}
+			}
+		}
+
+		entry.Size = uint32(unsafe.Sizeof(entry))
+		if nextErr := windows.Thread32Next(snapshot, &entry); nextErr != nil {
+			break
+		}
+	}
+
+	return resumedThreads, unresolvedErr
+}
+
+// jobMemberPIDs returns the PIDs currently associated with job.
+// maxJobMembers bounds the number of entries read from the trailing
+// variable-length array; a hook process tree is small, so this is a
+// generous ceiling rather than a measured one.
+const maxJobMembers = 1024
+
+func jobMemberPIDs(job windows.Handle) ([]uint32, error) {
+	bufLen := int(unsafe.Sizeof(jobObjectBasicProcessIDList{})) + (maxJobMembers-1)*int(unsafe.Sizeof(uintptr(0)))
+	buf := make([]byte, bufLen)
+
+	err := windows.QueryInformationJobObject(
+		job,
+		windows.JobObjectBasicProcessIdList,
+		uintptr(unsafe.Pointer(&buf[0])), //nolint:gosec // G103: QueryInformationJobObject takes the process ID list struct as a uintptr; x/sys/windows exposes no typed alternative
+		uint32(bufLen),
+		nil,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("QueryInformationJobObject(JobObjectBasicProcessIdList): %w", err)
+	}
+
+	list := (*jobObjectBasicProcessIDList)(unsafe.Pointer(&buf[0])) //nolint:gosec // G103: reading the over-allocated buffer back as the mirrored struct
+	count := min(list.NumberOfProcessIdsInList, maxJobMembers)
+
+	first := unsafe.Pointer(&list.ProcessIDList[0]) //nolint:gosec // G103: base address of the over-allocated trailing array
+	pids := make([]uint32, 0, count)
+	for i := range count {
+		entry := (*uintptr)(unsafe.Add(first, uintptr(i)*unsafe.Sizeof(uintptr(0)))) //nolint:gosec // G103: indexing past the fixed one-element array bound into the over-allocated buffer
+		pids = append(pids, uint32(*entry))                                          //nolint:gosec // G115: a Windows PID never exceeds uint32 range
+	}
+	return pids, nil
+}
+
+// scanSurvivors reports every process descended from rootPID that is
+// still alive after the drain returned. A discovered PID is not
+// pinned by any handle of ours, so each candidate is confirmed live
+// by opening it before it is reported; a candidate that cannot be
+// opened has exited or its identifier was recycled, and is dropped
+// rather than reported as a survivor.
+func scanSurvivors(rootPID uint32, jobPIDs []uint32) ([]hookSurvivor, error) {
+	snapshot, err := createToolhelp32SnapshotRetry(windows.TH32CS_SNAPPROCESS, 0)
+	if err != nil {
+		return nil, fmt.Errorf("process snapshot: %w", err)
+	}
+	defer func() { _ = windows.CloseHandle(snapshot) }()
+
+	type procInfo struct {
+		pid, parent uint32
+		image       string
+	}
+	var entries []procInfo
+
+	var entry windows.ProcessEntry32
+	entry.Size = uint32(unsafe.Sizeof(entry))
+	walkErr := windows.Process32First(snapshot, &entry)
+	for walkErr == nil {
+		entries = append(entries, procInfo{
+			pid:    entry.ProcessID,
+			parent: entry.ParentProcessID,
+			image:  windows.UTF16ToString(entry.ExeFile[:]),
+		})
+		entry.Size = uint32(unsafe.Sizeof(entry))
+		walkErr = windows.Process32Next(snapshot, &entry)
+	}
+
+	inJob := make(map[uint32]bool, len(jobPIDs))
+	for _, jobPID := range jobPIDs {
+		inJob[jobPID] = true
+	}
+
+	// Build the transitive closure of PIDs reachable from rootPID by
+	// following ParentProcessID edges, breadth-first, excluding
+	// rootPID itself.
+	closure := make(map[uint32]bool)
+	frontier := []uint32{rootPID}
+	for len(frontier) > 0 {
+		current := frontier[0]
+		frontier = frontier[1:]
+		for _, e := range entries {
+			if e.parent == current && e.pid != rootPID && !closure[e.pid] {
+				closure[e.pid] = true
+				frontier = append(frontier, e.pid)
+			}
+		}
+	}
+
+	survivors := make([]hookSurvivor, 0, len(closure))
+	for _, e := range entries {
+		if !closure[e.pid] {
+			continue
+		}
+		handle, openErr := windows.OpenProcess(windows.PROCESS_QUERY_LIMITED_INFORMATION, false, e.pid)
+		if openErr != nil {
+			// Exited, or the identifier was recycled; not a survivor.
+			continue
+		}
+		_ = windows.CloseHandle(handle)
+		survivors = append(survivors, hookSurvivor{
+			PID:       e.pid,
+			ParentPID: e.parent,
+			Image:     e.image,
+			InJob:     inJob[e.pid],
+		})
+	}
+	return survivors, nil
+}
+
+// probeHookRoot reports whether the hook root process (rootPID) is
+// still in the job's PID list and whether it is still openable after
+// the drain returned. os/exec releases its own handle to the child
+// when cmd.Wait returns, so a successful open after the drain means
+// the process object outlived both our handle and its removal from
+// the job's active count. PID reuse is guarded by comparing the
+// opened process's creation time against startedAt, the moment
+// cmd.Start returned: the identifier belonged to our root while our
+// root lived, so any later holder of it was created after that
+// moment, and a creation time after it means the PID was recycled
+// and is not our hook root.
+func probeHookRoot(rootPID uint32, jobPIDs []uint32, startedAt time.Time) (inList bool, openable bool, err error) {
+	inList = slices.Contains(jobPIDs, rootPID)
+
+	handle, openErr := windows.OpenProcess(windows.PROCESS_QUERY_LIMITED_INFORMATION, false, rootPID)
+	if openErr != nil {
+		// An exited root is the expected outcome on most runs.
+		return inList, false, nil
+	}
+	defer func() { _ = windows.CloseHandle(handle) }()
+
+	var creationTime, exitTime, kernelTime, userTime windows.Filetime
+	if timesErr := windows.GetProcessTimes(handle, &creationTime, &exitTime, &kernelTime, &userTime); timesErr != nil {
+		return inList, false, fmt.Errorf("GetProcessTimes: %w", timesErr)
+	}
+
+	if time.Unix(0, creationTime.Nanoseconds()).After(startedAt) {
+		// Created after our root was started, so the PID was
+		// recycled; this is not our hook root.
+		return inList, false, nil
+	}
+	return inList, true, nil
+}
+
 // jobObjectBasicAccountingInformation mirrors the Win32
 // JOBOBJECT_BASIC_ACCOUNTING_INFORMATION layout consumed by
 // QueryInformationJobObject; x/sys/windows does not define the type.
@@ -219,11 +629,12 @@ type jobObjectBasicAccountingInformation struct {
 }
 
 // waitJobDrained polls the job accounting counters until no process in
-// the job remains active or the deadline expires. Termination initiated
-// by TerminateJobObject completes asynchronously, so returning before
-// the active count reaches zero would let a dying child briefly outlive
+// the job remains active or the deadline expires, recording each
+// poll's counters into teardown. Termination initiated by
+// TerminateJobObject completes asynchronously, so returning before the
+// active count reaches zero would let a dying child briefly outlive
 // RunHook with its working-directory handle still open.
-func waitJobDrained(job windows.Handle) {
+func waitJobDrained(job windows.Handle, teardown *hookTeardown) {
 	const (
 		pollInterval = 5 * time.Millisecond
 		drainTimeout = 2 * time.Second
@@ -239,11 +650,18 @@ func waitJobDrained(job windows.Handle) {
 			uint32(unsafe.Sizeof(info)),
 			nil,
 		)
+		teardown.DrainPolls++
 		if err != nil {
 			slog.Warn("hook job accounting query failed; drain skipped",
 				slog.Any("error", err))
 			return
 		}
+		if teardown.DrainPolls == 1 {
+			teardown.ActiveFirst = info.ActiveProcesses
+		}
+		teardown.ActiveLast = info.ActiveProcesses
+		teardown.TotalProcesses = info.TotalProcesses
+		teardown.TotalTerminated = info.TotalTerminatedProcesses
 		if info.ActiveProcesses == 0 {
 			return
 		}

--- a/internal/workspace/hook_windows_test.go
+++ b/internal/workspace/hook_windows_test.go
@@ -5,11 +5,20 @@ package workspace
 import (
 	"context"
 	"errors"
+	"fmt"
+	"log/slog"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
+	"sync"
+	"syscall"
 	"testing"
 	"time"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
 )
 
 func requireHookError(t *testing.T, err error) *HookError {
@@ -129,19 +138,359 @@ func TestRunHook_Timeout(t *testing.T) {
 	}
 }
 
-func TestRunHook_ProcessTreeKill(t *testing.T) {
+// hookProcessTreeKillScript spawns a background child and blocks the
+// parent, both with ping (not pause): pause exits immediately when
+// stdin is /dev/null, but ping blocks on the network timer regardless
+// of stdin. Both processes must be killed by the Job Object when the
+// timeout fires.
+const hookProcessTreeKillScript = "start /b ping.exe -n 30 127.0.0.1 & ping -n 30 127.0.0.1"
+
+// hookNoBackgroundChildScript is hookProcessTreeKillScript with the
+// background child removed, so there is nothing for the job to fail
+// to catch.
+const hookNoBackgroundChildScript = "ping -n 30 127.0.0.1"
+
+// TestWindowsSuspendedProcessResumesViaThreadSnapshot confirms, on a
+// Windows runner and independently of any production helper, the
+// platform assumption the rest of this file's suspend-then-assign
+// fix depends on: that a system-wide TH32CS_SNAPTHREAD snapshot
+// enumerates the primary thread of a process created with
+// CREATE_SUSPENDED, and that resuming it starts the process. It
+// duplicates the minimal suspend/enumerate/resume sequence rather
+// than calling resumeHookProcess, because it exists to validate the
+// platform's behavior, not the helper's correctness.
+func TestWindowsSuspendedProcessResumesViaThreadSnapshot(t *testing.T) {
 	t.Parallel()
 
-	// Spawn a background child and block the parent both with ping (not pause).
-	// pause exits immediately when stdin is /dev/null; ping blocks on the
-	// network timer regardless of stdin. Both processes must be killed by the
-	// Job Object when the timeout fires.
-	script := "start /b ping.exe -n 30 127.0.0.1 & ping -n 30 127.0.0.1"
+	cmd := exec.Command("cmd.exe", "/C", "exit 0") //nolint:gosec // G204: fixed literal script, not user input
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		CreationFlags: windows.CREATE_SUSPENDED | windows.CREATE_NEW_PROCESS_GROUP,
+	}
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("Start() error: %v", err)
+	}
+	pid := uint32(cmd.Process.Pid) //nolint:gosec // G115: a Windows PID never exceeds uint32 range
+
+	snapshot, err := windows.CreateToolhelp32Snapshot(windows.TH32CS_SNAPTHREAD, 0)
+	if err != nil {
+		t.Fatalf("CreateToolhelp32Snapshot() error: %v", err)
+	}
+	defer func() { _ = windows.CloseHandle(snapshot) }()
+
+	var entry windows.ThreadEntry32
+	entry.Size = uint32(unsafe.Sizeof(entry))
+	if err := windows.Thread32First(snapshot, &entry); err != nil {
+		t.Fatalf("Thread32First() error: %v", err)
+	}
+
+	var primaryTID uint32
+	for {
+		if entry.OwnerProcessID == pid {
+			primaryTID = entry.ThreadID
+			break
+		}
+		entry.Size = uint32(unsafe.Sizeof(entry))
+		if err := windows.Thread32Next(snapshot, &entry); err != nil {
+			break
+		}
+	}
+	if primaryTID == 0 {
+		t.Fatalf("no thread found owned by pid %d", pid)
+	}
+
+	handle, err := windows.OpenThread(windows.THREAD_SUSPEND_RESUME, false, primaryTID)
+	if err != nil {
+		t.Fatalf("OpenThread() error: %v", err)
+	}
+	defer func() { _ = windows.CloseHandle(handle) }()
+
+	const maxAttempts = 8
+	resolved := false
+	for range maxAttempts {
+		prev, resumeErr := windows.ResumeThread(handle)
+		if resumeErr != nil {
+			t.Fatalf("ResumeThread() error: %v", resumeErr)
+		}
+		if prev == 1 {
+			resolved = true
+			break
+		}
+	}
+	if !resolved {
+		t.Fatalf("ResumeThread() previous suspend count never reached 1 within %d attempts", maxAttempts)
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- cmd.Wait() }()
+	select {
+	case waitErr := <-done:
+		if waitErr != nil {
+			t.Errorf("Wait() error: %v, want the resumed process to exit 0", waitErr)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("process did not complete within 10s of resume")
+	}
+}
+
+// windowsLogRecord is one record captured by [windowsLogSpy].
+type windowsLogRecord struct {
+	Level slog.Level
+	Msg   string
+	Attrs map[string]slog.Value
+}
+
+// windowsLogSpy is a [slog.Handler] that captures every log record's
+// level, message, and attribute set, so a test can assert on the
+// record RunHook emits. It is local to this package rather than
+// reusing internal/agent/agenttest's equivalent, because importing
+// that package would create a workspace -> agent import edge; the
+// technique, not the code, is shared.
+type windowsLogSpy struct {
+	mu      sync.Mutex
+	records []windowsLogRecord
+}
+
+func (s *windowsLogSpy) Enabled(context.Context, slog.Level) bool { return true }
+
+func (s *windowsLogSpy) Handle(_ context.Context, r slog.Record) error {
+	rec := windowsLogRecord{Level: r.Level, Msg: r.Message, Attrs: make(map[string]slog.Value, r.NumAttrs())}
+	r.Attrs(func(a slog.Attr) bool {
+		rec.Attrs[a.Key] = a.Value
+		return true
+	})
+	s.mu.Lock()
+	s.records = append(s.records, rec)
+	s.mu.Unlock()
+	return nil
+}
+
+func (s *windowsLogSpy) WithAttrs(_ []slog.Attr) slog.Handler { return s }
+func (s *windowsLogSpy) WithGroup(_ string) slog.Handler      { return s }
+
+// snapshot returns a copy of every record captured so far.
+func (s *windowsLogSpy) snapshot() []windowsLogRecord {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]windowsLogRecord, len(s.records))
+	copy(out, s.records)
+	return out
+}
+
+// installWindowsLogSpy replaces [slog.Default] with a spy logger for
+// the duration of the test and restores the previous default through
+// [testing.T.Cleanup]. The caller MUST be a non-parallel top-level
+// test: slog.SetDefault is process-global, and Go's testing package
+// releases paused parallel tests only after every non-parallel
+// top-level test has already run to completion, so a non-parallel
+// top-level test cannot overlap a parallel sibling.
+func installWindowsLogSpy(t *testing.T) *windowsLogSpy {
+	t.Helper()
+	spy := &windowsLogSpy{}
+	orig := slog.Default()
+	slog.SetDefault(slog.New(spy))
+	t.Cleanup(func() { slog.SetDefault(orig) })
+	return spy
+}
+
+// latestTeardownRecord returns the most recent hook-teardown record
+// (either message [logHookTeardown] emits) captured at index from or
+// later, so a caller can isolate the record produced by one RunHook
+// invocation from records any earlier invocation left behind.
+func latestTeardownRecord(spy *windowsLogSpy, from int) (windowsLogRecord, bool) {
+	records := spy.snapshot()
+	for i := len(records) - 1; i >= from; i-- {
+		if records[i].Msg == "hook process tree did not settle" || records[i].Msg == "hook process tree settled" {
+			return records[i], true
+		}
+	}
+	return windowsLogRecord{}, false
+}
+
+// TestRunHook_TeardownRecordShape asserts, in process, that RunHook
+// emits the mandatory teardown record shape on a passing test run
+// rather than relying on a human to read it out of a log.
+func TestRunHook_TeardownRecordShape(t *testing.T) {
+	spy := installWindowsLogSpy(t)
+
+	before := len(spy.snapshot())
+	_, err := RunHook(context.Background(), HookParams{
+		Script:    hookProcessTreeKillScript,
+		Dir:       t.TempDir(),
+		Env:       map[string]string{},
+		TimeoutMS: 300,
+	})
+	_ = requireHookError(t, err)
+
+	record, ok := latestTeardownRecord(spy, before)
+	if !ok {
+		t.Fatalf("no teardown record captured")
+	}
+
+	if _, ok := record.Attrs["total_processes"]; !ok {
+		t.Errorf("record missing attribute %q", "total_processes")
+	}
+	if _, ok := record.Attrs["root_openable"]; !ok {
+		t.Errorf("record missing attribute %q", "root_openable")
+	}
+	if _, ok := record.Attrs["root_in_job_list"]; !ok {
+		t.Errorf("record missing attribute %q", "root_in_job_list")
+	}
+}
+
+// runHookScenarioTotalProcesses runs the process-tree-kill scenario
+// once and returns the total_processes attribute from its captured
+// teardown record.
+func runHookScenarioTotalProcesses(t *testing.T, spy *windowsLogSpy) int64 {
+	t.Helper()
+	before := len(spy.snapshot())
+	_, err := RunHook(context.Background(), HookParams{
+		Script:    hookProcessTreeKillScript,
+		Dir:       t.TempDir(),
+		Env:       map[string]string{},
+		TimeoutMS: 300,
+	})
+	_ = requireHookError(t, err)
+
+	record, ok := latestTeardownRecord(spy, before)
+	if !ok {
+		t.Fatalf("no teardown record captured for this invocation")
+	}
+	total, ok := record.Attrs["total_processes"]
+	if !ok {
+		t.Fatalf("teardown record missing total_processes")
+	}
+	return total.Int64()
+}
+
+// TestRunHook_EscapeWithSeamDelay reproduces the start-to-assign
+// escape on demand through the hookAssignDelay seam, and asserts the
+// paired comparison the seam exists to make possible: a delay before
+// job assignment cannot lower the observed process count once the
+// process is created suspended. No process count is hard-coded.
+func TestRunHook_EscapeWithSeamDelay(t *testing.T) {
+	spy := installWindowsLogSpy(t)
+
+	hookAssignDelay.Store(0)
+	t.Cleanup(func() { hookAssignDelay.Store(0) })
+
+	var clean int64
+	for range 3 {
+		if v := runHookScenarioTotalProcesses(t, spy); v > clean {
+			clean = v
+		}
+	}
+
+	hookAssignDelay.Store(int64(50 * time.Millisecond))
+	delayed := runHookScenarioTotalProcesses(t, spy)
+
+	if delayed < clean {
+		t.Errorf("total_processes with the seam delay = %d, want >= the clean reference %d", delayed, clean)
+	}
+}
+
+// hookProbeClass is the outcome of re-probing a directory's
+// removability on a fixed cadence and window, after an assertion that
+// depends on the outcome has already been recorded.
+type hookProbeClass string
+
+const (
+	hookProbeTeardownLag hookProbeClass = "teardown_lag"
+	hookProbeAmbiguous   hookProbeClass = "ambiguous"
+	hookProbeLiveHolder  hookProbeClass = "live_holder"
+)
+
+// probeDirRemovable re-probes dir's removability at a 25 ms cadence
+// for up to a 5 s window, without changing any verdict the caller has
+// already recorded, and classifies how long the release took. The
+// window sits well above any plausible handle-teardown lag and well
+// below the roughly 29 s lifetime of the ping process the scenarios
+// in this file spawn, so the two classes cannot be confused with a
+// live holder.
+func probeDirRemovable(dir string) hookProbeClass {
+	const (
+		cadence = 25 * time.Millisecond
+		window  = 5 * time.Second
+	)
+	start := time.Now()
+	deadline := start.Add(window)
+	for {
+		if err := os.RemoveAll(dir); err == nil {
+			if time.Since(start) <= 100*time.Millisecond {
+				return hookProbeTeardownLag
+			}
+			return hookProbeAmbiguous
+		}
+		if time.Now().After(deadline) {
+			return hookProbeLiveHolder
+		}
+		time.Sleep(cadence)
+	}
+}
+
+// hookVerdicts reports which of the three independent conclusions the
+// diagnosis can reach are true for one run. Any subset may be true
+// together: an escape and a root lingering can both occur in the same
+// run, which is why these are independent booleans rather than one
+// classification.
+type hookVerdicts struct {
+	Escape        bool // V1: an escaped or short-counted descendant
+	RootLingering bool // V2: the hook root outlived its removal from the job
+	Environmental bool // V3: the control directory was also held
+}
+
+// evaluateHookVerdicts computes the three independent verdicts from
+// one background-child invocation's captured teardown record, the
+// clean total_processes reference, whether the hook directory was
+// still held when checked, the no-background-child invocation's
+// captured record and whether its directory was held, and whether the
+// control directory was held.
+func evaluateHookVerdicts(
+	backgroundRecord windowsLogRecord,
+	cleanReference int64,
+	hookHeld bool,
+	noChildRecord windowsLogRecord,
+	noChildHeld bool,
+	controlHeld bool,
+) hookVerdicts {
+	var v hookVerdicts
+
+	if total, ok := backgroundRecord.Attrs["total_processes"]; ok && total.Int64() < cleanReference {
+		v.Escape = true
+	}
+	if survivors, ok := backgroundRecord.Attrs["survivors"]; ok {
+		if list, ok := survivors.Any().([]hookSurvivor); ok && len(list) > 0 {
+			v.Escape = true
+		}
+	}
+	_ = hookHeld // V1 rests on the count and the survivor list, not on the hold itself.
+
+	if noChildHeld {
+		if openable, ok := noChildRecord.Attrs["root_openable"]; ok && openable.Bool() {
+			v.RootLingering = true
+		}
+	}
+
+	v.Environmental = controlHeld
+
+	return v
+}
+
+// TestRunHook_ProcessTreeKill exercises the background-child timeout
+// scenario, asserts the existing prompt-return and immediate-removal
+// invariants, and separates the four candidate causes of a held
+// directory into three independent, positively observed verdicts
+// rather than a single classification.
+func TestRunHook_ProcessTreeKill(t *testing.T) {
+	spy := installWindowsLogSpy(t)
 
 	dir := t.TempDir()
+	controlDir := t.TempDir()
+	noChildDir := t.TempDir()
+
 	start := time.Now()
+	before := len(spy.snapshot())
 	_, err := RunHook(context.Background(), HookParams{
-		Script:    script,
+		Script:    hookProcessTreeKillScript,
 		Dir:       dir,
 		Env:       map[string]string{},
 		TimeoutMS: 300,
@@ -159,11 +508,266 @@ func TestRunHook_ProcessTreeKill(t *testing.T) {
 		t.Errorf("RunHook took %v after timeout; expected prompt return (< 5s)", elapsed)
 	}
 
-	// The drain guarantee: when RunHook returns, no descendant still holds
-	// a handle into the hook directory, so removal must succeed on the
-	// first immediate attempt. Before the drain this failed intermittently
-	// with a sharing violation raised by the dying background child.
-	if err := os.RemoveAll(dir); err != nil {
-		t.Errorf("hook dir removal immediately after RunHook = %v, want success", err)
+	backgroundRecord, ok := latestTeardownRecord(spy, before)
+	if !ok {
+		t.Fatalf("no teardown record captured for the background-child scenario")
+	}
+
+	// A future failing run's log carrying this marker and no teardown
+	// record means the teardown path did not run; a log carrying
+	// neither means the log is not carrying records at all, and no
+	// inference from silence is valid without this marker.
+	slog.Warn("hook process tree kill test asserting removal")
+
+	// The drain guarantee: when RunHook returns, the job reports zero
+	// active processes. Removal must succeed on the first immediate
+	// attempt when nothing else is holding the directory. Before the
+	// start-to-assign fix this failed intermittently with a sharing
+	// violation raised by an escaped background child.
+	immediateErr := os.RemoveAll(dir)
+	if immediateErr != nil {
+		t.Errorf("hook dir removal immediately after RunHook = %v, want success", immediateErr)
+	}
+
+	// Re-probe removability without changing the verdict recorded
+	// above: it has already failed (or passed) and stays that way.
+	hookHeld := immediateErr != nil
+	hookClass := hookProbeTeardownLag
+	if hookHeld {
+		hookClass = probeDirRemovable(dir)
+	}
+
+	controlHeld := false
+	controlClass := hookProbeTeardownLag
+	if err := os.RemoveAll(controlDir); err != nil {
+		controlHeld = true
+		controlClass = probeDirRemovable(controlDir)
+	}
+
+	// A second scenario, identical except it spawns no background
+	// child: there is nothing to escape the job, so a hold observed
+	// here cannot be an escape.
+	beforeNoChild := len(spy.snapshot())
+	_, noChildErr := RunHook(context.Background(), HookParams{
+		Script:    hookNoBackgroundChildScript,
+		Dir:       noChildDir,
+		Env:       map[string]string{},
+		TimeoutMS: 300,
+	})
+	_ = requireHookError(t, noChildErr)
+	noChildRecord, ok := latestTeardownRecord(spy, beforeNoChild)
+	if !ok {
+		t.Fatalf("no teardown record captured for the no-background-child scenario")
+	}
+	noChildHeld := false
+	noChildClass := hookProbeTeardownLag
+	if err := os.RemoveAll(noChildDir); err != nil {
+		noChildHeld = true
+		noChildClass = probeDirRemovable(noChildDir)
+	}
+
+	// Clean reference: the maximum total_processes observed across
+	// three invocations of the background-child scenario with the
+	// fault-injection seam at its zero, production value.
+	var cleanReference int64
+	for range 3 {
+		if v := runHookScenarioTotalProcesses(t, spy); v > cleanReference {
+			cleanReference = v
+		}
+	}
+
+	verdicts := evaluateHookVerdicts(backgroundRecord, cleanReference, hookHeld, noChildRecord, noChildHeld, controlHeld)
+
+	t.Logf(
+		"verdicts: escape=%v root_lingering=%v environmental=%v; hook_held=%v hook_class=%s; "+
+			"control_held=%v control_class=%s; no_child_held=%v no_child_class=%s; clean_reference=%d",
+		verdicts.Escape, verdicts.RootLingering, verdicts.Environmental,
+		hookHeld, hookClass, controlHeld, controlClass, noChildHeld, noChildClass, cleanReference,
+	)
+
+	switch {
+	case !hookHeld && !verdicts.Escape && !verdicts.RootLingering && !verdicts.Environmental:
+		t.Logf("summary: clean (nothing held, no verdict fired)")
+	case hookHeld && !verdicts.Escape && !verdicts.RootLingering && !verdicts.Environmental:
+		t.Logf("summary: unexplained (directory held, no verdict fired)")
+	}
+}
+
+// hookStressIteration is one iteration's outcome inside
+// [TestRunHook_Stress].
+type hookStressIteration struct {
+	immediateRemovalFailed bool
+	waitDelayExpired       bool
+	totalProcesses         int64
+	survivorCount          int
+	rootLingering          bool
+	environmental          bool
+	// holdClasses is the hold-duration class from every
+	// probeDirRemovable call this iteration made (the hook directory,
+	// the control directory, or both), for the run-wide histogram.
+	holdClasses []hookProbeClass
+}
+
+// runHookStressIteration runs the background-child scenario once,
+// classifies it against a paired control directory, and reports what
+// was observed. t.TempDir handles cleanup even when the directory was
+// never released.
+func runHookStressIteration(t *testing.T, spy *windowsLogSpy) hookStressIteration {
+	t.Helper()
+
+	dir := t.TempDir()
+	controlDir := t.TempDir()
+
+	before := len(spy.snapshot())
+	_, _ = RunHook(context.Background(), HookParams{
+		Script:    hookProcessTreeKillScript,
+		Dir:       dir,
+		Env:       map[string]string{},
+		TimeoutMS: 300,
+	})
+	record, _ := latestTeardownRecord(spy, before)
+
+	var it hookStressIteration
+	if total, ok := record.Attrs["total_processes"]; ok {
+		it.totalProcesses = total.Int64()
+	}
+	if expired, ok := record.Attrs["wait_delay_expired"]; ok {
+		it.waitDelayExpired = expired.Bool()
+	}
+	if survivors, ok := record.Attrs["survivors"]; ok {
+		if list, ok := survivors.Any().([]hookSurvivor); ok {
+			it.survivorCount = len(list)
+		}
+	}
+
+	it.immediateRemovalFailed = os.RemoveAll(dir) != nil
+	if it.immediateRemovalFailed {
+		if openable, ok := record.Attrs["root_openable"]; ok && openable.Bool() {
+			it.rootLingering = true
+		}
+		it.holdClasses = append(it.holdClasses, probeDirRemovable(dir))
+	}
+
+	if err := os.RemoveAll(controlDir); err != nil {
+		it.environmental = true
+		it.holdClasses = append(it.holdClasses, probeDirRemovable(controlDir))
+	}
+
+	return it
+}
+
+// hookStressReport summarizes one half (serial or concurrent) of a
+// stress run for TestRunHook_Stress's report.
+func hookStressReport(label string, iterations []hookStressIteration, cleanReference int64) string {
+	var removalFailures, shortCount, survivorCount, rootLingering, environmental, waitDelayExpired int
+	var teardownLag, ambiguous, liveHolder int
+	for _, it := range iterations {
+		if it.immediateRemovalFailed {
+			removalFailures++
+		}
+		if it.totalProcesses < cleanReference {
+			shortCount++
+		}
+		if it.survivorCount > 0 {
+			survivorCount++
+		}
+		if it.rootLingering {
+			rootLingering++
+		}
+		if it.environmental {
+			environmental++
+		}
+		if it.waitDelayExpired {
+			waitDelayExpired++
+		}
+		for _, class := range it.holdClasses {
+			switch class {
+			case hookProbeTeardownLag:
+				teardownLag++
+			case hookProbeAmbiguous:
+				ambiguous++
+			case hookProbeLiveHolder:
+				liveHolder++
+			}
+		}
+	}
+	return fmt.Sprintf(
+		"%s: attempted=%d immediate_removal_failed=%d v1_short_count=%d v1_survivor_count=%d "+
+			"v2_root_lingering=%d v3_environmental=%d wait_delay_expired=%d "+
+			"hold_class_teardown_lag=%d hold_class_ambiguous=%d hold_class_live_holder=%d",
+		label, len(iterations), removalFailures, shortCount, survivorCount, rootLingering, environmental, waitDelayExpired,
+		teardownLag, ambiguous, liveHolder,
+	)
+}
+
+// TestRunHook_Stress runs the process-tree-kill scenario repeatedly,
+// with a serial half and a concurrently loaded half, and reports the
+// distribution of outcomes rather than a single pass/fail. It is
+// gated because it is not part of the ordinary pull-request signal:
+// its purpose is to accumulate a residual failure rate across many
+// dispatches, not to catch a regression on every push.
+func TestRunHook_Stress(t *testing.T) {
+	if os.Getenv("SORTIE_HOOKSTRESS_TEST") != "1" {
+		t.Skip("skipping hook stress test: set SORTIE_HOOKSTRESS_TEST=1 to enable")
+	}
+
+	iterations := 50
+	if v := os.Getenv("SORTIE_HOOKSTRESS_ITERATIONS"); v != "" {
+		if n, convErr := strconv.Atoi(v); convErr == nil && n > 0 {
+			iterations = n
+		}
+	}
+
+	spy := installWindowsLogSpy(t)
+	overallDeadline := time.Now().Add(20 * time.Minute)
+
+	var cleanReference int64
+	var serial, concurrent []hookStressIteration
+
+	for i := 0; i < iterations; i++ {
+		if time.Now().After(overallDeadline) {
+			t.Fatalf("hook stress test exceeded its 20-minute hang guard after %d of %d iterations", i, iterations)
+		}
+
+		if i < iterations/2 {
+			it := runHookStressIteration(t, spy)
+			if i < 5 && it.totalProcesses > cleanReference {
+				cleanReference = it.totalProcesses
+			}
+			serial = append(serial, it)
+			continue
+		}
+
+		var wg sync.WaitGroup
+		for range 4 {
+			wg.Go(func() {
+				loadDir := t.TempDir()
+				_, _ = RunHook(context.Background(), HookParams{
+					Script:    hookProcessTreeKillScript,
+					Dir:       loadDir,
+					Env:       map[string]string{},
+					TimeoutMS: 300,
+				})
+				_ = os.RemoveAll(loadDir)
+			})
+		}
+		it := runHookStressIteration(t, spy)
+		wg.Wait()
+		concurrent = append(concurrent, it)
+	}
+
+	summary := fmt.Sprintf("clean_reference=%d\n%s\n%s",
+		cleanReference,
+		hookStressReport("serial", serial, cleanReference),
+		hookStressReport("concurrent", concurrent, cleanReference),
+	)
+	t.Log(summary)
+
+	if path := os.Getenv("GITHUB_STEP_SUMMARY"); path != "" {
+		f, openErr := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+		if openErr == nil {
+			_, _ = f.WriteString(summary + "\n")
+			_ = f.Close()
+		}
 	}
 }

--- a/internal/workspace/hook_windows_test.go
+++ b/internal/workspace/hook_windows_test.go
@@ -169,6 +169,15 @@ func TestWindowsSuspendedProcessResumesViaThreadSnapshot(t *testing.T) {
 	if err := cmd.Start(); err != nil {
 		t.Fatalf("Start() error: %v", err)
 	}
+	// A failure between here and cmd.Wait would otherwise strand a
+	// suspended cmd.exe, which never exits on its own.
+	t.Cleanup(func() {
+		if cmd.ProcessState != nil {
+			return
+		}
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+	})
 	pid := uint32(cmd.Process.Pid) //nolint:gosec // G115: a Windows PID never exceeds uint32 range
 
 	snapshot, err := windows.CreateToolhelp32Snapshot(windows.TH32CS_SNAPTHREAD, 0)
@@ -294,12 +303,16 @@ func installWindowsLogSpy(t *testing.T) *windowsLogSpy {
 
 // latestTeardownRecord returns the most recent hook-teardown record
 // (either message [logHookTeardown] emits) captured at index from or
-// later, so a caller can isolate the record produced by one RunHook
-// invocation from records any earlier invocation left behind.
-func latestTeardownRecord(spy *windowsLogSpy, from int) (windowsLogRecord, bool) {
+// later whose dir attribute is dir. Matching on the directory as well
+// as the index is what keeps a concurrent invocation's record from
+// being read as this one's, since every invocation shares one spy.
+func latestTeardownRecord(spy *windowsLogSpy, from int, dir string) (windowsLogRecord, bool) {
 	records := spy.snapshot()
 	for i := len(records) - 1; i >= from; i-- {
-		if records[i].Msg == "hook process tree did not settle" || records[i].Msg == "hook process tree settled" {
+		if records[i].Msg != "hook process tree did not settle" && records[i].Msg != "hook process tree settled" {
+			continue
+		}
+		if recordDir, ok := records[i].Attrs["dir"]; ok && recordDir.String() == dir {
 			return records[i], true
 		}
 	}
@@ -312,16 +325,17 @@ func latestTeardownRecord(spy *windowsLogSpy, from int) (windowsLogRecord, bool)
 func TestRunHook_TeardownRecordShape(t *testing.T) {
 	spy := installWindowsLogSpy(t)
 
+	dir := t.TempDir()
 	before := len(spy.snapshot())
 	_, err := RunHook(context.Background(), HookParams{
 		Script:    hookProcessTreeKillScript,
-		Dir:       t.TempDir(),
+		Dir:       dir,
 		Env:       map[string]string{},
 		TimeoutMS: 300,
 	})
 	_ = requireHookError(t, err)
 
-	record, ok := latestTeardownRecord(spy, before)
+	record, ok := latestTeardownRecord(spy, before, dir)
 	if !ok {
 		t.Fatalf("no teardown record captured")
 	}
@@ -342,16 +356,17 @@ func TestRunHook_TeardownRecordShape(t *testing.T) {
 // teardown record.
 func runHookScenarioTotalProcesses(t *testing.T, spy *windowsLogSpy) int64 {
 	t.Helper()
+	dir := t.TempDir()
 	before := len(spy.snapshot())
 	_, err := RunHook(context.Background(), HookParams{
 		Script:    hookProcessTreeKillScript,
-		Dir:       t.TempDir(),
+		Dir:       dir,
 		Env:       map[string]string{},
 		TimeoutMS: 300,
 	})
 	_ = requireHookError(t, err)
 
-	record, ok := latestTeardownRecord(spy, before)
+	record, ok := latestTeardownRecord(spy, before, dir)
 	if !ok {
 		t.Fatalf("no teardown record captured for this invocation")
 	}
@@ -508,7 +523,7 @@ func TestRunHook_ProcessTreeKill(t *testing.T) {
 		t.Errorf("RunHook took %v after timeout; expected prompt return (< 5s)", elapsed)
 	}
 
-	backgroundRecord, ok := latestTeardownRecord(spy, before)
+	backgroundRecord, ok := latestTeardownRecord(spy, before, dir)
 	if !ok {
 		t.Fatalf("no teardown record captured for the background-child scenario")
 	}
@@ -555,7 +570,7 @@ func TestRunHook_ProcessTreeKill(t *testing.T) {
 		TimeoutMS: 300,
 	})
 	_ = requireHookError(t, noChildErr)
-	noChildRecord, ok := latestTeardownRecord(spy, beforeNoChild)
+	noChildRecord, ok := latestTeardownRecord(spy, beforeNoChild, noChildDir)
 	if !ok {
 		t.Fatalf("no teardown record captured for the no-background-child scenario")
 	}
@@ -619,13 +634,19 @@ func runHookStressIteration(t *testing.T, spy *windowsLogSpy) hookStressIteratio
 	controlDir := t.TempDir()
 
 	before := len(spy.snapshot())
-	_, _ = RunHook(context.Background(), HookParams{
+	_, runErr := RunHook(context.Background(), HookParams{
 		Script:    hookProcessTreeKillScript,
 		Dir:       dir,
 		Env:       map[string]string{},
 		TimeoutMS: 300,
 	})
-	record, _ := latestTeardownRecord(spy, before)
+	if he := requireHookError(t, runErr); he.Op != "timeout" {
+		t.Fatalf("HookError.Op = %q, want %q", he.Op, "timeout")
+	}
+	record, ok := latestTeardownRecord(spy, before, dir)
+	if !ok {
+		t.Fatalf("no teardown record captured for the iteration in %s", dir)
+	}
 
 	var it hookStressIteration
 	if total, ok := record.Attrs["total_processes"]; ok {
@@ -738,21 +759,37 @@ func TestRunHook_Stress(t *testing.T) {
 			continue
 		}
 
-		var wg sync.WaitGroup
+		var (
+			loadMu   sync.Mutex
+			loadErrs []error
+			wg       sync.WaitGroup
+		)
 		for range 4 {
 			wg.Go(func() {
 				loadDir := t.TempDir()
-				_, _ = RunHook(context.Background(), HookParams{
+				_, loadErr := RunHook(context.Background(), HookParams{
 					Script:    hookProcessTreeKillScript,
 					Dir:       loadDir,
 					Env:       map[string]string{},
 					TimeoutMS: 300,
 				})
+				var he *HookError
+				if !errors.As(loadErr, &he) || he.Op != "timeout" {
+					loadMu.Lock()
+					loadErrs = append(loadErrs, loadErr)
+					loadMu.Unlock()
+				}
+				// A load directory that will not release is the very
+				// condition under measurement, so its removal error is
+				// not a test failure; t.TempDir still cleans it up.
 				_ = os.RemoveAll(loadDir)
 			})
 		}
 		it := runHookStressIteration(t, spy)
 		wg.Wait()
+		for _, loadErr := range loadErrs {
+			t.Errorf("concurrent load invocation did not time out as expected: %v", loadErr)
+		}
 		concurrent = append(concurrent, it)
 	}
 


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Fix

**Intent:** On Windows, `RunHook` could return from a timed-out or cancelled hook while a background descendant it spawned was still alive and holding the hook working directory open, because the child could start running before the process was assigned to the Job Object that the timeout kills. Create the hook process suspended and only resume it after job assignment, closing that window, and make the teardown path observable so a future leak is diagnosable rather than just intermittent.

**Related Issues:** #883

### 🧭 Reviewer Guide

**Complexity:** Medium

#### Entry Point

`internal/workspace/hook_windows.go` - `RunHook` now creates the `cmd.exe` subprocess with `CREATE_SUSPENDED`, assigns it to the Job Object, and only then resumes its threads via the new `resumeHookProcess`. A resume failure is fatal (the process is terminated) and is classified as a `"timeout"` or `"start"` `HookError` depending on whether the context had already expired. Teardown also now collects a `hookTeardown` record (wait/drain timings, Job Object membership, and any surviving descendant process) and logs one record per invocation via `logHookTeardown`.

#### Sensitive Areas

- `internal/workspace/hook_windows.go`: Windows-only process lifecycle code (Job Objects, thread suspend/resume via Toolhelp32 snapshots, process tree scanning) - the race this fixes only reproduces intermittently, so review the suspend/assign/resume ordering itself rather than relying on test flakiness as a signal.
- `internal/workspace/hook_windows_test.go`: adds a fault-injection seam (`hookAssignDelay`, unexported, test-only) that widens the start-to-assign window on demand to force the race deterministically in `TestRunHook_EscapeWithSeamDelay`.
- `.github/workflows/nightly.yml`: new `hook-stress` job runs the hook harness repeatedly on `windows-latest` under `SORTIE_HOOKSTRESS_TEST=1`, since a single CI run does not reliably exercise a low-frequency race.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes. `HookError.Op` can now also be `"start"` for a resume failure, which was already a documented possible value for subprocess start failures.
- **Migrations/State:** No migrations or state changes.
