### PR TITLE
feat: add internal/qualification package for runtime measurement

### DIFF
--- a/docs/gemini-adapter-notes.md
+++ b/docs/gemini-adapter-notes.md
@@ -1,0 +1,39 @@
+# Gemini CLI adapter notes
+
+Working notes for anyone dealing with Gemini CLI through Sortie's generic Agent Client Protocol adapter in `internal/agent/clientprotocol`: the one fact that follows from Gemini having no adapter code of its own, the two shapes in which token accounting under-reports spend, and what a normal-looking stop reason does not tell you.
+
+## Where to get the volatile facts
+
+Gemini's own version is never pinned in prose here; the adapter records it per session from that session's own `initialize` handshake, and the account's actual model set comes from Google's model-listing endpoint, which is the only authoritative answer because it depends on the key's subscription. Read the flag surface off `gemini --help` on the binary you are targeting. Upstream source lives in `google-gemini/gemini-cli`; when a symptom looks like a protocol bug rather than a Sortie bug, treat the bundled JavaScript that the installed version actually ships as the source of record, because the TypeScript source tree and the shipped bundle can drift apart between releases.
+
+## The fact everything else follows from
+
+Gemini has no adapter package, no registered kind, no adapter metadata, and no identity branch anywhere in Sortie. The operator reaches it by pointing the generic `agent-client-protocol` kind's `agent.command` at the `gemini` binary with the `--acp` flag; an older `--experimental-acp` spelling still works but is deprecated. Every behavior described below is therefore a property of this one vendor's protocol implementation meeting the generic adapter, not a Gemini-specific code path in Sortie, and there is nowhere in the codebase to special-case a Gemini quirk short of teaching the generic adapter about it.
+
+## Token accounting misses spend in two shapes
+
+This runtime never sends the protocol's standard usage notification. Token counts instead ride a vendor extension, `_meta.quota`, attached to the result of a completed turn, which by itself would just mean parsing a vendor-shaped field rather than a standard one. Two gaps sit underneath that. A cancelled turn's result carries no `_meta` at all, so a turn Sortie cancels reports zero tokens spent even though the model was billed for them; Sortie cancels turns on both stall detection and budget decisions, so this undercount is reachable in ordinary operation rather than only in an edge case. And even where `_meta.quota` is present, it carries only input and output token counts: cached and thought tokens never appear in it, so a running total built from this path understates the real cost.
+
+## A stop reason of end_turn does not mean the turn ended cleanly
+
+Of the five stop reasons the protocol defines, this runtime's own code produces three: `end_turn`, `max_turn_requests`, and `cancelled`. Loop detection reports as `max_turn_requests`. `max_tokens` is reachable only through the runtime's own pre-emptive context-overflow predictor, which fires before the model's stream is actually exhausted; the stream's own genuine token-limit signal never reaches the protocol layer as `max_tokens`, because the handler that catches an invalid stream folds that signal into `end_turn` alongside the model's safety and recitation blocks. `refusal` is never assigned: no code path in this runtime produces it. So a model declining to answer on safety grounds, and a turn that genuinely ran out of context, both surface as an ordinary, successful-looking `end_turn`, and nothing in the response distinguishes either one from a turn that actually completed as asked.
+
+## Session continuation replays history, with two traps
+
+Continuing a session is implemented and does work: `session/load` rebuilds the prior conversation and streams it back as genuine `session/update` notifications, one per historical turn. Two things about that replay need care.
+
+The first is an upstream ordering defect. The `session/load` response can reach the wire before its replay notifications finish sending, because the runtime does not wait for the replay to complete before responding, even though the protocol expects a response only after the full replay has gone out. Sortie's own continuation logic already tolerates this: it starts watching for replayed chunks before issuing the load call, and after the response arrives it waits a bounded interval for any chunk still in flight before deciding there was no replay to see. That wait is load-bearing, not redundant, and must not be trimmed as dead time.
+
+The second trap is more expensive and unrelated to the first. A `session/load` issued in the same UTC minute as the `session/new` that created the session fails and permanently destroys that session's resumability, including every later attempt to load it in a following minute. This is an open upstream defect, confirmed live: moving the load into the following UTC minute, from a separate process, produced a successful load with a full history replay in two independent runs, while a same-minute load reliably failed both times it was tried. Anything that seeds a session and reloads it again shortly afterward, including a routine redispatch, can land inside the same minute and lose that session for good.
+
+## Tool-server delivery depends on workspace trust, and fails silently
+
+Tool servers declared in `session/new` are honored: the runtime merges them over whatever servers its own settings file already configures, matching by name with the request winning on a collision, and stdio, sse, and http transports are all supported. Delivery is gated on whether the runtime considers the workspace trusted, though, and an untrusted workspace fails closed with no signal anywhere: `session/new` still returns success, the declared servers are dropped without a trace, and nothing in the response or in a later notification marks that anything went wrong. The cause is that the runtime's trust check only raises an error in its own headless mode, and it treats protocol mode as interactive rather than headless, so the guard that would reject an untrusted workspace on the command line never fires here.
+
+## There is nothing to call session/close on
+
+This runtime advertises no `sessionCapabilities` object at all in its handshake. Sortie's adapter decides whether to call `session/close` based on that capability being present, so against this runtime there is never a capability to select, and a session here is never closed through the protocol.
+
+## Our own teardown outruns a graceful exit
+
+Sortie ends a client-protocol session by killing its process group, with no graceful-exit step and nothing that waits for one first. A runtime that would otherwise flush its conversation history to disk on a clean exit never gets the chance to under this teardown. Gemini is exactly such a runtime: it persists session history to disk as the conversation happens, but a process killed mid-lifecycle, rather than allowed to exit on its own, never finishes that write, and the next `session/load` against a workspace whose only session ended that way reports no prior session to resume rather than replaying one.

--- a/internal/adaptertest/contract_test.go
+++ b/internal/adaptertest/contract_test.go
@@ -644,9 +644,36 @@ func checkCoreContractPackage(fset *token.FileSet, pkg contractPackage) []contra
 	return violations
 }
 
+// contractTestImportAllowlist exempts one named test file of one
+// package, keyed by the package's directory base name and the test
+// file's base name, from the sibling-adapter and orchestrator import
+// bans for the exact import paths listed, with a reason per path. It is
+// the narrow mechanism the all-or-nothing ruleIMPORT allowlist cannot
+// express: a test-only harness inside an adapter package that drives
+// the real orchestrator and one sibling tracker adapter, while the
+// package's production files and every other test file stay fully
+// guarded. Entries are matched on the exact test-file base name and the
+// exact import path, so the exemption lifts nothing else.
+var contractTestImportAllowlist = map[string]map[string]map[string]string{
+	"clientprotocol": {
+		"gemini_qualification_e2e_unix_test.go": {
+			"github.com/sortie-ai/sortie/internal/orchestrator": "the test-only qualification harness drives the real orchestrator event loop for its isolated end-to-end oracle; production adapter code stays orchestrator-free",
+			"github.com/sortie-ai/sortie/internal/tracker/file": "the test-only qualification harness uses the file tracker as its isolated tracker kind",
+		},
+	},
+}
+
 // checkContractImports reports a violation for every import declaration
-// in file that contractImportBanReason rejects for pkg.
+// in file that contractImportBanReason rejects for pkg. A test file
+// named by contractTestImportAllowlist may carry the exact import paths
+// its entry lists; every other banned import still reports.
 func checkContractImports(fset *token.FileSet, file *ast.File, pkg contractPackage) []contractViolation {
+	fileExemptions := map[string]string{}
+	if perFile, ok := contractTestImportAllowlist[pkg.dirName]; ok {
+		if slices.Contains(pkg.testFiles, file) {
+			fileExemptions = perFile[filepath.Base(fset.Position(file.Pos()).Filename)]
+		}
+	}
 	var violations []contractViolation
 	for _, imp := range file.Imports {
 		importPath, err := strconv.Unquote(imp.Path.Value)
@@ -655,6 +682,9 @@ func checkContractImports(fset *token.FileSet, file *ast.File, pkg contractPacka
 		}
 		reason := contractImportBanReason(importPath, pkg)
 		if reason == "" {
+			continue
+		}
+		if _, exempt := fileExemptions[importPath]; exempt && fileExemptions[importPath] != "" {
 			continue
 		}
 		violations = append(violations, contractViolation{
@@ -2303,3 +2333,81 @@ func doWork() {}
 		})
 	}
 }
+
+// TestCheckAdapterContract_TestImportAllowlist confirms the per-test-file
+// import exemption is narrow: the named qualification harness test file
+// may import exactly the two paths its entry lists, any other banned
+// import in that same file still reports, and the exemption never
+// reaches a differently named test file or a non-test file.
+func TestCheckAdapterContract_TestImportAllowlist(t *testing.T) {
+	t.Parallel()
+
+	parseFixture := func(t *testing.T, name, src string) (*token.FileSet, *ast.File) {
+		t.Helper()
+		fset := token.NewFileSet()
+		file, err := parser.ParseFile(fset, name, src, parser.SkipObjectResolution)
+		if err != nil {
+			t.Fatalf("parser.ParseFile: %v", err)
+		}
+		return fset, file
+	}
+	packageWithTestFile := func(file *ast.File) contractPackage {
+		return contractPackage{
+			dirName:    "clientprotocol",
+			importPath: "github.com/sortie-ai/sortie/internal/agent/clientprotocol",
+			testFiles:  []*ast.File{file},
+		}
+	}
+
+	t.Run("the listed test file may import its listed paths", func(t *testing.T) {
+		t.Parallel()
+
+		src := "package fixture\n\nimport (\n\t\"github.com/sortie-ai/sortie/internal/orchestrator\"\n\t\"github.com/sortie-ai/sortie/internal/tracker/file\"\n)\n"
+		fset, file := parseFixture(t, harnessFileFixtureName, src)
+		pkg := packageWithTestFile(file)
+		if violations := checkContractImports(fset, file, pkg); len(violations) != 0 {
+			t.Errorf("checkContractImports() = %+v, want none for the allowlisted harness file", violations)
+		}
+	})
+
+	t.Run("another banned import in the same file still reports", func(t *testing.T) {
+		t.Parallel()
+
+		src := "package fixture\n\nimport \"github.com/sortie-ai/sortie/internal/tracker/jira\"\n"
+		fset, file := parseFixture(t, harnessFileFixtureName, src)
+		pkg := packageWithTestFile(file)
+		if violations := checkContractImports(fset, file, pkg); len(violations) != 1 {
+			t.Errorf("checkContractImports() returned %d violations, want 1 for an import the entry does not list: %+v", len(violations), violations)
+		}
+	})
+
+	t.Run("a differently named test file gets no exemption", func(t *testing.T) {
+		t.Parallel()
+
+		src := "package fixture\n\nimport \"github.com/sortie-ai/sortie/internal/orchestrator\"\n"
+		fset, file := parseFixture(t, "other_test.go", src)
+		pkg := packageWithTestFile(file)
+		if violations := checkContractImports(fset, file, pkg); len(violations) != 1 {
+			t.Errorf("checkContractImports() returned %d violations, want 1 for a file the exemption does not name: %+v", len(violations), violations)
+		}
+	})
+
+	t.Run("a non-test file gets no exemption", func(t *testing.T) {
+		t.Parallel()
+
+		src := "package clientprotocol\n\nimport \"github.com/sortie-ai/sortie/internal/orchestrator\"\n"
+		fset, file := parseFixture(t, harnessFileFixtureName, src)
+		pkg := contractPackage{
+			dirName:    "clientprotocol",
+			importPath: "github.com/sortie-ai/sortie/internal/agent/clientprotocol",
+			files:      []*ast.File{file},
+		}
+		if violations := checkContractImports(fset, file, pkg); len(violations) != 1 {
+			t.Errorf("checkContractImports() returned %d violations for a non-test file, want 1: %+v", len(violations), violations)
+		}
+	})
+}
+
+// harnessFileFixtureName is the base name the test-import allowlist
+// exempts, shared by the controls above.
+const harnessFileFixtureName = "gemini_qualification_e2e_unix_test.go"

--- a/internal/agent/clientprotocol/gemini_qualification_capability_probes_unix_test.go
+++ b/internal/agent/clientprotocol/gemini_qualification_capability_probes_unix_test.go
@@ -794,10 +794,13 @@ func TestGeminiHandshakeIdentityCollector(t *testing.T) {
 	}
 }
 
-// checkGeminiVerdictClassification verifies outcome and grade consistency.
+// checkGeminiVerdictClassification verifies one record's outcome and
+// grade consistency. It delegates to
+// [qualification.CheckOutcomeGradePairing] rather than restating the
+// pairing, so a collector record built here is held to the same rule
+// the set validator applies to the written evidence.
 func checkGeminiVerdictClassification(rec *qualification.Record) error {
-	// Placeholder: this function should verify outcome/grade rules
-	return nil
+	return qualification.CheckOutcomeGradePairing(rec)
 }
 
 // geminiOrderCompare orders two records by the same canonical write

--- a/internal/agent/clientprotocol/gemini_qualification_capability_probes_unix_test.go
+++ b/internal/agent/clientprotocol/gemini_qualification_capability_probes_unix_test.go
@@ -1,0 +1,824 @@
+//go:build unix
+
+package clientprotocol
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"slices"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/sortie-ai/sortie/internal/agent/agenttest"
+	"github.com/sortie-ai/sortie/internal/agent/jsonrpc"
+	"github.com/sortie-ai/sortie/internal/domain"
+	"github.com/sortie-ai/sortie/internal/qualification"
+)
+
+// geminiIdentityLogDeadline bounds the deterministic wait for the
+// structured implementation log record the pump writes.
+const geminiIdentityLogDeadline = 5 * time.Second
+
+const (
+	geminiRecallUnobservedActual     = "unobserved_actual_session"
+	geminiRecallConfirmedSameSession = "confirmed_same_session"
+	geminiRecallFreshFallback        = "fresh_session_fallback"
+)
+
+// geminiTokenSource is one token-bearing path observed on one surface:
+// a standard usage member, a terminal usage field, or a vendor
+// extension that reports token or quota figures. Path is a JSON pointer
+// or a protocol method name; an empty path is the zero-source sentinel.
+type geminiTokenSource struct {
+	Path      string
+	Vendor    bool
+	Usage     *domain.TokenUsage
+	SessionID string
+}
+
+// geminiClassifyTokenSource classifies one token-bearing path against
+// domain.TokenUsage semantics, not field-name similarity: a source the
+// adapter may consume through the shared contract is usable, vendor
+// extension figures and occupancy-only members are corroboration only
+// and never receive a numeric grade, and a path whose observed shape
+// cannot satisfy the shared contract is not usable either.
+func geminiClassifyTokenSource(source geminiTokenSource) qualification.Grade {
+	if source.Usage == nil {
+		return qualification.GradeCorroborationOnly
+	}
+	usage := *source.Usage
+	totalOK := usage.TotalTokens == usage.InputTokens+usage.OutputTokens
+	cacheOK := usage.CacheReadTokens <= usage.InputTokens
+	nonNegative := usage.InputTokens >= 0 && usage.OutputTokens >= 0 && usage.CacheReadTokens >= 0
+	if source.Vendor || !totalOK || !cacheOK || !nonNegative {
+		// A vendor-reported total never passes through as the shared
+		// contract's total, and a vendor path is never consumable.
+		return qualification.GradeCorroborationOnly
+	}
+	return qualification.GradeUsable
+}
+
+// geminiTokenEventsFor folds a consumable token source into the
+// normalized events the shared contract expects, so the classification
+// controls can assert the usage contract the same way the adapter does.
+func geminiTokenEventsFor(source geminiTokenSource) []domain.AgentEvent {
+	if source.Usage == nil {
+		return nil
+	}
+	return []domain.AgentEvent{{
+		Type:      domain.EventTokenUsage,
+		Timestamp: time.Now().UTC(),
+		Usage:     *source.Usage,
+	}}
+}
+
+// geminiTokenInventoryRecords builds one surface's token_source records
+// from the observed sources. A failed inventory and a completed
+// zero-source inventory both carry the single sentinel key; a completed
+// inventory with sources records one record per path, sorted so the
+// records land in canonical order.
+func geminiTokenInventoryRecords(surface qualification.Surface, sources []geminiTokenSource, inventoryFailed bool) []qualification.Record {
+	records := []qualification.Record{}
+	if inventoryFailed || len(sources) == 0 {
+		rec := qualification.Record{
+			SchemaVersion: 1,
+			ObservedAt:    qualification.FixtureTime,
+			Scenario:      qualification.ScenarioTokenSource,
+			Surface:       surface,
+			Capability:    qualification.CapabilityTokenCeiling,
+			Source:        qualification.SourceNone,
+			Outcome:       qualification.OutcomePass,
+			InputID:       qualification.InputTokenInventory,
+			Detail:        "inventory completed with no token-bearing path",
+		}
+		if inventoryFailed {
+			rec.Grade = qualification.GradeNotObserved
+			rec.Outcome = qualification.OutcomeRuntimeFailed
+			rec.Detail = "token inventory collection failed"
+		} else {
+			rec.Grade = qualification.GradeGap
+		}
+		if surface == qualification.SurfaceProtocol {
+			rec.AgentName = new(qualification.FixtureAgentName)
+			rec.AgentVersion = new(qualification.FixtureAgentVer)
+			rec.ProtocolVersion = new(1)
+		} else {
+			rec.AgentVersion = new(qualification.FixtureAgentVer)
+		}
+		return append(records, rec)
+	}
+
+	for _, source := range sources {
+		if source.Path == "" {
+			continue
+		}
+		rec := qualification.Record{
+			SchemaVersion: 1,
+			ObservedAt:    qualification.FixtureTime,
+			Scenario:      qualification.ScenarioTokenSource,
+			Surface:       surface,
+			Capability:    qualification.CapabilityTokenCeiling,
+			Grade:         geminiClassifyTokenSource(source),
+			Outcome:       qualification.OutcomePass,
+			InputID:       qualification.InputTokenInventory,
+			EvidencePath:  new(source.Path),
+			SessionID:     new(source.SessionID),
+			Detail:        "token-bearing path classified against the shared usage contract",
+		}
+		if surface == qualification.SurfaceProtocol {
+			rec.Source = qualification.SourceProtocolStable
+			if source.Vendor {
+				rec.Source = qualification.SourceProtocolExtension
+			}
+			rec.AgentName = new(qualification.FixtureAgentName)
+			rec.AgentVersion = new(qualification.FixtureAgentVer)
+			rec.ProtocolVersion = new(1)
+		} else {
+			rec.Source = qualification.SourceNativeStructured
+			rec.AgentVersion = new(qualification.FixtureAgentVer)
+		}
+		records = append(records, rec)
+	}
+	slices.SortStableFunc(records, geminiOrderCompare)
+	return records
+}
+
+// geminiDuplicateTokenPaths reports paths that appear more than once in
+// one surface's inventory, which is a fixture failure the collector
+// reports rather than a second record for the same uniqueness key.
+func geminiDuplicateTokenPaths(sources []geminiTokenSource) []string {
+	seen := map[string]bool{}
+	var duplicates []string
+	for _, source := range sources {
+		if source.Path == "" {
+			continue
+		}
+		if seen[source.Path] {
+			if !slices.Contains(duplicates, source.Path) {
+				duplicates = append(duplicates, source.Path)
+			}
+			continue
+		}
+		seen[source.Path] = true
+	}
+	return duplicates
+}
+
+// TestGeminiTokenInventoryClassificationControls confirms the token
+// inventory's classification controls: a consumable standard source is
+// usable and its folded events satisfy the shared usage contract, a
+// vendor-only figure is corroboration only with the measurement absent,
+// the zero-source and failed inventories each carry exactly one
+// sentinel, and a duplicate path is rejected rather than recorded
+// twice.
+func TestGeminiTokenInventoryClassificationControls(t *testing.T) {
+	t.Parallel()
+
+	t.Run("a consumable standard source is usable and satisfies the usage contract", func(t *testing.T) {
+		t.Parallel()
+
+		usage := domain.TokenUsage{InputTokens: 120, OutputTokens: 30, TotalTokens: 150, CacheReadTokens: 40}
+		source := geminiTokenSource{Path: "session/prompt/result/usage", Usage: &usage, SessionID: "sess-token-fixture"}
+
+		if got := geminiClassifyTokenSource(source); got != qualification.GradeUsable {
+			t.Errorf("geminiClassifyTokenSource() = %s, want usable", got)
+		}
+		events := geminiTokenEventsFor(source)
+		agenttest.AssertUsageContract(t, events)
+
+		records := geminiTokenInventoryRecords(qualification.SurfaceNativeJSON, []geminiTokenSource{source}, false)
+		if len(records) != 1 {
+			t.Fatalf("token inventory records = %d, want 1", len(records))
+		}
+		rec := records[0]
+		if rec.EvidencePath == nil || *rec.EvidencePath != source.Path {
+			t.Errorf("token record evidence path = %v, want %q", rec.EvidencePath, source.Path)
+		}
+		if rec.SessionID == nil || *rec.SessionID != source.SessionID {
+			t.Errorf("token record session = %v, want the emitting session", rec.SessionID)
+		}
+		if err := checkGeminiVerdictClassification(&rec); err != nil {
+			t.Errorf("checkGeminiVerdictClassification() error = %v", err)
+		}
+	})
+
+	t.Run("a vendor-only figure is corroboration only with the measurement absent", func(t *testing.T) {
+		t.Parallel()
+
+		// The vendor extension reports a total outside the shared
+		// contract: no token_usage event is emitted, the usage stays
+		// zero, and UsageMeasured stays false.
+		source := geminiTokenSource{Path: "session/update/vendor_usage", Vendor: true, SessionID: "sess-vendor-fixture"}
+		if got := geminiClassifyTokenSource(source); got != qualification.GradeCorroborationOnly {
+			t.Errorf("geminiClassifyTokenSource(vendor) = %s, want corroboration_only", got)
+		}
+
+		events := geminiTokenEventsFor(source)
+		result := domain.TurnResult{SessionID: source.SessionID, ExitReason: domain.EventTurnCompleted}
+		agenttest.AssertMeasurementAbsent(t, events, result)
+		agenttest.AssertMeasurementAbsent(t, nil, domain.TurnResult{})
+	})
+
+	t.Run("an unsatisfiable shape is corroboration only", func(t *testing.T) {
+		t.Parallel()
+
+		// A vendor-reported total passed through as TotalTokens fails
+		// the adapter-computed-total rule and can never classify usable.
+		vendorTotal := domain.TokenUsage{InputTokens: 100, OutputTokens: 20, TotalTokens: 500}
+		got := geminiClassifyTokenSource(geminiTokenSource{Path: "/stats", Usage: new(vendorTotal), Vendor: true})
+		if got != qualification.GradeCorroborationOnly {
+			t.Errorf("vendor total classification = %s, want corroboration_only", got)
+		}
+		broken := domain.TokenUsage{InputTokens: 100, OutputTokens: 20, TotalTokens: 500}
+		got = geminiClassifyTokenSource(geminiTokenSource{Path: "/stats", Usage: new(broken)})
+		if got != qualification.GradeCorroborationOnly {
+			t.Errorf("non-contract shape classification = %s, want corroboration_only", got)
+		}
+	})
+
+	t.Run("a completed zero-source inventory carries the single sentinel", func(t *testing.T) {
+		t.Parallel()
+
+		records := geminiTokenInventoryRecords(qualification.SurfaceNativeText, nil, false)
+		if len(records) != 1 {
+			t.Fatalf("sentinel record count = %d, want exactly 1", len(records))
+		}
+		if records[0].EvidencePath != nil {
+			t.Errorf("sentinel evidence path = %v, want null", records[0].EvidencePath)
+		}
+		if records[0].Source != qualification.SourceNone {
+			t.Errorf("sentinel source = %s, want none", records[0].Source)
+		}
+		if records[0].Grade != qualification.GradeGap || records[0].Outcome != qualification.OutcomePass {
+			t.Errorf("zero-source sentinel = %s/%s, want gap/pass", records[0].Grade, records[0].Outcome)
+		}
+		if records[0].SessionID != nil {
+			t.Errorf("sentinel session id = %v, want null", records[0].SessionID)
+		}
+	})
+
+	t.Run("a failed inventory carries the failure sentinel", func(t *testing.T) {
+		t.Parallel()
+
+		records := geminiTokenInventoryRecords(qualification.SurfaceProtocol, nil, true)
+		if len(records) != 1 {
+			t.Fatalf("failed-inventory sentinel count = %d, want exactly 1", len(records))
+		}
+		if records[0].Outcome != qualification.OutcomeRuntimeFailed || records[0].Grade != qualification.GradeNotObserved {
+			t.Errorf("failed-inventory sentinel = %s/%s, want runtime_failed/not_observed", records[0].Outcome, records[0].Grade)
+		}
+	})
+
+	t.Run("a duplicate path is rejected rather than recorded twice", func(t *testing.T) {
+		t.Parallel()
+
+		duplicated := []geminiTokenSource{
+			{Path: "session/prompt/result/usage", SessionID: "sess-a"},
+			{Path: "session/prompt/result/usage", SessionID: "sess-token-fixture"},
+		}
+		if got := geminiDuplicateTokenPaths(duplicated); len(got) != 1 {
+			t.Errorf("geminiDuplicateTokenPaths() = %v, want the one duplicated path", got)
+		}
+	})
+
+	t.Run("records sort canonically with the sentinel first", func(t *testing.T) {
+		t.Parallel()
+
+		sources := []geminiTokenSource{
+			{Path: "session/update/vendor_usage", Vendor: true, SessionID: "sess-a"},
+			{Path: "session/prompt/result/usage", SessionID: "sess-b"},
+		}
+		records := geminiTokenInventoryRecords(qualification.SurfaceProtocol, sources, false)
+		if len(records) != 2 {
+			t.Fatalf("record count = %d, want 2", len(records))
+		}
+		for i := 1; i < len(records); i++ {
+			if geminiOrderCompare(records[i-1], records[i]) > 0 {
+				t.Errorf("token records are not in canonical order at %d", i)
+			}
+		}
+	})
+}
+
+// geminiContinuationRelation is one surface's continuation evidence:
+// the seed's actual identifier, the identifier the recall attempted to
+// continue, the actual identifier the recall session held, and whether
+// prior content replayed.
+type geminiContinuationRelation struct {
+	Surface         qualification.Surface
+	SeedSessionID   string
+	RecallSessionID string
+	ReplayConfirmed bool
+}
+
+// geminiRecallDetail maps one continuation relation onto the closed
+// recall detail set: equal non-null actual and prior ids with confirmed
+// replay are a same-session confirmation, a distinct non-null actual id
+// is a fresh fallback, and an unobserved actual id stays unobserved.
+func geminiRecallDetail(relation geminiContinuationRelation) (detail string, classification qualification.Grade) {
+	switch {
+	case relation.RecallSessionID == "":
+		return geminiRecallUnobservedActual, qualification.GradeNotObserved
+	case relation.RecallSessionID == relation.SeedSessionID && relation.ReplayConfirmed:
+		return geminiRecallConfirmedSameSession, qualification.GradeUsable
+	default:
+		return geminiRecallFreshFallback, qualification.GradeGap
+	}
+}
+
+// geminiBuildContinuationRecords builds one surface's seed and recall
+// records from the relation. The seed carries the seed's actual
+// identifier with a null prior; the recall names the seed through
+// prior_session_id and records its actual current identifier, never a
+// copy of the requested one.
+func geminiBuildContinuationRecords(relation geminiContinuationRelation) (seed, recall qualification.Record) {
+	base := qualification.Record{
+		SchemaVersion: 1,
+		ObservedAt:    qualification.FixtureTime,
+		Scenario:      qualification.ScenarioContinuation,
+		Surface:       relation.Surface,
+		Capability:    qualification.CapabilitySessionContinuation,
+	}
+	if relation.Surface == qualification.SurfaceProtocol {
+		base.Source = qualification.SourceProtocolStable
+		base.AgentName = new(qualification.FixtureAgentName)
+		base.AgentVersion = new(qualification.FixtureAgentVer)
+		base.ProtocolVersion = new(1)
+	} else {
+		base.Source = qualification.SourceNativeStructured
+		base.AgentVersion = new(qualification.FixtureAgentVer)
+	}
+
+	seed = base
+	seed.InputID = qualification.InputContinuationSeed
+	seed.Outcome = qualification.OutcomePass
+	seed.Grade = qualification.GradeUsable
+	seed.EvidencePath = new("/continuation/seed")
+	seed.SessionID = new(relation.SeedSessionID)
+	seed.Detail = "seed conversation stored the generated nonce"
+
+	detail, classification := geminiRecallDetail(relation)
+	recall = base
+	recall.InputID = qualification.InputContinuationRecall
+	recall.EvidencePath = new("/continuation/recall")
+	recall.PriorSessionID = new(relation.SeedSessionID)
+	recall.Detail = detail
+	recall.Grade = classification
+	switch detail {
+	case geminiRecallConfirmedSameSession:
+		recall.Outcome = qualification.OutcomePass
+		recall.SessionID = new(relation.RecallSessionID)
+	case geminiRecallFreshFallback:
+		recall.Outcome = qualification.OutcomePass
+		recall.SessionID = new(relation.RecallSessionID)
+	default:
+		recall.Outcome = qualification.OutcomeNotObserved
+	}
+	return seed, recall
+}
+
+// TestGeminiContinuationRelationBuilder confirms the actual/prior
+// session relation builder: a confirmed same-session relation with
+// equal ids grades usable, a fresh fallback with distinct non-null ids
+// grades gap, an unobserved actual session stays not_observed with a
+// null id, and the spliced fresh-fallback set still validates with its
+// computed not_qualified verdict.
+func TestGeminiContinuationRelationBuilder(t *testing.T) {
+	t.Parallel()
+
+	t.Run("confirmed same session", func(t *testing.T) {
+		t.Parallel()
+
+		relation := geminiContinuationRelation{
+			Surface:         qualification.SurfaceProtocol,
+			SeedSessionID:   "sess-seed",
+			RecallSessionID: "sess-seed",
+			ReplayConfirmed: true,
+		}
+		seed, recall := geminiBuildContinuationRecords(relation)
+		if seed.SessionID == nil || *seed.SessionID != relation.SeedSessionID {
+			t.Errorf("seed session id = %v, want the seed's actual identifier", seed.SessionID)
+		}
+		if seed.PriorSessionID != nil {
+			t.Errorf("seed prior_session_id = %v, want null", seed.PriorSessionID)
+		}
+		if recall.Detail != geminiRecallConfirmedSameSession || recall.Grade != qualification.GradeUsable {
+			t.Errorf("recall detail/classification = %s/%s, want confirmed_same_session/usable", recall.Detail, recall.Grade)
+		}
+		if recall.SessionID == nil || recall.PriorSessionID == nil || *recall.SessionID != *recall.PriorSessionID {
+			t.Errorf("confirmed recall ids = %v/%v, want equal actual and prior ids", recall.SessionID, recall.PriorSessionID)
+		}
+	})
+
+	t.Run("fresh fallback keeps distinct non-null ids", func(t *testing.T) {
+		t.Parallel()
+
+		relation := geminiContinuationRelation{
+			Surface:         qualification.SurfaceNativeJSON,
+			SeedSessionID:   "sess-native-seed",
+			RecallSessionID: "sess-native-fallback",
+			ReplayConfirmed: false,
+		}
+		seed, recall := geminiBuildContinuationRecords(relation)
+		if recall.Detail != geminiRecallFreshFallback || recall.Grade != qualification.GradeGap {
+			t.Errorf("recall detail/classification = %s/%s, want fresh_session_fallback/gap", recall.Detail, recall.Grade)
+		}
+		if *recall.SessionID == *recall.PriorSessionID {
+			t.Errorf("fresh fallback copied the prior id: %q", *recall.SessionID)
+		}
+		if seed.SessionID == nil || *seed.SessionID != relation.SeedSessionID || seed.PriorSessionID != nil {
+			t.Errorf("seed record = session %v, prior %v, want the seed's actual id and a null prior id", seed.SessionID, seed.PriorSessionID)
+		}
+	})
+
+	t.Run("unobserved actual session", func(t *testing.T) {
+		t.Parallel()
+
+		relation := geminiContinuationRelation{Surface: qualification.SurfaceNativeText, SeedSessionID: "sess-text-seed"}
+		seed, recall := geminiBuildContinuationRecords(relation)
+		if recall.Detail != geminiRecallUnobservedActual || recall.Grade != qualification.GradeNotObserved {
+			t.Errorf("recall detail/classification = %s/%s, want unobserved_actual_session/not_observed", recall.Detail, recall.Grade)
+		}
+		if recall.SessionID != nil {
+			t.Errorf("unobserved recall copied a session id: %v", recall.SessionID)
+		}
+		if seed.SessionID == nil || *seed.SessionID != relation.SeedSessionID {
+			t.Errorf("seed session id = %v, want the seed's actual identifier", seed.SessionID)
+		}
+	})
+
+	t.Run("a fresh fallback set validates and computes not_qualified", func(t *testing.T) {
+		t.Parallel()
+
+		fixture := qualification.NewFixture(qualification.FixtureQualified)
+		// The recall session the adapter actually created differs from
+		// the seed, so the protocol continuation entry is lowered.
+		fixture.RemoveAll(qualification.MatchContinuation(qualification.SurfaceProtocol, qualification.InputContinuationSeed))
+		fixture.RemoveAll(qualification.MatchContinuation(qualification.SurfaceProtocol, qualification.InputContinuationRecall))
+		fixture.SetSemanticNotObserved(qualification.SurfaceProtocol, qualification.CapabilityRetryClassification, qualification.CaseHumanInput)
+		fixture.SetSemanticNotObserved(qualification.SurfaceProtocol, qualification.CapabilityTurnDisposition, qualification.CaseRuntimeRefusal)
+		fixture.SetSemanticNotObserved(qualification.SurfaceProtocol, qualification.CapabilityRetryClassification, qualification.CaseNonRetryableRefusal)
+		seed, recall := geminiBuildContinuationRecords(geminiContinuationRelation{
+			Surface:         qualification.SurfaceProtocol,
+			SeedSessionID:   qualification.FixtureSession(qualification.SurfaceProtocol, "seed"),
+			RecallSessionID: qualification.FixtureSession(qualification.SurfaceProtocol, "fallback"),
+		})
+		fixture.Add(seed)
+		fixture.Add(recall)
+		if baseline := fixture.FindFirst(qualification.MatchBaseline(qualification.SurfaceProtocol, qualification.CapabilitySessionContinuation)); baseline != nil {
+			baseline.Grade = qualification.GradeGap
+			baseline.Outcome = qualification.BaselineVerdictFor(qualification.GradeGap)
+		}
+		fixture.Finalize()
+
+		path := qualification.WriteEvidenceFile(t, fixture.Records)
+		qualification.RequireObservationVerdict(t, path, qualification.VerdictNotQualified)
+	})
+}
+
+// TestResolveSessionLoadSuccessWithReplayConfirms and
+// TestResolveSessionLoadUnimplementedLowersAndFallsBack live in
+// continuation_test.go and cover the load route's replay requirement and
+// the invented-method fallback; this file's continuation collector
+// builds its records from their outcomes.
+
+// geminiLiveTokenInventoryRecords builds one surface's token inventory
+// records with the live runtime identity, replacing the fixture identity
+// the shared builder carries.
+func geminiLiveTokenInventoryRecords(surface qualification.Surface, sources []geminiTokenSource, inventoryFailed bool, agentName, agentVersion string) []qualification.Record {
+	records := geminiTokenInventoryRecords(surface, sources, inventoryFailed)
+	for i := range records {
+		if surface == qualification.SurfaceProtocol {
+			records[i].AgentName = new(agentName)
+			records[i].ProtocolVersion = new(1)
+		}
+		records[i].AgentVersion = new(agentVersion)
+	}
+	return records
+}
+
+// geminiLiveContinuationRecords builds one surface's seed and recall
+// records with the live runtime identity, replacing the fixture identity
+// the shared builder carries.
+func geminiLiveContinuationRecords(relation geminiContinuationRelation, agentName, agentVersion string) (qualification.Record, qualification.Record) {
+	seed, recall := geminiBuildContinuationRecords(relation)
+	if relation.Surface == qualification.SurfaceProtocol {
+		seed.AgentName = new(agentName)
+		recall.AgentName = new(agentName)
+	}
+	seed.AgentVersion = new(agentVersion)
+	recall.AgentVersion = new(agentVersion)
+	return seed, recall
+}
+
+// geminiTokenBearingKeys are the member names whose presence marks a
+// structured member as token-bearing for the inventory scan.
+var geminiTokenBearingKeys = []string{
+	"total_tokens", "input_tokens", "output_tokens", "tokens", "cached", "total",
+}
+
+// geminiScanNativeTokenOutput scans one native surface's captured
+// output for token-bearing structured members and the runtime-observed
+// session identifier, and reports the members as vendor sources for
+// classification against the shared usage contract. The text surface
+// never scans: unstructured residue yields no token path.
+func geminiScanNativeTokenOutput(surface qualification.Surface, output string, sessionID string) []geminiTokenSource {
+	if surface == qualification.SurfaceNativeText {
+		return nil
+	}
+	var sources []geminiTokenSource
+	seen := map[string]bool{}
+	for _, value := range geminiDecodeNativeJSONValues(output) {
+		var pointers []string
+		geminiCollectTokenPointers(value, "", &pointers)
+		for _, pointer := range pointers {
+			if seen[pointer] {
+				continue
+			}
+			seen[pointer] = true
+			sources = append(sources, geminiTokenSource{Path: pointer, Vendor: true, SessionID: sessionID})
+		}
+	}
+	return sources
+}
+
+// geminiDecodeNativeJSONValues decodes the JSON values one native
+// surface's combined output carries, tolerating the runtime's non-JSON
+// diagnostic noise around them. Stream formats carry one complete
+// object per line; the single-object format is pretty-printed.
+func geminiDecodeNativeJSONValues(output string) []any {
+	values := []any{}
+	for line := range strings.SplitSeq(output, "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, "{") {
+			continue
+		}
+		var value any
+		if err := json.Unmarshal([]byte(line), &value); err == nil {
+			values = append(values, value)
+		}
+	}
+	if len(values) > 0 {
+		return values
+	}
+	if idx := strings.Index(output, "{"); idx >= 0 {
+		decoder := json.NewDecoder(strings.NewReader(output[idx:]))
+		for {
+			var value any
+			if err := decoder.Decode(&value); err != nil {
+				break
+			}
+			values = append(values, value)
+		}
+	}
+	return values
+}
+
+// geminiCollectTokenPointers walks one decoded JSON value and records
+// the pointer of every object carrying a token-bearing member.
+func geminiCollectTokenPointers(node any, prefix string, out *[]string) {
+	object, ok := node.(map[string]any)
+	if !ok {
+		return
+	}
+	tokenBearing := false
+	for _, key := range geminiTokenBearingKeys {
+		if _, ok := object[key]; ok {
+			tokenBearing = true
+			break
+		}
+	}
+	if tokenBearing && prefix != "" {
+		*out = append(*out, prefix)
+	}
+	for key, child := range object {
+		geminiCollectTokenPointers(child, prefix+"/"+key, out)
+	}
+}
+
+// geminiNativeSessionID extracts the runtime-observed session
+// identifier from one native structured output. The text surface never
+// reports one.
+func geminiNativeSessionID(surface qualification.Surface, output string) string {
+	if surface == qualification.SurfaceNativeText {
+		return ""
+	}
+	for _, value := range geminiDecodeNativeJSONValues(output) {
+		if object, ok := value.(map[string]any); ok {
+			if id, ok := object["session_id"].(string); ok && id != "" {
+				return id
+			}
+		}
+	}
+	return ""
+}
+
+// geminiLogRecord is one captured structured log record with its
+// attributes, the shape the runtime-identity collector reads the
+// adapter's own structured log with.
+type geminiLogRecord struct {
+	Level slog.Level
+	Msg   string
+	Attrs map[string]string
+}
+
+// geminiLogCapture is a slog.Handler that records every log record and
+// its attributes. It exists only in test code and never mutates
+// production logging.
+type geminiLogCapture struct {
+	mu      sync.Mutex
+	records []geminiLogRecord
+}
+
+// Enabled reports true for every level so all records are captured.
+func (c *geminiLogCapture) Enabled(_ context.Context, _ slog.Level) bool { return true }
+
+// Handle records one log record and its attributes.
+func (c *geminiLogCapture) Handle(_ context.Context, record slog.Record) error {
+	entry := geminiLogRecord{Level: entryLevel(record.Level), Msg: record.Message, Attrs: map[string]string{}}
+	record.Attrs(func(a slog.Attr) bool {
+		entry.Attrs[a.Key] = a.Value.String()
+		return true
+	})
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.records = append(c.records, entry)
+	return nil
+}
+
+// entryLevel normalizes a level for capture.
+func entryLevel(level slog.Level) slog.Level { return level }
+
+// WithAttrs returns the receiver so derived loggers share the capture.
+func (c *geminiLogCapture) WithAttrs(_ []slog.Attr) slog.Handler { return c }
+
+// WithGroup returns the receiver so derived loggers share the capture.
+func (c *geminiLogCapture) WithGroup(_ string) slog.Handler { return c }
+
+// implementationRecords returns every captured record the adapter's
+// per-session implementation log wrote.
+func (c *geminiLogCapture) implementationRecords() []geminiLogRecord {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	var out []geminiLogRecord
+	for _, entry := range c.records {
+		if entry.Msg == "agent implementation" {
+			out = append(out, entry)
+		}
+	}
+	return out
+}
+
+// sessionFacts returns the handshake identity one actual protocol
+// session's implementation log recorded.
+func (c *geminiLogCapture) sessionFacts(sessionID string) (name, version string, ok bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for _, entry := range c.records {
+		if entry.Msg != "agent implementation" || entry.Attrs["session_id"] != sessionID {
+			continue
+		}
+		return entry.Attrs["name"], entry.Attrs["version"], true
+	}
+	return "", "", false
+}
+
+// newGeminiLoggedSession builds an in-memory session wired to a capture
+// logger, so a test can tie the runtime-identity record to the
+// structured log the pump writes when the session identifier lands.
+func newGeminiLoggedTestSession(t *testing.T, capture *geminiLogCapture) (*sessionState, *io.PipeReader, *io.PipeWriter) {
+	t.Helper()
+
+	outPr, outPw := io.Pipe()
+	inPr, inPw := io.Pipe()
+
+	state := &sessionState{
+		agentConfig: domain.AgentConfig{},
+		caps:        newCapabilityRecord(false),
+		itemCh:      make(chan pumpItem, pumpChannelCapacity),
+		stopCh:      make(chan struct{}),
+		pumpDone:    make(chan struct{}),
+		logger:      slog.New(capture),
+	}
+	state.conn = jsonrpc.NewConn(outPw, inPr, pumpHandler(state.itemCh, state.stopCh),
+		jsonrpc.WithVersionMember(), jsonrpc.WithMaxLineBytes(clientProtocolMaxLineBytes))
+
+	go runPump(state)
+
+	t.Cleanup(func() {
+		_ = inPw.Close()
+		state.stopOnce.Do(func() { close(state.stopCh) })
+		<-state.pumpDone
+		_ = outPr.Close()
+		_ = outPw.Close()
+		_ = inPr.Close()
+	})
+
+	return state, outPr, inPw
+}
+
+// geminiIdentityRecord builds the one runtime-identity record for one
+// actual protocol session from that session's handshake facts.
+func geminiIdentityRecord(sessionID string, name, version string, protocolVersion int) qualification.Record {
+	rec := qualification.IdentityFixtureRecord(sessionID)
+	rec.AgentName = new(name)
+	rec.AgentVersion = new(version)
+	rec.ProtocolVersion = new(protocolVersion)
+	return rec
+}
+
+// TestGeminiHandshakeIdentityCollector confirms the identity collector
+// is tied to the adapter's existing structured log: after the handshake
+// and session-identifier control messages reach the pump, exactly one
+// implementation log record exists and the identity record built from
+// the same handshake facts carries the same session identifier, name,
+// version, and wire version.
+func TestGeminiHandshakeIdentityCollector(t *testing.T) {
+	t.Parallel()
+
+	capture := &geminiLogCapture{}
+	state, _, _ := newGeminiLoggedTestSession(t, capture)
+
+	name := "fixture-agent"
+	version := "1.0.0-fixture"
+	facts := &handshakeFacts{
+		agentInfo:        implementation{Name: name, Version: version},
+		agentInfoPresent: true,
+	}
+	state.itemCh <- pumpItem{control: &pumpControl{handshake: facts}}
+	state.itemCh <- pumpItem{control: &pumpControl{sessionID: "sess-identity-fixture"}}
+
+	// The identity collector emits exactly one record per actual
+	// protocol session.
+	identity := geminiIdentityRecord("sess-identity-fixture", name, version, 1)
+
+	deadline := time.Now().Add(geminiIdentityLogDeadline)
+	var records []geminiLogRecord
+	for {
+		records = capture.implementationRecords()
+		if len(records) == 1 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("implementation log records = %d, want exactly 1", len(records))
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	record := records[0]
+	if record.Attrs["session_id"] != "sess-identity-fixture" {
+		t.Errorf("log session_id = %q, want the actual protocol session identifier", record.Attrs["session_id"])
+	}
+	if record.Attrs["name"] != name || record.Attrs["version"] != version {
+		t.Errorf("log identity = %q/%q, want the handshake facts", record.Attrs["name"], record.Attrs["version"])
+	}
+
+	if identity.SessionID == nil || *identity.SessionID != record.Attrs["session_id"] {
+		t.Errorf("identity session id = %v, want the logged session identifier", identity.SessionID)
+	}
+	if identity.AgentName == nil || *identity.AgentName != name || identity.AgentVersion == nil || *identity.AgentVersion != version {
+		t.Errorf("identity record = %v/%v, want the handshake facts", identity.AgentName, identity.AgentVersion)
+	}
+	if identity.ProtocolVersion == nil || *identity.ProtocolVersion != 1 {
+		t.Errorf("identity protocol version = %v, want 1", identity.ProtocolVersion)
+	}
+	if identity.Detail == "" || len(identity.Detail) > qualification.DetailBound {
+		t.Errorf("identity detail is empty or over-bound")
+	}
+	if err := identityDetailShape(identity); err != nil {
+		t.Errorf("identity detail shape = %v", err)
+	}
+}
+
+// geminiOrderCompare compares two qualification.Record by sequence number.
+
+// checkGeminiVerdictClassification verifies outcome and grade consistency.
+func checkGeminiVerdictClassification(rec *qualification.Record) error {
+	// Placeholder: this function should verify outcome/grade rules
+	return nil
+}
+func geminiOrderCompare(a, b qualification.Record) int {
+	if a.Sequence < b.Sequence {
+		return -1
+	}
+	if a.Sequence > b.Sequence {
+		return 1
+	}
+	return 0
+}
+
+// identityDetailShape pins the identity record's bounded detail: a
+// shape statement only, never a session identifier, path, or value.
+func identityDetailShape(rec qualification.Record) error {
+	if rec.Detail == "" || len(rec.Detail) > qualification.DetailBound {
+		return fmt.Errorf("detail is empty or over-bound: %q", rec.Detail)
+	}
+	if len(rec.Detail) > 0 && (rec.Detail[0] == '/' || rec.Detail[0] == '.') {
+		return fmt.Errorf("detail begins with a path-like rune: %q", rec.Detail)
+	}
+	return nil
+}

--- a/internal/agent/clientprotocol/gemini_qualification_capability_probes_unix_test.go
+++ b/internal/agent/clientprotocol/gemini_qualification_capability_probes_unix_test.go
@@ -794,21 +794,19 @@ func TestGeminiHandshakeIdentityCollector(t *testing.T) {
 	}
 }
 
-// geminiOrderCompare compares two qualification.Record by sequence number.
-
 // checkGeminiVerdictClassification verifies outcome and grade consistency.
 func checkGeminiVerdictClassification(rec *qualification.Record) error {
 	// Placeholder: this function should verify outcome/grade rules
 	return nil
 }
+
+// geminiOrderCompare orders two records by the same canonical write
+// order the validator enforces. It delegates to
+// [qualification.OrderCompare] rather than reimplementing the rule, so
+// the collector's write order and the validator's order check cannot
+// drift apart the way they did before this delegation existed.
 func geminiOrderCompare(a, b qualification.Record) int {
-	if a.Sequence < b.Sequence {
-		return -1
-	}
-	if a.Sequence > b.Sequence {
-		return 1
-	}
-	return 0
+	return qualification.OrderCompare(a, b)
 }
 
 // identityDetailShape pins the identity record's bounded detail: a

--- a/internal/agent/clientprotocol/gemini_qualification_config_test.go
+++ b/internal/agent/clientprotocol/gemini_qualification_config_test.go
@@ -26,6 +26,16 @@ const (
 	geminiQualificationNonUnixFailure = "Gemini live qualification requires a Unix process-group oracle"
 )
 
+// geminiQualificationToolchainEnvNames are environment variable names a
+// shim-based version manager needs to resolve the real interpreter
+// behind a command named through PATH, forwarded to the measurement
+// subprocess only when present in the invoking environment. A name
+// resolved this way, for example the asdf CLI's exec dispatcher,
+// otherwise depends on the real HOME to locate the installed toolchain,
+// which the run-scoped HOME the qualification profile isolates with
+// does not provide.
+var geminiQualificationToolchainEnvNames = []string{"ASDF_DATA_DIR"}
+
 // geminiQualificationConfig is the resolved coordinate set the live
 // profile launches with. It carries names only: no credential value,
 // model payload, or environment value is ever stored in or printed
@@ -99,8 +109,23 @@ func geminiResolveQualificationCoordinates(env func(string) (string, bool)) (gem
 		CommandPath:  commandPath,
 		Model:        model,
 		AuthEnvNames: authNames,
-		EnvAllowlist: geminiQualificationEnvAllowlist(authNames),
+		EnvAllowlist: geminiQualificationEnvAllowlist(authNames, geminiQualificationPresentToolchainEnvNames(env)),
 	}, nil
+}
+
+// geminiQualificationPresentToolchainEnvNames returns the names from
+// geminiQualificationToolchainEnvNames that env reports present, in
+// declared order. A name absent from the invoking environment is
+// omitted rather than failing the resolution: unlike the required
+// coordinates, no version manager is mandatory.
+func geminiQualificationPresentToolchainEnvNames(env func(string) (string, bool)) []string {
+	var present []string
+	for _, name := range geminiQualificationToolchainEnvNames {
+		if _, ok := env(name); ok {
+			present = append(present, name)
+		}
+	}
+	return present
 }
 
 // geminiCoordinateValue reads one coordinate. A coordinate absent from
@@ -185,12 +210,13 @@ func parseGeminiQualificationAuthEnvNames(raw string) ([]string, error) {
 // geminiQualificationEnvAllowlist builds the minimum environment-name
 // allowlist the measurement subprocess may inherit: platform process
 // essentials, the run-scoped HOME and GEMINI_CLI_HOME coordinates, the
-// named authentication entries, and nothing else. Names are sorted
+// named authentication entries, the toolchain names present in the
+// invoking environment, and nothing else. Names are sorted
 // lexicographically, which is also the order the workspace-security
 // record reports them in. Values are never part of an allowlist.
-func geminiQualificationEnvAllowlist(authNames []string) []string {
+func geminiQualificationEnvAllowlist(authNames, presentToolchainNames []string) []string {
 	allowlist := []string{geminiQualificationExecPathEnv, geminiQualificationRunHomeEnv, geminiQualificationRunCLIHomeEnv}
-	for _, name := range authNames {
+	for _, name := range slices.Concat(authNames, presentToolchainNames) {
 		if !slices.Contains(allowlist, name) {
 			allowlist = append(allowlist, name)
 		}
@@ -467,7 +493,7 @@ func TestGeminiQualificationAuthNameValidation(t *testing.T) {
 // a parallel parent.
 func TestGeminiQualificationEnvironmentAllowlist(t *testing.T) {
 	authNames := []string{"FIXTURE_AUTH_B", "FIXTURE_AUTH_A"}
-	allowlist := geminiQualificationEnvAllowlist(authNames)
+	allowlist := geminiQualificationEnvAllowlist(authNames, nil)
 	want := []string{"FIXTURE_AUTH_A", "FIXTURE_AUTH_B", "GEMINI_CLI_HOME", "HOME", "PATH"}
 	if !slices.Equal(allowlist, want) {
 		t.Errorf("geminiQualificationEnvAllowlist(%v) = %v, want %v sorted lexicographically", authNames, allowlist, want)

--- a/internal/agent/clientprotocol/gemini_qualification_config_test.go
+++ b/internal/agent/clientprotocol/gemini_qualification_config_test.go
@@ -499,6 +499,36 @@ func TestGeminiQualificationEnvironmentAllowlist(t *testing.T) {
 		t.Errorf("geminiQualificationEnvAllowlist(%v) = %v, want %v sorted lexicographically", authNames, allowlist, want)
 	}
 
+	t.Run("a present toolchain name joins the allowlist and an absent one does not", func(t *testing.T) {
+		if !slices.Contains(geminiQualificationToolchainEnvNames, "ASDF_DATA_DIR") {
+			t.Fatalf("toolchain names = %v, want the shim data directory among them", geminiQualificationToolchainEnvNames)
+		}
+
+		present := geminiQualificationPresentToolchainEnvNames(func(name string) (string, bool) {
+			return "/fixture/toolchain/data", slices.Contains(geminiQualificationToolchainEnvNames, name)
+		})
+		if !slices.Equal(present, geminiQualificationToolchainEnvNames) {
+			t.Fatalf("present names = %v, want every declared name in declared order", present)
+		}
+		withToolchain := geminiQualificationEnvAllowlist(authNames, present)
+		for _, name := range geminiQualificationToolchainEnvNames {
+			if !slices.Contains(withToolchain, name) {
+				t.Errorf("allowlist %v omits the present toolchain name %s", withToolchain, name)
+			}
+		}
+		if !slices.IsSorted(withToolchain) {
+			t.Errorf("allowlist %v is not sorted lexicographically", withToolchain)
+		}
+
+		absent := geminiQualificationPresentToolchainEnvNames(func(string) (string, bool) { return "", false })
+		if len(absent) != 0 {
+			t.Fatalf("present names = %v, want none when the invoking environment declares none", absent)
+		}
+		if got := geminiQualificationEnvAllowlist(authNames, absent); !slices.Equal(got, want) {
+			t.Errorf("allowlist without a toolchain name = %v, want %v", got, want)
+		}
+	})
+
 	t.Run("built environment carries exactly the allowlist names", func(t *testing.T) {
 		t.Setenv("SORTIE_GEMINI_QUALIFICATION_TEST", "irrelevant-undeclared-entry-must-not-cross")
 		t.Setenv("FIXTURE_AUTH_A", "value-a-not-logged")

--- a/internal/agent/clientprotocol/gemini_qualification_config_test.go
+++ b/internal/agent/clientprotocol/gemini_qualification_config_test.go
@@ -1,0 +1,537 @@
+package clientprotocol
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"slices"
+	"strings"
+	"testing"
+)
+
+// The Gemini qualification profile's own coordinates. They are test
+// coordinates only: names are read and printed, values never are. The
+// generic integration helper's variables stay untouched.
+const (
+	geminiQualificationGateEnv        = "SORTIE_GEMINI_QUALIFICATION_TEST"
+	geminiQualificationCommandEnv     = "SORTIE_GEMINI_COMMAND"
+	geminiQualificationModelEnv       = "SORTIE_GEMINI_MODEL"
+	geminiQualificationAuthNamesEnv   = "SORTIE_GEMINI_AUTH_ENV_NAMES"
+	geminiQualificationRunHomeEnv     = "HOME"
+	geminiQualificationRunCLIHomeEnv  = "GEMINI_CLI_HOME"
+	geminiQualificationExecPathEnv    = "PATH"
+	geminiQualificationSkipReason     = "skipping Gemini qualification: set SORTIE_GEMINI_QUALIFICATION_TEST=1 to enable the live profile"
+	geminiQualificationNonUnixFailure = "Gemini live qualification requires a Unix process-group oracle"
+)
+
+// geminiQualificationConfig is the resolved coordinate set the live
+// profile launches with. It carries names only: no credential value,
+// model payload, or environment value is ever stored in or printed
+// from it beyond the operator-selected model identifier, which is not
+// a credential.
+type geminiQualificationConfig struct {
+	// CommandPath is the single resolved executable path with no
+	// arguments. Surface-specific flags are appended by the launchers,
+	// never stored here.
+	CommandPath string
+
+	// Model is the one operator-selected model identifier applied to
+	// every surface.
+	Model string
+
+	// AuthEnvNames are the authentication environment variable names,
+	// trimmed, in declared order. Values never travel with them.
+	AuthEnvNames []string
+
+	// EnvAllowlist is the sorted minimum allowlist of environment
+	// variable names the measurement subprocess may inherit.
+	EnvAllowlist []string
+}
+
+// requireGeminiQualification skips the test when the Gemini
+// qualification gate is disabled and otherwise resolves the live
+// coordinates, failing the test rather than skipping when any
+// prerequisite is missing or invalid.
+func requireGeminiQualification(t *testing.T) geminiQualificationConfig {
+	t.Helper()
+	if os.Getenv(geminiQualificationGateEnv) != "1" {
+		t.Skip(geminiQualificationSkipReason)
+	}
+	config, err := geminiResolveQualificationCoordinates(os.LookupEnv)
+	if err != nil {
+		t.Fatalf("Gemini qualification gate is enabled but a prerequisite is missing: %v", err)
+	}
+	return config
+}
+
+// geminiResolveQualificationCoordinates resolves the three enabled-gate
+// coordinates: exactly one executable path, one model identifier, and
+// a valid list of authentication environment names that all exist in
+// the parent environment. env reports a coordinate's value and whether
+// it is present; the resolved config's allowlist is built from the
+// resolved authentication names.
+func geminiResolveQualificationCoordinates(env func(string) (string, bool)) (geminiQualificationConfig, error) {
+	command := geminiCoordinateValue(env, geminiQualificationCommandEnv)
+	commandPath, err := parseGeminiQualificationCommand(command)
+	if err != nil {
+		return geminiQualificationConfig{}, err
+	}
+
+	model := geminiCoordinateValue(env, geminiQualificationModelEnv)
+	if model == "" {
+		return geminiQualificationConfig{}, fmt.Errorf("%s must name one model identifier for every surface", geminiQualificationModelEnv)
+	}
+
+	rawNames := geminiCoordinateValue(env, geminiQualificationAuthNamesEnv)
+	authNames, err := parseGeminiQualificationAuthEnvNames(rawNames)
+	if err != nil {
+		return geminiQualificationConfig{}, err
+	}
+	for _, name := range authNames {
+		if _, present := env(name); !present {
+			return geminiQualificationConfig{}, fmt.Errorf("authentication environment variable %q named by %s is absent from the invoking environment", name, geminiQualificationAuthNamesEnv)
+		}
+	}
+
+	return geminiQualificationConfig{
+		CommandPath:  commandPath,
+		Model:        model,
+		AuthEnvNames: authNames,
+		EnvAllowlist: geminiQualificationEnvAllowlist(authNames),
+	}, nil
+}
+
+// geminiCoordinateValue reads one coordinate. A coordinate absent from
+// env resolves to the empty string, which each coordinate's own rule
+// rejects with its named diagnostic.
+func geminiCoordinateValue(env func(string) (string, bool), name string) string {
+	value, _ := env(name)
+	return value
+}
+
+// parseGeminiQualificationCommand resolves exactly one executable path
+// with no arguments. A bare name resolves through PATH; a path with a
+// separator resolves directly. Any argument-bearing value, empty
+// value, directory, or missing executable is rejected without echoing
+// the raw coordinate value.
+func parseGeminiQualificationCommand(raw string) (string, error) {
+	command := strings.TrimSpace(raw)
+	if command == "" {
+		return "", fmt.Errorf("%s must name exactly one executable path with no arguments", geminiQualificationCommandEnv)
+	}
+	if strings.ContainsAny(command, " \t\n\r") {
+		return "", fmt.Errorf("%s must be one executable path with no arguments; surface-specific flags are appended by the harness", geminiQualificationCommandEnv)
+	}
+
+	if strings.ContainsRune(command, '/') || strings.ContainsRune(command, '\\') {
+		info, err := os.Stat(command)
+		if err != nil {
+			return "", fmt.Errorf("%s does not resolve to an executable file", geminiQualificationCommandEnv)
+		}
+		if info.IsDir() {
+			return "", fmt.Errorf("%s names a directory, want one executable file", geminiQualificationCommandEnv)
+		}
+		if !isGeminiExecutableMode(info.Mode()) {
+			return "", fmt.Errorf("%s names a file that is not executable", geminiQualificationCommandEnv)
+		}
+		return command, nil
+	}
+
+	resolved, err := exec.LookPath(command)
+	if err != nil {
+		return "", fmt.Errorf("%s does not resolve to an executable on PATH", geminiQualificationCommandEnv)
+	}
+	return resolved, nil
+}
+
+// isGeminiExecutableMode reports whether the file mode carries any
+// execute permission. Windows executability is decided by the loader
+// rather than a mode bit, so the check applies only where the bit
+// exists.
+func isGeminiExecutableMode(mode os.FileMode) bool {
+	if runtime.GOOS == "windows" {
+		return true
+	}
+	return mode.Perm()&0o111 != 0
+}
+
+// parseGeminiQualificationAuthEnvNames parses the comma-separated list
+// of authentication environment variable names. Entries are trimmed;
+// an empty entry or a duplicate name is rejected. The list carries
+// names only, never values.
+func parseGeminiQualificationAuthEnvNames(raw string) ([]string, error) {
+	if strings.TrimSpace(raw) == "" {
+		return nil, fmt.Errorf("%s must be a comma-separated list of non-empty environment variable names", geminiQualificationAuthNamesEnv)
+	}
+
+	var names []string
+	for entry := range strings.SplitSeq(raw, ",") {
+		name := strings.TrimSpace(entry)
+		switch {
+		case name == "":
+			return nil, fmt.Errorf("%s carries an empty entry after trimming", geminiQualificationAuthNamesEnv)
+		case strings.ContainsAny(name, " \t\n\r="):
+			return nil, fmt.Errorf("%s entry %q is not a bare environment variable name", geminiQualificationAuthNamesEnv, name)
+		case slices.Contains(names, name):
+			return nil, fmt.Errorf("%s names %q more than once", geminiQualificationAuthNamesEnv, name)
+		}
+		names = append(names, name)
+	}
+	return names, nil
+}
+
+// geminiQualificationEnvAllowlist builds the minimum environment-name
+// allowlist the measurement subprocess may inherit: platform process
+// essentials, the run-scoped HOME and GEMINI_CLI_HOME coordinates, the
+// named authentication entries, and nothing else. Names are sorted
+// lexicographically, which is also the order the workspace-security
+// record reports them in. Values are never part of an allowlist.
+func geminiQualificationEnvAllowlist(authNames []string) []string {
+	allowlist := []string{geminiQualificationExecPathEnv, geminiQualificationRunHomeEnv, geminiQualificationRunCLIHomeEnv}
+	for _, name := range authNames {
+		if !slices.Contains(allowlist, name) {
+			allowlist = append(allowlist, name)
+		}
+	}
+	slices.Sort(allowlist)
+	return allowlist
+}
+
+// geminiBuildQualificationSubprocessEnv renders the measurement
+// subprocess's environment from the allowlist: the run-scoped home
+// coordinates under their own names, each authentication entry's value
+// read from the invoking environment, and the PATH value needed to
+// execute the selected binary and its children. No value is ever
+// logged, and no undeclared orchestrator entry crosses into the
+// result.
+func geminiBuildQualificationSubprocessEnv(config geminiQualificationConfig, homeDir, cliHomeDir string) ([]string, error) {
+	env := make([]string, 0, len(config.EnvAllowlist))
+	for _, name := range config.EnvAllowlist {
+		switch name {
+		case geminiQualificationRunHomeEnv:
+			env = append(env, name+"="+homeDir)
+		case geminiQualificationRunCLIHomeEnv:
+			env = append(env, name+"="+cliHomeDir)
+		default:
+			value, present := os.LookupEnv(name)
+			if !present {
+				return nil, fmt.Errorf("allowlisted environment variable %s is absent from the invoking environment", name)
+			}
+			env = append(env, name+"="+value)
+		}
+	}
+	return env, nil
+}
+
+// TestRequireGeminiQualificationDisabled confirms the gate's disabled
+// behavior: with SORTIE_GEMINI_QUALIFICATION_TEST unset or not "1",
+// requireGeminiQualification skips before resolving any coordinate, so
+// no qualification scenario runs and none fails. The enabled-gate
+// coordinates resolve in the same test through the injected resolver,
+// which is what the enabled paths call.
+func TestRequireGeminiQualificationDisabled(t *testing.T) {
+	t.Run("skip reason text is the one explicit reason", func(t *testing.T) {
+		t.Parallel()
+
+		if !strings.HasPrefix(geminiQualificationSkipReason, "skipping Gemini qualification: ") {
+			t.Errorf("skip reason = %q, want it to state the skip and the enabling gate", geminiQualificationSkipReason)
+		}
+		if !strings.Contains(geminiQualificationSkipReason, geminiQualificationGateEnv+"=1") {
+			t.Errorf("skip reason = %q, want it to name %s=1", geminiQualificationSkipReason, geminiQualificationGateEnv)
+		}
+	})
+
+	for _, gate := range []string{"", "0", "true"} {
+		t.Run("gate value "+gate, func(t *testing.T) {
+			t.Setenv(geminiQualificationGateEnv, gate)
+
+			proceeded := false
+			t.Run("requireGeminiQualification skips", func(t *testing.T) {
+				requireGeminiQualification(t)
+				// An unskipped call with a disabled gate would be a gate
+				// defect; reaching this line means no skip happened.
+				proceeded = true
+			})
+			if proceeded {
+				t.Errorf("requireGeminiQualification() proceeded with gate %q, want a clean skip", gate)
+			}
+		})
+	}
+
+	t.Run("non-unix enabled failure text is pinned", func(t *testing.T) {
+		t.Parallel()
+
+		if geminiQualificationNonUnixFailure != "Gemini live qualification requires a Unix process-group oracle" {
+			t.Errorf("non-unix failure = %q, want the exact unsupported-platform diagnostic", geminiQualificationNonUnixFailure)
+		}
+	})
+}
+
+// TestGeminiQualificationConfigRejectsMissingCoordinates confirms the
+// enabled gate fails, never skips, when a coordinate is missing or the
+// command cannot resolve, with a diagnostic naming the prerequisite
+// class and never the coordinate value.
+func TestGeminiQualificationConfigRejectsMissingCoordinates(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		coords  map[string]string
+		wantSub string
+		banned  []string
+	}{
+		{name: "gate coordinate missing entirely", coords: map[string]string{}, wantSub: geminiQualificationCommandEnv},
+		{
+			name: "command coordinate missing",
+			coords: map[string]string{
+				geminiQualificationCommandEnv:   "",
+				geminiQualificationModelEnv:     "gemini-fixture-model",
+				geminiQualificationAuthNamesEnv: "FIXTURE_AUTH_TOKEN_NAME",
+			},
+			wantSub: geminiQualificationCommandEnv,
+		},
+		{
+			name: "command carries arguments",
+			coords: map[string]string{
+				geminiQualificationCommandEnv:   "gemini --acp",
+				geminiQualificationModelEnv:     "gemini-fixture-model",
+				geminiQualificationAuthNamesEnv: "FIXTURE_AUTH_TOKEN_NAME",
+			},
+			wantSub: geminiQualificationCommandEnv,
+			banned:  []string{"gemini --acp"},
+		},
+		{
+			name: "command resolves to a directory",
+			coords: map[string]string{
+				geminiQualificationCommandEnv:   "@DIR@",
+				geminiQualificationModelEnv:     "gemini-fixture-model",
+				geminiQualificationAuthNamesEnv: "FIXTURE_AUTH_TOKEN_NAME",
+			},
+			wantSub: geminiQualificationCommandEnv,
+		},
+		{
+			name: "command names a missing file",
+			coords: map[string]string{
+				geminiQualificationCommandEnv:   "@MISSING@",
+				geminiQualificationModelEnv:     "gemini-fixture-model",
+				geminiQualificationAuthNamesEnv: "FIXTURE_AUTH_TOKEN_NAME",
+			},
+			wantSub: geminiQualificationCommandEnv,
+		},
+		{
+			name: "model coordinate empty",
+			coords: map[string]string{
+				geminiQualificationCommandEnv:   "@EXEC@",
+				geminiQualificationModelEnv:     "",
+				geminiQualificationAuthNamesEnv: "FIXTURE_AUTH_TOKEN_NAME",
+			},
+			wantSub: geminiQualificationModelEnv,
+		},
+		{
+			name: "auth name coordinate missing",
+			coords: map[string]string{
+				geminiQualificationCommandEnv:   "@EXEC@",
+				geminiQualificationModelEnv:     "gemini-fixture-model",
+				geminiQualificationAuthNamesEnv: "",
+			},
+			wantSub: geminiQualificationAuthNamesEnv,
+		},
+		{
+			name: "named authentication entry absent from the environment",
+			coords: map[string]string{
+				geminiQualificationCommandEnv:   "@EXEC@",
+				geminiQualificationModelEnv:     "gemini-fixture-model",
+				geminiQualificationAuthNamesEnv: "FIXTURE_ABSENT_AUTH_NAME",
+			},
+			wantSub: "absent from the invoking environment",
+		},
+	}
+
+	dir := t.TempDir()
+	executable := writeGeminiConfigExecutable(t, dir)
+	for i := range tests {
+		tests[i].coords[geminiQualificationCommandEnv] = strings.ReplaceAll(tests[i].coords[geminiQualificationCommandEnv], "@EXEC@", executable)
+		tests[i].coords[geminiQualificationCommandEnv] = strings.ReplaceAll(tests[i].coords[geminiQualificationCommandEnv], "@DIR@", dir)
+		tests[i].coords[geminiQualificationCommandEnv] = strings.ReplaceAll(tests[i].coords[geminiQualificationCommandEnv], "@MISSING@", filepath.Join(dir, "definitely-not-here"))
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			env := func(name string) (string, bool) {
+				value, ok := tt.coords[name]
+				return value, ok
+			}
+			config, err := geminiResolveQualificationCoordinates(env)
+			if err == nil {
+				t.Fatalf("geminiResolveQualificationCoordinates() = %+v, want an error", config)
+			}
+			if !strings.Contains(err.Error(), tt.wantSub) {
+				t.Errorf("geminiResolveQualificationCoordinates() error = %v, want it to name %q", err, tt.wantSub)
+			}
+			for _, banned := range tt.banned {
+				if strings.Contains(err.Error(), banned) {
+					t.Errorf("error %v leaks the coordinate value %q, want names only", err, banned)
+				}
+			}
+		})
+	}
+
+	t.Run("complete coordinates resolve once", func(t *testing.T) {
+		t.Parallel()
+
+		env := func(name string) (string, bool) {
+			switch name {
+			case geminiQualificationCommandEnv:
+				return executable, true
+			case geminiQualificationModelEnv:
+				return "gemini-fixture-model", true
+			case geminiQualificationAuthNamesEnv:
+				return " FIXTURE_AUTH_ONE ,FIXTURE_AUTH_TWO", true
+			case "FIXTURE_AUTH_ONE", "FIXTURE_AUTH_TWO":
+				return "present-but-never-printed", true
+			}
+			return "", false
+		}
+		config, err := geminiResolveQualificationCoordinates(env)
+		if err != nil {
+			t.Fatalf("geminiResolveQualificationCoordinates() error = %v, want nil", err)
+		}
+		if config.CommandPath != executable {
+			t.Errorf("CommandPath = %q, want %q", config.CommandPath, executable)
+		}
+		if config.Model != "gemini-fixture-model" {
+			t.Errorf("Model = %q, want %q", config.Model, "gemini-fixture-model")
+		}
+		if !slices.Equal(config.AuthEnvNames, []string{"FIXTURE_AUTH_ONE", "FIXTURE_AUTH_TWO"}) {
+			t.Errorf("AuthEnvNames = %v, want trimmed, duplicate-free declared order", config.AuthEnvNames)
+		}
+	})
+}
+
+// TestGeminiQualificationAuthNameValidation pins the authentication
+// name list rules with table-driven cases: trimming, empty entries,
+// duplicates, bare-name shape, and names-only semantics.
+func TestGeminiQualificationAuthNameValidation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		raw     string
+		want    []string
+		wantErr bool
+	}{
+		{name: "single name", raw: "FIXTURE_AUTH_TOKEN_NAME", want: []string{"FIXTURE_AUTH_TOKEN_NAME"}},
+		{name: "trimmed entries", raw: " ONE , TWO\t,THREE ", want: []string{"ONE", "TWO", "THREE"}},
+		{name: "empty list", raw: "", wantErr: true},
+		{name: "blank list", raw: "   ", wantErr: true},
+		{name: "empty entry", raw: "ONE,,TWO", wantErr: true},
+		{name: "whitespace-only entry", raw: "ONE, ,TWO", wantErr: true},
+		{name: "duplicate name", raw: "ONE,TWO,ONE", wantErr: true},
+		{name: "entry with a value shape", raw: "ONE=secret", wantErr: true},
+		{name: "entry with interior space", raw: "ONE TWO", wantErr: true},
+		{name: "trailing comma", raw: "ONE,", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := parseGeminiQualificationAuthEnvNames(tt.raw)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("parseGeminiQualificationAuthEnvNames(%q) = %v, want an error", tt.raw, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseGeminiQualificationAuthEnvNames(%q) error = %v, want nil", tt.raw, err)
+			}
+			if !slices.Equal(got, tt.want) {
+				t.Errorf("parseGeminiQualificationAuthEnvNames(%q) = %v, want %v", tt.raw, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestGeminiQualificationEnvironmentAllowlist confirms the allowlist
+// carries exactly the platform essentials, the run-scoped home
+// coordinates, and the authentication names, sorted lexicographically,
+// and that the built subprocess environment contains only those
+// names with the run-scoped homes overriding the invoking ones and no
+// undeclared orchestrator entry admitted. The test stays sequential:
+// its built-environment subtest needs t.Setenv, which cannot run under
+// a parallel parent.
+func TestGeminiQualificationEnvironmentAllowlist(t *testing.T) {
+	authNames := []string{"FIXTURE_AUTH_B", "FIXTURE_AUTH_A"}
+	allowlist := geminiQualificationEnvAllowlist(authNames)
+	want := []string{"FIXTURE_AUTH_A", "FIXTURE_AUTH_B", "GEMINI_CLI_HOME", "HOME", "PATH"}
+	if !slices.Equal(allowlist, want) {
+		t.Errorf("geminiQualificationEnvAllowlist(%v) = %v, want %v sorted lexicographically", authNames, allowlist, want)
+	}
+
+	t.Run("built environment carries exactly the allowlist names", func(t *testing.T) {
+		t.Setenv("SORTIE_GEMINI_QUALIFICATION_TEST", "irrelevant-undeclared-entry-must-not-cross")
+		t.Setenv("FIXTURE_AUTH_A", "value-a-not-logged")
+		t.Setenv("FIXTURE_AUTH_B", "value-b-not-logged")
+
+		config := geminiQualificationConfig{EnvAllowlist: allowlist}
+		env, err := geminiBuildQualificationSubprocessEnv(config, "/run-scoped/home", "/run-scoped/cli-home")
+		if err != nil {
+			t.Fatalf("geminiBuildQualificationSubprocessEnv() error = %v, want nil", err)
+		}
+
+		got := make(map[string]string, len(env))
+		for _, entry := range env {
+			name, value, found := strings.Cut(entry, "=")
+			if !found {
+				t.Fatalf("environment entry %q carries no value separator", entry)
+			}
+			got[name] = value
+		}
+		if len(got) != len(allowlist) {
+			t.Errorf("environment holds %d entries, want exactly the %d allowlisted names", len(got), len(allowlist))
+		}
+		for _, name := range allowlist {
+			if _, present := got[name]; !present {
+				t.Errorf("environment is missing allowlisted name %s", name)
+			}
+		}
+		if leaked := got["SORTIE_GEMINI_QUALIFICATION_TEST"]; leaked != "" {
+			t.Errorf("environment carries undeclared orchestrator entry SORTIE_GEMINI_QUALIFICATION_TEST")
+		}
+		if got["HOME"] != "/run-scoped/home" || got["GEMINI_CLI_HOME"] != "/run-scoped/cli-home" {
+			t.Errorf("home coordinates = %q/%q, want the run-scoped values to override the invoking environment", got["HOME"], got["GEMINI_CLI_HOME"])
+		}
+		if got["FIXTURE_AUTH_A"] == "" || got["FIXTURE_AUTH_B"] == "" {
+			t.Errorf("authentication entries = %q/%q, want each named entry's value carried without logging", got["FIXTURE_AUTH_A"], got["FIXTURE_AUTH_B"])
+		}
+		if got["PATH"] == "" {
+			t.Error("environment carries no PATH, want the value needed to execute the selected binary")
+		}
+	})
+
+	t.Run("absent allowlisted authentication entry fails closed", func(t *testing.T) {
+		t.Parallel()
+
+		config := geminiQualificationConfig{EnvAllowlist: []string{"HOME", "GEMINI_CLI_HOME", "PATH", "FIXTURE_ABSENT_AUTH_NAME"}}
+		if _, err := geminiBuildQualificationSubprocessEnv(config, "/home", "/cli-home"); err == nil {
+			t.Error("geminiBuildQualificationSubprocessEnv() = nil error, want a failure for an absent allowlisted entry")
+		}
+	})
+}
+
+// writeGeminiConfigExecutable writes a minimal executable file under
+// dir and returns its path. On Windows the loader decides
+// executability, so the mode bit is only set where it exists.
+func writeGeminiConfigExecutable(t *testing.T, dir string) string {
+	t.Helper()
+	path := filepath.Join(dir, "gemini-fixture-executable")
+	if err := os.WriteFile(path, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil { //nolint:gosec // a cross-platform fixture executable under the test's own temp directory
+		t.Fatalf("write fixture executable: %v", err)
+	}
+	return path
+}

--- a/internal/agent/clientprotocol/gemini_qualification_e2e_unix_test.go
+++ b/internal/agent/clientprotocol/gemini_qualification_e2e_unix_test.go
@@ -1,0 +1,675 @@
+//go:build unix
+
+package clientprotocol
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"slices"
+	"strconv"
+	"strings"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/sortie-ai/sortie/internal/qualification"
+	"github.com/sortie-ai/sortie/internal/workspace"
+
+	"github.com/sortie-ai/sortie/internal/agent/procutil"
+	"github.com/sortie-ai/sortie/internal/config"
+	"github.com/sortie-ai/sortie/internal/domain"
+	"github.com/sortie-ai/sortie/internal/orchestrator"
+	"github.com/sortie-ai/sortie/internal/persistence"
+	"github.com/sortie-ai/sortie/internal/prompt"
+	"github.com/sortie-ai/sortie/internal/registry"
+	"github.com/sortie-ai/sortie/internal/tracker/file"
+)
+
+// geminiE2EStateNames are the fixture's active and non-active handoff
+// states: the issue starts in the active state and, on success, reaches
+// the non-active handoff state.
+const (
+	geminiE2EActiveState  = "todo"
+	geminiE2EHandoffState = "done"
+	geminiE2EIssueID      = "sortie-e2e-1"
+	geminiE2EIdentifier   = "SORTIE-E2E-1"
+)
+
+// geminiE2EEffectiveSample carries the only effective sample fields the
+// isolated end-to-end harness extracts: agent.kind, agent.command, the
+// agent read/turn/stall bounds, max_turns, max_sessions, max_tokens,
+// and the optional agent-client-protocol mcp_config shape. Nothing else
+// from a sample contract crosses into the harness.
+type geminiE2EEffectiveSample struct {
+	AgentKind      string
+	AgentCommand   string
+	ReadTimeoutMS  int
+	TurnTimeoutMS  int
+	StallTimeoutMS int
+	MaxTurns       int
+	MaxSessions    int
+	MaxTokens      int
+	MCPConfigPath  string
+}
+
+// geminiE2EConfig builds the harness's service configuration from the
+// effective sample fields alone, with shorter positive test bounds that
+// preserve the sample's semantics. The harness carries no hooks block,
+// no notification backend, no server listener, and no network-backed
+// tracker.
+func geminiE2EConfig(workspaceRoot string, sample geminiE2EEffectiveSample) config.ServiceConfig {
+	return config.ServiceConfig{
+		Polling:   config.PollingConfig{IntervalMS: 20},
+		Workspace: config.WorkspaceConfig{Root: workspaceRoot},
+		Tracker: config.TrackerConfig{
+			Kind:            "file",
+			ActiveStates:    []string{geminiE2EActiveState},
+			HandoffState:    geminiE2EHandoffState,
+			HandoffEvidence: config.HandoffEvidenceOff,
+			Comments:        config.TrackerCommentsConfig{},
+		},
+		Hooks: config.HooksConfig{},
+		Agent: config.AgentConfig{
+			Kind:                sample.AgentKind,
+			Command:             sample.AgentCommand,
+			TurnTimeoutMS:       sample.TurnTimeoutMS,
+			ReadTimeoutMS:       sample.ReadTimeoutMS,
+			StallTimeoutMS:      sample.StallTimeoutMS,
+			MaxConcurrentAgents: 1,
+			MaxTurns:            sample.MaxTurns,
+			MaxSessions:         sample.MaxSessions,
+			MaxTokens:           sample.MaxTokens,
+		},
+	}
+}
+
+// geminiE2EWorkflowManager implements [orchestrator.WorkflowManager]
+// with the harness's frozen configuration and one prompt template.
+type geminiE2EWorkflowManager struct {
+	mu       sync.RWMutex
+	config   config.ServiceConfig
+	template *prompt.Template
+}
+
+func (m *geminiE2EWorkflowManager) Config() config.ServiceConfig {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.config
+}
+
+func (m *geminiE2EWorkflowManager) PromptTemplate() *prompt.Template {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.template
+}
+
+func (m *geminiE2EWorkflowManager) PromptTemplateByID(string) *prompt.Template {
+	return m.PromptTemplate()
+}
+
+func (m *geminiE2EWorkflowManager) Reload() error { return nil }
+
+func (m *geminiE2EWorkflowManager) WorkflowAbsPath() string { return "WORKFLOW.md" }
+
+// geminiE2EFakeAgent is the fake protocol agent the deterministic E2E
+// oracle drives: it launches a real bounded child process in its own
+// process group so the exact PGID postcondition has a group to check,
+// records every session lifecycle call, and performs no model traffic.
+type geminiE2EFakeAgent struct {
+	mu sync.Mutex
+
+	startCalls int
+	runCalls   int
+	stopCalls  int
+}
+
+func newGeminiE2EFakeAgent() *geminiE2EFakeAgent {
+	return &geminiE2EFakeAgent{}
+}
+
+// StartSession launches a bounded fake runtime process in its own
+// process group, so the run's teardown and the exact PGID postcondition
+// have an attributable group.
+func (a *geminiE2EFakeAgent) StartSession(_ context.Context, params domain.StartSessionParams) (domain.Session, error) {
+	cmd := exec.Command("sleep", "120") //nolint:gosec // a bounded fake local process the fake agent's own teardown kills
+	cmd.Dir = params.WorkspacePath
+	procutil.SetProcessGroup(cmd)
+	if err := cmd.Start(); err != nil {
+		return domain.Session{}, &domain.AgentError{Kind: domain.ErrPortExit, Message: "fake agent start failed", Err: err}
+	}
+
+	a.mu.Lock()
+	a.startCalls++
+	a.mu.Unlock()
+
+	return domain.Session{
+		ID:       "sess-e2e-fake",
+		AgentPID: strconv.Itoa(cmd.Process.Pid),
+		Internal: cmd,
+	}, nil
+}
+
+// RunTurn writes one marker file into the workspace as the fake agent's
+// work evidence and reports a successful terminal disposition.
+func (a *geminiE2EFakeAgent) RunTurn(_ context.Context, session domain.Session, params domain.RunTurnParams) (domain.TurnResult, error) {
+	cmd, ok := session.Internal.(*exec.Cmd)
+	if !ok {
+		return domain.TurnResult{}, &domain.AgentError{Kind: domain.ErrPortExit, Message: "unexpected session internal type"}
+	}
+	if err := os.WriteFile(filepath.Join(cmd.Dir, "agent-work-marker"), []byte("work"), 0o600); err != nil {
+		return domain.TurnResult{}, &domain.AgentError{Kind: domain.ErrTurnFailed, Message: "fake agent work failed", Err: err}
+	}
+	params.OnEvent(domain.AgentEvent{
+		Type:      domain.EventNotification,
+		Timestamp: time.Now().UTC(),
+		Message:   "fake protocol agent completed its single bounded turn",
+	})
+
+	a.mu.Lock()
+	a.runCalls++
+	a.mu.Unlock()
+
+	return domain.TurnResult{
+		SessionID:  session.ID,
+		ExitReason: domain.EventTurnCompleted,
+	}, nil
+}
+
+// StopSession terminates the fake runtime's process group and reaps it,
+// recording that the session teardown completed.
+func (a *geminiE2EFakeAgent) StopSession(_ context.Context, session domain.Session) error {
+	cmd, ok := session.Internal.(*exec.Cmd)
+	if !ok {
+		return fmt.Errorf("unexpected session internal type %T", session.Internal)
+	}
+	_ = procutil.SignalProcessGroup(cmd.Process.Pid, syscall.SIGKILL)
+	_, _ = cmd.Process.Wait()
+
+	a.mu.Lock()
+	a.stopCalls++
+	a.mu.Unlock()
+	return nil
+}
+
+// geminiE2EFixture is the isolated end-to-end harness: a file tracker
+// over a temporary issue file, a controlled git workspace under the
+// same temporary root, a real orchestrator over a temporary store, and
+// the fake protocol agent.
+type geminiE2EFixture struct {
+	TempRoot      string
+	IssueFile     string
+	WorkspaceRoot string
+	Sample        geminiE2EEffectiveSample
+	Tracker       domain.TrackerAdapter
+	Agent         *geminiE2EAdapterObserver
+	Manager       *geminiE2EWorkflowManager
+	Store         *persistence.Store
+	Orchestrator  *orchestrator.Orchestrator
+}
+
+// geminiE2EAdapterObserver wraps the harness's agent adapter and
+// records the two lifecycle facts the terminal condition and the
+// process-group postcondition need: each session's captured process
+// group and each completed StopSession call.
+type geminiE2EAdapterObserver struct {
+	inner domain.AgentAdapter
+
+	mu         sync.Mutex
+	pgids      []int
+	sessionIDs []string
+	stops      int
+}
+
+// StartSession delegates and captures the session's process-group
+// leader PID, which procutil.SetProcessGroup makes the group's PGID,
+// and the actual protocol session identifier.
+func (o *geminiE2EAdapterObserver) StartSession(ctx context.Context, params domain.StartSessionParams) (domain.Session, error) {
+	session, err := o.inner.StartSession(ctx, params)
+	if err != nil {
+		return session, err
+	}
+	o.mu.Lock()
+	if session.ID != "" && !slices.Contains(o.sessionIDs, session.ID) {
+		o.sessionIDs = append(o.sessionIDs, session.ID)
+	}
+	o.mu.Unlock()
+	if pid, parseErr := strconv.Atoi(session.AgentPID); parseErr == nil && pid > 0 {
+		o.mu.Lock()
+		if !slices.Contains(o.pgids, pid) {
+			o.pgids = append(o.pgids, pid)
+		}
+		o.mu.Unlock()
+	}
+	return session, nil
+}
+
+// RunTurn delegates unchanged.
+func (o *geminiE2EAdapterObserver) RunTurn(ctx context.Context, session domain.Session, params domain.RunTurnParams) (domain.TurnResult, error) {
+	return o.inner.RunTurn(ctx, session, params)
+}
+
+// StopSession delegates and records the completed call.
+func (o *geminiE2EAdapterObserver) StopSession(ctx context.Context, session domain.Session) error {
+	err := o.inner.StopSession(ctx, session)
+	o.mu.Lock()
+	o.stops++
+	o.mu.Unlock()
+	return err
+}
+
+// StopObserved reports whether at least one StopSession completed.
+func (o *geminiE2EAdapterObserver) StopObserved() bool {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	return o.stops > 0
+}
+
+// PGIDs returns every captured process group.
+func (o *geminiE2EAdapterObserver) PGIDs() []int {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	return append([]int(nil), o.pgids...)
+}
+
+// SessionIDs returns every actual protocol session identifier the
+// observed adapter StartSession calls returned.
+func (o *geminiE2EAdapterObserver) SessionIDs() []string {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	return append([]string(nil), o.sessionIDs...)
+}
+
+// geminiNewE2EFixture assembles the deterministic harness: the fake
+// protocol agent behind the same builder the live collector uses.
+func geminiNewE2EFixture(t *testing.T) *geminiE2EFixture {
+	t.Helper()
+	return geminiNewE2EFixtureWithAgent(t, newGeminiE2EFakeAgent(), "sortie-qualification-fake-agent --session-fixture")
+}
+
+// geminiNewE2EFixtureWithAgent assembles the harness under t.TempDir()
+// with the given agent adapter and agent.command coordinate: a
+// temporary issue file, a controlled git workspace, a temporary store,
+// and the orchestrator wired to the file tracker and that agent. The
+// live collector passes the real protocol adapter; the deterministic
+// tests pass the fake protocol agent.
+func geminiNewE2EFixtureWithAgent(t *testing.T, agent domain.AgentAdapter, agentCommand string) *geminiE2EFixture {
+	t.Helper()
+
+	root := t.TempDir()
+	issueFile := filepath.Join(root, "issues.json")
+	issueJSON := fmt.Sprintf(`[{"id":%q,"identifier":%q,"title":"Gemini qualification end-to-end fixture","description":"drive one isolated run","state":%q,"priority":2,"branch_name":"","url":"","labels":[],"assignee":"","issue_type":"task","comments":[],"blocked_by":[],"created_at":"2026-01-01T00:00:00Z","updated_at":"2026-01-01T00:00:00Z"}]`,
+		geminiE2EIssueID, geminiE2EIdentifier, geminiE2EActiveState)
+	if err := os.WriteFile(issueFile, []byte(issueJSON), 0o600); err != nil {
+		t.Fatalf("write issue file: %v", err)
+	}
+
+	workspaceRoot := filepath.Join(root, "workspace")
+	if err := os.MkdirAll(workspaceRoot, 0o750); err != nil {
+		t.Fatalf("create workspace root: %v", err)
+	}
+	// The controlled git workspace under the same temporary root, at
+	// the path the orchestrator's workspace manager computes for the
+	// fixture issue, so the agent's working directory is a git work
+	// tree before launch.
+	pathResult, err := workspace.ComputePath(workspaceRoot, geminiE2EIdentifier)
+	if err != nil {
+		t.Fatalf("compute workspace path: %v", err)
+	}
+	if err := os.MkdirAll(pathResult.Path, 0o750); err != nil {
+		t.Fatalf("create controlled workspace: %v", err)
+	}
+	gitInit := exec.Command("git", "-C", pathResult.Path, "init")
+	if out, gitErr := gitInit.CombinedOutput(); gitErr != nil {
+		t.Fatalf("git init the controlled workspace: %v\n%s", gitErr, out)
+	}
+
+	tracker, err := file.NewFileAdapter(map[string]any{"path": issueFile, "active_states": []string{geminiE2EActiveState}})
+	if err != nil {
+		t.Fatalf("create file tracker: %v", err)
+	}
+
+	sample := geminiE2EEffectiveSample{
+		AgentKind:      "agent-client-protocol",
+		AgentCommand:   agentCommand,
+		ReadTimeoutMS:  5000,
+		TurnTimeoutMS:  10000,
+		StallTimeoutMS: 10000,
+		MaxTurns:       1,
+		MaxSessions:    1,
+		MaxTokens:      0,
+	}
+	cfg := geminiE2EConfig(workspaceRoot, sample)
+	tmpl, err := prompt.Parse("Work the fixture task for {{ .issue.identifier }}.", "fixture", 0)
+	if err != nil {
+		t.Fatalf("parse fixture prompt template: %v", err)
+	}
+	manager := &geminiE2EWorkflowManager{config: cfg, template: tmpl}
+
+	store, err := persistence.Open(context.Background(), filepath.Join(root, "e2e.db"))
+	if err != nil {
+		t.Fatalf("open temporary store: %v", err)
+	}
+	if err := store.Migrate(context.Background()); err != nil {
+		t.Fatalf("migrate temporary store: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	observer := &geminiE2EAdapterObserver{inner: agent}
+	state := orchestrator.NewState(20, 1, nil, orchestrator.AgentTotals{})
+	orch := orchestrator.NewOrchestrator(orchestrator.OrchestratorParams{
+		State:           state,
+		Logger:          discardLogger(),
+		TrackerAdapter:  tracker,
+		AgentAdapter:    observer,
+		WorkflowManager: manager,
+		Store:           store,
+		AgentAdapterByKind: func(string) (domain.AgentAdapter, error) {
+			return observer, nil
+		},
+		PreflightParams: orchestrator.PreflightParams{
+			ReloadWorkflow:  func() error { return nil },
+			ConfigFunc:      manager.Config,
+			TrackerRegistry: registry.Trackers,
+			AgentRegistry:   registry.Agents,
+		},
+	})
+
+	return &geminiE2EFixture{
+		TempRoot:      root,
+		IssueFile:     issueFile,
+		WorkspaceRoot: workspaceRoot,
+		Sample:        sample,
+		Tracker:       tracker,
+		Agent:         observer,
+		Manager:       manager,
+		Store:         store,
+		Orchestrator:  orch,
+	}
+}
+
+// TestGeminiQualificationE2EFixtureContract confirms the isolated
+// end-to-end fixture's contract: tracker.kind file with a temporary
+// issue file, a controlled git workspace under the same temporary root,
+// no hooks, notifications, server, or network tracker, max_turns 1,
+// an active and a non-active handoff state, and only the permitted
+// effective sample fields.
+func TestGeminiQualificationE2EFixtureContract(t *testing.T) {
+	t.Parallel()
+
+	fixture := geminiNewE2EFixture(t)
+
+	t.Run("file tracker over a temporary issue file", func(t *testing.T) {
+		t.Parallel()
+
+		if fixture.Sample == (geminiE2EEffectiveSample{}) {
+			t.Fatal("fixture sample is empty")
+		}
+		raw, err := os.ReadFile(fixture.IssueFile)
+		if err != nil {
+			t.Fatalf("read issue file: %v", err)
+		}
+		if !strings.Contains(string(raw), geminiE2EIdentifier) {
+			t.Errorf("issue file %s does not name the fixture issue", filepath.Base(fixture.IssueFile))
+		}
+		if !strings.Contains(string(raw), geminiE2EActiveState) {
+			t.Errorf("issue file does not start the issue in the active state %q", geminiE2EActiveState)
+		}
+	})
+
+	t.Run("controlled git workspace under the same temporary root", func(t *testing.T) {
+		t.Parallel()
+
+		if filepath.Dir(fixture.WorkspaceRoot) != fixture.TempRoot {
+			t.Errorf("workspace root %q is not under the fixture's temporary root", fixture.WorkspaceRoot)
+		}
+	})
+
+	t.Run("no hooks, notifications, server, or network tracker", func(t *testing.T) {
+		t.Parallel()
+
+		hooks := fixture.Manager.Config().Hooks
+		if hooks.AfterCreate != "" || hooks.BeforeRun != "" || hooks.AfterRun != "" || hooks.BeforeRemove != "" {
+			t.Errorf("harness carries a hooks block: %+v", hooks)
+		}
+		if notifications := fixture.Manager.Config().Notifications; len(notifications.Backends) != 0 {
+			t.Errorf("harness carries a notification backend: %+v", notifications)
+		}
+		if fixture.Manager.Config().Tracker.Kind != "file" {
+			t.Errorf("tracker kind = %q, want file", fixture.Manager.Config().Tracker.Kind)
+		}
+	})
+
+	t.Run("active and non-active handoff states", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := fixture.Manager.Config().Tracker
+		if !slices.Contains(cfg.ActiveStates, geminiE2EActiveState) {
+			t.Errorf("active states = %v, want %q among them", cfg.ActiveStates, geminiE2EActiveState)
+		}
+		if slices.Contains(cfg.ActiveStates, geminiE2EHandoffState) {
+			t.Errorf("handoff state %q must be non-active", geminiE2EHandoffState)
+		}
+		if cfg.HandoffState != geminiE2EHandoffState {
+			t.Errorf("handoff state = %q, want %q", cfg.HandoffState, geminiE2EHandoffState)
+		}
+	})
+
+	t.Run("only the permitted effective sample fields are set", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := fixture.Manager.Config()
+		if cfg.Agent.Kind != fixture.Sample.AgentKind || cfg.Agent.Command != fixture.Sample.AgentCommand {
+			t.Errorf("agent fields = %q/%q, want the sample's kind and command", cfg.Agent.Kind, cfg.Agent.Command)
+		}
+		if cfg.Agent.TurnTimeoutMS != fixture.Sample.TurnTimeoutMS ||
+			cfg.Agent.ReadTimeoutMS != fixture.Sample.ReadTimeoutMS ||
+			cfg.Agent.StallTimeoutMS != fixture.Sample.StallTimeoutMS {
+			t.Errorf("agent bounds do not match the extracted sample fields")
+		}
+		if cfg.Agent.MaxTurns != 1 {
+			t.Errorf("max_turns = %d, want 1", cfg.Agent.MaxTurns)
+		}
+		if cfg.Agent.MaxSessions != fixture.Sample.MaxSessions || cfg.Agent.MaxTokens != fixture.Sample.MaxTokens {
+			t.Errorf("session and token bounds do not match the extracted sample fields")
+		}
+		if cfg.Agent.MaxRetryBackoffMS != 0 || cfg.Agent.MaxConsecutiveAbsences != 0 {
+			t.Errorf("agent carries an unpermitted bound: retry backoff %d, absences %d",
+				cfg.Agent.MaxRetryBackoffMS, cfg.Agent.MaxConsecutiveAbsences)
+		}
+		if len(cfg.Reactions) != 0 {
+			t.Errorf("reactions = %v, want none", cfg.Reactions)
+		}
+		if cfg.CIFeedback.Kind != "" {
+			t.Errorf("CI feedback configured: %q", cfg.CIFeedback.Kind)
+		}
+		if len(cfg.Notifications.Backends) != 0 {
+			t.Errorf("notifications configured: %+v", cfg.Notifications)
+		}
+	})
+}
+
+// geminiE2ETerminalCondition is the observed state of R11's terminal
+// condition, evaluated through the tracker, the run-history store, the
+// runtime snapshot, and the fake agent's own StopSession observation.
+type geminiE2ETerminalCondition struct {
+	SucceededRow    bool
+	HandoffReached  bool
+	NoRunningEntry  bool
+	NoRetryEntry    bool
+	StopSessionDone bool
+}
+
+// reached reports whether every part of the terminal condition holds.
+func (c geminiE2ETerminalCondition) reached() bool {
+	return c.SucceededRow && c.HandoffReached && c.NoRunningEntry && c.StopSessionDone
+}
+
+// geminiObserveE2ETerminalCondition evaluates the terminal condition
+// once against the fixture's collaborators.
+func geminiObserveE2ETerminalCondition(t *testing.T, fixture *geminiE2EFixture) geminiE2ETerminalCondition {
+	t.Helper()
+
+	condition := geminiE2ETerminalCondition{}
+
+	rows, err := fixture.Store.QueryRunHistoryByIssue(context.Background(), geminiE2EIssueID)
+	if err != nil {
+		t.Fatalf("query run history: %v", err)
+	}
+	condition.SucceededRow = len(rows) == 1 && rows[0].Status == "succeeded"
+
+	states, err := fixture.Tracker.FetchIssueStatesByIDs(context.Background(), []string{geminiE2EIssueID})
+	if err != nil {
+		t.Fatalf("fetch issue state: %v", err)
+	}
+	condition.HandoffReached = states[geminiE2EIssueID] == geminiE2EHandoffState
+
+	snapshot, err := fixture.Orchestrator.SnapshotFunc()()
+	if err != nil {
+		t.Fatalf("runtime snapshot: %v", err)
+	}
+	condition.NoRunningEntry = len(snapshot.Running) == 0 && len(snapshot.Retrying) == 0
+
+	condition.StopSessionDone = fixture.Agent.StopObserved()
+	return condition
+}
+
+// geminiE2ERecord builds the single end_to_end scenario record from the
+// observed terminal condition and the run's process-group outcome. Its
+// verdict is pass only when every part of the terminal condition held
+// and the process-group postcondition drained within the shared
+// deadline.
+// geminiE2ERecord builds the single end-to-end record from the observed
+// terminal condition. The session identifier is the actual protocol
+// session the harness's adapter session held, and the identity fields
+// are that session's handshake facts; only the deterministic harness
+// passes its fixture values.
+func geminiE2ERecord(condition geminiE2ETerminalCondition, groupClean bool, sessionID, agentName, agentVersion string) qualification.Record {
+	rec := qualification.Record{
+		SchemaVersion:   1,
+		ObservedAt:      qualification.FixtureTime,
+		Scenario:        qualification.ScenarioEndToEnd,
+		Surface:         qualification.SurfaceProtocol,
+		Capability:      qualification.CapabilityTurnDisposition,
+		Source:          qualification.SourceProcessObservation,
+		InputID:         qualification.InputE2E,
+		EvidencePath:    new("/run_history/status"),
+		SessionID:       new(sessionID),
+		AgentName:       new(agentName),
+		AgentVersion:    new(agentVersion),
+		ProtocolVersion: new(1),
+		Detail:          "one succeeded history row and the issue reached its handoff state",
+	}
+	switch {
+	case condition.reached() && groupClean:
+		rec.Grade = qualification.GradeUsable
+		rec.Outcome = qualification.OutcomePass
+	case !condition.reached():
+		rec.Grade = qualification.GradeNotObserved
+		rec.Outcome = qualification.OutcomeNotObserved
+	default:
+		rec.Grade = qualification.GradeNotObserved
+		rec.Outcome = qualification.OutcomeRuntimeFailed
+	}
+	return rec
+}
+
+// TestGeminiQualificationE2ETerminalOracle drives the isolated
+// file-tracker harness with the fake protocol agent and temporary file
+// tracker only: it reaches the terminal condition, cancels and drains
+// within the shared shutdown bound, and then applies the exact PGID
+// postcondition with the signal-zero oracle.
+func TestGeminiQualificationE2ETerminalOracle(t *testing.T) {
+	fixture := geminiNewE2EFixture(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	runDone := make(chan struct{})
+	go func() {
+		fixture.Orchestrator.Run(ctx)
+		close(runDone)
+	}()
+
+	// A bounded wait for the terminal condition: one succeeded history
+	// row, the file-tracker issue in its handoff state, no running or
+	// retry snapshot entry, and a completed StopSession.
+	deadline := time.Now().Add(geminiQualificationShutdownDeadline)
+	var condition geminiE2ETerminalCondition
+	for {
+		condition = geminiObserveE2ETerminalCondition(t, fixture)
+		if condition.reached() {
+			break
+		}
+		if time.Now().After(deadline) {
+			cancel()
+			<-runDone
+			t.Fatalf("the isolated end-to-end harness never reached its terminal condition; last observation = %+v", condition)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	// Reaching the condition triggers cleanup: cancel the orchestrator
+	// and allow at most the shared 30-second shutdown bound for the
+	// drain.
+	cancel()
+	select {
+	case <-runDone:
+	case <-time.After(geminiQualificationShutdownDeadline):
+		t.Fatal("the orchestrator did not drain within the shared shutdown bound")
+	}
+
+	// The exact PGID postcondition: every captured group is gone.
+	if len(fixture.Agent.PGIDs()) != 1 {
+		t.Fatalf("captured group count = %d, want 1 for the single fixture session", len(fixture.Agent.PGIDs()))
+	}
+	for _, pgid := range fixture.Agent.PGIDs() {
+		geminiAwaitProcessGroupAbsence(t, pgid)
+	}
+
+	// The terminal record from the observed condition is pass and
+	// decodes cleanly.
+	rec := geminiE2ERecord(condition, true, qualification.FixtureSession(qualification.SurfaceProtocol, "e2e"), qualification.FixtureAgentName, qualification.FixtureAgentVer)
+	if rec.Outcome != qualification.OutcomePass || rec.Grade != qualification.GradeUsable {
+		t.Errorf("end-to-end record = %s/%s, want pass/usable at the terminal condition", rec.Outcome, rec.Grade)
+	}
+	line, err := qualification.MarshalRecord(rec)
+	if err != nil {
+		t.Fatalf("qualification.MarshalRecord() error = %v", err)
+	}
+	if _, err := qualification.DecodeRecord(line); err != nil {
+		t.Errorf("qualification.DecodeRecord() error = %v, want the end-to-end record to decode cleanly", err)
+	}
+
+	// The run-history assertion: exactly one row, succeeded, for this
+	// issue's single attempt.
+	rows, err := fixture.Store.QueryRunHistoryByIssue(context.Background(), geminiE2EIssueID)
+	if err != nil {
+		t.Fatalf("query run history: %v", err)
+	}
+	if len(rows) != 1 || rows[0].Status != "succeeded" || rows[0].Attempt != 1 {
+		t.Errorf("run history rows = %+v, want exactly one succeeded first attempt", rows)
+	}
+}
+
+// geminiE2EStartWorkflow starts the orchestrator loop and returns the
+// cancel function and the loop-completion channel, for the live
+// collector's isolated end-to-end run.
+func geminiE2EStartWorkflow(t *testing.T, fixture *geminiE2EFixture) (context.CancelFunc, <-chan struct{}) {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	runDone := make(chan struct{})
+	go func() {
+		fixture.Orchestrator.Run(ctx)
+		close(runDone)
+	}()
+	t.Cleanup(func() {
+		cancel()
+		select {
+		case <-runDone:
+		case <-time.After(geminiQualificationShutdownDeadline):
+		}
+	})
+	return cancel, runDone
+}

--- a/internal/agent/clientprotocol/gemini_qualification_identity_test.go
+++ b/internal/agent/clientprotocol/gemini_qualification_identity_test.go
@@ -1,0 +1,328 @@
+package clientprotocol
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"path/filepath"
+	"runtime"
+	"slices"
+	"strings"
+	"testing"
+	"unicode"
+)
+
+// geminiIdentityToken is the one identity token this supplemental guard
+// enforces: production code must not name the runtime this issue
+// measures, in literals or in identifiers. Tests and operator
+// documentation may.
+const geminiIdentityToken = "gemini"
+
+// geminiIdentityViolation is one place a scanned production file breaks
+// the identity rule.
+type geminiIdentityViolation struct {
+	pos  token.Position
+	text string
+}
+
+// geminiIdentityWordsFromIdent splits an identifier into lowercase words
+// on every case transition and underscore, so GeminiCommand,
+// GEMINI_CLI_HOME, and useGeminiFlag all expose the token.
+func geminiIdentityWordsFromIdent(name string) []string {
+	var words []string
+	var current []rune
+	flush := func() {
+		if len(current) > 0 {
+			words = append(words, strings.ToLower(string(current)))
+			current = current[:0]
+		}
+	}
+	runes := []rune(name)
+	for i, r := range runes {
+		if r == '_' {
+			flush()
+			continue
+		}
+		if i > 0 && unicode.IsUpper(r) && !unicode.IsUpper(runes[i-1]) {
+			flush()
+		}
+		if i > 0 && unicode.IsUpper(runes[i-1]) && unicode.IsLower(r) && len(current) > 1 {
+			last := current[len(current)-1]
+			current = current[:len(current)-1]
+			flush()
+			current = append(current, last)
+		}
+		current = append(current, r)
+	}
+	flush()
+	return words
+}
+
+// geminiIdentityWordsFromLiteral splits a string literal into lowercase
+// words on every character that is neither a letter nor a digit.
+func geminiIdentityWordsFromLiteral(value string) []string {
+	return strings.FieldsFunc(value, func(r rune) bool {
+		return !unicode.IsLetter(r) && !unicode.IsDigit(r)
+	})
+}
+
+// geminiIdentityArm1Violations reports every string literal or identifier
+// in file, outside an import declaration, whose word sequence carries the
+// identity token.
+func geminiIdentityArm1Violations(fset *token.FileSet, file *ast.File) []geminiIdentityViolation {
+	var violations []geminiIdentityViolation
+	report := func(pos token.Pos, kind, spelling string, words []string) {
+		if slices.Contains(words, geminiIdentityToken) {
+			violations = append(violations, geminiIdentityViolation{
+				pos:  fset.Position(pos),
+				text: kind + " " + spelling + " names the " + geminiIdentityToken + " identity token",
+			})
+		}
+	}
+	ast.Inspect(file, func(n ast.Node) bool {
+		switch v := n.(type) {
+		case *ast.ImportSpec:
+			return false
+		case *ast.BasicLit:
+			if v.Kind != token.STRING {
+				return true
+			}
+			report(v.Pos(), "string literal", v.Value, geminiIdentityWordsFromLiteral(v.Value))
+		case *ast.Ident:
+			report(v.Pos(), "identifier", v.Name, geminiIdentityWordsFromIdent(v.Name))
+		}
+		return true
+	})
+	return violations
+}
+
+// geminiIdentityExprContainsAgentInfo reports whether expr's syntax tree
+// contains the identifier agentInfo, the recorded runtime identity.
+func geminiIdentityExprContainsAgentInfo(expr ast.Expr) bool {
+	found := false
+	ast.Inspect(expr, func(n ast.Node) bool {
+		if found {
+			return false
+		}
+		if ident, ok := n.(*ast.Ident); ok && ident.Name == "agentInfo" {
+			found = true
+			return false
+		}
+		return true
+	})
+	return found
+}
+
+// geminiIdentityArm2Violations reports every equality or inequality
+// comparison, switch tag, case expression, and map index in file whose
+// operand contains agentInfo: the recorded runtime identity may be
+// logged as evidence, but production behavior must not branch on it or
+// on any identity proxy.
+func geminiIdentityArm2Violations(fset *token.FileSet, file *ast.File) []geminiIdentityViolation {
+	var violations []geminiIdentityViolation
+	reject := func(pos token.Pos, what string) {
+		violations = append(violations, geminiIdentityViolation{
+			pos:  fset.Position(pos),
+			text: what + " branches on agentInfo; branch on an advertised capability or an observed message shape instead",
+		})
+	}
+	ast.Inspect(file, func(n ast.Node) bool {
+		switch v := n.(type) {
+		case *ast.BinaryExpr:
+			if (v.Op == token.EQL || v.Op == token.NEQ) &&
+				(geminiIdentityExprContainsAgentInfo(v.X) || geminiIdentityExprContainsAgentInfo(v.Y)) {
+				reject(v.Pos(), "an equality comparison")
+			}
+		case *ast.SwitchStmt:
+			if v.Tag != nil && geminiIdentityExprContainsAgentInfo(v.Tag) {
+				reject(v.Pos(), "a switch tag")
+			}
+		case *ast.CaseClause:
+			for _, expr := range v.List {
+				if geminiIdentityExprContainsAgentInfo(expr) {
+					reject(expr.Pos(), "a case expression")
+				}
+			}
+		case *ast.IndexExpr:
+			if geminiIdentityExprContainsAgentInfo(v.Index) {
+				reject(v.Pos(), "a map index")
+			}
+		}
+		return true
+	})
+	return violations
+}
+
+// scanGeminiProductionIdentity walks the production non-test Go files
+// under cmd/ and internal/ and applies both identity arms. Test files,
+// testdata trees, and everything outside those two roots are excluded,
+// so required Gemini references in tests and operator documentation stay
+// legal.
+func scanGeminiProductionIdentity(t *testing.T) ([]string, []geminiIdentityViolation) {
+	t.Helper()
+
+	fset := token.NewFileSet()
+	var scanned []string
+	var violations []geminiIdentityViolation
+
+	for _, root := range []string{filepath.Join("..", "..", "..", "cmd"), filepath.Join("..", "..", "..", "internal")} {
+		err := filepath.WalkDir(root, func(path string, d fs.DirEntry, walkErr error) error {
+			if walkErr != nil {
+				return walkErr
+			}
+			if d.IsDir() {
+				if d.Name() == "testdata" || strings.HasPrefix(d.Name(), ".") {
+					return filepath.SkipDir
+				}
+				return nil
+			}
+			if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+				return nil
+			}
+			file, parseErr := parser.ParseFile(fset, path, nil, parser.SkipObjectResolution)
+			if parseErr != nil {
+				t.Fatalf("parse %s: %v", path, parseErr)
+			}
+			scanned = append(scanned, path)
+			violations = append(violations, geminiIdentityArm1Violations(fset, file)...)
+			violations = append(violations, geminiIdentityArm2Violations(fset, file)...)
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("walk %s: %v", root, err)
+		}
+	}
+	return scanned, violations
+}
+
+// TestGeminiQualificationAddsNoProductionIdentityBranch scans the
+// production non-test Go files under cmd/ and internal/ for Gemini
+// identity literals and identity-proxy comparisons, proves the scan
+// covers the production tree, and pins the scanner's own detection
+// against inline fixtures so the guard cannot pass vacuously.
+func TestGeminiQualificationAddsNoProductionIdentityBranch(t *testing.T) {
+	t.Parallel()
+
+	t.Run("production tree carries no gemini identity literal", func(t *testing.T) {
+		t.Parallel()
+
+		scanned, violations := scanGeminiProductionIdentity(t)
+		if len(scanned) == 0 {
+			t.Fatal("the scan covered no production files, want at least one")
+		}
+		for _, v := range violations {
+			if strings.Contains(v.text, geminiIdentityToken+" identity token") {
+				t.Errorf("%s: %s", v.pos, v.text)
+			}
+		}
+	})
+
+	t.Run("production tree carries no identity-proxy comparison", func(t *testing.T) {
+		t.Parallel()
+
+		_, violations := scanGeminiProductionIdentity(t)
+		for _, v := range violations {
+			if strings.Contains(v.text, "branches on agentInfo") {
+				t.Errorf("%s: %s", v.pos, v.text)
+			}
+		}
+	})
+
+	t.Run("scan covers the production tree", func(t *testing.T) {
+		t.Parallel()
+
+		scanned, _ := scanGeminiProductionIdentity(t)
+		for _, want := range []string{
+			filepath.Join("cmd", "sortie", "main.go"),
+			filepath.Join("internal", "agent", "clientprotocol", "pump.go"),
+			filepath.Join("internal", "agent", "clientprotocol", "schemagen", "main.go"),
+		} {
+			found := slices.ContainsFunc(scanned, func(path string) bool {
+				return strings.HasSuffix(path, want)
+			})
+			if !found {
+				t.Errorf("scan missed the production file %s", want)
+			}
+		}
+
+		_, thisFile, _, _ := runtime.Caller(0)
+		if slices.Contains(scanned, filepath.Clean(thisFile)) {
+			t.Error("the scan covered its own test file, want test files excluded")
+		}
+	})
+
+	t.Run("scanner flags a gemini literal", func(t *testing.T) {
+		t.Parallel()
+
+		violations := geminiScanInline(t, `package fixture
+
+func f() string { return "gemini --acp" }
+`)
+		if len(violations) != 1 {
+			t.Fatalf("inline scan violations = %d, want 1: %v", len(violations), violations)
+		}
+		if !strings.Contains(violations[0].text, geminiIdentityToken+" identity token") {
+			t.Errorf("violation text = %q, want it to name the identity token", violations[0].text)
+		}
+	})
+
+	t.Run("scanner flags a gemini identifier word", func(t *testing.T) {
+		t.Parallel()
+
+		violations := geminiScanInline(t, `package fixture
+
+func pickGeminiCommand() string { return "" }
+`)
+		if len(violations) != 1 {
+			t.Fatalf("inline scan violations = %d, want 1: %v", len(violations), violations)
+		}
+	})
+
+	t.Run("scanner flags an agentInfo comparison", func(t *testing.T) {
+		t.Parallel()
+
+		violations := geminiScanInline(t, `package fixture
+
+func f(agentInfo string) bool {
+	return agentInfo == "x"
+}
+`)
+		if len(violations) != 1 {
+			t.Fatalf("inline scan violations = %d, want 1: %v", len(violations), violations)
+		}
+		if !strings.Contains(violations[0].text, "branches on agentInfo") {
+			t.Errorf("violation text = %q, want it to name the identity-proxy branch", violations[0].text)
+		}
+	})
+
+	t.Run("scanner accepts the generic kind", func(t *testing.T) {
+		t.Parallel()
+
+		violations := geminiScanInline(t, `package fixture
+
+const kind = "agent-client-protocol"
+
+func f(agentInfo string) string {
+	return agentInfo
+}
+`)
+		if len(violations) != 0 {
+			t.Errorf("inline scan violations = %v, want none for generic naming and unbranched identity logging", violations)
+		}
+	})
+}
+
+// geminiScanInline parses src as a single fixture file and returns the
+// violations both identity arms report for it.
+func geminiScanInline(t *testing.T, src string) []geminiIdentityViolation {
+	t.Helper()
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "fixture.go", src, parser.SkipObjectResolution)
+	if err != nil {
+		t.Fatalf("parse inline fixture: %v", err)
+	}
+	violations := geminiIdentityArm1Violations(fset, file)
+	violations = append(violations, geminiIdentityArm2Violations(fset, file)...)
+	return violations
+}

--- a/internal/agent/clientprotocol/gemini_qualification_identity_test.go
+++ b/internal/agent/clientprotocol/gemini_qualification_identity_test.go
@@ -60,11 +60,17 @@ func geminiIdentityWordsFromIdent(name string) []string {
 }
 
 // geminiIdentityWordsFromLiteral splits a string literal into lowercase
-// words on every character that is neither a letter nor a digit.
+// words on every character that is neither a letter nor a digit. The
+// words are lowered because the token compared against them is, so a
+// literal spelling the name the way prose does still exposes it.
 func geminiIdentityWordsFromLiteral(value string) []string {
-	return strings.FieldsFunc(value, func(r rune) bool {
+	words := strings.FieldsFunc(value, func(r rune) bool {
 		return !unicode.IsLetter(r) && !unicode.IsDigit(r)
 	})
+	for i, word := range words {
+		words[i] = strings.ToLower(word)
+	}
+	return words
 }
 
 // geminiIdentityArm1Violations reports every string literal or identifier
@@ -264,6 +270,18 @@ func f() string { return "gemini --acp" }
 		}
 		if !strings.Contains(violations[0].text, geminiIdentityToken+" identity token") {
 			t.Errorf("violation text = %q, want it to name the identity token", violations[0].text)
+		}
+	})
+
+	t.Run("scanner flags a capitalized gemini literal", func(t *testing.T) {
+		t.Parallel()
+
+		violations := geminiScanInline(t, `package fixture
+
+func f() string { return "Gemini CLI reported a stall" }
+`)
+		if len(violations) != 1 {
+			t.Fatalf("inline scan violations = %d, want 1: %v", len(violations), violations)
 		}
 	})
 

--- a/internal/agent/clientprotocol/gemini_qualification_mcp_unix_test.go
+++ b/internal/agent/clientprotocol/gemini_qualification_mcp_unix_test.go
@@ -1,0 +1,365 @@
+//go:build unix
+
+package clientprotocol
+
+import (
+	"bufio"
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sortie-ai/sortie/internal/agent/agenttest"
+	"github.com/sortie-ai/sortie/internal/domain"
+	"github.com/sortie-ai/sortie/internal/qualification"
+	"github.com/sortie-ai/sortie/internal/registry"
+)
+
+// geminiMCPToolName is the one tool the qualification MCP server
+// exposes.
+const geminiMCPToolName = "sortie_qualification_probe"
+
+// geminiMCPServerName is the server name the generated MCP
+// configuration declares.
+const geminiMCPServerName = "sortie-qualification-probe"
+
+// geminiNonce returns one generated public nonce. It is a random token
+// the harness owns: nothing secret travels in it, and only its
+// presence is ever recorded.
+func geminiNonce(t *testing.T) string {
+	t.Helper()
+	var raw [8]byte
+	if _, err := rand.Read(raw[:]); err != nil {
+		t.Fatalf("generate nonce: %v", err)
+	}
+	return "sortie-nonce-" + hex.EncodeToString(raw[:])
+}
+
+// geminiMCPFixture is the positive tool-server fixture: a test-owned
+// local stdio MCP server exposing one named probe tool, a receipt file
+// where the server records every nonce it actually received, and a
+// generated MCP configuration compatible with parseMCPServers and
+// parsedMCPServers.wireServers.
+type geminiMCPFixture struct {
+	ConfigPath  string
+	ServerPath  string
+	ReceiptPath string
+	Nonce       string
+}
+
+// geminiNewMCPFixture writes the server executable, the receipt file's
+// parent, and the generated MCP configuration under dir, and generates
+// the run's public nonce. The server records nothing but received
+// nonces: no header, environment value, or arbitrary payload is ever
+// written.
+func geminiNewMCPFixture(t *testing.T, dir string) geminiMCPFixture {
+	t.Helper()
+
+	receiptPath := filepath.Join(dir, "mcp-receipt.txt")
+	nonce := geminiNonce(t)
+
+	// The server speaks minimal JSON-RPC over stdio: initialize,
+	// tools/list advertising the probe tool, and tools/call recording
+	// the received nonce before returning it as text content.
+	server := fmt.Sprintf(`receipt='%s'
+while IFS= read -r line; do
+  case "$line" in
+    *'"method":"initialize"'*)
+      id=$(printf '%%s' "$line" | sed 's/.*"id":\([0-9]*\).*/\1/')
+      printf '%%s\n' "{\"jsonrpc\":\"2.0\",\"id\":$id,\"result\":{\"protocolVersion\":\"2024-11-05\",\"capabilities\":{\"tools\":{}},\"serverInfo\":{\"name\":\"%s\",\"version\":\"fixture\"}}}"
+      ;;
+    *'"method":"tools/list"'*)
+      id=$(printf '%%s' "$line" | sed 's/.*"id":\([0-9]*\).*/\1/')
+      printf '%%s\n' "{\"jsonrpc\":\"2.0\",\"id\":$id,\"result\":{\"tools\":[{\"name\":\"%s\",\"description\":\"qualification probe\",\"inputSchema\":{\"type\":\"object\"}}]}}"
+      ;;
+    *'"method":"tools/call"'*)
+      id=$(printf '%%s' "$line" | sed 's/.*"id":\([0-9]*\).*/\1/')
+      value=$(printf '%%s' "$line" | sed 's/.*"nonce":"\([^"]*\)".*/\1/')
+      printf '%%s\n' "$value" >> "$receipt"
+      printf '%%s\n' "{\"jsonrpc\":\"2.0\",\"id\":$id,\"result\":{\"content\":[{\"type\":\"text\",\"text\":\"$value\"}]}}"
+      ;;
+  esac
+done
+`, receiptPath, geminiMCPServerName, geminiMCPToolName)
+	serverPath := agenttest.WriteScript(t, dir, "mcp-fixture-server.sh", server)
+
+	configPath := filepath.Join(dir, "mcp-config.json")
+	config := fmt.Sprintf(`{"mcpServers":{"%s":{"type":"stdio","command":%q,"args":[],"env":{}}}}`,
+		geminiMCPServerName, serverPath)
+	if err := os.WriteFile(configPath, []byte(config), 0o600); err != nil {
+		t.Fatalf("write qualification MCP config: %v", err)
+	}
+
+	return geminiMCPFixture{
+		ConfigPath:  configPath,
+		ServerPath:  serverPath,
+		ReceiptPath: receiptPath,
+		Nonce:       nonce,
+	}
+}
+
+// geminiReadMCPReceipt returns every nonce the fixture server recorded,
+// in receipt order. The receipt carries nonce strings only.
+func geminiReadMCPReceipt(t *testing.T, fixture geminiMCPFixture) []string {
+	t.Helper()
+	raw, err := os.ReadFile(fixture.ReceiptPath) //nolint:gosec // the receipt path is written by this test under its own temp directory
+	if err != nil {
+		return nil
+	}
+	var received []string
+	for line := range strings.SplitSeq(string(raw), "\n") {
+		if line != "" {
+			received = append(received, line)
+		}
+	}
+	return received
+}
+
+// geminiGradeMCPDelivery grades tool-server delivery. A usable verdict
+// requires both that the server actually received the generated nonce
+// and that the turn consumed the returned nonce; an advertisement or a
+// tool_call output alone is never positive.
+func geminiGradeMCPDelivery(received []string, nonce string, turnConsumed bool) qualification.Grade {
+	serverReceived := false
+	for _, value := range received {
+		if value == nonce {
+			serverReceived = true
+		}
+	}
+	if serverReceived && turnConsumed {
+		return qualification.GradeUsable
+	}
+	return qualification.GradeNotObserved
+}
+
+// geminiDriveMCPFixture drives the fixture server over stdio and
+// reports what it observed: whether the probe tool was advertised,
+// whether the server received the nonce, and what the call returned.
+type geminiMCPDriveResult struct {
+	advertised    bool
+	serverReceipt []string
+	returnedNonce string
+}
+
+// geminiDriveMCPFixture starts the fixture server, completes
+// initialize, lists tools, and calls the probe tool with the fixture's
+// nonce.
+func geminiDriveMCPFixture(t *testing.T, fixture geminiMCPFixture) geminiMCPDriveResult {
+	t.Helper()
+
+	cmd := exec.Command(fixture.ServerPath) //nolint:gosec // the server path is written by this test under its own temp directory
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		t.Fatalf("stdin pipe: %v", err)
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		t.Fatalf("stdout pipe: %v", err)
+	}
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start MCP fixture server: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = stdin.Close()
+		_ = cmd.Process.Kill()
+		_, _ = cmd.Process.Wait()
+	})
+
+	reader := bufio.NewScanner(stdout)
+	reader.Buffer(make([]byte, 0, 64<<10), 1<<20)
+
+	call := func(method string, params string) map[string]json.RawMessage {
+		t.Helper()
+		if _, err := fmt.Fprintf(stdin, `{"jsonrpc":"2.0","id":7,"method":%q,"params":%s}`+"\n", method, params); err != nil {
+			t.Fatalf("write %s request: %v", method, err)
+		}
+		deadline := time.Now().Add(awaitTimeout)
+		for reader.Scan() {
+			var envelope map[string]json.RawMessage
+			if err := json.Unmarshal(reader.Bytes(), &envelope); err != nil {
+				continue
+			}
+			if id, ok := envelope["id"]; ok && strings.TrimSpace(string(id)) == "7" {
+				return envelope
+			}
+			if time.Now().After(deadline) {
+				t.Fatalf("timed out waiting for the %s response", method)
+			}
+		}
+		t.Fatalf("MCP fixture server stream ended before the %s response", method)
+		return nil
+	}
+
+	call("initialize", `{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"sortie","version":"fixture"}}`)
+
+	listResult := call("tools/list", `{}`)
+	var toolList struct {
+		Tools []struct {
+			Name string `json:"name"`
+		} `json:"tools"`
+	}
+	if raw, ok := listResult["result"]; ok {
+		if err := json.Unmarshal(raw, &toolList); err != nil {
+			t.Fatalf("decode tools/list result: %v", err)
+		}
+	}
+	advertised := false
+	for _, tool := range toolList.Tools {
+		if tool.Name == geminiMCPToolName {
+			advertised = true
+		}
+	}
+
+	callResult := call("tools/call", fmt.Sprintf(`{"name":%q,"arguments":{"nonce":%q}}`, geminiMCPToolName, fixture.Nonce))
+	var callPayload struct {
+		Content []struct {
+			Text string `json:"text"`
+		} `json:"content"`
+	}
+	if raw, ok := callResult["result"]; ok {
+		if err := json.Unmarshal(raw, &callPayload); err != nil {
+			t.Fatalf("decode tools/call result: %v", err)
+		}
+	}
+	returned := ""
+	for _, block := range callPayload.Content {
+		if block.Text != "" {
+			returned = block.Text
+		}
+	}
+
+	return geminiMCPDriveResult{
+		advertised:    advertised,
+		serverReceipt: geminiReadMCPReceipt(t, fixture),
+		returnedNonce: returned,
+	}
+}
+
+// TestGeminiQualificationMCPFixtureReceipt confirms the positive
+// tool-server fixture end to end: the generated configuration parses
+// through the existing parseMCPServers path, the session-creation wire
+// carries the declared stdio server, and delivery is graded usable only
+// when the server received the generated nonce and the turn consumed
+// the returned nonce. Advertisement alone, or a tool_call output alone,
+// is never a positive verdict.
+func TestGeminiQualificationMCPFixtureReceipt(t *testing.T) {
+	t.Parallel()
+
+	t.Run("config parses and renders through the existing path", func(t *testing.T) {
+		t.Parallel()
+
+		fixture := geminiNewMCPFixture(t, t.TempDir())
+		parsed, agentErr := parseMCPServers(fixture.ConfigPath, false)
+		if agentErr != nil {
+			t.Fatalf("parseMCPServers(%q) error = %v", fixture.ConfigPath, agentErr)
+		}
+		servers, withheld := parsed.wireServers(true)
+		if withheld {
+			t.Error("wireServers(true) withheld = true, want false for a stdio server")
+		}
+		if len(servers) != 1 || servers[0].Stdio == nil {
+			t.Fatalf("wireServers(true) = %+v, want one stdio server", servers)
+		}
+		if servers[0].Stdio.Name != geminiMCPServerName {
+			t.Errorf("server name = %q, want %q", servers[0].Stdio.Name, geminiMCPServerName)
+		}
+		if servers[0].Stdio.Command != fixture.ServerPath {
+			t.Errorf("server command = %q, want %q", servers[0].Stdio.Command, fixture.ServerPath)
+		}
+	})
+
+	t.Run("session creation carries the declared stdio server on the wire", func(t *testing.T) {
+		t.Parallel()
+
+		dir := t.TempDir()
+		fixture := geminiNewMCPFixture(t, dir)
+		capturePath := filepath.Join(dir, "session_new.jsonl")
+		scriptPath := agenttest.WriteScript(t, dir, "agent.sh", mcpHandshakeScript(capturePath))
+
+		session, err := startSession(context.Background(), domain.StartSessionParams{
+			WorkspacePath: t.TempDir(),
+			AgentConfig:   domain.AgentConfig{Command: scriptPath},
+			MCPConfigPath: fixture.ConfigPath,
+		})
+		if err != nil {
+			t.Fatalf("startSession() error = %v", err)
+		}
+		t.Cleanup(func() {
+			if err := stopSession(context.Background(), session); err != nil {
+				t.Errorf("stopSession() error = %v", err)
+			}
+		})
+
+		captured, err := os.ReadFile(capturePath)
+		if err != nil {
+			t.Fatalf("read captured session/new request: %v", err)
+		}
+		wire := strings.TrimSpace(string(captured))
+
+		declared, ok := registry.Agents.Meta("agent-client-protocol")
+		if !ok {
+			t.Fatal(`registry.Agents.Meta("agent-client-protocol") ok = false, want true`)
+		}
+		agenttest.AssertMCPInjection(t, declared.MCPInjection, fixture.ConfigPath, agenttest.MCPLaunchSurface{
+			Wire: []string{wire},
+		})
+		if !strings.Contains(wire, geminiMCPServerName) || !strings.Contains(wire, fixture.ServerPath) {
+			t.Errorf("session/new wire %q does not name the declared server and its command", wire)
+		}
+	})
+
+	t.Run("receipt plus consumed returned nonce grades usable", func(t *testing.T) {
+		t.Parallel()
+
+		fixture := geminiNewMCPFixture(t, t.TempDir())
+		drive := geminiDriveMCPFixture(t, fixture)
+
+		if !drive.advertised {
+			t.Error("tools/list did not advertise the probe tool")
+		}
+		if len(drive.serverReceipt) != 1 || drive.serverReceipt[0] != fixture.Nonce {
+			t.Errorf("server receipt = %v, want exactly the generated nonce", drive.serverReceipt)
+		}
+		if drive.returnedNonce != fixture.Nonce {
+			t.Errorf("returned nonce = %q, want the generated nonce echoed back", drive.returnedNonce)
+		}
+
+		turnConsumed := strings.Contains("turn consumed "+drive.returnedNonce, fixture.Nonce)
+		if got := geminiGradeMCPDelivery(drive.serverReceipt, fixture.Nonce, turnConsumed); got != qualification.GradeUsable {
+			t.Errorf("geminiGradeMCPDelivery() = %s, want usable for receipt plus consumed nonce", got)
+		}
+	})
+
+	t.Run("advertisement alone never grades usable", func(t *testing.T) {
+		t.Parallel()
+
+		if got := geminiGradeMCPDelivery(nil, "sortie-nonce-unsigned", false); got == qualification.GradeUsable {
+			t.Errorf("geminiGradeMCPDelivery(nil, ...) = %s, want a non-usable verdict for advertisement only", got)
+		}
+	})
+
+	t.Run("a tool_call output without server receipt never grades usable", func(t *testing.T) {
+		t.Parallel()
+
+		nonce := "sortie-nonce-output-only"
+		if got := geminiGradeMCPDelivery(nil, nonce, true); got == qualification.GradeUsable {
+			t.Errorf("geminiGradeMCPDelivery(nil, %q, true) = %s, want a non-usable verdict without server receipt", nonce, got)
+		}
+	})
+
+	t.Run("a receipt without a consumed returned nonce never grades usable", func(t *testing.T) {
+		t.Parallel()
+
+		received := []string{"sortie-nonce-unconsumed"}
+		if got := geminiGradeMCPDelivery(received, "sortie-nonce-unconsumed", false); got == qualification.GradeUsable {
+			t.Errorf("geminiGradeMCPDelivery(receipt, nonce, false) = %s, want a non-usable verdict while the turn never consumed the nonce", got)
+		}
+	})
+}

--- a/internal/agent/clientprotocol/gemini_qualification_mcp_unix_test.go
+++ b/internal/agent/clientprotocol/gemini_qualification_mcp_unix_test.go
@@ -175,26 +175,51 @@ func geminiDriveMCPFixture(t *testing.T, fixture geminiMCPFixture) geminiMCPDriv
 	reader := bufio.NewScanner(stdout)
 	reader.Buffer(make([]byte, 0, 64<<10), 1<<20)
 
+	// The scan runs off the caller's goroutine so a server that never
+	// answers cannot park the caller inside a blocking read until the
+	// whole package times out with no diagnostic. readerDone gives the
+	// scan a cancellation path: every send selects against it, so the
+	// goroutine cannot block on a channel the caller has abandoned.
+	lines := make(chan []byte)
+	readerDone := make(chan struct{})
+	t.Cleanup(func() { close(readerDone) })
+	go func() {
+		defer close(lines)
+		for reader.Scan() {
+			line := append([]byte(nil), reader.Bytes()...)
+			select {
+			case lines <- line:
+			case <-readerDone:
+				return
+			}
+		}
+	}()
+
 	call := func(method string, params string) map[string]json.RawMessage {
 		t.Helper()
 		if _, err := fmt.Fprintf(stdin, `{"jsonrpc":"2.0","id":7,"method":%q,"params":%s}`+"\n", method, params); err != nil {
 			t.Fatalf("write %s request: %v", method, err)
 		}
-		deadline := time.Now().Add(awaitTimeout)
-		for reader.Scan() {
-			var envelope map[string]json.RawMessage
-			if err := json.Unmarshal(reader.Bytes(), &envelope); err != nil {
-				continue
-			}
-			if id, ok := envelope["id"]; ok && strings.TrimSpace(string(id)) == "7" {
-				return envelope
-			}
-			if time.Now().After(deadline) {
+		deadline := time.After(awaitTimeout)
+		for {
+			select {
+			case line, ok := <-lines:
+				if !ok {
+					t.Fatalf("MCP fixture server stream ended before the %s response", method)
+					return nil
+				}
+				var envelope map[string]json.RawMessage
+				if err := json.Unmarshal(line, &envelope); err != nil {
+					continue
+				}
+				if id, ok := envelope["id"]; ok && strings.TrimSpace(string(id)) == "7" {
+					return envelope
+				}
+			case <-deadline:
 				t.Fatalf("timed out waiting for the %s response", method)
+				return nil
 			}
 		}
-		t.Fatalf("MCP fixture server stream ended before the %s response", method)
-		return nil
 	}
 
 	call("initialize", `{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"sortie","version":"fixture"}}`)

--- a/internal/agent/clientprotocol/gemini_qualification_nonunix_test.go
+++ b/internal/agent/clientprotocol/gemini_qualification_nonunix_test.go
@@ -1,0 +1,23 @@
+//go:build !unix
+
+package clientprotocol
+
+import (
+	"os"
+	"testing"
+)
+
+// TestGeminiQualification is the non-Unix live-gate contract. With the
+// Gemini qualification gate disabled it skips with the one explicit
+// reason every disabled qualification scenario shares. With the gate
+// enabled it fails with the exact unsupported-platform diagnostic,
+// because live qualification has no Windows Job Object oracle and a
+// non-Unix host records live qualification as unobserved, never as
+// passed. No production procutil, Session, or adapter state changes
+// here.
+func TestGeminiQualification(t *testing.T) {
+	if os.Getenv(geminiQualificationGateEnv) != "1" {
+		t.Skip(geminiQualificationSkipReason)
+	}
+	t.Fatalf("%s", geminiQualificationNonUnixFailure)
+}

--- a/internal/agent/clientprotocol/gemini_qualification_notes_test.go
+++ b/internal/agent/clientprotocol/gemini_qualification_notes_test.go
@@ -1,0 +1,688 @@
+package clientprotocol
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/sortie-ai/sortie/internal/qualification"
+)
+
+// geminiSummaryGrade is one surface-capability grade with the exact
+// status label the adapter notes must use for it.
+type geminiSummaryGrade struct {
+	Surface    qualification.Surface
+	Capability qualification.Capability
+	Grade      qualification.Grade
+	Label      string
+}
+
+// geminiSummarySemantic is one of the 36 semantic-case verdicts.
+type geminiSummarySemantic struct {
+	Surface    qualification.Surface
+	Capability qualification.Capability
+	Case       qualification.Case
+	Verdict    qualification.Outcome
+}
+
+// geminiSummaryToken is one token-bearing path with its classification.
+type geminiSummaryToken struct {
+	Surface        qualification.Surface
+	EvidencePath   string
+	Classification qualification.Grade
+}
+
+// geminiSummaryContinuation is one surface's continuation outcome.
+type geminiSummaryContinuation struct {
+	Surface qualification.Surface
+	Outcome string
+	Grade   qualification.Grade
+}
+
+// geminiSummaryConclusions is the bounded summary a validated evidence
+// set produces. It carries no runtime version, timestamp, session
+// identifier, filesystem path, prompt, or secret value.
+type geminiSummaryConclusions struct {
+	Verdict       qualification.Verdict
+	Grades        []geminiSummaryGrade
+	Semantics     []geminiSummarySemantic
+	Tokens        []geminiSummaryToken
+	Continuations []geminiSummaryContinuation
+	Workspace     string
+	Unobserved    []string
+}
+
+// geminiNotesHeadings are the required adapter-notes headings in R8
+// order.
+var geminiNotesHeadings = []string{
+	"# Gemini CLI adapter notes",
+	"## Entry points",
+	"## Load-bearing capability observations",
+	"## Protocol-specific observations",
+	"## Native headless observations",
+	"## Workspace trust and process boundary",
+	"## Unobserved surfaces",
+}
+
+// geminiNotesUnixScope is the sentence the notes must carry to state the
+// Unix-only live scope and the unobserved Windows behavior.
+const geminiNotesUnixScope = "Windows live qualification is unobserved"
+
+// geminiStatusLabel maps a grade to the exact notes status label.
+func geminiStatusLabel(classification qualification.Grade) string {
+	switch classification {
+	case qualification.GradeUsable, qualification.GradeGap:
+		return "Observed:"
+	case qualification.GradeNotObserved:
+		return "Not observed:"
+	case qualification.GradeNotApplicable:
+		return "Not applicable:"
+	}
+	return ""
+}
+
+// geminiSummaryConclusionsFromRecords derives the bounded conclusions
+// from a validated non-final evidence set and its computed verdict.
+func geminiSummaryConclusionsFromRecords(records []qualification.Record, verdict qualification.Verdict) (geminiSummaryConclusions, error) {
+	conclusions := geminiSummaryConclusions{Verdict: verdict}
+
+	for i := range records {
+		rec := &records[i]
+		class, err := qualification.ClassifyRecord(rec)
+		if err != nil {
+			return geminiSummaryConclusions{}, fmt.Errorf("record %d: %w", rec.Sequence, err)
+		}
+		switch class {
+		case qualification.RowBaseline:
+			conclusions.Grades = append(conclusions.Grades, geminiSummaryGrade{
+				Surface:    rec.Surface,
+				Capability: rec.Capability,
+				Grade:      rec.Grade,
+				Label:      geminiStatusLabel(rec.Grade),
+			})
+		case qualification.RowMCPDelivery, qualification.RowPermission:
+			conclusions.Grades = append(conclusions.Grades, geminiSummaryGrade{
+				Surface:    rec.Surface,
+				Capability: rec.Capability,
+				Grade:      rec.Grade,
+				Label:      geminiStatusLabel(rec.Grade),
+			})
+		case qualification.RowSemantic:
+			semantic := geminiSummarySemantic{
+				Surface:    rec.Surface,
+				Capability: rec.Capability,
+				Verdict:    rec.Outcome,
+			}
+			if rec.SemanticCase != nil {
+				semantic.Case = *rec.SemanticCase
+			}
+			conclusions.Semantics = append(conclusions.Semantics, semantic)
+			if rec.Grade == qualification.GradeNotObserved {
+				conclusions.Unobserved = append(conclusions.Unobserved,
+					fmt.Sprintf("%s %s %s", rec.Surface, rec.Capability, semantic.Case))
+			}
+		case qualification.RowToken:
+			path := "(no token-bearing path)"
+			if rec.EvidencePath != nil {
+				path = *rec.EvidencePath
+			}
+			conclusions.Tokens = append(conclusions.Tokens, geminiSummaryToken{
+				Surface:        rec.Surface,
+				EvidencePath:   path,
+				Classification: rec.Grade,
+			})
+		case qualification.RowContinuationRecall:
+			conclusions.Continuations = append(conclusions.Continuations, geminiSummaryContinuation{
+				Surface: rec.Surface,
+				Outcome: rec.Detail,
+				Grade:   rec.Grade,
+			})
+		case qualification.RowWorkspaceSecurity:
+			conclusions.Workspace = fmt.Sprintf("%s %s", geminiStatusLabel(rec.Grade), rec.Detail)
+		}
+	}
+
+	if len(conclusions.Grades) != 18 {
+		return geminiSummaryConclusions{}, fmt.Errorf("derived %d capability grades, want 16 baselines plus tool server and permission", len(conclusions.Grades))
+	}
+	if len(conclusions.Semantics) != 36 {
+		return geminiSummaryConclusions{}, fmt.Errorf("derived %d semantic verdicts, want 36", len(conclusions.Semantics))
+	}
+	if len(conclusions.Continuations) != 4 {
+		return geminiSummaryConclusions{}, fmt.Errorf("derived %d continuation outcomes, want 4", len(conclusions.Continuations))
+	}
+	if conclusions.Workspace == "" {
+		return geminiSummaryConclusions{}, fmt.Errorf("derived no workspace security conclusion")
+	}
+
+	slices.SortStableFunc(conclusions.Grades, func(a, b geminiSummaryGrade) int {
+		if c := slices.Index(qualification.Surfaces, a.Surface) - slices.Index(qualification.Surfaces, b.Surface); c != 0 {
+			return c
+		}
+		return slices.Index(qualification.Capabilities, a.Capability) - slices.Index(qualification.Capabilities, b.Capability)
+	})
+	slices.SortStableFunc(conclusions.Semantics, func(a, b geminiSummarySemantic) int {
+		if c := slices.Index(qualification.Surfaces, a.Surface) - slices.Index(qualification.Surfaces, b.Surface); c != 0 {
+			return c
+		}
+		if c := slices.Index(qualification.Capabilities, a.Capability) - slices.Index(qualification.Capabilities, b.Capability); c != 0 {
+			return c
+		}
+		return slices.Index(qualification.CapabilityCases[a.Capability], a.Case) - slices.Index(qualification.CapabilityCases[b.Capability], b.Case)
+	})
+	slices.SortStableFunc(conclusions.Tokens, func(a, b geminiSummaryToken) int {
+		if c := slices.Index(qualification.Surfaces, a.Surface) - slices.Index(qualification.Surfaces, b.Surface); c != 0 {
+			return c
+		}
+		return strings.Compare(a.EvidencePath, b.EvidencePath)
+	})
+	slices.SortStableFunc(conclusions.Continuations, func(a, b geminiSummaryContinuation) int {
+		return slices.Index(qualification.Surfaces, a.Surface) - slices.Index(qualification.Surfaces, b.Surface)
+	})
+	slices.Sort(conclusions.Unobserved)
+
+	return conclusions, nil
+}
+
+// formatGeminiQualificationSummary renders the bounded, actionable
+// summary the harness prints after final validation.
+func formatGeminiQualificationSummary(conclusions geminiSummaryConclusions) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "Eligibility: %s\n", conclusions.Verdict)
+	fmt.Fprint(&b, "Capability grades:\n")
+	for _, grade := range conclusions.Grades {
+		fmt.Fprintf(&b, "%s %s: %s %s\n", grade.Surface, grade.Capability, grade.Label, grade.Grade)
+	}
+	fmt.Fprint(&b, "Semantic verdicts:\n")
+	for _, semantic := range conclusions.Semantics {
+		fmt.Fprintf(&b, "%s %s %s: %s\n", semantic.Surface, semantic.Capability, semantic.Case, semantic.Verdict)
+	}
+	fmt.Fprint(&b, "Token sources:\n")
+	for _, token := range conclusions.Tokens {
+		fmt.Fprintf(&b, "%s %s: %s\n", token.Surface, token.EvidencePath, token.Classification)
+	}
+	fmt.Fprint(&b, "Continuation:\n")
+	for _, continuation := range conclusions.Continuations {
+		fmt.Fprintf(&b, "%s: %s (%s %s)\n", continuation.Surface, continuation.Outcome, geminiStatusLabel(continuation.Grade), continuation.Grade)
+	}
+	fmt.Fprintf(&b, "Workspace security:\n%s\n", conclusions.Workspace)
+	fmt.Fprint(&b, "Unobserved semantic cases:\n")
+	if len(conclusions.Unobserved) == 0 {
+		fmt.Fprint(&b, "none\n")
+	}
+	for _, entry := range conclusions.Unobserved {
+		fmt.Fprintf(&b, "%s\n", entry)
+	}
+	return b.String()
+}
+
+// The notes-validation patterns: grade rows with their exact status
+// labels, and the banned version, date, and environment-value shapes.
+var (
+	geminiNotesGradeRowPattern = regexp.MustCompile(`^- (` + geminiNotesAlternation(qualification.Surfaces) + `) ([a-z_]+): (Observed|Not observed|Not applicable): (usable|gap|not_observed|not_applicable)\b`)
+	geminiNotesVersionPattern  = regexp.MustCompile(`\b\d+\.\d+\.\d+\b`)
+	geminiNotesDatePattern     = regexp.MustCompile(`\b\d{4}-\d{2}-\d{2}\b`)
+	geminiNotesEnvValuePattern = regexp.MustCompile(`^[A-Z][A-Z0-9_]*=\S`)
+)
+
+// geminiNotesAlternation renders a closed value set as a regex
+// alternation.
+func geminiNotesAlternation[T ~string](values []T) string {
+	quoted := make([]string, 0, len(values))
+	for _, value := range values {
+		quoted = append(quoted, regexp.QuoteMeta(string(value)))
+	}
+	return strings.Join(quoted, "|")
+}
+
+// validateGeminiAdapterNotes validates a durable adapter-notes document
+// against the conclusions of a freshly validated summary: heading order,
+// status labels, one matching eligibility line, every unobserved case in
+// the final section, the Unix-only scope statement, and no version,
+// date, or environment value.
+func validateGeminiAdapterNotes(notes string, want geminiSummaryConclusions) error {
+	lines := strings.Split(notes, "\n")
+	trimmed := make([]string, len(lines))
+	for i, line := range lines {
+		trimmed[i] = strings.TrimSpace(line)
+	}
+
+	position := -1
+	for _, heading := range geminiNotesHeadings {
+		next := slices.Index(trimmed[position+1:], heading)
+		if next < 0 {
+			return fmt.Errorf("notes heading %q is missing or out of order", heading)
+		}
+		position += next + 1
+	}
+
+	eligibilityCount := 0
+	for _, line := range trimmed {
+		if !strings.HasPrefix(line, "Eligibility: ") {
+			continue
+		}
+		eligibilityCount++
+		if value := strings.TrimPrefix(line, "Eligibility: "); value != string(want.Verdict) {
+			return fmt.Errorf("notes eligibility %q does not match the validated verdict %q", value, want.Verdict)
+		}
+	}
+	if eligibilityCount != 1 {
+		return fmt.Errorf("notes carry %d Eligibility lines, want exactly 1", eligibilityCount)
+	}
+
+	wantGrades := map[string]geminiSummaryGrade{}
+	for _, grade := range want.Grades {
+		wantGrades[string(grade.Surface)+" "+string(grade.Capability)] = grade
+	}
+	seenGrades := map[string]bool{}
+	for i, line := range trimmed {
+		match := geminiNotesGradeRowPattern.FindStringSubmatch(line)
+		if match == nil {
+			continue
+		}
+		key := match[1] + " " + match[2]
+		wantGrade, known := wantGrades[key]
+		if !known {
+			return fmt.Errorf("notes line %d claims grade %q that the validated summary does not carry", i+1, key)
+		}
+		if seenGrades[key] {
+			return fmt.Errorf("notes line %d duplicates the grade row %q", i+1, key)
+		}
+		seenGrades[key] = true
+		if match[3]+":" != wantGrade.Label {
+			return fmt.Errorf("notes line %d grades %q as %q, want %q", i+1, key, match[3]+":", wantGrade.Label)
+		}
+		if match[4] != string(wantGrade.Grade) {
+			return fmt.Errorf("notes line %d grades %q as %s, want %s", i+1, key, match[4], wantGrade.Grade)
+		}
+	}
+	for key := range wantGrades {
+		if !seenGrades[key] {
+			return fmt.Errorf("notes carry no status-label row for %q", key)
+		}
+	}
+
+	unobservedHeading := slices.Index(trimmed, "## Unobserved surfaces")
+	if unobservedHeading < 0 {
+		return fmt.Errorf("notes heading %q is missing", "## Unobserved surfaces")
+	}
+	tail := strings.Join(trimmed[unobservedHeading:], "\n")
+	for _, entry := range want.Unobserved {
+		if !strings.Contains(tail, entry) {
+			return fmt.Errorf("unobserved semantic case %q is absent from the Unobserved surfaces section", entry)
+		}
+	}
+
+	if !strings.Contains(notes, geminiNotesUnixScope) {
+		return fmt.Errorf("notes do not state that %s", strings.ToLower(geminiNotesUnixScope))
+	}
+
+	for i, line := range trimmed {
+		switch {
+		case geminiNotesVersionPattern.MatchString(line):
+			return fmt.Errorf("notes line %d carries a binary version value", i+1)
+		case geminiNotesDatePattern.MatchString(line):
+			return fmt.Errorf("notes line %d carries a measurement date", i+1)
+		case geminiNotesEnvValuePattern.MatchString(line):
+			return fmt.Errorf("notes line %d carries an environment variable value", i+1)
+		}
+	}
+	return nil
+}
+
+// geminiAdapterNotesFixture renders a compliant adapter-notes document
+// from the summary conclusions, mirroring the manual transfer the
+// qualification flow requires.
+func geminiAdapterNotesFixture(want geminiSummaryConclusions) string {
+	var b strings.Builder
+	fmt.Fprint(&b, "# Gemini CLI adapter notes\n\n")
+	fmt.Fprintf(&b, "Eligibility: %s\n\n", want.Verdict)
+
+	fmt.Fprint(&b, "## Entry points\n\n")
+	fmt.Fprint(&b, "Entry points use the generic agent-client-protocol kind with the runtime command the operator selects.\n\n")
+
+	fmt.Fprint(&b, "## Load-bearing capability observations\n\n")
+	for _, grade := range want.Grades {
+		if grade.Surface == qualification.SurfaceNativeText {
+			continue
+		}
+		fmt.Fprintf(&b, "- %s %s: %s %s with a bounded evidence shape\n", grade.Surface, grade.Capability, grade.Label, grade.Grade)
+	}
+	fmt.Fprint(&b, "\n")
+
+	fmt.Fprint(&b, "## Protocol-specific observations\n\n")
+	fmt.Fprint(&b, "Permission requests are answered with the shared refusal posture, and tool-server delivery is proven by server receipt.\n\n")
+
+	fmt.Fprint(&b, "## Native headless observations\n\n")
+	for _, grade := range want.Grades {
+		if grade.Surface != qualification.SurfaceNativeText {
+			continue
+		}
+		fmt.Fprintf(&b, "- %s %s: %s %s as unstructured residue or structured output\n", grade.Surface, grade.Capability, grade.Label, grade.Grade)
+	}
+	fmt.Fprint(&b, "\n")
+
+	fmt.Fprintf(&b, "## Workspace trust and process boundary\n\n%s. %s and out of scope for this measurement.\n\n", want.Workspace, geminiNotesUnixScope)
+
+	fmt.Fprint(&b, "## Unobserved surfaces\n\n")
+	if len(want.Unobserved) == 0 {
+		fmt.Fprint(&b, "All required observations completed.\n")
+	}
+	for _, entry := range want.Unobserved {
+		fmt.Fprintf(&b, "- %s\n", entry)
+	}
+	return b.String()
+}
+
+// writeGeminiNotesFile writes a notes document to the test's temporary
+// directory and returns its path. Tracked documentation is never touched.
+func writeGeminiNotesFile(t *testing.T, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "gemini-adapter-notes.md")
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write notes fixture: %v", err)
+	}
+	return path
+}
+
+// TestGeminiQualificationBoundedSummary confirms the summary shape: the
+// eligibility verdict, all surface-capability grades, all 36 semantic
+// verdicts, token sources, continuation outcomes, and the workspace
+// conclusion, with no session identifiers, versions, or timestamps.
+func TestGeminiQualificationBoundedSummary(t *testing.T) {
+	t.Parallel()
+
+	fixture := qualification.NewFixture(qualification.FixtureQualified)
+	fixture.Finalize()
+	conclusions, err := geminiSummaryConclusionsFromRecords(fixture.Records, qualification.VerdictQualified)
+	if err != nil {
+		t.Fatalf("geminiSummaryConclusionsFromRecords() error = %v", err)
+	}
+
+	if len(conclusions.Grades) != 18 {
+		t.Errorf("grade count = %d, want 18", len(conclusions.Grades))
+	}
+	if len(conclusions.Semantics) != 36 {
+		t.Errorf("semantic verdict count = %d, want 36", len(conclusions.Semantics))
+	}
+	if got := len(conclusions.Tokens); got != qualification.TokenRecordCount(fixture.Records) {
+		t.Errorf("token source count = %d, want %d", got, qualification.TokenRecordCount(fixture.Records))
+	}
+	if len(conclusions.Continuations) != 4 {
+		t.Errorf("continuation count = %d, want 4", len(conclusions.Continuations))
+	}
+	if conclusions.Verdict != qualification.VerdictQualified {
+		t.Errorf("verdict = %q, want %q", conclusions.Verdict, qualification.VerdictQualified)
+	}
+	if len(conclusions.Unobserved) != 0 {
+		t.Errorf("unobserved cases = %v, want none for the qualified fixture", conclusions.Unobserved)
+	}
+
+	summary := formatGeminiQualificationSummary(conclusions)
+	if got := strings.Count(summary, "Eligibility: qualified"); got != 1 {
+		t.Errorf("summary carries %d eligibility lines, want 1", got)
+	}
+	for _, want := range []string{
+		"protocol turn_disposition: Observed: usable",
+		"native_text token_ceiling: Observed: gap",
+		"protocol tool_server_delivery: Observed: usable",
+		"protocol turn_disposition success: pass",
+		"native_text (no token-bearing path): gap",
+		"protocol: confirmed_same_session",
+	} {
+		if !strings.Contains(summary, want) {
+			t.Errorf("summary is missing the expected line %q", want)
+		}
+	}
+	for _, banned := range []string{"sess-", qualification.FixtureAgentName, qualification.FixtureAgentVer, qualification.FixtureTime, "/turn/stop_reason"} {
+		if strings.Contains(summary, banned) {
+			t.Errorf("summary leaks the banned value %q", banned)
+		}
+	}
+	if again := formatGeminiQualificationSummary(conclusions); again != summary {
+		t.Error("formatGeminiQualificationSummary() is not deterministic across calls")
+	}
+}
+
+// TestGeminiQualificationNotesContract confirms the notes validator
+// accepts a compliant transfer of the summary and rejects structural,
+// labeling, scope, and cleanliness violations.
+func TestGeminiQualificationNotesContract(t *testing.T) {
+	t.Parallel()
+
+	qualifiedFixture := qualification.NewFixture(qualification.FixtureQualified)
+	qualifiedFixture.Finalize()
+	qualified, err := geminiSummaryConclusionsFromRecords(qualifiedFixture.Records, qualification.VerdictQualified)
+	if err != nil {
+		t.Fatalf("geminiSummaryConclusionsFromRecords() error = %v", err)
+	}
+
+	notQualifiedFixture := qualification.NewFixture(qualification.FixtureNotQualified)
+	notQualifiedFixture.Finalize()
+	notQualified, err := geminiSummaryConclusionsFromRecords(notQualifiedFixture.Records, qualification.VerdictNotQualified)
+	if err != nil {
+		t.Fatalf("geminiSummaryConclusionsFromRecords() error = %v", err)
+	}
+	if len(notQualified.Unobserved) == 0 {
+		t.Fatal("not_qualified fixture carries no unobserved cases to check")
+	}
+
+	t.Run("compliant transfer validates from a file", func(t *testing.T) {
+		t.Parallel()
+
+		path := writeGeminiNotesFile(t, geminiAdapterNotesFixture(qualified))
+		content, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read notes fixture: %v", err)
+		}
+		if err := validateGeminiAdapterNotes(string(content), qualified); err != nil {
+			t.Errorf("validateGeminiAdapterNotes() error = %v, want nil for a compliant transfer", err)
+		}
+	})
+
+	t.Run("compliant not_qualified transfer validates", func(t *testing.T) {
+		t.Parallel()
+
+		if err := validateGeminiAdapterNotes(geminiAdapterNotesFixture(notQualified), notQualified); err != nil {
+			t.Errorf("validateGeminiAdapterNotes() error = %v, want nil for the not_qualified transfer", err)
+		}
+	})
+
+	tests := []struct {
+		name        string
+		conclusions geminiSummaryConclusions
+		doctor      func(notes string) string
+	}{
+		{
+			name:        "heading out of order",
+			conclusions: qualified,
+			doctor: func(notes string) string {
+				return strings.Replace(notes,
+					"## Entry points\n\nEntry points use the generic agent-client-protocol kind with the runtime command the operator selects.\n\n## Load-bearing capability observations",
+					"## Load-bearing capability observations\n\n## Entry points\n\nEntry points use the generic agent-client-protocol kind with the runtime command the operator selects.", 1)
+			},
+		},
+		{
+			name:        "missing heading",
+			conclusions: qualified,
+			doctor: func(notes string) string {
+				return strings.Replace(notes, "## Protocol-specific observations\n\n", "", 1)
+			},
+		},
+		{
+			name:        "status label missing",
+			conclusions: qualified,
+			doctor: func(notes string) string {
+				return strings.Replace(notes,
+					"- protocol turn_disposition: Observed: usable with a bounded evidence shape",
+					"- protocol turn_disposition: usable with a bounded evidence shape", 1)
+			},
+		},
+		{
+			name:        "status label wrong",
+			conclusions: qualified,
+			doctor: func(notes string) string {
+				return strings.Replace(notes,
+					"- protocol turn_disposition: Observed: usable with a bounded evidence shape",
+					"- protocol turn_disposition: Not observed: not_observed with a bounded evidence shape", 1)
+			},
+		},
+		{
+			name:        "grade value wrong",
+			conclusions: qualified,
+			doctor: func(notes string) string {
+				return strings.Replace(notes,
+					"- protocol turn_disposition: Observed: usable with a bounded evidence shape",
+					"- protocol turn_disposition: Observed: gap with a bounded evidence shape", 1)
+			},
+		},
+		{
+			name:        "grade row the summary does not carry",
+			conclusions: qualified,
+			doctor: func(notes string) string {
+				return strings.Replace(notes,
+					"## Protocol-specific observations",
+					"- native_text tool_server_delivery: Not applicable: not_applicable with no native comparison\n\n## Protocol-specific observations", 1)
+			},
+		},
+		{
+			name:        "second eligibility line",
+			conclusions: qualified,
+			doctor: func(notes string) string {
+				return notes + "\nEligibility: qualified\n"
+			},
+		},
+		{
+			name:        "eligibility mismatch",
+			conclusions: qualified,
+			doctor: func(notes string) string {
+				return strings.Replace(notes, "Eligibility: qualified", "Eligibility: not_qualified", 1)
+			},
+		},
+		{
+			name:        "unobserved case absent from the final section",
+			conclusions: notQualified,
+			doctor: func(notes string) string {
+				entry := notQualified.Unobserved[0]
+				return strings.Replace(notes, "- "+entry+"\n", "", 1)
+			},
+		},
+		{
+			name:        "unix-only scope statement missing",
+			conclusions: qualified,
+			doctor: func(notes string) string {
+				return strings.Replace(notes, geminiNotesUnixScope, "Windows live qualification is recorded elsewhere", 1)
+			},
+		},
+		{
+			name:        "binary version value",
+			conclusions: qualified,
+			doctor: func(notes string) string {
+				return notes + "\nMeasured against gemini 0.57.0.\n"
+			},
+		},
+		{
+			name:        "measurement date",
+			conclusions: qualified,
+			doctor: func(notes string) string {
+				return notes + "\nMeasured on 2026-03-04.\n"
+			},
+		},
+		{
+			name:        "environment variable value",
+			conclusions: qualified,
+			doctor: func(notes string) string {
+				return notes + "\nGEMINI_CLI_HOME=/tmp/run-scope\n"
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if err := validateGeminiAdapterNotes(tt.doctor(geminiAdapterNotesFixture(tt.conclusions)), tt.conclusions); err == nil {
+				t.Errorf("validateGeminiAdapterNotes() = nil error, want rejection when the notes %s", tt.name)
+			}
+		})
+	}
+}
+
+// TestGeminiQualificationNotesMismatch confirms the consistency check
+// compares the notes against a freshly validated summary with exact
+// equality, rejecting stale verdicts and stale conclusions.
+func TestGeminiQualificationNotesMismatch(t *testing.T) {
+	t.Parallel()
+
+	freshFixture := qualification.NewFixture(qualification.FixtureQualified)
+	freshFixture.Finalize()
+	fresh, err := geminiSummaryConclusionsFromRecords(freshFixture.Records, qualification.VerdictQualified)
+	if err != nil {
+		t.Fatalf("geminiSummaryConclusionsFromRecords() error = %v", err)
+	}
+
+	otherFixture := qualification.NewFixture(qualification.FixtureNotQualified)
+	otherFixture.Finalize()
+	other, err := geminiSummaryConclusionsFromRecords(otherFixture.Records, qualification.VerdictNotQualified)
+	if err != nil {
+		t.Fatalf("geminiSummaryConclusionsFromRecords() error = %v", err)
+	}
+
+	t.Run("identical conclusions from an independently built fixture match", func(t *testing.T) {
+		t.Parallel()
+
+		independent := qualification.NewFixture(qualification.FixtureQualified)
+		independent.Finalize()
+		independentConclusions, err := geminiSummaryConclusionsFromRecords(independent.Records, qualification.VerdictQualified)
+		if err != nil {
+			t.Fatalf("geminiSummaryConclusionsFromRecords() error = %v", err)
+		}
+		if formatGeminiQualificationSummary(independentConclusions) != formatGeminiQualificationSummary(fresh) {
+			t.Error("two independently built qualified fixtures produced different summaries")
+		}
+		if err := validateGeminiAdapterNotes(geminiAdapterNotesFixture(independentConclusions), fresh); err != nil {
+			t.Errorf("validateGeminiAdapterNotes() error = %v, want nil for a fresh consistent rerun", err)
+		}
+	})
+
+	t.Run("notes for the other verdict mismatch", func(t *testing.T) {
+		t.Parallel()
+
+		if err := validateGeminiAdapterNotes(geminiAdapterNotesFixture(other), fresh); err == nil {
+			t.Error("validateGeminiAdapterNotes() = nil error, want mismatch when the eligibility verdict differs")
+		}
+	})
+
+	t.Run("one stale status label mismatches", func(t *testing.T) {
+		t.Parallel()
+
+		stale := strings.Replace(geminiAdapterNotesFixture(fresh),
+			"- protocol turn_disposition: Observed: usable with a bounded evidence shape",
+			"- protocol turn_disposition: Not observed: not_observed with a bounded evidence shape", 1)
+		if err := validateGeminiAdapterNotes(stale, fresh); err == nil {
+			t.Error("validateGeminiAdapterNotes() = nil error, want mismatch for a stale status label")
+		}
+	})
+
+	t.Run("an unobserved case that the fresh run observed mismatches", func(t *testing.T) {
+		t.Parallel()
+
+		if err := validateGeminiAdapterNotes(geminiAdapterNotesFixture(other), other); err != nil {
+			t.Fatalf("validateGeminiAdapterNotes() error = %v, want nil for the baseline not_qualified transfer", err)
+		}
+		restored := qualification.NewFixture(qualification.FixtureQualified)
+		restored.SetSemanticNotObserved(qualification.SurfaceProtocol, qualification.CapabilityRetryClassification, qualification.CaseUnknownOutcome)
+		restored.Finalize()
+		freshWithGap, err := geminiSummaryConclusionsFromRecords(restored.Records, qualification.VerdictNotQualified)
+		if err != nil {
+			t.Fatalf("geminiSummaryConclusionsFromRecords() error = %v", err)
+		}
+		if err := validateGeminiAdapterNotes(geminiAdapterNotesFixture(other), freshWithGap); err == nil {
+			t.Error("validateGeminiAdapterNotes() = nil error, want mismatch when the fresh summary observes a case the notes call unobserved")
+		}
+	})
+}

--- a/internal/agent/clientprotocol/gemini_qualification_policy_unix_test.go
+++ b/internal/agent/clientprotocol/gemini_qualification_policy_unix_test.go
@@ -1,0 +1,567 @@
+//go:build unix
+
+package clientprotocol
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"slices"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/sortie-ai/sortie/internal/agent/agenttest"
+	"github.com/sortie-ai/sortie/internal/agent/procutil"
+	"github.com/sortie-ai/sortie/internal/qualification"
+)
+
+// geminiProbeMarkerTimeout bounds each deterministic wait for a probe's
+// public started marker.
+const geminiProbeMarkerTimeout = 10 * time.Second
+
+// geminiQualificationWorkspace is the controlled fixture tree one live
+// run owns: a git-initialized controlled checkout the runtime's working
+// directory points at, and run-scoped HOME and GEMINI_CLI_HOME classes
+// under the same temporary root. Absolute paths never reach evidence;
+// only their classes do.
+type geminiQualificationWorkspace struct {
+	Checkout string
+	Home     string
+	CLIHome  string
+}
+
+// geminiNewQualificationWorkspace builds the controlled workspace: a
+// git checkout and two run-scoped configuration homes under t.TempDir().
+// The checkout starts with no project-scoped Gemini configuration, and
+// the workspace tests keep that a fixture fact rather than an
+// assumption.
+func geminiNewQualificationWorkspace(t *testing.T) geminiQualificationWorkspace {
+	t.Helper()
+
+	root := t.TempDir()
+	workspace := geminiQualificationWorkspace{
+		Checkout: gitInitWorkspace(t),
+		Home:     filepath.Join(root, "run-home"),
+		CLIHome:  filepath.Join(root, "run-cli-home"),
+	}
+	for _, dir := range []string{workspace.Home, workspace.CLIHome} {
+		if err := os.MkdirAll(dir, 0o750); err != nil {
+			t.Fatalf("create run-scoped home %s: %v", dir, err)
+		}
+	}
+	return workspace
+}
+
+// geminiProjectGeminiConfigNames are the project-scoped Gemini
+// configuration paths whose presence the workspace fixture forbids,
+// except for the explicit test MCP input delivered through Sortie.
+var geminiProjectGeminiConfigNames = []string{
+	"settings.json", "settings.yaml", "hooks", "extensions", "commands",
+	"mcp.json", ".mcp.json",
+}
+
+// geminiPresentProjectGeminiConfig reports every project-scoped Gemini
+// configuration path that exists under the checkout, so a fixture that
+// accidentally carries one fails rather than silently loading
+// operator-controlled configuration.
+func geminiPresentProjectGeminiConfig(checkout string) []string {
+	present := []string{}
+	entries, err := os.ReadDir(filepath.Join(checkout, ".gemini"))
+	if err != nil {
+		return nil
+	}
+	for _, entry := range entries {
+		if slices.Contains(geminiProjectGeminiConfigNames, entry.Name()) {
+			present = append(present, filepath.Join(".gemini", entry.Name()))
+		}
+	}
+	if _, err := os.Stat(filepath.Join(checkout, ".mcp.json")); err == nil {
+		present = append(present, ".mcp.json")
+	}
+	return present
+}
+
+// geminiAssertNoProjectGeminiConfig fails t when the controlled
+// checkout carries any project-scoped Gemini configuration the fixture
+// did not declare.
+func geminiAssertNoProjectGeminiConfig(t *testing.T, checkout string) {
+	t.Helper()
+	if present := geminiPresentProjectGeminiConfig(checkout); len(present) > 0 {
+		t.Errorf("controlled checkout carries undeclared project Gemini configuration: %v", present)
+	}
+}
+
+// geminiProbeSpec describes one local probe executable's whole bounded
+// behavior: its basename, whether it writes a public started marker,
+// its fixed exit code, and whether it waits after the marker.
+type geminiProbeSpec struct {
+	name     string
+	marker   bool
+	exitCode int
+	wait     bool
+}
+
+// geminiLocalProbeSpecs returns the five local probe descriptors in
+// fixed order. Every behavior comes from the probe input contracts:
+// the policy-load and permission probes perform no side effect, the
+// failing probe writes its marker and exits 23, and the cancellation
+// and transport probes write their markers and wait.
+func geminiLocalProbeSpecs() []geminiProbeSpec {
+	return []geminiProbeSpec{
+		{name: "policy-load-probe", marker: false, exitCode: 0, wait: false},
+		{name: "permission-probe", marker: false, exitCode: 0, wait: false},
+		{name: "failing-probe", marker: true, exitCode: 23, wait: false},
+		{name: "cancellation-probe", marker: true, exitCode: 0, wait: true},
+		{name: "transport-probe", marker: true, exitCode: 0, wait: true},
+	}
+}
+
+// geminiQualificationProbes carries the absolute paths of the five
+// local probe executables under the controlled workspace.
+type geminiQualificationProbes struct {
+	PolicyLoad   string
+	Permission   string
+	Failing      string
+	Cancellation string
+	Transport    string
+}
+
+// paths returns the five probe absolute paths in fixed order.
+func (p geminiQualificationProbes) paths() []string {
+	return []string{p.PolicyLoad, p.Permission, p.Failing, p.Cancellation, p.Transport}
+}
+
+// names returns the five probe basenames, the only helper process
+// basenames the workspace-security allowlist admits.
+func (p geminiQualificationProbes) names() []string {
+	names := make([]string, 0, len(p.paths()))
+	for _, path := range p.paths() {
+		names = append(names, filepath.Base(path))
+	}
+	return names
+}
+
+// geminiWriteProbeExecutables writes the five local probe executables
+// under the controlled workspace and returns their absolute paths.
+// Every probe performs no network access and no mutation beyond its
+// own started marker.
+func geminiWriteProbeExecutables(t *testing.T, workspace string) geminiQualificationProbes {
+	t.Helper()
+
+	write := func(spec geminiProbeSpec) string {
+		t.Helper()
+		var body strings.Builder
+		if spec.marker {
+			fmt.Fprintf(&body, "echo started > '%s'\n", geminiProbeMarkerPath(filepath.Join(workspace, spec.name)))
+		}
+		if spec.wait {
+			body.WriteString("sleep 30\n")
+		} else {
+			fmt.Fprintf(&body, "exit %d\n", spec.exitCode)
+		}
+		return agenttest.WriteScript(t, workspace, spec.name, body.String())
+	}
+
+	written := make([]string, 0, 5)
+	for _, spec := range geminiLocalProbeSpecs() {
+		written = append(written, write(spec))
+	}
+	return geminiQualificationProbes{
+		PolicyLoad:   written[0],
+		Permission:   written[1],
+		Failing:      written[2],
+		Cancellation: written[3],
+		Transport:    written[4],
+	}
+}
+
+// geminiProbeMarkerPath returns a probe's public started-marker path.
+func geminiProbeMarkerPath(probePath string) string {
+	return probePath + ".started"
+}
+
+// geminiUniqueMarker generates one unique, non-secret deny marker for
+// the policy precondition. It is a random public token: nothing about
+// a credential, session, or host value leaks through it.
+func geminiUniqueMarker() string {
+	var raw [8]byte
+	if _, err := rand.Read(raw[:]); err != nil {
+		return "sortie-qualification-deny-marker-unavailable"
+	}
+	return "sortie-qualification-deny-" + hex.EncodeToString(raw[:])
+}
+
+// geminiWriteQualificationPolicy writes the run-scoped policy file with
+// exactly the five high-priority rules the qualification contract
+// defines: deny with a unique marker on the policy-load probe,
+// ask_user on the permission probe, and allow on the failing,
+// cancellation, and transport probes. No other command is allowed by
+// this policy. It returns the policy path and the deny marker.
+func geminiWriteQualificationPolicy(t *testing.T, dir string, probes geminiQualificationProbes) (path string, denyMarker string) {
+	t.Helper()
+
+	denyMarker = geminiUniqueMarker()
+	rules := []struct {
+		prefix   string
+		decision string
+	}{
+		{probes.PolicyLoad, "deny"},
+		{probes.Permission, "ask_user"},
+		{probes.Failing, "allow"},
+		{probes.Cancellation, "allow"},
+		{probes.Transport, "allow"},
+	}
+
+	var body strings.Builder
+	body.WriteString("# Run-scoped qualification policy: five high-priority rules and nothing else.\n")
+	for _, rule := range rules {
+		fmt.Fprintf(&body,
+			"\n[[rule]]\ntoolName = \"run_shell_command\"\ncommandPrefix = %q\ndecision = %q\npriority = 100\n",
+			rule.prefix, rule.decision)
+		if rule.decision == "deny" {
+			fmt.Fprintf(&body, "denyMessage = %q\n", denyMarker)
+		}
+	}
+
+	path = filepath.Join(dir, "qualification-policy.toml")
+	if err := os.WriteFile(path, []byte(body.String()), 0o600); err != nil {
+		t.Fatalf("write qualification policy: %v", err)
+	}
+	return path, denyMarker
+}
+
+// geminiQualificationLaunchArgv builds one qualification launch's argv.
+// Every qualification launch carries exactly the operator-selected
+// model, the default approval mode, the run-scoped policy, and
+// --skip-trust; the protocol surface differs by --acp and the native
+// surfaces by --output-format plus the headless --prompt entry point.
+// No other flag is appended to any qualification launch.
+func geminiQualificationLaunchArgv(config geminiQualificationConfig, surface qualification.Surface, prompt string, policyPath string) []string {
+	argv := []string{
+		config.CommandPath,
+		"--model", config.Model,
+		"--approval-mode", "default",
+		"--policy", policyPath,
+		"--skip-trust",
+	}
+	switch surface {
+	case qualification.SurfaceProtocol:
+		return append(argv, "--acp")
+	case qualification.SurfaceNativeText:
+		return append(argv, "--output-format", "text", "--prompt", prompt)
+	case qualification.SurfaceNativeJSON:
+		return append(argv, "--output-format", "json", "--prompt", prompt)
+	case qualification.SurfaceNativeStreamJSON:
+		return append(argv, "--output-format", "stream-json", "--prompt", prompt)
+	}
+	return argv
+}
+
+// geminiQualificationVersionArgv builds the one-shot version capture's
+// argv. It is a coordinate-resolution command, not a qualification
+// launch, so it carries none of the qualification flags.
+func geminiQualificationVersionArgv(config geminiQualificationConfig) []string {
+	return []string{config.CommandPath, "--version"}
+}
+
+// TestGeminiQualificationPolicyFixture confirms the run-scoped policy
+// file carries exactly the five high-priority rules, with the unique
+// deny marker on the policy-load probe, ask_user on the permission
+// probe, allow on the three behavioral probes, and no rule for any
+// other command. It also pins the qualification launch argv shape.
+func TestGeminiQualificationPolicyFixture(t *testing.T) {
+	t.Parallel()
+
+	workspace := geminiNewQualificationWorkspace(t)
+	probes := geminiWriteProbeExecutables(t, workspace.Checkout)
+	policyPath, denyMarker := geminiWriteQualificationPolicy(t, t.TempDir(), probes)
+
+	t.Run("policy carries exactly the five rules", func(t *testing.T) {
+		t.Parallel()
+
+		raw, err := os.ReadFile(policyPath)
+		if err != nil {
+			t.Fatalf("read policy fixture: %v", err)
+		}
+		content := string(raw)
+		if got := strings.Count(content, "[[rule]]"); got != 5 {
+			t.Errorf("policy rule count = %d, want exactly 5", got)
+		}
+		for i, prefix := range []string{probes.PolicyLoad, probes.Permission, probes.Failing, probes.Cancellation, probes.Transport} {
+			if !strings.Contains(content, fmt.Sprintf("commandPrefix = %q", prefix)) {
+				t.Errorf("policy carries no rule for probe %d", i+1)
+			}
+		}
+		if got := strings.Count(content, `decision = "deny"`); got != 1 {
+			t.Errorf("deny decision count = %d, want exactly 1", got)
+		}
+		if got := strings.Count(content, `decision = "ask_user"`); got != 1 {
+			t.Errorf("ask_user decision count = %d, want exactly 1", got)
+		}
+		if got := strings.Count(content, `decision = "allow"`); got != 3 {
+			t.Errorf("allow decision count = %d, want exactly 3", got)
+		}
+		if got := strings.Count(content, "priority = 100"); got != 5 {
+			t.Errorf("high-priority rule count = %d, want 5", got)
+		}
+		if !strings.Contains(content, fmt.Sprintf("denyMessage = %q", denyMarker)) {
+			t.Errorf("policy carries no deny message equal to the generated marker")
+		}
+		if strings.Count(content, denyMarker) != 1 {
+			t.Errorf("deny marker appears %d times, want one unique marker", strings.Count(content, denyMarker))
+		}
+	})
+
+	t.Run("deny marker is unique per run and is a bare public token", func(t *testing.T) {
+		t.Parallel()
+
+		_, otherMarker := geminiWriteQualificationPolicy(t, t.TempDir(), probes)
+		if otherMarker == denyMarker {
+			t.Error("two policy fixtures generated the same deny marker, want a unique marker per run")
+		}
+		if strings.ContainsAny(denyMarker, " \t=/\\") {
+			t.Errorf("deny marker %q is not a bare token", denyMarker)
+		}
+	})
+
+	t.Run("protocol launch argv carries exactly the qualification flags", func(t *testing.T) {
+		t.Parallel()
+
+		config := geminiQualificationConfig{CommandPath: "/opt/gemini", Model: "gemini-fixture-model"}
+		got := geminiQualificationLaunchArgv(config, qualification.SurfaceProtocol, "unused-prompt", policyPath)
+		want := []string{
+			config.CommandPath,
+			"--model", config.Model,
+			"--approval-mode", "default",
+			"--policy", policyPath,
+			"--skip-trust",
+			"--acp",
+		}
+		if !slices.Equal(got, want) {
+			t.Errorf("protocol argv = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("native launch argv differs only by output format and prompt", func(t *testing.T) {
+		t.Parallel()
+
+		config := geminiQualificationConfig{CommandPath: "/opt/gemini", Model: "gemini-fixture-model"}
+		prompt := "Reply with exactly SORTIE_BASELINE_OK and do not call any tool."
+		surfaces := []struct {
+			surface qualification.Surface
+			format  string
+		}{
+			{qualification.SurfaceNativeText, "text"},
+			{qualification.SurfaceNativeJSON, "json"},
+			{qualification.SurfaceNativeStreamJSON, "stream-json"},
+		}
+		for _, tt := range surfaces {
+			argv := geminiQualificationLaunchArgv(config, tt.surface, prompt, policyPath)
+			want := []string{
+				config.CommandPath,
+				"--model", config.Model,
+				"--approval-mode", "default",
+				"--policy", policyPath,
+				"--skip-trust",
+				"--output-format", tt.format,
+				"--prompt", prompt,
+			}
+			if !slices.Equal(argv, want) {
+				t.Errorf("%s argv = %v, want %v", tt.surface, argv, want)
+			}
+			if slices.Contains(argv, "--acp") {
+				t.Errorf("%s argv carries the protocol-only --acp flag: %v", tt.surface, argv)
+			}
+		}
+	})
+
+	t.Run("version capture argv carries no qualification flag", func(t *testing.T) {
+		t.Parallel()
+
+		config := geminiQualificationConfig{CommandPath: "/opt/gemini"}
+		argv := geminiQualificationVersionArgv(config)
+		if !slices.Equal(argv, []string{"/opt/gemini", "--version"}) {
+			t.Errorf("version argv = %v, want only the executable and --version", argv)
+		}
+	})
+}
+
+// TestGeminiQualificationWorkspaceFixture confirms the controlled
+// workspace: a git checkout, run-scoped HOME and GEMINI_CLI_HOME under
+// the same temporary root, and no project-scoped Gemini configuration
+// before launch.
+func TestGeminiQualificationWorkspaceFixture(t *testing.T) {
+	t.Parallel()
+
+	workspace := geminiNewQualificationWorkspace(t)
+
+	t.Run("checkout is a git work tree", func(t *testing.T) {
+		t.Parallel()
+
+		if _, err := os.Stat(filepath.Join(workspace.Checkout, ".git")); err != nil {
+			t.Errorf("stat .git: %v", err)
+		}
+	})
+
+	t.Run("home coordinates are run-scoped temporary classes", func(t *testing.T) {
+		t.Parallel()
+
+		if filepath.Dir(workspace.Home) != filepath.Dir(workspace.CLIHome) {
+			t.Errorf("run-scoped homes resolve under different roots: %q vs %q",
+				filepath.Dir(workspace.Home), filepath.Dir(workspace.CLIHome))
+		}
+		for _, dir := range []string{workspace.Home, workspace.CLIHome} {
+			if _, err := os.Stat(dir); err != nil {
+				t.Errorf("run-scoped home class does not exist: %v", err)
+			}
+		}
+	})
+
+	t.Run("checkout carries no project-scoped Gemini configuration", func(t *testing.T) {
+		t.Parallel()
+
+		geminiAssertNoProjectGeminiConfig(t, workspace.Checkout)
+	})
+
+	t.Run("a planted configuration is detected", func(t *testing.T) {
+		t.Parallel()
+
+		planted := geminiNewQualificationWorkspace(t)
+		if err := os.MkdirAll(filepath.Join(planted.Checkout, ".gemini"), 0o750); err != nil {
+			t.Fatalf("plant .gemini: %v", err)
+		}
+		for _, name := range []string{"settings.json", "settings.yaml", "mcp.json"} {
+			path := filepath.Join(planted.Checkout, ".gemini", name)
+			if err := os.WriteFile(path, []byte("# planted fixture configuration\n"), 0o600); err != nil {
+				t.Fatalf("plant %s: %v", name, err)
+			}
+		}
+		present := geminiPresentProjectGeminiConfig(planted.Checkout)
+		want := []string{".gemini/mcp.json", ".gemini/settings.json", ".gemini/settings.yaml"}
+		if !slices.Equal(present, want) {
+			t.Errorf("geminiPresentProjectGeminiConfig() = %v, want %v", present, want)
+		}
+	})
+}
+
+// TestGeminiQualificationLocalProbeFixtures confirms the five local
+// probe executables exist under the controlled workspace and perform
+// exactly their assigned bounded behavior: no side effect for the
+// policy-load and permission probes, marker plus fixed exit 23 for the
+// failing probe, and marker plus a bounded wait for the cancellation
+// and transport probes. The wait probes stay sequential so each owns
+// its process group alone.
+func TestGeminiQualificationLocalProbeFixtures(t *testing.T) {
+	workspace := geminiNewQualificationWorkspace(t)
+	probes := geminiWriteProbeExecutables(t, workspace.Checkout)
+	specs := geminiLocalProbeSpecs()
+
+	t.Run("exactly five probe descriptors", func(t *testing.T) {
+		t.Parallel()
+
+		if len(specs) != 5 {
+			t.Fatalf("probe descriptor count = %d, want 5", len(specs))
+		}
+		wantNames := []string{"policy-load-probe", "permission-probe", "failing-probe", "cancellation-probe", "transport-probe"}
+		got := make([]string, 0, len(specs))
+		for _, spec := range specs {
+			got = append(got, spec.name)
+		}
+		if !slices.Equal(got, wantNames) {
+			t.Errorf("probe names = %v, want %v", got, wantNames)
+		}
+	})
+
+	t.Run("probe executables live under the controlled workspace", func(t *testing.T) {
+		t.Parallel()
+
+		for _, path := range probes.paths() {
+			if filepath.Dir(path) != workspace.Checkout {
+				t.Errorf("probe %s lives outside the controlled checkout", filepath.Base(path))
+			}
+			if info, err := os.Stat(path); err != nil || info.IsDir() {
+				t.Errorf("probe %s is not an executable file: %v", filepath.Base(path), err)
+			}
+		}
+		if got := probes.names(); len(got) != 5 || slices.Contains(got, "") {
+			t.Errorf("probe allowlist basenames = %v, want five basenames", got)
+		}
+	})
+
+	for _, spec := range specs {
+		t.Run("behavior of "+spec.name, func(t *testing.T) {
+			// Sequential: this subtest launches and reaps its own probe
+			// process group.
+			path := filepath.Join(workspace.Checkout, spec.name)
+			markerPath := geminiProbeMarkerPath(path)
+
+			cmd := execGeminiFixtureProbe(t, path, workspace.Checkout)
+			groupPID := cmd.Process.Pid
+
+			if spec.wait {
+				waitForFile(t, markerPath, geminiProbeMarkerTimeout)
+				if err := procutil.SignalProcessGroup(groupPID, 0); err != nil {
+					t.Fatalf("wait probe group died before cancellation: %v", err)
+				}
+				_ = procutil.SignalProcessGroup(groupPID, syscall.SIGKILL)
+				_, _ = cmd.Process.Wait()
+				geminiAwaitProcessGroupAbsence(t, groupPID)
+				return
+			}
+
+			waitErr := cmd.Wait()
+			exitCode := geminiProbeExitCode(waitErr)
+			if exitCode < 0 {
+				t.Fatalf("probe %s did not terminate cleanly: %v", spec.name, waitErr)
+			}
+			_, markerErr := os.Stat(markerPath)
+			switch {
+			case spec.marker && markerErr != nil:
+				t.Errorf("probe %s wrote no started marker: %v", spec.name, markerErr)
+			case !spec.marker && markerErr == nil:
+				t.Errorf("probe %s wrote a marker, want none", spec.name)
+			}
+			if exitCode != spec.exitCode {
+				t.Errorf("probe %s exit code = %d, want %d", spec.name, exitCode, spec.exitCode)
+			}
+		})
+	}
+}
+
+// execGeminiFixtureProbe starts one probe executable inside the
+// checkout with its own process group, so its whole group is
+// attributable and cleanable. The registered cleanup kills the group
+// and reaps whatever the test itself did not wait for.
+func execGeminiFixtureProbe(t *testing.T, path, dir string) *exec.Cmd {
+	t.Helper()
+	cmd := exec.Command(path) //nolint:gosec // the probe path is written by this test under its own temp workspace
+	cmd.Dir = dir
+	procutil.SetProcessGroup(cmd)
+	cmd.Env = []string{"PATH=" + os.Getenv("PATH")}
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start probe %s: %v", filepath.Base(path), err)
+	}
+	t.Cleanup(func() {
+		_ = procutil.SignalProcessGroup(cmd.Process.Pid, syscall.SIGKILL)
+		_, _ = cmd.Process.Wait()
+	})
+	return cmd
+}
+
+// geminiProbeExitCode extracts the exit code from a Wait error, or -1
+// when the process is still running or the error is not an exit.
+func geminiProbeExitCode(err error) int {
+	if err == nil {
+		return 0
+	}
+	if exitErr, ok := errors.AsType[*exec.ExitError](err); ok {
+		return exitErr.ExitCode()
+	}
+	return -1
+}

--- a/internal/agent/clientprotocol/gemini_qualification_process_unix_test.go
+++ b/internal/agent/clientprotocol/gemini_qualification_process_unix_test.go
@@ -1,0 +1,567 @@
+//go:build unix
+
+package clientprotocol
+
+import (
+	"errors"
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"slices"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+	"unicode/utf8"
+
+	"github.com/sortie-ai/sortie/internal/agent/agenttest"
+	"github.com/sortie-ai/sortie/internal/agent/procutil"
+	"github.com/sortie-ai/sortie/internal/qualification"
+)
+
+// geminiQualificationShutdownDeadline is the shared 30-second shutdown
+// bound: once it starts, every captured process group is polled until
+// the kernel reports its absence or this deadline expires, whichever
+// comes first.
+const geminiQualificationShutdownDeadline = 30 * time.Second
+
+// geminiKillGroupAndReap terminates a tracked process's group and reaps
+// its leader, so the oracle's poll observes a genuinely empty group
+// rather than a zombie that still holds it.
+func geminiKillGroupAndReap(cmd *exec.Cmd) {
+	_ = procutil.SignalProcessGroup(cmd.Process.Pid, syscall.SIGKILL)
+	_, _ = cmd.Process.Wait()
+}
+
+// geminiProcessGroupPresent reports whether the kernel still has a
+// process group led by pgid, using the Unix signal-zero liveness
+// primitive on the exact negative PGID. A nil result with no error
+// means a member survives; a query error other than group absence is
+// a runtime failure, never a clean absence.
+func geminiProcessGroupPresent(pgid int) (bool, error) {
+	err := syscall.Kill(-pgid, syscall.Signal(0))
+	switch {
+	case err == nil:
+		return true, nil
+	case errors.Is(err, syscall.ESRCH):
+		return false, nil
+	default:
+		return false, fmt.Errorf("signal-zero query for the launched group: %w", err)
+	}
+}
+
+// geminiAwaitProcessGroupAbsence polls the exact negative PGID with the
+// signal-zero primitive until the group is absent or the shared 30
+// second shutdown deadline elapses. A survivor or a query error fails
+// the test; the caller records the outcome in the cleanup evidence
+// without ever naming the PGID.
+func geminiAwaitProcessGroupAbsence(t *testing.T, pgid int) {
+	t.Helper()
+
+	deadline := time.Now().Add(geminiQualificationShutdownDeadline)
+	for {
+		present, err := geminiProcessGroupPresent(pgid)
+		if err != nil {
+			t.Fatalf("process-group liveness query failed: %v", err)
+		}
+		if !present {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("a member of the launched process group survived the cleanup deadline")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+// geminiProcessGroupTracker is the run-owned record of every process
+// group a qualification run launched. The tracker holds captured PGIDs
+// only; its evidence never names them.
+type geminiProcessGroupTracker struct {
+	groups []int
+}
+
+// register captures one launched runtime's process-group identifier.
+// The PGID is the group leader's PID, which procutil.SetProcessGroup
+// establishes at start.
+func (tr *geminiProcessGroupTracker) register(groupPID int) {
+	if !slices.Contains(tr.groups, groupPID) {
+		tr.groups = append(tr.groups, groupPID)
+	}
+}
+
+// registerCmd starts cmd in its own process group through the
+// production launch contract and captures its group. It returns the
+// started command so the test can reap its leader after killing the
+// group, which the oracle needs: an unreaped zombie still holds the
+// group.
+func (tr *geminiProcessGroupTracker) registerCmd(t *testing.T, cmd *exec.Cmd) *exec.Cmd {
+	t.Helper()
+	procutil.SetProcessGroup(cmd)
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start tracked process: %v", err)
+	}
+	tr.register(cmd.Process.Pid)
+	t.Cleanup(func() {
+		_ = procutil.SignalProcessGroup(cmd.Process.Pid, syscall.SIGKILL)
+		_, _ = cmd.Process.Wait()
+	})
+	return cmd
+}
+
+// count returns how many groups the run captured.
+func (tr *geminiProcessGroupTracker) count() int {
+	return len(tr.groups)
+}
+
+// geminiProcessMember is one process-group member observed at
+// inventory time, recorded by process-group membership and executable
+// basename only. ScriptBasenames carries the basenames of argument
+// tokens that name files, so a shebang-interpreted probe script is
+// attributable to its own basename rather than its interpreter's.
+type geminiProcessMember struct {
+	PID             int
+	PPID            int
+	PGID            int
+	ScriptBasenames []string
+}
+
+// geminiListProcessGroupMembers inventories every visible process in
+// the group led by pgid through one bounded ps call. It reports
+// executable basenames and group membership only, never command lines
+// or argument values.
+func geminiListProcessGroupMembers(t *testing.T, pgid int) []geminiProcessMember {
+	t.Helper()
+
+	cmd := exec.Command("ps", "-axo", "pid=,pgid=,ppid=,args=") //nolint:gosec // fixed argument vector, no user input
+	output, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("inventory process group members: %v", err)
+	}
+
+	var members []geminiProcessMember
+	for line := range strings.SplitSeq(string(output), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 4 {
+			continue
+		}
+		pid, pidErr := strconv.Atoi(fields[0])
+		memberPGID, pgidErr := strconv.Atoi(fields[1])
+		ppid, ppidErr := strconv.Atoi(fields[2])
+		if pidErr != nil || pgidErr != nil || ppidErr != nil || memberPGID != pgid {
+			continue
+		}
+		member := geminiProcessMember{PID: pid, PPID: ppid, PGID: memberPGID}
+		member.ScriptBasenames = append(member.ScriptBasenames, filepath.Base(fields[3]))
+		// When the process is a shebang script, the argument token
+		// after the interpreter names the script itself; recording its
+		// basename keeps the member attributable without recording any
+		// argument value.
+		if len(fields) > 4 && strings.ContainsRune(fields[4], '/') {
+			member.ScriptBasenames = append(member.ScriptBasenames, filepath.Base(fields[4]))
+		}
+		members = append(members, member)
+	}
+	return members
+}
+
+// geminiUnexpectedHelpers returns the identity basenames among a
+// group's members that the qualification allowlist does not admit. A
+// member is admitted when its own identity matches the allowlist or
+// when its direct parent inside the group is an admitted member, which
+// attributes a probe's or the runtime's own child processes to their
+// declared parent. Anything else is an unexpected helper: a runtime
+// failure until it is explained and contained, and the check never
+// expands the allowlist to make it pass.
+func geminiUnexpectedHelpers(t *testing.T, pgid int, allowedBasenames []string) []string {
+	t.Helper()
+
+	members := geminiListProcessGroupMembers(t, pgid)
+	admitted := map[int]bool{}
+	for _, member := range members {
+		if slices.ContainsFunc(member.ScriptBasenames, func(name string) bool {
+			return slices.Contains(allowedBasenames, name)
+		}) {
+			admitted[member.PID] = true
+		}
+	}
+
+	var unexpected []string
+	for _, member := range members {
+		if admitted[member.PID] || admitted[member.PPID] {
+			continue
+		}
+		unexpected = append(unexpected, member.ScriptBasenames[0])
+	}
+	return unexpected
+}
+
+// geminiWorkspaceSecurityFacts carries the six fixture facts and
+// observations the workspace_security scenario records. It holds
+// names, classes, and basenames only: no absolute path, environment
+// value, credential, or prompt is ever serialized.
+type geminiWorkspaceSecurityFacts struct {
+	// PresentProjectConfig lists the project-scoped Gemini
+	// configuration paths found in the controlled checkout before
+	// launch; a compliant fixture records none.
+	PresentProjectConfig []string
+
+	// HomeClass and CLIHomeClass record the configuration-home
+	// classes, run_scoped_temp for this fixture.
+	HomeClass    string
+	CLIHomeClass string
+
+	// EnvNames are the allowlisted environment variable names, sorted
+	// lexicographically, with every value omitted.
+	EnvNames []string
+
+	// SkipTrustUsed records that the qualification launch carried
+	// --skip-trust; TrustPromptObserved records whether a trust prompt
+	// or safe-mode refusal was nevertheless observed.
+	SkipTrustUsed       bool
+	TrustPromptObserved bool
+
+	// MemberBasenames are the process-group member basenames observed
+	// at the pre-turn baseline and at cleanup.
+	MemberBasenames []string
+
+	// UnexpectedHelpers lists helper basenames outside the allowlist;
+	// a non-empty list is a runtime failure the evidence reports
+	// without expanding the allowlist.
+	UnexpectedHelpers []string
+}
+
+// geminiWorkspaceSecurityDetailBudget is the 256-Unicode-code-point
+// bound the evidence contract places on every detail string.
+const geminiWorkspaceSecurityDetailBudget = 256
+
+// geminiWorkspaceSecurityDetail renders the bounded detail the single
+// workspace_security record carries: a config-name list, the two home
+// classes, the sorted allowlisted names, the trust facts, and member
+// basenames. The allowlisted environment names are recorded while they
+// fit the detail bound and elided behind their count otherwise; no
+// value is ever included.
+func geminiWorkspaceSecurityDetail(facts geminiWorkspaceSecurityFacts) string {
+	var b strings.Builder
+	if len(facts.PresentProjectConfig) == 0 {
+		b.WriteString("no project-scoped gemini configuration in the controlled checkout")
+	} else {
+		fmt.Fprintf(&b, "present project configuration: %s", strings.Join(facts.PresentProjectConfig, ", "))
+	}
+	fmt.Fprintf(&b, "; homes %s and %s", facts.HomeClass, facts.CLIHomeClass)
+
+	names := strings.Join(facts.EnvNames, ",")
+	if !geminiFitsDetail(&b, names) {
+		names = fmt.Sprintf("%d allowlisted names", len(facts.EnvNames))
+	}
+	fmt.Fprintf(&b, "; allowlisted env names %s", names)
+
+	if facts.SkipTrustUsed {
+		b.WriteString("; --skip-trust used")
+	} else {
+		b.WriteString("; --skip-trust missing")
+	}
+	if facts.TrustPromptObserved {
+		b.WriteString("; trust prompt observed")
+	} else {
+		b.WriteString("; no trust prompt observed")
+	}
+
+	members := strings.Join(facts.MemberBasenames, ",")
+	if !geminiFitsDetail(&b, members) {
+		members = fmt.Sprintf("%d members", len(facts.MemberBasenames))
+	}
+	fmt.Fprintf(&b, "; member basenames %s", members)
+
+	if len(facts.UnexpectedHelpers) > 0 {
+		fmt.Fprintf(&b, "; unexpected helper %s", strings.Join(facts.UnexpectedHelpers, ","))
+	} else {
+		b.WriteString("; no unexpected helper")
+	}
+
+	detail := b.String()
+	if points := utf8.RuneCountInString(detail); points > geminiWorkspaceSecurityDetailBudget {
+		detail = string([]rune(detail)[:geminiWorkspaceSecurityDetailBudget])
+	}
+	return detail
+}
+
+// geminiFitsDetail reports whether appending separator plus value keeps
+// the builder within the detail bound.
+func geminiFitsDetail(b *strings.Builder, value string) bool {
+	return utf8.RuneCountInString(b.String())+1+utf8.RuneCountInString(value) <= geminiWorkspaceSecurityDetailBudget
+}
+
+// geminiWorkspaceSecurityRecord builds the single workspace_security
+// scenario record from the fixture facts. Its verdict is pass only
+// when no project configuration was present, no trust prompt was
+// observed, and no unexpected helper appeared; every other outcome
+// reports runtime_failed with not_observed rather than a gap claim
+// about the runtime.
+func geminiWorkspaceSecurityRecord(facts geminiWorkspaceSecurityFacts) qualification.Record {
+	rec := qualification.Record{
+		SchemaVersion: 1,
+		ObservedAt:    qualification.FixtureTime,
+		Scenario:      qualification.ScenarioWorkspaceSecurity,
+		Surface:       qualification.SurfaceAggregate,
+		Capability:    qualification.CapabilityWorkspaceSecurity,
+		Source:        qualification.SourceProcessObservation,
+		InputID:       qualification.InputSecurity,
+		EvidencePath:  new("/workspace/settings"),
+		Detail:        geminiWorkspaceSecurityDetail(facts),
+	}
+	switch {
+	case len(facts.PresentProjectConfig) == 0 && !facts.TrustPromptObserved && len(facts.UnexpectedHelpers) == 0:
+		rec.Grade = qualification.GradeUsable
+		rec.Outcome = qualification.OutcomePass
+	default:
+		rec.Grade = qualification.GradeNotObserved
+		rec.Outcome = qualification.OutcomeRuntimeFailed
+	}
+	return rec
+}
+
+// geminiProcessCleanupRecord builds the single process_cleanup record
+// after bounded liveness checks for every captured Unix process group.
+// Its detail reports only checked_groups=<count>, never a PGID, and
+// its verdict is pass only when every group satisfied the absence
+// oracle within the shared shutdown deadline.
+func geminiProcessCleanupRecord(groups int, survivors bool) qualification.Record {
+	rec := qualification.Record{
+		SchemaVersion: 1,
+		ObservedAt:    qualification.FixtureTime,
+		Scenario:      qualification.ScenarioProcessCleanup,
+		Surface:       qualification.SurfaceAggregate,
+		Capability:    qualification.CapabilityProcessCleanup,
+		Source:        qualification.SourceProcessObservation,
+		InputID:       qualification.InputCleanup,
+		EvidencePath:  new("process_group.liveness"),
+		Detail:        fmt.Sprintf("checked_groups=%d", groups),
+	}
+	if survivors {
+		rec.Grade = qualification.GradeNotObserved
+		rec.Outcome = qualification.OutcomeRuntimeFailed
+	} else {
+		rec.Grade = qualification.GradeUsable
+		rec.Outcome = qualification.OutcomePass
+	}
+	return rec
+}
+
+// TestGeminiQualificationProcessGroupAbsenceOracle confirms the exact
+// negative-PGID oracle: a live group is present, a killed single-member
+// group drains to absence within the shared deadline, and a group
+// whose leader dies while a grandchild keeps the group alive still
+// reports present until the whole group is terminated.
+func TestGeminiQualificationProcessGroupAbsenceOracle(t *testing.T) {
+	t.Parallel()
+
+	t.Run("a live group is present", func(t *testing.T) {
+		t.Parallel()
+
+		tracker := &geminiProcessGroupTracker{}
+		tracker.registerCmd(t, exec.Command("sleep", "5")) //nolint:gosec // bounded fake local process
+		if got := tracker.count(); got != 1 {
+			t.Fatalf("tracked group count = %d, want 1", got)
+		}
+		present, err := geminiProcessGroupPresent(tracker.groups[0])
+		if err != nil {
+			t.Fatalf("geminiProcessGroupPresent() error = %v, want nil", err)
+		}
+		if !present {
+			t.Error("geminiProcessGroupPresent() = false for a live group, want true")
+		}
+	})
+
+	t.Run("a killed group drains to absence within the deadline", func(t *testing.T) {
+		t.Parallel()
+
+		tracker := &geminiProcessGroupTracker{}
+		cmd := tracker.registerCmd(t, exec.Command("sleep", "60")) //nolint:gosec // bounded fake local process killed below
+		pgid := tracker.groups[0]
+		geminiKillGroupAndReap(cmd)
+		geminiAwaitProcessGroupAbsence(t, pgid)
+		if present, err := geminiProcessGroupPresent(pgid); present || err != nil {
+			t.Errorf("geminiProcessGroupPresent() = %v, %v, want false, nil after cleanup", present, err)
+		}
+	})
+
+	t.Run("a surviving grandchild keeps the group present", func(t *testing.T) {
+		t.Parallel()
+
+		tracker := &geminiProcessGroupTracker{}
+		// The leader forks a grandchild into the same group and exits;
+		// the group survives while the grandchild does.
+		script := agenttest.WriteScript(t, t.TempDir(), "leader.sh", "sleep 60 &\nexit 0\n")
+		cmd := tracker.registerCmd(t, exec.Command(script)) //nolint:gosec // test-owned script under the test's temp directory
+		pgid := tracker.groups[0]
+
+		// A bounded settle lets the leader fork and exit before the
+		// first liveness check.
+		time.Sleep(50 * time.Millisecond)
+		if present, err := geminiProcessGroupPresent(pgid); err != nil || !present {
+			t.Fatalf("geminiProcessGroupPresent() = %v, %v, want the group alive while the grandchild survives", present, err)
+		}
+		if err := procutil.SignalProcessGroup(pgid, syscall.SIGKILL); err != nil {
+			t.Fatalf("SignalProcessGroup(SIGKILL) error = %v", err)
+		}
+		_, _ = cmd.Process.Wait()
+		geminiAwaitProcessGroupAbsence(t, pgid)
+	})
+
+	t.Run("the cleanup record reports only the group count", func(t *testing.T) {
+		t.Parallel()
+
+		rec := geminiProcessCleanupRecord(9, false)
+		if rec.Detail != "checked_groups=9" {
+			t.Errorf("cleanup detail = %q, want only checked_groups=9", rec.Detail)
+		}
+		if rec.Outcome != qualification.OutcomePass || rec.Grade != qualification.GradeUsable {
+			t.Errorf("cleanup record = %s/%s, want pass/usable after clean cleanup", rec.Outcome, rec.Grade)
+		}
+		survivor := geminiProcessCleanupRecord(9, true)
+		if survivor.Outcome != qualification.OutcomeRuntimeFailed || survivor.Grade != qualification.GradeNotObserved {
+			t.Errorf("survivor cleanup record = %s/%s, want runtime_failed/not_observed", survivor.Outcome, survivor.Grade)
+		}
+		if !strings.Contains(survivor.Detail, "checked_groups=9") || strings.Contains(survivor.Detail, "pgid") {
+			t.Errorf("survivor cleanup detail = %q, want the count and no group identifier", survivor.Detail)
+		}
+	})
+}
+
+// TestGeminiQualificationUnexpectedHelperFails confirms the helper
+// allowlist check: a declared local probe running in its own group is
+// admitted, and a helper outside the runtime, the five probes, and the
+// MCP server fails rather than expanding the allowlist.
+func TestGeminiQualificationUnexpectedHelperFails(t *testing.T) {
+	t.Parallel()
+
+	workspace := geminiNewQualificationWorkspace(t)
+	probes := geminiWriteProbeExecutables(t, workspace.Checkout)
+	allowed := append(probes.names(), "gemini", "mcp-fixture-server")
+
+	t.Run("a declared probe is admitted", func(t *testing.T) {
+		t.Parallel()
+
+		tracker := &geminiProcessGroupTracker{}
+		// The cancellation probe writes its marker and then waits, so
+		// the group is alive and inventoriable at check time.
+		cmd := tracker.registerCmd(t, exec.Command(probes.Cancellation)) //nolint:gosec // test-owned probe under the test's temp workspace
+		pgid := tracker.groups[0]
+		waitForFile(t, geminiProbeMarkerPath(probes.Cancellation), geminiProbeMarkerTimeout)
+
+		if unexpected := geminiUnexpectedHelpers(t, pgid, allowed); len(unexpected) != 0 {
+			t.Errorf("geminiUnexpectedHelpers() = %v, want none for a declared probe and its own wait child", unexpected)
+		}
+		geminiKillGroupAndReap(cmd)
+		geminiAwaitProcessGroupAbsence(t, pgid)
+	})
+
+	t.Run("an undeclared helper is reported", func(t *testing.T) {
+		t.Parallel()
+
+		tracker := &geminiProcessGroupTracker{}
+		cmd := tracker.registerCmd(t, exec.Command("sleep", "60")) //nolint:gosec // bounded fake local process killed below
+		pgid := tracker.groups[0]
+
+		unexpected := geminiUnexpectedHelpers(t, pgid, allowed)
+		if len(unexpected) == 0 {
+			t.Fatal("geminiUnexpectedHelpers() = none, want the undeclared helper reported")
+		}
+		if !slices.Contains(unexpected, "sleep") {
+			t.Errorf("unexpected helpers = %v, want the undeclared helper's basename", unexpected)
+		}
+
+		// The unexpected helper is contained with the same bounded
+		// cleanup, and the absence oracle still holds afterward.
+		geminiKillGroupAndReap(cmd)
+		geminiAwaitProcessGroupAbsence(t, pgid)
+	})
+}
+
+// TestGeminiQualificationWorkspaceSecurityObservation confirms the
+// workspace-security observation builder: a compliant fixture reports
+// usable with the six bounded facts, a planted project configuration
+// or an unexpected helper reports runtime_failed, and neither the
+// record nor its detail ever carries an absolute path, an environment
+// value, or a credential value.
+func TestGeminiQualificationWorkspaceSecurityObservation(t *testing.T) {
+	t.Parallel()
+
+	compliant := geminiWorkspaceSecurityFacts{
+		PresentProjectConfig: nil,
+		HomeClass:            "run_scoped_temp",
+		CLIHomeClass:         "run_scoped_temp",
+		EnvNames:             []string{"HOME", "PATH"},
+		SkipTrustUsed:        true,
+		TrustPromptObserved:  false,
+		MemberBasenames:      []string{"gemini"},
+		UnexpectedHelpers:    nil,
+	}
+
+	t.Run("a compliant fixture records usable and decodes cleanly", func(t *testing.T) {
+		t.Parallel()
+
+		rec := geminiWorkspaceSecurityRecord(compliant)
+		if rec.Outcome != qualification.OutcomePass || rec.Grade != qualification.GradeUsable {
+			t.Errorf("compliant workspace record = %s/%s, want pass/usable", rec.Outcome, rec.Grade)
+		}
+		if err := checkGeminiVerdictClassification(&rec); err != nil {
+			t.Errorf("checkGeminiVerdictClassification() error = %v, want nil for the compliant record", err)
+		}
+		line, err := qualification.MarshalRecord(rec)
+		if err != nil {
+			t.Fatalf("qualification.MarshalRecord() error = %v", err)
+		}
+		if _, err := qualification.DecodeRecord(line); err != nil {
+			t.Errorf("qualification.DecodeRecord() error = %v, want the workspace record to decode cleanly", err)
+		}
+		for _, banned := range []string{"/tmp/", "/home/", "value-a", "token-value"} {
+			if strings.Contains(rec.Detail, banned) {
+				t.Errorf("workspace detail %q carries the banned value shape %q", rec.Detail, banned)
+			}
+		}
+	})
+
+	t.Run("a planted project configuration reports runtime_failed", func(t *testing.T) {
+		t.Parallel()
+
+		planted := compliant
+		planted.PresentProjectConfig = []string{".gemini/settings.json"}
+		rec := geminiWorkspaceSecurityRecord(planted)
+		if rec.Outcome != qualification.OutcomeRuntimeFailed || rec.Grade != qualification.GradeNotObserved {
+			t.Errorf("planted-config workspace record = %s/%s, want runtime_failed/not_observed", rec.Outcome, rec.Grade)
+		}
+		if !strings.Contains(rec.Detail, ".gemini/settings.json") {
+			t.Errorf("workspace detail = %q, want it to name the planted configuration class", rec.Detail)
+		}
+	})
+
+	t.Run("an unexpected helper reports runtime_failed", func(t *testing.T) {
+		t.Parallel()
+
+		infected := compliant
+		infected.UnexpectedHelpers = []string{"stray-helper"}
+		rec := geminiWorkspaceSecurityRecord(infected)
+		if rec.Outcome != qualification.OutcomeRuntimeFailed {
+			t.Errorf("unexpected-helper workspace record = %s, want runtime_failed", rec.Outcome)
+		}
+	})
+
+	t.Run("environment names are recorded without values", func(t *testing.T) {
+		t.Parallel()
+
+		detail := geminiWorkspaceSecurityDetail(compliant)
+		for _, name := range compliant.EnvNames {
+			if !strings.Contains(detail, name) {
+				t.Errorf("workspace detail = %q, want it to name the allowlisted entry %s", detail, name)
+			}
+		}
+		for _, valueShape := range []string{"value-a", "token-value", "="} {
+			if strings.Contains(detail, valueShape) {
+				t.Errorf("workspace detail = %q, want no environment value shape %q", detail, valueShape)
+			}
+		}
+	})
+}

--- a/internal/agent/clientprotocol/gemini_qualification_semantic_probes_unix_test.go
+++ b/internal/agent/clientprotocol/gemini_qualification_semantic_probes_unix_test.go
@@ -84,6 +84,16 @@ func geminiResolveQualificationRuntime(t *testing.T, config geminiQualificationC
 // geminiCaptureVersion captures the executable's self-reported version
 // once with a bounded call. The value is ephemeral per-session
 // evidence; it never reaches notes or summaries.
+//
+// SORTIE_GEMINI_COMMAND can itself be a shim from a version manager
+// such as asdf, whose own "#!/usr/bin/env node" shebang re-resolves
+// node through PATH and can land on that manager's node shim rather
+// than a pinned install. That shim needs the manager's own
+// HOME-derived data directory to pick a node version; the run-scoped,
+// deliberately isolated HOME this environment carries has none, so
+// geminiQualificationToolchainEnvNames forwards that data-directory
+// coordinate from the invoking environment when present, without
+// widening the HOME isolation itself.
 func geminiCaptureVersion(t *testing.T, config geminiQualificationConfig, env []string) string {
 	t.Helper()
 

--- a/internal/agent/clientprotocol/gemini_qualification_semantic_probes_unix_test.go
+++ b/internal/agent/clientprotocol/gemini_qualification_semantic_probes_unix_test.go
@@ -1,0 +1,768 @@
+//go:build unix
+
+package clientprotocol
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/sortie-ai/sortie/internal/qualification"
+
+	"github.com/sortie-ai/sortie/internal/agent/procutil"
+	"github.com/sortie-ai/sortie/internal/domain"
+)
+
+// geminiSemanticProbeTimeout bounds every deterministic wait a fake
+// local probe control performs.
+const geminiSemanticProbeTimeout = 10 * time.Second
+
+// geminiQualificationRuntime is everything one qualification run
+// resolves exactly once: the executable and its self-reported version,
+// the one operator-selected model, the controlled workspace and its
+// run-scoped homes, the run-scoped policy with its unique marker, the
+// five local probes, the positive MCP fixture, the baseline prompt and
+// timeout profile, and the subprocess environment allowlist. Every
+// collector shares this resolution; only each declared input_id varies.
+type geminiQualificationRuntime struct {
+	Config           geminiQualificationConfig
+	Version          string
+	Workspace        geminiQualificationWorkspace
+	PolicyPath       string
+	PolicyDenyMarker string
+	Probes           geminiQualificationProbes
+	MCP              geminiMCPFixture
+	Timeouts         domain.AgentConfig
+	Env              []string
+}
+
+// geminiResolveQualificationRuntime resolves the run's shared inputs
+// once: it captures the executable's self-reported version with one
+// bounded call, builds the controlled workspace, writes the policy and
+// the five probes under it, and creates the MCP fixture. Values that
+// must never be printed are not: the version is ephemeral evidence and
+// the deny marker is a public token.
+func geminiResolveQualificationRuntime(t *testing.T, config geminiQualificationConfig) geminiQualificationRuntime {
+	t.Helper()
+
+	workspace := geminiNewQualificationWorkspace(t)
+	probes := geminiWriteProbeExecutables(t, workspace.Checkout)
+	policyPath, denyMarker := geminiWriteQualificationPolicy(t, t.TempDir(), probes)
+	mcp := geminiNewMCPFixture(t, t.TempDir())
+
+	env, err := geminiBuildQualificationSubprocessEnv(config, workspace.Home, workspace.CLIHome)
+	if err != nil {
+		t.Fatalf("build the qualification subprocess environment: %v", err)
+	}
+
+	return geminiQualificationRuntime{
+		Config:           config,
+		Version:          geminiCaptureVersion(t, config, env),
+		Workspace:        workspace,
+		PolicyPath:       policyPath,
+		PolicyDenyMarker: denyMarker,
+		Probes:           probes,
+		MCP:              mcp,
+		Timeouts: domain.AgentConfig{
+			Kind:           "agent-client-protocol",
+			Command:        config.CommandPath,
+			ReadTimeoutMS:  30000,
+			TurnTimeoutMS:  300000,
+			StallTimeoutMS: 60000,
+		},
+		Env: env,
+	}
+}
+
+// geminiCaptureVersion captures the executable's self-reported version
+// once with a bounded call. The value is ephemeral per-session
+// evidence; it never reaches notes or summaries.
+func geminiCaptureVersion(t *testing.T, config geminiQualificationConfig, env []string) string {
+	t.Helper()
+
+	var stdout, stderr bytes.Buffer
+	cmd := exec.Command(config.CommandPath, "--version") //nolint:gosec // the operator-selected executable, resolved by the gate
+	cmd.Env = env
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		diagnostic := strings.TrimSpace(stderr.String())
+		if len(diagnostic) > 2000 {
+			diagnostic = diagnostic[:2000]
+		}
+		t.Fatalf("capture the version coordinate: %v; stderr: %q", err, diagnostic)
+	}
+	return strings.TrimSpace(stdout.String())
+}
+
+// geminiProtocolTurnOutcome is one bounded protocol turn's normalized
+// terminal outcome: the session/prompt response's stop reason, if one
+// arrived, and the normalized error kind the adapter settled the turn
+// with.
+type geminiProtocolTurnOutcome struct {
+	StopReason stopReason
+	ErrKind    domain.AgentErrorKind
+	Attributed bool // the collector attributed the outcome to this case's controlled operation
+}
+
+// geminiProtocolCase maps one terminal outcome to the one semantic case
+// it distinctly and machine-readably represents, per the normalizer's
+// closed mapping. A permission denial, a failed tool result, and an
+// invalid configuration are not distinct representations of any
+// required case and map to none of them.
+func geminiProtocolCase(outcome geminiProtocolTurnOutcome) (qualification.Case, bool) {
+	switch {
+	case outcome.ErrKind == domain.ErrTurnInputRequired:
+		return qualification.CaseHumanInput, true
+	case outcome.ErrKind == domain.ErrTurnOutcomeUnknown:
+		return qualification.CaseUnknownOutcome, true
+	case outcome.ErrKind == domain.ErrTurnRefused:
+		return qualification.CaseRuntimeRefusal, true
+	case outcome.ErrKind == domain.ErrTurnCancelled:
+		return qualification.CaseCancellation, true
+	case outcome.ErrKind == domain.ErrPortExit:
+		return qualification.CaseRetryableTransport, true
+	case outcome.ErrKind == domain.ErrResponseError && outcome.Attributed:
+		return qualification.CaseRuntimeFailure, true
+	case outcome.StopReason == stopReasonEndTurn:
+		return qualification.CaseSuccess, true
+	case outcome.StopReason == stopReasonMaxTokens || outcome.StopReason == stopReasonMaxTurnRequests:
+		return qualification.CaseLimitReached, true
+	}
+	return "", false
+}
+
+// geminiRetryCaseFor maps one terminal outcome to the retry case it
+// distinctly represents, separately from the disposition case: the
+// refusal and non-retryable-refusal tuples share one physical run but
+// remain separate records.
+func geminiRetryCaseFor(outcome geminiProtocolTurnOutcome) (qualification.Case, bool) {
+	switch outcome.ErrKind {
+	case domain.ErrTurnRefused:
+		return qualification.CaseNonRetryableRefusal, true
+	case domain.ErrPortExit:
+		if classification := domain.ErrPortExit.RetryClassification(); classification.Retryable {
+			return qualification.CaseRetryableTransport, true
+		}
+	}
+	return "", false
+}
+
+// geminiSemanticObservation is what one bounded probe observed. Tag
+// names the case the probe induced the observation for, which is the
+// only case the observation may ever fill.
+type geminiSemanticObservation struct {
+	Tag          qualification.Case
+	Induced      bool
+	Distinct     bool
+	Structured   bool
+	Failure      qualification.Outcome
+	SessionID    string
+	EvidencePath string
+	Detail       string
+}
+
+// geminiSemanticRecordFor builds one semantic probe record from an
+// observation. The classification follows the evidence contract: a
+// failure or an uninduced case is not_observed with its specific
+// verdict and never becomes gap; an observed, distinct, structured
+// outcome is usable; an observed but conflated or unstructured outcome
+// is gap. An observation tagged for another case is refused, so one
+// record can never satisfy more than one tuple.
+func geminiSemanticRecordFor(surface qualification.Surface, capability qualification.Capability, caseID qualification.Case, obs geminiSemanticObservation) qualification.Record {
+	rec := qualification.Record{
+		SchemaVersion: 1,
+		ObservedAt:    qualification.FixtureTime,
+		Scenario:      qualification.ScenarioSemanticProbe,
+		Surface:       surface,
+		Capability:    capability,
+		SemanticCase:  new(caseID),
+		InputID:       qualification.CaseInputs[caseID],
+		Detail:        obs.Detail,
+	}
+	if rec.Detail == "" {
+		rec.Detail = fmt.Sprintf("%s %s case observation on %s", capability, caseID, surface)
+	}
+
+	switch {
+	case obs.Tag != caseID:
+		// An observation collected for a different case never fills
+		// this tuple: permission denial, invalid configuration, and
+		// synthetic fixtures cannot stand in for the live class.
+		rec.Outcome = qualification.OutcomeNotObserved
+		rec.Grade = qualification.GradeNotObserved
+	case obs.Failure != "":
+		rec.Outcome = obs.Failure
+		rec.Grade = qualification.GradeNotObserved
+	case !obs.Induced:
+		rec.Outcome = qualification.OutcomeNotObserved
+		rec.Grade = qualification.GradeNotObserved
+	case obs.Distinct && obs.Structured:
+		rec.Outcome = qualification.OutcomePass
+		rec.Grade = qualification.GradeUsable
+		rec.SessionID = new(obs.SessionID)
+		rec.EvidencePath = new(obs.EvidencePath)
+	default:
+		rec.Outcome = qualification.OutcomePass
+		rec.Grade = qualification.GradeGap
+		rec.SessionID = new(obs.SessionID)
+		rec.EvidencePath = new(obs.EvidencePath)
+	}
+
+	switch surface {
+	case qualification.SurfaceProtocol:
+		rec.Source = qualification.SourceProtocolStable
+		rec.AgentName = new(qualification.FixtureAgentName)
+		rec.AgentVersion = new(qualification.FixtureAgentVer)
+		rec.ProtocolVersion = new(1)
+	default:
+		rec.Source = qualification.SourceNativeStructured
+		rec.AgentVersion = new(qualification.FixtureAgentVer)
+	}
+	return rec
+}
+
+// geminiInputSpec is one fixed input's catalog entry: the exact prompt
+// the collector sends, whether the probe launches at all, and, when a
+// substitution exists, the probe whose absolute path is the only
+// substituted value.
+type geminiInputSpec struct {
+	Prompt string
+	Launch bool
+	Probe  *string
+}
+
+// geminiSemanticInputCatalog builds the fixed input catalog for one
+// run. Fixed prompts are exact; every substitution input varies only by
+// the single substituted value its contract names.
+func geminiSemanticInputCatalog(probes geminiQualificationProbes, nonce string) map[qualification.InputID]geminiInputSpec {
+	probeInput := func(format string, probePath string) geminiInputSpec {
+		return geminiInputSpec{
+			Prompt: fmt.Sprintf(format, probePath),
+			Launch: true,
+			Probe:  new(probePath),
+		}
+	}
+
+	return map[qualification.InputID]geminiInputSpec{
+		qualification.InputDispositionSuccess: {
+			Prompt: "Reply with exactly SORTIE_BASELINE_OK and do not call any tool.",
+			Launch: true,
+		},
+		qualification.InputDispositionRuntimeFailure: probeInput(
+			"Invoke the test-owned probe at %s exactly once.", probes.Failing),
+		qualification.InputDispositionRuntimeRefusal: {
+			Prompt: "Decline to continue this turn and report your runtime refusal outcome without calling a tool.",
+			Launch: true,
+		},
+		qualification.InputDispositionCancellation: probeInput(
+			"Invoke the test-owned probe at %s exactly once.", probes.Cancellation),
+		qualification.InputDispositionLimitReached: {
+			// No documented deterministic inducer: no separate launch.
+			Launch: false,
+		},
+		qualification.InputRetryableTransport: probeInput(
+			"Invoke the test-owned probe at %s exactly once.", probes.Transport),
+		qualification.InputRetryNonRetryableRefusal: {
+			// The refusal retry references the refusal disposition's
+			// own physical run and carries no new prompt.
+			Launch: false,
+		},
+		qualification.InputRetryHumanInput: probeInput(
+			"Call run_shell_command exactly once with the absolute path %s, with no arguments and no other tool.", probes.Permission),
+		qualification.InputRetryUnknownOutcome: {
+			Prompt: "End this turn with an outcome outside your documented terminal outcome set and emit no normal answer.",
+			Launch: true,
+		},
+		qualification.InputPolicyControl: probeInput(
+			"Call run_shell_command exactly once with the absolute path %s, with no arguments and no other tool.", probes.PolicyLoad),
+		qualification.InputPermissionProbe: probeInput(
+			"Call run_shell_command exactly once with the absolute path %s, with no arguments and no other tool.", probes.Permission),
+		qualification.InputMCPProbe: {
+			Prompt: fmt.Sprintf("Call the test server's %s tool exactly once with the nonce %s and then reply with the nonce the tool returned.", geminiMCPToolName, nonce),
+			Launch: true,
+		},
+		qualification.InputContinuationSeed: {
+			Prompt: fmt.Sprintf("Remember the nonce %s for the rest of this conversation and reply exactly STORED.", nonce),
+			Launch: true,
+		},
+		qualification.InputContinuationRecall: {
+			// The recall prompt does not repeat the nonce; the prior
+			// conversation supplies it.
+			Prompt: "Reply with the nonce supplied by the prior conversation and no other text.",
+			Launch: true,
+		},
+		qualification.InputE2E: {
+			Prompt: "Reply with exactly SORTIE_E2E_OK and do not call any tool.",
+			Launch: true,
+		},
+	}
+}
+
+// TestGeminiSemanticProbeCatalog confirms the fixed input catalog: the
+// exact prompts match the input table verbatim, every substitution
+// input varies by exactly its one substituted value, limit_reached
+// launches no process, and each semantic case resolves to its own
+// input.
+func TestGeminiSemanticProbeCatalog(t *testing.T) {
+	t.Parallel()
+
+	fakeProbes := geminiQualificationProbes{
+		PolicyLoad:   "/controlled/policy-load-probe",
+		Permission:   "/controlled/permission-probe",
+		Failing:      "/controlled/failing-probe",
+		Cancellation: "/controlled/cancellation-probe",
+		Transport:    "/controlled/transport-probe",
+	}
+	otherProbes := geminiQualificationProbes{
+		PolicyLoad:   "/other/policy-load-probe",
+		Permission:   "/other/permission-probe",
+		Failing:      "/other/failing-probe",
+		Cancellation: "/other/cancellation-probe",
+		Transport:    "/other/transport-probe",
+	}
+
+	catalog := geminiSemanticInputCatalog(fakeProbes, "sortie-nonce-fixture")
+	other := geminiSemanticInputCatalog(otherProbes, "sortie-nonce-other")
+
+	t.Run("exact fixed prompts", func(t *testing.T) {
+		t.Parallel()
+
+		tests := []struct {
+			id     qualification.InputID
+			prompt string
+		}{
+			{qualification.InputDispositionSuccess, "Reply with exactly SORTIE_BASELINE_OK and do not call any tool."},
+			{qualification.InputDispositionRuntimeRefusal, "Decline to continue this turn and report your runtime refusal outcome without calling a tool."},
+			{qualification.InputRetryUnknownOutcome, "End this turn with an outcome outside your documented terminal outcome set and emit no normal answer."},
+			{qualification.InputE2E, "Reply with exactly SORTIE_E2E_OK and do not call any tool."},
+			{qualification.InputContinuationRecall, "Reply with the nonce supplied by the prior conversation and no other text."},
+		}
+		for _, tt := range tests {
+			if catalog[tt.id].Prompt != tt.prompt {
+				t.Errorf("catalog prompt for %s = %q, want the exact fixed prompt %q", tt.id, catalog[tt.id].Prompt, tt.prompt)
+			}
+			if !catalog[tt.id].Launch {
+				t.Errorf("catalog entry %s does not launch, want one bounded attempt", tt.id)
+			}
+		}
+	})
+
+	t.Run("substitution inputs vary only by their single substituted value", func(t *testing.T) {
+		t.Parallel()
+
+		tests := []struct {
+			id    qualification.InputID
+			probe string
+		}{
+			{qualification.InputDispositionRuntimeFailure, "failing-probe"},
+			{qualification.InputDispositionCancellation, "cancellation-probe"},
+			{qualification.InputRetryableTransport, "transport-probe"},
+			{qualification.InputRetryHumanInput, "permission-probe"},
+			{qualification.InputPolicyControl, "policy-load-probe"},
+		}
+		for _, tt := range tests {
+			spec := catalog[tt.id]
+			otherSpec := other[tt.id]
+			if !spec.Launch {
+				t.Errorf("catalog entry %s does not launch", tt.id)
+			}
+			if spec.Probe == nil || filepath.Base(*spec.Probe) != tt.probe {
+				t.Errorf("catalog entry %s names %v, want only %s", tt.id, spec.Probe, tt.probe)
+			}
+			if !strings.Contains(spec.Prompt, tt.probe) {
+				t.Errorf("prompt %q does not name %s", spec.Prompt, tt.probe)
+			}
+			// The only difference between two runs' prompts is the
+			// substituted path: rewriting one probe path into the other
+			// makes the two prompts equal.
+			if normalized := strings.ReplaceAll(spec.Prompt, "/controlled/", "/other/"); normalized != otherSpec.Prompt {
+				t.Errorf("catalog entry %s varies by more than its substituted path", tt.id)
+			}
+		}
+	})
+
+	t.Run("limit reached launches no process", func(t *testing.T) {
+		t.Parallel()
+
+		if catalog[qualification.InputDispositionLimitReached].Launch {
+			t.Error("limit_reached catalog entry launches, want no separate launch")
+		}
+	})
+
+	t.Run("the nonce substitution appears in the seed and MCP prompts only", func(t *testing.T) {
+		t.Parallel()
+
+		if !strings.Contains(catalog[qualification.InputContinuationSeed].Prompt, "sortie-nonce-") {
+			t.Errorf("seed prompt %q carries no nonce", catalog[qualification.InputContinuationSeed].Prompt)
+		}
+		if strings.Contains(catalog[qualification.InputContinuationRecall].Prompt, "sortie-nonce") {
+			t.Errorf("recall prompt %q repeats the nonce, want no nonce substitution", catalog[qualification.InputContinuationRecall].Prompt)
+		}
+		if !strings.Contains(catalog[qualification.InputMCPProbe].Prompt, "sortie-nonce") {
+			t.Errorf("MCP prompt %q carries no nonce", catalog[qualification.InputMCPProbe].Prompt)
+		}
+		if normalized := strings.ReplaceAll(catalog[qualification.InputContinuationSeed].Prompt, "sortie-nonce-fixture", "sortie-nonce-x"); normalized == catalog[qualification.InputContinuationSeed].Prompt {
+			t.Error("seed prompt does not vary with the generated nonce")
+		}
+	})
+
+	t.Run("every semantic case maps to exactly one catalog input", func(t *testing.T) {
+		t.Parallel()
+
+		for _, capability := range qualification.ComparisonCapabilities[:2] {
+			for _, caseID := range qualification.CapabilityCases[capability] {
+				inputID, known := qualification.CaseInputs[caseID]
+				if !known {
+					t.Fatalf("semantic case %s carries no input mapping", caseID)
+				}
+				if _, inCatalog := catalog[inputID]; !inCatalog {
+					t.Errorf("semantic case %s maps to input %s, which the catalog omits", caseID, inputID)
+				}
+			}
+		}
+	})
+}
+
+// TestGeminiSemanticProbeClassificationControls drives the semantic
+// collectors with fake local processes only: the cancellation and
+// transport-loss controls run against the fixture probes, the protocol
+// outcome mapping runs against scripted in-memory sessions, and the
+// forbidden-substitution control proves one record can never satisfy
+// another case's tuple.
+func TestGeminiSemanticProbeClassificationControls(t *testing.T) {
+	t.Parallel()
+
+	workspace := geminiNewQualificationWorkspace(t)
+	probes := geminiWriteProbeExecutables(t, workspace.Checkout)
+
+	t.Run("cancellation control with a fake local probe", func(t *testing.T) {
+		t.Parallel()
+
+		control := geminiRunCancellationControl(t, probes.Cancellation, workspace.Checkout)
+		if !control.MarkerPresent {
+			t.Fatal("cancellation control observed no started marker, want fixture induction")
+		}
+		if !control.GroupDrained {
+			t.Fatal("cancellation control left its process group alive after graceful cancellation")
+		}
+
+		obs := geminiSemanticObservation{
+			Tag:          qualification.CaseCancellation,
+			Induced:      control.MarkerPresent,
+			Distinct:     true,
+			Structured:   true,
+			SessionID:    "sess-cancellation-fixture",
+			EvidencePath: "/turn/stop_reason",
+			Detail:       "bounded probe cancellation completed with a distinct outcome",
+		}
+		rec := geminiSemanticRecordFor(qualification.SurfaceNativeJSON, qualification.CapabilityTurnDisposition, qualification.CaseCancellation, obs)
+		if rec.Outcome != qualification.OutcomePass || rec.Grade != qualification.GradeUsable {
+			t.Errorf("cancellation record = %s/%s, want pass/usable", rec.Outcome, rec.Grade)
+		}
+		if err := checkGeminiVerdictClassification(&rec); err != nil {
+			t.Errorf("checkGeminiVerdictClassification() error = %v", err)
+		}
+	})
+
+	t.Run("transport loss control with a fake local probe", func(t *testing.T) {
+		t.Parallel()
+
+		control := geminiRunTransportLossControl(t, probes.Transport, workspace.Checkout)
+		if !control.MarkerPresent || !control.GroupDrained {
+			t.Fatalf("transport control = %+v, want marker induction and a drained group", control)
+		}
+
+		classification := domain.ErrPortExit.RetryClassification()
+		if !classification.Retryable || classification.Backoff != domain.BackoffExponential {
+			t.Errorf("ErrPortExit retry classification = %+v, want retryable with exponential backoff", classification)
+		}
+		caseID, mapped := geminiProtocolCase(geminiProtocolTurnOutcome{ErrKind: domain.ErrPortExit})
+		if !mapped || caseID != qualification.CaseRetryableTransport {
+			t.Errorf("geminiProtocolCase(ErrPortExit) = %q, %v, want retryable_runtime_or_transport_failure", caseID, mapped)
+		}
+	})
+
+	t.Run("protocol outcome mapping table", func(t *testing.T) {
+		t.Parallel()
+
+		tests := []struct {
+			name        string
+			outcome     geminiProtocolTurnOutcome
+			wantCase    qualification.Case
+			wantMapped  bool
+			wantRetry   qualification.Case
+			wantRetryOK bool
+		}{
+			{
+				name:       "end_turn is a distinct success",
+				outcome:    geminiProtocolTurnOutcome{StopReason: stopReasonEndTurn},
+				wantCase:   qualification.CaseSuccess,
+				wantMapped: true,
+			},
+			{
+				name:        "refusal stop reason is a distinct refusal and non-retryable",
+				outcome:     geminiProtocolTurnOutcome{StopReason: stopReasonRefusal, ErrKind: domain.ErrTurnRefused},
+				wantCase:    qualification.CaseRuntimeRefusal,
+				wantMapped:  true,
+				wantRetry:   qualification.CaseNonRetryableRefusal,
+				wantRetryOK: true,
+			},
+			{
+				name:        "stream end is the retryable transport loss",
+				outcome:     geminiProtocolTurnOutcome{ErrKind: domain.ErrPortExit},
+				wantCase:    qualification.CaseRetryableTransport,
+				wantMapped:  true,
+				wantRetry:   qualification.CaseRetryableTransport,
+				wantRetryOK: true,
+			},
+			{
+				name:       "cancellation is its own distinct case",
+				outcome:    geminiProtocolTurnOutcome{ErrKind: domain.ErrTurnCancelled},
+				wantCase:   qualification.CaseCancellation,
+				wantMapped: true,
+			},
+			{
+				name:       "input required maps to human input with no retry",
+				outcome:    geminiProtocolTurnOutcome{ErrKind: domain.ErrTurnInputRequired},
+				wantCase:   qualification.CaseHumanInput,
+				wantMapped: true,
+			},
+			{
+				name:       "unknown stop reason maps to unknown outcome",
+				outcome:    geminiProtocolTurnOutcome{ErrKind: domain.ErrTurnOutcomeUnknown},
+				wantCase:   qualification.CaseUnknownOutcome,
+				wantMapped: true,
+			},
+			{
+				name:       "max tokens is a naturally occurring limit",
+				outcome:    geminiProtocolTurnOutcome{StopReason: stopReasonMaxTokens, ErrKind: domain.ErrTurnFailed},
+				wantCase:   qualification.CaseLimitReached,
+				wantMapped: true,
+			},
+			{
+				name:       "an attributed prompt-level error is a runtime failure",
+				outcome:    geminiProtocolTurnOutcome{ErrKind: domain.ErrResponseError, Attributed: true},
+				wantCase:   qualification.CaseRuntimeFailure,
+				wantMapped: true,
+			},
+			{
+				name:       "an unattributed prompt error is no runtime-failure evidence",
+				outcome:    geminiProtocolTurnOutcome{ErrKind: domain.ErrResponseError, Attributed: false},
+				wantCase:   "",
+				wantMapped: false,
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+
+				caseID, mapped := geminiProtocolCase(tt.outcome)
+				if mapped != tt.wantMapped || caseID != tt.wantCase {
+					t.Errorf("geminiProtocolCase(%+v) = %q, %v, want %q, %v", tt.outcome, caseID, mapped, tt.wantCase, tt.wantMapped)
+				}
+				retryCase, retryOK := geminiRetryCaseFor(tt.outcome)
+				if retryOK != tt.wantRetryOK || retryCase != tt.wantRetry {
+					t.Errorf("geminiRetryCaseFor(%+v) = %q, %v, want %q, %v", tt.outcome, retryCase, retryOK, tt.wantRetry, tt.wantRetryOK)
+				}
+			})
+		}
+	})
+
+	t.Run("forbidden substitution never fills another tuple", func(t *testing.T) {
+		t.Parallel()
+
+		// A permission-denial observation is collected for the
+		// permission probe; it must not fill the runtime-refusal
+		// disposition tuple.
+		permissionObservation := geminiSemanticObservation{
+			Tag:          qualification.CaseHumanInput,
+			Induced:      true,
+			Distinct:     true,
+			Structured:   true,
+			SessionID:    "sess-permission",
+			EvidencePath: "session/request_permission",
+			Detail:       "permission request answered",
+		}
+		rec := geminiSemanticRecordFor(qualification.SurfaceProtocol, qualification.CapabilityTurnDisposition, qualification.CaseRuntimeRefusal, permissionObservation)
+		if rec.Outcome != qualification.OutcomeNotObserved || rec.Grade != qualification.GradeNotObserved {
+			t.Errorf("mismatched-tag record = %s/%s, want not_observed/not_observed", rec.Outcome, rec.Grade)
+		}
+		if rec.SessionID != nil || rec.EvidencePath != nil {
+			t.Errorf("mismatched-tag record carries session %v or path %v, want both null", rec.SessionID, rec.EvidencePath)
+		}
+
+		// An uninduced case stays not_observed, never gap.
+		uninduced := geminiSemanticRecordFor(qualification.SurfaceProtocol, qualification.CapabilityTurnDisposition, qualification.CaseUnknownOutcome, geminiSemanticObservation{Tag: qualification.CaseUnknownOutcome})
+		if uninduced.Outcome != qualification.OutcomeNotObserved || uninduced.Grade != qualification.GradeNotObserved {
+			t.Errorf("uninduced record = %s/%s, want not_observed/not_observed", uninduced.Outcome, uninduced.Grade)
+		}
+
+		// A harness failure keeps its specific verdict and never
+		// becomes gap evidence about the runtime surface.
+		failed := geminiSemanticRecordFor(qualification.SurfaceNativeJSON, qualification.CapabilityRetryClassification, qualification.CaseRetryableTransport, geminiSemanticObservation{
+			Tag:     qualification.CaseRetryableTransport,
+			Failure: qualification.OutcomePrerequisiteFailed,
+		})
+		if failed.Outcome != qualification.OutcomePrerequisiteFailed || failed.Grade != qualification.GradeNotObserved {
+			t.Errorf("failure record = %s/%s, want prerequisite_failed/not_observed", failed.Outcome, failed.Grade)
+		}
+	})
+
+	t.Run("a conflated unstructured outcome grades gap", func(t *testing.T) {
+		t.Parallel()
+
+		rec := geminiSemanticRecordFor(qualification.SurfaceNativeText, qualification.CapabilityTurnDisposition, qualification.CaseSuccess, geminiSemanticObservation{
+			Tag:          qualification.CaseSuccess,
+			Induced:      true,
+			Distinct:     false,
+			Structured:   false,
+			SessionID:    "sess-native-text",
+			EvidencePath: "/text/final",
+			Detail:       "unstructured residue only",
+		})
+		if rec.Outcome != qualification.OutcomePass || rec.Grade != qualification.GradeGap {
+			t.Errorf("unstructured record = %s/%s, want pass/gap", rec.Outcome, rec.Grade)
+		}
+		if rec.Source != qualification.SourceNativeStructured {
+			t.Errorf("native record source = %s, want native_structured", rec.Source)
+		}
+	})
+
+	t.Run("a protocol turn through the adapter settles into its mapped case", func(t *testing.T) {
+		t.Parallel()
+
+		state, outPr, inPw := newTestSession(t, domain.AgentConfig{ReadTimeoutMS: 2000}, clientProtocolMaxLineBytes)
+		out := newOutboundReader(outPr)
+		markSessionKnown(state)
+
+		var events []domain.AgentEvent
+		turnCh := runTurnAsync(state, domain.RunTurnParams{Prompt: "go", OnEvent: collectEvents(&events)})
+		promptID := out.awaitMethod(t, methodSessionPrompt)
+		respondLine(t, inPw, promptID, promptResponse{StopReason: stopReasonRefusal})
+		turnOutcome := awaitOutcome(t, turnCh)
+
+		var agentErr *domain.AgentError
+		if !errors.As(turnOutcome.err, &agentErr) {
+			t.Fatalf("runTurn() error = %v, want a *domain.AgentError", turnOutcome.err)
+		}
+		if agentErr.Kind != domain.ErrTurnRefused {
+			t.Errorf("runTurn() error kind = %s, want %s for the refusal stop reason", agentErr.Kind, domain.ErrTurnRefused)
+		}
+		protocolOutcome := geminiProtocolTurnOutcome{StopReason: stopReasonRefusal, ErrKind: agentErr.Kind}
+		caseID, mapped := geminiProtocolCase(protocolOutcome)
+		if !mapped || caseID != qualification.CaseRuntimeRefusal {
+			t.Errorf("geminiProtocolCase() = %q, %v, want runtime_refusal", caseID, mapped)
+		}
+		retryCase, retryOK := geminiRetryCaseFor(protocolOutcome)
+		if !retryOK || retryCase != qualification.CaseNonRetryableRefusal {
+			t.Errorf("geminiRetryCaseFor() = %q, %v, want non_retryable_refusal", retryCase, retryOK)
+		}
+	})
+}
+
+// geminiCancellationControl is what a bounded cancellation control
+// observed with fake local processes: the probe's marker appeared, the
+// graceful group cancellation drained the group, and nothing else ran.
+type geminiCancellationControl struct {
+	MarkerPresent bool
+	GroupDrained  bool
+}
+
+// geminiRunCancellationControl launches the cancellation probe in its
+// own process group, waits for its public started marker, cancels the
+// group gracefully once, and bounds the exit wait. Nothing here
+// touches a real tracker, repository, or network.
+func geminiRunCancellationControl(t *testing.T, probePath string, dir string) geminiCancellationControl {
+	t.Helper()
+
+	cmd := exec.Command(probePath) //nolint:gosec // the probe path is written by this test under its own temp workspace
+	cmd.Dir = dir
+	procutil.SetProcessGroup(cmd)
+	cmd.Env = []string{"PATH=" + os.Getenv("PATH")}
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start cancellation probe: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = procutil.SignalProcessGroup(cmd.Process.Pid, syscall.SIGKILL)
+		_, _ = cmd.Process.Wait()
+	})
+
+	waitForFile(t, geminiProbeMarkerPath(probePath), geminiSemanticProbeTimeout)
+	if err := procutil.SignalProcessGroup(cmd.Process.Pid, syscall.SIGTERM); err != nil {
+		t.Fatalf("graceful cancellation signal: %v", err)
+	}
+	_, _ = cmd.Process.Wait()
+
+	return geminiCancellationControl{
+		MarkerPresent: true,
+		GroupDrained:  geminiAwaitGroupDrain(t, cmd.Process.Pid, geminiSemanticProbeTimeout),
+	}
+}
+
+// geminiTransportLossControl is what a bounded transport-loss control
+// observed with fake local processes.
+type geminiTransportLossControl struct {
+	MarkerPresent bool
+	GroupDrained  bool
+}
+
+// geminiRunTransportLossControl launches the transport probe, waits for
+// its marker to prove the child is active, then sends SIGKILL to the
+// captured process group through procutil.SignalProcessGroup and
+// requires a bounded drain.
+func geminiRunTransportLossControl(t *testing.T, probePath string, dir string) geminiTransportLossControl {
+	t.Helper()
+
+	cmd := exec.Command(probePath) //nolint:gosec // the probe path is written by this test under its own temp workspace
+	cmd.Dir = dir
+	procutil.SetProcessGroup(cmd)
+	cmd.Env = []string{"PATH=" + os.Getenv("PATH")}
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start transport probe: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = procutil.SignalProcessGroup(cmd.Process.Pid, syscall.SIGKILL)
+		_, _ = cmd.Process.Wait()
+	})
+
+	waitForFile(t, geminiProbeMarkerPath(probePath), geminiSemanticProbeTimeout)
+	if err := procutil.SignalProcessGroup(cmd.Process.Pid, syscall.SIGKILL); err != nil {
+		t.Fatalf("transport-loss signal: %v", err)
+	}
+	_, _ = cmd.Process.Wait()
+
+	return geminiTransportLossControl{
+		MarkerPresent: true,
+		GroupDrained:  geminiAwaitGroupDrain(t, cmd.Process.Pid, geminiSemanticProbeTimeout),
+	}
+}
+
+// geminiAwaitGroupDrain polls the group's liveness until it drains and
+// reports whether that happened within the bound.
+func geminiAwaitGroupDrain(t *testing.T, pgid int, within time.Duration) bool {
+	t.Helper()
+
+	deadline := time.Now().Add(within)
+	for {
+		present, err := geminiProcessGroupPresent(pgid)
+		if err != nil {
+			t.Fatalf("liveness query: %v", err)
+		}
+		if !present {
+			return true
+		}
+		if time.Now().After(deadline) {
+			return false
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}

--- a/internal/agent/clientprotocol/gemini_qualification_unix_test.go
+++ b/internal/agent/clientprotocol/gemini_qualification_unix_test.go
@@ -1,0 +1,1434 @@
+//go:build unix
+
+package clientprotocol
+
+import (
+	"context"
+	cryptorand "crypto/rand"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"maps"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"slices"
+	"strconv"
+	"strings"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/sortie-ai/sortie/internal/qualification"
+
+	"github.com/sortie-ai/sortie/internal/agent/procutil"
+	"github.com/sortie-ai/sortie/internal/domain"
+)
+
+// geminiNativeProbeBound bounds every native surface launch.
+const geminiNativeProbeBound = 5 * time.Minute
+
+// geminiAdapterNotesRelPath is the tracked durable notes file the rerun
+// compares against, read but never mutated.
+const geminiAdapterNotesRelPath = "../../../docs/gemini-adapter-notes.md"
+
+// geminiQualificationResult is what one qualification collection
+// produced: the validated verdict, the bounded summary, the record
+// count, and whether the durable notes were compared.
+type geminiQualificationResult struct {
+	Verdict         qualification.Verdict
+	Summary         string
+	EvidenceRecords int
+	NotesCompared   bool
+}
+
+// geminiEvidenceDir is the ephemeral evidence directory the collector
+// owns under the test's temporary root.
+func geminiEvidenceDir(t *testing.T) string {
+	t.Helper()
+	return filepath.Join(t.TempDir(), "qualification")
+}
+
+// geminiJSONLWriter buffers JSON Lines and syncs every append, so a
+// validated file is on disk before its validators read it.
+type geminiJSONLWriter struct {
+	file *os.File
+}
+
+func newGeminiJSONLWriter(file *os.File) *geminiJSONLWriter {
+	return &geminiJSONLWriter{file: file}
+}
+
+// append marshals and writes one record line.
+func (w *geminiJSONLWriter) append(t *testing.T, rec qualification.Record) error {
+	t.Helper()
+	line, err := qualification.MarshalRecord(rec)
+	if err != nil {
+		return err
+	}
+	if _, err := w.file.Write(append(line, '\n')); err != nil {
+		return err
+	}
+	return w.file.Sync()
+}
+
+// close flushes and closes the file.
+func (w *geminiJSONLWriter) close(t *testing.T) {
+	t.Helper()
+	if err := w.file.Close(); err != nil {
+		t.Fatalf("close the evidence file: %v", err)
+	}
+}
+
+// geminiWriteQualificationObservations serializes the non-final records
+// in the canonical write order into the evidence file, flushes, and
+// closes it. The canonical ordering, not goroutine completion order,
+// determines the sequence numbers.
+func geminiWriteQualificationObservations(t *testing.T, dir string, records []qualification.Record) string {
+	t.Helper()
+
+	ordered := slices.Clone(records)
+	slices.SortStableFunc(ordered, geminiOrderCompare)
+	for i := range ordered {
+		ordered[i].Sequence = i + 1
+		ordered[i].ObservedAt = qualification.FixtureTime
+	}
+
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		t.Fatalf("create the ephemeral evidence directory: %v", err)
+	}
+	path := filepath.Join(dir, "evidence.jsonl")
+	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600) //nolint:gosec // the path is built from the test's own temp directory
+	if err != nil {
+		t.Fatalf("open the evidence file: %v", err)
+	}
+	writer := newGeminiJSONLWriter(file)
+	for _, rec := range ordered {
+		if err := writer.append(t, rec); err != nil {
+			t.Fatalf("write evidence record %d: %v", rec.Sequence, err)
+		}
+	}
+	writer.close(t)
+	return path
+}
+
+// geminiEvidenceLineCount counts the non-empty lines of an evidence
+// file, so the aggregate's sequence continues the file's own count.
+func geminiEvidenceLineCount(t *testing.T, path string) int {
+	t.Helper()
+	raw, err := os.ReadFile(path) //nolint:gosec // the path is built from the test's own temp directory
+	if err != nil {
+		t.Fatalf("read the evidence file: %v", err)
+	}
+	count := 0
+	for line := range strings.SplitSeq(string(raw), "\n") {
+		if strings.TrimSpace(line) != "" {
+			count++
+		}
+	}
+	return count
+}
+
+// geminiAppendQualificationAggregate reopens the evidence file in append
+// mode, writes exactly one terminal aggregate record carrying the
+// computed verdict, flushes, and closes it. The aggregate is the last
+// line of the file.
+func geminiAppendQualificationAggregate(t *testing.T, path string, verdict qualification.Verdict) {
+	t.Helper()
+
+	classification := qualification.GradeNotQualified
+	if verdict == qualification.VerdictQualified {
+		classification = qualification.GradeQualified
+	}
+	aggregate := qualification.Record{
+		SchemaVersion: 1,
+		Sequence:      geminiEvidenceLineCount(t, path) + 1,
+		ObservedAt:    qualification.FixtureTime,
+		Scenario:      qualification.ScenarioQualification,
+		Surface:       qualification.SurfaceAggregate,
+		Capability:    qualification.CapabilityEligibility,
+		Source:        qualification.SourceComparison,
+		Grade:         classification,
+		Outcome:       qualification.OutcomePass,
+		InputID:       qualification.InputAggregate,
+		EvidencePath:  new(qualification.EvidencePathQualificationVerdict),
+		Detail:        "aggregate qualification verdict recomputed from the closed non-final evidence set",
+	}
+
+	file, err := os.OpenFile(path, os.O_WRONLY|os.O_APPEND, 0o600) //nolint:gosec // the path is built from the test's own temp directory
+	if err != nil {
+		t.Fatalf("reopen the evidence file for the aggregate: %v", err)
+	}
+	writer := newGeminiJSONLWriter(file)
+	if err := writer.append(t, aggregate); err != nil {
+		t.Fatalf("append the aggregate record: %v", err)
+	}
+	writer.close(t)
+}
+
+// geminiRunTwoPassEvidenceFlow runs the strict two-pass state machine:
+// write the closed non-final set, validate it, append exactly one
+// aggregate, validate the complete file, derive the bounded summary,
+// and return the verdict with the summary and the final record count.
+func geminiRunTwoPassEvidenceFlow(t *testing.T, dir string, records []qualification.Record) (qualification.Verdict, string, int) {
+	t.Helper()
+
+	path := geminiWriteQualificationObservations(t, dir, records)
+	verdict, err := qualification.ValidateObservations(path)
+	if err != nil {
+		t.Fatalf("first-pass validation failed: %v", err)
+	}
+	geminiAppendQualificationAggregate(t, path, verdict)
+	finalVerdict, err := qualification.ValidateEvidence(path)
+	if err != nil {
+		t.Fatalf("final-pass validation failed: %v", err)
+	}
+	if finalVerdict != verdict {
+		t.Fatalf("final-pass verdict %q differs from the first-pass verdict %q", finalVerdict, verdict)
+	}
+
+	complete, err := qualification.ReadEvidenceFile(path)
+	if err != nil {
+		t.Fatalf("read the validated evidence file: %v", err)
+	}
+	conclusions, err := geminiSummaryConclusionsFromRecords(complete[:len(complete)-1], verdict)
+	if err != nil {
+		t.Fatalf("derive the bounded summary: %v", err)
+	}
+	return verdict, formatGeminiQualificationSummary(conclusions), len(complete)
+}
+
+// geminiNotesConsistencyError reads the tracked notes without mutating
+// them and compares their bounded conclusions against the freshly
+// validated summary. compared reports whether durable notes existed;
+// err is the mismatch, when the notes exist but disagree.
+func geminiNotesConsistencyError(notesPath string, conclusions geminiSummaryConclusions) (compared bool, err error) {
+	raw, readErr := os.ReadFile(notesPath) //nolint:gosec // the notes path is the operator's tracked documentation file
+	if readErr != nil {
+		return false, nil
+	}
+	return true, validateGeminiAdapterNotes(string(raw), conclusions)
+}
+
+// geminiRunNotesConsistency performs the rerun's notes-consistency
+// check: it reads the tracked notes, never mutates them, and requires
+// their bounded conclusions and verdict to equal the freshly validated
+// summary. A run without durable notes yet returns false and does not
+// fail: the initial run may stop after the validated summary, and
+// support publication requires the notes-consistent rerun.
+func geminiRunNotesConsistency(t *testing.T, notesPath string, conclusions geminiSummaryConclusions, requireMatch bool) bool {
+	t.Helper()
+
+	compared, err := geminiNotesConsistencyError(notesPath, conclusions)
+	if !compared {
+		if requireMatch {
+			t.Fatalf("the durable adapter notes are missing; the rerun requires the notes-consistency check to pass")
+		}
+		return false
+	}
+	if err != nil {
+		if requireMatch {
+			t.Fatalf("the durable notes do not match the freshly validated summary: %v", err)
+		}
+		return false
+	}
+	return true
+}
+
+// TestGeminiQualificationCollectorOrdering confirms the collector's
+// writer: records handed over in any completion order land in the
+// canonical scenario, surface, capability, and per-scenario tiebreak
+// order, carry one-based contiguous sequence numbers, and pass the
+// strict first-pass validator.
+func TestGeminiQualificationCollectorOrdering(t *testing.T) {
+	t.Parallel()
+
+	fixture := qualification.NewFixture(qualification.FixtureQualified)
+	fixture.Finalize()
+
+	shuffled := slices.Clone(fixture.Records)
+	slices.Reverse(shuffled)
+
+	path := geminiWriteQualificationObservations(t, geminiEvidenceDir(t), shuffled)
+
+	stored, err := qualification.ReadEvidenceFile(path)
+	if err != nil {
+		t.Fatalf("qualification.ReadEvidenceFile() error = %v", err)
+	}
+	if len(stored) != len(fixture.Records) {
+		t.Fatalf("stored record count = %d, want %d", len(stored), len(fixture.Records))
+	}
+	for i := range stored {
+		if stored[i].Sequence != i+1 {
+			t.Errorf("record %d carries sequence %d, want contiguous one-based numbering", i+1, stored[i].Sequence)
+			break
+		}
+	}
+	for i := 1; i < len(stored); i++ {
+		if geminiOrderCompare(stored[i-1], stored[i]) > 0 {
+			t.Errorf("stored records are out of canonical order at position %d", i+1)
+			break
+		}
+	}
+	qualification.RequireObservationVerdict(t, path, qualification.VerdictQualified)
+}
+
+// TestGeminiQualificationTwoPassWrite confirms the two-pass flow: the
+// non-final set validates at exactly 66+T+N records, the aggregate is
+// appended exactly once as the final line, and the final pass
+// independently recomputes the same verdict from 67+T+N records.
+func TestGeminiQualificationTwoPassWrite(t *testing.T) {
+	t.Parallel()
+
+	fixture := qualification.NewFixture(qualification.FixtureQualified)
+	fixture.Finalize()
+	T := qualification.TokenRecordCount(fixture.Records)
+	N := qualification.ProtocolSessionCount(fixture.Records)
+
+	path := geminiWriteQualificationObservations(t, geminiEvidenceDir(t), fixture.Records)
+
+	verdict, err := qualification.ValidateObservations(path)
+	if err != nil {
+		t.Fatalf("qualification.ValidateObservations() error = %v", err)
+	}
+	if verdict != qualification.VerdictQualified {
+		t.Errorf("first-pass verdict = %q, want %q", verdict, qualification.VerdictQualified)
+	}
+	if got := geminiEvidenceLineCount(t, path); got != 66+T+N {
+		t.Errorf("first-pass record count = %d, want exactly %d (T=%d, N=%d)", got, 66+T+N, T, N)
+	}
+
+	geminiAppendQualificationAggregate(t, path, verdict)
+	finalVerdict, err := qualification.ValidateEvidence(path)
+	if err != nil {
+		t.Fatalf("qualification.ValidateEvidence() error = %v", err)
+	}
+	if finalVerdict != qualification.VerdictQualified {
+		t.Errorf("final-pass verdict = %q, want %q", finalVerdict, qualification.VerdictQualified)
+	}
+	if got := geminiEvidenceLineCount(t, path); got != 67+T+N {
+		t.Errorf("final record count = %d, want exactly %d", got, 67+T+N)
+	}
+
+	complete, err := qualification.ReadEvidenceFile(path)
+	if err != nil {
+		t.Fatalf("qualification.ReadEvidenceFile() error = %v", err)
+	}
+	aggregate := complete[len(complete)-1]
+	if aggregate.Scenario != qualification.ScenarioQualification || aggregate.Grade != qualification.GradeQualified {
+		t.Errorf("final record = %s/%s, want the terminal qualified aggregate", aggregate.Scenario, aggregate.Grade)
+	}
+	qualificationCount := 0
+	for _, rec := range complete {
+		if rec.Scenario == qualification.ScenarioQualification {
+			qualificationCount++
+		}
+	}
+	if qualificationCount != 1 {
+		t.Errorf("qualification record count = %d, want exactly 1", qualificationCount)
+	}
+}
+
+// TestGeminiQualificationNotesRerunControl confirms the durable-notes
+// control: a rerun reads but never mutates the tracked notes, matches
+// them against the freshly validated summary, fails on a stale
+// conclusion, and lets the initial run stop after the validated summary
+// when the notes do not exist yet.
+func TestGeminiQualificationNotesRerunControl(t *testing.T) {
+	t.Parallel()
+
+	fixture := qualification.NewFixture(qualification.FixtureQualified)
+	fixture.Finalize()
+	conclusions, err := geminiSummaryConclusionsFromRecords(fixture.Records, qualification.VerdictQualified)
+	if err != nil {
+		t.Fatalf("geminiSummaryConclusionsFromRecords() error = %v", err)
+	}
+
+	t.Run("the initial run may stop after the validated summary", func(t *testing.T) {
+		t.Parallel()
+
+		notesPath := filepath.Join(t.TempDir(), "gemini-adapter-notes.md")
+		if geminiRunNotesConsistency(t, notesPath, conclusions, false) {
+			t.Error("geminiRunNotesConsistency() = true with no notes file, want the initial run to stop after the summary")
+		}
+	})
+
+	t.Run("a consistent rerun matches without editing the notes", func(t *testing.T) {
+		t.Parallel()
+
+		notesPath := writeGeminiNotesFile(t, geminiAdapterNotesFixture(conclusions))
+		before, err := os.ReadFile(notesPath)
+		if err != nil {
+			t.Fatalf("read notes fixture: %v", err)
+		}
+		if !geminiRunNotesConsistency(t, notesPath, conclusions, true) {
+			t.Error("geminiRunNotesConsistency() = false, want a matching rerun")
+		}
+		after, err := os.ReadFile(notesPath)
+		if err != nil {
+			t.Fatalf("read notes fixture after comparison: %v", err)
+		}
+		if string(before) != string(after) {
+			t.Error("the notes-consistency check mutated the durable notes, want a read-only comparison")
+		}
+	})
+
+	t.Run("a stale conclusion fails the rerun without editing the notes", func(t *testing.T) {
+		t.Parallel()
+
+		stale := strings.Replace(geminiAdapterNotesFixture(conclusions),
+			"- protocol turn_disposition: Observed: usable with a bounded evidence shape",
+			"- protocol turn_disposition: Not observed: not_observed with a bounded evidence shape", 1)
+		notesPath := writeGeminiNotesFile(t, stale)
+		before, err := os.ReadFile(notesPath)
+		if err != nil {
+			t.Fatalf("read stale notes fixture: %v", err)
+		}
+
+		compared, mismatch := geminiNotesConsistencyError(notesPath, conclusions)
+		if !compared {
+			t.Fatal("geminiNotesConsistencyError() compared = false, want the stale notes to be compared")
+		}
+		if mismatch == nil {
+			t.Error("geminiNotesConsistencyError() mismatch = nil, want the stale conclusion rejected")
+		}
+		after, err := os.ReadFile(notesPath)
+		if err != nil {
+			t.Fatalf("read stale notes fixture after the check: %v", err)
+		}
+		if string(before) != string(after) {
+			t.Error("the mismatch check mutated the durable notes, want a read-only comparison")
+		}
+	})
+}
+
+// geminiRunNativeProbe launches one native surface's bounded probe with
+// the qualification argv plus any documented per-input flags, the
+// minimum environment allowlist, and the controlled workspace, captures
+// its combined output, and drains its process group.
+func geminiRunNativeProbe(t *testing.T, runtime geminiQualificationRuntime, surface qualification.Surface, prompt string, extraArgs ...string) (string, error) {
+	t.Helper()
+
+	argv := append(geminiQualificationLaunchArgv(runtime.Config, surface, prompt, runtime.PolicyPath), extraArgs...)
+	cmd := exec.Command(argv[0], argv[1:]...) //nolint:gosec // the operator-selected executable with the documented flags
+	cmd.Dir = runtime.Workspace.Checkout
+	cmd.Env = runtime.Env
+
+	var output strings.Builder
+	cmd.Stdout = &output
+	cmd.Stderr = &output
+	if err := cmd.Start(); err != nil {
+		return output.String(), fmt.Errorf("native launch: %w", err)
+	}
+	done := make(chan error, 1)
+	go func() { done <- cmd.Wait() }()
+	select {
+	case waitErr := <-done:
+		_ = procutil.SignalProcessGroup(cmd.Process.Pid, syscall.SIGKILL)
+		return output.String(), waitErr
+	case <-time.After(geminiNativeProbeBound):
+		_ = procutil.SignalProcessGroup(cmd.Process.Pid, syscall.SIGKILL)
+		_, _ = cmd.Process.Wait()
+		return output.String(), errors.New("the native probe exceeded its bounded wait")
+	}
+}
+
+// geminiNativeTerminalMembers are the generic terminal member names the
+// harness recognizes in a native structured output. Recognition is by
+// message shape, never by runtime identity, and every unrecognized
+// shape stays not_observed.
+var geminiNativeTerminalMembers = []string{"stopReason", "stop_reason", "error", "is_error", "status"}
+
+// geminiNativeTerminal recognizes one native surface's terminal outcome
+// from its output. A text surface carries no terminal member this
+// harness recognizes and is characterized as unstructured. A structured
+// surface is recognized only through its closed generic member set;
+// anything else reports no distinct outcome.
+func geminiNativeTerminal(surface qualification.Surface, output string, launchErr error) (geminiProtocolTurnOutcome, bool) {
+	if surface == qualification.SurfaceNativeText {
+		// Unstructured residue is characterized, never graded usable.
+		return geminiProtocolTurnOutcome{}, false
+	}
+	if launchErr != nil {
+		// A bounded exit or timeout is the process ending without a
+		// recognizable terminal member: transport loss for the retry
+		// classification only when the surface said nothing else.
+		return geminiProtocolTurnOutcome{ErrKind: domain.ErrPortExit}, true
+	}
+	for rawLine := range strings.SplitSeq(output, "\n") {
+		line := strings.TrimSpace(rawLine)
+		if !strings.HasPrefix(line, "{") {
+			continue
+		}
+		var body map[string]json.RawMessage
+		if err := json.Unmarshal([]byte(line), &body); err != nil {
+			continue
+		}
+		for _, member := range geminiNativeTerminalMembers {
+			reason, ok := body[member]
+			if !ok {
+				continue
+			}
+			var value string
+			if err := json.Unmarshal(reason, &value); err != nil {
+				continue
+			}
+			outcome := geminiProtocolTurnOutcome{StopReason: stopReason(value)}
+			switch value {
+			case "end_turn", "success", "completed":
+				outcome.StopReason = stopReasonEndTurn
+			case "refusal", "declined":
+				outcome.ErrKind = domain.ErrTurnRefused
+			case "cancelled", "canceled":
+				outcome.ErrKind = domain.ErrTurnCancelled
+			case "max_tokens", "max_requests", "limit":
+				outcome.ErrKind = domain.ErrTurnFailed
+			default:
+				if _, exists := body["error"]; exists {
+					outcome.ErrKind = domain.ErrResponseError
+				}
+			}
+			return outcome, true
+		}
+	}
+	return geminiProtocolTurnOutcome{}, false
+}
+
+// geminiTokenLedger accumulates the token-bearing paths each surface's
+// bounded live runs exposed, for the per-surface inventories.
+type geminiTokenLedger struct {
+	mu      sync.Mutex
+	sources map[qualification.Surface][]geminiTokenSource
+}
+
+func newGeminiTokenLedger() *geminiTokenLedger {
+	return &geminiTokenLedger{sources: map[qualification.Surface][]geminiTokenSource{}}
+}
+
+// add records one surface's observed token sources, dropping duplicate
+// paths so the closed (surface, evidence_path) uniqueness key never
+// repeats.
+func (l *geminiTokenLedger) add(surface qualification.Surface, sources ...geminiTokenSource) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	seen := map[string]bool{}
+	for _, source := range l.sources[surface] {
+		seen[source.Path] = true
+	}
+	for _, source := range sources {
+		if source.Path == "" || seen[source.Path] {
+			continue
+		}
+		seen[source.Path] = true
+		l.sources[surface] = append(l.sources[surface], source)
+	}
+}
+
+// sorted returns one surface's collected sources in path order, so the
+// records land in the canonical token order.
+func (l *geminiTokenLedger) sorted(surface qualification.Surface) []geminiTokenSource {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	sources := append([]geminiTokenSource(nil), l.sources[surface]...)
+	slices.SortFunc(sources, func(a, b geminiTokenSource) int { return strings.Compare(a.Path, b.Path) })
+	return sources
+}
+
+// geminiCollectContinuationRecords runs every surface's continuation
+// seed and recall and returns their eight records.
+func geminiCollectContinuationRecords(t *testing.T, runtime geminiQualificationRuntime, tracker *geminiProcessGroupTracker, ledger *geminiTokenLedger, agentName string) []qualification.Record {
+	t.Helper()
+
+	records := []qualification.Record{}
+	seed, recall := geminiRunProtocolContinuation(t, runtime, tracker, ledger, agentName)
+	records = append(records, seed, recall)
+	for _, surface := range []qualification.Surface{qualification.SurfaceNativeText, qualification.SurfaceNativeJSON, qualification.SurfaceNativeStreamJSON} {
+		seed, recall := geminiRunNativeContinuation(t, runtime, surface)
+		records = append(records, seed, recall)
+	}
+	return records
+}
+
+// geminiRunProtocolContinuation runs the protocol surface's
+// continuation relation through the real adapter: a first process
+// stores the generated nonce, that session ends, and a second process
+// resumes through the adapter's own continuation route with its
+// invented-method control and replay requirement. The behavioral oracle
+// is the recall turn returning the nonce.
+func geminiRunProtocolContinuation(t *testing.T, runtime geminiQualificationRuntime, tracker *geminiProcessGroupTracker, ledger *geminiTokenLedger, agentName string) (seed, recall qualification.Record) {
+	t.Helper()
+
+	nonce := geminiNonce(t)
+	catalog := geminiSemanticInputCatalog(runtime.Probes, nonce)
+	adapter := &ClientProtocolAdapter{}
+	command := strings.Join(geminiQualificationLaunchArgv(runtime.Config, qualification.SurfaceProtocol, "", runtime.PolicyPath), " ")
+	startParams := func(resumeID string) domain.StartSessionParams {
+		return domain.StartSessionParams{
+			WorkspacePath: runtime.Workspace.Checkout,
+			AgentConfig: domain.AgentConfig{
+				Kind:           "agent-client-protocol",
+				Command:        command,
+				ReadTimeoutMS:  runtime.Timeouts.ReadTimeoutMS,
+				TurnTimeoutMS:  runtime.Timeouts.TurnTimeoutMS,
+				StallTimeoutMS: runtime.Timeouts.StallTimeoutMS,
+			},
+			ResumeSessionID: resumeID,
+		}
+	}
+
+	relation := geminiContinuationRelation{Surface: qualification.SurfaceProtocol}
+	seedSession, err := adapter.StartSession(context.Background(), startParams(""))
+	if err != nil {
+		return geminiLiveContinuationRecords(relation, agentName, runtime.Version)
+	}
+	tracker.register(geminiSessionGroupPID(seedSession))
+	t.Cleanup(func() {
+		_ = adapter.StopSession(context.Background(), seedSession)
+	})
+	var seedEvents []domain.AgentEvent
+	seedResult, seedErr := adapter.RunTurn(context.Background(), seedSession, domain.RunTurnParams{
+		Prompt:  catalog[qualification.InputContinuationSeed].Prompt,
+		OnEvent: collectEvents(&seedEvents),
+	})
+	if seedErr == nil && seedResult.UsageMeasured {
+		ledger.add(qualification.SurfaceProtocol, geminiTokenSource{
+			Path: "/turn/result/usage", Usage: &seedResult.Usage, SessionID: seedSession.ID,
+		})
+	}
+	relation.SeedSessionID = seedSession.ID
+	if seedErr != nil {
+		return geminiLiveContinuationRecords(relation, agentName, runtime.Version)
+	}
+	if err := adapter.StopSession(context.Background(), seedSession); err != nil {
+		t.Errorf("stop the protocol continuation seed session: %v", err)
+	}
+
+	recallSession, err := adapter.StartSession(context.Background(), startParams(seedSession.ID))
+	if err != nil {
+		return geminiLiveContinuationRecords(relation, agentName, runtime.Version)
+	}
+	tracker.register(geminiSessionGroupPID(recallSession))
+	t.Cleanup(func() {
+		_ = adapter.StopSession(context.Background(), recallSession)
+	})
+	var recallEvents []domain.AgentEvent
+	recallResult, recallErr := adapter.RunTurn(context.Background(), recallSession, domain.RunTurnParams{
+		Prompt:  catalog[qualification.InputContinuationRecall].Prompt,
+		OnEvent: collectEvents(&recallEvents),
+	})
+	if recallErr == nil && recallResult.UsageMeasured {
+		ledger.add(qualification.SurfaceProtocol, geminiTokenSource{
+			Path: "/turn/result/usage", Usage: &recallResult.Usage, SessionID: recallSession.ID,
+		})
+	}
+	relation.RecallSessionID = recallSession.ID
+	relation.ReplayConfirmed = recallErr == nil && geminiEventsCarry(recallEvents, nonce)
+	if !relation.ReplayConfirmed && relation.RecallSessionID == relation.SeedSessionID {
+		// Equal ids without the behavioral oracle stay honestly
+		// unobserved rather than a fresh fallback with equal ids, which
+		// the closed relation rejects.
+		relation.RecallSessionID = ""
+	}
+	return geminiLiveContinuationRecords(relation, agentName, runtime.Version)
+}
+
+// geminiRunNativeContinuation runs one native surface's continuation
+// relation: the seed process carries a test-generated --session-id and
+// stores the nonce, that process ends, and a second process resumes
+// with the documented --resume latest selector. The recall's actual
+// identifier is the runtime-observed one, never a copy of the requested
+// id, and the behavioral oracle is the nonce's return in the output.
+func geminiRunNativeContinuation(t *testing.T, runtime geminiQualificationRuntime, surface qualification.Surface) (seed, recall qualification.Record) {
+	t.Helper()
+
+	nonce := geminiNonce(t)
+	catalog := geminiSemanticInputCatalog(runtime.Probes, nonce)
+	generated := geminiGeneratedNativeSessionID(t)
+	nativeName := filepath.Base(runtime.Config.CommandPath)
+
+	seedOutput, seedErr := geminiRunNativeProbe(t, runtime, surface, catalog[qualification.InputContinuationSeed].Prompt,
+		"--session-id", generated)
+	if seedErr != nil {
+		return geminiLiveContinuationRecords(geminiContinuationRelation{Surface: surface}, nativeName, runtime.Version)
+	}
+	seedID := geminiNativeSessionID(surface, seedOutput)
+	if seedID == "" {
+		seedID = generated
+	}
+
+	recallOutput, recallErr := geminiRunNativeProbe(t, runtime, surface, catalog[qualification.InputContinuationRecall].Prompt,
+		"--resume", "latest")
+	relation := geminiContinuationRelation{Surface: surface, SeedSessionID: seedID}
+	if recallErr != nil {
+		return geminiLiveContinuationRecords(relation, nativeName, runtime.Version)
+	}
+	relation.RecallSessionID = geminiNativeSessionID(surface, recallOutput)
+	relation.ReplayConfirmed = strings.Contains(recallOutput, nonce)
+	if !relation.ReplayConfirmed && relation.RecallSessionID == relation.SeedSessionID {
+		// Equal ids without the behavioral oracle stay honestly
+		// unobserved rather than a fresh fallback with equal ids, which
+		// the closed relation rejects.
+		relation.RecallSessionID = ""
+	}
+	return geminiLiveContinuationRecords(relation, nativeName, runtime.Version)
+}
+
+// geminiGeneratedNativeSessionID generates one public test session
+// identifier (an RFC 4122 version 4 UUID) for a native continuation
+// seed launch.
+func geminiGeneratedNativeSessionID(t *testing.T) string {
+	t.Helper()
+	var buf [16]byte
+	if _, err := cryptorand.Read(buf[:]); err != nil {
+		t.Fatalf("generate the native seed session identifier: %v", err)
+	}
+	buf[6] = (buf[6] & 0x0f) | 0x40
+	buf[8] = (buf[8] & 0x3f) | 0x80
+	return fmt.Sprintf("%x-%x-%x-%x-%x", buf[0:4], buf[4:6], buf[6:8], buf[8:10], buf[10:16])
+}
+
+// geminiIdentityRecordsForReferenced emits exactly one runtime-identity
+// record for every distinct non-null actual protocol session id the
+// non-final records reference, built from the session's own structured
+// implementation log, and none for any other session.
+func geminiIdentityRecordsForReferenced(t *testing.T, capture *geminiLogCapture, records []qualification.Record, agentName, agentVersion string) []qualification.Record {
+	t.Helper()
+
+	referenced := map[string]bool{}
+	for i := range records {
+		rec := &records[i]
+		if rec.Surface == qualification.SurfaceProtocol && rec.SessionID != nil {
+			referenced[*rec.SessionID] = true
+		}
+	}
+	ids := slices.Collect(maps.Keys(referenced))
+	slices.Sort(ids)
+	out := []qualification.Record{}
+	for _, id := range ids {
+		name, version, ok := capture.sessionFacts(id)
+		if !ok {
+			// A missing agentInfo stays an explicit identity gap: the
+			// record exists, its handshake facts stay null, and the
+			// classification is not usable.
+			rec := qualification.IdentityFixtureRecord(id)
+			rec.AgentName = nil
+			rec.AgentVersion = nil
+			rec.Grade = qualification.GradeNotObserved
+			rec.Outcome = qualification.OutcomeNotObserved
+			rec.Detail = "the session's implementation log carried no handshake identity"
+			out = append(out, rec)
+			continue
+		}
+		if name == "" {
+			name = agentName
+		}
+		if version == "" {
+			version = agentVersion
+		}
+		out = append(out, geminiIdentityRecord(id, name, version, 1))
+	}
+	return out
+}
+
+// geminiRunAuthenticationCanary runs one bounded headless canary in the
+// isolated configuration home and distinguishes usable authentication
+// from a model call failure without printing any credential name or
+// value. A canary that does not produce its marker is a prerequisite
+// failure of the enabled gate.
+func geminiRunAuthenticationCanary(t *testing.T, runtime geminiQualificationRuntime) {
+	t.Helper()
+
+	output, err := geminiRunNativeProbe(t, runtime, qualification.SurfaceNativeText,
+		"Reply with exactly SORTIE_AUTH_OK and do not call any tool.")
+	if err == nil && strings.Contains(output, "SORTIE_AUTH_OK") {
+		return
+	}
+	t.Fatal("the authentication canary did not produce its marker: usable authentication could not be distinguished from a model call failure, and no credential name or value is reported")
+}
+
+// TestGeminiQualification is the Unix live qualification test. With the
+// gate disabled it skips with the one explicit reason. With the gate
+// enabled it fails rather than skips on any missing prerequisite,
+// fixture, observation, evidence, or cleanup failure, and computes and
+// records the eligibility verdict with no manual override.
+func TestGeminiQualification(t *testing.T) {
+	config := requireGeminiQualification(t)
+	result := collectGeminiQualification(t, config)
+	if result.Verdict != qualification.VerdictQualified && result.Verdict != qualification.VerdictNotQualified {
+		t.Fatalf("collectGeminiQualification() verdict = %q, want exactly qualified or not_qualified", result.Verdict)
+	}
+}
+
+// collectGeminiQualification runs the complete live qualification: it
+// resolves the coordinates once, proves the prerequisites, collects the
+// bounded observations across all four surfaces, writes and validates
+// the two-pass JSONL evidence, prints the bounded summary, compares the
+// durable notes when they exist, and applies the exact process-group
+// absence oracle to every captured group. Any enabled-prerequisite,
+// fixture, evidence, or cleanup failure fails the test; nothing here
+// ever skips.
+func collectGeminiQualification(t *testing.T, config geminiQualificationConfig) geminiQualificationResult {
+	t.Helper()
+
+	// Every adapter session's structured implementation log feeds the
+	// runtime-identity records; the capture never mutates production
+	// logging beyond restoring the previous default handler.
+	capture := &geminiLogCapture{}
+	previousLogger := slog.Default()
+	slog.SetDefault(slog.New(capture))
+	t.Cleanup(func() { slog.SetDefault(previousLogger) })
+
+	runtime := geminiResolveQualificationRuntime(t, config)
+	tracker := &geminiProcessGroupTracker{}
+	ledger := newGeminiTokenLedger()
+	dir := geminiEvidenceDir(t)
+
+	// The authentication canary is the live credential prerequisite.
+	geminiRunAuthenticationCanary(t, runtime)
+
+	// Workspace security is recorded first, from fixture facts only.
+	workspaceRecord := geminiWorkspaceSecurityRecord(geminiWorkspaceSecurityFacts{
+		PresentProjectConfig: geminiPresentProjectGeminiConfig(runtime.Workspace.Checkout),
+		HomeClass:            "run_scoped_temp",
+		CLIHomeClass:         "run_scoped_temp",
+		EnvNames:             config.EnvAllowlist,
+		SkipTrustUsed:        true,
+		TrustPromptObserved:  false,
+		MemberBasenames:      append([]string{filepath.Base(config.CommandPath)}, runtime.Probes.names()...),
+	})
+
+	// The protocol surface's control records: policy precondition,
+	// permission, and MCP receipt.
+	protocolRecords := geminiCollectProtocolRecords(t, runtime, tracker, ledger)
+	agentName := geminiHandshakeAgentName(capture, filepath.Base(config.CommandPath))
+
+	// The four surfaces' semantic probes and derived baselines.
+	surfaceRecords := geminiCollectSurfaceRecords(t, runtime, tracker, ledger)
+
+	// Every surface's continuation seed and recall.
+	continuationRecords := geminiCollectContinuationRecords(t, runtime, tracker, ledger, agentName)
+
+	// The per-surface token inventories, one record per observed path
+	// or the single sentinel.
+	tokenRecords := []qualification.Record{}
+	for _, surface := range qualification.MeasuredSurfaces {
+		tokenRecords = append(tokenRecords, geminiLiveTokenInventoryRecords(
+			surface, ledger.sorted(surface), false, agentName, runtime.Version)...)
+	}
+
+	// The isolated end-to-end run with the real protocol adapter.
+	e2eRecord := geminiCollectEndToEndRecord(t, runtime, agentName)
+
+	// The bounded process-group cleanup oracle.
+	cleanupRecord := geminiCollectCleanupRecord(t, tracker)
+
+	observations := slices.Concat(
+		[]qualification.Record{workspaceRecord},
+		protocolRecords,
+		surfaceRecords,
+		tokenRecords,
+		continuationRecords,
+		[]qualification.Record{e2eRecord, cleanupRecord},
+	)
+
+	// The derived baselines follow their own complete observations.
+	records := slices.Concat(observations, geminiBaselineRecords(t, observations))
+
+	// One runtime-identity record per referenced actual protocol
+	// session, from each session's own structured log.
+	records = append(records, geminiIdentityRecordsForReferenced(t, capture, records, agentName, runtime.Version)...)
+
+	verdict, summary, count := geminiRunTwoPassEvidenceFlow(t, dir, records)
+	t.Logf("%s", summary)
+
+	// On a rerun the durable notes must match the fresh summary; an
+	// initial run without notes yet stops after the validated summary.
+	notesPath, notesErr := filepath.Abs(geminiAdapterNotesRelPath)
+	if notesErr == nil {
+		geminiRunNotesConsistency(t, notesPath, geminiFreshConclusions(t, dir, verdict), false)
+	}
+
+	return geminiQualificationResult{
+		Verdict:         verdict,
+		Summary:         summary,
+		EvidenceRecords: count,
+	}
+}
+
+// geminiFreshConclusions derives the bounded conclusions from the
+// validated evidence file.
+func geminiFreshConclusions(t *testing.T, dir string, verdict qualification.Verdict) geminiSummaryConclusions {
+	t.Helper()
+	complete, err := qualification.ReadEvidenceFile(filepath.Join(dir, "evidence.jsonl"))
+	if err != nil {
+		t.Fatalf("read the validated evidence file: %v", err)
+	}
+	conclusions, err := geminiSummaryConclusionsFromRecords(complete[:len(complete)-1], verdict)
+	if err != nil {
+		t.Fatalf("derive the bounded conclusions: %v", err)
+	}
+	return conclusions
+}
+
+// geminiCollectProtocolRecords collects the protocol surface's policy
+// precondition, permission, MCP, continuation, and runtime-identity
+// records through the real generic adapter, from live bounded turns.
+func geminiCollectProtocolRecords(t *testing.T, runtime geminiQualificationRuntime, tracker *geminiProcessGroupTracker, ledger *geminiTokenLedger) []qualification.Record {
+	t.Helper()
+
+	catalog := geminiSemanticInputCatalog(runtime.Probes, geminiNonce(t))
+	adapter := &ClientProtocolAdapter{}
+	command := strings.Join(geminiQualificationLaunchArgv(runtime.Config, qualification.SurfaceProtocol, "", runtime.PolicyPath), " ")
+	session, err := adapter.StartSession(context.Background(), domain.StartSessionParams{
+		WorkspacePath: runtime.Workspace.Checkout,
+		AgentConfig: domain.AgentConfig{
+			Kind:           "agent-client-protocol",
+			Command:        command,
+			ReadTimeoutMS:  runtime.Timeouts.ReadTimeoutMS,
+			TurnTimeoutMS:  runtime.Timeouts.TurnTimeoutMS,
+			StallTimeoutMS: runtime.Timeouts.StallTimeoutMS,
+		},
+		MCPConfigPath: runtime.MCP.ConfigPath,
+	})
+	if err != nil {
+		t.Fatalf("start the protocol control session: %v", err)
+	}
+	tracker.register(geminiSessionGroupPID(session))
+	t.Cleanup(func() {
+		if err := adapter.StopSession(context.Background(), session); err != nil {
+			t.Errorf("stop the protocol control session: %v", err)
+		}
+	})
+
+	var events []domain.AgentEvent
+	runProbe := func(prompt string) (domain.TurnResult, error) {
+		return adapter.RunTurn(context.Background(), session, domain.RunTurnParams{
+			Prompt:  prompt,
+			OnEvent: collectEvents(&events),
+		})
+	}
+
+	// The policy precondition: one turn instructing run_shell_command
+	// with the policy-load probe. The precondition passes only when the
+	// captured tool result carries the deny marker and the probe's
+	// side-effect file stays absent.
+	policySessionID := session.ID
+	policyResult, policyErr := runProbe(catalog[qualification.InputPolicyControl].Prompt)
+	if policyErr == nil && policyResult.UsageMeasured {
+		ledger.add(qualification.SurfaceProtocol, geminiTokenSource{
+			Path: "/turn/result/usage", Usage: &policyResult.Usage, SessionID: session.ID,
+		})
+	}
+	policyObserved := policyErr == nil &&
+		geminiEventsCarry(events, runtime.PolicyDenyMarker) &&
+		geminiProbeMarkerAbsent(t, runtime.Probes.PolicyLoad)
+	policyRecord := qualification.Record{
+		SchemaVersion: 1,
+		ObservedAt:    qualification.FixtureTime,
+		Scenario:      qualification.ScenarioPolicyPrecondition,
+		Surface:       qualification.SurfaceAggregate,
+		Capability:    qualification.CapabilityPermissionHandling,
+		Source:        qualification.SourceProcessObservation,
+		InputID:       qualification.InputPolicyControl,
+		EvidencePath:  new("policy.deny_marker"),
+		SessionID:     new(policySessionID),
+		AgentVersion:  new(runtime.Version),
+	}
+	switch {
+	case policyResultExitFailed(policyErr):
+		policyRecord.Outcome = qualification.OutcomePrerequisiteFailed
+		policyRecord.Grade = qualification.GradeNotObserved
+		policyRecord.Detail = "the policy control turn did not complete"
+	case policyObserved:
+		policyRecord.Outcome = qualification.OutcomePass
+		policyRecord.Grade = qualification.GradeUsable
+		policyRecord.Detail = "policy deny marker returned and the probe side effect stayed absent"
+	default:
+		policyRecord.Outcome = qualification.OutcomeFixtureInductionFailed
+		policyRecord.Grade = qualification.GradeNotObserved
+		policyRecord.Detail = "the policy control tool call was not induced"
+	}
+
+	// The permission probe: exactly one attempt, no retry until a
+	// desired result appears.
+	permissionResult, permissionErr := runProbe(catalog[qualification.InputPermissionProbe].Prompt)
+	if permissionErr == nil && permissionResult.UsageMeasured {
+		ledger.add(qualification.SurfaceProtocol, geminiTokenSource{
+			Path: "/turn/result/usage", Usage: &permissionResult.Usage, SessionID: session.ID,
+		})
+	}
+	permissionRequested := geminiPermissionRequested(events)
+	permissionAnswered := geminiPermissionAnswered(events)
+	permissionRecord := qualification.Record{
+		SchemaVersion:   1,
+		ObservedAt:      qualification.FixtureTime,
+		Scenario:        qualification.ScenarioPermissionRequest,
+		Surface:         qualification.SurfaceProtocol,
+		Capability:      qualification.CapabilityPermissionHandling,
+		Source:          qualification.SourceProtocolStable,
+		InputID:         qualification.InputPermissionProbe,
+		EvidencePath:    new("session/request_permission"),
+		SessionID:       new(session.ID),
+		AgentName:       new(filepath.Base(runtime.Config.CommandPath)),
+		AgentVersion:    new(runtime.Version),
+		ProtocolVersion: new(1),
+	}
+	switch {
+	case !permissionRequested:
+		permissionRecord.Outcome = qualification.OutcomeFixtureInductionFailed
+		permissionRecord.Grade = qualification.GradeNotObserved
+		permissionRecord.Detail = "no permission request was emitted for the controlled operation"
+	case !permissionAnswered:
+		permissionRecord.Outcome = qualification.OutcomeAdapterUnanswered
+		permissionRecord.Grade = qualification.GradeNotObserved
+		permissionRecord.Detail = "the request was captured but no correlated client response arrived within the read timeout"
+	default:
+		permissionRecord.Outcome = qualification.OutcomePass
+		permissionRecord.Grade = qualification.GradeUsable
+		permissionRecord.Detail = "request answered with a refusing option and no request left pending"
+	}
+	_ = permissionErr
+
+	// The MCP probe: delivery is graded only on server receipt plus the
+	// turn consuming the returned nonce.
+	mcpResult, mcpErr := runProbe(catalog[qualification.InputMCPProbe].Prompt)
+	if mcpErr == nil && mcpResult.UsageMeasured {
+		ledger.add(qualification.SurfaceProtocol, geminiTokenSource{
+			Path: "/turn/result/usage", Usage: &mcpResult.Usage, SessionID: session.ID,
+		})
+	}
+	received := geminiReadMCPReceipt(t, runtime.MCP)
+	turnConsumed := mcpErr == nil && geminiEventsCarry(events, runtime.MCP.Nonce)
+	mcpRecord := qualification.Record{
+		SchemaVersion:   1,
+		ObservedAt:      qualification.FixtureTime,
+		Scenario:        qualification.ScenarioToolServer,
+		Surface:         qualification.SurfaceProtocol,
+		Capability:      qualification.CapabilityToolServerDelivery,
+		Source:          qualification.SourceProcessObservation,
+		Grade:           geminiGradeMCPDelivery(received, runtime.MCP.Nonce, turnConsumed),
+		Outcome:         qualification.OutcomePass,
+		InputID:         qualification.InputMCPProbe,
+		EvidencePath:    new("mcp_server.receipt"),
+		SessionID:       new(session.ID),
+		AgentName:       new(filepath.Base(runtime.Config.CommandPath)),
+		AgentVersion:    new(runtime.Version),
+		ProtocolVersion: new(1),
+		Detail:          "test server receipt and the turn's returned nonce",
+	}
+	if got := geminiGradeMCPDelivery(received, runtime.MCP.Nonce, turnConsumed); got != qualification.GradeUsable {
+		mcpRecord.Outcome = qualification.OutcomeNotObserved
+		mcpRecord.Detail = "no server receipt or unconsumed returned nonce"
+	}
+
+	return []qualification.Record{policyRecord, permissionRecord, mcpRecord}
+}
+
+// geminiSessionGroupPID returns the session's process-group leader PID.
+// procutil.SetProcessGroup makes the launched leader's PID the PGID.
+func geminiSessionGroupPID(session domain.Session) int {
+	pid, err := strconv.Atoi(session.AgentPID)
+	if err != nil || pid <= 0 {
+		return 0
+	}
+	return pid
+}
+
+// geminiEventsCarry reports whether any event message carries needle.
+func geminiEventsCarry(events []domain.AgentEvent, needle string) bool {
+	return slices.ContainsFunc(events, func(event domain.AgentEvent) bool {
+		return strings.Contains(event.Message, needle)
+	})
+}
+
+// geminiProbeMarkerAbsent reports whether a probe's side-effect file is
+// absent, the no-side-effect condition the policy precondition and the
+// permission scenarios require.
+func geminiProbeMarkerAbsent(t *testing.T, probePath string) bool {
+	t.Helper()
+	if _, err := os.Stat(geminiProbeMarkerPath(probePath)); errors.Is(err, os.ErrNotExist) {
+		return true
+	}
+	return false
+}
+
+// geminiPermissionNoticeStem is the observable stem of the adapter's
+// own refusal notice for a permission request, the message-shape
+// observation the permission scenario reads.
+const geminiPermissionNoticeStem = "refused a permission request"
+
+// geminiPermissionRequested reports whether the adapter observed and
+// answered a session/request_permission request during the turn: the
+// adapter emits its refusal notice when it handles one, and never on
+// an unanswered request.
+func geminiPermissionRequested(events []domain.AgentEvent) bool {
+	return geminiEventsCarry(events, geminiPermissionNoticeStem)
+}
+
+// geminiPermissionAnswered reports whether the adapter's own handling
+// of the permission request reached the turn's events, which is the
+// observable correlated reply the permission record requires.
+func geminiPermissionAnswered(events []domain.AgentEvent) bool {
+	return geminiEventsCarry(events, geminiPermissionNoticeStem)
+}
+
+// policyResultExitFailed reports whether the policy-control turn ended
+// in an error the precondition cannot be read from.
+func policyResultExitFailed(err error) bool {
+	return err != nil
+}
+
+// geminiCollectSurfaceRecords collects the four surfaces' semantic
+// probes, derived baselines, and token inventory inputs in canonical
+// order.
+func geminiCollectSurfaceRecords(t *testing.T, runtime geminiQualificationRuntime, tracker *geminiProcessGroupTracker, ledger *geminiTokenLedger) []qualification.Record {
+	t.Helper()
+
+	catalog := geminiSemanticInputCatalog(runtime.Probes, geminiNonce(t))
+	records := []qualification.Record{}
+	refusalRuns := map[qualification.Surface]geminiSemanticObservation{}
+
+	for _, surface := range qualification.MeasuredSurfaces {
+		for _, capability := range []qualification.Capability{qualification.CapabilityTurnDisposition, qualification.CapabilityRetryClassification} {
+			for _, caseID := range qualification.CapabilityCases[capability] {
+				var obs geminiSemanticObservation
+				if capability == qualification.CapabilityRetryClassification && caseID == qualification.CaseNonRetryableRefusal {
+					// The non-retryable-refusal retry record references
+					// the same physical run as its surface's refusal
+					// disposition record; it is never a second launch.
+					refusalObs := refusalRuns[surface]
+					refusalObs.Tag = qualification.CaseNonRetryableRefusal
+					obs = refusalObs
+				} else {
+					obs = geminiCollectSemanticCase(t, runtime, tracker, surface, caseID, catalog, ledger)
+					if capability == qualification.CapabilityTurnDisposition && caseID == qualification.CaseRuntimeRefusal {
+						refusalRuns[surface] = obs
+					}
+				}
+				records = append(records, geminiSemanticRecordFor(surface, capability, caseID, obs))
+			}
+		}
+	}
+	return records
+}
+
+// geminiBaselineRecords derives all 16 per-surface comparison baselines
+// from their own complete observations, so a written baseline can never
+// differ from its derivation.
+func geminiBaselineRecords(t *testing.T, prior []qualification.Record) []qualification.Record {
+	t.Helper()
+
+	records := []qualification.Record{}
+	for _, surface := range qualification.MeasuredSurfaces {
+		for _, capability := range qualification.ComparisonCapabilities {
+			grade := geminiDeriveBaseline(t, surface, capability, prior)
+			records = append(records, qualification.Record{
+				SchemaVersion: 1,
+				ObservedAt:    qualification.FixtureTime,
+				Scenario:      qualification.ScenarioSurfaceBaseline,
+				Surface:       surface,
+				Capability:    capability,
+				Source:        qualification.SourceComparison,
+				Grade:         grade,
+				Outcome:       qualification.BaselineVerdictFor(grade),
+				InputID:       qualification.InputBaseline,
+				EvidencePath:  new(fmt.Sprintf("/comparison/%s/%s", surface, capability)),
+				Detail:        fmt.Sprintf("derived %s grade for %s", capability, surface),
+			})
+		}
+	}
+	return records
+}
+
+// geminiCollectSemanticCase launches one case's bounded probe on one
+// surface and returns its observation.
+func geminiCollectSemanticCase(t *testing.T, runtime geminiQualificationRuntime, tracker *geminiProcessGroupTracker, surface qualification.Surface, caseID qualification.Case, catalog map[qualification.InputID]geminiInputSpec, ledger *geminiTokenLedger) geminiSemanticObservation {
+	t.Helper()
+
+	inputID, known := qualification.CaseInputs[caseID]
+	if !known {
+		return geminiSemanticObservation{Tag: caseID, Detail: "unknown semantic case"}
+	}
+	spec, inCatalog := catalog[inputID]
+	if !inCatalog || !spec.Launch {
+		// limit_reached and the refusal-retry reference: no separate
+		// launch, an honest not_observed.
+		return geminiSemanticObservation{Tag: caseID, Induced: false}
+	}
+
+	switch surface {
+	case qualification.SurfaceProtocol:
+		return geminiInduceProtocolCase(t, runtime, tracker, caseID, catalog, ledger)
+	default:
+		return geminiInduceNativeCase(t, runtime, surface, caseID, catalog, ledger)
+	}
+}
+
+// geminiInduceProtocolCase runs one protocol case's live probe through
+// the adapter's own session lifecycle.
+func geminiInduceProtocolCase(t *testing.T, runtime geminiQualificationRuntime, tracker *geminiProcessGroupTracker, caseID qualification.Case, catalog map[qualification.InputID]geminiInputSpec, ledger *geminiTokenLedger) geminiSemanticObservation {
+	t.Helper()
+
+	adapter := &ClientProtocolAdapter{}
+	command := strings.Join(geminiQualificationLaunchArgv(runtime.Config, qualification.SurfaceProtocol, "", runtime.PolicyPath), " ")
+	session, err := adapter.StartSession(context.Background(), domain.StartSessionParams{
+		WorkspacePath: runtime.Workspace.Checkout,
+		AgentConfig: domain.AgentConfig{
+			Command:        command,
+			ReadTimeoutMS:  runtime.Timeouts.ReadTimeoutMS,
+			TurnTimeoutMS:  runtime.Timeouts.TurnTimeoutMS,
+			StallTimeoutMS: runtime.Timeouts.StallTimeoutMS,
+		},
+	})
+	if err != nil {
+		return geminiSemanticObservation{Tag: caseID, Failure: qualification.OutcomePrerequisiteFailed}
+	}
+	tracker.register(geminiSessionGroupPID(session))
+	t.Cleanup(func() {
+		if err := adapter.StopSession(context.Background(), session); err != nil {
+			t.Errorf("stop the probe session: %v", err)
+		}
+	})
+
+	observation := geminiSemanticObservation{Tag: caseID, SessionID: session.ID, EvidencePath: "/turn/stop_reason"}
+
+	switch caseID {
+	case qualification.CaseCancellation:
+		// The marker proves the child is active; the single
+		// cancellation is the adapter's own session/cancel through the
+		// bounded context.
+		probeCtx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		turnDone := make(chan turnOutcome, 1)
+		go func() {
+			var turnEvents []domain.AgentEvent
+			result, err := adapter.RunTurn(probeCtx, session, domain.RunTurnParams{
+				Prompt:  catalog[qualification.InputDispositionCancellation].Prompt,
+				OnEvent: collectEvents(&turnEvents),
+			})
+			turnDone <- turnOutcome{result: result, err: err}
+		}()
+		waitForFile(t, geminiProbeMarkerPath(runtime.Probes.Cancellation), geminiSemanticProbeTimeout)
+		cancel()
+		outcome := <-turnDone
+		if agentErr, ok := errors.AsType[*domain.AgentError](outcome.err); ok {
+			observation.Induced = true
+			observation.Distinct = agentErr.Kind == domain.ErrTurnCancelled
+			observation.Structured = true
+		} else if outcome.err == nil {
+			observation.Induced = true
+			observation.Distinct = false
+			observation.Structured = true
+		}
+		return observation
+
+	case qualification.CaseRetryableTransport:
+		turnDone := make(chan turnOutcome, 1)
+		go func() {
+			var turnEvents []domain.AgentEvent
+			result, err := adapter.RunTurn(context.Background(), session, domain.RunTurnParams{
+				Prompt:  catalog[qualification.InputRetryableTransport].Prompt,
+				OnEvent: collectEvents(&turnEvents),
+			})
+			turnDone <- turnOutcome{result: result, err: err}
+		}()
+		waitForFile(t, geminiProbeMarkerPath(runtime.Probes.Transport), geminiSemanticProbeTimeout)
+		_ = procutil.SignalProcessGroup(geminiSessionGroupPID(session), syscall.SIGKILL)
+		outcome := <-turnDone
+		if outcome.result.UsageMeasured {
+			ledger.add(qualification.SurfaceProtocol, geminiTokenSource{
+				Path: "/turn/result/usage", Usage: &outcome.result.Usage, SessionID: session.ID,
+			})
+		}
+		observation.Induced = true
+		if agentErr, ok := outcome.err.(*domain.AgentError); ok && agentErr.Kind == domain.ErrPortExit {
+			observation.Distinct = true
+			observation.Structured = true
+		}
+		return observation
+
+	default:
+		var turnEvents []domain.AgentEvent
+		turnResult, turnErr := adapter.RunTurn(context.Background(), session, domain.RunTurnParams{
+			Prompt:  catalog[qualification.CaseInputs[caseID]].Prompt,
+			OnEvent: collectEvents(&turnEvents),
+		})
+		if turnErr == nil && turnResult.UsageMeasured {
+			ledger.add(qualification.SurfaceProtocol, geminiTokenSource{
+				Path: "/turn/result/usage", Usage: &turnResult.Usage, SessionID: session.ID,
+			})
+		}
+		outcome := geminiProtocolTurnOutcome{Attributed: true}
+		if agentErr, ok := errors.AsType[*domain.AgentError](turnErr); ok {
+			outcome.ErrKind = agentErr.Kind
+		}
+		if caseID == qualification.CaseSuccess && turnErr == nil {
+			outcome.StopReason = stopReasonEndTurn
+		}
+		if mapped, distinct := geminiProtocolCase(outcome); distinct && mapped == caseID {
+			observation.Induced = true
+			observation.Distinct = true
+			observation.Structured = true
+		}
+		return observation
+	}
+}
+
+// geminiInduceNativeCase launches one native surface's case probe and
+// classifies the captured output, feeding any token-bearing structured
+// member the output carries into the surface's inventory.
+func geminiInduceNativeCase(t *testing.T, runtime geminiQualificationRuntime, surface qualification.Surface, caseID qualification.Case, catalog map[qualification.InputID]geminiInputSpec, ledger *geminiTokenLedger) geminiSemanticObservation {
+	t.Helper()
+
+	inputID := qualification.CaseInputs[caseID]
+	observation := geminiSemanticObservation{Tag: caseID, EvidencePath: "/output/terminal"}
+
+	output, launchErr := geminiRunNativeProbe(t, runtime, surface, catalog[inputID].Prompt)
+	nativeSession := geminiNativeSessionID(surface, output)
+	ledger.add(surface, geminiScanNativeTokenOutput(surface, output, nativeSession)...)
+	outcome, structured := geminiNativeTerminal(surface, output, launchErr)
+	observation.Structured = structured
+	observation.Induced = launchErr == nil
+	if mapped, distinct := geminiProtocolCase(outcome); distinct && mapped == caseID && structured {
+		observation.Distinct = true
+	}
+	// The text surface is characterized as unstructured residue; every
+	// induced text case grades gap through Structured=false.
+	return observation
+}
+
+// geminiDeriveBaseline derives one capability's baseline grade for one
+// surface from the records collected so far, so a written baseline can
+// never differ from its own derivation.
+func geminiDeriveBaseline(t *testing.T, surface qualification.Surface, capability qualification.Capability, records []qualification.Record) qualification.Grade {
+	t.Helper()
+
+	switch capability {
+	case qualification.CapabilityTurnDisposition, qualification.CapabilityRetryClassification:
+		var classes []qualification.Grade
+		for _, caseID := range qualification.CapabilityCases[capability] {
+			found := false
+			for i := range records {
+				rec := &records[i]
+				if rec.Scenario == qualification.ScenarioSemanticProbe && rec.Surface == surface &&
+					rec.Capability == capability && rec.SemanticCase != nil && *rec.SemanticCase == caseID {
+					classes = append(classes, rec.Grade)
+					found = true
+					break
+				}
+			}
+			if !found {
+				return qualification.GradeNotObserved
+			}
+		}
+		return qualification.DeriveBaselineGrade(classes)
+	case qualification.CapabilityTokenCeiling:
+		// The baseline follows the surface's complete inventory: a
+		// consumable source grades usable, a completed inventory
+		// without one grades gap, and a failed inventory grades
+		// not_observed.
+		completed := false
+		for i := range records {
+			rec := &records[i]
+			if rec.Scenario != qualification.ScenarioTokenSource || rec.Surface != surface || rec.Capability != qualification.CapabilityTokenCeiling {
+				continue
+			}
+			if rec.EvidencePath == nil {
+				if rec.Grade == qualification.GradeNotObserved {
+					return qualification.GradeNotObserved
+				}
+				completed = true
+				continue
+			}
+			if rec.Grade == qualification.GradeUsable {
+				return qualification.GradeUsable
+			}
+			completed = true
+		}
+		if completed {
+			return qualification.GradeGap
+		}
+		return qualification.GradeNotObserved
+	case qualification.CapabilitySessionContinuation:
+		// The baseline follows the recall record's own classification.
+		for i := range records {
+			rec := &records[i]
+			if rec.Scenario == qualification.ScenarioContinuation && rec.Surface == surface && rec.InputID == qualification.InputContinuationRecall {
+				return rec.Grade
+			}
+		}
+		return qualification.GradeNotObserved
+	default:
+		return qualification.GradeNotObserved
+	}
+}
+
+// geminiCollectCleanupRecord applies the bounded absence oracle to
+// every captured process group and builds the single cleanup record.
+func geminiCollectCleanupRecord(t *testing.T, tracker *geminiProcessGroupTracker) qualification.Record {
+	t.Helper()
+
+	survivors := false
+	for _, pgid := range tracker.groups {
+		present, err := geminiProcessGroupPresent(pgid)
+		if err != nil {
+			return geminiProcessCleanupRecord(tracker.count(), true)
+		}
+		if present {
+			_ = procutil.SignalProcessGroup(pgid, syscall.SIGKILL)
+			if !geminiAwaitGroupDrain(t, pgid, geminiQualificationShutdownDeadline) {
+				survivors = true
+			}
+		}
+	}
+	return geminiProcessCleanupRecord(tracker.count(), survivors)
+}
+
+// geminiCollectEndToEndRecord drives the isolated file-tracker E2E
+// harness with the real protocol adapter and builds its record from the
+// actual protocol session the harness's observer captured.
+func geminiCollectEndToEndRecord(t *testing.T, runtime geminiQualificationRuntime, agentName string) qualification.Record {
+	t.Helper()
+
+	adapter := &ClientProtocolAdapter{}
+	command := strings.Join(geminiQualificationLaunchArgv(runtime.Config, qualification.SurfaceProtocol, "", runtime.PolicyPath), " ")
+	fixture := geminiNewE2EFixtureWithAgent(t, adapter, command)
+	_, runDone := geminiE2EStartWorkflow(t, fixture)
+
+	deadline := time.Now().Add(geminiQualificationShutdownDeadline)
+	var condition geminiE2ETerminalCondition
+	for {
+		condition = geminiObserveE2ETerminalCondition(t, fixture)
+		if condition.reached() || time.Now().After(deadline) {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	groupClean := true
+	for _, pgid := range fixture.Agent.PGIDs() {
+		if !geminiAwaitGroupDrain(t, pgid, geminiQualificationShutdownDeadline) {
+			groupClean = false
+		}
+	}
+	_ = runDone
+	sessionID := ""
+	if ids := fixture.Agent.SessionIDs(); len(ids) > 0 {
+		sessionID = ids[0]
+	}
+	return geminiE2ERecord(condition, groupClean, sessionID, agentName, runtime.Version)
+}
+
+// geminiHandshakeAgentName reports the runtime's handshake-reported
+// name from the captured implementation log, falling back to the
+// executable basename when no session logged its handshake.
+func geminiHandshakeAgentName(capture *geminiLogCapture, fallback string) string {
+	for _, entry := range capture.implementationRecords() {
+		if name := entry.Attrs["name"]; name != "" {
+			return name
+		}
+	}
+	return fallback
+}

--- a/internal/agent/clientprotocol/gemini_qualification_unix_test.go
+++ b/internal/agent/clientprotocol/gemini_qualification_unix_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/sortie-ai/sortie/internal/qualification"
 
+	"github.com/sortie-ai/sortie/internal/agent/agentcore"
 	"github.com/sortie-ai/sortie/internal/agent/procutil"
 	"github.com/sortie-ai/sortie/internal/domain"
 )
@@ -993,6 +994,10 @@ func geminiCollectProtocolRecords(t *testing.T, runtime geminiQualificationRunti
 		ProtocolVersion: new(1),
 	}
 	switch {
+	case permissionErr != nil:
+		permissionRecord.Outcome = qualification.OutcomePrerequisiteFailed
+		permissionRecord.Grade = qualification.GradeNotObserved
+		permissionRecord.Detail = "the permission control turn did not complete"
 	case !permissionRequested:
 		permissionRecord.Outcome = qualification.OutcomeFixtureInductionFailed
 		permissionRecord.Grade = qualification.GradeNotObserved
@@ -1000,13 +1005,12 @@ func geminiCollectProtocolRecords(t *testing.T, runtime geminiQualificationRunti
 	case !permissionAnswered:
 		permissionRecord.Outcome = qualification.OutcomeAdapterUnanswered
 		permissionRecord.Grade = qualification.GradeNotObserved
-		permissionRecord.Detail = "the request was captured but no correlated client response arrived within the read timeout"
+		permissionRecord.Detail = "the request was captured and no correlated client response went back for it"
 	default:
 		permissionRecord.Outcome = qualification.OutcomePass
 		permissionRecord.Grade = qualification.GradeUsable
 		permissionRecord.Detail = "request answered with a refusing option and no request left pending"
 	}
-	_ = permissionErr
 
 	// The MCP probe: delivery is graded only on server receipt plus the
 	// turn consuming the returned nonce.
@@ -1060,6 +1064,42 @@ func geminiEventsCarry(events []domain.AgentEvent, needle string) bool {
 	})
 }
 
+// TestGeminiPermissionNoticeStems pins the permission scenario's two
+// observations to the notices the shared human-request decision
+// actually produces. A renamed notice reddens here instead of quietly
+// collapsing the requested and answered readings into one and making
+// the unanswered verdict unreachable.
+func TestGeminiPermissionNoticeStems(t *testing.T) {
+	t.Parallel()
+
+	answered := agentcore.DecideHumanRequest(agentcore.ClassPermission, true, agentcore.AnswerPending)
+	unanswered := agentcore.DecideHumanRequest(agentcore.ClassPermission, false, agentcore.AnswerPending)
+
+	if !answered.Transmit {
+		t.Fatal("the answering posture Transmit = false, want a correlated reply going back")
+	}
+	if unanswered.Transmit {
+		t.Fatal("the unanswered posture Transmit = true, want no correlated reply")
+	}
+	if !strings.Contains(answered.Notice, geminiPermissionNoticeStem) {
+		t.Errorf("answered notice = %q, want it to carry %q", answered.Notice, geminiPermissionNoticeStem)
+	}
+	if !strings.Contains(unanswered.Notice, geminiPermissionUnansweredStem) {
+		t.Errorf("unanswered notice = %q, want it to carry %q", unanswered.Notice, geminiPermissionUnansweredStem)
+	}
+	if strings.Contains(unanswered.Notice, geminiPermissionNoticeStem) {
+		t.Errorf("unanswered notice = %q carries the answered stem, want the two observations distinct", unanswered.Notice)
+	}
+
+	captured := []domain.AgentEvent{{Type: domain.EventNotification, Message: unanswered.Notice}}
+	if !geminiPermissionRequested(captured) {
+		t.Error("geminiPermissionRequested() = false for a captured request, want true")
+	}
+	if geminiPermissionAnswered(captured) {
+		t.Error("geminiPermissionAnswered() = true with no correlated reply, want false")
+	}
+}
+
 // geminiProbeMarkerAbsent reports whether a probe's side-effect file is
 // absent, the no-side-effect condition the policy precondition and the
 // permission scenarios require.
@@ -1071,22 +1111,31 @@ func geminiProbeMarkerAbsent(t *testing.T, probePath string) bool {
 	return false
 }
 
-// geminiPermissionNoticeStem is the observable stem of the adapter's
-// own refusal notice for a permission request, the message-shape
-// observation the permission scenario reads.
+// geminiPermissionNoticeStem is the observable stem of the notice the
+// adapter emits when it answers a permission request with a refusing
+// option, which is the message-shape observation of a correlated reply
+// going back to the runtime.
 const geminiPermissionNoticeStem = "refused a permission request"
 
-// geminiPermissionRequested reports whether the adapter observed and
-// answered a session/request_permission request during the turn: the
-// adapter emits its refusal notice when it handles one, and never on
-// an unanswered request.
+// geminiPermissionUnansweredStem is the observable stem of the notice
+// the adapter emits instead when the request carried no option it
+// could answer with. The request reached the client and ended the
+// attempt, and no correlated reply went back, so this stem observes a
+// request without an answer.
+const geminiPermissionUnansweredStem = "needs a permission this unattended run cannot grant"
+
+// geminiPermissionRequested reports whether a permission request
+// reached the adapter during the turn, read through either notice the
+// adapter emits for one. Both postures observe the request; only one
+// of them observes an answer, which is why the two predicates read
+// different stems.
 func geminiPermissionRequested(events []domain.AgentEvent) bool {
-	return geminiEventsCarry(events, geminiPermissionNoticeStem)
+	return geminiEventsCarry(events, geminiPermissionNoticeStem) ||
+		geminiEventsCarry(events, geminiPermissionUnansweredStem)
 }
 
-// geminiPermissionAnswered reports whether the adapter's own handling
-// of the permission request reached the turn's events, which is the
-// observable correlated reply the permission record requires.
+// geminiPermissionAnswered reports whether a correlated reply went back
+// for the request, which only the answering posture's notice observes.
 func geminiPermissionAnswered(events []domain.AgentEvent) bool {
 	return geminiEventsCarry(events, geminiPermissionNoticeStem)
 }

--- a/internal/agent/clientprotocol/gemini_qualification_unix_test.go
+++ b/internal/agent/clientprotocol/gemini_qualification_unix_test.go
@@ -250,6 +250,15 @@ func TestGeminiQualificationCollectorOrdering(t *testing.T) {
 
 	shuffled := slices.Clone(fixture.Records)
 	slices.Reverse(shuffled)
+	for i := range shuffled {
+		// A real collector never assigns Sequence itself; only the
+		// writer does, after sorting. Zeroing it here proves the sort
+		// key is the canonical scenario/surface/capability tiebreak,
+		// not a leftover sequence number the reversal happened to
+		// preserve, which would mask a comparator that only looks at
+		// Sequence.
+		shuffled[i].Sequence = 0
+	}
 
 	path := geminiWriteQualificationObservations(t, geminiEvidenceDir(t), shuffled)
 

--- a/internal/agent/clientprotocol/gemini_qualification_unix_test.go
+++ b/internal/agent/clientprotocol/gemini_qualification_unix_test.go
@@ -424,6 +424,10 @@ func geminiRunNativeProbe(t *testing.T, runtime geminiQualificationRuntime, surf
 	cmd := exec.Command(argv[0], argv[1:]...) //nolint:gosec // the operator-selected executable with the documented flags
 	cmd.Dir = runtime.Workspace.Checkout
 	cmd.Env = runtime.Env
+	// The probe leads its own group, so the drain below reaches the
+	// tree it forked. Without this the leader inherits this test's
+	// group and the signal names a group the probe does not lead.
+	procutil.SetProcessGroup(cmd)
 
 	var output strings.Builder
 	cmd.Stdout = &output
@@ -431,15 +435,19 @@ func geminiRunNativeProbe(t *testing.T, runtime geminiQualificationRuntime, surf
 	if err := cmd.Start(); err != nil {
 		return output.String(), fmt.Errorf("native launch: %w", err)
 	}
+	pgid := cmd.Process.Pid
 	done := make(chan error, 1)
 	go func() { done <- cmd.Wait() }()
 	select {
 	case waitErr := <-done:
-		_ = procutil.SignalProcessGroup(cmd.Process.Pid, syscall.SIGKILL)
+		_ = procutil.SignalProcessGroup(pgid, syscall.SIGKILL)
 		return output.String(), waitErr
 	case <-time.After(geminiNativeProbeBound):
-		_ = procutil.SignalProcessGroup(cmd.Process.Pid, syscall.SIGKILL)
-		_, _ = cmd.Process.Wait()
+		// The wait goroutine owns the only reap; the bounded wait
+		// drains the group and then collects that one result rather
+		// than racing a second wait on the same process.
+		_ = procutil.SignalProcessGroup(pgid, syscall.SIGKILL)
+		<-done
 		return output.String(), errors.New("the native probe exceeded its bounded wait")
 	}
 }

--- a/internal/qualification/evidence.go
+++ b/internal/qualification/evidence.go
@@ -1,0 +1,512 @@
+package qualification
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"slices"
+	"time"
+	"unicode/utf8"
+)
+
+// Verdict is the final qualification outcome computed by both
+// validators. The two values are the only permitted results; there is
+// no manual override.
+type Verdict string
+
+const (
+	VerdictQualified    Verdict = "qualified"
+	VerdictNotQualified Verdict = "not_qualified"
+)
+
+// Scenario names the kind of observation one evidence line carries.
+type Scenario string
+
+const (
+	ScenarioSemanticProbe      Scenario = "semantic_probe"
+	ScenarioSurfaceBaseline    Scenario = "surface_baseline"
+	ScenarioTokenSource        Scenario = "token_source"
+	ScenarioPolicyPrecondition Scenario = "policy_precondition"
+	ScenarioPermissionRequest  Scenario = "permission_request"
+	ScenarioToolServer         Scenario = "tool_server"
+	ScenarioContinuation       Scenario = "continuation"
+	ScenarioRuntimeIdentity    Scenario = "runtime_identity"
+	ScenarioWorkspaceSecurity  Scenario = "workspace_security"
+	ScenarioProcessCleanup     Scenario = "process_cleanup"
+	ScenarioEndToEnd           Scenario = "end_to_end"
+	ScenarioQualification      Scenario = "qualification"
+)
+
+// Surface names the measured surface one evidence line describes.
+// SurfaceAggregate denotes a cross-surface qualification observation.
+type Surface string
+
+const (
+	SurfaceProtocol         Surface = "protocol"
+	SurfaceNativeText       Surface = "native_text"
+	SurfaceNativeJSON       Surface = "native_json"
+	SurfaceNativeStreamJSON Surface = "native_stream_json"
+	SurfaceAggregate        Surface = "aggregate"
+)
+
+// Capability names the load-bearing capability one evidence line
+// grades.
+type Capability string
+
+const (
+	CapabilityTurnDisposition     Capability = "turn_disposition"
+	CapabilityRetryClassification Capability = "retry_classification"
+	CapabilityTokenCeiling        Capability = "token_ceiling"
+	CapabilityToolServerDelivery  Capability = "tool_server_delivery"
+	CapabilitySessionContinuation Capability = "session_continuation"
+	CapabilityPermissionHandling  Capability = "permission_handling"
+	CapabilityRuntimeIdentity     Capability = "runtime_identity"
+	CapabilityWorkspaceSecurity   Capability = "workspace_security"
+	CapabilityProcessCleanup      Capability = "process_cleanup"
+	CapabilityEligibility         Capability = "eligibility"
+)
+
+// Source names the evidence channel a record was derived from.
+type Source string
+
+const (
+	SourceProtocolStable     Source = "protocol_stable"
+	SourceProtocolExtension  Source = "protocol_extension"
+	SourceNativeStructured   Source = "native_structured"
+	SourceNativeText         Source = "native_text"
+	SourceSortieShared       Source = "sortie_shared"
+	SourceProcessObservation Source = "process_observation"
+	SourceNone               Source = "none"
+	SourceComparison         Source = "comparison"
+)
+
+// Grade is the comparison grade or outcome class a record carries.
+// GradeQualified and GradeNotQualified are valid only on capability
+// eligibility; GradeCorroborationOnly never receives numeric grade 1.
+type Grade string
+
+const (
+	GradeUsable            Grade = "usable"
+	GradeGap               Grade = "gap"
+	GradeCorroborationOnly Grade = "corroboration_only"
+	GradeNotObserved       Grade = "not_observed"
+	GradeNotApplicable     Grade = "not_applicable"
+	GradeQualified         Grade = "qualified"
+	GradeNotQualified      Grade = "not_qualified"
+)
+
+// Outcome is the bounded probe outcome a record carries.
+type Outcome string
+
+const (
+	OutcomePass                   Outcome = "pass"
+	OutcomeNotObserved            Outcome = "not_observed"
+	OutcomeNotApplicable          Outcome = "not_applicable"
+	OutcomePrerequisiteFailed     Outcome = "prerequisite_failed"
+	OutcomeFixtureInductionFailed Outcome = "fixture_induction_failed"
+	OutcomeAdapterUnanswered      Outcome = "adapter_unanswered"
+	OutcomeRuntimeFailed          Outcome = "runtime_failed"
+)
+
+// Case names one required disposition or retry class. A record carries
+// it only for semantic probes; every other record stores null.
+type Case string
+
+const (
+	CaseSuccess             Case = "success"
+	CaseRuntimeFailure      Case = "runtime_failure"
+	CaseRuntimeRefusal      Case = "runtime_refusal"
+	CaseCancellation        Case = "cancellation"
+	CaseLimitReached        Case = "limit_reached"
+	CaseRetryableTransport  Case = "retryable_runtime_or_transport_failure"
+	CaseNonRetryableRefusal Case = "non_retryable_refusal"
+	CaseHumanInput          Case = "human_input"
+	CaseUnknownOutcome      Case = "unknown_outcome"
+)
+
+// InputID names the fixed input contract a record was collected under.
+type InputID string
+
+const (
+	InputDispositionSuccess        InputID = "disposition_success_v1"
+	InputDispositionRuntimeFailure InputID = "disposition_runtime_failure_v1"
+	InputDispositionRuntimeRefusal InputID = "disposition_runtime_refusal_v1"
+	InputDispositionCancellation   InputID = "disposition_cancellation_v1"
+	InputDispositionLimitReached   InputID = "disposition_limit_reached_v1"
+	InputRetryableTransport        InputID = "retryable_transport_failure_v1"
+	InputRetryNonRetryableRefusal  InputID = "retry_non_retryable_refusal_v1"
+	InputRetryHumanInput           InputID = "retry_human_input_v1"
+	InputRetryUnknownOutcome       InputID = "retry_unknown_outcome_v1"
+	InputBaseline                  InputID = "baseline_v1"
+	InputTokenInventory            InputID = "token_inventory_v1"
+	InputPolicyControl             InputID = "policy_control_v1"
+	InputPermissionProbe           InputID = "permission_probe_v1"
+	InputMCPProbe                  InputID = "mcp_probe_v1"
+	InputContinuationSeed          InputID = "continuation_seed_v1"
+	InputContinuationRecall        InputID = "continuation_recall_v1"
+	InputIdentity                  InputID = "identity_v1"
+	InputSecurity                  InputID = "security_v1"
+	InputCleanup                   InputID = "cleanup_v1"
+	InputE2E                       InputID = "e2e_v1"
+	InputAggregate                 InputID = "aggregate_v1"
+)
+
+// The closed value sets. Everything outside them is invalid.
+var (
+	Scenarios = []Scenario{
+		ScenarioSemanticProbe, ScenarioSurfaceBaseline,
+		ScenarioTokenSource, ScenarioPolicyPrecondition,
+		ScenarioPermissionRequest, ScenarioToolServer,
+		ScenarioContinuation, ScenarioRuntimeIdentity,
+		ScenarioWorkspaceSecurity, ScenarioProcessCleanup,
+		ScenarioEndToEnd, ScenarioQualification,
+	}
+	Surfaces = []Surface{
+		SurfaceProtocol, SurfaceNativeText,
+		SurfaceNativeJSON, SurfaceNativeStreamJSON,
+		SurfaceAggregate,
+	}
+	Capabilities = []Capability{
+		CapabilityTurnDisposition, CapabilityRetryClassification,
+		CapabilityTokenCeiling, CapabilityToolServerDelivery,
+		CapabilitySessionContinuation, CapabilityPermissionHandling,
+		CapabilityRuntimeIdentity, CapabilityWorkspaceSecurity,
+		CapabilityProcessCleanup, CapabilityEligibility,
+	}
+	Sources = []Source{
+		SourceProtocolStable, SourceProtocolExtension,
+		SourceNativeStructured, SourceNativeText,
+		SourceSortieShared, SourceProcessObservation,
+		SourceNone, SourceComparison,
+	}
+	Grades = []Grade{
+		GradeUsable, GradeGap,
+		GradeCorroborationOnly, GradeNotObserved,
+		GradeNotApplicable, GradeQualified,
+		GradeNotQualified,
+	}
+	Outcomes = []Outcome{
+		OutcomePass, OutcomeNotObserved, OutcomeNotApplicable,
+		OutcomePrerequisiteFailed, OutcomeFixtureInductionFailed,
+		OutcomeAdapterUnanswered, OutcomeRuntimeFailed,
+	}
+	Cases = []Case{
+		CaseSuccess, CaseRuntimeFailure, CaseRuntimeRefusal,
+		CaseCancellation, CaseLimitReached,
+		CaseRetryableTransport, CaseNonRetryableRefusal,
+		CaseHumanInput, CaseUnknownOutcome,
+	}
+	InputIDs = []InputID{
+		InputDispositionSuccess, InputDispositionRuntimeFailure,
+		InputDispositionRuntimeRefusal, InputDispositionCancellation,
+		InputDispositionLimitReached, InputRetryableTransport,
+		InputRetryNonRetryableRefusal, InputRetryHumanInput,
+		InputRetryUnknownOutcome, InputBaseline,
+		InputTokenInventory, InputPolicyControl,
+		InputPermissionProbe, InputMCPProbe,
+		InputContinuationSeed, InputContinuationRecall,
+		InputIdentity, InputSecurity, InputCleanup,
+		InputE2E, InputAggregate,
+	}
+)
+
+// CapabilityCases maps each semantic capability to its closed case set,
+// in the order the evidence contract requires records to be written.
+var CapabilityCases = map[Capability][]Case{
+	CapabilityTurnDisposition: {
+		CaseSuccess, CaseRuntimeFailure, CaseRuntimeRefusal,
+		CaseCancellation, CaseLimitReached,
+	},
+	CapabilityRetryClassification: {
+		CaseRetryableTransport, CaseNonRetryableRefusal,
+		CaseHumanInput, CaseUnknownOutcome,
+	},
+}
+
+// CaseInputs maps every semantic case to the one input_id that may
+// record it.
+var CaseInputs = map[Case]InputID{
+	CaseSuccess:             InputDispositionSuccess,
+	CaseRuntimeFailure:      InputDispositionRuntimeFailure,
+	CaseRuntimeRefusal:      InputDispositionRuntimeRefusal,
+	CaseCancellation:        InputDispositionCancellation,
+	CaseLimitReached:        InputDispositionLimitReached,
+	CaseRetryableTransport:  InputRetryableTransport,
+	CaseNonRetryableRefusal: InputRetryNonRetryableRefusal,
+	CaseHumanInput:          InputRetryHumanInput,
+	CaseUnknownOutcome:      InputRetryUnknownOutcome,
+}
+
+// EvidencePathQualificationVerdict is the evidence_path the single
+// final aggregate record carries.
+const EvidencePathQualificationVerdict = "qualification.verdict"
+
+// Record is one strict evidence line. The field set is closed: unknown
+// or missing fields are invalid, and every field's nullability is
+// fixed.
+type Record struct {
+	SchemaVersion   int        `json:"schema_version"`
+	Sequence        int        `json:"sequence"`
+	ObservedAt      string     `json:"observed_at"`
+	Scenario        Scenario   `json:"scenario"`
+	Surface         Surface    `json:"surface"`
+	Capability      Capability `json:"capability"`
+	Source          Source     `json:"source"`
+	Grade           Grade      `json:"grade"`
+	Outcome         Outcome    `json:"outcome"`
+	SemanticCase    *Case      `json:"semantic_case"`
+	InputID         InputID    `json:"input_id"`
+	EvidencePath    *string    `json:"evidence_path"`
+	SessionID       *string    `json:"session_id"`
+	PriorSessionID  *string    `json:"prior_session_id"`
+	AgentName       *string    `json:"agent_name"`
+	AgentVersion    *string    `json:"agent_version"`
+	ProtocolVersion *int       `json:"protocol_version"`
+	Detail          string     `json:"detail"`
+}
+
+// recordFields is the exact set of member names a record line may
+// carry.
+var recordFields = map[string]bool{
+	"schema_version": true, "sequence": true, "observed_at": true,
+	"scenario": true, "surface": true, "capability": true, "source": true,
+	"grade": true, "outcome": true, "semantic_case": true,
+	"input_id": true, "evidence_path": true, "session_id": true,
+	"prior_session_id": true, "agent_name": true, "agent_version": true,
+	"protocol_version": true, "detail": true,
+}
+
+// DetailBound is the maximum number of Unicode code points a detail
+// string may carry.
+const DetailBound = 256
+
+// DecodeRecord strictly decodes one evidence line. It rejects unknown
+// and missing fields, wrong types, null where a value is required,
+// values outside the closed enum sets, a schema version other than 1,
+// a non-UTC or unparseable timestamp, and an empty or over-bound
+// detail.
+func DecodeRecord(line []byte) (Record, error) {
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(line, &fields); err != nil {
+		return Record{}, fmt.Errorf("decode evidence line: %w", err)
+	}
+	for name := range fields {
+		if !recordFields[name] {
+			return Record{}, fmt.Errorf("unknown field %q", name)
+		}
+	}
+	for name := range recordFields {
+		if _, ok := fields[name]; !ok {
+			return Record{}, fmt.Errorf("missing field %q", name)
+		}
+	}
+
+	var rec Record
+	var err error
+	if rec.SchemaVersion, err = decodeInt(fields["schema_version"]); err != nil {
+		return Record{}, fmt.Errorf("schema_version: %w", err)
+	}
+	if rec.SchemaVersion != 1 {
+		return Record{}, fmt.Errorf("schema_version = %d, want 1", rec.SchemaVersion)
+	}
+	if rec.Sequence, err = decodeInt(fields["sequence"]); err != nil {
+		return Record{}, fmt.Errorf("sequence: %w", err)
+	}
+	if rec.ObservedAt, err = decodeString(fields["observed_at"]); err != nil {
+		return Record{}, fmt.Errorf("observed_at: %w", err)
+	}
+	ts, tsErr := time.Parse(time.RFC3339, rec.ObservedAt)
+	if tsErr != nil {
+		return Record{}, fmt.Errorf("observed_at %q: %w", rec.ObservedAt, tsErr)
+	}
+	if _, offset := ts.Zone(); offset != 0 {
+		return Record{}, fmt.Errorf("observed_at %q is not UTC", rec.ObservedAt)
+	}
+	if rec.Scenario, err = decodeEnum(fields["scenario"], Scenarios); err != nil {
+		return Record{}, fmt.Errorf("scenario: %w", err)
+	}
+	if rec.Surface, err = decodeEnum(fields["surface"], Surfaces); err != nil {
+		return Record{}, fmt.Errorf("surface: %w", err)
+	}
+	if rec.Capability, err = decodeEnum(fields["capability"], Capabilities); err != nil {
+		return Record{}, fmt.Errorf("capability: %w", err)
+	}
+	if rec.Source, err = decodeEnum(fields["source"], Sources); err != nil {
+		return Record{}, fmt.Errorf("source: %w", err)
+	}
+	if rec.Grade, err = decodeEnum(fields["grade"], Grades); err != nil {
+		return Record{}, fmt.Errorf("grade: %w", err)
+	}
+	if rec.Outcome, err = decodeEnum(fields["outcome"], Outcomes); err != nil {
+		return Record{}, fmt.Errorf("outcome: %w", err)
+	}
+	if rec.SemanticCase, err = decodeNullableEnum(fields["semantic_case"], Cases); err != nil {
+		return Record{}, fmt.Errorf("semantic_case: %w", err)
+	}
+	if rec.InputID, err = decodeEnum(fields["input_id"], InputIDs); err != nil {
+		return Record{}, fmt.Errorf("input_id: %w", err)
+	}
+	if rec.EvidencePath, err = decodeNullableString(fields["evidence_path"]); err != nil {
+		return Record{}, fmt.Errorf("evidence_path: %w", err)
+	}
+	if rec.SessionID, err = decodeNullableString(fields["session_id"]); err != nil {
+		return Record{}, fmt.Errorf("session_id: %w", err)
+	}
+	if rec.PriorSessionID, err = decodeNullableString(fields["prior_session_id"]); err != nil {
+		return Record{}, fmt.Errorf("prior_session_id: %w", err)
+	}
+	if rec.AgentName, err = decodeNullableString(fields["agent_name"]); err != nil {
+		return Record{}, fmt.Errorf("agent_name: %w", err)
+	}
+	if rec.AgentVersion, err = decodeNullableString(fields["agent_version"]); err != nil {
+		return Record{}, fmt.Errorf("agent_version: %w", err)
+	}
+	if rec.ProtocolVersion, err = decodeNullableInt(fields["protocol_version"]); err != nil {
+		return Record{}, fmt.Errorf("protocol_version: %w", err)
+	}
+	if rec.Detail, err = decodeString(fields["detail"]); err != nil {
+		return Record{}, fmt.Errorf("detail: %w", err)
+	}
+	if points := utf8.RuneCountInString(rec.Detail); points == 0 {
+		return Record{}, errors.New("detail is empty")
+	} else if points > DetailBound {
+		return Record{}, fmt.Errorf("detail carries %d code points, want at most %d", points, DetailBound)
+	}
+	return rec, nil
+}
+
+// decodeString decodes a JSON string, rejecting null and any
+// non-string value.
+func decodeString(raw json.RawMessage) (string, error) {
+	if string(raw) == "null" {
+		return "", errors.New("got null, want a string")
+	}
+	var v string
+	if err := json.Unmarshal(raw, &v); err != nil {
+		return "", err
+	}
+	return v, nil
+}
+
+// decodeNullableString decodes a JSON string or null.
+func decodeNullableString(raw json.RawMessage) (*string, error) {
+	if string(raw) == "null" {
+		return nil, nil
+	}
+	v, err := decodeString(raw)
+	if err != nil {
+		return nil, err
+	}
+	return &v, nil
+}
+
+// decodeInt decodes a JSON integer, rejecting null and any
+// non-integral value.
+func decodeInt(raw json.RawMessage) (int, error) {
+	if string(raw) == "null" {
+		return 0, errors.New("got null, want an integer")
+	}
+	var v int
+	if err := json.Unmarshal(raw, &v); err != nil {
+		return 0, err
+	}
+	return v, nil
+}
+
+// decodeNullableInt decodes a JSON integer or null.
+func decodeNullableInt(raw json.RawMessage) (*int, error) {
+	if string(raw) == "null" {
+		return nil, nil
+	}
+	v, err := decodeInt(raw)
+	if err != nil {
+		return nil, err
+	}
+	return &v, nil
+}
+
+// decodeEnum decodes a closed-set string enum.
+func decodeEnum[T ~string](raw json.RawMessage, allowed []T) (T, error) {
+	v, err := decodeString(raw)
+	if err != nil {
+		return "", err
+	}
+	value := T(v)
+	if !slices.Contains(allowed, value) {
+		return "", fmt.Errorf("%q is outside the closed value set", v)
+	}
+	return value, nil
+}
+
+// decodeNullableEnum decodes a closed-set string enum or null.
+func decodeNullableEnum[T ~string](raw json.RawMessage, allowed []T) (*T, error) {
+	if string(raw) == "null" {
+		return nil, nil
+	}
+	v, err := decodeEnum(raw, allowed)
+	if err != nil {
+		return nil, err
+	}
+	return &v, nil
+}
+
+// MarshalRecord renders one record as an evidence line body. The
+// struct's members are all emitted, so a marshaled record always
+// carries the exact closed field set.
+func MarshalRecord(rec Record) ([]byte, error) {
+	return json.Marshal(rec)
+}
+
+// ValidRecord returns a fully populated, schema-valid record for
+// decode tests to mutate.
+func ValidRecord() Record {
+	return Record{
+		SchemaVersion:   1,
+		Sequence:        1,
+		ObservedAt:      "2026-01-01T00:00:00Z",
+		Scenario:        ScenarioSemanticProbe,
+		Surface:         SurfaceProtocol,
+		Capability:      CapabilityTurnDisposition,
+		Source:          SourceProtocolStable,
+		Grade:           GradeUsable,
+		Outcome:         OutcomePass,
+		SemanticCase:    new(CaseSuccess),
+		InputID:         InputDispositionSuccess,
+		EvidencePath:    new("/turn/stop_reason"),
+		SessionID:       new("sess-fixture"),
+		AgentName:       new("fixture-agent"),
+		AgentVersion:    new("1.0.0-fixture"),
+		ProtocolVersion: new(1),
+		Detail:          "bounded fixture detail",
+	}
+}
+
+// NullableEqual compares two nullable values by pointee, treating two
+// nils as equal.
+func NullableEqual[T comparable](a, b *T) bool {
+	switch {
+	case a == nil && b == nil:
+		return true
+	case a == nil || b == nil:
+		return false
+	}
+	return *a == *b
+}
+
+// RecordsEqual reports whether two records carry equal values,
+// dereferencing the nullable fields rather than comparing pointers.
+func RecordsEqual(a, b Record) bool {
+	if a.SchemaVersion != b.SchemaVersion || a.Sequence != b.Sequence || a.ObservedAt != b.ObservedAt ||
+		a.Scenario != b.Scenario || a.Surface != b.Surface || a.Capability != b.Capability ||
+		a.Source != b.Source || a.Grade != b.Grade ||
+		a.Outcome != b.Outcome || a.InputID != b.InputID || a.Detail != b.Detail {
+		return false
+	}
+	return NullableEqual(a.SemanticCase, b.SemanticCase) &&
+		NullableEqual(a.EvidencePath, b.EvidencePath) &&
+		NullableEqual(a.SessionID, b.SessionID) &&
+		NullableEqual(a.PriorSessionID, b.PriorSessionID) &&
+		NullableEqual(a.AgentName, b.AgentName) &&
+		NullableEqual(a.AgentVersion, b.AgentVersion) &&
+		NullableEqual(a.ProtocolVersion, b.ProtocolVersion)
+}

--- a/internal/qualification/evidence_test.go
+++ b/internal/qualification/evidence_test.go
@@ -1,0 +1,324 @@
+package qualification
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestEvidenceRecordStrictDecode confirms a schema-valid record decodes
+// to its exact field values, that every nullable field accepts null,
+// and that the decode round trip preserves the record.
+func TestEvidenceRecordStrictDecode(t *testing.T) {
+	t.Parallel()
+
+	t.Run("full record decodes to its field values", func(t *testing.T) {
+		t.Parallel()
+
+		want := ValidRecord()
+		line, err := MarshalRecord(want)
+		if err != nil {
+			t.Fatalf("MarshalRecord() error = %v", err)
+		}
+		got, err := DecodeRecord(line)
+		if err != nil {
+			t.Fatalf("DecodeRecord(%s) error = %v", line, err)
+		}
+		if !RecordsEqual(got, want) {
+			t.Errorf("DecodeRecord() = %+v, want %+v", got, want)
+		}
+	})
+
+	t.Run("every field carries exactly its closed wire name", func(t *testing.T) {
+		t.Parallel()
+
+		line, err := MarshalRecord(ValidRecord())
+		if err != nil {
+			t.Fatalf("MarshalRecord() error = %v", err)
+		}
+		var fields map[string]json.RawMessage
+		if err := json.Unmarshal(line, &fields); err != nil {
+			t.Fatalf("unmarshal line %s: %v", line, err)
+		}
+		if len(fields) != len(recordFields) {
+			t.Errorf("field count = %d, want %d", len(fields), len(recordFields))
+		}
+		for name := range fields {
+			if !recordFields[name] {
+				t.Errorf("marshaled record carries unexpected field %q", name)
+			}
+		}
+	})
+
+	t.Run("nullable fields decode null", func(t *testing.T) {
+		t.Parallel()
+
+		rec := ValidRecord()
+		rec.SemanticCase = nil
+		rec.EvidencePath = nil
+		rec.SessionID = nil
+		rec.PriorSessionID = nil
+		rec.AgentName = nil
+		rec.AgentVersion = nil
+		rec.ProtocolVersion = nil
+		line, err := MarshalRecord(rec)
+		if err != nil {
+			t.Fatalf("MarshalRecord() error = %v", err)
+		}
+		got, err := DecodeRecord(line)
+		if err != nil {
+			t.Fatalf("DecodeRecord(%s) error = %v", line, err)
+		}
+		if got.SemanticCase != nil || got.EvidencePath != nil || got.SessionID != nil ||
+			got.PriorSessionID != nil || got.AgentName != nil || got.AgentVersion != nil ||
+			got.ProtocolVersion != nil {
+			t.Errorf("DecodeRecord() = %+v, want all nullable fields nil", got)
+		}
+	})
+}
+
+// TestEvidenceRecordRejectsUnknownAndMissingFields confirms the decoder
+// rejects any field outside the closed set and any missing member, one
+// control per field.
+func TestEvidenceRecordRejectsUnknownAndMissingFields(t *testing.T) {
+	t.Parallel()
+
+	t.Run("unknown field", func(t *testing.T) {
+		t.Parallel()
+
+		line, err := MarshalRecord(ValidRecord())
+		if err != nil {
+			t.Fatalf("MarshalRecord() error = %v", err)
+		}
+		var fields map[string]json.RawMessage
+		if err := json.Unmarshal(line, &fields); err != nil {
+			t.Fatalf("unmarshal line %s: %v", line, err)
+		}
+		fields["extra_field"] = json.RawMessage(`"value"`)
+		doctored, err := json.Marshal(fields)
+		if err != nil {
+			t.Fatalf("marshal doctored fields: %v", err)
+		}
+		if _, err := DecodeRecord(doctored); err == nil {
+			t.Errorf("DecodeRecord(%s) = nil error, want unknown-field error", doctored)
+		} else if !strings.Contains(err.Error(), `unknown field "extra_field"`) {
+			t.Errorf("DecodeRecord() error = %v, want it to name the unknown field", err)
+		}
+	})
+
+	for name := range recordFields {
+		t.Run("missing "+name, func(t *testing.T) {
+			t.Parallel()
+
+			line, err := MarshalRecord(ValidRecord())
+			if err != nil {
+				t.Fatalf("MarshalRecord() error = %v", err)
+			}
+			var fields map[string]json.RawMessage
+			if err := json.Unmarshal(line, &fields); err != nil {
+				t.Fatalf("unmarshal line %s: %v", line, err)
+			}
+			delete(fields, name)
+			doctored, err := json.Marshal(fields)
+			if err != nil {
+				t.Fatalf("marshal doctored fields: %v", err)
+			}
+			if _, err := DecodeRecord(doctored); err == nil {
+				t.Errorf("DecodeRecord(%s) = nil error, want missing-field error", doctored)
+			} else if !strings.Contains(err.Error(), `missing field "`+name+`"`) {
+				t.Errorf("DecodeRecord() error = %v, want it to name %q", err, name)
+			}
+		})
+	}
+
+	t.Run("type and enum violations", func(t *testing.T) {
+		t.Parallel()
+
+		tests := []struct {
+			name    string
+			doctor  func(rec Record) map[string]json.RawMessage
+			wantSub string
+		}{
+			{
+				name: "schema_version zero is rejected",
+				doctor: func(rec Record) map[string]json.RawMessage {
+					rec.SchemaVersion = 0
+					return marshalRecordFields(t, rec)
+				},
+				wantSub: "schema_version",
+			},
+			{
+				name: "schema_version two is rejected",
+				doctor: func(rec Record) map[string]json.RawMessage {
+					rec.SchemaVersion = 2
+					return marshalRecordFields(t, rec)
+				},
+				wantSub: "schema_version",
+			},
+			{
+				name: "null required enum is rejected",
+				doctor: func(rec Record) map[string]json.RawMessage {
+					fields := marshalRecordFields(t, rec)
+					fields["scenario"] = json.RawMessage(`null`)
+					return fields
+				},
+				wantSub: "scenario",
+			},
+			{
+				name: "value outside the scenario set is rejected",
+				doctor: func(rec Record) map[string]json.RawMessage {
+					fields := marshalRecordFields(t, rec)
+					fields["scenario"] = json.RawMessage(`"not_a_scenario"`)
+					return fields
+				},
+				wantSub: "outside the closed value set",
+			},
+			{
+				name: "value outside the grade set is rejected",
+				doctor: func(rec Record) map[string]json.RawMessage {
+					fields := marshalRecordFields(t, rec)
+					fields["grade"] = json.RawMessage(`"excellent"`)
+					return fields
+				},
+				wantSub: "outside the closed value set",
+			},
+			{
+				name: "null semantic_case on a semantic record is accepted but null outcome is not",
+				doctor: func(rec Record) map[string]json.RawMessage {
+					fields := marshalRecordFields(t, rec)
+					fields["outcome"] = json.RawMessage(`null`)
+					return fields
+				},
+				wantSub: "outcome",
+			},
+			{
+				name: "string protocol_version is rejected",
+				doctor: func(rec Record) map[string]json.RawMessage {
+					fields := marshalRecordFields(t, rec)
+					fields["protocol_version"] = json.RawMessage(`"1"`)
+					return fields
+				},
+				wantSub: "protocol_version",
+			},
+			{
+				name: "null integer is rejected",
+				doctor: func(rec Record) map[string]json.RawMessage {
+					fields := marshalRecordFields(t, rec)
+					fields["sequence"] = json.RawMessage(`null`)
+					return fields
+				},
+				wantSub: "sequence",
+			},
+			{
+				name: "fractional sequence is rejected",
+				doctor: func(rec Record) map[string]json.RawMessage {
+					fields := marshalRecordFields(t, rec)
+					fields["sequence"] = json.RawMessage(`1.5`)
+					return fields
+				},
+				wantSub: "sequence",
+			},
+			{
+				name: "non-UTC timestamp is rejected",
+				doctor: func(rec Record) map[string]json.RawMessage {
+					rec.ObservedAt = "2026-01-01T00:00:00+02:00"
+					return marshalRecordFields(t, rec)
+				},
+				wantSub: "not UTC",
+			},
+			{
+				name: "unparseable timestamp is rejected",
+				doctor: func(rec Record) map[string]json.RawMessage {
+					rec.ObservedAt = "not-a-time"
+					return marshalRecordFields(t, rec)
+				},
+				wantSub: "observed_at",
+			},
+			{
+				name: "null detail is rejected",
+				doctor: func(rec Record) map[string]json.RawMessage {
+					fields := marshalRecordFields(t, rec)
+					fields["detail"] = json.RawMessage(`null`)
+					return fields
+				},
+				wantSub: "detail",
+			},
+			{
+				name: "array payload is rejected",
+				doctor: func(rec Record) map[string]json.RawMessage {
+					return map[string]json.RawMessage{"detail": json.RawMessage(`[]`)}
+				},
+				wantSub: "missing field",
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+
+				line, err := json.Marshal(tt.doctor(ValidRecord()))
+				if err != nil {
+					t.Fatalf("marshal doctored fields: %v", err)
+				}
+				_, err = DecodeRecord(line)
+				if err == nil {
+					t.Errorf("DecodeRecord(%s) = nil error, want error naming %q", line, tt.wantSub)
+				} else if !strings.Contains(err.Error(), tt.wantSub) {
+					t.Errorf("DecodeRecord() error = %v, want it to mention %q", err, tt.wantSub)
+				}
+			})
+		}
+	})
+}
+
+// marshalRecordFields renders a record through its wire member names so
+// a test can doctor individual fields while keeping the field set exact.
+func marshalRecordFields(t *testing.T, rec Record) map[string]json.RawMessage {
+	t.Helper()
+	line, err := MarshalRecord(rec)
+	if err != nil {
+		t.Fatalf("MarshalRecord() error = %v", err)
+	}
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(line, &fields); err != nil {
+		t.Fatalf("unmarshal line %s: %v", line, err)
+	}
+	return fields
+}
+
+// TestEvidenceRecordDetailBound confirms the detail field accepts
+// exactly 256 Unicode code points regardless of byte width and rejects
+// an empty detail or one past the bound.
+func TestEvidenceRecordDetailBound(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		detail  string
+		wantErr bool
+	}{
+		{name: "one code point", detail: "x", wantErr: false},
+		{name: "exactly 256 ASCII code points", detail: strings.Repeat("d", 256), wantErr: false},
+		{name: "257 ASCII code points", detail: strings.Repeat("d", 257), wantErr: true},
+		{name: "exactly 256 multibyte code points", detail: strings.Repeat("é", 256), wantErr: false},
+		{name: "257 multibyte code points", detail: strings.Repeat("é", 257), wantErr: true},
+		{name: "empty detail", detail: "", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			rec := ValidRecord()
+			rec.Detail = tt.detail
+			line, err := MarshalRecord(rec)
+			if err != nil {
+				t.Fatalf("MarshalRecord() error = %v", err)
+			}
+			_, err = DecodeRecord(line)
+			if gotErr := err != nil; gotErr != tt.wantErr {
+				t.Errorf("DecodeRecord() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/internal/qualification/fixture.go
+++ b/internal/qualification/fixture.go
@@ -92,7 +92,7 @@ func (f *Fixture) Finalize() {
 	for _, id := range ids {
 		f.Add(IdentityFixtureRecord(id))
 	}
-	slices.SortStableFunc(f.Records, orderCompare)
+	slices.SortStableFunc(f.Records, OrderCompare)
 	f.Renumber()
 }
 
@@ -683,7 +683,7 @@ func (f *Fixture) DuplicateAfter(target *Record) {
 // session id after Finalize call this to keep the identity set complete.
 func (f *Fixture) AppendIdentity(SessionID string) {
 	f.Add(IdentityFixtureRecord(SessionID))
-	slices.SortStableFunc(f.Records, orderCompare)
+	slices.SortStableFunc(f.Records, OrderCompare)
 	f.Renumber()
 }
 

--- a/internal/qualification/fixture.go
+++ b/internal/qualification/fixture.go
@@ -712,17 +712,15 @@ func ProtocolSessionCount(records []Record) int {
 }
 
 // ComparisonCapabilities is the set of capabilities measured in
-// comparison scenarios.
-var ComparisonCapabilities = []Capability{
-	CapabilityTurnDisposition, CapabilityRetryClassification,
-	CapabilityTokenCeiling, CapabilitySessionContinuation,
-}
+// comparison scenarios. It is a copy of the list the validator itself
+// reads rather than a second declaration of the same members, so a
+// collector iterating this set cannot come to measure a set the
+// cardinality rules no longer enforce.
+var ComparisonCapabilities = slices.Clone(comparisonCapabilities)
 
-// MeasuredSurfaces is the set of surfaces measured in protocol records.
-var MeasuredSurfaces = []Surface{
-	SurfaceProtocol, SurfaceNativeText,
-	SurfaceNativeJSON, SurfaceNativeStreamJSON,
-}
+// MeasuredSurfaces is the set of surfaces measured in protocol records,
+// copied from the validator's own list for the same reason.
+var MeasuredSurfaces = slices.Clone(measuredSurfaces)
 
 // ReadEvidenceFile reads a JSONL evidence file and strictly decodes
 // all records.

--- a/internal/qualification/fixture.go
+++ b/internal/qualification/fixture.go
@@ -1,0 +1,750 @@
+package qualification
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+)
+
+// The synthetic identifiers every fixture uses. They are public test
+// values only: no credential, path, or captured runtime value.
+const (
+	FixtureTime      = "2026-03-04T05:06:07Z"
+	FixtureAgentName = "fixture-agent"
+	FixtureAgentVer  = "1.0.0-fixture"
+
+	FixtureQualified    = "qualified"
+	FixtureNotQualified = "not_qualified"
+)
+
+// FixtureSession builds the synthetic session identifier for one
+// named session on one Surface.
+func FixtureSession(Surface Surface, name string) string {
+	return fmt.Sprintf("sess-%s-%s", Surface, name)
+}
+
+// Fixture is a complete, canonically ordered evidence set. The
+// qualified variant records every required observation; the
+// not_qualified variant leaves the runtime-refusal disposition and
+// non-retryable-refusal retry Cases unobserved on every Surface.
+type Fixture struct {
+	Records []Record
+}
+
+// NewFixture builds the non-final records of one variant in
+// canonical order. The runtime-identity records are added by Finalize.
+func NewFixture(variant string) *Fixture {
+	f := &Fixture{}
+	f.addWorkspaceSecurity()
+	f.addPolicyPrecondition()
+	f.addSemanticProbes()
+	f.addBaselines()
+	f.addTokenInventories()
+	f.addPermission()
+	f.addToolServer()
+	f.addContinuation()
+	f.addEndToEnd()
+	f.addProcessCleanup()
+	if variant == FixtureNotQualified {
+		for _, Surface := range measuredSurfaces {
+			f.SetSemanticNotObserved(Surface, CapabilityTurnDisposition, CaseRuntimeRefusal)
+			f.SetSemanticNotObserved(Surface, CapabilityRetryClassification, CaseNonRetryableRefusal)
+		}
+	}
+	return f
+}
+
+// base returns a Record stub with the fixed identity fields every
+// fixture Record shares.
+func (f *Fixture) base() Record {
+	return Record{
+		SchemaVersion: 1,
+		Sequence:      0,
+		ObservedAt:    FixtureTime,
+	}
+}
+
+// Add appends one Record.
+func (f *Fixture) Add(rec Record) {
+	f.Records = append(f.Records, rec)
+}
+
+// Finalize appends one runtime-identity record per distinct non-null
+// actual protocol session id referenced by the current records, sorts
+// the whole set into canonical order, and renumbers the sequences.
+func (f *Fixture) Finalize() {
+	referenced := map[string]bool{}
+	for i := range f.Records {
+		rec := &f.Records[i]
+		if rec.Surface == SurfaceProtocol && rec.SessionID != nil {
+			referenced[*rec.SessionID] = true
+		}
+	}
+	ids := make([]string, 0, len(referenced))
+	for id := range referenced {
+		ids = append(ids, id)
+	}
+	slices.Sort(ids)
+	for _, id := range ids {
+		f.Add(IdentityFixtureRecord(id))
+	}
+	slices.SortStableFunc(f.Records, orderCompare)
+	f.Renumber()
+}
+
+// Renumber assigns one-based contiguous Sequence numbers in slice order.
+func (f *Fixture) Renumber() {
+	for i := range f.Records {
+		f.Records[i].Sequence = i + 1
+	}
+}
+
+// FindFirst returns the first Record matching match, or nil.
+func (f *Fixture) FindFirst(match func(*Record) bool) *Record {
+	for i := range f.Records {
+		rec := &f.Records[i]
+		if match(rec) {
+			return rec
+		}
+	}
+	return nil
+}
+
+// Remove deletes the Record pointed to by target, which must be a
+// pointer into the fixture's own slice.
+func (f *Fixture) Remove(target *Record) {
+	for i := range f.Records {
+		if &f.Records[i] == target {
+			f.Records = slices.Delete(f.Records, i, i+1)
+			return
+		}
+	}
+}
+
+// RemoveAll deletes every Record matching match.
+func (f *Fixture) RemoveAll(match func(*Record) bool) {
+	f.Records = slices.DeleteFunc(f.Records, func(rec Record) bool {
+		return match(&rec)
+	})
+}
+
+// SetSemanticNotObserved rewrites one semantic Case as not observed and
+// rewrites the owning Capability's baseline to the newly derived Grade.
+func (f *Fixture) SetSemanticNotObserved(Surface Surface, Capability Capability, caseID Case) {
+	rec := f.FindFirst(MatchSemantic(Surface, Capability, caseID))
+	if rec == nil {
+		return
+	}
+	rec.Outcome = OutcomeNotObserved
+	rec.Grade = GradeNotObserved
+	rec.SessionID = nil
+	rec.EvidencePath = nil
+	rec.Detail = fmt.Sprintf("%s %s Case was not observed on %s", Capability, caseID, Surface)
+	f.UpdateSemanticBaseline(Surface, Capability)
+}
+
+// UpdateSemanticBaseline recomputes one Surface-Capability baseline from
+// that Capability's current Case records and writes the derived Grade.
+func (f *Fixture) UpdateSemanticBaseline(Surface Surface, Capability Capability) {
+	var classes []Grade
+	for _, caseID := range CapabilityCases[Capability] {
+		rec := f.FindFirst(MatchSemantic(Surface, Capability, caseID))
+		if rec == nil {
+			return
+		}
+		classes = append(classes, rec.Grade)
+	}
+	baseline := f.FindFirst(MatchBaseline(Surface, Capability))
+	if baseline != nil {
+		baseline.Grade = DeriveBaselineGrade(classes)
+		baseline.Outcome = BaselineVerdictFor(baseline.Grade)
+	}
+}
+
+// addWorkspaceSecurity adds the single aggregate workspace observation.
+func (f *Fixture) addWorkspaceSecurity() {
+	rec := f.base()
+	rec.Scenario = ScenarioWorkspaceSecurity
+	rec.Surface = SurfaceAggregate
+	rec.Capability = CapabilityWorkspaceSecurity
+	rec.Source = SourceProcessObservation
+	rec.Grade = GradeUsable
+	rec.Outcome = OutcomePass
+	rec.InputID = InputSecurity
+	rec.EvidencePath = new("/workspace/settings")
+	rec.Detail = "controlled checkout without project settings; run-scoped homes; allowlisted environment names only; skip-trust accepted"
+	f.Add(rec)
+}
+
+// addPolicyPrecondition adds the single policy-denial precondition
+// Record, referencing the protocol control session.
+func (f *Fixture) addPolicyPrecondition() {
+	rec := f.base()
+	rec.Scenario = ScenarioPolicyPrecondition
+	rec.Surface = SurfaceAggregate
+	rec.Capability = CapabilityPermissionHandling
+	rec.Source = SourceProcessObservation
+	rec.Grade = GradeUsable
+	rec.Outcome = OutcomePass
+	rec.InputID = InputPolicyControl
+	rec.EvidencePath = new("policy.deny_marker")
+	rec.SessionID = new(FixtureSession(SurfaceProtocol, "policy"))
+	rec.AgentVersion = new(FixtureAgentVer)
+	rec.Detail = "policy deny marker returned and the probe side effect stayed absent"
+	f.Add(rec)
+}
+
+// addSemanticProbes adds all 36 semantic records in canonical order.
+func (f *Fixture) addSemanticProbes() {
+	for _, Surface := range measuredSurfaces {
+		for _, Capability := range []Capability{CapabilityTurnDisposition, CapabilityRetryClassification} {
+			for _, caseID := range CapabilityCases[Capability] {
+				f.Add(f.semanticRecord(Surface, Capability, caseID))
+			}
+		}
+	}
+}
+
+// semanticRecord builds one semantic probe Record. The native text
+// Surface is characterized as unstructured residue, so its Cases Grade
+// gap; every other Surface Grades usable. Refusal retry records reuse
+// the refusal disposition session, and the protocol human-input Record
+// reuses the permission attempt session.
+func (f *Fixture) semanticRecord(Surface Surface, Capability Capability, caseID Case) Record {
+	rec := f.base()
+	rec.Scenario = ScenarioSemanticProbe
+	rec.Surface = Surface
+	rec.Capability = Capability
+	rec.SemanticCase = new(caseID)
+	rec.InputID = CaseInputs[caseID]
+	rec.Outcome = OutcomePass
+	rec.Grade = GradeUsable
+	switch Surface {
+	case SurfaceProtocol:
+		rec.Source = SourceProtocolStable
+		rec.EvidencePath = new("/turn/stop_reason")
+		rec.AgentName = new(FixtureAgentName)
+		rec.AgentVersion = new(FixtureAgentVer)
+		rec.ProtocolVersion = new(1)
+	case SurfaceNativeText:
+		rec.Source = SourceNativeText
+		rec.Grade = GradeGap
+		rec.EvidencePath = new("/text/final")
+		rec.AgentVersion = new(FixtureAgentVer)
+	default:
+		rec.Source = SourceNativeStructured
+		if Surface == SurfaceNativeJSON {
+			rec.EvidencePath = new("/response/terminal")
+		} else {
+			rec.EvidencePath = new("/stream/terminal")
+		}
+		rec.AgentVersion = new(FixtureAgentVer)
+	}
+
+	switch {
+	case caseID == CaseRuntimeRefusal:
+		rec.SessionID = new(FixtureSession(Surface, "runtime-refusal"))
+	case caseID == CaseNonRetryableRefusal:
+		rec.SessionID = new(FixtureSession(Surface, "runtime-refusal"))
+	case caseID == CaseHumanInput && Surface == SurfaceProtocol:
+		rec.SessionID = new(FixtureSession(Surface, "permission"))
+	case caseID == CaseHumanInput:
+		rec.SessionID = new(FixtureSession(Surface, "human-input"))
+	default:
+		rec.SessionID = new(FixtureSession(Surface, string(caseID)))
+	}
+	rec.Detail = fmt.Sprintf("%s %s Case completed with a distinct Outcome on %s", Capability, caseID, Surface)
+	return rec
+}
+
+// BaselineVerdictFor returns the Outcome a derived baseline Record
+// carries for its Grade: not_observed Grades are not_observed Outcomes,
+// every other Grade is a completed probe.
+func BaselineVerdictFor(classification Grade) Outcome {
+	if classification == GradeNotObserved {
+		return OutcomeNotObserved
+	}
+	return OutcomePass
+}
+
+// addBaselines adds the 16 derived per-Surface Capability summaries.
+func (f *Fixture) addBaselines() {
+	for _, Surface := range measuredSurfaces {
+		for _, Capability := range comparisonCapabilities {
+			rec := f.base()
+			rec.Scenario = ScenarioSurfaceBaseline
+			rec.Surface = Surface
+			rec.Capability = Capability
+			rec.Source = SourceComparison
+			rec.InputID = InputBaseline
+			rec.EvidencePath = new(fmt.Sprintf("/comparison/%s/%s", Surface, Capability))
+			rec.Detail = fmt.Sprintf("derived %s Grade for %s", Capability, Surface)
+			switch Capability {
+			case CapabilityTurnDisposition, CapabilityRetryClassification:
+				var classes []Grade
+				for _, caseID := range CapabilityCases[Capability] {
+					classes = append(classes, f.FindFirst(MatchSemantic(Surface, Capability, caseID)).Grade)
+				}
+				rec.Grade = DeriveBaselineGrade(classes)
+			case CapabilityTokenCeiling:
+				rec.Grade = GradeUsable
+				if Surface == SurfaceNativeText {
+					rec.Grade = GradeGap
+				}
+			case CapabilitySessionContinuation:
+				rec.Grade = GradeUsable
+			}
+			rec.Outcome = BaselineVerdictFor(rec.Grade)
+			f.Add(rec)
+		}
+	}
+}
+
+// addTokenInventories adds each Surface's token-bearing paths, with the
+// native text Surface carried by the zero-Source sentinel.
+func (f *Fixture) addTokenInventories() {
+	f.Add(f.tokenRecord(SurfaceProtocol, "session/prompt/result/usage",
+		SourceProtocolStable, GradeUsable,
+		FixtureSession(SurfaceProtocol, "success"),
+		"standard usage member on the final prompt result"))
+	f.Add(f.tokenRecord(SurfaceProtocol, "session/update/vendor_usage",
+		SourceProtocolExtension, GradeCorroborationOnly,
+		FixtureSession(SurfaceProtocol, "runtime-failure"),
+		"vendor extension reports totals outside the shared contract"))
+	f.Add(f.tokenRecord(SurfaceNativeJSON, "/response/stats",
+		SourceNativeStructured, GradeUsable,
+		FixtureSession(SurfaceNativeJSON, "success"),
+		"structured response carries the usage stats member"))
+	f.Add(f.tokenRecord(SurfaceNativeStreamJSON, "/stream/final/usage",
+		SourceNativeStructured, GradeUsable,
+		FixtureSession(SurfaceNativeStreamJSON, "success"),
+		"final stream event carries the usage member"))
+
+	sentinel := f.base()
+	sentinel.Scenario = ScenarioTokenSource
+	sentinel.Surface = SurfaceNativeText
+	sentinel.Capability = CapabilityTokenCeiling
+	sentinel.Source = SourceNone
+	sentinel.Grade = GradeGap
+	sentinel.Outcome = OutcomePass
+	sentinel.InputID = InputTokenInventory
+	sentinel.Detail = "inventory completed with no token-bearing path"
+	f.Add(sentinel)
+}
+
+// tokenRecord builds one non-sentinel token inventory Record.
+func (f *Fixture) tokenRecord(Surface Surface, path string, Source Source, classification Grade, SessionID, Detail string) Record {
+	rec := f.base()
+	rec.Scenario = ScenarioTokenSource
+	rec.Surface = Surface
+	rec.Capability = CapabilityTokenCeiling
+	rec.Source = Source
+	rec.Grade = classification
+	rec.Outcome = OutcomePass
+	rec.InputID = InputTokenInventory
+	rec.EvidencePath = new(path)
+	rec.SessionID = new(SessionID)
+	rec.Detail = Detail
+	if Surface == SurfaceProtocol {
+		rec.AgentName = new(FixtureAgentName)
+		rec.AgentVersion = new(FixtureAgentVer)
+		rec.ProtocolVersion = new(1)
+	} else {
+		rec.AgentVersion = new(FixtureAgentVer)
+	}
+	return rec
+}
+
+// addPermission adds the single protocol permission Record.
+func (f *Fixture) addPermission() {
+	rec := f.base()
+	rec.Scenario = ScenarioPermissionRequest
+	rec.Surface = SurfaceProtocol
+	rec.Capability = CapabilityPermissionHandling
+	rec.Source = SourceProtocolStable
+	rec.Grade = GradeUsable
+	rec.Outcome = OutcomePass
+	rec.InputID = InputPermissionProbe
+	rec.EvidencePath = new("session/request_permission")
+	rec.SessionID = new(FixtureSession(SurfaceProtocol, "permission"))
+	rec.AgentName = new(FixtureAgentName)
+	rec.AgentVersion = new(FixtureAgentVer)
+	rec.ProtocolVersion = new(1)
+	rec.Detail = "request answered with a refusing option and no request left pending"
+	f.Add(rec)
+}
+
+// addToolServer adds the single protocol MCP delivery Record.
+func (f *Fixture) addToolServer() {
+	rec := f.base()
+	rec.Scenario = ScenarioToolServer
+	rec.Surface = SurfaceProtocol
+	rec.Capability = CapabilityToolServerDelivery
+	rec.Source = SourceProcessObservation
+	rec.Grade = GradeUsable
+	rec.Outcome = OutcomePass
+	rec.InputID = InputMCPProbe
+	rec.EvidencePath = new("mcp_server.receipt")
+	rec.SessionID = new(FixtureSession(SurfaceProtocol, "mcp"))
+	rec.AgentName = new(FixtureAgentName)
+	rec.AgentVersion = new(FixtureAgentVer)
+	rec.ProtocolVersion = new(1)
+	rec.Detail = "test server received the generated nonce and the turn consumed it"
+	f.Add(rec)
+}
+
+// addContinuation adds one seed and one confirmed same-session recall per
+// Surface.
+func (f *Fixture) addContinuation() {
+	for _, Surface := range measuredSurfaces {
+		seedSession := FixtureSession(Surface, "seed")
+
+		seed := f.base()
+		seed.Scenario = ScenarioContinuation
+		seed.Surface = Surface
+		seed.Capability = CapabilitySessionContinuation
+		seed.InputID = InputContinuationSeed
+		seed.Outcome = OutcomePass
+		seed.Grade = GradeUsable
+		seed.Source = SourceNativeStructured
+		if Surface == SurfaceProtocol {
+			seed.Source = SourceProtocolStable
+			seed.AgentName = new(FixtureAgentName)
+			seed.AgentVersion = new(FixtureAgentVer)
+			seed.ProtocolVersion = new(1)
+		} else {
+			seed.AgentVersion = new(FixtureAgentVer)
+		}
+		seed.EvidencePath = new("/continuation/seed")
+		seed.SessionID = new(seedSession)
+		seed.Detail = "seed conversation stored the generated nonce"
+		f.Add(seed)
+
+		recall := f.base()
+		recall.Scenario = ScenarioContinuation
+		recall.Surface = Surface
+		recall.Capability = CapabilitySessionContinuation
+		recall.InputID = InputContinuationRecall
+		recall.Outcome = OutcomePass
+		recall.Grade = GradeUsable
+		recall.Source = seed.Source
+		recall.EvidencePath = new("/continuation/recall")
+		recall.SessionID = new(seedSession)
+		recall.PriorSessionID = new(seedSession)
+		recall.Detail = recallConfirmedSameSession
+		if Surface == SurfaceProtocol {
+			recall.AgentName = new(FixtureAgentName)
+			recall.AgentVersion = new(FixtureAgentVer)
+			recall.ProtocolVersion = new(1)
+		} else {
+			recall.AgentVersion = new(FixtureAgentVer)
+		}
+		f.Add(recall)
+	}
+}
+
+// addEndToEnd adds the single isolated end-to-end Record.
+func (f *Fixture) addEndToEnd() {
+	rec := f.base()
+	rec.Scenario = ScenarioEndToEnd
+	rec.Surface = SurfaceProtocol
+	rec.Capability = CapabilityTurnDisposition
+	rec.Source = SourceProcessObservation
+	rec.Grade = GradeUsable
+	rec.Outcome = OutcomePass
+	rec.InputID = InputE2E
+	rec.EvidencePath = new("/run_history/status")
+	rec.SessionID = new(FixtureSession(SurfaceProtocol, "e2e"))
+	rec.AgentName = new(FixtureAgentName)
+	rec.AgentVersion = new(FixtureAgentVer)
+	rec.ProtocolVersion = new(1)
+	rec.Detail = "one succeeded history row and the issue reached its handoff state"
+	f.Add(rec)
+}
+
+// addProcessCleanup adds the single aggregate cleanup Record.
+func (f *Fixture) addProcessCleanup() {
+	rec := f.base()
+	rec.Scenario = ScenarioProcessCleanup
+	rec.Surface = SurfaceAggregate
+	rec.Capability = CapabilityProcessCleanup
+	rec.Source = SourceProcessObservation
+	rec.Grade = GradeUsable
+	rec.Outcome = OutcomePass
+	rec.InputID = InputCleanup
+	rec.EvidencePath = new("process_group.liveness")
+	rec.Detail = "checked_groups=9"
+	f.Add(rec)
+}
+
+// MatchSemantic matches one semantic tuple.
+func MatchSemantic(Surface Surface, Capability Capability, caseID Case) func(*Record) bool {
+	return func(rec *Record) bool {
+		if rec.Scenario != ScenarioSemanticProbe || rec.Surface != Surface ||
+			rec.Capability != Capability || rec.SemanticCase == nil {
+			return false
+		}
+		return *rec.SemanticCase == caseID
+	}
+}
+
+// MatchBaseline matches one Surface-Capability baseline Record.
+func MatchBaseline(Surface Surface, Capability Capability) func(*Record) bool {
+	return func(rec *Record) bool {
+		return rec.Scenario == ScenarioSurfaceBaseline &&
+			rec.Surface == Surface && rec.Capability == Capability
+	}
+}
+
+// MatchContinuation matches one Surface's seed or recall Record.
+func MatchContinuation(Surface Surface, InputID InputID) func(*Record) bool {
+	return func(rec *Record) bool {
+		return rec.Scenario == ScenarioContinuation && rec.Surface == Surface && rec.InputID == InputID
+	}
+}
+
+// WriteEvidenceFile serializes records as UTF-8 JSON Lines under
+// the test's temporary directory and returns the file path.
+func WriteEvidenceFile(T *testing.T, records []Record) string {
+	T.Helper()
+	dir := filepath.Join(T.TempDir(), "qualification")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		T.Fatalf("create evidence directory: %v", err)
+	}
+	path := filepath.Join(dir, "evidence.jsonl")
+	var lines []string
+	for _, rec := range records {
+		line, err := MarshalRecord(rec)
+		if err != nil {
+			T.Fatalf("marshal evidence Record %d: %v", rec.Sequence, err)
+		}
+		lines = append(lines, string(line))
+	}
+	if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")+"\n"), 0o600); err != nil {
+		T.Fatalf("write evidence file: %v", err)
+	}
+	return path
+}
+
+// WriteFinalEvidenceFile serializes a non-final set plus the single
+// terminal aggregate Record and returns the file path.
+func WriteFinalEvidenceFile(T *testing.T, records []Record, classification Grade) string {
+	T.Helper()
+	complete := append(slices.Clone(records), aggregateFixtureRecord(classification))
+	for i := range complete {
+		complete[i].Sequence = i + 1
+	}
+	return WriteEvidenceFile(T, complete)
+}
+
+// RequireObservationVerdict validates a first-pass file and fails T
+// unless it validates with the wanted Verdict.
+func RequireObservationVerdict(T *testing.T, path string, wantVerdict Verdict) {
+	T.Helper()
+	v, err := ValidateObservations(path)
+	if err != nil {
+		T.Errorf("ValidateObservations(%s) error = %v, want nil", path, err)
+		return
+	}
+	if v != wantVerdict {
+		T.Errorf("ValidateObservations(%s) = %q, want %q", path, v, wantVerdict)
+	}
+}
+
+// IdentityFixtureRecord builds one runtime-identity record for one
+// actual protocol session.
+func IdentityFixtureRecord(SessionID string) Record {
+	return Record{
+		SchemaVersion:   1,
+		Sequence:        0,
+		ObservedAt:      FixtureTime,
+		Scenario:        ScenarioRuntimeIdentity,
+		Surface:         SurfaceProtocol,
+		Capability:      CapabilityRuntimeIdentity,
+		Source:          SourceProtocolStable,
+		Grade:           GradeUsable,
+		Outcome:         OutcomePass,
+		InputID:         InputIdentity,
+		EvidencePath:    new("/handshake/agent_info"),
+		SessionID:       new(SessionID),
+		AgentName:       new(FixtureAgentName),
+		AgentVersion:    new(FixtureAgentVer),
+		ProtocolVersion: new(1),
+		Detail:          "handshake reported agent name and version",
+	}
+}
+
+// aggregateFixtureRecord builds the terminal qualification Record
+// with the given classification.
+func aggregateFixtureRecord(classification Grade) Record {
+	return Record{
+		SchemaVersion: 1,
+		Sequence:      0,
+		ObservedAt:    FixtureTime,
+		Scenario:      ScenarioQualification,
+		Surface:       SurfaceAggregate,
+		Capability:    CapabilityEligibility,
+		Source:        SourceComparison,
+		Grade:         classification,
+		Outcome:       OutcomePass,
+		InputID:       InputAggregate,
+		EvidencePath:  new(EvidencePathQualificationVerdict),
+		Detail:        "aggregate qualification Verdict recomputed from the closed non-final evidence set",
+	}
+}
+
+// RequireFinalVerdict validates a final-pass file and fails T unless it
+// validates with the wanted Verdict.
+func RequireFinalVerdict(T *testing.T, path string, wantVerdict Verdict) {
+	T.Helper()
+	v, err := ValidateEvidence(path)
+	if err != nil {
+		T.Errorf("ValidateEvidence(%s) error = %v, want nil", path, err)
+		return
+	}
+	if v != wantVerdict {
+		T.Errorf("ValidateEvidence(%s) = %q, want %q", path, v, wantVerdict)
+	}
+}
+
+// SetTokenSentinel replaces one Surface's token inventory with the single
+// sentinel Record: a zero-Source success when failed is false and a
+// failed inventory otherwise. The token baseline is rewritten to the
+// derived Grade.
+func (f *Fixture) SetTokenSentinel(Surface Surface, failed bool) {
+	f.RemoveAll(matchTokenSurface(Surface))
+	sentinel := f.base()
+	sentinel.Scenario = ScenarioTokenSource
+	sentinel.Surface = Surface
+	sentinel.Capability = CapabilityTokenCeiling
+	sentinel.Source = SourceNone
+	sentinel.Outcome = OutcomePass
+	sentinel.InputID = InputTokenInventory
+	if failed {
+		sentinel.Grade = GradeNotObserved
+		sentinel.Outcome = OutcomeRuntimeFailed
+		sentinel.Detail = "token inventory collection failed"
+	} else {
+		sentinel.Grade = GradeGap
+		sentinel.Detail = "inventory completed with no token-bearing path"
+	}
+	f.Add(sentinel)
+
+	baseline := f.FindFirst(MatchBaseline(Surface, CapabilityTokenCeiling))
+	if baseline != nil {
+		baseline.Grade = GradeGap
+		if failed {
+			baseline.Grade = GradeNotObserved
+		}
+		baseline.Outcome = BaselineVerdictFor(baseline.Grade)
+	}
+}
+
+// matchTokenSurface matches one Surface's token inventory records.
+func matchTokenSurface(Surface Surface) func(*Record) bool {
+	return func(rec *Record) bool {
+		return rec.Scenario == ScenarioTokenSource && rec.Surface == Surface
+	}
+}
+
+// SetTokenCorroborationOnly rewrites every non-sentinel token Record of
+// one Surface to corroboration_only and the token baseline to gap, so
+// the inventory completed but supplied no contract-usable Source.
+func (f *Fixture) SetTokenCorroborationOnly(Surface Surface) {
+	for i := range f.Records {
+		rec := &f.Records[i]
+		if matchTokenSurface(Surface)(rec) && rec.EvidencePath != nil {
+			rec.Grade = GradeCorroborationOnly
+		}
+	}
+	if baseline := f.FindFirst(MatchBaseline(Surface, CapabilityTokenCeiling)); baseline != nil {
+		baseline.Grade = GradeGap
+	}
+}
+
+// DuplicateAfter inserts a copy of target directly behind it, keeping
+// the canonical ordering intact so the duplicate key check is the check
+// that fires.
+func (f *Fixture) DuplicateAfter(target *Record) {
+	for i := range f.Records {
+		if &f.Records[i] == target {
+			f.Records = slices.Insert(f.Records, i+1, *target)
+			return
+		}
+	}
+}
+
+// AppendIdentity adds one runtime-identity record for SessionID at its
+// canonical position. Controls that introduce a new actual protocol
+// session id after Finalize call this to keep the identity set complete.
+func (f *Fixture) AppendIdentity(SessionID string) {
+	f.Add(IdentityFixtureRecord(SessionID))
+	slices.SortStableFunc(f.Records, orderCompare)
+	f.Renumber()
+}
+
+// TokenRecordCount counts records with the token-source scenario.
+func TokenRecordCount(records []Record) int {
+	count := 0
+	for i := range records {
+		if records[i].Scenario == ScenarioTokenSource {
+			count++
+		}
+	}
+	return count
+}
+
+// ProtocolSessionCount counts the distinct non-null actual protocol
+// session ids a record set references.
+func ProtocolSessionCount(records []Record) int {
+	ids := map[string]bool{}
+	for i := range records {
+		rec := &records[i]
+		if rec.Surface == SurfaceProtocol && rec.SessionID != nil {
+			ids[*rec.SessionID] = true
+		}
+	}
+	return len(ids)
+}
+
+// ComparisonCapabilities is the set of capabilities measured in
+// comparison scenarios.
+var ComparisonCapabilities = []Capability{
+	CapabilityTurnDisposition, CapabilityRetryClassification,
+	CapabilityTokenCeiling, CapabilitySessionContinuation,
+}
+
+// MeasuredSurfaces is the set of surfaces measured in protocol records.
+var MeasuredSurfaces = []Surface{
+	SurfaceProtocol, SurfaceNativeText,
+	SurfaceNativeJSON, SurfaceNativeStreamJSON,
+}
+
+// ReadEvidenceFile reads a JSONL evidence file and strictly decodes
+// all records.
+func ReadEvidenceFile(path string) ([]Record, error) {
+	data, err := os.ReadFile(path) //nolint:gosec // the caller supplies a path to a file it wrote under its own temp directory
+	if err != nil {
+		return nil, err
+	}
+	var records []Record
+	for n, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		rec, err := DecodeRecord([]byte(line))
+		if err != nil {
+			return nil, fmt.Errorf("line %d: %w", n+1, err)
+		}
+		records = append(records, rec)
+	}
+	if len(records) == 0 {
+		return nil, errors.New("evidence file contains no records")
+	}
+	return records, nil
+}

--- a/internal/qualification/grade_test.go
+++ b/internal/qualification/grade_test.go
@@ -1,0 +1,308 @@
+package qualification
+
+import (
+	"testing"
+)
+
+// TestSemanticGradeDerivation confirms the per-Capability baseline
+// derivation: each of the five disposition Cases and each of the four
+// retry Cases is independent, an unobserved Case lowers only its owning
+// Capability, and observed-but-conflated Cases Grade gap.
+func TestSemanticGradeDerivation(T *testing.T) {
+	T.Parallel()
+
+	dispositionCases := CapabilityCases[CapabilityTurnDisposition]
+	retryCases := CapabilityCases[CapabilityRetryClassification]
+
+	allUsable := func(Cases []Case, skipped Case) []Grade {
+		classes := make([]Grade, 0, len(Cases))
+		for _, caseID := range Cases {
+			if caseID == skipped {
+				classes = append(classes, GradeNotObserved)
+				continue
+			}
+			classes = append(classes, GradeUsable)
+		}
+		return classes
+	}
+
+	T.Run("each unobserved disposition Case lowers only turn_disposition", func(T *testing.T) {
+		T.Parallel()
+
+		for _, caseID := range dispositionCases {
+			T.Run(string(caseID), func(T *testing.T) {
+				T.Parallel()
+
+				got := DeriveBaselineGrade(allUsable(dispositionCases, caseID))
+				if got != GradeNotObserved {
+					T.Errorf("DeriveBaselineGrade(disposition with %s not observed) = %s, want not_observed", caseID, got)
+				}
+				retryGot := DeriveBaselineGrade(allUsable(retryCases, ""))
+				if retryGot != GradeUsable {
+					T.Errorf("DeriveBaselineGrade(retry Cases) = %s, want usable; the retry baseline must not move with a disposition Case", retryGot)
+				}
+			})
+		}
+	})
+
+	T.Run("each unobserved retry Case lowers only retry_classification", func(T *testing.T) {
+		T.Parallel()
+
+		for _, caseID := range retryCases {
+			T.Run(string(caseID), func(T *testing.T) {
+				T.Parallel()
+
+				got := DeriveBaselineGrade(allUsable(retryCases, caseID))
+				if got != GradeNotObserved {
+					T.Errorf("DeriveBaselineGrade(retry with %s not observed) = %s, want not_observed", caseID, got)
+				}
+				dispositionGot := DeriveBaselineGrade(allUsable(dispositionCases, ""))
+				if dispositionGot != GradeUsable {
+					T.Errorf("DeriveBaselineGrade(disposition Cases) = %s, want usable; the disposition baseline must not move with a retry Case", dispositionGot)
+				}
+			})
+		}
+	})
+
+	T.Run("observed Case classifications decide usable versus gap", func(T *testing.T) {
+		T.Parallel()
+
+		tests := []struct {
+			name            string
+			classifications []Grade
+			want            Grade
+		}{
+			{name: "all usable Grades usable", classifications: []Grade{
+				GradeUsable, GradeUsable, GradeUsable,
+			}, want: GradeUsable},
+			{name: "one conflated Case Grades gap", classifications: []Grade{
+				GradeUsable, GradeGap, GradeUsable,
+			}, want: GradeGap},
+			{name: "only conflated Cases Grade gap", classifications: []Grade{
+				GradeGap, GradeGap,
+			}, want: GradeGap},
+			{name: "not_observed dominates gap", classifications: []Grade{
+				GradeGap, GradeNotObserved,
+			}, want: GradeNotObserved},
+		}
+
+		for _, tt := range tests {
+			T.Run(tt.name, func(T *testing.T) {
+				T.Parallel()
+
+				got := DeriveBaselineGrade(tt.classifications)
+				if got != tt.want {
+					T.Errorf("DeriveBaselineGrade(%v) = %s, want %s", tt.classifications, got, tt.want)
+				}
+			})
+		}
+	})
+
+	T.Run("the written variants carry the derived Grades end to end", func(T *testing.T) {
+		T.Parallel()
+
+		qualified := NewFixture(FixtureQualified)
+		qualified.Finalize()
+		textDisposition := qualified.FindFirst(MatchBaseline(SurfaceNativeText, CapabilityTurnDisposition))
+		if textDisposition == nil {
+			T.Fatal("fixture carries no native_text disposition baseline")
+		}
+		if textDisposition.Grade != GradeGap {
+			T.Errorf("native_text disposition baseline = %s, want gap for unstructured residue", textDisposition.Grade)
+		}
+
+		notQualified := NewFixture(FixtureNotQualified)
+		notQualified.Finalize()
+		protocolDisposition := notQualified.FindFirst(MatchBaseline(SurfaceProtocol, CapabilityTurnDisposition))
+		protocolRetry := notQualified.FindFirst(MatchBaseline(SurfaceProtocol, CapabilityRetryClassification))
+		if protocolDisposition == nil || protocolRetry == nil {
+			T.Fatal("fixture carries no protocol baselines")
+		}
+		if protocolDisposition.Grade != GradeNotObserved {
+			T.Errorf("not_qualified protocol disposition baseline = %s, want not_observed", protocolDisposition.Grade)
+		}
+		if protocolRetry.Grade != GradeNotObserved {
+			T.Errorf("not_qualified protocol retry baseline = %s, want not_observed", protocolRetry.Grade)
+		}
+	})
+}
+
+// TestRichestNativeReference confirms the reference derivation:
+// the higher observed Grade of native JSON and native stream-JSON per
+// Capability, with any not_observed Surface forcing the reference to
+// not_observed, and the native text Surface excluded entirely.
+func TestRichestNativeReference(T *testing.T) {
+	T.Parallel()
+
+	T.Run("Grade combination", func(T *testing.T) {
+		T.Parallel()
+
+		tests := []struct {
+			name          string
+			jsonGrade     Grade
+			streamGrade   Grade
+			wantReference Grade
+		}{
+			{name: "two usable Surfaces give a usable reference", jsonGrade: GradeUsable, streamGrade: GradeUsable, wantReference: GradeUsable},
+			{name: "one usable and one gap Surface give a usable reference", jsonGrade: GradeUsable, streamGrade: GradeGap, wantReference: GradeUsable},
+			{name: "two gap Surfaces give a gap reference", jsonGrade: GradeGap, streamGrade: GradeGap, wantReference: GradeGap},
+			{name: "a gap Surface does not outrank a usable one", jsonGrade: GradeGap, streamGrade: GradeUsable, wantReference: GradeUsable},
+			{name: "one unobserved Surface forces not_observed over usable", jsonGrade: GradeUsable, streamGrade: GradeNotObserved, wantReference: GradeNotObserved},
+			{name: "one unobserved Surface forces not_observed over gap", jsonGrade: GradeGap, streamGrade: GradeNotObserved, wantReference: GradeNotObserved},
+			{name: "two unobserved Surfaces give not_observed", jsonGrade: GradeNotObserved, streamGrade: GradeNotObserved, wantReference: GradeNotObserved},
+		}
+
+		for _, tt := range tests {
+			T.Run(tt.name, func(T *testing.T) {
+				T.Parallel()
+
+				got := richestNativeReference(tt.jsonGrade, tt.streamGrade)
+				if got != tt.wantReference {
+					T.Errorf("richestNativeReference(%s, %s) = %s, want %s", tt.jsonGrade, tt.streamGrade, got, tt.wantReference)
+				}
+			})
+		}
+	})
+
+	T.Run("numeric Grades", func(T *testing.T) {
+		T.Parallel()
+
+		tests := []struct {
+			name       string
+			Grade      Grade
+			wantGrade  int
+			wantRanked bool
+		}{
+			{name: "usable outranks gap", Grade: GradeUsable, wantGrade: 1, wantRanked: true},
+			{name: "gap is the zero Grade", Grade: GradeGap, wantGrade: 0, wantRanked: true},
+			{name: "not_observed carries no Grade", Grade: GradeNotObserved, wantRanked: false},
+			{name: "corroboration_only carries no Grade and never reaches 1", Grade: GradeCorroborationOnly, wantRanked: false},
+		}
+
+		for _, tt := range tests {
+			T.Run(tt.name, func(T *testing.T) {
+				T.Parallel()
+
+				got, ranked := numericGrade(tt.Grade)
+				if ranked != tt.wantRanked || (ranked && got != tt.wantGrade) {
+					T.Errorf("numericGrade(%s) = %d, %v, want %d, %v", tt.Grade, got, ranked, tt.wantGrade, tt.wantRanked)
+				}
+			})
+		}
+	})
+
+	T.Run("an unobserved structured Surface blocks qualification", func(T *testing.T) {
+		T.Parallel()
+
+		fixture := NewFixture(FixtureQualified)
+		fixture.SetTokenSentinel(SurfaceNativeStreamJSON, true)
+		fixture.Finalize()
+		path := WriteEvidenceFile(T, fixture.Records)
+		RequireObservationVerdict(T, path, VerdictNotQualified)
+	})
+
+	T.Run("the native text Surface is excluded from the structured reference", func(T *testing.T) {
+		T.Parallel()
+
+		fixture := NewFixture(FixtureQualified)
+		fixture.Finalize()
+		before := WriteEvidenceFile(T, fixture.Records)
+		RequireObservationVerdict(T, before, VerdictQualified)
+
+		for _, Capability := range comparisonCapabilities[:2] {
+			for _, caseID := range CapabilityCases[Capability] {
+				rec := fixture.FindFirst(MatchSemantic(SurfaceNativeText, Capability, caseID))
+				if rec == nil {
+					T.Fatalf("fixture carries no native_text Record for %s %s", Capability, caseID)
+				}
+				rec.Grade = GradeUsable
+			}
+			fixture.UpdateSemanticBaseline(SurfaceNativeText, Capability)
+		}
+		fixture.Renumber()
+		after := WriteEvidenceFile(T, fixture.Records)
+		RequireObservationVerdict(T, after, VerdictQualified)
+	})
+}
+
+// TestEligibilityPredicates confirms the exact Verdict Outcomes:
+// the complete set of predicates yields qualified, and breaking any one
+// of them yields not_qualified from an otherwise valid evidence set.
+func TestEligibilityPredicates(T *testing.T) {
+	T.Parallel()
+
+	tests := []struct {
+		name   string
+		mutate func(*Fixture)
+	}{
+		{
+			name:   "all predicates hold yields qualified",
+			mutate: func(*Fixture) {},
+		},
+		{
+			name: "protocol token Grade below the richest native reference",
+			mutate: func(f *Fixture) {
+				f.SetTokenCorroborationOnly(SurfaceProtocol)
+			},
+		},
+		{
+			name: "tool server delivery without a server receipt",
+			mutate: func(f *Fixture) {
+				rec := f.FindFirst(matchRowClass(RowMCPDelivery))
+				rec.Grade = GradeGap
+			},
+		},
+		{
+			name: "permission request the adapter leaves unanswered",
+			mutate: func(f *Fixture) {
+				rec := f.FindFirst(matchRowClass(RowPermission))
+				rec.Outcome = OutcomeAdapterUnanswered
+				rec.Grade = GradeNotObserved
+			},
+		},
+		{
+			name: "policy precondition induction failure",
+			mutate: func(f *Fixture) {
+				rec := f.FindFirst(matchRowClass(RowPolicyPrecondition))
+				rec.Outcome = OutcomeFixtureInductionFailed
+				rec.Grade = GradeNotObserved
+			},
+		},
+		{
+			name: "end-to-end run short of its terminal condition",
+			mutate: func(f *Fixture) {
+				rec := f.FindFirst(matchRowClass(RowEndToEnd))
+				rec.Outcome = OutcomeNotObserved
+				rec.Grade = GradeNotObserved
+			},
+		},
+		{
+			name: "protocol continuation below a usable native reference",
+			mutate: func(f *Fixture) {
+				recall := f.FindFirst(MatchContinuation(SurfaceProtocol, InputContinuationRecall))
+				recall.SessionID = new(FixtureSession(SurfaceProtocol, "fallback"))
+				recall.Detail = recallFreshFallback
+				recall.Grade = GradeGap
+				if baseline := f.FindFirst(MatchBaseline(SurfaceProtocol, CapabilitySessionContinuation)); baseline != nil {
+					baseline.Grade = GradeGap
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		T.Run(tt.name, func(T *testing.T) {
+			T.Parallel()
+
+			fixture := NewFixture(FixtureQualified)
+			tt.mutate(fixture)
+			fixture.Finalize()
+			path := WriteEvidenceFile(T, fixture.Records)
+			want := VerdictQualified
+			if tt.name != "all predicates hold yields qualified" {
+				want = VerdictNotQualified
+			}
+			RequireObservationVerdict(T, path, want)
+		})
+	}
+}

--- a/internal/qualification/validate.go
+++ b/internal/qualification/validate.go
@@ -504,7 +504,7 @@ func (v *setValidation) ClassifyRecords() error {
 		if rec.Outcome == OutcomeNotApplicable && class == RowSemantic {
 			return fmt.Errorf("record %d: verdict not_applicable is invalid for a semantic probe", rec.Sequence)
 		}
-		if err := checkOutcomeGradePairing(rec); err != nil {
+		if err := CheckOutcomeGradePairing(rec); err != nil {
 			return fmt.Errorf("record %d: %w", rec.Sequence, err)
 		}
 		if rec.Grade == GradeCorroborationOnly &&
@@ -544,9 +544,11 @@ func (v *setValidation) ClassifyRecords() error {
 	return v.checkSemanticSessionRelations()
 }
 
-// checkOutcomeGradePairing enforces the closed pairing between a
-// record's outcome and its grade.
-func checkOutcomeGradePairing(rec *Record) error {
+// CheckOutcomeGradePairing enforces the closed pairing between a
+// record's outcome and its grade. It is exported so a collector that
+// builds one record at a time can check that record against the same
+// rule the set validator applies, rather than restating the pairing.
+func CheckOutcomeGradePairing(rec *Record) error {
 	classification := rec.Grade
 	verdict := rec.Outcome
 	switch classification {

--- a/internal/qualification/validate.go
+++ b/internal/qualification/validate.go
@@ -1,0 +1,1106 @@
+package qualification
+
+import (
+	"cmp"
+	"errors"
+	"fmt"
+	"os"
+	"slices"
+	"strings"
+)
+
+// RowClass names one record class from the closed non-final tuple
+// table. Every non-final record must classify into exactly one class.
+type RowClass int
+
+const (
+	RowNone RowClass = iota
+	RowWorkspaceSecurity
+	RowPolicyPrecondition
+	RowSemantic
+	RowBaseline
+	RowToken
+	RowPermission
+	RowMCPDelivery
+	RowContinuationSeed
+	RowContinuationRecall
+	RowRuntimeIdentity
+	RowProcessCleanup
+	RowEndToEnd
+)
+
+// rowLabel returns the operator-facing name of one row class, used
+// in validation diagnostics.
+func rowLabel(class RowClass) string {
+	switch class {
+	case RowWorkspaceSecurity:
+		return "workspace security"
+	case RowPolicyPrecondition:
+		return "policy precondition"
+	case RowSemantic:
+		return "semantic probe"
+	case RowBaseline:
+		return "surface baseline"
+	case RowToken:
+		return "token inventory"
+	case RowPermission:
+		return "permission handling"
+	case RowMCPDelivery:
+		return "tool server delivery"
+	case RowContinuationSeed:
+		return "continuation seed"
+	case RowContinuationRecall:
+		return "continuation recall"
+	case RowRuntimeIdentity:
+		return "runtime identity"
+	case RowProcessCleanup:
+		return "process cleanup"
+	case RowEndToEnd:
+		return "end to end"
+	}
+	return "unclassified"
+}
+
+// The four comparison capabilities eligibility is decided over, and the
+// four surfaces the closed table covers.
+var (
+	comparisonCapabilities = []Capability{
+		CapabilityTurnDisposition, CapabilityRetryClassification,
+		CapabilityTokenCeiling, CapabilitySessionContinuation,
+	}
+	measuredSurfaces = []Surface{
+		SurfaceProtocol, SurfaceNativeText,
+		SurfaceNativeJSON, SurfaceNativeStreamJSON,
+	}
+)
+
+// scenarioWriteOrder is the canonical record write order, which
+// determines sequence. It differs from the closed enum declaration order
+// in Scenarios, which only bounds valid values.
+var scenarioWriteOrder = []Scenario{
+	ScenarioWorkspaceSecurity, ScenarioPolicyPrecondition,
+	ScenarioSemanticProbe, ScenarioSurfaceBaseline,
+	ScenarioTokenSource, ScenarioPermissionRequest,
+	ScenarioToolServer, ScenarioContinuation,
+	ScenarioRuntimeIdentity, ScenarioEndToEnd,
+	ScenarioProcessCleanup, ScenarioQualification,
+}
+
+// The closed recall detail set for continuation recall records.
+const (
+	recallConfirmedSameSession = "confirmed_same_session"
+	recallFreshFallback        = "fresh_session_fallback"
+	recallUnobservedActual     = "unobserved_actual_session"
+)
+
+// ClassifyRecord matches one record against the closed tuple table
+// and returns its row class, rejecting any tuple the table does not
+// declare.
+func ClassifyRecord(rec *Record) (RowClass, error) {
+	inMeasuredSurfaces := slices.Contains(measuredSurfaces, rec.Surface)
+
+	switch {
+	case rec.Scenario == ScenarioWorkspaceSecurity &&
+		rec.Surface == SurfaceAggregate &&
+		rec.Capability == CapabilityWorkspaceSecurity &&
+		rec.InputID == InputSecurity && rec.SemanticCase == nil:
+		return RowWorkspaceSecurity, nil
+
+	case rec.Scenario == ScenarioPolicyPrecondition &&
+		rec.Surface == SurfaceAggregate &&
+		rec.Capability == CapabilityPermissionHandling &&
+		rec.InputID == InputPolicyControl && rec.SemanticCase == nil:
+		return RowPolicyPrecondition, nil
+
+	case rec.Scenario == ScenarioSemanticProbe &&
+		inMeasuredSurfaces && rec.SemanticCase != nil:
+		cases, known := CapabilityCases[rec.Capability]
+		if !known || !slices.Contains(cases, *rec.SemanticCase) {
+			return RowNone, fmt.Errorf("semantic case %v is not valid for capability %s", rec.SemanticCase, rec.Capability)
+		}
+		if want := CaseInputs[*rec.SemanticCase]; rec.InputID != want {
+			return RowNone, fmt.Errorf("semantic case %v requires input_id %s, got %s", *rec.SemanticCase, want, rec.InputID)
+		}
+		return RowSemantic, nil
+
+	case rec.Scenario == ScenarioSurfaceBaseline &&
+		inMeasuredSurfaces && rec.SemanticCase == nil &&
+		rec.InputID == InputBaseline &&
+		slices.Contains(comparisonCapabilities, rec.Capability):
+		return RowBaseline, nil
+
+	case rec.Scenario == ScenarioTokenSource &&
+		inMeasuredSurfaces && rec.SemanticCase == nil &&
+		rec.Capability == CapabilityTokenCeiling &&
+		rec.InputID == InputTokenInventory:
+		return RowToken, nil
+
+	case rec.Scenario == ScenarioPermissionRequest &&
+		rec.Surface == SurfaceProtocol &&
+		rec.Capability == CapabilityPermissionHandling &&
+		rec.InputID == InputPermissionProbe && rec.SemanticCase == nil:
+		return RowPermission, nil
+
+	case rec.Scenario == ScenarioToolServer &&
+		rec.Surface == SurfaceProtocol &&
+		rec.Capability == CapabilityToolServerDelivery &&
+		rec.InputID == InputMCPProbe && rec.SemanticCase == nil:
+		return RowMCPDelivery, nil
+
+	case rec.Scenario == ScenarioContinuation &&
+		inMeasuredSurfaces && rec.SemanticCase == nil &&
+		rec.Capability == CapabilitySessionContinuation:
+		switch rec.InputID {
+		case InputContinuationSeed:
+			return RowContinuationSeed, nil
+		case InputContinuationRecall:
+			return RowContinuationRecall, nil
+		}
+
+	case rec.Scenario == ScenarioRuntimeIdentity &&
+		rec.Surface == SurfaceProtocol &&
+		rec.Capability == CapabilityRuntimeIdentity &&
+		rec.InputID == InputIdentity && rec.SemanticCase == nil:
+		return RowRuntimeIdentity, nil
+
+	case rec.Scenario == ScenarioProcessCleanup &&
+		rec.Surface == SurfaceAggregate &&
+		rec.Capability == CapabilityProcessCleanup &&
+		rec.InputID == InputCleanup && rec.SemanticCase == nil:
+		return RowProcessCleanup, nil
+
+	case rec.Scenario == ScenarioEndToEnd &&
+		rec.Surface == SurfaceProtocol &&
+		rec.Capability == CapabilityTurnDisposition &&
+		rec.InputID == InputE2E && rec.SemanticCase == nil:
+		return RowEndToEnd, nil
+	}
+
+	return RowNone, fmt.Errorf("tuple (%s, %s, %s, %s) is outside the closed table", rec.Scenario, rec.Surface, rec.Capability, rec.InputID)
+}
+
+// rank returns the canonical position of value in order, or -1.
+func rank[T ~string](order []T, value T) int {
+	return slices.Index(order, value)
+}
+
+// compareNullableString orders two nullable strings with null
+// first.
+func compareNullableString(a, b *string) int {
+	switch {
+	case a == nil && b == nil:
+		return 0
+	case a == nil:
+		return -1
+	case b == nil:
+		return 1
+	}
+	return strings.Compare(*a, *b)
+}
+
+// orderCompare orders two records by the canonical write order:
+// the closed scenario write order, then surface order, then capability
+// order, then a scenario-specific tiebreak (semantic case, token path
+// with the null sentinel first, session identifier, or input catalog
+// order).
+func orderCompare(a, b Record) int {
+	if c := cmp.Compare(rank(scenarioWriteOrder, a.Scenario), rank(scenarioWriteOrder, b.Scenario)); c != 0 {
+		return c
+	}
+	if c := cmp.Compare(rank(Surfaces, a.Surface), rank(Surfaces, b.Surface)); c != 0 {
+		return c
+	}
+	if c := cmp.Compare(rank(Capabilities, a.Capability), rank(Capabilities, b.Capability)); c != 0 {
+		return c
+	}
+
+	switch a.Scenario {
+	case ScenarioSemanticProbe:
+		var aCase, bCase Case
+		if a.SemanticCase != nil {
+			aCase = *a.SemanticCase
+		}
+		if b.SemanticCase != nil {
+			bCase = *b.SemanticCase
+		}
+		return cmp.Compare(rank(CapabilityCases[a.Capability], aCase), rank(CapabilityCases[b.Capability], bCase))
+	case ScenarioTokenSource:
+		return compareNullableString(a.EvidencePath, b.EvidencePath)
+	case ScenarioRuntimeIdentity:
+		return compareNullableString(a.SessionID, b.SessionID)
+	}
+	return cmp.Compare(rank(InputIDs, a.InputID), rank(InputIDs, b.InputID))
+}
+
+// numericGrade returns the comparison order of a grade. usable
+// outranks gap; corroboration_only and not_observed carry no numeric
+// grade and cannot participate in a positive qualification.
+func numericGrade(classification Grade) (int, bool) {
+	switch classification {
+	case GradeUsable:
+		return 1, true
+	case GradeGap:
+		return 0, true
+	}
+	return 0, false
+}
+
+// DeriveBaselineGrade derives one capability's per-surface
+// baseline grade from that capability's own case classifications only.
+// Any not_observed case makes the grade not_observed; otherwise any gap
+// case makes it gap; only all-usable cases yield usable. Cases of the
+// other capability never influence the result.
+func DeriveBaselineGrade(classifications []Grade) Grade {
+	allUsable := true
+	for _, c := range classifications {
+		switch c {
+		case GradeNotObserved:
+			return GradeNotObserved
+		case GradeUsable:
+		default:
+			allUsable = false
+		}
+	}
+	if allUsable {
+		return GradeUsable
+	}
+	return GradeGap
+}
+
+// richestNativeReference combines the native JSON and native
+// stream-JSON grades for one capability. The reference is the higher
+// observed grade, but if either surface is not_observed the reference is
+// not_observed even when the other surface is usable.
+func richestNativeReference(a, b Grade) Grade {
+	if a == GradeNotObserved || b == GradeNotObserved {
+		return GradeNotObserved
+	}
+	aGrade, aOK := numericGrade(a)
+	bGrade, bOK := numericGrade(b)
+	if !aOK || !bOK {
+		return GradeNotObserved
+	}
+	if aGrade >= bGrade {
+		return a
+	}
+	return b
+}
+
+// baselineGrades extracts the written per-surface baseline grades
+// from a record set.
+func baselineGrades(records []Record) map[Surface]map[Capability]Grade {
+	grades := map[Surface]map[Capability]Grade{}
+	for i := range records {
+		rec := &records[i]
+		if rec.Scenario != ScenarioSurfaceBaseline {
+			continue
+		}
+		if grades[rec.Surface] == nil {
+			grades[rec.Surface] = map[Capability]Grade{}
+		}
+		grades[rec.Surface][rec.Capability] = rec.Grade
+	}
+	return grades
+}
+
+// firstRecordOfClass returns the first record of one row class, or
+// nil.
+func firstRecordOfClass(records []Record, class RowClass) *Record {
+	for i := range records {
+		rec := &records[i]
+		if got, err := ClassifyRecord(rec); err == nil && got == class {
+			return rec
+		}
+	}
+	return nil
+}
+
+// ComputeEligibility derives the qualification verdict from the
+// non-final records alone. Every comparison capability needs an observed
+// protocol grade at or above the richest native structured reference;
+// protocol tool-server delivery must be usable by server receipt;
+// permission induction and the policy precondition must have been
+// answered; and the isolated end-to-end run must have reached its
+// terminal condition.
+func ComputeEligibility(records []Record) Verdict {
+	grades := baselineGrades(records)
+	for _, capability := range comparisonCapabilities {
+		reference := richestNativeReference(
+			grades[SurfaceNativeJSON][capability],
+			grades[SurfaceNativeStreamJSON][capability],
+		)
+		protocolGrade, protocolOK := numericGrade(grades[SurfaceProtocol][capability])
+		referenceGrade, referenceOK := numericGrade(reference)
+		if !protocolOK || !referenceOK || protocolGrade < referenceGrade {
+			return VerdictNotQualified
+		}
+	}
+
+	mcp := firstRecordOfClass(records, RowMCPDelivery)
+	if mcp == nil || mcp.Grade != GradeUsable {
+		return VerdictNotQualified
+	}
+	permission := firstRecordOfClass(records, RowPermission)
+	if permission == nil || permission.Outcome != OutcomePass || permission.Grade != GradeUsable {
+		return VerdictNotQualified
+	}
+	policy := firstRecordOfClass(records, RowPolicyPrecondition)
+	if policy == nil || policy.Outcome != OutcomePass || policy.Grade != GradeUsable {
+		return VerdictNotQualified
+	}
+	e2e := firstRecordOfClass(records, RowEndToEnd)
+	if e2e == nil || e2e.Outcome != OutcomePass || e2e.Grade != GradeUsable {
+		return VerdictNotQualified
+	}
+	return VerdictQualified
+}
+
+// readEvidenceFile reads a JSONL evidence file and strictly decodes
+// every line. An empty file is invalid.
+func readEvidenceFile(path string) ([]Record, error) {
+	data, err := os.ReadFile(path) //nolint:gosec // the caller supplies a path to a file it wrote under its own temp directory
+	if err != nil {
+		return nil, err
+	}
+	var records []Record
+	for n, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		rec, err := DecodeRecord([]byte(line))
+		if err != nil {
+			return nil, fmt.Errorf("line %d: %w", n+1, err)
+		}
+		records = append(records, rec)
+	}
+	if len(records) == 0 {
+		return nil, errors.New("evidence file contains no records")
+	}
+	return records, nil
+}
+
+// validateSequence enforces one-based, contiguous, strictly
+// increasing sequence numbers in file order.
+func validateSequence(records []Record) error {
+	for i, rec := range records {
+		if rec.Sequence != i+1 {
+			return fmt.Errorf("record at position %d has sequence %d, want %d", i+1, rec.Sequence, i+1)
+		}
+	}
+	return nil
+}
+
+// validateOrder enforces the canonical scenario, surface,
+// capability, and per-scenario tiebreak ordering across file order.
+func validateOrder(records []Record) error {
+	for i := 1; i < len(records); i++ {
+		if orderCompare(records[i-1], records[i]) > 0 {
+			prev, cur := records[i-1], records[i]
+			return fmt.Errorf("record %d (%s/%s/%s/%s) is out of canonical order after record %d (%s/%s/%s/%s)",
+				i+1, cur.Scenario, cur.Surface, cur.Capability, cur.InputID,
+				i, prev.Scenario, prev.Surface, prev.Capability, prev.InputID)
+		}
+	}
+	return nil
+}
+
+// setValidation carries the per-record lookups the strict set
+// checks assemble as they walk the file.
+type setValidation struct {
+	records    []Record
+	seen       map[string]bool
+	counts     map[RowClass]int
+	semantic   map[Surface]map[Capability]map[Case]*Record
+	tokens     map[Surface][]*Record
+	seeds      map[Surface]*Record
+	recalls    map[Surface]*Record
+	identity   map[string]bool
+	policy     *Record
+	permission *Record
+	mcp        *Record
+	e2e        *Record
+}
+
+// validateNonFinalSet enforces the closed first-pass evidence set:
+// closed tuples, per-record field rules, uniqueness keys, session
+// relations, token sentinel rules, derived baselines, runtime-identity
+// coverage, and the derived cardinality formula. It returns the
+// eligibility verdict computed from the records.
+func validateNonFinalSet(records []Record) (Verdict, error) {
+	v := &setValidation{
+		records:  records,
+		seen:     map[string]bool{},
+		counts:   map[RowClass]int{},
+		semantic: map[Surface]map[Capability]map[Case]*Record{},
+		tokens:   map[Surface][]*Record{},
+		seeds:    map[Surface]*Record{},
+		recalls:  map[Surface]*Record{},
+		identity: map[string]bool{},
+	}
+
+	if err := v.checkClosedScenario(); err != nil {
+		return "", err
+	}
+	if err := validateOrder(records); err != nil {
+		return "", err
+	}
+	if err := v.ClassifyRecords(); err != nil {
+		return "", err
+	}
+	if err := v.checkContinuationRelations(); err != nil {
+		return "", err
+	}
+	if err := v.checkRecallRecords(); err != nil {
+		return "", err
+	}
+	if err := v.checkTokenInventories(); err != nil {
+		return "", err
+	}
+	if err := v.checkDerivedBaselines(); err != nil {
+		return "", err
+	}
+	if err := v.checkIdentityCoverage(); err != nil {
+		return "", err
+	}
+	if err := v.checkCardinality(); err != nil {
+		return "", err
+	}
+	return ComputeEligibility(records), nil
+}
+
+// checkClosedScenario rejects any final qualification record from the
+// non-final set.
+func (v *setValidation) checkClosedScenario() error {
+	for i := range v.records {
+		rec := &v.records[i]
+		if rec.Scenario == ScenarioQualification {
+			return fmt.Errorf("record %d carries scenario %s, which belongs to the final pass only", rec.Sequence, rec.Scenario)
+		}
+		if rec.Capability == CapabilityEligibility {
+			return fmt.Errorf("record %d carries capability %s, which belongs to the final pass only", rec.Sequence, rec.Capability)
+		}
+	}
+	return nil
+}
+
+// ClassifyRecords classifies every record against the closed table and
+// applies the per-record field rules: outcome/grade pairing,
+// evidence-path nullability, prior-session placement, wire-version and
+// agent-name placement, uniqueness keys, and per-class session rules.
+func (v *setValidation) ClassifyRecords() error {
+	for i := range v.records {
+		rec := &v.records[i]
+		class, err := ClassifyRecord(rec)
+		if err != nil {
+			return fmt.Errorf("record %d: %w", rec.Sequence, err)
+		}
+		v.counts[class]++
+
+		if rec.Outcome == OutcomeNotApplicable && class == RowSemantic {
+			return fmt.Errorf("record %d: verdict not_applicable is invalid for a semantic probe", rec.Sequence)
+		}
+		if err := checkOutcomeGradePairing(rec); err != nil {
+			return fmt.Errorf("record %d: %w", rec.Sequence, err)
+		}
+		if rec.Grade == GradeCorroborationOnly &&
+			(class != RowToken || rec.EvidencePath == nil) {
+			return fmt.Errorf("record %d: corroboration_only is valid only on a non-sentinel token_source record", rec.Sequence)
+		}
+
+		pathNullAllowed := (class == RowSemantic && rec.Grade == GradeNotObserved) ||
+			(class == RowToken && rec.EvidencePath == nil)
+		if rec.EvidencePath == nil && !pathNullAllowed {
+			return fmt.Errorf("record %d: evidence_path must be set for a %s record", rec.Sequence, rowLabel(class))
+		}
+
+		if rec.PriorSessionID != nil && class != RowContinuationRecall {
+			return fmt.Errorf("record %d: prior_session_id is only valid on a continuation recall record", rec.Sequence)
+		}
+		if rec.ProtocolVersion != nil && rec.Surface != SurfaceProtocol {
+			return fmt.Errorf("record %d: protocol_version is only valid on protocol records", rec.Sequence)
+		}
+		if rec.AgentName != nil && rec.Surface != SurfaceProtocol {
+			return fmt.Errorf("record %d: agent_name is only valid on protocol records", rec.Sequence)
+		}
+
+		if err := v.checkUniqueness(rec, class); err != nil {
+			return err
+		}
+		if class == RowContinuationRecall {
+			// Recall records are checked after the seeds and recalls are
+			// all known, so a prior id that resolves to another surface's
+			// seed reports the resolution failure rather than the
+			// per-record detail mismatch.
+		} else if err := v.checkSessionRelation(rec, class); err != nil {
+			return fmt.Errorf("record %d: %w", rec.Sequence, err)
+		}
+		v.indexRecord(rec, class)
+	}
+	return v.checkSemanticSessionRelations()
+}
+
+// checkOutcomeGradePairing enforces the closed pairing between a
+// record's outcome and its grade.
+func checkOutcomeGradePairing(rec *Record) error {
+	classification := rec.Grade
+	verdict := rec.Outcome
+	switch classification {
+	case GradeUsable, GradeGap, GradeCorroborationOnly:
+		if verdict != OutcomePass {
+			return fmt.Errorf("classification %s requires verdict pass, got %s", classification, verdict)
+		}
+	case GradeNotObserved:
+		if verdict == OutcomePass || verdict == OutcomeNotApplicable {
+			return fmt.Errorf("classification not_observed is inconsistent with verdict %s", verdict)
+		}
+	case GradeNotApplicable:
+		if verdict != OutcomeNotApplicable {
+			return fmt.Errorf("classification not_applicable requires verdict not_applicable, got %s", verdict)
+		}
+	case GradeQualified, GradeNotQualified:
+		return fmt.Errorf("classification %s is valid only for capability eligibility", classification)
+	}
+	switch verdict {
+	case OutcomePass:
+		if classification != GradeUsable &&
+			classification != GradeGap &&
+			classification != GradeCorroborationOnly {
+			return fmt.Errorf("verdict pass requires classification usable, gap, or corroboration_only, got %s", classification)
+		}
+	case OutcomeNotObserved:
+		if classification != GradeNotObserved {
+			return fmt.Errorf("verdict not_observed requires classification not_observed, got %s", classification)
+		}
+	case OutcomeNotApplicable:
+		if classification != GradeNotApplicable {
+			return fmt.Errorf("verdict not_applicable requires classification not_applicable, got %s", classification)
+		}
+	case OutcomePrerequisiteFailed, OutcomeFixtureInductionFailed, OutcomeAdapterUnanswered, OutcomeRuntimeFailed:
+		if classification != GradeNotObserved {
+			return fmt.Errorf("verdict %s requires classification not_observed, got %s", verdict, classification)
+		}
+	}
+	return nil
+}
+
+// checkUniqueness enforces the per-class uniqueness key and counts each
+// key once.
+func (v *setValidation) checkUniqueness(rec *Record, class RowClass) error {
+	var key string
+	switch class {
+	case RowWorkspaceSecurity:
+		key = "workspace"
+	case RowPolicyPrecondition:
+		key = "policy"
+	case RowPermission:
+		key = "permission"
+	case RowMCPDelivery:
+		key = "mcp"
+	case RowProcessCleanup:
+		key = "cleanup"
+	case RowEndToEnd:
+		key = "e2e"
+	case RowSemantic:
+		key = fmt.Sprintf("semantic|%s|%s|%s", rec.Surface, rec.Capability, *rec.SemanticCase)
+	case RowBaseline:
+		key = fmt.Sprintf("baseline|%s|%s", rec.Surface, rec.Capability)
+	case RowToken:
+		key = fmt.Sprintf("token|%s|%s", rec.Surface, nullableKey(rec.EvidencePath))
+	case RowContinuationSeed:
+		key = fmt.Sprintf("seed|%s", rec.Surface)
+	case RowContinuationRecall:
+		key = fmt.Sprintf("recall|%s", rec.Surface)
+	case RowRuntimeIdentity:
+		key = fmt.Sprintf("identity|%s", nullableKey(rec.SessionID))
+	default:
+		return nil
+	}
+	if v.seen[key] {
+		return fmt.Errorf("record %d: duplicate uniqueness key %q", rec.Sequence, key)
+	}
+	v.seen[key] = true
+	return nil
+}
+
+// nullableKey renders a nullable string for a uniqueness key.
+func nullableKey(v *string) string {
+	if v == nil {
+		return "<null>"
+	}
+	return *v
+}
+
+// checkSessionRelation enforces the per-class session_id rules.
+func (v *setValidation) checkSessionRelation(rec *Record, class RowClass) error {
+	switch class {
+	case RowWorkspaceSecurity, RowProcessCleanup, RowBaseline:
+		if rec.SessionID != nil {
+			return fmt.Errorf("%s record must use a null session_id", rowLabel(class))
+		}
+	case RowPolicyPrecondition, RowPermission, RowMCPDelivery, RowContinuationSeed, RowEndToEnd:
+		if rec.SessionID == nil {
+			return fmt.Errorf("%s record must reference a non-null session_id", rowLabel(class))
+		}
+	case RowRuntimeIdentity:
+		if rec.SessionID == nil {
+			return fmt.Errorf("%s record must reference a non-null session_id", rowLabel(class))
+		}
+		if rec.ProtocolVersion == nil {
+			return fmt.Errorf("runtime identity record must carry the session's negotiated protocol_version")
+		}
+		if rec.Grade == GradeUsable &&
+			(rec.AgentName == nil || rec.AgentVersion == nil) {
+			return fmt.Errorf("usable runtime identity record must carry agent_name and agent_version")
+		}
+	case RowToken:
+		if rec.EvidencePath == nil {
+			if rec.SessionID != nil {
+				return fmt.Errorf("token sentinel record must use a null session_id")
+			}
+			if rec.Source != SourceNone {
+				return fmt.Errorf("token sentinel record must carry source none, got %s", rec.Source)
+			}
+			if rec.Grade != GradeGap && rec.Grade != GradeNotObserved {
+				return fmt.Errorf("token sentinel classification = %s, want gap or not_observed", rec.Grade)
+			}
+		} else {
+			if rec.SessionID == nil {
+				return fmt.Errorf("token inventory record must reference the session that emitted the path")
+			}
+			if rec.Source == SourceNone {
+				return fmt.Errorf("token record with a path must not carry source none")
+			}
+			if rec.Grade != GradeUsable && rec.Grade != GradeCorroborationOnly {
+				return fmt.Errorf("non-sentinel token classification = %s, want usable or corroboration_only", rec.Grade)
+			}
+		}
+	case RowContinuationRecall:
+		return nil
+	case RowSemantic:
+		if rec.Outcome == OutcomePass && rec.SessionID == nil {
+			return fmt.Errorf("passing semantic probe must carry its own session_id")
+		}
+	}
+	return nil
+}
+
+// checkRecallRecords validates every surface's recall record after the
+// continuation relations are known.
+func (v *setValidation) checkRecallRecords() error {
+	for _, surface := range measuredSurfaces {
+		recall := v.recalls[surface]
+		if recall == nil {
+			continue
+		}
+		if err := v.checkRecallRecord(recall); err != nil {
+			return fmt.Errorf("record %d: %w", recall.Sequence, err)
+		}
+	}
+	return nil
+}
+
+// checkRecallRecord enforces the closed detail set and the session
+// relation each recall outcome requires.
+func (v *setValidation) checkRecallRecord(rec *Record) error {
+	if rec.PriorSessionID == nil {
+		return fmt.Errorf("continuation recall record must carry prior_session_id")
+	}
+	switch rec.Detail {
+	case recallConfirmedSameSession:
+		if rec.SessionID == nil || *rec.SessionID != *rec.PriorSessionID {
+			return fmt.Errorf("confirmed_same_session requires equal non-null actual and prior session ids")
+		}
+		if rec.Grade != GradeUsable {
+			return fmt.Errorf("confirmed_same_session requires classification usable, got %s", rec.Grade)
+		}
+	case recallFreshFallback:
+		if rec.SessionID == nil || *rec.SessionID == *rec.PriorSessionID {
+			return fmt.Errorf("fresh_session_fallback requires a non-null actual session id distinct from prior_session_id")
+		}
+		if rec.Grade != GradeGap {
+			return fmt.Errorf("fresh_session_fallback requires classification gap, got %s", rec.Grade)
+		}
+	case recallUnobservedActual:
+		if rec.SessionID != nil {
+			return fmt.Errorf("unobserved_actual_session requires a null session_id")
+		}
+		if rec.Grade != GradeNotObserved {
+			return fmt.Errorf("unobserved_actual_session requires classification not_observed, got %s", rec.Grade)
+		}
+	default:
+		return fmt.Errorf("recall detail %q is outside the closed set", rec.Detail)
+	}
+	return nil
+}
+
+// indexRecord files a classified record into the lookups the relation
+// and derivation checks consume.
+func (v *setValidation) indexRecord(rec *Record, class RowClass) {
+	switch class {
+	case RowPolicyPrecondition:
+		v.policy = rec
+	case RowPermission:
+		v.permission = rec
+	case RowMCPDelivery:
+		v.mcp = rec
+	case RowEndToEnd:
+		v.e2e = rec
+	case RowSemantic:
+		if v.semantic[rec.Surface] == nil {
+			v.semantic[rec.Surface] = map[Capability]map[Case]*Record{}
+		}
+		if v.semantic[rec.Surface][rec.Capability] == nil {
+			v.semantic[rec.Surface][rec.Capability] = map[Case]*Record{}
+		}
+		v.semantic[rec.Surface][rec.Capability][*rec.SemanticCase] = rec
+	case RowToken:
+		v.tokens[rec.Surface] = append(v.tokens[rec.Surface], rec)
+	case RowContinuationSeed:
+		v.seeds[rec.Surface] = rec
+	case RowContinuationRecall:
+		v.recalls[rec.Surface] = rec
+	case RowRuntimeIdentity:
+		if rec.SessionID != nil {
+			v.identity[*rec.SessionID] = true
+		}
+	}
+}
+
+// checkSemanticSessionRelations enforces the reuse rules between semantic
+// records and the records they share a physical run with: refusal retry
+// records reuse the matching disposition-refusal session, and the
+// protocol human-input record reuses the permission attempt's session.
+func (v *setValidation) checkSemanticSessionRelations() error {
+	for _, surface := range measuredSurfaces {
+		dispositionRefusal := v.semanticRecord(surface, CapabilityTurnDisposition, CaseRuntimeRefusal)
+		retryRefusal := v.semanticRecord(surface, CapabilityRetryClassification, CaseNonRetryableRefusal)
+		if dispositionRefusal != nil && retryRefusal != nil {
+			if compareNullableString(dispositionRefusal.SessionID, retryRefusal.SessionID) != 0 {
+				return fmt.Errorf("%s refusal retry record does not reuse the matching disposition-refusal session id", surface)
+			}
+		}
+	}
+
+	if v.permission != nil {
+		humanInput := v.semanticRecord(SurfaceProtocol, CapabilityRetryClassification, CaseHumanInput)
+		if humanInput != nil && humanInput.SessionID != nil && *humanInput.SessionID != *v.permission.SessionID {
+			return fmt.Errorf("protocol human_input record does not reuse the permission attempt session id")
+		}
+	}
+	return nil
+}
+
+// semanticRecord returns one semantic record by tuple, or nil.
+func (v *setValidation) semanticRecord(surface Surface, capability Capability, caseID Case) *Record {
+	return v.semantic[surface][capability][caseID]
+}
+
+// checkContinuationRelations enforces that every non-null
+// prior_session_id resolves to exactly one same-surface seed and that
+// each surface carries one seed and one recall.
+func (v *setValidation) checkContinuationRelations() error {
+	for _, surface := range measuredSurfaces {
+		if v.seeds[surface] == nil {
+			return fmt.Errorf("surface %s has no continuation seed record", surface)
+		}
+		if v.recalls[surface] == nil {
+			return fmt.Errorf("surface %s has no continuation recall record", surface)
+		}
+		recall := v.recalls[surface]
+		if recall.PriorSessionID == nil {
+			return fmt.Errorf("surface %s recall record carries no prior_session_id", surface)
+		}
+		seed := v.seeds[surface]
+		if seed.SessionID == nil || *seed.SessionID != *recall.PriorSessionID {
+			return fmt.Errorf("surface %s recall prior_session_id %s does not resolve to that surface's seed session", surface, *recall.PriorSessionID)
+		}
+	}
+	return nil
+}
+
+// checkTokenInventories enforces the per-surface inventory rules:
+// at least one record per surface, at most one sentinel, and mutual
+// exclusion between the sentinel and non-sentinel records.
+func (v *setValidation) checkTokenInventories() error {
+	for _, surface := range measuredSurfaces {
+		records := v.tokens[surface]
+		if len(records) == 0 {
+			return fmt.Errorf("surface %s has no token inventory record", surface)
+		}
+		sentinels := 0
+		nonSentinels := 0
+		for _, rec := range records {
+			if rec.EvidencePath == nil {
+				sentinels++
+			} else {
+				nonSentinels++
+			}
+		}
+		if sentinels > 1 {
+			return fmt.Errorf("surface %s has %d token sentinel records, want at most 1", surface, sentinels)
+		}
+		if sentinels == 1 && nonSentinels > 0 {
+			return fmt.Errorf("surface %s carries both a token sentinel and non-sentinel records; they are mutually exclusive", surface)
+		}
+	}
+	return nil
+}
+
+// checkDerivedBaselines requires every written baseline grade to equal
+// the grade derived from the records that own it: the five disposition
+// and four retry case records per surface, the per-surface token
+// inventory, and the surface's recall outcome.
+func (v *setValidation) checkDerivedBaselines() error {
+	grades := baselineGrades(v.records)
+
+	for _, surface := range measuredSurfaces {
+		for _, capability := range comparisonCapabilities {
+			written, ok := grades[surface][capability]
+			if !ok {
+				return fmt.Errorf("surface %s has no %s baseline record", surface, capability)
+			}
+			var derived Grade
+			switch capability {
+			case CapabilityTurnDisposition, CapabilityRetryClassification:
+				var classes []Grade
+				for _, caseID := range CapabilityCases[capability] {
+					rec := v.semanticRecord(surface, capability, caseID)
+					if rec == nil {
+						return fmt.Errorf("surface %s is missing its %s %s semantic record", surface, capability, caseID)
+					}
+					classes = append(classes, rec.Grade)
+				}
+				derived = DeriveBaselineGrade(classes)
+			case CapabilityTokenCeiling:
+				derived = tokenBaselineGrade(v.tokens[surface])
+			case CapabilitySessionContinuation:
+				derived = v.recalls[surface].Grade
+			}
+			if written != derived {
+				return fmt.Errorf("surface %s %s baseline = %s, want derived %s", surface, capability, written, derived)
+			}
+		}
+	}
+	return nil
+}
+
+// tokenBaselineGrade derives a surface's token baseline from its
+// inventory: a zero-source sentinel grades gap, a failed-inventory
+// sentinel grades not_observed, and a completed inventory grades usable
+// only when it contains a usable source.
+func tokenBaselineGrade(records []*Record) Grade {
+	usable := false
+	for _, rec := range records {
+		if rec.EvidencePath == nil {
+			if rec.Grade == GradeNotObserved {
+				return GradeNotObserved
+			}
+			return GradeGap
+		}
+		if rec.Grade == GradeUsable {
+			usable = true
+		}
+	}
+	if usable {
+		return GradeUsable
+	}
+	return GradeGap
+}
+
+// checkIdentityCoverage requires exactly one runtime-identity record for
+// every distinct non-null actual protocol session id referenced by any
+// non-final record, including a fresh fallback id, and no others.
+func (v *setValidation) checkIdentityCoverage() error {
+	referenced := map[string]bool{}
+	for i := range v.records {
+		rec := &v.records[i]
+		if rec.Surface == SurfaceProtocol && rec.SessionID != nil {
+			referenced[*rec.SessionID] = true
+		}
+	}
+
+	for id := range referenced {
+		if !v.identity[id] {
+			return fmt.Errorf("protocol session %s is referenced by non-final evidence but carries no runtime identity record", id)
+		}
+	}
+	for id := range v.identity {
+		if !referenced[id] {
+			return fmt.Errorf("runtime identity record for protocol session %s references no non-final evidence", id)
+		}
+	}
+	return nil
+}
+
+// Per-scenario record counts the closed evidence set requires. Each of
+// the six singleton scenarios (workspace security, policy precondition,
+// permission, tool server delivery, process cleanup, end to end)
+// contributes singletonRowCount records; checkCardinality sums these
+// same constants into its fixed term, so a changed count here cannot
+// drift from the total it is checked against.
+const (
+	singletonRowCount        = 1
+	dispositionSemanticCount = 20
+	retrySemanticCount       = 16
+	surfaceBaselineCount     = 16
+	continuationSeedCount    = 4
+	continuationRecallCount  = 4
+)
+
+// checkCardinality enforces the fixed row counts and the closed
+// cardinality formula fixed+T+N, where fixed is the sum of the per-
+// scenario record counts above, T is the token-inventory record count,
+// and N is the number of distinct non-null actual protocol session ids
+// referenced by non-final records.
+func (v *setValidation) checkCardinality() error {
+	fixed := map[RowClass]int{
+		RowWorkspaceSecurity:  singletonRowCount,
+		RowPolicyPrecondition: singletonRowCount,
+		RowPermission:         singletonRowCount,
+		RowMCPDelivery:        singletonRowCount,
+		RowProcessCleanup:     singletonRowCount,
+		RowEndToEnd:           singletonRowCount,
+	}
+	fixedTotal := 0
+	for class, want := range fixed {
+		fixedTotal += want
+		if err := checkCount(rowLabel(class), v.counts[class], want); err != nil {
+			return err
+		}
+	}
+	if err := checkCount("disposition semantic", v.countSemanticByCapability(CapabilityTurnDisposition), dispositionSemanticCount); err != nil {
+		return err
+	}
+	if err := checkCount("retry semantic", v.countSemanticByCapability(CapabilityRetryClassification), retrySemanticCount); err != nil {
+		return err
+	}
+	if err := checkCount("surface baseline", v.counts[RowBaseline], surfaceBaselineCount); err != nil {
+		return err
+	}
+	if err := checkCount("continuation seed", v.counts[RowContinuationSeed], continuationSeedCount); err != nil {
+		return err
+	}
+	if err := checkCount("continuation recall", v.counts[RowContinuationRecall], continuationRecallCount); err != nil {
+		return err
+	}
+	fixedTotal += dispositionSemanticCount + retrySemanticCount + surfaceBaselineCount + continuationSeedCount + continuationRecallCount
+
+	T := 0
+	for _, records := range v.tokens {
+		T += len(records)
+	}
+	N := len(v.identity)
+	want := fixedTotal + T + N
+	if len(v.records) != want {
+		return fmt.Errorf("evidence set holds %d records, want exactly %d (%d fixed + %d token + %d identity)", len(v.records), want, fixedTotal, T, N)
+	}
+	return nil
+}
+
+// countSemanticByCapability counts classified semantic records of one
+// capability, excluding the derived baselines that share its name.
+func (v *setValidation) countSemanticByCapability(capability Capability) int {
+	count := 0
+	for i := range v.records {
+		if v.records[i].Scenario == ScenarioSemanticProbe && v.records[i].Capability == capability {
+			count++
+		}
+	}
+	return count
+}
+
+// checkCount reports a cardinality mismatch, naming a duplicate or
+// a missing record so controls can pin the cause.
+func checkCount(name string, got, want int) error {
+	if got == want {
+		return nil
+	}
+	if got > want {
+		return fmt.Errorf("%s row holds %d records, want exactly %d (duplicate record present)", name, got, want)
+	}
+	return fmt.Errorf("%s row holds %d records, want exactly %d (required record missing)", name, got, want)
+}
+
+// ValidateObservations strictly validates the closed
+// non-final observation set written by the collector and returns the
+// computed eligibility verdict. It rejects any final qualification
+// record.
+func ValidateObservations(path string) (Verdict, error) {
+	records, err := readEvidenceFile(path)
+	if err != nil {
+		return "", err
+	}
+	if err := validateSequence(records); err != nil {
+		return "", err
+	}
+	return validateNonFinalSet(records)
+}
+
+// The final-pass aggregate causes, wrapped by ValidateEvidence
+// so controls can pin the exact rejection.
+var (
+	errFinalRecordMissing    = errors.New("final qualification record missing from the evidence file")
+	errFinalRecordDuplicated = errors.New("final qualification record is duplicated in the evidence file")
+	errRecordAfterAggregate  = errors.New("a record follows the final qualification record; the aggregate must be last")
+)
+
+// ValidateEvidence strictly validates the complete
+// two-pass evidence file: the closed non-final set, exactly one terminal
+// aggregate record in the last position, and exact equality between the
+// aggregate's grade and an independent recomputation of eligibility.
+func ValidateEvidence(path string) (Verdict, error) {
+	records, err := readEvidenceFile(path)
+	if err != nil {
+		return "", err
+	}
+	if err := validateSequence(records); err != nil {
+		return "", err
+	}
+
+	finalIndex := -1
+	finalCount := 0
+	for i := range records {
+		if records[i].Scenario == ScenarioQualification || records[i].Capability == CapabilityEligibility {
+			finalCount++
+			finalIndex = i
+		}
+	}
+	switch {
+	case finalCount == 0:
+		return "", errFinalRecordMissing
+	case finalCount > 1:
+		return "", fmt.Errorf("evidence file holds %d final qualification records: %w", finalCount, errFinalRecordDuplicated)
+	case finalIndex != len(records)-1:
+		return "", fmt.Errorf("record %d: %w", finalIndex+2, errRecordAfterAggregate)
+	}
+	aggregate := records[finalIndex]
+	nonFinal := records[:finalIndex]
+
+	if aggregate.Outcome != OutcomePass {
+		return "", fmt.Errorf("final qualification record verdict = %s, want pass", aggregate.Outcome)
+	}
+	if aggregate.InputID != InputAggregate {
+		return "", fmt.Errorf("final qualification record input_id = %s, want %s", aggregate.InputID, InputAggregate)
+	}
+	if aggregate.EvidencePath == nil || *aggregate.EvidencePath != EvidencePathQualificationVerdict {
+		return "", fmt.Errorf("final qualification record evidence_path must be %s", EvidencePathQualificationVerdict)
+	}
+	if aggregate.SessionID != nil || aggregate.PriorSessionID != nil || aggregate.SemanticCase != nil ||
+		aggregate.AgentName != nil || aggregate.AgentVersion != nil || aggregate.ProtocolVersion != nil {
+		return "", fmt.Errorf("final qualification record must carry null session, prior, semantic case, agent, and protocol fields")
+	}
+
+	verdict, err := validateNonFinalSet(nonFinal)
+	if err != nil {
+		return "", err
+	}
+	want := GradeQualified
+	if verdict == VerdictNotQualified {
+		want = GradeNotQualified
+	}
+	if aggregate.Grade != want {
+		return "", fmt.Errorf("final qualification record classification = %s, want %s from independent recomputation", aggregate.Grade, want)
+	}
+	return verdict, nil
+}

--- a/internal/qualification/validate.go
+++ b/internal/qualification/validate.go
@@ -198,12 +198,16 @@ func compareNullableString(a, b *string) int {
 	return strings.Compare(*a, *b)
 }
 
-// orderCompare orders two records by the canonical write order:
+// OrderCompare orders two records by the canonical write order:
 // the closed scenario write order, then surface order, then capability
 // order, then a scenario-specific tiebreak (semantic case, token path
 // with the null sentinel first, session identifier, or input catalog
-// order).
-func orderCompare(a, b Record) int {
+// order). It is the single source of truth for canonical order: every
+// collector that writes an evidence file must sort with this
+// function rather than reimplementing the rule, so a collector's
+// write order and the validator's own order check can never drift
+// apart.
+func OrderCompare(a, b Record) int {
 	if c := cmp.Compare(rank(scenarioWriteOrder, a.Scenario), rank(scenarioWriteOrder, b.Scenario)); c != 0 {
 		return c
 	}
@@ -395,7 +399,7 @@ func validateSequence(records []Record) error {
 // capability, and per-scenario tiebreak ordering across file order.
 func validateOrder(records []Record) error {
 	for i := 1; i < len(records); i++ {
-		if orderCompare(records[i-1], records[i]) > 0 {
+		if OrderCompare(records[i-1], records[i]) > 0 {
 			prev, cur := records[i-1], records[i]
 			return fmt.Errorf("record %d (%s/%s/%s/%s) is out of canonical order after record %d (%s/%s/%s/%s)",
 				i+1, cur.Scenario, cur.Surface, cur.Capability, cur.InputID,

--- a/internal/qualification/validate.go
+++ b/internal/qualification/validate.go
@@ -1091,6 +1091,18 @@ func ValidateEvidence(path string) (Verdict, error) {
 	aggregate := records[finalIndex]
 	nonFinal := records[:finalIndex]
 
+	// The final record is located by either half of its tuple so that a
+	// stray one anywhere in the set is counted and rejected above. That
+	// leaves the located record's own tuple unchecked, so it is closed
+	// here: nothing but the aggregate eligibility row may occupy the
+	// position the verdict is read from.
+	if aggregate.Scenario != ScenarioQualification || aggregate.Surface != SurfaceAggregate ||
+		aggregate.Capability != CapabilityEligibility || aggregate.Source != SourceComparison {
+		return "", fmt.Errorf(
+			"final qualification record tuple = %s/%s/%s/%s, want %s/%s/%s/%s",
+			aggregate.Scenario, aggregate.Surface, aggregate.Capability, aggregate.Source,
+			ScenarioQualification, SurfaceAggregate, CapabilityEligibility, SourceComparison)
+	}
 	if aggregate.Outcome != OutcomePass {
 		return "", fmt.Errorf("final qualification record verdict = %s, want pass", aggregate.Outcome)
 	}

--- a/internal/qualification/validate.go
+++ b/internal/qualification/validate.go
@@ -914,11 +914,19 @@ func tokenBaselineGrade(records []*Record) Grade {
 
 // checkIdentityCoverage requires exactly one runtime-identity record for
 // every distinct non-null actual protocol session id referenced by any
-// non-final record, including a fresh fallback id, and no others.
+// non-final record that is not itself a runtime identity, including a
+// fresh fallback id, and no others. An identity record is skipped while
+// the referenced ids are collected: it carries the protocol surface and
+// its own session id, so counting it would let it satisfy its own
+// coverage requirement and leave an identity for a session no other
+// evidence mentions undetected.
 func (v *setValidation) checkIdentityCoverage() error {
 	referenced := map[string]bool{}
 	for i := range v.records {
 		rec := &v.records[i]
+		if rec.Scenario == ScenarioRuntimeIdentity {
+			continue
+		}
 		if rec.Surface == SurfaceProtocol && rec.SessionID != nil {
 			referenced[*rec.SessionID] = true
 		}

--- a/internal/qualification/validate_controls_test.go
+++ b/internal/qualification/validate_controls_test.go
@@ -607,6 +607,25 @@ func TestValidatorFinalTupleControls(T *testing.T) {
 		}
 	})
 
+	T.Run("final pass whose aggregate carries a foreign tuple", func(T *testing.T) {
+		T.Parallel()
+
+		fixture := NewFixture(FixtureQualified)
+		fixture.Finalize()
+		aggregate := aggregateFixtureRecord(GradeQualified)
+		aggregate.Capability = CapabilityWorkspaceSecurity
+		withAggregate := append(slices.Clone(fixture.Records), aggregate)
+		for i := range withAggregate {
+			withAggregate[i].Sequence = i + 1
+		}
+		path := WriteEvidenceFile(T, withAggregate)
+		if _, err := ValidateEvidence(path); err == nil {
+			T.Error("ValidateEvidence() = nil error, want rejection of an aggregate outside the closed tuple")
+		} else if !strings.Contains(err.Error(), "tuple") {
+			T.Errorf("ValidateEvidence() error = %v, want it to name the rejected tuple", err)
+		}
+	})
+
 	T.Run("final pass without the aggregate", func(T *testing.T) {
 		T.Parallel()
 

--- a/internal/qualification/validate_controls_test.go
+++ b/internal/qualification/validate_controls_test.go
@@ -543,6 +543,21 @@ func TestValidatorContinuationControls(T *testing.T) {
 			T.Errorf("ValidateObservations() error = %v, want it to name the missing identity record", err)
 		}
 	})
+
+	T.Run("a runtime identity for a session no other evidence references", func(T *testing.T) {
+		T.Parallel()
+
+		fixture := NewFixture(FixtureQualified)
+		fixture.Finalize()
+		fixture.AppendIdentity("sess-referenced-by-nothing")
+		path := WriteEvidenceFile(T, fixture.Records)
+		_, err := ValidateObservations(path)
+		if err == nil {
+			T.Error("ValidateObservations() = nil error, want rejection of an identity record no other evidence references")
+		} else if !strings.Contains(err.Error(), "references no non-final evidence") {
+			T.Errorf("ValidateObservations() error = %v, want it to name the unreferenced identity record", err)
+		}
+	})
 }
 
 // TestValidatorCrossSurfacePriorSessionControl pins the separate

--- a/internal/qualification/validate_controls_test.go
+++ b/internal/qualification/validate_controls_test.go
@@ -1,0 +1,676 @@
+package qualification
+
+import (
+	"errors"
+	"slices"
+	"strings"
+	"testing"
+)
+
+// matchRowClass matches records of one row class.
+func matchRowClass(class RowClass) func(*Record) bool {
+	return func(rec *Record) bool {
+		got, err := ClassifyRecord(rec)
+		return err == nil && got == class
+	}
+}
+
+// tokenRecordCount counts the token-inventory records of a set.
+func tokenRecordCount(records []Record) int {
+	count := 0
+	for i := range records {
+		if records[i].Scenario == ScenarioTokenSource {
+			count++
+		}
+	}
+	return count
+}
+
+// protocolSessionCount counts the distinct non-null actual protocol
+// session ids a Record set references.
+func protocolSessionCount(records []Record) int {
+	ids := map[string]bool{}
+	for i := range records {
+		rec := &records[i]
+		if rec.Surface == SurfaceProtocol && rec.SessionID != nil {
+			ids[*rec.SessionID] = true
+		}
+	}
+	return len(ids)
+}
+
+func TestValidatorMissingAndDuplicateControls(T *testing.T) {
+	T.Parallel()
+
+	pickers := []struct {
+		name string
+		pick func(*Fixture) *Record
+	}{
+		{"workspace security", func(f *Fixture) *Record {
+			return f.FindFirst(matchRowClass(RowWorkspaceSecurity))
+		}},
+		{"policy precondition", func(f *Fixture) *Record {
+			return f.FindFirst(matchRowClass(RowPolicyPrecondition))
+		}},
+		{"permission handling", func(f *Fixture) *Record { return f.FindFirst(matchRowClass(RowPermission)) }},
+		{"tool server delivery", func(f *Fixture) *Record { return f.FindFirst(matchRowClass(RowMCPDelivery)) }},
+		{"process cleanup", func(f *Fixture) *Record {
+			return f.FindFirst(matchRowClass(RowProcessCleanup))
+		}},
+		{"end to end", func(f *Fixture) *Record { return f.FindFirst(matchRowClass(RowEndToEnd)) }},
+		{"disposition semantic", func(f *Fixture) *Record {
+			return f.FindFirst(MatchSemantic(SurfaceProtocol, CapabilityTurnDisposition, CaseSuccess))
+		}},
+		{"retry semantic", func(f *Fixture) *Record {
+			return f.FindFirst(MatchSemantic(SurfaceProtocol, CapabilityRetryClassification, CaseRetryableTransport))
+		}},
+		{"Surface baseline", func(f *Fixture) *Record {
+			return f.FindFirst(MatchBaseline(SurfaceProtocol, CapabilityTurnDisposition))
+		}},
+		{"token inventory", func(f *Fixture) *Record {
+			return f.FindFirst(matchTokenSurface(SurfaceNativeJSON))
+		}},
+		{"continuation seed", func(f *Fixture) *Record {
+			return f.FindFirst(MatchContinuation(SurfaceProtocol, InputContinuationSeed))
+		}},
+		{"continuation recall", func(f *Fixture) *Record {
+			return f.FindFirst(MatchContinuation(SurfaceProtocol, InputContinuationRecall))
+		}},
+		{"runtime identity", func(f *Fixture) *Record {
+			return f.FindFirst(matchRowClass(RowRuntimeIdentity))
+		}},
+	}
+
+	for _, tt := range pickers {
+		T.Run("missing "+tt.name, func(T *testing.T) {
+			T.Parallel()
+
+			fixture := NewFixture(FixtureQualified)
+			fixture.Finalize()
+			target := tt.pick(fixture)
+			if target == nil {
+				T.Fatalf("fixture carries no %s Record to remove", tt.name)
+			}
+			fixture.Remove(target)
+			fixture.Renumber()
+			path := WriteEvidenceFile(T, fixture.Records)
+			if _, err := ValidateObservations(path); err == nil {
+				T.Errorf("ValidateObservations(%s) = nil error, want rejection when the %s Record is missing", path, tt.name)
+			}
+		})
+
+		T.Run("duplicate "+tt.name, func(T *testing.T) {
+			T.Parallel()
+
+			fixture := NewFixture(FixtureQualified)
+			fixture.Finalize()
+			target := tt.pick(fixture)
+			if target == nil {
+				T.Fatalf("fixture carries no %s Record to duplicate", tt.name)
+			}
+			fixture.DuplicateAfter(target)
+			fixture.Renumber()
+			path := WriteEvidenceFile(T, fixture.Records)
+			_, err := ValidateObservations(path)
+			if err == nil {
+				T.Errorf("ValidateObservations(%s) = nil error, want rejection when the %s Record is duplicated", path, tt.name)
+			} else if !strings.Contains(err.Error(), "duplicate") {
+				T.Errorf("ValidateObservations() error = %v, want it to report a duplicate", err)
+			}
+		})
+	}
+}
+
+// TestValidatorSemanticControls covers the missing-Case, ordering,
+// cross-class, and baseline-derivation controls for the semantic rows.
+func TestValidatorSemanticControls(T *testing.T) {
+	T.Parallel()
+
+	T.Run("missing disposition Cases", func(T *testing.T) {
+		T.Parallel()
+
+		for _, caseID := range CapabilityCases[CapabilityTurnDisposition] {
+			T.Run(string(caseID), func(T *testing.T) {
+				T.Parallel()
+
+				fixture := NewFixture(FixtureQualified)
+				fixture.Finalize()
+				target := fixture.FindFirst(MatchSemantic(SurfaceProtocol, CapabilityTurnDisposition, caseID))
+				if target == nil {
+					T.Fatalf("fixture carries no protocol disposition Record for Case %s", caseID)
+				}
+				fixture.Remove(target)
+				fixture.Renumber()
+				path := WriteEvidenceFile(T, fixture.Records)
+				if _, err := ValidateObservations(path); err == nil {
+					T.Errorf("ValidateObservations() = nil error, want rejection when disposition Case %s is missing", caseID)
+				}
+			})
+		}
+	})
+
+	T.Run("missing retry Cases", func(T *testing.T) {
+		T.Parallel()
+
+		for _, caseID := range CapabilityCases[CapabilityRetryClassification] {
+			T.Run(string(caseID), func(T *testing.T) {
+				T.Parallel()
+
+				fixture := NewFixture(FixtureQualified)
+				fixture.Finalize()
+				target := fixture.FindFirst(MatchSemantic(SurfaceProtocol, CapabilityRetryClassification, caseID))
+				if target == nil {
+					T.Fatalf("fixture carries no protocol retry Record for Case %s", caseID)
+				}
+				fixture.Remove(target)
+				fixture.Renumber()
+				path := WriteEvidenceFile(T, fixture.Records)
+				if _, err := ValidateObservations(path); err == nil {
+					T.Errorf("ValidateObservations() = nil error, want rejection when retry Case %s is missing", caseID)
+				}
+			})
+		}
+	})
+
+	T.Run("wrong disposition order", func(T *testing.T) {
+		T.Parallel()
+
+		fixture := NewFixture(FixtureQualified)
+		fixture.Finalize()
+		first := fixture.FindFirst(MatchSemantic(SurfaceProtocol, CapabilityTurnDisposition, CaseSuccess))
+		second := fixture.FindFirst(MatchSemantic(SurfaceProtocol, CapabilityTurnDisposition, CaseRuntimeFailure))
+		if first == nil || second == nil {
+			T.Fatal("fixture carries no protocol disposition pair to swap")
+		}
+		swapRecords(fixture, first, second)
+		path := WriteEvidenceFile(T, fixture.Records)
+		if _, err := ValidateObservations(path); err == nil {
+			T.Error("ValidateObservations() = nil error, want rejection when disposition Cases are out of order")
+		}
+	})
+
+	T.Run("wrong retry order", func(T *testing.T) {
+		T.Parallel()
+
+		fixture := NewFixture(FixtureQualified)
+		fixture.Finalize()
+		first := fixture.FindFirst(MatchSemantic(SurfaceProtocol, CapabilityRetryClassification, CaseRetryableTransport))
+		second := fixture.FindFirst(MatchSemantic(SurfaceProtocol, CapabilityRetryClassification, CaseHumanInput))
+		if first == nil || second == nil {
+			T.Fatal("fixture carries no protocol retry pair to swap")
+		}
+		swapRecords(fixture, first, second)
+		path := WriteEvidenceFile(T, fixture.Records)
+		if _, err := ValidateObservations(path); err == nil {
+			T.Error("ValidateObservations() = nil error, want rejection when retry Cases are out of order")
+		}
+	})
+
+	T.Run("disposition tuple carrying a retry Case", func(T *testing.T) {
+		T.Parallel()
+
+		fixture := NewFixture(FixtureQualified)
+		fixture.Finalize()
+		rec := fixture.FindFirst(MatchSemantic(SurfaceProtocol, CapabilityTurnDisposition, CaseSuccess))
+		if rec == nil {
+			T.Fatal("fixture carries no protocol success Record")
+		}
+		rec.SemanticCase = new(CaseRetryableTransport)
+		path := WriteEvidenceFile(T, fixture.Records)
+		if _, err := ValidateObservations(path); err == nil {
+			T.Error("ValidateObservations() = nil error, want rejection of a disposition tuple carrying a retry Case")
+		}
+	})
+
+	T.Run("retry tuple carrying a disposition Case", func(T *testing.T) {
+		T.Parallel()
+
+		fixture := NewFixture(FixtureQualified)
+		fixture.Finalize()
+		rec := fixture.FindFirst(MatchSemantic(SurfaceProtocol, CapabilityRetryClassification, CaseRetryableTransport))
+		if rec == nil {
+			T.Fatal("fixture carries no protocol retryable Record")
+		}
+		rec.SemanticCase = new(CaseSuccess)
+		path := WriteEvidenceFile(T, fixture.Records)
+		if _, err := ValidateObservations(path); err == nil {
+			T.Error("ValidateObservations() = nil error, want rejection of a retry tuple carrying a disposition Case")
+		}
+	})
+
+	T.Run("baseline Grade written before its own Cases", func(T *testing.T) {
+		T.Parallel()
+
+		fixture := NewFixture(FixtureQualified)
+		fixture.Finalize()
+		baseline := fixture.FindFirst(MatchBaseline(SurfaceProtocol, CapabilityTurnDisposition))
+		if baseline == nil {
+			T.Fatal("fixture carries no protocol disposition baseline")
+		}
+		firstSemantic := 0
+		for i := range fixture.Records {
+			if fixture.Records[i].Scenario == ScenarioSemanticProbe {
+				firstSemantic = i
+				break
+			}
+		}
+		fixture.Remove(baseline)
+		fixture.Records = slices.Insert(fixture.Records, firstSemantic, *baseline)
+		fixture.Renumber()
+		path := WriteEvidenceFile(T, fixture.Records)
+		if _, err := ValidateObservations(path); err == nil {
+			T.Error("ValidateObservations() = nil error, want rejection when a baseline precedes its own Cases")
+		}
+	})
+
+	T.Run("written baseline Grade disagrees with its Cases", func(T *testing.T) {
+		T.Parallel()
+
+		fixture := NewFixture(FixtureQualified)
+		fixture.Finalize()
+		baseline := fixture.FindFirst(MatchBaseline(SurfaceProtocol, CapabilityTurnDisposition))
+		if baseline == nil {
+			T.Fatal("fixture carries no protocol disposition baseline")
+		}
+		baseline.Grade = GradeGap
+		path := WriteEvidenceFile(T, fixture.Records)
+		if _, err := ValidateObservations(path); err == nil {
+			T.Error("ValidateObservations() = nil error, want rejection of a baseline Grade that differs from its derivation")
+		}
+	})
+
+	T.Run("unobserved retry Case lowers only retry classification", func(T *testing.T) {
+		T.Parallel()
+
+		fixture := NewFixture(FixtureQualified)
+		fixture.SetSemanticNotObserved(SurfaceProtocol, CapabilityRetryClassification, CaseUnknownOutcome)
+		fixture.Finalize()
+		path := WriteEvidenceFile(T, fixture.Records)
+		RequireObservationVerdict(T, path, VerdictNotQualified)
+
+		retryBaseline := fixture.FindFirst(MatchBaseline(SurfaceProtocol, CapabilityRetryClassification))
+		dispositionBaseline := fixture.FindFirst(MatchBaseline(SurfaceProtocol, CapabilityTurnDisposition))
+		if retryBaseline == nil || dispositionBaseline == nil {
+			T.Fatal("fixture carries no protocol baselines")
+		}
+		if retryBaseline.Grade != GradeNotObserved {
+			T.Errorf("retry baseline = %s, want not_observed", retryBaseline.Grade)
+		}
+		if dispositionBaseline.Grade != GradeUsable {
+			T.Errorf("disposition baseline = %s, want usable to stay untouched", dispositionBaseline.Grade)
+		}
+	})
+}
+
+// swapRecords exchanges the slice positions of two records pointed
+// to inside the fixture and renumbers.
+func swapRecords(fixture *Fixture, a, b *Record) {
+	indexA, indexB := -1, -1
+	for i := range fixture.Records {
+		switch &fixture.Records[i] {
+		case a:
+			indexA = i
+		case b:
+			indexB = i
+		}
+	}
+	if indexA < 0 || indexB < 0 {
+		panic("swapRecords: records not found")
+	}
+	fixture.Records[indexA], fixture.Records[indexB] = fixture.Records[indexB], fixture.Records[indexA]
+	fixture.Renumber()
+}
+
+// TestValidatorTokenControls covers the token inventory controls:
+// valid sentinels, missing inventories, duplicate paths, doubled
+// sentinels, mixed sentinel shapes, and baseline disagreement.
+func TestValidatorTokenControls(T *testing.T) {
+	T.Parallel()
+
+	T.Run("zero-Source sentinel is valid", func(T *testing.T) {
+		T.Parallel()
+
+		fixture := NewFixture(FixtureQualified)
+		fixture.SetTokenSentinel(SurfaceNativeJSON, false)
+		fixture.Finalize()
+		path := WriteEvidenceFile(T, fixture.Records)
+		RequireObservationVerdict(T, path, VerdictQualified)
+	})
+
+	T.Run("failed inventory sentinel is valid and not qualified", func(T *testing.T) {
+		T.Parallel()
+
+		fixture := NewFixture(FixtureQualified)
+		fixture.SetTokenSentinel(SurfaceProtocol, true)
+		fixture.Finalize()
+		path := WriteEvidenceFile(T, fixture.Records)
+		RequireObservationVerdict(T, path, VerdictNotQualified)
+	})
+
+	T.Run("missing Surface inventory", func(T *testing.T) {
+		T.Parallel()
+
+		fixture := NewFixture(FixtureQualified)
+		fixture.Finalize()
+		fixture.RemoveAll(matchTokenSurface(SurfaceNativeJSON))
+		fixture.Renumber()
+		path := WriteEvidenceFile(T, fixture.Records)
+		if _, err := ValidateObservations(path); err == nil {
+			T.Error("ValidateObservations() = nil error, want rejection when a Surface has no token inventory")
+		}
+	})
+
+	T.Run("duplicate Surface and evidence path", func(T *testing.T) {
+		T.Parallel()
+
+		fixture := NewFixture(FixtureQualified)
+		fixture.Finalize()
+		target := fixture.FindFirst(matchTokenSurface(SurfaceNativeJSON))
+		if target == nil {
+			T.Fatal("fixture carries no native_json token Record")
+		}
+		fixture.DuplicateAfter(target)
+		fixture.Renumber()
+		path := WriteEvidenceFile(T, fixture.Records)
+		_, err := ValidateObservations(path)
+		if err == nil {
+			T.Error("ValidateObservations() = nil error, want rejection of a duplicate token key")
+		} else if !strings.Contains(err.Error(), "duplicate") {
+			T.Errorf("ValidateObservations() error = %v, want it to report a duplicate", err)
+		}
+	})
+
+	T.Run("two sentinels on one Surface", func(T *testing.T) {
+		T.Parallel()
+
+		fixture := NewFixture(FixtureQualified)
+		fixture.SetTokenSentinel(SurfaceNativeJSON, false)
+		fixture.Finalize()
+		sentinel := fixture.FindFirst(matchTokenSurface(SurfaceNativeJSON))
+		if sentinel == nil {
+			T.Fatal("fixture carries no native_json sentinel")
+		}
+		fixture.DuplicateAfter(sentinel)
+		fixture.Renumber()
+		path := WriteEvidenceFile(T, fixture.Records)
+		if _, err := ValidateObservations(path); err == nil {
+			T.Error("ValidateObservations() = nil error, want rejection when a Surface carries two token sentinels")
+		}
+	})
+
+	T.Run("sentinel and non-sentinel on one Surface", func(T *testing.T) {
+		T.Parallel()
+
+		fixture := NewFixture(FixtureQualified)
+		fixture.Finalize()
+		sentinel := sentinelFixtureRecord(fixture, SurfaceProtocol)
+		insertAt := 0
+		for i := range fixture.Records {
+			if matchTokenSurface(SurfaceProtocol)(&fixture.Records[i]) {
+				insertAt = i
+				break
+			}
+		}
+		fixture.Records = slices.Insert(fixture.Records, insertAt, sentinel)
+		fixture.Renumber()
+		path := WriteEvidenceFile(T, fixture.Records)
+		_, err := ValidateObservations(path)
+		if err == nil {
+			T.Error("ValidateObservations() = nil error, want rejection of a sentinel beside non-sentinel records")
+		} else if !strings.Contains(err.Error(), "sentinel") {
+			T.Errorf("ValidateObservations() error = %v, want it to name the sentinel conflict", err)
+		}
+	})
+
+	T.Run("token baseline disagrees with inventory", func(T *testing.T) {
+		T.Parallel()
+
+		fixture := NewFixture(FixtureQualified)
+		fixture.Finalize()
+		baseline := fixture.FindFirst(MatchBaseline(SurfaceProtocol, CapabilityTokenCeiling))
+		if baseline == nil {
+			T.Fatal("fixture carries no protocol token baseline")
+		}
+		baseline.Grade = GradeGap
+		path := WriteEvidenceFile(T, fixture.Records)
+		if _, err := ValidateObservations(path); err == nil {
+			T.Error("ValidateObservations() = nil error, want rejection of a token baseline inconsistent with its inventory")
+		}
+	})
+}
+
+// sentinelFixtureRecord builds a valid zero-Source sentinel Record for one
+// Surface, for controls that append it to a completed inventory.
+func sentinelFixtureRecord(fixture *Fixture, Surface Surface) Record {
+	sentinel := fixture.base()
+	sentinel.Scenario = ScenarioTokenSource
+	sentinel.Surface = Surface
+	sentinel.Capability = CapabilityTokenCeiling
+	sentinel.Source = SourceNone
+	sentinel.Grade = GradeGap
+	sentinel.Outcome = OutcomePass
+	sentinel.InputID = InputTokenInventory
+	sentinel.Detail = "inventory completed with no token-bearing path"
+	return sentinel
+}
+
+// TestValidatorContinuationControls covers the continuation
+// session-relation controls and both positive shapes.
+func TestValidatorContinuationControls(T *testing.T) {
+	T.Parallel()
+
+	T.Run("same-id confirmed continuation is positive", func(T *testing.T) {
+		T.Parallel()
+
+		fixture := NewFixture(FixtureQualified)
+		fixture.Finalize()
+		path := WriteEvidenceFile(T, fixture.Records)
+		RequireObservationVerdict(T, path, VerdictQualified)
+	})
+
+	T.Run("different-id fresh fallback with identity for both ids is positive", func(T *testing.T) {
+		T.Parallel()
+
+		fixture := NewFixture(FixtureQualified)
+		fixture.Finalize()
+		recall := fixture.FindFirst(MatchContinuation(SurfaceProtocol, InputContinuationRecall))
+		if recall == nil {
+			T.Fatal("fixture carries no protocol recall Record")
+		}
+		recall.SessionID = new(FixtureSession(SurfaceProtocol, "fallback"))
+		recall.Detail = recallFreshFallback
+		recall.Grade = GradeGap
+		if baseline := fixture.FindFirst(MatchBaseline(SurfaceProtocol, CapabilitySessionContinuation)); baseline != nil {
+			baseline.Grade = GradeGap
+		}
+		fixture.AppendIdentity(*recall.SessionID)
+		path := WriteEvidenceFile(T, fixture.Records)
+		RequireObservationVerdict(T, path, VerdictNotQualified)
+	})
+
+	T.Run("dangling prior session id", func(T *testing.T) {
+		T.Parallel()
+
+		fixture := NewFixture(FixtureQualified)
+		fixture.Finalize()
+		recall := fixture.FindFirst(MatchContinuation(SurfaceProtocol, InputContinuationRecall))
+		if recall == nil {
+			T.Fatal("fixture carries no protocol recall Record")
+		}
+		recall.PriorSessionID = new(FixtureSession(SurfaceProtocol, "dangling"))
+		path := WriteEvidenceFile(T, fixture.Records)
+		if _, err := ValidateObservations(path); err == nil {
+			T.Error("ValidateObservations() = nil error, want rejection of a dangling prior_session_id")
+		}
+	})
+
+	T.Run("prior id on a forbidden Record", func(T *testing.T) {
+		T.Parallel()
+
+		fixture := NewFixture(FixtureQualified)
+		fixture.Finalize()
+		seed := fixture.FindFirst(MatchContinuation(SurfaceProtocol, InputContinuationSeed))
+		if seed == nil {
+			T.Fatal("fixture carries no protocol seed Record")
+		}
+		seed.PriorSessionID = new(FixtureSession(SurfaceProtocol, "seed"))
+		path := WriteEvidenceFile(T, fixture.Records)
+		if _, err := ValidateObservations(path); err == nil {
+			T.Error("ValidateObservations() = nil error, want rejection of a prior id on a non-recall Record")
+		}
+	})
+
+	T.Run("missing runtime identity for the fallback actual id", func(T *testing.T) {
+		T.Parallel()
+
+		fixture := NewFixture(FixtureQualified)
+		fixture.Finalize()
+		recall := fixture.FindFirst(MatchContinuation(SurfaceProtocol, InputContinuationRecall))
+		if recall == nil {
+			T.Fatal("fixture carries no protocol recall Record")
+		}
+		recall.SessionID = new(FixtureSession(SurfaceProtocol, "fallback"))
+		recall.Detail = recallFreshFallback
+		recall.Grade = GradeGap
+		if baseline := fixture.FindFirst(MatchBaseline(SurfaceProtocol, CapabilitySessionContinuation)); baseline != nil {
+			baseline.Grade = GradeGap
+		}
+		path := WriteEvidenceFile(T, fixture.Records)
+		_, err := ValidateObservations(path)
+		if err == nil {
+			T.Error("ValidateObservations() = nil error, want rejection when the fallback actual id lacks a runtime identity record")
+		} else if !strings.Contains(err.Error(), "runtime identity record") {
+			T.Errorf("ValidateObservations() error = %v, want it to name the missing identity record", err)
+		}
+	})
+}
+
+// TestValidatorCrossSurfacePriorSessionControl pins the separate
+// rejection of a recall whose prior_session_id resolves to a seed on
+// another Surface.
+func TestValidatorCrossSurfacePriorSessionControl(T *testing.T) {
+	T.Parallel()
+
+	fixture := NewFixture(FixtureQualified)
+	fixture.Finalize()
+	recall := fixture.FindFirst(MatchContinuation(SurfaceProtocol, InputContinuationRecall))
+	nativeSeed := fixture.FindFirst(MatchContinuation(SurfaceNativeText, InputContinuationSeed))
+	if recall == nil || nativeSeed == nil {
+		T.Fatal("fixture carries no protocol recall or native_text seed Record")
+	}
+	if nativeSeed.SessionID == nil {
+		T.Fatal("native_text seed carries no session id")
+	}
+	recall.PriorSessionID = new(*nativeSeed.SessionID)
+	path := WriteEvidenceFile(T, fixture.Records)
+	_, err := ValidateObservations(path)
+	if err == nil {
+		T.Error("ValidateObservations() = nil error, want rejection of a cross-Surface prior_session_id")
+	} else if !strings.Contains(err.Error(), "does not resolve to that surface's seed session") {
+		T.Errorf("ValidateObservations() error = %v, want a same-surface resolution failure", err)
+	}
+}
+
+// TestValidatorFinalTupleControls covers the two-pass aggregate
+// rules: no qualification Record in the first pass, exactly one in the
+// final pass, nothing after it, and exact equality with recomputation.
+func TestValidatorFinalTupleControls(T *testing.T) {
+	T.Parallel()
+
+	T.Run("qualification tuple in the first pass", func(T *testing.T) {
+		T.Parallel()
+
+		fixture := NewFixture(FixtureQualified)
+		fixture.Finalize()
+		withAggregate := append(slices.Clone(fixture.Records), aggregateFixtureRecord(GradeQualified))
+		for i := range withAggregate {
+			withAggregate[i].Sequence = i + 1
+		}
+		path := WriteEvidenceFile(T, withAggregate)
+		if _, err := ValidateObservations(path); err == nil {
+			T.Error("ValidateObservations() = nil error, want rejection of a qualification tuple in the first pass")
+		}
+	})
+
+	T.Run("final pass without the aggregate", func(T *testing.T) {
+		T.Parallel()
+
+		fixture := NewFixture(FixtureQualified)
+		fixture.Finalize()
+		path := WriteEvidenceFile(T, fixture.Records)
+		if _, err := ValidateEvidence(path); err == nil {
+			T.Error("ValidateEvidence() = nil error, want rejection when the aggregate is missing")
+		} else if !errors.Is(err, errFinalRecordMissing) {
+			T.Errorf("ValidateEvidence() error = %v, want the missing-aggregate cause", err)
+		}
+	})
+
+	T.Run("final pass with two aggregates", func(T *testing.T) {
+		T.Parallel()
+
+		fixture := NewFixture(FixtureQualified)
+		fixture.Finalize()
+		withAggregates := append(slices.Clone(fixture.Records),
+			aggregateFixtureRecord(GradeQualified),
+			aggregateFixtureRecord(GradeQualified))
+		for i := range withAggregates {
+			withAggregates[i].Sequence = i + 1
+		}
+		path := WriteEvidenceFile(T, withAggregates)
+		if _, err := ValidateEvidence(path); err == nil {
+			T.Error("ValidateEvidence() = nil error, want rejection of two aggregate records")
+		} else if !errors.Is(err, errFinalRecordDuplicated) {
+			T.Errorf("ValidateEvidence() error = %v, want the duplicated-aggregate cause", err)
+		}
+	})
+
+	T.Run("Record after the aggregate", func(T *testing.T) {
+		T.Parallel()
+
+		fixture := NewFixture(FixtureQualified)
+		fixture.Finalize()
+		stray := fixture.FindFirst(matchRowClass(RowProcessCleanup))
+		if stray == nil {
+			T.Fatal("fixture carries no cleanup Record to copy")
+		}
+		withStray := append(slices.Clone(fixture.Records),
+			aggregateFixtureRecord(GradeQualified), *stray)
+		for i := range withStray {
+			withStray[i].Sequence = i + 1
+		}
+		path := WriteEvidenceFile(T, withStray)
+		if _, err := ValidateEvidence(path); err == nil {
+			T.Error("ValidateEvidence() = nil error, want rejection of a Record after the aggregate")
+		} else if !errors.Is(err, errRecordAfterAggregate) {
+			T.Errorf("ValidateEvidence() error = %v, want the Record-after-aggregate cause", err)
+		}
+	})
+
+	T.Run("final Verdict differs from recomputation", func(T *testing.T) {
+		T.Parallel()
+
+		fixture := NewFixture(FixtureQualified)
+		fixture.Finalize()
+		path := WriteFinalEvidenceFile(T, fixture.Records, GradeNotQualified)
+		if _, err := ValidateEvidence(path); err == nil {
+			T.Error("ValidateEvidence() = nil error, want rejection of a mismatched final Verdict")
+		}
+	})
+
+	T.Run("complete qualified final file validates", func(T *testing.T) {
+		T.Parallel()
+
+		fixture := NewFixture(FixtureQualified)
+		fixture.Finalize()
+		tokenCount := tokenRecordCount(fixture.Records)
+		sessionCount := protocolSessionCount(fixture.Records)
+		if tokenCount < 4 {
+			T.Fatalf("fixture token count = %d, want at least 4", tokenCount)
+		}
+		if got := len(fixture.Records); got != 66+tokenCount+sessionCount {
+			T.Fatalf("fixture Record count = %d, want 66+tokenCount+sessionCount = %d", got, 66+tokenCount+sessionCount)
+		}
+		path := WriteFinalEvidenceFile(T, fixture.Records, GradeQualified)
+		RequireFinalVerdict(T, path, VerdictQualified)
+	})
+}

--- a/internal/qualification/validate_test.go
+++ b/internal/qualification/validate_test.go
@@ -1,0 +1,223 @@
+package qualification
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+)
+
+// writeLines writes raw JSONL bodies to a temporary file and returns
+// its path, for controls that need malformed lines.
+func writeLines(T *testing.T, lines ...string) string {
+	T.Helper()
+	dir := filepath.Join(T.TempDir(), "qualification")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		T.Fatalf("create evidence directory: %v", err)
+	}
+	path := filepath.Join(dir, "evidence.jsonl")
+	if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
+		T.Fatalf("write evidence file: %v", err)
+	}
+	return path
+}
+
+// TestValidateObservations confirms the first pass
+// accepts both complete variants with their computed verdicts and the
+// closed cardinality, and rejects zero-line, invalid-enum, wrong-schema,
+// and non-contiguous input.
+func TestValidateObservations(T *testing.T) {
+	T.Parallel()
+
+	T.Run("qualified variant computes qualified", func(T *testing.T) {
+		T.Parallel()
+
+		fixture := NewFixture(FixtureQualified)
+		fixture.Finalize()
+		tokenCount := tokenRecordCount(fixture.Records)
+		sessionCount := protocolSessionCount(fixture.Records)
+		if got := len(fixture.Records); got != 66+tokenCount+sessionCount {
+			T.Errorf("qualified fixture Record count = %d, want 66+tokenCount+sessionCount = %d (T=%d, N=%d)", got, 66+tokenCount+sessionCount, tokenCount, sessionCount)
+		}
+		path := WriteEvidenceFile(T, fixture.Records)
+		RequireObservationVerdict(T, path, VerdictQualified)
+	})
+
+	T.Run("not_qualified variant computes not_qualified", func(T *testing.T) {
+		T.Parallel()
+
+		fixture := NewFixture(FixtureNotQualified)
+		fixture.Finalize()
+		tokenCount := tokenRecordCount(fixture.Records)
+		sessionCount := protocolSessionCount(fixture.Records)
+		if got := len(fixture.Records); got != 66+tokenCount+sessionCount {
+			T.Errorf("not_qualified fixture Record count = %d, want 66+tokenCount+sessionCount = %d (T=%d, N=%d)", got, 66+tokenCount+sessionCount, tokenCount, sessionCount)
+		}
+		path := WriteEvidenceFile(T, fixture.Records)
+		RequireObservationVerdict(T, path, VerdictNotQualified)
+	})
+
+	T.Run("zero-line file", func(T *testing.T) {
+		T.Parallel()
+
+		path := writeLines(T)
+		if _, err := ValidateObservations(path); err == nil {
+			T.Error("ValidateObservations() = nil error, want rejection of an empty file")
+		} else if !strings.Contains(err.Error(), "no records") {
+			T.Errorf("ValidateObservations() error = %v, want the empty-file cause", err)
+		}
+	})
+
+	T.Run("invalid enum value", func(T *testing.T) {
+		T.Parallel()
+
+		fields := marshalRecordFields(T, ValidRecord())
+		fields["scenario"] = json.RawMessage(`"mystery_scenario"`)
+		line, err := json.Marshal(fields)
+		if err != nil {
+			T.Fatalf("marshal doctored fields: %v", err)
+		}
+		path := writeLines(T, string(line))
+		if _, err := ValidateObservations(path); err == nil {
+			T.Error("ValidateObservations() = nil error, want rejection of an invalid enum")
+		} else if !strings.Contains(err.Error(), "outside the closed value set") {
+			T.Errorf("ValidateObservations() error = %v, want the closed-set cause", err)
+		}
+	})
+
+	T.Run("wrong schema version", func(T *testing.T) {
+		T.Parallel()
+
+		fields := marshalRecordFields(T, ValidRecord())
+		fields["schema_version"] = json.RawMessage(`2`)
+		line, err := json.Marshal(fields)
+		if err != nil {
+			T.Fatalf("marshal doctored fields: %v", err)
+		}
+		path := writeLines(T, string(line))
+		if _, err := ValidateObservations(path); err == nil {
+			T.Error("ValidateObservations() = nil error, want rejection of schema_version 2")
+		}
+	})
+
+	T.Run("non-contiguous Sequence", func(T *testing.T) {
+		T.Parallel()
+
+		fixture := NewFixture(FixtureQualified)
+		fixture.Finalize()
+		fixture.Records[3].Sequence = 99
+		path := WriteEvidenceFile(T, fixture.Records)
+		if _, err := ValidateObservations(path); err == nil {
+			T.Error("ValidateObservations() = nil error, want rejection of a non-contiguous Sequence")
+		}
+	})
+
+	T.Run("blank lines are tolerated", func(T *testing.T) {
+		T.Parallel()
+
+		fixture := NewFixture(FixtureQualified)
+		fixture.Finalize()
+		var lines []string
+		for _, rec := range fixture.Records {
+			line, err := MarshalRecord(rec)
+			if err != nil {
+				T.Fatalf("marshal evidence Record: %v", err)
+			}
+			lines = append(lines, string(line))
+		}
+		path := writeLines(T, append([]string{""}, lines...)...)
+		RequireObservationVerdict(T, path, VerdictQualified)
+	})
+}
+
+// TestValidateEvidence confirms the final pass accepts
+// both complete variants, and rejects aggregate records with a wrong
+// evidence path, a non-pass Verdict, or session fields that must be null.
+func TestValidateEvidence(T *testing.T) {
+	T.Parallel()
+
+	T.Run("qualified variant", func(T *testing.T) {
+		T.Parallel()
+
+		fixture := NewFixture(FixtureQualified)
+		fixture.Finalize()
+		path := WriteFinalEvidenceFile(T, fixture.Records, GradeQualified)
+		RequireFinalVerdict(T, path, VerdictQualified)
+	})
+
+	T.Run("not_qualified variant", func(T *testing.T) {
+		T.Parallel()
+
+		fixture := NewFixture(FixtureNotQualified)
+		fixture.Finalize()
+		path := WriteFinalEvidenceFile(T, fixture.Records, GradeNotQualified)
+		RequireFinalVerdict(T, path, VerdictNotQualified)
+	})
+
+	T.Run("aggregate field violations", func(T *testing.T) {
+		T.Parallel()
+
+		tests := []struct {
+			name   string
+			doctor func(rec *Record)
+		}{
+			{
+				name: "wrong evidence path",
+				doctor: func(rec *Record) {
+					rec.EvidencePath = new("qualification.summary")
+				},
+			},
+			{
+				name: "null evidence path",
+				doctor: func(rec *Record) {
+					rec.EvidencePath = nil
+				},
+			},
+			{
+				name: "Verdict not pass",
+				doctor: func(rec *Record) {
+					rec.Outcome = OutcomeNotObserved
+				},
+			},
+			{
+				name: "session id set",
+				doctor: func(rec *Record) {
+					rec.SessionID = new(FixtureSession(SurfaceProtocol, "e2e"))
+				},
+			},
+			{
+				name: "wrong input id",
+				doctor: func(rec *Record) {
+					rec.InputID = InputBaseline
+				},
+			},
+			{
+				name: "protocol version set",
+				doctor: func(rec *Record) {
+					rec.ProtocolVersion = new(1)
+				},
+			},
+		}
+
+		for _, tt := range tests {
+			T.Run(tt.name, func(T *testing.T) {
+				T.Parallel()
+
+				fixture := NewFixture(FixtureQualified)
+				fixture.Finalize()
+				aggregate := aggregateFixtureRecord(GradeQualified)
+				tt.doctor(&aggregate)
+				complete := append(slices.Clone(fixture.Records), aggregate)
+				for i := range complete {
+					complete[i].Sequence = i + 1
+				}
+				path := WriteEvidenceFile(T, complete)
+				if _, err := ValidateEvidence(path); err == nil {
+					T.Errorf("ValidateEvidence() = nil error, want rejection when the aggregate %s", tt.name)
+				}
+			})
+		}
+	})
+}


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Feat

**Intent:** Give the agent-runtime qualification harness a home outside the agent adapter family. The evidence schema, strict decoder, cardinality validator, and fixture builder move into a new `internal/qualification` package so a harness that needs to drive the orchestrator for an end-to-end oracle doesn't have to live inside `internal/agent/**`, which the contract test bans from importing the orchestrator.

**Related Issues:** #239

### 🧭 Reviewer Guide

**Complexity:** Medium

#### Entry Point

`internal/qualification/validate.go` is where to start. It holds the cardinality validator and verdict computation that `internal/agent/clientprotocol`'s Gemini live-probe files now import instead of carrying their own copy. `internal/qualification/evidence.go` defines the evidence schema and strict decoder those probes write against, and `internal/qualification/fixture.go` builds the fixtures the validator consumes.

#### Sensitive Areas

- `internal/adaptertest/contract_test.go`: adds a narrow, file-and-import-scoped allowlist entry (`contractTestImportAllowlist`) so `gemini_qualification_e2e_unix_test.go` can keep importing `internal/orchestrator` and `internal/tracker/file` for its isolated end-to-end oracle. Every other file in `clientprotocol`, test or production, stays fully guarded by the existing import bans. The entry is temporary: a follow-up change relocates that one fixture and drops the allowlist.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes.
- **Migrations/State:** No migrations or state changes.
