### PR TITLE
feat: add agent.stop_grace_ms, honored by every adapter family

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The new `agent-client-protocol` agent kind runs Agent Client Protocol-compatible runtimes over stdio and resumes previous sessions when supported by the runtime. Locally launched runtimes can use workflow-configured MCP servers, while requests requiring human input are refused or end the attempt rather than waiting indefinitely. Token-based budgets do not apply because the protocol does not report token usage.
   ([#976](https://github.com/sortie-ai/sortie/issues/976))
 
+- A new `agent.stop_grace_ms` field, default `5000`, sets the period an adapter waits for an agent to exit on its own before it force-terminates the process group, and now reaches every adapter kind that has such a period instead of leaving it fixed at a five-second built-in constant. The orchestrator's per-session stop deadline no longer follows `agent.read_timeout_ms` at all: it derives from `agent.stop_grace_ms` alone. The shutdown-drain ceiling now derives from the same field, which lengthens the worker drain at the default configuration from 30 s to 50 s.
+  ([#1014](https://github.com/sortie-ai/sortie/issues/1014))
+
 ### Fixed
 
 - A string-typed adapter configuration key whose value carries another YAML type, such as `tracker.endpoint: 123`, `agent.kind: 123`, or a mistyped `claude-code.model`, is now rejected with a diagnostic naming the key and the type found, instead of being silently coerced to the empty string and then treated as absent or defaulted to the adapter's own default. A workflow that previously started with such a value now fails at config load, at adapter construction, or offline through `sortie validate`, whichever reads the key first; the fix is to quote the value or remove the key.
@@ -34,6 +37,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - An `agent-client-protocol` turn that ends because the runtime reached a token limit no longer schedules a retry that resumes the same oversized context into the same limit; the claim is released instead. A turn that ends because the runtime's own request or turn budget was exhausted keeps its existing retryable classification, since a fresh session can complete within it.
   ([#1023](https://github.com/sortie-ai/sortie/issues/1023))
+
+### Changed
+
+- A second interrupt (Ctrl-C) during shutdown now ends every remaining shutdown wait at once, instead of being silently discarded until shutdown finishes on its own. Each abandoned wait logs a warning naming what was given up.
+  ([#1014](https://github.com/sortie-ai/sortie/issues/1014))
 
 ## [1.23.0] - 2026-08-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - An `agent-client-protocol` turn that ends because the runtime reached a token limit no longer schedules a retry that resumes the same oversized context into the same limit; the claim is released instead. A turn that ends because the runtime's own request or turn budget was exhausted keeps its existing retryable classification, since a fresh session can complete within it.
   ([#1023](https://github.com/sortie-ai/sortie/issues/1023))
 
+- Stopping a `codex` session now honors the caller's deadline, as every other agent kind already did. `StopSession` ignored the deadline it was given, so a stop asked to finish sooner than the configured stop grace waited out the whole grace anyway and then reported success. It now ends the graceful phase when the deadline expires, force-terminates the process group, and reports the deadline back to its caller.
+  ([#1014](https://github.com/sortie-ai/sortie/issues/1014))
+
 ### Changed
 
 - A second interrupt (Ctrl-C) during shutdown now ends every remaining shutdown wait at once, instead of being silently discarded until shutdown finishes on its own. Each abandoned wait logs a warning naming what was given up.

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -40,6 +40,7 @@ agent:
   turn_timeout_ms: 1800000
   read_timeout_ms: 10000
   stall_timeout_ms: 300000
+  stop_grace_ms: 5000
   max_retry_backoff_ms: 120000
 
 claude-code:

--- a/cmd/sortie/main.go
+++ b/cmd/sortie/main.go
@@ -62,9 +62,12 @@ var serverShutdownTimeout = 5 * time.Second
 
 // abandonCh is created by main before [run] is called, and the signal
 // goroutine closes it on a second interrupt so every in-flight shutdown
-// wait ends at once. It stays nil for the validate, resolve, and
-// --dry-run paths, and for tests, none of which construct an
-// orchestrator through this package's main.
+// wait ends at once. Every path through main gets a live channel,
+// including validate, resolve, and --dry-run; those construct no
+// orchestrator, so nothing ever reads it. It stays nil only for a
+// caller that invokes [run] directly, which is what tests do, and a
+// receive on a nil channel blocks forever, so an unwired abort never
+// fires.
 var abandonCh chan struct{}
 
 // buildAgentAdapterCache eagerly constructs every registered agent
@@ -245,6 +248,11 @@ func main() {
 	code := run(ctx, os.Args[1:], os.Stdout, os.Stderr)
 	stop()
 	signal.Stop(sigCh)
+	// Closing is safe only after signal.Stop returns, which guarantees
+	// the channel receives no further signals. It lets handleSignals
+	// drain and return rather than parking on a receive for the life of
+	// the process.
+	close(sigCh)
 	os.Exit(code)
 }
 

--- a/cmd/sortie/main.go
+++ b/cmd/sortie/main.go
@@ -60,6 +60,13 @@ import (
 // exercise the shutdown-error path without a 5-second wait.
 var serverShutdownTimeout = 5 * time.Second
 
+// abandonCh is created by main before [run] is called, and the signal
+// goroutine closes it on a second interrupt so every in-flight shutdown
+// wait ends at once. It stays nil for the validate, resolve, and
+// --dry-run paths, and for tests, none of which construct an
+// orchestrator through this package's main.
+var abandonCh chan struct{}
+
 // buildAgentAdapterCache eagerly constructs every registered agent
 // adapter so dispatch-rule routing can resolve any referenced kind
 // without per-issue construction. The workflow default kind reuses
@@ -223,25 +230,52 @@ func labelFixCommandActive(cfg config.ServiceConfig) bool {
 func main() {
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 
+	abandonCh = make(chan struct{})
+
 	// Log the signal that triggers shutdown. signal.NotifyContext
 	// cancels ctx but discards the signal identity, so a parallel
-	// channel captures it for operator diagnostics.
-	sigCh := make(chan os.Signal, 1)
+	// channel captures it for operator diagnostics. The buffer holds
+	// two: signal.Notify sends without blocking, and a buffer of one
+	// would drop the second interrupt whenever the goroutine is
+	// between receives, which is exactly the moment it arrives.
+	sigCh := make(chan os.Signal, 2)
 	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
-	go func() {
-		sig, ok := <-sigCh
-		if ok {
-			slog.Info("signal received, initiating shutdown",
-				slog.String("signal", sig.String()),
-				slog.Int("pid", os.Getpid()),
-			)
-		}
-	}()
+	go handleSignals(sigCh, abandonCh)
 
 	code := run(ctx, os.Args[1:], os.Stdout, os.Stderr)
 	stop()
 	signal.Stop(sigCh)
 	os.Exit(code)
+}
+
+// handleSignals reports shutdown progress and gives a repeated interrupt
+// an effect. The first signal only records that shutdown began: the
+// cancellation that starts it already reached the orchestrator through
+// the notified context. The second closes abandon, which ends every
+// in-flight shutdown wait at once. Later signals are ignored, because
+// the channel is already closed and there is nothing further to give up.
+// Returns when sigCh is closed.
+//
+// It reads the default logger on each signal instead of capturing one,
+// because it starts before the configured handler is installed.
+func handleSignals(sigCh <-chan os.Signal, abandon chan struct{}) {
+	received := 0
+	for sig := range sigCh {
+		received++
+		switch received {
+		case 1:
+			slog.Info("signal received, initiating shutdown",
+				slog.String("signal", sig.String()),
+				slog.Int("pid", os.Getpid()),
+			)
+		case 2:
+			slog.Warn("second signal received, abandoning in-flight shutdown work",
+				slog.String("signal", sig.String()),
+				slog.Int("pid", os.Getpid()),
+			)
+			close(abandon)
+		}
+	}
 }
 
 func run(ctx context.Context, args []string, stdout io.Writer, stderr io.Writer) int {
@@ -806,6 +840,7 @@ func run(ctx context.Context, args []string, stdout io.Writer, stderr io.Writer)
 		MergeCompletionConfig:             mergeCompletionConfig,
 		MergeCompletionReactionConfigured: mergeCompletionConfigured,
 		BlockerResolver:                   br.blockerResolver,
+		AbandonCh:                         abandonCh,
 	})
 
 	var srv *server.Server

--- a/cmd/sortie/main_test.go
+++ b/cmd/sortie/main_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"net"
 	"os"
 	"os/exec"
@@ -2115,5 +2116,85 @@ func TestRunFiveKindsWiring_AllEnablementRecordsLogged(t *testing.T) {
 		if !strings.Contains(logs, record) {
 			t.Errorf("expected %q in log, got:\n%s", record, logs)
 		}
+	}
+}
+
+// lockedBuffer serializes writes so the signal goroutine and the test
+// goroutine can share one log sink under the race detector.
+type lockedBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *lockedBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *lockedBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
+// TestHandleSignals pins what a repeated interrupt does: the first
+// signal reports shutdown and closes nothing, the second closes the
+// abandon channel, and a third neither panics nor closes it again.
+// Without the third-signal case a later refactor could reintroduce a
+// double close, which panics in the goroutine and takes the process down
+// during the very shutdown the operator asked to hurry.
+func TestHandleSignals(t *testing.T) {
+	sink := &lockedBuffer{}
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(sink, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	waitForLog := func(substr string) {
+		t.Helper()
+		deadline := time.Now().Add(5 * time.Second)
+		for time.Now().Before(deadline) {
+			if strings.Contains(sink.String(), substr) {
+				return
+			}
+			time.Sleep(time.Millisecond)
+		}
+		t.Fatalf("handleSignals() log = %q, want it to contain %q", sink.String(), substr)
+	}
+
+	sigCh := make(chan os.Signal, 3)
+	abandon := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		handleSignals(sigCh, abandon)
+		close(done)
+	}()
+
+	sigCh <- syscall.SIGINT
+	waitForLog("initiating shutdown")
+	select {
+	case <-abandon:
+		t.Fatal("handleSignals() closed the abandon channel on the first signal, want it left open")
+	default:
+	}
+
+	sigCh <- syscall.SIGINT
+	waitForLog("abandoning in-flight shutdown work")
+	select {
+	case <-abandon:
+	case <-time.After(5 * time.Second):
+		t.Fatal("handleSignals() left the abandon channel open after the second signal, want it closed")
+	}
+
+	sigCh <- syscall.SIGTERM
+	close(sigCh)
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("handleSignals() did not return after sigCh closed")
+	}
+
+	if got := strings.Count(sink.String(), "abandoning in-flight shutdown work"); got != 1 {
+		t.Errorf("handleSignals() logged the abandon warning %d times, want 1", got)
 	}
 }

--- a/cmd/sortie/sample_workflow_test.go
+++ b/cmd/sortie/sample_workflow_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -850,14 +851,14 @@ func TestShippedWorkflowsCarryStopGraceMS(t *testing.T) {
 			if err != nil {
 				t.Fatalf("workflow.Load: %v", err)
 			}
-			cfg, err := config.NewServiceConfig(wf.Config)
-			if err != nil {
-				t.Fatalf("config.NewServiceConfig: %v", err)
-			}
-			if cfg.Agent.StopGraceMS != 5000 {
-				t.Errorf("Agent.StopGraceMS = %d, want 5000", cfg.Agent.StopGraceMS)
-			}
 
+			// Both the kind and the value come from the front matter
+			// rather than from a resolved ServiceConfig.
+			// NewServiceConfig applies the SORTIE_* overrides, so an
+			// inherited SORTIE_AGENT_STOP_GRACE_MS would replace the
+			// file's own value and fail this test for every workflow
+			// even when every file on disk is correct. That the files
+			// still load is covered separately.
 			agentExt, ok := wf.Config["agent"]
 			if !ok {
 				t.Fatal("workflow front matter missing 'agent' block")
@@ -868,7 +869,7 @@ func TestShippedWorkflowsCarryStopGraceMS(t *testing.T) {
 			}
 			value, present := agentMap["stop_grace_ms"]
 
-			if cfg.Agent.Kind == "mock" {
+			if kind, _ := agentMap["kind"].(string); kind == "mock" {
 				if present {
 					t.Errorf("agent.stop_grace_ms present at %v for the mock kind, want absent: mock launches no process and has no graceful phase for the field to bound", value)
 				}
@@ -877,6 +878,9 @@ func TestShippedWorkflowsCarryStopGraceMS(t *testing.T) {
 
 			if !present {
 				t.Fatal("agent: block missing stop_grace_ms, want an explicit stop_grace_ms: 5000")
+			}
+			if got := fmt.Sprint(value); got != "5000" {
+				t.Errorf("agent.stop_grace_ms = %s, want 5000", got)
 			}
 		})
 	}

--- a/cmd/sortie/sample_workflow_test.go
+++ b/cmd/sortie/sample_workflow_test.go
@@ -823,3 +823,61 @@ func TestShippedWorkflowsProduceNoMissingBlockDiagnostic(t *testing.T) {
 		})
 	}
 }
+
+// TestShippedWorkflowsCarryStopGraceMS verifies that every shipped
+// WORKFLOW*.md carries an explicit stop_grace_ms: 5000 in its agent:
+// block, except the one kind with no graceful phase for the field to
+// bound. Presence is checked against the raw front-matter map rather
+// than the resolved config, because the default the config layer
+// applies to an absent key is the same 5000 the shipped value uses: a
+// resolved-value check alone would not fail if a file's key were
+// dropped. A workflow file added later without the key fails this
+// test, which is what keeps the shipped configurations from drifting
+// apart.
+func TestShippedWorkflowsCarryStopGraceMS(t *testing.T) {
+	t.Parallel()
+
+	for _, path := range shippedWorkflowPaths(t) {
+		name, err := filepath.Rel(repoRoot(t), path)
+		if err != nil {
+			name = filepath.Base(path)
+		}
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			wf, err := workflow.Load(path)
+			if err != nil {
+				t.Fatalf("workflow.Load: %v", err)
+			}
+			cfg, err := config.NewServiceConfig(wf.Config)
+			if err != nil {
+				t.Fatalf("config.NewServiceConfig: %v", err)
+			}
+			if cfg.Agent.StopGraceMS != 5000 {
+				t.Errorf("Agent.StopGraceMS = %d, want 5000", cfg.Agent.StopGraceMS)
+			}
+
+			agentExt, ok := wf.Config["agent"]
+			if !ok {
+				t.Fatal("workflow front matter missing 'agent' block")
+			}
+			agentMap, ok := agentExt.(map[string]any)
+			if !ok {
+				t.Fatalf("agent block type = %T, want map[string]any", agentExt)
+			}
+			value, present := agentMap["stop_grace_ms"]
+
+			if cfg.Agent.Kind == "mock" {
+				if present {
+					t.Errorf("agent.stop_grace_ms present at %v for the mock kind, want absent: mock launches no process and has no graceful phase for the field to bound", value)
+				}
+				return
+			}
+
+			if !present {
+				t.Fatal("agent: block missing stop_grace_ms, want an explicit stop_grace_ms: 5000")
+			}
+		})
+	}
+}

--- a/docs/architecture/05-workflow-specification.md
+++ b/docs/architecture/05-workflow-specification.md
@@ -271,6 +271,17 @@ Fields:
   - Changes are re-applied at runtime and affect every lane that evaluates the ceiling: future
     worker exits, retry timer evaluations, and the poll tick's park sweep.
   - The separate `max_sessions` governs the total per-issue session budget.
+- `stop_grace_ms` (integer)
+  - Default: `5000`.
+  - The period an adapter waits, after sending a catchable termination signal, for the agent to
+    exit on its own before it force-terminates the process group.
+  - `0`, a negative value, and a value above the largest millisecond count whose conversion to a
+    duration stays positive are rejected as a configuration error at parse time, so startup,
+    `sortie validate`, and the reload fail-safe path all reject them.
+  - Overridable through `SORTIE_AGENT_STOP_GRACE_MS`.
+  - Takes effect for future worker attempts, not an in-flight session.
+  - In `claude-code`, `copilot-cli`, `kiro`, and `opencode`, the same value also bounds a
+    cancelled turn's escalation to a force kill.
 
 Adapter-specific pass-through config:
 

--- a/docs/architecture/06-configuration-specification.md
+++ b/docs/architecture/06-configuration-specification.md
@@ -286,6 +286,12 @@ This section is intentionally redundant so a coding agent can implement the conf
   lifetime effort: any run that produces evidence of work resets the count to zero. Unreachable
   under `tracker.handoff_evidence: off`, since no verdict is computed and no absence is ever
   recorded. The separate `agent.max_sessions` governs the total per-issue session budget
+- `agent.stop_grace_ms`: positive integer, default `5000`; the period an adapter waits, after
+  sending a catchable termination signal, for the agent to exit on its own before it
+  force-terminates the process group. `0`, a negative value, and a value above `MaxDurationMS`
+  (the largest millisecond count whose conversion to a duration stays positive, about 292 years)
+  are rejected as a configuration error at parse time; `SORTIE_AGENT_STOP_GRACE_MS` overrides it.
+  Takes effect for future worker attempts, not an in-flight session
 - `ci_feedback.kind`: string, optional, **deprecated**; identifies the CI status provider adapter;
   presence activates CI feedback; use `reactions.ci_failure` instead
 - `ci_feedback.max_retries`: integer, default `2`; CI-fix continuation attempts before escalation

--- a/docs/architecture/10-agent-adapter-contract.md
+++ b/docs/architecture/10-agent-adapter-contract.md
@@ -544,6 +544,8 @@ Timeouts:
 - `agent.read_timeout_ms`: request/response timeout during startup and sync requests
 - `agent.turn_timeout_ms`: enforced by orchestrator based on wall-clock duration
 - `agent.stall_timeout_ms`: enforced by orchestrator based on event inactivity
+- `agent.stop_grace_ms`: the graceful-shutdown period a local subprocess launch spends before a
+  force-terminate; see [Section 10.7](#107-local-subprocess-launch-contract)
 
 Error mapping (recommended normalized categories):
 
@@ -617,8 +619,9 @@ Graceful shutdown sequence:
   shutdown signal to the process group:
   - POSIX: `SIGTERM` to the process group (`kill(-pgid, SIGTERM)`).
   - Windows: `CTRL_BREAK_EVENT` via `GenerateConsoleCtrlEvent` to the process group.
-- The grace period that follows (default 5 seconds) is a ceiling: a shorter caller deadline
-  shortens it. When the grace period or the caller's deadline elapses, whichever comes first,
+- The grace period that follows (`agent.stop_grace_ms`, default 5 seconds) is a ceiling: a
+  shorter caller deadline shortens it. When the grace period or the caller's deadline elapses,
+  whichever comes first,
   the adapter force-terminates the process tree:
   - POSIX: `SIGKILL` to the process group.
   - Windows: `TerminateJobObject` to kill all processes in the Job Object.
@@ -638,10 +641,12 @@ Standard-error drain before reap:
   a marker, and an adapter whose success evidence lives on standard error reports the turn
   failed rather than succeeded.
 - Teardown can spend time in up to four separately bounded waits: the graceful wait before the
-  force-terminate, the standard-error drain before the reap, the reap wait where an adapter
-  bounds it, and a second standard-error drain after that reap wait. Each defaults to five
-  seconds, so a teardown that runs all four spends at most 20 seconds in them at those defaults,
-  less whenever the caller's deadline is shorter.
+  force-terminate (`agent.stop_grace_ms`), the standard-error drain before the reap, the reap wait
+  where an adapter bounds it, and a second standard-error drain after that reap wait. The three
+  drain-related waits default to five seconds each; at the default `agent.stop_grace_ms` of 5000,
+  a teardown that runs all four spends at most 20 seconds in them, and raising
+  `agent.stop_grace_ms` lengthens that total by the same amount, less whenever the caller's
+  deadline is shorter.
 
 Recommended additional process settings:
 

--- a/docs/workflow-reference.md
+++ b/docs/workflow-reference.md
@@ -779,6 +779,7 @@ agent:
   turn_timeout_ms: 3600000
   read_timeout_ms: 5000
   stall_timeout_ms: 300000
+  stop_grace_ms: 5000
   max_retry_backoff_ms: 300000
   max_concurrent_agents_by_state:
     in progress: 3
@@ -792,6 +793,7 @@ agent:
 | `turn_timeout_ms`                | integer                           | No                                  | `3600000` (1h)  | Future worker attempts                     | Wall-clock bound on a single agent turn, enforced by the orchestrator. Must be positive.                                                                                         |
 | `read_timeout_ms`                | integer                           | No                                  | `5000` (5s)     | Future worker attempts                     | Request/response timeout during startup and synchronous operations.                                                                                                              |
 | `stall_timeout_ms`               | integer                           | No                                  | `300000` (5m)   | Future worker attempts                     | Inactivity timeout based on event stream gaps. Set to `0` or negative to **disable** stall detection.                                                                            |
+| `stop_grace_ms`                  | integer                           | No                                  | `5000` (5s)     | Future worker attempts                     | The period an adapter waits, after sending a catchable termination signal, for the agent to exit on its own before it force-terminates the process group. Must be positive; overridable through `SORTIE_AGENT_STOP_GRACE_MS`. In `claude-code`, `copilot-cli`, `kiro`, and `opencode`, the same value also bounds a cancelled turn's escalation to a force kill; `mock` launches no process, so it has no such period. The per-session stop deadline derives from this field alone, no longer from `agent.read_timeout_ms`, which shortens that deadline for a deployment that had set `read_timeout_ms` above `20000`. Raising this field also lengthens graceful shutdown by the same amount: a session still stopping when Sortie is asked to shut down is waited for rather than abandoned, and at the default the worker drain alone is 50s. A second Ctrl-C during shutdown ends every remaining shutdown wait at once, so a raised grace never strands the operator without an escape. |
 | `max_concurrent_agents`          | integer or string integer         | No                                  | `10`            | **Yes** — affects subsequent dispatch      | Global concurrency limit across all issues.                                                                                                                                      |
 | `max_turns`                      | integer                           | No                                  | `20`            | Future dispatches                          | Maximum coding-agent turns per worker session. The worker re-checks tracker state after each turn and starts another turn if the issue is still active, up to this limit.        |
 | `max_retry_backoff_ms`           | integer or string integer         | No                                  | `300000` (5m)   | **Yes** — affects future retry scheduling  | Maximum delay cap for exponential backoff on retries.                                                                                                                            |
@@ -1921,6 +1923,7 @@ Each variable maps to exactly one config field. The naming convention is
 | `SORTIE_AGENT_TURN_TIMEOUT_MS`       | `agent.turn_timeout_ms`       | int    |       |
 | `SORTIE_AGENT_READ_TIMEOUT_MS`       | `agent.read_timeout_ms`       | int    |       |
 | `SORTIE_AGENT_STALL_TIMEOUT_MS`      | `agent.stall_timeout_ms`      | int    |       |
+| `SORTIE_AGENT_STOP_GRACE_MS`         | `agent.stop_grace_ms`         | int    |       |
 | `SORTIE_AGENT_MAX_CONCURRENT_AGENTS` | `agent.max_concurrent_agents` | int    |       |
 | `SORTIE_AGENT_MAX_TURNS`             | `agent.max_turns`             | int    |       |
 | `SORTIE_AGENT_MAX_RETRY_BACKOFF_MS`  | `agent.max_retry_backoff_ms`  | int    |       |
@@ -3543,6 +3546,7 @@ re-applies configuration and prompt template without restart.
 | `agent.turn_timeout_ms`                | Future worker attempts, not in-flight sessions.                                                |
 | `agent.read_timeout_ms`                | Future worker attempts, not in-flight sessions.                                                |
 | `agent.stall_timeout_ms`               | Future worker attempts, not in-flight sessions.                                                |
+| `agent.stop_grace_ms`                  | Future worker attempts, not in-flight sessions.                                                |
 | `agent.max_concurrent_agents`          | **Immediate** — affects subsequent dispatch decisions.                                         |
 | `agent.max_turns`                      | Future dispatches.                                                                             |
 | `agent.max_retry_backoff_ms`           | **Immediate** — affects future retry scheduling.                                               |
@@ -3793,6 +3797,7 @@ lists the `SORTIE_*` variable that overrides the field, or "—" if not overrida
 | `agent.turn_timeout_ms`                 | integer          | `3600000`                    | `SORTIE_AGENT_TURN_TIMEOUT_MS`           | 1 hour; wall-clock bound per turn; `≤ 0` rejected                                      |
 | `agent.read_timeout_ms`                 | integer          | `5000`                       | `SORTIE_AGENT_READ_TIMEOUT_MS`           | 5 seconds                                                                              |
 | `agent.stall_timeout_ms`               | integer          | `300000`                     | `SORTIE_AGENT_STALL_TIMEOUT_MS`          | 5 min; `≤ 0` disables                                                                  |
+| `agent.stop_grace_ms`                    | integer          | `5000`                       | `SORTIE_AGENT_STOP_GRACE_MS`             | 5 seconds; graceful-shutdown period before a force kill; `≤ 0` rejected                |
 | `agent.max_concurrent_agents`           | integer          | `10`                         | `SORTIE_AGENT_MAX_CONCURRENT_AGENTS`     | Dynamic reload                                                                         |
 | `agent.max_turns`                       | integer          | `20`                         | `SORTIE_AGENT_MAX_TURNS`                 |                                                                                        |
 | `agent.max_retry_backoff_ms`            | integer          | `300000`                     | `SORTIE_AGENT_MAX_RETRY_BACKOFF_MS`      | 5 min; dynamic reload                                                                  |
@@ -3955,6 +3960,7 @@ agent:
   turn_timeout_ms: 1800000 # 30-minute turn timeout
   read_timeout_ms: 10000 # 10-second startup timeout
   stall_timeout_ms: 300000 # 5-minute stall detection
+  stop_grace_ms: 5000 # 5-second graceful-shutdown period before a force kill
   max_retry_backoff_ms: 120000 # 2-minute max retry delay
   max_concurrent_agents_by_state:
     in progress: 3 # Reserve 1 slot for new issues

--- a/examples/WORKFLOW.codex.md
+++ b/examples/WORKFLOW.codex.md
@@ -43,6 +43,7 @@ agent:
   turn_timeout_ms: 3600000
   read_timeout_ms: 5000
   stall_timeout_ms: 300000
+  stop_grace_ms: 5000
   max_retry_backoff_ms: 300000
 
 codex:

--- a/examples/WORKFLOW.copilot.md
+++ b/examples/WORKFLOW.copilot.md
@@ -41,6 +41,7 @@ agent:
   max_concurrent_agents: 4
   turn_timeout_ms: 1800000
   stall_timeout_ms: 300000
+  stop_grace_ms: 5000
   max_retry_backoff_ms: 300000
 
 copilot-cli:

--- a/examples/WORKFLOW.gitea.md
+++ b/examples/WORKFLOW.gitea.md
@@ -42,6 +42,7 @@ agent:
   turn_timeout_ms: 3600000
   read_timeout_ms: 5000
   stall_timeout_ms: 300000
+  stop_grace_ms: 5000
   max_retry_backoff_ms: 300000
   max_concurrent_agents_by_state:
     in-progress: 3

--- a/examples/WORKFLOW.gitlab.md
+++ b/examples/WORKFLOW.gitlab.md
@@ -42,6 +42,7 @@ agent:
   turn_timeout_ms: 3600000
   read_timeout_ms: 5000
   stall_timeout_ms: 300000
+  stop_grace_ms: 5000
   max_retry_backoff_ms: 300000
   max_concurrent_agents_by_state:
     in-progress: 3

--- a/examples/WORKFLOW.kiro.md
+++ b/examples/WORKFLOW.kiro.md
@@ -43,6 +43,7 @@ agent:
   # wall-clock bound; stall_timeout_ms below catches a silent turn.
   turn_timeout_ms: 1800000
   stall_timeout_ms: 300000
+  stop_grace_ms: 5000
   max_retry_backoff_ms: 300000
 
 kiro:

--- a/examples/WORKFLOW.linear.md
+++ b/examples/WORKFLOW.linear.md
@@ -42,6 +42,7 @@ agent:
   turn_timeout_ms: 3600000
   read_timeout_ms: 5000
   stall_timeout_ms: 300000
+  stop_grace_ms: 5000
   max_retry_backoff_ms: 300000
   max_concurrent_agents_by_state:
     in progress: 3

--- a/examples/WORKFLOW.md
+++ b/examples/WORKFLOW.md
@@ -43,6 +43,7 @@ agent:
   turn_timeout_ms: 3600000
   read_timeout_ms: 5000
   stall_timeout_ms: 300000
+  stop_grace_ms: 5000
   max_retry_backoff_ms: 300000
   max_concurrent_agents_by_state:
     in progress: 3

--- a/examples/WORKFLOW.opencode.md
+++ b/examples/WORKFLOW.opencode.md
@@ -43,6 +43,7 @@ agent:
   turn_timeout_ms: 3600000
   read_timeout_ms: 5000
   stall_timeout_ms: 300000
+  stop_grace_ms: 5000
   max_retry_backoff_ms: 300000
 
 opencode:

--- a/internal/adaptertest/contract_test.go
+++ b/internal/adaptertest/contract_test.go
@@ -512,6 +512,25 @@ func checkContractStopGrace(fset *token.FileSet, file *ast.File) []contractViola
 		return nil
 	}
 	var violations []contractViolation
+	// A dot import binds the constant to a bare identifier, so no
+	// selector node exists to match and the qualifier check below can
+	// never fire. Nothing in this repository dot-imports a non-test
+	// package, and no linter here forbids it, so the rule closes the
+	// hole itself rather than resting on a convention.
+	if procutilIdent == "." {
+		ast.Inspect(file, func(n ast.Node) bool {
+			ident, isIdent := n.(*ast.Ident)
+			if !isIdent || ident.Name != "DefaultStopGrace" {
+				return true
+			}
+			violations = append(violations, contractViolation{
+				pos:  fset.Position(ident.Pos()),
+				text: "references procutil.DefaultStopGrace directly; call " + contractStopGraceOwner,
+			})
+			return true
+		})
+		return violations
+	}
 	ast.Inspect(file, func(n ast.Node) bool {
 		sel, ok := n.(*ast.SelectorExpr)
 		if !ok || sel.Sel.Name != "DefaultStopGrace" {

--- a/internal/adaptertest/contract_test.go
+++ b/internal/adaptertest/contract_test.go
@@ -27,6 +27,11 @@ const contractRegistryImportPath = "github.com/sortie-ai/sortie/internal/registr
 // Track is caught regardless of the local import alias.
 const contractTrackermetricsImportPath = "github.com/sortie-ai/sortie/internal/trackermetrics"
 
+// contractProcutilImportPath is the import path the checker resolves
+// the "procutil" package qualifier from, per file, so an aliased
+// import cannot evade rule STOPGRACE.
+const contractProcutilImportPath = "github.com/sortie-ai/sortie/internal/agent/procutil"
+
 // contractBanTable maps a name this work extracted into a shared package
 // to the owner that received it. A top-level function re-declaring one of
 // these names is a violation; the banned name is the rule. The owner
@@ -95,13 +100,14 @@ var contractTrackerAdapterMethods = map[string]bool{
 type contractRule string
 
 const (
-	ruleBAN      contractRule = "BAN"
-	ruleMETRICS  contractRule = "METRICS"
-	ruleHOOK     contractRule = "HOOK"
-	ruleIMPORT   contractRule = "IMPORT"
-	ruleTEARDOWN contractRule = "TEARDOWN"
-	ruleBLOCKER  contractRule = "BLOCKER"
-	ruleIDENTITY contractRule = "IDENTITY"
+	ruleBAN       contractRule = "BAN"
+	ruleMETRICS   contractRule = "METRICS"
+	ruleHOOK      contractRule = "HOOK"
+	ruleIMPORT    contractRule = "IMPORT"
+	ruleTEARDOWN  contractRule = "TEARDOWN"
+	ruleBLOCKER   contractRule = "BLOCKER"
+	ruleIDENTITY  contractRule = "IDENTITY"
+	ruleSTOPGRACE contractRule = "STOPGRACE"
 )
 
 // Family roots and the orchestrator path rule IMPORT matches an import
@@ -181,7 +187,8 @@ var contractAllowlist = map[string]map[contractRule]string{
 		ruleHOOK: "no HTTP, no credential, no remote project, and no config to validate",
 	},
 	"procutil": {
-		ruleTEARDOWN: "owns SetGroupCancel, the helper every other launcher calls",
+		ruleTEARDOWN:  "owns SetGroupCancel, the helper every other launcher calls",
+		ruleSTOPGRACE: "owns DefaultStopGrace, the fallback every other family reaches through StopGrace",
 	},
 }
 
@@ -485,6 +492,39 @@ func checkContractTeardown(fset *token.FileSet, file *ast.File) []contractViolat
 				text: "assigns exec.Cmd." + sel.Sel.Name + " directly; call " + contractTeardownOwner,
 			})
 		}
+		return true
+	})
+	return violations
+}
+
+// contractStopGraceOwner is the helper rule STOPGRACE directs a family
+// to resolve a stop-grace duration through, instead of reading
+// [procutil.DefaultStopGrace] directly.
+const contractStopGraceOwner = "procutil.StopGrace"
+
+// checkContractStopGrace reports a violation for every reference to
+// procutil.DefaultStopGrace in file, with the procutil qualifier
+// resolved from file's own imports so an aliased import cannot evade
+// it.
+func checkContractStopGrace(fset *token.FileSet, file *ast.File) []contractViolation {
+	procutilIdent := resolveContractImportName(file, contractProcutilImportPath)
+	if procutilIdent == "" {
+		return nil
+	}
+	var violations []contractViolation
+	ast.Inspect(file, func(n ast.Node) bool {
+		sel, ok := n.(*ast.SelectorExpr)
+		if !ok || sel.Sel.Name != "DefaultStopGrace" {
+			return true
+		}
+		ident, isIdent := sel.X.(*ast.Ident)
+		if !isIdent || ident.Name != procutilIdent {
+			return true
+		}
+		violations = append(violations, contractViolation{
+			pos:  fset.Position(sel.Pos()),
+			text: "references procutil.DefaultStopGrace directly; call " + contractStopGraceOwner,
+		})
 		return true
 	})
 	return violations
@@ -1118,10 +1158,10 @@ func contractExempt(dirName string, rule contractRule) bool {
 }
 
 // checkAdapterContractPackage evaluates rules BAN, METRICS, HOOK,
-// IMPORT, and, for a package under the agent family root, IDENTITY
-// against pkg, honoring the allowlist entries for pkg.dirName. Rules
-// BAN, METRICS, HOOK, and IDENTITY read pkg.files only; rule IMPORT
-// reads pkg.files and pkg.testFiles.
+// IMPORT, and, for a package under the agent family root, IDENTITY and
+// STOPGRACE, against pkg, honoring the allowlist entries for
+// pkg.dirName. Rules BAN, METRICS, HOOK, IDENTITY, and STOPGRACE read
+// pkg.files only; rule IMPORT reads pkg.files and pkg.testFiles.
 //
 // A ruleIMPORT entry in contractAllowlist is all-or-nothing: it lifts the
 // orchestrator ban, the sibling-adapter ban, and the package's own
@@ -1187,6 +1227,12 @@ func checkAdapterContractPackage(fset *token.FileSet, pkg contractPackage) []con
 
 	if contractPathIsUnder(pkg.importPath, contractAgentFamilyPath) && !contractExempt(pkg.dirName, ruleIDENTITY) {
 		violations = append(violations, checkContractIdentity(fset, pkg)...)
+	}
+
+	if contractPathIsUnder(pkg.importPath, contractAgentFamilyPath) && !contractExempt(pkg.dirName, ruleSTOPGRACE) {
+		for _, file := range pkg.files {
+			violations = append(violations, checkContractStopGrace(fset, file)...)
+		}
 	}
 
 	return violations
@@ -1411,6 +1457,43 @@ type request struct {
 func configure(r *request) {
 	r.Cancel = func() error { return nil }
 	r.WaitDelay = 5
+}
+`,
+			wantCount: 0,
+		},
+		{
+			name:       "a non-test file referencing procutil.DefaultStopGrace directly is rejected",
+			dirName:    "fixture",
+			importPath: "github.com/sortie-ai/sortie/internal/agent/fixture",
+			src: `package fixture
+
+import (
+	"time"
+
+	"github.com/sortie-ai/sortie/internal/agent/procutil"
+)
+
+func grace() time.Duration {
+	return procutil.DefaultStopGrace
+}
+`,
+			wantCount:  1,
+			wantSubstr: "call procutil.StopGrace",
+		},
+		{
+			name:       "a package resolving its grace through procutil.StopGrace is accepted",
+			dirName:    "fixture",
+			importPath: "github.com/sortie-ai/sortie/internal/agent/fixture",
+			src: `package fixture
+
+import (
+	"time"
+
+	"github.com/sortie-ai/sortie/internal/agent/procutil"
+)
+
+func grace(ms int) time.Duration {
+	return procutil.StopGrace(ms)
 }
 `,
 			wantCount: 0,
@@ -1909,6 +1992,33 @@ func contractCheckIdentityAllowlist(r contractIdentityReporter, found map[string
 	}
 }
 
+// contractCheckStopGraceEvaluated reports when rule STOPGRACE was
+// evaluated for no package under the agent family root.
+func contractCheckStopGraceEvaluated(r contractIdentityReporter, walked []contractWalkedPackage) {
+	evaluated := 0
+	for _, w := range walked {
+		if contractPathIsUnder(w.pkg.importPath, contractAgentFamilyPath) && !contractExempt(w.pkg.dirName, ruleSTOPGRACE) {
+			evaluated++
+		}
+	}
+	if evaluated == 0 {
+		r.Errorf("rule %s was evaluated for no package under %s, want at least one", ruleSTOPGRACE, contractAgentFamilyPath)
+	}
+}
+
+// contractCheckStopGraceAllowlist reports each contractAllowlist entry
+// that exempts rule STOPGRACE for a directory the walk did not find.
+func contractCheckStopGraceAllowlist(r contractIdentityReporter, found map[string]bool) {
+	for dirName, reasons := range contractAllowlist {
+		if _, exempt := reasons[ruleSTOPGRACE]; !exempt {
+			continue
+		}
+		if !found[dirName] {
+			r.Errorf("contractAllowlist[%q] exempts %s, but the walk under %s did not find a directory named %q", dirName, ruleSTOPGRACE, contractAgentFamilyPath, dirName)
+		}
+	}
+}
+
 // TestContractIdentityRule_AppliesAndStaysCurrent guards rule IDENTITY
 // against going stale: it fails when the rule was evaluated for no
 // package under the agent family root, when the rule's own token
@@ -1979,6 +2089,65 @@ func TestContractIdentityRule_StalenessGuardCatchesRealBreaks(t *testing.T) {
 
 		reporter := &contractStalenessFakeReporter{}
 		contractCheckIdentityAllowlist(reporter, found)
+
+		if len(reporter.errors) == 0 {
+			t.Fatalf("staleness guard recorded no failure for an allowlist entry naming a directory absent from the walk, want at least one")
+		}
+	})
+}
+
+// TestContractStopGraceRule_AppliesAndStaysCurrent guards rule
+// STOPGRACE against going stale: it fails when the rule was evaluated
+// for no package under the agent family root, or when a
+// contractAllowlist entry naming ruleSTOPGRACE names a directory the
+// walk did not find.
+func TestContractStopGraceRule_AppliesAndStaysCurrent(t *testing.T) {
+	fset := token.NewFileSet()
+	walked, _ := contractWalkRoot(t, fset, filepath.Join("..", "agent"), contractAgentFamilyPath)
+
+	found := map[string]bool{}
+	for _, w := range walked {
+		found[w.pkg.dirName] = true
+	}
+
+	contractCheckStopGraceEvaluated(t, walked)
+	contractCheckStopGraceAllowlist(t, found)
+}
+
+// TestContractStopGraceRule_StalenessGuardCatchesRealBreaks proves the
+// two checks TestContractStopGraceRule_AppliesAndStaysCurrent performs
+// are themselves capable of failing, not merely capable of passing
+// against the current tree: fed a walk that evaluated rule STOPGRACE
+// for no package under the agent family root, or an allowlist naming a
+// directory that walk did not find, each check must record a failure.
+// The second subtest temporarily replaces the package-level
+// contractAllowlist, which a concurrently-running fixture test also
+// reads, so neither subtest runs in parallel.
+func TestContractStopGraceRule_StalenessGuardCatchesRealBreaks(t *testing.T) {
+	t.Run("zero packages evaluated under the agent family root", func(t *testing.T) {
+		walked := []contractWalkedPackage{
+			{pkg: contractPackage{dirName: "fixture", importPath: "github.com/sortie-ai/sortie/internal/tracker/fixture"}},
+		}
+
+		reporter := &contractStalenessFakeReporter{}
+		contractCheckStopGraceEvaluated(reporter, walked)
+
+		if len(reporter.errors) == 0 {
+			t.Fatalf("staleness guard recorded no failure for a walk carrying no package under %s, want at least one", contractAgentFamilyPath)
+		}
+	})
+
+	t.Run("an allowlist entry names a directory the walk did not find", func(t *testing.T) {
+		original := contractAllowlist
+		contractAllowlist = map[string]map[contractRule]string{
+			"ghost-adapter": {ruleSTOPGRACE: "does not exist on disk"},
+		}
+		t.Cleanup(func() { contractAllowlist = original })
+
+		found := map[string]bool{"claude": true, "codex": true, "mock": true}
+
+		reporter := &contractStalenessFakeReporter{}
+		contractCheckStopGraceAllowlist(reporter, found)
 
 		if len(reporter.errors) == 0 {
 			t.Fatalf("staleness guard recorded no failure for an allowlist entry naming a directory absent from the walk, want at least one")

--- a/internal/adaptertest/contract_test.go
+++ b/internal/adaptertest/contract_test.go
@@ -502,6 +502,18 @@ func checkContractTeardown(fset *token.FileSet, file *ast.File) []contractViolat
 // [procutil.DefaultStopGrace] directly.
 const contractStopGraceOwner = "procutil.StopGrace"
 
+// importPos returns the position of file's import of importPath, or
+// the file's own start when the import is absent, so a violation always
+// carries a position a reader can open.
+func importPos(file *ast.File, importPath string) token.Pos {
+	for _, imp := range file.Imports {
+		if path, err := strconv.Unquote(imp.Path.Value); err == nil && path == importPath {
+			return imp.Pos()
+		}
+	}
+	return file.Pos()
+}
+
 // checkContractStopGrace reports a violation for every reference to
 // procutil.DefaultStopGrace in file, with the procutil qualifier
 // resolved from file's own imports so an aliased import cannot evade
@@ -513,23 +525,19 @@ func checkContractStopGrace(fset *token.FileSet, file *ast.File) []contractViola
 	}
 	var violations []contractViolation
 	// A dot import binds the constant to a bare identifier, so no
-	// selector node exists to match and the qualifier check below can
-	// never fire. Nothing in this repository dot-imports a non-test
-	// package, and no linter here forbids it, so the rule closes the
-	// hole itself rather than resting on a convention.
+	// selector node exists for the qualifier check below to match and
+	// the rule would silently pass. Reporting the import itself is the
+	// precise answer: chasing bare identifiers instead would also flag
+	// a local that shadows the name and the selector half of an
+	// unrelated other.DefaultStopGrace, and telling those apart needs
+	// type information this check does not have. Nothing here
+	// dot-imports a non-test package and no linter forbids it, so the
+	// rule states the prohibition rather than resting on a convention.
 	if procutilIdent == "." {
-		ast.Inspect(file, func(n ast.Node) bool {
-			ident, isIdent := n.(*ast.Ident)
-			if !isIdent || ident.Name != "DefaultStopGrace" {
-				return true
-			}
-			violations = append(violations, contractViolation{
-				pos:  fset.Position(ident.Pos()),
-				text: "references procutil.DefaultStopGrace directly; call " + contractStopGraceOwner,
-			})
-			return true
-		})
-		return violations
+		return []contractViolation{{
+			pos:  fset.Position(importPos(file, contractProcutilImportPath)),
+			text: "dot-imports procutil, which hides a DefaultStopGrace reference from this rule; import it by name and call " + contractStopGraceOwner,
+		}}
 	}
 	ast.Inspect(file, func(n ast.Node) bool {
 		sel, ok := n.(*ast.SelectorExpr)
@@ -1498,6 +1506,77 @@ func grace() time.Duration {
 `,
 			wantCount:  1,
 			wantSubstr: "call procutil.StopGrace",
+		},
+		{
+			// The file also shadows the name and names it on an
+			// unrelated package. Reporting the import rather than every
+			// identifier is what keeps those from counting: an
+			// identifier walk cannot tell them apart without type
+			// information, so it would report three violations here
+			// instead of one.
+			name:       "a non-test file dot-importing procutil is rejected once, on the import",
+			dirName:    "fixture",
+			importPath: "github.com/sortie-ai/sortie/internal/agent/fixture",
+			src: `package fixture
+
+import (
+	"time"
+
+	. "github.com/sortie-ai/sortie/internal/agent/procutil"
+	other "github.com/sortie-ai/sortie/internal/agent/agentcore"
+)
+
+func grace(ms int) time.Duration {
+	DefaultStopGrace := StopGrace(ms)
+	_ = other.DefaultStopGrace
+	return DefaultStopGrace
+}
+
+func plain() time.Duration {
+	return DefaultStopGrace
+}
+`,
+			wantCount:  1,
+			wantSubstr: "dot-imports procutil",
+		},
+		{
+			name:       "a shadowing local named DefaultStopGrace is not a violation",
+			dirName:    "fixture",
+			importPath: "github.com/sortie-ai/sortie/internal/agent/fixture",
+			src: `package fixture
+
+import (
+	"time"
+
+	"github.com/sortie-ai/sortie/internal/agent/procutil"
+)
+
+func grace(ms int) time.Duration {
+	DefaultStopGrace := procutil.StopGrace(ms)
+	return DefaultStopGrace
+}
+`,
+			wantCount: 0,
+		},
+		{
+			name:       "an unrelated package's DefaultStopGrace is not a violation",
+			dirName:    "fixture",
+			importPath: "github.com/sortie-ai/sortie/internal/agent/fixture",
+			src: `package fixture
+
+import (
+	"time"
+
+	"github.com/sortie-ai/sortie/internal/agent/procutil"
+	other "github.com/sortie-ai/sortie/internal/agent/agentcore"
+)
+
+func grace(ms int) time.Duration {
+	_ = other.DefaultStopGrace
+	return procutil.StopGrace(ms)
+}
+`,
+			wantCount: 0,
 		},
 		{
 			name:       "a package resolving its grace through procutil.StopGrace is accepted",

--- a/internal/agent/agentcore/forkperturn.go
+++ b/internal/agent/agentcore/forkperturn.go
@@ -150,6 +150,13 @@ type ForkPerTurnSession struct {
 	// cmd.Wait call. Set by NewForkPerTurnSession; overridden only by
 	// tests in this package.
 	drainGrace time.Duration
+
+	// stopGrace bounds the graceful phase Stop waits before it force-
+	// terminates the process group, and the wait cmd.WaitDelay allows
+	// a cancelled turn before RunTurn's SetGroupCancel setup escalates
+	// to a force kill. Set by NewForkPerTurnSession from the operator's
+	// configured stop grace.
+	stopGrace time.Duration
 }
 
 // NewForkPerTurnSession constructs a ForkPerTurnSession. target must be a
@@ -159,10 +166,15 @@ type ForkPerTurnSession struct {
 // non-nil. All function fields in hooks except EmitSessionStartID are
 // required; NewForkPerTurnSession panics if any required field is nil or if
 // logger is nil.
+//
+// stopGraceMS is the operator's configured agent.stop_grace_ms, resolved
+// through [procutil.StopGrace]; a non-positive value therefore resolves
+// to [procutil.DefaultStopGrace].
 func NewForkPerTurnSession(
 	target *LaunchTarget,
 	hooks ForkPerTurnHooks,
 	logger *slog.Logger,
+	stopGraceMS int,
 ) *ForkPerTurnSession {
 	if hooks.BuildArgs == nil {
 		panic("agentcore: ForkPerTurnHooks.BuildArgs must be non-nil")
@@ -187,6 +199,7 @@ func NewForkPerTurnSession(
 		hooks:      hooks,
 		logger:     logger,
 		drainGrace: procutil.DefaultDrainGrace,
+		stopGrace:  procutil.StopGrace(stopGraceMS),
 	}
 }
 
@@ -203,8 +216,8 @@ func (s *ForkPerTurnSession) SetLogger(logger *slog.Logger) {
 // stdout via the ten-armed decision tree, and returns the outcome.
 //
 // ctx controls the turn lifetime. Cancellation triggers a graceful
-// shutdown (SIGTERM to the process group) followed by a 5-second grace
-// period before force-kill.
+// shutdown (SIGTERM to the process group) followed by the session's
+// configured stop grace before force-kill.
 //
 // prompt is passed verbatim to hooks.BuildArgs.
 //
@@ -244,7 +257,7 @@ func (s *ForkPerTurnSession) RunTurn(
 		allArgs := append(slices.Clip(s.target.Args), cmdArgs...)       //nolint:gocritic // intentional: target.Args has cap==len so append always allocates
 		cmd = exec.CommandContext(cmdCtx, s.target.Command, allArgs...) //nolint:gosec // args are constructed programmatically
 	}
-	procutil.SetGroupCancel(cmd)
+	procutil.SetGroupCancel(cmd, s.stopGrace)
 	cmd.Dir = s.target.WorkspacePath
 	cmd.Env = os.Environ()
 
@@ -460,8 +473,8 @@ func (s *ForkPerTurnSession) RunTurn(
 //
 // Shutdown sequence:
 //  1. SIGTERM to process group ([procutil.SignalGraceful])
-//  2. Wait up to 5 seconds for RunTurn to close waitCh
-//  3. If timeout elapses: SIGKILL to process group
+//  2. Wait up to the session's configured stop grace for RunTurn to close waitCh
+//  3. If the grace elapses: SIGKILL to process group
 //  4. If ctx is cancelled before waitCh closes: SIGKILL and return ctx.Err()
 func (s *ForkPerTurnSession) Stop(ctx context.Context) error {
 	s.mu.Lock()
@@ -476,13 +489,20 @@ func (s *ForkPerTurnSession) Stop(ctx context.Context) error {
 
 	_ = procutil.SignalGraceful(proc.Pid) //nolint:errcheck // best-effort signal; process may already be dead
 
+	started := time.Now()
+
 	select {
 	case <-waitCh:
+		s.logger.Debug("agent exited during the graceful phase", slog.String("outcome", "exited"))
 		return nil
-	case <-time.After(procutil.DefaultStopGrace):
+	case <-time.After(s.stopGrace):
+		s.logger.Warn("agent did not exit inside the graceful period and was force-terminated",
+			slog.String("outcome", "grace elapsed"), slog.Duration("grace", time.Since(started)))
 		_ = procutil.KillProcessGroup(proc.Pid) //nolint:errcheck // best-effort kill
 		return nil
 	case <-ctx.Done():
+		s.logger.Warn("agent did not exit inside the graceful period and was force-terminated",
+			slog.String("outcome", "caller deadline"), slog.Duration("grace", time.Since(started)))
 		_ = procutil.KillProcessGroup(proc.Pid) //nolint:errcheck // best-effort kill
 		return ctx.Err()
 	}

--- a/internal/agent/agentcore/forkperturn.go
+++ b/internal/agent/agentcore/forkperturn.go
@@ -497,12 +497,14 @@ func (s *ForkPerTurnSession) Stop(ctx context.Context) error {
 		return nil
 	case <-time.After(s.stopGrace):
 		s.logger.Warn("agent did not exit inside the graceful period and was force-terminated",
-			slog.String("outcome", "grace elapsed"), slog.Duration("grace", time.Since(started)))
+			slog.String("outcome", "grace elapsed"), slog.Duration("grace", s.stopGrace),
+			slog.Duration("elapsed", time.Since(started)))
 		_ = procutil.KillProcessGroup(proc.Pid) //nolint:errcheck // best-effort kill
 		return nil
 	case <-ctx.Done():
 		s.logger.Warn("agent did not exit inside the graceful period and was force-terminated",
-			slog.String("outcome", "caller deadline"), slog.Duration("grace", time.Since(started)))
+			slog.String("outcome", "caller deadline"), slog.Duration("grace", s.stopGrace),
+			slog.Duration("elapsed", time.Since(started)))
 		_ = procutil.KillProcessGroup(proc.Pid) //nolint:errcheck // best-effort kill
 		return ctx.Err()
 	}

--- a/internal/agent/agentcore/forkperturn_test.go
+++ b/internal/agent/agentcore/forkperturn_test.go
@@ -3,14 +3,17 @@
 package agentcore
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"log/slog"
 	"slices"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/sortie-ai/sortie/internal/agent/agenttest"
+	"github.com/sortie-ai/sortie/internal/agent/procutil"
 	"github.com/sortie-ai/sortie/internal/domain"
 )
 
@@ -94,7 +97,7 @@ func TestForkPerTurnSession(t *testing.T) {
 		tmpDir := t.TempDir()
 		script := agenttest.WriteScript(t, tmpDir, "agent", `sleep 60`)
 		target := newTestTarget(tmpDir, script)
-		sess := NewForkPerTurnSession(target, noopHooks(), slog.Default())
+		sess := NewForkPerTurnSession(target, noopHooks(), slog.Default(), 0)
 
 		ctx, cancel := context.WithCancel(context.Background())
 		emit, events := sinkEvents()
@@ -119,7 +122,7 @@ func TestForkPerTurnSession(t *testing.T) {
 		stubUsage := domain.TokenUsage{InputTokens: 500, OutputTokens: 100, TotalTokens: 600}
 		hooks := noopHooks()
 		hooks.GetUsage = func() domain.TokenUsage { return stubUsage }
-		sess := NewForkPerTurnSession(target, hooks, slog.Default())
+		sess := NewForkPerTurnSession(target, hooks, slog.Default(), 0)
 
 		ctx, cancel := context.WithCancel(context.Background())
 		emit, events := sinkEvents()
@@ -156,7 +159,7 @@ func TestForkPerTurnSession(t *testing.T) {
 		tmpDir := t.TempDir()
 		script := agenttest.WriteScript(t, tmpDir, "agent", `sleep 60`)
 		target := newTestTarget(tmpDir, script)
-		sess := NewForkPerTurnSession(target, noopHooks(), slog.Default())
+		sess := NewForkPerTurnSession(target, noopHooks(), slog.Default(), 0)
 
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
@@ -181,7 +184,7 @@ printf '\n'
 `)
 		spy := &agenttest.LogSpy{}
 		target := newTestTarget(tmpDir, script)
-		sess := NewForkPerTurnSession(target, noopHooks(), slog.New(spy))
+		sess := NewForkPerTurnSession(target, noopHooks(), slog.New(spy), 0)
 
 		emit, events := sinkEvents()
 		_, err := sess.RunTurn(context.Background(), "p", emit)
@@ -203,7 +206,7 @@ printf '\n'
 		stubUsage := domain.TokenUsage{InputTokens: 500, OutputTokens: 100, TotalTokens: 600}
 		hooks := noopHooks()
 		hooks.GetUsage = func() domain.TokenUsage { return stubUsage }
-		sess := NewForkPerTurnSession(target, hooks, slog.Default())
+		sess := NewForkPerTurnSession(target, hooks, slog.Default(), 0)
 
 		emit, events := sinkEvents()
 		result, err := sess.RunTurn(context.Background(), "p", emit)
@@ -229,7 +232,7 @@ printf '\n'
 		// the context deadline fires.
 		script := agenttest.WriteScript(t, tmpDir, "agent", `while true; do echo '{}'; done`)
 		target := newTestTarget(tmpDir, script)
-		sess := NewForkPerTurnSession(target, noopHooks(), slog.Default())
+		sess := NewForkPerTurnSession(target, noopHooks(), slog.Default(), 0)
 
 		ctx, cancel := context.WithTimeout(context.Background(), 150*time.Millisecond)
 		defer cancel()
@@ -246,7 +249,7 @@ printf '\n'
 exit 127`)
 		spy := &agenttest.LogSpy{}
 		target := newTestTarget(tmpDir, script)
-		sess := NewForkPerTurnSession(target, noopHooks(), slog.New(spy))
+		sess := NewForkPerTurnSession(target, noopHooks(), slog.New(spy), 0)
 
 		emit, events := sinkEvents()
 		_, err := sess.RunTurn(context.Background(), "p", emit)
@@ -265,7 +268,7 @@ exit 127`)
 		script := agenttest.WriteScript(t, tmpDir, "agent", `kill -TERM $$
 sleep 60`)
 		target := newTestTarget(tmpDir, script)
-		sess := NewForkPerTurnSession(target, noopHooks(), slog.Default())
+		sess := NewForkPerTurnSession(target, noopHooks(), slog.Default(), 0)
 
 		emit, events := sinkEvents()
 		_, err := sess.RunTurn(context.Background(), "p", emit)
@@ -294,7 +297,7 @@ sleep 60`)
 			EmitTurnCompleted(emit, "success", 0, domain.TokenUsage{})
 			return domain.TurnResult{ExitReason: domain.EventTurnCompleted}, nil
 		}
-		sess := NewForkPerTurnSession(target, hooks, slog.Default())
+		sess := NewForkPerTurnSession(target, hooks, slog.Default(), 0)
 
 		emit, events := sinkEvents()
 		_, err := sess.RunTurn(context.Background(), "p", emit)
@@ -322,7 +325,7 @@ sleep 60`)
 				Message: "arm7 error",
 			}
 		}
-		sess := NewForkPerTurnSession(target, hooks, slog.New(spy))
+		sess := NewForkPerTurnSession(target, hooks, slog.New(spy), 0)
 
 		emit, events := sinkEvents()
 		_, err := sess.RunTurn(context.Background(), "p", emit)
@@ -350,7 +353,7 @@ exit 1`)
 				Message: "exit code 1",
 			}
 		}
-		sess := NewForkPerTurnSession(target, hooks, slog.New(spy))
+		sess := NewForkPerTurnSession(target, hooks, slog.New(spy), 0)
 
 		emit, events := sinkEvents()
 		_, err := sess.RunTurn(context.Background(), "p", emit)
@@ -377,7 +380,7 @@ exit 1`)
 				Message: "agent exited without output",
 			}
 		}
-		sess := NewForkPerTurnSession(target, hooks, slog.New(spy))
+		sess := NewForkPerTurnSession(target, hooks, slog.New(spy), 0)
 
 		emit, events := sinkEvents()
 		_, err := sess.RunTurn(context.Background(), "p", emit)
@@ -403,7 +406,7 @@ exit 1`)
 				Usage:      domain.TokenUsage{OutputTokens: 10},
 			}, nil
 		}
-		sess := NewForkPerTurnSession(target, hooks, slog.Default())
+		sess := NewForkPerTurnSession(target, hooks, slog.Default(), 0)
 
 		emit, events := sinkEvents()
 		_, err := sess.RunTurn(context.Background(), "p", emit)
@@ -437,7 +440,7 @@ exit 0`)
 			EmitTurnCompleted(emit, "ok", 0, domain.TokenUsage{})
 			return domain.TurnResult{ExitReason: domain.EventTurnCompleted}, nil
 		}
-		sess := NewForkPerTurnSession(target, hooks, slog.New(spy))
+		sess := NewForkPerTurnSession(target, hooks, slog.New(spy), 0)
 		sess.drainGrace = 50 * time.Millisecond // ten times shorter than the subprocess lifetime
 
 		emit, _ := sinkEvents()
@@ -473,7 +476,7 @@ echo 'second stderr line' >&2`)
 			EmitTurnCompleted(emit, "ok", 0, domain.TokenUsage{})
 			return domain.TurnResult{ExitReason: domain.EventTurnCompleted}, nil
 		}
-		sess := NewForkPerTurnSession(target, hooks, slog.Default())
+		sess := NewForkPerTurnSession(target, hooks, slog.Default(), 0)
 
 		emit, _ := sinkEvents()
 		_, err := sess.RunTurn(context.Background(), "p", emit)
@@ -493,7 +496,7 @@ echo 'second stderr line' >&2`)
 		tmpDir := t.TempDir()
 		script := agenttest.WriteScript(t, tmpDir, "agent", `sleep 60`)
 		target := newTestTarget(tmpDir, script)
-		sess := NewForkPerTurnSession(target, noopHooks(), slog.Default())
+		sess := NewForkPerTurnSession(target, noopHooks(), slog.Default(), 0)
 
 		emit, _ := sinkEvents()
 		done := make(chan struct{})
@@ -514,6 +517,210 @@ echo 'second stderr line' >&2`)
 		}
 	})
 
