### PR TITLE
fix: report an uncallable tool delivery once per session

### DIFF
--- a/docs/agent-client-protocol-adapter-notes.md
+++ b/docs/agent-client-protocol-adapter-notes.md
@@ -22,7 +22,7 @@ The entry point is the `acp` subcommand. The handshake advertises `loadSession` 
 
 The entry point is the `--acp` flag; a `--experimental-acp` spelling also exists and is deprecated. The handshake advertises `loadSession` true and both `mcpCapabilities.http` and `mcpCapabilities.sse` true, and it advertises no `sessionCapabilities` object at all.
 
-This is the one runtime the gated suite was driven against end to end: a session starts, a turn runs to a completed outcome, a `session/request_permission` request arrives mid-turn and the adapter refuses it inside the protocol with the turn continuing past the refusal to completion, and the session stops cleanly afterward.
+This is the one runtime the gated suite was driven against end to end: a session starts, a turn runs to a completed outcome, a `session/request_permission` request arrives mid-turn and the adapter refuses it inside the protocol with the turn continuing past the refusal to completion, and the session stops cleanly afterward. `What a delivered tool server needs to be callable` below states what that refusal means for the tool servers this session delivered.
 
 Session continuation was probed by hand against this runtime, not through the gated suite. `session/load` replays the prior turn's messages, observed as `user_message_chunk` notifications arriving before the load response itself returns, when the workspace directory already carries earlier session history. Against a workspace used for the first time, whose only session was ended by a process-group kill with no graceful phase ahead of it, a reload of that session answers a JSON-RPC error reporting no prior session for the workspace instead of replaying anything; the adapter observes this exactly as it observes any other unconfirmed load, lowering the session continuation entry and falling back to a fresh session without failing the run. That probe predates the graceful phase teardown now runs, and it has not been repeated against it. `session/resume` is not exercised: this runtime advertises no `sessionCapabilities` object at all, so the adapter never selects it.
 
@@ -41,6 +41,14 @@ The Claude Code CLI exposes no protocol entry point in its own help output. Ther
 ### `codex`
 
 Codex exposes no protocol entry point either. Its `app-server` speaks a different JSON-RPC dialect, the one this project's separate `codex` adapter already drives, and that dialect is not the Agent Client Protocol.
+
+## What a delivered tool server needs to be callable
+
+Delivery and discovery are not the question: the session-creation request carries the declaration, and the runtime launches the server and reads its tool list. A runtime that asks the client for consent before invoking a tool gets a refusal, and the tool is not invoked. The protocol's stdio server declaration carries no trust or approval field, so a declared server cannot be marked pre-authorized on the wire. The only lever is the runtime's own configuration, reached through the operator's `agent.command` and whatever configuration that runtime reads: an approval mode that does not ask, or a rule pre-authorizing the tools of the server Sortie declares.
+
+This was measured on `gemini`, the one runtime above the gated suite drives end to end; the other runtimes in these notes are unmeasured on this point, and an absent probe is never read as a measured negative.
+
+When the situation arises, the adapter reports it once per session on two surfaces. The notification reaches the orchestrator's generic event handling and is recorded at `Debug`, its message overwritten by the next message-carrying event. The `Warn` record is the only surface that outlives the run, for as long as the run's log is kept.
 
 ## Verifying a change
 

--- a/docs/agent-client-protocol-adapter-notes.md
+++ b/docs/agent-client-protocol-adapter-notes.md
@@ -48,7 +48,7 @@ Delivery and discovery are not the question: the session-creation request carrie
 
 This was measured on `gemini`, the one runtime above the gated suite drives end to end; the other runtimes in these notes are unmeasured on this point, and an absent probe is never read as a measured negative.
 
-When the situation arises, the adapter reports it once per session on two surfaces. The notification reaches the orchestrator's generic event handling and is recorded at `Debug`, its message overwritten by the next message-carrying event. The `Warn` record is the only surface that outlives the run, for as long as the run's log is kept.
+When the situation arises, the adapter reports it once per session on two surfaces. The notification reaches the orchestrator's generic event handling, which records the event type at `Debug` and carries the message itself nowhere but the running entry's last agent message, where the next message-carrying event overwrites it. The `Warn` record is the only surface that outlives the run, for as long as the run's log is kept.
 
 ## Verifying a change
 

--- a/docs/architecture/10-agent-adapter-contract.md
+++ b/docs/architecture/10-agent-adapter-contract.md
@@ -155,6 +155,10 @@ Policy requirements:
 - Approval requests and user-input-required events MUST NOT leave a run stalled indefinitely. A
   configuration value that would let the agent stop and wait for a person is refused before the
   run, rather than satisfied when it arrives mid-turn.
