### PR TITLE
ci: set persist-credentials: false on remaining checkout steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
@@ -73,6 +74,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Lint shell scripts
         env:
@@ -86,6 +88,9 @@ jobs:
           [ -n "$changed" ] || exit 0
           printf '%s\n' "$changed"
           printf '%s\n' "$changed" | xargs -d '\n' -r shellcheck -x --
+
+      - name: Check checkout credentials
+        run: scripts/checkout-creds.sh
 
   lint-no-tests:
     name: Lint (shipped code only, ${{ matrix.goos }})
@@ -140,6 +145,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
@@ -168,6 +174,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
@@ -190,6 +197,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -192,6 +192,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
@@ -386,6 +388,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Verify tag is new
         run: |
@@ -83,6 +84,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
@@ -109,6 +112,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
@@ -143,6 +148,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
@@ -174,6 +181,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
@@ -206,6 +215,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
@@ -224,6 +235,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
@@ -245,6 +258,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
@@ -279,6 +294,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
@@ -309,6 +326,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
@@ -347,6 +366,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
@@ -385,6 +406,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
@@ -411,6 +434,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
@@ -449,6 +474,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
@@ -487,6 +514,9 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          # The Create and push tag step below runs git push origin to
+          # publish the tag, so this checkout keeps the credential.
+          persist-credentials: true
 
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
@@ -596,6 +626,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Determine pre-release
         id: prerelease