+	t.Run("StopGrace_ConfiguredValueResolved", func(t *testing.T) {
+		t.Parallel()
+		sess := NewForkPerTurnSession(&LaunchTarget{}, noopHooks(), slog.Default(), 250)
+
+		if sess.stopGrace != 250*time.Millisecond {
+			t.Errorf("NewForkPerTurnSession(..., 250).stopGrace = %v, want %v", sess.stopGrace, 250*time.Millisecond)
+		}
+	})
+
+	t.Run("StopGrace_AbsentDefaultsToBuiltIn", func(t *testing.T) {
+		t.Parallel()
+		sess := NewForkPerTurnSession(&LaunchTarget{}, noopHooks(), slog.Default(), 0)
+
+		if sess.stopGrace != procutil.DefaultStopGrace {
+			t.Errorf("NewForkPerTurnSession(..., 0).stopGrace = %v, want %v", sess.stopGrace, procutil.DefaultStopGrace)
+		}
+	})
+
+	t.Run("Stop_ConfiguredGraceBoundsTheWait", func(t *testing.T) {
+		t.Parallel()
+		tmpDir := t.TempDir()
+		script := agenttest.WriteScript(t, tmpDir, "agent", `trap '' TERM
+sleep 60`)
+		target := newTestTarget(tmpDir, script)
+		sess := NewForkPerTurnSession(target, noopHooks(), slog.Default(), 200)
+
+		emit, _ := sinkEvents()
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			sess.RunTurn(context.Background(), "p", emit) //nolint:errcheck // testing Stop's timing, not RunTurn's outcome
+		}()
+
+		time.Sleep(100 * time.Millisecond) // let the subprocess install its own TERM trap
+
+		start := time.Now()
+		if err := sess.Stop(context.Background()); err != nil {
+			t.Errorf("Stop() = %v, want nil", err)
+		}
+		elapsed := time.Since(start)
+
+		if elapsed > 2*time.Second {
+			t.Errorf("Stop() force-terminated after %v, want well under the built-in 5s default (proves the configured 200ms grace bounded the wait, not DefaultStopGrace)", elapsed)
+		}
+
+		select {
+		case <-done:
+		case <-time.After(6 * time.Second):
+			t.Fatal("RunTurn did not return within 6s after Stop")
+		}
+	})
+
+	t.Run("RunTurn_CancelledTurnEscalatesOnConfiguredGrace", func(t *testing.T) {
+		t.Parallel()
+		tmpDir := t.TempDir()
+		// A shell builtin busy-loop rather than "sleep 60": forking a
+		// separate sleep process would inherit the shell's ignored TERM
+		// disposition across exec (POSIX: SIG_IGN survives exec, unlike a
+		// caught handler) and keep the stdout pipe's write end open after
+		// os/exec's own WaitDelay escalation kills only the direct child,
+		// which would hang the scanner forever instead of exercising the
+		// bounded escalation this test measures.
+		script := agenttest.WriteScript(t, tmpDir, "agent", `trap '' TERM
+while :; do :; done`)
+		target := newTestTarget(tmpDir, script)
+		sess := NewForkPerTurnSession(target, noopHooks(), slog.Default(), 200)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		emit, _ := sinkEvents()
+		done := make(chan error, 1)
+		go func() {
+			_, err := sess.RunTurn(ctx, "p", emit)
+			done <- err
+		}()
+
+		time.Sleep(100 * time.Millisecond) // let the subprocess install its own TERM trap
+		start := time.Now()
+		cancel()
+
+		var err error
+		select {
+		case err = <-done:
+		case <-time.After(6 * time.Second):
+			t.Fatal("RunTurn did not return within 6s of cancellation")
+		}
+		elapsed := time.Since(start)
+
+		requireAgentError(t, err, domain.ErrTurnCancelled)
+		if elapsed > 2*time.Second {
+			t.Errorf("RunTurn's cancelled-turn escalation took %v, want well under the built-in 5s default (proves the configured 200ms grace bounded cmd.WaitDelay, not DefaultStopGrace)", elapsed)
+		}
+	})
+
+	t.Run("Stop_EscalationLogging", func(t *testing.T) {
+		t.Parallel()
+
+		t.Run("exit_inside_grace_emits_debug_and_no_warn", func(t *testing.T) {
+			t.Parallel()
+			tmpDir := t.TempDir()
+			script := agenttest.WriteScript(t, tmpDir, "agent", `trap 'exit 0' TERM
+sleep 60`)
+			target := newTestTarget(tmpDir, script)
+			var buf bytes.Buffer
+			logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+			sess := NewForkPerTurnSession(target, noopHooks(), logger, 2000)
+
+			emit, _ := sinkEvents()
+			done := make(chan struct{})
+			go func() {
+				defer close(done)
+				sess.RunTurn(context.Background(), "p", emit) //nolint:errcheck // testing log output, not the outcome
+			}()
+			time.Sleep(100 * time.Millisecond)
+
+			if err := sess.Stop(context.Background()); err != nil {
+				t.Errorf("Stop() = %v, want nil", err)
+			}
+			<-done
+
+			output := buf.String()
+			if !strings.Contains(output, "agent exited during the graceful phase") {
+				t.Errorf("Stop() did not log the exited-inside-grace Debug record: %s", output)
+			}
+			if !strings.Contains(output, `outcome=exited`) {
+				t.Errorf("Stop()'s Debug record missing outcome=exited: %s", output)
+			}
+			if strings.Contains(output, "level=WARN") {
+				t.Errorf("Stop() logged a Warn record for a clean exit, want none: %s", output)
+			}
+		})
+
+		t.Run("grace_elapsed_emits_warn_with_outcome_and_grace", func(t *testing.T) {
+			t.Parallel()
+			tmpDir := t.TempDir()
+			script := agenttest.WriteScript(t, tmpDir, "agent", `trap '' TERM
+sleep 60`)
+			target := newTestTarget(tmpDir, script)
+			var buf bytes.Buffer
+			logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+			sess := NewForkPerTurnSession(target, noopHooks(), logger, 150)
+
+			emit, _ := sinkEvents()
+			done := make(chan struct{})
+			go func() {
+				defer close(done)
+				sess.RunTurn(context.Background(), "p", emit) //nolint:errcheck // testing log output, not the outcome
+			}()
+			time.Sleep(100 * time.Millisecond)
+
+			if err := sess.Stop(context.Background()); err != nil {
+				t.Errorf("Stop() = %v, want nil", err)
+			}
+			<-done
+
+			output := buf.String()
+			if !strings.Contains(output, "agent did not exit inside the graceful period and was force-terminated") {
+				t.Errorf("Stop() did not log the grace-elapsed Warn record: %s", output)
+			}
+			if !strings.Contains(output, `outcome="grace elapsed"`) {
+				t.Errorf(`Stop()'s Warn record missing outcome="grace elapsed": %s`, output)
+			}
+			if !strings.Contains(output, "grace=") {
+				t.Errorf("Stop()'s Warn record missing the grace attribute: %s", output)
+			}
+		})
+
+		t.Run("caller_deadline_emits_warn_with_that_outcome", func(t *testing.T) {
+			t.Parallel()
+			tmpDir := t.TempDir()
+			script := agenttest.WriteScript(t, tmpDir, "agent", `trap '' TERM
+sleep 60`)
+			target := newTestTarget(tmpDir, script)
+			var buf bytes.Buffer
+			logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+			sess := NewForkPerTurnSession(target, noopHooks(), logger, 5000)
+
+			emit, _ := sinkEvents()
+			done := make(chan struct{})
+			go func() {
+				defer close(done)
+				sess.RunTurn(context.Background(), "p", emit) //nolint:errcheck // testing log output, not the outcome
+			}()
+			time.Sleep(100 * time.Millisecond)
+
+			stopCtx, cancel := context.WithTimeout(context.Background(), 150*time.Millisecond)
+			defer cancel()
+			err := sess.Stop(stopCtx)
+			if !errors.Is(err, context.DeadlineExceeded) {
+				t.Errorf("Stop() error = %v, want %v", err, context.DeadlineExceeded)
+			}
+
+			select {
+			case <-done:
+			case <-time.After(6 * time.Second):
+				t.Fatal("RunTurn did not return within 6s")
+			}
+
+			output := buf.String()
+			if !strings.Contains(output, `outcome="caller deadline"`) {
+				t.Errorf(`Stop()'s Warn record missing outcome="caller deadline": %s`, output)
+			}
+		})
+	})
+
 	t.Run("TurnCount_NotIncrementedOnStartFailure", func(t *testing.T) {
 		t.Parallel()
 		tmpDir := t.TempDir()
@@ -527,7 +734,7 @@ echo 'second stderr line' >&2`)
 			lastTurn = turn
 			return nil
 		}
-		sess := NewForkPerTurnSession(target, hooks, slog.Default())
+		sess := NewForkPerTurnSession(target, hooks, slog.Default(), 0)
 
 		// First call: cmd.Start() fails → s.turns must stay 0.
 		_, err := sess.RunTurn(context.Background(), "p", func(domain.AgentEvent) {})

--- a/internal/agent/agentcore/forkperturn_test.go
+++ b/internal/agent/agentcore/forkperturn_test.go
@@ -621,7 +621,11 @@ sleep 60`)
 			target := newTestTarget(tmpDir, script)
 			var buf bytes.Buffer
 			logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
-			sess := NewForkPerTurnSession(target, noopHooks(), logger, 2000)
+			// The grace is far longer than this exit needs. The subtest proves
+			// which record the clean-exit path emits, not that the grace bounds
+			// anything, and a tight bound races the runner's scheduler instead
+			// of testing the code.
+			sess := NewForkPerTurnSession(target, noopHooks(), logger, 30000)
 
 			emit, _ := sinkEvents()
 			done := make(chan struct{})

--- a/internal/agent/agentcore/forkperturn_test.go
+++ b/internal/agent/agentcore/forkperturn_test.go
@@ -6,7 +6,10 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
+	"os"
+	"path/filepath"
 	"slices"
 	"strings"
 	"testing"
@@ -18,6 +21,36 @@ import (
 )
 
 // --- helpers ---
+
+// writeTrapScript writes an agent script that installs a TERM trap,
+// touches a readiness marker, then runs body. It returns the script
+// path and the marker path. trap is the trap body quoted as the shell
+// expects it; body is the command the script blocks in afterwards.
+//
+// The marker exists because a fixed sleep cannot prove the trap is
+// installed. If the signal wins that race the shell exits on TERM's
+// default disposition, and the test then passes without exercising the
+// escalation it is named for.
+func writeTrapScript(t *testing.T, dir, trap, body string) (script, marker string) {
+	t.Helper()
+	marker = filepath.Join(dir, "trap-ready")
+	return agenttest.WriteScript(t, dir, "agent",
+		fmt.Sprintf("trap %s TERM\n: > %q\n%s", trap, marker, body)), marker
+}
+
+// waitForTrap blocks until the marker [writeTrapScript] returns appears,
+// so a caller signals the subprocess only once its trap is in place.
+func waitForTrap(t *testing.T, marker string) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(marker); err == nil {
+			return
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	t.Fatalf("subprocess did not install its TERM trap within 5s (marker %q absent)", marker)
+}
 
 // newTestTarget builds a minimal LaunchTarget pointing at absCmd with
 // tmpDir as the workspace directory.
@@ -538,8 +571,7 @@ echo 'second stderr line' >&2`)
 	t.Run("Stop_ConfiguredGraceBoundsTheWait", func(t *testing.T) {
 		t.Parallel()
 		tmpDir := t.TempDir()
-		script := agenttest.WriteScript(t, tmpDir, "agent", `trap '' TERM
-sleep 60`)
+		script, ready := writeTrapScript(t, tmpDir, `''`, "sleep 60")
 		target := newTestTarget(tmpDir, script)
 		sess := NewForkPerTurnSession(target, noopHooks(), slog.Default(), 200)
 
@@ -550,7 +582,7 @@ sleep 60`)
 			sess.RunTurn(context.Background(), "p", emit) //nolint:errcheck // testing Stop's timing, not RunTurn's outcome
 		}()
 
