### PR TITLE
fix: drop deprecated url.verified from the Homebrew cask

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -79,8 +79,6 @@ homebrew_casks:
     homepage: "https://github.com/sortie-ai/sortie"
     description: "Spec-first orchestration service for coding agents"
     skip_upload: "auto"
-    url:
-      verified: "github.com/sortie-ai/sortie/"
     hooks:
       post:
         install: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Stopping a `codex` session now honors the caller's deadline, as every other agent kind already did. `StopSession` ignored the deadline it was given, so a stop asked to finish sooner than the configured stop grace waited out the whole grace anyway and then reported success. It now ends the graceful phase when the deadline expires, force-terminates the process group, and reports the deadline back to its caller.
   ([#1014](https://github.com/sortie-ai/sortie/issues/1014))
 
+- A `brew` command that loads the sortie tap no longer prints Homebrew's deprecation warning for the `verified` parameter in the cask's `url` stanza. Homebrew does not honor that parameter and verifies cask download URLs through its own default behavior instead.
+  ([#1036](https://github.com/sortie-ai/sortie/issues/1036))
+
 ### Changed
 
 - A second interrupt (Ctrl-C) during shutdown now ends every remaining shutdown wait at once, instead of being silently discarded until shutdown finishes on its own. Each abandoned wait logs a warning naming what was given up.


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Fix

**Intent:** Homebrew now performs default URL verification for GitHub releases and strips the `verified:` parameter before building the URL, so the setting already does nothing except emit a deprecation warning on every `brew` command that loads the tap. Removing it silences that warning.

**Related Issues:** #1036

### 🧭 Reviewer Guide

**Complexity:** Low

#### Entry Point

`.goreleaser.yaml` - the `homebrew_casks.url.verified` key is removed. `CHANGELOG.md` records that removal as a new bullet at the bottom of `### Fixed` under `[Unreleased]`.

#### Sensitive Areas

- `.goreleaser.yaml`: release/packaging config, but this key is inert today, so removal has no effect on which URL Homebrew resolves or verifies.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes
- **Migrations/State:** No migrations or state changes