+- Where an adapter kind delivers the tool-registry execution channel (§10.4.3) per session and
+  its runtime asks for consent before invoking a tool, the refusal makes the delivered tools
+  uncallable, and the adapter reports that once per session rather than letting the turn end as
+  an ordinary success.
 
 Unsupported tool calls:
 

--- a/internal/agent/clientprotocol/harness_test.go
+++ b/internal/agent/clientprotocol/harness_test.go
@@ -39,6 +39,14 @@ func discardLogger() *slog.Logger {
 // itself already ended the stream, so no test leaks the goroutine.
 func newTestSession(t *testing.T, agentConfig domain.AgentConfig, maxLineBytes int) (*sessionState, *io.PipeReader, *io.PipeWriter) {
 	t.Helper()
+	return newTestSessionWithLogger(t, agentConfig, maxLineBytes, discardLogger())
+}
+
+// newTestSessionWithLogger behaves like newTestSession, but wires
+// state's logger to logger instead of one that discards everything,
+// for a test that needs to observe what the pump logs.
+func newTestSessionWithLogger(t *testing.T, agentConfig domain.AgentConfig, maxLineBytes int, logger *slog.Logger) (*sessionState, *io.PipeReader, *io.PipeWriter) {
+	t.Helper()
 
 	outPr, outPw := io.Pipe()
 	inPr, inPw := io.Pipe()
@@ -49,7 +57,7 @@ func newTestSession(t *testing.T, agentConfig domain.AgentConfig, maxLineBytes i
 		itemCh:      make(chan pumpItem, pumpChannelCapacity),
 		stopCh:      make(chan struct{}),
 		pumpDone:    make(chan struct{}),
-		logger:      discardLogger(),
+		logger:      logger,
 	}
 	state.conn = jsonrpc.NewConn(outPw, inPr, pumpHandler(state.itemCh, state.stopCh),
 		jsonrpc.WithVersionMember(), jsonrpc.WithMaxLineBytes(maxLineBytes))

--- a/internal/agent/clientprotocol/permission_test.go
+++ b/internal/agent/clientprotocol/permission_test.go
@@ -1,8 +1,11 @@
 package clientprotocol
 
 import (
+	"bytes"
 	"fmt"
+	"log/slog"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/sortie-ai/sortie/internal/agent/agentcore"
@@ -203,4 +206,293 @@ func TestPermissionRequestSelectsRefusingOption(t *testing.T) {
 	if !reflect.DeepEqual(gotNotice, wantNotice) {
 		t.Errorf("permission refusal notification = %+v, want shared emitter shape %+v", gotNotice, wantNotice)
 	}
+}
+
+// permissionRequestLine builds a session/request_permission wire line
+// naming id and options, for a session already marked known under
+// "sess-test".
+func permissionRequestLine(id, options string) string {
+	return fmt.Sprintf(
+		`{"jsonrpc":"2.0","id":%s,"method":"session/request_permission","params":{"sessionId":"sess-test","options":%s,"toolCall":{"toolCallId":"tc-1","title":"do a thing"}}}`,
+		id, options)
+}
+
+// countToolDeliveryNotifications reports how many events in events are
+// an EventNotification carrying toolDeliveryUncallableNotice.
+func countToolDeliveryNotifications(events []domain.AgentEvent) int {
+	var n int
+	for _, e := range events {
+		if e.Type == domain.EventNotification && e.Message == toolDeliveryUncallableNotice {
+			n++
+		}
+	}
+	return n
+}
+
+// TestToolDeliveryReportedOnceThenLatched confirms a session that
+// delivered tool servers reports the uncallable-tool notice on the
+// first permission request a refusal posture answers, and that a
+// second such request in the same turn does not repeat it. The
+// session's own capability record is untouched by this reporting
+// path: toolServers is reported strictly through the once-per-session
+// capability gap notice, a distinct mechanism this handshake leaves at
+// its stage-one state.
+func TestToolDeliveryReportedOnceThenLatched(t *testing.T) {
+	t.Parallel()
+
+	state, outPr, inPw := newTestSession(t, domain.AgentConfig{ReadTimeoutMS: 2000}, clientProtocolMaxLineBytes)
+	out := newOutboundReader(outPr)
+	state.itemCh <- pumpItem{control: &pumpControl{handshake: &handshakeFacts{toolServersDelivered: true}}}
+	markSessionKnown(state)
+
+	var events []domain.AgentEvent
+	outcomeCh := runTurnAsync(state, domain.RunTurnParams{Prompt: "do something", OnEvent: collectEvents(&events)})
+	promptID := out.awaitMethod(t, methodSessionPrompt)
+
+	sendLine(t, inPw, permissionRequestLine(`"perm-1"`, `[{"kind":"reject_once","name":"reject","optionId":"reject-id-1"}]`))
+	out.next(t)
+	sendLine(t, inPw, permissionRequestLine(`"perm-2"`, `[{"kind":"reject_once","name":"reject","optionId":"reject-id-2"}]`))
+	out.next(t)
+
+	respondLine(t, inPw, promptID, promptResponse{StopReason: stopReasonEndTurn})
+	outcome := awaitOutcome(t, outcomeCh)
+	if outcome.err != nil {
+		t.Fatalf("RunTurn() error = %v, want nil", outcome.err)
+	}
+
+	if got := countToolDeliveryNotifications(events); got != 1 {
+		t.Errorf("tool delivery uncallable notifications across two permission requests = %d, want 1", got)
+	}
+	if state.caps.toolServers != capabilityProtocol {
+		t.Errorf("caps.toolServers after the report = %q, want %q: this handshake never withholds tool servers", state.caps.toolServers, capabilityProtocol)
+	}
+}
+
+// TestToolDeliveryReportLogsWarnRecord confirms the uncallable-tool
+// report's Warn record carries exactly the message and the one
+// reason=permission_refused attribute the plan specifies, with no
+// other attribute attached.
+func TestToolDeliveryReportLogsWarnRecord(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	state, outPr, inPw := newTestSessionWithLogger(t, domain.AgentConfig{ReadTimeoutMS: 2000}, clientProtocolMaxLineBytes, logger)
+	out := newOutboundReader(outPr)
+	state.itemCh <- pumpItem{control: &pumpControl{handshake: &handshakeFacts{toolServersDelivered: true}}}
+	markSessionKnown(state)
+
+	outcomeCh := runTurnAsync(state, domain.RunTurnParams{Prompt: "do something", OnEvent: func(domain.AgentEvent) {}})
+	promptID := out.awaitMethod(t, methodSessionPrompt)
+
+	sendLine(t, inPw, permissionRequestLine(`"perm-1"`, `[{"kind":"reject_once","name":"reject","optionId":"reject-id"}]`))
+	out.next(t)
+
+	respondLine(t, inPw, promptID, promptResponse{StopReason: stopReasonEndTurn})
+	outcome := awaitOutcome(t, outcomeCh)
+	if outcome.err != nil {
+		t.Fatalf("RunTurn() error = %v, want nil", outcome.err)
+	}
+
+	var warnLines []string
+	for line := range strings.SplitSeq(strings.TrimRight(buf.String(), "\n"), "\n") {
+		if strings.Contains(line, "level=WARN") {
+			warnLines = append(warnLines, line)
+		}
+	}
+	if len(warnLines) != 1 {
+		t.Fatalf("Warn records logged = %d, want 1: %v", len(warnLines), warnLines)
+	}
+	warnLine := warnLines[0]
+	if !strings.Contains(warnLine, `msg="`+toolDeliveryUncallableLog+`"`) {
+		t.Errorf("Warn record = %q, want msg %q", warnLine, toolDeliveryUncallableLog)
+	}
+	if !strings.Contains(warnLine, "reason=permission_refused") {
+		t.Errorf("Warn record = %q, want attribute reason=permission_refused", warnLine)
+	}
+	if got := strings.Count(warnLine, "="); got != 4 {
+		t.Errorf("Warn record %q carries %d key=value fields, want 4 (time, level, msg, reason): exactly one attribute besides the standard record fields", warnLine, got)
+	}
+}
+
+// TestToolDeliveryReportCoversBothPostureArms confirms the
+// uncallable-tool report fires exactly once whether the permission
+// request offers a refusing option or not, covering both the option
+// list TestPermissionRequestSelectsRefusingOption exercises and the
+// two option-list shapes TestPermissionRequestNoRefusingOptionEndsAttempt
+// exercises for the arm with no refusing option.
+func TestToolDeliveryReportCoversBothPostureArms(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		options string
+	}{
+		{"a refusing kind offered", `[{"kind":"reject_once","name":"reject","optionId":"reject-id"}]`},
+		{"no refusing kind offered: only allowing kinds", `[{"kind":"allow_once","name":"allow","optionId":"allow-id"},{"kind":"allow_always","name":"allow-always","optionId":"allow-always-id"}]`},
+		{"no refusing kind offered: empty option list", `[]`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var buf bytes.Buffer
+			logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+			state, outPr, inPw := newTestSessionWithLogger(t, domain.AgentConfig{ReadTimeoutMS: 2000}, clientProtocolMaxLineBytes, logger)
+			out := newOutboundReader(outPr)
+			state.itemCh <- pumpItem{control: &pumpControl{handshake: &handshakeFacts{toolServersDelivered: true}}}
+			markSessionKnown(state)
+
+			var events []domain.AgentEvent
+			outcomeCh := runTurnAsync(state, domain.RunTurnParams{Prompt: "do something", OnEvent: collectEvents(&events)})
+			promptID := out.awaitMethod(t, methodSessionPrompt)
+
+			sendLine(t, inPw, permissionRequestLine("9", tt.options))
+			out.next(t)
+
+			respondLine(t, inPw, promptID, promptResponse{StopReason: stopReasonEndTurn})
+			awaitOutcome(t, outcomeCh)
+
+			if got := countToolDeliveryNotifications(events); got != 1 {
+				t.Errorf("tool delivery uncallable notifications = %d, want 1", got)
+			}
+			if got := strings.Count(buf.String(), toolDeliveryUncallableLog); got != 1 {
+				t.Errorf("tool delivery uncallable Warn records = %d, want 1: %s", got, buf.String())
+			}
+		})
+	}
+}
+
+// TestNoToolDeliveryReportWhenNoToolServersDelivered confirms a
+// session that never delivered a tool server produces neither the
+// notice nor the Warn record, for either posture arm, because
+// reportUncallableToolDelivery returns immediately when
+// toolServersDelivered is false.
+func TestNoToolDeliveryReportWhenNoToolServersDelivered(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		options string
+	}{
+		{"a refusing kind offered", `[{"kind":"reject_once","name":"reject","optionId":"reject-id"}]`},
+		{"no refusing kind offered", `[]`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var buf bytes.Buffer
+			logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+			state, outPr, inPw := newTestSessionWithLogger(t, domain.AgentConfig{ReadTimeoutMS: 2000}, clientProtocolMaxLineBytes, logger)
+			out := newOutboundReader(outPr)
+			markSessionKnown(state)
+
+			var events []domain.AgentEvent
+			outcomeCh := runTurnAsync(state, domain.RunTurnParams{Prompt: "do something", OnEvent: collectEvents(&events)})
+			promptID := out.awaitMethod(t, methodSessionPrompt)
+
+			sendLine(t, inPw, permissionRequestLine("9", tt.options))
+			out.next(t)
+
+			respondLine(t, inPw, promptID, promptResponse{StopReason: stopReasonEndTurn})
+			awaitOutcome(t, outcomeCh)
+
+			if got := countToolDeliveryNotifications(events); got != 0 {
+				t.Errorf("tool delivery uncallable notifications with no tool servers delivered = %d, want 0", got)
+			}
+			if strings.Contains(buf.String(), toolDeliveryUncallableLog) {
+				t.Errorf("unexpected tool delivery uncallable Warn record with no tool servers delivered: %s", buf.String())
+			}
+		})
+	}
+}
+
+// assertAdjacentNotifications fails t unless events contains an
+// EventNotification carrying ownNotice immediately followed by an
+// EventNotification carrying deliveryNotice, with nothing between
+// them.
+func assertAdjacentNotifications(t *testing.T, events []domain.AgentEvent, ownNotice, deliveryNotice string) {
+	t.Helper()
+	for i, e := range events {
+		if e.Type != domain.EventNotification || e.Message != ownNotice {
+			continue
+		}
+		if i+1 >= len(events) {
+			t.Fatalf("the posture's own notice %q is the last event in %+v, want the uncallable-tool notice right after it", ownNotice, events)
+		}
+		next := events[i+1]
+		if next.Type != domain.EventNotification || next.Message != deliveryNotice {
+			t.Fatalf("event immediately after the posture's own notice = %+v, want an %q notification carrying %q", next, domain.EventNotification, deliveryNotice)
+		}
+		return
+	}
+	t.Fatalf("no event in %+v carries the posture's own notice %q", events, ownNotice)
+}
+
+// TestToolDeliveryNoticeOrderAndStemExclusion confirms the
+// uncallable-tool notice is published immediately after the posture's
+// own notice, with nothing between them, whether the pair is
+// published into an active turn or queued out-of-turn and flushed
+// into the next turn's sink.
+func TestToolDeliveryNoticeOrderAndStemExclusion(t *testing.T) {
+	t.Parallel()
+
+	ownNotice := agentcore.DecideHumanRequest(agentcore.ClassPermission, true, agentcore.AnswerPending).NoticeWithDetail("")
+
+	t.Run("published into an active turn", func(t *testing.T) {
+		t.Parallel()
+
+		state, outPr, inPw := newTestSession(t, domain.AgentConfig{ReadTimeoutMS: 2000}, clientProtocolMaxLineBytes)
+		out := newOutboundReader(outPr)
+		state.itemCh <- pumpItem{control: &pumpControl{handshake: &handshakeFacts{toolServersDelivered: true}}}
+		markSessionKnown(state)
+
+		var events []domain.AgentEvent
+		outcomeCh := runTurnAsync(state, domain.RunTurnParams{Prompt: "do something", OnEvent: collectEvents(&events)})
+		promptID := out.awaitMethod(t, methodSessionPrompt)
+
+		sendLine(t, inPw, permissionRequestLine(`"perm-1"`, `[{"kind":"reject_once","name":"reject","optionId":"reject-id"}]`))
+		out.next(t)
+
+		respondLine(t, inPw, promptID, promptResponse{StopReason: stopReasonEndTurn})
+		outcome := awaitOutcome(t, outcomeCh)
+		if outcome.err != nil {
+			t.Fatalf("RunTurn() error = %v, want nil", outcome.err)
+		}
+
+		assertAdjacentNotifications(t, events, ownNotice, toolDeliveryUncallableNotice)
+	})
+
+	// This mirrors TestSessionUpdateBeforeAnyPromptNotLost's
+	// queue-then-flush pattern: the permission request is answered,
+	// and both notices are queued, before any turn exists, and both
+	// must survive the flush in the same relative order.
+	t.Run("queued out-of-turn then flushed into the next turn", func(t *testing.T) {
+		t.Parallel()
+
+		state, outPr, inPw := newTestSession(t, domain.AgentConfig{}, clientProtocolMaxLineBytes)
+		out := newOutboundReader(outPr)
+		markSessionKnown(state)
+		state.itemCh <- pumpItem{control: &pumpControl{handshake: &handshakeFacts{toolServersDelivered: true}}}
+
+		sendLine(t, inPw, permissionRequestLine(`"perm-1"`, `[{"kind":"reject_once","name":"reject","optionId":"reject-id"}]`))
+		out.next(t)
+
+		var events []domain.AgentEvent
+		outcomeCh := runTurnAsync(state, domain.RunTurnParams{Prompt: "go", OnEvent: collectEvents(&events)})
+		promptID := out.awaitMethod(t, methodSessionPrompt)
+		respondLine(t, inPw, promptID, promptResponse{StopReason: stopReasonEndTurn})
+		outcome := awaitOutcome(t, outcomeCh)
+		if outcome.err != nil {
+			t.Fatalf("RunTurn() error = %v, want nil", outcome.err)
+		}
+
+		if len(events) == 0 || events[0].Type != domain.EventSessionStarted {
+			t.Fatalf("first event = %+v, want %q", events, domain.EventSessionStarted)
+		}
+		assertAdjacentNotifications(t, events, ownNotice, toolDeliveryUncallableNotice)
+	})
 }