-		time.Sleep(100 * time.Millisecond) // let the subprocess install its own TERM trap
+		waitForTrap(t, ready)
 
 		start := time.Now()
 		if err := sess.Stop(context.Background()); err != nil {
@@ -579,8 +611,7 @@ sleep 60`)
 		// os/exec's own WaitDelay escalation kills only the direct child,
 		// which would hang the scanner forever instead of exercising the
 		// bounded escalation this test measures.
-		script := agenttest.WriteScript(t, tmpDir, "agent", `trap '' TERM
-while :; do :; done`)
+		script, ready := writeTrapScript(t, tmpDir, `''`, "while :; do :; done")
 		target := newTestTarget(tmpDir, script)
 		sess := NewForkPerTurnSession(target, noopHooks(), slog.Default(), 200)
 
@@ -592,7 +623,7 @@ while :; do :; done`)
 			done <- err
 		}()
 
-		time.Sleep(100 * time.Millisecond) // let the subprocess install its own TERM trap
+		waitForTrap(t, ready)
 		start := time.Now()
 		cancel()
 
@@ -616,8 +647,7 @@ while :; do :; done`)
 		t.Run("exit_inside_grace_emits_debug_and_no_warn", func(t *testing.T) {
 			t.Parallel()
 			tmpDir := t.TempDir()
-			script := agenttest.WriteScript(t, tmpDir, "agent", `trap 'exit 0' TERM
-sleep 60`)
+			script, ready := writeTrapScript(t, tmpDir, `'exit 0'`, "sleep 60")
 			target := newTestTarget(tmpDir, script)
 			var buf bytes.Buffer
 			logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
@@ -633,7 +663,7 @@ sleep 60`)
 				defer close(done)
 				sess.RunTurn(context.Background(), "p", emit) //nolint:errcheck // testing log output, not the outcome
 			}()
