### PR TITLE
feat: warn when an installed sortie binary is shadowed on PATH

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#1006](https://github.com/sortie-ai/sortie/issues/1006),
   [#1014](https://github.com/sortie-ai/sortie/issues/1014))
 
-- The install scripts for macOS, Linux, and Windows now warn when the `sortie` command still resolves to a different copy than the one just installed, naming that path and the version it reports. An older binary earlier in `PATH`, left by an install run as root or by the Homebrew cask, previously kept winning while the installer reported success. The macOS and Linux script also gains `-f`, `--force`, which reinstalls a release already present in the target directory instead of skipping it.
+- The install scripts for macOS, Linux, and Windows now warn when the `sortie` command still resolves to a different copy than the one just installed, naming that path. An older binary earlier in `PATH`, left by an install run as root or by the Homebrew cask, previously kept winning while the installer reported success. The macOS and Linux script also gains `-f`, `--force`, which reinstalls a release already present in the target directory instead of skipping it.
   ([PR #1046](https://github.com/sortie-ai/sortie/pull/1046))
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A second interrupt (Ctrl-C) during shutdown now ends every remaining shutdown wait at once, instead of being silently discarded until shutdown finishes on its own. Each abandoned wait logs a warning naming what was given up.
   ([#1014](https://github.com/sortie-ai/sortie/issues/1014))
 
+- The macOS and Linux install script now checks for every command it needs, including the SHA-256 tool used to verify the download, before it fetches anything, and names all missing ones in a single message. A missing `sha256sum` or `shasum` previously surfaced only after the release archive had already been downloaded.
+
 ## [1.23.0] - 2026-08-31
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#1006](https://github.com/sortie-ai/sortie/issues/1006),
   [#1014](https://github.com/sortie-ai/sortie/issues/1014))
 
+- The install scripts for macOS, Linux, and Windows now warn when the `sortie` command still resolves to a different copy than the one just installed, naming that path and the version it reports. An older binary earlier in `PATH`, left by an install run as root or by the Homebrew cask, previously kept winning while the installer reported success. The macOS and Linux script also gains `-f`, `--force`, which reinstalls a release already present in the target directory instead of skipping it.
+
 ### Fixed
 
 - A string-typed adapter configuration key whose value carries another YAML type, such as `tracker.endpoint: 123`, `agent.kind: 123`, or a mistyped `claude-code.model`, is now rejected with a diagnostic naming the key and the type found, instead of being silently coerced to the empty string and then treated as absent or defaulted to the adapter's own default. A workflow that previously started with such a value now fails at config load, at adapter construction, or offline through `sortie validate`, whichever reads the key first; the fix is to quote the value or remove the key.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   [#1014](https://github.com/sortie-ai/sortie/issues/1014))
 
 - The install scripts for macOS, Linux, and Windows now warn when the `sortie` command still resolves to a different copy than the one just installed, naming that path and the version it reports. An older binary earlier in `PATH`, left by an install run as root or by the Homebrew cask, previously kept winning while the installer reported success. The macOS and Linux script also gains `-f`, `--force`, which reinstalls a release already present in the target directory instead of skipping it.
+  ([PR #1046](https://github.com/sortie-ai/sortie/pull/1046))
 
 ### Fixed
 
@@ -50,6 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#1014](https://github.com/sortie-ai/sortie/issues/1014))
 
 - The macOS and Linux install script now checks for every command it needs, including the SHA-256 tool used to verify the download, before it fetches anything, and names all missing ones in a single message. A missing `sha256sum` or `shasum` previously surfaced only after the release archive had already been downloaded.
+  ([PR #1046](https://github.com/sortie-ai/sortie/pull/1046))
 
 ## [1.23.0] - 2026-08-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A second interrupt (Ctrl-C) during shutdown now ends every remaining shutdown wait at once, instead of being silently discarded until shutdown finishes on its own. Each abandoned wait logs a warning naming what was given up.
   ([#1014](https://github.com/sortie-ai/sortie/issues/1014))
 
-- The macOS and Linux install script now checks for every command it needs, including the SHA-256 tool used to verify the download, before it fetches anything, and names all missing ones in a single message. A missing `sha256sum` or `shasum` previously surfaced only after the release archive had already been downloaded.
+- The macOS and Linux install script now checks for the commands it needs to download and verify a release, `uname`, `tar`, `curl` or `wget`, and `sha256sum` or `shasum`, before it fetches anything, and names every missing one in a single message. A missing `sha256sum` or `shasum` previously surfaced only after the release archive had already been downloaded.
   ([PR #1046](https://github.com/sortie-ai/sortie/pull/1046))
 
 ## [1.23.0] - 2026-08-31

--- a/install.ps1
+++ b/install.ps1
@@ -27,11 +27,10 @@ $ErrorActionPreference = 'Stop'
 $Repo = 'sortie-ai/sortie'
 $Bin  = 'sortie'
 
-# ── Formatting ──────────────────────────────────────────────────────────────────
-
 # Mirror install.sh: info/ok use a ":: " prefix, err uses "error: ".
 function Write-Info { param([string]$Message) Write-Host ':: ' -ForegroundColor Cyan  -NoNewline; Write-Host $Message }
 function Write-Ok   { param([string]$Message) Write-Host ':: ' -ForegroundColor Green -NoNewline; Write-Host $Message }
+function Write-Warn { param([string]$Message) [Console]::Error.WriteLine("warning: $Message") }
 function Write-Err  { param([string]$Message) [Console]::Error.WriteLine("error: $Message") }
 
 # True when the console can render UTF-8 glyphs (ASCII art, spade).
@@ -43,8 +42,6 @@ function Test-Utf8Console {
     }
     catch { return $false }
 }
-
-# ── Platform detection ──────────────────────────────────────────────────────────
 
 # Map the host processor architecture to a release arch token (amd64|arm64).
 function Get-Architecture {
@@ -73,8 +70,6 @@ function Get-Architecture {
     throw "unsupported architecture: $envArch"
 }
 
-# ── HTTP helpers ────────────────────────────────────────────────────────────────
-
 # Download a URL to a file. -UseBasicParsing is required on 5.1 and harmless on 7.
 function Invoke-Download {
     param(
@@ -83,8 +78,6 @@ function Invoke-Download {
     )
     Invoke-WebRequest -Uri $Url -OutFile $OutFile -UseBasicParsing
 }
-
-# ── Version resolution ──────────────────────────────────────────────────────────
 
 # Use $env:SORTIE_VERSION when set, otherwise read the latest release tag from
 # the GitHub API. GitHub requires a User-Agent header.
@@ -109,8 +102,6 @@ function Resolve-Tag {
     }
     return $tagProp.Value
 }
-
-# ── Checksum verification ────────────────────────────────────────────────────────
 
 # Verify the SHA-256 of $FilePath against the entry for its file name in
 # checksums.txt (each line: "<hex-sha256>  <filename>").
@@ -140,8 +131,6 @@ function Test-Checksum {
     }
 }
 
-# ── Install directory resolution ──────────────────────────────────────────────────
-
 # $env:SORTIE_INSTALL_DIR when set, otherwise %LOCALAPPDATA%\Programs\sortie.
 # Never %ProgramFiles% by default - that would require elevation.
 function Resolve-InstallDir {
@@ -150,8 +139,6 @@ function Resolve-InstallDir {
     }
     return (Join-Path $env:LOCALAPPDATA 'Programs\sortie')
 }
-
-# ── PATH update ──────────────────────────────────────────────────────────────────
 
 # Append $Dir to the User-scope PATH if absent (registry-backed, not the merged
 # process PATH). Returns $true when the variable was modified.
@@ -180,7 +167,39 @@ function Add-ToUserPath {
     return $true
 }
 
-# ── Post-install summary ──────────────────────────────────────────────────────────
+# Versions rather than paths are compared: a copy of the same release elsewhere
+# on PATH changes nothing for the user. Must run before Add-ToUserPath, which
+# prepends $Dir to the session PATH and would hide the conflict.
+function Write-ShadowWarning {
+    param(
+        [Parameter(Mandatory)][string]$Target,
+        [Parameter(Mandatory)][string]$Version,
+        [Parameter(Mandatory)][string]$Dir
+    )
+
+    $found = Get-Command $Bin -CommandType Application -ErrorAction SilentlyContinue |
+        Select-Object -First 1
+    if ($null -eq $found -or $found.Source -ieq $Target) { return }
+
+    $other = ''
+    try {
+        $line = & $found.Source --version 2>$null | Select-Object -First 1
+        if (-not [string]::IsNullOrEmpty($line)) {
+            $fields = $line -split '\s+'
+            if ($fields.Count -ge 2) { $other = $fields[1] }
+        }
+    }
+    catch {
+        # An unrunnable binary still shadows; report it without a version.
+    }
+    if ($other -eq $Version) { return }
+
+    $shown = $found.Source
+    if (-not [string]::IsNullOrEmpty($other)) { $shown = "$($found.Source) ($other)" }
+
+    Write-Warn "$Bin on PATH is $shown, not the copy just installed"
+    [Console]::Error.WriteLine("  Remove that file, or put $Dir earlier in PATH.")
+}
 
 # Mirror install.sh's summary block exactly (taglines, labels, ordering).
 function Show-Summary {
@@ -225,8 +244,6 @@ function Show-Summary {
     }
     Write-Host ''
 }
-
-# ── Main ──────────────────────────────────────────────────────────────────────────
 
 function Invoke-Install {
     # Force TLS 1.2 for PS 5.1 on older Windows; -bor keeps TLS 1.3 on PS 7.
@@ -321,6 +338,8 @@ function Invoke-Install {
         Unblock-File -LiteralPath $target
 
         Write-Ok "Installed $Bin $tag to $target"
+
+        Write-ShadowWarning -Target $target -Version $version -Dir $dir
 
         if (Add-ToUserPath -Dir $dir) {
             Write-Host ''

--- a/install.ps1
+++ b/install.ps1
@@ -167,37 +167,23 @@ function Add-ToUserPath {
     return $true
 }
 
-# Versions rather than paths are compared: a copy of the same release elsewhere
-# on PATH changes nothing for the user. Must run before Add-ToUserPath, which
-# prepends $Dir to the session PATH and would hide the conflict.
+# Paths are compared rather than versions: probing the version would execute a
+# program an untrusted PATH entry chose, under whatever identity installs.
+# Trailing separators are trimmed as Add-ToUserPath trims them, so that two
+# spellings of one location compare equal. Must run before Add-ToUserPath,
+# which prepends $Dir to the session PATH and would hide the conflict.
 function Write-ShadowWarning {
     param(
         [Parameter(Mandatory)][string]$Target,
-        [Parameter(Mandatory)][string]$Version,
         [Parameter(Mandatory)][string]$Dir
     )
 
     $found = Get-Command $Bin -CommandType Application -ErrorAction SilentlyContinue |
         Select-Object -First 1
-    if ($null -eq $found -or $found.Source -ieq $Target) { return }
+    if ($null -eq $found) { return }
+    if ($found.Source.TrimEnd('\') -ieq $Target.TrimEnd('\')) { return }
 
-    $other = ''
-    try {
-        $line = & $found.Source --version 2>$null | Select-Object -First 1
-        if (-not [string]::IsNullOrEmpty($line)) {
-            $fields = $line -split '\s+'
-            if ($fields.Count -ge 2) { $other = $fields[1] }
-        }
-    }
-    catch {
-        # An unrunnable binary still shadows; report it without a version.
-    }
-    if ($other -eq $Version) { return }
-
-    $shown = $found.Source
-    if (-not [string]::IsNullOrEmpty($other)) { $shown = "$($found.Source) ($other)" }
-
-    Write-Warn "$Bin on PATH is $shown, not the copy just installed"
+    Write-Warn "$Bin on PATH is $($found.Source), not the copy just installed"
     [Console]::Error.WriteLine("  Remove that file, or put $Dir earlier in PATH.")
 }
 
@@ -339,7 +325,7 @@ function Invoke-Install {
 
         Write-Ok "Installed $Bin $tag to $target"
 
-        Write-ShadowWarning -Target $target -Version $version -Dir $dir
+        Write-ShadowWarning -Target $target -Dir $dir
 
         if (Add-ToUserPath -Dir $dir) {
             Write-Host ''

--- a/install.ps1
+++ b/install.ps1
@@ -167,11 +167,21 @@ function Add-ToUserPath {
     return $true
 }
 
-# Paths are compared rather than versions: probing the version would execute a
-# program an untrusted PATH entry chose, under whatever identity installs.
-# Trailing separators are trimmed as Add-ToUserPath trims them, so that two
-# spellings of one location compare equal. Must run before Add-ToUserPath,
-# which prepends $Dir to the session PATH and would hide the conflict.
+# Canonical form of a path, for comparison only. Resolve-Path resolves nothing
+# that does not exist, and $ErrorActionPreference is Stop, so a path that fails
+# to resolve falls back to its own text rather than ending the install.
+function Resolve-FilePath {
+    param([Parameter(Mandatory)][string]$Path)
+
+    try { return (Resolve-Path -LiteralPath $Path -ErrorAction Stop).ProviderPath.TrimEnd('\') }
+    catch { return $Path.TrimEnd('\') }
+}
+
+# Paths are compared rather than versions: reading the version means running
+# the file a PATH entry resolved to, and that entry may be one the person
+# installing does not control. Both sides are canonicalized first, so that two
+# spellings of one location do not read as a conflict. Must run before
+# Add-ToUserPath, which prepends $Dir to the session PATH and would hide it.
 function Write-ShadowWarning {
     param(
         [Parameter(Mandatory)][string]$Target,
@@ -181,7 +191,7 @@ function Write-ShadowWarning {
     $found = Get-Command $Bin -CommandType Application -ErrorAction SilentlyContinue |
         Select-Object -First 1
     if ($null -eq $found) { return }
-    if ($found.Source.TrimEnd('\') -ieq $Target.TrimEnd('\')) { return }
+    if ((Resolve-FilePath $found.Source) -ieq (Resolve-FilePath $Target)) { return }
 
     Write-Warn "$Bin on PATH is $($found.Source), not the copy just installed"
     [Console]::Error.WriteLine("  Remove that file, or put $Dir earlier in PATH.")

--- a/install.sh
+++ b/install.sh
@@ -221,17 +221,24 @@ shell_rc() {
     esac
 }
 
-# Versions rather than paths are compared: a symlink pointing at the binary
-# just installed is not a shadow.
+# Physical path of a file, so that two spellings of one location compare equal.
+canonical_file() {
+    _cf_dir=$(CDPATH='' cd -- "$(dirname -- "$1")" 2>/dev/null && pwd -P) || return 1
+    printf '%s/%s' "$_cf_dir" "$(basename -- "$1")"
+}
+
+# Paths are compared rather than versions: probing the version would execute a
+# binary an untrusted PATH entry chose, under whatever identity installs, and
+# installing to /usr/local/bin means root.
 warn_if_shadowed() {
     _found=$(command -v "$BIN" 2>/dev/null) || return 0
     [ -n "$_found" ] || return 0
-    [ "$_found" != "${_dir}/${BIN}" ] || return 0
 
-    _other=$(installed_version "$_found")
-    [ "$_other" != "$_version" ] || return 0
+    _found_real=$(canonical_file "$_found") || return 0
+    _target_real=$(canonical_file "${_dir}/${BIN}") || return 0
+    [ "$_found_real" != "$_target_real" ] || return 0
 
-    warn "${BIN} on PATH is ${_found}${_other:+ (${_other})}, not the copy just installed"
+    warn "${BIN} on PATH is ${_found}, not the copy just installed"
     printf '  %bRemove that file, or put %s earlier in PATH.%b\n' \
         "${DIM}" "$_dir" "${RESET}" >&2
 }

--- a/install.sh
+++ b/install.sh
@@ -227,9 +227,9 @@ canonical_file() {
     printf '%s/%s' "$_cf_dir" "$(basename -- "$1")"
 }
 
-# Paths are compared rather than versions: probing the version would execute a
-# binary an untrusted PATH entry chose, under whatever identity installs, and
-# installing to /usr/local/bin means root.
+# Paths are compared rather than versions: reading the version means running
+# the file a PATH entry resolved to, and that entry may be one the person
+# installing does not control. Installing to /usr/local/bin means root.
 warn_if_shadowed() {
     _found=$(command -v "$BIN" 2>/dev/null) || return 0
     [ -n "$_found" ] || return 0

--- a/install.sh
+++ b/install.sh
@@ -81,8 +81,6 @@ parse_args() {
     done
 }
 
-# ── Platform detection ────────────────────────────────────────────────────────
-
 detect_platform() {
     OS=$(uname -s)
     case "$OS" in
@@ -107,9 +105,24 @@ detect_platform() {
     fi
 }
 
-# ── HTTP abstraction ──────────────────────────────────────────────────────────
-
 need_cmd() { command -v "$1" >/dev/null 2>&1 || die "required command not found: $1"; }
+
+# Checking the checksum tool here rather than at its point of use keeps a
+# missing sha256sum from surfacing only after the archive has been downloaded.
+check_dependencies() {
+    _missing=""
+    for _cmd in uname tar; do
+        command -v "$_cmd" >/dev/null 2>&1 \
+            || _missing="${_missing:+$_missing, }$_cmd"
+    done
+    command -v curl >/dev/null 2>&1 || command -v wget >/dev/null 2>&1 \
+        || _missing="${_missing:+$_missing, }curl or wget"
+    if [ "${SORTIE_NO_VERIFY-}" != "1" ] && [ -z "$(sha256_cmd)" ]; then
+        _missing="${_missing:+$_missing, }sha256sum or shasum"
+    fi
+
+    [ -z "$_missing" ] || die "required commands not found: ${_missing}"
+}
 
 fetch() {
     _url=$1 _out=${2:-}
@@ -123,8 +136,6 @@ fetch() {
         die "curl or wget is required"
     fi
 }
-
-# ── Version resolution ────────────────────────────────────────────────────────
 
 # The releases/latest HTML endpoint redirects to the tagged release and, unlike
 # the GitHub API, is not rate-limited per IP - which is what breaks on shared
@@ -161,26 +172,27 @@ installed_version() {
     "$1" --version 2>/dev/null | awk 'NR == 1 { print $2 }'
 }
 
-# ── Checksum verification ────────────────────────────────────────────────────
+# Name of the available SHA-256 tool, empty when neither is installed.
+sha256_cmd() {
+    if command -v sha256sum >/dev/null 2>&1; then printf 'sha256sum'
+    elif command -v shasum >/dev/null 2>&1; then printf 'shasum'
+    fi
+}
 
 verify_checksum() {
     _file=$1 _sums=$2
     _want=$(awk -v f="$(basename "$_file")" '$2 == f {print $1}' "$_sums")
     [ -n "$_want" ] || die "no checksum entry for $(basename "$_file")"
 
-    if command -v sha256sum >/dev/null 2>&1; then
-        _got=$(sha256sum "$_file" | awk '{print $1}')
-    elif command -v shasum >/dev/null 2>&1; then
-        _got=$(shasum -a 256 "$_file" | awk '{print $1}')
-    else
-        die "sha256sum or shasum is required"
-    fi
+    case $(sha256_cmd) in
+        sha256sum) _got=$(sha256sum "$_file" | awk '{print $1}') ;;
+        shasum)    _got=$(shasum -a 256 "$_file" | awk '{print $1}') ;;
+        *)         die "sha256sum or shasum is required" ;;
+    esac
 
     [ "$_want" = "$_got" ] \
         || die "checksum mismatch (expected ${_want}, got ${_got})"
 }
-
-# ── Install directory resolution ──────────────────────────────────────────────
 
 resolve_install_dir() {
     if [ -n "${SORTIE_INSTALL_DIR-}" ]; then
@@ -226,8 +238,7 @@ install_local() {
 }
 
 install_release() {
-    need_cmd uname
-    need_cmd tar
+    check_dependencies
 
     detect_platform
     info "Platform: ${OS}/${ARCH}"

--- a/install.sh
+++ b/install.sh
@@ -345,8 +345,10 @@ main() {
         ok "Installed ${BIN} ${_tag} to ${_dir}/${BIN}"
     fi
 
+    warn_if_shadowed
+
     case ":${PATH}:" in
-        *":${_dir}:"*) warn_if_shadowed ;;
+        *":${_dir}:"*) ;;
         *)
             if [ "${GITHUB_ACTIONS-}" = "true" ] && [ -n "${GITHUB_PATH-}" ]; then
                 printf '%s\n' "$_dir" >> "$GITHUB_PATH"

--- a/install.sh
+++ b/install.sh
@@ -17,8 +17,7 @@ set -eu
 REPO="sortie-ai/sortie"
 BIN="sortie"
 BINARY=""
-
-# ── Formatting ────────────────────────────────────────────────────────────────
+FORCE=0
 
 setup_colors() {
     if [ -t 1 ] && [ "${TERM-}" != "dumb" ]; then
@@ -32,10 +31,9 @@ setup_colors() {
 
 info() { printf '%b%s\n' "${BOLD}${CYAN}:: ${RESET}" "$*"; }
 ok()   { printf '%b%s\n' "${BOLD}${GREEN}:: ${RESET}" "$*"; }
+warn() { printf '%b%s\n' "${BOLD}${YELLOW}warning: ${RESET}" "$*" >&2; }
 err()  { printf '%b%s\n' "${BOLD}${RED}error: ${RESET}" "$*" >&2; }
 die()  { err "$@"; exit 1; }
-
-# ── Arguments ─────────────────────────────────────────────────────────────────
 
 usage() {
     cat <<EOF
@@ -48,6 +46,7 @@ Options:
   -v, --version <version>   Install a specific release (default: latest)
   -d, --install-dir <dir>   Install into <dir>
   -b, --binary <path>       Install a local binary instead of downloading
+  -f, --force               Reinstall even if that version is already present
       --no-verify           Skip checksum verification
 
 Flags override the SORTIE_VERSION, SORTIE_INSTALL_DIR and SORTIE_NO_VERIFY
@@ -73,6 +72,8 @@ parse_args() {
             -b|--binary)
                 [ $# -ge 2 ] || die "$1 requires an argument"
                 BINARY=$2; shift 2 ;;
+            -f|--force)
+                FORCE=1; shift ;;
             --no-verify)
                 SORTIE_NO_VERIFY=1; shift ;;
             *)
@@ -220,11 +221,22 @@ shell_rc() {
     esac
 }
 
-# ── Cleanup ───────────────────────────────────────────────────────────────────
+# Versions rather than paths are compared: a symlink pointing at the binary
+# just installed is not a shadow.
+warn_if_shadowed() {
+    _found=$(command -v "$BIN" 2>/dev/null) || return 0
+    [ -n "$_found" ] || return 0
+    [ "$_found" != "${_dir}/${BIN}" ] || return 0
+
+    _other=$(installed_version "$_found")
+    [ "$_other" != "$_version" ] || return 0
+
+    warn "${BIN} on PATH is ${_found}${_other:+ (${_other})}, not the copy just installed"
+    printf '  %bRemove that file, or put %s earlier in PATH.%b\n' \
+        "${DIM}" "$_dir" "${RESET}" >&2
+}
 
 cleanup() { [ -d "${TMPDIR_INSTALL-}" ] && rm -rf "$TMPDIR_INSTALL"; }
-
-# ── Install strategies ────────────────────────────────────────────────────────
 
 install_local() {
     [ -f "$BINARY" ] || die "binary not found: ${BINARY}"
@@ -251,7 +263,7 @@ install_release() {
     _tag=$_version
     info "Release:  ${_version}"
 
-    if [ "$(installed_version "${_dir}/${BIN}")" = "$_version" ]; then
+    if [ "$FORCE" != 1 ] && [ "$(installed_version "${_dir}/${BIN}")" = "$_version" ]; then
         _already_installed=1
         return 0
     fi
@@ -306,8 +318,6 @@ install_release() {
     install -m 755 "${TMPDIR_INSTALL}/${BIN}" "${_dir}/${BIN}"
 }
 
-# ── Main ──────────────────────────────────────────────────────────────────────
-
 main() {
     setup_colors
     parse_args "$@"
@@ -329,7 +339,7 @@ main() {
     fi
 
     case ":${PATH}:" in
-        *":${_dir}:"*) ;;
+        *":${_dir}:"*) warn_if_shadowed ;;
         *)
             if [ "${GITHUB_ACTIONS-}" = "true" ] && [ -n "${GITHUB_PATH-}" ]; then
                 printf '%s\n' "$_dir" >> "$GITHUB_PATH"


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Feat

**Intent:** Make `install.sh` and `install.ps1` catch two silent-failure modes: a stale `sortie` earlier on `PATH` that keeps winning after a successful install, and a missing dependency (notably the SHA-256 tool) that previously surfaced only after the release archive had already been downloaded.

### 🧭 Reviewer Guide

**Complexity:** High

#### Entry Point

`install.sh` is where both changes live: `check_dependencies()` verifies `uname`, `tar`, `curl`/`wget`, and the SHA-256 tool before `install_release()` fetches anything, and `warn_if_shadowed()` reports when the `sortie` that `command -v` resolves is not the copy just installed. That comparison is between physical paths, through the `canonical_file()` helper, so two spellings of one location (a trailing slash, a doubled slash, a symlinked directory) do not read as a shadow. `install.ps1` carries the equivalent shadow check (`Write-ShadowWarning`) for Windows; it has no dependency-check equivalent since it uses `Invoke-WebRequest` rather than external CLI tools.

#### Sensitive Areas

- `install.sh` and `install.ps1`: neither shadow check runs the file it resolved. An earlier `PATH` entry can be chosen by someone other than the person installing, and the installer runs as root whenever the target directory is `/usr/local/bin`, so probing that file's `--version` would have executed it under that identity. A change here is worth reviewing for the reintroduction of any version probe.
- `install.sh`: the new `-f`/`--force` flag changes control flow in `install_release`, the function that decides whether to skip or redo an install.
- `install.sh`: `warn_if_shadowed` is called unconditionally from `main`, not from the `PATH` membership `case`. The `case` pattern does not match an entry spelled with a trailing slash, which would have skipped the check on exactly the setups that need it.
- `install.ps1`: `Write-ShadowWarning` must run before `Add-ToUserPath`, which prepends the install dir to the session `PATH` and would otherwise hide the shadow it is meant to detect.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes. The shadow warning names the conflicting path but no longer reports its version, because reading that version meant running that file.
- **Migrations/State:** No migrations or state changes.
