### PR TITLE
fix: space the continuation recall past the creation minute

### DIFF
--- a/internal/agent/clientprotocol/gemini_qualification_capability_probes_unix_test.go
+++ b/internal/agent/clientprotocol/gemini_qualification_capability_probes_unix_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"reflect"
 	"slices"
 	"strings"
 	"sync"
@@ -23,12 +24,6 @@ import (
 // geminiIdentityLogDeadline bounds the deterministic wait for the
 // structured implementation log record the pump writes.
 const geminiIdentityLogDeadline = 5 * time.Second
-
-const (
-	geminiRecallUnobservedActual     = "unobserved_actual_session"
-	geminiRecallConfirmedSameSession = "confirmed_same_session"
-	geminiRecallFreshFallback        = "fresh_session_fallback"
-)
 
 // geminiTokenSource is one token-bearing path observed on one surface:
 // a standard usage member, a terminal usage field, or a vendor
@@ -358,20 +353,27 @@ type geminiContinuationRelation struct {
 	SeedSessionID   string
 	RecallSessionID string
 	ReplayConfirmed bool
+	// PreconditionUnmet reports that the probe stopped before the
+	// recall because it could not establish the recall's precondition.
+	PreconditionUnmet bool
 }
 
 // geminiRecallDetail maps one continuation relation onto the closed
-// recall detail set: equal non-null actual and prior ids with confirmed
-// replay are a same-session confirmation, a distinct non-null actual id
-// is a fresh fallback, and an unobserved actual id stays unobserved.
+// recall detail set: a precondition failure stops the probe before it
+// ever tries the recall, equal non-null actual and prior ids with
+// confirmed replay are a same-session confirmation, a distinct
+// non-null actual id is a fresh fallback, and an unobserved actual id
+// stays unobserved.
 func geminiRecallDetail(relation geminiContinuationRelation) (detail string, classification qualification.Grade) {
 	switch {
+	case relation.PreconditionUnmet:
+		return qualification.RecallPreconditionUnmet, qualification.GradeNotObserved
 	case relation.RecallSessionID == "":
-		return geminiRecallUnobservedActual, qualification.GradeNotObserved
+		return qualification.RecallUnobservedActual, qualification.GradeNotObserved
 	case relation.RecallSessionID == relation.SeedSessionID && relation.ReplayConfirmed:
-		return geminiRecallConfirmedSameSession, qualification.GradeUsable
+		return qualification.RecallConfirmedSameSession, qualification.GradeUsable
 	default:
-		return geminiRecallFreshFallback, qualification.GradeGap
+		return qualification.RecallFreshFallback, qualification.GradeGap
 	}
 }
 
@@ -414,12 +416,14 @@ func geminiBuildContinuationRecords(relation geminiContinuationRelation) (seed, 
 	recall.Detail = detail
 	recall.Grade = classification
 	switch detail {
-	case geminiRecallConfirmedSameSession:
+	case qualification.RecallConfirmedSameSession:
 		recall.Outcome = qualification.OutcomePass
 		recall.SessionID = new(relation.RecallSessionID)
-	case geminiRecallFreshFallback:
+	case qualification.RecallFreshFallback:
 		recall.Outcome = qualification.OutcomePass
 		recall.SessionID = new(relation.RecallSessionID)
+	case qualification.RecallPreconditionUnmet:
+		recall.Outcome = qualification.OutcomePrerequisiteFailed
 	default:
 		recall.Outcome = qualification.OutcomeNotObserved
 	}
@@ -451,7 +455,7 @@ func TestGeminiContinuationRelationBuilder(t *testing.T) {
 		if seed.PriorSessionID != nil {
 			t.Errorf("seed prior_session_id = %v, want null", seed.PriorSessionID)
 		}
-		if recall.Detail != geminiRecallConfirmedSameSession || recall.Grade != qualification.GradeUsable {
+		if recall.Detail != qualification.RecallConfirmedSameSession || recall.Grade != qualification.GradeUsable {
 			t.Errorf("recall detail/classification = %s/%s, want confirmed_same_session/usable", recall.Detail, recall.Grade)
 		}
 		if recall.SessionID == nil || recall.PriorSessionID == nil || *recall.SessionID != *recall.PriorSessionID {
@@ -469,7 +473,7 @@ func TestGeminiContinuationRelationBuilder(t *testing.T) {
 			ReplayConfirmed: false,
 		}
 		seed, recall := geminiBuildContinuationRecords(relation)
-		if recall.Detail != geminiRecallFreshFallback || recall.Grade != qualification.GradeGap {
+		if recall.Detail != qualification.RecallFreshFallback || recall.Grade != qualification.GradeGap {
 			t.Errorf("recall detail/classification = %s/%s, want fresh_session_fallback/gap", recall.Detail, recall.Grade)
 		}
 		if *recall.SessionID == *recall.PriorSessionID {
@@ -485,7 +489,7 @@ func TestGeminiContinuationRelationBuilder(t *testing.T) {
 
 		relation := geminiContinuationRelation{Surface: qualification.SurfaceNativeText, SeedSessionID: "sess-text-seed"}
 		seed, recall := geminiBuildContinuationRecords(relation)
-		if recall.Detail != geminiRecallUnobservedActual || recall.Grade != qualification.GradeNotObserved {
+		if recall.Detail != qualification.RecallUnobservedActual || recall.Grade != qualification.GradeNotObserved {
 			t.Errorf("recall detail/classification = %s/%s, want unobserved_actual_session/not_observed", recall.Detail, recall.Grade)
 		}
 		if recall.SessionID != nil {
@@ -493,6 +497,55 @@ func TestGeminiContinuationRelationBuilder(t *testing.T) {
 		}
 		if seed.SessionID == nil || *seed.SessionID != relation.SeedSessionID {
 			t.Errorf("seed session id = %v, want the seed's actual identifier", seed.SessionID)
+		}
+	})
+
+	t.Run("precondition unmet stops the recall before it is tried", func(t *testing.T) {
+		t.Parallel()
+
+		// Each case shapes RecallSessionID/ReplayConfirmed to match one of
+		// the three other geminiRecallDetail branches, proving the
+		// PreconditionUnmet case wins regardless of which branch the rest
+		// of the relation would otherwise have matched.
+		tests := []struct {
+			name            string
+			recallSessionID string
+			replayConfirmed bool
+		}{
+			{"would otherwise be unobserved (empty RecallSessionID)", "", false},
+			{"would otherwise be confirmed same session", "sess-seed", true},
+			{"would otherwise be fresh fallback", "sess-fallback", false},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+
+				relation := geminiContinuationRelation{
+					Surface:           qualification.SurfaceProtocol,
+					SeedSessionID:     "sess-seed",
+					RecallSessionID:   tt.recallSessionID,
+					ReplayConfirmed:   tt.replayConfirmed,
+					PreconditionUnmet: true,
+				}
+				seed, recall := geminiBuildContinuationRecords(relation)
+				if recall.Detail != qualification.RecallPreconditionUnmet || recall.Grade != qualification.GradeNotObserved {
+					t.Errorf("recall detail/classification = %s/%s, want recall_precondition_unmet/not_observed", recall.Detail, recall.Grade)
+				}
+				if recall.Outcome != qualification.OutcomePrerequisiteFailed {
+					t.Errorf("recall outcome = %s, want prerequisite_failed", recall.Outcome)
+				}
+				if recall.SessionID != nil {
+					t.Errorf("precondition-unmet recall carries a session id: %v", recall.SessionID)
+				}
+
+				clearedRelation := relation
+				clearedRelation.PreconditionUnmet = false
+				wantSeed, _ := geminiBuildContinuationRecords(clearedRelation)
+				if !reflect.DeepEqual(seed, wantSeed) {
+					t.Errorf("seed record = %+v, want it byte-identical to the seed built with PreconditionUnmet unset: %+v", seed, wantSeed)
+				}
+			})
 		}
 	})
 

--- a/internal/agent/clientprotocol/gemini_qualification_unix_test.go
+++ b/internal/agent/clientprotocol/gemini_qualification_unix_test.go
@@ -819,6 +819,172 @@ func geminiCollectContinuationRecords(t *testing.T, runtime geminiQualificationR
 	return records
 }
 
+// geminiClearCreationMinute reports whether now has left createdAt's
+// UTC minute, waiting once for the shortfall when it has not. now and
+// sleep are seams: the live probe passes time.Now and time.Sleep.
+func geminiClearCreationMinute(createdAt time.Time, now func() time.Time, sleep func(time.Duration)) (cleared bool, waited time.Duration) {
+	wait := loadDeferral(createdAt, now())
+	if wait <= 0 {
+		return true, 0
+	}
+	sleep(wait)
+	return loadDeferral(createdAt, now()) <= 0, wait
+}
+
+// geminiStartRecallAfterCreationMinute clears createdAt's UTC minute
+// and only then starts the recall session through startRecall.
+// startRecall is a seam: the live probe passes the recall's own
+// StartSession call.
+func geminiStartRecallAfterCreationMinute(createdAt time.Time, now func() time.Time, sleep func(time.Duration), startRecall func() (domain.Session, error)) (session domain.Session, waited time.Duration, cleared bool, err error) {
+	cleared, waited = geminiClearCreationMinute(createdAt, now, sleep)
+	if !cleared {
+		return domain.Session{}, waited, cleared, nil
+	}
+	session, err = startRecall()
+	return session, waited, cleared, err
+}
+
+// TestGeminiClearCreationMinute confirms the boundary check: an instant
+// already outside the creation minute clears without sleeping, a
+// shortfall sleeps exactly once for exactly the shortfall and clears,
+// and a clock that never advances past the boundary still sleeps
+// exactly once but reports not cleared.
+func TestGeminiClearCreationMinute(t *testing.T) {
+	t.Parallel()
+
+	createdAt := time.Date(2026, 1, 1, 0, 0, 30, 0, time.UTC)
+	boundary := createdAt.Truncate(time.Minute).Add(time.Minute)
+
+	t.Run("already outside the creation minute never sleeps", func(t *testing.T) {
+		t.Parallel()
+
+		now := func() time.Time { return boundary.Add(time.Second) }
+		sleepCalls := 0
+		sleep := func(time.Duration) { sleepCalls++ }
+
+		cleared, waited := geminiClearCreationMinute(createdAt, now, sleep)
+		if !cleared || waited != 0 {
+			t.Errorf("geminiClearCreationMinute() = %v, %s, want true, 0", cleared, waited)
+		}
+		if sleepCalls != 0 {
+			t.Errorf("sleep called %d times, want 0", sleepCalls)
+		}
+	})
+
+	t.Run("sleeps exactly the millisecond shortfall and clears", func(t *testing.T) {
+		t.Parallel()
+
+		const shortfall = 250 * time.Millisecond
+		readings := []time.Time{boundary.Add(-shortfall), boundary.Add(time.Millisecond)}
+		call := 0
+		now := func() time.Time {
+			reading := readings[call]
+			call++
+			return reading
+		}
+		sleepCalls := 0
+		var sleptFor time.Duration
+		sleep := func(d time.Duration) {
+			sleepCalls++
+			sleptFor = d
+		}
+
+		cleared, waited := geminiClearCreationMinute(createdAt, now, sleep)
+		if !cleared || waited != shortfall {
+			t.Errorf("geminiClearCreationMinute() = %v, %s, want true, %s", cleared, waited, shortfall)
+		}
+		if sleepCalls != 1 || sleptFor != shortfall {
+			t.Errorf("sleep called %d times with %s, want 1 call with %s", sleepCalls, sleptFor, shortfall)
+		}
+	})
+
+	t.Run("a clock that does not advance past the boundary stays uncleared", func(t *testing.T) {
+		t.Parallel()
+
+		const shortfall = 250 * time.Millisecond
+		readings := []time.Time{boundary.Add(-shortfall), boundary.Add(-shortfall)}
+		call := 0
+		now := func() time.Time {
+			reading := readings[call]
+			call++
+			return reading
+		}
+		sleepCalls := 0
+		sleep := func(time.Duration) { sleepCalls++ }
+
+		cleared, _ := geminiClearCreationMinute(createdAt, now, sleep)
+		if cleared {
+			t.Error("geminiClearCreationMinute() cleared = true, want false when the clock never advances past the boundary")
+		}
+		if sleepCalls != 1 {
+			t.Errorf("sleep called %d times, want exactly 1", sleepCalls)
+		}
+	})
+}
+
+// TestGeminiStartRecallAfterCreationMinute confirms that startRecall is
+// never invoked when the boundary does not clear, and is invoked
+// exactly once, with its own results returned unchanged, when it does.
+func TestGeminiStartRecallAfterCreationMinute(t *testing.T) {
+	t.Parallel()
+
+	createdAt := time.Date(2026, 1, 1, 0, 0, 30, 0, time.UTC)
+	boundary := createdAt.Truncate(time.Minute).Add(time.Minute)
+
+	t.Run("uncleared boundary never calls startRecall", func(t *testing.T) {
+		t.Parallel()
+
+		now := func() time.Time { return boundary.Add(-100 * time.Millisecond) }
+		sleep := func(time.Duration) {}
+		calls := 0
+		startRecall := func() (domain.Session, error) {
+			calls++
+			return domain.Session{}, nil
+		}
+
+		session, _, cleared, err := geminiStartRecallAfterCreationMinute(createdAt, now, sleep, startRecall)
+		if cleared {
+			t.Error("geminiStartRecallAfterCreationMinute() cleared = true, want false")
+		}
+		if calls != 0 {
+			t.Errorf("startRecall called %d times, want 0", calls)
+		}
+		if err != nil {
+			t.Errorf("err = %v, want nil", err)
+		}
+		if !reflect.DeepEqual(session, domain.Session{}) {
+			t.Errorf("session = %+v, want the zero domain.Session", session)
+		}
+	})
+
+	t.Run("cleared boundary calls startRecall exactly once and returns its results unchanged", func(t *testing.T) {
+		t.Parallel()
+
+		now := func() time.Time { return boundary.Add(time.Second) }
+		sleep := func(time.Duration) { t.Fatal("sleep must not be called when the boundary already cleared") }
+		calls := 0
+		wantErr := errors.New("recall start failed")
+		startRecall := func() (domain.Session, error) {
+			calls++
+			return domain.Session{ID: "sess-recall"}, wantErr
+		}
+
+		session, _, cleared, err := geminiStartRecallAfterCreationMinute(createdAt, now, sleep, startRecall)
+		if !cleared {
+			t.Error("geminiStartRecallAfterCreationMinute() cleared = false, want true")
+		}
+		if calls != 1 {
+			t.Errorf("startRecall called %d times, want 1", calls)
+		}
+		if session.ID != "sess-recall" {
+			t.Errorf("session = %+v, want the id startRecall returned", session)
+		}
+		if !errors.Is(err, wantErr) {
+			t.Errorf("err = %v, want %v", err, wantErr)
+		}
+	})
+}
+
 // geminiRunProtocolContinuation runs the protocol surface's
 // continuation relation through the real adapter: a first process
 // stores the generated nonce, that session ends, and a second process
@@ -851,6 +1017,7 @@ func geminiRunProtocolContinuation(t *testing.T, runtime geminiQualificationRunt
 	if err != nil {
 		t.Fatalf("continuation seed on surface %s: StartSession failed: %v", qualification.SurfaceProtocol, err)
 	}
+	seedCreatedAt := time.Now()
 	tracker.register(geminiSessionGroupPID(seedSession))
 	t.Cleanup(func() {
 		_ = adapter.StopSession(context.Background(), seedSession)
@@ -873,7 +1040,17 @@ func geminiRunProtocolContinuation(t *testing.T, runtime geminiQualificationRunt
 		t.Errorf("stop the protocol continuation seed session: %v", err)
 	}
 
-	recallSession, err := adapter.StartSession(context.Background(), startParams(seedSession.ID))
+	startRecall := func() (domain.Session, error) {
+		return adapter.StartSession(context.Background(), startParams(seedSession.ID))
+	}
+	recallSession, waited, cleared, err := geminiStartRecallAfterCreationMinute(seedCreatedAt, time.Now, time.Sleep, startRecall)
+	if waited > 0 {
+		t.Logf("continuation recall waited %s to clear the seed's creation minute", waited)
+	}
+	if !cleared {
+		relation.PreconditionUnmet = true
+		return geminiLiveContinuationRecords(relation, agentName, runtime.Version)
+	}
 	if err != nil {
 		return geminiLiveContinuationRecords(relation, agentName, runtime.Version)
 	}

--- a/internal/qualification/evidence.go
+++ b/internal/qualification/evidence.go
@@ -312,6 +312,19 @@ const (
 // declaration may carry.
 var DeclaredGapReasons = []string{DeclaredGapNeverProduced, DeclaredGapFolded}
 
+// The closed recall detail set. A continuation recall record carries
+// exactly one of these; every other value is invalid.
+const (
+	RecallConfirmedSameSession = "confirmed_same_session"
+	RecallFreshFallback        = "fresh_session_fallback"
+	RecallUnobservedActual     = "unobserved_actual_session"
+	// RecallPreconditionUnmet states that the probe could not
+	// establish the condition its observation requires, so no
+	// continuation was tried and nothing about the runtime was
+	// observed.
+	RecallPreconditionUnmet = "recall_precondition_unmet"
+)
+
 // DeclaredGapPeers pairs the two semantic cases whose outcomes derive
 // from one physical run, so a declaration of one without the other is
 // incoherent.

--- a/internal/qualification/fixture.go
+++ b/internal/qualification/fixture.go
@@ -549,7 +549,7 @@ func (f *Fixture) addContinuation() {
 		recall.EvidencePath = new("/continuation/recall")
 		recall.SessionID = new(seedSession)
 		recall.PriorSessionID = new(seedSession)
-		recall.Detail = recallConfirmedSameSession
+		recall.Detail = RecallConfirmedSameSession
 		if Surface == SurfaceProtocol {
 			recall.AgentName = new(FixtureAgentName)
 			recall.AgentVersion = new(FixtureAgentVer)

--- a/internal/qualification/grade_test.go
+++ b/internal/qualification/grade_test.go
@@ -358,13 +358,28 @@ func TestEligibilityPredicates(T *testing.T) {
 			mutate: func(f *Fixture) {
 				recall := f.FindFirst(MatchContinuation(SurfaceProtocol, InputContinuationRecall))
 				recall.SessionID = new(FixtureSession(SurfaceProtocol, "fallback"))
-				recall.Detail = recallFreshFallback
+				recall.Detail = RecallFreshFallback
 				recall.Grade = GradeGap
 				if baseline := f.FindFirst(MatchBaseline(SurfaceProtocol, CapabilitySessionContinuation)); baseline != nil {
 					baseline.Grade = GradeGap
 				}
 			},
 			want: VerdictNotQualified,
+		},
+		{
+			name: "protocol continuation recall precondition unmet",
+			mutate: func(f *Fixture) {
+				recall := f.FindFirst(MatchContinuation(SurfaceProtocol, InputContinuationRecall))
+				recall.SessionID = nil
+				recall.Detail = RecallPreconditionUnmet
+				recall.Grade = GradeNotObserved
+				recall.Outcome = OutcomePrerequisiteFailed
+				if baseline := f.FindFirst(MatchBaseline(SurfaceProtocol, CapabilitySessionContinuation)); baseline != nil {
+					baseline.Grade = GradeNotObserved
+					baseline.Outcome = OutcomeNotObserved
+				}
+			},
+			want: VerdictUnmeasured,
 		},
 	}
 

--- a/internal/qualification/validate.go
+++ b/internal/qualification/validate.go
@@ -86,13 +86,6 @@ var scenarioWriteOrder = []Scenario{
 	ScenarioProcessCleanup, ScenarioQualification,
 }
 
-// The closed recall detail set for continuation recall records.
-const (
-	recallConfirmedSameSession = "confirmed_same_session"
-	recallFreshFallback        = "fresh_session_fallback"
-	recallUnobservedActual     = "unobserved_actual_session"
-)
-
 // ClassifyRecord matches one record against the closed tuple table
 // and returns its row class, rejecting any tuple the table does not
 // declare.
@@ -967,26 +960,36 @@ func (v *setValidation) checkRecallRecord(rec *Record) error {
 		return fmt.Errorf("continuation recall record must carry prior_session_id")
 	}
 	switch rec.Detail {
-	case recallConfirmedSameSession:
+	case RecallConfirmedSameSession:
 		if rec.SessionID == nil || *rec.SessionID != *rec.PriorSessionID {
 			return fmt.Errorf("confirmed_same_session requires equal non-null actual and prior session ids")
 		}
 		if rec.Grade != GradeUsable {
 			return fmt.Errorf("confirmed_same_session requires classification usable, got %s", rec.Grade)
 		}
-	case recallFreshFallback:
+	case RecallFreshFallback:
 		if rec.SessionID == nil || *rec.SessionID == *rec.PriorSessionID {
 			return fmt.Errorf("fresh_session_fallback requires a non-null actual session id distinct from prior_session_id")
 		}
 		if rec.Grade != GradeGap {
 			return fmt.Errorf("fresh_session_fallback requires classification gap, got %s", rec.Grade)
 		}
-	case recallUnobservedActual:
+	case RecallUnobservedActual:
 		if rec.SessionID != nil {
 			return fmt.Errorf("unobserved_actual_session requires a null session_id")
 		}
 		if rec.Grade != GradeNotObserved {
 			return fmt.Errorf("unobserved_actual_session requires classification not_observed, got %s", rec.Grade)
+		}
+	case RecallPreconditionUnmet:
+		if rec.SessionID != nil {
+			return fmt.Errorf("recall_precondition_unmet requires a null session_id")
+		}
+		if rec.Grade != GradeNotObserved {
+			return fmt.Errorf("recall_precondition_unmet requires classification not_observed, got %s", rec.Grade)
+		}
+		if rec.Outcome != OutcomePrerequisiteFailed {
+			return fmt.Errorf("recall_precondition_unmet requires verdict prerequisite_failed, got %s", rec.Outcome)
 		}
 	default:
 		return fmt.Errorf("recall detail %q is outside the closed set", rec.Detail)

--- a/internal/qualification/validate_controls_test.go
+++ b/internal/qualification/validate_controls_test.go
@@ -485,7 +485,7 @@ func TestValidatorContinuationControls(T *testing.T) {
 			T.Fatal("fixture carries no protocol recall Record")
 		}
 		recall.SessionID = new(FixtureSession(SurfaceProtocol, "fallback"))
-		recall.Detail = recallFreshFallback
+		recall.Detail = RecallFreshFallback
 		recall.Grade = GradeGap
 		if baseline := fixture.FindFirst(MatchBaseline(SurfaceProtocol, CapabilitySessionContinuation)); baseline != nil {
 			baseline.Grade = GradeGap
@@ -537,7 +537,7 @@ func TestValidatorContinuationControls(T *testing.T) {
 			T.Fatal("fixture carries no protocol recall Record")
 		}
 		recall.SessionID = new(FixtureSession(SurfaceProtocol, "fallback"))
-		recall.Detail = recallFreshFallback
+		recall.Detail = RecallFreshFallback
 		recall.Grade = GradeGap
 		if baseline := fixture.FindFirst(MatchBaseline(SurfaceProtocol, CapabilitySessionContinuation)); baseline != nil {
 			baseline.Grade = GradeGap
@@ -563,6 +563,115 @@ func TestValidatorContinuationControls(T *testing.T) {
 			T.Error("ValidateObservations() = nil error, want rejection of an identity record no other evidence references")
 		} else if !strings.Contains(err.Error(), "references no non-final evidence") {
 			T.Errorf("ValidateObservations() error = %v, want it to name the unreferenced identity record", err)
+		}
+	})
+
+	T.Run("a well-formed recall_precondition_unmet record validates", func(T *testing.T) {
+		T.Parallel()
+
+		fixture := NewFixture(FixtureQualified)
+		fixture.Finalize()
+		recall := fixture.FindFirst(MatchContinuation(SurfaceProtocol, InputContinuationRecall))
+		if recall == nil {
+			T.Fatal("fixture carries no protocol recall Record")
+		}
+		recall.SessionID = nil
+		recall.Detail = RecallPreconditionUnmet
+		recall.Grade = GradeNotObserved
+		recall.Outcome = OutcomePrerequisiteFailed
+		if baseline := fixture.FindFirst(MatchBaseline(SurfaceProtocol, CapabilitySessionContinuation)); baseline != nil {
+			baseline.Grade = GradeNotObserved
+			baseline.Outcome = OutcomeNotObserved
+		}
+		path := WriteEvidenceFile(T, fixture.Records)
+		RequireObservationVerdict(T, path, VerdictUnmeasured)
+	})
+
+	T.Run("recall_precondition_unmet rejects a non-null session_id", func(T *testing.T) {
+		T.Parallel()
+
+		fixture := NewFixture(FixtureQualified)
+		fixture.Finalize()
+		recall := fixture.FindFirst(MatchContinuation(SurfaceProtocol, InputContinuationRecall))
+		if recall == nil {
+			T.Fatal("fixture carries no protocol recall Record")
+		}
+		recall.Detail = RecallPreconditionUnmet
+		recall.Grade = GradeNotObserved
+		recall.Outcome = OutcomePrerequisiteFailed
+		if baseline := fixture.FindFirst(MatchBaseline(SurfaceProtocol, CapabilitySessionContinuation)); baseline != nil {
+			baseline.Grade = GradeNotObserved
+			baseline.Outcome = OutcomeNotObserved
+		}
+		path := WriteEvidenceFile(T, fixture.Records)
+		if _, err := ValidateObservations(path); err == nil {
+			T.Error("ValidateObservations() = nil error, want rejection of recall_precondition_unmet paired with a non-null session_id")
+		} else if !strings.Contains(err.Error(), "recall_precondition_unmet requires a null session_id") {
+			T.Errorf("ValidateObservations() error = %v, want the recall arm's session rejection", err)
+		}
+	})
+
+	T.Run("recall_precondition_unmet rejects a grade other than not_observed", func(T *testing.T) {
+		T.Parallel()
+
+		fixture := NewFixture(FixtureQualified)
+		fixture.Finalize()
+		recall := fixture.FindFirst(MatchContinuation(SurfaceProtocol, InputContinuationRecall))
+		if recall == nil {
+			T.Fatal("fixture carries no protocol recall Record")
+		}
+		recall.SessionID = nil
+		recall.Detail = RecallPreconditionUnmet
+		recall.Grade = GradeUsable
+		recall.Outcome = OutcomePass
+		path := WriteEvidenceFile(T, fixture.Records)
+		if _, err := ValidateObservations(path); err == nil {
+			T.Error("ValidateObservations() = nil error, want rejection of recall_precondition_unmet paired with a grade other than not_observed")
+		} else if !strings.Contains(err.Error(), "recall_precondition_unmet requires classification not_observed") {
+			T.Errorf("ValidateObservations() error = %v, want the recall arm's grade rejection", err)
+		}
+	})
+
+	T.Run("recall_precondition_unmet rejects an outcome other than prerequisite_failed", func(T *testing.T) {
+		T.Parallel()
+
+		fixture := NewFixture(FixtureQualified)
+		fixture.Finalize()
+		recall := fixture.FindFirst(MatchContinuation(SurfaceProtocol, InputContinuationRecall))
+		if recall == nil {
+			T.Fatal("fixture carries no protocol recall Record")
+		}
+		recall.SessionID = nil
+		recall.Detail = RecallPreconditionUnmet
+		recall.Grade = GradeNotObserved
+		recall.Outcome = OutcomeNotObserved
+		if baseline := fixture.FindFirst(MatchBaseline(SurfaceProtocol, CapabilitySessionContinuation)); baseline != nil {
+			baseline.Grade = GradeNotObserved
+			baseline.Outcome = OutcomeNotObserved
+		}
+		path := WriteEvidenceFile(T, fixture.Records)
+		if _, err := ValidateObservations(path); err == nil {
+			T.Error("ValidateObservations() = nil error, want rejection of recall_precondition_unmet paired with an outcome other than prerequisite_failed")
+		} else if !strings.Contains(err.Error(), "recall_precondition_unmet requires verdict prerequisite_failed") {
+			T.Errorf("ValidateObservations() error = %v, want the recall arm's verdict rejection", err)
+		}
+	})
+
+	T.Run("a recall detail outside the closed set is still rejected", func(T *testing.T) {
+		T.Parallel()
+
+		fixture := NewFixture(FixtureQualified)
+		fixture.Finalize()
+		recall := fixture.FindFirst(MatchContinuation(SurfaceProtocol, InputContinuationRecall))
+		if recall == nil {
+			T.Fatal("fixture carries no protocol recall Record")
+		}
+		recall.Detail = "fabricated_recall_detail"
+		path := WriteEvidenceFile(T, fixture.Records)
+		if _, err := ValidateObservations(path); err == nil {
+			T.Error("ValidateObservations() = nil error, want rejection of a recall detail outside the closed set")
+		} else if !strings.Contains(err.Error(), "outside the closed set") {
+			T.Errorf("ValidateObservations() error = %v, want it to name the closed set rejection", err)
 		}
 	})
 }


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Fix

**Intent:** The qualification protocol continuation probe started its recall session immediately after stopping the seed session, so both calls landed in the same UTC minute on any normal run - the one condition under which this runtime's `session/load` fails and permanently destroys resumability. The probe recorded that timing artifact as a fresh-session capability gap instead of the confirmed same-session recall the runtime actually supports.

**Related Issues:** #1003

### 🧭 Reviewer Guide

**Complexity:** Medium

#### Entry Point

`internal/agent/clientprotocol/gemini_qualification_unix_test.go` - `geminiClearCreationMinute` and `geminiStartRecallAfterCreationMinute` wait out the shortfall until the clock clears the seed session's creation-minute boundary before `geminiRunProtocolContinuation` issues the recall `StartSession` call. When the boundary still does not clear, the probe stops before trying the recall.

#### Sensitive Areas

- `internal/qualification/evidence.go`, `internal/qualification/validate.go`: adds `RecallPreconditionUnmet` to the closed recall detail set and its validator rule (null session id, grade `not_observed`, outcome `prerequisite_failed`), so a probe that could not establish its own precondition records that fact rather than leaving the row to be read later as a measured capability gap.
- `internal/agent/clientprotocol/gemini_qualification_capability_probes_unix_test.go`: `geminiRecallDetail` and `geminiBuildContinuationRecords` now prefer the precondition-unmet case over the other three recall outcomes.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes. `RecallPreconditionUnmet` is a new, additive member of an already-closed set; existing recall details and their validation are unchanged.
- **Migrations/State:** No migrations or state changes.