### PR TITLE
fix: bound the pre-cmd.Wait stderr drain in agent adapters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A string-typed adapter configuration key whose value carries another YAML type, such as `tracker.endpoint: 123`, `agent.kind: 123`, or a mistyped `claude-code.model`, is now rejected with a diagnostic naming the key and the type found, instead of being silently coerced to the empty string and then treated as absent or defaulted to the adapter's own default. A workflow that previously started with such a value now fails at config load, at adapter construction, or offline through `sortie validate`, whichever reads the key first; the fix is to quote the value or remove the key.
   ([#911](https://github.com/sortie-ai/sortie/issues/911))
 
+- A turn whose output handle is held open by a surviving descendant process no longer leaks its process group and no longer withholds its outcome: the wait for that output is now bounded, and the turn's reap, process-group cleanup, and result publication all still run once that bound expires. On `kiro`, such a turn is reported as a failure, because its success evidence lives on that output and could not be read.
+  ([#918](https://github.com/sortie-ai/sortie/issues/918))
+
 ## [1.23.0] - 2026-08-31
 
 ### Added

--- a/docs/architecture/10-agent-adapter-contract.md
+++ b/docs/architecture/10-agent-adapter-contract.md
@@ -614,6 +614,19 @@ Graceful shutdown sequence:
 - After `cmd.Wait()` returns, a best-effort force kill is sent to the process group to reap any
   children that survived the graceful signal.
 
+Standard-error drain before reap:
+
+- The adapter waits for its subprocess's standard-error reader to finish before reaping the
+  process, because reaping closes the pipe's read end and races a reader still consuming
+  buffered output. That wait is bounded, so a descendant that inherits the standard-error
+  handle and outlives the direct child cannot withhold the reap, the process-group termination,
+  or the publication of the turn's outcome.
+- Reaping the process and terminating its group are what release such a reader in the ordinary
+  case, so the turn keeps the standard-error output the reader had already collected.
+- When neither release ends the wait, the turn's collected standard-error output is replaced by
+  a marker, and an adapter whose success evidence lives on standard error reports the turn
+  failed rather than succeeded.
+
 Recommended additional process settings:
 
 - Max line size: 10 MB (for safe buffering)

--- a/docs/architecture/22-test-and-validation-matrix.md
+++ b/docs/architecture/22-test-and-validation-matrix.md
@@ -485,6 +485,8 @@ Unless otherwise noted, Sections 17.1 through 17.7 are `Core Conformance`. Bulle
 - An adapter whose runtime publishes a task-completion report carries a test driving both a turn
   the agent declared complete and a turn the runtime ended without that report through the
   adapter, asserting the two dispositions differ
+- A turn whose subprocess standard-error handle is held open by a surviving descendant still
+  publishes its outcome and cleans up its process group within a bounded time
 
 ### 17.6 Observability
 

--- a/docs/copilot-adapter-notes.md
+++ b/docs/copilot-adapter-notes.md
@@ -62,6 +62,8 @@ A configuration the CLI cannot parse can end the process with a zero exit and an
 
 An authentication problem can also produce a process that fails with nothing on stdout. The symptom is identical to the case above; the distinguishing evidence is again stderr.
 
+Stderr can also be missing outright. When it carries a single marker line saying it was not collected, a descendant process held the handle open past the direct child, the diagnostics were never read, and the wait for them was cut short so the turn could still be reaped and reported. That marker is the finding, not a truncated log.
+
 Two failures worth recognizing come from outside our code entirely, and both are worth checking before you go looking for a bug in the adapter. A resume that comes back with no conversation history, on a session whose journal is present on disk, points at the journal itself rather than at our resume logic: the journal is line-delimited JSON and a raw character sequence that breaks a line-oriented parse takes the whole history with it. And a subprocess that starts, prints nothing, and never exits has been seen under environment managers that wrap the shell and rearrange its file descriptors; there is nothing on our side to fix, and stall reconciliation is what ends such a turn. If either reproduces, confirm it against the current release before treating it as known.
 
 Session state accumulates under the user's home directory, outside the workspace, so removing a workspace does not reclaim it.

--- a/docs/kiro-adapter-notes.md
+++ b/docs/kiro-adapter-notes.md
@@ -20,7 +20,7 @@ Stall detection does still reach these turns. Each non-empty stripped stdout lin
 
 ## Exit zero does not mean the turn succeeded
 
-The cost trailer on stderr is the only positive proof that a turn actually ran. A turn that never ran because the credential was rejected also exits zero, with empty stdout and an authentication line on stderr and no trailer.
+The cost trailer on stderr is the only positive proof that a turn actually ran. A turn that never ran because the credential was rejected also exits zero, with empty stdout and an authentication line on stderr and no trailer. A turn whose standard error could not be collected has no trailer to read either, and is reported as a failure for the same reason.
 
 So the adapter never maps a bare zero exit to success. It reports success only when the trailer is present, reports a specific authentication failure when a zero exit arrives with the auth marker and empty stdout, and otherwise lets the shared decision treat a zero exit with no trailer as a turn that produced nothing. Both markers are matched by substring containment and never by the numbers that follow them, which is what keeps the classification stable while the values vary.
 

--- a/docs/opencode-adapter-notes.md
+++ b/docs/opencode-adapter-notes.md
@@ -24,7 +24,7 @@ That independence is a maintenance hazard. Improvements to the shared skeleton d
 
 The first-JSON deadline defaults to thirty seconds and is overridden by the workflow's read timeout. It stops once the first envelope arrives, so it guards a subprocess that never starts talking, not a mid-turn stall. Stalls are the orchestrator's business.
 
-There is one ordering constraint in the wait path that is easy to break and hard to see: the wait goroutine waits for both the stdout reader and the stderr collector to finish before reaping the process, because reaping closes the pipe read ends and races a scanner still draining buffered output. On stderr that race silently drops the permission-refusal warning that the finalize path depends on.
+There is one ordering constraint in the wait path that is easy to break and hard to see: the wait goroutine waits for both the stdout reader and the stderr collector to finish before reaping the process, because reaping closes the pipe read ends and races a scanner still draining buffered output. On stderr that race silently drops the permission-refusal warning that the finalize path depends on. The wait on the stdout reader stays unbounded; the wait on the stderr collector is bounded, so a descendant that inherits only the stderr handle and outlives the direct child cannot withhold the reap. Firing that bound costs the permission-refusal warning on the residual path where reaping the process does not also release the collector.
 
 ## Session identity and the dir-scoped resume
 

--- a/internal/agent/agentcore/forkperturn.go
+++ b/internal/agent/agentcore/forkperturn.go
@@ -148,6 +148,11 @@ type ForkPerTurnSession struct {
 	mu     sync.Mutex
 	proc   *os.Process
 	waitCh chan struct{}
+
+	// drainGrace bounds the wait for the stderr drain before each
+	// cmd.Wait call. Set by NewForkPerTurnSession; overridden only by
+	// tests in this package.
+	drainGrace time.Duration
 }
 
 // NewForkPerTurnSession constructs a ForkPerTurnSession. target must be a
@@ -181,9 +186,10 @@ func NewForkPerTurnSession(
 		panic("agentcore: ForkPerTurnSession logger must be non-nil")
 	}
 	return &ForkPerTurnSession{
-		target: target,
-		hooks:  hooks,
-		logger: logger,
+		target:     target,
+		hooks:      hooks,
+		logger:     logger,
+		drainGrace: procutil.DefaultDrainGrace,
 	}
 }
 
@@ -326,9 +332,9 @@ func (s *ForkPerTurnSession) RunTurn(
 
 	if scanErr := scanner.Err(); scanErr != nil {
 		cancelCmd()
-		stderrLines := stderrCollector.Lines()     // drain before cmd.Wait() closes the pipe
-		cmd.Wait()                                 //nolint:errcheck,gosec // best-effort reap; exit code is irrelevant on scanner failure
-		procutil.KillProcessGroup(cmd.Process.Pid) //nolint:errcheck,gosec // best-effort cleanup of surviving group members
+		drained := stderrCollector.WaitDone(s.drainGrace) // bound the wait before cmd.Wait() closes the pipe
+		cmd.Wait()                                        //nolint:errcheck,gosec // best-effort reap; exit code is irrelevant on scanner failure
+		procutil.KillProcessGroup(cmd.Process.Pid)        //nolint:errcheck,gosec // best-effort cleanup of surviving group members
 		procutil.CleanupProcess(cmd.Process.Pid)
 		close(localWaitCh)
 		s.mu.Lock()
@@ -353,6 +359,13 @@ func (s *ForkPerTurnSession) RunTurn(
 			}
 		}
 
+		if !drained {
+			if !stderrCollector.WaitDone(s.drainGrace) {
+				stderrCollector.Abandon(s.drainGrace)
+			}
+		}
+		stderrLines := stderrCollector.Lines()
+
 		procutil.EmitWarnLines(stderrLines, s.logger)
 		usage := s.hooks.GetUsage()
 		EmitTurnFailed(emit, "stdout read error: "+scanErr.Error(), 0, usage)
@@ -368,10 +381,11 @@ func (s *ForkPerTurnSession) RunTurn(
 		}
 	}
 
-	// Drain stderr before cmd.Wait() to avoid losing buffered data:
-	// cmd.Wait() closes the pipe read end, which can prevent the drain
-	// goroutine from reading data that the process already wrote.
-	stderrLines := stderrCollector.Lines()
+	// Bound the wait for stderr before cmd.Wait() to avoid losing
+	// buffered data: cmd.Wait() closes the pipe read end, which can
+	// prevent the drain goroutine from reading data that the process
+	// already wrote.
+	drained := stderrCollector.WaitDone(s.drainGrace)
 	waitErr := cmd.Wait()
 	procutil.KillProcessGroup(cmd.Process.Pid) //nolint:errcheck,gosec // best-effort cleanup of surviving group members
 	procutil.CleanupProcess(cmd.Process.Pid)
@@ -395,6 +409,13 @@ func (s *ForkPerTurnSession) RunTurn(
 			Err:     ctx.Err(),
 		}
 	}
+
+	if !drained {
+		if !stderrCollector.WaitDone(s.drainGrace) {
+			stderrCollector.Abandon(s.drainGrace)
+		}
+	}
+	stderrLines := stderrCollector.Lines()
 
 	exitCode := procutil.ExtractExitCode(waitErr)
 

--- a/internal/agent/agentcore/forkperturn_test.go
+++ b/internal/agent/agentcore/forkperturn_test.go
@@ -419,7 +419,12 @@ exit 1`)
 	t.Run("Bound_NoFireOnLongTurn", func(t *testing.T) {
 		t.Parallel()
 		tmpDir := t.TempDir()
+		// Closing the standard error handle right after the line is
+		// written puts the drain at EOF while the turn is still running,
+		// so the assertion that no bound fires does not depend on the
+		// drain goroutine being scheduled inside the grace.
 		script := agenttest.WriteScript(t, tmpDir, "agent", `echo 'long turn stderr' >&2
+exec 2>&-
 sleep 0.5
 exit 0`)
 		spy := &agenttest.LogSpy{}

--- a/internal/agent/agentcore/forkperturn_test.go
+++ b/internal/agent/agentcore/forkperturn_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"slices"
 	"testing"
 	"time"
 
@@ -412,6 +413,73 @@ exit 1`)
 		}
 		if !hasEventType(*events, domain.EventTurnCompleted) {
 			t.Errorf("EventTurnCompleted not emitted; got %v", *events)
+		}
+	})
+
+	t.Run("Bound_NoFireOnLongTurn", func(t *testing.T) {
+		t.Parallel()
+		tmpDir := t.TempDir()
+		script := agenttest.WriteScript(t, tmpDir, "agent", `echo 'long turn stderr' >&2
+sleep 0.5
+exit 0`)
+		spy := &agenttest.LogSpy{}
+		target := newTestTarget(tmpDir, script)
+
+		var gotStderrLines []string
+		hooks := noopHooks()
+		hooks.OnFinalize = func(emit func(domain.AgentEvent), lastParsed any, exitCode int, stderrLines []string) (domain.TurnResult, *domain.AgentError) {
+			gotStderrLines = stderrLines
+			EmitTurnCompleted(emit, "ok", 0, domain.TokenUsage{})
+			return domain.TurnResult{ExitReason: domain.EventTurnCompleted}, nil
+		}
+		sess := NewForkPerTurnSession(target, hooks, slog.New(spy))
+		sess.drainGrace = 50 * time.Millisecond // ten times shorter than the subprocess lifetime
+
+		emit, _ := sinkEvents()
+		_, err := sess.RunTurn(context.Background(), "p", emit)
+
+		if err != nil {
+			t.Fatalf("RunTurn() error = %v, want nil", err)
+		}
+
+		wantStderrLines := []string{"long turn stderr"}
+		if !slices.Equal(gotStderrLines, wantStderrLines) {
+			t.Errorf("OnFinalize stderrLines = %v, want %v", gotStderrLines, wantStderrLines)
+		}
+
+		for _, e := range spy.Entries() {
+			if e.Level == slog.LevelWarn && e.Msg == "agent stderr was not fully collected before the process was reaped" {
+				t.Errorf("unexpected abandonment WARN record emitted on a turn that outlived drainGrace: %+v", e)
+			}
+		}
+	})
+
+	t.Run("Bound_OrdinaryTurnStderrUnmodified", func(t *testing.T) {
+		t.Parallel()
+		tmpDir := t.TempDir()
+		script := agenttest.WriteScript(t, tmpDir, "agent", `echo 'first stderr line' >&2
+echo 'second stderr line' >&2`)
+		target := newTestTarget(tmpDir, script)
+
+		var gotStderrLines []string
+		hooks := noopHooks()
+		hooks.OnFinalize = func(emit func(domain.AgentEvent), lastParsed any, exitCode int, stderrLines []string) (domain.TurnResult, *domain.AgentError) {
+			gotStderrLines = stderrLines
+			EmitTurnCompleted(emit, "ok", 0, domain.TokenUsage{})
+			return domain.TurnResult{ExitReason: domain.EventTurnCompleted}, nil
+		}
+		sess := NewForkPerTurnSession(target, hooks, slog.Default())
+
+		emit, _ := sinkEvents()
+		_, err := sess.RunTurn(context.Background(), "p", emit)
+
+		if err != nil {
+			t.Fatalf("RunTurn() error = %v, want nil", err)
+		}
+
+		wantStderrLines := []string{"first stderr line", "second stderr line"}
+		if !slices.Equal(gotStderrLines, wantStderrLines) {
+			t.Errorf("OnFinalize stderrLines = %v, want %v", gotStderrLines, wantStderrLines)
 		}
 	})
 