-			time.Sleep(100 * time.Millisecond)
+			waitForTrap(t, ready)
 
 			if err := sess.Stop(context.Background()); err != nil {
 				t.Errorf("Stop() = %v, want nil", err)
@@ -655,8 +685,7 @@ sleep 60`)
 		t.Run("grace_elapsed_emits_warn_with_outcome_and_grace", func(t *testing.T) {
 			t.Parallel()
 			tmpDir := t.TempDir()
-			script := agenttest.WriteScript(t, tmpDir, "agent", `trap '' TERM
-sleep 60`)
+			script, ready := writeTrapScript(t, tmpDir, `''`, "sleep 60")
 			target := newTestTarget(tmpDir, script)
 			var buf bytes.Buffer
 			logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
@@ -668,7 +697,7 @@ sleep 60`)
 				defer close(done)
 				sess.RunTurn(context.Background(), "p", emit) //nolint:errcheck // testing log output, not the outcome
 			}()
-			time.Sleep(100 * time.Millisecond)
+			waitForTrap(t, ready)
 
 			if err := sess.Stop(context.Background()); err != nil {
 				t.Errorf("Stop() = %v, want nil", err)
@@ -683,15 +712,17 @@ sleep 60`)
 				t.Errorf(`Stop()'s Warn record missing outcome="grace elapsed": %s`, output)
 			}
 			if !strings.Contains(output, "grace=") {
-				t.Errorf("Stop()'s Warn record missing the grace attribute: %s", output)
+				t.Errorf("Stop()'s Warn record missing the configured grace ceiling: %s", output)
+			}
+			if !strings.Contains(output, "elapsed=") {
+				t.Errorf("Stop()'s Warn record missing the elapsed wait: %s", output)
 			}
 		})
 
 		t.Run("caller_deadline_emits_warn_with_that_outcome", func(t *testing.T) {
 			t.Parallel()
 			tmpDir := t.TempDir()
-			script := agenttest.WriteScript(t, tmpDir, "agent", `trap '' TERM
-sleep 60`)
+			script, ready := writeTrapScript(t, tmpDir, `''`, "sleep 60")
 			target := newTestTarget(tmpDir, script)
 			var buf bytes.Buffer
 			logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
@@ -703,7 +734,7 @@ sleep 60`)
 				defer close(done)
 				sess.RunTurn(context.Background(), "p", emit) //nolint:errcheck // testing log output, not the outcome
 			}()
-			time.Sleep(100 * time.Millisecond)
+			waitForTrap(t, ready)
 
 			stopCtx, cancel := context.WithTimeout(context.Background(), 150*time.Millisecond)
 			defer cancel()

--- a/internal/agent/agentcore/forkperturn_test.go
+++ b/internal/agent/agentcore/forkperturn_test.go
@@ -23,19 +23,28 @@ import (
 // --- helpers ---
 
 // writeTrapScript writes an agent script that installs a TERM trap,
-// touches a readiness marker, then runs body. It returns the script
-// path and the marker path. trap is the trap body quoted as the shell
-// expects it; body is the command the script blocks in afterwards.
+// touches a readiness marker, then blocks. It returns the script path
+// and the marker path. trap is the trap body quoted as the shell
+// expects it.
 //
 // The marker exists because a fixed sleep cannot prove the trap is
 // installed. If the signal wins that race the shell exits on TERM's
 // default disposition, and the test then passes without exercising the
 // escalation it is named for.
-func writeTrapScript(t *testing.T, dir, trap, body string) (script, marker string) {
+//
+// The script blocks in a shell builtin loop rather than in sleep, so
+// the shell is the only process in the group. A forked child reopens
+// the race the marker closes: the signal can reach the group in the
+// window between the marker and the fork, leaving a child that never
+// received it, that holds the output pipe open, and that therefore
+// keeps cmd.Wait from returning for the child's whole lifetime. The
+// loop costs a few microseconds on the arm where the trap exits, and
+// at most the configured grace on the arms that ignore the signal.
+func writeTrapScript(t *testing.T, dir, trap string) (script, marker string) {
 	t.Helper()
 	marker = filepath.Join(dir, "trap-ready")
 	return agenttest.WriteScript(t, dir, "agent",
-		fmt.Sprintf("trap %s TERM\n: > %q\n%s", trap, marker, body)), marker
+		fmt.Sprintf("trap %s TERM\n: > %q\nwhile :; do :; done", trap, marker)), marker
 }
 
 // waitForTrap blocks until the marker [writeTrapScript] returns appears,
@@ -571,7 +580,7 @@ echo 'second stderr line' >&2`)
 	t.Run("Stop_ConfiguredGraceBoundsTheWait", func(t *testing.T) {
 		t.Parallel()
 		tmpDir := t.TempDir()
-		script, ready := writeTrapScript(t, tmpDir, `''`, "sleep 60")
+		script, ready := writeTrapScript(t, tmpDir, `''`)
 		target := newTestTarget(tmpDir, script)
 		sess := NewForkPerTurnSession(target, noopHooks(), slog.Default(), 200)
 
@@ -611,7 +620,7 @@ echo 'second stderr line' >&2`)
 		// os/exec's own WaitDelay escalation kills only the direct child,
 		// which would hang the scanner forever instead of exercising the
 		// bounded escalation this test measures.
-		script, ready := writeTrapScript(t, tmpDir, `''`, "while :; do :; done")
+		script, ready := writeTrapScript(t, tmpDir, `''`)
 		target := newTestTarget(tmpDir, script)
 		sess := NewForkPerTurnSession(target, noopHooks(), slog.Default(), 200)
 
@@ -647,7 +656,7 @@ echo 'second stderr line' >&2`)
 		t.Run("exit_inside_grace_emits_debug_and_no_warn", func(t *testing.T) {
 			t.Parallel()
 			tmpDir := t.TempDir()
-			script, ready := writeTrapScript(t, tmpDir, `'exit 0'`, "sleep 60")
+			script, ready := writeTrapScript(t, tmpDir, `'exit 0'`)
 			target := newTestTarget(tmpDir, script)
 			var buf bytes.Buffer
 			logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
@@ -685,7 +694,7 @@ echo 'second stderr line' >&2`)
 		t.Run("grace_elapsed_emits_warn_with_outcome_and_grace", func(t *testing.T) {
 			t.Parallel()
 			tmpDir := t.TempDir()
-			script, ready := writeTrapScript(t, tmpDir, `''`, "sleep 60")
+			script, ready := writeTrapScript(t, tmpDir, `''`)
 			target := newTestTarget(tmpDir, script)
 			var buf bytes.Buffer
 			logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
@@ -722,7 +731,7 @@ echo 'second stderr line' >&2`)
 		t.Run("caller_deadline_emits_warn_with_that_outcome", func(t *testing.T) {
 			t.Parallel()
 			tmpDir := t.TempDir()
-			script, ready := writeTrapScript(t, tmpDir, `''`, "sleep 60")
+			script, ready := writeTrapScript(t, tmpDir, `''`)
 			target := newTestTarget(tmpDir, script)
 			var buf bytes.Buffer
 			logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))

--- a/internal/agent/agentcore/forkperturn_unix_test.go
+++ b/internal/agent/agentcore/forkperturn_unix_test.go
@@ -113,7 +113,7 @@ func TestForkPerTurnSession_ProcessGroupIsolation(t *testing.T) {
 	script := writePgidScript(t, tmpDir, pidFile)
 
 	target := newTestTarget(tmpDir, script)
-	sess := NewForkPerTurnSession(target, noopHooks(), slog.Default())
+	sess := NewForkPerTurnSession(target, noopHooks(), slog.Default(), 0)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -157,7 +157,7 @@ func TestForkPerTurnSession_DescendantHoldsStderrOnly(t *testing.T) {
 	}
 
 	target := newTestTarget(tmpDir, script)
-	sess := NewForkPerTurnSession(target, hooks, slog.Default())
+	sess := NewForkPerTurnSession(target, hooks, slog.Default(), 0)
 	sess.drainGrace = 200 * time.Millisecond
 
 	emit, events := sinkEvents()

--- a/internal/agent/claude/claude.go
+++ b/internal/agent/claude/claude.go
@@ -345,7 +345,7 @@ func (a *ClaudeCodeAdapter) StartSession(_ context.Context, params domain.StartS
 		EmitSessionStartID: nil, // Claude emits EventSessionStarted from ParseLine on "system/init"
 	}
 
-	state.forkSession = agentcore.NewForkPerTurnSession(&state.target, hooks, state.logger())
+	state.forkSession = agentcore.NewForkPerTurnSession(&state.target, hooks, state.logger(), state.agentConfig.StopGraceMS)
 
 	return domain.Session{
 		ID:       sessionUUID,

--- a/internal/agent/clientprotocol/session.go
+++ b/internal/agent/clientprotocol/session.go
@@ -215,7 +215,8 @@ func startSession(ctx context.Context, origins *sessionOrigins, params domain.St
 		cmd = exec.CommandContext(ctx, target.Command, target.Args...) //nolint:gosec // args are constructed programmatically
 		cmd.Dir = target.WorkspacePath
 	}
-	procutil.SetGroupCancel(cmd)
+	grace := procutil.StopGrace(state.agentConfig.StopGraceMS)
+	procutil.SetGroupCancel(cmd, grace)
 	cmd.Env = os.Environ()
 
 	stdinPipe, err := cmd.StdinPipe()
@@ -275,7 +276,7 @@ func startSession(ctx context.Context, origins *sessionOrigins, params domain.St
 	go runPump(state)
 
 	teardownOnFailure := func() {
-		graceCtx, cancel := context.WithTimeout(ctx, procutil.DefaultStopGrace)
+		graceCtx, cancel := context.WithTimeout(ctx, grace)
 		defer cancel()
 		runTeardown(state, defaultTeardownOrder(ctx, graceCtx))
 	}
@@ -518,7 +519,7 @@ func stopSession(ctx context.Context, session domain.Session) error {
 	if !ok {
 		return fmt.Errorf("unexpected session internal type %T", session.Internal)
 	}
-	graceCtx, cancel := context.WithTimeout(ctx, procutil.DefaultStopGrace)
+	graceCtx, cancel := context.WithTimeout(ctx, procutil.StopGrace(state.agentConfig.StopGraceMS))
 	defer cancel()
 	runTeardown(state, defaultTeardownOrder(ctx, graceCtx))
 	return nil

--- a/internal/agent/clientprotocol/session.go
+++ b/internal/agent/clientprotocol/session.go
@@ -278,7 +278,7 @@ func startSession(ctx context.Context, origins *sessionOrigins, params domain.St
 	teardownOnFailure := func() {
 		graceCtx, cancel := context.WithTimeout(ctx, grace)
 		defer cancel()
-		runTeardown(state, defaultTeardownOrder(ctx, graceCtx))
+		runTeardown(state, defaultTeardownOrder(ctx, graceCtx, grace))
 	}
 
 	initResp, agentErr := doInitialize(ctx, state)
@@ -519,9 +519,10 @@ func stopSession(ctx context.Context, session domain.Session) error {
 	if !ok {
 		return fmt.Errorf("unexpected session internal type %T", session.Internal)
 	}
-	graceCtx, cancel := context.WithTimeout(ctx, procutil.StopGrace(state.agentConfig.StopGraceMS))
+	grace := procutil.StopGrace(state.agentConfig.StopGraceMS)
+	graceCtx, cancel := context.WithTimeout(ctx, grace)
 	defer cancel()
-	runTeardown(state, defaultTeardownOrder(ctx, graceCtx))
+	runTeardown(state, defaultTeardownOrder(ctx, graceCtx, grace))
 	return nil
 }
 
@@ -560,12 +561,12 @@ type teardownStep struct {
 // before the pump's answer would be written. Closing that gap needs a
 // synchronization point between teardown and the pump that this order
 // does not add.
-func defaultTeardownOrder(callerCtx, graceCtx context.Context) []teardownStep {
+func defaultTeardownOrder(callerCtx, graceCtx context.Context, grace time.Duration) []teardownStep {
 	return []teardownStep{
 		{name: "answer_open", run: signalAnswerOpen},
 		{name: "signal_graceful", run: signalGraceful},
 		{name: "close_stdin", run: closeStdin},
-		{name: "await_exit", run: awaitExit(callerCtx, graceCtx)},
+		{name: "await_exit", run: awaitExit(callerCtx, graceCtx, grace)},
 		{name: "kill_process_group", run: killProcessGroup},
 		{name: "close_stdout", run: closeStdout},
 		{name: "close_connection", run: closeConnection},
@@ -625,7 +626,7 @@ func signalGraceful(state *sessionState) {
 // was already signalled and reaped ahead of StopSession, and treating
 // that race as an escalation would warn about a state loss that never
 // happened.
-func awaitExit(callerCtx, graceCtx context.Context) func(state *sessionState) {
+func awaitExit(callerCtx, graceCtx context.Context, grace time.Duration) func(state *sessionState) {
 	return func(state *sessionState) {
 		if state.pid <= 0 || state.waitCh == nil {
 			return
@@ -649,7 +650,8 @@ func awaitExit(callerCtx, graceCtx context.Context) func(state *sessionState) {
 				outcome = "caller deadline"
 			}
 			state.logger.Warn("agent did not exit inside the graceful period and was force-terminated",
-				slog.String("outcome", outcome), slog.Duration("grace", time.Since(started)))
+				slog.String("outcome", outcome), slog.Duration("grace", grace),
+				slog.Duration("elapsed", time.Since(started)))
 		}
 	}
 }

--- a/internal/agent/clientprotocol/session_teardown_test.go
+++ b/internal/agent/clientprotocol/session_teardown_test.go
@@ -784,3 +784,27 @@ func TestStopSessionTeardownEscalationLogging(t *testing.T) {
 		}
 	})
 }
+
+// TestStopSessionGrace_ConfiguredValueBoundsTheWait asserts that
+// stopSession's graceCtx expires at a configured agent.stop_grace_ms,
+// not at the built-in five-second default: a small configured grace
+// against an agent that ignores the graceful signal entirely must force
+// the process well short of the default's ceiling.
+func TestStopSessionGrace_ConfiguredValueBoundsTheWait(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	readyPath := filepath.Join(dir, "ready")
+	state := newGracefulTeardownSession(t, teardownIgnoresGracefulScript(readyPath), readyPath, nil)
+	state.agentConfig.StopGraceMS = 200
+
+	start := time.Now()
+	if err := stopSession(context.Background(), fakeSession(state)); err != nil {
+		t.Fatalf("stopSession() error = %v", err)
+	}
+	elapsed := time.Since(start)
+
+	if elapsed > 2*time.Second {
+		t.Errorf("stopSession() force-terminated after %v, want well under the built-in 5s default (proves the configured 200ms grace bounded graceCtx, not DefaultStopGrace)", elapsed)
+	}
+}

--- a/internal/agent/clientprotocol/session_teardown_test.go
+++ b/internal/agent/clientprotocol/session_teardown_test.go
@@ -606,7 +606,7 @@ func TestStopSessionTeardownGracefulHandler(t *testing.T) {
 			{name: "answer_open", run: signalAnswerOpen},
 			{name: "kill_process_group", run: killProcessGroup},
 			{name: "close_stdin", run: closeStdin},
-			{name: "await_exit", run: awaitExit(callerCtx, graceCtx)},
+			{name: "await_exit", run: awaitExit(callerCtx, graceCtx, procutil.DefaultStopGrace)},
 			{name: "signal_graceful", run: signalGraceful},
 			{name: "close_stdout", run: closeStdout},
 			{name: "close_connection", run: closeConnection},
@@ -750,13 +750,18 @@ func TestStopSessionTeardownEscalationLogging(t *testing.T) {
 		if !strings.Contains(output, `outcome="caller deadline"`) {
 			t.Errorf("teardown's Warn record did not carry outcome=\"caller deadline\": %s", output)
 		}
-		// The record reports the wait that actually elapsed, not the
-		// ceiling: a caller deadline shorter than the grace ends the
-		// wait early, and reporting the ceiling here would tell an
-		// operator the adapter waited five seconds when it waited a
-		// fraction of one.
-		if strings.Contains(output, "grace="+procutil.DefaultStopGrace.String()) {
-			t.Errorf("teardown's Warn record reported the full grace ceiling for a wait cut short by the caller's deadline: %s", output)
+		// The record carries both the configured ceiling and the wait
+		// that actually elapsed. A caller deadline shorter than the
+		// grace ends the wait early, so elapsed must not be the whole
+		// ceiling: reporting only the ceiling would tell an operator
+		// the adapter waited five seconds when it waited a fraction of
+		// one, and reporting only the elapsed time would hide what the
+		// operator configured.
+		if strings.Contains(output, "elapsed="+procutil.DefaultStopGrace.String()) {
+			t.Errorf("teardown's Warn record reported the full grace ceiling as elapsed for a wait cut short by the caller's deadline: %s", output)
+		}
+		if !strings.Contains(output, "grace=") {
+			t.Errorf("teardown's Warn record did not carry the configured grace ceiling: %s", output)
 		}
 	})
 

--- a/internal/agent/codex/codex.go
+++ b/internal/agent/codex/codex.go
@@ -895,8 +895,12 @@ func reroutedMessage(toModel string) string {
 	return "model rerouted to " + toModel
 }
 
-// StopSession terminates the persistent app-server subprocess.
-func (a *CodexAdapter) StopSession(_ context.Context, session domain.Session) error {
+// StopSession terminates the persistent app-server subprocess. The
+// configured stop grace is a ceiling on the wait for a clean exit; a
+// caller deadline that expires first ends the graceful phase and is
+// reported back, so the caller learns the stop did not complete on its
+// own terms.
+func (a *CodexAdapter) StopSession(ctx context.Context, session domain.Session) error {
 	state, ok := session.Internal.(*sessionState)
 	if !ok {
 		return fmt.Errorf("unexpected session internal type %T", session.Internal)
@@ -928,15 +932,16 @@ func (a *CodexAdapter) StopSession(_ context.Context, session domain.Session) er
 		state.threadID,
 	)
 
-	// Wait for process exit within the configured grace period.
+	// Wait for process exit within the configured grace period, or
+	// until the caller's deadline ends it first.
+	var stopErr error
 	if waitCh != nil {
+		grace := procutil.StopGrace(state.agentConfig.StopGraceMS)
 		started := time.Now()
-		select {
-		case <-waitCh:
-			logger.Debug("agent exited during the graceful phase", slog.String("outcome", "exited"))
-		case <-time.After(procutil.StopGrace(state.agentConfig.StopGraceMS)):
+		escalate := func(outcome string) {
 			logger.Warn("agent did not exit inside the graceful period and was force-terminated",
-				slog.String("outcome", "grace elapsed"), slog.Duration("grace", time.Since(started)))
+				slog.String("outcome", outcome), slog.Duration("grace", grace),
+				slog.Duration("elapsed", time.Since(started)))
 			if pid > 0 {
 				procutil.KillProcessGroup(pid) //nolint:errcheck,gosec // best-effort force kill
 			}
@@ -945,6 +950,15 @@ func (a *CodexAdapter) StopSession(_ context.Context, session domain.Session) er
 			case <-waitCh:
 			case <-time.After(2 * time.Second):
 			}
+		}
+		select {
+		case <-waitCh:
+			logger.Debug("agent exited during the graceful phase", slog.String("outcome", "exited"))
+		case <-time.After(grace):
+			escalate("grace elapsed")
+		case <-ctx.Done():
+			escalate("caller deadline")
+			stopErr = ctx.Err()
 		}
 	}
 
@@ -964,7 +978,7 @@ func (a *CodexAdapter) StopSession(_ context.Context, session domain.Session) er
 	state.waitCh = nil
 	state.mu.Unlock()
 
-	return nil
+	return stopErr
 }
 
 // isAgentError extracts an *[domain.AgentError] from err using type

--- a/internal/agent/codex/codex.go
+++ b/internal/agent/codex/codex.go
@@ -251,7 +251,8 @@ func (a *CodexAdapter) StartSession(ctx context.Context, params domain.StartSess
 	} else {
 		cmd = exec.CommandContext(ctx, target.Command, target.Args...) //nolint:gosec // args are constructed programmatically
 	}
-	procutil.SetGroupCancel(cmd)
+	grace := procutil.StopGrace(state.agentConfig.StopGraceMS)
+	procutil.SetGroupCancel(cmd, grace)
 	cmd.Dir = target.WorkspacePath
 	cmd.Env = os.Environ()
 
@@ -922,11 +923,20 @@ func (a *CodexAdapter) StopSession(_ context.Context, session domain.Session) er
 		procutil.SignalGraceful(pid) //nolint:errcheck,gosec // best-effort graceful shutdown
 	}
 
-	// Wait for process exit with a 5-second grace period.
+	logger := logging.WithSession(
+		slog.Default().With(slog.String("component", "codex-adapter")),
+		state.threadID,
+	)
+
+	// Wait for process exit within the configured grace period.
 	if waitCh != nil {
+		started := time.Now()
 		select {
 		case <-waitCh:
-		case <-time.After(5 * time.Second):
+			logger.Debug("agent exited during the graceful phase", slog.String("outcome", "exited"))
+		case <-time.After(procutil.StopGrace(state.agentConfig.StopGraceMS)):
+			logger.Warn("agent did not exit inside the graceful period and was force-terminated",
+				slog.String("outcome", "grace elapsed"), slog.Duration("grace", time.Since(started)))
 			if pid > 0 {
 				procutil.KillProcessGroup(pid) //nolint:errcheck,gosec // best-effort force kill
 			}
@@ -943,10 +953,6 @@ func (a *CodexAdapter) StopSession(_ context.Context, session domain.Session) er
 		select {
 		case <-state.readerDone:
 		case <-time.After(2 * time.Second):
-			logger := logging.WithSession(
-				slog.Default().With(slog.String("component", "codex-adapter")),
-				state.threadID,
-			)
 			logger.Warn("reader goroutine did not exit after process termination")
 		}
 	}

--- a/internal/agent/codex/codex_test.go
+++ b/internal/agent/codex/codex_test.go
@@ -771,11 +771,12 @@ while :; do :; done`, 200)
 	}
 }
 
-// TestStopSession_EscalationLogging asserts the escalation record pair
+// TestStopSession_EscalationLogging asserts the escalation records
 // codex's StopSession emits: Debug on an exit inside the grace, and
-// Warn naming the outcome and elapsed grace when it expires.
-// StopSession ignores its ctx parameter, so "grace elapsed" is the
-// only escalation outcome this family can report.
+// Warn naming the outcome, the configured ceiling and the elapsed wait
+// when the phase ends without one. Both escalation outcomes are
+// reachable here, because StopSession ends the phase on whichever of
+// the grace and the caller's deadline arrives first.
 func TestStopSession_EscalationLogging(t *testing.T) {
 	// No t.Parallel(): installs a global slog default.
 

--- a/internal/agent/codex/codex_test.go
+++ b/internal/agent/codex/codex_test.go
@@ -757,7 +757,7 @@ func TestStopSession_ConfiguredGraceBoundsTheWait(t *testing.T) {
 	t.Parallel()
 
 	state := startFakeCodexProcess(t, `trap '' TERM
-sleep 60`, 200)
+while :; do :; done`, 200)
 
 	start := time.Now()
 	err := (&CodexAdapter{}).StopSession(context.Background(), domain.Session{Internal: state})
@@ -790,7 +790,7 @@ func TestStopSession_EscalationLogging(t *testing.T) {
 		// anything, and a tight bound races the runner's scheduler instead
 		// of testing the code.
 		state := startFakeCodexProcess(t, `trap 'exit 0' TERM
-sleep 60`, 30000)
+while :; do :; done`, 30000)
 
 		if err := (&CodexAdapter{}).StopSession(context.Background(), domain.Session{Internal: state}); err != nil {
 			t.Errorf("StopSession() = %v, want nil", err)
@@ -815,7 +815,7 @@ sleep 60`, 30000)
 		t.Cleanup(func() { slog.SetDefault(orig) })
 
 		state := startFakeCodexProcess(t, `trap '' TERM
-sleep 60`, 150)
+while :; do :; done`, 150)
 
 		if err := (&CodexAdapter{}).StopSession(context.Background(), domain.Session{Internal: state}); err != nil {
 			t.Errorf("StopSession() = %v, want nil", err)
@@ -833,6 +833,42 @@ sleep 60`, 150)
 		}
 		if !strings.Contains(output, "elapsed=") {
 			t.Errorf("StopSession()'s Warn record missing the elapsed wait: %s", output)
+		}
+	})
+
+	t.Run("caller_deadline_ends_the_phase_and_is_reported", func(t *testing.T) {
+		var buf bytes.Buffer
+		orig := slog.Default()
+		slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+		t.Cleanup(func() { slog.SetDefault(orig) })
+
+		// The grace is far longer than the deadline, so only a
+		// StopSession that reads its context can end this phase. When
+		// it ignored the context, this arm waited out the whole grace
+		// and then reported success.
+		state := startFakeCodexProcess(t, `trap '' TERM
+while :; do :; done`, 30000)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 150*time.Millisecond)
+		defer cancel()
+
+		start := time.Now()
+		err := (&CodexAdapter{}).StopSession(ctx, domain.Session{Internal: state})
+		elapsed := time.Since(start)
+
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Errorf("StopSession() = %v, want context.DeadlineExceeded", err)
+		}
+		if elapsed > 10*time.Second {
+			t.Errorf("StopSession() returned after %v, want the caller's deadline to end the phase far below the 30s grace", elapsed)
+		}
+
+		output := buf.String()
+		if !strings.Contains(output, `outcome="caller deadline"`) {
+			t.Errorf(`StopSession()'s Warn record missing outcome="caller deadline": %s`, output)
+		}
+		if !strings.Contains(output, "grace=30s") {
+			t.Errorf("StopSession()'s Warn record did not report the configured 30s ceiling: %s", output)
 		}
 	})
 }

--- a/internal/agent/codex/codex_test.go
+++ b/internal/agent/codex/codex_test.go
@@ -829,7 +829,10 @@ sleep 60`, 150)
 			t.Errorf(`StopSession()'s Warn record missing outcome="grace elapsed": %s`, output)
 		}
 		if !strings.Contains(output, "grace=") {
-			t.Errorf("StopSession()'s Warn record missing the grace attribute: %s", output)
+			t.Errorf("StopSession()'s Warn record missing the configured grace ceiling: %s", output)
+		}
+		if !strings.Contains(output, "elapsed=") {
+			t.Errorf("StopSession()'s Warn record missing the elapsed wait: %s", output)
 		}
 	})
 }

