### PR TITLE
refactor: remove dead EventStream method from agent adapter

### DIFF
--- a/docs/architecture/10-agent-adapter-contract.md
+++ b/docs/architecture/10-agent-adapter-contract.md
@@ -13,13 +13,10 @@ An agent adapter must implement the following operations:
   - Returns an opaque session handle.
 - `RunTurn(session, prompt, issue, on_event) -> TurnResult`
   - Execute one agent turn with the given prompt.
-  - Delivers events to the orchestrator via `on_event` callback (push adapters) or returns
-    them in the result (synchronous adapters).
+  - Delivers every event to the orchestrator by calling `on_event` during the turn; the returned `TurnResult` carries the turn's outcome, not its events.
   - Returns when the turn completes (success, failure, or timeout).
 - `StopSession(session)`
   - Terminate the agent process/service cleanly.
-- `EventStream() -> <event channel>`
-  - Optional: adapters that push events asynchronously may expose an event channel.
 
 Built-in agent adapter kinds:
 

--- a/internal/agent/claude/claude.go
+++ b/internal/agent/claude/claude.go
@@ -398,12 +398,6 @@ func (a *ClaudeCodeAdapter) StopSession(ctx context.Context, session domain.Sess
 	return state.forkSession.Stop(ctx)
 }
 
-// EventStream returns nil. The Claude Code adapter delivers events
-// synchronously via the [domain.RunTurnParams] OnEvent callback.
-func (a *ClaudeCodeAdapter) EventStream() <-chan domain.AgentEvent {
-	return nil
-}
-
 // maxToolErrorLen is the maximum byte budget for [domain.AgentEvent.Message]
 // when a tool_result block carries is_error: true. Output that exceeds this
 // limit is formatted as first-line-plus-tail: the first line of the error

--- a/internal/agent/claude/claude_test.go
+++ b/internal/agent/claude/claude_test.go
@@ -553,15 +553,6 @@ func TestParsePassthroughConfig(t *testing.T) {
 	})
 }
 
-func TestEventStream(t *testing.T) {
-	t.Parallel()
-
-	adapter, _ := NewClaudeCodeAdapter(map[string]any{})
-	if ch := adapter.EventStream(); ch != nil {
-		t.Errorf("EventStream() = %v, want nil", ch)
-	}
-}
-
 func TestStopSession_NilProc(t *testing.T) {
 	t.Parallel()
 

--- a/internal/agent/clientprotocol/clientprotocol.go
+++ b/internal/agent/clientprotocol/clientprotocol.go
@@ -63,8 +63,3 @@ func (a *ClientProtocolAdapter) RunTurn(ctx context.Context, session domain.Sess
 func (a *ClientProtocolAdapter) StopSession(ctx context.Context, session domain.Session) error {
 	return stopSession(ctx, session)
 }
-
-// EventStream returns nil. This adapter delivers every event
-// synchronously through RunTurn's OnEvent callback, matching every
-// other registered kind.
-func (a *ClientProtocolAdapter) EventStream() <-chan domain.AgentEvent { return nil }

--- a/internal/agent/codex/codex.go
+++ b/internal/agent/codex/codex.go
@@ -961,10 +961,6 @@ func (a *CodexAdapter) StopSession(_ context.Context, session domain.Session) er
 	return nil
 }
 
-// EventStream returns nil. The Codex adapter delivers events
-// synchronously via [CodexAdapter.RunTurn]'s OnEvent callback.
-func (a *CodexAdapter) EventStream() <-chan domain.AgentEvent { return nil }
-
 // isAgentError extracts an *[domain.AgentError] from err using type
 // assertion.
 func isAgentError(err error, target **domain.AgentError) bool {

--- a/internal/agent/codex/codex_test.go
+++ b/internal/agent/codex/codex_test.go
@@ -117,18 +117,6 @@ func TestNewCodexAdapter(t *testing.T) {
 	})
 }
 