--- a/internal/agent/clientprotocol/pump.go
+++ b/internal/agent/clientprotocol/pump.go
@@ -29,6 +29,8 @@ const (
 	elicitationDetail                = "an answer to a question"
 	turnAlreadyInFlightMessage       = "a turn is already in flight for this session"
 	sessionEndedBeforeTurnMessage    = "the agent connection ended before this turn could start"
+	toolDeliveryUncallableNotice     = "this session delivered tool servers and the agent runtime asked for consent before running a tool; an unattended run grants no consent, so any delivered tool the runtime gates the same way cannot be called unless that runtime's own configuration allows it"
+	toolDeliveryUncallableLog        = "a tool call was gated by consent in a session that delivered tool servers"
 )
 
 // jsonrpcMethodNotFound is the JSON-RPC error code for a method the
@@ -101,6 +103,16 @@ type pumpState struct {
 	// session's first turn. A lowering observed after that point is
 	// logged at warn level instead of producing a second notice.
 	capabilityNoticeSent bool
+
+	// toolServersDelivered mirrors the handshake fact for the session:
+	// whether the session-creation request carried at least one tool
+	// server.
+	toolServersDelivered bool
+
+	// toolDeliveryReported latches the once-per-session uncallable-tool
+	// report so a later permission request in the same session does not
+	// repeat it.
+	toolDeliveryReported bool
 
 	// openRequests records the request the pump is answering while it is
 	// answering it. The pump answers each request inside the call that
@@ -211,6 +223,7 @@ func (p *pumpState) handleControl(ctrl pumpControl) {
 		p.agentInfo = ctrl.handshake.agentInfo
 		p.agentInfoPresent = ctrl.handshake.agentInfoPresent
 		p.caps = ctrl.handshake.caps
+		p.toolServersDelivered = ctrl.handshake.toolServersDelivered
 		p.applyHandshakeCapabilityLowering(ctrl.handshake)
 
 	case ctrl.sessionID != "":
@@ -741,6 +754,8 @@ func (p *pumpState) handlePermissionRequest(msg *jsonrpc.Message) {
 		agentcore.EmitNotification(p.emitOrQueue, posture.NoticeWithDetail(""))
 	}
 
+	p.reportUncallableToolDelivery()
+
 	if posture.Transmit {
 		p.respondSelected(msg.ID, optionID)
 	} else {
@@ -750,6 +765,24 @@ func (p *pumpState) handlePermissionRequest(msg *jsonrpc.Message) {
 	if posture.EndAttempt {
 		p.latchOrBeginEndAttempt("")
 	}
+}
+
+// reportUncallableToolDelivery reports, once per session, that a session
+// which delivered tool servers has met a permission request the shared
+// refusal posture answered, so any delivered tool the runtime gates the
+// same way cannot be called. It does nothing when the session delivered
+// no tool server or has already reported this.
+func (p *pumpState) reportUncallableToolDelivery() {
+	if !p.toolServersDelivered {
+		return
+	}
+	if p.toolDeliveryReported {
+		return
+	}
+	p.toolDeliveryReported = true
+
+	agentcore.EmitNotification(p.emitOrQueue, toolDeliveryUncallableNotice)
+	p.state.logger.Warn(toolDeliveryUncallableLog, slog.String("reason", "permission_refused"))
 }
 
 // answerMethodNotFound answers any request naming a method this client

--- a/internal/agent/clientprotocol/pump_test.go
+++ b/internal/agent/clientprotocol/pump_test.go
@@ -1,16 +1,22 @@
 package clientprotocol
 
 import (
+	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"go/ast"
 	"go/parser"
 	"go/token"
+	"io"
+	"log/slog"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/sortie-ai/sortie/internal/agent/agentcore"
 	"github.com/sortie-ai/sortie/internal/agent/agenttest/dispositiontest"
+	"github.com/sortie-ai/sortie/internal/agent/jsonrpc"
 	"github.com/sortie-ai/sortie/internal/domain"
 )
 
@@ -292,5 +298,141 @@ func TestAnsweredIDEcho(t *testing.T) {
 				t.Errorf("response = %+v, want a %d error for an unimplemented method", resp, jsonrpcMethodNotFound)
 			}
 		})
+	}
+}
+
+// TestToolDeliveryReportSkippedDuringWindDownAndTeardown confirms the
+// uncallable-tool report never fires for a permission request answered
+// by a path other than handlePermissionRequest's own non-winding-down
+// branch: neither a request a winding-down turn cancels immediately,
+// nor one teardown's handleAnswerOpen answers directly.
+func TestToolDeliveryReportSkippedDuringWindDownAndTeardown(t *testing.T) {
+	t.Parallel()
+
+	t.Run("a turn winding down toward cancellation answers a permission request without reporting", func(t *testing.T) {
+		t.Parallel()
+
+		var buf bytes.Buffer
+		logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+		state, outPr, inPw := newTestSessionWithLogger(t, domain.AgentConfig{ReadTimeoutMS: 2000}, clientProtocolMaxLineBytes, logger)
+		out := newOutboundReader(outPr)
+		state.itemCh <- pumpItem{control: &pumpControl{handshake: &handshakeFacts{toolServersDelivered: true}}}
+		markSessionKnown(state)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		var events []domain.AgentEvent
+		outcomeCh := runTurnAsyncCtx(ctx, state, domain.RunTurnParams{Prompt: "go", OnEvent: collectEvents(&events)})
+
+		promptID := out.awaitMethod(t, methodSessionPrompt)
+		cancel()
+		out.awaitMethod(t, methodSessionCancel)
+
+		sendLine(t, inPw, `{"jsonrpc":"2.0","id":"perm-1","method":"session/request_permission","params":{"sessionId":"sess-test","options":[{"kind":"reject_once","name":"reject","optionId":"reject-id"}],"toolCall":{"toolCallId":"tc-1","title":"do a thing"}}}`)
+
+		respLine := out.next(t)
+		resp := decodeResponse(t, respLine)
+		if resp.Result.Outcome.Outcome != outcomeCancelled {
+			t.Errorf("permission reply outcome during wind-down = %q, want %q", resp.Result.Outcome.Outcome, outcomeCancelled)
+		}
+
+		respondLine(t, inPw, promptID, promptResponse{StopReason: stopReasonCancelled})
+		awaitOutcome(t, outcomeCh)
+
+		if got := countToolDeliveryNotifications(events); got != 0 {
+			t.Errorf("tool delivery uncallable notifications during wind-down = %d, want 0", got)
+		}
+		if strings.Contains(buf.String(), toolDeliveryUncallableLog) {
+			t.Errorf("unexpected tool delivery uncallable Warn record during wind-down: %s", buf.String())
+		}
+	})
+
+	// openRequests holds an entry only for the duration of the
+	// handlePermissionRequest (or answerMethodNotFound) call that
+	// created it: both delete their own entry via defer before
+	// returning, and the pump processes one item from its input
+	// channel to completion before the next, so a live pump driven
+	// only through that channel can never observe handleAnswerOpen's
+	// defensive walk find anything but an empty map (see pump.go's own
+	// "ordinary case" comment on handleAnswerOpen). Proving
+	// handleAnswerOpen's own cancellation path never reports therefore
+	// needs a pumpState with a still-open entry constructed directly,
+	// the same way newPumpForCapabilityTests in capability_test.go
+	// exercises a pump method in isolation from a live pump goroutine.
+	t.Run("handleAnswerOpen answers a still-open permission request without reporting", func(t *testing.T) {
+		t.Parallel()
+
+		outPr, outPw := io.Pipe()
+		inPr, _ := io.Pipe()
+		var buf bytes.Buffer
+		state := &sessionState{
+			caps:   newCapabilityRecord(false),
+			itemCh: make(chan pumpItem, pumpChannelCapacity),
+			stopCh: make(chan struct{}),
+			logger: slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})),
+		}
+		state.conn = jsonrpc.NewConn(outPw, inPr, pumpHandler(state.itemCh, state.stopCh),
+			jsonrpc.WithVersionMember(), jsonrpc.WithMaxLineBytes(clientProtocolMaxLineBytes))
+		t.Cleanup(func() {
+			_ = outPr.Close()
+			_ = outPw.Close()
+			_ = inPr.Close()
+		})
+		go func() { _, _ = io.Copy(io.Discard, outPr) }()
+
+		p := &pumpState{
+			state:                state,
+			toolServersDelivered: true,
+			openRequests:         map[jsonrpc.ID]string{jsonrpc.NumberID(1): methodSessionRequestPermission},
+		}
+
+		p.handleAnswerOpen()
+
+		if len(p.openRequests) != 0 {
+			t.Errorf("openRequests after handleAnswerOpen() = %+v, want empty", p.openRequests)
+		}
+		if len(p.queued) != 0 {
+			t.Errorf("events queued by handleAnswerOpen() = %+v, want none", p.queued)
+		}
+		if strings.Contains(buf.String(), toolDeliveryUncallableLog) {
+			t.Errorf("unexpected tool delivery uncallable Warn record from handleAnswerOpen(): %s", buf.String())
+		}
+	})
+}
+
+// TestHandshakeToolServersDeliveredReachesPump confirms
+// toolServersDelivered reaches pumpState only through the handshake
+// control message handleControl applies, not from a value set on the
+// struct some other way: publishing that control message directly is
+// enough, on its own, for a later permission request to trigger the
+// uncallable-tool report.
+func TestHandshakeToolServersDeliveredReachesPump(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	state, outPr, inPw := newTestSessionWithLogger(t, domain.AgentConfig{ReadTimeoutMS: 2000}, clientProtocolMaxLineBytes, logger)
+	out := newOutboundReader(outPr)
+
+	state.itemCh <- pumpItem{control: &pumpControl{handshake: &handshakeFacts{toolServersDelivered: true}}}
+	markSessionKnown(state)
+
+	var events []domain.AgentEvent
+	outcomeCh := runTurnAsync(state, domain.RunTurnParams{Prompt: "go", OnEvent: collectEvents(&events)})
+	promptID := out.awaitMethod(t, methodSessionPrompt)
+
+	sendLine(t, inPw, `{"jsonrpc":"2.0","id":"perm-1","method":"session/request_permission","params":{"sessionId":"sess-test","options":[{"kind":"reject_once","name":"reject","optionId":"reject-id"}],"toolCall":{"toolCallId":"tc-1","title":"do a thing"}}}`)
+	out.next(t)
+
+	respondLine(t, inPw, promptID, promptResponse{StopReason: stopReasonEndTurn})
+	outcome := awaitOutcome(t, outcomeCh)
+	if outcome.err != nil {
+		t.Fatalf("RunTurn() error = %v, want nil", outcome.err)
+	}
+
+	if got := countToolDeliveryNotifications(events); got != 1 {
+		t.Errorf("tool delivery uncallable notifications = %d, want 1", got)
+	}
+	if !strings.Contains(buf.String(), toolDeliveryUncallableLog) {
+		t.Errorf("log output missing %q: %s", toolDeliveryUncallableLog, buf.String())
 	}
 }