--- a/scripts/checkout-creds.sh
+++ b/scripts/checkout-creds.sh
@@ -1,0 +1,89 @@
+#!/bin/sh
+# Fail if an actions/checkout step omits persist-credentials, so the
+# token's disposition is always explicit rather than the action's default.
+# Usage: checkout-creds.sh [DIR]   (DIR defaults to .github/workflows)
+
+set -eu
+
+dir=${1:-.github/workflows}
+checked=0
+failed=0
+
+# POSIX sh cannot return two values; sets IND and LT.
+split_indent() {
+	_lead=${1%%[! 	]*}
+	LT=${1#"$_lead"}
+	IND=${#_lead}
+}
+
+# Fails closed: an open anchor that never saw the key is reported.
+close_anchor() {
+	if [ -n "$anchor_line" ] && [ "$anchor_compliant" -eq 0 ]; then
+		printf '%s:%s: no persist-credentials key in step\n' "$file" "$anchor_line"
+		failed=$((failed + 1))
+	fi
+	anchor_line=""
+	anchor_indent=0
+	anchor_compliant=0
+}
+
+# A step region spans from an actions/checkout line to the next sequence
+# item at or above its indentation, the next non-blank line below it, or
+# EOF. Blank lines never end a region.
+scan_file() {
+	file=$1
+	anchor_line=""
+	anchor_indent=0
+	anchor_compliant=0
+	lineno=0
+
+	while IFS= read -r raw || [ -n "$raw" ]; do
+		lineno=$((lineno + 1))
+		split_indent "$raw"
+
+		if [ -n "$anchor_line" ] && [ -n "$LT" ]; then
+			case "$LT" in
+			-\ *)
+				if [ "$IND" -le "$anchor_indent" ]; then
+					close_anchor
+				fi
+				;;
+			*)
+				if [ "$IND" -lt "$anchor_indent" ]; then
+					close_anchor
+				fi
+				;;
+			esac
+		fi
+
+		case "$LT" in
+		*uses:*actions/checkout*)
+			close_anchor
+			checked=$((checked + 1))
+			anchor_line=$lineno
+			anchor_indent=$IND
+			;;
+		persist-credentials:*)
+			[ -n "$anchor_line" ] || continue
+			_val=${LT#persist-credentials:}
+			_val=${_val%% #*}
+			_val=$(printf '%s' "$_val" | tr -d ' 	')
+			case "$_val" in
+			true | false)
+				anchor_compliant=1
+				;;
+			esac
+			;;
+		esac
+	done <"$file"
+
+	close_anchor
+}
+
+for candidate in "$dir"/*.yml "$dir"/*.yaml; do
+	[ -e "$candidate" ] || continue
+	scan_file "$candidate"
+done
+
+[ "$failed" -eq 0 ] || exit 1
+printf 'checkout-creds: %s step(s) checked, all compliant\n' "$checked"

--- a/scripts/checkout-creds.sh
+++ b/scripts/checkout-creds.sh
@@ -26,10 +26,12 @@ close_anchor() {
 	anchor_indent=0
 	anchor_compliant=0
 	with_indent=-1
+	with_child=-1
 }
 
 # An anchor is a uses: key naming actions/checkout@; a mention inside a
-# comment or a run: body is not one. A step region spans from that anchor
+# comment or a run: body is not one. The key counts only as a direct
+# child of the step's with: mapping, never nested deeper. A step region spans from that anchor
 # to the next sequence
 # item at or above its indentation, the next non-blank line below it, or
 # EOF. Blank lines never end a region. Only a persist-credentials under
@@ -41,6 +43,7 @@ scan_file() {
 	anchor_indent=0
 	anchor_compliant=0
 	with_indent=-1
+	with_child=-1
 	lineno=0
 
 	while IFS= read -r raw || [ -n "$raw" ]; do
@@ -64,6 +67,11 @@ scan_file() {
 
 		if [ "$with_indent" -ge 0 ] && [ -n "$LT" ] && [ "$IND" -le "$with_indent" ]; then
 			with_indent=-1
+			with_child=-1
+		fi
+
+		if [ "$with_indent" -ge 0 ] && [ "$with_child" -lt 0 ] && [ -n "$LT" ]; then
+			with_child=$IND
 		fi
 
 		case "$LT" in
@@ -79,7 +87,7 @@ scan_file() {
 			fi
 			;;
 		persist-credentials:*)
-			if [ "$with_indent" -ge 0 ] && [ "$IND" -gt "$with_indent" ]; then
+			if [ "$with_child" -ge 0 ] && [ "$IND" -eq "$with_child" ]; then
 				_val=${LT#persist-credentials:}
 				_val=${_val%% #*}
 				_val=$(printf '%s' "$_val" | tr -d ' 	')

--- a/scripts/checkout-creds.sh
+++ b/scripts/checkout-creds.sh
@@ -28,7 +28,9 @@ close_anchor() {
 	with_indent=-1
 }
 
-# A step region spans from an actions/checkout line to the next sequence
+# An anchor is a uses: key naming actions/checkout@; a mention inside a
+# comment or a run: body is not one. A step region spans from that anchor
+# to the next sequence
 # item at or above its indentation, the next non-blank line below it, or
 # EOF. Blank lines never end a region. Only a persist-credentials under
 # the step's own with: mapping is an actions/checkout input; under env:
@@ -65,7 +67,7 @@ scan_file() {
 		fi
 
 		case "$LT" in
-		*uses:*actions/checkout*)
+		uses:*actions/checkout@* | -\ uses:*actions/checkout@*)
 			close_anchor
 			checked=$((checked + 1))
 			anchor_line=$lineno

--- a/scripts/checkout-creds.sh
+++ b/scripts/checkout-creds.sh
@@ -25,16 +25,20 @@ close_anchor() {
 	anchor_line=""
 	anchor_indent=0
 	anchor_compliant=0
+	with_indent=-1
 }
 
 # A step region spans from an actions/checkout line to the next sequence
 # item at or above its indentation, the next non-blank line below it, or
-# EOF. Blank lines never end a region.
+# EOF. Blank lines never end a region. Only a persist-credentials under
+# the step's own with: mapping is an actions/checkout input; under env:
+# it is an unrelated variable and the input keeps its default.
 scan_file() {
 	file=$1
 	anchor_line=""
 	anchor_indent=0
 	anchor_compliant=0
+	with_indent=-1
 	lineno=0
 
 	while IFS= read -r raw || [ -n "$raw" ]; do
@@ -56,6 +60,10 @@ scan_file() {
 			esac
 		fi
 
+		if [ "$with_indent" -ge 0 ] && [ -n "$LT" ] && [ "$IND" -le "$with_indent" ]; then
+			with_indent=-1
+		fi
+
 		case "$LT" in
 		*uses:*actions/checkout*)
 			close_anchor
@@ -63,16 +71,22 @@ scan_file() {
 			anchor_line=$lineno
 			anchor_indent=$IND
 			;;
+		with:*)
+			if [ -n "$anchor_line" ] && [ "$IND" -ge "$anchor_indent" ]; then
+				with_indent=$IND
+			fi
+			;;
 		persist-credentials:*)
-			[ -n "$anchor_line" ] || continue
-			_val=${LT#persist-credentials:}
-			_val=${_val%% #*}
-			_val=$(printf '%s' "$_val" | tr -d ' 	')
-			case "$_val" in
-			true | false)
-				anchor_compliant=1
-				;;
-			esac
+			if [ "$with_indent" -ge 0 ] && [ "$IND" -gt "$with_indent" ]; then
+				_val=${LT#persist-credentials:}
+				_val=${_val%% #*}
+				_val=$(printf '%s' "$_val" | tr -d ' 	')
+				case "$_val" in
+				true | false)
+					anchor_compliant=1
+					;;
+				esac
+			fi
 			;;
 		esac
 	done <"$file"


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Chore

**Intent:** `actions/checkout` defaults `persist-credentials` to `true`, leaving the job's token in the local git config for every step that runs after the checkout, whether or not that step needs it. One checkout was already hardened in #906; this sets `persist-credentials: false` on the remaining twenty-three checkout steps across `ci.yml`, `nightly.yml`, and `release.yml`, and adds a script that fails CI if a future checkout step omits the key.

**Related Issues:** #907

### 🧭 Reviewer Guide

**Complexity:** Medium

#### Entry Point

`scripts/checkout-creds.sh` is the new piece: a POSIX-sh scanner that walks `.github/workflows/*.yml`, finds each `actions/checkout` step, and fails if that step's region never sets `persist-credentials`. It is wired into the `lint-shell` job in `ci.yml` so a future checkout step that omits the key breaks CI instead of leaking a token by default. The workflow diffs themselves are mechanical once this script is trusted.

#### Sensitive Areas

- `.github/workflows/release.yml`: the "Create and push tag" job's checkout keeps `persist-credentials: true`, with a comment naming the `git push origin` step that needs the credential. Every other checkout in this file - including the ones that run `git tag`-reading or read-only git commands - was verified not to need the token and set to `false`.
- `scripts/checkout-creds.sh`: region-scanning logic (indentation-based step boundaries) is the only thing standing between a future checkout step and a silently reintroduced token leak; worth reading closely for edge cases in step/anchor closing.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes.
- **Migrations/State:** No migrations or state changes.