-func TestEventStream(t *testing.T) {
-	t.Parallel()
-
-	adapter, err := NewCodexAdapter(map[string]any{})
-	if err != nil {
-		t.Fatalf("NewCodexAdapter() error = %v", err)
-	}
-	if ch := adapter.EventStream(); ch != nil {
-		t.Errorf("EventStream() = %v, want nil", ch)
-	}
-}
-
 func TestRegistration(t *testing.T) {
 	t.Parallel()
 

--- a/internal/agent/copilot/copilot.go
+++ b/internal/agent/copilot/copilot.go
@@ -649,9 +649,3 @@ func (a *CopilotAdapter) StopSession(ctx context.Context, session domain.Session
 	}
 	return state.forkSession.Stop(ctx)
 }
-
-// EventStream returns nil. The Copilot CLI adapter delivers events
-// synchronously via the [domain.RunTurnParams] OnEvent callback.
-func (a *CopilotAdapter) EventStream() <-chan domain.AgentEvent {
-	return nil
-}

--- a/internal/agent/copilot/copilot_test.go
+++ b/internal/agent/copilot/copilot_test.go
@@ -130,16 +130,6 @@ func TestRegistration(t *testing.T) {
 	}
 }
 
-func TestEventStream(t *testing.T) {
-	t.Parallel()
-
-	adapter, _ := NewCopilotAdapter(map[string]any{})
-	ch := adapter.EventStream()
-	if ch != nil {
-		t.Errorf("EventStream() = non-nil channel, want nil (synchronous adapter)")
-	}
-}
-
 func TestStartSession(t *testing.T) {
 	t.Parallel()
 

--- a/internal/agent/kiro/kiro.go
+++ b/internal/agent/kiro/kiro.go
@@ -281,9 +281,3 @@ func (a *KiroAdapter) StopSession(ctx context.Context, session domain.Session) e
 	}
 	return state.forkSession.Stop(ctx)
 }
-
-// EventStream returns nil. The Kiro CLI adapter delivers events
-// synchronously via the [domain.RunTurnParams] OnEvent callback.
-func (a *KiroAdapter) EventStream() <-chan domain.AgentEvent {
-	return nil
-}

--- a/internal/agent/kiro/kiro_test.go
+++ b/internal/agent/kiro/kiro_test.go
@@ -448,18 +448,6 @@ func TestOnFinalize_ResumeRequestedOnSecondTurn(t *testing.T) {
 	}
 }
 
-func TestEventStream_Nil(t *testing.T) {
-	t.Parallel()
-
-	adapter, err := NewKiroAdapter(map[string]any{})
-	if err != nil {
-		t.Fatalf("NewKiroAdapter: %v", err)
-	}
-	if ch := adapter.EventStream(); ch != nil {
-		t.Errorf("EventStream() = non-nil channel, want nil (synchronous adapter)")
-	}
-}
-
 func TestRunTurn_NilOnEventPanics(t *testing.T) {
 	t.Parallel()
 

--- a/internal/agent/mock/mock.go
+++ b/internal/agent/mock/mock.go
@@ -316,12 +316,6 @@ func (m *MockAdapter) StopSession(_ context.Context, _ domain.Session) error {
 	return nil
 }
 
-// EventStream returns nil. The mock adapter delivers all events
-// synchronously via the [domain.RunTurnParams] OnEvent callback.
-func (m *MockAdapter) EventStream() <-chan domain.AgentEvent {
-	return nil
-}
-
 // outcomeAt returns the outcome string for the given turn index.
 // Falls back to "completed" when the index exceeds the configured
 // turn_outcomes slice.

--- a/internal/agent/mock/mock_test.go
+++ b/internal/agent/mock/mock_test.go
@@ -771,15 +771,6 @@ func TestStopSession(t *testing.T) {
 	}
 }
 
