### PR TITLE
feat: add session continuation to the ACP agent transport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- The new `agent-client-protocol` agent kind runs Agent Client Protocol-compatible runtimes over stdio and resumes previous sessions when supported by the runtime. Locally launched runtimes can use workflow-configured MCP servers, while requests requiring human input are refused or end the attempt rather than waiting indefinitely. Token-based budgets do not apply because the protocol does not report token usage.
+  ([#976](https://github.com/sortie-ai/sortie/issues/976))
+
 ### Fixed
 
 - A string-typed adapter configuration key whose value carries another YAML type, such as `tracker.endpoint: 123`, `agent.kind: 123`, or a mistyped `claude-code.model`, is now rejected with a diagnostic naming the key and the type found, instead of being silently coerced to the empty string and then treated as absent or defaulted to the adapter's own default. A workflow that previously started with such a value now fails at config load, at adapter construction, or offline through `sortie validate`, whichever reads the key first; the fix is to quote the value or remove the key.

--- a/docs/agent-client-protocol-adapter-notes.md
+++ b/docs/agent-client-protocol-adapter-notes.md
@@ -22,7 +22,9 @@ The entry point is the `acp` subcommand. The handshake advertises `loadSession` 
 
 The entry point is the `--acp` flag; a `--experimental-acp` spelling also exists and is deprecated. The handshake advertises `loadSession` true and both `mcpCapabilities.http` and `mcpCapabilities.sse` true, and it advertises no `sessionCapabilities` object at all.
 
-This is the one runtime the gated suite was driven against end to end: a session starts, a turn runs to a completed outcome, a `session/request_permission` request arrives mid-turn and the adapter refuses it inside the protocol with the turn continuing past the refusal to completion, and the session stops cleanly afterward. Session continuation, `session/load` and `session/resume`, is not exercised against this runtime in this work.
+This is the one runtime the gated suite was driven against end to end: a session starts, a turn runs to a completed outcome, a `session/request_permission` request arrives mid-turn and the adapter refuses it inside the protocol with the turn continuing past the refusal to completion, and the session stops cleanly afterward.
+
+Session continuation was probed by hand against this runtime, not through the gated suite. `session/load` replays the prior turn's messages, observed as `user_message_chunk` notifications arriving before the load response itself returns, when the workspace directory already carries earlier session history. Against a workspace used for the first time, whose only session was ended the way this adapter always ends one, by terminating the process group rather than by a graceful exit, a reload of that session answers a JSON-RPC error reporting no prior session for the workspace instead of replaying anything; the adapter observes this exactly as it observes any other unconfirmed load, lowering the session continuation entry and falling back to a fresh session without failing the run. `session/resume` is not exercised: this runtime advertises no `sessionCapabilities` object at all, so the adapter never selects it.
 
 ## Runtimes not observed
 

--- a/internal/agent/clientprotocol/capability.go
+++ b/internal/agent/clientprotocol/capability.go
@@ -47,10 +47,12 @@ type capabilityRecord struct {
 // before the handshake. remote reports whether the session's launch
 // target runs the agent on a remote host.
 //
-// sessionContinuation starts at gap because session continuation is
-// not implemented yet; a local launch with no generated tool-server
-// configuration at all still leaves toolServers at protocol, because
-// nothing was withheld when nothing was offered.
+// sessionContinuation starts at protocol: the handshake lowers it when
+// the agent advertises neither continuation method, and a continuation
+// call the agent does not deliver on lowers it later still. A local
+// launch with no generated tool-server configuration at all leaves
+// toolServers at protocol, because nothing was withheld when nothing
+// was offered.
 func newCapabilityRecord(remote bool) *capabilityRecord {
 	toolServers := capabilityProtocol
 	if remote {
@@ -59,7 +61,7 @@ func newCapabilityRecord(remote bool) *capabilityRecord {
 	return &capabilityRecord{
 		toolServers:         toolServers,
 		tokenCounts:         capabilityGap,
-		sessionContinuation: capabilityGap,
+		sessionContinuation: capabilityProtocol,
 		agentVersion:        capabilityProtocol,
 	}
 }
@@ -101,12 +103,11 @@ func (r capabilityRecord) gapNotice() (string, bool) {
 
 // advertisesSessionContinuation reports whether caps advertises support
 // for continuing a prior session through session/load or
-// session/resume.
+// session/resume. It defers to [chooseContinuationMethod] so the
+// handshake's lowering decision and resolveSession's routing decision
+// can never disagree about what caps advertises.
 func advertisesSessionContinuation(caps agentCapabilities) bool {
-	if caps.LoadSession != nil && *caps.LoadSession {
-		return true
-	}
-	return caps.SessionCapabilities != nil && caps.SessionCapabilities.Resume != nil
+	return chooseContinuationMethod(caps) != continuationNone
 }
 
 // lower moves *entry to the gap state and reports whether it actually

--- a/internal/agent/clientprotocol/capability_test.go
+++ b/internal/agent/clientprotocol/capability_test.go
@@ -50,11 +50,12 @@ func TestNewCapabilityRecordToolServersStageOne(t *testing.T) {
 
 // TestNewCapabilityRecordStageOneEntries confirms all four stage-one
 // entries independently of any handshake, for both launch arms. The
-// sessionContinuation case is the load-bearing one: session
-// continuation is not implemented, so the entry must start at gap
-// whichever way the launch resolves. Only a handshake-free assertion
-// can prove it, because the handshake lowers that entry anyway and
-// would mask a wrong default.
+// sessionContinuation case is the load-bearing one: it must start at
+// protocol whichever way the launch resolves, because nothing is known
+// yet about whether the agent advertises a continuation method. Only a
+// handshake-free assertion can prove it, because the handshake lowers
+// that entry when neither method is advertised and would mask a wrong
+// default.
 func TestNewCapabilityRecordStageOneEntries(t *testing.T) {
 	t.Parallel()
 
@@ -82,8 +83,8 @@ func TestNewCapabilityRecordStageOneEntries(t *testing.T) {
 			if record.tokenCounts != capabilityGap {
 				t.Errorf("newCapabilityRecord(%v).tokenCounts = %q, want %q", tt.remote, record.tokenCounts, capabilityGap)
 			}
-			if record.sessionContinuation != capabilityGap {
-				t.Errorf("newCapabilityRecord(%v).sessionContinuation = %q, want %q: session continuation is not implemented yet", tt.remote, record.sessionContinuation, capabilityGap)
+			if record.sessionContinuation != capabilityProtocol {
+				t.Errorf("newCapabilityRecord(%v).sessionContinuation = %q, want %q", tt.remote, record.sessionContinuation, capabilityProtocol)
 			}
 			if record.agentVersion != capabilityProtocol {
 				t.Errorf("newCapabilityRecord(%v).agentVersion = %q, want %q", tt.remote, record.agentVersion, capabilityProtocol)
@@ -371,6 +372,40 @@ func TestToolServersLoweredWhenWithheld(t *testing.T) {
 	}
 }
 
+// TestSessionContinuationLoweredWhenHandshakeAdvertisesNeither confirms
+// the handshake-based half of sessionContinuation's lowering: a
+// handshake advertising neither continuation method lowers the entry
+// from its now-protocol stage-one default, while advertising either
+// one leaves it there. This branch was inert before this piece flipped
+// newCapabilityRecord's stage-one default to protocol, so no earlier
+// test observed it doing anything.
+func TestSessionContinuationLoweredWhenHandshakeAdvertisesNeither(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		caps      agentCapabilities
+		wantState capabilityState
+	}{
+		{name: "neither loadSession nor resume advertised lowers the entry", caps: agentCapabilities{}, wantState: capabilityGap},
+		{name: "loadSession advertised leaves the entry at its stage-one state", caps: capsAdvertisingLoad(), wantState: capabilityProtocol},
+		{name: "sessionCapabilities.resume advertised leaves the entry at its stage-one state", caps: capsAdvertisingResume(), wantState: capabilityProtocol},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			state, p := newPumpForCapabilityTests(t)
+			p.applyHandshakeCapabilityLowering(&handshakeFacts{agentInfoPresent: true, caps: tt.caps})
+
+			if state.caps.sessionContinuation != tt.wantState {
+				t.Errorf("sessionContinuation after applyHandshakeCapabilityLowering(caps=%+v) = %q, want %q", tt.caps, state.caps.sessionContinuation, tt.wantState)
+			}
+		})
+	}
+}
+
 // TestAdvertisesSessionContinuation confirms the predicate over the
 // four shapes that matter. The asymmetry between the two branches is
 // schema-driven, not a testing inconsistency: LoadSession is a *bool,
@@ -423,6 +458,47 @@ func TestAdvertisesSessionContinuation(t *testing.T) {
 
 			if got != tt.want {
 				t.Errorf("advertisesSessionContinuation(%+v) = %v, want %v", tt.caps, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestAdvertisesSessionContinuationAgreesWithChooseContinuationMethod
+// confirms the handshake's lowering predicate and resolveSession's own
+// routing decision can never disagree about what caps advertises,
+// across a matrix wider than either function's own dedicated test: an
+// agent that advertised both, or that advertised one falsely, would
+// otherwise risk one predicate reporting a capability the other never
+// attempts, or an attempt the other reports as a gap.
+func TestAdvertisesSessionContinuationAgreesWithChooseContinuationMethod(t *testing.T) {
+	t.Parallel()
+
+	trueVal := true
+	falseVal := false
+	resume := &sessionCapabilities{Resume: &sessionResumeCapabilities{}}
+
+	tests := []struct {
+		name string
+		caps agentCapabilities
+	}{
+		{name: "neither advertised", caps: agentCapabilities{}},
+		{name: "loadSession true only", caps: agentCapabilities{LoadSession: &trueVal}},
+		{name: "loadSession false only", caps: agentCapabilities{LoadSession: &falseVal}},
+		{name: "resume only", caps: agentCapabilities{SessionCapabilities: resume}},
+		{name: "loadSession true and resume both advertised", caps: agentCapabilities{LoadSession: &trueVal, SessionCapabilities: resume}},
+		{name: "loadSession false and resume advertised", caps: agentCapabilities{LoadSession: &falseVal, SessionCapabilities: resume}},
+		{name: "sessionCapabilities present with close but no resume", caps: agentCapabilities{SessionCapabilities: &sessionCapabilities{Close: &sessionCloseCapabilities{}}}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			advertises := advertisesSessionContinuation(tt.caps)
+			routes := chooseContinuationMethod(tt.caps) != continuationNone
+
+			if advertises != routes {
+				t.Errorf("advertisesSessionContinuation(%+v) = %v, chooseContinuationMethod(%+v) != continuationNone = %v, want agreement", tt.caps, advertises, tt.caps, routes)
 			}
 		})
 	}

--- a/internal/agent/clientprotocol/continuation.go
+++ b/internal/agent/clientprotocol/continuation.go
@@ -1,0 +1,242 @@
+package clientprotocol
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/sortie-ai/sortie/internal/domain"
+)
+
+// negativeControlMethod names a request in a vendor namespace no
+// protocol release can claim, sent once before the first continuation
+// call of a session so an unimplemented continuation method and a
+// broken one are distinguishable by their error codes rather than
+// assumed apart.
+const negativeControlMethod = "_sortie.dev/probe/unimplemented"
+
+// continuationMethod is the route resolveSession chooses from the
+// handshake's advertised capabilities, in fixed order: session/load
+// when advertised, otherwise session/resume when advertised, otherwise
+// no continuation method at all.
+type continuationMethod uint8
+
+const (
+	continuationNone continuationMethod = iota
+	continuationLoad
+	continuationResume
+)
+
+// chooseContinuationMethod picks the continuation route caps allows.
+func chooseContinuationMethod(caps agentCapabilities) continuationMethod {
+	if caps.LoadSession != nil && *caps.LoadSession {
+		return continuationLoad
+	}
+	if caps.SessionCapabilities != nil && caps.SessionCapabilities.Resume != nil {
+		return continuationResume
+	}
+	return continuationNone
+}
+
+// negativeControlVerdict is what the negative control recorded: an
+// error code the agent actually answered with, or none when the agent
+// nonconformantly answered success.
+type negativeControlVerdict struct {
+	code     int
+	hadError bool
+}
+
+// matches reports whether code is the same error the negative control
+// itself produced.
+func (v negativeControlVerdict) matches(code int) bool {
+	return v.hadError && v.code == code
+}
+
+// sendNegativeControl sends the negative control request and records
+// the agent's answer. A stream end or a timeout while it is in flight
+// surfaces the same normalized failure any other loss of the agent
+// connection does.
+func sendNegativeControl(ctx context.Context, state *sessionState) (negativeControlVerdict, *domain.AgentError) {
+	callCtx, cancel := context.WithTimeout(ctx, readTimeout(state))
+	defer cancel()
+
+	resp, err := state.conn.Call(callCtx, negativeControlMethod, struct{}{})
+	if agentErr := translateCallError(err, callCtx); agentErr != nil {
+		return negativeControlVerdict{}, agentErr
+	}
+	if resp.Error != nil {
+		return negativeControlVerdict{code: resp.Error.Code, hadError: true}, nil
+	}
+	return negativeControlVerdict{}, nil
+}
+
+// resolveSession creates or continues the session: session/new alone
+// when resumeID is empty or the handshake advertised no continuation
+// method, otherwise the advertised route, confirmed against the
+// negative control and, for a load, against observed replay, falling
+// back to session/new within this same call whenever continuation is
+// not confirmed. It returns the identifier of the session the agent
+// actually created, which is the loaded identifier only when the load
+// route was confirmed.
+func resolveSession(ctx context.Context, state *sessionState, resumeID string, caps agentCapabilities, cwd string, servers []mcpServer) (string, *domain.AgentError) {
+	if resumeID == "" {
+		return createNewSession(ctx, state, cwd, servers)
+	}
+
+	method := chooseContinuationMethod(caps)
+	if method == continuationNone {
+		return createNewSession(ctx, state, cwd, servers)
+	}
+
+	control, agentErr := sendNegativeControl(ctx, state)
+	if agentErr != nil {
+		if agentErr.Kind != domain.ErrResponseTimeout {
+			return "", agentErr
+		}
+		state.logger.Warn("continuation negative control timed out", slog.String("method", negativeControlMethod))
+		return unconfirmedFallback(ctx, state, cwd, servers)
+	}
+
+	switch method {
+	case continuationLoad:
+		return resolveLoad(ctx, state, resumeID, cwd, servers, control)
+	case continuationResume:
+		return resolveResume(ctx, state, resumeID, cwd, servers, control)
+	default:
+		return createNewSession(ctx, state, cwd, servers)
+	}
+}
+
+// resolveLoad attempts session/load for resumeID. A response carrying
+// an error lowers sessionContinuation and falls back at once. A
+// successful response is not enough on its own: the pump must observe
+// at least one chunk replayed for resumeID, before the response
+// returns or within the connection's own read timeout after it, or the
+// entry is lowered and this falls back the same way. A call that times
+// out waiting for any response at all is treated the same as one that
+// answered with an error: the capability is not confirmed, not the
+// run.
+func resolveLoad(ctx context.Context, state *sessionState, resumeID, cwd string, servers []mcpServer, control negativeControlVerdict) (string, *domain.AgentError) {
+	if agentErr := sendControl(ctx, state, pumpItem{control: &pumpControl{expectLoad: resumeID}}); agentErr != nil {
+		return "", agentErr
+	}
+
+	callCtx, cancel := context.WithTimeout(ctx, readTimeout(state))
+	defer cancel()
+	resp, err := state.conn.Call(callCtx, methodSessionLoad, loadSessionRequest{
+		Cwd: cwd, MCPServers: servers, SessionID: sessionId(resumeID),
+	})
+	if agentErr := translateCallError(err, callCtx); agentErr != nil {
+		if agentErr.Kind != domain.ErrResponseTimeout {
+			return "", agentErr
+		}
+		state.logger.Warn("continuation call timed out", slog.String("method", methodSessionLoad))
+		return unconfirmedFallback(ctx, state, cwd, servers)
+	}
+	if resp.Error != nil {
+		logContinuationFailure(state, methodSessionLoad, resp.Error.Code, control)
+		return unconfirmedFallback(ctx, state, cwd, servers)
+	}
+
+	reply := make(chan bool, 1)
+	if agentErr := sendControl(ctx, state, pumpItem{control: &pumpControl{query: &replayQuery{reply: reply}}}); agentErr != nil {
+		return "", agentErr
+	}
+
+	timer := time.NewTimer(readTimeout(state))
+	defer timer.Stop()
+	select {
+	case confirmed := <-reply:
+		if confirmed {
+			return resumeID, nil
+		}
+	case <-timer.C:
+	}
+	return createNewSession(ctx, state, cwd, servers)
+}
+
+// resolveResume attempts session/resume for resumeID. No replay is
+// expected: a successful response alone confirms it. A response
+// carrying an error, or a timeout waiting for any response at all,
+// lowers sessionContinuation and falls back.
+func resolveResume(ctx context.Context, state *sessionState, resumeID, cwd string, servers []mcpServer, control negativeControlVerdict) (string, *domain.AgentError) {
+	callCtx, cancel := context.WithTimeout(ctx, readTimeout(state))
+	defer cancel()
+
+	var wireServers *[]mcpServer
+	if len(servers) > 0 {
+		wireServers = &servers
+	}
+	resp, err := state.conn.Call(callCtx, methodSessionResume, resumeSessionRequest{
+		Cwd: cwd, MCPServers: wireServers, SessionID: sessionId(resumeID),
+	})
+	if agentErr := translateCallError(err, callCtx); agentErr != nil {
+		if agentErr.Kind != domain.ErrResponseTimeout {
+			return "", agentErr
+		}
+		state.logger.Warn("continuation call timed out", slog.String("method", methodSessionResume))
+		return unconfirmedFallback(ctx, state, cwd, servers)
+	}
+	if resp.Error != nil {
+		logContinuationFailure(state, methodSessionResume, resp.Error.Code, control)
+		return unconfirmedFallback(ctx, state, cwd, servers)
+	}
+	return resumeID, nil
+}
+
+// unconfirmedFallback lowers sessionContinuation through the pump's
+// own mutation path and creates a fresh session with session/new. It
+// is the outcome required whenever a continuation call, or the
+// negative control that precedes it, does not confirm the entry: an
+// explicit error response or a timeout waiting for one. The fallback
+// itself never fails the run on its own account.
+func unconfirmedFallback(ctx context.Context, state *sessionState, cwd string, servers []mcpServer) (string, *domain.AgentError) {
+	if agentErr := sendControl(ctx, state, pumpItem{control: &pumpControl{query: &replayQuery{}}}); agentErr != nil {
+		return "", agentErr
+	}
+	return createNewSession(ctx, state, cwd, servers)
+}
+
+// sendControl publishes item to the pump's input channel, bounded by
+// ctx and the connection's own read timeout, so a stalled pump can
+// never leave a continuation call blocked on an unbounded send the way
+// runTurn's own control publish is bounded.
+func sendControl(ctx context.Context, state *sessionState, item pumpItem) *domain.AgentError {
+	timer := time.NewTimer(readTimeout(state))
+	defer timer.Stop()
+	select {
+	case state.itemCh <- item:
+		return nil
+	case <-ctx.Done():
+		return &domain.AgentError{Kind: domain.ErrPortExit, Message: "context ended before a control message reached the agent connection", Err: ctx.Err()}
+	case <-timer.C:
+		return &domain.AgentError{Kind: domain.ErrResponseTimeout, Message: "timed out publishing a control message to the agent connection", Err: context.DeadlineExceeded}
+	}
+}
+
+// createNewSession creates a fresh session with session/new: the route
+// taken when no continuation is attempted, none is advertised, or the
+// one attempted is not confirmed. A failure here is reported exactly
+// as it would have been had continuation never been attempted; the
+// fallback itself never fails the run on its own account.
+func createNewSession(ctx context.Context, state *sessionState, cwd string, servers []mcpServer) (string, *domain.AgentError) {
+	resp, agentErr := doNewSession(ctx, state, cwd, servers)
+	if agentErr != nil {
+		return "", agentErr
+	}
+	return string(resp.SessionID), nil
+}
+
+// logContinuationFailure records that a continuation call did not
+// confirm its capability. An error code matching the negative
+// control's own establishes the method as genuinely unimplemented; any
+// other code is a real failure of that call. Neither distinction
+// changes the outcome: both lower the capability entry and fall back
+// to a fresh session.
+func logContinuationFailure(state *sessionState, method string, code int, control negativeControlVerdict) {
+	if control.matches(code) {
+		state.logger.Debug("continuation method not implemented", slog.String("method", method))
+		return
+	}
+	state.logger.Warn("continuation call failed", slog.String("method", method), slog.Int("code", code))
+}

--- a/internal/agent/clientprotocol/continuation.go
+++ b/internal/agent/clientprotocol/continuation.go
@@ -150,9 +150,10 @@ func resolveLoad(ctx context.Context, state *sessionState, resumeID, cwd string,
 		if confirmed {
 			return resumeID, nil
 		}
+		return createNewSession(ctx, state, cwd, servers)
 	case <-timer.C:
+		return unconfirmedFallback(ctx, state, cwd, servers)
 	}
-	return createNewSession(ctx, state, cwd, servers)
 }
 
 // resolveResume attempts session/resume for resumeID. No replay is

--- a/internal/agent/clientprotocol/continuation_test.go
+++ b/internal/agent/clientprotocol/continuation_test.go
@@ -1,0 +1,537 @@
+package clientprotocol
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sortie-ai/sortie/internal/domain"
+)
+
+// resolveSessionOutcome bundles resolveSession's return values so a
+// test can hand them across a goroutine boundary on one channel.
+type resolveSessionOutcome struct {
+	sessionID string
+	err       *domain.AgentError
+}
+
+// runResolveSessionAsync starts resolveSession on its own goroutine
+// with an empty workspace and no tool servers, neither of which any
+// case in this file depends on, and returns the channel its outcome
+// arrives on so the calling test can drive the simulated peer while
+// the call is in flight.
+func runResolveSessionAsync(ctx context.Context, state *sessionState, resumeID string, caps agentCapabilities) <-chan resolveSessionOutcome {
+	ch := make(chan resolveSessionOutcome, 1)
+	go func() {
+		sessionID, err := resolveSession(ctx, state, resumeID, caps, "", nil)
+		ch <- resolveSessionOutcome{sessionID: sessionID, err: err}
+	}()
+	return ch
+}
+
+// awaitResolveSessionOutcome waits for outcome on ch, failing t if it
+// does not arrive within awaitTimeout.
+func awaitResolveSessionOutcome(t *testing.T, ch <-chan resolveSessionOutcome) resolveSessionOutcome {
+	t.Helper()
+	select {
+	case outcome := <-ch:
+		return outcome
+	case <-time.After(awaitTimeout):
+		t.Fatal("timed out waiting for resolveSession to return")
+		return resolveSessionOutcome{}
+	}
+}
+
+// capsAdvertisingLoad returns handshake-advertised capabilities that
+// select the session/load continuation route.
+func capsAdvertisingLoad() agentCapabilities {
+	loadSession := true
+	return agentCapabilities{LoadSession: &loadSession}
+}
+
+// capsAdvertisingResume returns handshake-advertised capabilities that
+// advertise session/resume and no session/load, so the resume route is
+// the one chooseContinuationMethod selects.
+func capsAdvertisingResume() agentCapabilities {
+	return agentCapabilities{SessionCapabilities: &sessionCapabilities{Resume: &sessionResumeCapabilities{}}}
+}
+
+// firstOutboundMethod decodes the very first line the pump wrote and
+// returns its method and raw id, failing t on a decode error. Unlike
+// outboundReader.awaitMethod, which discards lines for any other
+// method while scanning forward, this fails a test outright when an
+// earlier, unwanted line was written first.
+func firstOutboundMethod(t *testing.T, out *outboundReader) (method string, id json.RawMessage) {
+	t.Helper()
+	line := out.next(t)
+	var h wireHeader
+	if err := json.Unmarshal(line, &h); err != nil {
+		t.Fatalf("decode first outbound line %s: %v", line, err)
+	}
+	return h.Method, h.ID
+}
+
+// assertSessionContinuationEntry marks state's session id known, runs
+// one turn to completion, and fails t unless the once-per-session gap
+// notice's mention of the session continuation label matches wantGap.
+// A gap notice is guaranteed to fire regardless of the outcome under
+// test, because a local launch's stage-one record already carries
+// tokenCounts at gap.
+func assertSessionContinuationEntry(t *testing.T, state *sessionState, out *outboundReader, inPw io.Writer, wantGap bool) {
+	t.Helper()
+
+	markSessionKnown(state)
+	var events []domain.AgentEvent
+	outcomeCh := runTurnAsync(state, domain.RunTurnParams{Prompt: "go", OnEvent: collectEvents(&events)})
+	promptID := out.awaitMethod(t, methodSessionPrompt)
+	respondLine(t, inPw, promptID, promptResponse{StopReason: stopReasonEndTurn})
+	outcome := awaitOutcome(t, outcomeCh)
+	if outcome.err != nil {
+		t.Fatalf("RunTurn() error = %v, want nil", outcome.err)
+	}
+
+	notice := firstNotification(t, events)
+	gotGap := strings.Contains(notice.Message, capabilityLabelSessionContinuation)
+	if gotGap != wantGap {
+		t.Errorf("gap notice = %q, session continuation listed = %v, want %v", notice.Message, gotGap, wantGap)
+	}
+}
+
+// TestChooseContinuationMethod confirms the fixed priority order:
+// session/load first when advertised, session/resume only
+// when load is not, and no continuation method when neither is.
+func TestChooseContinuationMethod(t *testing.T) {
+	t.Parallel()
+
+	both := capsAdvertisingLoad()
+	both.SessionCapabilities = capsAdvertisingResume().SessionCapabilities
+
+	tests := []struct {
+		name string
+		caps agentCapabilities
+		want continuationMethod
+	}{
+		{name: "both load and resume advertised selects load", caps: both, want: continuationLoad},
+		{name: "only load advertised selects load", caps: capsAdvertisingLoad(), want: continuationLoad},
+		{name: "only resume advertised selects resume", caps: capsAdvertisingResume(), want: continuationResume},
+		{name: "neither advertised selects no continuation method", caps: agentCapabilities{}, want: continuationNone},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := chooseContinuationMethod(tt.caps)
+
+			if got != tt.want {
+				t.Errorf("chooseContinuationMethod(%+v) = %v, want %v", tt.caps, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestResolveSessionEmptyResumeIDSkipsContinuation confirms that an
+// empty ResumeSessionID calls session/new alone, with no negative
+// control and no continuation method ever sent, even though the
+// handshake advertised one.
+func TestResolveSessionEmptyResumeIDSkipsContinuation(t *testing.T) {
+	t.Parallel()
+
+	state, outPr, inPw := newTestSession(t, domain.AgentConfig{}, clientProtocolMaxLineBytes)
+	out := newOutboundReader(outPr)
+
+	outcomeCh := runResolveSessionAsync(context.Background(), state, "", capsAdvertisingLoad())
+
+	method, id := firstOutboundMethod(t, out)
+	if method != methodSessionNew {
+		t.Fatalf("first outbound method = %q, want %q: an empty ResumeSessionID must call session/new alone", method, methodSessionNew)
+	}
+	respondLine(t, inPw, id, newSessionResponse{SessionID: sessionId("brand-new")})
+
+	outcome := awaitResolveSessionOutcome(t, outcomeCh)
+	if outcome.err != nil {
+		t.Fatalf("resolveSession() error = %v, want nil", outcome.err)
+	}
+	if outcome.sessionID != "brand-new" {
+		t.Errorf("resolveSession() session id = %q, want %q", outcome.sessionID, "brand-new")
+	}
+}
+
+// TestResolveSessionLoadUnimplementedLowersAndFallsBack confirms that
+// a session/load call answered
+// with the negative control's own error code lowers the
+// sessionContinuation entry and falls back to a new session, without
+// failing the run.
+func TestResolveSessionLoadUnimplementedLowersAndFallsBack(t *testing.T) {
+	t.Parallel()
+
+	state, outPr, inPw := newTestSession(t, domain.AgentConfig{ReadTimeoutMS: 2000}, clientProtocolMaxLineBytes)
+	out := newOutboundReader(outPr)
+
+	outcomeCh := runResolveSessionAsync(context.Background(), state, "prior-session", capsAdvertisingLoad())
+
+	probeID := out.awaitMethod(t, negativeControlMethod)
+	respondErrorLine(t, inPw, probeID, jsonrpcMethodNotFound, "method not found")
+
+	loadID := out.awaitMethod(t, methodSessionLoad)
+	respondErrorLine(t, inPw, loadID, jsonrpcMethodNotFound, "method not found")
+
+	newID := out.awaitMethod(t, methodSessionNew)
+	respondLine(t, inPw, newID, newSessionResponse{SessionID: sessionId("fallback-session")})
+
+	outcome := awaitResolveSessionOutcome(t, outcomeCh)
+	if outcome.err != nil {
+		t.Fatalf("resolveSession() error = %v, want nil: a continuation the agent does not implement must not fail the run", outcome.err)
+	}
+	if outcome.sessionID != "fallback-session" {
+		t.Errorf("resolveSession() session id = %q, want %q: the fallback session/new's own identifier", outcome.sessionID, "fallback-session")
+	}
+
+	assertSessionContinuationEntry(t, state, out, inPw, true)
+}
+
+// TestResolveSessionLoadRealFailureLowersAndFallsBack confirms that a
+// session/load call answered with an error other than
+// the negative control's own code is a real failure of that call, and
+// it still lowers the sessionContinuation entry and falls back, the
+// same as the unimplemented case, because the capability did not
+// deliver either way.
+func TestResolveSessionLoadRealFailureLowersAndFallsBack(t *testing.T) {
+	t.Parallel()
+
+	state, outPr, inPw := newTestSession(t, domain.AgentConfig{ReadTimeoutMS: 2000}, clientProtocolMaxLineBytes)
+	out := newOutboundReader(outPr)
+
+	outcomeCh := runResolveSessionAsync(context.Background(), state, "prior-session", capsAdvertisingLoad())
+
+	probeID := out.awaitMethod(t, negativeControlMethod)
+	respondErrorLine(t, inPw, probeID, jsonrpcMethodNotFound, "method not found")
+
+	loadID := out.awaitMethod(t, methodSessionLoad)
+	respondErrorLine(t, inPw, loadID, -32000, "session store unavailable")
+
+	newID := out.awaitMethod(t, methodSessionNew)
+	respondLine(t, inPw, newID, newSessionResponse{SessionID: sessionId("fallback-session")})
+
+	outcome := awaitResolveSessionOutcome(t, outcomeCh)
+	if outcome.err != nil {
+		t.Fatalf("resolveSession() error = %v, want nil: a real continuation failure must still fall back rather than fail the run", outcome.err)
+	}
+	if outcome.sessionID != "fallback-session" {
+		t.Errorf("resolveSession() session id = %q, want %q", outcome.sessionID, "fallback-session")
+	}
+
+	assertSessionContinuationEntry(t, state, out, inPw, true)
+}
+
+// TestResolveSessionLoadSuccessNoReplayLowersAndFallsBack confirms
+// that a session/load response carrying success is not enough on its
+// own. With no chunk ever replayed for the loaded identifier, the
+// pump's own bounded wait elapses, the entry is lowered, and this
+// falls back to a new session exactly as a load error would.
+func TestResolveSessionLoadSuccessNoReplayLowersAndFallsBack(t *testing.T) {
+	t.Parallel()
+
+	const noReplayReadTimeoutMS = 50
+
+	state, outPr, inPw := newTestSession(t, domain.AgentConfig{ReadTimeoutMS: noReplayReadTimeoutMS}, clientProtocolMaxLineBytes)
+	out := newOutboundReader(outPr)
+
+	outcomeCh := runResolveSessionAsync(context.Background(), state, "prior-session", capsAdvertisingLoad())
+
+	probeID := out.awaitMethod(t, negativeControlMethod)
+	respondErrorLine(t, inPw, probeID, jsonrpcMethodNotFound, "method not found")
+
+	loadID := out.awaitMethod(t, methodSessionLoad)
+	respondLine(t, inPw, loadID, loadSessionResponse{})
+
+	newID := out.awaitMethod(t, methodSessionNew)
+	respondLine(t, inPw, newID, newSessionResponse{SessionID: sessionId("fallback-session")})
+
+	outcome := awaitResolveSessionOutcome(t, outcomeCh)
+	if outcome.err != nil {
+		t.Fatalf("resolveSession() error = %v, want nil: a load that replays nothing must not fail the run", outcome.err)
+	}
+	if outcome.sessionID != "fallback-session" {
+		t.Errorf("resolveSession() session id = %q, want %q: success with no observed replay must not be trusted", outcome.sessionID, "fallback-session")
+	}
+
+	// resolveLoad's own bounded wait and the pump's own replay deadline
+	// are both bound by the same read timeout but started microseconds
+	// apart, so resolveLoad can return before the pump has actually
+	// lowered the entry. A margin of several read timeouts gives the
+	// pump's own deadline time to fire before the assertion turn below
+	// reads the record, without the two racing directly against each
+	// other.
+	time.Sleep(5 * noReplayReadTimeoutMS * time.Millisecond)
+
+	assertSessionContinuationEntry(t, state, out, inPw, true)
+}
+
+// TestResolveSessionLoadEarlyChunkDoesNotConfirmReplay confirms that a
+// chunk observed before the session/load control message names the
+// identifier being loaded cannot confirm a load that replays nothing:
+// only a chunk observed for that identifier once the load call is
+// actually in flight counts as replay.
+func TestResolveSessionLoadEarlyChunkDoesNotConfirmReplay(t *testing.T) {
+	t.Parallel()
+
+	const noReplayReadTimeoutMS = 50
+
+	state, outPr, inPw := newTestSession(t, domain.AgentConfig{ReadTimeoutMS: noReplayReadTimeoutMS}, clientProtocolMaxLineBytes)
+	out := newOutboundReader(outPr)
+
+	outcomeCh := runResolveSessionAsync(context.Background(), state, "prior-session", capsAdvertisingLoad())
+
+	probeID := out.awaitMethod(t, negativeControlMethod)
+	sendLine(t, inPw, `{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"prior-session","update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"arrived before the load call was even sent"}}}}`)
+	respondErrorLine(t, inPw, probeID, jsonrpcMethodNotFound, "method not found")
+
+	loadID := out.awaitMethod(t, methodSessionLoad)
+	respondLine(t, inPw, loadID, loadSessionResponse{})
+
+	newID := out.awaitMethod(t, methodSessionNew)
+	respondLine(t, inPw, newID, newSessionResponse{SessionID: sessionId("fallback-session")})
+
+	outcome := awaitResolveSessionOutcome(t, outcomeCh)
+	if outcome.err != nil {
+		t.Fatalf("resolveSession() error = %v, want nil", outcome.err)
+	}
+	if outcome.sessionID != "fallback-session" {
+		t.Errorf("resolveSession() session id = %q, want %q: a chunk observed before the load call must not confirm the load", outcome.sessionID, "fallback-session")
+	}
+
+	time.Sleep(5 * noReplayReadTimeoutMS * time.Millisecond)
+
+	assertSessionContinuationEntry(t, state, out, inPw, true)
+}
+
+// TestResolveSessionLoadSuccessWithReplayConfirms confirms the
+// converse of the no-replay case: an agent_message_chunk observed for
+// the loaded identifier before the pump's bounded wait elapses
+// confirms the load, so resolveSession returns the loaded identifier
+// itself and never falls back to session/new.
+func TestResolveSessionLoadSuccessWithReplayConfirms(t *testing.T) {
+	t.Parallel()
+
+	state, outPr, inPw := newTestSession(t, domain.AgentConfig{ReadTimeoutMS: 2000}, clientProtocolMaxLineBytes)
+	out := newOutboundReader(outPr)
+
+	outcomeCh := runResolveSessionAsync(context.Background(), state, "prior-session", capsAdvertisingLoad())
+
+	probeID := out.awaitMethod(t, negativeControlMethod)
+	respondErrorLine(t, inPw, probeID, jsonrpcMethodNotFound, "method not found")
+
+	loadID := out.awaitMethod(t, methodSessionLoad)
+	sendLine(t, inPw, `{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"prior-session","update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"replayed from history"}}}}`)
+	respondLine(t, inPw, loadID, loadSessionResponse{})
+
+	outcome := awaitResolveSessionOutcome(t, outcomeCh)
+	if outcome.err != nil {
+		t.Fatalf("resolveSession() error = %v, want nil", outcome.err)
+	}
+	if outcome.sessionID != "prior-session" {
+		t.Errorf("resolveSession() session id = %q, want %q: observed replay must confirm the loaded session", outcome.sessionID, "prior-session")
+	}
+
+	assertSessionContinuationEntry(t, state, out, inPw, false)
+}
+
+// TestResolveSessionResumeSuccessConfirmsWithoutReplay confirms that a
+// successful session/resume response alone confirms continuation, with
+// no replay requirement, so resolveSession returns the resumed
+// identifier at once and the entry is never lowered.
+func TestResolveSessionResumeSuccessConfirmsWithoutReplay(t *testing.T) {
+	t.Parallel()
+
+	state, outPr, inPw := newTestSession(t, domain.AgentConfig{ReadTimeoutMS: 2000}, clientProtocolMaxLineBytes)
+	out := newOutboundReader(outPr)
+
+	outcomeCh := runResolveSessionAsync(context.Background(), state, "prior-session", capsAdvertisingResume())
+
+	probeID := out.awaitMethod(t, negativeControlMethod)
+	respondErrorLine(t, inPw, probeID, jsonrpcMethodNotFound, "method not found")
+
+	resumeID := out.awaitMethod(t, methodSessionResume)
+	respondLine(t, inPw, resumeID, resumeSessionResponse{})
+
+	outcome := awaitResolveSessionOutcome(t, outcomeCh)
+	if outcome.err != nil {
+		t.Fatalf("resolveSession() error = %v, want nil", outcome.err)
+	}
+	if outcome.sessionID != "prior-session" {
+		t.Errorf("resolveSession() session id = %q, want %q", outcome.sessionID, "prior-session")
+	}
+
+	assertSessionContinuationEntry(t, state, out, inPw, false)
+}
+
+// TestResolveSessionResumeFailureLowersAndFallsBack confirms a
+// session/resume error, like a session/load error, lowers the entry
+// and falls back to a new session rather than failing the run.
+func TestResolveSessionResumeFailureLowersAndFallsBack(t *testing.T) {
+	t.Parallel()
+
+	state, outPr, inPw := newTestSession(t, domain.AgentConfig{ReadTimeoutMS: 2000}, clientProtocolMaxLineBytes)
+	out := newOutboundReader(outPr)
+
+	outcomeCh := runResolveSessionAsync(context.Background(), state, "prior-session", capsAdvertisingResume())
+
+	probeID := out.awaitMethod(t, negativeControlMethod)
+	respondErrorLine(t, inPw, probeID, jsonrpcMethodNotFound, "method not found")
+
+	resumeID := out.awaitMethod(t, methodSessionResume)
+	respondErrorLine(t, inPw, resumeID, jsonrpcMethodNotFound, "method not found")
+
+	newID := out.awaitMethod(t, methodSessionNew)
+	respondLine(t, inPw, newID, newSessionResponse{SessionID: sessionId("fallback-session")})
+
+	outcome := awaitResolveSessionOutcome(t, outcomeCh)
+	if outcome.err != nil {
+		t.Fatalf("resolveSession() error = %v, want nil", outcome.err)
+	}
+	if outcome.sessionID != "fallback-session" {
+		t.Errorf("resolveSession() session id = %q, want %q", outcome.sessionID, "fallback-session")
+	}
+
+	assertSessionContinuationEntry(t, state, out, inPw, true)
+}
+
+// TestResolveSessionNegativeControlStreamEndFails confirms that a
+// stream end while the negative control is in flight fails resolveSession
+// with domain.ErrPortExit, the same as any other loss of the
+// subprocess, rather than being read as a method-not-found answer.
+func TestResolveSessionNegativeControlStreamEndFails(t *testing.T) {
+	t.Parallel()
+
+	state, outPr, inPw := newTestSession(t, domain.AgentConfig{ReadTimeoutMS: 2000}, clientProtocolMaxLineBytes)
+	out := newOutboundReader(outPr)
+
+	outcomeCh := runResolveSessionAsync(context.Background(), state, "prior-session", capsAdvertisingLoad())
+
+	out.awaitMethod(t, negativeControlMethod)
+	if err := inPw.Close(); err != nil {
+		t.Fatalf("close the simulated agent stream: %v", err)
+	}
+
+	outcome := awaitResolveSessionOutcome(t, outcomeCh)
+	if outcome.err == nil {
+		t.Fatal("resolveSession() error = nil, want an error for a stream end during the negative control")
+	}
+	if outcome.err.Kind != domain.ErrPortExit {
+		t.Errorf("resolveSession() error kind = %q, want %q", outcome.err.Kind, domain.ErrPortExit)
+	}
+}
+
+// TestResolveSessionCallTimeoutFallsBack confirms that a call that never
+// answers within the connection's own read timeout, whether it is the
+// negative control itself or the continuation method it gates, is
+// treated as an unconfirmed continuation: resolveSession falls back to
+// session/new in the same call and returns its identifier without
+// failing the run, the same as an explicit error response would. A
+// stream end is the one condition that still fails outright, pinned
+// separately above.
+func TestResolveSessionCallTimeoutFallsBack(t *testing.T) {
+	t.Parallel()
+
+	const shortReadTimeoutMS = 50
+
+	tests := []struct {
+		name               string
+		caps               agentCapabilities
+		answerProbe        bool
+		continuationMethod string
+	}{
+		{name: "negative control never answers", caps: capsAdvertisingLoad(), answerProbe: false},
+		{name: "session/load never answers", caps: capsAdvertisingLoad(), answerProbe: true, continuationMethod: methodSessionLoad},
+		{name: "session/resume never answers", caps: capsAdvertisingResume(), answerProbe: true, continuationMethod: methodSessionResume},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			state, outPr, inPw := newTestSession(t, domain.AgentConfig{ReadTimeoutMS: shortReadTimeoutMS}, clientProtocolMaxLineBytes)
+			out := newOutboundReader(outPr)
+
+			outcomeCh := runResolveSessionAsync(context.Background(), state, "prior-session", tt.caps)
+
+			probeID := out.awaitMethod(t, negativeControlMethod)
+			if tt.answerProbe {
+				respondErrorLine(t, inPw, probeID, jsonrpcMethodNotFound, "method not found")
+				out.awaitMethod(t, tt.continuationMethod)
+			}
+
+			newID := out.awaitMethod(t, methodSessionNew)
+			respondLine(t, inPw, newID, newSessionResponse{SessionID: sessionId("fallback-session")})
+
+			outcome := awaitResolveSessionOutcome(t, outcomeCh)
+			if outcome.err != nil {
+				t.Fatalf("resolveSession() error = %v, want nil: a call that never answers must fall back rather than fail the run", outcome.err)
+			}
+			if outcome.sessionID != "fallback-session" {
+				t.Errorf("resolveSession() session id = %q, want %q", outcome.sessionID, "fallback-session")
+			}
+
+			assertSessionContinuationEntry(t, state, out, inPw, true)
+		})
+	}
+}
+
+// TestUnconfirmedLoadClearsProvisionalSessionIDForFallbackUpdate confirms
+// that once a session/load falls back to a fresh session, the
+// provisional identifier resolveLoad's own expectLoad control adopted
+// is cleared before the fallback session/new is even sent: a
+// session/update naming the fallback session, arriving before the
+// definitive sessionID control message StartSession would publish
+// after resolveSession returns, is queued for the next turn rather than
+// dropped as foreign.
+func TestUnconfirmedLoadClearsProvisionalSessionIDForFallbackUpdate(t *testing.T) {
+	t.Parallel()
+
+	const replayedMessage = "from the fallback session"
+
+	state, outPr, inPw := newTestSession(t, domain.AgentConfig{ReadTimeoutMS: 2000}, clientProtocolMaxLineBytes)
+	out := newOutboundReader(outPr)
+
+	outcomeCh := runResolveSessionAsync(context.Background(), state, "prior-session", capsAdvertisingLoad())
+
+	probeID := out.awaitMethod(t, negativeControlMethod)
+	respondErrorLine(t, inPw, probeID, jsonrpcMethodNotFound, "method not found")
+
+	loadID := out.awaitMethod(t, methodSessionLoad)
+	respondErrorLine(t, inPw, loadID, jsonrpcMethodNotFound, "method not found")
+
+	newID := out.awaitMethod(t, methodSessionNew)
+	sendLine(t, inPw, `{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"fallback-session","update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"`+replayedMessage+`"}}}}`)
+	respondLine(t, inPw, newID, newSessionResponse{SessionID: sessionId("fallback-session")})
+
+	outcome := awaitResolveSessionOutcome(t, outcomeCh)
+	if outcome.err != nil {
+		t.Fatalf("resolveSession() error = %v, want nil", outcome.err)
+	}
+	if outcome.sessionID != "fallback-session" {
+		t.Fatalf("resolveSession() session id = %q, want %q", outcome.sessionID, "fallback-session")
+	}
+
+	state.itemCh <- pumpItem{control: &pumpControl{sessionID: outcome.sessionID}}
+
+	var events []domain.AgentEvent
+	turnCh := runTurnAsync(state, domain.RunTurnParams{Prompt: "go", OnEvent: collectEvents(&events)})
+	promptID := out.awaitMethod(t, methodSessionPrompt)
+	respondLine(t, inPw, promptID, promptResponse{StopReason: stopReasonEndTurn})
+	turnOutcome := awaitOutcome(t, turnCh)
+	if turnOutcome.err != nil {
+		t.Fatalf("RunTurn() error = %v, want nil", turnOutcome.err)
+	}
+
+	for _, ev := range events {
+		if ev.Type == domain.EventNotification && ev.Message == replayedMessage {
+			return
+		}
+	}
+	t.Errorf("events = %+v, want the session/update observed before the fallback session's identifier was confirmed to have reached the turn", events)
+}

--- a/internal/agent/clientprotocol/continuation_test.go
+++ b/internal/agent/clientprotocol/continuation_test.go
@@ -535,3 +535,59 @@ func TestUnconfirmedLoadClearsProvisionalSessionIDForFallbackUpdate(t *testing.T
 	}
 	t.Errorf("events = %+v, want the session/update observed before the fallback session's identifier was confirmed to have reached the turn", events)
 }
+
+// TestUnconfirmedLoadSuccessNoReplayClearsProvisionalSessionIDForFallbackUpdate
+// confirms the no-replay counterpart of
+// TestUnconfirmedLoadClearsProvisionalSessionIDForFallbackUpdate: a
+// session/load response carrying success but no replayed chunk still
+// clears the provisional identifier expectLoad adopted once the
+// pump's own bounded wait elapses, so a session/update naming the
+// fallback session, arriving once session/new has been answered,
+// reaches the turn rather than being dropped as foreign.
+func TestUnconfirmedLoadSuccessNoReplayClearsProvisionalSessionIDForFallbackUpdate(t *testing.T) {
+	t.Parallel()
+
+	const noReplayReadTimeoutMS = 50
+	const replayedMessage = "from the fallback session"
+
+	state, outPr, inPw := newTestSession(t, domain.AgentConfig{ReadTimeoutMS: noReplayReadTimeoutMS}, clientProtocolMaxLineBytes)
+	out := newOutboundReader(outPr)
+
+	outcomeCh := runResolveSessionAsync(context.Background(), state, "prior-session", capsAdvertisingLoad())
+
+	probeID := out.awaitMethod(t, negativeControlMethod)
+	respondErrorLine(t, inPw, probeID, jsonrpcMethodNotFound, "method not found")
+
+	loadID := out.awaitMethod(t, methodSessionLoad)
+	respondLine(t, inPw, loadID, loadSessionResponse{})
+
+	newID := out.awaitMethod(t, methodSessionNew)
+	respondLine(t, inPw, newID, newSessionResponse{SessionID: sessionId("fallback-session")})
+	sendLine(t, inPw, `{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"fallback-session","update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"`+replayedMessage+`"}}}}`)
+
+	outcome := awaitResolveSessionOutcome(t, outcomeCh)
+	if outcome.err != nil {
+		t.Fatalf("resolveSession() error = %v, want nil", outcome.err)
+	}
+	if outcome.sessionID != "fallback-session" {
+		t.Fatalf("resolveSession() session id = %q, want %q", outcome.sessionID, "fallback-session")
+	}
+
+	state.itemCh <- pumpItem{control: &pumpControl{sessionID: outcome.sessionID}}
+
+	var events []domain.AgentEvent
+	turnCh := runTurnAsync(state, domain.RunTurnParams{Prompt: "go", OnEvent: collectEvents(&events)})
+	promptID := out.awaitMethod(t, methodSessionPrompt)
+	respondLine(t, inPw, promptID, promptResponse{StopReason: stopReasonEndTurn})
+	turnOutcome := awaitOutcome(t, turnCh)
+	if turnOutcome.err != nil {
+		t.Fatalf("RunTurn() error = %v, want nil", turnOutcome.err)
+	}
+
+	for _, ev := range events {
+		if ev.Type == domain.EventNotification && ev.Message == replayedMessage {
+			return
+		}
+	}
+	t.Errorf("events = %+v, want the session/update observed once the fallback session/new was answered to have reached the turn", events)
+}

--- a/internal/agent/clientprotocol/harness_test.go
+++ b/internal/agent/clientprotocol/harness_test.go
@@ -244,6 +244,21 @@ func respondLine(t *testing.T, w io.Writer, id json.RawMessage, result any) {
 	sendLine(t, w, fmt.Sprintf(`{"jsonrpc":"2.0","id":%s,"result":%s}`, string(id), string(body)))
 }
 
+// respondErrorLine writes a JSON-RPC error response answering id with
+// code and message, splicing id in verbatim so it carries whatever
+// wire form the caller captured from a request line.
+func respondErrorLine(t *testing.T, w io.Writer, id json.RawMessage, code int, message string) {
+	t.Helper()
+	body, err := json.Marshal(struct {
+		Code    int    `json:"code"`
+		Message string `json:"message"`
+	}{Code: code, Message: message})
+	if err != nil {
+		t.Fatalf("marshal error response body: %v", err)
+	}
+	sendLine(t, w, fmt.Sprintf(`{"jsonrpc":"2.0","id":%s,"error":%s}`, string(id), string(body)))
+}
+
 // decodeResponse decodes line as a wireResponse, failing t on a
 // decode error.
 func decodeResponse(t *testing.T, line []byte) wireResponse {

--- a/internal/agent/clientprotocol/integration_test.go
+++ b/internal/agent/clientprotocol/integration_test.go
@@ -372,3 +372,68 @@ func TestIntegration_RunTurnWithPermissionContinuation(t *testing.T) {
 		t.Log("no session/request_permission was observed on this run; this runtime's default approval posture may not require one for this prompt")
 	}
 }
+
+// TestIntegration_SessionContinuation drives one session through a
+// full turn, stops it, then starts a second session against the same
+// workspace naming the first session's identifier as ResumeSessionID.
+// It reads the outcome through the once-per-session capability notice
+// the second session's first turn emits: the notice names the session
+// continuation label only when the entry was lowered, so its absence
+// is the positive confirmation and its presence is the clean,
+// non-failing fallback either way. This runtime's own
+// support for continuation is not asserted either way; whichever
+// branch fires, a confirmed continuation must return the identifier
+// the first session held, and an unconfirmed one must still complete
+// its turn.
+func TestIntegration_SessionContinuation(t *testing.T) {
+	skipUnlessClientProtocolIntegration(t)
+
+	adapter := mustNewClientProtocolAdapter(t)
+	workspace := gitInitWorkspace(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 180*time.Second)
+	defer cancel()
+
+	firstSession := mustStartClientProtocolSession(t, ctx, adapter, workspace)
+
+	onEvent1, _ := makeEventCollector(t)
+	if _, err := adapter.RunTurn(ctx, firstSession, domain.RunTurnParams{
+		Prompt:  "Reply with exactly one word: acknowledged.",
+		OnEvent: onEvent1,
+	}); err != nil {
+		t.Fatalf("first session RunTurn: %v", err)
+	}
+
+	if err := adapter.StopSession(ctx, firstSession); err != nil {
+		t.Fatalf("StopSession (first session): %v", err)
+	}
+
+	onEvent2, collected2 := makeEventCollector(t)
+	secondSession, err := adapter.StartSession(ctx, domain.StartSessionParams{
+		WorkspacePath:   workspace,
+		AgentConfig:     integrationAgentConfig(t),
+		ResumeSessionID: firstSession.ID,
+	})
+	if err != nil {
+		t.Fatalf("StartSession (continuation): %v", err)
+	}
+	t.Cleanup(func() { _ = adapter.StopSession(context.Background(), secondSession) })
+
+	if _, err := adapter.RunTurn(ctx, secondSession, domain.RunTurnParams{
+		Prompt:  "Reply with exactly one word: acknowledged.",
+		OnEvent: onEvent2,
+	}); err != nil {
+		t.Fatalf("second session RunTurn: %v", err)
+	}
+
+	notice := firstNotification(t, collected2())
+	confirmed := !strings.Contains(notice.Message, capabilityLabelSessionContinuation)
+	if confirmed {
+		t.Log("session continuation was confirmed by this runtime")
+		if secondSession.ID != firstSession.ID {
+			t.Errorf("second session id = %q, want %q: a confirmed continuation must return the identifier it actually loaded or resumed", secondSession.ID, firstSession.ID)
+		}
+	} else {
+		t.Log("session continuation was not confirmed by this runtime; the entry was lowered and the run fell back to a fresh session cleanly")
+	}
+}

--- a/internal/agent/clientprotocol/normalize.go
+++ b/internal/agent/clientprotocol/normalize.go
@@ -73,9 +73,9 @@ func applySessionUpdate(tracker *agentcore.ToolTracker, ev sessionUpdateEvent) n
 		}
 
 	case updateUserMessageChunk:
-		// No event on the pinned line: this variant carries replay
-		// evidence for session continuation only, which this piece does
-		// not implement.
+		// No event on the pinned line: this variant is replay evidence
+		// for session continuation, which the pump observes directly
+		// rather than through this function's return value.
 		return normalizedUpdate{}
 
 	case updateToolCall:

--- a/internal/agent/clientprotocol/pump.go
+++ b/internal/agent/clientprotocol/pump.go
@@ -109,6 +109,25 @@ type pumpState struct {
 	// rather than assuming one, not because a reply is expected to be
 	// outstanding.
 	openRequests map[jsonrpc.ID]string
+
+	// loadExpected reports whether an expectLoad control message has
+	// been processed. It gates observeReplay so a chunk observed before
+	// the session/load call itself, during the initialize or
+	// negative-control round trip, cannot confirm a load that replayed
+	// nothing.
+	loadExpected bool
+
+	// replayObserved reports whether the pump has seen a chunk replayed
+	// for the identifier a session/load control message named. It is
+	// set at most once per session and never cleared.
+	replayObserved bool
+
+	// pendingReplayQuery and replayDeadlineC track a replayQuery still
+	// awaiting an answer: set together when the query arrives with no
+	// replay observed yet, and cleared together once either a replayed
+	// chunk resolves it or the deadline does.
+	pendingReplayQuery *replayQuery
+	replayDeadlineC    <-chan time.Time
 }
 
 // runPump is the sole goroutine that consumes routed messages and
@@ -148,6 +167,8 @@ func runPump(state *sessionState) {
 				p.beginEndAttempt(turnEndCancelled, "")
 			case <-deadlineC:
 				p.finalizeActiveTurnOnDeadline()
+			case <-p.replayDeadlineC:
+				p.finalizeReplayQueryOnDeadline()
 			}
 			continue
 		}
@@ -163,6 +184,8 @@ func runPump(state *sessionState) {
 			p.beginEndAttempt(turnEndCancelled, "")
 		case <-deadlineC:
 			p.finalizeActiveTurnOnDeadline()
+		case <-p.replayDeadlineC:
+			p.finalizeReplayQueryOnDeadline()
 		case <-state.stopCh:
 			p.logDroppedQueue()
 			return
@@ -204,12 +227,100 @@ func (p *pumpState) handleControl(ctrl pumpControl) {
 			slog.String("name", p.agentInfo.Name),
 			slog.String("version", p.agentInfo.Version))
 
+	case ctrl.expectLoad != "":
+		// Adopted silently, ahead of the definitive sessionID control
+		// message that always follows: this closes the same race a
+		// session/new launch leaves open by deferring the filter,
+		// because here the identifier is already known. If the load is
+		// not confirmed, handleReplayQuery and
+		// finalizeReplayQueryOnDeadline clear both fields back to their
+		// deferred-filter state before the fallback's own definitive
+		// sessionID control message arrives; otherwise that message
+		// simply overwrites this value with the one already in place.
+		p.sessionID = ctrl.expectLoad
+		p.sessionIDKnown = true
+		p.loadExpected = true
+
+	case ctrl.query != nil:
+		p.handleReplayQuery(ctrl.query)
+
 	case ctrl.startTurn != nil:
 		p.handleStartTurn(ctrl.startTurn)
 
 	case ctrl.answerOpen:
 		p.handleAnswerOpen()
 	}
+}
+
+// handleReplayQuery applies q, the control message a session/load or
+// session/resume continuation call publishes once its own response is
+// known. A nil reply means the call already failed: the provisional
+// identifier expectLoad adopted is cleared back to unknown and the
+// entry is lowered at once, with nothing sent back. Otherwise the call
+// was a session/load that answered success: this answers true at once
+// when replay has already been observed, or defers the answer until
+// either a replayed chunk resolves it or this query's own bounded wait
+// elapses.
+func (p *pumpState) handleReplayQuery(q *replayQuery) {
+	if q.reply == nil {
+		p.clearProvisionalSessionID()
+		p.lowerCapability(&p.state.caps.sessionContinuation, capabilityLabelSessionContinuation)
+		return
+	}
+	if p.replayObserved {
+		q.reply <- true
+		return
+	}
+	p.pendingReplayQuery = q
+	p.replayDeadlineC = time.After(readTimeout(p.state))
+}
+
+// finalizeReplayQueryOnDeadline ends a pending replay query once its
+// bounded wait has elapsed with no replay observed: the session/load
+// succeeded but replayed nothing, so this answers false, clears the
+// provisional identifier expectLoad adopted, and lowers
+// sessionContinuation.
+func (p *pumpState) finalizeReplayQueryOnDeadline() {
+	if p.pendingReplayQuery == nil {
+		return
+	}
+	q := p.pendingReplayQuery
+	p.pendingReplayQuery = nil
+	p.replayDeadlineC = nil
+	q.reply <- false
+	p.clearProvisionalSessionID()
+	p.lowerCapability(&p.state.caps.sessionContinuation, capabilityLabelSessionContinuation)
+}
+
+// clearProvisionalSessionID reverts the identifier expectLoad adopted
+// back to unknown, restoring the deferred-filter state
+// handleSessionUpdateMessage relies on until the fallback's own
+// definitive sessionID control message arrives. Without this, an
+// update for the session session/new actually created would be
+// compared against the loaded session's stale identifier and dropped
+// as foreign.
+func (p *pumpState) clearProvisionalSessionID() {
+	p.sessionID = ""
+	p.sessionIDKnown = false
+}
+
+// observeReplay records that the pump has seen a chunk replayed for
+// the session a session/load control message named, and resolves a
+// pending replay query if one is waiting. A chunk observed before that
+// control message arrives is not counted: it cannot confirm a load
+// that has not yet been attempted.
+func (p *pumpState) observeReplay() {
+	if !p.loadExpected || p.replayObserved {
+		return
+	}
+	p.replayObserved = true
+	if p.pendingReplayQuery == nil {
+		return
+	}
+	q := p.pendingReplayQuery
+	p.pendingReplayQuery = nil
+	p.replayDeadlineC = nil
+	q.reply <- true
 }
 
 // applyHandshakeCapabilityLowering lowers the capability record's
@@ -404,6 +515,10 @@ func (p *pumpState) handleSessionUpdateMessage(msg *jsonrpc.Message) {
 		}
 		p.emitOrQueue(domain.AgentEvent{Type: domain.EventMalformed, Timestamp: time.Now().UTC(), Message: unrecognizedSessionUpdateMessage})
 		return
+	}
+
+	if sue.kind == updateUserMessageChunk || sue.kind == updateAgentMessageChunk {
+		p.observeReplay()
 	}
 
 	result := applySessionUpdate(p.tracker, sue)

--- a/internal/agent/clientprotocol/pump.go
+++ b/internal/agent/clientprotocol/pump.go
@@ -263,6 +263,7 @@ func (p *pumpState) handleControl(ctrl pumpControl) {
 // elapses.
 func (p *pumpState) handleReplayQuery(q *replayQuery) {
 	if q.reply == nil {
+		p.cancelPendingReplayQuery()
 		p.clearProvisionalSessionID()
 		p.lowerCapability(&p.state.caps.sessionContinuation, capabilityLabelSessionContinuation)
 		return
@@ -285,11 +286,19 @@ func (p *pumpState) finalizeReplayQueryOnDeadline() {
 		return
 	}
 	q := p.pendingReplayQuery
-	p.pendingReplayQuery = nil
-	p.replayDeadlineC = nil
-	q.reply <- false
+	p.cancelPendingReplayQuery()
 	p.clearProvisionalSessionID()
 	p.lowerCapability(&p.state.caps.sessionContinuation, capabilityLabelSessionContinuation)
+	q.reply <- false
+}
+
+// cancelPendingReplayQuery drops a replay query still waiting and
+// disarms its deadline, so a wait that has already been answered or
+// abandoned cannot fire later and act on a session that has since
+// been replaced.
+func (p *pumpState) cancelPendingReplayQuery() {
+	p.pendingReplayQuery = nil
+	p.replayDeadlineC = nil
 }
 
 // clearProvisionalSessionID reverts the identifier expectLoad adopted
@@ -302,6 +311,7 @@ func (p *pumpState) finalizeReplayQueryOnDeadline() {
 func (p *pumpState) clearProvisionalSessionID() {
 	p.sessionID = ""
 	p.sessionIDKnown = false
+	p.loadExpected = false
 }
 
 // observeReplay records that the pump has seen a chunk replayed for
@@ -318,8 +328,7 @@ func (p *pumpState) observeReplay() {
 		return
 	}
 	q := p.pendingReplayQuery
-	p.pendingReplayQuery = nil
-	p.replayDeadlineC = nil
+	p.cancelPendingReplayQuery()
 	q.reply <- true
 }
 

--- a/internal/agent/clientprotocol/schema_conformance_test.go
+++ b/internal/agent/clientprotocol/schema_conformance_test.go
@@ -943,6 +943,33 @@ func TestSchemaConformance(t *testing.T) {
 		respondLine(t, inPw, promptID, promptResponse{StopReason: stopReasonEndTurn})
 		awaitOutcome(t, outcomeCh)
 
+		loadState, loadOutPr, loadInPw := newTestSession(t, domain.AgentConfig{ReadTimeoutMS: 2000}, clientProtocolMaxLineBytes)
+		loadOut := newOutboundReader(loadOutPr)
+		loadOutcomeCh := make(chan resolveSessionOutcome, 1)
+		go func() {
+			sessionID, err := resolveSession(context.Background(), loadState, "prior-session", capsAdvertisingLoad(), "", servers)
+			loadOutcomeCh <- resolveSessionOutcome{sessionID: sessionID, err: err}
+		}()
+		loadProbeID := loadOut.awaitMethod(t, negativeControlMethod)
+		respondErrorLine(t, loadInPw, loadProbeID, jsonrpcMethodNotFound, "method not found")
+		loadRaw, loadReqID := nextRequestLine(t, loadOut, methodSessionLoad)
+		sendLine(t, loadInPw, `{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"prior-session","update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"replayed"}}}}`)
+		respondLine(t, loadInPw, loadReqID, loadSessionResponse{})
+		awaitResolveSessionOutcome(t, loadOutcomeCh)
+
+		resumeState, resumeOutPr, resumeInPw := newTestSession(t, domain.AgentConfig{ReadTimeoutMS: 2000}, clientProtocolMaxLineBytes)
+		resumeOut := newOutboundReader(resumeOutPr)
+		resumeOutcomeCh := make(chan resolveSessionOutcome, 1)
+		go func() {
+			sessionID, err := resolveSession(context.Background(), resumeState, "prior-session", capsAdvertisingResume(), "", servers)
+			resumeOutcomeCh <- resolveSessionOutcome{sessionID: sessionID, err: err}
+		}()
+		resumeProbeID := resumeOut.awaitMethod(t, negativeControlMethod)
+		respondErrorLine(t, resumeInPw, resumeProbeID, jsonrpcMethodNotFound, "method not found")
+		resumeRaw, resumeReqID := nextRequestLine(t, resumeOut, methodSessionResume)
+		respondLine(t, resumeInPw, resumeReqID, resumeSessionResponse{})
+		awaitResolveSessionOutcome(t, resumeOutcomeCh)
+
 		for _, tc := range []struct {
 			label   string
 			defName string
@@ -954,6 +981,8 @@ func TestSchemaConformance(t *testing.T) {
 			{"session/prompt", "PromptRequest", promptRaw, requestParams},
 			{"permission selected", "RequestPermissionResponse", selectedPermissionRaw, responseResult},
 			{"permission cancelled", "RequestPermissionResponse", cancelledPermissionRaw, responseResult},
+			{"session/load", "LoadSessionRequest", loadRaw, requestParams},
+			{"session/resume", "ResumeSessionRequest", resumeRaw, requestParams},
 		} {
 			t.Run(tc.label, func(t *testing.T) {
 				body := tc.body(t, tc.raw)

--- a/internal/agent/clientprotocol/schema_conformance_test.go
+++ b/internal/agent/clientprotocol/schema_conformance_test.go
@@ -945,9 +945,11 @@ func TestSchemaConformance(t *testing.T) {
 
 		loadState, loadOutPr, loadInPw := newTestSession(t, domain.AgentConfig{ReadTimeoutMS: 2000}, clientProtocolMaxLineBytes)
 		loadOut := newOutboundReader(loadOutPr)
+		loadCtx, cancelLoad := context.WithCancel(context.Background())
+		t.Cleanup(cancelLoad)
 		loadOutcomeCh := make(chan resolveSessionOutcome, 1)
 		go func() {
-			sessionID, err := resolveSession(context.Background(), loadState, "prior-session", capsAdvertisingLoad(), "", servers)
+			sessionID, err := resolveSession(loadCtx, loadState, "prior-session", capsAdvertisingLoad(), "", servers)
 			loadOutcomeCh <- resolveSessionOutcome{sessionID: sessionID, err: err}
 		}()
 		loadProbeID := loadOut.awaitMethod(t, negativeControlMethod)
@@ -959,9 +961,11 @@ func TestSchemaConformance(t *testing.T) {
 
 		resumeState, resumeOutPr, resumeInPw := newTestSession(t, domain.AgentConfig{ReadTimeoutMS: 2000}, clientProtocolMaxLineBytes)
 		resumeOut := newOutboundReader(resumeOutPr)
+		resumeCtx, cancelResume := context.WithCancel(context.Background())
+		t.Cleanup(cancelResume)
 		resumeOutcomeCh := make(chan resolveSessionOutcome, 1)
 		go func() {
-			sessionID, err := resolveSession(context.Background(), resumeState, "prior-session", capsAdvertisingResume(), "", servers)
+			sessionID, err := resolveSession(resumeCtx, resumeState, "prior-session", capsAdvertisingResume(), "", servers)
 			resumeOutcomeCh <- resolveSessionOutcome{sessionID: sessionID, err: err}
 		}()
 		resumeProbeID := resumeOut.awaitMethod(t, negativeControlMethod)

--- a/internal/agent/clientprotocol/session.go
+++ b/internal/agent/clientprotocol/session.go
@@ -83,13 +83,39 @@ type pumpItem struct {
 
 // pumpControl carries what StartSession learned on its own goroutine
 // and what RunTurn and teardown ask of the pump. Exactly one field is
-// set. This piece uses only these four; session continuation adds
-// expectLoad and a replay query later.
+// set.
 type pumpControl struct {
-	handshake  *handshakeFacts
-	sessionID  string
+	handshake *handshakeFacts
+	sessionID string
+
+	// expectLoad is published before a session/load call, naming the
+	// identifier being loaded. It lets the pump treat that identifier
+	// as the session's own before the definitive sessionID control
+	// message arrives, and count any chunk replayed for it.
+	expectLoad string
+
+	// query carries the continuation verdict of a session/load or
+	// session/resume call once that call's own response is known. See
+	// [replayQuery].
+	query *replayQuery
+
 	startTurn  *turnStart
 	answerOpen bool
+}
+
+// replayQuery is the control message a session/load or session/resume
+// continuation call publishes once its own response is known, so the
+// pump, the capability record's sole mutator, applies the
+// sessionContinuation lowering. A call already known to have failed
+// carries a nil reply: the pump lowers the entry at once and answers
+// nothing, because the caller already has its verdict and is not
+// waiting. A session/load call that answered success carries a
+// buffered reply of capacity one instead: the pump answers true as
+// soon as it observes a chunk replayed for the identifier the
+// expectLoad control message named, or lowers the entry itself and
+// answers false once its own bounded wait for that chunk elapses.
+type replayQuery struct {
+	reply chan bool
 }
 
 // handshakeFacts is what StartSession decoded from the initialize
@@ -141,12 +167,13 @@ func readTimeout(state *sessionState) time.Duration {
 }
 
 // startSession launches the runtime, performs the initialize handshake,
-// and creates a session with session/new. Session continuation is not
-// implemented by this piece: every session is created with session/new,
-// and ResumeSessionID is not read. The session capability record is
-// built with its stage-one states before the pump starts, and the pump
-// applies handshake-based lowering to it once the handshake control
-// message arrives.
+// and creates or continues a session. A non-empty ResumeSessionID picks
+// the continuation route the handshake advertises; every other case,
+// and a continuation that is not confirmed, creates the session with
+// session/new instead. The session capability record is built with its
+// stage-one states before the pump starts, and the pump applies
+// handshake- and continuation-based lowering to it once the
+// corresponding control message arrives.
 func startSession(ctx context.Context, params domain.StartSessionParams) (domain.Session, error) {
 	target, agentErr := agentcore.ResolveLaunchTarget(params, "")
 	if agentErr != nil {
@@ -255,22 +282,22 @@ func startSession(ctx context.Context, params domain.StartSessionParams) (domain
 		state.logger.Warn("configured tool servers were not delivered: the agent does not advertise HTTP tool-server support")
 	}
 
-	newSessResp, agentErr := doNewSession(ctx, state, target.WorkspacePath, wireServers)
+	var caps agentCapabilities
+	if initResp.AgentCapabilities != nil {
+		caps = *initResp.AgentCapabilities
+	}
+
+	sessionID, agentErr := resolveSession(ctx, state, params.ResumeSessionID, caps, target.WorkspacePath, wireServers)
 	if agentErr != nil {
 		teardownOnFailure()
 		return domain.Session{}, agentErr
 	}
 
-	facts := &handshakeFacts{toolServersWithheld: withheld}
-	if initResp.AgentCapabilities != nil {
-		facts.caps = *initResp.AgentCapabilities
-	}
+	facts := &handshakeFacts{toolServersWithheld: withheld, caps: caps}
 	if initResp.AgentInfo != nil {
 		facts.agentInfo = *initResp.AgentInfo
 		facts.agentInfoPresent = true
 	}
-
-	sessionID := string(newSessResp.SessionID)
 
 	state.itemCh <- pumpItem{control: &pumpControl{handshake: facts}}
 	state.itemCh <- pumpItem{control: &pumpControl{sessionID: sessionID}}


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Feat

**Intent:** Implement session continuation for the Agent Client Protocol transport: `session/load` and `session/resume` are selected from the handshake's advertised capabilities and confirmed by observation rather than trusted outright, so a run behaves correctly whether or not continuation actually works on the connected agent.

**Related Issues:** #976

### 🧭 Reviewer Guide

**Complexity:** Medium

#### Entry Point

`internal/agent/clientprotocol/continuation.go` - `resolveSession` picks the continuation route the handshake advertised (`session/load`, then `session/resume`, otherwise a fresh `session/new`), sends a vendor-namespace negative control ahead of the real call so an unimplemented method and a broken one are distinguishable by their error codes, and for a load, defers acceptance until the pump reports a message chunk actually replayed for that session before falling back to `session/new` when nothing confirms it.

#### Sensitive Areas

- `internal/agent/clientprotocol/pump.go`: adds the replay-observation state (`loadExpected`, `replayObserved`, `pendingReplayQuery`) that the pump - the sole mutator of the capability record - uses to confirm or reject a load asynchronously against the turn-processing loop.
- `internal/agent/clientprotocol/capability.go`: `sessionContinuation` now starts at `protocol` instead of `gap`, and `advertisesSessionContinuation` defers to the same route selection `resolveSession` uses so the handshake's lowering decision and the routing decision can never disagree.
- `internal/agent/clientprotocol/session.go`: `startSession` now reads `params.ResumeSessionID` and routes through `resolveSession` instead of unconditionally calling `session/new`.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes.
- **Migrations/State:** No migrations or state changes.