--- a/internal/agent/codex/codex_test.go
+++ b/internal/agent/codex/codex_test.go
@@ -3,12 +3,15 @@
 package codex
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -21,6 +24,7 @@ import (
 	"github.com/sortie-ai/sortie/internal/agent/agenttest"
 	"github.com/sortie-ai/sortie/internal/agent/agenttest/dispositiontest"
 	"github.com/sortie-ai/sortie/internal/agent/jsonrpc"
+	"github.com/sortie-ai/sortie/internal/agent/procutil"
 	"github.com/sortie-ai/sortie/internal/domain"
 	"github.com/sortie-ai/sortie/internal/registry"
 )
@@ -693,4 +697,135 @@ func TestStopSession_ReturnsWhileWriteParked(t *testing.T) {
 	case <-time.After(500 * time.Millisecond):
 		t.Fatal("StopSession() did not return while a write was parked, want it to return well short of its own 5-second graceful-wait ceiling")
 	}
+}
+
+// startFakeCodexProcess writes scriptBody, touching a readiness marker
+// right after its leading trap statement so a caller's subsequent
+// SignalGraceful cannot race the shell installing the trap, starts it
+// in its own process group, and wires a minimal sessionState around it
+// with an already-closed readerDone (this harness has no reader
+// goroutine for StopSession to wait for).
+func startFakeCodexProcess(t *testing.T, scriptBody string, stopGraceMS int) *sessionState {
+	t.Helper()
+
+	dir := t.TempDir()
+	readyPath := filepath.Join(dir, "ready")
+	trapLine, rest, ok := strings.Cut(scriptBody, "\n")
+	if !ok || !strings.HasPrefix(trapLine, "trap ") {
+		t.Fatalf("startFakeCodexProcess: scriptBody must start with a trap statement, got %q", scriptBody)
+	}
+	script := trapLine + "\ntouch '" + readyPath + "'\n" + rest
+	scriptPath := agenttest.WriteScript(t, dir, "agent.sh", script)
+
+	cmd := exec.Command(scriptPath) //nolint:gosec // fixed path under t.TempDir()
+	procutil.SetProcessGroup(cmd)
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("cmd.Start() = %v", err)
+	}
+	t.Cleanup(func() { procutil.KillProcessGroup(cmd.Process.Pid) }) //nolint:errcheck // best-effort cleanup
+
+	readerDone := make(chan struct{})
+	close(readerDone)
+
+	state := &sessionState{
+		agentConfig: domain.AgentConfig{StopGraceMS: stopGraceMS},
+		proc:        cmd.Process,
+		waitCh:      make(chan struct{}),
+		readerDone:  readerDone,
+		stopCh:      make(chan struct{}),
+	}
+	go func() {
+		cmd.Wait() //nolint:errcheck,gosec // best-effort reap; exit state is irrelevant here
+		close(state.waitCh)
+	}()
+
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(readyPath); err == nil {
+			return state
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("startFakeCodexProcess: readiness marker %q did not appear within 5s", readyPath)
+	return nil
+}
+
+// TestStopSession_ConfiguredGraceBoundsTheWait asserts that a
+// configured agent.stop_grace_ms bounds StopSession's graceful wait,
+// not the built-in five-second default.
+func TestStopSession_ConfiguredGraceBoundsTheWait(t *testing.T) {
+	t.Parallel()
+
+	state := startFakeCodexProcess(t, `trap '' TERM
+sleep 60`, 200)
+
+	start := time.Now()
+	err := (&CodexAdapter{}).StopSession(context.Background(), domain.Session{Internal: state})
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.Errorf("StopSession() = %v, want nil", err)
+	}
+	if elapsed > 2*time.Second {
+		t.Errorf("StopSession() force-terminated after %v, want well under the built-in 5s default (proves the configured 200ms grace bounded the wait, not DefaultStopGrace)", elapsed)
+	}
+}
+
+// TestStopSession_EscalationLogging asserts the escalation record pair
+// codex's StopSession emits: Debug on an exit inside the grace, and
+// Warn naming the outcome and elapsed grace when it expires.
+// StopSession ignores its ctx parameter, so "grace elapsed" is the
+// only escalation outcome this family can report.
+func TestStopSession_EscalationLogging(t *testing.T) {
+	// No t.Parallel(): installs a global slog default.
+
+	t.Run("exit_inside_grace_emits_debug_and_no_warn", func(t *testing.T) {
+		var buf bytes.Buffer
+		orig := slog.Default()
+		slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+		t.Cleanup(func() { slog.SetDefault(orig) })
+
+		state := startFakeCodexProcess(t, `trap 'exit 0' TERM
+sleep 60`, 2000)
+
+		if err := (&CodexAdapter{}).StopSession(context.Background(), domain.Session{Internal: state}); err != nil {
+			t.Errorf("StopSession() = %v, want nil", err)
+		}
+
+		output := buf.String()
+		if !strings.Contains(output, "agent exited during the graceful phase") {
+			t.Errorf("StopSession() did not log the exited-inside-grace Debug record: %s", output)
+		}
+		if !strings.Contains(output, `outcome=exited`) {
+			t.Errorf("StopSession()'s Debug record missing outcome=exited: %s", output)
+		}
+		if strings.Contains(output, "level=WARN") {
+			t.Errorf("StopSession() logged a Warn record for a clean exit, want none: %s", output)
+		}
+	})
+
+	t.Run("grace_elapsed_emits_warn_with_outcome_and_grace", func(t *testing.T) {
+		var buf bytes.Buffer
+		orig := slog.Default()
+		slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+		t.Cleanup(func() { slog.SetDefault(orig) })
+
+		state := startFakeCodexProcess(t, `trap '' TERM
+sleep 60`, 150)
+
+		if err := (&CodexAdapter{}).StopSession(context.Background(), domain.Session{Internal: state}); err != nil {
+			t.Errorf("StopSession() = %v, want nil", err)
+		}
+
+		output := buf.String()
+		if !strings.Contains(output, "agent did not exit inside the graceful period and was force-terminated") {
+			t.Errorf("StopSession() did not log the grace-elapsed Warn record: %s", output)
+		}
+		if !strings.Contains(output, `outcome="grace elapsed"`) {
+			t.Errorf(`StopSession()'s Warn record missing outcome="grace elapsed": %s`, output)
+		}
+		if !strings.Contains(output, "grace=") {
+			t.Errorf("StopSession()'s Warn record missing the grace attribute: %s", output)
+		}
+	})
 }

--- a/internal/agent/codex/codex_test.go
+++ b/internal/agent/codex/codex_test.go
@@ -785,8 +785,12 @@ func TestStopSession_EscalationLogging(t *testing.T) {
 		slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
 		t.Cleanup(func() { slog.SetDefault(orig) })
 
+		// The grace is far longer than this exit needs. The subtest proves
+		// which record the clean-exit path emits, not that the grace bounds
+		// anything, and a tight bound races the runner's scheduler instead
+		// of testing the code.
 		state := startFakeCodexProcess(t, `trap 'exit 0' TERM
-sleep 60`, 2000)
+sleep 60`, 30000)
 
 		if err := (&CodexAdapter{}).StopSession(context.Background(), domain.Session{Internal: state}); err != nil {
 			t.Errorf("StopSession() = %v, want nil", err)

--- a/internal/agent/copilot/copilot.go
+++ b/internal/agent/copilot/copilot.go
@@ -571,7 +571,7 @@ func (a *CopilotAdapter) StartSession(ctx context.Context, params domain.StartSe
 		EmitSessionStartID: func() string { return state.copilotSessionID },
 	}
 
-	state.forkSession = agentcore.NewForkPerTurnSession(&state.target, hooks, state.logger())
+	state.forkSession = agentcore.NewForkPerTurnSession(&state.target, hooks, state.logger(), state.agentConfig.StopGraceMS)
 
 	return domain.Session{
 		ID:       copilotSessionID,

--- a/internal/agent/kiro/kiro.go
+++ b/internal/agent/kiro/kiro.go
@@ -193,7 +193,7 @@ func (a *KiroAdapter) StartSession(ctx context.Context, params domain.StartSessi
 		},
 	}
 
-	state.forkSession = agentcore.NewForkPerTurnSession(&state.target, hooks, state.logger())
+	state.forkSession = agentcore.NewForkPerTurnSession(&state.target, hooks, state.logger(), state.agentConfig.StopGraceMS)
 
 	return domain.Session{
 		ID:       state.sessionID,

--- a/internal/agent/opencode/opencode.go
+++ b/internal/agent/opencode/opencode.go
@@ -225,7 +225,7 @@ func (a *OpenCodeAdapter) RunTurn(ctx context.Context, session domain.Session, p
 		allArgs := append(slices.Clone(state.target.Args), cmdArgs...)
 		cmd = exec.CommandContext(ctx, state.target.Command, allArgs...) //nolint:gosec // args are constructed programmatically
 	}
-	procutil.SetGroupCancel(cmd)
+	procutil.SetGroupCancel(cmd, procutil.StopGrace(state.agentConfig.StopGraceMS))
 	cmd.Dir = state.target.WorkspacePath
 	cmd.Env = env
 
@@ -519,7 +519,7 @@ func (a *OpenCodeAdapter) StopSession(ctx context.Context, session domain.Sessio
 	state.active = nil
 	state.mu.Unlock()
 
-	return stopActiveTurn(ctx, active)
+	return stopActiveTurn(ctx, active, procutil.StopGrace(state.agentConfig.StopGraceMS), state.logger())
 }
 
 // finalizeExitedTurn builds and emits the turn's terminal disposition once
@@ -760,7 +760,10 @@ func closeStop(runtime *turnRuntime) {
 	})
 }
 
-func stopActiveTurn(ctx context.Context, runtime *turnRuntime) error {
+// stopActiveTurn signals runtime's subprocess to exit gracefully and
+// waits up to grace for it to do so on its own before force-terminating
+// its process group. logger receives the graceful phase's outcome.
+func stopActiveTurn(ctx context.Context, runtime *turnRuntime, grace time.Duration, logger *slog.Logger) error {
 	if runtime == nil {
 		return nil
 	}
@@ -772,16 +775,22 @@ func stopActiveTurn(ctx context.Context, runtime *turnRuntime) error {
 
 	_ = procutil.SignalGraceful(runtime.proc.Pid) //nolint:errcheck // best-effort signal; process may already be dead
 
-	graceTimer := time.NewTimer(5 * time.Second)
+	started := time.Now()
+	graceTimer := time.NewTimer(grace)
 	defer stopTimer(graceTimer)
 
 	select {
 	case <-runtime.waitCh:
+		logger.Debug("agent exited during the graceful phase", slog.String("outcome", "exited"))
 		return nil
 	case <-graceTimer.C:
+		logger.Warn("agent did not exit inside the graceful period and was force-terminated",
+			slog.String("outcome", "grace elapsed"), slog.Duration("grace", time.Since(started)))
 		killTurnProcess(runtime)
 		return nil
 	case <-ctx.Done():
+		logger.Warn("agent did not exit inside the graceful period and was force-terminated",
+			slog.String("outcome", "caller deadline"), slog.Duration("grace", time.Since(started)))
 		killTurnProcess(runtime)
 		return ctx.Err()
 	}

--- a/internal/agent/opencode/opencode.go
+++ b/internal/agent/opencode/opencode.go
@@ -785,12 +785,14 @@ func stopActiveTurn(ctx context.Context, runtime *turnRuntime, grace time.Durati
 		return nil
 	case <-graceTimer.C:
 		logger.Warn("agent did not exit inside the graceful period and was force-terminated",
-			slog.String("outcome", "grace elapsed"), slog.Duration("grace", time.Since(started)))
+			slog.String("outcome", "grace elapsed"), slog.Duration("grace", grace),
+			slog.Duration("elapsed", time.Since(started)))
 		killTurnProcess(runtime)
 		return nil
 	case <-ctx.Done():
 		logger.Warn("agent did not exit inside the graceful period and was force-terminated",
-			slog.String("outcome", "caller deadline"), slog.Duration("grace", time.Since(started)))
+			slog.String("outcome", "caller deadline"), slog.Duration("grace", grace),
+			slog.Duration("elapsed", time.Since(started)))
 		killTurnProcess(runtime)
 		return ctx.Err()
 	}

--- a/internal/agent/opencode/opencode_test.go
+++ b/internal/agent/opencode/opencode_test.go
@@ -638,7 +638,10 @@ sleep 60`)
 			t.Errorf(`stopActiveTurn()'s Warn record missing outcome="grace elapsed": %s`, output)
 		}
 		if !strings.Contains(output, "grace=") {
-			t.Errorf("stopActiveTurn()'s Warn record missing the grace attribute: %s", output)
+			t.Errorf("stopActiveTurn()'s Warn record missing the configured grace ceiling: %s", output)
+		}
+		if !strings.Contains(output, "elapsed=") {
+			t.Errorf("stopActiveTurn()'s Warn record missing the elapsed wait: %s", output)
 		}
 	})
 