-func TestEventStream_ReturnsNil(t *testing.T) {
-	t.Parallel()
-
-	adapter, _ := NewMockAdapter(map[string]any{})
-	if ch := adapter.EventStream(); ch != nil {
-		t.Errorf("EventStream() = %v, want nil", ch)
-	}
-}
-
 // TestNewMockAdapter_ExtendedConfigKeys verifies that the new
 // cache_read_tokens_per_turn and model_name config keys are parsed.
 func TestNewMockAdapter_ExtendedConfigKeys(t *testing.T) {

--- a/internal/agent/opencode/opencode.go
+++ b/internal/agent/opencode/opencode.go
@@ -526,12 +526,6 @@ func (a *OpenCodeAdapter) StopSession(ctx context.Context, session domain.Sessio
 	return stopActiveTurn(ctx, active)
 }
 
-// EventStream returns nil because OpenCode events are delivered via the
-// RunTurn callback.
-func (a *OpenCodeAdapter) EventStream() <-chan domain.AgentEvent {
-	return nil
-}
-
 // finalizeExitedTurn builds and emits the turn's terminal disposition once
 // the subprocess has exited. It also scans the turn's stderr lines for a
 // denied-permission warning, which the runtime writes to stderr rather than

--- a/internal/agent/opencode/opencode_test.go
+++ b/internal/agent/opencode/opencode_test.go
@@ -156,15 +156,6 @@ func TestNewOpenCodeAdapter_OverlapErrorMatchesValidateConfig(t *testing.T) {
 	}
 }
 
