### PR TITLE
fix: bound Conn.Close against a write parked on stdin

### DIFF
--- a/internal/agent/clientprotocol/session.go
+++ b/internal/agent/clientprotocol/session.go
@@ -666,9 +666,10 @@ func closeStdout(state *sessionState) {
 	}
 }
 
-// closeConnection closes the JSON-RPC connection. Closing it before the
-// process group is terminated and the handles above are closed would
-// wait on the same parked write those two actions exist to release.
+// closeConnection closes the JSON-RPC connection. Closing the
+// connection does not release a write the pump has parked on standard
+// input, so the handle close and the group termination ahead of it are
+// what release the pump before the step that waits for it.
 func closeConnection(state *sessionState) {
 	if state.conn != nil {
 		state.conn.Close()

--- a/internal/agent/clientprotocol/session_teardown_test.go
+++ b/internal/agent/clientprotocol/session_teardown_test.go
@@ -89,10 +89,14 @@ const (
 	// fixture's own always-running reaper goroutine, mirroring
 	// StartSession's, races that automatic close against teardown's
 	// own closeStdin and closeStdout, and wins once
-	// kill_process_group has actually reaped the process. That is
-	// the right wiring for the bound case and for the first control,
-	// where kill_process_group either succeeds immediately or never
-	// runs at all, so the race never has a chance to matter.
+	// kill_process_group has actually reaped the process. That is the
+	// right wiring for the bound case and for
+	// TestStopSessionTeardownReturnsWithConnectionClosedFirst, where
+	// every step able to release the parked write runs after
+	// close_connection: whichever close wins the race between
+	// Cmd.Wait's automatic pipe close and teardown's own closes, that
+	// test's assertion is unchanged, and a Close that still waits on
+	// the parked write still fails it.
 	pipeWiringAutoClosing pipeWiring = iota
 
 	// pipeWiringManual connects a plain os.Pipe pair directly to
@@ -366,15 +370,16 @@ func runTeardownControl(t *testing.T, fx *parkedTeardownFixture, steps []teardow
 	assertSessionGoroutinesExited(t, fx.state)
 }
 
-// TestStopSessionTeardownControlConnectionBeforeKill is the first
-// negative control: closing the connection before the process group
-// is terminated waits on the write mutex the parked write holds, so
-// teardown must not return until the park is released from outside.
-func TestStopSessionTeardownControlConnectionBeforeKill(t *testing.T) {
+// TestStopSessionTeardownReturnsWithConnectionClosedFirst checks a
+// step order that closes the connection before the process group is
+// terminated. Closing the connection no longer waits on a parked
+// write, so this order returns inside the bound below instead of
+// parking until the write is released from outside.
+func TestStopSessionTeardownReturnsWithConnectionClosedFirst(t *testing.T) {
 	t.Parallel()
 
 	fx := newParkedTeardownSession(t, pipeWiringAutoClosing)
-	runTeardownControl(t, fx, []teardownStep{
+	steps := []teardownStep{
 		{name: "answer_open", run: signalAnswerOpen},
 		{name: "close_connection", run: closeConnection},
 		{name: "kill_process_group", run: killProcessGroup},
@@ -382,7 +387,21 @@ func TestStopSessionTeardownControlConnectionBeforeKill(t *testing.T) {
 		{name: "close_stdout", run: closeStdout},
 		{name: "stop_pump", run: stopPump},
 		{name: "drain_stderr_and_reap", run: drainStderrAndReap(context.Background())},
-	})
+	}
+
+	done := make(chan struct{})
+	go func() {
+		runTeardown(fx.state, steps)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(3*procutil.DefaultDrainGrace + teardownReturnOverhead):
+		t.Fatal("runTeardown() did not return inside the bound, want it to return without waiting for the parked write")
+	}
+
+	assertSessionGoroutinesExited(t, fx.state)
 }
 
 // TestStopSessionTeardownControlNoStdoutClose is the second negative

--- a/internal/agent/clientprotocol/session_unix_test.go
+++ b/internal/agent/clientprotocol/session_unix_test.go
@@ -81,13 +81,22 @@ func TestStartSessionMCPInjectionWire(t *testing.T) {
 	})
 }
 
-// mcpHandshakeThenGracefulExitScript answers startSession's handshake
-// exactly as mcpHandshakeScript does, then installs a handler for the
+// mcpHandshakeThenGracefulExitScript installs a handler for the
 // graceful signal that waits delaySeconds and writes evidencePath
-// before exiting, so a test can tell a catchable signal from an
-// uncatchable kill.
+// before exiting, then answers startSession's handshake exactly as
+// mcpHandshakeScript does, so a test can tell a catchable signal from
+// an uncatchable kill.
+//
+// The handler is installed before the handshake rather than after it.
+// A caller signals only once startSession has returned, which cannot
+// happen until the handshake below has been answered, so installing
+// first leaves no window in which the default disposition applies and
+// the evidence is never written. The idle loop sleeps in short
+// intervals because the handler does not run until the command it
+// interrupts has finished.
 func mcpHandshakeThenGracefulExitScript(evidencePath, delaySeconds string) string {
-	return `while IFS= read -r line; do
+	return `trap 'sleep ` + delaySeconds + `; touch "` + evidencePath + `"; exit 0' TERM
+while IFS= read -r line; do
   case "$line" in
     *'"method":"initialize"'*)
       printf '%s\n' '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":1}}'
@@ -98,8 +107,7 @@ func mcpHandshakeThenGracefulExitScript(evidencePath, delaySeconds string) strin
       ;;
   esac
 done
-trap 'sleep ` + delaySeconds + `; touch "` + evidencePath + `"; exit 0' TERM
-while :; do sleep 1; done
+while :; do sleep 0.05; done
 `
 }
 

--- a/internal/agent/codex/codex_test.go
+++ b/internal/agent/codex/codex_test.go
@@ -12,8 +12,10 @@ import (
 	"path/filepath"
 	"reflect"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/sortie-ai/sortie/internal/agent/agentcore"
 	"github.com/sortie-ai/sortie/internal/agent/agenttest"
@@ -611,5 +613,84 @@ func TestRunTurn_StdoutParseFailure(t *testing.T) {
 	}
 	if turnFailedEvents[0].Message != agentErr.Message {
 		t.Errorf("turn_failed Message = %q, want the same text as AgentError.Message %q", turnFailedEvents[0].Message, agentErr.Message)
+	}
+}
+
+// entrySignalingWriter wraps an io.Writer and closes done the instant
+// Write is entered, before delegating to the wrapped writer. Unlike
+// signalingWriter, which signals once Write returns, this lets a test
+// observe that a write has been parked inside a call that never
+// returns on its own.
+type entrySignalingWriter struct {
+	w    io.Writer
+	once sync.Once
+	done chan struct{}
+}
+
+func newEntrySignalingWriter(w io.Writer) *entrySignalingWriter {
+	return &entrySignalingWriter{w: w, done: make(chan struct{})}
+}
+
+func (s *entrySignalingWriter) Write(p []byte) (int, error) {
+	s.once.Do(func() { close(s.done) })
+	return s.w.Write(p)
+}
+
+// TestStopSession_ReturnsWhileWriteParked checks that StopSession
+// returns while another goroutine is parked writing on the session's
+// connection, proving that closeConnAndStop's call to conn.Close does
+// not wait for that write. The fixture leaves no process handle and
+// no wait channel, and readerDone already closed, so no other bounded
+// wait in StopSession can substitute for that proof.
+func TestStopSession_ReturnsWhileWriteParked(t *testing.T) {
+	t.Parallel()
+
+	pr, pw := io.Pipe()
+	sig := newEntrySignalingWriter(pw)
+
+	readerDone := make(chan struct{})
+	close(readerDone)
+
+	state := &sessionState{
+		msgCh:      make(chan jsonrpc.Message),
+		readerDone: readerDone,
+		stopCh:     make(chan struct{}),
+	}
+	state.conn = jsonrpc.NewConn(sig, strings.NewReader(""), sessionHandler(state))
+
+	writeErr := make(chan error, 1)
+	go func() {
+		writeErr <- state.conn.Notify("parked/notify", nil)
+	}()
+
+	// Registered before the assertions below, so a t.Fatal on the
+	// regression path still releases the parked write.
+	t.Cleanup(func() {
+		_ = pr.Close()
+		_ = pw.Close()
+		select {
+		case <-writeErr:
+		case <-time.After(2 * time.Second):
+		}
+	})
+
+	select {
+	case <-sig.done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for the write to enter the wrapped writer")
+	}
+
+	stopErr := make(chan error, 1)
+	go func() {
+		stopErr <- (&CodexAdapter{}).StopSession(context.Background(), domain.Session{Internal: state})
+	}()
+
+	select {
+	case err := <-stopErr:
+		if err != nil {
+			t.Errorf("StopSession() error = %v, want nil", err)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("StopSession() did not return while a write was parked, want it to return well short of its own 5-second graceful-wait ceiling")
 	}
 }

--- a/internal/agent/jsonrpc/jsonrpc.go
+++ b/internal/agent/jsonrpc/jsonrpc.go
@@ -97,8 +97,9 @@ func WithMaxLineBytes(n int) Option {
 //
 // NewConn panics when h is nil. It starts one reader goroutine before
 // returning, and it does not close w or r; closing them is the
-// caller's responsibility, and closing r is how the caller unblocks a
-// read parked on the stream. With no options passed, behavior is
+// caller's responsibility, closing r is how the caller unblocks a
+// read parked on the stream, and closing w is how the caller unblocks
+// a write parked on it. With no options passed, behavior is
 // byte-identical to a connection with none of this package's options
 // applied.
 func NewConn(w io.Writer, r io.Reader, h Handler, opts ...Option) *Conn {
@@ -141,6 +142,11 @@ type wireRequest struct {
 // write serializes one already-encoded line against every other
 // write on the connection, and reports ErrClosed after Close without
 // touching w.
+//
+// A write already past the closed check is not stopped by Close. A
+// write still waiting for the write mutex is not released by Close
+// either, and it reports ErrClosed only once the write ahead of it
+// finishes.
 func (c *Conn) write(line []byte) error {
 	c.writeMu.Lock()
 	defer c.writeMu.Unlock()
@@ -344,13 +350,14 @@ func (c *Conn) Call(ctx context.Context, method string, params any) (Response, e
 // any goroutine, and it does not close the underlying writer or
 // reader.
 //
-// Close acquires the write mutex while it marks the connection
-// closed, so no write is in flight when Close returns and none will
-// start.
+// Close never waits for the peer. At most one write, one that has
+// already passed the closed check, may still reach the underlying
+// writer after Close returns, and Close neither waits for it nor
+// interrupts it. Such a write reports whatever the underlying writer
+// reports, which once the caller closes that writer is the writer's
+// own error rather than one wrapping ErrClosed.
 func (c *Conn) Close() {
-	c.writeMu.Lock()
 	c.closeOnce.Do(func() { close(c.closed) })
-	c.writeMu.Unlock()
 
 	for id, ch := range c.drainPending() {
 		ch <- callResult{err: &closedCallError{id: id}}

--- a/internal/agent/jsonrpc/jsonrpc_test.go
+++ b/internal/agent/jsonrpc/jsonrpc_test.go
@@ -766,3 +766,86 @@ func TestNewConn_SkipsNilOptions(t *testing.T) {
 		t.Errorf("Notify() wrote %q, want the version member the non-nil option asked for", got)
 	}
 }
+
+// entrySignalingWriter wraps an io.Writer and closes done the instant
+// Write is entered, before delegating to the wrapped writer. Unlike a
+// writer that signals once Write returns, this lets a test observe
+// that a write has been parked inside a call that never returns on
+// its own.
+type entrySignalingWriter struct {
+	w    io.Writer
+	once sync.Once
+	done chan struct{}
+}
+
+func newEntrySignalingWriter(w io.Writer) *entrySignalingWriter {
+	return &entrySignalingWriter{w: w, done: make(chan struct{})}
+}
+
+func (s *entrySignalingWriter) Write(p []byte) (int, error) {
+	s.once.Do(func() { close(s.done) })
+	return s.w.Write(p)
+}
+
+// TestConn_CloseReturnsWithWriteParked checks that Close returns while
+// a write is parked on a writer that never accepts the bytes, rather
+// than waiting for the write to finish.
+func TestConn_CloseReturnsWithWriteParked(t *testing.T) {
+	t.Parallel()
+
+	pr, pw := io.Pipe()
+	sig := newEntrySignalingWriter(pw)
+	conn := jsonrpc.NewConn(sig, strings.NewReader(""), func(jsonrpc.Message) {})
+
+	writeErr := make(chan error, 1)
+	go func() {
+		writeErr <- conn.Notify("parked/notify", nil)
+	}()
+
+	// Registered before the assertions below, so a t.Fatal on the
+	// regression path still releases the parked write.
+	t.Cleanup(func() {
+		_ = pr.Close()
+		_ = pw.Close()
+		select {
+		case <-writeErr:
+		case <-time.After(2 * time.Second):
+		}
+	})
+
+	select {
+	case <-sig.done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for the write to enter the wrapped writer")
+	}
+
+	closeReturned := make(chan struct{})
+	go func() {
+		conn.Close()
+		close(closeReturned)
+	}()
+
+	select {
+	case <-closeReturned:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Close() did not return while a write was parked on a writer that does not accept bytes")
+	}
+}
+
+// TestConn_WriteAfterCloseReportsErrClosedWithoutTouchingWriter checks
+// that a write issued after Close reports an error wrapping ErrClosed
+// and never reaches the underlying writer.
+func TestConn_WriteAfterCloseReportsErrClosedWithoutTouchingWriter(t *testing.T) {
+	t.Parallel()
+
+	var w captureWriter
+	conn := jsonrpc.NewConn(&w, strings.NewReader(""), func(jsonrpc.Message) {})
+	conn.Close()
+
+	if err := conn.Notify("after/close", nil); !errors.Is(err, jsonrpc.ErrClosed) {
+		t.Errorf("Notify() after Close() error = %v, want error wrapping jsonrpc.ErrClosed", err)
+	}
+	if got := w.String(); got != "" {
+		t.Errorf("Notify() after Close() wrote %q to the writer, want none", got)
+	}
+}


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Fix

**Intent:** `Conn.Close` held the write mutex while marking the connection closed, so it waited behind any write already parked in the underlying `Write` call. When an agent stops draining its stdin and the pipe buffer fills, that write blocks indefinitely and `Close` blocks with it, with no deadline of its own. Since the Codex adapter's `StopSession` closes stdin and signals the process only after `Close` returns, a wedged agent could hold session teardown open indefinitely and leave its process unsignalled. `Close` no longer acquires the write mutex, so it returns without waiting for an in-flight write to finish.

**Related Issues:** #993

### 🧭 Reviewer Guide

**Complexity:** Medium

#### Entry Point

`internal/agent/jsonrpc/jsonrpc.go` - `Conn.Close` no longer acquires `writeMu` before marking the connection closed. This changes a previously documented guarantee (no write in flight once `Close` returns) into a narrower one: a write already past the closed check may still reach the underlying writer after `Close` returns, and `Close` neither waits for it nor interrupts it. The new guarantee is documented on both `Close` and `write`.

#### Sensitive Areas

- `internal/agent/jsonrpc/jsonrpc.go`: `Close` no longer serializes against `write` - review the tradeoff and its documentation carefully, since other callers may have relied on the old in-flight guarantee.
- `internal/agent/clientprotocol/session.go`: updated doc comment on `closeConnection` reflecting that closing the connection no longer releases a parked write; the handle close and process-group termination ahead of it are what release it.
- `internal/agent/clientprotocol/session_teardown_test.go`: `TestStopSessionTeardownControlConnectionBeforeKill` (a negative control asserting teardown parks) is renamed to `TestStopSessionTeardownReturnsWithConnectionClosedFirst` and now asserts a bounded return instead.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes. `Close`'s external contract (idempotent, drains pending calls, reports `ErrClosed` for writes issued after it returns) is unchanged; only the in-flight-write guarantee is narrowed, and that narrowing is documented in-package.
- **Migrations/State:** No migrations or state changes.