--- a/internal/agent/agentcore/forkperturn_unix_test.go
+++ b/internal/agent/agentcore/forkperturn_unix_test.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/sortie-ai/sortie/internal/agent/agenttest"
+	"github.com/sortie-ai/sortie/internal/domain"
 )
 
 // writePgidScript creates a script that spawns a long-running grandchild
@@ -32,6 +33,24 @@ func writePgidScript(t *testing.T, dir, pidFile string) string {
 		pidFile,
 	)
 	return agenttest.WriteScript(t, dir, "agent-pgid", content)
+}
+
+// writeStderrOnlyDescendantScript creates a script whose background job
+// redirects its own stdout away, so it inherits the parent script's stderr
+// handle only, and whose parent writes a stderr line of its own, the
+// descendant PID, and the notification line, then exits normally instead of
+// sleeping. Using agenttest.WriteScript avoids the ETXTBSY race on Linux.
+func writeStderrOnlyDescendantScript(t *testing.T, dir, pidFile string) string {
+	t.Helper()
+	content := fmt.Sprintf(
+		"printf '%%s\\n' 'direct child stderr' >&2\n"+
+			"sleep 3600 >/dev/null &\n"+
+			"CHILD_PID=$!\n"+
+			"printf '%%s\\n' \"$CHILD_PID\" > '%s'\n"+
+			"printf '{\"type\":\"notification\"}\\n'\n",
+		pidFile,
+	)
+	return agenttest.WriteScript(t, dir, "agent-stderr-only-descendant", content)
 }
 
 // pollPgidFile polls pidFile until it contains a valid positive integer