-func TestEventStream_ReturnsNil(t *testing.T) {
-	t.Parallel()
-
-	a, _ := NewOpenCodeAdapter(map[string]any{})
-	if ch := a.EventStream(); ch != nil {
-		t.Errorf("EventStream() = %v, want nil", ch)
-	}
-}
-
 func TestStartSession_InvalidWorkspace(t *testing.T) {
 	t.Parallel()
 

--- a/internal/domain/agent.go
+++ b/internal/domain/agent.go
@@ -306,9 +306,4 @@ type AgentAdapter interface {
 	// be called exactly once per session. Safe to call after a failed
 	// [AgentAdapter.RunTurn].
 	StopSession(ctx context.Context, session Session) error
-
-	// EventStream returns a read-only channel for adapters that push
-	// events asynchronously. Synchronous adapters (which deliver
-	// events via the RunTurn callback) return nil.
-	EventStream() <-chan AgentEvent
 }

--- a/internal/domain/agent_test.go
+++ b/internal/domain/agent_test.go
@@ -25,10 +25,6 @@ func (m *mockAgentAdapter) StopSession(_ context.Context, _ Session) error {
 	return nil
 }
 
-func (m *mockAgentAdapter) EventStream() <-chan AgentEvent {
-	return nil
-}
-
 func TestAgentEventType_Values(t *testing.T) {
 	t.Parallel()
 

--- a/internal/orchestrator/self_review_test.go
+++ b/internal/orchestrator/self_review_test.go
@@ -117,8 +117,6 @@ func (v *verdictWriter) StartSession(_ context.Context, _ domain.StartSessionPar
 
 func (v *verdictWriter) StopSession(_ context.Context, _ domain.Session) error { return nil }
 
-func (v *verdictWriter) EventStream() <-chan domain.AgentEvent { return nil }
-
 func (v *verdictWriter) RunTurn(ctx context.Context, session domain.Session, params domain.RunTurnParams) (domain.TurnResult, error) {
 	idx := v.callIdx
 	v.callIdx++
@@ -147,7 +145,6 @@ func (f *failOnFirstAdapter) StartSession(_ context.Context, _ domain.StartSessi
 	return domain.Session{ID: "fail-sess"}, nil
 }
 func (f *failOnFirstAdapter) StopSession(_ context.Context, _ domain.Session) error { return nil }
-func (f *failOnFirstAdapter) EventStream() <-chan domain.AgentEvent                 { return nil }
 func (f *failOnFirstAdapter) RunTurn(_ context.Context, s domain.Session, _ domain.RunTurnParams) (domain.TurnResult, error) {
 	f.callIdx++
 	return domain.TurnResult{}, fmt.Errorf("simulated turn error")
@@ -163,7 +160,6 @@ func (s *statusWriterAdapter) StartSession(_ context.Context, _ domain.StartSess
 	return domain.Session{ID: "status-sess"}, nil
 }
 func (s *statusWriterAdapter) StopSession(_ context.Context, _ domain.Session) error { return nil }
-func (s *statusWriterAdapter) EventStream() <-chan domain.AgentEvent                 { return nil }
 func (s *statusWriterAdapter) RunTurn(_ context.Context, sess domain.Session, _ domain.RunTurnParams) (domain.TurnResult, error) {
 	dir := filepath.Join(s.wsPath, ".sortie")
 	_ = os.MkdirAll(dir, 0o755)
@@ -197,7 +193,6 @@ func (s *scriptedReviewAdapter) StartSession(_ context.Context, _ domain.StartSe
 	return domain.Session{ID: "scripted-sess"}, nil
 }
 func (s *scriptedReviewAdapter) StopSession(_ context.Context, _ domain.Session) error { return nil }
-func (s *scriptedReviewAdapter) EventStream() <-chan domain.AgentEvent                 { return nil }
 func (s *scriptedReviewAdapter) RunTurn(_ context.Context, sess domain.Session, params domain.RunTurnParams) (domain.TurnResult, error) {
 	idx := s.callIdx
 	s.callIdx++
@@ -239,7 +234,6 @@ func (r *repeatingNeedsReviewAdapter) StartSession(_ context.Context, _ domain.S
 func (r *repeatingNeedsReviewAdapter) StopSession(_ context.Context, _ domain.Session) error {
 	return nil
 }
-func (r *repeatingNeedsReviewAdapter) EventStream() <-chan domain.AgentEvent { return nil }
 func (r *repeatingNeedsReviewAdapter) RunTurn(_ context.Context, sess domain.Session, params domain.RunTurnParams) (domain.TurnResult, error) {
 	writeStatusFile(r.t, r.wsPath, "needs-human-review")
 	writeVerdictFile(r.t, r.wsPath, domain.ReviewVerdict{Verdict: "iterate", Summary: "still broken"})
@@ -1533,7 +1527,6 @@ func (a *fixTurnTimeoutAdapter) StartSession(_ context.Context, _ domain.StartSe
 	return domain.Session{ID: "expiring-sess"}, nil
 }
 func (a *fixTurnTimeoutAdapter) StopSession(_ context.Context, _ domain.Session) error { return nil }
-func (a *fixTurnTimeoutAdapter) EventStream() <-chan domain.AgentEvent                 { return nil }
 func (a *fixTurnTimeoutAdapter) RunTurn(ctx context.Context, sess domain.Session, params domain.RunTurnParams) (domain.TurnResult, error) {
 	idx := a.callIdx
 	a.callIdx++

--- a/internal/orchestrator/worker_test.go
+++ b/internal/orchestrator/worker_test.go
@@ -124,8 +124,6 @@ func (m *mockAgentAdapter) StopSession(ctx context.Context, session domain.Sessi
 	return nil
 }
 
-func (m *mockAgentAdapter) EventStream() <-chan domain.AgentEvent { return nil }
-
 // transitionIssueCall records a single invocation of TransitionIssue.
 type transitionIssueCall struct {
 	IssueID     string

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -518,10 +518,6 @@ func (m *mockAgentAdapter) StopSession(_ context.Context, _ domain.Session) erro
 	return nil
 }
 
-func (m *mockAgentAdapter) EventStream() <-chan domain.AgentEvent {
-	return nil
-}
-
 func TestAgentRegistry(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Refactor

**Intent:** `domain.AgentAdapter` required every agent adapter to expose an asynchronous event channel that nothing used - each registered kind implemented it by returning `nil`, since events already reach the orchestrator through the synchronous `RunTurn` callback. Removing it means one fewer no-op method every future adapter has to implement before its package compiles.

**Related Issues:** #985

### 🧭 Reviewer Guide

**Complexity:** Low

#### Entry Point

`internal/domain/agent.go` - removes the `EventStream() <-chan AgentEvent` method from the `AgentAdapter` interface. From there the change is mechanical: the same method is deleted from each of the seven registered kinds (`claude`, `clientprotocol`, `codex`, `copilot`, `kiro`, `mock`, `opencode`), from the tests asserting it returned `nil`, and from the interface-only test doubles in `internal/orchestrator/self_review_test.go`, `internal/orchestrator/worker_test.go`, and `internal/registry/registry_test.go`. `docs/architecture/10-agent-adapter-contract.md` is updated in the same change so it no longer describes the method as an optional capability.

#### Sensitive Areas

None - this is a pure deletion of unused interface surface with no behavioral change.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes. `AgentAdapter` is an internal interface with no external consumers; no adapter gained a replacement channel in its place.
- **Migrations/State:** No migrations or state changes.
