### PR TITLE
fix: report lint findings for every LINT_GOOS platform

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,17 +51,27 @@ vet: ## Run go vet on all packages
 
 .PHONY: lint
 lint: ## Run golangci-lint for every target platform (LINT_GOOS=windows ...)
-	@for goos in $(LINT_GOOS); do \
+	@failed=''; \
+	for goos in $(LINT_GOOS); do \
 		printf '$(BOLD)golangci-lint: GOOS=%s$(RESET)\n' "$$goos"; \
-		GOOS=$$goos $(LINTER) run ./... || exit 1; \
-	done
+		GOOS=$$goos $(LINTER) run ./... || failed="$$failed $$goos"; \
+	done; \
+	if [ -n "$$failed" ]; then \
+		printf '$(RED)findings reported for:$(RESET)$(BOLD)%s$(RESET)\n' "$$failed"; \
+		exit 1; \
+	fi
 
 .PHONY: lint-no-tests
 lint-no-tests: ## Fail if shipped code is reachable only from its own test
-	@for goos in $(LINT_GOOS); do \
+	@failed=''; \
+	for goos in $(LINT_GOOS); do \
 		printf '$(BOLD)golangci-lint (shipped code only): GOOS=%s$(RESET)\n' "$$goos"; \
-		GOOS=$$goos $(LINTER) run --config .golangci-no-tests.yml --tests=false ./... || exit 1; \
-	done
+		GOOS=$$goos $(LINTER) run --config .golangci-no-tests.yml --tests=false ./... || failed="$$failed $$goos"; \
+	done; \
+	if [ -n "$$failed" ]; then \
+		printf '$(RED)findings reported for:$(RESET)$(BOLD)%s$(RESET)\n' "$$failed"; \
+		exit 1; \
+	fi
 
 .PHONY: lint-shell
 lint-shell: ## Run shellcheck on every tracked shell script


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Fix

**Intent:** The `lint` and `lint-no-tests` targets iterated `LINT_GOOS` and exited on the first platform that reported a finding, so a finding on a later platform stayed invisible until every earlier platform was clean. This turned a single round of fixes into as many rounds as there were platforms with findings.

**Related Issues:** #1009

### 🧭 Reviewer Guide

**Complexity:** Low

#### Entry Point

`Makefile` - the `lint` and `lint-no-tests` targets now run the `LINT_GOOS` loop to completion, collecting each platform whose `golangci-lint` run failed into a `failed` variable instead of exiting on the first failure. Once the loop finishes, it prints the list of platforms with findings and exits non-zero if any were collected.

#### Sensitive Areas

- `Makefile`: shell logic inside a `.PHONY` recipe - worth checking that a clean run for all platforms still exits 0, and that a failure on a non-first platform is no longer swallowed.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes
- **Migrations/State:** No migrations or state changes