@@ -112,4 +131,69 @@ func TestForkPerTurnSession_ProcessGroupIsolation(t *testing.T) {
 	<-done
 
 	assertPgidProcessDead(t, grandchildPID, 3*time.Second)
+}
+
+// TestForkPerTurnSession_DescendantHoldsStderrOnly verifies that a
+// descendant which inherits only the stderr handle, and whose direct parent
+// exits normally rather than blocking, no longer wedges RunTurn. Reaping the
+// direct child releases the stderr drain on this platform, so the turn
+// delivers the direct child's real stderr lines rather than
+// procutil.AbandonedMarker, follows the subprocess's actual exit code
+// instead of reporting a cancellation, and the surviving descendant is
+// still cleaned up.
+func TestForkPerTurnSession_DescendantHoldsStderrOnly(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	pidFile := filepath.Join(tmpDir, "descendant.pid")
+	script := writeStderrOnlyDescendantScript(t, tmpDir, pidFile)
+
+	var gotStderrLines []string
+	hooks := noopHooks()
+	hooks.OnFinalize = func(emit func(domain.AgentEvent), lastParsed any, exitCode int, stderrLines []string) (domain.TurnResult, *domain.AgentError) {
+		gotStderrLines = stderrLines
+		EmitTurnCompleted(emit, "ok", 0, domain.TokenUsage{})
+		return domain.TurnResult{ExitReason: domain.EventTurnCompleted}, nil
+	}
+
+	target := newTestTarget(tmpDir, script)
+	sess := NewForkPerTurnSession(target, hooks, slog.Default())
+	sess.drainGrace = 200 * time.Millisecond
+
+	emit, events := sinkEvents()
+	type outcome struct {
+		result domain.TurnResult
+		err    error
+	}
+	done := make(chan outcome, 1)
+	go func() {
+		result, err := sess.RunTurn(context.Background(), "p", emit)
+		done <- outcome{result, err}
+	}()
+
+	descendantPID := pollPgidFile(t, pidFile, 5*time.Second)
+
+	var got outcome
+	select {
+	case got = <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("RunTurn did not return within 10s")
+	}
+
+	if got.err != nil {
+		t.Fatalf("RunTurn() error = %v, want nil", got.err)
+	}
+	if got.result.ExitReason != domain.EventTurnCompleted {
+		t.Errorf("TurnResult.ExitReason = %q, want %q", got.result.ExitReason, domain.EventTurnCompleted)
+	}
+	if !hasEventType(*events, domain.EventTurnCompleted) {
+		t.Errorf("EventTurnCompleted not emitted; got %v", *events)
+	}
+
+	wantStderrLines := []string{"direct child stderr"}
+	if len(gotStderrLines) != len(wantStderrLines) || gotStderrLines[0] != wantStderrLines[0] {
+		t.Errorf("OnFinalize stderrLines = %v, want %v", gotStderrLines, wantStderrLines)
+	}
+
+	assertPgidProcessDead(t, descendantPID, 3*time.Second)
 }

--- a/internal/agent/kiro/parse_test.go
+++ b/internal/agent/kiro/parse_test.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/sortie-ai/sortie/internal/agent/agentcore"
+	"github.com/sortie-ai/sortie/internal/agent/procutil"
 	"github.com/sortie-ai/sortie/internal/domain"
 )
 
@@ -103,6 +105,12 @@ func TestClassifyStderr(t *testing.T) {
 			name:           "credits trailer embedded mid-line",
 			lines:          []string{"trailing noise ▸ Credits: 1.20 • Time: 12s done"},
 			wantCredits:    true,
+			wantAuthFailed: false,
+		},
+		{
+			name:           "abandonment marker is not evidence",
+			lines:          []string{procutil.AbandonedMarker},
+			wantCredits:    false,
 			wantAuthFailed: false,
 		},
 	}