--- a/internal/agent/clientprotocol/pump_test.go
+++ b/internal/agent/clientprotocol/pump_test.go
@@ -320,6 +320,7 @@ func TestToolDeliveryReportSkippedDuringWindDownAndTeardown(t *testing.T) {
 		markSessionKnown(state)
 
 		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
 		var events []domain.AgentEvent
 		outcomeCh := runTurnAsyncCtx(ctx, state, domain.RunTurnParams{Prompt: "go", OnEvent: collectEvents(&events)})
 

--- a/internal/agent/clientprotocol/session.go
+++ b/internal/agent/clientprotocol/session.go
@@ -130,6 +130,10 @@ type handshakeFacts struct {
 	// declared an HTTP tool server that this handshake's advertised MCP
 	// capabilities do not support, so it was omitted from session/new.
 	toolServersWithheld bool
+
+	// toolServersDelivered reports whether the session-creation request
+	// carried at least one tool server.
+	toolServersDelivered bool
 }
 
 // turnStart is what RunTurn publishes to start one turn.
@@ -297,7 +301,7 @@ func startSession(ctx context.Context, params domain.StartSessionParams) (domain
 		return domain.Session{}, agentErr
 	}
 
-	facts := &handshakeFacts{toolServersWithheld: withheld, caps: caps}
+	facts := &handshakeFacts{toolServersWithheld: withheld, toolServersDelivered: len(wireServers) > 0, caps: caps}
 	if initResp.AgentInfo != nil {
 		facts.agentInfo = *initResp.AgentInfo
 		facts.agentInfoPresent = true

--- a/internal/agent/clientprotocol/tool_delivery_unix_test.go
+++ b/internal/agent/clientprotocol/tool_delivery_unix_test.go
@@ -1,0 +1,27 @@
+//go:build unix
+
+package clientprotocol
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestToolDeliveryUncallableNoticeExcludesGeminiRefusalStems confirms
+// the uncallable-tool notice never carries either stem a Gemini
+// permission-refusal notice carries, so an operator reading the two
+// notices side by side never mistakes one for the other. This lives
+// behind the unix build tag because geminiPermissionNoticeStem and
+// geminiPermissionUnansweredStem are declared in a unix-only file;
+// permission_test.go carries no build constraint and must stay
+// buildable on every GOOS.
+func TestToolDeliveryUncallableNoticeExcludesGeminiRefusalStems(t *testing.T) {
+	t.Parallel()
+
+	if strings.Contains(toolDeliveryUncallableNotice, geminiPermissionNoticeStem) {
+		t.Errorf("toolDeliveryUncallableNotice = %q, must not contain %q", toolDeliveryUncallableNotice, geminiPermissionNoticeStem)
+	}
+	if strings.Contains(toolDeliveryUncallableNotice, geminiPermissionUnansweredStem) {
+		t.Errorf("toolDeliveryUncallableNotice = %q, must not contain %q", toolDeliveryUncallableNotice, geminiPermissionUnansweredStem)
+	}
+}


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Fix

**Intent:** An `agent-client-protocol` session that delivers a tool server to a runtime gating tool calls behind consent can never get that server called, because the adapter refuses every permission request by contract. The turn still ends with an ordinary stop reason and no adapter error, so a run that called nothing is recorded as an unremarkable success. This adds a once-per-session report so the operator learns the delivered tools were uncallable instead of reading a silent, empty success.

**Related Issues:** #1026

### 🧭 Reviewer Guide

**Complexity:** Medium

#### Entry Point

`internal/agent/clientprotocol/pump.go` - `reportUncallableToolDelivery` is the new behavior: it fires from `handlePermissionRequest` once per session, gated on a new `toolServersDelivered` flag (set from the handshake facts in `internal/agent/clientprotocol/session.go`, based on whether `session/new` carried at least one tool server) and latched by `toolDeliveryReported` so a session that hits multiple refused permission requests only reports once. It emits a notification through the existing `agentcore.EmitNotification` path and a `Warn` log line.

#### Sensitive Areas

- `internal/agent/clientprotocol/pump.go`: the report must fire only when the session actually delivered a tool server, and only once - review the two guard flags (`toolServersDelivered`, `toolDeliveryReported`) and where they are set.
- `docs/architecture/10-agent-adapter-contract.md`: adds a policy bullet for any adapter kind delivering the tool-registry execution channel; this is the contract other adapter kinds are held to, not adapter-local behavior.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes
- **Migrations/State:** No migrations or state changes