### PR TITLE
fix: report a type fault for a non-string adapter config value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- A string-typed adapter configuration key whose value carries another YAML type, such as `tracker.endpoint: 123`, `agent.kind: 123`, or a mistyped `claude-code.model`, is now rejected with a diagnostic naming the key and the type found, instead of being silently coerced to the empty string and then treated as absent or defaulted to the adapter's own default. A workflow that previously started with such a value now fails at config load, at adapter construction, or offline through `sortie validate`, whichever reads the key first; the fix is to quote the value or remove the key.
+  ([#911](https://github.com/sortie-ai/sortie/issues/911))
+
 ## [1.23.0] - 2026-08-31
 
 ### Added

--- a/docs/architecture/06-configuration-specification.md
+++ b/docs/architecture/06-configuration-specification.md
@@ -83,6 +83,10 @@ Per-tick dispatch validation:
 Validation checks:
 
 - Workflow file can be loaded and parsed.
+- A configuration key the config layer reads as a string is rejected when its value carries
+  another YAML type, distinct from the diagnostic for an absent key. This verdict is identical
+  at startup, at `sortie validate`, and on the reload fail-safe path, because all three read the
+  same config-construction result.
 - `tracker.kind` is present and supported.
 - `tracker.api_key` is present after `$` resolution, when required by the selected tracker adapter.
 - `tracker.project` is present when required by the selected tracker adapter.

--- a/docs/architecture/06-configuration-specification.md
+++ b/docs/architecture/06-configuration-specification.md
@@ -83,10 +83,12 @@ Per-tick dispatch validation:
 Validation checks:
 
 - Workflow file can be loaded and parsed.
-- A configuration key the config layer reads as a string is rejected when its value carries
-  another YAML type, distinct from the diagnostic for an absent key. This verdict is identical
-  at startup, at `sortie validate`, and on the reload fail-safe path, because all three read the
-  same config-construction result.
+- A `tracker`, `agent`, `ci_feedback` or `notifications` key the config layer reads as a string,
+  together with `db_path`, is rejected when its value carries another YAML type, distinct from the
+  diagnostic for an absent key. This verdict is identical at startup, at `sortie validate`, and on
+  the reload fail-safe path, because all three read the same config-construction result. The
+  `workspace.root`, hook-script and reaction-escalation keys are not covered: a wrong-typed value
+  there still reads as the empty string.
 - `tracker.kind` is present and supported.
 - `tracker.api_key` is present after `$` resolution, when required by the selected tracker adapter.
 - `tracker.project` is present when required by the selected tracker adapter.

--- a/docs/architecture/11-issue-tracker-integration-contract.md
+++ b/docs/architecture/11-issue-tracker-integration-contract.md
@@ -88,7 +88,8 @@ Recommended error categories:
 - `tracker_transport_error` (transport failures)
 - `tracker_auth_error` (authentication/authorization failures)
 - `tracker_api_error` (non-200 HTTP or API-level error)
-- `tracker_payload_error` (malformed or unexpected response structure)
+- `tracker_payload_error` (malformed or unexpected response structure, or an adapter
+  configuration value whose YAML type does not match what the reader requires)
 - `tracker_missing_end_cursor` (pagination integrity error)
 
 Each adapter maps its native errors to these categories.

--- a/docs/architecture/22-test-and-validation-matrix.md
+++ b/docs/architecture/22-test-and-validation-matrix.md
@@ -39,8 +39,9 @@ Unless otherwise noted, Sections 17.1 through 17.7 are `Core Conformance`. Bulle
   `9223372036854` itself is accepted
 - Per-state concurrency override map normalizes state names and ignores invalid values
 - A string-typed adapter configuration key whose value carries another YAML type is rejected with
-  a diagnostic naming the key and the type found, distinct from the absent-key diagnostic, at
-  config parse time, at construction, and offline through `sortie validate`
+  a diagnostic naming the key and the type found, distinct from the absent-key diagnostic, by the
+  earliest surface that reads it: config load for a key the config layer owns, adapter
+  construction and `sortie validate` for a key the adapter owns
 - A static check fails when a tracker, source-control, agent, notifier, or config-layer package
   gains a new discarded string type assertion outside its allowlisted sites
 - Prompt template renders `issue`, `attempt`, and `run`

--- a/docs/architecture/22-test-and-validation-matrix.md
+++ b/docs/architecture/22-test-and-validation-matrix.md
@@ -38,6 +38,11 @@ Unless otherwise noted, Sections 17.1 through 17.7 are `Core Conformance`. Bulle
   value above `9223372036854` are rejected at config parse time, naming the field and the value;
   `9223372036854` itself is accepted
 - Per-state concurrency override map normalizes state names and ignores invalid values
+- A string-typed adapter configuration key whose value carries another YAML type is rejected with
+  a diagnostic naming the key and the type found, distinct from the absent-key diagnostic, at
+  config parse time, at construction, and offline through `sortie validate`
+- A static check fails when a tracker, source-control, agent, notifier, or config-layer package
+  gains a new discarded string type assertion outside its allowlisted sites
 - Prompt template renders `issue`, `attempt`, and `run`
 - Prompt rendering fails on unknown variables (strict mode)
 

--- a/docs/file-based-tasks-spec.md
+++ b/docs/file-based-tasks-spec.md
@@ -231,7 +231,7 @@ tracker:
 
 ### 8.3 Configuration Errors
 
-If `path` is missing or empty, the adapter constructor returns a `TrackerError` with kind `tracker_payload_error` and the message `"missing required config key: path"`.
+If `path` is missing or empty, the adapter constructor returns a `TrackerError` with kind `tracker_payload_error` and the message `"missing required config key: path"`. If `path` is present with a non-string YAML value, the constructor returns a `TrackerError` with kind `tracker_payload_error` and the message `"path: expected string, got <type>"`.
 
 ## 9. Adapter Operations
 
@@ -289,6 +289,7 @@ Error conditions:
 | File contains invalid JSON                       | `"failed to parse file: <path>"`      |
 | Issue not found by ID                            | `"issue not found: <id>"`             |
 | Missing `path` config key                        | `"missing required config key: path"` |
+| `path` config key holds a non-string YAML value  | `"path: expected string, got <type>"` |
 
 ## 11. Validation Checklist
 

--- a/docs/workflow-reference.md
+++ b/docs/workflow-reference.md
@@ -2632,8 +2632,8 @@ itself refuses nothing and would launch on either. Every other value reaches the
 written, except `mcp_config`, which the generated configuration the worker writes
 supersedes. What the CLI does with an invalid value differs per flag: `--effort` falls
 back to the default effort with a warning, and an unknown model name reaches the API and
-fails there. A key whose YAML value has the wrong type is ignored and the default
-applies.
+fails there. A string key whose YAML value carries another type fails construction and,
+offline, is reported by `sortie validate` under the check `claude-code.<key>.wrong_type`.
 
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -2696,8 +2696,9 @@ with no session ID, on a session where none was known already, is followed by
 `--continue`, which resumes the most recent conversation in the workspace directory.
 The adapter validates none of these values and forwards each as written, except in the
 two cases described below: a non-positive `max_autopilot_continues` is replaced by `50`,
-and `mcp_config` is reformatted before it reaches `--additional-mcp-config`. A key whose
-YAML value has the wrong type is ignored and the default applies. The adapter reads the
+and `mcp_config` is reformatted before it reaches `--additional-mcp-config`. A string key
+whose YAML value carries another type fails construction and, offline, is reported by
+`sortie validate` under the check `copilot-cli.<key>.wrong_type`. The adapter reads the
 runtime's own task-completion report as the turn's outcome, not solely the terminal
 event's exit code.
 
@@ -2753,8 +2754,9 @@ The `codex` block is forwarded to the Codex adapter, which launches `codex app-s
 once per session and sends these fields on the `thread/start` and `turn/start`
 JSON-RPC requests as the session starts and as each turn runs. One key is checked
 before a run starts, `approval_policy`; the preflight refuses any value other than
-`never`, while the adapter itself refuses nothing further once a run starts. A key
-whose YAML value has the wrong type is ignored and the default applies.
+`never`, while the adapter itself refuses nothing further once a run starts. A string
+key whose YAML value carries another type fails construction and, offline, is reported
+by `sortie validate` under the check `codex.<key>.wrong_type`.
 
 The Codex adapter uses a persistent subprocess model: the app-server is launched
 once in `StartSession` and kept alive across turns, unlike the per-turn subprocess
@@ -3663,6 +3665,15 @@ Each error identifies the offending field path.
 | `config: agent.max_tokens: must be non-negative`                                | Negative value for `max_tokens`.                                         | Use `0` (unlimited) or a positive integer.                                                                                           |
 | `config: agent.max_consecutive_absences: must be greater than 0`                | `0` or a negative value for `max_consecutive_absences`.                  | Use a positive integer, or remove the key to take the default of `3`.                                                                |
 | `config: agent.max_consecutive_absences: invalid integer value: <val>`          | Non-integer value for `max_consecutive_absences`.                        | Use a plain integer (e.g., `3`) or a quoted string integer (e.g., `"3"`).                                                            |
+| `config: agent.kind: expected string, got <type>`                               | `agent.kind` is not a string (e.g., integer, boolean, list).             | Ensure the value is a string, quoted if necessary.                                                                                   |
+| `config: agent.command: expected string, got <type>`                            | `agent.command` is not a string (e.g., integer, boolean, list).          | Ensure the value is a string, quoted if necessary.                                                                                   |
+| `config: tracker.kind: expected string, got <type>`                             | `tracker.kind` is not a string (e.g., integer, boolean, list).           | Ensure the value is a string, quoted if necessary.                                                                                   |
+| `config: tracker.endpoint: expected string, got <type>`                         | `tracker.endpoint` is not a string (e.g., integer, boolean, list).       | Ensure the value is a string, quoted if necessary.                                                                                   |
+| `config: tracker.api_key: expected string, got <type>`                          | `tracker.api_key` is not a string (e.g., integer, boolean, list).        | Ensure the value is a string, quoted if necessary.                                                                                   |
+| `config: tracker.project: expected string, got <type>`                          | `tracker.project` is not a string (e.g., integer, boolean, list).        | Ensure the value is a string, quoted if necessary.                                                                                   |
+| `config: tracker.query_filter: expected string, got <type>`                     | `tracker.query_filter` is not a string (e.g., integer, boolean, list).   | Ensure the value is a string, quoted if necessary.                                                                                   |
+| `config: tracker.api_version: expected string, got <type>`                      | `tracker.api_version` is a type other than string and other than a whole number (e.g., boolean, list). A bare whole number (e.g., `2`) is coerced to its decimal string instead of raising this error. | Ensure the value is a string or a whole number, quoted if necessary. |
+| `config: <field>: expected string, got timestamp`                               | An unquoted date (e.g., `2026-01-01`) decodes to a YAML timestamp rather than a string. | Quote the value (e.g., `"2026-01-01"`) so it decodes as a string.                                                        |
 | `config: tracker.handoff_state: expected string, got <type>`                    | `handoff_state` is not a string (e.g., integer, boolean, list).          | Ensure the value is a string, quoted if necessary.                                                                                   |
 | `config: tracker.handoff_state: must not be empty`                              | `handoff_state` is set to an explicit empty string.                      | Provide a valid state name, or omit the field entirely to disable handoff.                                                           |
 | `config: tracker.handoff_state: resolved to empty (check environment variable)` | `$VAR` reference resolved to an empty string (variable unset or empty).  | Set the referenced environment variable to a valid state name.                                                                       |
@@ -3686,6 +3697,7 @@ Each error identifies the offending field path.
 | `config: workspace.retention_days: must be 0 to disable or at least 30 days`    | `retention_days` is between `1` and `29` inclusive.                       | Use `0` to disable the bound, or a value of `30` or greater.                                                                         |
 | `config: db_path: expected string, got <type>`                                  | `db_path` is not a string value.                                         | Use a string path value, quoted if necessary.                                                                                        |
 | `config: db_path: resolved to empty (check environment variable)`               | `$VAR` reference resolved to empty.                                      | Set the environment variable or use a literal path.                                                                                  |
+| `config: ci_feedback.kind: expected string, got <type>`                         | `ci_feedback.kind` is not a string (e.g., integer, boolean, list).       | Ensure the value is a string, quoted if necessary.                                                                                   |
 | `config: ci_feedback.max_retries: invalid integer value: <val>`                 | Non-integer value for `max_retries`.                                     | Use a plain integer (e.g., `2`).                                                                                                     |
 | `config: ci_feedback.max_retries: must be non-negative`                         | Negative value for `max_retries`.                                        | Use `0` (escalate immediately) or a positive integer.                                                                                |
 | `config: ci_feedback.max_log_lines: invalid integer value: <val>`               | Non-integer value for `max_log_lines`.                                   | Use a plain integer (e.g., `50`).                                                                                                    |
@@ -3693,6 +3705,7 @@ Each error identifies the offending field path.
 | `config: ci_feedback.escalation: must be "label" or "comment", got "<val>"`     | Invalid escalation strategy.                                             | Use `"label"` or `"comment"`.                                                                                                        |
 | `config: reactions.ci_failure.watch_window_ms: must not exceed 9223372036854 (about 292 years); use 0 for no time limit, got <val>` | `watch_window_ms` exceeds the ceiling. | Lower the value, or use `0` for no time limit. |
 | `config: reactions.ci_failure.watch_window_ms: must be non-negative, got <val>` | Negative value for `watch_window_ms`.                                    | Use `0` (no time limit) or a positive integer.                                                                                       |
+| `config: notifications[N].kind: expected string, got <type>`                   | The `kind` of the `N`th `notifications` entry is not a string (e.g., integer, boolean, list). | Ensure the value is a string, quoted if necessary.                                                                 |
 
 ### 9.3 Environment Variable Errors
 

--- a/docs/workflow-reference.md
+++ b/docs/workflow-reference.md
@@ -2777,7 +2777,7 @@ model used by `claude-code`, `copilot-cli`, and `opencode`.
 > the check `codex.approval_policy.interactive` and no agent is dispatched while that
 > value stands. Codex also accepts an object form of this policy, a `granular` member
 > whose booleans decide each approval category, but this key is read as a string only,
-> so a map value is treated as absent and `thread/start` receives `never`.
+> so a map value is a type fault that fails construction rather than a value Codex sees.
 
 > **Important:** When `thread_sandbox` is omitted, the adapter defaults to
 > `workspaceWrite` with `writableRoots` set to the workspace path and
@@ -2806,7 +2806,9 @@ The `opencode` block is forwarded to the OpenCode adapter. The adapter runs
 `opencode run --format json --dir <workspace>` once per turn, appends
 `--session <session_id>` when continuing a session, and recovers final token
 usage with `opencode export --sanitize <session_id>` when the session ID is
-known.
+known. A string key whose YAML value carries another type fails construction and,
+offline, is reported by `sortie validate` under the check
+`opencode.<key>.wrong_type`.
 
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -2847,7 +2849,9 @@ kiro:
 The `kiro` block is forwarded to the Kiro adapter, which runs
 `kiro-cli chat --no-interactive --wrap never` once per turn and adds `--resume`
 on continuation turns to attach to the cwd-scoped conversation. The Kiro CLI
-is the rebranded Amazon Q Developer CLI; the binary is `kiro-cli`.
+is the rebranded Amazon Q Developer CLI; the binary is `kiro-cli`. A string key whose
+YAML value carries another type fails construction and, offline, is reported by
+`sortie validate` under the check `kiro.<key>.wrong_type`.
 
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |

--- a/internal/adaptertest/contract_test.go
+++ b/internal/adaptertest/contract_test.go
@@ -52,6 +52,8 @@ var contractBanTable = map[string]string{
 	"findCurrentStateLabel":  "issuekit.CurrentLabelState",
 	"paginatePages":          "httpkit.NewPagePaginator",
 	"parseUTC":               "scmcore.ParseTimestamp or scmcore.ParseTimestampOrZero",
+	"stringFrom":             "typeutil.StringField",
+	"StringFrom":             "typeutil.StringField",
 }
 
 // contractTrackerAdapterMethods are the tracker operation method names

--- a/internal/adaptertest/stringassert_test.go
+++ b/internal/adaptertest/stringassert_test.go
@@ -1,0 +1,180 @@
+package adaptertest
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// contractConfigPath is the import path rule STRINGASSERT walks in
+// addition to the four family roots; internal/config holds no adapter
+// kind, so it carries no constant of its own elsewhere in this package.
+const contractConfigPath = "github.com/sortie-ai/sortie/internal/config"
+
+// contractStringAssertAllowlist exempts the sites that read a decoded
+// API payload or a test fixture rather than operator configuration from
+// the discarded string-assertion idiom ban, each with the reason it is
+// not the fault this rule exists to catch. Keyed by a path relative to
+// internal/, joined with "/" so the key is stable across platforms;
+// keying by directory alone would exempt every file in a package that
+// holds both an exempt site and a converted constructor.
+var contractStringAssertAllowlist = map[string]string{
+	"tracker/jira/adf.go":          "parses an Atlassian Document Format node from a tracker response",
+	"tracker/linear/pagination.go": "reads a GraphQL variables map the adapter itself built",
+	"agent/mock/mock.go":           "parses a scripted tool-call fixture",
+}
+
+// contractStringAssertRelPath returns file's path relative to internal/,
+// with OS-specific separators normalized to "/", for matching against
+// [contractStringAssertAllowlist]. Every root this rule walks is passed
+// to [contractWalkRoot] as a two-dot-relative path, so stripping that
+// leading segment yields a path relative to internal/.
+func contractStringAssertRelPath(fset *token.FileSet, file *ast.File) string {
+	name := filepath.ToSlash(fset.Position(file.Pos()).Filename)
+	return strings.TrimPrefix(name, "../")
+}
+
+// checkContractStringAssert walks pkg's non-test files for a discarded
+// two-result type assertion to string, `value, _ := v.(string)`, the
+// idiom that degrades a non-string configuration value to the empty
+// string instead of reporting it. A named second result and a
+// single-result assertion do not match: the first is a deliberate
+// decision by the reader, and the second panics rather than coercing.
+func checkContractStringAssert(fset *token.FileSet, pkg contractPackage) []contractViolation {
+	var violations []contractViolation
+	for _, file := range pkg.files {
+		if _, exempt := contractStringAssertAllowlist[contractStringAssertRelPath(fset, file)]; exempt {
+			continue
+		}
+		ast.Inspect(file, func(n ast.Node) bool {
+			assign, ok := n.(*ast.AssignStmt)
+			if !ok || len(assign.Lhs) != 2 || len(assign.Rhs) != 1 {
+				return true
+			}
+			blank, ok := assign.Lhs[1].(*ast.Ident)
+			if !ok || blank.Name != "_" {
+				return true
+			}
+			typeAssert, ok := assign.Rhs[0].(*ast.TypeAssertExpr)
+			if !ok || typeAssert.Type == nil {
+				return true
+			}
+			ident, ok := typeAssert.Type.(*ast.Ident)
+			if !ok || ident.Name != "string" {
+				return true
+			}
+			violations = append(violations, contractViolation{
+				pos:  fset.Position(assign.Pos()),
+				text: "discarded string type assertion; call typeutil.StringField instead",
+			})
+			return true
+		})
+	}
+	return violations
+}
+
+// TestCheckContractStringAssert walks internal/tracker, internal/scm,
+// internal/agent, internal/notify, and internal/config, excluding
+// testdata and test files, and fails when a non-test file outside
+// [contractStringAssertAllowlist] contains the discarded string
+// type-assertion idiom.
+func TestCheckContractStringAssert(t *testing.T) {
+	fset := token.NewFileSet()
+
+	roots := []struct {
+		dir        string
+		importPath string
+	}{
+		{filepath.Join("..", "tracker"), contractTrackerFamilyPath},
+		{filepath.Join("..", "scm"), contractSCMFamilyPath},
+		{filepath.Join("..", "agent"), contractAgentFamilyPath},
+		{filepath.Join("..", "notify"), contractNotifyFamilyPath},
+		{filepath.Join("..", "config"), contractConfigPath},
+	}
+
+	var walked []contractWalkedPackage
+	for _, root := range roots {
+		rootWalked, _ := contractWalkRoot(t, fset, root.dir, root.importPath)
+		walked = append(walked, rootWalked...)
+	}
+
+	sort.Slice(walked, func(i, j int) bool { return walked[i].dir < walked[j].dir })
+	for _, w := range walked {
+		for _, v := range checkContractStringAssert(fset, w.pkg) {
+			t.Errorf("%s: %s", v.pos, v.text)
+		}
+	}
+}
+
+// TestCheckContractStringAssert_DetectsViolations pins the detector's own
+// match rule against inline source fixtures: a discarded two-result
+// assertion is reported, while a named second result and a single-result
+// assertion are not, so the rule is proven capable of failing rather than
+// matching nothing.
+func TestCheckContractStringAssert_DetectsViolations(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		src       string
+		wantCount int
+	}{
+		{
+			name: "a discarded two-result string assertion is rejected",
+			src: `package fixture
+
+func read(config map[string]any) string {
+	value, _ := config["key"].(string)
+	return value
+}
+`,
+			wantCount: 1,
+		},
+		{
+			name: "a named second result is accepted",
+			src: `package fixture
+
+func read(config map[string]any) string {
+	value, ok := config["key"].(string)
+	if !ok {
+		return ""
+	}
+	return value
+}
+`,
+			wantCount: 0,
+		},
+		{
+			name: "a single-result assertion is accepted",
+			src: `package fixture
+
+func read(config map[string]any) string {
+	return config["key"].(string)
+}
+`,
+			wantCount: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			fset := token.NewFileSet()
+			file, err := parser.ParseFile(fset, "fixture.go", tt.src, parser.SkipObjectResolution)
+			if err != nil {
+				t.Fatalf("parser.ParseFile: %v", err)
+			}
+
+			pkg := contractPackage{dirName: "fixture", files: []*ast.File{file}}
+			got := checkContractStringAssert(fset, pkg)
+			if len(got) != tt.wantCount {
+				t.Errorf("checkContractStringAssert() returned %d violations, want %d: %+v", len(got), tt.wantCount, got)
+			}
+		})
+	}
+}

--- a/internal/agent/claude/claude.go
+++ b/internal/agent/claude/claude.go
@@ -111,7 +111,10 @@ func (s *sessionState) refreshForkLogger() {
 // "claude-code" sub-object in WORKFLOW.md. Command resolution is
 // deferred to [ClaudeCodeAdapter.StartSession].
 func NewClaudeCodeAdapter(config map[string]any) (domain.AgentAdapter, error) {
-	pt := parsePassthroughConfig(config)
+	pt, fault := parsePassthroughConfig(config)
+	if fault != nil {
+		return nil, fault
+	}
 	return &ClaudeCodeAdapter{passthrough: pt}, nil
 }
 

--- a/internal/agent/claude/claude_test.go
+++ b/internal/agent/claude/claude_test.go
@@ -404,7 +404,10 @@ func TestBuildArgs_AlwaysPresent(t *testing.T) {
 func TestBuildArgs_DefaultConfigurationSkipsPermissions(t *testing.T) {
 	t.Parallel()
 
-	pt := parsePassthroughConfig(map[string]any{})
+	pt, fault := parsePassthroughConfig(map[string]any{})
+	if fault != nil {
+		t.Fatalf("parsePassthroughConfig: %v", fault)
+	}
 	got := buildArgs(&sessionState{claudeSessionID: "sess-default"}, 1, "p", pt)
 
 	if !slices.Contains(got, "--dangerously-skip-permissions") {
@@ -443,7 +446,7 @@ func TestParsePassthroughConfig(t *testing.T) {
 
 	t.Run("full config", func(t *testing.T) {
 		t.Parallel()
-		cfg := parsePassthroughConfig(map[string]any{
+		cfg, fault := parsePassthroughConfig(map[string]any{
 			"permission_mode":     "dontAsk",
 			"model":               "claude-opus-4-20250514",
 			"fallback_model":      "claude-haiku-3",
@@ -456,6 +459,9 @@ func TestParsePassthroughConfig(t *testing.T) {
 			"mcp_config":          "/path/mcp.json",
 			"session_persistence": false,
 		})
+		if fault != nil {
+			t.Fatalf("parsePassthroughConfig: %v", fault)
+		}
 		if cfg.PermissionMode != "dontAsk" {
 			t.Errorf("PermissionMode = %q", cfg.PermissionMode)
 		}
@@ -475,7 +481,10 @@ func TestParsePassthroughConfig(t *testing.T) {
 
 	t.Run("empty config defaults", func(t *testing.T) {
 		t.Parallel()
-		cfg := parsePassthroughConfig(map[string]any{})
+		cfg, fault := parsePassthroughConfig(map[string]any{})
+		if fault != nil {
+			t.Fatalf("parsePassthroughConfig: %v", fault)
+		}
 		if cfg.PermissionMode != "" {
 			t.Errorf("PermissionMode = %q, want empty", cfg.PermissionMode)
 		}
@@ -487,15 +496,14 @@ func TestParsePassthroughConfig(t *testing.T) {
 		}
 	})
 
-	t.Run("wrong types ignored", func(t *testing.T) {
+	t.Run("wrong non-string types ignored", func(t *testing.T) {
 		t.Parallel()
-		cfg := parsePassthroughConfig(map[string]any{
-			"model":          42,     // int instead of string
+		cfg, fault := parsePassthroughConfig(map[string]any{
 			"max_turns":      "five", // string instead of int
 			"max_budget_usd": "lots", // string instead of float
 		})
-		if cfg.Model != "" {
-			t.Errorf("Model = %q, want empty (wrong type)", cfg.Model)
+		if fault != nil {
+			t.Fatalf("parsePassthroughConfig: %v", fault)
 		}
 		if cfg.MaxTurns != 0 {
 			t.Errorf("MaxTurns = %d, want 0 (wrong type)", cfg.MaxTurns)
@@ -505,11 +513,27 @@ func TestParsePassthroughConfig(t *testing.T) {
 		}
 	})
 
+	t.Run("wrong string type reports a fault", func(t *testing.T) {
+		t.Parallel()
+		_, fault := parsePassthroughConfig(map[string]any{
+			"model": 42, // int instead of string
+		})
+		if fault == nil {
+			t.Fatal("parsePassthroughConfig: got nil fault, want non-nil")
+		}
+		if fault.Key != "model" {
+			t.Errorf("fault.Key = %q, want %q", fault.Key, "model")
+		}
+	})
+
 	t.Run("int coerced from float64", func(t *testing.T) {
 		t.Parallel()
-		cfg := parsePassthroughConfig(map[string]any{
+		cfg, fault := parsePassthroughConfig(map[string]any{
 			"max_turns": float64(7),
 		})
+		if fault != nil {
+			t.Fatalf("parsePassthroughConfig: %v", fault)
+		}
 		if cfg.MaxTurns != 7 {
 			t.Errorf("MaxTurns = %d, want 7", cfg.MaxTurns)
 		}
@@ -517,9 +541,12 @@ func TestParsePassthroughConfig(t *testing.T) {
 
 	t.Run("float coerced from int", func(t *testing.T) {
 		t.Parallel()
-		cfg := parsePassthroughConfig(map[string]any{
+		cfg, fault := parsePassthroughConfig(map[string]any{
 			"max_budget_usd": 3,
 		})
+		if fault != nil {
+			t.Fatalf("parsePassthroughConfig: %v", fault)
+		}
 		if cfg.MaxBudgetUSD != 3.0 {
 			t.Errorf("MaxBudgetUSD = %f, want 3.0", cfg.MaxBudgetUSD)
 		}

--- a/internal/agent/claude/command.go
+++ b/internal/agent/claude/command.go
@@ -25,23 +25,57 @@ type passthroughConfig struct {
 	SessionPersistence bool
 }
 
-// parsePassthroughConfig extracts Claude Code-specific settings from
-// the raw config map. Missing or wrong-typed keys use zero-value
-// defaults; SessionPersistence defaults to true.
-func parsePassthroughConfig(config map[string]any) passthroughConfig {
+// parsePassthroughConfig extracts Claude Code-specific settings from the
+// raw config map. A missing key uses its zero-value default;
+// SessionPersistence defaults to true. A key present with a non-string
+// value for a string field reports a fault rather than defaulting.
+func parsePassthroughConfig(config map[string]any) (passthroughConfig, *typeutil.TypeFault) {
+	permissionMode, fault := typeutil.StringField(config, "permission_mode")
+	if fault != nil {
+		return passthroughConfig{}, fault
+	}
+	model, fault := typeutil.StringField(config, "model")
+	if fault != nil {
+		return passthroughConfig{}, fault
+	}
+	fallbackModel, fault := typeutil.StringField(config, "fallback_model")
+	if fault != nil {
+		return passthroughConfig{}, fault
+	}
+	effort, fault := typeutil.StringField(config, "effort")
+	if fault != nil {
+		return passthroughConfig{}, fault
+	}
+	allowedTools, fault := typeutil.StringField(config, "allowed_tools")
+	if fault != nil {
+		return passthroughConfig{}, fault
+	}
+	disallowedTools, fault := typeutil.StringField(config, "disallowed_tools")
+	if fault != nil {
+		return passthroughConfig{}, fault
+	}
+	systemPrompt, fault := typeutil.StringField(config, "system_prompt")
+	if fault != nil {
+		return passthroughConfig{}, fault
+	}
+	mcpConfig, fault := typeutil.StringField(config, "mcp_config")
+	if fault != nil {
+		return passthroughConfig{}, fault
+	}
+
 	return passthroughConfig{
-		PermissionMode:     typeutil.StringFrom(config, "permission_mode"),
-		Model:              typeutil.StringFrom(config, "model"),
-		FallbackModel:      typeutil.StringFrom(config, "fallback_model"),
+		PermissionMode:     permissionMode,
+		Model:              model,
+		FallbackModel:      fallbackModel,
 		MaxTurns:           typeutil.IntFrom(config, "max_turns", 0),
 		MaxBudgetUSD:       typeutil.FloatFrom(config, "max_budget_usd", 0),
-		Effort:             typeutil.StringFrom(config, "effort"),
-		AllowedTools:       typeutil.StringFrom(config, "allowed_tools"),
-		DisallowedTools:    typeutil.StringFrom(config, "disallowed_tools"),
-		SystemPrompt:       typeutil.StringFrom(config, "system_prompt"),
-		MCPConfig:          typeutil.StringFrom(config, "mcp_config"),
+		Effort:             effort,
+		AllowedTools:       allowedTools,
+		DisallowedTools:    disallowedTools,
+		SystemPrompt:       systemPrompt,
+		MCPConfig:          mcpConfig,
 		SessionPersistence: typeutil.BoolFrom(config, "session_persistence", true),
-	}
+	}, nil
 }
 
 // buildArgs constructs the CLI argument slice for a Claude Code

--- a/internal/agent/claude/command_test.go
+++ b/internal/agent/claude/command_test.go
@@ -41,23 +41,43 @@ func newFirstTurnState(mcpConfigPath string) *sessionState {
 
 // TestParsePassthroughConfig_TypeFault covers the funnel's fault path for
 // a wrong-typed string field: it returns the zero passthroughConfig and a
-// fault whose rendering names the key and the type found.
+// fault whose rendering names the key and the type found. Every string
+// key the funnel reads gets its own case, so a key whose fault arm was
+// never wired shows up as a gap here rather than at runtime.
 func TestParsePassthroughConfig_TypeFault(t *testing.T) {
 	t.Parallel()
 
-	pt, fault := parsePassthroughConfig(map[string]any{"model": 123})
+	keys := []string{
+		"permission_mode",
+		"model",
+		"fallback_model",
+		"effort",
+		"allowed_tools",
+		"disallowed_tools",
+		"system_prompt",
+		"mcp_config",
+	}
 
-	if fault == nil {
-		t.Fatal("parsePassthroughConfig(model=123) fault = nil, want non-nil")
-	}
-	if fault.Key != "model" {
-		t.Errorf("parsePassthroughConfig(model=123) fault.Key = %q, want %q", fault.Key, "model")
-	}
-	if fault.Error() != "model: expected string, got integer" {
-		t.Errorf("parsePassthroughConfig(model=123) fault.Error() = %q, want %q", fault.Error(), "model: expected string, got integer")
-	}
-	if pt != (passthroughConfig{}) {
-		t.Errorf("parsePassthroughConfig(model=123) passthroughConfig = %+v, want zero value", pt)
+	for _, key := range keys {
+		t.Run(key, func(t *testing.T) {
+			t.Parallel()
+
+			pt, fault := parsePassthroughConfig(map[string]any{key: 123})
+
+			if fault == nil {
+				t.Fatalf("parsePassthroughConfig(%s=123) fault = nil, want non-nil", key)
+			}
+			if fault.Key != key {
+				t.Errorf("parsePassthroughConfig(%s=123) fault.Key = %q, want %q", key, fault.Key, key)
+			}
+			wantErr := key + ": expected string, got integer"
+			if fault.Error() != wantErr {
+				t.Errorf("parsePassthroughConfig(%s=123) fault.Error() = %q, want %q", key, fault.Error(), wantErr)
+			}
+			if pt != (passthroughConfig{}) {
+				t.Errorf("parsePassthroughConfig(%s=123) passthroughConfig = %+v, want zero value", key, pt)
+			}
+		})
 	}
 }
 

--- a/internal/agent/claude/command_test.go
+++ b/internal/agent/claude/command_test.go
@@ -39,6 +39,28 @@ func newFirstTurnState(mcpConfigPath string) *sessionState {
 	}
 }
 
+// TestParsePassthroughConfig_TypeFault covers the funnel's fault path for
+// a wrong-typed string field: it returns the zero passthroughConfig and a
+// fault whose rendering names the key and the type found.
+func TestParsePassthroughConfig_TypeFault(t *testing.T) {
+	t.Parallel()
+
+	pt, fault := parsePassthroughConfig(map[string]any{"model": 123})
+
+	if fault == nil {
+		t.Fatal("parsePassthroughConfig(model=123) fault = nil, want non-nil")
+	}
+	if fault.Key != "model" {
+		t.Errorf("parsePassthroughConfig(model=123) fault.Key = %q, want %q", fault.Key, "model")
+	}
+	if fault.Error() != "model: expected string, got integer" {
+		t.Errorf("parsePassthroughConfig(model=123) fault.Error() = %q, want %q", fault.Error(), "model: expected string, got integer")
+	}
+	if pt != (passthroughConfig{}) {
+		t.Errorf("parsePassthroughConfig(model=123) passthroughConfig = %+v, want zero value", pt)
+	}
+}
+
 // TestMCPInjectionConformance proves claude-code's real buildArgs
 // output carries the generated MCP config path, matching its declared
 // disposition.

--- a/internal/agent/claude/validate.go
+++ b/internal/agent/claude/validate.go
@@ -20,8 +20,16 @@ var nonAskingPermissionModes = map[string]bool{
 // and returns diagnostics for the sortie validate pipeline. It does not
 // construct an adapter instance or launch a subprocess.
 func validateConfig(fields registry.AgentConfigFields) []registry.ValidationDiag {
-	mode := typeutil.StringFrom(fields.Passthrough, "permission_mode")
-	if mode == "" || nonAskingPermissionModes[mode] {
+	pt, fault := parsePassthroughConfig(fields.Passthrough)
+	if fault != nil {
+		return []registry.ValidationDiag{{
+			Severity: "error",
+			Check:    "claude-code." + fault.Key + ".wrong_type",
+			Message:  fault.Error(),
+		}}
+	}
+
+	if pt.PermissionMode == "" || nonAskingPermissionModes[pt.PermissionMode] {
 		return nil
 	}
 

--- a/internal/agent/claude/validate_test.go
+++ b/internal/agent/claude/validate_test.go
@@ -6,6 +6,38 @@ import (
 	"github.com/sortie-ai/sortie/internal/registry"
 )
 
+// TestValidateConfig_TypeFaultNoDrift covers the R6.5 no-drift property: a
+// wrong-typed value for a key the constructor reads fails
+// NewClaudeCodeAdapter with a plain error carrying the fault message, and
+// validateConfig reports the identical fault text under a
+// "claude-code.<key>.wrong_type" check for the same input, so the two
+// surfaces cannot diverge on what counts as a type fault.
+func TestValidateConfig_TypeFaultNoDrift(t *testing.T) {
+	t.Parallel()
+
+	config := map[string]any{"model": 123}
+
+	_, constructErr := NewClaudeCodeAdapter(config)
+	if constructErr == nil {
+		t.Fatal("NewClaudeCodeAdapter(model=123) error = nil, want non-nil")
+	}
+	if constructErr.Error() != "model: expected string, got integer" {
+		t.Errorf("NewClaudeCodeAdapter(model=123) error = %q, want %q", constructErr.Error(), "model: expected string, got integer")
+	}
+
+	diags := validateConfig(registry.AgentConfigFields{Kind: "claude-code", Passthrough: config})
+
+	if len(diags) != 1 {
+		t.Fatalf("validateConfig(model=123) returned %d diagnostics, want 1: %+v", len(diags), diags)
+	}
+	if diags[0].Check != "claude-code.model.wrong_type" {
+		t.Errorf("validateConfig(model=123)[0].Check = %q, want %q", diags[0].Check, "claude-code.model.wrong_type")
+	}
+	if diags[0].Message != constructErr.Error() {
+		t.Errorf("validateConfig(model=123)[0].Message = %q, want the same text the constructor failed with: %q", diags[0].Message, constructErr.Error())
+	}
+}
+
 // TestValidateConfig covers claude-code.permission_mode: absent or
 // "bypassPermissions" draws no diagnostic, and every other named mode plus
 // an arbitrary unrecognized string draws an error-severity diagnostic,

--- a/internal/agent/claude/validate_test.go
+++ b/internal/agent/claude/validate_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/sortie-ai/sortie/internal/registry"
 )
 
-// TestValidateConfig_TypeFaultNoDrift covers the R6.5 no-drift property: a
+// TestValidateConfig_TypeFaultNoDrift covers the no-drift property: a
 // wrong-typed value for a key the constructor reads fails
 // NewClaudeCodeAdapter with a plain error carrying the fault message, and
 // validateConfig reports the identical fault text under a

--- a/internal/agent/codex/codex.go
+++ b/internal/agent/codex/codex.go
@@ -104,7 +104,10 @@ type sessionState struct {
 // WORKFLOW.md. Command resolution is deferred to
 // [CodexAdapter.StartSession].
 func NewCodexAdapter(config map[string]any) (domain.AgentAdapter, error) {
-	pt := parsePassthroughConfig(config)
+	pt, fault := parsePassthroughConfig(config)
+	if fault != nil {
+		return nil, fault
+	}
 	adapter := &CodexAdapter{passthrough: pt}
 
 	return adapter, nil

--- a/internal/agent/codex/command.go
+++ b/internal/agent/codex/command.go
@@ -24,17 +24,40 @@ type passthroughConfig struct {
 	Personality       string
 }
 
-// parsePassthroughConfig extracts Codex-specific settings from the
-// raw config map. Missing or wrong-typed keys use zero-value defaults.
-func parsePassthroughConfig(config map[string]any) passthroughConfig {
-	return passthroughConfig{
-		Model:             typeutil.StringFrom(config, "model"),
-		Effort:            typeutil.StringFrom(config, "effort"),
-		ApprovalPolicy:    typeutil.StringFrom(config, "approval_policy"),
-		ThreadSandbox:     typeutil.StringFrom(config, "thread_sandbox"),
-		TurnSandboxPolicy: typeutil.MapFrom(config, "turn_sandbox_policy"),
-		Personality:       typeutil.StringFrom(config, "personality"),
+// parsePassthroughConfig extracts Codex-specific settings from the raw
+// config map. A missing key uses its zero-value default. A key present
+// with a non-string value for a string field reports a fault rather
+// than defaulting.
+func parsePassthroughConfig(config map[string]any) (passthroughConfig, *typeutil.TypeFault) {
+	model, fault := typeutil.StringField(config, "model")
+	if fault != nil {
+		return passthroughConfig{}, fault
 	}
+	effort, fault := typeutil.StringField(config, "effort")
+	if fault != nil {
+		return passthroughConfig{}, fault
+	}
+	approvalPolicy, fault := typeutil.StringField(config, "approval_policy")
+	if fault != nil {
+		return passthroughConfig{}, fault
+	}
+	threadSandbox, fault := typeutil.StringField(config, "thread_sandbox")
+	if fault != nil {
+		return passthroughConfig{}, fault
+	}
+	personality, fault := typeutil.StringField(config, "personality")
+	if fault != nil {
+		return passthroughConfig{}, fault
+	}
+
+	return passthroughConfig{
+		Model:             model,
+		Effort:            effort,
+		ApprovalPolicy:    approvalPolicy,
+		ThreadSandbox:     threadSandbox,
+		TurnSandboxPolicy: typeutil.MapFrom(config, "turn_sandbox_policy"),
+		Personality:       personality,
+	}, nil
 }
 
 // buildSSHRemoteCmd returns the remote command string for SSH mode.

--- a/internal/agent/codex/command_test.go
+++ b/internal/agent/codex/command_test.go
@@ -15,6 +15,28 @@ import (
 	"github.com/sortie-ai/sortie/internal/registry"
 )
 
+// TestParsePassthroughConfig_TypeFault covers the funnel's fault path for
+// a wrong-typed string field: it returns the zero passthroughConfig and a
+// fault whose rendering names the key and the type found.
+func TestParsePassthroughConfig_TypeFault(t *testing.T) {
+	t.Parallel()
+
+	pt, fault := parsePassthroughConfig(map[string]any{"approval_policy": 123})
+
+	if fault == nil {
+		t.Fatal("parsePassthroughConfig(approval_policy=123) fault = nil, want non-nil")
+	}
+	if fault.Key != "approval_policy" {
+		t.Errorf("parsePassthroughConfig(approval_policy=123) fault.Key = %q, want %q", fault.Key, "approval_policy")
+	}
+	if fault.Error() != "approval_policy: expected string, got integer" {
+		t.Errorf("parsePassthroughConfig(approval_policy=123) fault.Error() = %q, want %q", fault.Error(), "approval_policy: expected string, got integer")
+	}
+	if pt.Model != "" || pt.Effort != "" || pt.ApprovalPolicy != "" || pt.ThreadSandbox != "" || pt.Personality != "" || pt.TurnSandboxPolicy != nil {
+		t.Errorf("parsePassthroughConfig(approval_policy=123) passthroughConfig = %+v, want zero value", pt)
+	}
+}
+
 // TestMCPInjectionConformance proves codex's real launch surface
 // matches its declared disposition, on both a local and a remote
 // launch. codex renders the generated MCP config as override

--- a/internal/agent/codex/command_test.go
+++ b/internal/agent/codex/command_test.go
@@ -17,23 +17,40 @@ import (
 
 // TestParsePassthroughConfig_TypeFault covers the funnel's fault path for
 // a wrong-typed string field: it returns the zero passthroughConfig and a
-// fault whose rendering names the key and the type found.
+// fault whose rendering names the key and the type found. Every string
+// key the funnel reads gets its own case, so a key whose fault arm was
+// never wired shows up as a gap here rather than at runtime.
 func TestParsePassthroughConfig_TypeFault(t *testing.T) {
 	t.Parallel()
 
-	pt, fault := parsePassthroughConfig(map[string]any{"approval_policy": 123})
+	keys := []string{
+		"model",
+		"effort",
+		"approval_policy",
+		"thread_sandbox",
+		"personality",
+	}
 
-	if fault == nil {
-		t.Fatal("parsePassthroughConfig(approval_policy=123) fault = nil, want non-nil")
-	}
-	if fault.Key != "approval_policy" {
-		t.Errorf("parsePassthroughConfig(approval_policy=123) fault.Key = %q, want %q", fault.Key, "approval_policy")
-	}
-	if fault.Error() != "approval_policy: expected string, got integer" {
-		t.Errorf("parsePassthroughConfig(approval_policy=123) fault.Error() = %q, want %q", fault.Error(), "approval_policy: expected string, got integer")
-	}
-	if pt.Model != "" || pt.Effort != "" || pt.ApprovalPolicy != "" || pt.ThreadSandbox != "" || pt.Personality != "" || pt.TurnSandboxPolicy != nil {
-		t.Errorf("parsePassthroughConfig(approval_policy=123) passthroughConfig = %+v, want zero value", pt)
+	for _, key := range keys {
+		t.Run(key, func(t *testing.T) {
+			t.Parallel()
+
+			pt, fault := parsePassthroughConfig(map[string]any{key: 123})
+
+			if fault == nil {
+				t.Fatalf("parsePassthroughConfig(%s=123) fault = nil, want non-nil", key)
+			}
+			if fault.Key != key {
+				t.Errorf("parsePassthroughConfig(%s=123) fault.Key = %q, want %q", key, fault.Key, key)
+			}
+			wantErr := key + ": expected string, got integer"
+			if fault.Error() != wantErr {
+				t.Errorf("parsePassthroughConfig(%s=123) fault.Error() = %q, want %q", key, fault.Error(), wantErr)
+			}
+			if pt.Model != "" || pt.Effort != "" || pt.ApprovalPolicy != "" || pt.ThreadSandbox != "" || pt.Personality != "" || pt.TurnSandboxPolicy != nil {
+				t.Errorf("parsePassthroughConfig(%s=123) passthroughConfig = %+v, want zero value", key, pt)
+			}
+		})
 	}
 }
 

--- a/internal/agent/codex/parse_test.go
+++ b/internal/agent/codex/parse_test.go
@@ -72,12 +72,8 @@ func TestParsePassthroughConfig(t *testing.T) {
 			},
 		},
 		{
-			name: "wrong types use zero-value defaults",
+			name: "wrong non-string type uses zero-value default",
 			config: map[string]any{
-				"model":               42,
-				"effort":              false,
-				"approval_policy":     123,
-				"thread_sandbox":      []string{"not-a-string"},
 				"turn_sandbox_policy": "not-a-map",
 			},
 			want: passthroughConfig{},
@@ -87,7 +83,10 @@ func TestParsePassthroughConfig(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			got := parsePassthroughConfig(tt.config)
+			got, fault := parsePassthroughConfig(tt.config)
+			if fault != nil {
+				t.Fatalf("parsePassthroughConfig: %v", fault)
+			}
 			if got.Model != tt.want.Model {
 				t.Errorf("Model = %q, want %q", got.Model, tt.want.Model)
 			}
@@ -111,6 +110,17 @@ func TestParsePassthroughConfig(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("wrong string type reports a fault", func(t *testing.T) {
+		t.Parallel()
+		_, fault := parsePassthroughConfig(map[string]any{"model": 42})
+		if fault == nil {
+			t.Fatal("parsePassthroughConfig: got nil fault, want non-nil")
+		}
+		if fault.Key != "model" {
+			t.Errorf("fault.Key = %q, want %q", fault.Key, "model")
+		}
+	})
 }
 
 func TestParseMessage_Response(t *testing.T) {

--- a/internal/agent/codex/validate.go
+++ b/internal/agent/codex/validate.go
@@ -2,15 +2,22 @@ package codex
 
 import (
 	"github.com/sortie-ai/sortie/internal/registry"
-	"github.com/sortie-ai/sortie/internal/typeutil"
 )
 
 // validateConfig checks codex-specific configuration constraints and
 // returns diagnostics for the sortie validate pipeline. It does not
 // construct an adapter instance or launch a subprocess.
 func validateConfig(fields registry.AgentConfigFields) []registry.ValidationDiag {
-	policy := typeutil.StringFrom(fields.Passthrough, "approval_policy")
-	if policy == "" || policy == "never" {
+	pt, fault := parsePassthroughConfig(fields.Passthrough)
+	if fault != nil {
+		return []registry.ValidationDiag{{
+			Severity: "error",
+			Check:    "codex." + fault.Key + ".wrong_type",
+			Message:  fault.Error(),
+		}}
+	}
+
+	if pt.ApprovalPolicy == "" || pt.ApprovalPolicy == "never" {
 		return nil
 	}
 

--- a/internal/agent/codex/validate_test.go
+++ b/internal/agent/codex/validate_test.go
@@ -6,6 +6,38 @@ import (
 	"github.com/sortie-ai/sortie/internal/registry"
 )
 
+// TestValidateConfig_TypeFaultNoDrift covers the R6.5 no-drift property: a
+// wrong-typed value for a key the constructor reads fails NewCodexAdapter
+// with a plain error carrying the fault message, and validateConfig
+// reports the identical fault text under a "codex.<key>.wrong_type" check
+// for the same input, so the two surfaces cannot diverge on what counts
+// as a type fault.
+func TestValidateConfig_TypeFaultNoDrift(t *testing.T) {
+	t.Parallel()
+
+	config := map[string]any{"approval_policy": 123}
+
+	_, constructErr := NewCodexAdapter(config)
+	if constructErr == nil {
+		t.Fatal("NewCodexAdapter(approval_policy=123) error = nil, want non-nil")
+	}
+	if constructErr.Error() != "approval_policy: expected string, got integer" {
+		t.Errorf("NewCodexAdapter(approval_policy=123) error = %q, want %q", constructErr.Error(), "approval_policy: expected string, got integer")
+	}
+
+	diags := validateConfig(registry.AgentConfigFields{Kind: "codex", Passthrough: config})
+
+	if len(diags) != 1 {
+		t.Fatalf("validateConfig(approval_policy=123) returned %d diagnostics, want 1: %+v", len(diags), diags)
+	}
+	if diags[0].Check != "codex.approval_policy.wrong_type" {
+		t.Errorf("validateConfig(approval_policy=123)[0].Check = %q, want %q", diags[0].Check, "codex.approval_policy.wrong_type")
+	}
+	if diags[0].Message != constructErr.Error() {
+		t.Errorf("validateConfig(approval_policy=123)[0].Message = %q, want the same text the constructor failed with: %q", diags[0].Message, constructErr.Error())
+	}
+}
+
 // TestValidateConfig covers codex.approval_policy: absent or "never"
 // draws no diagnostic, and any other value draws an error-severity
 // diagnostic checked "codex.approval_policy.interactive".

--- a/internal/agent/codex/validate_test.go
+++ b/internal/agent/codex/validate_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/sortie-ai/sortie/internal/registry"
 )
 
-// TestValidateConfig_TypeFaultNoDrift covers the R6.5 no-drift property: a
+// TestValidateConfig_TypeFaultNoDrift covers the no-drift property: a
 // wrong-typed value for a key the constructor reads fails NewCodexAdapter
 // with a plain error carrying the fault message, and validateConfig
 // reports the identical fault text under a "codex.<key>.wrong_type" check

--- a/internal/agent/copilot/command.go
+++ b/internal/agent/copilot/command.go
@@ -24,23 +24,53 @@ type passthroughConfig struct {
 	Experimental          bool
 }
 
-// parsePassthroughConfig extracts Copilot CLI-specific settings from
-// the raw config map. Missing or wrong-typed keys use zero-value
-// defaults.
-func parsePassthroughConfig(config map[string]any) passthroughConfig {
+// parsePassthroughConfig extracts Copilot CLI-specific settings from the
+// raw config map. A missing key uses its zero-value default. A key
+// present with a non-string value for a string field reports a fault
+// rather than defaulting.
+func parsePassthroughConfig(config map[string]any) (passthroughConfig, *typeutil.TypeFault) {
+	model, fault := typeutil.StringField(config, "model")
+	if fault != nil {
+		return passthroughConfig{}, fault
+	}
+	agent, fault := typeutil.StringField(config, "agent")
+	if fault != nil {
+		return passthroughConfig{}, fault
+	}
+	allowedTools, fault := typeutil.StringField(config, "allowed_tools")
+	if fault != nil {
+		return passthroughConfig{}, fault
+	}
+	deniedTools, fault := typeutil.StringField(config, "denied_tools")
+	if fault != nil {
+		return passthroughConfig{}, fault
+	}
+	availableTools, fault := typeutil.StringField(config, "available_tools")
+	if fault != nil {
+		return passthroughConfig{}, fault
+	}
+	excludedTools, fault := typeutil.StringField(config, "excluded_tools")
+	if fault != nil {
+		return passthroughConfig{}, fault
+	}
+	mcpConfig, fault := typeutil.StringField(config, "mcp_config")
+	if fault != nil {
+		return passthroughConfig{}, fault
+	}
+
 	return passthroughConfig{
-		Model:                 typeutil.StringFrom(config, "model"),
+		Model:                 model,
 		MaxAutopilotContinues: typeutil.IntFrom(config, "max_autopilot_continues", 0),
-		Agent:                 typeutil.StringFrom(config, "agent"),
-		AllowedTools:          typeutil.StringFrom(config, "allowed_tools"),
-		DeniedTools:           typeutil.StringFrom(config, "denied_tools"),
-		AvailableTools:        typeutil.StringFrom(config, "available_tools"),
-		ExcludedTools:         typeutil.StringFrom(config, "excluded_tools"),
-		MCPConfig:             typeutil.StringFrom(config, "mcp_config"),
+		Agent:                 agent,
+		AllowedTools:          allowedTools,
+		DeniedTools:           deniedTools,
+		AvailableTools:        availableTools,
+		ExcludedTools:         excludedTools,
+		MCPConfig:             mcpConfig,
 		DisableBuiltinMCPs:    typeutil.BoolFrom(config, "disable_builtin_mcps", false),
 		NoCustomInstructions:  typeutil.BoolFrom(config, "no_custom_instructions", false),
 		Experimental:          typeutil.BoolFrom(config, "experimental", false),
-	}
+	}, nil
 }
 
 // buildArgs constructs the CLI argument slice for a Copilot CLI

--- a/internal/agent/copilot/command_test.go
+++ b/internal/agent/copilot/command_test.go
@@ -126,16 +126,34 @@ func TestParsePassthroughConfig(t *testing.T) {
 		})
 	}
 
-	t.Run("wrong type for string field reports a fault", func(t *testing.T) {
-		t.Parallel()
-		_, fault := parsePassthroughConfig(map[string]any{"model": 42})
-		if fault == nil {
-			t.Fatal("parsePassthroughConfig: got nil fault, want non-nil")
-		}
-		if fault.Key != "model" {
-			t.Errorf("fault.Key = %q, want %q", fault.Key, "model")
-		}
-	})
+	// Every string key the funnel reads gets its own case, so a key
+	// whose fault arm was never wired shows up as a gap here rather
+	// than at runtime.
+	keys := []string{
+		"model",
+		"agent",
+		"allowed_tools",
+		"denied_tools",
+		"available_tools",
+		"excluded_tools",
+		"mcp_config",
+	}
+
+	for _, key := range keys {
+		t.Run("wrong type for "+key+" reports a fault", func(t *testing.T) {
+			t.Parallel()
+			pt, fault := parsePassthroughConfig(map[string]any{key: 42})
+			if fault == nil {
+				t.Fatalf("parsePassthroughConfig(%s=42): got nil fault, want non-nil", key)
+			}
+			if fault.Key != key {
+				t.Errorf("parsePassthroughConfig(%s=42) fault.Key = %q, want %q", key, fault.Key, key)
+			}
+			if pt != (passthroughConfig{}) {
+				t.Errorf("parsePassthroughConfig(%s=42) passthroughConfig = %+v, want zero value", key, pt)
+			}
+		})
+	}
 }
 
 // TestMCPInjectionConformance proves copilot-cli's real buildArgs

--- a/internal/agent/copilot/command_test.go
+++ b/internal/agent/copilot/command_test.go
@@ -102,11 +102,6 @@ func TestParsePassthroughConfig(t *testing.T) {
 			want:   passthroughConfig{},
 		},
 		{
-			name:   "wrong type for string field produces empty string",
-			config: map[string]any{"model": 42},
-			want:   passthroughConfig{},
-		},
-		{
 			name:   "wrong type for bool field produces false",
 			config: map[string]any{"experimental": "yes"},
 			want:   passthroughConfig{},
@@ -121,12 +116,26 @@ func TestParsePassthroughConfig(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			got := parsePassthroughConfig(tt.config)
+			got, fault := parsePassthroughConfig(tt.config)
+			if fault != nil {
+				t.Fatalf("parsePassthroughConfig: %v", fault)
+			}
 			if got != tt.want {
 				t.Errorf("parsePassthroughConfig() =\n  %+v\nwant\n  %+v", got, tt.want)
 			}
 		})
 	}
+
+	t.Run("wrong type for string field reports a fault", func(t *testing.T) {
+		t.Parallel()
+		_, fault := parsePassthroughConfig(map[string]any{"model": 42})
+		if fault == nil {
+			t.Fatal("parsePassthroughConfig: got nil fault, want non-nil")
+		}
+		if fault.Key != "model" {
+			t.Errorf("fault.Key = %q, want %q", fault.Key, "model")
+		}
+	})
 }
 
 // TestMCPInjectionConformance proves copilot-cli's real buildArgs

--- a/internal/agent/copilot/copilot.go
+++ b/internal/agent/copilot/copilot.go
@@ -282,7 +282,10 @@ func (s *sessionState) recoverUsage(logger *slog.Logger) (usage domain.TokenUsag
 // "copilot-cli" sub-object in WORKFLOW.md. Command resolution is
 // deferred to [CopilotAdapter.StartSession].
 func NewCopilotAdapter(config map[string]any) (domain.AgentAdapter, error) {
-	pt := parsePassthroughConfig(config)
+	pt, fault := parsePassthroughConfig(config)
+	if fault != nil {
+		return nil, fault
+	}
 	return &CopilotAdapter{passthrough: pt}, nil
 }
 

--- a/internal/agent/copilot/validate.go
+++ b/internal/agent/copilot/validate.go
@@ -2,7 +2,6 @@ package copilot
 
 import (
 	"github.com/sortie-ai/sortie/internal/registry"
-	"github.com/sortie-ai/sortie/internal/typeutil"
 )
 
 // validateConfig checks copilot-cli-specific configuration constraints and
@@ -16,8 +15,16 @@ import (
 // warning rather than an error because the configuration is honored
 // exactly as written and no turn stalls waiting on it.
 func validateConfig(fields registry.AgentConfigFields) []registry.ValidationDiag {
-	allowed := typeutil.StringFrom(fields.Passthrough, "allowed_tools")
-	if blanketGrantApplies(allowed) {
+	pt, fault := parsePassthroughConfig(fields.Passthrough)
+	if fault != nil {
+		return []registry.ValidationDiag{{
+			Severity: "error",
+			Check:    "copilot-cli." + fault.Key + ".wrong_type",
+			Message:  fault.Error(),
+		}}
+	}
+
+	if blanketGrantApplies(pt.AllowedTools) {
 		return nil
 	}
 

--- a/internal/agent/copilot/validate_test.go
+++ b/internal/agent/copilot/validate_test.go
@@ -12,6 +12,38 @@ const wantAllowedToolsDiagMessage = "copilot-cli.allowed_tools replaces the --al
 	"is approved; every other permissioned call is denied without a prompt, the turn continues, " +
 	"and a turn whose calls were all denied still reports success"
 
+// TestValidateConfig_TypeFaultNoDrift covers the R6.5 no-drift property: a
+// wrong-typed value for a key the constructor reads fails
+// NewCopilotAdapter with a plain error carrying the fault message, and
+// validateConfig reports the identical fault text under a
+// "copilot-cli.<key>.wrong_type" check for the same input, so the two
+// surfaces cannot diverge on what counts as a type fault.
+func TestValidateConfig_TypeFaultNoDrift(t *testing.T) {
+	t.Parallel()
+
+	config := map[string]any{"allowed_tools": 123}
+
+	_, constructErr := NewCopilotAdapter(config)
+	if constructErr == nil {
+		t.Fatal("NewCopilotAdapter(allowed_tools=123) error = nil, want non-nil")
+	}
+	if constructErr.Error() != "allowed_tools: expected string, got integer" {
+		t.Errorf("NewCopilotAdapter(allowed_tools=123) error = %q, want %q", constructErr.Error(), "allowed_tools: expected string, got integer")
+	}
+
+	diags := validateConfig(registry.AgentConfigFields{Kind: "copilot-cli", Passthrough: config})
+
+	if len(diags) != 1 {
+		t.Fatalf("validateConfig(allowed_tools=123) returned %d diagnostics, want 1: %+v", len(diags), diags)
+	}
+	if diags[0].Check != "copilot-cli.allowed_tools.wrong_type" {
+		t.Errorf("validateConfig(allowed_tools=123)[0].Check = %q, want %q", diags[0].Check, "copilot-cli.allowed_tools.wrong_type")
+	}
+	if diags[0].Message != constructErr.Error() {
+		t.Errorf("validateConfig(allowed_tools=123)[0].Message = %q, want the same text the constructor failed with: %q", diags[0].Message, constructErr.Error())
+	}
+}
+
 // TestValidateConfig covers copilot-cli's allowed_tools diagnostic: only a
 // non-whitespace allowed_tools value draws a warning, because that
 // allow-list replaces the blanket grant the runtime otherwise passes.

--- a/internal/agent/copilot/validate_test.go
+++ b/internal/agent/copilot/validate_test.go
@@ -12,7 +12,7 @@ const wantAllowedToolsDiagMessage = "copilot-cli.allowed_tools replaces the --al
 	"is approved; every other permissioned call is denied without a prompt, the turn continues, " +
 	"and a turn whose calls were all denied still reports success"
 
-// TestValidateConfig_TypeFaultNoDrift covers the R6.5 no-drift property: a
+// TestValidateConfig_TypeFaultNoDrift covers the no-drift property: a
 // wrong-typed value for a key the constructor reads fails
 // NewCopilotAdapter with a plain error carrying the fault message, and
 // validateConfig reports the identical fault text under a

--- a/internal/agent/kiro/command.go
+++ b/internal/agent/kiro/command.go
@@ -30,28 +30,40 @@ type passthroughConfig struct {
 }
 
 // parsePassthroughConfig extracts Kiro-specific settings from the raw
-// config map. Missing or wrong-typed keys use zero-value defaults, except
+// config map. A missing key uses its zero-value default, except
 // TrustAllTools, which [resolveTrustPosture] defaults to true rather than
-// false when the config sets neither trust key.
-//
-// It returns a non-nil error when both trust_all_tools is true and
-// trust_tools is non-empty, because the two trust modes are mutually
-// exclusive.
-func parsePassthroughConfig(config map[string]any) (passthroughConfig, error) {
+// false when the config sets neither trust key. A key present with a
+// non-string value for a string field reports a fault rather than
+// defaulting; [checkCrossField] holds the trust_all_tools and
+// trust_tools conflict check.
+func parsePassthroughConfig(config map[string]any) (passthroughConfig, *typeutil.TypeFault) {
+	model, fault := typeutil.StringField(config, "model")
+	if fault != nil {
+		return passthroughConfig{}, fault
+	}
+	agent, fault := typeutil.StringField(config, "agent")
+	if fault != nil {
+		return passthroughConfig{}, fault
+	}
+
 	trustAllTools, trustTools := resolveTrustPosture(config)
 
-	pt := passthroughConfig{
-		Model:         typeutil.StringFrom(config, "model"),
+	return passthroughConfig{
+		Model:         model,
 		TrustAllTools: trustAllTools,
 		TrustTools:    trustTools,
-		Agent:         typeutil.StringFrom(config, "agent"),
-	}
+		Agent:         agent,
+	}, nil
+}
 
+// checkCrossField rejects a passthrough carrying both trust_all_tools and
+// a non-empty trust_tools, because the two trust modes are mutually
+// exclusive.
+func checkCrossField(pt passthroughConfig) error {
 	if pt.TrustAllTools && len(pt.TrustTools) > 0 {
-		return passthroughConfig{}, fmt.Errorf("%s", trustToolsConflictMessage)
+		return fmt.Errorf("%s", trustToolsConflictMessage)
 	}
-
-	return pt, nil
+	return nil
 }
 
 // resolveTrustPosture computes the effective trust_all_tools value and the

--- a/internal/agent/kiro/command_test.go
+++ b/internal/agent/kiro/command_test.go
@@ -160,11 +160,6 @@ func TestParsePassthroughConfig_Fields(t *testing.T) {
 			want:   passthroughConfig{Model: "claude-opus-4.7", TrustAllTools: true},
 		},
 		{
-			name:   "wrong-typed model takes zero-value default",
-			config: map[string]any{"model": 42},
-			want:   passthroughConfig{TrustAllTools: true},
-		},
-		{
 			name:   "wrong-typed trust_all_tools takes false default",
 			config: map[string]any{"trust_all_tools": "yes"},
 			want:   passthroughConfig{},
@@ -179,20 +174,15 @@ func TestParsePassthroughConfig_Fields(t *testing.T) {
 			config: map[string]any{"trust_tools": []any{"read", 7, "grep"}},
 			want:   passthroughConfig{TrustTools: []string{"read", "grep"}},
 		},
-		{
-			name:   "wrong-typed agent takes zero-value default",
-			config: map[string]any{"agent": true},
-			want:   passthroughConfig{TrustAllTools: true},
-		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			got, err := parsePassthroughConfig(tt.config)
-			if err != nil {
-				t.Fatalf("parsePassthroughConfig(%v) error = %v, want nil", tt.config, err)
+			got, fault := parsePassthroughConfig(tt.config)
+			if fault != nil {
+				t.Fatalf("parsePassthroughConfig(%v) fault = %v, want nil", tt.config, fault)
 			}
 
 			if got.Model != tt.want.Model {
@@ -209,6 +199,28 @@ func TestParsePassthroughConfig_Fields(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("wrong-typed model reports a fault", func(t *testing.T) {
+		t.Parallel()
+		_, fault := parsePassthroughConfig(map[string]any{"model": 42})
+		if fault == nil {
+			t.Fatal("parsePassthroughConfig: got nil fault, want non-nil")
+		}
+		if fault.Key != "model" {
+			t.Errorf("fault.Key = %q, want %q", fault.Key, "model")
+		}
+	})
+
+	t.Run("wrong-typed agent reports a fault", func(t *testing.T) {
+		t.Parallel()
+		_, fault := parsePassthroughConfig(map[string]any{"agent": true})
+		if fault == nil {
+			t.Fatal("parsePassthroughConfig: got nil fault, want non-nil")
+		}
+		if fault.Key != "agent" {
+			t.Errorf("fault.Key = %q, want %q", fault.Key, "agent")
+		}
+	})
 }
 
 // TestParsePassthroughConfig_ClonesTrustTools verifies the parsed slice does

--- a/internal/agent/kiro/kiro.go
+++ b/internal/agent/kiro/kiro.go
@@ -102,8 +102,11 @@ func (s *sessionState) logger() *slog.Logger {
 // trust_all_tools and a non-empty trust_tools list. Command resolution is
 // deferred to [KiroAdapter.StartSession].
 func NewKiroAdapter(config map[string]any) (domain.AgentAdapter, error) {
-	pt, err := parsePassthroughConfig(config)
-	if err != nil {
+	pt, fault := parsePassthroughConfig(config)
+	if fault != nil {
+		return nil, fault
+	}
+	if err := checkCrossField(pt); err != nil {
 		return nil, err
 	}
 	return &KiroAdapter{passthrough: pt}, nil

--- a/internal/agent/kiro/validate.go
+++ b/internal/agent/kiro/validate.go
@@ -25,6 +25,14 @@ const trustToolsUntrustedMessage = "trust_all_tools does not resolve to true, an
 func validateConfig(fields registry.AgentConfigFields) []registry.ValidationDiag {
 	var diags []registry.ValidationDiag
 
+	if _, fault := parsePassthroughConfig(fields.Passthrough); fault != nil {
+		diags = append(diags, registry.ValidationDiag{
+			Severity: "error",
+			Check:    "kiro." + fault.Key + ".wrong_type",
+			Message:  fault.Error(),
+		})
+	}
+
 	diags = append(diags, validateTrustToolsConflict(fields.Passthrough)...)
 	diags = append(diags, validateTrustToolsUntrusted(fields.Passthrough)...)
 
@@ -33,7 +41,7 @@ func validateConfig(fields registry.AgentConfigFields) []registry.ValidationDiag
 
 // validateTrustToolsConflict reports an error when trust_all_tools is
 // true and trust_tools is also non-empty, mirroring the check
-// [parsePassthroughConfig] used to enforce inline at construction.
+// [checkCrossField] used to enforce inline at construction.
 func validateTrustToolsConflict(passthrough map[string]any) []registry.ValidationDiag {
 	trustAllTools, _ := passthrough["trust_all_tools"].(bool)
 	trustTools := typeutil.ExtractStringSlice(passthrough["trust_tools"])

--- a/internal/agent/kiro/validate_test.go
+++ b/internal/agent/kiro/validate_test.go
@@ -1,6 +1,7 @@
 package kiro
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/sortie-ai/sortie/internal/registry"
@@ -135,6 +136,70 @@ func TestValidateConfig_TrustToolsUntrusted(t *testing.T) {
 				t.Errorf("validateConfig(%v) check %q Severity = %q, want %q", tt.passthrough, diag.Check, diag.Severity, "error")
 			}
 		})
+	}
+}
+
+// TestValidateConfig_TypeFaultNoDrift covers the R6.5 no-drift property: a
+// wrong-typed value for a key the constructor reads fails NewKiroAdapter
+// with a plain error carrying the fault message, and validateConfig
+// reports the identical fault text under a "kiro.<key>.wrong_type" check
+// for the same input, so the two surfaces cannot diverge on what counts
+// as a type fault.
+func TestValidateConfig_TypeFaultNoDrift(t *testing.T) {
+	t.Parallel()
+
+	config := map[string]any{"model": 123}
+
+	_, constructErr := NewKiroAdapter(config)
+	if constructErr == nil {
+		t.Fatal("NewKiroAdapter(model=123) error = nil, want non-nil")
+	}
+	if constructErr.Error() != "model: expected string, got integer" {
+		t.Errorf("NewKiroAdapter(model=123) error = %q, want %q", constructErr.Error(), "model: expected string, got integer")
+	}
+
+	got := validateConfig(registry.AgentConfigFields{Kind: "kiro", Passthrough: config})
+
+	diag := hasCheck(got, "kiro.model.wrong_type")
+	if diag == nil {
+		t.Fatalf("validateConfig(model=123) missing check %q; got %+v", "kiro.model.wrong_type", got)
+	}
+	if diag.Message != constructErr.Error() {
+		t.Errorf("validateConfig(model=123) check %q Message = %q, want the same text the constructor failed with: %q", diag.Check, diag.Message, constructErr.Error())
+	}
+}
+
+// TestValidateConfig_TrustConflictNotWrongType covers R6.6/R8.9: moving the
+// trust_all_tools/trust_tools conflict out of the funnel and into
+// [checkCrossField] must not turn it into a wrong_type diagnostic. A
+// config carrying only the conflict (no mistyped string key) reports
+// kiro.trust_tools.conflict exactly once and no kiro.*.wrong_type check.
+func TestValidateConfig_TrustConflictNotWrongType(t *testing.T) {
+	t.Parallel()
+
+	config := map[string]any{"trust_all_tools": true, "trust_tools": []any{"read"}}
+
+	_, constructErr := NewKiroAdapter(config)
+	if constructErr == nil {
+		t.Fatal("NewKiroAdapter(trust conflict) error = nil, want error")
+	}
+	if constructErr.Error() != trustToolsConflictMessage {
+		t.Errorf("NewKiroAdapter(trust conflict) error = %q, want %q", constructErr.Error(), trustToolsConflictMessage)
+	}
+
+	got := validateConfig(registry.AgentConfigFields{Kind: "kiro", Passthrough: config})
+
+	conflictCount := 0
+	for _, d := range got {
+		if d.Check == "kiro.trust_tools.conflict" {
+			conflictCount++
+		}
+		if strings.HasSuffix(d.Check, ".wrong_type") {
+			t.Errorf("validateConfig(trust conflict) unexpectedly has a wrong_type check: %+v", d)
+		}
+	}
+	if conflictCount != 1 {
+		t.Errorf("validateConfig(trust conflict) has %d kiro.trust_tools.conflict diagnostics, want exactly 1: %+v", conflictCount, got)
 	}
 }
 

--- a/internal/agent/kiro/validate_test.go
+++ b/internal/agent/kiro/validate_test.go
@@ -139,7 +139,7 @@ func TestValidateConfig_TrustToolsUntrusted(t *testing.T) {
 	}
 }
 
-// TestValidateConfig_TypeFaultNoDrift covers the R6.5 no-drift property: a
+// TestValidateConfig_TypeFaultNoDrift covers the no-drift property: a
 // wrong-typed value for a key the constructor reads fails NewKiroAdapter
 // with a plain error carrying the fault message, and validateConfig
 // reports the identical fault text under a "kiro.<key>.wrong_type" check
@@ -169,7 +169,7 @@ func TestValidateConfig_TypeFaultNoDrift(t *testing.T) {
 	}
 }
 
-// TestValidateConfig_TrustConflictNotWrongType covers R6.6/R8.9: moving the
+// TestValidateConfig_TrustConflictNotWrongType covers that moving the
 // trust_all_tools/trust_tools conflict out of the funnel and into
 // [checkCrossField] must not turn it into a wrong_type diagnostic. A
 // config carrying only the conflict (no mistyped string key) reports

--- a/internal/agent/opencode/command.go
+++ b/internal/agent/opencode/command.go
@@ -53,24 +53,45 @@ var knownPermissionKeys = map[string]struct{}{
 	"websearch":          {},
 }
 
-func parsePassthroughConfig(config map[string]any) (passthroughConfig, error) {
-	pt := passthroughConfig{
-		Model:                    typeutil.StringFrom(config, "model"),
-		Agent:                    typeutil.StringFrom(config, "agent"),
-		Variant:                  typeutil.StringFrom(config, "variant"),
+// parsePassthroughConfig extracts OpenCode-specific settings from the
+// raw config map. A missing key uses its zero-value default. A key
+// present with a non-string value for a string field reports a fault
+// rather than defaulting; [checkCrossField] holds the allowed_tools and
+// denied_tools overlap check.
+func parsePassthroughConfig(config map[string]any) (passthroughConfig, *typeutil.TypeFault) {
+	model, fault := typeutil.StringField(config, "model")
+	if fault != nil {
+		return passthroughConfig{}, fault
+	}
+	agent, fault := typeutil.StringField(config, "agent")
+	if fault != nil {
+		return passthroughConfig{}, fault
+	}
+	variant, fault := typeutil.StringField(config, "variant")
+	if fault != nil {
+		return passthroughConfig{}, fault
+	}
+
+	return passthroughConfig{
+		Model:                    model,
+		Agent:                    agent,
+		Variant:                  variant,
 		Thinking:                 typeutil.BoolFrom(config, "thinking", false),
 		Pure:                     typeutil.BoolFrom(config, "pure", false),
 		DangerousSkipPermissions: typeutil.BoolFrom(config, "dangerously_skip_permissions", true),
 		DisableAutocompact:       typeutil.BoolFrom(config, "disable_autocompact", true),
 		AllowedTools:             slices.Clone(typeutil.ExtractStringSlice(config["allowed_tools"])),
 		DeniedTools:              slices.Clone(typeutil.ExtractStringSlice(config["denied_tools"])),
-	}
+	}, nil
+}
 
+// checkCrossField rejects a passthrough whose allowed_tools and
+// denied_tools overlap.
+func checkCrossField(pt passthroughConfig) error {
 	if message := overlapMessage(pt.AllowedTools, pt.DeniedTools); message != "" {
-		return passthroughConfig{}, fmt.Errorf("%s", message)
+		return fmt.Errorf("%s", message)
 	}
-
-	return pt, nil
+	return nil
 }
 
 func buildRunArgs(state *sessionState, prompt string, pt passthroughConfig) []string {

--- a/internal/agent/opencode/command_test.go
+++ b/internal/agent/opencode/command_test.go
@@ -216,23 +216,34 @@ func TestNewOpenCodeAdapter_ParsePassthroughConfig(t *testing.T) {
 
 // TestParsePassthroughConfig_TypeFault covers the funnel's fault path for
 // a wrong-typed string field: it returns the zero passthroughConfig and a
-// fault whose rendering names the key and the type found.
+// fault whose rendering names the key and the type found. Every string
+// key the funnel reads gets its own case, so a key whose fault arm was
+// never wired shows up as a gap here rather than at runtime.
 func TestParsePassthroughConfig_TypeFault(t *testing.T) {
 	t.Parallel()
 
-	pt, fault := parsePassthroughConfig(map[string]any{"model": 123})
+	keys := []string{"model", "agent", "variant"}
 
-	if fault == nil {
-		t.Fatal("parsePassthroughConfig(model=123) fault = nil, want non-nil")
-	}
-	if fault.Key != "model" {
-		t.Errorf("parsePassthroughConfig(model=123) fault.Key = %q, want %q", fault.Key, "model")
-	}
-	if fault.Error() != "model: expected string, got integer" {
-		t.Errorf("parsePassthroughConfig(model=123) fault.Error() = %q, want %q", fault.Error(), "model: expected string, got integer")
-	}
-	if pt.Model != "" || pt.Agent != "" || pt.Variant != "" || pt.AllowedTools != nil || pt.DeniedTools != nil {
-		t.Errorf("parsePassthroughConfig(model=123) passthroughConfig = %+v, want zero value", pt)
+	for _, key := range keys {
+		t.Run(key, func(t *testing.T) {
+			t.Parallel()
+
+			pt, fault := parsePassthroughConfig(map[string]any{key: 123})
+
+			if fault == nil {
+				t.Fatalf("parsePassthroughConfig(%s=123) fault = nil, want non-nil", key)
+			}
+			if fault.Key != key {
+				t.Errorf("parsePassthroughConfig(%s=123) fault.Key = %q, want %q", key, fault.Key, key)
+			}
+			wantErr := key + ": expected string, got integer"
+			if fault.Error() != wantErr {
+				t.Errorf("parsePassthroughConfig(%s=123) fault.Error() = %q, want %q", key, fault.Error(), wantErr)
+			}
+			if pt.Model != "" || pt.Agent != "" || pt.Variant != "" || pt.AllowedTools != nil || pt.DeniedTools != nil {
+				t.Errorf("parsePassthroughConfig(%s=123) passthroughConfig = %+v, want zero value", key, pt)
+			}
+		})
 	}
 }
 

--- a/internal/agent/opencode/command_test.go
+++ b/internal/agent/opencode/command_test.go
@@ -214,6 +214,28 @@ func TestNewOpenCodeAdapter_ParsePassthroughConfig(t *testing.T) {
 	}
 }
 
+// TestParsePassthroughConfig_TypeFault covers the funnel's fault path for
+// a wrong-typed string field: it returns the zero passthroughConfig and a
+// fault whose rendering names the key and the type found.
+func TestParsePassthroughConfig_TypeFault(t *testing.T) {
+	t.Parallel()
+
+	pt, fault := parsePassthroughConfig(map[string]any{"model": 123})
+
+	if fault == nil {
+		t.Fatal("parsePassthroughConfig(model=123) fault = nil, want non-nil")
+	}
+	if fault.Key != "model" {
+		t.Errorf("parsePassthroughConfig(model=123) fault.Key = %q, want %q", fault.Key, "model")
+	}
+	if fault.Error() != "model: expected string, got integer" {
+		t.Errorf("parsePassthroughConfig(model=123) fault.Error() = %q, want %q", fault.Error(), "model: expected string, got integer")
+	}
+	if pt.Model != "" || pt.Agent != "" || pt.Variant != "" || pt.AllowedTools != nil || pt.DeniedTools != nil {
+		t.Errorf("parsePassthroughConfig(model=123) passthroughConfig = %+v, want zero value", pt)
+	}
+}
+
 // TestMCPInjectionConformance proves opencode's real launch surface
 // matches its declared disposition, on both a local and a remote
 // launch. Both channels the adapter builds are captured, not the

--- a/internal/agent/opencode/opencode.go
+++ b/internal/agent/opencode/opencode.go
@@ -110,8 +110,11 @@ type waitResult struct {
 // NewOpenCodeAdapter creates an [OpenCodeAdapter] from the raw "opencode"
 // adapter configuration in WORKFLOW.md.
 func NewOpenCodeAdapter(config map[string]any) (domain.AgentAdapter, error) {
-	pt, err := parsePassthroughConfig(config)
-	if err != nil {
+	pt, fault := parsePassthroughConfig(config)
+	if fault != nil {
+		return nil, fault
+	}
+	if err := checkCrossField(pt); err != nil {
 		return nil, err
 	}
 	return &OpenCodeAdapter{passthrough: pt}, nil

--- a/internal/agent/opencode/validate.go
+++ b/internal/agent/opencode/validate.go
@@ -13,11 +13,19 @@ import (
 // returns diagnostics for the sortie validate pipeline. It does not
 // construct an adapter instance or launch a subprocess. It shares the
 // overlap check with [NewOpenCodeAdapter], which reaches it through
-// parsePassthroughConfig, so the constructor's refusal and the offline
+// [checkCrossField], so the constructor's refusal and the offline
 // verdict report that fault identically. The warning below has no
 // constructor counterpart.
 func validateConfig(fields registry.AgentConfigFields) []registry.ValidationDiag {
 	var diags []registry.ValidationDiag
+
+	if _, fault := parsePassthroughConfig(fields.Passthrough); fault != nil {
+		diags = append(diags, registry.ValidationDiag{
+			Severity: "error",
+			Check:    "opencode." + fault.Key + ".wrong_type",
+			Message:  fault.Error(),
+		})
+	}
 
 	diags = append(diags, validateSkipPermissions(fields.Passthrough)...)
 	diags = append(diags, validateToolOverlap(fields.Passthrough)...)
@@ -46,7 +54,7 @@ func validateSkipPermissions(passthrough map[string]any) []registry.ValidationDi
 
 // validateToolOverlap reports an error when allowed_tools and
 // denied_tools name at least one of the same tools, mirroring the check
-// [parsePassthroughConfig] used to enforce inline at construction.
+// [checkCrossField] used to enforce inline at construction.
 func validateToolOverlap(passthrough map[string]any) []registry.ValidationDiag {
 	message := overlapMessage(
 		typeutil.ExtractStringSlice(passthrough["allowed_tools"]),

--- a/internal/agent/opencode/validate_test.go
+++ b/internal/agent/opencode/validate_test.go
@@ -96,7 +96,7 @@ func TestValidateConfig_ToolOverlap(t *testing.T) {
 	}
 }
 
-// TestValidateConfig_TypeFaultNoDrift covers the R6.5 no-drift property: a
+// TestValidateConfig_TypeFaultNoDrift covers the no-drift property: a
 // wrong-typed value for a key the constructor reads fails
 // NewOpenCodeAdapter with a plain error carrying the fault message, and
 // validateConfig reports the identical fault text under an
@@ -126,7 +126,7 @@ func TestValidateConfig_TypeFaultNoDrift(t *testing.T) {
 	}
 }
 
-// TestValidateConfig_TypeFaultAndToolOverlapBothReported covers R6.7/R8.10:
+// TestValidateConfig_TypeFaultAndToolOverlapBothReported covers the combination:
 // a passthrough carrying both a mistyped string key and an overlapping
 // allowed_tools/denied_tools pair fails NewOpenCodeAdapter with the type
 // fault (parsePassthroughConfig runs before checkCrossField), while

--- a/internal/agent/opencode/validate_test.go
+++ b/internal/agent/opencode/validate_test.go
@@ -95,3 +95,66 @@ func TestValidateConfig_ToolOverlap(t *testing.T) {
 		})
 	}
 }
+
+// TestValidateConfig_TypeFaultNoDrift covers the R6.5 no-drift property: a
+// wrong-typed value for a key the constructor reads fails
+// NewOpenCodeAdapter with a plain error carrying the fault message, and
+// validateConfig reports the identical fault text under an
+// "opencode.<key>.wrong_type" check for the same input, so the two
+// surfaces cannot diverge on what counts as a type fault.
+func TestValidateConfig_TypeFaultNoDrift(t *testing.T) {
+	t.Parallel()
+
+	config := map[string]any{"model": 123}
+
+	_, constructErr := NewOpenCodeAdapter(config)
+	if constructErr == nil {
+		t.Fatal("NewOpenCodeAdapter(model=123) error = nil, want non-nil")
+	}
+	if constructErr.Error() != "model: expected string, got integer" {
+		t.Errorf("NewOpenCodeAdapter(model=123) error = %q, want %q", constructErr.Error(), "model: expected string, got integer")
+	}
+
+	got := validateConfig(registry.AgentConfigFields{Kind: "opencode", Passthrough: config})
+
+	diag := hasCheck(got, "opencode.model.wrong_type")
+	if diag == nil {
+		t.Fatalf("validateConfig(model=123) missing check %q; got %+v", "opencode.model.wrong_type", got)
+	}
+	if diag.Message != constructErr.Error() {
+		t.Errorf("validateConfig(model=123) check %q Message = %q, want the same text the constructor failed with: %q", diag.Check, diag.Message, constructErr.Error())
+	}
+}
+
+// TestValidateConfig_TypeFaultAndToolOverlapBothReported covers R6.7/R8.10:
+// a passthrough carrying both a mistyped string key and an overlapping
+// allowed_tools/denied_tools pair fails NewOpenCodeAdapter with the type
+// fault (parsePassthroughConfig runs before checkCrossField), while
+// validateConfig, which does not gate the overlap check on the funnel's
+// fault, reports both diagnostics offline.
+func TestValidateConfig_TypeFaultAndToolOverlapBothReported(t *testing.T) {
+	t.Parallel()
+
+	config := map[string]any{
+		"model":         123,
+		"allowed_tools": []any{"bash"},
+		"denied_tools":  []any{"bash"},
+	}
+
+	_, constructErr := NewOpenCodeAdapter(config)
+	if constructErr == nil {
+		t.Fatal("NewOpenCodeAdapter(model=123, overlapping tools) error = nil, want the type fault")
+	}
+	if constructErr.Error() != "model: expected string, got integer" {
+		t.Errorf("NewOpenCodeAdapter(model=123, overlapping tools) error = %q, want the type fault, not the overlap error", constructErr.Error())
+	}
+
+	got := validateConfig(registry.AgentConfigFields{Kind: "opencode", Passthrough: config})
+
+	if hasCheck(got, "opencode.model.wrong_type") == nil {
+		t.Errorf("validateConfig(model=123, overlapping tools) missing check %q; got %+v", "opencode.model.wrong_type", got)
+	}
+	if hasCheck(got, "opencode.allowed_tools.overlap") == nil {
+		t.Errorf("validateConfig(model=123, overlapping tools) missing check %q; got %+v", "opencode.allowed_tools.overlap", got)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -13,6 +13,8 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+
+	"github.com/sortie-ai/sortie/internal/typeutil"
 )
 
 // ServiceConfig is the typed runtime view of WORKFLOW.md front matter.
@@ -444,7 +446,10 @@ func NewServiceConfig(raw map[string]any) (ServiceConfig, error) {
 	}
 
 	rawTracker := extractSubMap(raw, "tracker")
-	tracker := buildTrackerConfig(rawTracker, envKeys)
+	tracker, err := buildTrackerConfig(rawTracker, envKeys)
+	if err != nil {
+		return ServiceConfig{}, err
+	}
 
 	handoffEvidence, err := parseHandoffEvidencePolicy(rawTracker)
 	if err != nil {
@@ -452,81 +457,34 @@ func NewServiceConfig(raw map[string]any) (ServiceConfig, error) {
 	}
 	tracker.HandoffEvidence = handoffEvidence
 
-	// Validate handoff_state: enforce string type, reject explicit empty
-	// values, and detect env var indirection that resolved to empty.
-	if rawVal, ok := rawTracker["handoff_state"]; ok && rawVal != nil {
-		s, isStr := rawVal.(string)
-		if !isStr {
-			return ServiceConfig{}, &ConfigError{
-				Field:   "tracker.handoff_state",
-				Message: fmt.Sprintf("expected string, got %T", rawVal),
-			}
-		}
-		if s == "" {
-			return ServiceConfig{}, &ConfigError{
-				Field:   "tracker.handoff_state",
-				Message: "must not be empty",
-			}
-		}
-		if tracker.HandoffState == "" {
-			return ServiceConfig{}, &ConfigError{
-				Field:   "tracker.handoff_state",
-				Message: "resolved to empty (check environment variable)",
-			}
+	// The type check and the raw-empty check for handoff_state,
+	// no_change_state, and in_progress_state already ran inside
+	// buildTrackerConfig; only the post-resolution "resolved to empty"
+	// check, which reads the resolved field, stays here.
+	if rawVal, ok := rawTracker["handoff_state"]; ok && rawVal != nil && tracker.HandoffState == "" {
+		return ServiceConfig{}, &ConfigError{
+			Field:   "tracker.handoff_state",
+			Message: "resolved to empty (check environment variable)",
 		}
 	}
 	if err := ValidateHandoffState(tracker.HandoffState, tracker.ActiveStates, tracker.TerminalStates); err != nil {
 		return ServiceConfig{}, err
 	}
 
-	// Validate no_change_state: enforce string type, reject explicit empty
-	// values, and detect env var indirection that resolved to empty.
-	if rawVal, ok := rawTracker["no_change_state"]; ok && rawVal != nil {
-		s, isStr := rawVal.(string)
-		if !isStr {
-			return ServiceConfig{}, &ConfigError{
-				Field:   "tracker.no_change_state",
-				Message: fmt.Sprintf("expected string, got %T", rawVal),
-			}
-		}
-		if s == "" {
-			return ServiceConfig{}, &ConfigError{
-				Field:   "tracker.no_change_state",
-				Message: "must not be empty",
-			}
-		}
-		if tracker.NoChangeState == "" {
-			return ServiceConfig{}, &ConfigError{
-				Field:   "tracker.no_change_state",
-				Message: "resolved to empty (check environment variable)",
-			}
+	if rawVal, ok := rawTracker["no_change_state"]; ok && rawVal != nil && tracker.NoChangeState == "" {
+		return ServiceConfig{}, &ConfigError{
+			Field:   "tracker.no_change_state",
+			Message: "resolved to empty (check environment variable)",
 		}
 	}
 	if err := validateNoChangeState(tracker.NoChangeState, tracker.HandoffState, tracker.TerminalStates); err != nil {
 		return ServiceConfig{}, err
 	}
 
-	// Validate in_progress_state: enforce string type, reject explicit empty
-	// values, and detect env var indirection that resolved to empty.
-	if rawVal, ok := rawTracker["in_progress_state"]; ok && rawVal != nil {
-		s, isStr := rawVal.(string)
-		if !isStr {
-			return ServiceConfig{}, &ConfigError{
-				Field:   "tracker.in_progress_state",
-				Message: fmt.Sprintf("expected string, got %T", rawVal),
-			}
-		}
-		if s == "" {
-			return ServiceConfig{}, &ConfigError{
-				Field:   "tracker.in_progress_state",
-				Message: "must not be empty",
-			}
-		}
-		if tracker.InProgressState == "" {
-			return ServiceConfig{}, &ConfigError{
-				Field:   "tracker.in_progress_state",
-				Message: "resolved to empty (check environment variable)",
-			}
+	if rawVal, ok := rawTracker["in_progress_state"]; ok && rawVal != nil && tracker.InProgressState == "" {
+		return ServiceConfig{}, &ConfigError{
+			Field:   "tracker.in_progress_state",
+			Message: "resolved to empty (check environment variable)",
 		}
 	}
 	if err := ValidateInProgressState(tracker.InProgressState, tracker.ActiveStates, tracker.TerminalStates, tracker.HandoffState); err != nil {
@@ -641,60 +599,97 @@ func NewServiceConfig(raw map[string]any) (ServiceConfig, error) {
 	}, nil
 }
 
-func buildTrackerConfig(m map[string]any, envKeys map[string]bool) TrackerConfig {
+func buildTrackerConfig(m map[string]any, envKeys map[string]bool) (TrackerConfig, error) {
 	commentsMap := extractSubMap(m, "comments")
 
-	endpoint := extractString(m, "endpoint")
+	endpoint, fault := typeutil.StringField(m, "endpoint")
+	if fault != nil {
+		return TrackerConfig{}, &ConfigError{Field: "tracker.endpoint", Message: fault.Reason()}
+	}
 	if !envKeys["tracker.endpoint"] {
 		endpoint = resolveEnvRef(endpoint)
 	}
 
-	apiKey := extractString(m, "api_key")
+	apiKey, fault := typeutil.StringField(m, "api_key")
+	if fault != nil {
+		return TrackerConfig{}, &ConfigError{Field: "tracker.api_key", Message: fault.Reason()}
+	}
 	if !envKeys["tracker.api_key"] {
 		apiKey = resolveEnv(apiKey)
 	}
 
-	project := extractString(m, "project")
+	project, fault := typeutil.StringField(m, "project")
+	if fault != nil {
+		return TrackerConfig{}, &ConfigError{Field: "tracker.project", Message: fault.Reason()}
+	}
 	if !envKeys["tracker.project"] {
 		project = resolveEnvRef(project)
 	}
 
-	queryFilter := extractString(m, "query_filter")
+	queryFilter, fault := typeutil.StringField(m, "query_filter")
+	if fault != nil {
+		return TrackerConfig{}, &ConfigError{Field: "tracker.query_filter", Message: fault.Reason()}
+	}
 	if !envKeys["tracker.query_filter"] {
 		queryFilter = resolveEnvRef(queryFilter)
 	}
 
-	handoffState := extractString(m, "handoff_state")
+	handoffState, fault := typeutil.StringField(m, "handoff_state")
+	if fault != nil {
+		return TrackerConfig{}, &ConfigError{Field: "tracker.handoff_state", Message: fault.Reason()}
+	}
+	if rawVal, ok := m["handoff_state"]; ok && rawVal != nil && handoffState == "" {
+		return TrackerConfig{}, &ConfigError{Field: "tracker.handoff_state", Message: "must not be empty"}
+	}
 	if !envKeys["tracker.handoff_state"] {
 		handoffState = resolveEnvRef(handoffState)
 	}
 
-	noChangeState := extractString(m, "no_change_state")
+	noChangeState, fault := typeutil.StringField(m, "no_change_state")
+	if fault != nil {
+		return TrackerConfig{}, &ConfigError{Field: "tracker.no_change_state", Message: fault.Reason()}
+	}
+	if rawVal, ok := m["no_change_state"]; ok && rawVal != nil && noChangeState == "" {
+		return TrackerConfig{}, &ConfigError{Field: "tracker.no_change_state", Message: "must not be empty"}
+	}
 	if !envKeys["tracker.no_change_state"] {
 		noChangeState = resolveEnvRef(noChangeState)
 	}
 
-	inProgressState := extractString(m, "in_progress_state")
+	inProgressState, fault := typeutil.StringField(m, "in_progress_state")
+	if fault != nil {
+		return TrackerConfig{}, &ConfigError{Field: "tracker.in_progress_state", Message: fault.Reason()}
+	}
+	if rawVal, ok := m["in_progress_state"]; ok && rawVal != nil && inProgressState == "" {
+		return TrackerConfig{}, &ConfigError{Field: "tracker.in_progress_state", Message: "must not be empty"}
+	}
 	if !envKeys["tracker.in_progress_state"] {
 		inProgressState = resolveEnvRef(inProgressState)
 	}
 
-	apiVersion := extractString(m, "api_version")
-	if apiVersion == "" {
-		// A bare YAML integer (api_version: 2) is not a string, so
-		// extractString yields ""; coerce a whole-number value to its
-		// decimal form so a Server/DC config written as api_version: 2 is
-		// not silently treated as absent and defaulted to v3.
-		if n, err := coerceInt(mapVal(m, "api_version")); err == nil {
+	apiVersion, fault := typeutil.StringField(m, "api_version")
+	if fault != nil {
+		// A bare YAML integer (api_version: 2) is not a string; coerce a
+		// whole-number value to its decimal form so a Server/DC config
+		// written as api_version: 2 is not silently treated as absent
+		// and defaulted to v3.
+		if n, cerr := coerceInt(mapVal(m, "api_version")); cerr == nil {
 			apiVersion = strconv.Itoa(n)
+		} else {
+			return TrackerConfig{}, &ConfigError{Field: "tracker.api_version", Message: fault.Reason()}
 		}
 	}
 	if !envKeys["tracker.api_version"] {
 		apiVersion = resolveEnvRef(apiVersion)
 	}
 
+	kind, fault := typeutil.StringField(m, "kind")
+	if fault != nil {
+		return TrackerConfig{}, &ConfigError{Field: "tracker.kind", Message: fault.Reason()}
+	}
+
 	return TrackerConfig{
-		Kind:            extractString(m, "kind"),
+		Kind:            kind,
 		Endpoint:        endpoint,
 		APIKey:          apiKey,
 		Project:         project,
@@ -710,7 +705,7 @@ func buildTrackerConfig(m map[string]any, envKeys map[string]bool) TrackerConfig
 			OnCompletion: coerceBool(commentsMap, "on_completion"),
 			OnFailure:    coerceBool(commentsMap, "on_failure"),
 		},
-	}
+	}, nil
 }
 
 func parseHandoffEvidencePolicy(m map[string]any) (HandoffEvidencePolicy, error) {
@@ -719,11 +714,11 @@ func parseHandoffEvidencePolicy(m map[string]any) (HandoffEvidencePolicy, error)
 		return HandoffEvidenceObserved, nil
 	}
 
-	value, ok := raw.(string)
-	if !ok {
+	value, fault := typeutil.StringField(m, "handoff_evidence")
+	if fault != nil {
 		return "", &ConfigError{
 			Field:   "tracker.handoff_evidence",
-			Message: fmt.Sprintf("expected string, got %T", raw),
+			Message: fault.Reason(),
 		}
 	}
 
@@ -802,11 +797,11 @@ func buildDBPath(raw map[string]any, envKeys map[string]bool) (string, error) {
 	if !exists || v == nil {
 		return "", nil
 	}
-	s, ok := v.(string)
-	if !ok {
+	s, fault := typeutil.StringField(raw, "db_path")
+	if fault != nil {
 		return "", &ConfigError{
 			Field:   "db_path",
-			Message: fmt.Sprintf("expected string, got %T", v),
+			Message: fault.Reason(),
 		}
 	}
 	// Explicit empty string (db_path: "") is equivalent to omitting
@@ -831,12 +826,18 @@ func buildDBPath(raw map[string]any, envKeys map[string]bool) (string, error) {
 }
 
 func buildAgentConfig(m map[string]any) (AgentConfig, error) {
-	kind := extractString(m, "kind")
+	kind, fault := typeutil.StringField(m, "kind")
+	if fault != nil {
+		return AgentConfig{}, &ConfigError{Field: "agent.kind", Message: fault.Reason()}
+	}
 	if kind == "" {
 		kind = "claude-code"
 	}
 
-	command := extractString(m, "command")
+	command, fault := typeutil.StringField(m, "command")
+	if fault != nil {
+		return AgentConfig{}, &ConfigError{Field: "agent.command", Message: fault.Reason()}
+	}
 
 	turnTimeoutMS := 3600000
 	if v, exists := m["turn_timeout_ms"]; exists && v != nil {
@@ -971,7 +972,10 @@ func buildAgentConfig(m map[string]any) (AgentConfig, error) {
 const ciWatchWindowDefaultMS = 86400000
 
 func buildCIFeedbackConfig(m map[string]any) (CIFeedbackConfig, error) {
-	kind := extractString(m, "kind")
+	kind, fault := typeutil.StringField(m, "kind")
+	if fault != nil {
+		return CIFeedbackConfig{}, &ConfigError{Field: "ci_feedback.kind", Message: fault.Reason()}
+	}
 	if kind == "" {
 		return CIFeedbackConfig{}, nil
 	}
@@ -1471,6 +1475,10 @@ func extractSubMap(raw map[string]any, key string) map[string]any {
 	return m
 }
 
+// extractString reads a string field outside the adapter configuration
+// population, silently coercing a wrong-typed value to "". Adapter
+// configuration reads use [typeutil.StringField] instead, which reports
+// a wrong-typed value rather than coercing it.
 func extractString(m map[string]any, key string) string {
 	if m == nil {
 		return ""
@@ -1491,11 +1499,11 @@ func requireStringField(m map[string]any, key, fieldPath string) (string, bool, 
 	if !exists || raw == nil {
 		return "", false, nil
 	}
-	s, ok := raw.(string)
-	if !ok {
+	s, fault := typeutil.StringField(m, key)
+	if fault != nil {
 		return "", false, &ConfigError{
 			Field:   fieldPath,
-			Message: fmt.Sprintf("expected string, got %T", raw),
+			Message: fault.Reason(),
 		}
 	}
 	return s, true, nil

--- a/internal/config/config_api_version_test.go
+++ b/internal/config/config_api_version_test.go
@@ -8,13 +8,19 @@ import "testing"
 func TestBuildTrackerConfig_APIVersion(t *testing.T) {
 	t.Run("string value", func(t *testing.T) {
 		t.Parallel()
-		tc := buildTrackerConfig(map[string]any{"api_version": "2"}, nil)
+		tc, err := buildTrackerConfig(map[string]any{"api_version": "2"}, nil)
+		if err != nil {
+			t.Fatalf("buildTrackerConfig: %v", err)
+		}
 		assertStringEqual(t, "TrackerConfig.APIVersion", "2", tc.APIVersion)
 	})
 
 	t.Run("absent yields empty", func(t *testing.T) {
 		t.Parallel()
-		tc := buildTrackerConfig(map[string]any{}, nil)
+		tc, err := buildTrackerConfig(map[string]any{}, nil)
+		if err != nil {
+			t.Fatalf("buildTrackerConfig: %v", err)
+		}
 		assertStringEqual(t, "TrackerConfig.APIVersion", "", tc.APIVersion)
 	})
 
@@ -22,19 +28,28 @@ func TestBuildTrackerConfig_APIVersion(t *testing.T) {
 		t.Parallel()
 		// A bare YAML integer (api_version: 2) is coerced to its decimal
 		// string form so a Server/DC config is not silently defaulted to v3.
-		tc := buildTrackerConfig(map[string]any{"api_version": 2}, nil)
+		tc, err := buildTrackerConfig(map[string]any{"api_version": 2}, nil)
+		if err != nil {
+			t.Fatalf("buildTrackerConfig: %v", err)
+		}
 		assertStringEqual(t, "TrackerConfig.APIVersion", "2", tc.APIVersion)
 	})
 
 	t.Run("bare whole float coerced to string", func(t *testing.T) {
 		t.Parallel()
-		tc := buildTrackerConfig(map[string]any{"api_version": float64(2)}, nil)
+		tc, err := buildTrackerConfig(map[string]any{"api_version": float64(2)}, nil)
+		if err != nil {
+			t.Fatalf("buildTrackerConfig: %v", err)
+		}
 		assertStringEqual(t, "TrackerConfig.APIVersion", "2", tc.APIVersion)
 	})
 
 	t.Run("VAR indirection resolved", func(t *testing.T) {
 		t.Setenv("TEST_API_VERSION", "2")
-		tc := buildTrackerConfig(map[string]any{"api_version": "$TEST_API_VERSION"}, nil)
+		tc, err := buildTrackerConfig(map[string]any{"api_version": "$TEST_API_VERSION"}, nil)
+		if err != nil {
+			t.Fatalf("buildTrackerConfig: %v", err)
+		}
 		assertStringEqual(t, "TrackerConfig.APIVersion", "2", tc.APIVersion)
 	})
 
@@ -43,10 +58,13 @@ func TestBuildTrackerConfig_APIVersion(t *testing.T) {
 		// When the SORTIE_* override path already populated the value, the
 		// $VAR guard must leave the literal untouched, exactly as the other
 		// tracker string fields behave.
-		tc := buildTrackerConfig(
+		tc, err := buildTrackerConfig(
 			map[string]any{"api_version": "$TEST_API_VERSION"},
 			map[string]bool{"tracker.api_version": true},
 		)
+		if err != nil {
+			t.Fatalf("buildTrackerConfig: %v", err)
+		}
 		assertStringEqual(t, "TrackerConfig.APIVersion", "$TEST_API_VERSION", tc.APIVersion)
 	})
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1903,7 +1903,7 @@ func TestNewServiceConfig_TypeFaultOwnerGroups(t *testing.T) {
 	}
 }
 
-// TestNewServiceConfig_TypeFaultCredentialNotLeaked covers R1.2/R8.5: a
+// TestNewServiceConfig_TypeFaultCredentialNotLeaked covers the redaction rule: a
 // fault raised for a value that looks like a credential does not contain
 // that value in the rendered message.
 func TestNewServiceConfig_TypeFaultCredentialNotLeaked(t *testing.T) {
@@ -1923,7 +1923,7 @@ func TestNewServiceConfig_TypeFaultCredentialNotLeaked(t *testing.T) {
 	}
 }
 
-// TestNewServiceConfig_APIVersionCarveOutBool covers R8.3's non-carve-out
+// TestNewServiceConfig_APIVersionCarveOutBool covers the non-carve-out
 // half: tracker.api_version: true is a type fault, unlike a bare integer.
 func TestNewServiceConfig_APIVersionCarveOutBool(t *testing.T) {
 	t.Parallel()

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1785,6 +1785,161 @@ func TestNewServiceConfig_LabelCommandsExcludedFromReactionsMap(t *testing.T) {
 	}
 }
 
+// TestNewServiceConfig_TypeFaultOwnerGroups covers one key in each of the
+// four owner groups that route a wrong-typed value through
+// typeutil.StringField: a non-string value produces a *ConfigError naming
+// the field and the fault's Reason(), an absent key produces no error, and
+// a string value parses as before.
+func TestNewServiceConfig_TypeFaultOwnerGroups(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		field      string
+		buildRaw   func(v any) map[string]any
+		wrongValue any
+		wrongGot   string
+		// absentWantErr and absentWantMsg describe the existing, distinct
+		// absent-key diagnostic for this owner group. Three of the four
+		// groups have no required-key check ahead of the type check and
+		// so produce no error at all; notifications[0].kind is required,
+		// so its absent-key case keeps its own pre-existing message
+		// rather than becoming silent.
+		absentWantErr bool
+		absentWantMsg string
+	}{
+		{
+			name:  "tracker.endpoint",
+			field: "tracker.endpoint",
+			buildRaw: func(v any) map[string]any {
+				m := map[string]any{"kind": "jira"}
+				if v != nil {
+					m["endpoint"] = v
+				}
+				return map[string]any{"tracker": m}
+			},
+			wrongValue: 4242,
+			wrongGot:   "integer",
+		},
+		{
+			name:  "agent.kind",
+			field: "agent.kind",
+			buildRaw: func(v any) map[string]any {
+				m := map[string]any{}
+				if v != nil {
+					m["kind"] = v
+				}
+				return map[string]any{"agent": m}
+			},
+			wrongValue: true,
+			wrongGot:   "boolean",
+		},
+		{
+			name:  "ci_feedback.kind",
+			field: "ci_feedback.kind",
+			buildRaw: func(v any) map[string]any {
+				m := map[string]any{}
+				if v != nil {
+					m["kind"] = v
+				}
+				return map[string]any{"ci_feedback": m}
+			},
+			wrongValue: []any{"webhook"},
+			wrongGot:   "list",
+		},
+		{
+			name:  "notifications[0].kind",
+			field: "notifications[0].kind",
+			buildRaw: func(v any) map[string]any {
+				entry := map[string]any{}
+				if v != nil {
+					entry["kind"] = v
+				}
+				return map[string]any{"notifications": []any{entry}}
+			},
+			wrongValue:    7,
+			wrongGot:      "integer",
+			absentWantErr: true,
+			absentWantMsg: "kind is required and must be a non-empty string",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			t.Run("wrong type is a ConfigError", func(t *testing.T) {
+				t.Parallel()
+				_, err := NewServiceConfig(tt.buildRaw(tt.wrongValue))
+
+				assertConfigErrorField(t, err, tt.field)
+				var ce *ConfigError
+				if !errors.As(err, &ce) {
+					t.Fatalf("error type = %T, want *ConfigError", err)
+				}
+				wantMsg := "expected string, got " + tt.wrongGot
+				assertStringEqual(t, "ConfigError.Message", wantMsg, ce.Message)
+			})
+
+			t.Run("absent key stays distinct from the type fault", func(t *testing.T) {
+				t.Parallel()
+				_, err := NewServiceConfig(tt.buildRaw(nil))
+
+				if !tt.absentWantErr {
+					if err != nil {
+						t.Fatalf("NewServiceConfig() with %s absent = %v, want no error", tt.field, err)
+					}
+					return
+				}
+
+				assertConfigErrorField(t, err, tt.field)
+				var ce *ConfigError
+				if !errors.As(err, &ce) {
+					t.Fatalf("error type = %T, want *ConfigError", err)
+				}
+				assertStringEqual(t, "ConfigError.Message", tt.absentWantMsg, ce.Message)
+			})
+		})
+	}
+}
+
+// TestNewServiceConfig_TypeFaultCredentialNotLeaked covers R1.2/R8.5: a
+// fault raised for a value that looks like a credential does not contain
+// that value in the rendered message.
+func TestNewServiceConfig_TypeFaultCredentialNotLeaked(t *testing.T) {
+	t.Parallel()
+
+	_, err := NewServiceConfig(map[string]any{
+		"tracker": map[string]any{"kind": "jira", "api_key": 4242},
+	})
+
+	assertConfigErrorField(t, err, "tracker.api_key")
+	var ce *ConfigError
+	if !errors.As(err, &ce) {
+		t.Fatalf("error type = %T, want *ConfigError", err)
+	}
+	if strings.Contains(ce.Message, "4242") {
+		t.Errorf("ConfigError.Message = %q, must not contain the offending value", ce.Message)
+	}
+}
+
+// TestNewServiceConfig_APIVersionCarveOutBool covers R8.3's non-carve-out
+// half: tracker.api_version: true is a type fault, unlike a bare integer.
+func TestNewServiceConfig_APIVersionCarveOutBool(t *testing.T) {
+	t.Parallel()
+
+	_, err := NewServiceConfig(map[string]any{
+		"tracker": map[string]any{"kind": "jira", "api_version": true},
+	})
+
+	assertConfigErrorField(t, err, "tracker.api_version")
+	var ce *ConfigError
+	if !errors.As(err, &ce) {
+		t.Fatalf("error type = %T, want *ConfigError", err)
+	}
+	assertStringEqual(t, "ConfigError.Message", "expected string, got boolean", ce.Message)
+}
+
 // --- test helpers ---
 
 func assertConfigErrorField(t *testing.T, err error, wantField string) {

--- a/internal/config/notifications.go
+++ b/internal/config/notifications.go
@@ -1,6 +1,10 @@
 package config
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/sortie-ai/sortie/internal/typeutil"
+)
 
 // NotificationsConfig holds the parsed notifications list. The zero
 // value (nil Backends) means no backend is configured and the
@@ -77,7 +81,13 @@ func parseNotificationBackend(index int, elem any) (NotificationBackend, error) 
 		}
 	}
 
-	kind, _ := entry["kind"].(string)
+	kind, fault := typeutil.StringField(entry, "kind")
+	if fault != nil {
+		return NotificationBackend{}, &ConfigError{
+			Field:   field + ".kind",
+			Message: fault.Reason(),
+		}
+	}
 	if kind == "" {
 		return NotificationBackend{}, &ConfigError{
 			Field:   field + ".kind",

--- a/internal/config/notifications_test.go
+++ b/internal/config/notifications_test.go
@@ -82,6 +82,27 @@ func TestNotificationsConfig_MissingKind(t *testing.T) {
 	assertConfigErrorField(t, err, "notifications[0].kind")
 }
 
+func TestNotificationsConfig_WrongTypeKind(t *testing.T) {
+	t.Parallel()
+
+	raw := map[string]any{
+		"notifications": []any{
+			map[string]any{
+				"kind": 123,
+			},
+		},
+	}
+
+	_, err := NewServiceConfig(raw)
+
+	assertConfigErrorField(t, err, "notifications[0].kind")
+	var ce *ConfigError
+	if !errors.As(err, &ce) {
+		t.Fatalf("error type = %T, want *ConfigError", err)
+	}
+	assertStringEqual(t, "ConfigError.Message", "expected string, got integer", ce.Message)
+}
+
 func TestNotificationsConfig_EmptyKind(t *testing.T) {
 	t.Parallel()
 

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/sortie-ai/sortie/internal/maputil"
+	"github.com/sortie-ai/sortie/internal/typeutil"
 )
 
 // FieldType classifies the expected YAML type for a config field.
@@ -255,10 +256,14 @@ func ValidateFrontMatter(raw map[string]any, cfg ServiceConfig) []FrontMatterWar
 			knownNames[f.Name] = true
 		}
 
-		// Determine adapter kind for pass-through exemption.
+		// Determine adapter kind for pass-through exemption. A wrong-typed
+		// kind leaves adapterKind at its zero value, so the exemption is
+		// not applied: a non-string value cannot name a block.
 		var adapterKind string
 		if schema.AllowAdapterPassthrough {
-			adapterKind = extractString(sectionMap, "kind")
+			if kind, fault := typeutil.StringField(sectionMap, "kind"); fault == nil {
+				adapterKind = kind
+			}
 		}
 
 		// Flag sub-keys not recognized by the section schema.

--- a/internal/config/schema_test.go
+++ b/internal/config/schema_test.go
@@ -309,6 +309,22 @@ func TestValidateFrontMatter(t *testing.T) {
 			wantFields: []string{"tracker.jira"},
 		},
 		{
+			// tracker.kind is an integer, so the adapter-kind lookup faults
+			// and adapterKind stays "": the exemption cannot apply, since a
+			// non-string value cannot name a block. Both the sub-key and
+			// the kind's own type mismatch are reported.
+			name: "adapter passthrough sub-key not exempt when kind is mistyped",
+			raw: map[string]any{
+				"tracker": map[string]any{
+					"kind": 123,
+					"jira": map[string]any{"foo": "bar"},
+				},
+			},
+			wantCount:  2,
+			wantChecks: []string{"unknown_sub_key", "type_mismatch"},
+			wantFields: []string{"tracker.jira", "tracker.kind"},
+		},
+		{
 			name: "unknown nested sub-key in tracker.comments",
 			raw: map[string]any{
 				"tracker": map[string]any{

--- a/internal/notify/slack/slack.go
+++ b/internal/notify/slack/slack.go
@@ -20,6 +20,7 @@ import (
 	"github.com/sortie-ai/sortie/internal/domain"
 	"github.com/sortie-ai/sortie/internal/httpkit"
 	"github.com/sortie-ai/sortie/internal/registry"
+	"github.com/sortie-ai/sortie/internal/typeutil"
 )
 
 var _ domain.Notifier = (*notifier)(nil)
@@ -42,7 +43,10 @@ type notifier struct {
 // empty value (including a secret reference that resolved to the empty
 // string) is rejected.
 func newNotifier(config map[string]any) (domain.Notifier, error) {
-	rawURL, _ := config["webhook_url"].(string)
+	rawURL, fault := typeutil.StringField(config, "webhook_url")
+	if fault != nil {
+		return nil, fmt.Errorf("slack notifier: %w", fault)
+	}
 	endpoint := strings.TrimSpace(rawURL)
 	if endpoint == "" {
 		return nil, fmt.Errorf("slack notifier: webhook_url is required")

--- a/internal/notify/slack/slack_test.go
+++ b/internal/notify/slack/slack_test.go
@@ -88,6 +88,40 @@ func TestSlack_NewNotifier_MissingWebhookURL(t *testing.T) {
 	}
 }
 
+// TestSlack_NewNotifier_WrongTypeVsAbsentWebhookURL covers the distinction
+// between a wrong-typed webhook_url and an absent one: the type fault
+// carries the typed-fault message, while the absent key keeps its
+// existing "webhook_url is required" message.
+func TestSlack_NewNotifier_WrongTypeVsAbsentWebhookURL(t *testing.T) {
+	t.Parallel()
+
+	t.Run("webhook_url wrong type", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := newNotifier(map[string]any{"webhook_url": 4242})
+
+		if err == nil {
+			t.Fatal("newNotifier(webhook_url=4242) error = nil, want error")
+		}
+		if err.Error() != "slack notifier: webhook_url: expected string, got integer" {
+			t.Errorf("newNotifier(webhook_url=4242) error = %q, want %q", err.Error(), "slack notifier: webhook_url: expected string, got integer")
+		}
+	})
+
+	t.Run("webhook_url absent", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := newNotifier(map[string]any{})
+
+		if err == nil {
+			t.Fatal("newNotifier({}) error = nil, want error")
+		}
+		if err.Error() != "slack notifier: webhook_url is required" {
+			t.Errorf("newNotifier({}) error = %q, want %q", err.Error(), "slack notifier: webhook_url is required")
+		}
+	})
+}
+
 func TestSlack_NewNotifier_ValidWebhookURL(t *testing.T) {
 	t.Parallel()
 

--- a/internal/notify/webhook/webhook.go
+++ b/internal/notify/webhook/webhook.go
@@ -21,6 +21,7 @@ import (
 	"github.com/sortie-ai/sortie/internal/domain"
 	"github.com/sortie-ai/sortie/internal/httpkit"
 	"github.com/sortie-ai/sortie/internal/registry"
+	"github.com/sortie-ai/sortie/internal/typeutil"
 )
 
 var _ domain.Notifier = (*notifier)(nil)
@@ -43,7 +44,10 @@ type notifier struct {
 // value (including a secret reference that resolved to the empty string)
 // is rejected.
 func newNotifier(config map[string]any) (domain.Notifier, error) {
-	rawURL, _ := config["url"].(string)
+	rawURL, fault := typeutil.StringField(config, "url")
+	if fault != nil {
+		return nil, fmt.Errorf("webhook notifier: %w", fault)
+	}
 	endpoint := strings.TrimSpace(rawURL)
 	if endpoint == "" {
 		return nil, fmt.Errorf("webhook notifier: url is required")

--- a/internal/notify/webhook/webhook_test.go
+++ b/internal/notify/webhook/webhook_test.go
@@ -88,6 +88,40 @@ func TestWebhook_NewNotifier_MissingURL(t *testing.T) {
 	}
 }
 
+// TestWebhook_NewNotifier_WrongTypeVsAbsentURL covers the distinction
+// between a wrong-typed url and an absent one: the type fault carries the
+// typed-fault message, while the absent key keeps its existing "url is
+// required" message.
+func TestWebhook_NewNotifier_WrongTypeVsAbsentURL(t *testing.T) {
+	t.Parallel()
+
+	t.Run("url wrong type", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := newNotifier(map[string]any{"url": 4242})
+
+		if err == nil {
+			t.Fatal("newNotifier(url=4242) error = nil, want error")
+		}
+		if err.Error() != "webhook notifier: url: expected string, got integer" {
+			t.Errorf("newNotifier(url=4242) error = %q, want %q", err.Error(), "webhook notifier: url: expected string, got integer")
+		}
+	})
+
+	t.Run("url absent", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := newNotifier(map[string]any{})
+
+		if err == nil {
+			t.Fatal("newNotifier({}) error = nil, want error")
+		}
+		if err.Error() != "webhook notifier: url is required" {
+			t.Errorf("newNotifier({}) error = %q, want %q", err.Error(), "webhook notifier: url is required")
+		}
+	})
+}
+
 func TestWebhook_NewNotifier_ValidURL(t *testing.T) {
 	t.Parallel()
 

--- a/internal/scm/gitea/ci.go
+++ b/internal/scm/gitea/ci.go
@@ -14,6 +14,7 @@ import (
 	"github.com/sortie-ai/sortie/internal/httpkit"
 	"github.com/sortie-ai/sortie/internal/registry"
 	"github.com/sortie-ai/sortie/internal/scm/scmcore"
+	"github.com/sortie-ai/sortie/internal/typeutil"
 )
 
 func init() {
@@ -58,7 +59,10 @@ type GiteaCIProvider struct {
 // project is a string parse. The token travels only in the Authorization header
 // set by the shared client and is never logged.
 func NewGiteaCIProvider(maxLogLines int, adapterConfig map[string]any) (domain.CIStatusProvider, error) {
-	apiKey, _ := adapterConfig["api_key"].(string)
+	apiKey, fault := typeutil.StringField(adapterConfig, "api_key")
+	if fault != nil {
+		return nil, &domain.CIError{Kind: domain.ErrCIPayload, Message: fault.Error()}
+	}
 	if apiKey == "" {
 		return nil, &domain.CIError{
 			Kind:    domain.ErrCIAuth,
@@ -66,7 +70,10 @@ func NewGiteaCIProvider(maxLogLines int, adapterConfig map[string]any) (domain.C
 		}
 	}
 
-	project, _ := adapterConfig["project"].(string)
+	project, fault := typeutil.StringField(adapterConfig, "project")
+	if fault != nil {
+		return nil, &domain.CIError{Kind: domain.ErrCIPayload, Message: fault.Error()}
+	}
 	if project == "" {
 		return nil, &domain.CIError{
 			Kind:    domain.ErrCIPayload,
@@ -82,7 +89,10 @@ func NewGiteaCIProvider(maxLogLines int, adapterConfig map[string]any) (domain.C
 		}
 	}
 
-	endpointRaw, _ := adapterConfig["endpoint"].(string)
+	endpointRaw, fault := typeutil.StringField(adapterConfig, "endpoint")
+	if fault != nil {
+		return nil, &domain.CIError{Kind: domain.ErrCIPayload, Message: fault.Error()}
+	}
 	if endpointRaw == "" {
 		return nil, &domain.CIError{
 			Kind:    domain.ErrCIPayload,
@@ -101,7 +111,10 @@ func NewGiteaCIProvider(maxLogLines int, adapterConfig map[string]any) (domain.C
 		endpoint += "/api/v1"
 	}
 
-	userAgent, _ := adapterConfig["user_agent"].(string)
+	userAgent, fault := typeutil.StringField(adapterConfig, "user_agent")
+	if fault != nil {
+		return nil, &domain.CIError{Kind: domain.ErrCIPayload, Message: fault.Error()}
+	}
 	if userAgent == "" {
 		userAgent = "sortie/dev"
 	}

--- a/internal/scm/gitea/ci_test.go
+++ b/internal/scm/gitea/ci_test.go
@@ -840,6 +840,77 @@ func TestNewGiteaCIProvider(t *testing.T) {
 	})
 }
 
+// TestNewGiteaCIProvider_TypeFaultVsAbsentKey covers the distinction
+// between a wrong-typed config key and an absent one for the two keys
+// whose absent-key checks precede the endpoint check: api_key (a
+// different kind, ErrCIAuth vs ErrCIPayload) and project (the same kind,
+// distinguished by message).
+func TestNewGiteaCIProvider_TypeFaultVsAbsentKey(t *testing.T) {
+	t.Parallel()
+
+	t.Run("api_key wrong type", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := NewGiteaCIProvider(0, map[string]any{
+			"api_key":  4242,
+			"project":  testOwner + "/" + testRepo,
+			"endpoint": "http://gitea.invalid",
+		})
+
+		var ce *domain.CIError
+		if !errors.As(err, &ce) {
+			t.Fatalf("error type = %T, want *domain.CIError", err)
+		}
+		if ce.Kind != domain.ErrCIPayload {
+			t.Errorf("CIError.Kind = %q, want %q", ce.Kind, domain.ErrCIPayload)
+		}
+		if ce.Message != "api_key: expected string, got integer" {
+			t.Errorf("CIError.Message = %q, want %q", ce.Message, "api_key: expected string, got integer")
+		}
+	})
+
+	t.Run("project wrong type", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := NewGiteaCIProvider(0, map[string]any{
+			"api_key":  "test-token",
+			"project":  4242,
+			"endpoint": "http://gitea.invalid",
+		})
+
+		var ce *domain.CIError
+		if !errors.As(err, &ce) {
+			t.Fatalf("error type = %T, want *domain.CIError", err)
+		}
+		if ce.Kind != domain.ErrCIPayload {
+			t.Errorf("CIError.Kind = %q, want %q", ce.Kind, domain.ErrCIPayload)
+		}
+		if ce.Message != "project: expected string, got integer" {
+			t.Errorf("CIError.Message = %q, want %q", ce.Message, "project: expected string, got integer")
+		}
+	})
+
+	t.Run("project absent has the distinct existing message", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := NewGiteaCIProvider(0, map[string]any{
+			"api_key":  "test-token",
+			"endpoint": "http://gitea.invalid",
+		})
+
+		var ce *domain.CIError
+		if !errors.As(err, &ce) {
+			t.Fatalf("error type = %T, want *domain.CIError", err)
+		}
+		if ce.Kind != domain.ErrCIPayload {
+			t.Errorf("CIError.Kind = %q, want %q", ce.Kind, domain.ErrCIPayload)
+		}
+		if ce.Message != "missing required config key: project" {
+			t.Errorf("CIError.Message = %q, want %q", ce.Message, "missing required config key: project")
+		}
+	})
+}
+
 // TestNewGiteaCIProvider_RejectsInvalidEndpoint proves the endpoint values
 // in endpointRejectionCases fail construction with ErrCIPayload; none of
 // the config maps here register a server, since construction performs no

--- a/internal/scm/gitea/gitea.go
+++ b/internal/scm/gitea/gitea.go
@@ -82,7 +82,10 @@ type GiteaAdapter struct {
 // token or unknown repository), returns a [*domain.TrackerError] and blocks
 // construction.
 func NewGiteaAdapter(config map[string]any) (domain.TrackerAdapter, error) {
-	apiKey, _ := config["api_key"].(string)
+	apiKey, fault := typeutil.StringField(config, "api_key")
+	if fault != nil {
+		return nil, &domain.TrackerError{Kind: domain.ErrTrackerPayload, Message: fault.Error()}
+	}
 	if apiKey == "" {
 		return nil, &domain.TrackerError{
 			Kind:    domain.ErrMissingTrackerAPIKey,
@@ -90,7 +93,10 @@ func NewGiteaAdapter(config map[string]any) (domain.TrackerAdapter, error) {
 		}
 	}
 
-	project, _ := config["project"].(string)
+	project, fault := typeutil.StringField(config, "project")
+	if fault != nil {
+		return nil, &domain.TrackerError{Kind: domain.ErrTrackerPayload, Message: fault.Error()}
+	}
 	if project == "" {
 		return nil, &domain.TrackerError{
 			Kind:    domain.ErrMissingTrackerProject,
@@ -106,7 +112,10 @@ func NewGiteaAdapter(config map[string]any) (domain.TrackerAdapter, error) {
 		}
 	}
 
-	endpoint, _ := config["endpoint"].(string)
+	endpoint, fault := typeutil.StringField(config, "endpoint")
+	if fault != nil {
+		return nil, &domain.TrackerError{Kind: domain.ErrTrackerPayload, Message: fault.Error()}
+	}
 	if endpoint == "" {
 		return nil, &domain.TrackerError{
 			Kind:    domain.ErrTrackerPayload,
@@ -143,12 +152,25 @@ func NewGiteaAdapter(config map[string]any) (domain.TrackerAdapter, error) {
 		terminalStates[i] = strings.ToLower(s)
 	}
 
-	handoffRaw, _ := config["handoff_state"].(string)
+	handoffRaw, fault := typeutil.StringField(config, "handoff_state")
+	if fault != nil {
+		return nil, &domain.TrackerError{Kind: domain.ErrTrackerPayload, Message: fault.Error()}
+	}
 	handoffState := strings.ToLower(strings.TrimSpace(handoffRaw))
 
-	userAgent, _ := config["user_agent"].(string)
+	userAgent, fault := typeutil.StringField(config, "user_agent")
+	if fault != nil {
+		return nil, &domain.TrackerError{Kind: domain.ErrTrackerPayload, Message: fault.Error()}
+	}
 	if userAgent == "" {
 		userAgent = "sortie/dev"
+	}
+
+	// query_filter is read here, ahead of the preflight below, so a
+	// mistyped value is reported without depending on network reachability.
+	raw, fault := typeutil.StringField(config, "query_filter")
+	if fault != nil {
+		return nil, &domain.TrackerError{Kind: domain.ErrTrackerPayload, Message: fault.Error()}
 	}
 
 	client := newGiteaClient(baseURL, apiKey, userAgent)
@@ -157,7 +179,6 @@ func NewGiteaAdapter(config map[string]any) (domain.TrackerAdapter, error) {
 		return nil, err
 	}
 
-	raw, _ := config["query_filter"].(string)
 	filter, err := parseGiteaQueryFilter(raw)
 	if err != nil {
 		return nil, err

--- a/internal/scm/gitea/gitea_test.go
+++ b/internal/scm/gitea/gitea_test.go
@@ -174,6 +174,11 @@ func TestNewGiteaAdapter(t *testing.T) {
 			{"project with empty repo", map[string]any{"api_key": "tok", "project": "acme/", "endpoint": "http://localhost"}, domain.ErrTrackerPayload},
 			{"missing endpoint", map[string]any{"api_key": "tok", "project": "acme/widgets"}, domain.ErrTrackerPayload},
 			{"empty endpoint", map[string]any{"api_key": "tok", "project": "acme/widgets", "endpoint": ""}, domain.ErrTrackerPayload},
+			{"api_key wrong type", map[string]any{"api_key": 4242, "project": "acme/widgets", "endpoint": "http://localhost"}, domain.ErrTrackerPayload},
+			{"project wrong type", map[string]any{"api_key": "tok", "project": true, "endpoint": "http://localhost"}, domain.ErrTrackerPayload},
+			{"endpoint wrong type", map[string]any{"api_key": "tok", "project": "acme/widgets", "endpoint": 4242}, domain.ErrTrackerPayload},
+			{"handoff_state wrong type", map[string]any{"api_key": "tok", "project": "acme/widgets", "endpoint": "http://localhost", "handoff_state": 4242}, domain.ErrTrackerPayload},
+			{"user_agent wrong type", map[string]any{"api_key": "tok", "project": "acme/widgets", "endpoint": "http://localhost", "user_agent": 4242}, domain.ErrTrackerPayload},
 		}
 
 		for _, tt := range tests {
@@ -186,6 +191,70 @@ func TestNewGiteaAdapter(t *testing.T) {
 					t.Error("adapter should be nil on error")
 				}
 			})
+		}
+	})
+
+	// endpoint's wrong-type and absent-key faults share domain.ErrTrackerPayload,
+	// unlike api_key and project (which get a distinct kind for the absent
+	// case), so the two are distinguished here by message instead of kind.
+	t.Run("endpoint wrong type vs absent produce distinct messages", func(t *testing.T) {
+		t.Parallel()
+
+		wrongType, err := NewGiteaAdapter(map[string]any{"api_key": "tok", "project": "acme/widgets", "endpoint": 4242})
+		var te *domain.TrackerError
+		if !errors.As(err, &te) {
+			t.Fatalf("wrong-type endpoint: error type = %T, want *domain.TrackerError", err)
+		}
+		if te.Message != "endpoint: expected string, got integer" {
+			t.Errorf("wrong-type endpoint: TrackerError.Message = %q, want %q", te.Message, "endpoint: expected string, got integer")
+		}
+		if wrongType != nil {
+			t.Error("adapter should be nil on error")
+		}
+
+		absent, err := NewGiteaAdapter(map[string]any{"api_key": "tok", "project": "acme/widgets"})
+		if !errors.As(err, &te) {
+			t.Fatalf("absent endpoint: error type = %T, want *domain.TrackerError", err)
+		}
+		if te.Message != "tracker.endpoint is required for gitea" {
+			t.Errorf("absent endpoint: TrackerError.Message = %q, want %q", te.Message, "tracker.endpoint is required for gitea")
+		}
+		if absent != nil {
+			t.Error("adapter should be nil on error")
+		}
+	})
+
+	// query_filter is read ahead of the network preflight, so a mistyped
+	// value must be reported without any request reaching the server: the
+	// mux here registers no routes at all, and any request fails the test.
+	t.Run("query_filter wrong type is reported without a preflight call", func(t *testing.T) {
+		t.Parallel()
+
+		mux := http.NewServeMux()
+		mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+			t.Errorf("unexpected request: %s %s (query_filter fault must short-circuit before preflight)", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		})
+		srv := httptest.NewServer(mux)
+		defer srv.Close()
+
+		cfg := validConfig(srv.URL)
+		cfg["query_filter"] = 4242
+
+		a, err := NewGiteaAdapter(cfg)
+
+		var te *domain.TrackerError
+		if !errors.As(err, &te) {
+			t.Fatalf("error type = %T, want *domain.TrackerError", err)
+		}
+		if te.Kind != domain.ErrTrackerPayload {
+			t.Errorf("TrackerError.Kind = %q, want %q", te.Kind, domain.ErrTrackerPayload)
+		}
+		if te.Message != "query_filter: expected string, got integer" {
+			t.Errorf("TrackerError.Message = %q, want %q", te.Message, "query_filter: expected string, got integer")
+		}
+		if a != nil {
+			t.Error("adapter should be nil on error")
 		}
 	})
 

--- a/internal/scm/gitea/scm.go
+++ b/internal/scm/gitea/scm.go
@@ -15,6 +15,7 @@ import (
 	"github.com/sortie-ai/sortie/internal/httpkit"
 	"github.com/sortie-ai/sortie/internal/registry"
 	"github.com/sortie-ai/sortie/internal/scm/scmcore"
+	"github.com/sortie-ai/sortie/internal/typeutil"
 )
 
 func init() {
@@ -55,7 +56,10 @@ type GiteaSCMAdapter struct {
 // travels only in the Authorization header set by the shared client and is
 // never logged.
 func NewGiteaSCMAdapter(adapterConfig map[string]any) (domain.SCMAdapter, error) {
-	apiKey, _ := adapterConfig["api_key"].(string)
+	apiKey, fault := typeutil.StringField(adapterConfig, "api_key")
+	if fault != nil {
+		return nil, &domain.SCMError{Kind: domain.ErrSCMPayload, Message: fault.Error()}
+	}
 	if apiKey == "" {
 		return nil, &domain.SCMError{
 			Kind:    domain.ErrSCMAuth,
@@ -63,7 +67,10 @@ func NewGiteaSCMAdapter(adapterConfig map[string]any) (domain.SCMAdapter, error)
 		}
 	}
 
-	endpointRaw, _ := adapterConfig["endpoint"].(string)
+	endpointRaw, fault := typeutil.StringField(adapterConfig, "endpoint")
+	if fault != nil {
+		return nil, &domain.SCMError{Kind: domain.ErrSCMPayload, Message: fault.Error()}
+	}
 	if endpointRaw == "" {
 		return nil, &domain.SCMError{
 			Kind:    domain.ErrSCMPayload,
@@ -82,12 +89,18 @@ func NewGiteaSCMAdapter(adapterConfig map[string]any) (domain.SCMAdapter, error)
 		endpoint += "/api/v1"
 	}
 
-	userAgent, _ := adapterConfig["user_agent"].(string)
+	userAgent, fault := typeutil.StringField(adapterConfig, "user_agent")
+	if fault != nil {
+		return nil, &domain.SCMError{Kind: domain.ErrSCMPayload, Message: fault.Error()}
+	}
 	if userAgent == "" {
 		userAgent = "sortie/dev"
 	}
 
-	project, _ := adapterConfig["project"].(string)
+	project, fault := typeutil.StringField(adapterConfig, "project")
+	if fault != nil {
+		return nil, &domain.SCMError{Kind: domain.ErrSCMPayload, Message: fault.Error()}
+	}
 	preflightOwner, preflightRepo, ok := strings.Cut(project, "/")
 	if !ok || preflightOwner == "" || preflightRepo == "" || strings.Contains(preflightRepo, "/") {
 		preflightOwner, preflightRepo = "", ""

--- a/internal/scm/gitea/scm_test.go
+++ b/internal/scm/gitea/scm_test.go
@@ -56,6 +56,23 @@ func TestNewGiteaSCMAdapter(t *testing.T) {
 		assertSCMErrorKind(t, err, domain.ErrSCMPayload)
 	})
 
+	t.Run("api_key wrong type returns a payload error distinct from absent", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := NewGiteaSCMAdapter(map[string]any{"api_key": 4242, "endpoint": "http://gitea.invalid"})
+
+		var se *domain.SCMError
+		if !errors.As(err, &se) {
+			t.Fatalf("error type = %T, want *domain.SCMError", err)
+		}
+		if se.Kind != domain.ErrSCMPayload {
+			t.Errorf("SCMError.Kind = %q, want %q", se.Kind, domain.ErrSCMPayload)
+		}
+		if se.Message != "api_key: expected string, got integer" {
+			t.Errorf("SCMError.Message = %q, want %q", se.Message, "api_key: expected string, got integer")
+		}
+	})
+
 	t.Run("constructs without any network request", func(t *testing.T) {
 		t.Parallel()
 

--- a/internal/scm/github/ci.go
+++ b/internal/scm/github/ci.go
@@ -13,6 +13,7 @@ import (
 	"github.com/sortie-ai/sortie/internal/httpkit"
 	"github.com/sortie-ai/sortie/internal/registry"
 	"github.com/sortie-ai/sortie/internal/scm/scmcore"
+	"github.com/sortie-ai/sortie/internal/typeutil"
 )
 
 func init() {
@@ -66,7 +67,10 @@ type GitHubCIProvider struct {
 // http or https URL with a host returns a [*domain.CIError] of kind
 // [domain.ErrCIPayload]), "user_agent".
 func NewGitHubCIProvider(maxLogLines int, adapterConfig map[string]any) (domain.CIStatusProvider, error) {
-	apiKey, _ := adapterConfig["api_key"].(string)
+	apiKey, fault := typeutil.StringField(adapterConfig, "api_key")
+	if fault != nil {
+		return nil, &domain.CIError{Kind: domain.ErrCIPayload, Message: fault.Error()}
+	}
 	if apiKey == "" {
 		return nil, &domain.CIError{
 			Kind:    domain.ErrCIAuth,
@@ -74,7 +78,10 @@ func NewGitHubCIProvider(maxLogLines int, adapterConfig map[string]any) (domain.
 		}
 	}
 
-	project, _ := adapterConfig["project"].(string)
+	project, fault := typeutil.StringField(adapterConfig, "project")
+	if fault != nil {
+		return nil, &domain.CIError{Kind: domain.ErrCIPayload, Message: fault.Error()}
+	}
 	if project == "" {
 		return nil, &domain.CIError{
 			Kind:    domain.ErrCIPayload,
@@ -90,7 +97,10 @@ func NewGitHubCIProvider(maxLogLines int, adapterConfig map[string]any) (domain.
 		}
 	}
 
-	endpointRaw, _ := adapterConfig["endpoint"].(string)
+	endpointRaw, fault := typeutil.StringField(adapterConfig, "endpoint")
+	if fault != nil {
+		return nil, &domain.CIError{Kind: domain.ErrCIPayload, Message: fault.Error()}
+	}
 	endpoint, redactedEndpoint, endpointOK := resolveEndpoint(endpointRaw)
 	if !endpointOK {
 		return nil, &domain.CIError{
@@ -99,7 +109,10 @@ func NewGitHubCIProvider(maxLogLines int, adapterConfig map[string]any) (domain.
 		}
 	}
 
-	userAgent, _ := adapterConfig["user_agent"].(string)
+	userAgent, fault := typeutil.StringField(adapterConfig, "user_agent")
+	if fault != nil {
+		return nil, &domain.CIError{Kind: domain.ErrCIPayload, Message: fault.Error()}
+	}
 	if userAgent == "" {
 		userAgent = "sortie/dev"
 	}

--- a/internal/scm/github/ci_test.go
+++ b/internal/scm/github/ci_test.go
@@ -271,6 +271,29 @@ func TestNewGitHubCIProvider_MissingProject(t *testing.T) {
 	assertCIErrorKind(t, err, domain.ErrCIPayload)
 }
 
+// TestNewGitHubCIProvider_TypeFaultVsAbsentKey covers the distinction
+// between a wrong-typed api_key and an absent one: the type fault reports
+// domain.ErrCIPayload, distinct from the absent key's domain.ErrCIAuth.
+func TestNewGitHubCIProvider_TypeFaultVsAbsentKey(t *testing.T) {
+	t.Parallel()
+
+	_, err := NewGitHubCIProvider(0, map[string]any{
+		"api_key": 4242,
+		"project": "org/repo",
+	})
+
+	var ce *domain.CIError
+	if !errors.As(err, &ce) {
+		t.Fatalf("error type = %T, want *domain.CIError", err)
+	}
+	if ce.Kind != domain.ErrCIPayload {
+		t.Errorf("CIError.Kind = %q, want %q", ce.Kind, domain.ErrCIPayload)
+	}
+	if ce.Message != "api_key: expected string, got integer" {
+		t.Errorf("CIError.Message = %q, want %q", ce.Message, "api_key: expected string, got integer")
+	}
+}
+
 func TestNewGitHubCIProvider_MalformedProject(t *testing.T) {
 	t.Parallel()
 

--- a/internal/scm/github/review.go
+++ b/internal/scm/github/review.go
@@ -13,6 +13,7 @@ import (
 	"github.com/sortie-ai/sortie/internal/httpkit"
 	"github.com/sortie-ai/sortie/internal/registry"
 	"github.com/sortie-ai/sortie/internal/scm/scmcore"
+	"github.com/sortie-ai/sortie/internal/typeutil"
 )
 
 func init() {
@@ -67,7 +68,10 @@ type GitHubSCMAdapter struct {
 // absolute http or https URL with a host returns a [*domain.SCMError] of
 // kind [domain.ErrSCMPayload]), "user_agent".
 func NewGitHubSCMAdapter(adapterConfig map[string]any) (domain.SCMAdapter, error) {
-	apiKey, _ := adapterConfig["api_key"].(string)
+	apiKey, fault := typeutil.StringField(adapterConfig, "api_key")
+	if fault != nil {
+		return nil, &domain.SCMError{Kind: domain.ErrSCMPayload, Message: fault.Error()}
+	}
 	if apiKey == "" {
 		return nil, &domain.SCMError{
 			Kind:    domain.ErrSCMAuth,
@@ -75,7 +79,10 @@ func NewGitHubSCMAdapter(adapterConfig map[string]any) (domain.SCMAdapter, error
 		}
 	}
 
-	endpointRaw, _ := adapterConfig["endpoint"].(string)
+	endpointRaw, fault := typeutil.StringField(adapterConfig, "endpoint")
+	if fault != nil {
+		return nil, &domain.SCMError{Kind: domain.ErrSCMPayload, Message: fault.Error()}
+	}
 	endpoint, redactedEndpoint, endpointOK := resolveEndpoint(endpointRaw)
 	if !endpointOK {
 		return nil, &domain.SCMError{
@@ -84,7 +91,10 @@ func NewGitHubSCMAdapter(adapterConfig map[string]any) (domain.SCMAdapter, error
 		}
 	}
 
-	userAgent, _ := adapterConfig["user_agent"].(string)
+	userAgent, fault := typeutil.StringField(adapterConfig, "user_agent")
+	if fault != nil {
+		return nil, &domain.SCMError{Kind: domain.ErrSCMPayload, Message: fault.Error()}
+	}
 	if userAgent == "" {
 		userAgent = "sortie/dev"
 	}

--- a/internal/scm/github/review_test.go
+++ b/internal/scm/github/review_test.go
@@ -2,6 +2,7 @@ package github
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -68,6 +69,26 @@ func TestNewGitHubSCMAdapter_MissingAPIKey(t *testing.T) {
 
 	_, err := NewGitHubSCMAdapter(map[string]any{})
 	assertSCMErrorKind(t, err, domain.ErrSCMAuth)
+}
+
+// TestNewGitHubSCMAdapter_TypeFaultVsAbsentKey covers the distinction
+// between a wrong-typed api_key and an absent one: the type fault reports
+// domain.ErrSCMPayload, distinct from the absent key's domain.ErrSCMAuth.
+func TestNewGitHubSCMAdapter_TypeFaultVsAbsentKey(t *testing.T) {
+	t.Parallel()
+
+	_, err := NewGitHubSCMAdapter(map[string]any{"api_key": 4242})
+
+	var se *domain.SCMError
+	if !errors.As(err, &se) {
+		t.Fatalf("error type = %T, want *domain.SCMError", err)
+	}
+	if se.Kind != domain.ErrSCMPayload {
+		t.Errorf("SCMError.Kind = %q, want %q", se.Kind, domain.ErrSCMPayload)
+	}
+	if se.Message != "api_key: expected string, got integer" {
+		t.Errorf("SCMError.Message = %q, want %q", se.Message, "api_key: expected string, got integer")
+	}
 }
 
 func TestNewGitHubSCMAdapter_Valid(t *testing.T) {

--- a/internal/scm/github/tracker.go
+++ b/internal/scm/github/tracker.go
@@ -85,7 +85,10 @@ type GitHubAdapter struct {
 // "query_filter", "user_agent", "etag_cache_size" (int, default 1000;
 // set to 0 to disable ETag caching).
 func NewGitHubAdapter(config map[string]any) (domain.TrackerAdapter, error) {
-	apiKey, _ := config["api_key"].(string)
+	apiKey, fault := typeutil.StringField(config, "api_key")
+	if fault != nil {
+		return nil, &domain.TrackerError{Kind: domain.ErrTrackerPayload, Message: fault.Error()}
+	}
 	if apiKey == "" {
 		return nil, &domain.TrackerError{
 			Kind:    domain.ErrMissingTrackerAPIKey,
@@ -93,7 +96,10 @@ func NewGitHubAdapter(config map[string]any) (domain.TrackerAdapter, error) {
 		}
 	}
 
-	project, _ := config["project"].(string)
+	project, fault := typeutil.StringField(config, "project")
+	if fault != nil {
+		return nil, &domain.TrackerError{Kind: domain.ErrTrackerPayload, Message: fault.Error()}
+	}
 	if project == "" {
 		return nil, &domain.TrackerError{
 			Kind:    domain.ErrMissingTrackerProject,
@@ -109,7 +115,10 @@ func NewGitHubAdapter(config map[string]any) (domain.TrackerAdapter, error) {
 		}
 	}
 
-	endpointRaw, _ := config["endpoint"].(string)
+	endpointRaw, fault := typeutil.StringField(config, "endpoint")
+	if fault != nil {
+		return nil, &domain.TrackerError{Kind: domain.ErrTrackerPayload, Message: fault.Error()}
+	}
 	endpoint, redactedEndpoint, endpointOK := resolveEndpoint(endpointRaw)
 	if !endpointOK {
 		return nil, &domain.TrackerError{
@@ -136,12 +145,21 @@ func NewGitHubAdapter(config map[string]any) (domain.TrackerAdapter, error) {
 		terminalStates[i] = strings.ToLower(s)
 	}
 
-	handoffRaw, _ := config["handoff_state"].(string)
+	handoffRaw, fault := typeutil.StringField(config, "handoff_state")
+	if fault != nil {
+		return nil, &domain.TrackerError{Kind: domain.ErrTrackerPayload, Message: fault.Error()}
+	}
 	handoffState := strings.ToLower(strings.TrimSpace(handoffRaw))
 
-	queryFilter, _ := config["query_filter"].(string)
+	queryFilter, fault := typeutil.StringField(config, "query_filter")
+	if fault != nil {
+		return nil, &domain.TrackerError{Kind: domain.ErrTrackerPayload, Message: fault.Error()}
+	}
 
-	userAgent, _ := config["user_agent"].(string)
+	userAgent, fault := typeutil.StringField(config, "user_agent")
+	if fault != nil {
+		return nil, &domain.TrackerError{Kind: domain.ErrTrackerPayload, Message: fault.Error()}
+	}
 	if userAgent == "" {
 		userAgent = "sortie/dev"
 	}

--- a/internal/scm/github/tracker_test.go
+++ b/internal/scm/github/tracker_test.go
@@ -147,6 +147,18 @@ func TestNewGitHubAdapter(t *testing.T) {
 			wantErr:  true,
 			wantKind: domain.ErrTrackerPayload,
 		},
+		{
+			name:     "api_key wrong type",
+			config:   map[string]any{"api_key": 4242, "project": "owner/repo"},
+			wantErr:  true,
+			wantKind: domain.ErrTrackerPayload,
+		},
+		{
+			name:     "project wrong type",
+			config:   map[string]any{"api_key": "tok", "project": true},
+			wantErr:  true,
+			wantKind: domain.ErrTrackerPayload,
+		},
 	}
 
 	for _, tt := range tests {
@@ -169,6 +181,96 @@ func TestNewGitHubAdapter(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestNewGitHubAdapter_TypeFaultVsAbsentKey covers the distinction between
+// a wrong-typed config key and an absent one for api_key and project: the
+// type fault reports domain.ErrTrackerPayload with the typed-fault
+// message, distinct from the absent key's own kind
+// (domain.ErrMissingTrackerAPIKey / domain.ErrMissingTrackerProject) and
+// message.
+func TestNewGitHubAdapter_TypeFaultVsAbsentKey(t *testing.T) {
+	t.Parallel()
+
+	t.Run("api_key wrong type", func(t *testing.T) {
+		t.Parallel()
+
+		config := validConfig("https://api.github.com")
+		config["api_key"] = 4242
+
+		_, err := NewGitHubAdapter(config)
+
+		var te *domain.TrackerError
+		if !errors.As(err, &te) {
+			t.Fatalf("error type = %T, want *domain.TrackerError", err)
+		}
+		if te.Kind != domain.ErrTrackerPayload {
+			t.Errorf("TrackerError.Kind = %q, want %q", te.Kind, domain.ErrTrackerPayload)
+		}
+		if te.Message != "api_key: expected string, got integer" {
+			t.Errorf("TrackerError.Message = %q, want %q", te.Message, "api_key: expected string, got integer")
+		}
+	})
+
+	t.Run("api_key absent", func(t *testing.T) {
+		t.Parallel()
+
+		config := validConfig("https://api.github.com")
+		delete(config, "api_key")
+
+		_, err := NewGitHubAdapter(config)
+
+		var te *domain.TrackerError
+		if !errors.As(err, &te) {
+			t.Fatalf("error type = %T, want *domain.TrackerError", err)
+		}
+		if te.Kind != domain.ErrMissingTrackerAPIKey {
+			t.Errorf("TrackerError.Kind = %q, want %q", te.Kind, domain.ErrMissingTrackerAPIKey)
+		}
+		if te.Message != "missing required config key: api_key" {
+			t.Errorf("TrackerError.Message = %q, want %q", te.Message, "missing required config key: api_key")
+		}
+	})
+
+	t.Run("project wrong type", func(t *testing.T) {
+		t.Parallel()
+
+		config := validConfig("https://api.github.com")
+		config["project"] = true
+
+		_, err := NewGitHubAdapter(config)
+
+		var te *domain.TrackerError
+		if !errors.As(err, &te) {
+			t.Fatalf("error type = %T, want *domain.TrackerError", err)
+		}
+		if te.Kind != domain.ErrTrackerPayload {
+			t.Errorf("TrackerError.Kind = %q, want %q", te.Kind, domain.ErrTrackerPayload)
+		}
+		if te.Message != "project: expected string, got boolean" {
+			t.Errorf("TrackerError.Message = %q, want %q", te.Message, "project: expected string, got boolean")
+		}
+	})
+
+	t.Run("project absent", func(t *testing.T) {
+		t.Parallel()
+
+		config := validConfig("https://api.github.com")
+		delete(config, "project")
+
+		_, err := NewGitHubAdapter(config)
+
+		var te *domain.TrackerError
+		if !errors.As(err, &te) {
+			t.Fatalf("error type = %T, want *domain.TrackerError", err)
+		}
+		if te.Kind != domain.ErrMissingTrackerProject {
+			t.Errorf("TrackerError.Kind = %q, want %q", te.Kind, domain.ErrMissingTrackerProject)
+		}
+		if te.Message != "missing required config key: project" {
+			t.Errorf("TrackerError.Message = %q, want %q", te.Message, "missing required config key: project")
+		}
+	})
 }
 
 func TestNewGitHubAdapter_Defaults(t *testing.T) {

--- a/internal/scm/gitlab/ci.go
+++ b/internal/scm/gitlab/ci.go
@@ -14,6 +14,7 @@ import (
 	"github.com/sortie-ai/sortie/internal/httpkit"
 	"github.com/sortie-ai/sortie/internal/registry"
 	"github.com/sortie-ai/sortie/internal/scm/scmcore"
+	"github.com/sortie-ai/sortie/internal/typeutil"
 )
 
 func init() {
@@ -92,7 +93,10 @@ type GitLabCIProvider struct {
 // [domain.ErrCIAuth]; a missing or empty "project" returns one of kind
 // [domain.ErrCIPayload]. Construction performs no network request.
 func NewGitLabCIProvider(maxLogLines int, adapterConfig map[string]any) (domain.CIStatusProvider, error) {
-	apiKey, _ := adapterConfig["api_key"].(string)
+	apiKey, fault := typeutil.StringField(adapterConfig, "api_key")
+	if fault != nil {
+		return nil, &domain.CIError{Kind: domain.ErrCIPayload, Message: fault.Error()}
+	}
 	if apiKey == "" {
 		return nil, &domain.CIError{
 			Kind:    domain.ErrCIAuth,
@@ -100,7 +104,10 @@ func NewGitLabCIProvider(maxLogLines int, adapterConfig map[string]any) (domain.
 		}
 	}
 
-	project, _ := adapterConfig["project"].(string)
+	project, fault := typeutil.StringField(adapterConfig, "project")
+	if fault != nil {
+		return nil, &domain.CIError{Kind: domain.ErrCIPayload, Message: fault.Error()}
+	}
 	if project == "" {
 		return nil, &domain.CIError{
 			Kind:    domain.ErrCIPayload,
@@ -108,7 +115,10 @@ func NewGitLabCIProvider(maxLogLines int, adapterConfig map[string]any) (domain.
 		}
 	}
 
-	endpointRaw, _ := adapterConfig["endpoint"].(string)
+	endpointRaw, fault := typeutil.StringField(adapterConfig, "endpoint")
+	if fault != nil {
+		return nil, &domain.CIError{Kind: domain.ErrCIPayload, Message: fault.Error()}
+	}
 	parsedEndpoint, ok := httpkit.ResolveEndpoint(endpointRaw, defaultEndpoint)
 	if !ok {
 		return nil, &domain.CIError{
@@ -121,7 +131,10 @@ func NewGitLabCIProvider(maxLogLines int, adapterConfig map[string]any) (domain.
 		baseURL += "/api/v4"
 	}
 
-	userAgent, _ := adapterConfig["user_agent"].(string)
+	userAgent, fault := typeutil.StringField(adapterConfig, "user_agent")
+	if fault != nil {
+		return nil, &domain.CIError{Kind: domain.ErrCIPayload, Message: fault.Error()}
+	}
 	if userAgent == "" {
 		userAgent = "sortie/dev"
 	}

--- a/internal/scm/gitlab/ci_test.go
+++ b/internal/scm/gitlab/ci_test.go
@@ -269,6 +269,16 @@ func TestNewGitLabCIProvider_Validation(t *testing.T) {
 			config:   map[string]any{"api_key": "test-token", "project": testProject, "endpoint": "http://"},
 			wantKind: domain.ErrCIPayload,
 		},
+		{
+			name:     "api_key wrong type returns ErrCIPayload",
+			config:   map[string]any{"api_key": 4242, "project": testProject, "endpoint": "http://gitlab.invalid"},
+			wantKind: domain.ErrCIPayload,
+		},
+		{
+			name:     "project wrong type returns ErrCIPayload",
+			config:   map[string]any{"api_key": "test-token", "project": true, "endpoint": "http://gitlab.invalid"},
+			wantKind: domain.ErrCIPayload,
+		},
 	}
 
 	for _, tt := range tests {
@@ -350,6 +360,77 @@ func TestNewGitLabCIProvider_Validation(t *testing.T) {
 		}
 		if got := strings.Count(gotEscapedPath, "%2F"); got != 2 {
 			t.Errorf("request path %q carries %d occurrences of %%2F, want 2 (one percent-encoded segment for a three-part project)", gotEscapedPath, got)
+		}
+	})
+}
+
+// TestNewGitLabCIProvider_TypeFaultVsAbsentKey covers the distinction
+// between a wrong-typed config key and an absent one for the two keys
+// whose absent-key checks precede the endpoint check: api_key (a
+// different kind, ErrCIAuth vs ErrCIPayload) and project (the same kind,
+// distinguished by message).
+func TestNewGitLabCIProvider_TypeFaultVsAbsentKey(t *testing.T) {
+	t.Parallel()
+
+	t.Run("api_key wrong type", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := NewGitLabCIProvider(0, map[string]any{
+			"api_key":  4242,
+			"project":  testProject,
+			"endpoint": "http://gitlab.invalid",
+		})
+
+		var ce *domain.CIError
+		if !errors.As(err, &ce) {
+			t.Fatalf("error type = %T, want *domain.CIError", err)
+		}
+		if ce.Kind != domain.ErrCIPayload {
+			t.Errorf("CIError.Kind = %q, want %q", ce.Kind, domain.ErrCIPayload)
+		}
+		if ce.Message != "api_key: expected string, got integer" {
+			t.Errorf("CIError.Message = %q, want %q", ce.Message, "api_key: expected string, got integer")
+		}
+	})
+
+	t.Run("project wrong type", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := NewGitLabCIProvider(0, map[string]any{
+			"api_key":  "test-token",
+			"project":  4242,
+			"endpoint": "http://gitlab.invalid",
+		})
+
+		var ce *domain.CIError
+		if !errors.As(err, &ce) {
+			t.Fatalf("error type = %T, want *domain.CIError", err)
+		}
+		if ce.Kind != domain.ErrCIPayload {
+			t.Errorf("CIError.Kind = %q, want %q", ce.Kind, domain.ErrCIPayload)
+		}
+		if ce.Message != "project: expected string, got integer" {
+			t.Errorf("CIError.Message = %q, want %q", ce.Message, "project: expected string, got integer")
+		}
+	})
+
+	t.Run("project absent has the distinct existing message", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := NewGitLabCIProvider(0, map[string]any{
+			"api_key":  "test-token",
+			"endpoint": "http://gitlab.invalid",
+		})
+
+		var ce *domain.CIError
+		if !errors.As(err, &ce) {
+			t.Fatalf("error type = %T, want *domain.CIError", err)
+		}
+		if ce.Kind != domain.ErrCIPayload {
+			t.Errorf("CIError.Kind = %q, want %q", ce.Kind, domain.ErrCIPayload)
+		}
+		if ce.Message != "missing required config key: project" {
+			t.Errorf("CIError.Message = %q, want %q", ce.Message, "missing required config key: project")
 		}
 	})
 }

--- a/internal/scm/gitlab/gitlab.go
+++ b/internal/scm/gitlab/gitlab.go
@@ -317,7 +317,10 @@ func parseQueryFilter(raw string) (url.Values, error) {
 // key, or a preflight failure (invalid token or an unreachable project),
 // returns a [*domain.TrackerError] and blocks construction.
 func NewGitLabAdapter(config map[string]any) (domain.TrackerAdapter, error) {
-	apiKey, _ := config["api_key"].(string)
+	apiKey, fault := typeutil.StringField(config, "api_key")
+	if fault != nil {
+		return nil, &domain.TrackerError{Kind: domain.ErrTrackerPayload, Message: fault.Error()}
+	}
 	if apiKey == "" {
 		return nil, &domain.TrackerError{
 			Kind:    domain.ErrMissingTrackerAPIKey,
@@ -325,7 +328,10 @@ func NewGitLabAdapter(config map[string]any) (domain.TrackerAdapter, error) {
 		}
 	}
 
-	projectRaw, _ := config["project"].(string)
+	projectRaw, fault := typeutil.StringField(config, "project")
+	if fault != nil {
+		return nil, &domain.TrackerError{Kind: domain.ErrTrackerPayload, Message: fault.Error()}
+	}
 	project := strings.TrimSpace(projectRaw)
 	if project == "" {
 		return nil, &domain.TrackerError{
@@ -334,13 +340,19 @@ func NewGitLabAdapter(config map[string]any) (domain.TrackerAdapter, error) {
 		}
 	}
 
-	queryFilterRaw, _ := config["query_filter"].(string)
+	queryFilterRaw, fault := typeutil.StringField(config, "query_filter")
+	if fault != nil {
+		return nil, &domain.TrackerError{Kind: domain.ErrTrackerPayload, Message: fault.Error()}
+	}
 	queryFilter, err := parseQueryFilter(queryFilterRaw)
 	if err != nil {
 		return nil, err
 	}
 
-	endpointRaw, _ := config["endpoint"].(string)
+	endpointRaw, fault := typeutil.StringField(config, "endpoint")
+	if fault != nil {
+		return nil, &domain.TrackerError{Kind: domain.ErrTrackerPayload, Message: fault.Error()}
+	}
 	parsedEndpoint, ok := httpkit.ResolveEndpoint(endpointRaw, defaultEndpoint)
 	if !ok {
 		return nil, &domain.TrackerError{
@@ -371,10 +383,16 @@ func NewGitLabAdapter(config map[string]any) (domain.TrackerAdapter, error) {
 		terminalStates[i] = strings.ToLower(s)
 	}
 
-	handoffRaw, _ := config["handoff_state"].(string)
+	handoffRaw, fault := typeutil.StringField(config, "handoff_state")
+	if fault != nil {
+		return nil, &domain.TrackerError{Kind: domain.ErrTrackerPayload, Message: fault.Error()}
+	}
 	handoffState := strings.ToLower(strings.TrimSpace(handoffRaw))
 
-	userAgent, _ := config["user_agent"].(string)
+	userAgent, fault := typeutil.StringField(config, "user_agent")
+	if fault != nil {
+		return nil, &domain.TrackerError{Kind: domain.ErrTrackerPayload, Message: fault.Error()}
+	}
 	if userAgent == "" {
 		userAgent = "sortie/dev"
 	}

--- a/internal/scm/gitlab/gitlab_test.go
+++ b/internal/scm/gitlab/gitlab_test.go
@@ -346,6 +346,10 @@ func TestNewGitLabAdapter(t *testing.T) {
 			{"malformed endpoint scheme", map[string]any{"api_key": "tok", "project": testProject, "endpoint": "ftp://example.com"}, domain.ErrTrackerPayload, ""},
 			{"malformed endpoint no host", map[string]any{"api_key": "tok", "project": testProject, "endpoint": "http://"}, domain.ErrTrackerPayload, ""},
 
+			{"api_key wrong type", map[string]any{"api_key": 4242, "project": testProject, "endpoint": unreachable}, domain.ErrTrackerPayload, "api_key: expected string, got integer"},
+			{"project wrong type", map[string]any{"api_key": "tok", "project": true, "endpoint": unreachable}, domain.ErrTrackerPayload, "project: expected string, got boolean"},
+			{"query_filter wrong type", map[string]any{"api_key": "tok", "project": testProject, "endpoint": unreachable, "query_filter": 4242}, domain.ErrTrackerPayload, "query_filter: expected string, got integer"},
+
 			{"query_filter malformed percent-encoding", map[string]any{"api_key": "tok", "project": testProject, "endpoint": unreachable, "query_filter": "labels=%zz"}, domain.ErrTrackerPayload, ""},
 			{"query_filter semicolon separator", map[string]any{"api_key": "tok", "project": testProject, "endpoint": unreachable, "query_filter": "a=1;b=2"}, domain.ErrTrackerPayload, ""},
 

--- a/internal/scm/gitlab/scm.go
+++ b/internal/scm/gitlab/scm.go
@@ -12,6 +12,7 @@ import (
 	"github.com/sortie-ai/sortie/internal/httpkit"
 	"github.com/sortie-ai/sortie/internal/registry"
 	"github.com/sortie-ai/sortie/internal/scm/scmcore"
+	"github.com/sortie-ai/sortie/internal/typeutil"
 )
 
 func init() {
@@ -46,7 +47,10 @@ type GitLabSCMAdapter struct {
 //
 // Construction performs no network request.
 func NewGitLabSCMAdapter(adapterConfig map[string]any) (domain.SCMAdapter, error) {
-	apiKey, _ := adapterConfig["api_key"].(string)
+	apiKey, fault := typeutil.StringField(adapterConfig, "api_key")
+	if fault != nil {
+		return nil, &domain.SCMError{Kind: domain.ErrSCMPayload, Message: fault.Error()}
+	}
 	if apiKey == "" {
 		return nil, &domain.SCMError{
 			Kind:    domain.ErrSCMAuth,
@@ -54,7 +58,10 @@ func NewGitLabSCMAdapter(adapterConfig map[string]any) (domain.SCMAdapter, error
 		}
 	}
 
-	endpointRaw, _ := adapterConfig["endpoint"].(string)
+	endpointRaw, fault := typeutil.StringField(adapterConfig, "endpoint")
+	if fault != nil {
+		return nil, &domain.SCMError{Kind: domain.ErrSCMPayload, Message: fault.Error()}
+	}
 	parsedEndpoint, ok := httpkit.ResolveEndpoint(endpointRaw, defaultEndpoint)
 	if !ok {
 		return nil, &domain.SCMError{
@@ -67,7 +74,10 @@ func NewGitLabSCMAdapter(adapterConfig map[string]any) (domain.SCMAdapter, error
 		baseURL += "/api/v4"
 	}
 
-	userAgent, _ := adapterConfig["user_agent"].(string)
+	userAgent, fault := typeutil.StringField(adapterConfig, "user_agent")
+	if fault != nil {
+		return nil, &domain.SCMError{Kind: domain.ErrSCMPayload, Message: fault.Error()}
+	}
 	if userAgent == "" {
 		userAgent = "sortie/dev"
 	}

--- a/internal/scm/gitlab/scm_test.go
+++ b/internal/scm/gitlab/scm_test.go
@@ -115,6 +115,23 @@ func TestNewGitLabSCMAdapter_Validation(t *testing.T) {
 		adaptertest.AssertSCMErrorKind(t, err, domain.ErrSCMAuth)
 	})
 
+	t.Run("api_key wrong type returns ErrSCMPayload distinct from the absent-key ErrSCMAuth", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := NewGitLabSCMAdapter(map[string]any{"api_key": 4242, "endpoint": "http://gitlab.invalid"})
+
+		var se *domain.SCMError
+		if !errors.As(err, &se) {
+			t.Fatalf("error type = %T, want *domain.SCMError", err)
+		}
+		if se.Kind != domain.ErrSCMPayload {
+			t.Errorf("SCMError.Kind = %q, want %q", se.Kind, domain.ErrSCMPayload)
+		}
+		if se.Message != "api_key: expected string, got integer" {
+			t.Errorf("SCMError.Message = %q, want %q", se.Message, "api_key: expected string, got integer")
+		}
+	})
+
 	t.Run("malformed endpoint returns ErrSCMPayload", func(t *testing.T) {
 		t.Parallel()
 

--- a/internal/tracker/file/file.go
+++ b/internal/tracker/file/file.go
@@ -63,7 +63,10 @@ type FileAdapter struct {
 // Returns a [*domain.TrackerError] with Kind [domain.ErrTrackerPayload]
 // if "path" is missing or empty.
 func NewFileAdapter(config map[string]any) (domain.TrackerAdapter, error) {
-	path, _ := config["path"].(string)
+	path, fault := typeutil.StringField(config, "path")
+	if fault != nil {
+		return nil, &domain.TrackerError{Kind: domain.ErrTrackerPayload, Message: fault.Error()}
+	}
 	if path == "" {
 		return nil, &domain.TrackerError{
 			Kind:    domain.ErrTrackerPayload,

--- a/internal/tracker/file/file_test.go
+++ b/internal/tracker/file/file_test.go
@@ -98,6 +98,45 @@ func TestNewFileAdapter(t *testing.T) {
 	}
 }
 
+// TestNewFileAdapter_TypeFaultVsAbsentKey covers the distinction between a
+// wrong-typed path and an absent one: both report
+// domain.ErrTrackerPayload, but the type fault carries the typed-fault
+// message while the absent key keeps its existing "missing required
+// config key" message.
+func TestNewFileAdapter_TypeFaultVsAbsentKey(t *testing.T) {
+	t.Parallel()
+
+	t.Run("path wrong type", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := NewFileAdapter(map[string]any{"path": 4242})
+
+		requireTrackerError(t, err)
+		var te *domain.TrackerError
+		if !errors.As(err, &te) {
+			t.Fatalf("error type = %T, want *domain.TrackerError", err)
+		}
+		if te.Message != "path: expected string, got integer" {
+			t.Errorf("TrackerError.Message = %q, want %q", te.Message, "path: expected string, got integer")
+		}
+	})
+
+	t.Run("path absent", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := NewFileAdapter(map[string]any{})
+
+		requireTrackerError(t, err)
+		var te *domain.TrackerError
+		if !errors.As(err, &te) {
+			t.Fatalf("error type = %T, want *domain.TrackerError", err)
+		}
+		if te.Message != "missing required config key: path" {
+			t.Errorf("TrackerError.Message = %q, want %q", te.Message, "missing required config key: path")
+		}
+	})
+}
+
 func TestNewFileAdapter_YAMLAnySliceExtraction(t *testing.T) {
 	t.Parallel()
 

--- a/internal/tracker/jira/jira.go
+++ b/internal/tracker/jira/jira.go
@@ -84,7 +84,10 @@ type JiraAdapter struct {
 // malformed api_key, or a Cloud endpoint combined with api_version "2"
 // returns a [*domain.TrackerError] and blocks construction.
 func NewJiraAdapter(config map[string]any) (domain.TrackerAdapter, error) {
-	endpoint, _ := config["endpoint"].(string)
+	endpoint, fault := typeutil.StringField(config, "endpoint")
+	if fault != nil {
+		return nil, &domain.TrackerError{Kind: domain.ErrTrackerPayload, Message: fault.Error()}
+	}
 	if endpoint == "" {
 		return nil, &domain.TrackerError{
 			Kind:    domain.ErrTrackerPayload,
@@ -108,7 +111,10 @@ func NewJiraAdapter(config map[string]any) (domain.TrackerAdapter, error) {
 		return nil, err
 	}
 
-	apiKey, _ := config["api_key"].(string)
+	apiKey, fault := typeutil.StringField(config, "api_key")
+	if fault != nil {
+		return nil, &domain.TrackerError{Kind: domain.ErrTrackerPayload, Message: fault.Error()}
+	}
 	if apiKey == "" {
 		return nil, &domain.TrackerError{
 			Kind:    domain.ErrMissingTrackerAPIKey,
@@ -121,7 +127,10 @@ func NewJiraAdapter(config map[string]any) (domain.TrackerAdapter, error) {
 		return nil, err
 	}
 
-	project, _ := config["project"].(string)
+	project, fault := typeutil.StringField(config, "project")
+	if fault != nil {
+		return nil, &domain.TrackerError{Kind: domain.ErrTrackerPayload, Message: fault.Error()}
+	}
 	if project == "" {
 		return nil, &domain.TrackerError{
 			Kind:    domain.ErrMissingTrackerProject,
@@ -134,9 +143,15 @@ func NewJiraAdapter(config map[string]any) (domain.TrackerAdapter, error) {
 		activeStates = defaultActiveStates
 	}
 
-	queryFilter, _ := config["query_filter"].(string)
+	queryFilter, fault := typeutil.StringField(config, "query_filter")
+	if fault != nil {
+		return nil, &domain.TrackerError{Kind: domain.ErrTrackerPayload, Message: fault.Error()}
+	}
 
-	userAgent, _ := config["user_agent"].(string)
+	userAgent, fault := typeutil.StringField(config, "user_agent")
+	if fault != nil {
+		return nil, &domain.TrackerError{Kind: domain.ErrTrackerPayload, Message: fault.Error()}
+	}
 	if userAgent == "" {
 		userAgent = "sortie/dev"
 	}

--- a/internal/tracker/jira/jira_test.go
+++ b/internal/tracker/jira/jira_test.go
@@ -220,6 +220,55 @@ func TestNewJiraAdapter_EndpointTrailingSlash(t *testing.T) {
 	}
 }
 
+// TestNewJiraAdapter_TypeFaultVsAbsentKey covers the distinction between a
+// wrong-typed config key and an absent one: both report
+// domain.ErrTrackerPayload, but the type fault carries the typed-fault
+// message while the absent key keeps its existing "missing required
+// config key" message.
+func TestNewJiraAdapter_TypeFaultVsAbsentKey(t *testing.T) {
+	t.Parallel()
+
+	t.Run("endpoint wrong type", func(t *testing.T) {
+		t.Parallel()
+
+		config := validConfig("https://x.atlassian.net")
+		config["endpoint"] = 4242
+
+		_, err := NewJiraAdapter(config)
+
+		var te *domain.TrackerError
+		if !errors.As(err, &te) {
+			t.Fatalf("error type = %T, want *domain.TrackerError", err)
+		}
+		if te.Kind != domain.ErrTrackerPayload {
+			t.Errorf("TrackerError.Kind = %q, want %q", te.Kind, domain.ErrTrackerPayload)
+		}
+		if te.Message != "endpoint: expected string, got integer" {
+			t.Errorf("TrackerError.Message = %q, want %q", te.Message, "endpoint: expected string, got integer")
+		}
+	})
+
+	t.Run("endpoint absent", func(t *testing.T) {
+		t.Parallel()
+
+		config := validConfig("https://x.atlassian.net")
+		delete(config, "endpoint")
+
+		_, err := NewJiraAdapter(config)
+
+		var te *domain.TrackerError
+		if !errors.As(err, &te) {
+			t.Fatalf("error type = %T, want *domain.TrackerError", err)
+		}
+		if te.Kind != domain.ErrTrackerPayload {
+			t.Errorf("TrackerError.Kind = %q, want %q", te.Kind, domain.ErrTrackerPayload)
+		}
+		if te.Message != "missing required config key: endpoint" {
+			t.Errorf("TrackerError.Message = %q, want %q", te.Message, "missing required config key: endpoint")
+		}
+	})
+}
+
 func TestRegistration(t *testing.T) {
 	t.Parallel()
 

--- a/internal/tracker/linear/linear.go
+++ b/internal/tracker/linear/linear.go
@@ -83,7 +83,10 @@ type LinearAdapter struct {
 // an unknown team, or a configured state name absent from the team returns a
 // [*domain.TrackerError] and blocks construction.
 func NewLinearAdapter(config map[string]any) (domain.TrackerAdapter, error) {
-	endpointRaw, _ := config["endpoint"].(string)
+	endpointRaw, fault := typeutil.StringField(config, "endpoint")
+	if fault != nil {
+		return nil, &domain.TrackerError{Kind: domain.ErrTrackerPayload, Message: fault.Error()}
+	}
 	endpoint, redactedEndpoint, endpointOK := resolveEndpoint(endpointRaw)
 	if !endpointOK {
 		return nil, &domain.TrackerError{
@@ -92,7 +95,10 @@ func NewLinearAdapter(config map[string]any) (domain.TrackerAdapter, error) {
 		}
 	}
 
-	apiKey, _ := config["api_key"].(string)
+	apiKey, fault := typeutil.StringField(config, "api_key")
+	if fault != nil {
+		return nil, &domain.TrackerError{Kind: domain.ErrTrackerPayload, Message: fault.Error()}
+	}
 	if apiKey == "" {
 		return nil, &domain.TrackerError{
 			Kind:    domain.ErrMissingTrackerAPIKey,
@@ -100,7 +106,10 @@ func NewLinearAdapter(config map[string]any) (domain.TrackerAdapter, error) {
 		}
 	}
 
-	project, _ := config["project"].(string)
+	project, fault := typeutil.StringField(config, "project")
+	if fault != nil {
+		return nil, &domain.TrackerError{Kind: domain.ErrTrackerPayload, Message: fault.Error()}
+	}
 	if project == "" {
 		return nil, &domain.TrackerError{
 			Kind:    domain.ErrMissingTrackerProject,
@@ -116,15 +125,24 @@ func NewLinearAdapter(config map[string]any) (domain.TrackerAdapter, error) {
 	if len(terminalStates) == 0 {
 		terminalStates = defaultTerminalStates
 	}
-	handoffState, _ := config["handoff_state"].(string)
+	handoffState, fault := typeutil.StringField(config, "handoff_state")
+	if fault != nil {
+		return nil, &domain.TrackerError{Kind: domain.ErrTrackerPayload, Message: fault.Error()}
+	}
 
-	rawQueryFilter, _ := config["query_filter"].(string)
+	rawQueryFilter, fault := typeutil.StringField(config, "query_filter")
+	if fault != nil {
+		return nil, &domain.TrackerError{Kind: domain.ErrTrackerPayload, Message: fault.Error()}
+	}
 	queryFilter, err := parseQueryFilter(rawQueryFilter)
 	if err != nil {
 		return nil, err
 	}
 
-	userAgent, _ := config["user_agent"].(string)
+	userAgent, fault := typeutil.StringField(config, "user_agent")
+	if fault != nil {
+		return nil, &domain.TrackerError{Kind: domain.ErrTrackerPayload, Message: fault.Error()}
+	}
 	if userAgent == "" {
 		userAgent = "sortie/dev"
 	}

--- a/internal/tracker/linear/linear_test.go
+++ b/internal/tracker/linear/linear_test.go
@@ -74,6 +74,48 @@ func TestNewLinearAdapter(t *testing.T) {
 	}
 }
 
+// TestNewLinearAdapter_TypeFaultVsAbsentKey covers the distinction between
+// a wrong-typed api_key and an absent one: the type fault reports
+// domain.ErrTrackerPayload with the typed-fault message, while the absent
+// key keeps its existing domain.ErrMissingTrackerAPIKey kind and message.
+func TestNewLinearAdapter_TypeFaultVsAbsentKey(t *testing.T) {
+	t.Parallel()
+
+	t.Run("api_key wrong type", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := NewLinearAdapter(map[string]any{"api_key": 4242, "project": "SOR"})
+
+		var te *domain.TrackerError
+		if !errors.As(err, &te) {
+			t.Fatalf("error type = %T, want *domain.TrackerError", err)
+		}
+		if te.Kind != domain.ErrTrackerPayload {
+			t.Errorf("TrackerError.Kind = %q, want %q", te.Kind, domain.ErrTrackerPayload)
+		}
+		if te.Message != "api_key: expected string, got integer" {
+			t.Errorf("TrackerError.Message = %q, want %q", te.Message, "api_key: expected string, got integer")
+		}
+	})
+
+	t.Run("api_key absent", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := NewLinearAdapter(map[string]any{"project": "SOR"})
+
+		var te *domain.TrackerError
+		if !errors.As(err, &te) {
+			t.Fatalf("error type = %T, want *domain.TrackerError", err)
+		}
+		if te.Kind != domain.ErrMissingTrackerAPIKey {
+			t.Errorf("TrackerError.Kind = %q, want %q", te.Kind, domain.ErrMissingTrackerAPIKey)
+		}
+		if te.Message != "missing required config key: api_key" {
+			t.Errorf("TrackerError.Message = %q, want %q", te.Message, "missing required config key: api_key")
+		}
+	})
+}
+
 // endpointGuardConfig builds a config map for [TestNewLinearAdapterEndpointGuard].
 // api_key is deliberately never set: every case in that test isolates the
 // endpoint gate by relying on the next required-field check to fire only

--- a/internal/typeutil/typeutil.go
+++ b/internal/typeutil/typeutil.go
@@ -5,6 +5,7 @@ package typeutil
 
 import (
 	"strings"
+	"time"
 	"unicode/utf8"
 )
 
@@ -42,14 +43,71 @@ func TruncateRunes(s string, maxLen int) string {
 	return string(runes[:maxLen]) + "…"
 }
 
-// StringFrom returns the string value for key in config. Returns "" if
-// the key is absent or the value is not a string.
-func StringFrom(config map[string]any, key string) string {
-	v, ok := config[key].(string)
-	if !ok {
-		return ""
+// TypeFault reports one configuration value whose YAML type is not the
+// type its reader requires. Key is the config key as the operator wrote
+// it, without any section prefix; the caller supplies the prefix when it
+// has one.
+type TypeFault struct {
+	Key  string // e.g. "endpoint"
+	Want string // required YAML type name, e.g. "string"
+	Got  string // YAML type name found, e.g. "integer"
+}
+
+// Error renders the fault as "<Key>: expected <Want>, got <Got>".
+func (f *TypeFault) Error() string {
+	return f.Key + ": " + f.Reason()
+}
+
+// Reason renders the fault as "expected <Want>, got <Got>", for a caller
+// that carries the field path in its own field and would otherwise print
+// the key twice.
+func (f *TypeFault) Reason() string {
+	return "expected " + f.Want + ", got " + f.Got
+}
+
+// DescribeYAMLType returns the YAML type name of a decoded front-matter
+// value. It never names a Go type: that detail is internal and an
+// operator writing YAML cannot act on it.
+func DescribeYAMLType(v any) string {
+	switch v.(type) {
+	case string:
+		return "string"
+	case bool:
+		return "boolean"
+	case int, uint64, int8, int16, int32, int64, uint, uint8, uint16, uint32:
+		return "integer"
+	case float64, float32:
+		return "float"
+	case []any:
+		return "list"
+	case map[string]any, map[any]any:
+		return "mapping"
+	case time.Time:
+		return "timestamp"
+	case nil:
+		return "null"
+	default:
+		return "unrecognized value"
 	}
-	return v
+}
+
+// StringField returns the string value for key in config.
+//
+// An absent key, and a key whose value is nil, return ("", nil): the
+// required-key decision belongs to the caller. A value of any other YAML
+// type returns ("", fault) with the empty string, so a caller that
+// ignores the fault degrades to the previous behavior rather than to an
+// undefined value.
+func StringField(config map[string]any, key string) (string, *TypeFault) {
+	v, present := config[key]
+	if !present || v == nil {
+		return "", nil
+	}
+	s, ok := v.(string)
+	if !ok {
+		return "", &TypeFault{Key: key, Want: "string", Got: DescribeYAMLType(v)}
+	}
+	return s, nil
 }
 
 // IntFrom returns the integer value for key in config. Handles both int

--- a/internal/typeutil/typeutil_test.go
+++ b/internal/typeutil/typeutil_test.go
@@ -2,6 +2,7 @@ package typeutil
 
 import (
 	"testing"
+	"time"
 	"unicode/utf8"
 )
 
@@ -98,33 +99,6 @@ func repeatString(s string, n int) string {
 	return string(result)
 }
 
-func TestStringFrom(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name   string
-		config map[string]any
-		key    string
-		want   string
-	}{
-		{name: "key present string value", config: map[string]any{"k": "hello"}, key: "k", want: "hello"},
-		{name: "key present non-string value", config: map[string]any{"k": 42}, key: "k", want: ""},
-		{name: "key absent", config: map[string]any{}, key: "missing", want: ""},
-		{name: "nil value for key", config: map[string]any{"k": nil}, key: "k", want: ""},
-		{name: "empty string value", config: map[string]any{"k": ""}, key: "k", want: ""},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			got := StringFrom(tt.config, tt.key)
-			if got != tt.want {
-				t.Errorf("StringFrom(%q) = %q, want %q", tt.key, got, tt.want)
-			}
-		})
-	}
-}
-
 func TestIntFrom(t *testing.T) {
 	t.Parallel()
 
@@ -206,6 +180,105 @@ func TestBoolFrom(t *testing.T) {
 			got := BoolFrom(tt.config, tt.key, tt.defaultVal)
 			if got != tt.want {
 				t.Errorf("BoolFrom(%q) = %v, want %v", tt.key, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestStringField(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		config    map[string]any
+		key       string
+		want      string
+		wantFault bool
+		wantWant  string
+		wantGot   string
+	}{
+		{name: "string value", config: map[string]any{"k": "hello"}, key: "k", want: "hello"},
+		{name: "absent key", config: map[string]any{}, key: "missing", want: ""},
+		{name: "nil value", config: map[string]any{"k": nil}, key: "k", want: ""},
+		{name: "bool value", config: map[string]any{"k": true}, key: "k", wantFault: true, wantWant: "string", wantGot: "boolean"},
+		{name: "int value", config: map[string]any{"k": 42}, key: "k", wantFault: true, wantWant: "string", wantGot: "integer"},
+		{name: "uint64 value", config: map[string]any{"k": uint64(9223372036854775808)}, key: "k", wantFault: true, wantWant: "string", wantGot: "integer"},
+		{name: "float64 value", config: map[string]any{"k": 1.5}, key: "k", wantFault: true, wantWant: "string", wantGot: "float"},
+		{name: "[]any value", config: map[string]any{"k": []any{"x", "y"}}, key: "k", wantFault: true, wantWant: "string", wantGot: "list"},
+		{name: "map[string]any value", config: map[string]any{"k": map[string]any{"a": "b"}}, key: "k", wantFault: true, wantWant: "string", wantGot: "mapping"},
+		{name: "map[any]any value", config: map[string]any{"k": map[any]any{1: "b"}}, key: "k", wantFault: true, wantWant: "string", wantGot: "mapping"},
+		{name: "time.Time value", config: map[string]any{"k": time.Now()}, key: "k", wantFault: true, wantWant: "string", wantGot: "timestamp"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, fault := StringField(tt.config, tt.key)
+
+			if got != tt.want {
+				t.Errorf("StringField(%q) got = %q, want %q", tt.key, got, tt.want)
+			}
+
+			if !tt.wantFault {
+				if fault != nil {
+					t.Errorf("StringField(%q) fault = %v, want nil", tt.key, fault)
+				}
+				return
+			}
+
+			if fault == nil {
+				t.Fatalf("StringField(%q) fault = nil, want non-nil", tt.key)
+			}
+			if fault.Key != tt.key {
+				t.Errorf("StringField(%q) fault.Key = %q, want %q", tt.key, fault.Key, tt.key)
+			}
+			if fault.Want != tt.wantWant {
+				t.Errorf("StringField(%q) fault.Want = %q, want %q", tt.key, fault.Want, tt.wantWant)
+			}
+			if fault.Got != tt.wantGot {
+				t.Errorf("StringField(%q) fault.Got = %q, want %q", tt.key, fault.Got, tt.wantGot)
+			}
+		})
+	}
+}
+
+func TestDescribeYAMLType(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input any
+		want  string
+	}{
+		{name: "string", input: "text", want: "string"},
+		{name: "bool", input: true, want: "boolean"},
+		{name: "int", input: int(5), want: "integer"},
+		{name: "uint64", input: uint64(1), want: "integer"},
+		{name: "int8", input: int8(1), want: "integer"},
+		{name: "int16", input: int16(1), want: "integer"},
+		{name: "int32", input: int32(1), want: "integer"},
+		{name: "int64", input: int64(1), want: "integer"},
+		{name: "uint", input: uint(1), want: "integer"},
+		{name: "uint8", input: uint8(1), want: "integer"},
+		{name: "uint16", input: uint16(1), want: "integer"},
+		{name: "uint32", input: uint32(1), want: "integer"},
+		{name: "float64", input: float64(1.5), want: "float"},
+		{name: "float32", input: float32(1.5), want: "float"},
+		{name: "[]any", input: []any{"x"}, want: "list"},
+		{name: "map[string]any", input: map[string]any{"a": "b"}, want: "mapping"},
+		{name: "map[any]any", input: map[any]any{1: "b"}, want: "mapping"},
+		{name: "time.Time", input: time.Now(), want: "timestamp"},
+		{name: "nil", input: nil, want: "null"},
+		{name: "unrecognized value", input: complex(1, 2), want: "unrecognized value"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := DescribeYAMLType(tt.input)
+			if got != tt.want {
+				t.Errorf("DescribeYAMLType(%v) = %q, want %q", tt.input, got, tt.want)
 			}
 		})
 	}

--- a/internal/typeutil/typeutil_test.go
+++ b/internal/typeutil/typeutil_test.go
@@ -284,6 +284,19 @@ func TestDescribeYAMLType(t *testing.T) {
 	}
 }
 
+func TestTypeFault(t *testing.T) {
+	t.Parallel()
+
+	fault := &TypeFault{Key: "endpoint", Want: "string", Got: "integer"}
+
+	if got, want := fault.Error(), "endpoint: expected string, got integer"; got != want {
+		t.Errorf("TypeFault.Error() = %q, want %q", got, want)
+	}
+	if got, want := fault.Reason(), "expected string, got integer"; got != want {
+		t.Errorf("TypeFault.Reason() = %q, want %q", got, want)
+	}
+}
+
 func TestMapFrom(t *testing.T) {
 	t.Parallel()
 

--- a/internal/workflow/manager_test.go
+++ b/internal/workflow/manager_test.go
@@ -41,6 +41,13 @@ func ciWatchWindowWorkflow(ms int) []byte {
 	return fmt.Appendf(nil, "---\npolling:\n  interval_ms: 5000\nreactions:\n  ci_failure:\n    provider: github-actions\n    watch_window_ms: %d\n---\nDo the task for {{ .issue.title }}.\n", ms)
 }
 
+// trackerEndpointWorkflow returns a minimal WORKFLOW.md content with the
+// given tracker.endpoint value spliced in unquoted, so a numeric literal
+// decodes as a YAML integer rather than a string.
+func trackerEndpointWorkflow(endpoint string) []byte {
+	return fmt.Appendf(nil, "---\npolling:\n  interval_ms: 5000\ntracker:\n  kind: jira\n  endpoint: %s\n---\nDo the task for {{ .issue.title }}.\n", endpoint)
+}
+
 func testLogger() *slog.Logger {
 	return slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 }
@@ -240,6 +247,60 @@ func TestManager_ReloadRetainsOnError(t *testing.T) {
 	}
 	if mgr.LastLoadError() == nil {
 		t.Error("after failed Reload: LastLoadError() is nil, want non-nil")
+	}
+}
+
+// TestManager_ReloadRetainsOnConfigTypeFault covers the reload fail-safe
+// path for a config-layer type fault: a reload whose new WORKFLOW.md
+// carries a mistyped tracker.endpoint leaves Manager.Config() returning
+// the previously loaded configuration and LastLoadError() reporting the
+// fault, exercising the existing fail-safe path with no new call site
+// inside Manager.Reload.
+func TestManager_ReloadRetainsOnConfigTypeFault(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "WORKFLOW.md")
+	mustWriteFile(t, path, trackerEndpointWorkflow("https://jira.example.com"))
+
+	mgr, err := NewManager(path, testLogger())
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	if got := mgr.Config().Tracker.Endpoint; got != "https://jira.example.com" {
+		t.Fatalf("initial Config().Tracker.Endpoint = %q, want %q", got, "https://jira.example.com")
+	}
+
+	// A bare, unquoted number decodes as a YAML integer, not a string.
+	mustWriteFile(t, path, trackerEndpointWorkflow("123"))
+
+	err = mgr.Reload()
+	if err == nil {
+		t.Fatal("Reload() error = nil, want error")
+	}
+	var ce *config.ConfigError
+	if !errors.As(err, &ce) {
+		t.Fatalf("Reload() error type = %T, want *config.ConfigError", err)
+	}
+	if ce.Field != "tracker.endpoint" {
+		t.Errorf("Reload() ConfigError.Field = %q, want %q", ce.Field, "tracker.endpoint")
+	}
+	if ce.Message != "expected string, got integer" {
+		t.Errorf("Reload() ConfigError.Message = %q, want %q", ce.Message, "expected string, got integer")
+	}
+
+	if got := mgr.Config().Tracker.Endpoint; got != "https://jira.example.com" {
+		t.Errorf("after failed Reload: Config().Tracker.Endpoint = %q, want %q (retained)", got, "https://jira.example.com")
+	}
+	if mgr.LastLoadError() == nil {
+		t.Error("after failed Reload: LastLoadError() is nil, want non-nil")
+	}
+	var lastCe *config.ConfigError
+	if !errors.As(mgr.LastLoadError(), &lastCe) {
+		t.Fatalf("LastLoadError() type = %T, want *config.ConfigError", mgr.LastLoadError())
+	}
+	if lastCe.Field != "tracker.endpoint" {
+		t.Errorf("LastLoadError() ConfigError.Field = %q, want %q", lastCe.Field, "tracker.endpoint")
 	}
 }
 


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Fix

**Intent:** Every tracker and SCM adapter constructor read its pass-through config with a discarded type assertion (`value, _ := config["key"].(string)`), which silently coerced a wrong-typed value - e.g. `tracker.endpoint: 123` - to the empty string and reported it as though the key were absent. This change makes a wrong-typed string config key report a distinct diagnostic naming the key and the YAML type found, consistently across every tracker, SCM, agent, and notifier adapter.

**Related Issues:** #911

### 🧭 Reviewer Guide

**Complexity:** Medium

#### Entry Point

`internal/typeutil/typeutil.go` - `StringFrom` is replaced by `StringField`, which returns `(string, *TypeFault)` instead of silently coercing a non-string value to `""`. `TypeFault` carries the key and the YAML type found (via the new `DescribeYAMLType` helper), and an absent or nil key still returns `("", nil)` so the caller's own required-field handling is unchanged. Every other file in this PR is a call site threading that fault through: three tracker adapters, three SCM adapter families, five agent adapters, and two notifier backends, each converting a returned fault into that adapter's existing error type.

#### Sensitive Areas

- `internal/adaptertest/stringassert_test.go`: new static contract check (`STRINGASSERT`) that walks non-test files in the tracker, SCM, agent, and config-layer packages and fails the build if the discarded `value, _ := v.(string)` idiom reappears outside three allowlisted, non-config-reading sites (an ADF parser, a GraphQL variables reader, and a mock tool-call fixture parser). This is what keeps the fix from regressing one adapter at a time.
- `internal/config/config.go`: largest single diff: threads `TypeFault` through top-level config parsing (`agent.kind`, `agent.command`, `db_path`, etc.) in addition to the adapter constructors.
- `docs/workflow-reference.md`: adds `sortie validate` diagnostic rows and per-adapter `<adapter>.<key>.wrong_type` check names; verify these match the error strings the adapters actually construct.

### ⚠️ Risk Assessment

- **Breaking Changes:** No changes to adapter interfaces or the `TrackerError`/config error types. Behavioral: a workflow whose adapter config previously carried a wrong-typed string key (silently coerced to empty and defaulted, or reported as an absent key) will now fail - at config parse time, at adapter construction, or offline via `sortie validate` - with a diagnostic naming the key and the type found. An absent key's existing required-field message is unchanged.
- **Migrations/State:** No migrations or state changes.

