### PR TITLE
refactor(cmd): derive the SCM construction gate from the roster

### DIFF
--- a/cmd/sortie/main.go
+++ b/cmd/sortie/main.go
@@ -10,7 +10,6 @@
 package main
 
 import (
-	"cmp"
 	"context"
 	"errors"
 	"io"
@@ -131,6 +130,20 @@ type scmReactionKind struct {
 	provider string
 }
 
+// Kind identifiers shared by the roster, the wiring switches, and the
+// provider-conflict diagnostic. Their values are operator-facing, appearing
+// in the conflict log and in the sortie validate diagnostic, and MUST NOT
+// change.
+const (
+	scmKindReviewComments  = "review_comments"
+	scmKindAutoMerge       = "auto_merge"
+	scmKindBotReview       = "bot_review"
+	scmKindMergeConflicts  = "merge_conflicts"
+	scmKindLabelCommands   = "label_commands"
+	scmKindMergeCompletion = "merge_completion"
+	scmKindCIFailure       = "ci_failure"
+)
+
 // scmProviderConflict reports the active SCM reaction kinds and their
 // distinct providers. A single SCMAdapter is shared by all active SCM
 // reaction reconcile passes, so every active kind must name the same
@@ -158,29 +171,52 @@ func scmProviderConflict(kinds []scmReactionKind) (activeKinds, distinctProvider
 // the shared-provider check both the startup path and sortie validate
 // consume. A single SCMAdapter is shared by all active SCM reaction
 // reconcile passes, so every active kind in the roster must name the same
-// provider.
+// provider. The startup path also uses this result to decide whether an
+// SCM adapter is constructed at all and, when one is, which provider it is
+// constructed from.
 //
 // The returned slice always has seven entries, active or not; the caller
-// filters by the active field. activeSCMReactionKinds performs no registry
-// lookup, no adapter construction, and no I/O.
+// filters by the active field. Every entry with active == true carries a
+// non-empty provider. This invariant, combined with scmProviderConflict
+// recording a provider only for an entry it has accepted as active, makes
+// it safe for a caller to read the first value scmProviderConflict returns
+// as the selected provider once it has confirmed at least one kind is
+// active: that value belongs to an active reaction and is never empty.
+// activeSCMReactionKinds performs no registry lookup, no adapter
+// construction, and no I/O.
 func activeSCMReactionKinds(cfg config.ServiceConfig) []scmReactionKind {
-	reviewRC := cfg.Reactions["review_comments"]
-	autoMergeRC := cfg.Reactions["auto_merge"]
-	botReviewRC := cfg.Reactions["bot_review"]
-	mergeConflictRC := cfg.Reactions["merge_conflicts"]
-	mergeCompletionRC := cfg.Reactions["merge_completion"]
-	labelReviewActive := cfg.LabelCommands.Provider != "" && cfg.LabelCommands.ReviewLabel != ""
-	labelFixActive := cfg.LabelCommands.Provider != "" && cfg.LabelCommands.FixLabel != ""
+	reviewRC := cfg.Reactions[scmKindReviewComments]
+	autoMergeRC := cfg.Reactions[scmKindAutoMerge]
+	botReviewRC := cfg.Reactions[scmKindBotReview]
+	mergeConflictRC := cfg.Reactions[scmKindMergeConflicts]
+	mergeCompletionRC := cfg.Reactions[scmKindMergeCompletion]
+	labelReviewActive := labelReviewCommandActive(cfg)
+	labelFixActive := labelFixCommandActive(cfg)
 
 	return []scmReactionKind{
-		{name: "review_comments", active: reviewRC.Provider != "", provider: reviewRC.Provider},
-		{name: "auto_merge", active: autoMergeRC.Provider != "", provider: autoMergeRC.Provider},
-		{name: "bot_review", active: botReviewRC.Provider != "", provider: botReviewRC.Provider},
-		{name: "merge_conflicts", active: mergeConflictRC.Provider != "", provider: mergeConflictRC.Provider},
-		{name: "label_commands", active: labelReviewActive || labelFixActive, provider: cfg.LabelCommands.Provider},
-		{name: "merge_completion", active: mergeCompletionRC.Provider != "", provider: mergeCompletionRC.Provider},
-		{name: "ci_failure", active: cfg.CIFeedback.Kind != "", provider: cfg.CIFeedback.Kind},
+		{name: scmKindReviewComments, active: reviewRC.Provider != "", provider: reviewRC.Provider},
+		{name: scmKindAutoMerge, active: autoMergeRC.Provider != "", provider: autoMergeRC.Provider},
+		{name: scmKindBotReview, active: botReviewRC.Provider != "", provider: botReviewRC.Provider},
+		{name: scmKindMergeConflicts, active: mergeConflictRC.Provider != "", provider: mergeConflictRC.Provider},
+		{name: scmKindLabelCommands, active: labelReviewActive || labelFixActive, provider: cfg.LabelCommands.Provider},
+		{name: scmKindMergeCompletion, active: mergeCompletionRC.Provider != "", provider: mergeCompletionRC.Provider},
+		{name: scmKindCIFailure, active: cfg.CIFeedback.Kind != "", provider: cfg.CIFeedback.Kind},
 	}
+}
+
+// labelReviewCommandActive reports whether the review label command is
+// active. label_commands parses through its own dedicated field, never the
+// Reactions map; it activates when a provider and a review label are set.
+func labelReviewCommandActive(cfg config.ServiceConfig) bool {
+	return cfg.LabelCommands.Provider != "" && cfg.LabelCommands.ReviewLabel != ""
+}
+
+// labelFixCommandActive reports whether the fix label command is active.
+// The fix command activates independently when a provider and a fix label
+// are set; a fix-only configuration is valid and still constructs the SCM
+// adapter and joins the provider-conflict check.
+func labelFixCommandActive(cfg config.ServiceConfig) bool {
+	return cfg.LabelCommands.Provider != "" && cfg.LabelCommands.FixLabel != ""
 }
 
 func main() {
@@ -422,33 +458,20 @@ func run(ctx context.Context, args []string, stdout io.Writer, stderr io.Writer)
 	var mergeCompletionConfig orchestrator.MergeCompletionReactionConfig
 	var mergeCompletionConfigured bool
 
-	reviewRC, hasReview := br.cfg.Reactions["review_comments"]
-	autoMergeRC, hasAutoMerge := br.cfg.Reactions["auto_merge"]
-	botReviewRC, hasBotReview := br.cfg.Reactions["bot_review"]
-	mergeConflictRC, hasMergeConflict := br.cfg.Reactions["merge_conflicts"]
-	mergeCompletionRC, hasMergeCompletion := br.cfg.Reactions["merge_completion"]
-	reviewActive := hasReview && reviewRC.Provider != ""
-	autoMergeActive := hasAutoMerge && autoMergeRC.Provider != ""
-	botReviewActive := hasBotReview && botReviewRC.Provider != ""
-	mergeConflictActive := hasMergeConflict && mergeConflictRC.Provider != ""
-	mergeCompletionActive := hasMergeCompletion && mergeCompletionRC.Provider != ""
-	// label_commands parses through its own dedicated field, never the
-	// Reactions map; it activates when a provider and a review label are set.
-	labelReviewActive := br.cfg.LabelCommands.Provider != "" && br.cfg.LabelCommands.ReviewLabel != ""
-	// The fix command activates independently when a provider and a fix
-	// label are set; a fix-only configuration is valid and still
-	// constructs the SCM adapter and joins the provider-conflict check.
-	labelFixActive := br.cfg.LabelCommands.Provider != "" && br.cfg.LabelCommands.FixLabel != ""
-
-	ciFeedbackActive := br.cfg.CIFeedback.Kind != ""
+	reviewRC := br.cfg.Reactions[scmKindReviewComments]
+	autoMergeRC := br.cfg.Reactions[scmKindAutoMerge]
+	botReviewRC := br.cfg.Reactions[scmKindBotReview]
+	mergeConflictRC := br.cfg.Reactions[scmKindMergeConflicts]
+	mergeCompletionRC := br.cfg.Reactions[scmKindMergeCompletion]
 
 	activeSCMKinds := activeSCMReactionKinds(br.cfg)
-	if conflictKinds, conflictProviders := scmProviderConflict(activeSCMKinds); len(conflictProviders) > 1 {
+	activeKindNames, activeProviders := scmProviderConflict(activeSCMKinds)
+	if len(activeProviders) > 1 {
 		conflictAttrs := []any{
-			slog.String("kinds", strings.Join(conflictKinds, ", ")),
-			slog.String("providers", strings.Join(conflictProviders, ", ")),
+			slog.String("kinds", strings.Join(activeKindNames, ", ")),
+			slog.String("providers", strings.Join(activeProviders, ", ")),
 		}
-		if slices.Contains(conflictKinds, "ci_failure") {
+		if slices.Contains(activeKindNames, scmKindCIFailure) {
 			conflictAttrs = append(conflictAttrs, slog.String("reason",
 				"reactions.ci_failure now resolves the pull request's head through the SCM provider, so its provider must be the same forge as every other active SCM-backed reaction"))
 		}
@@ -456,8 +479,16 @@ func run(ctx context.Context, args []string, stdout io.Writer, stderr io.Writer)
 		return 1
 	}
 
-	if reviewActive || autoMergeActive || botReviewActive || mergeConflictActive || labelReviewActive || labelFixActive || mergeCompletionActive || ciFeedbackActive {
-		provider := cmp.Or(reviewRC.Provider, autoMergeRC.Provider, botReviewRC.Provider, mergeConflictRC.Provider, br.cfg.LabelCommands.Provider, mergeCompletionRC.Provider, br.cfg.CIFeedback.Kind)
+	reviewActive := slices.Contains(activeKindNames, scmKindReviewComments)
+	autoMergeActive := slices.Contains(activeKindNames, scmKindAutoMerge)
+	botReviewActive := slices.Contains(activeKindNames, scmKindBotReview)
+	mergeConflictActive := slices.Contains(activeKindNames, scmKindMergeConflicts)
+	mergeCompletionActive := slices.Contains(activeKindNames, scmKindMergeCompletion)
+	labelReviewActive := labelReviewCommandActive(br.cfg)
+	labelFixActive := labelFixCommandActive(br.cfg)
+
+	if len(activeKindNames) > 0 {
+		provider := activeProviders[0]
 		scmCtor, scmErr := registry.SCMAdapters.Get(provider)
 		if scmErr != nil {
 			br.logger.Error("unknown SCM adapter kind",

--- a/cmd/sortie/main_test.go
+++ b/cmd/sortie/main_test.go
@@ -1929,3 +1929,191 @@ func TestLabelFixInactive_NothingFires(t *testing.T) {
 		})
 	}
 }
+
+// --- Roster-gate consolidation coverage ---
+
+// labelCommandsBothLabelsEmptyRunWorkflow returns a WORKFLOW.md with a
+// reactions.label_commands block naming a provider while both command
+// labels are written as explicit empty strings, the one shape
+// buildLabelCommandsConfig rejects at parse time.
+func labelCommandsBothLabelsEmptyRunWorkflow(issuesPath, workspaceRoot string) []byte {
+	return fmt.Appendf(nil, `---
+tracker:
+  kind: file
+  project: DEMO
+  active_states:
+    - "To Do"
+  handoff_state: Done
+
+file:
+  path: %s
+
+agent:
+  kind: mock
+  max_turns: 1
+
+polling:
+  interval_ms: 500
+
+workspace:
+  root: %s
+
+reactions:
+  label_commands:
+    provider: github
+    review_label: ""
+    fix_label: ""
+---
+
+Fix issue {{ .issue.identifier }}.
+`, issuesPath, workspaceRoot)
+}
+
+// TestRunLabelCommandsBothLabelsEmpty_ConfigRejected verifies that a
+// reactions.label_commands block naming a provider with both command
+// labels written as explicit empty strings is refused by config parsing
+// before run() reaches the SCM construction gate, and that no per-kind
+// enablement record or gate diagnostic appears on stderr.
+// No t.Parallel: calls t.Chdir.
+func TestRunLabelCommandsBothLabelsEmpty_ConfigRejected(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	wsRoot := filepath.Join(dir, "workspaces")
+
+	issuesPath := filepath.Join(dir, "issues.json")
+	if err := os.WriteFile(issuesPath, quickStartIssues(), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	wfPath := writeCustomWorkflowFile(t, dir, labelCommandsBothLabelsEmptyRunWorkflow(issuesPath, wsRoot))
+
+	var stdout bytes.Buffer
+	var stderr lockedBuf
+	ctx, cancel := context.WithTimeout(context.Background(), runTestTimeout)
+	defer cancel()
+
+	code := run(ctx, []string{wfPath}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("exit code = %d, want 1 (label_commands both labels empty); stderr:\n%s", code, stderr.String())
+	}
+
+	logs := stderr.String()
+	const wantErr = "config: reactions.label_commands: an active provider requires at least one non-empty command label"
+	if !strings.Contains(logs, wantErr) {
+		t.Errorf("expected %q in stderr, got:\n%s", wantErr, logs)
+	}
+	if strings.Contains(logs, "unknown SCM adapter kind") {
+		t.Errorf("run reached the SCM construction gate despite the config-layer rejection; stderr:\n%s", logs)
+	}
+	for _, record := range []string{
+		"review comment routing enabled",
+		"auto_merge reaction enabled",
+		"bot review routing enabled",
+		"merge conflict reaction enabled",
+		"label review reaction enabled",
+		"label fix reaction enabled",
+		"merge completion reaction enabled",
+	} {
+		if strings.Contains(logs, record) {
+			t.Errorf("run logged %q despite the config-layer rejection; stderr:\n%s", record, logs)
+		}
+	}
+}
+
+// fiveKindsWiringWorkflow returns a WORKFLOW.md activating
+// reactions.review_comments, reactions.bot_review,
+// reactions.merge_conflicts, reactions.merge_completion, and a
+// review-only reactions.label_commands block (fix_label disabled), all
+// on the registered "github" provider, with no reactions.auto_merge
+// block, so none of the case's five reactions reaches an outbound scope
+// preflight.
+func fiveKindsWiringWorkflow(issuesPath, workspaceRoot string) []byte {
+	return fmt.Appendf(nil, `---
+tracker:
+  kind: file
+  project: DEMO
+  active_states:
+    - "To Do"
+  handoff_state: Handoff
+  terminal_states:
+    - "Done"
+    - "Rejected"
+
+file:
+  path: %s
+
+agent:
+  kind: mock
+  max_turns: 1
+
+polling:
+  interval_ms: 500
+
+workspace:
+  root: %s
+
+github:
+  api_key: "unused"
+  project: "acme/widgets"
+
+reactions:
+  review_comments:
+    provider: github
+  bot_review:
+    provider: github
+  merge_conflicts:
+    provider: github
+  merge_completion:
+    provider: github
+    target_state: Done
+  label_commands:
+    provider: github
+    review_label: "sortie:review"
+    fix_label: ""
+---
+
+Fix issue {{ .issue.identifier }}.
+`, issuesPath, workspaceRoot)
+}
+
+// TestRunFiveKindsWiring_AllEnablementRecordsLogged verifies that
+// review_comments, bot_review, merge_conflicts, merge_completion, and a
+// review-only label_commands block, all naming the same registered
+// provider, each construct their reaction config and log their
+// enablement record, and that startup exits 0. auto_merge and the
+// label-fix command are excluded: their startup preflights reach the
+// forge over HTTP and no in-repo fixture serves that call.
+// No t.Parallel: calls t.Chdir.
+func TestRunFiveKindsWiring_AllEnablementRecordsLogged(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	wsRoot := filepath.Join(dir, "workspaces")
+
+	issuesPath := filepath.Join(dir, "issues.json")
+	if err := os.WriteFile(issuesPath, quickStartIssues(), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	wfPath := writeCustomWorkflowFile(t, dir, fiveKindsWiringWorkflow(issuesPath, wsRoot))
+
+	var stdout bytes.Buffer
+	var stderr lockedBuf
+	ctx, cancel := context.WithTimeout(context.Background(), runTestTimeout)
+	defer cancel()
+
+	code := run(ctx, []string{wfPath}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit code = %d, want 0; stderr:\n%s", code, stderr.String())
+	}
+
+	logs := stderr.String()
+	for _, record := range []string{
+		"review comment routing enabled",
+		"bot review routing enabled",
+		"merge conflict reaction enabled",
+		"merge completion reaction enabled",
+		"label review reaction enabled",
+	} {
+		if !strings.Contains(logs, record) {
+			t.Errorf("expected %q in log, got:\n%s", record, logs)
+		}
+	}
+}

--- a/cmd/sortie/scmprovider_test.go
+++ b/cmd/sortie/scmprovider_test.go
@@ -87,6 +87,53 @@ func TestActiveSCMReactionKinds(t *testing.T) {
 			t.Errorf("activeSCMReactionKinds(cfg) ci_failure.provider = %q, want %q (CIFeedback.Kind, not the reactions map entry)", last.provider, "github")
 		}
 	})
+
+	labelCommandsBothLabelsSetEmptyProviderConfig := config.ServiceConfig{
+		LabelCommands: config.LabelCommandsConfig{ReviewLabel: "sortie:review", FixLabel: "sortie:fix"},
+	}
+
+	t.Run("label_commands with both labels set but no provider stays inactive", func(t *testing.T) {
+		t.Parallel()
+
+		got := activeSCMReactionKinds(labelCommandsBothLabelsSetEmptyProviderConfig)
+		var labelCommands scmReactionKind
+		for _, e := range got {
+			if e.name == "label_commands" {
+				labelCommands = e
+			}
+		}
+		if labelCommands.active {
+			t.Errorf("activeSCMReactionKinds(cfg) label_commands.active = true, want false (provider empty despite both command labels set)")
+		}
+	})
+
+	t.Run("no active entry carries an empty provider", func(t *testing.T) {
+		t.Parallel()
+
+		allActiveCfg := config.ServiceConfig{
+			Reactions: map[string]config.ReactionConfig{
+				"review_comments":  {Provider: "gitea"},
+				"auto_merge":       {Provider: "gitea"},
+				"bot_review":       {Provider: "gitea"},
+				"merge_conflicts":  {Provider: "gitea"},
+				"merge_completion": {Provider: "gitea"},
+			},
+			LabelCommands: config.LabelCommandsConfig{Provider: "gitea", ReviewLabel: "sortie:review"},
+			CIFeedback:    config.CIFeedbackConfig{Kind: "gitea"},
+		}
+
+		for _, cfg := range []config.ServiceConfig{
+			allActiveCfg,
+			{},
+			labelCommandsBothLabelsSetEmptyProviderConfig,
+		} {
+			for _, e := range activeSCMReactionKinds(cfg) {
+				if e.active && e.provider == "" {
+					t.Errorf("activeSCMReactionKinds(cfg) entry %q = %+v, want !(active && provider == \"\")", e.name, e)
+				}
+			}
+		}
+	})
 }
 
 func TestScmProviderConflict(t *testing.T) {


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Refactor

**Intent:** The startup path derived SCM reaction activity twice: once for the roster feeding `scmProviderConflict`, and again as a standalone disjunction over per-kind flags feeding a `cmp.Or` provider chain. This consolidates the second derivation so the SCM adapter construction gate reads its activity and provider choice from the same roster the provider-conflict check already uses, leaving reaction activity described in one place.

**Related Issues:** #891

### 🧭 Reviewer Guide

**Complexity:** Medium

#### Entry Point

`cmd/sortie/main.go` - the `run()` function's SCM construction gate now derives `reviewActive`, `autoMergeActive`, `botReviewActive`, `mergeConflictActive`, and `mergeCompletionActive` from the `activeKindNames` the roster already returned, and selects `provider := activeProviders[0]` instead of a separate `cmp.Or` chain. The `label_commands` activation predicate is factored into `labelReviewCommandActive` and `labelFixCommandActive`, shared by `activeSCMReactionKinds` and `run()`.

#### Sensitive Areas

- `cmd/sortie/main.go`: the SCM adapter construction gate controls which provider is wired up at startup; a regression here would misroute or skip SCM adapter construction.
- `cmd/sortie/scmprovider_test.go`: pins the invariant that every active roster entry carries a non-empty provider, which the gate now relies on without a fallback.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes. Adapter selection is unchanged for every previously valid configuration; `internal/config/config.go` already rejects the one configuration shape (`label_commands` naming a provider with both command labels empty) where the two prior derivations could have disagreed.
- **Migrations/State:** No migrations or state changes.
