### PR TITLE
feat: add a per-session capability record to clientprotocol

### DIFF
--- a/internal/agent/clientprotocol/capability.go
+++ b/internal/agent/clientprotocol/capability.go
@@ -1,0 +1,121 @@
+package clientprotocol
+
+import "strings"
+
+// capabilityState is the state of one entry in a session's capability
+// record. It holds exactly two values: a capability this transport
+// trusts a runtime to honor, and one known or observed not to be
+// delivered.
+type capabilityState string
+
+const (
+	capabilityProtocol capabilityState = "protocol"
+	capabilityGap      capabilityState = "gap"
+)
+
+// Operator labels for the capability record's four entries, reported
+// in this fixed order by the once-per-session gap notice.
+const (
+	capabilityLabelToolServers         = "tool servers"
+	capabilityLabelTokenCounts         = "token counts"
+	capabilityLabelSessionContinuation = "session continuation"
+	capabilityLabelAgentVersion        = "agent version"
+)
+
+// Compile-time fragments the once-per-session gap notice is assembled
+// from. Nothing about a specific runtime, configuration, or error is
+// ever interpolated into it.
+const (
+	capabilityGapNoticeStem      = "this session started with a declared capability gap in: "
+	capabilityGapNoticeSeparator = ", "
+)
+
+// capabilityRecord is a session's own record of which of this
+// transport's capabilities its runtime actually delivers. Every entry
+// starts at protocol or gap, resolved from structural knowledge and
+// the initialize handshake, and a lowering to gap holds for the rest
+// of the session: an entry never rises back to protocol once lowered.
+type capabilityRecord struct {
+	toolServers         capabilityState
+	tokenCounts         capabilityState
+	sessionContinuation capabilityState
+	agentVersion        capabilityState
+}
+
+// newCapabilityRecord builds a session's capability record with its
+// stage-one states, resolved from structural knowledge available
+// before the handshake. remote reports whether the session's launch
+// target runs the agent on a remote host.
+//
+// sessionContinuation starts at gap because session continuation is
+// not implemented yet; a local launch with no generated tool-server
+// configuration at all still leaves toolServers at protocol, because
+// nothing was withheld when nothing was offered.
+func newCapabilityRecord(remote bool) *capabilityRecord {
+	toolServers := capabilityProtocol
+	if remote {
+		toolServers = capabilityGap
+	}
+	return &capabilityRecord{
+		toolServers:         toolServers,
+		tokenCounts:         capabilityGap,
+		sessionContinuation: capabilityGap,
+		agentVersion:        capabilityProtocol,
+	}
+}
+
+// capabilityEntry pairs one capability record field with the operator
+// label it is reported under.
+type capabilityEntry struct {
+	label string
+	state capabilityState
+}
+
+// entries returns the record's four entries with their operator
+// labels, in the fixed order the once-per-session notice reports them.
+func (r capabilityRecord) entries() [4]capabilityEntry {
+	return [4]capabilityEntry{
+		{label: capabilityLabelToolServers, state: r.toolServers},
+		{label: capabilityLabelTokenCounts, state: r.tokenCounts},
+		{label: capabilityLabelSessionContinuation, state: r.sessionContinuation},
+		{label: capabilityLabelAgentVersion, state: r.agentVersion},
+	}
+}
+
+// gapNotice returns the once-per-session notice text listing every
+// entry of r in the gap state, in the record's own field order, and
+// reports whether there is at least one such entry. The text is
+// assembled only from compile-time constant fragments.
+func (r capabilityRecord) gapNotice() (string, bool) {
+	var labels []string
+	for _, entry := range r.entries() {
+		if entry.state == capabilityGap {
+			labels = append(labels, entry.label)
+		}
+	}
+	if len(labels) == 0 {
+		return "", false
+	}
+	return capabilityGapNoticeStem + strings.Join(labels, capabilityGapNoticeSeparator), true
+}
+
+// advertisesSessionContinuation reports whether caps advertises support
+// for continuing a prior session through session/load or
+// session/resume.
+func advertisesSessionContinuation(caps agentCapabilities) bool {
+	if caps.LoadSession != nil && *caps.LoadSession {
+		return true
+	}
+	return caps.SessionCapabilities != nil && caps.SessionCapabilities.Resume != nil
+}
+
+// lower moves *entry to the gap state and reports whether it actually
+// changed. Lowering an entry already at gap is idempotent: an entry
+// never rises back to protocol within a session.
+func lower(entry *capabilityState) bool {
+	if *entry == capabilityGap {
+		return false
+	}
+	*entry = capabilityGap
+	return true
+}