@@ -210,4 +218,41 @@ func TestResumePath(t *testing.T) {
 		turn2Args := buildArgs(state, 2, "second", state.passthrough)
 		assertNoToken(t, turn2Args, "--resume")
 	})
+}
+
+// TestOnFinalize_MarkerOnlyStderrSelectsZeroWorkRow pins the disposition
+// consequence of an abandoned stderr drain: marker-only stderr classifies
+// as neither the credits trailer nor an authentication failure, so the
+// evidence StartSession's OnFinalize closure builds from it selects the
+// shared decision's zero-work row and reports turn_failed rather than a
+// success. An end-to-end kiro turn is not exercised here because
+// drainGrace is unexported and this package cannot inject a short bound.
+func TestOnFinalize_MarkerOnlyStderrSelectsZeroWorkRow(t *testing.T) {
+	t.Parallel()
+
+	creditsSeen, authFailed := classifyStderr([]string{procutil.AbandonedMarker})
+	if creditsSeen || authFailed {
+		t.Fatalf("classifyStderr(%v) = (creditsSeen=%v, authFailed=%v), want (false, false)",
+			procutil.AbandonedMarker, creditsSeen, authFailed)
+	}
+
+	// Mirrors the TurnEvidence StartSession's OnFinalize closure builds in
+	// kiro.go: neither the success nor the auth-failure switch arm matches
+	// when creditsSeen and authFailed are both false, so Terminal stays
+	// TerminalAbsent and the shared table decides from ExitCode and Work.
+	ev := agentcore.TurnEvidence{
+		ExitObserved: true,
+		ExitCode:     0,
+		Work:         agentcore.WorkUnobservable,
+		WorkDetail:   "no credits trailer on stderr",
+	}
+
+	got := agentcore.DecideTurn(ev)
+
+	if got.Row != agentcore.RowZeroWork {
+		t.Errorf("DecideTurn(%+v).Row = %v, want %v", ev, got.Row, agentcore.RowZeroWork)
+	}
+	if got.ExitReason != domain.EventTurnFailed {
+		t.Errorf("DecideTurn(%+v).ExitReason = %q, want %q", ev, got.ExitReason, domain.EventTurnFailed)
+	}
 }

