### PR TITLE
test: extend the adapter contract checker to agent and notify

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,8 +99,8 @@ linter enforces:
 - **Shared adapter helpers:** don't re-implement a helper already extracted to a shared
   package (`internal/httpkit`, `internal/typeutil`, `internal/issuekit`, or an
   adapter-family package like `internal/scm/scmcore`). A contract test in
-  `internal/adaptertest` fails `make test` if a tracker or SCM package re-declares one of
-  these under a local name.
+  `internal/adaptertest` fails `make test` if a tracker, SCM, agent, or notifier package
+  re-declares one of these under a local name.
 
 ## Testing conventions
 

--- a/internal/adaptertest/contract_test.go
+++ b/internal/adaptertest/contract_test.go
@@ -24,8 +24,11 @@ const contractRegistryImportPath = "github.com/sortie-ai/sortie/internal/registr
 const contractTrackermetricsImportPath = "github.com/sortie-ai/sortie/internal/trackermetrics"
 
 // contractBanTable maps a reimplementation this work extracted to the
-// shared owner a tracker or source-control package must call instead. A
-// top-level function re-declaring one of these names is a violation.
+// shared owner a package under any family root must call instead. A
+// top-level function re-declaring one of these names is a violation. The
+// owner named for an entry was extracted from a tracker or source-control
+// package and is not guaranteed to be the correct owner for a package in
+// another family.
 var contractBanTable = map[string]string{
 	"classifyTransportError": "httpkit.ClassifyTransport",
 	"withRetry":              "httpkit.RetryWithBackoff",
@@ -93,7 +96,7 @@ const (
 	contractOrchestratorPath  = "github.com/sortie-ai/sortie/internal/orchestrator"
 )
 
-// The two remaining family roots that hold kind packages, and the
+// The agent and notify family roots that hold kind packages, and the
 // module-internal prefix the permit-map guard strips to reach a
 // directory.
 const (
@@ -112,15 +115,32 @@ var contractFamilyRoots = []string{
 	contractNotifyFamilyPath,
 }
 
+// contractSharedPackage records why a package under a family root holds
+// no adapter, and whether the orchestrator's production code may import
+// it. Rule IMPORT consults presence alone; the core-import rule consults
+// coreImportable as well.
+type contractSharedPackage struct {
+	reason         string
+	coreImportable bool
+}
+
 // contractSharedFamilyPackages names each package under a family root that
 // holds no adapter, so it may be imported by a package under a family
-// root and by the orchestrator, and states why. Keys are matched exactly,
-// so a subpackage of a permitted package needs its own entry. A package
-// under a family root that is absent from this map may be imported only
-// by itself and by packages under its own path.
-var contractSharedFamilyPackages = map[string]string{
-	"github.com/sortie-ai/sortie/internal/scm/scmcore":    "shared forge decision core; registers no kind and holds no adapter",
-	"github.com/sortie-ai/sortie/internal/agent/procutil": "shared subprocess group handling; registers no kind and holds no adapter",
+// root, and states why. Keys are matched exactly, so a subpackage of a
+// permitted package needs its own entry. A package under a family root
+// that is absent from this map may be imported only by itself and by
+// packages under its own path. Whether the orchestrator may import an
+// entry too is a per-entry property: an entry whose coreImportable is
+// false stays importable by packages under a family root but not by the
+// orchestrator's production code.
+var contractSharedFamilyPackages = map[string]contractSharedPackage{
+	"github.com/sortie-ai/sortie/internal/scm/scmcore":                     {reason: "shared forge decision core; registers no kind and holds no adapter", coreImportable: true},
+	"github.com/sortie-ai/sortie/internal/agent/procutil":                  {reason: "shared subprocess group handling; registers no kind and holds no adapter", coreImportable: true},
+	"github.com/sortie-ai/sortie/internal/agent/agentcore":                 {reason: "shared agent session, event, and disposition core; registers no kind and holds no adapter", coreImportable: true},
+	"github.com/sortie-ai/sortie/internal/agent/mcpconfig":                 {reason: "shared MCP configuration parsing; registers no kind and holds no adapter", coreImportable: true},
+	"github.com/sortie-ai/sortie/internal/agent/sshutil":                   {reason: "shared SSH invocation helpers; registers no kind and holds no adapter", coreImportable: true},
+	"github.com/sortie-ai/sortie/internal/agent/agenttest":                 {reason: "shared agent-adapter test support; registers no kind and holds no adapter; its non-test files import testing, so production code must not reach it", coreImportable: false},
+	"github.com/sortie-ai/sortie/internal/agent/agenttest/dispositiontest": {reason: "shared turn-disposition conformance assertion, keyed separately because keys match exactly; registers no kind and holds no adapter; its non-test files import testing, so production code must not reach it", coreImportable: false},
 }
 
 // contractPackageBannedImports maps one package's import path to the
@@ -145,11 +165,12 @@ var contractAllowlist = map[string]map[contractRule]string{
 	},
 }
 
-// The two outcomes checkContractCoreImports renders as
+// The three outcomes checkContractCoreImports renders as
 // "imports " + path + "; " + reason.
 const (
 	contractCoreRegistryReason     = "the orchestrator resolves an adapter kind through the registry rather than importing its package"
 	contractCoreRegistrationReason = "cmd/sortie owns the blank imports that trigger kind registration"
+	contractCoreTestSupportReason  = "the orchestrator's production code must not import a test-support package"
 )
 
 // contractViolation describes one place a file or package breaks the
@@ -550,8 +571,14 @@ func contractCoreImportBanReason(importPath string, blankImport, inTestFile bool
 		return ""
 	}
 
-	if _, shared := contractSharedFamilyPackages[importPath]; shared {
-		return ""
+	if shared, ok := contractSharedFamilyPackages[importPath]; ok {
+		if shared.coreImportable {
+			return ""
+		}
+		if inTestFile {
+			return ""
+		}
+		return contractCoreTestSupportReason
 	}
 
 	if blankImport && inTestFile {
@@ -775,13 +802,14 @@ func contractWalkRoot(t *testing.T, fset *token.FileSet, dir, importPath string)
 	return walked, registryImported
 }
 
-// TestCheckAdapterContract walks the Go files under internal/tracker and
-// internal/scm, excluding testdata, and fails when any package breaks the
-// shared-decision invariant this work establishes: a re-declared
-// reimplementation of a name the ban table names, a domain.TrackerAdapter
-// method that does not record through trackermetrics.Track, a direct
-// call to IncTrackerRequests, a tracker-registering package supplying no
-// config validation hook, or an import rule IMPORT rejects.
+// TestCheckAdapterContract walks the Go files under internal/tracker,
+// internal/scm, internal/agent, and internal/notify, excluding testdata,
+// and fails when any package breaks the shared-decision invariant this
+// work establishes: a re-declared reimplementation of a name the ban
+// table names, a domain.TrackerAdapter method that does not record
+// through trackermetrics.Track, a direct call to IncTrackerRequests, a
+// tracker-registering package supplying no config validation hook, or an
+// import rule IMPORT rejects.
 func TestCheckAdapterContract(t *testing.T) {
 	fset := token.NewFileSet()
 
@@ -791,18 +819,17 @@ func TestCheckAdapterContract(t *testing.T) {
 	}{
 		{filepath.Join("..", "tracker"), contractTrackerFamilyPath},
 		{filepath.Join("..", "scm"), contractSCMFamilyPath},
+		{filepath.Join("..", "agent"), contractAgentFamilyPath},
+		{filepath.Join("..", "notify"), contractNotifyFamilyPath},
 	}
 
 	var walked []contractWalkedPackage
-	registryImported := false
 	for _, root := range roots {
 		rootWalked, rootRegistryImported := contractWalkRoot(t, fset, root.dir, root.importPath)
+		if !rootRegistryImported {
+			t.Fatalf("no parsed file under %s imports %s, want at least one", root.importPath, contractRegistryImportPath)
+		}
 		walked = append(walked, rootWalked...)
-		registryImported = registryImported || rootRegistryImported
-	}
-
-	if !registryImported {
-		t.Fatalf("no parsed file under either root imports %s, want at least one", contractRegistryImportPath)
 	}
 
 	sort.Slice(walked, func(i, j int) bool { return walked[i].dir < walked[j].dir })
@@ -1148,6 +1175,51 @@ func markUnresolved(issue *domain.Issue) {
 `,
 			wantCount: 0,
 		},
+		{
+			name:       "a notifier backend importing a sibling notifier backend is rejected",
+			dirName:    "slack",
+			importPath: "github.com/sortie-ai/sortie/internal/notify/slack",
+			src: `package fixture
+
+import "github.com/sortie-ai/sortie/internal/notify/webhook"
+`,
+			wantCount: 1,
+		},
+		{
+			name:       "a notifier backend importing the orchestrator is rejected",
+			dirName:    "webhook",
+			importPath: "github.com/sortie-ai/sortie/internal/notify/webhook",
+			src: `package fixture
+
+import "github.com/sortie-ai/sortie/internal/orchestrator"
+`,
+			wantCount: 1,
+		},
+		{
+			name:       "an agent kind package importing a sibling agent kind package is rejected",
+			dirName:    "codex",
+			importPath: "github.com/sortie-ai/sortie/internal/agent/codex",
+			src: `package fixture
+
+import "github.com/sortie-ai/sortie/internal/agent/claude"
+`,
+			wantCount: 1,
+		},
+		{
+			name:       "an agent kind package importing the permitted shared packages is accepted",
+			dirName:    "codex",
+			importPath: "github.com/sortie-ai/sortie/internal/agent/codex",
+			src: `package fixture
+
+import (
+	"github.com/sortie-ai/sortie/internal/agent/agentcore"
+	"github.com/sortie-ai/sortie/internal/agent/agenttest"
+	"github.com/sortie-ai/sortie/internal/agent/agenttest/dispositiontest"
+)
+`,
+			inTestFile: true,
+			wantCount:  0,
+		},
 	}
 
 	for _, tt := range tests {
@@ -1220,15 +1292,16 @@ var _ = r.Trackers
 // contractSharedFamilyPackages against going stale: it fails when an
 // entry carries an empty reason, names a key contractSharedPackageDir
 // cannot resolve, names a directory with no parsable non-test Go file,
-// or names a package that contractPackageRegistersKind now reports true
-// for. It enumerates each named directory with os.ReadDir alone, never
-// descending into a subdirectory, so a permitted package's verdict never
-// depends on a subpackage the map does not name.
+// names a package that contractPackageRegistersKind now reports true
+// for, or carries coreImportable true for a directory whose non-test
+// files import testing. It enumerates each named directory with
+// os.ReadDir alone, never descending into a subdirectory, so a permitted
+// package's verdict never depends on a subpackage the map does not name.
 func TestContractSharedFamilyPackages_RegisterNoKind(t *testing.T) {
 	t.Parallel()
 
-	for importPath, reason := range contractSharedFamilyPackages {
-		if reason == "" {
+	for importPath, pkg := range contractSharedFamilyPackages {
+		if pkg.reason == "" {
 			t.Errorf("contractSharedFamilyPackages[%q] carries an empty reason", importPath)
 		}
 
@@ -1266,6 +1339,16 @@ func TestContractSharedFamilyPackages_RegisterNoKind(t *testing.T) {
 
 		if contractPackageRegistersKind(files) {
 			t.Errorf("%q is a permitted shared package but registers a kind", importPath)
+		}
+
+		if !pkg.coreImportable {
+			continue
+		}
+		for _, file := range files {
+			if resolveContractImportName(file, "testing") == "" {
+				continue
+			}
+			t.Errorf("%q carries coreImportable true but %s imports testing", importPath, fset.Position(file.Pos()).Filename)
 		}
 	}
 }
@@ -1448,6 +1531,38 @@ import "github.com/sortie-ai/sortie/internal/scm/scmcore/inner"
 			src: `package fixture
 
 import "github.com/sortie-ai/sortie/internal/scmwatch"
+`,
+			wantCount: 0,
+		},
+		{
+			name:       "a non-test orchestrator file importing the shared agent test-support package is rejected",
+			dirName:    "orchestrator",
+			importPath: contractOrchestratorPath,
+			src: `package fixture
+
+import "github.com/sortie-ai/sortie/internal/agent/agenttest"
+`,
+			wantCount:  1,
+			wantReason: contractCoreTestSupportReason,
+		},
+		{
+			name:       "an orchestrator test file importing the shared agent test-support package by name is accepted",
+			dirName:    "orchestrator",
+			importPath: contractOrchestratorPath,
+			src: `package fixture
+
+import "github.com/sortie-ai/sortie/internal/agent/agenttest"
+`,
+			inTestFile: true,
+			wantCount:  0,
+		},
+		{
+			name:       "a non-test orchestrator file importing the permitted agentcore package is accepted",
+			dirName:    "orchestrator",
+			importPath: contractOrchestratorPath,
+			src: `package fixture
+
+import "github.com/sortie-ai/sortie/internal/agent/agentcore"
 `,
 			wantCount: 0,
 		},

--- a/internal/adaptertest/contract_test.go
+++ b/internal/adaptertest/contract_test.go
@@ -23,12 +23,13 @@ const contractRegistryImportPath = "github.com/sortie-ai/sortie/internal/registr
 // Track is caught regardless of the local import alias.
 const contractTrackermetricsImportPath = "github.com/sortie-ai/sortie/internal/trackermetrics"
 
-// contractBanTable maps a reimplementation this work extracted to the
-// shared owner a package under any family root must call instead. A
-// top-level function re-declaring one of these names is a violation. The
-// owner named for an entry was extracted from a tracker or source-control
-// package and is not guaranteed to be the correct owner for a package in
-// another family.
+// contractBanTable maps a name this work extracted into a shared package
+// to the owner that received it. A top-level function re-declaring one of
+// these names is a violation; the banned name is the rule. The owner
+// records where the extraction landed rather than naming a universal
+// requirement: every entry came from a tracker or source-control package,
+// so a package in another family may satisfy the rule by choosing a
+// different name instead of calling an owner whose contract does not fit.
 var contractBanTable = map[string]string{
 	"classifyTransportError": "httpkit.ClassifyTransport",
 	"withRetry":              "httpkit.RetryWithBackoff",

--- a/internal/notify/slack/errors.go
+++ b/internal/notify/slack/errors.go
@@ -43,12 +43,12 @@ func classifyHTTPError(resp *http.Response, _, _ string) error {
 	}
 }
 
-// classifyTransportError maps a request, network, or body-read failure
+// classifyTransport maps a request, network, or body-read failure
 // to a [sendError] with a transport category. The underlying error is
 // wrapped for chain inspection but is never rendered into the category,
 // so the host and URL it embeds stay out of logs and agent-visible
 // results.
-func classifyTransportError(err error, _, _ string) error {
+func classifyTransport(err error, _, _ string) error {
 	return &sendError{Category: transportCategory(err), Err: err}
 }
 

--- a/internal/notify/slack/slack.go
+++ b/internal/notify/slack/slack.go
@@ -56,7 +56,7 @@ func newNotifier(config map[string]any) (domain.Notifier, error) {
 		BaseURL:           endpoint,
 		Timeout:           sendTimeout,
 		ClassifyError:     classifyHTTPError,
-		ClassifyTransport: classifyTransportError,
+		ClassifyTransport: classifyTransport,
 	})
 	return &notifier{client: client}, nil
 }

--- a/internal/notify/webhook/errors.go
+++ b/internal/notify/webhook/errors.go
@@ -43,12 +43,12 @@ func classifyHTTPError(resp *http.Response, _, _ string) error {
 	}
 }
 
-// classifyTransportError maps a request, network, or body-read failure
+// classifyTransport maps a request, network, or body-read failure
 // to a [sendError] with a transport category. The underlying error is
 // wrapped for chain inspection but is never rendered into the category,
 // so the host and URL it embeds stay out of logs and agent-visible
 // results.
-func classifyTransportError(err error, _, _ string) error {
+func classifyTransport(err error, _, _ string) error {
 	return &sendError{Category: transportCategory(err), Err: err}
 }
 

--- a/internal/notify/webhook/webhook.go
+++ b/internal/notify/webhook/webhook.go
@@ -57,7 +57,7 @@ func newNotifier(config map[string]any) (domain.Notifier, error) {
 		BaseURL:           endpoint,
 		Timeout:           sendTimeout,
 		ClassifyError:     classifyHTTPError,
-		ClassifyTransport: classifyTransportError,
+		ClassifyTransport: classifyTransport,
 	})
 	return &notifier{client: client}, nil
 }


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Test

**Intent:** `TestCheckAdapterContract` walked only `internal/tracker` and `internal/scm`, so the adapter-family boundary rules (no cross-adapter imports, no orchestrator imports, no re-declared shared helper) were defended by prose alone for the agent and notifier families. This extends the walk to those two roots and resolves the two ban-rule violations it surfaces.

**Related Issues:** #903

### 🧭 Reviewer Guide

**Complexity:** Medium

#### Entry Point

`internal/adaptertest/contract_test.go` - adds `internal/agent` and `internal/notify` to the walked roots, and reworks `contractSharedFamilyPackages` from a `map[string]string` of reasons into a `map[string]contractSharedPackage`, where each entry also states whether the orchestrator's production code may import it (`coreImportable`). The agent-family packages that register no kind (`agentcore`, `mcpconfig`, `sshutil`, `agenttest`, and the separately keyed `agenttest/dispositiontest`) are added with that flag set based on whether their non-test files import `testing`.

#### Sensitive Areas

- `internal/notify/slack/errors.go`, `internal/notify/webhook/errors.go`: each declared `classifyTransportError`, colliding with the ban-table entry that points at `httpkit.ClassifyTransport`. Both are renamed to `classifyTransport`, a pure rename with no behavior change. These backends deliberately do not call the shared classifier and should not be changed to: it returns a `*domain.TrackerError` whose `Error()` renders the wrapped cause, and `internal/tool/notify/notify.go` formats a send failure into an agent-visible tool result, so routing a notifier through it would put the secret-bearing endpoint URL in front of the agent. The local `classifyTransport` keeps host and URL out of the category string. `internal/tracker/linear/client.go` already carries the same name for the same reason. The duplication between the two backends predates this change and is left alone.
- `internal/adaptertest/contract_test.go`: `TestContractSharedFamilyPackages_RegisterNoKind` now also fails an entry marked `coreImportable: true` whose non-test files import `testing`, guarding the new core-import carve-out against drift. Note that `contractSharedFamilyPackages` is consulted by both the adapter import rule and the orchestrator core-import rule, which is why permitting a test-support package needs the per-entry flag rather than a bare presence check.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes
- **Migrations/State:** No migrations or state changes
