### PR TITLE
fix(codex): report a cancelled turn as cancelled, not success

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - On Windows, a hook's background child no longer escapes the timeout's process-tree kill by starting before the hook process joined the Job Object that the kill targets. The hook subprocess is now created suspended and only allowed to run once it is a member, closing the window in which such a child survived termination and kept the workspace directory locked. A hook whose Job Object cannot be created still runs, as it did before, and the failure is logged.
   ([#883](https://github.com/sortie-ai/sortie/issues/883))
 
+- A `codex` turn that Sortie already cancelled is now recorded as cancelled, not as a success, when the runtime's completion notification for that turn arrives afterward, whatever status the runtime reports. The turn no longer counts toward the run's completed turns.
+  ([#916](https://github.com/sortie-ai/sortie/issues/916))
+
 ### Changed
 
 - `reactions.review_comments`, `reactions.bot_review`, `reactions.merge_conflicts`, and `reactions.auto_merge` now bound a pending entry's age with a per-reaction `watch_window_ms` key instead of a hardcoded thirty-minute constant. The default stays `1800000` (thirty minutes), so a deployment that sets nothing behaves exactly as before; setting `0` removes the bound entirely. A workflow with no `auto_merge`, where a person reviews and merges, will normally want a larger value than the default. The four expiry log records changed their message text and renamed their `ttl_ms` attribute to `window_ms`.

--- a/docs/architecture/10-agent-adapter-contract.md
+++ b/docs/architecture/10-agent-adapter-contract.md
@@ -626,6 +626,9 @@ so that a new adapter inherits it rather than re-deriving it.
 The rule is evaluated as an ordered table. The first matching row decides the turn:
 
 1. The runtime reported the turn cancelled (an orchestrator-initiated cancellation): `turn_cancelled`.
+   This row matches on the orchestrator's own cancellation rather than on the word the runtime
+   uses: a runtime report that the turn completed, arriving after the orchestrator cancelled the
+   turn, does not displace this row.
 2. The adapter recognized a request only a person could answer that the turn cannot continue
    past: `turn_input_required`. It outranks every failure row below, so such a request is
    never reported as a generic turn failure, and it ranks under cancellation, so a shutdown

--- a/docs/codex-adapter-notes.md
+++ b/docs/codex-adapter-notes.md
@@ -30,7 +30,7 @@ Resume is a soft path. When resuming a thread fails, the adapter logs a warning 
 
 A Sortie turn is one turn request and the events that follow it until the runtime reports completion. On cancellation the adapter writes a single best-effort interrupt straight to the runtime's stdin, deliberately not through the cancelled context, and then keeps reading only until the runtime's own completion arrives, stdout closes, or the read timeout elapses. Past that bound it returns cancelled rather than waiting forever for an acknowledgement that may never come. The runtime acknowledges no client response at all, which is why that bound exists and why it is also the backstop for every refusal described below.
 
-One distinction is deliberate and worth preserving. A turn the runtime reports as interrupted when *we* cancelled it is a cancellation. The same status when our context was still live is a failure, because from the orchestrator's side an interruption nobody asked for must not release the claim in place of a retry.
+One distinction is deliberate and worth preserving. Any status the runtime reports in a `turn/completed` notification after *we* already cancelled the turn is reported as a cancellation, whatever word the runtime used. The same `interrupted` status when our context was still live stays a failure, because from the orchestrator's side an interruption nobody asked for must not release the claim in place of a retry.
 
 ## Approvals and requests only a person can answer
 

--- a/internal/agent/codex/codex.go
+++ b/internal/agent/codex/codex.go
@@ -638,10 +638,11 @@ func (a *CodexAdapter) RunTurn(ctx context.Context, session domain.Session, para
 				ev := agentcore.TurnEvidence{Work: agentcore.WorkUnobservable}
 
 				switch {
+				case ctx.Err() != nil:
+					ev.Terminal = agentcore.TerminalCancelled
+					ev.TerminalMessage = cancelledMessage(tc.Turn.Status, tc.Turn.Error)
 				case tc.Turn.Status == "completed":
 					ev.Terminal = agentcore.TerminalSuccess
-				case tc.Turn.Status == "interrupted" && ctx.Err() != nil:
-					ev.Terminal = agentcore.TerminalCancelled
 				case tc.Turn.Status == "interrupted":
 					// An interrupt sortie did not request is a failure,
 					// not a cancellation, from the orchestrator's side:
@@ -839,6 +840,23 @@ func (a *CodexAdapter) RunTurn(ctx context.Context, session domain.Session, para
 			}
 		}
 	}
+}
+
+// cancelledMessage composes the terminal message for a turn/completed
+// notification that arrives after the orchestrator has already cancelled
+// the turn. It names the runtime's reported status and, when the payload
+// carried one, appends the runtime's own error text.
+func cancelledMessage(status string, turnErr *turnError) string {
+	var message string
+	if status == "" {
+		message = "turn cancelled after the runtime reported no status"
+	} else {
+		message = "turn cancelled after the runtime reported status " + status
+	}
+	if turnErr != nil && turnErr.Message != "" {
+		message += ": " + turnErr.Message
+	}
+	return message
 }
 
 // StopSession terminates the persistent app-server subprocess.

--- a/internal/agent/codex/codex_test.go
+++ b/internal/agent/codex/codex_test.go
@@ -314,7 +314,7 @@ func TestRunTurn_InterruptedStatus(t *testing.T) {
 			contextIsLive: false,
 			wantEvidence: agentcore.TurnEvidence{
 				Terminal:        agentcore.TerminalCancelled,
-				TerminalMessage: "turn interrupted",
+				TerminalMessage: "turn cancelled after the runtime reported status interrupted",
 				Work:            agentcore.WorkUnobservable,
 			},
 		},
@@ -363,6 +363,95 @@ func TestRunTurn_InterruptedStatus(t *testing.T) {
 			result, err := got.result, got.err
 
 			dispositiontest.AssertDispositionContract(t, tt.wantEvidence, result, err)
+		})
+	}
+}
+
+// TestRunTurn_CompletedNotificationUnderCancelledContext pins the
+// cancelled-context mapping table: whatever status word (or absence of
+// one) the runtime reports in a turn/completed notification once the
+// orchestrator has already cancelled the turn, the disposition is a
+// cancellation carrying a message that names both facts.
+func TestRunTurn_CompletedNotificationUnderCancelledContext(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		params      string
+		wantMessage string
+	}{
+		{
+			name:        "completed status with no error object",
+			params:      `{"turn":{"id":"turn-001","status":"completed"}}`,
+			wantMessage: "turn cancelled after the runtime reported status completed",
+		},
+		{
+			name:        "interrupted status with no error object",
+			params:      `{"turn":{"id":"turn-001","status":"interrupted"}}`,
+			wantMessage: "turn cancelled after the runtime reported status interrupted",
+		},
+		{
+			name:        "failed status carrying a turn.error object",
+			params:      `{"turn":{"id":"turn-001","status":"failed","error":{"message":"context window exceeded","codexErrorInfo":"ContextWindowExceeded"}}}`,
+			wantMessage: "turn cancelled after the runtime reported status failed: context window exceeded",
+		},
+		{
+			name:        "unrecognized status",
+			params:      `{"turn":{"id":"turn-001","status":"queued_for_review"}}`,
+			wantMessage: "turn cancelled after the runtime reported status queued_for_review",
+		},
+		{
+			name:        "payload with no status member",
+			params:      `{"turn":{"id":"turn-001"}}`,
+			wantMessage: "turn cancelled after the runtime reported no status",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			state := newInterruptedStatusState()
+			close(state.readerDone)
+
+			var cancelled atomic.Bool
+			ctx := atomicErrContext{Context: context.Background(), cancelled: &cancelled}
+
+			type outcome struct {
+				result domain.TurnResult
+				err    error
+			}
+			outcomeCh := make(chan outcome, 1)
+
+			adapter, _ := NewCodexAdapter(map[string]any{})
+			go func() {
+				result, err := adapter.RunTurn(ctx, fakeSession(state), domain.RunTurnParams{
+					Prompt:  "go",
+					OnEvent: func(domain.AgentEvent) {},
+				})
+				outcomeCh <- outcome{result, err}
+			}()
+
+			// This send returns only once RunTurn's response-wait loop has
+			// received it, which happens strictly after the ctx.Err()
+			// fast-path check, so cancelled is still guaranteed false here.
+			state.msgCh <- parseMessage([]byte(`{"id":1,"result":{"turn":{"id":"turn-001","status":"starting"}}}`))
+
+			cancelled.Store(true)
+
+			// This send returns only once RunTurn's main loop is ready to
+			// receive again, which happens strictly after the turn/start
+			// response above has been fully processed.
+			state.msgCh <- parseMessage([]byte(`{"method":"turn/completed","params":` + tt.params + `}`))
+
+			got := <-outcomeCh
+			result, err := got.result, got.err
+
+			dispositiontest.AssertDispositionContract(t, agentcore.TurnEvidence{
+				Terminal:        agentcore.TerminalCancelled,
+				TerminalMessage: tt.wantMessage,
+				Work:            agentcore.WorkUnobservable,
+			}, result, err)
 		})
 	}
 }