--- a/internal/agent/opencode/opencode.go
+++ b/internal/agent/opencode/opencode.go
@@ -279,7 +279,7 @@ func (a *OpenCodeAdapter) RunTurn(ctx context.Context, session domain.Session, p
 
 	runtime.stderrCollector = procutil.NewStderrCollector(stderrPipe, logger)
 	startOpenCodeReader(stdoutPipe, runtime)
-	startWait(runtime, cmd)
+	startWait(runtime, cmd, procutil.DefaultDrainGrace)
 
 	emit := func(event domain.AgentEvent) {
 		if state.target.RemoteCommand == "" {
@@ -712,20 +712,31 @@ func startOpenCodeReader(stdout io.Reader, runtime *turnRuntime) {
 	}()
 }
 
-func startWait(runtime *turnRuntime, cmd *exec.Cmd) {
+// startWait reaps the turn's subprocess. grace bounds the wait for the
+// turn's stderr drain, once before cmd.Wait is called and once after
+// the process group is killed.
+func startWait(runtime *turnRuntime, cmd *exec.Cmd, grace time.Duration) {
 	go func() {
-		// Wait for both reader goroutines to finish before calling
-		// cmd.Wait(). cmd.Wait() closes the stdout and stderr pipe read
-		// ends after reaping the process, which races with a scanner
-		// still reading buffered output on either stream if called
-		// first; for stderr this can silently drop a permission-refusal
-		// warning that finalizeExitedTurn depends on.
+		// Wait for the stdout reader to finish before calling cmd.Wait().
+		// cmd.Wait() closes the stdout and stderr pipe read ends after
+		// reaping the process, which races with a scanner still reading
+		// buffered output on either stream if called first; for stderr
+		// this can silently drop a permission-refusal warning that
+		// finalizeExitedTurn depends on. The stderr wait is bounded so a
+		// descendant that inherits the stderr handle and outlives the
+		// direct child cannot withhold the reap.
 		<-runtime.readerDone
-		<-runtime.stderrCollector.Done()
+		drained := runtime.stderrCollector.WaitDone(grace)
 
 		waitErr := cmd.Wait()
 		procutil.KillProcessGroup(cmd.Process.Pid) //nolint:errcheck,gosec // best-effort cleanup of surviving group members
 		procutil.CleanupProcess(cmd.Process.Pid)
+
+		if !drained {
+			if !runtime.stderrCollector.WaitDone(grace) {
+				runtime.stderrCollector.Abandon(grace)
+			}
+		}
 
 		runtime.waitMu.Lock()
 		runtime.waitRes = waitResult{

--- a/internal/agent/opencode/opencode_test.go
+++ b/internal/agent/opencode/opencode_test.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -1728,18 +1729,137 @@ fi`, counterFile, counterFile))
 // on a synchronization primitive the test controls outright, so the guard
 // under test either blocks forever or doesn't - no timing luck involved.
 //
-// With the guard in place, startWait's goroutine cannot reach cmd.Wait
-// while the pipe is held open, so runtime.waitCh must still be open after
-// a generous bounded wait. Removing the
-// "<-runtime.stderrCollector.Done()" line in startWait lets the goroutine
-// call cmd.Wait immediately after readerDone closes; since the underlying
+// The first arm keeps the pipe open under a 5-second grace: startWait's
+// goroutine cannot reach cmd.Wait while the pipe is held open, so
+// runtime.waitCh must still be open after a generous bounded wait.
+// Removing the WaitDone guard in startWait lets the goroutine call
+// cmd.Wait immediately after readerDone closes; since the underlying
 // process ("true") has already exited, waitCh closes within a few
 // milliseconds, deterministically failing the first select below.
+//
+// The second arm never closes the pipe at all, under a 100-millisecond
+// grace: startWait must still close waitCh, with a real waitResult built
+// from cmd.Wait rather than a synthesized one, and the abandoned
+// collector must report [procutil.AbandonedMarker] rather than block.
 func TestStartWait_BlocksOnStderrDrainBeforeCmdWait(t *testing.T) {
 	t.Parallel()
 
+	t.Run("stderr drain held open blocks the wait", func(t *testing.T) {
+		t.Parallel()
+
+		pr, pw := io.Pipe()
+		collector := procutil.NewStderrCollector(pr, slog.Default())
+
+		cmd := exec.Command("true")
+		procutil.SetProcessGroup(cmd)
+		if err := cmd.Start(); err != nil {
+			t.Fatalf("cmd.Start() = %v", err)
+		}
+
+		readerDone := make(chan struct{})
+		close(readerDone)
+
+		runtime := &turnRuntime{
+			readerDone:      readerDone,
+			stderrCollector: collector,
+			waitCh:          make(chan waitResult, 1),
+		}
+
+		startWait(runtime, cmd, 5*time.Second)
+
+		select {
+		case <-runtime.waitCh:
+			t.Fatal("startWait closed waitCh before the stderr drain finished; " +
+				"the WaitDone guard is missing or bypassed")
+		case <-time.After(300 * time.Millisecond):
+		}
+
+		if err := pw.Close(); err != nil {
+			t.Fatalf("pw.Close() = %v", err)
+		}
+
+		select {
+		case <-runtime.waitCh:
+		case <-time.After(5 * time.Second):
+			t.Fatal("startWait did not close waitCh after the stderr drain finished")
+		}
+	})
+
+	t.Run("stderr drain never reaching EOF is abandoned within the grace", func(t *testing.T) {
+		t.Parallel()
+
+		pr, pw := io.Pipe()
+		t.Cleanup(func() { _ = pw.Close() })
+		collector := procutil.NewStderrCollector(pr, slog.Default())
+
+		cmd := exec.Command("true")
+		procutil.SetProcessGroup(cmd)
+		if err := cmd.Start(); err != nil {
+			t.Fatalf("cmd.Start() = %v", err)
+		}
+
+		readerDone := make(chan struct{})
+		close(readerDone)
+
+		runtime := &turnRuntime{
+			readerDone:      readerDone,
+			stderrCollector: collector,
+			waitCh:          make(chan waitResult, 1),
+		}
+
+		startWait(runtime, cmd, 100*time.Millisecond)
+
+		select {
+		case <-runtime.waitCh:
+		case <-time.After(5 * time.Second):
+			t.Fatal("startWait did not close waitCh within 5 seconds of a stderr drain that never reaches EOF")
+		}
+
+		runtime.waitMu.Lock()
+		got := runtime.waitRes
+		runtime.waitMu.Unlock()
+		if got.exitCode != 0 || got.err != nil {
+			t.Errorf("waitResult = {exitCode: %d, err: %v}, want {exitCode: 0, err: nil}", got.exitCode, got.err)
+		}
+
+		linesCh := make(chan []string, 1)
+		go func() { linesCh <- collector.Lines() }()
+		select {
+		case lines := <-linesCh:
+			if want := []string{procutil.AbandonedMarker}; !slices.Equal(lines, want) {
+				t.Errorf("Lines() after abandonment = %v, want %v", lines, want)
+			}
+		case <-time.After(1 * time.Second):
+			t.Fatal("Lines() did not return the abandonment marker within 1 second")
+		}
+	})
+}
+
+// TestStartWait_NoBoundFiresOnLongTurn pins that a turn whose stdout reader
+// outlives the stderr grace is not mistaken for an abandoned drain. The
+// stderr write end is closed synchronously before startWait is invoked, so
+// the drain has already finished by the time the grace would matter; this
+// removes any dependency on a goroutine being scheduled inside the short
+// grace window. runtime.readerDone closes only after 300 milliseconds, so
+// the wait-channel assertion at 200 milliseconds catches an implementation
+// that anchors the stderr bound on anything earlier than that close.
+func TestStartWait_NoBoundFiresOnLongTurn(t *testing.T) {
+	// No t.Parallel(): installs a global slog default.
+	spy := agenttest.InstallLogSpy(t)
+
 	pr, pw := io.Pipe()
 	collector := procutil.NewStderrCollector(pr, slog.Default())
+	if _, err := io.WriteString(pw, "stderr line\n"); err != nil {
+		t.Fatalf("pw.Write(stderr line) = %v", err)
+	}
+	if err := pw.Close(); err != nil {
+		t.Fatalf("pw.Close() = %v", err)
+	}
+	select {
+	case <-collector.Done():
+	case <-time.After(1 * time.Second):
+		t.Fatal("collector.Done() did not close after the write end was closed")
+	}
 
 	cmd := exec.Command("true")
 	procutil.SetProcessGroup(cmd)
@@ -1748,7 +1868,10 @@ func TestStartWait_BlocksOnStderrDrainBeforeCmdWait(t *testing.T) {
 	}
 
 	readerDone := make(chan struct{})
-	close(readerDone)
+	go func() {
+		time.Sleep(300 * time.Millisecond)
+		close(readerDone)
+	}()
 
 	runtime := &turnRuntime{
 		readerDone:      readerDone,
@@ -1756,22 +1879,29 @@ func TestStartWait_BlocksOnStderrDrainBeforeCmdWait(t *testing.T) {
 		waitCh:          make(chan waitResult, 1),
 	}
 
-	startWait(runtime, cmd)
+	startWait(runtime, cmd, 50*time.Millisecond)
 
 	select {
 	case <-runtime.waitCh:
-		t.Fatal("startWait closed waitCh before the stderr drain finished; " +
-			"the <-runtime.stderrCollector.Done() guard is missing or bypassed")
-	case <-time.After(300 * time.Millisecond):
-	}
-
-	if err := pw.Close(); err != nil {
-		t.Fatalf("pw.Close() = %v", err)
+		t.Fatal("startWait closed waitCh before runtime.readerDone closed; " +
+			"the wait on the stdout reader must stay unbounded")
+	case <-time.After(200 * time.Millisecond):
 	}
 
 	select {
 	case <-runtime.waitCh:
 	case <-time.After(5 * time.Second):
-		t.Fatal("startWait did not close waitCh after the stderr drain finished")
+		t.Fatal("startWait did not close waitCh after runtime.readerDone closed")
+	}
+
+	for _, e := range spy.Entries() {
+		if e.Level == slog.LevelWarn && e.Msg == "agent stderr was not fully collected before the process was reaped" {
+			t.Errorf("startWait() emitted an abandonment warning on a turn that outlived the grace; entry = %+v", e)
+		}
+	}
+
+	want := []string{"stderr line"}
+	if got := collector.Lines(); !slices.Equal(got, want) {
+		t.Errorf("Lines() = %v, want %v", got, want)
 	}
 }

--- a/internal/agent/opencode/opencode_test.go
+++ b/internal/agent/opencode/opencode_test.go
@@ -1748,6 +1748,7 @@ func TestStartWait_BlocksOnStderrDrainBeforeCmdWait(t *testing.T) {
 		t.Parallel()
 
 		pr, pw := io.Pipe()
+		t.Cleanup(func() { _ = pw.Close() })
 		collector := procutil.NewStderrCollector(pr, slog.Default())
 
 		cmd := exec.Command("true")

--- a/internal/agent/opencode/parse_test.go
+++ b/internal/agent/opencode/parse_test.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/sortie-ai/sortie/internal/agent/procutil"
 )
 
 // loadFixture reads testdata/<name> and returns its bytes.
@@ -175,6 +177,19 @@ func TestParseRunEvent_InvalidJSON(t *testing.T) {
 	_, err := parseRunEvent([]byte("not valid json"))
 	if err == nil {
 		t.Fatal("parseRunEvent(invalid) error = nil, want error")
+	}
+}
+
+// TestIsPermissionWarning_AbandonedMarkerIsNotAWarning pins that the stderr
+// abandonment marker can never be mistaken for a permission-refusal
+// warning. It references [procutil.AbandonedMarker] rather than a copy of
+// its text, so a future change to the marker cannot leave this guard
+// passing on stale text.
+func TestIsPermissionWarning_AbandonedMarkerIsNotAWarning(t *testing.T) {
+	t.Parallel()
+
+	if isPermissionWarning(procutil.AbandonedMarker) {
+		t.Errorf("isPermissionWarning(%q) = true, want false", procutil.AbandonedMarker)
 	}
 }
 

--- a/internal/agent/procutil/procutil.go
+++ b/internal/agent/procutil/procutil.go
@@ -9,6 +9,8 @@ import (
 	"io"
 	"log/slog"
 	"os/exec"
+	"sync"
+	"time"
 )
 
 const (
@@ -24,6 +26,16 @@ const (
 	// DefaultMaxBytes is the total byte budget for retained stderr
 	// lines across head and tail combined.
 	DefaultMaxBytes = 5 * 1024 * 1024
+
+	// DefaultDrainGrace is the time an adapter waits for a stderr drain
+	// to finish before it reaps the subprocess without it, and again
+	// before it gives up on the drain and reads the collector anyway.
+	DefaultDrainGrace = 5 * time.Second
+
+	// AbandonedMarker replaces the collected lines of a collector whose
+	// drain was abandoned. It is exported so an adapter that classifies
+	// stderr can pin, in its own tests, that the marker is not evidence.
+	AbandonedMarker = "... (agent stderr not collected: the output handle stayed open) ..."
 
 	droppedMarkerFmt = "... (%d lines discarded) ..."
 )
@@ -109,6 +121,13 @@ type StderrCollector struct {
 	scannerMax int
 	done       chan struct{}
 	logger     *slog.Logger
+
+	// abandonOnce guards the single transition into the abandoned state.
+	abandonOnce sync.Once
+
+	// abandoned closes when Abandon gives up on the drain goroutine.
+	// Readers select on it alongside done.
+	abandoned chan struct{}
 }
 
 // NewStderrCollector starts a goroutine that drains r line by line,
@@ -150,6 +169,7 @@ func NewStderrCollector(r io.Reader, logger *slog.Logger, opts ...CollectorOptio
 		scannerMax: cfg.scannerMax,
 		done:       make(chan struct{}),
 		logger:     logger,
+		abandoned:  make(chan struct{}),
 	}
 	go c.drain(r)
 	return c
@@ -204,21 +224,93 @@ func (c *StderrCollector) drain(r io.Reader) {
 // collected lines are available.
 //
 // A caller that owns the underlying [*exec.Cmd] and created the reader
-// via [exec.Cmd.StderrPipe] must wait on Done before calling
+// via [exec.Cmd.StderrPipe] waits for the drain before calling
 // [exec.Cmd.Wait]: Wait reaps the process and then closes the pipe's
 // read end, which races with a concurrent read in the drain goroutine
 // and can make it return early, silently discarding stderr lines that
-// were still buffered in the pipe.
+// were still buffered in the pipe. [StderrCollector.WaitDone] bounds
+// that wait; a caller that gives up on it reaps the process anyway and
+// falls back to [StderrCollector.Abandon] so a later reader does not
+// block.
 func (c *StderrCollector) Done() <-chan struct{} {
 	return c.done
 }
 
-// Lines blocks until the drain goroutine finishes and returns all
-// collected stderr lines in chronological order. When lines were
-// discarded, a synthetic marker line is inserted between the head and
-// tail sections. Safe to call after the subprocess has exited.
+// WaitDone waits up to d for the drain goroutine to finish and reports
+// whether it finished. It has no side effect: a false return leaves the
+// collector exactly as it was.
+//
+// A non-positive d polls once rather than waiting unboundedly.
+func (c *StderrCollector) WaitDone(d time.Duration) bool {
+	select {
+	case <-c.done:
+		return true
+	default:
+	}
+	if d <= 0 {
+		return false
+	}
+
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-c.done:
+		return true
+	case <-timer.C:
+		select {
+		case <-c.done:
+			return true
+		default:
+			return false
+		}
+	}
+}
+
+// Abandon gives up on a drain that a bounded wait did not finish, so
+// that Lines, Dropped, and WarnLines stop blocking on it. bound is the
+// wait that elapsed, reported with the warning Abandon logs.
+//
+// Abandon is a one-shot latch: only the first call across the
+// collector's lifetime has any effect, whatever the number of
+// concurrent or repeated calls. It returns without blocking, and does
+// nothing when the drain has already finished, so a drain that ends
+// between the caller's bounded wait and its Abandon call produces no
+// warning about output that was in fact collected.
+func (c *StderrCollector) Abandon(bound time.Duration) {
+	c.abandonOnce.Do(func() {
+		select {
+		case <-c.done:
+			return
+		default:
+		}
+		c.logger.Warn("agent stderr was not fully collected before the process was reaped",
+			slog.Duration("drain_bound", bound))
+		close(c.abandoned)
+	})
+}
+
+// Lines blocks until the drain goroutine finishes or the collector is
+// abandoned, whichever comes first, and returns all collected stderr
+// lines in chronological order. When lines were discarded, a synthetic
+// marker line is inserted between the head and tail sections. Safe to
+// call after the subprocess has exited.
+//
+// When the collector was abandoned before the drain finished, Lines
+// returns a single-element slice containing [AbandonedMarker] instead
+// of blocking. A drain that finishes after abandonment still wins: a
+// later call, or one already blocked when abandonment happened, reports
+// the real lines rather than the marker.
 func (c *StderrCollector) Lines() []string {
-	<-c.done
+	select {
+	case <-c.done:
+	case <-c.abandoned:
+	}
+
+	select {
+	case <-c.done:
+	default:
+		return []string{AbandonedMarker}
+	}
 
 	hasTail := c.tailFull || c.tailPos > 0
 	if len(c.head) == 0 && !hasTail {
@@ -245,23 +337,40 @@ func (c *StderrCollector) Lines() []string {
 	return result
 }
 
-// Dropped blocks until the drain goroutine finishes and returns the
-// number of stderr lines discarded due to the line cap or byte budget.
+// Dropped blocks until the drain goroutine finishes or the collector is
+// abandoned, whichever comes first, and returns the number of stderr
+// lines discarded due to the line cap or byte budget.
+//
+// When the collector was abandoned before the drain finished, Dropped
+// returns 0. That zero reports an unknown count rather than an empty
+// one: an abandoned collector cannot know what the drain discarded.
 func (c *StderrCollector) Dropped() int {
-	<-c.done
-	return c.dropped
+	select {
+	case <-c.done:
+	case <-c.abandoned:
+	}
+
+	select {
+	case <-c.done:
+		return c.dropped
+	default:
+		return 0
+	}
 }
 
-// WarnLines blocks until the drain goroutine finishes, then re-emits
-// each collected line at WARN level using logger. Intended for
-// surfacing agent subprocess diagnostics (e.g., startup rejections)
-// without requiring DEBUG logging.
+// WarnLines blocks until the drain goroutine finishes or the collector
+// is abandoned, then re-emits each collected line at WARN level using
+// logger. Intended for surfacing agent subprocess diagnostics (e.g.,
+// startup rejections) without requiring DEBUG logging.
 //
-// Callers that manage an [*exec.Cmd] MUST call [StderrCollector.Lines]
-// before calling [exec.Cmd.Wait]; [exec.Cmd.Wait] closes the pipe read
-// end, which can prevent the drain goroutine from reading buffered data.
-// Use [EmitWarnLines] with the result of [StderrCollector.Lines] to log
-// pre-collected lines after [exec.Cmd.Wait] returns.
+// A caller that manages an [*exec.Cmd] and cannot use
+// [StderrCollector.WaitDone] still has the option of draining with
+// [StderrCollector.Lines] before calling [exec.Cmd.Wait]; [exec.Cmd.Wait]
+// closes the pipe read end, which can prevent the drain goroutine from
+// reading buffered data. A caller that can adopt the bounded wait
+// should prefer it instead, and use [EmitWarnLines] with the result of
+// [StderrCollector.Lines] to log pre-collected lines after
+// [exec.Cmd.Wait] returns.
 //
 // If logger is nil, WarnLines uses [slog.Default].
 func (c *StderrCollector) WarnLines(logger *slog.Logger) {

--- a/internal/agent/procutil/procutil_test.go
+++ b/internal/agent/procutil/procutil_test.go
@@ -694,10 +694,10 @@ func TestStderrCollector_WaitDonePolling(t *testing.T) {
 	})
 }
 
-// TestStderrCollector_AbandonmentPriority pins R1.9 in both directions: a
-// drain that finishes always outranks abandonment, whichever happened
-// first. It also pins the R1.5 skip: abandoning an already-finished drain
-// has no effect.
+// TestStderrCollector_AbandonmentPriority pins the precedence in both
+// directions: a drain that finishes always outranks abandonment,
+// whichever happened first. It also pins that abandoning an
+// already-finished drain has no effect.
 func TestStderrCollector_AbandonmentPriority(t *testing.T) {
 	t.Parallel()
 

--- a/internal/agent/procutil/procutil_test.go
+++ b/internal/agent/procutil/procutil_test.go
@@ -551,3 +551,224 @@ func TestStderrCollector_DoneClosesOnlyAfterDrainComplete(t *testing.T) {
 		t.Fatalf("Lines() after Done() closed = %v, want %v", got, want)
 	}
 }
+
+// TestStderrCollector_WaitDoneHealthyDrain pins the healthy path: a drain
+// that reaches EOF is never abandoned.
+func TestStderrCollector_WaitDoneHealthyDrain(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+
+	c := NewStderrCollector(strings.NewReader("startup ok\n"), logger)
+
+	start := time.Now()
+	if !c.WaitDone(DefaultDrainGrace) {
+		t.Fatalf("WaitDone(%v) = false, want true", DefaultDrainGrace)
+	}
+	if elapsed := time.Since(start); elapsed >= DefaultDrainGrace {
+		t.Errorf("WaitDone(%v) took %v, want well under the bound", DefaultDrainGrace, elapsed)
+	}
+
+	want := []string{"startup ok"}
+	if got := c.Lines(); !slices.Equal(got, want) {
+		t.Errorf("Lines() = %v, want %v", got, want)
+	}
+	if strings.Contains(buf.String(), "not fully collected") {
+		t.Errorf("WaitDone() on a completed drain logged an abandonment warning; output = %q", buf.String())
+	}
+}
+
+// TestStderrCollector_AbandonAfterWaitDoneTimeout drives WaitDone and Abandon
+// over an io.Pipe whose write end the test holds open, so the drain goroutine
+// is still running (blocked in Read) while the abandoned readers run
+// concurrently with it. The race detector is the evidence that the abandoned
+// path reads none of the drain goroutine's state.
+func TestStderrCollector_AbandonAfterWaitDoneTimeout(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+
+	pr, pw := io.Pipe()
+	t.Cleanup(func() { _ = pw.Close() })
+	c := NewStderrCollector(pr, logger)
+
+	const bound = 50 * time.Millisecond
+
+	if c.WaitDone(bound) {
+		t.Fatal("WaitDone() = true over a pipe whose write end the test holds open, want false")
+	}
+	if buf.Len() != 0 {
+		t.Errorf("WaitDone() over an unfinished drain logged output; want none; got %q", buf.String())
+	}
+
+	c.Abandon(bound)
+	afterFirst := buf.String()
+	if !strings.Contains(afterFirst, "not fully collected") {
+		t.Errorf("Abandon() did not log the abandonment warning; output = %q", afterFirst)
+	}
+	if !strings.Contains(afterFirst, "drain_bound") {
+		t.Errorf("Abandon() warning missing the drain_bound attribute; output = %q", afterFirst)
+	}
+
+	c.Abandon(bound)
+	if got := buf.String(); got != afterFirst {
+		t.Errorf("second Abandon() call logged another record; output = %q", got)
+	}
+
+	select {
+	case <-c.Done():
+		t.Error("Done() closed after Abandon(); want it to stay open until the drain finishes")
+	default:
+	}
+
+	type readerResult struct {
+		lines   []string
+		dropped int
+	}
+	resCh := make(chan readerResult, 1)
+	go func() {
+		resCh <- readerResult{lines: c.Lines(), dropped: c.Dropped()}
+	}()
+
+	var res readerResult
+	select {
+	case res = <-resCh:
+	case <-time.After(1 * time.Second):
+		t.Fatal("Lines()/Dropped() blocked more than 1 second after Abandon()")
+	}
+	if want := []string{AbandonedMarker}; !slices.Equal(res.lines, want) {
+		t.Errorf("Lines() after Abandon() = %v, want %v", res.lines, want)
+	}
+	if res.dropped != 0 {
+		t.Errorf("Dropped() after Abandon() = %d, want 0", res.dropped)
+	}
+
+	warnDone := make(chan struct{})
+	go func() {
+		c.WarnLines(logger)
+		close(warnDone)
+	}()
+	select {
+	case <-warnDone:
+	case <-time.After(1 * time.Second):
+		t.Fatal("WarnLines() blocked more than 1 second after Abandon()")
+	}
+	if !strings.Contains(buf.String(), AbandonedMarker) {
+		t.Errorf("WarnLines() after Abandon() did not emit the marker; output = %q", buf.String())
+	}
+}
+
+// TestStderrCollector_WaitDonePolling pins the poll semantics of a
+// non-positive duration: it reports the current state immediately rather
+// than waiting, whatever that state is.
+func TestStderrCollector_WaitDonePolling(t *testing.T) {
+	t.Parallel()
+
+	t.Run("finished drain", func(t *testing.T) {
+		t.Parallel()
+
+		c := NewStderrCollector(strings.NewReader("done\n"), slog.Default())
+		<-c.Done()
+
+		for _, d := range []time.Duration{0, -1 * time.Millisecond} {
+			if !c.WaitDone(d) {
+				t.Errorf("WaitDone(%v) on a finished drain = false, want true", d)
+			}
+		}
+	})
+
+	t.Run("unfinished drain", func(t *testing.T) {
+		t.Parallel()
+
+		pr, pw := io.Pipe()
+		t.Cleanup(func() { _ = pw.Close() })
+		c := NewStderrCollector(pr, slog.Default())
+
+		for _, d := range []time.Duration{0, -1 * time.Millisecond} {
+			if c.WaitDone(d) {
+				t.Errorf("WaitDone(%v) on an unfinished drain = true, want false", d)
+			}
+		}
+	})
+}
+
+// TestStderrCollector_AbandonmentPriority pins R1.9 in both directions: a
+// drain that finishes always outranks abandonment, whichever happened
+// first. It also pins the R1.5 skip: abandoning an already-finished drain
+// has no effect.
+func TestStderrCollector_AbandonmentPriority(t *testing.T) {
+	t.Parallel()
+
+	t.Run("lines call already blocked returns the marker", func(t *testing.T) {
+		t.Parallel()
+
+		pr, pw := io.Pipe()
+		t.Cleanup(func() { _ = pw.Close() })
+		c := NewStderrCollector(pr, slog.Default())
+
+		resCh := make(chan []string, 1)
+		go func() { resCh <- c.Lines() }()
+		time.Sleep(50 * time.Millisecond)
+		c.Abandon(50 * time.Millisecond)
+
+		select {
+		case got := <-resCh:
+			if want := []string{AbandonedMarker}; !slices.Equal(got, want) {
+				t.Errorf("Lines() blocked before Abandon() = %v, want %v", got, want)
+			}
+		case <-time.After(1 * time.Second):
+			t.Fatal("Lines() call already blocked when Abandon() ran did not unblock within 1 second")
+		}
+	})
+
+	t.Run("drain finishing after abandonment wins on the next call", func(t *testing.T) {
+		t.Parallel()
+
+		pr, pw := io.Pipe()
+		c := NewStderrCollector(pr, slog.Default())
+
+		c.Abandon(50 * time.Millisecond)
+		if got := c.Lines(); !slices.Equal(got, []string{AbandonedMarker}) {
+			t.Fatalf("Lines() right after Abandon() = %v, want [%q]", got, AbandonedMarker)
+		}
+
+		if _, err := io.WriteString(pw, "real line\n"); err != nil {
+			t.Fatalf("pw.Write(real line) = %v", err)
+		}
+		if err := pw.Close(); err != nil {
+			t.Fatalf("pw.Close() = %v", err)
+		}
+
+		select {
+		case <-c.Done():
+		case <-time.After(5 * time.Second):
+			t.Fatal("Done() did not close after the reader reached EOF")
+		}
+
+		want := []string{"real line"}
+		if got := c.Lines(); !slices.Equal(got, want) {
+			t.Errorf("Lines() after the drain finished = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("abandon on an already-finished drain is a no-op", func(t *testing.T) {
+		t.Parallel()
+
+		var buf bytes.Buffer
+		logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+		c := NewStderrCollector(strings.NewReader("already collected\n"), logger)
+		<-c.Done()
+
+		c.Abandon(50 * time.Millisecond)
+
+		if buf.Len() != 0 {
+			t.Errorf("Abandon() on a finished drain logged output; want none; got %q", buf.String())
+		}
+		want := []string{"already collected"}
+		if got := c.Lines(); !slices.Equal(got, want) {
+			t.Errorf("Lines() after Abandon() on a finished drain = %v, want %v", got, want)
+		}
+	})
+}


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Fix

**Intent:** The `opencode` adapter's wait goroutine, and the shared per-turn skeleton (`agentcore.ForkPerTurnSession`) that `claude`, `copilot` and `kiro` drive their turns through, waited unboundedly for the stderr collector to reach EOF before calling `cmd.Wait()`. A descendant process that inherited the stderr handle and outlived the direct child kept the collector from ever seeing EOF, so `cmd.Wait()` was never reached, the process group was never killed, and the turn's result was never published. This bounds that wait so a stuck stderr drain can no longer withhold the reap, the process-group cleanup, or the turn outcome.

**Related Issues:** #918

### 🧭 Reviewer Guide

**Complexity:** Medium

#### Entry Point

`internal/agent/procutil/procutil.go` is where the bound itself lives - it is the shared helper both `internal/agent/agentcore/forkperturn.go` and `internal/agent/opencode/opencode.go` call into before reaping. Start there to see the bounded wait and the abandonment marker it produces when the bound fires, then look at the two call sites to see how each adapter's wait-and-reap sequence now runs unblocked either way.

#### Sensitive Areas

- `internal/agent/procutil/procutil.go`: introduces the bound and the abandonment marker; a wrong bound value or a missed cleanup path here would reintroduce leaked goroutines and process groups under the same conditions this fix addresses.
- `internal/agent/agentcore/forkperturn.go`: the shared per-turn skeleton used by `claude`, `copilot`, and `kiro` - a regression here has family-wide reach rather than affecting a single adapter.
- `internal/agent/opencode/opencode.go`: the stdout-reader wait stays unbounded by design; only the stderr-collector wait is now bounded, so the two waits behave differently on purpose.
- `internal/agent/kiro/parse_test.go`: pins that a turn whose stderr could not be collected is now reported as failed rather than succeeded, since kiro's only positive proof of success is the credits trailer on stderr.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes. Turns whose stderr drain is abandoned now report failure (previously they hung indefinitely rather than reporting anything), which is a behavior change but not an API or config change.
- **Migrations/State:** No migrations or state changes.
