### PR TITLE
fix: signal the process group when a Codex launch context is cancelled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `agent-client-protocol` transport now sends its subprocess a catchable termination signal and waits a bounded grace period for it to exit on its own before force-terminating its process group, instead of terminating the group immediately with no graceful phase at all; a runtime that flushes state on a clean exit now gets a chance to reach that exit path. Every adapter kind's stop deadline no longer follows `agent.read_timeout_ms` below a full teardown: a stop against an agent that ignores its termination signal can now hold a worker or a shutdown for up to 20 seconds, where the shipping default previously gave it 5.
   ([#1006](https://github.com/sortie-ai/sortie/issues/1006))
 
+- Cancelling a `codex` run now shuts down the whole process tree the agent started, instead of force-killing the agent alone and leaving its child processes running against the workspace. The agent first receives a catchable termination signal and a bounded grace period to exit on its own, so a runtime that flushes state on a clean exit reaches that path. Stopping a run already behaved this way; cancelling one did not.
+  ([#1013](https://github.com/sortie-ai/sortie/issues/1013))
+
+- A self-review verification command now stops the process it started when the command exceeds `self_review.verification_timeout_ms` or the run is cancelled. Previously only the shell wrapping the command was killed, so a build or test suite kept running against the workspace after the run had moved on, and a run cancelled rather than timed out left it running with nothing to stop it.
+  ([PR #1020](https://github.com/sortie-ai/sortie/pull/1020))
+
 ## [1.23.0] - 2026-08-31
 
 ### Added

--- a/internal/adaptertest/contract_test.go
+++ b/internal/adaptertest/contract_test.go
@@ -99,6 +99,7 @@ const (
 	ruleMETRICS  contractRule = "METRICS"
 	ruleHOOK     contractRule = "HOOK"
 	ruleIMPORT   contractRule = "IMPORT"
+	ruleTEARDOWN contractRule = "TEARDOWN"
 	ruleBLOCKER  contractRule = "BLOCKER"
 	ruleIDENTITY contractRule = "IDENTITY"
 )
@@ -178,6 +179,9 @@ var contractPackageBannedImports = map[string]map[string]string{
 var contractAllowlist = map[string]map[contractRule]string{
 	"file": {
 		ruleHOOK: "no HTTP, no credential, no remote project, and no config to validate",
+	},
+	"procutil": {
+		ruleTEARDOWN: "owns SetGroupCancel, the helper every other launcher calls",
 	},
 }
 
@@ -443,6 +447,49 @@ func checkContractBan(fset *token.FileSet, file *ast.File) []contractViolation {
 	return violations
 }
 
+// contractTeardownFields names the exec.Cmd fields a launcher must not
+// wire by hand. Assigning either one rebuilds, at a new call site, the
+// process-group teardown contractTeardownOwner already owns. The two
+// fields have to agree, and a launcher that sets one and forgets the
+// other silently keeps the os/exec default for it: a cancelled context
+// then force-kills the direct child alone and every descendant it
+// started outlives the cancellation.
+var contractTeardownFields = map[string]bool{
+	"Cancel":    true,
+	"WaitDelay": true,
+}
+
+// contractTeardownOwner is the helper rule TEARDOWN directs a launcher to.
+const contractTeardownOwner = "procutil.SetGroupCancel"
+
+// checkContractTeardown reports a violation for every assignment to an
+// exec.Cmd teardown field in file. It reads file only when file imports
+// os/exec, so a same-named field on an unrelated type is never matched.
+func checkContractTeardown(fset *token.FileSet, file *ast.File) []contractViolation {
+	if resolveContractImportName(file, "os/exec") == "" {
+		return nil
+	}
+	var violations []contractViolation
+	ast.Inspect(file, func(n ast.Node) bool {
+		assign, ok := n.(*ast.AssignStmt)
+		if !ok {
+			return true
+		}
+		for _, lhs := range assign.Lhs {
+			sel, isSel := lhs.(*ast.SelectorExpr)
+			if !isSel || !contractTeardownFields[sel.Sel.Name] {
+				continue
+			}
+			violations = append(violations, contractViolation{
+				pos:  fset.Position(sel.Pos()),
+				text: "assigns exec.Cmd." + sel.Sel.Name + " directly; call " + contractTeardownOwner,
+			})
+		}
+		return true
+	})
+	return violations
+}
+
 // bodyCallsTrackermetricsTrack reports whether body contains a call
 // resolving to trackermetrics.Track, with the qualifier resolved from
 // file's own imports.
@@ -637,6 +684,9 @@ func checkCoreContractPackage(fset *token.FileSet, pkg contractPackage) []contra
 	var violations []contractViolation
 	for _, file := range pkg.files {
 		violations = append(violations, checkContractCoreImports(fset, file, false)...)
+		if !contractExempt(pkg.dirName, ruleTEARDOWN) {
+			violations = append(violations, checkContractTeardown(fset, file)...)
+		}
 	}
 	for _, file := range pkg.testFiles {
 		violations = append(violations, checkContractCoreImports(fset, file, true)...)
@@ -1088,6 +1138,12 @@ func checkAdapterContractPackage(fset *token.FileSet, pkg contractPackage) []con
 		}
 	}
 
+	if !contractExempt(pkg.dirName, ruleTEARDOWN) {
+		for _, file := range pkg.files {
+			violations = append(violations, checkContractTeardown(fset, file)...)
+		}
+	}
+
 	registers, usedMeta, hasHook, hasBlockerSource, blockerSourceIsPerIssue, factsPos := contractRegistrationFacts(fset, pkg.files)
 
 	if !contractExempt(pkg.dirName, ruleMETRICS) {
@@ -1308,6 +1364,57 @@ func TestCheckAdapterContract_DetectsViolations(t *testing.T) {
 		// right count.
 		wantSubstr string
 	}{
+		{
+			name:       "a hand-wired exec.Cmd cancellation is rejected",
+			dirName:    "fixture",
+			importPath: "github.com/sortie-ai/sortie/internal/agent/fixture",
+			src: `package fixture
+
+import "os/exec"
+
+func launch(cmd *exec.Cmd) {
+	cmd.Cancel = func() error { return nil }
+}
+`,
+			wantCount:  1,
+			wantSubstr: "call procutil.SetGroupCancel",
+		},
+		{
+			name:       "a hand-wired exec.Cmd wait delay is rejected",
+			dirName:    "fixture",
+			importPath: "github.com/sortie-ai/sortie/internal/agent/fixture",
+			src: `package fixture
+
+import (
+	"os/exec"
+	"time"
+)
+
+func launch(cmd *exec.Cmd) {
+	cmd.WaitDelay = 5 * time.Second
+}
+`,
+			wantCount:  1,
+			wantSubstr: "call procutil.SetGroupCancel",
+		},
+		{
+			name:       "a same-named field in a package that never touches os/exec is accepted",
+			dirName:    "fixture",
+			importPath: "github.com/sortie-ai/sortie/internal/agent/fixture",
+			src: `package fixture
+
+type request struct {
+	Cancel    func() error
+	WaitDelay int
+}
+
+func configure(r *request) {
+	r.Cancel = func() error { return nil }
+	r.WaitDelay = 5
+}
+`,
+			wantCount: 0,
+		},
 		{
 			name:       "a re-declared ban-table name is rejected",
 			dirName:    "fixture",

--- a/internal/agent/agentcore/forkperturn.go
+++ b/internal/agent/agentcore/forkperturn.go
@@ -29,9 +29,6 @@ const (
 	// stdoutScannerMaxTokenSize is handled by bufio.Scanner automatically.
 	stdoutScannerInitialBufSize = 64 * 1024 // 64 KB
 
-	// stopGracePeriod is the time between SIGTERM and SIGKILL in Stop
-	// and in the cmd.WaitDelay grace period.
-	stopGracePeriod = 5 * time.Second
 )
 
 // ForkPerTurnHooks provides the adapter-specific behavior points plugged into
@@ -247,11 +244,7 @@ func (s *ForkPerTurnSession) RunTurn(
 		allArgs := append(slices.Clip(s.target.Args), cmdArgs...)       //nolint:gocritic // intentional: target.Args has cap==len so append always allocates
 		cmd = exec.CommandContext(cmdCtx, s.target.Command, allArgs...) //nolint:gosec // args are constructed programmatically
 	}
-	procutil.SetProcessGroup(cmd)
-	cmd.Cancel = func() error {
-		return procutil.SignalGraceful(cmd.Process.Pid)
-	}
-	cmd.WaitDelay = stopGracePeriod
+	procutil.SetGroupCancel(cmd)
 	cmd.Dir = s.target.WorkspacePath
 	cmd.Env = os.Environ()
 
@@ -486,7 +479,7 @@ func (s *ForkPerTurnSession) Stop(ctx context.Context) error {
 	select {
 	case <-waitCh:
 		return nil
-	case <-time.After(stopGracePeriod):
+	case <-time.After(procutil.DefaultStopGrace):
 		_ = procutil.KillProcessGroup(proc.Pid) //nolint:errcheck // best-effort kill
 		return nil
 	case <-ctx.Done():

--- a/internal/agent/clientprotocol/session.go
+++ b/internal/agent/clientprotocol/session.go
@@ -206,11 +206,7 @@ func startSession(ctx context.Context, params domain.StartSessionParams) (domain
 		cmd = exec.CommandContext(ctx, target.Command, target.Args...) //nolint:gosec // args are constructed programmatically
 		cmd.Dir = target.WorkspacePath
 	}
-	procutil.SetProcessGroup(cmd)
-	cmd.Cancel = func() error {
-		return procutil.SignalGraceful(cmd.Process.Pid)
-	}
-	cmd.WaitDelay = procutil.DefaultStopGrace
+	procutil.SetGroupCancel(cmd)
 	cmd.Env = os.Environ()
 
 	stdinPipe, err := cmd.StdinPipe()

--- a/internal/agent/codex/codex.go
+++ b/internal/agent/codex/codex.go
@@ -251,16 +251,7 @@ func (a *CodexAdapter) StartSession(ctx context.Context, params domain.StartSess
 	} else {
 		cmd = exec.CommandContext(ctx, target.Command, target.Args...) //nolint:gosec // args are constructed programmatically
 	}
-	procutil.SetProcessGroup(cmd)
-	// Cancelling ctx otherwise falls back to os/exec's default of killing
-	// only the direct child, giving the agent no chance to exit cleanly and
-	// leaving any descendant it started running. Signal the process group
-	// instead and grant the same 5-second grace period StopSession already
-	// waits before escalating to a force-kill.
-	cmd.Cancel = func() error {
-		return procutil.SignalGraceful(cmd.Process.Pid)
-	}
-	cmd.WaitDelay = 5 * time.Second
+	procutil.SetGroupCancel(cmd)
 	cmd.Dir = target.WorkspacePath
 	cmd.Env = os.Environ()
 

--- a/internal/agent/codex/codex.go
+++ b/internal/agent/codex/codex.go
@@ -252,6 +252,15 @@ func (a *CodexAdapter) StartSession(ctx context.Context, params domain.StartSess
 		cmd = exec.CommandContext(ctx, target.Command, target.Args...) //nolint:gosec // args are constructed programmatically
 	}
 	procutil.SetProcessGroup(cmd)
+	// Cancelling ctx otherwise falls back to os/exec's default of killing
+	// only the direct child, giving the agent no chance to exit cleanly and
+	// leaving any descendant it started running. Signal the process group
+	// instead and grant the same 5-second grace period StopSession already
+	// waits before escalating to a force-kill.
+	cmd.Cancel = func() error {
+		return procutil.SignalGraceful(cmd.Process.Pid)
+	}
+	cmd.WaitDelay = 5 * time.Second
 	cmd.Dir = target.WorkspacePath
 	cmd.Env = os.Environ()
 

--- a/internal/agent/codex/codex_unix_test.go
+++ b/internal/agent/codex/codex_unix_test.go
@@ -17,18 +17,43 @@ import (
 	"github.com/sortie-ai/sortie/internal/domain"
 )
 
+// writeDescendantScript creates the script the fake app-server spawns as
+// a background job. It publishes its own PID to pidFile, then idles until
+// a catchable termination signal arrives and records that it caught one
+// by writing markerFile.
+//
+// The marker is the evidence that a graceful signal reached the whole
+// process group rather than only its leader: this script is a grandchild
+// of the adapter, so it can only be signalled through the group.
+func writeDescendantScript(t *testing.T, dir, pidFile, markerFile string) string {
+	t.Helper()
+	content := fmt.Sprintf(
+		"trap 'printf terminated > %s; exit 0' TERM\n"+
+			"printf '%%s\\n' \"$$\" > %s\n"+
+			"while :; do sleep 1; done\n",
+		markerFile, pidFile,
+	)
+	return agenttest.WriteScript(t, dir, "fake-codex-descendant", content)
+}
+
 // writeFakeAppServerScript creates a script that fakes just enough of the
 // codex app-server JSON-RPC handshake (initialize, account/read,
-// thread/start) for StartSession to succeed, then spawns a long-running
-// grandchild (sleep 3600 &), writes the grandchild's PID to pidFile, and
-// blocks so the session stays "running" until it is signalled.
+// thread/start) for StartSession to succeed, then spawns descendantScript
+// as a background job and blocks until that descendant exits.
 //
-// Response ids are hardcoded (1, 2, 3) rather than parsed from the request
-// lines: jsonrpc.Conn allocates ids sequentially starting at 1, and
-// StartSession issues exactly these three calls in this order, so the
+// The script waits for its descendant inside its own TERM handler rather
+// than exiting immediately. That ordering is what makes the assertions
+// deterministic: the adapter's exit watcher force-kills the group only
+// after cmd.Wait returns, and cmd.Wait cannot return while this script is
+// still waiting, so the force kill can never race the descendant's
+// handler.
+//
+// Response ids are hardcoded (1, 2, 3) rather than parsed from the
+// request lines: jsonrpc.Conn allocates ids sequentially starting at 1,
+// and StartSession issues exactly these three calls in this order, so the
 // sequence is deterministic. Using agenttest.WriteScript avoids the
 // ETXTBSY race on Linux.
-func writeFakeAppServerScript(t *testing.T, dir, pidFile string) string {
+func writeFakeAppServerScript(t *testing.T, dir, descendantScript string) string {
 	t.Helper()
 	content := fmt.Sprintf(
 		"read -r _init_req\n"+
@@ -39,17 +64,17 @@ func writeFakeAppServerScript(t *testing.T, dir, pidFile string) string {
 			"read -r _thread_start_req\n"+
 			"printf '{\"id\":3,\"result\":{\"thread\":{\"id\":\"fake-thread-1\"}}}\\n'\n"+
 			"printf '{\"method\":\"thread/started\",\"params\":{}}\\n'\n"+
-			"sleep 3600 &\n"+
-			"CHILD_PID=$!\n"+
-			"printf '%%s\\n' \"$CHILD_PID\" > '%s'\n"+
-			"sleep 3600\n",
-		pidFile,
+			"%s &\n"+
+			"DESCENDANT_PID=$!\n"+
+			"trap 'wait \"$DESCENDANT_PID\"; exit 0' TERM\n"+
+			"wait \"$DESCENDANT_PID\"\n",
+		descendantScript,
 	)
 	return agenttest.WriteScript(t, dir, "fake-codex-app-server", content)
 }
 
-// pollPIDFile polls pidFile until it contains a valid positive integer PID,
-// or fails the test after timeout.
+// pollPIDFile polls pidFile until it contains a valid positive integer
+// PID, or fails the test after timeout.
 func pollPIDFile(t *testing.T, pidFile string, timeout time.Duration) int {
 	t.Helper()
 	deadline := time.Now().Add(timeout)
@@ -63,7 +88,7 @@ func pollPIDFile(t *testing.T, pidFile string, timeout time.Duration) int {
 		}
 		time.Sleep(20 * time.Millisecond)
 	}
-	t.Fatalf("pollPIDFile(%q): no valid PID after %v", pidFile, timeout)
+	t.Fatalf("pollPIDFile(%q) = no valid PID after %v, want a PID", pidFile, timeout)
 	return 0
 }
 
@@ -82,7 +107,7 @@ func isZombie(pid int) bool {
 
 // assertProcessDead polls until pid is gone (or a zombie) or the timeout
 // expires.
-func assertProcessDead(t *testing.T, pid int, timeout time.Duration) {
+func assertProcessDead(t *testing.T, label string, pid int, timeout time.Duration) {
 	t.Helper()
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
@@ -94,22 +119,49 @@ func assertProcessDead(t *testing.T, pid int, timeout time.Duration) {
 		}
 		time.Sleep(20 * time.Millisecond)
 	}
-	t.Errorf("assertProcessDead: process %d still alive after %v", pid, timeout)
+	t.Errorf("assertProcessDead(%s, %d) = alive after %v, want gone", label, pid, timeout)
+}
+
+// awaitFile polls until path exists or the timeout expires, reporting
+// whether it appeared.
+func awaitFile(t *testing.T, path string, timeout time.Duration) bool {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(path); err == nil {
+			return true
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	return false
+}
+
+// killGroupOnCleanup registers a best-effort force kill of the process
+// group led by pid, so a failing assertion cannot strand the subprocess
+// or its descendants for the rest of the run.
+func killGroupOnCleanup(t *testing.T, pid int) {
+	t.Helper()
+	t.Cleanup(func() {
+		_ = syscall.Kill(-pid, syscall.SIGKILL)
+	})
 }
 
 // TestStartSession_CancelSignalsProcessGroup verifies that cancelling the
-// context passed to StartSession, after the session has already been
-// established, terminates the app-server subprocess through the process
-// group rather than os/exec's default of killing only the direct child, so
-// a descendant the agent spawned does not survive the cancellation.
+// context passed to StartSession, after the session has been established,
+// tears the app-server down through its process group: the group receives
+// a catchable termination signal rather than os/exec's default force kill
+// of the direct child alone, and no descendant survives.
 //
-// Regression test for the defect described in #1013: with neither
-// cmd.Cancel nor cmd.WaitDelay set, a cancelled launch context force-kills
-// only cmd.Process, leaving any descendant it started (here, the "sleep
-// 3600 &" job the fake app-server spawns) running.
+// The load-bearing assertion is the descendant's marker. A descendant can
+// only be reached through the group, and it can only write the marker if
+// the signal was catchable, so the marker fails both when the signal
+// never reaches the group and when it arrives as an uncatchable kill.
+// Asserting only that the descendant is gone would not distinguish the
+// two: the adapter's exit watcher force-kills the group unconditionally
+// once cmd.Wait returns, and that alone reaps the descendant either way.
 //
-// Not run with t.Parallel(): it pins CODEX_API_KEY to empty via t.Setenv so
-// the fake app-server's account/read reply always takes the no-login
+// Not run with t.Parallel(): it pins CODEX_API_KEY to empty via t.Setenv
+// so the fake app-server's account/read reply always takes the no-login
 // branch in authenticateIfNeeded, regardless of the ambient environment,
 // and t.Setenv forbids parallel use.
 func TestStartSession_CancelSignalsProcessGroup(t *testing.T) {
@@ -117,11 +169,13 @@ func TestStartSession_CancelSignalsProcessGroup(t *testing.T) {
 
 	tmpDir := t.TempDir()
 	pidFile := filepath.Join(tmpDir, "descendant.pid")
-	script := writeFakeAppServerScript(t, tmpDir, pidFile)
+	markerFile := filepath.Join(tmpDir, "descendant.terminated")
+	descendant := writeDescendantScript(t, tmpDir, pidFile, markerFile)
+	script := writeFakeAppServerScript(t, tmpDir, descendant)
 
 	adapter, err := NewCodexAdapter(map[string]any{})
 	if err != nil {
-		t.Fatalf("NewCodexAdapter() error = %v", err)
+		t.Fatalf("NewCodexAdapter() error = %v, want nil", err)
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -132,18 +186,22 @@ func TestStartSession_CancelSignalsProcessGroup(t *testing.T) {
 		AgentConfig:   domain.AgentConfig{Command: script},
 	})
 	if err != nil {
-		t.Fatalf("StartSession() error = %v", err)
+		t.Fatalf("StartSession() error = %v, want nil", err)
 	}
 
 	directPID, convErr := strconv.Atoi(session.AgentPID)
 	if convErr != nil {
 		t.Fatalf("session.AgentPID = %q, want a PID: %v", session.AgentPID, convErr)
 	}
+	killGroupOnCleanup(t, directPID)
 
 	descendantPID := pollPIDFile(t, pidFile, 5*time.Second)
 
 	cancel()
 
-	assertProcessDead(t, directPID, 3*time.Second)
-	assertProcessDead(t, descendantPID, 3*time.Second)
+	if !awaitFile(t, markerFile, 5*time.Second) {
+		t.Errorf("cancelling the launch context left %q absent after %v, want the descendant to have caught a graceful signal", markerFile, 5*time.Second)
+	}
+	assertProcessDead(t, "app-server", directPID, 3*time.Second)
+	assertProcessDead(t, "descendant", descendantPID, 3*time.Second)
 }

--- a/internal/agent/codex/codex_unix_test.go
+++ b/internal/agent/codex/codex_unix_test.go
@@ -28,8 +28,10 @@ import (
 func writeDescendantScript(t *testing.T, dir, pidFile, markerFile string) string {
 	t.Helper()
 	content := fmt.Sprintf(
-		"trap 'printf terminated > %s; exit 0' TERM\n"+
-			"printf '%%s\\n' \"$$\" > %s\n"+
+		"MARKER='%s'\n"+
+			"PID_FILE='%s'\n"+
+			"trap 'printf terminated > \"$MARKER\"; exit 0' TERM\n"+
+			"printf '%%s\\n' \"$$\" > \"$PID_FILE\"\n"+
 			"while :; do sleep 1; done\n",
 		markerFile, pidFile,
 	)
@@ -64,7 +66,7 @@ func writeFakeAppServerScript(t *testing.T, dir, descendantScript string) string
 			"read -r _thread_start_req\n"+
 			"printf '{\"id\":3,\"result\":{\"thread\":{\"id\":\"fake-thread-1\"}}}\\n'\n"+
 			"printf '{\"method\":\"thread/started\",\"params\":{}}\\n'\n"+
-			"%s &\n"+
+			"'%s' &\n"+
 			"DESCENDANT_PID=$!\n"+
 			"trap 'wait \"$DESCENDANT_PID\"; exit 0' TERM\n"+
 			"wait \"$DESCENDANT_PID\"\n",

--- a/internal/agent/codex/codex_unix_test.go
+++ b/internal/agent/codex/codex_unix_test.go
@@ -1,0 +1,149 @@
+//go:build linux
+
+package codex
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/sortie-ai/sortie/internal/agent/agenttest"
+	"github.com/sortie-ai/sortie/internal/domain"
+)
+
+// writeFakeAppServerScript creates a script that fakes just enough of the
+// codex app-server JSON-RPC handshake (initialize, account/read,
+// thread/start) for StartSession to succeed, then spawns a long-running
+// grandchild (sleep 3600 &), writes the grandchild's PID to pidFile, and
+// blocks so the session stays "running" until it is signalled.
+//
+// Response ids are hardcoded (1, 2, 3) rather than parsed from the request
+// lines: jsonrpc.Conn allocates ids sequentially starting at 1, and
+// StartSession issues exactly these three calls in this order, so the
+// sequence is deterministic. Using agenttest.WriteScript avoids the
+// ETXTBSY race on Linux.
+func writeFakeAppServerScript(t *testing.T, dir, pidFile string) string {
+	t.Helper()
+	content := fmt.Sprintf(
+		"read -r _init_req\n"+
+			"printf '{\"id\":1,\"result\":{}}\\n'\n"+
+			"read -r _initialized_notif\n"+
+			"read -r _account_read_req\n"+
+			"printf '{\"id\":2,\"result\":{}}\\n'\n"+
+			"read -r _thread_start_req\n"+
+			"printf '{\"id\":3,\"result\":{\"thread\":{\"id\":\"fake-thread-1\"}}}\\n'\n"+
+			"printf '{\"method\":\"thread/started\",\"params\":{}}\\n'\n"+
+			"sleep 3600 &\n"+
+			"CHILD_PID=$!\n"+
+			"printf '%%s\\n' \"$CHILD_PID\" > '%s'\n"+
+			"sleep 3600\n",
+		pidFile,
+	)
+	return agenttest.WriteScript(t, dir, "fake-codex-app-server", content)
+}
+
+// pollPIDFile polls pidFile until it contains a valid positive integer PID,
+// or fails the test after timeout.
+func pollPIDFile(t *testing.T, pidFile string, timeout time.Duration) int {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		data, err := os.ReadFile(pidFile)
+		if err == nil {
+			pid, convErr := strconv.Atoi(strings.TrimSpace(string(data)))
+			if convErr == nil && pid > 0 {
+				return pid
+			}
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("pollPIDFile(%q): no valid PID after %v", pidFile, timeout)
+	return 0
+}
+
+// isZombie reports whether pid is a zombie by reading /proc/<pid>/stat.
+// Returns false if the file cannot be read.
+func isZombie(pid int) bool {
+	data, err := os.ReadFile(fmt.Sprintf("/proc/%d/stat", pid))
+	if err != nil {
+		return false
+	}
+	if i := strings.LastIndex(string(data), ")"); i >= 0 && i+2 < len(data) {
+		return data[i+2] == 'Z'
+	}
+	return false
+}
+
+// assertProcessDead polls until pid is gone (or a zombie) or the timeout
+// expires.
+func assertProcessDead(t *testing.T, pid int, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if err := syscall.Kill(pid, 0); err != nil {
+			return // any error means the process is gone or unreachable
+		}
+		if isZombie(pid) {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Errorf("assertProcessDead: process %d still alive after %v", pid, timeout)
+}
+
+// TestStartSession_CancelSignalsProcessGroup verifies that cancelling the
+// context passed to StartSession, after the session has already been
+// established, terminates the app-server subprocess through the process
+// group rather than os/exec's default of killing only the direct child, so
+// a descendant the agent spawned does not survive the cancellation.
+//
+// Regression test for the defect described in #1013: with neither
+// cmd.Cancel nor cmd.WaitDelay set, a cancelled launch context force-kills
+// only cmd.Process, leaving any descendant it started (here, the "sleep
+// 3600 &" job the fake app-server spawns) running.
+//
+// Not run with t.Parallel(): it pins CODEX_API_KEY to empty via t.Setenv so
+// the fake app-server's account/read reply always takes the no-login
+// branch in authenticateIfNeeded, regardless of the ambient environment,
+// and t.Setenv forbids parallel use.
+func TestStartSession_CancelSignalsProcessGroup(t *testing.T) {
+	t.Setenv("CODEX_API_KEY", "")
+
+	tmpDir := t.TempDir()
+	pidFile := filepath.Join(tmpDir, "descendant.pid")
+	script := writeFakeAppServerScript(t, tmpDir, pidFile)
+
+	adapter, err := NewCodexAdapter(map[string]any{})
+	if err != nil {
+		t.Fatalf("NewCodexAdapter() error = %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	session, err := adapter.StartSession(ctx, domain.StartSessionParams{
+		WorkspacePath: tmpDir,
+		AgentConfig:   domain.AgentConfig{Command: script},
+	})
+	if err != nil {
+		t.Fatalf("StartSession() error = %v", err)
+	}
+
+	directPID, convErr := strconv.Atoi(session.AgentPID)
+	if convErr != nil {
+		t.Fatalf("session.AgentPID = %q, want a PID: %v", session.AgentPID, convErr)
+	}
+
+	descendantPID := pollPIDFile(t, pidFile, 5*time.Second)
+
+	cancel()
+
+	assertProcessDead(t, directPID, 3*time.Second)
+	assertProcessDead(t, descendantPID, 3*time.Second)
+}

--- a/internal/agent/opencode/opencode.go
+++ b/internal/agent/opencode/opencode.go
@@ -225,11 +225,7 @@ func (a *OpenCodeAdapter) RunTurn(ctx context.Context, session domain.Session, p
 		allArgs := append(slices.Clone(state.target.Args), cmdArgs...)
 		cmd = exec.CommandContext(ctx, state.target.Command, allArgs...) //nolint:gosec // args are constructed programmatically
 	}
-	procutil.SetProcessGroup(cmd)
-	cmd.Cancel = func() error {
-		return procutil.SignalGraceful(cmd.Process.Pid)
-	}
-	cmd.WaitDelay = 5 * time.Second
+	procutil.SetGroupCancel(cmd)
 	cmd.Dir = state.target.WorkspacePath
 	cmd.Env = env
 

--- a/internal/agent/procutil/pgid.go
+++ b/internal/agent/procutil/pgid.go
@@ -1,0 +1,26 @@
+package procutil
+
+import "os/exec"
+
+// SetGroupCancel prepares cmd so that cancelling the context it was
+// built with tears down the whole process group rather than the direct
+// child alone. It places cmd in its own process group, sends that group
+// a catchable termination signal when the context is cancelled, and caps
+// the wait that follows at [DefaultStopGrace] before os/exec escalates
+// to a force kill.
+//
+// Call it before [exec.Cmd.Start], on a command created with
+// [exec.CommandContext]: os/exec rejects a cancellation function on a
+// command built without a context.
+//
+// A launcher that skips it inherits os/exec's default, which kills only
+// the direct child and does so uncatchably. A subprocess that flushes
+// state on a clean exit never reaches that path, and every descendant it
+// started outlives the cancellation.
+func SetGroupCancel(cmd *exec.Cmd) {
+	SetProcessGroup(cmd)
+	cmd.Cancel = func() error {
+		return SignalGraceful(cmd.Process.Pid)
+	}
+	cmd.WaitDelay = DefaultStopGrace
+}

--- a/internal/agent/procutil/pgid_test.go
+++ b/internal/agent/procutil/pgid_test.go
@@ -1,0 +1,64 @@
+package procutil
+
+import (
+	"os"
+	"os/exec"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// TestSetGroupCancel_Wiring covers what is observable without starting a
+// process: the command joins its own process group, its cancellation
+// function is no longer os/exec's, and the escalation to a force kill is
+// bounded by the shared grace period.
+//
+// The cancellation function is compared against the default one rather
+// than against nil. exec.CommandContext installs its own Cancel, which
+// kills the direct child alone, so a nil check would pass on a command
+// this helper never touched and prove nothing.
+func TestSetGroupCancel_Wiring(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	defaultCancel := reflect.ValueOf(exec.CommandContext(ctx, os.Args[0]).Cancel).Pointer()
+
+	cmd := exec.CommandContext(ctx, os.Args[0])
+	SetGroupCancel(cmd)
+
+	if cmd.SysProcAttr == nil {
+		t.Error("SetGroupCancel() SysProcAttr = nil, want non-nil (the command must join its own process group)")
+	}
+	if got := reflect.ValueOf(cmd.Cancel).Pointer(); got == defaultCancel {
+		t.Error("SetGroupCancel() Cancel = the os/exec default, want a group-signalling replacement")
+	}
+	if cmd.WaitDelay != DefaultStopGrace {
+		t.Errorf("SetGroupCancel() WaitDelay = %v, want %v", cmd.WaitDelay, DefaultStopGrace)
+	}
+}
+
+// TestSetGroupCancel_RequiresCommandContext pins the precondition the
+// godoc states: os/exec refuses to start a command that carries a Cancel
+// function but was built without a context, so a launcher that reaches
+// for this helper on an exec.Command fails loudly at Start rather than
+// silently losing group teardown.
+func TestSetGroupCancel_RequiresCommandContext(t *testing.T) {
+	t.Parallel()
+
+	// os.Args[0] is the test binary: a path that always resolves, so
+	// Start reaches the Cancel precondition instead of failing earlier
+	// on lookup. It is never executed, because that check returns first.
+	cmd := exec.Command(os.Args[0])
+	SetGroupCancel(cmd)
+
+	err := cmd.Start()
+	if err == nil {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+		t.Fatal("cmd.Start() = nil, want an error for a Cancel function without a context")
+	}
+	if !strings.Contains(err.Error(), "CommandContext") {
+		t.Errorf("cmd.Start() = %v, want an error naming CommandContext", err)
+	}
+}

--- a/internal/agent/procutil/pgid_unix_test.go
+++ b/internal/agent/procutil/pgid_unix_test.go
@@ -152,13 +152,16 @@ func TestSetGroupCancel_CancelReachesDescendant(t *testing.T) {
 	pidFile := filepath.Join(dir, "descendant.pid")
 
 	descendant := writeShellScript(t, dir, "descendant.sh", fmt.Sprintf(
-		"trap 'printf terminated > %s; exit 0' TERM\n"+
-			"printf '%%s\\n' \"$$\" > %s\n"+
+		"MARKER='%s'\n"+
+			"PID_FILE='%s'\n"+
+			"trap 'printf terminated > \"$MARKER\"; exit 0' TERM\n"+
+			"printf '%%s\\n' \"$$\" > \"$PID_FILE\"\n"+
 			"while :; do sleep 1; done\n",
 		marker, pidFile,
 	))
 	leader := writeShellScript(t, dir, "leader.sh", fmt.Sprintf(
-		"/bin/sh %s &\n"+
+		"DESCENDANT='%s'\n"+
+			"/bin/sh \"$DESCENDANT\" &\n"+
 			"DESCENDANT_PID=$!\n"+
 			"trap 'wait \"$DESCENDANT_PID\"; exit 0' TERM\n"+
 			"wait \"$DESCENDANT_PID\"\n",

--- a/internal/agent/procutil/pgid_unix_test.go
+++ b/internal/agent/procutil/pgid_unix_test.go
@@ -3,10 +3,17 @@
 package procutil
 
 import (
+	"context"
+	"fmt"
 	"math"
+	"os"
 	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
 	"syscall"
 	"testing"
+	"time"
 )
 
 func TestSetProcessGroup(t *testing.T) {
@@ -81,5 +88,103 @@ func TestSignalProcessGroup_LiveProcess(t *testing.T) {
 	err := cmd.Wait()
 	if !WasSignaled(err) {
 		t.Errorf("WasSignaled(cmd.Wait()) = false, want true (process should have been terminated by SIGTERM)")
+	}
+}
+
+// writeShellScript writes content to a file under dir and returns its
+// path. The file is never executed directly - callers pass it to
+// /bin/sh as an argument - so it needs no executable bit and cannot hit
+// the ETXTBSY race that direct execution of a just-written file has.
+func writeShellScript(t *testing.T, dir, name, content string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("os.WriteFile(%q) = %v, want nil", path, err)
+	}
+	return path
+}
+
+// pollForPID polls path until it holds a positive integer, returning it.
+func pollForPID(t *testing.T, path string, timeout time.Duration) int {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if data, err := os.ReadFile(path); err == nil {
+			if pid, convErr := strconv.Atoi(strings.TrimSpace(string(data))); convErr == nil && pid > 0 {
+				return pid
+			}
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("pollForPID(%q) = no PID after %v, want a PID", path, timeout)
+	return 0
+}
+
+// pollForFile reports whether path appears before the timeout expires.
+func pollForFile(path string, timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(path); err == nil {
+			return true
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	return false
+}
+
+// TestSetGroupCancel_CancelReachesDescendant verifies that cancelling the
+// context of a command prepared by SetGroupCancel delivers a catchable
+// termination signal to the whole process group, not just to the direct
+// child.
+//
+// The evidence is a marker written by a grandchild from inside its own
+// signal handler. A grandchild is reachable only through the group, and
+// it can only run a handler if the signal was catchable, so the marker
+// distinguishes a group-wide graceful signal from os/exec's default of
+// force-killing the direct child alone. The direct child waits for the
+// grandchild before exiting, so cmd.Wait cannot return until the marker
+// is on disk.
+func TestSetGroupCancel_CancelReachesDescendant(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	marker := filepath.Join(dir, "descendant.terminated")
+	pidFile := filepath.Join(dir, "descendant.pid")
+
+	descendant := writeShellScript(t, dir, "descendant.sh", fmt.Sprintf(
+		"trap 'printf terminated > %s; exit 0' TERM\n"+
+			"printf '%%s\\n' \"$$\" > %s\n"+
+			"while :; do sleep 1; done\n",
+		marker, pidFile,
+	))
+	leader := writeShellScript(t, dir, "leader.sh", fmt.Sprintf(
+		"/bin/sh %s &\n"+
+			"DESCENDANT_PID=$!\n"+
+			"trap 'wait \"$DESCENDANT_PID\"; exit 0' TERM\n"+
+			"wait \"$DESCENDANT_PID\"\n",
+		descendant,
+	))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "/bin/sh", leader)
+	SetGroupCancel(cmd)
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("cmd.Start() = %v, want nil", err)
+	}
+	leaderPID := cmd.Process.Pid
+	t.Cleanup(func() { _ = syscall.Kill(-leaderPID, syscall.SIGKILL) })
+
+	descendantPID := pollForPID(t, pidFile, 5*time.Second)
+
+	cancel()
+	_ = cmd.Wait() //nolint:errcheck // a cancelled command reports the cancellation, not a fault
+
+	if !pollForFile(marker, 5*time.Second) {
+		t.Errorf("SetGroupCancel(): cancelling left %q absent, want the descendant to have caught a graceful signal", marker)
+	}
+	if err := syscall.Kill(descendantPID, 0); err == nil {
+		t.Errorf("SetGroupCancel(): descendant %d still alive after cancellation, want gone", descendantPID)
 	}
 }

--- a/internal/orchestrator/self_review.go
+++ b/internal/orchestrator/self_review.go
@@ -110,22 +110,26 @@ func runSingleVerification(ctx context.Context, command, workspacePath string, t
 
 	cmd := exec.CommandContext(cmdCtx, "sh", "-c", command) //nolint:gosec // command comes from operator-controlled config
 	cmd.Dir = workspacePath
-	procutil.SetProcessGroup(cmd)
+	// The verification command's real work always runs as a grandchild of
+	// this shell, so a cancelled or timed-out run has to be signalled
+	// across the whole group: os/exec's default reaches the shell alone
+	// and leaves the build running. The wait delay this installs also lets
+	// cmd.Wait return when Go's internal I/O goroutines are still blocked
+	// on a pipe read, which they can be on Windows after the subprocess is
+	// killed.
+	procutil.SetGroupCancel(cmd)
 
 	// Use cappedWriter for stdout/stderr instead of StdoutPipe/StderrPipe.
 	// On Windows, ReadFile on a pipe can remain blocked after the subprocess
 	// is killed, causing wg.Wait() to hang before cmd.Wait() is reached.
 	// Assigning direct writers lets Go manage the internal pipe goroutines
-	// and WaitDelay ensures Wait returns even if those goroutines are stuck.
+	// and the wait delay ensures Wait returns even if those goroutines are
+	// stuck.
 	var stdoutBuf, stderrBuf cappedWriter
 	stdoutBuf.max = int(domain.MaxVerificationOutputBytes)
 	stderrBuf.max = int(domain.MaxVerificationOutputBytes)
 	cmd.Stdout = &stdoutBuf
 	cmd.Stderr = &stderrBuf
-
-	// WaitDelay lets cmd.Wait return after process termination even when
-	// internal I/O goroutines are still blocked on pipe reads (Windows).
-	cmd.WaitDelay = 5 * time.Second
 
 	start := time.Now()
 	if err := cmd.Start(); err != nil {
@@ -147,10 +151,14 @@ func runSingleVerification(ctx context.Context, command, workspacePath string, t
 
 	metrics.ObserveSelfReviewVerificationDuration(command, duration.Seconds())
 
+	// os/exec escalates a cancellation to a force kill of the direct child
+	// alone, so reap the group here on every cancelled outcome and not
+	// only on the timeout that reports TimedOut below.
+	if cmdCtx.Err() != nil && cmd.Process != nil {
+		_ = procutil.KillProcessGroup(cmd.Process.Pid)
+	}
+
 	if cmdCtx.Err() == context.DeadlineExceeded {
-		if cmd.Process != nil {
-			_ = procutil.KillProcessGroup(cmd.Process.Pid)
-		}
 		logger.Info("verification command timed out",
 			slog.String("command", command),
 			slog.Int64("duration_ms", duration.Milliseconds()),

--- a/internal/orchestrator/self_review_unix_test.go
+++ b/internal/orchestrator/self_review_unix_test.go
@@ -1,0 +1,105 @@
+//go:build unix
+
+package orchestrator
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/sortie-ai/sortie/internal/domain"
+)
+
+// TestRunVerification_TimeoutSignalsDescendantGroup verifies that a
+// verification command that overruns its timeout is torn down through
+// its process group.
+//
+// A verification command always runs as "sh -c", so the work an operator
+// configures - a build, a test suite - is a grandchild of the shell the
+// orchestrator starts. Killing the shell alone leaves that work running
+// against the workspace after the run has moved on.
+//
+// The evidence is a marker the grandchild writes from its own signal
+// handler: it is reachable only through the group, and it can only run a
+// handler if the signal was catchable. The shell waits for the
+// grandchild inside its own handler, so cmd.Wait cannot return, and the
+// post-wait group reap cannot run, until the marker is on disk.
+func TestRunVerification_TimeoutSignalsDescendantGroup(t *testing.T) {
+	t.Parallel()
+
+	wsPath := t.TempDir()
+	marker := filepath.Join(wsPath, "descendant.terminated")
+	pidFile := filepath.Join(wsPath, "descendant.pid")
+	descendant := filepath.Join(wsPath, "descendant.sh")
+
+	script := fmt.Sprintf(
+		"trap 'printf terminated > %s; exit 0' TERM\n"+
+			"printf '%%s\\n' \"$$\" > %s\n"+
+			"while :; do sleep 1; done\n",
+		marker, pidFile,
+	)
+	if err := os.WriteFile(descendant, []byte(script), 0o600); err != nil {
+		t.Fatalf("os.WriteFile(%q) = %v, want nil", descendant, err)
+	}
+
+	command := fmt.Sprintf(`/bin/sh %s & D=$!; trap 'wait "$D"; exit 0' TERM; wait "$D"`, descendant)
+
+	done := make(chan domain.VerificationResult, 1)
+	go func() {
+		done <- runSingleVerification(context.Background(), command, wsPath, 1000, discardLogger(), &domain.NoopMetrics{})
+	}()
+
+	descendantPID := pollVerificationPID(t, pidFile, 5*time.Second)
+	t.Cleanup(func() { _ = syscall.Kill(descendantPID, syscall.SIGKILL) })
+
+	var result domain.VerificationResult
+	select {
+	case result = <-done:
+	case <-time.After(30 * time.Second):
+		t.Fatal("runSingleVerification did not return within 30s, want a timed-out result")
+	}
+
+	if !result.TimedOut {
+		t.Errorf("runSingleVerification().TimedOut = false, want true")
+	}
+	if !pollVerificationFile(marker, 5*time.Second) {
+		t.Errorf("runSingleVerification() left %q absent, want the descendant to have caught a graceful signal", marker)
+	}
+	if err := syscall.Kill(descendantPID, 0); err == nil {
+		t.Errorf("runSingleVerification() left descendant %d alive, want gone", descendantPID)
+	}
+}
+
+// pollVerificationPID polls path until it holds a positive integer.
+func pollVerificationPID(t *testing.T, path string, timeout time.Duration) int {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if data, err := os.ReadFile(path); err == nil {
+			if pid, convErr := strconv.Atoi(strings.TrimSpace(string(data))); convErr == nil && pid > 0 {
+				return pid
+			}
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("pollVerificationPID(%q) = no PID after %v, want a PID", path, timeout)
+	return 0
+}
+
+// pollVerificationFile reports whether path appears before the timeout.
+func pollVerificationFile(path string, timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(path); err == nil {
+			return true
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	return false
+}

--- a/internal/orchestrator/self_review_unix_test.go
+++ b/internal/orchestrator/self_review_unix_test.go
@@ -39,8 +39,10 @@ func TestRunVerification_TimeoutSignalsDescendantGroup(t *testing.T) {
 	descendant := filepath.Join(wsPath, "descendant.sh")
 
 	script := fmt.Sprintf(
-		"trap 'printf terminated > %s; exit 0' TERM\n"+
-			"printf '%%s\\n' \"$$\" > %s\n"+
+		"MARKER='%s'\n"+
+			"PID_FILE='%s'\n"+
+			"trap 'printf terminated > \"$MARKER\"; exit 0' TERM\n"+
+			"printf '%%s\\n' \"$$\" > \"$PID_FILE\"\n"+
 			"while :; do sleep 1; done\n",
 		marker, pidFile,
 	)
@@ -48,7 +50,7 @@ func TestRunVerification_TimeoutSignalsDescendantGroup(t *testing.T) {
 		t.Fatalf("os.WriteFile(%q) = %v, want nil", descendant, err)
 	}
 
-	command := fmt.Sprintf(`/bin/sh %s & D=$!; trap 'wait "$D"; exit 0' TERM; wait "$D"`, descendant)
+	command := fmt.Sprintf(`DESCENDANT='%s'; /bin/sh "$DESCENDANT" & D=$!; trap 'wait "$D"; exit 0' TERM; wait "$D"`, descendant)
 
 	done := make(chan domain.VerificationResult, 1)
 	go func() {

--- a/internal/workspace/hook_unix.go
+++ b/internal/workspace/hook_unix.go
@@ -7,8 +7,9 @@ import (
 	"errors"
 	"fmt"
 	"os/exec"
-	"syscall"
 	"time"
+
+	"github.com/sortie-ai/sortie/internal/agent/procutil"
 )
 
 // RunHook executes a shell hook script in the specified workspace
@@ -45,15 +46,14 @@ func RunHook(ctx context.Context, params HookParams) (HookResult, error) {
 
 	// Place the shell and all descendants in a new process group so
 	// timeout termination kills the entire tree, not just the shell.
-	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	procutil.SetProcessGroup(cmd)
 
 	// Kill the entire process group when the context expires instead
-	// of only the direct child, preventing orphaned grandchildren.
+	// of only the direct child, preventing orphaned grandchildren. A
+	// hook that overran its timeout has already had its whole budget,
+	// so this path force-kills rather than signalling gracefully first.
 	cmd.Cancel = func() error {
-		if cmd.Process != nil {
-			return syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
-		}
-		return nil
+		return procutil.KillProcessGroup(cmd.Process.Pid)
 	}
 	// Allow child processes time to exit and release I/O pipes after
 	// the group signal before Go forcibly closes pipes.

--- a/internal/workspace/hook_windows.go
+++ b/internal/workspace/hook_windows.go
@@ -16,6 +16,8 @@ import (
 	"unsafe"
 
 	"golang.org/x/sys/windows"
+
+	"github.com/sortie-ai/sortie/internal/agent/procutil"
 )
 
 // statusControlCExit is the Windows NTSTATUS code for
@@ -107,9 +109,8 @@ func RunHook(ctx context.Context, params HookParams) (HookResult, error) {
 
 	cmd := exec.CommandContext(hookCtx, "cmd.exe", "/C", params.Script) //nolint:gosec // G204: hook scripts are from trusted workflow configuration
 	cmd.Dir = params.Dir
-	cmd.SysProcAttr = &syscall.SysProcAttr{
-		CreationFlags: windows.CREATE_NEW_PROCESS_GROUP | windows.CREATE_SUSPENDED,
-	}
+	cmd.SysProcAttr = &syscall.SysProcAttr{CreationFlags: windows.CREATE_SUSPENDED}
+	procutil.SetProcessGroup(cmd)
 	cmd.Env = hookEnv(params.Env)
 
 	buf := &limitedBuffer{max: MaxHookOutputBytes}


### PR DESCRIPTION
## Summary

`StartSession` launches the app-server subprocess via `exec.CommandContext` without setting `cmd.Cancel` or `cmd.WaitDelay`, so a cancelled launch context falls back to os/exec's default of killing only the direct child. The agent gets no chance to exit cleanly, and any descendant it started survives the cancellation.

## Fix

- Set `cmd.Cancel` to signal the whole process group via `procutil.SignalGraceful`, matching the pattern already used by the `claude-code`/`copilot-cli`/`kiro` (fork-per-turn) and `opencode` adapters in `internal/agent/agentcore/forkperturn.go`.
- Set `cmd.WaitDelay` to the same 5-second grace period `StopSession` already waits before escalating to a force-kill, so the two teardown paths behave consistently.
- No other change needed: the existing exit-watcher goroutine (`internal/agent/codex/codex.go`, the `go func() { cmd.Wait(); procutil.KillProcessGroup(...); ... }()` right after the process starts) already does an unconditional best-effort `KillProcessGroup` after `cmd.Wait()` returns, so once `cmd.Wait()` unblocks gracefully the existing cleanup takes it from there.

## Test plan

- Added `internal/agent/codex/codex_unix_test.go` (`//go:build linux`, mirroring the existing `internal/agent/agentcore/forkperturn_unix_test.go` pattern): fakes the minimal app-server JSON-RPC handshake (`initialize`, `account/read`, `thread/start`) so `StartSession` succeeds, has the fake server spawn a detached grandchild (`sleep 3600 &`), then cancels the launch context and asserts both the direct subprocess and the grandchild are gone.
- `go build ./...`, `go vet ./...` clean.
- `golangci-lint run` clean for `GOOS=linux`, `GOOS=darwin`, and `GOOS=windows` on the touched package.
- `go test ./...` passes on Windows except two pre-existing, unrelated failures (`TestWriteReviewSummary_SymlinkRejected`, `TestReadReviewVerdict_SymlinkRejection` in `internal/orchestrator`), caused by Windows requiring elevated privilege to create symlinks — unaffected by this change.
- The new `//go:build linux` test could not be executed locally (Windows dev machine); it type-checks cleanly under `GOOS=linux go vet`/`go build`, and will run for real under this repo's Linux CI.

Fixes #1013.

🤖 Generated with [Claude Code](https://claude.com/claude-code)