--- a/internal/agent/codex/runturn_test.go
+++ b/internal/agent/codex/runturn_test.go
@@ -618,6 +618,95 @@ func TestRunTurn_CancelledMainLoopWaitsForCompletion(t *testing.T) {
 	}
 }
 
+// TestRunTurn_CancelledMainLoopReportsCancelledDespiteCompletedStatus drives
+// the same cancel-then-interrupt sequence as
+// TestRunTurn_CancelledMainLoopWaitsForCompletion, but the app-server's
+// turn/completed notification, delivered after cancellation, reports status
+// completed rather than interrupted. The disposition must still be a
+// cancellation, and no turn_completed event may reach the stream.
+func TestRunTurn_CancelledMainLoopReportsCancelledDespiteCompletedStatus(t *testing.T) {
+	t.Parallel()
+
+	parentCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ctx := &countingDoneContext{Context: parentCtx}
+
+	state := newInterruptedStatusState()
+	close(state.readerDone)
+	stdin := &interruptTrackingWriteCloser{interrupts: make(chan struct{}, 1)}
+	state.stdin = stdin
+
+	type outcome struct {
+		result domain.TurnResult
+		err    error
+	}
+	outcomeCh := make(chan outcome, 1)
+	finished := make(chan struct{})
+
+	var events []domain.AgentEvent
+	adapter, _ := NewCodexAdapter(map[string]any{})
+	go func() {
+		defer close(finished)
+		result, err := adapter.RunTurn(ctx, fakeSession(state), domain.RunTurnParams{
+			Prompt:  "go",
+			OnEvent: collectEvents(&events),
+		})
+		outcomeCh <- outcome{result: result, err: err}
+	}()
+
+	t.Cleanup(func() {
+		select {
+		case <-finished:
+			return
+		default:
+		}
+		close(state.msgCh)
+		select {
+		case <-finished:
+		case <-time.After(time.Second):
+		}
+	})
+
+	// The unbuffered sends return only after RunTurn has received each
+	// message. The second message therefore proves that its main event loop,
+	// rather than the turn/start response loop, is running before cancellation.
+	state.msgCh <- parseMessage([]byte(`{"id":1,"result":{"turn":{"id":"turn-001","status":"starting"}}}`))
+	state.msgCh <- parseMessage([]byte(`{"method":"turn/started","params":{"turnId":"turn-001"}}`))
+
+	cancel()
+	select {
+	case <-stdin.interrupts:
+	case <-time.After(time.Second):
+		t.Fatal("RunTurn did not send turn/interrupt after cancellation")
+	}
+	if got := stdin.count.Load(); got != 1 {
+		t.Errorf("turn/interrupt request count = %d, want 1", got)
+	}
+
+	select {
+	case state.msgCh <- parseMessage([]byte(`{"method":"turn/completed","params":{"turn":{"id":"turn-001","status":"completed"}}}`)):
+	case <-time.After(time.Second):
+		t.Fatal("RunTurn did not wait for turn/completed after cancellation")
+	}
+
+	select {
+	case got := <-outcomeCh:
+		if got.result.ExitReason != domain.EventTurnCancelled {
+			t.Errorf("ExitReason = %q, want %q", got.result.ExitReason, domain.EventTurnCancelled)
+		}
+		requireAgentError(t, got.err, domain.ErrTurnCancelled)
+	case <-time.After(time.Second):
+		t.Fatal("RunTurn did not return after turn/completed")
+	}
+
+	if got := filterEventsOfType(events, domain.EventTurnCancelled); len(got) != 1 {
+		t.Errorf("turn_cancelled event count = %d, want 1", len(got))
+	}
+	if got := filterEventsOfType(events, domain.EventTurnCompleted); len(got) != 0 {
+		t.Errorf("turn_completed event count = %d, want 0", len(got))
+	}
+}
+
 func TestRunTurn_ItemStartedAndCompletedEmitsToolResult(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Fix

**Intent:** Stop the `codex` adapter from reporting an orchestrator-cancelled turn as a success. The app-server can deliver a `turn/completed` notification with status `completed` after the orchestrator already cancelled the turn's context but before the app-server processed the `turn/interrupt`, and the handler mapped that race outcome to a successful terminal disposition instead of a cancellation.

**Related Issues:** #916

### 🧭 Reviewer Guide

**Complexity:** Low

#### Entry Point

`internal/agent/codex/codex.go` - the `turn/completed` handler's terminal-outcome switch. The cancellation check (`ctx.Err() != nil`) now runs first, ahead of every status branch, so any notification arriving after cancellation is reported as cancelled regardless of what status word the runtime used. The new `cancelledMessage` helper composes the terminal message from the runtime's reported status (or its absence) and any runtime error text.

#### Sensitive Areas

- `internal/agent/codex/codex.go`: changes the precedence of a decision table that other terminal-outcome branches (interrupted, failed) also rely on - worth confirming the remaining branches are unreachable once cancellation is checked first.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes. The cancellation message text changes for the pre-existing `interrupted`-while-cancelled case (from `"turn interrupted"` to `"turn cancelled after the runtime reported status interrupted"`), which is reflected in the updated test expectations.
- **Migrations/State:** No migrations or state changes.