--- a/internal/agent/opencode/opencode_test.go
+++ b/internal/agent/opencode/opencode_test.go
@@ -578,7 +578,7 @@ func TestStopActiveTurn_GraceCoverage(t *testing.T) {
 	t.Run("configured_grace_bounds_the_wait", func(t *testing.T) {
 		t.Parallel()
 		runtime := startTurnRuntimeProcess(t, `trap '' TERM
-sleep 60`)
+while :; do :; done`)
 
 		start := time.Now()
 		err := stopActiveTurn(context.Background(), runtime, 200*time.Millisecond, slog.Default())
@@ -595,7 +595,7 @@ sleep 60`)
 	t.Run("exit_inside_grace_emits_debug_and_no_warn", func(t *testing.T) {
 		t.Parallel()
 		runtime := startTurnRuntimeProcess(t, `trap 'exit 0' TERM
-sleep 60`)
+while :; do :; done`)
 		var buf bytes.Buffer
 		logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
 
@@ -622,7 +622,7 @@ sleep 60`)
 	t.Run("grace_elapsed_emits_warn_with_outcome_and_grace", func(t *testing.T) {
 		t.Parallel()
 		runtime := startTurnRuntimeProcess(t, `trap '' TERM
-sleep 60`)
+while :; do :; done`)
 		var buf bytes.Buffer
 		logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
 
@@ -648,7 +648,7 @@ sleep 60`)
 	t.Run("caller_deadline_emits_warn_with_that_outcome", func(t *testing.T) {
 		t.Parallel()
 		runtime := startTurnRuntimeProcess(t, `trap '' TERM
-sleep 60`)
+while :; do :; done`)
 		var buf bytes.Buffer
 		logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
 

--- a/internal/agent/opencode/opencode_test.go
+++ b/internal/agent/opencode/opencode_test.go
@@ -508,6 +508,230 @@ while :; do sleep 1; done`)
 	}
 }
 
+// startTurnRuntimeProcess starts script as a real subprocess in its own
+// process group and wires a minimal turnRuntime around it, wiring
+// waitCh to close once the process is reaped. Used to exercise
+// stopActiveTurn directly, without the rest of RunTurn's JSONL parsing.
+// startTurnRuntimeProcess writes scriptBody with a leading trap
+// statement, starts it, and waits for it to touch a readiness marker
+// before returning, so the caller's subsequent SignalGraceful cannot
+// race the shell installing its trap. scriptBody's first line MUST be
+// a "trap ..." statement; the marker touch is inserted right after it.
+func startTurnRuntimeProcess(t *testing.T, scriptBody string) *turnRuntime {
+	t.Helper()
+
+	dir := t.TempDir()
+	readyPath := filepath.Join(dir, "ready")
+	trapLine, rest, ok := strings.Cut(scriptBody, "\n")
+	if !ok || !strings.HasPrefix(trapLine, "trap ") {
+		t.Fatalf("startTurnRuntimeProcess: scriptBody must start with a trap statement, got %q", scriptBody)
+	}
+	script := trapLine + "\ntouch '" + readyPath + "'\n" + rest
+	scriptPath := agenttest.WriteScript(t, dir, "agent.sh", script)
+
+	cmd := exec.Command(scriptPath) //nolint:gosec // fixed path under t.TempDir()
+	procutil.SetProcessGroup(cmd)
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("cmd.Start() = %v", err)
+	}
+	t.Cleanup(func() { procutil.KillProcessGroup(cmd.Process.Pid) }) //nolint:errcheck // best-effort cleanup
+
+	runtime := &turnRuntime{
+		proc:   cmd.Process,
+		waitCh: make(chan waitResult),
+		stopCh: make(chan struct{}),
+	}
+	go func() {
+		waitErr := cmd.Wait()
+		runtime.waitMu.Lock()
+		runtime.waitRes = waitResult{exitCode: procutil.ExtractExitCode(waitErr), err: waitErr}
+		runtime.waitMu.Unlock()
+		close(runtime.waitCh)
+	}()
+
+	waitForReady(t, readyPath)
+	return runtime
+}
+
+// waitForReady polls until path exists, failing t after 5 seconds. Used
+// to synchronize with a script that touches path only after installing
+// a signal trap, so a caller's subsequent signal cannot race the trap
+// installation.
+func waitForReady(t *testing.T, path string) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(path); err == nil {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("waitForReady(%q): marker did not appear within 5s", path)
+}
+
+// TestStopActiveTurn_GraceCoverage calls stopActiveTurn directly so the
+// configured grace and its escalation log records can be asserted
+// without spending the built-in five-second default in wall clock.
+func TestStopActiveTurn_GraceCoverage(t *testing.T) {
+	t.Parallel()
+
+	t.Run("configured_grace_bounds_the_wait", func(t *testing.T) {
+		t.Parallel()
+		runtime := startTurnRuntimeProcess(t, `trap '' TERM
+sleep 60`)
+
+		start := time.Now()
+		err := stopActiveTurn(context.Background(), runtime, 200*time.Millisecond, slog.Default())
+		elapsed := time.Since(start)
+
+		if err != nil {
+			t.Errorf("stopActiveTurn() = %v, want nil", err)
+		}
+		if elapsed > 2*time.Second {
+			t.Errorf("stopActiveTurn() force-terminated after %v, want well under the built-in 5s default (proves the configured 200ms grace bounded the wait, not DefaultStopGrace)", elapsed)
+		}
+	})
+
+	t.Run("exit_inside_grace_emits_debug_and_no_warn", func(t *testing.T) {
+		t.Parallel()
+		runtime := startTurnRuntimeProcess(t, `trap 'exit 0' TERM
+sleep 60`)
+		var buf bytes.Buffer
+		logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+		if err := stopActiveTurn(context.Background(), runtime, 2*time.Second, logger); err != nil {
+			t.Errorf("stopActiveTurn() = %v, want nil", err)
+		}
+
+		output := buf.String()
+		if !strings.Contains(output, "agent exited during the graceful phase") {
+			t.Errorf("stopActiveTurn() did not log the exited-inside-grace Debug record: %s", output)
+		}
+		if !strings.Contains(output, `outcome=exited`) {
+			t.Errorf("stopActiveTurn()'s Debug record missing outcome=exited: %s", output)
+		}
+		if strings.Contains(output, "level=WARN") {
+			t.Errorf("stopActiveTurn() logged a Warn record for a clean exit, want none: %s", output)
+		}
+	})
+
+	t.Run("grace_elapsed_emits_warn_with_outcome_and_grace", func(t *testing.T) {
+		t.Parallel()
+		runtime := startTurnRuntimeProcess(t, `trap '' TERM
+sleep 60`)
+		var buf bytes.Buffer
+		logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+		if err := stopActiveTurn(context.Background(), runtime, 150*time.Millisecond, logger); err != nil {
+			t.Errorf("stopActiveTurn() = %v, want nil", err)
+		}
+
+		output := buf.String()
+		if !strings.Contains(output, "agent did not exit inside the graceful period and was force-terminated") {
+			t.Errorf("stopActiveTurn() did not log the grace-elapsed Warn record: %s", output)
+		}
+		if !strings.Contains(output, `outcome="grace elapsed"`) {
+			t.Errorf(`stopActiveTurn()'s Warn record missing outcome="grace elapsed": %s`, output)
+		}
+		if !strings.Contains(output, "grace=") {
+			t.Errorf("stopActiveTurn()'s Warn record missing the grace attribute: %s", output)
+		}
+	})
+
+	t.Run("caller_deadline_emits_warn_with_that_outcome", func(t *testing.T) {
+		t.Parallel()
+		runtime := startTurnRuntimeProcess(t, `trap '' TERM
+sleep 60`)
+		var buf bytes.Buffer
+		logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+		ctx, cancel := context.WithTimeout(context.Background(), 150*time.Millisecond)
+		defer cancel()
+		if err := stopActiveTurn(ctx, runtime, 5*time.Second, logger); !errors.Is(err, context.DeadlineExceeded) {
+			t.Errorf("stopActiveTurn() = %v, want %v", err, context.DeadlineExceeded)
+		}
+
+		output := buf.String()
+		if !strings.Contains(output, `outcome="caller deadline"`) {
+			t.Errorf(`stopActiveTurn()'s Warn record missing outcome="caller deadline": %s`, output)
+		}
+	})
+}
+
+// TestRunTurn_CancelledTurnEscalatesOnConfiguredGrace asserts that a
+// cancelled turn's process-group cancellation, wired through
+// procutil.SetGroupCancel inside RunTurn, escalates on the session's
+// configured grace rather than the built-in five-second default.
+func TestRunTurn_CancelledTurnEscalatesOnConfiguredGrace(t *testing.T) {
+	t.Parallel()
+
+	testCtx, testCancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer testCancel()
+
+	tmpDir := t.TempDir()
+	// A shell builtin busy-loop rather than a forked "sleep": a forked
+	// child would inherit the shell's ignored TERM disposition across
+	// exec and keep the stdout pipe open after os/exec's own WaitDelay
+	// escalation kills only the direct child, hanging the reader
+	// instead of exercising the bounded escalation this test measures.
+	script := writeOpenCodeScript(t, tmpDir, `case "$1" in
+  export) echo '{"messages":[]}'; exit 0;;
+esac
+trap '' TERM
+printf '{"type":"step_start","timestamp":1000,"sessionID":"ses_abc123","part":{"id":"p1","messageID":"m1","sessionID":"ses_abc123","snapshot":"","type":"step-start"}}\n'
+while :; do :; done`)
+
+	a, _ := NewOpenCodeAdapter(map[string]any{})
+	session, err := a.StartSession(testCtx, domain.StartSessionParams{
+		WorkspacePath: tmpDir,
+		AgentConfig:   domain.AgentConfig{Command: script, StopGraceMS: 200},
+	})
+	if err != nil {
+		t.Fatalf("StartSession() error = %v", err)
+	}
+
+	gotEvent := make(chan struct{}, 1)
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		_, runErr := a.RunTurn(ctx, session, domain.RunTurnParams{
+			Prompt: "work",
+			OnEvent: func(_ domain.AgentEvent) {
+				select {
+				case gotEvent <- struct{}{}:
+				default:
+				}
+			},
+		})
+		done <- runErr
+	}()
+
+	select {
+	case <-gotEvent:
+	case <-testCtx.Done():
+		t.Fatal("timed out waiting for first event")
+	}
+
+	start := time.Now()
+	cancel()
+
+	var runErr error
+	select {
+	case runErr = <-done:
+	case <-time.After(6 * time.Second):
+		t.Fatal("RunTurn did not return within 6s of cancellation")
+	}
+	elapsed := time.Since(start)
+
+	var agentErr *domain.AgentError
+	if !errors.As(runErr, &agentErr) || agentErr.Kind != domain.ErrTurnCancelled {
+		t.Errorf("RunTurn() error = %v, want AgentError{Kind: %q}", runErr, domain.ErrTurnCancelled)
+	}
+	if elapsed > 2*time.Second {
+		t.Errorf("RunTurn's cancelled-turn escalation took %v, want well under the built-in 5s default (proves the configured 200ms grace bounded cmd.WaitDelay, not DefaultStopGrace)", elapsed)
+	}
+}
+
 func TestStopSession_WrongInternalType(t *testing.T) {
 	t.Parallel()
 

--- a/internal/agent/opencode/opencode_test.go
+++ b/internal/agent/opencode/opencode_test.go
@@ -599,7 +599,11 @@ sleep 60`)
 		var buf bytes.Buffer
 		logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
 
-		if err := stopActiveTurn(context.Background(), runtime, 2*time.Second, logger); err != nil {
+		// The grace is far longer than this exit needs. The subtest proves
+		// which record the clean-exit path emits, not that the grace bounds
+		// anything, and a tight bound races the runner's scheduler instead
+		// of testing the code.
+		if err := stopActiveTurn(context.Background(), runtime, 30*time.Second, logger); err != nil {
 			t.Errorf("stopActiveTurn() = %v, want nil", err)
 		}
 

--- a/internal/agent/procutil/pgid.go
+++ b/internal/agent/procutil/pgid.go
@@ -1,13 +1,18 @@
 package procutil
 
-import "os/exec"
+import (
+	"os/exec"
+	"time"
+)
 
 // SetGroupCancel prepares cmd so that cancelling the context it was
 // built with tears down the whole process group rather than the direct
 // child alone. It places cmd in its own process group, sends that group
 // a catchable termination signal when the context is cancelled, and caps
-// the wait that follows at [DefaultStopGrace] before os/exec escalates
-// to a force kill.
+// the wait that follows at grace before os/exec escalates to a force
+// kill. A non-positive grace resolves to [DefaultStopGrace]: os/exec
+// reads a zero WaitDelay as no limit, so passing zero through would
+// silently remove the escalation to a force kill.
 //
 // Call it before [exec.Cmd.Start], on a command created with
 // [exec.CommandContext]: os/exec rejects a cancellation function on a
@@ -17,10 +22,13 @@ import "os/exec"
 // the direct child and does so uncatchably. A subprocess that flushes
 // state on a clean exit never reaches that path, and every descendant it
 // started outlives the cancellation.
-func SetGroupCancel(cmd *exec.Cmd) {
+func SetGroupCancel(cmd *exec.Cmd, grace time.Duration) {
 	SetProcessGroup(cmd)
 	cmd.Cancel = func() error {
 		return SignalGraceful(cmd.Process.Pid)
 	}
-	cmd.WaitDelay = DefaultStopGrace
+	if grace <= 0 {
+		grace = DefaultStopGrace
+	}
+	cmd.WaitDelay = grace
 }

--- a/internal/agent/procutil/pgid_test.go
+++ b/internal/agent/procutil/pgid_test.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 )
 
 // TestSetGroupCancel_Wiring covers what is observable without starting a
@@ -25,7 +26,7 @@ func TestSetGroupCancel_Wiring(t *testing.T) {
 	defaultCancel := reflect.ValueOf(exec.CommandContext(ctx, os.Args[0]).Cancel).Pointer()
 
 	cmd := exec.CommandContext(ctx, os.Args[0])
-	SetGroupCancel(cmd)
+	SetGroupCancel(cmd, DefaultStopGrace)
 
 	if cmd.SysProcAttr == nil {
 		t.Error("SetGroupCancel() SysProcAttr = nil, want non-nil (the command must join its own process group)")
@@ -35,6 +36,39 @@ func TestSetGroupCancel_Wiring(t *testing.T) {
 	}
 	if cmd.WaitDelay != DefaultStopGrace {
 		t.Errorf("SetGroupCancel() WaitDelay = %v, want %v", cmd.WaitDelay, DefaultStopGrace)
+	}
+}
+
+// TestSetGroupCancel_GraceResolution asserts WaitDelay is set to
+// the grace passed when it is positive, and falls back to
+// DefaultStopGrace when it is non-positive, so a cancelled turn never
+// loses its escalation to a force kill by inheriting os/exec's
+// zero-WaitDelay "no limit" reading.
+func TestSetGroupCancel_GraceResolution(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		grace time.Duration
+		want  time.Duration
+	}{
+		{"PositiveGraceHonored", 250 * time.Millisecond, 250 * time.Millisecond},
+		{"ZeroGraceFallsBackToDefault", 0, DefaultStopGrace},
+		{"NegativeGraceFallsBackToDefault", -5 * time.Second, DefaultStopGrace},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := t.Context()
+			cmd := exec.CommandContext(ctx, os.Args[0])
+			SetGroupCancel(cmd, tt.grace)
+
+			if cmd.WaitDelay != tt.want {
+				t.Errorf("SetGroupCancel(cmd, %v) WaitDelay = %v, want %v", tt.grace, cmd.WaitDelay, tt.want)
+			}
+		})
 	}
 }
 
@@ -50,7 +84,7 @@ func TestSetGroupCancel_RequiresCommandContext(t *testing.T) {
 	// Start reaches the Cancel precondition instead of failing earlier
 	// on lookup. It is never executed, because that check returns first.
 	cmd := exec.Command(os.Args[0])
-	SetGroupCancel(cmd)
+	SetGroupCancel(cmd, DefaultStopGrace)
 
 	err := cmd.Start()
 	if err == nil {

--- a/internal/agent/procutil/pgid_unix_test.go
+++ b/internal/agent/procutil/pgid_unix_test.go
@@ -172,7 +172,7 @@ func TestSetGroupCancel_CancelReachesDescendant(t *testing.T) {
 	defer cancel()
 
 	cmd := exec.CommandContext(ctx, "/bin/sh", leader)
-	SetGroupCancel(cmd)
+	SetGroupCancel(cmd, DefaultStopGrace)
 	if err := cmd.Start(); err != nil {
 		t.Fatalf("cmd.Start() = %v, want nil", err)
 	}

--- a/internal/agent/procutil/procutil.go
+++ b/internal/agent/procutil/procutil.go
@@ -89,6 +89,21 @@ func WithScannerMax(n int) CollectorOption {
 	}
 }
 
+// StopGrace resolves a configured millisecond count to the duration an
+// adapter's graceful phase spends waiting for the agent to exit before
+// it force-terminates the process group. A non-positive ms resolves to
+// [DefaultStopGrace].
+//
+// Every adapter family reaches a stop-grace duration through StopGrace
+// rather than converting a millisecond count inline, so the
+// non-positive fallback cannot disagree between families.
+func StopGrace(ms int) time.Duration {
+	if ms <= 0 {
+		return DefaultStopGrace
+	}
+	return time.Duration(ms) * time.Millisecond
+}
+
 // ExtractExitCode returns the process exit code from an
 // [*exec.ExitError], or -1 if the error is not an ExitError.
 //

--- a/internal/agent/procutil/procutil_test.go
+++ b/internal/agent/procutil/procutil_test.go
@@ -64,6 +64,37 @@ func TestExtractExitCode(t *testing.T) {
 	}
 }
 
+// TestStopGrace asserts a non-positive ms resolves to
+// DefaultStopGrace, and a positive one resolves to the exact
+// millisecond-to-duration conversion.
+func TestStopGrace(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		ms   int
+		want time.Duration
+	}{
+		{"Zero", 0, DefaultStopGrace},
+		{"NegativeOne", -1, DefaultStopGrace},
+		{"LargeNegative", -60000, DefaultStopGrace},
+		{"OneMillisecond", 1, time.Millisecond},
+		{"OneSecond", 1000, time.Second},
+		{"ExactBuiltInDefaultInMS", 5000, DefaultStopGrace},
+		{"ArbitraryPositive", 1500, 1500 * time.Millisecond},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := StopGrace(tt.ms)
+			if got != tt.want {
+				t.Errorf("StopGrace(%d) = %v, want %v", tt.ms, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestStderrCollector(t *testing.T) {
 	t.Parallel()
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -218,6 +218,13 @@ type AgentConfig struct {
 	MaxConcurrentByState map[string]int
 	MaxSessions          int
 
+	// StopGraceMS is the period an adapter waits, after sending a
+	// catchable termination signal, for the agent to exit on its own
+	// before it force-terminates the process group. Always positive:
+	// the configuration layer rejects a non-positive value rather than
+	// reading it as a sentinel that removes the grace.
+	StopGraceMS int
+
 	// MaxTokens is the cumulative per-issue token ceiling enforced at
 	// dispatch preflight. 0 means unlimited.
 	MaxTokens int
@@ -261,17 +268,18 @@ const (
 // preflight validator and the adapter constructor read, so the two can
 // never disagree about what an adapter of that kind would see.
 //
-// The map carries exactly five keys derived from cfg.Agent's typed
+// The map carries exactly six keys derived from cfg.Agent's typed
 // fields: kind (set to the kind parameter rather than cfg.Agent.Kind,
 // so a dispatch-rule-routed kind resolves correctly), command,
-// turn_timeout_ms, read_timeout_ms, and stall_timeout_ms. Every other
+// turn_timeout_ms, read_timeout_ms, stall_timeout_ms, and
+// stop_grace_ms. Every other
 // [AgentConfig] field is intentionally excluded: those fields are
 // orchestrator-only, consumed through the typed [AgentConfig] before
 // this map reaches a constructor, and including them would shadow an
 // adapter extension key of the same name during the merge below.
 //
 // The kind-named sub-object under cfg.extensions, if present, is
-// merged in without overwriting any of the five keys above. The
+// merged in without overwriting any of the six keys above. The
 // returned map is freshly allocated on every call.
 func AgentAdapterConfig(cfg ServiceConfig, kind string) map[string]any {
 	m, _, _ := agentAdapterConfig(cfg, kind)
@@ -292,6 +300,7 @@ func agentAdapterConfig(cfg ServiceConfig, kind string) (m map[string]any, prese
 		"turn_timeout_ms":  cfg.Agent.TurnTimeoutMS,
 		"read_timeout_ms":  cfg.Agent.ReadTimeoutMS,
 		"stall_timeout_ms": cfg.Agent.StallTimeoutMS,
+		"stop_grace_ms":    cfg.Agent.StopGraceMS,
 	}
 	presence, description = mergeExtensionSection(m, cfg.extensions, kind)
 	return m, presence, description
@@ -315,7 +324,7 @@ type AgentSettings struct {
 
 	// BlockPresence reports what the front matter carries under the
 	// top-level key named Kind. Passthrough is never empty and cannot
-	// answer this: AgentAdapterConfig seeds five keys before any
+	// answer this: AgentAdapterConfig seeds six keys before any
 	// merge.
 	BlockPresence ExtensionBlockPresence
 
@@ -879,6 +888,30 @@ func buildAgentConfig(m map[string]any) (AgentConfig, error) {
 		stallTimeoutMS = parsed
 	}
 
+	stopGraceMS := 5000
+	if v, exists := m["stop_grace_ms"]; exists && v != nil {
+		parsed, err := coerceInt(v)
+		if err != nil {
+			return AgentConfig{}, &ConfigError{
+				Field:   "agent.stop_grace_ms",
+				Message: fmt.Sprintf("invalid integer value: %v", v),
+			}
+		}
+		stopGraceMS = parsed
+	}
+	if stopGraceMS <= 0 {
+		return AgentConfig{}, &ConfigError{
+			Field:   "agent.stop_grace_ms",
+			Message: "must be greater than 0",
+		}
+	}
+	if int64(stopGraceMS) > MaxDurationMS {
+		return AgentConfig{}, &ConfigError{
+			Field:   "agent.stop_grace_ms",
+			Message: fmt.Sprintf("must not exceed %d (about 292 years), got %d", MaxDurationMS, stopGraceMS),
+		}
+	}
+
 	maxConcurrent, err := coerceIntField(m, "max_concurrent_agents", "agent.max_concurrent_agents")
 	if err != nil {
 		return AgentConfig{}, err
@@ -955,6 +988,7 @@ func buildAgentConfig(m map[string]any) (AgentConfig, error) {
 		TurnTimeoutMS:          turnTimeoutMS,
 		ReadTimeoutMS:          readTimeoutMS,
 		StallTimeoutMS:         stallTimeoutMS,
+		StopGraceMS:            stopGraceMS,
 		MaxConcurrentAgents:    maxConcurrent,
 		MaxTurns:               maxTurns,
 		MaxRetryBackoffMS:      maxRetryBackoff,

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -2677,6 +2678,65 @@ func TestNewServiceConfig_AgentTurnTimeoutMS(t *testing.T) {
 	})
 }
 
+// TestNewServiceConfig_AgentStopGraceMS mirrors
+// TestNewServiceConfig_AgentTurnTimeoutMS for agent.stop_grace_ms: a
+// non-positive value is rejected, an absent key defaults to
+// procutil.DefaultStopGrace's millisecond equivalent, a non-integer
+// value is rejected, and a value above MaxDurationMS is rejected with
+// a message naming the ceiling.
+func TestNewServiceConfig_AgentStopGraceMS(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Zero", func(t *testing.T) {
+		t.Parallel()
+		_, err := NewServiceConfig(map[string]any{"agent": map[string]any{"stop_grace_ms": 0}})
+		assertConfigErrorField(t, err, "agent.stop_grace_ms")
+		var ce *ConfigError
+		errors.As(err, &ce)
+		assertStringEqual(t, "ConfigError.Message", "must be greater than 0", ce.Message)
+	})
+
+	t.Run("Negative", func(t *testing.T) {
+		t.Parallel()
+		_, err := NewServiceConfig(map[string]any{"agent": map[string]any{"stop_grace_ms": -1}})
+		assertConfigErrorField(t, err, "agent.stop_grace_ms")
+		var ce *ConfigError
+		errors.As(err, &ce)
+		assertStringEqual(t, "ConfigError.Message", "must be greater than 0", ce.Message)
+	})
+
+	t.Run("AbsentKeyDefaults", func(t *testing.T) {
+		t.Parallel()
+		cfg, err := NewServiceConfig(map[string]any{})
+		if err != nil {
+			t.Fatalf("NewServiceConfig: %v", err)
+		}
+		assertIntEqual(t, "Agent.StopGraceMS", 5000, cfg.Agent.StopGraceMS)
+	})
+
+	t.Run("NonInteger", func(t *testing.T) {
+		t.Parallel()
+		_, err := NewServiceConfig(map[string]any{"agent": map[string]any{"stop_grace_ms": "abc"}})
+		assertConfigErrorField(t, err, "agent.stop_grace_ms")
+		var ce *ConfigError
+		errors.As(err, &ce)
+		if !strings.Contains(ce.Message, "invalid integer value") {
+			t.Errorf("ConfigError.Message = %q, want it to contain %q", ce.Message, "invalid integer value")
+		}
+	})
+
+	t.Run("AboveCeiling", func(t *testing.T) {
+		t.Parallel()
+		over := int(MaxDurationMS) + 1
+		_, err := NewServiceConfig(map[string]any{"agent": map[string]any{"stop_grace_ms": over}})
+		assertConfigErrorField(t, err, "agent.stop_grace_ms")
+		var ce *ConfigError
+		errors.As(err, &ce)
+		wantMsg := fmt.Sprintf("must not exceed %d (about 292 years), got %d", MaxDurationMS, over)
+		assertStringEqual(t, "ConfigError.Message", wantMsg, ce.Message)
+	})
+}
+
 // TestPopulateCIFeedbackFromReactions exercises the bridge function that
 // maps a ReactionConfig for the "ci_failure" kind into a CIFeedbackConfig.
 func TestPopulateCIFeedbackFromReactions(t *testing.T) {
@@ -3392,10 +3452,10 @@ func TestNewServiceConfigExtensions(t *testing.T) {
 
 // --- AgentAdapterConfig tests ---
 
-// TestAgentAdapterConfig_ExactlyFiveKeysWithNoExtensions asserts that
-// AgentAdapterConfig returns exactly the five documented keys when
+// TestAgentAdapterConfig_ExactlySixKeysWithNoExtensions asserts that
+// AgentAdapterConfig returns exactly the six documented keys when
 // cfg.extensions carries no sub-object for kind.
-func TestAgentAdapterConfig_ExactlyFiveKeysWithNoExtensions(t *testing.T) {
+func TestAgentAdapterConfig_ExactlySixKeysWithNoExtensions(t *testing.T) {
 	t.Parallel()
 
 	cfg := ServiceConfig{
@@ -3405,6 +3465,7 @@ func TestAgentAdapterConfig_ExactlyFiveKeysWithNoExtensions(t *testing.T) {
 			TurnTimeoutMS:  3600000,
 			ReadTimeoutMS:  5000,
 			StallTimeoutMS: 300000,
+			StopGraceMS:    5000,
 		},
 	}
 
@@ -3416,6 +3477,7 @@ func TestAgentAdapterConfig_ExactlyFiveKeysWithNoExtensions(t *testing.T) {
 		"turn_timeout_ms":  3600000,
 		"read_timeout_ms":  5000,
 		"stall_timeout_ms": 300000,
+		"stop_grace_ms":    5000,
 	}
 	if len(got) != len(want) {
 		t.Fatalf("AgentAdapterConfig() = %v (len %d), want exactly %d keys: %v", got, len(got), len(want), want)
@@ -3474,9 +3536,9 @@ func TestAgentAdapterConfig_ExtensionCollisionWithOrchestratorOnlyFieldSurvives(
 		t.Errorf(`AgentAdapterConfig()["approval_policy"] = %v, want "never"`, got["approval_policy"])
 	}
 
-	// The exact key set: the five documented keys plus the two merged
+	// The exact key set: the six documented keys plus the two merged
 	// extension keys, nothing else.
-	wantKeys := []string{"kind", "command", "turn_timeout_ms", "read_timeout_ms", "stall_timeout_ms", "max_turns", "approval_policy"}
+	wantKeys := []string{"kind", "command", "turn_timeout_ms", "read_timeout_ms", "stall_timeout_ms", "stop_grace_ms", "max_turns", "approval_policy"}
 	if len(got) != len(wantKeys) {
 		t.Fatalf("AgentAdapterConfig() = %v (len %d), want exactly the keys %v", got, len(got), wantKeys)
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2727,7 +2727,10 @@ func TestNewServiceConfig_AgentStopGraceMS(t *testing.T) {
 
 	t.Run("AboveCeiling", func(t *testing.T) {
 		t.Parallel()
-		over := int(MaxDurationMS) + 1
+		// int64 throughout: int(MaxDurationMS) is a constant conversion
+		// that does not fit a 32-bit int, so it fails to compile on such a
+		// target rather than at run time. coerceInt accepts int64.
+		over := MaxDurationMS + 1
 		_, err := NewServiceConfig(map[string]any{"agent": map[string]any{"stop_grace_ms": over}})
 		assertConfigErrorField(t, err, "agent.stop_grace_ms")
 		var ce *ConfigError

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2680,10 +2680,13 @@ func TestNewServiceConfig_AgentTurnTimeoutMS(t *testing.T) {
 
 // TestNewServiceConfig_AgentStopGraceMS mirrors
 // TestNewServiceConfig_AgentTurnTimeoutMS for agent.stop_grace_ms: a
-// non-positive value is rejected, an absent key defaults to
-// procutil.DefaultStopGrace's millisecond equivalent, a non-integer
-// value is rejected, and a value above MaxDurationMS is rejected with
-// a message naming the ceiling.
+// non-positive value is rejected, an absent key defaults to 5000, a
+// non-integer value is rejected, and a value above MaxDurationMS is
+// rejected with a message naming the ceiling.
+//
+// The default is a literal here because this layer cannot import the
+// package that owns the built-in grace. That the two agree is asserted
+// where both are in scope, in the orchestrator's tests.
 func TestNewServiceConfig_AgentStopGraceMS(t *testing.T) {
 	t.Parallel()
 

--- a/internal/config/duration.go
+++ b/internal/config/duration.go
@@ -1,0 +1,10 @@
+package config
+
+import (
+	"math"
+	"time"
+)
+
+// MaxDurationMS is the largest millisecond count whose conversion to a
+// time.Duration stays positive.
+const MaxDurationMS int64 = math.MaxInt64 / int64(time.Millisecond)

--- a/internal/config/envoverride.go
+++ b/internal/config/envoverride.go
@@ -82,6 +82,7 @@ var envOverrides = []envOverride{
 	{"SORTIE_AGENT_MAX_SESSIONS", "agent", "max_sessions", coerceEnvInt},
 	{"SORTIE_AGENT_MAX_TOKENS", "agent", "max_tokens", coerceEnvInt},
 	{"SORTIE_AGENT_MAX_CONSECUTIVE_ABSENCES", "agent", "max_consecutive_absences", coerceEnvInt},
+	{"SORTIE_AGENT_STOP_GRACE_MS", "agent", "stop_grace_ms", coerceEnvInt},
 
 	// Top-level
 	{"SORTIE_DB_PATH", "", "db_path", coerceString},

--- a/internal/config/envoverride_test.go
+++ b/internal/config/envoverride_test.go
@@ -559,6 +559,60 @@ func TestApplyEnvOverrides(t *testing.T) {
 		assertEnvOverrideError(t, err, "agent.max_consecutive_absences", "must be greater than 0")
 	})
 
+	t.Run("agent stop grace override reaches config with no YAML key", func(t *testing.T) {
+		t.Setenv("SORTIE_AGENT_STOP_GRACE_MS", "1500")
+
+		cfg, err := NewServiceConfig(map[string]any{})
+		if err != nil {
+			t.Fatalf("NewServiceConfig: unexpected error: %v", err)
+		}
+		if cfg.Agent.StopGraceMS != 1500 {
+			t.Errorf("Agent.StopGraceMS = %d, want 1500", cfg.Agent.StopGraceMS)
+		}
+	})
+
+	t.Run("agent stop grace override replaces a file-supplied value", func(t *testing.T) {
+		t.Setenv("SORTIE_AGENT_STOP_GRACE_MS", "1500")
+
+		cfg, err := NewServiceConfig(map[string]any{
+			"agent": map[string]any{"stop_grace_ms": 3000},
+		})
+		if err != nil {
+			t.Fatalf("NewServiceConfig: unexpected error: %v", err)
+		}
+		if cfg.Agent.StopGraceMS != 1500 {
+			t.Errorf("Agent.StopGraceMS = %d, want 1500 (env overrides the file value)", cfg.Agent.StopGraceMS)
+		}
+	})
+
+	t.Run("agent stop grace override unset leaves file value", func(t *testing.T) {
+		t.Setenv("SORTIE_AGENT_STOP_GRACE_MS", "")
+
+		cfg, err := NewServiceConfig(map[string]any{
+			"agent": map[string]any{"stop_grace_ms": 9000},
+		})
+		if err != nil {
+			t.Fatalf("NewServiceConfig: unexpected error: %v", err)
+		}
+		if cfg.Agent.StopGraceMS != 9000 {
+			t.Errorf("Agent.StopGraceMS = %d, want 9000 (file value retained when unset)", cfg.Agent.StopGraceMS)
+		}
+	})
+
+	t.Run("agent stop grace override zero fails config construction", func(t *testing.T) {
+		t.Setenv("SORTIE_AGENT_STOP_GRACE_MS", "0")
+
+		_, err := NewServiceConfig(map[string]any{})
+		assertEnvOverrideError(t, err, "agent.stop_grace_ms", "must be greater than 0")
+	})
+
+	t.Run("agent stop grace override non-coercible value names the field and the variable", func(t *testing.T) {
+		t.Setenv("SORTIE_AGENT_STOP_GRACE_MS", "abc")
+
+		_, err := NewServiceConfig(map[string]any{})
+		assertEnvOverrideError(t, err, "agent.stop_grace_ms", "SORTIE_AGENT_STOP_GRACE_MS")
+	})
+
 	t.Run("top-level SORTIE_DB_PATH", func(t *testing.T) {
 		t.Setenv("SORTIE_DB_PATH", "/data/sortie.db")
 

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -97,6 +97,7 @@ var knownFieldsRegistry = map[string]SectionSchema{
 			{Name: "max_sessions", Type: FieldInt},
 			{Name: "max_tokens", Type: FieldInt},
 			{Name: "max_consecutive_absences", Type: FieldInt},
+			{Name: "stop_grace_ms", Type: FieldInt},
 		},
 		AllowAdapterPassthrough: true,
 	},

--- a/internal/config/schema_test.go
+++ b/internal/config/schema_test.go
@@ -590,6 +590,22 @@ func TestValidateFrontMatter(t *testing.T) {
 			wantFields: []string{"agent.max_consecutive_absences"},
 		},
 
+		// --- agent.stop_grace_ms schema registration ---
+		{
+			name:      "agent.stop_grace_ms known key produces no warning",
+			raw:       map[string]any{"agent": map[string]any{"stop_grace_ms": 5000}},
+			wantCount: 0,
+		},
+		{
+			name: "type mismatch agent.stop_grace_ms is string abc",
+			raw: map[string]any{
+				"agent": map[string]any{"stop_grace_ms": "abc"},
+			},
+			wantCount:  1,
+			wantChecks: []string{"type_mismatch"},
+			wantFields: []string{"agent.stop_grace_ms"},
+		},
+
 		// --- Full valid config: no warnings ---
 		{
 			name: "fully valid config with all known keys produces no warnings",

--- a/internal/config/watchwindow.go
+++ b/internal/config/watchwindow.go
@@ -2,13 +2,11 @@ package config
 
 import (
 	"fmt"
-	"math"
-	"time"
 )
 
 // MaxWatchWindowMS is the largest watch_window_ms value whose conversion to
 // a time.Duration stays positive.
-const MaxWatchWindowMS int64 = math.MaxInt64 / int64(time.Millisecond)
+const MaxWatchWindowMS int64 = MaxDurationMS
 
 // ValidateWatchWindowMS reports why ms is not a usable watch window in
 // milliseconds, and nil when it is.

--- a/internal/domain/agent.go
+++ b/internal/domain/agent.go
@@ -181,6 +181,13 @@ type AgentConfig struct {
 	// milliseconds before the orchestrator considers the session
 	// stalled. Non-positive values disable stall detection.
 	StallTimeoutMS int
+
+	// StopGraceMS is the period an adapter waits, after sending a
+	// catchable termination signal, for the agent to exit on its own
+	// before it force-terminates the process group. The value is
+	// always positive: the configuration layer rejects a
+	// non-positive one rather than treating it as a sentinel.
+	StopGraceMS int
 }
 
 // Session is an opaque handle returned by [AgentAdapter.StartSession].

--- a/internal/domain/agent.go
+++ b/internal/domain/agent.go
@@ -184,9 +184,14 @@ type AgentConfig struct {
 
 	// StopGraceMS is the period an adapter waits, after sending a
 	// catchable termination signal, for the agent to exit on its own
-	// before it force-terminates the process group. The value is
-	// always positive: the configuration layer rejects a
-	// non-positive one rather than treating it as a sentinel.
+	// before it force-terminates the process group.
+	//
+	// A value built from workflow configuration is always positive,
+	// because that layer rejects a non-positive one rather than
+	// treating it as a sentinel. A value assembled in code carries
+	// whatever it was given, zero included, so an adapter resolves it
+	// through the shared helper that maps a non-positive count to the
+	// built-in grace rather than reading it as no limit.
 	StopGraceMS int
 }
 

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -212,6 +212,14 @@ type OrchestratorParams struct {
 	// unread list is never read as an empty one. The production
 	// binary always populates this field.
 	BlockerResolver BlockerResolver
+
+	// AbandonCh, once closed, ends every in-flight shutdown wait at
+	// once: the worker drain, the triage drain, and the tracker-ops
+	// drain each return immediately instead of waiting out their
+	// bound. A nil channel means no abort is wired; a receive on a
+	// nil channel blocks forever, which is exactly the behavior an
+	// unwired abort needs. Read only during shutdown.
+	AbandonCh <-chan struct{}
 }
 
 // Orchestrator owns the poll-and-dispatch event loop and all runtime
@@ -229,6 +237,7 @@ type Orchestrator struct {
 	store              OrchestratorStore
 	metrics            domain.Metrics
 	blockerResolver    BlockerResolver
+	abandonCh          <-chan struct{}
 
 	workerExitCh chan WorkerResult
 	retryTimerCh chan string
@@ -237,8 +246,13 @@ type Orchestrator struct {
 	snapshotCh   chan snapshotRequest
 	refreshCh    chan struct{}
 
-	preflightParams                   PreflightParams
-	observers                         []Observer
+	preflightParams PreflightParams
+	observers       []Observer
+
+	// drainTimeout overrides the worker-drain wait when positive. A
+	// non-positive value, its zero value, resolves to the ceiling
+	// [Orchestrator.drainRunningWorkers] derives from the current
+	// configuration.
 	drainTimeout                      time.Duration
 	toolRegistry                      *domain.ToolRegistry
 	sessionToolRegistryFunc           SessionToolRegistryFunc
@@ -370,7 +384,6 @@ func NewOrchestrator(params OrchestratorParams) *Orchestrator {
 		refreshCh:                         make(chan struct{}, 1),
 		preflightParams:                   params.PreflightParams,
 		observers:                         observers,
-		drainTimeout:                      defaultDrainTimeout,
 		toolRegistry:                      params.ToolRegistry,
 		sessionToolRegistryFunc:           params.SessionToolRegistryFunc,
 		hostPool:                          hostPool,
@@ -394,6 +407,7 @@ func NewOrchestrator(params OrchestratorParams) *Orchestrator {
 		handoffParkingLabel:               handoffParkingLabel,
 		ciTriage:                          ciTriage,
 		blockerResolver:                   params.BlockerResolver,
+		abandonCh:                         params.AbandonCh,
 	}
 	// Startup preflight must have passed for the orchestrator to be
 	// constructed, so the initial value is true.
@@ -958,9 +972,11 @@ func (o *Orchestrator) activateReconstructedRetries() {
 	}
 }
 
-// defaultDrainTimeout is the maximum duration the orchestrator waits for
-// running workers to exit during graceful shutdown.
-const defaultDrainTimeout = 30 * time.Second
+// drainExitMargin is the budget for the post-stop teardown bookkeeping
+// that runs after [domain.AgentAdapter.StopSession] returns: persisting
+// the run history, releasing the workspace, and the other steps
+// [HandleWorkerExit] performs for one worker.
+const drainExitMargin = 30 * time.Second
 
 // sessionMetadataWriteInterval bounds how often the event loop writes an
 // in-flight session's token totals to session_metadata. At most one
@@ -1354,7 +1370,13 @@ func (o *Orchestrator) drainRunningWorkers() {
 		}
 	}
 
-	deadline := time.NewTimer(o.drainTimeout)
+	cfg := o.workflowManager.Config()
+	ceiling := stopSessionDeadline(cfg) + drainExitMargin
+	waitFor := o.drainTimeout
+	if waitFor <= 0 {
+		waitFor = ceiling
+	}
+	deadline := time.NewTimer(waitFor)
 	defer deadline.Stop()
 
 	// The parent ctx is already cancelled; SQLite writes in
@@ -1411,6 +1433,12 @@ func (o *Orchestrator) drainRunningWorkers() {
 				slog.Int("remaining", len(o.state.Running)),
 			)
 			return
+
+		case <-o.abandonCh:
+			o.logger.Warn("worker drain abandoned at the operator's request",
+				slog.Int("remaining", len(o.state.Running)),
+			)
+			return
 		}
 	}
 
@@ -1436,6 +1464,8 @@ func (o *Orchestrator) drainTrackerOps() {
 	case <-done:
 	case <-time.After(trackerOpsDrainTimeout):
 		o.logger.Warn("tracker ops drain timeout exceeded, abandoning in-flight calls")
+	case <-o.abandonCh:
+		o.logger.Warn("tracker ops drain abandoned at the operator's request")
 	}
 }
 
@@ -1456,6 +1486,8 @@ func (o *Orchestrator) drainTriageRuns() {
 	case <-done:
 	case <-time.After(trackerOpsDrainTimeout):
 		o.logger.Warn("reaction triage drain timeout exceeded, abandoning in-flight runs")
+	case <-o.abandonCh:
+		o.logger.Warn("reaction triage drain abandoned at the operator's request")
 	}
 }
 

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/sortie-ai/sortie/internal/agent/procutil"
 	"github.com/sortie-ai/sortie/internal/config"
 	"github.com/sortie-ai/sortie/internal/domain"
 	"github.com/sortie-ai/sortie/internal/persistence"
@@ -5597,6 +5598,275 @@ func TestDrainRunningWorkers_AbsenceCeiling(t *testing.T) {
 		if !strings.Contains(buf.String(), "absence_ceiling=5") {
 			t.Errorf("issue-parked log missing absence_ceiling=5, want the configured ceiling rather than the built-in default 3\nlogs: %s", buf.String())
 		}
+	})
+}
+
+// TestDrainRunningWorkers_CeilingFormula pins the exact ceiling value
+// drainRunningWorkers derives when o.drainTimeout carries no override:
+// 50s at the default configuration, and the configured grace plus
+// drainExitMargin for any other grace. Asserted against the formula
+// directly rather than by letting drainRunningWorkers actually run to
+// that bound, which the derived ceiling's own floor (agent.stop_grace_ms's
+// smallest admissible value plus three fixed drain periods) puts at
+// no less than 45s of real wait.
+func TestDrainRunningWorkers_CeilingFormula(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		stopGraceMS int
+		want        time.Duration
+	}{
+		{"DefaultConfiguration", 0, 50 * time.Second},
+		{"ConfiguredGraceRaisesTheCeiling", 60000, 60*time.Second + 3*procutil.DefaultDrainGrace + drainExitMargin},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := config.ServiceConfig{Agent: config.AgentConfig{StopGraceMS: tt.stopGraceMS}}
+			got := stopSessionDeadline(cfg) + drainExitMargin
+			if got != tt.want {
+				t.Errorf("stopSessionDeadline(cfg) + drainExitMargin at StopGraceMS=%d = %v, want %v", tt.stopGraceMS, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestDrainRunningWorkers_AbandonChannel covers each of the three
+// shutdown drains: a closed AbandonCh ends the wait promptly and logs
+// its own abandon warning, distinguishable from the timeout arm's
+// message; a nil AbandonCh (the zero value) leaves the existing bound
+// in force, asserted without spending it in wall clock.
+func TestDrainRunningWorkers_AbandonChannel(t *testing.T) {
+	t.Parallel()
+
+	t.Run("closed AbandonCh ends drainRunningWorkers promptly", func(t *testing.T) {
+		t.Parallel()
+
+		state := NewState(60000, 1, nil, AgentTotals{})
+		state.Running["id-1"] = &RunningEntry{
+			Identifier: "PROJ-1",
+			Issue:      domain.Issue{ID: "id-1", Identifier: "PROJ-1", State: "In Progress"},
+			StartedAt:  time.Now().UTC(),
+			CancelFunc: func() {},
+		}
+		store := &stubStore{}
+		tracker := &candidateTrackerAdapter{mockTrackerAdapter: &mockTrackerAdapter{}}
+		abandonCh := make(chan struct{})
+		close(abandonCh)
+		var buf bytes.Buffer
+		o := drainTestOrchestrator(state, budgetTickConfig(0), store, tracker, slog.New(slog.NewTextHandler(&buf, nil)), abandonCh)
+		o.drainTimeout = time.Hour // would time out long after the test itself, if the abandon arm did not fire first
+
+		done := make(chan struct{})
+		go func() {
+			o.drainRunningWorkers()
+			close(done)
+		}()
+
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Fatal("drainRunningWorkers did not return promptly with a closed AbandonCh")
+		}
+
+		output := buf.String()
+		if !strings.Contains(output, "worker drain abandoned at the operator's request") {
+			t.Errorf("drainRunningWorkers() did not log the abandon warning: %s", output)
+		}
+		if strings.Contains(output, "drain timeout exceeded") {
+			t.Errorf("drainRunningWorkers() logged the timeout message for an operator abort, want the two distinguishable: %s", output)
+		}
+	})
+
+	t.Run("nil AbandonCh leaves the existing bound in force", func(t *testing.T) {
+		t.Parallel()
+
+		state := NewState(60000, 1, nil, AgentTotals{})
+		state.Running["id-1"] = &RunningEntry{
+			Identifier: "PROJ-1",
+			Issue:      domain.Issue{ID: "id-1", Identifier: "PROJ-1", State: "In Progress"},
+			StartedAt:  time.Now().UTC(),
+			CancelFunc: func() {},
+		}
+		store := &stubStore{}
+		tracker := &candidateTrackerAdapter{mockTrackerAdapter: &mockTrackerAdapter{}}
+		o := drainTestOrchestrator(state, budgetTickConfig(0), store, tracker, discardLogger(), nil)
+		o.drainTimeout = 300 * time.Millisecond // short override so the timeout arm, not the 50s default ceiling, ends this test
+
+		start := time.Now()
+		done := make(chan struct{})
+		go func() {
+			o.drainRunningWorkers()
+			close(done)
+		}()
+
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Fatal("drainRunningWorkers did not return within 5s")
+		}
+		elapsed := time.Since(start)
+
+		if elapsed < 300*time.Millisecond {
+			t.Errorf("drainRunningWorkers() with a nil AbandonCh returned after %v, want it to have honored the 300ms drainTimeout override rather than returning early through a nil-channel receive", elapsed)
+		}
+	})
+}
+
+// TestDrainTrackerOps_AbandonChannel and TestDrainTriageRuns_AbandonChannel
+// cover the two remaining shutdown drains the same way
+// TestDrainRunningWorkers_AbandonChannel covers the worker drain: a
+// closed AbandonCh ends the wait promptly with its own warning, and a
+// nil AbandonCh leaves the existing bound in force. Both drains wait on
+// their own WaitGroup rather than o.state.Running, so in-flight work is
+// simulated by holding that WaitGroup open rather than by populating
+// Running.
+func TestDrainTrackerOps_AbandonChannel(t *testing.T) {
+	t.Parallel()
+
+	t.Run("closed AbandonCh ends drainTrackerOps promptly", func(t *testing.T) {
+		t.Parallel()
+
+		state := NewState(60000, 1, nil, AgentTotals{})
+		state.TrackerOpsWg.Add(1)
+		t.Cleanup(state.TrackerOpsWg.Done)
+		store := &stubStore{}
+		tracker := &candidateTrackerAdapter{mockTrackerAdapter: &mockTrackerAdapter{}}
+		abandonCh := make(chan struct{})
+		close(abandonCh)
+		var buf bytes.Buffer
+		o := drainTestOrchestrator(state, budgetTickConfig(0), store, tracker, slog.New(slog.NewTextHandler(&buf, nil)), abandonCh)
+
+		done := make(chan struct{})
+		go func() {
+			o.drainTrackerOps()
+			close(done)
+		}()
+
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Fatal("drainTrackerOps did not return promptly with a closed AbandonCh")
+		}
+
+		output := buf.String()
+		if !strings.Contains(output, "tracker ops drain abandoned at the operator's request") {
+			t.Errorf("drainTrackerOps() did not log the abandon warning: %s", output)
+		}
+		if strings.Contains(output, "drain timeout exceeded") {
+			t.Errorf("drainTrackerOps() logged the timeout message for an operator abort, want the two distinguishable: %s", output)
+		}
+	})
+
+	t.Run("nil AbandonCh leaves the wait entered rather than returning early", func(t *testing.T) {
+		t.Parallel()
+
+		state := NewState(60000, 1, nil, AgentTotals{})
+		state.TrackerOpsWg.Add(1)
+		t.Cleanup(state.TrackerOpsWg.Done)
+		store := &stubStore{}
+		tracker := &candidateTrackerAdapter{mockTrackerAdapter: &mockTrackerAdapter{}}
+		o := drainTestOrchestrator(state, budgetTickConfig(0), store, tracker, discardLogger(), nil)
+
+		done := make(chan struct{})
+		go func() {
+			o.drainTrackerOps()
+			close(done)
+		}()
+
+		select {
+		case <-done:
+			t.Fatal("drainTrackerOps returned with a nil AbandonCh and in-flight work still pending, want it to keep waiting")
+		case <-time.After(300 * time.Millisecond):
+			// Still waiting after 300ms, well short of the 35s
+			// trackerOpsDrainTimeout: this is the entered-the-wait
+			// evidence the nil arm must not have short-circuited past.
+		}
+	})
+}
+
+func TestDrainTriageRuns_AbandonChannel(t *testing.T) {
+	t.Parallel()
+
+	t.Run("closed AbandonCh ends drainTriageRuns promptly", func(t *testing.T) {
+		t.Parallel()
+
+		state := NewState(60000, 1, nil, AgentTotals{})
+		state.TriageWg.Add(1)
+		t.Cleanup(state.TriageWg.Done)
+		store := &stubStore{}
+		tracker := &candidateTrackerAdapter{mockTrackerAdapter: &mockTrackerAdapter{}}
+		abandonCh := make(chan struct{})
+		close(abandonCh)
+		var buf bytes.Buffer
+		o := drainTestOrchestrator(state, budgetTickConfig(0), store, tracker, slog.New(slog.NewTextHandler(&buf, nil)), abandonCh)
+
+		done := make(chan struct{})
+		go func() {
+			o.drainTriageRuns()
+			close(done)
+		}()
+
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Fatal("drainTriageRuns did not return promptly with a closed AbandonCh")
+		}
+
+		output := buf.String()
+		if !strings.Contains(output, "reaction triage drain abandoned at the operator's request") {
+			t.Errorf("drainTriageRuns() did not log the abandon warning: %s", output)
+		}
+		if strings.Contains(output, "drain timeout exceeded") {
+			t.Errorf("drainTriageRuns() logged the timeout message for an operator abort, want the two distinguishable: %s", output)
+		}
+	})
+
+	t.Run("nil AbandonCh leaves the wait entered rather than returning early", func(t *testing.T) {
+		t.Parallel()
+
+		state := NewState(60000, 1, nil, AgentTotals{})
+		state.TriageWg.Add(1)
+		t.Cleanup(state.TriageWg.Done)
+		store := &stubStore{}
+		tracker := &candidateTrackerAdapter{mockTrackerAdapter: &mockTrackerAdapter{}}
+		o := drainTestOrchestrator(state, budgetTickConfig(0), store, tracker, discardLogger(), nil)
+
+		done := make(chan struct{})
+		go func() {
+			o.drainTriageRuns()
+			close(done)
+		}()
+
+		select {
+		case <-done:
+			t.Fatal("drainTriageRuns returned with a nil AbandonCh and in-flight work still pending, want it to keep waiting")
+		case <-time.After(300 * time.Millisecond):
+			// Still waiting after 300ms, well short of the 35s
+			// trackerOpsDrainTimeout: this is the entered-the-wait
+			// evidence the nil arm must not have short-circuited past.
+		}
+	})
+}
+
+// drainTestOrchestrator mirrors budgetOrchestrator but wires an
+// explicit logger and AbandonCh, for the shutdown-drain abort tests.
+func drainTestOrchestrator(state *State, wm *stubWorkflowManager, store *stubStore, tracker *candidateTrackerAdapter, logger *slog.Logger, abandonCh <-chan struct{}) *Orchestrator {
+	regs := passingPreflightRegistries()
+	regs.ReloadWorkflow = func() error { return nil }
+	regs.ConfigFunc = wm.Config
+	return NewOrchestrator(OrchestratorParams{
+		State:           state,
+		Logger:          logger,
+		TrackerAdapter:  tracker,
+		AgentAdapter:    &mockAgentAdapter{},
+		WorkflowManager: wm,
+		Store:           store,
+		PreflightParams: regs,
+		AbandonCh:       abandonCh,
 	})
 }
 

--- a/internal/orchestrator/self_review.go
+++ b/internal/orchestrator/self_review.go
@@ -117,7 +117,7 @@ func runSingleVerification(ctx context.Context, command, workspacePath string, t
 	// cmd.Wait return when Go's internal I/O goroutines are still blocked
 	// on a pipe read, which they can be on Windows after the subprocess is
 	// killed.
-	procutil.SetGroupCancel(cmd)
+	procutil.SetGroupCancel(cmd, procutil.DefaultStopGrace)
 
 	// Use cappedWriter for stdout/stderr instead of StdoutPipe/StderrPipe.
 	// On Windows, ReadFile on a pipe can remain blocked after the subprocess

--- a/internal/orchestrator/worker.go
+++ b/internal/orchestrator/worker.go
@@ -425,15 +425,22 @@ func toDomainAgentConfig(c config.AgentConfig, kind string) domain.AgentConfig {
 		TurnTimeoutMS:  c.TurnTimeoutMS,
 		ReadTimeoutMS:  c.ReadTimeoutMS,
 		StallTimeoutMS: c.StallTimeoutMS,
+		StopGraceMS:    c.StopGraceMS,
 	}
+}
+
+// stopSessionDeadline returns the duration a session stop is allowed to
+// spend: the configured agent.stop_grace_ms plus three full graceful
+// teardown periods, one for each bounded drain wait the teardown can
+// spend.
+func stopSessionDeadline(cfg config.ServiceConfig) time.Duration {
+	return procutil.StopGrace(cfg.Agent.StopGraceMS) + 3*procutil.DefaultDrainGrace
 }
 
 // stopSessionBestEffort terminates the agent session using a detached
 // context so that teardown proceeds even when the worker's ctx is
-// cancelled. The timeout is the agent's ReadTimeoutMS config, floored
-// at the duration a full graceful teardown can take: a value above the
-// floor still lengthens the deadline, and no value shortens it below a
-// full teardown. Errors are logged and swallowed.
+// cancelled. The timeout is [stopSessionDeadline]. Errors are logged
+// and swallowed.
 func stopSessionBestEffort(
 	ctx context.Context,
 	adapter domain.AgentAdapter,
@@ -443,10 +450,7 @@ func stopSessionBestEffort(
 ) {
 	detachedCtx := context.WithoutCancel(ctx)
 
-	floor := procutil.DefaultStopGrace + 3*procutil.DefaultDrainGrace
-	timeout := max(time.Duration(cfg.Agent.ReadTimeoutMS)*time.Millisecond, floor)
-
-	stopCtx, cancel := context.WithTimeout(detachedCtx, timeout)
+	stopCtx, cancel := context.WithTimeout(detachedCtx, stopSessionDeadline(cfg))
 	defer cancel()
 
 	if err := adapter.StopSession(stopCtx, session); err != nil {

--- a/internal/orchestrator/worker_test.go
+++ b/internal/orchestrator/worker_test.go
@@ -7699,3 +7699,25 @@ func TestRunWorkerAttempt_TurnBudgetInPhaseNoChangeNeeded(t *testing.T) {
 		t.Errorf("status file still present after an in-phase no-change-needed declaration, want removed: err=%v", err)
 	}
 }
+
+// TestStopGraceDefaultMatchesBuiltIn pins the one invariant the two
+// layers cannot state to each other. The configuration layer defaults
+// agent.stop_grace_ms to a literal because it must not import the
+// package that owns the built-in grace, so nothing makes the two agree
+// at compile time. This package imports both, and a change to either
+// side alone fails here rather than silently shifting every adapter's
+// default teardown.
+func TestStopGraceDefaultMatchesBuiltIn(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := config.NewServiceConfig(map[string]any{
+		"agent": map[string]any{"kind": "mock"},
+	})
+	if err != nil {
+		t.Fatalf("config.NewServiceConfig() = %v, want nil", err)
+	}
+	got := time.Duration(cfg.Agent.StopGraceMS) * time.Millisecond
+	if got != procutil.DefaultStopGrace {
+		t.Errorf("agent.stop_grace_ms default = %v, want %v (procutil.DefaultStopGrace)", got, procutil.DefaultStopGrace)
+	}
+}

--- a/internal/orchestrator/worker_test.go
+++ b/internal/orchestrator/worker_test.go
@@ -2261,6 +2261,76 @@ func TestRunWorkerAttempt_AfterRunHookCannotReachWorkerResult(t *testing.T) {
 
 // --- stopSessionBestEffort unit tests ---
 
+// TestStopSessionDeadline asserts the pure formula directly: the
+// resolved grace plus three drain periods, tracking a configured
+// agent.stop_grace_ms rather than a fixed value.
+func TestStopSessionDeadline(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		stopGraceMS int
+	}{
+		{"AbsentDefaultsToBuiltIn", 0},
+		{"SmallConfiguredValue", 1000},
+		{"LargeConfiguredValue", 60000},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := config.ServiceConfig{Agent: config.AgentConfig{StopGraceMS: tt.stopGraceMS}}
+			want := procutil.StopGrace(tt.stopGraceMS) + 3*procutil.DefaultDrainGrace
+
+			if got := stopSessionDeadline(cfg); got != want {
+				t.Errorf("stopSessionDeadline(cfg with StopGraceMS=%d) = %v, want %v", tt.stopGraceMS, got, want)
+			}
+		})
+	}
+}
+
+// TestStopSessionBestEffort_DeadlineTracksConfiguredStopGrace asserts
+// the complement of "deadline_does_not_follow_read_timeout_ms": with
+// agent.read_timeout_ms held fixed, raising agent.stop_grace_ms raises
+// the deadline stopSessionBestEffort hands StopSession, proving the
+// deadline is derived from the configured grace rather than from a
+// constant that merely happens to be insensitive to read_timeout_ms.
+func TestStopSessionBestEffort_DeadlineTracksConfiguredStopGrace(t *testing.T) {
+	t.Parallel()
+
+	measureDeadline := func(t *testing.T, stopGraceMS int) time.Time {
+		t.Helper()
+		var deadlineReceived time.Time
+		adapter := &mockAgentAdapter{
+			stopSessionFn: func(ctx context.Context, _ domain.Session) error {
+				dl, _ := ctx.Deadline()
+				deadlineReceived = dl
+				return nil
+			},
+		}
+		cfg := config.ServiceConfig{
+			Agent: config.AgentConfig{ReadTimeoutMS: 5000, StopGraceMS: stopGraceMS},
+		}
+		stopSessionBestEffort(context.Background(), adapter, domain.Session{ID: "s1"}, cfg, discardLogger())
+		return deadlineReceived
+	}
+
+	shortDeadline := measureDeadline(t, 1000)
+	longDeadline := measureDeadline(t, 60000)
+
+	if !longDeadline.After(shortDeadline) {
+		t.Errorf("deadline at stop_grace_ms=60000 (%v) is not after the deadline at stop_grace_ms=1000 (%v), want the configured grace to raise it", longDeadline, shortDeadline)
+	}
+
+	cfg := config.ServiceConfig{Agent: config.AgentConfig{ReadTimeoutMS: 5000, StopGraceMS: 60000}}
+	wantGrowth := stopSessionDeadline(cfg) - (procutil.StopGrace(1000) + 3*procutil.DefaultDrainGrace)
+	gotGrowth := longDeadline.Sub(shortDeadline)
+	if gotGrowth < wantGrowth-2*time.Second || gotGrowth > wantGrowth+2*time.Second {
+		t.Errorf("deadline grew by %v between stop_grace_ms=1000 and stop_grace_ms=60000, want ~%v", gotGrowth, wantGrowth)
+	}
+}
+
 func TestStopSessionBestEffort(t *testing.T) {
 	t.Parallel()
 
@@ -2378,7 +2448,7 @@ func TestStopSessionBestEffort(t *testing.T) {
 		}
 	})
 
-	t.Run("deadline_above_the_floor_follows_the_field", func(t *testing.T) {
+	t.Run("deadline_does_not_follow_read_timeout_ms", func(t *testing.T) {
 		t.Parallel()
 
 		var deadlineReceived time.Time
@@ -2390,6 +2460,10 @@ func TestStopSessionBestEffort(t *testing.T) {
 			},
 		}
 
+		// agent.read_timeout_ms no longer contributes to the deadline
+		// at all: stopSessionDeadline derives it from agent.stop_grace_ms
+		// alone, so a read timeout well above the floor still lands on
+		// the same deadline an absent one would.
 		cfg := config.ServiceConfig{
 			Agent: config.AgentConfig{ReadTimeoutMS: 25000},
 		}
@@ -2397,9 +2471,9 @@ func TestStopSessionBestEffort(t *testing.T) {
 		before := time.Now()
 		stopSessionBestEffort(context.Background(), adapter, domain.Session{ID: "s1"}, cfg, discardLogger())
 
-		wantDeadline := before.Add(25 * time.Second)
+		wantDeadline := before.Add(stopSessionDeadline(cfg))
 		if deadlineReceived.Before(wantDeadline.Add(-2*time.Second)) || deadlineReceived.After(wantDeadline.Add(2*time.Second)) {
-			t.Errorf("deadline = %v, want ~%v: agent.read_timeout_ms=25000 sits above the floor and must reach the caller", deadlineReceived, wantDeadline)
+			t.Errorf("deadline = %v, want ~%v: agent.read_timeout_ms=25000 must not reach the caller", deadlineReceived, wantDeadline)
 		}
 	})
 
@@ -6746,7 +6820,7 @@ func TestRunWorkerAttempt_CancellationNotReportedAsTimeout(t *testing.T) {
 	}
 }
 
-func TestRunWorkerAttempt_TurnTimeoutTeardownUsesReadTimeout(t *testing.T) {
+func TestRunWorkerAttempt_TurnTimeoutTeardownIgnoresReadTimeout(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("after_run hook uses touch command")
 	}
@@ -6757,9 +6831,9 @@ func TestRunWorkerAttempt_TurnTimeoutTeardownUsesReadTimeout(t *testing.T) {
 
 	cfg := defaultWorkerConfig(tmpDir)
 	cfg.Agent.TurnTimeoutMS = 150
-	// Above the floor stopSessionBestEffort now applies (20s at
-	// defaults), so the deadline it builds still follows this field
-	// rather than the floor.
+	// stopSessionDeadline no longer reads agent.read_timeout_ms at all,
+	// so a value well above the deadline it derives from
+	// agent.stop_grace_ms must not reach the caller.
 	cfg.Agent.ReadTimeoutMS = 25000
 	cfg.Agent.StallTimeoutMS = 0
 	cfg.Agent.MaxTurns = 1
@@ -6816,8 +6890,9 @@ func TestRunWorkerAttempt_TurnTimeoutTeardownUsesReadTimeout(t *testing.T) {
 	if !hadDeadline {
 		t.Fatal("StopSession context has no deadline")
 	}
-	if remaining := time.Until(deadline); remaining <= 23*time.Second || remaining > 25*time.Second {
-		t.Errorf("StopSession context deadline = %v from now, want in (23s, 25s], reflecting read_timeout_ms=25000 rather than the 150ms turn bound", remaining)
+	wantDeadline := stopSessionDeadline(cfg)
+	if remaining := time.Until(deadline); remaining <= wantDeadline-2*time.Second || remaining > wantDeadline {
+		t.Errorf("StopSession context deadline = %v from now, want in (%v, %v], derived from agent.stop_grace_ms rather than agent.read_timeout_ms=25000", remaining, wantDeadline-2*time.Second, wantDeadline)
 	}
 
 	if _, err := os.Stat(markerPath); err != nil {


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Feat

**Intent:** Let an operator configure the grace period an agent adapter waits for a process to exit on its own before force-terminating it, instead of that period being a five-second literal or constant duplicated across the `agentcore`, `opencode`, `codex`, and `clientprotocol` families. An agent CLI whose shutdown behavior needs longer than the built-in default previously had no recourse short of a Sortie release, and the failure was silent data loss on force-kill.

**Related Issues:** #1014

### 🧭 Reviewer Guide

**Complexity:** Medium

#### Entry Point

Start with `internal/agent/procutil/procutil.go` (`StopGrace`) and `internal/agent/procutil/pgid.go` (`SetGroupCancel`'s new `grace` parameter) - the helper every adapter family now goes through to resolve a configured millisecond count to a wait duration, with a non-positive value falling back to `DefaultStopGrace`. From there, `internal/config/config.go` (`buildAgentConfig`) shows the new `agent.stop_grace_ms` field's validation (positive, capped at `MaxDurationMS`), and `internal/orchestrator/worker.go` (`stopSessionDeadline`) shows the per-session stop deadline now deriving from it instead of `agent.read_timeout_ms`.

#### Sensitive Areas

- `internal/adaptertest/contract_test.go`: adds a STOPGRACE contract rule that rejects any agent-family file referencing `procutil.DefaultStopGrace` directly, so a future adapter can't bypass the configured grace.
- `internal/agent/agentcore/forkperturn.go`, `internal/agent/opencode/opencode.go`, `internal/agent/codex/codex.go`: each graceful phase now emits the same pair of records the client-protocol transport was alone in emitting - a debug line when the agent exits inside the grace, and one warning naming the elapsed period when it does not. The message string and the attribute keys are identical across all four families, so an operator greps one string rather than four. Without it, someone who raises the field cannot tell a grace that now suffices from one that still does not on five of the six kinds that have a graceful phase.
- `internal/orchestrator/orchestrator.go`: `drainRunningWorkers`, `drainTrackerOps`, and `drainTriageRuns` each gain an `abandonCh` case - a second interrupt (Ctrl-C) now ends every in-flight shutdown wait at once instead of waiting out its bound, since raising the stop grace also lengthens shutdown.
- `cmd/sortie/main.go`: the signal-handling goroutine (`handleSignals`) now tracks a second signal and closes the new abandon channel; the signal channel buffer grew from 1 to 2 so a second interrupt arriving between receives isn't dropped.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes. `agent.stop_grace_ms` defaults to `5000`, matching every family's prior hardcoded value, so behavior at default configuration is unchanged. The one default-configuration behavior change: the worker drain ceiling now derives from the stop grace plus teardown margin rather than a fixed 30s constant, which lengthens the default drain to 50s.
- **Migrations/State:** No migrations or state changes.