--- a/internal/agent/clientprotocol/capability_test.go
+++ b/internal/agent/clientprotocol/capability_test.go
@@ -1,0 +1,621 @@
+package clientprotocol
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/sortie-ai/sortie/internal/domain"
+)
+
+// newPumpForCapabilityTests builds a *sessionState with a local
+// launch's stage-one capability record and a *pumpState pointing at
+// it, with no connection or subprocess involved: everything below
+// exercises the record's mutation path directly, never a decision that
+// needs a live wire.
+func newPumpForCapabilityTests(t *testing.T) (*sessionState, *pumpState) {
+	t.Helper()
+	state := &sessionState{caps: newCapabilityRecord(false), logger: discardLogger()}
+	return state, &pumpState{state: state}
+}
+
+// TestNewCapabilityRecordToolServersStageOne confirms the stage-one
+// toolServers state is decided by the remote flag alone: a remote
+// launch starts at gap because a remote runtime cannot be trusted to
+// deliver a locally-generated tool-server configuration, while a local
+// launch starts at protocol.
+func TestNewCapabilityRecordToolServersStageOne(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		remote    bool
+		wantState capabilityState
+	}{
+		{name: "a local launch starts toolServers at protocol", remote: false, wantState: capabilityProtocol},
+		{name: "a remote launch starts toolServers at gap", remote: true, wantState: capabilityGap},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			record := newCapabilityRecord(tt.remote)
+
+			if record.toolServers != tt.wantState {
+				t.Errorf("newCapabilityRecord(%v).toolServers = %q, want %q", tt.remote, record.toolServers, tt.wantState)
+			}
+		})
+	}
+}
+
+// TestNewCapabilityRecordStageOneEntries confirms all four stage-one
+// entries independently of any handshake, for both launch arms. The
+// sessionContinuation case is the load-bearing one: piece 4 (session
+// continuation) has not landed, so it must start at gap regardless of
+// remote, per the filed deviation from the plan's step 3.1 text.
+func TestNewCapabilityRecordStageOneEntries(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		remote bool
+	}{
+		{name: "local launch", remote: false},
+		{name: "remote launch", remote: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			record := newCapabilityRecord(tt.remote)
+
+			wantToolServers := capabilityProtocol
+			if tt.remote {
+				wantToolServers = capabilityGap
+			}
+			if record.toolServers != wantToolServers {
+				t.Errorf("newCapabilityRecord(%v).toolServers = %q, want %q", tt.remote, record.toolServers, wantToolServers)
+			}
+			if record.tokenCounts != capabilityGap {
+				t.Errorf("newCapabilityRecord(%v).tokenCounts = %q, want %q", tt.remote, record.tokenCounts, capabilityGap)
+			}
+			if record.sessionContinuation != capabilityGap {
+				t.Errorf("newCapabilityRecord(%v).sessionContinuation = %q, want %q: session continuation is not implemented yet", tt.remote, record.sessionContinuation, capabilityGap)
+			}
+			if record.agentVersion != capabilityProtocol {
+				t.Errorf("newCapabilityRecord(%v).agentVersion = %q, want %q", tt.remote, record.agentVersion, capabilityProtocol)
+			}
+		})
+	}
+}
+
+// TestCapabilityLoweringNeverRises confirms an entry the handshake
+// lowers to gap stays there for the rest of the session: a later
+// application reporting the same capability as present must not move
+// the entry back to protocol.
+func TestCapabilityLoweringNeverRises(t *testing.T) {
+	t.Parallel()
+
+	state, p := newPumpForCapabilityTests(t)
+
+	p.applyHandshakeCapabilityLowering(&handshakeFacts{agentInfoPresent: false, toolServersWithheld: true})
+	if state.caps.agentVersion != capabilityGap {
+		t.Fatalf("agentVersion after the first lowering = %q, want %q", state.caps.agentVersion, capabilityGap)
+	}
+	if state.caps.toolServers != capabilityGap {
+		t.Fatalf("toolServers after the first lowering = %q, want %q", state.caps.toolServers, capabilityGap)
+	}
+
+	// A later application reporting the capability as present must not
+	// raise either entry back to protocol; nothing in this record's
+	// mutation path offers a rise, and this proves that rather than
+	// merely assuming it.
+	p.applyHandshakeCapabilityLowering(&handshakeFacts{agentInfoPresent: true, toolServersWithheld: false})
+	if state.caps.agentVersion != capabilityGap {
+		t.Errorf("agentVersion after a later report of presence = %q, want %q: an entry must never rise once lowered", state.caps.agentVersion, capabilityGap)
+	}
+	if state.caps.toolServers != capabilityGap {
+		t.Errorf("toolServers after a later report of delivery = %q, want %q: an entry must never rise once lowered", state.caps.toolServers, capabilityGap)
+	}
+}
+
+// TestHandshakeLoweringPersistsAcrossTurns confirms the same invariant
+// end to end, through the running pump and two successive turns of the
+// same session, rather than through a direct call alone. It reads the
+// invariant through the event stream rather than through state.caps: the
+// pump goroutine is that record's sole owner, and reading its fields
+// from the test goroutine is race-free only by accident of this piece
+// having a single lowering trigger. A later piece that schedules
+// lowering from the pump mid-turn would turn that direct read into a
+// genuine data race.
+func TestHandshakeLoweringPersistsAcrossTurns(t *testing.T) {
+	t.Parallel()
+
+	state, outPr, inPw := newTestSession(t, domain.AgentConfig{}, clientProtocolMaxLineBytes)
+	out := newOutboundReader(outPr)
+
+	state.itemCh <- pumpItem{control: &pumpControl{handshake: &handshakeFacts{agentInfoPresent: false}}}
+	markSessionKnown(state)
+
+	var firstTurnEvents []domain.AgentEvent
+	outcomeCh := runTurnAsync(state, domain.RunTurnParams{Prompt: "go", OnEvent: collectEvents(&firstTurnEvents)})
+	promptID := out.awaitMethod(t, methodSessionPrompt)
+	respondLine(t, inPw, promptID, promptResponse{StopReason: stopReasonEndTurn})
+	outcome := awaitOutcome(t, outcomeCh)
+	if outcome.err != nil {
+		t.Fatalf("first RunTurn() error = %v, want nil", outcome.err)
+	}
+
+	notice := firstNotification(t, firstTurnEvents)
+	if !strings.Contains(notice.Message, capabilityLabelAgentVersion) {
+		t.Fatalf("first turn gap notice = %q, want it to list %q: the handshake lowered agentVersion", notice.Message, capabilityLabelAgentVersion)
+	}
+
+	// A second turn must not repeat the notice: the once-per-session gate
+	// already proves the first turn's lowering was not undone and
+	// reapplied, without this goroutine touching the pump-owned record.
+	var secondTurnEvents []domain.AgentEvent
+	outcomeCh2 := runTurnAsync(state, domain.RunTurnParams{Prompt: "go again", OnEvent: collectEvents(&secondTurnEvents)})
+	promptID2 := out.awaitMethod(t, methodSessionPrompt)
+	respondLine(t, inPw, promptID2, promptResponse{StopReason: stopReasonEndTurn})
+	outcome2 := awaitOutcome(t, outcomeCh2)
+	if outcome2.err != nil {
+		t.Fatalf("second RunTurn() error = %v, want nil", outcome2.err)
+	}
+	for _, ev := range secondTurnEvents {
+		if ev.Type == domain.EventNotification {
+			t.Errorf("second turn emitted a notification %q, want none: the lowering already reported by the first turn must not fire again", ev.Message)
+		}
+	}
+}
+
+// firstNotification returns the first domain.EventNotification event in
+// events, failing t if none is present.
+func firstNotification(t *testing.T, events []domain.AgentEvent) domain.AgentEvent {
+	t.Helper()
+	for _, ev := range events {
+		if ev.Type == domain.EventNotification {
+			return ev
+		}
+	}
+	t.Fatal("no notification event observed, want the gap notice")
+	return domain.AgentEvent{}
+}
+
+// TestTurnSnapshotIsolatesMidTurnLowering confirms a turn reads the
+// capability record as it stood when the turn began: capsSnapshot is a
+// value copy taken at turn start, so a lowering the pump applies while
+// that turn is still in flight does not retroactively change what the
+// turn already read. The lowering that takes effect from the next turn
+// onward is exercised here directly, because this piece's own
+// handshake is the only lowering trigger this transport has landed so
+// far; the observation-based trigger of a later piece lands on the
+// same lowerCapability path this test drives.
+func TestTurnSnapshotIsolatesMidTurnLowering(t *testing.T) {
+	t.Parallel()
+
+	state, p := newPumpForCapabilityTests(t)
+	turn := &activeTurn{capsSnapshot: *state.caps}
+
+	if turn.capsSnapshot.agentVersion != capabilityProtocol {
+		t.Fatalf("turn snapshot agentVersion at turn start = %q, want %q", turn.capsSnapshot.agentVersion, capabilityProtocol)
+	}
+
+	p.lowerCapability(&state.caps.agentVersion, capabilityLabelAgentVersion)
+
+	if state.caps.agentVersion != capabilityGap {
+		t.Fatalf("live record agentVersion after the lowering = %q, want %q", state.caps.agentVersion, capabilityGap)
+	}
+	if turn.capsSnapshot.agentVersion != capabilityProtocol {
+		t.Errorf("turn snapshot agentVersion after a mid-turn lowering = %q, want %q: a lowering observed mid-turn must not change decisions the turn already made", turn.capsSnapshot.agentVersion, capabilityProtocol)
+	}
+
+	// The next turn's own snapshot, taken after the lowering, does see it.
+	nextTurn := &activeTurn{capsSnapshot: *state.caps}
+	if nextTurn.capsSnapshot.agentVersion != capabilityGap {
+		t.Errorf("next turn's snapshot agentVersion = %q, want %q: the lowering takes effect from the following turn", nextTurn.capsSnapshot.agentVersion, capabilityGap)
+	}
+}
+
+// TestEmitCapabilityGapNoticeOnceReadsTurnSnapshot confirms the notice
+// is assembled from the turn's own capsSnapshot, not from the pump's
+// live record. The two tables below diverge the snapshot from the live
+// record in opposite directions: a snapshot that already carries a gap
+// the live record lacks, and a live record that carries a gap the
+// snapshot lacks. Reading the live record instead of the snapshot
+// would report the wrong outcome in both directions, even though a
+// production turn always builds the two equal in the same call.
+func TestEmitCapabilityGapNoticeOnceReadsTurnSnapshot(t *testing.T) {
+	t.Parallel()
+
+	allProtocol := capabilityRecord{
+		toolServers:         capabilityProtocol,
+		tokenCounts:         capabilityProtocol,
+		sessionContinuation: capabilityProtocol,
+		agentVersion:        capabilityProtocol,
+	}
+	withTokenCountsGap := allProtocol
+	withTokenCountsGap.tokenCounts = capabilityGap
+
+	tests := []struct {
+		name         string
+		liveCaps     capabilityRecord
+		capsSnapshot capabilityRecord
+		wantNotice   bool
+	}{
+		{
+			name:         "snapshot has a gap the live record does not",
+			liveCaps:     allProtocol,
+			capsSnapshot: withTokenCountsGap,
+			wantNotice:   true,
+		},
+		{
+			name:         "live record has a gap the snapshot does not",
+			liveCaps:     withTokenCountsGap,
+			capsSnapshot: allProtocol,
+			wantNotice:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			state := &sessionState{caps: &tt.liveCaps, logger: discardLogger()}
+			p := &pumpState{state: state}
+			turn := &activeTurn{
+				sink:         make(chan domain.AgentEvent, 1),
+				done:         make(chan struct{}),
+				capsSnapshot: tt.capsSnapshot,
+			}
+
+			p.emitCapabilityGapNoticeOnce(turn)
+
+			select {
+			case ev := <-turn.sink:
+				if !tt.wantNotice {
+					t.Fatalf("emitCapabilityGapNoticeOnce() published %+v, want no event: the turn's own snapshot carried no gap entry", ev)
+				}
+				if ev.Type != domain.EventNotification {
+					t.Fatalf("emitCapabilityGapNoticeOnce() published event type = %q, want %q", ev.Type, domain.EventNotification)
+				}
+			default:
+				if tt.wantNotice {
+					t.Fatal("emitCapabilityGapNoticeOnce() published no event, want the gap notice for the turn's own snapshot")
+				}
+			}
+		})
+	}
+}
+
+// TestAgentVersionLoweredByPresenceBoolean confirms an absent agentInfo
+// lowers the version entry through the agentInfoPresent boolean alone.
+// The zero-value case is the load-bearing one: if the lowering were
+// driven by comparing the recorded implementation value instead, a
+// present-but-zero-value agentInfo would be indistinguishable from an
+// absent one and would wrongly lower the entry.
+func TestAgentVersionLoweredByPresenceBoolean(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name             string
+		agentInfoPresent bool
+		agentInfo        implementation
+		wantGap          bool
+	}{
+		{
+			name:             "absent agentInfo lowers the version entry",
+			agentInfoPresent: false,
+			agentInfo:        implementation{},
+			wantGap:          true,
+		},
+		{
+			name:             "present agentInfo that happens to be the zero value lowers nothing",
+			agentInfoPresent: true,
+			agentInfo:        implementation{},
+			wantGap:          false,
+		},
+		{
+			name:             "present agentInfo with populated fields lowers nothing",
+			agentInfoPresent: true,
+			agentInfo:        implementation{Name: "some-agent", Version: "9.9.9"},
+			wantGap:          false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			state, p := newPumpForCapabilityTests(t)
+			p.applyHandshakeCapabilityLowering(&handshakeFacts{agentInfoPresent: tt.agentInfoPresent, agentInfo: tt.agentInfo})
+
+			gotGap := state.caps.agentVersion == capabilityGap
+			if gotGap != tt.wantGap {
+				t.Errorf("applyHandshakeCapabilityLowering(agentInfoPresent=%v) agentVersion gap = %v, want %v", tt.agentInfoPresent, gotGap, tt.wantGap)
+			}
+		})
+	}
+}
+
+// TestToolServersLoweredWhenWithheld confirms an HTTP tool server the
+// generated configuration declared, but the handshake's advertised MCP
+// capabilities do not support, lowers toolServers; a handshake that
+// withholds nothing leaves it at its stage-one state.
+func TestToolServersLoweredWhenWithheld(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		withheld  bool
+		wantState capabilityState
+	}{
+		{name: "an HTTP server withheld by the handshake lowers toolServers", withheld: true, wantState: capabilityGap},
+		{name: "nothing withheld leaves toolServers at its stage-one state", withheld: false, wantState: capabilityProtocol},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			state, p := newPumpForCapabilityTests(t)
+			p.applyHandshakeCapabilityLowering(&handshakeFacts{agentInfoPresent: true, toolServersWithheld: tt.withheld})
+
+			if state.caps.toolServers != tt.wantState {
+				t.Errorf("toolServers after applyHandshakeCapabilityLowering(toolServersWithheld=%v) = %q, want %q", tt.withheld, state.caps.toolServers, tt.wantState)
+			}
+		})
+	}
+}
+
+// TestAdvertisesSessionContinuation confirms the predicate over the
+// four shapes that matter. The asymmetry between the two branches is
+// schema-driven, not a testing inconsistency: LoadSession is a *bool,
+// so only a present and true value advertises continuation, while
+// Resume is a struct pointer with no boolean payload, so its mere
+// presence is the advertisement.
+func TestAdvertisesSessionContinuation(t *testing.T) {
+	t.Parallel()
+
+	trueVal := true
+	falseVal := false
+
+	tests := []struct {
+		name string
+		caps agentCapabilities
+		want bool
+	}{
+		{
+			name: "loadSession true advertises continuation",
+			caps: agentCapabilities{LoadSession: &trueVal},
+			want: true,
+		},
+		{
+			name: "loadSession present and false does not advertise continuation",
+			caps: agentCapabilities{LoadSession: &falseVal},
+			want: false,
+		},
+		{
+			name: "sessionCapabilities.resume present with loadSession absent advertises continuation",
+			caps: agentCapabilities{SessionCapabilities: &sessionCapabilities{Resume: &sessionResumeCapabilities{}}},
+			want: true,
+		},
+		{
+			name: "neither loadSession nor sessionCapabilities.resume present does not advertise continuation",
+			caps: agentCapabilities{},
+			want: false,
+		},
+		{
+			name: "sessionCapabilities present with close but no resume does not advertise continuation",
+			caps: agentCapabilities{SessionCapabilities: &sessionCapabilities{Close: &sessionCloseCapabilities{}}},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := advertisesSessionContinuation(tt.caps)
+
+			if got != tt.want {
+				t.Errorf("advertisesSessionContinuation(%+v) = %v, want %v", tt.caps, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestCapabilityRecordGapNotice confirms the notice text lists only the
+// entries in the gap state, in the record's own fixed field order,
+// assembled from nothing but the compile-time constant fragments.
+func TestCapabilityRecordGapNotice(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		record capabilityRecord
+		want   string
+		wantOK bool
+	}{
+		{
+			name: "no gap entries reports nothing to notify",
+			record: capabilityRecord{
+				toolServers: capabilityProtocol, tokenCounts: capabilityProtocol,
+				sessionContinuation: capabilityProtocol, agentVersion: capabilityProtocol,
+			},
+			wantOK: false,
+		},
+		{
+			name: "one gap entry lists only that label",
+			record: capabilityRecord{
+				toolServers: capabilityProtocol, tokenCounts: capabilityGap,
+				sessionContinuation: capabilityProtocol, agentVersion: capabilityProtocol,
+			},
+			want:   capabilityGapNoticeStem + capabilityLabelTokenCounts,
+			wantOK: true,
+		},
+		{
+			name: "two non-adjacent gap entries are joined without picking up a neighbor",
+			record: capabilityRecord{
+				toolServers: capabilityGap, tokenCounts: capabilityProtocol,
+				sessionContinuation: capabilityProtocol, agentVersion: capabilityGap,
+			},
+			want: capabilityGapNoticeStem + strings.Join([]string{
+				capabilityLabelToolServers, capabilityLabelAgentVersion,
+			}, capabilityGapNoticeSeparator),
+			wantOK: true,
+		},
+		{
+			name: "every entry gap lists all four labels in the record's own order",
+			record: capabilityRecord{
+				toolServers: capabilityGap, tokenCounts: capabilityGap,
+				sessionContinuation: capabilityGap, agentVersion: capabilityGap,
+			},
+			want: capabilityGapNoticeStem + strings.Join([]string{
+				capabilityLabelToolServers, capabilityLabelTokenCounts,
+				capabilityLabelSessionContinuation, capabilityLabelAgentVersion,
+			}, capabilityGapNoticeSeparator),
+			wantOK: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, ok := tt.record.gapNotice()
+			if ok != tt.wantOK {
+				t.Fatalf("gapNotice() ok = %v, want %v", ok, tt.wantOK)
+			}
+			if got != tt.want {
+				t.Errorf("gapNotice() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestCapabilityGapNoticeOncePerSession confirms the once-per-session
+// notice is the first notification of the session's first turn, is
+// never repeated by a later turn, and lists the entries the handshake
+// left in the gap state in the record's fixed order.
+func TestCapabilityGapNoticeOncePerSession(t *testing.T) {
+	t.Parallel()
+
+	state, outPr, inPw := newTestSession(t, domain.AgentConfig{}, clientProtocolMaxLineBytes)
+	out := newOutboundReader(outPr)
+
+	// A local launch's stage-one record already carries tokenCounts and
+	// sessionContinuation at gap; this handshake lowers the two
+	// remaining entries so the notice lists all four labels.
+	state.itemCh <- pumpItem{control: &pumpControl{handshake: &handshakeFacts{
+		agentInfoPresent:    false,
+		toolServersWithheld: true,
+	}}}
+	markSessionKnown(state)
+
+	var firstTurnEvents []domain.AgentEvent
+	outcomeCh := runTurnAsync(state, domain.RunTurnParams{Prompt: "go", OnEvent: collectEvents(&firstTurnEvents)})
+	promptID := out.awaitMethod(t, methodSessionPrompt)
+	respondLine(t, inPw, promptID, promptResponse{StopReason: stopReasonEndTurn})
+	outcome := awaitOutcome(t, outcomeCh)
+	if outcome.err != nil {
+		t.Fatalf("first RunTurn() error = %v, want nil", outcome.err)
+	}
+
+	if len(firstTurnEvents) < 2 {
+		t.Fatalf("first turn delivered %d events, want at least session_started and the gap notice", len(firstTurnEvents))
+	}
+	if firstTurnEvents[0].Type != domain.EventSessionStarted {
+		t.Fatalf("first event type = %q, want %q", firstTurnEvents[0].Type, domain.EventSessionStarted)
+	}
+	notice := firstTurnEvents[1]
+	if notice.Type != domain.EventNotification {
+		t.Fatalf("second event type = %q, want %q (the once-per-session gap notice)", notice.Type, domain.EventNotification)
+	}
+
+	wantMessage := capabilityGapNoticeStem + strings.Join([]string{
+		capabilityLabelToolServers, capabilityLabelTokenCounts,
+		capabilityLabelSessionContinuation, capabilityLabelAgentVersion,
+	}, capabilityGapNoticeSeparator)
+	if notice.Message != wantMessage {
+		t.Errorf("gap notice = %q, want %q", notice.Message, wantMessage)
+	}
+
+	for _, ev := range firstTurnEvents[2:] {
+		if ev.Type == domain.EventNotification {
+			t.Errorf("first turn emitted a second notification %q, want exactly one", ev.Message)
+		}
+	}
+
+	// A second turn in the same session must not repeat the notice, even
+	// though the record still carries the same gap entries.
+	var secondTurnEvents []domain.AgentEvent
+	outcomeCh2 := runTurnAsync(state, domain.RunTurnParams{Prompt: "go again", OnEvent: collectEvents(&secondTurnEvents)})
+	promptID2 := out.awaitMethod(t, methodSessionPrompt)
+	respondLine(t, inPw, promptID2, promptResponse{StopReason: stopReasonEndTurn})
+	outcome2 := awaitOutcome(t, outcomeCh2)
+	if outcome2.err != nil {
+		t.Fatalf("second RunTurn() error = %v, want nil", outcome2.err)
+	}
+	for _, ev := range secondTurnEvents {
+		if ev.Type == domain.EventNotification {
+			t.Errorf("second turn emitted a notification %q, want none: the gap notice fires exactly once per session", ev.Message)
+		}
+	}
+}
+
+// runOneTurnAndCaptureNotice starts a session carrying the given
+// handshake facts and session identifier, runs one turn to completion,
+// and returns the message of the notification event it observed.
+func runOneTurnAndCaptureNotice(t *testing.T, sessionID string, facts *handshakeFacts) string {
+	t.Helper()
+
+	state, outPr, inPw := newTestSession(t, domain.AgentConfig{}, clientProtocolMaxLineBytes)
+	out := newOutboundReader(outPr)
+
+	state.itemCh <- pumpItem{control: &pumpControl{handshake: facts}}
+	state.itemCh <- pumpItem{control: &pumpControl{sessionID: sessionID}}
+
+	var events []domain.AgentEvent
+	outcomeCh := runTurnAsync(state, domain.RunTurnParams{Prompt: "go", OnEvent: collectEvents(&events)})
+	promptID := out.awaitMethod(t, methodSessionPrompt)
+	respondLine(t, inPw, promptID, promptResponse{StopReason: stopReasonEndTurn})
+	outcome := awaitOutcome(t, outcomeCh)
+	if outcome.err != nil {
+		t.Fatalf("RunTurn() error = %v, want nil", outcome.err)
+	}
+
+	for _, ev := range events {
+		if ev.Type == domain.EventNotification {
+			return ev.Message
+		}
+	}
+	t.Fatal("no notification event observed, want the gap notice")
+	return ""
+}
+
+// TestCapabilityGapNoticeInterpolatesNoRuntimeValue confirms the notice
+// is byte-identical across two sessions that carry different runtime
+// details (session identifier, agent name and version) but land on the
+// same set of gap entries: it is assembled only from compile-time
+// constant fragments and never from a wire-derived value.
+func TestCapabilityGapNoticeInterpolatesNoRuntimeValue(t *testing.T) {
+	t.Parallel()
+
+	first := runOneTurnAndCaptureNotice(t, "sess-aaaa", &handshakeFacts{
+		agentInfo:        implementation{Name: "agent-one", Version: "1.2.3"},
+		agentInfoPresent: true,
+	})
+	second := runOneTurnAndCaptureNotice(t, "sess-bbbb", &handshakeFacts{
+		agentInfo:        implementation{Name: "a-completely-different-agent", Version: "9.9.9"},
+		agentInfoPresent: true,
+	})
+
+	if first != second {
+		t.Errorf("gap notice varied with runtime details: %q vs %q, want identical text for the same gap set", first, second)
+	}
+	if strings.Contains(first, "sess-aaaa") || strings.Contains(first, "agent-one") {
+		t.Errorf("gap notice = %q, contains a runtime value, want only constant fragments", first)
+	}
+}

--- a/internal/agent/clientprotocol/capability_test.go
+++ b/internal/agent/clientprotocol/capability_test.go
@@ -50,9 +50,11 @@ func TestNewCapabilityRecordToolServersStageOne(t *testing.T) {
 
 // TestNewCapabilityRecordStageOneEntries confirms all four stage-one
 // entries independently of any handshake, for both launch arms. The
-// sessionContinuation case is the load-bearing one: piece 4 (session
-// continuation) has not landed, so it must start at gap regardless of
-// remote, per the filed deviation from the plan's step 3.1 text.
+// sessionContinuation case is the load-bearing one: session
+// continuation is not implemented, so the entry must start at gap
+// whichever way the launch resolves. Only a handshake-free assertion
+// can prove it, because the handshake lowers that entry anyway and
+// would mask a wrong default.
 func TestNewCapabilityRecordStageOneEntries(t *testing.T) {
 	t.Parallel()
 

--- a/internal/agent/clientprotocol/harness_test.go
+++ b/internal/agent/clientprotocol/harness_test.go
@@ -45,6 +45,7 @@ func newTestSession(t *testing.T, agentConfig domain.AgentConfig, maxLineBytes i
 
 	state := &sessionState{
 		agentConfig: agentConfig,
+		caps:        newCapabilityRecord(false),
 		itemCh:      make(chan pumpItem, pumpChannelCapacity),
 		stopCh:      make(chan struct{}),
 		pumpDone:    make(chan struct{}),

--- a/internal/agent/clientprotocol/mcp_test.go
+++ b/internal/agent/clientprotocol/mcp_test.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/sortie-ai/sortie/internal/agent/mcpconfig"
 )
 
 // writeMCPConfig writes a generated MCP configuration file declaring
@@ -55,5 +57,33 @@ func TestParseMCPServersRemoteLaunchIgnoresPath(t *testing.T) {
 	}
 	if len(parsed.servers) != 0 {
 		t.Errorf("parseMCPServers(remote, empty path).servers = %v, want empty", parsed.servers)
+	}
+}
+
+// TestWireServersWithholdsUnsupportedHTTP confirms an HTTP tool server
+// declared in the generated configuration is withheld when the
+// handshake does not advertise HTTP MCP support, and is delivered,
+// with withheld left false, when it does.
+func TestWireServersWithholdsUnsupportedHTTP(t *testing.T) {
+	t.Parallel()
+
+	parsed := parsedMCPServers{servers: []mcpconfig.Server{
+		{Name: "remote-tools", Transport: mcpconfig.TransportHTTP, URL: "https://tools.example/mcp"},
+	}}
+
+	servers, withheld := parsed.wireServers(false)
+	if !withheld {
+		t.Error("wireServers(false) withheld = false, want true: an HTTP server the agent did not advertise support for must be withheld")
+	}
+	if len(servers) != 0 {
+		t.Errorf("wireServers(false) = %d servers, want 0", len(servers))
+	}
+
+	servers, withheld = parsed.wireServers(true)
+	if withheld {
+		t.Error("wireServers(true) withheld = true, want false: the agent advertised HTTP support")
+	}
+	if len(servers) != 1 || servers[0].HTTP == nil {
+		t.Fatalf("wireServers(true) = %+v, want one HTTP server", servers)
 	}
 }

--- a/internal/agent/clientprotocol/permission_test.go
+++ b/internal/agent/clientprotocol/permission_test.go
@@ -194,7 +194,7 @@ func TestPermissionRequestSelectsRefusingOption(t *testing.T) {
 
 	var gotNotice domain.AgentEvent
 	for _, event := range events {
-		if event.Type == domain.EventNotification {
+		if event.Type == domain.EventNotification && event.Message == wantNotice.Message {
 			gotNotice = event
 			break
 		}

--- a/internal/agent/clientprotocol/pump.go
+++ b/internal/agent/clientprotocol/pump.go
@@ -58,6 +58,12 @@ type activeTurn struct {
 	awaitedID    jsonrpc.ID
 	workObserved bool
 
+	// capsSnapshot is the capability record as it stood when this turn
+	// began. Every decision this turn makes from the record reads this
+	// copy rather than the pump's live one, so a lowering observed while
+	// the turn is in flight takes effect from the next turn onward.
+	capsSnapshot capabilityRecord
+
 	pendingEnd    turnEndKind
 	pendingDetail string
 	cancelSent    bool
@@ -89,6 +95,12 @@ type pumpState struct {
 
 	malformedVariantLogged bool
 	streamEnded            bool
+
+	// capabilityNoticeSent reports whether the once-per-session gap
+	// notice has already been emitted, as the first notification of the
+	// session's first turn. A lowering observed after that point is
+	// logged at warn level instead of producing a second notice.
+	capabilityNoticeSent bool
 
 	// openRequests records the request the pump is answering while it is
 	// answering it. The pump answers each request inside the call that
@@ -176,6 +188,7 @@ func (p *pumpState) handleControl(ctrl pumpControl) {
 		p.agentInfo = ctrl.handshake.agentInfo
 		p.agentInfoPresent = ctrl.handshake.agentInfoPresent
 		p.caps = ctrl.handshake.caps
+		p.applyHandshakeCapabilityLowering(ctrl.handshake)
 
 	case ctrl.sessionID != "":
 		p.sessionID = ctrl.sessionID
@@ -196,6 +209,36 @@ func (p *pumpState) handleControl(ctrl pumpControl) {
 
 	case ctrl.answerOpen:
 		p.handleAnswerOpen()
+	}
+}
+
+// applyHandshakeCapabilityLowering lowers the capability record's
+// stage-two entries from what the initialize response advertised. It
+// never raises an entry. In this piece a lowering here always precedes
+// the once-per-session notice, because the handshake control message is
+// always published and processed before the session's first turn can
+// begin.
+func (p *pumpState) applyHandshakeCapabilityLowering(facts *handshakeFacts) {
+	if !facts.agentInfoPresent {
+		p.lowerCapability(&p.state.caps.agentVersion, capabilityLabelAgentVersion)
+	}
+	if !advertisesSessionContinuation(facts.caps) {
+		p.lowerCapability(&p.state.caps.sessionContinuation, capabilityLabelSessionContinuation)
+	}
+	if facts.toolServersWithheld {
+		p.lowerCapability(&p.state.caps.toolServers, capabilityLabelToolServers)
+	}
+}
+
+// lowerCapability lowers entry to gap. When that happens after the
+// once-per-session notice has already been sent, it is logged at warn
+// level rather than folded into a second notice.
+func (p *pumpState) lowerCapability(entry *capabilityState, label string) {
+	if !lower(entry) {
+		return
+	}
+	if p.capabilityNoticeSent {
+		p.state.logger.Warn("capability lowered after the once-per-session notice", slog.String("capability", label))
 	}
 }
 
@@ -436,11 +479,12 @@ func (p *pumpState) handleStartTurn(ts *turnStart) {
 		return
 	}
 
-	turn := &activeTurn{sink: ts.sink, resultCh: ts.resultCh, done: ts.done, cancelCh: ts.cancelCh}
+	turn := &activeTurn{sink: ts.sink, resultCh: ts.resultCh, done: ts.done, cancelCh: ts.cancelCh, capsSnapshot: *p.state.caps}
 	p.activeTurn = turn
 	ts.reply <- turnVerdict{accepted: true}
 
 	agentcore.EmitSessionStarted(p.publish(turn), strconv.Itoa(p.state.pid), p.sessionID)
+	p.emitCapabilityGapNoticeOnce(turn)
 	p.flushQueued(turn)
 
 	if p.latchedHumanInput {
@@ -465,6 +509,25 @@ func (p *pumpState) handleStartTurn(ts *turnStart) {
 		return
 	}
 	turn.awaitedID = id
+}
+
+// emitCapabilityGapNoticeOnce emits the once-per-session notice listing
+// turn's capability snapshot entries in the gap state, the first time
+// any turn starts. It reads turn's own snapshot rather than the pump's
+// live record, so the notice always reports what the session's first
+// turn actually saw, and never runs a second time for the same
+// session.
+func (p *pumpState) emitCapabilityGapNoticeOnce(turn *activeTurn) {
+	if p.capabilityNoticeSent {
+		return
+	}
+	p.capabilityNoticeSent = true
+
+	message, hasGap := turn.capsSnapshot.gapNotice()
+	if !hasGap {
+		return
+	}
+	agentcore.EmitNotification(p.publish(turn), message)
 }
 
 // finalizeTurn ends the active turn, calling agentcore.FinalizeTurn

--- a/internal/agent/clientprotocol/pump_test.go
+++ b/internal/agent/clientprotocol/pump_test.go
@@ -188,8 +188,8 @@ func TestPumpDispatchNullID(t *testing.T) {
 
 // TestSessionUpdateBeforeAnyPromptNotLost confirms a message arriving
 // before any prompt is not lost. It is queued and flushed into the
-// next turn's sink immediately after that turn's own session_started
-// event.
+// next turn's sink after that turn's own session_started event and the
+// once-per-session capability notice.
 func TestSessionUpdateBeforeAnyPromptNotLost(t *testing.T) {
 	t.Parallel()
 
@@ -210,8 +210,12 @@ func TestSessionUpdateBeforeAnyPromptNotLost(t *testing.T) {
 		t.Fatalf("first event type = %q, want %q", first.Type, domain.EventSessionStarted)
 	}
 	second := waitEvent(t, eventCh)
-	if second.Type != domain.EventNotification || second.Message != "queued before any turn" {
-		t.Fatalf("second event = %+v, want the queued notification flushed right after session_started", second)
+	if second.Type != domain.EventNotification {
+		t.Fatalf("second event type = %q, want %q (the once-per-session capability notice)", second.Type, domain.EventNotification)
+	}
+	third := waitEvent(t, eventCh)
+	if third.Type != domain.EventNotification || third.Message != "queued before any turn" {
+		t.Fatalf("third event = %+v, want the queued notification flushed after session_started and the capability notice", third)
 	}
 
 	promptID := out.awaitMethod(t, methodSessionPrompt)

--- a/internal/agent/clientprotocol/session.go
+++ b/internal/agent/clientprotocol/session.go
@@ -52,6 +52,11 @@ type sessionState struct {
 	target      agentcore.LaunchTarget
 	agentConfig domain.AgentConfig
 
+	// caps is built with its stage-one states before the pump starts and
+	// is owned by the pump from that point on: nothing outside the pump
+	// goroutine may mutate the value it points to.
+	caps *capabilityRecord
+
 	conn *jsonrpc.Conn
 
 	pid             int
@@ -94,6 +99,11 @@ type handshakeFacts struct {
 	agentInfo        implementation
 	agentInfoPresent bool
 	caps             agentCapabilities
+
+	// toolServersWithheld reports whether the generated configuration
+	// declared an HTTP tool server that this handshake's advertised MCP
+	// capabilities do not support, so it was omitted from session/new.
+	toolServersWithheld bool
 }
 
 // turnStart is what RunTurn publishes to start one turn.
@@ -131,9 +141,12 @@ func readTimeout(state *sessionState) time.Duration {
 }
 
 // startSession launches the runtime, performs the initialize handshake,
-// and creates a session with session/new. Session continuation and the
-// capability record are not implemented by this piece: every session is
-// created with session/new, and ResumeSessionID is not read.
+// and creates a session with session/new. Session continuation is not
+// implemented by this piece: every session is created with session/new,
+// and ResumeSessionID is not read. The session capability record is
+// built with its stage-one states before the pump starts, and the pump
+// applies handshake-based lowering to it once the handshake control
+// message arrives.
 func startSession(ctx context.Context, params domain.StartSessionParams) (domain.Session, error) {
 	target, agentErr := agentcore.ResolveLaunchTarget(params, "")
 	if agentErr != nil {
@@ -213,6 +226,12 @@ func startSession(ctx context.Context, params domain.StartSessionParams) (domain
 		close(state.waitCh)
 	}()
 
+	// The capability record is built here, on this goroutine, with its
+	// stage-one states, before the pump starts. The pump's start orders
+	// this write exactly as it orders the launch target beside it:
+	// StartSession must not touch state.caps after this point.
+	state.caps = newCapabilityRecord(remote)
+
 	// Start the pump before the handshake, so it is the sole mutator of
 	// session protocol state from this point on; StartSession publishes
 	// what it learns as control messages rather than writing that state
@@ -242,7 +261,7 @@ func startSession(ctx context.Context, params domain.StartSessionParams) (domain
 		return domain.Session{}, agentErr
 	}
 
-	facts := &handshakeFacts{}
+	facts := &handshakeFacts{toolServersWithheld: withheld}
 	if initResp.AgentCapabilities != nil {
 		facts.caps = *initResp.AgentCapabilities
 	}

--- a/internal/agent/clientprotocol/session_teardown_test.go
+++ b/internal/agent/clientprotocol/session_teardown_test.go
@@ -165,6 +165,7 @@ func newParkedTeardownSession(t *testing.T, wiring pipeWiring) *parkedTeardownFi
 		pumpDone:     make(chan struct{}),
 		logger:       discardLogger(),
 		agentConfig:  domain.AgentConfig{ReadTimeoutMS: 60000},
+		caps:         newCapabilityRecord(false),
 	}
 	state.stderrCollector = procutil.NewStderrCollector(stderrPipe, state.logger)
 

--- a/internal/agent/clientprotocol/session_test.go
+++ b/internal/agent/clientprotocol/session_test.go
@@ -154,6 +154,7 @@ func TestRunTurnPreTurnWaits(t *testing.T) {
 			state := &sessionState{
 				agentConfig: domain.AgentConfig{ReadTimeoutMS: 50},
 				itemCh:      make(chan pumpItem, 1),
+				caps:        newCapabilityRecord(false),
 			}
 			if tt.fillQueue {
 				state.itemCh <- pumpItem{}
@@ -215,6 +216,7 @@ func TestDelayedTurnVerdictCannotBlockPump(t *testing.T) {
 		agentConfig: domain.AgentConfig{ReadTimeoutMS: 20},
 		itemCh:      make(chan pumpItem, 1),
 		logger:      discardLogger(),
+		caps:        newCapabilityRecord(false),
 	}
 
 	outcome := awaitOutcome(t, runTurnAsyncCtx(context.Background(), state, domain.RunTurnParams{
@@ -258,6 +260,7 @@ func TestAbandonedTurnIsNotStarted(t *testing.T) {
 		agentConfig: domain.AgentConfig{ReadTimeoutMS: 20},
 		itemCh:      make(chan pumpItem, 1),
 		logger:      discardLogger(),
+		caps:        newCapabilityRecord(false),
 	}
 
 	outcome := awaitOutcome(t, runTurnAsyncCtx(context.Background(), state, domain.RunTurnParams{


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Feat

**Intent:** Resolve capability differences between agents at runtime instead of declaring them per kind. The Agent Client Protocol session now carries a per-session capability record (tool servers, token counts, session continuation, agent version) seeded from structural knowledge and the initialize handshake, and it can only be lowered, never raised, for the life of the session.

**Related Issues:** #976

### 🧭 Reviewer Guide

**Complexity:** Medium

#### Entry Point

`internal/agent/clientprotocol/capability.go` - defines `capabilityRecord`, its four entries, and the once-per-session gap notice text. Start here to see the states an entry can hold (`protocol` / `gap`), that lowering is one-directional, and that the notice is assembled only from compile-time fragments so nothing runtime-specific is interpolated into it.

From there, `internal/agent/clientprotocol/pump.go` shows how the record is wired in: `startSession` builds the record with its stage-one states before the pump starts (`internal/agent/clientprotocol/session.go`), and the pump becomes the sole mutator from that point on. `applyHandshakeCapabilityLowering` lowers entries from what the initialize response actually advertised, and each `activeTurn` carries its own `capsSnapshot` so a lowering observed mid-turn takes effect from the next turn onward rather than changing a turn already in flight.

#### Sensitive Areas

- `internal/agent/clientprotocol/pump.go`: the pump is the single owner of session protocol state; `lowerCapability` and `emitCapabilityGapNoticeOnce` need to preserve that a lowering after the first notice logs a warning instead of emitting a second notice.
- `internal/agent/clientprotocol/session.go`: `state.caps` is built once, before the pump starts, and must not be touched by `startSession` afterward - the comment on that line documents the ownership handoff.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes.
- **Migrations/State:** No migrations or state changes.
